### PR TITLE
Adding Support for EIS-D210, its another name for ARK-1154

### DIFF
--- a/pkg/pillar/conf/AssignableAdapters/Advantech.EIS-D210.json
+++ b/pkg/pillar/conf/AssignableAdapters/Advantech.EIS-D210.json
@@ -1,0 +1,8 @@
+{ "IoBundleList": [
+    { "Type": 1, "Name": "eth0", "Members": [ "eth0" ], "Lookup": true },
+    { "Type": 1, "Name": "eth1", "Members": [ "eth1" ], "Lookup": true },
+    { "Type": 2, "Name": "USB", "Members": [ "USB0", "USB1", "USB2", "USB3" ], "PciLong": "0000:00:15.0", "PciShort": "00:15.0"},
+    { "Type": 3, "Name": "COM1", "Members": [ "COM1" ], "XenCfg": "irqs=[4]\nioports=['3f8-3ff']\n" },
+    { "Type": 3, "Name": "COM2", "Members": [ "COM2" ], "XenCfg": "irqs=[3]\nioports=['2f8-2ff']\n" },
+    { "Type": 255, "Name": "Audio", "Members": [ "AudioOut" ], "PciLong": "0000:00:0e.0", "PciShort":"00:0e.0" }
+] }

--- a/pkg/pillar/conf/DeviceNetworkConfig/Advantech.EIS-D210.json
+++ b/pkg/pillar/conf/DeviceNetworkConfig/Advantech.EIS-D210.json
@@ -1,0 +1,4 @@
+{
+    "Uplink":["eth0","wlan0","wwan0"],
+    "FreeUplinks":["eth0","wlan0"]
+}


### PR DESCRIPTION
Signed-off-by: Vijay Tapaskar <vijay@zededa.com>

ARK-1154 has another name EIS-D210