### PR TITLE
Update modules to use eve/api instead of eve/sdk

### DIFF
--- a/pkg/pillar/go.mod
+++ b/pkg/pillar/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.1 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/kr/fs v0.1.0 // indirect
-	github.com/lf-edge/eve/sdk/go v0.0.0-00010101000000-000000000000 // indirect
+	github.com/lf-edge/eve/api/go v0.0.0-00010101000000-000000000000
 	github.com/mdlayher/raw v0.0.0-20190419142535-64193704e472 // indirect
 	github.com/pkg/errors v0.8.1 // indirect
 	github.com/pkg/sftp v1.10.0
@@ -31,7 +31,6 @@ require (
 	github.com/sirupsen/logrus v1.2.0
 	github.com/vishvananda/netlink v0.0.0-20190319163122-f504738125a5 // indirect
 	github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc // indirect
-	github.com/lf-edge/eve/api/go v0.0.0-00010101000000-000000000000
 	golang.org/x/crypto v0.0.0-20190404164418-38d8ce5564a5
 	golang.org/x/net v0.0.0-20190419010253-1f3472d942ba
 	google.golang.org/api v0.3.2 // indirect

--- a/pkg/pillar/vendor/modules.txt
+++ b/pkg/pillar/vendor/modules.txt
@@ -69,7 +69,6 @@ github.com/go-ole/go-ole/oleutil
 # github.com/golang/protobuf v1.3.1
 github.com/golang/protobuf/proto
 github.com/golang/protobuf/ptypes
-github.com/golang/protobuf/ptypes/timestamp
 github.com/golang/protobuf/ptypes/any
 github.com/golang/protobuf/ptypes/duration
 github.com/golang/protobuf/ptypes/timestamp
@@ -108,6 +107,12 @@ github.com/jmespath/go-jmespath
 github.com/konsorten/go-windows-terminal-sequences
 # github.com/kr/fs v0.1.0
 github.com/kr/fs
+# github.com/lf-edge/eve/api/go v0.0.0-00010101000000-000000000000 => ../../api/go
+github.com/lf-edge/eve/api/go/config
+github.com/lf-edge/eve/api/go/register
+github.com/lf-edge/eve/api/go/logs
+github.com/lf-edge/eve/api/go/info
+github.com/lf-edge/eve/api/go/metrics
 # github.com/pkg/errors v0.8.1
 github.com/pkg/errors
 # github.com/pkg/sftp v1.10.0
@@ -132,12 +137,6 @@ github.com/sirupsen/logrus
 github.com/vishvananda/netlink/nl
 # github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc
 github.com/vishvananda/netns
-# github.com/lf-edge/eve/sdk/go v0.0.0-00010101000000-000000000000 => ../../sdk/go
-github.com/lf-edge/eve/sdk/go/config
-github.com/lf-edge/eve/sdk/go/register
-github.com/lf-edge/eve/sdk/go/logs
-github.com/lf-edge/eve/sdk/go/info
-github.com/lf-edge/eve/sdk/go/metrics
 # go.opencensus.io v0.20.1
 go.opencensus.io/plugin/ochttp
 go.opencensus.io/plugin/ochttp/propagation/tracecontext


### PR DESCRIPTION
This should make `make proto-vendor` work correctly on pillar.