### PR TITLE
Tune golangci-lint to make it more reliable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,12 @@ jobs:
       - run:
           name: install libpcap-dev
           command: apt-get -q install --no-install-recommends -y libpcap-dev
+      - run:
+          name: upgrade golangci-lint
+          command: >
+                    go get
+                    github.com/golangci/golangci-lint/cmd/golangci-lint@692dacb773b703162c091c2d8c59f9cd2d6801db
+                    && mv /root/go/bin/golangci-lint /usr/local/bin
       - checkout
       # create a fake artifact so that Apache Yetus knows the URL
       - run:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,13 @@ run:
 linters:
   enable-all: true
   disable:
-    - gochecknoglobals  # error on globals; unreliable output
+    - gochecknoglobals  # unreliable
+    - golint            # covered by revive
     - lll               # line length check
-    - unconvert         # Remove unnecessary type conversions; unreliable output
-    - deadcode          # dead code; unreliable output
+    - typecheck         # See golangci/golangci-lint#419
+    - unused            # deprecated
+    - varcheck          # unreliable
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0


### PR DESCRIPTION
* upgrade to a master commit which fixes a few bugs from the last release
* show all errors (workaround until Apache Yetus picks up a fix)
* disable redundant/broken linters

This doesn't fix it completely, but this is better.

Signed-off-by: Allen Wittenauer <aw@effectivemachines.com>