### PR TITLE
explicitly set go modules in case running in GOPATH

### DIFF
--- a/pkg/pillar/Makefile
+++ b/pkg/pillar/Makefile
@@ -30,7 +30,7 @@ build: $(APPS) $(APPS1)
 $(APPS): $(DISTDIR)/$(APPS)
 $(DISTDIR)/$(APPS): $(DISTDIR)
 	@echo "Building $@"
-	go build -mod=vendor -ldflags -X=main.Version=$(BUILD_VERSION) -o $@ ./$(@F)
+	GO111MODULE=on go build -mod=vendor -ldflags -X=main.Version=$(BUILD_VERSION) -o $@ ./$(@F)
 
 $(APPS1): $(DISTDIR)
 	@echo $@


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

Fixes #33 

This way, can run `make` (or `make all` or `make build`) whether in GOPATH or not.