### PR TITLE
Make device proxy connection work with golang version 1.12

### DIFF
--- a/pkg/pillar/zedcloud/lookupproxy.go
+++ b/pkg/pillar/zedcloud/lookupproxy.go
@@ -69,11 +69,7 @@ func LookupProxy(status *types.DeviceNetworkStatus, ifname string,
 			proxy0 = strings.Split(proxy0, " ")[1]
 			// Proxy address returned by PAC does not have the URL scheme.
 			// We prepend the scheme (http/https) of the incoming raw URL.
-			if len(u.Scheme) == 0 {
-				proxy0 = "http://" + proxy0
-			} else {
-				proxy0 = u.Scheme + "://" + proxy0
-			}
+			proxy0 = "http://" + proxy0
 			proxy, err := url.Parse(proxy0)
 			if err != nil {
 				errStr := fmt.Sprintf("LookupProxy: PAC file returned invalid proxy %s: %s",


### PR DESCRIPTION
Signed-off-by: GopiKrishna Kodali <gkodali@zededa.com>

Between golang versions 1.9.1 (old version we were using) and golang version 1.12 (new version we recently moved to), there are changes done in net/http module. Golang 1.9.1 did not have the capability to talk using https to a proxy server. So, even when we provided the proxy URL as https://x.x.x.x:yyyy to the library, it would fall back to http.

WIth golang 1.2 net/http library has the capability to talk https to proxy server. Since, we do not have a certificate installed in the proxy server and the corresponding root cert installed in device, https would not go through. So, the connection between client and proxy server should be http. 