### PR TITLE
Explicitly build for linux, so local builds do not fail

### DIFF
--- a/pkg/pillar/Makefile
+++ b/pkg/pillar/Makefile
@@ -30,7 +30,7 @@ build: $(APPS) $(APPS1)
 $(APPS): $(DISTDIR)/$(APPS)
 $(DISTDIR)/$(APPS): $(DISTDIR)
 	@echo "Building $@"
-	GO111MODULE=on go build -mod=vendor -ldflags -X=main.Version=$(BUILD_VERSION) -o $@ ./$(@F)
+	GO111MODULE=on GOOS=linux CGO_ENABLED=1 go build -mod=vendor -ldflags -X=main.Version=$(BUILD_VERSION) -o $@ ./$(@F)
 
 $(APPS1): $(DISTDIR)
 	@echo $@


### PR DESCRIPTION
This allows `make zedbox` to work. If you run it in docker or on a Linux box, it always works, with or without this, so that isn't an issue. This just ensures consistency.

At some point, it would be good to get zedbox working on other OSes, so we can test things out without booting a VM. For now, this will do.

cc @rvs 