### PR TITLE
Reorder dockerfile.in to make it possible to build just zedbox

### DIFF
--- a/pkg/pillar/Dockerfile.in
+++ b/pkg/pillar/Dockerfile.in
@@ -1,12 +1,6 @@
 # Copyright (c) 2018 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 ARG GOVER=1.12.4
-FROM LISP_TAG as lisp
-FROM XENTOOLS_TAG as xen-tools
-FROM DNSMASQ_TAG as dnsmasq
-FROM STRONGSWAN_TAG as strongswan
-FROM GPTTOOLS_TAG as gpttools
-FROM WATCHDOG_TAG as watchdog
 FROM golang:${GOVER}-alpine as build
 RUN apk update
 RUN apk add --no-cache git gcc linux-headers libc-dev util-linux libpcap-dev make
@@ -29,6 +23,19 @@ RUN [ -z "$GOARCH" ] || export CC=$(echo /*-cross/bin/*-gcc) ;\
     echo "Running go fmt" && ERR=$(gofmt -e -l -s $(find . -name \*.go | grep -v /vendor/)) && \
        if [ -n "$ERR" ] ; then echo $ERR ; exit 1 ; fi && \
     make DISTDIR=/dist build
+
+# hadolint ignore=DL3006
+FROM LISP_TAG as lisp
+# hadolint ignore=DL3006
+FROM XENTOOLS_TAG as xen-tools
+# hadolint ignore=DL3006
+FROM DNSMASQ_TAG as dnsmasq
+# hadolint ignore=DL3006
+FROM STRONGSWAN_TAG as strongswan
+# hadolint ignore=DL3006
+FROM GPTTOOLS_TAG as gpttools
+# hadolint ignore=DL3006
+FROM WATCHDOG_TAG as watchdog
 
 FROM alpine:3.8
 RUN apk add --no-cache \

--- a/pkg/pillar/Makefile
+++ b/pkg/pillar/Makefile
@@ -40,6 +40,9 @@ $(APPS1): $(DISTDIR)
 shell:
 	make -C ../.. shell
 
+build-docker-$(APPS):
+	docker build -f Dockerfile.in --target=build .
+
 build-docker:
 	docker build $(DOCKER_ARGS) -t $(DOCKER_TAG) .
 


### PR DESCRIPTION
Without this, you need to generate the proper `Dockerfile` from `Dockerfile.in` in order to build just this component, and you need to download all of them.

This does two things:

1. Reorder the Dockerfile so that you can build _just_ the binary in docker using `docker build -f Dockerfile.in --target=build .`
2. Add a simple `Makefile` target that calls it.

I don't love the `Makefile` target, but it is good enough for now just to keep track of it.

This build runs very quickly, and makes it easier to iterate on the binary without the other pillar dependencies.

cc @eriknordmark @rvs 