### PR TITLE
Fix bug in reporting mgmt link proxy status to cloud

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -1334,9 +1334,7 @@ func getNetInfo(interfaceDetail psutilnet.InterfaceStat,
 			errInfo.Timestamp = errTime
 			networkInfo.NetworkErr = errInfo
 		}
-		if port.Proxy != nil {
-			networkInfo.Proxy = encodeProxyStatus(port.Proxy)
-		}
+		networkInfo.Proxy = encodeProxyStatus(&port.ProxyConfig)
 	}
 	return networkInfo
 }


### PR DESCRIPTION
NetworkXObjectConfig inside NeworkPortStatus is no longer updated with proxy configuration. 