### PR TITLE
Three fixes

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1500,8 +1500,8 @@ func configToXencfg(config types.DomainConfig, status types.DomainStatus,
 			if i != 0 {
 				cfg = cfg + ", "
 			}
-			cfg = cfg + fmt.Sprintf("'%s'", pa)
-			// XXX cfg = cfg + fmt.Sprintf("'%s,rdm_policy=relaxed'", pa)
+			// XXX cfg = cfg + fmt.Sprintf("'%s'", pa)
+			cfg = cfg + fmt.Sprintf("'%s,rdm_policy=relaxed'", pa)
 		}
 		cfg = cfg + "]"
 		log.Debugf("Adding pci config <%s>\n", cfg)
@@ -1678,6 +1678,8 @@ func handleDelete(ctx *domainContext, key string, status *types.DomainStatus) {
 	cleanupAdapters(ctx, status.IoAdapterList, status.UUIDandVersion.UUID)
 
 	publishDomainStatus(ctx, status)
+
+	updateUsbAccess(ctx)
 
 	// Delete xen cfg file for good measure
 	filename := xenCfgFilename(status.AppNum)
@@ -2471,14 +2473,20 @@ func updateUsbAccess(ctx *domainContext) {
 			}
 			ib.IsPCIBack = true
 		}
-		if ctx.usbAccess && ib.IsPCIBack && ib.UsedByUUID == nilUUID {
-			log.Infof("Removing %s (%s %s) from pciback\n",
-				ib.Name, ib.PciLong, ib.PciShort)
-			err := pciAssignableRemove(ib.PciLong)
-			if err != nil {
-				log.Errorf("updateUsbAccess: %s\n", err)
+		if ctx.usbAccess && ib.IsPCIBack {
+			if ib.UsedByUUID == nilUUID {
+				log.Infof("Removing %s (%s %s) from pciback\n",
+					ib.Name, ib.PciLong, ib.PciShort)
+				err := pciAssignableRemove(ib.PciLong)
+				if err != nil {
+					log.Errorf("updateUsbAccess: %s\n", err)
+				}
+				ib.IsPCIBack = false
+			} else {
+				log.Warnf("No removing %s (%s %s) from pciback: used by %s",
+					ib.Name, ib.PciLong,
+					ib.PciShort, ib.UsedByUUID)
 			}
-			ib.IsPCIBack = false
 		}
 	}
 	checkIoBundleAll(ctx)

--- a/pkg/pillar/cmd/zedmanager/handleverifier.go
+++ b/pkg/pillar/cmd/zedmanager/handleverifier.go
@@ -167,6 +167,7 @@ func handleVerifyImageStatusModify(ctxArg interface{}, key string,
 
 	// Normal update work
 	updateAIStatusSafename(ctx, key)
+	updateAIStatusSha(ctx, config.ImageSha256)
 	log.Infof("handleVerifyImageStatusModify done for %s\n",
 		status.Safename)
 }
@@ -224,9 +225,11 @@ func lookupVerifyImageStatusAny(ctx *zedmanagerContext, safename string,
 func handleVerifyImageStatusDelete(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
+	status := cast.CastVerifyImageStatus(statusArg)
 	log.Infof("handleVerifyImageStatusDelete for %s\n", key)
 	ctx := ctxArg.(*zedmanagerContext)
 	removeAIStatusSafename(ctx, key)
+	removeAIStatusSha(ctx, status.ImageSha256)
 	// If we still publish a config with RefCount == 0 we delete it.
 	config := lookupVerifyImageConfig(ctx, key)
 	if config != nil && config.RefCount == 0 {

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -21,6 +21,7 @@ func updateAIStatusSafename(ctx *zedmanagerContext, safename string) {
 	log.Infof("updateAIStatusSafename for %s\n", safename)
 	pub := ctx.pubAppInstanceStatus
 	items := pub.GetAll()
+	found := false
 	for key, st := range items {
 		status := cast.CastAppInstanceStatus(st)
 		if status.Key() != key {
@@ -36,8 +37,42 @@ func updateAIStatusSafename(ctx *zedmanagerContext, safename string) {
 				log.Infof("Found StorageStatus URL %s safename %s\n",
 					ss.Name, safename)
 				updateAIStatusUUID(ctx, status.Key())
+				found = true
 			}
 		}
+	}
+	if !found {
+		log.Warnf("updateAIStatusSafename for %s not found\n", safename)
+	}
+}
+
+// Find all the config which refer to this safename.
+func updateAIStatusSha(ctx *zedmanagerContext, sha string) {
+
+	log.Infof("updateAIStatusSha for %s\n", sha)
+	pub := ctx.pubAppInstanceStatus
+	items := pub.GetAll()
+	found := false
+	for key, st := range items {
+		status := cast.CastAppInstanceStatus(st)
+		if status.Key() != key {
+			log.Errorf("updateAIStatusSha key/UUID mismatch %s vs %s; ignored %+v\n",
+				key, status.Key(), status)
+			continue
+		}
+		log.Debugf("Processing AppInstanceConfig for UUID %s\n",
+			status.UUIDandVersion.UUID)
+		for _, ss := range status.StorageStatusList {
+			if sha == ss.ImageSha256 {
+				log.Infof("Found StorageStatus URL %s sha %s\n",
+					ss.Name, sha)
+				updateAIStatusUUID(ctx, status.Key())
+				found = true
+			}
+		}
+	}
+	if !found {
+		log.Warnf("updateAIStatusSha for %s not found\n", sha)
 	}
 }
 
@@ -127,6 +162,7 @@ func removeAIStatusSafename(ctx *zedmanagerContext, safename string) {
 	log.Infof("removeAIStatusSafename for %s\n", safename)
 	pub := ctx.pubAppInstanceStatus
 	items := pub.GetAll()
+	found := false
 	for key, st := range items {
 		status := cast.CastAppInstanceStatus(st)
 		if status.Key() != key {
@@ -142,8 +178,42 @@ func removeAIStatusSafename(ctx *zedmanagerContext, safename string) {
 				log.Debugf("Found StorageStatus URL %s safename %s\n",
 					ss.Name, safename2)
 				updateOrRemove(ctx, status)
+				found = true
 			}
 		}
+	}
+	if !found {
+		log.Warnf("removeAIStatusSafename for %s not found\n", safename)
+	}
+}
+
+// Find all the Status which refer to this safename.
+func removeAIStatusSha(ctx *zedmanagerContext, sha string) {
+
+	log.Infof("removeAIStatusSha for %s\n", sha)
+	pub := ctx.pubAppInstanceStatus
+	items := pub.GetAll()
+	found := false
+	for key, st := range items {
+		status := cast.CastAppInstanceStatus(st)
+		if status.Key() != key {
+			log.Errorf("removeAIStatusSha key/UUID mismatch %s vs %s; ignored %+v\n",
+				key, status.Key(), status)
+			continue
+		}
+		log.Debugf("Processing AppInstanceStatus for UUID %s\n",
+			status.UUIDandVersion.UUID)
+		for _, ss := range status.StorageStatusList {
+			if sha == ss.ImageSha256 {
+				log.Debugf("Found StorageStatus URL %s sha %s\n",
+					ss.Name, sha)
+				updateOrRemove(ctx, status)
+				found = true
+			}
+		}
+	}
+	if !found {
+		log.Warnf("removeAIStatusSha for %s not found\n", sha)
 	}
 }
 


### PR DESCRIPTION
We might have to revisit the USB PCI relaxed thing later, but for now this seems to be the only way we can ensure that assignment of PCI USB controllers work; there doesn't seem to be a workable way to disable compatibility in all the BIOSes we've tried.