### PR TITLE
Adding CODEOWNERS to our repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence, these will
+# be requested for review when someone opens a pull request.
+*       @eriknordmark @rvs
+
+/api/   @eriknordmark @rvs @zedvijay @deitch


### PR DESCRIPTION
A proposed CODEOWNERS scheme.

To learn about how this is going to work, please take a look at 
    https://help.github.com/en/articles/about-code-owners
or follow up on EVE TSC mailing list