### PR TITLE
Enabling local controllers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ CONFIG_IMG=$(DIST)/config.img
 
 BIOS_IMG=$(DIST)/bios/OVMF.fd
 EFI_PART=$(DIST)/bios/EFI
+CONF_PART=$(CURDIR)/../adam/run/adam/config
 
 QEMU_OPTS_arm64= -machine virt,gic_version=3 -machine virtualization=true -cpu cortex-a57 -machine type=virt
 # -drive file=./bios/flash0.img,format=raw,if=pflash -drive file=./bios/flash1.img,format=raw,if=pflash
@@ -75,7 +76,7 @@ QEMU_OPTS_COMMON= -smbios type=1,serial=31415926 -m 4096 -smp 4 -display none -s
         -rtc base=utc,clock=rt \
         -netdev user,id=eth0,net=192.168.1.0/24,dhcpstart=192.168.1.10,hostfwd=tcp::$(SSH_PORT)-:22 -device e1000,netdev=eth0 \
         -netdev user,id=eth1,net=192.168.2.0/24,dhcpstart=192.168.2.10 -device e1000,netdev=eth1
-QEMU_OPTS=$(QEMU_OPTS_COMMON) $(QEMU_OPTS_$(ZARCH))
+QEMU_OPTS=$(QEMU_OPTS_COMMON) $(QEMU_OPTS_$(ZARCH)) $(shell [ -d $(CONF_PART) ] && echo '-drive file=fat:rw:$(CONF_PART),format=raw')
 
 GOOS=linux
 CGO_ENABLED=1

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,8 @@ QEMU_OPTS_COMMON= -smbios type=1,serial=31415926 -m 4096 -smp 4 -display none -s
         -rtc base=utc,clock=rt \
         -netdev user,id=eth0,net=192.168.1.0/24,dhcpstart=192.168.1.10,hostfwd=tcp::$(SSH_PORT)-:22 -device e1000,netdev=eth0 \
         -netdev user,id=eth1,net=192.168.2.0/24,dhcpstart=192.168.2.10 -device e1000,netdev=eth1
-QEMU_OPTS=$(QEMU_OPTS_COMMON) $(QEMU_OPTS_$(ZARCH)) $(shell [ -d $(CONF_PART) ] && echo '-drive file=fat:rw:$(CONF_PART),format=raw')
+QEMU_OPTS_CONF_PART=$(shell [ -d $(CONF_PART) ] && echo '-drive file=fat:rw:$(CONF_PART),format=raw')
+QEMU_OPTS=$(QEMU_OPTS_COMMON) $(QEMU_OPTS_$(ZARCH)) $(QEMU_OPTS_CONF_PART)
 
 GOOS=linux
 CGO_ENABLED=1

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -296,22 +296,17 @@ access_usb() {
             echo "$(date -Ins -u) mount $SPECIAL failed: $?"
             return
         fi
-        keyfile=/mnt/usb.json
-        if [ -f $keyfile ]; then
-            echo "$(date -Ins -u) Found $keyfile on $SPECIAL"
-            echo "$(date -Ins -u) Copying from $keyfile to $DPCDIR"
-            cp -p $keyfile $DPCDIR
-        else
-            echo "$(date -Ins -u) $keyfile not found on $SPECIAL"
-        fi
-        confdir=/mnt/config
-        if [ -d $confdir ]; then
-            echo "$(date -Ins -u) Found $confdir on $SPECIAL"
-            echo "$(date -Ins -u) Copying from $confdir to /config"
-            cp -p $confdir/* /config
-        else
-            echo "$(date -Ins -u) $confdir not found on $SPECIAL"
-        fi
+        for fd in "usb.json:$DPCDIR" hosts:/config server:/config ; do
+            file=/mnt/$(echo "$fd" | cut -f1 -d:)
+            dst=$(echo "$fd" | cut -f2 -d:)
+            if [ -f "$file" ]; then
+                echo "$(date -Ins -u) Found $file on $SPECIAL"
+                echo "$(date -Ins -u) Copying from $file to $dst"
+                cp -p "$file" "$dst"
+            else
+                echo "$(date -Ins -u) $file not found on $SPECIAL"
+            fi
+        done
         if [ -d /mnt/identity ] && [ -f $CONFIGDIR/device.cert.pem ]; then
             echo "$(date -Ins -u) Saving identity to USB stick"
             IDENTITYHASH=$(openssl sha256 $CONFIGDIR/device.cert.pem |awk '{print $2}')

--- a/pkg/pillar/scripts/mkusb.sh
+++ b/pkg/pillar/scripts/mkusb.sh
@@ -48,11 +48,6 @@ if [ -n "$FILE" ]; then
     fi
 fi
 
-if [ ! -b "$DEV" ]; then
-    echo "Not a special device: $DEV"
-    exit 1
-fi
-
 echo ""
 echo "THIS WILL ERASE $DEV"
 lsblk "$DEV"


### PR DESCRIPTION
This change aims at enabling local controllers by providing additional configuration files via a side-channel that is a USB stick or a QEMU simulated partition.

For Adam, that is checked out next to EVE the flow from now on is:
   $ ../adam/bin/adam server &
   $ make run

That's it.

This also enables other local controllers (like zedcloud on a local laptop) via:
   $ make CONF_PART=/path/to/hosts/and/server/file run