### PR TITLE
Early review: Enable Serial ports for HVM guests

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -900,18 +900,20 @@ func cleanupAdapters(ctx *domainContext, ioAdapterList []types.IoAdapter,
 	for _, adapter := range ioAdapterList {
 		log.Debugf("cleanupAdapters processing adapter %d %s\n",
 			adapter.Type, adapter.Name)
-		ib := types.LookupIoBundle(ctx.assignableAdapters,
+		list := ctx.assignableAdapters.LookupIoBundleGroup(
 			adapter.Type, adapter.Name)
-		if ib == nil {
+		if len(list) == 0 {
 			continue
 		}
-		if ib.UsedByUUID != myUuid {
-			continue
+		for _, ib := range list {
+			if ib.UsedByUUID != myUuid {
+				continue
+			}
+			log.Infof("cleanupAdapters clearing uuid for adapter %d %s member %s",
+				adapter.Type, adapter.Name, ib.Name)
+			ib.UsedByUUID = nilUUID
+			publishAssignableAdapters = true
 		}
-		log.Infof("cleanupAdapters clearing uuid for adapter %d %s\n",
-			adapter.Type, adapter.Name)
-		ib.UsedByUUID = nilUUID
-		publishAssignableAdapters = true
 	}
 	if publishAssignableAdapters {
 		ctx.publishAssignableAdapters()
@@ -923,46 +925,62 @@ func cleanupAdapters(ctx *domainContext, ioAdapterList []types.IoAdapter,
 func doAssignIoAdaptersToDomain(ctx *domainContext, config types.DomainConfig,
 	status *types.DomainStatus) {
 
+	publishAssignableAdapters := false
+	var assignments []string
 	for _, adapter := range config.IoAdapterList {
 		log.Debugf("doAssignIoAdaptersToDomain processing adapter %d %s\n",
 			adapter.Type, adapter.Name)
 
-		ib := types.LookupIoBundle(ctx.assignableAdapters,
+		list := ctx.assignableAdapters.LookupIoBundleGroup(
 			adapter.Type, adapter.Name)
 		// We reserved it in handleCreate so nobody could have stolen it
-		if ib == nil {
+		if len(list) == 0 {
 			log.Fatalf("doAssignIoAdaptersToDomain IoBundle disappeared %d %s for %s\n",
 				adapter.Type, adapter.Name, status.DomainName)
 		}
-		if ib.UsedByUUID != config.UUIDandVersion.UUID {
-			log.Fatalf("doAssignIoAdaptersToDomain IoBundle stolen by %s: %d %s for %s\n",
-				ib.UsedByUUID, adapter.Type, adapter.Name,
-				status.DomainName)
-		}
-		if ib.Type != types.IoUSB {
-			continue
-		}
-		if ib.Lookup { // XXX guard against using MPciShort
-			log.Fatalf("doAssignIoAdaptersToDomain lookup for USB: %d %s for %s\n",
-				adapter.Type, adapter.Name, status.DomainName)
-		}
-		if ib.PciShort == "" {
-			log.Warnf("doAssignIoAdaptersToDomain missing PciShort: %d %s for %s\n",
-				adapter.Type, adapter.Name, status.DomainName)
-		} else if ctx.usbAccess && !ib.IsPCIBack {
-			log.Infof("Assigning %s (%s %s) to %s\n",
-				ib.Name, ib.PciLong, ib.PciShort,
-				status.DomainName)
-			err := pciAssignableAdd(ib.PciLong)
-			if err != nil {
-				status.LastErr = fmt.Sprintf("%v", err)
-				status.LastErrTime = time.Now()
-				return
+		for _, ib := range list {
+			if ib == nil {
+				continue
 			}
-			ib.IsPCIBack = true
+			if ib.UsedByUUID != config.UUIDandVersion.UUID {
+				log.Fatalf("doAssignIoAdaptersToDomain IoBundle stolen by %s: %d %s for %s\n",
+					ib.UsedByUUID, adapter.Type, adapter.Name,
+					status.DomainName)
+			}
+			if ib.Type != types.IoUSB {
+				continue
+			}
+			if ib.PciLong == "" {
+				log.Warnf("doAssignIoAdaptersToDomain missing PciLong: %d %s for %s\n",
+					adapter.Type, adapter.Name, status.DomainName)
+			} else if ctx.usbAccess && !ib.IsPCIBack {
+				log.Infof("Assigning %s (%s) to %s\n",
+					ib.Name, ib.PciLong, status.DomainName)
+				assignments = addNoDuplicate(assignments, ib.PciLong)
+				ib.IsPCIBack = true
+				publishAssignableAdapters = true
+			}
+		}
+	}
+	for i, long := range assignments {
+		err := pciAssignableAdd(long)
+		if err != nil {
+			// Undo what we assigned
+			for j, long := range assignments {
+				if j >= i {
+					break
+				}
+				pciAssignableRemove(long)
+			}
+			status.LastErr = fmt.Sprintf("%v", err)
+			status.LastErrTime = time.Now()
+			return
 		}
 	}
 	checkIoBundleAll(ctx)
+	if publishAssignableAdapters {
+		ctx.publishAssignableAdapters()
+	}
 }
 
 func doActivate(ctx *domainContext, config types.DomainConfig,
@@ -1217,46 +1235,51 @@ func pciUnassign(ctx *domainContext, status *types.DomainStatus,
 		status.UUIDandVersion, ignoreErrors, status.DisplayName)
 
 	// Unassign any pci devices but keep UsedByUUID set and keep in status
+	var assignments []string
 	for _, adapter := range status.IoAdapterList {
 		log.Debugf("doInactivate processing adapter %d %s\n",
 			adapter.Type, adapter.Name)
-		ib := types.LookupIoBundle(ctx.assignableAdapters, adapter.Type, adapter.Name)
+		list := ctx.assignableAdapters.LookupIoBundleGroup(
+			adapter.Type, adapter.Name)
 		// We reserved it in handleCreate so nobody could have stolen it
-		if ib == nil {
+		if len(list) == 0 {
 			log.Fatalf("doInactivate IoBundle disappeared %d %s for %s\n",
 				adapter.Type, adapter.Name, status.DomainName)
 		}
-		if ib.UsedByUUID != status.UUIDandVersion.UUID {
-			log.Infof("doInactivate IoBundle not ours by %s: %d %s for %s\n",
-				ib.UsedByUUID, adapter.Type, adapter.Name,
-				status.DomainName)
-			continue
-		}
-		// XXX also unassign others and assign during Activate?
-		if ib.Type != types.IoUSB {
-			continue
-		}
-		if ib.Lookup { // XXX guard against using MPciShort
-			log.Fatalf("doInactivate lookup for USB: %d %s for %s\n",
-				adapter.Type, adapter.Name, status.DomainName)
-		}
-		if ib.PciShort == "" {
-			log.Warnf("doInactivate lookup missing: %d %s for %s\n",
-				adapter.Type, adapter.Name, status.DomainName)
-		} else if ctx.usbAccess && ib.IsPCIBack {
-			log.Infof("Removing %s (%s %s) from %s\n",
-				ib.Name, ib.PciLong, ib.PciShort,
-				status.DomainName)
-			err := pciAssignableRemove(ib.PciLong)
-			if err != nil && !ignoreErrors {
-				status.LastErr = fmt.Sprintf("%v", err)
-				status.LastErrTime = time.Now()
-			} else {
+		for _, ib := range list {
+			if ib == nil {
+				continue
+			}
+			if ib.UsedByUUID != status.UUIDandVersion.UUID {
+				log.Infof("doInactivate IoBundle not ours by %s: %d %s for %s\n",
+					ib.UsedByUUID, adapter.Type, adapter.Name,
+					status.DomainName)
+				continue
+			}
+			// XXX also unassign others and assign during Activate?
+			if ib.Type != types.IoUSB {
+				continue
+			}
+			if ib.PciLong == "" {
+				log.Warnf("doInactivate lookup missing: %d %s for %s\n",
+					adapter.Type, adapter.Name, status.DomainName)
+			} else if ctx.usbAccess && ib.IsPCIBack {
+				log.Infof("Removing %s (%s) from %s\n",
+					ib.Name, ib.PciLong, status.DomainName)
+				assignments = addNoDuplicate(assignments, ib.PciLong)
+
 				ib.IsPCIBack = false
 			}
+			ib.UsedByUUID = nilUUID // XXX see comment above. Clear if usbAccess only?
 		}
-		ib.UsedByUUID = nilUUID // XXX see comment above. Clear if usbAccess only?
 		checkIoBundleAll(ctx)
+	}
+	for _, long := range assignments {
+		err := pciAssignableRemove(long)
+		if err != nil && !ignoreErrors {
+			status.LastErr = fmt.Sprintf("%v", err)
+			status.LastErrTime = time.Now()
+		}
 	}
 	ctx.publishAssignableAdapters()
 }
@@ -1326,29 +1349,29 @@ func configAdapters(ctx *domainContext, config types.DomainConfig) error {
 		log.Debugf("configAdapters processing adapter %d %s\n",
 			adapter.Type, adapter.Name)
 		// Lookup to make sure adapter exists on this device
-		ib := types.LookupIoBundle(ctx.assignableAdapters, adapter.Type, adapter.Name)
-		if ib == nil {
-			return errors.New(fmt.Sprintf("Unknown adapter %d %s\n",
-				adapter.Type, adapter.Name))
+		list := ctx.assignableAdapters.LookupIoBundleGroup(
+			adapter.Type, adapter.Name)
+		if len(list) == 0 {
+			return fmt.Errorf("Unknown adapter %d %s\n",
+				adapter.Type, adapter.Name)
 		}
-		if ib.UsedByUUID != nilUUID {
-			return errors.New(fmt.Sprintf("Adapter %d %s used by %s\n",
-				adapter.Type, adapter.Name, ib.UsedByUUID))
-		}
-		for _, m := range ib.Members {
-			if isPort(ctx, m) {
-				return errors.New(fmt.Sprintf("Adapter %d %s member %s is (part of) a zedrouter port\n",
-					adapter.Type, adapter.Name, m))
+		for _, ibp := range list {
+			if ibp == nil {
+				continue
 			}
-		}
+			if ibp.UsedByUUID != nilUUID {
+				return errors.New(fmt.Sprintf("Adapter %d %s used by %s\n",
+					adapter.Type, adapter.Name, ibp.UsedByUUID))
+			}
+			if isPort(ctx, ibp.Name) {
+				return errors.New(fmt.Sprintf("Adapter %d %s member %s is (part of) a zedrouter port\n",
+					adapter.Type, adapter.Name, ibp.Name))
+			}
 
-		if ib.Lookup && ib.MPciShort == nil {
-			log.Fatalf("configAdapters lookup missing: %d %s for %s\n",
-				adapter.Type, adapter.Name, config.DisplayName)
+			log.Debugf("configAdapters setting uuid %s for adapter %d %s member %s",
+				config.Key(), adapter.Type, adapter.Name, ibp.Name)
+			ibp.UsedByUUID = config.UUIDandVersion.UUID
 		}
-		log.Debugf("configAdapters setting uuid %s for adapter %d %s\n",
-			config.Key(), adapter.Type, adapter.Name)
-		ib.UsedByUUID = config.UUIDandVersion.UUID
 	}
 	return nil
 }
@@ -1468,7 +1491,9 @@ func configToXencfg(config types.DomainConfig, status types.DomainStatus,
 	// XXX Should one be able to disable the serial console? Would need
 	// knob in manifest
 
-	serialString := "'pty'"
+	var serialAssignments []string
+	serialAssignments = append(serialAssignments, "'pty'")
+
 	// Always prefer CDROM vdisk over disk
 	file.WriteString(fmt.Sprintf("boot = \"%s\"\n", "dc"))
 
@@ -1515,76 +1540,49 @@ func configToXencfg(config types.DomainConfig, status types.DomainStatus,
 	// Gather all PCI assignments into a single line
 	// Also irqs, ioports, and serials
 	// irqs and ioports are used if we are pv; serials if hvm
-	// XXX Need to suppress duplicates when we flip
-	type typeAndPCI struct {
-		pciShort string
-		ioType   types.IoType
-	}
 	var pciAssignments []typeAndPCI
+	var irqAssignments []string
+	var ioportsAssignments []string
 
-	ioportString := ""
-	irqString := ""
 	for _, irq := range config.IRQs {
-		if irqString != "" {
-			irqString += ","
-		}
-		irqString += fmt.Sprintf("%d", irq)
+		irqString := fmt.Sprintf("%d", irq)
+		irqAssignments = addNoDuplicate(irqAssignments, irqString)
 	}
-
 	for _, adapter := range config.IoAdapterList {
 		log.Debugf("configToXenCfg processing adapter %d %s\n",
 			adapter.Type, adapter.Name)
-		ib := types.LookupIoBundle(aa, adapter.Type, adapter.Name)
+		list := aa.LookupIoBundleGroup(adapter.Type, adapter.Name)
 		// We reserved it in handleCreate so nobody could have stolen it
-		if ib == nil {
+		if len(list) == 0 {
 			log.Fatalf("configToXencfg IoBundle disappeared %d %s for %s\n",
 				adapter.Type, adapter.Name, status.DomainName)
 		}
-		if ib.UsedByUUID != config.UUIDandVersion.UUID {
-			log.Fatalf("configToXencfg IoBundle not ours %s: %d %s for %s\n",
-				ib.UsedByUUID, adapter.Type, adapter.Name,
-				status.DomainName)
-		}
-		if ib.Lookup {
-			if ib.MPciShort == nil {
-				log.Fatalf("configToXencfg lookup missing: %d %s\n",
-					ib.Type, ib.Name)
+		for _, ib := range list {
+			if ib == nil {
+				continue
 			}
-			for _, short := range ib.MPciShort {
-				tap := typeAndPCI{pciShort: short, ioType: ib.Type}
-				pciAssignments = append(pciAssignments, tap)
+			if ib.UsedByUUID != config.UUIDandVersion.UUID {
+				log.Fatalf("configToXencfg IoBundle not ours %s: %d %s for %s\n",
+					ib.UsedByUUID, adapter.Type, adapter.Name,
+					status.DomainName)
 			}
-		} else if ib.PciShort != "" {
-			tap := typeAndPCI{pciShort: ib.PciShort, ioType: ib.Type}
-			pciAssignments = append(pciAssignments, tap)
-		}
-		if ib.Irq != "" && config.VirtualizationMode == types.PV {
-			log.Infof("Adding irq <%s>\n", ib.Irq)
-			if irqString != "" {
-				irqString += ","
+			if ib.PciLong != "" {
+				tap := typeAndPCI{pciLong: ib.PciLong, ioType: ib.Type}
+				pciAssignments = addNoDuplicatePCI(pciAssignments, tap)
 			}
-			irqString += ib.Irq
-		}
-		if ib.Ioports != "" && config.VirtualizationMode == types.PV {
-			log.Infof("Adding ioport <%s>\n", ib.Ioports)
-			if ioportString != "" {
-				ioportString += ","
+			if ib.Irq != "" && config.VirtualizationMode == types.PV {
+				log.Infof("Adding irq <%s>\n", ib.Irq)
+				irqAssignments = addNoDuplicate(irqAssignments,
+					ib.Irq)
 			}
-			ioportString += ib.Ioports
-		}
-		if ib.Serial != "" && config.VirtualizationMode == types.HVM {
-			log.Infof("Adding serial <%s>\n", ib.Serial)
-			if serialString != "" {
-				serialString += ","
+			if ib.Ioports != "" && config.VirtualizationMode == types.PV {
+				log.Infof("Adding ioport <%s>\n", ib.Ioports)
+				ioportsAssignments = addNoDuplicate(ioportsAssignments, ib.Ioports)
 			}
-			serialString += "'" + ib.Serial + "'"
-		}
-
-		// XXX deprecate; end up with duplicate lines if multiple
-		// adapters use it
-		if ib.XenCfg != "" {
-			log.Infof("Adding io adapter config <%s>\n", ib.XenCfg)
-			file.WriteString(fmt.Sprintf("%s\n", ib.XenCfg))
+			if ib.Serial != "" && config.VirtualizationMode == types.HVM {
+				log.Infof("Adding serial <%s>\n", ib.Serial)
+				serialAssignments = addNoDuplicate(serialAssignments, ib.Serial)
+			}
 		}
 	}
 	if len(pciAssignments) != 0 {
@@ -1594,29 +1592,76 @@ func configToXencfg(config types.DomainConfig, status types.DomainStatus,
 			if i != 0 {
 				cfg = cfg + ", "
 			}
+			short := types.PCILongToShort(pa.pciLong)
 			// USB controller are subject to legacy USB support from
 			// some BIOS. Use relaxed to get past that.
 			if pa.ioType == types.IoUSB {
 				cfg = cfg + fmt.Sprintf("'%s,rdm_policy=relaxed'",
-					pa.pciShort)
+					short)
 			} else {
-				cfg = cfg + fmt.Sprintf("'%s'", pa.pciShort)
+				cfg = cfg + fmt.Sprintf("'%s'", short)
 			}
 		}
 		cfg = cfg + "]"
 		log.Debugf("Adding pci config <%s>\n", cfg)
 		file.WriteString(fmt.Sprintf("%s\n", cfg))
 	}
+	irqString := ""
+	for _, irq := range irqAssignments {
+		if irqString != "" {
+			irqString += ","
+		}
+		irqString += irq
+	}
 	if irqString != "" {
 		file.WriteString(fmt.Sprintf("irqs = [%s]\n", irqString))
 	}
+	ioportString := ""
+	for _, ioports := range ioportsAssignments {
+		if ioportString != "" {
+			ioportString += ","
+		}
+		ioportString += ioports
+	}
 	if ioportString != "" {
 		file.WriteString(fmt.Sprintf("ioports = [%s]\n", ioportString))
+	}
+	serialString := ""
+	for _, serial := range serialAssignments {
+		if serialString != "" {
+			serialString += ","
+		}
+		serialString += "'" + serial + "'"
 	}
 	if serialString != "" {
 		file.WriteString(fmt.Sprintf("serial = [%s]\n", serialString))
 	}
 	return nil
+}
+
+type typeAndPCI struct {
+	pciLong string
+	ioType  types.IoType
+}
+
+func addNoDuplicatePCI(list []typeAndPCI, tap typeAndPCI) []typeAndPCI {
+
+	for _, t := range list {
+		if t.pciLong == tap.pciLong {
+			return list
+		}
+	}
+	return append(list, tap)
+}
+
+func addNoDuplicate(list []string, add string) []string {
+
+	for _, s := range list {
+		if s == add {
+			return list
+		}
+	}
+	return append(list, add)
 }
 
 func cp(dst, src string) error {
@@ -2270,25 +2315,22 @@ func handleAAModify(ctxArg interface{}, config types.AssignableAdapters,
 	log.Infof("handleAAModify() %+v\n", status)
 	// Any deletes?
 	for _, statusIb := range (*status).IoBundleList {
-		configIb := types.LookupIoBundle(&config, statusIb.Type, statusIb.Name)
+		configIb := config.LookupIoBundle(statusIb.Type, statusIb.Name)
 		if configIb == nil {
 			handleIBDelete(ctx, statusIb, status)
 		}
 	}
 	// Any add or modify?
 	for _, configIb := range config.IoBundleList {
-		statusIb := types.LookupIoBundle(status, configIb.Type, configIb.Name)
+		statusIb := status.LookupIoBundle(configIb.Type, configIb.Name)
 		if statusIb == nil {
 			handleIBCreate(ctx, configIb, status)
-		} else if !cmp.Equal(statusIb.Members, configIb.Members) ||
-			statusIb.Lookup != configIb.Lookup ||
+		} else if statusIb.AssignmentGroup != configIb.AssignmentGroup ||
 			statusIb.PciLong != configIb.PciLong ||
-			statusIb.PciShort != configIb.PciShort ||
 			statusIb.Ifname != configIb.Ifname ||
 			statusIb.Irq != configIb.Irq ||
 			statusIb.Ioports != configIb.Ioports ||
-			statusIb.Serial != configIb.Serial ||
-			statusIb.XenCfg != configIb.XenCfg {
+			statusIb.Serial != configIb.Serial {
 
 			handleIBModify(ctx, *statusIb, configIb, status)
 		}
@@ -2315,7 +2357,7 @@ func handleAADelete(ctxArg interface{}, status *types.AssignableAdapters) {
 func handleIBCreate(ctx *domainContext, ib types.IoBundle,
 	status *types.AssignableAdapters) {
 
-	log.Infof("handleIBCreate(%d %s %v)\n", ib.Type, ib.Name, ib.Members)
+	log.Infof("handleIBCreate(%d %s %s)", ib.Type, ib.Name, ib.AssignmentGroup)
 	if err := checkAndSetIoBundle(ctx, &ib); err != nil {
 		log.Warnf("Not reporting non-existent PCI device %d %s: %v\n",
 			ib.Type, ib.Name, err)
@@ -2336,105 +2378,86 @@ func checkAndSetIoBundleAll(ctx *domainContext) {
 
 func checkAndSetIoBundle(ctx *domainContext, ib *types.IoBundle) error {
 
-	// Check any member is part of DevicePortConfig
+	// Check if part of DevicePortConfig
 	ib.IsPort = false
 	publishAssignableAdapters := false
-	for _, m := range ib.Members {
-		if types.IsPort(ctx.deviceNetworkStatus, m) {
-			log.Warnf("checkAndSetIoBundle(%d %s %v) part of zedrouter port\n",
-				ib.Type, ib.Name, ib.Members)
-			ib.IsPort = true
-			if ib.IsPCIBack {
-				log.Infof("checkAndSetIoBundle(%d %s %v) take back from pciback\n",
-					ib.Type, ib.Name, ib.Members)
-				removeAll(ib)
-				ib.IsPCIBack = false
-				publishAssignableAdapters = true
-				// Verify that it has been returned from pciback
-				_, _, err := types.IoBundleToPci(ib)
+	if types.IsPort(ctx.deviceNetworkStatus, ib.Name) {
+		log.Warnf("checkAndSetIoBundle(%d %s %s) part of zedrouter port\n",
+			ib.Type, ib.Name, ib.AssignmentGroup)
+		ib.IsPort = true
+		if ib.IsPCIBack {
+			log.Infof("checkAndSetIoBundle(%d %s %s) take back from pciback\n",
+				ib.Type, ib.Name, ib.AssignmentGroup)
+			if ib.PciLong != "" {
+				log.Infof("Removing %s (%s) from pciback\n",
+					ib.Name, ib.PciLong)
+				err := pciAssignableRemove(ib.PciLong)
 				if err != nil {
-					log.Warnf("checkAndSetIoBundle(%d %s %v) gone?: %s\n",
-						ib.Type, ib.Name, ib.Members, err)
+					log.Errorf("checkAndSetIoBundle(%d %s %s) pciAssignableRemove %s failed %v\n",
+						ib.Type, ib.Name, ib.AssignmentGroup, ib.PciLong, err)
 				}
 			}
-		} else {
-			// XXX potentially move to PCIBack if not already
-			// and with USB check
-			// XXX should not do that when Testing is set.
+			ib.IsPCIBack = false
+			publishAssignableAdapters = true
+			// Verify that it has been returned from pciback
+			_, err := types.IoBundleToPci(ib)
+			if err != nil {
+				log.Warnf("checkAndSetIoBundle(%d %s %s) gone?: %s\n",
+					ib.Type, ib.Name, ib.AssignmentGroup, err)
+			}
 		}
+	} else {
+		// XXX potentially move to PCIBack if not already
+		// and with USB check
+		// XXX should not do that when Testing is set.
 	}
 	if publishAssignableAdapters {
 		ctx.publishAssignableAdapters()
 	}
 
-	// XXX verify the different aliases exist
 	// For a new PCI device we check if it exists in hardware/kernel
-	if ib.Lookup && ib.MPciShort == nil {
-		longs, shorts, err := types.IoBundleToPci(ib)
-		if err != nil {
-			return err
-		}
-		ib.MPciLong = longs
-		ib.MPciShort = shorts
-		ib.MUnique = make([]string, len(ib.Members))
-		log.Infof("checkAndSetIoBundle(%d %s %v) found %v %v\n",
-			ib.Type, ib.Name, ib.Members, shorts, longs)
+	long, err := types.IoBundleToPci(ib)
+	if err != nil {
+		return err
+	}
+	if long != "" {
+		ib.PciLong = long
+		log.Infof("checkAndSetIoBundle(%d %s %s) found %s\n",
+			ib.Type, ib.Name, ib.AssignmentGroup, long)
 
 		// Save somewhat Unique string for debug
-		for i, long := range ib.MPciLong {
-			found, unique := types.PciLongToUnique(long)
-			if !found {
-				errStr := fmt.Sprintf("IoBundle(%d %s %v) %s/%s unique %s not foun\n",
-					ib.Type, ib.Name, ib.Members,
-					ib.MPciShort[i], ib.MPciLong[i], ib.MUnique[i])
-				log.Errorln(errStr)
-			} else {
-				ib.MUnique[i] = unique
-				log.Infof("checkAndSetIoBundle(%d %s %v) %s/%s unique %s\n",
-					ib.Type, ib.Name, ib.Members, ib.MPciShort[i],
-					ib.MPciLong[i], ib.MUnique[i])
-			}
-		}
-		if ib.Type == types.IoEth { // XXX all network types
-			ib.MMacAddr = make([]string, len(ib.Members))
-			for i, m := range ib.Members {
-				ib.MMacAddr[i] = getMacAddr(m)
-			}
-		}
-	}
-	// Save somewhat Unique string for debug
-	if ib.PciLong != "" {
-		found, unique := types.PciLongToUnique(ib.PciLong)
+		found, unique := types.PciLongToUnique(long)
 		if !found {
-			errStr := fmt.Sprintf("IoBundle(%d %s %v) %s/%s unique %s not foun\n",
-				ib.Type, ib.Name, ib.Members,
-				ib.PciShort, ib.PciLong, ib.Unique)
+			errStr := fmt.Sprintf("IoBundle(%d %s %s) %s unique not found",
+				ib.Type, ib.Name, ib.AssignmentGroup, long)
 			log.Errorln(errStr)
-			return errors.New(errStr)
 		} else {
 			ib.Unique = unique
-			log.Infof("checkAndSetIoBundle(%d %s %v) %s/%s unique %s\n",
-				ib.Type, ib.Name, ib.Members, ib.PciShort,
-				ib.PciLong, ib.Unique)
+			log.Infof("checkAndSetIoBundle(%d %s %s) %s unique %s",
+				ib.Type, ib.Name, ib.AssignmentGroup, long, unique)
 		}
+		if ib.Type.IsNet() {
+			ib.MacAddr = getMacAddr(ib.Name)
+		}
+		ctx.publishAssignableAdapters()
 	}
 
 	if !ib.IsPort && !ib.IsPCIBack {
-		if ctx.deviceNetworkStatus.Testing && ib.Type == types.IoEth {
-			log.Infof("Not assigning %s (%s %s) to pciback due to Testing\n",
-				ib.Name, ib.PciLong, ib.PciShort)
+		if ctx.deviceNetworkStatus.Testing && ib.Type.IsNet() {
+			log.Infof("Not assigning %s (%s) to pciback due to Testing\n",
+				ib.Name, ib.PciLong)
 		} else if ctx.usbAccess && ib.Type == types.IoUSB {
-			log.Infof("Not assigning %s (%s %s) to pciback due to usbAccess\n",
-				ib.Name, ib.PciLong, ib.PciShort)
-		} else {
-			err, done := assignAll(ib)
+			log.Infof("Not assigning %s (%s) to pciback due to usbAccess\n",
+				ib.Name, ib.PciLong)
+		} else if ib.PciLong != "" {
+			log.Infof("Assigning %s (%s) to pciback\n",
+				ib.Name, ib.PciLong)
+			err := pciAssignableAdd(ib.PciLong)
 			if err != nil {
 				return err
 			}
-			if done {
-				ib.IsPCIBack = true
-				ctx.publishAssignableAdapters()
-			}
+			ib.IsPCIBack = true
+			ctx.publishAssignableAdapters()
 		}
 	}
 	return nil
@@ -2450,64 +2473,6 @@ func getMacAddr(ifname string) string {
 		return ""
 	}
 	return link.Attrs().HardwareAddr.String()
-}
-
-func removeAll(ib *types.IoBundle) {
-	if ib.PciShort != "" {
-		log.Infof("Removing %s (%s %s) from pciback\n",
-			ib.Name, ib.PciLong, ib.PciShort)
-		err := pciAssignableRemove(ib.PciLong)
-		if err != nil {
-			log.Errorf("checkAndSetIoBundle(%d %s %v) pciAssignableRemove %s failed %v\n",
-				ib.Type, ib.Name, ib.Members, ib.PciLong, err)
-		}
-		return
-	}
-
-	for i, long := range ib.MPciLong {
-		log.Infof("Removing %s member %s (%s) from pciback\n",
-			ib.Name, ib.Members[i], long)
-		err := pciAssignableRemove(long)
-		if err != nil {
-			log.Errorf("checkAndSetIoBundle(%d %s %v) pciAssignableRemove %s failed %v\n",
-				ib.Type, ib.Name, ib.Members, long, err)
-		}
-	}
-}
-
-func assignAll(ib *types.IoBundle) (error, bool) {
-	if ib.PciShort != "" {
-		log.Infof("Assigning %s (%s %s) to pciback\n",
-			ib.Name, ib.PciLong, ib.PciShort)
-		err := pciAssignableAdd(ib.PciLong)
-		if err != nil {
-			return err, false
-		}
-		return nil, true
-	} else if ib.MPciLong != nil {
-		var oneError error
-		for i, long := range ib.MPciLong {
-			log.Infof("Assigning %s member %s (%s) to pciback\n",
-				ib.Name, ib.Members[i], long)
-			err := pciAssignableAdd(long)
-			if err != nil {
-				// XXX return all errors? Here we return one error
-				log.Errorf("Partial error for %s: %s\n", long, err)
-				oneError = err
-			}
-		}
-		if oneError != nil {
-			// Undo any assignments from above
-			for i, long := range ib.MPciLong {
-				log.Infof("Unassigning %s member %s (%s) to pciback\n",
-					ib.Name, ib.Members[i], long)
-				pciAssignableRemove(long)
-			}
-			return oneError, false
-		}
-		return nil, true
-	}
-	return nil, false
 }
 
 // Check if anything moved around
@@ -2526,65 +2491,26 @@ func checkIoBundleAll(ctx *domainContext) {
 // changed in addition to the name to pci-id lookup.
 func checkIoBundle(ctx *domainContext, ib *types.IoBundle) error {
 
-	if ib.Lookup {
-		longs, shorts, err := types.IoBundleToPci(ib)
-		if err != nil {
-			return err
-		}
-		if shorts == nil {
-			// Doesn't exist
-			return nil
-		}
-		if len(ib.MPciLong) != len(longs) || len(ib.MPciShort) != len(shorts) {
-			errStr := fmt.Sprintf("IoBundle(%d %s %v) changed num members from %d/%d to %d/%d\n",
-				ib.Type, ib.Name, ib.Members,
-				len(ib.MPciShort), len(ib.MPciLong), len(shorts), len(longs))
-			return errors.New(errStr)
-		}
-		for i, long := range ib.MPciLong {
-			if long != longs[i] {
-				errStr := fmt.Sprintf("IoBundle(%d %s %v) long changed from %s to %s\n",
-					ib.Type, ib.Name, ib.Members,
-					long, longs[i])
-				return errors.New(errStr)
-			}
-			found, unique := types.PciLongToUnique(long)
-			if !found {
-				errStr := fmt.Sprintf("IoBundle(%d %s %v) %s unique %s not foun\n",
-					ib.Type, ib.Name, ib.Members,
-					long, ib.MUnique[i])
-				return errors.New(errStr)
-			}
-			if unique != ib.MUnique[i] {
-				errStr := fmt.Sprintf("IoBundle(%d %s %v) changed unique from %s to %sn",
-					ib.Type, ib.Name, ib.Members,
-					ib.MUnique[i], unique)
-				return errors.New(errStr)
-			}
-		}
-		for i, short := range ib.MPciShort {
-			if short != shorts[i] {
-				errStr := fmt.Sprintf("IoBundle(%d %s %v) short changed from %s to %s\n",
-					ib.Type, ib.Name, ib.Members,
-					short, shorts[i])
-				return errors.New(errStr)
-			}
-		}
+	long, err := types.IoBundleToPci(ib)
+	if err != nil {
+		return err
 	}
-	if ib.PciLong != "" {
-		found, unique := types.PciLongToUnique(ib.PciLong)
-		if !found {
-			errStr := fmt.Sprintf("IoBundle(%d %s %v) %s/%s unique %s not foun\n",
-				ib.Type, ib.Name, ib.Members,
-				ib.PciShort, ib.PciLong, ib.Unique)
-			return errors.New(errStr)
-		}
-		if unique != ib.Unique {
-			errStr := fmt.Sprintf("IoBundle(%d %s %v) changed unique from %s to %sn",
-				ib.Type, ib.Name, ib.Members,
-				ib.Unique, unique)
-			return errors.New(errStr)
-		}
+	if long == "" {
+		// Doesn't exist
+		return nil
+	}
+	found, unique := types.PciLongToUnique(long)
+	if !found {
+		errStr := fmt.Sprintf("IoBundle(%d %s %s) %s unique %s not foun\n",
+			ib.Type, ib.Name, ib.AssignmentGroup,
+			long, ib.Unique)
+		return errors.New(errStr)
+	}
+	if unique != ib.Unique {
+		errStr := fmt.Sprintf("IoBundle(%d %s %s) changed unique from %s to %sn",
+			ib.Type, ib.Name, ib.AssignmentGroup,
+			ib.Unique, unique)
+		return errors.New(errStr)
 	}
 	return nil
 }
@@ -2592,60 +2518,83 @@ func checkIoBundle(ctx *domainContext, ib *types.IoBundle) error {
 func updateUsbAccess(ctx *domainContext) {
 
 	log.Infof("updateUsbAccess(%t)", ctx.usbAccess)
+	if !ctx.usbAccess {
+		maybeAssignableAdd(ctx)
+	} else {
+		maybeAssignableRem(ctx)
+	}
+	checkIoBundleAll(ctx)
+}
+
+func maybeAssignableAdd(ctx *domainContext) {
+
+	var assignments []string
 	for i := range ctx.assignableAdapters.IoBundleList {
 		ib := &ctx.assignableAdapters.IoBundleList[i]
 		if ib.Type != types.IoUSB {
 			continue
 		}
-		if !ctx.usbAccess && !ib.IsPCIBack {
-			log.Infof("Assigning %s (%s %s) to pciback\n",
-				ib.Name, ib.PciLong, ib.PciShort)
-			err := pciAssignableAdd(ib.PciLong)
-			if err != nil {
-				log.Errorf("updateUsbAccess: %s\n", err)
-			}
+		if !ib.IsPCIBack {
+			log.Infof("Assigning %s (%s) to pciback\n",
+				ib.Name, ib.PciLong)
+			assignments = addNoDuplicate(assignments, ib.PciLong)
 			ib.IsPCIBack = true
 		}
-		if ctx.usbAccess && ib.IsPCIBack {
+	}
+	for _, long := range assignments {
+		err := pciAssignableAdd(long)
+		if err != nil {
+			log.Errorf("updateUsbAccess add failed: %s", err)
+		}
+	}
+	if len(assignments) != 0 {
+		ctx.publishAssignableAdapters()
+	}
+}
+
+func maybeAssignableRem(ctx *domainContext) {
+
+	var assignments []string
+	for i := range ctx.assignableAdapters.IoBundleList {
+		ib := &ctx.assignableAdapters.IoBundleList[i]
+		if ib.Type != types.IoUSB {
+			continue
+		}
+		if ib.IsPCIBack {
 			if ib.UsedByUUID == nilUUID {
-				log.Infof("Removing %s (%s %s) from pciback\n",
-					ib.Name, ib.PciLong, ib.PciShort)
-				err := pciAssignableRemove(ib.PciLong)
-				if err != nil {
-					log.Errorf("updateUsbAccess: %s\n", err)
-				}
+				log.Infof("Removing %s (%s) from pciback\n",
+					ib.Name, ib.PciLong)
+				assignments = addNoDuplicate(assignments, ib.PciLong)
 				ib.IsPCIBack = false
 			} else {
-				log.Warnf("No removing %s (%s %s) from pciback: used by %s",
-					ib.Name, ib.PciLong,
-					ib.PciShort, ib.UsedByUUID)
+				log.Warnf("No removing %s (%s) from pciback: used by %s",
+					ib.Name, ib.PciLong, ib.UsedByUUID)
 			}
 		}
 	}
-	checkIoBundleAll(ctx)
+	for _, long := range assignments {
+		err := pciAssignableRemove(long)
+		if err != nil {
+			log.Errorf("updateUsbAccess remove failed: %s\n", err)
+		}
+	}
+	if len(assignments) != 0 {
+		ctx.publishAssignableAdapters()
+	}
 }
 
 func handleIBDelete(ctx *domainContext, ib types.IoBundle,
 	status *types.AssignableAdapters) {
 
-	log.Infof("handleIBDelete(%d %s %v)\n", ib.Type, ib.Name, ib.Members)
+	log.Infof("handleIBDelete(%d %s %s)", ib.Type, ib.Name, ib.AssignmentGroup)
 	if ib.IsPCIBack {
-		log.Infof("handleIBDelete: Assigning %s (%s %s) back\n",
-			ib.Name, ib.PciLong, ib.PciShort)
+		log.Infof("handleIBDelete: Assigning %s (%s) back\n",
+			ib.Name, ib.PciLong)
 		if ib.PciLong != "" {
 			err := pciAssignableRemove(ib.PciLong)
 			if err != nil {
-				log.Errorf("handleIBDelete(%d %s %v) pciAssignableRemove %s failed %v\n",
-					ib.Type, ib.Name, ib.Members, ib.PciLong, err)
-			}
-			ib.IsPCIBack = false
-		} else if ib.MPciLong != nil {
-			for _, long := range ib.MPciLong {
-				err := pciAssignableRemove(long)
-				if err != nil {
-					log.Errorf("handleIBDelete(%d %s %v) pciAssignableRemove %s failed %v\n",
-						ib.Type, ib.Name, ib.Members, long, err)
-				}
+				log.Errorf("handleIBDelete(%d %s %s) pciAssignableRemove %s failed %v\n",
+					ib.Type, ib.Name, ib.AssignmentGroup, ib.PciLong, err)
 			}
 			ib.IsPCIBack = false
 		}
@@ -2665,8 +2614,8 @@ func handleIBDelete(ctx *domainContext, ib types.IoBundle,
 func handleIBModify(ctx *domainContext, statusIb types.IoBundle, configIb types.IoBundle,
 	status *types.AssignableAdapters) {
 
-	log.Infof("handleIBModify(%d %s %v) from %v to %v\n",
-		statusIb.Type, statusIb.Name, statusIb.Members,
+	log.Infof("handleIBModify(%d %s %s) from %v to %v\n",
+		statusIb.Type, statusIb.Name, statusIb.AssignmentGroup,
 		statusIb, configIb)
 
 	for i := range status.IoBundleList {
@@ -2681,21 +2630,7 @@ func handleIBModify(ctx *domainContext, statusIb types.IoBundle, configIb types.
 				configIb.Type, configIb.Name, err)
 			return
 		}
-		e.IsPort = configIb.IsPort
-		e.IsPCIBack = configIb.IsPCIBack
-		e.Lookup = configIb.Lookup
-		e.Ifname = configIb.Ifname
-		e.PciLong = configIb.PciLong
-		e.PciShort = configIb.PciShort
-		e.Irq = configIb.Irq
-		e.Ioports = configIb.Ioports
-		e.Serial = configIb.Serial
-		e.XenCfg = configIb.XenCfg
-		e.Unique = configIb.Unique
-		e.MPciLong = configIb.MPciLong
-		e.MPciShort = configIb.MPciShort
-		e.MUnique = configIb.MUnique
-		e.MMacAddr = configIb.MMacAddr
+		*e = configIb
 	}
 	checkIoBundleAll(ctx)
 }

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1352,7 +1352,7 @@ func configAdapters(ctx *domainContext, config types.DomainConfig) error {
 		list := ctx.assignableAdapters.LookupIoBundleGroup(
 			adapter.Type, adapter.Name)
 		if len(list) == 0 {
-			return fmt.Errorf("Unknown adapter %d %s\n",
+			return fmt.Errorf("unknown adapter %d %s",
 				adapter.Type, adapter.Name)
 		}
 		for _, ibp := range list {
@@ -1360,12 +1360,12 @@ func configAdapters(ctx *domainContext, config types.DomainConfig) error {
 				continue
 			}
 			if ibp.UsedByUUID != nilUUID {
-				return errors.New(fmt.Sprintf("Adapter %d %s used by %s\n",
-					adapter.Type, adapter.Name, ibp.UsedByUUID))
+				return fmt.Errorf("adapter %d %s used by %s",
+					adapter.Type, adapter.Name, ibp.UsedByUUID)
 			}
 			if isPort(ctx, ibp.Name) {
-				return errors.New(fmt.Sprintf("Adapter %d %s member %s is (part of) a zedrouter port\n",
-					adapter.Type, adapter.Name, ibp.Name))
+				return fmt.Errorf("adapter %d %s member %s is (part of) a zedrouter port",
+					adapter.Type, adapter.Name, ibp.Name)
 			}
 
 			log.Debugf("configAdapters setting uuid %s for adapter %d %s member %s",

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1492,7 +1492,7 @@ func configToXencfg(config types.DomainConfig, status types.DomainStatus,
 	// knob in manifest
 
 	var serialAssignments []string
-	serialAssignments = append(serialAssignments, "'pty'")
+	serialAssignments = append(serialAssignments, "pty")
 
 	// Always prefer CDROM vdisk over disk
 	file.WriteString(fmt.Sprintf("boot = \"%s\"\n", "dc"))

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -812,7 +812,7 @@ func isAssigned(ctx *nimContext, ifname string) bool {
 
 	log.Infof("isAssigned(%s) have %d bundles\n",
 		ifname, len(ctx.AssignableAdapters.IoBundleList))
-	ib := ctx.AssignableAdapters.LookupIoBundleForMember(types.IoEth, ifname)
+	ib := ctx.AssignableAdapters.LookupIoBundleNet(ifname)
 	if ib == nil {
 		return false
 	}

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -1066,21 +1066,46 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 	// Domainmgr excludes adapters which do not currently exist in
 	// what it publishes.
 	// We also mark current management ports as such.
-	for i := range aa.IoBundleList {
-		ib := &aa.IoBundleList[i]
+	var seenBundles []string
+	for _, ib := range aa.IoBundleList {
+		// Report each group once
+		seen := false
+		for _, s := range seenBundles {
+			if s == ib.AssignmentGroup {
+				seen = true
+				break
+			}
+		}
+		if seen {
+			continue
+		}
+		seenBundles = append(seenBundles, ib.AssignmentGroup)
 		reportAA := new(info.ZioBundle)
 		reportAA.Type = info.IPhyIoType(ib.Type)
-		reportAA.Name = ib.Name
-		reportAA.Members = ib.Members
+		reportAA.Name = ib.AssignmentGroup
+		list := aa.LookupIoBundleGroup(ib.Type, ib.AssignmentGroup)
+		if len(list) == 0 {
+			log.Infof("Nothing to report for %d %s",
+				ib.Type, ib.AssignmentGroup)
+			continue
+		}
+		for _, b := range list {
+			if b == nil {
+				continue
+			}
+			reportAA.Members = append(reportAA.Members,
+				b.Name)
+			if b.MacAddr != "" {
+				reportMac := new(info.IoAddresses)
+				reportMac.MacAddress = b.MacAddr
+				reportAA.IoAddressList = append(reportAA.IoAddressList,
+					reportMac)
+			}
+		}
 		if ib.IsPort {
 			reportAA.UsedByBaseOS = true
 		} else if ib.UsedByUUID != nilUUID {
 			reportAA.UsedByAppUUID = ib.UsedByUUID.String()
-		}
-		for _, m := range ib.MMacAddr {
-			reportMac := new(info.IoAddresses)
-			reportMac.MacAddress = m
-			reportAA.IoAddressList = append(reportAA.IoAddressList, reportMac)
 		}
 		// XXX remove? debug?
 		log.Infof("AssignableAdapters for %s macs %v",
@@ -1520,18 +1545,22 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 			ReportAppInfo.BootTime = bootTime
 		}
 
-		for _, ib := range ds.IoAdapterList {
+		for _, ia := range ds.IoAdapterList {
 			reportAA := new(info.ZioBundle)
-			reportAA.Type = info.IPhyIoType(ib.Type)
-			reportAA.Name = ib.Name
+			reportAA.Type = info.IPhyIoType(ia.Type)
+			reportAA.Name = ia.Name
 			reportAA.UsedByAppUUID = ds.Key()
-			b := types.LookupIoBundle(aa, ib.Type, ib.Name)
-			if b != nil {
-				reportAA.Members = b.Members
-				for _, m := range b.MMacAddr {
+			list := aa.LookupIoBundleGroup(ia.Type, ia.Name)
+			for _, ib := range list {
+				if ib == nil {
+					continue
+				}
+				reportAA.Members = append(reportAA.Members, ib.Name)
+				if ib.MacAddr != "" {
 					reportMac := new(info.IoAddresses)
-					reportMac.MacAddress = m
-					reportAA.IoAddressList = append(reportAA.IoAddressList, reportMac)
+					reportMac.MacAddress = ib.MacAddr
+					reportAA.IoAddressList = append(reportAA.IoAddressList,
+						reportMac)
 				}
 				// XXX remove? debug?
 				log.Infof("AssignableAdapters for %s macs %v",

--- a/pkg/pillar/cmd/zedrouter/acl.go
+++ b/pkg/pillar/cmd/zedrouter/acl.go
@@ -921,10 +921,12 @@ func matchACLForPortMap(ACLs []types.ACE) bool {
 					// check for protocol/TargetPort
 					if action.TargetPort == action1.TargetPort &&
 						checkForMatchCondition(ace, ace1, matchTypes) {
+						log.Errorf("match found for %d %d: ace %v ace1 %v", idx, idx1, ace, ace1)
 						return true
 					}
 					// check for protocol/lport
 					if checkForMatchCondition(ace, ace1, matchTypes1) {
+						log.Errorf("match found for %d %d: ace %v ace1 %v", idx, idx1, ace, ace1)
 						return true
 					}
 				}
@@ -954,6 +956,7 @@ func matchACLsForPortMap(ACLs []types.ACE, ACLs1 []types.ACE) bool {
 					}
 					// match for protocol/lport
 					if checkForMatchCondition(ace, ace1, matchTypes) {
+						log.Errorf("match found for ace %v ace1 %v", ace, ace1)
 						return true
 					}
 				}
@@ -984,6 +987,8 @@ func checkForMatchCondition(ace types.ACE, ace1 types.ACE, matchTypes []string) 
 		value1 := valueList1[idx]
 		if value == "" || value1 == "" ||
 			value != value1 {
+			log.Infof("difference for %d: value %s value1 %s",
+				idx, value, value1)
 			return false
 		}
 	}

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -2682,11 +2682,15 @@ func validateAppNetworkConfig(ctx *zedrouterContext, appNetConfig types.AppNetwo
 	for _, cfg := range items {
 		appNetConfig1 := cast.CastAppNetworkConfig(cfg)
 		ulCfgList1 := appNetConfig1.UnderlayNetworkList
+		// XXX can an delete+add of app instance with same
+		// portmap result in a failure?
 		if appNetConfig.DisplayName == appNetConfig1.DisplayName ||
 			len(ulCfgList1) == 0 {
 			continue
 		}
 		if checkUnderlayNetworkForPortMapOverlap(ctx, appNetStatus, ulCfgList0, ulCfgList1) {
+			log.Errorf("app %s and %s have duplicate portmaps",
+				appNetConfig.DisplayName, appNetConfig1.DisplayName)
 			return false
 		}
 	}

--- a/pkg/pillar/conf/AssignableAdapters/AAEON.UP-APL01.json
+++ b/pkg/pillar/conf/AssignableAdapters/AAEON.UP-APL01.json
@@ -1,6 +1,8 @@
 { "IoBundleList": [
-    { "Type": 1, "Name": "eth0", "Members": [ "eth0" ], "Lookup": true },
-    { "Type": 1, "Name": "eth1", "Members": [ "eth1" ], "Lookup": true },
-    { "Type": 2, "Name": "USB", "Members": [ "USB0", "USB1", "USB2" ], "PciLong": "0000:00:15.0", "PciShort": "00:15.0" },
-    { "Type": 255, "Name": "Audio", "Members": [ "AudioOut" ], "PciLong": "0000:00:0e.0", "PciShort":"00:0e.0" }
+    { "Type": 1, "Name": "eth0", "AssignmentGroup": "eth0", "Ifname": "eth0" },
+    { "Type": 1, "Name": "eth1", "AssignmentGroup": "eth1", "Ifname": "eth1" },
+    { "Type": 2, "Name": "USB0", "AssignmentGroup": "USB", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB1", "AssignmentGroup": "USB", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB2", "AssignmentGroup": "USB", "PciLong": "0000:00:15.0"},
+    { "Type": 4, "Name": "Audio", "AssignmentGroup": "Audio", "PciLong": "0000:00:0e.0" }
 ] }

--- a/pkg/pillar/conf/AssignableAdapters/Advantech.ARK-1124.json
+++ b/pkg/pillar/conf/AssignableAdapters/Advantech.ARK-1124.json
@@ -1,8 +1,11 @@
 { "IoBundleList": [
-    { "Type": 1, "Name": "eth0", "Members": [ "eth0" ], "Lookup": true },
-    { "Type": 1, "Name": "eth1", "Members": [ "eth1" ], "Lookup": true },
-    { "Type": 2, "Name": "USB", "Members": [ "USB0", "USB1", "USB2", "USB3" ], "PciLong": "0000:00:15.0", "PciShort": "00:15.0"},
-    { "Type": 3, "Name": "COM1", "Members": [ "COM1" ], "XenCfg": "irqs=[4]\nioports=['3f8-3ff']\n" },
-    { "Type": 3, "Name": "COM2", "Members": [ "COM2" ], "XenCfg": "irqs=[3]\nioports=['2f8-2ff']\n" },
-    { "Type": 255, "Name": "Audio", "Members": [ "AudioOut" ], "PciLong": "0000:00:0e.0", "PciShort":"00:0e.0" }
+    { "Type": 1, "Name": "eth0", "AssignmentGroup": "eth0", "Ifname": "eth0" },
+    { "Type": 1, "Name": "eth1", "AssignmentGroup": "eth1", "Ifname": "eth1" },
+    { "Type": 2, "Name": "USB0", "AssignmentGroup": "USB", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB1", "AssignmentGroup": "USB", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB2", "AssignmentGroup": "USB", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB3", "AssignmentGroup": "USB", "PciLong": "0000:00:15.0"},
+    { "Type": 3, "Name": "COM1", "AssignmentGroup": "COM1", "Irq": "5", "Ioports": "3f8-3ff", "Serial": "/dev/ttyS0"},
+    { "Type": 3, "Name": "COM2", "AssignmentGroup": "COM2", "Irq": "3", "Ioports": "2f8-2ff", "Serial": "/dev/ttyS1"},
+    { "Type": 4, "Name": "Audio", "AssignmentGroup": "Audio", "PciLong": "0000:00:0e.0" }
 ] }

--- a/pkg/pillar/conf/AssignableAdapters/Advantech.EIS-D150.json
+++ b/pkg/pillar/conf/AssignableAdapters/Advantech.EIS-D150.json
@@ -1,6 +1,11 @@
 { "IoBundleList": [
-    { "Type": 1, "Name": "eth0", "Members": [ "eth0" ], "Lookup": true },
-    { "Type": 1, "Name": "eth1", "Members": [ "eth1" ], "Lookup": true },
-    { "Type": 1, "Name": "wlan0", "Members": [ "wlan0" ], "PciLong": "0000:01:00.0", "PciShort":"01:00.0" },
-    { "Type": 2, "Name": "USB", "Members": [ "USB0", "USB1", "USB2", "USB3", "USB4", "USB5" ], "PciLong": "0000:00:14.0", "PciShort": "00:14.0"}
+    { "Type": 1, "Name": "eth0", "AssignmentGroup": "eth0", "Ifname": "eth0" },
+    { "Type": 1, "Name": "eth1", "AssignmentGroup": "eth1", "Ifname": "eth1" },
+    { "Type": 5, "Name": "wlan0", "AssignmentGroup": "wlan0", "PciLong": "0000:01:00.0" },
+    { "Type": 2, "Name": "USB0", "AssignmentGroup": "USB", "PciLong": "0000:00:14.0"},
+    { "Type": 2, "Name": "USB1", "AssignmentGroup": "USB", "PciLong": "0000:00:14.0"},
+    { "Type": 2, "Name": "USB2", "AssignmentGroup": "USB", "PciLong": "0000:00:14.0"},
+    { "Type": 2, "Name": "USB3", "AssignmentGroup": "USB", "PciLong": "0000:00:14.0"},
+    { "Type": 2, "Name": "USB4", "AssignmentGroup": "USB", "PciLong": "0000:00:14.0"},
+    { "Type": 2, "Name": "USB5", "AssignmentGroup": "USB", "PciLong": "0000:00:14.0"}
 ] }

--- a/pkg/pillar/conf/AssignableAdapters/Advantech.EIS-D210.json
+++ b/pkg/pillar/conf/AssignableAdapters/Advantech.EIS-D210.json
@@ -1,8 +1,11 @@
 { "IoBundleList": [
-    { "Type": 1, "Name": "eth0", "Members": [ "eth0" ], "Lookup": true },
-    { "Type": 1, "Name": "eth1", "Members": [ "eth1" ], "Lookup": true },
-    { "Type": 2, "Name": "USB", "Members": [ "USB0", "USB1", "USB2", "USB3" ], "PciLong": "0000:00:15.0", "PciShort": "00:15.0"},
-    { "Type": 3, "Name": "COM1", "Members": [ "COM1" ], "XenCfg": "irqs=[4]\nioports=['3f8-3ff']\n" },
-    { "Type": 3, "Name": "COM2", "Members": [ "COM2" ], "XenCfg": "irqs=[3]\nioports=['2f8-2ff']\n" },
-    { "Type": 255, "Name": "Audio", "Members": [ "AudioOut" ], "PciLong": "0000:00:0e.0", "PciShort":"00:0e.0" }
+    { "Type": 1, "Name": "eth0", "AssignmentGroup": "eth0", "Ifname": "eth0" },
+    { "Type": 1, "Name": "eth1", "AssignmentGroup": "eth1", "Ifname": "eth1" },
+    { "Type": 2, "Name": "USB0", "AssignmentGroup": "USB", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB1", "AssignmentGroup": "USB", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB2", "AssignmentGroup": "USB", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB3", "AssignmentGroup": "USB", "PciLong": "0000:00:15.0"},
+    { "Type": 3, "Name": "COM1", "AssignmentGroup": "COM1", "Irq": "4", "Ioports": "3f8-3ff", "Serial": "/dev/ttyS0"},
+    { "Type": 3, "Name": "COM2", "AssignmentGroup": "COM2", "Irq": "3", "Ioports": "2f8-2ff", "Serial": "/dev/ttyS1"},
+    { "Type": 4, "Name": "Audio", "AssignmentGroup": "Audio", "PciLong": "0000:00:0e.0" }
 ] }

--- a/pkg/pillar/conf/AssignableAdapters/Advantech.FWA-1012VC.json
+++ b/pkg/pillar/conf/AssignableAdapters/Advantech.FWA-1012VC.json
@@ -1,10 +1,11 @@
 { "IoBundleList": [
-    { "Type": 1, "Name": "eth0", "Members": [ "eth0" ], "Lookup": true },
-    { "Type": 1, "Name": "eth1", "Members": [ "eth1" ], "Lookup": true },
-    { "Type": 1, "Name": "eth2", "Members": [ "eth2" ], "Lookup": true },
-    { "Type": 1, "Name": "eth3", "Members": [ "eth3" ], "Lookup": true },
-    { "Type": 1, "Name": "eth4", "Members": [ "eth4" ], "Lookup": true },
-    { "Type": 1, "Name": "eth5", "Members": [ "eth5" ], "Lookup": true },
-    { "Type": 1, "Name": "wlan0", "Members": [ "wlan0" ], "PciLong": "0000:02:00.0", "PciShort": "02:00.0" },
-    { "Type": 2, "Name": "USB", "Members": [ "USB0", "USB1" ], "PciLong": "0000:00:15.0", "PciShort": "00:15.0"}
+    { "Type": 1, "Name": "eth0", "AssignmentGroup": "eth0", "Ifname": "eth0" },
+    { "Type": 1, "Name": "eth1", "AssignmentGroup": "eth1", "Ifname": "eth1" },
+    { "Type": 1, "Name": "eth2", "AssignmentGroup": "eth2", "Ifname": "eth2" },
+    { "Type": 1, "Name": "eth3", "AssignmentGroup": "eth3", "Ifname": "eth3" },
+    { "Type": 1, "Name": "eth4", "AssignmentGroup": "eth4", "Ifname": "eth4" },
+    { "Type": 1, "Name": "eth5", "AssignmentGroup": "eth5", "Ifname": "eth5" },
+    { "Type": 5, "Name": "wlan0", "AssignmentGroup": "wlan0", "PciLong": "0000:02:00.0" },
+    { "Type": 2, "Name": "USB0", "AssignmentGroup": "USB", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB1", "AssignmentGroup": "USB", "PciLong": "0000:00:15.0"}
 ] }

--- a/pkg/pillar/conf/AssignableAdapters/Advantech.FWA-T011.json
+++ b/pkg/pillar/conf/AssignableAdapters/Advantech.FWA-T011.json
@@ -1,8 +1,9 @@
 { "IoBundleList": [
-    { "Type": 1, "Name": "eth0", "Members": [ "eth0" ], "Lookup": true },
-    { "Type": 1, "Name": "eth1", "Members": [ "eth1" ], "Lookup": true },
-    { "Type": 1, "Name": "eth2", "Members": [ "eth2" ], "Lookup": true },
-    { "Type": 1, "Name": "eth3", "Members": [ "eth3" ], "Lookup": true },
-    { "Type": 1, "Name": "wlan0", "Members": [ "wlan0" ], "PciLong": "0000:05:00.0", "PciShort": "05:00.0" },
-    { "Type": 2, "Name": "USB", "Members": [ "USB0", "USB1" ], "PciLong": "0000:00:15.0", "PciShort": "00:15.0"}
+    { "Type": 1, "Name": "eth0", "AssignmentGroup": "eth0", "Ifname": "eth0" },
+    { "Type": 1, "Name": "eth1", "AssignmentGroup": "eth1", "Ifname": "eth1" },
+    { "Type": 1, "Name": "eth2", "AssignmentGroup": "eth2", "Ifname": "eth2" },
+    { "Type": 1, "Name": "eth3", "AssignmentGroup": "eth3", "Ifname": "eth3" },
+    { "Type": 5, "Name": "wlan0", "AssignmentGroup": "wlan0", "PciLong": "0000:05:00.0" },
+    { "Type": 2, "Name": "USB0", "AssignmentGroup": "USB", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB1", "AssignmentGroup": "USB", "PciLong": "0000:00:15.0"}
 ] }

--- a/pkg/pillar/conf/AssignableAdapters/Advantech.UTX-3117.json
+++ b/pkg/pillar/conf/AssignableAdapters/Advantech.UTX-3117.json
@@ -1,9 +1,10 @@
 { "IoBundleList": [
-    { "Type": 1, "Name": "eth0", "Members": [ "eth0" ], "Lookup": true },
-    { "Type": 1, "Name": "eth1", "Members": [ "eth1" ], "Lookup": true },
-    { "Type": 1, "Name": "wlan0", "Members": [ "wlan0" ], "Lookup": true },
-    { "Type": 2, "Name": "USB-A", "Members": [ "USB0", "USB1" ], "PciLong": "0000:00:15.0", "PciShort": "00:15.0"},
-    { "Type": 3, "Name": "COM1", "Members": [ "COM1" ], "XenCfg": "irqs=[4]\nioports=['3f8-3ff']\n" },
-    { "Type": 3, "Name": "COM2", "Members": [ "COM2" ], "XenCfg": "irqs=[3]\nioports=['2f8-2ff']\n" },
-    { "Type": 255, "Name": "Audio", "Members": [ "AudioOut" ], "PciLong": "0000:00:0e.0", "PciShort":"00:0e.0" }
+    { "Type": 1, "Name": "eth0", "AssignmentGroup": "eth0", "Ifname": "eth0" },
+    { "Type": 1, "Name": "eth1", "AssignmentGroup": "eth1", "Ifname": "eth1" },
+    { "Type": 5, "Name": "wlan0", "AssignmentGroup": "wlan0", "Ifname": "wlan0" },
+    { "Type": 2, "Name": "USB0", "AssignmentGroup": "USB-A", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB1", "AssignmentGroup": "USB-A", "PciLong": "0000:00:15.0"},
+    { "Type": 3, "Name": "COM1", "AssignmentGroup": "COM1", "Irq": "4", "Ioports": "3f8-3ff", "Serial": "/dev/ttyS0"},
+    { "Type": 3, "Name": "COM2", "AssignmentGroup": "COM2", "Irq": "3", "Ioports": "2f8-2ff", "Serial": "/dev/ttyS1"},
+    { "Type": 4, "Name": "Audio", "AssignmentGroup": "Audio", "PciLong": "0000:00:0e.0" }
 ] }

--- a/pkg/pillar/conf/AssignableAdapters/Default string.Default string.json
+++ b/pkg/pillar/conf/AssignableAdapters/Default string.Default string.json
@@ -1,4 +1,4 @@
 { "IoBundleList": [
-    { "Type": 1, "Name": "eth0", "Members": [ "eth0" ], "Lookup": true },
-    { "Type": 1, "Name": "eth1", "Members": [ "eth1" ], "Lookup": true }
+    { "Type": 1, "Name": "eth0", "AssignmentGroup": "eth0", "Ifname": "eth0" },
+    { "Type": 1, "Name": "eth1", "AssignmentGroup": "eth1", "Ifname": "eth1" }
 ] }

--- a/pkg/pillar/conf/AssignableAdapters/Lanner.LEC-6041A.json
+++ b/pkg/pillar/conf/AssignableAdapters/Lanner.LEC-6041A.json
@@ -1,11 +1,12 @@
 { "IoBundleList": [
-    { "Type": 1, "Name": "eth0", "Members": [ "eth0" ], "Lookup": true },
-    { "Type": 1, "Name": "eth1", "Members": [ "eth1" ], "Lookup": true },
-    { "Type": 1, "Name": "eth2", "Members": [ "eth2" ], "Lookup": true },
-    { "Type": 1, "Name": "eth3", "Members": [ "eth3" ], "Lookup": true },
-    { "Type": 1, "Name": "eth4", "Members": [ "eth4" ], "Lookup": true },
-    { "Type": 1, "Name": "eth5", "Members": [ "eth5" ], "Lookup": true },
-    { "Type": 2, "Name": "USB-A", "Members": [ "USB0", "USB1" ], "PciLong": "0000:00:15.0", "PciShort": "00:15.0"},
-    { "Type": 3, "Name": "COM1", "Members": [ "COM1" ], "XenCfg": "irqs=[4]\nioports=['3f8-3ff']\n" },
-    { "Type": 3, "Name": "COM2", "Members": [ "COM2" ], "XenCfg": "irqs=[3]\nioports=['2f8-2ff']\n" }
+    { "Type": 1, "Name": "eth0", "AssignmentGroup": "eth0", "Ifname": "eth0" },
+    { "Type": 1, "Name": "eth1", "AssignmentGroup": "eth1", "Ifname": "eth1" },
+    { "Type": 1, "Name": "eth2", "AssignmentGroup": "eth2", "Ifname": "eth2" },
+    { "Type": 1, "Name": "eth3", "AssignmentGroup": "eth3", "Ifname": "eth3" },
+    { "Type": 1, "Name": "eth4", "AssignmentGroup": "eth4", "Ifname": "eth4" },
+    { "Type": 1, "Name": "eth5", "AssignmentGroup": "eth5", "Ifname": "eth5" },
+    { "Type": 2, "Name": "USB0", "AssignmentGroup": "USB-A", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB1", "AssignmentGroup": "USB-A", "PciLong": "0000:00:15.0"},
+    { "Type": 3, "Name": "COM1", "AssignmentGroup": "COM1", "Irq": "4", "Ioports": "3f8-3ff", "Serial": "/dev/ttyS0"},
+    { "Type": 3, "Name": "COM2", "AssignmentGroup": "COM2", "Irq": "3", "Ioports": "2f8-2ff", "Serial": "/dev/ttyS1"}
 ] }

--- a/pkg/pillar/conf/AssignableAdapters/Nexcom.NIFE105.json
+++ b/pkg/pillar/conf/AssignableAdapters/Nexcom.NIFE105.json
@@ -1,10 +1,13 @@
 { "IoBundleList": [
-    { "Type": 1, "Name": "eth0", "Members": [ "eth0" ], "Lookup": true },
-    { "Type": 1, "Name": "eth1", "Members": [ "eth1" ], "Lookup": true },
-    { "Type": 2, "Name": "USB", "Members": [ "USB0", "USB1", "USB2", "USB3" ], "PciLong": "0000:00:15.0", "PciShort": "00:15.0"},
-    { "Type": 3, "Name": "COM1", "Members": [ "COM1" ], "XenCfg": "irqs=[4]\nioports=['3f8-3ff']\n" },
-    { "Type": 3, "Name": "COM2", "Members": [ "COM2" ], "XenCfg": "irqs=[5]\nioports=['2f8-2ff']\n" },
-    { "Type": 3, "Name": "COM3", "Members": [ "COM3" ], "XenCfg": "irqs=[10]\nioports=['2e8-2ef']\n" },
-    { "Type": 3, "Name": "COM4", "Members": [ "COM4" ], "XenCfg": "irqs=[11]\nioports=['3e8-3ef']\n" },
-    { "Type": 255, "Name": "Audio", "Members": [ "AudioOut" ], "PciLong": "0000:00:0e.0", "PciShort":"00:0e.0" }
+    { "Type": 1, "Name": "eth0", "AssignmentGroup": "eth0", "Ifname": "eth0" },
+    { "Type": 1, "Name": "eth1", "AssignmentGroup": "eth1", "Ifname": "eth1" },
+    { "Type": 2, "Name": "USB0", "AssignmentGroup": "USB", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB1", "AssignmentGroup": "USB", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB2", "AssignmentGroup": "USB", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB3", "AssignmentGroup": "USB", "PciLong": "0000:00:15.0"},
+    { "Type": 3, "Name": "COM1", "AssignmentGroup": "COM1", "Irq": "4", "Ioports": "3f8-3ff", "Serial": "/dev/ttyS0"},
+    { "Type": 3, "Name": "COM2", "AssignmentGroup": "COM2", "Irq": "3", "Ioports": "2f8-2ff", "Serial": "/dev/ttyS1"},
+    { "Type": 3, "Name": "COM3", "AssignmentGroup": "COM3", "Irq": "10", "Ioports": "2e8-2ef", "Serial": "/dev/ttyS2"},
+    { "Type": 3, "Name": "COM4", "AssignmentGroup": "COM4", "Irq": "11", "Ioports": "3e8-3ef", "Serial": "/dev/ttyS3"},
+    { "Type": 4, "Name": "Audio", "AssignmentGroup": "Audio", "PciLong": "0000:00:0e.0" }
 ] }

--- a/pkg/pillar/conf/AssignableAdapters/QEMU.Standard PC (i440FX + PIIX, 1996).json
+++ b/pkg/pillar/conf/AssignableAdapters/QEMU.Standard PC (i440FX + PIIX, 1996).json
@@ -1,4 +1,4 @@
 { "IoBundleList": [
-    { "Type": 1, "Name": "eth0", "Members": [ "eth0" ], "Lookup": true },
-    { "Type": 1, "Name": "eth1", "Members": [ "eth1" ], "Lookup": true }
+    { "Type": 1, "Name": "eth0", "AssignmentGroup": "eth0", "Ifname": "eth0" },
+    { "Type": 1, "Name": "eth1", "AssignmentGroup": "eth1", "Ifname": "eth1" }
 ] }

--- a/pkg/pillar/conf/AssignableAdapters/SIEMENS AG.SIMATIC IPC127E.json
+++ b/pkg/pillar/conf/AssignableAdapters/SIEMENS AG.SIMATIC IPC127E.json
@@ -1,6 +1,9 @@
 { "IoBundleList": [
-    { "Type": 1, "Name": "eth0", "Members": [ "eth0" ], "Lookup": true },
-    { "Type": 1, "Name": "eth1", "Members": [ "eth1" ], "Lookup": true },
-    { "Type": 1, "Name": "eth2", "Members": [ "eth2" ], "Lookup": true },
-    { "Type": 2, "Name": "USB", "Members": [ "USB0", "USB1", "USB2", "USB3" ], "PciLong": "0000:00:15.0", "PciShort": "00:15.0"}
+    { "Type": 1, "Name": "eth0", "AssignmentGroup": "eth0", "Ifname": "eth0" },
+    { "Type": 1, "Name": "eth1", "AssignmentGroup": "eth1", "Ifname": "eth1" },
+    { "Type": 1, "Name": "eth2", "AssignmentGroup": "eth2", "Ifname": "eth2" },
+    { "Type": 2, "Name": "USB0", "AssignmentGroup": "USB", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB1", "AssignmentGroup": "USB", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB2", "AssignmentGroup": "USB", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB3", "AssignmentGroup": "USB", "PciLong": "0000:00:15.0"}
 ] }

--- a/pkg/pillar/conf/AssignableAdapters/SIEMENS AG.SIMATIC IPC427E.json
+++ b/pkg/pillar/conf/AssignableAdapters/SIEMENS AG.SIMATIC IPC427E.json
@@ -1,8 +1,11 @@
 { "IoBundleList": [
-    { "Type": 1, "Name": "eth0", "Members": [ "eth0" ], "Lookup": true },
-    { "Type": 1, "Name": "eth1", "Members": [ "eth1" ], "Lookup": true },
-    { "Type": 1, "Name": "eth2", "Members": [ "eth2" ], "Lookup": true },
-    { "Type": 2, "Name": "USB", "Members": [ "USB0", "USB1", "USB2", "USB3" ], "PciLong": "0000:00:14.0", "PciShort": "00:14.0"},
-    { "Type": 3, "Name": "COM1", "Members": [ "COM1" ], "XenCfg": "irqs=[4]\nioports=['3f8-3ff']\n" },
-    { "Type": 3, "Name": "COM2", "Members": [ "COM2" ], "XenCfg": "irqs=[3]\nioports=['2f8-2ff']\n" }
+    { "Type": 1, "Name": "eth0", "AssignmentGroup": "eth0", "Ifname": "eth0" },
+    { "Type": 1, "Name": "eth1", "AssignmentGroup": "eth1", "Ifname": "eth1" },
+    { "Type": 1, "Name": "eth2", "AssignmentGroup": "eth2", "Ifname": "eth2" },
+    { "Type": 2, "Name": "USB0", "AssignmentGroup": "USB", "PciLong": "0000:00:14.0"},
+    { "Type": 2, "Name": "USB1", "AssignmentGroup": "USB", "PciLong": "0000:00:14.0"},
+    { "Type": 2, "Name": "USB2", "AssignmentGroup": "USB", "PciLong": "0000:00:14.0"},
+    { "Type": 2, "Name": "USB3", "AssignmentGroup": "USB", "PciLong": "0000:00:14.0"},
+    { "Type": 3, "Name": "COM1", "AssignmentGroup": "COM1", "Irq": "4", "Ioports": "3f8-3ff", "Serial": "/dev/ttyS0"},
+    { "Type": 3, "Name": "COM2", "AssignmentGroup": "COM2", "Irq": "3", "Ioports": "2f8-2ff", "Serial": "/dev/ttyS1"}
 ] }

--- a/pkg/pillar/conf/AssignableAdapters/Supermicro.SYS-5018D-FN8T.json
+++ b/pkg/pillar/conf/AssignableAdapters/Supermicro.SYS-5018D-FN8T.json
@@ -1,8 +1,13 @@
 { "IoBundleList": [
-    { "Type": 1, "Name": "eth0-1", "Members": [ "eth0", "eth1"], "Lookup": true },
-    { "Type": 1, "Name": "eth2", "Members": [ "eth2" ], "Lookup": true },
-    { "Type": 1, "Name": "eth3", "Members": [ "eth3" ], "Lookup": true },
-    { "Type": 1, "Name": "eth4-7", "Members": [ "eth4", "eth5", "eth6", "eth7" ], "Lookup": true },
-    { "Type": 2, "Name": "USB", "Members": [ "USB0", "USB1" ], "PciLong": "0000:00:14.0", "Pcishort":"00:14.0" },
-    { "Type": 3, "Name": "COM1", "Members": [ "COM1" ], "XenCfg": "irqs=[4]\nioports=['3f8-3ff']\n" }
+    { "Type": 1, "Name": "eth0", "AssignmentGroup": "eth0-1", "Ifname": "eth0" },
+    { "Type": 1, "Name": "eth1", "AssignmentGroup": "eth0-1", "Ifname": "eth1" },
+    { "Type": 1, "Name": "eth2", "AssignmentGroup": "eth2", "Ifname": "eth2" },
+    { "Type": 1, "Name": "eth3", "AssignmentGroup": "eth3", "Ifname": "eth3" },
+    { "Type": 1, "Name": "eth4", "AssignmentGroup": "eth4-7", "Ifname": "eth4" },
+    { "Type": 1, "Name": "eth5", "AssignmentGroup": "eth4-7", "Ifname": "eth5" },
+    { "Type": 1, "Name": "eth6", "AssignmentGroup": "eth4-7", "Ifname": "eth6" },
+    { "Type": 1, "Name": "eth7", "AssignmentGroup": "eth4-7", "Ifname": "eth7" },
+    { "Type": 2, "Name": "USB0", "AssignmentGroup": "USB", "PciLong": "0000:00:14.0"},
+    { "Type": 2, "Name": "USB1", "AssignmentGroup": "USB", "PciLong": "0000:00:14.0"},
+    { "Type": 3, "Name": "COM1", "AssignmentGroup": "COM1", "Irq": "4", "Ioports": "3f8-3ff", "Serial": "/dev/ttyS0"}
 ] }

--- a/pkg/pillar/conf/AssignableAdapters/Supermicro.SYS-E100-9APP.json
+++ b/pkg/pillar/conf/AssignableAdapters/Supermicro.SYS-E100-9APP.json
@@ -1,10 +1,16 @@
 { "IoBundleList": [
-    { "Type": 1, "Name": "eth0", "Members": [ "eth0" ], "Lookup": true },
-    { "Type": 1, "Name": "eth1", "Members": [ "eth1" ], "Lookup": true },
-    { "Type": 2, "Name": "USB-C", "Members": [ "USB6" ], "PciLong": "0000:05:00.0", "Pcishort":"05:00.0" },
-    { "Type": 2, "Name": "USB-A", "Members": [ "USB0", "USB1", "USB2", "USB3", "USB4", "USB5" ], "PciLong": "0000:00:15.0", "PciShort": "00:15.0"},
-    { "Type": 3, "Name": "COM1", "Members": [ "COM1" ], "XenCfg": "irqs=[4]\nioports=['3f8-3ff']\n" },
-    { "Type": 3, "Name": "COM2", "Members": [ "COM2" ], "XenCfg": "irqs=[3]\nioports=['2f8-2ff']\n" },
-    { "Type": 3, "Name": "COM34", "Members": [ "COM3", "COM4" ], "XenCfg": "irqs=[7]\nioports=['3e8-3ef','2e8-2ef']\n" },
-    { "Type": 255, "Name": "Audio", "Members": [ "AudioOut" ], "PciLong": "0000:00:0e.0", "PciShort":"00:0e.0" }
+    { "Type": 1, "Name": "eth0", "AssignmentGroup": "eth0", "Ifname": "eth0" },
+    { "Type": 1, "Name": "eth1", "AssignmentGroup": "eth1", "Ifname": "eth1" },
+    { "Type": 2, "Name": "USB6", "AssignmentGroup": "USB-C", "PciLong": "0000:05:00.0" },
+    { "Type": 2, "Name": "USB0", "AssignmentGroup": "USB-A", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB1", "AssignmentGroup": "USB-A", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB2", "AssignmentGroup": "USB-A", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB3", "AssignmentGroup": "USB-A", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB4", "AssignmentGroup": "USB-A", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB5", "AssignmentGroup": "USB-A", "PciLong": "0000:00:15.0"},
+    { "Type": 3, "Name": "COM1", "AssignmentGroup": "COM1", "Irq": "4", "Ioports": "3f8-3ff", "Serial": "/dev/ttyS0"},
+    { "Type": 3, "Name": "COM2", "AssignmentGroup": "COM2", "Irq": "3", "Ioports": "2f8-2ff", "Serial": "/dev/ttyS1"},
+    { "Type": 3, "Name": "COM3", "AssignmentGroup": "COM34", "Irq": "7", "Ioports": "3e8-3ef", "Serial": "/dev/ttyS2"},
+    { "Type": 3, "Name": "COM4", "AssignmentGroup": "COM34", "Irq": "7", "Ioports": "2e8-2ef", "Serial": "/dev/ttyS3"},
+    { "Type": 4, "Name": "Audio", "AssignmentGroup": "Audio", "PciLong": "0000:00:0e.0" }
 ] }

--- a/pkg/pillar/conf/AssignableAdapters/Supermicro.SYS-E100-9APP.test
+++ b/pkg/pillar/conf/AssignableAdapters/Supermicro.SYS-E100-9APP.test
@@ -1,6 +1,0 @@
-{ "IoBundleList": [
-    { "Type": 1, "Name": "eth0", "Members": [ "eth0" ], "Lookup": true },
-    { "Type": 1, "Name": "eth1", "Members": [ "eth1" ], "Lookup": true },
-    { "Type": 2, "Name": "USB-C", "Members": [ "USB6" ], "PciLong": "0000:05:00.0", "Pcishort":"05:00.0" },
-    { "Type": 2, "Name": "USB-A", "Members": [ "USB0", "USB1", "USB2", "USB3", "USB4", "USB5" ], "PciLong": "0000:00:15.0", "PciShort": "00:15.0"}
-] }

--- a/pkg/pillar/conf/AssignableAdapters/Supermicro.SYS-E100-9S.json
+++ b/pkg/pillar/conf/AssignableAdapters/Supermicro.SYS-E100-9S.json
@@ -1,10 +1,16 @@
 { "IoBundleList": [
-    { "Type": 1, "Name": "eth0", "Members": [ "eth0" ], "Lookup": true },
-    { "Type": 1, "Name": "eth1", "Members": [ "eth1" ], "Lookup": true },
-    { "Type": 2, "Name": "USB-C", "Members": [ "USB6" ], "PciLong": "0000:05:00.0", "Pcishort":"05:00.0" },
-    { "Type": 2, "Name": "USB-A", "Members": [ "USB0", "USB1", "USB2", "USB3", "USB4", "USB5" ], "PciLong": "0000:00:15.0", "PciShort": "00:15.0"},
-    { "Type": 3, "Name": "COM1", "Members": [ "COM1" ], "XenCfg": "irqs=[4]\nioports=['3f8-3ff']\n" },
-    { "Type": 3, "Name": "COM2", "Members": [ "COM2" ], "XenCfg": "irqs=[3]\nioports=['2f8-2ff']\n" },
-    { "Type": 3, "Name": "COM34", "Members": [ "COM3", "COM4" ], "XenCfg": "irqs=[7]\nioports=['3e8-3ef','2e8-2ef']\n" },
-    { "Type": 255, "Name": "Audio", "Members": [ "AudioOut" ], "PciLong": "0000:00:0e.0", "PciShort":"00:0e.0" }
+    { "Type": 1, "Name": "eth0", "AssignmentGroup": "eth0", "Ifname": "eth0" },
+    { "Type": 1, "Name": "eth1", "AssignmentGroup": "eth1", "Ifname": "eth1" },
+    { "Type": 2, "Name": "USB6", "AssignmentGroup": "USB-C", "PciLong": "0000:05:00.0" },
+    { "Type": 2, "Name": "USB0", "AssignmentGroup": "USB-A", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB1", "AssignmentGroup": "USB-A", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB2", "AssignmentGroup": "USB-A", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB3", "AssignmentGroup": "USB-A", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB4", "AssignmentGroup": "USB-A", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB5", "AssignmentGroup": "USB-A", "PciLong": "0000:00:15.0"},
+    { "Type": 3, "Name": "COM1", "AssignmentGroup": "COM1", "Irq": "4", "Ioports": "3f8-3ff", "Serial": "/dev/ttyS0"},
+    { "Type": 3, "Name": "COM2", "AssignmentGroup": "COM2", "Irq": "3", "Ioports": "2f8-2ff", "Serial": "/dev/ttyS1"},
+    { "Type": 3, "Name": "COM3", "AssignmentGroup": "COM34", "Irq": "7", "Ioports": "3e8-3ef", "Serial": "/dev/ttyS2"},
+    { "Type": 3, "Name": "COM4", "AssignmentGroup": "COM34", "Irq": "7", "Ioports": "2e8-2ef", "Serial": "/dev/ttyS3"},
+    { "Type": 4, "Name": "Audio", "AssignmentGroup": "Audio", "PciLong": "0000:00:0e.0" }
 ] }

--- a/pkg/pillar/conf/AssignableAdapters/Supermicro.SYS-E300-8D.json
+++ b/pkg/pillar/conf/AssignableAdapters/Supermicro.SYS-E300-8D.json
@@ -1,8 +1,13 @@
 { "IoBundleList": [
-    { "Type": 1, "Name": "eth0-1", "Members": [ "eth0", "eth1"], "Lookup": true },
-    { "Type": 1, "Name": "eth2", "Members": [ "eth2" ], "Lookup": true },
-    { "Type": 1, "Name": "eth3", "Members": [ "eth3" ], "Lookup": true },
-    { "Type": 1, "Name": "eth4-7", "Members": [ "eth4", "eth5", "eth6", "eth7" ], "Lookup": true },
-    { "Type": 2, "Name": "USB", "Members": [ "USB0", "USB1" ], "PciLong": "0000:00:14.0", "Pcishort":"00:14.0" },
-    { "Type": 3, "Name": "COM1", "Members": [ "COM1" ], "XenCfg": "irqs=[4]\nioports=['3f8-3ff']\n" }
+    { "Type": 1, "Name": "eth0", "AssignmentGroup": "eth0-1", "Ifname": "eth0" },
+    { "Type": 1, "Name": "eth1", "AssignmentGroup": "eth0-1", "Ifname": "eth1" },
+    { "Type": 1, "Name": "eth2", "AssignmentGroup": "eth2", "Ifname": "eth2" },
+    { "Type": 1, "Name": "eth3", "AssignmentGroup": "eth3", "Ifname": "eth3" },
+    { "Type": 1, "Name": "eth4", "AssignmentGroup": "eth4-7", "Ifname": "eth4" },
+    { "Type": 1, "Name": "eth5", "AssignmentGroup": "eth4-7", "Ifname": "eth5" },
+    { "Type": 1, "Name": "eth6", "AssignmentGroup": "eth4-7", "Ifname": "eth6" },
+    { "Type": 1, "Name": "eth7", "AssignmentGroup": "eth4-7", "Ifname": "eth7" },
+    { "Type": 2, "Name": "USB0", "AssignmentGroup": "USB-A", "PciLong": "0000:00:14.0"},
+    { "Type": 2, "Name": "USB1", "AssignmentGroup": "USB-A", "PciLong": "0000:00:14.0"},
+    { "Type": 3, "Name": "COM1", "AssignmentGroup": "COM1", "Irq": "4", "Ioports": "3f8-3ff", "Serial": "/dev/ttyS0"}
 ] }

--- a/pkg/pillar/conf/AssignableAdapters/Supermicro.SYS-E300-9A-4CN10P.json
+++ b/pkg/pillar/conf/AssignableAdapters/Supermicro.SYS-E300-9A-4CN10P.json
@@ -1,9 +1,14 @@
 { "IoBundleList": [
-    { "Type": 1, "Name": "eth0-1", "Members": [ "eth0", "eth1"], "Lookup": true },
-    { "Type": 1, "Name": "eth2", "Members": [ "eth2" ], "Lookup": true },
-    { "Type": 1, "Name": "eth3", "Members": [ "eth3" ], "Lookup": true },
-    { "Type": 1, "Name": "eth4-7", "Members": [ "eth4", "eth5", "eth6", "eth7" ], "Lookup": true },
-    { "Type": 2, "Name": "USB", "Members": [ "USB0", "USB1" ], "PciLong": "0000:00:14.0", "Pcishort":"00:14.0" },
-    { "Type": 3, "Name": "COM1", "Members": [ "COM1" ], "XenCfg": "irqs=[4]\nioports=['3f8-3ff']\n" },
-    { "Type": 3, "Name": "Audio", "Members": [ "AudioOut" ], "PciLong": "0000:00:0e.0", "Pcishort":"00:0e.0" }
+    { "Type": 1, "Name": "eth0", "AssignmentGroup": "eth0-1", "Ifname": "eth0" },
+    { "Type": 1, "Name": "eth1", "AssignmentGroup": "eth0-1", "Ifname": "eth1" },
+    { "Type": 1, "Name": "eth2", "AssignmentGroup": "eth2", "Ifname": "eth2" },
+    { "Type": 1, "Name": "eth3", "AssignmentGroup": "eth3", "Ifname": "eth3" },
+    { "Type": 1, "Name": "eth4", "AssignmentGroup": "eth4-7", "Ifname": "eth4" },
+    { "Type": 1, "Name": "eth5", "AssignmentGroup": "eth4-7", "Ifname": "eth5" },
+    { "Type": 1, "Name": "eth6", "AssignmentGroup": "eth4-7", "Ifname": "eth6" },
+    { "Type": 1, "Name": "eth7", "AssignmentGroup": "eth4-7", "Ifname": "eth7" },
+    { "Type": 2, "Name": "USB0", "AssignmentGroup": "USB-A", "PciLong": "0000:00:14.0"},
+    { "Type": 2, "Name": "USB1", "AssignmentGroup": "USB-A", "PciLong": "0000:00:14.0"},
+    { "Type": 3, "Name": "COM1", "AssignmentGroup": "COM1", "Irq": "4", "Ioports": "3f8-3ff", "Serial": "/dev/ttyS0"},
+    { "Type": 4, "Name": "Audio", "AssignmentGroup": "Audio", "PciLong": "0000:00:0e.0" }
 ] }

--- a/pkg/pillar/conf/AssignableAdapters/Supermicro.SYS-E50-9AP-WiFi.json
+++ b/pkg/pillar/conf/AssignableAdapters/Supermicro.SYS-E50-9AP-WiFi.json
@@ -1,9 +1,12 @@
 { "IoBundleList": [
-    { "Type": 1, "Name": "eth0", "Members": [ "eth0" ], "Lookup": true },
-    { "Type": 1, "Name": "eth1", "Members": [ "eth1" ], "Lookup": true },
-    { "Type": 1, "Name": "wlan0", "Members": [ "wlan0" ], "PciLong": "0000:06:00.0", "PciShort": "06:00.0" },
-    { "Type": 2, "Name": "USB", "Members": [ "USB0", "USB1", "USB2", "USB3" ], "PciLong": "0000:00:15.0", "PciShort": "00:15.0"},
-    { "Type": 3, "Name": "COM1", "Members": [ "COM1" ], "XenCfg": "irqs=[4]\nioports=['3f8-3ff']\n" },
-    { "Type": 3, "Name": "COM2", "Members": [ "COM2" ], "XenCfg": "irqs=[3]\nioports=['2f8-2ff']\n" },
-    { "Type": 255, "Name": "Audio", "Members": [ "AudioOut" ], "PciLong": "0000:00:0e.0", "PciShort":"00:0e.0" }
+    { "Type": 1, "Name": "eth0", "AssignmentGroup": "eth0", "Ifname": "eth0" },
+    { "Type": 1, "Name": "eth1", "AssignmentGroup": "eth1", "Ifname": "eth1" },
+    { "Type": 5, "Name": "wlan0", "AssignmentGroup": "wlan0", "PciLong": "0000:06:00.0" },
+    { "Type": 2, "Name": "USB0", "AssignmentGroup": "USB", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB1", "AssignmentGroup": "USB", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB2", "AssignmentGroup": "USB", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB3", "AssignmentGroup": "USB", "PciLong": "0000:00:15.0"},
+    { "Type": 3, "Name": "COM1", "AssignmentGroup": "COM1", "Irq": "4", "Ioports": "3f8-3ff", "Serial": "/dev/ttyS0"},
+    { "Type": 3, "Name": "COM2", "AssignmentGroup": "COM2", "Irq": "3", "Ioports": "2f8-2ff", "Serial": "/dev/ttyS1"},
+    { "Type": 4, "Name": "Audio", "AssignmentGroup": "Audio", "PciLong": "0000:00:0e.0" }
 ] }

--- a/pkg/pillar/conf/AssignableAdapters/Supermicro.SYS-E50-9AP.json
+++ b/pkg/pillar/conf/AssignableAdapters/Supermicro.SYS-E50-9AP.json
@@ -1,8 +1,11 @@
 { "IoBundleList": [
-    { "Type": 1, "Name": "eth0", "Members": [ "eth0" ], "Lookup": true },
-    { "Type": 1, "Name": "eth1", "Members": [ "eth1" ], "Lookup": true },
-    { "Type": 2, "Name": "USB", "Members": [ "USB0", "USB1", "USB2", "USB3" ], "PciLong": "0000:00:15.0", "PciShort": "00:15.0"},
-    { "Type": 3, "Name": "COM1", "Members": [ "COM1" ], "XenCfg": "irqs=[4]\nioports=['3f8-3ff']\n" },
-    { "Type": 3, "Name": "COM2", "Members": [ "COM2" ], "XenCfg": "irqs=[3]\nioports=['2f8-2ff']\n" },
-    { "Type": 255, "Name": "Audio", "Members": [ "AudioOut" ], "PciLong": "0000:00:0e.0", "PciShort":"00:0e.0" }
+    { "Type": 1, "Name": "eth0", "AssignmentGroup": "eth0", "Ifname": "eth0" },
+    { "Type": 1, "Name": "eth1", "AssignmentGroup": "eth1", "Ifname": "eth1" },
+    { "Type": 2, "Name": "USB0", "AssignmentGroup": "USB", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB1", "AssignmentGroup": "USB", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB2", "AssignmentGroup": "USB", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB3", "AssignmentGroup": "USB", "PciLong": "0000:00:15.0"},
+    { "Type": 3, "Name": "COM1", "AssignmentGroup": "COM1", "Irq": "4", "Ioports": "3f8-3ff", "Serial": "/dev/ttyS0"},
+    { "Type": 3, "Name": "COM2", "AssignmentGroup": "COM2", "Irq": "3", "Ioports": "2f8-2ff", "Serial": "/dev/ttyS1"},
+    { "Type": 4, "Name": "Audio", "AssignmentGroup": "Audio", "PciLong": "0000:00:0e.0" }
 ] }

--- a/pkg/pillar/conf/AssignableAdapters/Supermicro.X11SSN-E.json
+++ b/pkg/pillar/conf/AssignableAdapters/Supermicro.X11SSN-E.json
@@ -1,10 +1,15 @@
 { "IoBundleList": [
-    { "Type": 1, "Name": "eth0", "Members": [ "eth0" ], "Lookup": true },
-    { "Type": 1, "Name": "eth1", "Members": [ "eth1" ], "Lookup": true },
-    { "Type": 2, "Name": "USB-C", "Members": [ "USB5", "USB6" ], "PciLong": "0000:00:14.0", "Pcishort":"00:14.0" },
-    { "Type": 2, "Name": "USB-A", "Members": [ "USB0", "USB1", "USB2", "USB3", "USB4" ], "PciLong": "0000:01:00.0", "PciShort": "01:00.0"},
-    { "Type": 3, "Name": "COM1", "Members": [ "COM1" ], "XenCfg": "irqs=[4]\nioports=['3f8-3ff']\n" },
-    { "Type": 3, "Name": "COM2", "Members": [ "COM2" ], "XenCfg": "irqs=[3]\nioports=['2f8-2ff']\n" },
-    { "Type": 3, "Name": "COM34", "Members": [ "COM3", "COM4" ], "XenCfg": "irqs=[7]\nioports=['3e8-3ef','2e8-2ef']\n" },
-    { "Type": 255, "Name": "Audio", "Members": [ "AudioOut" ], "PciLong": "0000:00:1f.3", "PciShort":"00:1f.3" }
+    { "Type": 1, "Name": "eth0", "AssignmentGroup": "eth0", "Ifname": "eth0" },
+    { "Type": 1, "Name": "eth1", "AssignmentGroup": "eth1", "Ifname": "eth1" },
+    { "Type": 2, "Name": "USB5", "AssignmentGroup": "USB-C", "PciLong": "0000:14:00.0" },
+    { "Type": 2, "Name": "USB6", "AssignmentGroup": "USB-C", "PciLong": "0000:14:00.0" },
+    { "Type": 2, "Name": "USB0", "AssignmentGroup": "USB-A", "PciLong": "0000:01:00.0"},
+    { "Type": 2, "Name": "USB1", "AssignmentGroup": "USB-A", "PciLong": "0000:01:00.0"},
+    { "Type": 2, "Name": "USB2", "AssignmentGroup": "USB-A", "PciLong": "0000:01:00.0"},
+    { "Type": 2, "Name": "USB3", "AssignmentGroup": "USB-A", "PciLong": "0000:01:00.0"},
+    { "Type": 3, "Name": "COM1", "AssignmentGroup": "COM1", "Irq": "4", "Ioports": "3f8-3ff", "Serial": "/dev/ttyS0"},
+    { "Type": 3, "Name": "COM2", "AssignmentGroup": "COM2", "Irq": "3", "Ioports": "2f8-2ff", "Serial": "/dev/ttyS1"},
+    { "Type": 3, "Name": "COM3", "AssignmentGroup": "COM34", "Irq": "7", "Ioports": "3e8-3ef", "Serial": "/dev/ttyS2"},
+    { "Type": 3, "Name": "COM4", "AssignmentGroup": "COM34", "Irq": "7", "Ioports": "2e8-2ef", "Serial": "/dev/ttyS3"},
+    { "Type": 4, "Name": "Audio", "AssignmentGroup": "Audio", "PciLong": "0000:00:1f.3" }
 ] }

--- a/pkg/pillar/conf/AssignableAdapters/Supermicro.X11SSN-L.json
+++ b/pkg/pillar/conf/AssignableAdapters/Supermicro.X11SSN-L.json
@@ -1,10 +1,16 @@
 { "IoBundleList": [
-    { "Type": 1, "Name": "eth0", "Members": [ "eth0" ], "Lookup": true },
-    { "Type": 1, "Name": "eth1", "Members": [ "eth1" ], "Lookup": true },
-    { "Type": 2, "Name": "USB-C", "Members": [ "USB6" ], "PciLong": "0000:05:00.0", "Pcishort":"05:00.0" },
-    { "Type": 2, "Name": "USB-A", "Members": [ "USB0", "USB1", "USB2", "USB3", "USB4", "USB5" ], "PciLong": "0000:00:15.0", "PciShort": "00:15.0"},
-    { "Type": 3, "Name": "COM1", "Members": [ "COM1" ], "XenCfg": "irqs=[4]\nioports=['3f8-3ff']\n" },
-    { "Type": 3, "Name": "COM2", "Members": [ "COM2" ], "XenCfg": "irqs=[3]\nioports=['2f8-2ff']\n" },
-    { "Type": 3, "Name": "COM34", "Members": [ "COM3", "COM4" ], "XenCfg": "irqs=[7]\nioports=['3e8-3ef','2e8-2ef']\n" },
-    { "Type": 255, "Name": "Audio", "Members": [ "AudioOut" ], "PciLong": "0000:00:0e.0", "PciShort":"00:0e.0" }
+    { "Type": 1, "Name": "eth0", "AssignmentGroup": "eth0", "Ifname": "eth0" },
+    { "Type": 1, "Name": "eth1", "AssignmentGroup": "eth1", "Ifname": "eth1" },
+    { "Type": 2, "Name": "USB6", "AssignmentGroup": "USB-C", "PciLong": "0000:05:00.0" },
+    { "Type": 2, "Name": "USB0", "AssignmentGroup": "USB-A", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB1", "AssignmentGroup": "USB-A", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB2", "AssignmentGroup": "USB-A", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB3", "AssignmentGroup": "USB-A", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB4", "AssignmentGroup": "USB-A", "PciLong": "0000:00:15.0"},
+    { "Type": 2, "Name": "USB5", "AssignmentGroup": "USB-A", "PciLong": "0000:00:15.0"},
+    { "Type": 3, "Name": "COM1", "AssignmentGroup": "COM1", "Irq": "4", "Ioports": "3f8-3ff", "Serial": "/dev/ttyS0"},
+    { "Type": 3, "Name": "COM2", "AssignmentGroup": "COM2", "Irq": "3", "Ioports": "2f8-2ff", "Serial": "/dev/ttyS1"},
+    { "Type": 3, "Name": "COM3", "AssignmentGroup": "COM34", "Irq": "7", "Ioports": "3e8-3ef", "Serial": "/dev/ttyS2"},
+    { "Type": 3, "Name": "COM4", "AssignmentGroup": "COM34", "Irq": "7", "Ioports": "2e8-2ef", "Serial": "/dev/ttyS3"},
+    { "Type": 4, "Name": "Audio", "AssignmentGroup": "Audio", "PciLong": "0000:00:0e.0" }
 ] }

--- a/pkg/pillar/conf/AssignableAdapters/default.json
+++ b/pkg/pillar/conf/AssignableAdapters/default.json
@@ -1,4 +1,4 @@
 { "IoBundleList": [
-    { "Type": 1, "Name": "eth0", "Members": [ "eth0" ], "Lookup": true },
-    { "Type": 1, "Name": "eth1", "Members": [ "eth1" ], "Lookup": true }
+    { "Type": 1, "Name": "eth0", "AssignmentGroup": "eth0", "Ifname": "eth0" },
+    { "Type": 1, "Name": "eth1", "AssignmentGroup": "eth1", "Ifname": "eth1" }
 ] }

--- a/pkg/pillar/conf/AssignableAdapters/iEi.SER0.json
+++ b/pkg/pillar/conf/AssignableAdapters/iEi.SER0.json
@@ -1,10 +1,17 @@
 { "IoBundleList": [
-    { "Type": 1, "Name": "eth0", "Members": [ "eth0" ], "Lookup": true },
-    { "Type": 1, "Name": "eth1", "Members": [ "eth1" ], "Lookup": true },
-    { "Type": 255, "Name": "VGA", "Members": [ "VGA" ], "PciLong": "0000:00:02.0", "PciShort":"00:02.0" },
-    { "Type": 2, "Name": "USB", "Members": [ "USB0", "USB1", "USB2", "USB3", "USB4", "USB5", "USB6", "USB7" ], "PciLong": "0000:00:14.0", "PciShort":"00:14.0" },
-    { "Type": 255, "Name": "Thermal subsystem", "Members": [ "Thermal subsystem" ], "PciLong": "0000:00:14.2", "PciShort":"00:14.2" },
-    { "Type": 255, "Name": "Communication controller", "Members": [ "Communication controller" ], "PciLong": "0000:00:16.0", "PciShort":"00:16.0" },
-    { "Type": 255, "Name": "Serial controller", "Members": [ "Serial controller" ], "PciLong": "0000:00:16.3", "PciShort":"00:16.3" },
-    { "Type": 255, "Name": "FPGA", "Members": [ "FPGA" ], "PciLong": "0000:01:00.0", "PciShort":"01:00.0" }
+    { "Type": 1, "Name": "eth0", "AssignmentGroup": "eth0", "Ifname": "eth0" },
+    { "Type": 1, "Name": "eth1", "AssignmentGroup": "eth1", "Ifname": "eth1" },
+    { "Type": 7, "Name": "VGA", "AssignmentGroup": "VGA", "PciLong": "0000:00:02.0" },
+    { "Type": 2, "Name": "USB0", "AssignmentGroup": "USB", "PciLong": "0000:00:14.0"},
+    { "Type": 2, "Name": "USB1", "AssignmentGroup": "USB", "PciLong": "0000:00:14.0"},
+    { "Type": 2, "Name": "USB2", "AssignmentGroup": "USB", "PciLong": "0000:00:14.0"},
+    { "Type": 2, "Name": "USB3", "AssignmentGroup": "USB", "PciLong": "0000:00:14.0"},
+    { "Type": 2, "Name": "USB4", "AssignmentGroup": "USB", "PciLong": "0000:00:14.0"},
+    { "Type": 2, "Name": "USB5", "AssignmentGroup": "USB", "PciLong": "0000:00:14.0"},
+    { "Type": 2, "Name": "USB6", "AssignmentGroup": "USB", "PciLong": "0000:00:14.0"},
+    { "Type": 2, "Name": "USB7", "AssignmentGroup": "USB", "PciLong": "0000:00:14.0"},
+    { "Type": 255, "Name": "Thermal subsystem", "AssignmentGroup": "USB", "PciLong": "0000:00:14.2" },
+    { "Type": 255, "Name": "Communication controller", "AssignmentGroup": "Communication", "PciLong": "0000:00:16.0" },
+    { "Type": 255, "Name": "Serial controller", "AssignmentGroup": "Communication", "PciLong": "0000:00:16.3" },
+    { "Type": 255, "Name": "FPGA", "AssignmentGroups": "FPGA", "PciLong": "0000:01:00.0" }
 ] }

--- a/pkg/pillar/conf/AssignableAdapters/innotek GmbH.VirtualBox.json
+++ b/pkg/pillar/conf/AssignableAdapters/innotek GmbH.VirtualBox.json
@@ -1,4 +1,4 @@
 { "IoBundleList": [
-    { "Type": 1, "Name": "eth0", "Members": [ "eth0" ], "Lookup": true },
-    { "Type": 1, "Name": "eth1", "Members": [ "eth1" ], "Lookup": true }
+    { "Type": 1, "Name": "eth0", "AssignmentGroup": "eth0", "Ifname": "eth0" },
+    { "Type": 1, "Name": "eth1", "AssignmentGroup": "eth1", "Ifname": "eth1" }
 ] }

--- a/pkg/pillar/conf/AssignableAdapters/linux,dummy-virt..json
+++ b/pkg/pillar/conf/AssignableAdapters/linux,dummy-virt..json
@@ -1,4 +1,4 @@
 { "IoBundleList": [
-    { "Type": 1, "Name": "eth0", "Members": [ "eth0" ], "Lookup": true },
-    { "Type": 1, "Name": "eth1", "Members": [ "eth1" ], "Lookup": true }
+    { "Type": 1, "Name": "eth0", "AssignmentGroup": "eth0", "Ifname": "eth0" },
+    { "Type": 1, "Name": "eth1", "AssignmentGroup": "eth1", "Ifname": "eth1" }
 ] }

--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -580,12 +580,12 @@ func HandleAssignableAdaptersModify(ctxArg interface{}, key string,
 
 	// ctxArg is DeviceNetworkContext
 	for _, ioBundle := range newAssignableAdapters.IoBundleList {
-		if ioBundle.Type != types.IoEth {
+		if !ioBundle.Type.IsNet() {
 			continue
 		}
 		if ctx.AssignableAdapters != nil {
-			currentIoBundle := types.LookupIoBundle(ctx.AssignableAdapters,
-				types.IoEth, ioBundle.Name)
+			currentIoBundle := ctx.AssignableAdapters.LookupIoBundle(
+				ioBundle.Type, ioBundle.Name)
 			if currentIoBundle != nil &&
 				ioBundle.IsPCIBack == currentIoBundle.IsPCIBack {
 				log.Infof("HandleAssignableAdaptersModify(): ioBundle (%+v) "+

--- a/pkg/pillar/types/assignableadapters.go
+++ b/pkg/pillar/types/assignableadapters.go
@@ -22,21 +22,18 @@ type AssignableAdapters struct {
 	IoBundleList []IoBundle
 }
 
-// IoBundle has one entry per bundle listing the members and their info.
-// XXX Flip this around to not have members but instead have a group reference
-// and one IoBundle per member/receptacle
+// IoBundle has one entry per individual receptacle with a reference
+// to a group name. Those sharing a group name needs to be assigned
+// together.
 type IoBundle struct {
 	// Type
 	//	Type of the IoBundle
 	Type IoType
 	// Name
-	//	Short hand name such as "com".
-	//  xxx - Any description is where this is used? How this is to be set etc??
-	Name string // Short hand name such as "com"
-	// Members
-	//	List of members ( names )
-	// XXX Have Members() become a function which returns all with matching group
-	Members []string // E.g., "com1", "com2"
+	//	Short hand name such as "COM1".
+	//	Used in the API to specify that a adapter should
+	//	be assigned to an application.
+	Name string
 
 	// Assignment Group, is unique label that is applied across PhysicalIOs
 	// Entire group can be assigned to application or nothing at all
@@ -47,41 +44,26 @@ type IoBundle struct {
 	//	For unassigned adapters, this is not set.
 	UsedByUUID uuid.UUID
 
-	// Local information not reported to cloud
-	Lookup   bool   // Look up name to find PCI; XXX deprecate for Ifname
-	Ifname   string // E.g., "eth1"
-	PciLong  string // If adapter on some bus and not Eth
-	PciShort string // If pci adapter and not Eth
+	// The following set of I/O addresses and info/aliases are used to find
+	// a device, and also to configure it.
+	// XXX TBD: Add PciClass, PciVendor and PciDevice strings as well
+	// for matching
+	Ifname  string // Matching for network PCI devices e.g., "eth1"
+	PciLong string // Specific PCI bus address in Domain:Bus:Device.Funcion syntax
 	// For non-PCI devices such as the ISA serial ports we have:
-	// XXX deprecate XenCfg; use irq and ioports instead
 	Irq     string // E.g., "5"
 	Ioports string // E.g., "2f8-2ff"
 	Serial  string // E.g., "/dev/ttyS1"
-	XenCfg  string // Fed verbatim into xen cfg file; XXX deprecate
 
-	Unique string // From firmware_node symlink; used for debug checks
-
-	// For each member we have these with the same indicies. Only used when
-	// Lookup is set.
-	// XXX a Member struct would make more sense but need compatibility with existing json
-	MPciLong  []string // If adapter on some bus
-	MPciShort []string // If pci adapter
-	MUnique   []string // From firmware_node symlink; used for debug checks
-	MMacAddr  []string // Set for networking adapters
+	Unique  string // From firmware_node symlink; used for debug checks
+	MacAddr string // Set for networking adapters. XXX Note used for match.
 
 	// IsPciBack
-	//	Is the IoBundle assigned to pciBack; means all members are assigned
+	//	Is the IoBundle assigned to pciBack; means other bundles in the same group are also assigned
 	//  If the device is managed by dom0, this is False.
 	//  If the device is ( or to be ) managed by DomU, this is True
 	IsPCIBack bool // Assigned to pciback
 	IsPort    bool // Whole or part of the bundle is a zedrouter port
-
-	// DeviceExists
-	//	This is to indicate if the device exists in the system
-	//  Currently, there are many checks using pciShort to see
-	//  if the device exists. This attribute is to abstract it out.
-	// DeviceExists bool
-
 }
 
 // Must match definition of PhyIoType in devmodel.proto which is an strict
@@ -91,7 +73,6 @@ type IoType uint8
 const (
 	IoNop     IoType = 0
 	IoNetEth  IoType = 1
-	IoEth     IoType = 1
 	IoUSB     IoType = 2
 	IoCom     IoType = 3
 	IoAudio   IoType = 4
@@ -101,8 +82,18 @@ const (
 	IoOther   IoType = 255
 )
 
+// IsNet checks if the type is any of the networking types.
+func (ioType IoType) IsNet() bool {
+	switch ioType {
+	case IoNetEth, IoNetWLAN, IoNetWWAN:
+		return true
+	default:
+		return false
+	}
+}
+
 // LookupIoBundle returns nil if not found
-func LookupIoBundle(aa *AssignableAdapters, ioType IoType, name string) *IoBundle {
+func (aa *AssignableAdapters) LookupIoBundle(ioType IoType, name string) *IoBundle {
 	for i, b := range aa.IoBundleList {
 		if b.Type == ioType && strings.EqualFold(b.Name, name) {
 			return &aa.IoBundleList[i]
@@ -111,30 +102,43 @@ func LookupIoBundle(aa *AssignableAdapters, ioType IoType, name string) *IoBundl
 	return nil
 }
 
-// LookupIoBundleForMember looks for a mach on any member name.
-// XXX deprecate when Member is replaced by Group
-func (aa *AssignableAdapters) LookupIoBundleForMember(
-	ioType IoType, memberName string) *IoBundle {
+// LookupIoBundleGroup returns an empty slice if not found
+// Returns pointers into aa
+func (aa *AssignableAdapters) LookupIoBundleGroup(ioType IoType, group string) []*IoBundle {
+
+	var list []*IoBundle
+	for i, b := range aa.IoBundleList {
+		if b.Type == ioType && strings.EqualFold(b.AssignmentGroup, group) {
+			list = append(list, &aa.IoBundleList[i])
+		}
+	}
+	return list
+}
+
+// LookupIoBundleOrGroup returns an empty slice if not found
+// Returns pointers into aa
+func (aa *AssignableAdapters) LookupIoBundleOrGroup(ioType IoType, nameOrGroup string) []*IoBundle {
+
+	var list []*IoBundle
 	for i, b := range aa.IoBundleList {
 		if b.Type != ioType {
 			continue
 		}
-		for _, member := range b.Members {
-			if strings.EqualFold(member, memberName) {
-				return &aa.IoBundleList[i]
-			}
+		if strings.EqualFold(b.Name, nameOrGroup) ||
+			strings.EqualFold(b.AssignmentGroup, nameOrGroup) {
+
+			list = append(list, &aa.IoBundleList[i])
+		}
+	}
+	return list
+}
+
+// LookupIoBundleNet checks for IoNet*
+func (aa *AssignableAdapters) LookupIoBundleNet(name string) *IoBundle {
+	for i, b := range aa.IoBundleList {
+		if b.Type.IsNet() && strings.EqualFold(b.Name, name) {
+			return &aa.IoBundleList[i]
 		}
 	}
 	return nil
-}
-
-// XXX deprecate
-func (aa *AssignableAdapters) getIoBundleOrBundleForMemberByName(
-	ioType IoType, adapter string) *IoBundle {
-	ib := LookupIoBundle(aa, ioType, adapter)
-	if ib == nil {
-		// Check if adapter is a member of iobundle
-		ib = aa.LookupIoBundleForMember(ioType, adapter)
-	}
-	return ib
 }

--- a/pkg/pillar/types/assignableadapters_test.go
+++ b/pkg/pillar/types/assignableadapters_test.go
@@ -13,22 +13,46 @@ var aa AssignableAdapters = AssignableAdapters{
 	Initialized: true,
 	IoBundleList: []IoBundle{
 		{
-			Type:    IoEth,
-			Name:    "eth0-1",
-			Members: []string{"eth0", "eth1"},
-			Lookup:  true,
+			Type:            IoNetEth,
+			AssignmentGroup: "eth0-1",
+			Name:            "eth0",
+			Ifname:          "eth0",
 		},
 		{
-			Type:    IoEth,
-			Name:    "eth2",
-			Members: []string{"eth2"},
-			Lookup:  true,
+			Type:            IoNetEth,
+			AssignmentGroup: "eth0-1",
+			Name:            "eth1",
+			Ifname:          "eth1",
 		},
 		{
-			Type:    IoEth,
-			Name:    "eTH4-7",
-			Members: []string{"eth4", "eth5", "eth6", "eth7"},
-			Lookup:  true,
+			Type:            IoNetEth,
+			AssignmentGroup: "eth2",
+			Name:            "eth2",
+			Ifname:          "eth2",
+		},
+		{
+			Type:            IoNetEth,
+			AssignmentGroup: "eTH4-7",
+			Name:            "eth4",
+			Ifname:          "eth4",
+		},
+		{
+			Type:            IoNetEth,
+			AssignmentGroup: "eTH4-7",
+			Name:            "eth5",
+			Ifname:          "eth5",
+		},
+		{
+			Type:            IoNetEth,
+			AssignmentGroup: "eTH4-7",
+			Name:            "eth6",
+			Ifname:          "eth6",
+		},
+		{
+			Type:            IoNetEth,
+			AssignmentGroup: "eTH4-7",
+			Name:            "eth7",
+			Ifname:          "eth7",
 		},
 	},
 }
@@ -45,8 +69,8 @@ func TestLookupIoBundle(t *testing.T) {
 		lookupName         string
 		expectedBundleName string
 	}{
-		"IoType: IoEth, LookupName: eth0-1": {
-			ioType:             IoEth,
+		"IoType: IoNetEth, LookupName: eth0-1": {
+			ioType:             IoNetEth,
 			lookupName:         "eth0-1",
 			expectedBundleName: "eth0-1",
 		},
@@ -55,18 +79,18 @@ func TestLookupIoBundle(t *testing.T) {
 			lookupName:         "eth2",
 			expectedBundleName: "",
 		},
-		"IoType: IoEth LookupName: eth1": {
-			ioType:             IoEth,
+		"IoType: IoNetEth LookupName: eth1": {
+			ioType:             IoNetEth,
 			lookupName:         "eth1",
 			expectedBundleName: "",
 		},
-		"IoType: IoEth LookupName: eth2": {
-			ioType:             IoEth,
+		"IoType: IoNetEth LookupName: eth2": {
+			ioType:             IoNetEth,
 			lookupName:         "eth2",
 			expectedBundleName: "eth2",
 		},
-		"IoType: IoEth LookupName: eth4-7": {
-			ioType:             IoEth,
+		"IoType: IoNetEth LookupName: eth4-7": {
+			ioType:             IoNetEth,
 			lookupName:         "eth4-7",
 			expectedBundleName: "eTH4-7",
 		},
@@ -74,11 +98,12 @@ func TestLookupIoBundle(t *testing.T) {
 
 	for testname, test := range testMatrix {
 		t.Logf("Running test case %s", testname)
-		ioBundle := LookupIoBundle(&aa, test.ioType, test.lookupName)
-		if ioBundle == nil {
+		list := aa.LookupIoBundleGroup(test.ioType, test.lookupName)
+		if list == nil || len(list) == 0 {
 			assert.Equal(t, test.expectedBundleName, "")
 		} else {
-			assert.Equal(t, test.expectedBundleName, ioBundle.Name)
+			assert.Equal(t, test.expectedBundleName,
+				list[0].AssignmentGroup)
 		}
 	}
 }
@@ -89,8 +114,8 @@ func TestLookupIoBundleForMember(t *testing.T) {
 		lookupName         string
 		expectedBundleName string
 	}{
-		"ioType: IoEth, lookupName: eth1": {
-			ioType:             IoEth,
+		"ioType: IoNetEth, lookupName: eth1": {
+			ioType:             IoNetEth,
 			lookupName:         "eth1",
 			expectedBundleName: "eth0-1",
 		},
@@ -100,19 +125,19 @@ func TestLookupIoBundleForMember(t *testing.T) {
 			lookupName:         "eth1",
 			expectedBundleName: "",
 		},
-		"ioType: IoEth, lookupName: eth3": {
-			ioType:             IoEth,
+		"ioType: IoNetEth, lookupName: eth3": {
+			ioType:             IoNetEth,
 			lookupName:         "eth3",
 			expectedBundleName: "",
 		}, // No such member
-		"ioType: IoEth, lookupName: eth7": {
-			ioType:             IoEth,
+		"ioType: IoNetEth, lookupName: eth7": {
+			ioType:             IoNetEth,
 			lookupName:         "eth7",
 			expectedBundleName: "eTH4-7",
 		},
 		// Test Ignore case
-		"ioType: IoEth, lookupName: ETH7": {
-			ioType:             IoEth,
+		"ioType: IoNetEth, lookupName: ETH7": {
+			ioType:             IoNetEth,
 			lookupName:         "ETH7",
 			expectedBundleName: "eTH4-7",
 		},
@@ -121,7 +146,7 @@ func TestLookupIoBundleForMember(t *testing.T) {
 	// Basic test
 	for testname, test := range testMatrix {
 		t.Logf("Running test case %s", testname)
-		ioBundle := aa.LookupIoBundleForMember(test.ioType, test.lookupName)
+		ioBundle := aa.LookupIoBundle(test.ioType, test.lookupName)
 		if ioBundle == nil {
 			assert.Equal(t, test.expectedBundleName, "")
 		} else {

--- a/pkg/pillar/types/ifnametopci.go
+++ b/pkg/pillar/types/ifnametopci.go
@@ -19,8 +19,8 @@ import (
 const basePath = "/sys/class/net"
 const pciPath = "/sys/bus/pci/devices"
 
-// Returns the long and short PCI IDs
-func ifNameToPci(ifName string) (string, string, error) {
+// Returns the long PCI IDs
+func ifNameToPci(ifName string) (string, error) {
 	// Match for PCI IDs
 	re := regexp.MustCompile("([0-9a-f]){4}:([0-9a-f]){2}:([0-9a-f]){2}.[ls0-9a-f]")
 	devPath := basePath + "/" + ifName + "/device"
@@ -29,23 +29,27 @@ func ifNameToPci(ifName string) (string, string, error) {
 		if !os.IsNotExist(err) {
 			log.Errorln(err)
 		}
-		return "", "", err
+		return "", err
 	}
 	if (info.Mode() & os.ModeSymlink) == 0 {
 		log.Errorf("Skipping non-symlink %s\n", devPath)
-		return "", "", errors.New(fmt.Sprintf("Not a symlink %s", devPath))
+		return "", fmt.Errorf("Not a symlink %s", devPath)
 	}
 	link, err := os.Readlink(devPath)
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 	target := path.Base(link)
 	if re.MatchString(target) {
-		return target, strings.SplitAfterN(target, ":", 2)[1], nil
+		return target, nil
 	} else {
-		return target, "",
-			errors.New(fmt.Sprintf("Not PCI %s", target))
+		return target, fmt.Errorf("Not PCI %s", target)
 	}
+}
+
+// PCILongToShort returns the PCI ID without the domain id
+func PCILongToShort(long string) string {
+	return strings.SplitAfterN(long, ":", 2)[1]
 }
 
 // Check if an ID like 0000:03:00.0 exists
@@ -82,42 +86,28 @@ func PciLongToUnique(long string) (bool, string) {
 	return true, link
 }
 
-// Returns the long and short PCI IDs; if Lookup is set there can be a PCI ID for
-// each member.
-// Check if PCI ID exists on system. Returns null strings for non-PCI
+// IoBundleToPci returns the long PCI ID if the bundle refers to a PCI controller.
+// Checks if PCI ID exists on system. Returns null strings for non-PCI
 // devices since we can't check if they exist.
-func IoBundleToPci(ib *IoBundle) ([]string, []string, error) {
-	var long, short string
-	var longs, shorts []string
-	if ib.Lookup {
-		longs = make([]string, len(ib.Members))
-		shorts = make([]string, len(ib.Members))
+// This can handle aliases like Ifname.
+func IoBundleToPci(ib *IoBundle) (string, error) {
+
+	var long string
+	if ib.PciLong != "" {
+		long = ib.PciLong
+	} else if ib.Ifname != "" {
 		var err error
-		for i, m := range ib.Members {
-			long, short, err = ifNameToPci(m)
-			if err == nil {
-				longs[i] = long
-				shorts[i] = short
-			}
-		}
+		long, err = ifNameToPci(ib.Ifname)
 		if err != nil {
-			return nil, nil, err
+			return long, err
 		}
-	} else if ib.PciShort != "" {
-		if !pciLongExists(ib.PciLong) {
-			errStr := fmt.Sprintf("PCI device %s does not exist",
-				ib.PciLong)
-			return nil, nil, errors.New(errStr)
-		}
-		longs = make([]string, 1)
-		shorts = make([]string, 1)
-		longs[0] = ib.PciLong
-		shorts[0] = ib.PciShort
+	} else {
+		return "", nil
 	}
-	for i := range shorts {
-		if !pciLongExists(longs[i]) {
-			return nil, nil, errors.New(fmt.Sprintf("PCI device (%s) does not exist", longs[i]))
-		}
+	if !pciLongExists(long) {
+		errStr := fmt.Sprintf("PCI device name %s id %s does not exist",
+			ib.Name, long)
+		return long, errors.New(errStr)
 	}
-	return longs, shorts, nil
+	return long, nil
 }

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -70,9 +70,10 @@ type AppInstanceOpsCmd struct {
 	ApplyTime string // XXX not currently used
 }
 
+// IoAdapter specifies that a group of ports should be assigned
 type IoAdapter struct {
 	Type IoType
-	Name string // Short hand name such as "com"
+	Name string // Short hand name such as "COM1" or "eth1-2"
 }
 
 func (config AppInstanceConfig) Key() string {

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -756,8 +756,7 @@ func (portConfig *DevicePortConfig) IsAnyPortInPciBack(
 	log.Infof("IsAnyPortInPciBack: aa init %t, %d bundles, %d ports",
 		aa.Initialized, len(aa.IoBundleList), len(portConfig.Ports))
 	for _, port := range portConfig.Ports {
-		ioBundle := aa.LookupIoBundleForMember(
-			IoEth, port.IfName)
+		ioBundle := aa.LookupIoBundleNet(port.IfName)
 		if ioBundle == nil {
 			// It is not guaranteed that all Ports are part of Assignable Adapters
 			// If not found, the adaptor is not capable of being assigned at


### PR DESCRIPTION
This requires redoing the IoBundle to match what we have in the API: one IoBundle per member with a reference to a AssignmentGroup.

That way we can specify the serial port (and other fields) for each member and collect them together for the assignment.
@kalyan please take a look. This makes it a lot easier to consume the new model from the device API.