### PR TITLE
extract zedbox from build-docker-zedbox target

### DIFF
--- a/pkg/pillar/Makefile
+++ b/pkg/pillar/Makefile
@@ -40,8 +40,13 @@ $(APPS1): $(DISTDIR)
 shell:
 	make -C ../.. shell
 
-build-docker-$(APPS):
-	docker build -f Dockerfile.in --target=build .
+build-docker-$(APPS): $(DISTDIR)
+	docker build -f Dockerfile.in --target=build -t $(APPS)-builder .
+	# all of this goes away when we switch to full buildkit-based docker builds
+	docker container create --name $(APPS)-extract $(APPS)-builder
+	docker container cp $(APPS)-extract:/dist/$(APPS) $(DISTDIR)/$(APPS)
+	docker container rm -f $(APPS)-extract
+
 
 build-docker:
 	docker build $(DOCKER_ARGS) -t $(DOCKER_TAG) .


### PR DESCRIPTION
This is a follow-on from #44  that extracts the built file. These are minor steps, but they are focused on making it possible to build and work with individual components independently, eventually shortening test and dev cycles.