### PR TITLE
make audio work with new enums

### DIFF
--- a/pkg/pillar/types/assignableadapters.go
+++ b/pkg/pillar/types/assignableadapters.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/satori/go.uuid"
+	log "github.com/sirupsen/logrus"
 )
 
 type AssignableAdapters struct {
@@ -95,7 +96,13 @@ func (ioType IoType) IsNet() bool {
 // LookupIoBundle returns nil if not found
 func (aa *AssignableAdapters) LookupIoBundle(ioType IoType, name string) *IoBundle {
 	for i, b := range aa.IoBundleList {
-		if b.Type == ioType && strings.EqualFold(b.Name, name) {
+		// XXX the new enums are sent as zero by the controller
+		// hence temporary workaround
+		if (ioType == 0 || b.Type == ioType) && strings.EqualFold(b.Name, name) {
+			if ioType == 0 {
+				log.Warnf("XXX Matching name %s for ioType 0",
+					b.Name)
+			}
 			return &aa.IoBundleList[i]
 		}
 	}
@@ -111,7 +118,13 @@ func (aa *AssignableAdapters) LookupIoBundleGroup(ioType IoType, group string) [
 		if b.AssignmentGroup == "" {
 			continue
 		}
-		if b.Type == ioType && strings.EqualFold(b.AssignmentGroup, group) {
+		// XXX the new enums are sent as zero by the controller
+		// hence temporary workaround
+		if (ioType == 0 || b.Type == ioType) && strings.EqualFold(b.AssignmentGroup, group) {
+			if ioType == 0 {
+				log.Warnf("XXX Matching group %s for ioType 0",
+					b.AssignmentGroup)
+			}
 			list = append(list, &aa.IoBundleList[i])
 		}
 	}


### PR DESCRIPTION
When the controller sees a new enum value (such as 4 for audio) it might send zero to the device. Make the code handle that by treating zero as a wildcard.
