### PR TITLE
Adding device Serial# in http header for on-boarding troubleshooting

### DIFF
--- a/api/API.md
+++ b/api/API.md
@@ -335,3 +335,12 @@ The response MUST contain no body content.
 Edge Devices are expected to have intermittent connectivity, with limited bandwidth, memory and storage. It is likely that, at some point, a Device will run out of local memory or storage to cache information, logs or metrics messages that need to be sent to a Controller.
 
 The choice of which messages to keep, how long to keep them, which to discard, and how to handle these overflows are implementation-dependent and are NOT specified in this document.
+
+## HTTP MetaData
+
+Edge Devices may send some MetaData in HTTP header to the controller. This will help
+the controller side troubleshooting at the HTTP level. The Device UUID can be included
+in the HTTP header 'X-Request-ID'. Since the UUID on Device is obtained from the
+controller, when the UUID is not available yet, the Device Serial-Number and
+Soft-Serial-Number can be included in the HTTP header fields 'X-Serial-Number' and
+'X-Soft-Serial' respectively.

--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -229,6 +229,11 @@ func Run() { //nolint:gocyclo
 		FailureFunc:         zedcloud.ZedCloudFailure,
 		SuccessFunc:         zedcloud.ZedCloudSuccess,
 	}
+
+	// Get device serail number
+	zedcloudCtx.DevSerial = hardware.GetProductSerial()
+	log.Infof("Client Get Device Serial %s\n", zedcloudCtx.DevSerial)
+
 	server, err := ioutil.ReadFile(serverFileName)
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -232,7 +232,9 @@ func Run() { //nolint:gocyclo
 
 	// Get device serail number
 	zedcloudCtx.DevSerial = hardware.GetProductSerial()
-	log.Infof("Client Get Device Serial %s\n", zedcloudCtx.DevSerial)
+	zedcloudCtx.DevSoftSerial = hardware.GetSoftSerial()
+	log.Infof("Client Get Device Serial %s, Soft Serial %s\n", zedcloudCtx.DevSerial,
+		zedcloudCtx.DevSoftSerial)
 
 	server, err := ioutil.ReadFile(serverFileName)
 	if err != nil {
@@ -356,9 +358,7 @@ func Run() { //nolint:gocyclo
 		// XXX add option to get this from a file in /config + override
 		// logic
 		productSerial := hardware.GetProductSerial()
-		productSerial = strings.TrimSpace(productSerial)
 		softSerial := hardware.GetSoftSerial()
-		softSerial = strings.TrimSpace(softSerial)
 		log.Infof("ProductSerial %s, SoftwareSerial %s\n", productSerial, softSerial)
 
 		registerCreate := &register.ZRegisterMsg{

--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -358,7 +358,9 @@ func Run() { //nolint:gocyclo
 		// XXX add option to get this from a file in /config + override
 		// logic
 		productSerial := hardware.GetProductSerial()
+		productSerial = strings.TrimSpace(productSerial)
 		softSerial := hardware.GetSoftSerial()
+		softSerial = strings.TrimSpace(softSerial)
 		log.Infof("ProductSerial %s, SoftwareSerial %s\n", productSerial, softSerial)
 
 		registerCreate := &register.ZRegisterMsg{

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -131,6 +131,11 @@ func Run() {
 		FailureFunc:         zedcloud.ZedCloudFailure,
 		SuccessFunc:         zedcloud.ZedCloudSuccess,
 	}
+
+	// Get device serail number
+	zedcloudCtx.DevSerial = hardware.GetProductSerial()
+	log.Infof("Diag Get Device Serial %s\n", zedcloudCtx.DevSerial)
+
 	if fileExists(deviceCertName) {
 		// Load device cert
 		cert, err := zedcloud.GetClientCert()

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -134,7 +134,9 @@ func Run() {
 
 	// Get device serail number
 	zedcloudCtx.DevSerial = hardware.GetProductSerial()
-	log.Infof("Diag Get Device Serial %s\n", zedcloudCtx.DevSerial)
+	zedcloudCtx.DevSoftSerial = hardware.GetSoftSerial()
+	log.Infof("Diag Get Device Serial %s, Soft Serial %s\n", zedcloudCtx.DevSerial,
+		zedcloudCtx.DevSoftSerial)
 
 	if fileExists(deviceCertName) {
 		// Load device cert

--- a/pkg/pillar/cmd/logmanager/logmanager.go
+++ b/pkg/pillar/cmd/logmanager/logmanager.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/cast"
 	"github.com/lf-edge/eve/pkg/pillar/flextimer"
+	"github.com/lf-edge/eve/pkg/pillar/hardware"
 	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
@@ -687,6 +688,10 @@ func sendCtxInit() {
 	zedcloudCtx.TlsConfig = tlsConfig
 	zedcloudCtx.FailureFunc = zedcloud.ZedCloudFailure
 	zedcloudCtx.SuccessFunc = zedcloud.ZedCloudSuccess
+
+	// get the edge box serial number
+	zedcloudCtx.DevSerial = hardware.GetProductSerial()
+	log.Infof("Log Get Device Serial %s\n", zedcloudCtx.DevSerial)
 
 	// In case we run early, wait for UUID file to appear
 	for {

--- a/pkg/pillar/cmd/logmanager/logmanager.go
+++ b/pkg/pillar/cmd/logmanager/logmanager.go
@@ -691,7 +691,9 @@ func sendCtxInit() {
 
 	// get the edge box serial number
 	zedcloudCtx.DevSerial = hardware.GetProductSerial()
-	log.Infof("Log Get Device Serial %s\n", zedcloudCtx.DevSerial)
+	zedcloudCtx.DevSoftSerial = hardware.GetSoftSerial()
+	log.Infof("Log Get Device Serial %s, Soft Serial %s\n", zedcloudCtx.DevSerial,
+		zedcloudCtx.DevSoftSerial)
 
 	// In case we run early, wait for UUID file to appear
 	for {

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -94,7 +94,9 @@ func handleConfigInit() {
 	zedcloudCtx.FailureFunc = zedcloud.ZedCloudFailure
 	zedcloudCtx.SuccessFunc = zedcloud.ZedCloudSuccess
 	zedcloudCtx.DevSerial = hardware.GetProductSerial()
-	log.Infof("Configure Get Device Serial %s\n", zedcloudCtx.DevSerial)
+	zedcloudCtx.DevSoftSerial = hardware.GetSoftSerial()
+	log.Infof("Configure Get Device Serial %s, Soft Serial %s\n", zedcloudCtx.DevSerial,
+		zedcloudCtx.DevSoftSerial)
 
 	b, err := ioutil.ReadFile(uuidFileName)
 	if err != nil {

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -18,6 +18,7 @@ import (
 	zconfig "github.com/lf-edge/eve/api/go/config"
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/flextimer"
+	"github.com/lf-edge/eve/pkg/pillar/hardware"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/zedcloud"
@@ -92,6 +93,8 @@ func handleConfigInit() {
 	zedcloudCtx.TlsConfig = tlsConfig
 	zedcloudCtx.FailureFunc = zedcloud.ZedCloudFailure
 	zedcloudCtx.SuccessFunc = zedcloud.ZedCloudSuccess
+	zedcloudCtx.DevSerial = hardware.GetProductSerial()
+	log.Infof("Configure Get Device Serial %s\n", zedcloudCtx.DevSerial)
 
 	b, err := ioutil.ReadFile(uuidFileName)
 	if err != nil {

--- a/pkg/pillar/devicenetwork/devicenetwork.go
+++ b/pkg/pillar/devicenetwork/devicenetwork.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"github.com/eriknordmark/ipinfo"
 	"github.com/eriknordmark/netlink"
+	"github.com/lf-edge/eve/pkg/pillar/hardware"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/zedcloud"
 	log "github.com/sirupsen/logrus"
@@ -92,6 +93,11 @@ func VerifyDeviceNetworkStatus(status types.DeviceNetworkStatus,
 	zedcloudCtx := zedcloud.ZedCloudContext{
 		DeviceNetworkStatus: &status,
 	}
+
+	// Get device serail number
+	zedcloudCtx.DevSerial = hardware.GetProductSerial()
+	log.Infof("NIM Get Device Serial %s\n", zedcloudCtx.DevSerial)
+
 	tlsConfig, err := zedcloud.GetTlsConfig(serverName, nil)
 	if err != nil {
 		log.Infof("VerifyDeviceNetworkStatus: " +

--- a/pkg/pillar/devicenetwork/devicenetwork.go
+++ b/pkg/pillar/devicenetwork/devicenetwork.go
@@ -96,7 +96,9 @@ func VerifyDeviceNetworkStatus(status types.DeviceNetworkStatus,
 
 	// Get device serail number
 	zedcloudCtx.DevSerial = hardware.GetProductSerial()
-	log.Infof("NIM Get Device Serial %s\n", zedcloudCtx.DevSerial)
+	zedcloudCtx.DevSoftSerial = hardware.GetSoftSerial()
+	log.Infof("NIM Get Device Serial %s, Soft Serial %s\n", zedcloudCtx.DevSerial,
+		zedcloudCtx.DevSoftSerial)
 
 	tlsConfig, err := zedcloud.GetTlsConfig(serverName, nil)
 	if err != nil {

--- a/pkg/pillar/hardware/model.go
+++ b/pkg/pillar/hardware/model.go
@@ -139,7 +139,7 @@ func massageCompatible(contents []byte) []byte {
 
 // GetSoftSerial returns software defined product serial number
 func GetSoftSerial() string {
-	return getOverride(softSerialFile)
+	return strings.TrimSuffix(getOverride(softSerialFile), "\n")
 }
 
 func GetProductSerial() string {

--- a/pkg/pillar/hardware/model.go
+++ b/pkg/pillar/hardware/model.go
@@ -150,7 +150,7 @@ func GetProductSerial() string {
 			err)
 		serial = []byte{}
 	}
-	return string(serial)
+	return strings.TrimSuffix(string(serial), "\n")
 }
 
 // Returns productManufacturer, productName, productVersion, productSerial, productUuid

--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -32,7 +32,10 @@ type ZedCloudContext struct {
 	SuccessFunc         func(intf string, url string, reqLen int64, respLen int64)
 	NoLedManager        bool // Don't call UpdateLedManagerConfig
 	DevUUID             uuid.UUID
+	DevSerial           string
 }
+
+var sendCounter uint32
 
 // Tries all interfaces (free first) until one succeeds. interation arg
 // ensure load spreading across multiple interfaces.
@@ -268,6 +271,16 @@ func SendOnIntf(ctx ZedCloudContext, destUrl string, intf string, reqlen int64, 
 		if devUuidStr != "" {
 			req.Header.Add("X-Request-Id", devUuidStr)
 		}
+
+		// Add Device Serial Number to the HTTP Header for initial tracability
+		devSerialNum := ctx.DevSerial
+		if devSerialNum != "" {
+			req.Header.Add("X-Serial-Number", devSerialNum)
+		}
+		log.Debugf("X-Serial-Number, count (%d), serial: %s",
+			sendCounter, devSerialNum)
+		sendCounter++
+
 		trace := &httptrace.ClientTrace{
 			GotConn: func(connInfo httptrace.GotConnInfo) {
 				log.Debugf("Got RemoteAddr: %+v, LocalAddr: %+v\n",


### PR DESCRIPTION
Sending 'serial number' in http header for device, pivotal #165749178. Have tested on zedcloud is receiving the 'serial#'.