### PR TITLE
Disable IOMMU for Intel graphics devices

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -87,7 +87,7 @@ function set_x86_64 {
 function set_x86_64_baremetal {
    set_generic
    set_x86_64
-   set_global xen_platform_tweaks "efi=no-rs"
+   set_global xen_platform_tweaks "efi=no-rs iommu=no-igfx"
    set_global linux_qemu_tweaks " "
    set_global linux_console "console=tty0"
 }


### PR DESCRIPTION
As per: https://xenbits.xen.org/docs/unstable/misc/xen-command-line.html#iommu this is to workaround the following:
```(XEN) [VT-D]DMAR:[DMA Read] Request device [0000:00:02.0] fault addr 8e43c000, iommu reg = ffff82c00021d000```

We've also files a bug report with Xen: https://lists.xenproject.org/archives/html/xen-devel/2019-07/msg01364.html