### PR TITLE
Removed count of members

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ that benefit the community at large, not just code contributions:
 * Fix bugs and add new features
 
 EVE governance is conducted by the Technical Steering Committee (TSC),
-which is currently composed of 22 active members:
+which is currently composed of the following members:
 
 * Allen Wittenauer <aw@effectivemachines.com>
 * Avi Deitcher <avi@deitcher.net>


### PR DESCRIPTION
No reason to have a hard coded count of active TSC members in addition to the list.