### PR TITLE
ACL nits.

### DIFF
--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -680,7 +680,10 @@ func handleAppNetworkConfigModify(ctxArg interface{}, key string, configArg inte
 		doAppNetworkConfigModify(ctx, key, config, status)
 	}
 	// on error, relinquish the acquired resource
-	if status != nil && status.Error != "" {
+	// only when, the network is meant to be activated
+	// and it is still not
+	if status != nil && status.Error != "" &&
+		config.Activate && !status.Activated {
 		releaseAppNetworkResources(ctx, key, status)
 	}
 	log.Infof("handleAppNetworkConfigModify(%s) done\n", key)
@@ -2687,7 +2690,7 @@ func validateAppNetworkConfig(ctx *zedrouterContext, appNetConfig types.AppNetwo
 	if len(ulCfgList0) == 0 {
 		return true
 	}
-	if containsACLPortMapRule(ctx, ulCfgList0) {
+	if containsHangingACLPortMapRule(ctx, ulCfgList0) {
 		log.Errorf("app (%s) on network with no uplink and has portmap rule\n",
 			appNetConfig.DisplayName)
 		errStr := fmt.Sprintf("network with no uplink, has portmap")
@@ -2703,7 +2706,7 @@ func validateAppNetworkConfig(ctx *zedrouterContext, appNetConfig types.AppNetwo
 		// XXX can an delete+add of app instance with same
 		// portmap result in a failure?
 		if appNetStatus.DisplayName == appNetStatus1.DisplayName ||
-			appNetStatus1.Error != "" || len(ulCfgList1) == 0 {
+			(appNetStatus1.Error != "" && !appNetStatus1.Activated) || len(ulCfgList1) == 0 {
 			continue
 		}
 		if checkUnderlayNetworkForPortMapOverlap(ctx, appNetStatus, ulCfgList0, ulCfgList1) {
@@ -2717,7 +2720,7 @@ func validateAppNetworkConfig(ctx *zedrouterContext, appNetConfig types.AppNetwo
 
 // whether there is a portmap rule, on with a network instance with no
 // uplink interface
-func containsACLPortMapRule(ctx *zedrouterContext,
+func containsHangingACLPortMapRule(ctx *zedrouterContext,
 	ulCfgList []types.UnderlayNetworkConfig) bool {
 	for _, ulCfg := range ulCfgList {
 		network := ulCfg.Network.String()
@@ -2796,14 +2799,11 @@ func scanAppNetworkStatusInErrorAndUpdate(ctx *zedrouterContext, key0 string) {
 	for key, st := range items {
 		status := cast.CastAppNetworkStatus(st)
 		config := lookupAppNetworkConfig(ctx, key)
-		if !config.Activate || status.Activated ||
+		if config == nil || !config.Activate ||
 			status.Error == "" || key == key0 {
 			continue
 		}
-		config = lookupAppNetworkConfig(ctx, key)
-		if config != nil {
-			doAppNetworkConfigModify(ctx, key, *config, &status)
-		}
+		doAppNetworkConfigModify(ctx, key, *config, &status)
 	}
 }
 
@@ -2812,23 +2812,23 @@ func scanAppNetworkStatusInErrorAndUpdate(ctx *zedrouterContext, key0 string) {
 func releaseAppNetworkResources(ctx *zedrouterContext, key string,
 	status *types.AppNetworkStatus) {
 	log.Infof("relaseAppNetworkResources(%s)\n", key)
-	for _, ulStatus := range status.UnderlayNetworkList {
+	for idx, ulStatus := range status.UnderlayNetworkList {
 		aclArgs := types.AppNetworkACLArgs{BridgeName: ulStatus.Bridge,
 			VifName: ulStatus.Vif}
 		ruleList, err := deleteACLConfiglet(aclArgs, ulStatus.ACLRules)
 		if err != nil {
 			addError(ctx, status, "deleteACL", err)
 		}
-		ulStatus.ACLRules = ruleList
+		status.UnderlayNetworkList[idx].ACLRules = ruleList
 	}
-	for _, olStatus := range status.OverlayNetworkList {
+	for idx, olStatus := range status.OverlayNetworkList {
 		aclArgs := types.AppNetworkACLArgs{BridgeName: olStatus.Bridge,
 			VifName: olStatus.Vif}
 		ruleList, err := deleteACLConfiglet(aclArgs, olStatus.ACLRules)
 		if err != nil {
 			addError(ctx, status, "deleteACL", err)
 		}
-		olStatus.ACLRules = ruleList
+		status.OverlayNetworkList[idx].ACLRules = ruleList
 	}
 	publishAppNetworkStatus(ctx, status)
 }


### PR DESCRIPTION
some corner cases for ACLs.
1.  For failed ACL updates, for an active or deactivated(config) app instance, should not kill/release resources for the app instance in run state.  The app instance will keep running or, remain in deactivated state, with the last good state. Added checks for preventing, release ACL resources, for an active/deactivated app instances , with update error.
2. While releasing ACLs for app instances in error state, the ACL lists were not getting properly updated.