### PR TITLE
Allowing stage1 Xen to use external xl.cfg

### DIFF
--- a/pkg/rkt-stage1/0003-rkt-seed-xl.patch
+++ b/pkg/rkt-stage1/0003-rkt-seed-xl.patch
@@ -1,0 +1,69 @@
+diff --git a/files/run b/files/run
+index 3f5fdc8..ab63fa0 100755
+--- a/files/run
++++ b/files/run
+@@ -55,26 +55,33 @@ mountpoint=$stage2
+ rm $outconfig &> /dev/null
+ echo "kernel='$workpath/kernel'" >> $outconfig
+ echo "ramdisk='$workpath/initrd'" >> $outconfig
+-echo "memory = 1024" >> $outconfig
+-echo "vcpus = 2" >> $outconfig
+-echo "serial='pty'" >> $outconfig
+-echo "boot='c'" >> $outconfig
+-if test $pvcalls -eq 0
+-then
+-	if test $bridge = "vif"
+-	then
+-		echo "vif=['script=vif-nat,ip=$ip']" >> $outconfig
+-	else
+-		echo "vif=['bridge=$bridge']" >> $outconfig
+-	fi
+-	echo extra=\'console=hvc0 root=9p ip=$ip gw=$gw route=$route\' >> $outconfig 
+-else
+-	echo "pvcalls=['']" >> $outconfig
+-	echo extra=\'console=hvc0 root=9p pvcalls=1\' >> $outconfig 
+-fi
+-echo "vfb=['vnc=1']" >> $outconfig
+ echo "p9=[ 'tag=share_dir,security_model=none,path=$mountpoint' ]" >> $outconfig
+-echo "name=\"$uuid\"" >> $outconfig
++
++if [ -f "$STAGE1_SEED_XL_CFG" ] ; then
++    grep -Ev '^(disk|type)' < "$STAGE1_SEED_XL_CFG" >> $outconfig
++    echo extra=\'console=hvc0 root=9p\' >> $outconfig
++else	
++    echo "memory = 1024" >> $outconfig
++    echo "vcpus = 2" >> $outconfig
++    echo "serial='pty'" >> $outconfig
++    echo "boot='c'" >> $outconfig
++    echo "vfb=['vnc=1']" >> $outconfig
++    echo "name=\"$uuid\"" >> $outconfig
++    if test $pvcalls -eq 0
++    then
++    	if test $bridge = "vif"
++    	then
++    		echo "vif=['script=vif-nat,ip=$ip']" >> $outconfig
++    	else
++    		echo "vif=['bridge=$bridge']" >> $outconfig
++    	fi
++    	echo extra=\'console=hvc0 root=9p ip=$ip gw=$gw route=$route\' >> $outconfig 
++    else
++    	echo "pvcalls=['']" >> $outconfig
++    	echo extra=\'console=hvc0 root=9p pvcalls=1\' >> $outconfig 
++    fi
++fi    
++
+ echo $cmdline > $mountpoint/cmdline
+ xl create $gargs $workpath/out/test.0
+ domid=`xl list | grep "$uuid" | awk '{print$2}'`
+diff --git a/files/stop b/files/stop
+index 17db70b..e3e69e3 100755
+--- a/files/stop
++++ b/files/stop
+@@ -1,4 +1,6 @@
+ #!/bin/bash
+ 
+-xl destroy $1 &>/dev/null
++domain=$(sed -ne '/^name *=/s/^.*"\(.*\)"/\1/p' < "/var/lib/rkt/pods/run/$1/stage1/rootfs/out/test.0")
++
++xl destroy $domain &>/dev/null
+ exit 0

--- a/pkg/rkt-stage1/Dockerfile.in
+++ b/pkg/rkt-stage1/Dockerfile.in
@@ -9,10 +9,9 @@ RUN apk add --no-cache bash git make autoconf gcc acl-dev musl-dev musl-utils li
 
 ADD https://github.com/rkt/stage1-xen/archive/master.zip /tmp
 RUN unzip /tmp/master.zip -d /go
-COPY 0001-Go-12-upgrade.patch /go/stage1-xen-master
-COPY 0002-eve-kernel.patch /go/stage1-xen-master
+COPY 000* /go/stage1-xen-master/
 WORKDIR /go/stage1-xen-master
-RUN patch -p1 < 0001-Go-12-upgrade.patch && patch -p1 < 0002-eve-kernel.patch
+RUN for p in *.patch ; do patch -p1 < "$p" ; done
 
 RUN bash build.sh
 COPY --from=eve-kernel /kernel /go/stage1-xen-master/target/rootfs


### PR DESCRIPTION
This change will allow to set STAGE1_SEED_XL_CFG to point to the seed xl.cfg file so that stage1 xen will use use that instead of constructing it from scratch