### PR TITLE
Introducing fscrypt as a pkg

### DIFF
--- a/pkg/fscrypt/Dockerfile
+++ b/pkg/fscrypt/Dockerfile
@@ -1,11 +1,10 @@
 FROM golang:1.12.4-alpine
 
-RUN apk add --no-cache git gcc linux-headers libc-dev util-linux \
-                       libpcap-dev make linux-pam-dev m4
+RUN apk add --no-cache git=2.20.1-r0 gcc=8.3.0-r0 linux-headers=4.18.13-r1 \
+                       libc-dev=0.7.1-r0 make=4.2.1-r2 linux-pam-dev=1.3.0-r0 m4=1.4.18-r1
 
-RUN mkdir -p $GOPATH/src/github.com/google && \
-    cd $GOPATH/src/github.com/google && \
-    git clone https://github.com/google/fscrypt
-WORKDIR $GOPATH/src/github.com/google/fscrypt
-
+RUN mkdir -p $GOPATH/src/github.com/google
+WORKDIR "$GOPATH"/src/github.com/google
+RUN git clone https://github.com/google/fscrypt
+WORKDIR "$GOPATH"/src/github.com/google/fscrypt
 RUN make && make install

--- a/pkg/fscrypt/Dockerfile
+++ b/pkg/fscrypt/Dockerfile
@@ -1,8 +1,11 @@
 FROM golang:1.12.4-alpine
 
-RUN apk add --no-cache git gcc linux-headers libc-dev util-linux libpcap-dev make linux-pam-dev
+RUN apk add --no-cache git gcc linux-headers libc-dev util-linux \
+                       libpcap-dev make linux-pam-dev m4
 
-RUN git clone https://github.com/google/fscrypt
-WORKDIR /go/rkt
-RUN git reset --hard tags/v0.2.4
-RUN make 
+RUN mkdir -p $GOPATH/src/github.com/google && \
+    cd $GOPATH/src/github.com/google && \
+    git clone https://github.com/google/fscrypt
+WORKDIR $GOPATH/src/github.com/google/fscrypt
+
+RUN make && make install

--- a/pkg/fscrypt/Dockerfile
+++ b/pkg/fscrypt/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.12.4-alpine
+
+RUN apk add --no-cache git gcc linux-headers libc-dev util-linux libpcap-dev make linux-pam-dev
+
+RUN git clone https://github.com/google/fscrypt
+WORKDIR /go/rkt
+RUN git reset --hard tags/v0.2.4
+RUN make 

--- a/pkg/fscrypt/Dockerfile
+++ b/pkg/fscrypt/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.4-alpine
+FROM golang:1.12.4-alpine as build
 
 RUN apk add --no-cache git=2.20.1-r0 gcc=8.3.0-r0 linux-headers=4.18.13-r1 \
                        libc-dev=0.7.1-r0 make=4.2.1-r2 linux-pam-dev=1.3.0-r0 \
@@ -8,4 +8,9 @@ RUN mkdir -p /go/src/github.com/google
 WORKDIR /go/src/github.com/google
 RUN git clone https://github.com/google/fscrypt
 WORKDIR /go/src/github.com/google/fscrypt
+RUN git reset --hard b41569d397d3e66099cde07d8eef36b2f42dd0ec
 RUN make && make install
+
+FROM scratch
+COPY --from=build /usr/local/bin/fscrypt /
+COPY --from=build /usr/local/lib/security/pam_fscrypt.so /

--- a/pkg/fscrypt/Dockerfile
+++ b/pkg/fscrypt/Dockerfile
@@ -1,10 +1,11 @@
 FROM golang:1.12.4-alpine
 
 RUN apk add --no-cache git=2.20.1-r0 gcc=8.3.0-r0 linux-headers=4.18.13-r1 \
-                       libc-dev=0.7.1-r0 make=4.2.1-r2 linux-pam-dev=1.3.0-r0 m4=1.4.18-r1
+                       libc-dev=0.7.1-r0 make=4.2.1-r2 linux-pam-dev=1.3.0-r0 \
+                       m4=1.4.18-r1
 
-RUN mkdir -p $GOPATH/src/github.com/google
-WORKDIR "$GOPATH"/src/github.com/google
+RUN mkdir -p /go/src/github.com/google
+WORKDIR /go/src/github.com/google
 RUN git clone https://github.com/google/fscrypt
-WORKDIR "$GOPATH"/src/github.com/google/fscrypt
+WORKDIR /go/src/github.com/google/fscrypt
 RUN make && make install

--- a/pkg/fscrypt/build.yml
+++ b/pkg/fscrypt/build.yml
@@ -1,0 +1,3 @@
+image: eve-fscrypt
+org: lfedge
+network: yes


### PR DESCRIPTION
This is first of many changes to implement disk encryption on EVE. The first step is to
build fscrypt as a separate stage. I will follow up with another commit to use this pkg
in pillar Dockerfile.

Once fscrypt is available as a apk package on Alpine, this can be removed.