### PR TITLE
simplify build line

### DIFF
--- a/pkg/pillar/Makefile
+++ b/pkg/pillar/Makefile
@@ -10,8 +10,12 @@ ARCH         ?= amd64
 DISTDIR      := dist/$(ARCH)
 BUILD_VERSION=$(shell scripts/getversion.sh 2>/dev/null)
 
-DOCKER_ARGS=$${GOARCH:+--build-arg GOARCH=}$(GOARCH)
-DOCKER_TAG=lfedge/eve-pillar:local$${GOARCH:+-}$(GOARCH)
+DOCKER_ARGS=
+DOCKER_TAG=lfedge/eve-pillar:local
+ifneq ($(GOARCH),)
+DOCKER_ARGS:=--build-arg GOARCH=$(GOARCH)
+DOCKER_TAG:=$(DOCKER_TAG)-$(GOARCH)
+endif
 
 APPS = zedbox
 APPS1 = logmanager ledmanager downloader verifier client zedrouter domainmgr \


### PR DESCRIPTION
Small but simplifying change. Same result, but does the `GOARCH` var expansion inside the Makefile instead of called out to the shell. This way, you actually can see the result.

Before:

```
$ make -n build-docker
docker build ${GOARCH:+--build-arg GOARCH=} -t lfedge/eve-pillar:local${GOARCH:+-} .
$ make -n build-docker GOARCH=arm64
docker build ${GOARCH:+--build-arg GOARCH=}arm64 -t lfedge/eve-pillar:local${GOARCH:+-}arm64 
```

That is a messy line to copy or work with.

After:

```
$ make -n build-docker
docker build  -t lfedge/eve-pillar:local .
$ make -n build-docker GOARCH=arm64
docker build --build-arg GOARCH=arm64 -t lfedge/eve-pillar:local-arm64 .
```

Minor change, easier to work with and understand