### PR TITLE
Applying [Xen-devel] [PATCH v2] 9pfs has a QEMU backend

### DIFF
--- a/pkg/xen-tools/patches-4.12.0/04-9pfs-has-a-QEMU-backend.patch
+++ b/pkg/xen-tools/patches-4.12.0/04-9pfs-has-a-QEMU-backend.patch
@@ -1,0 +1,57 @@
+Add 9pfs to the kind of PV drivers that has a QEMU backend, specifically
+to the macro QEMU_BACKEND.
+
+This is needed otherwise upon domain destroy we get a timeout error:
+
+libxl: error: libxl_device.c:1132:device_backend_callback: Domain 1:unable to 
+remove device with path /local/domain/0/backend/9pfs/1/0
+libxl: error: libxl_domain.c:1129:devices_destroy_cb: Domain 
+1:libxl__devices_destroy failed
+
+This change should have been part of b53b4037cef6 "libxl/xl: add support
+for Xen 9pfs".
+
+Also add a comment in libxl_types_internal.idl to help remember changing
+QEMU_BACKEND going forward.
+
+Signed-off-by: Stefano Stabellini <stefanos@xxxxxxxxxx>
+
+---
+
+Changes in v2:
+- add in-code comment
+- improve commit message
+
+---
+
+ tools/libxl/libxl_internal.h         | 1 +
+ tools/libxl/libxl_types_internal.idl | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/tools/libxl/libxl_internal.h b/tools/libxl/libxl_internal.h
+index a3102871f3..e7d9777930 100644
+--- a/tools/libxl/libxl_internal.h
++++ b/tools/libxl/libxl_internal.h
+@@ -636,6 +636,7 @@ typedef struct {
+     (dev)->backend_kind == LIBXL__DEVICE_KIND_QDISK || \
+     (dev)->backend_kind == LIBXL__DEVICE_KIND_VFB || \
+     (dev)->backend_kind == LIBXL__DEVICE_KIND_QUSB || \
++    (dev)->backend_kind == LIBXL__DEVICE_KIND_9PFS || \
+     (dev)->backend_kind == LIBXL__DEVICE_KIND_VKBD)
+ 
+ #define XC_PCI_BDF             "0x%x, 0x%x, 0x%x, 0x%x"
+diff --git a/tools/libxl/libxl_types_internal.idl 
+b/tools/libxl/libxl_types_internal.idl
+index 37402e49cb..cb85c3b37f 100644
+--- a/tools/libxl/libxl_types_internal.idl
++++ b/tools/libxl/libxl_types_internal.idl
+@@ -13,6 +13,7 @@ libxl__qmp_message_type = Enumeration("qmp_message_type", [
+     (5, "invalid"),
+     ])
+ 
++# Consider adding to QEMU_BACKEND in libxl_internal.h
+ libxl__device_kind = Enumeration("device_kind", [
+     (0, "NONE"),
+     (1, "VIF"),
+-- 
+2.17.1


### PR DESCRIPTION
This is coming from: https://lists.xenproject.org/archives/html/xen-devel/2019-08/msg00508.html

We need this for stage1 rkt container support