### PR TITLE
mkimage-raw-efi: use unsquashfs for squash rootfs.

### DIFF
--- a/pkg/mkimage-raw-efi/Dockerfile
+++ b/pkg/mkimage-raw-efi/Dockerfile
@@ -7,6 +7,7 @@ RUN apk add --no-cache \
   sgdisk \
   e2fsprogs \
   util-linux \
+  squashfs-tools \
   coreutils
 
 WORKDIR /

--- a/pkg/mkimage-raw-efi/make-raw
+++ b/pkg/mkimage-raw-efi/make-raw
@@ -91,11 +91,17 @@ function do_efi {
   sgdisk --new $NUM_PART:$SEC_START:$SEC_END --typecode=$NUM_PART:ef00 --change-name=$NUM_PART:'EFI System' \
          --attributes $NUM_PART:set:2 $IMGFILE
  
-  # Initialize partition...
-  #   ...extract GRUB bootloader
-  mount -o loop "$ROOTFS_IMG" /mnt
-  cp /mnt/EFI/BOOT/BOOT*EFI /efifs/EFI/BOOT/
-  umount /mnt
+  # Extract GRUB bootloader
+  # Try squashfs tools first in case ROOTFS_IMG is squashfs, otherwise use mount
+  rm -rf /tmp/grub
+  unsquashfs -d /tmp/grub "$ROOTFS_IMG" EFI/BOOT/ || (
+      mkdir -p /tmp/grub/EFI/BOOT
+      mount -o loop "$ROOTFS_IMG" /mnt
+      cp /mnt/EFI/BOOT/BOOT*EFI /tmp/grub/EFI/BOOT/
+      umount /mnt
+  )
+  cp /tmp/grub/EFI/BOOT/BOOT*EFI /efifs/EFI/BOOT
+
   #   ...copy EFI fs to EFI partition
   dd if=`dir2vfat /efifs $(( ($SEC_END - $SEC_START) / 2))` of=$IMGFILE bs=512 conv=notrunc seek=$SEC_START
 


### PR DESCRIPTION
On Mac builds you can't seem to be able to mount squashfs in Docker. Use squashfs tools to extract GRUB instead.