### PR TITLE
Fixed bugs in propagating ContainerImageId to AppInstanceStatus

### DIFF
--- a/pkg/pillar/cmd/verifier/verifier.go
+++ b/pkg/pillar/cmd/verifier/verifier.go
@@ -725,14 +725,15 @@ func handleCreate(ctx *verifierContext, objType string,
 	}
 
 	status := types.VerifyImageStatus{
-		Safename:    config.Safename,
-		ObjType:     objType,
-		ImageSha256: config.ImageSha256,
-		PendingAdd:  true,
-		State:       types.DOWNLOADED,
-		RefCount:    config.RefCount,
-		LastUse:     time.Now(),
-		IsContainer: config.IsContainer,
+		Safename:         config.Safename,
+		ObjType:          objType,
+		ImageSha256:      config.ImageSha256,
+		PendingAdd:       true,
+		State:            types.DOWNLOADED,
+		RefCount:         config.RefCount,
+		LastUse:          time.Now(),
+		IsContainer:      config.IsContainer,
+		ContainerImageID: config.ContainerImageID,
 	}
 	publishVerifyImageStatus(ctx, &status)
 


### PR DESCRIPTION
Fixed bugs in propagating ContainerImageId

1) When creating VerifyImageStatus, copy the ContainerImageId foeld from
VerifierImageConfig

2) Fix a bug in updating StorageStatus.ContainerImageId and publishing
the change

3) Fixed debug statements in doInstall routine to use the prefix
doInstall instead of doUpdate

4) When updating AppInstanceStatus with ContainerId from VerifierStatus,
    publish the status.