### PR TITLE
 add non-default routes to handle security gateways

### DIFF
--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -1452,9 +1452,9 @@ func natActivate(ctx *zedrouterContext,
 			log.Errorf("IptableCmd failed: %s", err)
 			return err
 		}
-		err = PbrRouteAddDefault(status.BridgeName, a)
+		err = PbrRouteAddAll(status.BridgeName, a)
 		if err != nil {
-			log.Errorf("PbrRouteAddDefault for Bridge(%s) and interface %s failed. "+
+			log.Errorf("PbrRouteAddAll for Bridge(%s) and interface %s failed. "+
 				"Err: %s", status.BridgeName, a, err)
 			return err
 		}
@@ -1514,9 +1514,9 @@ func natInactivate(ctx *zedrouterContext,
 		if err != nil {
 			log.Errorf("natInactivate: iptableCmd failed %s\n", err)
 		}
-		err = PbrRouteDeleteDefault(status.BridgeName, a)
+		err = PbrRouteDeleteAll(status.BridgeName, a)
 		if err != nil {
-			log.Errorf("natInactivate: PbrRouteDeleteDefault failed %s\n", err)
+			log.Errorf("natInactivate: PbrRouteDeleteAll failed %s\n", err)
 		}
 	}
 	// Remove from Pbr table
@@ -1691,4 +1691,33 @@ func vifNameToBridgeName(ctx *zedrouterContext, vifName string) string {
 		}
 	}
 	return ""
+}
+
+// Get All ifindices for the Network Instances which are using ifname
+func getAllNIindices(ctx *zedrouterContext, ifname string) []int {
+
+	var indicies []int
+	pub := ctx.pubNetworkInstanceStatus
+	if pub == nil {
+		return indicies
+	}
+	instanceItems := pub.GetAll()
+	for _, st := range instanceItems {
+		status := cast.CastNetworkInstanceStatus(st)
+		if !status.IsUsingPort(ifname) {
+			continue
+		}
+		if status.BridgeName == "" {
+			continue
+		}
+		link, err := netlink.LinkByName(status.BridgeName)
+		if err != nil {
+			errStr := fmt.Sprintf("LinkByName(%s) failed: %s",
+				status.BridgeName, err)
+			log.Errorln(errStr)
+			continue
+		}
+		indicies = append(indicies, link.Attrs().Index)
+	}
+	return indicies
 }

--- a/pkg/pillar/cmd/zedrouter/pbr.go
+++ b/pkg/pillar/cmd/zedrouter/pbr.go
@@ -73,8 +73,8 @@ func PbrRouteAddAll(bridgeName string, port string) error {
 			ifindex, index)
 		ifindex = index
 	}
+	MyTable := FreeTable + ifindex
 	for _, rt := range routes {
-		MyTable := FreeTable + ifindex
 		myrt := rt
 		myrt.Table = MyTable
 		// Clear any RTNH_F_LINKDOWN etc flags since add doesn't like them
@@ -119,8 +119,8 @@ func PbrRouteDeleteAll(bridgeName string, port string) error {
 		log.Errorln(errStr)
 		return errors.New(errStr)
 	}
+	MyTable := FreeTable + ifindex
 	for _, rt := range routes {
-		MyTable := FreeTable + ifindex
 		myrt := rt
 		myrt.Table = MyTable
 		// Clear any RTNH_F_LINKDOWN etc flags since del might not like them

--- a/pkg/pillar/cmd/zedrouter/pbr.go
+++ b/pkg/pillar/cmd/zedrouter/pbr.go
@@ -33,7 +33,7 @@ func PbrInit(ctx *zedrouterContext) {
 	flushRules(0)
 }
 
-// Add a default route for the bridgeName table to the specific port
+// PbrRouteAddAll adds all the routes for the bridgeName table to the specific port
 // Separately we handle changes in PbrRouteChange
 func PbrRouteAddAll(bridgeName string, port string) error {
 	log.Infof("PbrRouteAddAll(%s, %s)\n", bridgeName, port)
@@ -93,7 +93,7 @@ func PbrRouteAddAll(bridgeName string, port string) error {
 	return nil
 }
 
-// Delete all the default routes for the bridgeName table to the specific port
+// PbrRouteDeleteAll deletes all the routes for the bridgeName table to the specific port
 // Separately we handle changes in PbrRouteChange
 func PbrRouteDeleteAll(bridgeName string, port string) error {
 	log.Infof("PbrRouteDeleteAll(%s, %s)\n", bridgeName, port)

--- a/pkg/pillar/cmd/zedrouter/pbr.go
+++ b/pkg/pillar/cmd/zedrouter/pbr.go
@@ -34,8 +34,9 @@ func PbrInit(ctx *zedrouterContext) {
 }
 
 // Add a default route for the bridgeName table to the specific port
-func PbrRouteAddDefault(bridgeName string, port string) error {
-	log.Infof("PbrRouteAddDefault(%s, %s)\n", bridgeName, port)
+// Separately we handle changes in PbrRouteChange
+func PbrRouteAddAll(bridgeName string, port string) error {
+	log.Infof("PbrRouteAddAll(%s, %s)\n", bridgeName, port)
 
 	ifindex, err := devicenetwork.IfnameToIndex(port)
 	if err != nil {
@@ -44,9 +45,9 @@ func PbrRouteAddDefault(bridgeName string, port string) error {
 		log.Errorln(errStr)
 		return errors.New(errStr)
 	}
-	rt := getDefaultIPv4Route(ifindex)
-	if rt == nil {
-		log.Warnf("PbrRouteAddDefault(%s, %s) no default route\n",
+	routes := getAllIPv4Routes(ifindex)
+	if routes == nil {
+		log.Warnf("PbrRouteAddAll(%s, %s) no routes",
 			bridgeName, port)
 		return nil
 	}
@@ -58,7 +59,7 @@ func PbrRouteAddDefault(bridgeName string, port string) error {
 		log.Errorln(errStr)
 		return errors.New(errStr)
 	}
-	// XXX do they differ?
+	// XXX do they differ? Yes
 	link, err := netlink.LinkByName(bridgeName)
 	if err != nil {
 		errStr := fmt.Sprintf("LinkByName(%s) failed: %s",
@@ -72,27 +73,30 @@ func PbrRouteAddDefault(bridgeName string, port string) error {
 			ifindex, index)
 		ifindex = index
 	}
-	MyTable := FreeTable + ifindex
-	myrt := *rt
-	myrt.Table = MyTable
-	// Clear any RTNH_F_LINKDOWN etc flags since add doesn't like them
-	if rt.Flags != 0 {
-		myrt.Flags = 0
-	}
-	log.Infof("PbrRouteAddDefault(%s, %s) adding %v\n",
-		bridgeName, port, myrt)
-	if err := netlink.RouteAdd(&myrt); err != nil {
-		errStr := fmt.Sprintf("Failed to add %v to %d: %s",
-			myrt, myrt.Table, err)
-		log.Errorln(errStr)
-		return errors.New(errStr)
+	for _, rt := range routes {
+		MyTable := FreeTable + ifindex
+		myrt := rt
+		myrt.Table = MyTable
+		// Clear any RTNH_F_LINKDOWN etc flags since add doesn't like them
+		if rt.Flags != 0 {
+			myrt.Flags = 0
+		}
+		log.Infof("PbrRouteAddAll(%s, %s) adding %v\n",
+			bridgeName, port, myrt)
+		if err := netlink.RouteAdd(&myrt); err != nil {
+			errStr := fmt.Sprintf("Failed to add %v to %d: %s",
+				myrt, myrt.Table, err)
+			log.Errorln(errStr)
+			return errors.New(errStr)
+		}
 	}
 	return nil
 }
 
-// Delete the default route for the bridgeName table to the specific port
-func PbrRouteDeleteDefault(bridgeName string, port string) error {
-	log.Infof("PbrRouteDeleteDefault(%s, %s)\n", bridgeName, port)
+// Delete all the default routes for the bridgeName table to the specific port
+// Separately we handle changes in PbrRouteChange
+func PbrRouteDeleteAll(bridgeName string, port string) error {
+	log.Infof("PbrRouteDeleteAll(%s, %s)\n", bridgeName, port)
 
 	ifindex, err := devicenetwork.IfnameToIndex(port)
 	if err != nil {
@@ -101,9 +105,9 @@ func PbrRouteDeleteDefault(bridgeName string, port string) error {
 		log.Errorln(errStr)
 		return errors.New(errStr)
 	}
-	rt := getDefaultIPv4Route(ifindex)
-	if rt == nil {
-		log.Warnf("PbrRouteDeleteDefault(%s, %s) no default route\n",
+	routes := getAllIPv4Routes(ifindex)
+	if routes == nil {
+		log.Warnf("PbrRouteDeleteAll(%s, %s) no routes",
 			bridgeName, port)
 		return nil
 	}
@@ -115,20 +119,22 @@ func PbrRouteDeleteDefault(bridgeName string, port string) error {
 		log.Errorln(errStr)
 		return errors.New(errStr)
 	}
-	MyTable := FreeTable + ifindex
-	myrt := *rt
-	myrt.Table = MyTable
-	// Clear any RTNH_F_LINKDOWN etc flags since del might not like them
-	if rt.Flags != 0 {
-		myrt.Flags = 0
-	}
-	log.Infof("PbrRouteDeleteDefault(%s, %s) deleting %v\n",
-		bridgeName, port, myrt)
-	if err := netlink.RouteDel(&myrt); err != nil {
-		errStr := fmt.Sprintf("Failed to delete %v from %d: %s",
-			myrt, myrt.Table, err)
-		log.Errorln(errStr)
-		return errors.New(errStr)
+	for _, rt := range routes {
+		MyTable := FreeTable + ifindex
+		myrt := rt
+		myrt.Table = MyTable
+		// Clear any RTNH_F_LINKDOWN etc flags since del might not like them
+		if rt.Flags != 0 {
+			myrt.Flags = 0
+		}
+		log.Infof("PbrRouteDeleteAll(%s, %s) deleting %v\n",
+			bridgeName, port, myrt)
+		if err := netlink.RouteDel(&myrt); err != nil {
+			errStr := fmt.Sprintf("Failed to delete %v from %d: %s",
+				myrt, myrt.Table, err)
+			log.Errorln(errStr)
+			// We continue to try to delete all
+		}
 	}
 	return nil
 }
@@ -168,7 +174,8 @@ func pbrGetFreeRule(prefixStr string) (*netlink.Rule, error) {
 }
 
 // Handle a route change
-func PbrRouteChange(deviceNetworkStatus *types.DeviceNetworkStatus,
+func PbrRouteChange(ctx *zedrouterContext,
+	deviceNetworkStatus *types.DeviceNetworkStatus,
 	change netlink.RouteUpdate) {
 
 	rt := change.Route
@@ -222,6 +229,16 @@ func PbrRouteChange(deviceNetworkStatus *types.DeviceNetworkStatus,
 			log.Errorf("Failed to remove %v from %d: %s\n",
 				myrt, myrt.Table, err)
 		}
+		// find all bridges for network instances and del for them
+		indicies := getAllNIindices(ctx, ifname)
+		log.Infof("XXX Apply route del %v to %v", rt, indicies)
+		for _, ifindex := range indicies {
+			myrt.Table = FreeTable + ifindex
+			if err := netlink.RouteDel(&myrt); err != nil {
+				log.Errorf("Failed to remove %v from %d: %s\n",
+					myrt, myrt.Table, err)
+			}
+		}
 	} else if change.Type == getRouteUpdateTypeNEWROUTE() {
 		log.Debugf("Received route add %v\n", rt)
 		if doFreeTable {
@@ -233,6 +250,16 @@ func PbrRouteChange(deviceNetworkStatus *types.DeviceNetworkStatus,
 		if err := netlink.RouteAdd(&myrt); err != nil {
 			log.Errorf("Failed to add %v to %d: %s\n",
 				myrt, myrt.Table, err)
+		}
+		// find all bridges for network instances and add for them
+		indicies := getAllNIindices(ctx, ifname)
+		log.Infof("XXX Apply route add %v to %v", rt, indicies)
+		for _, ifindex := range indicies {
+			myrt.Table = FreeTable + ifindex
+			if err := netlink.RouteAdd(&myrt); err != nil {
+				log.Errorf("Failed to add %v from %d: %s\n",
+					myrt, myrt.Table, err)
+			}
 		}
 	}
 }

--- a/pkg/pillar/cmd/zedrouter/pbr_linux.go
+++ b/pkg/pillar/cmd/zedrouter/pbr_linux.go
@@ -18,31 +18,21 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// Return the first default route for one interface. XXX or return all?
-func getDefaultIPv4Route(ifindex int) *netlink.Route {
+// Return the all routes for one interface
+func getAllIPv4Routes(ifindex int) []netlink.Route {
 	table := syscall.RT_TABLE_MAIN
-	// Default route is nil Dst.
-	filter := netlink.Route{Table: table, LinkIndex: ifindex, Dst: nil}
+	filter := netlink.Route{Table: table, LinkIndex: ifindex}
 	fflags := netlink.RT_FILTER_TABLE
 	fflags |= netlink.RT_FILTER_OIF
-	fflags |= netlink.RT_FILTER_DST
-	log.Infof("getDefaultIPv4Route(%d) filter %v\n", ifindex, filter)
+	log.Infof("getAllIPv4Routes(%d) filter %v\n", ifindex, filter)
 	routes, err := netlink.RouteListFiltered(syscall.AF_INET,
 		&filter, fflags)
 	if err != nil {
 		log.Fatalf("RouteList failed: %v\n", err)
 	}
-	log.Debugf("getDefaultIPv4Route(%d) - got %d matches\n",
+	log.Debugf("getAllIPv4Routes(%d) - got %d matches\n",
 		ifindex, len(routes))
-	for _, rt := range routes {
-		if rt.LinkIndex != ifindex {
-			continue
-		}
-		log.Debugf("getDefaultIPv4Route(%d) returning %v\n",
-			ifindex, rt)
-		return &rt
-	}
-	return nil
+	return routes
 }
 
 func getDefaultRouteTable() int {

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -398,7 +398,8 @@ func Run() {
 				routeChanges = devicenetwork.RouteChangeInit()
 				break
 			}
-			PbrRouteChange(zedrouterCtx.deviceNetworkStatus, change)
+			PbrRouteChange(&zedrouterCtx,
+				zedrouterCtx.deviceNetworkStatus, change)
 
 		case <-publishTimer.C:
 			log.Debugln("publishTimer at", time.Now())

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -180,11 +180,13 @@ if P3=$(zboot partdev P3) && [ -n "$P3" ]; then
         # XXX note that if we have a bad ext3 partition this will ask questions
         # Need to either dd zeros over the partition of feed "yes" into mkfs.
         if ! mkfs -t ext3 -v "$P3"; then
+	    # XXX !? will be zero
             echo "$(date -Ins -u) mkfs $P3 failed: $?"
             # Try mounting below
         fi
     fi
     if ! mount -t ext3 -o dirsync,noatime "$P3" $PERSISTDIR; then
+	# XXX !? will be zero
         echo "$(date -Ins -u) mount $P3 failed: $?"
     fi
 else
@@ -306,6 +308,7 @@ access_usb() {
     if [ -n "$SPECIAL" ] && [ -b "$SPECIAL" ]; then
         echo "$(date -Ins -u) Found USB with DevicePortConfig: $SPECIAL"
         if ! mount -t vfat "$SPECIAL" /mnt; then
+	    # XXX !? will be zero
             echo "$(date -Ins -u) mount $SPECIAL failed: $?"
             return
         fi
@@ -470,6 +473,7 @@ if [ $SELF_REGISTER = 1 ]; then
     fi
     echo "$(date -Ins -u) Starting client selfRegister getUuid"
     if ! $BINDIR/client -c $CURPART selfRegister getUuid; then
+	# XXX $? is always zero
         echo "$(date -Ins -u) client selfRegister failed with $?"
         exit 1
     fi
@@ -559,6 +563,12 @@ if [ $MEASURE = 1 ]; then
     ping6 -c 3 -w 1000 zedcontrol
     echo "$(date -Ins -u) Measurement done"
 fi
+
+# XXX remove? Looking for watchdog
+sleep 5
+ps -ef
+# XXX redundant but doesn't always start
+/usr/sbin/watchdog -c $TMPDIR/watchdogall.conf -F -s &
 
 # If there is a USB stick inserted and debug.enable.usb is set, we periodically
 # check for any usb.json with DevicePortConfig, deposit our identity,

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -180,13 +180,13 @@ if P3=$(zboot partdev P3) && [ -n "$P3" ]; then
         # XXX note that if we have a bad ext3 partition this will ask questions
         # Need to either dd zeros over the partition of feed "yes" into mkfs.
         if ! mkfs -t ext3 -v "$P3"; then
-	    # XXX !? will be zero
+            # XXX !? will be zero
             echo "$(date -Ins -u) mkfs $P3 failed: $?"
             # Try mounting below
         fi
     fi
     if ! mount -t ext3 -o dirsync,noatime "$P3" $PERSISTDIR; then
-	# XXX !? will be zero
+        # XXX !? will be zero
         echo "$(date -Ins -u) mount $P3 failed: $?"
     fi
 else
@@ -308,7 +308,7 @@ access_usb() {
     if [ -n "$SPECIAL" ] && [ -b "$SPECIAL" ]; then
         echo "$(date -Ins -u) Found USB with DevicePortConfig: $SPECIAL"
         if ! mount -t vfat "$SPECIAL" /mnt; then
-	    # XXX !? will be zero
+            # XXX !? will be zero
             echo "$(date -Ins -u) mount $SPECIAL failed: $?"
             return
         fi
@@ -473,7 +473,7 @@ if [ $SELF_REGISTER = 1 ]; then
     fi
     echo "$(date -Ins -u) Starting client selfRegister getUuid"
     if ! $BINDIR/client -c $CURPART selfRegister getUuid; then
-	# XXX $? is always zero
+        # XXX $? is always zero
         echo "$(date -Ins -u) client selfRegister failed with $?"
         exit 1
     fi


### PR DESCRIPTION
When application instances want to connect to an IP address on the local subnet the PBR code used to always send to the default router. Some security gateway configurations do not allow such routing back to the same interface. Hence here we add all of the routes into the PBR table for the bridge.
