### PR TITLE
Container left in exit state after App Instance remove

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1188,7 +1188,10 @@ func doInactivate(ctx *domainContext, status *types.DomainStatus) {
 		}
 	}
 
-	if status.DomainId != 0 {
+	// Incase of rkt based container, DomainShutdown moves the
+	// container to exit state and the domain is destroyed
+	// Issue Domain Destroy irrespective in container case
+	if status.IsContainer || status.DomainId != 0 {
 		err := DomainDestroy(*status)
 		if err != nil {
 			log.Errorf("DomainDestroy %s failed: %s\n",
@@ -2221,17 +2224,6 @@ func DomainDestroy(status types.DomainStatus) error {
 	log.Infof("DomainDestroy %s %d\n", status.DomainName, status.DomainId)
 
 	if status.IsContainer {
-		// XXX:FIXME - Observed that "rkt stop" or "rkt stop --force=true"
-		// is not actually stopping the pod.
-		// And the subsequent invocation of rkt rm is failing, since
-		// the pod is still in running state
-		// As a work around, issuing xl destroy, wait for 3 seconds
-		// and then issue rkt rm to cleanup
-		log.Infof("First do xl destroy ... DomainName - %s  DomainID - %d\n",
-			status.DomainName, status.DomainId)
-		err = xlDestroy(status.DomainName, status.DomainId)
-		// wait for 3 seconds
-		time.Sleep(3)
 		// Use rkt tool
 		log.Infof("Using rkt tool ... PodUUID - %s\n", status.PodUUID)
 		err = rktRm(status.PodUUID)

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -242,7 +242,7 @@ type StorageStatus struct {
 	Progress           uint    // In percent i.e., 0-100
 	HasDownloaderRef   bool    // Reference against downloader to clean up
 	HasVerifierRef     bool    // Reference against verifier to clean up
-	IsContainer        bool    // Is the imge a Container??
+	IsContainer        bool    // Is the image a Container??
 	ContainerImageID   string  // Container Image ID if IsContainer=true
 	Vdev               string  // Allocated
 	ActiveFileLocation string  // Location of filestystem


### PR DESCRIPTION
1) Incase of rkt based container, Domain Shutdown moves the
container to exit state and the domain is destroyed.
The container is just left in exit state.
Issuing Domain Destroy after Domain Shutdown to destroy the container.
2) Remove workaround of invoking xlDestroy() before rktRm()

Signed-off-by: Sankar Patchineelam <sankar@zededa.com>