### PR TITLE
Apache Yetus flag change for junit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
             --revive-config=.revive.toml
             --linecomments=''
             --bugcomments=briefreport,htmlout,junit
-            --junit-results-xml=/tmp/yetus-out/results.xml
+            --junit-report-xml=/tmp/yetus-out/results.xml
             --tests-filter=checkmake,golang,golangcilint
             --continuous-improvement=true
       - store_test_results:


### PR DESCRIPTION
After apache/yetus#70 (aka YETUS-871) is committed, yetus runs will fail.  So here's a proactive patch after the commit to fix it here since we are still running master.  It should be noted that 0.11.0 will likely be cut in the next week and should be a good release to use instead of the top of the tree. :)