### PR TITLE
Try updating Container ImageId only for a Container

### DIFF
--- a/pkg/pillar/cmd/zedmanager/handledownloader.go
+++ b/pkg/pillar/cmd/zedmanager/handledownloader.go
@@ -125,8 +125,13 @@ func handleDownloaderStatusModify(ctxArg interface{}, key string,
 		return
 	}
 
+	updateContainerImageID := false
+	if status.IsContainer {
+		updateContainerImageID = true
+	}
+
 	// Normal update case
-	updateAIStatusWithStorageSafename(ctx, key, true, status.ContainerImageID)
+	updateAIStatusWithStorageSafename(ctx, key, updateContainerImageID, status.ContainerImageID)
 	log.Infof("handleDownloaderStatusModify done for %s\n",
 		status.Safename)
 }

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -42,14 +42,13 @@ func updateAIStatusWithStorageSafename(ctx *zedmanagerContext,
 			if safename == safename2 {
 				log.Infof("Found StorageStatus URL %s safename %s\n",
 					ssPtr.Name, safename)
-				changed := false
 				if updateContainerImageID {
 					if status.ContainerImageID != containerImageID {
 						log.Debugf("Update AIS containerImageID: %s\n",
 							containerImageID)
 						status.ContainerImageID = containerImageID
 						ssPtr.ContainerImageID = containerImageID
-						changed = true
+						publishAppInstanceStatus(ctx, &status)
 					} else {
 						log.Debugf("No change in ContainerId in Status. "+
 							"status.ContainerImageID: %s, containerImageID: %s, "+
@@ -57,9 +56,6 @@ func updateAIStatusWithStorageSafename(ctx *zedmanagerContext,
 							status.ContainerImageID, containerImageID,
 							ssPtr.ContainerImageID)
 					}
-				}
-				if changed {
-					publishAppInstanceStatus(ctx, &status)
 				}
 				updateAIStatusUUID(ctx, status.Key())
 				found = true


### PR DESCRIPTION
Even for a non container image Id, the message that contains image id is not updated is getting logged. This patch should take care of that situation.