### PR TITLE
 remove BaseOsConfig correctly

### DIFF
--- a/pkg/pillar/agentlog/agentlog.go
+++ b/pkg/pillar/agentlog/agentlog.go
@@ -278,12 +278,7 @@ func getCurrentIMGdir() string {
 	if currentIMGdir != "" {
 		return currentIMGdir
 	}
-	var partName string
-	if !zboot.IsAvailable() {
-		partName = "IMGA"
-	} else {
-		partName = zboot.GetCurrentPartition()
-	}
+	partName := zboot.GetCurrentPartition()
 	currentIMGdir = fmt.Sprintf("%s/%s", persistDir, partName)
 	return currentIMGdir
 }
@@ -294,9 +289,6 @@ func getOtherIMGdir(inprogressCheck bool) string {
 
 	if otherIMGdir != "" {
 		return otherIMGdir
-	}
-	if !zboot.IsAvailable() {
-		return ""
 	}
 	if inprogressCheck && !zboot.IsOtherPartitionStateInProgress() {
 		return ""

--- a/pkg/pillar/cmd/baseosmgr/baseosmgr.go
+++ b/pkg/pillar/cmd/baseosmgr/baseosmgr.go
@@ -199,6 +199,7 @@ func handleBaseOsConfigDelete(ctxArg interface{}, key string,
 // base os config modify event
 func handleBaseOsCreate(ctxArg interface{}, key string, configArg interface{}) {
 
+	log.Infof("handleBaseOsCreate(%s)\n", key)
 	ctx := ctxArg.(*baseOsMgrContext)
 	config := cast.CastBaseOsConfig(configArg)
 	status := types.BaseOsStatus{
@@ -216,11 +217,23 @@ func handleBaseOsCreate(ctxArg interface{}, key string, configArg interface{}) {
 		ss.ImageSha256 = sc.ImageSha256
 		ss.Target = sc.Target
 	}
+	// Check image count
+	err := validateBaseOsConfig(ctx, config)
+	if err != nil {
+		errStr := fmt.Sprintf("%v", err)
+		log.Errorln(errStr)
+		status.Error = errStr
+		status.ErrorTime = time.Now()
+		publishBaseOsStatus(ctx, &status)
+		return
+	}
 	publishBaseOsStatus(ctx, &status)
-
+	baseOsHandleStatusUpdate(ctx, &config, &status)
 }
+
 func handleBaseOsModify(ctxArg interface{}, key string, configArg interface{}) {
 
+	log.Infof("handleBaseOsModify(%s)\n", key)
 	ctx := ctxArg.(*baseOsMgrContext)
 	config := cast.CastBaseOsConfig(configArg)
 	status := lookupBaseOsStatus(ctx, key)

--- a/pkg/pillar/cmd/baseosmgr/handlebaseos.go
+++ b/pkg/pillar/cmd/baseosmgr/handlebaseos.go
@@ -634,12 +634,19 @@ func doBaseOsUninstall(ctx *baseOsMgrContext, uuidStr string,
 			!partStatus.CurrentPartition {
 			log.Infof("doBaseOsUninstall(%s) for %s, currently on other %s\n",
 				status.BaseOsVersion, uuidStr, partName)
-			log.Infof("Mark other partition %s, unused\n", partName)
-			zboot.SetOtherPartitionStateUnused()
-			publishZbootPartitionStatus(ctx, partName)
-			baseOsSetPartitionInfoInStatus(ctx, status,
-				status.PartitionLabel)
-			publishBaseOsStatus(ctx, status)
+			curPartState := getPartitionState(ctx,
+				zboot.GetCurrentPartition())
+			if curPartState == "active" {
+				log.Infof("Mark other partition %s, unused\n", partName)
+				zboot.SetOtherPartitionStateUnused()
+				publishZbootPartitionStatus(ctx, partName)
+				baseOsSetPartitionInfoInStatus(ctx, status,
+					status.PartitionLabel)
+				publishBaseOsStatus(ctx, status)
+			} else {
+				log.Warnf("Not mark other partition %s unused since curpart is %s",
+					partName, curPartState)
+			}
 		}
 		status.PartitionLabel = ""
 		changed = true

--- a/pkg/pillar/cmd/baseosmgr/handlebaseos.go
+++ b/pkg/pillar/cmd/baseosmgr/handlebaseos.go
@@ -1029,9 +1029,6 @@ func getZbootStatus(ctx *baseOsMgrContext, partName string) *types.ZbootStatus {
 func isValidBaseOsPartitionLabel(name string) bool {
 	partitionNames := []string{"IMGA", "IMGB"}
 	name = strings.TrimSpace(name)
-	if !zboot.IsAvailable() {
-		return false
-	}
 	for _, partName := range partitionNames {
 		if name == partName {
 			return true

--- a/pkg/pillar/cmd/baseosmgr/handlebaseos.go
+++ b/pkg/pillar/cmd/baseosmgr/handlebaseos.go
@@ -619,8 +619,9 @@ func doBaseOsUninstall(ctx *baseOsMgrContext, uuidStr string,
 	changed := false
 	removedAll := true
 
-	// If this image is on the !active partition we mark that
-	// as unused.
+	// In case this was a failed update we make sure we mark
+	// that !active partition as unused (in case it is inprogress),
+	// so that we can retry the same update.
 	if status.PartitionLabel != "" {
 		partName := status.PartitionLabel
 		partStatus := getZbootStatus(ctx, partName)

--- a/pkg/pillar/cmd/zedagent/handlebaseos.go
+++ b/pkg/pillar/cmd/zedagent/handlebaseos.go
@@ -8,7 +8,6 @@ package zedagent
 import (
 	"github.com/lf-edge/eve/pkg/pillar/cast"
 	"github.com/lf-edge/eve/pkg/pillar/types"
-	"github.com/lf-edge/eve/pkg/pillar/zboot"
 	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
@@ -153,9 +152,6 @@ func doBaseOsDeviceReboot(ctx *zedagentContext, status types.BaseOsStatus) {
 
 func isZbootValidPartitionLabel(name string) bool {
 	partitionNames := []string{"IMGA", "IMGB"}
-	if !zboot.IsAvailable() {
-		return false
-	}
 	for _, partName := range partitionNames {
 		if name == partName {
 			return true
@@ -188,10 +184,6 @@ func getZbootPartitionStatus(ctx *zedagentContext, partName string) *types.Zboot
 
 func getZbootCurrentPartition(ctx *zedagentContext) string {
 	var partName string
-	if !zboot.IsAvailable() {
-		log.Errorf("getZbootCurrentPartition, zboot not available\n")
-		return partName
-	}
 	items := getZbootPartitionStatusAll(ctx)
 	for _, st := range items {
 		status := cast.CastZbootStatus(st)
@@ -206,10 +198,6 @@ func getZbootCurrentPartition(ctx *zedagentContext) string {
 
 func getZbootOtherPartition(ctx *zedagentContext) string {
 	var partName string
-	if !zboot.IsAvailable() {
-		log.Errorf("getZbootOtherPartition, zboot not available\n")
-		return partName
-	}
 	items := getZbootPartitionStatusAll(ctx)
 	for _, st := range items {
 		status := cast.CastZbootStatus(st)

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -136,10 +136,6 @@ func parseBaseOsConfig(getconfigCtx *getconfigContext,
 	log.Infof("parseBaseOsConfig: Applying updated config sha % x vs. % x: %v\n",
 		baseosPrevConfigHash, configHash, cfgOsList)
 
-	baseOsCount := len(cfgOsList)
-	if baseOsCount == 0 {
-		return
-	}
 	if !zboot.IsAvailable() {
 		log.Errorf("No zboot; ignoring baseOsConfig\n")
 		return

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -136,11 +136,6 @@ func parseBaseOsConfig(getconfigCtx *getconfigContext,
 	log.Infof("parseBaseOsConfig: Applying updated config sha % x vs. % x: %v\n",
 		baseosPrevConfigHash, configHash, cfgOsList)
 
-	if !zboot.IsAvailable() {
-		log.Errorf("No zboot; ignoring baseOsConfig\n")
-		return
-	}
-
 	// First look for deleted ones
 	items := getconfigCtx.pubBaseOsConfig.GetAll()
 	for uuidStr := range items {

--- a/pkg/pillar/zboot/zboot.go
+++ b/pkg/pillar/zboot/zboot.go
@@ -42,10 +42,6 @@ func init() {
 // reset routine
 func Reset() {
 	log.Infof("Reset..\n")
-	if !IsAvailable() {
-		log.Infof("no zboot; can't do reset\n")
-		return
-	}
 	_, err := execWithRetry(true, "zboot", "reset")
 	if err != nil {
 		log.Fatalf("zboot reset: err %v\n", err)
@@ -108,9 +104,6 @@ func SetCurpart(curpart string) {
 
 // partition routines
 func GetCurrentPartition() string {
-	if !IsAvailable() {
-		return "IMGA"
-	}
 	if currentPartition != "" {
 		return currentPartition
 	}
@@ -176,13 +169,6 @@ func IsOtherPartition(partName string) bool {
 func GetPartitionState(partName string) string {
 
 	validatePartitionName(partName)
-	if !IsAvailable() {
-		if partName == "IMGA" {
-			return "active"
-		} else {
-			return "unused"
-		}
-	}
 	ret, err := execWithRetry(false, "zboot", "partstate", partName)
 	if err != nil {
 		log.Fatalf("zboot partstate %s: err %v\n", partName, err)
@@ -221,9 +207,6 @@ var partDev = make(map[string]string)
 
 func GetPartitionDevname(partName string) string {
 	validatePartitionName(partName)
-	if !IsAvailable() {
-		return ""
-	}
 	dev, ok := partDev[partName]
 	if ok {
 		return dev
@@ -287,9 +270,6 @@ func IsOtherPartitionStateUnused() bool {
 }
 
 func IsOtherPartitionStateUpdating() bool {
-	if !IsAvailable() {
-		return false
-	}
 	partName := GetOtherPartition()
 	return IsPartitionState(partName, "updating")
 }
@@ -441,9 +421,6 @@ func getVersion(part string, verFilename string, inContainer bool) string {
 		log.Infof("%s, readCurVersion %s\n", part, versionStr)
 		return versionStr
 	} else {
-		if !IsAvailable() {
-			return ""
-		}
 		devname := GetPartitionDevname(part)
 		target, err := ioutil.TempDir("/var/run", "tmpmnt")
 		if err != nil {
@@ -486,15 +463,5 @@ func getVersion(part string, verFilename string, inContainer bool) string {
 		versionStr = strings.TrimSpace(versionStr)
 		log.Infof("%s, readOtherVersion %s\n", part, versionStr)
 		return versionStr
-	}
-}
-
-// XXX temporary? Needed to run on hikey's with no zboot yet.
-func IsAvailable() bool {
-	filename := "/usr/bin/zboot"
-	if _, err := os.Stat(filename); err != nil {
-		return false
-	} else {
-		return true
 	}
 }


### PR DESCRIPTION
When the controller stops sending a base os config item, we should make sure we don't have a partition in inprogress state with that image, in order to be able to delete and then retry an update of the base os image.

@srinibas-zededa please take a look.

@archishou Please take a look at 2281673.