### PR TITLE
xencommons/qemu hang, ECONNREFUSED handling

### DIFF
--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -280,12 +280,13 @@ func Run() { //nolint:gocyclo
 	myPost := func(tlsConfig *tls.Config, retryCount int, requrl string, reqlen int64, b *bytes.Buffer) bool {
 
 		zedcloudCtx.TlsConfig = tlsConfig
-		resp, contents, cf, err := zedcloud.SendOnAllIntf(zedcloudCtx,
+		resp, contents, rtf, err := zedcloud.SendOnAllIntf(zedcloudCtx,
 			requrl, reqlen, b, retryCount, return400)
 		if err != nil {
-			log.Errorln(err)
-			if cf {
-				log.Errorln("Certificate failure")
+			if rtf {
+				log.Errorf("remoteTemporaryFailure %s", err)
+			} else {
+				log.Errorln(err)
 			}
 			return false
 		}
@@ -385,12 +386,13 @@ func Run() { //nolint:gocyclo
 	myGet := func(tlsConfig *tls.Config, requrl string, retryCount int) (bool, *http.Response, []byte) {
 
 		zedcloudCtx.TlsConfig = tlsConfig
-		resp, contents, cf, err := zedcloud.SendOnAllIntf(zedcloudCtx,
+		resp, contents, rtf, err := zedcloud.SendOnAllIntf(zedcloudCtx,
 			requrl, 0, nil, retryCount, return400)
 		if err != nil {
-			log.Errorln(err)
-			if cf {
-				log.Errorln("Certificate failure")
+			if rtf {
+				log.Errorf("remoteTemporaryFailure %s", err)
+			} else {
+				log.Errorln(err)
 			}
 			return false, nil, nil
 		}

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -798,14 +798,15 @@ func myGet(zedcloudCtx *zedcloud.ZedCloudContext, requrl string, ifname string,
 			ifname, proxyUrl.String(), requrl)
 	}
 	const allowProxy = true
-	resp, contents, cf, err := zedcloud.SendOnIntf(*zedcloudCtx,
+	resp, contents, rtf, err := zedcloud.SendOnIntf(*zedcloudCtx,
 		requrl, ifname, 0, nil, allowProxy, 15)
 	if err != nil {
-		fmt.Printf("ERROR: %s: get %s failed: %s\n",
-			ifname, requrl, err)
-		if cf {
-			fmt.Printf("ERROR: %s: get %s certificate failure\n",
-				ifname, requrl)
+		if rtf {
+			fmt.Printf("ERROR: %s: get %s remote temporary failure: %s\n",
+				ifname, requrl, err)
+		} else {
+			fmt.Printf("ERROR: %s: get %s failed: %s\n",
+				ifname, requrl, err)
 		}
 		return false, nil, nil
 	}

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -219,16 +219,24 @@ func getLatestConfig(url string, iteration int, updateInprogress bool,
 	}
 
 	const return400 = false
-	resp, contents, cf, err := zedcloud.SendOnAllIntf(zedcloudCtx, url, 0, nil, iteration, return400)
+	resp, contents, rtf, err := zedcloud.SendOnAllIntf(zedcloudCtx, url, 0, nil, iteration, return400)
 	if err != nil {
-		log.Errorf("getLatestConfig failed: %s\n", err)
-		if cf {
-			log.Errorf("getLatestConfig certificate failure")
+		newCount := 2
+		if rtf {
+			log.Errorf("getLatestConfig remoteTemporaryFailure: %s", err)
+			newCount = 3 // Almost connected to controller!
+			// Don't treat as upgrade failure
+			if updateInprogress {
+				log.Warnf("remoteTemporaryFailure don't fail update")
+				getconfigCtx.startTime = time.Now()
+			}
+		} else {
+			log.Errorf("getLatestConfig failed: %s", err)
 		}
 		if getconfigCtx.ledManagerCount == 4 {
 			// Inform ledmanager about loss of config from cloud
-			types.UpdateLedManagerConfig(2)
-			getconfigCtx.ledManagerCount = 2
+			types.UpdateLedManagerConfig(newCount)
+			getconfigCtx.ledManagerCount = newCount
 		}
 		// If we didn't yet get a config, then look for a file
 		// XXX should we try a few times?

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -1497,13 +1497,15 @@ func SendMetricsProtobuf(ReportMetrics *metrics.ZMetricMsg,
 	size := int64(proto.Size(ReportMetrics))
 	metricsUrl := serverNameAndPort + "/" + metricsApi
 	const return400 = false
-	_, _, cf, err := zedcloud.SendOnAllIntf(zedcloudCtx, metricsUrl,
+	_, _, rtf, err := zedcloud.SendOnAllIntf(zedcloudCtx, metricsUrl,
 		size, buf, iteration, return400)
 	if err != nil {
 		// Hopefully next timeout will be more successful
-		log.Errorf("SendMetricsProtobuf failed: %s\n", err)
-		if cf {
-			log.Errorf("SendMetricsProtobuf certificate failure")
+		if rtf {
+			log.Errorf("SendMetricsProtobuf remoteTemporaryFailure: %s",
+				err)
+		} else {
+			log.Errorf("SendMetricsProtobuf failed: %s", err)
 		}
 		return
 	} else {

--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -810,12 +810,15 @@ func sendFlowProtobuf(protoflows *flowlog.FlowMessage) {
 		size := int64(proto.Size(&pflows))
 		flowlogURL := serverNameAndPort + "/" + flowlogAPI
 		const return400 = false
-		_, _, cf, err := zedcloud.SendOnAllIntf(zedcloudCtx, flowlogURL,
+		_, _, rtf, err := zedcloud.SendOnAllIntf(zedcloudCtx, flowlogURL,
 			size, buf, flowIteration, return400)
 		if err != nil {
-			log.Errorf("FlowStats: sendFlowProtobuf failed: %s\n", err)
-			if cf {
-				log.Errorf("FlowStats: sendFlowProtobuf certificate failure")
+			if rtf {
+				log.Errorf("FlowStats: sendFlowProtobuf  remoteTemporaryFailure: %s",
+					err)
+			} else {
+				log.Errorf("FlowStats: sendFlowProtobuf failed: %s",
+					err)
 			}
 			flowIteration--
 			if flowQ.Len() > 100 { // if fail to send for too long, start to drop

--- a/pkg/pillar/devicenetwork/devicenetwork.go
+++ b/pkg/pillar/devicenetwork/devicenetwork.go
@@ -133,23 +133,25 @@ func VerifyDeviceNetworkStatus(status types.DeviceNetworkStatus,
 			return false, errors.New(errStr)
 		}
 	}
-	cloudReachable, cf, err := zedcloud.VerifyAllIntf(zedcloudCtx, testUrl, retryCount, 1)
+	cloudReachable, rtf, err := zedcloud.VerifyAllIntf(zedcloudCtx, testUrl, retryCount, 1)
 	if err != nil {
-		log.Errorf("VerifyDeviceNetworkStatus: VerifyAllIntf failed %s\n",
-			err)
-		if cf {
-			log.Errorf("VerifyDeviceNetworkStatus: VerifyAllIntf certificate failure")
+		if rtf {
+			log.Errorf("VerifyDeviceNetworkStatus: VerifyAllIntf remoteTemporaryFailure %s",
+				err)
+		} else {
+			log.Errorf("VerifyDeviceNetworkStatus: VerifyAllIntf failed %s",
+				err)
 		}
-		return cf, err
+		return rtf, err
 	}
 
 	if cloudReachable {
 		log.Infof("Uplink test SUCCESS to URL: %s", testUrl)
-		return cf, nil
+		return false, nil
 	}
 	errStr := fmt.Sprintf("Uplink test FAIL to URL: %s", testUrl)
 	log.Errorf("VerifyDeviceNetworkStatus: %s\n", errStr)
-	return cf, errors.New(errStr)
+	return rtf, errors.New(errStr)
 }
 
 // Calculate local IP addresses to make a types.DeviceNetworkStatus

--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -320,7 +320,7 @@ func VerifyPending(pending *DPCPending,
 	pending.TestCount = MaxDPCRetestCount
 
 	// We want connectivity to zedcloud via atleast one Management port.
-	cf, err := VerifyDeviceNetworkStatus(pending.PendDNS, 1)
+	rtf, err := VerifyDeviceNetworkStatus(pending.PendDNS, 1)
 	status := DPC_FAIL
 	if err == nil {
 		pending.PendDPC.LastSucceeded = time.Now()
@@ -331,12 +331,13 @@ func VerifyPending(pending *DPCPending,
 	} else {
 		errStr := fmt.Sprintf("Failed network test: %s",
 			err)
-		log.Errorf("VerifyPending: %s\n", errStr)
-		if cf {
-			log.Errorf("VerifyPending: certificate failure")
-			// NOTE: do not increase TestCount; we retry until
-			// the certificate is fixed on the server side.
+		if rtf {
+			log.Errorf("VerifyPending: remoteTemporaryFailure %s", errStr)
+			// NOTE: do not increase TestCount; we retry until e.g., the
+			// certificate or ECONNREFUSED is fixed on the server side.
 			status = DPC_WAIT
+		} else {
+			log.Errorf("VerifyPending: %s\n", errStr)
 		}
 		pending.PendDPC.LastFailed = time.Now()
 		pending.PendDPC.LastError = errStr

--- a/pkg/pillar/rootfs/init.sh
+++ b/pkg/pillar/rootfs/init.sh
@@ -6,20 +6,19 @@
 echo 'nameserver 8.8.8.8' > /etc/resolv.conf
 
 # Need to disable H/W TCP offload since it seems to mess us up
-for i in `cd /sys/class/net ; echo eth*` ; do
-  ethtool -K $i gro off
-  ethtool -K $i sg off
+for i in $(cd /sys/class/net || return ; echo eth*) ; do
+  ethtool -K "$i" gro off
+  ethtool -K "$i" sg off
 done
 
 # Need this for logrotate
 /usr/sbin/crond -d 8
 
 # Finally, we need to start Xen
-XENCONSOLED_ARGS='--log=all --log-dir=/var/log/xen' /etc/init.d/xencommons start
+# In case it hangs and we have no hardware watchdog we run it in the background
+XENCONSOLED_ARGS='--log=all --log-dir=/var/log/xen' /etc/init.d/xencommons start &
+sleep 5 # Let it come up
 
-# This is an optional component - only run it if it is there
-if [ -f /opt/zededa/bin/device-steps.sh ]; then
-    /opt/zededa/bin/device-steps.sh >/var/log/device-steps.log 2>&1
-fi
+echo 'Starting device-steps'
+/opt/zededa/bin/device-steps.sh >/var/log/device-steps.log 2>&1
 
-tail -f /dev/null /var/log/*.log


### PR DESCRIPTION
On devices without hardware watchdog we've seen cases when device-steps.sh doesn't even start. Make sure it starts to it can at least run a software watchdog.

Don't fail a baseimage update if we get ECONNREFUSED or certificate errors.