### PR TITLE
Optionally set proxy when building

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ $ sudo apt install qemu
 
 #### Get Project EVE
 
-EVE requires being built in Git repository (the tools keep looking up git commit IDs). The easiest way is to clone EVE repository from GitHub:
+EVE requires being built in a Git repository (the tools keep looking up git commit IDs). The easiest way is to clone EVE repository from GitHub:
 
 ```sh
 git clone https://github.com/lf-edge/eve.git
@@ -70,7 +70,7 @@ make build-tools
 make live
 ```
 
-This will download the relevant dockers from docker hub and create a bootable
+This will download the relevant docker images from docker hub and create a bootable
 image `dist/<ARCH>/live.img`.
 
 Please note that not all containers will be fetched from Docker Hub.
@@ -80,6 +80,23 @@ Please note that not all containers will be fetched from Docker Hub.
 > over the network it may occasionally time out and fail. Typically
 > re-running `make` fixes the issue. If it doesn't you can attempt a local
 > build of all the required EVE packages first by running `make pkgs`
+
+#### Proxies
+
+Building of the various images may require downloading packages from the Internet. If you have direct Internet access, everything will "just work".
+On the other hand, if you need to run behind a proxy, you may run into issues downloading. These manifest in two key areas:
+
+* docker: docker needs to download images from the image registries. Configuring your local installation of docker is beyond the scope of this
+document, please see [here](https://docs.docker.com/network/proxy/).
+* packages: the package updates _inside_ the images running in docker may need to use http/s proxies.
+
+To configure your build process to use proxies, you can set the following environment variables. They will be picked up automatically when running
+any `make` commands and used within the building containers. If they are _not_ set, no proxy is set:
+
+* `HTTP_PROXY`
+* `HTTPS_PROXY`
+* `ALL_PROXY`
+* `NO_PROXY`
 
 #### Running in QEMU
 

--- a/build-tools/src/scripts/Dockerfile
+++ b/build-tools/src/scripts/Dockerfile
@@ -4,6 +4,10 @@ ARG USER
 ARG GROUP
 ARG UID
 ARG GID
+# all_proxy is the standard proxy definer for socks proxies. Docker build only has built-ins for http_proxy,https_proxy,ftp_proxy,no_proxy
+# so we need to declare it explicitly
+# this must be an ARG so it doesn't carry through post-build phase
+ARG all_proxy
 RUN apk add --no-cache openssh-client git gcc linux-headers libc-dev util-linux libpcap-dev bash vim make protobuf protobuf-dev sudo
 RUN deluser ${USER} ; delgroup ${GROUP} || :
 RUN sed -ie /:${UID}:/d /etc/passwd /etc/shadow ; sed -ie /:${GID}:/d /etc/group || :


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

This saves the need for individual builders behind proxies to modify their `Dockerfile` to do builds; just set an environment var when running `make`

Please review @rvs; cc @jren1

**Note:** This _only_ sets it for creating the `eve-build-<USER>` image. It doesn't do the package ones yet. That requires more work, but I want this one in first, have real users (like @jren1) sign off, then we can expand to others with one more PR.