### PR TITLE
Increase http/send timeout to handle slower networks

### DIFF
--- a/pkg/pillar/agentlog/agentlog.go
+++ b/pkg/pillar/agentlog/agentlog.go
@@ -312,11 +312,42 @@ func GetOtherLogdir() string {
 	return fmt.Sprintf("%s/log", dirname)
 }
 
+// Debug info to tell how often/late we call stillRunning; keyed by agentName
+var lastStillMap map[string]time.Time = make(map[string]time.Time)
+
+const (
+	errorTime      = 3 * time.Minute
+	warningTime    = 30 * time.Second
+	errorTimeNim   = 40 * time.Second
+	warningTimeNim = 20 * time.Second
+)
+
 // Touch a file per agentName to signal the event loop is still running
 // Could be use by watchdog
 func StillRunning(agentName string) {
 
 	log.Debugf("StillRunning(%s)\n", agentName)
+
+	errTime := errorTime
+	warnTime := warningTime
+	if agentName == "nim" {
+		errTime = errorTimeNim
+		warnTime = warningTimeNim
+	}
+	if ls, found := lastStillMap[agentName]; !found {
+		lastStillMap[agentName] = time.Now()
+	} else {
+		elapsed := time.Since(ls)
+		if elapsed > errTime {
+			log.Errorf("StillRunning(%s) XXX took a long time: %d",
+				agentName, elapsed/time.Second)
+		} else if elapsed > warnTime {
+			log.Warnf("StillRunning(%s) took a long time: %d",
+				agentName, elapsed/time.Second)
+		}
+		lastStillMap[agentName] = time.Now()
+	}
+
 	filename := fmt.Sprintf("/var/run/%s.touch", agentName)
 	_, err := os.Stat(filename)
 	if err != nil {
@@ -337,5 +368,31 @@ func StillRunning(agentName string) {
 	if err != nil {
 		log.Errorf("StillRunning: %s\n", err)
 		return
+	}
+}
+
+// StartTime returns a start time which is later passed to CheckMaxTime*
+func StartTime() time.Time {
+	return time.Now()
+}
+
+// CheckMaxTime verifies if the time for a call has exeeded a reasonable
+// number.
+func CheckMaxTime(agentName string, start time.Time) {
+	errTime := errorTime
+	warnTime := warningTime
+	if agentName == "nim" {
+		errTime = errorTimeNim
+		warnTime = warningTimeNim
+	}
+	elapsed := time.Since(start)
+	if elapsed > errTime {
+		_, fn, line, _ := runtime.Caller(1)
+		log.Errorf("handler at %s:%d in %s XXX took a long time: %d",
+			fn, line, agentName, elapsed/time.Second)
+	} else if elapsed > warnTime {
+		_, fn, line, _ := runtime.Caller(1)
+		log.Warnf("handler at %s:%d in %s took a long time: %d",
+			fn, line, agentName, elapsed/time.Second)
 	}
 }

--- a/pkg/pillar/agentlog/agentlog.go
+++ b/pkg/pillar/agentlog/agentlog.go
@@ -313,7 +313,7 @@ func GetOtherLogdir() string {
 }
 
 // Debug info to tell how often/late we call stillRunning; keyed by agentName
-var lastStillMap map[string]time.Time = make(map[string]time.Time)
+var lastStillMap = make(map[string]time.Time)
 
 const (
 	errorTime      = 3 * time.Minute

--- a/pkg/pillar/agentlog/agentlog.go
+++ b/pkg/pillar/agentlog/agentlog.go
@@ -317,9 +317,9 @@ var lastStillMap map[string]time.Time = make(map[string]time.Time)
 
 const (
 	errorTime      = 3 * time.Minute
-	warningTime    = 30 * time.Second
-	errorTimeNim   = 40 * time.Second
-	warningTimeNim = 20 * time.Second
+	warningTime    = 40 * time.Second
+	errorTimeNim   = 60 * time.Second
+	warningTimeNim = 40 * time.Second
 )
 
 // Touch a file per agentName to signal the event loop is still running

--- a/pkg/pillar/cmd/baseosmgr/baseosmgr.go
+++ b/pkg/pillar/cmd/baseosmgr/baseosmgr.go
@@ -134,13 +134,17 @@ func Run() {
 	for !ctx.verifierRestarted {
 		select {
 		case change := <-ctx.subGlobalConfig.C:
+			start := agentlog.StartTime()
 			ctx.subGlobalConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-ctx.subBaseOsVerifierStatus.C:
+			start := agentlog.StartTime()
 			ctx.subBaseOsVerifierStatus.ProcessChange(change)
 			if ctx.verifierRestarted {
 				log.Infof("Verifier reported restarted\n")
 			}
+			agentlog.CheckMaxTime(agentName, start)
 		}
 	}
 
@@ -148,25 +152,39 @@ func Run() {
 	for {
 		select {
 		case change := <-ctx.subGlobalConfig.C:
+			start := agentlog.StartTime()
 			ctx.subGlobalConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-ctx.subCertObjConfig.C:
+			start := agentlog.StartTime()
 			ctx.subCertObjConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-ctx.subBaseOsConfig.C:
+			start := agentlog.StartTime()
 			ctx.subBaseOsConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-ctx.subZbootConfig.C:
+			start := agentlog.StartTime()
 			ctx.subZbootConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-ctx.subBaseOsDownloadStatus.C:
+			start := agentlog.StartTime()
 			ctx.subBaseOsDownloadStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-ctx.subBaseOsVerifierStatus.C:
+			start := agentlog.StartTime()
 			ctx.subBaseOsVerifierStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-ctx.subCertObjDownloadStatus.C:
+			start := agentlog.StartTime()
 			ctx.subCertObjDownloadStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case <-stillRunning.C:
 			agentlog.StillRunning(agentName)

--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -67,6 +67,7 @@ type clientContext struct {
 	deviceNetworkStatus    *types.DeviceNetworkStatus
 	usableAddressCount     int
 	subGlobalConfig        *pubsub.Subscription
+	globalConfig           *types.GlobalConfig
 }
 
 var debug = false
@@ -159,6 +160,7 @@ func Run() { //nolint:gocyclo
 
 	clientCtx := clientContext{
 		deviceNetworkStatus: &types.DeviceNetworkStatus{},
+		globalConfig:        &types.GlobalConfigDefaults,
 	}
 
 	// Look for global config such as log levels
@@ -228,6 +230,7 @@ func Run() { //nolint:gocyclo
 		DeviceNetworkStatus: clientCtx.deviceNetworkStatus,
 		FailureFunc:         zedcloud.ZedCloudFailure,
 		SuccessFunc:         zedcloud.ZedCloudSuccess,
+		NetworkSendTimeout:  clientCtx.globalConfig.NetworkSendTimeout,
 	}
 
 	// Get device serail number
@@ -603,8 +606,12 @@ func handleGlobalConfigModify(ctxArg interface{}, key string,
 		return
 	}
 	log.Infof("handleGlobalConfigModify for %s\n", key)
-	debug, _ = agentlog.HandleGlobalConfig(ctx.subGlobalConfig, agentName,
+	var gcp *types.GlobalConfig
+	debug, gcp = agentlog.HandleGlobalConfig(ctx.subGlobalConfig, agentName,
 		debugOverride)
+	if gcp != nil {
+		ctx.globalConfig = gcp
+	}
 	log.Infof("handleGlobalConfigModify done for %s\n", key)
 }
 
@@ -619,6 +626,7 @@ func handleGlobalConfigDelete(ctxArg interface{}, key string,
 	log.Infof("handleGlobalConfigDelete for %s\n", key)
 	debug, _ = agentlog.HandleGlobalConfig(ctx.subGlobalConfig, agentName,
 		debugOverride)
+	*ctx.globalConfig = types.GlobalConfigDefaults
 	log.Infof("handleGlobalConfigDelete done for %s\n", key)
 }
 

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -52,6 +52,7 @@ type diagContext struct {
 	ledCounter              int
 	derivedLedCounter       int // Based on ledCounter + usableAddressCount
 	subGlobalConfig         *pubsub.Subscription
+	globalConfig            *types.GlobalConfig
 	subLedBlinkCounter      *pubsub.Subscription
 	subDeviceNetworkStatus  *pubsub.Subscription
 	subDevicePortConfigList *pubsub.Subscription
@@ -110,13 +111,26 @@ func Run() {
 	}
 
 	ctx := diagContext{
-		forever:     *foreverPtr,
-		pacContents: *pacContentsPtr,
+		forever:      *foreverPtr,
+		pacContents:  *pacContentsPtr,
+		globalConfig: &types.GlobalConfigDefaults,
 	}
 	ctx.DeviceNetworkStatus = &types.DeviceNetworkStatus{}
 	ctx.DevicePortConfigList = &types.DevicePortConfigList{}
 
-	// XXX should we subscribe to and get GlobalConfig for debug??
+	// Make sure we have a GlobalConfig file with defaults
+	types.EnsureGCFile()
+
+	// Look for global config such as log levels
+	subGlobalConfig, err := pubsub.Subscribe("", types.GlobalConfig{},
+		false, &ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	subGlobalConfig.ModifyHandler = handleGlobalConfigModify
+	subGlobalConfig.DeleteHandler = handleGlobalConfigDelete
+	ctx.subGlobalConfig = subGlobalConfig
+	subGlobalConfig.Activate()
 
 	server, err := ioutil.ReadFile(serverFileName)
 	if err != nil {
@@ -129,6 +143,7 @@ func Run() {
 		DeviceNetworkStatus: ctx.DeviceNetworkStatus,
 		FailureFunc:         zedcloud.ZedCloudFailure,
 		SuccessFunc:         zedcloud.ZedCloudSuccess,
+		NetworkSendTimeout:  ctx.globalConfig.NetworkTestTimeout,
 	}
 
 	// Get device serail number
@@ -200,17 +215,28 @@ func Run() {
 
 	for {
 		select {
+		case change := <-subGlobalConfig.C:
+			start := agentlog.StartTime()
+			subGlobalConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
+
 		case change := <-subLedBlinkCounter.C:
+			start := agentlog.StartTime()
 			ctx.gotBC = true
 			subLedBlinkCounter.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subDeviceNetworkStatus.C:
+			start := agentlog.StartTime()
 			ctx.gotDNS = true
 			subDeviceNetworkStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subDevicePortConfigList.C:
+			start := agentlog.StartTime()
 			ctx.gotDPCList = true
 			subDevicePortConfigList.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 		}
 		if !ctx.forever && ctx.gotDNS && ctx.gotBC && ctx.gotDPCList {
 			break
@@ -799,7 +825,7 @@ func myGet(zedcloudCtx *zedcloud.ZedCloudContext, requrl string, ifname string,
 	}
 	const allowProxy = true
 	resp, contents, rtf, err := zedcloud.SendOnIntf(*zedcloudCtx,
-		requrl, ifname, 0, nil, allowProxy, 15)
+		requrl, ifname, 0, nil, allowProxy)
 	if err != nil {
 		if rtf {
 			fmt.Printf("ERROR: %s: get %s remote temporary failure: %s\n",
@@ -823,4 +849,37 @@ func myGet(zedcloudCtx *zedcloud.ZedCloudContext, requrl string, ifname string,
 			ifname, string(contents))
 		return false, nil, nil
 	}
+}
+
+func handleGlobalConfigModify(ctxArg interface{}, key string,
+	statusArg interface{}) {
+
+	ctx := ctxArg.(*diagContext)
+	if key != "global" {
+		log.Infof("handleGlobalConfigModify: ignoring %s\n", key)
+		return
+	}
+	log.Infof("handleGlobalConfigModify for %s\n", key)
+	var gcp *types.GlobalConfig
+	debug, gcp = agentlog.HandleGlobalConfig(ctx.subGlobalConfig, agentName,
+		debugOverride)
+	if gcp != nil {
+		ctx.globalConfig = gcp
+	}
+	log.Infof("handleGlobalConfigModify done for %s\n", key)
+}
+
+func handleGlobalConfigDelete(ctxArg interface{}, key string,
+	statusArg interface{}) {
+
+	ctx := ctxArg.(*diagContext)
+	if key != "global" {
+		log.Infof("handleGlobalConfigDelete: ignoring %s\n", key)
+		return
+	}
+	log.Infof("handleGlobalConfigDelete for %s\n", key)
+	debug, _ = agentlog.HandleGlobalConfig(ctx.subGlobalConfig, agentName,
+		debugOverride)
+	*ctx.globalConfig = types.GlobalConfigDefaults
+	log.Infof("handleGlobalConfigDelete done for %s\n", key)
 }

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -230,10 +230,14 @@ func Run() {
 		log.Infof("Waiting for DeviceNetworkStatus init\n")
 		select {
 		case change := <-subGlobalConfig.C:
+			start := agentlog.StartTime()
 			subGlobalConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subDeviceNetworkStatus.C:
+			start := agentlog.StartTime()
 			subDeviceNetworkStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 		}
 	}
 
@@ -254,13 +258,19 @@ func Run() {
 		log.Infof("Waiting for AssignableAdapters")
 		select {
 		case change := <-subGlobalConfig.C:
+			start := agentlog.StartTime()
 			subGlobalConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subDeviceNetworkStatus.C:
+			start := agentlog.StartTime()
 			subDeviceNetworkStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subPhysicalIOAdapter.C:
+			start := agentlog.StartTime()
 			subPhysicalIOAdapter.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 		}
 	}
 	log.Infof("Have %d assignable adapters", len(aa.IoBundleList))
@@ -285,19 +295,29 @@ func Run() {
 	for {
 		select {
 		case change := <-subGlobalConfig.C:
+			start := agentlog.StartTime()
 			subGlobalConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subDomainConfig.C:
+			start := agentlog.StartTime()
 			subDomainConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subDeviceNetworkStatus.C:
+			start := agentlog.StartTime()
 			subDeviceNetworkStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subPhysicalIOAdapter.C:
+			start := agentlog.StartTime()
 			subPhysicalIOAdapter.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case <-gc.C:
+			start := agentlog.StartTime()
 			gcObjects(&domainCtx, rwImgDirname)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case <-stillRunning.C:
 			agentlog.StillRunning(agentName)

--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -249,13 +249,19 @@ func Run() {
 
 		select {
 		case change := <-subGlobalConfig.C:
+			start := agentlog.StartTime()
 			subGlobalConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subDeviceNetworkStatus.C:
+			start := agentlog.StartTime()
 			subDeviceNetworkStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subGlobalDownloadConfig.C:
+			start := agentlog.StartTime()
 			subGlobalDownloadConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		// This wait can take an unbounded time since we wait for IP
 		// addresses. Punch StillRunning
@@ -275,34 +281,52 @@ func Run() {
 	for {
 		select {
 		case change := <-subGlobalConfig.C:
+			start := agentlog.StartTime()
 			subGlobalConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subDeviceNetworkStatus.C:
+			start := agentlog.StartTime()
 			subDeviceNetworkStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subCertObjConfig.C:
+			start := agentlog.StartTime()
 			subCertObjConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subAppImgConfig.C:
+			start := agentlog.StartTime()
 			subAppImgConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subBaseOsConfig.C:
+			start := agentlog.StartTime()
 			subBaseOsConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subDatastoreConfig.C:
+			start := agentlog.StartTime()
 			subDatastoreConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subGlobalDownloadConfig.C:
+			start := agentlog.StartTime()
 			subGlobalDownloadConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case <-publishTimer.C:
+			start := agentlog.StartTime()
 			err := pub.Publish("global", zedcloud.GetCloudMetrics())
 			if err != nil {
 				log.Errorln(err)
 			}
+			agentlog.CheckMaxTime(agentName, start)
 
 		case <-gc.C:
+			start := agentlog.StartTime()
 			gcObjects(&ctx)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case <-stillRunning.C:
 			agentlog.StillRunning(agentName)

--- a/pkg/pillar/cmd/identitymgr/identitymgr.go
+++ b/pkg/pillar/cmd/identitymgr/identitymgr.go
@@ -118,10 +118,14 @@ func Run() {
 	for {
 		select {
 		case change := <-subGlobalConfig.C:
+			start := agentlog.StartTime()
 			subGlobalConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subEIDConfig.C:
+			start := agentlog.StartTime()
 			subEIDConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case <-stillRunning.C:
 			agentlog.StillRunning(agentName)

--- a/pkg/pillar/cmd/ledmanager/ledmanager.go
+++ b/pkg/pillar/cmd/ledmanager/ledmanager.go
@@ -205,13 +205,19 @@ func Run() {
 	for {
 		select {
 		case change := <-subGlobalConfig.C:
+			start := agentlog.StartTime()
 			subGlobalConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subDeviceNetworkStatus.C:
+			start := agentlog.StartTime()
 			subDeviceNetworkStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subLedBlinkCounter.C:
+			start := agentlog.StartTime()
 			subLedBlinkCounter.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case <-stillRunning.C:
 			// Fault injection

--- a/pkg/pillar/cmd/logmanager/logmanager.go
+++ b/pkg/pillar/cmd/logmanager/logmanager.go
@@ -227,10 +227,14 @@ func Run() {
 	for DNSctx.usableAddressCount == 0 && !force {
 		select {
 		case change := <-subGlobalConfig.C:
+			start := agentlog.StartTime()
 			subGlobalConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subDeviceNetworkStatus.C:
+			start := agentlog.StartTime()
 			subDeviceNetworkStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		// This wait can take an unbounded time since we wait for IP
 		// addresses. Punch StillRunning
@@ -322,27 +326,38 @@ func Run() {
 	for {
 		select {
 		case change := <-subGlobalConfig.C:
+			start := agentlog.StartTime()
 			subGlobalConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subDomainStatus.C:
+			start := agentlog.StartTime()
 			subDomainStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subDeviceNetworkStatus.C:
+			start := agentlog.StartTime()
 			subDeviceNetworkStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case <-publishTimer.C:
+			start := agentlog.StartTime()
 			log.Debugln("publishTimer at", time.Now())
 			err := pub.Publish("global", zedcloud.GetCloudMetrics())
 			if err != nil {
 				log.Errorln(err)
 			}
+			agentlog.CheckMaxTime(agentName, start)
+
 		case change := <-deferredChan:
+			start := agentlog.StartTime()
 			done := zedcloud.HandleDeferred(change, 1*time.Second)
 			dbg.FreeOSMemory()
 			globalDeferInprogress = !done
 			if globalDeferInprogress {
 				log.Warnf("logmanager: globalDeferInprogress")
 			}
+			agentlog.CheckMaxTime(agentName, start)
 
 		case <-stillRunning.C:
 			// Fault injection

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -279,10 +279,14 @@ func Run() {
 			nimCtx.GCInitialized, nimCtx.DNCInitialized)
 		select {
 		case change := <-subGlobalConfig.C:
+			start := agentlog.StartTime()
 			subGlobalConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subDeviceNetworkConfig.C:
+			start := agentlog.StartTime()
 			subDeviceNetworkConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 		}
 	}
 
@@ -347,25 +351,38 @@ func Run() {
 		log.Infof("Waiting for AA to initialize")
 		select {
 		case change := <-subGlobalConfig.C:
+			start := agentlog.StartTime()
 			subGlobalConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subDeviceNetworkConfig.C:
+			start := agentlog.StartTime()
 			subDeviceNetworkConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subDevicePortConfigO.C:
+			start := agentlog.StartTime()
 			subDevicePortConfigO.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subDevicePortConfigS.C:
+			start := agentlog.StartTime()
 			subDevicePortConfigS.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subAssignableAdapters.C:
+			start := agentlog.StartTime()
 			subAssignableAdapters.ProcessChange(change)
 			updateFilteredFallback(&nimCtx)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subNetworkInstanceStatus.C:
+			start := agentlog.StartTime()
 			subNetworkInstanceStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change, ok := <-addrChanges:
+			start := agentlog.StartTime()
 			if !ok {
 				log.Errorf("addrChanges closed\n")
 				// XXX Need to discard all cached information?
@@ -375,8 +392,10 @@ func Run() {
 					devicenetwork.HandleAddressChange(&nimCtx.DeviceNetworkContext)
 				}
 			}
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change, ok := <-linkChanges:
+			start := agentlog.StartTime()
 			if !ok {
 				log.Errorf("linkChanges closed\n")
 				linkChanges = devicenetwork.LinkChangeInit()
@@ -385,24 +404,30 @@ func Run() {
 				handleLinkChange(&nimCtx)
 				// XXX trigger testing??
 			}
+			agentlog.CheckMaxTime(agentName, start)
 
 		case <-geoTimer.C:
+			start := agentlog.StartTime()
 			log.Debugln("geoTimer at", time.Now())
 			change := devicenetwork.UpdateDeviceNetworkGeo(
 				geoRedoTime, nimCtx.DeviceNetworkStatus)
 			if change {
 				publishDeviceNetworkStatus(&nimCtx)
 			}
+			agentlog.CheckMaxTime(agentName, start)
 
 		case _, ok := <-dnc.Pending.PendTimer.C:
+			start := agentlog.StartTime()
 			if !ok {
 				log.Infof("Device port test timer stopped?")
 			} else {
 				log.Debugln("PendTimer at", time.Now())
 				devicenetwork.VerifyDevicePortConfig(dnc)
 			}
+			agentlog.CheckMaxTime(agentName, start)
 
 		case _, ok := <-dnc.NetworkTestTimer.C:
+			start := agentlog.StartTime()
 			if !ok {
 				log.Infof("Network test timer stopped?")
 			} else if nimCtx.DevicePortConfigList.CurrentIndex == -1 {
@@ -424,8 +449,10 @@ func Run() {
 						time.Since(start))
 				}
 			}
+			agentlog.CheckMaxTime(agentName, start)
 
 		case _, ok := <-dnc.NetworkTestBetterTimer.C:
+			start := agentlog.StartTime()
 			if !ok {
 				log.Infof("Network testBetterTimer stopped?")
 			} else if dnc.NextDPCIndex == 0 {
@@ -439,6 +466,7 @@ func Run() {
 				log.Infof("Network testBetterTimer done at index %d. Took %v",
 					dnc.NextDPCIndex, time.Since(start))
 			}
+			agentlog.CheckMaxTime(agentName, start)
 
 		case <-stillRunning.C:
 			agentlog.StillRunning(agentName)
@@ -449,28 +477,43 @@ func Run() {
 	for {
 		select {
 		case change := <-subGlobalConfig.C:
+			start := agentlog.StartTime()
 			subGlobalConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subDeviceNetworkConfig.C:
+			start := agentlog.StartTime()
 			subDeviceNetworkConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subDevicePortConfigA.C:
+			start := agentlog.StartTime()
 			subDevicePortConfigA.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subDevicePortConfigO.C:
+			start := agentlog.StartTime()
 			subDevicePortConfigO.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subDevicePortConfigS.C:
+			start := agentlog.StartTime()
 			subDevicePortConfigS.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subAssignableAdapters.C:
+			start := agentlog.StartTime()
 			subAssignableAdapters.ProcessChange(change)
 			updateFilteredFallback(&nimCtx)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subNetworkInstanceStatus.C:
+			start := agentlog.StartTime()
 			subNetworkInstanceStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change, ok := <-addrChanges:
+			start := agentlog.StartTime()
 			if !ok {
 				log.Errorf("addrChanges closed\n")
 				addrChanges = devicenetwork.AddrChangeInit()
@@ -480,8 +523,10 @@ func Run() {
 					devicenetwork.HandleAddressChange(&nimCtx.DeviceNetworkContext)
 				}
 			}
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change, ok := <-linkChanges:
+			start := agentlog.StartTime()
 			if !ok {
 				log.Errorf("linkChanges closed\n")
 				linkChanges = devicenetwork.LinkChangeInit()
@@ -490,24 +535,30 @@ func Run() {
 				handleLinkChange(&nimCtx)
 				// XXX trigger testing??
 			}
+			agentlog.CheckMaxTime(agentName, start)
 
 		case <-geoTimer.C:
+			start := agentlog.StartTime()
 			log.Debugln("geoTimer at", time.Now())
 			change := devicenetwork.UpdateDeviceNetworkGeo(
 				geoRedoTime, nimCtx.DeviceNetworkStatus)
 			if change {
 				publishDeviceNetworkStatus(&nimCtx)
 			}
+			agentlog.CheckMaxTime(agentName, start)
 
 		case _, ok := <-dnc.Pending.PendTimer.C:
+			start := agentlog.StartTime()
 			if !ok {
 				log.Infof("Device port test timer stopped?")
 			} else {
 				log.Debugln("PendTimer at", time.Now())
 				devicenetwork.VerifyDevicePortConfig(dnc)
 			}
+			agentlog.CheckMaxTime(agentName, start)
 
 		case _, ok := <-dnc.NetworkTestTimer.C:
+			start := agentlog.StartTime()
 			if !ok {
 				log.Infof("Network test timer stopped?")
 			} else {
@@ -522,8 +573,10 @@ func Run() {
 						time.Since(start))
 				}
 			}
+			agentlog.CheckMaxTime(agentName, start)
 
 		case _, ok := <-dnc.NetworkTestBetterTimer.C:
+			start := agentlog.StartTime()
 			if !ok {
 				log.Infof("Network testBetterTimer stopped?")
 			} else if dnc.NextDPCIndex == 0 {
@@ -537,6 +590,7 @@ func Run() {
 				log.Infof("Network testBetterTimer done at index %d. Took %v",
 					dnc.NextDPCIndex, time.Since(start))
 			}
+			agentlog.CheckMaxTime(agentName, start)
 
 		case <-stillRunning.C:
 			agentlog.StillRunning(agentName)

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -302,7 +302,7 @@ func Run() {
 		time.Duration(geoMax))
 
 	dnc := &nimCtx.DeviceNetworkContext
-	// TIme we wait for DHCP to get an address before giving up
+	// Time we wait for DHCP to get an address before giving up
 	dnc.DPCTestDuration = nimCtx.globalConfig.NetworkTestDuration
 
 	// Timer for checking/verifying pending device network status
@@ -317,9 +317,7 @@ func Run() {
 
 	// Periodic timer that tests device cloud connectivity
 	dnc.NetworkTestInterval = nimCtx.globalConfig.NetworkTestInterval
-	networkTestInterval := time.Duration(time.Duration(dnc.NetworkTestInterval) * time.Second)
-	networkTestTimer := time.NewTimer(networkTestInterval)
-	dnc.NetworkTestTimer = networkTestTimer
+	dnc.NetworkTestTimer = time.NewTimer(time.Duration(dnc.NetworkTestInterval) * time.Second)
 	// We start assuming cloud connectivity works
 	dnc.CloudConnectivityWorks = true
 
@@ -631,7 +629,7 @@ func updateFilteredFallback(ctx *nimContext) {
 }
 
 func tryDeviceConnectivityToCloud(ctx *devicenetwork.DeviceNetworkContext) bool {
-	rtf, err := devicenetwork.VerifyDeviceNetworkStatus(*ctx.DeviceNetworkStatus, 1)
+	rtf, err := devicenetwork.VerifyDeviceNetworkStatus(*ctx.DeviceNetworkStatus, 1, ctx.TestSendTimeout)
 	if err == nil {
 		log.Infof("tryDeviceConnectivityToCloud: Device cloud connectivity test passed.")
 		if ctx.NextDPCIndex < len(ctx.DevicePortConfigList.PortConfigList) {
@@ -740,6 +738,10 @@ func handleGlobalConfigModify(ctxArg interface{}, key string,
 			ctx.NetworkTestBetterInterval = gcp.NetworkTestBetterInterval
 		}
 		ctx.globalConfig = gcp
+		dnc := &ctx.DeviceNetworkContext
+		dnc.NetworkTestInterval = ctx.globalConfig.NetworkTestInterval
+		dnc.DPCTestDuration = ctx.globalConfig.NetworkTestDuration
+		dnc.TestSendTimeout = ctx.globalConfig.NetworkTestTimeout
 	}
 	ctx.GCInitialized = true
 	log.Infof("handleGlobalConfigModify done for %s\n", key)

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -91,6 +91,7 @@ func getDeviceNetworkConfigFile() string {
 	// don't have a DeviceNetworkConfig
 	// After some tries we fall back to default.json which is eth0, wlan0
 	// and wwan0
+	// XXX remove default.json
 	// If we have a DevicePortConfig/override.json we proceed
 	// without a DNCFilename!
 	if fileExists(DPCOverride) {

--- a/pkg/pillar/cmd/verifier/verifier.go
+++ b/pkg/pillar/cmd/verifier/verifier.go
@@ -210,16 +210,24 @@ func Run() {
 	for {
 		select {
 		case change := <-subGlobalConfig.C:
+			start := agentlog.StartTime()
 			subGlobalConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subAppImgConfig.C:
+			start := agentlog.StartTime()
 			subAppImgConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subBaseOsConfig.C:
+			start := agentlog.StartTime()
 			subBaseOsConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case <-gc.C:
+			start := agentlog.StartTime()
 			gcVerifiedObjects(&ctx)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case <-stillRunning.C:
 			agentlog.StillRunning(agentName)

--- a/pkg/pillar/cmd/waitforaddr/waitforaddr.go
+++ b/pkg/pillar/cmd/waitforaddr/waitforaddr.go
@@ -101,7 +101,10 @@ func Run() {
 		log.Infof("Waiting for usable address(es)\n")
 		select {
 		case change := <-subDeviceNetworkStatus.C:
+			start := agentlog.StartTime()
 			subDeviceNetworkStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
+
 		case <-timer.C:
 			log.Infoln("Exit since we got timeout")
 			done = true

--- a/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
+++ b/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
@@ -136,23 +136,33 @@ func Run() {
 		log.Infof("Waiting for DomainNetworkStatus\n")
 		select {
 		case change := <-subGlobalConfig.C:
+			start := agentlog.StartTime()
 			subGlobalConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subDeviceNetworkStatus.C:
+			start := agentlog.StartTime()
 			subDeviceNetworkStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 		}
 	}
 
 	for {
 		select {
 		case change := <-subGlobalConfig.C:
+			start := agentlog.StartTime()
 			subGlobalConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subDeviceNetworkStatus.C:
+			start := agentlog.StartTime()
 			subDeviceNetworkStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subAppInstanceConfig.C:
+			start := agentlog.StartTime()
 			subAppInstanceConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case <-stillRunning.C:
 			agentlog.StillRunning(agentName)

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -97,6 +97,7 @@ func handleConfigInit() {
 	zedcloudCtx.SuccessFunc = zedcloud.ZedCloudSuccess
 	zedcloudCtx.DevSerial = hardware.GetProductSerial()
 	zedcloudCtx.DevSoftSerial = hardware.GetSoftSerial()
+	zedcloudCtx.NetworkSendTimeout = globalConfig.NetworkSendTimeout
 	log.Infof("Configure Get Device Serial %s, Soft Serial %s\n", zedcloudCtx.DevSerial,
 		zedcloudCtx.DevSoftSerial)
 

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -140,6 +140,7 @@ func configTimerTask(handleChannel chan interface{},
 	for {
 		select {
 		case <-ticker.C:
+			start := agentlog.StartTime()
 			iteration += 1
 			// check whether the device is still in progress state
 			// once activated, it does not go back to the inprogress
@@ -150,6 +151,7 @@ func configTimerTask(handleChannel chan interface{},
 			rebootFlag := getLatestConfig(configUrl, iteration,
 				updateInprogress, getconfigCtx)
 			getconfigCtx.rebootFlag = getconfigCtx.rebootFlag || rebootFlag
+			agentlog.CheckMaxTime(agentName+"config", start)
 
 		case <-stillRunning.C:
 			agentlog.StillRunning(agentName + "config")

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -74,8 +74,11 @@ func metricsTimerTask(ctx *zedagentContext, handleChannel chan interface{}) {
 	for {
 		select {
 		case <-ticker.C:
+			start := agentlog.StartTime()
 			iteration += 1
 			publishMetrics(ctx, iteration)
+			agentlog.CheckMaxTime(agentName+"metrics", start)
+
 		case <-stillRunning.C:
 			agentlog.StillRunning(agentName + "metrics")
 		}

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -1556,6 +1556,15 @@ func parseConfigItems(config *zconfig.EdgeDevConfig, ctx *getconfigContext) {
 			}
 			newGlobalConfig.MetricInterval = uint32(i64)
 
+		case "timer.send.timeout":
+			i64, err := strconv.ParseInt(item.Value, 10, 32)
+			if err != nil {
+				log.Errorf("parseConfigItems: bad int value %s for %s: %s\n",
+					item.Value, key, err)
+				continue
+			}
+			newGlobalConfig.NetworkSendTimeout = uint32(i64)
+
 		case "timer.reboot.no.network":
 			i64, err := strconv.ParseInt(item.Value, 10, 32)
 			if err != nil {
@@ -1618,6 +1627,15 @@ func parseConfigItems(config *zconfig.EdgeDevConfig, ctx *getconfigContext) {
 				continue
 			}
 			newGlobalConfig.NetworkTestInterval = uint32(i64)
+
+		case "timer.port.timeout":
+			i64, err := strconv.ParseInt(item.Value, 10, 32)
+			if err != nil {
+				log.Errorf("parseConfigItems: bad int value %s for %s: %s\n",
+					item.Value, key, err)
+				continue
+			}
+			newGlobalConfig.NetworkTestTimeout = uint32(i64)
 
 		case "timer.port.testbetterinterval":
 			i64, err := strconv.ParseInt(item.Value, 10, 32)

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -504,7 +504,9 @@ func Run() {
 		log.Infof("Waiting for GCInitialized\n")
 		select {
 		case change := <-subGlobalConfig.C:
+			start := agentlog.StartTime()
 			subGlobalConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 		}
 	}
 
@@ -519,17 +521,21 @@ func Run() {
 	for !zedagentCtx.zbootRestarted {
 		select {
 		case change := <-subZbootStatus.C:
+			start := agentlog.StartTime()
 			subZbootStatus.ProcessChange(change)
 			if zedagentCtx.zbootRestarted {
 				log.Infof("Zboot reported restarted\n")
 			}
+			agentlog.CheckMaxTime(agentName, start)
 
 		case <-t1.C:
+			start := agentlog.StartTime()
 			// reboot, if not available, within a wait time
 			errStr := "zboot status is still not available - rebooting"
 			log.Errorf(errStr)
 			agentlog.RebootReason(errStr)
 			execReboot(true)
+			agentlog.CheckMaxTime(agentName, start)
 		}
 	}
 
@@ -542,48 +548,72 @@ func Run() {
 
 		select {
 		case change := <-subGlobalConfig.C:
+			start := agentlog.StartTime()
 			subGlobalConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-zedagentCtx.subBaseOsVerifierStatus.C:
+			start := agentlog.StartTime()
 			zedagentCtx.subBaseOsVerifierStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-zedagentCtx.subBaseOsDownloadStatus.C:
+			start := agentlog.StartTime()
 			zedagentCtx.subBaseOsDownloadStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-zedagentCtx.subAppImgVerifierStatus.C:
+			start := agentlog.StartTime()
 			zedagentCtx.subAppImgVerifierStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-zedagentCtx.subAppImgDownloadStatus.C:
+			start := agentlog.StartTime()
 			zedagentCtx.subAppImgDownloadStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-zedagentCtx.subCertObjDownloadStatus.C:
+			start := agentlog.StartTime()
 			zedagentCtx.subCertObjDownloadStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subDeviceNetworkStatus.C:
+			start := agentlog.StartTime()
 			subDeviceNetworkStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subAssignableAdapters.C:
+			start := agentlog.StartTime()
 			subAssignableAdapters.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subDevicePortConfigList.C:
+			start := agentlog.StartTime()
 			subDevicePortConfigList.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-deferredChan:
+			start := agentlog.StartTime()
 			zedcloud.HandleDeferred(change, 100*time.Millisecond)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case <-t1.C:
+			start := agentlog.StartTime()
 			errStr := "Exceeded outage for cloud connectivity - rebooting"
 			log.Errorf(errStr)
 			agentlog.RebootReason(errStr)
 			execReboot(true)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case <-t2.C:
+			start := agentlog.StartTime()
 			if updateInprogress {
 				errStr := "Exceeded fallback outage for cloud connectivity - rebooting"
 				log.Errorf(errStr)
 				agentlog.RebootReason(errStr)
 				execReboot(true)
 			}
+			agentlog.CheckMaxTime(agentName, start)
 		}
 	}
 	t1.Stop()
@@ -628,28 +658,41 @@ func Run() {
 	for !zedagentCtx.verifierRestarted {
 		select {
 		case change := <-subGlobalConfig.C:
+			start := agentlog.StartTime()
 			subGlobalConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subBaseOsVerifierStatus.C:
+			start := agentlog.StartTime()
 			subBaseOsVerifierStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 			if zedagentCtx.verifierRestarted {
 				log.Infof("Verifier reported restarted\n")
 				break
 			}
 
 		case change := <-zedagentCtx.subBaseOsDownloadStatus.C:
+			start := agentlog.StartTime()
 			zedagentCtx.subBaseOsDownloadStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-zedagentCtx.subAppImgVerifierStatus.C:
+			start := agentlog.StartTime()
 			zedagentCtx.subAppImgVerifierStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-zedagentCtx.subAppImgDownloadStatus.C:
+			start := agentlog.StartTime()
 			zedagentCtx.subAppImgDownloadStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-zedagentCtx.subCertObjDownloadStatus.C:
+			start := agentlog.StartTime()
 			zedagentCtx.subCertObjDownloadStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subDeviceNetworkStatus.C:
+			start := agentlog.StartTime()
 			subDeviceNetworkStatus.ProcessChange(change)
 			if DNSctx.triggerDeviceInfo {
 				// IP/DNS in device info could have changed
@@ -657,21 +700,30 @@ func Run() {
 				publishDevInfo(&zedagentCtx)
 				DNSctx.triggerDeviceInfo = false
 			}
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subAssignableAdapters.C:
+			start := agentlog.StartTime()
 			subAssignableAdapters.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subDevicePortConfigList.C:
+			start := agentlog.StartTime()
 			subDevicePortConfigList.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-deferredChan:
+			start := agentlog.StartTime()
 			zedcloud.HandleDeferred(change, 100*time.Millisecond)
+			agentlog.CheckMaxTime(agentName, start)
 		}
 		// UsedByUUID, baseos subStatus, DevicePortConfigList etc
 		if zedagentCtx.TriggerDeviceInfo {
 			log.Infof("triggered PublishDeviceInfo\n")
+			start := agentlog.StartTime()
 			publishDevInfo(&zedagentCtx)
 			zedagentCtx.TriggerDeviceInfo = false
+			agentlog.CheckMaxTime(agentName, start)
 		}
 	}
 
@@ -684,33 +736,52 @@ func Run() {
 	for {
 		select {
 		case change := <-subZbootStatus.C:
+			start := agentlog.StartTime()
 			subZbootStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subGlobalConfig.C:
+			start := agentlog.StartTime()
 			subGlobalConfig.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subAppInstanceStatus.C:
+			start := agentlog.StartTime()
 			subAppInstanceStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subBaseOsStatus.C:
+			start := agentlog.StartTime()
 			subBaseOsStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-zedagentCtx.subBaseOsVerifierStatus.C:
+			start := agentlog.StartTime()
 			zedagentCtx.subBaseOsVerifierStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-zedagentCtx.subBaseOsDownloadStatus.C:
+			start := agentlog.StartTime()
 			zedagentCtx.subBaseOsDownloadStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-zedagentCtx.subAppImgVerifierStatus.C:
+			start := agentlog.StartTime()
 			zedagentCtx.subAppImgVerifierStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-zedagentCtx.subAppImgDownloadStatus.C:
+			start := agentlog.StartTime()
 			zedagentCtx.subAppImgDownloadStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-zedagentCtx.subCertObjDownloadStatus.C:
+			start := agentlog.StartTime()
 			zedagentCtx.subCertObjDownloadStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subDeviceNetworkStatus.C:
+			start := agentlog.StartTime()
 			subDeviceNetworkStatus.ProcessChange(change)
 			if DNSctx.triggerGetConfig {
 				triggerGetConfig(configTickerHandle)
@@ -722,11 +793,15 @@ func Run() {
 				publishDevInfo(&zedagentCtx)
 				DNSctx.triggerDeviceInfo = false
 			}
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subAssignableAdapters.C:
+			start := agentlog.StartTime()
 			subAssignableAdapters.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subNetworkMetrics.C:
+			start := agentlog.StartTime()
 			subNetworkMetrics.ProcessChange(change)
 			m, err := subNetworkMetrics.Get("global")
 			if err != nil {
@@ -735,8 +810,10 @@ func Run() {
 			} else {
 				networkMetrics = types.CastNetworkMetrics(m)
 			}
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subClientMetrics.C:
+			start := agentlog.StartTime()
 			subClientMetrics.ProcessChange(change)
 			m, err := subClientMetrics.Get("global")
 			if err != nil {
@@ -745,8 +822,10 @@ func Run() {
 			} else {
 				clientMetrics = m
 			}
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subLogmanagerMetrics.C:
+			start := agentlog.StartTime()
 			subLogmanagerMetrics.ProcessChange(change)
 			m, err := subLogmanagerMetrics.Get("global")
 			if err != nil {
@@ -755,8 +834,10 @@ func Run() {
 			} else {
 				logmanagerMetrics = m
 			}
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subDownloaderMetrics.C:
+			start := agentlog.StartTime()
 			subDownloaderMetrics.ProcessChange(change)
 			m, err := subDownloaderMetrics.Get("global")
 			if err != nil {
@@ -765,22 +846,33 @@ func Run() {
 			} else {
 				downloaderMetrics = m
 			}
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-deferredChan:
+			start := agentlog.StartTime()
 			zedcloud.HandleDeferred(change, 100*time.Millisecond)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subNetworkInstanceStatus.C:
+			start := agentlog.StartTime()
 			subNetworkInstanceStatus.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subNetworkInstanceMetrics.C:
+			start := agentlog.StartTime()
 			subNetworkInstanceMetrics.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subDevicePortConfigList.C:
+			start := agentlog.StartTime()
 			subDevicePortConfigList.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case change := <-subAppFlowMonitor.C:
+			start := agentlog.StartTime()
 			log.Debugf("FlowStats: change called")
 			subAppFlowMonitor.ProcessChange(change)
+			agentlog.CheckMaxTime(agentName, start)
 
 		case <-stillRunning.C:
 			agentlog.StillRunning(agentName)
@@ -788,8 +880,10 @@ func Run() {
 		// UsedByUUID, baseos subStatus, DevicePortConfigList etc
 		if zedagentCtx.TriggerDeviceInfo {
 			log.Infof("triggered PublishDeviceInfo\n")
+			start := agentlog.StartTime()
 			publishDevInfo(&zedagentCtx)
 			zedagentCtx.TriggerDeviceInfo = false
+			agentlog.CheckMaxTime(agentName, start)
 		}
 	}
 }

--- a/pkg/pillar/devicenetwork/devicenetwork.go
+++ b/pkg/pillar/devicenetwork/devicenetwork.go
@@ -70,7 +70,7 @@ func IsProxyConfigEmpty(proxyConfig types.ProxyConfig) bool {
 
 // Check if device can talk to outside world via atleast one of the free uplinks
 func VerifyDeviceNetworkStatus(status types.DeviceNetworkStatus,
-	retryCount int) (bool, error) {
+	retryCount int, timeout uint32) (bool, error) {
 
 	log.Infof("VerifyDeviceNetworkStatus() %d\n", retryCount)
 	// Check if it is 1970 in which case we declare success since
@@ -92,6 +92,7 @@ func VerifyDeviceNetworkStatus(status types.DeviceNetworkStatus,
 
 	zedcloudCtx := zedcloud.ZedCloudContext{
 		DeviceNetworkStatus: &status,
+		NetworkSendTimeout:  timeout,
 	}
 
 	// Get device serail number

--- a/pkg/pillar/devicenetwork/dhcpcd.go
+++ b/pkg/pillar/devicenetwork/dhcpcd.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Manage dhcpcd for ports including static
-// XXX wwan0? Skip for now
+// XXX wwan*? Skip for now since wwan container handles configuring IP
 
 package devicenetwork
 
@@ -65,8 +65,7 @@ func doDhcpClientActivate(nuc types.NetworkPortConfig) {
 	log.Infof("doDhcpClientActivate(%s) dhcp %v addr %s gateway %s\n",
 		nuc.IfName, nuc.Dhcp, nuc.AddrSubnet,
 		nuc.Gateway.String())
-	// XXX skipping wwan0
-	if nuc.IfName == "wwan0" {
+	if strings.HasPrefix(nuc.IfName, "wwan") {
 		log.Infof("doDhcpClientActivate: skipping %s\n",
 			nuc.IfName)
 		return
@@ -182,8 +181,7 @@ func doDhcpClientInactivate(nuc types.NetworkPortConfig) {
 	log.Infof("doDhcpClientInactivate(%s) dhcp %v addr %s gateway %s\n",
 		nuc.IfName, nuc.Dhcp, nuc.AddrSubnet,
 		nuc.Gateway.String())
-	// XXX skipping wwan0
-	if nuc.IfName == "wwan0" {
+	if strings.HasPrefix(nuc.IfName, "wwan") {
 		log.Infof("doDhcpClientInactivate: skipping %s\n",
 			nuc.IfName)
 		return

--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -464,8 +464,7 @@ func VerifyDevicePortConfig(ctx *DeviceNetworkContext) {
 	pending.Inprogress = false
 
 	// Did we get a new at index zero?
-	if ctx.DevicePortConfigList.PortConfigList[0].IsDPCUntested() ||
-		ctx.DevicePortConfigList.PortConfigList[0].WasDPCWorking() {
+	if ctx.DevicePortConfigList.PortConfigList[0].IsDPCUntested() {
 		log.Warn("VerifyDevicePortConfig DPC_SUCCESS: New DPC arrived " +
 			"or a old working DPC moved up to top of DPC list while network testing " +
 			"was in progress. Restarting DPC verification.")

--- a/pkg/pillar/devicenetwork/wpad.go
+++ b/pkg/pillar/devicenetwork/wpad.go
@@ -91,8 +91,9 @@ func CheckAndGetNetworkProxy(deviceNetworkStatus *types.DeviceNetworkStatus,
 }
 
 var ctx = zedcloud.ZedCloudContext{
-	FailureFunc: zedcloud.ZedCloudFailure,
-	SuccessFunc: zedcloud.ZedCloudSuccess,
+	FailureFunc:        zedcloud.ZedCloudFailure,
+	SuccessFunc:        zedcloud.ZedCloudSuccess,
+	NetworkSendTimeout: 15, // XXX short since it is part of larger operation
 }
 
 func getPacFile(status *types.DeviceNetworkStatus, url string,
@@ -102,7 +103,7 @@ func getPacFile(status *types.DeviceNetworkStatus, url string,
 	// Avoid using a proxy to fetch the wpad.dat; 15 second timeout
 	const allowProxy = false
 	resp, contents, _, err := zedcloud.SendOnIntf(ctx, url, ifname, 0, nil,
-		allowProxy, 15)
+		allowProxy)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/pillar/docs/global-config-variables.md
+++ b/pkg/pillar/docs/global-config-variables.md
@@ -1,24 +1,30 @@
-# Controlling EVE behavior at boot and later.
+# Controlling EVE behavior at boot and later
 
 The following variables can be set in the controller and carried to the device
 using the configItem API. That can be done either on a per-project basis using e.g.,
-```
+
+```bash
     zcli project update <name> [--config=<key:value>...]
 ```
+
 or on a per asset basis using
-```
+
+```bash
    zcli device update <name> [--config=<key:value>...]
 ```
+
 For example,
-```
+
+```bash
 zcli device update myqemu --config="debug.enable.ssh:`cat .ssh/id_rsa.pub`"
 ```
+
 will allow ssh access to the device for debugging issues.
 
 The same variables can be specified in a json file included in /config/GlobalConfig/global.json. The format of that file is the natural json encoding of GlobalConfig as specified in types/global.go
 See [build-config-files.md](build-config-files.md) for how to include such a file in the image.
 
-# List of config variables
+## List of config variables
 
 | Name | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
@@ -44,7 +50,7 @@ See [build-config-files.md](build-config-files.md) for how to include such a fil
 | debug.enable.usb | boolean | false | allow USB e.g. keyboards on device |
 | debug.enable.ssh | boolean, or authorized ssh key | false | allow ssh to EVE |
 | debug.default.loglevel | string | info | min level saved in files on device |
-| debug.default.remote.loglevel	| string | warning | min level sent to controller |
+| debug.default.remote.loglevel | string | warning | min level sent to controller |
 
 In addition, for each agentname, there are specific overrides for the default
 ones with the names:

--- a/pkg/pillar/docs/global-config-variables.md
+++ b/pkg/pillar/docs/global-config-variables.md
@@ -25,6 +25,7 @@ See [build-config-files.md](build-config-files.md) for how to include such a fil
 | app.allow.vnc | boolean | false | allow access to the app using the VNC tcp port |
 | timer.config.interval | integer in seconds | 60 | how frequently device gets config |
 | timer.metric.interval  | integer in seconds | 60 | how frequently device reports metrics |
+| timer.send.timeout | timer in seconds | 120 | time for each http/send |
 | timer.reboot.no.network | integer in seconds | 7 days | reboot after no cloud connectivity |
 | timer.update.fallback.no.network | integer in seconds | 300 | fallback after no cloud connectivity |
 | timer.test.baseimage.update | integer in seconds | 600 | commit to update |
@@ -37,6 +38,7 @@ See [build-config-files.md](build-config-files.md) for how to include such a fil
 | timer.port.georetry | integer in seconds | 600 | retry geolocation after failure |
 | timer.port.testduration | integer in seconds | 30 | wait for DHCP to give address |
 | timer.port.testinterval | timer in seconds | 300 | retest the current port config |
+| timer.port.timeout | timer in seconds | 15 | time for each http/send |
 | timer.port.testbetterinterval | timer in seconds | 0 (disabled) | test a higher prio port config |
 | network.fallback.any.eth | "enabled" or "disabled" | enabled | if no connectivity try any Ethernet port |
 | debug.enable.usb | boolean | false | allow USB e.g. keyboards on device |

--- a/pkg/pillar/docs/global-config-variables.md
+++ b/pkg/pillar/docs/global-config-variables.md
@@ -40,7 +40,7 @@ See [build-config-files.md](build-config-files.md) for how to include such a fil
 | timer.port.testinterval | timer in seconds | 300 | retest the current port config |
 | timer.port.timeout | timer in seconds | 15 | time for each http/send |
 | timer.port.testbetterinterval | timer in seconds | 0 (disabled) | test a higher prio port config |
-| network.fallback.any.eth | "enabled" or "disabled" | enabled | if no connectivity try any Ethernet port |
+| network.fallback.any.eth | "enabled" or "disabled" | enabled | if no connectivity try any Ethernet, WiFi, or LTE |
 | debug.enable.usb | boolean | false | allow USB e.g. keyboards on device |
 | debug.enable.ssh | boolean, or authorized ssh key | false | allow ssh to EVE |
 | debug.default.loglevel | string | info | min level saved in files on device |

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -570,6 +570,8 @@ ps -ef
 # XXX redundant but doesn't always start
 /usr/sbin/watchdog -c $TMPDIR/watchdogall.conf -F -s &
 
+echo "$(date -Ins -u) Done starting EVE version: $(cat $BINDIR/versioninfo)"
+
 # If there is a USB stick inserted and debug.enable.usb is set, we periodically
 # check for any usb.json with DevicePortConfig, deposit our identity,
 # and dump any diag information

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -43,7 +43,7 @@ type GlobalConfig struct {
 	NetworkTestDuration       uint32   // Time we wait for DHCP to complete
 	NetworkTestInterval       uint32   // Re-test DevicePortConfig
 	NetworkTestBetterInterval uint32   // Look for better DevicePortConfig
-	NetworkFallbackAnyEth     TriState // When no connectivity try any Ethernet; XXX LTE?
+	NetworkFallbackAnyEth     TriState // When no connectivity try any Ethernet, wlan, and wwan
 	NetworkTestTimeout        uint32   // Timeout for each test http/send
 
 	// zedagent, logmanager, etc

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -44,6 +44,10 @@ type GlobalConfig struct {
 	NetworkTestInterval       uint32   // Re-test DevicePortConfig
 	NetworkTestBetterInterval uint32   // Look for better DevicePortConfig
 	NetworkFallbackAnyEth     TriState // When no connectivity try any Ethernet; XXX LTE?
+	NetworkTestTimeout        uint32   // Timeout for each test http/send
+
+	// zedagent, logmanager, etc
+	NetworkSendTimeout uint32 // Timeout for each http/send
 
 	// UsbAccess
 	// Determines if Dom0 can use USB devices.
@@ -100,6 +104,9 @@ var GlobalConfigDefaults = GlobalConfig{
 	NetworkTestInterval:       300, // 5 minutes
 	NetworkTestBetterInterval: 0,   // Disabled
 	NetworkFallbackAnyEth:     TS_ENABLED,
+	NetworkTestTimeout:        15,
+
+	NetworkSendTimeout: 120,
 
 	UsbAccess:             true, // Contoller likely to default to false
 	SshAccess:             true, // Contoller likely to default to false
@@ -148,6 +155,12 @@ func ApplyGlobalConfig(newgc GlobalConfig) GlobalConfig {
 
 	if newgc.NetworkFallbackAnyEth == TS_NONE {
 		newgc.NetworkFallbackAnyEth = GlobalConfigDefaults.NetworkFallbackAnyEth
+	}
+	if newgc.NetworkTestTimeout == 0 {
+		newgc.NetworkTestTimeout = GlobalConfigDefaults.NetworkTestTimeout
+	}
+	if newgc.NetworkSendTimeout == 0 {
+		newgc.NetworkSendTimeout = GlobalConfigDefaults.NetworkSendTimeout
 	}
 	if newgc.StaleConfigTime == 0 {
 		newgc.StaleConfigTime = GlobalConfigDefaults.StaleConfigTime


### PR DESCRIPTION
and make the timer values configurable.

Also, add some logging to track if handlers take a long time so we can test that by injecting network failures.