### PR TITLE
Use json.marshal instead of proto.marshal when calculating sha of config sections

### DIFF
--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -19,7 +19,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	zconfig "github.com/lf-edge/eve/api/go/config"
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
@@ -72,22 +71,25 @@ func parseConfig(config *zconfig.EdgeDevConfig, getconfigCtx *getconfigContext,
 			otherPart)
 	}
 
+	log.Debugf("parseConfig: EdgeDevConfig: %v\n", *config)
+
 	// Look for timers and other settings in configItems
+	// Process Config items even when rebootFlag is set.. Allows us to
+	//  recover if the system got stuck after setting rebootFlag
 	parseConfigItems(config, getconfigCtx)
-	parseDatastoreConfig(config, getconfigCtx)
 
-	// XXX Deprecated but used for systemAdapters
-	//	parseNetworkXObjectConfig
-	parseNetworkXObjectConfig(config, getconfigCtx)
-
-	parseSystemAdapterConfig(config, getconfigCtx, false)
-	parseDeviceIoListConfig(config, getconfigCtx)
-
-	parseBaseOsConfig(getconfigCtx, config)
-
-	parseNetworkInstanceConfig(config, getconfigCtx)
-	parseAppInstanceConfig(config, getconfigCtx)
-
+	if getconfigCtx.rebootFlag {
+		log.Debugf("parseConfig: Ignoring config as rebootFlag set\n")
+	} else {
+		parseDatastoreConfig(config, getconfigCtx)
+		// Network objects are used for systemAdapters
+		parseNetworkXObjectConfig(config, getconfigCtx)
+		parseSystemAdapterConfig(config, getconfigCtx, false)
+		parseDeviceIoListConfig(config, getconfigCtx)
+		parseBaseOsConfig(getconfigCtx, config)
+		parseNetworkInstanceConfig(config, getconfigCtx)
+		parseAppInstanceConfig(config, getconfigCtx)
+	}
 	return false
 }
 
@@ -128,14 +130,16 @@ func parseBaseOsConfig(getconfigCtx *getconfigContext,
 	}
 	configHash := h.Sum(nil)
 	same := bytes.Equal(configHash, baseosPrevConfigHash)
-	baseosPrevConfigHash = configHash
 	if same {
-		log.Debugf("parseBaseOsConfig: baseos sha is unchanged: % x\n",
-			configHash)
 		return
 	}
-	log.Infof("parseBaseOsConfig: Applying updated config sha % x vs. % x: %v\n",
+	log.Infof("parseBaseOsConfig: Applying updated config\n"+
+		"prevSha: % x\n"+
+		"NewSha : % x\n"+
+		"cfgOsList: %v\n",
 		baseosPrevConfigHash, configHash, cfgOsList)
+
+	baseosPrevConfigHash = configHash
 
 	// First look for deleted ones
 	items := getconfigCtx.pubBaseOsConfig.GetAll()
@@ -227,14 +231,15 @@ func parseNetworkXObjectConfig(config *zconfig.EdgeDevConfig,
 	}
 	configHash := h.Sum(nil)
 	same := bytes.Equal(configHash, networkConfigPrevConfigHash)
-	networkConfigPrevConfigHash = configHash
 	if same {
-		log.Debugf("parseNetworkXObjectConfig: network sha is unchanged: % x\n",
-			configHash)
 		return
 	}
-	log.Infof("parseNetworkXObjectConfig: Applying updated config sha % x vs. % x: %v\n",
+	log.Infof("parseNetworkXObjectConfig: Applying updated config.\n"+
+		"prevSha: % x\n"+
+		"NewSha : % x\n"+
+		"networks: %v\n",
 		networkConfigPrevConfigHash, configHash, nets)
+	networkConfigPrevConfigHash = configHash
 	// Export NetworkXObjectConfig for ourselves; systemAdapter
 	// XXX
 	// System Adapter points to network for Proxy configuration.
@@ -468,13 +473,15 @@ func parseNetworkInstanceConfig(config *zconfig.EdgeDevConfig,
 	}
 	configHash := h.Sum(nil)
 	same := bytes.Equal(configHash, networkInstancePrevConfigHash)
-	networkConfigPrevConfigHash = configHash
 	if same {
 		return
 	}
-	log.Infof("parseNetworkInstanceConfig: Applying updated config "+
-		"sha % x vs. % x: %v\n",
+	log.Infof("parseNetworkInstanceConfig: Applying updated config\n"+
+		"prevSha: % x\n"+
+		"NewSha : % x\n"+
+		"networkInstances: %v\n",
 		networkInstancePrevConfigHash, configHash, networkInstances)
+	networkInstancePrevConfigHash = configHash
 	// Export NetworkInstanceConfig to zedrouter
 	publishNetworkInstanceConfig(getconfigCtx, networkInstances)
 }
@@ -483,7 +490,6 @@ var appinstancePrevConfigHash []byte
 
 func parseAppInstanceConfig(config *zconfig.EdgeDevConfig,
 	getconfigCtx *getconfigContext) {
-	log.Debugf("EdgeDevConfig: %v\n", *config)
 
 	Apps := config.GetApps()
 	h := sha256.New()
@@ -492,19 +498,15 @@ func parseAppInstanceConfig(config *zconfig.EdgeDevConfig,
 	}
 	configHash := h.Sum(nil)
 	same := bytes.Equal(configHash, appinstancePrevConfigHash)
-	appinstancePrevConfigHash = configHash
 	if same {
-		log.Debugf("parseAppInstanceConfig: appinstance sha is unchanged: % x\n",
-			configHash)
 		return
 	}
-	if getconfigCtx.rebootFlag {
-		log.Infof("parseAppInstanceConfig: ignoring updated config due to rebootFlag: %v\n",
-			Apps)
-		return
-	}
-	log.Infof("parseAppInstanceConfig: Applying updated config sha % x vs. % x: %v\n",
+	log.Infof("parseAppInstanceConfig: Applying updated config\n"+
+		"prevSha: % x\n"+
+		"NewSha : % x\n"+
+		"Apps: %v\n",
 		appinstancePrevConfigHash, configHash, Apps)
+	appinstancePrevConfigHash = configHash
 
 	// First look for deleted ones
 	items := getconfigCtx.pubAppInstanceConfig.GetAll()
@@ -603,7 +605,6 @@ var systemAdaptersPrevConfigHash []byte
 
 func parseSystemAdapterConfig(config *zconfig.EdgeDevConfig,
 	getconfigCtx *getconfigContext, forceParse bool) {
-	log.Debugf("parseSystemAdapterConfig: EdgeDevConfig: %v\n", *config)
 
 	sysAdapters := config.GetSystemAdapterList()
 	h := sha256.New()
@@ -613,16 +614,12 @@ func parseSystemAdapterConfig(config *zconfig.EdgeDevConfig,
 	configHash := h.Sum(nil)
 	same := bytes.Equal(configHash, systemAdaptersPrevConfigHash)
 	if same && !forceParse {
-		log.Debugf("parseSystemAdapterConfig: system adapter sha is unchanged: % x\n",
-			configHash)
 		return
 	}
-	if getconfigCtx.rebootFlag {
-		log.Infof("parseSystemAdapterConfig: ignoring updated config due to rebootFlag: %v\n",
-			sysAdapters)
-		return
-	}
-	log.Infof("parseSystemAdapterConfig: Applying updated config sha % x vs. % x: %v\n",
+	log.Infof("parseSystemAdapterConfig: Applying updated config\n"+
+		"prevSha: % x\n"+
+		"NewSha : % x\n"+
+		"sysAdapters: %v\n",
 		systemAdaptersPrevConfigHash, configHash, sysAdapters)
 
 	systemAdaptersPrevConfigHash = configHash
@@ -746,7 +743,8 @@ func parseSystemAdapterConfig(config *zconfig.EdgeDevConfig,
 	// Any content change?
 	if cmp.Equal(getconfigCtx.devicePortConfig.Ports, portConfig.Ports) &&
 		getconfigCtx.devicePortConfig.Version == portConfig.Version {
-		log.Infof("parseSystemAdapterConfig: Done with no change")
+		log.Infof("parseSystemAdapterConfig: DevicePortConfig - " +
+			"Done with no change")
 		return
 	}
 	log.Infof("parseSystemAdapterConfig: version %d/%d diff %v",
@@ -767,7 +765,6 @@ var deviceIoListPrevConfigHash []byte
 
 func parseDeviceIoListConfig(config *zconfig.EdgeDevConfig,
 	getconfigCtx *getconfigContext) {
-	log.Debugf("parseDeviceIoListConfig: EdgeDevConfig: %v\n", *config)
 
 	deviceIoList := config.GetDeviceIoList()
 	h := sha256.New()
@@ -777,16 +774,12 @@ func parseDeviceIoListConfig(config *zconfig.EdgeDevConfig,
 	configHash := h.Sum(nil)
 	same := bytes.Equal(configHash, deviceIoListPrevConfigHash)
 	if same {
-		log.Debugf("parseDeviceIoListConfig: deviceIo sha is unchanged: % x\n",
-			configHash)
 		return
 	}
-	if getconfigCtx.rebootFlag {
-		log.Infof("parseDeviceIoListConfig: ignoring updated config due to rebootFlag: %v\n",
-			deviceIoList)
-		return
-	}
-	log.Infof("parseDeviceIoListConfig: Applying updated config sha % x vs. % x: %v\n",
+	log.Infof("parseDeviceIoListConfig: Applying updated config\n"+
+		"prevSha: % x\n"+
+		"NewSha : % x\n"+
+		"deviceIoList: %v\n",
 		deviceIoListPrevConfigHash, configHash, deviceIoList)
 
 	deviceIoListPrevConfigHash = configHash
@@ -863,14 +856,15 @@ func parseDatastoreConfig(config *zconfig.EdgeDevConfig,
 	}
 	configHash := h.Sum(nil)
 	same := bytes.Equal(configHash, datastoreConfigPrevConfigHash)
-	datastoreConfigPrevConfigHash = configHash
 	if same {
-		log.Debugf("parseDatastoreConfig: datastore sha is unchanged: % x\n",
-			configHash)
 		return
 	}
-	log.Infof("parseDatastoreConfig: Applying updated datastore config shaa % x vs. % x:  %v\n",
+	log.Infof("parseDatastoreConfig: Applying updated datastore config\n"+
+		"prevSha: % x\n"+
+		"NewSha : % x\n"+
+		"stores: %v\n",
 		datastoreConfigPrevConfigHash, configHash, stores)
+	datastoreConfigPrevConfigHash = configHash
 	publishDatastoreConfig(getconfigCtx, stores)
 }
 
@@ -1522,11 +1516,12 @@ func parseConfigItems(config *zconfig.EdgeDevConfig, ctx *getconfigContext) {
 	same := bytes.Equal(configHash, itemsPrevConfigHash)
 	itemsPrevConfigHash = configHash
 	if same {
-		log.Debugf("parseConfigItems: items sha is unchanged: % x\n",
-			configHash)
 		return
 	}
-	log.Infof("parseConfigItems: Applying updated config sha % x vs. % x: %v\n",
+	log.Infof("parseConfigItems: Applying updated config\n"+
+		"prevSha: % x\n"+
+		"NewSha : % x\n"+
+		"items: %v\n",
 		itemsPrevConfigHash, configHash, items)
 
 	// Start with the defaults so that we revert to default when no data
@@ -1932,8 +1927,8 @@ func unpublishCertObjConfig(getconfigCtx *getconfigContext, uuidStr string) {
 
 // Get sha256 for a subset of the protobuf message.
 // Used to determine which pieces changed
-func computeConfigSha(msg proto.Message) []byte {
-	data, err := proto.Marshal(msg)
+func computeConfigSha(msg interface{}) []byte {
+	data, err := json.Marshal(msg)
 	if err != nil {
 		log.Fatalf("computeConfigSha: proto.Marshal: %s\n", err)
 	}
@@ -1944,11 +1939,10 @@ func computeConfigSha(msg proto.Message) []byte {
 
 // Get sha256 for a subset of the protobuf message.
 // Used to determine which pieces changed
-func computeConfigElementSha(h hash.Hash, msg proto.Message) {
-	data, err := proto.Marshal(msg)
+func computeConfigElementSha(h hash.Hash, msg interface{}) {
+	data, err := json.Marshal(msg)
 	if err != nil {
-		log.Fatalf("computeConfigItemSha: proto.Marshal: %s\n",
-			err)
+		log.Fatalf("computeConfigItemSha: json.Marshal: %s\n", err)
 	}
 	h.Write(data)
 }
@@ -1984,8 +1978,6 @@ func scheduleReboot(reboot *zconfig.DeviceOpsCmd,
 	same := bytes.Equal(configHash, rebootPrevConfigHash)
 	rebootPrevConfigHash = configHash
 	if same {
-		log.Debugf("scheduleReboot: reboot sha is unchanged: % x\n",
-			configHash)
 		return rebootPrevReturn
 	}
 	log.Infof("scheduleReboot: Applying updated config %v\n", reboot)
@@ -2076,8 +2068,6 @@ func scheduleBackup(backup *zconfig.DeviceOpsCmd) {
 	same := bytes.Equal(configHash, backupPrevConfigHash)
 	backupPrevConfigHash = configHash
 	if same {
-		log.Debugf("scheduleBackup: backup sha is unchanged: % x\n",
-			configHash)
 		return
 	}
 	log.Infof("scheduleBackup: Applying updated config %v\n", backup)

--- a/pkg/pillar/diskmetrics/usage.go
+++ b/pkg/pillar/diskmetrics/usage.go
@@ -13,7 +13,7 @@ func SizeFromDir(dirname string) uint64 {
 	var totalUsed uint64
 	locations, err := ioutil.ReadDir(dirname)
 	if err != nil {
-		log.Debugf("Dir %s is missing. Set the size to zero\n", dirname)
+		//log.Debugf("Dir %s is missing. Set the size to zero\n", dirname)
 		return totalUsed
 	}
 	for _, location := range locations {


### PR DESCRIPTION
1) Use json.marshal instead of proto.marshal when calculating sha of config sections
    - This allows maps to be used in the proto buf data structures.

2) Cleaned up logging in parseconfig and a couple of other files to not to overwhelm with non-useful debugs.

3) Moved most config processing to be done only if rebootFlag is not set
    - Moved the flag checking from individual sectional routines into parseConfig itself