### PR TITLE
Removed aa.IoType as a lookup parameter for looking up IoBundles

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -923,8 +923,7 @@ func cleanupAdapters(ctx *domainContext, ioAdapterList []types.IoAdapter,
 	for _, adapter := range ioAdapterList {
 		log.Debugf("cleanupAdapters processing adapter %d %s\n",
 			adapter.Type, adapter.Name)
-		list := ctx.assignableAdapters.LookupIoBundleGroup(
-			adapter.Type, adapter.Name)
+		list := ctx.assignableAdapters.LookupIoBundleGroup(adapter.Name)
 		if len(list) == 0 {
 			continue
 		}
@@ -954,8 +953,7 @@ func doAssignIoAdaptersToDomain(ctx *domainContext, config types.DomainConfig,
 		log.Debugf("doAssignIoAdaptersToDomain processing adapter %d %s\n",
 			adapter.Type, adapter.Name)
 
-		list := ctx.assignableAdapters.LookupIoBundleGroup(
-			adapter.Type, adapter.Name)
+		list := ctx.assignableAdapters.LookupIoBundleGroup(adapter.Name)
 		// We reserved it in handleCreate so nobody could have stolen it
 		if len(list) == 0 {
 			log.Fatalf("doAssignIoAdaptersToDomain IoBundle disappeared %d %s for %s\n",
@@ -1266,8 +1264,7 @@ func pciUnassign(ctx *domainContext, status *types.DomainStatus,
 	for _, adapter := range status.IoAdapterList {
 		log.Debugf("doInactivate processing adapter %d %s\n",
 			adapter.Type, adapter.Name)
-		list := ctx.assignableAdapters.LookupIoBundleGroup(
-			adapter.Type, adapter.Name)
+		list := ctx.assignableAdapters.LookupIoBundleGroup(adapter.Name)
 		// We reserved it in handleCreate so nobody could have stolen it
 		if len(list) == 0 {
 			log.Fatalf("doInactivate IoBundle disappeared %d %s for %s\n",
@@ -1388,8 +1385,7 @@ func configAdapters(ctx *domainContext, config types.DomainConfig) error {
 		log.Debugf("configAdapters processing adapter %d %s\n",
 			adapter.Type, adapter.Name)
 		// Lookup to make sure adapter exists on this device
-		list := ctx.assignableAdapters.LookupIoBundleGroup(
-			adapter.Type, adapter.Name)
+		list := ctx.assignableAdapters.LookupIoBundleGroup(adapter.Name)
 		if len(list) == 0 {
 			return fmt.Errorf("unknown adapter %d %s",
 				adapter.Type, adapter.Name)
@@ -1590,7 +1586,7 @@ func configToXencfg(config types.DomainConfig, status types.DomainStatus,
 	for _, adapter := range config.IoAdapterList {
 		log.Debugf("configToXenCfg processing adapter %d %s\n",
 			adapter.Type, adapter.Name)
-		list := aa.LookupIoBundleGroup(adapter.Type, adapter.Name)
+		list := aa.LookupIoBundleGroup(adapter.Name)
 		// We reserved it in handleCreate so nobody could have stolen it
 		if len(list) == 0 {
 			log.Fatalf("configToXencfg IoBundle disappeared %d %s for %s\n",
@@ -2552,7 +2548,7 @@ func handlePhysicalIOAdapterListCreateModify(ctxArg interface{},
 	// Any add or modify?
 	for _, phyAdapter := range phyIOAdapterList.AdapterList {
 		ib := *types.IoBundleFromPhyAdapter(phyAdapter)
-		currentIbPtr := aa.LookupIoBundle(0, phyAdapter.Phylabel)
+		currentIbPtr := aa.LookupIoBundle(phyAdapter.Phylabel)
 		if currentIbPtr == nil {
 			log.Infof("handlePhysicalIOAdapterListCreateModify: Adapter %s "+
 				"added. %+v\n", phyAdapter.Phylabel, ib)
@@ -2863,7 +2859,7 @@ func handleIBDelete(ctx *domainContext, name string) {
 	log.Infof("handleIBDelete(%s)", name)
 	aa := ctx.assignableAdapters
 
-	ib := aa.LookupIoBundle(0, name)
+	ib := aa.LookupIoBundle(name)
 	if ib == nil {
 		log.Infof("handleIBDelete: Adapter ( %s ) not found", name)
 		return
@@ -2895,7 +2891,7 @@ func handleIBDelete(ctx *domainContext, name string) {
 
 func handleIBModify(ctx *domainContext, newIb types.IoBundle) {
 	aa := ctx.assignableAdapters
-	currentIbPtr := aa.LookupIoBundle(newIb.Type, newIb.Name)
+	currentIbPtr := aa.LookupIoBundle(newIb.Name)
 	if currentIbPtr == nil {
 		log.Errorf("Failed to find IoBundle (%d %s).  aa: %+v\n",
 			newIb.Type, newIb.Name, aa)

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -927,7 +927,7 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 		reportAA := new(info.ZioBundle)
 		reportAA.Type = info.IPhyIoType(ib.Type)
 		reportAA.Name = ib.AssignmentGroup
-		list := aa.LookupIoBundleGroup(ib.Type, ib.AssignmentGroup)
+		list := aa.LookupIoBundleGroup(ib.AssignmentGroup)
 		if len(list) == 0 {
 			log.Infof("Nothing to report for %d %s",
 				ib.Type, ib.AssignmentGroup)
@@ -1372,7 +1372,7 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 			reportAA.Type = info.IPhyIoType(ia.Type)
 			reportAA.Name = ia.Name
 			reportAA.UsedByAppUUID = aiStatus.Key()
-			list := aa.LookupIoBundleGroup(ia.Type, ia.Name)
+			list := aa.LookupIoBundleGroup(ia.Name)
 			for _, ib := range list {
 				if ib == nil {
 					continue

--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -594,7 +594,7 @@ func HandleAssignableAdaptersModify(ctxArg interface{}, key string,
 		}
 		if ctx.AssignableAdapters != nil {
 			currentIoBundle := ctx.AssignableAdapters.LookupIoBundle(
-				ioBundle.Type, ioBundle.Name)
+				ioBundle.Name)
 			if currentIoBundle != nil &&
 				ioBundle.IsPCIBack == currentIoBundle.IsPCIBack {
 				log.Infof("HandleAssignableAdaptersModify(): ioBundle (%+v) "+

--- a/pkg/pillar/types/assignableadapters.go
+++ b/pkg/pillar/types/assignableadapters.go
@@ -183,15 +183,9 @@ func (ioType IoType) IsNet() bool {
 }
 
 // LookupIoBundle returns nil if not found
-func (aa *AssignableAdapters) LookupIoBundle(ioType IoType, name string) *IoBundle {
+func (aa *AssignableAdapters) LookupIoBundle(name string) *IoBundle {
 	for i, b := range aa.IoBundleList {
-		// XXX the new enums are sent as zero by the controller
-		// hence temporary workaround
-		if (ioType == 0 || b.Type == ioType) && strings.EqualFold(b.Name, name) {
-			if ioType == 0 {
-				log.Warnf("XXX Matching name %s for ioType 0",
-					b.Name)
-			}
+		if strings.EqualFold(b.Name, name) {
 			return &aa.IoBundleList[i]
 		}
 	}
@@ -200,20 +194,14 @@ func (aa *AssignableAdapters) LookupIoBundle(ioType IoType, name string) *IoBund
 
 // LookupIoBundleGroup returns an empty slice if not found
 // Returns pointers into aa
-func (aa *AssignableAdapters) LookupIoBundleGroup(ioType IoType, group string) []*IoBundle {
+func (aa *AssignableAdapters) LookupIoBundleGroup(group string) []*IoBundle {
 
 	var list []*IoBundle
 	for i, b := range aa.IoBundleList {
 		if b.AssignmentGroup == "" {
 			continue
 		}
-		// XXX the new enums are sent as zero by the controller
-		// hence temporary workaround
-		if (ioType == 0 || b.Type == ioType) && strings.EqualFold(b.AssignmentGroup, group) {
-			if ioType == 0 {
-				log.Warnf("XXX Matching group %s for ioType 0",
-					b.AssignmentGroup)
-			}
+		if strings.EqualFold(b.AssignmentGroup, group) {
 			list = append(list, &aa.IoBundleList[i])
 		}
 	}

--- a/pkg/pillar/types/assignableadapters_test.go
+++ b/pkg/pillar/types/assignableadapters_test.go
@@ -69,11 +69,6 @@ func TestLookupIoBundleGroup(t *testing.T) {
 			lookupName:         "eth0-1",
 			expectedBundleName: "eth0-1",
 		},
-		"IoType: IoUSB LookupName: eth2": {
-			ioType:             IoUSB,
-			lookupName:         "eth2",
-			expectedBundleName: "",
-		},
 		"IoType: IoNetEth LookupName: eth1": {
 			ioType:             IoNetEth,
 			lookupName:         "eth1",
@@ -93,7 +88,7 @@ func TestLookupIoBundleGroup(t *testing.T) {
 
 	for testname, test := range testMatrix {
 		t.Logf("Running test case %s", testname)
-		list := aa.LookupIoBundleGroup(test.ioType, test.lookupName)
+		list := aa.LookupIoBundleGroup(test.lookupName)
 		if len(list) == 0 {
 			assert.Equal(t, test.expectedBundleName, "")
 		} else {
@@ -113,12 +108,6 @@ func TestLookupIoBundle(t *testing.T) {
 			ioType:             IoNetEth,
 			lookupName:         "eth1",
 			expectedBundleName: "eth1",
-		},
-		// Type should also be considered.
-		"ioType: IoUSB, lookupName: eth1": {
-			ioType:             IoUSB,
-			lookupName:         "eth1",
-			expectedBundleName: "",
 		},
 		"ioType: IoNetEth, lookupName: eth3": {
 			ioType:             IoNetEth,
@@ -141,7 +130,7 @@ func TestLookupIoBundle(t *testing.T) {
 	// Basic test
 	for testname, test := range testMatrix {
 		t.Logf("Running test case %s", testname)
-		ioBundle := aa.LookupIoBundle(test.ioType, test.lookupName)
+		ioBundle := aa.LookupIoBundle(test.lookupName)
 		if ioBundle == nil {
 			assert.Equal(t, test.expectedBundleName, "")
 		} else {


### PR DESCRIPTION
Name is now guaranteed to be unique. So no need to use IoType for lookup