### PR TITLE
record failures and success from the try code

### DIFF
--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -199,8 +199,7 @@ func compressAndPublishDevicePortConfigList(ctx *DeviceNetworkContext) types.Dev
 
 	dpcl := compressDPCL(ctx.DevicePortConfigList)
 	if ctx.PubDevicePortConfigList != nil {
-		log.Infof("publishing DevicePortConfigList: %+v\n",
-			ctx.DevicePortConfigList)
+		log.Infof("publishing DevicePortConfigList: %+v\n", dpcl)
 		ctx.PubDevicePortConfigList.Publish("global", dpcl)
 	}
 	return dpcl


### PR DESCRIPTION
This seems to be missing, which confused me when I was looking at /persist/status/nim/DevicePortConfigList/global.json after I unplugged eth0.
Failures don't get updated until we start testing the alternatives.