### PR TITLE
Added check for Available DiskSpace during App Instance Activate.

### DIFF
--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/uuidtonum"
 	"github.com/satori/go.uuid"
+	"github.com/shirou/gopsutil/disk"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -258,6 +259,52 @@ func updateOrRemove(ctx *zedmanagerContext, status types.AppInstanceStatus) {
 	}
 }
 
+func checkDiskSize(ctxPtr *zedmanagerContext,
+	status types.AppInstanceStatus) error {
+
+	log.Infof("checkDiskSize: app %s\n", status.UUIDandVersion.UUID.String())
+	var totalAppDiskSize uint64
+	appDiskSizeList := ""
+	pub := ctxPtr.pubAppInstanceStatus
+	items := pub.GetAll()
+	for _, iterStatusJSON := range items {
+		iterStatus := cast.CastAppInstanceStatus(iterStatusJSON)
+		if iterStatus.State < types.INSTALLED {
+			log.Debugf("App %s State %d < INSTALLED",
+				iterStatus.UUIDandVersion, iterStatus.State)
+			continue
+		}
+		appDiskSize, err := iterStatus.GetDiskSize()
+		if err != nil {
+			log.Errorf("checkDiskSize: err: %s", err.Error())
+			return err
+		}
+		totalAppDiskSize += appDiskSize
+		appDiskSizeList += fmt.Sprintf("App: %s (Size: %d),\n",
+			iterStatus.UUIDandVersion.UUID.String(), appDiskSize)
+	}
+	deviceDiskUsage, err := disk.Usage("/persist")
+	if err != nil {
+		err := fmt.Errorf("Failed to get diskUsage for /persist. err: %s",
+			err.Error())
+		log.Errorf("checkDiskSize: err:%s", err.Error())
+		return err
+	}
+	deviceDiskSize := deviceDiskUsage.Total
+	allowedDeviceDiskSizeForApps := float64(deviceDiskSize) * 0.8
+	if allowedDeviceDiskSizeForApps < float64(totalAppDiskSize) {
+		err := fmt.Errorf("Disk space not available for app - "+
+			"deviceDiskSize: %+v, "+
+			"allowedDeviceDiskSizeForApps: %+v, totalAppDiskSize: %+v, "+
+			"AppDiskSizeList: %s",
+			deviceDiskSize, allowedDeviceDiskSizeForApps, totalAppDiskSize,
+			appDiskSizeList)
+		log.Errorf("checkDiskSize: err:%s", err.Error())
+		return err
+	}
+	return nil
+}
+
 func doUpdate(ctx *zedmanagerContext, uuidStr string,
 	config types.AppInstanceConfig, status *types.AppInstanceStatus) bool {
 
@@ -335,8 +382,7 @@ func doInstall(ctx *zedmanagerContext, uuidStr string,
 			len(status.StorageStatusList))
 		if status.PurgeInprogress == types.NONE {
 			log.Errorln(errString)
-			status.Error = errString
-			status.ErrorTime = time.Now()
+			status.SetError(errString, "Invalid PurgeInProgress", time.Now())
 			changed = true
 			return changed, false
 		}
@@ -358,9 +404,7 @@ func doInstall(ctx *zedmanagerContext, uuidStr string,
 				ss)
 			if status.ErrorSource == ss.ErrorSource {
 				log.Infof("Removing error %s\n", status.Error)
-				status.Error = ""
-				status.ErrorSource = ""
-				status.ErrorTime = time.Time{}
+				status.ClearError()
 			}
 			c := MaybeRemoveStorageStatus(ctx, ss)
 			if c {
@@ -714,6 +758,8 @@ func doPrepare(ctx *zedmanagerContext, uuidStr string,
 // Really a constant
 var nilUUID uuid.UUID
 
+// doActivate - Returns if the status has changed. Doesn't publish any changes.
+// It is caller's responsibility to publish.
 func doActivate(ctx *zedmanagerContext, uuidStr string,
 	config types.AppInstanceConfig, status *types.AppInstanceStatus) bool {
 
@@ -745,6 +791,14 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 	// Track that we have cleanup work in case something fails
 	status.ActivateInprogress = true
 
+	// Check
+	err := checkDiskSize(ctx, *status)
+	if err != nil {
+		log.Errorf("doActivate: checkDiskSize Failed. err: %s", err)
+		status.SetError(err.Error(), "CheckDiskSize", time.Now())
+		return true
+	}
+
 	// Make sure we have an AppNetworkConfig
 	MaybeAddAppNetworkConfig(ctx, config, status)
 
@@ -761,9 +815,8 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 	if ns.Error != "" {
 		log.Errorf("Received error from zedrouter for %s: %s\n",
 			uuidStr, ns.Error)
-		status.Error = ns.Error
-		status.ErrorSource = pubsub.TypeToName(types.AppNetworkStatus{})
-		status.ErrorTime = ns.ErrorTime
+		status.SetError(ns.Error, pubsub.TypeToName(types.AppNetworkStatus{}),
+			ns.ErrorTime)
 		changed = true
 		return changed
 	}
@@ -774,15 +827,13 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 	}
 	if status.ErrorSource == pubsub.TypeToName(types.AppNetworkStatus{}) {
 		log.Infof("Clearing zedrouter error %s\n", status.Error)
-		status.Error = ""
-		status.ErrorSource = ""
-		status.ErrorTime = time.Time{}
+		status.ClearError()
 		changed = true
 	}
 	log.Debugf("Done with AppNetworkStatus for %s\n", uuidStr)
 
 	// Make sure we have a DomainConfig
-	err := MaybeAddDomainConfig(ctx, config, *status, ns)
+	err = MaybeAddDomainConfig(ctx, config, *status, ns)
 	if err != nil {
 		log.Errorf("Error from MaybeAddDomainConfig for %s: %s\n",
 			uuidStr, err)

--- a/pkg/pillar/diskmetrics/diskmetrics.go
+++ b/pkg/pillar/diskmetrics/diskmetrics.go
@@ -40,6 +40,15 @@ func GetImgInfo(diskfile string) (*ImgInfo, error) {
 	return &imgInfo, nil
 }
 
+// GetDiskVirtualSize - returns VirtualSize of the image
+func GetDiskVirtualSize(diskfile string) (uint64, error) {
+	imgInfo, err := GetImgInfo(diskfile)
+	if err != nil {
+		return 0, err
+	}
+	return imgInfo.VirtualSize, nil
+}
+
 func ResizeImg(diskfile string, newsize uint64) error {
 
 	if _, err := os.Stat(diskfile); err != nil {

--- a/pkg/pillar/types/downloadertypes.go
+++ b/pkg/pillar/types/downloadertypes.go
@@ -140,7 +140,6 @@ type DatastoreContext struct {
 }
 
 const (
-	appImgObj = "appImg.obj"
 	baseOsObj = "baseOs.obj"
 	certObj   = "cert.obj"
 )

--- a/pkg/pillar/types/locationconsts.go
+++ b/pkg/pillar/types/locationconsts.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2017 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+const (
+	appImgObj = "appImg.obj"
+
+	// TmpDirname - Temporary dir for zededa components
+	TmpDirname = "/var/tmp/zededa"
+	// PersistDir - Persist Directory
+	PersistDir = "/persist"
+	// PersistRktDataDir - persist rkt dir used by rkt
+	PersistRktDataDir = PersistDir + "/rkt"
+	// RwImgDirname - location for images
+	RwImgDirname = PersistDir + "/img" // We store images here
+	// DownloadDirname - Location for downloader to download images
+	DownloadDirname = PersistDir + "/downloads"
+	// ImgCatalogDirname - Location for App Images
+	ImgCatalogDirname = DownloadDirname + "/" + appImgObj
+	// VerifiedDirname - Read-only images named based on sha256 hash each
+	// in its own directory
+	VerifiedDirname = ImgCatalogDirname + "/verified"
+)

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -4,9 +4,16 @@
 package types
 
 import (
+	"errors"
+	"fmt"
+	"io/ioutil"
 	"net"
+	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
+	"github.com/lf-edge/eve/pkg/pillar/diskmetrics"
 	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
 )
@@ -179,6 +186,58 @@ func (status AppInstanceStatus) GetAppInterfaceList() []string {
 	return viflist
 }
 
+// SetError - Clears error state of Status
+func (statusPtr *AppInstanceStatus) SetError( //revive:disable-line
+	errStr string, source string,
+	errTime time.Time) {
+	statusPtr.Error = errStr
+	statusPtr.ErrorSource = source
+	statusPtr.ErrorTime = errTime
+}
+
+// ClearError - Clears error state of Status
+func (statusPtr *AppInstanceStatus) ClearError() { //revive:disable-line
+	statusPtr.Error = ""
+	statusPtr.ErrorSource = ""
+	statusPtr.ErrorTime = time.Time{}
+}
+
+// GetDiskSize - Returns sum of all sizes of all disks in App Instance
+func (statusPtr *AppInstanceStatus) GetDiskSize() ( //revive:disable-line
+	uint64, error) {
+	var totalSize uint64
+	for indx := range statusPtr.StorageStatusList {
+		ssPtr := &statusPtr.StorageStatusList[indx]
+		if ssPtr.IsContainer || ssPtr.ReadOnly {
+			continue
+		}
+		fileLocation, err := VerifiedImageFileLocation(ssPtr.IsContainer,
+			ssPtr.ContainerImageID, ssPtr.ImageSha256)
+		if err != nil {
+			err = fmt.Errorf("GetDiskSize: App: %s. Failed to get "+
+				"VerifiedImageFileLocation. err: %s",
+				statusPtr.UUIDandVersion.UUID.String(),
+				err.Error())
+			log.Errorf("VerifiedImageFileLocation failed: %s", err.Error())
+			return 0, err
+		}
+		imageVirtualSize, err := diskmetrics.GetDiskVirtualSize(fileLocation)
+		if err != nil {
+			errStr := fmt.Sprintf("GetDiskSize: App: %s. Failed to get "+
+				"Virtual Size. %s", statusPtr.UUIDandVersion.UUID.String(),
+				err.Error())
+			log.Errorf("GetDiskSize failed: %s", errStr)
+			return 0, errors.New(errStr)
+		}
+		if imageVirtualSize > ssPtr.Maxsizebytes {
+			totalSize += imageVirtualSize
+		} else {
+			totalSize += ssPtr.Maxsizebytes
+		}
+	}
+	return totalSize, nil
+}
+
 type EIDOverlayConfig struct {
 	Name string // From proto message
 	EIDConfigDetails
@@ -281,4 +340,54 @@ type SignatureInfo struct {
 	IntermediateCertsPem []byte
 	SignerCertPem        []byte
 	Signature            []byte
+}
+
+func locationFromDir(locationDir string) (string, error) {
+	if _, err := os.Stat(locationDir); err != nil {
+		log.Errorf("Missing directory: %s, %s\n", locationDir, err)
+		return "", err
+	}
+	// locationDir is a directory. Need to find single file inside
+	// which the verifier ensures.
+	locations, err := ioutil.ReadDir(locationDir)
+	if err != nil {
+		log.Errorln(err)
+		return "", err
+	}
+	if len(locations) != 1 {
+		log.Errorf("Multiple files in %s\n", locationDir)
+		return "", fmt.Errorf("Multiple files in %s\n",
+			locationDir)
+	}
+	if len(locations) == 0 {
+		log.Errorf("No files in %s\n", locationDir)
+		return "", fmt.Errorf("No files in %s\n",
+			locationDir)
+	}
+	return locationDir + "/" + locations[0].Name(), nil
+}
+
+// VerifiedImageFileLocation - Gives the file location for a verified image.
+func VerifiedImageFileLocation(isContainer bool, containerImageID string,
+	imageSha256 string) (string, error) {
+	var location string
+	if isContainer {
+		// Check if statusPtr.ContainerImageID has "sha512-" substring at the beginning
+		if strings.Index(containerImageID, "sha512-") != 0 {
+			err := fmt.Errorf("status.ContainerImageID should start with "+
+				" sha512-, but is %s", containerImageID)
+			return "", err
+		}
+		location = filepath.Join(PersistRktDataDir,
+			"cas", "blob", "sha512",
+			string(containerImageID[7:9]), containerImageID)
+	} else {
+		locationDir := VerifiedDirname + "/" + imageSha256
+		var err error
+		location, err = locationFromDir(locationDir)
+		if err != nil {
+			return "", err
+		}
+	}
+	return location, nil
 }


### PR DESCRIPTION
Added check for Available DiskSpace during App Instance Activate.
the total diskspace used by all apps at any point of time must be less
than a threshold ( default 80% of /persist ). The rest of the
20% is reserved for Dom0. When calculating this diskspace:
1) readonly drives are not included in the calculation.
2) Only Apps with all images downloaded and verified are taken into
account
3) Containers are not included in this calculation.

Other cleanup done:

1) Added two methods for AppInstanceStatus - SetError and ClearError.
2) Moved some routines into diskmetrics from domainmgr.