### PR TITLE
Add configItem to allow app download over LTE 

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -21,6 +21,8 @@
 | timer.port.timeout | timer in seconds | 15 | time for each http/send |
 | timer.port.testbetterinterval | timer in seconds | 0 (disabled) | test a higher prio port config |
 | network.fallback.any.eth | "enabled" or "disabled" | enabled | if no connectivity try any Ethernet, WiFi, or LTE |
+| network.allow.wwan.app.download | "enabled" or "disabled" | disabled | allow app image download over non-free ports like LTE |
+| network.allow.wwan.baseos.download | "enabled" or "disabled" | enabled | allow baseos image download over non-free ports like LTE |
 | debug.enable.usb | boolean | false | allow USB e.g. keyboards on device |
 | debug.enable.ssh | boolean, or authorized ssh key | false | allow ssh to EVE |
 | debug.default.loglevel | string | info | min level saved in files on device |

--- a/pkg/pillar/cmd/baseosmgr/baseosmgr.go
+++ b/pkg/pillar/cmd/baseosmgr/baseosmgr.go
@@ -67,6 +67,7 @@ type baseOsMgrContext struct {
 	pubZbootStatus           *pubsub.Publication
 
 	subGlobalConfig          *pubsub.Subscription
+	globalConfig             *types.GlobalConfig
 	subBaseOsConfig          *pubsub.Subscription
 	subZbootConfig           *pubsub.Subscription
 	subCertObjConfig         *pubsub.Subscription
@@ -111,7 +112,9 @@ func Run() {
 	agentlog.StillRunning(agentName)
 
 	// Context to pass around
-	ctx := baseOsMgrContext{}
+	ctx := baseOsMgrContext{
+		globalConfig: &types.GlobalConfigDefaults,
+	}
 
 	// initialize publishing handles
 	initializeSelfPublishHandles(&ctx)
@@ -436,8 +439,12 @@ func handleGlobalConfigModify(ctxArg interface{}, key string,
 		log.Infof("handleGlobalConfigModify: ignoring %s\n", key)
 		return
 	}
-	debug, _ = agentlog.HandleGlobalConfig(ctx.subGlobalConfig, agentName,
+	var gcp *types.GlobalConfig
+	debug, gcp = agentlog.HandleGlobalConfig(ctx.subGlobalConfig, agentName,
 		debugOverride)
+	if gcp != nil {
+		ctx.globalConfig = gcp
+	}
 	log.Infof("handleGlobalConfigModify done for %s\n", key)
 }
 
@@ -452,6 +459,7 @@ func handleGlobalConfigDelete(ctxArg interface{}, key string,
 	log.Infof("handleGlobalConfigDelete for %s\n", key)
 	debug, _ = agentlog.HandleGlobalConfig(ctx.subGlobalConfig, agentName,
 		debugOverride)
+	*ctx.globalConfig = types.GlobalConfigDefaults
 	log.Infof("handleGlobalConfigDelete done for %s\n", key)
 }
 

--- a/pkg/pillar/cmd/baseosmgr/handledownload.go
+++ b/pkg/pillar/cmd/baseosmgr/handledownload.go
@@ -50,14 +50,15 @@ func createDownloaderConfig(ctx *baseOsMgrContext, objType string, safename stri
 	} else {
 		log.Infof("createDownloaderConfig(%s) add\n", safename)
 		n := types.DownloaderConfig{
-			DatastoreID:      sc.DatastoreID,
-			Safename:         safename,
-			Name:             sc.Name,
-			NameIsURL:        sc.NameIsURL,
-			UseFreeMgmtPorts: false,
-			Size:             sc.Size,
-			ImageSha256:      sc.ImageSha256,
-			RefCount:         1,
+			DatastoreID: sc.DatastoreID,
+			Safename:    safename,
+			Name:        sc.Name,
+			NameIsURL:   sc.NameIsURL,
+			AllowNonFreePort: types.AllowNonFreePort(*ctx.globalConfig,
+				objType),
+			Size:        sc.Size,
+			ImageSha256: sc.ImageSha256,
+			RefCount:    1,
 		}
 		publishDownloaderConfig(ctx, objType, &n)
 	}
@@ -93,14 +94,15 @@ func updateDownloaderStatus(ctx *baseOsMgrContext,
 		log.Infof("updateDownloaderStatus adding RefCount=0 config %s\n",
 			key)
 		n := types.DownloaderConfig{
-			DatastoreID:      status.DatastoreID,
-			Safename:         status.Safename,
-			Name:             status.Name,
-			NameIsURL:        status.NameIsURL,
-			UseFreeMgmtPorts: status.UseFreeMgmtPorts,
-			Size:             status.Size,
-			ImageSha256:      status.ImageSha256,
-			RefCount:         0,
+			DatastoreID: status.DatastoreID,
+			Safename:    status.Safename,
+			Name:        status.Name,
+			NameIsURL:   status.NameIsURL,
+			AllowNonFreePort: types.AllowNonFreePort(*ctx.globalConfig,
+				objType),
+			Size:        status.Size,
+			ImageSha256: status.ImageSha256,
+			RefCount:    0,
 		}
 		publishDownloaderConfig(ctx, status.ObjType, &n)
 		return

--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -631,7 +631,7 @@ func handleCreate(ctx *downloaderContext, objType string,
 		IsContainer:      config.IsContainer,
 		RefCount:         config.RefCount,
 		LastUse:          time.Now(),
-		UseFreeMgmtPorts: config.UseFreeMgmtPorts,
+		AllowNonFreePort: config.AllowNonFreePort,
 		ImageSha256:      config.ImageSha256,
 		PendingAdd:       true,
 	}
@@ -1626,11 +1626,11 @@ func handleSyncOp(ctx *downloaderContext, key string,
 
 	locFilename = locFilename + "/" + config.Safename
 
-	log.Infof("Downloading <%s> to <%s> using %v free management port\n",
-		config.Name, locFilename, config.UseFreeMgmtPorts)
+	log.Infof("Downloading <%s> to <%s> using %v allow non-free port\n",
+		config.Name, locFilename, config.AllowNonFreePort)
 
 	var addrCount int
-	if config.UseFreeMgmtPorts {
+	if !config.AllowNonFreePort {
 		addrCount = types.CountLocalAddrFreeNoLinkLocal(ctx.deviceNetworkStatus)
 		log.Infof("Have %d free management port addresses\n", addrCount)
 		err = errors.New("No free IP management port addresses for download")
@@ -1651,7 +1651,7 @@ func handleSyncOp(ctx *downloaderContext, key string,
 	// Loop through all interfaces until a success
 	for addrIndex := 0; addrIndex < addrCount; addrIndex += 1 {
 		var ipSrc net.IP
-		if config.UseFreeMgmtPorts {
+		if !config.AllowNonFreePort {
 			ipSrc, err = types.GetLocalAddrFreeNoLinkLocal(ctx.deviceNetworkStatus,
 				addrIndex, "")
 		} else {

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -1731,6 +1731,24 @@ func parseConfigItems(config *zconfig.EdgeDevConfig, ctx *getconfigContext) {
 			}
 			newGlobalConfig.DomainBootRetryTime = uint32(i64)
 
+		case "network.allow.wwan.app.download":
+			newTs, err := types.ParseTriState(item.Value)
+			if err != nil {
+				log.Errorf("parseConfigItems: bad tristate value %s for %s: %s\n",
+					item.Value, key, err)
+				continue
+			}
+			newGlobalConfig.AllowNonFreeAppImages = newTs
+
+		case "network.allow.wwan.baseos.download":
+			newTs, err := types.ParseTriState(item.Value)
+			if err != nil {
+				log.Errorf("parseConfigItems: bad tristate value %s for %s: %s\n",
+					item.Value, key, err)
+				continue
+			}
+			newGlobalConfig.AllowNonFreeBaseImages = newTs
+
 		case "debug.default.loglevel":
 			newGlobalConfig.DefaultLogLevel = item.Value
 

--- a/pkg/pillar/cmd/zedmanager/handledownloader.go
+++ b/pkg/pillar/cmd/zedmanager/handledownloader.go
@@ -25,15 +25,16 @@ func AddOrRefcountDownloaderConfig(ctx *zedmanagerContext, safename string,
 		log.Debugf("AddOrRefcountDownloaderConfig: add for %s\n",
 			safename)
 		n := types.DownloaderConfig{
-			DatastoreID:      ss.DatastoreID,
-			Safename:         safename,
-			Name:             ss.Name,
-			NameIsURL:        ss.NameIsURL,
-			IsContainer:      ss.IsContainer,
-			UseFreeMgmtPorts: true,
-			Size:             ss.Size,
-			ImageSha256:      ss.ImageSha256,
-			RefCount:         1,
+			DatastoreID: ss.DatastoreID,
+			Safename:    safename,
+			Name:        ss.Name,
+			NameIsURL:   ss.NameIsURL,
+			IsContainer: ss.IsContainer,
+			AllowNonFreePort: types.AllowNonFreePort(*ctx.globalConfig,
+				appImgObj),
+			Size:        ss.Size,
+			ImageSha256: ss.ImageSha256,
+			RefCount:    1,
 		}
 		log.Infof("AddOrRefcountDownloaderConfig: DownloaderConfig: %+v\n", n)
 		publishDownloaderConfig(ctx, &n)
@@ -104,15 +105,16 @@ func handleDownloaderStatusModify(ctxArg interface{}, key string,
 		log.Infof("handleDownloaderStatusModify adding RefCount=0 config %s\n",
 			key)
 		n := types.DownloaderConfig{
-			DatastoreID:      status.DatastoreID,
-			Safename:         status.Safename,
-			Name:             status.Name,
-			NameIsURL:        status.NameIsURL,
-			IsContainer:      status.IsContainer,
-			UseFreeMgmtPorts: status.UseFreeMgmtPorts,
-			Size:             status.Size,
-			ImageSha256:      status.ImageSha256,
-			RefCount:         0,
+			DatastoreID: status.DatastoreID,
+			Safename:    status.Safename,
+			Name:        status.Name,
+			NameIsURL:   status.NameIsURL,
+			IsContainer: status.IsContainer,
+			AllowNonFreePort: types.AllowNonFreePort(*ctx.globalConfig,
+				appImgObj),
+			Size:        status.Size,
+			ImageSha256: status.ImageSha256,
+			RefCount:    0,
 		}
 		publishDownloaderConfig(ctx, &n)
 		return

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -53,6 +53,7 @@ type zedmanagerContext struct {
 	pubAppImgVerifierConfig *pubsub.Publication
 	subAppImgVerifierStatus *pubsub.Subscription
 	subGlobalConfig         *pubsub.Subscription
+	globalConfig            *types.GlobalConfig
 	pubUuidToNum            *pubsub.Publication
 }
 
@@ -94,8 +95,9 @@ func Run() {
 	agentlog.StillRunning(agentName)
 
 	// Any state needed by handler functions
-	ctx := zedmanagerContext{}
-
+	ctx := zedmanagerContext{
+		globalConfig: &types.GlobalConfigDefaults,
+	}
 	// Create publish before subscribing and activating subscriptions
 	pubAppInstanceStatus, err := pubsub.Publish(agentName,
 		types.AppInstanceStatus{})
@@ -765,8 +767,12 @@ func handleGlobalConfigModify(ctxArg interface{}, key string,
 		return
 	}
 	log.Infof("handleGlobalConfigModify for %s\n", key)
-	debug, _ = agentlog.HandleGlobalConfig(ctx.subGlobalConfig, agentName,
+	var gcp *types.GlobalConfig
+	debug, gcp = agentlog.HandleGlobalConfig(ctx.subGlobalConfig, agentName,
 		debugOverride)
+	if gcp != nil {
+		ctx.globalConfig = gcp
+	}
 	log.Infof("handleGlobalConfigModify done for %s\n", key)
 }
 
@@ -781,5 +787,6 @@ func handleGlobalConfigDelete(ctxArg interface{}, key string,
 	log.Infof("handleGlobalConfigDelete for %s\n", key)
 	debug, _ = agentlog.HandleGlobalConfig(ctx.subGlobalConfig, agentName,
 		debugOverride)
+	*ctx.globalConfig = types.GlobalConfigDefaults
 	log.Infof("handleGlobalConfigDelete done for %s\n", key)
 }

--- a/pkg/pillar/types/downloadertypes.go
+++ b/pkg/pillar/types/downloadertypes.go
@@ -32,7 +32,7 @@ type DownloaderConfig struct {
 	Name             string
 	NameIsURL        bool // If not we form URL based on datastore info
 	IsContainer      bool
-	UseFreeMgmtPorts bool
+	AllowNonFreePort bool
 	Size             uint64 // In bytes
 	ImageSha256      string // sha256 of immutable image
 	FinalObjDir      string // final Object Store
@@ -75,7 +75,7 @@ type DownloaderStatus struct {
 	LastUse          time.Time // When RefCount dropped to zero
 	Expired          bool      // Handshake to client
 	NameIsURL        bool      // If not we form URL based on datastore info
-	UseFreeMgmtPorts bool
+	AllowNonFreePort bool
 	ImageSha256      string // sha256 of immutable image
 	ContainerImageID string
 	State            SwState // DOWNLOADED etc
@@ -137,4 +137,29 @@ type DatastoreContext struct {
 	APIKey          string
 	Password        string
 	Region          string
+}
+
+const (
+	appImgObj = "appImg.obj"
+	baseOsObj = "baseOs.obj"
+	certObj   = "cert.obj"
+)
+
+// AllowNonFreePort looks at GlobalConfig to determine which policy
+// to apply for the download of the object.
+func AllowNonFreePort(gc GlobalConfig, objType string) bool {
+
+	switch objType {
+	case appImgObj:
+		return gc.AllowNonFreeAppImages == TS_ENABLED
+	case baseOsObj:
+		return gc.AllowNonFreeBaseImages == TS_ENABLED
+	case certObj:
+		return (gc.AllowNonFreeBaseImages == TS_ENABLED) ||
+			(gc.AllowNonFreeAppImages == TS_ENABLED)
+	default:
+		log.Fatalf("AllowNonFreePort: Unknown ObjType %s\n",
+			objType)
+		return false
+	}
 }

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -66,11 +66,19 @@ type GlobalConfig struct {
 	SshAccess         bool
 	SshAuthorizedKeys string
 
-	AllowAppVnc           bool
+	AllowAppVnc bool
+
+	// Normally the EVE microservices as well as baseos images downloads
+	// will use free and non-free (e.g., WWAN) ports, while app images will
+	// only download using the free ports. These globals can change that behavior:
+	AllowNonFreeAppImages  TriState // For app images
+	AllowNonFreeBaseImages TriState // For baseos images
+
+	// XXX add max space for downloads?
+	// XXX add max space for running images?
+
 	DefaultLogLevel       string
 	DefaultRemoteLogLevel string
-	// XXX add max space for downloads?
-	// XXX add LTE management port usage policy?
 
 	// Per agent settings of log levels; if set for an agent it
 	// overrides the Default*Level above
@@ -109,14 +117,18 @@ var GlobalConfigDefaults = GlobalConfig{
 
 	NetworkSendTimeout: 120,
 
-	UsbAccess:             true, // Contoller likely to default to false
-	SshAccess:             true, // Contoller likely to default to false
-	SshAuthorizedKeys:     "",
-	StaleConfigTime:       600,    // Use stale config for up to 10 minutes
-	DownloadGCTime:        600,    // 10 minutes
-	VdiskGCTime:           3600,   // 1 hour
-	DownloadRetryTime:     600,    // 10 minutes
-	DomainBootRetryTime:   600,    // 10 minutes
+	UsbAccess:           true, // Contoller likely to default to false
+	SshAccess:           true, // Contoller likely to default to false
+	SshAuthorizedKeys:   "",
+	StaleConfigTime:     600,  // Use stale config for up to 10 minutes
+	DownloadGCTime:      600,  // 10 minutes
+	VdiskGCTime:         3600, // 1 hour
+	DownloadRetryTime:   600,  // 10 minutes
+	DomainBootRetryTime: 600,  // 10 minutes
+
+	AllowNonFreeAppImages:  TS_DISABLED,
+	AllowNonFreeBaseImages: TS_ENABLED,
+
 	DefaultLogLevel:       "info", // XXX Should we change to warning?
 	DefaultRemoteLogLevel: "info", // XXX Should we change to warning?
 }
@@ -183,6 +195,12 @@ func ApplyGlobalConfig(newgc GlobalConfig) GlobalConfig {
 	}
 	if newgc.DefaultRemoteLogLevel == "" {
 		newgc.DefaultRemoteLogLevel = GlobalConfigDefaults.DefaultRemoteLogLevel
+	}
+	if newgc.AllowNonFreeAppImages == TS_NONE {
+		newgc.AllowNonFreeAppImages = GlobalConfigDefaults.AllowNonFreeAppImages
+	}
+	if newgc.AllowNonFreeBaseImages == TS_NONE {
+		newgc.AllowNonFreeBaseImages = GlobalConfigDefaults.AllowNonFreeBaseImages
 	}
 	return newgc
 }


### PR DESCRIPTION
To be able to test complete network failover from a free to a non-free management interface we need to have a way to perform fallback app image download over the non-free interface.
(We can already use LTE by marking it as free=true, but that doesn't allow us to test the failover.)

Note that later we will need a way to adjust the policy and priority for management port usable with more flexibility. That is outlined in https://wiki.lfedge.org/display/EVE/ECO+connectivity+failover+and+improved+policy+control
It will presumably include new device APIs etc.
So this is a short-term removal of the hard-coded policy we have today for handling free vs. non-free.