### PR TITLE
Fix Container App Launch

### DIFF
--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -270,7 +270,7 @@ func (ss *StorageStatus) UpdateFromStorageConfig(sc StorageConfig) {
 	ss.Maxsizebytes = sc.Maxsizebytes
 	ss.Devtype = sc.Devtype
 	ss.Target = sc.Target
-	if ss.Format == "8" {
+	if ss.Format == "container" {
 		ss.IsContainer = true
 	}
 	return


### PR DESCRIPTION
Launching a Container App has been broken for some time.
Identifcation of a Container App has changed, resulting in the App being flagged as Non Container and the subsequent Download Issues

Signed-off-by: Sankar Patchineelam <sankar@zededa.com>