### PR TITLE
Erraneous configuration should not result in termination of a micro service

### DIFF
--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -1783,7 +1783,7 @@ func handleSyncOp(ctx *downloaderContext, key string,
 				return
 			}
 		default:
-			log.Fatal("unsupported transport method")
+			errStr = "unsupported transport method " + dsCtx.TransportMethod
 		}
 	}
 	log.Errorf("All source IP addresses failed. All errors:%s\n", errStr)


### PR DESCRIPTION
When controller inputs erraneous configuration, the downloader shouldn't terminate but return back the error to controller.

Signed-off-by: Sankar Patchineelam <sankar@zededa.com>