### PR TITLE
guard against zero ruleID from controller

### DIFF
--- a/pkg/pillar/cmd/zedrouter/acl.go
+++ b/pkg/pillar/cmd/zedrouter/acl.go
@@ -561,6 +561,13 @@ func aceToRules(aclArgs types.AppNetworkACLArgs, ace types.ACE) (types.IPTablesR
 	error) {
 	var rulesList types.IPTablesRuleList
 
+	// Sanity check for old/incorrect controller
+	if ace.RuleID == 0 {
+		errStr := fmt.Sprintf("ACE with zero RuleID not supported: %+v",
+			ace)
+		log.Errorln(errStr)
+		return nil, errors.New(errStr)
+	}
 	// Extract lport and protocol from the Matches to use for PortMap
 	// Keep others to make sure we put the protocol before the port
 	// number(s)


### PR DESCRIPTION
Just as a safety for controllers using old APIs or not filling it in, since a zero ruleID results in a mark which can cause packet drops even for EVE control-plane traffic.