### PR TITLE
When all_proxy set, use git proxy to build xen-tools

### DIFF
--- a/pkg/xen-tools/Dockerfile
+++ b/pkg/xen-tools/Dockerfile
@@ -1,4 +1,5 @@
 FROM alpine:3.8 as kernel-build
+ENV GIT_HTTP=y
 # hadolint ignore=DL3018
 RUN apk add --no-cache \
     gcc make libc-dev dev86 xz-dev perl bash python-dev \


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

When `all_proxy` is set, use a git proxy for building `pkg/xen-tools`.

Fixes #150 

Please test @jren1

cc @rvs 