### PR TITLE
track oldDPC to determine differences

### DIFF
--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -294,6 +294,7 @@ func VerifyPending(pending *DPCPending,
 		log.Infof("VerifyPending: DPC changed. update DhcpClient.\n")
 		if UpdateDhcpClient(pending.PendDPC, pending.OldDPC) {
 			log.Warnf("VerifyPending: update DhcpClient: retry")
+			pending.OldDPC = pending.PendDPC
 			return DPC_WAIT
 		}
 		pending.OldDPC = pending.PendDPC


### PR DESCRIPTION
@gopi I created a separate branch with just your fix. But I think we need to update oldDPC in both cases the retry and not retry cases.