### PR TITLE
Issue with images used when multiple containers are launched

### DIFF
--- a/pkg/pillar/cmd/zedmanager/handleverifier.go
+++ b/pkg/pillar/cmd/zedmanager/handleverifier.go
@@ -202,6 +202,10 @@ func lookupVerifyImageStatus(ctx *zedmanagerContext,
 func lookupVerifyImageStatusSha256(ctx *zedmanagerContext,
 	sha256 string) *types.VerifyImageStatus {
 
+	if sha256 == "" {
+		log.Debugf("lookupVerifyImageStatusSha256: sha256 is empty\n")
+		return nil
+	}
 	sub := ctx.subAppImgVerifierStatus
 	items := sub.GetAll()
 	for _, st := range items {


### PR DESCRIPTION
When multiple containers with different images are launched, the first one downloads the expected image, but the subsequent containers use the 1st downloaded image, even though the ask is different.

This has to do with ImageSha256 field not being populated for container Apps.

Signed-off-by: Sankar Patchineelam <sankar@zededa.com>