### PR TITLE
avoid dhcp release/request churn due to nil != ""

### DIFF
--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -716,9 +716,11 @@ func parseSystemAdapterConfig(config *zconfig.EdgeDevConfig,
 				continue
 			}
 			network := cast.CastNetworkXObjectConfig(networkXObject)
-			addrSubnet := network.Subnet
-			addrSubnet.IP = ip
-			port.AddrSubnet = addrSubnet.String()
+			if ip != nil {
+				addrSubnet := network.Subnet
+				addrSubnet.IP = ip
+				port.AddrSubnet = addrSubnet.String()
+			}
 
 			port.Gateway = network.Gateway
 			port.DomainName = network.DomainName


### PR DESCRIPTION
The \"nil\" string in AddrSubnet caused UpdateDhcpClient to determine there was a diff when the device connected to zedcloud, which resulted in releasing the DHCP lease and later reacquiring it.