### PR TITLE
run zedagent publish of device info in a separate go routine 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,8 +192,8 @@ $(CONFIG_IMG): conf/server conf/onboard.cert.pem conf/wpa_supplicant.conf conf/a
 
 $(ROOTFS_IMG): images/rootfs.yml | $(DIST)
 	./tools/makerootfs.sh $< $(ROOTFS_FORMAT) $@
-	@[ $$(wc -c < "$@") -gt $$(( 250 * 1024 * 1024 )) ] && \
-          echo "ERROR: size of $@ is greater than 250MB (bigger than allocated partition)" && exit 1 || :
+	@[ $$(wc -c < "$@") -gt $$(( 260 * 1024 * 1024 )) ] && \
+          echo "ERROR: size of $@ is greater than 260MB (bigger than allocated partition)" && exit 1 || :
 
 $(LIVE_IMG).img: $(LIVE_IMG).$(IMG_FORMAT) | $(DIST)
 	@rm -f $@ >/dev/null 2>&1 || :

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -283,7 +283,7 @@ func getLatestConfig(url string, iteration int, updateInprogress bool,
 			ctx.remainingTestTime = 0
 		}
 		// Send updated remainingTestTime to zedcloud
-		ctx.TriggerDeviceInfo = true
+		triggerPublishDevInfo(ctx)
 	}
 
 	if err := validateConfigMessage(url, resp); err != nil {
@@ -453,7 +453,7 @@ func inhaleDeviceConfig(config *zconfig.EdgeDevConfig, getconfigCtx *getconfigCo
 					zcdevUUID.String(), id.String())
 				zcdevUUID = id
 				ctx := getconfigCtx.zedagentCtx
-				ctx.TriggerDeviceInfo = true
+				triggerPublishDevInfo(ctx)
 			}
 
 		}

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -90,7 +90,7 @@ type zedagentContext struct {
 	iteration                 int
 	subNetworkInstanceStatus  *pubsub.Subscription
 	subCertObjConfig          *pubsub.Subscription
-	TriggerDeviceInfo         bool
+	TriggerDeviceInfo         chan<- struct{}
 	subBaseOsStatus           *pubsub.Subscription
 	subBaseOsDownloadStatus   *pubsub.Subscription
 	subCertObjDownloadStatus  *pubsub.Subscription
@@ -169,7 +169,8 @@ func Run() {
 
 	log.Infof("Starting %s\n", agentName)
 
-	zedagentCtx := zedagentContext{}
+	triggerDeviceInfo := make(chan struct{})
+	zedagentCtx := zedagentContext{TriggerDeviceInfo: triggerDeviceInfo}
 	zedagentCtx.physicalIoAdapterMap = make(map[string]types.PhysicalIOAdapter)
 
 	// If we have a reboot reason from this or the other partition
@@ -233,6 +234,7 @@ func Run() {
 	agentlog.StillRunning(agentName)
 	agentlog.StillRunning(agentName + "config")
 	agentlog.StillRunning(agentName + "metrics")
+	agentlog.StillRunning(agentName + "devinfo")
 
 	// Tell ourselves to go ahead
 	// initialize the module specifig stuff
@@ -643,8 +645,12 @@ func Run() {
 		log.Fatal(err)
 	}
 
+	// Use a go routine to make sure we have wait/timeout without
+	// blocking the main select loop
+	go deviceInfoTask(&zedagentCtx, triggerDeviceInfo)
+
 	// Publish initial device info.
-	publishDevInfo(&zedagentCtx)
+	triggerPublishDevInfo(&zedagentCtx)
 
 	// start the metrics reporting task
 	handleChannel := make(chan interface{})
@@ -697,7 +703,7 @@ func Run() {
 			if DNSctx.triggerDeviceInfo {
 				// IP/DNS in device info could have changed
 				log.Infof("NetworkStatus triggered PublishDeviceInfo\n")
-				publishDevInfo(&zedagentCtx)
+				triggerPublishDevInfo(&zedagentCtx)
 				DNSctx.triggerDeviceInfo = false
 			}
 			agentlog.CheckMaxTime(agentName, start)
@@ -718,22 +724,9 @@ func Run() {
 			agentlog.CheckMaxTime(agentName, start)
 		case <-stillRunning.C:
 		}
-		// XXX verifierRestarted can take 5 minutes??
 		agentlog.StillRunning(agentName)
 		// Need to tickle this since the configTimerTask is not yet started
 		agentlog.StillRunning(agentName + "config")
-		// UsedByUUID, baseos subStatus, DevicePortConfigList etc
-		if zedagentCtx.TriggerDeviceInfo {
-			log.Infof("triggered PublishDeviceInfo\n")
-			start := agentlog.StartTime()
-			publishDevInfo(&zedagentCtx)
-			zedagentCtx.TriggerDeviceInfo = false
-			agentlog.CheckMaxTime(agentName, start)
-			agentlog.StillRunning(agentName)
-			// Need to tickle this since the configTimerTask is not
-			// yet started
-			agentlog.StillRunning(agentName + "config")
-		}
 	}
 
 	// start the config fetch tasks, when zboot status is ready
@@ -800,11 +793,8 @@ func Run() {
 			if DNSctx.triggerDeviceInfo {
 				// IP/DNS in device info could have changed
 				log.Infof("NetworkStatus triggered PublishDeviceInfo\n")
-				start := agentlog.StartTime()
-				publishDevInfo(&zedagentCtx)
+				triggerPublishDevInfo(&zedagentCtx)
 				DNSctx.triggerDeviceInfo = false
-				agentlog.CheckMaxTime(agentName, start)
-				agentlog.StillRunning(agentName)
 			}
 
 		case change := <-subAssignableAdapters.C:
@@ -889,21 +879,38 @@ func Run() {
 		case <-stillRunning.C:
 		}
 		agentlog.StillRunning(agentName)
-		// UsedByUUID, baseos subStatus, DevicePortConfigList etc
-		if zedagentCtx.TriggerDeviceInfo {
-			log.Infof("triggered PublishDeviceInfo\n")
-			start := agentlog.StartTime()
-			publishDevInfo(&zedagentCtx)
-			zedagentCtx.TriggerDeviceInfo = false
-			agentlog.CheckMaxTime(agentName, start)
-			agentlog.StillRunning(agentName)
-		}
 	}
 }
 
-func publishDevInfo(ctx *zedagentContext) {
-	PublishDeviceInfoToZedCloud(ctx)
-	ctx.iteration += 1
+func triggerPublishDevInfo(ctxPtr *zedagentContext) {
+
+	log.Info("Triggered PublishDeviceInfo")
+	select {
+	case ctxPtr.TriggerDeviceInfo <- struct{}{}:
+		// Do nothing more
+	default:
+		log.Info("Failed to send on PublishDeviceInfo")
+	}
+}
+
+func deviceInfoTask(ctxPtr *zedagentContext, triggerDeviceInfo <-chan struct{}) {
+
+	// Run a periodic timer so we always update StillRunning
+	stillRunning := time.NewTicker(25 * time.Second)
+	for {
+		select {
+		case <-triggerDeviceInfo:
+			start := agentlog.StartTime()
+			log.Info("deviceInfoTask got message")
+
+			PublishDeviceInfoToZedCloud(ctxPtr)
+			ctxPtr.iteration++
+			log.Info("deviceInfoTask done with message")
+			agentlog.CheckMaxTime(agentName+"config", start)
+		case <-stillRunning.C:
+		}
+		agentlog.StillRunning(agentName + "devinfo")
+	}
 }
 
 func handleVerifierRestarted(ctxArg interface{}, done bool) {
@@ -995,7 +1002,7 @@ func handleAppInstanceStatusModify(ctxArg interface{}, key string,
 	uuidStr := status.Key()
 	PublishAppInfoToZedCloud(ctx, uuidStr, &status, ctx.assignableAdapters,
 		ctx.iteration)
-	ctx.iteration += 1
+	ctx.iteration++
 }
 
 func handleAppInstanceStatusDelete(ctxArg interface{}, key string,
@@ -1005,7 +1012,7 @@ func handleAppInstanceStatusDelete(ctxArg interface{}, key string,
 	uuidStr := key
 	PublishAppInfoToZedCloud(ctx, uuidStr, nil, ctx.assignableAdapters,
 		ctx.iteration)
-	ctx.iteration += 1
+	ctx.iteration++
 }
 
 func lookupAppInstanceStatus(ctx *zedagentContext, key string) *types.AppInstanceStatus {
@@ -1089,7 +1096,7 @@ func handleDPCLModify(ctxArg interface{}, key string, statusArg interface{}) {
 	log.Infof("handleDPCLModify: changed %v",
 		cmp.Diff(ctx.devicePortConfigList, status))
 	ctx.devicePortConfigList = status
-	ctx.TriggerDeviceInfo = true
+	triggerPublishDevInfo(ctx)
 }
 
 func handleDPCLDelete(ctxArg interface{}, key string, statusArg interface{}) {
@@ -1101,7 +1108,7 @@ func handleDPCLDelete(ctxArg interface{}, key string, statusArg interface{}) {
 	}
 	log.Infof("handleDPCLDelete for %s\n", key)
 	ctx.devicePortConfigList = types.DevicePortConfigList{}
-	ctx.TriggerDeviceInfo = true
+	triggerPublishDevInfo(ctx)
 }
 
 // base os status event handlers
@@ -1115,7 +1122,7 @@ func handleBaseOsStatusModify(ctxArg interface{}, key string, statusArg interfac
 		return
 	}
 	doBaseOsDeviceReboot(ctx, status)
-	publishDevInfo(ctx)
+	triggerPublishDevInfo(ctx)
 	log.Infof("handleBaseOsStatusModify(%s) done\n", key)
 }
 
@@ -1124,7 +1131,7 @@ func handleBaseOsStatusDelete(ctxArg interface{}, key string,
 
 	log.Infof("handleBaseOsStatusDelete(%s)\n", key)
 	ctx := ctxArg.(*zedagentContext)
-	publishDevInfo(ctx)
+	triggerPublishDevInfo(ctx)
 	log.Infof("handleBaseOsStatusDelete(%s) done\n", key)
 }
 
@@ -1183,7 +1190,7 @@ func handleAAModify(ctxArg interface{}, key string,
 	}
 	log.Infof("handleAAModify() %+v\n", status)
 	*ctx.assignableAdapters = status
-	ctx.TriggerDeviceInfo = true
+	triggerPublishDevInfo(ctx)
 	log.Infof("handleAAModify() done\n")
 }
 
@@ -1197,7 +1204,7 @@ func handleAADelete(ctxArg interface{}, key string,
 	}
 	log.Infof("handleAADelete()\n")
 	ctx.assignableAdapters.Initialized = false
-	ctx.TriggerDeviceInfo = true
+	triggerPublishDevInfo(ctx)
 	log.Infof("handleAADelete() done\n")
 }
 
@@ -1212,7 +1219,7 @@ func handleZbootStatusModify(ctxArg interface{}, key string,
 	}
 	log.Infof("handleZbootStatusModify: for %s\n", key)
 	doZbootTestComplete(ctx, status)
-	publishDevInfo(ctx)
+	triggerPublishDevInfo(ctx)
 }
 
 func handleZbootStatusDelete(ctxArg interface{}, key string,

--- a/pkg/pillar/go.mod
+++ b/pkg/pillar/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	contrib.go.opencensus.io/exporter/ocagent v0.4.11 // indirect
+	git.apache.org/thrift.git v0.12.0 // indirect
 	github.com/Azure/azure-sdk-for-go v11.3.0-beta+incompatible
 	github.com/Azure/go-autorest v11.7.0+incompatible // indirect
 	github.com/VictorLowther/godmi v0.0.0-20190311134151-270258a8252d // indirect
@@ -42,7 +43,6 @@ require (
 	google.golang.org/api v0.3.2 // indirect
 	google.golang.org/genproto v0.0.0-20190404172233-64821d5d2107 // indirect
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
-        git.apache.org/thrift.git v0.12.0 // indirect
 )
 
 replace github.com/lf-edge/eve/api/go => ../../api/go

--- a/pkg/pillar/go.sum
+++ b/pkg/pillar/go.sum
@@ -56,6 +56,8 @@ github.com/eriknordmark/netlink v0.0.0-20190909223052-1f4a41dfab61 h1:xfymSdH08Q
 github.com/eriknordmark/netlink v0.0.0-20190909223052-1f4a41dfab61/go.mod h1:soOZqKlU/iJvZpZ7sm+okQFBzrlpol0IIQr+gWeZS0k=
 github.com/eriknordmark/netlink v0.0.0-20190909231655-fd5b380483db h1:rURpPLaYdPoU/yaMFeZu/EhM/WISptw4EcPX9BCb6iA=
 github.com/eriknordmark/netlink v0.0.0-20190909231655-fd5b380483db/go.mod h1:soOZqKlU/iJvZpZ7sm+okQFBzrlpol0IIQr+gWeZS0k=
+github.com/eriknordmark/netlink v0.0.0-20190912172510-3b6b45309321 h1:kOrNhuMnLwmM2pyHXX0WLOWYOOQLoQVr2orjrWZq7t0=
+github.com/eriknordmark/netlink v0.0.0-20190912172510-3b6b45309321/go.mod h1:soOZqKlU/iJvZpZ7sm+okQFBzrlpol0IIQr+gWeZS0k=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -120,6 +120,8 @@ file = /var/run/${AGENT}config.touch
 change = 300
 file = /var/run/${AGENT}metrics.touch
 change = 300
+file = /var/run/${AGENT}devinfo.touch
+change = 300
 EOF
     fi
 done

--- a/pkg/pillar/scripts/watchdog-report.sh
+++ b/pkg/pillar/scripts/watchdog-report.sh
@@ -21,7 +21,7 @@ if [ $# -ge 2 ]; then
     agent=$(echo "$2" | grep '/var/run/.*\.touch' | sed 's,/var/run/\(.*\)\.touch,\1,')
     if [ -n "$agent" ]; then
         # Map the various zedagent* to zedagent
-        if [ "$agent" = "zedagentmetrics" ] -o [ "$agent" = "zedagentconfig" ]; then
+        if [ "$agent" = "zedagentmetrics" ] -o [ "$agent" = "zedagentconfig" ] -o [ "$agent" = "zedagentdevinfo" ]; then
             agent="zedagent"
         fi
         echo "pkill -USR1 /opt/zededa/bin/$agent"


### PR DESCRIPTION
This is to avoid additional delays on boot when there are connectivity failures, since the golang select loop might end up serving multiple cases of triggered device info until it services the fact that DeviceNetworkStatus or verifier has been updated.

@naiming-zededa for some reason I can't pick you as a code reviewer