### PR TITLE
DNS failover for uplink ports

### DIFF
--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -688,7 +688,8 @@ func tryLookupIP(ctx *diagContext, ifname string) bool {
 			d := net.Dialer{LocalAddr: &localUDPAddr}
 			return d.Dial(network, address)
 		}
-		r := net.Resolver{Dial: resolverDial}
+		r := net.Resolver{Dial: resolverDial, PreferGo: true,
+			StrictErrors: false}
 		ips, err := r.LookupIPAddr(context.Background(), ctx.serverName)
 		if err != nil {
 			fmt.Printf("ERROR: %s: DNS lookup of %s failed: %s\n",

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -577,7 +577,7 @@ func handleDomainCreate(ctxArg interface{}, key string, configArg interface{}) {
 	if ok {
 		log.Fatalf("handleDomainCreate called on config that already exists")
 	}
-	h1 := make(chan interface{})
+	h1 := make(chan interface{}, 1)
 	handlerMap[config.Key()] = h1
 	go runHandler(ctx, key, h1)
 	h = h1

--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -505,7 +505,7 @@ func handleDownloaderCreate(ctxArg interface{}, objType string,
 	if ok {
 		log.Fatalf("handleDownloaderCreate called on config that already exists")
 	}
-	h1 := make(chan interface{})
+	h1 := make(chan interface{}, 1)
 	handlerMap[config.Key()] = h1
 	go runHandler(ctx, objType, key, h1)
 	h = h1

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -741,6 +741,7 @@ func publishDeviceNetworkStatus(ctx *nimContext) {
 	log.Infof("PublishDeviceNetworkStatus: %+v\n",
 		ctx.DeviceNetworkStatus)
 	devicenetwork.UpdateResolvConf(*ctx.DeviceNetworkStatus)
+	devicenetwork.UpdatePBR(*ctx.DeviceNetworkStatus)
 	ctx.DeviceNetworkStatus.Testing = false
 	ctx.PubDeviceNetworkStatus.Publish("global", ctx.DeviceNetworkStatus)
 }

--- a/pkg/pillar/cmd/verifier/verifier.go
+++ b/pkg/pillar/cmd/verifier/verifier.go
@@ -693,7 +693,7 @@ func handleVerifyImageCreate(ctxArg interface{}, objType string,
 	if ok {
 		log.Fatalf("handleVerifyImageCreate called on config that already exists")
 	}
-	h1 := make(chan interface{})
+	h1 := make(chan interface{}, 1)
 	handlerMap[config.Key()] = h1
 	go runHandler(ctx, objType, key, h1)
 	h = h1

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -169,7 +169,7 @@ func Run() {
 
 	log.Infof("Starting %s\n", agentName)
 
-	triggerDeviceInfo := make(chan struct{})
+	triggerDeviceInfo := make(chan struct{}, 1)
 	zedagentCtx := zedagentContext{TriggerDeviceInfo: triggerDeviceInfo}
 	zedagentCtx.physicalIoAdapterMap = make(map[string]types.PhysicalIOAdapter)
 

--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -1480,12 +1480,6 @@ func natActivate(ctx *zedrouterContext,
 			return err
 		}
 	}
-	// Add to Pbr table
-	err := PbrNATAdd(subnetStr)
-	if err != nil {
-		log.Errorf("PbrNATAdd failed for port %s - err = %s\n", status.Port, err)
-		return err
-	}
 	return nil
 }
 
@@ -1539,11 +1533,6 @@ func natInactivate(ctx *zedrouterContext,
 		if err != nil {
 			log.Errorf("natInactivate: PbrRouteDeleteAll failed %s\n", err)
 		}
-	}
-	// Remove from Pbr table
-	err := PbrNATDel(subnetStr)
-	if err != nil {
-		log.Errorf("natInactivate: PbrNATDel failed %s\n", err)
 	}
 }
 

--- a/pkg/pillar/cmd/zedrouter/pbr.go
+++ b/pkg/pillar/cmd/zedrouter/pbr.go
@@ -1,8 +1,8 @@
 // Copyright (c) 2017 Zededa, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Create ip rules and ip routing tables for each ifindex and also a free
-// one for the collection of free management ports.
+// Create ip rules and ip routing tables for each ifindex for the bridges used
+// for network instances.
 
 package zedrouter
 
@@ -18,23 +18,18 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var FreeTable = 500 // Need a FreeMgmtPort policy for NAT+underlay
+var baseTableIndex = 500 // Number tables from here + ifindex
 
 // Call before setting up routeChanges, addrChanges, and linkChanges
 func PbrInit(ctx *zedrouterContext) {
 
 	log.Debugf("PbrInit()\n")
-
-	setFreeMgmtPorts(types.GetMgmtPortsFree(*ctx.deviceNetworkStatus, 0))
-
-	flushRoutesTable(FreeTable, 0)
-
-	// flush any old rules using RuleList
-	flushRules(0)
 }
 
 // PbrRouteAddAll adds all the routes for the bridgeName table to the specific port
 // Separately we handle changes in PbrRouteChange
+// XXX used by networkinstance only
+// XXX Can't we use MoveRoutesTable?
 func PbrRouteAddAll(bridgeName string, port string) error {
 	log.Infof("PbrRouteAddAll(%s, %s)\n", bridgeName, port)
 
@@ -79,7 +74,7 @@ func PbrRouteAddAll(bridgeName string, port string) error {
 			ifindex, index)
 		ifindex = index
 	}
-	MyTable := FreeTable + ifindex
+	MyTable := baseTableIndex + ifindex
 	for _, rt := range routes {
 		myrt := rt
 		myrt.Table = MyTable
@@ -101,6 +96,8 @@ func PbrRouteAddAll(bridgeName string, port string) error {
 
 // PbrRouteDeleteAll deletes all the routes for the bridgeName table to the specific port
 // Separately we handle changes in PbrRouteChange
+// XXX used by networkinstance only
+// XXX can't we flush the table?
 func PbrRouteDeleteAll(bridgeName string, port string) error {
 	log.Infof("PbrRouteDeleteAll(%s, %s)\n", bridgeName, port)
 
@@ -131,7 +128,7 @@ func PbrRouteDeleteAll(bridgeName string, port string) error {
 		log.Errorln(errStr)
 		return errors.New(errStr)
 	}
-	MyTable := FreeTable + ifindex
+	MyTable := baseTableIndex + ifindex
 	for _, rt := range routes {
 		myrt := rt
 		myrt.Table = MyTable
@@ -151,41 +148,6 @@ func PbrRouteDeleteAll(bridgeName string, port string) error {
 	return nil
 }
 
-// XXX The PbrNAT functions are no-ops for now.
-// The prefix for the NAT linux bridge interface is in its own pbr table
-// XXX put the default route(s) for the selected Adapter for the service
-// into the table for the bridge to avoid using other ports.
-func PbrNATAdd(prefix string) error {
-
-	log.Debugf("PbrNATAdd(%s)\n", prefix)
-	return nil
-}
-
-// XXX The PbrNAT functions are no-ops for now.
-func PbrNATDel(prefix string) error {
-
-	log.Debugf("PbrNATDel(%s)\n", prefix)
-	return nil
-}
-
-func pbrGetFreeRule(prefixStr string) (*netlink.Rule, error) {
-
-	// Create rule for FreeTable; src NAT range
-	// XXX for IPv6 underlay we also need rules.
-	// Can we use iif match for all the bo* interfaces?
-	// If so, use bu* matches for this rule
-	freeRule := netlink.NewRule()
-	_, prefix, err := net.ParseCIDR(prefixStr)
-	if err != nil {
-		return nil, err
-	}
-	freeRule.Src = prefix
-	freeRule.Table = FreeTable
-	freeRule.Family = syscall.AF_INET
-	freeRule.Priority = 10000
-	return freeRule, nil
-}
-
 // Handle a route change
 func PbrRouteChange(ctx *zedrouterContext,
 	deviceNetworkStatus *types.DeviceNetworkStatus,
@@ -196,79 +158,51 @@ func PbrRouteChange(ctx *zedrouterContext,
 		// Ignore since we will not add to other table
 		return
 	}
-	doFreeTable := false
-	ifname, _, err := devicenetwork.IfindexToName(rt.LinkIndex)
+	op := "NONE"
+	if change.Type == getRouteUpdateTypeDELROUTE() {
+		op = "DELROUTE"
+	} else if change.Type == getRouteUpdateTypeNEWROUTE() {
+		op = "NEWROUTE"
+	}
+	ifname, linkType, err := devicenetwork.IfindexToName(rt.LinkIndex)
 	if err != nil {
-		// We'll check on ifname when we see a linkchange
 		log.Errorf("PbrRouteChange IfindexToName failed for %d: %s\n",
 			rt.LinkIndex, err)
-	} else {
-		if types.IsFreeMgmtPort(*deviceNetworkStatus, ifname) {
-			log.Debugf("Applying to FreeTable: %v\n", rt)
-			doFreeTable = true
-		}
+		return
 	}
-	srt := rt
-	srt.Table = FreeTable
-	// Multiple IPv6 link-locals can't be added to the same
-	// table unless the Priority differs. Different
-	// LinkIndex, Src, Scope doesn't matter.
-	if rt.Dst != nil && rt.Dst.IP.IsLinkLocalUnicast() {
-		log.Debugf("Forcing IPv6 priority to %v\n", rt.LinkIndex)
-		// Hack to make the kernel routes not appear identical
-		srt.Priority = rt.LinkIndex
+	if linkType != "bridge" {
+		// Ignore
+		return
 	}
+	log.Infof("RouteChange(%d/%s) %s %+v", rt.LinkIndex, ifname, op, rt)
 
-	// Add for all ifindices
-	MyTable := FreeTable + rt.LinkIndex
+	// XXX introduce common devicenetwork.AddRouteToTable(rt, baseTableIndex + rt.LinkIndex)
 
-	// Add to ifindex specific table
+	// Apply to any bridges used by network instances
 	myrt := rt
-	myrt.Table = MyTable
 	// Clear any RTNH_F_LINKDOWN etc flags since add doesn't like them
-	if rt.Flags != 0 {
-		srt.Flags = 0
+	if myrt.Flags != 0 {
 		myrt.Flags = 0
 	}
 	if change.Type == getRouteUpdateTypeDELROUTE() {
-		log.Debugf("Received route del %v\n", rt)
-		if doFreeTable {
-			if err := netlink.RouteDel(&srt); err != nil {
-				log.Errorf("Failed to remove %v from %d: %s\n",
-					srt, srt.Table, err)
-			}
-		}
-		if err := netlink.RouteDel(&myrt); err != nil {
-			log.Errorf("Failed to remove %v from %d: %s\n",
-				myrt, myrt.Table, err)
-		}
+		log.Infof("Received route del %v\n", rt)
 		// find all bridges for network instances and del for them
 		indicies := getAllNIindices(ctx, ifname)
 		log.Infof("XXX Apply route del %v to %v", rt, indicies)
 		for _, ifindex := range indicies {
-			myrt.Table = FreeTable + ifindex
+			myrt.Table = baseTableIndex + ifindex
 			if err := netlink.RouteDel(&myrt); err != nil {
 				log.Errorf("Failed to remove %v from %d: %s\n",
 					myrt, myrt.Table, err)
 			}
 		}
 	} else if change.Type == getRouteUpdateTypeNEWROUTE() {
-		log.Debugf("Received route add %v\n", rt)
-		if doFreeTable {
-			if err := netlink.RouteAdd(&srt); err != nil {
-				log.Errorf("Failed to add %v to %d: %s\n",
-					srt, srt.Table, err)
-			}
-		}
-		if err := netlink.RouteAdd(&myrt); err != nil {
-			log.Errorf("Failed to add %v to %d: %s\n",
-				myrt, myrt.Table, err)
-		}
+		log.Infof("Received route add %v\n", rt)
 		// find all bridges for network instances and add for them
 		indicies := getAllNIindices(ctx, ifname)
 		log.Infof("XXX Apply route add %v to %v", rt, indicies)
 		for _, ifindex := range indicies {
-			myrt.Table = FreeTable + ifindex
+			myrt.Table = baseTableIndex + ifindex
 			if err := netlink.RouteAdd(&myrt); err != nil {
 				log.Errorf("Failed to add %v from %d: %s\n",
 					myrt, myrt.Table, err)
@@ -292,9 +226,10 @@ func PbrAddrChange(deviceNetworkStatus *types.DeviceNetworkStatus,
 				log.Errorf("XXX NewAddr IfindexToName(%d) failed %s\n",
 					change.LinkIndex, err)
 			}
-			// XXX only call for ports and bridges?
-			addSourceRule(change.LinkIndex, change.LinkAddress,
-				linkType == "bridge")
+			if linkType == "bridge" {
+				devicenetwork.AddSourceRule(change.LinkIndex, change.LinkAddress,
+					linkType == "bridge")
+			}
 		}
 	} else {
 		changed = devicenetwork.IfindexToAddrsDel(change.LinkIndex,
@@ -305,9 +240,10 @@ func PbrAddrChange(deviceNetworkStatus *types.DeviceNetworkStatus,
 				log.Errorf("XXX DelAddr IfindexToName(%d) failed %s\n",
 					change.LinkIndex, err)
 			}
-			// XXX only call for ports and bridges?
-			delSourceRule(change.LinkIndex, change.LinkAddress,
-				linkType == "bridge")
+			if linkType == "bridge" {
+				devicenetwork.DelSourceRule(change.LinkIndex, change.LinkAddress,
+					linkType == "bridge")
+			}
 		}
 	}
 	if changed {
@@ -322,181 +258,13 @@ func PbrAddrChange(deviceNetworkStatus *types.DeviceNetworkStatus,
 	return ""
 }
 
-// We track the freeMgmtPort list to be able to detect changes and
-// update the free table with the routes from all the free management ports.
-// XXX TBD: do we need a separate table for all the management ports?
-
-var freeMgmtPortList []string // The subset we add to FreeTable
-
-// Can be called to update the list.
-func setFreeMgmtPorts(freeMgmtPorts []string) {
-
-	log.Debugf("setFreeMgmtPorts(%v)\n", freeMgmtPorts)
-	// Determine which ones were added; moveRoutesTable to add to free table
-	for _, u := range freeMgmtPorts {
-		found := false
-		for _, old := range freeMgmtPortList {
-			if old == u {
-				found = true
-				break
-			}
-		}
-		if !found {
-			ifindex, err := devicenetwork.IfnameToIndex(u)
-			if err == nil {
-				moveRoutesTable(0, ifindex, FreeTable)
-			}
-		}
-	}
-	// Determine which ones were deleted; flushRoutesTable to remove from
-	// free table
-	for _, old := range freeMgmtPortList {
-		found := false
-		for _, u := range freeMgmtPorts {
-			if old == u {
-				found = true
-				break
-			}
-		}
-		if !found {
-			ifindex, err := devicenetwork.IfnameToIndex(old)
-			if err == nil {
-				flushRoutesTable(FreeTable, ifindex)
-			}
-		}
-	}
-	freeMgmtPortList = freeMgmtPorts
-}
-
-// =====
-
-// If ifindex is non-zero we also compare it
-func flushRoutesTable(table int, ifindex int) {
-	filter := netlink.Route{Table: table, LinkIndex: ifindex}
-	fflags := netlink.RT_FILTER_TABLE
-	if ifindex != 0 {
-		fflags |= netlink.RT_FILTER_OIF
-	}
-	routes, err := netlink.RouteListFiltered(syscall.AF_UNSPEC,
-		&filter, fflags)
-	if err != nil {
-		log.Fatalf("RouteList failed: %v\n", err)
-	}
-	log.Debugf("flushRoutesTable(%d, %d) - got %d\n",
-		table, ifindex, len(routes))
-	for _, rt := range routes {
-		if rt.Table != table {
-			continue
-		}
-		if ifindex != 0 && rt.LinkIndex != ifindex {
-			continue
-		}
-		log.Debugf("flushRoutesTable(%d, %d) deleting %v\n",
-			table, ifindex, rt)
-		if err := netlink.RouteDel(&rt); err != nil {
-			// XXX was Fatalf
-			log.Errorf("flushRoutesTable - RouteDel %v failed %s\n",
-				rt, err)
-		}
-	}
-}
-
-// ==== manage the ip rules
-
-// Flush the rules we create. If ifindex is non-zero we also compare it
-// Otherwise we flush the FreeTable
-func flushRules(ifindex int) {
-	rules, err := netlink.RuleList(syscall.AF_UNSPEC)
-	if err != nil {
-		log.Fatalf("RuleList failed: %v\n", err)
-	}
-	log.Debugf("flushRules(%d) - got %d\n", ifindex, len(rules))
-	for _, r := range rules {
-		if ifindex == 0 && r.Table != FreeTable {
-			continue
-		}
-		if ifindex != 0 && r.Table != FreeTable+ifindex {
-			continue
-		}
-		log.Debugf("flushRules: RuleDel %v\n", r)
-		if err := netlink.RuleDel(&r); err != nil {
-			log.Fatalf("flushRules - RuleDel %v failed %s\n",
-				r, err)
-		}
-	}
-}
-
-// If it is a bridge interface we add a rule for the subnet. Otherwise
-// just for the host.
-func addSourceRule(ifindex int, p net.IPNet, bridge bool) {
-
-	log.Debugf("addSourceRule(%d, %v, %v)\n", ifindex, p.String(), bridge)
-	r := netlink.NewRule()
-	r.Table = FreeTable + ifindex
-	r.Priority = 10000
-	// Add rule for /32 or /128
-	if p.IP.To4() != nil {
-		r.Family = syscall.AF_INET
-		if bridge {
-			r.Src = &p
-		} else {
-			r.Src = &net.IPNet{IP: p.IP, Mask: net.CIDRMask(32, 32)}
-		}
-	} else {
-		r.Family = syscall.AF_INET6
-		if bridge {
-			r.Src = &p
-		} else {
-			r.Src = &net.IPNet{IP: p.IP, Mask: net.CIDRMask(128, 128)}
-		}
-	}
-	log.Debugf("addSourceRule: RuleAdd %v\n", r)
-	// Avoid duplicate rules
-	_ = netlink.RuleDel(r)
-	if err := netlink.RuleAdd(r); err != nil {
-		log.Errorf("RuleAdd %v failed with %s\n", r, err)
-		return
-	}
-}
-
-// If it is a bridge interface we add a rule for the subnet. Otherwise
-// just for the host.
-func delSourceRule(ifindex int, p net.IPNet, bridge bool) {
-
-	log.Debugf("delSourceRule(%d, %v, %v)\n", ifindex, p.String(), bridge)
-	r := netlink.NewRule()
-	r.Table = FreeTable + ifindex
-	r.Priority = 10000
-	// Add rule for /32 or /128
-	if p.IP.To4() != nil {
-		r.Family = syscall.AF_INET
-		if bridge {
-			r.Src = &p
-		} else {
-			r.Src = &net.IPNet{IP: p.IP, Mask: net.CIDRMask(32, 32)}
-		}
-	} else {
-		r.Family = syscall.AF_INET6
-		if bridge {
-			r.Src = &p
-		} else {
-			r.Src = &net.IPNet{IP: p.IP, Mask: net.CIDRMask(128, 128)}
-		}
-	}
-	log.Debugf("delSourceRule: RuleDel %v\n", r)
-	if err := netlink.RuleDel(r); err != nil {
-		log.Errorf("RuleDel %v failed with %s\n", r, err)
-		return
-	}
-}
-
 func AddOverlayRuleAndRoute(bridgeName string, iifIndex int,
 	oifIndex int, ipnet *net.IPNet) error {
 	log.Debugf("AddOverlayRuleAndRoute: IIF index %d, Prefix %s, OIF index %d",
 		iifIndex, ipnet.String(), oifIndex)
 
 	r := netlink.NewRule()
-	myTable := FreeTable + iifIndex
+	myTable := baseTableIndex + iifIndex
 	r.Table = myTable
 	r.IifName = bridgeName
 	r.Priority = 10000
@@ -534,7 +302,7 @@ func AddOverlayRuleAndRoute(bridgeName string, iifIndex int,
 func AddFwMarkRuleToDummy(fwmark uint32, iifIndex int) error {
 
 	r := netlink.NewRule()
-	myTable := FreeTable + iifIndex
+	myTable := baseTableIndex + iifIndex
 	r.Table = myTable
 	r.Mark = int(fwmark)
 	r.Mask = 0x00ffffff

--- a/pkg/pillar/cmd/zedrouter/pbr_linux.go
+++ b/pkg/pillar/cmd/zedrouter/pbr_linux.go
@@ -47,56 +47,6 @@ func getRouteUpdateTypeNEWROUTE() uint16 {
 	return syscall.RTM_NEWROUTE
 }
 
-// Used when FreeMgmtPorts get a link added
-// If ifindex is non-zero we also compare it
-func moveRoutesTable(srcTable int, ifindex int, dstTable int) {
-	if srcTable == 0 {
-		srcTable = getDefaultRouteTable()
-	}
-	filter := netlink.Route{Table: srcTable, LinkIndex: ifindex}
-	fflags := netlink.RT_FILTER_TABLE
-	if ifindex != 0 {
-		fflags |= netlink.RT_FILTER_OIF
-	}
-	routes, err := netlink.RouteListFiltered(syscall.AF_UNSPEC,
-		&filter, fflags)
-	if err != nil {
-		log.Fatalf("RouteList failed: %v\n", err)
-	}
-	log.Debugf("moveRoutesTable(%d, %d, %d) - got %d\n",
-		srcTable, ifindex, dstTable, len(routes))
-	for _, rt := range routes {
-		if rt.Table != srcTable {
-			continue
-		}
-		if ifindex != 0 && rt.LinkIndex != ifindex {
-			continue
-		}
-		art := rt
-		art.Table = dstTable
-		// Multiple IPv6 link-locals can't be added to the same
-		// table unless the Priority differs. Different
-		// LinkIndex, Src, Scope doesn't matter.
-		if rt.Dst != nil && rt.Dst.IP.IsLinkLocalUnicast() {
-			log.Debugf("Forcing IPv6 priority to %v\n",
-				rt.LinkIndex)
-			// Hack to make the kernel routes not appear identical
-			art.Priority = rt.LinkIndex
-		}
-		// Clear any RTNH_F_LINKDOWN etc flags since add doesn't
-		// like them
-		if rt.Flags != 0 {
-			art.Flags = 0
-		}
-		log.Debugf("moveRoutesTable(%d, %d, %d) adding %v\n",
-			srcTable, ifindex, dstTable, art)
-		if err := netlink.RouteAdd(&art); err != nil {
-			log.Errorf("moveRoutesTable failed to add %v to %d: %s\n",
-				art, art.Table, err)
-		}
-	}
-}
-
 // Handle a link being added or deleted
 // Returns the ifname if there was a change
 func PbrLinkChange(deviceNetworkStatus *types.DeviceNetworkStatus,
@@ -115,26 +65,14 @@ func PbrLinkChange(deviceNetworkStatus *types.DeviceNetworkStatus,
 			relevantFlag, upFlag)
 		if added {
 			changed = true
-			if types.IsFreeMgmtPort(*deviceNetworkStatus,
-				ifname) {
-
-				log.Debugf("PbrLinkChange moving to FreeTable %s\n",
-					ifname)
-				moveRoutesTable(0, ifindex, FreeTable)
-			}
 		}
 	case syscall.RTM_DELLINK:
 		gone := devicenetwork.IfindexToNameDel(ifindex, ifname)
 		if gone {
 			changed = true
-			if types.IsFreeMgmtPort(*deviceNetworkStatus,
-				ifname) {
-
-				flushRoutesTable(FreeTable, ifindex)
-			}
-			MyTable := FreeTable + ifindex
-			flushRoutesTable(MyTable, 0)
-			flushRules(ifindex)
+			MyTable := baseTableIndex + ifindex
+			devicenetwork.FlushRoutesTable(MyTable, 0)
+			devicenetwork.FlushRules(ifindex)
 		}
 	}
 	if changed {

--- a/pkg/pillar/cmd/zedrouter/pbr_macos.go
+++ b/pkg/pillar/cmd/zedrouter/pbr_macos.go
@@ -29,10 +29,6 @@ func getRouteUpdateTypeNEWROUTE() uint16 {
 	return 0
 }
 
-func moveRoutesTable(srcTable int, ifindex int, dstTable int) {
-	return
-}
-
 // Handle a link being added or deleted
 func PbrLinkChange(deviceNetworkStatus *types.DeviceNetworkStatus,
 	change netlink.LinkUpdate) string {

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -334,8 +334,6 @@ func Run() {
 	flowStatTimer := flextimer.NewRangeTicker(time.Duration(fmin),
 		time.Duration(fmax))
 
-	setFreeMgmtPorts(types.GetMgmtPortsFree(*zedrouterCtx.deviceNetworkStatus, 0))
-
 	zedrouterCtx.ready = true
 	log.Infof("zedrouterCtx.ready\n")
 
@@ -527,7 +525,6 @@ func maybeHandleDNS(ctx *zedrouterContext) {
 	}
 	updateLispConfiglets(ctx, ctx.legacyDataPlane)
 
-	setFreeMgmtPorts(types.GetMgmtPortsFree(*ctx.deviceNetworkStatus, 0))
 	// XXX do a NatInactivate/NatActivate if management ports changed?
 }
 

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -222,6 +222,12 @@ func Run() {
 	}
 	zedrouterCtx.pubAppFlowMonitor = pubAppFlowMonitor
 
+	nms := getNetworkMetrics(&zedrouterCtx) // Need type of data
+	pub, err := pubsub.Publish(agentName, nms)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	appNumAllocatorInit(&zedrouterCtx)
 	bridgeNumAllocatorInit(&zedrouterCtx)
 	handleInit(runDirname)
@@ -315,11 +321,6 @@ func Run() {
 	linkChanges := devicenetwork.LinkChangeInit()
 
 	// Publish network metrics for zedagent every 10 seconds
-	nms := getNetworkMetrics(&zedrouterCtx) // Need type of data
-	pub, err := pubsub.Publish(agentName, nms)
-	if err != nil {
-		log.Fatal(err)
-	}
 	interval := time.Duration(10 * time.Second)
 	max := float64(interval)
 	min := max * 0.3

--- a/pkg/pillar/devicenetwork/addrchange.go
+++ b/pkg/pillar/devicenetwork/addrchange.go
@@ -132,6 +132,7 @@ func RouteChangeInit() chan netlink.RouteUpdate {
 // Check if ports in the given DeviceNetworkStatus have atleast one
 // IP address each and at least one DNS server.
 func checkIfAllPortsHaveIPandDNS(status types.DeviceNetworkStatus) bool {
+	log.Infof("XXX checkIfAllPortsHaveIPandDNS")
 	mgmtPorts := types.GetMgmtPortsAny(status, 0)
 	if len(mgmtPorts) == 0 {
 		log.Infof("XXX no management ports")
@@ -247,14 +248,15 @@ func RouteChange(ctx DeviceNetworkContext, change netlink.RouteUpdate) (bool, in
 	return changed, rt.LinkIndex
 }
 
-// updatePBR makes sure we have PBR rules and routing tables for all the ports
-// Track the list of old port addresses to detect if a port is added or deleted,
-// or if the set of IP addresses change
+// Track changes to set of ports where we have applied PBR
 var ifnameHasPBR = make(map[string][]net.IP)
 
-func updatePBR(status types.DeviceNetworkStatus) {
+// UpdatePBR makes sure we have PBR rules and routing tables for all the ports
+// Track the list of old port addresses to detect if a port is added or deleted,
+// or if the set of IP addresses change
+func UpdatePBR(status types.DeviceNetworkStatus) {
 
-	log.Infof("updatePBR: %d ports", len(status.Ports))
+	log.Infof("UpdatePBR: %d ports", len(status.Ports))
 	// Track any ifnames which need to have PBR deleted
 	ifnameFound := make(map[string]bool)
 

--- a/pkg/pillar/devicenetwork/addrchange.go
+++ b/pkg/pillar/devicenetwork/addrchange.go
@@ -9,8 +9,8 @@ import (
 	"github.com/eriknordmark/netlink"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	log "github.com/sirupsen/logrus"
+	"net"
 	"reflect"
-	"syscall"
 )
 
 // Returns a channel for address updates
@@ -41,7 +41,7 @@ func AddrChangeInit() chan netlink.AddrUpdate {
 }
 
 // AddrChange handles an IP address change. Returns ifindex for changed interface
-func AddrChange(change netlink.AddrUpdate) (bool, int) {
+func AddrChange(ctx DeviceNetworkContext, change netlink.AddrUpdate) (bool, int) {
 
 	changed := false
 	if change.NewAddr {
@@ -54,6 +54,22 @@ func AddrChange(change netlink.AddrUpdate) (bool, int) {
 			change.LinkIndex, change.LinkAddress.String())
 		changed = IfindexToAddrsDel(change.LinkIndex,
 			change.LinkAddress.IP)
+	}
+	if changed {
+		ifname, _, err := IfindexToName(change.LinkIndex)
+		if err != nil {
+			log.Errorf("AddrChange IfindexToName failed for %d: %s\n",
+				change.LinkIndex, err)
+			return false, 0
+		}
+		isPort := types.IsMgmtPort(*ctx.DeviceNetworkStatus, ifname)
+		if isPort {
+			if change.NewAddr {
+				AddSourceRule(change.LinkIndex, change.LinkAddress, false)
+			} else {
+				DelSourceRule(change.LinkIndex, change.LinkAddress, false)
+			}
+		}
 	}
 	log.Infof("AddrChange %t %d %s", changed,
 		change.LinkIndex, change.LinkAddress.String())
@@ -114,18 +130,25 @@ func RouteChangeInit() chan netlink.RouteUpdate {
 }
 
 // Check if ports in the given DeviceNetworkStatus have atleast one
-// IP address each.
-func checkIfAllDNSPortsHaveIPAddrs(status types.DeviceNetworkStatus) bool {
-	mgmtPorts := types.GetMgmtPortsFree(status, 0)
+// IP address each and at least one DNS server.
+func checkIfAllPortsHaveIPandDNS(status types.DeviceNetworkStatus) bool {
+	mgmtPorts := types.GetMgmtPortsAny(status, 0)
 	if len(mgmtPorts) == 0 {
+		log.Infof("XXX no management ports")
 		return false
 	}
 
 	for _, port := range mgmtPorts {
 		numAddrs := types.CountLocalIPv4AddrAnyNoLinkLocalIf(status, port)
-		log.Debugf("checkIfAllDNSPortsHaveIPAddrs: Port %s has %d addresses.",
-			port, numAddrs)
 		if numAddrs < 1 {
+			log.Infof("XXX No addresses on %s", port)
+			log.Debugf("No addresses on %s", port)
+			return false
+		}
+		numDNSServers := types.CountDNSServers(status, port)
+		if numDNSServers < 1 {
+			log.Infof("XXX Have addresses but no DNS on %s", port)
+			log.Debugf("Have addresses but no DNS on %s", port)
 			return false
 		}
 	}
@@ -159,7 +182,7 @@ func HandleAddressChange(ctx *DeviceNetworkContext) {
 		if !reflect.DeepEqual(ctx.Pending.PendDNS, dnStatus) {
 			log.Infof("HandleAddressChange pending: change from %v to %v\n",
 				ctx.Pending.PendDNS, dnStatus)
-			pingTestDNS := checkIfAllDNSPortsHaveIPAddrs(dnStatus)
+			pingTestDNS := checkIfAllPortsHaveIPandDNS(dnStatus)
 			if pingTestDNS {
 				// We have a suitable candiate for running our cloud ping test.
 				log.Infof("HandleAddressChange: Running cloud ping test now, " +
@@ -174,22 +197,132 @@ func HandleAddressChange(ctx *DeviceNetworkContext) {
 
 // RouteChange checks if a route change implies that an interface IP address might have changed.
 // Returns ifindex for potentially changed interface
-func RouteChange(change netlink.RouteUpdate) (bool, int) {
+func RouteChange(ctx DeviceNetworkContext, change netlink.RouteUpdate) (bool, int) {
 
 	rt := change.Route
-	if rt.Table != syscall.RT_TABLE_MAIN {
+	if rt.Table != getDefaultRouteTable() {
 		// Ignore
 		return false, 0
 	}
 	op := "NONE"
-	if change.Type == syscall.RTM_DELROUTE {
+	if change.Type == getRouteUpdateTypeDELROUTE() {
 		op = "DELROUTE"
-	} else if change.Type == syscall.RTM_NEWROUTE {
+	} else if change.Type == getRouteUpdateTypeNEWROUTE() {
 		op = "NEWROUTE"
 	}
-	ifname, _, _ := IfindexToName(rt.LinkIndex)
-	log.Debugf("RouteChange(%d/%s) %s %+v", rt.LinkIndex, ifname, op, rt)
+	ifname, _, err := IfindexToName(rt.LinkIndex)
+	if err != nil {
+		log.Errorf("RouteChange IfindexToName failed for %d: %s\n",
+			rt.LinkIndex, err)
+		return false, 0
+	}
+	isPort := types.IsMgmtPort(*ctx.DeviceNetworkStatus, ifname)
+	if !isPort {
+		return false, 0
+	}
+	log.Infof("RouteChange(%d/%s) %s %+v", rt.LinkIndex, ifname, op, rt)
+	MyTable := baseTableIndex + rt.LinkIndex
+	// Apply to ifindex specific table
+	myrt := rt
+	myrt.Table = MyTable
+	// Clear any RTNH_F_LINKDOWN etc flags since add doesn't like them
+	if myrt.Flags != 0 {
+		myrt.Flags = 0
+	}
+	if change.Type == getRouteUpdateTypeDELROUTE() {
+		log.Infof("Received route del %v\n", rt)
+		if err := netlink.RouteDel(&myrt); err != nil {
+			log.Errorf("Failed to remove %v from %d: %s\n",
+				myrt, myrt.Table, err)
+		}
+	} else if change.Type == getRouteUpdateTypeNEWROUTE() {
+		log.Infof("Received route add %v\n", rt)
+		if err := netlink.RouteAdd(&myrt); err != nil {
+			log.Errorf("Failed to add %v to %d: %s\n",
+				myrt, myrt.Table, err)
+		}
+	}
 	// Guess any onlink/attached route can imply an address change
 	changed := (rt.Gw == nil)
 	return changed, rt.LinkIndex
+}
+
+// updatePBR makes sure we have PBR rules and routing tables for all the ports
+// Track the list of old port addresses to detect if a port is added or deleted,
+// or if the set of IP addresses change
+var ifnameHasPBR = make(map[string][]net.IP)
+
+func updatePBR(status types.DeviceNetworkStatus) {
+
+	log.Infof("updatePBR: %d ports", len(status.Ports))
+	// Track any ifnames which need to have PBR deleted
+	ifnameFound := make(map[string]bool)
+
+	for _, u := range status.Ports {
+		ifnameFound[u.IfName] = true
+
+		var addrs []net.IP
+		for _, ai := range u.AddrInfoList {
+			addrs = append(addrs, ai.Addr)
+		}
+		if oldAddrs, ok := ifnameHasPBR[u.IfName]; ok {
+			if reflect.DeepEqual(oldAddrs, addrs) {
+				log.Infof("Ifname %s already has PBR",
+					u.IfName)
+				continue
+			}
+			log.Infof("Ifname %s PBR changed from %v to %v",
+				u.IfName, oldAddrs, addrs)
+			delPBR(status, u.IfName)
+			addPBR(status, u.IfName, addrs)
+			ifnameHasPBR[u.IfName] = addrs
+			continue
+		}
+		addPBR(status, u.IfName, addrs)
+		ifnameHasPBR[u.IfName] = addrs
+	}
+	for old := range ifnameHasPBR {
+		if _, ok := ifnameFound[old]; ok {
+			continue
+		}
+		delPBR(status, old)
+		delete(ifnameHasPBR, old)
+	}
+}
+
+func addPBR(status types.DeviceNetworkStatus, ifname string, addrs []net.IP) {
+	log.Infof("addPBR(%s) addrs %v", ifname, addrs)
+	ifindex, err := IfnameToIndex(ifname)
+	if err != nil {
+		log.Errorf("addPBR can't find ifindex for %s", ifname)
+		return
+	}
+	for _, a := range addrs {
+		if a.To4() != nil {
+			AddSourceRule(ifindex,
+				net.IPNet{IP: a, Mask: net.CIDRMask(32, 32)},
+				false)
+		} else {
+			AddSourceRule(ifindex,
+				net.IPNet{IP: a, Mask: net.CIDRMask(128, 128)},
+				false)
+		}
+	}
+	// Flush then copy all routes for this interface to the table
+	// for this ifindex
+	table := baseTableIndex + ifindex
+	FlushRoutesTable(table, 0)
+	CopyRoutesTable(0, ifindex, table)
+}
+
+func delPBR(status types.DeviceNetworkStatus, ifname string) {
+	log.Infof("delPBR(%s)", ifname)
+	ifindex, err := IfnameToIndex(ifname)
+	if err != nil {
+		log.Errorf("delPBR can't find ifindex for %s", ifname)
+		return
+	}
+	FlushRules(ifindex)
+	table := baseTableIndex + ifindex
+	FlushRoutesTable(table, 0)
 }

--- a/pkg/pillar/devicenetwork/addrchange_linux.go
+++ b/pkg/pillar/devicenetwork/addrchange_linux.go
@@ -15,6 +15,18 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+func getDefaultRouteTable() int {
+	return syscall.RT_TABLE_MAIN
+}
+
+func getRouteUpdateTypeDELROUTE() uint16 {
+	return syscall.RTM_DELROUTE
+}
+
+func getRouteUpdateTypeNEWROUTE() uint16 {
+	return syscall.RTM_NEWROUTE
+}
+
 // LinkChange handles a link change. Returns ifindex for changed interface
 func LinkChange(change netlink.LinkUpdate) (bool, int) {
 

--- a/pkg/pillar/devicenetwork/devicenetwork.go
+++ b/pkg/pillar/devicenetwork/devicenetwork.go
@@ -238,7 +238,7 @@ func MakeDeviceNetworkStatus(globalConfig types.DevicePortConfig, oldStatus type
 	}
 	// Need to write resolv.conf for Geo
 	UpdateResolvConf(globalStatus)
-	updatePBR(globalStatus)
+	UpdatePBR(globalStatus)
 	// Immediate check
 	UpdateDeviceNetworkGeo(time.Second, &globalStatus)
 	log.Infof("MakeDeviceNetworkStatus() DONE\n")

--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -5,6 +5,7 @@ package devicenetwork
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"reflect"
 	"time"
@@ -17,7 +18,7 @@ import (
 )
 
 const (
-	MaxDPCRetestCount = 3
+	MaxDPCRetestCount = 5
 )
 
 type PendDNSStatus uint32
@@ -120,6 +121,7 @@ func RestartVerify(ctx *DeviceNetworkContext, caller string) {
 		// Need to publish so that other agents see we have initialized
 		// even if we have no IPs
 		UpdateResolvConf(*ctx.DeviceNetworkStatus)
+		updatePBR(*ctx.DeviceNetworkStatus)
 		if ctx.PubDeviceNetworkStatus != nil {
 			ctx.DeviceNetworkStatus.Testing = false
 			log.Infof("PublishDeviceNetworkStatus: %+v\n",
@@ -247,8 +249,8 @@ func VerifyPending(pending *DPCPending,
 	pending.PendDNS = pend2
 	// XXX assume we're doing at least IPv4, so count only those to check if DHCP done
 	numUsableAddrs := types.CountLocalIPv4AddrAnyNoLinkLocal(pending.PendDNS)
-	numUsableDNSServers := types.CountDNSServers(pending.PendDNS)
-	if numUsableAddrs == 0 || numUsableDNSServers == 0 {
+	numDNSServers := types.CountDNSServers(pending.PendDNS, "")
+	if numUsableAddrs == 0 || numDNSServers == 0 {
 		var errStr string
 		ifs := types.GetExistingInterfaceList(pending.PendDNS)
 		if len(ifs) == 0 {
@@ -262,44 +264,61 @@ func VerifyPending(pending *DPCPending,
 		}
 		if pending.TestCount < MaxDPCRetestCount {
 			pending.TestCount += 1
-			log.Infof("VerifyPending: %s for %+v\n",
-				errStr, pending.PendDNS)
+			log.Infof("VerifyPending: TestCount %d: %s for %+v\n",
+				pending.TestCount, errStr, pending.PendDNS)
 			return DPC_WAIT
 		} else {
-			log.Errorf("VerifyPending: %s for %+v\n",
+			log.Errorf("VerifyPending: exceeded TestCount: %s for %+v\n",
 				errStr, pending.PendDNS)
 			pending.PendDPC.LastFailed = time.Now()
 			pending.PendDPC.LastError = errStr
 			return DPC_FAIL
 		}
 	}
-	// Do not entertain re-testing this DPC anymore.
-	pending.TestCount = MaxDPCRetestCount
+	if false {
+		// XXX remove?
+		// Do not entertain re-testing this DPC anymore.
+		pending.TestCount = MaxDPCRetestCount
+		log.Infof("Forcing TestCount to %d for %+v", pending.TestCount,
+			pending.PendDNS)
+	}
 
 	// We want connectivity to zedcloud via atleast one Management port.
 	rtf, err := VerifyDeviceNetworkStatus(pending.PendDNS, 1, timeout)
-	status := DPC_FAIL
 	if err == nil {
 		pending.PendDPC.LastSucceeded = time.Now()
 		pending.PendDPC.LastError = ""
-		status = DPC_SUCCESS
 		log.Infof("VerifyPending: DPC passed network test: %+v",
 			pending.PendDPC)
-	} else {
-		errStr := fmt.Sprintf("Failed network test: %s",
-			err)
-		if rtf {
-			log.Errorf("VerifyPending: remoteTemporaryFailure %s", errStr)
-			// NOTE: do not increase TestCount; we retry until e.g., the
-			// certificate or ECONNREFUSED is fixed on the server side.
-			status = DPC_WAIT
-		} else {
-			log.Errorf("VerifyPending: %s\n", errStr)
-		}
-		pending.PendDPC.LastFailed = time.Now()
-		pending.PendDPC.LastError = errStr
+		return DPC_SUCCESS
 	}
-	return status
+	errStr := fmt.Sprintf("Failed network test: %s", err)
+	if rtf {
+		log.Errorf("VerifyPending: remoteTemporaryFailure %s", errStr)
+		// NOTE: do not increase TestCount; we retry until e.g., the
+		// certificate or ECONNREFUSED is fixed on the server side.
+		return DPC_WAIT
+	}
+	if !checkIfAllPortsHaveIPandDNS(pending.PendDNS) {
+		// Still waiting for IP or DNS
+		if pending.TestCount < MaxDPCRetestCount {
+			pending.TestCount += 1
+			log.Infof("VerifyPending no IP/DNS: TestCount %d: %s for %+v\n",
+				pending.TestCount, errStr, pending.PendDNS)
+			return DPC_WAIT
+		} else {
+			log.Errorf("VerifyPending no IP/DNS: exceeded TestCount: %s for %+v\n",
+				errStr, pending.PendDNS)
+			pending.PendDPC.LastFailed = time.Now()
+			pending.PendDPC.LastError = errStr
+			return DPC_FAIL
+		}
+	}
+	log.Errorf("VerifyPending: %s\n", errStr)
+	pending.TestCount = MaxDPCRetestCount
+	pending.PendDPC.LastFailed = time.Now()
+	pending.PendDPC.LastError = errStr
+	return DPC_FAIL
 }
 
 func VerifyDevicePortConfig(ctx *DeviceNetworkContext) {
@@ -320,6 +339,7 @@ func VerifyDevicePortConfig(ctx *DeviceNetworkContext) {
 		res := VerifyPending(&ctx.Pending, ctx.AssignableAdapters,
 			ctx.TestSendTimeout)
 		UpdateResolvConf(ctx.Pending.PendDNS)
+		updatePBR(ctx.Pending.PendDNS)
 		if ctx.PubDeviceNetworkStatus != nil {
 			log.Infof("PublishDeviceNetworkStatus: pending %+v\n",
 				ctx.Pending.PendDNS)
@@ -510,7 +530,8 @@ func HandleDPCModify(ctxArg interface{}, key string, configArg interface{}) {
 	// we should go ahead and call RestartVerify even when "configChanged" is false.
 	// Also if we have no working one (index -1) we restart.
 	ipAddrCount := types.CountLocalIPv4AddrAnyNoLinkLocal(*ctx.DeviceNetworkStatus)
-	if !configChanged && ipAddrCount > 0 && ctx.DevicePortConfigList.CurrentIndex != -1 {
+	numDNSServers := types.CountDNSServers(*ctx.DeviceNetworkStatus, "")
+	if !configChanged && ipAddrCount > 0 && numDNSServers > 0 && ctx.DevicePortConfigList.CurrentIndex != -1 {
 		log.Infof("HandleDPCModify: Config already current. No changes to process\n")
 		return
 	}
@@ -798,6 +819,7 @@ func DoDNSUpdate(ctx *DeviceNetworkContext) {
 		ctx.UsableAddressCount = newAddrCount
 	}
 	UpdateResolvConf(*ctx.DeviceNetworkStatus)
+	updatePBR(*ctx.DeviceNetworkStatus)
 	if ctx.PubDeviceNetworkStatus != nil {
 		ctx.DeviceNetworkStatus.Testing = false
 		log.Infof("PublishDeviceNetworkStatus: %+v\n",
@@ -806,17 +828,22 @@ func DoDNSUpdate(ctx *DeviceNetworkContext) {
 			ctx.DeviceNetworkStatus)
 	}
 	ctx.Changed = true
-	// Also create a resolv.conf based on all of the management interfaces
-	UpdateResolvConf(*ctx.DeviceNetworkStatus)
 }
 
 const destFilename = "/etc/resolv.conf"
 
 // UpdateResolvConf produces a /etc/resolv.conf based on the management ports
 // in DeviceNetworkStatus
+var lastServers []net.IP
+
 func UpdateResolvConf(globalStatus types.DeviceNetworkStatus) int {
 
 	log.Infof("UpdateResolvConf")
+	servers := getDNSServers(globalStatus)
+	if reflect.DeepEqual(lastServers, servers) {
+		log.Infof("UpdateResolvConf: no change: %d", len(lastServers))
+		return len(lastServers)
+	}
 	destfile, err := os.Create(destFilename)
 	if err != nil {
 		log.Errorln("Create ", err)
@@ -826,14 +853,29 @@ func UpdateResolvConf(globalStatus types.DeviceNetworkStatus) int {
 
 	numAddrs := generateResolvConf(globalStatus, destfile)
 	log.Infof("UpdateResolvConf DONE %d addrs", numAddrs)
+	lastServers = servers
 	return numAddrs
 }
 
+func getDNSServers(globalStatus types.DeviceNetworkStatus) []net.IP {
+	var servers []net.IP
+	for _, us := range globalStatus.Ports {
+		if !us.IsMgmt {
+			continue
+		}
+		for _, server := range us.DnsServers {
+			servers = append(servers, server)
+		}
+	}
+	return servers
+}
+
+// Note that we don't add a search nor domainname option since
+// it seems to mess up the retry logic
 func generateResolvConf(globalStatus types.DeviceNetworkStatus, destfile *os.File) int {
 	destfile.WriteString("# Generated by nim\n")
 	destfile.WriteString("# Do not edit\n")
-	wroteDomainName := false
-	numAddrs := 0
+	var written []net.IP
 	log.Infof("generateResolvConf %d ports", len(globalStatus.Ports))
 	for _, us := range globalStatus.Ports {
 		if !us.IsMgmt {
@@ -843,24 +885,28 @@ func generateResolvConf(globalStatus types.DeviceNetworkStatus, destfile *os.Fil
 		if len(us.AddrInfoList) == 0 {
 			continue
 		}
-		log.Infof("generateResolvConf %s has %d servers",
-			us.IfName, len(us.DnsServers))
-		if us.DomainName != "" && !wroteDomainName {
-			destfile.WriteString(fmt.Sprintf("# From %s\n", us.IfName))
-			destfile.WriteString(fmt.Sprintf("domainname %s\n",
-				us.DomainName))
-			wroteDomainName = true
-		} else {
-			destfile.WriteString(fmt.Sprintf("# From %s\n", us.IfName))
-		}
-		// We do not drop duplicate IP addresses from nameservers.
+		log.Infof("generateResolvConf %s has %d servers: %v",
+			us.IfName, len(us.DnsServers), us.DnsServers)
+		destfile.WriteString(fmt.Sprintf("# From %s\n", us.IfName))
+		// Avoid duplicate IP addresses for nameservers.
 		for _, server := range us.DnsServers {
-			destfile.WriteString(fmt.Sprintf("nameserver %s\n",
-				server))
-			numAddrs++
+			duplicate := false
+			for _, a := range written {
+				if a.Equal(server) {
+					duplicate = true
+				}
+			}
+			if duplicate {
+				destfile.WriteString(fmt.Sprintf("# nameserver %s\n",
+					server))
+			} else {
+				destfile.WriteString(fmt.Sprintf("nameserver %s\n",
+					server))
+				written = append(written, server)
+			}
 		}
 	}
 	destfile.WriteString("options rotate\n")
 	destfile.Sync()
-	return numAddrs
+	return len(written)
 }

--- a/pkg/pillar/devicenetwork/pbr.go
+++ b/pkg/pillar/devicenetwork/pbr.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2017-2019 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package devicenetwork
+
+import (
+	"net"
+	"syscall"
+
+	"github.com/eriknordmark/netlink"
+	log "github.com/sirupsen/logrus"
+)
+
+const baseTableIndex = 500
+
+// ===== Manage routes in a particular table.
+// See also pbr_linux.go
+
+// FlushRoutesTable removes all rules from this table.
+// If ifindex is non-zero we also compare it
+func FlushRoutesTable(table int, ifindex int) {
+	filter := netlink.Route{Table: table, LinkIndex: ifindex}
+	fflags := netlink.RT_FILTER_TABLE
+	if ifindex != 0 {
+		fflags |= netlink.RT_FILTER_OIF
+	}
+	routes, err := netlink.RouteListFiltered(syscall.AF_UNSPEC,
+		&filter, fflags)
+	if err != nil {
+		log.Fatalf("RouteList failed: %v", err)
+	}
+	log.Debugf("FlushRoutesTable(%d, %d) - got %d",
+		table, ifindex, len(routes))
+	for _, rt := range routes {
+		if rt.Table != table {
+			continue
+		}
+		if ifindex != 0 && rt.LinkIndex != ifindex {
+			continue
+		}
+		log.Debugf("FlushRoutesTable(%d, %d) deleting %v",
+			table, ifindex, rt)
+		if err := netlink.RouteDel(&rt); err != nil {
+			log.Errorf("FlushRoutesTable - RouteDel %v failed %s",
+				rt, err)
+		}
+	}
+}
+
+// ==== manage the ip rules
+
+// FlushRules removes any rules we created for this ifindex
+func FlushRules(ifindex int) {
+	rules, err := netlink.RuleList(syscall.AF_UNSPEC)
+	if err != nil {
+		log.Fatalf("RuleList failed: %v", err)
+	}
+	log.Debugf("FlushRules(%d) - got %d", ifindex, len(rules))
+	for _, r := range rules {
+		if r.Table != baseTableIndex+ifindex {
+			continue
+		}
+		log.Infof("FlushRules: RuleDel %v", r)
+		if err := netlink.RuleDel(&r); err != nil {
+			log.Fatalf("FlushRules - RuleDel %v failed %s",
+				r, err)
+		}
+	}
+}
+
+// AddSourceRule create a pbr rule for the address or subet which refers to the
+// specific table for the ifindex.
+func AddSourceRule(ifindex int, p net.IPNet, addForSubnet bool) {
+
+	log.Infof("AddSourceRule(%d, %v, %v)", ifindex, p.String(), addForSubnet)
+	r := netlink.NewRule()
+	r.Table = baseTableIndex + ifindex
+	r.Priority = 10000
+	// Add rule for /32 or /128
+	if p.IP.To4() != nil {
+		r.Family = syscall.AF_INET
+		if addForSubnet {
+			r.Src = &p
+		} else {
+			r.Src = &net.IPNet{IP: p.IP, Mask: net.CIDRMask(32, 32)}
+		}
+	} else {
+		r.Family = syscall.AF_INET6
+		if addForSubnet {
+			r.Src = &p
+		} else {
+			r.Src = &net.IPNet{IP: p.IP, Mask: net.CIDRMask(128, 128)}
+		}
+	}
+	log.Debugf("AddSourceRule: RuleAdd %v", r)
+	// Avoid duplicate rules
+	_ = netlink.RuleDel(r)
+	if err := netlink.RuleAdd(r); err != nil {
+		log.Errorf("RuleAdd %v failed with %s", r, err)
+		return
+	}
+}
+
+// DelSourceRule removes the pbr rule for the address or subet which refers to the
+// specific table for the ifindex.
+func DelSourceRule(ifindex int, p net.IPNet, addForSubnet bool) {
+
+	log.Infof("DelSourceRule(%d, %v, %v)", ifindex, p.String(), addForSubnet)
+	r := netlink.NewRule()
+	r.Table = baseTableIndex + ifindex
+	r.Priority = 10000
+	// Add rule for /32 or /128
+	if p.IP.To4() != nil {
+		r.Family = syscall.AF_INET
+		if addForSubnet {
+			r.Src = &p
+		} else {
+			r.Src = &net.IPNet{IP: p.IP, Mask: net.CIDRMask(32, 32)}
+		}
+	} else {
+		r.Family = syscall.AF_INET6
+		if addForSubnet {
+			r.Src = &p
+		} else {
+			r.Src = &net.IPNet{IP: p.IP, Mask: net.CIDRMask(128, 128)}
+		}
+	}
+	log.Debugf("DelSourceRule: RuleDel %v", r)
+	if err := netlink.RuleDel(r); err != nil {
+		log.Errorf("RuleDel %v failed with %s", r, err)
+		return
+	}
+}

--- a/pkg/pillar/devicenetwork/pbr_linux.go
+++ b/pkg/pillar/devicenetwork/pbr_linux.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2017 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Create ip rules and ip routing tables for each ifindex and also a free
+// one for the collection of free management ports.
+
+// This file is built only for linux
+// +build linux
+
+package devicenetwork
+
+import (
+	"syscall"
+
+	"github.com/eriknordmark/netlink"
+	log "github.com/sirupsen/logrus"
+)
+
+// CopyRoutesTable adds routes from one table to another.
+// If ifindex is non-zero we also compare it
+func CopyRoutesTable(srcTable int, ifindex int, dstTable int) {
+	if srcTable == 0 {
+		srcTable = getDefaultRouteTable()
+	}
+	filter := netlink.Route{Table: srcTable, LinkIndex: ifindex}
+	fflags := netlink.RT_FILTER_TABLE
+	if ifindex != 0 {
+		fflags |= netlink.RT_FILTER_OIF
+	}
+	routes, err := netlink.RouteListFiltered(syscall.AF_UNSPEC,
+		&filter, fflags)
+	if err != nil {
+		log.Fatalf("RouteList failed: %v", err)
+	}
+	log.Infof("CopyRoutesTable(%d, %d, %d) - got %d",
+		srcTable, ifindex, dstTable, len(routes))
+	for _, rt := range routes {
+		if rt.Table != srcTable {
+			continue
+		}
+		if ifindex != 0 && rt.LinkIndex != ifindex {
+			continue
+		}
+		art := rt
+		art.Table = dstTable
+		// Multiple IPv6 link-locals can't be added to the same
+		// table unless the Priority differs. Different
+		// LinkIndex, Src, Scope doesn't matter.
+		if rt.Dst != nil && rt.Dst.IP.IsLinkLocalUnicast() {
+			log.Debugf("Forcing IPv6 priority to %v",
+				rt.LinkIndex)
+			// Hack to make the kernel routes not appear identical
+			art.Priority = rt.LinkIndex
+		}
+		// Clear any RTNH_F_LINKDOWN etc flags since add doesn't
+		// like them
+		if rt.Flags != 0 {
+			art.Flags = 0
+		}
+		log.Debugf("CopyRoutesTable(%d, %d, %d) adding %v",
+			srcTable, ifindex, dstTable, art)
+		if err := netlink.RouteAdd(&art); err != nil {
+			log.Errorf("CopyRoutesTable failed to add %v to %d: %s",
+				art, art.Table, err)
+		}
+	}
+}

--- a/pkg/pillar/devicenetwork/pbr_macos.go
+++ b/pkg/pillar/devicenetwork/pbr_macos.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2019 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//
+// Stub file to allow compilation of pbr.go to go thru on macos.
+// We don't need the actual functionality to work
+// +build darwin
+
+package devicenetwork
+
+// CopyRoutesTable adds routes from one table to another.
+// If ifindex is non-zero we also compare it
+func CopyRoutesTable(srcTable int, ifindex int, dstTable int) {
+}

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -431,10 +431,20 @@ func CountLocalIPv4AddrAnyNoLinkLocal(globalStatus DeviceNetworkStatus) int {
 	return count
 }
 
-// CountDNSServers returns the number of DNS servers
-func CountDNSServers(globalStatus DeviceNetworkStatus) int {
+// CountDNSServers returns the number of DNS servers; for port if set
+func CountDNSServers(globalStatus DeviceNetworkStatus, port string) int {
+
+	var ifname string
+	if port != "" {
+		ifname = AdapterToIfName(&globalStatus, port)
+	} else {
+		ifname = port
+	}
 	count := 0
 	for _, us := range globalStatus.Ports {
+		if us.IfName != ifname && ifname != "" {
+			continue
+		}
 		count += len(us.DnsServers)
 	}
 	return count


### PR DESCRIPTION
Need PBR logic in nim to handle failures which exist at boot time.
Avoid domainname/search options in resolv.conf since they mess up the DNS retry limits.
Delete unused FreeTable (which in the past was used for NAT).

Also takes care of a bug where we end up sending before /etc/resolv.conf has been set up, which results in falling back to an lower priority DevicePortConfig and errors in the logs referring to 127.0.0.1:53