### PR TITLE
ignore editor swap files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.swp
 obj
 dist/
 build-tools/bin/


### PR DESCRIPTION
This trivial patch adds a line to gitignore that that prevents editor swap files from being added accidentally.