### PR TITLE
Fix timing issue between lisp-ztr control thread and ETR threads.

### DIFF
--- a/pkg/pillar/dataplane/dptypes/dataplanetypes.go
+++ b/pkg/pillar/dataplane/dptypes/dataplanetypes.go
@@ -218,6 +218,8 @@ type EtrRunStatus struct {
 
 	// Kill message channel
 	KillChannel chan bool
+	// Killed ACK message channel
+	AckChannel chan bool
 
 	//Ring    *pfring.Ring
 

--- a/pkg/pillar/dataplane/etr/etr.go
+++ b/pkg/pillar/dataplane/etr/etr.go
@@ -134,11 +134,13 @@ func HandleDeviceNetworkChange(deviceNetworkStatus types.DeviceNetworkStatus) {
 
 			// Send a message on channel to kill the ETR thread when required.
 			killChannel := make(chan bool, 1)
+			ackChannel := make(chan bool, 1)
 
 			// Create new ETR thread
 			if EtrTable.EphPort != -1 {
 				//ring, fd = StartEtrNat(EtrTable.EphPort, link.IfName)
-				handle, fd4, fd6 = StartEtrNat(EtrTable.EphPort, link.IfName, killChannel)
+				handle, fd4, fd6 = StartEtrNat(EtrTable.EphPort, link.IfName,
+					killChannel, ackChannel)
 				log.Debugf("HandleDeviceNetworkChange: Creating ETR thread "+
 					"for UP link %s", link.IfName)
 			}
@@ -149,6 +151,7 @@ func HandleDeviceNetworkChange(deviceNetworkStatus types.DeviceNetworkStatus) {
 				Fd4:         fd4,
 				Fd6:         fd6,
 				KillChannel: killChannel,
+				AckChannel:  ackChannel,
 			}
 			log.Infof("HandleDeviceNetworkChange: Creating ETR thread for UP link %s",
 				link.IfName)
@@ -161,7 +164,7 @@ func HandleDeviceNetworkChange(deviceNetworkStatus types.DeviceNetworkStatus) {
 			log.Infof("HandleDeviceNetworkChange: Stopping ETR thread for UP link %s", key)
 			link.KillChannel <- true
 			// Wait for the thread to confirm that it died
-			<-link.KillChannel
+			<-link.AckChannel
 			log.Infof("HandleDeviceNetworkChange: ETR thread for UPlink %s exited", key)
 			syscall.Close(link.Fd4)
 			syscall.Close(link.Fd6)
@@ -195,7 +198,8 @@ func HandleEtrEphPort(ephPort int) {
 				link.IfName)
 			//ring, fd := StartEtrNat(EtrTable.EphPort, link.IfName)
 			//ling.Ring = ring
-			handle, fd4, fd6 := StartEtrNat(EtrTable.EphPort, link.IfName, link.KillChannel)
+			handle, fd4, fd6 := StartEtrNat(EtrTable.EphPort, link.IfName,
+				link.KillChannel, link.AckChannel)
 			link.Handle = handle
 			link.Fd4 = fd4
 			link.Fd6 = fd6
@@ -233,7 +237,7 @@ func HandleEtrEphPort(ephPort int) {
 //func StartEtrNat(ephPort int, upLink string) (*pfring.Ring, int) {
 func StartEtrNat(ephPort int,
 	upLink string,
-	killChannel chan bool) (*afpacket.TPacket, int, int) {
+	killChannel <-chan bool, ackChannel chan<- bool) (*afpacket.TPacket, int, int) {
 
 	//ring := SetupEtrPktCapture(ephPort, upLink)
 	//if ring == nil {
@@ -266,7 +270,7 @@ func StartEtrNat(ephPort int,
 		syscall.Close(fd4)
 	}
 	//go ProcessCapturedPkts(fd, ring)
-	go ProcessCapturedPkts(fd4, fd6, handle, killChannel)
+	go ProcessCapturedPkts(fd4, fd6, handle, killChannel, ackChannel)
 
 	//return ring, fd
 	return handle, fd4, fd6
@@ -537,7 +541,7 @@ func ProcessETRPkts(fd4 int, fd6 int, serverConn *net.UDPConn) bool {
 //func ProcessCapturedPkts(fd6 int, ring *pfring.Ring) {
 func ProcessCapturedPkts(fd4 int, fd6 int,
 	handle *afpacket.TPacket,
-	killChannel chan bool) {
+	killChannel <-chan bool, ackChannel chan<- bool) {
 	// close the raw sockets when we decide to leave this function
 	defer syscall.Close(fd4)
 	defer syscall.Close(fd6)
@@ -565,7 +569,7 @@ func ProcessCapturedPkts(fd4 int, fd6 int,
 				"ProcessCapturedPkts: It could be the ETR thread handle closure leading to this")
 			log.Infof("ProcessCapturedPkts: Closing packet capture handle")
 			handle.Close()
-			killChannel <- true
+			ackChannel <- true
 			return
 		default:
 		}


### PR DESCRIPTION
When there are cables pulled out from uplink ports, lisp-ztr responds by trying to kill the ETR threads that capture packets from corresponding ports. There is a timing issue between the lisp-ztr control thread that deletes the context and the actual ETR threads.

Control thread simply sends a signal to ETR (ETR should exit on seeing this signal - kill channel message), and deletes the current context. ETR thread is expected to close the AF packet handle and exit. But, the ETR at that time could be busy polling for packets (with 5 second timeout) and not exit. Meanwhile if the cables are plugged into the ports, new ETR threads are created. Apparently AF packet would return the same existing handle (underlying socket) for the same ports. Now, the old thread gets unblocked and deletes the AF packet context. This makes the new ETR thread go into ERROR state and indefinitly block and for some reason uses a lot of CPU resource.

Fix is to make the control thread expect a reverse channel message from ETR, before the control thread proceeds to next step. The ETR thread when it sees the kill message sends a message back to control thread using the same kill channel just before exiting.


Signed-off-by: GopiKrishna Kodali <gkodali@zededa.com>