### PR TITLE
[Dell 300x series] improve installer support

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -37,7 +37,8 @@ Then add the valid json file named as global.json in that directory.
 Finally:
 
 ```bash
-make config.img; make installer.raw
+make config
+make installer
 ```
 
 or just copy them into the partition called EVE on the writable installation medium.

--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -89,7 +89,7 @@ function set_x86_64_baremetal {
    set_x86_64
    set_global xen_platform_tweaks "efi=no-rs"
    set_global linux_qemu_tweaks " "
-   set_global linux_console "console=tty0"
+   set_global linux_console "console=tty0 console=ttyS0"
 }
 
 function set_x86_64_qemu {

--- a/pkg/mkimage-raw-efi/Dockerfile
+++ b/pkg/mkimage-raw-efi/Dockerfile
@@ -1,3 +1,9 @@
+# This mkimage-raw-efi produces the raw EFI partition for EVE,
+# including the files in efi-files in the image.  This includes:
+#
+#   /EFI/BOOT/grub.cfg - Chainloads main bootloader
+#   /UsbInvocationScript.txt - Enables USB boot on Dell 3000 series
+#
 FROM alpine:3.7
 
 RUN apk add --no-cache \

--- a/pkg/mkimage-raw-efi/efi-files/UsbInvocationScript.txt
+++ b/pkg/mkimage-raw-efi/efi-files/UsbInvocationScript.txt
@@ -1,0 +1,2 @@
+usb_disable_secure_boot noreset;
+usb_one_time_boot usb nolog;


### PR DESCRIPTION
This series of patches improves support for the Dell Edge Gateway 3000 series hardware.

Principally, a new document describing the quirks and tricks for using its hardware is added in a new subdirectory (`docs/targets/`). This document describes the current state of affairs for using the hardware and provides notes that would allow further development of improvements to proceed. Notably, it references using the Dell Configure | Control utility on the official Dell Ubuntu Server image, along with some information about the various peripherals that will assist with sorting out missing driver and user space support.

Beyond documentation, this series makes two minor changes to make the installer work seamlessly on these targets:

1. Adds a `UsbInvocationScript.txt` file to the configuration partition to make the target boot the installer automatically when powered on with the USB drive in place. See issue #313 
2. Adds `console=ttyS0` to the kernel boot arguments in grub, allowing the internal serial port to be used as console on the headless targets (3001/3002). See issue #318

With those changes, the standard installer image works seamlessly for the 3001/3002/3003 hardware. The USB key boots the installer, the live image is installed on its internal storage, the live system boots, and the system can be used via the serial console.