### PR TITLE
Networks with out gateway and DNS server should be accepted. App IP a…

### DIFF
--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -736,8 +736,8 @@ func parseSystemAdapterConfig(config *zconfig.EdgeDevConfig,
 					break
 				}
 				if port.AddrSubnet == "" {
-					log.Errorf("parseSystemAdapterConfig: DT_STATIC but missing parameters in %+v; ignored\n",
-						port)
+					log.Errorf("parseSystemAdapterConfig: DT_STATIC but missing "+
+						"subnet address in %+v; ignored", port)
 					continue
 				}
 			case types.DT_CLIENT:

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -735,8 +735,7 @@ func parseSystemAdapterConfig(config *zconfig.EdgeDevConfig,
 					port.Dhcp = types.DT_NONE
 					break
 				}
-				if port.Gateway.IsUnspecified() || port.AddrSubnet == "" ||
-					port.DnsServers == nil {
+				if port.AddrSubnet == "" {
 					log.Errorf("parseSystemAdapterConfig: DT_STATIC but missing parameters in %+v; ignored\n",
 						port)
 					continue

--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -842,7 +842,7 @@ func lookupOrAllocateIPv4(
 		// allocated new one. Since bridge IP address is also stored
 		// as part of IPAssignments, the actual allocated IP address
 		// numner is 1 less than the length of IPAssignments map size.
-		allocated -= 1
+		allocated--
 	}
 	a := addToIP(status.DhcpRange.Start, allocated)
 	for status.DhcpRange.End == nil ||

--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -836,9 +836,17 @@ func lookupOrAllocateIPv4(
 
 	// Starting guess based on number allocated
 	allocated := uint(len(status.IPAssignments))
+	if status.Gateway != nil {
+		// With Gateway present in network instance status,
+		// we would have used that as our Bridge IP address and not
+		// allocated new one. Since bridge IP address is also stored
+		// as part of IPAssignments, the actual allocated IP address
+		// numner is 1 less than the length of IPAssignments map size.
+		allocated -= 1
+	}
 	a := addToIP(status.DhcpRange.Start, allocated)
 	for status.DhcpRange.End == nil ||
-		bytes.Compare(a, status.DhcpRange.End) < 0 {
+		bytes.Compare(a, status.DhcpRange.End) <= 0 {
 
 		log.Infof("lookupOrAllocateIPv4(%s) testing %s\n",
 			mac.String(), a.String())

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -1907,6 +1907,7 @@ func getUlAddrs(ctx *zedrouterContext,
 		addr, err = lookupOrAllocateIPv4(ctx, netInstStatus, mac)
 		if err != nil {
 			log.Errorf("getUlAddrs: App IP address allocation failed: %s\n", err)
+			return bridgeIPAddr, appIPAddr, err
 		} else {
 			appIPAddr = addr
 		}


### PR DESCRIPTION
…ddr logic boundary handling fix. App IP address allocation should propagate error to AppNetworkStatus

Three part fix:
1) zedagent should accept sysadapters attached to networks that do not have gateway, DNS server configured.
2) App IP allocation boundary check fix. Basically do not consider bridge IP as part to allocated count when bridge IP comes from network instance configuration. Also, boundary end condition fix.
3) When IP address allocation for an App fails, we should stop there and propagate this error into AppNetworkStatus such that the App error status reaches cloud.

Signed-off-by: GopiKrishna Kodali <gkodali@zededa.com>