### PR TITLE
Skip uplink interface cloud is not reachable while talking to cloud

### DIFF
--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -701,7 +701,9 @@ func updateFilteredFallback(ctx *nimContext) {
 }
 
 func tryDeviceConnectivityToCloud(ctx *devicenetwork.DeviceNetworkContext) bool {
-	rtf, err := devicenetwork.VerifyDeviceNetworkStatus(*ctx.DeviceNetworkStatus, 1, ctx.TestSendTimeout)
+	rtf, err := devicenetwork.VerifyDeviceNetworkStatus(ctx.DeviceNetworkStatus, 1, ctx.TestSendTimeout)
+	// Some of the uplink ports might have their CloudReachable state changed
+	ctx.PubDeviceNetworkStatus.Publish("global", ctx.DeviceNetworkStatus)
 	if err == nil {
 		log.Infof("tryDeviceConnectivityToCloud: Device cloud connectivity test passed.")
 		if ctx.NextDPCIndex < len(ctx.DevicePortConfigList.PortConfigList) {

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -702,7 +702,7 @@ func updateFilteredFallback(ctx *nimContext) {
 
 func tryDeviceConnectivityToCloud(ctx *devicenetwork.DeviceNetworkContext) bool {
 	rtf, err := devicenetwork.VerifyDeviceNetworkStatus(ctx.DeviceNetworkStatus, 1, ctx.TestSendTimeout)
-	// Some of the uplink ports might have their CloudReachable state changed
+	// Some of the uplink ports might have their CloudUnReachable state changed
 	ctx.PubDeviceNetworkStatus.Publish("global", ctx.DeviceNetworkStatus)
 	if err == nil {
 		log.Infof("tryDeviceConnectivityToCloud: Device cloud connectivity test passed.")

--- a/pkg/pillar/devicenetwork/addrchange.go
+++ b/pkg/pillar/devicenetwork/addrchange.go
@@ -171,7 +171,7 @@ func HandleAddressChange(ctx *DeviceNetworkContext) {
 		for i := range status.Ports {
 			ifName := status.Ports[i].IfName
 			portStatus := dnStatus.GetPortByIfName(ifName)
-			status.Ports[i].CloudReachable = portStatus.CloudReachable
+			status.Ports[i].CloudUnReachable = portStatus.CloudUnReachable
 		}
 
 		if !reflect.DeepEqual(*ctx.DeviceNetworkStatus, status) {

--- a/pkg/pillar/devicenetwork/addrchange.go
+++ b/pkg/pillar/devicenetwork/addrchange.go
@@ -167,6 +167,13 @@ func HandleAddressChange(ctx *DeviceNetworkContext) {
 		status, _ := MakeDeviceNetworkStatus(*ctx.DevicePortConfig,
 			dnStatus)
 
+		// Copy port level cloud reachability flag
+		for i := range status.Ports {
+			ifName := status.Ports[i].IfName
+			portStatus := dnStatus.GetPortByIfName(ifName)
+			status.Ports[i].CloudReachable = portStatus.CloudReachable
+		}
+
 		if !reflect.DeepEqual(*ctx.DeviceNetworkStatus, status) {
 			log.Infof("HandleAddressChange: change from %v to %v\n",
 				*ctx.DeviceNetworkStatus, status)

--- a/pkg/pillar/devicenetwork/devicenetwork.go
+++ b/pkg/pillar/devicenetwork/devicenetwork.go
@@ -258,7 +258,7 @@ func CheckDNSUpdate(ctx *DeviceNetworkContext) {
 		for i := range status.Ports {
 			ifName := status.Ports[i].IfName
 			portStatus := dnStatus.GetPortByIfName(ifName)
-			status.Ports[i].CloudReachable = portStatus.CloudReachable
+			status.Ports[i].CloudUnReachable = portStatus.CloudUnReachable
 		}
 
 		if !reflect.DeepEqual(*ctx.DeviceNetworkStatus, status) {

--- a/pkg/pillar/devicenetwork/devicenetwork.go
+++ b/pkg/pillar/devicenetwork/devicenetwork.go
@@ -254,6 +254,12 @@ func CheckDNSUpdate(ctx *DeviceNetworkContext) {
 		dnStatus = *ctx.DeviceNetworkStatus
 		status, _ := MakeDeviceNetworkStatus(*ctx.DevicePortConfig,
 			dnStatus)
+		// Copy port level cloud reachability flag
+		for i := range status.Ports {
+			ifName := status.Ports[i].IfName
+			portStatus := dnStatus.GetPortByIfName(ifName)
+			status.Ports[i].CloudReachable = portStatus.CloudReachable
+		}
 
 		if !reflect.DeepEqual(*ctx.DeviceNetworkStatus, status) {
 			log.Infof("CheckDNSUpdate: change from %v to %v\n",

--- a/pkg/pillar/devicenetwork/devicenetwork.go
+++ b/pkg/pillar/devicenetwork/devicenetwork.go
@@ -60,7 +60,7 @@ func IsProxyConfigEmpty(proxyConfig types.ProxyConfig) bool {
 }
 
 // Check if device can talk to outside world via atleast one of the free uplinks
-func VerifyDeviceNetworkStatus(status types.DeviceNetworkStatus,
+func VerifyDeviceNetworkStatus(status *types.DeviceNetworkStatus,
 	retryCount int, timeout uint32) (bool, error) {
 
 	log.Infof("VerifyDeviceNetworkStatus() %d\n", retryCount)
@@ -81,7 +81,7 @@ func VerifyDeviceNetworkStatus(status types.DeviceNetworkStatus,
 	testUrl := serverNameAndPort + "/api/v1/edgedevice/ping"
 
 	zedcloudCtx := zedcloud.ZedCloudContext{
-		DeviceNetworkStatus: &status,
+		DeviceNetworkStatus: status,
 		NetworkSendTimeout:  timeout,
 	}
 
@@ -114,7 +114,7 @@ func VerifyDeviceNetworkStatus(status types.DeviceNetworkStatus,
 	}
 	zedcloudCtx.TlsConfig = tlsConfig
 	for ix := range status.Ports {
-		err = CheckAndGetNetworkProxy(&status, &status.Ports[ix])
+		err = CheckAndGetNetworkProxy(status, &status.Ports[ix])
 		if err != nil {
 			errStr := fmt.Sprintf("GetNetworkProxy failed %s", err)
 			log.Errorf("VerifyDeviceNetworkStatus: %s\n", errStr)

--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -249,7 +249,7 @@ func VerifyPending(pending *DPCPending,
 	pending.PendDNS = pend2
 
 	// We want connectivity to zedcloud via atleast one Management port.
-	rtf, err := VerifyDeviceNetworkStatus(pending.PendDNS, 1, timeout)
+	rtf, err := VerifyDeviceNetworkStatus(&pending.PendDNS, 1, timeout)
 	if err == nil {
 		pending.PendDPC.LastSucceeded = time.Now()
 		pending.PendDPC.LastError = ""

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -294,8 +294,9 @@ type NetworkPortStatus struct {
 	NetworkXObjectConfig
 	AddrInfoList []AddrInfo
 	ProxyConfig
-	Error     string
-	ErrorTime time.Time
+	Error          string
+	ErrorTime      time.Time
+	CloudReachable bool
 }
 
 type AddrInfo struct {
@@ -313,10 +314,10 @@ type DeviceNetworkStatus struct {
 
 func (status *DeviceNetworkStatus) GetPortByName(
 	port string) *NetworkPortStatus {
-	for _, portStatus := range status.Ports {
+	for i, portStatus := range status.Ports {
 		if strings.EqualFold(portStatus.Name, port) {
 			log.Infof("Found NetworkPortStatus for %s", port)
-			return &portStatus
+			return &status.Ports[i]
 		}
 	}
 	return nil
@@ -324,10 +325,10 @@ func (status *DeviceNetworkStatus) GetPortByName(
 
 func (status *DeviceNetworkStatus) GetPortByIfName(
 	port string) *NetworkPortStatus {
-	for _, portStatus := range status.Ports {
+	for i, portStatus := range status.Ports {
 		if portStatus.IfName == port {
 			log.Infof("Found NetworkPortStatus for %s", port)
-			return &portStatus
+			return &status.Ports[i]
 		}
 	}
 	return nil

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -294,9 +294,9 @@ type NetworkPortStatus struct {
 	NetworkXObjectConfig
 	AddrInfoList []AddrInfo
 	ProxyConfig
-	Error          string
-	ErrorTime      time.Time
-	CloudReachable bool
+	Error            string
+	ErrorTime        time.Time
+	CloudUnReachable bool
 }
 
 type AddrInfo struct {

--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -149,13 +149,14 @@ func VerifyAllIntf(ctx ZedCloudContext,
 			if rtf {
 				remoteTemporaryFailure = true
 			}
+			portStatus := ctx.DeviceNetworkStatus.GetPortByIfName(intf)
 			if err != nil {
 				log.Errorf("Zedcloud un-reachable via interface %s: %s",
 					intf, err)
 				errorList = append(errorList, err)
+				portStatus.CloudReachable = false
 				continue
 			}
-			portStatus := ctx.DeviceNetworkStatus.GetPortByIfName(intf)
 			switch resp.StatusCode {
 			case http.StatusOK, http.StatusCreated:
 				log.Infof("VerifyAllIntf: Zedcloud reachable via interface %s", intf)

--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -84,7 +84,7 @@ func SendOnAllIntf(ctx ZedCloudContext, url string, reqlen int64, b *bytes.Buffe
 		for _, intf := range intfs {
 			portStatus := ctx.DeviceNetworkStatus.GetPortByIfName(intf)
 			if portStatus != nil {
-				if portStatus.CloudReachable == false {
+				if portStatus.CloudUnReachable == true {
 					log.Infof("SendOnAllIntf: XXXXX Skipping interface %s, since cloud is not "+
 						"reachable via this interface", intf)
 					continue
@@ -154,14 +154,14 @@ func VerifyAllIntf(ctx ZedCloudContext,
 				log.Errorf("Zedcloud un-reachable via interface %s: %s",
 					intf, err)
 				errorList = append(errorList, err)
-				portStatus.CloudReachable = false
+				portStatus.CloudUnReachable = true
 				continue
 			}
 			switch resp.StatusCode {
 			case http.StatusOK, http.StatusCreated:
 				log.Infof("VerifyAllIntf: Zedcloud reachable via interface %s", intf)
 				intfSuccessCount += 1
-				portStatus.CloudReachable = true
+				portStatus.CloudUnReachable = false
 			default:
 				errStr := fmt.Sprintf("Uplink test FAILED via %s to URL %s with "+
 					"status code %d and status %s",
@@ -169,7 +169,7 @@ func VerifyAllIntf(ctx ZedCloudContext,
 				log.Errorln(errStr)
 				err = errors.New(errStr)
 				errorList = append(errorList, err)
-				portStatus.CloudReachable = false
+				portStatus.CloudUnReachable = true
 				continue
 			}
 		}


### PR DESCRIPTION
1) Add a per port "CloudReachable" indicator per NetworkPortStatus.
2) While testing device cloud connectivity test all uplink ports and update the CloudReachable flag accordingly.
3) Some ports might get IP addresses a bit late. When we do "tryDeviceConnectivityToCloud" CloudReaclable flag might change for one/more ports. So, update device network status after cloud connectivity test. 

Signed-off-by: GopiKrishna Kodali <gkodali@zededa.com>