### PR TITLE
fix acrn build failure due to python3 version

### DIFF
--- a/pkg/acrn/Dockerfile
+++ b/pkg/acrn/Dockerfile
@@ -26,7 +26,7 @@ RUN apk add --no-cache \
     bash=4.4.19-r1 \
     socat=1.7.3.2-r4 \
     openssh=7.7_p1-r4 \
-    python3=3.6.8-r0 \
+    python3=3.6.9-r1 \
     libc-dev=0.7.1-r0 \
     openssl-dev=1.0.2t-r0 \
     openssl=1.0.2t-r0 \


### PR DESCRIPTION
@glguida @rvs Don't understand why we didn't see this fail earlier but it is failing in the 4.1 branch since yesterday e.g.,
https://circleci.com/gh/lf-edge/eve/4214