### PR TITLE
baseos upgrade validation failure handling and some cleanups

### DIFF
--- a/pkg/pillar/cmd/nodeagent/handlebaseos.go
+++ b/pkg/pillar/cmd/nodeagent/handlebaseos.go
@@ -21,7 +21,7 @@ func doZbootBaseOsInstallationComplete(ctxPtr *nodeagentContext,
 		log.Errorf("Partition(%s) Config not found\n", key)
 		return
 	}
-	if isZbootOtherPartitionStateUpdating(ctxPtr) && !ctxPtr.needsReboot {
+	if isZbootOtherPartitionStateUpdating(ctxPtr) && !ctxPtr.deviceReboot {
 		infoStr := fmt.Sprintf("NORMAL: baseos-update(%s) reboot\n", key)
 		log.Infof(infoStr)
 		scheduleNodeReboot(ctxPtr, infoStr)

--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -11,15 +11,17 @@
 // nodeagent subscribes to the following topics
 //   * global config
 //   * zboot status                 <baseosmgr> / <zboot> / <status>
-//   * zedagent status              <zedagent>/ <status>
+//   * zedagent status              <zedagent>  / <status>
 
 package nodeagent
 
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
@@ -35,15 +37,19 @@ import (
 )
 
 const (
-	agentName               = "nodeagent"
-	timeTickInterval uint32 = 10
-	watchdogInterval uint32 = 25
-	networkUpTimeout uint32 = 300
+	agentName                 = "nodeagent"
+	timeTickInterval   uint32 = 10
+	watchdogInterval   uint32 = 25
+	networkUpTimeout   uint32 = 300
+	configDir                 = "/config"
+	tmpDirname                = "/var/tmp/zededa"
+	firstbootFile             = tmpDirname + "/first-boot"
+	restartCounterFile        = configDir + "/restartcounter"
 )
 
 // Version : module version
 var Version = "No version specified"
-var rebootDelay = 40 // take 40 second delay, incase zedagent fails
+var rebootDelay = 30
 
 type nodeagentContext struct {
 	GCInitialized          bool // Received initial GlobalConfig
@@ -57,12 +63,12 @@ type nodeagentContext struct {
 	pubNodeAgentStatus     *pubsub.Publication
 	curPart                string
 	upgradeTestStartTime   uint32
+	tickerTimer            *time.Ticker
+	stillRunning           *time.Ticker
 	remainingTestTime      time.Duration
 	lastConfigReceivedTime uint32
 	configGetStatus        types.ConfigGetStatus
 	deviceNetworkStatus    *types.DeviceNetworkStatus
-	needsReboot            bool
-	rebootReason           string
 	deviceRegistered       bool
 	updateInprogress       bool
 	updateComplete         bool
@@ -71,8 +77,12 @@ type nodeagentContext struct {
 	testInprogress         bool
 	timeTickCount          uint32
 	usableAddressCount     int
-	tickerTimer            *time.Ticker
-	stillRunning           *time.Ticker
+	rebootCmd              bool
+	deviceReboot           bool
+	rebootReason           string
+	rebootStack            string
+	rebootTime             time.Time
+	restartCounter         uint32
 }
 
 var debug = false
@@ -124,6 +134,9 @@ func Run() {
 
 	// Make sure we have a GlobalConfig file with defaults
 	types.EnsureGCFile()
+
+	// get the last reboot reason
+	handleLastRebootReason(&nodeagentCtx)
 
 	// publisher of NodeAgent Status
 	pubNodeAgentStatus, err := pubsub.Publish(agentName,
@@ -323,6 +336,7 @@ func handleZedAgentStatusModify(ctxArg interface{},
 			key, status.Key(), status)
 		return
 	}
+	handleRebootCmd(ctxPtr, status)
 	updateZedagentCloudConnectStatus(ctxPtr, status)
 	log.Debugf("handleZedAgentStatusModify(%s) done\n", key)
 }
@@ -462,7 +476,102 @@ func isZedAgentAlive(ctxPtr *nodeagentContext) bool {
 	return false
 }
 
-// publish nodeagent status for consumption by zedagent
+// If we have a reboot reason from this or the other partition
+// (assuming the other is in inprogress) then we log it
+// we will push this as part of baseos status
+func handleLastRebootReason(ctx *nodeagentContext) {
+
+	ctx.rebootReason, ctx.rebootTime, ctx.rebootStack =
+		agentlog.GetCurrentRebootReason()
+	if ctx.rebootReason != "" {
+		log.Warnf("Current partition rebooted reason: %s\n",
+			ctx.rebootReason)
+		agentlog.DiscardCurrentRebootReason()
+	}
+	otherRebootReason, otherRebootTime, otherRebootStack := agentlog.GetOtherRebootReason()
+	if otherRebootReason != "" {
+		log.Warnf("Other partition rebooted reason: %s\n",
+			otherRebootReason)
+		agentlog.DiscardOtherRebootReason()
+	}
+	commonRebootReason, commonRebootTime, commonRebootStack := agentlog.GetCommonRebootReason()
+	if commonRebootReason != "" {
+		log.Warnf("Common rebooted reason: %s\n",
+			commonRebootReason)
+		agentlog.DiscardCommonRebootReason()
+	}
+	// first, pick up from other partition
+	if ctx.rebootReason == "" {
+		ctx.rebootReason = otherRebootReason
+		ctx.rebootTime = otherRebootTime
+		ctx.rebootStack = otherRebootStack
+	}
+	// if still not found, pick up the common
+	if ctx.rebootReason == "" {
+		ctx.rebootReason = commonRebootReason
+		ctx.rebootTime = commonRebootTime
+		ctx.rebootStack = commonRebootStack
+	}
+
+	// still nothing, fillup the default
+	if ctx.rebootReason == "" {
+		ctx.rebootTime = time.Now()
+		dateStr := ctx.rebootTime.Format(time.RFC3339Nano)
+		var reason string
+		if fileExists(firstbootFile) {
+			reason = fmt.Sprintf("NORMAL: First boot of device - at %s\n",
+				dateStr)
+		} else {
+			reason = fmt.Sprintf("Unknown reboot reason - power failure or crash - at %s\n",
+				dateStr)
+		}
+		log.Warnf(reason)
+		ctx.rebootReason = reason
+		ctx.rebootTime = time.Now()
+		ctx.rebootStack = ""
+	}
+	// remove the first boot file, if it is present
+	if fileExists(firstbootFile) {
+		os.Remove(firstbootFile)
+	}
+
+	// Read and increment restartCounter
+	ctx.restartCounter = incrementRestartCounter()
+}
+
+// If the file doesn't exist we pick zero.
+// Return value before increment; write new value to file
+func incrementRestartCounter() uint32 {
+	var restartCounter uint32
+
+	if _, err := os.Stat(restartCounterFile); err == nil {
+		b, err := ioutil.ReadFile(restartCounterFile)
+		if err != nil {
+			log.Errorf("incrementRestartCounter: %s\n", err)
+		} else {
+			c, err := strconv.Atoi(string(b))
+			if err != nil {
+				log.Errorf("incrementRestartCounter: %s\n", err)
+			} else {
+				restartCounter = uint32(c)
+				log.Infof("incrementRestartCounter: read %d\n", restartCounter)
+			}
+		}
+	}
+	b := []byte(fmt.Sprintf("%d", restartCounter+1))
+	err := ioutil.WriteFile(restartCounterFile, b, 0644)
+	if err != nil {
+		log.Errorf("incrementRestartCounter write: %s\n", err)
+	}
+	return restartCounter
+}
+
+func fileExists(filename string) bool {
+	_, err := os.Stat(filename)
+	return err == nil
+}
+
+// publish nodeagent status
 func publishNodeAgentStatus(ctxPtr *nodeagentContext) {
 	pub := ctxPtr.pubNodeAgentStatus
 	status := types.NodeAgentStatus{
@@ -470,8 +579,11 @@ func publishNodeAgentStatus(ctxPtr *nodeagentContext) {
 		CurPart:           ctxPtr.curPart,
 		RemainingTestTime: ctxPtr.remainingTestTime,
 		UpdateInprogress:  ctxPtr.updateInprogress,
-		NeedsReboot:       ctxPtr.needsReboot,
+		DeviceReboot:      ctxPtr.deviceReboot,
 		RebootReason:      ctxPtr.rebootReason,
+		RebootStack:       ctxPtr.rebootStack,
+		RebootTime:        ctxPtr.rebootTime,
+		RestartCounter:    ctxPtr.restartCounter,
 	}
 	pub.Publish(agentName, status)
 }

--- a/pkg/pillar/cmd/zedagent/handlebaseos.go
+++ b/pkg/pillar/cmd/zedagent/handlebaseos.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2017-2018 Zededa, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// base os event handlers
+// basic zboot partition status APIs
 
 package zedagent
 
@@ -12,78 +12,7 @@ import (
 	"strings"
 )
 
-func lookupBaseOsConfig(ctx *getconfigContext, key string) *types.BaseOsConfig {
-	pub := ctx.pubBaseOsConfig
-	st, _ := pub.Get(key)
-	if st == nil {
-		log.Infof("lookupBaseOsConfig(%s) not found\n", key)
-		return nil
-	}
-	config := cast.CastBaseOsConfig(st)
-	if config.Key() != key {
-		log.Errorf("lookupBaseOsConfig(%s) got %s; ignored %+v\n",
-			key, config.Key(), config)
-		return nil
-	}
-	return &config
-}
-
-func lookupBaseOsStatus(ctx *zedagentContext, key string) *types.BaseOsStatus {
-	sub := ctx.subBaseOsStatus
-	st, _ := sub.Get(key)
-	if st == nil {
-		log.Infof("lookupBaseOsStatus(%s) not found\n", key)
-		return nil
-	}
-	status := cast.CastBaseOsStatus(st)
-	if status.Key() != key {
-		log.Errorf("lookupBaseOsStatus(%s) got %s; ignored %+v\n",
-			key, status.Key(), status)
-		return nil
-	}
-	return &status
-}
-
-func lookupZbootStatus(ctx *zedagentContext, key string) *types.ZbootStatus {
-	sub := ctx.subZbootStatus
-	st, _ := sub.Get(key)
-	if st == nil {
-		log.Infof("lookupZbootStatus(%s) not found\n", key)
-		return nil
-	}
-	status := cast.ZbootStatus(st)
-	if status.Key() != key {
-		log.Errorf("lookupZbootStatus(%s) got %s; ignored %+v\n",
-			key, status.Key(), status)
-		return nil
-	}
-	return &status
-}
-
-// node reboot request received from nodeagent module
-func initiateDeviceReboot(ctx *zedagentContext, infoStr string) {
-	if ctx.deviceReboot {
-		log.Debugf("deviceReboot is already set\n")
-		return
-	}
-	log.Infof("initiateDeviceReboot(%s)", infoStr)
-	ctx.rebootReason = infoStr
-	triggerDeviceReboot(ctx)
-}
-
-func handleDeviceReboot(ctx *zedagentContext) {
-	if ctx.deviceReboot {
-		log.Debugf("deviceReboot is already set\n")
-		return
-	}
-	log.Infof("Executing device reboot (%s)", ctx.rebootReason)
-	ctx.deviceReboot = true
-	shutdownAppsGlobal(ctx)
-	scheduleExecReboot(ctx.rebootReason)
-}
-
 // utility routines to access baseos partition status
-
 func isZbootValidPartitionLabel(name string) bool {
 	partitionNames := []string{"IMGA", "IMGB"}
 	for _, partName := range partitionNames {
@@ -142,48 +71,4 @@ func getZbootOtherPartition(ctx *zedagentContext) string {
 	}
 	log.Errorf("getZbootOtherPartition() not found\n")
 	return partName
-}
-
-func isBaseOsCurrentPartition(ctx *zedagentContext, partName string) bool {
-	if status := getZbootPartitionStatus(ctx, partName); status != nil {
-		return status.CurrentPartition
-	}
-	return false
-}
-
-func isBaseOsOtherPartition(ctx *zedagentContext, partName string) bool {
-	if status := getZbootPartitionStatus(ctx, partName); status != nil {
-		return !status.CurrentPartition
-	}
-	return false
-}
-
-func isBaseOsOtherPartitionStateUpdating(ctx *zedagentContext) bool {
-	partName := getZbootOtherPartition(ctx)
-	if status := getZbootPartitionStatus(ctx, partName); status != nil {
-		if status.PartitionState == "updating" {
-			return true
-		}
-	}
-	return false
-}
-
-func isBaseOsOtherPartitionStateInProgress(ctx *zedagentContext) bool {
-	partName := getZbootOtherPartition(ctx)
-	if status := getZbootPartitionStatus(ctx, partName); status != nil {
-		if status.PartitionState == "inprogress" {
-			return true
-		}
-	}
-	return false
-}
-
-func isBaseOsCurrentPartitionStateInProgress(ctx *zedagentContext) bool {
-	partName := getZbootCurrentPartition(ctx)
-	if status := getZbootPartitionStatus(ctx, partName); status != nil {
-		if status.PartitionState == "inprogress" {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -412,9 +412,12 @@ func inhaleDeviceConfig(config *zconfig.EdgeDevConfig, getconfigCtx *getconfigCo
 }
 
 func publishZedAgentStatus(getconfigCtx *getconfigContext) {
+	ctx := getconfigCtx.zedagentCtx
 	status := types.ZedAgentStatus{
 		Name:            agentName,
 		ConfigGetStatus: getconfigCtx.configGetStatus,
+		RebootCmd:       ctx.rebootCmd,
+		RebootReason:    ctx.rebootReason,
 	}
 	pub := getconfigCtx.pubZedAgentStatus
 	pub.Publish(agentName, status)

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -29,9 +29,7 @@ import (
 	"container/list"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
-	"strconv"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -85,7 +83,6 @@ type zedagentContext struct {
 	subCertObjConfig          *pubsub.Subscription
 	TriggerDeviceInfo         chan<- struct{}
 	zbootRestarted            bool // published by baseosmgr
-	TriggerDeviceReboot       chan<- struct{}
 	subBaseOsStatus           *pubsub.Subscription
 	subBaseOsDownloadStatus   *pubsub.Subscription
 	subCertObjDownloadStatus  *pubsub.Subscription
@@ -97,6 +94,7 @@ type zedagentContext struct {
 	subGlobalConfig           *pubsub.Subscription
 	GCInitialized             bool // Received initial GlobalConfig
 	subZbootStatus            *pubsub.Subscription
+	rebootCmd                 bool
 	rebootCmdDeferred         bool
 	deviceReboot              bool
 	rebootReason              string
@@ -166,66 +164,8 @@ func Run() {
 	log.Infof("Starting %s\n", agentName)
 
 	triggerDeviceInfo := make(chan struct{}, 1)
-	triggerDeviceReboot := make(chan struct{}, 1)
-	zedagentCtx := zedagentContext{TriggerDeviceInfo: triggerDeviceInfo,
-		TriggerDeviceReboot: triggerDeviceReboot}
+	zedagentCtx := zedagentContext{TriggerDeviceInfo: triggerDeviceInfo}
 	zedagentCtx.physicalIoAdapterMap = make(map[string]types.PhysicalIOAdapter)
-
-	// If we have a reboot reason from this or the other partition
-	// (assuming the other is in inprogress) then we log it
-	// We assume the log makes it reliably to zedcloud hence we discard
-	// the reason.
-	zedagentCtx.rebootReason, zedagentCtx.rebootTime, zedagentCtx.rebootStack =
-		agentlog.GetCurrentRebootReason()
-	if zedagentCtx.rebootReason != "" {
-		log.Warnf("Current partition rebooted reason: %s\n",
-			zedagentCtx.rebootReason)
-		agentlog.DiscardCurrentRebootReason()
-	}
-	otherRebootReason, otherRebootTime, otherRebootStack := agentlog.GetOtherRebootReason()
-	if otherRebootReason != "" {
-		log.Warnf("Other partition rebooted reason: %s\n",
-			otherRebootReason)
-		agentlog.DiscardOtherRebootReason()
-	}
-	commonRebootReason, commonRebootTime, commonRebootStack := agentlog.GetCommonRebootReason()
-	if commonRebootReason != "" {
-		log.Warnf("Common rebooted reason: %s\n",
-			commonRebootReason)
-		agentlog.DiscardCommonRebootReason()
-	}
-	if zedagentCtx.rebootReason == "" {
-		zedagentCtx.rebootReason = otherRebootReason
-		zedagentCtx.rebootTime = otherRebootTime
-		zedagentCtx.rebootStack = otherRebootStack
-	}
-	if zedagentCtx.rebootReason == "" {
-		zedagentCtx.rebootReason = commonRebootReason
-		zedagentCtx.rebootTime = commonRebootTime
-		zedagentCtx.rebootStack = commonRebootStack
-	}
-	if zedagentCtx.rebootReason == "" {
-		zedagentCtx.rebootTime = time.Now()
-		dateStr := zedagentCtx.rebootTime.Format(time.RFC3339Nano)
-		var reason string
-		if fileExists(firstbootFile) {
-			reason = fmt.Sprintf("NORMAL: First boot of device - at %s\n",
-				dateStr)
-		} else {
-			reason = fmt.Sprintf("Unknown reboot reason - power failure or crash - at %s\n",
-				dateStr)
-		}
-		log.Warnf(reason)
-		zedagentCtx.rebootReason = reason
-		zedagentCtx.rebootTime = time.Now()
-		zedagentCtx.rebootStack = ""
-	}
-	if fileExists(firstbootFile) {
-		os.Remove(firstbootFile)
-	}
-
-	// Read and increment restartCounter
-	zedagentCtx.restartCounter = incrementRestartCounter()
 
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(25 * time.Second)
@@ -233,7 +173,6 @@ func Run() {
 	agentlog.StillRunning(agentName + "config")
 	agentlog.StillRunning(agentName + "metrics")
 	agentlog.StillRunning(agentName + "devinfo")
-	agentlog.StillRunning(agentName + "reboot")
 
 	// Tell ourselves to go ahead
 	// initialize the module specifig stuff
@@ -517,9 +456,6 @@ func Run() {
 	zedagentCtx.subDevicePortConfigList = subDevicePortConfigList
 	subDevicePortConfigList.Activate()
 
-	// start device reboot handler task
-	go deviceRebootTask(&zedagentCtx, triggerDeviceReboot)
-
 	// Read the GlobalConfig first
 	// Wait for initial GlobalConfig
 	for !zedagentCtx.GCInitialized {
@@ -744,11 +680,6 @@ func Run() {
 
 	for {
 		select {
-		case change := <-subZbootStatus.C:
-			start := agentlog.StartTime()
-			subZbootStatus.ProcessChange(change)
-			agentlog.CheckMaxTime(agentName, start)
-
 		case change := <-subGlobalConfig.C:
 			start := agentlog.StartTime()
 			subGlobalConfig.ProcessChange(change)
@@ -922,33 +853,6 @@ func deviceInfoTask(ctxPtr *zedagentContext, triggerDeviceInfo <-chan struct{}) 
 		case <-stillRunning.C:
 		}
 		agentlog.StillRunning(agentName + "devinfo")
-	}
-}
-
-func triggerDeviceReboot(ctxPtr *zedagentContext) {
-	log.Info("Trigger DeviceReboot")
-	select {
-	case ctxPtr.TriggerDeviceReboot <- struct{}{}:
-		// Do nothing more
-	default:
-		log.Info("Failed to send on DeviceReboot")
-	}
-}
-
-func deviceRebootTask(ctxPtr *zedagentContext, triggerDeviceReboot <-chan struct{}) {
-
-	// Run a periodic timer so we always update StillRunning
-	stillRunning := time.NewTicker(25 * time.Second)
-	for {
-		select {
-		case <-triggerDeviceReboot:
-			start := agentlog.StartTime()
-			log.Info("deviceReboot request received")
-			handleDeviceReboot(ctxPtr)
-			agentlog.CheckMaxTime(agentName+"reboot", start)
-		case <-stillRunning.C:
-		}
-		agentlog.StillRunning(agentName + "reboot")
 	}
 }
 
@@ -1285,19 +1189,22 @@ func handleNodeAgentStatusModify(ctxArg interface{}, key string,
 	ctx := getconfigCtx.zedagentCtx
 	ctx.remainingTestTime = status.RemainingTestTime
 	getconfigCtx.updateInprogress = status.UpdateInprogress
-	if status.NeedsReboot {
-		initiateDeviceReboot(ctx, status.RebootReason)
-	} else {
-		// if config reboot command was initiated and
-		// was deferred, and the device is not in inprogress
-		// state, initiate the reboot process
-		if ctx.rebootCmdDeferred &&
-			updateInprogress && !status.UpdateInprogress {
-			log.Infof("TestComplete and deferred reboot\n")
-			ctx.rebootCmdDeferred = false
-			infoStr := fmt.Sprintf("TestComplete and deferred Reboot\n")
-			initiateDeviceReboot(ctx, infoStr)
-		}
+	ctx.rebootTime = status.RebootTime
+	ctx.rebootStack = status.RebootStack
+	ctx.rebootReason = status.RebootReason
+	ctx.restartCounter = status.RestartCounter
+	// if config reboot command was initiated and
+	// was deferred, and the device is not in inprogress
+	// state, initiate the reboot process
+	if ctx.rebootCmdDeferred &&
+		updateInprogress && !status.UpdateInprogress {
+		log.Infof("TestComplete and deferred reboot\n")
+		ctx.rebootCmdDeferred = false
+		infoStr := fmt.Sprintf("TestComplete and deferred Reboot Cmd\n")
+		handleRebootCmd(ctx, infoStr)
+	}
+	if status.DeviceReboot {
+		handleDeviceReboot(ctx)
 	}
 	triggerPublishDevInfo(ctx)
 	log.Infof("handleNodeAgentStatusModify: done.\n")
@@ -1314,36 +1221,4 @@ func handleNodeAgentStatusDelete(ctxArg interface{}, key string,
 	log.Infof("handleNodeAgentStatusDelete: for %s\n", key)
 	// Nothing to do
 	triggerPublishDevInfo(ctx)
-}
-
-// If the file doesn't exist we pick zero.
-// Return value before increment; write new value to file
-func incrementRestartCounter() uint32 {
-	var restartCounter uint32
-
-	if _, err := os.Stat(restartCounterFile); err == nil {
-		b, err := ioutil.ReadFile(restartCounterFile)
-		if err != nil {
-			log.Errorf("incrementRestartCounter: %s\n", err)
-		} else {
-			c, err := strconv.Atoi(string(b))
-			if err != nil {
-				log.Errorf("incrementRestartCounter: %s\n", err)
-			} else {
-				restartCounter = uint32(c)
-				log.Infof("incrementRestartCounter: read %d\n", restartCounter)
-			}
-		}
-	}
-	b := []byte(fmt.Sprintf("%d", restartCounter+1))
-	err := ioutil.WriteFile(restartCounterFile, b, 0644)
-	if err != nil {
-		log.Errorf("incrementRestartCounter write: %s\n", err)
-	}
-	return restartCounter
-}
-
-func fileExists(filename string) bool {
-	_, err := os.Stat(filename)
-	return err == nil
 }

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -125,8 +125,6 @@ file = /var/run/${AGENT}metrics.touch
 change = 300
 file = /var/run/${AGENT}devinfo.touch
 change = 300
-file = /var/run/${AGENT}reboot.touch
-change = 300
 EOF
     fi
 done

--- a/pkg/pillar/types/zedagenttypes.go
+++ b/pkg/pillar/types/zedagenttypes.go
@@ -214,9 +214,11 @@ type NodeAgentStatus struct {
 	CurPart           string
 	UpdateInprogress  bool
 	RemainingTestTime time.Duration
-	NeedsReboot       bool
+	DeviceReboot      bool
 	RebootReason      string
-	ErrorStr          string
+	RebootStack       string
+	RebootTime        time.Time
+	RestartCounter    uint32
 }
 
 // Key :
@@ -239,6 +241,8 @@ const (
 type ZedAgentStatus struct {
 	Name            string
 	ConfigGetStatus ConfigGetStatus
+	RebootCmd       bool
+	RebootReason    string
 }
 
 // Key :


### PR DESCRIPTION
> reboot reason handling is now part of nodeagent, (moved from zedagent)
> baseOs ugrade validation failure is picked up from node rebootReason,
      - introduced some reboot specific fields in nodeagent status
      - are picked up be baseosmgr for populating the baseos status
> moved the reboot handling functionality to nodeagent,
> the user triggered reboot command, passed to nodeagent through zedagent status
> removed some dead code from zedagent

Signed-off-by: Srinibas Maharana <srinibas@zededa.com>