### PR TITLE
Added support for a config knob to change minDiskSize reserved for dom0

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -28,6 +28,7 @@
 | debug.enable.ssh | boolean, or authorized ssh key | false | allow ssh to EVE |
 | debug.default.loglevel | string | info | min level saved in files on device |
 | debug.default.remote.loglevel | string | warning | min level sent to controller |
+| storage.dom0.disk.minusage.percent | integer percent | 20 | min. percent of persist partition reserved for dom0 |
 
 In addition, for each agentname, there are specific overrides for the default ones with the names:
 

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -290,7 +290,8 @@ func checkDiskSize(ctxPtr *zedmanagerContext) error {
 		return err
 	}
 	deviceDiskSize := deviceDiskUsage.Total
-	allowedDeviceDiskSizeForApps := float64(deviceDiskSize) * 0.8
+	allowedDeviceDiskSizeForApps := float64(deviceDiskSize) *
+		float64(ctxPtr.globalConfig.Dom0MinDiskUsagePercent) * 0.01
 	if allowedDeviceDiskSizeForApps < float64(totalAppDiskSize) {
 		err := fmt.Errorf("Disk space not available for app - "+
 			"deviceDiskSize: %+v, "+


### PR DESCRIPTION
Signed-off-by: Kalyan Nidumolu <kalyan@zadeda.com>

1) Added Config item to set minDiskSize for Dom0 ( storage.dom0MinDiskUsagePercent )

2) Added Slice Errors to types.GlobalConfig to record any errors found in configItems.
    - Will add the ability to propagate these errors to zedcloud in a subsequent PR.
