### PR TITLE
Run rkt garbage collector periodically.

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -12,6 +12,7 @@
 | timer.use.config.checkpoint | integer in seconds | 600 | use checkpointed config if no cloud connectivity |
 | timer.gc.download | integer in seconds |  600 | garbage collect unused downloaded objects |
 | timer.gc.vdisk | integer in seconds | 1 hour | garbage collect unused instance virtual disk |
+| timer.gc.rkt.graceperiod | integer in seconds | 300 | grace period to be used in rkt gc command |
 | timer.download.retry | integer in seconds | 600 | retry a failed download |
 | timer.boot.retry | integer in seconds | 600 | retry a failed domain boot |
 | timer.port.georedo | integer in seconds | 1 hour | redo IP geolocation |

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -1759,6 +1759,15 @@ func parseConfigItems(config *zconfig.EdgeDevConfig, ctx *getconfigContext) {
 			}
 			newGlobalConfig.VdiskGCTime = uint32(i64)
 
+		case "timer.gc.rkt.graceperiod":
+			i64, err := strconv.ParseInt(item.Value, 10, 32)
+			if err != nil {
+				log.Errorf("parseConfigItems: bad int value %s for %s: %s\n",
+					item.Value, key, err)
+				continue
+			}
+			newGlobalConfig.RktGCGracePeriod = uint32(i64)
+
 		case "timer.download.retry":
 			i64, err := strconv.ParseInt(item.Value, 10, 32)
 			if err != nil {

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -34,6 +34,7 @@ type GlobalConfig struct {
 	StaleConfigTime         uint32 // On reboot use saved config if not stale
 	DownloadGCTime          uint32 // Garbage collect if no use
 	VdiskGCTime             uint32 // Garbage collect RW disk if no use
+	RktGCGracePeriod        uint32 // GracePeriod to be used with rkt gc
 
 	DownloadRetryTime   uint32 // Retry failed download after N sec
 	DomainBootRetryTime uint32 // Retry failed boot after N sec
@@ -124,6 +125,7 @@ var GlobalConfigDefaults = GlobalConfig{
 	VdiskGCTime:         3600, // 1 hour
 	DownloadRetryTime:   600,  // 10 minutes
 	DomainBootRetryTime: 600,  // 10 minutes
+	RktGCGracePeriod:    300,  // 5 minutes
 
 	AllowNonFreeAppImages:  TS_ENABLED,
 	AllowNonFreeBaseImages: TS_ENABLED,
@@ -201,6 +203,9 @@ func ApplyGlobalConfig(newgc GlobalConfig) GlobalConfig {
 	if newgc.AllowNonFreeBaseImages == TS_NONE {
 		newgc.AllowNonFreeBaseImages = GlobalConfigDefaults.AllowNonFreeBaseImages
 	}
+	if newgc.RktGCGracePeriod == 0 {
+		newgc.RktGCGracePeriod = GlobalConfigDefaults.RktGCGracePeriod
+	}
 	return newgc
 }
 
@@ -223,6 +228,7 @@ var GlobalConfigMinimums = GlobalConfig{
 	VdiskGCTime:         60,
 	DownloadRetryTime:   60,
 	DomainBootRetryTime: 10,
+	RktGCGracePeriod:    30,
 }
 
 func EnforceGlobalConfigMinimums(newgc GlobalConfig) GlobalConfig {
@@ -300,6 +306,11 @@ func EnforceGlobalConfigMinimums(newgc GlobalConfig) GlobalConfig {
 		log.Warnf("Enforce minimum DomainBootRetryTime received %d; using %d",
 			newgc.DomainBootRetryTime, GlobalConfigMinimums.DomainBootRetryTime)
 		newgc.DomainBootRetryTime = GlobalConfigMinimums.DomainBootRetryTime
+	}
+	if newgc.RktGCGracePeriod < GlobalConfigMinimums.RktGCGracePeriod {
+		log.Warnf("Enforce minimum RktGCGracePeriod received %d; using %d",
+			newgc.RktGCGracePeriod, GlobalConfigMinimums.RktGCGracePeriod)
+		newgc.RktGCGracePeriod = GlobalConfigMinimums.RktGCGracePeriod
 	}
 	return newgc
 }


### PR DESCRIPTION
1) Run rkt garbage collector periodically.
2) Added a config item to set the grace-period for garbage collection
      timer.gc.rktGracePeriod

Testing:
 1) Verified rkt garbage collector is being run periodically with the specified grace period.
 2) Verified the rkt gc graceperiod can be set with:
        zcli edge-node update $DEVICE --config="timer.gc.rktGracePeriod:100"
        zcli edge-node update $DEVICE --config="timer.gc.rktGracePeriod:default"
           - Reset Graceperiod to default
        zcli edge-node update $DEVICE --config="timer.gc.rktGracePeriod:0"
          - Negative Test - Verified min. graceperiod of 30s is being enforced.

        
Signed-off-by: Kalyan Nidumolu <kalyan@zadeda.com>