### PR TITLE
Azure error handling and updating blob URL while uploading

### DIFF
--- a/pkg/pillar/zedUpload/datastore_azure.go
+++ b/pkg/pillar/zedUpload/datastore_azure.go
@@ -16,6 +16,7 @@ import (
 func (ep *AzureTransportMethod) Action(req *DronaRequest) error {
 	var err error
 	var size int
+	var loc string
 	var list []string
 	var contentLength int64
 	var remoteFileMD5 string
@@ -24,7 +25,8 @@ func (ep *AzureTransportMethod) Action(req *DronaRequest) error {
 	case SyncOpDownload:
 		err = ep.processAzureDownload(req)
 	case SyncOpUpload:
-		err = ep.processAzureUpload(req)
+		loc, err = ep.processAzureUpload(req)
+		req.objloc = loc
 	case SyncOpDelete:
 		err = ep.processAzureBlobDelete(req)
 	case SyncOpList:
@@ -75,13 +77,13 @@ func (ep *AzureTransportMethod) WithLogging(onoff bool) error {
 }
 
 // File upload to Azure Blob Datastore
-func (ep *AzureTransportMethod) processAzureUpload(req *DronaRequest) error {
+func (ep *AzureTransportMethod) processAzureUpload(req *DronaRequest) (string, error) {
 	file := req.name
-	err := azure.UploadAzureBlob(ep.acName, ep.acKey, ep.container, file, req.objloc, ep.hClient)
+	loc, err := azure.UploadAzureBlob(ep.acName, ep.acKey, ep.container, file, req.objloc, ep.hClient)
 	if err != nil {
-		return err
+		return loc, err
 	}
-	return nil
+	return loc, nil
 }
 
 // File download from Azure Blob Datastore


### PR DESCRIPTION
1. While checking azure container exists or not, we are returning proper
error.
2. While uploading to azure, we are updating the blob URL in the zedUpload structure.

Signed-off-by: zed-rishabh <rgupta@zededa.com>