### PR TITLE
siwtched NI IfNameList should not take from probing CurrUplinkIntf

### DIFF
--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -333,7 +333,8 @@ func publishNetworkInstanceConfig(ctx *getconfigContext,
 					networkInstanceConfig.DisplayName,
 					networkInstanceConfig.IpType,
 					types.AddressTypeNone)
-				continue
+				// Let's relax the requirement until cloud side update the right IpType
+				networkInstanceConfig.IpType = types.AddressTypeNone
 			}
 			ctx.pubNetworkInstanceConfig.Publish(networkInstanceConfig.UUID.String(),
 				&networkInstanceConfig)

--- a/pkg/pillar/cmd/zedrouter/acl.go
+++ b/pkg/pillar/cmd/zedrouter/acl.go
@@ -946,9 +946,9 @@ func aceToRules(aclArgs types.AppNetworkACLArgs, ace types.ACE) (types.IPTablesR
 	aclRule3.IsUserConfigured = true
 	aclRule3.RuleID = ace.RuleID
 	if aclArgs.NIType == types.NetworkInstanceTypeSwitch {
-		if len(aclArgs.UpLinks) > 1 {
-			errStr := fmt.Sprintf("aceToRules: Switch network instance with more than ONE " +
-				"uplink attached is not supported now.")
+		if len(aclArgs.UpLinks) != 1 {
+			errStr := fmt.Sprintf("aceToRules: Switch network instance is only supported with exactly one " +
+				"uplink attached for now.")
 			log.Errorln(errStr)
 			return nil, errors.New(errStr)
 		} else {

--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -1140,7 +1140,12 @@ func doNetworkInstanceActivate(ctx *zedrouterContext,
 	}
 
 	// Get a list of IfNames to the ones we have an ifIndex for.
-	status.IfNameList = getIfNameListForPort(ctx, status.CurrentUplinkIntf)
+	if status.Type == types.NetworkInstanceTypeSwitch {
+		// switched NI is not probed and does not have a CurrentUplinkIntf
+		status.IfNameList = getIfNameListForPort(ctx, status.Port)
+	} else {
+		status.IfNameList = getIfNameListForPort(ctx, status.CurrentUplinkIntf)
+	}
 	log.Infof("IfNameList: %+v", status.IfNameList)
 
 	switch status.Type {


### PR DESCRIPTION
Signed-off-by: Naiming Shen <naiming@zededa.com>

- when do activate NI, check the NI type, if is switchnet type, using the status.Port to acquire the IfNameList, since the NI is not probing related
- in ACL code, check for switchnet NI need to have only one uplink port, in case the switchnet have a need to attach to uplink port 'None'
- relax the check for IpType on switched NI in configure until the server side is corrected the type