### PR TITLE
Working around Xen 4.13 RC2

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -87,7 +87,7 @@ function set_x86_64 {
 function set_x86_64_baremetal {
    set_generic
    set_x86_64
-   set_global xen_platform_tweaks "efi=no-rs"
+   set_global xen_platform_tweaks " "
    set_global linux_qemu_tweaks " "
    set_global linux_console "console=tty0 console=ttyS0"
 }
@@ -154,8 +154,6 @@ menuentry "Boot ${rootfs_title}" {
 
         $hv_cmd
         $dom0_cmd
-        $initrd_cmd
-        $devicetree_cmd
 }
 
 submenu 'Set Boot Options' {


### PR DESCRIPTION
A potential workaround that would allow us to keep testing Xen 4.13 RC2 