### PR TITLE
Use gotestsum To Run Unit Tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ QEMU_SYSTEM=$(QEMU_SYSTEM_$(ZARCH))
 
 # where we store outputs
 DIST=$(CURDIR)/dist/$(ZARCH)
+DOCKER_DIST=/eve/dist/$(ZARCH)
 
 DOCKER_ARCH_TAG=$(ZARCH)
 
@@ -142,7 +143,7 @@ all: help
 
 test: $(GOBUILDER) | $(DIST)
 	@echo Running tests on $(GOMODULE)
-	@$(DOCKER_GO) "set -o pipefail ; go test -v ./... 2>&1 | go-junit-report | sed -e 1d" $(GOTREE) $(GOMODULE) > $(DIST)/results.xml
+	@$(DOCKER_GO) "gotestsum --junitfile $(DOCKER_DIST)/results.xml" $(GOTREE) $(GOMODULE)
 
 clean:
 	rm -rf $(DIST) pkg/pillar/Dockerfile pkg/qrexec-lib/Dockerfile pkg/qrexec-dom0/Dockerfile \

--- a/build-tools/src/scripts/Dockerfile
+++ b/build-tools/src/scripts/Dockerfile
@@ -15,7 +15,7 @@ RUN addgroup -g ${GID} ${GROUP} && adduser -h /home/${USER} -G ${GROUP} -D -H -u
 RUN echo "${USER} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/${USER}
 RUN go get github.com/golang/dep/cmd/dep 
 RUN go get -u github.com/golang/protobuf/protoc-gen-go
-RUN go get -u github.com/jstemmer/go-junit-report
+RUN go get -u gotest.tools/gotestsum
 RUN mv /go/bin/* /usr/bin
 ENV HOME /home/${USER}
 ENV GOFLAGS=-mod=vendor


### PR DESCRIPTION
This commit uses the gotestsum tool to run unit tests.
gotestsum provides human-readable output from go test while also
outputting a Junit XML file.

Relates-To: #121

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>