### PR TITLE
Fix bugs in handling rkt fetch - Support multiple repos / Fix buggy removal of files.

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1276,6 +1276,9 @@ func doInactivate(ctx *domainContext, status *types.DomainStatus) {
 	// Do we need to delete any rw files that should
 	// not be preserved across reboots?
 	for _, ds := range status.DiskStatusList {
+		if status.IsContainer {
+			continue
+		}
 		if !ds.ReadOnly && !ds.Preserve {
 			log.Infof("Delete copy at %s\n", ds.ActiveFileLocation)
 			if err := os.Remove(ds.ActiveFileLocation); err != nil {

--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -39,10 +39,9 @@ import (
 
 const (
 	agentName = "downloader"
-	// persistRktLocalConfigDir - Location of dir used by rkt local data
-	persistRktLocalConfigDir = types.PersistDir + "/rktlocal"
-	// persistRktLocalConfigAuthDir - used for storing auth files by rkt
-	persistRktLocalConfigAuthDir = persistRktLocalConfigDir + "/auth.d"
+	// persistRktLocalConfigBase - Base Dir used for LocalConfigDir for
+	//  rkt Container images
+	persistRktLocalConfigBase = types.PersistDir + "/rktlocal"
 )
 
 // Go doesn't like this as a constant
@@ -628,6 +627,7 @@ func handleCreate(ctx *downloaderContext, objType string,
 	// Start by marking with PendingAdd
 	status := types.DownloaderStatus{
 		DatastoreID:      config.DatastoreID,
+		ImageID:          config.ImageID,
 		Safename:         config.Safename,
 		Name:             config.Name,
 		ObjType:          objType,
@@ -800,6 +800,13 @@ func handleDelete(ctx *downloaderContext, key string,
 
 	status.PendingDelete = true
 	publishDownloaderStatus(ctx, status)
+
+	// If Container, delete LocalConfigDir
+	if status.ContainerRktLocalConfigDir != "" {
+		if err := os.RemoveAll(status.ContainerRktLocalConfigDir); err != nil {
+			log.Fatal(err)
+		}
+	}
 
 	// Update globalStatus and status
 	unreserveSpace(ctx, status)
@@ -1514,26 +1521,30 @@ func rktFetch(url string, localConfigDir string, pullPolicy string) (string, err
 	return imageID, nil
 }
 
-func rktAuthFilename(appName string) string {
-	return persistRktLocalConfigAuthDir + "/rktAuth" + appName + ".json"
-}
-
-func rktCreateAuthFile(config *types.DownloaderConfig,
-	dsCtx types.DatastoreContext, registry string) (string, error) {
+// createRktLocalDirAndAuthFile
+//  Return Values: localConfigDir, AuthFileName, err
+func createRktLocalDirAndAuthFile(imageID uuid.UUID,
+	dsCtx types.DatastoreContext, registry string) (string, string, error) {
 
 	if len(strings.TrimSpace(dsCtx.APIKey)) == 0 {
-		log.Debugf("rktCreateAuthFile: empty APIKey. Skipping AuthFile")
-		return "", nil
+		log.Debugf("createRktLocalDirAndAuthFile: empty APIKey. " +
+			"Skipping AuthFile")
+		return "", "", nil
 	}
 
-	err := os.MkdirAll(persistRktLocalConfigAuthDir, 0755)
+	// Create Local Directory with name imageSafeName
+	// The directory structure should be:
+	// <persistRktLocalConfigBase>/<uuid>/auth.d/rktAuth<appName>.json
+	localConfigDir := persistRktLocalConfigBase + "/" + imageID.String() +
+		"/auth.d"
+	authFileName := localConfigDir + "/docker.json"
+	err := os.MkdirAll(localConfigDir, 0755)
 	if err != nil {
-		log.Errorf("rktCreateAuthFile: empty username. Skipping AuthFile")
-		return "", fmt.Errorf("Failed create dir %s, "+
-			"err: %+v\n", persistRktLocalConfigAuthDir, err)
+		log.Errorf("createRktLocalDirAndAuthFile: empty username." +
+			" Skipping AuthFile")
+		return "", "", fmt.Errorf("Failed create dir %s, err: %+v\n",
+			localConfigDir, err)
 	}
-
-	filename := rktAuthFilename(config.Safename)
 
 	rktAuth := types.RktAuthInfo{
 		RktKind:    "dockerAuth",
@@ -1544,21 +1555,21 @@ func rktCreateAuthFile(config *types.DownloaderConfig,
 			Password: dsCtx.Password,
 		},
 	}
-	log.Infof("rktCreateAuthFile: created Auth file %s\n"+
+	log.Infof("createRktLocalDirAndAuthFile: created Auth file %s\n"+
 		"RktKind: %s, RktVersion: %s, Registries: %+v, \n",
-		filename, rktAuth.RktKind, rktAuth.RktVersion, rktAuth.Registries)
+		authFileName, rktAuth.RktKind, rktAuth.RktVersion, rktAuth.Registries)
 
-	file, err := json.MarshalIndent(rktAuth, "", " ")
+	rktAuthJson, err := json.MarshalIndent(rktAuth, "", " ")
 	if err != nil {
-		return "", fmt.Errorf("Failed convert rktAuth to json"+
+		return "", "", fmt.Errorf("Failed convert rktAuth to json"+
 			"err: %+v\n", err)
 	}
-	err = ioutil.WriteFile(filename, file, 0644)
+	err = ioutil.WriteFile(authFileName, rktAuthJson, 0644)
 	if err != nil {
-		return "", fmt.Errorf("Failed to create Auth file for"+
+		return "", "", fmt.Errorf("Failed to create Auth file for"+
 			"rkt fetch: %+v\n", err)
 	}
-	return filename, nil
+	return localConfigDir, authFileName, nil
 }
 
 func rktFetchContainerImage(ctx *downloaderContext, key string,
@@ -1569,18 +1580,17 @@ func rktFetchContainerImage(ctx *downloaderContext, key string,
 	publishDownloaderStatus(ctx, status)
 
 	imageID := ""
-	var authFile string
+	var authFile, localConfigDir string
 	registry, downloadURL, err := getContainerRegistry(dsCtx.DownloadURL)
 	if err == nil {
 		// Save credentials to Auth file
 		log.Infof("rktFetchContainerImage: fetch  <%s>\n", dsCtx.DownloadURL)
-		authFile, err = rktCreateAuthFile(&config, dsCtx, registry)
+		localConfigDir, authFile, err = createRktLocalDirAndAuthFile(
+			config.ImageID, dsCtx, registry)
 		if err == nil {
-			log.Debugf("rktFetchContainerImage: authFile: %s\n", authFile)
-			// We should really move to have per-fetch directory..
-			localConfigDir := persistRktLocalConfigDir
+			log.Debugf("rktFetchContainerImage: localConfigDir: %s, authFile: %s\n",
+				localConfigDir, authFile)
 			if len(authFile) == 0 {
-				localConfigDir = ""
 				log.Infof("rktFetchContainerImage: no Auth File")
 			}
 			imageID, err = rktFetch(downloadURL, localConfigDir, pullPolicy)
@@ -1611,6 +1621,8 @@ func rktFetchContainerImage(ctx *downloaderContext, key string,
 	// We do not clear any status.RetryCount, LastErr, etc. The caller
 	// should look at State == DOWNLOADED to determine it is done.
 	status.ContainerImageID = imageID
+	status.ContainerRktLocalConfigDir = localConfigDir
+	status.ContainerRktAuthFileName = authFile
 	status.ModTime = time.Now()
 	status.PendingAdd = false
 	status.State = types.DOWNLOADED

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -953,7 +953,7 @@ func parseStorageConfigList(objType string,
 			id, _ := uuid.FromString(drive.Image.DsId)
 			image.DatastoreID = id
 			image.Name = drive.Image.Name
-
+			image.ImageID, _ = uuid.FromString(drive.Image.Uuidandversion.Uuid)
 			image.Format = strings.ToLower(drive.Image.Iformat.String())
 			image.Size = uint64(drive.Image.SizeBytes)
 			image.ImageSignature = drive.Image.Siginfo.Signature

--- a/pkg/pillar/cmd/zedmanager/handledownloader.go
+++ b/pkg/pillar/cmd/zedmanager/handledownloader.go
@@ -26,6 +26,7 @@ func AddOrRefcountDownloaderConfig(ctx *zedmanagerContext, safename string,
 			safename)
 		n := types.DownloaderConfig{
 			DatastoreID: ss.DatastoreID,
+			ImageID:     ss.ImageID,
 			Safename:    safename,
 			Name:        ss.Name,
 			NameIsURL:   ss.NameIsURL,

--- a/pkg/pillar/types/downloadertypes.go
+++ b/pkg/pillar/types/downloadertypes.go
@@ -27,7 +27,9 @@ type RktAuthInfo struct {
 // The key/index to this is the Safename which is allocated by ZedManager.
 // That is the filename in which we store the corresponding json files.
 type DownloaderConfig struct {
-	DatastoreID      uuid.UUID
+	DatastoreID uuid.UUID
+	// ImageID - UUID of the image
+	ImageID          uuid.UUID
 	Safename         string
 	Name             string
 	NameIsURL        bool // If not we form URL based on datastore info
@@ -63,7 +65,9 @@ type CertConfig struct {
 // The key/index to this is the Safename which comes from DownloaderConfig.
 // That is the filename in which we store the corresponding json files.
 type DownloaderStatus struct {
-	DatastoreID      uuid.UUID
+	DatastoreID uuid.UUID
+	// ImageID - UUID of the image
+	ImageID          uuid.UUID
 	Safename         string
 	Name             string
 	ObjType          string
@@ -76,8 +80,7 @@ type DownloaderStatus struct {
 	Expired          bool      // Handshake to client
 	NameIsURL        bool      // If not we form URL based on datastore info
 	AllowNonFreePort bool
-	ImageSha256      string // sha256 of immutable image
-	ContainerImageID string
+	ImageSha256      string  // sha256 of immutable image
 	State            SwState // DOWNLOADED etc
 	ReservedSpace    uint64  // Contribution to global ReservedSpace
 	Size             uint64  // Once DOWNLOADED; in bytes
@@ -86,6 +89,17 @@ type DownloaderStatus struct {
 	LastErr          string // Download error
 	LastErrTime      time.Time
 	RetryCount       int
+
+	// Conttainer Related Info
+	// ContainerImageID - Rkt ImageID of Container. This is the IMAGE ID
+	// assigned to the Container Image when rkt downloads it.
+	ContainerImageID string
+	// ContainerRktLocalDir - Local Dir ( Absolute path ) used by rkt to
+	// fetch the container
+	ContainerRktLocalConfigDir string
+	// ContainerRktAuthFileName - AuthFileName for the image. his file would
+	// be in ContainerRktLocalDir.
+	ContainerRktAuthFileName string
 }
 
 func (status DownloaderStatus) Key() string {

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -219,7 +219,10 @@ type EIDOverlayConfig struct {
 // - "ramdisk"
 // - "device_tree"
 type StorageConfig struct {
-	DatastoreID      uuid.UUID
+	// DatastoreID - UUID of the DataStore
+	DatastoreID uuid.UUID
+	// ImageID - UUID of the image
+	ImageID          uuid.UUID
 	Name             string   // XXX Do depend on URL for clobber avoidance?
 	NameIsURL        bool     // If not we form URL based on datastore info
 	Size             uint64   // In bytes
@@ -242,7 +245,9 @@ func RoundupToKB(b uint64) uint64 {
 }
 
 type StorageStatus struct {
-	DatastoreID        uuid.UUID
+	DatastoreID uuid.UUID
+	// ImageID - UUID of the image
+	ImageID            uuid.UUID
 	Name               string
 	ImageSha256        string   // sha256 of immutable image
 	NameIsURL          bool     // If not we form URL based on datastore info
@@ -273,6 +278,7 @@ type StorageStatus struct {
 // UpdateFromStorageConfig sets up StorageStatus based on StorageConfig struct
 func (ss *StorageStatus) UpdateFromStorageConfig(sc StorageConfig) {
 	ss.DatastoreID = sc.DatastoreID
+	ss.ImageID = sc.ImageID
 	ss.Name = sc.Name
 	ss.NameIsURL = sc.NameIsURL
 	ss.ImageSha256 = sc.ImageSha256


### PR DESCRIPTION
1) Create separate local directories for each image with datasore authentication information

2) Added support to store Image UUID for all images.
   - Use this for any image name uses instead of safe name.

3) Fixed a bug to not remove rkt files un-intentionally

Signed-off-by: Kalyan Nidumolu <kalyan@zadeda.com>