### PR TITLE
Fix bug in Storage usage check for Apps

### DIFF
--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -647,7 +647,8 @@ func handleCreate(ctx *downloaderContext, objType string,
 	// XXX RefCount -> 0 should keep it reserved.
 	kb := types.RoundupToKB(config.Size)
 	if !tryReserveSpace(ctx, &status, kb) {
-		errString := fmt.Sprintf("Would exceed remaining space %d vs %d\n",
+		errString := fmt.Sprintf("Would exceed remaining space. "+
+			"SizeOfAppImage: %d, RemainingSpace: %d\n",
 			kb, ctx.globalStatus.RemainingSpace)
 		log.Errorln(errString)
 		status.PendingAdd = false


### PR DESCRIPTION
1) Fix race condition between zedagent and DownloadMgr - Make zedagent start before Download Mgr 
     - Start Downloader, verifier and domainMgr after Level1 agents

2) Fix a bug in enforcing minDom0Percent.

3) Improve error messages for App instance failure due to disk space
   not available.

Signed-off-by: Kalyan Nidumolu <kalyan@zadeda.com>