### PR TITLE
Optimization of disk usage by tpm2-tools

### DIFF
--- a/pkg/vtpm/Dockerfile
+++ b/pkg/vtpm/Dockerfile
@@ -34,6 +34,8 @@ RUN ./bootstrap && \
 WORKDIR /
 RUN git clone --branch=4.0.1-rc0 https://github.com/tpm2-software/tpm2-tools
 WORKDIR /tpm2-tools
+ADD patch-tpm2-tools.diff .
+RUN patch -p1 < patch-tpm2-tools.diff
 
 #There is a known issue: curl-dev and openssl-dev don't go together,
 #due to conflict between openssl-dev and libressl-dev(from curl-dev).
@@ -50,6 +52,9 @@ RUN apk add --no-cache openssl-dev=1.0.2t-r0
 COPY --from=curl-dev-bits /usr/include/curl /usr/include/curl
 COPY --from=curl-dev-bits /usr/lib/libcurl.so /usr/lib/libcurl.so
 RUN make
+RUN mkdir /out
+RUN cp lib/.libs/libcommon.so* /out/
+RUN cp tools/.libs/tpm2_* /out/
 
 #The vTPM server
 COPY ./ /vtpm_server
@@ -67,16 +72,32 @@ COPY --from=build /usr/local/lib/libtss2-esys.so.0 /usr/local/lib
 COPY --from=build /usr/local/lib/libtss2-sys.so.0.0.0 /usr/local/lib
 COPY --from=build /usr/local/lib/libtss2-sys.so.0 /usr/local/lib
 COPY --from=build /usr/local/lib/libtss2-tcti-device.so.0 /usr/local/lib
-COPY --from=build /tpm2-tools/tools/tpm2_createek /usr/bin/
-COPY --from=build /tpm2-tools/tools/tpm2_createak /usr/bin/
-COPY --from=build /tpm2-tools/tools/tpm2_createprimary /usr/bin/
-COPY --from=build /tpm2-tools/tools/tpm2_getcap /usr/bin/
-COPY --from=build /tpm2-tools/tools/tpm2_sign /usr/bin/
-COPY --from=build /tpm2-tools/tools/tpm2_verifysignature /usr/bin/
-COPY --from=build /tpm2-tools/tools/tpm2_evictcontrol /usr/bin/
-COPY --from=build /tpm2-tools/tools/tpm2_import /usr/bin/
-COPY --from=build /tpm2-tools/tools/tpm2_load /usr/bin/
-COPY --from=build /tpm2-tools/tools/tpm2_hmac /usr/bin/
+COPY --from=build /out/libcommon.so.0.0.0 /usr/local/lib
+COPY --from=build /out/libcommon.so.0 /usr/local/lib
+COPY --from=build /out/libcommon.so /usr/local/lib
+COPY --from=build /out/tpm2_createek /usr/bin/
+COPY --from=build /out/tpm2_createak /usr/bin/
+COPY --from=build /out/tpm2_createprimary /usr/bin/
+COPY --from=build /out/tpm2_getcap /usr/bin/
+COPY --from=build /out/tpm2_sign /usr/bin/
+COPY --from=build /out/tpm2_verifysignature /usr/bin/
+COPY --from=build /out/tpm2_evictcontrol /usr/bin/
+COPY --from=build /out/tpm2_import /usr/bin/
+COPY --from=build /out/tpm2_load /usr/bin/
+COPY --from=build /out/tpm2_hmac /usr/bin/
+COPY --from=build /out/tpm2_readpublic /usr/bin/
+COPY --from=build /out/tpm2_activatecredential /usr/bin
+COPY --from=build /out/tpm2_makecredential /usr/bin
+COPY --from=build /out/tpm2_dictionarylockout /usr/bin
+COPY --from=build /out/tpm2_startauthsession /usr/bin
+COPY --from=build /out/tpm2_policysecret /usr/bin
+COPY --from=build /out/tpm2_policypassword /usr/bin
+COPY --from=build /out/tpm2_policycommandcode /usr/bin
+COPY --from=build /out/tpm2_create /usr/bin
+COPY --from=build /out/tpm2_loadexternal /usr/bin
+COPY --from=build /out/tpm2_duplicate /usr/bin
+COPY --from=build /out/tpm2_flushcontext /usr/bin
+COPY --from=build /out/tpm2_rsadecrypt /usr/bin
 COPY --from=build /vtpm_server/vtpm_server /usr/bin/
 COPY init.sh /usr/bin/
 ENTRYPOINT []

--- a/pkg/vtpm/Dockerfile
+++ b/pkg/vtpm/Dockerfile
@@ -34,7 +34,7 @@ RUN ./bootstrap && \
 WORKDIR /
 RUN git clone --branch=4.0.1-rc0 https://github.com/tpm2-software/tpm2-tools
 WORKDIR /tpm2-tools
-ADD patch-tpm2-tools.diff .
+COPY patch-tpm2-tools.diff .
 RUN patch -p1 < patch-tpm2-tools.diff
 
 #There is a known issue: curl-dev and openssl-dev don't go together,

--- a/pkg/vtpm/patch-tpm2-tools.diff
+++ b/pkg/vtpm/patch-tpm2-tools.diff
@@ -1,0 +1,44 @@
+diff --git a/Makefile.am b/Makefile.am
+index 13b23dcd..e75eb091 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -14,7 +14,7 @@ include src_vars.mk
+ ACLOCAL_AMFLAGS = -I m4 --install
+ 
+ INCLUDE_DIRS = -I$(top_srcdir)/tools -I$(top_srcdir)/lib
+-LIB_COMMON := lib/libcommon.a
++LIB_COMMON := lib/libcommon.la
+ 
+ AM_CFLAGS := \
+     $(INCLUDE_DIRS) $(EXTRA_CFLAGS) $(TSS2_ESYS_CFLAGS) $(TSS2_MU_CFLAGS) \
+@@ -105,9 +105,9 @@ bin_PROGRAMS = \
+     tools/tpm2_verifysignature
+ 
+ 
+-noinst_LIBRARIES = $(LIB_COMMON)
+-lib_libcommon_a_SOURCES = $(LIB_SRC)
+-lib_libcommon_a_CFLAGS = -fPIC $(AM_CFLAGS)
++lib_LTLIBRARIES = $(LIB_COMMON)
++lib_libcommon_la_SOURCES = $(LIB_SRC)
++lib_libcommon_la_CFLAGS = -fPIC -shared $(AM_CFLAGS)
+ TOOL_SRC := tools/tpm2_tool.c tools/tpm2_tool.h
+ 
+ tools_misc_tpm2_checkquote_SOURCES = tools/misc/tpm2_checkquote.c $(TOOL_SRC)
+diff --git a/tools/tpm2_import.c b/tools/tpm2_import.c
+index b782edeb..ee8aea4b 100644
+--- a/tools/tpm2_import.c
++++ b/tools/tpm2_import.c
+@@ -583,13 +583,6 @@ static tool_rc tpm_import(ESYS_CONTEXT *ectx) {
+         return tool_rc_general_error;
+     }
+ 
+-public.publicArea.authPolicy.size = sizeof(public.publicArea.authPolicy.buffer);
+-    result = files_load_bytes_from_path(ctx.policy,
+-        public.publicArea.authPolicy.buffer,
+-            &public.publicArea.authPolicy.size);
+-    if (!result) {
+-        return tool_rc_general_error;
+-    }
+ 
+     rc = tpm2_import(ectx, &ctx.parent.object, &enc_key, &public, &duplicate,
+             &encrypted_seed, &sym_alg, &imported_private);


### PR DESCRIPTION
- Changed libcommon library from static to shared
- Earlier each of tpm2_* commands(e.g. tpm2_sign) were statically linked to this.
- With this change, total rootfs size has come down by 2MB.

Signed-off-by: Hariharasubramanian C S <cshari@zededa.com>