### PR TITLE
Added knob to ignore disk check.

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -29,6 +29,7 @@
 | debug.default.loglevel | string | info | min level saved in files on device |
 | debug.default.remote.loglevel | string | warning | min level sent to controller |
 | storage.dom0.disk.minusage.percent | integer percent | 20 | min. percent of persist partition reserved for dom0 |
+| storage.apps.ignore.disk.check | boolean | false | Ignore disk usage check for Apps. Allows apps to create images bigger than available disk|
 
 In addition, for each agentname, there are specific overrides for the default ones with the names:
 

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -1860,6 +1860,15 @@ func parseConfigItems(config *zconfig.EdgeDevConfig, ctx *getconfigContext) {
 			log.Infof("Set storage.dom0MinDiskUsagePercent to %d",
 				newGlobalConfig.Dom0MinDiskUsagePercent)
 
+		case "storage.apps.ignore.disk.check":
+			newBool, err := strconv.ParseBool(item.Value)
+			if err != nil {
+				log.Errorf("parseConfigItems: bad bool value %s for %s: %s\n",
+					item.Value, key, err)
+				continue
+			}
+			newGlobalConfig.IgnoreDiskCheckForApps = newBool
+
 		default:
 			// Handle agentname items for loglevels
 			newString := item.Value

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -263,6 +263,12 @@ func updateOrRemove(ctx *zedmanagerContext, status types.AppInstanceStatus) {
 func checkDiskSize(ctxPtr *zedmanagerContext) error {
 
 	var totalAppDiskSize uint64
+
+	if ctxPtr.globalConfig.IgnoreDiskCheckForApps {
+		log.Debugf("Ignoring diskchecks for Apps")
+		return nil
+	}
+
 	appDiskSizeList := ""
 	pub := ctxPtr.pubAppInstanceStatus
 	items := pub.GetAll()

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -77,6 +77,7 @@ type GlobalConfig struct {
 	// Dom0MinDiskUsagePercent - Percentage of available storage reserved for
 	// dom0. The rest is available for Apps.
 	Dom0MinDiskUsagePercent uint32
+	IgnoreDiskCheckForApps  bool
 
 	// XXX add max space for downloads?
 	// XXX add max space for running images?
@@ -141,6 +142,7 @@ var GlobalConfigDefaults = GlobalConfig{
 	DefaultRemoteLogLevel: "info", // XXX Should we change to warning?
 
 	Dom0MinDiskUsagePercent: 20,
+	IgnoreDiskCheckForApps:  false,
 }
 
 // Check which values are set and which should come from defaults


### PR DESCRIPTION
1) If assignGrp for an adaptor is empty, set it to physicalLabel in
parseConfig. With this, all io-adapters are treated as part of some
group - even if it is a single member group

2) Added a new Globak Config - storage.apps.ignore.disk.check
   to skip storage checks for apps. This allows the storage to be
   oversubscribed.

Signed-off-by: Kalyan Nidumolu <kalyan@zadeda.com>