### PR TITLE
Fix verfier crash due to negativeRefcount for VerifierConfig

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -684,7 +684,7 @@ func verifyStatus(ctx *domainContext, status *types.DomainStatus) {
 		if status.Activated && !isQemuRunning(status.DomainId) {
 			errStr := fmt.Sprintf("verifyStatus(%s) qemu crashed",
 				status.Key())
-			log.Warnln(errStr)
+			log.Errorf(errStr)
 			status.LastErr = "qemu crashed - please restart application instance"
 			status.LastErrTime = time.Now()
 			status.Activated = false

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -975,6 +975,17 @@ func parseStorageConfigList(objType string,
 		image.Target = strings.ToLower(drive.Target.String())
 		image.Devtype = strings.ToLower(drive.Drvtype.String())
 		image.ImageSha256 = drive.Image.Sha256
+		if image.Format == "container" && image.ImageSha256 == "" {
+			// XXX HACK - The right fix is to use ImageIDs to Track
+			// images instead of SHA.
+			// Currently, for container images, Zedcloud doesn't have
+			// The SHA for the image. Use ImageID as the Sha.
+			// Download Config add verifier config / status are keyed by SHA.
+			// TIll we move away from that, set ImageSha to ImageID to
+			// handle this case.
+			image.ImageSha256 = image.ImageID.String()
+
+		}
 		storageList[idx] = *image
 		idx++
 	}

--- a/pkg/pillar/cmd/zedmanager/handledownloader.go
+++ b/pkg/pillar/cmd/zedmanager/handledownloader.go
@@ -53,11 +53,13 @@ func MaybeRemoveDownloaderConfig(ctx *zedmanagerContext, safename string) {
 			safename)
 		return
 	}
-	m.RefCount -= 1
-	if m.RefCount < 0 {
-		log.Fatalf("MaybeRemoveDownloaderConfig: negative RefCount %d for %s\n",
-			m.RefCount, safename)
+	if m.RefCount == 0 {
+		log.Fatalf("MaybeRemoveDownloaderConfig: Attempting to reduce "+
+			"0 RefCount. Image Details - Name: %s, SafeName: %s, "+
+			"ImageSha256:%s, IsContainer: %t\n",
+			m.Name, m.Safename, m.ImageSha256, m.IsContainer)
 	}
+	m.RefCount -= 1
 	log.Infof("MaybeRemoveDownloaderConfig remaining RefCount %d for %s\n",
 		m.RefCount, safename)
 	publishDownloaderConfig(ctx, m)
@@ -84,14 +86,10 @@ func unpublishDownloaderConfig(ctx *zedmanagerContext,
 func handleDownloaderStatusModify(ctxArg interface{}, key string,
 	statusArg interface{}) {
 	status := cast.CastDownloaderStatus(statusArg)
-	if status.Key() != key {
-		log.Errorf("handleDownloaderStatusModify key/UUID mismatch %s vs %s; ignored %+v\n",
-			key, status.Key(), status)
-		return
-	}
 	ctx := ctxArg.(*zedmanagerContext)
-	log.Infof("handleDownloaderStatusModify for %s RefCount %d\n",
-		status.Safename, status.RefCount)
+	log.Infof("handleDownloaderStatusModify for %s status.RefCount %d"+
+		"status.Expired: %+v\n",
+		status.Safename, status.RefCount, status.Expired)
 
 	// Handling even if Pending is set to process Progress updates
 

--- a/pkg/pillar/cmd/zedmanager/handleverifier.go
+++ b/pkg/pillar/cmd/zedmanager/handleverifier.go
@@ -97,11 +97,14 @@ func MaybeRemoveVerifyImageConfigSha256(ctx *zedmanagerContext, sha256 string) {
 			sha256)
 		return
 	}
-	m.RefCount -= 1
-	if m.RefCount < 0 {
-		log.Fatalf("MaybeRemoveVerifyImageConfigSha256: negative RefCount %d for %s\n",
-			m.RefCount, sha256)
+	if m.RefCount == 0 {
+		log.Fatalf("MaybeRemoveVerifyImageConfigSha256: Attempting to reduce "+
+			"0 RefCount. Image Details - Name: %s, SafeName: %s, "+
+			"ImageSha256:%s, IsContainer: %t, ContainerImageID: %s\n",
+			m.Name, m.Safename, m.ImageSha256, m.IsContainer,
+			m.ContainerImageID)
 	}
+	m.RefCount -= 1
 	log.Infof("MaybeRemoveVerifyImageConfigSha256: RefCount to %d for %s\n",
 		m.RefCount, sha256)
 	log.Infof("MaybeRemoveVerifyImageConfigSha256 done for %s\n", sha256)
@@ -175,7 +178,7 @@ func handleVerifyImageStatusModify(ctxArg interface{}, key string,
 
 	// Normal update work
 	updateAIStatusWithStorageSafename(ctx, key, false, "")
-	updateAIStatusSha(ctx, config.ImageSha256)
+	updateAIStatusWithImageSha(ctx, config.ImageSha256)
 	log.Infof("handleVerifyImageStatusModify done for %s\n",
 		status.Safename)
 }

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -525,6 +525,8 @@ func handleCreate(ctxArg interface{}, key string,
 
 	// if some error, return
 	if status.Error != "" {
+		log.Debugf("AppInstance(Name:%s, UUID:%s): Errors in App Instance "+
+			"Create.", config.DisplayName, config.UUIDandVersion.UUID)
 		return
 	}
 


### PR DESCRIPTION
1) Set Sha for Containers in StorageStatus to ImageID so that there is no mixup of Download Config / Verifier Config when deleting the app instance. There are places when we lookup Download/Verifier config with SHA - leading to verifier crash as the wrong Status was getting deleted.

2) Enhanced Info messages to give more information to debug RefCount issues.

3) Fixed bugs in refCount checking. It is a uint - so don't comapre with  < 0

Signed-off-by: Kalyan Nidumolu <kalyan@zadeda.com>