### PR TITLE
Fixing Xen regression on Dell boxes

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -87,7 +87,7 @@ function set_x86_64 {
 function set_x86_64_baremetal {
    set_generic
    set_x86_64
-   set_global xen_platform_tweaks " "
+   set_global xen_platform_tweaks "efi=no-rs"
    set_global linux_qemu_tweaks " "
    set_global linux_console "console=tty0 console=ttyS0"
 }

--- a/pkg/pillar/Dockerfile.in
+++ b/pkg/pillar/Dockerfile.in
@@ -51,7 +51,7 @@ RUN apk add --no-cache \
     apk-cron coreutils dmidecode sudo libbz2 libuuid ipset \
     libaio logrotate pixman glib curl radvd perl ethtool \
     util-linux e2fsprogs libcrypto1.0 xorriso \
-    python libpcap libffi jq e2fsprogs-extra keyutils
+    python libpcap libffi jq e2fsprogs-extra keyutils libgcc
 
 # The following is for xen-tools
 RUN [ `uname -m` = "aarch64" ] && apk add --no-cache libfdt || :

--- a/pkg/xen/Dockerfile
+++ b/pkg/xen/Dockerfile
@@ -45,6 +45,9 @@ RUN \
 COPY xen_config* /xen/
 WORKDIR /xen/xen
 
+COPY patch /tmp
+RUN patch -p2 < /tmp/patch
+
 RUN case $(uname -m) in \
     x86_64) \
         XEN_DEF_CONF=/xen/xen/arch/x86/configs/x86_64_defconfig; \

--- a/pkg/xen/patch
+++ b/pkg/xen/patch
@@ -1,0 +1,33 @@
+diff --git a/xen/common/efi/runtime.c b/xen/common/efi/runtime.c
+index 22fd6c9b53..8c2ece468d 100644
+--- a/xen/common/efi/runtime.c
++++ b/xen/common/efi/runtime.c
+@@ -211,6 +211,8 @@ int efi_get_info(uint32_t idx, union xenpf_efi_info *info)
+         break;
+     case XEN_FW_EFI_RT_VERSION:
+     {
++        if ( !efi_enabled(EFI_RS) )
++            return -EOPNOTSUPP;
+         info->version = efi_rs->Hdr.Revision;
+         break;
+     }
+@@ -613,7 +615,7 @@ int efi_runtime_call(struct xenpf_efi_runtime_call *op)
+             break;
+         }
+ 
+-        if ( (efi_rs->Hdr.Revision >> 16) < 2 )
++        if ( !efi_enabled(EFI_RS) || (efi_rs->Hdr.Revision >> 16) < 2 )
+             return -EOPNOTSUPP;
+         state = efi_rs_enter();
+         if ( !state.cr3 )
+@@ -631,7 +633,7 @@ int efi_runtime_call(struct xenpf_efi_runtime_call *op)
+         if ( op->misc )
+             return -EINVAL;
+ 
+-        if ( (efi_rs->Hdr.Revision >> 16) < 2 )
++        if ( !efi_enabled(EFI_RS) || (efi_rs->Hdr.Revision >> 16) < 2 )
+             return -EOPNOTSUPP;
+         /* XXX fall through for now */
+     default:
+-- 
+2.11.0


### PR DESCRIPTION
This restores Xen ability to boot on Dell boxes and doesn't seem to compromise that on any other box.

Note, that the patch is being merged in upstream Xen -- hence a somewhat hacky way of integrating it here -- we will remove that block of code next week anyway when the next Xen RC comes out.