### PR TITLE
640M ought to be enough for anybody

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -77,7 +77,7 @@ function set_generic {
 }
 
 function set_x86_64 {
-   set_global dom0_settings "dom0_mem=1024M,max:1024M dom0_max_vcpus=1 dom0_vcpus_pin smt=false"
+   set_global dom0_settings "dom0_mem=640M,max:640M dom0_max_vcpus=1 dom0_vcpus_pin smt=false"
    set_global boot_xen_cmd multiboot2
    set_global boot_dom0_cmd module2
    set_global xen /boot/xen.gz
@@ -101,7 +101,7 @@ function set_x86_64_qemu {
 }
 
 function set_arm64 {
-   set_global dom0_settings "dom0_mem=1024M dom0_max_vcpus=1 dom0_vcpus_pin"
+   set_global dom0_settings "dom0_mem=640M dom0_max_vcpus=1 dom0_vcpus_pin"
    set_global boot_xen_cmd xen_hypervisor
    set_global boot_dom0_cmd xen_module
    set_global xen /boot/xen.efi


### PR DESCRIPTION
We're now starting to see more and more systems with 2G (or even 1G) of RAM and we need to start thinking about supporting those.

This also provides a good forcing function for us to keep EVE's memory footprint small.