### PR TITLE
Fix refcount checks when decrementing in BaseOs Mgr

### DIFF
--- a/pkg/pillar/cmd/baseosmgr/handledownload.go
+++ b/pkg/pillar/cmd/baseosmgr/handledownload.go
@@ -138,11 +138,11 @@ func removeDownloaderConfig(ctx *baseOsMgrContext, objType string, safename stri
 			objType, safename)
 		return
 	}
-	config.RefCount -= 1
-	if config.RefCount < 0 {
-		log.Fatalf("removeDownloaderConfig(%s/%s): negative RefCount %d\n",
-			objType, safename, config.RefCount)
+	if config.RefCount == 0 {
+		log.Fatalf("removeDownloaderConfig(%s/%s): RefCount already 0. Cannot"+
+			" decrement it.", objType, safename)
 	}
+	config.RefCount -= 1
 	log.Infof("removeDownloaderConfig(%s/%s) decrementing refCount to %d\n",
 		objType, safename, config.RefCount)
 	publishDownloaderConfig(ctx, objType, config)

--- a/pkg/pillar/cmd/baseosmgr/handleverifier.go
+++ b/pkg/pillar/cmd/baseosmgr/handleverifier.go
@@ -148,11 +148,12 @@ func MaybeRemoveVerifierConfigSha256(ctx *baseOsMgrContext, objType string,
 	log.Infof("MaybeRemoveVerifierConfigSha256 found safename %s\n",
 		m.Safename)
 
-	m.RefCount -= 1
-	if m.RefCount < 0 {
-		log.Fatalf("MaybeRemoveVerifyImageConfigSha256: negative RefCount %d for %s\n",
-			m.RefCount, sha256)
+	if m.RefCount == 0 {
+		log.Fatalf("MaybeRemoveVerifyImageConfigSha256: RefCount for "+
+			"objType: %s, sha256: %s already zero. Cannot decrement.",
+			objType, sha256)
 	}
+	m.RefCount -= 1
 	log.Infof("MaybeRemoveVerifierConfigSha256 remaining RefCount %d for %s\n",
 		m.RefCount, sha256)
 	publishVerifierConfig(ctx, objType, m)


### PR DESCRIPTION
Fix refcount checks when decrementing in BaseOs Mgr. it is a uint, but was comparing to < 0. Fixed the check for == 0 before decrement.

Signed-off-by: Kalyan Nidumolu <kalyan@zadeda.com>