### PR TITLE
[WIP] Restructure pubsub into interface and implementation

### DIFF
--- a/pkg/pillar/pubsub/change.go
+++ b/pkg/pillar/pubsub/change.go
@@ -1,0 +1,17 @@
+package pubsub
+
+type Operation byte
+
+const (
+	Restart Operation = iota
+	Create
+	Delete
+	Modify
+)
+
+// Change the message to go into a change channel
+type Change struct {
+	Operation Operation
+	Key       string
+	Value     interface{}
+}

--- a/pkg/pillar/pubsub/doc.go
+++ b/pkg/pillar/pubsub/doc.go
@@ -1,0 +1,86 @@
+// Package pubsub provides access to publish/subscribe semantics and engine
+// in a single host context across processes. The actual implementation of
+// the publishing and subscribing are provided by an engine passed to `pubsub`.
+//
+// This documentation covers:
+//
+// * how to use pubsub in another module
+// * how to implement a driver.
+//
+// Usage
+//
+// To use pubsub, you must first instantiate a pubsub instance, passing it a
+// driver, and then use the instance. In general, there will be one pubsub
+// instance per process, but that is not strictly necessary.
+//
+// Once instantiated, you can retrieve a publisher or a subscriber from the
+// `pubsub.PubSub`.
+//
+//
+// To instantiate pubsub:
+//   import "github.com/lf-edge/eve/pkg/pillar/pubsub"
+//   ps := pubsub.New(driver)
+//
+// where `driver` is a `struct` that implements `pubsub.Driver`.
+//
+// Included is the `SocketDriver`, which uses a Unix-domain socket to
+// communicate between publishers and subscribers, and local directories to
+// store persistent messages.
+//
+//
+// see the documentation for each element to understand its usage.
+//
+// For example:
+//
+//   import (
+//     "github.com/lf-edge/eve/pkg/pillar/pubsub"
+//     "github.com/lf-edge/eve/pkg/pillar/pubsub/socketdriver"
+//   )
+//
+//   func foo() {
+//     driver := socketdriver.SocketDriver{}
+//     ps := pubsub.New(&driver)
+//     pub, err := ps.Publish("my-agent", element)
+//     pub, err := ps.PublishPersistent("other-agent", element)
+//     sub, err := ps.Subscribe("my-agent", element, true, ctx)
+//   }
+//
+//
+// Driver
+//
+// The driver is responsible for implementing the underlying mechanics of
+// publishing and subscribing. While `pubsub.PubSub` and its components -
+// `Publication` and `Subscription` - handle the in-memory and diff aspects,
+// the driver itself is responsible for communicating between the publisher
+// and subscriber, and performing any persistence.
+//
+// The driver is expected to implement the `Driver` interface, which primarily
+// involves being able to return the `DriverPublisher` and `DriverSubscriber`.
+// These in turn are used by `Publication` and `Subscription` to publish and
+// subscribe messages.
+//
+// The `DriverPublisher` and `DriverSubscriber` are expected to function as
+// follows.
+//
+// DriverPublisher
+//
+// The `DriverPublisher` publishes messages and, optionally, persists them.
+// It also can `Unpublish` messages, as well as `Load` all messages from
+// persistence store. Finally, it must be able to set and clear a `restarted`
+// flag.
+//
+// The actual interface is key-value pairs, where it either is requested to
+// publish a key (string) and value (`interface{}`), or unpublish a key.
+//
+// See the documentation for the `DriverPublisher` interface to learn more.
+//
+// DriverSubscriber
+//
+// The `DriverSubscriber` subscribes to messages. As with the `DriverPublisher`,
+// the caller has no understanding of the underlying mechanism or semantics.
+// Once started, the subscriber is expected to send any changes to the channel
+// which was passed to it at startup. These changes are in the format of
+// `pubsub.Change`, which encapsulates the change operation, key and value.
+//
+// See the documentation for the `DriverSubscriber` interface ot learn more.
+package pubsub

--- a/pkg/pillar/pubsub/driver.go
+++ b/pkg/pillar/pubsub/driver.go
@@ -1,0 +1,58 @@
+package pubsub
+
+// Driver a backend driver for pubsub
+type Driver interface {
+	// Publisher return a `DriverPublisher` for the given name and topic.
+	// The caller passes the `Updaters`, `Restarted` checker and `Differ`.
+	// These can be used to:
+	// * add to or remove from the updaters
+	// * determine if the topic has been restarted
+	// * diff the current known state from the target known state
+	Publisher(global bool, name, topic string, persistent bool, updaterList *Updaters, restarted Restarted, differ Differ) (DriverPublisher, error)
+	// Subscriber return a `DriverSubscriber` for the given name and topic.
+	// This is expected to create a `DriverSubscriber`, but not start it.
+	// Once started, when changes arrive, they should be published to the provided
+	// channel. Each update to the channel is of type `Change`, which encapsulates
+	// the operation, key and value.
+	Subscriber(global bool, name, topic string, persistent bool, C chan Change) (DriverSubscriber, error)
+}
+
+// DriverSubscriber interface that a driver for subscribing must implement
+type DriverSubscriber interface {
+	// Start subscribing to a name and topic and publish changes to the channel
+	Start() error
+	// DefaultName Return the default name to use for an agent, when the name
+	// is not provided.
+	DefaultName() string
+}
+
+// DriverPublisher interface that a driver for publishing must implement
+type DriverPublisher interface {
+	// Start the publisher
+	Start() error
+	// Load current status from persistence. Usually called only on first start.
+	// The implementation is responsible for determining if the load is necessary
+	// or already has been performed. If it has been already, it should not change
+	// anything. The caller has no knowledge of where the persistent state was
+	// stored: disk, databases, or vellum. All it cares about is that it gets
+	// a key-value list.
+	Load() (map[string]interface{}, bool, error)
+	// Publish a key-value pair to all subscribers and optionally persistence
+	Publish(key string, item interface{}) error
+	// Unpublish a key, i.e. delete it and publish its deletion to all subscribers
+	Unpublish(key string) error
+	// Restart set the state of the topic to restarted, or cancel the restarted
+	// state
+	Restart(restarted bool) error
+}
+
+// Restarted interface that lets you determine if a Publication has been restarted
+type Restarted interface {
+	IsRestarted() bool
+}
+
+// Differ interface that updates a LocalCollection from previous state to current state,
+// and returns a slice of keys that have changed
+type Differ interface {
+	DetermineDiffs(slaveCollection LocalCollection) []string
+}

--- a/pkg/pillar/pubsub/publish.go
+++ b/pkg/pillar/pubsub/publish.go
@@ -1,17 +1,26 @@
 package pubsub
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
-	"os"
 
 	"github.com/google/go-cmp/cmp"
 	log "github.com/sirupsen/logrus"
 )
 
+const (
+	Global = "global"
+)
+
+// Used locally by each serverConnection goroutine to track updates
+// to send.
+type LocalCollection map[string]interface{}
+
+// simple struct to pass notification messages
+type Notify struct{}
+
+// Publication to publish to an individual topic
 // Usage:
 //  p1, err := pubsub.Publish("foo", fooStruct{})
 //  ...
@@ -23,54 +32,22 @@ import (
 //
 //  foo := p1.Get(key)
 //  fooAll := p1.GetAll()
-
 type Publication struct {
-	// Private fields
-	topicType  interface{}
 	agentName  string
 	agentScope string
 	topic      string
 	km         keyMap
-	sockName   string
-	listener   net.Listener
+	global     bool
 
-	publishToDir bool // Handle special case of file only info
-	dirName      string
-	persistent   bool
+	updaterList *Updaters
+
+	driver DriverPublisher
 }
 
-// Send a notification to all the matching channels which does not yet
-// have one queued.
-func (pub *Publication) updatersNotify(name string) {
-	updaterList.lock.Lock()
-	for _, nn := range updaterList.servers {
-		if nn.name != name {
-			continue
-		}
-		select {
-		case nn.ch <- notify{}:
-			log.Debugf("updaterNotify sent to %s/%d\n",
-				nn.name, nn.instance)
-		default:
-			log.Debugf("updaterNotify NOT sent to %s/%d\n",
-				nn.name, nn.instance)
-		}
-	}
-	updaterList.lock.Unlock()
+func (pub *Publication) IsRestarted() bool {
+	return pub.km.restarted
 }
 
-func (pub *Publication) nameString() string {
-	if pub.publishToDir {
-		return pub.dirName
-	} else if pub.agentScope == "" {
-		return fmt.Sprintf("%s/%s", pub.agentName, pub.topic)
-	} else {
-		return fmt.Sprintf("%s/%s/%s", pub.agentName, pub.agentScope,
-			pub.topic)
-	}
-}
-
-// Publish publish an item on a given key
 func (pub *Publication) Publish(key string, item interface{}) error {
 	topic := TypeToName(item)
 	name := pub.nameString()
@@ -98,22 +75,12 @@ func (pub *Publication) Publish(key string, item interface{}) error {
 	}
 	pub.updatersNotify(name)
 
-	fileName := pub.dirName + "/" + key + ".json"
-	log.Debugf("Publish writing %s\n", fileName)
-
-	// XXX already did a marshal in deepCopy; save that result?
-	b, err := json.Marshal(item)
-	if err != nil {
-		log.Fatal("json Marshal in Publish", err)
-	}
-	err = WriteRename(fileName, b)
-	if err != nil {
+	if err := pub.driver.Publish(key, item); err != nil {
 		return err
 	}
 	return nil
 }
 
-// Unpublish unpublish the value at a given key
 func (pub *Publication) Unpublish(key string) error {
 	name := pub.nameString()
 	if m, ok := pub.km.key.Load(key); ok {
@@ -130,31 +97,143 @@ func (pub *Publication) Unpublish(key string) error {
 	}
 	pub.updatersNotify(name)
 
-	fileName := pub.dirName + "/" + key + ".json"
-	log.Debugf("Unpublish deleting file %s\n", fileName)
-	if err := os.Remove(fileName); err != nil {
-		errStr := fmt.Sprintf("Unpublish(%s/%s): failed %s",
-			name, key, err)
-		return errors.New(errStr)
+	if err := pub.driver.Unpublish(key); err != nil {
+		return err
 	}
 	return nil
 }
 
-// SignalRestarted signal that a publication is restarted
 func (pub *Publication) SignalRestarted() error {
 	log.Debugf("pub.SignalRestarted(%s)\n", pub.nameString())
 	return pub.restartImpl(true)
 }
 
-// ClearRestarted clear the restart signal
 func (pub *Publication) ClearRestarted() error {
 	log.Debugf("pub.ClearRestarted(%s)\n", pub.nameString())
 	return pub.restartImpl(false)
 }
 
+func (pub *Publication) Get(key string) (interface{}, error) {
+	m, ok := pub.km.key.Load(key)
+	if ok {
+		return m, nil
+	} else {
+		name := pub.nameString()
+		errStr := fmt.Sprintf("Get(%s) unknown key %s", name, key)
+		return nil, errors.New(errStr)
+	}
+}
+
+// Enumerate all the key, value for the collection
+func (pub *Publication) GetAll() map[string]interface{} {
+	result := make(map[string]interface{})
+	assigner := func(key string, val interface{}) bool {
+		result[key] = val
+		return true
+	}
+	pub.km.key.Range(assigner)
+	return result
+}
+
+// methods just for this implementation of Publisher
+
+// Send a notification to all the matching channels which does not yet
+// have one queued.
+func (pub *Publication) updatersNotify(name string) {
+	pub.updaterList.lock.Lock()
+	for _, nn := range pub.updaterList.servers {
+		if nn.name != name {
+			continue
+		}
+		select {
+		case nn.ch <- Notify{}:
+			log.Debugf("updaterNotify sent to %s/%d\n",
+				nn.name, nn.instance)
+		default:
+			log.Debugf("updaterNotify NOT sent to %s/%d\n",
+				nn.name, nn.instance)
+		}
+	}
+	pub.updaterList.lock.Unlock()
+}
+
+// Only reads json files. Sets restarted if that file was found.
+func (pub *Publication) populate() {
+	name := pub.nameString()
+
+	log.Infof("populate(%s)\n", name)
+
+	pairs, restarted, err := pub.driver.Load()
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
+	for key, item := range pairs {
+		pub.km.key.Store(key, item)
+	}
+	pub.km.restarted = restarted
+	log.Infof("populate(%s) done\n", name)
+}
+
+// go routine which runs the AF_UNIX server.
+func (pub *Publication) publisher() {
+	pub.driver.Start()
+}
+
+// Returns the deleted keys before the added/modified ones
+func (pub *Publication) DetermineDiffs(slaveCollection LocalCollection) []string {
+	var keys []string
+	name := pub.nameString()
+	items := pub.GetAll()
+	// Look for deleted
+	for slaveKey := range slaveCollection {
+		_, ok := items[slaveKey]
+		if !ok {
+			log.Debugf("determineDiffs(%s): key %s deleted\n",
+				name, slaveKey)
+			delete(slaveCollection, slaveKey)
+			keys = append(keys, slaveKey)
+		}
+
+	}
+	// Look for new/changed
+	for masterKey, master := range items {
+		slave := lookupSlave(slaveCollection, masterKey)
+		if slave == nil {
+			log.Debugf("determineDiffs(%s): key %s added\n",
+				name, masterKey)
+			// XXX is deepCopy needed?
+			slaveCollection[masterKey] = deepCopy(master)
+			keys = append(keys, masterKey)
+		} else if !cmp.Equal(master, *slave) {
+			log.Debugf("determineDiffs(%s): key %s replacing due to diff %v\n",
+				name, masterKey,
+				cmp.Diff(master, *slave))
+			// XXX is deepCopy needed?
+			slaveCollection[masterKey] = deepCopy(master)
+			keys = append(keys, masterKey)
+		} else {
+			log.Debugf("determineDiffs(%s): key %s unchanged\n",
+				name, masterKey)
+		}
+	}
+	return keys
+}
+
+func (pub *Publication) nameString() string {
+	var name string
+	switch {
+	case pub.global:
+		name = Global
+	case pub.agentScope == "":
+		name = fmt.Sprintf("%s/%s", pub.agentName, pub.topic)
+	default:
+		name = fmt.Sprintf("%s/%s/%s", pub.agentName, pub.agentScope, pub.topic)
+	}
+	return name
+}
+
 // Record the restarted state and send over socket/file.
 func (pub *Publication) restartImpl(restarted bool) error {
-
 	name := pub.nameString()
 	log.Infof("pub.restartImpl(%s, %v)\n", name, restarted)
 
@@ -170,109 +249,11 @@ func (pub *Publication) restartImpl(restarted bool) error {
 		// Implicit in updaters lock??
 		pub.updatersNotify(name)
 	}
-
-	restartFile := pub.dirName + "/" + "restarted"
-	if restarted {
-		f, err := os.OpenFile(restartFile, os.O_RDONLY|os.O_CREATE, 0600)
-		if err != nil {
-			errStr := fmt.Sprintf("pub.restartImpl(%s): openfile failed %s",
-				name, err)
-			return errors.New(errStr)
-		}
-		f.Close()
-	} else {
-		if err := os.Remove(restartFile); err != nil {
-			errStr := fmt.Sprintf("pub.restartImpl(%s): remove failed %s",
-				name, err)
-			return errors.New(errStr)
-		}
+	if err := pub.driver.Restart(restarted); err != nil {
+		return err
 	}
+
 	return nil
-}
-
-func (pub *Publication) serialize(sock net.Conn, keys []string,
-	sendToPeer localCollection) error {
-
-	name := pub.nameString()
-	log.Debugf("serialize(%s, %v)\n", name, keys)
-
-	for _, key := range keys {
-		val, ok := sendToPeer[key]
-		if ok {
-			err := pub.sendUpdate(sock, key, val)
-			if err != nil {
-				log.Errorf("serialize(%s) sendUpdate failed %s\n",
-					name, err)
-				return err
-			}
-		} else {
-			err := pub.sendDelete(sock, key)
-			if err != nil {
-				log.Errorf("serialize(%s) sendDelete failed %s\n",
-					name, err)
-				return err
-			}
-		}
-	}
-	return nil
-}
-
-func (pub *Publication) sendUpdate(sock net.Conn, key string,
-	val interface{}) error {
-
-	log.Debugf("sendUpdate(%s): key %s\n", pub.nameString(), key)
-	b, err := json.Marshal(val)
-	if err != nil {
-		log.Fatal("json Marshal in sendUpdate", err)
-	}
-	// base64-encode to avoid having spaces in the key and val
-	sendKey := base64.StdEncoding.EncodeToString([]byte(key))
-	sendVal := base64.StdEncoding.EncodeToString(b)
-	buf := fmt.Sprintf("update %s %s %s", pub.topic, sendKey, sendVal)
-	if len(buf) >= maxsize {
-		log.Fatalf("Too large message (%d bytes) sent to %s topic %s key %s",
-			len(buf), pub.nameString(), pub.topic, key)
-	}
-	_, err = sock.Write([]byte(buf))
-	return err
-}
-
-func (pub *Publication) sendDelete(sock net.Conn, key string) error {
-
-	log.Debugf("sendDelete(%s): key %s\n", pub.nameString(), key)
-	// base64-encode to avoid having spaces in the key
-	sendKey := base64.StdEncoding.EncodeToString([]byte(key))
-	buf := fmt.Sprintf("delete %s %s", pub.topic, sendKey)
-	if len(buf) >= maxsize {
-		log.Fatalf("Too large message (%d bytes) sent to %s topic %s key %s",
-			len(buf), pub.nameString(), pub.topic, key)
-	}
-	_, err := sock.Write([]byte(buf))
-	return err
-}
-
-func (pub *Publication) sendRestarted(sock net.Conn) error {
-
-	log.Infof("sendRestarted(%s)\n", pub.nameString())
-	buf := fmt.Sprintf("restarted %s", pub.topic)
-	if len(buf) >= maxsize {
-		log.Fatalf("Too large message (%d bytes) sent to %s topic %s",
-			len(buf), pub.nameString(), pub.topic)
-	}
-	_, err := sock.Write([]byte(buf))
-	return err
-}
-
-func (pub *Publication) sendComplete(sock net.Conn) error {
-
-	log.Infof("sendComplete(%s)\n", pub.nameString())
-	buf := fmt.Sprintf("complete %s", pub.topic)
-	if len(buf) >= maxsize {
-		log.Fatalf("Too large message (%d bytes) sent to %s topic %s",
-			len(buf), pub.nameString(), pub.topic)
-	}
-	_, err := sock.Write([]byte(buf))
-	return err
 }
 
 func (pub *Publication) dump(infoStr string) {
@@ -289,32 +270,4 @@ func (pub *Publication) dump(infoStr string) {
 	}
 	pub.km.key.Range(dumper)
 	log.Debugf("\trestarted %t\n", pub.km.restarted)
-}
-
-// Get get the value for a specific key
-func (pub *Publication) Get(key string) (interface{}, error) {
-	m, ok := pub.km.key.Load(key)
-	if ok {
-		return m, nil
-	} else {
-		name := pub.nameString()
-		errStr := fmt.Sprintf("Get(%s) unknown key %s", name, key)
-		return nil, errors.New(errStr)
-	}
-}
-
-// GetAll enumerate all the key, value for the collection
-func (pub *Publication) GetAll() map[string]interface{} {
-	result := make(map[string]interface{})
-	assigner := func(key string, val interface{}) bool {
-		result[key] = val
-		return true
-	}
-	pub.km.key.Range(assigner)
-	return result
-}
-
-// Topic returns the string definiting the topic
-func (pub *Publication) Topic() string {
-	return pub.topic
 }

--- a/pkg/pillar/pubsub/pubsub.go
+++ b/pkg/pillar/pubsub/pubsub.go
@@ -7,39 +7,26 @@
 package pubsub
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io/ioutil"
-	"net"
-	"os"
-	"path"
-	"strings"
-	"time"
-
-	"github.com/google/go-cmp/cmp"
 	log "github.com/sirupsen/logrus"
 )
 
-// Protocol over AF_UNIX or other IPC mechanism
-// "request" from client after connect to sanity check subject.
-// Server sends the other messages; "update" for initial values.
-// "complete" once all initial keys/values in collection have been sent.
-// "restarted" if/when pub.km.restarted is set.
-// Ongoing we send "update" and "delete" messages.
-// They keys and values are base64-encoded since they might contain spaces.
-// We include typeName after command word for sanity checks.
-// Hence the message format is
-//	"request" topic
-//	"hello"  topic
-//	"update" topic key json-val
-//	"delete" topic key
-//	"complete" topic (aka synchronized)
-//	"restarted" topic
-
-// Used locally by each serverConnection goroutine to track updates
-// to send.
-type localCollection map[string]interface{}
+// SubHandler is a generic handler to handle create, modify and delete
+// Usage:
+//  s1 := pubsub.Subscribe("foo", fooStruct{}, true, &myctx)
+// Or
+//  s1 := pubsub.Subscribe("foo", fooStruct{}, false, &myctx)
+//  s1.ModifyHandler = func(...), // Optional
+//  s1.DeleteHandler = func(...), // Optional
+//  s1.RestartHandler = func(...), // Optional
+//  [ Initialize myctx ]
+//  s1.Activate()
+//  ...
+//  select {
+//     case change := <- s1.C:
+//         s1.ProcessChange(change, ctx)
+//  }
+type SubHandler func(ctx interface{}, key string, status interface{})
+type SubRestartHandler func(ctx interface{}, restarted bool)
 
 // Maintain a collection which is used to handle the restart of a subscriber
 // map of agentname, key to get a json string
@@ -49,412 +36,116 @@ type keyMap struct {
 	key       *LockedStringMap
 }
 
-// We always publish to our collection.
-// We always write to a file in order to have a checkpoint on process restart.
-// That directory could be persistent in which case it will survive
-// a reboot.
-// The special agent name "" implies always reading from the /var/run/zededa/
-// directory.
-const (
-	publishToSock     = true  // XXX
-	subscribeFromDir  = false // XXX
-	subscribeFromSock = true  // XXX
-
-	// For a subscription, if the agentName is empty we interpret that as
-	// being directory in /var/tmp/zededa
-	fixedName = "zededa"
-	fixedDir  = "/var/tmp/" + fixedName
-	maxsize   = 65535 // Max size for json which can be read or written
-
-	// Copied from types package to avoid cycle in package dependencies
-	// PersistDir - Location to store persistent files.
-	PersistDir = "/persist"
-	// PersistConfigDir is where we keep some configuration across reboots
-	PersistConfigDir = PersistDir + "/config"
-)
-
-func Publish(agentName string, topicType interface{}) (*Publication, error) {
-	return publishImpl(agentName, "", topicType, false)
+// PubSub is a system for publishing and subscribing to messages
+// it manages the creation of Publication and Subscription, which handle the actual
+// implementation of in-memory structures and logic
+// the message passing and persistence are handled by a Driver
+type PubSub struct {
+	driver      Driver
+	updaterList *Updaters
 }
 
-func PublishPersistent(agentName string, topicType interface{}) (*Publication, error) {
-	return publishImpl(agentName, "", topicType, true)
+func New(driver Driver) *PubSub {
+	return &PubSub{
+		driver: driver,
+	}
 }
 
-func PublishScope(agentName string, agentScope string, topicType interface{}) (*Publication, error) {
-	return publishImpl(agentName, agentScope, topicType, false)
+func (p *PubSub) Publish(agentName string, topicType interface{}) (Publication, error) {
+	return p.publishImpl(agentName, "", topicType, false)
+}
+
+func (p *PubSub) PublishPersistent(agentName string, topicType interface{}) (Publication, error) {
+	return p.publishImpl(agentName, "", topicType, true)
+}
+
+func (p *PubSub) PublishScope(agentName string, agentScope string, topicType interface{}) (Publication, error) {
+	return p.publishImpl(agentName, agentScope, topicType, false)
+}
+
+func (p *PubSub) Subscribe(agentName string, topicType interface{}, activate bool,
+	ctx interface{}) (Subscription, error) {
+	return p.subscribeImpl(agentName, "", topicType, activate, ctx, false)
+}
+
+func (p *PubSub) SubscribeScope(agentName string, agentScope string, topicType interface{},
+	activate bool, ctx interface{}) (Subscription, error) {
+	return p.subscribeImpl(agentName, agentScope, topicType, activate, ctx,
+		false)
+}
+
+func (p *PubSub) SubscribePersistent(agentName string, topicType interface{}, activate bool,
+	ctx interface{}) (Subscription, error) {
+	return p.subscribeImpl(agentName, "", topicType, activate, ctx, true)
+}
+
+// methods unique to this implementation
+
+func (p *PubSub) subscribeImpl(agentName string, agentScope string, topicType interface{},
+	activate bool, ctx interface{}, persistent bool) (Subscription, error) {
+
+	topic := TypeToName(topicType)
+	changes := make(chan Change)
+	sub := Subscription{
+		C:          changes,
+		agentName:  agentName,
+		agentScope: agentScope,
+		topic:      topic,
+		userCtx:    ctx,
+		km:         keyMap{key: NewLockedStringMap()},
+	}
+	name := sub.nameString()
+	global := agentName == ""
+	driver, err := p.driver.Subscriber(global, name, topic, persistent, changes)
+	if err != nil {
+		return sub, err
+	}
+	sub.driver = driver
+
+	log.Infof("Subscribe(%s)\n", name)
+	if activate {
+		if err := sub.Activate(); err != nil {
+			return sub, err
+		}
+	}
+	return sub, nil
 }
 
 // Init function to create directory and socket listener based on above settings
 // We read any checkpointed state from dirName and insert in pub.km as initial
 // values.
-func publishImpl(agentName string, agentScope string,
-	topicType interface{}, persistent bool) (*Publication, error) {
+func (p *PubSub) publishImpl(agentName string, agentScope string,
+	topicType interface{}, persistent bool) (Publication, error) {
 
 	topic := TypeToName(topicType)
-	pub := new(Publication)
-	pub.topicType = topicType
-	pub.agentName = agentName
-	pub.agentScope = agentScope
-	pub.topic = topic
-	pub.km = keyMap{key: NewLockedStringMap()}
-	pub.persistent = persistent
+	// ensure the updaterlist is populated. This is the only place we consume it,
+	//  so fine to set it here
+	if p.updaterList == nil {
+		p.updaterList = &Updaters{}
+	}
+	pub := Publication{
+		agentName:   agentName,
+		agentScope:  agentScope,
+		topic:       topic,
+		km:          keyMap{key: NewLockedStringMap()},
+		updaterList: p.updaterList,
+	}
+	// create the driver
 	name := pub.nameString()
+	global := agentName == ""
+	driver, err := p.driver.Publisher(global, name, topic, persistent, p.updaterList, &pub, &pub)
+	if err != nil {
+		return pub, err
+	}
+	pub.driver = driver
 
+	pub.populate()
+	if log.GetLevel() == log.DebugLevel {
+		pub.dump("after populate")
+	}
 	log.Infof("Publish(%s)\n", name)
 
-	// We always write to the directory as a checkpoint for process restart
-	// That directory could be persistent in which case it will survive
-	// a reboot.
-	if pub.persistent {
-		if agentName == "" {
-			// Special case for /persist/config/
-			pub.publishToDir = true
-			pub.dirName = fmt.Sprintf("%s/%s",
-				PersistConfigDir, name)
-		} else {
-			pub.dirName = PersistentDirName(name)
-		}
-	} else {
-		if agentName == "" {
-			// Special case for /var/tmp/zededa/
-			pub.publishToDir = true
-			pub.dirName = FixedDirName(name)
-		} else {
-			pub.dirName = PubDirName(name)
-		}
-	}
-	dirName := pub.dirName
-	if _, err := os.Stat(dirName); err != nil {
-		log.Infof("Publish Create %s\n", dirName)
-		if err := os.MkdirAll(dirName, 0700); err != nil {
-			errStr := fmt.Sprintf("Publish(%s): %s",
-				name, err)
-			return nil, errors.New(errStr)
-		}
-	} else {
-		// Read existing status from dir
-		pub.populate()
-		if log.GetLevel() == log.DebugLevel {
-			pub.dump("after populate")
-		}
-	}
+	pub.publisher()
 
-	if !pub.publishToDir && publishToSock {
-		sockName := SockName(name)
-		dir := path.Dir(sockName)
-		if _, err := os.Stat(dir); err != nil {
-			log.Infof("Publish Create %s\n", dir)
-			if err := os.MkdirAll(dir, 0700); err != nil {
-				errStr := fmt.Sprintf("Publish(%s): %s",
-					name, err)
-				return nil, errors.New(errStr)
-			}
-		}
-		if _, err := os.Stat(sockName); err == nil {
-			if err := os.Remove(sockName); err != nil {
-				errStr := fmt.Sprintf("Publish(%s): %s",
-					name, err)
-				return nil, errors.New(errStr)
-			}
-		}
-		s, err := net.Listen("unixpacket", sockName)
-		if err != nil {
-			errStr := fmt.Sprintf("Publish(%s): failed %s",
-				name, err)
-			return nil, errors.New(errStr)
-		}
-		pub.sockName = sockName
-		pub.listener = s
-		go pub.publisher()
-	}
 	return pub, nil
-}
-
-// Only reads json files. Sets restarted if that file was found.
-func (pub *Publication) populate() {
-	name := pub.nameString()
-	dirName := pub.dirName
-	foundRestarted := false
-
-	log.Infof("populate(%s)\n", name)
-
-	files, err := ioutil.ReadDir(dirName)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	for _, file := range files {
-		if !strings.HasSuffix(file.Name(), ".json") {
-			if file.Name() == "restarted" {
-				foundRestarted = true
-			}
-			continue
-		}
-		// Remove .json from name */
-		key := strings.Split(file.Name(), ".json")[0]
-
-		statusFile := dirName + "/" + file.Name()
-		if _, err := os.Stat(statusFile); err != nil {
-			// File just vanished!
-			log.Errorf("populate: File disappeared <%s>\n",
-				statusFile)
-			continue
-		}
-
-		log.Infof("populate found key %s file %s\n", key, statusFile)
-
-		sb, err := ioutil.ReadFile(statusFile)
-		if err != nil {
-			log.Errorf("populate: %s for %s\n", err, statusFile)
-			continue
-		}
-		var item interface{}
-		if err := json.Unmarshal(sb, &item); err != nil {
-			log.Errorf("populate: %s file: %s\n",
-				err, statusFile)
-			continue
-		}
-		pub.km.key.Store(key, item)
-	}
-	pub.km.restarted = foundRestarted
-	log.Infof("populate(%s) done\n", name)
-}
-
-// go routine which runs the AF_UNIX server.
-func (pub *Publication) publisher() {
-	name := pub.nameString()
-	instance := 0
-	for {
-		c, err := pub.listener.Accept()
-		if err != nil {
-			log.Errorf("publisher(%s) failed %s\n", name, err)
-			continue
-		}
-		go pub.serveConnection(c, instance)
-		instance++
-	}
-}
-
-func (pub *Publication) serveConnection(s net.Conn, instance int) {
-	name := pub.nameString()
-	log.Infof("serveConnection(%s/%d)\n", name, instance)
-	defer s.Close()
-
-	// Track the set of keys/values we are sending to the peer
-	sendToPeer := make(localCollection)
-	sentRestarted := false
-	// Read request
-	buf := make([]byte, 65536)
-	res, err := s.Read(buf)
-	if err != nil {
-		// Likely truncated
-		log.Fatalf("serveConnection(%s/%d) read error: %v", name, instance, err)
-	}
-	if res == len(buf) {
-		// Likely truncated
-		log.Fatalf("serveConnection(%s/%d) request likely truncated\n",
-			name, instance)
-	}
-
-	request := strings.Split(string(buf[0:res]), " ")
-	log.Infof("serveConnection read %d: %v\n", len(request), request)
-	if len(request) != 2 || request[0] != "request" || request[1] != pub.topic {
-		log.Errorf("Invalid request message: %v\n", request)
-		return
-	}
-
-	_, err = s.Write([]byte(fmt.Sprintf("hello %s", pub.topic)))
-	if err != nil {
-		log.Errorf("serveConnection(%s/%d) failed %s\n",
-			name, instance, err)
-		return
-	}
-	// Insert our notification channel before we get the initial
-	// snapshot to avoid missing any updates/deletes.
-	updater := make(chan notify, 1)
-	updatersAdd(updater, name, instance)
-	defer updatersRemove(updater)
-
-	// Get a local snapshot of the collection and the set of keys
-	// we need to send these. Updates the slave collection.
-	keys := pub.determineDiffs(sendToPeer)
-
-	// Send the keys we just determined; all since this is the initial
-	err = pub.serialize(s, keys, sendToPeer)
-	if err != nil {
-		log.Errorf("serveConnection(%s/%d) serialize failed %s\n",
-			name, instance, err)
-		return
-	}
-	err = pub.sendComplete(s)
-	if err != nil {
-		log.Errorf("serveConnection(%s/%d) sendComplete failed %s\n",
-			name, instance, err)
-		return
-	}
-	if pub.km.restarted && !sentRestarted {
-		err = pub.sendRestarted(s)
-		if err != nil {
-			log.Errorf("serveConnection(%s/%d) sendRestarted failed %s\n",
-				name, instance, err)
-			return
-		}
-		sentRestarted = true
-	}
-
-	// Handle any changes
-	for {
-		log.Debugf("serveConnection(%s/%d) waiting for notification\n",
-			name, instance)
-		startWait := time.Now()
-		<-updater
-		waitTime := time.Since(startWait)
-		log.Debugf("serveConnection(%s/%d) received notification waited %d seconds\n",
-			name, instance, waitTime/time.Second)
-
-		// Update and determine which keys changed
-		keys := pub.determineDiffs(sendToPeer)
-
-		// Send the updates and deletes for those keys
-		err = pub.serialize(s, keys, sendToPeer)
-		if err != nil {
-			log.Errorf("serveConnection(%s/%d) serialize failed %s\n",
-				name, instance, err)
-			return
-		}
-
-		if pub.km.restarted && !sentRestarted {
-			err = pub.sendRestarted(s)
-			if err != nil {
-				log.Errorf("serveConnection(%s/%d) sendRestarted failed %s\n",
-					name, instance, err)
-				return
-			}
-			sentRestarted = true
-		}
-	}
-}
-
-// Returns the deleted keys before the added/modified ones
-func (pub *Publication) determineDiffs(slaveCollection localCollection) []string {
-
-	var keys []string
-	name := pub.nameString()
-	items := pub.GetAll()
-	// Look for deleted
-	for slaveKey := range slaveCollection {
-		_, ok := items[slaveKey]
-		if !ok {
-			log.Debugf("determineDiffs(%s): key %s deleted\n",
-				name, slaveKey)
-			delete(slaveCollection, slaveKey)
-			keys = append(keys, slaveKey)
-		}
-
-	}
-	// Look for new/changed
-	for masterKey, master := range items {
-		slave := lookupSlave(slaveCollection, masterKey)
-		if slave == nil {
-			log.Debugf("determineDiffs(%s): key %s added\n",
-				name, masterKey)
-			// XXX is deepCopy needed?
-			slaveCollection[masterKey] = deepCopy(master)
-			keys = append(keys, masterKey)
-		} else if !cmp.Equal(master, *slave) {
-			log.Debugf("determineDiffs(%s): key %s replacing due to diff %v\n",
-				name, masterKey,
-				cmp.Diff(master, *slave))
-			// XXX is deepCopy needed?
-			slaveCollection[masterKey] = deepCopy(master)
-			keys = append(keys, masterKey)
-		} else {
-			log.Debugf("determineDiffs(%s): key %s unchanged\n",
-				name, masterKey)
-		}
-	}
-	return keys
-}
-
-func SockName(name string) string {
-	return fmt.Sprintf("/var/run/%s.sock", name)
-}
-
-func PubDirName(name string) string {
-	return fmt.Sprintf("/var/run/%s", name)
-}
-
-func FixedDirName(name string) string {
-	return fmt.Sprintf("%s/%s", fixedDir, name)
-}
-
-func PersistentDirName(name string) string {
-	return fmt.Sprintf("%s/status/%s", "/persist", name)
-}
-
-// Init function for Subscribe; returns a context.
-// Assumption is that agent with call Get(key) later or specify
-// handleModify and/or handleDelete functions
-// watch ensures that any restart/restarted notification is after any other
-// notifications from ReadDir
-func Subscribe(agentName string, topicType interface{}, activate bool,
-	ctx interface{}) (*Subscription, error) {
-
-	return subscribeImpl(agentName, "", topicType, activate, ctx, false)
-}
-
-func SubscribeScope(agentName string, agentScope string, topicType interface{},
-	activate bool, ctx interface{}) (*Subscription, error) {
-
-	return subscribeImpl(agentName, agentScope, topicType, activate, ctx,
-		false)
-}
-
-func SubscribePersistent(agentName string, topicType interface{}, activate bool,
-	ctx interface{}) (*Subscription, error) {
-
-	return subscribeImpl(agentName, "", topicType, activate, ctx, true)
-}
-
-func subscribeImpl(agentName string, agentScope string, topicType interface{},
-	activate bool, ctx interface{}, persistent bool) (*Subscription, error) {
-
-	topic := TypeToName(topicType)
-	changes := make(chan string)
-	sub := new(Subscription)
-	sub.C = changes
-	sub.sendChan = changes
-	sub.topicType = topicType
-	sub.agentName = agentName
-	sub.agentScope = agentScope
-	sub.topic = topic
-	sub.userCtx = ctx
-	sub.km = keyMap{key: NewLockedStringMap()}
-	sub.persistent = persistent
-	name := sub.nameString()
-
-	// Special case for files in /var/tmp/zededa/ and also
-	// for zedclient going away yet metrics being read after it
-	// is gone.
-	if agentName == "" {
-		sub.subscribeFromDir = true
-		sub.dirName = FixedDirName(name)
-	} else if agentName == "zedclient" {
-		sub.subscribeFromDir = true
-		sub.dirName = PubDirName(name)
-	} else if persistent {
-		sub.subscribeFromDir = true
-		sub.dirName = PersistentDirName(name)
-	} else {
-		sub.subscribeFromDir = subscribeFromDir
-		sub.dirName = PubDirName(name)
-	}
-	log.Infof("Subscribe(%s)\n", name)
-	if activate {
-		if err := sub.Activate(); err != nil {
-			return nil, err
-		}
-	}
-	return sub, nil
 }

--- a/pkg/pillar/pubsub/smoke_test.go
+++ b/pkg/pillar/pubsub/smoke_test.go
@@ -1,0 +1,18 @@
+package pubsub_test
+
+// This file is just a temporary smoke test to instantiate the SocketDriver and
+// pubsub.New(), and ensure that all interfaces are met.
+// It will be replaced shortly by real unit tests.
+
+import (
+	"fmt"
+
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub/socketdriver"
+)
+
+func foo() {
+	driver := socketdriver.SocketDriver{}
+	ps := pubsub.New(&driver)
+	fmt.Println(ps)
+}

--- a/pkg/pillar/pubsub/socketdriver/driver.go
+++ b/pkg/pillar/pubsub/socketdriver/driver.go
@@ -1,0 +1,188 @@
+package socketdriver
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path"
+
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	log "github.com/sirupsen/logrus"
+)
+
+// Protocol over AF_UNIX or other IPC mechanism
+// "request" from client after connect to sanity check subject.
+// Server sends the other messages; "update" for initial values.
+// "complete" once all initial keys/values in collection have been sent.
+// "restarted" if/when pub.km.restarted is set.
+// Ongoing we send "update" and "delete" messages.
+// They keys and values are base64-encoded since they might contain spaces.
+// We include typeName after command word for sanity checks.
+// Hence the message format is
+//	"request" topic
+//	"hello"  topic
+//	"update" topic key json-val
+//	"delete" topic key
+//	"complete" topic (aka synchronized)
+//	"restarted" topic
+
+// We always publish to our collection.
+// We always write to a file in order to have a checkpoint on restart
+// The special agent name "" implies always reading from the /var/run/zededa/
+// directory.
+const (
+	publishToSock     = true  // XXX
+	subscribeFromDir  = false // XXX
+	subscribeFromSock = true  // XXX
+
+	// For a subscription, if the agentName is empty we interpret that as
+	// being directory in /var/tmp/zededa
+	fixedName = "zededa"
+	fixedDir  = "/var/tmp/" + fixedName
+	maxsize   = 65535 // Max size for json which can be read or written
+
+	// Copied from types package to avoid cycle in package dependencies
+	// persistDir - Location to store persistent files.
+	persistDir = "/persist"
+	// persistConfigDir is where we keep some configuration across reboots
+	persistConfigDir = persistDir + "/config"
+)
+
+/*
+ Driver for pubsub using local unix-domain socket and files
+*/
+type SocketDriver struct {
+}
+
+func (s *SocketDriver) Publisher(global bool, name, topic string, persistent bool, updaterList *pubsub.Updaters, restarted pubsub.Restarted, differ pubsub.Differ) (pubsub.DriverPublisher, error) {
+	var (
+		dirName, sockName string
+		publishToDir      bool
+		listener          net.Listener
+		err               error
+	)
+	shouldPopulate := false
+
+	// We always write to the directory as a checkpoint for process restart
+	// That directory could be persistent in which case it will survive
+	// a reboot.
+
+	// if the agentName is "", signal that we publish to dir, rather than
+	// to sock
+	if global {
+		publishToDir = true
+	}
+
+	// the dirName depends on if we are persistent, and if it is the global config
+	switch {
+	case persistent && publishToDir:
+		// Special case for /persist/config/
+		dirName = fmt.Sprintf("%s/%s", persistConfigDir, name)
+	case persistent && !publishToDir:
+		dirName = s.persistentDirName(name)
+	case !persistent && publishToDir:
+		// Special case for /var/tmp/zededa/
+		dirName = s.fixedDirName(name)
+	default:
+		dirName = s.pubDirName(name)
+	}
+
+	if _, err := os.Stat(dirName); err != nil {
+		log.Infof("Publish Create %s\n", dirName)
+		if err := os.MkdirAll(dirName, 0700); err != nil {
+			errStr := fmt.Sprintf("Publish(%s): %s",
+				name, err)
+			return nil, errors.New(errStr)
+		}
+	} else {
+		// Read existing status from dir
+		shouldPopulate = true
+	}
+
+	if !publishToDir && publishToSock {
+		sockName = s.sockName(name)
+		dir := path.Dir(sockName)
+		if _, err := os.Stat(dir); err != nil {
+			log.Infof("Publish Create %s\n", dir)
+			if err := os.MkdirAll(dir, 0700); err != nil {
+				errStr := fmt.Sprintf("Publish(%s): %s",
+					name, err)
+				return nil, errors.New(errStr)
+			}
+		}
+		if _, err := os.Stat(sockName); err == nil {
+			if err := os.Remove(sockName); err != nil {
+				errStr := fmt.Sprintf("Publish(%s): %s",
+					name, err)
+				return nil, errors.New(errStr)
+			}
+		}
+		listener, err = net.Listen("unixpacket", sockName)
+		if err != nil {
+			errStr := fmt.Sprintf("Publish(%s): failed %s",
+				name, err)
+			return nil, errors.New(errStr)
+		}
+	}
+	return &SocketDriverPublish{
+		sockName:       sockName,
+		listener:       listener,
+		dirName:        dirName,
+		shouldPopulate: shouldPopulate,
+		name:           name,
+		topic:          topic,
+		updaters:       updaterList,
+		differ:         differ,
+		restarted:      restarted,
+	}, nil
+}
+func (s *SocketDriver) Subscriber(global bool, name, topic string, persistent bool, C chan pubsub.Change) (pubsub.DriverSubscriber, error) {
+	var (
+		sockName   = s.sockName(name)
+		dirName    string
+		subFromDir bool
+	)
+
+	// Special case for files in /var/tmp/zededa/ and also
+	// for zedclient going away yet metrics being read after it
+	// is gone.
+	agentName := name
+	if agentName == "" {
+		subFromDir = true
+		dirName = s.fixedDirName(name)
+	} else if agentName == "zedclient" {
+		subFromDir = true
+		dirName = s.pubDirName(name)
+	} else if persistent {
+		subFromDir = true
+		dirName = s.persistentDirName(name)
+	} else {
+		subFromDir = subscribeFromDir
+		dirName = s.pubDirName(name)
+	}
+	return &SocketDriverSubscribe{
+		subscribeFromDir: subFromDir,
+		dirName:          dirName,
+		name:             name,
+		topic:            topic,
+		sockName:         sockName,
+		C:                C,
+	}, nil
+}
+
+func (s *SocketDriver) sockName(name string) string {
+	return fmt.Sprintf("/var/run/%s.sock", name)
+}
+
+func (s *SocketDriver) pubDirName(name string) string {
+	return fmt.Sprintf("/var/run/%s", name)
+}
+
+func (s *SocketDriver) fixedDirName(name string) string {
+	return fmt.Sprintf("%s/%s", fixedDir, name)
+}
+
+func (s *SocketDriver) persistentDirName(name string) string {
+	return fmt.Sprintf("%s/status/%s", "/persist", name)
+}

--- a/pkg/pillar/pubsub/socketdriver/publish.go
+++ b/pkg/pillar/pubsub/socketdriver/publish.go
@@ -1,0 +1,332 @@
+package socketdriver
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	log "github.com/sirupsen/logrus"
+)
+
+type SocketDriverPublish struct {
+	sock           net.Conn // For socket subscriptions
+	sockName       string   // there is one socket per publishing agent
+	listener       net.Listener
+	dirName        string
+	shouldPopulate bool // indicate on start if we need to populate
+	name           string
+	topic          string
+	updaters       *pubsub.Updaters
+	differ         pubsub.Differ
+	restarted      pubsub.Restarted
+}
+
+func (s *SocketDriverPublish) Publish(key string, item interface{}) error {
+	fileName := s.dirName + "/" + key + ".json"
+	log.Debugf("Publish writing %s\n", fileName)
+
+	// XXX already did a marshal in deepCopy; save that result?
+	b, err := json.Marshal(item)
+	if err != nil {
+		log.Fatal("json Marshal in Publish", err)
+	}
+	err = s.writeRename(fileName, b)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *SocketDriverPublish) Unpublish(key string) error {
+	fileName := s.dirName + "/" + key + ".json"
+	log.Debugf("Unpublish deleting file %s\n", fileName)
+	if err := os.Remove(fileName); err != nil {
+		return fmt.Errorf("Unpublish(%s/%s): failed %s", s.name, key, err)
+	}
+	return nil
+}
+
+func (s *SocketDriverPublish) Load() (map[string]interface{}, bool, error) {
+	dirName := s.dirName
+	foundRestarted := false
+	items := make(map[string]interface{})
+
+	log.Infof("Load(%s)\n", s.name)
+
+	files, err := ioutil.ReadDir(dirName)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, file := range files {
+		if !strings.HasSuffix(file.Name(), ".json") {
+			if file.Name() == "restarted" {
+				foundRestarted = true
+			}
+			continue
+		}
+		// Remove .json from name */
+		key := strings.Split(file.Name(), ".json")[0]
+
+		statusFile := dirName + "/" + file.Name()
+		if _, err := os.Stat(statusFile); err != nil {
+			// File just vanished!
+			log.Errorf("populate: File disappeared <%s>\n",
+				statusFile)
+			continue
+		}
+
+		log.Infof("populate found key %s file %s\n", key, statusFile)
+
+		sb, err := ioutil.ReadFile(statusFile)
+		if err != nil {
+			log.Errorf("populate: %s for %s\n", err, statusFile)
+			continue
+		}
+		var item interface{}
+		if err := json.Unmarshal(sb, &item); err != nil {
+			log.Errorf("populate: %s file: %s\n",
+				err, statusFile)
+			continue
+		}
+		items[key] = item
+	}
+	return items, foundRestarted, err
+}
+
+func (s *SocketDriverPublish) Start() error {
+	instance := 0
+	for {
+		c, err := s.listener.Accept()
+		if err != nil {
+			log.Errorf("publisher(%s) failed %s\n", s.name, err)
+			continue
+		}
+		go s.serveConnection(c, instance)
+		instance++
+	}
+}
+
+func (s *SocketDriverPublish) Restart(restarted bool) error {
+	restartFile := s.dirName + "/" + "restarted"
+	if restarted {
+		f, err := os.OpenFile(restartFile, os.O_RDONLY|os.O_CREATE, 0600)
+		if err != nil {
+			errStr := fmt.Sprintf("pub.restartImpl(%s): openfile failed %s", s.name, err)
+			return errors.New(errStr)
+		}
+		f.Close()
+	} else {
+		if err := os.Remove(restartFile); err != nil {
+			errStr := fmt.Sprintf("pub.restartImpl(%s): remove failed %s", s.name, err)
+			return errors.New(errStr)
+		}
+	}
+	return nil
+}
+
+func (s *SocketDriverPublish) serveConnection(conn net.Conn, instance int) {
+	log.Infof("serveConnection(%s/%d)\n", s.name, instance)
+	defer conn.Close()
+
+	// Track the set of keys/values we are sending to the peer
+	sendToPeer := make(pubsub.LocalCollection)
+	sentRestarted := false
+	// Read request
+	buf := make([]byte, 65536)
+	res, err := conn.Read(buf)
+	if err != nil {
+		log.Fatalf("serveConnection(%s/%d) error: %v", s.name, instance, err)
+	}
+	if res == len(buf) {
+		// Likely truncated
+		log.Fatalf("serveConnection(%s/%d) request likely truncated\n", s.name, instance)
+	}
+
+	request := strings.Split(string(buf[0:res]), " ")
+	log.Infof("serveConnection read %d: %v\n", len(request), request)
+	if len(request) != 2 || request[0] != "request" || request[1] != s.topic {
+		log.Errorf("Invalid request message: %v\n", request)
+		return
+	}
+
+	_, err = conn.Write([]byte(fmt.Sprintf("hello %s", s.topic)))
+	if err != nil {
+		log.Errorf("serveConnection(%s/%d) failed %s\n", s.name, instance, err)
+		return
+	}
+	// Insert our notification channel before we get the initial
+	// snapshot to avoid missing any updates/deletes.
+	updater := make(chan pubsub.Notify, 1)
+	s.updaters.Add(updater, s.name, instance)
+	defer s.updaters.Remove(updater)
+
+	// Get a local snapshot of the collection and the set of keys
+	// we need to send these. Updates the slave collection.
+	keys := s.differ.DetermineDiffs(sendToPeer)
+
+	// Send the keys we just determined; all since this is the initial
+	err = s.serialize(conn, keys, sendToPeer)
+	if err != nil {
+		log.Errorf("serveConnection(%s/%d) serialize failed %s\n", s.name, instance, err)
+		return
+	}
+	err = s.sendComplete(conn)
+	if err != nil {
+		log.Errorf("serveConnection(%s/%d) sendComplete failed %s\n", s.name, instance, err)
+		return
+	}
+	if s.restarted.IsRestarted() && !sentRestarted {
+		err = s.sendRestarted(conn)
+		if err != nil {
+			log.Errorf("serveConnection(%s/%d) sendRestarted failed %s\n", s.name, instance, err)
+			return
+		}
+		sentRestarted = true
+	}
+
+	// Handle any changes
+	for {
+		log.Debugf("serveConnection(%s/%d) waiting for notification\n", s.name, instance)
+		startWait := time.Now()
+		<-updater
+		waitTime := time.Since(startWait)
+		log.Debugf("serveConnection(%s/%d) received notification waited %d seconds\n", s.name, instance, waitTime/time.Second)
+
+		// Update and determine which keys changed
+		keys := s.differ.DetermineDiffs(sendToPeer)
+
+		// Send the updates and deletes for those keys
+		err = s.serialize(conn, keys, sendToPeer)
+		if err != nil {
+			log.Errorf("serveConnection(%s/%d) serialize failed %s\n", s.name, instance, err)
+			return
+		}
+
+		if s.restarted.IsRestarted() && !sentRestarted {
+			err = s.sendRestarted(conn)
+			if err != nil {
+				log.Errorf("serveConnection(%s/%d) sendRestarted failed %s\n", s.name, instance, err)
+				return
+			}
+			sentRestarted = true
+		}
+	}
+}
+
+func (s *SocketDriverPublish) serialize(sock net.Conn, keys []string,
+	sendToPeer pubsub.LocalCollection) error {
+
+	log.Debugf("serialize(%s, %v)\n", s.name, keys)
+
+	for _, key := range keys {
+		val, ok := sendToPeer[key]
+		if ok {
+			err := s.sendUpdate(sock, key, val)
+			if err != nil {
+				log.Errorf("serialize(%s) sendUpdate failed %s\n", s.name, err)
+				return err
+			}
+		} else {
+			err := s.sendDelete(sock, key)
+			if err != nil {
+				log.Errorf("serialize(%s) sendDelete failed %s\n", s.name, err)
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (s *SocketDriverPublish) sendUpdate(sock net.Conn, key string,
+	val interface{}) error {
+
+	log.Debugf("sendUpdate(%s): key %s\n", s.name, key)
+	b, err := json.Marshal(val)
+	if err != nil {
+		log.Fatal("json Marshal in sendUpdate", err)
+	}
+	// base64-encode to avoid having spaces in the key and val
+	sendKey := base64.StdEncoding.EncodeToString([]byte(key))
+	sendVal := base64.StdEncoding.EncodeToString(b)
+	buf := fmt.Sprintf("update %s %s %s", s.topic, sendKey, sendVal)
+	if len(buf) >= maxsize {
+		log.Fatalf("Too large message (%d bytes) sent to %s topic %s key %s",
+			len(buf), s.name, s.topic, key)
+	}
+	_, err = sock.Write([]byte(buf))
+	return err
+}
+
+func (s *SocketDriverPublish) sendDelete(sock net.Conn, key string) error {
+	log.Debugf("sendDelete(%s): key %s\n", s.name, key)
+	// base64-encode to avoid having spaces in the key
+	sendKey := base64.StdEncoding.EncodeToString([]byte(key))
+	buf := fmt.Sprintf("delete %s %s", s.topic, sendKey)
+	if len(buf) >= maxsize {
+		log.Fatalf("Too large message (%d bytes) sent to %s topic %s key %s",
+			len(buf), s.name, s.topic, key)
+	}
+	_, err := sock.Write([]byte(buf))
+	return err
+}
+
+func (s *SocketDriverPublish) sendRestarted(sock net.Conn) error {
+	log.Infof("sendRestarted(%s)\n", s.name)
+	buf := fmt.Sprintf("restarted %s", s.topic)
+	if len(buf) >= maxsize {
+		log.Fatalf("Too large message (%d bytes) sent to %s topic %s",
+			len(buf), s.name, s.topic)
+	}
+	_, err := sock.Write([]byte(buf))
+	return err
+}
+
+func (s *SocketDriverPublish) sendComplete(sock net.Conn) error {
+	log.Infof("sendComplete(%s)\n", s.name)
+	buf := fmt.Sprintf("complete %s", s.topic)
+	if len(buf) >= maxsize {
+		log.Fatalf("Too large message (%d bytes) sent to %s topic %s",
+			len(buf), s.name, s.topic)
+	}
+	_, err := sock.Write([]byte(buf))
+	return err
+}
+
+// writeRename write data to a fmpfile and then rename it to a desired name
+func (s *SocketDriverPublish) writeRename(fileName string, b []byte) error {
+	dirName := filepath.Dir(fileName)
+	// Do atomic rename to avoid partially written files
+	tmpfile, err := ioutil.TempFile(dirName, "pubsub")
+	if err != nil {
+		errStr := fmt.Sprintf("writeRename(%s): %s",
+			fileName, err)
+		return errors.New(errStr)
+	}
+	defer tmpfile.Close()
+	defer os.Remove(tmpfile.Name())
+	_, err = tmpfile.Write(b)
+	if err != nil {
+		errStr := fmt.Sprintf("writeRename(%s): %s",
+			fileName, err)
+		return errors.New(errStr)
+	}
+	if err := tmpfile.Close(); err != nil {
+		errStr := fmt.Sprintf("writeRename(%s): %s",
+			fileName, err)
+		return errors.New(errStr)
+	}
+	if err := os.Rename(tmpfile.Name(), fileName); err != nil {
+		errStr := fmt.Sprintf("writeRename(%s): %s",
+			fileName, err)
+		return errors.New(errStr)
+	}
+	return nil
+}

--- a/pkg/pillar/pubsub/socketdriver/subscribe.go
+++ b/pkg/pillar/pubsub/socketdriver/subscribe.go
@@ -1,0 +1,248 @@
+package socketdriver
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/watch"
+	log "github.com/sirupsen/logrus"
+)
+
+type SocketDriverSubscribe struct {
+	sockName         string   // there is one socket per publishing agent
+	sock             net.Conn // For socket subscriptions
+	subscribeFromDir bool     // Handle special case of file only info
+	name             string
+	topic            string
+	dirName          string
+	C                chan<- pubsub.Change
+}
+
+// Start start the subscriber listening on the given name and topic
+// internally, will watch for changes on either the socket or the file, and then
+// send the change summary to s.C
+func (s *SocketDriverSubscribe) Start() error {
+	// We handle both subscribeFromDir and subscribeFromSock
+	// Note that change filename includes .json for subscribeFromDir. That
+	// is removed by the translator.
+	if s.subscribeFromDir {
+		// Waiting for directory to appear
+		for {
+			if _, err := os.Stat(s.dirName); err != nil {
+				errStr := fmt.Sprintf("Subscribe(%s): failed %s; waiting", s.name, err)
+				log.Errorln(errStr)
+				time.Sleep(10 * time.Second)
+			} else {
+				break
+			}
+		}
+		// WatchStatus updates the channel with messages in a slightly different
+		// format than the standard for pubsub
+		// we pass it through a translator
+		translator := make(chan string)
+		go watch.WatchStatus(s.dirName, true, translator)
+		go s.translate(translator, s.C)
+		return nil
+	} else if subscribeFromSock {
+		go s.watchSock()
+		return nil
+	} else {
+		errStr := fmt.Sprintf("Subscribe(%s): failed %s", s.name, "nowhere to subscribe")
+		return errors.New(errStr)
+	}
+}
+
+// DefaultName default name for an agent when none is provided
+func (s *SocketDriverSubscribe) DefaultName() string {
+	return fixedName
+}
+
+func (s *SocketDriverSubscribe) watchSock() {
+	for {
+		msg, key, val := s.connectAndRead()
+		switch msg {
+		case "hello":
+			// Do nothing
+		case "complete":
+			// XXX to handle restart we need to handle "complete"
+			// by doing a sweep across the KeyMap to handleDelete
+			// what we didn't see before the "complete"
+			s.C <- pubsub.Change{Operation: pubsub.Create, Key: "done"}
+
+		case "restarted":
+			s.C <- pubsub.Change{Operation: pubsub.Restart, Key: "done"}
+
+		case "delete":
+			s.C <- pubsub.Change{Operation: pubsub.Delete, Key: key}
+
+		case "update":
+			// XXX is size of val any issue? pointer?
+			s.C <- pubsub.Change{Operation: pubsub.Create, Key: key, Value: val}
+		}
+	}
+}
+
+// Returns msg, key, val
+// key and val are base64-encoded
+func (s *SocketDriverSubscribe) connectAndRead() (string, string, string) {
+	buf := make([]byte, maxsize+1)
+
+	// Waiting for publisher to appear; retry on error
+	for {
+		if s.sock == nil {
+			sock, err := net.Dial("unixpacket", s.sockName)
+			if err != nil {
+				errStr := fmt.Sprintf("connectAndRead(%s): Dial failed %s",
+					s.name, err)
+				log.Warnln(errStr)
+				time.Sleep(10 * time.Second)
+				continue
+			}
+			s.sock = sock
+			req := fmt.Sprintf("request %s", s.topic)
+			_, err = sock.Write([]byte(req))
+			if err != nil {
+				errStr := fmt.Sprintf("connectAndRead(%s): sock write failed %s",
+					s.name, err)
+				log.Errorln(errStr)
+				s.sock.Close()
+				s.sock = nil
+				continue
+			}
+		}
+
+		res, err := s.sock.Read(buf)
+		if err != nil {
+			errStr := fmt.Sprintf("connectAndRead(%s): sock read failed %s",
+				s.name, err)
+			log.Errorln(errStr)
+			s.sock.Close()
+			s.sock = nil
+			continue
+		}
+
+		if res == len(buf) {
+			// Likely truncated
+			log.Fatalf("connectAndRead(%s) request likely truncated\n", s.name)
+		}
+		reply := strings.Split(string(buf[0:res]), " ")
+		count := len(reply)
+		if count < 2 {
+			errStr := fmt.Sprintf("connectAndRead(%s): too short read", s.name)
+			log.Errorln(errStr)
+			continue
+		}
+		msg := reply[0]
+		t := reply[1]
+
+		if t != s.topic {
+			errStr := fmt.Sprintf("connectAndRead(%s): mismatched topic %s vs. %s for %s", s.name, t, s.topic, msg)
+			log.Errorln(errStr)
+			// XXX continue
+		}
+
+		// XXX are there error cases where we should Close and
+		// continue aka reconnect?
+		switch msg {
+		case "hello", "restarted", "complete":
+			log.Debugf("connectAndRead(%s) Got message %s type %s\n", s.name, msg, t)
+			return msg, "", ""
+
+		case "delete":
+			if count < 3 {
+				errStr := fmt.Sprintf("connectAndRead(%s): too short delete", s.name)
+				log.Errorln(errStr)
+				continue
+			}
+			recvKey := reply[2]
+
+			if log.GetLevel() == log.DebugLevel {
+				key, err := base64.StdEncoding.DecodeString(recvKey)
+				if err != nil {
+					errStr := fmt.Sprintf("connectAndRead(%s): base64 failed %s", s.name, err)
+					log.Errorln(errStr)
+					continue
+				}
+				log.Debugf("connectAndRead(%s): delete type %s key %s\n", s.name, t, string(key))
+			}
+			return msg, recvKey, ""
+
+		case "update":
+			if count < 4 {
+				errStr := fmt.Sprintf("connectAndRead(%s): too short update", s.name)
+				log.Errorln(errStr)
+				continue
+			}
+			if count > 4 {
+				errStr := fmt.Sprintf("connectAndRead(%s): too long update", s.name)
+				log.Errorln(errStr)
+				continue
+			}
+			recvKey := reply[2]
+			recvVal := reply[3]
+			if log.GetLevel() == log.DebugLevel {
+				key, err := base64.StdEncoding.DecodeString(recvKey)
+				if err != nil {
+					errStr := fmt.Sprintf("connectAndRead(%s): base64 failed %s", s.name, err)
+					log.Errorln(errStr)
+					continue
+				}
+				val, err := base64.StdEncoding.DecodeString(recvVal)
+				if err != nil {
+					errStr := fmt.Sprintf("connectAndRead(%s): base64 val failed %s", s.name, err)
+					log.Errorln(errStr)
+					continue
+				}
+				log.Debugf("connectAndRead(%s): update type %s key %s val %s\n", s.name, t, string(key), string(val))
+			}
+			return msg, recvKey, recvVal
+
+		default:
+			errStr := fmt.Sprintf("connectAndRead(%s): unknown message %s", s.name, msg)
+			log.Errorln(errStr)
+			continue
+		}
+	}
+}
+
+func (s *SocketDriverSubscribe) translate(in <-chan string, out chan<- pubsub.Change) {
+	statusDirName := s.dirName
+	for change := range in {
+		operation := string(change[0])
+		fileName := string(change[2:])
+		// Remove .json from name */
+		name := strings.Split(fileName, ".json")
+		switch {
+		case operation == "R":
+			log.Infof("Received restart <%s>\n", fileName)
+			out <- pubsub.Change{Operation: pubsub.Restart}
+		case operation == "M" && fileName == "restarted":
+			log.Debugf("Found restarted file\n")
+			out <- pubsub.Change{Operation: pubsub.Modify}
+		case !strings.HasSuffix(fileName, ".json"):
+			// log.Debugf("Ignoring file <%s> operation %s\n",
+			//	fileName, operation)
+			continue
+		case operation == "D":
+			out <- pubsub.Change{Operation: pubsub.Delete, Key: name[0]}
+		case operation == "M":
+			statusFile := path.Join(statusDirName, fileName)
+			cb, err := ioutil.ReadFile(statusFile)
+			if err != nil {
+				log.Errorf("%s for %s\n", err, statusFile)
+				continue
+			}
+			out <- pubsub.Change{Operation: pubsub.Modify, Key: name[0], Value: cb}
+		default:
+			log.Fatal("Unknown operation from Watcher: ", operation)
+		}
+	}
+}

--- a/pkg/pillar/pubsub/subscribe.go
+++ b/pkg/pillar/pubsub/subscribe.go
@@ -1,48 +1,22 @@
 package pubsub
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
-	"os"
-	"strings"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/lf-edge/eve/pkg/pillar/watch"
 	log "github.com/sirupsen/logrus"
 )
 
-// SubHandler is a generic handler to handle create, modify and delete
-// Usage:
-//  s1 := pubsub.Subscribe("foo", fooStruct{}, true, &myctx)
-// Or
-//  s1 := pubsub.Subscribe("foo", fooStruct{}, false, &myctx)
-//  s1.ModifyHandler = func(...), // Optional
-//  s1.DeleteHandler = func(...), // Optional
-//  s1.RestartHandler = func(...), // Optional
-//  [ Initialize myctx ]
-//  s1.Activate()
-//  ...
-//  select {
-//     case change := <- s1.C:
-//         s1.ProcessChange(change, ctx)
-//  }
 //  The ProcessChange function calls the various handlers (if set) and updates
 //  the subscribed collection. The subscribed collection can be accessed using:
 //  foo := s1.Get(key)
 //  fooAll := s1.GetAll()
 // SubHandler is a generic handler to handle create, modify and delete
-type SubHandler func(ctx interface{}, key string, status interface{})
-
-// SubRestartHandler is a generic handler to handle restart and synchronized
-type SubRestartHandler func(ctx interface{}, restarted bool)
-
-// Subscription holds subscription to a single topic with its channel
 type Subscription struct {
-	C                   <-chan string
+	C                   <-chan Change
 	CreateHandler       SubHandler
 	ModifyHandler       SubHandler
 	DeleteHandler       SubHandler
@@ -52,309 +26,38 @@ type Subscription struct {
 	MaxProcessTimeError time.Duration // If set generate warning if ProcessChange
 
 	// Private fields
-	sendChan   chan<- string
-	topicType  interface{}
-	agentName  string
-	agentScope string
-	topic      string
-	km         keyMap
-	userCtx    interface{}
-	sock       net.Conn // For socket subscriptions
-
-	synchronized     bool
-	subscribeFromDir bool // Handle special case of file only info
-	dirName          string
-	persistent       bool
+	agentName    string
+	agentScope   string
+	topic        string
+	km           keyMap
+	userCtx      interface{}
+	synchronized bool
+	driver       DriverSubscriber
 }
 
-func (sub *Subscription) nameString() string {
-	agentName := sub.agentName
-	if agentName == "" {
-		agentName = fixedName
-	}
-	if sub.agentScope == "" {
-		return fmt.Sprintf("%s/%s", sub.agentName, sub.topic)
-	} else {
-		return fmt.Sprintf("%s/%s/%s", sub.agentName, sub.agentScope,
-			sub.topic)
-	}
-}
-
-// If the agentName is empty we interpret that as being dir /var/tmp/zededa
+// If the agentName is empty we interpret that as being global
 func (sub *Subscription) Activate() error {
-
-	name := sub.nameString()
-	if sub.subscribeFromDir {
-		// Waiting for directory to appear
-		for {
-			if _, err := os.Stat(sub.dirName); err != nil {
-				errStr := fmt.Sprintf("Subscribe(%s): failed %s; waiting",
-					name, err)
-				log.Errorln(errStr)
-				time.Sleep(10 * time.Second)
-			} else {
-				break
-			}
-		}
-		go watch.WatchStatus(sub.dirName, true, sub.sendChan)
-		return nil
-	} else if subscribeFromSock {
-		go sub.watchSock()
-		return nil
-	} else {
-		errStr := fmt.Sprintf("Subscribe(%s): failed %s",
-			name, "nowhere to subscribe")
-		return errors.New(errStr)
+	if err := sub.driver.Start(); err != nil {
+		return err
 	}
+	return nil
 }
 
-func (sub *Subscription) watchSock() {
-
-	for {
-		msg, key, val := sub.connectAndRead()
-		switch msg {
-		case "hello":
-			// Do nothing
-		case "complete":
-			// XXX to handle restart we need to handle "complete"
-			// by doing a sweep across the KeyMap to handleDelete
-			// what we didn't see before the "complete"
-			sub.sendChan <- "C done"
-
-		case "restarted":
-			sub.sendChan <- "R done"
-
-		case "delete":
-			sub.sendChan <- "D " + key
-
-		case "update":
-			// XXX is size of val any issue? pointer?
-			sub.sendChan <- "M " + key + " " + val
-		}
-	}
-}
-
-// Returns msg, key, val
-// key and val are base64-encoded
-func (sub *Subscription) connectAndRead() (string, string, string) {
-
-	name := sub.nameString()
-	sockName := SockName(name)
-	buf := make([]byte, maxsize+1)
-
-	// Waiting for publisher to appear; retry on error
-	for {
-		if sub.sock == nil {
-			s, err := net.Dial("unixpacket", sockName)
-			if err != nil {
-				errStr := fmt.Sprintf("connectAndRead(%s): Dial failed %s",
-					name, err)
-				log.Warnln(errStr)
-				time.Sleep(10 * time.Second)
-				continue
-			}
-			sub.sock = s
-			req := fmt.Sprintf("request %s", sub.topic)
-			_, err = s.Write([]byte(req))
-			if err != nil {
-				errStr := fmt.Sprintf("connectAndRead(%s): sock write failed %s",
-					name, err)
-				log.Errorln(errStr)
-				sub.sock.Close()
-				sub.sock = nil
-				continue
-			}
-		}
-
-		res, err := sub.sock.Read(buf)
-		if err != nil {
-			errStr := fmt.Sprintf("connectAndRead(%s): sock read failed %s",
-				name, err)
-			log.Errorln(errStr)
-			sub.sock.Close()
-			sub.sock = nil
-			continue
-		}
-
-		if res == len(buf) {
-			// Likely truncated
-			log.Fatalf("connectAndRead(%s) request likely truncated\n",
-				name)
-		}
-		reply := strings.Split(string(buf[0:res]), " ")
-		count := len(reply)
-		if count < 2 {
-			errStr := fmt.Sprintf("connectAndRead(%s): too short read",
-				name)
-			log.Errorln(errStr)
-			continue
-		}
-		msg := reply[0]
-		t := reply[1]
-
-		if t != sub.topic {
-			errStr := fmt.Sprintf("connectAndRead(%s): mismatched topic %s vs. %s for %s",
-				name, t, sub.topic, msg)
-			log.Errorln(errStr)
-			// XXX continue
-		}
-
-		// XXX are there error cases where we should Close and
-		// continue aka reconnect?
-		switch msg {
-		case "hello", "restarted", "complete":
-			log.Debugf("connectAndRead(%s) Got message %s type %s\n",
-				name, msg, t)
-			return msg, "", ""
-
-		case "delete":
-			if count < 3 {
-				errStr := fmt.Sprintf("connectAndRead(%s): too short delete",
-					name)
-				log.Errorln(errStr)
-				continue
-			}
-			recvKey := reply[2]
-
-			if log.GetLevel() == log.DebugLevel {
-				key, err := base64.StdEncoding.DecodeString(recvKey)
-				if err != nil {
-					errStr := fmt.Sprintf("connectAndRead(%s): base64 failed %s",
-						name, err)
-					log.Errorln(errStr)
-					continue
-				}
-				log.Debugf("connectAndRead(%s): delete type %s key %s\n",
-					name, t, string(key))
-			}
-			return msg, recvKey, ""
-
-		case "update":
-			if count < 4 {
-				errStr := fmt.Sprintf("connectAndRead(%s): too short update",
-					name)
-				log.Errorln(errStr)
-				continue
-			}
-			if count > 4 {
-				errStr := fmt.Sprintf("connectAndRead(%s): too long update",
-					name)
-				log.Errorln(errStr)
-				continue
-			}
-			recvKey := reply[2]
-			recvVal := reply[3]
-			if log.GetLevel() == log.DebugLevel {
-				key, err := base64.StdEncoding.DecodeString(recvKey)
-				if err != nil {
-					errStr := fmt.Sprintf("connectAndRead(%s): base64 failed %s",
-						name, err)
-					log.Errorln(errStr)
-					continue
-				}
-				val, err := base64.StdEncoding.DecodeString(recvVal)
-				if err != nil {
-					errStr := fmt.Sprintf("connectAndRead(%s): base64 val failed %s",
-						name, err)
-					log.Errorln(errStr)
-					continue
-				}
-				log.Debugf("connectAndRead(%s): update type %s key %s val %s\n",
-					name, t, string(key), string(val))
-			}
-			return msg, recvKey, recvVal
-
-		default:
-			errStr := fmt.Sprintf("connectAndRead(%s): unknown message %s",
-				name, msg)
-			log.Errorln(errStr)
-			continue
-		}
-	}
-}
-
-// We handle both subscribeFromDir and subscribeFromSock
-// Note that change filename includes .json for subscribeFromDir. That
-// is removed by HandleStatusEvent.
-func (sub *Subscription) ProcessChange(change string) {
-
+// ProcessChange process a single change and its parameters
+func (sub *Subscription) ProcessChange(change Change) {
 	start := time.Now()
-	if sub.subscribeFromDir {
-		var restartFn watch.StatusRestartHandler = handleRestart
-		var completeFn watch.StatusRestartHandler = handleSynchronized
-		watch.HandleStatusEvent(change, sub,
-			sub.dirName, &sub.topicType,
-			handleModify, handleDelete, &restartFn,
-			&completeFn)
-	} else if subscribeFromSock {
-		name := sub.nameString()
-		reply := strings.Split(change, " ")
-		operation := reply[0]
 
-		switch operation {
-		case "C":
-			handleSynchronized(sub, true)
-		case "R":
-			handleRestart(sub, true)
-		case "D":
-			recvKey := reply[1]
-			key, err := base64.StdEncoding.DecodeString(recvKey)
-			if err != nil {
-				errStr := fmt.Sprintf("ProcessChange(%s): base64 failed %s",
-					name, err)
-				log.Errorln(errStr)
-				break
-			}
-			handleDelete(sub, string(key))
-
-		case "M":
-			recvKey := reply[1]
-			recvVal := reply[2]
-			key, err := base64.StdEncoding.DecodeString(recvKey)
-			if err != nil {
-				errStr := fmt.Sprintf("ProcessChange(%s): base64 failed %s",
-					name, err)
-				log.Errorln(errStr)
-				break
-			}
-			val, err := base64.StdEncoding.DecodeString(recvVal)
-			if err != nil {
-				errStr := fmt.Sprintf("ProcessChange(%s): base64 val failed %s",
-					name, err)
-				log.Errorln(errStr)
-				break
-			}
-			var output interface{}
-			if err := json.Unmarshal(val, &output); err != nil {
-				errStr := fmt.Sprintf("ProcessChange(%s): json failed %s",
-					name, err)
-				log.Errorln(errStr)
-				break
-			}
-			handleModify(sub, string(key), output)
-		}
-	} else {
-		// Enforced in Subscribe()
-		log.Fatal("ProcessChange: neither subscribeFromDir nor subscribeFromSock")
+	switch change.Operation {
+	case Restart:
+		handleRestart(sub, true)
+	case Create:
+		handleSynchronized(sub, true)
+	case Delete:
+		handleDelete(sub, change.Key)
+	case Modify:
+		handleModify(sub, change.Key, change.Value)
 	}
-	CheckMaxTimeTopic(sub.agentName, sub.topic, start,
-		sub.MaxProcessTimeWarn, sub.MaxProcessTimeError)
-}
-
-func (sub *Subscription) dump(infoStr string) {
-	name := sub.nameString()
-	log.Debugf("dump(%s) %s\n", name, infoStr)
-	dumper := func(key string, val interface{}) bool {
-		b, err := json.Marshal(val)
-		if err != nil {
-			log.Fatal("json Marshal in dump", err)
-		}
-		log.Debugf("\tkey %s val %s\n", key, b)
-		return true
-	}
-	sub.km.key.Range(dumper)
-	log.Debugf("\trestarted %t\n", sub.km.restarted)
-	log.Debugf("\tsynchronized %t\n", sub.synchronized)
+	CheckMaxTimeTopic(sub.agentName, sub.topic, start, sub.MaxProcessTimeWarn, sub.MaxProcessTimeError)
 }
 
 func (sub *Subscription) Get(key string) (interface{}, error) {
@@ -392,6 +95,20 @@ func (sub *Subscription) Topic() string {
 	return sub.topic
 }
 
+func (sub *Subscription) nameString() string {
+	var name string
+	agentName := sub.agentName
+	if agentName == "" {
+		agentName = sub.driver.DefaultName()
+	}
+	if sub.agentScope == "" {
+		name = fmt.Sprintf("%s/%s", sub.agentName, sub.topic)
+	} else {
+		name = fmt.Sprintf("%s/%s/%s", sub.agentName, sub.agentScope, sub.topic)
+	}
+	return name
+}
+
 // handlers
 func handleModify(ctxArg interface{}, key string, item interface{}) {
 	sub := ctxArg.(*Subscription)
@@ -425,6 +142,22 @@ func handleModify(ctxArg interface{}, key string, item interface{}) {
 		(sub.ModifyHandler)(sub.userCtx, key, newItem)
 	}
 	log.Debugf("pubsub.handleModify(%s) done for key %s\n", name, key)
+}
+
+func (sub *Subscription) dump(infoStr string) {
+	name := sub.nameString()
+	log.Debugf("dump(%s) %s\n", name, infoStr)
+	dumper := func(key string, val interface{}) bool {
+		b, err := json.Marshal(val)
+		if err != nil {
+			log.Fatal("json Marshal in dump", err)
+		}
+		log.Debugf("\tkey %s val %s\n", key, b)
+		return true
+	}
+	sub.km.key.Range(dumper)
+	log.Debugf("\trestarted %t\n", sub.km.restarted)
+	log.Debugf("\tsynchronized %t\n", sub.synchronized)
 }
 
 func handleDelete(ctxArg interface{}, key string) {

--- a/pkg/pillar/pubsub/util.go
+++ b/pkg/pillar/pubsub/util.go
@@ -2,14 +2,10 @@ package pubsub
 
 import (
 	"encoding/json"
-	"errors"
-	"fmt"
-	"io/ioutil"
-	"log"
-	"os"
-	"path/filepath"
 	"reflect"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func deepCopy(in interface{}) interface{} {
@@ -24,7 +20,7 @@ func deepCopy(in interface{}) interface{} {
 	return output
 }
 
-func lookupSlave(slaveCollection localCollection, key string) *interface{} {
+func lookupSlave(slaveCollection LocalCollection, key string) *interface{} {
 	for slaveKey := range slaveCollection {
 		if slaveKey == key {
 			res := slaveCollection[slaveKey]
@@ -39,35 +35,4 @@ func TypeToName(something interface{}) string {
 	t := reflect.TypeOf(something)
 	out := strings.Split(t.String(), ".")
 	return out[len(out)-1]
-}
-
-// WriteRename write data to a fmpfile and then rename it to a desired name
-func WriteRename(fileName string, b []byte) error {
-	dirName := filepath.Dir(fileName)
-	// Do atomic rename to avoid partially written files
-	tmpfile, err := ioutil.TempFile(dirName, "pubsub")
-	if err != nil {
-		errStr := fmt.Sprintf("WriteRename(%s): %s",
-			fileName, err)
-		return errors.New(errStr)
-	}
-	defer tmpfile.Close()
-	defer os.Remove(tmpfile.Name())
-	_, err = tmpfile.Write(b)
-	if err != nil {
-		errStr := fmt.Sprintf("WriteRename(%s): %s",
-			fileName, err)
-		return errors.New(errStr)
-	}
-	if err := tmpfile.Close(); err != nil {
-		errStr := fmt.Sprintf("WriteRename(%s): %s",
-			fileName, err)
-		return errors.New(errStr)
-	}
-	if err := os.Rename(tmpfile.Name(), fileName); err != nil {
-		errStr := fmt.Sprintf("WriteRename(%s): %s",
-			fileName, err)
-		return errors.New(errStr)
-	}
-	return nil
 }


### PR DESCRIPTION
**This is a Work In Progress! Do not think about merging until `[WIP]` is removed!**

This highlights how I want to restructure pubsub. Rather than each publishing or subscribing component (downloader, verifier, identitymgr, zedagent, etc. etc.) actually calling publish and subscribe functions, they would receive something implementing an `interface` which lets them call those functions.

Rationale. Right now it is hard to: 

* test individual functions as many need to publish or subscribe
* run an individual component as a standalone all by itself, e.g. verifier, because it needs to publish or subscribe

Replacing the actual implementation and funcs they call with something that implements the interface would allow us to call any of them with any such implementation. That means we could:

* simply use command-line or stdin/stdout
* use test mocks that can track messages published and subscribe them without an actual socket
* essentially convert many tests to simple, fast go unit tests
* run some of these command-line and pass information in a different way

The purpose of this PR is to highlight the idea and get feedback. Tests **will** fail until the rest is done.

What have we completed?

1. Create all of interfaces necessary in `pubsub/pubsub.go`
1. Create an actual implementation that implements the interface while doing pubsub the way we originally did it in `pubsub/pubsubimpl.go`, `subscribe.go`, `publish.go`, `updaters.go`
1. Update the tests so they pass
1. Verify that it passes linting and `go vet`

What has to be done to complete it?

1. Get sign-on from the crew
1. Change pretty much every user so that they work with the interface
1. Change the primary entrypoint (`zedagent`) so that it passes in the correct implementation

The remainder work is gruntwork, but is much easier and likely faster than what has been done to date.

Let's get people onboard and then we can complete it.

cc @kalyan-nidumolu @nordmark @rvs 

As an example, of how we would complete it.

In `zedbox.go`

```go
func main() {
	basename := filepath.Base(os.Args[0])
        ps := &pubsub.PubSubImpl{}
	switch basename {
	case "client":
		client.Run(ps)
	case "diag":
		diag.Run(ps)
```

etc.

And then in one of them (downloader, e.g.):

```go
func Run(ps pubsub.PubSub) {
	handlersInit()
        // pass on the ps to everything that needs it
```

@kalyan-nidumolu and I are thinking of ways to clean up that part even more, but one step at a time.

My motivation for this: besides good cleanliness and easy to work with, I want to be able to do a better job testing changes I implement. I also expect to be running `downloader` locally on a machine by itself.
