### PR TITLE
Fixed bugs in handling device-reboot for containers which left device stuck in init state.

### DIFF
--- a/pkg/pillar/cmd/zedmanager/handledomainmgr.go
+++ b/pkg/pillar/cmd/zedmanager/handledomainmgr.go
@@ -57,7 +57,6 @@ func MaybeAddDomainConfig(ctx *zedmanagerContext,
 		VmConfig:          aiConfig.FixedResources,
 		IoAdapterList:     aiConfig.IoAdapterList,
 		CloudInitUserData: aiConfig.CloudInitUserData,
-		ImageID:           aiStatus.ImageID,
 	}
 
 	// Determine number of "disk" targets in list
@@ -88,6 +87,7 @@ func MaybeAddDomainConfig(ctx *zedmanagerContext,
 		switch sc.Target {
 		case "", "disk", "tgtunknown":
 			disk := &dc.DiskConfigList[i]
+			disk.ImageID = sc.ImageID
 			disk.ImageSha256 = sc.ImageSha256
 			disk.ReadOnly = sc.ReadOnly
 			disk.Preserve = sc.Preserve

--- a/pkg/pillar/cmd/zedmanager/handleverifier.go
+++ b/pkg/pillar/cmd/zedmanager/handleverifier.go
@@ -145,12 +145,12 @@ func handleVerifyImageStatusModify(ctxArg interface{}, key string,
 		return
 	}
 	ctx := ctxArg.(*zedmanagerContext)
-	log.Infof("handleVerifyImageStatusModify for %s RefCount %d\n",
-		status.Safename, status.RefCount)
+	log.Infof("handleVerifyImageStatusModify for ImageID: %s, Safename: %s, "+
+		" RefCount %d\n", status.ImageID, status.Safename, status.RefCount)
 	// Ignore if any Pending* flag is set
 	if status.Pending() {
-		log.Infof("handleVerifyImageStatusModify skipped due to Pending* for %s\n",
-			status.Safename)
+		log.Infof("handleVerifyImageStatusModify skipped due to Pending* for"+
+			" ImageID: %s, Safename: %s", status.ImageID, status.Safename)
 		return
 	}
 
@@ -171,6 +171,7 @@ func handleVerifyImageStatusModify(ctxArg interface{}, key string,
 			IsContainer:      status.IsContainer,
 			ContainerImageID: status.ContainerImageID,
 			RefCount:         0,
+			ImageID:          status.ImageID,
 		}
 		publishVerifyImageConfig(ctx, &n)
 		return

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -494,7 +494,6 @@ func handleCreate(ctxArg interface{}, key string,
 			// FIXME - We really need a top level flag to tell the app is
 			//  a container. Deriving it from Storage seems hacky.
 			status.IsContainer = true
-			status.ImageID = ss.ImageID
 		}
 	}
 

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -4,9 +4,10 @@
 package types
 
 import (
+	"time"
+
 	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
-	"time"
 )
 
 // The information XenManager needs to boot and halt domains
@@ -27,9 +28,8 @@ type DomainConfig struct {
 	IoAdapterList     []IoAdapter
 	CloudInitUserData string // base64-encoded
 	// Container related info
-	IsContainer      bool      // Is this Domain for a Container?
-	ContainerImageID string    // SHA-512 of rkt container image
-	ImageID          uuid.UUID // UUID of the image
+	IsContainer      bool   // Is this Domain for a Container?
+	ContainerImageID string // SHA-512 of rkt container image
 }
 
 func (config DomainConfig) Key() string {
@@ -108,10 +108,9 @@ type DomainStatus struct {
 	LastErrTime        time.Time
 	BootFailed         bool
 	AdaptersFailed     bool
-	IsContainer        bool      // Is this Domain for a Container?
-	ContainerImageID   string    // SHA-512 of rkt container image
-	PodUUID            string    // Pod UUID outputted by rkt
-	ImageID            uuid.UUID // UUID of the image
+	IsContainer        bool   // Is this Domain for a Container?
+	ContainerImageID   string // SHA-512 of rkt container image
+	PodUUID            string // Pod UUID outputted by rkt
 }
 
 func (status DomainStatus) Key() string {
@@ -156,7 +155,8 @@ type VifInfo struct {
 // Note that vdev in general can be hd[x], xvd[x], sd[x] but here we only
 // use xvd
 type DiskConfig struct {
-	ImageSha256 string // sha256 of immutable image
+	ImageID     uuid.UUID // UUID of the image
+	ImageSha256 string    // sha256 of immutable image
 	ReadOnly    bool
 	Preserve    bool // If set a rw disk will be preserved across
 	// boots (acivate/inactivate)
@@ -166,7 +166,8 @@ type DiskConfig struct {
 }
 
 type DiskStatus struct {
-	ImageSha256        string // sha256 of immutable image
+	ImageID            uuid.UUID // sha256 of immutable image
+	ImageSha256        string    // sha256 of immutable image
 	ReadOnly           bool
 	Preserve           bool
 	FileLocation       string // Local location of Image

--- a/pkg/pillar/types/verifiertypes.go
+++ b/pkg/pillar/types/verifiertypes.go
@@ -6,9 +6,10 @@
 package types
 
 import (
+	"time"
+
 	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
-	"time"
 )
 
 // XXX more than images; rename type and clean up comments

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -114,7 +114,6 @@ type AppInstanceStatus struct {
 	PurgeCmd            AppInstanceOpsCmd
 	RestartInprogress   Inprogress
 	PurgeInprogress     Inprogress
-	ImageID             uuid.UUID // UUID of the image
 
 	// Container related state
 	IsContainer      bool
@@ -289,6 +288,7 @@ func (ss *StorageStatus) UpdateFromStorageConfig(sc StorageConfig) {
 	ss.DatastoreID = sc.DatastoreID
 	ss.Name = sc.Name
 	ss.NameIsURL = sc.NameIsURL
+	ss.ImageID = sc.ImageID
 	ss.ImageSha256 = sc.ImageSha256
 	ss.Size = sc.Size
 	ss.CertificateChain = sc.CertificateChain


### PR DESCRIPTION
Fixed handling of verified images for Containers on reboot.
When reconstructing VerifierImageStatus from images on /persist,
take into account the naming schemes used for Containers and VMs.

Cleaned up ImageID - removed it from top level structs ( AppInstance
Config/Status, DomainConfig/Status and moved it to Disk related
structures.

Improved Log statements..

Signed-off-by: Kalyan Nidumolu <kalyan@zadeda.com>