### PR TITLE
Add uploading IP address info to cloud for switched net, add broadcas…

### DIFF
--- a/pkg/pillar/cast/cast.go
+++ b/pkg/pillar/cast/cast.go
@@ -453,6 +453,19 @@ func CastFlowStatus(in interface{}) types.IPFlow { //revive:disable-line
 	return output
 }
 
+// CastVifIPTrig : Cast interface type into types.VifIPTrig
+func CastVifIPTrig(in interface{}) types.VifIPTrig { //revive:disable-line
+	b, err := json.Marshal(in)
+	if err != nil {
+		log.Fatalf("json Marshal in CastVifIPTrig, %v", err)
+	}
+	var output types.VifIPTrig
+	if err := json.Unmarshal(b, &output); err != nil {
+		log.Fatalf("json Unmarshal in CastVifIPTrig, %v", err)
+	}
+	return output
+}
+
 // CastPhysicalIOAdapterList : Cast interface type into
 //       types.PhysicalIOAdapterList
 func CastPhysicalIOAdapterList(in interface{}) types.PhysicalIOAdapterList { //revive:disable-line

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -1624,27 +1624,14 @@ func getDefaultRouters(ifname string) []string {
 func getAppIP(ctx *zedagentContext, aiStatus *types.AppInstanceStatus,
 	vifname string) (string, bool, string) {
 
-	sub := ctx.subNetworkInstanceStatus
 	log.Debugf("getAppIP(%s, %s)\n", aiStatus.Key(), vifname)
 	for _, ulStatus := range aiStatus.UnderlayNetworks {
 		if ulStatus.Vif != vifname {
 			continue
 		}
-		appIP := ulStatus.AllocatedIPAddr
-		ulconfig := ulStatus.UnderlayNetworkConfig
-		st, _ := sub.Get(ulconfig.Network.String())
-		if st != nil {
-			netstatus := cast.CastNetworkInstanceStatus(st)
-			if netstatus.Type == types.NetworkInstanceTypeSwitch {
-				log.Debugf("getAppIP: type switch on %s, mac %s, ip assignments %v", netstatus.BridgeName, ulStatus.Mac, netstatus.IPAssignments)
-				if _, ok := netstatus.IPAssignments[ulStatus.Mac]; ok {
-					appIP = netstatus.IPAssignments[ulStatus.Mac].String()
-				}
-			}
-		}
 		log.Debugf("getAppIP(%s, %s) found underlay %s assigned %v mac %s\n",
-			aiStatus.Key(), vifname, appIP, ulStatus.Assigned, ulStatus.Mac)
-		return appIP, ulStatus.Assigned, ulStatus.Mac
+			aiStatus.Key(), vifname, ulStatus.AllocatedIPAddr, ulStatus.Assigned, ulStatus.Mac)
+		return ulStatus.AllocatedIPAddr, ulStatus.Assigned, ulStatus.Mac
 	}
 	for _, olStatus := range aiStatus.OverlayNetworks {
 		if olStatus.Vif != vifname {

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -1624,15 +1624,27 @@ func getDefaultRouters(ifname string) []string {
 func getAppIP(ctx *zedagentContext, aiStatus *types.AppInstanceStatus,
 	vifname string) (string, bool, string) {
 
+	sub := ctx.subNetworkInstanceStatus
 	log.Debugf("getAppIP(%s, %s)\n", aiStatus.Key(), vifname)
 	for _, ulStatus := range aiStatus.UnderlayNetworks {
 		if ulStatus.Vif != vifname {
 			continue
 		}
+		appIP := ulStatus.AllocatedIPAddr
+		ulconfig := ulStatus.UnderlayNetworkConfig
+		st, _ := sub.Get(ulconfig.Network.String())
+		if st != nil {
+			netstatus := cast.CastNetworkInstanceStatus(st)
+			if netstatus.Type == types.NetworkInstanceTypeSwitch {
+				log.Debugf("getAppIP: type switch on %s, mac %s, ip assignments %v", netstatus.BridgeName, ulStatus.Mac, netstatus.IPAssignments)
+				if _, ok := netstatus.IPAssignments[ulStatus.Mac]; ok {
+					appIP = netstatus.IPAssignments[ulStatus.Mac].String()
+				}
+			}
+		}
 		log.Debugf("getAppIP(%s, %s) found underlay %s assigned %v mac %s\n",
-			aiStatus.Key(), vifname,
-			ulStatus.AllocatedIPAddr, ulStatus.Assigned, ulStatus.Mac)
-		return ulStatus.AllocatedIPAddr, ulStatus.Assigned, ulStatus.Mac
+			aiStatus.Key(), vifname, appIP, ulStatus.Assigned, ulStatus.Mac)
+		return appIP, ulStatus.Assigned, ulStatus.Mac
 	}
 	for _, olStatus := range aiStatus.OverlayNetworks {
 		if olStatus.Vif != vifname {

--- a/pkg/pillar/cmd/zedrouter/flowstats.go
+++ b/pkg/pillar/cmd/zedrouter/flowstats.go
@@ -757,6 +757,7 @@ func checkDHCPPacketInfo(bnNum int, packet gopacket.Packet, ctx *zedrouterContex
 							}
 						}
 						vifTrig.MacAddr = vif.MacAddr
+						vifTrig.IPAddr = dhcpv4.YourClientIP
 						break
 					}
 				}
@@ -780,7 +781,8 @@ func checkDHCPPacketInfo(bnNum int, packet gopacket.Packet, ctx *zedrouterContex
 
 	if needUpdate {
 		log.Infof("checkDHCPPacketInfo: need update %v, %v\n", vifInfo, netstatus.IPAssignments)
-		publishNetworkInstanceStatus(ctx, &netstatus)
+		pub := ctx.pubNetworkInstanceStatus
+		pub.Publish(netstatus.Key(), &netstatus)
 		// trigger the AppInfo update to cloud
 		ctx.pubAppVifIPTrig.Publish(vifTrig.MacAddr, &vifTrig)
 	}

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -74,6 +74,7 @@ type zedrouterContext struct {
 	pubNetworkInstanceStatus  *pubsub.Publication
 	pubNetworkInstanceMetrics *pubsub.Publication
 	pubAppFlowMonitor         *pubsub.Publication
+	pubAppVifIPTrig           *pubsub.Publication
 	networkInstanceStatusMap  map[uuid.UUID]*types.NetworkInstanceStatus
 	dnsServers                map[string][]net.IP
 	checkNIUplinks            chan bool
@@ -227,6 +228,12 @@ func Run() {
 		log.Fatal(err)
 	}
 	zedrouterCtx.pubAppFlowMonitor = pubAppFlowMonitor
+
+	pubAppVifIPTrig, err := pubsub.Publish(agentName, types.VifIPTrig{})
+	if err != nil {
+		log.Fatal(err)
+	}
+	zedrouterCtx.pubAppVifIPTrig = pubAppVifIPTrig
 
 	nms := getNetworkMetrics(&zedrouterCtx) // Need type of data
 	pub, err := pubsub.Publish(agentName, nms)

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -198,10 +198,11 @@ func (statusPtr *AppInstanceStatus) ClearError() { //revive:disable-line
 	statusPtr.ErrorTime = time.Time{}
 }
 
-// HasUnderlayMacAddr - Check if the AI status has the underlay network with this Mac Address
-func (statusPtr *AppInstanceStatus) HasUnderlayMacAddr(MacAddr string) bool {
-	for _, ulStatus := range statusPtr.UnderlayNetworks {
-		if ulStatus.VifInfo.Mac == MacAddr {
+// MaybeUpdateAppIPAddr - Check if the AI status has the underlay network with this Mac Address
+func (status *AppInstanceStatus) MaybeUpdateAppIPAddr(macAddr, ipAddr string) bool {
+	for idx, ulStatus := range status.UnderlayNetworks {
+		if ulStatus.VifInfo.Mac == macAddr {
+			status.UnderlayNetworks[idx].AllocatedIPAddr = ipAddr
 			return true
 		}
 	}

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -198,6 +198,16 @@ func (statusPtr *AppInstanceStatus) ClearError() { //revive:disable-line
 	statusPtr.ErrorTime = time.Time{}
 }
 
+// HasUnderlayMacAddr - Check if the AI status has the underlay network with this Mac Address
+func (statusPtr *AppInstanceStatus) HasUnderlayMacAddr(MacAddr string) bool {
+	for _, ulStatus := range statusPtr.UnderlayNetworks {
+		if ulStatus.VifInfo.Mac == MacAddr {
+			return true
+		}
+	}
+	return false
+}
+
 type EIDOverlayConfig struct {
 	Name string // From proto message
 	EIDConfigDetails

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -1777,3 +1777,13 @@ type IPFlow struct {
 func (flows IPFlow) Key() string {
 	return flows.Scope.UUID.String() + flows.Scope.NetUUID.String() + flows.Scope.Sequence
 }
+
+// VifIPTrig - structure contains Mac Address
+type VifIPTrig struct {
+	MacAddr string
+}
+
+// Key - VifIPTrig key function
+func (vifIP VifIPTrig) Key() string {
+	return vifIP.MacAddr
+}

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -1781,6 +1781,7 @@ func (flows IPFlow) Key() string {
 // VifIPTrig - structure contains Mac Address
 type VifIPTrig struct {
 	MacAddr string
+	IPAddr  net.IP
 }
 
 // Key - VifIPTrig key function


### PR DESCRIPTION
…t mac for dhcp server in snooping

Signed-off-by: Naiming Shen <naiming@zededa.com>

Currently the NI status includes the switchnet ip address to be displayed in the cloud when in the NI basic-info page, but this information is more naturally needed in the App info section. Add the supprt in the app-info on device.