### PR TITLE
Fixed a bug in not using the correct Safename everywhere when procsessing container updates

### DIFF
--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -560,7 +560,8 @@ func handleModify(ctxArg interface{}, key string,
 	if needRestart ||
 		config.RestartCmd.Counter != status.RestartCmd.Counter {
 
-		log.Infof("handleModify(%v) for %s restartcmd from %d to %d need %v\n",
+		log.Infof("handleModify(%v) for %s restartcmd from %d to %d "+
+			"needRestart: %v\n",
 			config.UUIDandVersion, config.DisplayName,
 			status.RestartCmd.Counter, config.RestartCmd.Counter,
 			needRestart)
@@ -578,7 +579,8 @@ func handleModify(ctxArg interface{}, key string,
 		}
 	}
 	if needPurge || config.PurgeCmd.Counter != status.PurgeCmd.Counter {
-		log.Infof("handleModify(%v) for %s purgecmd from %d to %d need %v\n",
+		log.Infof("handleModify(%v) for %s purgecmd from %d to %d "+
+			"needPurge: %v\n",
 			config.UUIDandVersion, config.DisplayName,
 			status.PurgeCmd.Counter, config.PurgeCmd.Counter,
 			needPurge)

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -306,6 +306,17 @@ func (ss *StorageStatus) UpdateFromStorageConfig(sc StorageConfig) {
 	return
 }
 
+// Safename - Returns Safename for the StorageStatus
+func (ss StorageStatus) Safename() string {
+	if ss.IsContainer {
+		// For Containers, SafeName = ImageID.
+		return ss.ImageID.String()
+	}
+	// Else..VMs
+	// XXX - Move VMs to also use ImageID as the Safename.
+	return UrlToSafename(ss.Name, ss.ImageSha256)
+}
+
 // GetErrorInfo sets the errorInfo for the Storage Object
 func (ss StorageStatus) GetErrorInfo() ErrorInfo {
 	errInfo := ErrorInfo{


### PR DESCRIPTION
Move safename compilation routine to be a method of StorageStatus (storageStatus.Safename() ). Call it from all places to get safename for
storage status.

Signed-off-by: Kalyan Nidumolu <kalyan@zadeda.com>