### PR TITLE
separate downloader into files to ease restructure

### DIFF
--- a/pkg/pillar/cmd/downloader/appimg.go
+++ b/pkg/pillar/cmd/downloader/appimg.go
@@ -1,0 +1,22 @@
+package downloader
+
+import (
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// for function name consistency
+func handleAppImgModify(ctxArg interface{}, key string,
+	configArg interface{}) {
+
+	handleDownloaderModify(ctxArg, types.AppImgObj, key, configArg)
+}
+
+func handleAppImgCreate(ctxArg interface{}, key string,
+	configArg interface{}) {
+
+	handleDownloaderCreate(ctxArg, types.AppImgObj, key, configArg)
+}
+
+func handleAppImgDelete(ctxArg interface{}, key string, configArg interface{}) {
+	handleDownloaderDelete(ctxArg, key, configArg)
+}

--- a/pkg/pillar/cmd/downloader/baseos.go
+++ b/pkg/pillar/cmd/downloader/baseos.go
@@ -1,0 +1,21 @@
+package downloader
+
+import (
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+func handleBaseOsModify(ctxArg interface{}, key string,
+	configArg interface{}) {
+
+	handleDownloaderModify(ctxArg, types.BaseOsObj, key, configArg)
+}
+
+func handleBaseOsCreate(ctxArg interface{}, key string,
+	configArg interface{}) {
+
+	handleDownloaderCreate(ctxArg, types.BaseOsObj, key, configArg)
+}
+
+func handleBaseOsDelete(ctxArg interface{}, key string, configArg interface{}) {
+	handleDownloaderDelete(ctxArg, key, configArg)
+}

--- a/pkg/pillar/cmd/downloader/certobj.go
+++ b/pkg/pillar/cmd/downloader/certobj.go
@@ -1,0 +1,20 @@
+package downloader
+
+import (
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+func handleCertObjModify(ctxArg interface{}, key string,
+	configArg interface{}) {
+
+	handleDownloaderModify(ctxArg, types.CertObj, key, configArg)
+}
+func handleCertObjCreate(ctxArg interface{}, key string,
+	configArg interface{}) {
+
+	handleDownloaderCreate(ctxArg, types.CertObj, key, configArg)
+}
+
+func handleCertObjDelete(ctxArg interface{}, key string, configArg interface{}) {
+	handleDownloaderDelete(ctxArg, key, configArg)
+}

--- a/pkg/pillar/cmd/downloader/datastoreconfig.go
+++ b/pkg/pillar/cmd/downloader/datastoreconfig.go
@@ -1,0 +1,22 @@
+package downloader
+
+import (
+	"github.com/lf-edge/eve/pkg/pillar/cast"
+	log "github.com/sirupsen/logrus"
+)
+
+// Handles both create and modify events
+func handleDatastoreConfigModify(ctxArg interface{}, key string,
+	configArg interface{}) {
+
+	ctx := ctxArg.(*downloaderContext)
+	config := cast.CastDatastoreConfig(configArg)
+	log.Infof("handleDatastoreConfigModify for %s\n", key)
+	checkAndUpdateDownloadableObjects(ctx, config.UUID)
+	log.Infof("handleDatastoreConfigModify for %s, done\n", key)
+}
+
+func handleDatastoreConfigDelete(ctxArg interface{}, key string,
+	configArg interface{}) {
+	log.Infof("handleDatastoreConfigDelete for %s\n", key)
+}

--- a/pkg/pillar/cmd/downloader/dirs.go
+++ b/pkg/pillar/cmd/downloader/dirs.go
@@ -1,0 +1,57 @@
+package downloader
+
+import (
+	"os"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	log "github.com/sirupsen/logrus"
+)
+
+func initializeDirs() {
+
+	// Remove any files which didn't make it to the verifier.
+	// XXX space calculation doesn't take into account files in verifier
+	// XXX get space report from verifier??
+	clearInProgressDownloadDirs(downloaderObjTypes)
+
+	// create the object download directories
+	createDownloadDirs(downloaderObjTypes)
+}
+
+// Create the object download directories we own
+func createDownloadDirs(objTypes []string) {
+
+	workingDirTypes := []string{"pending"}
+
+	// now create the download dirs
+	for _, objType := range objTypes {
+		for _, dirType := range workingDirTypes {
+			dirName := types.DownloadDirname + "/" + objType + "/" + dirType
+			if _, err := os.Stat(dirName); err != nil {
+				log.Debugf("Create %s\n", dirName)
+				if err := os.MkdirAll(dirName, 0700); err != nil {
+					log.Fatal(err)
+				}
+			}
+		}
+	}
+}
+
+// clear in-progress object download directories
+func clearInProgressDownloadDirs(objTypes []string) {
+
+	inProgressDirTypes := []string{"pending"}
+
+	// now create the download dirs
+	for _, objType := range objTypes {
+		for _, dirType := range inProgressDirTypes {
+			dirName := types.DownloadDirname + "/" + objType +
+				"/" + dirType
+			if _, err := os.Stat(dirName); err == nil {
+				if err := os.RemoveAll(dirName); err != nil {
+					log.Fatal(err)
+				}
+			}
+		}
+	}
+}

--- a/pkg/pillar/cmd/downloader/globalconfig.go
+++ b/pkg/pillar/cmd/downloader/globalconfig.go
@@ -1,0 +1,47 @@
+package downloader
+
+import (
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/agentlog"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	log "github.com/sirupsen/logrus"
+)
+
+// Handles both create and modify events
+func handleGlobalConfigModify(ctxArg interface{}, key string,
+	statusArg interface{}) {
+
+	ctx := ctxArg.(*downloaderContext)
+	if key != "global" {
+		log.Infof("handleGlobalConfigModify: ignoring %s\n", key)
+		return
+	}
+	log.Infof("handleGlobalConfigModify for %s\n", key)
+	var gcp *types.GlobalConfig
+	debug, gcp = agentlog.HandleGlobalConfig(ctx.subGlobalConfig, agentName,
+		debugOverride)
+	if gcp != nil {
+		if gcp.DownloadGCTime != 0 {
+			downloadGCTime = time.Duration(gcp.DownloadGCTime) * time.Second
+		}
+		if gcp.DownloadRetryTime != 0 {
+			downloadRetryTime = time.Duration(gcp.DownloadRetryTime) * time.Second
+		}
+	}
+	log.Infof("handleGlobalConfigModify done for %s\n", key)
+}
+
+func handleGlobalConfigDelete(ctxArg interface{}, key string,
+	statusArg interface{}) {
+
+	ctx := ctxArg.(*downloaderContext)
+	if key != "global" {
+		log.Infof("handleGlobalConfigDelete: ignoring %s\n", key)
+		return
+	}
+	log.Infof("handleGlobalConfigDelete for %s\n", key)
+	debug, _ = agentlog.HandleGlobalConfig(ctx.subGlobalConfig, agentName,
+		debugOverride)
+	log.Infof("handleGlobalConfigDelete done for %s\n", key)
+}

--- a/pkg/pillar/cmd/downloader/globaldownloadconfig.go
+++ b/pkg/pillar/cmd/downloader/globaldownloadconfig.go
@@ -1,0 +1,21 @@
+package downloader
+
+import (
+	"github.com/lf-edge/eve/pkg/pillar/cast"
+	log "github.com/sirupsen/logrus"
+)
+
+// Handles both create and modify events
+func handleGlobalDownloadConfigModify(ctxArg interface{}, key string,
+	configArg interface{}) {
+
+	ctx := ctxArg.(*downloaderContext)
+	config := cast.CastGlobalDownloadConfig(configArg)
+	if key != "global" {
+		log.Errorf("handleGlobalDownloadConfigModify: unexpected key %s\n", key)
+		return
+	}
+	log.Infof("handleGlobalDownloadConfigModify for %s\n", key)
+	ctx.globalConfig = config
+	log.Infof("handleGlobalDownloadConfigModify done for %s\n", key)
+}

--- a/pkg/pillar/cmd/downloader/space.go
+++ b/pkg/pillar/cmd/downloader/space.go
@@ -1,0 +1,74 @@
+package downloader
+
+import (
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	log "github.com/sirupsen/logrus"
+)
+
+func initSpace(ctx *downloaderContext, kb uint64) {
+	ctx.globalStatusLock.Lock()
+	ctx.globalStatus.UsedSpace = 0
+	ctx.globalStatus.ReservedSpace = 0
+	updateRemainingSpace(ctx)
+
+	ctx.globalStatus.UsedSpace = kb
+	// Note that the UsedSpace calculated during initialization can
+	// exceed MaxSpace, and RemainingSpace is a uint!
+	if ctx.globalStatus.UsedSpace > ctx.globalConfig.MaxSpace {
+		ctx.globalStatus.UsedSpace = ctx.globalConfig.MaxSpace
+	}
+	updateRemainingSpace(ctx)
+	ctx.globalStatusLock.Unlock()
+
+	publishGlobalStatus(ctx)
+}
+
+// Returns true if there was space
+func tryReserveSpace(ctx *downloaderContext, status *types.DownloaderStatus,
+	kb uint64) bool {
+
+	ctx.globalStatusLock.Lock()
+	if kb >= ctx.globalStatus.RemainingSpace {
+		ctx.globalStatusLock.Unlock()
+		return false
+	}
+	ctx.globalStatus.ReservedSpace += kb
+	updateRemainingSpace(ctx)
+	ctx.globalStatusLock.Unlock()
+
+	publishGlobalStatus(ctx)
+	status.ReservedSpace = kb
+	return true
+}
+
+func unreserveSpace(ctx *downloaderContext, status *types.DownloaderStatus) {
+	ctx.globalStatusLock.Lock()
+	ctx.globalStatus.ReservedSpace -= status.ReservedSpace
+	status.ReservedSpace = 0
+	ctx.globalStatus.UsedSpace += types.RoundupToKB(status.Size)
+
+	updateRemainingSpace(ctx)
+	ctx.globalStatusLock.Unlock()
+
+	publishGlobalStatus(ctx)
+}
+
+func deleteSpace(ctx *downloaderContext, kb uint64) {
+	ctx.globalStatusLock.Lock()
+	ctx.globalStatus.UsedSpace -= kb
+	updateRemainingSpace(ctx)
+	ctx.globalStatusLock.Unlock()
+
+	publishGlobalStatus(ctx)
+}
+
+// Caller must hold ctx.globalStatusLock.Lock() but no way to assert in go
+func updateRemainingSpace(ctx *downloaderContext) {
+
+	ctx.globalStatus.RemainingSpace = ctx.globalConfig.MaxSpace -
+		ctx.globalStatus.UsedSpace - ctx.globalStatus.ReservedSpace
+
+	log.Infof("RemainingSpace %d, maxspace %d, usedspace %d, reserved %d\n",
+		ctx.globalStatus.RemainingSpace, ctx.globalConfig.MaxSpace,
+		ctx.globalStatus.UsedSpace, ctx.globalStatus.ReservedSpace)
+}


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

As discussed in #414 . This is the first step in breaking it into parts. This covers the 1st and 3rd bullet points from [this comment](https://github.com/lf-edge/eve/pull/414#issuecomment-559222850):

* the following files modified are just code moved into a different file to make it easier to read: appimg.go, baseos.go, certobj.go, datastoreconfig.go, dirs.go, globalconfig.go, globaldownloadconfig.go, space.go
* the file syncop.go moves some code as-is from downloader.go into the file. This is code that is only called by other code in this file (moving it home, as it were)

No logic is changed at all in this PR; it is solely moving code between files in the same package for greater readability (and so that we can do logic changes in follow-on PRs).

cc @kalyan-nidumolu @eriknordmark 