### PR TITLE
Remove unused const

### DIFF
--- a/pkg/pillar/cmd/downloader/rkt.go
+++ b/pkg/pillar/cmd/downloader/rkt.go
@@ -21,8 +21,6 @@ const (
 	// persistRktLocalConfigBase - Base Dir used for LocalConfigDir for
 	//  rkt Container images
 	persistRktLocalConfigBase = types.PersistDir + "/rktlocal"
-	// persistRktLocalConfigDir - Location of dir used by rkt local data
-	persistRktLocalConfigDir = types.PersistDir + "/rktlocal"
 )
 
 // getContainerRegistry will extract container registry and form download url


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

There was an unused `const` in `pkg/pillar/cmd/downloader/download.go`. Linters complained about it. This removes it.

Resolves fourth bullet point in [this comment](https://github.com/lf-edge/eve/pull/414#issuecomment-559222850), i.e.:

* the file rkt.go just removes an unused const (it was flagged by linter)

cc @kalyan-nidumolu @eriknordmark 