### PR TITLE
Fixed bugs in handling race condition for verified status / Fixed a bug when domain mgr deletes container .aci file in Verified dir.. It should not.

### DIFF
--- a/pkg/pillar/cmd/verifier/verifier.go
+++ b/pkg/pillar/cmd/verifier/verifier.go
@@ -1297,10 +1297,7 @@ func handleDelete(ctx *verifierContext, status *types.VerifyImageStatus) {
 func doDelete(status *types.VerifyImageStatus) {
 	log.Infof("doDelete(%v)\n", status.Safename)
 
-	objType := status.ObjType
-	downloadDirname := types.DownloadDirname + "/" + objType
-	verifierDirname := downloadDirname + "/verifier/" + status.ImageSha256
-	verifiedDirname := downloadDirname + "/verified/" + status.ImageSha256
+	_, verifierDirname, verifiedDirname := status.ImageDownloadDirNames()
 
 	_, err := os.Stat(verifierDirname)
 	if err == nil {

--- a/pkg/pillar/cmd/verifier/verifier.go
+++ b/pkg/pillar/cmd/verifier/verifier.go
@@ -1269,7 +1269,8 @@ func handleModify(ctx *verifierContext, config *types.VerifyImageConfig,
 	handleCreate(ctx, status.ObjType, config)
 	status.PendingModify = false
 	publishVerifyImageStatus(ctx, status)
-	log.Infof("handleModify done for %s\n", config.Name)
+	log.Infof("handleModify done for %s. Status.RefCount=%d, Config.RefCount:%d",
+		config.Name, status.RefCount, config.RefCount)
 }
 
 func handleDelete(ctx *verifierContext, status *types.VerifyImageStatus) {

--- a/pkg/pillar/cmd/zedmanager/handledomainmgr.go
+++ b/pkg/pillar/cmd/zedmanager/handledomainmgr.go
@@ -53,7 +53,6 @@ func MaybeAddDomainConfig(ctx *zedmanagerContext,
 		Activate:          aiConfig.Activate,
 		AppNum:            AppNum,
 		IsContainer:       aiStatus.IsContainer,
-		ContainerImageID:  aiStatus.ContainerImageID,
 		VmConfig:          aiConfig.FixedResources,
 		IoAdapterList:     aiConfig.IoAdapterList,
 		CloudInitUserData: aiConfig.CloudInitUserData,
@@ -71,12 +70,16 @@ func MaybeAddDomainConfig(ctx *zedmanagerContext,
 	}
 	dc.DiskConfigList = make([]types.DiskConfig, numDisks)
 	i := 0
-	for _, sc := range aiConfig.StorageConfigList {
+	for index, sc := range aiConfig.StorageConfigList {
 		// Check that file is verified
 		locationDir := types.VerifiedAppImgDirname + "/" + sc.ImageSha256
 		location := ""
 		if aiStatus.IsContainer {
 			location = types.PersistRktDataDir
+			if dc.ContainerImageID == "" {
+				dc.ContainerImageID =
+					aiStatus.StorageStatusList[index].ContainerImageID
+			}
 		} else {
 			var err error
 			location, err = locationFromDir(locationDir)

--- a/pkg/pillar/cmd/zedmanager/handleverifier.go
+++ b/pkg/pillar/cmd/zedmanager/handleverifier.go
@@ -43,9 +43,10 @@ func lookupVerifyImageConfigSha256(ctx *zedmanagerContext,
 }
 
 // If checkCerts is set this can return false. Otherwise not.
-func MaybeAddVerifyImageConfig(ctx *zedmanagerContext, uuidStr string, safename string,
+func MaybeAddVerifyImageConfig(ctx *zedmanagerContext, uuidStr string,
 	ss types.StorageStatus, checkCerts bool) (bool, types.ErrorInfo) {
 
+	safename := ss.Safename()
 	log.Infof("MaybeAddVerifyImageConfig for %s, checkCerts: %v, "+
 		"isContainer: %v\n", safename, checkCerts, ss.IsContainer)
 

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -531,11 +531,10 @@ func handleCreate(ctxArg interface{}, key string,
 	}
 
 	// If there are no errors, go ahead with Instance creation.
-	uuidStr := status.Key()
-	changed := doUpdate(ctx, uuidStr, config, &status)
+	changed := doUpdate(ctx, config, &status)
 	if changed {
-		log.Infof("handleCreate status change for %s\n",
-			uuidStr)
+		log.Infof("AppInstance(Name:%s, UUID:%s): handleCreate status change.",
+			config.DisplayName, config.UUIDandVersion.UUID)
 		publishAppInstanceStatus(ctx, &status)
 	}
 	log.Infof("handleCreate done for %s\n", config.DisplayName)
@@ -592,11 +591,9 @@ func handleModify(ctxArg interface{}, key string,
 	status.UUIDandVersion = config.UUIDandVersion
 	publishAppInstanceStatus(ctx, status)
 
-	uuidStr := status.Key()
-	changed := doUpdate(ctx, uuidStr, config, status)
+	changed := doUpdate(ctx, config, status)
 	if changed {
-		log.Infof("handleModify status change for %s\n",
-			uuidStr)
+		log.Infof("handleModify status change for %s", status.Key())
 		publishAppInstanceStatus(ctx, status)
 	}
 	status.FixedResources = config.FixedResources

--- a/pkg/pillar/types/verifiertypes.go
+++ b/pkg/pillar/types/verifiertypes.go
@@ -85,6 +85,45 @@ func (status VerifyImageStatus) VerifyFilename(fileName string) bool {
 	return ret
 }
 
+// ImageDownloadDirNames - Returns pendingDirname, verifierDirname, verifiedDirname
+// for the image.
+func (status VerifyImageStatus) ImageDownloadDirNames() (string, string, string) {
+	downloadDirname := DownloadDirname + "/" + status.ObjType
+
+	var pendingDirname, verifierDirname, verifiedDirname string
+	if status.IsContainer {
+		pendingDirname = downloadDirname + "/pending/" + status.ImageID.String()
+		verifierDirname = downloadDirname + "/verifier/" + status.ImageID.String()
+		verifiedDirname = downloadDirname + "/verified/" + status.ImageID.String()
+	} else {
+		// Else..VMs
+		pendingDirname = downloadDirname + "/pending/" + status.ImageSha256
+		verifierDirname = downloadDirname + "/verifier/" + status.ImageSha256
+		verifiedDirname = downloadDirname + "/verified/" + status.ImageSha256
+	}
+	return pendingDirname, verifierDirname, verifiedDirname
+}
+
+// ImageDownloadFilenames - Returns pendingFilename, verifierFilename, verifiedFilename
+// for the image
+func (status VerifyImageStatus) ImageDownloadFilenames() (string, string, string) {
+	var pendingFilename, verifierFilename, verifiedFilename string
+
+	pendingDirname, verifierDirname, verifiedDirname :=
+		status.ImageDownloadDirNames()
+	if status.IsContainer {
+		pendingFilename = pendingDirname + "/" + status.ContainerImageID + ".aci"
+		verifierFilename = verifierDirname + "/" + status.ContainerImageID + ".aci"
+		verifiedFilename = verifiedDirname + "/" + status.ContainerImageID + ".aci"
+	} else {
+		// Else..VMs
+		pendingFilename = pendingDirname + "/" + status.Safename
+		verifierFilename = verifierDirname + "/" + status.Safename
+		verifiedFilename = verifiedDirname + "/" + status.Safename
+	}
+	return pendingFilename, verifierFilename, verifiedFilename
+}
+
 func (status VerifyImageStatus) CheckPendingAdd() bool {
 	return status.PendingAdd
 }

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -116,8 +116,7 @@ type AppInstanceStatus struct {
 	PurgeInprogress     Inprogress
 
 	// Container related state
-	IsContainer      bool
-	ContainerImageID string
+	IsContainer bool
 
 	// Mininum state across all steps and all StorageStatus.
 	// Error* set implies error.


### PR DESCRIPTION
    1) Fixed a raceCondition in using VerifyImageStatus in zedmanager. Make sure there vs.RefCount > 0 OR there is a
    Verifier config already existing before using it. This is the main Fix. The rest are just cleanups.
        - Refactored processing of Images with VerifierStatus present into doInstallProcessStorageEntriesWithVerifiedImage
        - The real fix is really a few lines:
            if vs.RefCount == 0 && verifyImageConfig == nil:
                   return // Treat like verifier status not found. Re-download the image..
    
    2)     For containers, do not delete .aci file in the Verified directory from
    domainMgr..
    2) Fixed a logMfg from Errorf to Infof
    3) Added a couple more Info messages in Verifier to make it easy to debug.
    4) Removed uuidStr as an argument to functions taking AppInstanceStatus as another     argument. Passing uuidStr as another arg is superfluous in such cases - doUpdate, doInstall, doPrepare, doInactivateHalt
    5) Removed safename argument from MaybeAddVerifyImageConfig as it is part of StorageStatus already which is another arg.