### PR TITLE
struct for handlerMap in downloader

### DIFF
--- a/pkg/pillar/cmd/downloader/appimg.go
+++ b/pkg/pillar/cmd/downloader/appimg.go
@@ -8,15 +8,15 @@ import (
 func handleAppImgModify(ctxArg interface{}, key string,
 	configArg interface{}) {
 
-	handleDownloaderModify(ctxArg, types.AppImgObj, key, configArg)
+	dHandler.modify(ctxArg, types.AppImgObj, key, configArg)
 }
 
 func handleAppImgCreate(ctxArg interface{}, key string,
 	configArg interface{}) {
 
-	handleDownloaderCreate(ctxArg, types.AppImgObj, key, configArg)
+	dHandler.create(ctxArg, types.AppImgObj, key, configArg)
 }
 
 func handleAppImgDelete(ctxArg interface{}, key string, configArg interface{}) {
-	handleDownloaderDelete(ctxArg, key, configArg)
+	dHandler.delete(ctxArg, key, configArg)
 }

--- a/pkg/pillar/cmd/downloader/baseos.go
+++ b/pkg/pillar/cmd/downloader/baseos.go
@@ -7,15 +7,15 @@ import (
 func handleBaseOsModify(ctxArg interface{}, key string,
 	configArg interface{}) {
 
-	handleDownloaderModify(ctxArg, types.BaseOsObj, key, configArg)
+	dHandler.modify(ctxArg, types.BaseOsObj, key, configArg)
 }
 
 func handleBaseOsCreate(ctxArg interface{}, key string,
 	configArg interface{}) {
 
-	handleDownloaderCreate(ctxArg, types.BaseOsObj, key, configArg)
+	dHandler.create(ctxArg, types.BaseOsObj, key, configArg)
 }
 
 func handleBaseOsDelete(ctxArg interface{}, key string, configArg interface{}) {
-	handleDownloaderDelete(ctxArg, key, configArg)
+	dHandler.delete(ctxArg, key, configArg)
 }

--- a/pkg/pillar/cmd/downloader/certobj.go
+++ b/pkg/pillar/cmd/downloader/certobj.go
@@ -7,14 +7,14 @@ import (
 func handleCertObjModify(ctxArg interface{}, key string,
 	configArg interface{}) {
 
-	handleDownloaderModify(ctxArg, types.CertObj, key, configArg)
+	dHandler.modify(ctxArg, types.CertObj, key, configArg)
 }
 func handleCertObjCreate(ctxArg interface{}, key string,
 	configArg interface{}) {
 
-	handleDownloaderCreate(ctxArg, types.CertObj, key, configArg)
+	dHandler.create(ctxArg, types.CertObj, key, configArg)
 }
 
 func handleCertObjDelete(ctxArg interface{}, key string, configArg interface{}) {
-	handleDownloaderDelete(ctxArg, key, configArg)
+	dHandler.delete(ctxArg, key, configArg)
 }

--- a/pkg/pillar/cmd/downloader/handlers.go
+++ b/pkg/pillar/cmd/downloader/handlers.go
@@ -1,0 +1,81 @@
+package downloader
+
+import (
+	"github.com/lf-edge/eve/pkg/pillar/cast"
+	log "github.com/sirupsen/logrus"
+)
+
+type downloadHandler struct {
+	// We have one goroutine per provisioned domU object.
+	// Channel is used to send config (new and updates)
+	// Channel is closed when the object is deleted
+	// The go-routine owns writing status for the object
+	// The key in the map is the objects Key().
+
+	handlers map[string]chan<- interface{}
+}
+
+func makeDownloadHandler() *downloadHandler {
+	return &downloadHandler{
+		handlers: make(map[string]chan<- interface{}),
+	}
+}
+
+// Wrappers around createObject, modifyObject, and deleteObject
+
+// Determine whether it is an create or modify
+func (d *downloadHandler) modify(ctxArg interface{}, objType string,
+	key string, configArg interface{}) {
+
+	log.Infof("downloadHandler.modify(%s)\n", key)
+	config := cast.CastDownloaderConfig(configArg)
+	if config.Key() != key {
+		log.Errorf("downloadHandler.modify key/UUID mismatch %s vs %s; ignored %+v\n",
+			key, config.Key(), config)
+		return
+	}
+	h, ok := d.handlers[config.Key()]
+	if !ok {
+		log.Fatalf("downloadHandler.modify called on config that does not exist")
+	}
+	h <- configArg
+}
+
+func (d *downloadHandler) create(ctxArg interface{}, objType string,
+	key string, configArg interface{}) {
+
+	log.Infof("downloadHandler.create(%s)\n", key)
+	ctx := ctxArg.(*downloaderContext)
+	config := cast.CastDownloaderConfig(configArg)
+	if config.Key() != key {
+		log.Errorf("downloadHandler.create key/UUID mismatch %s vs %s; ignored %+v\n",
+			key, config.Key(), config)
+		return
+	}
+	h, ok := d.handlers[config.Key()]
+	if ok {
+		log.Fatalf("downloadHandler.create called on config that already exists")
+	}
+	h1 := make(chan interface{}, 1)
+	d.handlers[config.Key()] = h1
+	go runHandler(ctx, objType, key, h1)
+	h = h1
+	h <- configArg
+}
+
+func (d *downloadHandler) delete(ctxArg interface{}, key string,
+	configArg interface{}) {
+
+	log.Infof("downloadHandler.delete(%s)\n", key)
+	// Do we have a channel/goroutine?
+	h, ok := d.handlers[key]
+	if ok {
+		log.Debugf("Closing channel\n")
+		close(h)
+		delete(d.handlers, key)
+	} else {
+		log.Debugf("downloadHandler.delete: unknown %s\n", key)
+		return
+	}
+	log.Infof("downloadHandler.delete(%s) done\n", key)
+}


### PR DESCRIPTION
* Moves the `handlerMap` into a `struct` that contains it, and the member methods to operate on it, all in a file called `handlers.go`
* creates the `dHandler = &downloadHandler{}` to instantiate that object
* Changes all calls to `handlerDownloadCreate`, `handleDownloadModify`, `handleDownloadDelete` to `dHandler.create`, `dHandler.modify`, `dHandler.delete` respectively
* in `downloader.go`, moves all of the `var` declarations into a single block

Addresses the fifth bullet point in [this comment](https://github.com/lf-edge/eve/pull/414#issuecomment-559222850), i.e.:

* the file handlers.go takes the type handlers map[string]chan<- interface{} and the global (in the package) var handlerMap, as well as the funcs that manipulated it, and turns it into a struct with methods. It replaces the code removed here

cc @kalyan-nidumolu @eriknordmark 

This should run another run of testing.