### PR TITLE
extract verifyHandler into own struct

### DIFF
--- a/pkg/pillar/cmd/verifier/appimg.go
+++ b/pkg/pillar/cmd/verifier/appimg.go
@@ -1,0 +1,19 @@
+package verifier
+
+import (
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// wrappers to add objType for create. The Delete wrappers are merely
+// for function name consistency
+func handleAppImgModify(ctxArg interface{}, key string, configArg interface{}) {
+	vHandler.modify(ctxArg, types.AppImgObj, key, configArg)
+}
+
+func handleAppImgCreate(ctxArg interface{}, key string, configArg interface{}) {
+	vHandler.create(ctxArg, types.AppImgObj, key, configArg)
+}
+
+func handleAppImgDelete(ctxArg interface{}, key string, configArg interface{}) {
+	vHandler.delete(ctxArg, key, configArg)
+}

--- a/pkg/pillar/cmd/verifier/baseos.go
+++ b/pkg/pillar/cmd/verifier/baseos.go
@@ -1,0 +1,17 @@
+package verifier
+
+import (
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+func handleBaseOsModify(ctxArg interface{}, key string, configArg interface{}) {
+	vHandler.modify(ctxArg, types.BaseOsObj, key, configArg)
+}
+
+func handleBaseOsCreate(ctxArg interface{}, key string, configArg interface{}) {
+	vHandler.create(ctxArg, types.BaseOsObj, key, configArg)
+}
+
+func handleBaseOsDelete(ctxArg interface{}, key string, configArg interface{}) {
+	vHandler.delete(ctxArg, key, configArg)
+}

--- a/pkg/pillar/cmd/verifier/handlers.go
+++ b/pkg/pillar/cmd/verifier/handlers.go
@@ -1,0 +1,83 @@
+package verifier
+
+import (
+	"github.com/lf-edge/eve/pkg/pillar/cast"
+	log "github.com/sirupsen/logrus"
+)
+
+type verifyHandler struct {
+	// We have one goroutine per provisioned domU object.
+	// Channel is used to send config (new and updates)
+	// Channel is closed when the object is deleted
+	// The go-routine owns writing status for the object
+	// The key in the map is the objects Key()
+
+	handlers map[string]chan<- interface{}
+}
+
+func makeVerifyHandler() *verifyHandler {
+	return &verifyHandler{
+		handlers: make(map[string]chan<- interface{}),
+	}
+}
+
+// Wrappers around handleCreate, handleModify, and handleDelete
+
+// Determine whether it is an create or modify
+func (v *verifyHandler) modify(ctxArg interface{}, objType string,
+	key string, configArg interface{}) {
+
+	log.Infof("verifyHandler.modify(%s)\n", key)
+	config := cast.CastVerifyImageConfig(configArg)
+	if config.Key() != key {
+		log.Errorf("verifyHandler.modify key/UUID mismatch %s vs %s; ignored %+v\n",
+			key, config.Key(), config)
+		return
+	}
+	h, ok := v.handlers[config.Key()]
+	if !ok {
+		log.Fatalf("verifyHandler.modify called on config that does not exist")
+	}
+	h <- configArg
+	log.Infof("verifyHandler.modify(%s) done\n", key)
+}
+
+func (v *verifyHandler) create(ctxArg interface{}, objType string,
+	key string, configArg interface{}) {
+
+	log.Infof("verifyHandler.create(%s)\n", key)
+	ctx := ctxArg.(*verifierContext)
+	config := cast.CastVerifyImageConfig(configArg)
+	if config.Key() != key {
+		log.Errorf("verifyHandler.create key/UUID mismatch %s vs %s; ignored %+v\n",
+			key, config.Key(), config)
+		return
+	}
+	h, ok := v.handlers[config.Key()]
+	if ok {
+		log.Fatalf("verifyHandler.create called on config that already exists")
+	}
+	h1 := make(chan interface{}, 1)
+	v.handlers[config.Key()] = h1
+	go runHandler(ctx, objType, key, h1)
+	h = h1
+	h <- configArg
+	log.Infof("verifyHandler.create(%s) done\n", key)
+}
+
+func (v *verifyHandler) delete(ctxArg interface{}, key string,
+	configArg interface{}) {
+
+	log.Infof("verifyHandler.delete(%s)\n", key)
+	// Do we have a channel/goroutine?
+	h, ok := v.handlers[key]
+	if ok {
+		log.Debugf("Closing channel\n")
+		close(h)
+		delete(v.handlers, key)
+	} else {
+		log.Debugf("verifyHandler.delete: unknown %s\n", key)
+		return
+	}
+	log.Infof("verifyHandler.delete(%s) done\n", key)
+}


### PR DESCRIPTION
As discussed with @eriknordmark in [this comment](https://github.com/lf-edge/eve/pull/435#issuecomment-562712235), brings the handlers for verifier, which are very similar to downloader, inline with the same structure just put in #435 for downloader.

As of yet, does not remove repetitive code between the two to a common usable element. This PR just extracts them to parallel what is done there, which is a safe change. Following that, we can look at both and figure out how to extract the common elements.

cc @kalyan-nidumolu @eriknordmark 