### PR TITLE
Fix Downloader Bootup crash / Fix Zedmgr to set ErrTimestamp when setting  AppInstStatus.Err

### DIFF
--- a/pkg/pillar/cmd/downloader/context.go
+++ b/pkg/pillar/cmd/downloader/context.go
@@ -31,7 +31,7 @@ type downloaderContext struct {
 func (ctx *downloaderContext) registerHandlers() error {
 	// Look for global config such as log levels
 	subGlobalConfig, err := pubsub.Subscribe("", types.GlobalConfig{},
-		false, &ctx)
+		false, ctx)
 	if err != nil {
 		return err
 	}
@@ -42,7 +42,7 @@ func (ctx *downloaderContext) registerHandlers() error {
 	subGlobalConfig.Activate()
 
 	subDeviceNetworkStatus, err := pubsub.Subscribe("nim",
-		types.DeviceNetworkStatus{}, false, &ctx)
+		types.DeviceNetworkStatus{}, false, ctx)
 	if err != nil {
 		return err
 	}
@@ -53,7 +53,7 @@ func (ctx *downloaderContext) registerHandlers() error {
 	subDeviceNetworkStatus.Activate()
 
 	subGlobalDownloadConfig, err := pubsub.Subscribe("",
-		types.GlobalDownloadConfig{}, false, &ctx)
+		types.GlobalDownloadConfig{}, false, ctx)
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func (ctx *downloaderContext) registerHandlers() error {
 	// before any download config ( App/baseos/cert). Without DataStore Config,
 	// Image Downloads will run into errors.
 	subDatastoreConfig, err := pubsub.Subscribe("zedagent",
-		types.DatastoreConfig{}, false, &ctx)
+		types.DatastoreConfig{}, false, ctx)
 	if err != nil {
 		return err
 	}
@@ -109,7 +109,7 @@ func (ctx *downloaderContext) registerHandlers() error {
 	pubCertObjStatus.ClearRestarted()
 
 	subAppImgConfig, err := pubsub.SubscribeScope("zedmanager",
-		types.AppImgObj, types.DownloaderConfig{}, false, &ctx)
+		types.AppImgObj, types.DownloaderConfig{}, false, ctx)
 	if err != nil {
 		return err
 	}
@@ -120,7 +120,7 @@ func (ctx *downloaderContext) registerHandlers() error {
 	subAppImgConfig.Activate()
 
 	subBaseOsConfig, err := pubsub.SubscribeScope("baseosmgr",
-		types.BaseOsObj, types.DownloaderConfig{}, false, &ctx)
+		types.BaseOsObj, types.DownloaderConfig{}, false, ctx)
 	if err != nil {
 		return err
 	}
@@ -131,7 +131,7 @@ func (ctx *downloaderContext) registerHandlers() error {
 	subBaseOsConfig.Activate()
 
 	subCertObjConfig, err := pubsub.SubscribeScope("baseosmgr",
-		types.CertObj, types.DownloaderConfig{}, false, &ctx)
+		types.CertObj, types.DownloaderConfig{}, false, ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -521,12 +521,17 @@ func handleCreate(ctxArg interface{}, key string,
 		errStr := "Invalid Cpu count - 0\n"
 		status.Error += errStr
 	}
+	if status.Error != "" {
+		status.SetError(status.Error, "Zedmanager Create Handler",
+			time.Now())
+	}
 	publishAppInstanceStatus(ctx, &status)
 
 	// if some error, return
 	if status.Error != "" {
-		log.Debugf("AppInstance(Name:%s, UUID:%s): Errors in App Instance "+
-			"Create.", config.DisplayName, config.UUIDandVersion.UUID)
+		log.Errorf("AppInstance(Name:%s, UUID:%s): Errors in App Instance "+
+			"Create. Error: %s",
+			config.DisplayName, config.UUIDandVersion.UUID, status.Error)
 		return
 	}
 


### PR DESCRIPTION
1) Fix recent regression in Downloader bootup - Pass ctx Ptr instead of &(ctx ptr ) to Subscriptions

2) In Zedmgr, whe setting AppInstStatus.Err also set Err timestamp. If ErrTimestamp is zero, error is not sent in Info msg.