### PR TITLE
nodeagent truncating the rebootStack fix, some  nits in handling cert…

### DIFF
--- a/pkg/pillar/cmd/baseosmgr/handledownload.go
+++ b/pkg/pillar/cmd/baseosmgr/handledownload.go
@@ -285,11 +285,13 @@ func checkStorageDownloadStatus(ctx *baseOsMgrContext, objType string,
 		if ds.LastErr != "" {
 			log.Errorf("checkStorageDownloadStatus %s, downloader error, %s\n",
 				uuidStr, ds.LastErr)
-			ss.Error = ds.LastErr
-			ret.AllErrors = appendError(ret.AllErrors, "downloader",
-				ds.LastErr)
-			ss.ErrorSource = pubsub.TypeToName(types.VerifyImageStatus{})
-			ss.ErrorTime = ds.LastErrTime
+			errInfo := types.ErrorInfo{
+				Error:       ds.LastErr,
+				ErrorTime:   ds.LastErrTime,
+				ErrorSource: pubsub.TypeToName(types.VerifyImageStatus{}),
+			}
+			ss.SetErrorInfo(errInfo)
+			ret.AllErrors = appendError(ret.AllErrors, "downloader", ds.LastErr)
 			ret.ErrorTime = ss.ErrorTime
 			ret.Changed = true
 		}
@@ -436,9 +438,12 @@ func installDownloadedObject(objType string, safename string,
 		status.State = types.INSTALLED
 		log.Infof("installDownloadedObject(%s) done\n", safename)
 	} else {
-		status.Error = fmt.Sprintf("%s", ret)
-		status.ErrorSource = pubsub.TypeToName(types.VerifyImageStatus{})
-		status.ErrorTime = time.Now()
+		errInfo := types.ErrorInfo{
+			Error:       fmt.Sprintf("%s", ret),
+			ErrorTime:   time.Now(),
+			ErrorSource: pubsub.TypeToName(types.VerifyImageStatus{}),
+		}
+		status.SetErrorInfo(errInfo)
 	}
 	return ret
 }

--- a/pkg/pillar/cmd/baseosmgr/handledownload.go
+++ b/pkg/pillar/cmd/baseosmgr/handledownload.go
@@ -288,6 +288,7 @@ func checkStorageDownloadStatus(ctx *baseOsMgrContext, objType string,
 			ss.Error = ds.LastErr
 			ret.AllErrors = appendError(ret.AllErrors, "downloader",
 				ds.LastErr)
+			ss.ErrorSource = pubsub.TypeToName(types.VerifyImageStatus{})
 			ss.ErrorTime = ds.LastErrTime
 			ret.ErrorTime = ss.ErrorTime
 			ret.Changed = true
@@ -436,6 +437,7 @@ func installDownloadedObject(objType string, safename string,
 		log.Infof("installDownloadedObject(%s) done\n", safename)
 	} else {
 		status.Error = fmt.Sprintf("%s", ret)
+		status.ErrorSource = pubsub.TypeToName(types.VerifyImageStatus{})
 		status.ErrorTime = time.Now()
 	}
 	return ret

--- a/pkg/pillar/cmd/baseosmgr/handleverifier.go
+++ b/pkg/pillar/cmd/baseosmgr/handleverifier.go
@@ -260,6 +260,7 @@ func checkStorageVerifierStatus(ctx *baseOsMgrContext, objType string, uuidStr s
 			log.Errorf("checkStorageVerifierStatus(%s) verifier error for %s: %s\n",
 				uuidStr, safename, vs.LastErr)
 			ss.Error = vs.LastErr
+			ss.ErrorSource = pubsub.TypeToName(types.VerifyImageStatus{})
 			ret.AllErrors = appendError(ret.AllErrors, "verifier",
 				vs.LastErr)
 			ss.ErrorTime = vs.LastErrTime

--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -543,13 +543,13 @@ func handleLastRebootReason(ctx *nodeagentContext) {
 	}
 
 	// if reboot stack size crosses max size, truncate
-	if len(ctx.rebootStack) > maxRebootStackSize {
+	headerSize := 100
+	if len(ctx.rebootStack) > (maxRebootStackSize + headerSize) {
 		runes := bytes.Runes([]byte(ctx.rebootStack))
-		if len(runes) > maxRebootStackSize {
+		if len(runes) > (maxRebootStackSize + headerSize) {
 			runes = runes[:maxRebootStackSize]
 		}
-		ctx.rebootStack = fmt.Sprintf("Truncated stack: %v",
-			ctx.rebootStack)
+		ctx.rebootStack = fmt.Sprintf("Truncated stack: %v", string(runes))
 	}
 	// Read and increment restartCounter
 	ctx.restartCounter = incrementRestartCounter()

--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -43,7 +43,7 @@ const (
 	watchdogInterval     uint32 = 25
 	networkUpTimeout     uint32 = 300
 	maxRebootStackSize          = 1600
-	maxJsonAttributeSize        = maxRebootStackSize + 100
+	maxJSONAttributeSize        = maxRebootStackSize + 100
 	configDir                   = "/config"
 	tmpDirname                  = "/var/tmp/zededa"
 	firstbootFile               = tmpDirname + "/first-boot"
@@ -544,9 +544,9 @@ func handleLastRebootReason(ctx *nodeagentContext) {
 	}
 
 	// if reboot stack size crosses max size, truncate
-	if len(ctx.rebootStack) > maxJsonAttributeSize {
+	if len(ctx.rebootStack) > maxJSONAttributeSize {
 		runes := bytes.Runes([]byte(ctx.rebootStack))
-		if len(runes) > maxJsonAttributeSize {
+		if len(runes) > maxJSONAttributeSize {
 			runes = runes[:maxRebootStackSize]
 		}
 		ctx.rebootStack = fmt.Sprintf("Truncated stack: %v", string(runes))

--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -38,15 +38,16 @@ import (
 )
 
 const (
-	agentName                 = "nodeagent"
-	timeTickInterval   uint32 = 10
-	watchdogInterval   uint32 = 25
-	networkUpTimeout   uint32 = 300
-	maxRebootStackSize        = 1600
-	configDir                 = "/config"
-	tmpDirname                = "/var/tmp/zededa"
-	firstbootFile             = tmpDirname + "/first-boot"
-	restartCounterFile        = configDir + "/restartcounter"
+	agentName                   = "nodeagent"
+	timeTickInterval     uint32 = 10
+	watchdogInterval     uint32 = 25
+	networkUpTimeout     uint32 = 300
+	maxRebootStackSize          = 1600
+	maxJsonAttributeSize        = maxRebootStackSize + 100
+	configDir                   = "/config"
+	tmpDirname                  = "/var/tmp/zededa"
+	firstbootFile               = tmpDirname + "/first-boot"
+	restartCounterFile          = configDir + "/restartcounter"
 )
 
 // Version : module version
@@ -543,10 +544,9 @@ func handleLastRebootReason(ctx *nodeagentContext) {
 	}
 
 	// if reboot stack size crosses max size, truncate
-	headerSize := 100
-	if len(ctx.rebootStack) > (maxRebootStackSize + headerSize) {
+	if len(ctx.rebootStack) > maxJsonAttributeSize {
 		runes := bytes.Runes([]byte(ctx.rebootStack))
-		if len(runes) > (maxRebootStackSize + headerSize) {
+		if len(runes) > maxJsonAttributeSize {
 			runes = runes[:maxRebootStackSize]
 		}
 		ctx.rebootStack = fmt.Sprintf("Truncated stack: %v", string(runes))

--- a/pkg/pillar/types/zedagenttypes.go
+++ b/pkg/pillar/types/zedagenttypes.go
@@ -6,6 +6,7 @@ package types
 import (
 	"time"
 
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
 )
@@ -158,6 +159,25 @@ func (status CertObjStatus) CheckPendingModify() bool {
 
 func (status CertObjStatus) CheckPendingDelete() bool {
 	return false
+}
+
+// getCertObjStatus finds a certificate, and checks the status
+func (certObjStatus CertObjStatus) getCertStatus(certURL string) (bool, bool, ErrorInfo) {
+	for _, certObj := range certObjStatus.StorageStatusList {
+		if certObj.Name == certURL {
+			installed := true
+			if certObj.Error != "" || certObj.State != INSTALLED {
+				installed = false
+			}
+			return true, installed, certObj.GetErrorInfo()
+		}
+	}
+	errorInfo := ErrorInfo{
+		Error:       "Invalid Certificate, not found",
+		ErrorSource: pubsub.TypeToName(VerifyImageStatus{}),
+		ErrorTime:   time.Now(),
+	}
+	return false, false, errorInfo
 }
 
 // return value holder

--- a/pkg/pillar/types/zedagenttypes.go
+++ b/pkg/pillar/types/zedagenttypes.go
@@ -162,8 +162,8 @@ func (status CertObjStatus) CheckPendingDelete() bool {
 }
 
 // getCertObjStatus finds a certificate, and checks the status
-func (certObjStatus CertObjStatus) getCertStatus(certURL string) (bool, bool, ErrorInfo) {
-	for _, certObj := range certObjStatus.StorageStatusList {
+func (status CertObjStatus) getCertStatus(certURL string) (bool, bool, ErrorInfo) {
+	for _, certObj := range status.StorageStatusList {
 		if certObj.Name == certURL {
 			installed := true
 			if certObj.Error != "" || certObj.State != INSTALLED {

--- a/pkg/pillar/types/zedagenttypes.go
+++ b/pkg/pillar/types/zedagenttypes.go
@@ -161,7 +161,11 @@ func (status CertObjStatus) CheckPendingDelete() bool {
 	return false
 }
 
-// getCertObjStatus finds a certificate, and checks the status
+// getCertObjStatus finds a certificate, and returns the status
+// returns three values,
+//  - whether the cert object status is found
+//  - whether the cert object is installed
+//  - any error information
 func (status CertObjStatus) getCertStatus(certURL string) (bool, bool, ErrorInfo) {
 	for _, certObj := range status.StorageStatusList {
 		if certObj.Name == certURL {

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -413,28 +413,16 @@ func (ss StorageStatus) checkCertsStatusForObject(safename string,
 	certObjStatus CertObjStatus) (bool, ErrorInfo) {
 
 	if ss.SignatureKey != "" {
-		for _, certObj := range certObjStatus.StorageStatusList {
-			if certObj.Name == ss.SignatureKey {
-				if certObj.Error != "" {
-					return false, certObj.GetErrorInfo()
-				}
-				if certObj.State != DELIVERED {
-					return false, ErrorInfo{}
-				}
-			}
+		found, installed, errInfo := certObjStatus.getCertStatus(ss.SignatureKey)
+		if !found || !installed {
+			return false, errInfo
 		}
 	}
 
 	for _, certURL := range ss.CertificateChain {
-		for _, certObj := range certObjStatus.StorageStatusList {
-			if certObj.Name == certURL {
-				if certObj.Error != "" {
-					return false, certObj.GetErrorInfo()
-				}
-				if certObj.State != DELIVERED {
-					return false, ErrorInfo{}
-				}
-			}
+		found, installed, errInfo := certObjStatus.getCertStatus(certURL)
+		if !found || !installed {
+			return false, errInfo
 		}
 	}
 	return true, ErrorInfo{}


### PR DESCRIPTION
1. nodeagent truncating the rebootStack fix
  -  fix assignment for the rebootstack 
  -  added a header of 100-bytes for indicating truncation
2. some  nits in handling cert object status handling
   - consolidated both error and not found case to a method
     for certObjectStatus
  - changed the check to INSTALLED, inplace of DELIVERED.

Signed-off-by: Srinibas Maharana <srinibas@zededa.com>