### PR TITLE
Workaround/patch for qemu 9P buffer overrun issue with containers

### DIFF
--- a/pkg/xen-tools/patches-4.13.0-rc4/06-9p-debug.patch
+++ b/pkg/xen-tools/patches-4.13.0-rc4/06-9p-debug.patch
@@ -1,0 +1,146 @@
+--- xen/tools/qemu-xen/hw/9pfs/9p.c
++++ 9p.c
+@@ -26,6 +26,15 @@
+ #include "migration/blocker.h"
+ #include "sysemu/qtest.h"
+ 
++#define DEBUG_v9fs_init_qiov_from_pdu(qiov, pdu, skip, size, is_write) { \
++	size_t final_size = size; \
++	v9fs_init_qiov_from_pdu(qiov, pdu, skip, &final_size, is_write); \
++        if (size != final_size) { \
++            printf("DEBUG %s %d requested size=%lu actual size=%lu\n",__func__,__LINE__,(size_t)size,(size_t)final_size); \
++        } \
++        size = final_size; \
++}
++
+ int open_fd_hw;
+ int total_open_fd;
+ static int open_fd_rc;
+@@ -1682,22 +1691,29 @@
+  * with qemu_iovec_destroy().
+  */
+ static void v9fs_init_qiov_from_pdu(QEMUIOVector *qiov, V9fsPDU *pdu,
+-                                    size_t skip, size_t size,
++                                    size_t skip, size_t *size,
+                                     bool is_write)
+ {
+     QEMUIOVector elem;
+     struct iovec *iov;
+     unsigned int niov;
++    size_t my_size = *size + skip;
+ 
+     if (is_write) {
+-        pdu->s->transport->init_out_iov_from_pdu(pdu, &iov, &niov, size + skip);
++        pdu->s->transport->init_out_iov_from_pdu(pdu, &iov, &niov, my_size);
+     } else {
+-        pdu->s->transport->init_in_iov_from_pdu(pdu, &iov, &niov, size + skip);
++        pdu->s->transport->init_in_iov_from_pdu(pdu, &iov, &niov, &my_size);
+     }
+ 
++    if (my_size < skip) {
++        *size = 0;
++    } else {
++        *size = my_size - skip; 
++    }
++
+     qemu_iovec_init_external(&elem, iov, niov);
+     qemu_iovec_init(qiov, niov);
+-    qemu_iovec_concat(qiov, &elem, skip, size);
++    qemu_iovec_concat(qiov, &elem, skip, *size);
+ }
+ 
+ static int v9fs_xattr_read(V9fsState *s, V9fsPDU *pdu, V9fsFidState *fidp,
+@@ -1722,7 +1738,7 @@
+     }
+     offset += err;
+ 
+-    v9fs_init_qiov_from_pdu(&qiov_full, pdu, offset, read_count, false);
++    DEBUG_v9fs_init_qiov_from_pdu(&qiov_full, pdu, offset, read_count, false);
+     err = v9fs_pack(qiov_full.iov, qiov_full.niov, 0,
+                     ((char *)fidp->fs.xattr.value) + off,
+                     read_count);
+@@ -1852,7 +1868,7 @@
+         QEMUIOVector qiov;
+         int32_t len;
+ 
+-        v9fs_init_qiov_from_pdu(&qiov_full, pdu, offset + 4, max_count, false);
++        DEBUG_v9fs_init_qiov_from_pdu(&qiov_full, pdu, offset + 4, max_count, false);
+         qemu_iovec_init(&qiov, qiov_full.niov);
+         do {
+             qemu_iovec_reset(&qiov);
+@@ -2085,7 +2102,7 @@
+         return;
+     }
+     offset += err;
+-    v9fs_init_qiov_from_pdu(&qiov_full, pdu, offset, count, true);
++    DEBUG_v9fs_init_qiov_from_pdu(&qiov_full, pdu, offset, count, true);
+     trace_v9fs_write(pdu->tag, pdu->id, fid, off, count, qiov_full.niov);
+ 
+     fidp = get_fid(pdu, fid);
+--- xen/tools/qemu-xen/hw/9pfs/9p.h
++++ 9p.h
+@@ -365,7 +365,7 @@
+     ssize_t     (*pdu_vunmarshal)(V9fsPDU *pdu, size_t offset, const char *fmt,
+                                   va_list ap);
+     void        (*init_in_iov_from_pdu)(V9fsPDU *pdu, struct iovec **piov,
+-                                        unsigned int *pniov, size_t size);
++                                        unsigned int *pniov, size_t *size);
+     void        (*init_out_iov_from_pdu)(V9fsPDU *pdu, struct iovec **piov,
+                                          unsigned int *pniov, size_t size);
+     void        (*push_and_notify)(V9fsPDU *pdu);
+--- xen/tools/qemu-xen/hw/9pfs/virtio-9p-device.c
++++ virtio-9p-device.c
+@@ -146,19 +146,19 @@
+ }
+ 
+ static void virtio_init_in_iov_from_pdu(V9fsPDU *pdu, struct iovec **piov,
+-                                        unsigned int *pniov, size_t size)
++                                        unsigned int *pniov, size_t *size)
+ {
+     V9fsState *s = pdu->s;
+     V9fsVirtioState *v = container_of(s, V9fsVirtioState, state);
+     VirtQueueElement *elem = v->elems[pdu->idx];
+     size_t buf_size = iov_size(elem->in_sg, elem->in_num);
+ 
+-    if (buf_size < size) {
++    if (buf_size < *size) {
+         VirtIODevice *vdev = VIRTIO_DEVICE(v);
+ 
+         virtio_error(vdev,
+                      "VirtFS reply type %d needs %zu bytes, buffer has %zu",
+-                     pdu->id + 1, size, buf_size);
++                     pdu->id + 1, *size, buf_size);
+     }
+ 
+     *piov = elem->in_sg;
+--- xen/tools/qemu-xen/hw/9pfs/xen-9p-backend.c
++++ xen-9p-backend.c
+@@ -187,7 +187,7 @@
+ static void xen_9pfs_init_in_iov_from_pdu(V9fsPDU *pdu,
+                                           struct iovec **piov,
+                                           unsigned int *pniov,
+-                                          size_t size)
++                                          size_t *size)
+ {
+     Xen9pfsDev *xen_9pfs = container_of(pdu->s, Xen9pfsDev, state);
+     Xen9pfsRing *ring = &xen_9pfs->rings[pdu->tag % xen_9pfs->num_rings];
+@@ -197,15 +197,14 @@
+     g_free(ring->sg);
+ 
+     ring->sg = g_new0(struct iovec, 2);
+-    xen_9pfs_in_sg(ring, ring->sg, &num, pdu->idx, size);
++    xen_9pfs_in_sg(ring, ring->sg, &num, pdu->idx, *size);
+ 
+     buf_size = iov_size(ring->sg, num);
+-    if (buf_size  < size) {
++    if (buf_size  < *size) {
++        *size = buf_size;
+         xen_pv_printf(&xen_9pfs->xendev, 0, "Xen 9pfs request type %d"
+-                "needs %zu bytes, buffer has %zu\n", pdu->id, size,
++                "needs %zu bytes, buffer has %zu\n", pdu->id, *size,
+                 buf_size);
+-        xen_be_set_state(&xen_9pfs->xendev, XenbusStateClosing);
+-        xen_9pfs_disconnect(&xen_9pfs->xendev);
+     }
+ 
+     *piov = ring->sg;


### PR DESCRIPTION
What can I say -- the subject says it all. We need to get to the bottom of the buffer overrun issue, but for now this should suffice and help us diagnose the problem somewhat more.