### PR TITLE
A few improvements for CircleCI version tagging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,9 @@ jobs:
           command: >
             make ${DOCKERHUB_USERNAME:+LINUXKIT_PKG_TARGET=push} eve
       - store_artifacts:
-          path: dist/amd64/rootfs.img
+          path: dist/amd64/installer/rootfs.img
+      - store_artifacts:
+          path: images/rootfs-xen.yml
   yetus:
     docker:
       - image: apache/yetus:0.11.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
       - run:
           name: EVE
           command: >
-            make ${DOCKERHUB_USERNAME:+LINUXKIT_PKG_TARGET=push} eve
+            make ${DOCKERHUB_USERNAME:+LINUXKIT_PKG_TARGET=push EVE_SNAPSHOT_VERSION=0.0.0-snapshot} eve
       - store_artifacts:
           path: dist/amd64/installer/rootfs.img
       - store_artifacts:

--- a/tools/parse-pkgs.sh
+++ b/tools/parse-pkgs.sh
@@ -13,7 +13,7 @@ eve_version() {
   local vers="`get_git_tag`"
 
   if [ -z "$vers" ] ; then
-    vers="0.0.0-`git rev-parse --abbrev-ref HEAD | tr / _`-`git describe --match v --abbrev=8 --always --dirty`-`date -u +"%Y-%m-%d.%H.%M"`"
+    vers="${EVE_SNAPSHOT_VERSION:-0.0.0}-$(git rev-parse --abbrev-ref HEAD | tr / _)-$(git describe --match v --abbrev=8 --always --dirty)-$(date -u +"%Y-%m-%d.%H.%M")"
     vers=`echo ${vers} | sed -e 's#-master##'`
   fi
 

--- a/tools/parse-pkgs.sh
+++ b/tools/parse-pkgs.sh
@@ -13,7 +13,7 @@ eve_version() {
   local vers="`get_git_tag`"
 
   if [ -z "$vers" ] ; then
-    vers="0.0.0-`git rev-parse --abbrev-ref HEAD`-`git describe --match v --abbrev=8 --always --dirty`-`date -u +"%Y-%m-%d.%H.%M"`"
+    vers="0.0.0-`git rev-parse --abbrev-ref HEAD | tr / _`-`git describe --match v --abbrev=8 --always --dirty`-`date -u +"%Y-%m-%d.%H.%M"`"
     vers=`echo ${vers} | sed -e 's#-master##'`
   fi
 


### PR DESCRIPTION
Once of it is expected to make @kalyan-nidumolu very very happy (we're now tagging all official snapshot builds with 0.0.0-snapshot) the other one allows us to always get the rootfs images off of CircleCI artifatcs download page