### PR TITLE
Making CONFIG partition detection more robust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ QEMU_SYSTEM_arm64=qemu-system-aarch64
 QEMU_SYSTEM_amd64=qemu-system-x86_64
 QEMU_SYSTEM=$(QEMU_SYSTEM_$(ZARCH))
 
-QEMU_OPTS_arm64= -machine virt,gic_version=3 -machine virtualization=true -cpu cortex-a57 -machine type=virt -drive file=fat:rw:$(dir $(DEVICETREE_DTB)),format=vvfat
+QEMU_OPTS_arm64= -machine virt,gic_version=3 -machine virtualization=true -cpu cortex-a57 -machine type=virt -drive file=fat:rw:$(dir $(DEVICETREE_DTB)),label=QEMU_DTB,format=vvfat
 # -drive file=./bios/flash0.img,format=raw,if=pflash -drive file=./bios/flash1.img,format=raw,if=pflash
 # [ -f bios/flash1.img ] || dd if=/dev/zero of=bios/flash1.img bs=1048576 count=64
 QEMU_OPTS_amd64= -cpu SandyBridge

--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -110,11 +110,18 @@ function set_rootfs_root {
 }
 
 function set_config_overrides {
-  search.part_label CONFIG config_part "$root"
-  if [ -n "$config_part" ]; then
-     set_to_existing_file config_grub_cfg "($config_part)/grub.cfg"
-     if [ "$grub_virt" != qemu ]; then
-        set_to_existing_file devicetree "($config_part)/eve.dtb"
+  set self_dev="$cmddevice"
+  if [ -z "$self_dev" ]; then
+     set self_dev="$root"
+  fi
+  regexp --set self_drive "^([^,]*,)gpt" "$self_dev"
+  if [ -n "$self_drive" ]; then
+     search.part_label CONFIG config_part "$self_drive"
+     if [ -n "$config_part" ]; then
+        set_to_existing_file config_grub_cfg "($config_part)/grub.cfg"
+        if [ "$grub_virt" != qemu ]; then
+           set_to_existing_file devicetree "($config_part)/eve.dtb"
+        fi
      fi
   fi
 }
@@ -182,7 +189,7 @@ function set_arm64_qemu {
    set_arm64
    set_global dom0_platform_tweaks "hmp-unsafe=true"
    # if running under QEMU, make sure to check dynamic partition for device trees
-   search.fs_label "QEMU VVFAT" qemu_part
+   search.fs_label QEMU_DTB qemu_part
    set_to_existing_file devicetree "($qemu_part)/eve.dtb"
 }
 


### PR DESCRIPTION
Turns out, GRUB needs a special syntax of a literal string (with the comma at the end):
`device,`
to actually iterate over all partitions on a given drive *before* it iterates over all partitions on all the drives. We rely on this technique to guarantee that CONFIG partition that gets consulted comes from exactly the same drive that the GRUB itself came from (otherwise we may be reading from CONFIG partitions on other drives -- which can confuse us).

Additionally adding a check to only trigger this logic when we are presented with GPT partitions. This has a nice effect of removing annoying (although harmless!) messages "drive not found" when running ISO installer.

Finally, giving a proper name to a dynamic DTB drive that we attach to QEMU when running ARM.