### PR TITLE
Restructure pubsub into driver-based implementation

### DIFF
--- a/pkg/pillar/cmd/baseosmgr/baseosmgr.go
+++ b/pkg/pillar/cmd/baseosmgr/baseosmgr.go
@@ -38,6 +38,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	pubsublegacy "github.com/lf-edge/eve/pkg/pillar/pubsub/legacy"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	log "github.com/sirupsen/logrus"
 )
@@ -450,7 +451,7 @@ func handleGlobalConfigDelete(ctxArg interface{}, key string,
 }
 
 func initializeSelfPublishHandles(ctx *baseOsMgrContext) {
-	pubBaseOsStatus, err := pubsub.Publish(agentName,
+	pubBaseOsStatus, err := pubsublegacy.Publish(agentName,
 		types.BaseOsStatus{})
 	if err != nil {
 		log.Fatal(err)
@@ -458,7 +459,7 @@ func initializeSelfPublishHandles(ctx *baseOsMgrContext) {
 	pubBaseOsStatus.ClearRestarted()
 	ctx.pubBaseOsStatus = pubBaseOsStatus
 
-	pubBaseOsDownloadConfig, err := pubsub.PublishScope(agentName,
+	pubBaseOsDownloadConfig, err := pubsublegacy.PublishScope(agentName,
 		types.BaseOsObj, types.DownloaderConfig{})
 	if err != nil {
 		log.Fatal(err)
@@ -466,7 +467,7 @@ func initializeSelfPublishHandles(ctx *baseOsMgrContext) {
 	pubBaseOsDownloadConfig.ClearRestarted()
 	ctx.pubBaseOsDownloadConfig = pubBaseOsDownloadConfig
 
-	pubBaseOsVerifierConfig, err := pubsub.PublishScope(agentName,
+	pubBaseOsVerifierConfig, err := pubsublegacy.PublishScope(agentName,
 		types.BaseOsObj, types.VerifyImageConfig{})
 	if err != nil {
 		log.Fatal(err)
@@ -474,7 +475,7 @@ func initializeSelfPublishHandles(ctx *baseOsMgrContext) {
 	pubBaseOsVerifierConfig.ClearRestarted()
 	ctx.pubBaseOsVerifierConfig = pubBaseOsVerifierConfig
 
-	pubCertObjStatus, err := pubsub.Publish(agentName,
+	pubCertObjStatus, err := pubsublegacy.Publish(agentName,
 		types.CertObjStatus{})
 	if err != nil {
 		log.Fatal(err)
@@ -482,7 +483,7 @@ func initializeSelfPublishHandles(ctx *baseOsMgrContext) {
 	pubCertObjStatus.ClearRestarted()
 	ctx.pubCertObjStatus = pubCertObjStatus
 
-	pubCertObjDownloadConfig, err := pubsub.PublishScope(agentName,
+	pubCertObjDownloadConfig, err := pubsublegacy.PublishScope(agentName,
 		types.CertObj, types.DownloaderConfig{})
 	if err != nil {
 		log.Fatal(err)
@@ -490,7 +491,7 @@ func initializeSelfPublishHandles(ctx *baseOsMgrContext) {
 	pubCertObjDownloadConfig.ClearRestarted()
 	ctx.pubCertObjDownloadConfig = pubCertObjDownloadConfig
 
-	pubZbootStatus, err := pubsub.Publish(agentName, types.ZbootStatus{})
+	pubZbootStatus, err := pubsublegacy.Publish(agentName, types.ZbootStatus{})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -501,7 +502,7 @@ func initializeSelfPublishHandles(ctx *baseOsMgrContext) {
 func initializeGlobalConfigHandles(ctx *baseOsMgrContext) {
 
 	// Look for global config such as log levels
-	subGlobalConfig, err := pubsub.Subscribe("", types.GlobalConfig{},
+	subGlobalConfig, err := pubsublegacy.Subscribe("", types.GlobalConfig{},
 		false, ctx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleGlobalConfigModify,
 			ModifyHandler: handleGlobalConfigModify,
@@ -518,7 +519,7 @@ func initializeGlobalConfigHandles(ctx *baseOsMgrContext) {
 
 func initializeNodeAgentHandles(ctx *baseOsMgrContext) {
 	// Look for NodeAgentStatus, from zedagent
-	subNodeAgentStatus, err := pubsub.Subscribe("nodeagent",
+	subNodeAgentStatus, err := pubsublegacy.Subscribe("nodeagent",
 		types.NodeAgentStatus{}, false, ctx, &pubsub.SubscriptionOptions{
 			ModifyHandler: handleNodeAgentStatusModify,
 			DeleteHandler: handleNodeAgentStatusDelete,
@@ -532,7 +533,7 @@ func initializeNodeAgentHandles(ctx *baseOsMgrContext) {
 	subNodeAgentStatus.Activate()
 
 	// Look for ZbootConfig, from nodeagent
-	subZbootConfig, err := pubsub.Subscribe("nodeagent",
+	subZbootConfig, err := pubsublegacy.Subscribe("nodeagent",
 		types.ZbootConfig{}, false, ctx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleZbootConfigModify,
 			ModifyHandler: handleZbootConfigModify,
@@ -549,7 +550,7 @@ func initializeNodeAgentHandles(ctx *baseOsMgrContext) {
 
 func initializeZedagentHandles(ctx *baseOsMgrContext) {
 	// Look for BaseOsConfig , from zedagent
-	subBaseOsConfig, err := pubsub.Subscribe("zedagent",
+	subBaseOsConfig, err := pubsublegacy.Subscribe("zedagent",
 		types.BaseOsConfig{}, false, ctx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleBaseOsCreate,
 			ModifyHandler: handleBaseOsModify,
@@ -564,7 +565,7 @@ func initializeZedagentHandles(ctx *baseOsMgrContext) {
 	subBaseOsConfig.Activate()
 
 	// Look for CertObjConfig, from zedagent
-	subCertObjConfig, err := pubsub.Subscribe("zedagent",
+	subCertObjConfig, err := pubsublegacy.Subscribe("zedagent",
 		types.CertObjConfig{}, false, ctx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleCertObjCreate,
 			ModifyHandler: handleCertObjModify,
@@ -581,7 +582,7 @@ func initializeZedagentHandles(ctx *baseOsMgrContext) {
 
 func initializeDownloaderHandles(ctx *baseOsMgrContext) {
 	// Look for BaseOs DownloaderStatus from downloader
-	subBaseOsDownloadStatus, err := pubsub.SubscribeScope("downloader",
+	subBaseOsDownloadStatus, err := pubsublegacy.SubscribeScope("downloader",
 		types.BaseOsObj, types.DownloaderStatus{}, false, ctx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleDownloadStatusModify,
 			ModifyHandler: handleDownloadStatusModify,
@@ -596,7 +597,7 @@ func initializeDownloaderHandles(ctx *baseOsMgrContext) {
 	subBaseOsDownloadStatus.Activate()
 
 	// Look for Certs DownloaderStatus from downloader
-	subCertObjDownloadStatus, err := pubsub.SubscribeScope("downloader",
+	subCertObjDownloadStatus, err := pubsublegacy.SubscribeScope("downloader",
 		types.CertObj, types.DownloaderStatus{}, false, ctx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleDownloadStatusModify,
 			ModifyHandler: handleDownloadStatusModify,
@@ -614,7 +615,7 @@ func initializeDownloaderHandles(ctx *baseOsMgrContext) {
 
 func initializeVerifierHandles(ctx *baseOsMgrContext) {
 	// Look for VerifyImageStatus from verifier
-	subBaseOsVerifierStatus, err := pubsub.SubscribeScope("verifier",
+	subBaseOsVerifierStatus, err := pubsublegacy.SubscribeScope("verifier",
 		types.BaseOsObj, types.VerifyImageStatus{}, false, ctx, &pubsub.SubscriptionOptions{
 			CreateHandler:  handleVerifierStatusModify,
 			ModifyHandler:  handleVerifierStatusModify,

--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -24,6 +24,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/hardware"
 	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	pubsublegacy "github.com/lf-edge/eve/pkg/pillar/pubsub/legacy"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils"
 	"github.com/lf-edge/eve/pkg/pillar/zedcloud"
@@ -134,7 +135,7 @@ func Run() { //nolint:gocyclo
 	nameFileName := types.IdentityDirname + "/name"
 
 	cms := zedcloud.GetCloudMetrics() // Need type of data
-	pub, err := pubsub.Publish(agentName, cms)
+	pub, err := pubsublegacy.Publish(agentName, cms)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -157,7 +158,7 @@ func Run() { //nolint:gocyclo
 	}
 
 	// Look for global config such as log levels
-	subGlobalConfig, err := pubsub.Subscribe("", types.GlobalConfig{},
+	subGlobalConfig, err := pubsublegacy.Subscribe("", types.GlobalConfig{},
 		false, &clientCtx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleGlobalConfigModify,
 			ModifyHandler: handleGlobalConfigModify,
@@ -171,7 +172,7 @@ func Run() { //nolint:gocyclo
 	clientCtx.subGlobalConfig = subGlobalConfig
 	subGlobalConfig.Activate()
 
-	subDeviceNetworkStatus, err := pubsub.Subscribe("nim",
+	subDeviceNetworkStatus, err := pubsublegacy.Subscribe("nim",
 		types.DeviceNetworkStatus{}, false, &clientCtx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleDNSModify,
 			ModifyHandler: handleDNSModify,

--- a/pkg/pillar/cmd/dataplane/dataplane.go
+++ b/pkg/pillar/cmd/dataplane/dataplane.go
@@ -25,6 +25,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/dataplane/itr"
 	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	pubsublegacy "github.com/lf-edge/eve/pkg/pillar/pubsub/legacy"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	log "github.com/sirupsen/logrus"
 )
@@ -210,21 +211,21 @@ func initPubsubChannels() *dptypes.DataplaneContext {
 	dataplaneContext := &dptypes.DataplaneContext{}
 
 	// Create pubsub publish channels for LispInfo and Metrics
-	pubLispInfoStatus, err := pubsub.Publish(agentName,
+	pubLispInfoStatus, err := pubsublegacy.Publish(agentName,
 		types.LispInfoStatus{})
 	if err != nil {
 		log.Fatal(err)
 	}
 	dataplaneContext.PubLispInfoStatus = pubLispInfoStatus
 
-	pubLispMetrics, err := pubsub.Publish(agentName,
+	pubLispMetrics, err := pubsublegacy.Publish(agentName,
 		types.LispMetrics{})
 	if err != nil {
 		log.Fatal(err)
 	}
 	dataplaneContext.PubLispMetrics = pubLispMetrics
 
-	subLispConfig, err := pubsub.Subscribe("zedrouter",
+	subLispConfig, err := pubsublegacy.Subscribe("zedrouter",
 		types.LispDataplaneConfig{}, false, dataplaneContext, &pubsub.SubscriptionOptions{
 			CreateHandler: handleExpModify,
 			ModifyHandler: handleExpModify,
@@ -239,7 +240,7 @@ func initPubsubChannels() *dptypes.DataplaneContext {
 	subLispConfig.Activate()
 
 	// Look for global config like debug
-	subGlobalConfig, err := pubsub.Subscribe("",
+	subGlobalConfig, err := pubsublegacy.Subscribe("",
 		types.GlobalConfig{}, false, dataplaneContext, &pubsub.SubscriptionOptions{
 			CreateHandler: handleGlobalConfigModify,
 			ModifyHandler: handleGlobalConfigModify,
@@ -417,7 +418,7 @@ func handleDNSDelete(ctxArg interface{}, key string, statusArg interface{}) {
 func handleConfig(c *net.UnixConn, dpContext *dptypes.DataplaneContext) {
 	defer c.Close()
 
-	subDeviceNetworkStatus, err := pubsub.Subscribe("nim",
+	subDeviceNetworkStatus, err := pubsublegacy.Subscribe("nim",
 		types.DeviceNetworkStatus{}, false, nil, &pubsub.SubscriptionOptions{
 			ModifyHandler: handleDNSModify,
 			DeleteHandler: handleDNSDelete,

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -25,6 +25,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/devicenetwork"
 	"github.com/lf-edge/eve/pkg/pillar/hardware"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	pubsublegacy "github.com/lf-edge/eve/pkg/pillar/pubsub/legacy"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils"
 	"github.com/lf-edge/eve/pkg/pillar/zedcloud"
@@ -118,7 +119,7 @@ func Run() {
 	utils.EnsureGCFile()
 
 	// Look for global config such as log levels
-	subGlobalConfig, err := pubsub.Subscribe("", types.GlobalConfig{},
+	subGlobalConfig, err := pubsublegacy.Subscribe("", types.GlobalConfig{},
 		false, &ctx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleGlobalConfigModify,
 			ModifyHandler: handleGlobalConfigModify,
@@ -183,7 +184,7 @@ func Run() {
 	zedcloudCtx.TlsConfig = tlsConfig
 	ctx.zedcloudCtx = &zedcloudCtx
 
-	subLedBlinkCounter, err := pubsub.Subscribe("", types.LedBlinkCounter{},
+	subLedBlinkCounter, err := pubsublegacy.Subscribe("", types.LedBlinkCounter{},
 		false, &ctx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleLedBlinkModify,
 			ModifyHandler: handleLedBlinkModify,
@@ -197,7 +198,7 @@ func Run() {
 	ctx.subLedBlinkCounter = subLedBlinkCounter
 	subLedBlinkCounter.Activate()
 
-	subDeviceNetworkStatus, err := pubsub.Subscribe("nim",
+	subDeviceNetworkStatus, err := pubsublegacy.Subscribe("nim",
 		types.DeviceNetworkStatus{}, false, &ctx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleDNSModify,
 			ModifyHandler: handleDNSModify,
@@ -212,7 +213,7 @@ func Run() {
 	ctx.subDeviceNetworkStatus = subDeviceNetworkStatus
 	subDeviceNetworkStatus.Activate()
 
-	subDevicePortConfigList, err := pubsub.SubscribePersistent("nim",
+	subDevicePortConfigList, err := pubsublegacy.SubscribePersistent("nim",
 		types.DevicePortConfigList{}, false, &ctx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleDPCModify,
 			ModifyHandler: handleDPCModify,

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -33,6 +33,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/flextimer"
 	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	pubsublegacy "github.com/lf-edge/eve/pkg/pillar/pubsub/legacy"
 	"github.com/lf-edge/eve/pkg/pillar/sema"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils"
@@ -193,14 +194,14 @@ func Run() {
 	domainCtx.createSema = sema.Create(1)
 	domainCtx.createSema.P(1)
 
-	pubDomainStatus, err := pubsub.Publish(agentName, types.DomainStatus{})
+	pubDomainStatus, err := pubsublegacy.Publish(agentName, types.DomainStatus{})
 	if err != nil {
 		log.Fatal(err)
 	}
 	domainCtx.pubDomainStatus = pubDomainStatus
 	pubDomainStatus.ClearRestarted()
 
-	pubImageStatus, err := pubsub.Publish(agentName, types.ImageStatus{})
+	pubImageStatus, err := pubsublegacy.Publish(agentName, types.ImageStatus{})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -211,7 +212,7 @@ func Run() {
 	populateInitialImageStatus(&domainCtx, rwImgDirname)
 	pubImageStatus.SignalRestarted()
 
-	pubAssignableAdapters, err := pubsub.Publish(agentName,
+	pubAssignableAdapters, err := pubsublegacy.Publish(agentName,
 		types.AssignableAdapters{})
 	if err != nil {
 		log.Fatal(err)
@@ -220,7 +221,7 @@ func Run() {
 	pubAssignableAdapters.ClearRestarted()
 
 	// Look for global config such as log levels
-	subGlobalConfig, err := pubsub.Subscribe("", types.GlobalConfig{},
+	subGlobalConfig, err := pubsublegacy.Subscribe("", types.GlobalConfig{},
 		false, &domainCtx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleGlobalConfigModify,
 			ModifyHandler: handleGlobalConfigModify,
@@ -234,7 +235,7 @@ func Run() {
 	domainCtx.subGlobalConfig = subGlobalConfig
 	subGlobalConfig.Activate()
 
-	subDeviceNetworkStatus, err := pubsub.Subscribe("nim",
+	subDeviceNetworkStatus, err := pubsublegacy.Subscribe("nim",
 		types.DeviceNetworkStatus{}, false, &domainCtx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleDNSModify,
 			ModifyHandler: handleDNSModify,
@@ -277,7 +278,7 @@ func Run() {
 	}
 
 	// Subscribe to PhysicalIOAdapterList from zedagent
-	subPhysicalIOAdapter, err := pubsub.Subscribe("zedagent",
+	subPhysicalIOAdapter, err := pubsublegacy.Subscribe("zedagent",
 		types.PhysicalIOAdapterList{}, false, &domainCtx, &pubsub.SubscriptionOptions{
 			CreateHandler: handlePhysicalIOAdapterListCreateModify,
 			ModifyHandler: handlePhysicalIOAdapterListCreateModify,
@@ -313,7 +314,7 @@ func Run() {
 	log.Infof("Have %d assignable adapters", len(aa.IoBundleList))
 
 	// Subscribe to DomainConfig from zedmanager
-	subDomainConfig, err := pubsub.Subscribe("zedmanager",
+	subDomainConfig, err := pubsublegacy.Subscribe("zedmanager",
 		types.DomainConfig{}, false, &domainCtx, &pubsub.SubscriptionOptions{
 			CreateHandler:  handleDomainCreate,
 			ModifyHandler:  handleDomainModify,

--- a/pkg/pillar/cmd/domainmgr/rkt.go
+++ b/pkg/pillar/cmd/domainmgr/rkt.go
@@ -48,6 +48,7 @@ type RktManifest struct {
 // with thanks to https://github.com/appc/docker2aci
 // from is the file to convert from; to is the path where to place the aci file
 func rktConvertTarToAci(from, to string) ([]string, error) {
+	log.Infof("rktConvertTarToAci from v1 tar file %s to aci directory %s", from, to)
 	var convertTag string
 	legacyTmpDir, err := ioutil.TempDir("", "v1ToLegacyTarContainer")
 	if err != nil {
@@ -60,6 +61,7 @@ func rktConvertTarToAci(from, to string) ([]string, error) {
 		return nil, fmt.Errorf("error creating temporary directory for aci conversion")
 	}
 	// first convert from v1 to legacy
+	log.Infof("rktConvertAciTar: converting v1 tarball %s to legacy tarball %s", from, legacyPath)
 	img, err := v1tarball.ImageFromPath(from, nil)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get image from v1 tarball %s input: %v", from, err)
@@ -95,6 +97,9 @@ func rktConvertTarToAci(from, to string) ([]string, error) {
 		return nil, fmt.Errorf("unable to write legacy tar file %s: %v", legacyPath, err)
 	}
 	w.Close()
+	log.Infof("rktConvertAciTar: done converting v1 tarball %s to legacy tarball %s", from, legacyPath)
+
+	log.Infof("rktConvertAciTar: converting legacy tarball %s to aci file", legacyPath)
 
 	cfg := docker2aci.CommonConfig{
 		Squash:      true,
@@ -109,7 +114,12 @@ func rktConvertTarToAci(from, to string) ([]string, error) {
 		CommonConfig: cfg,
 		DockerURL:    "",
 	}
-	return docker2aci.ConvertSavedFile(legacyPath, fileConfig)
+	aciFiles, err := docker2aci.ConvertSavedFile(legacyPath, fileConfig)
+	if err != nil {
+		return nil, fmt.Errorf("docker2aci error: %v", err)
+	}
+	log.Infof("rktConvertTarToAci done: v1 tar file %s converted to aci files: %v", from, aciFiles)
+	return aciFiles, nil
 }
 
 // ociToRktImageHash given an OCI tar file, get the rkt hash for it.

--- a/pkg/pillar/cmd/downloader/context.go
+++ b/pkg/pillar/cmd/downloader/context.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	pubsublegacy "github.com/lf-edge/eve/pkg/pillar/pubsub/legacy"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/zedUpload"
 	log "github.com/sirupsen/logrus"
@@ -31,7 +32,7 @@ type downloaderContext struct {
 
 func (ctx *downloaderContext) registerHandlers() error {
 	// Look for global config such as log levels
-	subGlobalConfig, err := pubsub.Subscribe("", types.GlobalConfig{},
+	subGlobalConfig, err := pubsublegacy.Subscribe("", types.GlobalConfig{},
 		false, ctx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleGlobalConfigModify,
 			ModifyHandler: handleGlobalConfigModify,
@@ -45,7 +46,7 @@ func (ctx *downloaderContext) registerHandlers() error {
 	ctx.subGlobalConfig = subGlobalConfig
 	subGlobalConfig.Activate()
 
-	subDeviceNetworkStatus, err := pubsub.Subscribe("nim",
+	subDeviceNetworkStatus, err := pubsublegacy.Subscribe("nim",
 		types.DeviceNetworkStatus{}, false, ctx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleDNSModify,
 			ModifyHandler: handleDNSModify,
@@ -59,7 +60,7 @@ func (ctx *downloaderContext) registerHandlers() error {
 	ctx.subDeviceNetworkStatus = subDeviceNetworkStatus
 	subDeviceNetworkStatus.Activate()
 
-	subGlobalDownloadConfig, err := pubsub.Subscribe("",
+	subGlobalDownloadConfig, err := pubsublegacy.Subscribe("",
 		types.GlobalDownloadConfig{}, false, ctx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleGlobalDownloadConfigModify,
 			ModifyHandler: handleGlobalDownloadConfigModify,
@@ -75,7 +76,7 @@ func (ctx *downloaderContext) registerHandlers() error {
 	// Look for DatastoreConfig. We should process this
 	// before any download config ( App/baseos/cert). Without DataStore Config,
 	// Image Downloads will run into errors.
-	subDatastoreConfig, err := pubsub.Subscribe("zedagent",
+	subDatastoreConfig, err := pubsublegacy.Subscribe("zedagent",
 		types.DatastoreConfig{}, false, ctx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleDatastoreConfigModify,
 			ModifyHandler: handleDatastoreConfigModify,
@@ -89,7 +90,7 @@ func (ctx *downloaderContext) registerHandlers() error {
 	ctx.subDatastoreConfig = subDatastoreConfig
 	subDatastoreConfig.Activate()
 
-	pubGlobalDownloadStatus, err := pubsub.Publish(agentName,
+	pubGlobalDownloadStatus, err := pubsublegacy.Publish(agentName,
 		types.GlobalDownloadStatus{})
 	if err != nil {
 		return err
@@ -97,7 +98,7 @@ func (ctx *downloaderContext) registerHandlers() error {
 	ctx.pubGlobalDownloadStatus = pubGlobalDownloadStatus
 
 	// Set up our publications before the subscriptions so ctx is set
-	pubAppImgStatus, err := pubsub.PublishScope(agentName, types.AppImgObj,
+	pubAppImgStatus, err := pubsublegacy.PublishScope(agentName, types.AppImgObj,
 		types.DownloaderStatus{})
 	if err != nil {
 		return err
@@ -105,7 +106,7 @@ func (ctx *downloaderContext) registerHandlers() error {
 	ctx.pubAppImgStatus = pubAppImgStatus
 	pubAppImgStatus.ClearRestarted()
 
-	pubBaseOsStatus, err := pubsub.PublishScope(agentName, types.BaseOsObj,
+	pubBaseOsStatus, err := pubsublegacy.PublishScope(agentName, types.BaseOsObj,
 		types.DownloaderStatus{})
 	if err != nil {
 		return err
@@ -113,7 +114,7 @@ func (ctx *downloaderContext) registerHandlers() error {
 	ctx.pubBaseOsStatus = pubBaseOsStatus
 	pubBaseOsStatus.ClearRestarted()
 
-	pubCertObjStatus, err := pubsub.PublishScope(agentName, types.CertObj,
+	pubCertObjStatus, err := pubsublegacy.PublishScope(agentName, types.CertObj,
 		types.DownloaderStatus{})
 	if err != nil {
 		return err
@@ -121,7 +122,7 @@ func (ctx *downloaderContext) registerHandlers() error {
 	ctx.pubCertObjStatus = pubCertObjStatus
 	pubCertObjStatus.ClearRestarted()
 
-	subAppImgConfig, err := pubsub.SubscribeScope("zedmanager",
+	subAppImgConfig, err := pubsublegacy.SubscribeScope("zedmanager",
 		types.AppImgObj, types.DownloaderConfig{}, false, ctx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleAppImgCreate,
 			ModifyHandler: handleAppImgModify,
@@ -135,7 +136,7 @@ func (ctx *downloaderContext) registerHandlers() error {
 	ctx.subAppImgConfig = subAppImgConfig
 	subAppImgConfig.Activate()
 
-	subBaseOsConfig, err := pubsub.SubscribeScope("baseosmgr",
+	subBaseOsConfig, err := pubsublegacy.SubscribeScope("baseosmgr",
 		types.BaseOsObj, types.DownloaderConfig{}, false, ctx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleBaseOsCreate,
 			ModifyHandler: handleBaseOsModify,
@@ -149,7 +150,7 @@ func (ctx *downloaderContext) registerHandlers() error {
 	ctx.subBaseOsConfig = subBaseOsConfig
 	subBaseOsConfig.Activate()
 
-	subCertObjConfig, err := pubsub.SubscribeScope("baseosmgr",
+	subCertObjConfig, err := pubsublegacy.SubscribeScope("baseosmgr",
 		types.CertObj, types.DownloaderConfig{}, false, ctx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleCertObjCreate,
 			ModifyHandler: handleCertObjModify,

--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -18,6 +18,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/flextimer"
 	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	pubsublegacy "github.com/lf-edge/eve/pkg/pillar/pubsub/legacy"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/zedUpload"
 	"github.com/lf-edge/eve/pkg/pillar/zedcloud"
@@ -77,7 +78,7 @@ func Run() {
 	agentlog.StillRunning(agentName, warningTime, errorTime)
 
 	cms := zedcloud.GetCloudMetrics() // Need type of data
-	pub, err := pubsub.Publish(agentName, cms)
+	pub, err := pubsublegacy.Publish(agentName, cms)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/pillar/cmd/identitymgr/identitymgr.go
+++ b/pkg/pillar/cmd/identitymgr/identitymgr.go
@@ -28,6 +28,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	pubsublegacy "github.com/lf-edge/eve/pkg/pillar/pubsub/legacy"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	log "github.com/sirupsen/logrus"
 )
@@ -87,7 +88,7 @@ func Run() {
 
 	identityCtx := identityContext{}
 
-	pubEIDStatus, err := pubsub.Publish(agentName,
+	pubEIDStatus, err := pubsublegacy.Publish(agentName,
 		types.EIDStatus{})
 	if err != nil {
 		log.Fatal(err)
@@ -96,7 +97,7 @@ func Run() {
 	pubEIDStatus.ClearRestarted()
 
 	// Look for global config such as log levels
-	subGlobalConfig, err := pubsub.Subscribe("", types.GlobalConfig{},
+	subGlobalConfig, err := pubsublegacy.Subscribe("", types.GlobalConfig{},
 		false, &identityCtx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleGlobalConfigModify,
 			ModifyHandler: handleGlobalConfigModify,
@@ -111,7 +112,7 @@ func Run() {
 	subGlobalConfig.Activate()
 
 	// Subscribe to EIDConfig from zedmanager
-	subEIDConfig, err := pubsub.Subscribe("zedmanager",
+	subEIDConfig, err := pubsublegacy.Subscribe("zedmanager",
 		types.EIDConfig{}, false, &identityCtx, &pubsub.SubscriptionOptions{
 			CreateHandler:  handleCreate,
 			ModifyHandler:  handleModify,

--- a/pkg/pillar/cmd/ledmanager/ledmanager.go
+++ b/pkg/pillar/cmd/ledmanager/ledmanager.go
@@ -30,6 +30,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/hardware"
 	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	pubsublegacy "github.com/lf-edge/eve/pkg/pillar/pubsub/legacy"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	log "github.com/sirupsen/logrus"
 )
@@ -172,7 +173,7 @@ func Run() {
 	ctx.countChange = make(chan int)
 	go TriggerBlinkOnDevice(ctx.countChange, blinkFunc)
 
-	subLedBlinkCounter, err := pubsub.Subscribe("", types.LedBlinkCounter{},
+	subLedBlinkCounter, err := pubsublegacy.Subscribe("", types.LedBlinkCounter{},
 		false, &ctx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleLedBlinkModify,
 			ModifyHandler: handleLedBlinkModify,
@@ -186,7 +187,7 @@ func Run() {
 	ctx.subLedBlinkCounter = subLedBlinkCounter
 	subLedBlinkCounter.Activate()
 
-	subDeviceNetworkStatus, err := pubsub.Subscribe("nim",
+	subDeviceNetworkStatus, err := pubsublegacy.Subscribe("nim",
 		types.DeviceNetworkStatus{}, false, &ctx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleDNSModify,
 			ModifyHandler: handleDNSModify,
@@ -201,7 +202,7 @@ func Run() {
 	subDeviceNetworkStatus.Activate()
 
 	// Look for global config such as log levels
-	subGlobalConfig, err := pubsub.Subscribe("", types.GlobalConfig{},
+	subGlobalConfig, err := pubsublegacy.Subscribe("", types.GlobalConfig{},
 		false, &ctx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleGlobalConfigModify,
 			ModifyHandler: handleGlobalConfigModify,

--- a/pkg/pillar/cmd/logmanager/logmanager.go
+++ b/pkg/pillar/cmd/logmanager/logmanager.go
@@ -26,6 +26,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/hardware"
 	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	pubsublegacy "github.com/lf-edge/eve/pkg/pillar/pubsub/legacy"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/watch"
 	"github.com/lf-edge/eve/pkg/pillar/zboot"
@@ -187,7 +188,7 @@ func Run() {
 		}
 	}
 	cms := zedcloud.GetCloudMetrics() // Need type of data
-	pub, err := pubsub.Publish(agentName, cms)
+	pub, err := pubsublegacy.Publish(agentName, cms)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -196,7 +197,7 @@ func Run() {
 		globalConfig: &types.GlobalConfigDefaults,
 	}
 	// Look for global config such as log levels
-	subGlobalConfig, err := pubsub.Subscribe("", types.GlobalConfig{},
+	subGlobalConfig, err := pubsublegacy.Subscribe("", types.GlobalConfig{},
 		false, &logmanagerCtx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleGlobalConfigModify,
 			ModifyHandler: handleGlobalConfigModify,
@@ -211,7 +212,7 @@ func Run() {
 	subGlobalConfig.Activate()
 
 	// Get DomainStatus from domainmgr
-	subDomainStatus, err := pubsub.Subscribe("domainmgr",
+	subDomainStatus, err := pubsublegacy.Subscribe("domainmgr",
 		types.DomainStatus{}, false, &logmanagerCtx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleDomainStatusModify,
 			ModifyHandler: handleDomainStatusModify,
@@ -229,7 +230,7 @@ func Run() {
 	DNSctx := DNSContext{}
 	DNSctx.usableAddressCount = types.CountLocalAddrAnyNoLinkLocal(*deviceNetworkStatus)
 
-	subDeviceNetworkStatus, err := pubsub.Subscribe("nim",
+	subDeviceNetworkStatus, err := pubsublegacy.Subscribe("nim",
 		types.DeviceNetworkStatus{}, false, &DNSctx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleDNSModify,
 			ModifyHandler: handleDNSModify,

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -25,6 +25,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/iptables"
 	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	pubsublegacy "github.com/lf-edge/eve/pkg/pillar/pubsub/legacy"
 	"github.com/lf-edge/eve/pkg/pillar/ssh"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils"
@@ -122,21 +123,21 @@ func Run() {
 	// Make sure we have a GlobalConfig file with defaults
 	utils.EnsureGCFile()
 
-	pubDeviceNetworkStatus, err := pubsub.Publish(agentName,
+	pubDeviceNetworkStatus, err := pubsublegacy.Publish(agentName,
 		types.DeviceNetworkStatus{})
 	if err != nil {
 		log.Fatal(err)
 	}
 	pubDeviceNetworkStatus.ClearRestarted()
 
-	pubDevicePortConfig, err := pubsub.Publish(agentName,
+	pubDevicePortConfig, err := pubsublegacy.Publish(agentName,
 		types.DevicePortConfig{})
 	if err != nil {
 		log.Fatal(err)
 	}
 	pubDevicePortConfig.ClearRestarted()
 
-	pubDevicePortConfigList, err := pubsub.PublishPersistent(agentName,
+	pubDevicePortConfigList, err := pubsublegacy.PublishPersistent(agentName,
 		types.DevicePortConfigList{})
 	if err != nil {
 		log.Fatal(err)
@@ -144,7 +145,7 @@ func Run() {
 	pubDevicePortConfigList.ClearRestarted()
 
 	// Look for global config such as log levels
-	subGlobalConfig, err := pubsub.Subscribe("", types.GlobalConfig{},
+	subGlobalConfig, err := pubsublegacy.Subscribe("", types.GlobalConfig{},
 		false, &nimCtx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleGlobalConfigModify,
 			ModifyHandler: handleGlobalConfigModify,
@@ -171,7 +172,7 @@ func Run() {
 	// 1. zedagent publishing DevicePortConfig
 	// 2. override file in /var/tmp/zededa/DevicePortConfig/*.json
 	// 3. "lastresort" derived from the set of network interfaces
-	subDevicePortConfigA, err := pubsub.Subscribe("zedagent",
+	subDevicePortConfigA, err := pubsublegacy.Subscribe("zedagent",
 		types.DevicePortConfig{}, false,
 		&nimCtx.DeviceNetworkContext, &pubsub.SubscriptionOptions{
 			CreateHandler: devicenetwork.HandleDPCModify,
@@ -186,7 +187,7 @@ func Run() {
 	nimCtx.SubDevicePortConfigA = subDevicePortConfigA
 	subDevicePortConfigA.Activate()
 
-	subDevicePortConfigO, err := pubsub.Subscribe("",
+	subDevicePortConfigO, err := pubsublegacy.Subscribe("",
 		types.DevicePortConfig{}, false,
 		&nimCtx.DeviceNetworkContext, &pubsub.SubscriptionOptions{
 			CreateHandler: devicenetwork.HandleDPCModify,
@@ -201,7 +202,7 @@ func Run() {
 	nimCtx.SubDevicePortConfigO = subDevicePortConfigO
 	subDevicePortConfigO.Activate()
 
-	subDevicePortConfigS, err := pubsub.Subscribe(agentName,
+	subDevicePortConfigS, err := pubsublegacy.Subscribe(agentName,
 		types.DevicePortConfig{}, false,
 		&nimCtx.DeviceNetworkContext, &pubsub.SubscriptionOptions{
 			CreateHandler: devicenetwork.HandleDPCModify,
@@ -216,7 +217,7 @@ func Run() {
 	nimCtx.SubDevicePortConfigS = subDevicePortConfigS
 	subDevicePortConfigS.Activate()
 
-	subAssignableAdapters, err := pubsub.Subscribe("domainmgr",
+	subAssignableAdapters, err := pubsublegacy.Subscribe("domainmgr",
 		types.AssignableAdapters{}, false,
 		&nimCtx.DeviceNetworkContext, &pubsub.SubscriptionOptions{
 			CreateHandler: devicenetwork.HandleAssignableAdaptersModify,
@@ -231,7 +232,7 @@ func Run() {
 	nimCtx.SubAssignableAdapters = subAssignableAdapters
 	subAssignableAdapters.Activate()
 
-	subNetworkInstanceStatus, err := pubsub.Subscribe("zedrouter",
+	subNetworkInstanceStatus, err := pubsublegacy.Subscribe("zedrouter",
 		types.NetworkInstanceStatus{}, false, &nimCtx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleNetworkInstanceModify,
 			ModifyHandler: handleNetworkInstanceModify,

--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -31,6 +31,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/iptables"
 	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	pubsublegacy "github.com/lf-edge/eve/pkg/pillar/pubsub/legacy"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils"
 	"github.com/lf-edge/eve/pkg/pillar/zboot"
@@ -145,7 +146,7 @@ func Run() {
 	handleLastRebootReason(&nodeagentCtx)
 
 	// publisher of NodeAgent Status
-	pubNodeAgentStatus, err := pubsub.Publish(agentName,
+	pubNodeAgentStatus, err := pubsublegacy.Publish(agentName,
 		types.NodeAgentStatus{})
 	if err != nil {
 		log.Fatal(err)
@@ -154,7 +155,7 @@ func Run() {
 	nodeagentCtx.pubNodeAgentStatus = pubNodeAgentStatus
 
 	// publisher of Zboot Config
-	pubZbootConfig, err := pubsub.Publish(agentName, types.ZbootConfig{})
+	pubZbootConfig, err := pubsublegacy.Publish(agentName, types.ZbootConfig{})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -162,7 +163,7 @@ func Run() {
 	nodeagentCtx.pubZbootConfig = pubZbootConfig
 
 	// Look for global config such as log levels
-	subGlobalConfig, err := pubsub.Subscribe("", types.GlobalConfig{},
+	subGlobalConfig, err := pubsublegacy.Subscribe("", types.GlobalConfig{},
 		false, &nodeagentCtx, &pubsub.SubscriptionOptions{
 			ModifyHandler: handleGlobalConfigModify,
 			DeleteHandler: handleGlobalConfigDelete,
@@ -240,7 +241,7 @@ func Run() {
 	}
 
 	// subscribe to zboot status events
-	subZbootStatus, err := pubsub.Subscribe("baseosmgr",
+	subZbootStatus, err := pubsublegacy.Subscribe("baseosmgr",
 		types.ZbootStatus{}, false, &nodeagentCtx, &pubsub.SubscriptionOptions{
 			ModifyHandler: handleZbootStatusModify,
 			DeleteHandler: handleZbootStatusDelete,
@@ -254,7 +255,7 @@ func Run() {
 	subZbootStatus.Activate()
 
 	// subscribe to zedagent status events
-	subZedAgentStatus, err := pubsub.Subscribe("zedagent",
+	subZedAgentStatus, err := pubsublegacy.Subscribe("zedagent",
 		types.ZedAgentStatus{}, false, &nodeagentCtx, &pubsub.SubscriptionOptions{
 			ModifyHandler: handleZedAgentStatusModify,
 			DeleteHandler: handleZedAgentStatusDelete,
@@ -390,7 +391,7 @@ func handleZbootStatusDelete(ctxArg interface{},
 
 func checkNetworkConnectivity(ctxPtr *nodeagentContext) {
 	// for device network status
-	subDeviceNetworkStatus, err := pubsub.Subscribe("nim",
+	subDeviceNetworkStatus, err := pubsublegacy.Subscribe("nim",
 		types.DeviceNetworkStatus{}, false, ctxPtr, &pubsub.SubscriptionOptions{
 			ModifyHandler: handleDNSModify,
 			DeleteHandler: handleDNSDelete,

--- a/pkg/pillar/cmd/vaultmgr/vaultmgr.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgr.go
@@ -18,6 +18,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/cmd/tpmmgr"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	pubsublegacy "github.com/lf-edge/eve/pkg/pillar/pubsub/legacy"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	log "github.com/sirupsen/logrus"
 )
@@ -388,7 +389,7 @@ func fetchFscryptStatus() (info.DataSecAtRestStatus, string) {
 }
 
 func initializeSelfPublishHandles(ctx *vaultMgrContext) {
-	pubVaultStatus, err := pubsub.Publish(agentName,
+	pubVaultStatus, err := pubsublegacy.Publish(agentName,
 		types.VaultStatus{})
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/pillar/cmd/verifier/verifier.go
+++ b/pkg/pillar/cmd/verifier/verifier.go
@@ -37,6 +37,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	pubsublegacy "github.com/lf-edge/eve/pkg/pillar/pubsub/legacy"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/wrap"
 	"github.com/satori/go.uuid"
@@ -122,7 +123,7 @@ func Run() {
 	}
 
 	// Set up our publications before the subscriptions so ctx is set
-	pubAppImgStatus, err := pubsub.PublishScope(agentName, types.AppImgObj,
+	pubAppImgStatus, err := pubsublegacy.PublishScope(agentName, types.AppImgObj,
 		types.VerifyImageStatus{})
 	if err != nil {
 		log.Fatal(err)
@@ -130,7 +131,7 @@ func Run() {
 	ctx.pubAppImgStatus = pubAppImgStatus
 	pubAppImgStatus.ClearRestarted()
 
-	pubBaseOsStatus, err := pubsub.PublishScope(agentName, types.BaseOsObj,
+	pubBaseOsStatus, err := pubsublegacy.PublishScope(agentName, types.BaseOsObj,
 		types.VerifyImageStatus{})
 	if err != nil {
 		log.Fatal(err)
@@ -139,7 +140,7 @@ func Run() {
 	pubBaseOsStatus.ClearRestarted()
 
 	// Look for global config such as log levels
-	subGlobalConfig, err := pubsub.Subscribe("", types.GlobalConfig{},
+	subGlobalConfig, err := pubsublegacy.Subscribe("", types.GlobalConfig{},
 		false, &ctx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleGlobalConfigModify,
 			ModifyHandler: handleGlobalConfigModify,
@@ -153,7 +154,7 @@ func Run() {
 	ctx.subGlobalConfig = subGlobalConfig
 	subGlobalConfig.Activate()
 
-	subAppImgConfig, err := pubsub.SubscribeScope("zedmanager",
+	subAppImgConfig, err := pubsublegacy.SubscribeScope("zedmanager",
 		types.AppImgObj, types.VerifyImageConfig{}, false, &ctx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleAppImgCreate,
 			ModifyHandler: handleAppImgModify,
@@ -167,7 +168,7 @@ func Run() {
 	ctx.subAppImgConfig = subAppImgConfig
 	subAppImgConfig.Activate()
 
-	subBaseOsConfig, err := pubsub.SubscribeScope("baseosmgr",
+	subBaseOsConfig, err := pubsublegacy.SubscribeScope("baseosmgr",
 		types.BaseOsObj, types.VerifyImageConfig{}, false, &ctx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleBaseOsCreate,
 			ModifyHandler: handleBaseOsModify,
@@ -181,7 +182,7 @@ func Run() {
 	ctx.subBaseOsConfig = subBaseOsConfig
 	subBaseOsConfig.Activate()
 
-	subAssignableAdapters, err := pubsub.Subscribe("domainmgr",
+	subAssignableAdapters, err := pubsublegacy.Subscribe("domainmgr",
 		types.AssignableAdapters{}, false, &ctx, &pubsub.SubscriptionOptions{
 			ModifyHandler: handleAAModify,
 			DeleteHandler: handleAADelete,

--- a/pkg/pillar/cmd/waitforaddr/waitforaddr.go
+++ b/pkg/pillar/cmd/waitforaddr/waitforaddr.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	pubsublegacy "github.com/lf-edge/eve/pkg/pillar/pubsub/legacy"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	log "github.com/sirupsen/logrus"
 )
@@ -85,7 +86,7 @@ func Run() {
 
 	DNSctx := DNSContext{}
 
-	subDeviceNetworkStatus, err := pubsub.Subscribe("nim",
+	subDeviceNetworkStatus, err := pubsublegacy.Subscribe("nim",
 		types.DeviceNetworkStatus{}, false, &DNSctx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleDNSModify,
 			ModifyHandler: handleDNSModify,

--- a/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
+++ b/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
@@ -16,6 +16,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	pubsublegacy "github.com/lf-edge/eve/pkg/pillar/pubsub/legacy"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/zedcloud"
 	log "github.com/sirupsen/logrus"
@@ -91,7 +92,7 @@ func Run() {
 	wscCtx := wstunnelclientContext{}
 
 	// Look for global config such as log levels
-	subGlobalConfig, err := pubsub.Subscribe("", types.GlobalConfig{},
+	subGlobalConfig, err := pubsublegacy.Subscribe("", types.GlobalConfig{},
 		false, &wscCtx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleGlobalConfigModify,
 			ModifyHandler: handleGlobalConfigModify,
@@ -105,7 +106,7 @@ func Run() {
 	wscCtx.subGlobalConfig = subGlobalConfig
 	subGlobalConfig.Activate()
 
-	subDeviceNetworkStatus, err := pubsub.Subscribe("nim",
+	subDeviceNetworkStatus, err := pubsublegacy.Subscribe("nim",
 		types.DeviceNetworkStatus{}, false, &DNSctx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleDNSModify,
 			ModifyHandler: handleDNSModify,
@@ -121,7 +122,7 @@ func Run() {
 
 	// Look for AppInstanceConfig from zedagent
 	// XXX is it better to look for AppInstanceStatus from zedmanager?
-	subAppInstanceConfig, err := pubsub.Subscribe("zedagent",
+	subAppInstanceConfig, err := pubsublegacy.Subscribe("zedagent",
 		types.AppInstanceConfig{}, false, &wscCtx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleAppInstanceConfigModify,
 			ModifyHandler: handleAppInstanceConfigModify,

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -20,9 +20,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 	zconfig "github.com/lf-edge/eve/api/go/config"
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
-	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/ssh"
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 	"github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
 )
@@ -2115,7 +2115,7 @@ func scheduleReboot(reboot *zconfig.DeviceOpsCmd,
 		if err != nil {
 			log.Fatal(err)
 		}
-		err = pubsub.WriteRename(rebootConfigFilename, bytes)
+		err = fileutils.WriteRename(rebootConfigFilename, bytes)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -2144,7 +2144,7 @@ func scheduleReboot(reboot *zconfig.DeviceOpsCmd,
 		// store current config, persistently
 		bytes, err = json.Marshal(reboot)
 		if err == nil {
-			err := pubsub.WriteRename(rebootConfigFilename, bytes)
+			err := fileutils.WriteRename(rebootConfigFilename, bytes)
 			if err != nil {
 				log.Errorf("scheduleReboot: failed %s\n",
 					err)

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -36,6 +36,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	pubsublegacy "github.com/lf-edge/eve/pkg/pillar/pubsub/legacy"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils"
 	"github.com/lf-edge/eve/pkg/pillar/zedcloud"
@@ -184,7 +185,7 @@ func Run() {
 
 	zedagentCtx.physicalIoAdapterMap = make(map[string]types.PhysicalIOAdapter)
 
-	zedagentCtx.pubGlobalConfig, err = pubsub.PublishPersistent("",
+	zedagentCtx.pubGlobalConfig, err = pubsublegacy.PublishPersistent("",
 		types.GlobalConfig{})
 	if err != nil {
 		log.Fatal(err)
@@ -219,7 +220,7 @@ func Run() {
 	// Make sure we have a GlobalConfig file with defaults
 	utils.ReadAndUpdateGCFile(zedagentCtx.pubGlobalConfig)
 
-	subAssignableAdapters, err := pubsub.Subscribe("domainmgr",
+	subAssignableAdapters, err := pubsublegacy.Subscribe("domainmgr",
 		types.AssignableAdapters{}, false, &zedagentCtx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleAAModify,
 			ModifyHandler: handleAAModify,
@@ -233,7 +234,7 @@ func Run() {
 	zedagentCtx.subAssignableAdapters = subAssignableAdapters
 	subAssignableAdapters.Activate()
 
-	pubPhysicalIOAdapters, err := pubsub.Publish(agentName,
+	pubPhysicalIOAdapters, err := pubsublegacy.Publish(agentName,
 		types.PhysicalIOAdapterList{})
 	if err != nil {
 		log.Fatal(err)
@@ -241,7 +242,7 @@ func Run() {
 	pubPhysicalIOAdapters.ClearRestarted()
 	getconfigCtx.pubPhysicalIOAdapters = pubPhysicalIOAdapters
 
-	pubDevicePortConfig, err := pubsub.Publish(agentName,
+	pubDevicePortConfig, err := pubsublegacy.Publish(agentName,
 		types.DevicePortConfig{})
 	if err != nil {
 		log.Fatal(err)
@@ -249,21 +250,21 @@ func Run() {
 	getconfigCtx.pubDevicePortConfig = pubDevicePortConfig
 
 	// Publish NetworkXObjectConfig and for outselves. XXX remove
-	pubNetworkXObjectConfig, err := pubsub.Publish(agentName,
+	pubNetworkXObjectConfig, err := pubsublegacy.Publish(agentName,
 		types.NetworkXObjectConfig{})
 	if err != nil {
 		log.Fatal(err)
 	}
 	getconfigCtx.pubNetworkXObjectConfig = pubNetworkXObjectConfig
 
-	pubNetworkInstanceConfig, err := pubsub.Publish(agentName,
+	pubNetworkInstanceConfig, err := pubsublegacy.Publish(agentName,
 		types.NetworkInstanceConfig{})
 	if err != nil {
 		log.Fatal(err)
 	}
 	getconfigCtx.pubNetworkInstanceConfig = pubNetworkInstanceConfig
 
-	pubAppInstanceConfig, err := pubsub.Publish(agentName,
+	pubAppInstanceConfig, err := pubsublegacy.Publish(agentName,
 		types.AppInstanceConfig{})
 	if err != nil {
 		log.Fatal(err)
@@ -271,7 +272,7 @@ func Run() {
 	getconfigCtx.pubAppInstanceConfig = pubAppInstanceConfig
 	pubAppInstanceConfig.ClearRestarted()
 
-	pubAppNetworkConfig, err := pubsub.Publish(agentName,
+	pubAppNetworkConfig, err := pubsublegacy.Publish(agentName,
 		types.AppNetworkConfig{})
 	if err != nil {
 		log.Fatal(err)
@@ -282,7 +283,7 @@ func Run() {
 	// XXX defer this until we have some config from cloud or saved copy
 	pubAppInstanceConfig.SignalRestarted()
 
-	pubCertObjConfig, err := pubsub.Publish(agentName,
+	pubCertObjConfig, err := pubsublegacy.Publish(agentName,
 		types.CertObjConfig{})
 	if err != nil {
 		log.Fatal(err)
@@ -290,7 +291,7 @@ func Run() {
 	pubCertObjConfig.ClearRestarted()
 	getconfigCtx.pubCertObjConfig = pubCertObjConfig
 
-	pubBaseOsConfig, err := pubsub.Publish(agentName,
+	pubBaseOsConfig, err := pubsublegacy.Publish(agentName,
 		types.BaseOsConfig{})
 	if err != nil {
 		log.Fatal(err)
@@ -298,14 +299,14 @@ func Run() {
 	pubBaseOsConfig.ClearRestarted()
 	getconfigCtx.pubBaseOsConfig = pubBaseOsConfig
 
-	pubZedAgentStatus, err := pubsub.Publish(agentName,
+	pubZedAgentStatus, err := pubsublegacy.Publish(agentName,
 		types.ZedAgentStatus{})
 	if err != nil {
 		log.Fatal(err)
 	}
 	pubZedAgentStatus.ClearRestarted()
 	getconfigCtx.pubZedAgentStatus = pubZedAgentStatus
-	pubDatastoreConfig, err := pubsub.Publish(agentName,
+	pubDatastoreConfig, err := pubsublegacy.Publish(agentName,
 		types.DatastoreConfig{})
 	if err != nil {
 		log.Fatal(err)
@@ -314,7 +315,7 @@ func Run() {
 	pubDatastoreConfig.ClearRestarted()
 
 	// Look for global config such as log levels
-	subGlobalConfig, err := pubsub.Subscribe("", types.GlobalConfig{},
+	subGlobalConfig, err := pubsublegacy.Subscribe("", types.GlobalConfig{},
 		false, &zedagentCtx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleGlobalConfigModify,
 			ModifyHandler: handleGlobalConfigModify,
@@ -328,7 +329,7 @@ func Run() {
 	zedagentCtx.subGlobalConfig = subGlobalConfig
 	subGlobalConfig.Activate()
 
-	subNetworkInstanceStatus, err := pubsub.Subscribe("zedrouter",
+	subNetworkInstanceStatus, err := pubsublegacy.Subscribe("zedrouter",
 		types.NetworkInstanceStatus{}, false, &zedagentCtx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleNetworkInstanceModify,
 			ModifyHandler: handleNetworkInstanceModify,
@@ -342,7 +343,7 @@ func Run() {
 	zedagentCtx.subNetworkInstanceStatus = subNetworkInstanceStatus
 	subNetworkInstanceStatus.Activate()
 
-	subNetworkInstanceMetrics, err := pubsub.Subscribe("zedrouter",
+	subNetworkInstanceMetrics, err := pubsublegacy.Subscribe("zedrouter",
 		types.NetworkInstanceMetrics{}, false, &zedagentCtx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleNetworkInstanceMetricsModify,
 			ModifyHandler: handleNetworkInstanceMetricsModify,
@@ -356,7 +357,7 @@ func Run() {
 	zedagentCtx.subNetworkInstanceMetrics = subNetworkInstanceMetrics
 	subNetworkInstanceMetrics.Activate()
 
-	subAppFlowMonitor, err := pubsub.Subscribe("zedrouter",
+	subAppFlowMonitor, err := pubsublegacy.Subscribe("zedrouter",
 		types.IPFlow{}, false, &zedagentCtx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleAppFlowMonitorModify,
 			ModifyHandler: handleAppFlowMonitorModify,
@@ -371,7 +372,7 @@ func Run() {
 	flowQ = list.New()
 	log.Infof("FlowStats: create subFlowStatus")
 
-	subAppVifIPTrig, err := pubsub.Subscribe("zedrouter",
+	subAppVifIPTrig, err := pubsublegacy.Subscribe("zedrouter",
 		types.VifIPTrig{}, false, &zedagentCtx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleAppVifIPTrigModify,
 			ModifyHandler: handleAppVifIPTrigModify,
@@ -384,7 +385,7 @@ func Run() {
 	subAppVifIPTrig.Activate()
 
 	// Look for AppInstanceStatus from zedmanager
-	subAppInstanceStatus, err := pubsub.Subscribe("zedmanager",
+	subAppInstanceStatus, err := pubsublegacy.Subscribe("zedmanager",
 		types.AppInstanceStatus{}, false, &zedagentCtx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleAppInstanceStatusModify,
 			ModifyHandler: handleAppInstanceStatusModify,
@@ -399,7 +400,7 @@ func Run() {
 	subAppInstanceStatus.Activate()
 
 	// Look for zboot status
-	subZbootStatus, err := pubsub.Subscribe("baseosmgr",
+	subZbootStatus, err := pubsublegacy.Subscribe("baseosmgr",
 		types.ZbootStatus{}, false, &zedagentCtx, &pubsub.SubscriptionOptions{
 			CreateHandler:  handleZbootStatusModify,
 			ModifyHandler:  handleZbootStatusModify,
@@ -414,7 +415,7 @@ func Run() {
 	zedagentCtx.subZbootStatus = subZbootStatus
 	subZbootStatus.Activate()
 
-	subBaseOsStatus, err := pubsub.Subscribe("baseosmgr",
+	subBaseOsStatus, err := pubsublegacy.Subscribe("baseosmgr",
 		types.BaseOsStatus{}, false, &zedagentCtx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleBaseOsStatusModify,
 			ModifyHandler: handleBaseOsStatusModify,
@@ -428,7 +429,7 @@ func Run() {
 	zedagentCtx.subBaseOsStatus = subBaseOsStatus
 	subBaseOsStatus.Activate()
 
-	subVaultStatus, err := pubsub.Subscribe("vaultmgr",
+	subVaultStatus, err := pubsublegacy.Subscribe("vaultmgr",
 		types.VaultStatus{}, false, &zedagentCtx, &pubsub.SubscriptionOptions{
 			ModifyHandler: handleVaultStatusModify,
 			DeleteHandler: handleVaultStatusDelete,
@@ -443,7 +444,7 @@ func Run() {
 
 	// Look for DownloaderStatus from downloader
 	// used only for downloader storage stats collection
-	subBaseOsDownloadStatus, err := pubsub.SubscribeScope("downloader",
+	subBaseOsDownloadStatus, err := pubsublegacy.SubscribeScope("downloader",
 		types.BaseOsObj, types.DownloaderStatus{}, false, &zedagentCtx, &pubsub.SubscriptionOptions{
 			WarningTime: warningTime,
 			ErrorTime:   errorTime,
@@ -456,7 +457,7 @@ func Run() {
 
 	// Look for DownloaderStatus from downloader
 	// used only for downloader storage stats collection
-	subCertObjDownloadStatus, err := pubsub.SubscribeScope("downloader",
+	subCertObjDownloadStatus, err := pubsublegacy.SubscribeScope("downloader",
 		types.CertObj, types.DownloaderStatus{}, false, &zedagentCtx, &pubsub.SubscriptionOptions{
 			WarningTime: warningTime,
 			ErrorTime:   errorTime,
@@ -469,7 +470,7 @@ func Run() {
 
 	// Look for VerifyBaseOsImageStatus from verifier
 	// used only for verifier storage stats collection
-	subBaseOsVerifierStatus, err := pubsub.SubscribeScope("verifier",
+	subBaseOsVerifierStatus, err := pubsublegacy.SubscribeScope("verifier",
 		types.BaseOsObj, types.VerifyImageStatus{}, false, &zedagentCtx, &pubsub.SubscriptionOptions{
 			ModifyHandler:  handleVerifierStatusModify,
 			DeleteHandler:  handleVerifierStatusDelete,
@@ -485,7 +486,7 @@ func Run() {
 
 	// Look for VerifyImageStatus from verifier
 	// used only for verifier storage stats collection
-	subAppImgVerifierStatus, err := pubsub.SubscribeScope("verifier",
+	subAppImgVerifierStatus, err := pubsublegacy.SubscribeScope("verifier",
 		types.AppImgObj, types.VerifyImageStatus{}, false, &zedagentCtx, &pubsub.SubscriptionOptions{
 			WarningTime: warningTime,
 			ErrorTime:   errorTime,
@@ -498,7 +499,7 @@ func Run() {
 
 	// Look for DownloaderStatus from downloader for metric reporting
 	// used only for downloader storage stats collection
-	subAppImgDownloadStatus, err := pubsub.SubscribeScope("downloader",
+	subAppImgDownloadStatus, err := pubsublegacy.SubscribeScope("downloader",
 		types.AppImgObj, types.DownloaderStatus{}, false, &zedagentCtx, &pubsub.SubscriptionOptions{
 			WarningTime: warningTime,
 			ErrorTime:   errorTime,
@@ -510,7 +511,7 @@ func Run() {
 	subAppImgDownloadStatus.Activate()
 
 	// Look for nodeagent status
-	subNodeAgentStatus, err := pubsub.Subscribe("nodeagent",
+	subNodeAgentStatus, err := pubsublegacy.Subscribe("nodeagent",
 		types.NodeAgentStatus{}, false, &getconfigCtx, &pubsub.SubscriptionOptions{
 			ModifyHandler: handleNodeAgentStatusModify,
 			DeleteHandler: handleNodeAgentStatusDelete,
@@ -526,7 +527,7 @@ func Run() {
 	DNSctx := DNSContext{}
 	DNSctx.usableAddressCount = types.CountLocalAddrAnyNoLinkLocal(*deviceNetworkStatus)
 
-	subDeviceNetworkStatus, err := pubsub.Subscribe("nim",
+	subDeviceNetworkStatus, err := pubsublegacy.Subscribe("nim",
 		types.DeviceNetworkStatus{}, false, &DNSctx, &pubsub.SubscriptionOptions{
 			ModifyHandler: handleDNSModify,
 			DeleteHandler: handleDNSDelete,
@@ -539,7 +540,7 @@ func Run() {
 	DNSctx.subDeviceNetworkStatus = subDeviceNetworkStatus
 	subDeviceNetworkStatus.Activate()
 
-	subDevicePortConfigList, err := pubsub.Subscribe("nim",
+	subDevicePortConfigList, err := pubsublegacy.Subscribe("nim",
 		types.DevicePortConfigList{}, false, &zedagentCtx, &pubsub.SubscriptionOptions{
 			ModifyHandler: handleDPCLModify,
 			DeleteHandler: handleDPCLDelete,
@@ -642,24 +643,24 @@ func Run() {
 	}
 
 	// Subscribe to network metrics from zedrouter
-	subNetworkMetrics, err := pubsub.Subscribe("zedrouter",
+	subNetworkMetrics, err := pubsublegacy.Subscribe("zedrouter",
 		types.NetworkMetrics{}, true, &zedagentCtx, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
 	// Subscribe to cloud metrics from different agents
 	cms := zedcloud.GetCloudMetrics()
-	subClientMetrics, err := pubsub.Subscribe("zedclient", cms,
+	subClientMetrics, err := pubsublegacy.Subscribe("zedclient", cms,
 		true, &zedagentCtx, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
-	subLogmanagerMetrics, err := pubsub.Subscribe("logmanager",
+	subLogmanagerMetrics, err := pubsublegacy.Subscribe("logmanager",
 		cms, true, &zedagentCtx, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
-	subDownloaderMetrics, err := pubsub.Subscribe("downloader",
+	subDownloaderMetrics, err := pubsublegacy.Subscribe("downloader",
 		cms, true, &zedagentCtx, nil)
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	pubsublegacy "github.com/lf-edge/eve/pkg/pillar/pubsub/legacy"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/uuidtonum"
 	log "github.com/sirupsen/logrus"
@@ -100,7 +101,7 @@ func Run() {
 		globalConfig: &types.GlobalConfigDefaults,
 	}
 	// Create publish before subscribing and activating subscriptions
-	pubAppInstanceStatus, err := pubsub.Publish(agentName,
+	pubAppInstanceStatus, err := pubsublegacy.Publish(agentName,
 		types.AppInstanceStatus{})
 	if err != nil {
 		log.Fatal(err)
@@ -108,7 +109,7 @@ func Run() {
 	ctx.pubAppInstanceStatus = pubAppInstanceStatus
 	pubAppInstanceStatus.ClearRestarted()
 
-	pubAppNetworkConfig, err := pubsub.Publish(agentName,
+	pubAppNetworkConfig, err := pubsublegacy.Publish(agentName,
 		types.AppNetworkConfig{})
 	if err != nil {
 		log.Fatal(err)
@@ -116,7 +117,7 @@ func Run() {
 	ctx.pubAppNetworkConfig = pubAppNetworkConfig
 	pubAppNetworkConfig.ClearRestarted()
 
-	pubDomainConfig, err := pubsub.Publish(agentName,
+	pubDomainConfig, err := pubsublegacy.Publish(agentName,
 		types.DomainConfig{})
 	if err != nil {
 		log.Fatal(err)
@@ -124,7 +125,7 @@ func Run() {
 	ctx.pubDomainConfig = pubDomainConfig
 	pubDomainConfig.ClearRestarted()
 
-	pubEIDConfig, err := pubsub.Publish(agentName,
+	pubEIDConfig, err := pubsublegacy.Publish(agentName,
 		types.EIDConfig{})
 	if err != nil {
 		log.Fatal(err)
@@ -132,7 +133,7 @@ func Run() {
 	ctx.pubEIDConfig = pubEIDConfig
 	pubEIDConfig.ClearRestarted()
 
-	pubAppImgDownloadConfig, err := pubsub.PublishScope(agentName,
+	pubAppImgDownloadConfig, err := pubsublegacy.PublishScope(agentName,
 		types.AppImgObj, types.DownloaderConfig{})
 	if err != nil {
 		log.Fatal(err)
@@ -140,7 +141,7 @@ func Run() {
 	pubAppImgDownloadConfig.ClearRestarted()
 	ctx.pubAppImgDownloadConfig = pubAppImgDownloadConfig
 
-	pubAppImgVerifierConfig, err := pubsub.PublishScope(agentName,
+	pubAppImgVerifierConfig, err := pubsublegacy.PublishScope(agentName,
 		types.AppImgObj, types.VerifyImageConfig{})
 	if err != nil {
 		log.Fatal(err)
@@ -148,7 +149,7 @@ func Run() {
 	pubAppImgVerifierConfig.ClearRestarted()
 	ctx.pubAppImgVerifierConfig = pubAppImgVerifierConfig
 
-	pubUuidToNum, err := pubsub.PublishPersistent(agentName,
+	pubUuidToNum, err := pubsublegacy.PublishPersistent(agentName,
 		types.UuidToNum{})
 	if err != nil {
 		log.Fatal(err)
@@ -157,7 +158,7 @@ func Run() {
 	pubUuidToNum.ClearRestarted()
 
 	// Look for global config such as log levels
-	subGlobalConfig, err := pubsub.Subscribe("", types.GlobalConfig{},
+	subGlobalConfig, err := pubsublegacy.Subscribe("", types.GlobalConfig{},
 		false, &ctx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleGlobalConfigModify,
 			ModifyHandler: handleGlobalConfigModify,
@@ -172,7 +173,7 @@ func Run() {
 	subGlobalConfig.Activate()
 
 	// Get AppInstanceConfig from zedagent
-	subAppInstanceConfig, err := pubsub.Subscribe("zedagent",
+	subAppInstanceConfig, err := pubsublegacy.Subscribe("zedagent",
 		types.AppInstanceConfig{}, false, &ctx, &pubsub.SubscriptionOptions{
 			CreateHandler:  handleCreate,
 			ModifyHandler:  handleModify,
@@ -188,7 +189,7 @@ func Run() {
 	subAppInstanceConfig.Activate()
 
 	// Get AppNetworkStatus from zedrouter
-	subAppNetworkStatus, err := pubsub.Subscribe("zedrouter",
+	subAppNetworkStatus, err := pubsublegacy.Subscribe("zedrouter",
 		types.AppNetworkStatus{}, false, &ctx, &pubsub.SubscriptionOptions{
 			CreateHandler:  handleAppNetworkStatusModify,
 			ModifyHandler:  handleAppNetworkStatusModify,
@@ -204,7 +205,7 @@ func Run() {
 	subAppNetworkStatus.Activate()
 
 	// Get DomainStatus from domainmgr
-	subDomainStatus, err := pubsub.Subscribe("domainmgr",
+	subDomainStatus, err := pubsublegacy.Subscribe("domainmgr",
 		types.DomainStatus{}, false, &ctx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleDomainStatusModify,
 			ModifyHandler: handleDomainStatusModify,
@@ -219,7 +220,7 @@ func Run() {
 	subDomainStatus.Activate()
 
 	// Get DomainStatus from domainmgr
-	subImageStatus, err := pubsub.Subscribe("domainmgr",
+	subImageStatus, err := pubsublegacy.Subscribe("domainmgr",
 		types.ImageStatus{}, false, &ctx, &pubsub.SubscriptionOptions{
 			WarningTime:    warningTime,
 			ErrorTime:      errorTime,
@@ -232,7 +233,7 @@ func Run() {
 	subImageStatus.Activate()
 
 	// Look for DownloaderStatus from downloader
-	subAppImgDownloadStatus, err := pubsub.SubscribeScope("downloader",
+	subAppImgDownloadStatus, err := pubsublegacy.SubscribeScope("downloader",
 		types.AppImgObj, types.DownloaderStatus{}, false, &ctx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleDownloaderStatusModify,
 			ModifyHandler: handleDownloaderStatusModify,
@@ -247,7 +248,7 @@ func Run() {
 	subAppImgDownloadStatus.Activate()
 
 	// Look for VerifyImageStatus from verifier
-	subAppImgVerifierStatus, err := pubsub.SubscribeScope("verifier",
+	subAppImgVerifierStatus, err := pubsublegacy.SubscribeScope("verifier",
 		types.AppImgObj, types.VerifyImageStatus{}, false, &ctx, &pubsub.SubscriptionOptions{
 			CreateHandler:  handleVerifyImageStatusModify,
 			ModifyHandler:  handleVerifyImageStatusModify,
@@ -263,7 +264,7 @@ func Run() {
 	subAppImgVerifierStatus.Activate()
 
 	// Get IdentityStatus from identitymgr
-	subEIDStatus, err := pubsub.Subscribe("identitymgr",
+	subEIDStatus, err := pubsublegacy.Subscribe("identitymgr",
 		types.EIDStatus{}, false, &ctx, &pubsub.SubscriptionOptions{
 			CreateHandler:  handleEIDStatusModify,
 			ModifyHandler:  handleEIDStatusModify,
@@ -278,7 +279,7 @@ func Run() {
 	ctx.subEIDStatus = subEIDStatus
 	subEIDStatus.Activate()
 
-	subDeviceNetworkStatus, err := pubsub.Subscribe("nim",
+	subDeviceNetworkStatus, err := pubsublegacy.Subscribe("nim",
 		types.DeviceNetworkStatus{}, false, &ctx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleDNSModify,
 			ModifyHandler: handleDNSModify,
@@ -293,7 +294,7 @@ func Run() {
 	subDeviceNetworkStatus.Activate()
 
 	// Look for CertObjStatus from baseosmgr
-	subCertObjStatus, err := pubsub.Subscribe("baseosmgr",
+	subCertObjStatus, err := pubsublegacy.Subscribe("baseosmgr",
 		types.CertObjStatus{}, false, &ctx, &pubsub.SubscriptionOptions{
 			CreateHandler: handleCertObjStatusModify,
 			ModifyHandler: handleCertObjStatusModify,

--- a/pkg/pillar/cmd/zedrouter/ipsec.go
+++ b/pkg/pillar/cmd/zedrouter/ipsec.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 
 	"github.com/lf-edge/eve/pkg/pillar/iptables"
-	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -869,7 +869,7 @@ func sysctlConfigSet() error {
 
 func ipSecConfigFileWrite(filename string, writeStr string) error {
 	data := []byte(writeStr)
-	if err := pubsub.WriteRename(filename, data); err != nil {
+	if err := fileutils.WriteRename(filename, data); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/pillar/pubsub/change.go
+++ b/pkg/pillar/pubsub/change.go
@@ -1,0 +1,25 @@
+package pubsub
+
+// Operation type for a single change operation
+type Operation byte
+
+const (
+	// Restart operation is a restart
+	Restart Operation = iota
+	// Create operation is create a new key
+	Create
+	// Delete operation is delete an existing key
+	Delete
+	// Modify operation is modify the value of an existing key
+	Modify
+)
+
+// Change the message to go into a change channel
+type Change struct {
+	// Operation which operation is performed by this change
+	Operation Operation
+	// Key the key of the affected item, if any
+	Key string
+	// Value the value of the affected item, if any
+	Value []byte
+}

--- a/pkg/pillar/pubsub/doc.go
+++ b/pkg/pillar/pubsub/doc.go
@@ -1,0 +1,86 @@
+// Package pubsub provides access to publish/subscribe semantics and engine
+// in a single host context across processes. The actual implementation of
+// the publishing and subscribing are provided by an engine passed to `pubsub`.
+//
+// This documentation covers:
+//
+// * how to use pubsub in another module
+// * how to implement a driver.
+//
+// Usage
+//
+// To use pubsub, you must first instantiate a pubsub instance, passing it a
+// driver, and then use the instance. In general, there will be one pubsub
+// instance per process, but that is not strictly necessary.
+//
+// Once instantiated, you can retrieve a publisher or a subscriber from the
+// `pubsub.PubSub`.
+//
+//
+// To instantiate pubsub:
+//   import "github.com/lf-edge/eve/pkg/pillar/pubsub"
+//   ps := pubsub.New(driver)
+//
+// where `driver` is a `struct` that implements `pubsub.Driver`.
+//
+// Included is the `SocketDriver`, which uses a Unix-domain socket to
+// communicate between publishers and subscribers, and local directories to
+// store persistent messages.
+//
+//
+// see the documentation for each element to understand its usage.
+//
+// For example:
+//
+//   import (
+//     "github.com/lf-edge/eve/pkg/pillar/pubsub"
+//     "github.com/lf-edge/eve/pkg/pillar/pubsub/socketdriver"
+//   )
+//
+//   func foo() {
+//     driver := socketdriver.SocketDriver{}
+//     ps := pubsub.New(&driver)
+//     pub, err := ps.Publish("my-agent", element)
+//     pub, err := ps.PublishPersistent("other-agent", element)
+//     sub, err := ps.Subscribe("my-agent", element, true, ctx)
+//   }
+//
+//
+// Driver
+//
+// The driver is responsible for implementing the underlying mechanics of
+// publishing and subscribing. While `pubsub.PubSub` and its components -
+// `Publication` and `Subscription` - handle the in-memory and diff aspects,
+// the driver itself is responsible for communicating between the publisher
+// and subscriber, and performing any persistence.
+//
+// The driver is expected to implement the `Driver` interface, which primarily
+// involves being able to return the `DriverPublisher` and `DriverSubscriber`.
+// These in turn are used by `Publication` and `Subscription` to publish and
+// subscribe messages.
+//
+// The `DriverPublisher` and `DriverSubscriber` are expected to function as
+// follows.
+//
+// DriverPublisher
+//
+// The `DriverPublisher` publishes messages and, optionally, persists them.
+// It also can `Unpublish` messages, as well as `Load` all messages from
+// persistence store. Finally, it must be able to set and clear a `restarted`
+// flag.
+//
+// The actual interface is key-value pairs, where it either is requested to
+// publish a key (string) and value (`interface{}`), or unpublish a key.
+//
+// See the documentation for the `DriverPublisher` interface to learn more.
+//
+// DriverSubscriber
+//
+// The `DriverSubscriber` subscribes to messages. As with the `DriverPublisher`,
+// the caller has no understanding of the underlying mechanism or semantics.
+// Once started, the subscriber is expected to send any changes to the channel
+// which was passed to it at startup. These changes are in the format of
+// `pubsub.Change`, which encapsulates the change operation, key and value.
+//
+// See the documentation for the `DriverSubscriber` interface ot learn more.
+package pubsub

--- a/pkg/pillar/pubsub/driver.go
+++ b/pkg/pillar/pubsub/driver.go
@@ -1,0 +1,64 @@
+package pubsub
+
+// Driver a backend driver for pubsub
+type Driver interface {
+	// Publisher return a `DriverPublisher` for the given name and topic.
+	// The caller passes the `Updaters`, `Restarted` checker and `Differ`.
+	// These can be used to:
+	// * add to or remove from the updaters
+	// * determine if the topic has been restarted
+	// * diff the current known state from the target known state
+	Publisher(global bool, name, topic string, persistent bool, updaterList *Updaters, restarted Restarted, differ Differ) (DriverPublisher, error)
+	// Subscriber return a `DriverSubscriber` for the given name and topic.
+	// This is expected to create a `DriverSubscriber`, but not start it.
+	// Once started, when changes arrive, they should be published to the provided
+	// channel. Each update to the channel is of type `Change`, which encapsulates
+	// the operation, key and value.
+	Subscriber(global bool, name, topic string, persistent bool, C chan Change) (DriverSubscriber, error)
+	// DefaultName Return the default name to use for an agent, when the name
+	// is not provided.
+	DefaultName() string
+}
+
+// DriverSubscriber interface that a driver for subscribing must implement
+type DriverSubscriber interface {
+	// Start subscribing to a name and topic and publish changes to the channel.
+	// This is expected to return immediately. If it needs to run in the
+	// background, it is the responsibility of the driver to run it as a separate
+	// goroutine.
+	Start() error
+}
+
+// DriverPublisher interface that a driver for publishing must implement
+type DriverPublisher interface {
+	// Start the publisher, if any startup is necessary.
+	// This is expected to return immediately. If it needs to run in the
+	// background, it is the responsibility of the driver to run it as a separate
+	// goroutine.
+	Start() error
+	// Load current status from persistence. Usually called only on first start.
+	// The implementation is responsible for determining if the load is necessary
+	// or already has been performed. If it has been already, it should not change
+	// anything. The caller has no knowledge of where the persistent state was
+	// stored: disk, databases, or vellum. All it cares about is that it gets
+	// a key-value list.
+	Load() (map[string][]byte, bool, error)
+	// Publish a key-value pair to all subscribers and optionally persistence
+	Publish(key string, item []byte) error
+	// Unpublish a key, i.e. delete it and publish its deletion to all subscribers
+	Unpublish(key string) error
+	// Restart set the state of the topic to restarted, or cancel the restarted
+	// state
+	Restart(restarted bool) error
+}
+
+// Restarted interface that lets you determine if a Publication has been restarted
+type Restarted interface {
+	IsRestarted() bool
+}
+
+// Differ interface that updates a LocalCollection from previous state to current state,
+// and returns a slice of keys that have changed
+type Differ interface {
+	DetermineDiffs(slaveCollection LocalCollection) []string
+}

--- a/pkg/pillar/pubsub/legacy/legacy.go
+++ b/pkg/pillar/pubsub/legacy/legacy.go
@@ -1,0 +1,60 @@
+package legacy
+
+import (
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub/socketdriver"
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	defaultPubsub = pubsub.New(&socketdriver.SocketDriver{})
+)
+
+// Publish create a `Publication` for the given agent name and topic type.
+func Publish(agentName string, topicType interface{}) (pubsub.Publication, error) {
+	log.Infof("legacy.Publish agentName(%s)", agentName)
+	return defaultPubsub.Publish(agentName, topicType)
+}
+
+// PublishPersistent create a `Publication` for the given agent name and topic
+// type, but with persistence of the messages across reboots.
+func PublishPersistent(agentName string, topicType interface{}) (pubsub.Publication, error) {
+	log.Infof("legacy.PublishPersistent agentName(%s)", agentName)
+	return defaultPubsub.PublishPersistent(agentName, topicType)
+}
+
+// PublishScope create a `Publication` for the given agent name and topic,
+// restricted to a given scope.
+func PublishScope(agentName string, agentScope string, topicType interface{}) (pubsub.Publication, error) {
+	log.Infof("legacy.PublishScope agentName(%s), agentScope (%s)", agentName, agentScope)
+	return defaultPubsub.PublishScope(agentName, agentScope, topicType)
+}
+
+// Subscribe create a subscription for the given agent name and topic
+// optionally activating immediately. If `activate` is set to `false`
+// (the default), then the subscription will not begin to send messages
+// on the channel or process them until `Subscription.Start()` is called.
+func Subscribe(agentName string, topicType interface{}, activate bool,
+	ctx interface{}, options *pubsub.SubscriptionOptions) (pubsub.Subscription, error) {
+	return defaultPubsub.Subscribe(agentName, topicType, activate, ctx, options)
+}
+
+// SubscribeScope create a subscription for the given agent name and topic,
+// limited to a given scope,
+// optionally activating immediately. If `activate` is set to `false`
+// (the default), then the subscription will not begin to send messages
+// on the channel or process them until `Subscription.Start()` is called.
+func SubscribeScope(agentName string, agentScope string, topicType interface{},
+	activate bool, ctx interface{}, options *pubsub.SubscriptionOptions) (pubsub.Subscription, error) {
+	return defaultPubsub.SubscribeScope(agentName, agentScope, topicType, activate, ctx, options)
+}
+
+// SubscribePersistent create a subscription for the given agent name and topic,
+// persistent,
+// optionally activating immediately. If `activate` is set to `false`
+// (the default), then the subscription will not begin to send messages
+// on the channel or process them until `Subscription.Start()` is called.
+func SubscribePersistent(agentName string, topicType interface{}, activate bool,
+	ctx interface{}, options *pubsub.SubscriptionOptions) (pubsub.Subscription, error) {
+	return defaultPubsub.SubscribePersistent(agentName, topicType, activate, ctx, options)
+}

--- a/pkg/pillar/pubsub/pubsub_test.go
+++ b/pkg/pillar/pubsub/pubsub_test.go
@@ -16,14 +16,53 @@ type Item struct {
 	aString string
 }
 
-var item = Item{
-	aString: "aString",
+var (
+	item = Item{
+		aString: "aString",
+	}
+)
+
+type EmptyDriver struct{}
+
+func (e *EmptyDriver) Publisher(global bool, name, topic string, persistent bool, updaterList *Updaters, restarted Restarted, differ Differ) (DriverPublisher, error) {
+	return &EmptyDriverPublisher{}, nil
+}
+func (e *EmptyDriver) Subscriber(global bool, name, topic string, persistent bool, C chan Change) (DriverSubscriber, error) {
+	return &EmptyDriverSubscriber{}, nil
+}
+func (e *EmptyDriver) DefaultName() string {
+	return "empty"
+}
+
+type EmptyDriverPublisher struct{}
+
+func (e *EmptyDriverPublisher) Start() error {
+	return nil
+}
+func (e *EmptyDriverPublisher) Load() (map[string][]byte, bool, error) {
+	return make(map[string][]byte), false, nil
+}
+func (e *EmptyDriverPublisher) Publish(key string, item []byte) error {
+	return nil
+}
+func (e *EmptyDriverPublisher) Unpublish(key string) error {
+	return nil
+}
+func (e *EmptyDriverPublisher) Restart(restarted bool) error {
+	return nil
+}
+
+type EmptyDriverSubscriber struct{}
+
+func (e *EmptyDriverSubscriber) Start() error {
+	return nil
 }
 
 func TestHandleModify(t *testing.T) {
-	sub, err := SubscribeScope(agentName, agentScope, item, false, &item, nil)
+	ps := New(&EmptyDriver{})
+	sub, err := ps.SubscribeScope(agentName, agentScope, item, false, &item, nil)
 	if err != nil {
-		t.Fatalf("unable to Subscribe to %s", agentName)
+		t.Fatalf("unable to subscribe: %v", err)
 	}
 	subImpl, ok := sub.(*SubscriptionImpl)
 	if !ok {

--- a/pkg/pillar/pubsub/pubsubintf.go
+++ b/pkg/pillar/pubsub/pubsubintf.go
@@ -30,9 +30,9 @@ type Subscription interface {
 	// Restarted report if this subscription has been marked as restarted
 	Restarted() bool
 	// ProcessChange - Invoked on the string msg from Subscription Channel
-	ProcessChange(change string)
+	ProcessChange(change Change)
 	// MsgChan - Message Channel for Subscription
-	MsgChan() <-chan string
+	MsgChan() <-chan Change
 	// Activate start the subscription
 	Activate() error
 }

--- a/pkg/pillar/pubsub/smoke_test.go
+++ b/pkg/pillar/pubsub/smoke_test.go
@@ -1,0 +1,18 @@
+package pubsub_test
+
+// This file is just a temporary smoke test to instantiate the SocketDriver and
+// pubsub.New(), and ensure that all interfaces are met.
+// It will be replaced shortly by real unit tests.
+
+import (
+	"fmt"
+
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub/socketdriver"
+)
+
+func foo() {
+	driver := socketdriver.SocketDriver{}
+	ps := pubsub.New(&driver)
+	fmt.Println(ps)
+}

--- a/pkg/pillar/pubsub/socketdriver/driver.go
+++ b/pkg/pillar/pubsub/socketdriver/driver.go
@@ -1,0 +1,197 @@
+package socketdriver
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path"
+
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	log "github.com/sirupsen/logrus"
+)
+
+// Protocol over AF_UNIX or other IPC mechanism
+// "request" from client after connect to sanity check subject.
+// Server sends the other messages; "update" for initial values.
+// "complete" once all initial keys/values in collection have been sent.
+// "restarted" if/when pub.km.restarted is set.
+// Ongoing we send "update" and "delete" messages.
+// They keys and values are base64-encoded since they might contain spaces.
+// We include typeName after command word for sanity checks.
+// Hence the message format is
+//	"request" topic
+//	"hello"  topic
+//	"update" topic key json-val
+//	"delete" topic key
+//	"complete" topic (aka synchronized)
+//	"restarted" topic
+
+// We always publish to our collection.
+// We always write to a file in order to have a checkpoint on restart
+// The special agent name "" implies always reading from the /var/run/zededa/
+// directory.
+const (
+	publishToSock     = true  // XXX
+	subscribeFromDir  = false // XXX
+	subscribeFromSock = true  // XXX
+
+	// For a subscription, if the agentName is empty we interpret that as
+	// being directory in /var/tmp/zededa
+	fixedName = "zededa"
+	fixedDir  = "/var/tmp/" + fixedName
+	maxsize   = 65535 // Max size for json which can be read or written
+
+	// Copied from types package to avoid cycle in package dependencies
+	// persistDir - Location to store persistent files.
+	persistDir = "/persist"
+	// persistConfigDir is where we keep some configuration across reboots
+	persistConfigDir = persistDir + "/config"
+)
+
+// SocketDriver driver for pubsub using local unix-domain socket and files
+type SocketDriver struct {
+}
+
+// Publisher return an implementation of `pubsub.DriverPublisher` for
+// `SocketDriver`
+func (s *SocketDriver) Publisher(global bool, name, topic string, persistent bool, updaterList *pubsub.Updaters, restarted pubsub.Restarted, differ pubsub.Differ) (pubsub.DriverPublisher, error) {
+	var (
+		dirName, sockName string
+		publishToDir      bool
+		listener          net.Listener
+		err               error
+	)
+	shouldPopulate := false
+
+	// We always write to the directory as a checkpoint for process restart
+	// That directory could be persistent in which case it will survive
+	// a reboot.
+
+	// if the agentName is "", signal that we publish to dir, rather than
+	// to sock
+	if global {
+		publishToDir = true
+	}
+
+	// the dirName depends on if we are persistent, and if it is the global config
+	switch {
+	case persistent && publishToDir:
+		// Special case for /persist/config/
+		dirName = fmt.Sprintf("%s/%s", persistConfigDir, name)
+	case persistent && !publishToDir:
+		dirName = s.persistentDirName(name)
+	case !persistent && publishToDir:
+		// Special case for /var/tmp/zededa/
+		dirName = s.fixedDirName(name)
+	default:
+		dirName = s.pubDirName(name)
+	}
+
+	if _, err := os.Stat(dirName); err != nil {
+		log.Infof("Publish Create %s\n", dirName)
+		if err := os.MkdirAll(dirName, 0700); err != nil {
+			errStr := fmt.Sprintf("Publish(%s): %s",
+				name, err)
+			return nil, errors.New(errStr)
+		}
+	} else {
+		// Read existing status from dir
+		shouldPopulate = true
+	}
+
+	if !publishToDir && publishToSock {
+		sockName = s.sockName(name)
+		dir := path.Dir(sockName)
+		if _, err := os.Stat(dir); err != nil {
+			log.Infof("Publish Create %s\n", dir)
+			if err := os.MkdirAll(dir, 0700); err != nil {
+				errStr := fmt.Sprintf("Publish(%s): %s",
+					name, err)
+				return nil, errors.New(errStr)
+			}
+		}
+		if _, err := os.Stat(sockName); err == nil {
+			if err := os.Remove(sockName); err != nil {
+				errStr := fmt.Sprintf("Publish(%s): %s",
+					name, err)
+				return nil, errors.New(errStr)
+			}
+		}
+		listener, err = net.Listen("unixpacket", sockName)
+		if err != nil {
+			errStr := fmt.Sprintf("Publish(%s): failed %s",
+				name, err)
+			return nil, errors.New(errStr)
+		}
+	}
+	return &Publisher{
+		sockName:       sockName,
+		listener:       listener,
+		dirName:        dirName,
+		shouldPopulate: shouldPopulate,
+		name:           name,
+		topic:          topic,
+		updaters:       updaterList,
+		differ:         differ,
+		restarted:      restarted,
+	}, nil
+}
+
+// Subscriber return an implementation of `pubsub.DriverSubscriber` for
+// `SocketDriver`
+func (s *SocketDriver) Subscriber(global bool, name, topic string, persistent bool, C chan pubsub.Change) (pubsub.DriverSubscriber, error) {
+	var (
+		sockName   = s.sockName(name)
+		dirName    string
+		subFromDir bool
+	)
+
+	// Special case for files in /var/tmp/zededa/ and also
+	// for zedclient going away yet metrics being read after it
+	// is gone.
+	agentName := name
+
+	if global {
+		subFromDir = true
+		dirName = s.fixedDirName(name)
+	} else if agentName == "zedclient" {
+		subFromDir = true
+		dirName = s.pubDirName(name)
+	} else if persistent {
+		subFromDir = true
+		dirName = s.persistentDirName(name)
+	} else {
+		subFromDir = subscribeFromDir
+		dirName = s.pubDirName(name)
+	}
+	return &Subscriber{
+		subscribeFromDir: subFromDir,
+		dirName:          dirName,
+		name:             name,
+		topic:            topic,
+		sockName:         sockName,
+		C:                C,
+	}, nil
+}
+
+// DefaultName default name for an agent when none is provided
+func (s *SocketDriver) DefaultName() string {
+	return fixedName
+}
+
+func (s *SocketDriver) sockName(name string) string {
+	return fmt.Sprintf("/var/run/%s.sock", name)
+}
+
+func (s *SocketDriver) pubDirName(name string) string {
+	return fmt.Sprintf("/var/run/%s", name)
+}
+
+func (s *SocketDriver) fixedDirName(name string) string {
+	return fmt.Sprintf("%s/%s", fixedDir, name)
+}
+
+func (s *SocketDriver) persistentDirName(name string) string {
+	return fmt.Sprintf("%s/status/%s", "/persist", name)
+}

--- a/pkg/pillar/pubsub/socketdriver/publish.go
+++ b/pkg/pillar/pubsub/socketdriver/publish.go
@@ -1,0 +1,301 @@
+package socketdriver
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
+	log "github.com/sirupsen/logrus"
+)
+
+// Publisher implementation of `pubsub.DriverPublisher` for `SocketDriver`.
+// Implements Unix-domain socket or directory publication,
+// and directory-based persistence.
+type Publisher struct {
+	sock           net.Conn // For socket subscriptions
+	sockName       string   // there is one socket per publishing agent
+	listener       net.Listener
+	dirName        string
+	shouldPopulate bool // indicate on start if we need to populate
+	name           string
+	topic          string
+	updaters       *pubsub.Updaters
+	differ         pubsub.Differ
+	restarted      pubsub.Restarted
+}
+
+// Publish publish a key-value pair
+func (s *Publisher) Publish(key string, item []byte) error {
+	fileName := s.dirName + "/" + key + ".json"
+	log.Debugf("Publish writing %s\n", fileName)
+
+	err := fileutils.WriteRename(fileName, item)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Unpublish delete a key and publish its deletion
+func (s *Publisher) Unpublish(key string) error {
+	fileName := s.dirName + "/" + key + ".json"
+	log.Debugf("Unpublish deleting file %s\n", fileName)
+	if err := os.Remove(fileName); err != nil {
+		return fmt.Errorf("Unpublish(%s/%s): failed %s", s.name, key, err)
+	}
+	return nil
+}
+
+// Load load entire persisted data set into a map
+func (s *Publisher) Load() (map[string][]byte, bool, error) {
+	dirName := s.dirName
+	foundRestarted := false
+	items := make(map[string][]byte)
+
+	log.Infof("Load(%s)\n", s.name)
+
+	files, err := ioutil.ReadDir(dirName)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, file := range files {
+		if !strings.HasSuffix(file.Name(), ".json") {
+			if file.Name() == "restarted" {
+				foundRestarted = true
+			}
+			continue
+		}
+		// Remove .json from name */
+		key := strings.Split(file.Name(), ".json")[0]
+
+		statusFile := dirName + "/" + file.Name()
+		if _, err := os.Stat(statusFile); err != nil {
+			// File just vanished!
+			log.Errorf("populate: File disappeared <%s>\n",
+				statusFile)
+			continue
+		}
+
+		log.Infof("populate found key %s file %s\n", key, statusFile)
+
+		sb, err := ioutil.ReadFile(statusFile)
+		if err != nil {
+			log.Errorf("populate: %s for %s\n", err, statusFile)
+			continue
+		}
+		items[key] = sb
+	}
+	return items, foundRestarted, err
+}
+
+// Start start publishing on the socket
+func (s *Publisher) Start() error {
+	// we only do this for not publishing to dir, and publishing to socket
+	// which already was indicated by having the listener set up
+	if s.listener == nil {
+		return nil
+	}
+	go func(s *Publisher) {
+		instance := 0
+		for {
+			c, err := s.listener.Accept()
+			if err != nil {
+				log.Errorf("publisher(%s) failed %s\n", s.name, err)
+				continue
+			}
+			go s.serveConnection(c, instance)
+			instance++
+		}
+	}(s)
+	return nil
+}
+
+// Restart indicate that the topic is restarted, or clear it
+func (s *Publisher) Restart(restarted bool) error {
+	restartFile := s.dirName + "/" + "restarted"
+	if restarted {
+		f, err := os.OpenFile(restartFile, os.O_RDONLY|os.O_CREATE, 0600)
+		if err != nil {
+			errStr := fmt.Sprintf("pub.restartImpl(%s): openfile failed %s", s.name, err)
+			return errors.New(errStr)
+		}
+		f.Close()
+	} else {
+		if err := os.Remove(restartFile); err != nil {
+			errStr := fmt.Sprintf("pub.restartImpl(%s): remove failed %s", s.name, err)
+			return errors.New(errStr)
+		}
+	}
+	return nil
+}
+
+func (s *Publisher) serveConnection(conn net.Conn, instance int) {
+	log.Infof("serveConnection(%s/%d)\n", s.name, instance)
+	defer conn.Close()
+
+	// Track the set of keys/values we are sending to the peer
+	sendToPeer := make(pubsub.LocalCollection)
+	sentRestarted := false
+	// Read request
+	buf := make([]byte, 65536)
+	res, err := conn.Read(buf)
+	if err != nil {
+		log.Fatalf("serveConnection(%s/%d) error: %v", s.name, instance, err)
+	}
+	if res == len(buf) {
+		// Likely truncated
+		log.Fatalf("serveConnection(%s/%d) request likely truncated\n", s.name, instance)
+	}
+
+	request := strings.Split(string(buf[0:res]), " ")
+	log.Infof("serveConnection read %d: %v\n", len(request), request)
+	if len(request) != 2 || request[0] != "request" || request[1] != s.topic {
+		log.Errorf("Invalid request message: %v\n", request)
+		return
+	}
+
+	_, err = conn.Write([]byte(fmt.Sprintf("hello %s", s.topic)))
+	if err != nil {
+		log.Errorf("serveConnection(%s/%d) failed %s\n", s.name, instance, err)
+		return
+	}
+	// Insert our notification channel before we get the initial
+	// snapshot to avoid missing any updates/deletes.
+	updater := make(chan pubsub.Notify, 1)
+	s.updaters.Add(updater, s.name, instance)
+	defer s.updaters.Remove(updater)
+
+	// Get a local snapshot of the collection and the set of keys
+	// we need to send these. Updates the slave collection.
+	keys := s.differ.DetermineDiffs(sendToPeer)
+
+	// Send the keys we just determined; all since this is the initial
+	err = s.serialize(conn, keys, sendToPeer)
+	if err != nil {
+		log.Errorf("serveConnection(%s/%d) serialize failed %s\n", s.name, instance, err)
+		return
+	}
+	err = s.sendComplete(conn)
+	if err != nil {
+		log.Errorf("serveConnection(%s/%d) sendComplete failed %s\n", s.name, instance, err)
+		return
+	}
+	if s.restarted.IsRestarted() && !sentRestarted {
+		err = s.sendRestarted(conn)
+		if err != nil {
+			log.Errorf("serveConnection(%s/%d) sendRestarted failed %s\n", s.name, instance, err)
+			return
+		}
+		sentRestarted = true
+	}
+
+	// Handle any changes
+	for {
+		log.Debugf("serveConnection(%s/%d) waiting for notification\n", s.name, instance)
+		startWait := time.Now()
+		<-updater
+		waitTime := time.Since(startWait)
+		log.Debugf("serveConnection(%s/%d) received notification waited %d seconds\n", s.name, instance, waitTime/time.Second)
+
+		// Update and determine which keys changed
+		keys := s.differ.DetermineDiffs(sendToPeer)
+
+		// Send the updates and deletes for those keys
+		err = s.serialize(conn, keys, sendToPeer)
+		if err != nil {
+			log.Errorf("serveConnection(%s/%d) serialize failed %s\n", s.name, instance, err)
+			return
+		}
+
+		if s.restarted.IsRestarted() && !sentRestarted {
+			err = s.sendRestarted(conn)
+			if err != nil {
+				log.Errorf("serveConnection(%s/%d) sendRestarted failed %s\n", s.name, instance, err)
+				return
+			}
+			sentRestarted = true
+		}
+	}
+}
+
+func (s *Publisher) serialize(sock net.Conn, keys []string,
+	sendToPeer pubsub.LocalCollection) error {
+
+	log.Debugf("serialize(%s, %v)\n", s.name, keys)
+
+	for _, key := range keys {
+		val, ok := sendToPeer[key]
+		if ok {
+			err := s.sendUpdate(sock, key, val)
+			if err != nil {
+				log.Errorf("serialize(%s) sendUpdate failed %s\n", s.name, err)
+				return err
+			}
+		} else {
+			err := s.sendDelete(sock, key)
+			if err != nil {
+				log.Errorf("serialize(%s) sendDelete failed %s\n", s.name, err)
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (s *Publisher) sendUpdate(sock net.Conn, key string,
+	val []byte) error {
+
+	log.Debugf("sendUpdate(%s): key %s\n", s.name, key)
+	// base64-encode to avoid having spaces in the key and val
+	sendKey := base64.StdEncoding.EncodeToString([]byte(key))
+	sendVal := base64.StdEncoding.EncodeToString(val)
+	buf := fmt.Sprintf("update %s %s %s", s.topic, sendKey, sendVal)
+	if len(buf) >= maxsize {
+		log.Fatalf("Too large message (%d bytes) sent to %s topic %s key %s",
+			len(buf), s.name, s.topic, key)
+	}
+	_, err := sock.Write([]byte(buf))
+	return err
+}
+
+func (s *Publisher) sendDelete(sock net.Conn, key string) error {
+	log.Debugf("sendDelete(%s): key %s\n", s.name, key)
+	// base64-encode to avoid having spaces in the key
+	sendKey := base64.StdEncoding.EncodeToString([]byte(key))
+	buf := fmt.Sprintf("delete %s %s", s.topic, sendKey)
+	if len(buf) >= maxsize {
+		log.Fatalf("Too large message (%d bytes) sent to %s topic %s key %s",
+			len(buf), s.name, s.topic, key)
+	}
+	_, err := sock.Write([]byte(buf))
+	return err
+}
+
+func (s *Publisher) sendRestarted(sock net.Conn) error {
+	log.Infof("sendRestarted(%s)\n", s.name)
+	buf := fmt.Sprintf("restarted %s", s.topic)
+	if len(buf) >= maxsize {
+		log.Fatalf("Too large message (%d bytes) sent to %s topic %s",
+			len(buf), s.name, s.topic)
+	}
+	_, err := sock.Write([]byte(buf))
+	return err
+}
+
+func (s *Publisher) sendComplete(sock net.Conn) error {
+	log.Infof("sendComplete(%s)\n", s.name)
+	buf := fmt.Sprintf("complete %s", s.topic)
+	if len(buf) >= maxsize {
+		log.Fatalf("Too large message (%d bytes) sent to %s topic %s",
+			len(buf), s.name, s.topic)
+	}
+	_, err := sock.Write([]byte(buf))
+	return err
+}

--- a/pkg/pillar/pubsub/socketdriver/subscribe.go
+++ b/pkg/pillar/pubsub/socketdriver/subscribe.go
@@ -1,0 +1,245 @@
+package socketdriver
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/watch"
+	log "github.com/sirupsen/logrus"
+)
+
+// Subscriber implementation of `pubsub.DriverSubscriber` for `SocketDriver`.
+// Implements Unix-domain socket or directory subscription,
+// and directory-based persistence.
+type Subscriber struct {
+	sockName         string   // there is one socket per publishing agent
+	sock             net.Conn // For socket subscriptions
+	subscribeFromDir bool     // Handle special case of file only info
+	name             string
+	topic            string
+	dirName          string
+	C                chan<- pubsub.Change
+}
+
+// Start start the subscriber listening on the given name and topic
+// internally, will watch for changes on either the socket or the file, and then
+// send the change summary to s.C
+func (s *Subscriber) Start() error {
+	// We handle both subscribeFromDir and subscribeFromSock
+	// Note that change filename includes .json for subscribeFromDir. That
+	// is removed by the translator.
+	if s.subscribeFromDir {
+		// Waiting for directory to appear
+		for {
+			if _, err := os.Stat(s.dirName); err != nil {
+				errStr := fmt.Sprintf("Subscribe(%s): failed %s; waiting", s.name, err)
+				log.Errorln(errStr)
+				time.Sleep(10 * time.Second)
+			} else {
+				break
+			}
+		}
+		// WatchStatus updates the channel with messages in a slightly different
+		// format than the standard for pubsub
+		// we pass it through a translator
+		translator := make(chan string)
+		go watch.WatchStatus(s.dirName, true, translator)
+		go s.translate(translator, s.C)
+		return nil
+	} else if subscribeFromSock {
+		go s.watchSock()
+		return nil
+	} else {
+		errStr := fmt.Sprintf("Subscribe(%s): failed %s", s.name, "nowhere to subscribe")
+		return errors.New(errStr)
+	}
+}
+
+func (s *Subscriber) watchSock() {
+	for {
+		msg, key, val := s.connectAndRead()
+		switch msg {
+		case "hello":
+			// Do nothing
+		case "complete":
+			// XXX to handle restart we need to handle "complete"
+			// by doing a sweep across the KeyMap to handleDelete
+			// what we didn't see before the "complete"
+			s.C <- pubsub.Change{Operation: pubsub.Create, Key: "done"}
+
+		case "restarted":
+			s.C <- pubsub.Change{Operation: pubsub.Restart, Key: "done"}
+
+		case "delete":
+			s.C <- pubsub.Change{Operation: pubsub.Delete, Key: key}
+
+		case "update":
+			// XXX is size of val any issue? pointer?
+			s.C <- pubsub.Change{Operation: pubsub.Modify, Key: key, Value: val}
+		}
+	}
+}
+
+// Returns msg, key, val
+// key and val are base64-encoded
+func (s *Subscriber) connectAndRead() (string, string, []byte) {
+	buf := make([]byte, maxsize+1)
+
+	// Waiting for publisher to appear; retry on error
+	for {
+		if s.sock == nil {
+			sock, err := net.Dial("unixpacket", s.sockName)
+			if err != nil {
+				errStr := fmt.Sprintf("connectAndRead(%s): Dial failed %s",
+					s.name, err)
+				log.Warnln(errStr)
+				time.Sleep(10 * time.Second)
+				continue
+			}
+			s.sock = sock
+			req := fmt.Sprintf("request %s", s.topic)
+			_, err = sock.Write([]byte(req))
+			if err != nil {
+				errStr := fmt.Sprintf("connectAndRead(%s): sock write failed %s",
+					s.name, err)
+				log.Errorln(errStr)
+				s.sock.Close()
+				s.sock = nil
+				continue
+			}
+		}
+
+		res, err := s.sock.Read(buf)
+		if err != nil {
+			errStr := fmt.Sprintf("connectAndRead(%s): sock read failed %s",
+				s.name, err)
+			log.Errorln(errStr)
+			s.sock.Close()
+			s.sock = nil
+			continue
+		}
+
+		if res == len(buf) {
+			// Likely truncated
+			log.Fatalf("connectAndRead(%s) request likely truncated\n", s.name)
+		}
+		reply := strings.Split(string(buf[0:res]), " ")
+		count := len(reply)
+		if count < 2 {
+			errStr := fmt.Sprintf("connectAndRead(%s): too short read", s.name)
+			log.Errorln(errStr)
+			continue
+		}
+		msg := reply[0]
+		t := reply[1]
+
+		if t != s.topic {
+			errStr := fmt.Sprintf("connectAndRead(%s): mismatched topic %s vs. %s for %s", s.name, t, s.topic, msg)
+			log.Errorln(errStr)
+			// XXX continue
+		}
+
+		// XXX are there error cases where we should Close and
+		// continue aka reconnect?
+		switch msg {
+		case "hello", "restarted", "complete":
+			log.Debugf("connectAndRead(%s) Got message %s type %s\n", s.name, msg, t)
+			return msg, "", nil
+
+		case "delete":
+			if count < 3 {
+				errStr := fmt.Sprintf("connectAndRead(%s): too short delete", s.name)
+				log.Errorln(errStr)
+				continue
+			}
+			recvKey := reply[2]
+
+			key, err := base64.StdEncoding.DecodeString(recvKey)
+			if err != nil {
+				errStr := fmt.Sprintf("connectAndRead(%s): base64 failed %s", s.name, err)
+				log.Errorln(errStr)
+				continue
+			}
+			if log.GetLevel() == log.DebugLevel {
+				log.Debugf("connectAndRead(%s): delete type %s key %s\n", s.name, t, string(key))
+			}
+			return msg, string(key), nil
+
+		case "update":
+			if count != 4 {
+				errStr := fmt.Sprintf("connectAndRead(%s): update of %d parts instead of expected 4", s.name, count)
+				log.Errorln(errStr)
+				continue
+			}
+			recvKey := reply[2]
+			recvVal := reply[3]
+			key, err := base64.StdEncoding.DecodeString(recvKey)
+			if err != nil {
+				errStr := fmt.Sprintf("connectAndRead(%s): base64 key failed %s", s.name, err)
+				log.Errorln(errStr)
+				continue
+			}
+			val, err := base64.StdEncoding.DecodeString(recvVal)
+			if err != nil {
+				errStr := fmt.Sprintf("connectAndRead(%s): base64 val failed %s", s.name, err)
+				log.Errorln(errStr)
+				continue
+			}
+			if log.GetLevel() == log.DebugLevel {
+				log.Debugf("connectAndRead(%s): update type %s key %s val %s\n", s.name, t, string(key), string(val))
+			}
+			return msg, string(key), val
+
+		default:
+			errStr := fmt.Sprintf("connectAndRead(%s): unknown message %s", s.name, msg)
+			log.Errorln(errStr)
+			continue
+		}
+	}
+}
+
+func (s *Subscriber) translate(in <-chan string, out chan<- pubsub.Change) {
+	statusDirName := s.dirName
+	for change := range in {
+		log.Debugf("translate received message '%s'", change)
+		operation := string(change[0])
+		fileName := string(change[2:])
+		// Remove .json from name */
+		name := strings.Split(fileName, ".json")
+		switch {
+		case operation == "R":
+			log.Infof("Received restart <%s>\n", fileName)
+			// I do not know why, but the "R" operation from the file watcher
+			// historically called the Complete operation, leading to the
+			// "Synchronized" handler being called.
+			out <- pubsub.Change{Operation: pubsub.Create}
+		case operation == "M" && fileName == "restarted":
+			log.Debugf("Found restarted file\n")
+			out <- pubsub.Change{Operation: pubsub.Restart}
+		case !strings.HasSuffix(fileName, ".json"):
+			// log.Debugf("Ignoring file <%s> operation %s\n",
+			//	fileName, operation)
+			continue
+		case operation == "D":
+			out <- pubsub.Change{Operation: pubsub.Delete, Key: name[0]}
+		case operation == "M":
+			statusFile := path.Join(statusDirName, fileName)
+			cb, err := ioutil.ReadFile(statusFile)
+			if err != nil {
+				log.Errorf("%s for %s\n", err, statusFile)
+				continue
+			}
+			out <- pubsub.Change{Operation: pubsub.Modify, Key: name[0], Value: cb}
+		default:
+			log.Fatal("Unknown operation from Watcher: ", operation)
+		}
+	}
+}

--- a/pkg/pillar/pubsub/subscribe.go
+++ b/pkg/pillar/pubsub/subscribe.go
@@ -1,48 +1,21 @@
 package pubsub
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
-	"os"
-	"strings"
+	"reflect"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/lf-edge/eve/pkg/pillar/watch"
 	log "github.com/sirupsen/logrus"
 )
 
-// SubHandler is a generic handler to handle create, modify and delete
-// Usage:
-//  s1 := pubsub.Subscribe("foo", fooStruct{}, true, &myctx)
-// Or
-//  s1 := pubsub.Subscribe("foo", fooStruct{}, false, &myctx)
-//  s1.ModifyHandler = func(...), // Optional
-//  s1.DeleteHandler = func(...), // Optional
-//  s1.RestartHandler = func(...), // Optional
-//  [ Initialize myctx ]
-//  s1.Activate()
-//  ...
-//  select {
-//     case change := <- s1.C:
-//         s1.ProcessChange(change, ctx)
-//  }
-//  The ProcessChange function calls the various handlers (if set) and updates
-//  the subscribed collection. The subscribed collection can be accessed using:
-//  foo := s1.Get(key)
-//  fooAll := s1.GetAll()
-// SubHandler is a generic handler to handle create, modify and delete
-type SubHandler func(ctx interface{}, key string, status interface{})
-
-// SubRestartHandler is a generic handler to handle restart and synchronized
-type SubRestartHandler func(ctx interface{}, restarted bool)
-
-// SubscriptionImpl holds subscription to a single topic with its channel
+// SubscriptionImpl handle a subscription to a single agent+topic, optionally scope
+// as well. Never should be instantiated directly. Rather, call
+// `PubSub.Subscribe*`
 type SubscriptionImpl struct {
-	C                   <-chan string
+	C                   <-chan Change
 	CreateHandler       SubHandler
 	ModifyHandler       SubHandler
 	DeleteHandler       SubHandler
@@ -52,307 +25,47 @@ type SubscriptionImpl struct {
 	MaxProcessTimeError time.Duration // If set generate warning if ProcessChange
 
 	// Private fields
-	sendChan   chan<- string
-	topicType  interface{}
-	agentName  string
-	agentScope string
-	topic      string
-	km         keyMap
-	userCtx    interface{}
-	sock       net.Conn // For socket subscriptions
-
-	synchronized     bool
-	subscribeFromDir bool // Handle special case of file only info
-	dirName          string
-	persistent       bool
+	agentName    string
+	agentScope   string
+	topic        string
+	topicType    reflect.Type
+	km           keyMap
+	userCtx      interface{}
+	synchronized bool
+	driver       DriverSubscriber
+	defaultName  string
 }
 
-// MsgChan - Returns the Message Channel for the Subscription.
-func (sub *SubscriptionImpl) MsgChan() <-chan string {
+// MsgChan return the Message Channel for the Subscription.
+func (sub *SubscriptionImpl) MsgChan() <-chan Change {
 	return sub.C
 }
 
-func (sub *SubscriptionImpl) nameString() string {
-	agentName := sub.agentName
-	if agentName == "" {
-		agentName = fixedName
-	}
-	if sub.agentScope == "" {
-		return fmt.Sprintf("%s/%s", sub.agentName, sub.topic)
-	} else {
-		return fmt.Sprintf("%s/%s/%s", sub.agentName, sub.agentScope,
-			sub.topic)
-	}
-}
-
-// Activate - If the agentName is empty we interpret that as being dir /var/tmp/zededa
+// Activate start the subscription
 func (sub *SubscriptionImpl) Activate() error {
-
-	name := sub.nameString()
-	if sub.subscribeFromDir {
-		// Waiting for directory to appear
-		for {
-			if _, err := os.Stat(sub.dirName); err != nil {
-				errStr := fmt.Sprintf("Subscribe(%s): failed %s; waiting",
-					name, err)
-				log.Errorln(errStr)
-				time.Sleep(10 * time.Second)
-			} else {
-				break
-			}
-		}
-		go watch.WatchStatus(sub.dirName, true, sub.sendChan)
-		return nil
-	} else if subscribeFromSock {
-		go sub.watchSock()
-		return nil
-	} else {
-		errStr := fmt.Sprintf("Subscribe(%s): failed %s",
-			name, "nowhere to subscribe")
-		return errors.New(errStr)
-	}
+	return sub.driver.Start()
 }
 
-func (sub *SubscriptionImpl) watchSock() {
-
-	for {
-		msg, key, val := sub.connectAndRead()
-		switch msg {
-		case "hello":
-			// Do nothing
-		case "complete":
-			// XXX to handle restart we need to handle "complete"
-			// by doing a sweep across the KeyMap to handleDelete
-			// what we didn't see before the "complete"
-			sub.sendChan <- "C done"
-
-		case "restarted":
-			sub.sendChan <- "R done"
-
-		case "delete":
-			sub.sendChan <- "D " + key
-
-		case "update":
-			// XXX is size of val any issue? pointer?
-			sub.sendChan <- "M " + key + " " + val
-		}
-	}
-}
-
-// Returns msg, key, val
-// key and val are base64-encoded
-func (sub *SubscriptionImpl) connectAndRead() (string, string, string) {
-
-	name := sub.nameString()
-	sockName := SockName(name)
-	buf := make([]byte, maxsize+1)
-
-	// Waiting for publisher to appear; retry on error
-	for {
-		if sub.sock == nil {
-			s, err := net.Dial("unixpacket", sockName)
-			if err != nil {
-				errStr := fmt.Sprintf("connectAndRead(%s): Dial failed %s",
-					name, err)
-				log.Warnln(errStr)
-				time.Sleep(10 * time.Second)
-				continue
-			}
-			sub.sock = s
-			req := fmt.Sprintf("request %s", sub.topic)
-			_, err = s.Write([]byte(req))
-			if err != nil {
-				errStr := fmt.Sprintf("connectAndRead(%s): sock write failed %s",
-					name, err)
-				log.Errorln(errStr)
-				sub.sock.Close()
-				sub.sock = nil
-				continue
-			}
-		}
-
-		res, err := sub.sock.Read(buf)
-		if err != nil {
-			errStr := fmt.Sprintf("connectAndRead(%s): sock read failed %s",
-				name, err)
-			log.Errorln(errStr)
-			sub.sock.Close()
-			sub.sock = nil
-			continue
-		}
-
-		if res == len(buf) {
-			// Likely truncated
-			log.Fatalf("connectAndRead(%s) request likely truncated\n",
-				name)
-		}
-		reply := strings.Split(string(buf[0:res]), " ")
-		count := len(reply)
-		if count < 2 {
-			errStr := fmt.Sprintf("connectAndRead(%s): too short read",
-				name)
-			log.Errorln(errStr)
-			continue
-		}
-		msg := reply[0]
-		t := reply[1]
-
-		if t != sub.topic {
-			errStr := fmt.Sprintf("connectAndRead(%s): mismatched topic %s vs. %s for %s",
-				name, t, sub.topic, msg)
-			log.Errorln(errStr)
-			// XXX continue
-		}
-
-		// XXX are there error cases where we should Close and
-		// continue aka reconnect?
-		switch msg {
-		case "hello", "restarted", "complete":
-			log.Debugf("connectAndRead(%s) Got message %s type %s\n",
-				name, msg, t)
-			return msg, "", ""
-
-		case "delete":
-			if count < 3 {
-				errStr := fmt.Sprintf("connectAndRead(%s): too short delete",
-					name)
-				log.Errorln(errStr)
-				continue
-			}
-			recvKey := reply[2]
-
-			if log.GetLevel() == log.DebugLevel {
-				key, err := base64.StdEncoding.DecodeString(recvKey)
-				if err != nil {
-					errStr := fmt.Sprintf("connectAndRead(%s): base64 failed %s",
-						name, err)
-					log.Errorln(errStr)
-					continue
-				}
-				log.Debugf("connectAndRead(%s): delete type %s key %s\n",
-					name, t, string(key))
-			}
-			return msg, recvKey, ""
-
-		case "update":
-			if count < 4 {
-				errStr := fmt.Sprintf("connectAndRead(%s): too short update",
-					name)
-				log.Errorln(errStr)
-				continue
-			}
-			if count > 4 {
-				errStr := fmt.Sprintf("connectAndRead(%s): too long update",
-					name)
-				log.Errorln(errStr)
-				continue
-			}
-			recvKey := reply[2]
-			recvVal := reply[3]
-			if log.GetLevel() == log.DebugLevel {
-				key, err := base64.StdEncoding.DecodeString(recvKey)
-				if err != nil {
-					errStr := fmt.Sprintf("connectAndRead(%s): base64 failed %s",
-						name, err)
-					log.Errorln(errStr)
-					continue
-				}
-				val, err := base64.StdEncoding.DecodeString(recvVal)
-				if err != nil {
-					errStr := fmt.Sprintf("connectAndRead(%s): base64 val failed %s",
-						name, err)
-					log.Errorln(errStr)
-					continue
-				}
-				log.Debugf("connectAndRead(%s): update type %s key %s val %s\n",
-					name, t, string(key), string(val))
-			}
-			return msg, recvKey, recvVal
-
-		default:
-			errStr := fmt.Sprintf("connectAndRead(%s): unknown message %s",
-				name, msg)
-			log.Errorln(errStr)
-			continue
-		}
-	}
-}
-
-// ProcessChange - Process message received on Msg Chan.
-// We handle both subscribeFromDir and subscribeFromSock
-// Note that change filename includes .json for subscribeFromDir. That
-// is removed by HandleStatusEvent.
-func (sub *SubscriptionImpl) ProcessChange(change string) {
-
+// ProcessChange process a single change and its parameters. It
+// calls the various handlers (if set) and updates the subscribed collection.
+// The subscribed collection can be accessed using:
+//   foo := s1.Get(key)
+//   fooAll := s1.GetAll()
+func (sub *SubscriptionImpl) ProcessChange(change Change) {
 	start := time.Now()
-	if sub.subscribeFromDir {
-		var restartFn watch.StatusRestartHandler = handleRestart
-		var completeFn watch.StatusRestartHandler = handleSynchronized
-		watch.HandleStatusEvent(change, sub, sub.dirName,
-			handleModify, handleDelete, &restartFn,
-			&completeFn)
-	} else if subscribeFromSock {
-		name := sub.nameString()
-		reply := strings.Split(change, " ")
-		operation := reply[0]
+	log.Debugf("ProcessChange agentName(%s) agentScope(%s) topic(%s): %#v", sub.agentName, sub.agentScope, sub.topic, change)
 
-		switch operation {
-		case "C":
-			handleSynchronized(sub, true)
-		case "R":
-			handleRestart(sub, true)
-		case "D":
-			recvKey := reply[1]
-			key, err := base64.StdEncoding.DecodeString(recvKey)
-			if err != nil {
-				errStr := fmt.Sprintf("ProcessChange(%s): base64 failed %s",
-					name, err)
-				log.Errorln(errStr)
-				break
-			}
-			handleDelete(sub, string(key))
-
-		case "M":
-			recvKey := reply[1]
-			recvVal := reply[2]
-			key, err := base64.StdEncoding.DecodeString(recvKey)
-			if err != nil {
-				errStr := fmt.Sprintf("ProcessChange(%s): base64 failed %s",
-					name, err)
-				log.Errorln(errStr)
-				break
-			}
-			val, err := base64.StdEncoding.DecodeString(recvVal)
-			if err != nil {
-				errStr := fmt.Sprintf("ProcessChange(%s): base64 val failed %s",
-					name, err)
-				log.Errorln(errStr)
-				break
-			}
-			handleModify(sub, string(key), val)
-		}
-	} else {
-		// Enforced in Subscribe()
-		log.Fatal("ProcessChange: neither subscribeFromDir nor subscribeFromSock")
+	switch change.Operation {
+	case Restart:
+		handleRestart(sub, true)
+	case Create:
+		handleSynchronized(sub, true)
+	case Delete:
+		handleDelete(sub, change.Key)
+	case Modify:
+		handleModify(sub, change.Key, change.Value)
 	}
-	CheckMaxTimeTopic(sub.agentName, sub.topic, start,
-		sub.MaxProcessTimeWarn, sub.MaxProcessTimeError)
-}
-
-func (sub *SubscriptionImpl) dump(infoStr string) {
-	name := sub.nameString()
-	log.Debugf("dump(%s) %s\n", name, infoStr)
-	dumper := func(key string, val interface{}) bool {
-		b, err := json.Marshal(val)
-		if err != nil {
-			log.Fatal("json Marshal in dump", err)
-		}
-		log.Debugf("\tkey %s val %s\n", key, b)
-		return true
-	}
-	sub.km.key.Range(dumper)
-	log.Debugf("\trestarted %t\n", sub.km.restarted)
-	log.Debugf("\tsynchronized %t\n", sub.synchronized)
+	CheckMaxTimeTopic(sub.agentName, sub.topic, start, sub.MaxProcessTimeWarn, sub.MaxProcessTimeError)
 }
 
 // Get - Get object with specified Key from this Subscription.
@@ -391,6 +104,36 @@ func (sub *SubscriptionImpl) Synchronized() bool {
 // Topic returns the string definiting the topic
 func (sub *SubscriptionImpl) Topic() string {
 	return sub.topic
+}
+
+func (sub *SubscriptionImpl) nameString() string {
+	var name string
+	agentName := sub.agentName
+	if agentName == "" {
+		agentName = sub.defaultName
+	}
+	if sub.agentScope == "" {
+		name = fmt.Sprintf("%s/%s", sub.agentName, sub.topic)
+	} else {
+		name = fmt.Sprintf("%s/%s/%s", sub.agentName, sub.agentScope, sub.topic)
+	}
+	return name
+}
+
+func (sub *SubscriptionImpl) dump(infoStr string) {
+	name := sub.nameString()
+	log.Debugf("dump(%s) %s\n", name, infoStr)
+	dumper := func(key string, val interface{}) bool {
+		b, err := json.Marshal(val)
+		if err != nil {
+			log.Fatal("json Marshal in dump", err)
+		}
+		log.Debugf("\tkey %s val %s\n", key, b)
+		return true
+	}
+	sub.km.key.Range(dumper)
+	log.Debugf("\trestarted %t\n", sub.km.restarted)
+	log.Debugf("\tsynchronized %t\n", sub.synchronized)
 }
 
 // handlers

--- a/pkg/pillar/pubsub/updaters.go
+++ b/pkg/pillar/pubsub/updaters.go
@@ -1,38 +1,38 @@
 package pubsub
 
 import (
-	"log"
 	"sync"
+
+	log "github.com/sirupsen/logrus"
 )
-
-type notify struct{}
-
-// The set of channels to which we need to send notifications
-type updaters struct {
-	lock    sync.Mutex
-	servers []notifyName
-}
 
 type notifyName struct {
 	name     string // From pub.nameString()
 	instance int
-	ch       chan<- notify
+	ch       chan<- Notify
 }
 
-var updaterList updaters
+// Updaters list of channels to which notifications should be sent. Global
+// across an entire `PubSub struct`. Can `Add()` and `Remove()`.
+type Updaters struct {
+	lock    sync.Mutex
+	servers []notifyName
+}
 
-func updatersAdd(updater chan notify, name string, instance int) {
-	updaterList.lock.Lock()
+// Add an updater
+func (u *Updaters) Add(updater chan Notify, name string, instance int) {
+	u.lock.Lock()
 	nn := notifyName{name: name, instance: instance, ch: updater}
-	updaterList.servers = append(updaterList.servers, nn)
-	updaterList.lock.Unlock()
+	u.servers = append(u.servers, nn)
+	u.lock.Unlock()
 }
 
-func updatersRemove(updater chan notify) {
-	updaterList.lock.Lock()
-	servers := make([]notifyName, len(updaterList.servers))
+// Remove an updater
+func (u *Updaters) Remove(updater chan Notify) {
+	u.lock.Lock()
+	servers := make([]notifyName, len(u.servers))
 	found := false
-	for _, old := range updaterList.servers {
+	for _, old := range u.servers {
 		if old.ch == updater {
 			found = true
 		} else {
@@ -40,8 +40,8 @@ func updatersRemove(updater chan notify) {
 		}
 	}
 	if !found {
-		log.Fatal("updatersRemove: not found\n")
+		log.Fatal("updaters.remove(): not found\n")
 	}
-	updaterList.servers = servers
-	updaterList.lock.Unlock()
+	u.servers = servers
+	u.lock.Unlock()
 }

--- a/pkg/pillar/utils/file/file.go
+++ b/pkg/pillar/utils/file/file.go
@@ -1,0 +1,40 @@
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+// WriteRename write data to a fmpfile and then rename it to a desired name
+func WriteRename(fileName string, b []byte) error {
+	dirName := filepath.Dir(fileName)
+	// Do atomic rename to avoid partially written files
+	tmpfile, err := ioutil.TempFile(dirName, "pubsub")
+	if err != nil {
+		errStr := fmt.Sprintf("WriteRename(%s): %s",
+			fileName, err)
+		return errors.New(errStr)
+	}
+	defer tmpfile.Close()
+	defer os.Remove(tmpfile.Name())
+	_, err = tmpfile.Write(b)
+	if err != nil {
+		errStr := fmt.Sprintf("WriteRename(%s): %s",
+			fileName, err)
+		return errors.New(errStr)
+	}
+	if err := tmpfile.Close(); err != nil {
+		errStr := fmt.Sprintf("WriteRename(%s): %s",
+			fileName, err)
+		return errors.New(errStr)
+	}
+	if err := os.Rename(tmpfile.Name(), fileName); err != nil {
+		errStr := fmt.Sprintf("writeRename(%s): %s",
+			fileName, err)
+		return errors.New(errStr)
+	}
+	return nil
+}

--- a/pkg/pillar/utils/globalutils.go
+++ b/pkg/pillar/utils/globalutils.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	pubsublegacy "github.com/lf-edge/eve/pkg/pillar/pubsub/legacy"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	log "github.com/sirupsen/logrus"
 )
@@ -22,7 +23,7 @@ const (
 // EnsureGCFile is used by agents which wait for GlobalConfig to become initialized
 // on startup in order to make sure we have a GlobalConfig file.
 func EnsureGCFile() {
-	pubGlobalConfig, err := pubsub.PublishPersistent("", types.GlobalConfig{})
+	pubGlobalConfig, err := pubsublegacy.PublishPersistent("", types.GlobalConfig{})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/pillar/utils/ledmanagerutils.go
+++ b/pkg/pillar/utils/ledmanagerutils.go
@@ -4,7 +4,7 @@
 package utils
 
 import (
-	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	pubsublegacy "github.com/lf-edge/eve/pkg/pillar/pubsub/legacy"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	log "github.com/sirupsen/logrus"
 )
@@ -18,7 +18,7 @@ func UpdateLedManagerConfig(count int) {
 	blinkCount := types.LedBlinkCounter{
 		BlinkCounter: count,
 	}
-	pub, err := pubsub.Publish("", types.LedBlinkCounter{})
+	pub, err := pubsublegacy.Publish("", types.LedBlinkCounter{})
 	if err != nil {
 		log.Fatal("Publish LedBlinkCounter")
 	}


### PR DESCRIPTION
This PR replaces the closed #416, as it does it in a completely different fashion. It still targets the same goal: abstracting pubsub so that it can be standalone, use different persistence or communications methods, be replaced in testing, etc.

For specific review @kalyan-nidumolu and @eriknordmark .

I added a lot of godoc code on the package, as well as a `smoke_test.go` file to show how it works. `pubsub_test.go` also was restructured. 

What this still is missing:

- [ ] unit tests
- [ ] all of the packages that consume it need to be updated

We will address the above once we have agreement on this direction. For now, it passes `go vet` and `go test`, at least at the level of `pkg/pillar/pubsub/` and below.

## What this does

Disentangles the in-memory part of pubsub, and all logic related to publishing and subscription, from the actual implementation of publishing and subscribing, as well as persistence. 

In our case, those were provided by a Unix-domain socket, and filesystems.

Instead, when you create a `pubsub.PubSub{}` (I really dislike that naming scheme, and it fails some linters; once we have agreement, I will try to rename), you pass it a driver implementation. That driver handles:

* the actual publishing and subscribing mechanism
* any encoding/decoding of messages (e.g. base64 or anything else, or filenames) for transmitting on whatever channel is used
* persistence, both selection of location as well as implementation (e.g. which directories and what filenames to use, as well as writing/reading)

The consistent and shared pubsub itself handles:

* any in-memory logic
* a uniform item to pass to anything that needs it
* diffing logic
* ongoing state

The actual implementation we have used until now is moved to a `SocketDriver`, which is located in `pkg/pillar/pubsub/socketdriver/`. 

The intent for running other unit tests is to replace the `SocketDriver` with, e.g. `MemoryDriver` or other mechanisms that will allow unit tests to run, and even some degree of integration, without requiring actual Unix-domain sockets or file persistence.

I have rebased this based on the previous PRs #445 and #449 that made recent changes to pubsub.

Unfortunately, this affects 13 or so files, and has some real changes. I tried to separate unto multiple commits, but no one commit would pass basic vetting or tests without the others. I did try to keep them small, e.g. `change.go` just has a struct and some constants, `doc.go` is just documentation, `driver.go` is just the driver interfaces, etc.

I believe this hits all of the comments from the now-closed #416. Looking forward to feedback on this.

