### PR TITLE
Fix boot time errors from storage-init container

### DIFF
--- a/pkg/storage-init/Dockerfile
+++ b/pkg/storage-init/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.10.3
 WORKDIR /
 # hadolint ignore=DL3018
 RUN apk add --no-cache bash glib squashfs-tools util-linux e2fsprogs \
-        e2fsprogs-extra keyutils
+        e2fsprogs-extra keyutils dosfstools coreutils
 COPY storage-init.sh /storage-init.sh
 
 ENTRYPOINT []

--- a/pkg/storage-init/storage-init.sh
+++ b/pkg/storage-init/storage-init.sh
@@ -10,11 +10,11 @@ chmod 700 $PERSISTDIR
 mkdir -p $CONFIGDIR
 chmod 700 $CONFIGDIR
 if CONFIG=$(/hostfs/sbin/findfs PARTLABEL=CONFIG) && [ -n "$CONFIG" ]; then
-    if ! mount -t vfat -o dirsync,noatime "$CONFIG" $CONFIGDIR; then
-        echo "$(date -Ins -u) mount $CONFIG failed"
-    fi
     if ! fsck.vfat -y "$CONFIG"; then
         echo "$(date -Ins -u) fsck.vfat $CONFIG failed"
+    fi
+    if ! mount -t vfat -o dirsync,noatime "$CONFIG" $CONFIGDIR; then
+        echo "$(date -Ins -u) mount $CONFIG failed"
     fi
 else
     echo "$(date -Ins -u) No separate $CONFIGDIR partition"

--- a/pkg/storage-init/storage-init.sh
+++ b/pkg/storage-init/storage-init.sh
@@ -13,6 +13,9 @@ if CONFIG=$(/hostfs/sbin/findfs PARTLABEL=CONFIG) && [ -n "$CONFIG" ]; then
     if ! mount -t vfat -o dirsync,noatime "$CONFIG" $CONFIGDIR; then
         echo "$(date -Ins -u) mount $CONFIG failed"
     fi
+    if ! fsck.vfat -y "$CONFIG"; then
+        echo "$(date -Ins -u) fsck.vfat $CONFIG failed"
+    fi
 else
     echo "$(date -Ins -u) No separate $CONFIGDIR partition"
 fi


### PR DESCRIPTION
Signed-off-by: GopiKrishna Kodali <gkodali@zededa.com>

1) storage-init container did not have coreutils package due to which "date" command execution leads to error message dump.
2) Add dosfsutils to check for errors/correct in /dev/sda4 (config partition).
3) The other message corresponding to /dev/sda9 seem to be because we do not have /dev/sda9 formatted already while booting with qemu. I have not seen this message with devices that have this partition already formatted.