### PR TITLE
Further tweaks for Xen 4.13

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -153,7 +153,7 @@ function set_x86_64 {
 function set_x86_64_baremetal {
    set_generic
    set_x86_64
-   set_global hv_platform_tweaks "$hv_platform_tweaks efi=no-rs"
+   set_global hv_platform_tweaks "$hv_platform_tweaks efi=attr=uc"
    set_global dom0_platform_tweaks " "
    set_global dom0_console "console=tty0 console=ttyS0"
 }
@@ -183,7 +183,7 @@ function set_arm64_baremetal {
    set_global load_devicetree_cmd devicetree
    set_global dom0_platform_tweaks " "
    # FIXME: the following needs to go away once we figure out correct devicetree for HiKey
-   set_global hv_dom0_mem_settings "dom0_mem=640M"
+   set_global hv_dom0_mem_settings "dom0_mem=512M"
 }
 
 function set_arm64_qemu {


### PR DESCRIPTION
Xen elders have come down from the mountain and gave us sage advice on how to tune our EFI usage: https://lists.xenproject.org/archives/html/xen-devel/2019-11/msg01620.html

Also, if we want installer to boot on ARM64 we need to reduce dom0 memory even further to 512M. Note, that once installer is done installing it is possible to go back to 640M for the dom0, but I'd rather have a forcing function to keep us in 512M budget (and besides you can always tweak that *after* installation is done in /config/grub.cfg)