### PR TITLE
Allowing building ARM configuration image on x86

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,11 +41,12 @@ HOSTARCH:=$(subst aarch64,arm64,$(subst x86_64,amd64,$(shell uname -m)))
 # by default, take the host architecture as the target architecture, but can override with `make ZARCH=foo`
 #    assuming that the toolchain supports it, of course...
 ZARCH ?= $(HOSTARCH)
+export ZARCH
 # warn if we are cross-compiling and track it
 CROSS ?=
 ifneq ($(HOSTARCH),$(ZARCH))
 CROSS = 1
-$(warning "WARNING: We are assembling a $(ZARCH) image on $(HOSTARCH). Things may break.")
+$(warning "WARNING: We are assembling an $(ZARCH) image on $(HOSTARCH). Things may break.")
 endif
 
 DOCKER_ARCH_TAG=$(ZARCH)
@@ -205,14 +206,15 @@ $(DIST) $(INSTALLER):
 	mkdir -p $@
 
 # convenience targets - so you can do `make config` instead of `make dist/config.img`, and `make installer` instead of `make dist/amd64/installer.img
+initrd: $(INITRD_IMG)
 config: $(CONFIG_IMG)
 rootfs: $(ROOTFS_IMG)
 live: $(LIVE_IMG).img
 installer: $(INSTALLER).raw
 installer-iso: $(INSTALLER).iso
 
-$(CONFIG_IMG): conf/server conf/onboard.cert.pem conf/authorized_keys conf/ | $(INSTALLER)
-	./tools/makeconfig.sh $(CONF_DIR) $@
+$(CONFIG_IMG): $(CONF_DIR) FORCE | $(INSTALLER)
+	./tools/makeconfig.sh $< $@
 
 $(ROOTFS_IMG): $(ROOTFS_YML) | $(INSTALLER)
 	./tools/makerootfs.sh $< $(ROOTFS_FORMAT) $@

--- a/pkg/mkconf/make-config
+++ b/pkg/mkconf/make-config
@@ -12,7 +12,7 @@ CONFIG_SIZE_KB=1024
 
 DTS=/conf/eve.dts
 if [ -f "$DTS" ]; then
-   [ "$(uname -m)" = aarch64 ] && dtc -O dtb -o /conf/eve.dtb -I dts "$DTS"
+   [ "$ZARCH" = arm64 ] && dtc -O dtb -o /conf/eve.dtb -I dts "$DTS"
    rm "$DTS"
 fi
 


### PR DESCRIPTION
This PR fully restores EVE's ability to assemble ARM images on x86.

IOW, the following will now be fully possible again:
```
make ZARCH=arm64 eve
```

This gets us one step away from having fully functional EVE builds on HiKey again (last step is getting Xen 4.13's memory management issue fixed)