### PR TITLE
fix deadlock hanging zedrouter

### DIFF
--- a/pkg/pillar/cmd/zedrouter/probe.go
+++ b/pkg/pillar/cmd/zedrouter/probe.go
@@ -429,12 +429,12 @@ func launchHostProbe(ctx *zedrouterContext) {
 			probeMutex.Lock()
 		}
 	}
+	iteration++
+	probeMutex.Unlock()
 	if needSendSignal {
 		log.Debugf("launchHostProbe: send uplink signal\n")
 		ctx.checkNIUplinks <- true
 	}
-	iteration++
-	probeMutex.Unlock()
 	setProbeTimer(ctx, nhProbeInterval)
 }
 


### PR DESCRIPTION
@naiming-zededa please take a look.
Without this fix I sometimes get zedrouter to hang when booting under qemu.