### PR TITLE
hack to ignore cloud wifi null configure, some override changes

### DIFF
--- a/conf/DevicePortConfig/override.json.template
+++ b/conf/DevicePortConfig/override.json.template
@@ -57,7 +57,7 @@
             "IfName": "wlan0",
             "Name": "Management",
             "IsMgmt": true,
-            "NetworkProxyEnable": true,
+            "NetworkProxyEnable": false,
             "NetworkProxyURL": "",
             "NtpServer": "",
             "Pacfile": "",


### PR DESCRIPTION
Signed-off-by: Naiming Shen <naiming@zededa.com>
- hack to ignore cloud configure of null wifi setting if the existing wifi is valid, since we currently don't have a way to configure the wifi params from the zedcontrol
- when the DevicePortConfig update is 'override' type, even it's the first time, somehow it compares equal to the old config, just let this to run the configure anyway
- fixed a typo in the template of wifi configure