### PR TITLE
bump to go 1.13.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #
 # Run make (with no arguments) to see help on what targets are available
 
-GOVER ?= 1.12.4
+GOVER ?= 1.13.5
 PKGBASE=github.com/lf-edge/eve
 GOMODULE=$(PKGBASE)/pkg/pillar
 GOTREE=$(CURDIR)/pkg/pillar

--- a/pkg/pillar/Dockerfile.in
+++ b/pkg/pillar/Dockerfile.in
@@ -1,6 +1,6 @@
 # Copyright (c) 2018 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-ARG GOVER=1.12.4
+ARG GOVER=1.13.5
 FROM golang:${GOVER}-alpine as build
 RUN apk update
 RUN apk add --no-cache git gcc linux-headers libc-dev util-linux libpcap-dev make


### PR DESCRIPTION
It has much better output messages for module issues.

Have not had a chance to do a full build with this quite yet