### PR TITLE
During bootup, for existing applications with RW images, avoid waiting for verification of downloaded images.

### DIFF
--- a/pkg/pillar/cmd/zedmanager/handleimagestatus.go
+++ b/pkg/pillar/cmd/zedmanager/handleimagestatus.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2017-2018 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package zedmanager
+
+import (
+	"github.com/lf-edge/eve/pkg/pillar/cast"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	uuid "github.com/satori/go.uuid"
+	log "github.com/sirupsen/logrus"
+)
+
+func lookupImageStatusForApp(
+	ctx *zedmanagerContext, appUUID uuid.UUID,
+	imageSha string) *types.ImageStatus {
+
+	imageStatusList := ctx.subImageStatus.GetAll()
+	for _, item := range imageStatusList {
+		status := cast.CastImageStatus(item)
+		if status.AppInstUUID == appUUID && status.ImageSha256 == imageSha {
+			log.Debugf("lookupImageStatusForApp: IS found. appUUID: %s, "+
+				"imageSha: %s", appUUID.String(), imageSha)
+			return &status
+		}
+	}
+	log.Debugf("lookupImageStatusForApp: Image Status NOT found. appUUID: %s, "+
+		"imageSha: %s", appUUID.String(), imageSha)
+	return nil
+}

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -180,8 +180,10 @@ type DiskStatus struct {
 
 // Track the active image files in rwImgDirname
 type ImageStatus struct {
-	Filename     string // Basename; used as key
-	FileLocation string // Local location of Image
+	AppInstUUID  uuid.UUID // UUID of App Instance using the image.
+	ImageSha256  string    // ImageSha256 of original image
+	Filename     string    // Basename; used as key
+	FileLocation string    // Local location of Image
 	RefCount     uint
 	LastUse      time.Time // When RefCount dropped to zero
 	Size         uint64

--- a/pkg/pillar/types/verifiertypes.go
+++ b/pkg/pillar/types/verifiertypes.go
@@ -119,7 +119,8 @@ func (status VerifyImageStatus) ImageDownloadFilenames() (string, string, string
 		// Else..VMs
 		pendingFilename = pendingDirname + "/" + status.Safename
 		verifierFilename = verifierDirname + "/" + status.Safename
-		verifiedFilename = verifiedDirname + "/" + status.Safename
+		filename := SafenameToFilename(status.Safename)
+		verifiedFilename = verifiedDirname + "/" + filename
 	}
 	return pendingFilename, verifierFilename, verifiedFilename
 }


### PR DESCRIPTION
During bootup, for existing applications with RW images, avoid waiting for verification of downloaded images.

1) DomainMgr should publish AppUUID for the images in ImageStatus
2) Zedmanager, when creating an App instance, should check if
    the image is already available in ImageStatus for RW images.
    if yes, it should just add Verifier config and skip waiting for
    verifier
3) Verifier - Skip verifying images on bootup
    - These can be verified with the first verifier config is added.

Signed-off-by: Kalyan Nidumolu <kalyan@zadeda.com>

Fix Verifier to not wait for images in verified/ dir to be re-verified
after bootup.

Signed-off-by: Kalyan Nidumolu <kalyan@zadeda.com>