### PR TITLE
fix missing routes in table for eth1

### DIFF
--- a/pkg/pillar/cmd/zedrouter/pbr.go
+++ b/pkg/pillar/cmd/zedrouter/pbr.go
@@ -235,7 +235,7 @@ func PbrRouteChange(ctx *zedrouterContext,
 	}
 }
 
-func isErrno(err error, errno int) bool {
+func isErrno(err error, errno syscall.Errno) bool {
 	e1, ok := err.(syscall.Errno)
 	if !ok {
 		log.Warnf("XXX not Errno: %T", err)

--- a/pkg/pillar/cmd/zedrouter/pbr.go
+++ b/pkg/pillar/cmd/zedrouter/pbr.go
@@ -29,7 +29,6 @@ func PbrInit(ctx *zedrouterContext) {
 // PbrRouteAddAll adds all the routes for the bridgeName table to the specific port
 // Separately we handle changes in PbrRouteChange
 // XXX used by networkinstance only
-// XXX Can't we use MoveRoutesTable?
 func PbrRouteAddAll(bridgeName string, port string) error {
 	log.Infof("PbrRouteAddAll(%s, %s)\n", bridgeName, port)
 
@@ -172,7 +171,7 @@ func PbrRouteChange(ctx *zedrouterContext,
 	}
 	if linkType != "bridge" && !types.IsPort(*deviceNetworkStatus, ifname) {
 		// Ignore
-		log.Errorf("PbrRouteChange ignore %s: neither bridge nor port. route %v\n",
+		log.Infof("PbrRouteChange ignore %s: neither bridge nor port. route %v\n",
 			ifname, rt)
 		return
 	}
@@ -211,8 +210,14 @@ func PbrRouteChange(ctx *zedrouterContext,
 		if linkType == "bridge" {
 			log.Infof("Apply route add to bridge %s", ifname)
 			if err := netlink.RouteAdd(&myrt); err != nil {
-				log.Errorf("Failed to add %v to %d: %s\n",
-					myrt, myrt.Table, err)
+				// XXX ditto for ENXIO?? for del?
+				if isErrno(err, syscall.EEXIST) {
+					log.Infof("Failed to add %v to %d: %s\n",
+						myrt, myrt.Table, err)
+				} else {
+					log.Errorf("Failed to add %v to %d: %s\n",
+						myrt, myrt.Table, err)
+				}
 			}
 		}
 		// find all bridges for network instances and add for them
@@ -223,11 +228,20 @@ func PbrRouteChange(ctx *zedrouterContext,
 		for _, ifindex := range indicies {
 			myrt.Table = baseTableIndex + ifindex
 			if err := netlink.RouteAdd(&myrt); err != nil {
-				log.Errorf("Failed to add %v from %d: %s\n",
+				log.Errorf("Failed to add %v to %d: %s\n",
 					myrt, myrt.Table, err)
 			}
 		}
 	}
+}
+
+func isErrno(err error, errno int) bool {
+	e1, ok := err.(syscall.Errno)
+	if !ok {
+		log.Warnf("XXX not Errno: %T", err)
+		return false
+	}
+	return e1 == errno
 }
 
 // Handle an IP address change


### PR DESCRIPTION
The changes to use CurrentUplinkIntf 4 months back seem to have caused a race since CurrentUplinkIntf isn't set until some probing is done.

Also the check for valid Port names should be applied to the Port and not to CurrentUplinkIntf since we want to catch the labels like "uplink" in the check.

@naiming-zededa please take a look