### PR TITLE
Turns out it is the last console that becomes /dev/console

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -155,7 +155,7 @@ function set_x86_64_baremetal {
    set_x86_64
    set_global hv_platform_tweaks "$hv_platform_tweaks efi=attr=uc"
    set_global dom0_platform_tweaks " "
-   set_global dom0_console "console=tty0 console=ttyS0"
+   set_global dom0_console "console=ttyS0 console=tty0"
 }
 
 function set_x86_64_qemu {
@@ -240,7 +240,7 @@ submenu 'Set Boot Options' {
    menuentry 'skip hypervisor booting' {
      set_global load_hv_cmd echo
      set_global load_dom0_cmd linux
-     set_global dom0_console "console=tty0 console=ttyS0"
+     set_global dom0_console "console=ttyS0 console=tty0"
      set_global load_initrd_cmd initrd
    }
 


### PR DESCRIPTION
We need to make sure that installer has access to the default console (VT) as opposed to a serial one. This combination works even if serial console is the only one present, while the reverse is not true.