### PR TITLE
rename funcs in zedUpload.DroneEndpoint to comply with golang and lint

### DIFF
--- a/pkg/pillar/cmd/downloader/download.go
+++ b/pkg/pillar/cmd/downloader/download.go
@@ -37,9 +37,9 @@ func download(ctx *downloaderContext, trType zedUpload.SyncTransportType,
 		&ctx.deviceNetworkStatus, ifname, downloadURL)
 	if err == nil && proxyUrl != nil {
 		log.Infof("%s: Using proxy %s", trType, proxyUrl.String())
-		dEndPoint.WithSrcIpAndProxySelection(ipSrc, proxyUrl)
+		dEndPoint.WithSrcIPAndProxySelection(ipSrc, proxyUrl)
 	} else {
-		dEndPoint.WithSrcIpSelection(ipSrc)
+		dEndPoint.WithSrcIPSelection(ipSrc)
 	}
 
 	var respChan = make(chan *zedUpload.DronaRequest)

--- a/pkg/pillar/zedUpload/datastore.go
+++ b/pkg/pillar/zedUpload/datastore.go
@@ -53,8 +53,8 @@ type DronaEndPoint interface {
 	Open() error
 	Action(req *DronaRequest) error
 	Close() error
-	WithSrcIpSelection(localAddr net.IP) error
-	WithSrcIpAndProxySelection(localAddr net.IP, proxy *url.URL) error
+	WithSrcIPSelection(localAddr net.IP) error
+	WithSrcIPAndProxySelection(localAddr net.IP, proxy *url.URL) error
 	WithBindIntf(intf string) error
 	WithLogging(onoff bool) error
 }

--- a/pkg/pillar/zedUpload/datastore_aws.go
+++ b/pkg/pillar/zedUpload/datastore_aws.go
@@ -5,13 +5,14 @@ package zedUpload
 
 import (
 	"fmt"
-	zedAWS "github.com/lf-edge/eve/pkg/pillar/zedUpload/awsutil"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
 	"time"
+
+	zedAWS "github.com/lf-edge/eve/pkg/pillar/zedUpload/awsutil"
 )
 
 //
@@ -57,13 +58,15 @@ func (ep *AwsTransportMethod) Close() error {
 	return nil
 }
 
-// use the specific ip as source address for this connection
-func (ep *AwsTransportMethod) WithSrcIpSelection(localAddr net.IP) error {
+// WithSrcIPSelection use the specific ip as source address for this connection
+func (ep *AwsTransportMethod) WithSrcIPSelection(localAddr net.IP) error {
 	ep.hClient = httpClientSrcIP(localAddr, nil)
 	return nil
 }
 
-func (ep *AwsTransportMethod) WithSrcIpAndProxySelection(localAddr net.IP,
+// WithSrcIPAndProxySelection use the specific ip as source address for this
+// connection and connect via the provided proxy URL
+func (ep *AwsTransportMethod) WithSrcIPAndProxySelection(localAddr net.IP,
 	proxy *url.URL) error {
 	ep.hClient = httpClientSrcIP(localAddr, proxy)
 	return nil

--- a/pkg/pillar/zedUpload/datastore_azure.go
+++ b/pkg/pillar/zedUpload/datastore_azure.go
@@ -5,10 +5,12 @@ package zedUpload
 
 import (
 	"fmt"
-	azure "github.com/lf-edge/eve/pkg/pillar/zedUpload/azureutil"
 	"net"
 	"net/http"
 	"net/url"
+
+	azure "github.com/lf-edge/eve/pkg/pillar/zedUpload/azureutil"
+
 	//	"strings"
 	"time"
 )
@@ -55,13 +57,15 @@ func (ep *AzureTransportMethod) Close() error {
 	return nil
 }
 
-// use the specific ip as source address for this connection
-func (ep *AzureTransportMethod) WithSrcIpSelection(localAddr net.IP) error {
+// WithSrcIPSelection use the specific ip as source address for this connection
+func (ep *AzureTransportMethod) WithSrcIPSelection(localAddr net.IP) error {
 	ep.hClient = httpClientSrcIP(localAddr, nil)
 	return nil
 }
 
-func (ep *AzureTransportMethod) WithSrcIpAndProxySelection(localAddr net.IP,
+// WithSrcIPAndProxySelection use the specific ip as source address for this
+// connection and connect via the provided proxy URL
+func (ep *AzureTransportMethod) WithSrcIPAndProxySelection(localAddr net.IP,
 	proxy *url.URL) error {
 	ep.hClient = httpClientSrcIP(localAddr, proxy)
 	return nil

--- a/pkg/pillar/zedUpload/datastore_http.go
+++ b/pkg/pillar/zedUpload/datastore_http.go
@@ -5,11 +5,12 @@ package zedUpload
 
 import (
 	"fmt"
-	zedHttp "github.com/lf-edge/eve/pkg/pillar/zedUpload/httputil"
 	"net"
 	"net/http"
 	"net/url"
 	"time"
+
+	zedHttp "github.com/lf-edge/eve/pkg/pillar/zedUpload/httputil"
 )
 
 type HttpTransportMethod struct {
@@ -62,13 +63,15 @@ func (ep *HttpTransportMethod) Close() error {
 	return nil
 }
 
-// use the specific ip as source address for this connection
-func (ep *HttpTransportMethod) WithSrcIpSelection(localAddr net.IP) error {
+// WithSrcIPSelection use the specific ip as source address for this connection
+func (ep *HttpTransportMethod) WithSrcIPSelection(localAddr net.IP) error {
 	ep.hClient = httpClientSrcIP(localAddr, nil)
 	return nil
 }
 
-func (ep *HttpTransportMethod) WithSrcIpAndProxySelection(localAddr net.IP,
+// WithSrcIPAndProxySelection use the specific ip as source address for this
+// connection and connect via the provided proxy URL
+func (ep *HttpTransportMethod) WithSrcIPAndProxySelection(localAddr net.IP,
 	proxy *url.URL) error {
 	ep.hClient = httpClientSrcIP(localAddr, proxy)
 	return nil

--- a/pkg/pillar/zedUpload/datastore_sftp.go
+++ b/pkg/pillar/zedUpload/datastore_sftp.go
@@ -82,12 +82,14 @@ func (ep *SftpTransportMethod) Close() error {
 	return nil
 }
 
-// use the specific ip as source address for this connection
-func (ep *SftpTransportMethod) WithSrcIpSelection(localAddr net.IP) error {
+// WithSrcIPSelection use the specific ip as source address for this connection
+func (ep *SftpTransportMethod) WithSrcIPSelection(localAddr net.IP) error {
 	return fmt.Errorf("not supported")
 }
 
-func (ep *SftpTransportMethod) WithSrcIpAndProxySelection(localAddr net.IP,
+// WithSrcIPAndProxySelection use the specific ip as source address for this
+// connection and connect via the provided proxy URL
+func (ep *SftpTransportMethod) WithSrcIPAndProxySelection(localAddr net.IP,
 	proxy *url.URL) error {
 	return fmt.Errorf("not supported")
 }


### PR DESCRIPTION
This fixes some naming conventions so that lint passes. This wouldn't be necessary on its own - although a very good idea - but as #490 makes changes to some of these files, yetus raises it, so might as well fix it. It is better than creating exceptions there.