### PR TITLE
xl insist on requiring a no-op with-system-ovmf

### DIFF
--- a/pkg/xen-tools/Dockerfile
+++ b/pkg/xen-tools/Dockerfile
@@ -39,7 +39,8 @@ RUN mkdir -p /out
 COPY gmp.patch /xen/stubdom
 WORKDIR /xen
 RUN [ "$(uname -m)" = "x86_64" ] && FEATURES="--enable-stubdom --enable-vtpm-stubdom --enable-vtpmmgr-stubdom" ;\
-    ./configure --prefix=/usr --disable-xen --disable-qemu-traditional --disable-docs --enable-9pfs $FEATURES
+    ./configure --prefix=/usr --disable-xen --disable-qemu-traditional --disable-docs --enable-9pfs \
+                --with-system-ovmf=/usr/lib/xen/boot/ovmf.bin $FEATURES
 RUN make && make dist
 RUN dist/install.sh /out
 


### PR DESCRIPTION
This will enable UEFI HVM support

This will allow us to see how it compares against legacy BIOS (SeaBIOS) and whether we should potentially move to UEFI BIOS wholesale