### PR TITLE
Fixing eveimage-update issue due to PR#494

### DIFF
--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -192,16 +192,17 @@ fi
 P3=$(zboot partdev P3)
 P3_FS_TYPE=$(blkid "$P3"| awk '{print $3}' | sed 's/TYPE=//' | sed 's/"//g')
 if [ -c $TPM_DEVICE_PATH ] && ! [ -f $CONFIGDIR/disable-tpm ] && [ "$P3_FS_TYPE" = "ext4" ]; then
-    #It is a device with TPM, and formatted with ext4, go ahead with fscrypt
+    #It is a device with TPM, and formatted with ext4, setup fscrypt
+    echo "$(date -Ins -u) EXT4 partitioned $PERSISTDIR, enabling fscrypt"
     #Initialize fscrypt algorithm, hash length etc.
     $BINDIR/vaultmgr -c "$CURPART" setupVaults
+fi
 
-    #Migrate old installations to new location
-    if [ -f $PERSISTCONFIGDIR/tpm_in_use ]; then
-        echo "$(date -Ins -u) Moving tpm_in_use from $PERSISTCONFIGDIR to $CONFIGDIR"
-        mv $PERSISTCONFIGDIR/tpm_in_use $CONFIGDIR/tpm_in_use
-        sync
-    fi
+#Migrate old installations to new location
+if [ -f $PERSISTCONFIGDIR/tpm_in_use ]; then
+    echo "$(date -Ins -u) Copying tpm_in_use from $PERSISTCONFIGDIR to $CONFIGDIR"
+    cp -p $PERSISTCONFIGDIR/tpm_in_use $CONFIGDIR/tpm_in_use
+    sync
 fi
 
 if [ ! -d "$PERSIST_RKT_DATA_DIR" ]; then


### PR DESCRIPTION
- tpm_in_use is not copied to /config in case of ext3 formatted /persist.
- Corrected the same in this PR
- To take care of downgrade, changed move to copy as well.

Signed-off-by: Hariharasubramanian C S <cshari@zededa.com>