### PR TITLE
Get GlobalConfig to get loglevel/debug up front

### DIFF
--- a/pkg/pillar/cmd/baseosmgr/baseosmgr.go
+++ b/pkg/pillar/cmd/baseosmgr/baseosmgr.go
@@ -65,6 +65,7 @@ type baseOsMgrContext struct {
 
 	subGlobalConfig          *pubsub.Subscription
 	globalConfig             *types.GlobalConfig
+	GCInitialized            bool
 	subBaseOsConfig          *pubsub.Subscription
 	subZbootConfig           *pubsub.Subscription
 	subCertObjConfig         *pubsub.Subscription
@@ -131,6 +132,18 @@ func Run() {
 
 	// report other agents, about, zboot status availability
 	ctx.pubZbootStatus.SignalRestarted()
+
+	// Pick up debug aka log level before we start real work
+	for !ctx.GCInitialized {
+		log.Infof("waiting for GCInitialized")
+		select {
+		case change := <-ctx.subGlobalConfig.C:
+			ctx.subGlobalConfig.ProcessChange(change)
+		case <-stillRunning.C:
+		}
+		agentlog.StillRunning(agentName, warningTime, errorTime)
+	}
+	log.Infof("processed GlobalConfig")
 
 	// First we process the verifierStatus to avoid downloading
 	// an image we already have in place.
@@ -439,6 +452,7 @@ func handleGlobalConfigModify(ctxArg interface{}, key string,
 		debugOverride)
 	if gcp != nil {
 		ctx.globalConfig = gcp
+		ctx.GCInitialized = true
 	}
 	log.Infof("handleGlobalConfigModify done for %s\n", key)
 }

--- a/pkg/pillar/cmd/downloader/context.go
+++ b/pkg/pillar/cmd/downloader/context.go
@@ -26,6 +26,7 @@ type downloaderContext struct {
 	globalStatusLock        sync.Mutex
 	globalStatus            types.GlobalDownloadStatus
 	subGlobalConfig         *pubsub.Subscription
+	GCInitialized           bool
 }
 
 func (ctx *downloaderContext) registerHandlers() error {

--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -99,6 +99,18 @@ func Run() {
 		log.Fatal(err)
 	}
 
+	// Pick up debug aka log level before we start real work
+	for !ctx.GCInitialized {
+		log.Infof("waiting for GCInitialized")
+		select {
+		case change := <-ctx.subGlobalConfig.C:
+			ctx.subGlobalConfig.ProcessChange(change)
+		case <-stillRunning.C:
+		}
+		agentlog.StillRunning(agentName, warningTime, errorTime)
+	}
+	log.Infof("processed GlobalConfig")
+
 	// First wait to have some management ports with addresses
 	// Looking at any management ports since we can do baseOS download over all
 	// Also ensure GlobalDownloadConfig has been read

--- a/pkg/pillar/cmd/downloader/globalconfig.go
+++ b/pkg/pillar/cmd/downloader/globalconfig.go
@@ -28,6 +28,7 @@ func handleGlobalConfigModify(ctxArg interface{}, key string,
 		if gcp.DownloadRetryTime != 0 {
 			downloadRetryTime = time.Duration(gcp.DownloadRetryTime) * time.Second
 		}
+		ctx.GCInitialized = true
 	}
 	log.Infof("handleGlobalConfigModify done for %s\n", key)
 }

--- a/pkg/pillar/cmd/logmanager/logmanager.go
+++ b/pkg/pillar/cmd/logmanager/logmanager.go
@@ -69,6 +69,7 @@ type logmanagerContext struct {
 	subGlobalConfig *pubsub.Subscription
 	globalConfig    *types.GlobalConfig
 	subDomainStatus *pubsub.Subscription
+	GCInitialized   bool
 }
 
 // Set from Makefile
@@ -238,6 +239,18 @@ func Run() {
 	subDeviceNetworkStatus.DeleteHandler = handleDNSDelete
 	DNSctx.subDeviceNetworkStatus = subDeviceNetworkStatus
 	subDeviceNetworkStatus.Activate()
+
+	// Pick up debug aka log level before we start real work
+	for !logmanagerCtx.GCInitialized {
+		log.Infof("waiting for GCInitialized")
+		select {
+		case change := <-subGlobalConfig.C:
+			subGlobalConfig.ProcessChange(change)
+		case <-stillRunning.C:
+		}
+		agentlog.StillRunning(agentName, warningTime, errorTime)
+	}
+	log.Infof("processed GlobalConfig")
 
 	log.Infof("Waiting until we have some management ports with usable addresses\n")
 	for DNSctx.usableAddressCount == 0 && !force {
@@ -1042,6 +1055,7 @@ func handleGlobalConfigModify(ctxArg interface{}, key string,
 		agentName, debugOverride)
 	if gcp != nil {
 		ctx.globalConfig = gcp
+		ctx.GCInitialized = true
 	}
 	foundAgents := make(map[string]bool)
 	if status.DefaultRemoteLogLevel != "" {

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -253,6 +253,7 @@ func Run() {
 			subGlobalConfig.ProcessChange(change)
 		}
 	}
+	log.Infof("processed GlobalConfig")
 
 	// We refresh the gelocation information when the underlay
 	// IP address(es) change, plus periodically based on this timer

--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -185,10 +185,10 @@ func Run() {
 		nodeagentCtx.updateInprogress)
 	publishNodeAgentStatus(&nodeagentCtx)
 
-	// Read the GlobalConfig first
-	// Wait for initial GlobalConfig
+	// Pick up debug aka log level before we start real work
 	log.Infof("Waiting for GCInitialized\n")
 	for !nodeagentCtx.GCInitialized {
+		log.Infof("waiting for GCInitialized")
 		select {
 		case change := <-subGlobalConfig.C:
 			subGlobalConfig.ProcessChange(change)
@@ -200,6 +200,7 @@ func Run() {
 		}
 		agentlog.StillRunning(agentName, warningTime, errorTime)
 	}
+	log.Infof("processed GlobalConfig")
 
 	// when the partition status is inprogress state
 	// check network connectivity for 300 seconds

--- a/pkg/pillar/cmd/verifier/verifier.go
+++ b/pkg/pillar/cmd/verifier/verifier.go
@@ -74,6 +74,7 @@ type verifierContext struct {
 	subAssignableAdapters *pubsub.Subscription
 	gc                    *time.Ticker
 	RktGCGracePeriod      uint32
+	GCInitialized         bool
 }
 
 var debug = false
@@ -190,6 +191,18 @@ func Run() {
 	ctx.subAssignableAdapters = subAssignableAdapters
 	subAssignableAdapters.Activate()
 
+	// Pick up debug aka log level before we start real work
+	for !ctx.GCInitialized {
+		log.Infof("waiting for GCInitialized")
+		select {
+		case change := <-subGlobalConfig.C:
+			subGlobalConfig.ProcessChange(change)
+		case <-stillRunning.C:
+		}
+		agentlog.StillRunning(agentName, warningTime, errorTime)
+	}
+	log.Infof("processed GlobalConfig")
+
 	// Publish status for any objects that were verified before reboot
 	// The signatures will be re-checked during handleModify for App images.
 	handleInit(&ctx)
@@ -296,6 +309,7 @@ func handleInitWorkinProgressObjects(ctx *verifierContext) {
 }
 
 // Recreate status files for verified objects as types.DOWNLOADED
+// except containers which we mark as types.DELIVERED
 func handleInitVerifiedObjects(ctx *verifierContext) {
 
 	for _, objType := range verifierObjTypes {
@@ -1167,11 +1181,14 @@ func handleGlobalConfigModify(ctxArg interface{}, key string,
 	var gcp *types.GlobalConfig
 	debug, gcp = agentlog.HandleGlobalConfig(ctx.subGlobalConfig, agentName,
 		debugOverride)
-	if gcp != nil && gcp.DownloadGCTime != 0 {
-		downloadGCTime = time.Duration(gcp.DownloadGCTime) * time.Second
+	if gcp != nil {
+		if gcp.DownloadGCTime != 0 {
+			downloadGCTime = time.Duration(gcp.DownloadGCTime) * time.Second
+		}
 		if gcp.RktGCGracePeriod != 0 {
 			ctx.RktGCGracePeriod = gcp.RktGCGracePeriod
 		}
+		ctx.GCInitialized = true
 	}
 	log.Infof("handleGlobalConfigModify done for %s\n", key)
 }

--- a/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
+++ b/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
@@ -42,6 +42,7 @@ type DNSContext struct {
 
 type wstunnelclientContext struct {
 	subGlobalConfig      *pubsub.Subscription
+	GCInitialized        bool
 	subAppInstanceConfig *pubsub.Subscription
 	serverNameAndPort    string
 	wstunnelclient       *zedcloud.WSTunnelClient
@@ -140,6 +141,18 @@ func Run() {
 
 	subAppInstanceConfig.Activate()
 
+	// Pick up debug aka log level before we start real work
+	for !wscCtx.GCInitialized {
+		log.Infof("waiting for GCInitialized")
+		select {
+		case change := <-subGlobalConfig.C:
+			subGlobalConfig.ProcessChange(change)
+		case <-stillRunning.C:
+		}
+		agentlog.StillRunning(agentName, warningTime, errorTime)
+	}
+	log.Infof("processed GlobalConfig")
+
 	wscCtx.dnsContext = &DNSctx
 	// Wait for knowledge about IP addresses. XXX needed?
 	for !DNSctx.DNSinitialized {
@@ -180,8 +193,12 @@ func handleGlobalConfigModify(ctxArg interface{}, key string,
 		return
 	}
 	log.Infof("handleGlobalConfigModify for %s\n", key)
-	debug, _ = agentlog.HandleGlobalConfig(ctx.subGlobalConfig, agentName,
+	var gcp *types.GlobalConfig
+	debug, gcp = agentlog.HandleGlobalConfig(ctx.subGlobalConfig, agentName,
 		debugOverride)
+	if gcp != nil {
+		ctx.GCInitialized = true
+	}
 	log.Infof("handleGlobalConfigModify done for %s\n", key)
 }
 

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -535,8 +535,7 @@ func Run() {
 	zedagentCtx.subDevicePortConfigList = subDevicePortConfigList
 	subDevicePortConfigList.Activate()
 
-	// Read the GlobalConfig first
-	// Wait for initial GlobalConfig
+	// Pick up debug aka log level before we start real work
 	for !zedagentCtx.GCInitialized {
 		log.Infof("Waiting for GCInitialized\n")
 		select {
@@ -547,6 +546,7 @@ func Run() {
 			getconfigCtx.subNodeAgentStatus.ProcessChange(change)
 		}
 	}
+	log.Infof("processed GlobalConfig")
 
 	// wait till, zboot status is ready
 	for !zedagentCtx.zbootRestarted {

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -69,6 +69,7 @@ type zedrouterContext struct {
 	deviceNetworkStatus    *types.DeviceNetworkStatus
 	ready                  bool
 	subGlobalConfig        *pubsub.Subscription
+	GCInitialized          bool
 	pubUuidToNum           *pubsub.Publication
 	dhcpLeases             []dnsmasqLease
 
@@ -249,6 +250,18 @@ func Run() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// Pick up debug aka log level before we start real work
+	for !zedrouterCtx.GCInitialized {
+		log.Infof("waiting for GCInitialized")
+		select {
+		case change := <-subGlobalConfig.C:
+			subGlobalConfig.ProcessChange(change)
+		case <-stillRunning.C:
+		}
+		agentlog.StillRunning(agentName, warningTime, errorTime)
+	}
+	log.Infof("processed GlobalConfig")
 
 	appNumAllocatorInit(&zedrouterCtx)
 	bridgeNumAllocatorInit(&zedrouterCtx)
@@ -2753,8 +2766,12 @@ func handleGlobalConfigModify(ctxArg interface{}, key string,
 		return
 	}
 	log.Infof("handleGlobalConfigModify for %s\n", key)
-	debug, _ = agentlog.HandleGlobalConfig(ctx.subGlobalConfig, agentName,
+	var gcp *types.GlobalConfig
+	debug, gcp = agentlog.HandleGlobalConfig(ctx.subGlobalConfig, agentName,
 		debugOverride)
+	if gcp != nil {
+		ctx.GCInitialized = true
+	}
 	log.Infof("handleGlobalConfigModify done for %s\n", key)
 }
 

--- a/pkg/pillar/devicenetwork/pbr.go
+++ b/pkg/pillar/devicenetwork/pbr.go
@@ -63,7 +63,7 @@ func FlushRules(ifindex int) {
 		}
 		log.Infof("FlushRules: RuleDel %v", r)
 		if err := netlink.RuleDel(&r); err != nil {
-			log.Fatalf("FlushRules - RuleDel %v failed %s",
+			log.Errorf("FlushRules - RuleDel %v failed %s",
 				r, err)
 		}
 	}


### PR DESCRIPTION
@deitch ran into this when debugging verifier. Adding it uniformly to all the agents which use GlobalConfig

Also, tripped on a nim watchdog when testing this. Never seen that before.