### PR TITLE
Reverting the change to migrate fscrypt keys

### DIFF
--- a/pkg/pillar/cmd/vaultmgr/vaultmgr.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgr.go
@@ -277,7 +277,7 @@ func unlockVault(vaultPath string, cloudKeyOnlyMode bool) error {
 
 //createVault expects an empty, existing dir at vaultPath
 func createVault(vaultPath string) error {
-	if err := stageKey(false, keyDir, keyFile); err != nil {
+	if err := stageKey(true, keyDir, keyFile); err != nil {
 		return err
 	}
 	defer unstageKey(keyDir, keyFile)
@@ -313,7 +313,7 @@ func setupVault(vaultPath string) error {
 		if err := unlockVault(vaultPath, true); err != nil {
 			return err
 		}
-		return changeProtector(vaultPath)
+		//return changeProtector(vaultPath)
 	}
 	return nil
 }

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -192,16 +192,17 @@ fi
 P3=$(zboot partdev P3)
 P3_FS_TYPE=$(blkid "$P3"| awk '{print $3}' | sed 's/TYPE=//' | sed 's/"//g')
 if [ -c $TPM_DEVICE_PATH ] && ! [ -f $CONFIGDIR/disable-tpm ] && [ "$P3_FS_TYPE" = "ext4" ]; then
-    #It is a device with TPM, and formatted with ext4, go ahead with fscrypt
+    #It is a device with TPM, and formatted with ext4, setup fscrypt
+    echo "$(date -Ins -u) EXT4 partitioned $PERSISTDIR, enabling fscrypt"
     #Initialize fscrypt algorithm, hash length etc.
     $BINDIR/vaultmgr -c "$CURPART" setupVaults
+fi
 
-    #Migrate old installations to new location
-    if [ -f $PERSISTCONFIGDIR/tpm_in_use ]; then
-        echo "$(date -Ins -u) Moving tpm_in_use from $PERSISTCONFIGDIR to $CONFIGDIR"
-        mv $PERSISTCONFIGDIR/tpm_in_use $CONFIGDIR/tpm_in_use
-        sync
-    fi
+#Migrate old installations to new location
+if [ -f $PERSISTCONFIGDIR/tpm_in_use ]; then
+    echo "$(date -Ins -u) Copying tpm_in_use from $PERSISTCONFIGDIR to $CONFIGDIR"
+    cp -p $PERSISTCONFIGDIR/tpm_in_use $CONFIGDIR/tpm_in_use
+    sync
 fi
 
 if [ ! -d "$PERSIST_RKT_DATA_DIR" ]; then


### PR DESCRIPTION
- Reverting it for now, as this breaks downward image compatibility on EXT4 systems
- Currently, with the changes proposed in this PR,
   - device tries both the keys to unlock the vault (this will set the stage for future changes)
   - but never changes the existing keys to new one
   - once current release goes out, we can add key migration in the next release
   - the path to image upgrade to next release will be to go through the
     upcoming release, and not do a direct upgrade to the next release