### PR TITLE
Fixing instance format in xen config file

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1618,7 +1618,7 @@ func configToXencfg(config types.DomainConfig, status types.DomainStatus,
 			access = "ro"
 		}
 		oneDisk := fmt.Sprintf("'%s,%s,%s,%s'",
-			ds.ActiveFileLocation, ds.Format, ds.Vdev, access)
+			ds.ActiveFileLocation, strings.ToLower(ds.Format.String()), ds.Vdev, access)
 		log.Debugf("Processing disk %d: %s\n", i, oneDisk)
 		if diskString == "" {
 			diskString = oneDisk


### PR DESCRIPTION
Because of https://github.com/lf-edge/eve/pull/505, deployment of VM instance is failing with the following error:

xl create failed: Parsing config from /var/run/domainmgr/xen/xen2.cfg\n/var/run/domainmgr/xen/xen2.cfg: config parsing error in disk specification: unknown value for format: near `QCOW2' in `/persist/img/EFA50C64CAACF8D43F334A05F8048F39A27FEA26FC1D155F2543D38D13176C17-8fbd54bc-0130-4b1f-a842-c72e6b68bf68.qcow2,QCOW2,xvda,rw'\n\n
