### PR TITLE
Getting rid of using tpm_in_use file.

### DIFF
--- a/pkg/pillar/cmd/tpmmgr/tpmmgr.go
+++ b/pkg/pillar/cmd/tpmmgr/tpmmgr.go
@@ -31,9 +31,6 @@ const (
 	//TpmDevicePath is the TPM device file path
 	TpmDevicePath = "/dev/tpmrm0"
 
-	//TpmEnabledFile is the file to indicate if TPM is being used by SW
-	TpmEnabledFile = types.IdentityDirname + "/tpm_in_use"
-
 	//TpmDeviceKeyHdl is the well known TPM permanent handle for device key
 	TpmDeviceKeyHdl tpmutil.Handle = 0x817FFFFF
 
@@ -97,10 +94,14 @@ var vendorRegistry = map[uint32]string{
 	0x474F4F47: "Google",
 }
 
-//IsTpmEnabled checks if TPM is being used by SW
+func fileExists(filename string) bool {
+	_, err := os.Stat(filename)
+	return err == nil
+}
+
+//IsTpmEnabled checks if TPM is being used by SW for creating device cert
 func IsTpmEnabled() bool {
-	_, err := os.Stat(TpmEnabledFile)
-	return (err == nil)
+	return fileExists(types.DeviceCertName) && !fileExists(types.DeviceKeyName)
 }
 
 func createDeviceKey() error {

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -6,7 +6,6 @@
 USE_HW_WATCHDOG=1
 CONFIGDIR=/config
 PERSISTDIR=/persist
-PERSISTCONFIGDIR=/persist/config
 PERSIST_RKT_DATA_DIR=$PERSISTDIR/rkt
 BINDIR=/opt/zededa/bin
 TMPDIR=/var/tmp/zededa
@@ -195,13 +194,6 @@ if [ -c $TPM_DEVICE_PATH ] && ! [ -f $CONFIGDIR/disable-tpm ] && [ "$P3_FS_TYPE"
     echo "$(date -Ins -u) EXT4 partitioned $PERSISTDIR, enabling fscrypt"
     #Initialize fscrypt algorithm, hash length etc.
     $BINDIR/vaultmgr -c "$CURPART" setupVaults
-fi
-
-#Migrate old installations to new location
-if [ -f $PERSISTCONFIGDIR/tpm_in_use ]; then
-    echo "$(date -Ins -u) Copying tpm_in_use from $PERSISTCONFIGDIR to $CONFIGDIR"
-    cp -p $PERSISTCONFIGDIR/tpm_in_use $CONFIGDIR/tpm_in_use
-    sync
 fi
 
 if [ ! -d "$PERSIST_RKT_DATA_DIR" ]; then
@@ -432,20 +424,9 @@ if [ ! -f $CONFIGDIR/device.cert.pem ]; then
         echo "$(date -Ins -u) TPM device is present and allowed, creating TPM based device key"
         if ! $BINDIR/generate-device.sh -b $CONFIGDIR/device -t; then
             echo "$(date -Ins -u) TPM is malfunctioning, falling back to software certs"
-            rm -f $CONFIGDIR/tpm_in_use
-            sync
-            blockdev --flushbufs "$CONFIGDEV"
             $BINDIR/generate-device.sh -b $CONFIGDIR/device
-        else
-            touch $CONFIGDIR/tpm_in_use
-            sync
-            blockdev --flushbufs "$CONFIGDEV"
         fi
     else
-        #Just in case, it got disabled in BIOS later on.
-        rm -f $CONFIGDIR/tpm_in_use
-        sync
-        blockdev --flushbufs "$CONFIGDEV"
         $BINDIR/generate-device.sh -b $CONFIGDIR/device
     fi
     # Reduce chance that we register with controller and crash before
@@ -535,7 +516,7 @@ if [ ! -d $LISPDIR ]; then
     exit 1
 fi
 
-if ! [ -f $CONFIGDIR/tpm_in_use ]; then
+if [ -f $CONFIGDIR/device.key.pem ]; then
     # Need a key for device-to-device map-requests
     cp -p $CONFIGDIR/device.key.pem $LISPDIR/lisp-sig.pem
 fi


### PR DESCRIPTION
Whether TPM is being used or not is derived from
the presence of device.cert.pem and absence of
device.key.pem

Signed-off-by: Hariharasubramanian C S <cshari@zededa.com>