### PR TITLE
Pubsub interface update

### DIFF
--- a/pkg/pillar/cmd/baseosmgr/baseosmgr.go
+++ b/pkg/pillar/cmd/baseosmgr/baseosmgr.go
@@ -502,15 +502,16 @@ func initializeGlobalConfigHandles(ctx *baseOsMgrContext) {
 
 	// Look for global config such as log levels
 	subGlobalConfig, err := pubsub.Subscribe("", types.GlobalConfig{},
-		false, ctx)
+		false, ctx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleGlobalConfigModify,
+			ModifyHandler: handleGlobalConfigModify,
+			DeleteHandler: handleGlobalConfigDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subGlobalConfig.MaxProcessTimeWarn = warningTime
-	subGlobalConfig.MaxProcessTimeError = errorTime
-	subGlobalConfig.ModifyHandler = handleGlobalConfigModify
-	subGlobalConfig.CreateHandler = handleGlobalConfigModify
-	subGlobalConfig.DeleteHandler = handleGlobalConfigDelete
 	ctx.subGlobalConfig = subGlobalConfig
 	subGlobalConfig.Activate()
 }
@@ -518,28 +519,30 @@ func initializeGlobalConfigHandles(ctx *baseOsMgrContext) {
 func initializeNodeAgentHandles(ctx *baseOsMgrContext) {
 	// Look for NodeAgentStatus, from zedagent
 	subNodeAgentStatus, err := pubsub.Subscribe("nodeagent",
-		types.NodeAgentStatus{}, false, ctx)
+		types.NodeAgentStatus{}, false, ctx, &pubsub.SubscriptionOptions{
+			ModifyHandler: handleNodeAgentStatusModify,
+			DeleteHandler: handleNodeAgentStatusDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subNodeAgentStatus.MaxProcessTimeWarn = warningTime
-	subNodeAgentStatus.MaxProcessTimeError = errorTime
-	subNodeAgentStatus.ModifyHandler = handleNodeAgentStatusModify
-	subNodeAgentStatus.DeleteHandler = handleNodeAgentStatusDelete
 	ctx.subNodeAgentStatus = subNodeAgentStatus
 	subNodeAgentStatus.Activate()
 
 	// Look for ZbootConfig, from nodeagent
 	subZbootConfig, err := pubsub.Subscribe("nodeagent",
-		types.ZbootConfig{}, false, ctx)
+		types.ZbootConfig{}, false, ctx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleZbootConfigModify,
+			ModifyHandler: handleZbootConfigModify,
+			DeleteHandler: handleZbootConfigDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subZbootConfig.MaxProcessTimeWarn = warningTime
-	subZbootConfig.MaxProcessTimeError = errorTime
-	subZbootConfig.ModifyHandler = handleZbootConfigModify
-	subZbootConfig.CreateHandler = handleZbootConfigModify
-	subZbootConfig.DeleteHandler = handleZbootConfigDelete
 	ctx.subZbootConfig = subZbootConfig
 	subZbootConfig.Activate()
 }
@@ -547,29 +550,31 @@ func initializeNodeAgentHandles(ctx *baseOsMgrContext) {
 func initializeZedagentHandles(ctx *baseOsMgrContext) {
 	// Look for BaseOsConfig , from zedagent
 	subBaseOsConfig, err := pubsub.Subscribe("zedagent",
-		types.BaseOsConfig{}, false, ctx)
+		types.BaseOsConfig{}, false, ctx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleBaseOsCreate,
+			ModifyHandler: handleBaseOsModify,
+			DeleteHandler: handleBaseOsConfigDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subBaseOsConfig.MaxProcessTimeWarn = warningTime
-	subBaseOsConfig.MaxProcessTimeError = errorTime
-	subBaseOsConfig.ModifyHandler = handleBaseOsModify
-	subBaseOsConfig.CreateHandler = handleBaseOsCreate
-	subBaseOsConfig.DeleteHandler = handleBaseOsConfigDelete
 	ctx.subBaseOsConfig = subBaseOsConfig
 	subBaseOsConfig.Activate()
 
 	// Look for CertObjConfig, from zedagent
 	subCertObjConfig, err := pubsub.Subscribe("zedagent",
-		types.CertObjConfig{}, false, ctx)
+		types.CertObjConfig{}, false, ctx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleCertObjCreate,
+			ModifyHandler: handleCertObjModify,
+			DeleteHandler: handleCertObjConfigDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subCertObjConfig.MaxProcessTimeWarn = warningTime
-	subCertObjConfig.MaxProcessTimeError = errorTime
-	subCertObjConfig.ModifyHandler = handleCertObjModify
-	subCertObjConfig.CreateHandler = handleCertObjCreate
-	subCertObjConfig.DeleteHandler = handleCertObjConfigDelete
 	ctx.subCertObjConfig = subCertObjConfig
 	subCertObjConfig.Activate()
 }
@@ -577,29 +582,31 @@ func initializeZedagentHandles(ctx *baseOsMgrContext) {
 func initializeDownloaderHandles(ctx *baseOsMgrContext) {
 	// Look for BaseOs DownloaderStatus from downloader
 	subBaseOsDownloadStatus, err := pubsub.SubscribeScope("downloader",
-		types.BaseOsObj, types.DownloaderStatus{}, false, ctx)
+		types.BaseOsObj, types.DownloaderStatus{}, false, ctx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleDownloadStatusModify,
+			ModifyHandler: handleDownloadStatusModify,
+			DeleteHandler: handleDownloadStatusDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subBaseOsDownloadStatus.MaxProcessTimeWarn = warningTime
-	subBaseOsDownloadStatus.MaxProcessTimeError = errorTime
-	subBaseOsDownloadStatus.ModifyHandler = handleDownloadStatusModify
-	subBaseOsDownloadStatus.CreateHandler = handleDownloadStatusModify
-	subBaseOsDownloadStatus.DeleteHandler = handleDownloadStatusDelete
 	ctx.subBaseOsDownloadStatus = subBaseOsDownloadStatus
 	subBaseOsDownloadStatus.Activate()
 
 	// Look for Certs DownloaderStatus from downloader
 	subCertObjDownloadStatus, err := pubsub.SubscribeScope("downloader",
-		types.CertObj, types.DownloaderStatus{}, false, ctx)
+		types.CertObj, types.DownloaderStatus{}, false, ctx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleDownloadStatusModify,
+			ModifyHandler: handleDownloadStatusModify,
+			DeleteHandler: handleDownloadStatusDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subCertObjDownloadStatus.MaxProcessTimeWarn = warningTime
-	subCertObjDownloadStatus.MaxProcessTimeError = errorTime
-	subCertObjDownloadStatus.ModifyHandler = handleDownloadStatusModify
-	subCertObjDownloadStatus.CreateHandler = handleDownloadStatusModify
-	subCertObjDownloadStatus.DeleteHandler = handleDownloadStatusDelete
 	ctx.subCertObjDownloadStatus = subCertObjDownloadStatus
 	subCertObjDownloadStatus.Activate()
 
@@ -608,16 +615,16 @@ func initializeDownloaderHandles(ctx *baseOsMgrContext) {
 func initializeVerifierHandles(ctx *baseOsMgrContext) {
 	// Look for VerifyImageStatus from verifier
 	subBaseOsVerifierStatus, err := pubsub.SubscribeScope("verifier",
-		types.BaseOsObj, types.VerifyImageStatus{}, false, ctx)
+		types.BaseOsObj, types.VerifyImageStatus{}, false, ctx, &pubsub.SubscriptionOptions{
+			CreateHandler:  handleVerifierStatusModify,
+			ModifyHandler:  handleVerifierStatusModify,
+			RestartHandler: handleVerifierRestarted,
+			WarningTime:    warningTime,
+			ErrorTime:      errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subBaseOsVerifierStatus.MaxProcessTimeWarn = warningTime
-	subBaseOsVerifierStatus.MaxProcessTimeError = errorTime
-	subBaseOsVerifierStatus.ModifyHandler = handleVerifierStatusModify
-	subBaseOsVerifierStatus.CreateHandler = handleVerifierStatusModify
-	subBaseOsVerifierStatus.DeleteHandler = handleVerifierStatusDelete
-	subBaseOsVerifierStatus.RestartHandler = handleVerifierRestarted
 	ctx.subBaseOsVerifierStatus = subBaseOsVerifierStatus
 	subBaseOsVerifierStatus.Activate()
 }

--- a/pkg/pillar/cmd/dataplane/dataplane.go
+++ b/pkg/pillar/cmd/dataplane/dataplane.go
@@ -225,29 +225,31 @@ func initPubsubChannels() *dptypes.DataplaneContext {
 	dataplaneContext.PubLispMetrics = pubLispMetrics
 
 	subLispConfig, err := pubsub.Subscribe("zedrouter",
-		types.LispDataplaneConfig{}, false, dataplaneContext)
+		types.LispDataplaneConfig{}, false, dataplaneContext, &pubsub.SubscriptionOptions{
+			CreateHandler: handleExpModify,
+			ModifyHandler: handleExpModify,
+			DeleteHandler: handleExpDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subLispConfig.MaxProcessTimeWarn = warningTime
-	subLispConfig.MaxProcessTimeError = errorTime
-	subLispConfig.ModifyHandler = handleExpModify
-	subLispConfig.CreateHandler = handleExpModify
-	subLispConfig.DeleteHandler = handleExpDelete
 	dataplaneContext.SubLispConfig = subLispConfig
 	subLispConfig.Activate()
 
 	// Look for global config like debug
 	subGlobalConfig, err := pubsub.Subscribe("",
-		types.GlobalConfig{}, false, dataplaneContext)
+		types.GlobalConfig{}, false, dataplaneContext, &pubsub.SubscriptionOptions{
+			CreateHandler: handleGlobalConfigModify,
+			ModifyHandler: handleGlobalConfigModify,
+			DeleteHandler: handleGlobalConfigDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subGlobalConfig.MaxProcessTimeWarn = warningTime
-	subGlobalConfig.MaxProcessTimeError = errorTime
-	subGlobalConfig.ModifyHandler = handleGlobalConfigModify
-	subGlobalConfig.CreateHandler = handleGlobalConfigModify
-	subGlobalConfig.DeleteHandler = handleGlobalConfigDelete
 	dataplaneContext.SubGlobalConfig = subGlobalConfig
 	subGlobalConfig.Activate()
 
@@ -416,14 +418,15 @@ func handleConfig(c *net.UnixConn, dpContext *dptypes.DataplaneContext) {
 	defer c.Close()
 
 	subDeviceNetworkStatus, err := pubsub.Subscribe("nim",
-		types.DeviceNetworkStatus{}, false, nil)
+		types.DeviceNetworkStatus{}, false, nil, &pubsub.SubscriptionOptions{
+			ModifyHandler: handleDNSModify,
+			DeleteHandler: handleDNSDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subDeviceNetworkStatus.MaxProcessTimeWarn = warningTime
-	subDeviceNetworkStatus.MaxProcessTimeError = errorTime
-	subDeviceNetworkStatus.ModifyHandler = handleDNSModify
-	subDeviceNetworkStatus.DeleteHandler = handleDNSDelete
 	dpContext.SubDeviceNetworkStatus = subDeviceNetworkStatus
 	subDeviceNetworkStatus.Activate()
 
@@ -431,7 +434,7 @@ func handleConfig(c *net.UnixConn, dpContext *dptypes.DataplaneContext) {
 	buf := make([]byte, 8192)
 	for {
 		select {
-		case change := <-subDeviceNetworkStatus.C:
+		case change := <-subDeviceNetworkStatus.MsgChan():
 			subDeviceNetworkStatus.ProcessChange(change)
 			log.Debugf("handleConfig: Detected a change in DeviceNetworkStatus")
 			ManageEtrDNS(deviceNetworkStatus)

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -220,28 +220,30 @@ func Run() {
 
 	// Look for global config such as log levels
 	subGlobalConfig, err := pubsub.Subscribe("", types.GlobalConfig{},
-		false, &domainCtx)
+		false, &domainCtx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleGlobalConfigModify,
+			ModifyHandler: handleGlobalConfigModify,
+			DeleteHandler: handleGlobalConfigDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subGlobalConfig.MaxProcessTimeWarn = warningTime
-	subGlobalConfig.MaxProcessTimeError = errorTime
-	subGlobalConfig.ModifyHandler = handleGlobalConfigModify
-	subGlobalConfig.CreateHandler = handleGlobalConfigModify
-	subGlobalConfig.DeleteHandler = handleGlobalConfigDelete
 	domainCtx.subGlobalConfig = subGlobalConfig
 	subGlobalConfig.Activate()
 
 	subDeviceNetworkStatus, err := pubsub.Subscribe("nim",
-		types.DeviceNetworkStatus{}, false, &domainCtx)
+		types.DeviceNetworkStatus{}, false, &domainCtx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleDNSModify,
+			ModifyHandler: handleDNSModify,
+			DeleteHandler: handleDNSDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subDeviceNetworkStatus.MaxProcessTimeWarn = warningTime
-	subDeviceNetworkStatus.MaxProcessTimeError = errorTime
-	subDeviceNetworkStatus.ModifyHandler = handleDNSModify
-	subDeviceNetworkStatus.CreateHandler = handleDNSModify
-	subDeviceNetworkStatus.DeleteHandler = handleDNSDelete
 	domainCtx.subDeviceNetworkStatus = subDeviceNetworkStatus
 	subDeviceNetworkStatus.Activate()
 
@@ -249,7 +251,7 @@ func Run() {
 	for !domainCtx.GCInitialized {
 		log.Infof("waiting for GCInitialized")
 		select {
-		case change := <-subGlobalConfig.C:
+		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
 		case <-stillRunning.C:
 		}
@@ -263,10 +265,10 @@ func Run() {
 
 		log.Infof("Waiting for DeviceNetworkStatus init\n")
 		select {
-		case change := <-subGlobalConfig.C:
+		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
 
-		case change := <-subDeviceNetworkStatus.C:
+		case change := <-subDeviceNetworkStatus.MsgChan():
 			subDeviceNetworkStatus.ProcessChange(change)
 		case <-stillRunning.C:
 		}
@@ -275,15 +277,16 @@ func Run() {
 
 	// Subscribe to PhysicalIOAdapterList from zedagent
 	subPhysicalIOAdapter, err := pubsub.Subscribe("zedagent",
-		types.PhysicalIOAdapterList{}, false, &domainCtx)
+		types.PhysicalIOAdapterList{}, false, &domainCtx, &pubsub.SubscriptionOptions{
+			CreateHandler: handlePhysicalIOAdapterListCreateModify,
+			ModifyHandler: handlePhysicalIOAdapterListCreateModify,
+			DeleteHandler: handlePhysicalIOAdapterListDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subPhysicalIOAdapter.MaxProcessTimeWarn = warningTime
-	subPhysicalIOAdapter.MaxProcessTimeError = errorTime
-	subPhysicalIOAdapter.CreateHandler = handlePhysicalIOAdapterListCreateModify
-	subPhysicalIOAdapter.ModifyHandler = handlePhysicalIOAdapterListCreateModify
-	subPhysicalIOAdapter.DeleteHandler = handlePhysicalIOAdapterListDelete
 	domainCtx.subPhysicalIOAdapter = subPhysicalIOAdapter
 	subPhysicalIOAdapter.Activate()
 
@@ -291,13 +294,13 @@ func Run() {
 	for !domainCtx.assignableAdapters.Initialized {
 		log.Infof("Waiting for AssignableAdapters")
 		select {
-		case change := <-subGlobalConfig.C:
+		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
 
-		case change := <-subDeviceNetworkStatus.C:
+		case change := <-subDeviceNetworkStatus.MsgChan():
 			subDeviceNetworkStatus.ProcessChange(change)
 
-		case change := <-subPhysicalIOAdapter.C:
+		case change := <-subPhysicalIOAdapter.MsgChan():
 			subPhysicalIOAdapter.ProcessChange(change)
 
 		// Run stillRunning since we waiting for zedagent to deliver
@@ -310,16 +313,17 @@ func Run() {
 
 	// Subscribe to DomainConfig from zedmanager
 	subDomainConfig, err := pubsub.Subscribe("zedmanager",
-		types.DomainConfig{}, false, &domainCtx)
+		types.DomainConfig{}, false, &domainCtx, &pubsub.SubscriptionOptions{
+			CreateHandler:  handleDomainCreate,
+			ModifyHandler:  handleDomainModify,
+			DeleteHandler:  handleDomainDelete,
+			RestartHandler: handleRestart,
+			WarningTime:    warningTime,
+			ErrorTime:      errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subDomainConfig.MaxProcessTimeWarn = warningTime
-	subDomainConfig.MaxProcessTimeError = errorTime
-	subDomainConfig.ModifyHandler = handleDomainModify
-	subDomainConfig.CreateHandler = handleDomainCreate
-	subDomainConfig.DeleteHandler = handleDomainDelete
-	subDomainConfig.RestartHandler = handleRestart
 	domainCtx.subDomainConfig = subDomainConfig
 	subDomainConfig.Activate()
 
@@ -332,16 +336,16 @@ func Run() {
 
 	for {
 		select {
-		case change := <-subGlobalConfig.C:
+		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
 
-		case change := <-subDomainConfig.C:
+		case change := <-subDomainConfig.MsgChan():
 			subDomainConfig.ProcessChange(change)
 
-		case change := <-subDeviceNetworkStatus.C:
+		case change := <-subDeviceNetworkStatus.MsgChan():
 			subDeviceNetworkStatus.ProcessChange(change)
 
-		case change := <-subPhysicalIOAdapter.C:
+		case change := <-subPhysicalIOAdapter.MsgChan():
 			subPhysicalIOAdapter.ProcessChange(change)
 
 		case <-gc.C:

--- a/pkg/pillar/cmd/downloader/context.go
+++ b/pkg/pillar/cmd/downloader/context.go
@@ -32,40 +32,43 @@ type downloaderContext struct {
 func (ctx *downloaderContext) registerHandlers() error {
 	// Look for global config such as log levels
 	subGlobalConfig, err := pubsub.Subscribe("", types.GlobalConfig{},
-		false, ctx)
+		false, ctx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleGlobalConfigModify,
+			ModifyHandler: handleGlobalConfigModify,
+			DeleteHandler: handleGlobalConfigDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		return err
 	}
-	subGlobalConfig.MaxProcessTimeWarn = warningTime
-	subGlobalConfig.MaxProcessTimeError = errorTime
-	subGlobalConfig.ModifyHandler = handleGlobalConfigModify
-	subGlobalConfig.CreateHandler = handleGlobalConfigModify
-	subGlobalConfig.DeleteHandler = handleGlobalConfigDelete
 	ctx.subGlobalConfig = subGlobalConfig
 	subGlobalConfig.Activate()
 
 	subDeviceNetworkStatus, err := pubsub.Subscribe("nim",
-		types.DeviceNetworkStatus{}, false, ctx)
+		types.DeviceNetworkStatus{}, false, ctx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleDNSModify,
+			ModifyHandler: handleDNSModify,
+			DeleteHandler: handleDNSDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		return err
 	}
-	subDeviceNetworkStatus.MaxProcessTimeWarn = warningTime
-	subDeviceNetworkStatus.MaxProcessTimeError = errorTime
-	subDeviceNetworkStatus.ModifyHandler = handleDNSModify
-	subDeviceNetworkStatus.CreateHandler = handleDNSModify
-	subDeviceNetworkStatus.DeleteHandler = handleDNSDelete
 	ctx.subDeviceNetworkStatus = subDeviceNetworkStatus
 	subDeviceNetworkStatus.Activate()
 
 	subGlobalDownloadConfig, err := pubsub.Subscribe("",
-		types.GlobalDownloadConfig{}, false, ctx)
+		types.GlobalDownloadConfig{}, false, ctx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleGlobalDownloadConfigModify,
+			ModifyHandler: handleGlobalDownloadConfigModify,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		return err
 	}
-	subGlobalDownloadConfig.MaxProcessTimeWarn = warningTime
-	subGlobalDownloadConfig.MaxProcessTimeError = errorTime
-	subGlobalDownloadConfig.ModifyHandler = handleGlobalDownloadConfigModify
-	subGlobalDownloadConfig.CreateHandler = handleGlobalDownloadConfigModify
 	ctx.subGlobalDownloadConfig = subGlobalDownloadConfig
 	subGlobalDownloadConfig.Activate()
 
@@ -73,15 +76,16 @@ func (ctx *downloaderContext) registerHandlers() error {
 	// before any download config ( App/baseos/cert). Without DataStore Config,
 	// Image Downloads will run into errors.
 	subDatastoreConfig, err := pubsub.Subscribe("zedagent",
-		types.DatastoreConfig{}, false, ctx)
+		types.DatastoreConfig{}, false, ctx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleDatastoreConfigModify,
+			ModifyHandler: handleDatastoreConfigModify,
+			DeleteHandler: handleDatastoreConfigDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		return err
 	}
-	subDatastoreConfig.MaxProcessTimeWarn = warningTime
-	subDatastoreConfig.MaxProcessTimeError = errorTime
-	subDatastoreConfig.ModifyHandler = handleDatastoreConfigModify
-	subDatastoreConfig.CreateHandler = handleDatastoreConfigModify
-	subDatastoreConfig.DeleteHandler = handleDatastoreConfigDelete
 	ctx.subDatastoreConfig = subDatastoreConfig
 	subDatastoreConfig.Activate()
 
@@ -118,41 +122,44 @@ func (ctx *downloaderContext) registerHandlers() error {
 	pubCertObjStatus.ClearRestarted()
 
 	subAppImgConfig, err := pubsub.SubscribeScope("zedmanager",
-		types.AppImgObj, types.DownloaderConfig{}, false, ctx)
+		types.AppImgObj, types.DownloaderConfig{}, false, ctx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleAppImgCreate,
+			ModifyHandler: handleAppImgModify,
+			DeleteHandler: handleAppImgDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		return err
 	}
-	subAppImgConfig.MaxProcessTimeWarn = warningTime
-	subAppImgConfig.MaxProcessTimeError = errorTime
-	subAppImgConfig.ModifyHandler = handleAppImgModify
-	subAppImgConfig.CreateHandler = handleAppImgCreate
-	subAppImgConfig.DeleteHandler = handleAppImgDelete
 	ctx.subAppImgConfig = subAppImgConfig
 	subAppImgConfig.Activate()
 
 	subBaseOsConfig, err := pubsub.SubscribeScope("baseosmgr",
-		types.BaseOsObj, types.DownloaderConfig{}, false, ctx)
+		types.BaseOsObj, types.DownloaderConfig{}, false, ctx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleBaseOsCreate,
+			ModifyHandler: handleBaseOsModify,
+			DeleteHandler: handleBaseOsDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		return err
 	}
-	subBaseOsConfig.MaxProcessTimeWarn = warningTime
-	subBaseOsConfig.MaxProcessTimeError = errorTime
-	subBaseOsConfig.ModifyHandler = handleBaseOsModify
-	subBaseOsConfig.CreateHandler = handleBaseOsCreate
-	subBaseOsConfig.DeleteHandler = handleBaseOsDelete
 	ctx.subBaseOsConfig = subBaseOsConfig
 	subBaseOsConfig.Activate()
 
 	subCertObjConfig, err := pubsub.SubscribeScope("baseosmgr",
-		types.CertObj, types.DownloaderConfig{}, false, ctx)
+		types.CertObj, types.DownloaderConfig{}, false, ctx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleCertObjCreate,
+			ModifyHandler: handleCertObjModify,
+			DeleteHandler: handleCertObjDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		return err
 	}
-	subCertObjConfig.MaxProcessTimeWarn = warningTime
-	subCertObjConfig.MaxProcessTimeError = errorTime
-	subCertObjConfig.ModifyHandler = handleCertObjModify
-	subCertObjConfig.CreateHandler = handleCertObjCreate
-	subCertObjConfig.DeleteHandler = handleCertObjDelete
 	ctx.subCertObjConfig = subCertObjConfig
 	subCertObjConfig.Activate()
 

--- a/pkg/pillar/cmd/identitymgr/identitymgr.go
+++ b/pkg/pillar/cmd/identitymgr/identitymgr.go
@@ -97,30 +97,32 @@ func Run() {
 
 	// Look for global config such as log levels
 	subGlobalConfig, err := pubsub.Subscribe("", types.GlobalConfig{},
-		false, &identityCtx)
+		false, &identityCtx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleGlobalConfigModify,
+			ModifyHandler: handleGlobalConfigModify,
+			DeleteHandler: handleGlobalConfigDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subGlobalConfig.MaxProcessTimeWarn = warningTime
-	subGlobalConfig.MaxProcessTimeError = errorTime
-	subGlobalConfig.ModifyHandler = handleGlobalConfigModify
-	subGlobalConfig.CreateHandler = handleGlobalConfigModify
-	subGlobalConfig.DeleteHandler = handleGlobalConfigDelete
 	identityCtx.subGlobalConfig = subGlobalConfig
 	subGlobalConfig.Activate()
 
 	// Subscribe to EIDConfig from zedmanager
 	subEIDConfig, err := pubsub.Subscribe("zedmanager",
-		types.EIDConfig{}, false, &identityCtx)
+		types.EIDConfig{}, false, &identityCtx, &pubsub.SubscriptionOptions{
+			CreateHandler:  handleCreate,
+			ModifyHandler:  handleModify,
+			DeleteHandler:  handleEIDConfigDelete,
+			RestartHandler: handleRestart,
+			WarningTime:    warningTime,
+			ErrorTime:      errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subEIDConfig.MaxProcessTimeWarn = warningTime
-	subEIDConfig.MaxProcessTimeError = errorTime
-	subEIDConfig.ModifyHandler = handleModify
-	subEIDConfig.CreateHandler = handleCreate
-	subEIDConfig.DeleteHandler = handleEIDConfigDelete
-	subEIDConfig.RestartHandler = handleRestart
 	identityCtx.subEIDConfig = subEIDConfig
 	subEIDConfig.Activate()
 
@@ -128,7 +130,7 @@ func Run() {
 	for !identityCtx.GCInitialized {
 		log.Infof("waiting for GCInitialized")
 		select {
-		case change := <-subGlobalConfig.C:
+		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
 		case <-stillRunning.C:
 		}
@@ -138,10 +140,10 @@ func Run() {
 
 	for {
 		select {
-		case change := <-subGlobalConfig.C:
+		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
 
-		case change := <-subEIDConfig.C:
+		case change := <-subEIDConfig.MsgChan():
 			subEIDConfig.ProcessChange(change)
 
 		case <-stillRunning.C:

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -145,16 +145,17 @@ func Run() {
 
 	// Look for global config such as log levels
 	subGlobalConfig, err := pubsub.Subscribe("", types.GlobalConfig{},
-		false, &nimCtx)
+		false, &nimCtx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleGlobalConfigModify,
+			ModifyHandler: handleGlobalConfigModify,
+			DeleteHandler: handleGlobalConfigDelete,
+			SyncHandler:   handleGlobalConfigSynchronized,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subGlobalConfig.MaxProcessTimeWarn = warningTime
-	subGlobalConfig.MaxProcessTimeError = errorTime
-	subGlobalConfig.ModifyHandler = handleGlobalConfigModify
-	subGlobalConfig.CreateHandler = handleGlobalConfigModify
-	subGlobalConfig.DeleteHandler = handleGlobalConfigDelete
-	subGlobalConfig.SynchronizedHandler = handleGlobalConfigSynchronized
 	nimCtx.subGlobalConfig = subGlobalConfig
 	subGlobalConfig.Activate()
 
@@ -172,70 +173,75 @@ func Run() {
 	// 3. "lastresort" derived from the set of network interfaces
 	subDevicePortConfigA, err := pubsub.Subscribe("zedagent",
 		types.DevicePortConfig{}, false,
-		&nimCtx.DeviceNetworkContext)
+		&nimCtx.DeviceNetworkContext, &pubsub.SubscriptionOptions{
+			CreateHandler: devicenetwork.HandleDPCModify,
+			ModifyHandler: devicenetwork.HandleDPCModify,
+			DeleteHandler: devicenetwork.HandleDPCDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subDevicePortConfigA.MaxProcessTimeWarn = warningTime
-	subDevicePortConfigA.MaxProcessTimeError = errorTime
-	subDevicePortConfigA.ModifyHandler = devicenetwork.HandleDPCModify
-	subDevicePortConfigA.CreateHandler = devicenetwork.HandleDPCModify
-	subDevicePortConfigA.DeleteHandler = devicenetwork.HandleDPCDelete
 	nimCtx.SubDevicePortConfigA = subDevicePortConfigA
 	subDevicePortConfigA.Activate()
 
 	subDevicePortConfigO, err := pubsub.Subscribe("",
 		types.DevicePortConfig{}, false,
-		&nimCtx.DeviceNetworkContext)
+		&nimCtx.DeviceNetworkContext, &pubsub.SubscriptionOptions{
+			CreateHandler: devicenetwork.HandleDPCModify,
+			ModifyHandler: devicenetwork.HandleDPCModify,
+			DeleteHandler: devicenetwork.HandleDPCDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subDevicePortConfigO.MaxProcessTimeWarn = warningTime
-	subDevicePortConfigO.MaxProcessTimeError = errorTime
-	subDevicePortConfigO.ModifyHandler = devicenetwork.HandleDPCModify
-	subDevicePortConfigO.CreateHandler = devicenetwork.HandleDPCModify
-	subDevicePortConfigO.DeleteHandler = devicenetwork.HandleDPCDelete
 	nimCtx.SubDevicePortConfigO = subDevicePortConfigO
 	subDevicePortConfigO.Activate()
 
 	subDevicePortConfigS, err := pubsub.Subscribe(agentName,
 		types.DevicePortConfig{}, false,
-		&nimCtx.DeviceNetworkContext)
+		&nimCtx.DeviceNetworkContext, &pubsub.SubscriptionOptions{
+			CreateHandler: devicenetwork.HandleDPCModify,
+			ModifyHandler: devicenetwork.HandleDPCModify,
+			DeleteHandler: devicenetwork.HandleDPCDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subDevicePortConfigS.MaxProcessTimeWarn = warningTime
-	subDevicePortConfigS.MaxProcessTimeError = errorTime
-	subDevicePortConfigS.ModifyHandler = devicenetwork.HandleDPCModify
-	subDevicePortConfigS.CreateHandler = devicenetwork.HandleDPCModify
-	subDevicePortConfigS.DeleteHandler = devicenetwork.HandleDPCDelete
 	nimCtx.SubDevicePortConfigS = subDevicePortConfigS
 	subDevicePortConfigS.Activate()
 
 	subAssignableAdapters, err := pubsub.Subscribe("domainmgr",
 		types.AssignableAdapters{}, false,
-		&nimCtx.DeviceNetworkContext)
+		&nimCtx.DeviceNetworkContext, &pubsub.SubscriptionOptions{
+			CreateHandler: devicenetwork.HandleAssignableAdaptersModify,
+			ModifyHandler: devicenetwork.HandleAssignableAdaptersModify,
+			DeleteHandler: devicenetwork.HandleAssignableAdaptersDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subAssignableAdapters.MaxProcessTimeWarn = warningTime
-	subAssignableAdapters.MaxProcessTimeError = errorTime
-	subAssignableAdapters.ModifyHandler = devicenetwork.HandleAssignableAdaptersModify
-	subAssignableAdapters.CreateHandler = devicenetwork.HandleAssignableAdaptersModify
-	subAssignableAdapters.DeleteHandler = devicenetwork.HandleAssignableAdaptersDelete
 	nimCtx.SubAssignableAdapters = subAssignableAdapters
 	subAssignableAdapters.Activate()
 
 	subNetworkInstanceStatus, err := pubsub.Subscribe("zedrouter",
-		types.NetworkInstanceStatus{}, false, &nimCtx)
+		types.NetworkInstanceStatus{}, false, &nimCtx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleNetworkInstanceModify,
+			ModifyHandler: handleNetworkInstanceModify,
+			DeleteHandler: handleNetworkInstanceDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subNetworkInstanceStatus.MaxProcessTimeWarn = warningTime
-	subNetworkInstanceStatus.MaxProcessTimeError = errorTime
-	subNetworkInstanceStatus.ModifyHandler = handleNetworkInstanceModify
-	subNetworkInstanceStatus.CreateHandler = handleNetworkInstanceModify
-	subNetworkInstanceStatus.DeleteHandler = handleNetworkInstanceDelete
 	nimCtx.subNetworkInstanceStatus = subNetworkInstanceStatus
 	subNetworkInstanceStatus.Activate()
 
@@ -248,7 +254,7 @@ func Run() {
 	for !nimCtx.GCInitialized {
 		log.Infof("Waiting for GCInitialized")
 		select {
-		case change := <-subGlobalConfig.C:
+		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
 		}
 	}
@@ -316,10 +322,10 @@ func Run() {
 	for nimCtx.networkFallbackAnyEth == types.TS_ENABLED &&
 		len(dnc.DevicePortConfigList.PortConfigList) == 0 {
 		select {
-		case change := <-subGlobalConfig.C:
+		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
 
-		case change := <-subDevicePortConfigS.C:
+		case change := <-subDevicePortConfigS.MsgChan():
 			subDevicePortConfigS.ProcessChange(change)
 			log.Infof("Got subDevicePortConfigS: len %d",
 				len(dnc.DevicePortConfigList.PortConfigList))
@@ -342,20 +348,20 @@ func Run() {
 	for !nimCtx.AssignableAdapters.Initialized {
 		log.Infof("Waiting for AA to initialize")
 		select {
-		case change := <-subGlobalConfig.C:
+		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
 
-		case change := <-subDevicePortConfigO.C:
+		case change := <-subDevicePortConfigO.MsgChan():
 			subDevicePortConfigO.ProcessChange(change)
 
-		case change := <-subDevicePortConfigS.C:
+		case change := <-subDevicePortConfigS.MsgChan():
 			subDevicePortConfigS.ProcessChange(change)
 
-		case change := <-subAssignableAdapters.C:
+		case change := <-subAssignableAdapters.MsgChan():
 			subAssignableAdapters.ProcessChange(change)
 			updateFilteredFallback(&nimCtx)
 
-		case change := <-subNetworkInstanceStatus.C:
+		case change := <-subNetworkInstanceStatus.MsgChan():
 			subNetworkInstanceStatus.ProcessChange(change)
 
 		case change, ok := <-addrChanges:
@@ -480,23 +486,23 @@ func Run() {
 
 	for {
 		select {
-		case change := <-subGlobalConfig.C:
+		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
 
-		case change := <-subDevicePortConfigA.C:
+		case change := <-subDevicePortConfigA.MsgChan():
 			subDevicePortConfigA.ProcessChange(change)
 
-		case change := <-subDevicePortConfigO.C:
+		case change := <-subDevicePortConfigO.MsgChan():
 			subDevicePortConfigO.ProcessChange(change)
 
-		case change := <-subDevicePortConfigS.C:
+		case change := <-subDevicePortConfigS.MsgChan():
 			subDevicePortConfigS.ProcessChange(change)
 
-		case change := <-subAssignableAdapters.C:
+		case change := <-subAssignableAdapters.MsgChan():
 			subAssignableAdapters.ProcessChange(change)
 			updateFilteredFallback(&nimCtx)
 
-		case change := <-subNetworkInstanceStatus.C:
+		case change := <-subNetworkInstanceStatus.MsgChan():
 			subNetworkInstanceStatus.ProcessChange(change)
 
 		case change, ok := <-addrChanges:

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -220,15 +220,16 @@ func Run() {
 	utils.ReadAndUpdateGCFile(zedagentCtx.pubGlobalConfig)
 
 	subAssignableAdapters, err := pubsub.Subscribe("domainmgr",
-		types.AssignableAdapters{}, false, &zedagentCtx)
+		types.AssignableAdapters{}, false, &zedagentCtx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleAAModify,
+			ModifyHandler: handleAAModify,
+			DeleteHandler: handleAADelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subAssignableAdapters.MaxProcessTimeWarn = warningTime
-	subAssignableAdapters.MaxProcessTimeError = errorTime
-	subAssignableAdapters.ModifyHandler = handleAAModify
-	subAssignableAdapters.CreateHandler = handleAAModify
-	subAssignableAdapters.DeleteHandler = handleAADelete
 	zedagentCtx.subAssignableAdapters = subAssignableAdapters
 	subAssignableAdapters.Activate()
 
@@ -314,196 +315,211 @@ func Run() {
 
 	// Look for global config such as log levels
 	subGlobalConfig, err := pubsub.Subscribe("", types.GlobalConfig{},
-		false, &zedagentCtx)
+		false, &zedagentCtx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleGlobalConfigModify,
+			ModifyHandler: handleGlobalConfigModify,
+			DeleteHandler: handleGlobalConfigDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subGlobalConfig.MaxProcessTimeWarn = warningTime
-	subGlobalConfig.MaxProcessTimeError = errorTime
-	subGlobalConfig.ModifyHandler = handleGlobalConfigModify
-	subGlobalConfig.CreateHandler = handleGlobalConfigModify
-	subGlobalConfig.DeleteHandler = handleGlobalConfigDelete
 	zedagentCtx.subGlobalConfig = subGlobalConfig
 	subGlobalConfig.Activate()
 
 	subNetworkInstanceStatus, err := pubsub.Subscribe("zedrouter",
-		types.NetworkInstanceStatus{}, false, &zedagentCtx)
+		types.NetworkInstanceStatus{}, false, &zedagentCtx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleNetworkInstanceModify,
+			ModifyHandler: handleNetworkInstanceModify,
+			DeleteHandler: handleNetworkInstanceDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subNetworkInstanceStatus.MaxProcessTimeWarn = warningTime
-	subNetworkInstanceStatus.MaxProcessTimeError = errorTime
-	subNetworkInstanceStatus.ModifyHandler = handleNetworkInstanceModify
-	subNetworkInstanceStatus.CreateHandler = handleNetworkInstanceModify
-	subNetworkInstanceStatus.DeleteHandler = handleNetworkInstanceDelete
 	zedagentCtx.subNetworkInstanceStatus = subNetworkInstanceStatus
 	subNetworkInstanceStatus.Activate()
 
 	subNetworkInstanceMetrics, err := pubsub.Subscribe("zedrouter",
-		types.NetworkInstanceMetrics{}, false, &zedagentCtx)
+		types.NetworkInstanceMetrics{}, false, &zedagentCtx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleNetworkInstanceMetricsModify,
+			ModifyHandler: handleNetworkInstanceMetricsModify,
+			DeleteHandler: handleNetworkInstanceMetricsDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subNetworkInstanceMetrics.MaxProcessTimeWarn = warningTime
-	subNetworkInstanceMetrics.MaxProcessTimeError = errorTime
-	subNetworkInstanceMetrics.ModifyHandler = handleNetworkInstanceMetricsModify
-	subNetworkInstanceMetrics.CreateHandler = handleNetworkInstanceMetricsModify
-	subNetworkInstanceMetrics.DeleteHandler = handleNetworkInstanceMetricsDelete
 	zedagentCtx.subNetworkInstanceMetrics = subNetworkInstanceMetrics
 	subNetworkInstanceMetrics.Activate()
 
 	subAppFlowMonitor, err := pubsub.Subscribe("zedrouter",
-		types.IPFlow{}, false, &zedagentCtx)
+		types.IPFlow{}, false, &zedagentCtx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleAppFlowMonitorModify,
+			ModifyHandler: handleAppFlowMonitorModify,
+			DeleteHandler: handleAppFlowMonitorDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subAppFlowMonitor.MaxProcessTimeWarn = warningTime
-	subAppFlowMonitor.MaxProcessTimeError = errorTime
-	subAppFlowMonitor.ModifyHandler = handleAppFlowMonitorModify
-	subAppFlowMonitor.CreateHandler = handleAppFlowMonitorModify
-	subAppFlowMonitor.DeleteHandler = handleAppFlowMonitorDelete
 	subAppFlowMonitor.Activate()
 	flowQ = list.New()
 	log.Infof("FlowStats: create subFlowStatus")
 
 	subAppVifIPTrig, err := pubsub.Subscribe("zedrouter",
-		types.VifIPTrig{}, false, &zedagentCtx)
+		types.VifIPTrig{}, false, &zedagentCtx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleAppVifIPTrigModify,
+			ModifyHandler: handleAppVifIPTrigModify,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subAppVifIPTrig.MaxProcessTimeWarn = warningTime
-	subAppVifIPTrig.MaxProcessTimeError = errorTime
-	subAppVifIPTrig.ModifyHandler = handleAppVifIPTrigModify
-	subAppVifIPTrig.CreateHandler = handleAppVifIPTrigModify
 	subAppVifIPTrig.Activate()
 
 	// Look for AppInstanceStatus from zedmanager
 	subAppInstanceStatus, err := pubsub.Subscribe("zedmanager",
-		types.AppInstanceStatus{}, false, &zedagentCtx)
+		types.AppInstanceStatus{}, false, &zedagentCtx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleAppInstanceStatusModify,
+			ModifyHandler: handleAppInstanceStatusModify,
+			DeleteHandler: handleAppInstanceStatusDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subAppInstanceStatus.MaxProcessTimeWarn = warningTime
-	subAppInstanceStatus.MaxProcessTimeError = errorTime
-	subAppInstanceStatus.ModifyHandler = handleAppInstanceStatusModify
-	subAppInstanceStatus.CreateHandler = handleAppInstanceStatusModify
-	subAppInstanceStatus.DeleteHandler = handleAppInstanceStatusDelete
 	getconfigCtx.subAppInstanceStatus = subAppInstanceStatus
 	subAppInstanceStatus.Activate()
 
 	// Look for zboot status
 	subZbootStatus, err := pubsub.Subscribe("baseosmgr",
-		types.ZbootStatus{}, false, &zedagentCtx)
+		types.ZbootStatus{}, false, &zedagentCtx, &pubsub.SubscriptionOptions{
+			CreateHandler:  handleZbootStatusModify,
+			ModifyHandler:  handleZbootStatusModify,
+			DeleteHandler:  handleZbootStatusDelete,
+			RestartHandler: handleZbootRestarted,
+			WarningTime:    warningTime,
+			ErrorTime:      errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subZbootStatus.MaxProcessTimeWarn = warningTime
-	subZbootStatus.MaxProcessTimeError = errorTime
-	subZbootStatus.ModifyHandler = handleZbootStatusModify
-	subZbootStatus.CreateHandler = handleZbootStatusModify
-	subZbootStatus.DeleteHandler = handleZbootStatusDelete
-	subZbootStatus.RestartHandler = handleZbootRestarted
 	zedagentCtx.subZbootStatus = subZbootStatus
 	subZbootStatus.Activate()
 
 	subBaseOsStatus, err := pubsub.Subscribe("baseosmgr",
-		types.BaseOsStatus{}, false, &zedagentCtx)
+		types.BaseOsStatus{}, false, &zedagentCtx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleBaseOsStatusModify,
+			ModifyHandler: handleBaseOsStatusModify,
+			DeleteHandler: handleBaseOsStatusDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subBaseOsStatus.MaxProcessTimeWarn = warningTime
-	subBaseOsStatus.MaxProcessTimeError = errorTime
-	subBaseOsStatus.ModifyHandler = handleBaseOsStatusModify
-	subBaseOsStatus.CreateHandler = handleBaseOsStatusModify
-	subBaseOsStatus.DeleteHandler = handleBaseOsStatusDelete
 	zedagentCtx.subBaseOsStatus = subBaseOsStatus
 	subBaseOsStatus.Activate()
 
 	subVaultStatus, err := pubsub.Subscribe("vaultmgr",
-		types.VaultStatus{}, false, &zedagentCtx)
+		types.VaultStatus{}, false, &zedagentCtx, &pubsub.SubscriptionOptions{
+			ModifyHandler: handleVaultStatusModify,
+			DeleteHandler: handleVaultStatusDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subVaultStatus.MaxProcessTimeWarn = warningTime
-	subVaultStatus.MaxProcessTimeError = errorTime
-	subVaultStatus.ModifyHandler = handleVaultStatusModify
-	subVaultStatus.DeleteHandler = handleVaultStatusDelete
 	zedagentCtx.subVaultStatus = subVaultStatus
 	subVaultStatus.Activate()
 
 	// Look for DownloaderStatus from downloader
 	// used only for downloader storage stats collection
 	subBaseOsDownloadStatus, err := pubsub.SubscribeScope("downloader",
-		types.BaseOsObj, types.DownloaderStatus{}, false, &zedagentCtx)
+		types.BaseOsObj, types.DownloaderStatus{}, false, &zedagentCtx, &pubsub.SubscriptionOptions{
+			WarningTime: warningTime,
+			ErrorTime:   errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subBaseOsDownloadStatus.MaxProcessTimeWarn = warningTime
-	subBaseOsDownloadStatus.MaxProcessTimeError = errorTime
 	zedagentCtx.subBaseOsDownloadStatus = subBaseOsDownloadStatus
 	subBaseOsDownloadStatus.Activate()
 
 	// Look for DownloaderStatus from downloader
 	// used only for downloader storage stats collection
 	subCertObjDownloadStatus, err := pubsub.SubscribeScope("downloader",
-		types.CertObj, types.DownloaderStatus{}, false, &zedagentCtx)
+		types.CertObj, types.DownloaderStatus{}, false, &zedagentCtx, &pubsub.SubscriptionOptions{
+			WarningTime: warningTime,
+			ErrorTime:   errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subCertObjDownloadStatus.MaxProcessTimeWarn = warningTime
-	subCertObjDownloadStatus.MaxProcessTimeError = errorTime
 	zedagentCtx.subCertObjDownloadStatus = subCertObjDownloadStatus
 	subCertObjDownloadStatus.Activate()
 
 	// Look for VerifyBaseOsImageStatus from verifier
 	// used only for verifier storage stats collection
 	subBaseOsVerifierStatus, err := pubsub.SubscribeScope("verifier",
-		types.BaseOsObj, types.VerifyImageStatus{}, false, &zedagentCtx)
+		types.BaseOsObj, types.VerifyImageStatus{}, false, &zedagentCtx, &pubsub.SubscriptionOptions{
+			ModifyHandler:  handleVerifierStatusModify,
+			DeleteHandler:  handleVerifierStatusDelete,
+			RestartHandler: handleVerifierRestarted,
+			WarningTime:    warningTime,
+			ErrorTime:      errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subBaseOsVerifierStatus.MaxProcessTimeWarn = warningTime
-	subBaseOsVerifierStatus.MaxProcessTimeError = errorTime
-	subBaseOsVerifierStatus.ModifyHandler = handleVerifierStatusModify
-	subBaseOsVerifierStatus.DeleteHandler = handleVerifierStatusDelete
-	subBaseOsVerifierStatus.RestartHandler = handleVerifierRestarted
 	zedagentCtx.subBaseOsVerifierStatus = subBaseOsVerifierStatus
 	subBaseOsVerifierStatus.Activate()
 
 	// Look for VerifyImageStatus from verifier
 	// used only for verifier storage stats collection
 	subAppImgVerifierStatus, err := pubsub.SubscribeScope("verifier",
-		types.AppImgObj, types.VerifyImageStatus{}, false, &zedagentCtx)
+		types.AppImgObj, types.VerifyImageStatus{}, false, &zedagentCtx, &pubsub.SubscriptionOptions{
+			WarningTime: warningTime,
+			ErrorTime:   errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subAppImgVerifierStatus.MaxProcessTimeWarn = warningTime
-	subAppImgVerifierStatus.MaxProcessTimeError = errorTime
 	zedagentCtx.subAppImgVerifierStatus = subAppImgVerifierStatus
 	subAppImgVerifierStatus.Activate()
 
 	// Look for DownloaderStatus from downloader for metric reporting
 	// used only for downloader storage stats collection
 	subAppImgDownloadStatus, err := pubsub.SubscribeScope("downloader",
-		types.AppImgObj, types.DownloaderStatus{}, false, &zedagentCtx)
+		types.AppImgObj, types.DownloaderStatus{}, false, &zedagentCtx, &pubsub.SubscriptionOptions{
+			WarningTime: warningTime,
+			ErrorTime:   errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subAppImgDownloadStatus.MaxProcessTimeWarn = warningTime
-	subAppImgDownloadStatus.MaxProcessTimeError = errorTime
 	zedagentCtx.subAppImgDownloadStatus = subAppImgDownloadStatus
 	subAppImgDownloadStatus.Activate()
 
 	// Look for nodeagent status
 	subNodeAgentStatus, err := pubsub.Subscribe("nodeagent",
-		types.NodeAgentStatus{}, false, &getconfigCtx)
+		types.NodeAgentStatus{}, false, &getconfigCtx, &pubsub.SubscriptionOptions{
+			ModifyHandler: handleNodeAgentStatusModify,
+			DeleteHandler: handleNodeAgentStatusDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subNodeAgentStatus.MaxProcessTimeWarn = warningTime
-	subNodeAgentStatus.MaxProcessTimeError = errorTime
-	subNodeAgentStatus.ModifyHandler = handleNodeAgentStatusModify
-	subNodeAgentStatus.DeleteHandler = handleNodeAgentStatusDelete
 	getconfigCtx.subNodeAgentStatus = subNodeAgentStatus
 	subNodeAgentStatus.Activate()
 
@@ -511,26 +527,28 @@ func Run() {
 	DNSctx.usableAddressCount = types.CountLocalAddrAnyNoLinkLocal(*deviceNetworkStatus)
 
 	subDeviceNetworkStatus, err := pubsub.Subscribe("nim",
-		types.DeviceNetworkStatus{}, false, &DNSctx)
+		types.DeviceNetworkStatus{}, false, &DNSctx, &pubsub.SubscriptionOptions{
+			ModifyHandler: handleDNSModify,
+			DeleteHandler: handleDNSDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subDeviceNetworkStatus.MaxProcessTimeWarn = warningTime
-	subDeviceNetworkStatus.MaxProcessTimeError = errorTime
-	subDeviceNetworkStatus.ModifyHandler = handleDNSModify
-	subDeviceNetworkStatus.DeleteHandler = handleDNSDelete
 	DNSctx.subDeviceNetworkStatus = subDeviceNetworkStatus
 	subDeviceNetworkStatus.Activate()
 
 	subDevicePortConfigList, err := pubsub.Subscribe("nim",
-		types.DevicePortConfigList{}, false, &zedagentCtx)
+		types.DevicePortConfigList{}, false, &zedagentCtx, &pubsub.SubscriptionOptions{
+			ModifyHandler: handleDPCLModify,
+			DeleteHandler: handleDPCLDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subDevicePortConfigList.MaxProcessTimeWarn = warningTime
-	subDevicePortConfigList.MaxProcessTimeError = errorTime
-	subDevicePortConfigList.ModifyHandler = handleDPCLModify
-	subDevicePortConfigList.DeleteHandler = handleDPCLDelete
 	zedagentCtx.subDevicePortConfigList = subDevicePortConfigList
 	subDevicePortConfigList.Activate()
 
@@ -617,24 +635,24 @@ func Run() {
 
 	// Subscribe to network metrics from zedrouter
 	subNetworkMetrics, err := pubsub.Subscribe("zedrouter",
-		types.NetworkMetrics{}, true, &zedagentCtx)
+		types.NetworkMetrics{}, true, &zedagentCtx, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
 	// Subscribe to cloud metrics from different agents
 	cms := zedcloud.GetCloudMetrics()
 	subClientMetrics, err := pubsub.Subscribe("zedclient", cms,
-		true, &zedagentCtx)
+		true, &zedagentCtx, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
 	subLogmanagerMetrics, err := pubsub.Subscribe("logmanager",
-		cms, true, &zedagentCtx)
+		cms, true, &zedagentCtx, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
 	subDownloaderMetrics, err := pubsub.Subscribe("downloader",
-		cms, true, &zedagentCtx)
+		cms, true, &zedagentCtx, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -157,141 +157,151 @@ func Run() {
 
 	// Look for global config such as log levels
 	subGlobalConfig, err := pubsub.Subscribe("", types.GlobalConfig{},
-		false, &ctx)
+		false, &ctx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleGlobalConfigModify,
+			ModifyHandler: handleGlobalConfigModify,
+			DeleteHandler: handleGlobalConfigDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subGlobalConfig.MaxProcessTimeWarn = warningTime
-	subGlobalConfig.MaxProcessTimeError = errorTime
-	subGlobalConfig.ModifyHandler = handleGlobalConfigModify
-	subGlobalConfig.CreateHandler = handleGlobalConfigModify
-	subGlobalConfig.DeleteHandler = handleGlobalConfigDelete
 	ctx.subGlobalConfig = subGlobalConfig
 	subGlobalConfig.Activate()
 
 	// Get AppInstanceConfig from zedagent
 	subAppInstanceConfig, err := pubsub.Subscribe("zedagent",
-		types.AppInstanceConfig{}, false, &ctx)
+		types.AppInstanceConfig{}, false, &ctx, &pubsub.SubscriptionOptions{
+			CreateHandler:  handleCreate,
+			ModifyHandler:  handleModify,
+			DeleteHandler:  handleAppInstanceConfigDelete,
+			RestartHandler: handleConfigRestart,
+			WarningTime:    warningTime,
+			ErrorTime:      errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subAppInstanceConfig.MaxProcessTimeWarn = warningTime
-	subAppInstanceConfig.MaxProcessTimeError = errorTime
-	subAppInstanceConfig.ModifyHandler = handleModify
-	subAppInstanceConfig.CreateHandler = handleCreate
-	subAppInstanceConfig.DeleteHandler = handleAppInstanceConfigDelete
-	subAppInstanceConfig.RestartHandler = handleConfigRestart
 	ctx.subAppInstanceConfig = subAppInstanceConfig
 	subAppInstanceConfig.Activate()
 
 	// Get AppNetworkStatus from zedrouter
 	subAppNetworkStatus, err := pubsub.Subscribe("zedrouter",
-		types.AppNetworkStatus{}, false, &ctx)
+		types.AppNetworkStatus{}, false, &ctx, &pubsub.SubscriptionOptions{
+			CreateHandler:  handleAppNetworkStatusModify,
+			ModifyHandler:  handleAppNetworkStatusModify,
+			DeleteHandler:  handleAppNetworkStatusDelete,
+			RestartHandler: handleZedrouterRestarted,
+			WarningTime:    warningTime,
+			ErrorTime:      errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subAppNetworkStatus.MaxProcessTimeWarn = warningTime
-	subAppNetworkStatus.MaxProcessTimeError = errorTime
-	subAppNetworkStatus.ModifyHandler = handleAppNetworkStatusModify
-	subAppNetworkStatus.CreateHandler = handleAppNetworkStatusModify
-	subAppNetworkStatus.DeleteHandler = handleAppNetworkStatusDelete
-	subAppNetworkStatus.RestartHandler = handleZedrouterRestarted
 	ctx.subAppNetworkStatus = subAppNetworkStatus
 	subAppNetworkStatus.Activate()
 
 	// Get DomainStatus from domainmgr
 	subDomainStatus, err := pubsub.Subscribe("domainmgr",
-		types.DomainStatus{}, false, &ctx)
+		types.DomainStatus{}, false, &ctx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleDomainStatusModify,
+			ModifyHandler: handleDomainStatusModify,
+			DeleteHandler: handleDomainStatusDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subDomainStatus.MaxProcessTimeWarn = warningTime
-	subDomainStatus.MaxProcessTimeError = errorTime
-	subDomainStatus.ModifyHandler = handleDomainStatusModify
-	subDomainStatus.CreateHandler = handleDomainStatusModify
-	subDomainStatus.DeleteHandler = handleDomainStatusDelete
 	ctx.subDomainStatus = subDomainStatus
 	subDomainStatus.Activate()
 
 	// Get DomainStatus from domainmgr
 	subImageStatus, err := pubsub.Subscribe("domainmgr",
-		types.ImageStatus{}, false, &ctx)
+		types.ImageStatus{}, false, &ctx, &pubsub.SubscriptionOptions{
+			WarningTime: warningTime,
+			ErrorTime:   errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subImageStatus.MaxProcessTimeWarn = warningTime
-	subImageStatus.MaxProcessTimeError = errorTime
 	ctx.subImageStatus = subImageStatus
 	subImageStatus.Activate()
 
 	// Look for DownloaderStatus from downloader
 	subAppImgDownloadStatus, err := pubsub.SubscribeScope("downloader",
-		types.AppImgObj, types.DownloaderStatus{}, false, &ctx)
+		types.AppImgObj, types.DownloaderStatus{}, false, &ctx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleDownloaderStatusModify,
+			ModifyHandler: handleDownloaderStatusModify,
+			DeleteHandler: handleDownloaderStatusDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subAppImgDownloadStatus.MaxProcessTimeWarn = warningTime
-	subAppImgDownloadStatus.MaxProcessTimeError = errorTime
-	subAppImgDownloadStatus.ModifyHandler = handleDownloaderStatusModify
-	subAppImgDownloadStatus.CreateHandler = handleDownloaderStatusModify
-	subAppImgDownloadStatus.DeleteHandler = handleDownloaderStatusDelete
 	ctx.subAppImgDownloadStatus = subAppImgDownloadStatus
 	subAppImgDownloadStatus.Activate()
 
 	// Look for VerifyImageStatus from verifier
 	subAppImgVerifierStatus, err := pubsub.SubscribeScope("verifier",
-		types.AppImgObj, types.VerifyImageStatus{}, false, &ctx)
+		types.AppImgObj, types.VerifyImageStatus{}, false, &ctx, &pubsub.SubscriptionOptions{
+			CreateHandler:  handleVerifyImageStatusModify,
+			ModifyHandler:  handleVerifyImageStatusModify,
+			DeleteHandler:  handleVerifyImageStatusDelete,
+			RestartHandler: handleVerifierRestarted,
+			WarningTime:    warningTime,
+			ErrorTime:      errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subAppImgVerifierStatus.MaxProcessTimeWarn = warningTime
-	subAppImgVerifierStatus.MaxProcessTimeError = errorTime
-	subAppImgVerifierStatus.ModifyHandler = handleVerifyImageStatusModify
-	subAppImgVerifierStatus.CreateHandler = handleVerifyImageStatusModify
-	subAppImgVerifierStatus.DeleteHandler = handleVerifyImageStatusDelete
-	subAppImgVerifierStatus.RestartHandler = handleVerifierRestarted
 	ctx.subAppImgVerifierStatus = subAppImgVerifierStatus
 	subAppImgVerifierStatus.Activate()
 
 	// Get IdentityStatus from identitymgr
 	subEIDStatus, err := pubsub.Subscribe("identitymgr",
-		types.EIDStatus{}, false, &ctx)
+		types.EIDStatus{}, false, &ctx, &pubsub.SubscriptionOptions{
+			CreateHandler:  handleEIDStatusModify,
+			ModifyHandler:  handleEIDStatusModify,
+			DeleteHandler:  handleEIDStatusDelete,
+			RestartHandler: handleIdentitymgrRestarted,
+			WarningTime:    warningTime,
+			ErrorTime:      errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subEIDStatus.MaxProcessTimeWarn = warningTime
-	subEIDStatus.MaxProcessTimeError = errorTime
-	subEIDStatus.ModifyHandler = handleEIDStatusModify
-	subEIDStatus.CreateHandler = handleEIDStatusModify
-	subEIDStatus.DeleteHandler = handleEIDStatusDelete
-	subEIDStatus.RestartHandler = handleIdentitymgrRestarted
 	ctx.subEIDStatus = subEIDStatus
 	subEIDStatus.Activate()
 
 	subDeviceNetworkStatus, err := pubsub.Subscribe("nim",
-		types.DeviceNetworkStatus{}, false, &ctx)
+		types.DeviceNetworkStatus{}, false, &ctx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleDNSModify,
+			ModifyHandler: handleDNSModify,
+			DeleteHandler: handleDNSDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subDeviceNetworkStatus.MaxProcessTimeWarn = warningTime
-	subDeviceNetworkStatus.MaxProcessTimeError = errorTime
-	subDeviceNetworkStatus.ModifyHandler = handleDNSModify
-	subDeviceNetworkStatus.CreateHandler = handleDNSModify
-	subDeviceNetworkStatus.DeleteHandler = handleDNSDelete
 	ctx.subDeviceNetworkStatus = subDeviceNetworkStatus
 	subDeviceNetworkStatus.Activate()
 
 	// Look for CertObjStatus from baseosmgr
 	subCertObjStatus, err := pubsub.Subscribe("baseosmgr",
-		types.CertObjStatus{}, false, &ctx)
+		types.CertObjStatus{}, false, &ctx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleCertObjStatusModify,
+			ModifyHandler: handleCertObjStatusModify,
+			DeleteHandler: handleCertObjStatusDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subCertObjStatus.MaxProcessTimeWarn = warningTime
-	subCertObjStatus.MaxProcessTimeError = errorTime
-	subCertObjStatus.ModifyHandler = handleCertObjStatusModify
-	subCertObjStatus.CreateHandler = handleCertObjStatusModify
-	subCertObjStatus.DeleteHandler = handleCertObjStatusDelete
 	ctx.subCertObjStatus = subCertObjStatus
 	subCertObjStatus.Activate()
 
@@ -299,7 +309,7 @@ func Run() {
 	for !ctx.GCInitialized {
 		log.Infof("waiting for GCInitialized")
 		select {
-		case change := <-subGlobalConfig.C:
+		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
 		case <-stillRunning.C:
 		}
@@ -312,10 +322,10 @@ func Run() {
 	log.Infof("Handling initial verifier Status\n")
 	for !ctx.verifierRestarted {
 		select {
-		case change := <-subGlobalConfig.C:
+		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
 
-		case change := <-subAppImgVerifierStatus.C:
+		case change := <-subAppImgVerifierStatus.MsgChan():
 			subAppImgVerifierStatus.ProcessChange(change)
 			if ctx.verifierRestarted {
 				log.Infof("Verifier reported restarted\n")
@@ -329,35 +339,35 @@ func Run() {
 	log.Infof("Handling all inputs\n")
 	for {
 		select {
-		case change := <-subGlobalConfig.C:
+		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
 
 		// handle cert ObjectsChanges
-		case change := <-subCertObjStatus.C:
+		case change := <-subCertObjStatus.MsgChan():
 			subCertObjStatus.ProcessChange(change)
 
-		case change := <-subAppImgDownloadStatus.C:
+		case change := <-subAppImgDownloadStatus.MsgChan():
 			subAppImgDownloadStatus.ProcessChange(change)
 
-		case change := <-subAppImgVerifierStatus.C:
+		case change := <-subAppImgVerifierStatus.MsgChan():
 			subAppImgVerifierStatus.ProcessChange(change)
 
-		case change := <-subEIDStatus.C:
+		case change := <-subEIDStatus.MsgChan():
 			subEIDStatus.ProcessChange(change)
 
-		case change := <-subAppNetworkStatus.C:
+		case change := <-subAppNetworkStatus.MsgChan():
 			subAppNetworkStatus.ProcessChange(change)
 
-		case change := <-subDomainStatus.C:
+		case change := <-subDomainStatus.MsgChan():
 			subDomainStatus.ProcessChange(change)
 
-		case change := <-subImageStatus.C:
+		case change := <-subImageStatus.MsgChan():
 			subImageStatus.ProcessChange(change)
 
-		case change := <-subAppInstanceConfig.C:
+		case change := <-subAppInstanceConfig.MsgChan():
 			subAppInstanceConfig.ProcessChange(change)
 
-		case change := <-subDeviceNetworkStatus.C:
+		case change := <-subDeviceNetworkStatus.MsgChan():
 			subDeviceNetworkStatus.ProcessChange(change)
 
 		case <-stillRunning.C:

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -157,42 +157,45 @@ func Run() {
 		make(map[uuid.UUID]*types.NetworkInstanceStatus)
 
 	subDeviceNetworkStatus, err := pubsub.Subscribe("nim",
-		types.DeviceNetworkStatus{}, false, &zedrouterCtx)
+		types.DeviceNetworkStatus{}, false, &zedrouterCtx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleDNSModify,
+			ModifyHandler: handleDNSModify,
+			DeleteHandler: handleDNSDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subDeviceNetworkStatus.MaxProcessTimeWarn = warningTime
-	subDeviceNetworkStatus.MaxProcessTimeError = errorTime
-	subDeviceNetworkStatus.ModifyHandler = handleDNSModify
-	subDeviceNetworkStatus.CreateHandler = handleDNSModify
-	subDeviceNetworkStatus.DeleteHandler = handleDNSDelete
 	zedrouterCtx.subDeviceNetworkStatus = subDeviceNetworkStatus
 	subDeviceNetworkStatus.Activate()
 
 	subAssignableAdapters, err := pubsub.Subscribe("domainmgr",
-		types.AssignableAdapters{}, false, &zedrouterCtx)
+		types.AssignableAdapters{}, false, &zedrouterCtx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleAAModify,
+			ModifyHandler: handleAAModify,
+			DeleteHandler: handleAADelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subAssignableAdapters.MaxProcessTimeWarn = warningTime
-	subAssignableAdapters.MaxProcessTimeError = errorTime
-	subAssignableAdapters.ModifyHandler = handleAAModify
-	subAssignableAdapters.CreateHandler = handleAAModify
-	subAssignableAdapters.DeleteHandler = handleAADelete
 	zedrouterCtx.subAssignableAdapters = subAssignableAdapters
 	subAssignableAdapters.Activate()
 
 	// Look for global config such as log levels
 	subGlobalConfig, err := pubsub.Subscribe("", types.GlobalConfig{},
-		false, &zedrouterCtx)
+		false, &zedrouterCtx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleGlobalConfigModify,
+			ModifyHandler: handleGlobalConfigModify,
+			DeleteHandler: handleGlobalConfigDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subGlobalConfig.MaxProcessTimeWarn = warningTime
-	subGlobalConfig.MaxProcessTimeError = errorTime
-	subGlobalConfig.ModifyHandler = handleGlobalConfigModify
-	subGlobalConfig.CreateHandler = handleGlobalConfigModify
-	subGlobalConfig.DeleteHandler = handleGlobalConfigDelete
 	zedrouterCtx.subGlobalConfig = subGlobalConfig
 	subGlobalConfig.Activate()
 
@@ -254,7 +257,7 @@ func Run() {
 	for !zedrouterCtx.GCInitialized {
 		log.Infof("waiting for GCInitialized")
 		select {
-		case change := <-subGlobalConfig.C:
+		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
 		case <-stillRunning.C:
 		}
@@ -271,13 +274,13 @@ func Run() {
 	for !zedrouterCtx.assignableAdapters.Initialized {
 		log.Infof("Waiting for AssignableAdapters\n")
 		select {
-		case change := <-subGlobalConfig.C:
+		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
 
-		case change := <-subAssignableAdapters.C:
+		case change := <-subAssignableAdapters.MsgChan():
 			subAssignableAdapters.ProcessChange(change)
 
-		case change := <-subDeviceNetworkStatus.C:
+		case change := <-subDeviceNetworkStatus.MsgChan():
 			subDeviceNetworkStatus.ProcessChange(change)
 
 		// Run stillRunning since we waiting for zedagent to deliver
@@ -290,69 +293,74 @@ func Run() {
 	log.Infof("Have %d assignable adapters\n", len(aa.IoBundleList))
 
 	subNetworkInstanceConfig, err := pubsub.Subscribe("zedagent",
-		types.NetworkInstanceConfig{}, false, &zedrouterCtx)
+		types.NetworkInstanceConfig{}, false, &zedrouterCtx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleNetworkInstanceModify,
+			ModifyHandler: handleNetworkInstanceModify,
+			DeleteHandler: handleNetworkInstanceDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subNetworkInstanceConfig.MaxProcessTimeWarn = warningTime
-	subNetworkInstanceConfig.MaxProcessTimeError = errorTime
-	subNetworkInstanceConfig.ModifyHandler = handleNetworkInstanceModify
-	subNetworkInstanceConfig.CreateHandler = handleNetworkInstanceModify
-	subNetworkInstanceConfig.DeleteHandler = handleNetworkInstanceDelete
 	zedrouterCtx.subNetworkInstanceConfig = subNetworkInstanceConfig
 	subNetworkInstanceConfig.Activate()
 	log.Infof("Subscribed to NetworkInstanceConfig")
 
 	// Subscribe to AppNetworkConfig from zedmanager and from zedagent
 	subAppNetworkConfig, err := pubsub.Subscribe("zedmanager",
-		types.AppNetworkConfig{}, false, &zedrouterCtx)
+		types.AppNetworkConfig{}, false, &zedrouterCtx, &pubsub.SubscriptionOptions{
+			CreateHandler:  handleAppNetworkCreate,
+			ModifyHandler:  handleAppNetworkModify,
+			DeleteHandler:  handleAppNetworkConfigDelete,
+			RestartHandler: handleRestart,
+			WarningTime:    warningTime,
+			ErrorTime:      errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subAppNetworkConfig.MaxProcessTimeWarn = warningTime
-	subAppNetworkConfig.MaxProcessTimeError = errorTime
-	subAppNetworkConfig.ModifyHandler = handleAppNetworkModify
-	subAppNetworkConfig.CreateHandler = handleAppNetworkCreate
-	subAppNetworkConfig.DeleteHandler = handleAppNetworkConfigDelete
-	subAppNetworkConfig.RestartHandler = handleRestart
 	zedrouterCtx.subAppNetworkConfig = subAppNetworkConfig
 	subAppNetworkConfig.Activate()
 
 	// Subscribe to AppNetworkConfig from zedmanager
 	subAppNetworkConfigAg, err := pubsub.Subscribe("zedagent",
-		types.AppNetworkConfig{}, false, &zedrouterCtx)
+		types.AppNetworkConfig{}, false, &zedrouterCtx, &pubsub.SubscriptionOptions{
+			CreateHandler: handleAppNetworkCreate,
+			ModifyHandler: handleAppNetworkModify,
+			DeleteHandler: handleAppNetworkConfigDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subAppNetworkConfigAg.MaxProcessTimeWarn = warningTime
-	subAppNetworkConfigAg.MaxProcessTimeError = errorTime
-	subAppNetworkConfigAg.ModifyHandler = handleAppNetworkModify
-	subAppNetworkConfigAg.CreateHandler = handleAppNetworkCreate
-	subAppNetworkConfigAg.DeleteHandler = handleAppNetworkConfigDelete
 	zedrouterCtx.subAppNetworkConfigAg = subAppNetworkConfigAg
 	subAppNetworkConfigAg.Activate()
 
 	subLispInfoStatus, err := pubsub.Subscribe("lisp-ztr",
-		types.LispInfoStatus{}, false, &zedrouterCtx)
+		types.LispInfoStatus{}, false, &zedrouterCtx, &pubsub.SubscriptionOptions{
+			ModifyHandler: handleLispInfoModify,
+			DeleteHandler: handleLispInfoDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subLispInfoStatus.MaxProcessTimeWarn = warningTime
-	subLispInfoStatus.MaxProcessTimeError = errorTime
-	subLispInfoStatus.ModifyHandler = handleLispInfoModify
-	subLispInfoStatus.DeleteHandler = handleLispInfoDelete
 	zedrouterCtx.subLispInfoStatus = subLispInfoStatus
 	subLispInfoStatus.Activate()
 
 	subLispMetrics, err := pubsub.Subscribe("lisp-ztr",
-		types.LispMetrics{}, false, &zedrouterCtx)
+		types.LispMetrics{}, false, &zedrouterCtx, &pubsub.SubscriptionOptions{
+			ModifyHandler: handleLispMetricsModify,
+			DeleteHandler: handleLispMetricsDelete,
+			WarningTime:   warningTime,
+			ErrorTime:     errorTime,
+		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	subLispMetrics.MaxProcessTimeWarn = warningTime
-	subLispMetrics.MaxProcessTimeError = errorTime
-	subLispMetrics.ModifyHandler = handleLispMetricsModify
-	subLispMetrics.DeleteHandler = handleLispMetricsDelete
 	zedrouterCtx.subLispMetrics = subLispMetrics
 	subLispMetrics.Activate()
 
@@ -390,19 +398,19 @@ func Run() {
 	for !subAppNetworkConfig.Restarted() {
 		log.Infof("Waiting for zedmanager to report restarted\n")
 		select {
-		case change := <-subGlobalConfig.C:
+		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
 
-		case change := <-subAssignableAdapters.C:
+		case change := <-subAssignableAdapters.MsgChan():
 			subAssignableAdapters.ProcessChange(change)
 
-		case change := <-subAppNetworkConfig.C:
+		case change := <-subAppNetworkConfig.MsgChan():
 			subAppNetworkConfig.ProcessChange(change)
 
-		case change := <-subDeviceNetworkStatus.C:
+		case change := <-subDeviceNetworkStatus.MsgChan():
 			subDeviceNetworkStatus.ProcessChange(change)
 
-		case change := <-subNetworkInstanceConfig.C:
+		case change := <-subNetworkInstanceConfig.MsgChan():
 			log.Infof("AppNetworkConfig - waiting to Restart - "+
 				"InstanceConfig change at %+v", time.Now())
 			subNetworkInstanceConfig.ProcessChange(change)
@@ -423,19 +431,19 @@ func Run() {
 
 	for {
 		select {
-		case change := <-subGlobalConfig.C:
+		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
 
-		case change := <-subAssignableAdapters.C:
+		case change := <-subAssignableAdapters.MsgChan():
 			subAssignableAdapters.ProcessChange(change)
 
-		case change := <-subAppNetworkConfig.C:
+		case change := <-subAppNetworkConfig.MsgChan():
 			subAppNetworkConfig.ProcessChange(change)
 
-		case change := <-subAppNetworkConfigAg.C:
+		case change := <-subAppNetworkConfigAg.MsgChan():
 			subAppNetworkConfigAg.ProcessChange(change)
 
-		case change := <-subDeviceNetworkStatus.C:
+		case change := <-subDeviceNetworkStatus.MsgChan():
 			subDeviceNetworkStatus.ProcessChange(change)
 
 		case change, ok := <-addrChanges:
@@ -542,14 +550,14 @@ func Run() {
 			pubsub.CheckMaxTimeTopic(agentName, "checkAndReprogram", start,
 				warningTime, errorTime)
 
-		case change := <-subNetworkInstanceConfig.C:
+		case change := <-subNetworkInstanceConfig.MsgChan():
 			log.Infof("NetworkInstanceConfig change at %+v", time.Now())
 			subNetworkInstanceConfig.ProcessChange(change)
 
-		case change := <-subLispInfoStatus.C:
+		case change := <-subLispInfoStatus.MsgChan():
 			subLispInfoStatus.ProcessChange(change)
 
-		case change := <-subLispMetrics.C:
+		case change := <-subLispMetrics.MsgChan():
 			subLispMetrics.ProcessChange(change)
 
 		case <-stillRunning.C:

--- a/pkg/pillar/pubsub/pubsubintf.go
+++ b/pkg/pillar/pubsub/pubsubintf.go
@@ -13,6 +13,8 @@ type Publication interface {
 	Unpublish(key string) error
 	// SignalRestarted - Signal the publisher has started.
 	SignalRestarted() error
+	// ClearRestarted clear the restarted flag
+	ClearRestarted() error
 	// Get - Lookup an object
 	Get(key string) (interface{}, error)
 	// GetAll - Get a copy of the objects.
@@ -25,8 +27,12 @@ type Subscription interface {
 	Get(key string) (interface{}, error)
 	// GetAll - Get a copy of the objects.
 	GetAll() map[string]interface{}
+	// Restarted report if this subscription has been marked as restarted
+	Restarted() bool
 	// ProcessChange - Invoked on the string msg from Subscription Channel
 	ProcessChange(change string)
 	// MsgChan - Message Channel for Subscription
 	MsgChan() <-chan string
+	// Activate start the subscription
+	Activate() error
 }


### PR DESCRIPTION
This finishes the work of #500 by making the agents consume `Publication` and `Subscription` (the interfaces) and not `PublicationImpl` and `SubscriptionImpl`, the concrete implementations which should be hidden from the agents.

There are 2 commits. The first is the changes to `pubsub/`, while the second is the changes in the consumption.

I recreated the work I had done when I originally turned pubsub into interfaces (like you did in #500  @kalyan-nidumolu ), but I had to redo it all from memory. Worked out well, though.