### PR TITLE
Use imageID to identify VMs and containers

### DIFF
--- a/pkg/pillar/cmd/baseosmgr/baseosmgr.go
+++ b/pkg/pillar/cmd/baseosmgr/baseosmgr.go
@@ -239,7 +239,7 @@ func handleBaseOsCreate(ctxArg interface{}, key string, configArg interface{}) {
 	for i, sc := range config.StorageConfigList {
 		ss := &status.StorageStatusList[i]
 		ss.Name = sc.Name
-		ss.ImageSha256 = sc.ImageSha256
+		ss.ImageID = sc.ImageID
 		ss.Target = sc.Target
 	}
 	// Check image count
@@ -327,7 +327,7 @@ func handleCertObjCreate(ctxArg interface{}, key string, configArg interface{}) 
 	for i, sc := range config.StorageConfigList {
 		ss := &status.StorageStatusList[i]
 		ss.Name = sc.Name
-		ss.ImageSha256 = sc.ImageSha256
+		ss.ImageID = sc.ImageID
 		ss.FinalObjDir = types.CertificateDirname
 	}
 
@@ -376,7 +376,7 @@ func handleDownloadStatusModify(ctxArg interface{}, key string,
 	status := statusArg.(types.DownloaderStatus)
 	ctx := ctxArg.(*baseOsMgrContext)
 	log.Infof("handleDownloadStatusModify for %s\n",
-		status.Safename)
+		status.ImageID)
 	updateDownloaderStatus(ctx, &status)
 }
 
@@ -397,7 +397,7 @@ func handleVerifierStatusModify(ctxArg interface{}, key string,
 
 	status := statusArg.(types.VerifyImageStatus)
 	ctx := ctxArg.(*baseOsMgrContext)
-	log.Infof("handleVerifierStatusModify for %s\n", status.Safename)
+	log.Infof("handleVerifierStatusModify for %s\n", status.ImageID)
 	updateVerifierStatus(ctx, &status)
 }
 

--- a/pkg/pillar/cmd/baseosmgr/handlecerts.go
+++ b/pkg/pillar/cmd/baseosmgr/handlecerts.go
@@ -11,24 +11,25 @@ import (
 	"time"
 
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
 )
 
-func lookupCertObjSafename(ctx *baseOsMgrContext, safename string) *types.CertObjConfig {
+// Returns a list of all matching cert objects
+func lookupCertObjImageID(ctx *baseOsMgrContext, imageID uuid.UUID) []*types.CertObjConfig {
 
+	var result []*types.CertObjConfig
 	sub := ctx.subCertObjConfig
 	items := sub.GetAll()
 	for _, c := range items {
 		config := c.(types.CertObjConfig)
 		for _, sc := range config.StorageConfigList {
-			safename1 := types.UrlToSafename(sc.Name,
-				sc.ImageSha256)
-			if safename == safename1 {
-				return &config
+			if uuid.Equal(imageID, sc.ImageID) {
+				result = append(result, &config)
 			}
 		}
 	}
-	return nil
+	return result
 }
 
 // check if the storage object config have changed
@@ -55,27 +56,27 @@ func certObjCheckConfigModify(ctx *baseOsMgrContext, uuidStr string,
 	return false
 }
 
-// XXX but there can be multiple CertObjConfig/Status with the same safename!
-// This only looks for one.
-func certObjHandleStatusUpdateSafename(ctx *baseOsMgrContext, safename string) {
+func certObjHandleStatusUpdateImageID(ctx *baseOsMgrContext, imageID uuid.UUID) {
 
-	log.Infof("certObjHandleStatusUpdateSafename(%s)\n", safename)
-	config := lookupCertObjSafename(ctx, safename)
-	if config == nil {
-		log.Infof("certObjHandleStatusUpdateSafename(%s) not found\n",
-			safename)
+	log.Infof("certObjHandleStatusUpdateImageId(%s)\n", imageID)
+	configPtrList := lookupCertObjImageID(ctx, imageID)
+	if len(configPtrList) == 0 {
+		log.Infof("certObjHandleStatusUpdateImageID(%s) not found\n",
+			imageID)
 		return
 	}
-	uuidStr := config.Key()
-	status := lookupCertObjStatus(ctx, uuidStr)
-	if status == nil {
-		log.Infof("certObjHandleStatusUpdateSafename(%s) no status\n",
-			safename)
-		return
+	for _, configPtr := range configPtrList {
+		uuidStr := configPtr.Key()
+		statusPtr := lookupCertObjStatus(ctx, uuidStr)
+		if statusPtr == nil {
+			log.Infof("certObjHandleStatusUpdateImageID(%s) no status\n",
+				imageID)
+			continue
+		}
+		log.Infof("certObjHandleStatusUpdateImageID(%s) found %s\n",
+			imageID, uuidStr)
+		certObjHandleStatusUpdate(ctx, configPtr, statusPtr)
 	}
-	log.Infof("certObjHandleStatusUpdateSafename(%s) found %s\n",
-		safename, uuidStr)
-	certObjHandleStatusUpdate(ctx, config, status)
 }
 
 func certObjHandleStatusUpdate(ctx *baseOsMgrContext,
@@ -139,12 +140,11 @@ func doCertObjInstall(ctx *baseOsMgrContext, uuidStr string, config types.CertOb
 	for i, sc := range config.StorageConfigList {
 		ss := &status.StorageStatusList[i]
 
-		if ss.Name != sc.Name ||
-			ss.ImageSha256 != sc.ImageSha256 {
+		if ss.Name != sc.Name || !uuid.Equal(ss.ImageID, sc.ImageID) {
 			// Report to zedcloud
 			errString := fmt.Sprintf("%s, Storage config mismatch:\n\t%s\n\t%s\n\t%s\n\t%s\n\n", uuidStr,
 				sc.Name, ss.Name,
-				sc.ImageSha256, ss.ImageSha256)
+				sc.ImageID, ss.ImageID)
 			log.Errorln(errString)
 			status.Error = errString
 			status.ErrorTime = time.Now()
@@ -240,21 +240,20 @@ func doCertObjUninstall(ctx *baseOsMgrContext, uuidStr string,
 	for i := range status.StorageStatusList {
 
 		ss := &status.StorageStatusList[i]
-		safename := types.UrlToSafename(ss.Name, ss.ImageSha256)
-		log.Infof("doCertObjUninstall(%s) safename %s\n",
-			uuidStr, safename)
+		log.Infof("doCertObjUninstall(%s) imageID %s\n",
+			uuidStr, ss.ImageID)
 		// Decrease refcount if we had increased it
 		if ss.HasDownloaderRef {
-			removeDownloaderConfig(ctx, types.CertObj, safename)
+			removeDownloaderConfig(ctx, types.CertObj, ss.ImageID)
 			ss.HasDownloaderRef = false
 			changed = true
 		}
 
-		ds := lookupDownloaderStatus(ctx, types.CertObj, safename)
+		ds := lookupDownloaderStatus(ctx, types.CertObj, ss.ImageID)
 		// XXX if additional refs it will not go away
 		if false && ds != nil {
 			log.Infof("doCertObjUninstall(%s) download %s not yet gone\n",
-				uuidStr, safename)
+				uuidStr, ss.ImageID)
 			removedAll = false
 			continue
 		}
@@ -274,6 +273,7 @@ func doCertObjUninstall(ctx *baseOsMgrContext, uuidStr string,
 	return changed, del
 }
 
+// key is UUIDandVersion string
 func lookupCertObjConfig(ctx *baseOsMgrContext, key string) *types.CertObjConfig {
 
 	sub := ctx.subCertObjConfig
@@ -286,6 +286,7 @@ func lookupCertObjConfig(ctx *baseOsMgrContext, key string) *types.CertObjConfig
 	return &config
 }
 
+// key is UUIDandVersion string
 func lookupCertObjStatus(ctx *baseOsMgrContext, key string) *types.CertObjStatus {
 	pub := ctx.pubCertObjStatus
 	st, _ := pub.Get(key)

--- a/pkg/pillar/cmd/baseosmgr/handleverifier.go
+++ b/pkg/pillar/cmd/baseosmgr/handleverifier.go
@@ -188,6 +188,12 @@ func checkStorageVerifierStatus(ctx *baseOsMgrContext, objType string, uuidStr s
 			ret.MinState = types.DOWNLOADED
 			continue
 		}
+		if ss.ImageSha256 != vs.ImageSha256 {
+			log.Infof("updating imagesha from %s to %s",
+				ss.ImageSha256, vs.ImageSha256)
+			ss.ImageSha256 = vs.ImageSha256
+			ret.Changed = true
+		}
 		if ret.MinState > vs.State {
 			ret.MinState = vs.State
 		}

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1421,6 +1421,7 @@ func configToStatus(ctx *domainContext, config types.DomainConfig,
 	for i, dc := range config.DiskConfigList {
 		ds := &status.DiskStatusList[i]
 		ds.ImageID = dc.ImageID
+		ds.ImageSha256 = dc.ImageSha256
 		ds.ReadOnly = dc.ReadOnly
 		ds.Preserve = dc.Preserve
 		ds.Format = dc.Format
@@ -1449,7 +1450,7 @@ func configToStatus(ctx *domainContext, config types.DomainConfig,
 		} else {
 			log.Infof("getting image file location IsContainer(%v), ContainerImageId(%s), ImageSha256(%s)",
 				status.IsContainer, ds.ImageID.String(), dc.ImageSha256)
-			location, err := utils.VerifiedImageFileLocation(ds.ImageID)
+			location, err := utils.VerifiedImageFileLocation(ds.ImageSha256)
 			if err != nil {
 				log.Errorf("configToStatus: Failed to get Image File Location. "+
 					"err: %+s", err.Error())
@@ -2056,15 +2057,16 @@ func DomainCreate(status types.DomainStatus) (int, string, error) {
 		// get the rkt image hash for this file; if we do not have it in the rkt cache,
 		// convert it
 		// XXX we assume a container has one image. XXX do we check somewhere?
-		imageID := status.DiskStatusList[0].ImageID
-		ociFilename, err := utils.VerifiedImageFileLocation(imageID)
+		ociFilename, err := utils.VerifiedImageFileLocation(status.DiskStatusList[0].ImageSha256)
 		if err != nil {
 			log.Errorf("DomainCreate: Failed to get Image File Location. "+
 				"err: %+s", err.Error())
 			return domainID, podUUID, err
 		}
+		log.Infof("ociFilename %s sha %s", ociFilename, status.DiskStatusList[0].ImageSha256)
 		imageHash, err := ociToRktImageHash(ociFilename)
 		if err != nil {
+			log.Error(err)
 			return domainID, podUUID, fmt.Errorf("unable to get rkt image hash: %v", err)
 		}
 		domainID, podUUID, err = rktRun(status.DomainName, filename, imageHash)

--- a/pkg/pillar/cmd/domainmgr/rkt.go
+++ b/pkg/pillar/cmd/domainmgr/rkt.go
@@ -128,6 +128,7 @@ func ociToRktImageHash(ociFilename string) (string, error) {
 	// this will not be true long-run, but this all goes away when rkt does.
 	dockerHash, err := ociGetHash(ociFilename)
 	if err != nil {
+		log.Errorf(err.Error())
 		return "", fmt.Errorf("error getting hash of repository for OCI file %s: %v", ociFilename, err)
 	}
 	// if we already have it, just return it

--- a/pkg/pillar/cmd/downloader/syncop.go
+++ b/pkg/pillar/cmd/downloader/syncop.go
@@ -30,7 +30,7 @@ func handleSyncOp(ctx *downloaderContext, key string,
 
 	if status.ObjType == "" {
 		log.Fatalf("handleSyncOp: No ObjType for %s\n",
-			status.Safename)
+			status.ImageID)
 	}
 
 	// get the datastore context
@@ -41,14 +41,13 @@ func handleSyncOp(ctx *downloaderContext, key string,
 
 	locDirname := types.DownloadDirname + "/" + status.ObjType
 	locFilename = locDirname + "/pending"
+	// XXX common routines to determine pathnames?
+	locFilename = locFilename + "/" + config.ImageID.String()
 
 	// update status to DOWNLOAD STARTED
+	status.FileLocation = locFilename
 	status.State = types.DOWNLOAD_STARTED
 	publishDownloaderStatus(ctx, status)
-
-	if config.ImageSha256 != "" {
-		locFilename = locFilename + "/" + config.ImageSha256
-	}
 
 	if _, err := os.Stat(locFilename); err != nil {
 		log.Debugf("Create %s\n", locFilename)
@@ -57,9 +56,8 @@ func handleSyncOp(ctx *downloaderContext, key string,
 		}
 	}
 
-	filename := types.SafenameToFilename(config.Safename)
-
-	locFilename = locFilename + "/" + config.Safename
+	filename := config.Name // XXX set for containers?
+	locFilename = locFilename + "/" + config.Name
 
 	log.Infof("Downloading <%s> to <%s> using %v allow non-free port\n",
 		config.Name, locFilename, config.AllowNonFreePort)
@@ -228,7 +226,7 @@ func handleSyncOpResponse(ctx *downloaderContext, config types.DownloaderConfig,
 
 	if status.ObjType == "" {
 		log.Fatalf("handleSyncOpResponse: No ObjType for %s\n",
-			status.Safename)
+			status.ImageID)
 	}
 	locDirname := types.DownloadDirname + "/" + status.ObjType
 	if errStr != "" {

--- a/pkg/pillar/cmd/verifier/verifier.go
+++ b/pkg/pillar/cmd/verifier/verifier.go
@@ -730,18 +730,9 @@ func verifyObjectSha(ctx *verifierContext, config *types.VerifyImageConfig,
 
 	imageHash := fmt.Sprintf("%x", imageHashB)
 	configuredHash := strings.ToLower(config.ImageSha256)
-	// XXX: the ImageSha256 property should never be filled with anything
-	// other than a sha256 hash of the image. It should be valid as blank,
-	// which means "do not verify, as I have nothing to verify against."
-	// Unfortunately, some parts of the code assume that ImageSha256 alwats will
-	// have something, so containers override it with the imageUUID. Once that is
-	// changed, this code should go away.
-	if _, err := uuid.FromString(config.ImageSha256); err == nil {
-		configuredHash = ""
-	}
-
 	if configuredHash == "" {
-		log.Infof("no image hash provided, skipping root validation")
+		log.Infof("no image hash provided, skipping root validation. Setting to %s for %s", imageHash, config.ImageID)
+		status.ImageSha256 = strings.ToUpper(imageHash)
 	} else if imageHash != configuredHash {
 		log.Errorf("computed   %s\n", imageHash)
 		log.Errorf("configured %s\n", configuredHash)

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -475,9 +475,9 @@ func PublishMetricsToZedCloud(ctx *zedagentContext, cpuMemoryStat [][]string,
 	for _, st := range verifierStatusMap {
 		vs := st.(types.VerifyImageStatus)
 		log.Debugf("verifierStatusMap %s size %d\n",
-			vs.Safename, vs.Size)
+			vs.Name, vs.Size)
 		metric := metrics.DiskMetric{
-			Disk:  vs.Safename,
+			Disk:  vs.Name,
 			Total: RoundToMbytes(uint64(vs.Size)),
 		}
 		ReportDeviceMetric.Disk = append(ReportDeviceMetric.Disk, &metric)
@@ -486,13 +486,13 @@ func PublishMetricsToZedCloud(ctx *zedagentContext, cpuMemoryStat [][]string,
 	for _, st := range downloaderStatusMap {
 		ds := st.(types.DownloaderStatus)
 		log.Debugf("downloaderStatusMap %s size %d\n",
-			ds.Safename, ds.Size)
+			ds.Name, ds.Size)
 		if _, found := verifierStatusMap[ds.Key()]; found {
 			log.Debugf("Found verifierStatusMap for %s\n", ds.Key())
 			continue
 		}
 		metric := metrics.DiskMetric{
-			Disk:  ds.Safename,
+			Disk:  ds.Name,
 			Total: RoundToMbytes(uint64(ds.Size)),
 		}
 		ReportDeviceMetric.Disk = append(ReportDeviceMetric.Disk, &metric)

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -968,17 +968,6 @@ func parseStorageConfigList(objType string,
 		image.Target = strings.ToLower(drive.Target.String())
 		image.Devtype = strings.ToLower(drive.Drvtype.String())
 		image.ImageSha256 = drive.Image.Sha256
-		if image.Format == zconfig.Format_CONTAINER && image.ImageSha256 == "" {
-			// XXX HACK - The right fix is to use ImageIDs to Track
-			// images instead of SHA.
-			// Currently, for container images, Zedcloud doesn't have
-			// The SHA for the image. Use ImageID as the Sha.
-			// Download Config add verifier config / status are keyed by SHA.
-			// TIll we move away from that, set ImageSha to ImageID to
-			// handle this case.
-			image.ImageSha256 = image.ImageID.String()
-
-		}
 		storageList[idx] = *image
 		idx++
 	}

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -912,7 +912,7 @@ func handleVerifierStatusModify(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
 	status := statusArg.(types.VerifyImageStatus)
-	log.Infof("handleVerifierStatusModify for %s\n", status.Safename)
+	log.Infof("handleVerifierStatusModify for %s\n", status.ImageID)
 	// Nothing to do
 }
 

--- a/pkg/pillar/cmd/zedmanager/handledomainmgr.go
+++ b/pkg/pillar/cmd/zedmanager/handledomainmgr.go
@@ -73,7 +73,8 @@ func MaybeAddDomainConfig(ctx *zedmanagerContext,
 			log.Error(errStr)
 			return errors.New(errStr)
 		}
-		location := aiStatus.StorageStatusList[index].ActiveFileLocation
+		ssPtr := &aiStatus.StorageStatusList[index]
+		location := ssPtr.ActiveFileLocation
 		if location == "" {
 			errStr := "No ActiveFileLocation"
 			log.Error(errStr)
@@ -84,7 +85,8 @@ func MaybeAddDomainConfig(ctx *zedmanagerContext,
 		case "", "disk", "tgtunknown":
 			disk := &dc.DiskConfigList[i]
 			disk.ImageID = sc.ImageID
-			disk.ImageSha256 = sc.ImageSha256 // For compat with running images
+			// Pick up sha from verifier
+			disk.ImageSha256 = ssPtr.ImageSha256
 			disk.ReadOnly = sc.ReadOnly
 			disk.Preserve = sc.Preserve
 			disk.Format = sc.Format

--- a/pkg/pillar/cmd/zedmanager/handledomainmgr.go
+++ b/pkg/pillar/cmd/zedmanager/handledomainmgr.go
@@ -80,17 +80,11 @@ func MaybeAddDomainConfig(ctx *zedmanagerContext,
 			return errors.New(errStr)
 		}
 
-		if aiStatus.IsContainer {
-			if dc.ContainerImageID == "" {
-				dc.ContainerImageID =
-					aiStatus.StorageStatusList[index].ContainerImageID
-			}
-		}
 		switch sc.Target {
 		case "", "disk", "tgtunknown":
 			disk := &dc.DiskConfigList[i]
 			disk.ImageID = sc.ImageID
-			disk.ImageSha256 = sc.ImageSha256
+			disk.ImageSha256 = sc.ImageSha256 // For compat with running images
 			disk.ReadOnly = sc.ReadOnly
 			disk.Preserve = sc.Preserve
 			disk.Format = sc.Format

--- a/pkg/pillar/cmd/zedmanager/handleimagestatus.go
+++ b/pkg/pillar/cmd/zedmanager/handleimagestatus.go
@@ -9,6 +9,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// The /persist/img directory does not include ImageIDs and we don't want to add it
+// in order to avoid a flag day for running applications. Hence we lookup on the ImageSha256
 func lookupImageStatusForApp(
 	ctx *zedmanagerContext, appUUID uuid.UUID,
 	imageSha string) *types.ImageStatus {
@@ -16,7 +18,7 @@ func lookupImageStatusForApp(
 	imageStatusList := ctx.subImageStatus.GetAll()
 	for _, item := range imageStatusList {
 		status := item.(types.ImageStatus)
-		if status.AppInstUUID == appUUID && status.ImageSha256 == imageSha {
+		if uuid.Equal(status.AppInstUUID, appUUID) && status.ImageSha256 == imageSha {
 			log.Debugf("lookupImageStatusForApp: IS found. appUUID: %s, "+
 				"imageSha: %s", appUUID.String(), imageSha)
 			return &status

--- a/pkg/pillar/cmd/zedmanager/handleimagestatus.go
+++ b/pkg/pillar/cmd/zedmanager/handleimagestatus.go
@@ -9,8 +9,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// The /persist/img directory does not include ImageIDs and we don't want to add it
-// in order to avoid a flag day for running applications. Hence we lookup on the ImageSha256
+// The /persist/img directory does not include ImageIDs and we don't want to add
+// it in order to avoid a flag day for running applications. Hence we lookup on
+// the ImageSha256 and not ImageID in this function
 func lookupImageStatusForApp(
 	ctx *zedmanagerContext, appUUID uuid.UUID,
 	imageSha string) *types.ImageStatus {

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -16,78 +16,31 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// Find all the config which refer to this safename.
-func updateAIStatusWithStorageSafename(ctx *zedmanagerContext,
-	safename string,
-	updateContainerImageID bool, containerImageID string) {
+// Find all the config which refer to this imageID.
+func updateAIStatusWithStorageImageID(ctx *zedmanagerContext, imageID uuid.UUID) {
 
-	log.Infof("updateAIStatusWithStorageSafename for %s - "+
-		"updateContainerImageID: %v, containerImageID: %s\n",
-		safename, updateContainerImageID, containerImageID)
+	log.Infof("updateAIStatusWithStorageImageID for %s", imageID)
 
 	pub := ctx.pubAppInstanceStatus
 	items := pub.GetAll()
 	found := false
 	for _, st := range items {
 		status := st.(types.AppInstanceStatus)
-		log.Debugf("updateAIStatusWithStorageSafename: Processing "+
+		log.Debugf("updateAIStatusWithStorageImageID Processing "+
 			"AppInstanceConfig for UUID %s\n",
 			status.UUIDandVersion.UUID)
 		for ssIndx := range status.StorageStatusList {
 			ssPtr := &status.StorageStatusList[ssIndx]
-			safename2 := (*ssPtr).Safename()
-			if safename == safename2 {
-				log.Infof("Found StorageStatus URL %s safename %s\n",
-					ssPtr.Name, safename)
-				if updateContainerImageID {
-					if ssPtr.ContainerImageID != containerImageID {
-						log.Debugf("Update AIS containerImageID: %s\n",
-							containerImageID)
-						ssPtr.ContainerImageID = containerImageID
-						publishAppInstanceStatus(ctx, &status)
-					} else {
-						log.Debugf("No change in ContainerId in Status. "+
-							"ssPtr.ContainerImageID: %s, containerImageID: %s",
-							ssPtr.ContainerImageID, containerImageID)
-					}
-				}
+			if uuid.Equal((*ssPtr).ImageID, imageID) {
+				log.Infof("Found StorageStatus URL %s imageID %s\n",
+					ssPtr.Name, imageID)
 				updateAIStatusUUID(ctx, status.Key())
 				found = true
 			}
 		}
 	}
 	if !found {
-		log.Warnf("updateAIStatusWithStorageSafename for %s not found\n", safename)
-	}
-}
-
-// updateAIStatusWithImageSha
-//  Update AI Sattus for all App Instances that use the specified image
-func updateAIStatusWithImageSha(ctx *zedmanagerContext, sha string) {
-
-	log.Infof("updateAIStatusWithImageSha for %s\n", sha)
-	pub := ctx.pubAppInstanceStatus
-	items := pub.GetAll()
-	found := false
-	for _, st := range items {
-		status := st.(types.AppInstanceStatus)
-		log.Debugf("Processing AppInstanceConfig for UUID %s\n",
-			status.UUIDandVersion.UUID)
-		for _, ss := range status.StorageStatusList {
-			if sha == ss.ImageSha256 {
-				log.Infof("Found StorageStatus URL %s sha %s\n",
-					ss.Name, sha)
-				updateAIStatusUUID(ctx, status.Key())
-				found = true
-				break
-			}
-		}
-		if found {
-			break
-		}
-	}
-	if !found {
-		log.Warnf("updateAIStatusWithImageSha for %s not found\n", sha)
+		log.Warnf("updateAIStatusWithStorageImageID for %s not found\n", imageID)
 	}
 }
 
@@ -171,10 +124,10 @@ func removeAIStatus(ctx *zedmanagerContext, status *types.AppInstanceStatus) {
 	}
 }
 
-// Find all the Status which refer to this safename.
-func removeAIStatusSafename(ctx *zedmanagerContext, safename string) {
+// Find all the Status which refer to this imageID
+func removeAIStatusImageID(ctx *zedmanagerContext, imageID uuid.UUID) {
 
-	log.Infof("removeAIStatusSafename for %s\n", safename)
+	log.Infof("removeAIStatusImageID for %s\n", imageID)
 	pub := ctx.pubAppInstanceStatus
 	items := pub.GetAll()
 	found := false
@@ -183,42 +136,16 @@ func removeAIStatusSafename(ctx *zedmanagerContext, safename string) {
 		log.Debugf("Processing AppInstanceStatus for UUID %s\n",
 			status.UUIDandVersion.UUID)
 		for _, ss := range status.StorageStatusList {
-			safename2 := ss.Safename()
-			if safename == safename2 {
-				log.Debugf("Found StorageStatus URL %s safename %s\n",
-					ss.Name, safename2)
+			if uuid.Equal(ss.ImageID, imageID) {
+				log.Debugf("Found StorageStatus URL %s imageID %s\n",
+					ss.Name, ss.ImageID)
 				updateOrRemove(ctx, status)
 				found = true
 			}
 		}
 	}
 	if !found {
-		log.Warnf("removeAIStatusSafename for %s not found\n", safename)
-	}
-}
-
-// Find all the Status which refer to this safename.
-func removeAIStatusSha(ctx *zedmanagerContext, sha string) {
-
-	log.Infof("removeAIStatusSha for %s\n", sha)
-	pub := ctx.pubAppInstanceStatus
-	items := pub.GetAll()
-	found := false
-	for _, st := range items {
-		status := st.(types.AppInstanceStatus)
-		log.Debugf("Processing AppInstanceStatus for UUID %s\n",
-			status.UUIDandVersion.UUID)
-		for _, ss := range status.StorageStatusList {
-			if sha == ss.ImageSha256 {
-				log.Debugf("Found StorageStatus URL %s sha %s\n",
-					ss.Name, sha)
-				updateOrRemove(ctx, status)
-				found = true
-			}
-		}
-	}
-	if !found {
-		log.Warnf("removeAIStatusSha for %s not found\n", sha)
+		log.Warnf("removeAIStatusImageID for %s not found\n", imageID)
 	}
 }
 
@@ -377,7 +304,7 @@ func doInstallProcessStorageEntriesWithVerifiedImage(
 	*types.VerifyImageStatus, bool) {
 
 	changed := false
-	safename := ssPtr.Safename()
+	imageID := ssPtr.ImageID
 
 	// Check if the image is already present in ImageStatus. If yes,
 	// go ahead and use it.
@@ -395,45 +322,36 @@ func doInstallProcessStorageEntriesWithVerifiedImage(
 		return isPtr, nil, changed
 	}
 	// Check if image is already verified
-	vs := lookupVerifyImageStatusAny(ctx, safename, ssPtr.ImageSha256)
+	vs := lookupVerifyImageStatus(ctx, ssPtr.ImageID)
 	// Handle post-reboot verification in progress by allowing
 	// types.DOWNLOADED. If the verification later fails we will
 	// get a delete of the VerifyImageStatus and skip this
 	if vs == nil {
 		log.Debugf("Verifier status not found for %s sha %s",
-			safename, ssPtr.ImageSha256)
+			imageID, ssPtr.ImageSha256)
 		return nil, nil, false
 	}
 	if vs.Expired {
 		log.Infof("Vs.Expired Set. Re-download image %s, sha %s",
-			safename, ssPtr.ImageSha256)
+			imageID, ssPtr.ImageSha256)
 		return nil, nil, false
 	}
 	switch vs.State {
 	case types.DELIVERED:
 		log.Infof("Found verified image for %s sha %s\n",
-			safename, ssPtr.ImageSha256)
+			imageID, ssPtr.ImageSha256)
 
 	case types.DOWNLOADED:
 		log.Infof("Found downloaded/verified image for %s sha %s\n",
-			safename, ssPtr.ImageSha256)
+			imageID, ssPtr.ImageSha256)
 	default:
-		log.Infof("vs.State (%d) not DELIVERED / DOWNLOADED. safename: %s"+
-			" sha %s", vs.State, safename, ssPtr.ImageSha256)
+		log.Infof("vs.State (%d) not DELIVERED / DOWNLOADED. imageID: %s"+
+			" sha %s", vs.State, imageID, ssPtr.ImageSha256)
 		return nil, nil, false
 	}
-	if vs.Safename != safename {
-		// If found based on sha256
-		log.Infof("Found diff safename %s\n", vs.Safename)
-	}
 	if ssPtr.IsContainer {
-		log.Debugf("Container. ssPtr.ContainerImageID: %s, "+
-			"vs.IsContainer = %t, vs.ContainerImageID: %s\n",
-			ssPtr.ContainerImageID, vs.IsContainer, vs.ContainerImageID)
-		if len(ssPtr.ContainerImageID) == 0 {
-			ssPtr.ContainerImageID = vs.ContainerImageID
-			changed = true
-		}
+		log.Debugf("Container. vs.IsContainer = %t, vs.ImageID: %s",
+			vs.IsContainer, vs.ImageID)
 	}
 	if vs.State != ssPtr.State {
 		ssPtr.State = vs.State
@@ -543,9 +461,9 @@ func doInstall(ctx *zedmanagerContext,
 
 	for i := range status.StorageStatusList {
 		ss := &status.StorageStatusList[i]
-		safename := ss.Safename()
-		log.Infof("StorageStatus Name: %s, safename %s, ImageSha256: %s",
-			ss.Name, safename, ss.ImageSha256)
+		imageID := ss.ImageID
+		log.Infof("StorageStatus Name: %s, imageID %s, ImageSha256: %s",
+			ss.Name, imageID, ss.ImageSha256)
 
 		// Check if VerifierStatus already exists.
 		isPtr, vs, statusUpdated := doInstallProcessStorageEntriesWithVerifiedImage(
@@ -553,8 +471,8 @@ func doInstall(ctx *zedmanagerContext,
 		changed = changed || statusUpdated
 		if isPtr != nil {
 			log.Infof("doInstall: Installed image exists. StorageStatus "+
-				"Name: %s, safename %s, ImageSha256: %s",
-				ss.Name, safename, ss.ImageSha256)
+				"Name: %s, imageID %s, ImageSha256: %s",
+				ss.Name, imageID, ss.ImageSha256)
 			// Image with imageStatus is in INSTALLED state
 			if minState > types.INSTALLED {
 				minState = types.INSTALLED
@@ -563,8 +481,8 @@ func doInstall(ctx *zedmanagerContext,
 		}
 		if vs != nil {
 			log.Infof("doInstall: Verified image exists. StorageStatus "+
-				"Name: %s, safename %s, ImageSha256: %s",
-				ss.Name, safename, ss.ImageSha256)
+				"Name: %s, imageID %s, ImageSha256: %s",
+				ss.Name, imageID, ss.ImageSha256)
 			if minState > vs.State {
 				minState = vs.State
 			}
@@ -572,22 +490,28 @@ func doInstall(ctx *zedmanagerContext,
 		}
 		if !ss.HasDownloaderRef {
 			log.Infof("doInstall !HasDownloaderRef for %s\n",
-				safename)
-			AddOrRefcountDownloaderConfig(ctx, safename, *ss)
+				imageID)
+			AddOrRefcountDownloaderConfig(ctx, imageID, *ss)
 			ss.HasDownloaderRef = true
 			changed = true
 		}
-		ds := lookupDownloaderStatus(ctx, safename)
+		ds := lookupDownloaderStatus(ctx, imageID)
 		if ds == nil || ds.Expired {
 			if ds == nil {
-				log.Infof("downloadStatus not found. name: %s", safename)
+				log.Infof("downloadStatus not found. name: %s", imageID)
 			} else {
-				log.Infof("downloadStatusExpired set. name: %s", safename)
+				log.Infof("downloadStatusExpired set. name: %s", imageID)
 			}
 			minState = types.DOWNLOAD_STARTED
 			ss.State = types.DOWNLOAD_STARTED
 			changed = true
 			continue
+		}
+		if ds.FileLocation != "" && ss.ActiveFileLocation == "" {
+			ss.ActiveFileLocation = ds.FileLocation
+			changed = true
+			log.Infof("From ds set ActiveFileLocation to %s for %s",
+				ds.FileLocation, imageID)
 		}
 		if minState > ds.State {
 			minState = ds.State
@@ -602,12 +526,12 @@ func doInstall(ctx *zedmanagerContext,
 		}
 		if ds.Pending() {
 			log.Infof("lookupDownloaderStatus %s Pending\n",
-				safename)
+				imageID)
 			continue
 		}
 		if ds.LastErr != "" {
 			log.Errorf("Received error from downloader for %s: %s\n",
-				safename, ds.LastErr)
+				imageID, ds.LastErr)
 			ss.Error = ds.LastErr
 			ss.ErrorSource = pubsub.TypeToName(types.DownloaderStatus{})
 			errorSource = ss.ErrorSource
@@ -688,31 +612,29 @@ func doInstall(ctx *zedmanagerContext,
 	minState = types.MAXSTATE
 	for i := range status.StorageStatusList {
 		ss := &status.StorageStatusList[i]
-		safename := ss.Safename()
+		imageID := ss.ImageID
 		isPtr := lookupImageStatusForApp(ctx, config.UUIDandVersion.UUID,
 			ss.ImageSha256)
 		if isPtr != nil {
-			log.Infof("Found ImageStatus %s for URL %s safename %s\n",
-				isPtr.FileLocation, ss.Name, safename)
+			log.Infof("Found ImageStatus %s for URL %s imageID %s\n",
+				isPtr.FileLocation, ss.Name, imageID)
 
-			if ss.ActiveFileLocation != isPtr.FileLocation {
-				ss.ActiveFileLocation = isPtr.FileLocation
-				log.Infof("Update SSL ActiveFileLocation for %s: %s\n",
-					uuidStr, ss.ActiveFileLocation)
-				changed = true
-			}
+			ss.ActiveFileLocation = isPtr.FileLocation
+			log.Infof("Update SSL ActiveFileLocation for %s: %s\n",
+				uuidStr, ss.ActiveFileLocation)
+			changed = true
 		} else {
-			vs := lookupVerifyImageStatusAny(ctx, safename, ss.ImageSha256)
+			vs := lookupVerifyImageStatus(ctx, ss.ImageID)
 			if vs == nil || vs.Expired {
 				log.Infof("VerifyImageStatus for %s sha %s not found or Expired (%v)\n",
-					safename, ss.ImageSha256, vs)
+					imageID, ss.ImageSha256, vs)
 				// Keep at current state
 				minState = types.DOWNLOADED
 				changed = true
 				continue
 			}
-			log.Infof("Found VerifyImageStatus for URL %s safename %s\n",
-				ss.Name, safename)
+			log.Infof("Found VerifyImageStatus for URL %s imageID %s\n",
+				ss.Name, imageID)
 
 			if minState > vs.State {
 				minState = vs.State
@@ -722,12 +644,12 @@ func doInstall(ctx *zedmanagerContext,
 				changed = true
 			}
 			if vs.Pending() {
-				log.Infof("lookupVerifyImageStatusAny %s Pending\n", safename)
+				log.Infof("lookupVerifyImageStatusAny %s Pending\n", imageID)
 				continue
 			}
 			if vs.LastErr != "" {
 				log.Errorf("Received error from verifier for %s: %s\n",
-					safename, vs.LastErr)
+					imageID, vs.LastErr)
 				ss.Error = vs.LastErr
 				ss.ErrorSource = pubsub.TypeToName(types.VerifyImageStatus{})
 				errorSource = ss.ErrorSource
@@ -747,18 +669,14 @@ func doInstall(ctx *zedmanagerContext,
 			case types.INITIAL:
 				// Nothing to do
 			default:
-				_, _, filelocation := vs.ImageDownloadFilenames()
-				if ss.ActiveFileLocation != filelocation {
-					ss.ActiveFileLocation = filelocation
-					log.Infof("Update SSL ActiveFileLocation for %s: %s\n",
-						uuidStr, ss.ActiveFileLocation)
-					changed = true
-				}
+				ss.ActiveFileLocation = vs.FileLocation
+				log.Infof("Update SSL ActiveFileLocation for %s: %s\n",
+					uuidStr, ss.ActiveFileLocation)
+				changed = true
 			}
 		}
-		log.Infof("doInstall: StorageStatus ImageID:%s, Safename: %s, "+
-			"minState:%d ActiveFileLocation:%s",
-			ss.ImageID, ss.Name, minState, ss.ActiveFileLocation)
+		log.Infof("doInstall: StorageStatus ImageID:%s, Name: %s, "+
+			"minState:%d", ss.ImageID, ss.Name, minState)
 	}
 	if minState == types.MAXSTATE {
 		// Odd; no StorageConfig in list
@@ -1040,7 +958,7 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 		found := false
 		for i := range status.StorageStatusList {
 			ss := &status.StorageStatusList[i]
-			if ss.ImageSha256 == disk.ImageSha256 {
+			if uuid.Equal(ss.ImageID, disk.ImageID) {
 				found = true
 				log.Infof("Found SSL ActiveFileLocation for %s: %s\n",
 					uuidStr, disk.ActiveFileLocation)
@@ -1167,21 +1085,20 @@ func MaybeRemoveStorageStatus(ctx *zedmanagerContext, ss *types.StorageStatus) b
 	changed := false
 
 	log.Infof("MaybeRemoveStorageStatus: removing StorageStatus for:"+
-		"Name: %s, ImageSha256: %s, HasDownloaderRef: %t, HasVerifierRef: %t,"+
-		"IsContainer: %t, ContainerImageID: %s, Error: %s",
-		ss.Name, ss.ImageSha256, ss.HasDownloaderRef, ss.HasVerifierRef,
-		ss.IsContainer, ss.ContainerImageID, ss.Error)
+		"Name: %s, ImageID: %s, HasDownloaderRef: %t, HasVerifierRef: %t,"+
+		"IsContainer: %t, Error: %s",
+		ss.Name, ss.ImageID, ss.HasDownloaderRef, ss.HasVerifierRef,
+		ss.IsContainer, ss.Error)
 
 	// Decrease refcount if we had increased it
 	if ss.HasVerifierRef {
-		MaybeRemoveVerifyImageConfigSha256(ctx, ss.ImageSha256)
+		MaybeRemoveVerifyImageConfig(ctx, ss.ImageID)
 		ss.HasVerifierRef = false
 		changed = true
 	}
 	// Decrease refcount if we had increased it
 	if ss.HasDownloaderRef {
-		safename := ss.Safename()
-		MaybeRemoveDownloaderConfig(ctx, safename)
+		MaybeRemoveDownloaderConfig(ctx, ss.ImageID)
 		ss.HasDownloaderRef = false
 		changed = true
 	}

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -708,9 +708,9 @@ func quantifyChanges(config types.AppInstanceConfig,
 	} else {
 		for i, sc := range config.StorageConfigList {
 			ss := status.StorageStatusList[i]
-			if ss.ImageSha256 != sc.ImageSha256 {
-				log.Infof("quantifyChanges storage sha changed from %s to %s\n",
-					ss.ImageSha256, sc.ImageSha256)
+			if ss.ImageID != sc.ImageID {
+				log.Infof("quantifyChanges storage imageID changed from %s to %s\n",
+					ss.ImageID, sc.ImageID)
 				needPurge = true
 			}
 			if ss.ReadOnly != sc.ReadOnly {

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -166,6 +166,7 @@ type DiskConfig struct {
 
 type DiskStatus struct {
 	ImageID            uuid.UUID // UUID of immutable image
+	ImageSha256        string    // sha256 of immutable image
 	ReadOnly           bool
 	Preserve           bool
 	FileLocation       string // Local location of Image

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -11,7 +11,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// The information XenManager needs to boot and halt domains
+// The information DomainManager needs to boot and halt domains
 // If the the version (in UUIDandVersion) changes then the domain needs to
 // halted and booted?? NO, because an ACL change from ZedControl would bump
 // the version. Who determines which changes require halt+reboot?
@@ -29,8 +29,7 @@ type DomainConfig struct {
 	IoAdapterList     []IoAdapter
 	CloudInitUserData *string // base64-encoded
 	// Container related info
-	IsContainer      bool   // Is this Domain for a Container?
-	ContainerImageID string // SHA-512 of rkt container image
+	IsContainer bool // Is this Domain for a Container?
 }
 
 func (config DomainConfig) Key() string {
@@ -110,7 +109,6 @@ type DomainStatus struct {
 	BootFailed         bool
 	AdaptersFailed     bool
 	IsContainer        bool   // Is this Domain for a Container?
-	ContainerImageID   string // SHA-512 of rkt container image
 	PodUUID            string // Pod UUID outputted by rkt
 }
 
@@ -150,7 +148,7 @@ type VifInfo struct {
 	Mac    string
 }
 
-// XenManager will pass these to the xen xl config file
+// DomainManager will pass these to the xen xl config file
 // The vdev is automatically assigned as xvd[x], where X is a, b, c etc,
 // based on the order in the DiskList
 // Note that vdev in general can be hd[x], xvd[x], sd[x] but here we only
@@ -167,8 +165,7 @@ type DiskConfig struct {
 }
 
 type DiskStatus struct {
-	ImageID            uuid.UUID // sha256 of immutable image
-	ImageSha256        string    // sha256 of immutable image
+	ImageID            uuid.UUID // UUID of immutable image
 	ReadOnly           bool
 	Preserve           bool
 	FileLocation       string // Local location of Image
@@ -180,6 +177,9 @@ type DiskStatus struct {
 }
 
 // Track the active image files in rwImgDirname
+// The ImageSha256 is used when an app instance has multiple virtual disks.
+// We do not have an imageID in the pathnames for the RW images hence we can't report
+// an imageID on startup.
 type ImageStatus struct {
 	AppInstUUID  uuid.UUID // UUID of App Instance using the image.
 	ImageSha256  string    // ImageSha256 of original image

--- a/pkg/pillar/types/types.go
+++ b/pkg/pillar/types/types.go
@@ -33,11 +33,14 @@ const (
 	MAXSTATE   //
 )
 
+// NoHash should XXX deprecate?
 const (
 	// NoHash constant to indicate that we have no real hash
 	NoHash = "sha"
 )
 
+// UrlToSafename returns a safename
+// XXX deprecate? We might need something for certs
 func UrlToSafename(url string, sha string) string {
 
 	var safename string
@@ -50,8 +53,10 @@ func UrlToSafename(url string, sha string) string {
 	return safename
 }
 
+// SafenameToFilename returns the filename from inside the safename
 // Remove initial part up to last '/' in URL. Note that '/' was converted
 // to ' ' in Safename
+// XXX deprecate? We might need something for certs
 func SafenameToFilename(safename string) string {
 	comp := strings.Split(safename, " ")
 	last := comp[len(comp)-1]
@@ -65,6 +70,9 @@ func SafenameToFilename(safename string) string {
 	return last
 }
 
+// UrlToFilename returns the last component of a URL.
+// XXX deprecate? We might need something for certs
+// XXX assumes len
 func UrlToFilename(urlName string) string {
 	comp := strings.Split(urlName, "/")
 	last := comp[len(comp)-1]

--- a/pkg/pillar/types/types_test.go
+++ b/pkg/pillar/types/types_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 )
 
+// XXX deprecate? We might need something for certs
 func TestUrlToSafename(t *testing.T) {
 	testMatrix := map[string]struct {
 		safename string

--- a/pkg/pillar/types/verifiertypes.go
+++ b/pkg/pillar/types/verifiertypes.go
@@ -21,65 +21,61 @@ import (
 // dom0 has moved the image file to a read-only directory before asking
 // for the file to be verified.
 
-// The key/index to this is the Safename which is allocated by ZedManager.
-// That is the filename in which we store the corresponding json files.
+// The key/index to this is the ImageID which is allocated by the controller.
 type VerifyImageConfig struct {
-	Safename         string // Also refers to the dirname in pending dir
-	Name             string // For logging output
+	ImageID          uuid.UUID // UUID of the image
+	Name             string
 	ImageSha256      string // sha256 of immutable image
 	RefCount         uint
-	CertificateChain []string  //name of intermediate certificates
-	ImageSignature   []byte    //signature of image
-	SignatureKey     string    //certificate containing public key
-	IsContainer      bool      // Is this Domain for a Container?
-	ContainerImageID string    // Container Image ID
-	ImageID          uuid.UUID // UUID of the image
+	CertificateChain []string //name of intermediate certificates
+	ImageSignature   []byte   //signature of image
+	SignatureKey     string   //certificate containing public key
+	IsContainer      bool     // Is this image for a Container?
 }
 
 func (config VerifyImageConfig) Key() string {
-	return config.Safename
+	return config.ImageID.String()
 }
 
 func (config VerifyImageConfig) VerifyFilename(fileName string) bool {
 	expect := config.Key() + ".json"
 	ret := expect == fileName
 	if !ret {
-		log.Errorf("Mismatch between filename and contained Safename: %s vs. %s\n",
+		log.Errorf("Mismatch between filename and contained key: %s vs. %s\n",
 			fileName, expect)
 	}
 	return ret
 }
 
-// The key/index to this is the Safename which comes from VerifyImageConfig.
-// That is the filename in which we store the corresponding json files.
+// The key/index to this is the ImageID which comes from VerifyImageConfig.
 type VerifyImageStatus struct {
-	Safename         string
-	ObjType          string
-	PendingAdd       bool
-	PendingModify    bool
-	PendingDelete    bool
-	IsContainer      bool    // Is this Domain for a Container?
-	ContainerImageID string  // Container Image ID if IsContainer=true
-	ImageSha256      string  // sha256 of immutable image
-	State            SwState // DELIVERED; LastErr* set if failed
-	LastErr          string  // Verification error
-	LastErrTime      time.Time
-	Size             int64
-	RefCount         uint
-	LastUse          time.Time // When RefCount dropped to zero
-	Expired          bool      // Handshake to client
-	ImageID          uuid.UUID // UUID of the image
+	ImageID       uuid.UUID // UUID of the image
+	Name          string
+	ObjType       string
+	PendingAdd    bool
+	PendingModify bool
+	PendingDelete bool
+	FileLocation  string  // Current location; should be info about file
+	IsContainer   bool    // Is this image for a Container?
+	ImageSha256   string  // sha256 of immutable image
+	State         SwState // DELIVERED; LastErr* set if failed
+	LastErr       string  // Verification error
+	LastErrTime   time.Time
+	Size          int64
+	RefCount      uint
+	LastUse       time.Time // When RefCount dropped to zero
+	Expired       bool      // Handshake to client
 }
 
 func (status VerifyImageStatus) Key() string {
-	return status.Safename
+	return status.ImageID.String()
 }
 
 func (status VerifyImageStatus) VerifyFilename(fileName string) bool {
 	expect := status.Key() + ".json"
 	ret := expect == fileName
 	if !ret {
-		log.Errorf("Mismatch between filename and contained Safename: %s vs. %s\n",
+		log.Errorf("Mismatch between filename and contained key: %s vs. %s\n",
 			fileName, expect)
 	}
 	return ret
@@ -91,16 +87,10 @@ func (status VerifyImageStatus) ImageDownloadDirNames() (string, string, string)
 	downloadDirname := DownloadDirname + "/" + status.ObjType
 
 	var pendingDirname, verifierDirname, verifiedDirname string
-	if status.IsContainer {
-		pendingDirname = downloadDirname + "/pending/" + status.ImageID.String()
-		verifierDirname = downloadDirname + "/verifier/" + status.ImageID.String()
-		verifiedDirname = downloadDirname + "/verified/" + status.ImageID.String()
-	} else {
-		// Else..VMs
-		pendingDirname = downloadDirname + "/pending/" + status.ImageSha256
-		verifierDirname = downloadDirname + "/verifier/" + status.ImageSha256
-		verifiedDirname = downloadDirname + "/verified/" + status.ImageSha256
-	}
+	pendingDirname = downloadDirname + "/pending/" + status.ImageID.String()
+	verifierDirname = downloadDirname + "/verifier/" + status.ImageID.String()
+	// XXX change to be sha/uuid? Parser on boot?
+	verifiedDirname = downloadDirname + "/verified/" + status.ImageID.String()
 	return pendingDirname, verifierDirname, verifiedDirname
 }
 
@@ -111,18 +101,9 @@ func (status VerifyImageStatus) ImageDownloadFilenames() (string, string, string
 
 	pendingDirname, verifierDirname, verifiedDirname :=
 		status.ImageDownloadDirNames()
-	pendingFilename = pendingDirname + "/" + status.Safename
-	verifierFilename = verifierDirname + "/" + status.Safename
-	// TODO:
-	// most of the filename and safename for containers and VMs have been
-	// unified, so we need fewer "if IsContainer" but this one still needs to
-	// exist. It should be cleaned up.
-	if status.IsContainer {
-		verifiedFilename = verifiedDirname + "/" + status.Safename
-	} else {
-		filename := SafenameToFilename(status.Safename)
-		verifiedFilename = verifiedDirname + "/" + filename
-	}
+	pendingFilename = pendingDirname + "/" + status.Name
+	verifierFilename = verifierDirname + "/" + status.Name
+	verifiedFilename = verifiedDirname + "/" + status.Name
 	return pendingFilename, verifierFilename, verifiedFilename
 }
 

--- a/pkg/pillar/types/verifiertypes.go
+++ b/pkg/pillar/types/verifiertypes.go
@@ -89,8 +89,7 @@ func (status VerifyImageStatus) ImageDownloadDirNames() (string, string, string)
 	var pendingDirname, verifierDirname, verifiedDirname string
 	pendingDirname = downloadDirname + "/pending/" + status.ImageID.String()
 	verifierDirname = downloadDirname + "/verifier/" + status.ImageID.String()
-	// XXX change to be sha/uuid? Parser on boot?
-	verifiedDirname = downloadDirname + "/verified/" + status.ImageID.String()
+	verifiedDirname = downloadDirname + "/verified/" + status.ImageSha256
 	return pendingDirname, verifierDirname, verifiedDirname
 }
 

--- a/pkg/pillar/utils/verifierutils.go
+++ b/pkg/pillar/utils/verifierutils.go
@@ -11,6 +11,7 @@ import (
 	"os"
 
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -38,21 +39,14 @@ func locationFromDir(locationDir string) (string, error) {
 
 // VerifiedImageDirLocation - Gives the directory for a verified image, but not
 // the file itself, which is subject to possible algorithms
-func VerifiedImageDirLocation(isContainer bool, containerImageID string,
-	imageSha256 string) string {
-	var locationDir string
-	if isContainer {
-		locationDir = types.VerifiedAppImgDirname + "/" + containerImageID
-	} else {
-		locationDir = types.VerifiedAppImgDirname + "/" + imageSha256
-	}
-	return locationDir
+// XXX sha or uuid?
+func VerifiedImageDirLocation(imageID uuid.UUID) string {
+	return types.VerifiedAppImgDirname + "/" + imageID.String()
 }
 
 // VerifiedImageFileLocation - Gives the file location for a verified image.
-func VerifiedImageFileLocation(isContainer bool, containerImageID string,
-	imageSha256 string) (string, error) {
-	locationDir := VerifiedImageDirLocation(isContainer, containerImageID, imageSha256)
+func VerifiedImageFileLocation(imageID uuid.UUID) (string, error) {
+	locationDir := VerifiedImageDirLocation(imageID)
 	location, err := locationFromDir(locationDir)
 	// logging the error here kind of violates functional principles,
 	// since it would be legitimate to ask, "where is the verified image file,

--- a/pkg/pillar/utils/verifierutils.go
+++ b/pkg/pillar/utils/verifierutils.go
@@ -11,7 +11,6 @@ import (
 	"os"
 
 	"github.com/lf-edge/eve/pkg/pillar/types"
-	"github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -39,14 +38,13 @@ func locationFromDir(locationDir string) (string, error) {
 
 // VerifiedImageDirLocation - Gives the directory for a verified image, but not
 // the file itself, which is subject to possible algorithms
-// XXX sha or uuid?
-func VerifiedImageDirLocation(imageID uuid.UUID) string {
-	return types.VerifiedAppImgDirname + "/" + imageID.String()
+func VerifiedImageDirLocation(sha256 string) string {
+	return types.VerifiedAppImgDirname + "/" + sha256
 }
 
 // VerifiedImageFileLocation - Gives the file location for a verified image.
-func VerifiedImageFileLocation(imageID uuid.UUID) (string, error) {
-	locationDir := VerifiedImageDirLocation(imageID)
+func VerifiedImageFileLocation(sha256 string) (string, error) {
+	locationDir := VerifiedImageDirLocation(sha256)
 	location, err := locationFromDir(locationDir)
 	// logging the error here kind of violates functional principles,
 	// since it would be legitimate to ask, "where is the verified image file,


### PR DESCRIPTION
Using the ImageID in pending and verifier directories, and the sha256 (extracted from a container with a tag if none specified) in the verified directory.
Separate PRs will explore 1) reporting the extracted sha to zedcloud and 2) checking if the sha has already been verified (this code checks whether the imageID has already been verified) 
Note that the naming in /persist/img/ is unchanged so that already deployed app instances will not be affected by an upgrade.