### PR TITLE
Wait for a maximum of 60 minutes for logread to start. If it does not…

### DIFF
--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -3,6 +3,7 @@
 # Copyright (c) 2018 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+LOGREAD_PID_WAIT=3600
 USE_HW_WATCHDOG=1
 CONFIGDIR=/config
 PERSISTDIR=/persist
@@ -53,6 +54,18 @@ else
     echo "$(date -Ins -u) Platform has no /dev/watchdog"
     USE_HW_WATCHDOG=0
 fi
+
+LOOP_COUNT=0
+while [ -z "$(pgrep logread)" ];
+do
+    sleep 1
+    LOOP_COUNT=$((LOOP_COUNT + 1))
+    if [ "$LOOP_COUNT" -ge "$LOGREAD_PID_WAIT" ]; then
+        echo "$(date -Ins -u) Error: Could not find logread process"
+        sleep 1
+        reboot
+    fi
+done
 
 LOGREAD_PID=$(pgrep logread)
 if [ -n "$LOGREAD_PID" ]; then


### PR DESCRIPTION
… start in 60 minutes reboot the device

Signed-off-by: GopiKrishna Kodali <gkodali@zededa.com>