### PR TITLE
Fix rsyslogd incompatibility with old directories

### DIFF
--- a/pkg/pillar/Makefile
+++ b/pkg/pillar/Makefile
@@ -21,7 +21,7 @@ APPS = zedbox
 APPS1 = logmanager ledmanager downloader verifier client zedrouter domainmgr \
         identitymgr zedmanager zedagent hardwaremodel ipcmonitor nim diag    \
         baseosmgr wstunnelclient conntrack lisp-ztr waitforaddr tpmmgr \
-        vaultmgr nodeagent
+        vaultmgr nodeagent waitforsyslog
 
 .PHONY: all clean build test build-docker build-docker-git shell
 

--- a/pkg/pillar/README.md
+++ b/pkg/pillar/README.md
@@ -9,6 +9,7 @@ The agents are:
 - ledmanager - make LEDs light/blink for feedback to the person installing the hardware
 - nim - network interface manager (ensures that there is connectivity to the controller)
 - waitforaddr - merely waiting for a few minutes max for IP address(es) for a more orderly boot in the normal case
+- waitforsyslog - waits until the AF_UNIX syslog service is available. That service is provided by rsyslogd
 - vaultmgr - responsible of creation and operations over, encrypted vault(s) for mutable application images and device configuration data
 - nodeagent - montior the device health, while node is in baseos upgrade or normal operation mode. Also orchestrates baseos installation and upgrade validation by interacting with baseosmgr and zedagent.
 - zedagent - communicate using the device API to the controller to retrieve configuration and send status and metrics

--- a/pkg/pillar/agentlog/agentlog.go
+++ b/pkg/pillar/agentlog/agentlog.go
@@ -67,6 +67,7 @@ func initImpl(agentName string, logdir string, redirect bool,
 			if err == nil {
 				log.AddHook(hook)
 			} else {
+				fmt.Printf("NewSyslogHook fatal failed %s: %s\n", agentName, err)
 				return nil, err
 			}
 		} else {

--- a/pkg/pillar/cmd/waitforsyslog/waitforsyslog.go
+++ b/pkg/pillar/cmd/waitforsyslog/waitforsyslog.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Wait for being able to connect to the syslog service for
+// at most maxTime
+package waitforsyslog
+
+import (
+	"fmt"
+	"log/syslog"
+	"os"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/agentlog"
+	"github.com/lf-edge/eve/pkg/pillar/pidfile"
+	lSyslog "github.com/sirupsen/logrus/hooks/syslog"
+)
+
+const (
+	agentName   = "waitforsyslog"
+	errorTime   = 3 * time.Minute
+	warningTime = 40 * time.Second
+	maxTime     = 300 * time.Second
+)
+
+func Run() {
+	fmt.Printf("Starting %s\n", agentName)
+	startTime := time.Now()
+
+	if err := pidfile.CheckAndCreatePidfile(agentName); err != nil {
+		fmt.Printf("Fatal error for %s: %s\n", agentName, err)
+	}
+	agentlog.StillRunning(agentName, warningTime, errorTime)
+
+	syslogFlags := syslog.LOG_INFO | syslog.LOG_DEBUG | syslog.LOG_ERR |
+		syslog.LOG_NOTICE | syslog.LOG_WARNING | syslog.LOG_CRIT |
+		syslog.LOG_ALERT | syslog.LOG_EMERG
+
+	// Run a periodic timer so we always update StillRunning
+	// Use this timer to retry the hook as well
+	stillRunning := time.NewTicker(5 * time.Second)
+
+	for {
+		fmt.Printf("NewSyslogHook called for %s\n", agentName)
+		_, err := lSyslog.NewSyslogHook("", "", syslogFlags, agentName)
+		elapsed := time.Since(startTime)
+		if err == nil {
+			fmt.Printf("NewSyslogHook success for %s\n", agentName)
+			fmt.Printf("%s DONE after %d seconds\n", agentName,
+				elapsed/time.Second)
+			return
+		}
+		fmt.Printf("NewSyslogHook failed for %s: %s\n", agentName, err)
+		if elapsed > maxTime {
+			fmt.Printf("%s giving up after %d seconds\n",
+				agentName, elapsed/time.Second)
+			os.Exit(1)
+		}
+		fmt.Printf("%s has %d seconds remaining\n", agentName,
+			(maxTime-elapsed)/time.Second)
+		<-stillRunning.C
+		agentlog.StillRunning(agentName, warningTime, errorTime)
+	}
+}

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -177,6 +177,11 @@ killwait_watchdog
 # Always run watchdog(8) in case we have a hardware watchdog timer to advance
 /usr/sbin/watchdog -c $TMPDIR/watchdogbase.conf -F -s &
 
+# XXX could add watchdog or check error return
+echo "$(date -Ins -u) Starting waitforsyslog"
+$BINDIR/waitforsyslog
+echo "$(date -Ins -u) Done waitforsyslog"
+
 if ! mount -o remount,flush,dirsync,noatime $CONFIGDIR; then
     echo "$(date -Ins -u) Remount $CONFIGDIR failed"
 fi

--- a/pkg/pillar/zedbox/zedbox.go
+++ b/pkg/pillar/zedbox/zedbox.go
@@ -23,6 +23,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/cmd/vaultmgr"
 	"github.com/lf-edge/eve/pkg/pillar/cmd/verifier"
 	"github.com/lf-edge/eve/pkg/pillar/cmd/waitforaddr"
+	"github.com/lf-edge/eve/pkg/pillar/cmd/waitforsyslog"
 	"github.com/lf-edge/eve/pkg/pillar/cmd/wstunnelclient"
 	"github.com/lf-edge/eve/pkg/pillar/cmd/zedagent"
 	"github.com/lf-edge/eve/pkg/pillar/cmd/zedmanager"
@@ -60,6 +61,8 @@ func main() {
 		verifier.Run()
 	case "waitforaddr":
 		waitforaddr.Run()
+	case "waitforsyslog":
+		waitforsyslog.Run()
 	case "zedagent":
 		zedagent.Run()
 	case "zedmanager":

--- a/pkg/rsyslog/init.sh
+++ b/pkg/rsyslog/init.sh
@@ -1,8 +1,16 @@
 #!/bin/sh
 
 RSYSLOG_WORK_DIR=/persist/rsyslog
+OLD_DIR=/persist/syslog
+# We need to clean up old state it seems. Use $OLD_DIR as the hint
+if [ -d "$OLD_DIR" ]; then
+    echo "Moving old $OLD_DIR and $RSYSLOG_WORK_DIR out of the way"
+    mv "$OLD_DIR" "$OLD_DIR".old
+    mv "$RSYSLOG_WORK_DIR" "$RSYSLOG_WORK_DIR".old
+fi
 if [ ! -d "$RSYSLOG_WORK_DIR" ]; then
   mkdir -p $RSYSLOG_WORK_DIR
   chmod 644 $RSYSLOG_WORK_DIR
 fi
+# XXX IMGB?
 IMGP=IMGA /usr/sbin/rsyslogd


### PR DESCRIPTION
Don't know why this fails, but rsyslogd seems to hang or crash when baseimage updating from something a few days old.

Also, the agents log.Fatal if rsyslogd isn't fully running when the agent starts. Making device-steps.sh wait for that.