### PR TITLE
Passing environment variable - stage1 patch

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -2099,9 +2099,6 @@ func rktRun(domainName, xenCfgFilename, imageHash string) (int, string, error) {
 		"--insecure-options=image",
 		"run",
 		imageHash,
-		//This is added to verify that setting env var works.
-		//TODO: Remove this once passing env var flow from UI is setup
-		"--set-env=FOO=bar",
 		"--stage1-path=/usr/sbin/stage1-xen.aci",
 		"--uuid-file-save=" + uuidFile,
 	}

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -2092,6 +2092,9 @@ func rktRun(domainName, xenCfgFilename, imageHash string) (int, string, error) {
 		"--insecure-options=image",
 		"run",
 		imageHash,
+		//This is added to verify that setting env var works.
+		//TODO: Remove this once passing env var flow from UI is setup
+		"--set-env=FOO=bar",
 		"--stage1-path=/usr/sbin/stage1-xen.aci",
 		"--uuid-file-save=" + uuidFile,
 	}

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -2083,8 +2083,15 @@ func DomainCreate(status types.DomainStatus) (int, string, error) {
 // Launch app/container thru rkt
 // returns domainID, podUUID and error
 func rktRun(domainName, xenCfgFilename, imageHash string) (int, string, error) {
-
-	// STAGE1_XL_OPTS=-p STAGE1_SEED_XL_CFG=xenCfgFilename rkt --dir=<RKT_DATA_DIR> --insecure-options=image run <SHA> --stage1-path=/usr/sbin/stage1-xen.aci --uuid-file-save=uuid_file
+	// STAGE1_XL_OPTS=-p STAGE1_SEED_XL_CFG=xenCfgFilename rkt --dir=<RKT_DATA_DIR> --insecure-options=image run <SHA> --stage1-path=/usr/sbin/stage1-xen.aci --uuid-file-save=uuid_file --set-env=ENV-KEY=env-value
+	//TODO: envVars must be read from image config once we decide on how we will be passing this info from UI
+	envVars := map[string]string{}
+	var (
+		envVarSlice = make([]string, 0)
+	)
+	for k, v := range envVars {
+		envVarSlice = append(envVarSlice, fmt.Sprintf("--set-env=%s=%s", k, v))
+	}
 	log.Infof("rktRun %s\n", domainName)
 	cmd := "rkt"
 	args := []string{
@@ -2098,6 +2105,7 @@ func rktRun(domainName, xenCfgFilename, imageHash string) (int, string, error) {
 		"--stage1-path=/usr/sbin/stage1-xen.aci",
 		"--uuid-file-save=" + uuidFile,
 	}
+	args = append(args, envVarSlice...)
 	stage1XlOpts := "STAGE1_XL_OPTS=-p"
 	stage1XlCfg := "STAGE1_SEED_XL_CFG=" + xenCfgFilename
 	log.Infof("Calling command %s %v\n", cmd, args)

--- a/pkg/rkt-stage1/0010-Patch-to-read-evn-var-stage1.patch
+++ b/pkg/rkt-stage1/0010-Patch-to-read-evn-var-stage1.patch
@@ -84,3 +84,13 @@ index 94c0f4c..a9965f4 100644
  func main() {
  	rp := parseFlags()
  	stage1initcommon.InitDebug(debug)
+diff --git a/kernel/init-initrd b/kernel/init-initrd
+index 317d698..98b2256 100755
+--- a/kernel/init-initrd
++++ b/kernel/init-initrd
+@@ -82,4 +82,5 @@ chmod +x /mnt/rootfs/launcher.sh
+ cmd=`cat /mnt/cmdline`
+ echo "Executing $cmd"
+ source /mnt/environment
++source /mnt/external-environment
+ eval setsid -c chroot /mnt/rootfs /launcher.sh $cmd <> /dev/console 2>&1

--- a/pkg/rkt-stage1/0010-Patch-to-read-evn-var-stage1.patch
+++ b/pkg/rkt-stage1/0010-Patch-to-read-evn-var-stage1.patch
@@ -1,5 +1,5 @@
 diff --git a/init/init.go b/init/init.go
-index 94c0f4c..4eab62c 100644
+index 94c0f4c..91317b2 100644
 --- a/init/init.go
 +++ b/init/init.go
 @@ -15,6 +15,7 @@
@@ -15,7 +15,7 @@ index 94c0f4c..4eab62c 100644
  	}
 
 +	ra := p.Manifest.Apps[0]
-+	appEnv := composeEnviron(ra.App.Environment)
++	appEnv := composeEnvironment(ra.App.Environment)
 +	appsPath := common.AppPath(p.Root, ra.Name)
 +
 +	if err := writeEnvFile(appsPath, appEnv); err != nil {
@@ -26,14 +26,14 @@ index 94c0f4c..4eab62c 100644
  	args, env, err := getArgsEnv(p, flavor, debug, n)
  	if err != nil {
  		log.FatalE("cannot get environment", err)
-@@ -221,9 +231,57 @@ func stage1(rp *stage1commontypes.RuntimePod) int {
+@@ -221,9 +231,54 @@ func stage1(rp *stage1commontypes.RuntimePod) int {
  		log.FatalE(fmt.Sprintf("failed to execute %q", args[0]), err)
  	}
- 
+
 +
  	return 0
  }
- 
+
 +// writeEnvFile creates an external-environment file under appDir
 +// with entries from PodManifest.App.Environments
 +func writeEnvFile(appDir string, environment types.Environment) error {
@@ -57,11 +57,8 @@ index 94c0f4c..4eab62c 100644
 +	return nil
 +}
 +
-+// ComposeEnviron formats the environment into a slice of strings,
-+// each of the form "key=value".  The minimum required environment
-+// variables by the appc spec will be set to sensible defaults here if
-+// they're not provided by env.
-+func composeEnviron(env types.Environment) types.Environment {
++// composeEnvironment formats the environment into a slice of types.Environment.
++func composeEnvironment(env types.Environment) types.Environment {
 +	var composed types.Environment
 +	var defaultEnv = map[string]string{
 +		"PATH":    "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",

--- a/pkg/rkt-stage1/0010-Patch-to-read-evn-var-stage1.patch
+++ b/pkg/rkt-stage1/0010-Patch-to-read-evn-var-stage1.patch
@@ -1,33 +1,62 @@
 diff --git a/init/init.go b/init/init.go
-index 94c0f4c..29426e0 100644
+index 94c0f4c..a9965f4 100644
 --- a/init/init.go
 +++ b/init/init.go
-@@ -18,6 +18,7 @@ import (
+@@ -15,6 +15,7 @@
+ package main
+ 
+ import (
++	"bytes"
  	"errors"
  	"flag"
  	"fmt"
-+	"github.com/rkt/rkt/pkg/user"
- 	"io/ioutil"
- 	"net"
- 	"os"
-@@ -217,6 +218,13 @@ func stage1(rp *stage1commontypes.RuntimePod) int {
- 		return syscall.Exec(args[0], args, env)
- 	})
+@@ -202,6 +203,15 @@ func stage1(rp *stage1commontypes.RuntimePod) int {
+ 		}
+ 	}
  
 +	ra := p.Manifest.Apps[0]
 +	appEnv := composeEnviron(ra.App.Environment)
-+	if err = common.WriteEnvFile(appEnv, user.NewBlankUidRange(), stage1initcommon.EnvFilePath(p.Root, ra.Name)); err != nil {
++	appsPath := common.AppsPath(p.Root)
++
++	if err := writeEnvFile(appsPath, appEnv); err != nil {
 +		log.PrintE("can't write env", err)
 +		return 254
 +	}
 +
+ 	args, env, err := getArgsEnv(p, flavor, debug, n)
  	if err != nil {
+ 		log.FatalE("cannot get environment", err)
+@@ -221,9 +231,57 @@ func stage1(rp *stage1commontypes.RuntimePod) int {
  		log.FatalE(fmt.Sprintf("failed to execute %q", args[0]), err)
  	}
-@@ -224,6 +232,30 @@ func stage1(rp *stage1commontypes.RuntimePod) int {
+ 
++
  	return 0
  }
  
++// writeEnvFile creates an external-environment file under appDir
++// with entries from PodManifest.App.Environments
++func writeEnvFile(appDir string, environment types.Environment) error {
++	envFilePath := filepath.Join(appDir, "external-environment")
++	ef := bytes.Buffer{}
++
++	//If environment is nil, then empty file will be created
++	if environment != nil {
++		for _, env := range environment {
++			fmt.Fprintf(&ef, "export %s='%s'\n", env.Name, env.Value)
++		}
++	}
++
++	if err := os.MkdirAll(filepath.Dir(envFilePath), 0755); err != nil {
++		return err
++	}
++
++	if err := ioutil.WriteFile(envFilePath, ef.Bytes(), 0644); err != nil {
++		return err
++	}
++	return nil
++}
++
 +// ComposeEnviron formats the environment into a slice of strings,
 +// each of the form "key=value".  The minimum required environment
 +// variables by the appc spec will be set to sensible defaults here if

--- a/pkg/rkt-stage1/0010-Patch-to-read-evn-var-stage1.patch
+++ b/pkg/rkt-stage1/0010-Patch-to-read-evn-var-stage1.patch
@@ -1,0 +1,57 @@
+diff --git a/init/init.go b/init/init.go
+index 94c0f4c..29426e0 100644
+--- a/init/init.go
++++ b/init/init.go
+@@ -18,6 +18,7 @@ import (
+ 	"errors"
+ 	"flag"
+ 	"fmt"
++	"github.com/rkt/rkt/pkg/user"
+ 	"io/ioutil"
+ 	"net"
+ 	"os"
+@@ -217,6 +218,13 @@ func stage1(rp *stage1commontypes.RuntimePod) int {
+ 		return syscall.Exec(args[0], args, env)
+ 	})
+ 
++	ra := p.Manifest.Apps[0]
++	appEnv := composeEnviron(ra.App.Environment)
++	if err = common.WriteEnvFile(appEnv, user.NewBlankUidRange(), stage1initcommon.EnvFilePath(p.Root, ra.Name)); err != nil {
++		log.PrintE("can't write env", err)
++		return 254
++	}
++
+ 	if err != nil {
+ 		log.FatalE(fmt.Sprintf("failed to execute %q", args[0]), err)
+ 	}
+@@ -224,6 +232,30 @@ func stage1(rp *stage1commontypes.RuntimePod) int {
+ 	return 0
+ }
+ 
++// ComposeEnviron formats the environment into a slice of strings,
++// each of the form "key=value".  The minimum required environment
++// variables by the appc spec will be set to sensible defaults here if
++// they're not provided by env.
++func composeEnviron(env types.Environment) types.Environment {
++	var composed types.Environment
++	var defaultEnv = map[string]string{
++		"PATH":    "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
++		"SHELL":   "/bin/sh",
++		"USER":    "root",
++		"LOGNAME": "root",
++		"HOME":    "/root",
++	}
++
++	for dk, dv := range defaultEnv {
++		if _, exists := env.Get(dk); !exists {
++			composed = append(composed, types.EnvironmentVariable{Name:dk, Value:dv})
++		}
++	}
++
++	composed = append(composed, env...)
++	return composed
++}
++
+ func main() {
+ 	rp := parseFlags()
+ 	stage1initcommon.InitDebug(debug)

--- a/pkg/rkt-stage1/0010-Patch-to-read-evn-var-stage1.patch
+++ b/pkg/rkt-stage1/0010-Patch-to-read-evn-var-stage1.patch
@@ -1,10 +1,10 @@
 diff --git a/init/init.go b/init/init.go
-index 94c0f4c..a9965f4 100644
+index 94c0f4c..4eab62c 100644
 --- a/init/init.go
 +++ b/init/init.go
 @@ -15,6 +15,7 @@
  package main
- 
+
  import (
 +	"bytes"
  	"errors"
@@ -13,10 +13,10 @@ index 94c0f4c..a9965f4 100644
 @@ -202,6 +203,15 @@ func stage1(rp *stage1commontypes.RuntimePod) int {
  		}
  	}
- 
+
 +	ra := p.Manifest.Apps[0]
 +	appEnv := composeEnviron(ra.App.Environment)
-+	appsPath := common.AppsPath(p.Root)
++	appsPath := common.AppPath(p.Root, ra.Name)
 +
 +	if err := writeEnvFile(appsPath, appEnv); err != nil {
 +		log.PrintE("can't write env", err)


### PR DESCRIPTION
Stage1-xen receives env variables from rkt, but they weren’t exported into the application.
 Patch on stage1-xen: When stage1-xen receives an application to boot along with its config (which also includes env variables), we load the env variables to a file /stage2/`app-name`/external-environment. Env variables in this file will be exported during init phase of the application. After this patch, all methods of setting env variable as per the rkt document will work with stage1-xen.

Doc explaining multiple approaches to do the same: https://docs.google.com/document/d/1ii303aLskeEvc36ZNUNbMCJteXtPcpoZAq_eld8rPVg/edit# 