### PR TITLE
Reintroduce reboot-reason post rsyslogd

### DIFF
--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -107,8 +107,12 @@ func Run() { //nolint:gocyclo
 	}
 	defer logf.Close()
 	if useStdout {
-		multi := io.MultiWriter(logf, os.Stdout)
-		log.SetOutput(multi)
+		if logf == nil {
+			log.SetOutput(os.Stdout)
+		} else {
+			multi := io.MultiWriter(logf, os.Stdout)
+			log.SetOutput(multi)
+		}
 	}
 	if !noPidFlag {
 		if err := pidfile.CheckAndCreatePidfile(agentName); err != nil {

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -103,10 +103,15 @@ func Run() {
 	defer logf.Close()
 
 	if useStdout {
-		multi := io.MultiWriter(logf, os.Stdout)
-		log.SetOutput(multi)
+		if logf == nil {
+			log.SetOutput(os.Stdout)
+		} else {
+			multi := io.MultiWriter(logf, os.Stdout)
+			log.SetOutput(multi)
+		}
 	}
 
+	log.Infof("Starting %s", agentName)
 	ctx := diagContext{
 		forever:      *foreverPtr,
 		pacContents:  *pacContentsPtr,

--- a/pkg/pillar/cmd/domainmgr/rkt.go
+++ b/pkg/pillar/cmd/domainmgr/rkt.go
@@ -357,7 +357,7 @@ tarloop:
 // rktImportAciFile import a local aci file into the rkt cache. returns the
 // rkt hash and any errors.
 func rktImportAciFile(aciFilename string) (string, error) {
-	log.Info("rktGetHashes")
+	log.Info("rktImportAciFile")
 
 	cmd := "rkt"
 	baseArgs := []string{

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -107,8 +107,12 @@ func Run() {
 	}
 	defer logf.Close()
 	if nimCtx.useStdout {
-		multi := io.MultiWriter(logf, os.Stdout)
-		log.SetOutput(multi)
+		if logf == nil {
+			log.SetOutput(os.Stdout)
+		} else {
+			multi := io.MultiWriter(logf, os.Stdout)
+			log.SetOutput(multi)
+		}
 	}
 
 	if err := pidfile.CheckAndCreatePidfile(agentName); err != nil {

--- a/pkg/pillar/cmd/waitforaddr/waitforaddr.go
+++ b/pkg/pillar/cmd/waitforaddr/waitforaddr.go
@@ -70,8 +70,12 @@ func Run() {
 	}
 	defer logf.Close()
 	if useStdout {
-		multi := io.MultiWriter(logf, os.Stdout)
-		log.SetOutput(multi)
+		if logf == nil {
+			log.SetOutput(os.Stdout)
+		} else {
+			multi := io.MultiWriter(logf, os.Stdout)
+			log.SetOutput(multi)
+		}
 	}
 	if !noPidFlag {
 		if err := pidfile.CheckAndCreatePidfile(agentName); err != nil {

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -126,9 +126,13 @@ func Run() {
 	curpartPtr := flag.String("c", "", "Current partition")
 	parsePtr := flag.String("p", "", "parse checkpoint file")
 	validatePtr := flag.Bool("V", false, "validate UTF-8 in checkpoint")
+	fatalPtr := flag.Bool("F", false, "Cause log.Fatal fault injection")
+	hangPtr := flag.Bool("H", false, "Cause watchdog .touch fault injection")
 	flag.Parse()
 	debug = *debugPtr
 	debugOverride = debug
+	fatalFlag := *fatalPtr
+	hangFlag := *hangPtr
 	if debugOverride {
 		log.SetLevel(log.DebugLevel)
 	} else {
@@ -580,8 +584,16 @@ func Run() {
 			getconfigCtx.subNodeAgentStatus.ProcessChange(change)
 
 		case <-stillRunning.C:
+			// Fault injection
+			if fatalFlag {
+				log.Fatal("Requested fault injection to cause watchdog")
+			}
 		}
-		agentlog.StillRunning(agentName, warningTime, errorTime)
+		if hangFlag {
+			log.Infof("Requested to not touch to cause watchdog")
+		} else {
+			agentlog.StillRunning(agentName, warningTime, errorTime)
+		}
 		// Need to tickle this since the configTimerTask is not yet started
 		agentlog.StillRunning(agentName+"config", warningTime, errorTime)
 		agentlog.StillRunning(agentName+"metrics", warningTime, errorTime)
@@ -634,8 +646,16 @@ func Run() {
 				warningTime, errorTime)
 
 		case <-stillRunning.C:
+			// Fault injection
+			if fatalFlag {
+				log.Fatal("Requested fault injection to cause watchdog")
+			}
 		}
-		agentlog.StillRunning(agentName, warningTime, errorTime)
+		if hangFlag {
+			log.Infof("Requested to not touch to cause watchdog")
+		} else {
+			agentlog.StillRunning(agentName, warningTime, errorTime)
+		}
 		// Need to tickle this since the configTimerTask is not yet started
 		agentlog.StillRunning(agentName+"config", warningTime, errorTime)
 		agentlog.StillRunning(agentName+"metrics", warningTime, errorTime)
@@ -734,8 +754,16 @@ func Run() {
 			zedcloud.HandleDeferred(change, 100*time.Millisecond)
 
 		case <-stillRunning.C:
+			// Fault injection
+			if fatalFlag {
+				log.Fatal("Requested fault injection to cause watchdog")
+			}
 		}
-		agentlog.StillRunning(agentName, warningTime, errorTime)
+		if hangFlag {
+			log.Infof("Requested to not touch to cause watchdog")
+		} else {
+			agentlog.StillRunning(agentName, warningTime, errorTime)
+		}
 		// Need to tickle this since the configTimerTask is not yet started
 		agentlog.StillRunning(agentName+"config", warningTime, errorTime)
 	}
@@ -860,8 +888,16 @@ func Run() {
 			subVaultStatus.ProcessChange(change)
 
 		case <-stillRunning.C:
+			// Fault injection
+			if fatalFlag {
+				log.Fatal("Requested fault injection to cause watchdog")
+			}
 		}
-		agentlog.StillRunning(agentName, warningTime, errorTime)
+		if hangFlag {
+			log.Infof("Requested to not touch to cause watchdog")
+		} else {
+			agentlog.StillRunning(agentName, warningTime, errorTime)
+		}
 	}
 }
 

--- a/pkg/pillar/scripts/watchdog-report.sh
+++ b/pkg/pillar/scripts/watchdog-report.sh
@@ -13,10 +13,7 @@ DATE=$(date -Ins)
 echo "Watchdog report at $DATE: $*" >>/persist/reboot-reason
 sync
 
-CURPART=$(zboot curpart)
 # If a /var/run/<agent.touch> then try sending a SIGUSR1 to get a stack trace
-# and extract that stack trace.
-stack=""
 if [ $# -ge 2 ]; then
     agent=$(echo "$2" | grep '/var/run/.*\.touch' | sed 's,/var/run/\(.*\)\.touch,\1,')
     if [ -n "$agent" ]; then
@@ -26,13 +23,6 @@ if [ $# -ge 2 ]; then
         fi
         echo "pkill -USR1 /opt/zededa/bin/$agent"
         pkill -USR1 /opt/zededa/bin/"$agent"
-        sleep 5
-        # Note that logmanager.log is not json format
-        if [ "$agent" = "logmanager" ]; then
-            stack=$(grep level=warning /persist/log/logmanager.log | grep "stack trace")
-        else
-            stack=$(grep level...warning "/persist/$CURPART/log/$agent.log" | grep "stack trace")
-        fi
     fi
 fi
 
@@ -40,26 +30,8 @@ echo "Watchdog report at $DATE: $*" >>/persist/log/watchdog.log
 ps >>/persist/log/watchdog.log
 echo "Watchdog report done" >>/persist/log/watchdog.log
 
+CURPART=$(zboot curpart)
 echo "Watchdog report at $DATE: $*" >>/persist/"$CURPART"/reboot-reason
-# If a /var/run/<agent.pid> then look for a level fatal" message in its log
-fatal=""
-if [ $# -ge 2 ]; then
-    agent=$(echo "$2" | grep '/var/run/.*\.pid' | sed 's,/var/run/\(.*\)\.pid,\1,')
-    # Note that logmanager.log is not json format
-    if [ "$agent" = "logmanager" ]; then
-        fatal=$(grep level=fatal /persist/log/logmanager.log)
-        stack=$(grep level=error /persist/log/logmanager.log | grep "stack trace")
-    elif [ -n "$agent" ]; then
-        fatal=$(grep level...fatal "/persist/$CURPART/log/$agent.log")
-        stack=$(grep level...error "/persist/$CURPART/log/$agent.log" | grep "stack trace")
-    fi
-fi
-if [ -n "$fatal" ]; then
-   echo "$fatal" >>/persist/"$CURPART"/reboot-reason
-fi
-if [ -n "$stack" ]; then
-   echo "$stack" >>/persist/"$CURPART"/reboot-stack
-fi
 
 sync
 sleep 30


### PR DESCRIPTION
The code to extract it from /persist/IMGx/log/*.log is no longer working.

Also, when we delete an app instance we don't need to wait for 11 minutes; this causes issues for some tests especially if the domU is somehow hosed.

Also added -H and -F options to zedagent to be able to inject faults in the form of a hang (not updating the zedagent.touch) and doing a log.Fatal, respectively.
We've had those -H and -F for logmanager but zedagent is more useful for fault injection testing.
Used that to manually test that we get the reboot-reason and reboot-stack sent to zedcloud for a hang, log.Fatal, and agent crash (pkill zedrouter).