### PR TITLE
Supplying rsyslog with EVE identity + getting rid of spurious 'can't load message'

### DIFF
--- a/pkg/dom0-ztools/rootfs/etc/init.d/009-id
+++ b/pkg/dom0-ztools/rootfs/etc/init.d/009-id
@@ -1,0 +1,2 @@
+#!/bin/sh
+zboot curpart > /run/eve.id

--- a/pkg/rsyslog/build.yml
+++ b/pkg/rsyslog/build.yml
@@ -3,6 +3,7 @@ org: lfedge
 network: yes
 config:
   binds:
+    - /run:/run
     - /dev:/dev
     - /etc/resolv.conf:/etc/resolv.conf
     - /var/persist:/persist

--- a/pkg/rsyslog/init.sh
+++ b/pkg/rsyslog/init.sh
@@ -13,7 +13,7 @@ if [ ! -d "$RSYSLOG_WORK_DIR" ]; then
   chmod 644 $RSYSLOG_WORK_DIR
 fi
 
-# XXX IMGB?
-IMGP=IMGA /usr/sbin/rsyslogd
+IMGP=$(cat /run/eve.id 2>/dev/null)
+IMGP=${IMGP:-IMGX} /usr/sbin/rsyslogd
 
 waitforsyslog

--- a/pkg/rsyslog/rsyslog.conf
+++ b/pkg/rsyslog/rsyslog.conf
@@ -7,7 +7,6 @@ set $/IMGP = getenv("IMGP");
 module(load="imklog")
 module(load="imuxsock" SysSock.Name="/dev/log")
 module(load="mmjsonparse")
-module(load="omfile")
 
 # default permissions for all log files.
 $FileOwner root


### PR DESCRIPTION
Simple change to bring back IMGA/IMGB tags in our logs.

I may still much with how/where EVE's ID is stored (for the desegregation efforts) but the beauty of this approach is that rsyslog won't be affected.

Depending on whether we will move rsyslog to the root FS or into services section this may slightly change as well. 