### PR TITLE
Remove code that redirects dnsmasq logs to files in /persist/IMGx/log directory

### DIFF
--- a/pkg/pillar/agentlog/agentlog.go
+++ b/pkg/pillar/agentlog/agentlog.go
@@ -49,8 +49,7 @@ func initImpl(agentName string, logdir string, redirect bool,
 
 	if text {
 		logfile := fmt.Sprintf("%s/%s.log", logdir, agentName)
-		logf, err = os.OpenFile(logfile, os.O_RDWR|os.O_CREATE|os.O_APPEND,
-			0666)
+		logf, err = os.OpenFile(logfile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 		if err != nil {
 			return nil, err
 		}
@@ -330,7 +329,7 @@ func InitWithDirText(agentName string, logdir string, curpart string) (*os.File,
 // Setup and return a logf, but don't redirect our log.*
 func InitChild(agentName string) (*os.File, error) {
 	logdir := GetCurrentLogdir()
-	return initImpl(agentName, logdir, false, false)
+	return initImpl(agentName, logdir, false, true)
 }
 
 var currentIMGdir = ""

--- a/pkg/pillar/cmd/zedrouter/dnsmasq.go
+++ b/pkg/pillar/cmd/zedrouter/dnsmasq.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	log "github.com/sirupsen/logrus"
 )
@@ -360,27 +359,7 @@ func startDnsmasq(bridgeName string) {
 		"-C",
 		cfgPathname,
 	}
-	logFilename := fmt.Sprintf("dnsmasq.%s", bridgeName)
-	logf, err := agentlog.InitChild(logFilename)
-	if err != nil {
-		log.Fatalf("startDnsmasq agentlog failed: %s\n", err)
-	}
-	w := bufio.NewWriter(logf)
-	ts := time.Now().Format(time.RFC3339Nano)
-	fmt.Fprintf(w, "%s Starting %s %v\n", ts, name, args)
 	cmd := exec.Command(name, args...)
-	// Report nano timestamps
-	formatter := log.JSONFormatter{
-		TimestampFormat: time.RFC3339Nano,
-	}
-	var tslog = &log.Logger{
-		Out:       logf,
-		Formatter: &formatter,
-		Hooks:     make(log.LevelHooks),
-		Level:     log.InfoLevel,
-	}
-	cmd.Stdout = tslog.Writer()
-	cmd.Stderr = tslog.Writer()
 	log.Infof("Calling command %s %v\n", name, args)
 	go cmd.Run()
 }


### PR DESCRIPTION
Zedrouter sets the stdout/stderr of dnsmasq command to files created in /persist/IMGx/log directory. With new code changes, we do not even create the files required. This leads to error messages being dumped in device-steps.log when dnsmasq sends logs.

Logs from dnsmasq are already sent directly to syslog by dnsmasq itself.

However, zedrouter also starts dhcpcd in the same way. I see we start dhcpcd with "-d" option that tells dhcpcd to send logs to both stdout and syslog. But I do not see logs coming from dhcpcd to syslog. I still have not figured out the reason why dhcpcd does not send logs to syslog. For now, I'm retaining the file mechanism that zedrouter uses for dhcpcd. Will come back to this latest. I'll also create a story for this now.

Signed-off-by: GopiKrishna Kodali <gkodali@zededa.com>