### PR TITLE
dhcpcd is made to run in background and send logs to syslog. But, it …

### DIFF
--- a/pkg/pillar/rootfs/dhcpcd.conf
+++ b/pkg/pillar/rootfs/dhcpcd.conf
@@ -42,3 +42,6 @@ noarp
 
 # wait for ipv4 address
 waitip 4
+
+# send logs to syslog
+debug


### PR DESCRIPTION
…has been found that dhcpcd does not tag it's own logs with process name. As a result, logs generated by dhcpcd will have source populated with empty string in logs exported to cloud.

Signed-off-by: GopiKrishna Kodali <gkodali@zededa.com>