### PR TITLE
No compression for temporary aci file

### DIFF
--- a/pkg/pillar/cmd/domainmgr/rkt.go
+++ b/pkg/pillar/cmd/domainmgr/rkt.go
@@ -119,7 +119,7 @@ func rktConvertTarToAci(from, to string) ([]string, error) {
 		Squash:      true,
 		OutputDir:   to,
 		TmpDir:      tmpDir,
-		Compression: common.GzipCompression,
+		Compression: common.NoCompression,
 		Debug:       acilog.NewNopLogger(),
 		Info:        acilog.NewStdLogger(os.Stderr),
 	}


### PR DESCRIPTION
The docker2aci implementation was doing much of gzip compression in memory. Since the aci file is temporary anyways, not much need for it.

E.g. converting a 553MB `tar` file with gzip compression ate up ~160MB memory; without compression, 40KB.