### PR TITLE
Avoid waitforsyslog and make agents retry

### DIFF
--- a/pkg/rsyslog/init.sh
+++ b/pkg/rsyslog/init.sh
@@ -16,4 +16,5 @@ fi
 IMGP=$(cat /run/eve.id 2>/dev/null)
 IMGP=${IMGP:-IMGX} /usr/sbin/rsyslogd
 
-waitforsyslog
+# XXX this can hang forever?? And we don't have a way to recover
+# waitforsyslog


### PR DESCRIPTION
Until we figure out how to never make rsyslogd core dump and/or somehow watch the rsyslogd process from the start I suggest we make the system come up.

On failure such as rsyslogd core dump or hang on startup  the agent logs go to stdout i.e., device-steps.log
In that case we will not get any logs sent to the controller (@gkodali-zededa or logmanager keep sending device-steps.log?) 
