### PR TITLE
simplify old image cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -336,6 +336,12 @@ eve-%: pkg/%/Dockerfile build-tools $(RESCAN_DEPS)
 	@$(DOCKER_GO) "dep ensure -update $(GODEP_NAME)" $(dir $@)
 	@echo Done updating $@
 
+oldimages:
+	./tools/oldimages.sh
+
+imageclean:
+	docker rmi -f $(shell ./tools/oldimages.sh)
+
 .PHONY: all clean test run pkgs help build-tools live rootfs config installer live FORCE $(DIST) HOSTARCH
 FORCE:
 

--- a/tools/oldimages.sh
+++ b/tools/oldimages.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# get all of the lfedge images
+IMGS=$(docker image ls --format "{{.Repository}}\t{{.Tag}}\t{{.ID}}"  --filter reference='lfedge/*')
+# get the image names without tags
+IMGNAMES=
+
+# limit to just a few as an option
+if [ $# -gt 0 ]; then
+	IMGNAMES="$@" 
+else
+	IMGNAMES=$(echo "$IMGS" | awk '{print $1}' | sort | uniq)
+fi
+
+# find the IDs of each image name, all but the most recent
+IMGIDS=""
+for i in $IMGNAMES; do
+	TMPIDS=$(echo "$IMGS" | grep -w "^$i" | awk '{print $3}' | uniq)
+	IDCOUNT=$(echo "$TMPIDS" | wc -w)
+	if [ $IDCOUNT -gt 1 ]; then
+		TMPIDS=$(echo "$TMPIDS" | tail -n +2)
+		IMGIDS="$IMGIDS $TMPIDS"
+	fi
+done
+
+echo $IMGIDS


### PR DESCRIPTION
Simple tool. I often find that I want to clean up old images. I can do `docker system prune`, but that eliminates some useful interim layers, making the build take immensely longer.

We should be smarter about this, e.g. removing dangling images except for the ones that would be used on next build, but this is a first step.

It finds all of the images with a repository name `lfedge/*`, then for each one finds all of their image IDs, and deletes all except for the most recent.

Also adds make targets to report the images it would delete and to delete them.

I found it very useful for a quick cleanup as `make imageclean` to remove all of those old images and free up gigabytes of space, without having to do an entire rebuild next time I `make`.