### PR TITLE
1) Have watchdog monitor rsyslogd using pid at /hostfs/run/rsyslogd.pid

### DIFF
--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -125,6 +125,7 @@ pidfile = /var/run/xen/xenconsoled.pid
 pidfile = /var/run/xen/xenstored.pid
 pidfile = /var/run/crond.pid
 pidfile = /var/run/logread.pid
+pidfile = /run/rsyslogd.pid
 EOF
 # XXX Other processes we should potentially watch but they run outside
 # of this container:

--- a/pkg/pillar/scripts/watchdog-report.sh
+++ b/pkg/pillar/scripts/watchdog-report.sh
@@ -53,6 +53,19 @@ if [ -n "$oom" ]; then
    echo "$oom" >>/persist/"$CURPART"/reboot-reason
 fi
 
+# Check if it is rsyslogd that crashed.
+# Tar the contents inside /persist/rsyslog directory and reboot.
+if [ $# -ge 2 ]; then
+    agent=$(echo "$2" | grep '/run/.*\.pid' | sed 's,/run/\(.*\)\.pid,\1,')
+    if [ "$agent" = "rsyslogd" ]; then
+        mkdir -p /persist/rsyslog-backup
+        # Tar contents of /persist/rsyslog
+        NAME="rsyslogd-$(date '+%Y-%m-%d-%H-%M-%S').tar.gz"
+        tar -cvzf "/persist/rsyslog-backup/$NAME" /persist/rsyslog/*
+        rm -rf /persist/rsyslog
+    fi
+fi
+
 sync
 sleep 30
 sync

--- a/pkg/rsyslog/rsyslog.conf
+++ b/pkg/rsyslog/rsyslog.conf
@@ -28,7 +28,7 @@ main_queue(
   queue.checkpointinterval="1"
   queue.syncqueuefiles="on"
   queue.saveOnShutdown="on"
-  queue.maxFileSize="10k"
+  queue.maxFileSize="100m"
 )
 
 template(name="jsonOutput" type="list" option.jsonf="on") {
@@ -55,12 +55,14 @@ action(type="mmjsonparse" cookie="")
 
 if $parsesuccess == "FAIL" then {
     *.* action(type="omfwd"
+               action.resumeRetryCount="-1"
                Target="127.0.0.1"
                Port="5140"
                Protocol="tcp"
                template="nonJsonOutput")
 } else {
     *.* action(type="omfwd"
+               action.resumeRetryCount="-1"
                Target="127.0.0.1"
                Port="5140"
                Protocol="tcp"


### PR DESCRIPTION
2) Have watchdog-parse.sh look for rsyslogd crashes and then tar the existing contents
of /persist/rsyslog into /persist/rsyslog-backup
3) In the event of rsyslgod crash, clear the current contents (after backing up) of /persist/rsyslog
4) We currently use a queue block size of 10k bytes for rsyslogd main queue. This is very less
and have seen only two messages fit in a single block (metrics messages). This leads to rapid
rotation of these block files which slows down rsyslogd. This also increases the probability
of *.qi file corruption. I've increased the queue block size to 100M for now. Let me know.

Signed-off-by: GopiKrishna Kodali <gkodali@zededa.com>