### PR TITLE
Adding disk images in xen config file for container instances

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -994,7 +994,7 @@ func handleCreate(ctx *domainContext, key string, config *types.DomainConfig) {
 	// Do we need to copy any rw files? !Preserve ones are copied upon
 	// activation.
 	for _, ds := range status.DiskStatusList {
-		if zconfig.Format_CONTAINER == ds.Format {
+		if ds.Format == zconfig.Format_CONTAINER {
 			continue
 		}
 		if ds.ReadOnly || !ds.Preserve {
@@ -1188,7 +1188,7 @@ func doActivate(ctx *domainContext, config types.DomainConfig,
 	// Do we need to copy any rw files? Preserve ones are copied upon
 	// creation
 	for _, ds := range status.DiskStatusList {
-		if zconfig.Format_CONTAINER == ds.Format {
+		if ds.Format == zconfig.Format_CONTAINER {
 			continue
 		}
 		if ds.ReadOnly || ds.Preserve {
@@ -1423,7 +1423,7 @@ func doInactivate(ctx *domainContext, status *types.DomainStatus, impatient bool
 	// Do we need to delete any rw files that should
 	// not be preserved across reboots?
 	for _, ds := range status.DiskStatusList {
-		if zconfig.Format_CONTAINER == ds.Format {
+		if ds.Format == zconfig.Format_CONTAINER {
 			continue
 		}
 		if !ds.ReadOnly && !ds.Preserve {
@@ -1743,6 +1743,9 @@ func configToXencfg(config types.DomainConfig, status types.DomainStatus,
 
 	diskString := ""
 	for i, ds := range status.DiskStatusList {
+		if ds.Format == zconfig.Format_CONTAINER {
+			continue
+		}
 		access := "rw"
 		if ds.ReadOnly {
 			access = "ro"

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -994,7 +994,7 @@ func handleCreate(ctx *domainContext, key string, config *types.DomainConfig) {
 	// Do we need to copy any rw files? !Preserve ones are copied upon
 	// activation.
 	for _, ds := range status.DiskStatusList {
-		if status.IsContainer {
+		if zconfig.Format_CONTAINER == ds.Format {
 			continue
 		}
 		if ds.ReadOnly || !ds.Preserve {
@@ -1188,7 +1188,7 @@ func doActivate(ctx *domainContext, config types.DomainConfig,
 	// Do we need to copy any rw files? Preserve ones are copied upon
 	// creation
 	for _, ds := range status.DiskStatusList {
-		if status.IsContainer {
+		if zconfig.Format_CONTAINER == ds.Format {
 			continue
 		}
 		if ds.ReadOnly || ds.Preserve {
@@ -1423,7 +1423,7 @@ func doInactivate(ctx *domainContext, status *types.DomainStatus, impatient bool
 	// Do we need to delete any rw files that should
 	// not be preserved across reboots?
 	for _, ds := range status.DiskStatusList {
-		if status.IsContainer {
+		if zconfig.Format_CONTAINER == ds.Format {
 			continue
 		}
 		if !ds.ReadOnly && !ds.Preserve {


### PR DESCRIPTION
In an existing code, we are not handling disk images in the drives for the container instances. We are simply ignoring them if the instance is of container type but we are adding them in the Xen file.
After these changes, we are looking for the disks for the container instance also. The rest of the code for the VM and Container instances are the same like if ReadOnly is set for the disk we will copy it in /persist/img, if Preserve is set we will not delete the disk at reboot etc. We are only ignoring the disks of container type in drives.

We are also skipping container disks to be added in the Xen file.

Signed-off-by: zed-rishabh <rgupta@zededa.com>