### PR TITLE
fix a build break if running make proto-vendor

### DIFF
--- a/pkg/pillar/go.mod
+++ b/pkg/pillar/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	contrib.go.opencensus.io/exporter/ocagent v0.4.11 // indirect
 	github.com/Azure/azure-sdk-for-go v19.1.1+incompatible
-	github.com/Azure/go-autorest v11.7.0+incompatible // indirect
+	github.com/Azure/go-autorest v13.0.1+incompatible // indirect
 	github.com/VictorLowther/godmi v0.0.0-20190311134151-270258a8252d // indirect
 	github.com/appc/docker2aci v0.17.2
 	github.com/appc/spec v0.8.11 // indirect

--- a/pkg/pillar/go.sum
+++ b/pkg/pillar/go.sum
@@ -7,7 +7,7 @@ github.com/Azure/azure-sdk-for-go v19.1.1+incompatible/go.mod h1:9XXNKU+eRnpl9mo
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-autorest v10.15.5+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest v11.7.0+incompatible h1:gzma19dc9ejB75D90E5S+/wXouzpZyA+CV+/MJPSD/k=
-github.com/Azure/go-autorest v11.7.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
+github.com/Azure/go-autorest v13.0.1+incompatible h1:wRg6hB3T3dp7qjj5v3NmVsdU9IyXodW+SQnN9xlpGEA=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=


### PR DESCRIPTION
Signed-off-by: Naiming Shen <naiming@zededa.com>
- this patch fixes the 'make pkgs' breakage if after running 'make proto-vendor'
   the problem started 1/26/2020 after some changes from vendor directory
- this was the error msg:
Running go vet
build github.com/lf-edge/eve/pkg/pillar/zedbox: cannot load github.com/Azure/go-autorest/autorest: open /pillar/vendor/github.com/Azure/go-autorest/autorest: no such file or directory