### PR TITLE
Allow goroutine handlers to take a long time

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -808,7 +808,7 @@ func maybeRetryBoot(ctx *domainContext, status *types.DomainStatus) {
 	elapsed := t.Sub(status.LastErrTime)
 	timeLimit := time.Duration(ctx.domainBootRetryTime) * time.Second
 	if elapsed < timeLimit {
-		log.Infof("maybeRetryBoot(%s) %v remaining\n",
+		log.Infof("maybeRetryBoot(%s) %d remaining\n",
 			status.Key(),
 			(timeLimit-elapsed)/time.Second)
 		return

--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -239,7 +239,7 @@ func lookupDownloaderConfig(ctx *downloaderContext, objType string,
 
 // Server for each domU
 func runHandler(ctx *downloaderContext, objType string, key string,
-	c <-chan interface{}) {
+	c <-chan Notify) {
 
 	log.Infof("runHandler starting\n")
 
@@ -250,9 +250,15 @@ func runHandler(ctx *downloaderContext, objType string, key string,
 	closed := false
 	for !closed {
 		select {
-		case configArg, ok := <-c:
+		case _, ok := <-c:
 			if ok {
-				config := configArg.(types.DownloaderConfig)
+				sub := ctx.subscription(objType)
+				c, err := sub.Get(key)
+				if err != nil {
+					log.Errorf("runHandler no config for %s", key)
+					continue
+				}
+				config := c.(types.DownloaderConfig)
 				status := lookupDownloaderStatus(ctx,
 					objType, key)
 				if status == nil {


### PR DESCRIPTION
The domainmgr shutdown can take a long time (tested with the mirage app instance which takes between 10 and 20 minutes since it is PV but has no shutdown handler).

This ensures that the main event loop doesn't get stuck (and domainmgr.touch doesn't cause a watchdog).

Also updated the code in verifier and downloader which has the same channel to a goroutine setup.
They all pass a notification instead of a config, and runHandler picks up the most recent config from the subscription.

