### PR TITLE
how to read qemu files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ pkg/qrexec-dom0/Dockerfile
 pkg/qrexec-lib/Dockerfile
 .go/
 tags
+tmp/

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -226,3 +226,17 @@ created by github.com/lf-edge/eve/pkg/pillar/pubsub/socketdriver.(*Publisher).St
 ```
 
 Looking at the above, we can see all of the go routines. Specifically, the `main` routine shows where it is processing and in which file.
+
+### Log Files in QEMU
+
+If you are running in qemu and want to pull the log files off, use the following utility:
+
+```sh
+tools/extract-persist.sh [<type>] [<arch>]
+```
+
+It will extract the contents of the `/persist` partition to `./tmp/persist.tgz` for the given type and architecture.
+
+* `type`: either `live` or `installer`. Defaults to `live`.
+* `arch`: any supported architecture, currently `arm64` or `amd64`. Defaults to `amd64`.
+

--- a/tools/extract-persist.sh
+++ b/tools/extract-persist.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+set -e
+
+FILE="$1"
+ARCH="$2"
+
+# set defaults
+if [ -z "$1" ]; then
+  FILE="live"
+fi
+if [ -z "$2" ]; then
+  ARCH="amd64"
+fi
+
+# because the convenient name "installer" is not the file name
+if [ "$FILE" = "installer" ]; then
+  FILE="target"
+fi
+
+TMPDIR=./tmp
+OUTFILE=${TMPDIR}/persist.tgz
+TMPFILE=${TMPDIR}/${FILE}-${ARCH}.qcow2
+INFILE=./dist/${ARCH}/${FILE}.qcow2
+
+if [ ! -f "${INFILE}" ]; then
+  echo "input file ${INFILE} does not exist; are you running this from the right directory? Did you already run make live?" >&2
+  exit 1
+fi
+
+# set out temporary working directory
+mkdir -p ${TMPDIR}
+
+# copy the live file over
+cp ${INFILE} ${TMPFILE}
+
+# ensure that network block device is installed
+sudo modprobe nbd max_part=10
+
+# connect the qcow2 file as a network block device
+sudo qemu-nbd -c /dev/nbd0 ${TMPFILE}
+
+# get the persist partition, which is the 9th partition
+sudo mount /dev/nbd0p9 /mnt
+
+# optionally, create a tgz file with the contents
+sudo tar -C /mnt -zcvf ${OUTFILE}  -C /mnt .
+
+# unmount the persist partition
+sudo umount /mnt
+
+# remove the network block device
+sudo qemu-nbd -d /dev/nbd0
+
+# remove the temporary file
+rm -f ${TMPFILE}
+
+# report
+echo "persist directory extracted to ${OUTFILE}"


### PR DESCRIPTION
I often find that I need to copy the persist directory out of qemu when working with it, to test. This creates a small script to extract them to `tmp/persist.tgz`, after which you can do with it as you please.