### PR TITLE
Moving all logs to memlogd/rsyslog

### DIFF
--- a/images/rootfs-acrn.yml.in
+++ b/images/rootfs-acrn.yml.in
@@ -23,9 +23,9 @@ onboot:
    - name: modprobe
      image: linuxkit/modprobe:v0.5
      command: ["modprobe", "-a", "nct6775", "w83627hf_wdt", "wlcore_sdio", "wl18xx", "br_netfilter"]
+services:
    - name: rsyslogd
      image: RSYSLOGD_TAG
-services:
    - name: ntpd
      image: linuxkit/openntpd:v0.5
    - name: sshd

--- a/images/rootfs-xen.yml.in
+++ b/images/rootfs-xen.yml.in
@@ -23,9 +23,9 @@ onboot:
    - name: modprobe
      image: linuxkit/modprobe:v0.5
      command: ["modprobe", "-a", "nct6775", "w83627hf_wdt", "wlcore_sdio", "wl18xx", "br_netfilter"]
+services:
    - name: rsyslogd
      image: RSYSLOGD_TAG
-services:
    - name: ntpd
      image: linuxkit/openntpd:v0.5
    - name: sshd

--- a/pkg/pillar/Dockerfile.in
+++ b/pkg/pillar/Dockerfile.in
@@ -45,8 +45,6 @@ FROM FSCRYPT_TAG as fscrypt-build
 # hadolint ignore=DL3006
 FROM UEFI_TAG as uefi-build
 
-FROM linuxkit/memlogd:v0.5 as memlogd
-
 FROM alpine:3.8
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
@@ -89,7 +87,6 @@ COPY --from=rkt-stage1-build /go/stage1-xen-master/stage1-xen.aci /usr/sbin/stag
 COPY --from=fscrypt-build /fscrypt /opt/zededa/bin/fscrypt
 COPY --from=uefi-build /OVMF.fd /usr/lib/xen/boot/ovmf.bin
 COPY --from=uefi-build /OVMF_PVH.fd /usr/lib/xen/boot/ovmf-pvh.bin
-COPY --from=memlogd /usr/bin/logread /usr/bin/logread
 
 # We need to keep a slim profile, which means removing things we don't need
 RUN rm /usr/lib/libxen*.a /usr/lib/libxl*.a

--- a/pkg/pillar/rootfs/init.sh
+++ b/pkg/pillar/rootfs/init.sh
@@ -20,5 +20,4 @@ XENCONSOLED_ARGS='--log=all --log-dir=/var/log/xen' /etc/init.d/xencommons start
 sleep 5 # Let it come up
 
 echo 'Starting device-steps'
-/opt/zededa/bin/device-steps.sh >/var/log/device-steps.log 2>&1
-
+/opt/zededa/bin/device-steps.sh

--- a/pkg/rsyslog/Dockerfile
+++ b/pkg/rsyslog/Dockerfile
@@ -1,14 +1,3 @@
-FROM linuxkit/alpine:3683c9a66cd4da40bd7d6c7da599b2dcd738b559 AS build
-
-RUN apk add --no-cache  \
-    go=1.10.1-r0        \
-    musl-dev=1.1.19-r10 \
-    binutils=2.30-r5
-
-COPY cmd/waitforsyslog /go/src/waitforsyslog
-RUN go-compile.sh /go/src/waitforsyslog
-RUN strip /go/bin/waitforsyslog
-
 FROM alpine:3.10.3
 WORKDIR /
 RUN apk add --no-cache \
@@ -17,7 +6,6 @@ RUN apk add --no-cache \
 COPY rsyslog.conf /etc/rsyslog.conf
 COPY init.sh /init.sh
 COPY rotate.sh /rotate.sh
-COPY --from=build /go/bin/waitforsyslog /bin/
 
 ENTRYPOINT []
 CMD ["/init.sh"]

--- a/pkg/rsyslog/build.yml
+++ b/pkg/rsyslog/build.yml
@@ -7,6 +7,7 @@ config:
     - /dev:/dev
     - /etc/resolv.conf:/etc/resolv.conf
     - /var/persist:/persist
+    - /usr/bin/logread:/usr/bin/logread
   net: host
   capabilities:
     - all

--- a/pkg/rsyslog/init.sh
+++ b/pkg/rsyslog/init.sh
@@ -16,5 +16,4 @@ fi
 IMGP=$(cat /run/eve.id 2>/dev/null)
 IMGP=${IMGP:-IMGX} /usr/sbin/rsyslogd
 
-# XXX this can hang forever?? And we don't have a way to recover
-# waitforsyslog
+while true; do /usr/bin/logread -F -socket /run/memlogdq.sock | logger ; done

--- a/pkg/rsyslog/rsyslog.conf
+++ b/pkg/rsyslog/rsyslog.conf
@@ -59,14 +59,16 @@ if $parsesuccess == "FAIL" then {
                Target="127.0.0.1"
                Port="5140"
                Protocol="tcp"
-               template="nonJsonOutput")
+               template="nonJsonOutput"
+               queue.size="1000" queue.type="LinkedList")
 } else {
     *.* action(type="omfwd"
                action.resumeRetryCount="-1"
                Target="127.0.0.1"
                Port="5140"
                Protocol="tcp"
-               template="jsonOutput")
+               template="jsonOutput"
+               queue.size="1000" queue.type="LinkedList")
 }
 
 *.* :omfile:$local

--- a/pkg/vtpm/init.sh
+++ b/pkg/vtpm/init.sh
@@ -2,4 +2,4 @@
 
 #Launch the VTPM server
 mkdir jail; cd jail || exit;
-/usr/bin/vtpm_server > vtpm_server.log 2>&1
+/usr/bin/vtpm_server


### PR DESCRIPTION
This is the clean up portion of me working on a lot of EVE functionality lately and needing sane logs to go with it. This leaves rsyslog work at a stage where @gkodali-zededa can proceed with his work on making rsyslog more reliable.

What do we get at this point:
   * rsyslog moved to services section
   * all containers are now more than welcome to log simply to stdout/stderr, all of that gets scooped up by memlogd and will eventually end up in syslog queue
   * if containers decide to log directly to syslog -- that's fine too, but if that fails stdout/stderr is always available as a reliable backup

What makes me really happy about the current situation is that we only have a handful of logs still in the filesystem. Almost everything else got cleaned up and is now logging directly to memlogd.

What's left to implement (I think @gkodali-zededa agreed to pick up some of this)
   * making rsyslog container much more reliable with re-tries, etc.
   * re-implementing logread | logger stanza as a plugin for rsyslogd
   * much more clean up on the remaining text logs in the filesystem