### PR TITLE
move xen to domainmgr

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -81,11 +81,14 @@ type domainContext struct {
 	subGlobalConfig        pubsub.Subscription
 	pubImageStatus         pubsub.Publication
 	pubAssignableAdapters  pubsub.Publication
+	pubDomainMetric        pubsub.Publication
+	pubHostMemory          pubsub.Publication
 	usbAccess              bool
 	createSema             sema.Semaphore
 	GCInitialized          bool
 	vdiskGCTime            uint32 // In seconds
 	domainBootRetryTime    uint32 // In seconds
+	metricInterval         uint32 // In seconds
 }
 
 // appRwImageName - Returns name of the image ( including parent dir )
@@ -227,7 +230,21 @@ func Run() {
 		log.Fatal(err)
 	}
 	domainCtx.pubAssignableAdapters = pubAssignableAdapters
-	pubAssignableAdapters.ClearRestarted()
+
+	pubDomainMetric, err := pubsublegacy.Publish(agentName,
+		types.DomainMetric{})
+	if err != nil {
+		log.Fatal(err)
+	}
+	domainCtx.pubDomainMetric = pubDomainMetric
+
+	pubHostMemory, err := pubsublegacy.Publish(agentName,
+		types.HostMemory{})
+	if err != nil {
+		log.Fatal(err)
+	}
+	domainCtx.pubHostMemory = pubHostMemory
+	pubHostMemory.ClearRestarted()
 
 	// Look for global config such as log levels
 	subGlobalConfig, err := pubsublegacy.Subscribe("", types.GlobalConfig{},
@@ -269,6 +286,8 @@ func Run() {
 		agentlog.StillRunning(agentName, warningTime, errorTime)
 	}
 	log.Infof("processed GlobalConfig")
+
+	go metricsTimerTask(&domainCtx)
 
 	// Wait for DeviceNetworkStatus to be init so we know the management
 	// ports and then wait for assignableAdapters.
@@ -2686,6 +2705,9 @@ func handleGlobalConfigModify(ctxArg interface{}, key string,
 		if gcp.UsbAccess != ctx.usbAccess {
 			ctx.usbAccess = gcp.UsbAccess
 			updateUsbAccess(ctx)
+		}
+		if gcp.MetricInterval != 0 {
+			ctx.metricInterval = gcp.MetricInterval
 		}
 		ctx.GCInitialized = true
 	}

--- a/pkg/pillar/cmd/domainmgr/metric.go
+++ b/pkg/pillar/cmd/domainmgr/metric.go
@@ -1,0 +1,390 @@
+// Copyright (c) 2017-2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package domainmgr
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/agentlog"
+	"github.com/lf-edge/eve/pkg/pillar/flextimer"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	uuid "github.com/satori/go.uuid"
+	"github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/mem"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	dom0Name = "Domain-0"
+)
+
+// Run a periodic post of the metrics
+func metricsTimerTask(ctx *domainContext) {
+	log.Infoln("starting metrics timer task")
+	getAndPublishMetrics(ctx)
+
+	// Publish 4X more often than zedagent publishes to controller
+	interval := time.Duration(ctx.metricInterval) * time.Second
+	max := float64(interval) / 4
+	min := max * 0.3
+	ticker := flextimer.NewRangeTicker(time.Duration(min), time.Duration(max))
+
+	// Run a periodic timer so we always update StillRunning
+	stillRunning := time.NewTicker(25 * time.Second)
+	agentlog.StillRunning(agentName+"metrics", warningTime, errorTime)
+
+	for {
+		select {
+		case <-ticker.C:
+			start := time.Now()
+			getAndPublishMetrics(ctx)
+			pubsub.CheckMaxTimeTopic(agentName+"metrics", "publishMetrics", start,
+				warningTime, errorTime)
+
+		case <-stillRunning.C:
+		}
+		agentlog.StillRunning(agentName+"metrics", warningTime, errorTime)
+	}
+}
+
+func getAndPublishMetrics(ctx *domainContext) {
+	getAndPublishCPUMemory(ctx)
+	getAndPublishHostMemory(ctx)
+}
+
+func getAndPublishCPUMemory(ctx *domainContext) {
+	var dmList map[string]types.DomainMetric
+	cpuMemoryStat := executeXentopCmd()
+	if len(cpuMemoryStat) == 0 {
+		dmList = fallbackDomainMetric()
+	} else {
+		dmList = parseCPUMemoryStat(cpuMemoryStat)
+	}
+	for domainName, dm := range dmList {
+		uuid, err := domainnameToUUID(ctx, domainName)
+		if err != nil {
+			log.Errorf("domainname %s: %s", domainName, err)
+			continue
+		}
+		dm.UUIDandVersion.UUID = uuid
+		ctx.pubDomainMetric.Publish(dm.Key(), dm)
+	}
+	if false {
+		// debug code to compare Xen and fallback
+		log.Infof("XXX reported DomainMetric %+v", dmList)
+		dmList = fallbackDomainMetric()
+		log.Infof("XXX fallback DomainMetric %+v", dmList)
+	}
+}
+
+// Returns zero for the host/overhead
+func domainnameToUUID(ctx *domainContext, domainName string) (uuid.UUID, error) {
+	if domainName == dom0Name {
+		return uuid.UUID{}, nil
+	}
+	pub := ctx.pubDomainStatus
+	items := pub.GetAll()
+	for _, st := range items {
+		status := st.(types.DomainStatus)
+		if status.DomainName == domainName {
+			return status.UUIDandVersion.UUID, nil
+		}
+	}
+	return uuid.UUID{}, fmt.Errorf("Unknown domainname %s", domainName)
+}
+
+// First approximation for a host without Xen
+// XXX Assumes that all of the used memory in the host is overhead the same way dom0 is
+// overhead, which is completely incorrect when running containers
+func fallbackDomainMetric() map[string]types.DomainMetric {
+	dmList := make(map[string]types.DomainMetric)
+	vm, err := mem.VirtualMemory()
+	if err != nil {
+		log.Errorf("mem.VirtualMemory failed: %s", err)
+		return dmList
+	}
+	var usedMemoryPercent float64
+	if vm.Total != 0 {
+		usedMemoryPercent = float64(100 * (vm.Total - vm.Available) / vm.Total)
+	}
+	total := roundFromBytesToMbytes(vm.Total)
+	available := roundFromBytesToMbytes(vm.Available)
+	dm := types.DomainMetric{
+		UsedMemory:        uint32(total - available),
+		AvailableMemory:   uint32(available),
+		UsedMemoryPercent: usedMemoryPercent,
+	}
+	// Ask for one total entry
+	cpuStat, err := cpu.Times(false)
+	if err != nil {
+		log.Errorf("cpu.TimesStat failed: %s", err)
+		return dmList
+	}
+	for _, cpu := range cpuStat {
+		log.Infof("cpuStat %s: %v", cpu.CPU, cpu)
+		dm.CPUTotal = uint64(cpu.Total())
+		break
+	}
+	dmList[dom0Name] = dm
+	return dmList
+}
+
+// XXX can we use libxenstat? /usr/local/lib/libxenstat.so on hikey
+// /usr/lib/libxenstat.so in container
+func executeXentopCmd() [][]string {
+	var cpuMemoryStat [][]string
+
+	count := 0
+	counter := 0
+	arg1 := "xentop"
+	arg2 := "-b"
+	arg3 := "-d"
+	arg4 := "1"
+	arg5 := "-i"
+	arg6 := "2"
+	arg7 := "-f"
+
+	stdout, ok, err := execWithTimeout(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+	if err != nil {
+		log.Errorf("xentop failed: %s", err)
+		return [][]string{}
+	}
+	if !ok {
+		log.Warnf("xentop timed out")
+		return nil
+	}
+
+	xentopInfo := string(stdout)
+
+	splitXentopInfo := strings.Split(xentopInfo, "\n")
+
+	splitXentopInfoLength := len(splitXentopInfo)
+	var i int
+	var start int
+
+	for i = 0; i < splitXentopInfoLength; i++ {
+
+		str := splitXentopInfo[i]
+		re := regexp.MustCompile(" ")
+
+		spaceRemovedsplitXentopInfo := re.ReplaceAllLiteralString(str, "")
+		matched, err := regexp.MatchString("NAMESTATECPU.*", spaceRemovedsplitXentopInfo)
+
+		if err != nil {
+			log.Debugf("MatchString failed: %s", err)
+		} else if matched {
+
+			count++
+			log.Debugf("string matched: %s", str)
+			if count == 2 {
+				start = i + 1
+				log.Debugf("value of i: %d", start)
+			}
+		}
+	}
+
+	length := splitXentopInfoLength - 1 - start
+	finalOutput := make([][]string, length)
+
+	for j := start; j < splitXentopInfoLength-1; j++ {
+
+		finalOutput[j-start] = strings.Fields(strings.TrimSpace(splitXentopInfo[j]))
+	}
+
+	cpuMemoryStat = make([][]string, length)
+
+	for i := range cpuMemoryStat {
+		cpuMemoryStat[i] = make([]string, 20)
+	}
+
+	// Need to treat "no limit" as one token
+	for f := 0; f < length; f++ {
+
+		// First name and state
+		out := 0
+		counter++
+		cpuMemoryStat[f][counter] = finalOutput[f][out]
+		out++
+		counter++
+		cpuMemoryStat[f][counter] = finalOutput[f][out]
+		out++
+		for ; out < len(finalOutput[f]); out++ {
+
+			if finalOutput[f][out] == "no" {
+
+			} else if finalOutput[f][out] == "limit" {
+				counter++
+				cpuMemoryStat[f][counter] = "no limit"
+			} else {
+				counter++
+				cpuMemoryStat[f][counter] = finalOutput[f][out]
+			}
+		}
+		counter = 0
+	}
+	log.Debugf("ExecuteXentopCmd return %+v", cpuMemoryStat)
+	return cpuMemoryStat
+}
+
+func execWithTimeout(command string, args ...string) ([]byte, bool, error) {
+
+	ctx, cancel := context.WithTimeout(context.Background(),
+		10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, command, args...)
+	out, err := cmd.Output()
+	if ctx.Err() == context.DeadlineExceeded {
+		return nil, false, nil
+	}
+	return out, true, err
+}
+
+// Returns cpuTotal, usedMemory, availableMemory, usedPercentage
+func parseCPUMemoryStat(cpuMemoryStat [][]string) map[string]types.DomainMetric {
+
+	result := make(map[string]types.DomainMetric)
+	for _, stat := range cpuMemoryStat {
+		if len(stat) <= 2 {
+			continue
+		}
+		domainname := strings.TrimSpace(stat[1])
+		if len(stat) <= 6 {
+			continue
+		}
+		log.Debugf("lookupCPUMemoryStat for %s %d elem: %+v",
+			domainname, len(stat), stat)
+		cpuTotal, err := strconv.ParseUint(stat[3], 10, 0)
+		if err != nil {
+			log.Errorf("ParseUint(%s) failed: %s",
+				stat[3], err)
+			cpuTotal = 0
+		}
+		// This is in kbytes
+		totalMemory, err := strconv.ParseUint(stat[5], 10, 0)
+		if err != nil {
+			log.Errorf("ParseUint(%s) failed: %s",
+				stat[5], err)
+			totalMemory = 0
+		}
+		totalMemory = RoundFromKbytesToMbytes(totalMemory)
+		usedMemoryPercent, err := strconv.ParseFloat(stat[6], 10)
+		if err != nil {
+			log.Errorf("ParseFloat(%s) failed: %s",
+				stat[6], err)
+			usedMemoryPercent = 0
+		}
+		usedMemory := (float64(totalMemory) * (usedMemoryPercent)) / 100
+		availableMemory := float64(totalMemory) - usedMemory
+
+		dm := types.DomainMetric{
+			CPUTotal:          cpuTotal,
+			UsedMemory:        uint32(usedMemory),
+			AvailableMemory:   uint32(availableMemory),
+			UsedMemoryPercent: float64(usedMemoryPercent),
+		}
+		result[domainname] = dm
+	}
+	return result
+}
+
+// RoundFromKbytesToMbytes rounds
+func RoundFromKbytesToMbytes(byteCount uint64) uint64 {
+	const kbyte = 1024
+
+	return (byteCount + kbyte/2) / kbyte
+}
+
+func roundFromBytesToMbytes(byteCount uint64) uint64 {
+	const kbyte = 1024
+
+	kbytes := (byteCount + kbyte/2) / kbyte
+	return (kbytes + kbyte/2) / kbyte
+}
+
+func getAndPublishHostMemory(ctx *domainContext) {
+
+	dict := executeXlInfoCmd()
+	if dict == nil {
+		hm := fallbackHostMemory()
+		ctx.pubHostMemory.Publish("global", hm)
+		return
+	}
+	var err error
+	hm := types.HostMemory{}
+	hm.TotalMemoryMB, err = strconv.ParseUint(dict["total_memory"], 10, 64)
+	if err != nil {
+		log.Errorf("Failed parsing total_memory: %s", err)
+		hm.TotalMemoryMB = 0
+	}
+	hm.FreeMemoryMB, err = strconv.ParseUint(dict["free_memory"], 10, 64)
+	if err != nil {
+		log.Errorf("Failed parsing free_memory: %s", err)
+		hm.FreeMemoryMB = 0
+	}
+
+	// Note that this is the set of physical CPUs which is different
+	// than the set of CPUs assigned to dom0
+	var ncpus uint64
+	ncpus, err = strconv.ParseUint(dict["nr_cpus"], 10, 32)
+	if err != nil {
+		log.Errorln("error while converting ncpus to int: ", err)
+		ncpus = 0
+	}
+	hm.Ncpus = uint32(ncpus)
+	ctx.pubHostMemory.Publish("global", hm)
+	if false {
+		// debug code to compare Xen and fallback
+		// XXX remove debug code
+		hm2 := fallbackHostMemory()
+		log.Infof("XXX xen %+v fallback %+v", hm, hm2)
+	}
+}
+
+// First approximation for a host without Xen
+func fallbackHostMemory() types.HostMemory {
+	hm := types.HostMemory{}
+	vm, err := mem.VirtualMemory()
+	if err != nil {
+		log.Errorf("mem.VirtualMemory failed: %s", err)
+		return hm
+	}
+	hm.TotalMemoryMB = roundFromBytesToMbytes(vm.Total)
+	hm.FreeMemoryMB = roundFromBytesToMbytes(vm.Available)
+
+	info, err := cpu.Info()
+	if err != nil {
+		log.Errorf("cpu.Info failed: %s", err)
+		return hm
+	}
+	hm.Ncpus = uint32(len(info))
+	return hm
+}
+
+func executeXlInfoCmd() map[string]string {
+	xlCmd := exec.Command("xl", "info")
+	stdout, err := xlCmd.Output()
+	if err != nil {
+		log.Errorf("xl info failed %s\n", err)
+		return nil
+	}
+	xlInfo := string(stdout)
+	splitXlInfo := strings.Split(xlInfo, "\n")
+
+	dict := make(map[string]string, len(splitXlInfo)-1)
+	for _, str := range splitXlInfo {
+		res := strings.SplitN(str, ":", 2)
+		if len(res) == 2 {
+			dict[strings.TrimSpace(res[0])] = strings.TrimSpace(res[1])
+		}
+	}
+	return dict
+}

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -49,6 +49,8 @@ type getconfigContext struct {
 	devicePortConfig         types.DevicePortConfig
 	pubNetworkXObjectConfig  pubsub.Publication
 	subAppInstanceStatus     pubsub.Subscription
+	subDomainMetric          pubsub.Subscription
+	subHostMemory            pubsub.Subscription
 	subNodeAgentStatus       pubsub.Subscription
 	pubZedAgentStatus        pubsub.Publication
 	pubAppInstanceConfig     pubsub.Publication

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -403,6 +403,27 @@ func Run() {
 	getconfigCtx.subAppInstanceStatus = subAppInstanceStatus
 	subAppInstanceStatus.Activate()
 
+	// Look for DomainMetric from domainmgr
+	subDomainMetric, err := pubsublegacy.Subscribe("domainmgr",
+		types.DomainMetric{}, true, &zedagentCtx, &pubsub.SubscriptionOptions{
+			WarningTime: warningTime,
+			ErrorTime:   errorTime,
+		})
+	if err != nil {
+		log.Fatal(err)
+	}
+	getconfigCtx.subDomainMetric = subDomainMetric
+
+	subHostMemory, err := pubsublegacy.Subscribe("domainmgr",
+		types.HostMemory{}, true, &zedagentCtx, &pubsub.SubscriptionOptions{
+			WarningTime: warningTime,
+			ErrorTime:   errorTime,
+		})
+	if err != nil {
+		log.Fatal(err)
+	}
+	getconfigCtx.subHostMemory = subHostMemory
+
 	// Look for zboot status
 	subZbootStatus, err := pubsublegacy.Subscribe("baseosmgr",
 		types.ZbootStatus{}, false, &zedagentCtx, &pubsub.SubscriptionOptions{
@@ -784,6 +805,12 @@ func Run() {
 
 		case change := <-subAppInstanceStatus.MsgChan():
 			subAppInstanceStatus.ProcessChange(change)
+
+		case change := <-subDomainMetric.MsgChan():
+			subDomainMetric.ProcessChange(change)
+
+		case change := <-subHostMemory.MsgChan():
+			subHostMemory.ProcessChange(change)
 
 		case change := <-subBaseOsStatus.MsgChan():
 			subBaseOsStatus.ProcessChange(change)

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -218,3 +218,26 @@ type ImageStatus struct {
 func (status ImageStatus) Key() string {
 	return status.Filename
 }
+
+// DomainMetric carries CPU and memory usage. UUID=devUUID for the dom0/host metrics overhead
+type DomainMetric struct {
+	UUIDandVersion    UUIDandVersion
+	CPUTotal          uint64 // Seconds since Domain boot
+	UsedMemory        uint32
+	AvailableMemory   uint32
+	UsedMemoryPercent float64
+}
+
+// Key returns the key for pubsub
+func (metric DomainMetric) Key() string {
+	return metric.UUIDandVersion.UUID.String()
+}
+
+// HostMemory reports global stats. Published under "global" key
+// Note that Ncpus is the set of physical CPUs which is different
+// than the set of CPUs assigned to dom0
+type HostMemory struct {
+	TotalMemoryMB uint64
+	FreeMemoryMB  uint64
+	Ncpus         uint32
+}


### PR DESCRIPTION
The code is mostly a move. I'm sure the scraper of xentop and xl info could be improved but deferring that.

Note that there are some fallback functions if there is no xentop and xl commands.

I've verified that the CPU and memory reports in the UI (for device and app instances) look the same after these changes.