### PR TITLE
Moving watchdog into a seprate container

### DIFF
--- a/images/rootfs-acrn.yml.in
+++ b/images/rootfs-acrn.yml.in
@@ -38,6 +38,10 @@ services:
      image: GUACD_TAG
    - name: pillar
      image: PILLAR_TAG
+   - name: vtpm
+     image: VTPM_TAG
+   - name: watchdog
+     image: WATCHDOG_TAG
 files:
    - path: /etc/eve-release
      contents: 'EVE_VERSION'

--- a/images/rootfs-xen.yml.in
+++ b/images/rootfs-xen.yml.in
@@ -40,6 +40,8 @@ services:
      image: PILLAR_TAG
    - name: vtpm
      image: VTPM_TAG
+   - name: watchdog
+     image: WATCHDOG_TAG
 files:
    - path: /etc/eve-release
      contents: 'EVE_VERSION'

--- a/pkg/pillar/Dockerfile.in
+++ b/pkg/pillar/Dockerfile.in
@@ -35,8 +35,6 @@ FROM STRONGSWAN_TAG as strongswan
 # hadolint ignore=DL3006
 FROM GPTTOOLS_TAG as gpttools
 # hadolint ignore=DL3006
-FROM WATCHDOG_TAG as watchdog
-# hadolint ignore=DL3006
 FROM RKT_TAG as rkt-build
 # hadolint ignore=DL3006
 FROM RKT_STAGE1_TAG as rkt-stage1-build
@@ -65,7 +63,6 @@ ADD scripts/device-steps.sh \
     scripts/generate-device.sh \
     scripts/generate-self-signed.sh \
     scripts/handlezedserverconfig.sh \
-    scripts/watchdog-report.sh \
   /opt/zededa/bin/
 ADD conf/lisp.config.base /var/tmp/zededa/lisp.config.base
 
@@ -81,7 +78,6 @@ COPY --from=lisp / /
 COPY --from=gpttools / /
 COPY --from=dnsmasq /usr/sbin/dnsmasq /opt/zededa/bin/dnsmasq
 COPY --from=strongswan / /
-COPY --from=watchdog /usr/sbin /usr/sbin
 COPY --from=rkt-build /go/rkt/build-rkt-1.26.0/target/bin/rkt /usr/sbin/rkt
 COPY --from=rkt-stage1-build /go/stage1-xen-master/stage1-xen.aci /usr/sbin/stage1-xen.aci
 COPY --from=fscrypt-build /fscrypt /opt/zededa/bin/fscrypt

--- a/pkg/pillar/rootfs/init.sh
+++ b/pkg/pillar/rootfs/init.sh
@@ -16,6 +16,7 @@ done
 
 # Finally, we need to start Xen
 # In case it hangs and we have no hardware watchdog we run it in the background
+mkdir -p /var/run/xen/ /var/run/xenstored
 XENCONSOLED_ARGS='--log=all --log-dir=/var/log/xen' /etc/init.d/xencommons start &
 sleep 5 # Let it come up
 

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -215,7 +215,7 @@ echo "$(date -Ins -u) Starting nodeagent"
 $BINDIR/nodeagent -c $CURPART &
 wait_for_touch nodeagent
 
-mkdir -p "$WATCHDOG_PID" "$WATCHDOG_PID"
+mkdir -p "$WATCHDOG_PID" "$WATCHDOG_FILE"
 touch "$WATCHDOG_PID/crond.pid"                                      \
       "$WATCHDOG_PID/nodeagent.pid" "$WATCHDOG_FILE/nodeagent.touch" \
       "$WATCHDOG_PID/ledmanager.pid" "$WATCHDOG_FILE/ledmanager.touch"

--- a/pkg/rsyslog/init.sh
+++ b/pkg/rsyslog/init.sh
@@ -1,16 +1,7 @@
 #!/bin/sh
 
-register_watchdog() {
-  local WATCHDOG_CTL
-  WATCHDOG_CTL=/run/watchdog.ctl
-  set $@
-  [ -p "$WATCHDOG_CTL" ] || (rm -rf "$WATCHDOG_CTL" ; mkfifo "$WATCHDOG_CTL")
-  for i in "$@"; do
-    echo "$i" >> "$WATCHDOG_CTL"
-  done
-}
-
-register_watchdog /pid/run/logread.pid /pid/run/rsyslogd.pid /pid/run/monitor-rsyslogd.pid
+mkdir -p /run/watchdog/pid 2>/dev/null || :
+(cd /run/watchdog/pid && touch logread.pid rsyslogd.pid monitor-rsyslogd.pid)
 
 ./monitor-rsyslog.sh &
 

--- a/pkg/rsyslog/init.sh
+++ b/pkg/rsyslog/init.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-mkdir -p /run/watchdog/pid 2>/dev/null || :
+mkdir -p /run/watchdog/pid
 
 ./monitor-rsyslog.sh &
 

--- a/pkg/rsyslog/init.sh
+++ b/pkg/rsyslog/init.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 mkdir -p /run/watchdog/pid 2>/dev/null || :
-(cd /run/watchdog/pid && touch logread.pid rsyslogd.pid monitor-rsyslogd.pid)
 
 ./monitor-rsyslog.sh &
 
@@ -14,6 +13,7 @@ do
     fi
     (/usr/bin/logread -F -socket /run/memlogdq.sock | logger) &
     echo $! > /run/logread.pid
+    touch /run/watchdog/pid/logread.pid
 
     LOOP_COUNT=0
     while [ -z "$(pgrep logread)" ];

--- a/pkg/rsyslog/monitor-rsyslog.sh
+++ b/pkg/rsyslog/monitor-rsyslog.sh
@@ -17,6 +17,7 @@ start_rsyslogd()
 
     IMGP=$(cat /run/eve.id 2>/dev/null)
     IMGP=${IMGP:-IMGX} /usr/sbin/rsyslogd -n &
+    touch /run/watchdog/pid/rsyslogd.pid
 }
 
 wait_for_rsyslogd()
@@ -36,6 +37,7 @@ wait_for_rsyslogd()
 
 # write our own PID to /run/monitor-rsyslogd.pid
 echo $$ > /run/monitor-rsyslogd.pid
+touch /run/watchdog/pid/monitor-rsyslogd.pid
 
 # start rsyslogd for the fist time after device boot
 start_rsyslogd

--- a/pkg/watchdog/Dockerfile
+++ b/pkg/watchdog/Dockerfile
@@ -39,11 +39,14 @@ ENV CONFIGURE_OPTS "--disable-nfs"
 RUN \
     CPPFLAGS=-I/usr/include/tirpc ./configure ${CONFIGURE_OPTS} && make && make install DESTDIR=/out
 
-FROM scratch
-ENTRYPOINT []
-CMD []
+FROM alpine:3.8
 WORKDIR /
 COPY --from=watchdog-build /out/etc /etc
 COPY --from=watchdog-build /out/usr/sbin /usr/sbin
 COPY --from=watchdog-build /out/usr/share /usr/share
+COPY init.sh /
+COPY watchdog.conf.seed /etc/
+COPY watchdog-report.sh /sbin/
 
+ENTRYPOINT []
+CMD ["/init.sh"]

--- a/pkg/watchdog/build.yml
+++ b/pkg/watchdog/build.yml
@@ -1,2 +1,8 @@
 image: eve-watchdog
 org: lfedge
+config:
+  binds:
+    - /run:/run
+    - /dev:/dev
+    - /etc/resolv.conf:/etc/resolv.conf
+    - /var/persist:/persist

--- a/pkg/watchdog/build.yml
+++ b/pkg/watchdog/build.yml
@@ -6,3 +6,4 @@ config:
     - /dev:/dev
     - /etc/resolv.conf:/etc/resolv.conf
     - /var/persist:/persist
+  pid: host

--- a/pkg/watchdog/init.sh
+++ b/pkg/watchdog/init.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+USE_HW_WATCHDOG=1
+WATCHDOG_CTL=/run/watchdog.ctl
+
+register_watchdog() {
+  set $@
+  [ -p "$WATCHDOG_CTL" ] || (rm -rf "$WATCHDOG_CTL" ; mkfifo "$WATCHDOG_CTL")
+  for i in "$@"; do
+    echo "$i" >> "$WATCHDOG_CTL"
+  done
+}
+
+reload_watchdog() {
+    if [ -f /var/run/watchdog.pid ]; then
+        wp=$(cat /var/run/watchdog.pid)
+        log "Killing watchdog $wp"
+        kill "$wp"
+        # Wait for it to exit so it can be restarted
+        while kill -0 "$wp"; do
+            log "Waiting for watchdog to exit"
+            if [ $USE_HW_WATCHDOG = 1 ]; then
+                wdctl
+            fi
+            sleep 1
+        done
+        log "Killed watchdog"
+        sync
+    fi
+    /usr/sbin/watchdog -F -s &
+}
+
+log() {
+   echo "$(date -Is) $*"
+}
+
+
+# Lets get this party started
+
+if [ -c /dev/watchdog ]; then
+    if [ $USE_HW_WATCHDOG = 0 ]; then
+        log "Disabling use of /dev/watchdog"
+        wdctl /dev/watchdog
+    fi
+else
+    log "Platform has no /dev/watchdog"
+    USE_HW_WATCHDOG=0
+fi
+
+# Create the watchdog(8) config files we will use
+# XXX should we enable realtime in the kernel?
+if [ $USE_HW_WATCHDOG = 1 ]; then
+   echo 'watchdog-device = /dev/watchdog' >> /etc/watchdog.conf.seed
+fi
+
+# Create a control channel if it doesn't exist yet
+[ -p "$WATCHDOG_CTL" ] || (rm -rf "$WATCHDOG_CTL" ; mkfifo "$WATCHDOG_CTL")
+
+LAST_RELOAD="$(date -u +%s)"
+while true; do
+   read cmd < "$WATCHDOG_CTL"
+   log "Received the following watchdog request $cmd"
+   rm -f /etc/watchdog.conf
+   (cat /etc/watchdog.conf.seed
+   case "$cmd" in
+      /*) echo "file = $cmd"
+          echo "change = 300"
+          ;;
+      @*) echo "pidfile = ${cmd//@/}"
+          ;;
+   esac) >> /etc/watchdog.conf
+   # do the reload every 30 seconds only to not oscilate too much
+   if [ $((LAST_RELOAD + 30)) -lt "$(date -u +%s)" ]; then
+      reload_watchdog
+      LAST_RELOAD="$(date -u +%s)"
+   else
+      [ "$cmd" ] && (sleep 30 ; echo "" >> "$WATCHDOG_CTL") &
+   fi
+done

--- a/pkg/watchdog/watchdog-report.sh
+++ b/pkg/watchdog/watchdog-report.sh
@@ -9,7 +9,7 @@
 
 # First log to /persist in case zboot/kernel is hung on disk
 
-DATE=$(date -Ins)
+DATE=$(date -Is)
 echo "Watchdog report at $DATE: $*" >>/persist/reboot-reason
 sync
 

--- a/pkg/watchdog/watchdog.conf.seed
+++ b/pkg/watchdog/watchdog.conf.seed
@@ -1,0 +1,19 @@
+admin =
+#realtime = yes
+#priority = 1
+interval = 1
+logtick  = 60
+repair-binary=/sbin/watchdog-report.sh
+pidfile = /run/xen/qemu-dom0.pid
+pidfile = /run/xen/xenconsoled.pid
+pidfile = /run/xen/xenstored.pid
+pidfile = /run/crond.pid
+pidfile = /run/monitor-rsyslogd.pid
+# XXX Other processes we should potentially watch but they run outside
+# of this container:
+# sshd.pid
+# services.linuxkit/zededa-tools/init.pid
+# services.linuxkit/wwan/init.pid
+# services.linuxkit/wlan/init.pid
+# services.linuxkit/ntpd/init.pid
+# services.linuxkit/guacd/init.pid

--- a/pkg/watchdog/watchdog.conf.seed
+++ b/pkg/watchdog/watchdog.conf.seed
@@ -6,3 +6,9 @@ logtick  = 60
 repair-binary=/sbin/watchdog-report.sh
 # XXX Other processes we should potentially watch but they run outside
 # of this container:
+# sshd.pid
+# services.linuxkit/zededa-tools/init.pid
+# services.linuxkit/wwan/init.pid
+# services.linuxkit/wlan/init.pid
+# services.linuxkit/ntpd/init.pid
+# services.linuxkit/guacd/init.pid

--- a/pkg/watchdog/watchdog.conf.seed
+++ b/pkg/watchdog/watchdog.conf.seed
@@ -4,16 +4,5 @@ admin =
 interval = 1
 logtick  = 60
 repair-binary=/sbin/watchdog-report.sh
-pidfile = /run/xen/qemu-dom0.pid
-pidfile = /run/xen/xenconsoled.pid
-pidfile = /run/xen/xenstored.pid
-pidfile = /run/crond.pid
-pidfile = /run/monitor-rsyslogd.pid
 # XXX Other processes we should potentially watch but they run outside
 # of this container:
-# sshd.pid
-# services.linuxkit/zededa-tools/init.pid
-# services.linuxkit/wwan/init.pid
-# services.linuxkit/wlan/init.pid
-# services.linuxkit/ntpd/init.pid
-# services.linuxkit/guacd/init.pid

--- a/pkg/xen-tools/Dockerfile
+++ b/pkg/xen-tools/Dockerfile
@@ -45,7 +45,7 @@ RUN make && make dist
 RUN dist/install.sh /out
 
 # Filter out a few things that we don't currently need
-RUN rm /out/usr/share/qemu-xen/qemu/edk2-*
+RUN rm -rf /out/usr/share/qemu-xen/qemu/edk2-* /out/var/run
 
 FROM scratch
 ENTRYPOINT []


### PR DESCRIPTION
This is the 2nd PR in a WIP series that tried to decompose pillar into standalone mircoservices thus making it much more flexible to deal with different kinds of use case (like running separate hypervisors).

The idea behind this PR is to run watchdog in its own container and:
   1. have a /run/watchdog.ctl pipe for telling watchdog what to watch fo
   2. having all init.sh scripts for all the other microservices dynamically registering with watchdog by sending lines of text /FULL/PATH/NAME to watch for a file updates or @/PIF/FILE/NAME to watch for a PID

NOTE1: #1 would allow xen-tools container to dynamically tell watchdog that Xen is not enabled and hence there's no reason to watch for qemu, etc.

NOTE2: current implementation is very much an MVP to show where this is going and doesn't really allow to incrementally add/remove things for the watchdog to watch. I didn't want to implement that additional (albeit trivial) logic until we agree that this looks OK

This is still a work and progress (and I may even replace the shell script implementation of watchdog control program with a C based one) but it seems to be good enough for now.

Looking for feedback.