### PR TITLE
Stage1-xen patch to mount volume from xen.cfg

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -70,7 +70,7 @@ func isPort(ctx *domainContext, ifname string) bool {
 type MountPoints struct {
 	targetPath string //Target path inside VM or container. Mandatory
 	fileSystem string //What type of file-system is expected to be mounted. Not mandatory, default: vfat
-	partition  int    //Which partition of the disk should be mounted. Not mandatory, default:efault: 1
+	partition  int    //Which partition of the disk should be mounted. Not mandatory, default: 1
 }
 
 var FileSystems = map[string]int32{
@@ -1648,12 +1648,12 @@ func configAdapters(ctx *domainContext, config types.DomainConfig) error {
 }
 
 func writeMountPointsToFile(mountPoints []MountPoints, status types.DomainStatus, file *os.File) error {
-	//if len(mountPoints) != len(status.DiskStatusList){
-	//	err := fmt.Errorf("writeMountPointsToFile: Number of source: %v and target: %v mismatch.",
-	//		len(status.DiskStatusList), len(mountPoints))
-	//	log.Errorf(err.Error() )
-	//	return err
-	//}
+	if len(mountPoints) != len(status.DiskStatusList){
+		err := fmt.Errorf("writeMountPointsToFile: Number of source: %v and target: %v mismatch.",
+			len(status.DiskStatusList), len(mountPoints))
+		log.Errorf(err.Error() )
+		return err
+	}
 
 	for i, mp := range mountPoints {
 		if mp.fileSystem == "" {
@@ -2214,7 +2214,7 @@ func handleDelete(ctx *domainContext, key string, status *types.DomainStatus) {
 		log.Errorln(err)
 	}
 
-	// Delete mountPoint file for good measure
+	// Delete mountPoint file
 	mpFileName := mountPointFileName(status.AppNum)
 	if err := os.Remove(mpFileName); err != nil {
 		log.Errorln(err)
@@ -2317,11 +2317,11 @@ func rktRun(domainName, xenCfgFilename, mountPointFileName, imageHash string, en
 	args = append(args, envVarSlice...)
 	stage1XlOpts := "STAGE1_XL_OPTS=-p"
 	stage1XlCfg := "STAGE1_SEED_XL_CFG=" + xenCfgFilename
-	stage1MP := "STAGE2_MNT_PTS=" + mountPointFileName
+	stage2MP := "STAGE2_MNT_PTS=" + mountPointFileName
 	log.Infof("Calling command %s %v\n", cmd, args)
-	log.Infof("Also setting env vars %s %s %s\n", stage1XlOpts, stage1XlCfg, stage1MP)
+	log.Infof("Also setting env vars %s %s %s\n", stage1XlOpts, stage1XlCfg, stage2MP)
 	cmdLine := exec.Command(cmd, args...)
-	cmdLine.Env = append(os.Environ(), stage1XlOpts, stage1XlCfg, stage1MP)
+	cmdLine.Env = append(os.Environ(), stage1XlOpts, stage1XlCfg, stage2MP)
 	stdoutStderr, err := cmdLine.CombinedOutput()
 	if err != nil {
 		log.Errorln("rkt run failed ", err)

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1623,7 +1623,7 @@ func configAdapters(ctx *domainContext, config types.DomainConfig) error {
 func createMountPointFile(imageHash, mpFileName string, status types.DomainStatus) error {
 	file, err := os.Create(mpFileName)
 	if err != nil {
-		log.Errorf("os.Create for ", mpFileName, err)
+		log.Errorf("createMountPointFile: os.Create for %v, failed: %v", mpFileName, err.Error())
 	}
 	defer file.Close()
 

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -69,12 +69,12 @@ func isPort(ctx *domainContext, ifname string) bool {
 //MountPoints - Holds mount target information which will be used when bringing up container
 type MountPoints struct {
 	targetPath string //Target path inside VM or container. Mandatory
-	fileSystem     string //What type of file-system is expected to be mounted. Not mandatory, default: vfat
-	partition   int   //Which partition of the disk should be mounted. Not mandatory, default:efault: 1
+	fileSystem string //What type of file-system is expected to be mounted. Not mandatory, default: vfat
+	partition  int    //Which partition of the disk should be mounted. Not mandatory, default:efault: 1
 }
 
 var FileSystems = map[string]int32{
-	"vfat":     0,
+	"vfat": 0,
 }
 
 // Information for handleCreate/Modify/Delete
@@ -1667,12 +1667,12 @@ func writeMountPointsToFile(mountPoints []MountPoints, status types.DomainStatus
 	//}
 
 	for i, mp := range mountPoints {
-		if mp.fileSystem == ""{
+		if mp.fileSystem == "" {
 			mp.fileSystem = "vfat"
 		} else {
-			if _, ok := FileSystems[mp.fileSystem]; !ok{
+			if _, ok := FileSystems[mp.fileSystem]; !ok {
 				err := fmt.Errorf("writeMountPointsToFile: Invalid/unrecognized filesystem: %v", mp.fileSystem)
-				log.Errorf(err.Error() )
+				log.Errorf(err.Error())
 				return err
 			}
 		}
@@ -1680,19 +1680,19 @@ func writeMountPointsToFile(mountPoints []MountPoints, status types.DomainStatus
 			mp.partition = 1
 		} else {
 			if mp.partition > 4 || mp.partition < 0 {
-				err := fmt.Errorf("writeMountPointsToFile: Invalid partition: %v. Must be between 1 - 4", mp.partition )
-				log.Errorf(err.Error() )
+				err := fmt.Errorf("writeMountPointsToFile: Invalid partition: %v. Must be between 1 - 4", mp.partition)
+				log.Errorf(err.Error())
 				return err
 			}
 		}
-		if mp.targetPath == ""{
+		if mp.targetPath == "" {
 			err := fmt.Errorf("writeMountPointsToFile: targetPath cannot be empty")
-			log.Errorf(err.Error() )
+			log.Errorf(err.Error())
 			return err
-		}else if !strings.HasPrefix(mp.targetPath, "/"){
+		} else if !strings.HasPrefix(mp.targetPath, "/") {
 			//Target path is expected to be absolute.
 			err := fmt.Errorf("writeMountPointsToFile: targetPath should be absolute")
-			log.Errorf(err.Error() )
+			log.Errorf(err.Error())
 			return err
 		}
 		targetString := fmt.Sprintf("%s:%s:%d", mp.targetPath, mp.fileSystem, mp.partition)

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -66,18 +66,6 @@ func isPort(ctx *domainContext, ifname string) bool {
 	return types.IsPort(ctx.deviceNetworkStatus, ifname)
 }
 
-//MountPoints - Holds mount target information which will be used when bringing up container
-type MountPoints struct {
-	targetPath string //Target path inside VM or container. Mandatory
-	fileSystem string //What type of file-system is expected to be mounted. Not mandatory, default: vfat
-	partition  int    //Which partition of the disk should be mounted. Not mandatory, default: 1
-}
-
-//fileSystems - map of supported file-systems
-var fileSystems = map[string]int32{
-	"vfat": 0,
-}
-
 // Information for handleCreate/Modify/Delete
 type domainContext struct {
 	// The isPort function is called by different goroutines
@@ -1635,7 +1623,7 @@ func configAdapters(ctx *domainContext, config types.DomainConfig) error {
 func createMountPointFile(imageHash, mpFileName string, status types.DomainStatus) error {
 	file, err := os.Create(mpFileName)
 	if err != nil {
-		log.Fatal("os.Create for ", mpFileName, err)
+		log.Errorf("os.Create for ", mpFileName, err)
 	}
 	defer file.Close()
 
@@ -1644,6 +1632,7 @@ func createMountPointFile(imageHash, mpFileName string, status types.DomainStatu
 		return fmt.Errorf("createMountPointFile: Error while fetching app manfest: %v", err.Error())
 	}
 
+	//Ignoring container image in status.DiskStatusList
 	if (len(status.DiskStatusList) - 1) != len(appManifest.App.MountPoints) {
 		if len(status.DiskStatusList) > len(appManifest.App.MountPoints) {
 			log.Warnf("createMountPointFile: Number of volumes provided: %v is more than number of mount-points: %v. "+

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1244,17 +1244,6 @@ func doActivate(ctx *domainContext, config types.DomainConfig,
 
 	//TODO: mountPoints must be fill with target paths on the container once we decide UI to domainmgr flow for vol mount.
 	mountPoints := make([]MountPoints, 0)
-	mountPoints = append(mountPoints, MountPoints{
-		targetPath: "/mnt/dir1",
-		fileSystem: "vfat",
-		partition:  1,
-	})
-
-	mountPoints = append(mountPoints, MountPoints{
-		targetPath: "/mnt/dir2",
-		fileSystem: "",
-		partition:  0,
-	})
 	mpFileName := mountPointFileName(config.AppNum)
 	mpFile, err := os.Create(mpFileName)
 	if err != nil {

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -73,7 +73,8 @@ type MountPoints struct {
 	partition  int    //Which partition of the disk should be mounted. Not mandatory, default: 1
 }
 
-var FileSystems = map[string]int32{
+//fileSystems - map of supported file-systems
+var fileSystems = map[string]int32{
 	"vfat": 0,
 }
 
@@ -1648,10 +1649,10 @@ func configAdapters(ctx *domainContext, config types.DomainConfig) error {
 }
 
 func writeMountPointsToFile(mountPoints []MountPoints, status types.DomainStatus, file *os.File) error {
-	if len(mountPoints) != len(status.DiskStatusList){
+	if len(mountPoints) != len(status.DiskStatusList) {
 		err := fmt.Errorf("writeMountPointsToFile: Number of source: %v and target: %v mismatch.",
 			len(status.DiskStatusList), len(mountPoints))
-		log.Errorf(err.Error() )
+		log.Errorf(err.Error())
 		return err
 	}
 
@@ -1659,7 +1660,7 @@ func writeMountPointsToFile(mountPoints []MountPoints, status types.DomainStatus
 		if mp.fileSystem == "" {
 			mp.fileSystem = "vfat"
 		} else {
-			if _, ok := FileSystems[mp.fileSystem]; !ok {
+			if _, ok := fileSystems[mp.fileSystem]; !ok {
 				err := fmt.Errorf("writeMountPointsToFile: Invalid/unrecognized filesystem: %v", mp.fileSystem)
 				log.Errorf(err.Error())
 				return err

--- a/pkg/pillar/cmd/domainmgr/rkt.go
+++ b/pkg/pillar/cmd/domainmgr/rkt.go
@@ -43,12 +43,14 @@ type RktManifest struct {
 	App         App        `json:"app,omitempty"`
 }
 
+// MountPoint - represents mountpoints of an app
 type MountPoint struct {
 	Name     string `json:"name"`
 	Path     string `json:"path"`
 	ReadOnly bool   `json:"readOnly,omitempty"`
 }
 
+// App - holds app details in manifest
 type App struct {
 	MountPoints []MountPoint `json:"mountPoints,omitempty"`
 }

--- a/pkg/pillar/cmd/domainmgr/rkt.go
+++ b/pkg/pillar/cmd/domainmgr/rkt.go
@@ -240,7 +240,7 @@ func rktGetHashes() (map[string]string, error) {
 	rktHashes := strings.Fields(string(stdoutStderr))
 	// now go through each one and get its docker hash
 	for _, rh := range rktHashes {
-		manifest, err := getAppManifest(rh)
+		manifest, err := getRktManifest(rh)
 		if err != nil {
 			return m, fmt.Errorf("rkt manifect fetch failed: %s", err.Error())
 		}
@@ -258,7 +258,7 @@ func rktGetHashes() (map[string]string, error) {
 	return m, nil
 }
 
-func getAppManifest(imageHash string) (RktManifest, error) {
+func getRktManifest(imageHash string) (RktManifest, error) {
 	// process the json to get the exact item we need
 	var manifest RktManifest
 

--- a/pkg/pillar/cmd/domainmgr/rkt.go
+++ b/pkg/pillar/cmd/domainmgr/rkt.go
@@ -35,13 +35,22 @@ type KeyValue struct {
 
 // RktManifest represents a rkt manifest
 type RktManifest struct {
-	ACKind      string
-	ACVersion   string
-	Name        string
-	Labels      []KeyValue
-	Annotations []KeyValue
-	// we don't care about the App part
-	App interface{}
+	ACKind      string     `json:"acKind"`
+	ACVersion   string     `json:"acVersion"`
+	Name        string     `json:"name"`
+	Labels      []KeyValue `json:"labels,omitempty"`
+	Annotations []KeyValue `json:"annotations,omitempty"`
+	App         App        `json:"app,omitempty"`
+}
+
+type MountPoint struct {
+	Name     string `json:"name"`
+	Path     string `json:"path"`
+	ReadOnly bool   `json:"readOnly,omitempty"`
+}
+
+type App struct {
+	MountPoints []MountPoint `json:"mountPoints,omitempty"`
 }
 
 // rktConvertTarToAci convert an OCI image tarfile into an ACI bundle
@@ -229,23 +238,9 @@ func rktGetHashes() (map[string]string, error) {
 	rktHashes := strings.Fields(string(stdoutStderr))
 	// now go through each one and get its docker hash
 	for _, rh := range rktHashes {
-		args = append(baseArgs,
-			"image",
-			"cat-manifest",
-			rh,
-		)
-		cmdLine = exec.Command(cmd, args...)
-		stdoutStderr, err = cmdLine.CombinedOutput()
+		manifest, err := getAppManifest(rh)
 		if err != nil {
-			log.Errorf("rkt image cat-manifest %s failed: %v", rh, err)
-			log.Errorf("rkt image cat-manifest %s output: %v", rh, string(stdoutStderr))
-			return m, fmt.Errorf("rkt image cat-manifest %s failed: %s", rh, string(stdoutStderr))
-		}
-		// process the json to get the exact item we need
-		var manifest RktManifest
-		err = json.Unmarshal(stdoutStderr, &manifest)
-		if err != nil {
-			return m, fmt.Errorf("error parsing rkt manifest for %s: %v", rh, err)
+			return m, fmt.Errorf("rkt manifect fetch failed: %s", err.Error())
 		}
 		// go through the annotations to find the hash for the correct label
 		for _, a := range manifest.Annotations {
@@ -259,6 +254,36 @@ func rktGetHashes() (map[string]string, error) {
 	log.Infof("rkt hashes load complete; found %d images with docker hashes", len(m))
 	log.Debugf("rkt hashes: %+v", m)
 	return m, nil
+}
+
+func getAppManifest(imageHash string) (RktManifest, error) {
+	// process the json to get the exact item we need
+	var manifest RktManifest
+
+	cmd := "rkt"
+	baseArgs := []string{
+		"--dir=" + types.PersistRktDataDir,
+		"--insecure-options=image",
+	}
+
+	args := append(baseArgs,
+		"image",
+		"cat-manifest",
+		imageHash,
+	)
+	cmdLine := exec.Command(cmd, args...)
+	stdoutStderr, err := cmdLine.CombinedOutput()
+	if err != nil {
+		log.Errorf("rkt image cat-manifest %s failed: %v", imageHash, err)
+		log.Errorf("rkt image cat-manifest %s output: %v", imageHash, string(stdoutStderr))
+		return manifest, fmt.Errorf("rkt image cat-manifest %s failed: %s", imageHash, string(stdoutStderr))
+	}
+
+	err = json.Unmarshal(stdoutStderr, &manifest)
+	if err != nil {
+		return manifest, fmt.Errorf("error parsing rkt manifest for %s: %v", imageHash, err)
+	}
+	return manifest, nil
 }
 
 // ociGetHash extract the hash from an OCI tar file

--- a/pkg/rkt-stage1/0011-Patch-to-mount-vol-stage2.patch
+++ b/pkg/rkt-stage1/0011-Patch-to-mount-vol-stage2.patch
@@ -13,23 +13,15 @@ index 04fceb6..9c623f3 100755
  # Clean the repo, but save the vendor area
 diff --git a/files/mount_disk.sh b/files/mount_disk.sh
 new file mode 100644
-index 0000000..c7fb944
+index 0000000..d51f1e8
 --- /dev/null
 +++ b/files/mount_disk.sh
-@@ -0,0 +1,70 @@
+@@ -0,0 +1,62 @@
 +#!/bin/sh
 +
 +mountPointLineNo=1
 +ls /sys/block/ | grep xvd | while read -r disk ; do
 +  echo "Processing $disk"
-+
-+  #Fetching corresponding mount point from mountPoint file
-+  moint_point=$(sed "${mountPointLineNo}q;d" mountPoint | tr ":" "\n")
-+  if [ -z "$moint_point" ]
-+    then
-+      echo "Error while mounting: No Mount-Point found for $disk."
-+      exit 0
-+  fi
 +
 +  #Fetching Major and Minor device
 +  IN=$(cat /sys/block/$disk/dev | tr ":" "\n")
@@ -54,7 +46,7 @@ index 0000000..c7fb944
 +  echo
 +
 +  #Creating a block device with partitioned disk
-+  partitionToBeMounted=$(echo ${moint_point} | cut -d' ' -f3)
++  partitionToBeMounted=1
 +  partedDisk="$disk""$partitionToBeMounted"
 +  echo "Creating device file /dev/$partedDisk"
 +  mknod /dev/$partedDisk b $major $(($minor + 1)) && \
@@ -63,7 +55,7 @@ index 0000000..c7fb944
 +  echo
 +
 +  #Creating a file system inside the partition
-+  fileSystem=$(echo ${moint_point} | cut -d' ' -f2)
++  fileSystem="vfat"
 +  echo "Creating $fileSystem file system on /dev/$partedDisk"
 +  mkfs.$fileSystem /dev/$partedDisk && \
 +  echo "Successfully created $fileSystem file system on /dev/$partedDisk" || \
@@ -71,17 +63,17 @@ index 0000000..c7fb944
 +  echo
 +
 +  #Mounting the partition onto a target directory
-+  targetDir=$(echo ${moint_point} | cut -d' ' -f1)
++  targetDir=$(sed "${mountPointLineNo}q;d" /mnt/mountPoints)
 +  diskAccess=$(cat /sys/block/$disk/ro)
 +  if [ $diskAccess -eq 0 ]; then
 +    accessRight=rw
 +  else
 +    accessRight=ro
 +  fi
-+
-+  echo "Mounting /dev/$partedDisk on $targetDir with access: $accessRight"
-+  mkdir -p $targetDir
-+  mount -O remount,$accessRight /dev/$partedDisk $targetDir && \
++  stage2TargetPath="/mnt/rootfs"$targetDir
++  echo "Mounting /dev/$partedDisk on $stage2TargetPath with access: $accessRight"
++  mkdir -p $stage2TargetPath
++  mount -O remount,$accessRight /dev/$partedDisk $stage2TargetPath && \
 +  echo "Successfully mounted file system:/dev/$partedDisk on $targetDir" || \
 +  echo "Failed to mount file system:/dev/$partedDisk on $targetDir"
 +

--- a/pkg/rkt-stage1/0011-Patch-to-mount-vol-stage2.patch
+++ b/pkg/rkt-stage1/0011-Patch-to-mount-vol-stage2.patch
@@ -13,16 +13,21 @@ index 04fceb6..9c623f3 100755
  # Clean the repo, but save the vendor area
 diff --git a/files/mount_disk.sh b/files/mount_disk.sh
 new file mode 100644
-index 0000000..d51f1e8
+index 0000000..db70141
 --- /dev/null
 +++ b/files/mount_disk.sh
-@@ -0,0 +1,62 @@
+@@ -0,0 +1,56 @@
 +#!/bin/sh
 +
 +mountPointLineNo=1
 +ls /sys/block/ | grep xvd | while read -r disk ; do
 +  echo "Processing $disk"
-+
++  targetDir=$(sed "${mountPointLineNo}q;d" /mnt/mountPoints)
++  if [ -z "$targetDir" ]
++    then
++      echo "Error while mounting: No Mount-Point found for $disk."
++      exit 0
++  fi
 +  #Fetching Major and Minor device
 +  IN=$(cat /sys/block/$disk/dev | tr ":" "\n")
 +  major=$(echo ${IN} | cut -d' ' -f1)
@@ -33,16 +38,6 @@ index 0000000..d51f1e8
 +  mknod /dev/$disk b $major $minor && \
 +  echo "Successfully created device file for /dev/$disk" || \
 +  echo "Failed to create device file for /dev/$disk"
-+  echo
-+
-+  #Creating partition on block device
-+  partition_number=1
-+  first_sector=
-+  last_sector=
-+  echo "Creating partition:$partition_number for /dev/$disk"
-+  (echo n; echo p; echo $partition_number; echo $first_sector; echo $last_sector; echo w) | fdisk /dev/$disk && \
-+  echo "Successfully created partition:$partition_number for /dev/$disk" || \
-+  echo "Failed to create partition:$partition_number for /dev/$disk"
 +  echo
 +
 +  #Creating a block device with partitioned disk
@@ -63,7 +58,6 @@ index 0000000..d51f1e8
 +  echo
 +
 +  #Mounting the partition onto a target directory
-+  targetDir=$(sed "${mountPointLineNo}q;d" /mnt/mountPoints)
 +  diskAccess=$(cat /sys/block/$disk/ro)
 +  if [ $diskAccess -eq 0 ]; then
 +    accessRight=rw

--- a/pkg/rkt-stage1/0011-Patch-to-mount-vol-stage2.patch
+++ b/pkg/rkt-stage1/0011-Patch-to-mount-vol-stage2.patch
@@ -68,16 +68,17 @@ index 0000000..9a199d7
 +done
 \ No newline at end of file
 diff --git a/files/run b/files/run
-index a26edca..d16ad28 100755
+index a26edca..aed470a 100755
 --- a/files/run
 +++ b/files/run
-@@ -62,8 +62,12 @@ fi
+@@ -62,8 +62,13 @@ fi
  echo "ramdisk='$workpath/initrd'" >> $outconfig
  echo "p9=[ 'tag=share_dir,security_model=none,path=$mountpoint' ]" >> $outconfig
- 
+
 +if [ -f "$STAGE1_SEED_MNT_PT" ] ; then
 +  cp "$STAGE1_SEED_MNT_PT" $stage2
 +fi
++cp $stage1/mount_disk.sh $stage2
 +
  if [ -f "$STAGE1_SEED_XL_CFG" ] ; then
 -    grep -Ev '^(disk|bootloader|root|extra|kernel)' < "$STAGE1_SEED_XL_CFG" >> $outconfig

--- a/pkg/rkt-stage1/0011-Patch-to-mount-vol-stage2.patch
+++ b/pkg/rkt-stage1/0011-Patch-to-mount-vol-stage2.patch
@@ -1,0 +1,87 @@
+diff --git a/files/mount_disk.sh b/files/mount_disk.sh
+new file mode 100644
+index 0000000..9a199d7
+--- /dev/null
++++ b/files/mount_disk.sh
+@@ -0,0 +1,62 @@
++#!/bin/sh
++
++ls /sys/block/ | grep xvd | while read -r disk ; do
++        echo "Processing $disk"
++
++        #Fetching Major and Minor device
++        IN=$(cat /sys/block/$disk/dev | tr ":" "\n")
++        major=$(echo ${IN} | cut -d' ' -f1)
++        minor=$(echo ${IN} | cut -d' ' -f2)
++
++        #Creating a block device under /dev with Major and minor devices
++        echo "Creating device file /dev/$disk"
++        mknod /dev/$disk b $major $minor && \
++        echo "Successfully created device file for /dev/$disk" || \
++        echo "Failed to create device file for /dev/$disk"
++        echo
++        echo
++
++        #Creating partition on block device
++        partition_number=1
++        first_sector=
++        last_sector=
++        echo "Creating partition:$partition_number for /dev/$disk"
++        (echo n; echo p; echo $partition_number; echo $first_sector; echo $last_sector; echo w) | fdisk /dev/$disk && \
++        echo "Successfully created partition:$partition_number for /dev/$disk" || \
++        echo "Failed to create partition:$partition_number for /dev/$disk"
++        echo
++        echo
++
++        #Creating a block device with partitioned disk
++        partedDisk="$disk"1
++        echo "Creating device file /dev/$partedDisk"
++        mknod /dev/$partedDisk b $major $(($minor + 1)) && \
++        echo "Successfully created device file for /dev/$partedDisk" || \
++        echo "Failed to create device file for /dev/$partedDisk"
++        echo
++        echo
++
++        #Creating a file system inside the partition
++        fileSystem=vfat
++        echo "Creating $fileSystem file system on /dev/$partedDisk"
++        mkfs.$fileSystem /dev/$partedDisk && \
++        echo "Successfully created $fileSystem file system on /dev/$partedDisk" || \
++        echo "Failed to create $fileSystem file system on /dev/$partedDisk"
++        echo
++        echo
++
++        #Mounting the partition onto a target directory
++        targetDir=/mnt
++        diskAccess=$(cat /sys/block/$disk/ro)
++        if [ $diskAccess -eq 0 ]; then
++          accessRight=rw
++        else
++          accessRight=ro
++        fi
++
++        echo "Mounting /dev/$partedDisk on $targetDir with access: $accessRight"
++        mkdir -p $targetDir
++        mount -o remount,$accessRight /dev/$partedDisk $targetDir && \
++        echo "Successfully mounted file system:/dev/$partedDisk on $targetDir" || \
++        echo "Failed to mount file system:/dev/$partedDisk on $targetDir"
++done
+\ No newline at end of file
+diff --git a/files/run b/files/run
+index a26edca..d16ad28 100755
+--- a/files/run
++++ b/files/run
+@@ -62,8 +62,12 @@ fi
+ echo "ramdisk='$workpath/initrd'" >> $outconfig
+ echo "p9=[ 'tag=share_dir,security_model=none,path=$mountpoint' ]" >> $outconfig
+ 
++if [ -f "$STAGE1_SEED_MNT_PT" ] ; then
++  cp "$STAGE1_SEED_MNT_PT" $stage2
++fi
++
+ if [ -f "$STAGE1_SEED_XL_CFG" ] ; then
+-    grep -Ev '^(disk|bootloader|root|extra|kernel)' < "$STAGE1_SEED_XL_CFG" >> $outconfig
++    grep -Ev '^(bootloader|root|extra|kernel)' < "$STAGE1_SEED_XL_CFG" >> $outconfig
+     if test $dhcp -eq 0
+     then
+         echo extra=\'console=hvc0 root=9p\' >> $outconfig

--- a/pkg/rkt-stage1/0011-Patch-to-mount-vol-stage2.patch
+++ b/pkg/rkt-stage1/0011-Patch-to-mount-vol-stage2.patch
@@ -1,84 +1,104 @@
+diff --git a/build.sh b/build.sh
+index 04fceb6..9c623f3 100755
+--- a/build.sh
++++ b/build.sh
+@@ -24,7 +24,7 @@ then
+     exit 1
+ fi
+
+-execs="enter run stop udhcpc_script.sh launcher.sh"
++execs="enter run stop udhcpc_script.sh launcher.sh mount_disk.sh"
+ netplugins="main/ptp main/bridge main/macvlan main/ipvlan ipam/host-local meta/flannel meta/tuning"
+
+ # Clean the repo, but save the vendor area
 diff --git a/files/mount_disk.sh b/files/mount_disk.sh
 new file mode 100644
-index 0000000..9a199d7
+index 0000000..c7fb944
 --- /dev/null
 +++ b/files/mount_disk.sh
-@@ -0,0 +1,62 @@
+@@ -0,0 +1,70 @@
 +#!/bin/sh
 +
++mountPointLineNo=1
 +ls /sys/block/ | grep xvd | while read -r disk ; do
-+        echo "Processing $disk"
++  echo "Processing $disk"
 +
-+        #Fetching Major and Minor device
-+        IN=$(cat /sys/block/$disk/dev | tr ":" "\n")
-+        major=$(echo ${IN} | cut -d' ' -f1)
-+        minor=$(echo ${IN} | cut -d' ' -f2)
++  #Fetching corresponding mount point from mountPoint file
++  moint_point=$(sed "${mountPointLineNo}q;d" mountPoint | tr ":" "\n")
++  if [ -z "$moint_point" ]
++    then
++      echo "Error while mounting: No Mount-Point found for $disk."
++      exit 0
++  fi
 +
-+        #Creating a block device under /dev with Major and minor devices
-+        echo "Creating device file /dev/$disk"
-+        mknod /dev/$disk b $major $minor && \
-+        echo "Successfully created device file for /dev/$disk" || \
-+        echo "Failed to create device file for /dev/$disk"
-+        echo
-+        echo
++  #Fetching Major and Minor device
++  IN=$(cat /sys/block/$disk/dev | tr ":" "\n")
++  major=$(echo ${IN} | cut -d' ' -f1)
++  minor=$(echo ${IN} | cut -d' ' -f2)
 +
-+        #Creating partition on block device
-+        partition_number=1
-+        first_sector=
-+        last_sector=
-+        echo "Creating partition:$partition_number for /dev/$disk"
-+        (echo n; echo p; echo $partition_number; echo $first_sector; echo $last_sector; echo w) | fdisk /dev/$disk && \
-+        echo "Successfully created partition:$partition_number for /dev/$disk" || \
-+        echo "Failed to create partition:$partition_number for /dev/$disk"
-+        echo
-+        echo
++  #Creating a block device under /dev with Major and minor devices
++  echo "Creating device file /dev/$disk"
++  mknod /dev/$disk b $major $minor && \
++  echo "Successfully created device file for /dev/$disk" || \
++  echo "Failed to create device file for /dev/$disk"
++  echo
 +
-+        #Creating a block device with partitioned disk
-+        partedDisk="$disk"1
-+        echo "Creating device file /dev/$partedDisk"
-+        mknod /dev/$partedDisk b $major $(($minor + 1)) && \
-+        echo "Successfully created device file for /dev/$partedDisk" || \
-+        echo "Failed to create device file for /dev/$partedDisk"
-+        echo
-+        echo
++  #Creating partition on block device
++  partition_number=1
++  first_sector=
++  last_sector=
++  echo "Creating partition:$partition_number for /dev/$disk"
++  (echo n; echo p; echo $partition_number; echo $first_sector; echo $last_sector; echo w) | fdisk /dev/$disk && \
++  echo "Successfully created partition:$partition_number for /dev/$disk" || \
++  echo "Failed to create partition:$partition_number for /dev/$disk"
++  echo
 +
-+        #Creating a file system inside the partition
-+        fileSystem=vfat
-+        echo "Creating $fileSystem file system on /dev/$partedDisk"
-+        mkfs.$fileSystem /dev/$partedDisk && \
-+        echo "Successfully created $fileSystem file system on /dev/$partedDisk" || \
-+        echo "Failed to create $fileSystem file system on /dev/$partedDisk"
-+        echo
-+        echo
++  #Creating a block device with partitioned disk
++  partitionToBeMounted=$(echo ${moint_point} | cut -d' ' -f3)
++  partedDisk="$disk""$partitionToBeMounted"
++  echo "Creating device file /dev/$partedDisk"
++  mknod /dev/$partedDisk b $major $(($minor + 1)) && \
++  echo "Successfully created device file for /dev/$partedDisk" || \
++  echo "Failed to create device file for /dev/$partedDisk"
++  echo
 +
-+        #Mounting the partition onto a target directory
-+        targetDir=/mnt
-+        diskAccess=$(cat /sys/block/$disk/ro)
-+        if [ $diskAccess -eq 0 ]; then
-+          accessRight=rw
-+        else
-+          accessRight=ro
-+        fi
++  #Creating a file system inside the partition
++  fileSystem=$(echo ${moint_point} | cut -d' ' -f2)
++  echo "Creating $fileSystem file system on /dev/$partedDisk"
++  mkfs.$fileSystem /dev/$partedDisk && \
++  echo "Successfully created $fileSystem file system on /dev/$partedDisk" || \
++  echo "Failed to create $fileSystem file system on /dev/$partedDisk"
++  echo
 +
-+        echo "Mounting /dev/$partedDisk on $targetDir with access: $accessRight"
-+        mkdir -p $targetDir
-+        mount -o remount,$accessRight /dev/$partedDisk $targetDir && \
-+        echo "Successfully mounted file system:/dev/$partedDisk on $targetDir" || \
-+        echo "Failed to mount file system:/dev/$partedDisk on $targetDir"
++  #Mounting the partition onto a target directory
++  targetDir=$(echo ${moint_point} | cut -d' ' -f1)
++  diskAccess=$(cat /sys/block/$disk/ro)
++  if [ $diskAccess -eq 0 ]; then
++    accessRight=rw
++  else
++    accessRight=ro
++  fi
++
++  echo "Mounting /dev/$partedDisk on $targetDir with access: $accessRight"
++  mkdir -p $targetDir
++  mount -O remount,$accessRight /dev/$partedDisk $targetDir && \
++  echo "Successfully mounted file system:/dev/$partedDisk on $targetDir" || \
++  echo "Failed to mount file system:/dev/$partedDisk on $targetDir"
++
++  mountPointLineNo=$(expr $mountPointLineNo + 1)
 +done
 \ No newline at end of file
 diff --git a/files/run b/files/run
-index a26edca..aed470a 100755
+index a26edca..32d0b7d 100755
 --- a/files/run
 +++ b/files/run
-@@ -62,8 +62,13 @@ fi
+@@ -62,8 +62,12 @@ fi
  echo "ramdisk='$workpath/initrd'" >> $outconfig
  echo "p9=[ 'tag=share_dir,security_model=none,path=$mountpoint' ]" >> $outconfig
 
-+if [ -f "$STAGE1_SEED_MNT_PT" ] ; then
-+  cp "$STAGE1_SEED_MNT_PT" $stage2
++if [ -f "$STAGE2_MNT_PTS" ] ; then
++  cp "$STAGE2_MNT_PTS" $stage2/mountPoints
 +fi
-+cp $stage1/mount_disk.sh $stage2
 +
  if [ -f "$STAGE1_SEED_XL_CFG" ] ; then
 -    grep -Ev '^(disk|bootloader|root|extra|kernel)' < "$STAGE1_SEED_XL_CFG" >> $outconfig
@@ -86,17 +106,30 @@ index a26edca..aed470a 100755
      if test $dhcp -eq 0
      then
          echo extra=\'console=hvc0 root=9p\' >> $outconfig
+@@ -95,6 +99,8 @@ fi
+
+ cp $stage1/launcher.sh $stage2
+ chmod +x $stage2/launcher.sh
++cp $stage1/mount_disk.sh $stage2
++chmod +x $stage2/mount_disk.sh
+ echo $cmdline > $mountpoint/cmdline
+ export IFS=$'\n'
+ stage2manifest=$mountpoint/manifest
 diff --git a/kernel/init-initrd b/kernel/init-initrd
-index 98b2256..8ec35c5 100755
+index 98b2256..caa744c 100755
 --- a/kernel/init-initrd
 +++ b/kernel/init-initrd
-@@ -78,7 +78,9 @@ then
- fi
+@@ -79,8 +79,13 @@ fi
  cp /mnt/cmdline /mnt/rootfs
  cp /mnt/launcher.sh /mnt/rootfs
-+cp /mnt/mount_disk.sh /mnt/rootfs
  chmod +x /mnt/rootfs/launcher.sh
 +chmod +x /mnt/rootfs/mount_disk.sh
  cmd=`cat /mnt/cmdline`
  echo "Executing $cmd"
  source /mnt/environment
+ source /mnt/external-environment
++
++echo "Executing /mnt/mount_disk.sh"
++/mnt/mount_disk.sh
++
+ eval setsid -c chroot /mnt/rootfs /launcher.sh $cmd <> /dev/console 2>&1

--- a/pkg/rkt-stage1/0011-Patch-to-mount-vol-stage2.patch
+++ b/pkg/rkt-stage1/0011-Patch-to-mount-vol-stage2.patch
@@ -116,15 +116,10 @@ index a26edca..32d0b7d 100755
  export IFS=$'\n'
  stage2manifest=$mountpoint/manifest
 diff --git a/kernel/init-initrd b/kernel/init-initrd
-index 98b2256..caa744c 100755
+index 98b2256..d1109c2 100755
 --- a/kernel/init-initrd
 +++ b/kernel/init-initrd
-@@ -79,8 +79,13 @@ fi
- cp /mnt/cmdline /mnt/rootfs
- cp /mnt/launcher.sh /mnt/rootfs
- chmod +x /mnt/rootfs/launcher.sh
-+chmod +x /mnt/rootfs/mount_disk.sh
- cmd=`cat /mnt/cmdline`
+@@ -83,4 +83,8 @@ cmd=`cat /mnt/cmdline`
  echo "Executing $cmd"
  source /mnt/environment
  source /mnt/external-environment

--- a/pkg/rkt-stage1/0011-Patch-to-mount-vol-stage2.patch
+++ b/pkg/rkt-stage1/0011-Patch-to-mount-vol-stage2.patch
@@ -86,3 +86,17 @@ index a26edca..aed470a 100755
      if test $dhcp -eq 0
      then
          echo extra=\'console=hvc0 root=9p\' >> $outconfig
+diff --git a/kernel/init-initrd b/kernel/init-initrd
+index 98b2256..8ec35c5 100755
+--- a/kernel/init-initrd
++++ b/kernel/init-initrd
+@@ -78,7 +78,9 @@ then
+ fi
+ cp /mnt/cmdline /mnt/rootfs
+ cp /mnt/launcher.sh /mnt/rootfs
++cp /mnt/mount_disk.sh /mnt/rootfs
+ chmod +x /mnt/rootfs/launcher.sh
++chmod +x /mnt/rootfs/mount_disk.sh
+ cmd=`cat /mnt/cmdline`
+ echo "Executing $cmd"
+ source /mnt/environment


### PR DESCRIPTION
Added a patch on Stage1-xen to accept mount volumes through xen.cfg.

As per the implementation in this PR, user uploads a `qcow2` type image of required size and access permissions to be mounted as a volume to the container. Target location is expected to be available in AppManifest

Target locations will be added to a file inside stage2  and the newly added script in stage1-xen mount_disk.sh reads that file and mounts volume accordingly.