### PR TITLE
Add ability to specify separate TLS root certs for API V2

### DIFF
--- a/api/proto/info/info.proto
+++ b/api/proto/info/info.proto
@@ -311,6 +311,8 @@ message ProxyStatus {
   bool networkProxyEnable = 4;
   string networkProxyURL = 5;
   string wpadURL = 6;
+  // XXX add? In config
+  // repeated bytes proxyCertPEM = 7;
 }
 
 message ProxyEntry {

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -7,7 +7,8 @@ In general, EVE is trying to make sure that its controller always has the last w
 * `grub.cfg` - local tweaks to an [otherwise readonly grub.cfg](README.md#runtime-lifecycle)
 * `DevicePortConfig/override.json` - initial configuration for all of EVE's network interfaces (see below for details)
 * `server` - contains a FQDN of a controller and its port (e.g. controller.acme.com:123)
-* `root-certificate.pem` - contains an x509 root certificate for the controller
+* `root-certificate.pem` - contains an x509 root certificate to trust for the controller for TLS in V1 API and object signing in V2 API
+* `v2tlsbaseroot-certificates.pem` - contains the x509 root certificate to trust for the TLS to the controller when using the V2 API
 * `onboard.cert.pem` - onboarding certificate for the [initial registration](REGISTRATION.md) with the controller
 * `wpa_supplicant.conf` - a legacy way of configuring EVE's WiFi
 * `authorized_keys` - initial authorized SSH keys for accessing EVE's debug console

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -56,7 +56,8 @@ The EVE contributors and community need to prioritize which security risks to fo
 Recall that EVE's deployment model presupposes a controller that can exercise arbitrary control over Edge Nodes. EVE provides the following capabilities that can protect against an adversary trying to take control over an Edge Node by pretending to be a controller:
 
 * The controller's network address (hostname and port) is considered immutable and can only be changed by a total reinstall of EVE
-* The controller's identity is verified by a Root CA which is also considered immutable and sealed in TPM where possible
+* The controller's identity is verified by a Root CA which is also considered immutable and sealed in TPM where possible. This is used in the TLS verification for API V1 and in the object signature verification in API V2
+ * The TLS identity of the controller is verified by a Root CA. This is a single Root CA in API V1 and a larger set of root CAs plus the ability to express trust in proxy certificates in API V2.
 
 The principle that EVE's node forever gets bound to a fixed controller may strike some as too restrictive, but it allows a much easier reasoning about security properties and, since controller gets identified by the DNS name still allows a certain flexibility in deployment. It does, however, stand in stark contrast to EVE's fundamental guarantee of never ever requiring a "truck roll" to manage software on Edge Nodes. Unfortunately, avoiding a "truck roll" in this particular case will require us to design a comprehensive asset transfer protocol that tackles a whole host of thorny problems like:
 
@@ -65,7 +66,7 @@ The principle that EVE's node forever gets bound to a fixed controller may strik
 
 Given the complexity of designing such a protocol for EVE (especially solving the hardware validation problem), we are currently punting on the problem and declaring software-based asset transfer out of scope for now. However, we are in no way suggesting that this should be a permanent state of affairs.
 
-If there's an attempted modification of either controller's address (stored in /config/server) and controller's Root CA (/config/root.cert.pem) Edge Node should get disconnected from the controller and should be forced to do a hardware-assisted clear operation and start all over again.
+If there's an attempted modification of either controller's address (stored in /config/server) and controller's Root CA (/config/root-certificate.pem) Edge Node should get disconnected from the controller and should be forced to do a hardware-assisted clear operation and start all over again.
 
 On systems where TPM is available, the idea is to change TPM authentication policy from password to HMAC based authentication (TPM2_PolicyAuthValue), with hash calculated from the Root CA.  When device key is created, HMAC from Root CA will be passed, which is to be honored for every TPM command related to the key entity. i.e Each time Sign command is passed to TPM, the Root CA hash needs to be the same. If someone changes Root CA, HMAC will not match, and the device will be disconnected from zedCloud, forcing the user to do a TPM clear and start all over again.
 

--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -49,7 +49,7 @@ var Version = "No version specified"
 
 // Assumes the config files are in IdentityDirname, which is /config
 // by default. The files are
-//  root-certificate.pem	Fixed? Written if redirected. factory-root-cert?
+//  root-certificate.pem	Root CA cert(s) for object signing
 //  server			Fixed? Written if redirected. factory-root-cert?
 //  onboard.cert.pem, onboard.key.pem	Per device onboarding certificate/key
 //  		   		for selfRegister operation
@@ -232,11 +232,14 @@ func Run() { //nolint:gocyclo
 	log.Infof("Got for deviceNetworkConfig: %d addresses\n",
 		clientCtx.usableAddressCount)
 
+	// XXX set propertly
+	v2api := false
 	zedcloudCtx := zedcloud.ZedCloudContext{
 		DeviceNetworkStatus: clientCtx.deviceNetworkStatus,
 		FailureFunc:         zedcloud.ZedCloudFailure,
 		SuccessFunc:         zedcloud.ZedCloudSuccess,
 		NetworkSendTimeout:  clientCtx.globalConfig.NetworkSendTimeout,
+		V2API:               v2api,
 	}
 
 	// Get device serail number
@@ -264,7 +267,8 @@ func Run() { //nolint:gocyclo
 		if err != nil {
 			log.Fatal(err)
 		}
-		onboardTLSConfig, err = zedcloud.GetTlsConfig(serverName, &onboardCert)
+		onboardTLSConfig, err = zedcloud.GetTlsConfig(zedcloudCtx.DeviceNetworkStatus,
+			serverName, &onboardCert, zedcloudCtx.V2API)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -280,7 +284,8 @@ func Run() { //nolint:gocyclo
 	if err != nil {
 		log.Fatal(err)
 	}
-	tlsConfig, err := zedcloud.GetTlsConfig(serverName, &deviceCert)
+	tlsConfig, err := zedcloud.GetTlsConfig(zedcloudCtx.DeviceNetworkStatus,
+		serverName, &deviceCert, zedcloudCtx.V2API)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/pillar/cmd/logmanager/logmanager.go
+++ b/pkg/pillar/cmd/logmanager/logmanager.go
@@ -763,21 +763,24 @@ func sendCtxInit(ctx *logmanagerContext) {
 	//set log url
 	logsUrl = serverNameAndPort + "/" + logsApi
 
-	tlsConfig, err := zedcloud.GetTlsConfig(serverName, nil)
-	if err != nil {
-		log.Fatal(err)
-	}
+	v2api := false // XXX set
 	zedcloudCtx.DeviceNetworkStatus = deviceNetworkStatus
-	zedcloudCtx.TlsConfig = tlsConfig
 	zedcloudCtx.FailureFunc = zedcloud.ZedCloudFailure
 	zedcloudCtx.SuccessFunc = zedcloud.ZedCloudSuccess
 	zedcloudCtx.NetworkSendTimeout = ctx.globalConfig.NetworkSendTimeout
+	zedcloudCtx.V2API = v2api
 
 	// get the edge box serial number
 	zedcloudCtx.DevSerial = hardware.GetProductSerial()
 	zedcloudCtx.DevSoftSerial = hardware.GetSoftSerial()
 	log.Infof("Log Get Device Serial %s, Soft Serial %s\n", zedcloudCtx.DevSerial,
 		zedcloudCtx.DevSoftSerial)
+
+	// XXX need to redo this since the root certificates can change when DeviceNetworkStatus changes
+	err = zedcloud.UpdateTLSConfig(&zedcloudCtx, serverName, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	// In case we run early, wait for UUID file to appear
 	for {

--- a/pkg/pillar/cmd/verifier/verifier.go
+++ b/pkg/pillar/cmd/verifier/verifier.go
@@ -858,7 +858,7 @@ func verifyObjectShaSignature(status *types.VerifyImageStatus, config *types.Ver
 	//Create the set of root certificates...
 	roots := x509.NewCertPool()
 
-	// Read the root cerificates from /config
+	// Read the signing root cerificates from /config
 	rootCertificate, err := ioutil.ReadFile(types.RootCertFileName)
 	if err != nil {
 		log.Errorln(err)
@@ -882,6 +882,7 @@ func verifyObjectShaSignature(status *types.VerifyImageStatus, config *types.Ver
 			return cerr
 		}
 
+		// XXX must put these in Intermediates not Rootfs
 		if ok := roots.AppendCertsFromPEM(bytes); !ok {
 			cerr := fmt.Sprintf("failed to parse intermediate certificate")
 			return cerr

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -84,19 +84,22 @@ func handleConfigInit(networkSendTimeout uint32) {
 	serverNameAndPort = strings.TrimSpace(string(bytes))
 	serverName = strings.Split(serverNameAndPort, ":")[0]
 
-	tlsConfig, err := zedcloud.GetTlsConfig(serverName, nil)
-	if err != nil {
-		log.Fatal(err)
-	}
+	v2api := false // XXX set
 	zedcloudCtx.DeviceNetworkStatus = deviceNetworkStatus
-	zedcloudCtx.TlsConfig = tlsConfig
 	zedcloudCtx.FailureFunc = zedcloud.ZedCloudFailure
 	zedcloudCtx.SuccessFunc = zedcloud.ZedCloudSuccess
 	zedcloudCtx.DevSerial = hardware.GetProductSerial()
 	zedcloudCtx.DevSoftSerial = hardware.GetSoftSerial()
 	zedcloudCtx.NetworkSendTimeout = networkSendTimeout
+	zedcloudCtx.V2API = v2api
 	log.Infof("Configure Get Device Serial %s, Soft Serial %s\n", zedcloudCtx.DevSerial,
 		zedcloudCtx.DevSoftSerial)
+
+	// XXX need to redo this since the root certificates can change
+	err = zedcloud.UpdateTLSConfig(&zedcloudCtx, serverName, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	b, err := ioutil.ReadFile(types.UUIDFileName)
 	if err != nil {

--- a/pkg/pillar/cmd/zedagent/handlelookupparam.go
+++ b/pkg/pillar/cmd/zedagent/handlelookupparam.go
@@ -44,18 +44,6 @@ type DeviceLispConfig struct {
 	ClientAddr      string // To detect NATs
 }
 
-// Assumes the config files are in IdentityDirname, which is /config. Files are:
-//  device.cert.pem,
-//  device.key.pem		Device certificate/key created before this
-//  		     		client is started.
-//  infra			If this file exists assume zedcontrol and do not
-//  				create ACLs
-//  root-certificate.pem	Root CA cert(s)
-//
-//  In addition we have:
-//  /var/tmp/zededa/zedserverconfig Written by us; zed server EIDs
-//  /var/tmp/zededa/uuid	Written by us
-//
 var lispPrevConfigHash []byte
 var prevLispConfig DeviceLispConfig
 

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -1141,6 +1141,7 @@ func encodeProxyStatus(proxyConfig *types.ProxyConfig) *info.ProxyStatus {
 	status.NetworkProxyEnable = proxyConfig.NetworkProxyEnable
 	status.NetworkProxyURL = proxyConfig.NetworkProxyURL
 	status.WpadURL = proxyConfig.WpadURL
+	// XXX add? status.ProxyCertPEM = proxyConfig.ProxyCertPEM
 	log.Debugf("encodeProxyStatus: %+v\n", status)
 	return status
 }

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -1059,6 +1059,7 @@ func parseOneNetworkXObjectConfig(ctx *getconfigContext, netEnt *zconfig.Network
 			NetworkProxyEnable: netProxyConfig.NetworkProxyEnable,
 			NetworkProxyURL:    netProxyConfig.NetworkProxyURL,
 			Pacfile:            netProxyConfig.Pacfile,
+			ProxyCertPEM:       netProxyConfig.ProxyCertPEM,
 		}
 		proxyConfig.Exceptions = netProxyConfig.Exceptions
 

--- a/pkg/pillar/devicenetwork/devicenetwork.go
+++ b/pkg/pillar/devicenetwork/devicenetwork.go
@@ -92,9 +92,12 @@ func VerifyDeviceNetworkStatus(status types.DeviceNetworkStatus,
 	serverName := strings.Split(serverNameAndPort, ":")[0]
 	testUrl := serverNameAndPort + "/api/v1/edgedevice/ping"
 
+	// XXX set by caller?
+	v2api := false
 	zedcloudCtx := zedcloud.ZedCloudContext{
 		DeviceNetworkStatus: &status,
 		NetworkSendTimeout:  timeout,
+		V2API:               v2api,
 	}
 
 	// Get device serial number
@@ -103,7 +106,8 @@ func VerifyDeviceNetworkStatus(status types.DeviceNetworkStatus,
 	log.Infof("NIM Get Device Serial %s, Soft Serial %s\n", zedcloudCtx.DevSerial,
 		zedcloudCtx.DevSoftSerial)
 
-	tlsConfig, err := zedcloud.GetTlsConfig(serverName, nil)
+	tlsConfig, err := zedcloud.GetTlsConfig(zedcloudCtx.DeviceNetworkStatus, serverName,
+		nil, zedcloudCtx.V2API)
 	if err != nil {
 		log.Infof("VerifyDeviceNetworkStatus: " +
 			"Device certificate not found, looking for Onboarding certificate")
@@ -116,7 +120,8 @@ func VerifyDeviceNetworkStatus(status types.DeviceNetworkStatus,
 			return false, errors.New(errStr)
 		}
 		clientCert := &onboardingCert
-		tlsConfig, err = zedcloud.GetTlsConfig(serverName, clientCert)
+		tlsConfig, err = zedcloud.GetTlsConfig(zedcloudCtx.DeviceNetworkStatus,
+			serverName, clientCert, zedcloudCtx.V2API)
 		if err != nil {
 			errStr := "TLS configuration for talking to Zedcloud cannot be found"
 

--- a/pkg/pillar/types/locationconsts.go
+++ b/pkg/pillar/types/locationconsts.go
@@ -39,8 +39,10 @@ const (
 	OnboardCertName = IdentityDirname + "/onboard.cert.pem"
 	// OnboardKeyName - onboard key
 	OnboardKeyName = IdentityDirname + "/onboard.key.pem"
-	// RootCertFileName - what we trust
+	// RootCertFileName - what we trust for signatures and object encryption
 	RootCertFileName = IdentityDirname + "/root-certificate.pem"
+	// V2TLSCertShaFilename - find TLS root cert for API V2 based on this sha
+	V2TLSCertShaFilename = CertificateDirname + "/v2tlsbaseroot-certificates.sha256"
 	// UUIDFileName - device UUID
 	UUIDFileName = IdentityDirname + "/uuid"
 

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -298,9 +298,10 @@ type ProxyConfig struct {
 	Pacfile    string
 	// If Enable is set we use WPAD. If the URL is not set we try
 	// the various DNS suffixes until we can download a wpad.dat file
-	NetworkProxyEnable bool   // Enable WPAD
-	NetworkProxyURL    string // Complete URL i.e., with /wpad.dat
-	WpadURL            string // The URL determined from DNS
+	NetworkProxyEnable bool     // Enable WPAD
+	NetworkProxyURL    string   // Complete URL i.e., with /wpad.dat
+	WpadURL            string   // The URL determined from DNS
+	ProxyCertPEM       [][]byte // List of certs which will be added to TLS trust
 }
 
 type DhcpConfig struct {

--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -39,6 +39,7 @@ type ZedCloudContext struct {
 	DevSerial           string
 	DevSoftSerial       string
 	NetworkSendTimeout  uint32 // In seconds
+	V2API               bool   // XXX Needed?
 }
 
 var sendCounter uint32

--- a/pkg/pillar/zedcloud/wstunnelclient.go
+++ b/pkg/pillar/zedcloud/wstunnelclient.go
@@ -97,7 +97,8 @@ func (t *WSTunnelClient) TestConnection(proxyURL *url.URL, localAddr net.IP) err
 	log.Debugf("Testing connection to %s on local address: %v, proxy: %v", t.Tunnel, localAddr, proxyURL)
 
 	serverName := strings.Split(t.TunnelServerNameAndPort, ":")[0]
-	tlsConfig, err := GetTlsConfig(serverName, nil)
+	// XXX assume v1 API for now
+	tlsConfig, err := GetTlsConfig(nil, serverName, nil, false)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
In order to enable the V2 APIs the device needs to track a separate set of CA certificates for TLS for V2.
This PR allows the build to specify a separate list in conf/ and if none is present, use the Alpine list of root CA certificates.
It also adds the ability to pull in the proxy root CA certificates but that is WIP since it needs code to change the list in use when the proxy config changes. Diag currently handles that, but other users will need notifiers to update the tlsConfig on such changes.