### PR TITLE
Container storage volume management in the pillar component

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1515,7 +1515,7 @@ func configToStatus(ctx *domainContext, config types.DomainConfig,
 	numOfContainerDisks := 0
 	for i, dc := range config.DiskConfigList {
 		if dc.Format == zconfig.Format_CONTAINER {
-			numOfContainerDisks += 1
+			numOfContainerDisks++
 		}
 		ds := &status.DiskStatusList[i]
 		ds.ImageID = dc.ImageID

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1525,8 +1525,17 @@ func configToStatus(ctx *domainContext, config types.DomainConfig,
 		ds.Format = dc.Format
 		ds.Maxsizebytes = dc.Maxsizebytes
 		ds.Devtype = dc.Devtype
-		// map from i=1 to xvda, 2 to xvdb etc
-		xv := "xvd" + string(int('a')+i)
+		var xv string
+		if status.IsContainer {
+			// map from i=1 to xvdb, 2 to xvdc etc
+			// For container instances xvda will be used for container disk
+			// So for other disks we are starting from xvdb
+			// Currently, we are not supporting multiple container disks inside a pod
+			xv = "xvd" + string(int('b')+i)
+		} else {
+			// map from i=1 to xvda, 2 to xvdb etc
+			xv = "xvd" + string(int('a')+i)
+		}
 		ds.Vdev = xv
 
 		target := ""


### PR DESCRIPTION
Signed-off-by: zed-rishabh <rgupta@zededa.com>

1. For container bundles copying rw disk images other than container
disks to /persist/img
2. While domain create, we have an assumption that drives contains only
one disk for the container bundles. Now we are iterating over the drives and
taking the image sha of the container disk. We are also checking for more
than one container disk in the drives and returning an error.