### PR TITLE
Fixing datastore path for signing certificates

### DIFF
--- a/pkg/pillar/cmd/downloader/syncop.go
+++ b/pkg/pillar/cmd/downloader/syncop.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"os"
 	"path"
-	"strings"
 	"time"
 
 	zconfig "github.com/lf-edge/eve/api/go/config"

--- a/pkg/pillar/cmd/downloader/syncop.go
+++ b/pkg/pillar/cmd/downloader/syncop.go
@@ -283,9 +283,6 @@ func handleSyncOpResponse(ctx *downloaderContext, config types.DownloaderConfig,
 // cloud storage interface functions/APIs
 func constructDatastoreContext(config types.DownloaderConfig, status *types.DownloaderStatus, dst *types.DatastoreConfig) *types.DatastoreContext {
 	dpath := dst.Dpath
-	if status.ObjType == types.CertObj {
-		dpath = strings.Replace(dpath, "-images", "-certs", 1)
-	}
 	downloadURL := config.Name
 	if !config.NameIsURL {
 		downloadURL = dst.Fqdn


### PR DESCRIPTION
Image signing management:
Currently, we are assuming that the datastore containing signing certificates and images will have the same credentials which are not true always. To solve it to some extent, we are enforcing to store both signing certificates and images in the same datastore.