### PR TITLE
Correcting instance state for exited containers

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -782,6 +782,10 @@ func verifyStatus(ctx *domainContext, status *types.DomainStatus) {
 			log.Warnln(errStr)
 			status.Activated = false
 			status.State = types.HALTED
+			if status.IsContainer {
+				status.LastErr = "container exited - please restart application instance"
+				status.LastErrTime = time.Now()
+			}
 		}
 		status.DomainId = 0
 		publishDomainStatus(ctx, status)


### PR DESCRIPTION
Signed-off-by: zed-rishabh <rgupta@zededa.com>

Currently for exited containers, instance run state is 'HALTED'.
With these changes run state will be 'Error'