### PR TITLE
[DO NOT MERGE] track where we use gopacket CGO code

### DIFF
--- a/pkg/pillar/gopacket.md
+++ b/pkg/pillar/gopacket.md
@@ -1,0 +1,71 @@
+# CGO Usage in Pillar
+
+This document outlines where we use CGO code in pillar, and thus require `CGO_ENABLED=1`.
+Removing `CGO_ENABLED=1` will make cross-compilation dramatically simpler
+and general compilation much faster.
+
+The entire dependency on `CGO` is in https://github.com/google/gopacket and its
+dependencies, which are for native packet processing.
+
+Once we understand what we actually process, we will be able to seek alternatives.
+
+Note that only some of it is CGO, from godoc:
+
+```
+* layers: You'll probably use this every time.  This contains of the logic
+    built into gopacket for decoding packet protocols.  Note that all example
+    code below assumes that you have imported both gopacket and
+    gopacket/layers.
+* pcap: C bindings to use libpcap to read packets off the wire.
+* pfring: C bindings to use PF_RING to read packets off the wire.
+* afpacket: C bindings for Linux's AF_PACKET to read packets off the wire.
+* tcpassembly: TCP stream reassembly
+```
+
+So the only parts we care about are those which have C bindings:
+
+* `afpacket` - used for packet capture and send - THIS IS THE MAIN AREA
+* `pcap` - used only to compile BPF Filters - THIS ALSO IS C
+* `pfring` - unused
+
+## Usage
+
+Since the separation of lisp into its own container in [this PR](https://github.com/lf-edge/eve/pull/607),
+the only remaining usage of `gopacket`, and hence `CGO`, in pillar is:
+
+```sh
+$ grep -r -w 'afpacket\|pcap' --exclude-dir=vendor --exclude-dir=dist --exclude='gopacket.md' pkg/pillar/*
+pkg/pillar/cmd/zedrouter/flowstats.go:	"github.com/google/gopacket/pcap"
+pkg/pillar/cmd/zedrouter/flowstats.go:		handle      *pcap.Handle
+pkg/pillar/cmd/zedrouter/flowstats.go:	handle, err = pcap.OpenLive(bn, snapshotLen, promiscuous, timeout)
+```
+
+The above excludes `go.mod`, `go.sum`, binary file matches, comment-only lines, and documents.
+
+As can be seen, the usage is very small, in a small number of places, entirely contained within a single function
+in a single file, `cmd/zedrouter/flowstats.go`:
+
+```go
+func DNSMonitor(bn string, bnNum int, ctx *zedrouterContext, status *types.NetworkInstanceStatus) {
+}
+```
+
+This function has the following purpose. Whenever a `NetworkInstance` is created by `zedrouter`, it spins off a separate
+goroutine that calls `DNSMonitor()` in `flowstats.go`, as above. This func does the following:
+
+* opens a live pcap capture for the network interface
+* adds a BPF filter for "udp and port 53" or "udp and (port 53 or port 67)"
+* enters an infinite `for{ }` loop around the channel provided by the pcap implementation
+
+When each packet comes in, it determines if it is DHCP or DNS, calls an appropriate routine to extract relevant information
+from the packet, and then saves it in a private structure `dnssys`.
+
+A separate goroutine regularly updates the cloud controller with the information cached in `dnssys`.
+
+This process enables the controller to be aware of every DNS and DHCP request and response, and to which ECO they belong.
+
+The question is:
+
+* Can we replace the function, or the way it works, with something else?
+* If not, should zedrouter be part of pillar, or can it be moved to another container, just like lisp?
+* Are there alternatives?


### PR DESCRIPTION
This is not meant to be merged. This is just a branch with a document showing where we still use CGO in pillar and what it is used for, in the hopes of eventually getting rid of it. The benefits are:

* simpler compile
* drop-dead simple cross-compile
* easier to run pillar as standalone, on different architectures or even OSes

Open questions @kalyan-nidumolu @rvs @eriknordmark 