### PR TITLE
Add EVE CLI support for attaching /persist to another block device

### DIFF
--- a/pkg/dom0-ztools/rootfs/bin/eve
+++ b/pkg/dom0-ztools/rootfs/bin/eve
@@ -13,8 +13,36 @@ Welcome to EVE!
             pause <qube>
             resume <qube>
             destroy <qube>
+            persist list
+            persist attach <disk>
 __EOT__
   exit 1
+}
+
+sec_start=2048
+sec_end=0
+num_p3_part=9
+p3_old_tag=P3_OLD
+
+list_partitions() {
+  p3_dev=$(/sbin/findfs PARTLABEL=P3)
+  p3_dev_base=$(basename "$p3_dev")
+  /bin/lsblk -o KNAME,TYPE,SIZE,MODEL,PARTLABEL
+  echo "CURRENT PERSIST PARTITION IS: $p3_dev_base"
+}
+
+relabel_dev() {
+  /usr/bin/sgdisk -c 9:"$1" "$2"
+}
+
+clear_gpt() {
+  /usr/bin/sgdisk -g --clear "$1"
+}
+
+create_new_p3_part() {
+  /usr/bin/sgdisk --new "$num_p3_part":"$sec_start":"$sec_end" \
+                  --typecode="$num_p3_part":7dcc9ef1-b744-454a-b6ee-c15af7e3eea9 \
+                  --change-name="$num_p3_part":'P3' "$1"
 }
 
 case "$1" in
@@ -44,6 +72,36 @@ case "$1" in
           ;;
   resume) [ -z "$2" ] && help
           ${CTR_CMD} t resume $2
+          ;;
+ persist) case "$2" in
+               list) list_partitions
+                     ;;
+             attach) [ -z "$3" ] && help
+                     shift 2
+                     #fetch current P3 partition
+                     curr_p3_dev=$(/sbin/findfs PARTLABEL=P3)
+                     [ -z "$curr_p3_dev" ] && echo "Failed to find current P3 device" && exit 1
+                     curr_p3_dsk="/dev/"$(lsblk -no pkname "$curr_p3_dev")
+
+                     #rename current partition label
+                     relabel_dev "$p3_old_tag" "$curr_p3_dsk"
+
+                     #Clear GPT on new device, and create P3 partition
+                     clear_gpt "$1"
+                     create_new_p3_part "$1"
+
+                     #check the result
+                     new_p3_dev=$(/sbin/findfs PARTLABEL=P3)
+                     new_p3_dsk="/dev/"$(lsblk -no pkname "$new_p3_dev")
+                     [ "$new_p3_dsk" != "$1" ] && echo "Failed to attach persist to $1" && exit 1
+                     echo "Attached persist to $1"
+
+                     #print the partition
+                     list_partitions
+                     ;;
+                  *) help
+                     ;;
+          esac
           ;;
        *) help 
           ;;

--- a/pkg/gpt-tools/files/zboot
+++ b/pkg/gpt-tools/files/zboot
@@ -71,6 +71,16 @@ partdev() {
 }
 
 #
+# PARTDEVALL: get device from partition label, search all drives
+#
+partdevall() {
+    if [ ! $# -eq 1 ]; then
+	usage
+    fi
+    cgpt find -l $1
+}
+
+#
 # PARTSTATE <LABEL>: get state from partition label
 #
 partstate() {
@@ -133,6 +143,7 @@ shift 1
 case $cmd in
     curpart) curpart ;;
     partdev) partdev "$@" ;;
+    partdevall) partdevall "$@" ;;
     partstate) partstate "$@" ;;
     set_partstate) set_partstate "$@" ;;
     reset) reset ;;

--- a/pkg/gpt-tools/files/zboot
+++ b/pkg/gpt-tools/files/zboot
@@ -75,9 +75,9 @@ partdev() {
 #
 partdevall() {
     if [ ! $# -eq 1 ]; then
-	usage
+        usage
     fi
-    cgpt find -l $1
+    cgpt find -l "$1"
 }
 
 #

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -123,7 +123,7 @@ if [ ! -d $LOGDIRB ]; then
     mkdir -p $LOGDIRB
 fi
 
-P3=$(zboot partdev P3)
+P3=$(/hostfs/sbin/findfs PARTLABEL=P3)
 P3_FS_TYPE=$(blkid "$P3"| awk '{print $3}' | sed 's/TYPE=//' | sed 's/"//g')
 if [ -c $TPM_DEVICE_PATH ] && ! [ -f $CONFIGDIR/disable-tpm ] && [ "$P3_FS_TYPE" = "ext4" ]; then
     #It is a device with TPM, and formatted with ext4, setup fscrypt


### PR DESCRIPTION
 - `eve persist list` lists partitions and mentions which one is currently persist partition
 - `eve persist attach XXX` creates single partition on given disk, and marks it as the P3 partition.
    It also removes P3 label from the exisiting partition.
 - zboot partdev is searching for P3 only in root disk, added a zboot partdevall option to search all disks
 - device-steps was using zboot partdev, migrated it to findfs to align with storage-init.sh

Signed-off-by: Hariharasubramanian C S <cshari@zededa.com>