### PR TITLE
"eve persist attach" CLI - addressing pending comments from @rvs

### DIFF
--- a/pkg/dom0-ztools/rootfs/bin/eve
+++ b/pkg/dom0-ztools/rootfs/bin/eve
@@ -32,7 +32,7 @@ list_partitions() {
 }
 
 relabel_dev() {
-  /usr/bin/sgdisk -c 9:"$1" "$2"
+  /usr/bin/sgdisk -c "$num_p3_part":"$1" "$2"
 }
 
 clear_gpt() {
@@ -83,19 +83,24 @@ case "$1" in
                      [ -z "$curr_p3_dev" ] && echo "Failed to find current P3 device" && exit 1
                      curr_p3_dsk="/dev/"$(lsblk -no pkname "$curr_p3_dev")
 
-                     #rename current partition label
-                     relabel_dev "$p3_old_tag" "$curr_p3_dsk"
+                     #Attach must be idempotent
+                     [ "$curr_p3_dsk" = "$1" ] && echo "Persist is already on the given disk. Nothing to be done." && exit 0
 
                      #Clear GPT on new device, and create P3 partition
                      clear_gpt "$1"
                      create_new_p3_part "$1"
 
-                     #check the result
-                     new_p3_dev=$(/sbin/findfs PARTLABEL=P3)
+                     #check the result. At this point we should have two P3 partitions.
+                     #since findfs returns only the first P3, use cgpt to be more specific
+                     new_p3_dev=$(/usr/bin/cgpt find -l P3 "$1")
                      new_p3_dsk="/dev/"$(lsblk -no pkname "$new_p3_dev")
                      [ "$new_p3_dsk" != "$1" ] && echo "Failed to attach persist to $1" && exit 1
-                     echo "Attached persist to $1"
 
+                     #now rename current partition label
+                     echo "Removing P3 label from the old partition $curr_p3_dev"
+                     relabel_dev "$p3_old_tag" "$curr_p3_dsk"
+
+                     echo "Done. Attached persist to $1"
                      #print the partition
                      list_partitions
                      ;;


### PR DESCRIPTION
Comment, response:
a. "Instead of 9 this probably should've been $num_p3_part"
   - Fixed.

b. "If this fails, shouldn't we relabled back? Or better yet -- should we relable for the first time only at this point?"
   - Fixed. Also added a check to see if supplied disk already has a P3 partition.

c. "What's wrong with keep using zboot here?"
   - this is to use a consistent command to check P3 across storage-init and pillar containers and eve CLI
     (storage-init uses findfs. The "eve persist attach xx" tool also uses findfs)

Signed-off-by: Hariharasubramanian C S <cshari@zededa.com>