### PR TITLE
Run TPM mgr as a service agent

### DIFF
--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -448,6 +448,13 @@ done
 $BINDIR/vaultmgr -c "$CURPART" runAsService &
 wait_for_touch vaultmgr
 
+# Start tpmmgr as a service
+if [ -c $TPM_DEVICE_PATH ] && ! [ -f $CONFIGDIR/disable-tpm ] ; then
+    echo "$(date -Ins -u) Starting tpmmgr as a service agent"
+    $BINDIR/tpmmgr -c "$CURPART" runAsService &
+    wait_for_touch tpmmgr
+fi
+
 #If logmanager is already running we don't have to start it.
 if ! pgrep logmanager >/dev/null; then
     echo "$(date -Ins -u) Starting logmanager"


### PR DESCRIPTION
- This is required to anchor keys mgmt/rotation, certs mgmt, attestation publishing etc
- This is also required to publish TPM operational info via pubsub. (Today zedagent directly calls tpmmgr APIs)
- This is the initial commit, will follow it up with more content for certs creation etc
- Right now it is not watchdog enabled. Will enable it once we have reasonable content added.
- This is same as https://github.com/lf-edge/eve/pull/618 (I had to close that and re-open this, since
  I deleted that branch prematurely)

Signed-off-by: Hariharasubramanian C S <cshari@zededa.com>