### PR TITLE
Return per-interface errors when verifying DevicePortConfig

### DIFF
--- a/pkg/pillar/cmd/logmanager/logmanager.go
+++ b/pkg/pillar/cmd/logmanager/logmanager.go
@@ -336,7 +336,7 @@ func Run(ps *pubsub.PubSub) {
 				warningTime, errorTime)
 
 		case change := <-deferredChan:
-			_, err := devicenetwork.VerifyDeviceNetworkStatus(*deviceNetworkStatus, 1, 15)
+			_, _, err := devicenetwork.VerifyDeviceNetworkStatus(*deviceNetworkStatus, 1, 15)
 			if err != nil {
 				log.Errorf("logmanager(Run): log message processing still in "+
 					"deferred state. err: %s", err)
@@ -506,7 +506,7 @@ func processEvents(image string, logChan <-chan logEntry,
 					image)
 				continue
 			}
-			_, err := devicenetwork.VerifyDeviceNetworkStatus(*deviceNetworkStatus, 1, 15)
+			_, _, err := devicenetwork.VerifyDeviceNetworkStatus(*deviceNetworkStatus, 1, 15)
 			if err != nil {
 				log.Warnf("processEvents:(%s) log message processing still"+
 					" in deferred state", image)

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -730,7 +730,9 @@ func updateFilteredFallback(ctx *nimContext) {
 }
 
 func tryDeviceConnectivityToCloud(ctx *devicenetwork.DeviceNetworkContext) bool {
-	rtf, err := devicenetwork.VerifyDeviceNetworkStatus(*ctx.DeviceNetworkStatus, 1, ctx.TestSendTimeout)
+	rtf, intfErrMap, err := devicenetwork.VerifyDeviceNetworkStatus(
+		*ctx.DeviceNetworkStatus, 1, ctx.TestSendTimeout)
+	ctx.DevicePortConfig.SetPortErrorsFromIntfErrMap(intfErrMap)
 	if err == nil {
 		log.Infof("tryDeviceConnectivityToCloud: Device cloud connectivity test passed.")
 		if ctx.NextDPCIndex < len(ctx.DevicePortConfigList.PortConfigList) {

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -730,9 +730,9 @@ func updateFilteredFallback(ctx *nimContext) {
 }
 
 func tryDeviceConnectivityToCloud(ctx *devicenetwork.DeviceNetworkContext) bool {
-	rtf, intfErrMap, err := devicenetwork.VerifyDeviceNetworkStatus(
+	rtf, intfStatusMap, err := devicenetwork.VerifyDeviceNetworkStatus(
 		*ctx.DeviceNetworkStatus, 1, ctx.TestSendTimeout)
-	ctx.DevicePortConfig.SetPortErrorsFromIntfErrMap(intfErrMap)
+	ctx.DevicePortConfig.UpdatePortStatusFromIntfStatusMap(intfStatusMap)
 	if err == nil {
 		log.Infof("tryDeviceConnectivityToCloud: Device cloud connectivity test passed.")
 		if ctx.NextDPCIndex < len(ctx.DevicePortConfigList.PortConfigList) {

--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -254,8 +254,8 @@ func VerifyPending(ctx *DeviceNetworkContext, pending *DPCPending,
 	pending.PendDNS = pend2
 
 	// We want connectivity to zedcloud via atleast one Management port.
-	rtf, intfErrMap, err := VerifyDeviceNetworkStatus(pending.PendDNS, 1, timeout)
-	pending.PendDPC.SetPortErrorsFromIntfErrMap(intfErrMap)
+	rtf, intfStatusMap, err := VerifyDeviceNetworkStatus(pending.PendDNS, 1, timeout)
+	pending.PendDPC.UpdatePortStatusFromIntfStatusMap(intfStatusMap)
 
 	if err == nil {
 		if checkIfMgmtPortsHaveIPandDNS(pending.PendDNS) {

--- a/pkg/pillar/types/errortime.go
+++ b/pkg/pillar/types/errortime.go
@@ -18,6 +18,25 @@ type ErrorAndTime struct {
 	ErrorTime time.Time
 }
 
+// SetOrAppendError - Add or Append an error to ErrorAndTime
+func (etPtr *ErrorAndTime) SetOrAppendError(et ErrorAndTime) {
+	if etPtr.HasError() {
+		// Error Alread Set. Append errors
+		// This is a simplistic way to carry all the errors. If we see this
+		// happening more and more, maintain an array of ErrorAndTime
+		if et.HasError() {
+			// Error Already set. Append errors
+			etPtr.Error = etPtr.Error + " \n " + et.Error
+			// Retain the timestamp of first error
+		}
+		// Else - new et doesn't have an error. etPtr already has an error.
+		//  Ignore et
+	} else {
+		// Current state is success - so just update it.
+		*etPtr = et
+	}
+}
+
 // SetErrorNow uses the current time
 func (etPtr *ErrorAndTime) SetErrorNow(errStr string) {
 	etPtr.Error = errStr
@@ -44,6 +63,11 @@ func (etPtr *ErrorAndTime) HasError() bool {
 // NewErrorAndTime returns instance of ErrorAndTime with the specified values
 func NewErrorAndTime(errStr string, errTime time.Time) ErrorAndTime {
 	return ErrorAndTime{Error: errStr, ErrorTime: errTime}
+}
+
+// NewErrorAndTimeNow returns instance of ErrorAndTime with the specified values
+func NewErrorAndTimeNow(errStr string) ErrorAndTime {
+	return ErrorAndTime{Error: errStr, ErrorTime: time.Now()}
 }
 
 // ErrorAndTimeWithSource has an additional field "ErrorSourceType"


### PR DESCRIPTION
For Both periodic testing done by Nim and the testing triggered by config changes, store the per-interface errors seen in the testing.

1) If there is no error in DPC - it doesn’t really mean there is no error. It could also mean the interface was never tested
2) At any point, the Per-Port errors in DPC reflect the last time that port was tested. If the port was never tested, there would be no errors.

Per-Interface Errors:

1) This will have map of all interfaces tested
2) If intf is successful, ErrorInfo would be empty
3) If Intf Fails testing, ErrorInfo would have appropriate Error
4) If Intf not present — the interface was not tested. 
        - If there is an Error for that interface in DPC, the error would be retained.

Signed-off-by: Kalyan Nidumolu <kalyan@zadeda.com>