### PR TITLE
Fixing environment parsing from cloudinit for containers

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -2867,7 +2867,7 @@ func fetchEnvVariablesFromCloudInit(config types.DomainConfig) (map[string]strin
 	envList := make(map[string]string, 0)
 	list := strings.Split(string(ud), "\n")
 	for _, v := range list {
-		pair := strings.Split(v, ":")
+		pair := strings.SplitN(v, ":", 2)
 		envList[pair[0]] = pair[1]
 	}
 


### PR DESCRIPTION
Issue was if value has more than one ':' in the environment variable,
we are not parsing them properly. Now we are splitting the variable only
at the first occurence of delimiter ':'

Signed-off-by: zed-rishabh <rgupta@zededa.com>