### PR TITLE
Fixing downloading images progress bar

### DIFF
--- a/pkg/pillar/pubsub/publish.go
+++ b/pkg/pillar/pubsub/publish.go
@@ -132,7 +132,8 @@ func (pub *PublicationImpl) ClearRestarted() error {
 func (pub *PublicationImpl) Get(key string) (interface{}, error) {
 	m, ok := pub.km.key.Load(key)
 	if ok {
-		return m, nil
+		newIntf := deepCopy(m)
+		return newIntf, nil
 	} else {
 		name := pub.nameString()
 		errStr := fmt.Sprintf("Get(%s) unknown key %s", name, key)
@@ -144,7 +145,8 @@ func (pub *PublicationImpl) Get(key string) (interface{}, error) {
 func (pub *PublicationImpl) GetAll() map[string]interface{} {
 	result := make(map[string]interface{})
 	assigner := func(key string, val interface{}) bool {
-		result[key] = val
+		newVal := deepCopy(val)
+		result[key] = newVal
 		return true
 	}
 	pub.km.key.Range(assigner)


### PR DESCRIPTION
Get / GetAll always returned a shallow copy of the object from pubsub KeyMap.
But we had those Cast functions which converted into Json and back - thus creating a Deep Copy.
Somewhere in Jan - we got rid of this conversion and just started doing a static cast.
So, we are static casting the shallow copy and changing the copy. This caused the bug.

Signed-off-by: zed-rishabh <rgupta@zededa.com>