### PR TITLE
begin conversion of direct pubsub. calls to eliminate legacy

### DIFF
--- a/pkg/pillar/cmd/baseosmgr/baseosmgr.go
+++ b/pkg/pillar/cmd/baseosmgr/baseosmgr.go
@@ -80,7 +80,7 @@ type baseOsMgrContext struct {
 var debug = false
 var debugOverride bool // From command line arg
 
-func Run() {
+func Run(ps *pubsub.PubSub) {
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")
 	curpartPtr := flag.String("c", "", "Current partition")

--- a/pkg/pillar/cmd/conntrack/conntrack.go
+++ b/pkg/pillar/cmd/conntrack/conntrack.go
@@ -6,13 +6,15 @@ package conntrack
 import (
 	"flag"
 	"fmt"
-	"github.com/eriknordmark/netlink"
-	log "github.com/sirupsen/logrus"
 	"net"
 	"syscall"
+
+	"github.com/eriknordmark/netlink"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	log "github.com/sirupsen/logrus"
 )
 
-func Run() {
+func Run(ps *pubsub.PubSub) {
 	// XXX curpartPtr := flag.String("c", "", "Current partition")
 	delFlow := flag.Bool("D", false, "Delete flow")
 	delSrcIP := flag.String("s", "", "Delete flow with Srouce IP")

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -76,7 +76,7 @@ var simulateDnsFailure = false
 var simulatePingFailure = false
 var outfile = os.Stdout
 
-func Run() {
+func Run(ps *pubsub.PubSub) {
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")
 	curpartPtr := flag.String("c", "", "Current partition")

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -120,7 +120,7 @@ func (ctx *domainContext) publishAssignableAdapters() {
 var debug = false
 var debugOverride bool // From command line arg
 
-func Run() {
+func Run(ps *pubsub.PubSub) {
 	handlersInit()
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")

--- a/pkg/pillar/cmd/downloader/context.go
+++ b/pkg/pillar/cmd/downloader/context.go
@@ -165,6 +165,7 @@ func (ctx *downloaderContext) registerHandlers(ps *pubsub.PubSub) error {
 		AgentName:     "baseosmgr",
 		AgentScope:    types.BaseOsObj,
 		TopicImpl:     types.DownloaderConfig{},
+		Ctx:           ctx,
 	})
 	if err != nil {
 		return err

--- a/pkg/pillar/cmd/downloader/context.go
+++ b/pkg/pillar/cmd/downloader/context.go
@@ -4,7 +4,6 @@ import (
 	"sync"
 
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
-	pubsublegacy "github.com/lf-edge/eve/pkg/pillar/pubsub/legacy"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/zedUpload"
 	log "github.com/sirupsen/logrus"
@@ -30,43 +29,48 @@ type downloaderContext struct {
 	GCInitialized           bool
 }
 
-func (ctx *downloaderContext) registerHandlers() error {
+func (ctx *downloaderContext) registerHandlers(ps *pubsub.PubSub) error {
 	// Look for global config such as log levels
-	subGlobalConfig, err := pubsublegacy.Subscribe("", types.GlobalConfig{},
-		false, ctx, &pubsub.SubscriptionOptions{
-			CreateHandler: handleGlobalConfigModify,
-			ModifyHandler: handleGlobalConfigModify,
-			DeleteHandler: handleGlobalConfigDelete,
-			WarningTime:   warningTime,
-			ErrorTime:     errorTime,
-		})
+	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		CreateHandler: handleGlobalConfigModify,
+		ModifyHandler: handleGlobalConfigModify,
+		DeleteHandler: handleGlobalConfigDelete,
+		WarningTime:   warningTime,
+		ErrorTime:     errorTime,
+		TopicImpl:     types.GlobalConfig{},
+		Ctx:           ctx,
+	})
+
 	if err != nil {
 		return err
 	}
 	ctx.subGlobalConfig = subGlobalConfig
 	subGlobalConfig.Activate()
 
-	subDeviceNetworkStatus, err := pubsublegacy.Subscribe("nim",
-		types.DeviceNetworkStatus{}, false, ctx, &pubsub.SubscriptionOptions{
-			CreateHandler: handleDNSModify,
-			ModifyHandler: handleDNSModify,
-			DeleteHandler: handleDNSDelete,
-			WarningTime:   warningTime,
-			ErrorTime:     errorTime,
-		})
+	subDeviceNetworkStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		CreateHandler: handleDNSModify,
+		ModifyHandler: handleDNSModify,
+		DeleteHandler: handleDNSDelete,
+		WarningTime:   warningTime,
+		ErrorTime:     errorTime,
+		TopicImpl:     types.DeviceNetworkStatus{},
+		Ctx:           ctx,
+		AgentName:     "nim",
+	})
 	if err != nil {
 		return err
 	}
 	ctx.subDeviceNetworkStatus = subDeviceNetworkStatus
 	subDeviceNetworkStatus.Activate()
 
-	subGlobalDownloadConfig, err := pubsublegacy.Subscribe("",
-		types.GlobalDownloadConfig{}, false, ctx, &pubsub.SubscriptionOptions{
-			CreateHandler: handleGlobalDownloadConfigModify,
-			ModifyHandler: handleGlobalDownloadConfigModify,
-			WarningTime:   warningTime,
-			ErrorTime:     errorTime,
-		})
+	subGlobalDownloadConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		CreateHandler: handleGlobalDownloadConfigModify,
+		ModifyHandler: handleGlobalDownloadConfigModify,
+		WarningTime:   warningTime,
+		ErrorTime:     errorTime,
+		Ctx:           ctx,
+		TopicImpl:     types.GlobalDownloadConfig{},
+	})
 	if err != nil {
 		return err
 	}
@@ -76,88 +80,109 @@ func (ctx *downloaderContext) registerHandlers() error {
 	// Look for DatastoreConfig. We should process this
 	// before any download config ( App/baseos/cert). Without DataStore Config,
 	// Image Downloads will run into errors.
-	subDatastoreConfig, err := pubsublegacy.Subscribe("zedagent",
-		types.DatastoreConfig{}, false, ctx, &pubsub.SubscriptionOptions{
-			CreateHandler: handleDatastoreConfigModify,
-			ModifyHandler: handleDatastoreConfigModify,
-			DeleteHandler: handleDatastoreConfigDelete,
-			WarningTime:   warningTime,
-			ErrorTime:     errorTime,
-		})
+	subDatastoreConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		CreateHandler: handleDatastoreConfigModify,
+		ModifyHandler: handleDatastoreConfigModify,
+		DeleteHandler: handleDatastoreConfigDelete,
+		WarningTime:   warningTime,
+		ErrorTime:     errorTime,
+		AgentName:     "zedagent",
+		TopicImpl:     types.DatastoreConfig{},
+		Ctx:           ctx,
+	})
 	if err != nil {
 		return err
 	}
 	ctx.subDatastoreConfig = subDatastoreConfig
 	subDatastoreConfig.Activate()
 
-	pubGlobalDownloadStatus, err := pubsublegacy.Publish(agentName,
-		types.GlobalDownloadStatus{})
+	pubGlobalDownloadStatus, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName: agentName,
+		TopicType: types.GlobalDownloadStatus{},
+	})
 	if err != nil {
 		return err
 	}
 	ctx.pubGlobalDownloadStatus = pubGlobalDownloadStatus
 
 	// Set up our publications before the subscriptions so ctx is set
-	pubAppImgStatus, err := pubsublegacy.PublishScope(agentName, types.AppImgObj,
-		types.DownloaderStatus{})
+	pubAppImgStatus, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName:  agentName,
+		AgentScope: types.AppImgObj,
+		TopicType:  types.DownloaderStatus{},
+	})
 	if err != nil {
 		return err
 	}
 	ctx.pubAppImgStatus = pubAppImgStatus
 	pubAppImgStatus.ClearRestarted()
 
-	pubBaseOsStatus, err := pubsublegacy.PublishScope(agentName, types.BaseOsObj,
-		types.DownloaderStatus{})
+	pubBaseOsStatus, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName:  agentName,
+		AgentScope: types.BaseOsObj,
+		TopicType:  types.DownloaderStatus{},
+	})
 	if err != nil {
 		return err
 	}
 	ctx.pubBaseOsStatus = pubBaseOsStatus
 	pubBaseOsStatus.ClearRestarted()
 
-	pubCertObjStatus, err := pubsublegacy.PublishScope(agentName, types.CertObj,
-		types.DownloaderStatus{})
+	pubCertObjStatus, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName:  agentName,
+		AgentScope: types.CertObj,
+		TopicType:  types.DownloaderStatus{},
+	})
 	if err != nil {
 		return err
 	}
 	ctx.pubCertObjStatus = pubCertObjStatus
 	pubCertObjStatus.ClearRestarted()
 
-	subAppImgConfig, err := pubsublegacy.SubscribeScope("zedmanager",
-		types.AppImgObj, types.DownloaderConfig{}, false, ctx, &pubsub.SubscriptionOptions{
-			CreateHandler: handleAppImgCreate,
-			ModifyHandler: handleAppImgModify,
-			DeleteHandler: handleAppImgDelete,
-			WarningTime:   warningTime,
-			ErrorTime:     errorTime,
-		})
+	subAppImgConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		CreateHandler: handleAppImgCreate,
+		ModifyHandler: handleAppImgModify,
+		DeleteHandler: handleAppImgDelete,
+		WarningTime:   warningTime,
+		ErrorTime:     errorTime,
+		AgentName:     "zedmanager",
+		AgentScope:    types.AppImgObj,
+		TopicImpl:     types.DownloaderConfig{},
+		Ctx:           ctx,
+	})
 	if err != nil {
 		return err
 	}
 	ctx.subAppImgConfig = subAppImgConfig
 	subAppImgConfig.Activate()
 
-	subBaseOsConfig, err := pubsublegacy.SubscribeScope("baseosmgr",
-		types.BaseOsObj, types.DownloaderConfig{}, false, ctx, &pubsub.SubscriptionOptions{
-			CreateHandler: handleBaseOsCreate,
-			ModifyHandler: handleBaseOsModify,
-			DeleteHandler: handleBaseOsDelete,
-			WarningTime:   warningTime,
-			ErrorTime:     errorTime,
-		})
+	subBaseOsConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		CreateHandler: handleBaseOsCreate,
+		ModifyHandler: handleBaseOsModify,
+		DeleteHandler: handleBaseOsDelete,
+		WarningTime:   warningTime,
+		ErrorTime:     errorTime,
+		AgentName:     "baseosmgr",
+		AgentScope:    types.BaseOsObj,
+		TopicImpl:     types.DownloaderConfig{},
+	})
 	if err != nil {
 		return err
 	}
 	ctx.subBaseOsConfig = subBaseOsConfig
 	subBaseOsConfig.Activate()
 
-	subCertObjConfig, err := pubsublegacy.SubscribeScope("baseosmgr",
-		types.CertObj, types.DownloaderConfig{}, false, ctx, &pubsub.SubscriptionOptions{
-			CreateHandler: handleCertObjCreate,
-			ModifyHandler: handleCertObjModify,
-			DeleteHandler: handleCertObjDelete,
-			WarningTime:   warningTime,
-			ErrorTime:     errorTime,
-		})
+	subCertObjConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		CreateHandler: handleCertObjCreate,
+		ModifyHandler: handleCertObjModify,
+		DeleteHandler: handleCertObjDelete,
+		WarningTime:   warningTime,
+		ErrorTime:     errorTime,
+		AgentName:     "baseosmgr",
+		AgentScope:    types.CertObj,
+		TopicImpl:     types.DownloaderConfig{},
+		Ctx:           ctx,
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/pillar/cmd/hardwaremodel/hardwaremodel.go
+++ b/pkg/pillar/cmd/hardwaremodel/hardwaremodel.go
@@ -7,13 +7,15 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"log"
+	"os"
+
 	"github.com/lf-edge/eve/pkg/pillar/hardware"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/rackn/gohai/plugins/dmi"
 	"github.com/rackn/gohai/plugins/net"
 	"github.com/rackn/gohai/plugins/storage"
 	"github.com/rackn/gohai/plugins/system"
-	"log"
-	"os"
 )
 
 // Set from Makefile
@@ -51,7 +53,7 @@ func hwFp() {
 	enc.Encode(infos)
 }
 
-func Run() {
+func Run(ps *pubsub.PubSub) {
 	versionPtr := flag.Bool("v", false, "Version")
 	cPtr := flag.Bool("c", false, "No CRLF")
 	hwPtr := flag.Bool("f", false, "Fingerprint hardware")

--- a/pkg/pillar/cmd/identitymgr/identitymgr.go
+++ b/pkg/pillar/cmd/identitymgr/identitymgr.go
@@ -54,7 +54,7 @@ type identityContext struct {
 var debug = false
 var debugOverride bool // From command line arg
 
-func Run() {
+func Run(ps *pubsub.PubSub) {
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")
 	curpartPtr := flag.String("c", "", "Current partition")

--- a/pkg/pillar/cmd/ipcmonitor/ipcmonitor.go
+++ b/pkg/pillar/cmd/ipcmonitor/ipcmonitor.go
@@ -19,14 +19,16 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"net"
 	"strings"
+
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	log "github.com/sirupsen/logrus"
 )
 
 var debugOverride bool // From command line arg
 
-func Run() {
+func Run(ps *pubsub.PubSub) {
 	agentNamePtr := flag.String("a", "zedrouter",
 		"Agent name")
 	agentScopePtr := flag.String("s", "", "agentScope")

--- a/pkg/pillar/cmd/ledmanager/ledmanager.go
+++ b/pkg/pillar/cmd/ledmanager/ledmanager.go
@@ -113,7 +113,7 @@ var debugOverride bool // From command line arg
 // Set from Makefile
 var Version = "No version specified"
 
-func Run() {
+func Run(ps *pubsub.PubSub) {
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug")
 	curpartPtr := flag.String("c", "", "Current partition")

--- a/pkg/pillar/cmd/logmanager/logmanager.go
+++ b/pkg/pillar/cmd/logmanager/logmanager.go
@@ -129,7 +129,7 @@ type zedcloudLogs struct {
 }
 
 // Run is an entry point into running logmanager
-func Run() {
+func Run(ps *pubsub.PubSub) {
 	defaultLogdirname := agentlog.GetCurrentLogdir()
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug")

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -86,7 +86,7 @@ func (ctx *nimContext) processArgs() {
 }
 
 // Run - Main function - invoked from zedbox.go
-func Run() {
+func Run(ps *pubsub.PubSub) {
 	nimCtx := nimContext{
 		fallbackPortMap:  make(map[string]bool),
 		filteredFallback: make(map[string]bool),

--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -126,7 +126,7 @@ func newNodeagentContext() nodeagentContext {
 }
 
 // Run : nodeagent run entry function
-func Run() {
+func Run(ps *pubsub.PubSub) {
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")
 	curpartPtr := flag.String("c", "", "Current partition")

--- a/pkg/pillar/cmd/tpmmgr/tpmmgr.go
+++ b/pkg/pillar/cmd/tpmmgr/tpmmgr.go
@@ -870,7 +870,7 @@ func testEcdhAES() error {
 	return nil
 }
 
-func Run() {
+func Run(ps *pubsub.PubSub) {
 	curpartPtr := flag.String("c", "", "Current partition")
 	debugPtr := flag.Bool("d", false, "Debug flag")
 	flag.Parse()

--- a/pkg/pillar/cmd/vaultmgr/vaultmgr.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgr.go
@@ -434,7 +434,7 @@ func GetOperInfo() (info.DataSecAtRestStatus, string) {
 }
 
 //Run is the entrypoint for running vaultmgr as a standalone program
-func Run() {
+func Run(ps *pubsub.PubSub) {
 
 	curpartPtr := flag.String("c", "", "Current partition")
 	debugPtr := flag.Bool("d", false, "Debug flag")

--- a/pkg/pillar/cmd/verifier/verifier.go
+++ b/pkg/pillar/cmd/verifier/verifier.go
@@ -79,7 +79,7 @@ var debug = false
 var debugOverride bool                                // From command line arg
 var downloadGCTime = time.Duration(600) * time.Second // Unless from GlobalConfig
 
-func Run() {
+func Run(ps *pubsub.PubSub) {
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")
 	curpartPtr := flag.String("c", "", "Current partition")

--- a/pkg/pillar/cmd/waitforaddr/waitforaddr.go
+++ b/pkg/pillar/cmd/waitforaddr/waitforaddr.go
@@ -43,7 +43,7 @@ type DNSContext struct {
 var debug = false
 var debugOverride bool // From command line arg
 
-func Run() {
+func Run(ps *pubsub.PubSub) {
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")
 	curpartPtr := flag.String("c", "", "Current partition")

--- a/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
+++ b/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
@@ -53,7 +53,7 @@ type wstunnelclientContext struct {
 var debug = false
 var debugOverride bool // From command line arg
 
-func Run() {
+func Run(ps *pubsub.PubSub) {
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")
 	curpartPtr := flag.String("c", "", "Current partition")

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -120,7 +120,7 @@ var debug = false
 var debugOverride bool // From command line arg
 var flowQ *list.List
 
-func Run() {
+func Run(ps *pubsub.PubSub) {
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")
 	curpartPtr := flag.String("c", "", "Current partition")

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -64,7 +64,7 @@ var deviceNetworkStatus types.DeviceNetworkStatus
 var debug = false
 var debugOverride bool // From command line arg
 
-func Run() {
+func Run(ps *pubsub.PubSub) {
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")
 	curpartPtr := flag.String("c", "", "Current partition")

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -90,7 +90,7 @@ type zedrouterContext struct {
 var debug = false
 var debugOverride bool // From command line arg
 
-func Run() {
+func Run(ps *pubsub.PubSub) {
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")
 	curpartPtr := flag.String("c", "", "Current partition")

--- a/pkg/pillar/zedbox/zedbox.go
+++ b/pkg/pillar/zedbox/zedbox.go
@@ -26,55 +26,59 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/cmd/zedagent"
 	"github.com/lf-edge/eve/pkg/pillar/cmd/zedmanager"
 	"github.com/lf-edge/eve/pkg/pillar/cmd/zedrouter"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub/socketdriver"
 	"os"
 	"path/filepath"
 )
 
 func main() {
+	ps := pubsub.New(&socketdriver.SocketDriver{})
+
 	basename := filepath.Base(os.Args[0])
 	switch basename {
 	case "client":
-		client.Run()
+		client.Run(ps)
 	case "diag":
-		diag.Run()
+		diag.Run(ps)
 	case "domainmgr":
-		domainmgr.Run()
+		domainmgr.Run(ps)
 	case "downloader":
-		downloader.Run()
+		downloader.Run(ps)
 	case "hardwaremodel":
-		hardwaremodel.Run()
+		hardwaremodel.Run(ps)
 	case "identitymgr":
-		identitymgr.Run()
+		identitymgr.Run(ps)
 	case "ledmanager":
-		ledmanager.Run()
+		ledmanager.Run(ps)
 	case "logmanager":
-		logmanager.Run()
+		logmanager.Run(ps)
 	case "nim":
-		nim.Run()
+		nim.Run(ps)
 	case "nodeagent":
-		nodeagent.Run()
+		nodeagent.Run(ps)
 	case "verifier":
-		verifier.Run()
+		verifier.Run(ps)
 	case "waitforaddr":
-		waitforaddr.Run()
+		waitforaddr.Run(ps)
 	case "zedagent":
-		zedagent.Run()
+		zedagent.Run(ps)
 	case "zedmanager":
-		zedmanager.Run()
+		zedmanager.Run(ps)
 	case "zedrouter":
-		zedrouter.Run()
+		zedrouter.Run(ps)
 	case "ipcmonitor":
-		ipcmonitor.Run()
+		ipcmonitor.Run(ps)
 	case "baseosmgr":
-		baseosmgr.Run()
+		baseosmgr.Run(ps)
 	case "wstunnelclient":
-		wstunnelclient.Run()
+		wstunnelclient.Run(ps)
 	case "conntrack":
-		conntrack.Run()
+		conntrack.Run(ps)
 	case "tpmmgr":
-		tpmmgr.Run()
+		tpmmgr.Run(ps)
 	case "vaultmgr":
-		vaultmgr.Run()
+		vaultmgr.Run(ps)
 	default:
 		fmt.Printf("Unknown package: %s\n", basename)
 	}


### PR DESCRIPTION
As promised, this is the first step in removing `pubsublegacy`. It does three things:

1. Creates an instance of `pubsub.PubSub{}` in the zedbox, i.e. `package main`
1. Passes it to `client.Run()` and adapts `pkg/pillar/cmd/client` to use it
1. Passes it to `downloader.Run()` and adapts `pkg/pillar/cmd/downloader` to use it, as well as passing it to other internal-to-downloader structs as needed.

Obviously, if this passes and is accepted, we will have to repeat for the other agents.

The benefits here are twofold:

* we eliminate the `pkg/pillar/pubsub/legacy` holdover
* we have the various functions inside the agents get a `PubSub` passed to them, which allows us to replace it at will, test with different drivers, etc. In short: decoupling.

cc @kalyan-nidumolu @archishou @rvs @eriknordmark 