### PR TITLE
Add executor of commands, execlib, and command example client

### DIFF
--- a/pkg/pillar/Makefile
+++ b/pkg/pillar/Makefile
@@ -20,7 +20,8 @@ endif
 APPS = zedbox
 APPS1 = logmanager ledmanager downloader verifier client zedrouter domainmgr \
         identitymgr zedmanager zedagent hardwaremodel ipcmonitor nim diag    \
-        baseosmgr wstunnelclient conntrack waitforaddr tpmmgr vaultmgr nodeagent
+        baseosmgr wstunnelclient conntrack waitforaddr tpmmgr vaultmgr nodeagent \
+	executor command
 
 .PHONY: all clean build test build-docker build-docker-git shell
 

--- a/pkg/pillar/cmd/command/command.go
+++ b/pkg/pillar/cmd/command/command.go
@@ -1,0 +1,132 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// A test application for the executor microservice
+// Reads commands and arguments from stdin and prints the output
+
+// Example usage:
+// # echo 'ls -l -R /config' | dist/amd64/command -q
+// /config:
+// total 212
+// -rw-r--r-- 1 nordmark nordmark    664 Aug 21 05:04 device.cert.pem
+// -rw------- 1 nordmark nordmark    227 Aug 21 05:04 device.key.pem
+// -rw-r--r-- 1 root     root       2134 Jan 30 20:04 root-certificate.pem
+// -rw-r--r-- 1 root     root         26 Jan 30 20:03 server
+// -rw-r--r-- 1 root     root     200061 Sep 24 02:45 v2tlsbaseroot-certificates.pem
+//
+// # echo 'ls /x' | dist/amd64/command -q
+// Failed with exit code 2
+// Output:
+//
+// # echo 'ls /x' | dist/amd64/command -c -q
+// Failed with exit code 2
+// Output:
+// ls: cannot access '/x': No such file or directory
+//
+// # echo date | dist/amd64/command -e TZ=CET -q
+// Output:
+// Sat Feb 15 07:51:05 CET 2020
+//
+// # echo 'sleep 5' | dist/amd64/command -t 2 -q
+// Timed out by server. Output:
+//
+// # echo 'ls /x' |  dist/amd64/command -W
+// requested DontWait: no output
+
+package command
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/execlib"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	log "github.com/sirupsen/logrus"
+)
+
+const agentName = "command"
+
+var (
+	timeLimit      uint
+	combinedOutput bool
+	environ        []string
+	dontWait       bool
+)
+
+// Run is the main aka only entrypoint
+func Run(ps *pubsub.PubSub) {
+	// Report nano timestamps
+	formatter := log.JSONFormatter{
+		TimestampFormat: time.RFC3339Nano,
+	}
+	log.SetFormatter(&formatter)
+
+	debugPtr := flag.Bool("d", false, "Debug flag")
+	quietPtr := flag.Bool("q", false, "Quiet flag")
+	timeLimitPtr := flag.Uint("t", 200, "Maximum time to wait for command")
+	combinedPtr := flag.Bool("c", false, "Combine stdout and stderr")
+	environPtr := flag.String("e", "", "set single environment variable with name=val syntax")
+	dontWaitPtr := flag.Bool("W", false, "don't wait for result")
+	flag.Parse()
+	timeLimit = *timeLimitPtr
+	combinedOutput = *combinedPtr
+	dontWait = *dontWaitPtr
+	if *environPtr != "" {
+		// XXX Syntax to add multiple? This is just for testing
+		environ = append(environ, *environPtr)
+	}
+	if *quietPtr {
+		log.SetLevel(log.WarnLevel)
+	} else if *debugPtr {
+		log.SetLevel(log.DebugLevel)
+	} else {
+		log.SetLevel(log.InfoLevel)
+	}
+
+	hdl, err := execlib.New(ps, agentName, "executor")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	r := bufio.NewReader(os.Stdin)
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			if err != io.EOF {
+				fmt.Fprintf(os.Stderr, "Read failed: %s\n", err)
+			}
+			break
+		}
+		tokens := strings.Split(strings.TrimSpace(line), " ")
+		if len(tokens) == 0 {
+			continue
+		}
+		execute(hdl, tokens[0], tokens[1:])
+	}
+}
+
+func execute(hdl *execlib.ExecuteHandle, command string, args []string) {
+	out, err := hdl.Execute(execlib.ExecuteArgs{
+		Command:        command,
+		Args:           args,
+		Environ:        environ,
+		TimeLimit:      timeLimit,
+		CombinedOutput: combinedOutput,
+		DontWait:       dontWait,
+	})
+	if err != nil {
+		fmt.Printf("Failed: %s\n", err)
+		fmt.Printf("Failed output: %s\n", out)
+		return
+	}
+	if dontWait {
+		fmt.Printf("requested DontWait: no output\n")
+	} else {
+		fmt.Printf("Output:\n%s\n", out)
+	}
+}

--- a/pkg/pillar/cmd/executor/exec.go
+++ b/pkg/pillar/cmd/executor/exec.go
@@ -1,0 +1,371 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// A single-threaded way to have other microservices request exec of a command
+// in a different container or VM where this executor runs
+
+package executor
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/agentlog"
+	"github.com/lf-edge/eve/pkg/pillar/pidfile"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	agentName = "executor"
+	// Time limits for event loop handlers
+	errorTime   = 3 * time.Minute
+	warningTime = 40 * time.Second
+)
+
+// Version can be set from Makefile
+var Version = "No version specified"
+
+// Any state used by handlers goes here
+type executorContext struct {
+	subTmpConfig      pubsub.Subscription
+	subCommandConfig  pubsub.Subscription
+	subVerifierConfig pubsub.Subscription
+	subDomainConfig   pubsub.Subscription
+	pubExecStatus     pubsub.Publication
+
+	subGlobalConfig pubsub.Subscription
+	GCInitialized   bool
+
+	// CLI args
+	debug         bool
+	debugOverride bool // From command line arg
+	timeLimit     uint // In seconds
+}
+
+// Run is the main aka only entrypoint
+func Run(ps *pubsub.PubSub) {
+	versionPtr := flag.Bool("v", false, "Version")
+	debugPtr := flag.Bool("d", false, "Debug flag")
+	curpartPtr := flag.String("c", "", "Current partition")
+	timeLimitPtr := flag.Uint("t", 120, "Maximum time to wait for command")
+	flag.Parse()
+	execCtx := executorContext{}
+	execCtx.debug = *debugPtr
+	execCtx.debugOverride = execCtx.debug
+	if execCtx.debugOverride {
+		log.SetLevel(log.DebugLevel)
+	} else {
+		log.SetLevel(log.InfoLevel)
+	}
+	execCtx.timeLimit = *timeLimitPtr
+	curpart := *curpartPtr
+	err := agentlog.Init(agentName, curpart)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if *versionPtr {
+		fmt.Printf("%s: %s\n", os.Args[0], Version)
+		return
+	}
+	if err := pidfile.CheckAndCreatePidfile(agentName); err != nil {
+		log.Fatal(err)
+	}
+	log.Infof("Starting %s\n", agentName)
+
+	// Run a periodic timer so we always update StillRunning
+	stillRunning := time.NewTicker(25 * time.Second)
+	agentlog.StillRunning(agentName, warningTime, errorTime)
+
+	pubExecStatus, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName: agentName,
+		TopicType: types.ExecStatus{},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	execCtx.pubExecStatus = pubExecStatus
+
+	// Look for global config such as log levels
+	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		TopicImpl:     types.GlobalConfig{},
+		Ctx:           &execCtx,
+		CreateHandler: handleGlobalConfigModify,
+		ModifyHandler: handleGlobalConfigModify,
+		DeleteHandler: handleGlobalConfigDelete,
+		WarningTime:   warningTime,
+		ErrorTime:     errorTime,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	execCtx.subGlobalConfig = subGlobalConfig
+	subGlobalConfig.Activate()
+
+	// Pick up debug aka log level before we start real work
+	for !execCtx.GCInitialized {
+		log.Infof("waiting for GCInitialized")
+		select {
+		case change := <-subGlobalConfig.MsgChan():
+			subGlobalConfig.ProcessChange(change)
+		case <-stillRunning.C:
+		}
+		agentlog.StillRunning(agentName, warningTime, errorTime)
+	}
+	log.Infof("processed GlobalConfig")
+
+	subTmpConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		TopicImpl:     types.ExecConfig{},
+		Ctx:           &execCtx,
+		CreateHandler: handleCreate,
+		ModifyHandler: handleModify,
+		DeleteHandler: handleDelete,
+		WarningTime:   warningTime,
+		ErrorTime:     errorTime,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	execCtx.subTmpConfig = subTmpConfig
+	subTmpConfig.Activate()
+
+	subCommandConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:     "command",
+		Ctx:           &execCtx,
+		TopicImpl:     types.ExecConfig{},
+		CreateHandler: handleCreate,
+		ModifyHandler: handleModify,
+		DeleteHandler: handleDelete,
+		WarningTime:   warningTime,
+		ErrorTime:     errorTime,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	execCtx.subCommandConfig = subCommandConfig
+	subCommandConfig.Activate()
+
+	subVerifierConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:     "verifier",
+		Ctx:           &execCtx,
+		TopicImpl:     types.ExecConfig{},
+		CreateHandler: handleCreate,
+		ModifyHandler: handleModify,
+		DeleteHandler: handleDelete,
+		WarningTime:   warningTime,
+		ErrorTime:     errorTime,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	execCtx.subVerifierConfig = subVerifierConfig
+	subVerifierConfig.Activate()
+
+	subDomainConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:     "domainmgr",
+		Ctx:           &execCtx,
+		TopicImpl:     types.ExecConfig{},
+		CreateHandler: handleCreate,
+		ModifyHandler: handleModify,
+		DeleteHandler: handleDelete,
+		WarningTime:   warningTime,
+		ErrorTime:     errorTime,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	execCtx.subDomainConfig = subDomainConfig
+	subDomainConfig.Activate()
+
+	for {
+		select {
+		case change := <-subGlobalConfig.MsgChan():
+			subGlobalConfig.ProcessChange(change)
+
+		case change := <-execCtx.subTmpConfig.MsgChan():
+			execCtx.subTmpConfig.ProcessChange(change)
+		case change := <-execCtx.subCommandConfig.MsgChan():
+			execCtx.subCommandConfig.ProcessChange(change)
+		case change := <-execCtx.subVerifierConfig.MsgChan():
+			execCtx.subVerifierConfig.ProcessChange(change)
+		case change := <-execCtx.subDomainConfig.MsgChan():
+			execCtx.subDomainConfig.ProcessChange(change)
+
+		case <-stillRunning.C:
+		}
+		agentlog.StillRunning(agentName, warningTime, errorTime)
+	}
+}
+
+func handleCreate(ctxArg interface{}, key string,
+	configArg interface{}) {
+
+	execCtx := ctxArg.(*executorContext)
+	config := configArg.(types.ExecConfig)
+	log.Infof("handleCreate(%s.%d) %s",
+		config.Caller, config.Sequence, config.Command)
+	status := launchCmd(execCtx, config)
+	if status != nil {
+		execCtx.pubExecStatus.Publish(status.Key(), *status)
+		log.Infof("handleCreate(%s.%d) Done",
+			config.Caller, config.Sequence)
+	} else {
+		log.Warnf("handleCreate(%s.%d) No status",
+			config.Caller, config.Sequence)
+	}
+}
+
+func handleModify(ctxArg interface{}, key string,
+	configArg interface{}) {
+
+	execCtx := ctxArg.(*executorContext)
+	config := configArg.(types.ExecConfig)
+	status := lookupExecStatus(execCtx, key)
+	if config.Sequence == status.Sequence {
+		log.Infof("handleModify(%s.%d) no change",
+			config.Caller, config.Sequence)
+		return
+	}
+	log.Infof("handleModify(%s.%d) %s",
+		config.Caller, config.Sequence, config.Command)
+	status = launchCmd(execCtx, config)
+	if status != nil {
+		if config.DontWait {
+			log.Infof("handleModify(%s.%d) Done with DontWait",
+				config.Caller, config.Sequence)
+		} else {
+			execCtx.pubExecStatus.Publish(status.Key(), *status)
+			log.Infof("handleModify(%s.%d) Done",
+				config.Caller, config.Sequence)
+		}
+	} else {
+		log.Infof("handleModify(%s.%d) No status",
+			config.Caller, config.Sequence)
+	}
+}
+
+func handleDelete(ctxArg interface{}, key string,
+	configArg interface{}) {
+
+	execCtx := ctxArg.(*executorContext)
+	config := configArg.(types.ExecConfig)
+	log.Infof("handleDelete(%s.%d) %s",
+		config.Caller, config.Sequence, config.Command)
+	status := lookupExecStatus(execCtx, key)
+	if status != nil {
+		execCtx.pubExecStatus.Unpublish(status.Key())
+		log.Infof("handleDelete(%s.%d) Done",
+			config.Caller, config.Sequence)
+	} else {
+		log.Warnf("handleDelete(%s.%d) No status",
+			config.Caller, config.Sequence)
+	}
+}
+
+func lookupExecStatus(execCtx *executorContext, key string) *types.ExecStatus {
+	s, _ := execCtx.pubExecStatus.Get(key)
+	if s == nil {
+		return nil
+	}
+	status := s.(types.ExecStatus)
+	return &status
+}
+
+func launchCmd(execCtx *executorContext, config types.ExecConfig) *types.ExecStatus {
+	log.Infof("launchCmd %+v", config)
+	status := types.ExecStatus{
+		Caller:   config.Caller,
+		Sequence: config.Sequence,
+	}
+	timeLimit := execCtx.timeLimit
+	if config.TimeLimit != 0 && config.TimeLimit < timeLimit {
+		timeLimit = config.TimeLimit
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(),
+		time.Duration(timeLimit)*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, config.Command, config.Args...)
+	cmd.Env = config.Environ
+	var out []byte
+	var err error
+	if config.Combined {
+		out, err = cmd.CombinedOutput()
+	} else {
+		out, err = cmd.Output()
+	}
+	if ctx.Err() == context.DeadlineExceeded {
+		log.Warnf("Exceeded time limit %d", timeLimit)
+		status.TimedOut = true
+		status.Output = string(out)
+		return &status
+	}
+	if err != nil {
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			// The program has exited with an exit code != 0
+			if exitStatus, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+				log.Infof("Exit code: %d", exitStatus.ExitStatus())
+				status.ExitValue = exitStatus.ExitStatus()
+			} else {
+				log.Warnf("No exitStatus but %T: %s",
+					exiterr.Sys(), exiterr.Sys())
+				if config.Combined {
+					status.Output = err.Error()
+				}
+				status.ExitValue = -2
+			}
+		} else {
+			log.Warnf("No exitError but %T: %s", err, err)
+			if config.Combined {
+				status.Output = err.Error()
+			}
+			status.ExitValue = -1
+		}
+		status.Output = string(out)
+		return &status
+	}
+	status.Output = string(out)
+	log.Infof("Succeeded %+v", status)
+	return &status
+}
+
+// Handles both create and modify events
+func handleGlobalConfigModify(ctxArg interface{}, key string,
+	statusArg interface{}) {
+
+	execCtx := ctxArg.(*executorContext)
+	if key != "global" {
+		log.Infof("handleGlobalConfigModify: ignoring %s\n", key)
+		return
+	}
+	log.Infof("handleGlobalConfigModify for %s\n", key)
+	var gcp *types.GlobalConfig
+	execCtx.debug, gcp = agentlog.HandleGlobalConfig(execCtx.subGlobalConfig, agentName,
+		execCtx.debugOverride)
+	if gcp != nil {
+		execCtx.GCInitialized = true
+	}
+	log.Infof("handleGlobalConfigModify done for %s\n", key)
+}
+
+func handleGlobalConfigDelete(ctxArg interface{}, key string,
+	statusArg interface{}) {
+
+	execCtx := ctxArg.(*executorContext)
+	if key != "global" {
+		log.Infof("handleGlobalConfigDelete: ignoring %s\n", key)
+		return
+	}
+	log.Infof("handleGlobalConfigDelete for %s\n", key)
+	execCtx.debug, _ = agentlog.HandleGlobalConfig(execCtx.subGlobalConfig, agentName,
+		execCtx.debugOverride)
+	log.Infof("handleGlobalConfigDelete done for %s\n", key)
+}

--- a/pkg/pillar/execlib/execlib.go
+++ b/pkg/pillar/execlib/execlib.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// A client package which talks to the executor service
+// Call init first to set up pubsub
+// Note that the executor must be setup to subscribe to us for the commands.
+
+package execlib
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	log "github.com/sirupsen/logrus"
+)
+
+// ExecuteHandle is returned by New and passed to the Execute function
+type ExecuteHandle struct {
+	// Private fields
+	caller        string
+	executor      string
+	pubExecConfig pubsub.Publication
+	subExecStatus pubsub.Subscription
+	sequence      int
+	matchedStatus types.ExecStatus
+}
+
+// ExecuteArgs is passed for each command
+type ExecuteArgs struct {
+	Command        string
+	Args           []string
+	Environ        []string
+	TimeLimit      uint // In seconds
+	CombinedOutput bool // If set stderr and stdout are in output
+	DontWait       bool // Do not wait for response
+}
+
+// New returns the handle to use with Execute
+func New(ps *pubsub.PubSub, agentName string, executor string) (*ExecuteHandle, error) {
+
+	pubExecConfig, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName: agentName,
+		TopicType: types.ExecConfig{},
+	})
+	pubExecConfig.Unpublish(agentName)
+
+	// Start with a random number in case the process as run before
+	// and used some sequence
+	now := time.Now()
+	_, _, seed := now.Clock()
+	seed += now.Nanosecond()
+	rand.Seed(int64(seed))
+	sequence := rand.Int()
+
+	handle := ExecuteHandle{
+		caller:        agentName,
+		executor:      executor,
+		pubExecConfig: pubExecConfig,
+		sequence:      sequence,
+	}
+	subExecStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:     "executor",
+		TopicImpl:     types.ExecStatus{},
+		Ctx:           &handle,
+		CreateHandler: handleStatus,
+		ModifyHandler: handleStatus,
+	})
+	if err != nil {
+		return nil, err
+	}
+	handle.subExecStatus = subExecStatus
+	subExecStatus.Activate()
+
+	return &handle, nil
+}
+
+// Execute runs a command and waits for response unless DontWait is set
+func (hdl *ExecuteHandle) Execute(args ExecuteArgs) (string, error) {
+
+	config := types.ExecConfig{
+		Caller:    hdl.caller,
+		Sequence:  hdl.sequence,
+		Command:   args.Command,
+		Args:      args.Args,
+		Environ:   args.Environ,
+		TimeLimit: args.TimeLimit,
+		Combined:  args.CombinedOutput,
+		DontWait:  args.DontWait,
+	}
+	log.Infof("publish %+v", config)
+	hdl.pubExecConfig.Publish(config.Key(), config)
+	if args.DontWait {
+		return "", nil
+	}
+	// wait for result
+	// Fixed local timer; remote should honor timeLimit
+	duration := 10 * time.Minute
+	maxTimer := time.NewTimer(duration)
+	for hdl.matchedStatus.Sequence != hdl.sequence {
+		select {
+		case change := <-hdl.subExecStatus.MsgChan():
+			hdl.subExecStatus.ProcessChange(change)
+
+		case <-maxTimer.C:
+			err := errors.New("Local time out; is server broken?")
+			return "", err
+		}
+	}
+	status := hdl.matchedStatus
+	if status.TimedOut {
+		err := fmt.Errorf("Timed out by server")
+		return status.Output, err
+	}
+	if status.ExitValue != 0 {
+		err := fmt.Errorf("Failed with exit code %d", status.ExitValue)
+		return status.Output, err
+	}
+	return status.Output, nil
+}
+
+func handleStatus(ctxArg interface{}, key string,
+	statusArg interface{}) {
+
+	hdl := ctxArg.(*ExecuteHandle)
+	log.Infof("handleStatus %s", key)
+	if key != hdl.caller {
+		log.Infof("Mismatched key %s vs %s\n", key, hdl.caller)
+		return
+	}
+	status := statusArg.(types.ExecStatus)
+	if status.Sequence != hdl.sequence {
+		log.Infof("Mismatched sequence %d vs %d\n",
+			status.Sequence, hdl.sequence)
+		return
+	}
+	hdl.matchedStatus = status
+}

--- a/pkg/pillar/types/exectypes.go
+++ b/pkg/pillar/types/exectypes.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Types for a remote exec (in different container or VM) pubsub service
+
+package types
+
+import (
+	log "github.com/sirupsen/logrus"
+)
+
+// ExecConfig contains a command to be executed
+// The Caller+Sequence is assumed to be unique. When an item is added or
+// modified in Caller or Sequence, the command is executed.
+type ExecConfig struct {
+	Caller    string // Typically agentName
+	Sequence  int    // To be able to repeat same command
+	Command   string
+	Args      []string
+	Environ   []string
+	TimeLimit uint // In seconds; zero means server default
+	Combined  bool // Combined Ouput - stdout and stderr
+	DontWait  bool // Caller doesn't want result
+}
+
+// Key returns the pubsub key
+func (config ExecConfig) Key() string {
+	return config.Caller
+}
+
+// VerifyFilename returns a json filename
+func (config ExecConfig) VerifyFilename(fileName string) bool {
+	expect := config.Key() + ".json"
+	ret := expect == fileName
+	if !ret {
+		log.Errorf("Mismatch between filename and contained Key: %s vs. %s\n",
+			fileName, expect)
+	}
+	return ret
+}
+
+// ExecStatus contains the results of executing a command
+// The Caller+Sequence is the unique Key
+type ExecStatus struct {
+	Caller    string // Typically agentName
+	Sequence  int    // To be able to repeat same command
+	ExitValue int
+	Output    string
+	TimedOut  bool // Exceeded timeout
+}
+
+// Key returns the pubsub key
+func (status ExecStatus) Key() string {
+	return status.Caller
+}
+
+// VerifyFilename returns a json filename
+func (status ExecStatus) VerifyFilename(fileName string) bool {
+	expect := status.Key() + ".json"
+	ret := expect == fileName
+	if !ret {
+		log.Errorf("Mismatch between filename and contained Key: %s vs. %s\n",
+			fileName, expect)
+	}
+	return ret
+}

--- a/pkg/pillar/zedbox/zedbox.go
+++ b/pkg/pillar/zedbox/zedbox.go
@@ -10,10 +10,12 @@ import (
 
 	"github.com/lf-edge/eve/pkg/pillar/cmd/baseosmgr"
 	"github.com/lf-edge/eve/pkg/pillar/cmd/client"
+	"github.com/lf-edge/eve/pkg/pillar/cmd/command"
 	"github.com/lf-edge/eve/pkg/pillar/cmd/conntrack"
 	"github.com/lf-edge/eve/pkg/pillar/cmd/diag"
 	"github.com/lf-edge/eve/pkg/pillar/cmd/domainmgr"
 	"github.com/lf-edge/eve/pkg/pillar/cmd/downloader"
+	"github.com/lf-edge/eve/pkg/pillar/cmd/executor"
 	"github.com/lf-edge/eve/pkg/pillar/cmd/hardwaremodel"
 	"github.com/lf-edge/eve/pkg/pillar/cmd/identitymgr"
 	"github.com/lf-edge/eve/pkg/pillar/cmd/ipcmonitor"
@@ -35,9 +37,11 @@ import (
 
 var entrypoints = map[string]func(*pubsub.PubSub){
 	"client":         client.Run,
+	"command":        command.Run,
 	"diag":           diag.Run,
 	"domainmgr":      domainmgr.Run,
 	"downloader":     downloader.Run,
+	"executor":       executor.Run,
 	"hardwaremodel":  hardwaremodel.Run,
 	"identitymgr":    identitymgr.Run,
 	"ledmanager":     ledmanager.Run,
@@ -65,5 +69,6 @@ func main() {
 		entrypoint(ps)
 	} else {
 		fmt.Printf("Unknown package: %s\n", basename)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
@rvs If this executor works for you (see example calls in command.go), then I can add it.
Note that every command runs in the foreground with a timelimit.

The execlib.New and exevlib.Execute is used by the example command.go to show how to use this.