### PR TITLE
Introduce new PersistImageConfig/Status to handle garbage collection of images

### DIFF
--- a/pkg/pillar/cmd/verifier/handlepersist.go
+++ b/pkg/pillar/cmd/verifier/handlepersist.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2017-2018 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Handlers for PersistImageConfig
+
+package verifier
+
+import (
+	"os"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	log "github.com/sirupsen/logrus"
+)
+
+// Track the RefCount on the Persist object
+func handlePersistCreate(ctx *verifierContext, objType string,
+	config *types.PersistImageConfig) {
+
+	log.Infof("handlePersistCreate(%s) objType %s for %s\n",
+		config.ImageSha256, objType, config.Name)
+	if objType == "" {
+		log.Fatalf("handlePersistCreate: No ObjType for %s\n",
+			config.ImageSha256)
+	}
+
+	status := types.PersistImageStatus{
+		VerifyStatus: types.VerifyStatus{
+			Name:        config.Name,
+			ObjType:     objType,
+			ImageSha256: config.ImageSha256,
+		},
+		RefCount: config.RefCount,
+		LastUse:  time.Now(),
+	}
+	publishPersistImageStatus(ctx, &status)
+	log.Infof("handlePersistCreate done for %s\n", config.Name)
+}
+
+// Track RefCount on persistent object
+func handlePersistModify(ctx *verifierContext, config *types.PersistImageConfig,
+	status *types.PersistImageStatus) {
+
+	changed := false
+	log.Infof("handlePersistModify(%s) objType %s for %s, config.RefCount: %d, "+
+		"status.RefCount: %d",
+		status.ImageSha256, status.ObjType, config.Name, config.RefCount,
+		status.RefCount)
+
+	if status.ObjType == "" {
+		log.Fatalf("handlePersistModify: No ObjType for %s\n",
+			status.ImageSha256)
+	}
+
+	// Always update RefCount
+	if status.RefCount != config.RefCount {
+		log.Infof("handlePersistModify RefCount change %s from %d to %d Expired %v\n",
+			config.Name, status.RefCount, config.RefCount,
+			status.Expired)
+		status.RefCount = config.RefCount
+		status.Expired = false
+		changed = true
+	}
+
+	if status.RefCount == 0 {
+		// GC timer will clean up by marking status Expired
+		// and some point in time.
+		// Then user (zedmanager/baseosmgr) will delete config.
+		status.LastUse = time.Now()
+		changed = true
+	}
+
+	if changed {
+		publishPersistImageStatus(ctx, status)
+	}
+	log.Infof("handlePersistModify done for %s. Status.RefCount=%d, Expired=%t",
+		config.Name, status.RefCount, status.Expired)
+}
+
+func handlePersistDelete(ctx *verifierContext, status *types.PersistImageStatus) {
+
+	log.Infof("handlePersistDelete(%s) objType %s refcount %d lastUse %v Expired %v\n",
+		status.ImageSha256, status.ObjType, status.RefCount,
+		status.LastUse, status.Expired)
+
+	if status.ObjType == "" {
+		log.Fatalf("handlePersistDelete: No ObjType for %s\n",
+			status.ImageSha256)
+	}
+
+	// No more use for this image. Delete
+	verifiedDirname := status.ImageDownloadDirName()
+	_, err := os.Stat(verifiedDirname)
+	if err == nil {
+		if _, err := os.Stat(preserveFilename); err != nil {
+			log.Infof("doDelete removing %s\n", verifiedDirname)
+			if err := os.RemoveAll(verifiedDirname); err != nil {
+				log.Fatal(err)
+			}
+		} else {
+			log.Infof("doDelete preserving %s\n", verifiedDirname)
+		}
+	}
+
+	unpublishPersistImageStatus(ctx, status)
+	log.Infof("handlePersistDelete done for %s\n", status.ImageSha256)
+}

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -1051,8 +1051,8 @@ func handleVerifierStatusDelete(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
 	status := statusArg.(types.VerifyImageStatus)
-	log.Infof("handleVeriferStatusDelete RefCount %d Expired %v for %s\n",
-		status.RefCount, status.Expired, key)
+	log.Infof("handleVeriferStatusDelete RefCount %d for %s\n",
+		status.RefCount, key)
 	// Nothing to do
 }
 

--- a/pkg/pillar/types/verifiertypes.go
+++ b/pkg/pillar/types/verifiertypes.go
@@ -22,18 +22,26 @@ import (
 // dom0 has moved the image file to a read-only directory before asking
 // for the file to be verified.
 
+// VerifyImageConfig captures the verifications which have been requested.
 // The key/index to this is the ImageID which is allocated by the controller.
+// The ImageSha256 may not be known when the VerifyImageConfig is created
 type VerifyImageConfig struct {
-	ImageID          uuid.UUID // UUID of the image
-	Name             string
+	ImageID uuid.UUID // UUID of the image
+	VerifyConfig
+	IsContainer bool // Is this image for a Container?
+	RefCount    uint
+}
+
+// VerifyConfig is shared between VerifyImageConfig and PersistImageConfig
+type VerifyConfig struct {
 	ImageSha256      string // sha256 of immutable image
-	RefCount         uint
+	Name             string
 	CertificateChain []string //name of intermediate certificates
 	ImageSignature   []byte   //signature of image
 	SignatureKey     string   //certificate containing public key
-	IsContainer      bool     // Is this image for a Container?
 }
 
+// Key returns the pubsub Key
 func (config VerifyImageConfig) Key() string {
 	return config.ImageID.String()
 }
@@ -48,26 +56,48 @@ func (config VerifyImageConfig) VerifyFilename(fileName string) bool {
 	return ret
 }
 
-// The key/index to this is the ImageID which comes from VerifyImageConfig.
+// PersistImageConfig captures the images which already exists in /persist
+// e.g., from before a reboot. Normally these become requested with a
+// VerifyImageConfig, or are garbage collected.
+// The key is the ImageSha256. The existence of a VerifyImageConfig means
+// the client does not want to to be garbage collected. See handshake using
+// the Expired boolean in PersistImageStatus
+type PersistImageConfig struct {
+	VerifyConfig
+	RefCount uint
+}
+
+// Key returns the pubsub Key
+func (config PersistImageConfig) Key() string {
+	return config.ImageSha256
+}
+
+// VerifyImageStatus captures the verifications which have been requested.
+// The key/index to this is the ImageID if known otherwise the ImageSha256
+// The sha can come from the verified filename
 type VerifyImageStatus struct {
-	ImageID       uuid.UUID // UUID of the image
-	Name          string
-	ObjType       string
+	ImageID uuid.UUID // UUID of the image if known
+	VerifyStatus
 	PendingAdd    bool
 	PendingModify bool
 	PendingDelete bool
-	FileLocation  string  // Current location; should be info about file
 	IsContainer   bool    // Is this image for a Container?
-	ImageSha256   string  // sha256 of immutable image
 	State         SwState // DELIVERED; LastErr* set if failed
 	LastErr       string  // Verification error
 	LastErrTime   time.Time
-	Size          int64
 	RefCount      uint
-	LastUse       time.Time // When RefCount dropped to zero
-	Expired       bool      // Handshake to client
 }
 
+// The VerifyStatus is shared between VerifyImageStatus and PersistImageStatus
+type VerifyStatus struct {
+	ImageSha256  string // sha256 of immutable image
+	Name         string
+	ObjType      string
+	FileLocation string // Current location; should be info about file
+	Size         int64
+}
+
+// Key returns the pubsub Key
 func (status VerifyImageStatus) Key() string {
 	return status.ImageID.String()
 }
@@ -80,6 +110,21 @@ func (status VerifyImageStatus) VerifyFilename(fileName string) bool {
 			fileName, expect)
 	}
 	return ret
+}
+
+// PersistImageStatus captures the images which already exists in /persist
+// The key/index to this is the ImageSha256
+// The sha comes from the verified filename
+type PersistImageStatus struct {
+	VerifyStatus
+	RefCount uint
+	LastUse  time.Time // When RefCount dropped to zero
+	Expired  bool      // Handshake to client to ask for permission to delete
+}
+
+// Key returns the pubsub Key
+func (status PersistImageStatus) Key() string {
+	return status.ImageSha256
 }
 
 // ImageDownloadDirNames - Returns pendingDirname, verifierDirname, verifiedDirname
@@ -123,4 +168,11 @@ func (status VerifyImageStatus) CheckPendingDelete() bool {
 
 func (status VerifyImageStatus) Pending() bool {
 	return status.PendingAdd || status.PendingModify || status.PendingDelete
+}
+
+// ImageDownloadDirName - Returns verifiedDirname
+// for the image.
+func (status PersistImageStatus) ImageDownloadDirName() string {
+	downloadDirname := DownloadDirname + "/" + status.ObjType
+	return downloadDirname + "/verified/" + status.ImageSha256
 }


### PR DESCRIPTION
The bug is that we no longer garbage collect unused app images and base images, since the code in the verifier assumes the directory name contains a UUID and they only contain a sha.

Fixing this was a bit complex since we want to track the verified objects are named by their sha, even for containers where the sha is determined as part of the verification.

The fix is to introduce PersistImageConfig/Status structs which carry the interaction between the verifier and its clients when it comes to the verified images discovered after reboot, and also the garbage collect handshake  between the verifier and its clients. (using the Expired flag)

Prior to making the containers and VMs being identified by the imageID, we had the VMs being identified by the sha in VerifyImageConfig/Status and the containers being identified by having a zero sha in those structs. Then some intermediate state where we used imageID, then switching completely to imageID. The GC hasn't worked since we moved the VM images to be identified by imageID and not having the imageID in the verified directory name; at an intermediate state we had both imageID and sha in the directory name hence GC worked.