### PR TITLE
Container instance purge and restart mechanism

### DIFF
--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -657,17 +657,8 @@ func handleModify(ctxArg interface{}, key string,
 			status.PurgeCmd.Counter, config.PurgeCmd.Counter,
 			needPurge)
 		status.PurgeCmd.Counter = config.PurgeCmd.Counter
-		if status.IsContainer {
-			status.RestartInprogress = types.BRING_DOWN
-			status.State = types.RESTARTING
-			uuidtonum.UuidToNumAllocate(ctx.pubUuidToNum,
-				status.UUIDandVersion.UUID,
-				int(status.PurgeCmd.Counter),
-				false, "purgeCmdCounter")
-		} else {
-			status.PurgeInprogress = types.DOWNLOAD
-			status.State = types.PURGING
-		}
+		status.PurgeInprogress = types.DOWNLOAD
+		status.State = types.PURGING
 		// We persist the PurgeCmd Counter when PurgeInprogress is done
 	}
 	status.UUIDandVersion = config.UUIDandVersion

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -657,8 +657,17 @@ func handleModify(ctxArg interface{}, key string,
 			status.PurgeCmd.Counter, config.PurgeCmd.Counter,
 			needPurge)
 		status.PurgeCmd.Counter = config.PurgeCmd.Counter
-		status.PurgeInprogress = types.DOWNLOAD
-		status.State = types.PURGING
+		if status.IsContainer {
+			status.RestartInprogress = types.BRING_DOWN
+			status.State = types.RESTARTING
+			uuidtonum.UuidToNumAllocate(ctx.pubUuidToNum,
+				status.UUIDandVersion.UUID,
+				int(status.PurgeCmd.Counter),
+				false, "purgeCmdCounter")
+		} else {
+			status.PurgeInprogress = types.DOWNLOAD
+			status.State = types.PURGING
+		}
 		// We persist the PurgeCmd Counter when PurgeInprogress is done
 	}
 	status.UUIDandVersion = config.UUIDandVersion


### PR DESCRIPTION
Currently, container bootable disks are read-only so basically there will
be a no-op for container instances in case of purge/restart. We are
not unpublishing the domain config for containers we simply deactivating
it and in doActivate MayBeAddDomainConfig will update the config if there
are any changes.

Signed-off-by: zed-rishabh <rgupta@zededa.com>