### PR TITLE
[WIP] move vaultmgr/ fscrypt to storage-init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,6 +262,8 @@ pkg/qrexec-dom0: pkg/qrexec-lib pkg/xen-tools eve-qrexec-dom0
 	@true
 pkg/qrexec-lib: pkg/xen-tools eve-qrexec-lib
 	@true
+pkg/storage-init: pkg/pillar eve-storage-init
+	@true
 pkg/%: eve-% FORCE
 	@true
 

--- a/pkg/lisp/Dockerfile
+++ b/pkg/lisp/Dockerfile
@@ -43,7 +43,8 @@ RUN apk add --no-cache \
         python=2.7.15-r3   \
         openssl=1.0.2u-r0  \
         iproute2=4.13.0-r0 \
-        tini=0.18.0-r0
+        tini=0.18.0-r0     \
+        keyutils=1.5.10-r0
 
 COPY --from=lisp /lisp /lisp/
 COPY --from=lisp /usr/bin/pydoc /usr/bin/smtpd.py /usr/bin/

--- a/pkg/lisp/rootfs/init.sh
+++ b/pkg/lisp/rootfs/init.sh
@@ -18,11 +18,25 @@ tail -f logs/lisp-flow.log &
 # don't get EOF, but rather block)
 sh -c 'kill -STOP $$' 3>>logs/lisp-traceback.log 4>>logs/lisp-flow.log &
 
+#Link user keyring with session keyring of this container, to access fscrypt keys
+keyctl link @u @s
+
+# XXX Remove this when we have move to subscribing to GlobalStatus and not GlobalConfig
+# ls the content of /persist to a file
+logPersist() {
+    myfile=/persist/log/lisp.ls
+    echo "$(date -Is -u) Content of /persist at $1" >>$myfile
+    ls -lR /persist >>$myfile
+    echo "$(date -Is -u) Done with content of /persist at $1" >>$myfile
+}
+
+logPersist "Pre-check"
 # Need to wait for /persist/config to be decrypted by tpmmgr in the pillar container
 # XXX Remove this when we have move to subscribing to GlobalStatus and not GlobalConfig
 while [ ! -d /persist/config/GlobalConfig ]; do
     echo "Waiting for /persist/config/GlobalConfig"
     sleep 10
+    logPersist "Waited"
 done
 
 # run lisp main loop
@@ -39,9 +53,11 @@ while true; do
      # shellcheck disable=SC1091
      (. lisp.config.sh ; /lisp/RUN-LISP 8080 "$LISP_PORT_IFNAME")
 
+     logPersist "Restarting LISP"
      # start EVE's own dataplane
      /lisp/lisp-ztr -c "${EVE_ID:-IMGX}" -lisp /lisp &
      touch /run/watchdog/pid/lisp-ztr.pid
+     logPersist "Restarted LISP"
   fi
 
   sleep 30

--- a/pkg/pillar/rootfs/init.sh
+++ b/pkg/pillar/rootfs/init.sh
@@ -12,4 +12,8 @@ for i in $(cd /sys/class/net || return ; echo eth*) ; do
 done
 
 echo 'Starting device-steps'
+
+#Link user keyring with session keyring of this container, to access fscrypt keys
+keyctl link @u @s
+
 /opt/zededa/bin/device-steps.sh

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -124,15 +124,6 @@ if [ ! -d $LOGDIRB ]; then
     mkdir -p $LOGDIRB
 fi
 
-P3=$(/hostfs/sbin/findfs PARTLABEL=P3)
-P3_FS_TYPE=$(blkid "$P3"| awk '{print $3}' | sed 's/TYPE=//' | sed 's/"//g')
-if [ -c $TPM_DEVICE_PATH ] && ! [ -f $CONFIGDIR/disable-tpm ] && [ "$P3_FS_TYPE" = "ext4" ]; then
-    #It is a device with TPM, and formatted with ext4, setup fscrypt
-    echo "$(date -Ins -u) EXT4 partitioned $PERSISTDIR, enabling fscrypt"
-    #Initialize fscrypt algorithm, hash length etc.
-    $BINDIR/vaultmgr -c "$CURPART" setupVaults
-fi
-
 # FIXME: remove these two once we get rid of rkt (or move it to xen-tools)
 if [ ! -d "$PERSIST_RKT_DATA_DIR" ]; then
     echo "$(date -Ins -u) Create $PERSIST_RKT_DATA_DIR"

--- a/pkg/storage-init/Dockerfile
+++ b/pkg/storage-init/Dockerfile
@@ -1,9 +1,0 @@
-FROM alpine:3.10.3
-WORKDIR /
-# hadolint ignore=DL3018
-RUN apk add --no-cache bash glib squashfs-tools util-linux e2fsprogs \
-        e2fsprogs-extra keyutils dosfstools coreutils
-COPY storage-init.sh /storage-init.sh
-
-ENTRYPOINT []
-CMD ["/storage-init.sh"]

--- a/pkg/storage-init/Dockerfile.in
+++ b/pkg/storage-init/Dockerfile.in
@@ -1,0 +1,12 @@
+FROM PILLAR_TAG as pillar
+FROM alpine:3.10.3
+WORKDIR /
+# hadolint ignore=DL3018
+RUN apk add --no-cache bash glib squashfs-tools util-linux e2fsprogs \
+        e2fsprogs-extra keyutils dosfstools coreutils libpcap-dev
+COPY storage-init.sh /storage-init.sh
+COPY --from=pillar /opt/zededa/bin/fscrypt /usr/bin/fscrypt
+COPY --from=pillar /opt/zededa/bin/vaultmgr /usr/bin/vaultmgr
+
+ENTRYPOINT []
+CMD ["/storage-init.sh"]

--- a/pkg/xen-tools/Dockerfile.in
+++ b/pkg/xen-tools/Dockerfile.in
@@ -58,7 +58,9 @@ RUN apk add --no-cache \
     glib=2.56.1-r1     \
     pixman=0.34.0-r5   \
     yajl=2.1.0-r0      \
-    xz-libs=5.2.4-r0
+    xz-libs=5.2.4-r0   \
+    keyutils=1.5.10-r0
+
 RUN if [ "$(uname -m)" = "aarch64" ]; then apk add --no-cache libfdt=1.4.4-r0 ;fi
 COPY --from=kernel-build /out/ /
 COPY --from=uefi-build /OVMF.fd /usr/lib/xen/boot/ovmf.bin

--- a/pkg/xen-tools/init.sh
+++ b/pkg/xen-tools/init.sh
@@ -7,6 +7,9 @@ if [ -d /proc/xen/ ]; then
    mkdir -p /var/log/xen
    mkfifo /var/log/xen/xen-hotplug.log
 
+   #Link user keyring with session keyring of this container, to access fscrypt keys
+   keyctl link @u @s
+
    # start collecting logs (make sure that FIFO remains alway open for
    # writing - so readers don't get EOF, but rather block)
    tail -f /var/log/xen/xen-hotplug.log &


### PR DESCRIPTION
- This is required to make sure fscrypt runs on the native ext4 fs, and not over bind-mounts
- add user keys to session keys for every service container that needs access to the vaults
- vaultmgr as a service still exists inside pillar, to report oper status to zedagent.

Signed-off-by: Hariharasubramanian C S <cshari@zededa.com>