### PR TITLE
Making root (uid 0) keychain available in containers

### DIFF
--- a/pkg/lisp/Dockerfile
+++ b/pkg/lisp/Dockerfile
@@ -43,6 +43,7 @@ RUN apk add --no-cache \
         python=2.7.15-r3   \
         openssl=1.0.2u-r0  \
         iproute2=4.13.0-r0 \
+        keyutils=1.5.10-r0 \
         tini=0.18.0-r0
 
 COPY --from=lisp /lisp /lisp/

--- a/pkg/lisp/rootfs/init.sh
+++ b/pkg/lisp/rootfs/init.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# FIXME: this will need to be absorbed by containerd/shim
+keyctl link @u @s
+
 EVE_ID="$(cat /run/eve.id 2>/dev/null)"
 
 cd /lisp || exit 1

--- a/pkg/xen-tools/Dockerfile.in
+++ b/pkg/xen-tools/Dockerfile.in
@@ -58,6 +58,7 @@ RUN apk add --no-cache \
     glib=2.56.1-r1     \
     pixman=0.34.0-r5   \
     yajl=2.1.0-r0      \
+    keyutils=1.5.10-r0 \
     xz-libs=5.2.4-r0
 RUN if [ "$(uname -m)" = "aarch64" ]; then apk add --no-cache libfdt=1.4.4-r0 ;fi
 COPY --from=kernel-build /out/ /

--- a/pkg/xen-tools/init.sh
+++ b/pkg/xen-tools/init.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# FIXME: this will need to be absorbed by containerd/shim
+keyctl link @u @s
+
 if [ -d /proc/xen/ ]; then
    echo "Xen hypervisor support detected"
 


### PR DESCRIPTION
This is an attempt at a much simpler workaround that would allow us to have to time to do the right thing with #659 