### PR TITLE
1. Map un-recognized log levels (err, emerg -> error, notice -> info)

### DIFF
--- a/pkg/rsyslog/rsyslog.conf
+++ b/pkg/rsyslog/rsyslog.conf
@@ -64,6 +64,7 @@ if $parsesuccess == "FAIL" then {
                Port="5140"
                Protocol="tcp"
                template="nonJsonOutput"
+               ResendLastMSGOnReconnect="on"
                queue.size="1000" queue.type="LinkedList")
 } else {
     *.* action(type="omfwd"
@@ -72,6 +73,7 @@ if $parsesuccess == "FAIL" then {
                Port="5140"
                Protocol="tcp"
                template="jsonOutput"
+               ResendLastMSGOnReconnect="on"
                queue.size="1000" queue.type="LinkedList")
 }
 


### PR DESCRIPTION
2. Logmanager already handles deferring log send to cloud when network connectivity is lost. Add an additional test to verify if the current DeviceNetworkStatus works before we resume re-trying deferred logs.

With this code, I unplugged eth from an e50 and kept it unplugged for about 17 hours. Rsyslogd accumulated about 400+ MB of logs in it's queues. The next morning I plugged eth back and saw logs flowing to cloud from where it left. But, it takes a long long time for the device to export all these queued logs. Approximately 1 hour per 100MB of logs.

Signed-off-by: GopiKrishna Kodali <gkodali@zededa.com>