### PR TITLE
Latch container image sha for AppUUID/imageID to avoid re-download of containers on boot

### DIFF
--- a/pkg/pillar/cmd/verifier/handlepersist.go
+++ b/pkg/pillar/cmd/verifier/handlepersist.go
@@ -93,12 +93,12 @@ func handlePersistDelete(ctx *verifierContext, status *types.PersistImageStatus)
 	_, err := os.Stat(verifiedDirname)
 	if err == nil {
 		if _, err := os.Stat(preserveFilename); err != nil {
-			log.Infof("doDelete removing %s\n", verifiedDirname)
+			log.Infof("handlePersistDelete removing %s\n", verifiedDirname)
 			if err := os.RemoveAll(verifiedDirname); err != nil {
 				log.Fatal(err)
 			}
 		} else {
-			log.Infof("doDelete preserving %s\n", verifiedDirname)
+			log.Infof("handlePersistDelete preserving %s\n", verifiedDirname)
 		}
 	}
 

--- a/pkg/pillar/cmd/zedmanager/appandimage.go
+++ b/pkg/pillar/cmd/zedmanager/appandimage.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Interact with the persistent mapping from AppUUID, ImageID to sha of the
+// image
+
+package zedmanager
+
+import (
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	uuid "github.com/satori/go.uuid"
+	log "github.com/sirupsen/logrus"
+)
+
+// Add or update
+func addAppAndImageHash(ctx *zedmanagerContext, appUUID uuid.UUID, imageID uuid.UUID, hash string) {
+	log.Infof("addAppAndImageHash(%s, %s, %s)", appUUID, imageID, hash)
+	if hash == "" {
+		log.Errorf("addAppAndImageHash(%s, %s) empty hash",
+			appUUID, imageID)
+		return
+	}
+	aih := types.AppAndImageToHash{
+		AppUUID: appUUID,
+		ImageID: imageID,
+		Hash:    hash,
+	}
+	item, _ := ctx.pubAppAndImageToHash.Get(aih.Key())
+	if item != nil {
+		old := item.(types.AppAndImageToHash)
+		if old.Hash == aih.Hash {
+			log.Warnf("addAppAndImageHash(%s, %s) no change %s",
+				appUUID, imageID, old.Hash)
+			return
+		}
+		log.Warnf("addAppAndImageHash(%s, %s) change from %s to %s",
+			appUUID, imageID, old.Hash, aih.Hash)
+	}
+	ctx.pubAppAndImageToHash.Publish(aih.Key(), aih)
+	log.Infof("addAppAndImageHash(%s, %s, %s) done", appUUID, imageID, hash)
+}
+
+// Delete for a specific image
+func deleteAppAndImageHash(ctx *zedmanagerContext, appUUID uuid.UUID, imageID uuid.UUID) {
+	log.Infof("deleteAppAndImageHash(%s, %s)", appUUID, imageID)
+	aih := types.AppAndImageToHash{
+		AppUUID: appUUID,
+		ImageID: imageID,
+	}
+	item, _ := ctx.pubAppAndImageToHash.Get(aih.Key())
+	if item == nil {
+		log.Errorf("deleteAppAndImageHash(%s, %s) not found",
+			appUUID, imageID)
+		return
+	}
+	ctx.pubAppAndImageToHash.Unpublish(aih.Key())
+	log.Infof("deleteAppAndImageHash(%s, %s) done", appUUID, imageID)
+}
+
+// Purge all for appUUID
+func purgeAppAndImageHash(ctx *zedmanagerContext, appUUID uuid.UUID) {
+
+	log.Infof("purgeAppAndImageHash(%s)", appUUID)
+	items := ctx.pubAppAndImageToHash.GetAll()
+	for _, a := range items {
+		aih := a.(types.AppAndImageToHash)
+		log.Errorf("purgeAppAndImageHash(%s) deleting %s hash %s",
+			appUUID, aih.ImageID, aih.Hash)
+		ctx.pubAppAndImageToHash.Unpublish(aih.Key())
+	}
+	log.Infof("purgeAppAndImageHash(%s) done", appUUID)
+}
+
+// Returns "" string if not found
+func lookupAppAndImageHash(ctx *zedmanagerContext, appUUID uuid.UUID, imageID uuid.UUID) string {
+	log.Infof("lookupAppAndImageHash(%s, %s)", appUUID, imageID)
+	temp := types.AppAndImageToHash{
+		AppUUID: appUUID,
+		ImageID: imageID,
+	}
+	item, _ := ctx.pubAppAndImageToHash.Get(temp.Key())
+	if item == nil {
+		log.Infof("lookupAppAndImageHash(%s, %s) not found",
+			appUUID, imageID)
+		return ""
+	}
+	aih := item.(types.AppAndImageToHash)
+	log.Infof("lookupAppAndImageHash(%s, %s) found %s",
+		appUUID, imageID, aih.Hash)
+	return aih.Hash
+}

--- a/pkg/pillar/cmd/zedmanager/handleverifier.go
+++ b/pkg/pillar/cmd/zedmanager/handleverifier.go
@@ -192,21 +192,32 @@ func updatePersistImageConfig(ctx *zedmanagerContext, imageSha string) {
 	var refcount uint
 	sub := ctx.subAppImgVerifierStatus
 	items := sub.GetAll()
+	name := ""
 	for _, s := range items {
 		status := s.(types.VerifyImageStatus)
 		if status.ImageSha256 == imageSha {
 			log.Infof("Adding RefCount %d from %s to %s",
 				status.RefCount, status.ImageID, imageSha)
 			refcount += status.RefCount
+			name = status.Name
 		}
 	}
 	config := lookupPersistImageConfig(ctx, imageSha)
 	if config == nil {
 		log.Errorf("updatePersistImageConfig(%s): config not found",
 			imageSha)
-		return
-	}
-	if config.RefCount == refcount {
+		if refcount == 0 {
+			return
+		}
+		n := types.PersistImageConfig{
+			VerifyConfig: types.VerifyConfig{
+				Name:        name,
+				ImageSha256: imageSha,
+			},
+			RefCount: 0,
+		}
+		config = &n
+	} else if config.RefCount == refcount {
 		log.Infof("updatePersistImageConfig(%s): no RefCount change %d",
 			imageSha, refcount)
 		return

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -191,7 +191,8 @@ func checkDiskSize(ctxPtr *zedmanagerContext) error {
 		appDiskSize, diskSizeList, err := utils.GetDiskSizeForAppInstance(iterStatus)
 		if err != nil {
 			log.Errorf("checkDiskSize: err: %s", err.Error())
-			return err
+			// Assume application is going down and its disks
+			// are going away.
 		}
 		totalAppDiskSize += appDiskSize
 		appDiskSizeList += fmt.Sprintf("App: %s (Size: %d)\n%s\n",

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -453,3 +453,17 @@ type SignatureInfo struct {
 	SignerCertPem        []byte
 	Signature            []byte
 }
+
+// AppAndImageToHash is used to retain <app,image> to sha maps across reboots.
+// Key for OCI images which can be specified with a tag and we need to be
+// able to latch the sha and choose when to update/refresh from the tag.
+type AppAndImageToHash struct {
+	AppUUID uuid.UUID
+	ImageID uuid.UUID
+	Hash    string
+}
+
+// Key is used for pubsub
+func (aih AppAndImageToHash) Key() string {
+	return fmt.Sprintf("%s.%s", aih.AppUUID.String(), aih.ImageID.String())
+}


### PR DESCRIPTION
This is a step towards avoid downloading containers each time we boot. 
If we then have the verified SHA object in /persist/downloads/appImg/verified/ we will not re-download after a boot.
