### PR TITLE
add manifest size to reported total filesize

### DIFF
--- a/pkg/pillar/zedUpload/ociutil/common.go
+++ b/pkg/pillar/zedUpload/ociutil/common.go
@@ -1,11 +1,13 @@
 package ociutil
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	v1tarball "github.com/google/go-containerregistry/pkg/v1/tarball"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -56,13 +58,30 @@ func manifestsDescImg(image string, options []remote.Option) (name.Reference, *r
 		return ref, desc, img, manifestDirect, manifestResolved, size, fmt.Errorf("error getting resolved manifest object: %v", err)
 	}
 
+	cfgName := manifest.Config.Digest
+	layerFiles := make([]string, 0)
+
 	// size starts at the default of 0
 	// add the size of the config
 	size += manifest.Config.Size
-	// next the layers and their sizes
+
+	// next the layers and their sizes, along with filenames for the manifest
 	for _, layer := range manifest.Layers {
 		size += layer.Size
+		layerFiles = append(layerFiles, fmt.Sprintf("%s.tar.gz", layer.Digest))
 	}
+
+	// get our manifestFile that will be added, convert to bytes, get size
+	manifestFile := v1tarball.Descriptor{
+		Config:   cfgName.String(),
+		RepoTags: []string{image},
+		Layers:   layerFiles,
+	}
+	manifestFileBytes, err := json.Marshal(manifestFile)
+	if err != nil {
+		return ref, desc, img, manifestDirect, manifestResolved, size, fmt.Errorf("error converting tar manifest file to json: %v", err)
+	}
+	size += int64(len(manifestFileBytes))
 
 	return ref, desc, img, manifestDirect, manifestResolved, size, nil
 }


### PR DESCRIPTION
As requested by @ zed-rishabh, the reported file size is too small, since the download library also writes the manifest. This adds calculation of the manifest to the reported size, so that the final size should be correct.

It only is an interim measure, until we can get the upstream library to support it natively.