### PR TITLE
missing setting reboot reason resulting in false alarm about unknown

### DIFF
--- a/pkg/pillar/cmd/baseosmgr/baseosmgr.go
+++ b/pkg/pillar/cmd/baseosmgr/baseosmgr.go
@@ -75,8 +75,8 @@ type baseOsMgrContext struct {
 	subBaseOsVerifierStatus  pubsub.Subscription
 	subBaseOsPersistStatus   pubsub.Subscription
 	subNodeAgentStatus       pubsub.Subscription
-	rebootReason             string
-	rebootTime               time.Time
+	rebootReason             string    // From last reboot
+	rebootTime               time.Time // From last reboot
 }
 
 var debug = false

--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -89,11 +89,12 @@ type nodeagentContext struct {
 	testInprogress         bool
 	timeTickCount          uint32
 	usableAddressCount     int
-	rebootCmd              bool
+	rebootCmd              bool // Are we rebooting?
 	deviceReboot           bool
-	rebootReason           string
-	rebootStack            string
-	rebootTime             time.Time
+	currentRebootReason    string    // Reason we are rebooting
+	rebootReason           string    // From last reboot
+	rebootStack            string    // From last reboot
+	rebootTime             time.Time // From last reboot
 	restartCounter         uint32
 
 	// Some contants.. Declared here as variables to enable unit tests
@@ -527,13 +528,13 @@ func handleLastRebootReason(ctx *nodeagentContext) {
 	ctx.rebootReason, ctx.rebootTime, rebootStack =
 		agentlog.GetCurrentRebootReason()
 	if ctx.rebootReason != "" {
-		log.Warnf("Current partition rebooted reason: %s\n",
+		log.Warnf("Current partition RebootReason: %s\n",
 			ctx.rebootReason)
 		agentlog.DiscardCurrentRebootReason()
 	}
 	otherRebootReason, otherRebootTime, otherRebootStack := agentlog.GetOtherRebootReason()
 	if otherRebootReason != "" {
-		log.Warnf("Other partition rebooted reason: %s\n",
+		log.Warnf("Other partition RebootReason: %s\n",
 			otherRebootReason)
 		// if other partition state is "inprogress"
 		// do not erase the reboot reason, going to
@@ -544,7 +545,7 @@ func handleLastRebootReason(ctx *nodeagentContext) {
 	}
 	commonRebootReason, commonRebootTime, commonRebootStack := agentlog.GetCommonRebootReason()
 	if commonRebootReason != "" {
-		log.Warnf("Common rebooted reason: %s\n",
+		log.Warnf("Common RebootReason: %s\n",
 			commonRebootReason)
 		agentlog.DiscardCommonRebootReason()
 	}
@@ -573,7 +574,7 @@ func handleLastRebootReason(ctx *nodeagentContext) {
 			reason = fmt.Sprintf("Unknown reboot reason - power failure or crash - at %s\n",
 				dateStr)
 		}
-		log.Warnf(reason)
+		log.Warnf("Default RebootReason: %s", reason)
 		ctx.rebootReason = reason
 		ctx.rebootTime = time.Now()
 		rebootStack = ""

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -462,7 +462,7 @@ func publishZedAgentStatus(getconfigCtx *getconfigContext) {
 		Name:            agentName,
 		ConfigGetStatus: getconfigCtx.configGetStatus,
 		RebootCmd:       ctx.rebootCmd,
-		RebootReason:    ctx.rebootReason,
+		RebootReason:    ctx.currentRebootReason,
 	}
 	pub := getconfigCtx.pubZedAgentStatus
 	pub.Publish(agentName, status)

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -2240,7 +2240,8 @@ func handleRebootCmd(ctxPtr *zedagentContext, infoStr string) {
 	// shutdown the application instances
 	shutdownAppsGlobal(ctxPtr)
 	getconfigCtx := ctxPtr.getconfigCtx
-	ctxPtr.rebootReason = infoStr
+	ctxPtr.currentRebootReason = infoStr
+
 	publishZedAgentStatus(getconfigCtx)
 	log.Infof(infoStr)
 }

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -106,9 +106,10 @@ type zedagentContext struct {
 	rebootCmd                 bool
 	rebootCmdDeferred         bool
 	deviceReboot              bool
-	rebootReason              string
-	rebootStack               string
-	rebootTime                time.Time
+	currentRebootReason       string    // Set by zedagent
+	rebootReason              string    // Previous reboot from nodeagent
+	rebootStack               string    // Previous reboot from nodeagent
+	rebootTime                time.Time // Previous reboot from nodeagent
 	restartCounter            uint32
 	subDevicePortConfigList   pubsub.Subscription
 	devicePortConfigList      types.DevicePortConfigList

--- a/pkg/pillar/types/zedagenttypes.go
+++ b/pkg/pillar/types/zedagenttypes.go
@@ -242,9 +242,9 @@ type NodeAgentStatus struct {
 	UpdateInprogress  bool
 	RemainingTestTime time.Duration
 	DeviceReboot      bool
-	RebootReason      string
-	RebootStack       string
-	RebootTime        time.Time
+	RebootReason      string    // From last reboot
+	RebootStack       string    // From last reboot
+	RebootTime        time.Time // From last reboot
 	RestartCounter    uint32
 }
 
@@ -269,7 +269,7 @@ type ZedAgentStatus struct {
 	Name            string
 	ConfigGetStatus ConfigGetStatus
 	RebootCmd       bool
-	RebootReason    string
+	RebootReason    string // Current reason to reboot
 }
 
 // Key :


### PR DESCRIPTION
We see some cases of Unknown reason; power failure or crash.
Caught one case of this when the device was running the test suite and the logs show that node agent was processing the NORMAL reboot string.
Turns out that the system is confusing the reboot state (reason, time, and stack) which is read from the system on start and refers to the reason it went down, with zedagent telling nodeagent the reason that it should reboot now. This mixup means that the reason string can be cleared as things are racing.

@srinibas-zededa please take a look