### PR TITLE
Reduce logging bandwith; Downgrade some log statements to debu

### DIFF
--- a/pkg/pillar/cmd/client/parseuuid.go
+++ b/pkg/pillar/cmd/client/parseuuid.go
@@ -29,13 +29,10 @@ func parseConfig(configUrl string, resp *http.Response, contents []byte) (uuid.U
 	}
 
 	if resp.StatusCode == http.StatusNotModified {
-		log.Infof("StatusNotModified")
-		if len(contents) > 0 {
-			log.Infof("XXX StatusNotModified with len %d",
-				len(contents))
-		}
-		// Signal as error since we are not returning any useful values.
-		return devUUID, hardwaremodel, enterprise, name, fmt.Errorf("Unchanged StatusNotModified")
+		log.Debugf("StatusNotModified len %d", len(contents))
+		// Return as error since we are not returning any useful values.
+		return devUUID, hardwaremodel, enterprise, name,
+			fmt.Errorf("Unchanged StatusNotModified")
 	}
 
 	configResponse, err := readConfigResponseProtoMessage(contents)
@@ -45,14 +42,10 @@ func parseConfig(configUrl string, resp *http.Response, contents []byte) (uuid.U
 	}
 	hash := configResponse.GetConfigHash()
 	if hash == prevConfigHash {
-		log.Infof("Same ConfigHash %s", hash)
-		if len(contents) > 0 {
-			// XXX controller should omit full content
-			log.Infof("XXX same hash %s with len %d",
-				hash, len(contents))
-		}
-		// Signal as error since we are not returning any useful values.
-		return devUUID, hardwaremodel, enterprise, name, fmt.Errorf("Unchanged config hash")
+		log.Debugf("Same ConfigHash %s len %d", hash, len(contents))
+		// Return as error since we are not returning any useful values.
+		return devUUID, hardwaremodel, enterprise, name,
+			fmt.Errorf("Unchanged config hash")
 	}
 	log.Infof("Change in ConfigHash from %s to %s", prevConfigHash, hash)
 	prevConfigHash = hash

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -839,11 +839,7 @@ func parsePrint(configURL string, resp *http.Response, contents []byte) {
 	}
 
 	if resp.StatusCode == http.StatusNotModified {
-		log.Infof("StatusNotModified")
-		if len(contents) > 0 {
-			log.Infof("XXX StatusNotModified with len %d",
-				len(contents))
-		}
+		log.Debugf("StatusNotModified len %d", len(contents))
 		return
 	}
 
@@ -854,12 +850,7 @@ func parsePrint(configURL string, resp *http.Response, contents []byte) {
 	}
 	hash := configResponse.GetConfigHash()
 	if hash == prevConfigHash {
-		log.Infof("Same ConfigHash")
-		if len(contents) > 0 {
-			// XXX controller should omit full content
-			log.Infof("XXX len %d hash %s",
-				len(contents), hash)
-		}
+		log.Debugf("Same ConfigHash len %d", len(contents))
 		return
 	}
 	log.Infof("Change in ConfigHash from %s to %s", prevConfigHash, hash)

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -388,12 +388,7 @@ func generateConfigRequest() ([]byte, *zconfig.ConfigRequest, error) {
 func readConfigResponseProtoMessage(resp *http.Response, contents []byte) (bool, *zconfig.EdgeDevConfig, error) {
 
 	if resp.StatusCode == http.StatusNotModified {
-		log.Debugf("StatusNotModified")
-		if len(contents) > 0 {
-			// XXX controller should omit full content
-			log.Infof("XXX StatusNotModified with len %d",
-				len(contents))
-		}
+		log.Debugf("StatusNotModified len %d", len(contents))
 		return false, nil, nil
 	}
 
@@ -405,12 +400,7 @@ func readConfigResponseProtoMessage(resp *http.Response, contents []byte) (bool,
 	}
 	hash := configResponse.GetConfigHash()
 	if hash == prevConfigHash {
-		log.Debugf("Same ConfigHash %s", hash)
-		if len(contents) > 0 {
-			// XXX controller should omit full content
-			log.Infof("XXX same hash %s with len %d",
-				hash, len(contents))
-		}
+		log.Debugf("Same ConfigHash %s len %d", hash, len(contents))
 		return false, nil, nil
 	}
 	log.Debugf("Change in ConfigHash from %s to %s", prevConfigHash, hash)

--- a/pkg/pillar/cmd/zedrouter/flowstats.go
+++ b/pkg/pillar/cmd/zedrouter/flowstats.go
@@ -151,7 +151,7 @@ func FlowStatsCollect(ctx *zedrouterContext) {
 			return
 		}
 
-		log.Infof("***FlowStats(%d): device=%v, size of the flows %d\n", proto, devUUID, len(connT))
+		log.Debugf("***FlowStats(%d): device=%v, size of the flows %d\n", proto, devUUID, len(connT))
 
 		for _, entry := range connT { // loop through and process current timedout flow collection
 
@@ -166,7 +166,7 @@ func FlowStatsCollect(ctx *zedrouterContext) {
 		}
 	}
 
-	log.Infof("FlowStats ++ Total timedout flows %d, loopcount debug %d\n", totalFlow, loopcount)
+	log.Debugf("FlowStats ++ Total timedout flows %d, loopcount debug %d\n", totalFlow, loopcount)
 	loopcount++
 
 	// per app/bridge packing flow stats to be uploaded

--- a/pkg/pillar/cmd/zedrouter/probe.go
+++ b/pkg/pillar/cmd/zedrouter/probe.go
@@ -304,7 +304,7 @@ func launchHostProbe(ctx *zedrouterContext) {
 	nhPing := make(map[string]bool)
 	localDown := make(map[string]bool)
 	remoteProbe := make(map[string]map[string]probeRes)
-	log.Infof("launchHostProbe: enter\n")
+	log.Debugf("launchHostProbe: enter\n")
 	dpub := ctx.subDeviceNetworkStatus
 	ditems := dpub.GetAll()
 
@@ -462,7 +462,7 @@ func probeCheckStatus(status *types.NetworkInstanceStatus) {
 		if currIntf != "" {
 			if currinfo, ok := status.PInfo[currIntf]; ok {
 				numOfUps = infoUpCount(currinfo)
-				log.Infof("probeCheckStatus: level %d, currintf %s, num Ups %d\n", c, currIntf, numOfUps)
+				log.Debugf("probeCheckStatus: level %d, currintf %s, num Ups %d\n", c, currIntf, numOfUps)
 			}
 		}
 		if numOfUps > 0 {
@@ -633,7 +633,7 @@ func getProbeRatio(netstatus *types.NetworkInstanceStatus) uint32 {
 func probeProcessReply(info *types.ProbeInfo, gotReply bool, latency int64, isLocal bool) bool {
 	var stateChange bool
 	if isLocal {
-		log.Infof("probeProcessReply: intf %s, gw up %v, sucess count %d, down count %d, got reply %v\n",
+		log.Debugf("probeProcessReply: intf %s, gw up %v, sucess count %d, down count %d, got reply %v\n",
 			info.IfName, info.GatewayUP, info.SuccessCnt, info.FailedCnt, gotReply)
 		if gotReply {
 			// fast convergence treatment for local ping, if the intf has stayed down for a while

--- a/pkg/pillar/devicenetwork/devicenetwork.go
+++ b/pkg/pillar/devicenetwork/devicenetwork.go
@@ -79,7 +79,7 @@ func IsProxyConfigEmpty(proxyConfig types.ProxyConfig) bool {
 func VerifyDeviceNetworkStatus(status types.DeviceNetworkStatus,
 	retryCount int, timeout uint32) (bool, error) {
 
-	log.Infof("VerifyDeviceNetworkStatus() %d\n", retryCount)
+	log.Debugf("VerifyDeviceNetworkStatus() %d\n", retryCount)
 	// Check if it is 1970 in which case we declare success since
 	// our certificates will not work until NTP has brought the time
 	// forward.
@@ -107,7 +107,7 @@ func VerifyDeviceNetworkStatus(status types.DeviceNetworkStatus,
 	// Get device serial number
 	zedcloudCtx.DevSerial = hardware.GetProductSerial()
 	zedcloudCtx.DevSoftSerial = hardware.GetSoftSerial()
-	log.Infof("NIM Get Device Serial %s, Soft Serial %s\n", zedcloudCtx.DevSerial,
+	log.Debugf("NIM Get Device Serial %s, Soft Serial %s\n", zedcloudCtx.DevSerial,
 		zedcloudCtx.DevSoftSerial)
 
 	tlsConfig, err := zedcloud.GetTlsConfig(zedcloudCtx.DeviceNetworkStatus, serverName,

--- a/pkg/pillar/devicenetwork/wpad.go
+++ b/pkg/pillar/devicenetwork/wpad.go
@@ -21,7 +21,7 @@ func CheckAndGetNetworkProxy(deviceNetworkStatus *types.DeviceNetworkStatus,
 	ifname := status.IfName
 	proxyConfig := &status.ProxyConfig
 
-	log.Infof("CheckAndGetNetworkProxy(%s): enable %v, url %s\n",
+	log.Debugf("CheckAndGetNetworkProxy(%s): enable %v, url %s\n",
 		ifname, proxyConfig.NetworkProxyEnable,
 		proxyConfig.NetworkProxyURL)
 

--- a/pkg/pillar/pubsub/legacy/legacy.go
+++ b/pkg/pillar/pubsub/legacy/legacy.go
@@ -12,7 +12,7 @@ var (
 
 // Publish create a `Publication` for the given agent name and topic type.
 func Publish(agentName string, topicType interface{}) (pubsub.Publication, error) {
-	log.Infof("legacy.Publish agentName(%s)", agentName)
+	log.Debugf("legacy.Publish agentName(%s)", agentName)
 	return defaultPubsub.NewPublication(pubsub.PublicationOptions{
 		AgentName: agentName,
 		TopicType: topicType,

--- a/pkg/pillar/pubsub/publish.go
+++ b/pkg/pillar/pubsub/publish.go
@@ -187,7 +187,7 @@ func (pub *PublicationImpl) updatersNotify(name string) {
 func (pub *PublicationImpl) populate() {
 	name := pub.nameString()
 
-	log.Infof("populate(%s)\n", name)
+	log.Debugf("populate(%s)\n", name)
 
 	pairs, restarted, err := pub.driver.Load()
 	if err != nil {
@@ -205,7 +205,7 @@ func (pub *PublicationImpl) populate() {
 		pub.km.key.Store(key, item)
 	}
 	pub.km.restarted = restarted
-	log.Infof("populate(%s) done\n", name)
+	log.Debugf("populate(%s) done\n", name)
 }
 
 // go routine which runs the AF_UNIX server.

--- a/pkg/pillar/pubsub/pubsub.go
+++ b/pkg/pillar/pubsub/pubsub.go
@@ -160,7 +160,7 @@ func (p *PubSub) NewPublication(options PublicationOptions) (Publication, error)
 	// create the driver
 	name := pub.nameString()
 	global := options.AgentName == ""
-	log.Infof("publishImpl agentName(%s), agentScope(%s), topic(%s), nameString(%s), global(%v), persistent(%v)\n",
+	log.Debugf("publishImpl agentName(%s), agentScope(%s), topic(%s), nameString(%s), global(%v), persistent(%v)\n",
 		options.AgentName, options.AgentScope, topic, name, global, options.Persistent)
 	driver, err := p.driver.Publisher(global, name, topic, options.Persistent, p.updaterList, pub, pub)
 	if err != nil {
@@ -172,7 +172,7 @@ func (p *PubSub) NewPublication(options PublicationOptions) (Publication, error)
 	if log.GetLevel() == log.DebugLevel {
 		pub.dump("after populate")
 	}
-	log.Infof("Publish(%s)\n", name)
+	log.Debugf("Publish(%s)\n", name)
 
 	pub.publisher()
 

--- a/pkg/pillar/pubsub/socketdriver/publish.go
+++ b/pkg/pillar/pubsub/socketdriver/publish.go
@@ -59,7 +59,7 @@ func (s *Publisher) Load() (map[string][]byte, bool, error) {
 	foundRestarted := false
 	items := make(map[string][]byte)
 
-	log.Infof("Load(%s)\n", s.name)
+	log.Debugf("Load(%s)\n", s.name)
 
 	files, err := ioutil.ReadDir(dirName)
 	if err != nil {
@@ -85,11 +85,11 @@ func (s *Publisher) Load() (map[string][]byte, bool, error) {
 			continue
 		}
 
-		log.Infof("populate found key %s file %s\n", key, statusFile)
+		log.Debugf("Load found key %s file %s\n", key, statusFile)
 
 		sb, err := ioutil.ReadFile(statusFile)
 		if err != nil {
-			log.Errorf("populate: %s for %s\n", err, statusFile)
+			log.Errorf("Load: %s for %s\n", err, statusFile)
 			continue
 		}
 		items[key] = sb

--- a/pkg/pillar/pubsub/socketdriver/subscribe.go
+++ b/pkg/pillar/pubsub/socketdriver/subscribe.go
@@ -100,7 +100,10 @@ func (s *Subscriber) connectAndRead() (string, string, []byte) {
 			if err != nil {
 				errStr := fmt.Sprintf("connectAndRead(%s): Dial failed %s",
 					s.name, err)
-				log.Warnln(errStr)
+				// During startup and after a publisher has
+				// exited we get these failures; treat
+				// as debug
+				log.Debugln(errStr)
 				time.Sleep(10 * time.Second)
 				continue
 			}

--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -153,7 +153,7 @@ func VerifyAllIntf(ctx ZedCloudContext,
 			}
 			switch resp.StatusCode {
 			case http.StatusOK, http.StatusCreated:
-				log.Infof("VerifyAllIntf: Zedcloud reachable via interface %s", intf)
+				log.Debugf("VerifyAllIntf: Zedcloud reachable via interface %s", intf)
 				intfSuccessCount += 1
 			default:
 				errStr := fmt.Sprintf("Uplink test FAILED via %s to URL %s with "+

--- a/pkg/rsyslog/monitor-rsyslog.sh
+++ b/pkg/rsyslog/monitor-rsyslog.sh
@@ -93,7 +93,7 @@ do
             echo "Started rsyslogd again with pid $RSYSLOG_PID"
         fi
     fi
-    if [ -n "$PID" ]; then
-        echo "rsyslogd running with pid $PID"
+    if [ -z "$PID" ]; then
+        echo "rsyslogd NOT running"
     fi
 done


### PR DESCRIPTION
A device running EVE 4.9.1 with 2 app instances (and no changes) for a couple of hours on average had log traffic of 317MByte/hour
(this is with info-level remote logging)

To compare, the metrics used160kByte/hour and the config 75kByte/hour (the latter is inflated due to polling for config changed every 5 seconds which is a lot lower than the default).

So this PR makes the periodic/background logging into Debug (and in one case inverts the log to the error case)