### PR TITLE
set kernel.softlockup_panic

### DIFF
--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -627,7 +627,14 @@ func handleInit(runDirname string) {
 	// ipsets which are independent of config
 	createDefaultIpset()
 
+	// sysctl not related to networking, but keep with rest
 	_, err := wrap.Command("sysctl", "-w",
+		"kernel.softlockup_panic=1").Output()
+	if err != nil {
+		log.Fatal("Failed setting kernel.softlockup_panic ", err)
+	}
+
+	_, err = wrap.Command("sysctl", "-w",
 		"net.ipv4.ip_forward=1").Output()
 	if err != nil {
 		log.Fatal("Failed setting ip_forward ", err)


### PR DESCRIPTION
For devices which do not have a Linux hardware watchdog driver, or no hardware watchdog at all, it seems useful to force a panic when the kernel locks up.