### PR TITLE
Add statusNotModified return for SendOnIntf

### DIFF
--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -443,6 +443,9 @@ func SendOnIntf(ctx ZedCloudContext, destUrl string, intf string, reqlen int64, 
 		case http.StatusCreated:
 			log.Debugf("SendOnIntf to %s StatusCreated\n", reqUrl)
 			return resp, contents, false, nil
+		case http.StatusNotModified:
+			log.Debugf("SendOnIntf to %s StatusNotModified\n", reqUrl)
+			return resp, contents, false, nil
 		default:
 			errStr := fmt.Sprintf("sendOnIntf to %s reqlen %d statuscode %d %s",
 				reqUrl, reqlen, resp.StatusCode,


### PR DESCRIPTION
As mentioned in https://github.com/lf-edge/adam/pull/5#issuecomment-591943847 EVE does not pass StatusNotModified response from method SendOnIntf (required by [myPost](https://github.com/lf-edge/eve/blob/43cf0e139d280f561764e5b5b97bc0be00689320/pkg/pillar/cmd/client/client.go#L466)).
After this modification it is possible to return StatusNotModified from adam.

lf-edge/adam#5
Signed-off-by: giggsoff <giggsoff@gmail.com> 
