### PR TITLE
Remove check of Content-Type for empty response

### DIFF
--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -282,7 +282,10 @@ func getLatestConfig(url string, iteration int,
 }
 
 func validateConfigMessage(url string, r *http.Response) error {
-
+	//No check Content-Type for empty response
+	if r.ContentLength == 0 {
+		return nil
+	}
 	var ctTypeStr = "Content-Type"
 	var ctTypeProtoStr = "application/x-proto-binary"
 


### PR DESCRIPTION
Response 401 (StatusNotModified) removes the Content-Type from response [server.go](https://github.com/golang/go/blob/cd9fd640db419ec81026945eb4f22bfe5ff5a27f/src/net/http/server.go#L1392). So, Content-Type must not break validateConfigMessage for empty response.

Signed-off-by: giggsoff <giggsoff@gmail.com>