### PR TITLE
[DO NOT MERGE] Prepare container rootfs with containerdPrepare method

### DIFF
--- a/pkg/pillar/cmd/domainmgr/containerd.go
+++ b/pkg/pillar/cmd/domainmgr/containerd.go
@@ -183,13 +183,13 @@ func ctrCreate(ctrdCtx context.Context, ctrdClient *containerd.Client, container
 		log.Errorf("Could not build new containerd container: %v. %v", containerID, err.Error())
 		return fmt.Errorf("ctrCreate: Could not build new containerd container: %v. %v", containerID, err.Error())
 	}
-	imageConfigJson, err := getImageInfoJSON(ctrdCtx, ctrdImage)
+	imageConfigJSON, err := getImageInfoJSON(ctrdCtx, ctrdImage)
 	if err != nil {
 		container.Delete(ctrdCtx)
 		log.Errorf("Could not build json of image: %v. %v", ctrdImage.Name(), err.Error())
 		return fmt.Errorf("ctrCreate: Could not build json of image: %v. %v", ctrdImage.Name(), err.Error())
 	}
-	err = createBundle(ctrdCtx, ctrdClient, container, containerSnapshot, imageConfigJson)
+	err = createBundle(ctrdCtx, ctrdClient, container, containerSnapshot, imageConfigJSON)
 	if err != nil {
 		container.Delete(ctrdCtx)
 		deleteBundle(containerID)
@@ -347,7 +347,7 @@ func getContainerInfo(ctrdCtx context.Context, container containerd.Container) (
 }
 
 //createBundle - assigns a UUID and creates a bundle for container's rootFs
-func createBundle(ctrdCtx context.Context, ctrdClient *containerd.Client, container containerd.Container, snapshotName, imageConfigJson string) error {
+func createBundle(ctrdCtx context.Context, ctrdClient *containerd.Client, container containerd.Container, snapshotName, imageConfigJSON string) error {
 	appDir := getContainerPath(container.ID())
 	rootFsDir := path.Join(appDir, containerRootfsPath)
 	//rootFsDir := getContainerRootfs(container.ID())
@@ -367,7 +367,7 @@ func createBundle(ctrdCtx context.Context, ctrdClient *containerd.Client, contai
 	if err != nil {
 		return fmt.Errorf("Exception while writing container info to %v/%v. %v", appDir, containerConfigFilename, err)
 	}
-	err = ioutil.WriteFile(filepath.Join(appDir, imageConfigFilename), []byte(imageConfigJson), 0666)
+	err = ioutil.WriteFile(filepath.Join(appDir, imageConfigFilename), []byte(imageConfigJSON), 0666)
 	if err != nil {
 		return fmt.Errorf("Exception while writing image info to %v/%v. %v", appDir, imageConfigFilename, err)
 	}
@@ -472,8 +472,8 @@ func executeShellCommands(commands []*command) ([]string, error) {
 	return results, nil
 }
 
-func deleteBundle(containerId string) {
-	os.RemoveAll(getContainerPath(containerId))
+func deleteBundle(containerID string) {
+	os.RemoveAll(getContainerPath(containerID))
 }
 
 func isContainerNotFound(e error) bool {

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -9,7 +9,6 @@
 package domainmgr
 
 import (
-	"bytes"
 	"encoding/base64"
 	"errors"
 	"flag"
@@ -1669,6 +1668,24 @@ func createMountPointExecEnvFiles(rootFs string, mountpoints map[string]struct{}
 	cmdFileName := rootFs + "/cmdline"
 	envFileName := rootFs + "/environment"
 
+	mpFile, err := os.Create(mpFileName)
+	if err != nil {
+		log.Errorf("createMountPointExecEnvFiles: os.Create for %v, failed: %v", mpFileName, err.Error())
+	}
+	defer mpFile.Close()
+
+	cmdFile, err := os.Create(cmdFileName)
+	if err != nil {
+		log.Errorf("createMountPointExecEnvFiles: os.Create for %v, failed: %v", cmdFileName, err.Error())
+	}
+	defer cmdFile.Close()
+
+	envFile, err := os.Create(envFileName)
+	if err != nil {
+		log.Errorf("createMountPointExecEnvFiles: os.Create for %v, failed: %v", envFileName, err.Error())
+	}
+	defer envFile.Close()
+
 	//Ignoring container image in status.DiskStatusList
 	noOfDisks = noOfDisks - 1
 
@@ -1684,7 +1701,7 @@ func createMountPointExecEnvFiles(rootFs string, mountpoints map[string]struct{}
 		return fmt.Errorf("createMountPointExecEnvFiles: Number of volumes provided: %v is less than number of mount-points: %v. ",
 			noOfDisks, len(mountpoints))
 	}
-	var mpBuffer bytes.Buffer
+
 	for path := range mountpoints {
 		if !strings.HasPrefix(path, "/") {
 			//Target path is expected to be absolute.
@@ -1693,10 +1710,11 @@ func createMountPointExecEnvFiles(rootFs string, mountpoints map[string]struct{}
 			return err
 		}
 		log.Infof("createMountPointExecEnvFiles: Processing mount point %s\n", path)
-		mpBuffer.WriteString(fmt.Sprintf("%s\n", path))
-	}
-	if err := ioutil.WriteFile(mpFileName, mpBuffer.Bytes(), 0666); err != nil {
-		return fmt.Errorf("createMountPointExecEnvFiles: exception while writing file %v. %v", mpFileName, err)
+		if _, err := mpFile.WriteString(fmt.Sprintf("%s\n", path)); err != nil {
+			err := fmt.Errorf("createMountPointExecEnvFiles: writing to %s failed %v", mpFileName, err)
+			log.Errorf(err.Error())
+			return err
+		}
 	}
 
 	// each item needs to be independently quoted for initrd
@@ -1704,8 +1722,10 @@ func createMountPointExecEnvFiles(rootFs string, mountpoints map[string]struct{}
 	for _, s := range execpath {
 		execpathQuoted = append(execpathQuoted, fmt.Sprintf("\"%s\"", s))
 	}
-	if err := ioutil.WriteFile(cmdFileName, []byte(strings.Join(execpathQuoted, " ")), 0666); err != nil {
-		return fmt.Errorf("createMountPointExecEnvFiles: exception while writing file %v. %v", mpFileName, err)
+	if _, err := cmdFile.WriteString(strings.Join(execpathQuoted, " ")); err != nil {
+		err := fmt.Errorf("createMountPointExecEnvFiles: writing to %s failed %v", cmdFileName, err)
+		log.Errorf(err.Error())
+		return err
 	}
 
 	envContent := ""
@@ -1715,8 +1735,10 @@ func createMountPointExecEnvFiles(rootFs string, mountpoints map[string]struct{}
 	for _, e := range env {
 		envContent = envContent + fmt.Sprintf("export %s\n", e)
 	}
-	if err := ioutil.WriteFile(envFileName, []byte(envContent), 0666); err != nil {
-		return fmt.Errorf("createMountPointExecEnvFiles: exception while writing file %v. %v", mpFileName, err)
+	if _, err := envFile.WriteString(envContent); err != nil {
+		err := fmt.Errorf("createMountPointExecEnvFiles: writing to %s failed %v", envFileName, err)
+		log.Errorf(err.Error())
+		return err
 	}
 
 	return nil

--- a/pkg/pillar/cmd/domainmgr/domainmgr_test.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr_test.go
@@ -9,12 +9,7 @@
 package domainmgr
 
 import (
-	"fmt"
-	"io/ioutil"
-	"os"
-	"path"
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/lf-edge/eve/pkg/pillar/types"
@@ -164,166 +159,382 @@ func TestFetchEnvVariablesFromCloudInit(t *testing.T) {
 	}
 }
 
-func TestCreateMountPointExecEnvFiles(t *testing.T) {
-	content := `
-{
-  "acVersion": "1.26.0",
-  "acKind": "PodManifest",
-  "apps": [
-    {
-      "name": "foobarbaz",
-      "image": {
-        "name": "registry-1.docker.io/library/redis",
-        "id": "sha512-572dff895cc8521bcc800c7fa5224a121d3afa8b545ff9fd9c87d9c5ff090469",
-        "labels": [
-          {
-            "name": "os",
-            "value": "linux"
-          },
-          {
-            "name": "arch",
-            "value": "amd64"
-          },
-          {
-            "name": "version",
-            "value": "latest"
-          }
-        ]
-      },
-      "app": {
-        "exec": [
-          "docker-entrypoint.sh",
-          "redis-server"
-        ],
-        "user": "0",
-        "group": "0",
-        "workingDirectory": "/data",
-        "environment": [
-          {
-            "name": "PATH",
-            "value": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-          },
-          {
-            "name": "GOSU_VERSION",
-            "value": "1.11"
-          },
-          {
-            "name": "REDIS_VERSION",
-            "value": "5.0.7"
-          },
-          {
-            "name": "REDIS_DOWNLOAD_URL",
-            "value": "http://download.redis.io/releases/redis-5.0.7.tar.gz"
-          },
-          {
-            "name": "REDIS_DOWNLOAD_SHA",
-            "value": "61db74eabf6801f057fd24b590232f2f337d422280fd19486eca03be87d3a82b"
-          }
-        ],
-        "mountPoints": [
-          {
-            "name": "volume-data",
-            "path": "/data"
-          },
-					{
-            "name": "foo",
-            "path": "/foo"
-          },
-					{
-            "name": "bar",
-            "path": "/bar"
-          }
-        ],
-        "ports": [
-          {
-            "name": "6379-tcp",
-            "protocol": "tcp",
-            "port": 6379,
-            "count": 1,
-            "socketActivated": false
-          }
-        ]
-      }
-    }
-  ],
-  "volumes": null,
-  "isolators": null,
-  "annotations": [
-    {
-      "name": "coreos.com/rkt/stage1/mutable",
-      "value": "false"
-    }
-  ],
-  "ports": []
-}
-`
-	// create a temp dir to hold resulting files
-	dir, _ := ioutil.TempDir("/tmp", "podfiles")
-	rootDir := path.Join(dir, "runx")
-	podPath := path.Join(dir, "pod")
-	err := os.MkdirAll(rootDir, 0777)
-	if err != nil {
-		t.Errorf("failed to create temporary dir")
-	} else {
-		defer os.RemoveAll(dir)
-	}
-
-	// now create a fake pod file
-	file, _ := os.Create(podPath)
-	_, err = file.WriteString(content)
-	if err != nil {
-		t.Errorf("failed to write to a pod file")
-	}
-
-	status := types.DomainStatus{DiskStatusList: []types.DiskStatus{{ImageSha256: "rootfs"}, {ImageSha256: "extraDiskData"}, {ImageSha256: "extraDiskFoo"}, {ImageSha256: "extraDiskBar"}}}
-	execpath := []string{"docker-entrypoint.sh", "redis-server"}
-	// the proper format for this
-	execpathStr := "\"docker-entrypoint.sh\" \"redis-server\""
-	workdir := "/data"
-	mountpoints := []string{"/data", "/foo", "/bar"}
-	env := []KeyValue{
-		{Name: "PATH", Value: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
-		{Name: "GOSU_VERSION", Value: "1.11"},
-		{Name: "REDIS_VERSION", Value: "5.0.7"},
-		{Name: "REDIS_DOWNLOAD_URL", Value: "http://download.redis.io/releases/redis-5.0.7.tar.gz"},
-		{Name: "REDIS_DOWNLOAD_SHA", Value: "61db74eabf6801f057fd24b590232f2f337d422280fd19486eca03be87d3a82b"},
-	}
-
-	err = createMountPointExecEnvFiles(rootDir, mountpoints, execpath, workdir, env, &status)
-	if err != nil {
-		t.Errorf("createMountPointExecEnvFiles failed %v", err)
-	}
-
-	cmdlineFile := path.Join(rootDir, "cmdline")
-	cmdline, err := ioutil.ReadFile(cmdlineFile)
-	if err != nil {
-		t.Errorf("createMountPointExecEnvFiles failed to create cmdline file %s %v", cmdlineFile, err)
-	}
-	if string(cmdline) != execpathStr {
-		t.Errorf("mismatched cmdline file content, actual '%s' expected '%s'", string(cmdline), execpathStr)
-	}
-
-	mountFile := path.Join(rootDir, "mountPoints")
-	mountExpected := strings.Join(mountpoints, "\n") + "\n"
-	mounts, err := ioutil.ReadFile(mountFile)
-	if err != nil {
-		t.Errorf("createMountPointExecEnvFiles failed to create mountPoints file %s %v", mountFile, err)
-	}
-	if string(mounts) != mountExpected {
-		t.Errorf("mismatched mountpoints file content, actual '%s' expected '%s'", string(mounts), mountExpected)
-	}
-
-	envFile := path.Join(rootDir, "environment")
-	envActual, err := ioutil.ReadFile(envFile)
-	// start with WORKDIR
-	envExpect := fmt.Sprintf("export WORKDIR=\"%s\"\n", workdir)
-	for _, v := range env {
-		envExpect = envExpect + fmt.Sprintf("export %s=\"%s\"\n", v.Name, v.Value)
-	}
-	if err != nil {
-		t.Errorf("createMountPointExecEnvFiles failed to create environment file %s %v", envFile, err)
-	}
-	if string(envActual) != envExpect {
-		t.Errorf("mismatched env file content, actual '%s' expected '%s'", string(envActual), envExpect)
-	}
-}
+//func TestCreateMountPointExecEnvFiles(t *testing.T) {
+//	content := `
+//{
+//  "acVersion": "1.26.0",
+//  "acKind": "PodManifest",
+//  "apps": [
+//    {
+//      "name": "foobarbaz",
+//      "image": {
+//        "name": "registry-1.docker.io/library/redis",
+//        "id": "sha512-572dff895cc8521bcc800c7fa5224a121d3afa8b545ff9fd9c87d9c5ff090469",
+//        "labels": [
+//          {
+//            "name": "os",
+//            "value": "linux"
+//          },
+//          {
+//            "name": "arch",
+//            "value": "amd64"
+//          },
+//          {
+//            "name": "version",
+//            "value": "latest"
+//          }
+//        ]
+//      },
+//      "app": {
+//        "exec": [
+//          "docker-entrypoint.sh",
+//          "redis-server"
+//        ],
+//        "user": "0",
+//        "group": "0",
+//        "workingDirectory": "/data",
+//        "environment": [
+//          {
+//            "name": "PATH",
+//            "value": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+//          },
+//          {
+//            "name": "GOSU_VERSION",
+//            "value": "1.11"
+//          },
+//          {
+//            "name": "REDIS_VERSION",
+//            "value": "5.0.7"
+//          },
+//          {
+//            "name": "REDIS_DOWNLOAD_URL",
+//            "value": "http://download.redis.io/releases/redis-5.0.7.tar.gz"
+//          },
+//          {
+//            "name": "REDIS_DOWNLOAD_SHA",
+//            "value": "61db74eabf6801f057fd24b590232f2f337d422280fd19486eca03be87d3a82b"
+//          }
+//        ],
+//        "mountPoints": [
+//          {
+//            "name": "volume-data",
+//            "path": "/data"
+//          },
+//					{
+//            "name": "foo",
+//            "path": "/foo"
+//          },
+//					{
+//            "name": "bar",
+//            "path": "/bar"
+//          }
+//        ],
+//        "ports": [
+//          {
+//            "name": "6379-tcp",
+//            "protocol": "tcp",
+//            "port": 6379,
+//            "count": 1,
+//            "socketActivated": false
+//          }
+//        ]
+//      }
+//    }
+//  ],
+//  "volumes": null,
+//  "isolators": null,
+//  "annotations": [
+//    {
+//      "name": "coreos.com/rkt/stage1/mutable",
+//      "value": "false"
+//    }
+//  ],
+//  "ports": []
+//}
+//`
+//	newContent := `{
+//   "ociVersion":"1.0.1",
+//   "process":{
+//      "user":{
+//         "uid":0,
+//         "gid":0
+//      },
+//      "args":[
+//         "/bin/sh"
+//      ],
+//      "env":[
+//         "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+//         "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+//      ],
+//      "cwd":"/",
+//      "capabilities":{
+//         "bounding":[
+//            "CAP_CHOWN",
+//            "CAP_DAC_OVERRIDE",
+//            "CAP_FSETID",
+//            "CAP_FOWNER",
+//            "CAP_MKNOD",
+//            "CAP_NET_RAW",
+//            "CAP_SETGID",
+//            "CAP_SETUID",
+//            "CAP_SETFCAP",
+//            "CAP_SETPCAP",
+//            "CAP_NET_BIND_SERVICE",
+//            "CAP_SYS_CHROOT",
+//            "CAP_KILL",
+//            "CAP_AUDIT_WRITE"
+//         ],
+//         "effective":[
+//            "CAP_CHOWN",
+//            "CAP_DAC_OVERRIDE",
+//            "CAP_FSETID",
+//            "CAP_FOWNER",
+//            "CAP_MKNOD",
+//            "CAP_NET_RAW",
+//            "CAP_SETGID",
+//            "CAP_SETUID",
+//            "CAP_SETFCAP",
+//            "CAP_SETPCAP",
+//            "CAP_NET_BIND_SERVICE",
+//            "CAP_SYS_CHROOT",
+//            "CAP_KILL",
+//            "CAP_AUDIT_WRITE"
+//         ],
+//         "inheritable":[
+//            "CAP_CHOWN",
+//            "CAP_DAC_OVERRIDE",
+//            "CAP_FSETID",
+//            "CAP_FOWNER",
+//            "CAP_MKNOD",
+//            "CAP_NET_RAW",
+//            "CAP_SETGID",
+//            "CAP_SETUID",
+//            "CAP_SETFCAP",
+//            "CAP_SETPCAP",
+//            "CAP_NET_BIND_SERVICE",
+//            "CAP_SYS_CHROOT",
+//            "CAP_KILL",
+//            "CAP_AUDIT_WRITE"
+//         ],
+//         "permitted":[
+//            "CAP_CHOWN",
+//            "CAP_DAC_OVERRIDE",
+//            "CAP_FSETID",
+//            "CAP_FOWNER",
+//            "CAP_MKNOD",
+//            "CAP_NET_RAW",
+//            "CAP_SETGID",
+//            "CAP_SETUID",
+//            "CAP_SETFCAP",
+//            "CAP_SETPCAP",
+//            "CAP_NET_BIND_SERVICE",
+//            "CAP_SYS_CHROOT",
+//            "CAP_KILL",
+//            "CAP_AUDIT_WRITE"
+//         ]
+//      },
+//      "rlimits":[
+//         {
+//            "type":"RLIMIT_NOFILE",
+//            "hard":1024,
+//            "soft":1024
+//         }
+//      ],
+//      "noNewPrivileges":true
+//   },
+//   "root":{
+//      "path":"rootfs"
+//   },
+//   "mounts":[
+//      {
+//         "destination":"/proc",
+//         "type":"proc",
+//         "source":"proc"
+//      },
+//      {
+//         "destination":"/dev",
+//         "type":"tmpfs",
+//         "source":"tmpfs",
+//         "options":[
+//            "nosuid",
+//            "strictatime",
+//            "mode=755",
+//            "size=65536k"
+//         ]
+//      },
+//      {
+//         "destination":"/dev/pts",
+//         "type":"devpts",
+//         "source":"devpts",
+//         "options":[
+//            "nosuid",
+//            "noexec",
+//            "newinstance",
+//            "ptmxmode=0666",
+//            "mode=0620",
+//            "gid=5"
+//         ]
+//      },
+//      {
+//         "destination":"/dev/shm",
+//         "type":"tmpfs",
+//         "source":"shm",
+//         "options":[
+//            "nosuid",
+//            "noexec",
+//            "nodev",
+//            "mode=1777",
+//            "size=65536k"
+//         ]
+//      },
+//      {
+//         "destination":"/dev/mqueue",
+//         "type":"mqueue",
+//         "source":"mqueue",
+//         "options":[
+//            "nosuid",
+//            "noexec",
+//            "nodev"
+//         ]
+//      },
+//      {
+//         "destination":"/sys",
+//         "type":"sysfs",
+//         "source":"sysfs",
+//         "options":[
+//            "nosuid",
+//            "noexec",
+//            "nodev",
+//            "ro"
+//         ]
+//      },
+//      {
+//         "destination":"/run",
+//         "type":"tmpfs",
+//         "source":"tmpfs",
+//         "options":[
+//            "nosuid",
+//            "strictatime",
+//            "mode=755",
+//            "size=65536k"
+//         ]
+//      }
+//   ],
+//   "linux":{
+//      "resources":{
+//         "devices":[
+//            {
+//               "allow":false,
+//               "access":"rwm"
+//            }
+//         ]
+//      },
+//      "cgroupsPath":"/eve-user-apps/alpine",
+//      "namespaces":[
+//         {
+//            "type":"pid"
+//         },
+//         {
+//            "type":"ipc"
+//         },
+//         {
+//            "type":"uts"
+//         },
+//         {
+//            "type":"mount"
+//         },
+//         {
+//            "type":"network"
+//         }
+//      ],
+//      "maskedPaths":[
+//         "/proc/acpi",
+//         "/proc/kcore",
+//         "/proc/keys",
+//         "/proc/latency_stats",
+//         "/proc/timer_list",
+//         "/proc/timer_stats",
+//         "/proc/sched_debug",
+//         "/sys/firmware",
+//         "/proc/scsi"
+//      ],
+//      "readonlyPaths":[
+//         "/proc/asound",
+//         "/proc/bus",
+//         "/proc/fs",
+//         "/proc/irq",
+//         "/proc/sys",
+//         "/proc/sysrq-trigger"
+//      ]
+//   }
+//}`
+//	// create a temp dir to hold resulting files
+//	dir, _ := ioutil.TempDir("/tmp", "podfiles")
+//	rootDir := path.Join(dir, "runx")
+//	podPath := path.Join(dir, "pod")
+//	err := os.MkdirAll(rootDir, 0777)
+//	if err != nil {
+//		t.Errorf("failed to create temporary dir")
+//	} else {
+//		defer os.RemoveAll(dir)
+//	}
+//
+//	// now create a fake pod file
+//	file, _ := os.Create(podPath)
+//	_, err = file.WriteString(content)
+//	if err != nil {
+//		t.Errorf("failed to write to a pod file")
+//	}
+//
+//	status := types.DomainStatus{DiskStatusList: []types.DiskStatus{{ImageSha256: "rootfs"}, {ImageSha256: "extraDiskData"}, {ImageSha256: "extraDiskFoo"}, {ImageSha256: "extraDiskBar"}}}
+//	execpath := []string{"docker-entrypoint.sh", "redis-server"}
+//	// the proper format for this
+//	execpathStr := "\"docker-entrypoint.sh\" \"redis-server\""
+//	workdir := "/data"
+//	mountpoints := []string{"/data", "/foo", "/bar"}
+//	env := []KeyValue{
+//		{Name: "PATH", Value: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
+//		{Name: "GOSU_VERSION", Value: "1.11"},
+//		{Name: "REDIS_VERSION", Value: "5.0.7"},
+//		{Name: "REDIS_DOWNLOAD_URL", Value: "http://download.redis.io/releases/redis-5.0.7.tar.gz"},
+//		{Name: "REDIS_DOWNLOAD_SHA", Value: "61db74eabf6801f057fd24b590232f2f337d422280fd19486eca03be87d3a82b"},
+//	}
+//
+//	err = createMountPointExecEnvFiles(rootDir, mountpoints, execpath, workdir, env, &status)
+//	if err != nil {
+//		t.Errorf("createMountPointExecEnvFiles failed %v", err)
+//	}
+//
+//	cmdlineFile := path.Join(rootDir, "cmdline")
+//	cmdline, err := ioutil.ReadFile(cmdlineFile)
+//	if err != nil {
+//		t.Errorf("createMountPointExecEnvFiles failed to create cmdline file %s %v", cmdlineFile, err)
+//	}
+//	if string(cmdline) != execpathStr {
+//		t.Errorf("mismatched cmdline file content, actual '%s' expected '%s'", string(cmdline), execpathStr)
+//	}
+//
+//	mountFile := path.Join(rootDir, "mountPoints")
+//	mountExpected := strings.Join(mountpoints, "\n") + "\n"
+//	mounts, err := ioutil.ReadFile(mountFile)
+//	if err != nil {
+//		t.Errorf("createMountPointExecEnvFiles failed to create mountPoints file %s %v", mountFile, err)
+//	}
+//	if string(mounts) != mountExpected {
+//		t.Errorf("mismatched mountpoints file content, actual '%s' expected '%s'", string(mounts), mountExpected)
+//	}
+//
+//	envFile := path.Join(rootDir, "environment")
+//	envActual, err := ioutil.ReadFile(envFile)
+//	// start with WORKDIR
+//	envExpect := fmt.Sprintf("export WORKDIR=\"%s\"\n", workdir)
+//	for _, v := range env {
+//		envExpect = envExpect + fmt.Sprintf("export %s=\"%s\"\n", v.Name, v.Value)
+//	}
+//	if err != nil {
+//		t.Errorf("createMountPointExecEnvFiles failed to create environment file %s %v", envFile, err)
+//	}
+//	if string(envActual) != envExpect {
+//		t.Errorf("mismatched env file content, actual '%s' expected '%s'", string(envActual), envExpect)
+//	}
+//}

--- a/pkg/pillar/cmd/domainmgr/domainmgr_test.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr_test.go
@@ -9,6 +9,9 @@
 package domainmgr
 
 import (
+	"io/ioutil"
+	"os"
+	"path"
 	"reflect"
 	"testing"
 
@@ -159,382 +162,118 @@ func TestFetchEnvVariablesFromCloudInit(t *testing.T) {
 	}
 }
 
-//func TestCreateMountPointExecEnvFiles(t *testing.T) {
-//	content := `
-//{
-//  "acVersion": "1.26.0",
-//  "acKind": "PodManifest",
-//  "apps": [
-//    {
-//      "name": "foobarbaz",
-//      "image": {
-//        "name": "registry-1.docker.io/library/redis",
-//        "id": "sha512-572dff895cc8521bcc800c7fa5224a121d3afa8b545ff9fd9c87d9c5ff090469",
-//        "labels": [
-//          {
-//            "name": "os",
-//            "value": "linux"
-//          },
-//          {
-//            "name": "arch",
-//            "value": "amd64"
-//          },
-//          {
-//            "name": "version",
-//            "value": "latest"
-//          }
-//        ]
-//      },
-//      "app": {
-//        "exec": [
-//          "docker-entrypoint.sh",
-//          "redis-server"
-//        ],
-//        "user": "0",
-//        "group": "0",
-//        "workingDirectory": "/data",
-//        "environment": [
-//          {
-//            "name": "PATH",
-//            "value": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-//          },
-//          {
-//            "name": "GOSU_VERSION",
-//            "value": "1.11"
-//          },
-//          {
-//            "name": "REDIS_VERSION",
-//            "value": "5.0.7"
-//          },
-//          {
-//            "name": "REDIS_DOWNLOAD_URL",
-//            "value": "http://download.redis.io/releases/redis-5.0.7.tar.gz"
-//          },
-//          {
-//            "name": "REDIS_DOWNLOAD_SHA",
-//            "value": "61db74eabf6801f057fd24b590232f2f337d422280fd19486eca03be87d3a82b"
-//          }
-//        ],
-//        "mountPoints": [
-//          {
-//            "name": "volume-data",
-//            "path": "/data"
-//          },
-//					{
-//            "name": "foo",
-//            "path": "/foo"
-//          },
-//					{
-//            "name": "bar",
-//            "path": "/bar"
-//          }
-//        ],
-//        "ports": [
-//          {
-//            "name": "6379-tcp",
-//            "protocol": "tcp",
-//            "port": 6379,
-//            "count": 1,
-//            "socketActivated": false
-//          }
-//        ]
-//      }
-//    }
-//  ],
-//  "volumes": null,
-//  "isolators": null,
-//  "annotations": [
-//    {
-//      "name": "coreos.com/rkt/stage1/mutable",
-//      "value": "false"
-//    }
-//  ],
-//  "ports": []
-//}
-//`
-//	newContent := `{
-//   "ociVersion":"1.0.1",
-//   "process":{
-//      "user":{
-//         "uid":0,
-//         "gid":0
-//      },
-//      "args":[
-//         "/bin/sh"
-//      ],
-//      "env":[
-//         "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-//         "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-//      ],
-//      "cwd":"/",
-//      "capabilities":{
-//         "bounding":[
-//            "CAP_CHOWN",
-//            "CAP_DAC_OVERRIDE",
-//            "CAP_FSETID",
-//            "CAP_FOWNER",
-//            "CAP_MKNOD",
-//            "CAP_NET_RAW",
-//            "CAP_SETGID",
-//            "CAP_SETUID",
-//            "CAP_SETFCAP",
-//            "CAP_SETPCAP",
-//            "CAP_NET_BIND_SERVICE",
-//            "CAP_SYS_CHROOT",
-//            "CAP_KILL",
-//            "CAP_AUDIT_WRITE"
-//         ],
-//         "effective":[
-//            "CAP_CHOWN",
-//            "CAP_DAC_OVERRIDE",
-//            "CAP_FSETID",
-//            "CAP_FOWNER",
-//            "CAP_MKNOD",
-//            "CAP_NET_RAW",
-//            "CAP_SETGID",
-//            "CAP_SETUID",
-//            "CAP_SETFCAP",
-//            "CAP_SETPCAP",
-//            "CAP_NET_BIND_SERVICE",
-//            "CAP_SYS_CHROOT",
-//            "CAP_KILL",
-//            "CAP_AUDIT_WRITE"
-//         ],
-//         "inheritable":[
-//            "CAP_CHOWN",
-//            "CAP_DAC_OVERRIDE",
-//            "CAP_FSETID",
-//            "CAP_FOWNER",
-//            "CAP_MKNOD",
-//            "CAP_NET_RAW",
-//            "CAP_SETGID",
-//            "CAP_SETUID",
-//            "CAP_SETFCAP",
-//            "CAP_SETPCAP",
-//            "CAP_NET_BIND_SERVICE",
-//            "CAP_SYS_CHROOT",
-//            "CAP_KILL",
-//            "CAP_AUDIT_WRITE"
-//         ],
-//         "permitted":[
-//            "CAP_CHOWN",
-//            "CAP_DAC_OVERRIDE",
-//            "CAP_FSETID",
-//            "CAP_FOWNER",
-//            "CAP_MKNOD",
-//            "CAP_NET_RAW",
-//            "CAP_SETGID",
-//            "CAP_SETUID",
-//            "CAP_SETFCAP",
-//            "CAP_SETPCAP",
-//            "CAP_NET_BIND_SERVICE",
-//            "CAP_SYS_CHROOT",
-//            "CAP_KILL",
-//            "CAP_AUDIT_WRITE"
-//         ]
-//      },
-//      "rlimits":[
-//         {
-//            "type":"RLIMIT_NOFILE",
-//            "hard":1024,
-//            "soft":1024
-//         }
-//      ],
-//      "noNewPrivileges":true
-//   },
-//   "root":{
-//      "path":"rootfs"
-//   },
-//   "mounts":[
-//      {
-//         "destination":"/proc",
-//         "type":"proc",
-//         "source":"proc"
-//      },
-//      {
-//         "destination":"/dev",
-//         "type":"tmpfs",
-//         "source":"tmpfs",
-//         "options":[
-//            "nosuid",
-//            "strictatime",
-//            "mode=755",
-//            "size=65536k"
-//         ]
-//      },
-//      {
-//         "destination":"/dev/pts",
-//         "type":"devpts",
-//         "source":"devpts",
-//         "options":[
-//            "nosuid",
-//            "noexec",
-//            "newinstance",
-//            "ptmxmode=0666",
-//            "mode=0620",
-//            "gid=5"
-//         ]
-//      },
-//      {
-//         "destination":"/dev/shm",
-//         "type":"tmpfs",
-//         "source":"shm",
-//         "options":[
-//            "nosuid",
-//            "noexec",
-//            "nodev",
-//            "mode=1777",
-//            "size=65536k"
-//         ]
-//      },
-//      {
-//         "destination":"/dev/mqueue",
-//         "type":"mqueue",
-//         "source":"mqueue",
-//         "options":[
-//            "nosuid",
-//            "noexec",
-//            "nodev"
-//         ]
-//      },
-//      {
-//         "destination":"/sys",
-//         "type":"sysfs",
-//         "source":"sysfs",
-//         "options":[
-//            "nosuid",
-//            "noexec",
-//            "nodev",
-//            "ro"
-//         ]
-//      },
-//      {
-//         "destination":"/run",
-//         "type":"tmpfs",
-//         "source":"tmpfs",
-//         "options":[
-//            "nosuid",
-//            "strictatime",
-//            "mode=755",
-//            "size=65536k"
-//         ]
-//      }
-//   ],
-//   "linux":{
-//      "resources":{
-//         "devices":[
-//            {
-//               "allow":false,
-//               "access":"rwm"
-//            }
-//         ]
-//      },
-//      "cgroupsPath":"/eve-user-apps/alpine",
-//      "namespaces":[
-//         {
-//            "type":"pid"
-//         },
-//         {
-//            "type":"ipc"
-//         },
-//         {
-//            "type":"uts"
-//         },
-//         {
-//            "type":"mount"
-//         },
-//         {
-//            "type":"network"
-//         }
-//      ],
-//      "maskedPaths":[
-//         "/proc/acpi",
-//         "/proc/kcore",
-//         "/proc/keys",
-//         "/proc/latency_stats",
-//         "/proc/timer_list",
-//         "/proc/timer_stats",
-//         "/proc/sched_debug",
-//         "/sys/firmware",
-//         "/proc/scsi"
-//      ],
-//      "readonlyPaths":[
-//         "/proc/asound",
-//         "/proc/bus",
-//         "/proc/fs",
-//         "/proc/irq",
-//         "/proc/sys",
-//         "/proc/sysrq-trigger"
-//      ]
-//   }
-//}`
-//	// create a temp dir to hold resulting files
-//	dir, _ := ioutil.TempDir("/tmp", "podfiles")
-//	rootDir := path.Join(dir, "runx")
-//	podPath := path.Join(dir, "pod")
-//	err := os.MkdirAll(rootDir, 0777)
-//	if err != nil {
-//		t.Errorf("failed to create temporary dir")
-//	} else {
-//		defer os.RemoveAll(dir)
-//	}
-//
-//	// now create a fake pod file
-//	file, _ := os.Create(podPath)
-//	_, err = file.WriteString(content)
-//	if err != nil {
-//		t.Errorf("failed to write to a pod file")
-//	}
-//
-//	status := types.DomainStatus{DiskStatusList: []types.DiskStatus{{ImageSha256: "rootfs"}, {ImageSha256: "extraDiskData"}, {ImageSha256: "extraDiskFoo"}, {ImageSha256: "extraDiskBar"}}}
-//	execpath := []string{"docker-entrypoint.sh", "redis-server"}
-//	// the proper format for this
-//	execpathStr := "\"docker-entrypoint.sh\" \"redis-server\""
-//	workdir := "/data"
-//	mountpoints := []string{"/data", "/foo", "/bar"}
-//	env := []KeyValue{
-//		{Name: "PATH", Value: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
-//		{Name: "GOSU_VERSION", Value: "1.11"},
-//		{Name: "REDIS_VERSION", Value: "5.0.7"},
-//		{Name: "REDIS_DOWNLOAD_URL", Value: "http://download.redis.io/releases/redis-5.0.7.tar.gz"},
-//		{Name: "REDIS_DOWNLOAD_SHA", Value: "61db74eabf6801f057fd24b590232f2f337d422280fd19486eca03be87d3a82b"},
-//	}
-//
-//	err = createMountPointExecEnvFiles(rootDir, mountpoints, execpath, workdir, env, &status)
-//	if err != nil {
-//		t.Errorf("createMountPointExecEnvFiles failed %v", err)
-//	}
-//
-//	cmdlineFile := path.Join(rootDir, "cmdline")
-//	cmdline, err := ioutil.ReadFile(cmdlineFile)
-//	if err != nil {
-//		t.Errorf("createMountPointExecEnvFiles failed to create cmdline file %s %v", cmdlineFile, err)
-//	}
-//	if string(cmdline) != execpathStr {
-//		t.Errorf("mismatched cmdline file content, actual '%s' expected '%s'", string(cmdline), execpathStr)
-//	}
-//
-//	mountFile := path.Join(rootDir, "mountPoints")
-//	mountExpected := strings.Join(mountpoints, "\n") + "\n"
-//	mounts, err := ioutil.ReadFile(mountFile)
-//	if err != nil {
-//		t.Errorf("createMountPointExecEnvFiles failed to create mountPoints file %s %v", mountFile, err)
-//	}
-//	if string(mounts) != mountExpected {
-//		t.Errorf("mismatched mountpoints file content, actual '%s' expected '%s'", string(mounts), mountExpected)
-//	}
-//
-//	envFile := path.Join(rootDir, "environment")
-//	envActual, err := ioutil.ReadFile(envFile)
-//	// start with WORKDIR
-//	envExpect := fmt.Sprintf("export WORKDIR=\"%s\"\n", workdir)
-//	for _, v := range env {
-//		envExpect = envExpect + fmt.Sprintf("export %s=\"%s\"\n", v.Name, v.Value)
-//	}
-//	if err != nil {
-//		t.Errorf("createMountPointExecEnvFiles failed to create environment file %s %v", envFile, err)
-//	}
-//	if string(envActual) != envExpect {
-//		t.Errorf("mismatched env file content, actual '%s' expected '%s'", string(envActual), envExpect)
-//	}
-//}
+func TestCreateMountPointExecEnvFiles(t *testing.T) {
+
+	newContent := `{
+    "created": "2020-02-05T00:52:57.387773144Z",
+    "author": "adarsh@zededa.com",
+    "architecture": "amd64",
+    "os": "linux",
+    "config": {
+        "Env": [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        ],
+        "Cmd": [
+            "/bin/sh"
+        ],
+        "Volumes": {
+            "/myvol": {}
+        }
+    },
+    "rootfs": {
+        "type": "layers",
+        "diff_ids": [
+            "sha256:a79a1aaf8143bbbe6061bc5326a1dcc490d9b9c1ea6b9c27d14c182e15c535ee",
+            "sha256:a235ff03ae531a929c240688c52e802c4f3714b2446d1f34b1d20bfd59ce1965"
+        ]
+    },
+    "history": [
+        {
+            "created": "2019-01-30T22:20:20.383667418Z",
+            "created_by": "/bin/sh -c #(nop) ADD file:eaf29f2198d25cc0e88b84af6478f422db6a8ffb6919bf746117252cfcd88a47 in / "
+        },
+        {
+            "created": "2019-01-30T22:20:20.590559734Z",
+            "created_by": "/bin/sh -c #(nop)  CMD [\"/bin/sh\"]",
+            "empty_layer": true
+        },
+        {
+            "created": "2020-02-05T00:52:55.559839255Z",
+            "created_by": "/bin/sh -c #(nop)  MAINTAINER adarsh@zededa.com",
+            "author": "adarsh@zededa.com",
+            "empty_layer": true
+        },
+        {
+            "created": "2020-02-05T00:52:57.115531308Z",
+            "created_by": "/bin/sh -c mkdir /myvol",
+            "author": "adarsh@zededa.com"
+        },
+        {
+            "created": "2020-02-05T00:52:57.387773144Z",
+            "created_by": "/bin/sh -c #(nop)  VOLUME [/myvol]",
+            "author": "adarsh@zededa.com",
+            "empty_layer": true
+        }
+    ]
+}`
+	// create a temp dir to hold resulting files
+	dir, _ := ioutil.TempDir("/tmp", "podfiles")
+	rootDir := path.Join(dir, "runx")
+	podPath := path.Join(dir, "pod")
+	err := os.MkdirAll(rootDir, 0777)
+	if err != nil {
+		t.Errorf("failed to create temporary dir")
+	} else {
+		defer os.RemoveAll(dir)
+	}
+
+	// now create a fake pod file
+	file, _ := os.Create(podPath)
+	_, err = file.WriteString(newContent)
+	if err != nil {
+		t.Errorf("failed to write to a pod file")
+	}
+	execpath := []string{"/bin/sh"}
+	// the proper format for this
+	execpathStr := "\"/bin/sh\""
+	workdir := "/data"
+	mountpoints := map[string]struct{}{
+		"/myvol": {},
+	}
+	env := []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}
+
+	err = createMountPointExecEnvFiles(rootDir, mountpoints, execpath, workdir, env, 0)
+	if err != nil {
+		t.Errorf("createMountPointExecEnvFiles failed %v", err)
+	}
+
+	cmdlineFile := path.Join(rootDir, "cmdline")
+	cmdline, err := ioutil.ReadFile(cmdlineFile)
+	if err != nil {
+		t.Errorf("createMountPointExecEnvFiles failed to create cmdline file %s %v", cmdlineFile, err)
+	}
+	if string(cmdline) != execpathStr {
+		t.Errorf("mismatched cmdline file content, actual '%s' expected '%s'", string(cmdline), execpathStr)
+	}
+
+	mountFile := path.Join(rootDir, "mountPoints")
+	mountExpected := "/myvol" + "\n"
+	mounts, err := ioutil.ReadFile(mountFile)
+	if err != nil {
+		t.Errorf("createMountPointExecEnvFiles failed to create mountPoints file %s %v", mountFile, err)
+	}
+	if string(mounts) != mountExpected {
+		t.Errorf("mismatched mountpoints file content, actual '%s' expected '%s'", string(mounts), mountExpected)
+	}
+
+	envFile := path.Join(rootDir, "environment")
+	envActual, err := ioutil.ReadFile(envFile)
+	// start with WORKDIR
+	envExpect := "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+	if err != nil {
+		t.Errorf("createMountPointExecEnvFiles failed to create environment file %s %v", envFile, err)
+	}
+	if string(envActual) != envExpect {
+		t.Errorf("mismatched env file content, actual '%s' expected '%s'", string(envActual), envExpect)
+	}
+}

--- a/pkg/pillar/cmd/domainmgr/domainmgr_test.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr_test.go
@@ -164,7 +164,7 @@ func TestFetchEnvVariablesFromCloudInit(t *testing.T) {
 
 func TestCreateMountPointExecEnvFiles(t *testing.T) {
 
-	newContent := `{
+	content := `{
     "created": "2020-02-05T00:52:57.387773144Z",
     "author": "adarsh@zededa.com",
     "architecture": "amd64",
@@ -216,7 +216,7 @@ func TestCreateMountPointExecEnvFiles(t *testing.T) {
         }
     ]
 }`
-	// create a temp dir to hold resulting files
+	//create a temp dir to hold resulting files
 	dir, _ := ioutil.TempDir("/tmp", "podfiles")
 	rootDir := path.Join(dir, "runx")
 	podPath := path.Join(dir, "pod")
@@ -229,7 +229,7 @@ func TestCreateMountPointExecEnvFiles(t *testing.T) {
 
 	// now create a fake pod file
 	file, _ := os.Create(podPath)
-	_, err = file.WriteString(newContent)
+	_, err = file.WriteString(content)
 	if err != nil {
 		t.Errorf("failed to write to a pod file")
 	}
@@ -242,7 +242,7 @@ func TestCreateMountPointExecEnvFiles(t *testing.T) {
 	}
 	env := []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}
 
-	err = createMountPointExecEnvFiles(rootDir, mountpoints, execpath, workdir, env, 0)
+	err = createMountPointExecEnvFiles(rootDir, mountpoints, execpath, workdir, env, 2)
 	if err != nil {
 		t.Errorf("createMountPointExecEnvFiles failed %v", err)
 	}
@@ -269,7 +269,7 @@ func TestCreateMountPointExecEnvFiles(t *testing.T) {
 	envFile := path.Join(rootDir, "environment")
 	envActual, err := ioutil.ReadFile(envFile)
 	// start with WORKDIR
-	envExpect := "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+	envExpect := "export WORKDIR=\"/data\"\nexport PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n"
 	if err != nil {
 		t.Errorf("createMountPointExecEnvFiles failed to create environment file %s %v", envFile, err)
 	}

--- a/pkg/pillar/go.mod
+++ b/pkg/pillar/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/containerd/continuity v0.0.0-20200228182428-0f16d7a0959c // indirect
 	github.com/containerd/fifo v0.0.0-20191213151349-ff969a566b00 // indirect
 	github.com/containerd/ttrpc v0.0.0-20200121165050-0be804eadb15 // indirect
-	github.com/containerd/typeurl v0.0.0-20200205145503-b45ef1f1f737 // indirect
+	github.com/containerd/typeurl v0.0.0-20200205145503-b45ef1f1f737
 	github.com/coreos/ioprogress v0.0.0-20151023204047-4637e494fd9b // indirect
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c // indirect
@@ -33,8 +33,9 @@ require (
 	github.com/lf-edge/eve/api/go v0.0.0-00010101000000-000000000000
 	github.com/mdlayher/raw v0.0.0-20190419142535-64193704e472 // indirect
 	github.com/ochapman/godmi v0.0.0-20140902235245-2527e2081a16 // indirect
+	github.com/opencontainers/image-spec v1.0.1
 	github.com/opencontainers/runc v0.1.1 // indirect
-	github.com/opencontainers/runtime-spec v1.0.1 // indirect
+	github.com/opencontainers/runtime-spec v1.0.1
 	github.com/pkg/sftp v1.10.0
 	github.com/rackn/gohai v0.0.0-20190321191141-5053e7f1fa36
 	github.com/robertkrimen/otto v0.0.0-20180617131154-15f95af6e78d // indirect

--- a/pkg/pillar/go.mod
+++ b/pkg/pillar/go.mod
@@ -65,4 +65,4 @@ replace git.apache.org/thrift.git => github.com/apache/thrift v0.12.0
 replace github.com/google/go-tpm => github.com/cshari-zededa/go-tpm v0.0.0-20200113112746-a8476c2d6eb3
 
 // because containerd
-replace github.com/docker/distribution => github.com/docker/distribution v0.0.0-20190205005809-0d3efadf0154+incompatible
+replace github.com/docker/distribution => github.com/docker/distribution v0.0.0-20190205005809-0d3efadf0154

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -21,7 +21,6 @@ AGENTS0="logmanager ledmanager nim nodeagent"
 AGENTS1="zedmanager zedrouter domainmgr downloader verifier identitymgr zedagent baseosmgr wstunnelclient"
 AGENTS="$AGENTS0 $AGENTS1"
 TPM_DEVICE_PATH="/dev/tpmrm0"
-XDG_RUNTIME_DIR=/run/tmp
 PATH=$BINDIR:$PATH
 
 echo "$(date -Ins -u) Starting device-steps.sh"
@@ -64,8 +63,7 @@ if [ -d $TMPDIR ]; then
 fi
 mkdir -p $TMPDIR
 export TMPDIR
-mkdir -p $XDG_RUNTIME_DIR
-export XDG_RUNTIME_DIR
+
 mkdir -p $PERSISTDIR/containerd
 ln -s $PERSISTDIR/containerd /var/lib/containerd
 

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -21,7 +21,7 @@ AGENTS0="logmanager ledmanager nim nodeagent"
 AGENTS1="zedmanager zedrouter domainmgr downloader verifier identitymgr zedagent baseosmgr wstunnelclient"
 AGENTS="$AGENTS0 $AGENTS1"
 TPM_DEVICE_PATH="/dev/tpmrm0"
-XDG_RUNTIME_DIR=/var/persist/tmp
+XDG_RUNTIME_DIR=/run/tmp
 PATH=$BINDIR:$PATH
 
 echo "$(date -Ins -u) Starting device-steps.sh"
@@ -64,7 +64,10 @@ if [ -d $TMPDIR ]; then
 fi
 mkdir -p $TMPDIR
 export TMPDIR
+mkdir -p $XDG_RUNTIME_DIR
 export XDG_RUNTIME_DIR
+mkdir -p $PERSISTDIR/containerd
+ln -s $PERSISTDIR/containerd /var/lib/containerd
 
 if ! mount -o remount,flush,dirsync,noatime $CONFIGDIR; then
     echo "$(date -Ins -u) Remount $CONFIGDIR failed"

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -21,7 +21,7 @@ AGENTS0="logmanager ledmanager nim nodeagent"
 AGENTS1="zedmanager zedrouter domainmgr downloader verifier identitymgr zedagent baseosmgr wstunnelclient"
 AGENTS="$AGENTS0 $AGENTS1"
 TPM_DEVICE_PATH="/dev/tpmrm0"
-
+XDG_RUNTIME_DIR=/var/persist/tmp
 PATH=$BINDIR:$PATH
 
 echo "$(date -Ins -u) Starting device-steps.sh"
@@ -64,6 +64,7 @@ if [ -d $TMPDIR ]; then
 fi
 mkdir -p $TMPDIR
 export TMPDIR
+export XDG_RUNTIME_DIR
 
 if ! mount -o remount,flush,dirsync,noatime $CONFIGDIR; then
     echo "$(date -Ins -u) Remount $CONFIGDIR failed"

--- a/pkg/pillar/vendor/github.com/docker/distribution/registry/api/errcode/errors.go
+++ b/pkg/pillar/vendor/github.com/docker/distribution/registry/api/errcode/errors.go
@@ -207,11 +207,11 @@ func (errs Errors) MarshalJSON() ([]byte, error) {
 	for _, daErr := range errs {
 		var err Error
 
-		switch daErr.(type) {
+		switch daErr := daErr.(type) {
 		case ErrorCode:
-			err = daErr.(ErrorCode).WithDetail(nil)
+			err = daErr.WithDetail(nil)
 		case Error:
-			err = daErr.(Error)
+			err = daErr
 		default:
 			err = ErrorCodeUnknown.WithDetail(daErr)
 

--- a/pkg/pillar/vendor/modules.txt
+++ b/pkg/pillar/vendor/modules.txt
@@ -85,6 +85,7 @@ github.com/containerd/cgroups/stats/v1
 # github.com/containerd/containerd v1.3.0
 github.com/containerd/containerd
 github.com/containerd/containerd/namespaces
+github.com/containerd/containerd/oci
 github.com/containerd/containerd/api/services/containers/v1
 github.com/containerd/containerd/api/services/content/v1
 github.com/containerd/containerd/api/services/diff/v1
@@ -114,7 +115,6 @@ github.com/containerd/containerd/leases
 github.com/containerd/containerd/leases/proxy
 github.com/containerd/containerd/log
 github.com/containerd/containerd/mount
-github.com/containerd/containerd/oci
 github.com/containerd/containerd/pkg/dialer
 github.com/containerd/containerd/platforms
 github.com/containerd/containerd/plugin
@@ -239,8 +239,8 @@ github.com/opencontainers/image-spec/identity
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1
 # github.com/opencontainers/runc v0.1.1
-github.com/opencontainers/runc/libcontainer/system
 github.com/opencontainers/runc/libcontainer/user
+github.com/opencontainers/runc/libcontainer/system
 # github.com/opencontainers/runtime-spec v1.0.1
 github.com/opencontainers/runtime-spec/specs-go
 # github.com/pkg/errors v0.9.1


### PR DESCRIPTION
Changes in this PR:
1) With the loaded image, `ctrCreate()` creates a new container.
2)  New Task is created using `ctrCreateNewTask()` at the time of container creation (`ctrCreate()`)
3) `containersRoot` and `containerRootfsPath` is updated to the path where the snapshot will be extracted by `ctrCreateNewTask()` step
4) `getContainerConfigs()` returns config details from container's spec
5) `ctrRm()` deletes task and container for the given id. This will eventually cleanup unused snapshots.

Pending changes:
1) Test cases
2) How to handle image clean-up? 