### PR TITLE
update domU bootTime when reboot from inside

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -815,6 +815,7 @@ func verifyStatus(ctx *domainContext, status *types.DomainStatus) {
 			log.Warnf("verifyDomain(%s) domainID changed from %d to %d\n",
 				status.Key(), status.DomainId, domainID)
 			status.DomainId = domainID
+			status.BootTime = time.Now()
 			publishDomainStatus(ctx, status)
 		}
 		// check if qemu processes has crashed


### PR DESCRIPTION
Once this code has made it to canary we can change the tests to check boot time in the rebootFromInside function.