### PR TITLE
Fix lack of AtTimeStamp in ZiNetworkInstance info message

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -54,6 +54,7 @@ func prepareAndPublishNetworkInstanceInfoMsg(ctx *zedagentContext,
 	*infoType = zinfo.ZInfoTypes_ZiNetworkInstance
 	infoMsg.DevId = *proto.String(zcdevUUID.String())
 	infoMsg.Ztype = *infoType
+	infoMsg.AtTimeStamp = ptypes.TimestampNow()
 
 	uuid := status.Key()
 	info := new(zinfo.ZInfoNetworkInstance)


### PR DESCRIPTION
Fix problems with parsing info protobuf (nil AtTimeStamp field) of ZiNetworkInstance info in adam.

Signed-off-by: giggsoff <giggsoff@gmail.com>