### PR TITLE
Fix regression for test_app_nat

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -2982,6 +2982,8 @@ func handlePhysicalIOAdapterListCreateModify(ctxArg interface{},
 		// Setup list first because functions lookup in IoBundleList
 		for _, phyAdapter := range phyIOAdapterList.AdapterList {
 			ib := *types.IoBundleFromPhyAdapter(phyAdapter)
+			// We assume AddOrUpdateIoBundle will preserve any
+			// existing IsPort/IsPCIBack/UsedByUUID
 			aa.AddOrUpdateIoBundle(ib)
 		}
 		// Now initialize each entry
@@ -3066,6 +3068,7 @@ func handleIBCreate(ctx *domainContext, ib types.IoBundle) {
 			ib.Type, ib.Name, err)
 		return
 	}
+	// We assume AddOrUpdateIoBundle will preserve any existing Unique/MacAddr
 	aa.AddOrUpdateIoBundle(ib)
 }
 
@@ -3393,13 +3396,14 @@ func handleIBDelete(ctx *domainContext, name string) {
 			ib.IsPCIBack = false
 		}
 	}
+	// Create a new list with everything but "ib" included
 	replace := types.AssignableAdapters{Initialized: true,
 		IoBundleList: make([]types.IoBundle, len(aa.IoBundleList)-1)}
 	for _, e := range aa.IoBundleList {
 		if e.Type == ib.Type && e.Name == ib.Name {
 			continue
 		}
-		replace.AddOrUpdateIoBundle(e)
+		replace.IoBundleList = append(replace.IoBundleList, e)
 	}
 	*ctx.assignableAdapters = replace
 	checkIoBundleAll(ctx)

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -405,6 +405,8 @@ func Run(ps *pubsub.PubSub) {
 			subAssignableAdapters.ProcessChange(change)
 
 		case change := <-subAppNetworkConfig.MsgChan():
+			// If we have an NetworkInstanceConfig process it first
+			checkAndProcessNetworkInstanceConfig(&zedrouterCtx)
 			subAppNetworkConfig.ProcessChange(change)
 
 		case change := <-subDeviceNetworkStatus.MsgChan():
@@ -438,6 +440,8 @@ func Run(ps *pubsub.PubSub) {
 			subAssignableAdapters.ProcessChange(change)
 
 		case change := <-subAppNetworkConfig.MsgChan():
+			// If we have an NetworkInstanceConfig process it first
+			checkAndProcessNetworkInstanceConfig(&zedrouterCtx)
 			subAppNetworkConfig.ProcessChange(change)
 
 		case change := <-subAppNetworkConfigAg.MsgChan():
@@ -573,6 +577,17 @@ func Run(ps *pubsub.PubSub) {
 			pubsub.CheckMaxTimeTopic(agentName, "allocatorGC", start,
 				warningTime, errorTime)
 		}
+	}
+}
+
+// If we have an NetworkInstanceConfig process it first
+func checkAndProcessNetworkInstanceConfig(ctx *zedrouterContext) {
+	select {
+	case change := <-ctx.subNetworkInstanceConfig.MsgChan():
+		log.Infof("Processing NetworkInstanceConfig before AppNetworkConfig")
+		ctx.subNetworkInstanceConfig.ProcessChange(change)
+	default:
+		log.Infof("NO NetworkInstanceConfig before AppNetworkConfig")
 	}
 }
 

--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -232,7 +232,8 @@ func VerifyPending(pending *DPCPending,
 		log.Infof("VerifyPending: DPC changed. update DhcpClient.\n")
 		if UpdateDhcpClient(pending.PendDPC, pending.OldDPC) {
 			log.Warnf("VerifyPending: update DhcpClient: retry")
-			pending.OldDPC = pending.PendDPC
+			// UpdateDhcpClient has done no changes when it returns
+			// retry
 			return DPC_WAIT
 		}
 		pending.OldDPC = pending.PendDPC


### PR DESCRIPTION
Seems like https://github.com/lf-edge/eve/commit/0379e19cf4f7ad6126c866f0d20d6b5aedb2fd5f#diff-bc26bf2277b11c7941454eb603296598 or something earlier introduced race conditions for handling of AssignableAdapters, so we can accidentally reset IsPCIBack and IsPort.

Plus two other fixes.