### PR TITLE
Refactoring to allow pluggable hypervisors

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -126,12 +126,12 @@ var hyper hypervisor.Hypervisor // Current hypervisor
 
 func Run(ps *pubsub.PubSub) {
 	handlersInit()
+	allHypervisors, enabledHypervisors := hypervisor.GetAvailableHypervisors()
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")
 	curpartPtr := flag.String("c", "", "Current partition")
-	hypervisorPtr := flag.String("h", "xen", "Current hypervisor (xen, kvm, acrn, null). Default is xen")
+	hypervisorPtr := flag.String("h", enabledHypervisors[0], fmt.Sprintf("Current hypervisor %+q", allHypervisors))
 	flag.Parse()
-	hyper = hypervisor.GetHypervisor(*hypervisorPtr)
 	debug = *debugPtr
 	debugOverride = debug
 	if debugOverride {
@@ -145,6 +145,11 @@ func Run(ps *pubsub.PubSub) {
 		return
 	}
 	err := agentlog.Init(agentName, curpart)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	hyper, err = hypervisor.GetHypervisor(*hypervisorPtr)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/pillar/cmd/domainmgr/domainmgr_test.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr_test.go
@@ -29,9 +29,9 @@ type appImageNameEntry struct {
 func TestDefaultXenHypervisor(t *testing.T) {
 	hypervisorPtr := flag.String("h", "xen", "")
 	flag.CommandLine.Parse([]string{""})
-	hyper = hypervisor.GetHypervisor(*hypervisorPtr)
-	if hyper.Name() != "xen" {
-		t.Errorf("Expected xen default hypervisor, got %s", hyper.Name())
+	hyper, err := hypervisor.GetHypervisor(*hypervisorPtr)
+	if err != nil || hyper.Name() != "xen" {
+		t.Errorf("Expected xen default hypervisor, got %s with error %v", hyper.Name(), err)
 	}
 }
 

--- a/pkg/pillar/cmd/domainmgr/domainmgr_test.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr_test.go
@@ -9,6 +9,8 @@
 package domainmgr
 
 import (
+	"flag"
+	"github.com/lf-edge/eve/pkg/pillar/hypervisor"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"io/ioutil"
 	"os"
@@ -22,6 +24,15 @@ type appImageNameEntry struct {
 	sha         string
 	appUUID     string
 	imageFormat string
+}
+
+func TestDefaultXenHypervisor(t *testing.T) {
+	hypervisorPtr := flag.String("h", "xen", "")
+	flag.CommandLine.Parse([]string{""})
+	hyper = hypervisor.GetHypervisor(*hypervisorPtr)
+	if hyper.Name() != "xen" {
+		t.Errorf("Expected xen default hypervisor, got %s", hyper.Name())
+	}
 }
 
 func TestParseAppRwImageName(t *testing.T) {

--- a/pkg/pillar/hypervisor/acrn.go
+++ b/pkg/pillar/hypervisor/acrn.go
@@ -3,53 +3,64 @@
 
 package hypervisor
 
-type AcrnContext struct {
+type acrnContext struct {
 }
 
 func newAcrn() Hypervisor {
-	return AcrnContext{}
+	return acrnContext{}
 }
 
-func (ctx AcrnContext) Name() string {
+// Name returns the name of this hypervisor implementation
+func (ctx acrnContext) Name() string {
 	return "acrn"
 }
 
-func (ctx AcrnContext) Create(domainName string, xenCfgFilename string) (int, error) {
+// Create creates a domain in a stopped state
+func (ctx acrnContext) Create(domainName string, xenCfgFilename string) (int, error) {
 	return 0, nil
 }
 
-func (ctx AcrnContext) Start(domainName string, domainID int) error {
+// Start starts a stopped domain
+func (ctx acrnContext) Start(domainName string, domainID int) error {
 	return nil
 }
 
-func (ctx AcrnContext) Stop(domainName string, domainID int, force bool) error {
+// Stop stops a running domain
+func (ctx acrnContext) Stop(domainName string, domainID int, force bool) error {
 	return nil
 }
 
-func (ctx AcrnContext) Delete(domainName string, domainID int) error {
+// Delete deletes a domain in any state (stopped or running)
+func (ctx acrnContext) Delete(domainName string, domainID int) error {
 	return nil
 }
 
-func (ctx AcrnContext) Info(domainName string, domainID int) error {
+// Info outputs domain info via logging
+func (ctx acrnContext) Info(domainName string, domainID int) error {
 	return nil
 }
 
-func (ctx AcrnContext) LookupByName(domainName string, domainID int) (int, error) {
+// LookupByName returns domain ID for a domain with a given symbolic name
+func (ctx acrnContext) LookupByName(domainName string, domainID int) (int, error) {
 	return 0, nil
 }
 
-func (ctx AcrnContext) Tune(domainName string, domainID int, vifCount int) error {
+// Tune allows for additional performance tweaks on a stopped domain
+func (ctx acrnContext) Tune(domainName string, domainID int, vifCount int) error {
 	return nil
 }
 
-func (ctx AcrnContext) PCIReserve(long string) error {
+// PCIReserve takes a PCI device away from the host kernel and makes it available for Domain assignments
+func (ctx acrnContext) PCIReserve(long string) error {
 	return nil
 }
 
-func (ctx AcrnContext) PCIRelease(long string) error {
+// PCIRelease gives a PCI device back to the host kernel
+func (ctx acrnContext) PCIRelease(long string) error {
 	return nil
 }
 
-func (ctx AcrnContext) IsDeviceModelAlive(domid int) bool {
+// IsDeviceModelAlive returns true if a process supplying device model to a domain is still running
+func (ctx acrnContext) IsDeviceModelAlive(domid int) bool {
 	return true
 }

--- a/pkg/pillar/hypervisor/acrn.go
+++ b/pkg/pillar/hypervisor/acrn.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2017-2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package hypervisor
+
+type AcrnContext struct {
+}
+
+func newAcrn() Hypervisor {
+	return AcrnContext{}
+}
+
+func (ctx AcrnContext) Name() string {
+	return "acrn"
+}
+
+func (ctx AcrnContext) Create(domainName string, xenCfgFilename string) (int, error) {
+	return 0, nil
+}
+
+func (ctx AcrnContext) Start(domainName string, domainID int) error {
+	return nil
+}
+
+func (ctx AcrnContext) Stop(domainName string, domainID int, force bool) error {
+	return nil
+}
+
+func (ctx AcrnContext) Delete(domainName string, domainID int) error {
+	return nil
+}
+
+func (ctx AcrnContext) Info(domainName string, domainID int) error {
+	return nil
+}
+
+func (ctx AcrnContext) LookupByName(domainName string, domainID int) (int, error) {
+	return 0, nil
+}
+
+func (ctx AcrnContext) Tune(domainName string, domainID int, vifCount int) error {
+	return nil
+}
+
+func (ctx AcrnContext) PCIReserve(long string) error {
+	return nil
+}
+
+func (ctx AcrnContext) PCIRelease(long string) error {
+	return nil
+}
+
+func (ctx AcrnContext) IsDeviceModelAlive(domid int) bool {
+	return true
+}

--- a/pkg/pillar/hypervisor/hypervisor.go
+++ b/pkg/pillar/hypervisor/hypervisor.go
@@ -7,6 +7,7 @@ import (
 	"os"
 )
 
+// Hypervisor provides methods for manipulating domains on the host
 type Hypervisor interface {
 	Name() string
 
@@ -25,6 +26,7 @@ type Hypervisor interface {
 	PCIRelease(string) error
 }
 
+// GetHypervisor returns a particular hypervisor implementation
 func GetHypervisor(hint string) Hypervisor {
 	var knownHypervisors = map[string]func() Hypervisor{
 		"xen":  newXen,

--- a/pkg/pillar/hypervisor/hypervisor.go
+++ b/pkg/pillar/hypervisor/hypervisor.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2017-2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package hypervisor
+
+import (
+	"os"
+)
+
+type Hypervisor interface {
+	Name() string
+
+	Create(string, string) (int, error)
+
+	Start(string, int) error
+	Tune(string, int, int) error
+	Stop(string, int, bool) error
+	Delete(string, int) error
+	Info(string, int) error
+	LookupByName(string, int) (int, error)
+
+	IsDeviceModelAlive(int) bool
+
+	PCIReserve(string) error
+	PCIRelease(string) error
+}
+
+func GetHypervisor(hint string) Hypervisor {
+	var knownHypervisors = map[string]func() Hypervisor{
+		"xen":  newXen,
+		"null": newNull,
+		"kvm":  newKvm,
+		"acrn": newAcrn,
+	}
+
+	if knownHypervisors[hint] == nil {
+		// direct hint failed, lets do dynamic discovery
+		if _, err := os.Stat("/proc/xen"); os.IsNotExist(err) {
+			hint = "xen"
+		} else if _, err := os.Stat("/dev/kvm"); os.IsNotExist(err) {
+			hint = "kvm"
+		} else if _, err := os.Stat("/dev/acrn"); os.IsNotExist(err) {
+			hint = "acrn"
+		} else {
+			hint = "null"
+		}
+	}
+
+	return knownHypervisors[hint]()
+}

--- a/pkg/pillar/hypervisor/hypervisor.go
+++ b/pkg/pillar/hypervisor/hypervisor.go
@@ -4,6 +4,7 @@
 package hypervisor
 
 import (
+	"fmt"
 	"os"
 )
 
@@ -26,27 +27,38 @@ type Hypervisor interface {
 	PCIRelease(string) error
 }
 
-// GetHypervisor returns a particular hypervisor implementation
-func GetHypervisor(hint string) Hypervisor {
-	var knownHypervisors = map[string]func() Hypervisor{
-		"xen":  newXen,
-		"null": newNull,
-		"kvm":  newKvm,
-		"acrn": newAcrn,
-	}
+type hypervisorDesc struct {
+	constructor func() Hypervisor
+	dom0handle  string
+}
 
-	if knownHypervisors[hint] == nil {
-		// direct hint failed, lets do dynamic discovery
-		if _, err := os.Stat("/proc/xen"); os.IsNotExist(err) {
-			hint = "xen"
-		} else if _, err := os.Stat("/dev/kvm"); os.IsNotExist(err) {
-			hint = "kvm"
-		} else if _, err := os.Stat("/dev/acrn"); os.IsNotExist(err) {
-			hint = "acrn"
-		} else {
-			hint = "null"
+var knownHypervisors = map[string]hypervisorDesc{
+	"xen":  {constructor: newXen, dom0handle: "/proc/xen"},
+	"kvm":  {constructor: newKvm, dom0handle: "/dev/kvm"},
+	"acrn": {constructor: newAcrn, dom0handle: "/dev/acrn"},
+	"null": {constructor: newNull, dom0handle: ""},
+}
+
+// GetHypervisor returns a particular hypervisor implementation
+func GetHypervisor(hint string) (Hypervisor, error) {
+	if _, found := knownHypervisors[hint]; !found {
+		return nil, fmt.Errorf("Unknown hypervisor %s", hint)
+	} else {
+		return knownHypervisors[hint].constructor(), nil
+	}
+}
+
+// GetAvailableHypervisors returns a list of all available hypervisors plus
+// the one that is enabled on the system. Note that you don't have to follow
+// the advice of this function and always ask for the enabled one.
+func GetAvailableHypervisors() (all []string, enabled []string) {
+	for k, v := range knownHypervisors {
+		all = append(all, k)
+		if _, err := os.Stat(v.dom0handle); err == nil {
+			enabled = append(enabled, k)
 		}
 	}
-
-	return knownHypervisors[hint]()
+	// null is always enabled for now
+	enabled = append(enabled, "null")
+	return
 }

--- a/pkg/pillar/hypervisor/hypervisor_test.go
+++ b/pkg/pillar/hypervisor/hypervisor_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2017-2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package hypervisor
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestGetHypervisor(t *testing.T) {
+	if _, err := GetHypervisor("quantum computing"); err == nil {
+		t.Errorf("Expected GetHypervisor to fail for quantum computing hypervisor (it doesn't have enough qbits yes)")
+	}
+
+	if hyper, err := GetHypervisor("null"); err != nil || hyper.Name() != "null" {
+		t.Errorf("Requested null hypervisor got %s (with error %v) instead", hyper.Name(), err)
+	}
+}
+
+func TestGetAvailableHypervisors(t *testing.T) {
+	all, enabled := GetAvailableHypervisors()
+	expected := []string{"acrn", "kvm", "null", "xen"}
+
+	sort.Strings(all)
+	if !reflect.DeepEqual(all, expected) {
+		t.Errorf("wrong list of available hypervisors: %+q vs. %+q", all, expected)
+	}
+
+	if len(enabled) < 0 {
+		t.Errorf("Not a single enabled hypervisor")
+	}
+
+	for _, v := range enabled {
+		if v == "null" {
+			return
+		}
+	}
+	t.Errorf("null is not in the list of enabled hypervisors")
+}

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2017-2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package hypervisor
+
+type KvmContext struct {
+}
+
+func newKvm() Hypervisor {
+	return KvmContext{}
+}
+
+func (ctx KvmContext) Name() string {
+	return "kvm"
+}
+
+func (ctx KvmContext) Create(domainName string, xenCfgFilename string) (int, error) {
+	return 0, nil
+}
+
+func (ctx KvmContext) Start(domainName string, domainID int) error {
+	return nil
+}
+
+func (ctx KvmContext) Stop(domainName string, domainID int, force bool) error {
+	return nil
+}
+
+func (ctx KvmContext) Delete(domainName string, domainID int) error {
+	return nil
+}
+
+func (ctx KvmContext) Info(domainName string, domainID int) error {
+	return nil
+}
+
+func (ctx KvmContext) LookupByName(domainName string, domainID int) (int, error) {
+	return 0, nil
+}
+
+func (ctx KvmContext) Tune(domainName string, domainID int, vifCount int) error {
+	return nil
+}
+
+func (ctx KvmContext) PCIReserve(long string) error {
+	return nil
+}
+
+func (ctx KvmContext) PCIRelease(long string) error {
+	return nil
+}
+
+func (ctx KvmContext) IsDeviceModelAlive(domid int) bool {
+	return true
+}

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -3,53 +3,53 @@
 
 package hypervisor
 
-type KvmContext struct {
+type kvmContext struct {
 }
 
 func newKvm() Hypervisor {
-	return KvmContext{}
+	return kvmContext{}
 }
 
-func (ctx KvmContext) Name() string {
+func (ctx kvmContext) Name() string {
 	return "kvm"
 }
 
-func (ctx KvmContext) Create(domainName string, xenCfgFilename string) (int, error) {
+func (ctx kvmContext) Create(domainName string, xenCfgFilename string) (int, error) {
 	return 0, nil
 }
 
-func (ctx KvmContext) Start(domainName string, domainID int) error {
+func (ctx kvmContext) Start(domainName string, domainID int) error {
 	return nil
 }
 
-func (ctx KvmContext) Stop(domainName string, domainID int, force bool) error {
+func (ctx kvmContext) Stop(domainName string, domainID int, force bool) error {
 	return nil
 }
 
-func (ctx KvmContext) Delete(domainName string, domainID int) error {
+func (ctx kvmContext) Delete(domainName string, domainID int) error {
 	return nil
 }
 
-func (ctx KvmContext) Info(domainName string, domainID int) error {
+func (ctx kvmContext) Info(domainName string, domainID int) error {
 	return nil
 }
 
-func (ctx KvmContext) LookupByName(domainName string, domainID int) (int, error) {
+func (ctx kvmContext) LookupByName(domainName string, domainID int) (int, error) {
 	return 0, nil
 }
 
-func (ctx KvmContext) Tune(domainName string, domainID int, vifCount int) error {
+func (ctx kvmContext) Tune(domainName string, domainID int, vifCount int) error {
 	return nil
 }
 
-func (ctx KvmContext) PCIReserve(long string) error {
+func (ctx kvmContext) PCIReserve(long string) error {
 	return nil
 }
 
-func (ctx KvmContext) PCIRelease(long string) error {
+func (ctx kvmContext) PCIRelease(long string) error {
 	return nil
 }
 
-func (ctx KvmContext) IsDeviceModelAlive(domid int) bool {
+func (ctx kvmContext) IsDeviceModelAlive(domid int) bool {
 	return true
 }

--- a/pkg/pillar/hypervisor/null.go
+++ b/pkg/pillar/hypervisor/null.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2017-2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package hypervisor
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type domState struct {
+	id     int
+	config string
+	state  string
+}
+
+type NullContext struct {
+	tempDir    string
+	doms       map[string]*domState
+	domCounter int
+	PCI        map[string]bool
+}
+
+func newNull() Hypervisor {
+	res := NullContext{tempDir: "/tmp",
+		doms:       map[string]*domState{},
+		domCounter: 0,
+		PCI:        map[string]bool{}}
+	if dir, err := ioutil.TempDir("", "null_domains"); err == nil {
+		res.tempDir = dir
+	}
+	return res
+}
+
+func (ctx NullContext) Name() string {
+	return "null"
+}
+
+func (ctx NullContext) Create(domainName string, cfgFilename string) (int, error) {
+	// pre-flight checks
+	if _, err := os.Stat(cfgFilename); domainName == "" || err != nil {
+		return 0, fmt.Errorf("Null Domain create failed to create domain with either empty name or empty config %s\n", domainName)
+	}
+	if _, found := ctx.doms[domainName]; found {
+		return 0, fmt.Errorf("Null Domain create failed to create existing domain %s\n", domainName)
+	}
+
+	domDescriptor := ctx.tempDir + "/" + domainName
+	domFile, err := os.Create(domDescriptor)
+	if err != nil {
+		return 0, fmt.Errorf("Null Domain create failed to create domain descriptor %v\n", err)
+	}
+
+	config, err := ioutil.ReadFile(cfgFilename)
+	if err != nil {
+		return 0, fmt.Errorf("Null Domain create failed to read cfgFilename %s %v\n", cfgFilename, err)
+	}
+
+	if _, err := domFile.Write(config); err != nil {
+		return 0, fmt.Errorf("Null Domain create failed to write domain descriptor %s %v\n", domDescriptor, err)
+	}
+
+	// calls to Create are serialized in the consumer: no need to worry about locking
+	ctx.domCounter++
+	ctx.doms[domainName] = &domState{id: ctx.domCounter, config: string(config), state: "stopped"}
+
+	return ctx.domCounter, nil
+}
+
+func (ctx NullContext) Start(domainName string, domainID int) error {
+	if dom, found := ctx.doms[domainName]; found && dom.state == "stopped" {
+		dom.state = "running"
+		return nil
+	} else {
+		return fmt.Errorf("null domain %s doesn't exist or is not stopped", domainName)
+	}
+}
+
+func (ctx NullContext) Stop(domainName string, domainID int, force bool) error {
+	if dom, found := ctx.doms[domainName]; found && dom.state == "running" {
+		dom.state = "stopped"
+		return nil
+	} else {
+		return fmt.Errorf("null domain %s doesn't exist or is not running", domainName)
+	}
+}
+
+func (ctx NullContext) Delete(domainName string, domainID int) error {
+	// calls to Delete are serialized in the consumer: no need to worry about locking
+	os.RemoveAll(ctx.tempDir + "/" + domainName)
+	delete(ctx.doms, domainName)
+	return nil
+}
+
+func (ctx NullContext) Info(domainName string, domainID int) error {
+	if dom, found := ctx.doms[domainName]; found {
+		log.Infof("Null Domain %s is %s and has the following config %s\n", domainName, dom.state, dom.config)
+		return nil
+	} else {
+		log.Errorf("Null Domain %s doesn't exist", domainName)
+		return fmt.Errorf("null domain %s doesn't exist", domainName)
+	}
+}
+
+func (ctx NullContext) LookupByName(domainName string, domainID int) (int, error) {
+	if dom, found := ctx.doms[domainName]; found {
+		return dom.id, nil
+	} else {
+		return 0, fmt.Errorf("null domain %s doesn't exist", domainName)
+	}
+}
+
+func (ctx NullContext) Tune(string, int, int) error {
+	return nil
+}
+
+func (ctx NullContext) PCIReserve(long string) error {
+	if ctx.PCI[long] {
+		return fmt.Errorf("PCI %s is already reserved", long)
+	} else {
+		ctx.PCI[long] = true
+		return nil
+	}
+}
+
+func (ctx NullContext) PCIRelease(long string) error {
+	if !ctx.PCI[long] {
+		return fmt.Errorf("PCI %s is not reserved", long)
+	} else {
+		ctx.PCI[long] = false
+		return nil
+	}
+}
+
+func (ctx NullContext) IsDeviceModelAlive(int) bool {
+	return true
+}

--- a/pkg/pillar/hypervisor/null.go
+++ b/pkg/pillar/hypervisor/null.go
@@ -17,7 +17,7 @@ type domState struct {
 	state  string
 }
 
-type NullContext struct {
+type nullContext struct {
 	tempDir    string
 	doms       map[string]*domState
 	domCounter int
@@ -25,7 +25,7 @@ type NullContext struct {
 }
 
 func newNull() Hypervisor {
-	res := NullContext{tempDir: "/tmp",
+	res := nullContext{tempDir: "/tmp",
 		doms:       map[string]*domState{},
 		domCounter: 0,
 		PCI:        map[string]bool{}}
@@ -35,11 +35,11 @@ func newNull() Hypervisor {
 	return res
 }
 
-func (ctx NullContext) Name() string {
+func (ctx nullContext) Name() string {
 	return "null"
 }
 
-func (ctx NullContext) Create(domainName string, cfgFilename string) (int, error) {
+func (ctx nullContext) Create(domainName string, cfgFilename string) (int, error) {
 	// pre-flight checks
 	if _, err := os.Stat(cfgFilename); domainName == "" || err != nil {
 		return 0, fmt.Errorf("Null Domain create failed to create domain with either empty name or empty config %s\n", domainName)
@@ -70,7 +70,7 @@ func (ctx NullContext) Create(domainName string, cfgFilename string) (int, error
 	return ctx.domCounter, nil
 }
 
-func (ctx NullContext) Start(domainName string, domainID int) error {
+func (ctx nullContext) Start(domainName string, domainID int) error {
 	if dom, found := ctx.doms[domainName]; found && dom.state == "stopped" {
 		dom.state = "running"
 		return nil
@@ -79,7 +79,7 @@ func (ctx NullContext) Start(domainName string, domainID int) error {
 	}
 }
 
-func (ctx NullContext) Stop(domainName string, domainID int, force bool) error {
+func (ctx nullContext) Stop(domainName string, domainID int, force bool) error {
 	if dom, found := ctx.doms[domainName]; found && dom.state == "running" {
 		dom.state = "stopped"
 		return nil
@@ -88,14 +88,14 @@ func (ctx NullContext) Stop(domainName string, domainID int, force bool) error {
 	}
 }
 
-func (ctx NullContext) Delete(domainName string, domainID int) error {
+func (ctx nullContext) Delete(domainName string, domainID int) error {
 	// calls to Delete are serialized in the consumer: no need to worry about locking
 	os.RemoveAll(ctx.tempDir + "/" + domainName)
 	delete(ctx.doms, domainName)
 	return nil
 }
 
-func (ctx NullContext) Info(domainName string, domainID int) error {
+func (ctx nullContext) Info(domainName string, domainID int) error {
 	if dom, found := ctx.doms[domainName]; found {
 		log.Infof("Null Domain %s is %s and has the following config %s\n", domainName, dom.state, dom.config)
 		return nil
@@ -105,7 +105,7 @@ func (ctx NullContext) Info(domainName string, domainID int) error {
 	}
 }
 
-func (ctx NullContext) LookupByName(domainName string, domainID int) (int, error) {
+func (ctx nullContext) LookupByName(domainName string, domainID int) (int, error) {
 	if dom, found := ctx.doms[domainName]; found {
 		return dom.id, nil
 	} else {
@@ -113,11 +113,11 @@ func (ctx NullContext) LookupByName(domainName string, domainID int) (int, error
 	}
 }
 
-func (ctx NullContext) Tune(string, int, int) error {
+func (ctx nullContext) Tune(string, int, int) error {
 	return nil
 }
 
-func (ctx NullContext) PCIReserve(long string) error {
+func (ctx nullContext) PCIReserve(long string) error {
 	if ctx.PCI[long] {
 		return fmt.Errorf("PCI %s is already reserved", long)
 	} else {
@@ -126,7 +126,7 @@ func (ctx NullContext) PCIReserve(long string) error {
 	}
 }
 
-func (ctx NullContext) PCIRelease(long string) error {
+func (ctx nullContext) PCIRelease(long string) error {
 	if !ctx.PCI[long] {
 		return fmt.Errorf("PCI %s is not reserved", long)
 	} else {
@@ -135,6 +135,6 @@ func (ctx NullContext) PCIRelease(long string) error {
 	}
 }
 
-func (ctx NullContext) IsDeviceModelAlive(int) bool {
+func (ctx nullContext) IsDeviceModelAlive(int) bool {
 	return true
 }

--- a/pkg/pillar/hypervisor/null_test.go
+++ b/pkg/pillar/hypervisor/null_test.go
@@ -68,33 +68,33 @@ serial = ['pty']
 		conf.Close()
 	}
 
-	domId, err := hyper.Create("test.1", conf.Name())
+	domID, err := hyper.Create("test.1", conf.Name())
 	if err != nil {
 		t.Errorf("Create domain test failed %v", err)
 	}
 
-	ctx := hyper.(NullContext)
+	ctx := hyper.(nullContext)
 	if _, err := os.Stat(ctx.tempDir + "/test.1"); err != nil {
 		t.Errorf("Create domain didn't deposit a file %s %v", ctx.tempDir, err)
 	}
 
-	if err := hyper.Stop("test.1", domId, true); err == nil {
+	if err := hyper.Stop("test.1", domID, true); err == nil {
 		t.Errorf("Stop domain should've failed for a domain that is not running")
 	}
 
-	if err := hyper.Start("test.1", domId); err != nil {
+	if err := hyper.Start("test.1", domID); err != nil {
 		t.Errorf("Couldn't start a domain %v", err)
 	}
 
-	if err := hyper.Start("test.1", domId); err == nil {
+	if err := hyper.Start("test.1", domID); err == nil {
 		t.Errorf("Start domain should've failed for a domain that is already running")
 	}
 
-	if err := hyper.Stop("test.1", domId, false); err != nil {
+	if err := hyper.Stop("test.1", domID, false); err != nil {
 		t.Errorf("Couldn't stop a domain %v", err)
 	}
 
-	if id, err := hyper.LookupByName("test.1", domId); err != nil || id != domId {
+	if id, err := hyper.LookupByName("test.1", domID); err != nil || id != domID {
 		t.Errorf("LookupByName domain failed %d %v", id, err)
 	}
 
@@ -106,11 +106,11 @@ serial = ['pty']
 		t.Errorf("Info domain should've failed for a domain that is non-existent")
 	}
 
-	if err := hyper.Info("test.1", domId); err != nil {
+	if err := hyper.Info("test.1", domID); err != nil {
 		t.Errorf("Info domain failed %v", err)
 	}
 
-	if err := hyper.Delete("test.1", domId); err != nil {
+	if err := hyper.Delete("test.1", domID); err != nil {
 		t.Errorf("Delete domain failed %v", err)
 	}
 }

--- a/pkg/pillar/hypervisor/null_test.go
+++ b/pkg/pillar/hypervisor/null_test.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2017-2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package hypervisor
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+var hyper = GetHypervisor("null")
+
+func TestNullCreate(t *testing.T) {
+	if _, err := hyper.Create("", ""); err == nil {
+		t.Errorf("Create domain should've failed for empty arguments")
+	}
+
+	if _, err := hyper.Create("", "/foo-bar-baz"); err == nil {
+		t.Errorf("Create domain should've failed for non-existen config")
+	}
+}
+
+func TestPCIAssignments(t *testing.T) {
+	if err := hyper.PCIRelease("00:1f.0"); err == nil {
+		t.Errorf("PCIRelease should've failed for a PCI endpoint that isn't reserved")
+	}
+
+	if err := hyper.PCIReserve("00:1f.0"); err != nil {
+		t.Errorf("PCIReserve failed %v", err)
+	}
+
+	if err := hyper.PCIReserve("00:1f.0"); err == nil {
+		t.Errorf("PCIReserve should've failed for a PCI endpoint that is already reserved")
+	}
+
+	if err := hyper.PCIRelease("00:1f.0"); err != nil {
+		t.Errorf("PCIRelease failed %v", err)
+	}
+}
+
+func TestBasicNullDomainWorkflow(t *testing.T) {
+	// t.Logf("Running test case")
+	conf, err := ioutil.TempFile("", "config")
+	if err != nil {
+		t.Errorf("Can't create config file for a domain %v", err)
+	} else {
+		defer os.Remove(conf.Name())
+	}
+	if _, err := conf.WriteString(`name = "test.1"
+type = "pv"
+uuid = "9330ccad-9b9d-4a9d-8059-ba03c70376f5"
+kernel = "/persist/downloads/appImg.obj/verified/604A43D23373715D0F7C26F4107698A9FB60AAE7067470B0CB60870A2F6AF174/mirage"
+vnc = 0
+memory = 250
+maxmem = 250
+vcpus = 1
+maxcpus = 1
+root = "/dev/xvda1"
+extra = "console=hvc0 appuuid=9330ccad-9b9d-4a9d-8059-ba03c70376f5 "
+boot = "dc"
+disk = []
+vif = []
+serial = ['pty']
+`); err != nil {
+		t.Errorf("Can't write config file for a domain %v", err)
+	} else {
+		conf.Close()
+	}
+
+	domId, err := hyper.Create("test.1", conf.Name())
+	if err != nil {
+		t.Errorf("Create domain test failed %v", err)
+	}
+
+	ctx := hyper.(NullContext)
+	if _, err := os.Stat(ctx.tempDir + "/test.1"); err != nil {
+		t.Errorf("Create domain didn't deposit a file %s %v", ctx.tempDir, err)
+	}
+
+	if err := hyper.Stop("test.1", domId, true); err == nil {
+		t.Errorf("Stop domain should've failed for a domain that is not running")
+	}
+
+	if err := hyper.Start("test.1", domId); err != nil {
+		t.Errorf("Couldn't start a domain %v", err)
+	}
+
+	if err := hyper.Start("test.1", domId); err == nil {
+		t.Errorf("Start domain should've failed for a domain that is already running")
+	}
+
+	if err := hyper.Stop("test.1", domId, false); err != nil {
+		t.Errorf("Couldn't stop a domain %v", err)
+	}
+
+	if id, err := hyper.LookupByName("test.1", domId); err != nil || id != domId {
+		t.Errorf("LookupByName domain failed %d %v", id, err)
+	}
+
+	if err := hyper.Info("", 0); err == nil {
+		t.Errorf("Info domain should've failed for a domain that is empty")
+	}
+
+	if err := hyper.Info("foo-bar-baz", 0); err == nil {
+		t.Errorf("Info domain should've failed for a domain that is non-existent")
+	}
+
+	if err := hyper.Info("test.1", domId); err != nil {
+		t.Errorf("Info domain failed %v", err)
+	}
+
+	if err := hyper.Delete("test.1", domId); err != nil {
+		t.Errorf("Delete domain failed %v", err)
+	}
+}

--- a/pkg/pillar/hypervisor/null_test.go
+++ b/pkg/pillar/hypervisor/null_test.go
@@ -4,12 +4,21 @@
 package hypervisor
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
 )
 
-var hyper = GetHypervisor("null")
+var hyper Hypervisor
+
+func init() {
+	var err error
+	hyper, err = GetHypervisor("null")
+	if hyper.Name() != "null" || err != nil {
+		panic(fmt.Sprintf("Requested null hypervisor, got %s (with error %v) instead", hyper.Name(), err))
+	}
+}
 
 func TestNullCreate(t *testing.T) {
 	if _, err := hyper.Create("", ""); err == nil {

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -14,18 +14,18 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-type XenContext struct {
+type xenContext struct {
 }
 
 func newXen() Hypervisor {
-	return XenContext{}
+	return xenContext{}
 }
 
-func (ctx XenContext) Name() string {
+func (ctx xenContext) Name() string {
 	return "xen"
 }
 
-func (ctx XenContext) Create(domainName string, xenCfgFilename string) (int, error) {
+func (ctx xenContext) Create(domainName string, xenCfgFilename string) (int, error) {
 	log.Infof("xlCreate %s %s\n", domainName, xenCfgFilename)
 	cmd := "xl"
 	args := []string{
@@ -62,7 +62,7 @@ func (ctx XenContext) Create(domainName string, xenCfgFilename string) (int, err
 	return domainID, nil
 }
 
-func (ctx XenContext) Start(domainName string, domainID int) error {
+func (ctx xenContext) Start(domainName string, domainID int) error {
 	log.Infof("xlUnpause %s %d\n", domainName, domainID)
 	cmd := "xl"
 	args := []string{
@@ -80,7 +80,7 @@ func (ctx XenContext) Start(domainName string, domainID int) error {
 	return nil
 }
 
-func (ctx XenContext) Stop(domainName string, domainID int, force bool) error {
+func (ctx xenContext) Stop(domainName string, domainID int, force bool) error {
 	log.Infof("xlShutdown %s %d\n", domainName, domainID)
 	cmd := "xl"
 	var args []string
@@ -107,7 +107,7 @@ func (ctx XenContext) Stop(domainName string, domainID int, force bool) error {
 	return nil
 }
 
-func (ctx XenContext) Delete(domainName string, domainID int) error {
+func (ctx xenContext) Delete(domainName string, domainID int) error {
 	log.Infof("xlDestroy %s %d\n", domainName, domainID)
 	cmd := "xl"
 	args := []string{
@@ -125,7 +125,7 @@ func (ctx XenContext) Delete(domainName string, domainID int) error {
 	return nil
 }
 
-func (ctx XenContext) Info(domainName string, domainID int) error {
+func (ctx xenContext) Info(domainName string, domainID int) error {
 	log.Infof("xlStatus %s %d\n", domainName, domainID)
 	// XXX xl list -l domainName returns json. XXX but state not included!
 	// Note that state is not very useful anyhow
@@ -149,7 +149,7 @@ func (ctx XenContext) Info(domainName string, domainID int) error {
 	return nil
 }
 
-func (ctx XenContext) LookupByName(domainName string, domainID int) (int, error) {
+func (ctx xenContext) LookupByName(domainName string, domainID int) (int, error) {
 	log.Debugf("xlDomid %s %d\n", domainName, domainID)
 	cmd := "xl"
 	args := []string{
@@ -179,7 +179,7 @@ func (ctx XenContext) LookupByName(domainName string, domainID int) (int, error)
 
 // Perform xenstore write to disable all of these for all VIFs
 // feature-sg, feature-gso-tcpv4, feature-gso-tcpv6, feature-ipv6-csum-offload
-func (ctx XenContext) Tune(domainName string, domainID int, vifCount int) error {
+func (ctx xenContext) Tune(domainName string, domainID int, vifCount int) error {
 	log.Infof("xlDisableVifOffload %s %d %d\n",
 		domainName, domainID, vifCount)
 	pref := "/local/domain"
@@ -229,7 +229,7 @@ func (ctx XenContext) Tune(domainName string, domainID int, vifCount int) error 
 	return nil
 }
 
-func (ctx XenContext) PCIReserve(long string) error {
+func (ctx xenContext) PCIReserve(long string) error {
 	log.Infof("pciAssignableAdd %s\n", long)
 	cmd := "xl"
 	args := []string{
@@ -247,7 +247,7 @@ func (ctx XenContext) PCIReserve(long string) error {
 	return nil
 }
 
-func (ctx XenContext) PCIRelease(long string) error {
+func (ctx xenContext) PCIRelease(long string) error {
 	log.Infof("pciAssignableRemove %s\n", long)
 	cmd := "xl"
 	args := []string{
@@ -266,7 +266,7 @@ func (ctx XenContext) PCIRelease(long string) error {
 	return nil
 }
 
-func (ctx XenContext) IsDeviceModelAlive(domid int) bool {
+func (ctx xenContext) IsDeviceModelAlive(domid int) bool {
 	// create pgrep command to see if dataplane is running
 	match := fmt.Sprintf("domid %d", domid)
 	cmd := wrap.Command("pgrep", "-f", match)

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -1,0 +1,286 @@
+// Copyright (c) 2017-2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package hypervisor
+
+import (
+	"errors"
+	"fmt"
+	"github.com/lf-edge/eve/pkg/pillar/wrap"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type XenContext struct {
+}
+
+func newXen() Hypervisor {
+	return XenContext{}
+}
+
+func (ctx XenContext) Name() string {
+	return "xen"
+}
+
+func (ctx XenContext) Create(domainName string, xenCfgFilename string) (int, error) {
+	log.Infof("xlCreate %s %s\n", domainName, xenCfgFilename)
+	cmd := "xl"
+	args := []string{
+		"create",
+		xenCfgFilename,
+		"-p",
+	}
+	stdoutStderr, err := wrap.Command(cmd, args...).CombinedOutput()
+	if err != nil {
+		log.Errorln("xl create failed ", err)
+		log.Errorln("xl create output ", string(stdoutStderr))
+		return 0, fmt.Errorf("xl create failed: %s\n",
+			string(stdoutStderr))
+	}
+	log.Infof("xl create done\n")
+
+	args = []string{
+		"domid",
+		domainName,
+	}
+	stdoutStderr, err = wrap.Command(cmd, args...).CombinedOutput()
+	if err != nil {
+		log.Errorln("xl domid failed ", err)
+		log.Errorln("xl domid output ", string(stdoutStderr))
+		return 0, fmt.Errorf("xl domid failed: %s\n",
+			string(stdoutStderr))
+	}
+	res := strings.TrimSpace(string(stdoutStderr))
+	domainID, err := strconv.Atoi(res)
+	if err != nil {
+		log.Errorf("Can't extract domainID from %s: %s\n", res, err)
+		return 0, fmt.Errorf("Can't extract domainID from %s: %s\n", res, err)
+	}
+	return domainID, nil
+}
+
+func (ctx XenContext) Start(domainName string, domainID int) error {
+	log.Infof("xlUnpause %s %d\n", domainName, domainID)
+	cmd := "xl"
+	args := []string{
+		"unpause",
+		domainName,
+	}
+	stdoutStderr, err := wrap.Command(cmd, args...).CombinedOutput()
+	if err != nil {
+		log.Errorln("xl unpause failed ", err)
+		log.Errorln("xl unpause output ", string(stdoutStderr))
+		return fmt.Errorf("xl unpause failed: %s\n",
+			string(stdoutStderr))
+	}
+	log.Infof("xlUnpause done. Result %s\n", string(stdoutStderr))
+	return nil
+}
+
+func (ctx XenContext) Stop(domainName string, domainID int, force bool) error {
+	log.Infof("xlShutdown %s %d\n", domainName, domainID)
+	cmd := "xl"
+	var args []string
+	if force {
+		args = []string{
+			"shutdown",
+			"-F",
+			domainName,
+		}
+	} else {
+		args = []string{
+			"shutdown",
+			domainName,
+		}
+	}
+	stdoutStderr, err := wrap.Command(cmd, args...).CombinedOutput()
+	if err != nil {
+		log.Errorln("xl shutdown failed ", err)
+		log.Errorln("xl shutdown output ", string(stdoutStderr))
+		return fmt.Errorf("xl shutdown failed: %s\n",
+			string(stdoutStderr))
+	}
+	log.Infof("xl shutdown done\n")
+	return nil
+}
+
+func (ctx XenContext) Delete(domainName string, domainID int) error {
+	log.Infof("xlDestroy %s %d\n", domainName, domainID)
+	cmd := "xl"
+	args := []string{
+		"destroy",
+		domainName,
+	}
+	stdoutStderr, err := wrap.Command(cmd, args...).CombinedOutput()
+	if err != nil {
+		log.Errorln("xl destroy failed ", err)
+		log.Errorln("xl destroy output ", string(stdoutStderr))
+		return fmt.Errorf("xl destroy failed: %s\n",
+			string(stdoutStderr))
+	}
+	log.Infof("xl destroy done\n")
+	return nil
+}
+
+func (ctx XenContext) Info(domainName string, domainID int) error {
+	log.Infof("xlStatus %s %d\n", domainName, domainID)
+	// XXX xl list -l domainName returns json. XXX but state not included!
+	// Note that state is not very useful anyhow
+	cmd := "xl"
+	args := []string{
+		"list",
+		"-l",
+		domainName,
+	}
+	stdoutStderr, err := wrap.Command(cmd, args...).CombinedOutput()
+	if err != nil {
+		log.Errorln("xl list failed ", err)
+		log.Errorln("xl list output ", string(stdoutStderr))
+		return fmt.Errorf("xl list failed: %s\n",
+			string(stdoutStderr))
+	}
+	// XXX parse json to look at state? Not currently included
+	// XXX note that there is a warning at the top of the combined
+	// output. If we want to parse the json we need to get Output()
+	log.Infof("xl list done. Result %s\n", string(stdoutStderr))
+	return nil
+}
+
+func (ctx XenContext) LookupByName(domainName string, domainID int) (int, error) {
+	log.Debugf("xlDomid %s %d\n", domainName, domainID)
+	cmd := "xl"
+	args := []string{
+		"domid",
+		domainName,
+	}
+	// Avoid wrap since we are called periodically
+	stdoutStderr, err := exec.Command(cmd, args...).CombinedOutput()
+	if err != nil {
+		log.Debugln("xl domid failed ", err)
+		log.Debugln("xl domid output ", string(stdoutStderr))
+		return domainID, fmt.Errorf("xl domid failed: %s\n",
+			string(stdoutStderr))
+	}
+	res := strings.TrimSpace(string(stdoutStderr))
+	domainID2, err := strconv.Atoi(res)
+	if err != nil {
+		log.Errorf("xl domid not integer %s: failed %s\n", res, err)
+		return domainID, err
+	}
+	if domainID2 != domainID {
+		log.Warningf("domainid changed from %d to %d for %s\n",
+			domainID, domainID2, domainName)
+	}
+	return domainID2, err
+}
+
+// Perform xenstore write to disable all of these for all VIFs
+// feature-sg, feature-gso-tcpv4, feature-gso-tcpv6, feature-ipv6-csum-offload
+func (ctx XenContext) Tune(domainName string, domainID int, vifCount int) error {
+	log.Infof("xlDisableVifOffload %s %d %d\n",
+		domainName, domainID, vifCount)
+	pref := "/local/domain"
+	for i := 0; i < vifCount; i += 1 {
+		varNames := []string{
+			fmt.Sprintf("%s/0/backend/vif/%d/%d/feature-sg",
+				pref, domainID, i),
+			fmt.Sprintf("%s/0/backend/vif/%d/%d/feature-gso-tcpv4",
+				pref, domainID, i),
+			fmt.Sprintf("%s/0/backend/vif/%d/%d/feature-gso-tcpv6",
+				pref, domainID, i),
+			fmt.Sprintf("%s/0/backend/vif/%d/%d/feature-ipv4-csum-offload",
+				pref, domainID, i),
+			fmt.Sprintf("%s/0/backend/vif/%d/%d/feature-ipv6-csum-offload",
+				pref, domainID, i),
+			fmt.Sprintf("%s/%d/device/vif/%d/feature-sg",
+				pref, domainID, i),
+			fmt.Sprintf("%s/%d/device/vif/%d/feature-gso-tcpv4",
+				pref, domainID, i),
+			fmt.Sprintf("%s/%d/device/vif/%d/feature-gso-tcpv6",
+				pref, domainID, i),
+			fmt.Sprintf("%s/%d/device/vif/%d/feature-ipv4-csum-offload",
+				pref, domainID, i),
+			fmt.Sprintf("%s/%d/device/vif/%d/feature-ipv6-csum-offload",
+				pref, domainID, i),
+		}
+		for _, varName := range varNames {
+			cmd := "xenstore"
+			args := []string{
+				"write",
+				varName,
+				"0",
+			}
+			stdoutStderr, err := wrap.Command(cmd, args...).CombinedOutput()
+			if err != nil {
+				log.Errorln("xenstore write failed ", err)
+				log.Errorln("xenstore write output ", string(stdoutStderr))
+				return fmt.Errorf("xenstore write failed: %s\n",
+					string(stdoutStderr))
+			}
+			log.Debugf("xenstore write done. Result %s\n",
+				string(stdoutStderr))
+		}
+	}
+
+	log.Infof("xlDisableVifOffload done.\n")
+	return nil
+}
+
+func (ctx XenContext) PCIReserve(long string) error {
+	log.Infof("pciAssignableAdd %s\n", long)
+	cmd := "xl"
+	args := []string{
+		"pci-assignable-add",
+		long,
+	}
+	stdoutStderr, err := wrap.Command(cmd, args...).CombinedOutput()
+	if err != nil {
+		errStr := fmt.Sprintf("xl pci-assignable-add failed: %s\n",
+			string(stdoutStderr))
+		log.Errorln(errStr)
+		return errors.New(errStr)
+	}
+	log.Infof("xl pci-assignable-add done\n")
+	return nil
+}
+
+func (ctx XenContext) PCIRelease(long string) error {
+	log.Infof("pciAssignableRemove %s\n", long)
+	cmd := "xl"
+	args := []string{
+		"pci-assignable-rem",
+		"-r",
+		long,
+	}
+	stdoutStderr, err := wrap.Command(cmd, args...).CombinedOutput()
+	if err != nil {
+		errStr := fmt.Sprintf("xl pci-assignable-rem failed: %s\n",
+			string(stdoutStderr))
+		log.Errorln(errStr)
+		return errors.New(errStr)
+	}
+	log.Infof("xl pci-assignable-rem done\n")
+	return nil
+}
+
+func (ctx XenContext) IsDeviceModelAlive(domid int) bool {
+	// create pgrep command to see if dataplane is running
+	match := fmt.Sprintf("domid %d", domid)
+	cmd := wrap.Command("pgrep", "-f", match)
+
+	// pgrep returns 0 when there is atleast one matching program running
+	// cmd.Output returns nil when pgrep returns 0, otherwise pids.
+	out, err := cmd.Output()
+
+	if err != nil {
+		log.Infof("IsDeviceModelAlive: %s process is not running: %s",
+			match, err)
+		return false
+	}
+	log.Infof("IsDeviceModelAlive: Instances of %s is running: %s",
+		match, out)
+	return true
+}


### PR DESCRIPTION
This is a first tiny step on a long road to refactor domainmanager in order to support pluggable hypervisor frameworks. What's included in this PR:
   1. a trivial move of existing functionality out of domainmanager into hypervisor package (under xen implementation)
   2. introduction of a new null hypervisor that doesn't really do anything at all, but is very useful for testing (hint: we can now start writing unit tests for the domainmanager itself) and also while running EVE as a virtual instance.
   3. introduction of skeletons for kvm and acrn hypervisors

Now, I admit that #3 could be a tad... aspirational... but I got pretty excited and for both I actually have code ready to go in.

Also, note that since this is the first step in refactoring, I really didn't want to change the signatures on all those methods I was moving out of domainmanager. That will come later and is very likely to be modeled on the vmadm API for SmartOS https://smartos.org/man/1m/vmadm (because friends, don't let friends use libvirt APIs)

An a finally note on null hypervisor: this is proving to be pretty useful in testing with virtualized (read qemu hosted) version of EVE. Granted, you can't really run domains on EVE that way, but because domainmanager is fully under the impression that the are running just fine -- you can test all the rest of the EVE workflows by simply statically configuring null (via -h null option passed to domainmanager from device-steps.sh). Once we improve this further I'll make this part more dynamic -- but it is really useful even as-is as I'm discovering in my testing.