### PR TITLE
First step towards enabling EVE deployments via docker-compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,6 +211,10 @@ run-grub: $(BIOS_IMG) $(EFI_PART) $(DEVICETREE_DTB)
 	[ -f $(EFI_PART)/BOOT/grub.cfg ] && mv $(EFI_PART)/BOOT/grub.cfg $(EFI_PART)/BOOT/grub.cfg.$(notdir $(shell mktemp))
 	$(QEMU_SYSTEM) $(QEMU_OPTS) -drive format=vvfat,label=EVE,file=fat:rw:$(EFI_PART)/..
 
+run-compose: images/docker-compose.yml images/version.yml
+	docker-compose -f $< run storage-init sh -c 'rm -rf /run/* /config/* ; cp -Lr /conf/* /config/ ; echo IMGA > /run/eve.id'
+	docker-compose -f $< up
+
 # ensure the dist directory exists
 $(DIST) $(INSTALLER):
 	mkdir -p $@
@@ -380,6 +384,7 @@ help:
 	@echo "   installer-iso  builds an ISO installers image (to be installed on bootable media)"
 	@echo
 	@echo "Commonly used run targets (note they don't automatically rebuild images they run):"
+	@echo "   run-compose       runs all EVE microservices via docker-compose deployment"
 	@echo "   run-live          runs a full fledged virtual device on qemu (as close as it gets to actual h/w)"
 	@echo "   run-rootfs        runs a rootfs.img (limited usefulness e.g. quick test before cloud upload)"
 	@echo "   run-grub          runs our copy of GRUB bootloader and nothing else (very limited usefulness)"

--- a/images/docker-compose.yml.in
+++ b/images/docker-compose.yml.in
@@ -6,6 +6,21 @@ volumes:
     run: {}
 
 networks:
+    # eve-host:
+    #    external:
+    #        name: host
+    # eve-ipvlan:
+    #    driver: ipvlan
+    #    driver_opts:
+    #        parent: eth0.50
+    #        ipvlan_mode: l2
+    #    enable_ipv6: true
+    #    ipam:
+    #        config:
+    #            - subnet: fde3:84ac:fc48::/48
+    #            - gateway: fde3:84ac:fc48::1
+    #            - subnet: 1.1.1.0/24
+    #            - gateway: 1.1.1.1
     eve:
         driver: bridge
         driver_opts:
@@ -33,6 +48,7 @@ services:
             - type: bind
               source: CURDIR/pkg
               target: /pkg
+        # network_mode: host
         networks:
             - eve
 
@@ -43,6 +59,7 @@ services:
             - persist:/persist
             - config:/config
             - run:/run
+        # network_mode: host
         networks:
             - eve
 
@@ -53,6 +70,7 @@ services:
             - persist:/persist
             - config:/config
             - run:/run
+        # network_mode: host
         networks:
             - eve
 
@@ -63,6 +81,7 @@ services:
             - persist:/persist
             - config:/config
             - run:/run
+        # network_mode: host
         networks:
             - eve
 
@@ -73,6 +92,7 @@ services:
             - persist:/persist
             - config:/config
             - run:/run
+        # network_mode: host
         networks:
             - eve
 
@@ -83,6 +103,7 @@ services:
             - persist:/persist
             - config:/config
             - run:/run
+        # network_mode: host
         networks:
             - eve
 
@@ -93,6 +114,7 @@ services:
             - persist:/persist
             - config:/config
             - run:/run
+        # network_mode: host
         networks:
             - eve
 
@@ -103,6 +125,7 @@ services:
             - persist:/persist
             - config:/config
             - run:/run
+        # network_mode: host
         networks:
             - eve
 
@@ -113,6 +136,7 @@ services:
             - persist:/persist
             - config:/config
             - run:/run
+        # network_mode: host
         networks:
             - eve
 
@@ -123,6 +147,7 @@ services:
             - persist:/persist
             - config:/config
             - run:/run
+        # network_mode: host
         networks:
             - eve
 
@@ -142,6 +167,7 @@ services:
             - type: bind
               source: CURDIR/tools/fake-zboot.sh
               target: /usr/bin/zboot
+        # network_mode: host
         networks:
             - eve
 
@@ -152,5 +178,6 @@ services:
             - persist:/persist
             - config:/config
             - run:/run
+        # network_mode: host
         networks:
             - eve

--- a/images/docker-compose.yml.in
+++ b/images/docker-compose.yml.in
@@ -1,0 +1,156 @@
+version: '2.3'
+
+volumes:
+    persist: {}
+    config: {}
+    run: {}
+
+networks:
+    eve:
+        driver: bridge
+        driver_opts:
+            com.docker.network.bridge.enable_ip_masquerade: 'true'
+            com.docker.network.bridge.default_bridge: 'true'
+            com.docker.network.bridge.enable_icc: 'true'
+            com.docker.network.bridge.host_binding_ipv4: '0.0.0.0'
+            com.docker.network.driver.mtu: '1500'
+        enable_ipv6: true
+        ipam:
+            config:
+                - subnet: fde3:84ac:fc48::/48
+                - subnet: 1.1.1.0/24
+
+services:
+    # this is the only service from the onboot: section
+    storage-init:
+        image: STORAGE_INIT_TAG
+        volumes:
+            - persist:/persist
+            - config:/config
+            - type: bind
+              source: CURDIR/conf
+              target: /conf
+            - type: bind
+              source: CURDIR/pkg
+              target: /pkg
+        networks:
+            - eve
+
+    ntpd:
+        image: linuxkit/openntpd:v0.5
+        privileged: true
+        volumes:
+            - persist:/persist
+            - config:/config
+            - run:/run
+        networks:
+            - eve
+
+    rsyslogd:
+        image: RSYSLOGD_TAG
+        privileged: true
+        volumes:
+            - persist:/persist
+            - config:/config
+            - run:/run
+        networks:
+            - eve
+
+    wwan:
+        image: WWAN_TAG
+        privileged: true
+        volumes:
+            - persist:/persist
+            - config:/config
+            - run:/run
+        networks:
+            - eve
+
+    wlan:
+        image: WLAN_TAG
+        privileged: true
+        volumes:
+            - persist:/persist
+            - config:/config
+            - run:/run
+        networks:
+            - eve
+
+    lisp:
+        image: LISP_TAG
+        privileged: true
+        volumes:
+            - persist:/persist
+            - config:/config
+            - run:/run
+        networks:
+            - eve
+
+    guacd:
+        image: GUACD_TAG
+        privileged: true
+        volumes:
+            - persist:/persist
+            - config:/config
+            - run:/run
+        networks:
+            - eve
+
+    vtpm:
+        image: VTPM_TAG
+        privileged: true
+        volumes:
+            - persist:/persist
+            - config:/config
+            - run:/run
+        networks:
+            - eve
+
+    watchdog:
+        image: WATCHDOG_TAG
+        privileged: true
+        volumes:
+            - persist:/persist
+            - config:/config
+            - run:/run
+        networks:
+            - eve
+
+    xen-tools:
+        image: XENTOOLS_TAG
+        privileged: true
+        volumes:
+            - persist:/persist
+            - config:/config
+            - run:/run
+        networks:
+            - eve
+
+    pillar:
+        image: PILLAR_TAG
+        # privileged: true
+        volumes:
+            - persist:/persist
+            - config:/config
+            - run:/run
+            - type: bind
+              source: CURDIR/images/version.yml
+              target: /opt/zededa/bin/versioninfo
+            - type: bind
+              source: CURDIR/images/version.yml
+              target: /etc/eve-release
+            - type: bind
+              source: CURDIR/tools/fake-zboot.sh
+              target: /usr/bin/zboot
+        networks:
+            - eve
+
+    sshd:
+        image: linuxkit/sshd:v0.5
+        privileged: true
+        volumes:
+            - persist:/persist
+            - config:/config
+            - run:/run
+        networks:
+            - eve

--- a/images/version.yml.in
+++ b/images/version.yml.in
@@ -1,0 +1,1 @@
+EVE_VERSION

--- a/pkg/watchdog/watchdog-report.sh
+++ b/pkg/watchdog/watchdog-report.sh
@@ -30,8 +30,8 @@ echo "Watchdog report at $DATE: $*" >>/persist/log/watchdog.log
 ps >>/persist/log/watchdog.log
 echo "Watchdog report done" >>/persist/log/watchdog.log
 
-CURPART=$(zboot curpart)
-echo "Watchdog report at $DATE: $*" >>/persist/"$CURPART"/reboot-reason
+CURPART=$(cat /run/eve.id)
+echo "Watchdog report at $DATE: $*" >>/persist/"${CURPART:-IMGA}"/reboot-reason
 
 # If a /run/<agent.pid> then look for an oom message in dmesg for that agent
 # and always record <agent> in reboot-reason

--- a/tools/fake-zboot.sh
+++ b/tools/fake-zboot.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo IMGA

--- a/tools/parse-pkgs.sh
+++ b/tools/parse-pkgs.sh
@@ -64,6 +64,7 @@ resolve_tags() {
 sed -e '/-.*linuxkit\/.*:/s# *$#'${ARCH}# \
     -e '/image:.*linuxkit\/.*:/s# *$#'${ARCH}# \
     -e "s#EVE_VERSION#$EVE_VERSION#" \
+    -e "s#CURDIR#$(pwd)#" \
     -e "s#ACRN_KERNEL_TAG#$ACRN_KERNEL_TAG#" \
     -e "s#KERNEL_TAG#$KERNEL_TAG#" \
     -e "s#FW_TAG#$FW_TAG#" \


### PR DESCRIPTION
This now allows one to type make run-compose and have a lot of fun.

Seriously, though -- there's still quite a bit of work left in making pillar services do the right thing in this type of environment -- but the first results are pretty promising.