### PR TITLE
Minor refining on containerd.go 

### DIFF
--- a/pkg/pillar/cmd/domainmgr/containerd.go
+++ b/pkg/pillar/cmd/domainmgr/containerd.go
@@ -236,13 +236,13 @@ func ctrPrepare(ociFilename string, envVars map[string]string, noOfDisks int) (s
 		return containerID, fmt.Errorf("ctrPrepare: failed to create container %s, error: %v", containerID, err.Error())
 	}
 	// inject a few files of our own into the bundle
-	containerRootfs := getContainerRootfs(containerID)
+	containerpath := getContainerPath(containerID)
 	mountpoints, execpath, workdir, env, err := getContainerConfigs(imageInfo, envVars)
 	if err != nil {
 		return containerID, fmt.Errorf("ctrPrepare: unable to get container config: %v", err)
 	}
 
-	err = createMountPointExecEnvFiles(containerRootfs, mountpoints, execpath, workdir, env, noOfDisks)
+	err = createMountPointExecEnvFiles(containerpath, mountpoints, execpath, workdir, env, noOfDisks)
 
 	return containerID, err
 }

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1253,7 +1253,7 @@ func doActivate(ctx *domainContext, config types.DomainConfig,
 			return
 		}
 
-		file.WriteString(fmt.Sprintf("p9=[ 'tag=share_dir,security_model=none,path=%s']\n", getContainerRootfs(podUUID)))
+		file.WriteString(fmt.Sprintf("p9=[ 'tag=share_dir,security_model=none,path=%s']\n", getContainerPath(podUUID)))
 
 		status.PodUUID = podUUID
 	}
@@ -1668,10 +1668,10 @@ func configAdapters(ctx *domainContext, config types.DomainConfig) error {
 	return nil
 }
 
-func createMountPointExecEnvFiles(rootFs string, mountpoints map[string]struct{}, execpath []string, workdir string, env []string, noOfDisks int) error {
-	mpFileName := rootFs + "/mountPoints"
-	cmdFileName := rootFs + "/cmdline"
-	envFileName := rootFs + "/environment"
+func createMountPointExecEnvFiles(containerPath string, mountpoints map[string]struct{}, execpath []string, workdir string, env []string, noOfDisks int) error {
+	mpFileName := containerPath + "/mountPoints"
+	cmdFileName := containerPath + "/cmdline"
+	envFileName := containerPath + "/environment"
 
 	mpFile, err := os.Create(mpFileName)
 	if err != nil {

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -363,6 +363,10 @@ func Run(ps *pubsub.PubSub) {
 	gc := time.NewTicker(duration * time.Second)
 	gcResetObjectsLastUse(&domainCtx, rwImgDirname)
 
+	if err := initContainerdClient(); err != nil {
+		log.Fatal(err)
+	}
+	defer ctrdClient.Close()
 	for {
 		select {
 		case change := <-subGlobalConfig.MsgChan():

--- a/pkg/xen-tools/initrd/mount_disk.sh
+++ b/pkg/xen-tools/initrd/mount_disk.sh
@@ -14,13 +14,6 @@ ls /sys/block/ | grep xvd | while read -r disk ; do
   major=$(echo ${IN} | cut -d' ' -f1)
   minor=$(echo ${IN} | cut -d' ' -f2)
 
-  #Creating a block device under /dev with Major and minor devices
-  echo "Creating device file /dev/$disk"
-  mknod /dev/$disk b $major $minor && \
-  echo "Successfully created device file for /dev/$disk" || \
-  echo "Failed to create device file for /dev/$disk"
-  echo
-
   #Checking and creating a file system inside the partition
   fileSystem="vfat"
   existingFileSystem="$(eval $(blkid /dev/$disk | awk ' { print $3 } '); echo $TYPE)"


### PR DESCRIPTION
1. Cleaning up bundle was failing as rootfs was not unmounted before deleting the bundle. Fixed that.
2. Initializing containerd client and context at the init of donmainmgr. 
3. Removed use of exec to mount rootfs. Will be using inbuilt Mount() of mount object which internally uses unix.Mount() 