### PR TITLE
Missing code to report ParseError in DevicePortStatus

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -1225,6 +1225,13 @@ func encodeNetworkPortConfig(npc *types.NetworkPortConfig) *info.DevicePort {
 	// XXX  string dhcpRangeHigh = 18;
 
 	dp.Proxy = encodeProxyStatus(&npc.ProxyConfig)
+	if !npc.ParseErrorTime.IsZero() {
+		errInfo := new(info.ErrorInfo)
+		errInfo.Description = npc.ParseError
+		errTime, _ := ptypes.TimestampProto(npc.ParseErrorTime)
+		errInfo.Timestamp = errTime
+		dp.Err = errInfo
+	}
 	return dp
 }
 


### PR DESCRIPTION
Seems like this was never tested.