### PR TITLE
Being more agressive in clearing out existing GPT partitions

### DIFF
--- a/pkg/mkimage-raw-efi/make-raw
+++ b/pkg/mkimage-raw-efi/make-raw
@@ -282,10 +282,10 @@ case "$(sgdisk -p $IMGFILE 2>/dev/null | sed -ne '/^Number/,$s/^.* //p' | tr '\0
       ;;
   "Name System IMGA IMGB CONFIG P3"*)
       echo "Found EVE GPT partition table on $IMGFILE"
-      sgdisk -g --clear $IMGFILE 2>/dev/null
+      sgdisk -Z --clear $IMGFILE 2>/dev/null
       ;;
    *) echo "Unknown (or unrecongnizable) GTP partition table on $IMGFILE"
-      sgdisk -g --clear $IMGFILE 2>/dev/null
+      sgdisk -Z --clear $IMGFILE 2>/dev/null
       ;;
 esac
 


### PR DESCRIPTION
So the issue is that sgdisk in its infinite wisdom is actually doing the right thing with -g on disks that have a *corrupted* GPT partition but then it returns a non-0 exist code.

It seems that -Z (which is much more aggressive) doesn't have that problem and since we don't really care about preserving anything on the existing disk -- lets just use that.