### PR TITLE
[DO_NOT_MERGE] Enable key migration for the vaults to use TPM based keys.

### DIFF
--- a/pkg/pillar/cmd/vaultmgr/vaultmgr.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgr.go
@@ -319,7 +319,7 @@ func setupVault(vaultPath string) error {
 		if err := unlockVault(vaultPath, true); err != nil {
 			return err
 		}
-		//return changeProtector(vaultPath)
+		return changeProtector(vaultPath)
 	}
 	return nil
 }


### PR DESCRIPTION
Any production device upgrading to this device needs to be
upgraded to one of 4.9.x/4.10.x first.

Signed-off-by: Hariharasubramanian C S <cshari@zededa.com>