### PR TITLE
adapter assignments from controller now refer by name not assignmentGroup

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1135,7 +1135,7 @@ func cleanupAdapters(ctx *domainContext, ioAdapterList []types.IoAdapter,
 	for _, adapter := range ioAdapterList {
 		log.Debugf("cleanupAdapters processing adapter %d %s\n",
 			adapter.Type, adapter.Name)
-		list := ctx.assignableAdapters.LookupIoBundleGroup(adapter.Name)
+		list := ctx.assignableAdapters.LookupIoBundleAny(adapter.Name)
 		if len(list) == 0 {
 			continue
 		}
@@ -1166,7 +1166,7 @@ func doAssignIoAdaptersToDomain(ctx *domainContext, config types.DomainConfig,
 			adapter.Type, adapter.Name)
 
 		aa := ctx.assignableAdapters
-		list := aa.LookupIoBundleGroup(adapter.Name)
+		list := aa.LookupIoBundleAny(adapter.Name)
 		// We reserved it in handleCreate so nobody could have stolen it
 		if len(list) == 0 {
 			log.Fatalf("doAssignIoAdaptersToDomain IoBundle disappeared %d %s for %s\n",
@@ -1522,7 +1522,7 @@ func pciUnassign(ctx *domainContext, status *types.DomainStatus,
 		log.Debugf("doInactivate processing adapter %d %s\n",
 			adapter.Type, adapter.Name)
 		aa := ctx.assignableAdapters
-		list := aa.LookupIoBundleGroup(adapter.Name)
+		list := aa.LookupIoBundleAny(adapter.Name)
 		// We reserved it in handleCreate so nobody could have stolen it
 		if len(list) == 0 {
 			log.Fatalf("doInactivate IoBundle disappeared %d %s for %s\n",
@@ -1679,7 +1679,7 @@ func configAdapters(ctx *domainContext, config types.DomainConfig) error {
 		log.Debugf("configAdapters processing adapter %d %s\n",
 			adapter.Type, adapter.Name)
 		// Lookup to make sure adapter exists on this device
-		list := ctx.assignableAdapters.LookupIoBundleGroup(adapter.Name)
+		list := ctx.assignableAdapters.LookupIoBundleAny(adapter.Name)
 		if len(list) == 0 {
 			return fmt.Errorf("unknown adapter %d %s",
 				adapter.Type, adapter.Name)

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -823,7 +823,7 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 				break
 			}
 		}
-		if seen {
+		if seen && ib.AssignmentGroup != "" {
 			continue
 		}
 		seenBundles = append(seenBundles, ib.AssignmentGroup)
@@ -835,8 +835,10 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 			if ib.AssignmentGroup != "" {
 				log.Infof("Nothing to report for %d %s",
 					ib.Type, ib.AssignmentGroup)
+				continue
 			}
-			continue
+			// Singleton
+			list = append(list, &ib)
 		}
 		for _, b := range list {
 			if b == nil {
@@ -1298,7 +1300,7 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 			reportAA.Type = info.IPhyIoType(ia.Type)
 			reportAA.Name = ia.Name
 			reportAA.UsedByAppUUID = aiStatus.Key()
-			list := aa.LookupIoBundleGroup(ia.Name)
+			list := aa.LookupIoBundleAny(ia.Name)
 			for _, ib := range list {
 				if ib == nil {
 					continue

--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -113,7 +113,7 @@ func prepareAndPublishNetworkInstanceInfoMsg(ctx *zedagentContext,
 			reportAA.Type = zinfo.IPhyIoType(ia.Type)
 			reportAA.Name = ia.Name
 			reportAA.UsedByAppUUID = zcdevUUID.String()
-			list := ctx.assignableAdapters.LookupIoBundleGroup(ia.Name)
+			list := ctx.assignableAdapters.LookupIoBundleAny(ia.Name)
 			for _, ib := range list {
 				if ib == nil {
 					continue

--- a/pkg/pillar/devicenetwork/devicenetwork.go
+++ b/pkg/pillar/devicenetwork/devicenetwork.go
@@ -262,7 +262,7 @@ func MakeDeviceNetworkStatus(globalConfig types.DevicePortConfig, oldStatus type
 	return globalStatus
 }
 
-// write the access-point name into /run/cccesspoint directory
+// write the access-point name into /run/accesspoint directory
 // the filenames are the physical ports with access-point address/name in content
 func devPortInstallAPname(ifname string, wconfig types.WirelessConfig) {
 	if _, err := os.Stat(apDirname); err != nil {

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -250,7 +250,7 @@ func (ctx xenContext) CreateDomConfig(domainName string, config types.DomainConf
 	for _, adapter := range config.IoAdapterList {
 		log.Debugf("configToXenCfg processing adapter %d %s\n",
 			adapter.Type, adapter.Name)
-		list := aa.LookupIoBundleGroup(adapter.Name)
+		list := aa.LookupIoBundleAny(adapter.Name)
 		// We reserved it in handleCreate so nobody could have stolen it
 		if len(list) == 0 {
 			log.Fatalf("configToXencfg IoBundle disappeared %d %s for %s\n",

--- a/pkg/pillar/types/assignableadapters.go
+++ b/pkg/pillar/types/assignableadapters.go
@@ -247,6 +247,9 @@ func (aa *AssignableAdapters) LookupIoBundle(name string) *IoBundle {
 func (aa *AssignableAdapters) LookupIoBundleGroup(group string) []*IoBundle {
 
 	var list []*IoBundle
+	if group == "" {
+		return list
+	}
 	for i, b := range aa.IoBundleList {
 		if b.AssignmentGroup == "" {
 			continue
@@ -256,6 +259,27 @@ func (aa *AssignableAdapters) LookupIoBundleGroup(group string) []*IoBundle {
 		}
 	}
 	return list
+}
+
+// LookupIoBundleAny returns an empty slice if not found; name can be
+// a member or a group
+// Returns pointers into aa
+func (aa *AssignableAdapters) LookupIoBundleAny(name string) []*IoBundle {
+
+	list := aa.LookupIoBundleGroup(name)
+	if len(list) != 0 {
+		return list
+	}
+	ib := aa.LookupIoBundle(name)
+	if ib == nil {
+		return list
+	}
+	if ib.AssignmentGroup == "" {
+		// Singleton
+		list = append(list, ib)
+		return list
+	}
+	return aa.LookupIoBundleGroup(ib.AssignmentGroup)
 }
 
 // LookupIoBundleNet checks for IoNet*


### PR DESCRIPTION
This is the companion to https://github.com/zededa/zedcloud/pull/2558/ and the motivation is the same; recent breakage for the device assignment of things that are typically bundles such as USB and COM.

Keeping the ability to handle the old case of receiving a assignmentGroup while adding handling receiving the name. Hence the new Any lookup function.