### PR TITLE
fix use of phylabel, logicallabel, and ifname

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1145,7 +1145,7 @@ func cleanupAdapters(ctx *domainContext, ioAdapterList []types.IoAdapter,
 				continue
 			}
 			log.Infof("cleanupAdapters clearing uuid for adapter %d %s member %s",
-				adapter.Type, adapter.Name, ib.Name)
+				adapter.Type, adapter.Name, ib.Phylabel)
 			ib.UsedByUUID = nilUUID
 			publishAssignableAdapters = true
 		}
@@ -1190,7 +1190,7 @@ func doAssignIoAdaptersToDomain(ctx *domainContext, config types.DomainConfig,
 					adapter.Type, adapter.Name, status.DomainName)
 			} else if ctx.usbAccess && !ib.IsPCIBack {
 				log.Infof("Assigning %s (%s) to %s\n",
-					ib.Name, ib.PciLong, status.DomainName)
+					ib.Phylabel, ib.PciLong, status.DomainName)
 				assignments = addNoDuplicate(assignments, ib.PciLong)
 				ib.IsPCIBack = true
 				publishAssignableAdapters = true
@@ -1550,7 +1550,7 @@ func pciUnassign(ctx *domainContext, status *types.DomainStatus,
 					adapter.Type, adapter.Name, status.DomainName)
 			} else if ctx.usbAccess && ib.IsPCIBack {
 				log.Infof("Removing %s (%s) from %s\n",
-					ib.Name, ib.PciLong, status.DomainName)
+					ib.Phylabel, ib.PciLong, status.DomainName)
 				assignments = addNoDuplicate(assignments, ib.PciLong)
 
 				ib.IsPCIBack = false
@@ -1695,9 +1695,9 @@ func configAdapters(ctx *domainContext, config types.DomainConfig) error {
 				return fmt.Errorf("adapter %d %s used by %s",
 					adapter.Type, adapter.Name, ibp.UsedByUUID)
 			}
-			if isPort(ctx, ibp.Name) {
+			if isPort(ctx, ibp.Ifname) {
 				return fmt.Errorf("adapter %d %s member %s is (part of) a zedrouter port",
-					adapter.Type, adapter.Name, ibp.Name)
+					adapter.Type, adapter.Name, ibp.Phylabel)
 			}
 		}
 		for _, ibp := range list {
@@ -1705,7 +1705,7 @@ func configAdapters(ctx *domainContext, config types.DomainConfig) error {
 				continue
 			}
 			log.Debugf("configAdapters setting uuid %s for adapter %d %s member %s",
-				config.Key(), adapter.Type, adapter.Name, ibp.Name)
+				config.Key(), adapter.Type, adapter.Name, ibp.Phylabel)
 			ibp.UsedByUUID = config.UUIDandVersion.UUID
 		}
 	}
@@ -2359,20 +2359,20 @@ func handlePhysicalIOAdapterListCreateModify(ctxArg interface{},
 	// Loop first then delete to avoid deleting while we iterate
 	var deleteList []string
 	for indx := range aa.IoBundleList {
-		name := aa.IoBundleList[indx].Name
-		phyAdapter := phyIOAdapterList.LookupAdapter(name)
+		phylabel := aa.IoBundleList[indx].Phylabel
+		phyAdapter := phyIOAdapterList.LookupAdapter(phylabel)
 		if phyAdapter == nil {
-			deleteList = append(deleteList, name)
+			deleteList = append(deleteList, phylabel)
 		}
 	}
-	for _, name := range deleteList {
-		handleIBDelete(ctx, name)
+	for _, phylabel := range deleteList {
+		handleIBDelete(ctx, phylabel)
 	}
 
 	// Any add or modify?
 	for _, phyAdapter := range phyIOAdapterList.AdapterList {
 		ib := *types.IoBundleFromPhyAdapter(phyAdapter)
-		currentIbPtr := aa.LookupIoBundle(phyAdapter.Phylabel)
+		currentIbPtr := aa.LookupIoBundlePhylabel(phyAdapter.Phylabel)
 		if currentIbPtr == nil {
 			log.Infof("handlePhysicalIOAdapterListCreateModify: Adapter %s "+
 				"added. %+v\n", phyAdapter.Phylabel, ib)
@@ -2401,10 +2401,10 @@ func handlePhysicalIOAdapterListDelete(ctxArg interface{},
 		"deleted\n")
 
 	for indx := range phyAdapterList.AdapterList {
-		name := phyAdapterList.AdapterList[indx].Phylabel
+		phylabel := phyAdapterList.AdapterList[indx].Phylabel
 		log.Infof("handlePhysicalIOAdapterListDelete: Deleting Adapter %s\n",
-			name)
-		handleIBDelete(ctx, name)
+			phylabel)
+		handleIBDelete(ctx, phylabel)
 	}
 	ctx.publishAssignableAdapters()
 	log.Infof("handlePhysicalIOAdapterListDelete done\n")
@@ -2415,11 +2415,11 @@ func handlePhysicalIOAdapterListDelete(ctxArg interface{},
 // Assign to pciback
 func handleIBCreate(ctx *domainContext, ib types.IoBundle) {
 
-	log.Infof("handleIBCreate(%d %s %s)", ib.Type, ib.Name, ib.AssignmentGroup)
+	log.Infof("handleIBCreate(%d %s %s)", ib.Type, ib.Phylabel, ib.AssignmentGroup)
 	aa := ctx.assignableAdapters
 	if err := checkAndSetIoBundle(ctx, &ib, false); err != nil {
 		log.Warnf("Not reporting non-existent PCI device %d %s: %v\n",
-			ib.Type, ib.Name, err)
+			ib.Type, ib.Phylabel, err)
 		return
 	}
 	// We assume AddOrUpdateIoBundle will preserve any existing Unique/MacAddr
@@ -2441,7 +2441,7 @@ func checkAndSetIoBundle(ctx *domainContext, ib *types.IoBundle,
 	publish bool) error {
 
 	log.Infof("checkAndSetIoBundle(%d %s %s) publish %t",
-		ib.Type, ib.Name, ib.AssignmentGroup, publish)
+		ib.Type, ib.Phylabel, ib.AssignmentGroup, publish)
 	aa := ctx.assignableAdapters
 	var list []*types.IoBundle
 
@@ -2453,12 +2453,12 @@ func checkAndSetIoBundle(ctx *domainContext, ib *types.IoBundle,
 	// Is any member a port? If so treat all as port
 	isPort := false
 	for _, ib := range list {
-		if types.IsPort(ctx.deviceNetworkStatus, ib.Name) {
+		if types.IsPort(ctx.deviceNetworkStatus, ib.Ifname) {
 			isPort = true
 		}
 	}
 	log.Infof("checkAndSetIoBundle(%d %s %s) isPort %t members %v",
-		ib.Type, ib.Name, ib.AssignmentGroup, isPort, list)
+		ib.Type, ib.Phylabel, ib.AssignmentGroup, isPort, list)
 	for _, ib := range list {
 		err := checkAndSetIoMember(ctx, ib, isPort, publish)
 		if err != nil {
@@ -2472,31 +2472,31 @@ func checkAndSetIoBundle(ctx *domainContext, ib *types.IoBundle,
 func checkAndSetIoMember(ctx *domainContext, ib *types.IoBundle, isPort bool, publish bool) error {
 
 	log.Infof("checkAndSetIoMember(%d %s %s) isPort %t publish %t",
-		ib.Type, ib.Name, ib.AssignmentGroup, isPort, publish)
+		ib.Type, ib.Phylabel, ib.AssignmentGroup, isPort, publish)
 	aa := ctx.assignableAdapters
 	// Check if part of DevicePortConfig
 	ib.IsPort = false
 	changed := false
 	if isPort {
 		log.Warnf("checkAndSetIoMember(%d %s %s) part of zedrouter port\n",
-			ib.Type, ib.Name, ib.AssignmentGroup)
+			ib.Type, ib.Phylabel, ib.AssignmentGroup)
 		ib.IsPort = true
 		changed = true
 		if ib.UsedByUUID != nilUUID {
 			log.Errorf("checkAndSetIoMember(%d %s %s) used by %s",
-				ib.Type, ib.Name, ib.AssignmentGroup,
+				ib.Type, ib.Phylabel, ib.AssignmentGroup,
 				ib.UsedByUUID.String())
 
 		} else if ib.IsPCIBack {
 			log.Infof("checkAndSetIoMember(%d %s %s) take back from pciback\n",
-				ib.Type, ib.Name, ib.AssignmentGroup)
+				ib.Type, ib.Phylabel, ib.AssignmentGroup)
 			if ib.PciLong != "" {
 				log.Infof("Removing %s (%s) from pciback\n",
-					ib.Name, ib.PciLong)
+					ib.Phylabel, ib.PciLong)
 				err := hyper.PCIRelease(ib.PciLong)
 				if err != nil {
 					log.Errorf("checkAndSetIoMember(%d %s %s) PCIRelease %s failed %v\n",
-						ib.Type, ib.Name, ib.AssignmentGroup, ib.PciLong, err)
+						ib.Type, ib.Phylabel, ib.AssignmentGroup, ib.PciLong, err)
 				}
 				// Seems like like no risk for race; when we return
 				// from above the driver has been attached and
@@ -2504,10 +2504,10 @@ func checkAndSetIoMember(ctx *domainContext, ib *types.IoBundle, isPort bool, pu
 				found, ifname := types.PciLongToIfname(ib.PciLong)
 				if !found {
 					log.Errorf("Not found: %d %s %s",
-						ib.Type, ib.Name, ib.Ifname)
+						ib.Type, ib.Phylabel, ib.Ifname)
 				} else if ifname != ib.Ifname {
 					log.Warnf("Found: %d %s %s at %s",
-						ib.Type, ib.Name, ib.Ifname,
+						ib.Type, ib.Phylabel, ib.Ifname,
 						ifname)
 					types.IfRename(ifname, ib.Ifname)
 				}
@@ -2518,15 +2518,15 @@ func checkAndSetIoMember(ctx *domainContext, ib *types.IoBundle, isPort bool, pu
 			_, err := types.IoBundleToPci(ib)
 			if err != nil {
 				log.Warnf("checkAndSetIoMember(%d %s %s) gone?: %s\n",
-					ib.Type, ib.Name, ib.AssignmentGroup, err)
+					ib.Type, ib.Phylabel, ib.AssignmentGroup, err)
 			}
 		}
 	}
 	if ib.Type.IsNet() && ib.MacAddr == "" {
-		ib.MacAddr = getMacAddr(ib.Name)
+		ib.MacAddr = getMacAddr(ib.Ifname)
 		changed = true
 		log.Infof("checkAndSetIoMember(%d %s %s) long %s macaddr %s",
-			ib.Type, ib.Name, ib.AssignmentGroup, ib.PciLong, ib.MacAddr)
+			ib.Type, ib.Ifname, ib.AssignmentGroup, ib.PciLong, ib.MacAddr)
 	}
 
 	if publish && changed {
@@ -2544,35 +2544,35 @@ func checkAndSetIoMember(ctx *domainContext, ib *types.IoBundle, isPort bool, pu
 		ib.PciLong = long
 		changed = true
 		log.Infof("checkAndSetIoMember(%d %s %s) found %s\n",
-			ib.Type, ib.Name, ib.AssignmentGroup, long)
+			ib.Type, ib.Phylabel, ib.AssignmentGroup, long)
 
 		// Save somewhat Unique string for debug
 		found, unique := types.PciLongToUnique(long)
 		if !found {
 			errStr := fmt.Sprintf("IoBundle(%d %s %s) %s unique not found",
-				ib.Type, ib.Name, ib.AssignmentGroup, long)
+				ib.Type, ib.Phylabel, ib.AssignmentGroup, long)
 			log.Errorln(errStr)
 		} else {
 			ib.Unique = unique
 			changed = true
 			log.Infof("checkAndSetIoMember(%d %s %s) %s unique %s",
-				ib.Type, ib.Name, ib.AssignmentGroup, long, unique)
+				ib.Type, ib.Phylabel, ib.AssignmentGroup, long, unique)
 		}
 	} else {
 		log.Infof("checkAndSetIoMember(%d %s %s) not found PCI",
-			ib.Type, ib.Name, ib.AssignmentGroup)
+			ib.Type, ib.Phylabel, ib.AssignmentGroup)
 	}
 
 	if !ib.IsPort && !ib.IsPCIBack {
 		if ctx.deviceNetworkStatus.Testing && ib.Type.IsNet() {
 			log.Infof("Not assigning %s (%s) to pciback due to Testing\n",
-				ib.Name, ib.PciLong)
+				ib.Phylabel, ib.PciLong)
 		} else if ctx.usbAccess && isInUsbGroup(*aa, *ib) {
 			log.Infof("Not assigning %s (%s) to pciback due to usbAccess\n",
-				ib.Name, ib.PciLong)
+				ib.Phylabel, ib.PciLong)
 		} else if ib.PciLong != "" {
 			log.Infof("Assigning %s (%s) to pciback\n",
-				ib.Name, ib.PciLong)
+				ib.Phylabel, ib.PciLong)
 			err := hyper.PCIReserve(ib.PciLong)
 			if err != nil {
 				return err
@@ -2628,22 +2628,22 @@ func checkIoBundle(ctx *domainContext, ib *types.IoBundle) error {
 	found, unique := types.PciLongToUnique(long)
 	if !found {
 		errStr := fmt.Sprintf("IoBundle(%d %s %s) %s unique %s not foun\n",
-			ib.Type, ib.Name, ib.AssignmentGroup,
+			ib.Type, ib.Phylabel, ib.AssignmentGroup,
 			long, ib.Unique)
 		return errors.New(errStr)
 	}
 	if unique != ib.Unique && ib.Unique != "" {
 		errStr := fmt.Sprintf("IoBundle(%d %s %s) changed unique from %s to %s",
-			ib.Type, ib.Name, ib.AssignmentGroup,
+			ib.Type, ib.Phylabel, ib.AssignmentGroup,
 			ib.Unique, unique)
 		return errors.New(errStr)
 	}
 	if ib.Type.IsNet() && ib.MacAddr != "" {
-		macAddr := getMacAddr(ib.Name)
+		macAddr := getMacAddr(ib.Phylabel)
 		// Will be empty string if adapter is assigned away
 		if macAddr != "" && macAddr != ib.MacAddr {
 			errStr := fmt.Sprintf("IoBundle(%d %s %s) changed MacAddr from %s to %s",
-				ib.Type, ib.Name, ib.AssignmentGroup,
+				ib.Type, ib.Phylabel, ib.AssignmentGroup,
 				ib.MacAddr, macAddr)
 			return errors.New(errStr)
 		}
@@ -2676,7 +2676,7 @@ func maybeAssignableAdd(ctx *domainContext) {
 		}
 		if !ib.IsPCIBack {
 			log.Infof("maybeAssignableAdd: Assigning %s (%s) to pciback\n",
-				ib.Name, ib.PciLong)
+				ib.Phylabel, ib.PciLong)
 			assignments = addNoDuplicate(assignments, ib.PciLong)
 			ib.IsPCIBack = true
 		}
@@ -2707,12 +2707,12 @@ func maybeAssignableRem(ctx *domainContext) {
 		if ib.IsPCIBack {
 			if ib.UsedByUUID == nilUUID {
 				log.Infof("Removing %s (%s) from pciback\n",
-					ib.Name, ib.PciLong)
+					ib.Phylabel, ib.PciLong)
 				assignments = addNoDuplicate(assignments, ib.PciLong)
 				ib.IsPCIBack = false
 			} else {
 				log.Warnf("No removing %s (%s) from pciback: used by %s",
-					ib.Name, ib.PciLong, ib.UsedByUUID)
+					ib.Phylabel, ib.PciLong, ib.UsedByUUID)
 			}
 		}
 	}
@@ -2727,25 +2727,25 @@ func maybeAssignableRem(ctx *domainContext) {
 	}
 }
 
-func handleIBDelete(ctx *domainContext, name string) {
+func handleIBDelete(ctx *domainContext, phylabel string) {
 
-	log.Infof("handleIBDelete(%s)", name)
+	log.Infof("handleIBDelete(%s)", phylabel)
 	aa := ctx.assignableAdapters
 
-	ib := aa.LookupIoBundle(name)
+	ib := aa.LookupIoBundlePhylabel(phylabel)
 	if ib == nil {
-		log.Infof("handleIBDelete: Adapter ( %s ) not found", name)
+		log.Infof("handleIBDelete: Adapter ( %s ) not found", phylabel)
 		return
 	}
 
 	if ib.IsPCIBack {
 		log.Infof("handleIBDelete: Assigning %s (%s) back\n",
-			ib.Name, ib.PciLong)
+			ib.Phylabel, ib.PciLong)
 		if ib.PciLong != "" {
 			err := hyper.PCIRelease(ib.PciLong)
 			if err != nil {
 				log.Errorf("handleIBDelete(%d %s %s) PCIRelease %s failed %v\n",
-					ib.Type, ib.Name, ib.AssignmentGroup, ib.PciLong, err)
+					ib.Type, ib.Phylabel, ib.AssignmentGroup, ib.PciLong, err)
 			}
 			ib.IsPCIBack = false
 		}
@@ -2754,7 +2754,7 @@ func handleIBDelete(ctx *domainContext, name string) {
 	replace := types.AssignableAdapters{Initialized: true,
 		IoBundleList: make([]types.IoBundle, len(aa.IoBundleList)-1)}
 	for _, e := range aa.IoBundleList {
-		if e.Type == ib.Type && e.Name == ib.Name {
+		if e.Type == ib.Type && e.Phylabel == ib.Phylabel {
 			continue
 		}
 		replace.IoBundleList = append(replace.IoBundleList, e)
@@ -2765,20 +2765,20 @@ func handleIBDelete(ctx *domainContext, name string) {
 
 func handleIBModify(ctx *domainContext, newIb types.IoBundle) {
 	aa := ctx.assignableAdapters
-	currentIbPtr := aa.LookupIoBundle(newIb.Name)
+	currentIbPtr := aa.LookupIoBundlePhylabel(newIb.Phylabel)
 	if currentIbPtr == nil {
 		log.Errorf("Failed to find IoBundle (%d %s).  aa: %+v\n",
-			newIb.Type, newIb.Name, aa)
+			newIb.Type, newIb.Phylabel, aa)
 		return
 	}
 
 	log.Infof("handleIBModify(%d %s %s) from %v to %v\n",
-		currentIbPtr.Type, currentIbPtr.Name, currentIbPtr.AssignmentGroup,
+		currentIbPtr.Type, currentIbPtr.Phylabel, currentIbPtr.AssignmentGroup,
 		*currentIbPtr, newIb)
 
 	if err := checkAndSetIoBundle(ctx, &newIb, false); err != nil {
 		log.Warnf("Not reporting non-existent PCI device %d %s: %v\n",
-			newIb.Type, newIb.Name, err)
+			newIb.Type, newIb.Phylabel, err)
 		return
 	}
 
@@ -2801,7 +2801,7 @@ func isInUsbGroup(aa types.AssignableAdapters, ib types.IoBundle) bool {
 	for _, m := range list {
 		if m.Type == types.IoUSB {
 			log.Infof("isInUsbGroup for %s found USB for %s",
-				ib.Name, m.Name)
+				ib.Phylabel, m.Phylabel)
 			return true
 		}
 	}

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -959,7 +959,7 @@ func isAssigned(ctx *nimContext, ifname string) bool {
 
 	log.Debugf("isAssigned(%s) have %d bundles\n",
 		ifname, len(ctx.AssignableAdapters.IoBundleList))
-	ib := ctx.AssignableAdapters.LookupIoBundleNet(ifname)
+	ib := ctx.AssignableAdapters.LookupIoBundleIfName(ifname)
 	if ib == nil {
 		return false
 	}
@@ -984,7 +984,7 @@ func isSwitch(ctx *nimContext, ifname string) bool {
 	for _, st := range items {
 		status := st.(types.NetworkInstanceStatus)
 
-		if !status.IsUsingPort(ifname) {
+		if !status.IsUsingIfName(ifname) {
 			continue
 		}
 		log.Debugf("isSwitch(%s) found use in %s/%s\n",

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -184,10 +184,10 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 
 	// Use the network metrics from zedrouter subscription
 	// Only report stats for the ports in DeviceNetworkStatus
-	portNames := types.ReportPorts(*deviceNetworkStatus)
-	for _, port := range portNames {
+	phylabelList := types.ReportPhylabels(*deviceNetworkStatus)
+	for _, phylabel := range phylabelList {
 		var metric *types.NetworkMetric
-		ifname := types.AdapterToIfName(deviceNetworkStatus, port)
+		ifname := types.PhylabelToIfName(deviceNetworkStatus, phylabel)
 		for _, m := range networkMetrics.MetricList {
 			if ifname == m.IfName {
 				metric = &m
@@ -199,7 +199,7 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 		}
 		networkDetails := new(metrics.NetworkMetric)
 		networkDetails.LocalName = metric.IfName
-		networkDetails.IName = port
+		networkDetails.IName = phylabel
 
 		networkDetails.TxPkts = metric.TxPkts
 		networkDetails.RxPkts = metric.RxPkts
@@ -785,15 +785,15 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 	// Read interface name from library and match it with port name from
 	// global status. Only report the ports in DeviceNetworkStatus
 	interfaces, _ := psutilnet.Interfaces()
-	portNames := types.ReportPorts(*deviceNetworkStatus)
-	for _, port := range portNames {
-		ifname := types.AdapterToIfName(deviceNetworkStatus, port)
+	phylabelList := types.ReportPhylabels(*deviceNetworkStatus)
+	for _, phylabel := range phylabelList {
+		ifname := types.PhylabelToIfName(deviceNetworkStatus, phylabel)
 		for _, interfaceDetail := range interfaces {
 			if ifname != interfaceDetail.Name {
 				continue
 			}
 			ReportDeviceNetworkInfo := getNetInfo(interfaceDetail, true)
-			ReportDeviceNetworkInfo.DevName = *proto.String(port)
+			ReportDeviceNetworkInfo.DevName = *proto.String(phylabel)
 			ReportDeviceInfo.Network = append(ReportDeviceInfo.Network,
 				ReportDeviceNetworkInfo)
 		}
@@ -845,7 +845,7 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 				continue
 			}
 			reportAA.Members = append(reportAA.Members,
-				b.Name)
+				b.Phylabel)
 			if b.MacAddr != "" {
 				reportMac := new(info.IoAddresses)
 				reportMac.MacAddress = b.MacAddr
@@ -1203,7 +1203,8 @@ func encodeSystemAdapterInfo(dpcl types.DevicePortConfigList) *info.SystemAdapte
 func encodeNetworkPortConfig(npc *types.NetworkPortConfig) *info.DevicePort {
 	dp := new(info.DevicePort)
 	dp.Ifname = npc.IfName
-	dp.Name = npc.Name
+	// XXX rename the protobuf field Name to Phylabel and add Logicallabel?
+	dp.Name = npc.Phylabel
 	dp.IsMgmt = npc.IsMgmt
 	dp.Free = npc.Free
 	// DhcpConfig
@@ -1305,7 +1306,7 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 				if ib == nil {
 					continue
 				}
-				reportAA.Members = append(reportAA.Members, ib.Name)
+				reportAA.Members = append(reportAA.Members, ib.Phylabel)
 				if ib.MacAddr != "" {
 					reportMac := new(info.IoAddresses)
 					reportMac.MacAddress = ib.MacAddr

--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -104,21 +104,21 @@ func prepareAndPublishNetworkInstanceInfoMsg(ctx *zedagentContext,
 		}
 		info.Ipv4Eid = status.Ipv4Eid
 		for _, ifname := range status.IfNameList {
-			ia := ctx.assignableAdapters.LookupIoBundle(ifname)
+			ia := ctx.assignableAdapters.LookupIoBundleIfName(ifname)
 			if ia == nil {
 				log.Warnf("Missing adapter for ifname %s", ifname)
 				continue
 			}
 			reportAA := new(zinfo.ZioBundle)
 			reportAA.Type = zinfo.IPhyIoType(ia.Type)
-			reportAA.Name = ia.Name
+			reportAA.Name = ia.Phylabel
 			reportAA.UsedByAppUUID = zcdevUUID.String()
-			list := ctx.assignableAdapters.LookupIoBundleAny(ia.Name)
+			list := ctx.assignableAdapters.LookupIoBundleAny(ia.Phylabel)
 			for _, ib := range list {
 				if ib == nil {
 					continue
 				}
-				reportAA.Members = append(reportAA.Members, ib.Name)
+				reportAA.Members = append(reportAA.Members, ib.Phylabel)
 				if ib.MacAddr != "" {
 					reportMac := new(zinfo.IoAddresses)
 					reportMac.MacAddress = ib.MacAddr

--- a/pkg/pillar/cmd/zedrouter/dnsmasq.go
+++ b/pkg/pillar/cmd/zedrouter/dnsmasq.go
@@ -134,7 +134,7 @@ func createDnsmasqConfiglet(
 	advertizeRouter := true
 	var router string
 
-	if netconf.Port == "" {
+	if netconf.Logicallabel == "" {
 		log.Infof("Internal switch without external port case, dnsmasq suppress router advertize\n")
 		advertizeRouter = false
 	} else if Ipv4Eid {

--- a/pkg/pillar/cmd/zedrouter/ipsec.go
+++ b/pkg/pillar/cmd/zedrouter/ipsec.go
@@ -161,7 +161,7 @@ func ipTablesRuleCreate(vpnConfig types.VpnConfig) error {
 		}
 	}
 	if err := ipTablesCounterRulesSet(vpnConfig.PolicyBased,
-		tunnelConfig.Name, portConfig.Name); err != nil {
+		tunnelConfig.Name, portConfig.IfName); err != nil {
 		return err
 	}
 	return nil
@@ -184,7 +184,7 @@ func ipTablesRulesDelete(vpnConfig types.VpnConfig) error {
 		}
 	}
 	if err := ipTablesCounterRulesReset(vpnConfig.PolicyBased,
-		tunnelConfig.Name, portConfig.Name); err != nil {
+		tunnelConfig.Name, portConfig.IfName); err != nil {
 		return err
 	}
 	return nil
@@ -827,15 +827,15 @@ func charonConfigReset() error {
 func sysctlConfigCreate(vpnConfig types.VpnConfig) error {
 
 	portConfig := vpnConfig.PortConfig
-	log.Infof("%s: %s config\n", portConfig.Name, "sysctl")
+	log.Infof("%s: %s config\n", portConfig.IfName, "sysctl")
 
 	writeStr := ""
 	if vpnConfig.PolicyBased {
-		writeStr = writeStr + "\n net.ipv4.conf." + portConfig.Name + ".disable_xfrm=0"
-		writeStr = writeStr + "\n net.ipv4.conf." + portConfig.Name + ".disable_policy=0\n"
+		writeStr = writeStr + "\n net.ipv4.conf." + portConfig.IfName + ".disable_xfrm=0"
+		writeStr = writeStr + "\n net.ipv4.conf." + portConfig.IfName + ".disable_policy=0\n"
 	} else {
-		writeStr = writeStr + "\n net.ipv4.conf." + portConfig.Name + ".disable_xfrm=1"
-		writeStr = writeStr + "\n net.ipv4.conf." + portConfig.Name + ".disable_policy=1\n"
+		writeStr = writeStr + "\n net.ipv4.conf." + portConfig.IfName + ".disable_xfrm=1"
+		writeStr = writeStr + "\n net.ipv4.conf." + portConfig.IfName + ".disable_policy=1\n"
 		for _, clientConfig := range vpnConfig.ClientConfigList {
 			tunnelConfig := clientConfig.TunnelConfig
 			log.Infof("%s: %s config\n", tunnelConfig.Name, "sysctl")

--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -35,14 +35,14 @@ func allowSharedPort(status *types.NetworkInstanceStatus) bool {
 //  NetworkInstanceTypeSwitch, all other current types of network instance
 //  can share the port. Whether such ports can be used by network instance
 //  can be checked  using allowSharedPort() function
-func isSharedPortLabel(port string) bool {
+func isSharedPortLabel(label string) bool {
 	// XXX - I think we can get rid of these built-in labels (uplink/freeuplink).
 	//	This will be cleaned up as part of support for deviceConfig
 	//	from cloud.
-	if strings.EqualFold(port, "uplink") {
+	if strings.EqualFold(label, "uplink") {
 		return true
 	}
-	if strings.EqualFold(port, "freeuplink") {
+	if strings.EqualFold(label, "freeuplink") {
 		return true
 	}
 	return false
@@ -59,12 +59,12 @@ func checkPortAvailable(
 	ctx *zedrouterContext,
 	status *types.NetworkInstanceStatus) error {
 
-	log.Infof("NetworkInstance(%s-%s), port: %s, currentUplinkIntf: %s",
-		status.DisplayName, status.UUID, status.Port,
+	log.Infof("NetworkInstance(%s-%s), logicallabel: %s, currentUplinkIntf: %s",
+		status.DisplayName, status.UUID, status.Logicallabel,
 		status.CurrentUplinkIntf)
 
 	if status.CurrentUplinkIntf == "" {
-		log.Infof("Port not specified\n")
+		log.Infof("CurrentUplinkIntf not specified\n")
 		return nil
 	}
 
@@ -82,15 +82,11 @@ func checkPortAvailable(
 			return errors.New(errStr)
 		}
 	}
-	portStatus := ctx.deviceNetworkStatus.GetPortByName(status.CurrentUplinkIntf)
+	portStatus := ctx.deviceNetworkStatus.GetPortByIfName(status.CurrentUplinkIntf)
 	if portStatus == nil {
-		// XXX Fallback until we have complete Name support in UI
-		portStatus = ctx.deviceNetworkStatus.GetPortByIfName(status.CurrentUplinkIntf)
-		if portStatus == nil {
-			errStr := fmt.Sprintf("PortStatus for %s not found for network instance %s-%s\n",
-				status.CurrentUplinkIntf, status.Key(), status.DisplayName)
-			return errors.New(errStr)
-		}
+		errStr := fmt.Sprintf("PortStatus for %s not found for network instance %s-%s\n",
+			status.CurrentUplinkIntf, status.Key(), status.DisplayName)
+		return errors.New(errStr)
 	}
 
 	if allowSharedPort(status) {
@@ -106,11 +102,11 @@ func checkPortAvailable(
 			if status == iterStatusEntry {
 				continue
 			}
-			if !iterStatusEntry.IsUsingPort(status.CurrentUplinkIntf) {
+			if !iterStatusEntry.IsUsingIfName(status.CurrentUplinkIntf) {
 				continue
 			}
 			if !allowSharedPort(iterStatusEntry) {
-				errStr := fmt.Sprintf("Port %s already used by "+
+				errStr := fmt.Sprintf("Ifname %s already used by "+
 					"Switch NetworkInstance %s-%s. It cannot be used by "+
 					"any other Network Instance such as %s-%s\n",
 					status.CurrentUplinkIntf, iterStatusEntry.UUID,
@@ -132,8 +128,8 @@ func checkPortAvailable(
 			if status == iterStatusEntry {
 				continue
 			}
-			if iterStatusEntry.IsUsingPort(status.CurrentUplinkIntf) {
-				errStr := fmt.Sprintf("Port %s already used by NetworkInstance %s-%s. "+
+			if iterStatusEntry.IsUsingIfName(status.CurrentUplinkIntf) {
+				errStr := fmt.Sprintf("Ifname %s already used by NetworkInstance %s-%s. "+
 					"Cannot be used by Switch Network Instance %s-%s\n",
 					status.CurrentUplinkIntf, iterStatusEntry.UUID, iterStatusEntry.DisplayName,
 					status.UUID, status.DisplayName)
@@ -711,9 +707,11 @@ func doNetworkInstanceModify(ctx *zedrouterContext,
 			errors.New("Changing Type of NetworkInstance is not supported"))
 	}
 
-	if config.Port != status.Port {
-		status.SetError(
-			errors.New("Changing Port in NetworkInstance is not yet supported"))
+	if config.Logicallabel != status.Logicallabel {
+		err := fmt.Errorf("Changing Logicallabel in NetworkInstance is not yet supported: from %s to %s",
+			status.Logicallabel, config.Logicallabel)
+		log.Error(err)
+		status.SetError(err)
 		return
 	}
 
@@ -732,10 +730,10 @@ func doNetworkInstanceModify(ctx *zedrouterContext,
 	}
 }
 
-// getSwitchNetworkInstanceUsingPort
+// getSwitchNetworkInstanceUsingIfname
 //		This function assumes if a port used by networkInstance of type SWITCH
 //		is not shared ie., is not used by any other network instance.
-func getSwitchNetworkInstanceUsingPort(
+func getSwitchNetworkInstanceUsingIfname(
 	ctx *zedrouterContext,
 	ifname string) (status *types.NetworkInstanceStatus) {
 
@@ -744,8 +742,8 @@ func getSwitchNetworkInstanceUsingPort(
 
 	for _, st := range items {
 		status := st.(types.NetworkInstanceStatus)
-		ifname2 := types.AdapterToIfName(ctx.deviceNetworkStatus,
-			status.Port)
+		ifname2 := types.LogicallabelToIfName(ctx.deviceNetworkStatus,
+			status.Logicallabel)
 		if ifname2 != ifname {
 			log.Infof("maybeUpdateBridgeIPAddr - NI (%s) not using %s\n",
 				status.DisplayName, ifname)
@@ -753,14 +751,14 @@ func getSwitchNetworkInstanceUsingPort(
 		}
 
 		// Found Status using the Port.
-		log.Infof("getSwitchNetworkInstanceUsingPort: networkInstance (%s) using "+
-			"port %s, ifname: %s, type: %d\n",
-			status.DisplayName, status.Port, ifname, status.Type)
+		log.Infof("getSwitchNetworkInstanceUsingIfname: networkInstance (%s) using "+
+			"logicallabel: %s, ifname: %s, type: %d\n",
+			status.DisplayName, status.Logicallabel, ifname, status.Type)
 
 		if status.Type == types.NetworkInstanceTypeSwitch {
 			return &status
 		}
-		log.Infof("getSwitchNetworkInstanceUsingPort: networkInstance (%s) "+
+		log.Infof("getSwitchNetworkInstanceUsingIfname: networkInstance (%s) "+
 			"not of type (%d) switch\n",
 			status.DisplayName, status.Type)
 		break
@@ -944,16 +942,16 @@ func doConfigureIpAddrOnInterface(
 func getPortIPv4Addr(ctx *zedrouterContext,
 	status *types.NetworkInstanceStatus) (string, error) {
 	// Find any service which is associated with the appLink UUID
-	log.Infof("NetworkInstance UUID:%s, Name: %s, Port: %s\n",
-		status.UUID, status.DisplayName, status.Port)
+	log.Infof("NetworkInstance UUID:%s, Name: %s, LogicalLabel: %s\n",
+		status.UUID, status.DisplayName, status.Logicallabel)
 
-	if status.Port == "" {
-		log.Infof("no Port\n")
+	if status.Logicallabel == "" {
+		log.Infof("no Logicallabel\n")
 		return "", nil
 	}
 
-	// Get IP address from adapter
-	ifname := types.AdapterToIfName(ctx.deviceNetworkStatus, status.Port)
+	// Get IP address from Logicallabel
+	ifname := types.LogicallabelToIfName(ctx.deviceNetworkStatus, status.Logicallabel)
 	ifindex, err := devicenetwork.IfnameToIndex(ifname)
 	if err != nil {
 		return "", err
@@ -970,7 +968,7 @@ func getPortIPv4Addr(ctx *zedrouterContext,
 			return addr.String(), nil
 		}
 	}
-	log.Infof("No IPv4 address on %s yet\n", status.Port)
+	log.Infof("No IPv4 address on %s yet\n", status.Logicallabel)
 	return "", nil
 }
 
@@ -1106,7 +1104,7 @@ func maybeUpdateBridgeIPAddr(
 	ctx *zedrouterContext,
 	ifname string) {
 
-	status := getSwitchNetworkInstanceUsingPort(ctx, ifname)
+	status := getSwitchNetworkInstanceUsingIfname(ctx, ifname)
 	if status == nil {
 		return
 	}
@@ -1131,11 +1129,11 @@ func doNetworkInstanceActivate(ctx *zedrouterContext,
 
 	// Check that Port is either "uplink", "freeuplink", or
 	// an existing port name assigned to domO/zedrouter.
-	// A Bridge only works with a single adapter interface.
+	// A Bridge only works with a single logicallabel interface.
 	// Management ports are not allowed to be part of Switch networks.
 	err := checkPortAvailable(ctx, status)
 	if err != nil {
-		log.Errorf("checkPortAvailable failed: Port: %s, err:%s",
+		log.Errorf("checkPortAvailable failed: CurrentUplinkIntf: %s, err:%s",
 			status.CurrentUplinkIntf, err)
 		return err
 	}
@@ -1143,9 +1141,9 @@ func doNetworkInstanceActivate(ctx *zedrouterContext,
 	// Get a list of IfNames to the ones we have an ifIndex for.
 	if status.Type == types.NetworkInstanceTypeSwitch {
 		// switched NI is not probed and does not have a CurrentUplinkIntf
-		status.IfNameList = getIfNameListForPort(ctx, status.Port)
+		status.IfNameList = getIfNameListForLLOrIfname(ctx, status.Logicallabel)
 	} else {
-		status.IfNameList = getIfNameListForPort(ctx, status.CurrentUplinkIntf)
+		status.IfNameList = getIfNameListForLLOrIfname(ctx, status.CurrentUplinkIntf)
 	}
 	log.Infof("IfNameList: %+v", status.IfNameList)
 
@@ -1177,18 +1175,18 @@ func doNetworkInstanceActivate(ctx *zedrouterContext,
 	return err
 }
 
-// getIfNameListForPort
+// getIfNameListForLLorIfname takes a logicallabel or a ifname
 // Get a list of IfNames to the ones we have an ifIndex for.
 // In the case where the port maps to multiple underlying ports
 // (For Ex: uplink), only include ports that have an ifindex.
 //	If there is no such port with ifindex, then retain the whole list.
 //	NetworkInstance creation will fail when programming default routes
 //  and iptable rules in that case - and that should be fine.
-func getIfNameListForPort(
+func getIfNameListForLLOrIfname(
 	ctx *zedrouterContext,
-	port string) []string {
+	llOrIfname string) []string {
 
-	ifNameList := adapterToIfNames(ctx, port)
+	ifNameList := labelToIfNames(ctx, llOrIfname)
 	log.Infof("ifNameList: %+v", ifNameList)
 
 	filteredList := make([]string, 0)
@@ -1210,15 +1208,16 @@ func getIfNameListForPort(
 					ifName, err.Error())
 			}
 		} else {
-			log.Infof("DeviceNetworkStatus not found for port(%s)", port)
+			log.Infof("DeviceNetworkStatus not found for ifName(%s)",
+				ifName)
 		}
 	}
 	if len(filteredList) > 0 {
 		log.Infof("filteredList: %+v", filteredList)
 		return filteredList
 	}
-	log.Infof("ifname or ifindex not found for any interface for port(%s)."+
-		"Returning the unfiltered list: %+v", port, ifNameList)
+	log.Infof("ifname or ifindex not found for any interface for logicallabel(%s)."+
+		"Returning the unfiltered list: %+v", llOrIfname, ifNameList)
 	return ifNameList
 }
 
@@ -1383,29 +1382,29 @@ func bridgeActivate(ctx *zedrouterContext,
 			status.BridgeName, err)
 		return errors.New(errStr)
 	}
-	// Find adapter
-	ifname := types.AdapterToIfName(ctx.deviceNetworkStatus, status.Port)
+	// Find logicallabel
+	ifname := types.LogicallabelToIfName(ctx.deviceNetworkStatus, status.Logicallabel)
 	alink, _ := netlink.LinkByName(ifname)
 	if alink == nil {
-		errStr := fmt.Sprintf("Unknown adapter %s, %s",
-			status.Port, ifname)
+		errStr := fmt.Sprintf("Unknown Logicallabel %s, %s",
+			status.Logicallabel, ifname)
 		return errors.New(errStr)
 	}
 	// Make sure it is up
-	//    ip link set ${adapter} up
+	//    ip link set ${logicallabel} up
 	if err := netlink.LinkSetUp(alink); err != nil {
-		errStr := fmt.Sprintf("LinkSetUp on %s failed: %s",
-			status.Port, err)
+		errStr := fmt.Sprintf("LinkSetUp on %s ifname %s failed: %s",
+			status.Logicallabel, ifname, err)
 		return errors.New(errStr)
 	}
-	// ip link set ${adapter} master ${bridge_name}
+	// ip link set ${logicallabel} master ${bridge_name}
 	if err := netlink.LinkSetMaster(alink, bridgeLink); err != nil {
-		errStr := fmt.Sprintf("LinkSetMaster %s %s failed: %s",
-			status.Port, status.BridgeName, err)
+		errStr := fmt.Sprintf("LinkSetMaster %s ifname %s bridge %s failed: %s",
+			status.Logicallabel, ifname, status.BridgeName, err)
 		return errors.New(errStr)
 	}
-	log.Infof("bridgeActivate: added %s to bridge %s\n",
-		status.Port, status.BridgeName)
+	log.Infof("bridgeActivate: added %s ifname %s to bridge %s\n",
+		status.Logicallabel, ifname, status.BridgeName)
 	return nil
 }
 
@@ -1413,24 +1412,24 @@ func bridgeInactivateforNetworkInstance(ctx *zedrouterContext,
 	status *types.NetworkInstanceStatus) {
 
 	log.Infof("bridgeInactivateforNetworkInstance(%s)\n", status.DisplayName)
-	// Find adapter
-	ifname := types.AdapterToIfName(ctx.deviceNetworkStatus, status.Port)
+	// Find logicallabel
+	ifname := types.LogicallabelToIfName(ctx.deviceNetworkStatus, status.Logicallabel)
 	alink, _ := netlink.LinkByName(ifname)
 	if alink == nil {
-		errStr := fmt.Sprintf("Unknown adapter %s, %s",
-			status.Port, ifname)
+		errStr := fmt.Sprintf("Unknown logicallabel %s, %s",
+			status.Logicallabel, ifname)
 		log.Errorln(errStr)
 		return
 	}
-	// ip link set ${adapter} nomaster
+	// ip link set ${logicallabel} nomaster
 	if err := netlink.LinkSetNoMaster(alink); err != nil {
-		errStr := fmt.Sprintf("LinkSetNoMaster %s failed: %s",
-			status.Port, err)
+		errStr := fmt.Sprintf("LinkSetNoMaster %s ifname %s failed: %s",
+			status.Logicallabel, ifname, err)
 		log.Infoln(errStr)
 		return
 	}
-	log.Infof("bridgeInactivateforNetworkInstance: removed %s from bridge\n",
-		status.Port)
+	log.Infof("bridgeInactivateforNetworkInstance: removed %s ifname %s from bridge\n",
+		status.Logicallabel, ifname)
 }
 
 // ==== Lisp
@@ -1706,19 +1705,19 @@ func strongswanNetworkInstanceInactivate(ctx *zedrouterContext,
 	}
 }
 
-// adapterToIfNames
+// labelToIfNames
 //	XXX - Probably should move this to ZedRouter.go as a method
 //		of zedRouterContext
-// Expand the generic names, and return the interface name
-// Does not verify the existence of the adapters/interfaces
-func adapterToIfNames(ctx *zedrouterContext, adapter string) []string {
-	if strings.EqualFold(adapter, "uplink") {
+// Expand the generic names, and return the interface names.
+// Does not verify the existence of the logicallabels/interfaces
+func labelToIfNames(ctx *zedrouterContext, llOrIfname string) []string {
+	if strings.EqualFold(llOrIfname, "uplink") {
 		return types.GetMgmtPortsAny(*ctx.deviceNetworkStatus, 0)
 	}
-	if strings.EqualFold(adapter, "freeuplink") {
+	if strings.EqualFold(llOrIfname, "freeuplink") {
 		return types.GetMgmtPortsFree(*ctx.deviceNetworkStatus, 0)
 	}
-	ifname := types.AdapterToIfName(ctx.deviceNetworkStatus, adapter)
+	ifname := types.LogicallabelToIfName(ctx.deviceNetworkStatus, llOrIfname)
 	if len(ifname) == 0 {
 		return []string{}
 	}
@@ -1749,7 +1748,7 @@ func getAllNIindices(ctx *zedrouterContext, ifname string) []int {
 	instanceItems := pub.GetAll()
 	for _, st := range instanceItems {
 		status := st.(types.NetworkInstanceStatus)
-		if !status.IsUsingPort(ifname) {
+		if !status.IsUsingIfName(ifname) {
 			continue
 		}
 		if status.BridgeName == "" {
@@ -1800,7 +1799,7 @@ func doNetworkInstanceFallback(
 
 	var err error
 	// Get a list of IfNames to the ones we have an ifIndex for.
-	status.IfNameList = getIfNameListForPort(ctx, status.CurrentUplinkIntf)
+	status.IfNameList = getIfNameListForLLOrIfname(ctx, status.CurrentUplinkIntf)
 	publishNetworkInstanceStatus(ctx, status)
 	log.Infof("IfNameList: %+v", status.IfNameList)
 

--- a/pkg/pillar/devicenetwork/devicenetwork.go
+++ b/pkg/pillar/devicenetwork/devicenetwork.go
@@ -45,6 +45,8 @@ func makeDevicePortConfig(ctx *DeviceNetworkContext, ports []string, free []stri
 	config.Ports = make([]types.NetworkPortConfig, len(ports))
 	for ix, u := range ports {
 		config.Ports[ix].IfName = u
+		config.Ports[ix].Phylabel = u
+		config.Ports[ix].Logicallabel = u
 		for _, f := range free {
 			if f == u {
 				config.Ports[ix].Free = true
@@ -52,7 +54,6 @@ func makeDevicePortConfig(ctx *DeviceNetworkContext, ports []string, free []stri
 			}
 		}
 		config.Ports[ix].IsMgmt = true
-		config.Ports[ix].Name = config.Ports[ix].IfName
 		config.Ports[ix].Dhcp = types.DT_CLIENT
 		port, err := ctx.DevicePortConfig.GetPortByIfName(u)
 		if err == nil {
@@ -169,7 +170,8 @@ func MakeDeviceNetworkStatus(globalConfig types.DevicePortConfig, oldStatus type
 		len(globalConfig.Ports))
 	for ix, u := range globalConfig.Ports {
 		globalStatus.Ports[ix].IfName = u.IfName
-		globalStatus.Ports[ix].Name = u.Name
+		globalStatus.Ports[ix].Phylabel = u.Phylabel
+		globalStatus.Ports[ix].Logicallabel = u.Logicallabel
 		globalStatus.Ports[ix].IsMgmt = u.IsMgmt
 		globalStatus.Ports[ix].Free = u.Free
 		globalStatus.Ports[ix].ProxyConfig = u.ProxyConfig

--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -563,30 +563,28 @@ func HandleAssignableAdaptersModify(ctxArg interface{}, key string,
 			continue
 		}
 		if ctx.AssignableAdapters != nil {
-			currentIoBundle := ctx.AssignableAdapters.LookupIoBundle(
-				ioBundle.Name)
+			currentIoBundle := ctx.AssignableAdapters.LookupIoBundlePhylabel(
+				ioBundle.Phylabel)
 			if currentIoBundle != nil &&
 				ioBundle.IsPCIBack == currentIoBundle.IsPCIBack {
 				log.Infof("HandleAssignableAdaptersModify(): ioBundle (%+v) "+
 					"PCIBack status (%+v) unchanged\n",
-					ioBundle.Name, ioBundle.IsPCIBack)
+					ioBundle.Phylabel, ioBundle.IsPCIBack)
 				continue
 			}
 		} else {
 			log.Infof("HandleAssignableAdaptersModify(): " +
 				"ctx.AssignableAdapters = nil\n")
 		}
-		// XXX this assumes that ioBundle.Name is the ifname known
-		// by the kernel/ifconfig
 		if ioBundle.IsPCIBack {
 			log.Infof("HandleAssignableAdaptersModify(): ioBundle (%+v) changed "+
-				"to pciBack", ioBundle.Name)
+				"to pciBack", ioBundle.Phylabel)
 			// Interface put back in pciBack list.
 			// Stop dhcp and update DeviceNetworkStatus
 			//doDhcpClientInactivate()  KALYAN- FIXTHIS BEFORE MERGE
 		} else {
 			log.Infof("HandleAssignableAdaptersModify(): ioBundle (%+v) changed "+
-				"to pciBack=false", ioBundle.Name)
+				"to pciBack=false", ioBundle.Phylabel)
 			// Interface moved out of PciBack mode.
 		}
 	}

--- a/pkg/pillar/devicenetwork/ifindex.go
+++ b/pkg/pillar/devicenetwork/ifindex.go
@@ -158,7 +158,7 @@ func RelevantLastResort(link netlink.Link) (bool, bool) {
 	loopbackFlag := (linkFlags & net.FlagLoopback) != 0
 	broadcastFlag := (linkFlags & net.FlagBroadcast) != 0
 	upFlag := (attrs.OperState == netlink.OperUp)
-	isVif := strings.HasPrefix(ifname, "vif") || strings.HasPrefix(ifname, "nbu")
+	isVif := strings.HasPrefix(ifname, "vif") || strings.HasPrefix(ifname, "nbu") || strings.HasPrefix(ifname, "nbo")
 	if linkType == "device" && !loopbackFlag && broadcastFlag &&
 		attrs.MasterIndex == 0 && !isVif {
 

--- a/pkg/pillar/types/assignableadapters_test.go
+++ b/pkg/pillar/types/assignableadapters_test.go
@@ -16,43 +16,43 @@ var aa AssignableAdapters = AssignableAdapters{
 		{
 			Type:            IoNetEth,
 			AssignmentGroup: "eth0-1",
-			Name:            "eth0",
+			Phylabel:        "eth0",
 			Ifname:          "eth0",
 		},
 		{
 			Type:            IoNetEth,
 			AssignmentGroup: "eth0-1",
-			Name:            "eth1",
+			Phylabel:        "eth1",
 			Ifname:          "eth1",
 		},
 		{
 			Type:            IoNetEth,
 			AssignmentGroup: "eth2",
-			Name:            "eth2",
+			Phylabel:        "eth2",
 			Ifname:          "eth2",
 		},
 		{
 			Type:            IoNetEth,
 			AssignmentGroup: "eTH4-7",
-			Name:            "eth4",
+			Phylabel:        "eth4",
 			Ifname:          "eth4",
 		},
 		{
 			Type:            IoNetEth,
 			AssignmentGroup: "eTH4-7",
-			Name:            "eth5",
+			Phylabel:        "eth5",
 			Ifname:          "eth5",
 		},
 		{
 			Type:            IoNetEth,
 			AssignmentGroup: "eTH4-7",
-			Name:            "eth6",
+			Phylabel:        "eth6",
 			Ifname:          "eth6",
 		},
 		{
 			Type:            IoNetEth,
 			AssignmentGroup: "eTH4-7",
-			Name:            "eth7",
+			Phylabel:        "eth7",
 			Ifname:          "eth7",
 		},
 	},
@@ -98,7 +98,7 @@ func TestLookupIoBundleGroup(t *testing.T) {
 	}
 }
 
-func TestLookupIoBundle(t *testing.T) {
+func TestLookupIoBundlePhylabel(t *testing.T) {
 	testMatrix := map[string]struct {
 		ioType             IoType
 		lookupName         string
@@ -130,11 +130,11 @@ func TestLookupIoBundle(t *testing.T) {
 	// Basic test
 	for testname, test := range testMatrix {
 		t.Logf("Running test case %s", testname)
-		ioBundle := aa.LookupIoBundle(test.lookupName)
+		ioBundle := aa.LookupIoBundlePhylabel(test.lookupName)
 		if ioBundle == nil {
 			assert.Equal(t, test.expectedBundleName, "")
 		} else {
-			assert.Equal(t, test.expectedBundleName, ioBundle.Name)
+			assert.Equal(t, test.expectedBundleName, ioBundle.Phylabel)
 		}
 	}
 }
@@ -160,7 +160,7 @@ func TestIoBundleFromPhyAdapter(t *testing.T) {
 	ibPtr := IoBundleFromPhyAdapter(phyAdapter)
 	assert.NotEqual(t, ibPtr, nil)
 	assert.Equal(t, IoType(phyAdapter.Ptype), ibPtr.Type)
-	assert.Equal(t, phyAdapter.Phylabel, ibPtr.Name)
+	assert.Equal(t, phyAdapter.Phylabel, ibPtr.Phylabel)
 	assert.Equal(t, phyAdapter.Logicallabel, ibPtr.Logicallabel)
 	assert.Equal(t, phyAdapter.Assigngrp, ibPtr.AssignmentGroup)
 	assert.Equal(t, phyAdapter.Phyaddr.Ifname, ibPtr.Ifname)

--- a/pkg/pillar/types/ifnametopci.go
+++ b/pkg/pillar/types/ifnametopci.go
@@ -160,8 +160,8 @@ func IoBundleToPci(ib *IoBundle) (string, error) {
 		return "", nil
 	}
 	if !pciLongExists(long) {
-		errStr := fmt.Sprintf("PCI device name %s id %s does not exist",
-			ib.Name, long)
+		errStr := fmt.Sprintf("PCI device ifname %s long %s does not exist",
+			ib.Ifname, long)
 		return long, errors.New(errStr)
 	}
 	return long, nil

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"os"
 	"reflect"
-	"strings"
 	"time"
 
 	"github.com/eriknordmark/ipinfo"
@@ -159,14 +158,14 @@ type DevicePortConfigVersion uint32
 
 // GetPortByIfName - DevicePortConfig Methord to Get Port structure by IfName
 func (portConfig *DevicePortConfig) GetPortByIfName(
-	u string) (NetworkPortConfig, error) {
+	ifname string) (NetworkPortConfig, error) {
 	var port NetworkPortConfig
 	for _, port = range portConfig.Ports {
-		if u == port.IfName {
+		if ifname == port.IfName {
 			return port, nil
 		}
 	}
-	err := fmt.Errorf("DevicePortConfig can't find port %s", u)
+	err := fmt.Errorf("DevicePortConfig can't find port %s", ifname)
 	return port, err
 }
 
@@ -207,13 +206,18 @@ func (portConfig *DevicePortConfig) DoSanitize(
 		}
 	}
 	if sanitizeName {
-		// In case Name isn't set we make it match IfName
+		// In case Phylabel isn't set we make it match IfName. Ditto for Logicallabel
 		// XXX still needed?
 		for i := range portConfig.Ports {
 			port := &portConfig.Ports[i]
-			if port.Name == "" {
-				port.Name = port.IfName
-				log.Infof("DoSanitize: Forcing Name for %s ifname %s\n",
+			if port.Phylabel == "" {
+				port.Phylabel = port.IfName
+				log.Infof("XXX DoSanitize: Forcing Phylabel for %s ifname %s\n",
+					key, port.IfName)
+			}
+			if port.Logicallabel == "" {
+				port.Logicallabel = port.IfName
+				log.Infof("XXX DoSanitize: Forcing Logicallabel for %s ifname %s\n",
 					key, port.IfName)
 			}
 		}
@@ -248,7 +252,8 @@ func (portConfig *DevicePortConfig) Equal(portConfig2 *DevicePortConfig) bool {
 	for i, p1 := range portConfig.Ports {
 		p2 := portConfig2.Ports[i]
 		if p1.IfName != p2.IfName ||
-			p1.Name != p2.Name ||
+			p1.Phylabel != p2.Phylabel ||
+			p1.Logicallabel != p2.Logicallabel ||
 			p1.IsMgmt != p2.IsMgmt ||
 			p1.Free != p2.Free {
 			return false
@@ -402,10 +407,11 @@ type WirelessConfig struct {
 // for one IfName.
 // Note that if fields are added the Equal function needs to be updated.
 type NetworkPortConfig struct {
-	IfName string
-	Name   string // New logical name set by controller/model
-	IsMgmt bool   // Used to talk to controller
-	Free   bool   // Higher priority to talk to controller since no cost
+	IfName       string
+	Phylabel     string // Physical name set by controller/model
+	Logicallabel string
+	IsMgmt       bool // Used to talk to controller
+	Free         bool // Higher priority to talk to controller since no cost
 	DhcpConfig
 	ProxyConfig
 	WirelessCfg WirelessConfig
@@ -415,10 +421,11 @@ type NetworkPortConfig struct {
 }
 
 type NetworkPortStatus struct {
-	IfName string
-	Name   string // New logical name set by controller/model
-	IsMgmt bool   // Used to talk to controller
-	Free   bool
+	IfName       string
+	Phylabel     string // Physical name set by controller/model
+	Logicallabel string
+	IsMgmt       bool // Used to talk to controller
+	Free         bool
 	NetworkXObjectConfig
 	AddrInfoList []AddrInfo
 	ProxyConfig
@@ -439,22 +446,11 @@ type DeviceNetworkStatus struct {
 	Ports   []NetworkPortStatus
 }
 
-func (status *DeviceNetworkStatus) GetPortByName(
-	port string) *NetworkPortStatus {
-	for _, portStatus := range status.Ports {
-		if strings.EqualFold(portStatus.Name, port) {
-			log.Infof("Found NetworkPortStatus for %s", port)
-			return &portStatus
-		}
-	}
-	return nil
-}
-
 func (status *DeviceNetworkStatus) GetPortByIfName(
-	port string) *NetworkPortStatus {
+	ifname string) *NetworkPortStatus {
 	for _, portStatus := range status.Ports {
-		if portStatus.IfName == port {
-			log.Infof("Found NetworkPortStatus for %s", port)
+		if portStatus.IfName == ifname {
+			log.Infof("Found NetworkPortStatus for %s", ifname)
 			return &portStatus
 		}
 	}
@@ -488,7 +484,7 @@ func GetMgmtPortsNonFree(globalStatus DeviceNetworkStatus, rotation int) []strin
 func getMgmtPortsImpl(globalStatus DeviceNetworkStatus, rotation int,
 	freeOnly bool, nonfreeOnly bool) []string {
 
-	var ports []string
+	var ifnameList []string
 	for _, us := range globalStatus.Ports {
 		if freeOnly && !us.Free {
 			continue
@@ -500,9 +496,9 @@ func getMgmtPortsImpl(globalStatus DeviceNetworkStatus, rotation int,
 			!us.IsMgmt {
 			continue
 		}
-		ports = append(ports, us.IfName)
+		ifnameList = append(ifnameList, us.IfName)
 	}
-	return rotate(ports, rotation)
+	return rotate(ifnameList, rotation)
 }
 
 // Return number of local IP addresses for all the management ports
@@ -517,10 +513,10 @@ func CountLocalAddrAnyNoLinkLocal(globalStatus DeviceNetworkStatus) int {
 // Return number of local IP addresses for all the management ports
 // excluding link-local addresses
 func CountLocalAddrAnyNoLinkLocalIf(globalStatus DeviceNetworkStatus,
-	port string) int {
+	phylabelOrIfname string) int {
 
 	// Count the number of addresses which apply
-	addrs, _ := getInterfaceAddr(globalStatus, false, port, false)
+	addrs, _ := getInterfaceAddr(globalStatus, false, phylabelOrIfname, false)
 	return len(addrs)
 }
 
@@ -559,14 +555,14 @@ func CountLocalIPv4AddrAnyNoLinkLocal(globalStatus DeviceNetworkStatus) int {
 	return count
 }
 
-// CountDNSServers returns the number of DNS servers; for port if set
-func CountDNSServers(globalStatus DeviceNetworkStatus, port string) int {
+// CountDNSServers returns the number of DNS servers; for phylabelOrIfname if set
+func CountDNSServers(globalStatus DeviceNetworkStatus, phylabelOrIfname string) int {
 
 	var ifname string
-	if port != "" {
-		ifname = AdapterToIfName(&globalStatus, port)
+	if phylabelOrIfname != "" {
+		ifname = PhylabelToIfName(&globalStatus, phylabelOrIfname)
 	} else {
-		ifname = port
+		ifname = phylabelOrIfname
 	}
 	count := 0
 	for _, us := range globalStatus.Ports {
@@ -578,15 +574,9 @@ func CountDNSServers(globalStatus DeviceNetworkStatus, port string) int {
 	return count
 }
 
-// GetDNSServers returns all, or the ones on one interface if port is set
-func GetDNSServers(globalStatus DeviceNetworkStatus, port string) []net.IP {
+// GetDNSServers returns all, or the ones on one interface if ifname is set
+func GetDNSServers(globalStatus DeviceNetworkStatus, ifname string) []net.IP {
 
-	var ifname string
-	if port != "" {
-		ifname = AdapterToIfName(&globalStatus, port)
-	} else {
-		ifname = port
-	}
 	var servers []net.IP
 	for _, us := range globalStatus.Ports {
 		if !us.IsMgmt {
@@ -605,10 +595,10 @@ func GetDNSServers(globalStatus DeviceNetworkStatus, port string) []net.IP {
 // Return number of local IP addresses for all the management ports with given name
 // excluding link-local addresses
 func CountLocalAddrFreeNoLinkLocalIf(globalStatus DeviceNetworkStatus,
-	port string) int {
+	phylabelOrIfname string) int {
 
 	// Count the number of addresses which apply
-	addrs, _ := getInterfaceAddr(globalStatus, true, port, false)
+	addrs, _ := getInterfaceAddr(globalStatus, true, phylabelOrIfname, false)
 	return len(addrs)
 }
 
@@ -616,13 +606,13 @@ func CountLocalAddrFreeNoLinkLocalIf(globalStatus DeviceNetworkStatus,
 // excluding link-local addresses
 // Only IPv4 counted
 func CountLocalIPv4AddrAnyNoLinkLocalIf(globalStatus DeviceNetworkStatus,
-	port string) int {
+	phylabelOrIfname string) int {
 
 	// Count the number of addresses which apply
-	addrs, _ := getInterfaceAddr(globalStatus, true, port, false)
+	addrs, _ := getInterfaceAddr(globalStatus, true, phylabelOrIfname, false)
 	count := 0
 	log.Infof("CountLocalIPv4AddrAnyNoLinkLocalIf(%s): total %d: %v\n",
-		port, len(addrs), addrs)
+		phylabelOrIfname, len(addrs), addrs)
 	for _, addr := range addrs {
 		if addr.To4() == nil {
 			continue
@@ -632,50 +622,50 @@ func CountLocalIPv4AddrAnyNoLinkLocalIf(globalStatus DeviceNetworkStatus,
 	return count
 }
 
-// Pick one address from all of the management ports, unless if port is set
-// in which we pick from that port. Includes link-local addresses.
+// Pick one address from all of the management ports, unless if phylabelOrIfname is set
+// in which we pick from that phylabelOrIfname. Includes link-local addresses.
 // We put addresses from the free management ports first in the list i.e.,
 // returned for the lower 'pickNum'
 func GetLocalAddrAny(globalStatus DeviceNetworkStatus, pickNum int,
-	port string) (net.IP, error) {
+	phylabelOrIfname string) (net.IP, error) {
 
 	freeOnly := false
 	includeLinkLocal := true
-	return getLocalAddrImpl(globalStatus, pickNum, port, freeOnly,
+	return getLocalAddrImpl(globalStatus, pickNum, phylabelOrIfname, freeOnly,
 		includeLinkLocal)
 }
 
-// Pick one address from all of the management ports, unless if port is set
-// in which we pick from that port. Excludes link-local addresses.
+// Pick one address from all of the management ports, unless if phylabelOrIfname is set
+// in which we pick from that phylabelOrIfname. Excludes link-local addresses.
 // We put addresses from the free management ports first in the list i.e.,
 // returned for the lower 'pickNum'
 func GetLocalAddrAnyNoLinkLocal(globalStatus DeviceNetworkStatus, pickNum int,
-	port string) (net.IP, error) {
+	phylabelOrIfname string) (net.IP, error) {
 
 	freeOnly := false
 	includeLinkLocal := false
-	return getLocalAddrImpl(globalStatus, pickNum, port, freeOnly,
+	return getLocalAddrImpl(globalStatus, pickNum, phylabelOrIfname, freeOnly,
 		includeLinkLocal)
 }
 
-// Pick one address from the free management ports, unless if port is set
-// in which we pick from that port. Excludes link-local addresses.
+// Pick one address from the free management ports, unless if phylabelOrIfname is set
+// in which we pick from that phylabelOrIfname. Excludes link-local addresses.
 // We put addresses from the free management ports first in the list i.e.,
 // returned for the lower 'pickNum'
 func GetLocalAddrFreeNoLinkLocal(globalStatus DeviceNetworkStatus, pickNum int,
-	port string) (net.IP, error) {
+	phylabelOrIfname string) (net.IP, error) {
 
 	freeOnly := true
 	includeLinkLocal := false
-	return getLocalAddrImpl(globalStatus, pickNum, port, freeOnly,
+	return getLocalAddrImpl(globalStatus, pickNum, phylabelOrIfname, freeOnly,
 		includeLinkLocal)
 }
 
 func getLocalAddrImpl(globalStatus DeviceNetworkStatus, pickNum int,
-	port string, freeOnly bool, includeLinkLocal bool) (net.IP, error) {
+	phylabelOrIfname string, freeOnly bool, includeLinkLocal bool) (net.IP, error) {
 
 	// Count the number of addresses which apply
-	addrs, err := getInterfaceAddr(globalStatus, freeOnly, port,
+	addrs, err := getInterfaceAddr(globalStatus, freeOnly, phylabelOrIfname,
 		includeLinkLocal)
 	if err != nil {
 		return net.IP{}, err
@@ -685,15 +675,15 @@ func getLocalAddrImpl(globalStatus DeviceNetworkStatus, pickNum int,
 	return addrs[pickNum], nil
 }
 
-func getInterfaceAndAddr(globalStatus DeviceNetworkStatus, free bool, port string,
+func getInterfaceAndAddr(globalStatus DeviceNetworkStatus, free bool, phylabelOrIfname string,
 	includeLinkLocal bool) ([]NetworkPortStatus, error) {
 
 	var links []NetworkPortStatus
 	var ifname string
-	if port != "" {
-		ifname = AdapterToIfName(&globalStatus, port)
+	if phylabelOrIfname != "" {
+		ifname = PhylabelToIfName(&globalStatus, phylabelOrIfname)
 	} else {
-		ifname = port
+		ifname = phylabelOrIfname
 	}
 	for _, us := range globalStatus.Ports {
 		if globalStatus.Version >= DPCIsMgmt &&
@@ -709,10 +699,11 @@ func getInterfaceAndAddr(globalStatus DeviceNetworkStatus, free bool, port strin
 		}
 
 		link := NetworkPortStatus{
-			IfName: us.IfName,
-			Name:   us.Name,
-			IsMgmt: us.IsMgmt,
-			Free:   us.Free,
+			IfName:       us.IfName,
+			Phylabel:     us.Phylabel,
+			Logicallabel: us.Logicallabel,
+			IsMgmt:       us.IsMgmt,
+			Free:         us.Free,
 		}
 		if includeLinkLocal {
 			link.AddrInfoList = us.AddrInfoList
@@ -754,10 +745,10 @@ func GetExistingInterfaceList(globalStatus DeviceNetworkStatus) []string {
 	return ifs
 }
 
-// Check if an interface/adapter name is a port owned by zedrouter
-func IsPort(globalStatus DeviceNetworkStatus, port string) bool {
+// Check if an interface name is a port owned by zedrouter
+func IsPort(globalStatus DeviceNetworkStatus, ifname string) bool {
 	for _, us := range globalStatus.Ports {
-		if us.Name != port && us.IfName != port {
+		if us.IfName != ifname {
 			continue
 		}
 		return true
@@ -765,10 +756,10 @@ func IsPort(globalStatus DeviceNetworkStatus, port string) bool {
 	return false
 }
 
-// Check if an interface/adapter name is a management port
-func IsMgmtPort(globalStatus DeviceNetworkStatus, port string) bool {
+// Check if a physical label or ifname is a management port
+func IsMgmtPort(globalStatus DeviceNetworkStatus, phylabelOrIfname string) bool {
 	for _, us := range globalStatus.Ports {
-		if us.Name != port && us.IfName != port {
+		if us.Phylabel != phylabelOrIfname && us.IfName != phylabelOrIfname {
 			continue
 		}
 		if globalStatus.Version >= DPCIsMgmt &&
@@ -780,10 +771,10 @@ func IsMgmtPort(globalStatus DeviceNetworkStatus, port string) bool {
 	return false
 }
 
-// Check if an interface/adapter name is a free management port
-func IsFreeMgmtPort(globalStatus DeviceNetworkStatus, port string) bool {
+// Check if a physical label or ifname is a free management port
+func IsFreeMgmtPort(globalStatus DeviceNetworkStatus, phylabelOrIfname string) bool {
 	for _, us := range globalStatus.Ports {
-		if us.Name != port && us.IfName != port {
+		if us.Phylabel != phylabelOrIfname && us.IfName != phylabelOrIfname {
 			continue
 		}
 		if globalStatus.Version >= DPCIsMgmt &&
@@ -795,9 +786,9 @@ func IsFreeMgmtPort(globalStatus DeviceNetworkStatus, port string) bool {
 	return false
 }
 
-func GetPort(globalStatus DeviceNetworkStatus, port string) *NetworkPortStatus {
+func GetPort(globalStatus DeviceNetworkStatus, phylabelOrIfname string) *NetworkPortStatus {
 	for _, us := range globalStatus.Ports {
-		if us.Name != port && us.IfName != port {
+		if us.Phylabel != phylabelOrIfname && us.IfName != phylabelOrIfname {
 			continue
 		}
 		if globalStatus.Version < DPCIsMgmt {
@@ -828,15 +819,15 @@ func GetMgmtPortFromAddr(globalStatus DeviceNetworkStatus, addr net.IP) string {
 // IPv6 link-locals. Only applies to management ports.
 // If free is not set, the addresses from the free management ports are first.
 func getInterfaceAddr(globalStatus DeviceNetworkStatus, free bool,
-	port string, includeLinkLocal bool) ([]net.IP, error) {
+	phylabelOrIfname string, includeLinkLocal bool) ([]net.IP, error) {
 
 	var freeAddrs []net.IP
 	var nonfreeAddrs []net.IP
 	var ifname string
-	if port != "" {
-		ifname = AdapterToIfName(&globalStatus, port)
+	if phylabelOrIfname != "" {
+		ifname = PhylabelToIfName(&globalStatus, phylabelOrIfname)
 	} else {
-		ifname = port
+		ifname = phylabelOrIfname
 	}
 	for _, us := range globalStatus.Ports {
 		if free && !us.Free {
@@ -870,44 +861,59 @@ func getInterfaceAddr(globalStatus DeviceNetworkStatus, free bool,
 	}
 }
 
-// Return list of port names we will report in info and metrics
-func ReportPorts(deviceNetworkStatus DeviceNetworkStatus) []string {
+// ReportPhylabels returns a list of Phylabels we will report in info and metrics
+func ReportPhylabels(deviceNetworkStatus DeviceNetworkStatus) []string {
 
 	var names []string
 	for _, port := range deviceNetworkStatus.Ports {
-		names = append(names, port.Name)
+		names = append(names, port.Phylabel)
 	}
 	return names
 }
 
-// lookup port Name to find IfName
-// Can also match on IfName
-// If not found, return the adapter string
-func AdapterToIfName(deviceNetworkStatus *DeviceNetworkStatus,
-	adapter string) string {
+// PhylabelToIfName looks up a port Phylabel or IfName to find an existing IfName
+// If not found, return the phylabelOrIfname argument string
+func PhylabelToIfName(deviceNetworkStatus *DeviceNetworkStatus,
+	phylabelOrIfname string) string {
 
 	for _, p := range deviceNetworkStatus.Ports {
-		if p.Name == adapter {
-			log.Debugf("AdapterToIfName: found %s for %s\n",
-				p.IfName, adapter)
+		if p.Phylabel == phylabelOrIfname {
+			log.Debugf("PhylabelToIfName: found %s for %s\n",
+				p.IfName, phylabelOrIfname)
 			return p.IfName
 		}
 	}
 	for _, p := range deviceNetworkStatus.Ports {
-		if p.IfName == adapter {
-			log.Debugf("AdapterToIfName: matched %s\n", adapter)
-			return adapter
+		if p.IfName == phylabelOrIfname {
+			log.Debugf("PhylabelToIfName: matched %s\n", phylabelOrIfname)
+			return phylabelOrIfname
 		}
 	}
-	log.Debugf("AdapterToIfName: no match for %s\n", adapter)
-	return adapter
+	log.Debugf("PhylabelToIfName: no match for %s\n", phylabelOrIfname)
+	return phylabelOrIfname
+}
+
+// LogicallabelToIfName looks up a port Logical label to find an existing IfName
+// If not found, return the logicallabel argument string
+func LogicallabelToIfName(deviceNetworkStatus *DeviceNetworkStatus,
+	logicallabel string) string {
+
+	for _, p := range deviceNetworkStatus.Ports {
+		if p.Logicallabel == logicallabel {
+			log.Infof("XXX LogicallabelToIfName: found %s for %s\n",
+				p.IfName, logicallabel)
+			return p.IfName
+		}
+	}
+	log.Infof("XXX LogicallabelToIfName: no match for %s\n", logicallabel)
+	return logicallabel
 }
 
 // IsAnyPortInPciBack
-//		Checks is any of the Ports are part of IO bundles which are in PCIback.
-//		If true, it also returns the portName ( NOT bundle name )
-//		Also returns whether it is currently used by an application by
-//		returning a UUID. If the UUID is zero it is in PCIback but available.
+//	Checks is any of the Ports are part of IO bundles which are in PCIback.
+//	If true, it also returns the ifName ( NOT bundle name )
+//	Also returns whether it is currently used by an application by
+//	returning a UUID. If the UUID is zero it is in PCIback but available.
 func (portConfig *DevicePortConfig) IsAnyPortInPciBack(
 	aa *AssignableAdapters) (bool, string, uuid.UUID) {
 	if aa == nil {
@@ -917,12 +923,10 @@ func (portConfig *DevicePortConfig) IsAnyPortInPciBack(
 	log.Infof("IsAnyPortInPciBack: aa init %t, %d bundles, %d ports",
 		aa.Initialized, len(aa.IoBundleList), len(portConfig.Ports))
 	for _, port := range portConfig.Ports {
-		// XXX this assumes that ioBundle.Name is the ifname known
-		// by the kernel/ifconfig
-		ioBundle := aa.LookupIoBundleNet(port.IfName)
+		ioBundle := aa.LookupIoBundleIfName(port.IfName)
 		if ioBundle == nil {
 			// It is not guaranteed that all Ports are part of Assignable Adapters
-			// If not found, the adaptor is not capable of being assigned at
+			// If not found, the adapter is not capable of being assigned at
 			// PCI level. So it cannot be in PCI back.
 			log.Infof("IsAnyPortInPciBack: ifname %s not found",
 				port.IfName)
@@ -1102,7 +1106,7 @@ const (
 	NT_NOOP      NetworkType = 0
 	NT_IPV4                  = 4
 	NT_IPV6                  = 6
-	NT_CryptoEID             = 14 // Either IPv6 or IPv4; adapter Addr
+	NT_CryptoEID             = 14 // Either IPv6 or IPv4; IP Address
 	// determines whether IPv4 EIDs are in use.
 	NT_CryptoV4 = 24 // Not used
 	NT_CryptoV6 = 26 // Not used
@@ -1145,7 +1149,7 @@ type NetworkInstanceInfo struct {
 	BridgeIPAddr string
 	BridgeMac    string
 
-	// interface names for the Port
+	// interface names for the Logicallabel
 	IfNameList []string // Recorded at time of activate
 
 	// Collection of address assignments; from MAC address to IP address
@@ -1335,8 +1339,9 @@ type NetworkInstanceConfig struct {
 	// Activate - Activate the config.
 	Activate bool
 
-	// Port - Port name specified in the Device Config.
-	Port string
+	// Logicallabel - name specified in the Device Config.
+	// Can be a specific logicallabel for an interface, or a tag like "uplink"
+	Logicallabel string
 
 	// IP configuration for the Application
 	IpType          AddressType
@@ -1522,13 +1527,10 @@ func (status *NetworkInstanceStatus) IsIpAssigned(ip net.IP) bool {
 	return false
 }
 
-// Check if port is used even if a label like "uplink" is used to specify it
-func (status *NetworkInstanceStatus) IsUsingPort(port string) bool {
-	if strings.EqualFold(port, status.Port) {
-		return true
-	}
-	for _, ifname := range status.IfNameList {
-		if ifname == port {
+// IsUsingIfName checks if ifname is used
+func (status *NetworkInstanceStatus) IsUsingIfName(ifname string) bool {
+	for _, ifname2 := range status.IfNameList {
+		if ifname2 == ifname {
 			return true
 		}
 	}
@@ -1630,7 +1632,7 @@ type VpnConfig struct {
 }
 
 type NetLinkConfig struct {
-	Name        string
+	IfName      string
 	IpAddr      string
 	SubnetBlock string
 }

--- a/pkg/pillar/types/zedroutertypes_test.go
+++ b/pkg/pillar/types/zedroutertypes_test.go
@@ -125,26 +125,29 @@ func TestIsNetworkUsed(t *testing.T) {
 
 // Make sure IsDPCUsable passes
 var usablePort = NetworkPortConfig{
-	IfName:     "eth0",
-	Name:       "eth0",
-	IsMgmt:     true,
-	DhcpConfig: DhcpConfig{Dhcp: DT_CLIENT},
+	IfName:       "eth0",
+	Phylabel:     "eth0",
+	Logicallabel: "eth0",
+	IsMgmt:       true,
+	DhcpConfig:   DhcpConfig{Dhcp: DT_CLIENT},
 }
 var usablePorts = []NetworkPortConfig{usablePort}
 
 var unusablePort1 = NetworkPortConfig{
-	IfName:     "eth0",
-	Name:       "eth0",
-	IsMgmt:     false,
-	DhcpConfig: DhcpConfig{Dhcp: DT_CLIENT},
+	IfName:       "eth0",
+	Phylabel:     "eth0",
+	Logicallabel: "eth0",
+	IsMgmt:       false,
+	DhcpConfig:   DhcpConfig{Dhcp: DT_CLIENT},
 }
 var unusablePorts1 = []NetworkPortConfig{unusablePort1}
 
 var unusablePort2 = NetworkPortConfig{
-	IfName:     "eth0",
-	Name:       "eth0",
-	IsMgmt:     true,
-	DhcpConfig: DhcpConfig{Dhcp: DT_NONE},
+	IfName:       "eth0",
+	Phylabel:     "eth0",
+	Logicallabel: "eth0",
+	IsMgmt:       true,
+	DhcpConfig:   DhcpConfig{Dhcp: DT_NONE},
 }
 var unusablePorts2 = []NetworkPortConfig{unusablePort2}
 var mixedPorts = []NetworkPortConfig{usablePort, unusablePort1, unusablePort2}
@@ -322,31 +325,6 @@ func TestWasDPCWorking(t *testing.T) {
 		t.Logf("Running test case %s", testname)
 		value := test.devicePortConfig.WasDPCWorking()
 		assert.Equal(t, test.expectedValue, value)
-	}
-}
-
-func TestGetPortByName(t *testing.T) {
-	testMatrix := map[string]struct {
-		deviceNetworkStatus DeviceNetworkStatus
-		port                string
-		expectedValue       NetworkPortStatus
-	}{
-		"Test name is port one": {
-			deviceNetworkStatus: DeviceNetworkStatus{
-				Ports: []NetworkPortStatus{
-					{Name: "port one"},
-				},
-			},
-			port: "port one",
-			expectedValue: NetworkPortStatus{
-				Name: "port one",
-			},
-		},
-	}
-	for testname, test := range testMatrix {
-		t.Logf("Running test case %s", testname)
-		value := test.deviceNetworkStatus.GetPortByName(test.port)
-		assert.Equal(t, test.expectedValue, *value)
 	}
 }
 


### PR DESCRIPTION
Which includes renaming fields, variables, and functions so it is more clear what we refer to.
That removes use like "adapter string" and "port string" because those are very undefined.

Still running the integration tests on this.