### PR TITLE
handle signing certs changes

### DIFF
--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -595,7 +595,7 @@ func fetchCertChain(zedcloudCtx *zedcloud.ZedCloudContext, tlsConfig *tls.Config
 
 	zedcloudCtx.TlsConfig = tlsConfig
 	// verify the certificate chain and write the siging cert to file
-	certBytes, err := zedcloud.VerifyCloudCertChain(zedcloudCtx, serverName, contents)
+	certBytes, err := zedcloud.VerifySigningCertChain(zedcloudCtx, contents)
 	if err != nil {
 		log.Errorf("client fetchCertChain: verify err %v", err)
 		return false

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -317,7 +317,7 @@ func getCloudCertChain(ctx *zedagentContext) bool {
 	// for cipher object handling
 	parseControllerCerts(ctx, contents)
 
-	certBytes, err := zedcloud.VerifyCloudCertChain(&zedcloudCtx, serverName, contents)
+	certBytes, err := zedcloud.VerifySigningCertChain(&zedcloudCtx, contents)
 	if err != nil {
 		log.Errorf("getCloudCertChain: verify err %v", err)
 		return false

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -456,6 +456,7 @@ func Run(ps *pubsub.PubSub) {
 			AgentName:     agentName,
 			TopicImpl:     types.ControllerCertStatus{},
 			Activate:      false,
+			Ctx:           &zedagentCtx,
 			CreateHandler: handleControllerCertStatusModify,
 			ModifyHandler: handleControllerCertStatusModify,
 			DeleteHandler: handleControllerCertStatusDelete,


### PR DESCRIPTION
Signed-off-by: Naiming Shen <naiming@zededa.com>
- skip the cert type 3
- root cert from private root-certificate file for V2
- not verify the server name in the chain
- fixed a crash in missing context init of sub controllercerts
- tested with gamma (private TLS certs) for v1 -> v2