### PR TITLE
Getting rid of perl dependency once and for all

### DIFF
--- a/pkg/pillar/Dockerfile.in
+++ b/pkg/pillar/Dockerfile.in
@@ -39,7 +39,7 @@ SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 RUN apk add --no-cache \
     yajl xz bash openssl iptables ip6tables iproute2 dhcpcd      \
     coreutils dmidecode libbz2 libuuid ipset       \
-    curl radvd perl ethtool \
+    curl radvd ethtool \
     util-linux e2fsprogs libcrypto1.0 xorriso qemu-img \
     libpcap jq e2fsprogs-extra keyutils
 

--- a/pkg/xen-tools/Dockerfile.in
+++ b/pkg/xen-tools/Dockerfile.in
@@ -61,6 +61,10 @@ RUN dist/install.sh /out
 # Filter out a few things that we don't currently need
 RUN rm -rf /out/usr/share/qemu-xen/qemu/edk2-* /out/var/run
 
+# this tiny C code is there to replace a perl dependency
+COPY rightfile.c /tmp
+RUN gcc -o /out/usr/bin/rightfile /tmp/rightfile.c
+
 FROM alpine:3.8
 RUN apk add --no-cache \
     bash=4.4.19-r1     \
@@ -82,7 +86,7 @@ COPY init.sh /
 RUN ln -s qemu-system-x86_64 /usr/lib/xen/bin/qemu-system-i386
 
 # We need to keep a slim profile, which means removing things we don't need
-RUN rm -rf /usr/lib/libxen*.a /usr/lib/libxl*.a /usr/lib/debug
+RUN rm -rf /usr/lib/libxen*.a /usr/lib/libxl*.a /usr/lib/debug /usr/lib/python2.7
 
 # Adjust /var/run to be shared
 RUN rm -rf /var/run && ln -s /run /var/run

--- a/pkg/xen-tools/patches-4.13.0/10-remove-perl.patch
+++ b/pkg/xen-tools/patches-4.13.0/10-remove-perl.patch
@@ -1,0 +1,16 @@
+--- xen/tools/hotplug/Linux/locking.sh	2019-07-19 12:54:37.000000000 -0700
++++ xen/tools/hotplug/Linux/locking.sh	2020-03-21 00:14:37.000000000 -0700
+@@ -51,12 +51,7 @@
+         # guaranteed that our stat(2) won't lose the race with an
+         # rm(1) between reading the synthetic link and traversing the
+         # file system to find the inum.  Perl is very fast so use that.
+-        rightfile=$( perl -e '
+-            open STDIN, "<&'$_lockfd'" or die $!;
+-            my $fd_inum = (stat STDIN)[1]; die $! unless defined $fd_inum;
+-            my $file_inum = (stat $ARGV[0])[1];
+-            print "y\n" if $fd_inum eq $file_inum;
+-                             ' "$_lockfile" )
++        rightfile=$(rightfile "$_lockfile" <&$_lockfd)
+         if [ x$rightfile = xy ]; then break; fi
+ 	# Some versions of bash appear to be buggy if the same
+ 	# $_lockfile is opened repeatedly. Close the current fd here.

--- a/pkg/xen-tools/rightfile.c
+++ b/pkg/xen-tools/rightfile.c
@@ -1,0 +1,25 @@
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+int main(int argc, char **argv) {
+    struct stat st;
+    int fd_inum, file_inum;
+
+    if (fstat(0, &st) < 0) {
+        return -1;
+    }
+    fd_inum = st.st_ino;
+
+    if (stat(argv[1], &st) < 0) {
+        return -1;
+    }
+    file_inum = st.st_ino;
+
+    if (file_inum == fd_inum) {
+        printf("y\n");
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Turns out, there was still one crazy little nook where we needed perl for xen-tools. I rewrote that part in C.

Also, got rid of useless python modules in xen-tools (there's no python to execute them there anyway).

Finally, got rid of perl dependency from pillar after confirming that nothing really uses it there anymore.