### PR TITLE
globalStatus sent to zedcloud gets cleared out

### DIFF
--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -1944,7 +1944,6 @@ func parseConfigItems(config *zconfig.EdgeDevConfig, ctx *getconfigContext) {
 			err = nil
 		}
 	}
-	ctx.zedagentCtx.globalStatus = newGlobalStatus
 	newGlobalConfig = types.ApplyGlobalConfig(newGlobalConfig)
 	// XXX - Should we also not call EnforceGlobalConfigMinimums on
 	// newGlobalConfig here before checking if anything changed??
@@ -1959,6 +1958,7 @@ func parseConfigItems(config *zconfig.EdgeDevConfig, ctx *getconfigContext) {
 
 		// Set GlobalStatus Values from GlobalConfig.
 		newGlobalStatus.UpdateItemValuesFromGlobalConfig(*gcPtr)
+		ctx.zedagentCtx.globalStatus = newGlobalStatus
 
 		if gcPtr.ConfigInterval != oldGlobalConfig.ConfigInterval {
 			log.Infof("parseConfigItems: %s change from %d to %d\n",


### PR DESCRIPTION
I was trying to use configItemStatus from the controller and noticed that it gets emptied out (unless there is an error).
It is useful to be able to check whether e.g. debug.default.loglevel has been set which means we need to report this info to the controller.