### PR TITLE
Verifying domain before deciding on qemu crash.

### DIFF
--- a/pkg/pillar/cmd/domainmgr/containerd.go
+++ b/pkg/pillar/cmd/domainmgr/containerd.go
@@ -142,7 +142,7 @@ func ctrRm(containerPath string, silent bool) error {
 	if container == nil {
 		return nil
 	}
-	if err := container.Delete(ctrdCtx); err != nil {
+	if err := container.Delete(ctrdCtx, containerd.WithSnapshotCleanup); err != nil {
 		err = fmt.Errorf("ctrRm: unable to delete container: %v. %v", containerID, err.Error())
 		log.Error(err)
 		if !silent {


### PR DESCRIPTION
To get an idea about the issue please refer: https://www.pivotaltracker.com/story/show/171962732 

The fix for this issue is to check on the domain again before declaring qemu crashed error. Even with this approach, we might face the same issue, so to be on the safer side, added a wait time of 3 sec before checking on the domain. 3 sec is enough time for the domain to kill qemu and kill self in the case of domain crash. 