### PR TITLE
SIGUSR2 logs current memory allocations with stack traces

### DIFF
--- a/pkg/pillar/agentlog/agentlog.go
+++ b/pkg/pillar/agentlog/agentlog.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"runtime"
 	dbg "runtime/debug"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -110,7 +111,7 @@ func handleSignals(sigs chan os.Signal) {
 			case syscall.SIGUSR2:
 				log.Warnf("SIGUSR2 triggered memory info:\n")
 				logMemUsage()
-				logGCStats()
+				logMemAllocationSites()
 			}
 		}
 	}
@@ -300,23 +301,37 @@ func logGCStats() {
 	log.Infof("GCStats %+v\n", m)
 }
 
+// Print in sorted order based on top bytes
+func logMemAllocationSites() {
+	reportZeroInUse := false
+	numSites, sites := GetMemAllocationSites(reportZeroInUse)
+	log.Warnf("alloc %d sites len %d", numSites, len(sites))
+	sort.Slice(sites,
+		func(i, j int) bool {
+			return sites[i].InUseBytes > sites[j].InUseBytes ||
+				(sites[i].InUseBytes == sites[j].InUseBytes &&
+					sites[i].AllocBytes > sites[j].AllocBytes)
+		})
+	for _, site := range sites {
+		log.Warnf("alloc %d bytes %d objects total %d/%d at:\n%s",
+			site.InUseBytes, site.InUseObjects, site.AllocBytes,
+			site.AllocObjects, site.PrintedStack)
+	}
+}
+
 // LogMemoryUsage provides for user-triggered memory reports
 func LogMemoryUsage() {
 	log.Info("User-triggered memory report")
 	logMemUsage()
-	logGCStats()
+	logMemAllocationSites()
 }
 
 func logMemUsage() {
 	var m runtime.MemStats
 
 	runtime.ReadMemStats(&m)
-
-	log.Infof("Alloc %v Mb", roundToMb(m.Alloc))
-	log.Infof("TotalAlloc %v Mb", roundToMb(m.TotalAlloc))
-	log.Infof("Sys %v Mb", roundToMb(m.Sys))
-	log.Infof("NumGC %v", m.NumGC)
-	log.Infof("MemStats %+v", m)
+	log.Infof("Alloc %d Mb, TotalAlloc %d Mb, Sys %d Mb, NumGC %d",
+		roundToMb(m.Alloc), roundToMb(m.TotalAlloc), roundToMb(m.Sys), m.NumGC)
 }
 
 func roundToMb(b uint64) uint64 {

--- a/pkg/pillar/agentlog/memprofile.go
+++ b/pkg/pillar/agentlog/memprofile.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2018 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package agentlog
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+// MemAllocationSite is the return value of GetMemProfile
+type MemAllocationSite struct {
+	InUseBytes   int64
+	InUseObjects int64
+	AllocBytes   int64
+	AllocObjects int64
+	PrintedStack string
+}
+
+// GetMemAllocationSites returns the non-zero allocation sites in the form of
+// an array of strings; each string is for one allocation call site.
+// If reportZeroInUse is set it also reports with zero InUse.
+func GetMemAllocationSites(reportZeroInUse bool) (int, []MemAllocationSite) {
+	var sites []MemAllocationSite
+
+	// Determine how many sites we have
+	nprof := 100
+	prof := make([]runtime.MemProfileRecord, 100)
+	var n = 0
+	for {
+		var ok bool
+		n, ok = runtime.MemProfile(prof, reportZeroInUse)
+		if ok {
+			break
+		}
+		fmt.Printf("MemProfile failed for %d\n", nprof)
+		nprof += 100
+		prof = append(prof, make([]runtime.MemProfileRecord, 100)...)
+	}
+	for i := 0; i < n; i++ {
+		site := MemAllocationSite{
+			InUseBytes:   prof[i].InUseBytes(),
+			InUseObjects: prof[i].InUseObjects(),
+			AllocBytes:   prof[i].AllocBytes,
+			AllocObjects: prof[i].AllocObjects,
+		}
+		frames := runtime.CallersFrames(prof[i].Stack())
+
+		var lines string
+		for {
+			frame, more := frames.Next()
+			// Don't print the entries inside the runtime
+			// XXX
+			if false && strings.Contains(frame.File, "runtime/") {
+				if !more {
+					break
+				}
+				continue
+			}
+			line := fmt.Sprintf("%s[%d] %s\n",
+				frame.File, frame.Line, frame.Function)
+			lines += line
+			if !more {
+				break
+			}
+		}
+		site.PrintedStack = lines
+		sites = append(sites, site)
+	}
+	return n, sites
+}


### PR DESCRIPTION
@naiming-zededa note that if you want to e.g., periodically get this info as part of debugging you can call agentlog.LogMemoryUsage()
Or pkill -USR2.
