### PR TITLE
Move repetitive agent code to agent.go

### DIFF
--- a/pkg/pillar/agentbase/agent.go
+++ b/pkg/pillar/agentbase/agent.go
@@ -1,0 +1,63 @@
+package agentbase
+
+import (
+	"flag"
+	"github.com/lf-edge/eve/pkg/pillar/agentlog"
+	"github.com/lf-edge/eve/pkg/pillar/pidfile"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// AgentBase - Interface for all agents to use the AgentBase.
+// Each agent is expected to have a Context that implements
+// this interface.
+type AgentBase interface {
+	AgentBaseContext() *Context
+	AddAgentSpecificCLIFlags()
+	ProcessAgentSpecificCLIFlags()
+}
+
+// CliParams - stores all the common cli params
+type CliParams struct {
+	DebugOverride bool
+}
+
+// Context - a struct that represents a general agent context
+type Context struct {
+	CLIParams    CliParams
+	ErrorTime    time.Duration
+	WarningTime  time.Duration
+	AgentName    string
+	NeedWatchdog bool
+}
+
+// processCLIFlags - Add flags common to all agents
+func processCLIFlags(agentBase AgentBase) {
+	debugPtr := flag.Bool("d", false, "Debug flag")
+	agentBase.AddAgentSpecificCLIFlags()
+	flag.Parse()
+	ctx := agentBase.AgentBaseContext()
+	ctx.CLIParams.DebugOverride = *debugPtr
+	agentBase.ProcessAgentSpecificCLIFlags()
+}
+
+// Run - a general run function that will handle all of the common code for agents
+func Run(agentSpecificContext AgentBase) {
+	processCLIFlags(agentSpecificContext)
+	ctx := agentSpecificContext.AgentBaseContext()
+	debugOverride := ctx.CLIParams.DebugOverride
+	if debugOverride {
+		log.SetLevel(log.DebugLevel)
+	} else {
+		log.SetLevel(log.InfoLevel)
+	}
+	agentlog.Init(ctx.AgentName)
+	if err := pidfile.CheckAndCreatePidfile(ctx.AgentName); err != nil {
+		log.Fatal(err)
+	}
+	log.Infof("Starting %s\n", ctx.AgentName)
+	if ctx.NeedWatchdog {
+		agentlog.StillRunning(ctx.AgentName, ctx.WarningTime, ctx.ErrorTime)
+	}
+}


### PR DESCRIPTION
The goal of this PR is to start moving some of the repetitive code in the agents to an AgentBase interface. There is also an AgentContext, which will define what we expect the context of an agent to look like.

Items that could be moved into agent.go in the future. 

CLI parsing
Main Loop for Reacting to PubSubs
Heartbeat handling 
Handling of Global Settings / Logging etc

This PR handles the first one, CLI parsing. 