### PR TITLE
fix an issue vm app w/ disk format error after reboot

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1820,6 +1820,9 @@ func addNoDuplicate(list []string, add string) []string {
 }
 
 func cp(dst, src string) error {
+	if strings.Compare(dst, src) == 0 {
+		return nil
+	}
 	s, err := os.Open(src)
 	if err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: Naiming Shen <naiming@zededa.com>
- opened pivotal story #172015368
- seen the VM App gets error: Disk format mismatch, every time reboot the device, never recover
- the issue is the /persist/img has the app img after reboot, and due to some decision to not preserve, and the target already exist, we still copy from the src to dest, but in this case, the src and dest are the same. during the cp(), the dest is os.Create() first and zero'ed out the file. A valid img file ends up with a zero content file. thus the error.