### PR TITLE
Fixing building bug on local machine in a dirty worktree

### DIFF
--- a/tools/parse-pkgs.sh
+++ b/tools/parse-pkgs.sh
@@ -23,7 +23,8 @@ eve_version() {
 }
 
 linuxkit_tag() {
-    echo "$(linuxkit pkg show-tag ${EVE_HASH:+--hash $EVE_HASH} "$EVE/$1")$ARCH"
+    local tag=$(linuxkit pkg show-tag ${EVE_HASH:+--hash $EVE_HASH} "$EVE/$1")
+    echo "${tag%-dirty}$ARCH"
 }
 
 immutable_tag() {


### PR DESCRIPTION
The issue happens when Go updates go.mod and go.sum during building
process. In this case from Git perspective a working tree becomes dirty
and commands chain: linuxkit pkg show-tag ... -> git describe ...
produces wrong pkg/* image tags for packages which folders become
updated. At the same time there is no images with a -dirty suffix
on the Docker Hub.