### PR TITLE
mitm proxy for websocket support of remote console access

### DIFF
--- a/pkg/pillar/zedcloud/proxy.go
+++ b/pkg/pillar/zedcloud/proxy.go
@@ -112,10 +112,12 @@ func (cfg *config) proxyForURL(reqURL *url.URL) (*url.URL, error) {
 			}
 		}
 	*/
+	// since ws and wss use the same port numbers as http and https, send ws and wss
+	// to the same proxy configured makes sense
 	switch reqURL.Scheme {
-	case "https":
+	case "https", "wss":
 		proxy = cfg.httpsProxy
-	case "http":
+	case "http", "ws":
 		proxy = cfg.httpProxy
 	}
 	if proxy == nil {


### PR DESCRIPTION
Signed-off-by: Naiming Shen <naiming@zededa.com>
- support of V2 mitm for remote console access
- changes for wstunnel with v2 support
- redirect wss to https proxy if configured
- tested w/ special configured proxy software supporting websocket, zedcloud support on gamma
- remote console function seems to work through a mitm proxy