### PR TITLE
forgot to test agentsettings

### DIFF
--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -702,6 +702,9 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddStringItem(DefaultLogLevel, "info", parseLevel)
 	configItemSpecMap.AddStringItem(DefaultRemoteLogLevel, "info", parseLevel)
 
+	configItemSpecMap.AddAgentSettingStringItem(LogLevel, "info", parseLevel)
+	configItemSpecMap.AddAgentSettingStringItem(RemoteLogLevel, "info", parseLevel)
+
 	return configItemSpecMap
 }
 


### PR DESCRIPTION
This clearly needed end-to-end testing.

With this fix it works to set
debug.zedrouter.loglevel and
debug.zedrouter.remote.loglevel 

However, @archishou the code hits at the new syntax should be
agent.zedrouter.debug.loglevel 
and two issues:
1. That is not documented in docs/CONFIG-PROPERTIES.md
2. It fails with this in the logs:
{"file":"/pillar/types/global.go:330","func":"github.com/lf-edge/eve/pkg/pillar/types.(*ConfigItemSpecMap).parseAgentItem","level":"error","msg":"***parseAgentItem: ERROR: Unable to find agent name for per-agent setting. Key: debug.zedrouter.loglevel","pid":1986,"source":"zedagent","time":"2020-04-02T12:57:19.967666351Z"}

@kalyan-nidumolu can you file a bug story to fix that new syntax issues?

