### PR TITLE
check v2 trig timer for pull certs from zedagent

### DIFF
--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -192,9 +192,6 @@ func getLatestConfig(url string, iteration int,
 
 	log.Debugf("getLatestConfig(%s, %d)\n", url, iteration)
 
-	// trigger a one sec timer to acquire new certs from cloud
-	triggerFetchCerts(getconfigCtx.zedagentCtx)
-
 	const return400 = false
 	getconfigCtx.configGetStatus = types.ConfigGetFail
 	b, cr, err := generateConfigRequest()
@@ -286,8 +283,6 @@ func getLatestConfig(url string, iteration int,
 }
 
 func getCloudCertChain(ctx *zedagentContext) bool {
-	// get Certs is always V2 API, if the reply turns out it's not, will reset it, use http for now
-	zedcloudCtx.V2API = true
 	certURL := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, true, nilUUID, "certs")
 	resp, contents, rtf, err := zedcloud.SendOnAllIntf(&zedcloudCtx, certURL, 0, nil, 0, false)
 	if err != nil {
@@ -304,7 +299,6 @@ func getCloudCertChain(ctx *zedagentContext) bool {
 		log.Infof("getCloudCertChain: status %s\n", resp.Status)
 	case http.StatusNotFound, http.StatusUnauthorized, http.StatusNotImplemented, http.StatusBadRequest:
 		log.Infof("getCloudCertChain: server %s does not support V2 API\n", serverName)
-		zedcloudCtx.V2API = false
 		return false
 	default:
 		log.Errorf("getCloudCertChain: statuscode %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -1047,8 +1047,11 @@ func Run(ps *pubsub.PubSub) {
 	// XXX close handleChannels?
 	getconfigCtx.configTickerHandle = configTickerHandle
 
+	// let zedagent get the certs for encryption/decryption at least once if V2
 	zedagentCtx.getCertsTimer = time.NewTimer(1 * time.Second)
-	zedagentCtx.getCertsTimer.Stop()
+	if !zedcloud.UseV2API() {
+		zedagentCtx.getCertsTimer.Stop()
+	}
 
 	for {
 		select {


### PR DESCRIPTION
Signed-off-by: Naiming Shen <naiming@zededa.com>
- check V2 to allow the getCertsTimer to fire in zedagent
- remove stale code inside getCloudCertChain() which can cause problem if accidentally called
- remove the previous committed trigger for certs in getLatestConfig()
- tested on V1 and V2 devices