### PR TITLE
Creting a separate rootfs image for KVM

### DIFF
--- a/images/rootfs-kvm.yml.in
+++ b/images/rootfs-kvm.yml.in
@@ -1,0 +1,56 @@
+kernel:
+  image: KERNEL_TAG
+  cmdline: "rootdelay=3"
+init:
+  - linuxkit/init:v0.5
+  - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
+  - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
+  - linuxkit/getty:v0.5
+  - linuxkit/memlogd:v0.5
+  - GRUB_TAG
+  - FW_TAG
+  - XEN_TAG
+  - GPTTOOLS_TAG
+  - DOM0ZTOOLS_TAG
+onboot:
+   - name: storage-init
+     image: STORAGE_INIT_TAG
+   - name: sysctl
+     image: linuxkit/sysctl:v0.5
+     binds:
+        - /etc/sysctl.d:/etc/sysctl.d
+   - name: rngd
+     image: RNGD_TAG
+     command: ["/sbin/rngd", "-1"]
+   - name: modprobe
+     image: linuxkit/modprobe:v0.5
+     command: ["modprobe", "-a", "nct6775", "w83627hf_wdt", "wlcore_sdio", "wl18xx", "br_netfilter"]
+services:
+   - name: rsyslogd
+     image: RSYSLOGD_TAG
+   - name: ntpd
+     image: linuxkit/openntpd:v0.5
+   - name: sshd
+     image: linuxkit/sshd:v0.5
+   - name: wwan
+     image: WWAN_TAG
+   - name: wlan
+     image: WLAN_TAG
+   - name: lisp
+     image: LISP_TAG
+   - name: guacd
+     image: GUACD_TAG
+   - name: pillar
+     image: PILLAR_TAG
+   - name: vtpm
+     image: VTPM_TAG
+   - name: watchdog
+     image: WATCHDOG_TAG
+   - name: xen-tools
+     image: XENTOOLS_TAG
+files:
+   - path: /etc/eve-release
+     contents: 'EVE_VERSION-kvm'
+trust:
+  org:
+    - linuxkit

--- a/pkg/eve/Dockerfile
+++ b/pkg/eve/Dockerfile
@@ -6,5 +6,6 @@ RUN apk add --no-cache qemu-system-x86_64 qemu-system-aarch64 bash make git squa
 COPY . /bits/
 COPY runme.sh /
 RUN ln -s installer/* .
+RUN rm -f installer/rootfs.img  && ln -s rootfs-xen.img installer/rootfs.img
 
 ENTRYPOINT [ "/runme.sh" ]

--- a/pkg/eve/runme.sh
+++ b/pkg/eve/runme.sh
@@ -11,8 +11,8 @@ if [ $# -eq 0 ] ; then
 elif [ "$1" = "-" ] ; then
    tar -C /bits -czf - .
 elif [ "$1" = "version" ] ; then
-   unsquashfs -d /tmp/v /bits/rootfs.img /containers/services/pillar/lower/opt/zededa/bin/versioninfo > /dev/null 2>&1 || bail "can't unpack rootfs"
-   VERSION=$(cat /tmp/v/containers/services/pillar/lower/opt/zededa/bin/versioninfo)
+   unsquashfs -d /tmp/v /bits/rootfs.img /etc/eve-release > /dev/null 2>&1 || bail "can't unpack rootfs"
+   VERSION=$(cat /tmp/v/etc/eve-release)
    echo "$VERSION"
 else
    bash -c "$*"

--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -193,10 +193,24 @@ function set_arm64_qemu {
    set_to_existing_file devicetree "($qemu_part)/eve.dtb"
 }
 
+function set_kvm_boot {
+   set_global load_hv_cmd echo
+   set_global load_dom0_cmd linux
+   set_global dom0_console "console=ttyS0 console=tty0"
+   set_global load_initrd_cmd initrd
+}
+
+function set_eve_flavor {
+   if regexp -- '-kvm$' $rootfs_title ; then
+      set_kvm_boot
+   fi
+}
+
 set_grub_virt
 set_rootfs_root
 set_rootfs_title
 set_${grub_cpu}_${grub_virt}
+set_eve_flavor
 
 # now set a few override file names (if files exist)
 set_config_overrides
@@ -236,10 +250,7 @@ submenu 'Set Boot Options' {
    }
 
    menuentry 'skip hypervisor booting' {
-     set_global load_hv_cmd echo
-     set_global load_dom0_cmd linux
-     set_global dom0_console "console=ttyS0 console=tty0"
-     set_global load_initrd_cmd initrd
+      set_kvm_boot
    }
 
    menuentry 'show boot options' {


### PR DESCRIPTION
After pondering for a bit how to have KVM builds in parallel with Xen builds, I've finally decided to propose this scheme. It is simple in that it introduces a separate rootfs image (and thus a separate rootfs-kvm.xml). This means that from now on you will see a proper `rootfs-kvm.img` and `rootfs-xen.img` after you run `make HV=xen|kvm rootfs` (or anything that triggers it).

The default is still xen so there's an old school `rootfs.img` that is being maintained -- but it is a symlink now (to the artifact that came from the latest build).

The KVM rootfs' version now has a -kvm at the end of the version string (which is an exteremely good thing since it will allow us to know exactly that image we're testing/running on every given device). The version string also tells GRUB to boot in the KVM mode (you can still change that with the `/conf/grub.cfg` tho).

The last part is extremely nice -- since it allows each image to boot into the proper hypervisor by default without the user doing anything special.

Both rootfs images are now being packaged into the lfedge/eve container (which is the only downside -- since it makes that container slightly bigger).