### PR TITLE
Latching onto particular versions of json-c libubox uqmi libraries

### DIFF
--- a/pkg/wwan/Dockerfile
+++ b/pkg/wwan/Dockerfile
@@ -20,13 +20,13 @@ RUN git clone https://git.openwrt.org/project/libubox.git
 RUN git clone https://github.com/json-c/json-c.git
 
 WORKDIR /json-c
-RUN ./autogen.sh && ./configure && make install
+RUN git checkout ed54353d && ./autogen.sh && ./configure && make install
 
 WORKDIR /libubox
-RUN cmake . -DBUILD_LUA=OFF -DBUILD_EXAMPLES=OFF && make install
+RUN git checkout 7da66430 && cmake . -DBUILD_LUA=OFF -DBUILD_EXAMPLES=OFF && make install
 
 WORKDIR /uqmi
-RUN cmake -DBUILD_STATIC=true . && make
+RUN git checkout 1965c713 && cmake -DBUILD_STATIC=true . && make
 
 # second stage (new-ish Docker feature) for smaller image
 FROM alpine:3.6 


### PR DESCRIPTION
Up until this point we've been living on the edge with these 3 libraries (partially because they don't seem to produce releases for us to latch on) fetching the latest master from them.

This is not a good idea to begin with (since they can break us at any point) and it finally has happened.

At this point I'm latching onto the versions that were known to be good at the time of EVE 5.0.0 release.