### PR TITLE
Fixing race condition in parsing cipher context

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -20,10 +20,11 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var certConfigHash []byte
+var certHash []byte
 
 // parse and update controller certs
 func parseControllerCerts(ctx *zedagentContext, contents []byte) {
+	log.Infof("Started parsing controller certs")
 	cfgConfig := &zcert.ZControllerCert{}
 	err := proto.Unmarshal(contents, cfgConfig)
 	if err != nil {
@@ -36,22 +37,22 @@ func parseControllerCerts(ctx *zedagentContext, contents []byte) {
 	for _, cfgCert := range cfgCerts {
 		computeConfigElementSha(h, cfgCert)
 	}
-	newConfigHash := h.Sum(nil)
-	if bytes.Equal(newConfigHash, certConfigHash) {
+	newHash := h.Sum(nil)
+	if bytes.Equal(newHash, certHash) {
 		return
 	}
 	log.Infof("parseControllerCerts: Applying updated config\n"+
 		"Last Sha: % x\n"+
 		"New  Sha: % x\n"+
 		"cfgCertList: %v\n",
-		certConfigHash, newConfigHash, cfgCerts)
+		certHash, newHash, cfgCerts)
 
-	certConfigHash = newConfigHash
+	certHash = newHash
 
 	// First look for deleted ones
-	items := ctx.subControllerCertConfig.GetAll()
+	items := ctx.getconfigCtx.pubControllerCert.GetAll()
 	for _, item := range items {
-		config := item.(types.ControllerCertConfig)
+		config := item.(types.ControllerCert)
 		configHash := config.CertHash
 		found := false
 		for _, cfgConfig := range cfgCerts {
@@ -62,167 +63,64 @@ func parseControllerCerts(ctx *zedagentContext, contents []byte) {
 			}
 		}
 		if !found {
-			unpublishControllerCertConfig(ctx.getconfigCtx, config.Key())
+			log.Infof("parseControllerCerts: deleting %s\n", config.Key())
+			unpublishControllerCert(ctx.getconfigCtx, config.Key())
 		}
 	}
 
 	for _, cfgConfig := range cfgCerts {
-		config := types.ControllerCertConfig{
-			HashAlgo: cfgConfig.GetHashAlgo(),
-			Type:     cfgConfig.GetType(),
-			Cert:     cfgConfig.GetCert(),
-			CertHash: cfgConfig.GetCertHash(),
+		certKey := hex.EncodeToString(cfgConfig.GetCertHash())
+		cert := lookupControllerCert(ctx.getconfigCtx, certKey)
+		if cert == nil {
+			log.Infof("parseControllerCerts: not found %s\n", certKey)
+			cert = &types.ControllerCert{
+				HashAlgo: cfgConfig.GetHashAlgo(),
+				Type:     cfgConfig.GetType(),
+				Cert:     cfgConfig.GetCert(),
+				CertHash: cfgConfig.GetCertHash(),
+			}
+			publishControllerCert(ctx.getconfigCtx, *cert)
 		}
-		publishControllerCertConfig(ctx.getconfigCtx, config)
 	}
+	log.Infof("parsing controller certs done\n")
 }
 
-// handler for controller cert config object triggers
-func handleControllerCertConfigModify(ctxArg interface{}, key string,
-	configArg interface{}) {
-	log.Infof("handleControllerCertConfigModify(%s)\n", key)
-	ctx := ctxArg.(*zedagentContext)
-	config := configArg.(types.ControllerCertConfig)
-	handleControllerCertConfigUpdate(ctx.getconfigCtx, config, false)
-	log.Debugf("handleControllerCertConfigModify(%s) done %v\n", key, config)
-}
-
-func handleControllerCertConfigDelete(ctxArg interface{}, key string,
-	configArg interface{}) {
-	log.Infof("handleControllerCertConfigDelete(%s)\n", key)
-	ctx := ctxArg.(*zedagentContext)
-	config := configArg.(types.ControllerCertConfig)
-	handleControllerCertConfigUpdate(ctx.getconfigCtx, config, true)
-	log.Debugf("handleControllerCertConfigDelete(%s) done\n", key)
-}
-
-// handler for controller cert status object triggers
-func handleControllerCertStatusModify(ctxArg interface{}, key string,
-	statusArg interface{}) {
-	log.Infof("handleControllerCertStatusModify(%s)\n", key)
-	ctx := ctxArg.(*zedagentContext)
-	status := statusArg.(types.ControllerCertStatus)
-	handleControllerCertStatusUpdate(ctx.getconfigCtx, status, false)
-	log.Debugf("handleControllerCertStatusModify(%s) done %v\n", key, status)
-}
-
-func handleControllerCertStatusDelete(ctxArg interface{}, key string,
-	statusArg interface{}) {
-	log.Infof("handleControllerCertStatusDelete(%s)\n", key)
-	ctx := ctxArg.(*zedagentContext)
-	status := statusArg.(types.ControllerCertStatus)
-	handleControllerCertStatusUpdate(ctx.getconfigCtx, status, true)
-	log.Debugf("handleControllerCertStatusDelete(%s) done\n", key)
-}
-
-func handleControllerCertConfigUpdate(ctx *getconfigContext,
-	config types.ControllerCertConfig, reset bool) {
-	if reset {
-		unpublishControllerCertStatus(ctx, config.Key())
-		return
-	}
-	status := getControllerCertStatus(ctx.zedagentCtx, config.Key())
-	if status == nil {
-		// create controller cert status
-		status0 := types.ControllerCertStatus{
-			HashAlgo: config.HashAlgo,
-			Type:     config.Type,
-			Cert:     config.Cert,
-			CertHash: config.CertHash,
-		}
-		status = &status0
-	}
-	status.ClearErrorInfo()
-	// TBD:XXX, validate the the certificate
-	// and update the ErrorInfo accordingly
-	publishControllerCertStatus(ctx, *status)
-	return
-}
-
-// controller cert status update, triggers cipher context update
-func handleControllerCertStatusUpdate(ctx *getconfigContext,
-	status types.ControllerCertStatus, reset bool) {
-	switch status.Type {
-	case zcert.ZCertType_CERT_TYPE_CONTROLLER_ECDH_EXCHANGE:
-		updateCipherContextsWithControllerCert(ctx, status, reset)
-		return
-	case zcert.ZCertType_CERT_TYPE_CONTROLLER_SIGNING:
-	case zcert.ZCertType_CERT_TYPE_CONTROLLER_INTERMEDIATE:
-		// TBD:XXX add appropriate handlers
-	}
-	return
-}
-
-// update the cipher context(s) status with the controller cert
-func updateCipherContextsWithControllerCert(ctx *getconfigContext,
-	status types.ControllerCertStatus, reset bool) {
-	log.Infof("%v, update cipher contexts, reset:%v\n",
-		status.Key(), reset)
-	items := ctx.pubCipherContext.GetAll()
-	for _, item := range items {
-		cipherCtx := item.(types.CipherContext)
-		if !bytes.Equal(cipherCtx.ControllerCertHash,
-			status.CertHash) {
-			continue
-		}
-		log.Infof("%v, updating ciphercontext, %s\n",
-			status.Key(), cipherCtx.Key())
-		if reset {
-			cipherCtx.ControllerCert = []byte{}
-			errStr := fmt.Sprintf("Controller Cert deleted")
-			cipherCtx.SetErrorInfo(agentName, errStr)
-			publishCipherContext(ctx, cipherCtx)
-			continue
-		}
-		cipherCtx.ControllerCert = status.Cert
-		if len(status.Error) != 0 {
-			cipherCtx.SetErrorInfo(agentName, status.Error)
-		}
-		publishCipherContext(ctx, cipherCtx)
-	}
-}
-
-// fetch controller cert config
-func getControllerCertConfig(ctx *zedagentContext,
-	key string) *types.ControllerCertConfig {
-	sub := ctx.subControllerCertConfig
-	item, err := sub.Get(key)
+// look up controller cert
+func lookupControllerCert(ctx *getconfigContext,
+	key string) *types.ControllerCert {
+	log.Infof("lookupControllerCert(%s)\n", key)
+	pub := ctx.pubControllerCert
+	item, err := pub.Get(key)
 	if err != nil {
+		log.Errorf("lookupControllerCert(%s) not found\n", key)
 		return nil
 	}
-	config := item.(types.ControllerCertConfig)
-	return &config
-}
-
-// fetch controller cert status
-func getControllerCertStatus(ctx *zedagentContext,
-	key string) *types.ControllerCertStatus {
-	sub := ctx.subControllerCertStatus
-	item, err := sub.Get(key)
-	if err != nil {
-		return nil
-	}
-	status := item.(types.ControllerCertStatus)
+	status := item.(types.ControllerCert)
+	log.Infof("lookupControllerCert(%s) Done\n", key)
 	return &status
 }
 
 // fetch controller cert
-func getControllerCert(ctx *zedagentContext,
+func getControllerCert(ctx *getconfigContext,
 	suppliedHash []byte) ([]byte, error) {
-	log.Infof("%v, get controller cert\n", suppliedHash)
-	items := ctx.subControllerCertStatus.GetAll()
+
+	hexStr := hex.EncodeToString(suppliedHash)
+	log.Infof("%v, get controller cert\n", hexStr)
+	items := ctx.pubControllerCert.GetAll()
 	for _, item := range items {
-		status := item.(types.ControllerCertStatus)
+		status := item.(types.ControllerCert)
 		if bytes.Equal(status.CertHash, suppliedHash) {
 			if status.Error != "" {
+				log.Errorf("get controller cert failed because cert has following error: %v",
+					status.Error)
 				return status.Cert, errors.New(status.Error)
 			}
+			log.Infof("%v, controller certificate found\n", hexStr)
 			return status.Cert, nil
 		}
 	}
 	// TBD:XXX, schedule a cert API Get Call for
 	// the suppliedHash
-	hexStr := hex.EncodeToString(suppliedHash)
 	errStr := fmt.Sprintf("%s, controller certificate not found", hexStr)
 	return []byte{}, errors.New(errStr)
 }
@@ -230,15 +128,22 @@ func getControllerCert(ctx *zedagentContext,
 // for device cert
 func getDeviceCert(hashScheme zconfig.CipherHashAlgorithm,
 	suppliedHash []byte) ([]byte, error) {
-	log.Infof("%v, get device cert\n", suppliedHash)
+
+	hexStr := hex.EncodeToString(suppliedHash)
+	log.Infof("%v, get device cert\n", hexStr)
+
 	// TBD:XXX as of now, only one
 	certBytes, err := ioutil.ReadFile(types.DeviceCertName)
-	if err == nil {
-		if computeAndMatchHash(certBytes, suppliedHash, hashScheme) {
-			return certBytes, nil
-		}
+	if err != nil {
+		errStr := fmt.Sprintf("get device cert failed while reading device certificate: %v",
+			err)
+		log.Errorf(errStr)
+		return []byte{}, errors.New(errStr)
 	}
-	hexStr := hex.EncodeToString(suppliedHash)
+	if computeAndMatchHash(certBytes, suppliedHash, hashScheme) {
+		log.Infof("%v, device cert found", hexStr)
+		return certBytes, nil
+	}
 	errStr := fmt.Sprintf("%s, device certificate not found", hexStr)
 	return []byte{}, errors.New(errStr)
 }
@@ -267,43 +172,24 @@ func computeAndMatchHash(cert []byte, suppliedHash []byte,
 }
 
 // pubsub functions
-
-// for controller cert config
-func publishControllerCertConfig(ctx *getconfigContext,
-	config types.ControllerCertConfig) {
+// for controller cert
+func publishControllerCert(ctx *getconfigContext,
+	config types.ControllerCert) {
 	key := config.Key()
-	log.Debugf("publishControllerCertConfig %s\n", key)
-	pub := ctx.pubControllerCertConfig
+	log.Debugf("publishControllerCert %s\n", key)
+	pub := ctx.pubControllerCert
 	pub.Publish(key, config)
+	log.Debugf("publishControllerCert %s Done\n", key)
 }
 
-func unpublishControllerCertConfig(ctx *getconfigContext, key string) {
-	log.Debugf("unpublishControllerCertConfig %s\n", key)
-	pub := ctx.pubControllerCertConfig
+func unpublishControllerCert(ctx *getconfigContext, key string) {
+	log.Debugf("unpublishControllerCert %s\n", key)
+	pub := ctx.pubControllerCert
 	c, _ := pub.Get(key)
 	if c == nil {
-		log.Errorf("unpublishCertObjConfig(%s) not found\n", key)
+		log.Errorf("unpublishControllerCert(%s) not found\n", key)
 		return
 	}
-	pub.Unpublish(key)
-}
-
-// for controller cert status
-func publishControllerCertStatus(ctx *getconfigContext,
-	status types.ControllerCertStatus) {
-	key := status.Key()
-	log.Debugf("publishControllerCertStatus %s\n", key)
-	pub := ctx.pubControllerCertStatus
-	pub.Publish(key, status)
-}
-
-func unpublishControllerCertStatus(ctx *getconfigContext, key string) {
-	log.Debugf("unpublishControllerCertStatus %s\n", key)
-	pub := ctx.pubControllerCertStatus
-	c, _ := pub.Get(key)
-	if c == nil {
-		log.Errorf("unpublishCertObjStatus(%s) not found\n", key)
-		return
-	}
+	log.Debugf("unpublishControllerCert %s Done\n", key)
 	pub.Unpublish(key)
 }

--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -158,9 +158,9 @@ func updateCipherContextsWithControllerCert(ctx *getconfigContext,
 	status types.ControllerCertStatus, reset bool) {
 	log.Infof("%v, update cipher contexts, reset:%v\n",
 		status.Key(), reset)
-	items := ctx.pubCipherContextStatus.GetAll()
+	items := ctx.pubCipherContext.GetAll()
 	for _, item := range items {
-		cipherCtx := item.(types.CipherContextStatus)
+		cipherCtx := item.(types.CipherContext)
 		if !bytes.Equal(cipherCtx.ControllerCertHash,
 			status.CertHash) {
 			continue
@@ -171,14 +171,14 @@ func updateCipherContextsWithControllerCert(ctx *getconfigContext,
 			cipherCtx.ControllerCert = []byte{}
 			errStr := fmt.Sprintf("Controller Cert deleted")
 			cipherCtx.SetErrorInfo(agentName, errStr)
-			publishCipherContextStatus(ctx, cipherCtx)
+			publishCipherContext(ctx, cipherCtx)
 			continue
 		}
 		cipherCtx.ControllerCert = status.Cert
 		if len(status.Error) != 0 {
 			cipherCtx.SetErrorInfo(agentName, status.Error)
 		}
-		publishCipherContextStatus(ctx, cipherCtx)
+		publishCipherContext(ctx, cipherCtx)
 	}
 }
 

--- a/pkg/pillar/cmd/zedagent/handlecipherconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecipherconfig.go
@@ -15,10 +15,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var cipherCtxConfigHash []byte
+var cipherCtxHash []byte
 
-// cipher context config parsing routine
-func parseCipherContextConfig(ctx *getconfigContext,
+// cipher context parsing routine
+func parseCipherContext(ctx *getconfigContext,
 	config *zconfig.EdgeDevConfig) {
 
 	cfgCipherContextList := config.GetCipherContexts()
@@ -26,20 +26,20 @@ func parseCipherContextConfig(ctx *getconfigContext,
 	for _, cfgCipherContext := range cfgCipherContextList {
 		computeConfigElementSha(h, cfgCipherContext)
 	}
-	newConfigHash := h.Sum(nil)
-	if bytes.Equal(newConfigHash, cipherCtxConfigHash) {
+	newHash := h.Sum(nil)
+	if bytes.Equal(newHash, cipherCtxHash) {
 		return
 	}
-	log.Infof("parseCipherContextConfig: Applying updated config\n"+
+	log.Infof("parseCipherContext: Applying updated config\n"+
 		"Last Sha: % x\n"+
 		"New  Sha: % x\n"+
 		"cfgCipherContextList: %v\n",
-		cipherCtxConfigHash, newConfigHash, cfgCipherContextList)
+		cipherCtxHash, newHash, cfgCipherContextList)
 
-	cipherCtxConfigHash = newConfigHash
+	cipherCtxHash = newHash
 
 	// First look for deleted ones
-	items := ctx.pubCipherContextConfig.GetAll()
+	items := ctx.pubCipherContext.GetAll()
 	for idStr := range items {
 		found := false
 		for _, cfgCipherContext := range cfgCipherContextList {
@@ -50,17 +50,17 @@ func parseCipherContextConfig(ctx *getconfigContext,
 		}
 		// cipherContext not found, delete
 		if !found {
-			log.Infof("parseCipherContextConfig: deleting %s\n", idStr)
-			unpublishCipherContextConfig(ctx, idStr)
+			log.Infof("parseCipherContext: deleting %s\n", idStr)
+			unpublishCipherContext(ctx, idStr)
 		}
 	}
 
 	for _, cfgCipherContext := range cfgCipherContextList {
 		if cfgCipherContext.GetContextId() == "" {
-			log.Debugf("parseCipherContextConfig ignoring empty\n")
+			log.Debugf("parseCipherContext ignoring empty\n")
 			continue
 		}
-		config := types.CipherContextConfig{
+		context := types.CipherContext{
 			ContextID:          cfgCipherContext.GetContextId(),
 			HashScheme:         cfgCipherContext.GetHashScheme(),
 			KeyExchangeScheme:  cfgCipherContext.GetKeyExchangeScheme(),
@@ -68,28 +68,38 @@ func parseCipherContextConfig(ctx *getconfigContext,
 			DeviceCertHash:     cfgCipherContext.GetDeviceCertHash(),
 			ControllerCertHash: cfgCipherContext.GetControllerCertHash(),
 		}
-		publishCipherContextConfig(ctx, config)
+		context.ClearErrorInfo()
+		if err := updateCipherContextCerts(ctx, &context); err != nil {
+			errStr := fmt.Sprintf("%s, CipherContextUpdateCerts failed, %s",
+				context.Key(), err)
+			context.SetErrorInfo(agentName, errStr)
+		}
+		publishCipherContext(ctx, context)
 	}
 }
 
 // on create/modification, update the cipher context certs
 func updateCipherContextCerts(ctx *getconfigContext,
-	status *types.CipherContextStatus) error {
+	context *types.CipherContext) error {
+	log.Infof("Updating certs of cipher context %s\n", context.ContextID)
 	// get controller cert
 	ccert, err0 := getControllerCert(ctx.zedagentCtx,
-		status.ControllerCertHash)
+		context.ControllerCertHash)
 	if err0 != nil {
+		log.Errorf("getControllerCert(%s) failed: %s\n", context.ContextID, err0)
 		return err0
 	}
-	status.ControllerCert = ccert
+	context.ControllerCert = ccert
 
 	// get device cert
-	dcert, err1 := getDeviceCert(status.HashScheme,
-		status.DeviceCertHash)
+	dcert, err1 := getDeviceCert(context.HashScheme,
+		context.DeviceCertHash)
 	if err1 != nil {
+		log.Errorf("getDeviceCert(%s) failed: %v\n", context.ContextID, err1)
 		return err1
 	}
-	status.DeviceCert = dcert
+	context.DeviceCert = dcert
+	log.Infof("Updating certs of cipher context %s done\n", context.ContextID)
 	return nil
 }
 
@@ -121,8 +131,7 @@ func parseCipherBlock(ctx *getconfigContext, key string,
 		cipherBlock.CipherContextID)
 
 	// get the cipher context
-	cipherCtx := getCipherContextStatus(ctx.zedagentCtx,
-		cipherBlock.CipherContextID)
+	cipherCtx := getCipherContext(ctx, cipherBlock.CipherContextID)
 	if cipherCtx == nil {
 		errStr := fmt.Sprintf("cipherContext not found %s\n",
 			cipherBlock.CipherContextID)
@@ -134,132 +143,8 @@ func parseCipherBlock(ctx *getconfigContext, key string,
 	return cipherBlock
 }
 
-// for cipher context config
-func handleCipherContextConfigModify(ctxArg interface{}, key string,
-	configArg interface{}) {
-	log.Infof("handleCipherContextConfigModify(%s)\n", key)
-	ctx := ctxArg.(*zedagentContext)
-	config := configArg.(types.CipherContextConfig)
-	handleCipherContextConfigUpdate(ctx.getconfigCtx, config, false)
-	log.Debugf("handleCipherContextConfigModify(%s) done %v\n", key, config)
-}
-
-func handleCipherContextConfigDelete(ctxArg interface{}, key string,
-	configArg interface{}) {
-	log.Infof("handleCipherContextConfigDelete(%s)\n", key)
-	ctx := ctxArg.(*zedagentContext)
-	config := configArg.(types.CipherContextConfig)
-	handleCipherContextConfigUpdate(ctx.getconfigCtx, config, true)
-	log.Debugf("handleCipherContextConfigDone(%s) done\n", key)
-}
-
-// for cipher context status
-func handleCipherContextStatusModify(ctxArg interface{}, key string,
-	statusArg interface{}) {
-	log.Infof("handleCipherContextStatusModify(%s)\n", key)
-	ctx := ctxArg.(*zedagentContext)
-	status := statusArg.(types.CipherContextStatus)
-	handleCipherContextStatusUpdate(ctx.getconfigCtx, status, false)
-	log.Debugf("handleCipherContexStatustModify(%s) done %v\n", key, status)
-}
-
-func handleCipherContextStatusDelete(ctxArg interface{}, key string,
-	statusArg interface{}) {
-	log.Infof("handleCipherContextStatusDelete(%s)\n", key)
-	ctx := ctxArg.(*zedagentContext)
-	status := statusArg.(types.CipherContextStatus)
-	//  clear matching cipher blocks
-	handleCipherContextStatusUpdate(ctx.getconfigCtx, status, true)
-	log.Debugf("handleCipherContextStatusDone(%s) done\n", key)
-}
-
-// on cipher context config update, update the cipher status
-func handleCipherContextConfigUpdate(ctx *getconfigContext,
-	config types.CipherContextConfig, reset bool) {
-
-	log.Infof("%s, update cipher config, reset: %v\n",
-		config.Key(), reset)
-	if reset {
-		unpublishCipherContextStatus(ctx, config.Key())
-		return
-	}
-	status := getCipherContextStatus(ctx.zedagentCtx, config.Key())
-
-	// nothing needs to be done
-	if status == nil {
-		if reset {
-			return
-		}
-		status0 := types.CipherContextStatus{
-			ContextID:          config.ContextID,
-			HashScheme:         config.HashScheme,
-			KeyExchangeScheme:  config.KeyExchangeScheme,
-			EncryptionScheme:   config.EncryptionScheme,
-			DeviceCertHash:     config.DeviceCertHash,
-			ControllerCertHash: config.ControllerCertHash,
-		}
-		status = &status0
-	}
-	status.ClearErrorInfo()
-	if err := updateCipherContextCerts(ctx, status); err != nil {
-		errStr := fmt.Sprintf("%s, CipherContextUpdateCerts failed, %s",
-			status.Key(), err)
-		status.SetErrorInfo(agentName, errStr)
-	}
-	publishCipherContextStatus(ctx, *status)
-}
-
-// cipher context status update, triggers cipher block updates
-func handleCipherContextStatusUpdate(ctx *getconfigContext,
-	status types.CipherContextStatus, reset bool) {
-
-	log.Infof("%s, update cipherblocks\n", status.Key())
-	// app instances cloud init data
-	appItems := ctx.pubAppInstanceConfig.GetAll()
-	for _, item := range appItems {
-		appCfg := item.(types.AppInstanceConfig)
-		if updateCipherBlock(status, &appCfg.CipherBlockStatus,
-			appCfg.Key(), reset) {
-			log.Infof("%s, updating app instance cipherblock %s\n",
-				status.Key(), appCfg.DisplayName)
-			ctx.pubAppInstanceConfig.Publish(appCfg.Key(), appCfg)
-		}
-	}
-
-	// data stores
-	dsItems := ctx.pubDatastoreConfig.GetAll()
-	for _, item := range dsItems {
-		dsCfg := item.(types.DatastoreConfig)
-		if updateCipherBlock(status, &dsCfg.CipherBlockStatus,
-			dsCfg.Key(), reset) {
-			log.Infof("%s, updating datastore cipherblock %s\n",
-				status.Key(), dsCfg.Key())
-			ctx.pubDatastoreConfig.Publish(dsCfg.Key(), dsCfg)
-		}
-	}
-
-	// device networks
-	netItems := ctx.pubNetworkXObjectConfig.GetAll()
-	for _, item := range netItems {
-		netCfg := item.(types.NetworkXObjectConfig)
-		wifiCfgs := netCfg.WirelessCfg.Wifi
-		change := false
-		for _, wifiCfg := range wifiCfgs {
-			if updateCipherBlock(status, &wifiCfg.CipherBlockStatus,
-				netCfg.Key(), reset) {
-				change = true
-			}
-		}
-		if change {
-			log.Infof("%s, updating network wifi cipherblock %s\n",
-				status.Key(), netCfg.Key())
-			ctx.pubNetworkXObjectConfig.Publish(netCfg.Key(), netCfg)
-		}
-	}
-}
-
 // cipherContext publish/get utilities
-func updateCipherBlock(status types.CipherContextStatus,
+func updateCipherBlock(status types.CipherContext,
 	cipherBlock *types.CipherBlockStatus, key string, reset bool) bool {
 	if !cipherBlock.IsCipher ||
 		cipherBlock.CipherContextID != status.Key() {
@@ -301,56 +186,36 @@ func updateCipherBlock(status types.CipherContextStatus,
 	return true
 }
 
-func getCipherContextCerts(status types.CipherContextStatus) ([]byte, []byte) {
+func getCipherContextCerts(status types.CipherContext) ([]byte, []byte) {
 	return status.ControllerCert, status.DeviceCert
 }
 
-// pub/sub utilities for cipher context config and status
-func publishCipherContextConfig(ctx *getconfigContext,
-	config types.CipherContextConfig) {
-	key := config.Key()
-	log.Debugf("publishCipherContext %s\n", key)
-	pub := ctx.pubCipherContextConfig
-	pub.Publish(key, config)
-}
-
-func unpublishCipherContextConfig(ctx *getconfigContext, key string) {
-	log.Debugf("unpublishCipherContextConfig(%s)\n", key)
-	pub := ctx.pubCipherContextConfig
-	c, _ := pub.Get(key)
-	if c == nil {
-		log.Errorf("unpublishCipherContext(%s) not found\n", key)
-		return
-	}
-	pub.Unpublish(key)
-}
-
-func getCipherContextStatus(ctx *zedagentContext,
-	key string) *types.CipherContextStatus {
-	pub := ctx.subCipherContextStatus
+func getCipherContext(ctx *getconfigContext,
+	key string) *types.CipherContext {
+	pub := ctx.pubCipherContext
 	st, _ := pub.Get(key)
 	if st == nil {
-		log.Errorf("getCipherContextStatus(%s) not found\n", key)
+		log.Errorf("getCipherContext(%s) not found\n", key)
 		return nil
 	}
-	status := st.(types.CipherContextStatus)
+	status := st.(types.CipherContext)
 	return &status
 }
 
-func publishCipherContextStatus(ctx *getconfigContext,
-	status types.CipherContextStatus) {
+func publishCipherContext(ctx *getconfigContext,
+	status types.CipherContext) {
 	key := status.Key()
-	log.Debugf("publishCipherContextStatus %s\n", key)
-	pub := ctx.pubCipherContextStatus
+	log.Debugf("publishCipherContext %s\n", key)
+	pub := ctx.pubCipherContext
 	pub.Publish(key, status)
 }
 
-func unpublishCipherContextStatus(ctx *getconfigContext, key string) {
-	log.Debugf("unpublishCipherContextStatus(%s)\n", key)
-	pub := ctx.pubCipherContextStatus
+func unpublishCipherContext(ctx *getconfigContext, key string) {
+	log.Debugf("unpublishCipherContext(%s)\n", key)
+	pub := ctx.pubCipherContext
 	c, _ := pub.Get(key)
 	if c == nil {
-		log.Errorf("unpublishCipherContextStatus(%s) not found\n", key)
+		log.Errorf("unpublishCipherContext(%s) not found\n", key)
 		return
 	}
 	pub.Unpublish(key)

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -55,9 +55,8 @@ type getconfigContext struct {
 	pubBaseOsConfig          pubsub.Publication
 	pubDatastoreConfig       pubsub.Publication
 	pubNetworkInstanceConfig pubsub.Publication
-	pubCipherContextConfig   pubsub.Publication
 	pubControllerCertConfig  pubsub.Publication
-	pubCipherContextStatus   pubsub.Publication
+	pubCipherContext         pubsub.Publication
 	pubControllerCertStatus  pubsub.Publication
 	rebootFlag               bool
 }

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -55,9 +55,8 @@ type getconfigContext struct {
 	pubBaseOsConfig          pubsub.Publication
 	pubDatastoreConfig       pubsub.Publication
 	pubNetworkInstanceConfig pubsub.Publication
-	pubControllerCertConfig  pubsub.Publication
+	pubControllerCert        pubsub.Publication
 	pubCipherContext         pubsub.Publication
-	pubControllerCertStatus  pubsub.Publication
 	rebootFlag               bool
 }
 

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -54,7 +54,7 @@ func parseConfig(config *zconfig.EdgeDevConfig, getconfigCtx *getconfigContext,
 	if getconfigCtx.rebootFlag || ctx.deviceReboot {
 		log.Debugf("parseConfig: Ignoring config as rebootFlag set\n")
 	} else {
-		parseCipherContextConfig(getconfigCtx, config)
+		parseCipherContext(getconfigCtx, config)
 		parseDatastoreConfig(config, getconfigCtx)
 		// DeviceIoList has some defaults for Usage and UsagePolicy
 		// used by systemAdapters

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -54,6 +54,7 @@ func parseConfig(config *zconfig.EdgeDevConfig, getconfigCtx *getconfigContext,
 	if getconfigCtx.rebootFlag || ctx.deviceReboot {
 		log.Debugf("parseConfig: Ignoring config as rebootFlag set\n")
 	} else {
+		parseCipherContextConfig(getconfigCtx, config)
 		parseDatastoreConfig(config, getconfigCtx)
 		// DeviceIoList has some defaults for Usage and UsagePolicy
 		// used by systemAdapters
@@ -64,7 +65,6 @@ func parseConfig(config *zconfig.EdgeDevConfig, getconfigCtx *getconfigContext,
 		// on Physio configuration and Networks configuration. If either of
 		// Physio or Networks change, we should re-parse system adapters and
 		// publish updated configuration.
-		parseCipherContextConfig(getconfigCtx, config)
 		forceSystemAdaptersParse := physioChanged || networksChanged
 		parseSystemAdapterConfig(config, getconfigCtx, forceSystemAdaptersParse)
 		parseBaseOsConfig(getconfigCtx, config)

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -81,9 +81,7 @@ type zedagentContext struct {
 	assignableAdapters        *types.AssignableAdapters
 	subAssignableAdapters     pubsub.Subscription
 	iteration                 int
-	subCipherContextConfig    pubsub.Subscription
 	subControllerCertConfig   pubsub.Subscription
-	subCipherContextStatus    pubsub.Subscription
 	subControllerCertStatus   pubsub.Subscription
 	subNetworkInstanceStatus  pubsub.Subscription
 	subCertObjConfig          pubsub.Subscription
@@ -357,18 +355,6 @@ func Run(ps *pubsub.PubSub) {
 	getconfigCtx.pubDatastoreConfig = pubDatastoreConfig
 	pubDatastoreConfig.ClearRestarted()
 
-	pubCipherContextConfig, err := ps.NewPublication(
-		pubsub.PublicationOptions{
-			AgentName:  agentName,
-			Persistent: true,
-			TopicType:  types.CipherContextConfig{},
-		})
-	if err != nil {
-		log.Fatal(err)
-	}
-	pubCipherContextConfig.ClearRestarted()
-	getconfigCtx.pubCipherContextConfig = pubCipherContextConfig
-
 	pubControllerCertConfig, err := ps.NewPublication(
 		pubsub.PublicationOptions{
 			AgentName:  agentName,
@@ -382,17 +368,17 @@ func Run(ps *pubsub.PubSub) {
 	getconfigCtx.pubControllerCertConfig = pubControllerCertConfig
 
 	// for CipherContextStatus Publisher
-	pubCipherContextStatus, err := ps.NewPublication(
+	pubCipherContext, err := ps.NewPublication(
 		pubsub.PublicationOptions{
 			AgentName:  agentName,
 			Persistent: true,
-			TopicType:  types.CipherContextStatus{},
+			TopicType:  types.CipherContext{},
 		})
 	if err != nil {
 		log.Fatal(err)
 	}
-	pubCipherContextStatus.ClearRestarted()
-	getconfigCtx.pubCipherContextStatus = pubCipherContextStatus
+	pubCipherContext.ClearRestarted()
+	getconfigCtx.pubCipherContext = pubCipherContext
 
 	// for ControllerCertStatus Publisher
 	pubControllerCertStatus, err := ps.NewPublication(
@@ -406,26 +392,6 @@ func Run(ps *pubsub.PubSub) {
 	}
 	pubControllerCertStatus.ClearRestarted()
 	getconfigCtx.pubControllerCertStatus = pubControllerCertStatus
-
-	// for handling changes in the cipher context
-	subCipherContextConfig, err := ps.NewSubscription(
-		pubsub.SubscriptionOptions{
-			AgentName:     agentName,
-			TopicImpl:     types.CipherContextConfig{},
-			Activate:      false,
-			Ctx:           &zedagentCtx,
-			CreateHandler: handleCipherContextConfigModify,
-			ModifyHandler: handleCipherContextConfigModify,
-			DeleteHandler: handleCipherContextConfigDelete,
-			WarningTime:   warningTime,
-			ErrorTime:     errorTime,
-			Persistent:    true,
-		})
-	if err != nil {
-		log.Fatal(err)
-	}
-	zedagentCtx.subCipherContextConfig = subCipherContextConfig
-	subCipherContextConfig.Activate()
 
 	// for handling changes in the controller certificate
 	subControllerCertConfig, err := ps.NewSubscription(
@@ -446,26 +412,6 @@ func Run(ps *pubsub.PubSub) {
 	}
 	zedagentCtx.subControllerCertConfig = subControllerCertConfig
 	subControllerCertConfig.Activate()
-
-	// for CipherContextStatus Subscriber Modify/Delete
-	subCipherContextStatus, err := ps.NewSubscription(
-		pubsub.SubscriptionOptions{
-			AgentName:     agentName,
-			TopicImpl:     types.CipherContextStatus{},
-			Activate:      false,
-			Ctx:           &zedagentCtx,
-			CreateHandler: handleCipherContextStatusModify,
-			ModifyHandler: handleCipherContextStatusModify,
-			DeleteHandler: handleCipherContextStatusDelete,
-			WarningTime:   warningTime,
-			ErrorTime:     errorTime,
-			Persistent:    true,
-		})
-	if err != nil {
-		log.Fatal(err)
-	}
-	zedagentCtx.subCipherContextStatus = subCipherContextStatus
-	subCipherContextStatus.Activate()
 
 	// for ControllerCertStatus Subscriber Modify/Delete
 	subControllerCertStatus, err := ps.NewSubscription(
@@ -904,14 +850,8 @@ func Run(ps *pubsub.PubSub) {
 		case change := <-subVaultStatus.MsgChan():
 			subVaultStatus.ProcessChange(change)
 
-		case change := <-subCipherContextConfig.MsgChan():
-			subCipherContextConfig.ProcessChange(change)
-
 		case change := <-subControllerCertConfig.MsgChan():
 			subControllerCertConfig.ProcessChange(change)
-
-		case change := <-subCipherContextStatus.MsgChan():
-			subCipherContextStatus.ProcessChange(change)
 
 		case change := <-subControllerCertStatus.MsgChan():
 			subControllerCertStatus.ProcessChange(change)
@@ -1043,14 +983,8 @@ func Run(ps *pubsub.PubSub) {
 		case change := <-subVaultStatus.MsgChan():
 			subVaultStatus.ProcessChange(change)
 
-		case change := <-subCipherContextConfig.MsgChan():
-			subCipherContextConfig.ProcessChange(change)
-
 		case change := <-subControllerCertConfig.MsgChan():
 			subControllerCertConfig.ProcessChange(change)
-
-		case change := <-subCipherContextStatus.MsgChan():
-			subCipherContextStatus.ProcessChange(change)
 
 		case change := <-subControllerCertStatus.MsgChan():
 			subControllerCertStatus.ProcessChange(change)
@@ -1204,14 +1138,8 @@ func Run(ps *pubsub.PubSub) {
 		case change := <-subVaultStatus.MsgChan():
 			subVaultStatus.ProcessChange(change)
 
-		case change := <-subCipherContextConfig.MsgChan():
-			subCipherContextConfig.ProcessChange(change)
-
 		case change := <-subControllerCertConfig.MsgChan():
 			subControllerCertConfig.ProcessChange(change)
-
-		case change := <-subCipherContextStatus.MsgChan():
-			subCipherContextStatus.ProcessChange(change)
 
 		case change := <-subControllerCertStatus.MsgChan():
 			subControllerCertStatus.ProcessChange(change)

--- a/pkg/pillar/types/certinfotypes.go
+++ b/pkg/pillar/types/certinfotypes.go
@@ -9,23 +9,9 @@ import (
 	"time"
 )
 
-// ControllerCertConfig : controller certicate
+// ControllerCert : controller certicate
 // config received from controller
-type ControllerCertConfig struct {
-	HashAlgo zcert.CertHashAlgorithm
-	Type     zcert.ZCertType
-	Cert     []byte
-	CertHash []byte
-}
-
-// Key :
-func (cert *ControllerCertConfig) Key() string {
-	return hex.EncodeToString(cert.CertHash)
-}
-
-// ControllerCertStatus : controller certicate
-// status
-type ControllerCertStatus struct {
+type ControllerCert struct {
 	HashAlgo zcert.CertHashAlgorithm
 	Type     zcert.ZCertType
 	Cert     []byte
@@ -34,19 +20,19 @@ type ControllerCertStatus struct {
 }
 
 // Key :
-func (cert *ControllerCertStatus) Key() string {
+func (cert *ControllerCert) Key() string {
 	return hex.EncodeToString(cert.CertHash)
 }
 
 // SetErrorInfo : sets errorinfo on the controller cert
-func (cert *ControllerCertStatus) SetErrorInfo(agentName, errStr string) {
+func (cert *ControllerCert) SetErrorInfo(agentName, errStr string) {
 	cert.Error = errStr
 	cert.ErrorTime = time.Now()
 	cert.ErrorSource = agentName
 }
 
 // ClearErrorInfo : clears errorinfo on the controller cert
-func (cert *ControllerCertStatus) ClearErrorInfo() {
+func (cert *ControllerCert) ClearErrorInfo() {
 	cert.Error = ""
 	cert.ErrorSource = ""
 	cert.ErrorTime = time.Time{}

--- a/pkg/pillar/types/cipherinfotypes.go
+++ b/pkg/pillar/types/cipherinfotypes.go
@@ -8,26 +8,10 @@ import (
 	"time"
 )
 
-// CipherContextConfig : a pair of device and controller certificate
+// CipherContext : a pair of device and controller certificate
 // published by controller along with some attributes
 // part of EdgeDevConfig block, received from controller
-type CipherContextConfig struct {
-	ContextID          string
-	HashScheme         zconfig.CipherHashAlgorithm
-	KeyExchangeScheme  zconfig.KeyExchangeScheme
-	EncryptionScheme   zconfig.EncryptionScheme
-	ControllerCertHash []byte
-	DeviceCertHash     []byte
-}
-
-// Key :
-func (config *CipherContextConfig) Key() string {
-	return config.ContextID
-}
-
-// CipherContextStatus : context information for the pair
-// of certificates
-type CipherContextStatus struct {
+type CipherContext struct {
 	ContextID          string
 	HashScheme         zconfig.CipherHashAlgorithm
 	KeyExchangeScheme  zconfig.KeyExchangeScheme
@@ -40,19 +24,19 @@ type CipherContextStatus struct {
 }
 
 // Key :
-func (status *CipherContextStatus) Key() string {
+func (status *CipherContext) Key() string {
 	return status.ContextID
 }
 
 // SetErrorInfo : sets errorinfo on the cipher context status object
-func (status *CipherContextStatus) SetErrorInfo(agentName, strErr string) {
+func (status *CipherContext) SetErrorInfo(agentName, strErr string) {
 	status.Error = strErr
 	status.ErrorTime = time.Now()
 	status.ErrorSource = agentName
 }
 
 // ClearErrorInfo : clears errorinfo on the cipher context status object
-func (status *CipherContextStatus) ClearErrorInfo() {
+func (status *CipherContext) ClearErrorInfo() {
 	status.Error = ""
 	status.ErrorSource = ""
 	status.ErrorTime = time.Time{}


### PR DESCRIPTION
Cipher context should be parsed before publishing the network config.
The issue in the master is cipher context status is not ready at the time of
parsing wifi config.

I also removed subscriber for cipher context and controller cert from zedagent

Signed-off-by: zed-rishabh <rgupta@zededa.com>