### PR TITLE
automatically determine command names

### DIFF
--- a/pkg/pillar/Makefile
+++ b/pkg/pillar/Makefile
@@ -18,10 +18,7 @@ DOCKER_TAG:=$(DOCKER_TAG)-$(GOARCH)
 endif
 
 APPS = zedbox
-APPS1 = logmanager ledmanager downloader verifier client zedrouter domainmgr \
-        identitymgr zedmanager zedagent hardwaremodel ipcmonitor nim diag    \
-        baseosmgr wstunnelclient conntrack waitforaddr tpmmgr vaultmgr nodeagent \
-	executor command upgradeconverter
+APPS1 = $(notdir $(wildcard cmd/*))
 
 .PHONY: all clean build test build-docker build-docker-git shell
 


### PR DESCRIPTION
It is too brittle having a list in the Makefile that duplicates every entry in `cmd`. This just automatically determines it. 