### PR TITLE
SNAT post routing rule for port map should not apply for apps attache…

### DIFF
--- a/pkg/pillar/cmd/zedrouter/acl.go
+++ b/pkg/pillar/cmd/zedrouter/acl.go
@@ -878,7 +878,7 @@ func aceToRules(aclArgs types.AppNetworkACLArgs, ace types.ACE) (types.IPTablesR
 			aclRule2.Table = "nat"
 			aclRule2.Chain = "POSTROUTING"
 			aclRule2.Rule = []string{"-o", aclArgs.BridgeName, "-p", protocol,
-				"--dport", targetPort}
+				"--dport", targetPort, "-m", "physdev", "!", "--physdev-is-bridged"}
 			aclRule2.Action = []string{"-j", "SNAT", "--to-source", aclArgs.BridgeIP}
 			aclRule2.IsPortMapRule = true
 			aclRule2.IsUserConfigured = true


### PR DESCRIPTION
…d to same network instance.

Signed-off-by: GopiKrishna Kodali <gkodali@zededa.com>