### PR TITLE
Fix for xl create failure.

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -624,7 +624,8 @@ func verifyStatus(ctx *domainContext, status *types.DomainStatus) {
 		}
 		// check if qemu processes has crashed
 		hasQemu := status.VirtualizationMode == types.HVM || status.VirtualizationMode == types.FML || status.IsContainer
-		if configActivate && status.Activated && hasQemu && !hyper.IsDeviceModelAlive(status.DomainId) {
+		if configActivate && status.Activated && hyper.IsDomainKnownHealthy(status.DomainName) &&
+			hasQemu && !hyper.IsDeviceModelAlive(status.DomainId) {
 			errStr := fmt.Sprintf("verifyStatus(%s) qemu crashed",
 				status.Key())
 			log.Errorf(errStr)

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -624,8 +624,8 @@ func verifyStatus(ctx *domainContext, status *types.DomainStatus) {
 		}
 		// check if qemu processes has crashed
 		hasQemu := status.VirtualizationMode == types.HVM || status.VirtualizationMode == types.FML || status.IsContainer
-		if configActivate && status.Activated && hyper.IsDomainKnownHealthy(status.DomainName) &&
-			hasQemu && !hyper.IsDeviceModelAlive(status.DomainId) {
+		if configActivate && status.Activated && hasQemu && !hyper.IsDomainPotentiallyShuttingDown(status.DomainName) &&
+			!hyper.IsDeviceModelAlive(status.DomainId) {
 			errStr := fmt.Sprintf("verifyStatus(%s) qemu crashed",
 				status.Key())
 			log.Errorf(errStr)
@@ -1058,7 +1058,6 @@ func doActivateTail(ctx *domainContext, status *types.DomainStatus,
 
 	log.Infof("created domainID %d for %s\n", domainID, status.DomainName)
 	status.DomainId = domainID
-	status.Activated = true
 	status.BootTime = time.Now()
 	log.Infof("Set domainId %d bootTime %s for %s",
 		status.DomainId, status.BootTime.Format(time.RFC3339Nano),
@@ -1098,6 +1097,7 @@ func doActivateTail(ctx *domainContext, status *types.DomainStatus,
 			status.DomainId, status.BootTime.Format(time.RFC3339Nano),
 			status.Key())
 	}
+	status.Activated = true
 	log.Infof("doActivateTail(%v) done for %s\n",
 		status.UUIDandVersion, status.DisplayName)
 }

--- a/pkg/pillar/hypervisor/acrn.go
+++ b/pkg/pillar/hypervisor/acrn.go
@@ -69,6 +69,10 @@ func (ctx acrnContext) PCIRelease(long string) error {
 	return nil
 }
 
+func (ctx acrnContext) IsDomainKnownHealthy(domainName string) bool {
+	return true
+}
+
 // IsDeviceModelAlive returns true if a process supplying device model to a domain is still running
 func (ctx acrnContext) IsDeviceModelAlive(domid int) bool {
 	return true

--- a/pkg/pillar/hypervisor/acrn.go
+++ b/pkg/pillar/hypervisor/acrn.go
@@ -69,8 +69,8 @@ func (ctx acrnContext) PCIRelease(long string) error {
 	return nil
 }
 
-func (ctx acrnContext) IsDomainKnownHealthy(domainName string) bool {
-	return true
+func (ctx acrnContext) IsDomainPotentiallyShuttingDown(domainName string) bool {
+	return false
 }
 
 // IsDeviceModelAlive returns true if a process supplying device model to a domain is still running

--- a/pkg/pillar/hypervisor/hypervisor.go
+++ b/pkg/pillar/hypervisor/hypervisor.go
@@ -26,7 +26,7 @@ type Hypervisor interface {
 	Info(string, int) error
 	LookupByName(string, int) (int, error)
 
-	IsDomainKnownHealthy(string) bool
+	IsDomainPotentiallyShuttingDown(string) bool
 	IsDeviceModelAlive(int) bool
 
 	PCIReserve(string) error

--- a/pkg/pillar/hypervisor/hypervisor.go
+++ b/pkg/pillar/hypervisor/hypervisor.go
@@ -26,6 +26,7 @@ type Hypervisor interface {
 	Info(string, int) error
 	LookupByName(string, int) (int, error)
 
+	IsDomainKnownHealthy(string) bool
 	IsDeviceModelAlive(int) bool
 
 	PCIReserve(string) error

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -607,14 +607,14 @@ func (ctx kvmContext) PCIRelease(long string) error {
 	return nil
 }
 
-//IsDomainKnownHealthy: returns true if domain's status is healthy (i.e. 'running')
-func (ctx kvmContext) IsDomainKnownHealthy(domainName string) bool {
+//IsDomainPotentiallyShuttingDown: returns false if domain's status is healthy (i.e. 'running')
+func (ctx kvmContext) IsDomainPotentiallyShuttingDown(domainName string) bool {
 	if status, err := getQemuStatus(getQmpFile(domainName)); err != nil || status != "running" {
-		log.Errorf("IsDomainKnownHealthy: domain %s is not healthy. domainState: %s", domainName, status)
-		return false
+		log.Errorf("IsDomainPotentiallyShuttingDown: domain %s is not healthy. domainState: %s", domainName, status)
+		return true
 	}
-	log.Debugf("IsDomainKnownHealthy: domain %s is healthy", domainName)
-	return true
+	log.Debugf("IsDomainPotentiallyShuttingDown: domain %s is healthy", domainName)
+	return false
 }
 
 func (ctx kvmContext) IsDeviceModelAlive(domid int) bool {

--- a/pkg/pillar/hypervisor/null.go
+++ b/pkg/pillar/hypervisor/null.go
@@ -140,8 +140,8 @@ func (ctx nullContext) PCIRelease(long string) error {
 	}
 }
 
-func (ctx nullContext) IsDomainKnownHealthy(domainName string) bool {
-	return true
+func (ctx nullContext) IsDomainPotentiallyShuttingDown(domainName string) bool {
+	return false
 }
 
 func (ctx nullContext) IsDeviceModelAlive(int) bool {

--- a/pkg/pillar/hypervisor/null.go
+++ b/pkg/pillar/hypervisor/null.go
@@ -140,6 +140,10 @@ func (ctx nullContext) PCIRelease(long string) error {
 	}
 }
 
+func (ctx nullContext) IsDomainKnownHealthy(domainName string) bool {
+	return true
+}
+
 func (ctx nullContext) IsDeviceModelAlive(int) bool {
 	return true
 }

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -488,9 +488,6 @@ func (ctx xenContext) LookupByName(domainName string, domainID int) (int, error)
 		log.Warningf("domainid changed from %d to %d for %s\n",
 			domainID, domainID2, domainName)
 	}
-	if !isDomainRunning(domainID2) { //check if domain is shutting down.
-		return domainID2, fmt.Errorf("xl domain %s not running", domainName)
-	}
 	return domainID2, nil
 }
 
@@ -581,6 +578,52 @@ func (ctx xenContext) PCIRelease(long string) error {
 	}
 	log.Infof("xl pci-assignable-rem done\n")
 	return nil
+}
+
+//IsDomainKnownHealthy: Verifies if a domain is up and running by its state. Domain can have the following states:
+//r - currently running
+//b - blocked, and not running or runnable
+//p - paused
+//s - a shutdown command has been sent, but the domain isn't dying yet
+//c - the domain has crashed
+//d - the domain is dying, but hasn't properly shut down or crashed
+//Returns false in case of undetermined/unknown health state ( e.g., due to a pending state transition).
+//Caller must not assume that domain is unhealthy, since it might be transitioning between healthy states.
+func (ctx xenContext) IsDomainKnownHealthy(domainName string) bool {
+	domainState := ""
+	cmd := "xl"
+	args := []string{
+		"list",
+		domainName,
+	}
+	stdoutStderr, err := wrap.Command(cmd, args...).CombinedOutput()
+	if err != nil {
+		//domain is not present
+		log.Errorln("IsDomainKnownHealthy: xl list failed ", err)
+		log.Errorln("IsDomainKnownHealthy: xl list output ", string(stdoutStderr))
+		return false
+	}
+	//Removing all extra space between column result and split the result as array.
+	xlDomainResult := regexp.MustCompile(`\s+`).ReplaceAllString(strings.Split(string(stdoutStderr), "\n")[1], " ")
+	//Domain's status is 5th column in xl list <domain> result
+	domainState = strings.Split(xlDomainResult, " ")[4]
+	//Removing all unset state bits represented by "-"
+	domainState = strings.ReplaceAll(domainState, "-", "")
+	if len(domainState) < 1 {
+		log.Errorf("IsDomainKnownHealthy: domain %s in undetermined state", domainName)
+		return false
+	}
+	log.Debugf("IsDomainKnownHealthy: domain: %s domainState: %s.", domainName, domainState)
+	//In case of more that 1 (logically possible) domain state, will consider the last state.
+	lastState := domainState[len(domainState)-1:]
+	log.Debugf("IsDomainKnownHealthy: domain: %s lastState: %s.", domainName, lastState)
+	//if domainState is not 'r' or 'b' then the domain is not healthy.
+	if lastState != "r" && lastState != "b" {
+		log.Errorf("IsDomainKnownHealthy: domain %s is not healthy. domainState: %s", domainName, lastState)
+		return false
+	}
+	log.Debugf("IsDomainKnownHealthy: domain %s is healthy", domainName)
+	return true
 }
 
 func (ctx xenContext) IsDeviceModelAlive(domid int) bool {
@@ -831,46 +874,4 @@ func execWithTimeout(command string, args ...string) ([]byte, bool, error) {
 		return nil, false, nil
 	}
 	return out, true, err
-}
-
-//verifyDomainState: Verifies if a domain is up and running by its state. Domain can have the following states:
-//r - currently running
-//b - blocked, and not running or runnable
-//p - paused
-//s - a shutdown command has been sent, but the domain isn't dying yet
-//c - the domain has crashed
-//d - the domain is dying, but hasn't properly shut down or crashed
-func isDomainRunning(domainID int) bool {
-	cmd := "xl"
-	args := []string{
-		"list",
-		strconv.Itoa(domainID),
-	}
-	stdoutStderr, err := wrap.Command(cmd, args...).CombinedOutput()
-	if err != nil {
-		//domain is not present
-		log.Errorln("verifyDomainState: xl list failed ", err)
-		log.Errorln("verifyDomainState: xl list output ", string(stdoutStderr))
-		return false
-	}
-	//Removing all extra space between column result and split the result as array.
-	xlDomainResult := regexp.MustCompile(`\s+`).ReplaceAllString(strings.Split(string(stdoutStderr), "\n")[1], " ")
-	//Domain's status is 5th column in xl list <domain> result
-	domainState := strings.Split(xlDomainResult, " ")[4]
-	//Sometimes the domain can be in multiple states (logically possible) at the same time.
-	// In such cases we can consider the last state. For example when a domain is shutting down its state will be
-	//"--psc-", we can consider "c" to represent that domain is in middle of shutting down.
-	var lastState string
-	for _, state := range domainState {
-		if state != '-' {
-			lastState = string(state)
-		}
-	}
-	log.Debugf("verifyDomainState: domain: %d domainState: %s.", domainID, domainState)
-	log.Debugf("verifyDomainState: domain: %d lastState: %s.", domainID, lastState)
-	if lastState == "r" || lastState == "b" {
-		//domain is up and running.
-		return true
-	}
-	return false
 }


### PR DESCRIPTION
After qemu-crash race condition was fixed, another race condition introduced. When confirmed whether a domain is running by checking if the domain's state has ‘r’ or ‘b’, if not then we declared that domain is shutting down. But when the domain transitions between states (‘p’ -> ‘b’ -> ‘r’), for a fraction of time the domain does not report any state.
```
Wed Apr  8 09:12:42 UTC 2020
Name                                        ID   Mem VCPUs	State	Time(s)
ubuntu-xenial-16.04.3                        4  1000     1     -b----       0.0
Wed Apr  8 09:12:42 UTC 2020
Name                                        ID   Mem VCPUs	State	Time(s)
ubuntu-xenial-16.04.3                        4  1000     1     ------       0.2
Wed Apr  8 09:12:43 UTC 2020
Name                                        ID   Mem VCPUs	State	Time(s)
ubuntu-xenial-16.04.3                        4  1000     1     ------       0.2
Wed Apr  8 09:12:43 UTC 2020
Name                                        ID   Mem VCPUs	State	Time(s)
ubuntu-xenial-16.04.3                        4  1000     1     ------       0.2
Wed Apr  8 09:12:44 UTC 2020
Name                                        ID   Mem VCPUs	State	Time(s)
ubuntu-xenial-16.04.3                        4  1000     1     ------       0.2
Wed Apr  8 09:12:44 UTC 2020
Name                                        ID   Mem VCPUs	State	Time(s)
ubuntu-xenial-16.04.3                        4  1000     1     ------       0.2
Wed Apr  8 09:12:44 UTC 2020
Name                                        ID   Mem VCPUs	State	Time(s)
ubuntu-xenial-16.04.3                        4  1000     1     ------       0.2
Wed Apr  8 09:12:45 UTC 2020
Name                                        ID   Mem VCPUs	State	Time(s)
ubuntu-xenial-16.04.3                        4  1000     1     ------       0.2
Wed Apr  8 09:12:45 UTC 2020
Name                                        ID   Mem VCPUs	State	Time(s)
ubuntu-xenial-16.04.3                        4  1000     1     r-----       0.2
```
This issue affected the below chain of events:
1. A domain x-1 is created and activated by reserving `nbu1x2` vif nics resource.
2. While verifying the status of x-1 because of the above issue we reported that domain is shutting down and deactivated domainStatus.
3. Domain delete is triggered
4. Checks that domain is not active, marks all resources of x-1 as deallocated and doesn’t delete the domain.
5. Another app y-1 is created with `nbu1x2` vif nics resource.
6. xl create of y-1 will fails as x-1 is still using `nbu1x2`.

Logs where the above case occurred: 
https://zedcloud-logs.alpha.priv.zededa.net:5601/goto/2f686c702513d7c354db0949e7a51d49?security_tenant=global 