### PR TITLE
Reporting userdata read error on container reboot flow

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -976,7 +976,7 @@ func doActivate(ctx *domainContext, config types.DomainConfig,
 		status.IoAdapterList = config.IoAdapterList
 	}
 
-	if status.IsContainer {
+	if status.IsContainer && config.CloudInitUserData != nil {
 		envList, err := fetchEnvVariablesFromCloudInit(ctx, config)
 		if err != nil {
 			fetchError := fmt.Errorf("failed to fetch environment variable from userdata. %s", err.Error())

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -976,7 +976,7 @@ func doActivate(ctx *domainContext, config types.DomainConfig,
 		status.IoAdapterList = config.IoAdapterList
 	}
 
-	if status.IsContainer && config.CloudInitUserData != nil {
+	if status.IsContainer && (config.IsCipher || config.CloudInitUserData != nil) {
 		envList, err := fetchEnvVariablesFromCloudInit(ctx, config)
 		if err != nil {
 			fetchError := fmt.Errorf("failed to fetch environment variable from userdata. %s", err.Error())


### PR DESCRIPTION
When there is an userdata parse error while deploying container, if we restart the appInstance then the parse error was ignored and we booted the container.

This fix includes parsing userdata on reboot flow as well so that if there is some error then we can handle it accordingly. 