### PR TITLE
Graceful shutdown of domains before device reboot.

### DIFF
--- a/pkg/pillar/cmd/nodeagent/handletimers.go
+++ b/pkg/pillar/cmd/nodeagent/handletimers.go
@@ -217,8 +217,9 @@ func allDomainsHalted(ctxPtr *nodeagentContext) bool {
 				ds.UUIDandVersion.UUID.String(), ds.DisplayName, ds.State)
 			return false
 		}
+		log.Debugf("allDomainsHalted: %s is deactivated", ds.DisplayName)
 	}
-	log.Debugf("allDomainsHalted: All Domains Halted.")
+	log.Infof("allDomainsHalted: All Domains Halted.")
 	return true
 
 }

--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -316,6 +316,9 @@ func Run(ps *pubsub.PubSub) {
 		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
 
+		case change := <-subDomainStatus.MsgChan():
+			subDomainStatus.ProcessChange(change)
+
 		case change := <-subZbootStatus.MsgChan():
 			subZbootStatus.ProcessChange(change)
 


### PR DESCRIPTION
Device reboot was not waiting for domain to shutdown. 
Reason: `subDomainStatus` events were not received in nodeagent.go hence `subDomainStatus.GetAll()` always returned empty result because of which the flow went ahead assuming there were no active domains.