### PR TITLE
[WIP] Move GlobalConfig to AgentBase

### DIFF
--- a/pkg/pillar/agentbase/agent.go
+++ b/pkg/pillar/agentbase/agent.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/pidfile"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/types"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -14,14 +16,44 @@ import (
 // this interface.
 type AgentBase interface {
 	AgentBaseContext() *Context
-	AddAgentSpecificCLIFlags()
-	ProcessAgentSpecificCLIFlags()
+}
+
+const (
+	DefaultErrorTime   = 3 * time.Minute
+	DefaultWarningTime = 40 * time.Second
+)
+
+// DefaultContext - returns a context with default values
+func DefaultContext(agentName string) Context {
+	return Context{
+		AgentName:   agentName,
+		WarningTime: DefaultWarningTime,
+		ErrorTime:   DefaultErrorTime,
+		AgentOptions: AgentOptions{
+			NeedWatchdog:          true,
+			CheckAndCreatePidFile: true,
+			InitializeAgent:       true,
+			CreateGlobalConfigSub: true,
+		},
+	}
 }
 
 // CliParams - stores all the common cli params
 type CliParams struct {
 	DebugOverride bool
+	Debug         bool
 }
+type AgentOptions struct {
+	NeedWatchdog              bool
+	CheckAndCreatePidFile     bool
+	AddAgentCLIFlagsFnPtr     ContextCallbackFnType
+	ProcessAgentCLIFlagsFnPtr ContextCallbackFnType
+	InitializeAgent           bool
+	CreateGlobalConfigSub     bool
+}
+
+// ContextCallbackFnType - Defines a structure for the type of function we use to add and process cli flags
+type ContextCallbackFnType func()
 
 // Context - a struct that represents a general agent context
 type Context struct {
@@ -29,35 +61,59 @@ type Context struct {
 	ErrorTime    time.Duration
 	WarningTime  time.Duration
 	AgentName    string
-	NeedWatchdog bool
+	AgentOptions AgentOptions
+
+	StillRunning *time.Ticker
+
+	subGlobalConfig pubsub.Subscription
+	globalConfig    *types.ConfigItemValueMap
+	GCInitialized   bool
 }
 
 // processCLIFlags - Add flags common to all agents
 func processCLIFlags(agentBase AgentBase) {
-	debugPtr := flag.Bool("d", false, "Debug flag")
-	agentBase.AddAgentSpecificCLIFlags()
-	flag.Parse()
 	ctx := agentBase.AgentBaseContext()
-	ctx.CLIParams.DebugOverride = *debugPtr
-	agentBase.ProcessAgentSpecificCLIFlags()
+	flag.BoolVar(&ctx.CLIParams.Debug, "d", false, "Debug flag")
+	if ctx.AgentOptions.AddAgentCLIFlagsFnPtr != nil {
+		ctx.AgentOptions.AddAgentCLIFlagsFnPtr()
+	}
+	flag.Parse()
+	if ctx.AgentOptions.ProcessAgentCLIFlagsFnPtr != nil {
+		ctx.AgentOptions.ProcessAgentCLIFlagsFnPtr()
+	}
+	ctx.CLIParams.DebugOverride = ctx.CLIParams.Debug
 }
 
 // Run - a general run function that will handle all of the common code for agents
-func Run(agentSpecificContext AgentBase) {
-	processCLIFlags(agentSpecificContext)
-	ctx := agentSpecificContext.AgentBaseContext()
-	debugOverride := ctx.CLIParams.DebugOverride
-	if debugOverride {
+func Run(ps *pubsub.PubSub, ctx interface{}) {
+	agentBase := ctx.(AgentBase)
+	processCLIFlags(agentBase)
+	agentBaseContext := agentBase.AgentBaseContext()
+	if agentBaseContext.CLIParams.DebugOverride {
 		log.SetLevel(log.DebugLevel)
 	} else {
 		log.SetLevel(log.InfoLevel)
 	}
-	agentlog.Init(ctx.AgentName)
-	if err := pidfile.CheckAndCreatePidfile(ctx.AgentName); err != nil {
-		log.Fatal(err)
+	if agentBaseContext.AgentOptions.InitializeAgent {
+		agentlog.Init(agentBaseContext.AgentName)
 	}
-	log.Infof("Starting %s\n", ctx.AgentName)
-	if ctx.NeedWatchdog {
-		agentlog.StillRunning(ctx.AgentName, ctx.WarningTime, ctx.ErrorTime)
+	if agentBaseContext.AgentOptions.CheckAndCreatePidFile {
+		if err := pidfile.CheckAndCreatePidfile(agentBaseContext.AgentName); err != nil {
+			log.Fatal(err)
+		}
+	}
+	log.Infof("Starting %s\n", agentBaseContext.AgentName)
+	if agentBaseContext.AgentOptions.NeedWatchdog {
+		agentlog.StillRunning(agentBaseContext.AgentName, agentBaseContext.WarningTime, agentBaseContext.ErrorTime)
+	}
+
+	agentBaseContext.StillRunning = time.NewTicker(25 * time.Second)
+
+	if agentBaseContext.AgentOptions.CreateGlobalConfigSub {
+		globalConfigSub, err := NewGlobalConfigSub(ps, ctx)
+		globalConfigSub.Activate()
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 }

--- a/pkg/pillar/agentbase/globalconfig.go
+++ b/pkg/pillar/agentbase/globalconfig.go
@@ -1,0 +1,57 @@
+package agentbase
+
+import (
+	"github.com/lf-edge/eve/pkg/pillar/agentlog"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func NewGlobalConfigSub(ps *pubsub.PubSub, ctx interface{}) (pubsub.Subscription, error) {
+	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:     "",
+		TopicImpl:     types.ConfigItemValueMap{},
+		Activate:      false,
+		Ctx:           ctx,
+		ModifyHandler: handleGlobalConfigModify,
+		DeleteHandler: handleGlobalConfigDelete,
+		WarningTime:   DefaultWarningTime,
+		ErrorTime:     DefaultErrorTime,
+	})
+	return subGlobalConfig, err
+}
+
+func handleGlobalConfigModify(ctxArg interface{},
+	key string, statusArg interface{}) {
+
+	ctxPtr := ctxArg.(*Context)
+	if key != "global" {
+		log.Infof("handleGlobalConfigModify: ignoring %s\n", key)
+		return
+	}
+	log.Infof("handleGlobalConfigModify for %s\n", key)
+	var gcp *types.ConfigItemValueMap
+	ctxPtr.CLIParams.Debug, gcp = agentlog.HandleGlobalConfig(ctxPtr.subGlobalConfig, ctxPtr.AgentName,
+		ctxPtr.CLIParams.DebugOverride)
+	if gcp != nil && !ctxPtr.GCInitialized {
+		ctxPtr.globalConfig = gcp
+		ctxPtr.GCInitialized = true
+	}
+	log.Infof("handleGlobalConfigModify(%s): done\n", key)
+}
+
+func handleGlobalConfigDelete(ctxArg interface{},
+	key string, statusArg interface{}) {
+
+	ctxPtr := ctxArg.(*Context)
+	if key != "global" {
+		log.Infof("handleGlobalConfigDelete: ignoring %s\n", key)
+		return
+	}
+	log.Infof("handleGlobalConfigDelete for %s\n", key)
+	ctxPtr.CLIParams.Debug, _ = agentlog.HandleGlobalConfig(ctxPtr.subGlobalConfig, ctxPtr.AgentName,
+		ctxPtr.CLIParams.DebugOverride)
+	ctxPtr.globalConfig = types.DefaultConfigItemValueMap()
+	log.Infof("handleGlobalConfigDelete done for %s\n", key)
+}

--- a/pkg/pillar/cmd/downloader/globalconfig.go
+++ b/pkg/pillar/cmd/downloader/globalconfig.go
@@ -19,8 +19,8 @@ func handleGlobalConfigModify(ctxArg interface{}, key string,
 	}
 	log.Infof("handleGlobalConfigModify for %s\n", key)
 	var gcp *types.ConfigItemValueMap
-	debug, gcp = agentlog.HandleGlobalConfig(ctx.subGlobalConfig, agentName,
-		debugOverride)
+	ctx.agentBaseContext.CLIParams.Debug, gcp = agentlog.HandleGlobalConfig(ctx.subGlobalConfig, agentName,
+		ctx.agentBaseContext.CLIParams.DebugOverride)
 	if gcp != nil {
 		if gcp.GlobalValueInt(types.DownloadGCTime) != 0 {
 			downloadGCTime = time.Duration(gcp.GlobalValueInt(types.DownloadGCTime)) * time.Second
@@ -42,7 +42,7 @@ func handleGlobalConfigDelete(ctxArg interface{}, key string,
 		return
 	}
 	log.Infof("handleGlobalConfigDelete for %s\n", key)
-	debug, _ = agentlog.HandleGlobalConfig(ctx.subGlobalConfig, agentName,
-		debugOverride)
+	ctx.agentBaseContext.CLIParams.Debug, _ = agentlog.HandleGlobalConfig(ctx.subGlobalConfig, agentName,
+		ctx.agentBaseContext.CLIParams.DebugOverride)
 	log.Infof("handleGlobalConfigDelete done for %s\n", key)
 }

--- a/pkg/pillar/cmd/hardwaremodel/hardwaremodel.go
+++ b/pkg/pillar/cmd/hardwaremodel/hardwaremodel.go
@@ -18,9 +18,6 @@ import (
 	"github.com/rackn/gohai/plugins/system"
 )
 
-// Set from Makefile
-var Version = "No version specified"
-
 type info interface {
 	Class() string
 }
@@ -54,14 +51,9 @@ func hwFp() {
 }
 
 func Run(ps *pubsub.PubSub) {
-	versionPtr := flag.Bool("v", false, "Version")
 	cPtr := flag.Bool("c", false, "No CRLF")
 	hwPtr := flag.Bool("f", false, "Fingerprint hardware")
 	flag.Parse()
-	if *versionPtr {
-		fmt.Printf("%s: %s\n", os.Args[0], Version)
-		return
-	}
 	if *hwPtr {
 		hwFp()
 		return

--- a/pkg/pillar/cmd/logmanager/domainstatus.go
+++ b/pkg/pillar/cmd/logmanager/domainstatus.go
@@ -20,7 +20,7 @@ func lookupDomainName(ctxArg interface{}, domainName string) string {
 }
 
 // Map from domainName to the UUID
-var domainUuid map[string]string = make(map[string]string)
+var domainUuid = make(map[string]string)
 
 func handleDomainStatusModify(ctxArg interface{}, key string,
 	statusArg interface{}) {


### PR DESCRIPTION
This cherry picks #810, so a lot of the current diff is duplicated from there. The changes specific  to PR are in agent.go, globalconfig.go and baseosmgr.go. The purpose of this PR is get all of the global config subscription code into agentbase.