### PR TITLE
Allowing storage init to expand P3 to entire disk

### DIFF
--- a/pkg/storage-init/Dockerfile
+++ b/pkg/storage-init/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.10.3
 WORKDIR /
 # hadolint ignore=DL3018
 RUN apk add --no-cache bash glib squashfs-tools util-linux e2fsprogs \
-        e2fsprogs-extra keyutils dosfstools coreutils
+        e2fsprogs-extra keyutils dosfstools coreutils sgdisk
 COPY storage-init.sh /storage-init.sh
 
 ENTRYPOINT []

--- a/pkg/storage-init/storage-init.sh
+++ b/pkg/storage-init/storage-init.sh
@@ -35,19 +35,23 @@ fi
 P3_FS_TYPE="ext3"
 FSCK_FAILED=0
 
-# First lets see if we're missing P3 (/persist) altogether and try to create it.
-# This is safe, since the worst case scenario we may hose the system, but the
-# system without P3 (/persist) is almost a warm brick anyways. The reason we are
-# not refusing to proceed though, is that we still hope that if everything else
-# fails useful feedback will be reported to the controller about the "warm brick"
-# state.
+# First lets see if we're running with the disk that hasn't been properly
+# initialized. This could happen when we run in a virtualized cloud
+# environment where the initial disk image gets resized to its proper
+# size when EVE is started (it can also happen when you're preparing a
+# live image for something like HiKey and put it dirrectly on the flash
+# card bypassing using EVE's installer).
+#
+# The criteria we're using to determine if the disk hasn't been fully
+# initialized is when it is missing both P3 (/persist) and IMGB partition
+# entries. If that's the case we're willing to (potentially destructively)
+# manipulate partition table. The logic here is simple: if we're missing
+# both IMGB and P3 the following code is probably the *least* risky thing
+# we can do.
 P3=$(/hostfs/sbin/findfs PARTLABEL=P3)
 IMGA=$(/hostfs/sbin/findfs PARTLABEL=IMGA)
 IMGB=$(/hostfs/sbin/findfs PARTLABEL=IMGB)
-# if we don't have a P3 (/persist) partition, but we do have at least IMGA, then
-# we can calculate where the P3 (/persist) should exist on disk and make it.
-# Optionally same applies to IMGB partition (if it is missing in the GPT).
-if [ -z "$P3" ] && [ -n "$IMGA" ]; then
+if [ -n "$IMGA" ] && [ -z "$P3" ] && [ -z "$IMGB" ]; then
    DEV=$(echo /sys/block/*/"${IMGA#/dev/}")
    DEV="/dev/$(echo "$DEV" | cut -f4 -d/)"
 
@@ -65,30 +69,25 @@ if [ -z "$P3" ] && [ -n "$IMGA" ]; then
        dd if="$DEV" of="$DEV" bs=1 skip=446 seek=$(( 446 + 16)) count=16 conv=noerror,sync,notrunc
        # restore 1st MBR entry + first partition entry
        dd if=/tmp/mbr.bin of="$DEV" bs=1 conv=noerror,sync,notrunc
-
-       # focrce kernel to re-scan partition table
-       partprobe "$DEV"
    fi
 
-   # lets see if IMGB partition is around, if not - create it
-   if [ -z "$IMGB" ]; then
-      IMGA_ID=$(sgdisk -p "$DEV" | grep "IMGA$" | awk '{print $1;}')
+   # now that GPT itself is fixed, lets add IMGB & P3 partitions
+   IMGA_ID=$(sgdisk -p "$DEV" | grep "IMGA$" | awk '{print $1;}')
+   IMGB_ID=$((IMGA_ID + 1))
+   P3_ID=$((IMGA_ID + 7))
 
-      IMGA_SIZE=$(sgdisk -i "$IMGA_ID" "$DEV" | awk '/^Partition size:/ { print $3; }')
-      IMGA_GUID=$(sgdisk -i "$IMGA_ID" "$DEV" | awk '/^Partition unique GUID:/ { print $4; }')
+   IMGA_SIZE=$(sgdisk -i "$IMGA_ID" "$DEV" | awk '/^Partition size:/ { print $3; }')
+   IMGA_GUID=$(sgdisk -i "$IMGA_ID" "$DEV" | awk '/^Partition unique GUID:/ { print $4; }')
 
-      SEC_START=$(sgdisk -f "$DEV")
-      SEC_END=$((SEC_START + IMGA_SIZE))
-      IMGB_ID=$((IMGA_ID + 1))
+   SEC_START=$(sgdisk -f "$DEV")
+   SEC_END=$((SEC_START + IMGA_SIZE))
 
-      sgdisk --new "$IMGB_ID:$SEC_START:$SEC_END" \
-             --typecode="$IMGB_ID:$IMGA_GUID" --change-name="$IMGB_ID:IMGB" "$DEV"
-   fi
+   sgdisk --new "$IMGB_ID:$SEC_START:$SEC_END" --typecode="$IMGB_ID:$IMGA_GUID" --change-name="$IMGB_ID:IMGB" "$DEV"
+   sgdisk --largest-new="$P3_ID" --typecode="$P3_ID:5f24425a-2dfa-11e8-a270-7b663faccc2c" --change-name="$P3_ID:P3" "$DEV"
 
-   LAST_PART_ID=$(sgdisk -p "$DEV" | awk '{a=$1;} END { print a;}')
-   P3_ID=$((LAST_PART_ID + 1))
-   sgdisk --largest-new="$P3_ID" \
-          --typecode="$P3_ID:5f24425a-2dfa-11e8-a270-7b663faccc2c" --change-name="$P3_ID:P3" "$DEV"
+   # focrce kernel to re-scan partition table
+   partprobe "$DEV"
+   partx -a --nr "$IMGB_ID:$P3_ID" "$DEV"
 fi
 
 #For systems with ext3 filesystem, try not to change to ext4, since it will brick


### PR DESCRIPTION
This change allows creation of live images that are very compact (just the size of the rootfs). The rest of the disk structure is created on the first boot by storage-init.

This is mostly useful when putting EVE on live media that is much bigger.

As the comment says -- this change seems to be pretty safe, since if the P3 partition is not located anywhere -- we may as well try reasonably dangerous actions like resizing the disk.

Finally, this change is next to the last step to allow creating EVE instances as VMs on Google cloud.

P.S. And yest, I do realize that the entire storage-init should probably be re-written in Go -- but this is the task for another time.