### PR TITLE
Remove ErrorSource confusion and misuse

### DIFF
--- a/pkg/pillar/cmd/baseosmgr/baseosmgr.go
+++ b/pkg/pillar/cmd/baseosmgr/baseosmgr.go
@@ -169,10 +169,8 @@ func handleBaseOsCreate(ctxArg interface{}, key string, configArg interface{}) {
 	// Check image count
 	err := validateBaseOsConfig(ctx, config)
 	if err != nil {
-		errStr := fmt.Sprintf("%v", err)
-		log.Errorln(errStr)
-		status.Error = errStr
-		status.ErrorTime = time.Now()
+		log.Error(err)
+		status.SetErrorNow(err.Error())
 		publishBaseOsStatus(ctx, &status)
 		return
 	}
@@ -197,10 +195,8 @@ func handleBaseOsModify(ctxArg interface{}, key string, configArg interface{}) {
 	// Check image count
 	err := validateBaseOsConfig(ctx, config)
 	if err != nil {
-		errStr := fmt.Sprintf("%v", err)
-		log.Errorln(errStr)
-		status.Error = errStr
-		status.ErrorTime = time.Now()
+		log.Error(err)
+		status.SetErrorNow(err.Error())
 		publishBaseOsStatus(ctx, status)
 		return
 	}

--- a/pkg/pillar/cmd/baseosmgr/handledownload.go
+++ b/pkg/pillar/cmd/baseosmgr/handledownload.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
@@ -96,16 +95,12 @@ func checkVolumeStatus(ctx *baseOsMgrContext,
 				imageID)
 			continue
 		}
-		if vs.LastErr != "" {
+		if vs.Error != "" {
 			log.Errorf("checkVolumeStatus %s, volumemgr error, %s\n",
-				uuidStr, vs.LastErr)
-			errInfo := types.ErrorInfo{
-				Error:       vs.LastErr,
-				ErrorTime:   vs.LastErrTime,
-				ErrorSource: pubsub.TypeToName(types.VolumeStatus{}),
-			}
-			ss.SetErrorInfo(errInfo)
-			ret.AllErrors = appendError(ret.AllErrors, "volumemgr", vs.LastErr)
+				uuidStr, vs.Error)
+			ss.SetErrorWithSource(vs.Error, types.VolumeStatus{},
+				vs.ErrorTime)
+			ret.AllErrors = appendError(ret.AllErrors, "volumemgr", vs.Error)
 			ret.ErrorTime = ss.ErrorTime
 			ret.Changed = true
 		}
@@ -188,12 +183,8 @@ func installDownloadedObject(imageID uuid.UUID,
 		ssPtr.State = types.INSTALLED
 		log.Infof("installDownloadedObject(%s) done", imageID)
 	} else {
-		errInfo := types.ErrorInfo{
-			Error:       fmt.Sprintf("installDownloadedObject: %s", ret),
-			ErrorTime:   time.Now(),
-			ErrorSource: pubsub.TypeToName(types.VolumeStatus{}),
-		}
-		ssPtr.SetErrorInfo(errInfo)
+		errStr := fmt.Sprintf("installDownloadedObject: %s", ret)
+		ssPtr.SetErrorWithSource(errStr, types.VolumeStatus{}, time.Now())
 	}
 	return ret
 }

--- a/pkg/pillar/cmd/baseosmgr/handledownload.go
+++ b/pkg/pillar/cmd/baseosmgr/handledownload.go
@@ -95,7 +95,7 @@ func checkVolumeStatus(ctx *baseOsMgrContext,
 				imageID)
 			continue
 		}
-		if vs.Error != "" {
+		if vs.HasError() {
 			log.Errorf("checkVolumeStatus %s, volumemgr error, %s\n",
 				uuidStr, vs.Error)
 			ss.SetErrorWithSource(vs.Error, types.VolumeStatus{},

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -654,7 +654,7 @@ func printProxy(ctx *diagContext, port types.NetworkPortStatus,
 		fmt.Fprintf(outfile, "INFO: %s: proxy exceptions %s\n",
 			ifname, port.ProxyConfig.Exceptions)
 	}
-	if port.Error != "" {
+	if port.HasError() {
 		fmt.Fprintf(outfile, "ERROR: %s: from WPAD? %s\n", ifname, port.Error)
 	}
 	if port.ProxyConfig.NetworkProxyEnable {

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1506,7 +1506,7 @@ func handleModify(ctx *domainContext, key string,
 
 		// This has the effect of trying a boot again for any
 		// handleModify after an error.
-		if status.Error != "" {
+		if status.HasError() {
 			log.Infof("handleModify(%v) ignoring existing error for %s\n",
 				config.UUIDandVersion, config.DisplayName)
 			status.ClearError()
@@ -1528,7 +1528,7 @@ func handleModify(ctx *domainContext, key string,
 	} else if !config.Activate {
 		log.Infof("handleModify(%v) NOT activating for %s",
 			config.UUIDandVersion, config.DisplayName)
-		if status.Error != "" {
+		if status.HasError() {
 			log.Infof("handleModify(%v) clearing existing error for %s\n",
 				config.UUIDandVersion, config.DisplayName)
 			status.ClearError()
@@ -1566,7 +1566,7 @@ func handleModify(ctx *domainContext, key string,
 		return
 	}
 
-	// XXX check if we have status.Error != "" and delete and retry
+	// XXX check if we have status.HasError() and delete and retry
 	// even if same version. XXX won't the above Activate/Activated checks
 	// result in redoing things? Could have failures during copy i.e.
 	// before activation.

--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -292,11 +292,11 @@ func maybeRetryDownload(ctx *downloaderContext,
 
 	// object is either in download progress or,
 	// successfully downloaded, nothing to do
-	if status.LastErr == "" {
+	if status.Error == "" {
 		return
 	}
 	t := time.Now()
-	elapsed := t.Sub(status.LastErrTime)
+	elapsed := t.Sub(status.ErrorTime)
 	if elapsed < downloadRetryTime {
 		log.Infof("maybeRetryDownload(%s) %d remaining\n",
 			status.Key(),
@@ -304,7 +304,7 @@ func maybeRetryDownload(ctx *downloaderContext,
 		return
 	}
 	log.Infof("maybeRetryDownload(%s) after %s at %v\n",
-		status.Key(), status.LastErr, status.LastErrTime)
+		status.Key(), status.Error, status.ErrorTime)
 
 	config := lookupDownloaderConfig(ctx, status.ObjType, status.Key())
 	if config == nil {
@@ -313,9 +313,9 @@ func maybeRetryDownload(ctx *downloaderContext,
 		return
 	}
 
-	// reset ErrorInfo, to start download again
+	// reset Error, to start download again
 	status.RetryCount++
-	status.ClearErrorInfo()
+	status.ClearError()
 	publishDownloaderStatus(ctx, status)
 
 	doDownload(ctx, *config, status)

--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -292,7 +292,7 @@ func maybeRetryDownload(ctx *downloaderContext,
 
 	// object is either in download progress or,
 	// successfully downloaded, nothing to do
-	if status.Error == "" {
+	if !status.HasError() {
 		return
 	}
 	t := time.Now()

--- a/pkg/pillar/cmd/downloader/resolveconfig.go
+++ b/pkg/pillar/cmd/downloader/resolveconfig.go
@@ -94,7 +94,7 @@ func resolveTagsToHash(ctx *downloaderContext, rc types.ResolveConfig) {
 			Counter:     rc.Counter,
 		}
 	}
-	rs.ClearErrorInfo()
+	rs.ClearError()
 
 	sha := maybeNameHasSha(rc.Name)
 	if sha != "" {
@@ -105,7 +105,7 @@ func resolveTagsToHash(ctx *downloaderContext, rc types.ResolveConfig) {
 
 	dst, errStr := lookupDatastoreConfig(ctx, rc.DatastoreID, rc.Name)
 	if errStr != "" {
-		rs.SetErrorInfo(agentName, errStr)
+		rs.SetErrorNow(errStr)
 		publishResolveStatus(ctx, rs)
 		return
 	}
@@ -113,7 +113,7 @@ func resolveTagsToHash(ctx *downloaderContext, rc types.ResolveConfig) {
 	dsCtx, err := constructDatastoreContext(ctx, rc.Name, false, *dst)
 	if err != nil {
 		errStr := fmt.Sprintf("%s, Datastore construction failed, %s", rc.Name, err)
-		rs.SetErrorInfo(agentName, errStr)
+		rs.SetErrorNow(errStr)
 		publishResolveStatus(ctx, rs)
 		return
 	}
@@ -132,8 +132,7 @@ func resolveTagsToHash(ctx *downloaderContext, rc types.ResolveConfig) {
 		err = errors.New("No IP management port addresses for download")
 	}
 	if addrCount == 0 {
-		errStr = err.Error()
-		rs.SetErrorInfo(agentName, errStr)
+		rs.SetErrorNow(err.Error())
 		publishResolveStatus(ctx, rs)
 		return
 	}
@@ -162,7 +161,7 @@ func resolveTagsToHash(ctx *downloaderContext, rc types.ResolveConfig) {
 	// and return, but we will get to it later
 	if errStr != "" {
 		log.Errorf("Error preparing to download. All errors:%s\n", errStr)
-		rs.SetErrorInfo(agentName, errStr)
+		rs.SetErrorNow(errStr)
 		publishResolveStatus(ctx, rs)
 		return
 	}
@@ -200,7 +199,7 @@ func resolveTagsToHash(ctx *downloaderContext, rc types.ResolveConfig) {
 
 	}
 	log.Errorf("All source IP addresses failed. All errors:%s\n", errStr)
-	rs.SetErrorInfo(agentName, errStr)
+	rs.SetErrorNow(errStr)
 	publishResolveStatus(ctx, rs)
 }
 

--- a/pkg/pillar/cmd/downloader/syncop.go
+++ b/pkg/pillar/cmd/downloader/syncop.go
@@ -279,7 +279,7 @@ func handleSyncOpResponse(ctx *downloaderContext, config types.DownloaderConfig,
 
 	log.Infof("handleSyncOpResponse(%s): successful <%s>\n",
 		config.Name, locFilename)
-	// We do not clear any status.RetryCount, LastErr, etc. The caller
+	// We do not clear any status.RetryCount, Error, etc. The caller
 	// should look at State == DOWNLOADED to determine it is done.
 
 	status.ModTime = time.Now()

--- a/pkg/pillar/cmd/vaultmgr/vaultmgr.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgr.go
@@ -346,14 +346,12 @@ func publishVaultStatus(ctx *vaultMgrContext,
 	status.Name = vaultName
 	if fscryptStatus != info.DataSecAtRestStatus_DATASEC_AT_REST_ENABLED {
 		status.Status = fscryptStatus
-		status.Error = fscryptError
-		status.ErrorTime = time.Now()
+		status.SetErrorNow(fscryptError)
 	} else {
 		args := getStatusParams(vaultPath)
 		if stderr, _, err := execCmd(fscryptPath, args...); err != nil {
 			status.Status = info.DataSecAtRestStatus_DATASEC_AT_REST_ERROR
-			status.Error = stderr
-			status.ErrorTime = time.Now()
+			status.SetErrorNow(stderr)
 		} else {
 			status.Status = info.DataSecAtRestStatus_DATASEC_AT_REST_ENABLED
 		}

--- a/pkg/pillar/cmd/verifier/verifier.go
+++ b/pkg/pillar/cmd/verifier/verifier.go
@@ -573,8 +573,7 @@ func gcVerifiedObjects(ctx *verifierContext) {
 func updateVerifyErrStatus(ctx *verifierContext,
 	status *types.VerifyImageStatus, lastErr string) {
 
-	status.LastErr = lastErr
-	status.LastErrTime = time.Now()
+	status.SetErrorNow(lastErr)
 	status.PendingAdd = false
 	publishVerifyImageStatus(ctx, status)
 }

--- a/pkg/pillar/cmd/volumemgr/handlecerts.go
+++ b/pkg/pillar/cmd/volumemgr/handlecerts.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"time"
 
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
@@ -134,8 +133,8 @@ func doCertObjInstall(ctx *volumemgrContext, uuidStr string, config types.CertOb
 		errString := fmt.Sprintf("%s, Storage length mismatch: %d vs %d\n", uuidStr,
 			len(config.StorageConfigList),
 			len(status.StorageStatusList))
-		status.Error = errString
-		status.ErrorTime = time.Now()
+		log.Error(errString)
+		status.SetErrorNow(errString)
 		return changed, false
 	}
 
@@ -147,9 +146,8 @@ func doCertObjInstall(ctx *volumemgrContext, uuidStr string, config types.CertOb
 			errString := fmt.Sprintf("%s, Storage config mismatch:\n\t%s\n\t%s\n\t%s\n\t%s\n\n", uuidStr,
 				sc.Name, ss.Name,
 				sc.ImageID, ss.ImageID)
-			log.Errorln(errString)
-			status.Error = errString
-			status.ErrorTime = time.Now()
+			log.Error(errString)
+			status.SetErrorNow(errString)
 			changed = true
 			return changed, false
 		}
@@ -182,8 +180,7 @@ func checkCertObjStorageDownloadStatus(ctx *volumemgrContext, uuidStr string,
 	//		config.StorageConfigList, status.StorageStatusList)
 	var ret types.RetStatus
 	status.State = ret.MinState
-	status.Error = ret.AllErrors
-	status.ErrorTime = ret.ErrorTime
+	status.SetError(ret.AllErrors, ret.ErrorTime)
 
 	log.Infof("checkCertObjDownloadStatus %s, %v\n", uuidStr, ret.MinState)
 

--- a/pkg/pillar/cmd/volumemgr/handleverifier.go
+++ b/pkg/pillar/cmd/volumemgr/handleverifier.go
@@ -39,7 +39,7 @@ func lookupPersistImageConfig(ctx *volumemgrContext, objType string,
 
 // If checkCerts is set this can return false. Otherwise not.
 func MaybeAddVerifyImageConfig(ctx *volumemgrContext,
-	status types.VolumeStatus, checkCerts bool) (bool, types.ErrorInfo) {
+	status types.VolumeStatus, checkCerts bool) (bool, types.ErrorAndTime) {
 
 	log.Infof("MaybeAddVerifyImageConfig for %s, checkCerts: %v",
 		status.VolumeID, checkCerts)
@@ -96,7 +96,7 @@ func MaybeAddVerifyImageConfig(ctx *volumemgrContext,
 		log.Debugf("MaybeAddVerifyImageConfig - config: %+v\n", n)
 	}
 	log.Infof("MaybeAddVerifyImageConfig done for %s\n", status.VolumeID)
-	return true, types.ErrorInfo{}
+	return true, types.ErrorAndTime{}
 }
 
 // MaybeRemoveVerifyImageConfig decreases the refcount and if it

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -53,7 +53,7 @@ func doUpdate(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool) {
 			log.Infof("lookupVerifyImageStatus %s Pending\n", status.VolumeID)
 			return changed, false
 		}
-		if vs.Error != "" {
+		if vs.HasError() {
 			log.Errorf("Received error from verifier for %s: %s\n",
 				status.VolumeID, vs.Error)
 			status.SetErrorWithSource(vs.Error, types.VerifyImageStatus{},
@@ -140,7 +140,7 @@ func doUpdate(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool) {
 			status.VolumeID)
 		return changed, false
 	}
-	if ds.Error != "" {
+	if ds.HasError() {
 		log.Errorf("Received error from downloader for %s: %s\n",
 			status.VolumeID, ds.Error)
 		status.SetErrorWithSource(ds.Error, types.DownloaderStatus{},
@@ -178,7 +178,7 @@ func doUpdate(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool) {
 func kickVerifier(ctx *volumemgrContext, status *types.VolumeStatus, checkCerts bool) bool {
 	changed := false
 	if !status.DownloadOrigin.HasVerifierRef {
-		done, errInfo := MaybeAddVerifyImageConfig(ctx, *status, checkCerts)
+		done, errorAndTime := MaybeAddVerifyImageConfig(ctx, *status, checkCerts)
 		if done {
 			status.DownloadOrigin.HasVerifierRef = true
 			changed = true
@@ -186,8 +186,8 @@ func kickVerifier(ctx *volumemgrContext, status *types.VolumeStatus, checkCerts 
 		}
 		// if errors, set the certError flag
 		// otherwise, mark as waiting for certs
-		if errInfo.Error != "" {
-			status.SetError(errInfo.Error, errInfo.ErrorTime)
+		if errorAndTime.HasError() {
+			status.SetError(errorAndTime.Error, errorAndTime.ErrorTime)
 			changed = true
 		} else if !status.WaitingForCerts {
 			status.WaitingForCerts = true

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -6,7 +6,6 @@ package volumemgr
 import (
 	"time"
 
-	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
@@ -54,19 +53,16 @@ func doUpdate(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool) {
 			log.Infof("lookupVerifyImageStatus %s Pending\n", status.VolumeID)
 			return changed, false
 		}
-		if vs.LastErr != "" {
+		if vs.Error != "" {
 			log.Errorf("Received error from verifier for %s: %s\n",
-				status.VolumeID, vs.LastErr)
-			status.ErrorSource = pubsub.TypeToName(types.VerifyImageStatus{})
-			status.LastErr = vs.LastErr
-			status.LastErrTime = vs.LastErrTime
+				status.VolumeID, vs.Error)
+			status.SetErrorWithSource(vs.Error, types.VerifyImageStatus{},
+				vs.ErrorTime)
 			changed = true
 			return changed, false
-		} else if status.ErrorSource == pubsub.TypeToName(types.VerifyImageStatus{}) {
-			log.Infof("Clearing verifier error %s\n", status.LastErr)
-			status.LastErr = ""
-			status.ErrorSource = ""
-			status.LastErrTime = time.Time{}
+		} else if status.IsErrorSource(types.VerifyImageStatus{}) {
+			log.Infof("Clearing verifier error %s\n", status.Error)
+			status.ClearErrorWithSource()
 			changed = true
 		}
 		switch vs.State {
@@ -81,9 +77,8 @@ func doUpdate(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool) {
 			}
 			c, err := createVolume(ctx, status, vs.FileLocation)
 			if err != nil {
-				status.ErrorSource = pubsub.TypeToName(types.VolumeStatus{})
-				status.LastErr = err.Error()
-				status.LastErrTime = time.Now()
+				status.SetErrorWithSource(err.Error(),
+					types.VolumeStatus{}, time.Now())
 				changed = true
 				return changed, false
 			}
@@ -145,19 +140,17 @@ func doUpdate(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool) {
 			status.VolumeID)
 		return changed, false
 	}
-	if ds.LastErr != "" {
+	if ds.Error != "" {
 		log.Errorf("Received error from downloader for %s: %s\n",
-			status.VolumeID, ds.LastErr)
-		status.ErrorSource = pubsub.TypeToName(types.DownloaderStatus{})
-		status.LastErr = ds.LastErr
-		status.LastErrTime = ds.LastErrTime
+			status.VolumeID, ds.Error)
+		status.SetErrorWithSource(ds.Error, types.DownloaderStatus{},
+			ds.ErrorTime)
 		changed = true
 		return changed, false
-	} else if status.ErrorSource == pubsub.TypeToName(types.DownloaderStatus{}) {
-		log.Infof("Clearing downloader error %s\n", status.LastErr)
-		status.LastErr = ""
-		status.ErrorSource = ""
-		status.LastErrTime = time.Time{}
+	}
+	if status.IsErrorSource(types.DownloaderStatus{}) {
+		log.Infof("Clearing downloader error %s\n", status.Error)
+		status.ClearErrorWithSource()
 		changed = true
 	}
 	switch ds.State {
@@ -185,24 +178,20 @@ func doUpdate(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool) {
 func kickVerifier(ctx *volumemgrContext, status *types.VolumeStatus, checkCerts bool) bool {
 	changed := false
 	if !status.DownloadOrigin.HasVerifierRef {
-		ret, errInfo := MaybeAddVerifyImageConfig(ctx, *status, checkCerts)
-		if ret {
+		done, errInfo := MaybeAddVerifyImageConfig(ctx, *status, checkCerts)
+		if done {
 			status.DownloadOrigin.HasVerifierRef = true
 			changed = true
-		} else {
-			// if errors, set the certError flag
-			// otherwise, mark as waiting for certs
-			if errInfo.Error != "" {
-				status.ErrorSource = errInfo.ErrorSource
-				status.LastErr = errInfo.Error
-				status.LastErrTime = errInfo.ErrorTime
-				changed = true
-			} else {
-				if !status.WaitingForCerts {
-					changed = true
-					status.WaitingForCerts = true
-				}
-			}
+			return changed
+		}
+		// if errors, set the certError flag
+		// otherwise, mark as waiting for certs
+		if errInfo.Error != "" {
+			status.SetError(errInfo.Error, errInfo.ErrorTime)
+			changed = true
+		} else if !status.WaitingForCerts {
+			status.WaitingForCerts = true
+			changed = true
 		}
 	}
 	return changed
@@ -301,9 +290,8 @@ func doDelete(ctx *volumemgrContext, status *types.VolumeStatus) bool {
 	if status.VolumeCreated {
 		_, err := destroyVolume(ctx, status)
 		if err != nil {
-			status.ErrorSource = pubsub.TypeToName(types.VolumeStatus{})
-			status.LastErr = err.Error()
-			status.LastErrTime = time.Now()
+			status.SetErrorWithSource(err.Error(), types.VolumeStatus{},
+				time.Now())
 			changed = true
 			return changed
 		}

--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -110,7 +110,7 @@ func getControllerCert(ctx *getconfigContext,
 	for _, item := range items {
 		status := item.(types.ControllerCert)
 		if bytes.Equal(status.CertHash, suppliedHash) {
-			if status.Error != "" {
+			if status.HasError() {
 				log.Errorf("get controller cert failed because cert has following error: %v",
 					status.Error)
 				return status.Cert, errors.New(status.Error)

--- a/pkg/pillar/cmd/zedagent/handlecipherconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecipherconfig.go
@@ -176,7 +176,7 @@ func updateCipherBlock(status types.CipherContext,
 	}
 	// when we have both the certificates,
 	// mark the cipher block as valid
-	if status.Error != "" {
+	if status.HasError() {
 		cipherBlock.SetErrorNow(status.Error)
 	} else {
 		cipherBlock.ControllerCert = ccert

--- a/pkg/pillar/cmd/zedagent/handlecipherconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecipherconfig.go
@@ -69,11 +69,11 @@ func parseCipherContext(ctx *getconfigContext,
 			DeviceCertHash:     cfgCipherContext.GetDeviceCertHash(),
 			ControllerCertHash: cfgCipherContext.GetControllerCertHash(),
 		}
-		context.ClearErrorInfo()
+		context.ClearError()
 		if err := updateCipherContextCerts(ctx, &context); err != nil {
 			errStr := fmt.Sprintf("%s, CipherContextUpdateCerts failed, %s",
 				context.Key(), err)
-			context.SetErrorInfo(agentName, errStr)
+			context.SetErrorNow(errStr)
 		}
 		publishCipherContext(ctx, context)
 	}
@@ -127,7 +127,7 @@ func parseCipherBlock(ctx *getconfigContext, key string,
 		len(cipherBlock.CipherContextID) == 0 {
 		errStr := fmt.Sprintf("%s, block contains incomplete data", key)
 		log.Errorf(errStr)
-		cipherBlock.SetErrorInfo(agentName, errStr)
+		cipherBlock.SetErrorNow(errStr)
 		return cipherBlock
 	}
 	cipherBlock.IsCipher = true
@@ -139,7 +139,7 @@ func parseCipherBlock(ctx *getconfigContext, key string,
 		errStr := fmt.Sprintf("parseCipherBlock(%s) cipherContext not found %s\n",
 			key, cipherBlock.CipherContextID)
 		log.Errorf(errStr)
-		cipherBlock.SetErrorInfo(agentName, errStr)
+		cipherBlock.SetErrorNow(errStr)
 	} else {
 		log.Infof("parseCipherBlock(%s) cipherContext found %s\n",
 			key, cipherBlock.CipherContextID)
@@ -161,7 +161,7 @@ func updateCipherBlock(status types.CipherContext,
 
 	// first mark the cipher block as not ready,
 	// copy the relavant attributes, from cipher context to cipher block
-	cipherBlock.ClearErrorInfo()
+	cipherBlock.ClearError()
 	cipherBlock.KeyExchangeScheme = status.KeyExchangeScheme
 	cipherBlock.EncryptionScheme = status.EncryptionScheme
 
@@ -171,13 +171,13 @@ func updateCipherBlock(status types.CipherContext,
 		dcert = []byte{}
 		errStr := fmt.Sprintf("CipherContext(%s) deleted for the cipherBlock",
 			status.Key())
-		cipherBlock.SetErrorInfo(agentName, errStr)
+		cipherBlock.SetErrorNow(errStr)
 		return true
 	}
 	// when we have both the certificates,
 	// mark the cipher block as valid
 	if status.Error != "" {
-		cipherBlock.SetErrorInfo(agentName, status.Error)
+		cipherBlock.SetErrorNow(status.Error)
 	} else {
 		cipherBlock.ControllerCert = ccert
 		cipherBlock.DeviceCert = dcert
@@ -188,7 +188,7 @@ func updateCipherBlock(status types.CipherContext,
 			errStr := fmt.Sprintf("%s, certs are not ready",
 				cipherBlock.Key())
 			log.Errorf(errStr)
-			cipherBlock.SetErrorInfo(agentName, errStr)
+			cipherBlock.SetErrorNow(errStr)
 		}
 	}
 	return true

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -1083,8 +1083,8 @@ func parseOneNetworkXObjectConfig(ctx *getconfigContext, netEnt *zconfig.Network
 	if err != nil {
 		errStr := fmt.Sprintf("parseOneNetworkXObjectConfig: Malformed UUID ignored: %s",
 			err)
-		config.Error = errStr
-		config.ErrorTime = time.Now()
+		log.Error(errStr)
+		config.SetErrorNow(errStr)
 		return config
 	}
 	config.UUID = id
@@ -1144,8 +1144,7 @@ func parseOneNetworkXObjectConfig(ctx *getconfigContext, netEnt *zconfig.Network
 			errStr := fmt.Sprintf("parseOneNetworkXObjectConfig: Missing ipspec for %s in %v",
 				config.Key(), netEnt)
 			log.Error(errStr)
-			config.Error = errStr
-			config.ErrorTime = time.Now()
+			config.SetErrorNow(errStr)
 			return config
 		}
 		err := parseIpspecNetworkXObject(ipspec, config)
@@ -1153,8 +1152,7 @@ func parseOneNetworkXObjectConfig(ctx *getconfigContext, netEnt *zconfig.Network
 			errStr := fmt.Sprintf("parseOneNetworkXObjectConfig: parseIpspec failed for %s: %s",
 				config.Key(), err)
 			log.Error(errStr)
-			config.Error = errStr
-			config.ErrorTime = time.Now()
+			config.SetErrorNow(errStr)
 			return config
 		}
 	case types.NT_NOOP:
@@ -1167,8 +1165,7 @@ func parseOneNetworkXObjectConfig(ctx *getconfigContext, netEnt *zconfig.Network
 				errStr := fmt.Sprintf("parseOneNetworkXObjectConfig: parseIpspec ignored for %s: %s",
 					config.Key(), err)
 				log.Error(errStr)
-				config.Error = errStr
-				config.ErrorTime = time.Now()
+				config.SetErrorNow(errStr)
 				return config
 			}
 		}
@@ -1177,8 +1174,7 @@ func parseOneNetworkXObjectConfig(ctx *getconfigContext, netEnt *zconfig.Network
 		errStr := fmt.Sprintf("parseOneNetworkXObjectConfig: Unknown NetworkConfig type %d for %s in %v; ignored",
 			config.Type, id.String(), netEnt)
 		log.Error(errStr)
-		config.Error = errStr
-		config.ErrorTime = time.Now()
+		config.SetErrorNow(errStr)
 		return config
 	}
 
@@ -1200,8 +1196,7 @@ func parseOneNetworkXObjectConfig(ctx *getconfigContext, netEnt *zconfig.Network
 				errStr := fmt.Sprintf("parseOneNetworkXObjectConfig: bad dnsEntry %s for %s",
 					strAddr, config.Key())
 				log.Error(errStr)
-				config.Error = errStr
-				config.ErrorTime = time.Now()
+				config.SetErrorNow(errStr)
 				return config
 			}
 		}

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -750,7 +750,7 @@ func parseOneSystemAdapterConfig(getconfigCtx *getconfigContext,
 			net := networkXObject.(types.NetworkXObjectConfig)
 			port.NetworkUUID = net.UUID
 			network = &net
-			if network.Error != "" {
+			if network.HasError() {
 				errStr := fmt.Sprintf("parseSystemAdapterConfig: Port %s Network error: %v",
 					port.IfName, network.Error)
 				port.ParseError = errStr

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -443,7 +443,7 @@ func doInstall(ctx *zedmanagerContext,
 				ss.Name)
 			continue
 		}
-		if vs.Error != "" {
+		if vs.HasError() {
 			log.Errorf("Received error from volumemgr for %s: %s",
 				ss.Name, vs.Error)
 			ss.SetErrorWithSource(vs.Error,
@@ -585,7 +585,7 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 			if c {
 				changed = true
 			}
-			if !ds.Activated && ds.Error == "" {
+			if !ds.Activated && !ds.HasError() {
 				log.Infof("RestartInprogress(%s) came down - set bring up\n",
 					status.Key())
 				status.RestartInprogress = types.BringUp
@@ -619,7 +619,7 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 		log.Infof("Waiting for AppNetworkStatus !Pending for %s\n", uuidStr)
 		return changed
 	}
-	if ns.Error != "" {
+	if ns.HasError() {
 		log.Errorf("Received error from zedrouter for %s: %s\n",
 			uuidStr, ns.Error)
 		status.SetErrorWithSource(ns.Error, types.AppNetworkStatus{},
@@ -697,7 +697,7 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 	}
 	// Look for xen errors. Ignore if we are going down
 	if status.RestartInprogress != types.BringDown {
-		if ds.Error != "" {
+		if ds.HasError() {
 			log.Errorf("Received error from domainmgr for %s: %s\n",
 				uuidStr, ds.Error)
 			status.SetErrorWithSource(ds.Error, types.DomainStatus{},
@@ -709,7 +709,7 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 			changed = true
 		}
 	} else {
-		if ds.Error != "" {
+		if ds.HasError() {
 			log.Warnf("bringDown sees error from domainmgr for %s: %s\n",
 				uuidStr, ds.Error)
 		}
@@ -989,7 +989,7 @@ func doInactivate(ctx *zedmanagerContext, appInstID uuid.UUID,
 			changed = true
 		}
 		// Look for errors
-		if ds.Error != "" {
+		if ds.HasError() {
 			log.Errorf("Received error from domainmgr for %s: %s\n",
 				uuidStr, ds.Error)
 			status.SetErrorWithSource(ds.Error, types.DomainStatus{},
@@ -1031,7 +1031,7 @@ func doInactivate(ctx *zedmanagerContext, appInstID uuid.UUID,
 			log.Infof("Waiting for AppNetworkStatus !Activated for %s\n",
 				uuidStr)
 		}
-		if ns.Error != "" {
+		if ns.HasError() {
 			log.Errorf("Received error from zedrouter for %s: %s\n",
 				uuidStr, ns.Error)
 			status.SetErrorWithSource(ns.Error, types.AppNetworkStatus{},
@@ -1134,7 +1134,7 @@ func doInactivateHalt(ctx *zedmanagerContext,
 		return changed
 	}
 	// XXX should we make it not Activated?
-	if ns.Error != "" {
+	if ns.HasError() {
 		log.Errorf("Received error from zedrouter for %s: %s\n",
 			uuidStr, ns.Error)
 		status.SetErrorWithSource(ns.Error, types.AppNetworkStatus{},
@@ -1193,7 +1193,7 @@ func doInactivateHalt(ctx *zedmanagerContext,
 		}
 	}
 	// Ignore errors during a halt
-	if ds.Error != "" {
+	if ds.HasError() {
 		log.Warnf("doInactivateHalt sees error from domainmgr for %s: %s\n",
 			uuidStr, ds.Error)
 	}

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -490,7 +490,7 @@ func handleCreate(ctxArg interface{}, key string,
 	publishAppInstanceStatus(ctx, &status)
 
 	// if some error, return
-	if status.Error != "" {
+	if status.HasError() {
 		log.Errorf("AppInstance(Name:%s, UUID:%s): Errors in App Instance "+
 			"Create. Error: %s",
 			config.DisplayName, config.UUIDandVersion.UUID, status.Error)

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -487,10 +487,6 @@ func handleCreate(ctxArg interface{}, key string,
 		errStr := "Invalid Cpu count - 0\n"
 		status.Error += errStr
 	}
-	if status.Error != "" {
-		status.SetError(status.Error, "Zedmanager Create Handler",
-			time.Now())
-	}
 	publishAppInstanceStatus(ctx, &status)
 
 	// if some error, return
@@ -601,7 +597,7 @@ func handleModify(ctxArg interface{}, key string,
 	} else if needRestart {
 		errStr := "Need restart due to change but not a restartCmd"
 		log.Errorf("handleModify(%s) failed: %s", status.Key(), errStr)
-		status.SetError(errStr, "", time.Now())
+		status.SetError(errStr, time.Now())
 		publishAppInstanceStatus(ctx, status)
 		return
 	}
@@ -619,7 +615,7 @@ func handleModify(ctxArg interface{}, key string,
 	} else if needPurge {
 		errStr := "Need purge due to change but not a purgeCmd"
 		log.Errorf("handleModify(%s) failed: %s", status.Key(), errStr)
-		status.SetError(errStr, "", time.Now())
+		status.SetError(errStr, time.Now())
 		publishAppInstanceStatus(ctx, status)
 		return
 	}

--- a/pkg/pillar/cmd/zedrouter/probe.go
+++ b/pkg/pillar/cmd/zedrouter/probe.go
@@ -123,7 +123,7 @@ func niProbingUpdatePort(ctx *zedrouterContext, port types.NetworkPortStatus,
 	netstatus *types.NetworkInstanceStatus) bool {
 	var needTrigPing bool
 	log.Debugf("niProbingUpdatePort: %s, type %v, enter\n", netstatus.BridgeName, netstatus.Type)
-	if netstatus.Error != "" {
+	if netstatus.HasError() {
 		log.Errorf("niProbingUpdatePort: Network instance is in errored state: %s",
 			netstatus.Error)
 		return needTrigPing

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -1077,7 +1077,7 @@ func handleAppNetworkCreate(ctxArg interface{}, key string, configArg interface{
 	status.PendingAdd = false
 	publishAppNetworkStatus(ctx, &status)
 	log.Infof("handleAppNetworkCreate done for %s\n", config.DisplayName)
-	if status.Error != "" && config.Activate && !status.Activated {
+	if status.HasError() && config.Activate && !status.Activated {
 		releaseAppNetworkResources(ctx, key, &status)
 	}
 	log.Infof("handleAppNetworkCreate(%s) done\n", key)
@@ -1210,7 +1210,7 @@ func appNetworkDoActivateUnderlayNetwork(
 		addError(ctx, status, "doActivate underlay", err)
 		return
 	}
-	if netInstStatus.Error != "" {
+	if netInstStatus.HasError() {
 		log.Errorf("doActivate sees network error %s\n",
 			netInstStatus.Error)
 		addError(ctx, status, "error from network instance",
@@ -1373,7 +1373,7 @@ func appNetworkDoActivateOverlayNetwork(
 		addError(ctx, status, "handlecreate overlay", err)
 		return
 	}
-	if netInstStatus.Error != "" {
+	if netInstStatus.HasError() {
 		log.Errorf("doActivate sees network error %s\n",
 			netInstStatus.Error)
 		addError(ctx, status, "netstatus.Error",
@@ -1811,7 +1811,7 @@ func checkAndRecreateAppNetwork(
 		}
 		log.Infof("checkAndRecreateAppNetwork(%s) recreating for %s\n",
 			network.String(), status.DisplayName)
-		if status.Error != "" {
+		if status.HasError() {
 			log.Infof("checkAndRecreateAppNetwork(%s) remove error %s for %s\n",
 				network.String(), status.Error,
 				status.DisplayName)
@@ -2020,7 +2020,7 @@ func handleAppNetworkModify(ctxArg interface{}, key string, configArg interface{
 	publishAppNetworkStatus(ctx, status)
 	log.Infof("handleAppNetworkModify done for %s\n", config.DisplayName)
 
-	if status != nil && status.Error != "" &&
+	if status != nil && status.HasError() &&
 		config.Activate && !status.Activated {
 		releaseAppNetworkResources(ctx, key, status)
 	}
@@ -2877,7 +2877,7 @@ func validateAppNetworkConfig(ctx *zedrouterContext, appNetConfig types.AppNetwo
 		// XXX can an delete+add of app instance with same
 		// portmap result in a failure?
 		if appNetStatus.DisplayName == appNetStatus1.DisplayName ||
-			(appNetStatus1.Error != "" && !appNetStatus1.Activated) || len(ulCfgList1) == 0 {
+			(appNetStatus1.HasError() && !appNetStatus1.Activated) || len(ulCfgList1) == 0 {
 			continue
 		}
 		if checkUnderlayNetworkForPortMapOverlap(ctx, appNetStatus, ulCfgList0, ulCfgList1) {
@@ -2969,8 +2969,7 @@ func checkAppNetworkErrorAndStartTimer(ctx *zedrouterContext) {
 	for _, st := range items {
 		status := st.(types.AppNetworkStatus)
 		config := lookupAppNetworkConfig(ctx, status.Key())
-		if config == nil || !config.Activate ||
-			status.Error == "" {
+		if config == nil || !config.Activate || !status.HasError() {
 			continue
 		}
 		// We wouldn't have even copied underlay/overlay
@@ -2994,8 +2993,7 @@ func scanAppNetworkStatusInErrorAndUpdate(ctx *zedrouterContext) {
 	for _, st := range items {
 		status := st.(types.AppNetworkStatus)
 		config := lookupAppNetworkConfig(ctx, status.Key())
-		if config == nil || !config.Activate ||
-			status.Error == "" {
+		if config == nil || !config.Activate || !status.HasError() {
 			continue
 		}
 		// called from the timer, run the AppNetworkCreate to retry

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -1815,8 +1815,7 @@ func checkAndRecreateAppNetwork(
 			log.Infof("checkAndRecreateAppNetwork(%s) remove error %s for %s\n",
 				network.String(), status.Error,
 				status.DisplayName)
-			status.Error = ""
-			status.ErrorTime = time.Time{}
+			status.ClearError()
 		}
 		doActivate(ctx, *config, &status)
 		log.Infof("checkAndRecreateAppNetwork done for %s\n",
@@ -1930,7 +1929,8 @@ func getUlAddrs(ctx *zedrouterContext,
 func addError(ctx *zedrouterContext,
 	status *types.AppNetworkStatus, tag string, err error) {
 
-	log.Infof("%s: %s\n", tag, err.Error())
+	log.Errorf("%s: %s\n", tag, err.Error())
+	// XXX The use of appendError() could be more normalized
 	status.Error = appendError(status.Error, tag, err.Error())
 	status.ErrorTime = time.Now()
 	publishAppNetworkStatus(ctx, status)
@@ -1950,8 +1950,7 @@ func handleAppNetworkModify(ctxArg interface{}, key string, configArg interface{
 	log.Infof("handleAppNetworkModify(%v) for %s\n",
 		config.UUIDandVersion, config.DisplayName)
 	// reset error status and mark pending modify as true
-	status.Error = ""
-	status.ErrorTime = time.Time{}
+	status.ClearError()
 	status.PendingModify = true
 	publishAppNetworkStatus(ctx, status)
 

--- a/pkg/pillar/types/certinfotypes.go
+++ b/pkg/pillar/types/certinfotypes.go
@@ -6,7 +6,6 @@ package types
 import (
 	"encoding/hex"
 	zcert "github.com/lf-edge/eve/api/go/certs"
-	"time"
 )
 
 // ControllerCert : controller certicate
@@ -16,24 +15,11 @@ type ControllerCert struct {
 	Type     zcert.ZCertType
 	Cert     []byte
 	CertHash []byte
-	ErrorInfo
+	// ErrorAndTime provides SetErrorNow() and ClearError()
+	ErrorAndTime
 }
 
 // Key :
 func (cert *ControllerCert) Key() string {
 	return hex.EncodeToString(cert.CertHash)
-}
-
-// SetErrorInfo : sets errorinfo on the controller cert
-func (cert *ControllerCert) SetErrorInfo(agentName, errStr string) {
-	cert.Error = errStr
-	cert.ErrorTime = time.Now()
-	cert.ErrorSource = agentName
-}
-
-// ClearErrorInfo : clears errorinfo on the controller cert
-func (cert *ControllerCert) ClearErrorInfo() {
-	cert.Error = ""
-	cert.ErrorSource = ""
-	cert.ErrorTime = time.Time{}
 }

--- a/pkg/pillar/types/cipherinfotypes.go
+++ b/pkg/pillar/types/cipherinfotypes.go
@@ -5,7 +5,6 @@ package types
 
 import (
 	zconfig "github.com/lf-edge/eve/api/go/config"
-	"time"
 )
 
 // CipherContext : a pair of device and controller certificate
@@ -20,26 +19,13 @@ type CipherContext struct {
 	DeviceCertHash     []byte
 	ControllerCert     []byte // resolved through cert API
 	DeviceCert         []byte // local device certificate
-	ErrorInfo
+	// ErrorAndTime provides SetErrorNow() and ClearError()
+	ErrorAndTime
 }
 
 // Key :
 func (status *CipherContext) Key() string {
 	return status.ContextID
-}
-
-// SetErrorInfo : sets errorinfo on the cipher context status object
-func (status *CipherContext) SetErrorInfo(agentName, strErr string) {
-	status.Error = strErr
-	status.ErrorTime = time.Now()
-	status.ErrorSource = agentName
-}
-
-// ClearErrorInfo : clears errorinfo on the cipher context status object
-func (status *CipherContext) ClearErrorInfo() {
-	status.Error = ""
-	status.ErrorSource = ""
-	status.ErrorTime = time.Time{}
 }
 
 // CipherBlockStatus : Object specific encryption information
@@ -54,24 +40,11 @@ type CipherBlockStatus struct {
 	CipherData        []byte
 	ClearTextHash     []byte
 	IsCipher          bool
-	ErrorInfo
+	// ErrorAndTime provides SetErrorNow() and ClearError()
+	ErrorAndTime
 }
 
 // Key :
 func (status *CipherBlockStatus) Key() string {
 	return status.CipherBlockID
-}
-
-// SetErrorInfo : sets errorinfo on the cipher block status object
-func (status *CipherBlockStatus) SetErrorInfo(agentName, errStr string) {
-	status.Error = errStr
-	status.ErrorTime = time.Now()
-	status.ErrorSource = agentName
-}
-
-// ClearErrorInfo : clears errorinfo on the cipher block status object
-func (status *CipherBlockStatus) ClearErrorInfo() {
-	status.Error = ""
-	status.ErrorSource = ""
-	status.ErrorTime = time.Time{}
 }

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -120,12 +120,12 @@ type DomainStatus struct {
 	VncDisplay         uint32
 	VncPasswd          string
 	TriedCount         int
-	LastErr            string // Xen error
-	LastErrTime        time.Time
-	BootFailed         bool
-	AdaptersFailed     bool
-	IsContainer        bool              // Is this Domain for a Container?
-	EnvVariables       map[string]string // List of environment variables to be set in container
+	// ErrorAndTime provides SetErrorNow() and ClearError()
+	ErrorAndTime
+	BootFailed     bool
+	AdaptersFailed bool
+	IsContainer    bool              // Is this Domain for a Container?
+	EnvVariables   map[string]string // List of environment variables to be set in container
 }
 
 func (status DomainStatus) Key() string {

--- a/pkg/pillar/types/downloadertypes.go
+++ b/pkg/pillar/types/downloadertypes.go
@@ -66,9 +66,9 @@ type DownloaderStatus struct {
 	Size             uint64  // Once DOWNLOADED; in bytes
 	Progress         uint    // In percent i.e., 0-100
 	ModTime          time.Time
-	LastErr          string // Download error
-	LastErrTime      time.Time
-	RetryCount       int
+	// ErrorAndTime provides SetErrorNow() and ClearError()
+	ErrorAndTime
+	RetryCount int
 }
 
 func (status DownloaderStatus) Key() string {
@@ -101,18 +101,6 @@ func (status DownloaderStatus) Pending() bool {
 	return status.PendingAdd || status.PendingModify || status.PendingDelete
 }
 
-// SetErrorInfo : Set Error Information for DownloaderStatus
-func (status *DownloaderStatus) SetErrorInfo(errStr string) {
-	status.LastErr = errStr
-	status.LastErrTime = time.Now()
-}
-
-// ClearErrorInfo : Clear Error Information for DownloaderStatus
-func (status *DownloaderStatus) ClearErrorInfo() {
-	status.LastErr = ""
-	status.LastErrTime = time.Time{}
-}
-
 // ClearPendingStatus : Clear Pending Status for DownloaderStatus
 func (status *DownloaderStatus) ClearPendingStatus() {
 	if status.PendingAdd {
@@ -125,7 +113,7 @@ func (status *DownloaderStatus) ClearPendingStatus() {
 
 // HandleDownloadFail : Do Failure specific tasks
 func (status *DownloaderStatus) HandleDownloadFail(errStr string) {
-	status.SetErrorInfo(errStr)
+	status.SetErrorNow(errStr)
 	status.ClearPendingStatus()
 }
 
@@ -205,7 +193,8 @@ type ResolveStatus struct {
 	Name        string
 	ImageSha256 string
 	Counter     uint32
-	ErrorInfo
+	// ErrorAndTime provides SetErrorNow() and ClearError()
+	ErrorAndTime
 }
 
 // Key : DatastoreID, name and sequence counter are used
@@ -223,18 +212,4 @@ func (status ResolveStatus) VerifyFilename(fileName string) bool {
 			fileName, expect)
 	}
 	return ret
-}
-
-// SetErrorInfo : sets errorinfo on the app image resolve status object
-func (status *ResolveStatus) SetErrorInfo(agentName, errStr string) {
-	status.Error = errStr
-	status.ErrorTime = time.Now()
-	status.ErrorSource = agentName
-}
-
-// ClearErrorInfo : clears errorinfo on the app image resolve status object
-func (status *ResolveStatus) ClearErrorInfo() {
-	status.Error = ""
-	status.ErrorSource = ""
-	status.ErrorTime = time.Time{}
 }

--- a/pkg/pillar/types/errortime.go
+++ b/pkg/pillar/types/errortime.go
@@ -36,6 +36,11 @@ func (etPtr *ErrorAndTime) ClearError() {
 	etPtr.ErrorTime = time.Time{}
 }
 
+// HasError returns true if there is an error
+func (etPtr *ErrorAndTime) HasError() bool {
+	return etPtr.Error != ""
+}
+
 // ErrorAndTimeWithSource has an additional field "ErrorSourceType"
 // which is used to selectively clear errors by calling IsErrorSource before
 // calling ClearErrorWithSource. See zedmanager and volumemgr for example use.
@@ -69,7 +74,7 @@ func (etsPtr *ErrorAndTimeWithSource) IsErrorSource(source interface{}) bool {
 	if !allowedSourceType(source) {
 		log.Fatalf("Bad ErrorSourceType %T", source)
 	}
-	if etsPtr.Error == "" {
+	if !etsPtr.HasError() {
 		return false
 	}
 	return reflect.TypeOf(source) == reflect.TypeOf(etsPtr.ErrorSourceType)
@@ -80,6 +85,11 @@ func (etsPtr *ErrorAndTimeWithSource) ClearErrorWithSource() {
 	etsPtr.Error = ""
 	etsPtr.ErrorSourceType = nil
 	etsPtr.ErrorTime = time.Time{}
+}
+
+// HasError returns true if there is an error
+func (etsPtr *ErrorAndTimeWithSource) HasError() bool {
+	return etsPtr.Error != ""
 }
 
 // Disallow leaf types and pointers, since pointers

--- a/pkg/pillar/types/errortime.go
+++ b/pkg/pillar/types/errortime.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"reflect"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// Common error with timestamp
+
+// ErrorAndTime is used by many EVE agents
+type ErrorAndTime struct {
+	Error     string
+	ErrorTime time.Time
+}
+
+// SetErrorNow uses the current time
+func (etPtr *ErrorAndTime) SetErrorNow(errStr string) {
+	etPtr.Error = errStr
+	etPtr.ErrorTime = time.Now()
+}
+
+// SetError is when time is specified
+func (etPtr *ErrorAndTime) SetError(errStr string, errorTime time.Time) {
+	etPtr.Error = errStr
+	etPtr.ErrorTime = errorTime
+}
+
+// ClearError removes it
+func (etPtr *ErrorAndTime) ClearError() {
+	etPtr.Error = ""
+	etPtr.ErrorTime = time.Time{}
+}
+
+// ErrorAndTimeWithSource has an additional field "ErrorSourceType"
+// which is used to selectively clear errors by calling IsErrorSource before
+// calling ClearErrorWithSource. See zedmanager and volumemgr for example use.
+type ErrorAndTimeWithSource struct {
+	ErrorSourceType interface{}
+	Error           string
+	ErrorTime       time.Time
+}
+
+// SetError - Sets error state with no source type
+func (etsPtr *ErrorAndTimeWithSource) SetError(errStr string, errTime time.Time) {
+	etsPtr.Error = errStr
+	etsPtr.ErrorSourceType = nil
+	etsPtr.ErrorTime = errTime
+}
+
+// SetErrorWithSource - Sets error state. Source needs to be a type
+func (etsPtr *ErrorAndTimeWithSource) SetErrorWithSource(errStr string,
+	source interface{}, errTime time.Time) {
+
+	if !allowedSourceType(source) {
+		log.Fatalf("Bad ErrorSourceType %T", source)
+	}
+	etsPtr.Error = errStr
+	etsPtr.ErrorSourceType = source
+	etsPtr.ErrorTime = errTime
+}
+
+// IsErrorSource returns true if the source type matches
+func (etsPtr *ErrorAndTimeWithSource) IsErrorSource(source interface{}) bool {
+	if !allowedSourceType(source) {
+		log.Fatalf("Bad ErrorSourceType %T", source)
+	}
+	if etsPtr.Error == "" {
+		return false
+	}
+	return reflect.TypeOf(source) == reflect.TypeOf(etsPtr.ErrorSourceType)
+}
+
+// ClearErrorWithSource - Clears error state
+func (etsPtr *ErrorAndTimeWithSource) ClearErrorWithSource() {
+	etsPtr.Error = ""
+	etsPtr.ErrorSourceType = nil
+	etsPtr.ErrorTime = time.Time{}
+}
+
+// Disallow leaf types and pointers, since pointers
+// and their struct types do not compare as equal
+func allowedSourceType(source interface{}) bool {
+	// Catch common mistakes like a string
+	switch source.(type) {
+	case int:
+		return false
+	case string:
+		return false
+	case bool:
+		return false
+	}
+	val := reflect.ValueOf(source)
+	if val.Kind() == reflect.Ptr {
+		return false
+	}
+	return true
+}

--- a/pkg/pillar/types/vaultmgrtypes.go
+++ b/pkg/pillar/types/vaultmgrtypes.go
@@ -5,15 +5,14 @@ package types
 
 import (
 	"github.com/lf-edge/eve/api/go/info"
-	"time"
 )
 
 //VaultStatus represents running status of a Vault
 type VaultStatus struct {
-	Name      string
-	Status    info.DataSecAtRestStatus
-	Error     string
-	ErrorTime time.Time
+	Name   string
+	Status info.DataSecAtRestStatus
+	// ErrorAndTime provides SetErrorNow() and ClearError()
+	ErrorAndTime
 }
 
 //Key returns the key used for indexing into a list of vaults

--- a/pkg/pillar/types/verifiertypes.go
+++ b/pkg/pillar/types/verifiertypes.go
@@ -83,9 +83,9 @@ type VerifyImageStatus struct {
 	PendingDelete bool
 	IsContainer   bool    // Is this image for a Container?
 	State         SwState // DELIVERED; LastErr* set if failed
-	LastErr       string  // Verification error
-	LastErrTime   time.Time
-	RefCount      uint
+	// ErrorAndTime provides SetErrorNow() and ClearError()
+	ErrorAndTime
+	RefCount uint
 }
 
 // The VerifyStatus is shared between VerifyImageStatus and PersistImageStatus

--- a/pkg/pillar/types/volumes.go
+++ b/pkg/pillar/types/volumes.go
@@ -182,11 +182,10 @@ type VolumeStatus struct {
 
 	WaitingForCerts bool
 
-	State       SwState // DOWNLOADED etc
-	Progress    uint    // In percent i.e., 0-100
-	ErrorSource string  // typename for Downloader, Verifier, etc
-	LastErr     string
-	LastErrTime time.Time
+	State    SwState // DOWNLOADED etc
+	Progress uint    // In percent i.e., 0-100
+	// ErrorAndTimeWithSource provides SetError, SetErrrorWithSource, etc
+	ErrorAndTimeWithSource
 
 	FileLocation string // Current location; should be info about file
 

--- a/pkg/pillar/types/zedagenttypes.go
+++ b/pkg/pillar/types/zedagenttypes.go
@@ -170,7 +170,7 @@ func (status CertObjStatus) getCertStatus(certURL string) (bool, bool, ErrorAndT
 	for _, certObj := range status.StorageStatusList {
 		if certObj.Name == certURL {
 			installed := true
-			if certObj.Error != "" || certObj.State != INSTALLED {
+			if certObj.HasError() || certObj.State != INSTALLED {
 				installed = false
 			}
 			// An Error in StorageStatus can be from

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -1035,6 +1035,7 @@ type OverlayNetworkConfig struct {
 	AppIPAddr     net.IP           // EIDv4 or EIDv6
 	Network       uuid.UUID        // Points to a NetworkInstance.
 
+	// XXX Shouldn't we use ErrorAndTime here
 	// Error
 	//	If there is a parsing error and this uLNetwork config cannot be
 	//	processed, set the error here. This allows the error to be propagated
@@ -1078,6 +1079,7 @@ type UnderlayNetworkConfig struct {
 	AppIPAddr  net.IP           // If set use DHCP to assign to app
 	IntfOrder  int32            // XXX need to get from API
 
+	// XXX Shouldn't we use ErrorAndTime here
 	// Error
 	//	If there is a parsing error and this uLNetwork config cannot be
 	//	processed, set the error here. This allows the error to be propagated

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -112,8 +112,8 @@ type AppNetworkStatus struct {
 	UnderlayNetworkList []UnderlayNetworkStatus
 	MissingNetwork      bool // If any Missing flag is set in the networks
 	// Any errros from provisioning the network
-	Error     string
-	ErrorTime time.Time
+	// ErrorAndTime provides SetErrorNow() and ClearError()
+	ErrorAndTime
 }
 
 func (status AppNetworkStatus) Key() string {
@@ -430,8 +430,8 @@ type NetworkPortStatus struct {
 	NetworkXObjectConfig
 	AddrInfoList []AddrInfo
 	ProxyConfig
-	Error     string
-	ErrorTime time.Time
+	// ErrorAndTime provides SetErrorNow() and ClearError()
+	ErrorAndTime
 }
 
 type AddrInfo struct {
@@ -1131,8 +1131,8 @@ type NetworkXObjectConfig struct {
 	Proxy           *ProxyConfig
 	WirelessCfg     WirelessConfig
 	// Any errrors from the parser
-	Error     string
-	ErrorTime time.Time
+	// ErrorAndTime provides SetErrorNow() and ClearError()
+	ErrorAndTime
 }
 
 type IpRange struct {
@@ -1165,8 +1165,8 @@ type NetworkInstanceInfo struct {
 	Ipv4Eid bool // Track if this is a CryptoEid with IPv4 EIDs
 
 	// Any errrors from provisioning the network
-	Error     string
-	ErrorTime time.Time
+	// ErrorAndTime provides SetErrorNow() and ClearError()
+	ErrorAndTime
 
 	// Vif metric map. This should have a union of currently existing
 	// vifs and previously deleted vifs.
@@ -1509,13 +1509,6 @@ func (status *NetworkInstanceStatus) UpdateBridgeMetrics(
 		netMetric.TxAclRateLimitDrops += bridgeMetric.TxAclRateLimitDrops
 		netMetric.RxAclRateLimitDrops += bridgeMetric.RxAclRateLimitDrops
 	}
-}
-
-func (status *NetworkInstanceStatus) SetError(err error) {
-	log.Errorln(err.Error())
-	status.Error = err.Error()
-	status.ErrorTime = time.Now()
-	return
 }
 
 // Returns true if found

--- a/pkg/pillar/utils/cipherutils.go
+++ b/pkg/pillar/utils/cipherutils.go
@@ -88,8 +88,7 @@ func GetCipherData(agentName string, status types.CipherBlockStatus,
 func handleCipherBlockCredError(agentName string, status *types.CipherBlockStatus,
 	decBlock zconfig.EncryptionBlock, err error) (types.CipherBlockStatus, zconfig.EncryptionBlock, error) {
 	if err != nil {
-		errStr := fmt.Sprintf("%v", err)
-		status.SetErrorInfo(agentName, errStr)
+		status.SetErrorNow(err.Error())
 		// we have already captured the error info above
 		// for valid encryption block info, reset the error to proceed
 		if !reflect.DeepEqual(decBlock, zconfig.EncryptionBlock{}) {
@@ -103,8 +102,7 @@ func handleCipherBlockCredError(agentName string, status *types.CipherBlockStatu
 func handleCipherBlockError(agentName string, status *types.CipherBlockStatus,
 	data *string, err error) (types.CipherBlockStatus, *string, error) {
 	if err != nil {
-		errStr := fmt.Sprintf("%v", err)
-		status.SetErrorInfo(agentName, errStr)
+		status.SetErrorNow(err.Error())
 		// we have already captured the error info above
 		// for valid data, reset the error to proceed
 		if data != nil {


### PR DESCRIPTION
The only utility of the ErrorSource field is for zedmanager and volumemgr to be able to know the origin (in the form of another agent providing some *Status type) of an error so that the global error for a AppInstance can be cleared when that agent/*Status provides an update, without accidentally clearing an errror provided by another agent and another *Status struct.

However, the code has grown is setting and passing of this field in different ways.
In some places and agentName is used, and in other cases it looks like a human readable string. However, none of those are acted on by any of the EVE agents, and ErrorSource is never passed to the controller.

Hence this is just unneeded complexity and should be removed.
To ensure that the intended and useful use it not misappropriated in the future this PR changes 'ErrorSource string' to 'ErrorSourceType interface{}'. and requires that this is the name of a go datastucture.