### PR TITLE
Regularizing Makefile structure and adding GCP image generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ git clone https://github.com/lf-edge/eve.git
 cd eve
 ```
 
+#### Build Project EVE
+
 Build both the build-tools as well as the live image in the source directory:
 
 ```sh
@@ -89,8 +91,10 @@ make live
 This will download the relevant docker images from docker hub and create a bootable
 image `dist/<ARCH>/live.img`.
 
-Please note that not all containers will be fetched from Docker Hub.
-`mkimage-raw-efi` in particular will be built.
+Since almost all developer workflow is driven by the Makefile, it may be useful
+to familiarize yourself with various Makefile targets that Project EVE offers.
+A short summary of those is available by simply running make without any arguments
+`make` and a more detailed explanation [is available as part of our documentation](docs/BUILD.md)
 
 > **_NOTE:_** Since the initial build fetches a LOT of bits
 > over the network it may occasionally time out and fail. Typically

--- a/README.md
+++ b/README.md
@@ -178,15 +178,12 @@ Raspberry Pi 4 is a tiny, but capable enough ARM board that allows EVE to run wi
 Since a full Raspberry Pi 4 support is only available in upstream Linux kernels starting from 5.6.0, you'll have to use that bleeding edge kernel for your build. Another peculiar aspect of this board is that it doesn't use a standard [bootloader (e.g. u-boot or UEFI)](https://www.raspberrypi.org/documentation/configuration/boot_folder.md) so we need to trick it into using our own u-boot as UEFI environment. Thankfully, our Makefile logic tries to automate as much of it as possible. Thus, putting it all together, here are the steps to run EVE on Raspberry Pi 4:
 
 1. Make sure you have a clean build directory (since this is a non-standard build) `rm -rf dist/arm64`
-2. Build a live image `make ZARCH=arm64 MEDIA_SIZE=15000 live.rpi` (you should replace MEDIA_SIZE with the value that corresponds to the size of your SD card in MB -- keep in mind that because of flash wear, the actual size may be smaller than what is advertised by the manufacturer e.g  15000 is a reasonable value for a card that is advertised as 16G)
-3. Flash the `dist/arm64/live.rpi` live EVE image onto your SD card by [following these instructions](#how-to-write-eve-image-and-installer-onto-an-sd-card-or-an-installer-medium)
-4. Always make sure to verify the image by running `gdisk /dev/XXX` and picking 'v' option
-
-Step #4 is extermely important and can NOT be skipped (otherwise you will end up with and EVE image that can NOT be upgraded).
+2. Build a live image `make ZARCH=arm64 HV=rpi-kvm live-raw`
+3. Flash the `dist/arm64/live.raw` live EVE image onto your SD card by [following these instructions](#how-to-write-eve-image-and-installer-onto-an-sd-card-or-an-installer-medium)
 
 Once your Raspberry Pi 4 is happily running an EVE image you can start using EVE controller for further updates (so that you don't ever have to take an SD card out of your board). Build your rootfs by running `make ZARCH=arm64 rootfs-kvm-rpi` and give resulting `dist/arm64/installer/rootfs.img` to the controller.
 
-You may notice that the Makefile logic doesn't produce regular devicetree blob for Raspberry Pi 4 and only enables it to run in KVM hypervisor mode. Both of these may change in the future as we evolve support for this board, but for now you just need to keep this in mind and alway build `live.rpi` instead of `live.img` (the default live image of EVE).
+You may notice that the Makefile logic doesn't produce regular devicetree blob for Raspberry Pi 4 and only enables it to run in KVM hypervisor mode. Both of these may change in the future as we evolve support for this board, but for now you just need to keep this in mind and alway build with a special option `HV=rpi-kvm`.
 
 One final note about Raspberry Pi 4 GPU support is that since we are running EVE in 64bit (aarch64) mode we are still waiting for the proper [VC4 DRM BCM2711 drivers](https://lore.kernel.org/dri-devel/cover.6c896ace9a5a7840e9cec008b553cbb004ca1f91.1582533919.git-series.maxime@cerno.tech/T/#m0275b55e1518be1fb2154d3c95e13c1b7de1f347) to be upstreamed. Currently it is expected that Kernel 5.7 may actually ship the fully functional driver.
 

--- a/build-tools/src/scripts/Dockerfile
+++ b/build-tools/src/scripts/Dockerfile
@@ -8,7 +8,7 @@ ARG GID
 # so we need to declare it explicitly
 # this must be an ARG so it doesn't carry through post-build phase
 ARG all_proxy
-RUN apk add --no-cache openssh-client git gcc linux-headers libc-dev util-linux libpcap-dev bash vim make protobuf protobuf-dev sudo
+RUN apk add --no-cache openssh-client git gcc linux-headers libc-dev util-linux libpcap-dev bash vim make protobuf protobuf-dev sudo tar
 RUN deluser ${USER} ; delgroup ${GROUP} || :
 RUN sed -ie /:${UID}:/d /etc/passwd /etc/shadow ; sed -ie /:${GID}:/d /etc/group || :
 RUN addgroup -g ${GID} ${GROUP} && adduser -h /home/${USER} -G ${GROUP} -D -H -u ${UID} ${USER}

--- a/images/rootfs-kvm-rpi.yml.in.patch
+++ b/images/rootfs-kvm-rpi.yml.in.patch
@@ -1,0 +1,1 @@
+rootfs-rpi-kvm.yml.in.patch


### PR DESCRIPTION
This is the final piece of the puzzle that gets rid of all the special casing for RPi in our Makefile (the only two left are CONF_FILES and PART_SPEC and even those are likely to go away real soon now).

This also introduces a new target called live-gcp that generates a Google Cloud compatible live EVE image. That, in turn, enables the following workflow:

```
make live-gcp
linuxkit push gcp -img-name live-eve -bucket lf-edge-eve -project zededa-sandbox -nested-virt dist/amd64/live.img.tar.gz
linuxkit run gcp -project zededa-sandbox -zone us-west1-a -machine n1-standard-2 live-eve
```

Not sure if it makes sense to wrap the two commands in a makefile target of some kind, but it seems to work as is (maybe we should teach linuxkit to take those values from some local configuration file instead -- what do you think @deitch ?)