### PR TITLE
pass UUID for baseos volumes to fix file already exists

### DIFF
--- a/pkg/pillar/cmd/baseosmgr/handledownload.go
+++ b/pkg/pillar/cmd/baseosmgr/handledownload.go
@@ -19,9 +19,10 @@ import (
 var nilUUID uuid.UUID
 
 func checkVolumeStatus(ctx *baseOsMgrContext,
-	uuidStr string, config []types.StorageConfig,
+	baseOsUUID uuid.UUID, config []types.StorageConfig,
 	status []types.StorageStatus) *types.RetStatus {
 
+	uuidStr := baseOsUUID.String()
 	ret := &types.RetStatus{}
 	log.Infof("checkVolumeStatus for %s\n", uuidStr)
 
@@ -48,14 +49,14 @@ func checkVolumeStatus(ctx *baseOsMgrContext,
 
 		if !ss.HasVolumemgrRef {
 			log.Infof("checkVolumeStatus %s, !HasVolumemgrRef\n", sc.ImageID)
-			// XXX This means using only the sha as key
+			// We use the baseos object UUID as appInstID here
 			AddOrRefcountVolumeConfig(ctx, ss.ImageSha256,
-				nilUUID, ss.ImageID, *ss)
+				baseOsUUID, ss.ImageID, *ss)
 			ss.HasVolumemgrRef = true
 			ret.Changed = true
 		}
-		// XXX This means using only the sha as key
-		vs := lookupVolumeStatus(ctx, ss.ImageSha256, nilUUID, ss.ImageID)
+		// We use the baseos object UUID as appInstID here
+		vs := lookupVolumeStatus(ctx, ss.ImageSha256, baseOsUUID, ss.ImageID)
 		if vs == nil || vs.RefCount == 0 {
 			if vs == nil {
 				log.Infof("VolumeStatus not found. name: %s",

--- a/pkg/pillar/cmd/baseosmgr/handlevolumemgr.go
+++ b/pkg/pillar/cmd/baseosmgr/handlevolumemgr.go
@@ -13,6 +13,7 @@ import (
 
 // AddOrRefcountVolumeConfig makes sure we have a VolumeConfig with a non-zero
 // RefCount
+// We use the baseos object UUID as appInstID here
 func AddOrRefcountVolumeConfig(ctx *baseOsMgrContext, blobSha256 string,
 	appInstID uuid.UUID, volumeID uuid.UUID, ss types.StorageStatus) {
 
@@ -65,6 +66,7 @@ func AddOrRefcountVolumeConfig(ctx *baseOsMgrContext, blobSha256 string,
 
 // MaybeRemoveVolumeConfig decreases the RefCount and deletes the VolumeConfig
 // when the RefCount reaches zero
+// We use the baseos object UUID as appInstID here
 func MaybeRemoveVolumeConfig(ctx *baseOsMgrContext, blobSha256 string,
 	appInstID uuid.UUID, volumeID uuid.UUID) {
 
@@ -104,6 +106,7 @@ func lookupVolumeConfig(ctx *baseOsMgrContext, key string) *types.VolumeConfig {
 }
 
 // Note that this function returns the entry even if Pending* is set.
+// We use the baseos object UUID as appInstID here
 func lookupVolumeStatus(ctx *baseOsMgrContext, blobSha256 string,
 	appInstID uuid.UUID, volumeID uuid.UUID) *types.VolumeStatus {
 


### PR DESCRIPTION
To fix error when we switch back and forth between two eveimage versions in the tests.
Error is
volumemgr: Can not create /persist/img/124D84621595E65A61AA95C42BB4DFE1AD102A46F673D05F7F31FAEE31F025DD-00000000-0000-0000-0000-000000000000.qcow2 for 124D84621595E65A61AA95C42BB4DFE1AD102A46F673D05F7F31FAEE31F025DD+00000000-0000-0000-0000-000000000000: exists

