### PR TITLE
Changet DevicePortConfig.GetPortByIfName() to return a pointer to port

### DIFF
--- a/pkg/pillar/devicenetwork/devicenetwork.go
+++ b/pkg/pillar/devicenetwork/devicenetwork.go
@@ -7,6 +7,13 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"reflect"
+	"strings"
+	"time"
+
 	"github.com/eriknordmark/ipinfo"
 	"github.com/eriknordmark/netlink"
 	zconfig "github.com/lf-edge/eve/api/go/config"
@@ -15,12 +22,6 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/utils"
 	"github.com/lf-edge/eve/pkg/pillar/zedcloud"
 	log "github.com/sirupsen/logrus"
-	"io/ioutil"
-	"net"
-	"os"
-	"reflect"
-	"strings"
-	"time"
 )
 
 const (
@@ -55,9 +56,9 @@ func makeDevicePortConfig(ctx *DeviceNetworkContext, ports []string, free []stri
 		}
 		config.Ports[ix].IsMgmt = true
 		config.Ports[ix].Dhcp = types.DT_CLIENT
-		port, err := ctx.DevicePortConfig.GetPortByIfName(u)
-		if err == nil {
-			config.Ports[ix].WirelessCfg = port.WirelessCfg
+		portPtr := ctx.DevicePortConfig.GetPortByIfName(u)
+		if portPtr != nil {
+			config.Ports[ix].WirelessCfg = portPtr.WirelessCfg
 		}
 	}
 	return config

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -158,15 +158,14 @@ type DevicePortConfigVersion uint32
 
 // GetPortByIfName - DevicePortConfig Methord to Get Port structure by IfName
 func (portConfig *DevicePortConfig) GetPortByIfName(
-	ifname string) (NetworkPortConfig, error) {
-	var port NetworkPortConfig
-	for _, port = range portConfig.Ports {
-		if ifname == port.IfName {
-			return port, nil
+	ifname string) *NetworkPortConfig {
+	for indx := range portConfig.Ports {
+		portPtr := &portConfig.Ports[indx]
+		if ifname == portPtr.IfName {
+			return portPtr
 		}
 	}
-	err := fmt.Errorf("DevicePortConfig can't find port %s", ifname)
-	return port, err
+	return nil
 }
 
 // When new fields and/or new semantics are added to DevicePortConfig a new


### PR DESCRIPTION
Changet DevicePortConfig.GetPortByIfName() to return a pointer to port
rather than copy of the port. This is needed for setting the per-port
errors.

Part of splitting up the PortErr diffs..

Signed-off-by: Kalyan Nidumolu <kalyan@zadeda.com>