### PR TITLE
restore default behavior of debug.enable.usb

### DIFF
--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -1727,6 +1727,14 @@ func parseConfigItems(config *zconfig.EdgeDevConfig, ctx *getconfigContext) {
 	//  value or retain the previous value.
 	gcPtr := &ctx.zedagentCtx.globalConfig
 	newGlobalConfig := types.DefaultConfigItemValueMap()
+	// Note: UsbAccess is special in that it has two defaults.
+	// When the device first boots the default is "true" as specified
+	// in the DefaultConfigItemValueMap. But when connecting to the
+	// controller, if the controller does not include the item, it
+	// should default to "false".
+	// That way bringup of new hardware models can be done using an
+	// attached keyboard.
+	newGlobalConfig.SetGlobalValueBool(types.UsbAccess, false)
 	newGlobalStatus := types.NewGlobalStatus()
 
 	for _, item := range items {

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -704,7 +704,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddIntItem(Dom0MinDiskUsagePercent, 20, 20, 0xFFFFFFFF)
 
 	// Add Bool Items
-	configItemSpecMap.AddBoolItem(UsbAccess, true)
+	configItemSpecMap.AddBoolItem(UsbAccess, true) // Controller likely default to false
 	configItemSpecMap.AddBoolItem(AllowAppVnc, false)
 	configItemSpecMap.AddBoolItem(IgnoreDiskCheckForApps, false)
 


### PR DESCRIPTION
This subtlety was missed in my code review of the ConfigItemMap work.

@cshari-zededa this bug explains the odd issue you saw yesterday; I saw the same thing later in the day.