### PR TITLE
Passing context id in cipher block instead of copying certs

### DIFF
--- a/pkg/pillar/cipher/cipher.go
+++ b/pkg/pillar/cipher/cipher.go
@@ -4,7 +4,7 @@
 // Common routines for cipher information handling
 // across multiple agents
 
-package utils
+package cipher
 
 import (
 	"encoding/base64"
@@ -14,7 +14,6 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	zconfig "github.com/lf-edge/eve/api/go/config"
-	"github.com/lf-edge/eve/pkg/pillar/cmd/tpmmgr"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	log "github.com/sirupsen/logrus"
 )
@@ -31,8 +30,8 @@ func getEncryptionBlock(
 }
 
 // GetCipherCredentials : decrypt encryption block
-func GetCipherCredentials(agentName string, status types.CipherBlockStatus) (types.CipherBlockStatus,
-	types.EncryptionBlock, error) {
+func GetCipherCredentials(ctx *DecryptCipherContext, agentName string,
+	status types.CipherBlockStatus) (types.CipherBlockStatus, types.EncryptionBlock, error) {
 	cipherBlock := new(types.CipherBlockStatus)
 	*cipherBlock = status
 	var decBlock types.EncryptionBlock
@@ -48,7 +47,7 @@ func GetCipherCredentials(agentName string, status types.CipherBlockStatus) (typ
 		err := errors.New(errStr)
 		return handleCipherBlockCredError(agentName, cipherBlock, decBlock, err)
 	}
-	clearBytes, err := tpmmgr.DecryptCipherBlock(*cipherBlock)
+	clearBytes, err := DecryptCipherBlock(ctx, *cipherBlock)
 	if err != nil {
 		log.Errorf("%s, cipherblock decryption failed, %v\n",
 			cipherBlock.Key(), err)
@@ -68,7 +67,7 @@ func GetCipherCredentials(agentName string, status types.CipherBlockStatus) (typ
 }
 
 // GetCipherData : decrypt plain text
-func GetCipherData(agentName string, status types.CipherBlockStatus,
+func GetCipherData(ctx *DecryptCipherContext, agentName string, status types.CipherBlockStatus,
 	data *string) (types.CipherBlockStatus, *string, error) {
 	cipherBlock := new(types.CipherBlockStatus)
 	*cipherBlock = status
@@ -84,7 +83,7 @@ func GetCipherData(agentName string, status types.CipherBlockStatus,
 		err := errors.New(errStr)
 		return handleCipherBlockError(agentName, cipherBlock, data, err)
 	}
-	clearBytes, err := tpmmgr.DecryptCipherBlock(*cipherBlock)
+	clearBytes, err := DecryptCipherBlock(ctx, *cipherBlock)
 	if err != nil {
 		log.Errorf("%s, cipherblock decryption failed, %v\n",
 			cipherBlock.Key(), err)

--- a/pkg/pillar/cipher/handlecipher.go
+++ b/pkg/pillar/cipher/handlecipher.go
@@ -1,0 +1,245 @@
+// Copyright (c) 2018-2019 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cipher
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io/ioutil"
+
+	zconfig "github.com/lf-edge/eve/api/go/config"
+	zcommon "github.com/lf-edge/eve/api/go/evecommon"
+	"github.com/lf-edge/eve/pkg/pillar/cmd/tpmmgr"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	log "github.com/sirupsen/logrus"
+)
+
+// DecryptCipherContext has subscriptions to controller certs
+// and cipher contexts for doing decryption
+type DecryptCipherContext struct {
+	SubControllerCert pubsub.Subscription
+	SubCipherContext  pubsub.Subscription
+}
+
+// look up controller cert
+func lookupControllerCert(ctx *DecryptCipherContext, key string) *types.ControllerCert {
+	log.Infof("lookupControllerCert(%s)\n", key)
+	sub := ctx.SubControllerCert
+	item, err := sub.Get(key)
+	if err != nil {
+		log.Errorf("lookupControllerCert(%s) not found\n", key)
+		return nil
+	}
+	status := item.(types.ControllerCert)
+	log.Infof("lookupControllerCert(%s) Done\n", key)
+	return &status
+}
+
+// look up cipher context
+func lookupCipherContext(ctx *DecryptCipherContext, key string) *types.CipherContext {
+	log.Infof("lookupCipherContext(%s)\n", key)
+	sub := ctx.SubCipherContext
+	item, err := sub.Get(key)
+	if err != nil {
+		log.Errorf("lookupCipherContext(%s) not found\n", key)
+		return nil
+	}
+	status := item.(types.CipherContext)
+	log.Infof("lookupCipherContext(%s) done\n", key)
+	return &status
+}
+
+func getControllerCert(ctx *DecryptCipherContext,
+	cipherBlock types.CipherBlockStatus) ([]byte, error) {
+
+	log.Infof("getControllerCert for %s\n", cipherBlock.CipherBlockID)
+	cipherContext := lookupCipherContext(ctx, cipherBlock.CipherContextID)
+	if cipherContext == nil {
+		errStr := fmt.Sprintf("cipher context %s not found\n",
+			cipherBlock.CipherContextID)
+		log.Error(errStr)
+		return []byte{}, errors.New(errStr)
+	}
+	controllerCert := lookupControllerCert(ctx, cipherContext.ControllerCertKey())
+	if controllerCert == nil {
+		errStr := fmt.Sprintf("controller cert %s not found\n",
+			cipherContext.ControllerCertKey())
+		log.Error(errStr)
+		return []byte{}, errors.New(errStr)
+	}
+	if controllerCert.HasError() {
+		errStr := fmt.Sprintf("controller cert has following error: %v",
+			controllerCert.Error)
+		log.Error(errStr)
+		return []byte{}, errors.New(errStr)
+	}
+	log.Infof("getControllerCert for %s Done\n", cipherBlock.CipherBlockID)
+	return controllerCert.Cert, nil
+}
+
+func getDeviceCert(ctx *DecryptCipherContext,
+	cipherBlock types.CipherBlockStatus) ([]byte, error) {
+
+	log.Infof("getDeviceCert for %s\n", cipherBlock.CipherBlockID)
+	cipherContext := lookupCipherContext(ctx, cipherBlock.CipherContextID)
+	if cipherContext == nil {
+		errStr := fmt.Sprintf("cipher context %s not found\n",
+			cipherBlock.CipherContextID)
+		log.Error(errStr)
+		return []byte{}, errors.New(errStr)
+	}
+	// TBD:XXX as of now, only one
+	certBytes, err := ioutil.ReadFile(types.DeviceCertName)
+	if err != nil {
+		errStr := fmt.Sprintf("getDeviceCert failed while reading device certificate: %v",
+			err)
+		log.Error(errStr)
+		return []byte{}, errors.New(errStr)
+	}
+	if computeAndMatchHash(certBytes, cipherContext.DeviceCertHash,
+		cipherContext.HashScheme) {
+		log.Infof("getDeviceCert for %s Done\n", cipherBlock.CipherBlockID)
+		return certBytes, nil
+	}
+	errStr := fmt.Sprintf("getDeviceCert for %s not found\n",
+		cipherBlock.CipherBlockID)
+	log.Error(errStr)
+	return []byte{}, errors.New(errStr)
+}
+
+// hash function
+func computeAndMatchHash(cert []byte, suppliedHash []byte,
+	hashScheme zcommon.HashAlgorithm) bool {
+
+	switch hashScheme {
+	case zcommon.HashAlgorithm_HASH_ALGORITHM_INVALID:
+		return false
+
+	case zcommon.HashAlgorithm_HASH_ALGORITHM_SHA256_16BYTES:
+		h := sha256.New()
+		h.Write(cert)
+		computedHash := h.Sum(nil)
+		return bytes.Equal(suppliedHash, computedHash[:16])
+
+	case zcommon.HashAlgorithm_HASH_ALGORITHM_SHA256_32BYTES:
+		h := sha256.New()
+		h.Write(cert)
+		computedHash := h.Sum(nil)
+		return bytes.Equal(suppliedHash, computedHash)
+	}
+	return false
+}
+
+// DecryptCipherBlock : Decryption API, for encrypted object information received from controller
+func DecryptCipherBlock(ctx *DecryptCipherContext,
+	cipherBlock types.CipherBlockStatus) ([]byte, error) {
+	if len(cipherBlock.CipherData) == 0 {
+		return []byte{}, errors.New("Invalid Cipher Payload")
+	}
+	cipherContext := lookupCipherContext(ctx, cipherBlock.CipherContextID)
+	if cipherContext == nil {
+		errStr := fmt.Sprintf("cipher context %s not found\n",
+			cipherBlock.CipherContextID)
+		log.Error(errStr)
+		return []byte{}, errors.New(errStr)
+	}
+	switch cipherContext.KeyExchangeScheme {
+	case zconfig.KeyExchangeScheme_KEA_NONE:
+		return []byte{}, errors.New("No Key Exchange Scheme")
+
+	case zconfig.KeyExchangeScheme_KEA_ECDH:
+		clearData, err := decryptCipherBlockWithECDH(ctx, cipherBlock)
+		if err != nil {
+			return []byte{}, err
+		}
+		if ret := validateDataHash(clearData,
+			cipherBlock.ClearTextHash); !ret {
+			return []byte{}, errors.New("Data Validation Failed")
+		}
+		return clearData, nil
+	}
+	return []byte{}, errors.New("Unsupported Cipher Key Exchange Scheme")
+}
+
+func decryptCipherBlockWithECDH(ctx *DecryptCipherContext,
+	cipherBlock types.CipherBlockStatus) ([]byte, error) {
+	cert, err := getControllerCertEcdhKey(ctx, cipherBlock)
+	if err != nil {
+		log.Errorf("Could not extract ECDH Certificate Information")
+		return []byte{}, err
+	}
+	cipherContext := lookupCipherContext(ctx, cipherBlock.CipherContextID)
+	if cipherContext == nil {
+		errStr := fmt.Sprintf("cipher context %s not found\n",
+			cipherBlock.CipherContextID)
+		log.Error(errStr)
+		return []byte{}, errors.New(errStr)
+	}
+	switch cipherContext.EncryptionScheme {
+	case zconfig.EncryptionScheme_SA_NONE:
+		return []byte{}, errors.New("No Encryption")
+
+	case zconfig.EncryptionScheme_SA_AES_256_CFB:
+		if len(cipherBlock.InitialValue) == 0 {
+			return []byte{}, errors.New("Invalid Initial value")
+		}
+		clearData := make([]byte, len(cipherBlock.CipherData))
+		err = tpmmgr.DecryptSecretWithEcdhKey(cert.X, cert.Y,
+			cipherBlock.InitialValue, cipherBlock.CipherData, clearData)
+		if err != nil {
+			errStr := fmt.Sprintf("Decryption failed with error %v\n", err)
+			log.Error(errStr)
+			return []byte{}, errors.New(errStr)
+		}
+		return clearData, nil
+	}
+	return []byte{}, errors.New("Unsupported Encryption protocol")
+}
+
+func getControllerCertEcdhKey(ctx *DecryptCipherContext,
+	cipherBlock types.CipherBlockStatus) (*ecdsa.PublicKey, error) {
+	var ecdhPubKey *ecdsa.PublicKey
+	block, err := getControllerCert(ctx, cipherBlock)
+	if err != nil {
+		return nil, err
+	}
+	certs := []*x509.Certificate{}
+	for b, rest := pem.Decode(block); b != nil; b, rest = pem.Decode(rest) {
+		if b.Type == "CERTIFICATE" {
+			c, e := x509.ParseCertificates(b.Bytes)
+			if e != nil {
+				continue
+			}
+			certs = append(certs, c...)
+		}
+	}
+	if len(certs) == 0 {
+		return nil, errors.New("No X509 Certificate")
+	}
+	// use the first valid certificate in the chain
+	switch certs[0].PublicKey.(type) {
+	case *ecdsa.PublicKey:
+		ecdhPubKey = certs[0].PublicKey.(*ecdsa.PublicKey)
+	default:
+		return ecdhPubKey, errors.New("Not ECDSA Key")
+	}
+	return ecdhPubKey, nil
+}
+
+// validateDataHash : returns true, on hash match
+func validateDataHash(data []byte, suppliedHash []byte) bool {
+	if len(data) == 0 || len(suppliedHash) == 0 {
+		return false
+	}
+	h := sha256.New()
+	h.Write(data)
+	computedHash := h.Sum(nil)
+	return bytes.Equal(suppliedHash, computedHash)
+}

--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -142,6 +142,12 @@ func Run(ps *pubsub.PubSub) {
 
 	for {
 		select {
+		case change := <-ctx.SubControllerCert.MsgChan():
+			ctx.SubControllerCert.ProcessChange(change)
+
+		case change := <-ctx.SubCipherContext.MsgChan():
+			ctx.SubCipherContext.ProcessChange(change)
+
 		case change := <-ctx.subGlobalConfig.MsgChan():
 			ctx.subGlobalConfig.ProcessChange(change)
 

--- a/pkg/pillar/cmd/downloader/syncop.go
+++ b/pkg/pillar/cmd/downloader/syncop.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	zconfig "github.com/lf-edge/eve/api/go/config"
+	"github.com/lf-edge/eve/pkg/pillar/cipher"
 	"github.com/lf-edge/eve/pkg/pillar/types"
-	"github.com/lf-edge/eve/pkg/pillar/utils"
 	"github.com/lf-edge/eve/pkg/pillar/zedUpload"
 	"github.com/lf-edge/eve/pkg/pillar/zedcloud"
 	log "github.com/sirupsen/logrus"
@@ -328,8 +328,8 @@ func sourceFailureError(ip, ifname, url string, err error) {
 func getDatastoreCredential(ctx *downloaderContext,
 	dst types.DatastoreConfig) (types.EncryptionBlock, error) {
 	if dst.CipherBlockStatus.IsCipher {
-		status, decBlock, err := utils.GetCipherCredentials(agentName,
-			dst.CipherBlockStatus)
+		status, decBlock, err := cipher.GetCipherCredentials(&ctx.DecryptCipherContext,
+			agentName, dst.CipherBlockStatus)
 		ctx.pubCipherBlockStatus.Publish(status.Key(), status)
 		if err != nil {
 			log.Errorf("%s, datastore config cipherblock decryption unsuccessful, falling back to cleartext: %v",

--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -9,13 +9,9 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
-	"errors"
-	"fmt"
-	"io/ioutil"
 
 	"github.com/golang/protobuf/proto"
 	zcert "github.com/lf-edge/eve/api/go/certs"
-	zcommon "github.com/lf-edge/eve/api/go/evecommon"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	log "github.com/sirupsen/logrus"
 )
@@ -98,77 +94,6 @@ func lookupControllerCert(ctx *getconfigContext,
 	status := item.(types.ControllerCert)
 	log.Infof("lookupControllerCert(%s) Done\n", key)
 	return &status
-}
-
-// fetch controller cert
-func getControllerCert(ctx *getconfigContext,
-	suppliedHash []byte) ([]byte, error) {
-
-	hexStr := hex.EncodeToString(suppliedHash)
-	log.Infof("%v, get controller cert\n", hexStr)
-	items := ctx.pubControllerCert.GetAll()
-	for _, item := range items {
-		status := item.(types.ControllerCert)
-		if bytes.Equal(status.CertHash, suppliedHash) {
-			if status.HasError() {
-				log.Errorf("get controller cert failed because cert has following error: %v",
-					status.Error)
-				return status.Cert, errors.New(status.Error)
-			}
-			log.Infof("%v, controller certificate found\n", hexStr)
-			return status.Cert, nil
-		}
-	}
-	// TBD:XXX, schedule a cert API Get Call for
-	// the suppliedHash
-	errStr := fmt.Sprintf("%s, controller certificate not found", hexStr)
-	return []byte{}, errors.New(errStr)
-}
-
-// for device cert
-func getDeviceCert(hashScheme zcommon.HashAlgorithm,
-	suppliedHash []byte) ([]byte, error) {
-
-	hexStr := hex.EncodeToString(suppliedHash)
-	log.Infof("%v, get device cert\n", hexStr)
-
-	// TBD:XXX as of now, only one
-	certBytes, err := ioutil.ReadFile(types.DeviceCertName)
-	if err != nil {
-		errStr := fmt.Sprintf("get device cert failed while reading device certificate: %v",
-			err)
-		log.Errorf(errStr)
-		return []byte{}, errors.New(errStr)
-	}
-	if computeAndMatchHash(certBytes, suppliedHash, hashScheme) {
-		log.Infof("%v, device cert found", hexStr)
-		return certBytes, nil
-	}
-	errStr := fmt.Sprintf("%s, device certificate not found", hexStr)
-	return []byte{}, errors.New(errStr)
-}
-
-// hash function
-func computeAndMatchHash(cert []byte, suppliedHash []byte,
-	hashScheme zcommon.HashAlgorithm) bool {
-
-	switch hashScheme {
-	case zcommon.HashAlgorithm_HASH_ALGORITHM_INVALID:
-		return false
-
-	case zcommon.HashAlgorithm_HASH_ALGORITHM_SHA256_16BYTES:
-		h := sha256.New()
-		h.Write(cert)
-		computedHash := h.Sum(nil)
-		return bytes.Equal(suppliedHash, computedHash[:16])
-
-	case zcommon.HashAlgorithm_HASH_ALGORITHM_SHA256_32BYTES:
-		h := sha256.New()
-		h.Write(cert)
-		computedHash := h.Sum(nil)
-		return bytes.Equal(suppliedHash, computedHash)
-	}
-	return false
 }
 
 // pubsub functions

--- a/pkg/pillar/cmd/zedagent/handlecipherconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecipherconfig.go
@@ -69,39 +69,9 @@ func parseCipherContext(ctx *getconfigContext,
 			DeviceCertHash:     cfgCipherContext.GetDeviceCertHash(),
 			ControllerCertHash: cfgCipherContext.GetControllerCertHash(),
 		}
-		context.ClearError()
-		if err := updateCipherContextCerts(ctx, &context); err != nil {
-			errStr := fmt.Sprintf("%s, CipherContextUpdateCerts failed, %s",
-				context.Key(), err)
-			context.SetErrorNow(errStr)
-		}
 		publishCipherContext(ctx, context)
 	}
 	log.Infof("parsing cipher context done\n")
-}
-
-// on create/modification, update the cipher context certs
-func updateCipherContextCerts(ctx *getconfigContext,
-	context *types.CipherContext) error {
-	log.Infof("Updating certs of cipher context %s\n", context.ContextID)
-	// get controller cert
-	ccert, err0 := getControllerCert(ctx, context.ControllerCertHash)
-	if err0 != nil {
-		log.Errorf("getControllerCert(%s) failed: %s\n", context.ContextID, err0)
-		return err0
-	}
-	context.ControllerCert = ccert
-
-	// get device cert
-	dcert, err1 := getDeviceCert(context.HashScheme,
-		context.DeviceCertHash)
-	if err1 != nil {
-		log.Errorf("getDeviceCert(%s) failed: %v\n", context.ContextID, err1)
-		return err1
-	}
-	context.DeviceCert = dcert
-	log.Infof("Updating certs of cipher context %s done\n", context.ContextID)
-	return nil
 }
 
 // parseCipherBlock : will collate all the relevant information
@@ -130,86 +100,11 @@ func parseCipherBlock(ctx *getconfigContext, key string,
 		cipherBlock.SetErrorNow(errStr)
 		return cipherBlock
 	}
-	cipherBlock.IsCipher = true
 	log.Infof("%s, marking cipher as true\n", key)
+	cipherBlock.IsCipher = true
 
-	// get the cipher context
-	cipherCtx := lookupCipherContext(ctx, cipherBlock.CipherContextID)
-	if cipherCtx == nil {
-		errStr := fmt.Sprintf("parseCipherBlock(%s) cipherContext not found %s\n",
-			key, cipherBlock.CipherContextID)
-		log.Errorf(errStr)
-		cipherBlock.SetErrorNow(errStr)
-	} else {
-		log.Infof("parseCipherBlock(%s) cipherContext found %s\n",
-			key, cipherBlock.CipherContextID)
-		updateCipherBlock(*cipherCtx, &cipherBlock, key, false)
-	}
 	log.Infof("parseCipherBlock(%s) done\n", key)
 	return cipherBlock
-}
-
-// cipherContext publish/get utilities
-func updateCipherBlock(status types.CipherContext,
-	cipherBlock *types.CipherBlockStatus, key string, reset bool) bool {
-
-	log.Infof("%s, updating cipherblock\n", status.Key())
-	if !cipherBlock.IsCipher ||
-		cipherBlock.CipherContextID != status.Key() {
-		return false
-	}
-
-	// first mark the cipher block as not ready,
-	// copy the relavant attributes, from cipher context to cipher block
-	cipherBlock.ClearError()
-	cipherBlock.KeyExchangeScheme = status.KeyExchangeScheme
-	cipherBlock.EncryptionScheme = status.EncryptionScheme
-
-	ccert, dcert := getCipherContextCerts(status)
-	if reset {
-		ccert = []byte{}
-		dcert = []byte{}
-		errStr := fmt.Sprintf("CipherContext(%s) deleted for the cipherBlock",
-			status.Key())
-		cipherBlock.SetErrorNow(errStr)
-		return true
-	}
-	// when we have both the certificates,
-	// mark the cipher block as valid
-	if status.HasError() {
-		cipherBlock.SetErrorNow(status.Error)
-	} else {
-		cipherBlock.ControllerCert = ccert
-		cipherBlock.DeviceCert = dcert
-		if len(ccert) != 0 && len(dcert) != 0 {
-			log.Infof("cipherBlock is marked ready, %s\n",
-				cipherBlock.CipherContextID)
-		} else {
-			errStr := fmt.Sprintf("%s, certs are not ready",
-				cipherBlock.Key())
-			log.Errorf(errStr)
-			cipherBlock.SetErrorNow(errStr)
-		}
-	}
-	return true
-}
-
-func getCipherContextCerts(status types.CipherContext) ([]byte, []byte) {
-	return status.ControllerCert, status.DeviceCert
-}
-
-func lookupCipherContext(ctx *getconfigContext,
-	key string) *types.CipherContext {
-	log.Infof("lookupCipherContext(%s)\n", key)
-	pub := ctx.pubCipherContext
-	st, _ := pub.Get(key)
-	if st == nil {
-		log.Errorf("lookupCipherContext(%s) not found\n", key)
-		return nil
-	}
-	status := st.(types.CipherContext)
-	log.Infof("lookupCipherContext(%s) done\n", key)
-	return &status
 }
 
 func publishCipherContext(ctx *getconfigContext,

--- a/pkg/pillar/devicenetwork/devicenetwork.go
+++ b/pkg/pillar/devicenetwork/devicenetwork.go
@@ -16,9 +16,9 @@ import (
 
 	"github.com/eriknordmark/ipinfo"
 	"github.com/eriknordmark/netlink"
+	"github.com/lf-edge/eve/pkg/pillar/cipher"
 	"github.com/lf-edge/eve/pkg/pillar/hardware"
 	"github.com/lf-edge/eve/pkg/pillar/types"
-	"github.com/lf-edge/eve/pkg/pillar/utils"
 	"github.com/lf-edge/eve/pkg/pillar/zedcloud"
 	log "github.com/sirupsen/logrus"
 )
@@ -400,8 +400,8 @@ func devPortInstallWifiConfig(ctx *DeviceNetworkContext,
 func getWifiCredential(ctx *DeviceNetworkContext,
 	wifi types.WifiConfig) (types.EncryptionBlock, error) {
 	if wifi.CipherBlockStatus.IsCipher {
-		status, decBlock, err := utils.GetCipherCredentials("devicenetwork",
-			wifi.CipherBlockStatus)
+		status, decBlock, err := cipher.GetCipherCredentials(&ctx.DecryptCipherContext,
+			"devicenetwork", wifi.CipherBlockStatus)
 		ctx.PubCipherBlockStatus.Publish(status.Key(), status)
 		if err != nil {
 			log.Errorf("%s, wifi config cipherblock decryption unsuccessful, falling back to cleartext: %v\n",

--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/lf-edge/eve/pkg/pillar/cipher"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/satori/go.uuid"
@@ -39,6 +40,7 @@ type DPCPending struct {
 }
 
 type DeviceNetworkContext struct {
+	cipher.DecryptCipherContext
 	UsableAddressCount      int
 	DevicePortConfig        *types.DevicePortConfig // Currently in use
 	DevicePortConfigList    *types.DevicePortConfigList

--- a/pkg/pillar/types/cipherinfotypes.go
+++ b/pkg/pillar/types/cipherinfotypes.go
@@ -4,6 +4,8 @@
 package types
 
 import (
+	"encoding/hex"
+
 	zconfig "github.com/lf-edge/eve/api/go/config"
 	zcommon "github.com/lf-edge/eve/api/go/evecommon"
 )
@@ -18,8 +20,6 @@ type CipherContext struct {
 	EncryptionScheme   zconfig.EncryptionScheme
 	ControllerCertHash []byte
 	DeviceCertHash     []byte
-	ControllerCert     []byte // resolved through cert API
-	DeviceCert         []byte // local device certificate
 	// ErrorAndTime provides SetErrorNow() and ClearError()
 	ErrorAndTime
 }
@@ -29,18 +29,19 @@ func (status *CipherContext) Key() string {
 	return status.ContextID
 }
 
+// ControllerCertKey :
+func (status *CipherContext) ControllerCertKey() string {
+	return hex.EncodeToString(status.ControllerCertHash)
+}
+
 // CipherBlockStatus : Object specific encryption information
 type CipherBlockStatus struct {
-	CipherBlockID     string                    // constructed using individual reference
-	CipherContextID   string                    // cipher context id
-	KeyExchangeScheme zconfig.KeyExchangeScheme // from cipher context
-	EncryptionScheme  zconfig.EncryptionScheme  // from cipher context
-	ControllerCert    []byte                    // inherited from cipher context
-	DeviceCert        []byte                    // inherited from cipher context
-	InitialValue      []byte
-	CipherData        []byte
-	ClearTextHash     []byte
-	IsCipher          bool
+	CipherBlockID   string // constructed using individual reference
+	CipherContextID string // cipher context id
+	InitialValue    []byte
+	CipherData      []byte
+	ClearTextHash   []byte
+	IsCipher        bool
 	// ErrorAndTime provides SetErrorNow() and ClearError()
 	ErrorAndTime
 }


### PR DESCRIPTION
Currently, we are supporting encryption for three objects:
1. Wifi credentials
2. Datastore credentials
3. User data in the app configuration

And to support it, we have three structures defined in EVE types:
1. ControllerCert:
It has controller certificates and its type like signing, intermediate, ECDH, etc.
2. CipherContext:
It has attributes like hashing algorithm, key exchange scheme, encryption scheme, etc, received as part of the edge device configuration from the controller.
It has a copy of the controller certificate and device certificate required for decryption.
3. CipherBlockStatus:
It has object specific encryption information like initial value used for encryption, cipher data, etc.
It copies all data from CipherContext in its structure.

With these changes, we are avoiding copying certificates in different structures. We added subscription in agents to certificates and contexts. Whenever an agent wants to decrypt sensitive information, it will lookup for the certificates and contexts.
