### PR TITLE
Publish ECDH certificate from TPM mgr to Zedagent

### DIFF
--- a/pkg/pillar/cmd/tpmmgr/tpmmgr.go
+++ b/pkg/pillar/cmd/tpmmgr/tpmmgr.go
@@ -1025,7 +1025,7 @@ func getCertHash(cert []byte, hashAlgo types.CertHashType) ([]byte, error) {
 	case types.CertHashTypeSha256First16:
 		return certHash[:16], nil
 	default:
-		return []byte{}, fmt.Errorf("Unsupported cert hash type")
+		return []byte{}, fmt.Errorf("Unsupported cert hash type: %d\n", hashAlgo)
 	}
 }
 

--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -193,3 +193,21 @@ func unpublishControllerCert(ctx *getconfigContext, key string) {
 	log.Debugf("unpublishControllerCert %s Done\n", key)
 	pub.Unpublish(key)
 }
+
+func handleAttestCertModify(ctxArg interface{}, key string,
+	configArg interface{}) {
+
+	// XXX TBD
+	status := configArg.(types.AttestCert)
+	log.Infof("handleAttestCertModify for %s\n", status.Key())
+	return
+}
+
+func handleAttestCertDelete(ctxArg interface{}, key string,
+	configArg interface{}) {
+
+	// XXX TBD
+	status := configArg.(types.AttestCert)
+	log.Infof("handleAttestCertDelete for %s\n", status.Key())
+	return
+}

--- a/pkg/pillar/types/attesttypes.go
+++ b/pkg/pillar/types/attesttypes.go
@@ -66,13 +66,13 @@ const (
 
 //AttestCert contains attest signing certificate published by tpmmgr
 type AttestCert struct {
-	hashAlgo CertHashType //hash method used to arrive at certHash
-	certID   []byte       //Hash of the cert, computed using hashAlgo
-	certType CertType     //type of the certificate
-	cert     []byte       //PEM encoded
+	HashAlgo CertHashType //hash method used to arrive at certHash
+	CertID   []byte       //Hash of the cert, computed using hashAlgo
+	CertType CertType     //type of the certificate
+	Cert     []byte       //PEM encoded
 }
 
 //Key uniquely identifies an AttestCert object
 func (cert AttestCert) Key() string {
-	return hex.EncodeToString(cert.certID)
+	return hex.EncodeToString(cert.CertID)
 }


### PR DESCRIPTION
Added support of publishing ECDH certificate from the TPM manager to the Zedagent which will be used for the encryption by the controller. The missing part in this PR is publishing the certificate to the controller from the zedagent after receiving them. I had a discussion with @srinibas-zededa , he will take care of it in a separate PR.