### PR TITLE
Introducing native containerd container execution

### DIFF
--- a/pkg/pillar/containerd/README.md
+++ b/pkg/pillar/containerd/README.md
@@ -1,0 +1,11 @@
+# Notes on developing with containerd
+
+## Snapshotters
+
+Performance of containerd filesystem operations depends a great deal on the choice of a snapshotter. Currently we're using the default overlayfs one, but the choice is vast and constantly evolving. There are a few benchmarks available [here](http://people.redhat.com/mskinner/rhug/q1.2017/Container-Storage-Best-Practices-2017.pdf) and [here](https://integratedcode.us/2016/08/30/storage-drivers-in-docker-a-deep-dive/) but the recommendations are constantly changing based on improvements in the underlying filesystem implementations. Case in point here is ZFS: it used to be great for snapshotters back in 2014, then it got really bad and then it got fixed again around 2020.
+
+At the time of this writeup it is unclear whether we can leverage Docker's overlayfs2 implementation and whether it would give us any real benefits over default overlayfs.
+
+## Tools
+
+containerd structures most of its state in pretty simple formats. The only exception to that rule is how it keeps its metadata around. That state is stored in an embedded [bolt DB](https://github.com/boltdb/bolt) and using [boltbrowser](https://github.com/br0xen/boltbrowser) on `meta.db` is highly recommended when debugging containerd issues.

--- a/pkg/pillar/containerd/containerd.go
+++ b/pkg/pillar/containerd/containerd.go
@@ -404,6 +404,19 @@ func prepareProcess(pid int, VifList []types.VifInfo) error {
 	return nil
 }
 
+// CtrInfo looks up
+func CtrInfo(name string) (int, string, error) {
+	c, err := loadContainer(name)
+	if err == nil {
+		if t, err := c.Task(ctrdCtx, nil); err == nil {
+			if stat, err := t.Status(ctrdCtx); err == nil {
+				return int(t.Pid()), string(stat.Status), nil
+			}
+		}
+	}
+	return 0, "", err
+}
+
 // CtrStart starts the default task in a pre-existing container and attaches its logging to memlogd
 func CtrStart(domainName string) (int, error) {
 	ctr, err := loadContainer(domainName)
@@ -492,9 +505,12 @@ func CtrStop(containerID string, force bool) error {
 // CtrDelete is a simple wrapper around container.Delete()
 func CtrDelete(containerID string) error {
 	ctr, err := loadContainer(containerID)
-	if err != nil || ctr == nil {
+	if err != nil {
 		return err
 	}
+
+	// do this just in case
+	_ = CtrStop(containerID, true)
 
 	return ctr.Delete(ctrdCtx)
 }

--- a/pkg/pillar/containerd/logging.go
+++ b/pkg/pillar/containerd/logging.go
@@ -1,0 +1,194 @@
+// This file is drived from the code available in linuxkit project under Apache License v2
+//    https://github.com/linuxkit/linuxkit/blob/master/pkg/init/cmd/service/logging.go
+
+package containerd
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"github.com/containerd/containerd/cio"
+	"io"
+	"io/ioutil"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	logDumpCommand byte = iota
+)
+
+type logio struct {
+	config cio.Config
+}
+
+func (c *logio) Config() cio.Config {
+	return c.config
+}
+
+func (c *logio) Cancel() {
+}
+
+func (c *logio) Wait() {
+}
+
+func (c *logio) Close() error {
+	return nil
+}
+
+// Log provides access to a log by path or io.WriteCloser
+type Log interface {
+	Path(string) string                  // Path of the log file (may be a FIFO)
+	Open(string) (io.WriteCloser, error) // Opens a log stream
+	Dump(string)                         // Copies logs to the console
+}
+
+// GetLog returns the log destination we should use.
+func GetLog() Log {
+	if _, err := os.Stat(logWriteSocket); !os.IsNotExist(err) {
+		return &remoteLog{
+			fifoDir: "/var/run",
+		}
+	}
+	return &nullLog{}
+}
+
+type nullWriterCloser struct {
+	io.Writer
+}
+
+func (n nullWriterCloser) Close() error {
+	return nil
+}
+
+type nullLog struct {
+}
+
+// Path returns the name of a log file path for the named service.
+func (f *nullLog) Path(n string) string {
+	return "/dev/null"
+}
+
+// Open a log file for the named service.
+func (f *nullLog) Open(n string) (io.WriteCloser, error) {
+	return nullWriterCloser{ioutil.Discard}, nil
+}
+
+// Dump copies logs to the console.
+func (f *nullLog) Dump(n string) {
+}
+
+type remoteLog struct {
+	fifoDir string
+}
+
+// Path returns the name of a FIFO connected to the logging daemon.
+func (r *remoteLog) Path(n string) string {
+	path := filepath.Join(r.fifoDir, n+".log")
+	if err := syscall.Mkfifo(path, 0600); err != nil {
+		return "/dev/null"
+	}
+	go func() {
+		// In a goroutine because Open of the FIFO will block until
+		// containerd opens it when the task is started.
+		fd, err := syscall.Open(path, syscall.O_RDONLY, 0)
+		if err != nil {
+			// Should never happen: we just created the fifo
+			log.Printf("failed to open fifo %s: %s", path, err)
+		}
+		defer syscall.Close(fd)
+		if err := sendToLogger(n, fd); err != nil {
+			// Should never happen: logging is enabled
+			log.Printf("failed to send fifo %s to logger: %s", path, err)
+		}
+	}()
+	return path
+}
+
+// Open a log file for the named service.
+func (r *remoteLog) Open(n string) (io.WriteCloser, error) {
+	fds, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		log.Fatal("Unable to create socketpair: ", err)
+	}
+	logFile := os.NewFile(uintptr(fds[0]), "")
+
+	if err := sendToLogger(n, fds[1]); err != nil {
+		return nil, err
+	}
+	return logFile, nil
+}
+
+// Dump copies logs to the console.
+func (r *remoteLog) Dump(n string) {
+	addr := net.UnixAddr{
+		Name: logReadSocket,
+		Net:  "unix",
+	}
+	conn, err := net.DialUnix("unix", nil, &addr)
+	if err != nil {
+		log.Printf("Failed to connect to logger: %s", err)
+		return
+	}
+	defer conn.Close()
+	nWritten, err := conn.Write([]byte{logDumpCommand})
+	if err != nil || nWritten < 1 {
+		log.Printf("Failed to request logs from logger: %s", err)
+		return
+	}
+	reader := bufio.NewReader(conn)
+	for {
+		line, err := reader.ReadString('\n')
+		if err == io.EOF {
+			return
+		}
+		if err != nil {
+			log.Printf("Failed to read log message: %s", err)
+			return
+		}
+		// a line is of the form
+		// <timestamp>,<log>;<body>
+		prefixBody := strings.SplitN(line, ";", 2)
+		csv := strings.Split(prefixBody[0], ",")
+		if len(csv) < 2 {
+			log.Printf("Failed to parse log message: %s", line)
+			continue
+		}
+		if csv[1] == n {
+			fmt.Print(line)
+		}
+	}
+}
+
+func sendToLogger(name string, fd int) error {
+	var ctlSocket int
+	var err error
+	if ctlSocket, err = syscall.Socket(syscall.AF_UNIX, syscall.SOCK_DGRAM, 0); err != nil {
+		return err
+	}
+
+	var ctlConn net.Conn
+	if ctlConn, err = net.FileConn(os.NewFile(uintptr(ctlSocket), "")); err != nil {
+		return err
+	}
+	defer ctlConn.Close()
+
+	ctlUnixConn, ok := ctlConn.(*net.UnixConn)
+	if !ok {
+		// should never happen
+		log.Fatal("Internal error, invalid cast.")
+	}
+
+	raddr := net.UnixAddr{Name: logWriteSocket, Net: "unixgram"}
+	oobs := syscall.UnixRights(fd)
+	_, _, err = ctlUnixConn.WriteMsgUnix([]byte(name), oobs, &raddr)
+	if err != nil {
+		return errors.New("logging system not enabled")
+	}
+	return nil
+}

--- a/pkg/pillar/containerd/oci.go
+++ b/pkg/pillar/containerd/oci.go
@@ -22,6 +22,7 @@ import (
 	"os"
 )
 
+//revive:disable
 type ociSpec struct {
 	specs.Spec
 	name         string
@@ -32,7 +33,6 @@ type ociSpec struct {
 }
 
 // NewOciSpec returns a default oci spec from the containerd point of view
-//revive:disable
 func NewOciSpec(name string) (*ociSpec, error) {
 	s := &ociSpec{name: name}
 	// we need a dummy container object to trick containerd
@@ -48,6 +48,7 @@ func NewOciSpec(name string) (*ociSpec, error) {
 	s.Root.Path = "/"
 	return s, nil
 }
+
 //revive:enable
 
 // Save stores json representation of the oci spec in a file

--- a/pkg/pillar/containerd/oci.go
+++ b/pkg/pillar/containerd/oci.go
@@ -1,0 +1,173 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// This is basically re-implementation of:
+//    https://github.com/opencontainers/runtime-tools/blob/master/generate/generate.go
+// The reason we're not using it verbatim is that we only need a tiny
+// subset of its functionality AND we are paranoid about being compatible
+// with containerd defaults. Should containerd itself migrate to using
+// OCI runtime-tools library -- we'd gladly switch
+
+package containerd
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/oci"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"os"
+)
+
+type ociSpec struct {
+	specs.Spec
+	name         string
+	exposedPorts map[string]struct{}
+	volumes      map[string]struct{}
+	labels       map[string]string
+	stopSignal   string
+}
+
+// NewOciSpec returns a default oci spec from the containerd point of view
+//revive:disable:unexported-return
+func NewOciSpec(name string) (*ociSpec, error) {
+	s := &ociSpec{name: name}
+	// we need a dummy container object to trick containerd
+	// initialization functions into filling out defaults
+	dummy := containers.Container{ID: s.name}
+
+	if err := oci.WithDefaultSpec()(ctrdCtx, CtrdClient, &dummy, &s.Spec); err != nil {
+		return nil, err
+	}
+	if s.Process == nil {
+		s.Process = &specs.Process{}
+	}
+	s.Root.Path = "/"
+	return s, nil
+}
+
+// Save stores json representation of the oci spec in a file
+func (s *ociSpec) Save(file *os.File) error {
+	b, err := json.MarshalIndent(s.Spec, "", "    ")
+	if err != nil {
+		return fmt.Errorf("failed to serialize JSON spec %v", err)
+	}
+
+	if r, err := file.Write(b); err != nil || r != len(b) {
+		return fmt.Errorf("failed to write %d bytes to file %s (%v)", len(b), file.Name(), err)
+	}
+	return nil
+}
+
+// Load loads json representation of the oci spec from file
+func (s *ociSpec) Load(file *os.File) error {
+	var ns *specs.Spec
+	if err := json.NewDecoder(file).Decode(&ns); err != nil {
+		return err
+	}
+	s.Spec = *ns
+	return nil
+}
+
+// CreateContainer starts an OCI container based on the spec
+func (s *ociSpec) CreateContainer(removeExisting bool) error {
+	c, err := CtrdClient.NewContainer(ctrdCtx, s.name, containerd.WithSpec(&s.Spec))
+	// if container exists, is stopped and we are asked to remove existing - try that
+	if err != nil && removeExisting {
+		var t containerd.Task
+		var stat containerd.Status
+		if c, err = CtrdClient.LoadContainer(ctrdCtx, s.name); err == nil {
+			if t, err = c.Task(ctrdCtx, nil); err == nil {
+				if stat, err = t.Status(ctrdCtx); err == nil && stat.Status != containerd.Running && stat.Status != containerd.Pausing {
+					err = c.Delete(ctrdCtx)
+				}
+			}
+		}
+		if err == nil {
+			// one last attempt to create a container
+			_, err = CtrdClient.NewContainer(ctrdCtx, s.name, containerd.WithSpec(&s.Spec))
+		}
+	}
+	return err
+}
+
+// UpdateFromDomain updates values in the OCI spec based on EVE DomainConfig settings
+func (s *ociSpec) UpdateFromDomain(dom types.DomainConfig) {
+	if s.Linux != nil {
+		if s.Linux.Resources == nil {
+			s.Linux.Resources = &specs.LinuxResources{}
+		}
+		if s.Linux.Resources.Memory == nil {
+			s.Linux.Resources.Memory = &specs.LinuxMemory{}
+		}
+		if s.Linux.Resources.CPU == nil {
+			s.Linux.Resources.CPU = &specs.LinuxCPU{}
+		}
+
+		m := int64(dom.Memory * 1024)
+		p := uint64(100000)
+		q := int64(100000 * dom.VCpus)
+		s.Linux.Resources.Memory.Limit = &m
+		s.Linux.Resources.CPU.Period = &p
+		s.Linux.Resources.CPU.Quota = &q
+	}
+}
+
+// UpdateFromVolume updates values in the OCI spec based on the location
+// of an EVE volume. EVE volume's are expected to be structured as directories
+// in the filesystem with a json file containing the corresponding Image
+// manifest and a rootfs subfolder with a full rootfs filesystem
+func (s *ociSpec) UpdateFromVolume(volume string) error {
+	imgInfo, err := getSavedImageInfo(volume)
+	if err != nil {
+		return fmt.Errorf("couldn't load saved image config from %s", volume)
+	}
+
+	if err = s.updateFromImageConfig(imgInfo.Config); err == nil {
+		s.Root.Path = "/var" + volume + "/rootfs"
+	}
+
+	return err
+}
+
+// UpdateFromImageConfig updates values in the OCI spec based
+// on the values provided in the Image Config section as per:
+//    https://github.com/opencontainers/image-spec/blob/master/config.md
+func (s *ociSpec) updateFromImageConfig(config v1.ImageConfig) error {
+	// the following gets into our extensions of the Spec, these
+	// values will be missing if we serialize the spec into JSON and
+	// read it back: these don't map to OCI runtime spec
+	s.exposedPorts = config.ExposedPorts
+	s.volumes = config.Volumes
+	s.labels = config.Labels
+	s.stopSignal = config.StopSignal
+
+	// we need a dummy container object to trick containerd
+	// initialization functions into filling out defaults
+	dummy := containers.Container{ID: s.name}
+
+	if len(config.Env) == 0 {
+		_ = oci.WithDefaultPathEnv(ctrdCtx, CtrdClient, &dummy, &s.Spec)
+	} else {
+		s.Process.Env = config.Env
+	}
+	s.Process.Args = append(config.Entrypoint, config.Cmd...)
+
+	cwd := config.WorkingDir
+	if cwd == "" {
+		cwd = "/"
+	}
+	s.Process.Cwd = cwd
+	if config.User != "" {
+		if err := oci.WithUser(config.User)(ctrdCtx, CtrdClient, &dummy, &s.Spec); err != nil {
+			return err
+		}
+		if err := oci.WithAdditionalGIDs(fmt.Sprintf("%d", s.Process.User.UID))(ctrdCtx, CtrdClient, &dummy, &s.Spec); err != nil {
+			return err
+		}
+	}
+	return oci.WithAdditionalGIDs("root")(ctrdCtx, CtrdClient, &dummy, &s.Spec)
+}

--- a/pkg/pillar/containerd/oci_test.go
+++ b/pkg/pillar/containerd/oci_test.go
@@ -1,11 +1,6 @@
 // Copyright (c) 2020 Zededa, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Manage Xen guest domains based on the subscribed collection of DomainConfig
-// and publish the result in a collection of DomainStatus structs.
-// We run a separate go routine for each domU to be able to boot and halt
-// them concurrently and also pick up their state periodically.
-
 package containerd
 
 import (

--- a/pkg/pillar/containerd/oci_test.go
+++ b/pkg/pillar/containerd/oci_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Manage Xen guest domains based on the subscribed collection of DomainConfig
+// and publish the result in a collection of DomainStatus structs.
+// We run a separate go routine for each domU to be able to boot and halt
+// them concurrently and also pick up their state periodically.
+
+package containerd
+
+import (
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+const imageConfig = `
+{
+    "created": "2020-04-21T00:39:14.5857389Z",
+    "architecture": "amd64",
+    "os": "linux",
+    "config": {
+        "Env": [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        ],
+        "Cmd": [
+            "/bin/sh",
+            "-c",
+            "/runme.sh"
+        ]
+    },
+    "rootfs": {
+        "type": "layers",
+        "diff_ids": [
+            "sha256:beee9f30bc1f711043e78d4a2be0668955d4b761d587d6f60c2c8dc081efb203",
+            "sha256:2aee9ebb1000a3f178b7354e3b908016995d49933ef55611faa14c44ec6ad5f3"
+        ]
+    },
+    "history": [
+        {
+            "created": "2020-03-23T21:19:34.027725872Z",
+            "created_by": "/bin/sh -c #(nop) ADD file:0c4555f363c2672e350001f1293e689875a3760afe7b3f9146886afe67121cba in / "
+        },
+        {
+            "created": "2020-03-23T21:19:34.196162891Z",
+            "created_by": "/bin/sh -c #(nop)  CMD [\"/bin/sh\"]",
+            "empty_layer": true
+        },
+        {
+            "created": "2020-04-21T00:39:14.4357591Z",
+            "created_by": "/bin/sh -c #(nop) COPY file:460e7e85dc47719c898d4bccd36051f5010ecc18b7d0bcb627d19ada0321099a in / "
+        },
+        {
+            "created": "2020-04-21T00:39:14.5857389Z",
+            "created_by": "/bin/sh -c #(nop)  CMD [\"/bin/sh\" \"-c\" \"/runme.sh\"]",
+            "empty_layer": true
+        }
+    ]
+}
+`
+
+func TestOciSpec(t *testing.T) {
+	if err := InitContainerdClient(); err != nil {
+		t.Logf("failed to init containerd client %v", err)
+	}
+
+	spec, err := NewOciSpec("test")
+	if err != nil {
+		t.Errorf("failed to create default OCI spec %v", err)
+	}
+
+	tmpfile, err := ioutil.TempFile("/tmp", "oci_spec*.json")
+	if err != nil {
+		t.Errorf("failed to create tmpfile %v", err)
+	} else {
+		defer os.Remove(tmpfile.Name())
+	}
+	tmpdir, err := ioutil.TempDir("/tmp", "volume")
+	if err != nil {
+		t.Errorf("failed to create tmpdir %v", err)
+	} else {
+		defer os.RemoveAll(tmpdir)
+	}
+	if ioutil.WriteFile(tmpdir+"/image-config.json", []byte(imageConfig), 0777) != nil {
+		t.Errorf("failed to write to temp file %s", tmpdir+"/image-config.json")
+	}
+
+	spec.UpdateFromDomain(types.DomainConfig{VmConfig: types.VmConfig{Memory: 1234, VCpus: 4}})
+	spec.UpdateFromVolume(tmpdir)
+
+	if err := spec.Save(tmpfile); err != nil {
+		t.Errorf("failed to save OCI spec file %s %v", tmpfile.Name(), err)
+	}
+
+	tmpfile.Seek(0, 0)
+	if err := spec.Load(tmpfile); err != nil {
+		t.Errorf("failed to load OCI spec file from file %s %v", tmpfile.Name(), err)
+	}
+
+	assert.Equal(t, *spec.Linux.Resources.Memory.Limit, int64(1234*1024),
+		"Got incorrect memory limit")
+	assert.Equal(t, float64(*spec.Linux.Resources.CPU.Quota)/float64(*spec.Linux.Resources.CPU.Period), float64(4),
+		"Got incorrect CPU limit")
+	assert.Equal(t, spec.Root.Path, "/var"+tmpdir+"/rootfs",
+		"Got incorrect rootfs")
+	assert.Equal(t, spec.Process.Env, []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
+		"Got incorrect ENV")
+	assert.Equal(t, spec.Process.Args, []string{"/bin/sh", "-c", "/runme.sh"},
+		"Got incorrect cmd")
+}

--- a/pkg/pillar/hypervisor/containerd.go
+++ b/pkg/pillar/hypervisor/containerd.go
@@ -1,0 +1,147 @@
+// Copyright (c) 2017-2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package hypervisor
+
+import (
+	"fmt"
+	zconfig "github.com/lf-edge/eve/api/go/config"
+	"github.com/lf-edge/eve/pkg/pillar/containerd"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"os"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type ctrdContext struct {
+	doms       map[string]*domState
+	domCounter int
+	PCI        map[string]bool
+}
+
+func newContainerd() Hypervisor {
+	if err := containerd.InitContainerdClient(); err != nil {
+		log.Fatal(err)
+		return nil
+	}
+	return ctrdContext{
+		doms:       map[string]*domState{},
+		domCounter: 0,
+		PCI:        map[string]bool{},
+	}
+}
+
+func (ctx ctrdContext) Name() string {
+	return "containerd"
+}
+
+func (ctx ctrdContext) CreateDomConfig(domainName string, config types.DomainConfig, diskStatusList []types.DiskStatus, aa *types.AssignableAdapters, file *os.File) error {
+	if len(diskStatusList) != 1 || diskStatusList[0].Format != zconfig.Format_CONTAINER {
+		return logError("failed to create container for %s containerd only supports ECOs with a single drive in an image format for now", domainName)
+	}
+
+	spec, err := containerd.NewOciSpec(domainName)
+	if err != nil {
+		return logError("requesting default OCI spec for domain %s failed %v", domainName, err)
+	}
+
+	spec.UpdateFromDomain(config)
+	if err := spec.UpdateFromVolume(diskStatusList[0].FileLocation); err != nil {
+		return logError("failed to update OCI spec from volume %s (%v)", diskStatusList[0].FileLocation, err)
+	}
+
+	return spec.Save(file)
+}
+
+func (ctx ctrdContext) Create(domainName string, cfgFilename string, VirtualizationMode types.VmMode) (int, error) {
+	spec, err := containerd.NewOciSpec(domainName)
+	if err == nil {
+		err = spec.CreateContainer(true)
+	}
+
+	if err == nil {
+		// calls to Create are serialized in the consumer: no need to worry about locking
+		ctx.domCounter++
+		ctx.doms[domainName] = &domState{id: ctx.domCounter, config: cfgFilename, state: "stopped"}
+		return ctx.domCounter, nil
+	}
+	return 0, err
+}
+
+func (ctx ctrdContext) Start(domainName string, domainID int) error {
+	id, err := containerd.CtrStart(domainName)
+	if err != nil {
+		return err
+	}
+	log.Infof("container %s running with PID %d", domainName, id)
+	// ctx.doms[domainName].id = id
+	ctx.doms[domainName].state = "running"
+
+	return nil
+}
+
+func (ctx ctrdContext) Stop(domainName string, domainID int, force bool) error {
+	ctx.doms[domainName].state = "stopped"
+	return containerd.CtrStop(domainName, force)
+}
+
+func (ctx ctrdContext) Delete(domainName string, domainID int) error {
+	delete(ctx.doms, domainName)
+	return containerd.CtrDelete(domainName)
+}
+
+func (ctx ctrdContext) Info(domainName string, domainID int) error {
+	if dom, found := ctx.doms[domainName]; found {
+		log.Infof("Container Domain %s is %s and has the following config %s\n", domainName, dom.state, dom.config)
+		return nil
+	} else {
+		log.Errorf("Container Domain %s doesn't exist", domainName)
+		return fmt.Errorf("container domain %s doesn't exist", domainName)
+	}
+}
+
+func (ctx ctrdContext) LookupByName(domainName string, domainID int) (int, error) {
+	if dom, found := ctx.doms[domainName]; found {
+		return dom.id, nil
+	} else {
+		return 0, fmt.Errorf("container domain %s %d doesn't exist", domainName, domainID)
+	}
+}
+
+func (ctx ctrdContext) Tune(string, int, int) error {
+	return nil
+}
+
+func (ctx ctrdContext) PCIReserve(long string) error {
+	if ctx.PCI[long] {
+		return fmt.Errorf("PCI %s is already reserved", long)
+	} else {
+		ctx.PCI[long] = true
+		return nil
+	}
+}
+
+func (ctx ctrdContext) PCIRelease(long string) error {
+	if !ctx.PCI[long] {
+		return fmt.Errorf("PCI %s is not reserved", long)
+	} else {
+		ctx.PCI[long] = false
+		return nil
+	}
+}
+
+func (ctx ctrdContext) IsDomainPotentiallyShuttingDown(domainName string) bool {
+	return false
+}
+
+func (ctx ctrdContext) IsDeviceModelAlive(int) bool {
+	return true
+}
+
+func (ctx ctrdContext) GetHostCPUMem() (types.HostMemory, error) {
+	return selfDomCPUMem()
+}
+
+func (ctx ctrdContext) GetDomsCPUMem() (map[string]types.DomainMetric, error) {
+	return nil, nil
+}

--- a/pkg/pillar/hypervisor/hypervisor.go
+++ b/pkg/pillar/hypervisor/hypervisor.go
@@ -42,10 +42,11 @@ type hypervisorDesc struct {
 }
 
 var knownHypervisors = map[string]hypervisorDesc{
-	"xen":  {constructor: newXen, dom0handle: "/proc/xen"},
-	"kvm":  {constructor: newKvm, dom0handle: "/dev/kvm"},
-	"acrn": {constructor: newAcrn, dom0handle: "/dev/acrn"},
-	"null": {constructor: newNull, dom0handle: ""},
+	"xen":        {constructor: newXen, dom0handle: "/proc/xen"},
+	"kvm":        {constructor: newKvm, dom0handle: "/dev/kvm"},
+	"acrn":       {constructor: newAcrn, dom0handle: "/dev/acrn"},
+	"containerd": {constructor: newContainerd, dom0handle: "/run/containerd/containerd.sock"},
+	"null":       {constructor: newNull, dom0handle: ""},
 }
 
 // GetHypervisor returns a particular hypervisor implementation

--- a/pkg/pillar/hypervisor/hypervisor_test.go
+++ b/pkg/pillar/hypervisor/hypervisor_test.go
@@ -21,7 +21,7 @@ func TestGetHypervisor(t *testing.T) {
 
 func TestGetAvailableHypervisors(t *testing.T) {
 	all, enabled := GetAvailableHypervisors()
-	expected := []string{"acrn", "kvm", "null", "xen"}
+	expected := []string{"acrn", "containerd", "kvm", "null", "xen"}
 
 	sort.Strings(all)
 	if !reflect.DeepEqual(all, expected) {


### PR DESCRIPTION
This PR introduces a "fake" (some would call it void) hypervisor that doesn't do any isolation but simply relies on containerd to launch the tasks. Obviously the only type of Apps this type of hypervisor can run are the ones with the containerd Volume as their root filesystem, but this is actually very nice for e2e testing when running qemu.

Aside from the entertainment value of being able to run native containers without any hypervisor on EVE, it actually has a new function that will be the basis of this proposal:
    https://github.com/rvs/eve/blob/ctrd/pkg/pillar/containerd/containerd.go#L755

What this function does -- it allows us to launch honest, containerd tasks (wrapped in an honest container) instead of doing weird cross-container calls like this one:
     https://github.com/rvs/eve/blob/ctrd/pkg/pillar/rootfs/usr/sbin/qemu-system-aarch64

My proposal is to use that function instead of wrap.Command() calls that we do today. Thus, instead of:
```
    stdoutStderr, err := wrap.Command(ctx.dmExec, append(dmArgs,
           "-name", domainName,
           "-readconfig", cfgFilename,
           "-pidfile", pidFile)...).CombinedOutput()
```
from here https://github.com/rvs/eve/blob/ctrd/pkg/pillar/hypervisor/kvm.go#L472 we will actually do something along the lines of:
```
containerd.LKLaunch(domainName, "xen-tools", domConfig,
    append(ctx.dmExec, dmArgs,
                 "-name", domainName,
                 "-readconfig", cfgFilename,
                  "-pidfile", pidFile))
```
This will have an effect of starting an actual task named domainNamewithin the container created on the basis of the root filesystem from"xen-tools" for the sole purpose of running qemu there AND enforcingcgroups memory and CPU controls. Additional benefits include seamless logging that goes straight to memlogdand full integration with containerd statistics gathering tools and techniques. The nice property of this becomes that containerd containers that arelocated in eve-user-apps namespace then get to represent EVE tasksregardless of whether they are running with or without a hypervisor. This symmetry will give us a bunch of nice properties down the roadand will simplify management side of things.