### PR TITLE
block network instance config with app-direct port

### DIFF
--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -315,20 +315,6 @@ func publishNetworkInstanceConfig(ctx *getconfigContext,
 
 		if apiConfigEntry.Port != nil {
 			networkInstanceConfig.Logicallabel = apiConfigEntry.Port.Name
-			foundPort := false
-			for _, portCfg := range ctx.devicePortConfig.Ports {
-				if niHasValidPort(networkInstanceConfig.Logicallabel, portCfg.Logicallabel) {
-					foundPort = true
-					break
-				}
-			}
-			// To prevent the NI physical port bound to an App-Direct type
-			if !foundPort {
-				log.Errorf("publishNetworkInstanceConfig: network instance port %s does not exist\n",
-					networkInstanceConfig.Logicallabel)
-				continue
-			}
-			log.Infof("publishNetworkInstanceConfig: network instance port %s check ok\n", networkInstanceConfig.Logicallabel)
 		}
 		networkInstanceConfig.IpType = types.AddressType(apiConfigEntry.IpType)
 
@@ -2088,12 +2074,4 @@ func handleDeviceReboot(ctxPtr *zedagentContext) {
 	// shutdown the application instances
 	shutdownAppsGlobal(ctxPtr)
 	// nothing else to be done
-}
-
-func niHasValidPort(label, portLable string) bool {
-	if label == "" || strings.EqualFold(label, "uplink") ||
-		strings.EqualFold(label, "freeuplink") || label == portLable {
-		return true
-	}
-	return false
 }

--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -565,6 +565,12 @@ func doNetworkInstanceSanityCheck(
 	log.Infof("Sanity Checking NetworkInstance(%s-%s): type:%d, IpType:%d\n",
 		status.DisplayName, status.UUID, status.Type, status.IpType)
 
+	err := checkNIphysicalPort(ctx, status)
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
 	//  Check NetworkInstanceType
 	switch status.Type {
 	case types.NetworkInstanceTypeLocal:
@@ -711,6 +717,13 @@ func doNetworkInstanceModify(ctx *zedrouterContext,
 		status.SetErrorNow(err.Error())
 	}
 
+	err := checkNIphysicalPort(ctx, status)
+	if err != nil {
+		log.Error(err)
+		status.SetErrorNow(err.Error())
+		return
+	}
+
 	if config.Logicallabel != status.Logicallabel {
 		err := fmt.Errorf("Changing Logicallabel in NetworkInstance is not yet supported: from %s to %s",
 			status.Logicallabel, config.Logicallabel)
@@ -733,6 +746,21 @@ func doNetworkInstanceModify(ctx *zedrouterContext,
 		doNetworkInstanceInactivate(ctx, status)
 		status.Activated = false
 	}
+}
+
+func checkNIphysicalPort(ctx *zedrouterContext, status *types.NetworkInstanceStatus) error {
+	// check the NI have the valid physical port binding to
+	label := status.Logicallabel
+	if label != "" && !strings.EqualFold(label, "uplink") &&
+		!strings.EqualFold(label, "freeuplink") {
+		ifname := types.LogicallabelToIfName(ctx.deviceNetworkStatus, label)
+		devPort := ctx.deviceNetworkStatus.GetPortByIfName(ifname)
+		if devPort == nil {
+			err := fmt.Sprintf("Network Instance port %s does not exist", label)
+			return errors.New(err)
+		}
+	}
+	return nil
 }
 
 // getSwitchNetworkInstanceUsingIfname


### PR DESCRIPTION
Signed-off-by: Naiming Shen <naiming@zededa.com>
- fix an error fatal condition due to NI bound to port with App-Direct mode
- UI does not allow such a config, test scripts need to be fixed to block this later
- with the patch, the zedcloud will show NI is there with 'Unknown' status, the error is in log
- tested with SmokeSuite, only one fail 'test_app_purge_bad', which is in the same condition trying to config the NI with App-Direct (blocked by this patch), but may fail the test for not able to purge
