### PR TITLE
Added a config item to restrict maxDiskSpace for Dom0 to an absolute value, not just a percentage of total disk

### DIFF
--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -138,6 +138,9 @@ const (
 	NetworkSendTimeout GlobalSettingKey = "timer.send.timeout"
 	// Dom0MinDiskUsagePercent global setting key
 	Dom0MinDiskUsagePercent GlobalSettingKey = "storage.dom0.disk.minusage.percent"
+	// Dom0DiskUsageMaxBytes - Max disk usage for Dom0. Dom0 can use
+	//  Dom0MinDiskUsagePercent upto a max of  Dom0DiskUsageMaxBytes
+	Dom0DiskUsageMaxBytes GlobalSettingKey = "storage.dom0.disk.maxusagebytes"
 
 	// Bool Items
 	// UsbAccess global setting key
@@ -702,6 +705,9 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddIntItem(NetworkTestTimeout, 15, 0, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(NetworkSendTimeout, 120, 0, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(Dom0MinDiskUsagePercent, 20, 20, 0xFFFFFFFF)
+	// Dom0DiskUsageMaxBytes - Default is 2GB, min is 100MB
+	configItemSpecMap.AddIntItem(Dom0DiskUsageMaxBytes, 2*1024*1024*1024,
+		100*1024*1024, 0xFFFFFFFF)
 
 	// Add Bool Items
 	configItemSpecMap.AddBoolItem(UsbAccess, true) // Controller likely default to false

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -165,6 +165,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		NetworkTestTimeout,
 		NetworkSendTimeout,
 		Dom0MinDiskUsagePercent,
+		Dom0DiskUsageMaxBytes,
 		// Bool Items
 		UsbAccess,
 		AllowAppVnc,


### PR DESCRIPTION
Added a new configItem "storage.dom0.disk.maxusagebytes"
This puts a max value of disk reserved for Dom0. For devices with larger disks, reserving 20% ( Say, for a device with 256G drive, reserving 50G for Dom0 ) is too much. hence have the ability to configure a max disk size for dom0

diskReservedForDom0 = min(Value from Dom0MinDiskUsagePercent, maxDom0DiskSize )

Currently, Int for config items are U32 ( can store upto 4G ). To allow bigger values for dom0, we need to make it U64. Will make that change in a separate PR.. Till that happens, storage.dom0.disk.maxusagebytes can be upto 4G.