### PR TITLE
Minor log enhancement

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -44,8 +44,8 @@ func parseControllerCerts(ctx *zedagentContext, contents []byte) {
 	log.Infof("parseControllerCerts: Applying updated config\n"+
 		"Last Sha: % x\n"+
 		"New  Sha: % x\n"+
-		"cfgCertList: %v\n",
-		certHash, newHash, cfgCerts)
+		"Num of cfgCert: %d\n",
+		certHash, newHash, len(cfgCerts))
 
 	certHash = newHash
 

--- a/pkg/pillar/cmd/zedagent/handlecipherconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecipherconfig.go
@@ -34,8 +34,8 @@ func parseCipherContext(ctx *getconfigContext,
 	log.Infof("parseCipherContext: Applying updated config\n"+
 		"Last Sha: % x\n"+
 		"New  Sha: % x\n"+
-		"cfgCipherContextList: %v\n",
-		cipherCtxHash, newHash, cfgCipherContextList)
+		"Num of cfgCipherContext: %d\n",
+		cipherCtxHash, newHash, len(cfgCipherContextList))
 
 	cipherCtxHash = newHash
 


### PR DESCRIPTION
Adding number of controller certs and cipher contexts in the logs instead
of dumping whole thing.

Signed-off-by: zed-rishabh <rgupta@zededa.com>