### PR TITLE
NetworkPortStatus Error disamiguation

### DIFF
--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -561,20 +561,20 @@ func printOutput(ctx *diagContext) {
 		}
 
 		fmt.Fprintf(outfile, "INFO: %s: DNS servers: ", ifname)
-		for _, ds := range port.DnsServers {
+		for _, ds := range port.NetworkXConfig.DnsServers {
 			fmt.Fprintf(outfile, "%s, ", ds.String())
 		}
 		fmt.Fprintf(outfile, "\n")
 		// If static print static config
-		if port.Dhcp == types.DT_STATIC {
+		if port.NetworkXConfig.Dhcp == types.DT_STATIC {
 			fmt.Fprintf(outfile, "INFO: %s: Static IP subnet: %s\n",
-				ifname, port.Subnet.String())
+				ifname, port.NetworkXConfig.Subnet.String())
 			fmt.Fprintf(outfile, "INFO: %s: Static IP router: %s\n",
-				ifname, port.Gateway.String())
+				ifname, port.NetworkXConfig.Gateway.String())
 			fmt.Fprintf(outfile, "INFO: %s: Static Domain Name: %s\n",
-				ifname, port.DomainName)
+				ifname, port.NetworkXConfig.DomainName)
 			fmt.Fprintf(outfile, "INFO: %s: Static NTP server: %s\n",
-				ifname, port.NtpServer.String())
+				ifname, port.NetworkXConfig.NtpServer.String())
 		}
 		printProxy(ctx, port, ifname)
 
@@ -655,7 +655,8 @@ func printProxy(ctx *diagContext, port types.NetworkPortStatus,
 			ifname, port.ProxyConfig.Exceptions)
 	}
 	if port.HasError() {
-		fmt.Fprintf(outfile, "ERROR: %s: from WPAD? %s\n", ifname, port.Error)
+		fmt.Fprintf(outfile, "ERROR: %s: from WPAD? %s\n",
+			ifname, port.Error)
 	}
 	if port.ProxyConfig.NetworkProxyEnable {
 		if port.ProxyConfig.NetworkProxyURL == "" {

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -1165,8 +1165,8 @@ func getNetInfo(interfaceDetail psutilnet.InterfaceStat,
 		networkInfo.Uplink = port.IsMgmt
 		// fill in ZInfoDNS
 		networkInfo.Dns = new(info.ZInfoDNS)
-		networkInfo.Dns.DNSdomain = port.DomainName
-		for _, server := range port.DnsServers {
+		networkInfo.Dns.DNSdomain = port.NetworkXConfig.DomainName
+		for _, server := range port.NetworkXConfig.DnsServers {
 			networkInfo.Dns.DNSservers = append(networkInfo.Dns.DNSservers,
 				server.String())
 		}

--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -91,7 +91,7 @@ func checkPortAvailable(
 
 	if allowSharedPort(status) {
 		// Make sure it is configured for IP or will be
-		if portStatus.Dhcp == types.DT_NONE {
+		if portStatus.NetworkXConfig.Dhcp == types.DT_NONE {
 			errStr := fmt.Sprintf("Port %s not configured for shared use. "+
 				"Cannot be used by Switch Network Instance %s-%s\n",
 				status.CurrentUplinkIntf, status.UUID, status.DisplayName)
@@ -117,10 +117,10 @@ func checkPortAvailable(
 		}
 	} else {
 		// Make sure it will not be configured for IP
-		if portStatus.Dhcp != types.DT_NONE {
+		if portStatus.NetworkXConfig.Dhcp != types.DT_NONE {
 			errStr := fmt.Sprintf("Port %s configured for shared use with DHCP type %d. "+
 				"Cannot be used by Switch Network Instance %s-%s\n",
-				status.CurrentUplinkIntf, portStatus.Dhcp, status.UUID, status.DisplayName)
+				status.CurrentUplinkIntf, portStatus.NetworkXConfig.Dhcp, status.UUID, status.DisplayName)
 			return errors.New(errStr)
 		}
 		// Make sure it is not used by any other NetworkInstance

--- a/pkg/pillar/cmd/zedrouter/probe.go
+++ b/pkg/pillar/cmd/zedrouter/probe.go
@@ -130,7 +130,7 @@ func niProbingUpdatePort(ctx *zedrouterContext, port types.NetworkPortStatus,
 	}
 	// we skip the non-Mgmt port for now
 	if !port.IsMgmt {
-		log.Infof("niProbingUpdatePort: %s is type %v, not mgmt, skip\n", port.IfName, port.Type)
+		log.Infof("niProbingUpdatePort: %s is type %v, not mgmt, skip\n", port.IfName, port.NetworkXConfig.Type)
 		if info, ok := netstatus.PInfo[port.IfName]; ok {
 			log.Infof("niProbingUpdatePort:   info intf %s is present %v\n", info.IfName, info.IsPresent)
 		}
@@ -149,7 +149,7 @@ func niProbingUpdatePort(ctx *zedrouterContext, port types.NetworkPortStatus,
 			IfName:       port.IfName,
 			IsPresent:    true,
 			GatewayUP:    true,
-			NhAddr:       port.Gateway,
+			NhAddr:       port.NetworkXConfig.Gateway,
 			LocalAddr:    portGetIntfAddr(port),
 			IsFree:       port.Free,
 			RemoteHostUP: true,
@@ -165,7 +165,7 @@ func niProbingUpdatePort(ctx *zedrouterContext, port types.NetworkPortStatus,
 		info := netstatus.PInfo[port.IfName]
 		prevLocalAddr := info.LocalAddr
 		info.IsPresent = true
-		info.NhAddr = port.Gateway
+		info.NhAddr = port.NetworkXConfig.Gateway
 		info.LocalAddr = portGetIntfAddr(port)
 		info.IsFree = port.Free
 		// the probe status are copied inside publish NI status
@@ -289,7 +289,7 @@ func checkNIprobeUplink(ctx *zedrouterContext, status *types.NetworkInstanceStat
 func portGetIntfAddr(port types.NetworkPortStatus) net.IP {
 	var localip net.IP
 	for _, addrinfo := range port.AddrInfoList {
-		if port.Subnet.Contains(addrinfo.Addr) {
+		if port.NetworkXConfig.Subnet.Contains(addrinfo.Addr) {
 			localip = addrinfo.Addr
 		}
 	}

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -3034,24 +3034,24 @@ func isDNSServerChanged(ctx *zedrouterContext, newStatus *types.DeviceNetworkSta
 		if _, ok := ctx.dnsServers[port.IfName]; !ok {
 			// if dnsServer does not have valid server IPs, assign now
 			// and if we lose uplink connection, it will not overwrite the previous server IPs
-			if len(port.DnsServers) > 0 { // just assigned
-				ctx.dnsServers[port.IfName] = port.DnsServers
+			if len(port.NetworkXConfig.DnsServers) > 0 { // just assigned
+				ctx.dnsServers[port.IfName] = port.NetworkXConfig.DnsServers
 			}
 		} else {
 			// only check if we have valid new DNS server sets on the uplink
 			// valid DNS server IP changes will trigger the restart of dnsmasq.
-			if len(port.DnsServers) != 0 {
+			if len(port.NetworkXConfig.DnsServers) != 0 {
 				// new one has different entries, and not the Internet disconnect case
-				if len(ctx.dnsServers[port.IfName]) != len(port.DnsServers) {
-					ctx.dnsServers[port.IfName] = port.DnsServers
+				if len(ctx.dnsServers[port.IfName]) != len(port.NetworkXConfig.DnsServers) {
+					ctx.dnsServers[port.IfName] = port.NetworkXConfig.DnsServers
 					dnsDiffer = true
 					continue
 				}
-				for idx, server := range port.DnsServers { // compare each one and update if changed
+				for idx, server := range port.NetworkXConfig.DnsServers { // compare each one and update if changed
 					if server.Equal(ctx.dnsServers[port.IfName][idx]) == false {
 						log.Infof("isDnsServerChanged: intf %s exist %v, new %v\n",
-							port.IfName, ctx.dnsServers[port.IfName], port.DnsServers)
-						ctx.dnsServers[port.IfName] = port.DnsServers
+							port.IfName, ctx.dnsServers[port.IfName], port.NetworkXConfig.DnsServers)
+						ctx.dnsServers[port.IfName] = port.NetworkXConfig.DnsServers
 						dnsDiffer = true
 						break
 					}

--- a/pkg/pillar/devicenetwork/devicenetwork.go
+++ b/pkg/pillar/devicenetwork/devicenetwork.go
@@ -198,15 +198,15 @@ func MakeDeviceNetworkStatus(globalConfig types.DevicePortConfig, oldStatus type
 		globalStatus.Ports[ix].Free = u.Free
 		globalStatus.Ports[ix].ProxyConfig = u.ProxyConfig
 		// Set fields from the config...
-		globalStatus.Ports[ix].Dhcp = u.Dhcp
+		globalStatus.Ports[ix].NetworkXConfig.Dhcp = u.Dhcp
 		_, subnet, _ := net.ParseCIDR(u.AddrSubnet)
 		if subnet != nil {
-			globalStatus.Ports[ix].Subnet = *subnet
+			globalStatus.Ports[ix].NetworkXConfig.Subnet = *subnet
 		}
-		globalStatus.Ports[ix].Gateway = u.Gateway
-		globalStatus.Ports[ix].DomainName = u.DomainName
-		globalStatus.Ports[ix].NtpServer = u.NtpServer
-		globalStatus.Ports[ix].DnsServers = u.DnsServers
+		globalStatus.Ports[ix].NetworkXConfig.Gateway = u.Gateway
+		globalStatus.Ports[ix].NetworkXConfig.DomainName = u.DomainName
+		globalStatus.Ports[ix].NetworkXConfig.NtpServer = u.NtpServer
+		globalStatus.Ports[ix].NetworkXConfig.DnsServers = u.DnsServers
 		globalStatus.Ports[ix].ErrorAndTime = u.ErrorAndTime
 		ifindex, err := IfnameToIndex(u.IfName)
 		if err != nil {

--- a/pkg/pillar/devicenetwork/devicenetwork.go
+++ b/pkg/pillar/devicenetwork/devicenetwork.go
@@ -239,12 +239,7 @@ func MakeDeviceNetworkStatus(globalConfig types.DevicePortConfig, oldStatus type
 			globalStatus.Ports[ix].AddrInfoList[i].Addr = addr
 		}
 		// Get DNS etc info from dhcpcd. Updates DomainName and DnsServers
-		err = GetDhcpInfo(&globalStatus.Ports[ix])
-		if err != nil {
-			errStr := fmt.Sprintf("GetDhcpInfo failed %s", err)
-			globalStatus.Ports[ix].Error = errStr
-			globalStatus.Ports[ix].ErrorTime = time.Now()
-		}
+		GetDhcpInfo(&globalStatus.Ports[ix])
 		GetDNSInfo(&globalStatus.Ports[ix])
 
 		// Attempt to get a wpad.dat file if so configured
@@ -255,6 +250,7 @@ func MakeDeviceNetworkStatus(globalConfig types.DevicePortConfig, oldStatus type
 			&globalStatus.Ports[ix])
 		if err != nil {
 			errStr := fmt.Sprintf("GetNetworkProxy failed %s", err)
+			// Clobbers ErrorAndTime from above
 			globalStatus.Ports[ix].Error = errStr
 			globalStatus.Ports[ix].ErrorTime = time.Now()
 		}

--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -892,10 +892,11 @@ func generateResolvConf(globalStatus types.DeviceNetworkStatus, destfile *os.Fil
 			continue
 		}
 		log.Infof("generateResolvConf %s has %d servers: %v",
-			us.IfName, len(us.DnsServers), us.DnsServers)
+			us.IfName, len(us.NetworkXConfig.DnsServers),
+			us.NetworkXConfig.DnsServers)
 		destfile.WriteString(fmt.Sprintf("# From %s\n", us.IfName))
 		// Avoid duplicate IP addresses for nameservers.
-		for _, server := range us.DnsServers {
+		for _, server := range us.NetworkXConfig.DnsServers {
 			duplicate := false
 			for _, a := range written {
 				if a.Equal(server) {

--- a/pkg/pillar/devicenetwork/dns.go
+++ b/pkg/pillar/devicenetwork/dns.go
@@ -18,14 +18,14 @@ import (
 // GetDhcpInfo gets info from dhcpcd. Updates Gateway and Subnet
 // XXX set NtpServer once we know what name it has
 // XXX add IPv6 support?
-func GetDhcpInfo(us *types.NetworkPortStatus) error {
+func GetDhcpInfo(us *types.NetworkPortStatus) {
 
 	log.Infof("GetDhcpInfo(%s)\n", us.IfName)
 	if us.Dhcp != types.DT_CLIENT {
-		return nil
+		return
 	}
 	if strings.HasPrefix(us.IfName, "wwan") {
-		return nil
+		return
 	}
 	// XXX get error -1 unless we have -4
 	// XXX add IPv6 support
@@ -36,7 +36,7 @@ func GetDhcpInfo(us *types.NetworkPortStatus) error {
 		errStr := fmt.Sprintf("dhcpcd -U failed %s: %s",
 			string(stdoutStderr), err)
 		log.Errorln(errStr)
-		return nil
+		return
 	}
 	log.Debugf("dhcpcd -U got %v\n", string(stdoutStderr))
 	lines := strings.Split(string(stdoutStderr), "\n")
@@ -82,7 +82,6 @@ func GetDhcpInfo(us *types.NetworkPortStatus) error {
 		}
 	}
 	us.Subnet = net.IPNet{IP: subnet, Mask: net.CIDRMask(masklen, 32)}
-	return nil
 }
 
 // GetDNSInfo gets DNS info from /run files. Updates DomainName and DnsServers

--- a/pkg/pillar/devicenetwork/dns.go
+++ b/pkg/pillar/devicenetwork/dns.go
@@ -21,7 +21,7 @@ import (
 func GetDhcpInfo(us *types.NetworkPortStatus) {
 
 	log.Infof("GetDhcpInfo(%s)\n", us.IfName)
-	if us.Dhcp != types.DT_CLIENT {
+	if us.NetworkXConfig.Dhcp != types.DT_CLIENT {
 		return
 	}
 	if strings.HasPrefix(us.IfName, "wwan") {
@@ -59,7 +59,7 @@ func GetDhcpInfo(us *types.NetworkPortStatus) {
 				log.Errorf("Failed to parse %s\n", routers)
 				continue
 			}
-			us.Gateway = ip
+			us.NetworkXConfig.Gateway = ip
 		case "network_number":
 			network := trimQuotes(items[1])
 			log.Infof("GetDhcpInfo(%s) network_number %s\n", us.IfName,
@@ -81,14 +81,14 @@ func GetDhcpInfo(us *types.NetworkPortStatus) {
 			}
 		}
 	}
-	us.Subnet = net.IPNet{IP: subnet, Mask: net.CIDRMask(masklen, 32)}
+	us.NetworkXConfig.Subnet = net.IPNet{IP: subnet, Mask: net.CIDRMask(masklen, 32)}
 }
 
 // GetDNSInfo gets DNS info from /run files. Updates DomainName and DnsServers
 func GetDNSInfo(us *types.NetworkPortStatus) {
 
 	log.Infof("GetDNSInfo(%s)\n", us.IfName)
-	if us.Dhcp != types.DT_CLIENT {
+	if us.NetworkXConfig.Dhcp != types.DT_CLIENT {
 		return
 	}
 	filename := IfnameToResolvConf(us.IfName)
@@ -106,11 +106,11 @@ func GetDNSInfo(us *types.NetworkPortStatus) {
 			log.Errorf("Failed to parse %s\n", server)
 			continue
 		}
-		us.DnsServers = append(us.DnsServers, ip)
+		us.NetworkXConfig.DnsServers = append(us.NetworkXConfig.DnsServers, ip)
 	}
 	// XXX just pick first since have one DomainName slot
 	for _, dn := range dc.Search {
-		us.DomainName = dn
+		us.NetworkXConfig.DomainName = dn
 		break
 	}
 }

--- a/pkg/pillar/devicenetwork/wpad.go
+++ b/pkg/pillar/devicenetwork/wpad.go
@@ -47,7 +47,7 @@ func CheckAndGetNetworkProxy(deviceNetworkStatus *types.DeviceNetworkStatus,
 		proxyConfig.Pacfile = pac
 		return nil
 	}
-	dn := status.DomainName
+	dn := status.NetworkXConfig.DomainName
 	if dn == "" {
 		errStr := fmt.Sprintf("NetworkProxyEnable for %s but neither a NetworkProxyURL nor a DomainName",
 			ifname)

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -496,13 +496,13 @@ type NetworkPortConfig struct {
 }
 
 type NetworkPortStatus struct {
-	IfName       string
-	Phylabel     string // Physical name set by controller/model
-	Logicallabel string
-	IsMgmt       bool // Used to talk to controller
-	Free         bool
-	NetworkXObjectConfig
-	AddrInfoList []AddrInfo
+	IfName         string
+	Phylabel       string // Physical name set by controller/model
+	Logicallabel   string
+	IsMgmt         bool // Used to talk to controller
+	Free           bool
+	NetworkXConfig NetworkXObjectConfig
+	AddrInfoList   []AddrInfo
 	ProxyConfig
 	// ErrorAndTime provides SetErrorNow() and ClearError()
 	ErrorAndTime
@@ -645,7 +645,7 @@ func CountDNSServers(globalStatus DeviceNetworkStatus, phylabelOrIfname string) 
 		if us.IfName != ifname && ifname != "" {
 			continue
 		}
-		count += len(us.DnsServers)
+		count += len(us.NetworkXConfig.DnsServers)
 	}
 	return count
 }
@@ -661,7 +661,7 @@ func GetDNSServers(globalStatus DeviceNetworkStatus, ifname string) []net.IP {
 		if ifname != "" && ifname != us.IfName {
 			continue
 		}
-		for _, server := range us.DnsServers {
+		for _, server := range us.NetworkXConfig.DnsServers {
 			servers = append(servers, server)
 		}
 	}


### PR DESCRIPTION
NetworkPortStatus embeds an ErrorAndTime, which is fine.
But it also embeds a NetworkXObjectConfig, which in turn embeds an ErrorAndTime.

This has compiled just fine since golang silently gets preference to the directly embeedded struct over the indirectly embedded.
This is rather confusion and and lead to future errors if some code accesses nps.ErrorAndTime and other code nps.NetworkXObjectConfig.ErrorAndTime.

Hence changing things to not embed NetworkXObjectConfig