### PR TITLE
Refactoring containerd volume support to skip container creation

### DIFF
--- a/pkg/pillar/cmd/volumemgr/create.go
+++ b/pkg/pillar/cmd/volumemgr/create.go
@@ -92,7 +92,7 @@ func createContainerVolume(ctx *volumemgrContext, status *types.VolumeStatus, sr
 		return changed, errors.New(errStr)
 	}
 	log.Infof("ociFilename %s sha %s", ociFilename, status.ContainerSha256)
-	if err := containerd.CtrPrepare(filelocation, ociFilename); err != nil {
+	if err := containerd.SnapshotPrepare(filelocation, ociFilename); err != nil {
 		log.Errorf("Failed to create ctr bundle. Error %s", err)
 		return changed, err
 	}
@@ -155,7 +155,7 @@ func destroyContainerVolume(ctx *volumemgrContext, status *types.VolumeStatus) (
 
 	changed := false
 	log.Infof("Removing container volume %s", status.FileLocation)
-	if err := containerd.CtrRm(status.FileLocation, false); err != nil {
+	if err := containerd.SnapshotRm(status.FileLocation, false); err != nil {
 		return changed, err
 	}
 	status.FileLocation = ""


### PR DESCRIPTION
Adding @adarsh-zededa -- somehow I couldn't add you to the reviewers list

There's currently no reason for us to create actual containers when we create snapshots for Image filesystems. In fact, it is actually counter productive since we have tons of dangling containers on the system which we never clean up.

I'm not yet changing the ctrCreate method (it will get significantly refactored with #898) but I'm basically replacing a call to it with direct getImageInfoJSON/createBundle calls.

At the same time -- I'm getting rid of containerConfigFilename creation for now -- since we're not using it for anything yet AND the way it is created is a bit useless anyway.