### PR TITLE
Have nim test all management interfaces and report failure/success

### DIFF
--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -656,7 +656,7 @@ func printProxy(ctx *diagContext, port types.NetworkPortStatus,
 	}
 	if port.HasError() {
 		fmt.Fprintf(outfile, "ERROR: %s: from WPAD? %s\n",
-			ifname, port.Error)
+			ifname, port.LastError)
 	}
 	if port.ProxyConfig.NetworkProxyEnable {
 		if port.ProxyConfig.NetworkProxyURL == "" {

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -729,9 +729,18 @@ func updateFilteredFallback(ctx *nimContext) {
 	}
 }
 
+// Hard-coded at 1 for now; at least one interface needs to work
+const successCount uint = 1
+
+// Verify that at least one of the management interfaces work.
+// Start with a different one (based on Iteration) to make sure that we try
+// all over time.
 func tryDeviceConnectivityToCloud(ctx *devicenetwork.DeviceNetworkContext) bool {
+	// Start with a different port to cycle through them all over time
+	ctx.Iteration++
 	rtf, intfStatusMap, err := devicenetwork.VerifyDeviceNetworkStatus(
-		*ctx.DeviceNetworkStatus, 1, ctx.TestSendTimeout)
+		*ctx.DeviceNetworkStatus, successCount, ctx.Iteration,
+		ctx.TestSendTimeout)
 	ctx.DevicePortConfig.UpdatePortStatusFromIntfStatusMap(intfStatusMap)
 	// Use TestResults to update the DevicePortConfigList and publish
 	// Note that the TestResults will at least have an updated timestamp

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -669,7 +669,7 @@ func parseOneSystemAdapterConfig(getconfigCtx *getconfigContext,
 			sysAdapter.Name, sysAdapter.LowerLayerName)
 		log.Error(errStr)
 		// Report error but set Dhcp, isMgmt, and isFree to sane values
-		port.SetErrorNow(errStr)
+		port.RecordFailure(errStr)
 		port.Logicallabel = port.Phylabel
 		port.IfName = sysAdapter.Name
 		isFree = true
@@ -726,7 +726,7 @@ func parseOneSystemAdapterConfig(getconfigCtx *getconfigContext,
 				"SysAdapter.Addr %s. The IP address is ignored. Please fix the "+
 				"device configuration.", sysAdapter.Name, sysAdapter.Addr)
 			log.Errorf("parseSystemAdapterConfig: %s", errStr)
-			port.SetErrorNow(errStr)
+			port.RecordFailure(errStr)
 			// IP will not be set below
 		}
 		// Note that ip is not used unless we have a network UUID
@@ -744,7 +744,7 @@ func parseOneSystemAdapterConfig(getconfigCtx *getconfigContext,
 				"device configuration.",
 				port.IfName, sysAdapter.NetworkUUID, err)
 			log.Errorf("parseSystemAdapterConfig: %s", errStr)
-			port.SetErrorNow(errStr)
+			port.RecordFailure(errStr)
 		} else {
 			net := networkXObject.(types.NetworkXObjectConfig)
 			port.NetworkUUID = net.UUID
@@ -754,7 +754,7 @@ func parseOneSystemAdapterConfig(getconfigCtx *getconfigContext,
 					"(UUID: %s) which has an error (%s).",
 					port.IfName, port.NetworkUUID, network.Error)
 				log.Errorf("parseSystemAdapterConfig: %s", errStr)
-				port.SetErrorNow(errStr)
+				port.RecordFailure(errStr)
 			}
 		}
 
@@ -779,7 +779,7 @@ func parseOneSystemAdapterConfig(getconfigCtx *getconfigContext,
 					"missing subnet address. SysAdapter - Name: %s, Addr:%s",
 					port.IfName, sysAdapter.Name, sysAdapter.Addr)
 				log.Errorf("parseSystemAdapterConfig: %s", errStr)
-				port.SetErrorNow(errStr)
+				port.RecordFailure(errStr)
 			}
 		case types.DT_CLIENT:
 			// Do nothing
@@ -791,13 +791,13 @@ func parseOneSystemAdapterConfig(getconfigCtx *getconfigContext,
 					port.IfName, types.DT_NONE)
 
 				log.Errorf("parseSystemAdapterConfig: %s", errStr)
-				port.SetErrorNow(errStr)
+				port.RecordFailure(errStr)
 			}
 		default:
 			errStr := fmt.Sprintf("Port %s configured with unknown DHCP type %v",
 				port.IfName, network.Dhcp)
 			log.Errorf("parseSystemAdapterConfig: %s", errStr)
-			port.SetErrorNow(errStr)
+			port.RecordFailure(errStr)
 		}
 		// XXX use DnsNameToIpList?
 		if network != nil && network.Proxy != nil {
@@ -808,7 +808,7 @@ func parseOneSystemAdapterConfig(getconfigCtx *getconfigContext,
 			"configuring a Network. Network is required for Management ports",
 			port.IfName)
 		log.Errorf("parseSystemAdapterConfig: %s", errStr)
-		port.SetErrorNow(errStr)
+		port.RecordFailure(errStr)
 	}
 	return port
 }

--- a/pkg/pillar/devicenetwork/devicenetwork.go
+++ b/pkg/pillar/devicenetwork/devicenetwork.go
@@ -77,8 +77,8 @@ func IsProxyConfigEmpty(proxyConfig types.ProxyConfig) bool {
 }
 
 // VerifyDeviceNetworkStatus
-//  Check if device can talk to outside world via atleast one of the
-//  free uplinks
+//  Check if device can talk to outside world via atleast 'successCount' of the
+//  uplinks
 // Return Values:
 //  Success / Failure
 //  error - Overall Error
@@ -88,9 +88,10 @@ func IsProxyConfigEmpty(proxyConfig types.ProxyConfig) bool {
 //      set Error ( If success, set to "")
 //      set ErrorTime to time of testing ( Even if verify Successful )
 func VerifyDeviceNetworkStatus(status types.DeviceNetworkStatus,
-	retryCount int, timeout uint32) (bool, types.IntfStatusMap, error) {
+	successCount uint, iteration int, timeout uint32) (bool, types.IntfStatusMap, error) {
 
-	log.Debugf("VerifyDeviceNetworkStatus() %d\n", retryCount)
+	log.Debugf("VerifyDeviceNetworkStatus() successCount %d, iteration %d",
+		successCount, iteration)
 
 	// Map of per-interface errors
 	intfStatusMap := *types.NewIntfStatusMap()
@@ -157,7 +158,7 @@ func VerifyDeviceNetworkStatus(status types.DeviceNetworkStatus,
 		}
 	}
 	cloudReachable, rtf, tempIntfStatusMap, err := zedcloud.VerifyAllIntf(
-		&zedcloudCtx, testURL, retryCount, 1)
+		&zedcloudCtx, testURL, successCount, iteration)
 	intfStatusMap.SetOrUpdateFromMap(tempIntfStatusMap)
 	log.Debugf("VerifyDeviceNetworkStatus: intfStatusMap - %+v", intfStatusMap)
 	if err != nil {

--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -61,6 +61,7 @@ type DeviceNetworkContext struct {
 	NetworkTestBetterTimer *time.Timer
 	NextDPCIndex           int
 	CloudConnectivityWorks bool
+	Iteration              int // Start with different interfaces each time
 
 	// Timers in seconds
 	DPCTestDuration           uint32 // Wait for DHCP address
@@ -252,7 +253,11 @@ func VerifyPending(ctx *DeviceNetworkContext, pending *DPCPending,
 	pending.PendDNS = pend2
 
 	// We want connectivity to zedcloud via atleast one Management port.
-	rtf, intfStatusMap, err := VerifyDeviceNetworkStatus(pending.PendDNS, 1, timeout)
+	// Hard-coded at 1 for now; at least one interface needs to work
+	const successCount uint = 1
+	ctx.Iteration++
+	rtf, intfStatusMap, err := VerifyDeviceNetworkStatus(pending.PendDNS,
+		successCount, ctx.Iteration, timeout)
 	// Use TestResults to update the DevicePortConfigList and DeviceNetworkStatus
 	// Note that the TestResults will at least have an updated timestamp
 	// for one of the ports.

--- a/pkg/pillar/devicenetwork/dnc_test.go
+++ b/pkg/pillar/devicenetwork/dnc_test.go
@@ -78,32 +78,40 @@ var testMatrix = map[string]compressDPCLTestEntry{
 			CurrentIndex: 0,
 			PortConfigList: []types.DevicePortConfig{
 				{ // Successful Zedagent Entry
-					Version:       1,
-					Key:           "zedagent",
-					TimePriority:  time.Date(2000, 3, 3, 0, 0, 0, 0, time.UTC),
-					LastSucceeded: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
-					Ports:         []types.NetworkPortConfig{},
+					Version:      1,
+					Key:          "zedagent",
+					TimePriority: time.Date(2000, 3, 3, 0, 0, 0, 0, time.UTC),
+					TestResults: types.TestResults{
+						LastSucceeded: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
+					},
+					Ports: []types.NetworkPortConfig{},
 				},
 				{ // Successful ZedAgent Entry
-					Version:       1,
-					Key:           "zedagent",
-					TimePriority:  time.Date(2000, 3, 2, 0, 0, 0, 0, time.UTC),
-					LastSucceeded: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
-					Ports:         []types.NetworkPortConfig{},
+					Version:      1,
+					Key:          "zedagent",
+					TimePriority: time.Date(2000, 3, 2, 0, 0, 0, 0, time.UTC),
+					TestResults: types.TestResults{
+						LastSucceeded: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
+					},
+					Ports: []types.NetworkPortConfig{},
 				},
 				{ // lastresort - NOT DELETED
 					Version:      1,
 					Key:          "lastresort",
 					TimePriority: time.Date(2000, 3, 0, 0, 0, 0, 0, time.UTC),
-					LastFailed:   time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
-					Ports:        []types.NetworkPortConfig{},
+					TestResults: types.TestResults{
+						LastFailed: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
+					},
+					Ports: []types.NetworkPortConfig{},
 				},
 				{ // Unknown Key
 					Version:      1,
 					Key:          "hardware",
 					TimePriority: time.Date(2000, 3, 0, 0, 0, 0, 0, time.UTC),
-					LastFailed:   time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
-					Ports:        []types.NetworkPortConfig{},
+					TestResults: types.TestResults{
+						LastFailed: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
+					},
+					Ports: []types.NetworkPortConfig{},
 				},
 			}, // PortConfigList
 		}, // dpcl
@@ -121,29 +129,37 @@ var testMatrix = map[string]compressDPCLTestEntry{
 					Version:      1,
 					Key:          "zedagent",
 					TimePriority: time.Date(2000, 3, 3, 0, 0, 0, 0, time.UTC),
-					LastFailed:   time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
-					Ports:        []types.NetworkPortConfig{},
+					TestResults: types.TestResults{
+						LastFailed: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
+					},
+					Ports: []types.NetworkPortConfig{},
 				},
 				{
-					Version:       1,
-					Key:           "zedagent",
-					TimePriority:  time.Date(2000, 3, 0, 0, 0, 0, 0, time.UTC),
-					LastSucceeded: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
-					Ports:         []types.NetworkPortConfig{},
+					Version:      1,
+					Key:          "zedagent",
+					TimePriority: time.Date(2000, 3, 0, 0, 0, 0, 0, time.UTC),
+					TestResults: types.TestResults{
+						LastSucceeded: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
+					},
+					Ports: []types.NetworkPortConfig{},
 				},
 				{
 					Version:      1,
 					Key:          "override",
 					TimePriority: time.Date(2000, 3, 0, 0, 0, 0, 0, time.UTC),
-					LastFailed:   time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
-					Ports:        []types.NetworkPortConfig{},
+					TestResults: types.TestResults{
+						LastFailed: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
+					},
+					Ports: []types.NetworkPortConfig{},
 				},
 				{
 					Version:      1,
 					Key:          "hardware",
 					TimePriority: time.Date(2000, 3, 0, 0, 0, 0, 0, time.UTC),
-					LastFailed:   time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
-					Ports:        []types.NetworkPortConfig{},
+					TestResults: types.TestResults{
+						LastFailed: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
+					},
+					Ports: []types.NetworkPortConfig{},
 				},
 			}, // PortConfigList
 		}, // dpcl
@@ -167,32 +183,40 @@ var testMatrix = map[string]compressDPCLTestEntry{
 			CurrentIndex: 0,
 			PortConfigList: []types.DevicePortConfig{
 				{
-					Version:       1,
-					Key:           "lastresort",
-					TimePriority:  time.Date(2000, 3, 3, 0, 0, 0, 0, time.UTC),
-					LastSucceeded: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
-					Ports:         []types.NetworkPortConfig{},
+					Version:      1,
+					Key:          "lastresort",
+					TimePriority: time.Date(2000, 3, 3, 0, 0, 0, 0, time.UTC),
+					TestResults: types.TestResults{
+						LastSucceeded: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
+					},
+					Ports: []types.NetworkPortConfig{},
 				},
 				{
-					Version:       1,
-					Key:           "zedagent",
-					TimePriority:  time.Date(2000, 3, 0, 0, 0, 0, 0, time.UTC),
-					LastSucceeded: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
-					Ports:         []types.NetworkPortConfig{},
+					Version:      1,
+					Key:          "zedagent",
+					TimePriority: time.Date(2000, 3, 0, 0, 0, 0, 0, time.UTC),
+					TestResults: types.TestResults{
+						LastSucceeded: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
+					},
+					Ports: []types.NetworkPortConfig{},
 				},
 				{
 					Version:      1,
 					Key:          "override",
 					TimePriority: time.Date(2000, 3, 0, 0, 0, 0, 0, time.UTC),
-					LastFailed:   time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
-					Ports:        []types.NetworkPortConfig{},
+					TestResults: types.TestResults{
+						LastFailed: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
+					},
+					Ports: []types.NetworkPortConfig{},
 				},
 				{
 					Version:      1,
 					Key:          "hardware",
 					TimePriority: time.Date(2000, 3, 0, 0, 0, 0, 0, time.UTC),
-					LastFailed:   time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
-					Ports:        []types.NetworkPortConfig{},
+					TestResults: types.TestResults{
+						LastFailed: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
+					},
+					Ports: []types.NetworkPortConfig{},
 				},
 			}, // PortConfigList
 		}, // dpcl
@@ -209,29 +233,37 @@ var testMatrix = map[string]compressDPCLTestEntry{
 					Version:      1,
 					Key:          "zedagent",
 					TimePriority: time.Date(2000, 3, 3, 0, 0, 0, 0, time.UTC),
-					LastFailed:   time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
-					Ports:        []types.NetworkPortConfig{},
+					TestResults: types.TestResults{
+						LastFailed: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
+					},
+					Ports: []types.NetworkPortConfig{},
 				},
 				{
-					Version:       1,
-					Key:           "zedagent",
-					TimePriority:  time.Date(2000, 3, 0, 0, 0, 0, 0, time.UTC),
-					LastSucceeded: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
-					Ports:         []types.NetworkPortConfig{},
+					Version:      1,
+					Key:          "zedagent",
+					TimePriority: time.Date(2000, 3, 0, 0, 0, 0, 0, time.UTC),
+					TestResults: types.TestResults{
+						LastSucceeded: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
+					},
+					Ports: []types.NetworkPortConfig{},
 				},
 				{
 					Version:      1,
 					Key:          "override",
 					TimePriority: time.Date(2000, 3, 0, 0, 0, 0, 0, time.UTC),
-					LastFailed:   time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
-					Ports:        []types.NetworkPortConfig{},
+					TestResults: types.TestResults{
+						LastFailed: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
+					},
+					Ports: []types.NetworkPortConfig{},
 				},
 				{
 					Version:      1,
 					Key:          "hardware",
 					TimePriority: time.Date(2000, 3, 0, 0, 0, 0, 0, time.UTC),
-					LastFailed:   time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
-					Ports:        []types.NetworkPortConfig{},
+					TestResults: types.TestResults{
+						LastFailed: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
+					},
+					Ports: []types.NetworkPortConfig{},
 				},
 			}, // PortConfigList
 		}, // dpcl
@@ -245,39 +277,49 @@ var testMatrix = map[string]compressDPCLTestEntry{
 			CurrentIndex: 0,
 			PortConfigList: []types.DevicePortConfig{
 				{
-					Version:       1,
-					Key:           "zedagent",
-					TimePriority:  time.Date(2000, 3, 3, 0, 0, 0, 0, time.UTC),
-					LastSucceeded: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
-					Ports:         []types.NetworkPortConfig{},
+					Version:      1,
+					Key:          "zedagent",
+					TimePriority: time.Date(2000, 3, 3, 0, 0, 0, 0, time.UTC),
+					TestResults: types.TestResults{
+						LastSucceeded: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
+					},
+					Ports: []types.NetworkPortConfig{},
 				},
 				{ // DELETED
-					Version:       2,
-					Key:           "zedagent",
-					TimePriority:  time.Date(2000, 3, 0, 0, 0, 0, 0, time.UTC),
-					LastSucceeded: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
-					Ports:         []types.NetworkPortConfig{},
+					Version:      2,
+					Key:          "zedagent",
+					TimePriority: time.Date(2000, 3, 0, 0, 0, 0, 0, time.UTC),
+					TestResults: types.TestResults{
+						LastSucceeded: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
+					},
+					Ports: []types.NetworkPortConfig{},
 				},
 				{ // DELETED
 					Version:      3,
 					Key:          "override",
 					TimePriority: time.Date(2000, 3, 0, 0, 0, 0, 0, time.UTC),
-					LastFailed:   time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
-					Ports:        []types.NetworkPortConfig{},
+					TestResults: types.TestResults{
+						LastFailed: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
+					},
+					Ports: []types.NetworkPortConfig{},
 				},
 				{ // DELETED
 					Version:      4,
 					Key:          "hardware",
 					TimePriority: time.Date(2000, 3, 0, 0, 0, 0, 0, time.UTC),
-					LastFailed:   time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
-					Ports:        []types.NetworkPortConfig{},
+					TestResults: types.TestResults{
+						LastFailed: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
+					},
+					Ports: []types.NetworkPortConfig{},
 				},
 				{ // Retained
-					Version:       5,
-					Key:           "lastresort",
-					TimePriority:  time.Date(2000, 3, 0, 0, 0, 0, 0, time.UTC),
-					LastSucceeded: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
-					Ports:         []types.NetworkPortConfig{},
+					Version:      5,
+					Key:          "lastresort",
+					TimePriority: time.Date(2000, 3, 0, 0, 0, 0, 0, time.UTC),
+					TestResults: types.TestResults{
+						LastSucceeded: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
+					},
+					Ports: []types.NetworkPortConfig{},
 				},
 			}, // PortConfigList
 		}, // dpcl
@@ -291,32 +333,40 @@ var testMatrix = map[string]compressDPCLTestEntry{
 			CurrentIndex: 0,
 			PortConfigList: []types.DevicePortConfig{
 				{
-					Version:       1,
-					Key:           "zedagent",
-					TimePriority:  time.Date(2000, 3, 3, 0, 0, 0, 0, time.UTC),
-					LastSucceeded: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
-					Ports:         []types.NetworkPortConfig{},
+					Version:      1,
+					Key:          "zedagent",
+					TimePriority: time.Date(2000, 3, 3, 0, 0, 0, 0, time.UTC),
+					TestResults: types.TestResults{
+						LastSucceeded: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
+					},
+					Ports: []types.NetworkPortConfig{},
 				},
 				{ // DELETED
-					Version:       2,
-					Key:           "zedagent",
-					TimePriority:  time.Date(2000, 3, 0, 0, 0, 0, 0, time.UTC),
-					LastSucceeded: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
-					Ports:         []types.NetworkPortConfig{},
+					Version:      2,
+					Key:          "zedagent",
+					TimePriority: time.Date(2000, 3, 0, 0, 0, 0, 0, time.UTC),
+					TestResults: types.TestResults{
+						LastSucceeded: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
+					},
+					Ports: []types.NetworkPortConfig{},
 				},
 				{ // DELETED
 					Version:      3,
 					Key:          "override",
 					TimePriority: time.Date(2000, 3, 0, 0, 0, 0, 0, time.UTC),
-					LastFailed:   time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
-					Ports:        []types.NetworkPortConfig{},
+					TestResults: types.TestResults{
+						LastFailed: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
+					},
+					Ports: []types.NetworkPortConfig{},
 				},
 				{ // DELETED
 					Version:      4,
 					Key:          "hardware",
 					TimePriority: time.Date(2000, 3, 0, 0, 0, 0, 0, time.UTC),
-					LastFailed:   time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
-					Ports:        []types.NetworkPortConfig{},
+					TestResults: types.TestResults{
+						LastFailed: time.Date(2000, 3, 4, 0, 0, 0, 0, time.UTC),
+					},
+					Ports: []types.NetworkPortConfig{},
 				},
 			}, // PortConfigList
 		}, // dpcl

--- a/pkg/pillar/types/errortime.go
+++ b/pkg/pillar/types/errortime.go
@@ -18,25 +18,6 @@ type ErrorAndTime struct {
 	ErrorTime time.Time
 }
 
-// SetOrAppendError - Add or Append an error to ErrorAndTime
-func (etPtr *ErrorAndTime) SetOrAppendError(et ErrorAndTime) {
-	if etPtr.HasError() {
-		// Error Alread Set. Append errors
-		// This is a simplistic way to carry all the errors. If we see this
-		// happening more and more, maintain an array of ErrorAndTime
-		if et.HasError() {
-			// Error Already set. Append errors
-			etPtr.Error = etPtr.Error + " \n " + et.Error
-			// Retain the timestamp of first error
-		}
-		// Else - new et doesn't have an error. etPtr already has an error.
-		//  Ignore et
-	} else {
-		// Current state is success - so just update it.
-		*etPtr = et
-	}
-}
-
 // SetErrorNow uses the current time
 func (etPtr *ErrorAndTime) SetErrorNow(errStr string) {
 	if errStr == "" {

--- a/pkg/pillar/types/errortime.go
+++ b/pkg/pillar/types/errortime.go
@@ -39,12 +39,18 @@ func (etPtr *ErrorAndTime) SetOrAppendError(et ErrorAndTime) {
 
 // SetErrorNow uses the current time
 func (etPtr *ErrorAndTime) SetErrorNow(errStr string) {
+	if errStr == "" {
+		log.Fatal("Missing error string")
+	}
 	etPtr.Error = errStr
 	etPtr.ErrorTime = time.Now()
 }
 
 // SetError is when time is specified
 func (etPtr *ErrorAndTime) SetError(errStr string, errorTime time.Time) {
+	if errStr == "" {
+		log.Fatal("Missing error string")
+	}
 	etPtr.Error = errStr
 	etPtr.ErrorTime = errorTime
 }
@@ -81,6 +87,9 @@ type ErrorAndTimeWithSource struct {
 
 // SetError - Sets error state with no source type
 func (etsPtr *ErrorAndTimeWithSource) SetError(errStr string, errTime time.Time) {
+	if errStr == "" {
+		log.Fatal("Missing error string")
+	}
 	etsPtr.Error = errStr
 	etsPtr.ErrorSourceType = nil
 	etsPtr.ErrorTime = errTime
@@ -92,6 +101,9 @@ func (etsPtr *ErrorAndTimeWithSource) SetErrorWithSource(errStr string,
 
 	if !allowedSourceType(source) {
 		log.Fatalf("Bad ErrorSourceType %T", source)
+	}
+	if errStr == "" {
+		log.Fatal("Missing error string")
 	}
 	etsPtr.Error = errStr
 	etsPtr.ErrorSourceType = source

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -698,7 +698,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddIntItem(NetworkGeoRetryTime, 600, 5, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(NetworkTestDuration, 30, 10, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(NetworkTestInterval, 300, 300, 0xFFFFFFFF)
-	configItemSpecMap.AddIntItem(NetworkTestBetterInterval, 0, 0, 0xFFFFFFFF)
+	configItemSpecMap.AddIntItem(NetworkTestBetterInterval, 600, 0, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(NetworkTestTimeout, 15, 0, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(NetworkSendTimeout, 120, 0, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(Dom0MinDiskUsagePercent, 20, 20, 0xFFFFFFFF)

--- a/pkg/pillar/types/zedroutertypes_test.go
+++ b/pkg/pillar/types/zedroutertypes_test.go
@@ -160,33 +160,41 @@ func TestIsDPCUsable(t *testing.T) {
 	}{
 		"Management and DT_CLIENT": {
 			devicePortConfig: DevicePortConfig{
-				LastFailed:    time.Time{},
-				LastSucceeded: n,
-				Ports:         usablePorts,
+				TestResults: TestResults{
+					LastFailed:    time.Time{},
+					LastSucceeded: n,
+				},
+				Ports: usablePorts,
 			},
 			expectedValue: true,
 		},
 		"Mixture of usable and unusable ports": {
 			devicePortConfig: DevicePortConfig{
-				LastFailed:    time.Time{},
-				LastSucceeded: n,
-				Ports:         mixedPorts,
+				TestResults: TestResults{
+					LastFailed:    time.Time{},
+					LastSucceeded: n,
+				},
+				Ports: mixedPorts,
 			},
 			expectedValue: true,
 		},
 		"Not management and DT_CLIENT": {
 			devicePortConfig: DevicePortConfig{
-				LastFailed:    time.Time{},
-				LastSucceeded: n,
-				Ports:         unusablePorts1,
+				TestResults: TestResults{
+					LastFailed:    time.Time{},
+					LastSucceeded: n,
+				},
+				Ports: unusablePorts1,
 			},
 			expectedValue: false,
 		},
 		"Management and DT_NONE": {
 			devicePortConfig: DevicePortConfig{
-				LastFailed:    time.Time{},
-				LastSucceeded: n,
-				Ports:         unusablePorts2,
+				TestResults: TestResults{
+					LastFailed:    time.Time{},
+					LastSucceeded: n,
+				},
+				Ports: unusablePorts2,
 			},
 			expectedValue: false,
 		},
@@ -206,41 +214,51 @@ func TestIsDPCTestable(t *testing.T) {
 	}{
 		"Difference is exactly 60 seconds": {
 			devicePortConfig: DevicePortConfig{
-				LastFailed:    n.Add(time.Second * 60),
-				LastSucceeded: n,
-				Ports:         usablePorts,
+				TestResults: TestResults{
+					LastFailed:    n.Add(time.Second * 60),
+					LastSucceeded: n,
+				},
+				Ports: usablePorts,
 			},
 			expectedValue: false,
 		},
 		"Difference is 61 seconds": {
 			devicePortConfig: DevicePortConfig{
-				LastFailed:    n.Add(time.Second * 61),
-				LastSucceeded: n,
-				Ports:         usablePorts,
+				TestResults: TestResults{
+					LastFailed:    n.Add(time.Second * 61),
+					LastSucceeded: n,
+				},
+				Ports: usablePorts,
 			},
 			expectedValue: false,
 		},
 		"Difference is 59 seconds": {
 			devicePortConfig: DevicePortConfig{
-				LastFailed:    n.Add(time.Second * 59),
-				LastSucceeded: n,
-				Ports:         usablePorts,
+				TestResults: TestResults{
+					LastFailed:    n.Add(time.Second * 59),
+					LastSucceeded: n,
+				},
+				Ports: usablePorts,
 			},
 			expectedValue: false,
 		},
 		"LastFailed is 0": {
 			devicePortConfig: DevicePortConfig{
-				LastFailed:    time.Time{},
-				LastSucceeded: n,
-				Ports:         usablePorts,
+				TestResults: TestResults{
+					LastFailed:    time.Time{},
+					LastSucceeded: n,
+				},
+				Ports: usablePorts,
 			},
 			expectedValue: true,
 		},
 		"Last Succeded is after Last Failed": {
 			devicePortConfig: DevicePortConfig{
-				LastFailed:    n,
-				LastSucceeded: n.Add(time.Second * 61),
-				Ports:         usablePorts,
+				TestResults: TestResults{
+					LastFailed:    n,
+					LastSucceeded: n.Add(time.Second * 61),
+				},
+				Ports: usablePorts,
 			},
 			expectedValue: true,
 		},
@@ -260,25 +278,31 @@ func TestIsDPCUntested(t *testing.T) {
 	}{
 		"Last failed and Last Succesed are 0": {
 			devicePortConfig: DevicePortConfig{
-				LastFailed:    time.Time{},
-				LastSucceeded: time.Time{},
-				Ports:         usablePorts,
+				TestResults: TestResults{
+					LastFailed:    time.Time{},
+					LastSucceeded: time.Time{},
+				},
+				Ports: usablePorts,
 			},
 			expectedValue: true,
 		},
 		"Last Succesed is not 0": {
 			devicePortConfig: DevicePortConfig{
-				LastFailed:    time.Time{},
-				LastSucceeded: n,
-				Ports:         usablePorts,
+				TestResults: TestResults{
+					LastFailed:    time.Time{},
+					LastSucceeded: n,
+				},
+				Ports: usablePorts,
 			},
 			expectedValue: false,
 		},
 		"Last failed is not 0": {
 			devicePortConfig: DevicePortConfig{
-				LastFailed:    time.Time{},
-				LastSucceeded: n,
-				Ports:         usablePorts,
+				TestResults: TestResults{
+					LastFailed:    time.Time{},
+					LastSucceeded: n,
+				},
+				Ports: usablePorts,
 			},
 			expectedValue: false,
 		},
@@ -298,25 +322,31 @@ func TestWasDPCWorking(t *testing.T) {
 	}{
 		"LastSucceeded is 0": {
 			devicePortConfig: DevicePortConfig{
-				LastFailed:    n,
-				LastSucceeded: time.Time{},
-				Ports:         usablePorts,
+				TestResults: TestResults{
+					LastFailed:    n,
+					LastSucceeded: time.Time{},
+				},
+				Ports: usablePorts,
 			},
 			expectedValue: false,
 		},
 		"Last Succeded is after Last Failed": {
 			devicePortConfig: DevicePortConfig{
-				LastFailed:    n,
-				LastSucceeded: n.Add(time.Second * 60),
-				Ports:         usablePorts,
+				TestResults: TestResults{
+					LastFailed:    n,
+					LastSucceeded: n.Add(time.Second * 60),
+				},
+				Ports: usablePorts,
 			},
 			expectedValue: true,
 		},
 		"Last Failed is after Last Succeeded": {
 			devicePortConfig: DevicePortConfig{
-				LastFailed:    n.Add(time.Second * 60),
-				LastSucceeded: n,
-				Ports:         usablePorts,
+				TestResults: TestResults{
+					LastFailed:    n.Add(time.Second * 60),
+					LastSucceeded: n,
+				},
+				Ports: usablePorts,
 			},
 			expectedValue: false,
 		},

--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -148,9 +148,9 @@ func SendOnAllIntf(ctx *ZedCloudContext, url string, reqlen int64, b *bytes.Buff
 //      If an intf is success, Error == "" Else - Set to appropriate Error
 //      ErrorTime will always be set for the interface.
 func VerifyAllIntf(ctx *ZedCloudContext,
-	url string, successCount int,
+	url string, successCount uint,
 	iteration int) (bool, bool, types.IntfStatusMap, error) {
-	var intfSuccessCount int = 0
+	var intfSuccessCount uint
 	const allowProxy = true
 	var errorList []error
 
@@ -222,7 +222,7 @@ func VerifyAllIntf(ctx *ZedCloudContext,
 		log.Errorln(errStr)
 		return false, remoteTemporaryFailure, intfStatusMap, errors.New(errStr)
 	}
-	log.Debugf("VerifyAllIntf: Verifiy done. intfStatusMap: %+v", intfStatusMap)
+	log.Debugf("VerifyAllIntf: Verify done. intfStatusMap: %+v", intfStatusMap)
 	return true, remoteTemporaryFailure, intfStatusMap, nil
 }
 

--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -189,14 +189,13 @@ func VerifyAllIntf(ctx *ZedCloudContext,
 				log.Errorf("Zedcloud un-reachable via interface %s: %s",
 					intf, err)
 				errorList = append(errorList, err)
-				intfStatusMap.SetOrUpdateIntfStatus(intf,
-					types.NewErrorAndTimeNow(err.Error()))
+				intfStatusMap.RecordFailure(intf, err.Error())
 				continue
 			}
 			switch resp.StatusCode {
 			case http.StatusOK, http.StatusCreated:
 				log.Debugf("VerifyAllIntf: Zedcloud reachable via interface %s", intf)
-				intfStatusMap.SetIntfSuccessNow(intf)
+				intfStatusMap.RecordSuccess(intf)
 				intfSuccessCount += 1
 			default:
 				errStr := fmt.Sprintf("Uplink test FAILED via %s to URL %s with "+
@@ -205,8 +204,7 @@ func VerifyAllIntf(ctx *ZedCloudContext,
 				log.Errorln(errStr)
 				err = errors.New(errStr)
 				errorList = append(errorList, err)
-				intfStatusMap.SetOrUpdateIntfStatus(
-					intf, types.NewErrorAndTimeNow(err.Error()))
+				intfStatusMap.RecordFailure(intf, err.Error())
 				continue
 			}
 		}


### PR DESCRIPTION
The 4 commits are somewhat independent but have been tested together (and nim is a bit complex).

First one is to make sure ErrorAndTime is used for errors and not for "string plus timestamp".

That requires the second commit which is to create a new TestResult struct and use it for the test results in DevicePortConfig and DeviceNetworkStatus.
As part of testing it was discovered that nim's try* function doesn't propagate the intfStatusMap to the DPCL and DNS,hence the errors and successes from there were not reported to the controller. So that is also part of the second commit.

The third commit is to make nim's try* function start with a different management interface each time, so that they would all be reported (albeit slowly since the try* function is invoked every 5 minutes by default). In fixing that it was discovered that the two args interation and successCount where swapped (but it "worked" since both were always one). So fixed that and made confusion less likely in the future by using int vs. uint.

Forth commit is to make nim by default run a timer so that if CurrentIndex is not 0, it will (re-)try DPC index zero.
