### PR TITLE
make errors more specific than "No IP addresses ..."

### DIFF
--- a/pkg/pillar/devicenetwork/ifindex.go
+++ b/pkg/pillar/devicenetwork/ifindex.go
@@ -157,13 +157,14 @@ func RelevantLastResort(link netlink.Link) (bool, bool) {
 	linkFlags := attrs.Flags
 	loopbackFlag := (linkFlags & net.FlagLoopback) != 0
 	broadcastFlag := (linkFlags & net.FlagBroadcast) != 0
+	adminUpFlag := (linkFlags & net.FlagUp) != 0
 	upFlag := (attrs.OperState == netlink.OperUp)
 	isVif := strings.HasPrefix(ifname, "vif") || strings.HasPrefix(ifname, "nbu") || strings.HasPrefix(ifname, "nbo")
 	if linkType == "device" && !loopbackFlag && broadcastFlag &&
 		attrs.MasterIndex == 0 && !isVif {
 
-		log.Infof("Relevant %s up %t operState %s\n",
-			ifname, upFlag, attrs.OperState.String())
+		log.Infof("Relevant %s adminUp %t operState %s\n",
+			ifname, adminUpFlag, attrs.OperState.String())
 		return true, upFlag
 	} else {
 		return false, false


### PR DESCRIPTION
If you pick an interface without an Ethernet cable with this PR you will get 
ERROR: Link not up to connect to https://zedcloud.alpha.zededa.net/api/v2/edgedevice/ping using intf eth0: down

as oppsed to
ERROR: No IP addresses to connect to https://zedcloud.alpha.zededa.net/api/v2/edgedevice/ping using intf eth0

The latter message still appears if there is no DHCP server etc.
