### PR TITLE
Workaround for Xen Dom0 support on ARM64

### DIFF
--- a/pkg/xen-tools/init.sh
+++ b/pkg/xen-tools/init.sh
@@ -18,6 +18,12 @@ if [ -d /proc/xen/ ]; then
    # Finally, we need to start Xen
    # In case it hangs and we have no hardware watchdog we run it in the background
    mkdir -p /var/run/xen/ /var/run/xenstored
+   # FIXME: this is a workaround for Xen on ARM still requiring qemu-system-i386
+   #   https://wiki.xenproject.org/wiki/Xen_ARM_with_Virtualization_Extensions#Use_of_qemu-system-i386_on_ARM
+   if [ "$(uname -m)" = aarch64 ]; then
+      export QEMU_XEN=/bin/true
+      echo 1 > /var/run/xen/qemu-dom0.pid
+   fi
    XENCONSOLED_ARGS='--log=all --log-dir=/var/log/xen' /etc/init.d/xencommons start
 
    # Now start the watchdog


### PR DESCRIPTION
It seems that Xen community still hasn't resolved an issue of running an architecture appropriate qemu backend for disk services in Dom0: https://wiki.xenproject.org/wiki/Xen_ARM_with_Virtualization_Extensions#Use_of_qemu-system-i386_on_ARM

The problem is that now we need an architecture specific qemu for KVM support and we'd rather avoid having two separate EVE images. A burden of having two qemu binaries would be unfortunate since it is no small binary ~15Mb.

We have a few options of where to go from here:
   * actually fix aarch64 qemu to be capable of supplying disk backend services
   * bite the bullet and build two qemu images on ARM
   * get rid of qemu completely

I'll be reaching out to Xen community to see which one is more feasible, but for now -- I'm simply trying to disable qemu use on arm64 altogether. Lets see if this proves to be an adequate stop gap (since I don't have access to HiKey @eriknordmark will have to test it).