### PR TITLE
Adding resolver retry mechanism

### DIFF
--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -37,11 +37,12 @@ var (
 	debug              = false
 	debugOverride      bool                               // From command line arg
 	downloadGCTime     = time.Duration(600) * time.Second // Unless from GlobalConfig
-	downloadRetryTime  = time.Duration(600) * time.Second // Unless from GlobalConfig
+	retryTime          = time.Duration(600) * time.Second // Unless from GlobalConfig
 	downloaderObjTypes = []string{types.AppImgObj, types.BaseOsObj, types.CertObj}
 	Version            = "No version specified" // Set from Makefile
 	nilUUID            uuid.UUID                // should be a const, just the default nil value of uuid.UUID
 	dHandler           = makeDownloadHandler()
+	resHandler         = makeResolveHandler()
 )
 
 func Run(ps *pubsub.PubSub) {
@@ -242,7 +243,7 @@ func runHandler(ctx *downloaderContext, objType string, key string,
 
 	log.Infof("runHandler starting")
 
-	max := float64(downloadRetryTime)
+	max := float64(retryTime)
 	min := max * 0.3
 	ticker := flextimer.NewRangeTicker(time.Duration(min),
 		time.Duration(max))
@@ -297,10 +298,10 @@ func maybeRetryDownload(ctx *downloaderContext,
 	}
 	t := time.Now()
 	elapsed := t.Sub(status.ErrorTime)
-	if elapsed < downloadRetryTime {
+	if elapsed < retryTime {
 		log.Infof("maybeRetryDownload(%s) %d remaining",
 			status.Key(),
-			(downloadRetryTime-elapsed)/time.Second)
+			(retryTime-elapsed)/time.Second)
 		return
 	}
 	log.Infof("maybeRetryDownload(%s) after %s at %v",

--- a/pkg/pillar/cmd/downloader/globalconfig.go
+++ b/pkg/pillar/cmd/downloader/globalconfig.go
@@ -26,7 +26,7 @@ func handleGlobalConfigModify(ctxArg interface{}, key string,
 			downloadGCTime = time.Duration(gcp.GlobalValueInt(types.DownloadGCTime)) * time.Second
 		}
 		if gcp.GlobalValueInt(types.DownloadRetryTime) != 0 {
-			downloadRetryTime = time.Duration(gcp.GlobalValueInt(types.DownloadRetryTime)) * time.Second
+			retryTime = time.Duration(gcp.GlobalValueInt(types.DownloadRetryTime)) * time.Second
 		}
 		ctx.GCInitialized = true
 	}

--- a/pkg/pillar/cmd/downloader/resolvehandler.go
+++ b/pkg/pillar/cmd/downloader/resolvehandler.go
@@ -1,0 +1,61 @@
+package downloader
+
+import (
+	log "github.com/sirupsen/logrus"
+)
+
+type resolveHandler struct {
+	// We have one goroutine per provisioned domU object.
+	// Channel is used to send notifications about config (add and updates)
+	// Channel is closed when the object is deleted
+	// The go-routine owns writing status for the object
+	// The key in the map is the objects Key().
+
+	handlers map[string]chan<- Notify
+}
+
+func makeResolveHandler() *resolveHandler {
+	return &resolveHandler{
+		handlers: make(map[string]chan<- Notify),
+	}
+}
+
+// Wrappers around modifyObject, and deleteObject
+
+func (r *resolveHandler) modify(ctxArg interface{},
+	key string, configArg interface{}) {
+
+	log.Infof("resolveHandler.modify(%s)", key)
+	ctx := ctxArg.(*downloaderContext)
+	h, ok := r.handlers[key]
+	if !ok {
+		h1 := make(chan Notify, 1)
+		r.handlers[key] = h1
+		go runResolveHandler(ctx, key, h1)
+		h = h1
+	}
+	select {
+	case h <- Notify{}:
+		log.Infof("resolveHandler.modify(%s) sent notify", key)
+	default:
+		// handler is slow
+		log.Warnf("resolveHandler.modify(%s) NOT sent notify. Slow handler?", key)
+	}
+}
+
+func (r *resolveHandler) delete(ctxArg interface{}, key string,
+	configArg interface{}) {
+
+	log.Infof("resolveHandler.delete(%s)", key)
+	// Do we have a channel/goroutine?
+	h, ok := r.handlers[key]
+	if ok {
+		log.Debugf("Closing channel")
+		close(h)
+		delete(r.handlers, key)
+	} else {
+		log.Debugf("resolveHandler.delete: unknown %s", key)
+		return
+	}
+	log.Infof("resolveHandler.delete(%s) done", key)
+}

--- a/pkg/pillar/cmd/downloader/resolveimg.go
+++ b/pkg/pillar/cmd/downloader/resolveimg.go
@@ -1,0 +1,21 @@
+package downloader
+
+import (
+	log "github.com/sirupsen/logrus"
+)
+
+// for function name consistency
+func handleAppImgResolveModify(ctxArg interface{}, key string,
+	configArg interface{}) {
+
+	log.Infof("handleAppImgResolveModify for %s", key)
+	resHandler.modify(ctxArg, key, configArg)
+	log.Infof("handleAppImgResolveModify for %s, done", key)
+}
+
+func handleAppImgResolveDelete(ctxArg interface{}, key string, configArg interface{}) {
+
+	log.Infof("handleAppImgResolveDelete for %s", key)
+	resHandler.delete(ctxArg, key, configArg)
+	log.Infof("handleAppImgResolveDelete for %s, done", key)
+}

--- a/pkg/pillar/types/downloadertypes.go
+++ b/pkg/pillar/types/downloadertypes.go
@@ -195,6 +195,7 @@ type ResolveStatus struct {
 	Name        string
 	ImageSha256 string
 	Counter     uint32
+	RetryCount  int
 	// ErrorAndTime provides SetErrorNow() and ClearError()
 	ErrorAndTime
 }


### PR DESCRIPTION
zedmanager calls resolver for resolving container tags to SHA. With these changes, we will be able to retry the resolver in case of failure.