### PR TITLE
fix containerd issue

### DIFF
--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -3,8 +3,8 @@ kernel:
   cmdline: "rootdelay=3"
 init:
   - linuxkit/init:v0.5
-  - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
-  - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/getty:v0.5
   - linuxkit/memlogd:v0.5
   - GRUB_TAG


### PR DESCRIPTION
This bumps containerd to 1.3.4, which includes the fix for "disappearing /dev" (cc @rvs ). 