### PR TITLE
Enable encrypted WiFi credentials - persistent subscription at boot

### DIFF
--- a/pkg/pillar/cmd/ipcmonitor/ipcmonitor.go
+++ b/pkg/pillar/cmd/ipcmonitor/ipcmonitor.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/types"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -35,6 +36,7 @@ func Run(ps *pubsub.PubSub) {
 	topicPtr := flag.String("t", "DeviceNetworkStatus",
 		"topic")
 	debugPtr := flag.Bool("d", false, "Debug flag")
+	persistentPtr := flag.Bool("P", false, "Persistent flag")
 	flag.Parse()
 	agentName := *agentNamePtr
 	agentScope := *agentScopePtr
@@ -45,6 +47,11 @@ func Run(ps *pubsub.PubSub) {
 	} else {
 		log.SetLevel(log.InfoLevel)
 	}
+	if *persistentPtr {
+		testPersistent(ps, agentName, agentScope, topic)
+		return
+	}
+
 	name := nameString(agentName, agentScope, topic)
 	sockName := fmt.Sprintf("/var/run/%s.sock", name)
 	s, err := net.Dial("unixpacket", sockName)
@@ -133,5 +140,58 @@ func nameString(agentname, agentscope, topic string) string {
 		return fmt.Sprintf("%s/%s", agentname, topic)
 	} else {
 		return fmt.Sprintf("%s/%s/%s", agentname, agentscope, topic)
+	}
+}
+
+func testPersistent(ps *pubsub.PubSub, agentName string, agentScope string, topic string) {
+	ctx := 3
+	sub, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:  agentName,
+		AgentScope: agentScope,
+		// XXX hard-coded; need nameToType ;-)
+		TopicImpl:     types.DevicePortConfigList{},
+		Activate:      false,
+		Persistent:    true,
+		Ctx:           &ctx,
+		CreateHandler: handleCreate,
+		ModifyHandler: handleModify,
+		DeleteHandler: handleDelete,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	sub.Activate()
+}
+
+func handleCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+
+	log.Infof("handleCreate(%s) type %T\n", key, statusArg)
+	switch statusArg.(type) {
+	case types.DevicePortConfigList:
+		dpcl := statusArg.(types.DevicePortConfigList)
+		log.Infof("DPCL %+v\n", dpcl)
+	}
+}
+
+func handleModify(ctxArg interface{}, key string,
+	statusArg interface{}) {
+
+	log.Infof("handleModify(%s) type %T\n", key, statusArg)
+	switch statusArg.(type) {
+	case types.DevicePortConfigList:
+		dpcl := statusArg.(types.DevicePortConfigList)
+		log.Infof("DPCL %+v\n", dpcl)
+	}
+}
+
+func handleDelete(ctxArg interface{}, key string,
+	statusArg interface{}) {
+
+	log.Infof("handleDelete(%s) type %T\n", key, statusArg)
+	switch statusArg.(type) {
+	case types.DevicePortConfigList:
+		dpcl := statusArg.(types.DevicePortConfigList)
+		log.Infof("DPCL %+v\n", dpcl)
 	}
 }

--- a/pkg/pillar/pubsub/driver.go
+++ b/pkg/pillar/pubsub/driver.go
@@ -27,6 +27,14 @@ type DriverSubscriber interface {
 	// background, it is the responsibility of the driver to run it as a separate
 	// goroutine.
 	Start() error
+
+	// Load initial status from persistence. Usually called only on first start.
+	// The implementation is responsible for determining if the load is necessary
+	// or already has been performed. If it has been already, it should not change
+	// anything. The caller has no knowledge of where the persistent state was
+	// stored: disk, databases, or vellum. All it cares about is that it gets
+	// a key-value list.
+	Load() (map[string][]byte, bool, error)
 }
 
 // DriverPublisher interface that a driver for publishing must implement

--- a/pkg/pillar/pubsub/pubsub.go
+++ b/pkg/pillar/pubsub/pubsub.go
@@ -105,6 +105,7 @@ func (p *PubSub) NewSubscription(options SubscriptionOptions) (Subscription, err
 		SynchronizedHandler: options.SyncHandler,
 		MaxProcessTimeWarn:  options.WarningTime,
 		MaxProcessTimeError: options.ErrorTime,
+		Persistent:          options.Persistent,
 	}
 	name := sub.nameString()
 	global := options.AgentName == ""

--- a/pkg/pillar/pubsub/pubsub_test.go
+++ b/pkg/pillar/pubsub/pubsub_test.go
@@ -58,6 +58,12 @@ func (e *EmptyDriverSubscriber) Start() error {
 	return nil
 }
 
+// Load load entire persisted data set into a map
+func (e *EmptyDriverSubscriber) Load() (map[string][]byte, bool, error) {
+	res := make(map[string][]byte)
+	return res, false, nil
+}
+
 func TestHandleModify(t *testing.T) {
 	ps := New(&EmptyDriver{})
 	sub, err := ps.NewSubscription(SubscriptionOptions{


### PR DESCRIPTION
Nim starts and subscribes to a persistent publication from zedagent. It needs to get the persistent data from that publication before zedagent starts.

Solves by having NewSubscription call the handlers based on what it is the directory (using the same pattern we use for intially populating the persistent *publication*.
