### PR TITLE
move the nim sub-controller-cert to later stage

### DIFF
--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -163,7 +163,7 @@ func Run(ps *pubsub.PubSub) {
 		log.Fatal(err)
 	}
 	nimCtx.SubControllerCert = subControllerCert
-	subControllerCert.Activate()
+	// move subControllerCert.Activate() to later and wait for zedagent publish that
 
 	// Look for cipher context which will be used for decryption
 	subCipherContext, err := ps.NewSubscription(pubsub.SubscriptionOptions{
@@ -537,6 +537,9 @@ func Run(ps *pubsub.PubSub) {
 		agentlog.StillRunning(agentName, warningTime, errorTime)
 	}
 	log.Infof("AA initialized")
+
+	subControllerCert.Activate()
+	log.Infof("nim: done activate ControllerCert sub\n")
 
 	for {
 		select {


### PR DESCRIPTION
Signed-off-by: Naiming Shen <naiming@zededa.com>
- move the nim subControllCert to later, after AA
- tested by remove the /persist/status/nim/ControllerCert directory to reboot fine.
