### PR TITLE
move the nim CipherContext sub also to later stage

### DIFF
--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -179,7 +179,7 @@ func Run(ps *pubsub.PubSub) {
 		log.Fatal(err)
 	}
 	nimCtx.SubCipherContext = subCipherContext
-	subCipherContext.Activate()
+	// move subCipherContext.Activate() to later and wait for zedagent publish that
 
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
@@ -539,7 +539,8 @@ func Run(ps *pubsub.PubSub) {
 	log.Infof("AA initialized")
 
 	subControllerCert.Activate()
-	log.Infof("nim: done activate ControllerCert sub\n")
+	subCipherContext.Activate()
+	log.Infof("nim: done activate ControllerCert and CipherContext sub\n")
 
 	for {
 		select {


### PR DESCRIPTION
Signed-off-by: Naiming Shen <naiming@zededa.com>
- missed moving the subCipherContext.Activate() to later stage also.
- remove the zedagent dir in /persist/status, and reboot, tested fine.