### PR TITLE
nim is very slow on first boot due to persistent subscriptions

### DIFF
--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -163,7 +163,7 @@ func Run(ps *pubsub.PubSub) {
 		log.Fatal(err)
 	}
 	nimCtx.SubControllerCert = subControllerCert
-	// move subControllerCert.Activate() to later and wait for zedagent publish that
+	subControllerCert.Activate()
 
 	// Look for cipher context which will be used for decryption
 	subCipherContext, err := ps.NewSubscription(pubsub.SubscriptionOptions{
@@ -179,7 +179,7 @@ func Run(ps *pubsub.PubSub) {
 		log.Fatal(err)
 	}
 	nimCtx.SubCipherContext = subCipherContext
-	// move subCipherContext.Activate() to later and wait for zedagent publish that
+	subCipherContext.Activate()
 
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
@@ -537,10 +537,6 @@ func Run(ps *pubsub.PubSub) {
 		agentlog.StillRunning(agentName, warningTime, errorTime)
 	}
 	log.Infof("AA initialized")
-
-	subControllerCert.Activate()
-	subCipherContext.Activate()
-	log.Infof("nim: done activate ControllerCert and CipherContext sub\n")
 
 	for {
 		select {

--- a/pkg/pillar/pubsub/socketdriver/driver.go
+++ b/pkg/pillar/pubsub/socketdriver/driver.go
@@ -159,7 +159,9 @@ func (s *SocketDriver) Subscriber(global bool, name, topic string, persistent bo
 		subFromDir = true
 		dirName = s.pubDirName(name)
 	} else if persistent {
-		subFromDir = true
+		// We do the initial Load from the directory if it
+		// exists, but subsequent updates come over IPC
+		subFromDir = false
 		dirName = s.persistentDirName(name)
 	} else {
 		subFromDir = subscribeFromDir


### PR DESCRIPTION
The recently added persistent subscriptions in nim for ControllerCert and CipherContext makes nim wait 'forever' when /persist is blank (such as make run, or installing a new device).

We haven't used persistent subscriptions before; the intent was to read initial content from directory if it exists then use IPC.