### PR TITLE
makefile override options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,13 +124,18 @@ QEMU_OPTS_NET1_FIRST_IP=192.168.1.10
 QEMU_OPTS_NET2=192.168.2.0/24
 QEMU_OPTS_NET2_FIRST_IP=192.168.2.10
 
+QEMU_MEMORY:=4096
+
+ifeq ($(PFLASH),)
 QEMU_OPTS_BIOS=-bios $(BIOS_IMG)
-# BIOS_IMG=$(DIST)/OVMF*
-# QEMU_OPTS_BIOS=-drive if=pflash,format=raw,unit=0,readonly,file=$(DIST)/OVMF_CODE.fd -drive if=pflash,format=raw,unit=1,file=$(DIST)/OVMF_VARS.fd
+else
+BIOS_IMG=$(DIST)/OVMF*
+QEMU_OPTS_BIOS=-drive if=pflash,format=raw,unit=0,readonly,file=$(DIST)/OVMF_CODE.fd -drive if=pflash,format=raw,unit=1,file=$(DIST)/OVMF_VARS.fd
+endif
 
 QEMU_OPTS_arm64= -machine virt,gic_version=3 -machine virtualization=true -cpu cortex-a57 -machine type=virt -drive file=fat:rw:$(dir $(DEVICETREE_DTB)),label=QEMU_DTB,format=vvfat
 QEMU_OPTS_amd64= -cpu SandyBridge $(QEMU_ACCEL)
-QEMU_OPTS_COMMON= -smbios type=1,serial=31415926 -m 4096 -smp 4 -display none $(QEMU_OPTS_BIOS) \
+QEMU_OPTS_COMMON= -smbios type=1,serial=31415926 -m $(QEMU_MEMORY) -smp 4 -display none $(QEMU_OPTS_BIOS) \
         -serial mon:stdio      \
         -rtc base=utc,clock=rt \
         -netdev user,id=eth0,net=$(QEMU_OPTS_NET1),dhcpstart=$(QEMU_OPTS_NET1_FIRST_IP),hostfwd=tcp::$(SSH_PORT)-:22 -device virtio-net-pci,netdev=eth0 \

--- a/README.md
+++ b/README.md
@@ -133,8 +133,21 @@ make run
 
 > **_NOTE:_**  The default QEMU configuration needs 4GB of memory available.
 > If you get an error message about being unable to allocate memory, try freeing up some RAM.
-> If you can't free up 4GB, you can reduce the memory allocation in the `Makefile` from 4096 (4GB) to 2048 (2GB).
-> Running QEMU with less than 2GB of memory is not recommended.
+> If you can't free up 4GB, you can reduce the memory allocation to qemu from 4096 (4GB) to 2048 (2GB).
+> Running QEMU with less than 2GB of memory is not recommended. To run with a different amount of
+> memory, provide the desired amount in KB as:
+
+```console
+make run QEMU_MEMORY=2048
+```
+
+> **_NOTE:_** `make run` launches qemu with the `-bios` option. On some systems, this does not work,
+> and you need to run it with the `-pflash` argument (or its equivalent properly configured `-drive`
+> instead). To enable pflash, run:
+
+```console
+make run PFLASH=true
+```
 
 Once the image boots you can interact with it either by using the console
 (right there in the terminal window from which make run was executed).


### PR DESCRIPTION
This provides 2 override options in the makefile, as well as documenting them.

* qemu memory: In the README, we describe how the default is 4096, but this can be changed in the Makefile. Running `make run QEMU_MEMORY=2048` changes the amount passed to qemu.
* pflash: when running on some systems, we need to change the `-bios` qemu command to `pflash`-based options. That has entailed changing the Makefile and then changing it back. This makes it possible to run `make run PFLASH=true` and get the option. 

I am aware that we would like to unify the bios options soon. However, until we do, let's make this easy to use. When it is unified, we can remove the option and doc for it.