### PR TITLE
Creating a uuid everytime we create a ctr task

### DIFF
--- a/pkg/pillar/rootfs/usr/bin/xenstore
+++ b/pkg/pillar/rootfs/usr/bin/xenstore
@@ -1,3 +1,3 @@
 #!/bin/sh
 # shellcheck disable=SC2046,SC2086
-exec chroot /hostfs /usr/bin/ctr --namespace services.linuxkit t exec --cwd / --exec-id xenstore xen-tools xenstore "$@"
+exec chroot /hostfs /usr/bin/ctr --namespace services.linuxkit t exec --cwd / --exec-id "$(uuidgen)" xen-tools xenstore "$@"

--- a/pkg/pillar/rootfs/usr/sbin/qemu-system-aarch64
+++ b/pkg/pillar/rootfs/usr/sbin/qemu-system-aarch64
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec chroot /hostfs /usr/bin/ctr --namespace services.linuxkit t exec --cwd / --exec-id qemu-system-aarch64 xen-tools /usr/lib/xen/bin/qemu-system-aarch64 "$@"
+exec chroot /hostfs /usr/bin/ctr --namespace services.linuxkit t exec --cwd / --exec-id "$(uuidgen)" xen-tools /usr/lib/xen/bin/qemu-system-aarch64 "$@"

--- a/pkg/pillar/rootfs/usr/sbin/qemu-system-x86_64
+++ b/pkg/pillar/rootfs/usr/sbin/qemu-system-x86_64
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec chroot /hostfs /usr/bin/ctr --namespace services.linuxkit t exec --cwd / --exec-id qemu-system-x86_64 xen-tools /usr/lib/xen/bin/qemu-system-x86_64 "$@"
+exec chroot /hostfs /usr/bin/ctr --namespace services.linuxkit t exec --cwd / --exec-id "$(uuidgen)" xen-tools /usr/lib/xen/bin/qemu-system-x86_64 "$@"

--- a/pkg/pillar/rootfs/usr/sbin/xentop
+++ b/pkg/pillar/rootfs/usr/sbin/xentop
@@ -1,3 +1,3 @@
 #!/bin/sh
 # shellcheck disable=SC2046,SC2086
-exec chroot /hostfs /usr/bin/ctr --namespace services.linuxkit t exec --cwd / ${TERM:+-t} --exec-id xentop xen-tools env ${TERM:+TERM=}$TERM $(basename $0) "$@"
+exec chroot /hostfs /usr/bin/ctr --namespace services.linuxkit t exec --cwd / ${TERM:+-t} --exec-id "$(uuidgen)" xen-tools env ${TERM:+TERM=}$TERM $(basename $0) "$@"

--- a/pkg/pillar/rootfs/usr/sbin/xl
+++ b/pkg/pillar/rootfs/usr/sbin/xl
@@ -1,7 +1,7 @@
 #!/bin/sh
 # shellcheck disable=SC2046,SC2086
 if [ "$1" = console ]; then
-   exec chroot /hostfs /usr/bin/ctr --namespace services.linuxkit t exec --cwd / ${TERM:+-t} --exec-id xl xen-tools env ${TERM:+TERM=}$TERM xl "$@"
+   exec chroot /hostfs /usr/bin/ctr --namespace services.linuxkit t exec --cwd / ${TERM:+-t} --exec-id "$(uuidgen)" xen-tools env ${TERM:+TERM=}$TERM xl "$@"
 else
-   exec chroot /hostfs /usr/bin/ctr --namespace services.linuxkit t exec --cwd / --exec-id xl xen-tools xl "$@"
+   exec chroot /hostfs /usr/bin/ctr --namespace services.linuxkit t exec --cwd / --exec-id "$(uuidgen)" xen-tools xl "$@"
 fi


### PR DESCRIPTION
Creating a new uuid everytime we create a ctr task. This will avoid `ctr: id <ID>: already exists` error. 