### PR TITLE
Cleaning up backward filling of SHA for container images

### DIFF
--- a/pkg/pillar/cmd/verifier/verifier.go
+++ b/pkg/pillar/cmd/verifier/verifier.go
@@ -937,10 +937,7 @@ func verifyObjectSha(ctx *verifierContext, config *types.VerifyImageConfig,
 
 	imageHash := fmt.Sprintf("%x", imageHashB)
 	configuredHash := strings.ToLower(config.ImageSha256)
-	if configuredHash == "" {
-		log.Infof("no image hash provided, skipping root validation. Setting to %s for %s", imageHash, config.ImageID)
-		status.ImageSha256 = strings.ToUpper(imageHash)
-	} else if imageHash != configuredHash {
+	if imageHash != configuredHash {
 		log.Errorf("computed   %s", imageHash)
 		log.Errorf("configured %s", configuredHash)
 		cerr := fmt.Sprintf("computed %s configured %s",
@@ -1193,19 +1190,6 @@ func handleModify(ctx *verifierContext, config *types.VerifyImageConfig,
 	if status.ObjType == "" {
 		log.Fatalf("handleModify: No ObjType for %s",
 			status.ImageID)
-	}
-
-	if config.IsContainer != status.IsContainer {
-		log.Infof("handleModify: Setting IsContainer to %t for %s",
-			config.IsContainer, status.ImageID)
-		status.IsContainer = config.IsContainer
-		changed = true
-	}
-	if status.ImageSha256 == "" && config.ImageSha256 != "" {
-		log.Infof("handleModify: Setting ImageSha256 to %s for %s",
-			config.ImageSha256, status.ImageID)
-		status.ImageSha256 = config.ImageSha256
-		changed = true
 	}
 
 	// Always update RefCount

--- a/pkg/pillar/cmd/volumemgr/create.go
+++ b/pkg/pillar/cmd/volumemgr/create.go
@@ -84,14 +84,14 @@ func createContainerVolume(ctx *volumemgrContext, status types.VolumeStatus, src
 	created := false
 	filelocation := containerd.GetContainerPath(status.AppInstID.String())
 
-	ociFilename, err := utils.VerifiedImageFileLocation(status.ContainerSha256)
+	ociFilename, err := utils.VerifiedImageFileLocation(status.BlobSha256)
 	if err != nil {
 		errStr := fmt.Sprintf("failed to get Image File Location. err: %+s",
 			err)
 		log.Error(errStr)
 		return created, filelocation, errors.New(errStr)
 	}
-	log.Infof("ociFilename %s sha %s", ociFilename, status.ContainerSha256)
+	log.Infof("ociFilename %s sha %s", ociFilename, status.BlobSha256)
 	created = true
 	if err := containerd.SnapshotPrepare(filelocation, ociFilename); err != nil {
 		log.Errorf("Failed to create ctr bundle. Error %s", err)

--- a/pkg/pillar/cmd/volumemgr/handledownloader.go
+++ b/pkg/pillar/cmd/volumemgr/handledownloader.go
@@ -15,10 +15,6 @@ func AddOrRefcountDownloaderConfig(ctx *volumemgrContext, status types.VolumeSta
 	m := lookupDownloaderConfig(ctx, status.ObjType, status.BlobSha256)
 	if m != nil {
 		m.RefCount += 1
-		if m.IsContainer != status.DownloadOrigin.IsContainer {
-			log.Infof("change IsContainer to %t for %s",
-				status.DownloadOrigin.IsContainer, status.VolumeID)
-		}
 		log.Infof("downloader config exists for %s to refcount %d\n",
 			status.VolumeID, m.RefCount)
 		publishDownloaderConfig(ctx, status.ObjType, m)

--- a/pkg/pillar/cmd/volumemgr/handleverifier.go
+++ b/pkg/pillar/cmd/volumemgr/handleverifier.go
@@ -64,17 +64,6 @@ func MaybeAddVerifyImageConfig(ctx *volumemgrContext,
 		m.RefCount += 1
 		log.Infof("MaybeAddVerifyImageConfig: refcnt to %d for %s\n",
 			m.RefCount, status.BlobSha256)
-		// XXX this doesn't appear to happen
-		if m.IsContainer != status.DownloadOrigin.IsContainer {
-			log.Infof("MaybeAddVerifyImageConfig: change IsContainer to %t for %s",
-				status.DownloadOrigin.IsContainer, status.VolumeID)
-		}
-		m.IsContainer = status.DownloadOrigin.IsContainer
-		if m.ImageSha256 != status.BlobSha256 {
-			log.Infof("MaybeAddVerifyImageConfig: change ImageSha256 to %s for %s",
-				status.BlobSha256, status.VolumeID)
-			m.ImageSha256 = status.BlobSha256
-		}
 		publishVerifyImageConfig(ctx, status.ObjType, m)
 	} else {
 		log.Infof("MaybeAddVerifyImageConfig: add for %s, IsContainer: %t",

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -29,20 +29,6 @@ func doUpdate(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool) {
 		log.Infof("Found %s based on VolumeID %s sha %s",
 			status.DisplayName, status.VolumeID, status.BlobSha256)
 
-		// XXX should not happen once ResolveConfig in place
-		// XXX messes up container since end up with different object
-		// XXX temporary container field HACK
-		// XXX create logic...
-		if status.ContainerSha256 != status.BlobSha256 {
-			status.ContainerSha256 = status.BlobSha256
-		}
-		// XXX compare logic ...
-		if status.ContainerSha256 != vs.ImageSha256 {
-			log.Infof("updating image sha from %s to %s",
-				status.ContainerSha256, vs.ImageSha256)
-			status.ContainerSha256 = vs.ImageSha256
-			changed = true
-		}
 		if status.State != vs.State {
 			status.State = vs.State
 			changed = true

--- a/pkg/pillar/types/volumes.go
+++ b/pkg/pillar/types/volumes.go
@@ -162,9 +162,6 @@ type VolumeStatus struct {
 	VolumeID     uuid.UUID
 	PurgeCounter uint32
 
-	// XXX temporary hack for containers until we get a ResolveConfig
-	ContainerSha256 string
-
 	DisplayName string // User-friendly name for logging
 	ObjType     string
 


### PR DESCRIPTION
As we implemented resolver service for computing SHA for container images, so now we don't need a backward filling of SHA for container images in volumemgr and verifier.