### PR TITLE
Set stdout/stderr of dhcpcd to nil. This prompts golang os/exec to pr…

### DIFF
--- a/pkg/pillar/devicenetwork/dhcpcd.go
+++ b/pkg/pillar/devicenetwork/dhcpcd.go
@@ -240,8 +240,8 @@ func dhcpcdCmd(op string, extras []string, ifname string, background bool) bool 
 	args = append(args, ifname)
 	if background {
 		cmd := exec.Command(name, args...)
-		cmd.Stdout = os.NewFile(0, os.DevNull)
-		cmd.Stderr = os.NewFile(0, os.DevNull)
+		cmd.Stdout = nil
+		cmd.Stderr = nil
 
 		log.Infof("Background command %s %v\n", name, args)
 		go func() {


### PR DESCRIPTION
…operly point them to /dev/null

Signed-off-by: Gopi krishna Kodali <gkodali@zededa.com>