### PR TITLE
fix set for oci download

### DIFF
--- a/pkg/pillar/zedUpload/ociutil/oci.go
+++ b/pkg/pillar/zedUpload/ociutil/oci.go
@@ -124,7 +124,7 @@ func Pull(registry, repo, localFile, username, apiKey string, client *http.Clien
 	c := make(chan v1.Update, 200)
 	go func(c chan v1.Update, n NotifChan, stats UpdateStats) {
 		for update := range c {
-			atomic.AddInt64(&stats.Asize, update.Complete)
+			atomic.StoreInt64(&stats.Asize, update.Complete)
 			sendStats(n, stats)
 			if update.Error != nil {
 				return


### PR DESCRIPTION
Previously, we had been catching each write at a low-level, and so we had to _add_ via `atomic.AddInt64` to the previous status. Now, we are at a higher level and receive from the channel the total written, so we need to _set_ via `atomic.StoreInt64` the previous status.