### PR TITLE
fix occasional test failure where DPC is not updated

### DIFF
--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -703,8 +703,12 @@ func (ctx *DeviceNetworkContext) doUpdatePortConfigListAndPublish(
 			log.Infof("doUpdatePortConfigListAndPublish: no change but timestamps %v %v\n",
 				oldConfig.TimePriority, portConfig.TimePriority)
 
-			if current != nil && current.Equal(oldConfig) {
-				log.Infof("doUpdatePortConfigListAndPublish: no change and same Ports as current\n")
+			// If this is current and current is in use (index=0)
+			// then no work needed. Otherwise we reorder
+			if current != nil && current.Equal(oldConfig) &&
+				currentIndex == 0 {
+
+				log.Infof("doUpdatePortConfigListAndPublish: no change and same Ports as currentIndex=0")
 				return false
 			}
 			log.Infof("doUpdatePortConfigListAndPublish: changed ports from current; reorder\n")


### PR DESCRIPTION
This only happened after there was some failure to talk to the controller, which made the device switch to currentIndex>0 and then a test was switching to a zedagent DPC which was already in the list.
We need to have that trigger a reorder of the list so that the newest DPC from the controller gets tested and used.