### PR TITLE
support mitm proxy for various datastore download

### DIFF
--- a/pkg/pillar/Dockerfile.in
+++ b/pkg/pillar/Dockerfile.in
@@ -56,7 +56,7 @@ RUN apk add --no-cache \
     coreutils dmidecode libbz2 libuuid ipset       \
     curl radvd ethtool \
     util-linux e2fsprogs libcrypto1.0 xorriso qemu-img \
-    jq e2fsprogs-extra keyutils
+    jq e2fsprogs-extra keyutils ca-certificates
 
 # We have to make sure configs survive in some location, but they don't pollute
 # the default /config (since that is expected to be an empty mount point)

--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -202,6 +202,7 @@ func Run(ps *pubsub.PubSub) { //nolint:gocyclo
 		NeedStatsFunc:    true,
 		Serial:           hardware.GetProductSerial(),
 		SoftSerial:       hardware.GetSoftSerial(),
+		AgentName:        agentName,
 	})
 
 	clientCtx.zedcloudCtx = &zedcloudCtx
@@ -719,6 +720,7 @@ func handleDNSModify(ctxArg interface{}, key string, statusArg interface{}) {
 	cloudCtx := zedcloud.NewContext(zedcloud.ContextOptions{
 		DevNetworkStatus: ctx.zedcloudCtx.DeviceNetworkStatus,
 		TLSConfig:        devtlsConfig,
+		AgentName:        agentName,
 	})
 	cloudCtx.PrevCertPEM = ctx.zedcloudCtx.PrevCertPEM
 	updated := zedcloud.UpdateTLSProxyCerts(&cloudCtx)

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -153,6 +153,7 @@ func Run(ps *pubsub.PubSub) {
 		NeedStatsFunc:    true,
 		Serial:           hardware.GetProductSerial(),
 		SoftSerial:       hardware.GetSoftSerial(),
+		AgentName:        agentName,
 	})
 	log.Infof("Diag Get Device Serial %s, Soft Serial %s", zedcloudCtx.DevSerial,
 		zedcloudCtx.DevSoftSerial)

--- a/pkg/pillar/cmd/downloader/download.go
+++ b/pkg/pillar/cmd/downloader/download.go
@@ -91,7 +91,6 @@ func download(ctx *downloaderContext, trType zedUpload.SyncTransportType,
 		status.Progress(100)
 		return nil
 	}
-	log.Infof("download: failed here\n")
 	// if we got here, channel was closed
 	// range ends on a closed channel, which is the equivalent of "!ok"
 	errStr := fmt.Sprintf("respChan EOF for <%s>, <%s>, <%s>",

--- a/pkg/pillar/cmd/downloader/download.go
+++ b/pkg/pillar/cmd/downloader/download.go
@@ -37,11 +37,11 @@ func download(ctx *downloaderContext, trType zedUpload.SyncTransportType,
 		return err
 	}
 	// check for proxies on the selected management port interface
-	proxyUrl, err := zedcloud.LookupProxy(
-		&ctx.deviceNetworkStatus, ifname, downloadURL)
-	if err == nil && proxyUrl != nil {
-		log.Infof("%s: Using proxy %s", trType, proxyUrl.String())
-		dEndPoint.WithSrcIPAndProxySelection(ipSrc, proxyUrl)
+	proxyLookupURL := zedcloud.IntfLookupProxyCfg(&ctx.deviceNetworkStatus, ifname, downloadURL)
+	proxyURL, err := zedcloud.LookupProxy(&ctx.deviceNetworkStatus, ifname, proxyLookupURL)
+	if err == nil && proxyURL != nil {
+		log.Infof("%s: Using proxy %s", trType, proxyURL.String())
+		dEndPoint.WithSrcIPAndProxySelection(ipSrc, proxyURL)
 	} else {
 		dEndPoint.WithSrcIPSelection(ipSrc)
 	}
@@ -91,6 +91,7 @@ func download(ctx *downloaderContext, trType zedUpload.SyncTransportType,
 		status.Progress(100)
 		return nil
 	}
+	log.Infof("download: failed here\n")
 	// if we got here, channel was closed
 	// range ends on a closed channel, which is the equivalent of "!ok"
 	errStr := fmt.Sprintf("respChan EOF for <%s>, <%s>, <%s>",
@@ -119,8 +120,9 @@ func objectMetadata(ctx *downloaderContext, trType zedUpload.SyncTransportType,
 		return sha256, err
 	}
 	// check for proxies on the selected management port interface
-	proxyURL, err := zedcloud.LookupProxy(
-		&ctx.deviceNetworkStatus, ifname, downloadURL)
+	proxyLookupURL := zedcloud.IntfLookupProxyCfg(&ctx.deviceNetworkStatus, ifname, downloadURL)
+
+	proxyURL, err := zedcloud.LookupProxy(&ctx.deviceNetworkStatus, ifname, proxyLookupURL)
 	if err == nil && proxyURL != nil {
 		log.Infof("%s: Using proxy %s", trType, proxyURL.String())
 		dEndPoint.WithSrcIPAndProxySelection(ipSrc, proxyURL)

--- a/pkg/pillar/cmd/logmanager/logmanager.go
+++ b/pkg/pillar/cmd/logmanager/logmanager.go
@@ -952,6 +952,7 @@ func sendCtxInit(ctx *logmanagerContext, dnsCtx *DNSContext) {
 		NeedStatsFunc:    true,
 		Serial:           hardware.GetProductSerial(),
 		SoftSerial:       hardware.GetSoftSerial(),
+		AgentName:        agentName,
 	})
 	log.Infof("sendCtxInit: Use V2 API %v", zedcloud.UseV2API())
 

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -88,6 +88,7 @@ func handleConfigInit(networkSendTimeout uint32) {
 		NeedStatsFunc:    true,
 		Serial:           hardware.GetProductSerial(),
 		SoftSerial:       hardware.GetSoftSerial(),
+		AgentName:        agentName,
 	})
 
 	log.Infof("Configure Get Device Serial %s, Soft Serial %s, Use V2 API %v\n", zedcloudCtx.DevSerial,

--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -64,6 +64,7 @@ func prepareAndPublishNetworkInstanceInfoMsg(ctx *zedagentContext,
 	info.NetworkVersion = status.UUIDandVersion.Version
 	info.Displayname = status.DisplayName
 	info.InstType = uint32(status.Type)
+	info.CurrentUplinkIntf = status.CurrentUplinkIntf
 
 	if !status.ErrorTime.IsZero() {
 		errInfo := new(zinfo.ErrorInfo)

--- a/pkg/pillar/cmd/zedrouter/probe.go
+++ b/pkg/pillar/cmd/zedrouter/probe.go
@@ -51,6 +51,7 @@ var zcloudCtx = zedcloud.NewContext(zedcloud.ContextOptions{
 	Timeout:       maxRemoteProbeWait,
 	TLSConfig:     &tls.Config{InsecureSkipVerify: true},
 	NeedStatsFunc: true,
+	AgentName:     agentName,
 })
 
 // use probeMutex to protect the status.PInfo[] map entries. When the external

--- a/pkg/pillar/devicenetwork/devicenetwork.go
+++ b/pkg/pillar/devicenetwork/devicenetwork.go
@@ -115,6 +115,7 @@ func VerifyDeviceNetworkStatus(status types.DeviceNetworkStatus,
 		Timeout:          timeout,
 		Serial:           hardware.GetProductSerial(),
 		SoftSerial:       hardware.GetSoftSerial(),
+		AgentName:        "devicenetwork",
 	})
 	log.Infof("VerifyDeviceNetworkStatus: Use V2 API %v\n", zedcloud.UseV2API())
 	testURL := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, false, nilUUID, "ping")

--- a/pkg/pillar/devicenetwork/wpad.go
+++ b/pkg/pillar/devicenetwork/wpad.go
@@ -93,6 +93,7 @@ func CheckAndGetNetworkProxy(deviceNetworkStatus *types.DeviceNetworkStatus,
 var ctx = zedcloud.NewContext(zedcloud.ContextOptions{
 	Timeout:       15,
 	NeedStatsFunc: true,
+	AgentName:     "wpad",
 })
 
 func getPacFile(status *types.DeviceNetworkStatus, url string,

--- a/pkg/pillar/types/locationconsts.go
+++ b/pkg/pillar/types/locationconsts.go
@@ -51,6 +51,8 @@ const (
 	// ServerSigningCertFileName - filename for server signing leaf certificate
 	ServerSigningCertFileName = CertificateDirname + "/server-signing-cert.pem"
 
+	// ShareCertDirname - directory to place private proxy server certificates
+	ShareCertDirname = "/usr/local/share/ca-certificates"
 	// AppImgObj - name of app image obj dir
 	AppImgObj = "appImg.obj"
 	// BaseOsObj - name of base image obj dir

--- a/pkg/pillar/zedcloud/lookupproxy.go
+++ b/pkg/pillar/zedcloud/lookupproxy.go
@@ -124,53 +124,31 @@ func LookupProxy(status *types.DeviceNetworkStatus, ifname string,
 
 // IntfLookupProxyCfg - check if the intf has proxy configured
 func IntfLookupProxyCfg(status *types.DeviceNetworkStatus, ifname, downloadURL string) string {
-	var mayChange bool
 	// if proxy is not on the intf, then don't change anything
 	// if download URL has "http://" or "https://" then no change here regardless of proxy
-	// if there is proxy on this intf, treeat empty url scheme as for https,
-	// treat passed in download url schem docker://" and maybe sftp://just as https
-	if strings.Contains(downloadURL, "http") {
-		return downloadURL
-	} else if strings.Contains(downloadURL, "docker:") {
-		mayChange = true
-	}
-
-	var scheme string
-	for _, port := range status.Ports {
-		if ifname != port.IfName {
-			continue
-		}
-		var hasHTTP, hasHTTPS bool
-		for _, proxy := range port.ProxyConfig.Proxies {
-			switch proxy.Type {
-			case types.NPT_HTTP:
-				hasHTTP = true
-			case types.NPT_HTTPS:
-				hasHTTPS = true
-			}
-		}
-		if hasHTTPS {
-			scheme = "https://"
-		} else if hasHTTP {
-			scheme = "http://"
-		}
-		break
-	}
-
-	if !mayChange { // empty url scheme in downloadURL
-		return scheme + downloadURL
-	} else if scheme == "" { // if don't have proxy on intf, return original, no change
-		return downloadURL
-	}
-
-	// intf has proxy, may need to replace scheme for https with proxy cert case
+	// if there is proxy on this intf, treat empty url scheme as for https or http but prefer https,
+	// replace the passed-in download-url scheme "docker://" and maybe "sftp://" later, to https
 	passURL, err := url.Parse(downloadURL)
 	if err != nil {
 		return downloadURL
 	}
-	downloadURL = passURL.Host
-	if passURL.Path != "" {
-		downloadURL += ("/" + passURL.Path)
+
+	switch passURL.Scheme {
+	case "http://", "https://":
+		return downloadURL
 	}
-	return scheme + downloadURL
+
+	tmpURL := passURL
+	tmpURL.Scheme = "https://"
+	proxyURL, err := LookupProxy(status, ifname, tmpURL.String())
+	if err == nil && proxyURL != nil {
+		return tmpURL.String()
+	}
+	tmpURL.Scheme = "http://"
+	proxyURL, err = LookupProxy(status, ifname, tmpURL.String())
+	if err == nil && proxyURL != nil {
+		return tmpURL.String()
+	}
+
+	return downloadURL
 }

--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -42,6 +42,7 @@ type ZedCloudContext struct {
 	DevSoftSerial       string
 	NetworkSendTimeout  uint32 // In seconds
 	V2API               bool   // XXX Needed?
+	AgentName           string // the agent process name
 	// V2 related items
 	PrevCertPEM           [][]byte // cached proxy certs for later comparison
 	onBoardCert           *tls.Certificate
@@ -61,6 +62,7 @@ type ContextOptions struct {
 	Timeout          uint32
 	Serial           string
 	SoftSerial       string
+	AgentName        string
 }
 
 var sendCounter uint32
@@ -653,6 +655,7 @@ func NewContext(opt ContextOptions) ZedCloudContext {
 		V2API:               UseV2API(),
 		DevSerial:           opt.Serial,
 		DevSoftSerial:       opt.SoftSerial,
+		AgentName:           opt.AgentName,
 	}
 	if opt.NeedStatsFunc {
 		ctx.FailureFunc = ZedCloudFailure

--- a/pkg/pillar/zedcloud/tls.go
+++ b/pkg/pillar/zedcloud/tls.go
@@ -261,7 +261,7 @@ func UpdateTLSProxyCerts(ctx *ZedCloudContext) bool {
 		}
 	}
 
-	// updating the /etc/ssl/certs for proxy certs
+	// May updating the /etc/ssl/certs for proxy certs in /usr/local/share/ca-certificates directory
 	updateEtcSSLforProxyCerts(ctx, devNS)
 
 	log.Infof("UpdateTLSProxyCerts: root CA updated")
@@ -306,8 +306,9 @@ func stapledCheck(connState *tls.ConnectionState) bool {
 }
 
 func updateEtcSSLforProxyCerts(ctx *ZedCloudContext, dns *types.DeviceNetworkStatus) {
+	// Only zedagent is to update the host ca-certificates
 	if !ctx.V2API || ctx.AgentName != "zedagent" {
-		log.Infof("updateEtcSSLforProxyCerts: skip agent %s\n", ctx.AgentName)
+		log.Infof("updateEtcSSLforProxyCerts: skip agent %s", ctx.AgentName)
 		return
 	}
 
@@ -321,7 +322,7 @@ func updateEtcSSLforProxyCerts(ctx *ZedCloudContext, dns *types.DeviceNetworkSta
 			return filepath.SkipDir
 		}
 		if strings.HasPrefix(path, proxyCertDirFile) {
-			log.Infof("updateEtcSSLforProxyCerts: remove file %s\n", path)
+			log.Infof("updateEtcSSLforProxyCerts: remove file %s", path)
 			os.Remove(path)
 		}
 		return err
@@ -337,12 +338,12 @@ func updateEtcSSLforProxyCerts(ctx *ZedCloudContext, dns *types.DeviceNetworkSta
 		if err != nil {
 			log.Errorf("updateEtcSSLforProxyCerts: file %s save err %v", proxyFilename, err)
 		}
-		log.Infof("updateEtcSSLforProxyCerts: file saved to %s\n", proxyFilename)
+		log.Infof("updateEtcSSLforProxyCerts: file saved to %s", proxyFilename)
 	}
 
 	cmdName := "/usr/sbin/update-ca-certificates"
 	cmd := exec.Command(cmdName)
-	log.Infof("updateEtcSSLforProxyCerts: Calling command %s\n", cmdName)
+	log.Infof("updateEtcSSLforProxyCerts: Calling command %s", cmdName)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Errorf("updateEtcSSLforProxyCerts: update-ca-certificates, certs num %d, (%s)", len(newCerts), err)

--- a/pkg/pillar/zedcloud/tls.go
+++ b/pkg/pillar/zedcloud/tls.go
@@ -14,9 +14,14 @@ import (
 	"fmt"
 	etpm "github.com/lf-edge/eve/pkg/pillar/evetpm"
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ocsp"
 	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -256,6 +261,9 @@ func UpdateTLSProxyCerts(ctx *ZedCloudContext) bool {
 		}
 	}
 
+	// updating the /etc/ssl/certs for proxy certs
+	updateEtcSSLforProxyCerts(ctx, devNS)
+
 	log.Infof("UpdateTLSProxyCerts: root CA updated")
 	ctx.TlsConfig.RootCAs = caCertPool
 	// save the new proxy Certs, or null it out
@@ -295,4 +303,50 @@ func stapledCheck(connState *tls.ConnectionState) bool {
 		log.Errorln("Certificate Status Revoked")
 	}
 	return resp.Status == ocsp.Good
+}
+
+func updateEtcSSLforProxyCerts(ctx *ZedCloudContext, dns *types.DeviceNetworkStatus) {
+	if !ctx.V2API || ctx.AgentName != "zedagent" {
+		log.Infof("updateEtcSSLforProxyCerts: skip agent %s\n", ctx.AgentName)
+		return
+	}
+
+	proxyCertPrefix := "/proxy-cert-"
+	proxyCertDirFile := types.ShareCertDirname + proxyCertPrefix
+	err := filepath.Walk(types.ShareCertDirname, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			log.Error(err)
+		}
+		if path != types.ShareCertDirname && info.IsDir() {
+			return filepath.SkipDir
+		}
+		if strings.HasPrefix(path, proxyCertDirFile) {
+			log.Infof("updateEtcSSLforProxyCerts: remove file %s\n", path)
+			os.Remove(path)
+		}
+		return err
+	})
+	if err != nil {
+		log.Errorf("updateEtcSSLforProxyCerts: reomove proxy certs (%s)", err)
+	}
+
+	newCerts := cacheProxyCerts(dns)
+	for i, pem := range newCerts {
+		proxyFilename := proxyCertDirFile + strconv.Itoa(i) + ".pem"
+		err = fileutils.WriteRename(proxyFilename, pem)
+		if err != nil {
+			log.Errorf("updateEtcSSLforProxyCerts: file %s save err %v", proxyFilename, err)
+		}
+		log.Infof("updateEtcSSLforProxyCerts: file saved to %s\n", proxyFilename)
+	}
+
+	cmdName := "/usr/sbin/update-ca-certificates"
+	cmd := exec.Command(cmdName)
+	log.Infof("updateEtcSSLforProxyCerts: Calling command %s\n", cmdName)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Errorf("updateEtcSSLforProxyCerts: update-ca-certificates, certs num %d, (%s)", len(newCerts), err)
+	} else {
+		log.Infof("updateEtcSSLforProxyCerts: update-ca-certificates %s, certs num %d", out, len(newCerts))
+	}
 }


### PR DESCRIPTION
Signed-off-by: Naiming Shen <naiming@zededa.com>
- handle https downloading through proxy mitm
- handle azure and oci (docker.io) which uses https
- handle proxy certificate in alpine linux ca-certificates
- tested by vijay S and myself.
- sneak in 'CurrentUplinkIntf' info upload to cloud