### PR TITLE
Fixing re-downloading of container images at bootup

### DIFF
--- a/pkg/pillar/cmd/volumemgr/handlework_test.go
+++ b/pkg/pillar/cmd/volumemgr/handlework_test.go
@@ -47,7 +47,7 @@ func TestHandleWorkCreate(t *testing.T) {
 			BlobSha256:  "somesha",
 			ExpectFail:  true,
 			ExpectedLocation: appRwVolumeName("somesha", status.AppInstID.String(),
-				status.PurgeCounter, status.Format, status.Origin),
+				status.PurgeCounter, status.Format, status.Origin, false),
 
 			ExpectCreated: true,
 		},

--- a/pkg/pillar/cmd/volumemgr/initialvolumestatus.go
+++ b/pkg/pillar/cmd/volumemgr/initialvolumestatus.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -31,14 +32,17 @@ var nilUUID = uuid.UUID{}
 // we could switch this to imageID
 // XXX other types of volumes might want a different name.
 func appRwVolumeName(sha256, uuidStr string, purgeCounter uint32, format zconfig.Format,
-	origin types.OriginType) string {
+	origin types.OriginType, isContainer bool) string {
 
-	if origin != types.OriginTypeDownload {
-		log.Fatalf("XXX unsupported origin %v", origin)
-	}
 	purgeString := ""
 	if purgeCounter != 0 {
 		purgeString = fmt.Sprintf("#%d", purgeCounter)
+	}
+	if isContainer {
+		return fmt.Sprintf("%s-%s%s", sha256, uuidStr, purgeString)
+	}
+	if origin != types.OriginTypeDownload {
+		log.Fatalf("XXX unsupported origin %v", origin)
 	}
 	formatStr := strings.ToLower(format.String())
 	return fmt.Sprintf("%s/%s-%s%s.%s", rwImgDirname, sha256,
@@ -46,10 +50,16 @@ func appRwVolumeName(sha256, uuidStr string, purgeCounter uint32, format zconfig
 }
 
 // parseAppRwVolumeName - Returns rwImgDirname, sha256, uuidStr, purgeCounter
-func parseAppRwVolumeName(image string) (string, string, string, uint32) {
+func parseAppRwVolumeName(image string, isContainer bool) (string, string, string, uint32) {
 	// VolumeSha is provided by the controller - it can be uppercase
 	// or lowercase.
-	re1 := regexp.MustCompile(`(.+)/([0-9A-Fa-f]+)-([0-9a-fA-F\-]+)#([0-9]+)\.(.+)`)
+	var re1 *regexp.Regexp
+	var re2 *regexp.Regexp
+	if isContainer {
+		re1 = regexp.MustCompile(`(.+)/([0-9A-Fa-f]+)-([0-9a-fA-F\-]+)#([0-9]+)`)
+	} else {
+		re1 = regexp.MustCompile(`(.+)/([0-9A-Fa-f]+)-([0-9a-fA-F\-]+)#([0-9]+)\.(.+)`)
+	}
 	if re1.MatchString(image) {
 		// With purgeCounter
 		parsedStrings := re1.FindStringSubmatch(image)
@@ -62,7 +72,11 @@ func parseAppRwVolumeName(image string) (string, string, string, uint32) {
 			uint32(count)
 	}
 	// Without purgeCounter
-	re2 := regexp.MustCompile(`(.+)/([0-9A-Fa-f]+)-([0-9a-fA-F\-]+)\.([^\.]+)`)
+	if isContainer {
+		re2 = regexp.MustCompile(`(.+)/([0-9A-Fa-f]+)-([0-9a-fA-F\-]+)`)
+	} else {
+		re2 = regexp.MustCompile(`(.+)/([0-9A-Fa-f]+)-([0-9a-fA-F\-]+)\.([^\.]+)`)
+	}
 	if !re2.MatchString(image) {
 		log.Errorf("AppRwVolumeName %s doesn't match pattern", image)
 		return "", "", "", 0
@@ -76,6 +90,12 @@ func parseAppRwVolumeName(image string) (string, string, string, uint32) {
 func populateInitialVolumeStatus(ctx *volumemgrContext, dirName string) {
 
 	log.Infof("populateInitialVolumeStatus(%s)", dirName)
+	var isContainer bool
+	if dirName == rwImgDirname {
+		isContainer = false
+	} else if dirName == roContImgDirname {
+		isContainer = true
+	}
 
 	// Record host boot time for comparisons
 	hinfo, err := host.Info()
@@ -91,11 +111,11 @@ func populateInitialVolumeStatus(ctx *volumemgrContext, dirName string) {
 
 	for _, location := range locations {
 		filelocation := dirName + "/" + location.Name()
-		if location.IsDir() {
+		if location.IsDir() && !isContainer {
 			log.Debugf("populateInitialVolumeStatus: directory %s ignored", filelocation)
 			continue
 		}
-
+		var size int64
 		info, err := os.Stat(filelocation)
 		if err != nil {
 			log.Errorf("Error in getting file information. Err: %s. "+
@@ -103,9 +123,11 @@ func populateInitialVolumeStatus(ctx *volumemgrContext, dirName string) {
 			deleteFile(filelocation)
 			continue
 		}
-
-		size := info.Size()
-		_, sha256, appUUIDStr, purgeCounter := parseAppRwVolumeName(filelocation)
+		size = info.Size()
+		if isContainer {
+			size, _ = dirSize(filelocation)
+		}
+		_, sha256, appUUIDStr, purgeCounter := parseAppRwVolumeName(filelocation, isContainer)
 		log.Infof("populateInitialVolumeStatus: Processing sha256: %s, AppUuid: %s, "+
 			"%d Mbytes, fileLocation:%s",
 			sha256, appUUIDStr, size/(1024*1024), filelocation)
@@ -248,4 +270,18 @@ func deleteFile(filelocation string) {
 		log.Errorf("Failed to delete file %s. Error: %s",
 			filelocation, err.Error())
 	}
+}
+
+func dirSize(path string) (int64, error) {
+	var size int64
+	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			size += info.Size()
+		}
+		return err
+	})
+	return size, err
 }

--- a/pkg/pillar/cmd/volumemgr/initialvolumestatus_test.go
+++ b/pkg/pillar/cmd/volumemgr/initialvolumestatus_test.go
@@ -14,6 +14,7 @@ type appVolumeNameEntry struct {
 	appUUID      string
 	purgeCounter uint32
 	imageFormat  string
+	isContainer  bool
 }
 
 func TestParseAppRwVolumeName(t *testing.T) {
@@ -24,6 +25,15 @@ func TestParseAppRwVolumeName(t *testing.T) {
 			sha:          "EFA50C64CAACF8D43F334A05F8048F39A27FEA26FC1D155F2543D38D13176C17",
 			appUUID:      "dfde839b-61f8-4df9-a840-d49cc0940d5c",
 			purgeCounter: 0,
+			isContainer:  false,
+		},
+		"Test lowercase SHA cont": {
+			filename:     "/persist/img/EFA50C64CAACF8D43F334A05F8048F39A27FEA26FC1D155F2543D38D13176C17-dfde839b-61f8-4df9-a840-d49cc0940d5c",
+			dir:          "/persist/img",
+			sha:          "EFA50C64CAACF8D43F334A05F8048F39A27FEA26FC1D155F2543D38D13176C17",
+			appUUID:      "dfde839b-61f8-4df9-a840-d49cc0940d5c",
+			purgeCounter: 0,
+			isContainer:  true,
 		},
 		"Test uppercase SHA": {
 			filename:     "/persist/img/01434c4de5e7646dbaf026fe8c522e637a298daa2af71bd1dade03826d442848-dfde839b-61f8-4df9-a840-d49cc0940d5c.qcow2",
@@ -31,6 +41,15 @@ func TestParseAppRwVolumeName(t *testing.T) {
 			sha:          "01434c4de5e7646dbaf026fe8c522e637a298daa2af71bd1dade03826d442848",
 			appUUID:      "dfde839b-61f8-4df9-a840-d49cc0940d5c",
 			purgeCounter: 0,
+			isContainer:  false,
+		},
+		"Test uppercase SHA cont": {
+			filename:     "/persist/img/01434c4de5e7646dbaf026fe8c522e637a298daa2af71bd1dade03826d442848-dfde839b-61f8-4df9-a840-d49cc0940d5c",
+			dir:          "/persist/img",
+			sha:          "01434c4de5e7646dbaf026fe8c522e637a298daa2af71bd1dade03826d442848",
+			appUUID:      "dfde839b-61f8-4df9-a840-d49cc0940d5c",
+			purgeCounter: 0,
+			isContainer:  true,
 		},
 		"Test purgeCounter": {
 			filename:     "/persist/img/01434c4de5e7646dbaf026fe8c522e637a298daa2af71bd1dade03826d442848-dfde839b-61f8-4df9-a840-d49cc0940d5c#3.qcow2",
@@ -38,6 +57,15 @@ func TestParseAppRwVolumeName(t *testing.T) {
 			sha:          "01434c4de5e7646dbaf026fe8c522e637a298daa2af71bd1dade03826d442848",
 			appUUID:      "dfde839b-61f8-4df9-a840-d49cc0940d5c",
 			purgeCounter: 3,
+			isContainer:  false,
+		},
+		"Test purgeCounter cont": {
+			filename:     "/persist/img/01434c4de5e7646dbaf026fe8c522e637a298daa2af71bd1dade03826d442848-dfde839b-61f8-4df9-a840-d49cc0940d5c#3",
+			dir:          "/persist/img",
+			sha:          "01434c4de5e7646dbaf026fe8c522e637a298daa2af71bd1dade03826d442848",
+			appUUID:      "dfde839b-61f8-4df9-a840-d49cc0940d5c",
+			purgeCounter: 3,
+			isContainer:  true,
 		},
 		"Test No Dir": {
 			filename: "01434c4de5e7646dbaf026fe8c522e637a298daa2af71bd1dade03826d442848-dfde839b-61f8-4df9-a840-d49cc0940d5c.qcow2",
@@ -46,6 +74,16 @@ func TestParseAppRwVolumeName(t *testing.T) {
 			sha:          "",
 			appUUID:      "",
 			purgeCounter: 0,
+			isContainer:  false,
+		},
+		"Test No Dir cont": {
+			filename: "01434c4de5e7646dbaf026fe8c522e637a298daa2af71bd1dade03826d442848-dfde839b-61f8-4df9-a840-d49cc0940d5c",
+			// We get return values of ""
+			dir:          "",
+			sha:          "",
+			appUUID:      "",
+			purgeCounter: 0,
+			isContainer:  true,
 		},
 		"Test Invalid Hash": {
 			filename: "/persist/img/01434c4dK-dfde839b-61f8-4df9-a840-d49cc0940d5c.qcow2",
@@ -54,6 +92,16 @@ func TestParseAppRwVolumeName(t *testing.T) {
 			sha:          "",
 			appUUID:      "",
 			purgeCounter: 0,
+			isContainer:  false,
+		},
+		"Test Invalid Hash cont": {
+			filename: "/persist/img/01434c4dK-dfde839b-61f8-4df9-a840-d49cc0940d5c",
+			// We get return values of ""
+			dir:          "",
+			sha:          "",
+			appUUID:      "",
+			purgeCounter: 0,
+			isContainer:  true,
 		},
 		"Test Invalid UUID": {
 			filename: "/persist/img/01434c4de5e7646dbaf026fe8c522e637a298daa2af71bd1dade03826d442848.qcow2",
@@ -62,11 +110,21 @@ func TestParseAppRwVolumeName(t *testing.T) {
 			sha:          "",
 			appUUID:      "",
 			purgeCounter: 0,
+			isContainer:  false,
+		},
+		"Test Invalid UUID cont": {
+			filename: "/persist/img/01434c4de5e7646dbaf026fe8c522e637a298daa2af71bd1dade03826d442848",
+			// We get return values of ""
+			dir:          "",
+			sha:          "",
+			appUUID:      "",
+			purgeCounter: 0,
+			isContainer:  true,
 		},
 	}
 	for testname, test := range testMatrix {
 		t.Logf("Running test case %s", testname)
-		dir, sha, uuid, purgeCounter := parseAppRwVolumeName(test.filename)
+		dir, sha, uuid, purgeCounter := parseAppRwVolumeName(test.filename, test.isContainer)
 		if dir != test.dir {
 			t.Errorf("dir ( %s ) != Expected value ( %s )", dir, test.dir)
 		}

--- a/pkg/pillar/containerd/containerd.go
+++ b/pkg/pillar/containerd/containerd.go
@@ -41,7 +41,7 @@ const (
 	containerdRunTime = "io.containerd.runtime.v1.linux"
 
 	// root path to all containers
-	containersRoot = "/persist/runx/pods/prepared"
+	containersRoot = types.ROContImgDirname
 	// relative path to rootfs for an individual container
 	containerRootfsPath = "rootfs/"
 	// container config file name
@@ -76,8 +76,8 @@ func InitContainerdClient() error {
 
 // GetContainerPath return the path to the root of the container. This is *not*
 // necessarily the rootfs, which may be a layer below
-func GetContainerPath(containerID string) string {
-	return path.Join(containersRoot, containerID)
+func GetContainerPath(containerDir string) string {
+	return path.Join(containersRoot, containerDir)
 }
 
 // containerdLoadImageTar load an image tar into the containerd content store
@@ -320,10 +320,10 @@ func getContainerPath(containerID string) string {
 	}
 }
 
-func getSavedImageInfo(containerID string) (v1.Image, error) {
+func getSavedImageInfo(containerPath string) (v1.Image, error) {
 	var image v1.Image
 
-	appDir := getContainerPath(containerID)
+	appDir := getContainerPath(containerPath)
 	data, err := ioutil.ReadFile(filepath.Join(appDir, imageConfigFilename))
 	if err != nil {
 		return image, err
@@ -564,7 +564,7 @@ func CtrDelete(containerID string) error {
 func CtrPrepareMount(containerID uuid.UUID, containerPath string, envVars map[string]string, noOfDisks int) error {
 	log.Infof("ctrPrepareMount(%s, %s, %v, %d)", containerID, containerPath,
 		envVars, noOfDisks)
-	imageInfo, err := getSavedImageInfo(containerID.String())
+	imageInfo, err := getSavedImageInfo(containerPath)
 	if err != nil {
 		log.Errorf("ctrPrepareMount(%s, %s) getImageInfo failed: %s",
 			containerID, containerPath, err)

--- a/pkg/pillar/types/locationconsts.go
+++ b/pkg/pillar/types/locationconsts.go
@@ -17,6 +17,10 @@ const (
 	DownloadDirname = PersistDir + "/downloads"
 	// CertificateDirname - Location of certificates
 	CertificateDirname = PersistDir + "/certs"
+	// RWImgDirname - Location of read/write images used by app instances
+	RWImgDirname = PersistDir + "/img"
+	// ROContImgDirname - Location of read only images used by containerd
+	ROContImgDirname = PersistDir + "/runx/pods/prepared"
 	// AppImgDirname - location of downloaded app images. Read-only images
 	// named based on sha256 hash each in its own directory
 	AppImgDirname = DownloadDirname + "/" + AppImgObj


### PR DESCRIPTION
At bootup, container bootable disks are always downloading because we are not creating VolumeStatus for them. For VM images, we are iterating over files present in ```persist/img``` and we don't trigger the download for the available images. Similarly, we have to iterate over files present in ```persist/runx/pods/prepared``` directory to identify already downloaded bootable disks for container instances. 