### PR TITLE
Fix phylabel/logicallabel confusion in info and metrics messages

### DIFF
--- a/api/proto/config/devcommon.proto
+++ b/api/proto/config/devcommon.proto
@@ -44,6 +44,8 @@ message ConfigItem {
 
 
 // Adapter bundles corresponding to a subset of what is in ZioBundle
+// When used by a NetworkInstanceConfig the name is the logicallabel
+// for the network adapter.
 message Adapter {
   org.lfedge.eve.common.PhyIoType type = 1;
   string name = 2;	// Short hand name such as "com" from bundle

--- a/api/proto/info/info.proto
+++ b/api/proto/info/info.proto
@@ -99,7 +99,7 @@ message ZInfoNetwork {
   // deprecated = 2;
   string macAddr = 3;
 
-  // devName - Must be set to SystemAdapter.Name
+  // devName - Must be set to SystemAdapter.Name which is the Logicallabel
   string devName = 4;
   // alias - Must be set to SystemAdapter.alias
   string alias = 40;
@@ -281,7 +281,7 @@ message DevicePortStatus {
 
 message DevicePort {
   string ifname = 1;
-  string name = 2;	// Logical name set by controller
+  string name = 2;   // Logical name set by controller; same as logicallabel
   bool isMgmt = 3;
   bool free = 4;
   // DhcpConfig

--- a/api/proto/metrics/metrics.proto
+++ b/api/proto/metrics/metrics.proto
@@ -24,7 +24,7 @@ message memoryMetric {
 }
 
 message networkMetric {
-  // iName - Set to SystemAdapter.Name
+  // iName - Set to SystemAdapter.Name which is the Logicallabel in phyio
   string iName = 1;	// name from config; displayName for network instance
   // alias - Set to SystemAdapter.alias
   string alias = 20;

--- a/pkg/pillar/devicenetwork/devicenetwork.go
+++ b/pkg/pillar/devicenetwork/devicenetwork.go
@@ -193,6 +193,7 @@ func MakeDeviceNetworkStatus(globalConfig types.DevicePortConfig, oldStatus type
 		globalStatus.Ports[ix].IfName = u.IfName
 		globalStatus.Ports[ix].Phylabel = u.Phylabel
 		globalStatus.Ports[ix].Logicallabel = u.Logicallabel
+		globalStatus.Ports[ix].Alias = u.Alias
 		globalStatus.Ports[ix].IsMgmt = u.IsMgmt
 		globalStatus.Ports[ix].Free = u.Free
 		globalStatus.Ports[ix].ProxyConfig = u.ProxyConfig


### PR DESCRIPTION
@bharani-zededa this includes some comment changes in the EVE API, plus the code changes to use the logical label in the info and metrics messages. Have verified this using qemu to date.
Also verifying that things work correctly when all three of logicallabel, physical label, and ifname differ.
(Only issue there seems to be that I can't change the model for an existing device - but creating a new device is working.)

