### PR TITLE
[WIP] Fixed UpdateDhcpClient to return per-interface errors and try all interfaces instead of failing at the first error.

### DIFF
--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -779,13 +779,13 @@ func tryDeviceConnectivityToCloud(ctx *devicenetwork.DeviceNetworkContext) bool 
 	rtf, intfStatusMap, err := devicenetwork.VerifyDeviceNetworkStatus(
 		*ctx.DeviceNetworkStatus, successCount, ctx.Iteration,
 		ctx.TestSendTimeout)
-	ctx.DevicePortConfig.UpdatePortStatusFromIntfStatusMap(intfStatusMap)
+	ctx.DevicePortConfig.UpdatePortStatusFromIntfStatusMap(intfStatusMap, false)
 	// Use TestResults to update the DevicePortConfigList and publish
 	// Note that the TestResults will at least have an updated timestamp
 	// for one of the ports.
 	if ctx.NextDPCIndex < len(ctx.DevicePortConfigList.PortConfigList) {
 		dpc := &ctx.DevicePortConfigList.PortConfigList[ctx.NextDPCIndex]
-		dpc.UpdatePortStatusFromIntfStatusMap(intfStatusMap)
+		dpc.UpdatePortStatusFromIntfStatusMap(intfStatusMap, false)
 		log.Infof("publishing DevicePortConfigList update: %+v",
 			*ctx.DevicePortConfigList)
 		ctx.PubDevicePortConfigList.Publish("global",

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -191,7 +191,17 @@ func (intfMap *IntfStatusMap) HasSuccessfulIntf() bool {
 	return false
 }
 
-// AllErrorStr returns if there is atleast one Successful interface
+// HasErrorIntf returns if there is atleast 1 interface with error
+func (intfMap *IntfStatusMap) HasErrorIntf() bool {
+	for _, tr := range intfMap.StatusMap {
+		if tr.HasError() {
+			return true
+		}
+	}
+	return false
+}
+
+// AllErrorStr returns concatenated string of all errors
 func (intfMap *IntfStatusMap) AllErrorStr() string {
 	errStr := ""
 	for _, tr := range intfMap.StatusMap {
@@ -470,12 +480,14 @@ func (portConfig DevicePortConfig) WasDPCWorking() bool {
 // those from intfStatusMap. If a port is not found in intfStatusMap, it means
 // the port was not tested, so we retain the original TestResults for the port.
 func (portConfig *DevicePortConfig) UpdatePortStatusFromIntfStatusMap(
-	intfStatusMap IntfStatusMap) {
+	intfStatusMap IntfStatusMap, errorsOnly bool) {
 	for indx := range portConfig.Ports {
 		portPtr := &portConfig.Ports[indx]
 		tr, ok := intfStatusMap.StatusMap[portPtr.IfName]
 		if ok {
-			portPtr.TestResults.Update(tr)
+			if !errorsOnly || tr.HasError() {
+				portPtr.TestResults.Update(tr)
+			}
 		}
 		// Else - Port not tested hence no change
 	}

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -172,6 +172,36 @@ func (intfMap *IntfStatusMap) SetOrUpdateFromMap(
 	}
 }
 
+// IntfHasError returns if the given interface has any error
+func (intfMap *IntfStatusMap) IntfHasError(ifname string) bool {
+	tr, ok := intfMap.StatusMap[ifname]
+	if ok {
+		return tr.HasError()
+	}
+	return false
+}
+
+// HasSuccessfulIntf returns if there is atleast one Successful interface
+func (intfMap *IntfStatusMap) HasSuccessfulIntf() bool {
+	for _, tr := range intfMap.StatusMap {
+		if tr.IsSuccess() {
+			return true
+		}
+	}
+	return false
+}
+
+// AllErrorStr returns if there is atleast one Successful interface
+func (intfMap *IntfStatusMap) AllErrorStr() string {
+	errStr := ""
+	for _, tr := range intfMap.StatusMap {
+		if tr.HasError() {
+			errStr += tr.LastError + "\n"
+		}
+	}
+	return errStr
+}
+
 // NewIntfStatusMap - Create a new instance of IntfStatusMap
 func NewIntfStatusMap() *IntfStatusMap {
 	intfStatusMap := IntfStatusMap{}
@@ -227,6 +257,13 @@ func (trPtr *TestResults) RecordFailure(errStr string) {
 // Returns false if it was never tested i.e., both timestamps zero
 func (trPtr *TestResults) HasError() bool {
 	return trPtr.LastFailed.After(trPtr.LastSucceeded)
+}
+
+// IsSuccess returns true if the test result is a success. Returns false
+// if no success was recorded.
+func (trPtr *TestResults) IsSuccess() bool {
+	return !trPtr.LastSucceeded.IsZero() &&
+		trPtr.LastSucceeded.After(trPtr.LastFailed)
 }
 
 // Update uses the src to add info to the results


### PR DESCRIPTION
The intended design for config with multiple management ports is for the config to be treated as successful if *atleast* one of the ports is able to successfully pass the connectivity test. For the ports that fail the test, send the individual port errors to zedcloud.

Currently, when trying to activate DHCP Client as part of the verifying config, if any of the interface fails this part ( Only check is - kernel device must be present ), we currently retry a few times and if it still fails, the entire config is Failed. 

This PR fixes this to change the algorithm as follows:

1) Keep retrying till max-retry count is reached if there is an error on *any* interface

2) When max-retry count is reached, We check if there is *atleast one* successful interface
    - If yes, record failures on the failed ports And continue with testing
    - If no Successful interface, mark the config as Failed

3) Introduced a map to keep track of all dhcp failed interfaces
   - When doing updateDhcpClient - if an interface has failure, always test it again


Signed-off-by: Kalyan Nidumolu <kalyan@zadeda.com>