### PR TITLE
[WIP] Introduce new State values for tag resolution and volume creation

### DIFF
--- a/pkg/pillar/base/logobjecttypes.go
+++ b/pkg/pillar/base/logobjecttypes.go
@@ -41,6 +41,10 @@ const (
 	VolumeConfigLogType LogObjectType = "volume_config"
 	// VolumeStatusLogType :
 	VolumeStatusLogType LogObjectType = "volume_status"
+	// DomainConfigLogType :
+	DomainConfigLogType LogObjectType = "domain_config"
+	// DomainStatusLogType :
+	DomainStatusLogType LogObjectType = "domain_status"
 )
 
 // RelationObjectType :

--- a/pkg/pillar/base/logobjecttypes.go
+++ b/pkg/pillar/base/logobjecttypes.go
@@ -39,6 +39,8 @@ const (
 	AppInstanceConfigLogType LogObjectType = "app_instance_config"
 	// VolumeConfigLogType :
 	VolumeConfigLogType LogObjectType = "volume_config"
+	// VolumeStatusLogType :
+	VolumeStatusLogType LogObjectType = "volume_status"
 )
 
 // RelationObjectType :

--- a/pkg/pillar/cmd/baseosmgr/handlebaseos.go
+++ b/pkg/pillar/cmd/baseosmgr/handlebaseos.go
@@ -287,7 +287,7 @@ func doBaseOsActivate(ctx *baseOsMgrContext, uuidStr string,
 			publishBaseOsStatus(ctx, status)
 			return changed
 		}
-		// move the state from DELIVERED to INSTALLED
+		// move the state from CREATED_VOLUME to INSTALLED
 		setProgressDone(status, types.INSTALLED)
 		publishZbootPartitionStatus(ctx, status.PartitionLabel)
 		baseOsSetPartitionInfoInStatus(ctx, status,
@@ -492,7 +492,7 @@ func checkBaseOsVolumeStatus(ctx *baseOsMgrContext, baseOsUUID uuid.UUID,
 		return ret.Changed, false
 	}
 
-	if ret.MinState < types.DELIVERED {
+	if ret.MinState < types.CREATED_VOLUME {
 		log.Infof("checkBaseOsVolumeStatus(%s) for %s, Waiting for volumemgr",
 			config.BaseOsVersion, uuidStr)
 		return ret.Changed, false

--- a/pkg/pillar/cmd/baseosmgr/handledownload.go
+++ b/pkg/pillar/cmd/baseosmgr/handledownload.go
@@ -49,6 +49,8 @@ func checkVolumeStatus(ctx *baseOsMgrContext,
 		if !ss.HasVolumemgrRef {
 			log.Infof("checkVolumeStatus %s, !HasVolumemgrRef", sc.ImageID)
 			// We use the baseos object UUID as appInstID here
+			// XXX note that we use the ImageID for the VolumeID
+			// argument since we do not have a VolumeID
 			AddOrRefcountVolumeConfig(ctx, ss.ImageSha256,
 				baseOsUUID, ss.ImageID, *ss)
 			ss.HasVolumemgrRef = true

--- a/pkg/pillar/cmd/baseosmgr/handledownload.go
+++ b/pkg/pillar/cmd/baseosmgr/handledownload.go
@@ -64,8 +64,8 @@ func checkVolumeStatus(ctx *baseOsMgrContext,
 				log.Infof("VolumeStatus RefCount zero. name: %s",
 					ss.Name)
 			}
-			ret.MinState = types.DOWNLOAD_STARTED
-			ss.State = types.DOWNLOAD_STARTED
+			ret.MinState = types.DOWNLOADING
+			ss.State = types.DOWNLOADING
 			ret.Changed = true
 			continue
 		}
@@ -125,7 +125,7 @@ func installDownloadedObjects(uuidStr string,
 	for i := range *status {
 		ssPtr := &(*status)[i]
 
-		if ssPtr.State == types.DELIVERED {
+		if ssPtr.State == types.VERIFIED {
 			err := installDownloadedObject(ssPtr.ImageID, ssPtr)
 			if err != nil {
 				log.Error(err)
@@ -151,15 +151,15 @@ func installDownloadedObject(imageID uuid.UUID,
 	log.Infof("installDownloadedObject(%s, %v)",
 		imageID, ssPtr.State)
 
-	if ssPtr.State != types.DELIVERED {
+	if ssPtr.State != types.CREATED_VOLUME {
 		return nil
 	}
 	srcFilename = ssPtr.ActiveFileLocation
 	if srcFilename == "" {
-		log.Fatalf("XXX no ActiveFileLocation for DELIVERED %s",
+		log.Fatalf("XXX no ActiveFileLocation for CREATED_VOLUME %s",
 			imageID)
 	}
-	log.Infof("For %s ActiveFileLocation for DELIVERED: %s",
+	log.Infof("For %s ActiveFileLocation for CREATED_VOLUME: %s",
 		imageID, srcFilename)
 
 	// ensure the file is present

--- a/pkg/pillar/cmd/downloader/syncop.go
+++ b/pkg/pillar/cmd/downloader/syncop.go
@@ -57,8 +57,8 @@ func handleSyncOp(ctx *downloaderContext, key string,
 	// by default the metricsURL _is_ the DownloadURL, but can override in switch
 	metricsUrl := dsCtx.DownloadURL
 
-	// update status to DOWNLOAD STARTED
-	status.State = types.DOWNLOAD_STARTED
+	// update status to DOWNLOADING
+	status.State = types.DOWNLOADING
 	// save the name of the Target filename to our status. In theory, this can be
 	// derived, but it is good for the status to say where it *is*, as opposed to
 	// config, which says where it *should be*

--- a/pkg/pillar/cmd/verifier/verifier.go
+++ b/pkg/pillar/cmd/verifier/verifier.go
@@ -395,7 +395,7 @@ func handleInitWorkinProgressObjects(ctx *verifierContext) {
 }
 
 // Recreate status files for verified objects as types.DOWNLOADED
-// except containers which we mark as types.DELIVERED
+// except containers which we mark as types.VERIFIED
 func handleInitVerifiedObjects(ctx *verifierContext) {
 
 	for _, objType := range verifierObjTypes {
@@ -827,7 +827,7 @@ func handleCreate(ctx *verifierContext, objType string,
 				config.ImageSha256, config.ImageID)
 			status.VerifyStatus = ps.VerifyStatus
 			status.PendingAdd = false
-			status.State = types.DELIVERED
+			status.State = types.VERIFIED
 			status.FileLocation = ps.FileLocation
 			publishVerifyImageStatus(ctx, &status)
 			log.Infof("handleCreate done for %s", config.Name)
@@ -855,7 +855,7 @@ func handleCreate(ctx *verifierContext, objType string,
 		log.Fatalf("Verified but no FileLocation for %s", status.Key())
 	}
 	status.PendingAdd = false
-	status.State = types.DELIVERED
+	status.State = types.VERIFIED
 	publishVerifyImageStatus(ctx, &status)
 	log.Infof("handleCreate done for %s", config.Name)
 }

--- a/pkg/pillar/cmd/volumemgr/handleconfig.go
+++ b/pkg/pillar/cmd/volumemgr/handleconfig.go
@@ -99,9 +99,7 @@ func vcCreate(ctx *volumemgrContext, objType string, key string,
 		initStatus.TargetSizeBytes = config.TargetSizeBytes // XXX change?
 		initStatus.ReadOnly = config.ReadOnly
 
-		// XXX Add state enum for volume created?
-		// XXX api and zmsg enum?
-		initStatus.State = types.DELIVERED
+		initStatus.State = types.CREATED_VOLUME
 		initStatus.Progress = 100
 
 		// FileLocation unchanged
@@ -126,6 +124,7 @@ func vcCreate(ctx *volumemgrContext, objType string, key string,
 		TargetSizeBytes: config.TargetSizeBytes,
 		ReadOnly:        config.ReadOnly,
 		Format:          config.Format,
+		State:           types.INITIAL,
 		// XXX if these are not needed in Status they are not needed in Config
 		//	DevType: config.DevType,
 		//	Target: config.Target,

--- a/pkg/pillar/cmd/volumemgr/initialvolumestatus.go
+++ b/pkg/pillar/cmd/volumemgr/initialvolumestatus.go
@@ -148,6 +148,7 @@ func populateInitialVolumeStatus(ctx *volumemgrContext, dirName string) {
 			PurgeCounter: purgeCounter,
 			DisplayName:  "Found in /persist/img",
 			FileLocation: filelocation,
+			State:        types.CREATED_VOLUME,
 			// XXX Is this the correct size? vs. qcow2 size?
 			TargetSizeBytes: uint64(size),
 			ObjType:         types.UnknownObj,

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -784,7 +784,7 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 			swInfo.PartitionLabel = bos.PartitionLabel
 			swInfo.PartitionDevice = bos.PartitionDevice
 			swInfo.PartitionState = bos.PartitionState
-			swInfo.Status = info.ZSwState(bos.State)
+			swInfo.Status = bos.State.ZSwState()
 			swInfo.ShortVersion = bos.BaseOsVersion
 			swInfo.LongVersion = "" // XXX
 			if len(bos.StorageStatusList) > 0 {
@@ -798,7 +798,7 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 				swInfo.SwErr = encodeErrorInfo(bos.ErrorAndTime)
 			}
 			if swInfo.ShortVersion == "" {
-				swInfo.Status = info.ZSwState(types.INITIAL)
+				swInfo.Status = info.ZSwState_INITIAL
 				swInfo.DownloadProgress = 0
 			}
 		} else {
@@ -812,11 +812,10 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 				swInfo.LongVersion = partStatus.LongVersion
 			}
 			if swInfo.ShortVersion != "" {
-				// Must be factory install i.e. INSTALLED
-				swInfo.Status = info.ZSwState(types.INSTALLED)
+				swInfo.Status = info.ZSwState_INSTALLED
 				swInfo.DownloadProgress = 100
 			} else {
-				swInfo.Status = info.ZSwState(types.INITIAL)
+				swInfo.Status = info.ZSwState_INITIAL
 				swInfo.DownloadProgress = 0
 			}
 		}
@@ -838,7 +837,7 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 		log.Debugf("reportMetrics sending unattached bos for %s",
 			bos.BaseOsVersion)
 		swInfo := new(info.ZInfoDevSW)
-		swInfo.Status = info.ZSwState(bos.State)
+		swInfo.Status = bos.State.ZSwState()
 		swInfo.ShortVersion = bos.BaseOsVersion
 		swInfo.LongVersion = "" // XXX
 		if len(bos.StorageStatusList) > 0 {
@@ -1344,10 +1343,10 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 
 	ReportAppInfo.AppID = uuid
 	ReportAppInfo.SystemApp = false
-	ReportAppInfo.State = info.ZSwState(types.HALTED)
+	ReportAppInfo.State = info.ZSwState_HALTED
 	if aiStatus != nil {
 		ReportAppInfo.AppName = aiStatus.DisplayName
-		ReportAppInfo.State = info.ZSwState(aiStatus.State)
+		ReportAppInfo.State = aiStatus.State.ZSwState()
 
 		if !aiStatus.ErrorTime.IsZero() {
 			errInfo := encodeErrorInfo(
@@ -1365,7 +1364,7 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 				ReportSoftwareInfo.SwVersion = aiStatus.UUIDandVersion.Version
 				ReportSoftwareInfo.ImageName = ss.Name
 				ReportSoftwareInfo.SwHash = ss.ImageSha256
-				ReportSoftwareInfo.State = info.ZSwState(ss.State)
+				ReportSoftwareInfo.State = ss.State.ZSwState()
 				ReportSoftwareInfo.DownloadProgress = uint32(ss.Progress)
 
 				ReportSoftwareInfo.Target = ss.Target

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -455,6 +455,7 @@ func handleCreate(ctxArg interface{}, key string,
 		IoAdapterList:       config.IoAdapterList,
 		RestartCmd:          config.RestartCmd,
 		PurgeCmd:            config.PurgeCmd,
+		State:               types.INITIAL,
 	}
 
 	// Do we have a PurgeCmd counter from before the reboot?

--- a/pkg/pillar/types/types.go
+++ b/pkg/pillar/types/types.go
@@ -9,29 +9,116 @@ import (
 	"strings"
 	"time"
 
+	"github.com/lf-edge/eve/api/go/info"
 	"github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
 )
 
-// Enum names from OMA-TS-LWM2M_SwMgmt-V1_0-20151201-C
-// The ones starting with BOOTING are in addition to OMA and represent
-// operational/activated states.
+// SwState started with enum names from OMA-TS-LWM2M_SwMgmt-V1_0-20151201-C
+// but now has many additions.
+// They are in order of progression (except for the RESTARTING and PURGING ones)
+// We map this to info.ZSwState
 type SwState uint8
 
 const (
-	INITIAL          SwState = iota + 1
-	DOWNLOAD_STARTED         // Really download in progress
+	// INITIAL is 100 to be able to tell any confusion with ZSwState
+	INITIAL       SwState = iota + 100 // Initial value
+	RESOLVING_TAG                      // Resolving an image tag
+	RESOLVED_TAG                       // Tag has been resolved or resolution failed
+	DOWNLOADING
 	DOWNLOADED
-	DELIVERED // Package integrity verified
-	INSTALLED // Available to be activated
+	VERIFYING
+	VERIFIED
+	CREATING_VOLUME // Volume create in progress
+	CREATED_VOLUME  // Volume create done or failed
+	INSTALLED       // Available to be activated
 	BOOTING
 	RUNNING
 	HALTING // being halted
 	HALTED
 	RESTARTING // Restarting due to config change or zcli
 	PURGING    // Purging due to config change
-	MAXSTATE   //
+	MAXSTATE
 )
+
+// String returns the string name
+func (state SwState) String() string {
+	switch state {
+	case INITIAL:
+		return "INITIAL"
+	case RESOLVING_TAG:
+		return "RESOLVING_TAG"
+	case RESOLVED_TAG:
+		return "RESOLVED_TAG"
+	case DOWNLOADING:
+		return "DOWNLOAD_STARTED"
+	case DOWNLOADED, VERIFYING:
+		return "DOWNLOADED"
+	case VERIFIED:
+		return "DELIVERED"
+	case CREATING_VOLUME:
+		return "CREATING_VOLUME"
+	case CREATED_VOLUME:
+		return "CREATED_VOLUME"
+	case INSTALLED:
+		return "INSTALLED"
+	case BOOTING:
+		return "BOOTING"
+	case RUNNING:
+		return "RUNNING"
+	case HALTING:
+		return "HALTING"
+	case HALTED:
+		return "HALTED"
+	case RESTARTING:
+		return "RESTARTING"
+	case PURGING:
+		return "PURGING"
+	default:
+		return fmt.Sprintf("Unknown state %d", state)
+	}
+}
+
+// ZSwState returns different numbers and in some cases mapped many to one
+func (state SwState) ZSwState() info.ZSwState {
+	switch state {
+	case 0:
+		return 0
+	case INITIAL:
+		return info.ZSwState_INITIAL
+	case RESOLVING_TAG:
+		return info.ZSwState_RESOLVING_TAG
+	case RESOLVED_TAG:
+		return info.ZSwState_RESOLVED_TAG
+	case DOWNLOADING:
+		return info.ZSwState_DOWNLOAD_STARTED
+	case DOWNLOADED, VERIFYING:
+		return info.ZSwState_DOWNLOADED
+	case VERIFIED:
+		return info.ZSwState_DELIVERED
+	case CREATING_VOLUME:
+		return info.ZSwState_CREATING_VOLUME
+	case CREATED_VOLUME:
+		return info.ZSwState_CREATED_VOLUME
+	case INSTALLED:
+		return info.ZSwState_INSTALLED
+	case BOOTING:
+		return info.ZSwState_BOOTING
+	case RUNNING:
+		return info.ZSwState_RUNNING
+	case HALTING:
+		return info.ZSwState_HALTING
+	case HALTED:
+		return info.ZSwState_HALTED
+	case RESTARTING:
+		return info.ZSwState_RESTARTING
+	case PURGING:
+		return info.ZSwState_PURGING
+	default:
+		log.Fatalf("Unknown state %d", state)
+	}
+	return info.ZSwState_INITIAL
+}
 
 // NoHash should XXX deprecate?
 const (

--- a/pkg/pillar/types/volumes.go
+++ b/pkg/pillar/types/volumes.go
@@ -260,7 +260,7 @@ func (status VolumeStatus) LogCreate() {
 	if logObject == nil {
 		return
 	}
-	logObject.CloneAndAddField("state", status.State).
+	logObject.CloneAndAddField("state", status.State.String()).
 		AddField("volume-created", status.VolumeCreated).
 		Infof("Volume status create")
 }
@@ -277,16 +277,16 @@ func (status VolumeStatus) LogModify(old interface{}) {
 	if oldStatus.State != status.State ||
 		oldStatus.VolumeCreated != status.VolumeCreated {
 
-		logObject.CloneAndAddField("state", status.State).
+		logObject.CloneAndAddField("state", status.State.String()).
 			AddField("volume-created", status.VolumeCreated).
-			AddField("old-state", oldStatus.VolumeCreated).
+			AddField("old-state", oldStatus.State.String()).
 			AddField("old-volume-created", oldStatus.VolumeCreated).
 			Infof("Volume status modify")
 	}
 
 	if status.HasError() {
 		errAndTime := status.ErrorAndTime()
-		logObject.CloneAndAddField("state", status.State).
+		logObject.CloneAndAddField("state", status.State.String()).
 			AddField("volume-created", status.VolumeCreated).
 			AddField("error", errAndTime.Error).
 			AddField("error-time", errAndTime.ErrorTime).
@@ -298,7 +298,7 @@ func (status VolumeStatus) LogModify(old interface{}) {
 func (status VolumeStatus) LogDelete() {
 	logObject := base.EnsureLogObject(base.VolumeStatusLogType, status.DisplayName,
 		status.VolumeID, status.LogKey())
-	logObject.CloneAndAddField("state", status.State).
+	logObject.CloneAndAddField("state", status.State.String()).
 		AddField("volume-created", status.VolumeCreated).
 		Infof("Volume status delete")
 

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -189,7 +189,7 @@ func (status AppInstanceStatus) LogCreate() {
 	if logObject == nil {
 		return
 	}
-	logObject.CloneAndAddField("state", status.State).
+	logObject.CloneAndAddField("state", status.State.String()).
 		AddField("restart-in-progress", status.RestartInprogress).
 		AddField("purge-in-progress", status.PurgeInprogress).
 		Infof("App instance status create")
@@ -208,10 +208,10 @@ func (status AppInstanceStatus) LogModify(old interface{}) {
 		oldStatus.RestartInprogress != status.RestartInprogress ||
 		oldStatus.PurgeInprogress != status.PurgeInprogress {
 
-		logObject.CloneAndAddField("state", status.State).
+		logObject.CloneAndAddField("state", status.State.String()).
 			AddField("restart-in-progress", status.RestartInprogress).
 			AddField("purge-in-progress", status.PurgeInprogress).
-			AddField("old-state", oldStatus.State).
+			AddField("old-state", oldStatus.State.String()).
 			AddField("old-restart-in-progress", oldStatus.RestartInprogress).
 			AddField("old-purge-in-progress", oldStatus.PurgeInprogress).
 			Infof("App instance status modify")
@@ -219,7 +219,7 @@ func (status AppInstanceStatus) LogModify(old interface{}) {
 
 	if status.HasError() {
 		errAndTime := status.ErrorAndTime()
-		logObject.CloneAndAddField("state", status.State).
+		logObject.CloneAndAddField("state", status.State.String()).
 			AddField("restart-in-progress", status.RestartInprogress).
 			AddField("purge-in-progress", status.PurgeInprogress).AddField("error", errAndTime.Error).
 			AddField("error-time", errAndTime.ErrorTime).
@@ -231,7 +231,7 @@ func (status AppInstanceStatus) LogModify(old interface{}) {
 func (status AppInstanceStatus) LogDelete() {
 	logObject := base.EnsureLogObject(base.AppInstanceStatusLogType, status.DisplayName,
 		status.UUIDandVersion.UUID, status.LogKey())
-	logObject.CloneAndAddField("state", status.State).
+	logObject.CloneAndAddField("state", status.State.String()).
 		AddField("restart-in-progress", status.RestartInprogress).
 		AddField("purge-in-progress", status.PurgeInprogress).
 		Infof("App instance status delete")

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -92,7 +92,8 @@ func (config AppInstanceConfig) LogCreate() {
 	if logObject == nil {
 		return
 	}
-	logObject.CloneAndAddField("activate", config.Activate).AddField("remote-console", config.RemoteConsole).
+	logObject.CloneAndAddField("activate", config.Activate).
+		AddField("remote-console", config.RemoteConsole).
 		Infof("App instance config create")
 }
 
@@ -108,7 +109,10 @@ func (config AppInstanceConfig) LogModify(old interface{}) {
 	if oldConfig.Activate != config.Activate ||
 		oldConfig.RemoteConsole != config.RemoteConsole {
 
-		logObject.CloneAndAddField("activate", config.Activate).AddField("remote-console", config.RemoteConsole).
+		logObject.CloneAndAddField("activate", config.Activate).
+			AddField("remote-console", config.RemoteConsole).
+			AddField("old-activate", oldConfig.Activate).
+			AddField("old-remote-console", oldConfig.RemoteConsole).
 			Infof("App instance config modify")
 	}
 
@@ -116,6 +120,12 @@ func (config AppInstanceConfig) LogModify(old interface{}) {
 
 // LogDelete :
 func (config AppInstanceConfig) LogDelete() {
+	logObject := base.EnsureLogObject(base.AppInstanceConfigLogType, config.DisplayName,
+		config.UUIDandVersion.UUID, config.LogKey())
+	logObject.CloneAndAddField("activate", config.Activate).
+		AddField("remote-console", config.RemoteConsole).
+		Infof("App instance config delete")
+
 	base.DeleteLogObject(config.LogKey())
 }
 
@@ -179,8 +189,10 @@ func (status AppInstanceStatus) LogCreate() {
 	if logObject == nil {
 		return
 	}
-	logObject.CloneAndAddField("state", status.State).AddField("restart-in-progress", status.RestartInprogress).
-		AddField("purge-in-progress", status.PurgeInprogress).Infof("App instance status create")
+	logObject.CloneAndAddField("state", status.State).
+		AddField("restart-in-progress", status.RestartInprogress).
+		AddField("purge-in-progress", status.PurgeInprogress).
+		Infof("App instance status create")
 }
 
 // LogModify :
@@ -192,25 +204,38 @@ func (status AppInstanceStatus) LogModify(old interface{}) {
 	if !ok {
 		log.Errorf("LogModify: Old object interface passed is not of AppInstanceStatus type")
 	}
-	if status.HasError() {
-		errAndTime := status.ErrorAndTime()
-		logObject.CloneAndAddField("state", status.State).AddField("restart-in-progress", status.RestartInprogress).
-			AddField("purge-in-progress", status.PurgeInprogress).AddField("error", errAndTime.Error).
-			AddField("error-time", errAndTime.ErrorTime).Errorf("App instance status modify")
-		return
-	}
 	if oldStatus.State != status.State ||
 		oldStatus.RestartInprogress != status.RestartInprogress ||
 		oldStatus.PurgeInprogress != status.PurgeInprogress {
 
-		logObject.CloneAndAddField("state", status.State).AddField("restart-in-progress", status.RestartInprogress).
-			AddField("purge-in-progress", status.PurgeInprogress).Infof("App instance status modify")
+		logObject.CloneAndAddField("state", status.State).
+			AddField("restart-in-progress", status.RestartInprogress).
+			AddField("purge-in-progress", status.PurgeInprogress).
+			AddField("old-state", oldStatus.State).
+			AddField("old-restart-in-progress", oldStatus.RestartInprogress).
+			AddField("old-purge-in-progress", oldStatus.PurgeInprogress).
+			Infof("App instance status modify")
 	}
 
+	if status.HasError() {
+		errAndTime := status.ErrorAndTime()
+		logObject.CloneAndAddField("state", status.State).
+			AddField("restart-in-progress", status.RestartInprogress).
+			AddField("purge-in-progress", status.PurgeInprogress).AddField("error", errAndTime.Error).
+			AddField("error-time", errAndTime.ErrorTime).
+			Errorf("App instance status modify")
+	}
 }
 
 // LogDelete :
 func (status AppInstanceStatus) LogDelete() {
+	logObject := base.EnsureLogObject(base.AppInstanceStatusLogType, status.DisplayName,
+		status.UUIDandVersion.UUID, status.LogKey())
+	logObject.CloneAndAddField("state", status.State).
+		AddField("restart-in-progress", status.RestartInprogress).
+		AddField("purge-in-progress", status.PurgeInprogress).
+		Infof("App instance status delete")
+
 	base.DeleteLogObject(status.LogKey())
 }
 

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -221,7 +221,8 @@ func (status AppInstanceStatus) LogModify(old interface{}) {
 		errAndTime := status.ErrorAndTime()
 		logObject.CloneAndAddField("state", status.State.String()).
 			AddField("restart-in-progress", status.RestartInprogress).
-			AddField("purge-in-progress", status.PurgeInprogress).AddField("error", errAndTime.Error).
+			AddField("purge-in-progress", status.PurgeInprogress).
+			AddField("error", errAndTime.Error).
 			AddField("error-time", errAndTime.ErrorTime).
 			Errorf("App instance status modify")
 	}


### PR DESCRIPTION
This includes a mapping to the protobuf info.ZSwState since it is easier in zedmanager when the state numbers for the StorageStatus increase numerically during the progression.

When I run this today I see the UI reporting "StateNone" for the new ones. So once we agree on this it might make sense to take the proto file changes and run that through the controller and UI before we start using the new state values in EVE @bharani-zededa 

As part of this adding the new event logging for VolumeStatus and tweaking it for app instances. @gopi please take a look