### PR TITLE
nim logging for observability; refactor out interface check from DHCP code

### DIFF
--- a/pkg/pillar/base/logobjecttypes.go
+++ b/pkg/pillar/base/logobjecttypes.go
@@ -73,6 +73,12 @@ const (
 	ContentTreeConfigLogType LogObjectType = "contenttree_config"
 	// ContentTreeStatusLogType :
 	ContentTreeStatusLogType LogObjectType = "contenttree_status"
+	// DevicePortConfig : object being logged
+	DevicePortConfigLogType LogObjectType = "deviceport_config"
+	// DevicePortConfigList :
+	DevicePortConfigListLogType LogObjectType = "deviceportconfig_list"
+	// DeviceNetworkStatus :
+	DeviceNetworkStatusLogType LogObjectType = "devicenetwork_status"
 )
 
 // RelationObjectType :

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -674,11 +674,9 @@ func parseOneSystemAdapterConfig(getconfigCtx *getconfigContext,
 		errStr := fmt.Sprintf("Missing phyio for %s lower %s; ignored",
 			sysAdapter.Name, sysAdapter.LowerLayerName)
 		log.Error(errStr)
-		// Report error but set Dhcp, isMgmt, and isFree to sane values
-		port.RecordFailure(errStr)
-		port.IfName = sysAdapter.Name
-		isFree = true
-	} else if !types.IoType(phyio.Ptype).IsNet() {
+		return nil
+	}
+	if !types.IoType(phyio.Ptype).IsNet() {
 		errStr := fmt.Sprintf("phyio for %s lower %s not IsNet; ignored",
 			sysAdapter.Name, sysAdapter.LowerLayerName)
 		log.Error(errStr)

--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -740,7 +740,8 @@ func (ctx *DeviceNetworkContext) doUpdatePortConfigListAndPublish(
 	if newplace == nil {
 		// Current Got deleted. If [0] was working we stick to it, otherwise we
 		// restart looking through the list.
-		if ctx.DevicePortConfigList.PortConfigList[0].WasDPCWorking() {
+		if len(ctx.DevicePortConfigList.PortConfigList) != 0 &&
+			ctx.DevicePortConfigList.PortConfigList[0].WasDPCWorking() {
 			ctx.DevicePortConfigList.CurrentIndex = 0
 		} else {
 			ctx.DevicePortConfigList.CurrentIndex = -1

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -247,32 +247,40 @@ func (config DevicePortConfigList) LogDelete() {
 
 // LogKey :
 func (config DevicePortConfigList) LogKey() string {
-	return string(base.DevicePortConfigListLogType) + "-" + config.Key
+	return string(base.DevicePortConfigListLogType) + "-" + config.PubKey()
 }
 
 // PendDPCStatus tracks the internal progression of a DPC
 type PendDPCStatus uint32
 
-// DPC_FAIL and friends is the internal state of the testing
+// DPC_NONE and friends is the internal state of the testing
 const (
-	DPC_FAIL PendDPCStatus = iota
+	DPC_NONE PendDPCStatus = iota
+	DPC_FAIL
 	DPC_SUCCESS
-	DPC_WAIT
-	DPC_PCI_WAIT
-	// XXX add DPC_INTF_WAIT?
+	DPC_IPDNS_WAIT  // DPC_IPDNS_WAIT means not IP and DNS server yet
+	DPC_PCI_WAIT    // DPC_PCI_WAIT means some interface still in pci back
+	DPC_INTF_WAIT   // DPC_INTF_WAIT means some interface missing from kernel
+	DPC_REMOTE_WAIT // DPC_REMOTE_WAIT means controller is down or has old certificate
 )
 
 // String returns the string name
 func (status PendDPCStatus) String() string {
 	switch status {
+	case DPC_NONE:
+		return ""
 	case DPC_FAIL:
 		return "DPC_FAIL"
 	case DPC_SUCCESS:
 		return "DPC_SUCCESS"
-	case DPC_WAIT:
-		return "DPC_WAIT"
+	case DPC_IPDNS_WAIT:
+		return "DPC_IPDNS_WAIT"
 	case DPC_PCI_WAIT:
 		return "DPC_PCI_WAIT"
+	case DPC_INTF_WAIT:
+		return "DPC_INTF_WAIT"
+	case DPC_REMOTE_WAIT:
+		return "DPC_REMOTE_WAIT"
 	default:
 		return fmt.Sprintf("Unknown status %d", status)
 	}
@@ -395,7 +403,7 @@ func (config DevicePortConfig) LogDelete() {
 
 // LogKey :
 func (config DevicePortConfig) LogKey() string {
-	return string(base.DevicePortConfigLogType) + "-" + config.Key
+	return string(base.DevicePortConfigLogType) + "-" + config.PubKey()
 }
 
 // TestResults is used to record when some test Failed or Succeeded.


### PR DESCRIPTION
Please review each commit separately.

Make it more clear that we are checking for the existence of the network interfaces, so the code is clearer on how much we wait for them to appear (after the are back from PCI assignment).

Add object logging for nim object (DevicePortConfig, DevicePortConfigList, DeviceNetworkStatus) including dummy publishing of DevicePortConfig to get logs from pubsub. Added saving/logging of DPC_FAIL, plus introducing separate DPC_*WAIT to make it more clear in the logs.

The last commit does potentially change the behavior when the phyio model comming from the controller is broken. Might mean that a device would use last-resort explicitly as opposed to pretenting that e.g., eth1 coming from the controller should be a DHCP client. So EVE should be robust even against a bad config.