### PR TITLE
Zedcloud UseCase: added support for chunked download(s3 and azure)

### DIFF
--- a/pkg/pillar/zedUpload/commonutils.go
+++ b/pkg/pillar/zedUpload/commonutils.go
@@ -1,0 +1,45 @@
+// Copyright(c) 2017-2018 Zededa, Inc.
+// All rights reserved.
+
+package zedUpload
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+)
+
+const (
+	//SingleMB represents data size of 1MB
+	SingleMB int64 = 1024 * 1024
+)
+
+// ChunkData contains the details of Chunks being downloaded
+type ChunkData struct {
+	Size  int64  // complete size to upload/download
+	Chunk []byte // chunk data being uploaded/downloaded
+	EOF   bool   // denotes last chunk of the file
+}
+
+func processChunkByChunk(readCloser io.ReadCloser, size int64, chunkChan chan ChunkData) error {
+	fmt.Println("processChunkByChunk started", size)
+	var processed int64
+	var eof bool
+	for processed < size {
+		var rbuf bytes.Buffer
+		bufferSize := size - processed
+		if bufferSize > SingleMB {
+			bufferSize = SingleMB
+		} else {
+			eof = true
+		}
+		written, err := io.CopyN(&rbuf, readCloser, int64(bufferSize))
+		if err != nil {
+			return err
+		}
+		chunkChan <- ChunkData{Size: size, Chunk: rbuf.Bytes(), EOF: eof}
+		processed += written
+	}
+	readCloser.Close()
+	return nil
+}

--- a/pkg/pillar/zedUpload/datastore.go
+++ b/pkg/pillar/zedUpload/datastore.go
@@ -29,8 +29,8 @@ const (
 	SyncOpGetURI                = 7
 	SysOpPutPart                = 8
 	SysOpCompleteParts          = 9
-
-	DefaultNumberOfHandlers = 10
+	SysOpDownloadByChunks       = 10
+	DefaultNumberOfHandlers     = 11
 
 	StatsUpdateTicker = 5 * time.Second // timer for updating client for stats
 	FailPostTimeout   = 2 * time.Minute
@@ -169,6 +169,13 @@ func (ctx *DronaCtx) postSize(req *DronaRequest, size, asize int64) {
 	req.setInprogress()
 	req.updateOsize(size)
 	req.updateAsize(asize)
+	req.result <- req
+}
+
+// postChunk:
+//  post the chunk data which is downloaded from the respective datastore
+func (ctx *DronaCtx) postChunk(req *DronaRequest, chunkDetail ChunkData) {
+	req.chunkInfoChan <- chunkDetail
 	req.result <- req
 }
 

--- a/pkg/pillar/zedUpload/datastore_azure.go
+++ b/pkg/pillar/zedUpload/datastore_azure.go
@@ -9,10 +9,9 @@ import (
 	"net/http"
 	"net/url"
 
-	azure "github.com/lf-edge/eve/pkg/pillar/zedUpload/azureutil"
-
-	//	"strings"
 	"time"
+
+	azure "github.com/lf-edge/eve/pkg/pillar/zedUpload/azureutil"
 )
 
 func (ep *AzureTransportMethod) Action(req *DronaRequest) error {
@@ -47,6 +46,8 @@ func (ep *AzureTransportMethod) Action(req *DronaRequest) error {
 		if err == nil {
 			req.SasURI = sasURI
 		}
+	case SysOpDownloadByChunks:
+		err = ep.processAzureDownloadByChunks(req)
 	default:
 		err = fmt.Errorf("Unknown Azure Blob datastore operation")
 	}
@@ -160,6 +161,21 @@ func (ep *AzureTransportMethod) getContext() *DronaCtx {
 
 func (ep *AzureTransportMethod) processAzureUploadByChunks(req *DronaRequest) error {
 	return azure.UploadPartByChunk(ep.acName, ep.acKey, ep.container, req.localName, req.UploadID, ep.hClient, req.Adata)
+}
+
+func (ep *AzureTransportMethod) processAzureDownloadByChunks(req *DronaRequest) error {
+	readCloser, size, err := azure.DownloadAzureBlobByChunks(ep.acName, ep.acKey, ep.container, req.name, req.objloc, ep.hClient)
+	if err != nil {
+		return err
+	}
+	req.chunkInfoChan = make(chan ChunkData, 1)
+	chunkChan := make(chan ChunkData)
+	go func(chunkChan chan ChunkData) {
+		for chunkData := range chunkChan {
+			ep.ctx.postChunk(req, chunkData)
+		}
+	}(chunkChan)
+	return processChunkByChunk(readCloser, size, chunkChan)
 }
 
 func (ep *AzureTransportMethod) processGenerateBlobSasURI(req *DronaRequest) (string, error) {

--- a/pkg/pillar/zedUpload/datastore_http.go
+++ b/pkg/pillar/zedUpload/datastore_http.go
@@ -44,6 +44,8 @@ func (ep *HttpTransportMethod) Action(req *DronaRequest) error {
 	case SyncOpGetObjectMetaData:
 		err, contentLength = ep.processHttpObjectMetaData(req)
 		req.contentLength = contentLength
+	case SysOpDownloadByChunks:
+		err = fmt.Errorf("Chunk download for HTTP transport is not supported yet")
 	default:
 		err = fmt.Errorf("Unknown HTTP datastore operation")
 	}

--- a/pkg/pillar/zedUpload/datastore_oci.go
+++ b/pkg/pillar/zedUpload/datastore_oci.go
@@ -57,6 +57,8 @@ func (ep *OCITransportMethod) Action(req *DronaRequest) error {
 		sha256, contentLength, err = ep.processObjectMetaData(req)
 		req.contentLength = contentLength
 		req.ImageSha256 = sha256
+	case SysOpDownloadByChunks:
+		err = fmt.Errorf("Chunk download for OCI tansport is not supported yet")
 	default:
 		err = fmt.Errorf("Unknown OCI registry operation")
 	}

--- a/pkg/pillar/zedUpload/datastore_req.go
+++ b/pkg/pillar/zedUpload/datastore_req.go
@@ -83,6 +83,8 @@ type DronaRequest struct {
 	UploadID string
 	// generated after uploading the part to the multipart file
 	EtagID string
+	// chunkInfoChan used for communication of chunk details
+	chunkInfoChan chan ChunkData
 }
 
 // Return object local name
@@ -194,6 +196,14 @@ func (req *DronaRequest) updateOsize(size int64) {
 	req.Lock()
 	defer req.Unlock()
 	req.objectSize = size
+}
+
+// GetChunkDetails Return the chunk details
+func (req *DronaRequest) GetChunkDetails() (int64, []byte, bool) {
+	req.Lock()
+	defer req.Unlock()
+	chunkDetails := <-req.chunkInfoChan
+	return chunkDetails.Size, chunkDetails.Chunk, chunkDetails.EOF
 }
 
 // Return the if the object was downloaded with error

--- a/pkg/pillar/zedUpload/datastore_sftp.go
+++ b/pkg/pillar/zedUpload/datastore_sftp.go
@@ -63,6 +63,8 @@ func (ep *SftpTransportMethod) Action(req *DronaRequest) error {
 	case SyncOpGetObjectMetaData:
 		err, contentLength = ep.processSftpObjectMetaData(req)
 		req.contentLength = contentLength
+	case SysOpDownloadByChunks:
+		err = fmt.Errorf("Chunk download for SFTP transport is not supported yet")
 	default:
 		err = fmt.Errorf("Unknown SFTP datastore operation")
 	}

--- a/pkg/pillar/zedUpload/httputil/http.go
+++ b/pkg/pillar/zedUpload/httputil/http.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"crypto/tls"
 	"fmt"
-	"golang.org/x/net/html"
 	"io"
 	"io/ioutil"
 	"mime/multipart"
@@ -16,6 +15,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"golang.org/x/net/html"
 )
 
 const (

--- a/pkg/pillar/zedUpload/sftputil/sftp.go
+++ b/pkg/pillar/zedUpload/sftputil/sftp.go
@@ -5,14 +5,15 @@ package sftp
 
 import (
 	"fmt"
-	"github.com/pkg/sftp"
-	"golang.org/x/crypto/ssh"
 	"io"
 	"log"
 	"net"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/pkg/sftp"
+	"golang.org/x/crypto/ssh"
 )
 
 const (


### PR DESCRIPTION
Signed-off-by: chethan-zededa <chethan@zededa.com>
added support for downloading file chunk by chunk without writing full file into local file.
i.e., as and when downloading small chunk of data (1MB), will be posted to the caller.