### PR TITLE
Fixing volumemgr fatal in case persist dir doesn't exist

### DIFF
--- a/pkg/pillar/cmd/volumemgr/initialvolumestatus.go
+++ b/pkg/pillar/cmd/volumemgr/initialvolumestatus.go
@@ -106,7 +106,9 @@ func populateInitialVolumeStatus(ctx *volumemgrContext, dirName string) {
 
 	locations, err := ioutil.ReadDir(dirName)
 	if err != nil {
-		log.Fatal(err)
+		log.Errorf("populateInitialVolumeStatus: read directory '%s' failed: %v",
+			dirName, err)
+		return
 	}
 
 	for _, location := range locations {


### PR DESCRIPTION
Volumemgr is crashing while base OS upgrade on the devices which don't have ```/persist/runx/pods/prepared``` directory. And this directory won't be present on those devices on which no container instance is deployed in the past.