### PR TITLE
do not use baseos image until CREATED_VOLUME 

### DIFF
--- a/pkg/pillar/base/logobjecttypes.go
+++ b/pkg/pillar/base/logobjecttypes.go
@@ -45,6 +45,10 @@ const (
 	DomainConfigLogType LogObjectType = "domain_config"
 	// DomainStatusLogType :
 	DomainStatusLogType LogObjectType = "domain_status"
+	// BaseOsConfigLogType :
+	BaseOsConfigLogType LogObjectType = "baseos_config"
+	// BaseOsStatusLogType :
+	BaseOsStatusLogType LogObjectType = "baseos_status"
 )
 
 // RelationObjectType :

--- a/pkg/pillar/base/logobjecttypes.go
+++ b/pkg/pillar/base/logobjecttypes.go
@@ -49,6 +49,10 @@ const (
 	BaseOsConfigLogType LogObjectType = "baseos_config"
 	// BaseOsStatusLogType :
 	BaseOsStatusLogType LogObjectType = "baseos_status"
+	// ZbootConfigLogType :
+	ZbootConfigLogType LogObjectType = "zboot_config"
+	// ZbootStatusLogType :
+	ZbootStatusLogType LogObjectType = "zboot_status"
 )
 
 // RelationObjectType :

--- a/pkg/pillar/cmd/baseosmgr/handledownload.go
+++ b/pkg/pillar/cmd/baseosmgr/handledownload.go
@@ -110,7 +110,7 @@ func checkVolumeStatus(ctx *baseOsMgrContext,
 
 	if ret.MinState == types.MAXSTATE {
 		// No StorageStatus
-		ret.MinState = types.DOWNLOADED
+		ret.MinState = types.INITIAL
 		ret.Changed = true
 	}
 
@@ -127,7 +127,7 @@ func installDownloadedObjects(uuidStr string,
 	for i := range *status {
 		ssPtr := &(*status)[i]
 
-		if ssPtr.State == types.VERIFIED {
+		if ssPtr.State == types.CREATED_VOLUME {
 			err := installDownloadedObject(ssPtr.ImageID, ssPtr)
 			if err != nil {
 				log.Error(err)

--- a/pkg/pillar/types/zboottypes.go
+++ b/pkg/pillar/types/zboottypes.go
@@ -3,6 +3,11 @@
 
 package types
 
+import (
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	log "github.com/sirupsen/logrus"
+)
+
 // ZbootConfig contains information fed from zedagent to baseosmgr.
 // Only used to indicate that the testing of the image/partition is complete.
 type ZbootConfig struct {
@@ -11,8 +16,52 @@ type ZbootConfig struct {
 }
 
 // Key returns the key used in pubsub for ZbootConfig
-func (status ZbootConfig) Key() string {
-	return status.PartitionLabel
+func (config ZbootConfig) Key() string {
+	return config.PartitionLabel
+}
+
+// LogCreate :
+func (config ZbootConfig) LogCreate() {
+	logObject := base.NewLogObject(base.ZbootConfigLogType, "",
+		nilUUID, config.LogKey())
+	if logObject == nil {
+		return
+	}
+	logObject.CloneAndAddField("test-complete-bool", config.TestComplete).
+		Infof("Zboot config create")
+}
+
+// LogModify :
+func (config ZbootConfig) LogModify(old interface{}) {
+	logObject := base.EnsureLogObject(base.ZbootConfigLogType, "",
+		nilUUID, config.LogKey())
+
+	oldConfig, ok := old.(ZbootConfig)
+	if !ok {
+		log.Errorf("LogModify: Old object interface passed is not of ZbootConfig type")
+	}
+	if oldConfig.TestComplete != config.TestComplete {
+
+		logObject.CloneAndAddField("test-complete-bool", config.TestComplete).
+			AddField("old-test-complete-bool", oldConfig.TestComplete).
+			Infof("Zboot config modify")
+	}
+
+}
+
+// LogDelete :
+func (config ZbootConfig) LogDelete() {
+	logObject := base.EnsureLogObject(base.ZbootConfigLogType, "",
+		nilUUID, config.LogKey())
+	logObject.CloneAndAddField("test-complete-bool", config.TestComplete).
+		Infof("Zboot config delete")
+
+	base.DeleteLogObject(config.LogKey())
+}
+
+// LogKey : XXX note that this only the IMGx, while Status includes ShortVersion for logs
+func (config ZbootConfig) LogKey() string {
+	return string(base.ZbootConfigLogType) + "-" + config.PartitionLabel
 }
 
 type ZbootStatus struct {
@@ -27,4 +76,57 @@ type ZbootStatus struct {
 
 func (status ZbootStatus) Key() string {
 	return status.PartitionLabel
+}
+
+// LogCreate :
+func (status ZbootStatus) LogCreate() {
+	logObject := base.NewLogObject(base.ZbootStatusLogType, "",
+		nilUUID, status.LogKey())
+	if logObject == nil {
+		return
+	}
+	logObject.CloneAndAddField("partition-state", status.PartitionState).
+		AddField("current-partition-bool", status.CurrentPartition).
+		AddField("test-complete-bool", status.TestComplete).
+		Infof("Zboot status create")
+}
+
+// LogModify :
+func (status ZbootStatus) LogModify(old interface{}) {
+	logObject := base.EnsureLogObject(base.ZbootStatusLogType, "",
+		nilUUID, status.LogKey())
+
+	oldStatus, ok := old.(ZbootStatus)
+	if !ok {
+		log.Errorf("LogModify: Old object interface passed is not of ZbootStatus type")
+	}
+	if oldStatus.PartitionState != status.PartitionState ||
+		oldStatus.CurrentPartition != status.CurrentPartition ||
+		oldStatus.TestComplete != status.TestComplete {
+
+		logObject.CloneAndAddField("partition-state", status.PartitionState).
+			AddField("old-partition-state", oldStatus.PartitionState).
+			AddField("current-partition-bool", status.CurrentPartition).
+			AddField("old-current-partition-bool", oldStatus.CurrentPartition).
+			AddField("test-complete-bool", status.TestComplete).
+			AddField("old-test-complete-bool", oldStatus.TestComplete).
+			Infof("Zboot status modify")
+	}
+}
+
+// LogDelete :
+func (status ZbootStatus) LogDelete() {
+	logObject := base.EnsureLogObject(base.ZbootStatusLogType, "",
+		nilUUID, status.LogKey())
+	logObject.CloneAndAddField("partition-state", status.PartitionState).
+		AddField("current-partition-bool", status.CurrentPartition).
+		AddField("test-complete-bool", status.TestComplete).
+		Infof("Zboot status delete")
+
+	base.DeleteLogObject(status.LogKey())
+}
+
+// LogKey : XXX note that this includes the ShortVersion, while Status only the PartitionLabel
+func (status ZbootStatus) LogKey() string {
+	return string(base.ZbootStatusLogType) + "-" + status.PartitionLabel + "-" + status.ShortVersion
 }


### PR DESCRIPTION
The introduction of volumemgr's new states a week ago plus the placement of the results more recently might result in a timing issue where sometimes an eveimage update results in looking for an image which has not yet been dd'ed to the second partition.
What we saw once was that the version string in the second partition was empty, resulting in a failure reported to the controller.

This correction to the state check should ensure that the dd has completed.

The other two commits are to introduce event logging for the relevant types so that we can more easily follow the changes during the baseos lifecycle should this problem or similar problem be observed again.