### PR TITLE
Cleaning up of filling IsContainer flag in download status

### DIFF
--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -398,12 +398,6 @@ func handleModify(ctx *downloaderContext, key string,
 		status.ImageID, status.RefCount, config.RefCount,
 		status.Expired, status.Name)
 
-	if config.IsContainer != status.IsContainer {
-		log.Infof("handleModify: Setting IsContainer to %t for %s",
-			config.IsContainer, status.ImageID)
-		status.IsContainer = config.IsContainer
-		publishDownloaderStatus(ctx, status)
-	}
 	// If RefCount from zero to non-zero then do install
 	if status.RefCount == 0 && config.RefCount != 0 {
 		log.Infof("handleModify installing %s", config.Name)

--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -344,7 +344,6 @@ func handleCreate(ctx *downloaderContext, objType string,
 			Name:             config.Name,
 			ImageSha256:      config.ImageSha256,
 			ObjType:          objType,
-			IsContainer:      config.IsContainer,
 			RefCount:         config.RefCount,
 			LastUse:          time.Now(),
 			AllowNonFreePort: config.AllowNonFreePort,
@@ -357,7 +356,6 @@ func handleCreate(ctx *downloaderContext, objType string,
 		status.ImageID = config.ImageID
 		status.DatastoreID = config.DatastoreID
 		status.ImageSha256 = config.ImageSha256
-		status.IsContainer = config.IsContainer
 		status.RefCount = config.RefCount
 		status.LastUse = time.Now()
 		status.Expired = false

--- a/pkg/pillar/cmd/volumemgr/handledownloader.go
+++ b/pkg/pillar/cmd/volumemgr/handledownloader.go
@@ -38,7 +38,6 @@ func AddOrRefcountDownloaderConfig(ctx *volumemgrContext, status types.VolumeSta
 			Name:        name, // XXX URL? DisplayName?
 			NameIsURL:   status.DownloadOrigin.NameIsURL,
 			ImageSha256: status.DownloadOrigin.ImageSha256,
-			IsContainer: status.DownloadOrigin.IsContainer,
 			AllowNonFreePort: types.AllowNonFreePort(*ctx.globalConfig,
 				types.AppImgObj),
 			Size:     size,
@@ -63,9 +62,8 @@ func MaybeRemoveDownloaderConfig(ctx *volumemgrContext, objType string, imageSha
 	}
 	if m.RefCount == 0 {
 		log.Fatalf("MaybeRemoveDownloaderConfig: Attempting to reduce "+
-			"0 RefCount. Image Details - Name: %s, ImageSha: %s, "+
-			"IsContainer: %t",
-			m.Name, m.ImageSha256, m.IsContainer)
+			"0 RefCount. Image Details - Name: %s, ImageSha: %s, ",
+			m.Name, m.ImageSha256)
 	}
 	m.RefCount -= 1
 	log.Infof("MaybeRemoveDownloaderConfig remaining RefCount %d for %s",
@@ -129,8 +127,6 @@ func handleDownloaderStatusModify(ctxArg interface{}, key string,
 			Name:        status.Name,
 			NameIsURL:   status.NameIsURL,
 			ImageSha256: status.ImageSha256,
-			// IsContainer might not be known by downloader
-			IsContainer: status.IsContainer,
 			AllowNonFreePort: types.AllowNonFreePort(*ctx.globalConfig,
 				types.AppImgObj),
 			Size:     status.Size,

--- a/pkg/pillar/types/downloadertypes.go
+++ b/pkg/pillar/types/downloadertypes.go
@@ -19,7 +19,6 @@ type DownloaderConfig struct {
 	Name             string
 	Target           string // file path where to download the file
 	NameIsURL        bool   // If not we form URL based on datastore info
-	IsContainer      bool
 	AllowNonFreePort bool
 	Size             uint64 // In bytes
 	FinalObjDir      string // final Object Store
@@ -55,7 +54,6 @@ type DownloaderStatus struct {
 	Target           string // file path where we download the file
 	Name             string
 	ObjType          string
-	IsContainer      bool
 	PendingAdd       bool
 	PendingModify    bool
 	PendingDelete    bool


### PR DESCRIPTION
Backward filing of IsContainer flag in downloader status is not needed so removing it from downloader.