### PR TITLE
Skipping download if earlier download completed

### DIFF
--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -359,6 +359,7 @@ func handleCreate(ctx *downloaderContext, objType string,
 		status.RefCount = config.RefCount
 		status.LastUse = time.Now()
 		status.Expired = false
+		status.ClearError()
 	}
 	publishDownloaderStatus(ctx, status)
 
@@ -396,8 +397,9 @@ func handleModify(ctx *downloaderContext, key string,
 		status.ImageID, status.RefCount, config.RefCount,
 		status.Expired, status.Name)
 
-	// If RefCount from zero to non-zero then do install
-	if status.RefCount == 0 && config.RefCount != 0 {
+	// If RefCount from zero to non-zero and status has error
+	// or status is not downloaded then do install
+	if config.RefCount != 0 && (status.HasError() || status.State != types.DOWNLOADED) {
 		log.Infof("handleModify installing %s", config.Name)
 		handleCreate(ctx, status.ObjType, config, status, key)
 	} else if status.RefCount != config.RefCount {


### PR DESCRIPTION
With these changes, we are fixing two issues:
1. If EVE is downloading an image (~30G) and in between, we deleted the app instance then refcount in downloader config and status will be 0. And now if we deploy the second instance using the same image, the downloader forces the redownloading of the image again.
2. When downloader redownloading the image for an existing downloader status, it is not cleaning up the previous errors from the status.
