### PR TITLE
Two fixes

### DIFF
--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -633,7 +633,11 @@ func handleModify(ctxArg interface{}, key string,
 	// We detect significant changes which require a reboot and/or
 	// purge of disk changes, so we can generate errors if it is
 	// not a PurgeCmd and RestartCmd, respectively
+	// If we are purging then restart is redundant.
 	needPurge, needRestart := quantifyChanges(config, *status)
+	if needPurge {
+		needRestart = false
+	}
 
 	if config.RestartCmd.Counter != status.RestartCmd.Counter {
 

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -564,5 +564,9 @@ type AppAndImageToHash struct {
 
 // Key is used for pubsub
 func (aih AppAndImageToHash) Key() string {
-	return fmt.Sprintf("%s.%s.%d", aih.AppUUID.String(), aih.ImageID.String(), aih.PurgeCounter)
+	if aih.PurgeCounter == 0 {
+		return fmt.Sprintf("%s.%s", aih.AppUUID.String(), aih.ImageID.String())
+	} else {
+		return fmt.Sprintf("%s.%s.%d", aih.AppUUID.String(), aih.ImageID.String(), aih.PurgeCounter)
+	}
 }


### PR DESCRIPTION
Turns out test_app_upgrade has been failing for a while since zedmanager found that both needPurge and needRestart was set. Silly bug.

When upgrading an edge-node running an OCI container and the tag was latched to a sha, the latch+download was redone. That was due to the purgeCounter having been added to the AppAndImageHash key recently. We don't need to add it when it is zero which will reduce redownload on EVE update.