### PR TITLE
fix a zedagent devinfo watchdog due to timer channel hang

### DIFF
--- a/pkg/pillar/flextimer/flextimer.go
+++ b/pkg/pillar/flextimer/flextimer.go
@@ -48,7 +48,7 @@ type flexTickerConfig struct {
 func NewRangeTicker(minTime time.Duration, maxTime time.Duration) FlexTickerHandle {
 	initialConfig := flexTickerConfig{minTime: minTime,
 		maxTime: maxTime}
-	configChan := make(chan flexTickerConfig, 1)
+	configChan := make(chan flexTickerConfig, 5)
 	tickChan := newFlexTicker(configChan)
 	configChan <- initialConfig
 	return FlexTickerHandle{C: tickChan, privateChan: tickChan, configChan: configChan}
@@ -58,7 +58,7 @@ func NewExpTicker(minTime time.Duration, maxTime time.Duration, randomFactor flo
 	initialConfig := flexTickerConfig{minTime: minTime,
 		maxTime: maxTime, exponential: true,
 		randomFactor: randomFactor}
-	configChan := make(chan flexTickerConfig, 1)
+	configChan := make(chan flexTickerConfig, 5)
 	tickChan := newFlexTicker(configChan)
 	configChan <- initialConfig
 	return FlexTickerHandle{C: tickChan, configChan: configChan}

--- a/pkg/pillar/zedcloud/deferred.go
+++ b/pkg/pillar/zedcloud/deferred.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"github.com/lf-edge/eve/pkg/pillar/flextimer"
 	log "github.com/sirupsen/logrus"
+	"sync"
 	"time"
 )
 
@@ -42,6 +43,8 @@ const longTime2 = time.Hour * 48
 type DeferredContext struct {
 	deferredItems map[string]deferredItemList
 	ticker        flextimer.FlexTickerHandle
+	deferMutex    sync.Mutex
+	timerTrigged  bool
 }
 
 // From first InitDeferred
@@ -82,6 +85,9 @@ func (ctx *DeferredContext) handleDeferred(event time.Time,
 
 	log.Infof("HandleDeferred(%v, %v) map %d\n",
 		event, spacing, len(ctx.deferredItems))
+	defaultCtx.deferMutex.Lock()
+	ctx.timerTrigged = false
+	defaultCtx.deferMutex.Unlock()
 	iteration := 0 // Do some load spreading
 	for key, l := range ctx.deferredItems {
 		log.Infof("Trying to send for %s items %d\n", key, len(l.list))
@@ -124,9 +130,11 @@ func (ctx *DeferredContext) handleDeferred(event time.Time,
 			}
 		}
 	}
+	defaultCtx.deferMutex.Lock()
 	if len(ctx.deferredItems) == 0 {
 		stopTimer(ctx)
 	}
+	defaultCtx.deferMutex.Unlock()
 	log.Infof("HandleDeferred() done map %d\n", len(ctx.deferredItems))
 	return len(ctx.deferredItems) == 0
 }
@@ -165,10 +173,6 @@ func (ctx *DeferredContext) removeDeferred(key string) {
 	}
 	log.Debugf("Deleting key %s\n", key)
 	delete(ctx.deferredItems, key)
-
-	if len(ctx.deferredItems) == 0 {
-		stopTimer(ctx)
-	}
 }
 
 // Replace any item for the specified key. If timer not running start it
@@ -178,7 +182,9 @@ func SetDeferred(key string, buf *bytes.Buffer, size int64, url string,
 	if defaultCtx == nil {
 		log.Fatal("SetDeferred no defaultCtx")
 	}
+	defaultCtx.deferMutex.Lock()
 	defaultCtx.setDeferred(key, buf, size, url, zedcloudCtx, return400)
+	defaultCtx.deferMutex.Unlock()
 }
 
 func (ctx *DeferredContext) setDeferred(key string, buf *bytes.Buffer,
@@ -214,7 +220,9 @@ func AddDeferred(key string, buf *bytes.Buffer, size int64, url string,
 	if defaultCtx == nil {
 		log.Fatal("SetDeferred no defaultCtx")
 	}
+	defaultCtx.deferMutex.Lock()
 	defaultCtx.addDeferred(key, buf, size, url, zedcloudCtx, return400)
+	defaultCtx.deferMutex.Unlock()
 }
 
 func (ctx *DeferredContext) addDeferred(key string, buf *bytes.Buffer,
@@ -246,9 +254,14 @@ func (ctx *DeferredContext) addDeferred(key string, buf *bytes.Buffer,
 func startTimer(ctx *DeferredContext) {
 
 	log.Infof("startTimer()\n")
+	if ctx.timerTrigged {
+		log.Infof("startTimer() timer already set\n") // XXX
+		return
+	}
 	min := 1 * time.Minute
 	max := 15 * time.Minute
 	ctx.ticker.UpdateExpTicker(min, max, 0.3)
+	ctx.timerTrigged = true
 }
 
 func stopTimer(ctx *DeferredContext) {


### PR DESCRIPTION
Signed-off-by: Naiming Shen <naiming@zededa.com>
- seen this watchdog in case of northbound traffic is blocked by firewall, the zedagent task of NI Status modify (thus NI info upload), and device info periodically upload fail and stop and start the defer timer.
- the issue of the current code is inside flextimer, when the first timer is triggered, the the zedagent timer if delay for a long time, if a second deferred timer triggers again, it blocks when sending the timer to the timer channel. This block cause the other stopTimer() and startTimer() configure events to be blocked. Thus in turn blocks the zedagent timer to be fired. This causes the deadlock inside zedagent.
- The changed fix is not to block the timer channel inside the flextimer using select and default case if the timer is already been triggered and not yet served.
- this approach means only one timer (the first time) is taking effect, the later timer modify does not matter. but this is the case where even the first timer can not be served properly at this moment, and there is no need to serve the later one right now.
