### PR TITLE
Ignore PID for the logs that donot come with one. eg:kernel, lisp.out…

### DIFF
--- a/pkg/rsyslog/rsyslog.conf
+++ b/pkg/rsyslog/rsyslog.conf
@@ -40,7 +40,7 @@ template(name="nonJsonOutput" type="list" option.jsonf="on") {
   property(outname="time" name="timereported" dateFormat="rfc3339" format="jsonf")
   property(outname="level" name="syslogpriority-text" format="jsonf")
   property(outname="msg" name="$!msg" format="jsonf")
-  property(outname="pid" name="procid" format="jsonf")
+  property(outname="pid" name="procid" format="jsonf" datatype="number" onEmpty="skip")
   property(outname="partition" name="$/IMGP" format="jsonf")
 }
 


### PR DESCRIPTION
… etc. Also explicitly set the pid type to number to make it align with new device index template in elastic search.

Signed-off-by: Gopi krishna Kodali <gkodali@zededa.com>