### PR TITLE
Fixing downloading of containers if name has SHA instead of tag

### DIFF
--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -111,7 +111,9 @@ func doUpdate(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool) {
 		}
 	}
 	if status.State == types.CREATING_VOLUME && status.VolumeCreated {
-		status.State = types.CREATED_VOLUME
+		if !status.HasError() {
+			status.State = types.CREATED_VOLUME
+		}
 		changed = true
 		// Work is done
 		DeleteWorkCreate(ctx, status)


### PR DESCRIPTION
Containerd is unable to import the image if the image name has SHA instead of tag in the config while downloading.