### PR TITLE
Latching SHA with name for container images

### DIFF
--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -486,6 +486,7 @@ func doInstallStorageStatus(ctx *zedmanagerContext,
 				rs.ImageSha256, ss.ImageID)
 			ss.ImageSha256 = rs.ImageSha256
 			ss.HasResolverRef = false
+			ss.Name = maybeInsertSha(ss.Name, ss.ImageSha256)
 			addAppAndImageHash(ctx, config.UUIDandVersion.UUID,
 				ss.ImageID, ss.ImageSha256, ss.PurgeCounter)
 			maybeLatchImageSha(ctx, config, ss)


### PR DESCRIPTION
With these changes, we are latching SHA with the image name for the container instances after resolving the tags.