### PR TITLE
PersistImageStatus and VerifyImageStatue fix.

### DIFF
--- a/pkg/pillar/cmd/verifier/handlepersist.go
+++ b/pkg/pillar/cmd/verifier/handlepersist.go
@@ -24,16 +24,26 @@ func handlePersistCreate(ctx *verifierContext, objType string,
 			config.ImageSha256)
 	}
 	// Require a status since we otherwise don't have a FileLocation
-	status := lookupPersistImageStatus(ctx, objType, config.ImageSha256)
+	var status *types.PersistImageStatus
+	status = lookupPersistImageStatus(ctx, objType, config.ImageSha256)
 	if status == nil {
-		log.Errorf("No PersistImageStatus but config for %s/%s",
-			objType, config.ImageSha256)
-		return
+		status = &types.PersistImageStatus{
+			VerifyStatus: types.VerifyStatus{
+				Name:         config.Name,
+				ObjType:      objType,
+				FileLocation: config.FileLocation,
+				ImageSha256:  config.ImageSha256,
+				Size:         config.Size,
+			},
+			LastUse:  time.Now(),
+			RefCount: config.RefCount,
+		}
+	} else {
+		// Update
+		status.Name = config.Name
+		status.RefCount = config.RefCount
+		status.LastUse = time.Now()
 	}
-	// Update
-	status.Name = config.Name
-	status.RefCount = config.RefCount
-	status.LastUse = time.Now()
 	publishPersistImageStatus(ctx, status)
 	log.Infof("handlePersistCreate done for %s", config.Name)
 }

--- a/pkg/pillar/types/verifiertypes.go
+++ b/pkg/pillar/types/verifiertypes.go
@@ -39,6 +39,8 @@ type VerifyConfig struct {
 	CertificateChain []string //name of intermediate certificates
 	ImageSignature   []byte   //signature of image
 	SignatureKey     string   //certificate containing public key
+	FileLocation     string   // Current location; should be info about file
+	Size             int64    //FileLocation size
 }
 
 // Key returns the pubsub Key


### PR DESCRIPTION
Signed-off-by: adarsh-zededa <adarsh@zededa.com>
This PR has fixes 2 issues:
Issue1: 
When we deployed-delete-deployed an AppInstance, the image was already present in verified dir for the second deploy but there was no PersistImageStatus for that verified image also. But the DownloadConfig from previous deploy was still lingering as it wasn't GCed. So volumeMgr get the (already existing) DownloadConfig, and detects that there is no VerifyImageStatus or PersistImageStatus. Hence volumeMgr assume that it's a newly downloaded image and checks for it in /pending dir and that operation fails. 

Fix 1:
Instead of creating PersistImageStatus only on service boot, creating it if we create a new PersistImageConfig. So when we redeploy an AppInstance, we can reuse the same verified image as we'll have its PersistImageStatus.  


Issue2:
When we deployed a container AppInstance and reboot the device, we recreated the AppInstance's VolumeStatus but we didn't create its VerifyImageStatus. Since there was no VerifyImageStatus, the  PersistImageStatus for that AppInstance's verified image had as refCount=0. Because of which, verifier GCed PersistImageStatus and deleted AppInstance's verified image. This caused an issue after we rebooted the device again where volumeMgr assumes that the AppInst has a verified image and tries to access it. 

Fix 2: 
When the device reboots if we are recreating VolumeStatus for the AppInstance, making sure that we are creating a VerifyImageStaus also, which keep the refCount of PersistImageStatus as 1 and not GC it.