### PR TITLE
avoid redownload of verified image/container

### DIFF
--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -61,7 +61,7 @@ func doUpdate(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool) {
 					status.Key(), status.FileLocation)
 				changed = true
 			}
-		} else {
+		} else if status.State != types.DOWNLOADED {
 			log.Infof("VerifyImageStatus %s for %s sha %s not found",
 				status.DisplayName, status.VolumeID,
 				status.BlobSha256)
@@ -69,6 +69,11 @@ func doUpdate(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool) {
 			if c {
 				changed = true
 			}
+			return changed, false
+		} else {
+			log.Infof("VerifyImageStatus %s for %s sha %s not found; waiting for DOWNLOADED to VERIFIED",
+				status.DisplayName, status.VolumeID,
+				status.BlobSha256)
 			return changed, false
 		}
 	}


### PR DESCRIPTION
We've been putting them in the pending directory even though we have the verified image in place.
Don't know exactly when this was introduced; could have been when volumemgr was introduced in EVE or some time more recently.