### PR TITLE
Minor fixes - with a DownloaderConfig one

### DIFF
--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -344,6 +344,7 @@ func handleCreate(ctx *downloaderContext, objType string,
 			Name:             config.Name,
 			ImageSha256:      config.ImageSha256,
 			ObjType:          objType,
+			State:            types.DOWNLOADING,
 			RefCount:         config.RefCount,
 			LastUse:          time.Now(),
 			AllowNonFreePort: config.AllowNonFreePort,
@@ -356,6 +357,7 @@ func handleCreate(ctx *downloaderContext, objType string,
 		status.ImageID = config.ImageID
 		status.DatastoreID = config.DatastoreID
 		status.ImageSha256 = config.ImageSha256
+		status.State = types.DOWNLOADING
 		status.RefCount = config.RefCount
 		status.LastUse = time.Now()
 		status.Expired = false

--- a/pkg/pillar/cmd/verifier/verifier.go
+++ b/pkg/pillar/cmd/verifier/verifier.go
@@ -812,7 +812,7 @@ func handleCreate(ctx *verifierContext, objType string,
 			ImageSha256: config.ImageSha256,
 		},
 		PendingAdd:  true,
-		State:       types.DOWNLOADED,
+		State:       types.VERIFYING,
 		RefCount:    config.RefCount,
 		IsContainer: config.IsContainer,
 	}

--- a/pkg/pillar/cmd/verifier/verifier.go
+++ b/pkg/pillar/cmd/verifier/verifier.go
@@ -289,7 +289,8 @@ func Run(ps *pubsub.PubSub) {
 	log.Infof("processed GlobalConfig")
 
 	// Publish status for any objects that were verified before reboot
-	// The signatures will be re-checked during handleModify for App images.
+	// The signatures and shas can re-checked during handleCreate
+	// by inserting code.
 	handleInit(&ctx)
 
 	// Report to volumemgr that init is done

--- a/pkg/pillar/cmd/volumemgr/handledownloader.go
+++ b/pkg/pillar/cmd/volumemgr/handledownloader.go
@@ -84,7 +84,12 @@ func MaybeRemoveDownloaderConfig(ctx *volumemgrContext, objType string, imageSha
 	m.RefCount -= 1
 	log.Infof("MaybeRemoveDownloaderConfig remaining RefCount %d for %s",
 		m.RefCount, imageSha)
-	publishDownloaderConfig(ctx, objType, m)
+	if m.RefCount == 0 {
+		unpublishDownloaderConfig(ctx, objType, m)
+	} else {
+		publishDownloaderConfig(ctx, objType, m)
+	}
+	log.Infof("MaybeRemoveDownloaderConfig done for %s", imageSha)
 }
 
 func publishDownloaderConfig(ctx *volumemgrContext, objType string,

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -204,8 +204,7 @@ func getRemainingAppDiskSpace(ctxPtr *zedmanagerContext) (uint64, string, error)
 		// XXX does this work for a container??
 		appDiskSize, diskSizeList, err := utils.GetDiskSizeForAppInstance(iterStatus)
 		if err != nil {
-			log.Errorf("getRemainingAppDiskSpace: err: %s", err.Error())
-			return 0, appDiskSizeList, err
+			log.Warnf("getRemainingAppDiskSpace: err: %s", err.Error())
 		}
 		totalAppDiskSize += appDiskSize
 		appDiskSizeList += fmt.Sprintf("App: %s (Size: %d)\n%s\n",

--- a/pkg/pillar/types/types.go
+++ b/pkg/pillar/types/types.go
@@ -51,11 +51,13 @@ func (state SwState) String() string {
 	case RESOLVED_TAG:
 		return "RESOLVED_TAG"
 	case DOWNLOADING:
-		return "DOWNLOAD_STARTED"
-	case DOWNLOADED, VERIFYING:
+		return "DOWNLOADING"
+	case DOWNLOADED:
 		return "DOWNLOADED"
+	case VERIFYING:
+		return "VERIFYING"
 	case VERIFIED:
-		return "DELIVERED"
+		return "VERIFIED"
 	case CREATING_VOLUME:
 		return "CREATING_VOLUME"
 	case CREATED_VOLUME:

--- a/pkg/pillar/types/verifiertypes.go
+++ b/pkg/pillar/types/verifiertypes.go
@@ -125,7 +125,7 @@ func (config PersistImageConfig) LogCreate() {
 		return
 	}
 	logObject.CloneAndAddField("refcount-int64", config.RefCount).
-		Infof("VerifyImage config create")
+		Infof("PersistImage config create")
 }
 
 // LogModify :
@@ -141,7 +141,7 @@ func (config PersistImageConfig) LogModify(old interface{}) {
 
 		logObject.CloneAndAddField("refcount-int64", config.RefCount).
 			AddField("old-refcount-int64", oldConfig.RefCount).
-			Infof("VerifyImage config modify")
+			Infof("PersistImage config modify")
 	}
 }
 


### PR DESCRIPTION
The only one with some possible behavioral implact is the DownloaderConfig one. Rest is cleanup around logs, and avoiding unnecessary error propagation by treating images files as taking zero diskspace.

The last commit (waiting for verifier) removes a potential race between volumemgr and verifier, but we haven't seen such races in real life. The log sequence looked odd which is how I saw the race.