### PR TITLE
Review Only: Guess image partition/version for log messages that do not comes with…

### DIFF
--- a/pkg/pillar/agentlog/agentlog.go
+++ b/pkg/pillar/agentlog/agentlog.go
@@ -58,6 +58,8 @@ type SourceHook struct {
 func (hook *SourceHook) Fire(entry *log.Entry) error {
 	entry.Data["source"] = savedAgentName
 	entry.Data["pid"] = savedPid
+	entry.Data["image"] = EveCurrentPartition()
+	entry.Data["eveVersion"] = EveVersion()
 	return nil
 }
 

--- a/pkg/pillar/agentlog/parsejson.go
+++ b/pkg/pillar/agentlog/parsejson.go
@@ -10,12 +10,14 @@ import (
 // Extend this structure with optional specific tags from
 // log.WithFields
 type Loginfo struct {
-	Level    string `json:"level"`
-	Time     string `json:"time"` // RFC3339 with Nanoseconds
-	Msg      string `json:"msg"`
-	Function string `json:"func"`
-	Filename string `json:"file"`
-	Source   string `json:"source"`
+	Level      string `json:"level"`
+	Time       string `json:"time"` // RFC3339 with Nanoseconds
+	Msg        string `json:"msg"`
+	Function   string `json:"func"`
+	Filename   string `json:"file"`
+	Source     string `json:"source"`
+	Image      string `json:"image"`
+	EveVersion string `json:"eveversion"`
 }
 
 // Returns loginfo, ok

--- a/pkg/rsyslog/rsyslog.conf
+++ b/pkg/rsyslog/rsyslog.conf
@@ -2,8 +2,6 @@
 # If you do not load inputs, nothing happens!
 # You may need to set the module load path if modules are not found.
 
-set $/IMGP = getenv("IMGP");
-
 module(load="imklog")
 module(load="imuxsock" SysSock.Name="/dev/log")
 module(load="imemlogd")
@@ -41,7 +39,6 @@ template(name="nonJsonOutput" type="list" option.jsonf="on") {
   property(outname="level" name="syslogpriority-text" format="jsonf")
   property(outname="msg" name="$!msg" format="jsonf")
   property(outname="pid" name="procid" format="jsonf" datatype="number" onEmpty="skip")
-  property(outname="partition" name="$/IMGP" format="jsonf")
 }
 
 action(type="mmutf8fix")


### PR DESCRIPTION
… them set.

With rsyslogd eve image version and partition are set after logs messages get de-queued from disk. This results in eve version/partition being set to current running version even for those logs that were generated with a older software. With this patch
1) We make EVE services send eve version/parition as part of json log objects.
2) If logmanager has a bundle of logs that do not have eve version set (non eve service logs), it would fill the running eve version for bundle.
3) If atleast one of the logs has version set, logmanager sets that software version on bundle.
4) If logmanager sees a change in eve version in logs, current bundle is exported and new bundle with then new version is started./

Signed-off-by: Gopi krishna Kodali <gkodali@zededa.com>