### PR TITLE
fix the ECSDA R & S packing issue

### DIFF
--- a/pkg/pillar/cmd/identitymgr/identitymgr.go
+++ b/pkg/pillar/cmd/identitymgr/identitymgr.go
@@ -29,6 +29,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/lf-edge/eve/pkg/pillar/zedcloud"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -414,8 +415,7 @@ func generateLispSignature(eid net.IP, iid uint32,
 	}
 	log.Debugf("r.bytes %d s.bytes %d", len(r.Bytes()),
 		len(s.Bytes()))
-	sigres := r.Bytes()
-	sigres = append(sigres, s.Bytes()...)
+	sigres := zedcloud.RSCombinedBytes(r.Bytes(), s.Bytes())
 	log.Debugf("sigres (len %d): % x", len(sigres), sigres)
 	return base64.StdEncoding.EncodeToString(sigres), nil
 }

--- a/pkg/pillar/cmd/identitymgr/identitymgr.go
+++ b/pkg/pillar/cmd/identitymgr/identitymgr.go
@@ -415,7 +415,10 @@ func generateLispSignature(eid net.IP, iid uint32,
 	}
 	log.Debugf("r.bytes %d s.bytes %d", len(r.Bytes()),
 		len(s.Bytes()))
-	sigres := zedcloud.RSCombinedBytes(r.Bytes(), s.Bytes())
+	sigres, err := zedcloud.RSCombinedBytes(r.Bytes(), s.Bytes(), &keypair.PublicKey)
+	if err != nil {
+		return "", err
+	}
 	log.Debugf("sigres (len %d): % x", len(sigres), sigres)
 	return base64.StdEncoding.EncodeToString(sigres), nil
 }

--- a/pkg/pillar/cmd/zedagent/handlelookupparam.go
+++ b/pkg/pillar/cmd/zedagent/handlelookupparam.go
@@ -186,7 +186,11 @@ func handleLookupParam(getconfigCtx *getconfigContext,
 		}
 		log.Debugf("r.bytes %d s.bytes %d", len(r.Bytes()),
 			len(s.Bytes()))
-		sigres := zedcloud.RSCombinedBytes(r.Bytes(), s.Bytes())
+		sigres, err := zedcloud.RSCombinedBytes(r.Bytes(), s.Bytes(), key.PublicKey.(*ecdsa.PublicKey))
+		if err != nil {
+			log.Errorf("handleLookupParam: error %v", err)
+			return
+		}
 		signature = base64.StdEncoding.EncodeToString(sigres)
 		log.Debugf("sigres (len %d): % x",
 			len(sigres), sigres)
@@ -198,7 +202,11 @@ func handleLookupParam(getconfigCtx *getconfigContext,
 		}
 		log.Debugf("r.bytes %d s.bytes %d", len(r.Bytes()),
 			len(s.Bytes()))
-		sigres := zedcloud.RSCombinedBytes(r.Bytes(), s.Bytes())
+		sigres, err := zedcloud.RSCombinedBytes(r.Bytes(), s.Bytes(), &key.PublicKey)
+		if err != nil {
+			log.Errorf("handleLookupParam: error %v", err)
+			return
+		}
 		signature = base64.StdEncoding.EncodeToString(sigres)
 		log.Debugf("sigres (len %d): % x",
 			len(sigres), sigres)

--- a/pkg/pillar/cmd/zedagent/handlelookupparam.go
+++ b/pkg/pillar/cmd/zedagent/handlelookupparam.go
@@ -186,8 +186,7 @@ func handleLookupParam(getconfigCtx *getconfigContext,
 		}
 		log.Debugf("r.bytes %d s.bytes %d", len(r.Bytes()),
 			len(s.Bytes()))
-		sigres := r.Bytes()
-		sigres = append(sigres, s.Bytes()...)
+		sigres := zedcloud.RSCombinedBytes(r.Bytes(), s.Bytes())
 		signature = base64.StdEncoding.EncodeToString(sigres)
 		log.Debugf("sigres (len %d): % x",
 			len(sigres), sigres)
@@ -199,8 +198,7 @@ func handleLookupParam(getconfigCtx *getconfigContext,
 		}
 		log.Debugf("r.bytes %d s.bytes %d", len(r.Bytes()),
 			len(s.Bytes()))
-		sigres := r.Bytes()
-		sigres = append(sigres, s.Bytes()...)
+		sigres := zedcloud.RSCombinedBytes(r.Bytes(), s.Bytes())
 		signature = base64.StdEncoding.EncodeToString(sigres)
 		log.Debugf("sigres (len %d): % x",
 			len(sigres), sigres)


### PR DESCRIPTION
Signed-off-by: Naiming Shen <naiming@zededa.com>
- have a bug where ecdsa sign generating R & S integers, we convert them into []byte and append them. unfortunately the size of the R & S converted into byte array is not always the same, occasionally it can be shorter. We would be ok if there is lengths associated with the API but we assume R & S in fixed length, which causes verify error whenever that shorter length is encountered.
- this patch uses the left padded to fixed size, 32bytes byte array, similar this this url: https://github.com/istio/old_vendor-istio_repo/blob/master/github.com/dgrijalva/jwt-go/ecdsa.go
- the zedcloud size uses the same code, and needs to be fixed too.