### PR TITLE
save EVE fatal, stdout, etc to files on persistent storage

### DIFF
--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -8,6 +8,7 @@ WATCHDOG_FILE=/run/watchdog/file
 CONFIGDIR=/config
 PERSISTDIR=/persist
 PERSIST_CERTS=$PERSISTDIR/certs
+PERSIST_AGENT_DEBUG=$PERSISTDIR/agentdebug
 BINDIR=/opt/zededa/bin
 TMPDIR=/persist/tmp
 ZTMPDIR=/var/tmp/zededa
@@ -68,7 +69,7 @@ if ! mount -o remount,flush,dirsync,noatime $CONFIGDIR; then
     echo "$(date -Ins -u) Remount $CONFIGDIR failed"
 fi
 
-DIRS="$CONFIGDIR $ZTMPDIR $CONFIGDIR/DevicePortConfig $PERSIST_CERTS"
+DIRS="$CONFIGDIR $ZTMPDIR $CONFIGDIR/DevicePortConfig $PERSIST_CERTS $PERSIST_AGENT_DEBUG"
 
 for d in $DIRS; do
     d1=$(dirname "$d")

--- a/pkg/pillar/types/locationconsts.go
+++ b/pkg/pillar/types/locationconsts.go
@@ -21,6 +21,8 @@ const (
 	RWImgDirname = PersistDir + "/img"
 	// ROContImgDirname - Location of read only images used by containerd
 	ROContImgDirname = PersistDir + "/runx/pods/prepared"
+	// PersistDebugDir - Location for service specific debug/traces
+	PersistDebugDir = PersistDir + "/agentdebug"
 	// AppImgDirname - location of downloaded app images. Read-only images
 	// named based on sha256 hash each in its own directory
 	AppImgDirname = DownloadDirname + "/" + AppImgObj


### PR DESCRIPTION
1) Create a per agent debug directory in /persist/agentdebug/ with agentname as the name of directory.
2) Apart from forwarding to cloud, Redirect stdout, sigusr1, sigusr2, fatal stack, fatal reason into seperate files in the above created directory. Latest content should overwrite the old contents in these files. 

Unexpected service crashes will still go to cloud as logs.

Signed-off-by: Gopi krishna Kodali <gkodali@zededa.com>