### PR TITLE
Avoiding volume creation for base images in volumemgr

### DIFF
--- a/pkg/pillar/cmd/baseosmgr/handlebaseos.go
+++ b/pkg/pillar/cmd/baseosmgr/handlebaseos.go
@@ -492,7 +492,7 @@ func checkBaseOsVolumeStatus(ctx *baseOsMgrContext, baseOsUUID uuid.UUID,
 		return ret.Changed, false
 	}
 
-	if ret.MinState < types.CREATED_VOLUME {
+	if ret.MinState < types.VERIFIED {
 		log.Infof("checkBaseOsVolumeStatus(%s) for %s, Waiting for volumemgr",
 			config.BaseOsVersion, uuidStr)
 		return ret.Changed, false

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -77,6 +77,10 @@ func doUpdate(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool) {
 			return changed, false
 		}
 	}
+	if status.State == types.VERIFIED && status.ObjType == types.BaseOsObj {
+		// For base images, we don't need to create volumes
+		return changed, true
+	}
 	if status.State == types.VERIFIED && !status.VolumeCreated {
 		status.State = types.CREATING_VOLUME
 		changed = true


### PR DESCRIPTION
With these changes, we are avoiding to create volumes for base images. In the latest master, qcow2 images are getting accumulated in ```persist/img``` for base images which never get cleaned up.