### PR TITLE
Make rsyslogd spend less time with disk operations. Sync logs to disk…

### DIFF
--- a/pkg/rsyslog/rsyslog.conf
+++ b/pkg/rsyslog/rsyslog.conf
@@ -29,7 +29,7 @@ main_queue(
   queue.fileName="main_edge_node_log_queue"
   queue.maxDiskSpace="2g"
   queue.discardSeverity="7"
-  queue.checkpointinterval="1"
+  queue.checkpointinterval="10"
   queue.syncqueuefiles="on"
   queue.saveOnShutdown="on"
   queue.maxFileSize="100m"
@@ -40,7 +40,7 @@ template(name="nonJsonOutput" type="list" option.jsonf="on") {
   property(outname="time" name="timereported" dateFormat="rfc3339" format="jsonf")
   property(outname="level" name="syslogpriority-text" format="jsonf")
   property(outname="msg" name="$!msg" format="jsonf")
-  property(outname="pid" name="procid" format="jsonf" datatype="number" onEmpty="skip")
+  property(outname="pid" name="procid" format="jsonf" datatype="number" onEmpty="skip" regex.expression="^[0-9]*$" regex.nomatchmode="ZERO")
   property(outname="partition" name="$/IMGP" format="jsonf")
 }
 


### PR DESCRIPTION
… once per 10 log messages.

Signed-off-by: Gopi krishna Kodali <gkodali@zededa.com>