### PR TITLE
Getting qemu-system-i386 back on ARM64

### DIFF
--- a/pkg/xen-tools/Dockerfile.in
+++ b/pkg/xen-tools/Dockerfile.in
@@ -60,6 +60,10 @@ RUN dist/install.sh /out
 
 # Filter out a few things that we don't currently need
 RUN rm -rf /out/usr/share/qemu-xen/qemu/edk2-* /out/var/run
+# FIXME: this is a workaround for Xen on ARM still requiring qemu-system-i386
+#   https://wiki.xenproject.org/wiki/Xen_ARM_with_Virtualization_Extensions#Use_of_qemu-system-i386_on_ARM
+WORKDIR /out/usr/lib/xen/bin/
+RUN if [ "$(uname -m)" = "aarch64" ]; then strip qemu-system-*; else rm -f qemu-system-i386 && ln -s "qemu-system-$(uname -m)" qemu-system-i386 ;fi
 
 # this tiny C code is there to replace a perl dependency
 COPY rightfile.c /tmp
@@ -82,9 +86,6 @@ COPY --from=uefi-build /OVMF_PVH.fd /usr/lib/xen/boot/ovmf-pvh.bin
 COPY --from=runx-build /runx-initrd /usr/lib/xen/boot/runx-initrd
 COPY init.sh /
 COPY qemu-ifup /etc/xen/scripts/qemu-ifup
-
-# FIXME: maybe we need to tweak configure
-RUN ln -s "qemu-system-$(uname -m)" /usr/lib/xen/bin/qemu-system-i386
 
 # We need to keep a slim profile, which means removing things we don't need
 RUN rm -rf /usr/lib/libxen*.a /usr/lib/libxl*.a /usr/lib/debug /usr/lib/python2.7

--- a/pkg/xen-tools/init.sh
+++ b/pkg/xen-tools/init.sh
@@ -18,12 +18,7 @@ if [ -d /proc/xen/ ]; then
    # Finally, we need to start Xen
    # In case it hangs and we have no hardware watchdog we run it in the background
    mkdir -p /var/run/xen/ /var/run/xenstored
-   # FIXME: this is a workaround for Xen on ARM still requiring qemu-system-i386
-   #   https://wiki.xenproject.org/wiki/Xen_ARM_with_Virtualization_Extensions#Use_of_qemu-system-i386_on_ARM
-   if [ "$(uname -m)" = aarch64 ]; then
-      export QEMU_XEN=/bin/true
-      echo 1 > /var/run/xen/qemu-dom0.pid
-   fi
+
    XENCONSOLED_ARGS='--log=all --log-dir=/var/log/xen' /etc/init.d/xencommons start
 
    # Now start the watchdog

--- a/pkg/xen-tools/patches-4.13.0/09-enable-kvm.patch
+++ b/pkg/xen-tools/patches-4.13.0/09-enable-kvm.patch
@@ -5,7 +5,7 @@
  	fi ; \
  	PKG_CONFIG_PATH=$(XEN_ROOT)/tools/pkg-config$${PKG_CONFIG_PATH:+:$${PKG_CONFIG_PATH}} \
 -	$$source/configure --enable-xen --target-list=i386-softmmu \
-+	$$source/configure --enable-xen --target-list=$$(uname -m)-softmmu \
++	$$source/configure --enable-xen --target-list=i386-softmmu,$$(uname -m)-softmmu \
  		$(QEMU_XEN_ENABLE_DEBUG) \
  		$$enable_trace_backend \
  		--prefix=$(LIBEXEC) \


### PR DESCRIPTION
Since it appeared there's no cheap way to retrofit qemu-system-aarch64 to do the job of  qemu-system-i386 on ARM (yes, Karl, on ARM!) we're bringing it back. The only way to still fit into our budget of 250Mb of rootfs is to strip both binaries -- but since we're stripping everything else on ARM as well it feels like a reasonable tradeoff.