### PR TITLE
document nim behavior and timers

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -19,7 +19,7 @@
 | timer.port.testduration | integer in seconds | 30 | wait for DHCP to give address |
 | timer.port.testinterval | timer in seconds | 300 | retest the current port config |
 | timer.port.timeout | timer in seconds | 15 | time for each http/send |
-| timer.port.testbetterinterval | timer in seconds | 0 (disabled) | test a higher prio port config |
+| timer.port.testbetterinterval | timer in seconds | 600 | test a higher prio port config |
 | network.fallback.any.eth | "enabled" or "disabled" | enabled | if no connectivity try any Ethernet, WiFi, or LTE |
 | network.allow.wwan.app.download | "enabled" or "disabled" | disabled | allow app image download over non-free ports like LTE |
 | network.allow.wwan.baseos.download | "enabled" or "disabled" | enabled | allow baseos image download over non-free ports like LTE |

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -176,21 +176,15 @@ zcli edge-node create.
 
 ### Adding configuration to the install image
 
-It is possible to provide an initial DevicePortConfig and/or GlobalConfig
-during the build of the installation medium.
+It is possible to provide an initial DevicePortConfig during the build of the installation medium.
 
-The former can be used to specify proxies and static IP configuration for
+It can be used to specify proxies and static IP configuration for
 the ports, if that is necessary to have the device connect to the controller.
 But a DevicePortConfig can also be added to a USB stick in which case it
 will be copied from the USB stick on boot. See [tools/makeusbconf.sh](../tools/makeusbconf.sh)
 
-The latter can be used to specify the initial timers and ssh/usb behavior
-which will be in place until the device connects to the controller and gets its
-configuration from there. The variables are documented in
-[runtime configuration properties](CONFIG-PROPERTIES.md)
-
-To add either during the build, in EVE's conf directory create a
-subdirectory called DevicePortConfig or GlobalConfig, respectively.
+To add it during the build, in EVE's conf directory create a
+subdirectory called DevicePortConfig.
 Then add the valid json file named as global.json in that directory.
 Finally:
 make config.img; make installer.raw

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -25,34 +25,12 @@ We plan to completely transition to this way of configuring all aspects of EVE i
 
 ## Controlling EVE behavior at boot via legacy configuration management
 
-When the device boots it determines the set of network interfaces.
-By default this is determined by extracting the manufacturer and model
-strings from dmidecode; /opt/zededa/bin/hardwaremodel does this determination.
+When the device boots the first time it determines the set of potentially usable network interfaces to use to reach the controller, as specified in [DEVICE-CONNECTIVITY last resort](DEVICE-CONNECTIVITY.md).
 
-That model string is used to look up a json file in /var/tmp/zededa/DeviceNetworkConfig/
-If no such json file is found the device uses /var/tmp/zededa/DeviceNetworkConfig/default.json
-
-Those files merely specify the set of management ports, plus which of them
-do not have per usage charging (to separate out e.g., LTE modems).
-
-The default.json is:
-
-```json
-{
-    "Uplink":["eth0","wlan0","wwan0"],
-    "FreeUplinks":["eth0","wlan0"]
-}
-```
-
-Note that the above file uses the old "uplink" terminology; new terminology for
-this concept is "management port".
-
-This per-model comfiguration can be overridden by an optional file in
+That default configuration can be overridden by an optional file in
 /config which is added when the image is built/installed.
 That file is /config/DevicePortConfig/override.json
-[Note that this file does not override cloud configuration. TBD: should we rename
-it to local.json instead?]
-And futher overridden by a USB memory stick plugged in when the device is powered
+And futher it can be overridden by a USB memory stick plugged in when the device is powered
 on. The [tools/makeusbconf.sh](../tools/makeusbconf.sh) can be used to create a
 USB stick with a json file specifying the device connectivity based on the
 examples below.
@@ -62,10 +40,11 @@ systemAdapter part of the API. The most recent information DevicePortConfig
 becomes the highest priority, but the device tests that it works before using it
 (and falls back to a lower-priority working config.)
 
-That build/USB file can specify multiple management interfaces, as well as
+More specifics in how this is handled are in [DEVICE-CONNECTIVITY](DEVICE-CONNECTIVITY.md).
+
+The above build/USB file can specify multiple management interfaces, as well as
 non-mananagement interface, and can specify static IP and DNS configuration
-(for environments where DHCP is not used). In addition it can specify proxies
-using several different mechanism.
+(for environments where DHCP is not used), plus WiFi and cellular modem specifics. In addition it can specify proxies using several different mechanism.
 
 ### Example DevicePortConfig
 

--- a/docs/DEVICE-CONNECTIVITY.md
+++ b/docs/DEVICE-CONNECTIVITY.md
@@ -1,10 +1,10 @@
 # Device Connectivity
 
-EVE needs to always be able to connect to the controller, yet the configuration of the ports might be both complex and changing over time.
+EVE needs to always be able to connect to the controller, yet the configuration of the network ports might be both complex and changing over time.
 
-In addition some ports might be designated to application usage, or the underlying I/O bus controllers (e.g., PCI controllers) be designated for assignment to applications. That part of the configuration can also change.
+In addition some network ports might be designated to application usage, or the underlying I/O bus controllers (e.g., PCI controllers) be designated for assignment to applications. That part of the configuration can also change.
 
-Such configuration changes can not turn the device into a brick; it needs to have a way to fall back to a working port configuration which works well enough to connect to the controller (and as part of that be able to receive more configuration changes.)
+Any network port configuration changes which might affect the connectivity to the controller requires care to avoid permanently loosing connectivity to the controller and become unmanageable as a result. Thus it is required to perform testing as part of a configuration change and have a way to fall back to a working port configuration.
 
 This is accomplished by logic to test connectivity to the controller (implemented in the Network Interface Manager [nim](../pkg/pillar/cmd/nim) with help from the [devicenetwork](../pkg/pillar/devicenetwork) package, and maintaining a list of current working and fallback configuration in ```/persist/status/nim/DevicePortConfigList/global.json```
 
@@ -12,21 +12,25 @@ This is accomplished by logic to test connectivity to the controller (implemente
 
 There are several sources from which nim gets the potential port configurations. Those all use the ```DevicePortConfig``` type. There are examples of such configurations in [legacy EVE configuration](CONFIG.md)
 
-### Hardware-model based baseline
+### Fresh install
 
-The device currently has one configuration derived from the hardware model, in the form a file in ```/var/tmp/zededa/DeviceNetworkConfig```.
+When EVE is installed on a device it only has the last-resort configuration specified below. This is sufficient to connect to the controller if
 
-Note that the output ```/opt/bin/zededa/hardwaremodel``` provides the model string which is used to find the name of that file.
+- DHCP is enabled on one of the Ethernet ports
+- WiFi is not assumed (since WiFi needs credentials)
+- If cellular connectivity is assumed, the default APN will work to connect to the network
+- No enterprise proxy configuration is required to be able to connect to the controller.
 
-Those files just describe the set of ports (so that we can specify that wwan0 is a choice, or to use eth3 instead of eh0) and is likely to be replaced with an approach instantiated from the controller instead of having json files in the EVE image.
-
-Those input files are used to construct a file with the same information but using the ```DevicePortConfig``` type in ```/var/run/nim/DevicePortConfig```
+If any of those cases apply, then a USB stick is needed to specify the initial port configuration so that the device can connect to the controller.
 
 ### Override the configuration using a USB stick
 
-If the deployment site requires use of http enterprise proxies and/or static IP configuration, then a file containing a DevicePortConfig can be placed on a USB stick. Note that this requires that the USB controller is enabled using debug.enable.usb as specified in [configuration properties](CONFIG-PROPERTIES.md)
+If the deployment site requires use of HTTP enterprise proxies and/or static IP configuration, then a file containing a DevicePortConfig can be placed on a USB stick prior to booting the device. Note that this requires that the USB controller is enabled using debug.enable.usb as specified in [configuration properties](CONFIG-PROPERTIES.md)
 
 There are examples of such configurations in [legacy EVE configuration](CONFIG.md)
+
+Such a file will be used by nim until it can connect to the controller and receive the configuration (either the same, or subsequent updates). Thus for a new device using enterprise proxies and/or static IP it is imperative that the configuration first be set in the controller, then a USB stick be created with that configuration, and the device booted with that USB stick in place.
+That ensures that the configuration doesn't revert back once the device has connected to the controller.
 
 ### From the controller
 
@@ -34,18 +38,71 @@ The systemAdapter in the API specifies the intended port configuration.
 This is fed into the logic in nim by [zedagent](../pkg/pillar/cmd/zedagent) publishing a ```DevicePortConfig``` item.
 
 The API for this is [SystemAdapter](../api/proto/config/devmodel.proto).
-
-Note that the device reports the status of all of the device connectivity using [SystemAdapterInfo](../api/proto/info/info.proto).
+At least one port must be set to be a management port, and that port needs to refer to a network with IP configuration for the device to even try to use the SystemAdapter configuration.
 
 ### Last resort
 
-If the network.fallback.any.eth config is set to true as specified in [configuration properties](CONFIG-PROPERTIES.md), then there an additional lowest priority item in the list of DevicePortConfigs, based on finding all of the Ethernet and Ethernet-like interfaces (an example of the latter is WiFi) which are not used exclusively by applications.
+Unless the network.fallback.any.eth configuration item is set to false (as specified in [configuration properties](CONFIG-PROPERTIES.md)), then there is an additional lowest priority item in the list of DevicePortConfigs, based on finding all of the Ethernet and Ethernet-like interfaces (an example of the latter is WiFi and cellular modems) which are not used exclusively by applications. The last resort configuration assumes DHCP and no enterprise proxies.
+
+Note that if static IP and/or enterprise proxies are used it is useful to set network.fallback.any.eth to false to avoid having the device try DHCP without proxies when there is some network outage.
 
 ## Prioritizing the list
 
 The nim retains the currently working configuration, plus the following in priority order in ```/persist/status/nim/DevicePortConfigList```:
-* The most recently received configuration from the controller
-* The known working configuration from the controller
-* An override file from a USB stick (if any)
-* The hardware-model derived config
-* The last resort if so enabled
+
+1. The most recently received configuration from the controller
+1. The last known working configuration from the controller
+1. An override file from a USB stick (if any)
+1. The last resort if so enabled
+
+Once the most recent configuration received from the controller has been tested and found to be usable, then all but the (optional) last resort configuration are pruned from the above list.
+When a new configuration is received from the controller it will keep the old configuration from the controller as a fallback.
+
+## Testing
+
+The Network Interface Manager performs two types of testing
+
+- Validate that a new configuration is working before replacing the current configuration
+- Periodically check that the existing configuration is working
+
+### Testing a new configuration from the controller
+
+The testing is triggered by receiving a new configuration from the controller and completes when at least one of the management ports can be used to reach the controller. If there are multiple management ports in the configuration, there might be an error reported for ports which are not working (depending on the order in which the ports are tried).
+
+[TBD Should we verify that the new configuration is usable for some minimum time e.g., 10 minutes before discarding the previous/fallback configuration?]
+
+If no management port can be used to reach the controller, then nim switches to using the next configuration in the DevicePortConfigList, which is normally the previously used configuration.
+In that case a failure is reported in the [SystemAdapterInfo](../api/proto/info/info.proto) by setting lastError in DevicePortStatus and the currentIndex is set to the currently used DevicePortStatus in the list. Note that lastFailed and lastSucceeded can be used to see if a configuration has succeeded in the past or always failed.
+
+### Periodic testing
+
+The default timer for this is 5 minutes and can be set with [timer.port.testinterval](CONFIG-PROPERTIES.md). At those intervals the device verifies that it can still reach the controller using one of the management ports.
+
+Each attempt it starts with a different management port, which ensures that all management ports are tested for connectivity. Any management port which sees a failure gets an error in the [SystemAdapterInfo](../api/proto/info/info.proto) in the ErrorInfo for the particular DevicePort.
+
+Note that if a port was tested and succeeded the ErrorInfo.timestamp is updated and the ErrorInfo.description is empty; this indicates the most recent successful test.
+
+If after two attempts (spaced the above 5 minute timer apart) the device can not connect to the controller on any of the management ports in the current configuration, then it will try the fallback configuration (and if that succeeds the fact that it is using a fallback is reported with a zero currentIndex as above).
+
+### Trying a better configuration
+
+If for some reason the most recent (aka highest priority) configuration is not used (and currentIndex is reported as non-zero per above), the device will re-try the highest priority configuration.
+The default timer for this is 10 minutes and can be set with [timer.port.testbetterinterval](CONFIG-PROPERTIES.md). That timer can be set to zero to disable this re-try.
+
+If the re-try succeeds then SystemAdapterInfo is updated with the previously reported error cleared. The fact that it has failed in the past can be seen from the reported lastFailed timestamp in SystemAdapterInfo being non-zero.
+
+### Handling remote (temporary) failures
+
+There is a set of failures which can be attributed to the controller having issues which does not warrant any churn or fallback on the device. The current cases are:
+
+- the server certificate having expired (or not yet being valid)
+- the server responding with a TCP Reset/Connection refused (and proxy is not in the path)
+
+In those cases nim proceeds with the current configuration and assumes that the server will at some point in time be corrected.
+
+## Failure reporting
+
+The device reports the status of all of the device connectivity using [SystemAdapterInfo](../api/proto/info/info.proto). There are two levels of errors:
+
+- A new SystemAdapter configuration was tested, but none of the management ports could be used to connect to the controller. In that case a failure is reported by setting lastError in DevicePortStatus and the currentIndex is set to the currently used DevicePortStatus in the list. Note that lastFailed and lastSucceeded can be used to see if a configuration has succeeded in the past or always failed.
+- A particular management port could not be used to reach the controller. In that case the ErrorInfo for the particular DevicePort is set to indicate the error and timestamp.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -11,9 +11,7 @@ zcli edge-node update myqemu --config="debug.enable.ssh:`cat .ssh/id_rsa.pub`"
 
 ## 2. Legacy method for out-of-band configuration delivery
 
-It is possible to provide an initial DevicePortConfig and/or GlobalConfig during
-the build. Read up on legacy EVE [configuration management](CONFIG.md) for more
-details on how these are structured.
+It is possible to provide an initial DevicePortConfig during the build. Read up on [legacy EVE configuration management](CONFIG.md) for more details on how it is structured.
 
 The DevicePortConfig can be statically put into EVE's configuration partition under */config/DevicePortConfig/global.json*
 to specify proxies and static IPs for the ports. This could be required
@@ -23,17 +21,7 @@ be copied from the USB stick during boot and used.  See [tools/makeusbconf.sh](.
 for details. The format of the DevicePortConfig/global.json is specified with
 examples in [legacy EVE configuration management](CONFIG.md)
 
-The GlobalConfig can be used to specify the initial timers and ssh/usb behavior
-which will be in place until the device connects to the controller and gets its
-configuration from there. All of that is specified using [Runtime Configuration
-Properties](CONFIG-PROPERTIES.md) in a json file included in */config/GlobalConfig/global.json*.
-The format of that file is the natural json encoding of GlobalConfig as specified
-in [types/global.go](../pkg/pillar/types/global.go). The variables are documented
-in [configuration properties table](CONFIG-PROPERTIES.md)
-
-To add either during the build, in EVE's conf directory create a
-subdirectory called DevicePortConfig or GlobalConfig, respectively.
-Then add the valid json file named as global.json in that directory.
+To add it during the build, in EVE's conf directory create a subdirectory called DevicePortConfig. Then add the valid json file named as global.json in that directory.
 Finally:
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -192,8 +192,7 @@ implementation would simply be able to consume exactly the same protobuf encoded
 binary blob that it receives from the Controller, currently we still have to
 rely on an ad-hoc collection of configuration files that serve the same purpose.
 We expect these configuration files to go away relatively quickly, but for now
-EVE is still stuck with at least *DevicePortConfig/global.json* and
-*GlobalConfig/global.json* and they are documented in [legacy configuration](CONFIG.md).
+EVE is still stuck with at least *DevicePortConfig/global.json* and it is documented in [legacy configuration](CONFIG.md).
 See [the following FAQ entry](FAQ.md) for how to manage both of these
 legacy files.
 
@@ -225,11 +224,6 @@ always start with debug.*microservice*.
 
 You can find a complete list of generic and microservices specific configuration
 properties in [configuration properties table](CONFIG-PROPERTIES.md).
-
-It goes without saying that runtime configuration properties can also be
-delivered out-of-band just like any other part of the EVE's configuration
-object. While in transition from legacy configuration files, you will have
-to use [GlobalConfig/global.json](FAQ.md) to make them available to EVE.
 
 ## Installing EVE on Edge Nodes
 

--- a/pkg/pillar/docs/domainmgr.md
+++ b/pkg/pillar/docs/domainmgr.md
@@ -11,19 +11,20 @@ Domainmgr is the interface to the hypervisor to start DomU instances:
 
 ## Key Input/Output
 
-Domain Manager interacts with the Cloud controller (e.g. zedcloud) indirectly using three key messages:
+Domain Manager interacts with the Cloud controller (e.g. zedcloud) indirectly using four key messages:
 - DomainConfig from controller is fed to domainmgr. This contains the configuration information about a DomU instance. DomainConfig is defined in `pillar/types/domainmgrtypes.go`
 - DomainStatus is fed from `domainmgr` to controller. This contains the operational information about a DomU instance. DomainStatus is defined in `pillar/types/domainmgrtypes.go`
 - DomainMetric with CPU and memory metrics for the host (dom0) and the applications
+- PhysicalIOAdapterList specifes the set of physical I/O adapters which can potentially be used for adapter assignment.
 
-zedmanager publishes DomainConfig and subscribes to DomainStatus, while zedagent subscribes to DomainMetric.
+zedmanager publishes DomainConfig and subscribes to DomainStatus, while zedagent publishes PhysicalIOAdapterList and subscribes to DomainMetric.
 
 ## PCI Device Management
 
 - XEN uses a PCI backend driver called pciback, to provide PCI passthrough to DomU instances. For more details, see <https://wiki.xen.org/wiki/Xen_PCI_Passthrough>
 - Domain Manager assigns PCI devices that are not in use in Dom0 to pciback driver for use in DomU instances, i.e. all PCI networking devices are assigned to pciback unless they are a port in DeviceNetworkStatus (from `pillar/cmd/nim`), and all USB controllers are assigned to pciback unless debug.enable.usb is set to true in Dom0 configuration.
 - Note that the assigning away doesn’t happen until domainmgr starts. domainmgr starts once the device has been successfully onboarded in the Cloud controller.
-- Since each hardware model can have different set of network or USB adapters, for every hardware model, there is JSON file which lists the adapters that are available for assignment to pciback on that device model. One can find these files under `/var/tmp/zededa/AssignableAdapters/` directory on the device.
+- Since each hardware model can have different set of network or USB adapters, for every hardware model, the controller provides a [PhysicalIO](../../api/proto/config/devmodel.proto) in the API which zedagent publishes as `PhysicalIOAdapterList`.
 
 ## Internal Operation
 

--- a/pkg/pillar/docs/volumemgr.md
+++ b/pkg/pillar/docs/volumemgr.md
@@ -48,7 +48,6 @@ Both VolumeStatus and VolumeConfig use the agentScope mechanism to keep the base
 
 Volume Manager in turn requests work from downloader and verifier. This consists of a set of objects (all using the agentScope mechanism):
 
-- PersistImageConfig is published by verifier for the verified images, including those found on disk after a device reboot.
 - PersistImageStatus is published by volumemgr to track reference counts on the verified images, including a handshake when the verifier wishes to garbage collection unused images.
 - DownloaderConfig is published by volumemgr and subscribed to by downloader. This specifies the desire to find a downloaded blob for a particular object.
 - DownloaderStatus is publishes by downloader to capture progress, errors, and completion of downloading blobs.
@@ -80,9 +79,7 @@ When volumemgr starts it finds existing volumes on disk and publishes those (for
 
 When volumemgr gets a request for a volume, it first looks whether it matches an existing volume. That might exist in the above "unknown" agentScope collection, in which case it is promoted to the agentScope for the particular requester. In this case its work is complete.
 
-Otherwise (for the `OriginTypeDownload`), volumemgr looks for any existing already verified blob in `VerifyImageStatus` and
-`PersistImageStatus`. If one is found, it ensures that there is a corresponding `VerifyImageConfig` and `PersistImageConfig`
-to retain a reference count on the verified image.
+Otherwise (for the `OriginTypeDownload`), the volumemgr looks for any existing already verified blob in `VerifyImageStatus` and `PersistImageStatus`. If one is found, it ensures that there is a corresponding `VerifyImageConfig` and/or `PersistImageStatus` to retain a reference count on the verified image.
 
 Once there is a `VerifyImageStatus` indicating a successful verification, it is used to construct the volume.
 
@@ -137,7 +134,7 @@ For a container this uses containerd to prepare the container for use.
 
 ### Destroying volumes
 
-When zedmanager or baseosmgr deletes a VolumeConfig, then volumemgr will destroy the volume (and delete the VolumeStatus). This includes dropping any reference counts it has on a DownloaderConfig, VerifyImageConfig, and/or PersistImageConfig. Finally any Read/Write volume is deleted.
+When zedmanager or baseosmgr deletes a VolumeConfig, then volumemgr will destroy the volume (and delete the VolumeStatus). This includes dropping any reference counts it has on a DownloaderConfig, VerifyImageConfig, and/or PersistImageStatus. Finally any Read/Write volume is deleted.
 
 ### Garbage collection
 


### PR DESCRIPTION
Including the fact that documentation wasn't updated when the default for timer.port.testbetterinterval was changed.

The three bonus commits are about removing/rewriting the documentations references to things which have been changed/removed.