### PR TITLE
Add App container config & metric API items

### DIFF
--- a/api/proto/config/appconfig.proto
+++ b/api/proto/config/appconfig.proto
@@ -86,4 +86,13 @@ message AppInstanceConfig {
   // container in the order they are listed, e.g., the first VM image
   // will be the root disk.
   repeated string volumeRefs = 14;
+
+  // The static IP address assigned on the NetworkAdapter which App Container
+  // stats collection uses. If the 'collectStatsIPAddr' is not empty and valid,
+  // it enables the container stats collection for this App.
+  // During App instance creation, after user enables the collection of stats
+  // from App, cloud needs to make sure at least one 'Local' type of Network-Instance
+  // is assigned to the App interface, and based on the subnet of the NI, statically
+  // assign an IP address on the same subnet, e.g. 10.1.0.100
+  string collectStatsIPAddr = 15;
 }

--- a/api/proto/metrics/metrics.proto
+++ b/api/proto/metrics/metrics.proto
@@ -75,7 +75,8 @@ message appCpuMetric {
   // deprecated = 2;
   // deprecated = 3;
   google.protobuf.Timestamp upTime = 4;
-  uint64 total = 5;                   // cpu total in secs.
+  uint64 total = 5;                   // cpu total in secs. In docker stats, it's the container user usage
+  uint64 systemTotal = 6;             // docker host system cpu total in secs. inc user, system and idle
 }
 
 message deviceMetric {
@@ -91,6 +92,16 @@ message deviceMetric {
   uint64 appRunTimeStorageMB = 10;         // In MB
   memoryMetric systemServicesMemoryMB = 11;  // In MB
   logMetric log = 12;
+}
+
+message appContainerMetric {
+  string appContainerName = 1; // the unique key for the container in a VM or IoT Edge
+  string status = 2;           // Status string e.g. Uptime 3 hours
+  uint32 PIDs = 3;             // Number of PIDs inside the container
+  appCpuMetric cpu = 4;        // container cpu usage
+  memoryMetric memory = 5;     // container memory usage, will fill 'usedMem', 'availMem' initially
+  networkMetric network = 6;   // container network usage, will fill 'txBytes', 'rxBytes' initially
+  diskMetric disk = 7;         // container Block IO, will fill 'readBytes', 'writeBytes' initially
 }
 
 enum MetricItemType {
@@ -143,6 +154,7 @@ message appMetric {
   memoryMetric memory = 4;
   repeated networkMetric network = 5;
   repeated appDiskMetric disk = 6;
+  repeated appContainerMetric container = 7;
 }
 
 // We track device and app logs separately with these counters.


### PR DESCRIPTION
Signed-off-by: Naiming Shen <naiming@zededa.com>
- due to massive conflict of protobuf vendor apis, move the previous PR #1031 to this
- Add protobuf api for configure of App Azure IoT Edge stats collect
- Add protobuf api for container stats collection
