### PR TITLE
proto changes for object encryption interface between zedcloud and eve

### DIFF
--- a/api/proto/attest/attest.proto
+++ b/api/proto/attest/attest.proto
@@ -13,7 +13,9 @@ option java_package = "org.lfedge.eve.attest";
 message ZAttestReq {
   ZAttestReqType reqType = 1;  //type of the request
   ZAttestQuote quote = 2;      //attestation quote msg
+  // to be depcrecated
   repeated ZEveCert certs = 3; //X509 certs in .PEM format, signed by device certificate
+  repeated org.lfedge.eve.common.ZCert node_certs = 4; // eve node generated certificate
 }
 
 // This is the response payload for POST /api/v2/edgeDevice/id/<uuid>/attest
@@ -58,14 +60,17 @@ message ZAttestQuoteResp {
   ZAttestResponseCode response = 1; //result of quote validation
 }
 
+// to be depcrecated, moved to evecommon
 message ZEveCert {
   org.lfedge.eve.common.HashAlgorithm hashAlgo = 1; //hash method used to arrive at certHash
   bytes certHash = 2;            //Hash of the cert, computed using hashAlgo
   ZEveCertType type = 3;         //what kind of certificate(to identify the target use case)
   bytes cert = 4;                //X509 cert in .PEM format
+
   ZEveCertAttr attributes = 5;   //properties of this certificate
 }
 
+// to be depcrecated, moved to evecommon
 enum ZEveCertType {
   CERT_TYPE_DEVICE_NONE = 0;
   CERT_TYPE_DEVICE_ONBOARDING = 1;         //set for certificate used by edge node for identifying the device
@@ -74,6 +79,7 @@ enum ZEveCertType {
   CERT_TYPE_DEVICE_ECDH_EXCHANGE = 4;      //set for certificate used by edge node to share symmetric key using ECDH
 }
 
+// to be depcrecated, moved to evecommon
 message ZEveCertAttr {
   bool isMutable = 1; //set to false for immutable certificates
 }

--- a/api/proto/certs/certs.proto
+++ b/api/proto/certs/certs.proto
@@ -13,9 +13,12 @@ option java_package = "org.lfedge.eve.certs";
 // ZControllerCert carries a set of X.509 certificate and their properties
 // from Controller to EVE.
 message ZControllerCert {
+  // deprecated, to be inherited from eveommon
   repeated ZCert certs = 1;  //list of certificates sent by controller
+  repeated org.lfedge.eve.common.ZCert ccerts = 2; //controller certificated
 }
 
+// to be deprecated, moved to evecommon
 message ZCert {
   org.lfedge.eve.common.HashAlgorithm hashAlgo = 1; //hash method used to arrive at certHash
   bytes certHash = 2;             //truncated hash of the cert, according to hashing scheme in hashAlgo
@@ -23,6 +26,7 @@ message ZCert {
   bytes cert = 4;                 //X509 cert in .PEM format
 }
 
+// to be deprecated, moved to evecommon
 enum ZCertType {
   CERT_TYPE_CONTROLLER_NONE = 0;
   CERT_TYPE_CONTROLLER_SIGNING = 1;        //set for the leaf certificate used by controller to sign payload envelopes

--- a/api/proto/config/devconfig.proto
+++ b/api/proto/config/devconfig.proto
@@ -68,6 +68,14 @@ message EdgeDevConfig {
   // Application instances will refer to the volumes.
   repeated ContentTree contentInfo = 20;
   repeated Volume volumes = 21;
+
+  // each sha256 field is 256 bytes long hex string,
+  // they are controller and eve node certficate list configuration sum sha256 value.
+  // sha256 is computed for the each type of configuration; e.g., controller,
+  // eve node cerfificate list sum
+  // eve node certificate sha256 is for ECDH certificates only
+  string controllercert_confighash = 22;
+  string nodecert_confighash = 23;
 }
 
 message ConfigRequest {

--- a/api/proto/evecommon/evecommon.proto
+++ b/api/proto/evecommon/evecommon.proto
@@ -10,8 +10,35 @@ option java_package = "org.lfedge.eve.common";
 option java_multiple_files = true;
 option java_outer_classname = "Evecommon";
 
+message ZCert {
+  HashAlgorithm hash_algo = 1; //hash method used to arrive at certHash
+  ZCertType type = 2;          // certificate type
+  bytes hash = 3;              // certificate hash, defined by hash algorithm
+  bytes cert = 4;             //X509 cert in .PEM format
+  ZCertAttr attributes = 5;   //properties of this certificate
+}
+
+message ZCertAttr {
+  bool is_mutable = 1; //set to false for immutable certificates
+}
+
 enum HashAlgorithm {
   HASH_ALGORITHM_INVALID = 0;
   HASH_ALGORITHM_SHA256_16BYTES = 1; // hash with sha256, the 1st 16 bytes of result
   HASH_ALGORITHM_SHA256_32BYTES = 2; // hash with sha256, the whole 32 bytes of result
+}
+
+enum ZCertType {
+  Z_CERT_TYPE_INVALID = 0;
+
+  // controller generated certificates
+  Z_CERT_TYPE_CONTROLLER_SIGNING = 1;        //to sign payload envelopes
+  Z_CERT_TYPE_CONTROLLER_INTERMEDIATE = 2;   //intermediate certs used to validate the certificates
+  Z_CERT_TYPE_CONTROLLER_ECDH_EXCHANGE = 3;  //to share symmetric key using ECDH
+
+  // device generated certificates
+  Z_CERT_TYPE_DEVICE_ONBOARDING = 10;         //for identifying the device
+  Z_CERT_TYPE_DEVICE_RESTRICTED_SIGNING = 11; //node for attestation
+  Z_CERT_TYPE_DEVICE_ENDORSEMENT_RSA = 12;    //endorsement key certificate with RSASSA signing algorithm
+  Z_CERT_TYPE_DEVICE_ECDH_EXCHANGE = 13;      //to share symmetric key using ECDH
 }

--- a/api/proto/info/info.proto
+++ b/api/proto/info/info.proto
@@ -63,6 +63,7 @@ enum ZInfoTypes {
   ZiVolume = 7;
   ZiContentTree = 8;
   ZiBlobList = 9;
+  Z_INFO_TYPES_CIPHER_INFO = 10;
 }
 
 // Information about assignable I/O adapter bundles
@@ -544,6 +545,41 @@ message ZInfoVolume {
   int64 generation_count = 8; // version of volume
 }
 
+// cipher object type
+enum CipherObjectType {
+ CIPHER_OBJECT_TYPE_INVALID          = 0;
+ CIPHER_OBJECT_TYPE_CONTEXT          = 1;
+ CIPHER_OBJECT_TYPE_CONTROLLER_CERT  = 2;
+ CIPHER_OBJECT_TYPE_NODE_CERT        = 3;
+ CIPHER_OBJECT_TYPE_NIM_BLOCK        = 4;
+ CIPHER_OBJECT_TYPE_DOMAINMGR_BLOCK  = 5;
+ CIPHER_OBJECT_TYPE_DOWNLOADER_BLOCK = 6;
+}
+
+// cipher object event
+enum CipherObjectEvent {
+ CIPHER_OBJECT_EVENT_INVALID  = 0;
+ CIPHER_OBJECT_EVENT_CREATE   = 1;
+ CIPHER_OBJECT_EVENT_DELETE   = 2;
+ CIPHER_OBJECT_EVENT_MODIFY   = 3;
+ CIPHER_OBJECT_EVENT_DECRYPT  = 4;
+}
+
+enum CipherObjectStatus {
+ CIPHER_OBJECT_STATUS_INVALID  = 0;
+ CIPHER_OBJECT_STATUS_SUCCESS  = 1;
+ CIPHER_OBJECT_STATUS_ERROR    = 2;
+}
+
+// for conveying the cipher procesing status
+message  ZInfoCipher {
+   string id = 1;
+   CipherObjectType type = 2;
+   CipherObjectEvent event = 3;
+   CipherObjectStatus status = 4;
+   ErrorInfo err = 5;
+}
+
 message ContentResources {
   uint64 curSizeBytes = 1;  // Current disk usage
 }
@@ -598,6 +634,7 @@ message ZInfoMsg {
     ZInfoVolume vinfo = 13;
     ZInfoContentTree cinfo = 14;
     ZInfoBlobList binfo = 15;
+    ZInfoCipher cipherinfo = 16;
   }
   google.protobuf.Timestamp atTimeStamp = 6;
 }


### PR DESCRIPTION
Signed-off-by: Srinibas Maharana <srinibas@zededa.com>
Please review.
Proto changes, covering
1. created ZCert message in evecommon, to be used in  attest/certs API.
2. Also includes the associated ZType changes for the certificate types.
3. info API inclues a message template for cipher object status events.
4. config API will have the CertShas (for Node and Controller). These will be the driver for pulling changes in controller certs pull  and node certificate push function on EVE.