### PR TITLE
app container stats collect, part 1, config part

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -29,6 +29,7 @@
 | debug.default.remote.loglevel | string | warning | min level sent to controller |
 | storage.dom0.disk.minusage.percent | integer percent | 20 | min. percent of persist partition reserved for dom0 |
 | storage.apps.ignore.disk.check | boolean | false | Ignore disk usage check for Apps. Allows apps to create images bigger than available disk|
+| timer.appcontainer.stats.interval | integer in seconds | 300 | collect applicatio container stats |
 
 
 In addition, there can be per-agent settings.

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -513,7 +513,7 @@ func parseAppInstanceConfig(config *zconfig.EdgeDevConfig,
 			cfgApp.Drives)
 
 		// fill in the collect stats IP address of the App
-		appInstance.CollectStatsIPAddr = cfgApp.GetCollectStatsIPAddr()
+		appInstance.CollectStatsIPAddr = net.ParseIP(cfgApp.GetCollectStatsIPAddr())
 
 		// fill the overlay/underlay config
 		parseAppNetworkConfig(&appInstance, cfgApp, config.Networks,

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -512,6 +512,9 @@ func parseAppInstanceConfig(config *zconfig.EdgeDevConfig,
 		parseStorageConfigList(types.AppImgObj, appInstance.StorageConfigList,
 			cfgApp.Drives)
 
+		// fill in the collect stats IP address of the App
+		appInstance.CollectStatsIPAddr = cfgApp.GetCollectStatsIPAddr()
+
 		// fill the overlay/underlay config
 		parseAppNetworkConfig(&appInstance, cfgApp, config.Networks,
 			config.NetworkInstances)

--- a/pkg/pillar/cmd/zedmanager/handlezedrouter.go
+++ b/pkg/pillar/cmd/zedmanager/handlezedrouter.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	log "github.com/sirupsen/logrus"
+	"strings"
 )
 
 // MaybeAddAppNetworkConfig ensures we have an AppNetworkConfig
@@ -38,6 +39,11 @@ func MaybeAddAppNetworkConfig(ctx *zedmanagerContext,
 				m.Activate, aiConfig.Activate)
 			changed = true
 		}
+		if strings.Compare(m.GetStatsIPAddr, aiConfig.CollectStatsIPAddr) != 0 {
+			log.Infof("MaybeAddAppNetworkConfig: stats ip changed from  %s to %s",
+				m.GetStatsIPAddr, aiConfig.CollectStatsIPAddr)
+			changed = true
+		}
 		for i, new := range aiConfig.OverlayNetworkList {
 			old := m.OverlayNetworkList[i]
 			if !reflect.DeepEqual(new.ACLs, old.ACLs) {
@@ -66,6 +72,7 @@ func MaybeAddAppNetworkConfig(ctx *zedmanagerContext,
 			DisplayName:    aiConfig.DisplayName,
 			IsZedmanager:   false,
 			Activate:       aiConfig.Activate,
+			GetStatsIPAddr: aiConfig.CollectStatsIPAddr,
 		}
 		nc.OverlayNetworkList = make([]types.OverlayNetworkConfig,
 			len(aiStatus.EIDList))

--- a/pkg/pillar/cmd/zedmanager/handlezedrouter.go
+++ b/pkg/pillar/cmd/zedmanager/handlezedrouter.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	log "github.com/sirupsen/logrus"
-	"strings"
 )
 
 // MaybeAddAppNetworkConfig ensures we have an AppNetworkConfig
@@ -39,9 +38,9 @@ func MaybeAddAppNetworkConfig(ctx *zedmanagerContext,
 				m.Activate, aiConfig.Activate)
 			changed = true
 		}
-		if strings.Compare(m.GetStatsIPAddr, aiConfig.CollectStatsIPAddr) != 0 {
+		if !m.GetStatsIPAddr.Equal(aiConfig.CollectStatsIPAddr) {
 			log.Infof("MaybeAddAppNetworkConfig: stats ip changed from  %s to %s",
-				m.GetStatsIPAddr, aiConfig.CollectStatsIPAddr)
+				m.GetStatsIPAddr.String(), aiConfig.CollectStatsIPAddr.String())
 			changed = true
 		}
 		for i, new := range aiConfig.OverlayNetworkList {

--- a/pkg/pillar/cmd/zedrouter/appcontainer.go
+++ b/pkg/pillar/cmd/zedrouter/appcontainer.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Process input in the form of a collection of AppNetworkConfig structs
+// from zedmanager and zedagent. Publish the status as AppNetworkStatus.
+// Produce the updated configlets (for radvd, dnsmasq, ip*tables, lisp.config,
+// ipset, ip link/addr/route configuration) based on that and apply those
+// configlets.
+
+package zedrouter
+
+import (
+	"strings"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	log "github.com/sirupsen/logrus"
+)
+
+// check if we need to launch the goroutine to collect App container stats
+func appCheckStatsCollect(ctx *zedrouterContext, config types.AppNetworkConfig,
+	status *types.AppNetworkStatus) {
+
+	oldIPAddr := status.GetStatsIPAddr
+	status.GetStatsIPAddr = config.GetStatsIPAddr
+	if strings.Compare(config.GetStatsIPAddr, oldIPAddr) != 0 {
+		log.Infof("appCheckStatsCollect: config ip %s, status ip %s", config.GetStatsIPAddr, oldIPAddr)
+		if oldIPAddr == "" && config.GetStatsIPAddr != "" {
+			ctx.appStatsMutex.Lock()
+			publishAppNetworkStatus(ctx, status)
+			if !ctx.appCollectStatsRunning {
+				ctx.appStatsMutex.Unlock()
+				go appStatsCollect(ctx)
+			} else {
+				ctx.appStatsMutex.Unlock()
+			}
+		}
+	}
+}
+
+// goroutine for App container stats collection
+func appStatsCollect(ctx *zedrouterContext) {
+	log.Infof("appStatsCollect: containerStats, started")
+	appStatsCollectTimer := time.NewTimer(600 * time.Second)
+	for {
+		select {
+		case <-appStatsCollectTimer.C:
+			var numStatsIP int
+			ctx.appStatsMutex.Lock()
+			pub := ctx.pubAppNetworkStatus
+			items := pub.GetAll()
+			for _, st := range items {
+				status := st.(types.AppNetworkStatus)
+				if status.GetStatsIPAddr != "" {
+					numStatsIP++
+				}
+			}
+			if numStatsIP == 0 {
+				log.Infof("appStatsCollect: no stats IP anymore. stop and exit out")
+				ctx.appCollectStatsRunning = false
+				ctx.appStatsMutex.Unlock()
+				return
+			}
+			ctx.appStatsMutex.Unlock()
+			for _, st := range items {
+				status := st.(types.AppNetworkStatus)
+				if status.GetStatsIPAddr != "" {
+					// XXX temp for later, collection function to fill in here
+				}
+			}
+			appStatsCollectTimer = time.NewTimer(600 * time.Second)
+		}
+	}
+}

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -87,6 +87,7 @@ type zedrouterContext struct {
 	appNetCreateTimer         *time.Timer
 	appCollectStatsRunning    bool
 	appStatsMutex             sync.Mutex // to protect the changing appNetworkStatus & appCollectStatsRunning
+	appStatsInterval          uint32
 }
 
 var debug = false
@@ -189,6 +190,9 @@ func Run(ps *pubsub.PubSub) {
 	}
 	zedrouterCtx.subAssignableAdapters = subAssignableAdapters
 	subAssignableAdapters.Activate()
+
+	gcp := *types.DefaultConfigItemValueMap()
+	zedrouterCtx.appStatsInterval = gcp.GlobalValueInt(types.AppContainerStatsInterval)
 
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
@@ -2777,6 +2781,7 @@ func handleGlobalConfigModify(ctxArg interface{}, key string,
 		debugOverride)
 	if gcp != nil {
 		ctx.GCInitialized = true
+		ctx.appStatsInterval = gcp.GlobalValueInt(types.AppContainerStatsInterval)
 	}
 	log.Infof("handleGlobalConfigModify done for %s\n", key)
 }
@@ -2792,6 +2797,8 @@ func handleGlobalConfigDelete(ctxArg interface{}, key string,
 	log.Infof("handleGlobalConfigDelete for %s\n", key)
 	debug, _ = agentlog.HandleGlobalConfig(ctx.subGlobalConfig, agentName,
 		debugOverride)
+	gcp := *types.DefaultConfigItemValueMap()
+	ctx.appStatsInterval = gcp.GlobalValueInt(types.AppContainerStatsInterval)
 	log.Infof("handleGlobalConfigDelete done for %s\n", key)
 }
 

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -141,6 +141,8 @@ const (
 	// Dom0DiskUsageMaxBytes - Max disk usage for Dom0. Dom0 can use
 	//  Dom0MinDiskUsagePercent upto a max of  Dom0DiskUsageMaxBytes
 	Dom0DiskUsageMaxBytes GlobalSettingKey = "storage.dom0.disk.maxusagebytes"
+	// AppContainerStatsInterval - App Container Stats Collection
+	AppContainerStatsInterval GlobalSettingKey = "timer.appcontainer.stats.interval"
 
 	// Bool Items
 	// UsbAccess global setting key
@@ -705,6 +707,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddIntItem(NetworkTestTimeout, 15, 0, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(NetworkSendTimeout, 120, 0, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(Dom0MinDiskUsagePercent, 20, 20, 0xFFFFFFFF)
+	configItemSpecMap.AddIntItem(AppContainerStatsInterval, 300, 1, 0xFFFFFFFF)
 	// Dom0DiskUsageMaxBytes - Default is 2GB, min is 100MB
 	configItemSpecMap.AddIntItem(Dom0DiskUsageMaxBytes, 2*1024*1024*1024,
 		100*1024*1024, 0xFFFFFFFF)

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -164,6 +164,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		NetworkTestTimeout,
 		NetworkSendTimeout,
 		Dom0MinDiskUsagePercent,
+		AppContainerStatsInterval,
 		Dom0DiskUsageMaxBytes,
 		// Bool Items
 		UsbAccess,

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -69,6 +69,8 @@ type AppInstanceConfig struct {
 	// XXX: to be deprecated, use CipherBlockStatus instead
 	CloudInitUserData *string // base64-encoded
 	RemoteConsole     bool
+	// Collect Stats IP Address
+	CollectStatsIPAddr string
 
 	// CipherBlockStatus, for encrypted cloud-init data
 	CipherBlockStatus

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -69,8 +69,8 @@ type AppInstanceConfig struct {
 	// XXX: to be deprecated, use CipherBlockStatus instead
 	CloudInitUserData *string // base64-encoded
 	RemoteConsole     bool
-	// Collect Stats IP Address
-	CollectStatsIPAddr string
+	// Collect Stats IP Address, assume port is the default docker API for http: 2375
+	CollectStatsIPAddr net.IP
 
 	// CipherBlockStatus, for encrypted cloud-init data
 	CipherBlockStatus

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -27,7 +27,7 @@ type AppNetworkConfig struct {
 	Activate            bool
 	IsZedmanager        bool
 	LegacyDataPlane     bool
-	GetStatsIPAddr      string
+	GetStatsIPAddr      net.IP
 	OverlayNetworkList  []OverlayNetworkConfig
 	UnderlayNetworkList []UnderlayNetworkConfig
 }
@@ -109,7 +109,7 @@ type AppNetworkStatus struct {
 	// Copy from the AppNetworkConfig; used to delete when config is gone.
 	IsZedmanager        bool
 	LegacyDataPlane     bool
-	GetStatsIPAddr      string
+	GetStatsIPAddr      net.IP
 	OverlayNetworkList  []OverlayNetworkStatus
 	UnderlayNetworkList []UnderlayNetworkStatus
 	MissingNetwork      bool // If any Missing flag is set in the networks

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -27,6 +27,7 @@ type AppNetworkConfig struct {
 	Activate            bool
 	IsZedmanager        bool
 	LegacyDataPlane     bool
+	GetStatsIPAddr      string
 	OverlayNetworkList  []OverlayNetworkConfig
 	UnderlayNetworkList []UnderlayNetworkConfig
 }
@@ -108,6 +109,7 @@ type AppNetworkStatus struct {
 	// Copy from the AppNetworkConfig; used to delete when config is gone.
 	IsZedmanager        bool
 	LegacyDataPlane     bool
+	GetStatsIPAddr      string
 	OverlayNetworkList  []OverlayNetworkStatus
 	UnderlayNetworkList []UnderlayNetworkStatus
 	MissingNetwork      bool // If any Missing flag is set in the networks


### PR DESCRIPTION
Signed-off-by: Naiming Shen <naiming@zededa.com>
- first part of the app container stats collection
- config change trigger the launch of goroutine for stats collection the first time
- will shutdown if there is no more appinstance needs this.