### PR TITLE
GET /certs should use TLS

### DIFF
--- a/api/APIv1.md
+++ b/api/APIv1.md
@@ -226,7 +226,7 @@ The `EdgeDevConfig` message can contain zero, one or more `ConfigItem` entries, 
 
 ### Controller Certificates
 
-Retrieve Certificates that Controller will use. Controller can include one or more certificates in the response, and include information about each certificate such as unique identifier for the certificate, the target usage for the certificate and any other properties related to the certificate. Each certificate MUST be a X.509 certificate in PEM format. The device will verify the certificate chains against its trusted root certificate hence the controller certificates are sent in the clear.
+Retrieve Certificates that Controller will use. Controller can include one or more certificates in the response, and include information about each certificate such as unique identifier for the certificate, the target usage for the certificate and any other properties related to the certificate. Each certificate MUST be a X.509 certificate in PEM format. The device will verify the certificate chains against its trusted root certificate.
 
    GET /api/v1/edgeDevice/certs
 

--- a/api/APIv2.md
+++ b/api/APIv2.md
@@ -60,7 +60,7 @@ In general, there is one directory for each API endpoint:
 
 ## Authentication
 
-All communication messages, except `/ping` and `/certs`,  MUST be encrypted with TLS v1.2 or higher, and MUST authenticate the server using TLS. It is RECOMMENDED to use TLS v1.3 or higher to provider better privacy for the Device certificate and faster communication initialization. There is no client TLS authentication in this version of the API.
+All communication messages MUST be encrypted with TLS v1.2 or higher, and MUST authenticate the server using TLS. It is RECOMMENDED to use TLS v1.3 or higher to provider better privacy for the Device certificate and faster communication initialization. There is no client TLS authentication in this version of the API.
 
 In addition the payload of the message MUST use the [auth.AuthContainer](./proto/auth/auth.proto) to provide end-to-end integrity of the message payload in the presence of MiTM TLS proxies and/or server-side load balancers. More information about this object signing is in [Object Signing](./OBJECT-SIGNING.md).
 
@@ -73,7 +73,7 @@ A Controller MUST NOT expose other any endpoints that do not offer TLS encryptio
 
 The `ping` endpoint may be useful for a Device to check connectivity before registering. Since the device has not yet registered, it MUST use its onboarding certificate to authenticate to the `ping` endpoint. The Controller SHOULD rate limit the endpoint when authenticated via onboarding certificate. A Device MUST expect that its Controller may rate limit the `ping` endpoint, and have an appropriate backoff scheme for retrying.
 
-The `certs` API is used early during device initialization to bootstrap the use of the AuthContainer. It is not protected by TLS, but by the verification of the received signature chains. The Controller SHOULD rate limit the endpoint and a Device MUST expect that its Controller may rate limit the endpoint, and have an appropriate backoff scheme for retrying.
+The `certs` API is used early during device initialization to bootstrap the use of the AuthContainer. It is protected by server TLS, but also the received signature chains are the verified against the trusted root. The Controller SHOULD rate limit the endpoint and a Device MUST expect that its Controller may rate limit the endpoint, and have an appropriate backoff scheme for retrying.
 
 The common return codes for failed authentication or authorization are:
 
@@ -204,7 +204,7 @@ The `EdgeDevConfig` message can contain zero, one or more `ConfigItem` entries, 
 
 ### Controller Certificates
 
-Retrieve Certificates that Controller will use. Controller can include one or more certificates in the response, and include information about each certificate such as unique identifier for the certificate, the target usage for the certificate and any other properties related to the certificate. Each certificate MUST be a X.509 certificate in PEM format. The device will verify the certificate chains against its trusted root certificate hence the controller certificates are sent in the clear.
+Retrieve Certificates that Controller will use. Controller can include one or more certificates in the response, and include information about each certificate such as unique identifier for the certificate, the target usage for the certificate and any other properties related to the certificate. Each certificate MUST be a X.509 certificate in PEM format. The device will verify the certificate chains against its trusted root certificate.
 
    GET /api/v2/edgeDevice/certs
 

--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -535,7 +535,7 @@ func selfRegister(zedcloudCtx *zedcloud.ZedCloudContext, tlsConfig *tls.Config, 
 		return false
 	}
 	// in V2 API, register does not send UUID string
-	requrl := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, false, nilUUID, "register")
+	requrl := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, nilUUID, "register")
 	done, resp, _, contents := myPost(zedcloudCtx, tlsConfig,
 		requrl, retryCount,
 		int64(len(b)), bytes.NewBuffer(b))
@@ -568,7 +568,7 @@ func fetchCertChain(zedcloudCtx *zedcloud.ZedCloudContext, tlsConfig *tls.Config
 	}
 
 	// certs API is always V2, and without UUID, use https
-	requrl := zedcloud.URLPathString(serverNameAndPort, true, false, nilUUID, "certs")
+	requrl := zedcloud.URLPathString(serverNameAndPort, true, nilUUID, "certs")
 	// currently there is no data included for the request, same as myGet()
 	done, resp, _, contents = myPost(zedcloudCtx, tlsConfig, requrl, retryCount, 0, nil)
 	if resp != nil {
@@ -615,7 +615,7 @@ func doGetUUID(ctx *clientContext, tlsConfig *tls.Config,
 	zedcloudCtx := ctx.zedcloudCtx
 
 	// get UUID does not have UUID string in V2 API
-	requrl := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, false, nilUUID, "config")
+	requrl := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, nilUUID, "config")
 	b, err := generateConfigRequest()
 	if err != nil {
 		log.Errorln(err)

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -773,7 +773,7 @@ func tryPing(ctx *diagContext, ifname string, reqURL string) bool {
 	zedcloudCtx := ctx.zedcloudCtx
 	// Set the TLS config on each attempt in case it has changed due to proxies etc
 	if reqURL == "" {
-		reqURL = zedcloud.URLPathString(ctx.serverNameAndPort, zedcloudCtx.V2API, false, nilUUID, "ping")
+		reqURL = zedcloud.URLPathString(ctx.serverNameAndPort, zedcloudCtx.V2API, nilUUID, "ping")
 		err := zedcloud.UpdateTLSConfig(zedcloudCtx, ctx.serverName, ctx.cert)
 		if err != nil {
 			errStr := fmt.Sprintf("ERROR: %s: internal UpdateTLSConfig failed %s\n",
@@ -833,7 +833,7 @@ func tryPostUUID(ctx *diagContext, ifname string) bool {
 	}
 	zedcloudCtx := ctx.zedcloudCtx
 
-	reqURL := zedcloud.URLPathString(ctx.serverNameAndPort, zedcloudCtx.V2API, false, ctx.devUUID, "config")
+	reqURL := zedcloud.URLPathString(ctx.serverNameAndPort, zedcloudCtx.V2API, ctx.devUUID, "config")
 	// Set the TLS config on each attempt in case it has changed due to proxies etc
 	err = zedcloud.UpdateTLSConfig(zedcloudCtx, ctx.serverName, ctx.cert)
 	if err != nil {

--- a/pkg/pillar/cmd/logmanager/logmanager.go
+++ b/pkg/pillar/cmd/logmanager/logmanager.go
@@ -884,7 +884,7 @@ func sendProtoStrForAppLogs(appUUID string, appLogs *logs.AppInstanceLogBundle,
 	}
 	// Preserve port
 	serverNameAndPort := strings.TrimSpace(string(serverBytes))
-	appLogsURL := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, false,
+	appLogsURL := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API,
 		devUUID, appLogURL)
 
 	// For any 400 error we abandon
@@ -994,7 +994,7 @@ func sendCtxInit(ctx *logmanagerContext, dnsCtx *DNSContext) {
 		break
 	}
 	// wait for uuid of logs V2 URL string
-	logsURL = zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, false, devUUID, "logs")
+	logsURL = zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, devUUID, "logs")
 	log.Infof("Read UUID %s", devUUID)
 }
 

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -284,7 +284,7 @@ func getLatestConfig(url string, iteration int,
 }
 
 func getCloudCertChain(ctx *zedagentContext) bool {
-	certURL := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, true, nilUUID, "certs")
+	certURL := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, false, nilUUID, "certs")
 	resp, contents, rtf, err := zedcloud.SendOnAllIntf(&zedcloudCtx, certURL, 0, nil, 0, false)
 	if err != nil {
 		if rtf == types.SenderStatusRemTempFail {

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -121,7 +121,7 @@ func handleConfigInit(networkSendTimeout uint32) {
 func configTimerTask(handleChannel chan interface{},
 	getconfigCtx *getconfigContext) {
 
-	configUrl := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, false, devUUID, "config")
+	configUrl := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, devUUID, "config")
 	iteration := 0
 	getconfigCtx.rebootFlag = getLatestConfig(configUrl, iteration,
 		getconfigCtx)
@@ -284,7 +284,7 @@ func getLatestConfig(url string, iteration int,
 }
 
 func getCloudCertChain(ctx *zedagentContext) bool {
-	certURL := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, false, nilUUID, "certs")
+	certURL := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, nilUUID, "certs")
 	resp, contents, rtf, err := zedcloud.SendOnAllIntf(&zedcloudCtx, certURL, 0, nil, 0, false)
 	if err != nil {
 		if rtf == types.SenderStatusRemTempFail {

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -1028,7 +1028,7 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 		log.Fatal("PublishDeviceInfoToZedCloud proto marshaling error: ", err)
 	}
 
-	statusUrl := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, false, devUUID, "info")
+	statusUrl := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, devUUID, "info")
 	zedcloud.RemoveDeferred(deviceUUID)
 	buf := bytes.NewBuffer(data)
 	if buf == nil {
@@ -1453,7 +1453,7 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 	if err != nil {
 		log.Fatal("PublishAppInfoToZedCloud proto marshaling error: ", err)
 	}
-	statusUrl := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, false, devUUID, "info")
+	statusUrl := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, devUUID, "info")
 
 	zedcloud.RemoveDeferred(uuid)
 	buf := bytes.NewBuffer(data)
@@ -1522,7 +1522,7 @@ func PublishContentInfoToZedCloud(ctx *zedagentContext, uuid string,
 	if err != nil {
 		log.Fatal("PublishContentInfoToZedCloud proto marshaling error: ", err)
 	}
-	statusURL := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, false, devUUID, "info")
+	statusURL := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, devUUID, "info")
 
 	zedcloud.RemoveDeferred(uuid)
 	buf := bytes.NewBuffer(data)
@@ -1587,7 +1587,7 @@ func SendMetricsProtobuf(ReportMetrics *metrics.ZMetricMsg,
 
 	buf := bytes.NewBuffer(data)
 	size := int64(proto.Size(ReportMetrics))
-	metricsUrl := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, false, devUUID, "metrics")
+	metricsUrl := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, devUUID, "metrics")
 	const return400 = false
 	_, _, rtf, err := zedcloud.SendOnAllIntf(&zedcloudCtx, metricsUrl,
 		size, buf, iteration, return400)

--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -688,7 +688,7 @@ func publishInfoToZedCloud(UUID string, infoMsg *zinfo.ZInfoMsg, iteration int) 
 	if err != nil {
 		log.Fatal("publishInfoToZedCloud proto marshaling error: ", err)
 	}
-	statusUrl := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, false, devUUID, "info")
+	statusUrl := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, devUUID, "info")
 	zedcloud.RemoveDeferred(UUID)
 	buf := bytes.NewBuffer(data)
 	if buf == nil {
@@ -844,7 +844,7 @@ func sendFlowProtobuf(protoflows *flowlog.FlowMessage) {
 		flowIteration++
 		buf := bytes.NewBuffer(data)
 		size := int64(proto.Size(pflowsPtr))
-		flowlogURL := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, false, devUUID, "flowlog")
+		flowlogURL := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, devUUID, "flowlog")
 		const return400 = false
 		_, _, rtf, err := zedcloud.SendOnAllIntf(&zedcloudCtx, flowlogURL,
 			size, buf, flowIteration, return400)

--- a/pkg/pillar/devicenetwork/devicenetwork.go
+++ b/pkg/pillar/devicenetwork/devicenetwork.go
@@ -118,7 +118,7 @@ func VerifyDeviceNetworkStatus(status types.DeviceNetworkStatus,
 		AgentName:        "devicenetwork",
 	})
 	log.Infof("VerifyDeviceNetworkStatus: Use V2 API %v\n", zedcloud.UseV2API())
-	testURL := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, false, nilUUID, "ping")
+	testURL := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, nilUUID, "ping")
 
 	log.Debugf("NIM Get Device Serial %s, Soft Serial %s\n", zedcloudCtx.DevSerial,
 		zedcloudCtx.DevSoftSerial)

--- a/pkg/pillar/zedcloud/authen.go
+++ b/pkg/pillar/zedcloud/authen.go
@@ -487,7 +487,7 @@ func UseV2API() bool {
 }
 
 // URLPathString - generate url for either v1 or v1 API path
-func URLPathString(server string, isV2api, isHTTP bool, devUUID uuid.UUID, action string) string {
+func URLPathString(server string, isV2api bool, devUUID uuid.UUID, action string) string {
 	var urlstr string
 	if !isV2api {
 		urlstr = server + "/api/v1/edgedevice/" + action
@@ -497,9 +497,6 @@ func URLPathString(server string, isV2api, isHTTP bool, devUUID uuid.UUID, actio
 			urlstr = urlstr + "id/" + devUUID.String() + "/"
 		}
 		urlstr = urlstr + action
-	}
-	if isHTTP {
-		return "http://" + urlstr
 	}
 	return urlstr
 }

--- a/pkg/pillar/zedcloud/wstunnelclient.go
+++ b/pkg/pillar/zedcloud/wstunnelclient.go
@@ -123,7 +123,7 @@ func (t *WSTunnelClient) TestConnection(devNetStatus *types.DeviceNetworkStatus,
 		dialer.Proxy = http.ProxyURL(proxyURL)
 	}
 
-	pingURL := URLPathString(t.Tunnel, zedcloudCtx.V2API, false, devUUID, "connection/ping")
+	pingURL := URLPathString(t.Tunnel, zedcloudCtx.V2API, devUUID, "connection/ping")
 	_, resp, err := dialer.Dial(pingURL, nil)
 	if resp == nil { // this can get error, but with resp code is still 200
 		log.Infof("TestConnection: url %s, resp %v, err %v", pingURL, resp, err)
@@ -132,7 +132,7 @@ func (t *WSTunnelClient) TestConnection(devNetStatus *types.DeviceNetworkStatus,
 	log.Debugf("Read ping response status code: %v for ping url: %s", resp.StatusCode, pingURL)
 
 	if resp.StatusCode == http.StatusOK {
-		url := URLPathString(t.Tunnel, zedcloudCtx.V2API, false, devUUID, "connection/tunnel")
+		url := URLPathString(t.Tunnel, zedcloudCtx.V2API, devUUID, "connection/tunnel")
 		t.DestURL = url
 		t.Dialer = dialer
 		log.Infof("Connection test succeeded for url: %s on local address: %v, proxy: %v", url, localAddr, proxyURL)


### PR DESCRIPTION
To make our security statements about the API simpler.

@naiming-zededa I've tested this works against zedcloud alpha.
@saurabh-zededa this didn't need any changes to zedcloud, so just a heads up.