### PR TITLE
add a queuelock to be used by nim

### DIFF
--- a/pkg/pillar/queuelock/queuelock.go
+++ b/pkg/pillar/queuelock/queuelock.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// queuelock is a package which implements a locking queue
+// where only one operation is performed at a time.
+// This is at some level analogous to a channel with a single worker
+// reading work from the channel, with the key difference is that
+// the queuelock compresses multiple identical requests.
+// That is done by identifying each piece of work with a unique
+// enum value.
+
+package queuelock
+
+import (
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// Handle is the handle used by the caller
+type Handle struct {
+	sync.Mutex
+	isRunning bool      // is something currently running?
+	running   uint      // what is currently running holding the lock
+	waiting   []uint    // things waiting to run
+	next      chan uint // Tell user what to run next
+}
+
+// NewQueueLock creates a lock
+func NewQueueLock() *Handle {
+	log.Infof("NewQueueLock()")
+	handle := Handle{next: make(chan uint, 1)}
+	return &handle
+}
+
+// MsgChan returns the channel
+func (hdl *Handle) MsgChan() <-chan uint {
+	return hdl.next
+}
+
+// Enter returns true if successful i.e., nothing was already running
+// Otherwise the caller is expected to select on MsgChan to get notified
+// when it can try again.
+func (hdl *Handle) Enter(work uint) bool {
+	hdl.Lock()
+	defer hdl.Unlock()
+	if hdl.isRunning {
+		hdl.enqueue(work)
+		log.Infof("Enter(%d) queued", work)
+		return false
+	}
+	hdl.isRunning = true
+	hdl.running = work
+	log.Infof("Enter(%d) ok", work)
+	return true
+}
+
+// Exit ends the lock for this work and kicks the channel if there is
+// waiting work. Caller must pass the same work as in the Enter call.
+func (hdl *Handle) Exit(work uint) {
+	hdl.Lock()
+	defer hdl.Unlock()
+	if !hdl.isRunning {
+		log.Fatalf("Exit but not running")
+	}
+	if hdl.running != work {
+		log.Fatalf("Exit mismatched running %d work %d",
+			hdl.running, work)
+	}
+	hdl.isRunning = false
+	hdl.running = 0
+	if len(hdl.waiting) == 0 {
+		log.Infof("Exit(%d) no waiting", work)
+		return
+	}
+	log.Infof("Exit(%d) %d waiting", work, len(hdl.waiting))
+	next := hdl.dequeue()
+	select {
+	case hdl.next <- next:
+		log.Infof("Exit() sent %d", next)
+	default:
+		log.Fatalf("Exit channel busy")
+	}
+}
+
+// IsBusy returns whether the queuelock is held by anybody
+func (hdl *Handle) IsBusy() bool {
+	return hdl.isRunning
+}
+
+// IsRunning returns whether the queuelock is held by work
+func (hdl *Handle) IsRunning(work uint) bool {
+	return hdl.IsBusy() && hdl.running == work
+}
+
+// NumWaiters returns the number of work items waiting
+func (hdl *Handle) NumWaiters() int {
+	hdl.Lock()
+	defer hdl.Unlock()
+	return len(hdl.waiting)
+}
+
+// Caller must hold lock
+// Supress duplicates when adding
+func (hdl *Handle) enqueue(work uint) {
+	log.Infof("enqueue(%d) %d waiting", work, len(hdl.waiting))
+	for i := range hdl.waiting {
+		if hdl.waiting[i] == work {
+			log.Infof("queue(%d) duplicate at %d, %d waiting",
+				work, i, len(hdl.waiting))
+			return
+		}
+	}
+	hdl.waiting = append(hdl.waiting, work)
+	log.Infof("queue(%d) done, %d waiting", work, len(hdl.waiting))
+}
+
+// Caller must hold lock
+// Panic if empty
+func (hdl *Handle) dequeue() uint {
+	log.Infof("dequeue() %d waiting", len(hdl.waiting))
+	if len(hdl.waiting) == 0 {
+		log.Fatalf("dequeue empty waiting")
+	}
+	work := hdl.waiting[0]
+	hdl.waiting = hdl.waiting[1:]
+	log.Infof("dequeue -> %d, %d waiting", work, len(hdl.waiting))
+	return work
+}

--- a/pkg/pillar/queuelock/queuelock.go
+++ b/pkg/pillar/queuelock/queuelock.go
@@ -61,10 +61,10 @@ func (hdl *Handle) Exit(work uint) {
 	hdl.Lock()
 	defer hdl.Unlock()
 	if !hdl.isRunning {
-		log.Fatalf("Exit but not running")
+		log.Panicf("Exit but not running")
 	}
 	if hdl.running != work {
-		log.Fatalf("Exit mismatched running %d work %d",
+		log.Panicf("Exit mismatched running %d work %d",
 			hdl.running, work)
 	}
 	hdl.isRunning = false
@@ -79,7 +79,7 @@ func (hdl *Handle) Exit(work uint) {
 	case hdl.next <- next:
 		log.Infof("Exit() sent %d", next)
 	default:
-		log.Fatalf("Exit channel busy")
+		log.Panicf("Exit channel busy")
 	}
 }
 
@@ -120,7 +120,7 @@ func (hdl *Handle) enqueue(work uint) {
 func (hdl *Handle) dequeue() uint {
 	log.Infof("dequeue() %d waiting", len(hdl.waiting))
 	if len(hdl.waiting) == 0 {
-		log.Fatalf("dequeue empty waiting")
+		log.Panicf("dequeue empty waiting")
 	}
 	work := hdl.waiting[0]
 	hdl.waiting = hdl.waiting[1:]

--- a/pkg/pillar/queuelock/queuelock_test.go
+++ b/pkg/pillar/queuelock/queuelock_test.go
@@ -1,0 +1,209 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// queuelock is a package which implements a locking queue
+// where only one operation is performed at a time.
+// This is at some level analogous to a channel with a single worker
+// reading work from the channel, with the key difference is that
+// the queuelock compresses multiple identical requests.
+// That is done by identifying each piece of work with a unique
+// enum value.
+
+package queuelock
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+// enum values for work
+type myWork uint
+
+const (
+	myWorkUpdate = uint(iota) // enum for key scheme
+	myWorkValidate
+	myWorkTest
+	myWorkRestart
+)
+
+func TestBadExit(t *testing.T) {
+	h := NewQueueLock()
+	assert.NotNil(t, h)
+	assert.Equal(t, 0, h.NumWaiters())
+	assert.False(t, h.IsBusy())
+
+	// XXX can we test for exit/panic with h.Exit(myWorkValidate)
+	// h.Exit(myWorkValidate)
+}
+
+func TestOne(t *testing.T) {
+	h := NewQueueLock()
+	assert.NotNil(t, h)
+	assert.Equal(t, 0, h.NumWaiters())
+	assert.False(t, h.IsBusy())
+
+	entered := h.Enter(myWorkUpdate)
+	assert.True(t, entered)
+	assert.Equal(t, 0, h.NumWaiters())
+	assert.True(t, h.IsBusy())
+	assert.True(t, h.IsRunning(myWorkUpdate))
+
+	h.Exit(myWorkUpdate)
+	assert.Equal(t, 0, h.NumWaiters())
+	assert.False(t, h.IsBusy())
+}
+
+// Returns work, ok from channel
+func tryChannel(h *Handle) (uint, bool) {
+	select {
+	case work := <-h.MsgChan():
+		return work, true
+	default:
+		return uint(0), false
+	}
+}
+
+func TestTwo(t *testing.T) {
+	h := NewQueueLock()
+	assert.NotNil(t, h)
+	assert.Equal(t, 0, h.NumWaiters())
+	assert.False(t, h.IsBusy())
+
+	e1 := h.Enter(myWorkUpdate)
+	assert.True(t, e1)
+	assert.Equal(t, 0, h.NumWaiters())
+	assert.True(t, h.IsBusy())
+	assert.True(t, h.IsRunning(myWorkUpdate))
+
+	e2 := h.Enter(myWorkTest)
+	assert.False(t, e2)
+	assert.Equal(t, 1, h.NumWaiters())
+	assert.True(t, h.IsBusy())
+	assert.True(t, h.IsRunning(myWorkUpdate))
+
+	h.Exit(myWorkUpdate)
+	assert.Equal(t, 0, h.NumWaiters()) // Handed to channel
+	assert.False(t, h.IsBusy())
+
+	work, ok := tryChannel(h)
+	assert.True(t, ok)
+	assert.Equal(t, myWorkTest, work)
+	e3 := h.Enter(work)
+	assert.True(t, e3)
+	assert.True(t, h.IsBusy())
+	assert.True(t, h.IsRunning(work))
+	h.Exit(work)
+}
+
+func TestThree(t *testing.T) {
+	h := NewQueueLock()
+	assert.NotNil(t, h)
+	assert.Equal(t, 0, h.NumWaiters())
+	assert.False(t, h.IsBusy())
+
+	e1 := h.Enter(myWorkUpdate)
+	assert.True(t, e1)
+	assert.Equal(t, 0, h.NumWaiters())
+	assert.True(t, h.IsBusy())
+	assert.True(t, h.IsRunning(myWorkUpdate))
+
+	e2 := h.Enter(myWorkTest)
+	assert.False(t, e2)
+	assert.Equal(t, 1, h.NumWaiters())
+	assert.True(t, h.IsBusy())
+	assert.True(t, h.IsRunning(myWorkUpdate))
+
+	e3 := h.Enter(myWorkValidate)
+	assert.False(t, e3)
+	assert.Equal(t, 2, h.NumWaiters())
+	assert.True(t, h.IsBusy())
+	assert.True(t, h.IsRunning(myWorkUpdate))
+
+	h.Exit(myWorkUpdate)
+	assert.Equal(t, 1, h.NumWaiters()) // One handed to channel
+	assert.False(t, h.IsBusy())
+
+	work, ok := tryChannel(h)
+	assert.True(t, ok)
+	assert.Equal(t, myWorkTest, work)
+	e4 := h.Enter(work)
+	assert.True(t, e4)
+	assert.True(t, h.IsBusy())
+	assert.True(t, h.IsRunning(work))
+	h.Exit(work)
+
+	assert.False(t, h.IsBusy())
+	assert.Equal(t, 0, h.NumWaiters()) // Last one sent to channel
+
+	work, ok = tryChannel(h)
+	assert.True(t, ok)
+	assert.Equal(t, myWorkValidate, work)
+	e5 := h.Enter(work)
+	assert.True(t, e5)
+	assert.True(t, h.IsBusy())
+	assert.True(t, h.IsRunning(work))
+	h.Exit(work)
+
+	assert.False(t, h.IsBusy())
+	assert.Equal(t, 0, h.NumWaiters())
+}
+
+func TestThreeDuplicate(t *testing.T) {
+	h := NewQueueLock()
+	assert.NotNil(t, h)
+	assert.Equal(t, 0, h.NumWaiters())
+	assert.False(t, h.IsBusy())
+
+	e1 := h.Enter(myWorkUpdate)
+	assert.True(t, e1)
+	assert.Equal(t, 0, h.NumWaiters())
+	assert.True(t, h.IsBusy())
+	assert.True(t, h.IsRunning(myWorkUpdate))
+
+	e2 := h.Enter(myWorkTest)
+	assert.False(t, e2)
+	assert.Equal(t, 1, h.NumWaiters())
+	assert.True(t, h.IsBusy())
+	assert.True(t, h.IsRunning(myWorkUpdate))
+
+	e3 := h.Enter(myWorkValidate)
+	assert.False(t, e3)
+	assert.Equal(t, 2, h.NumWaiters())
+	assert.True(t, h.IsBusy())
+	assert.True(t, h.IsRunning(myWorkUpdate))
+
+	// This will not add since myWorkTest is already waiting
+	e := h.Enter(myWorkTest)
+	assert.False(t, e)
+	assert.Equal(t, 2, h.NumWaiters())
+	assert.True(t, h.IsBusy())
+	assert.True(t, h.IsRunning(myWorkUpdate))
+
+	h.Exit(myWorkUpdate)
+	assert.Equal(t, 1, h.NumWaiters()) // One handed to channel
+	assert.False(t, h.IsBusy())
+
+	work, ok := tryChannel(h)
+	assert.True(t, ok)
+	assert.Equal(t, myWorkTest, work)
+	e4 := h.Enter(work)
+	assert.True(t, e4)
+	assert.True(t, h.IsBusy())
+	assert.True(t, h.IsRunning(work))
+	h.Exit(work)
+
+	assert.False(t, h.IsBusy())
+	assert.Equal(t, 0, h.NumWaiters()) // Last one sent to channel
+
+	work, ok = tryChannel(h)
+	assert.True(t, ok)
+	assert.Equal(t, myWorkValidate, work)
+	e5 := h.Enter(work)
+	assert.True(t, e5)
+	assert.True(t, h.IsBusy())
+	assert.True(t, h.IsRunning(work))
+	h.Exit(work)
+
+	assert.False(t, h.IsBusy())
+	assert.Equal(t, 0, h.NumWaiters())
+}


### PR DESCRIPTION
Will use this to make sure that nim does one activity at a time (verify current DPC, test a new DPC, update DPCL based on new config from zedagent etc).