### PR TITLE
useful utility for fmt, vet, fmt-check in pkg/pillar

### DIFF
--- a/pkg/pillar/Makefile
+++ b/pkg/pillar/Makefile
@@ -20,6 +20,9 @@ endif
 APPS = zedbox
 APPS1 = $(notdir $(wildcard cmd/*))
 
+# find all GOFILES
+GOFILES = $(shell find . -path ./vendor -prune -o -name '*go' -print)
+
 .PHONY: all clean build test build-docker build-docker-git shell
 
 all: build
@@ -61,3 +64,12 @@ test:
 
 clean:
 	@rm -rf $(DISTDIR)
+
+fmt:
+	@gofmt -w -s $(GOFILES)
+
+fmt-check:
+	@gofmt -l $(GOFILES)
+
+vet:
+	go vet ./...


### PR DESCRIPTION
Small change, but nice convenience. When running in `pkg/pillar/` (e.g. when you run `make shell`), you will have some convenience commands:

* `make fmt-check` - reports any files that are misformatted (and therefore will cause CI to fail)
* `make fmt` - fix any files that are misformatted
* `make vet` - run `go vet` on the tree

I got tired of having to do this manually.