### PR TITLE
report sizes when downloading

### DIFF
--- a/pkg/pillar/cmd/downloader/download.go
+++ b/pkg/pillar/cmd/downloader/download.go
@@ -74,7 +74,7 @@ func download(ctx *downloaderContext, trType zedUpload.SyncTransportType,
 				log.Errorln(errStr)
 				return errors.New(errStr)
 			}
-			status.Progress(progress)
+			status.Progress(progress, osize, asize)
 			continue
 		}
 		if syncOp == zedUpload.SyncOpDownload {
@@ -85,10 +85,11 @@ func download(ctx *downloaderContext, trType zedUpload.SyncTransportType,
 		if resp.IsError() {
 			return err
 		}
+		asize, osize := resp.GetAsize(), resp.GetOsize()
 		log.Infof("Done for %v: size %v/%v",
 			resp.GetLocalName(),
-			resp.GetAsize(), resp.GetOsize())
-		status.Progress(100)
+			asize, osize)
+		status.Progress(100, osize, asize)
 		return nil
 	}
 	// if we got here, channel was closed

--- a/pkg/pillar/cmd/downloader/status.go
+++ b/pkg/pillar/cmd/downloader/status.go
@@ -6,7 +6,7 @@ import (
 
 // Status provides a struct that can be called to update download progress
 type Status interface {
-	Progress(uint)
+	Progress(uint, int64, int64)
 }
 
 // PublishStatus practical implementation of Status
@@ -18,7 +18,9 @@ type PublishStatus struct {
 }
 
 // Progress report progress as a percentage of completeness
-func (d *PublishStatus) Progress(p uint) {
+func (d *PublishStatus) Progress(p uint, osize, asize int64) {
 	d.status.Progress = p
+	d.status.CurrentSize = osize
+	d.status.TotalSize = asize
 	publishDownloaderStatus(d.ctx, d.status)
 }

--- a/pkg/pillar/types/downloadertypes.go
+++ b/pkg/pillar/types/downloadertypes.go
@@ -123,7 +123,9 @@ type DownloaderStatus struct {
 	State            SwState // DOWNLOADED etc
 	ReservedSpace    uint64  // Contribution to global ReservedSpace
 	Size             uint64  // Once DOWNLOADED; in bytes
-	Progress         uint    // In percent i.e., 0-100
+	TotalSize        int64   // expected size as reported by the downloader, if any
+	CurrentSize      int64   // current total downloaded size as reported by the downloader
+	Progress         uint    // In percent i.e., 0-100, given by CurrentSize/ExpectedSize
 	ModTime          time.Time
 	// ErrorAndTime provides SetErrorNow() and ClearError()
 	ErrorAndTime


### PR DESCRIPTION
We already reported progress when downloading as a percentage. The progress is osize/asize. This reports the expected total size (asize) and current size (osize), so that calculations beyond just "percentage done" can be performed.

This is especially useful when downloading multiple blobs for a single image/content-tree, where the progress percentage depends on multiple blobs.

As discussed with @eriknordmark 