### PR TITLE
Fix bug in PCIRelease() implementation in KVM hypervisor

### DIFF
--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -679,7 +679,7 @@ func (ctx kvmContext) PCIRelease(long string) error {
 	unbindFile := sysfsPciDevices + long + "/driver/unbind"
 
 	//Write Empty string, to clear driver_override for the device
-	if err := ioutil.WriteFile(overrideFile, []byte(""), 0644); err != nil {
+	if err := ioutil.WriteFile(overrideFile, []byte("\n"), 0644); err != nil {
 		log.Fatalf("driver_override failure for PCI device %s: %v",
 			long, err)
 	}


### PR DESCRIPTION
Writing []byte("") is not correct to clear contents of /driver_override,
as it translates to a byte slice of zero length(which will just return success
without doing anything in the fs). Instead write "\n", as expected by
https://github.com/torvalds/linux/blob/v4.19/drivers/pci/pci-sysfs.c#L715

Signed-off-by: Hariharasubramanian C S <cshari@zededa.com>