### PR TITLE
Refactor CAS containerd interaction

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1032,7 +1032,7 @@ func doActivate(ctx *domainContext, config types.DomainConfig,
 		}
 		// XXX apparently this is under the appInstID and not under
 		// the ImageID aka VolumeID
-		if err := containerd.CtrPrepareMount(config.UUIDandVersion.UUID,
+		if err := containerd.PrepareMount(config.UUIDandVersion.UUID,
 			ds.FileLocation, status.EnvVariables,
 			len(status.DiskStatusList)); err != nil {
 

--- a/pkg/pillar/containerd/containerd.go
+++ b/pkg/pillar/containerd/containerd.go
@@ -7,11 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/containerd/typeurl"
-	"github.com/eriknordmark/netlink"
-	"github.com/lf-edge/eve/pkg/pillar/types"
-	"github.com/opencontainers/image-spec/identity"
-	uuid "github.com/satori/go.uuid"
 	"golang.org/x/sys/unix"
 	"io/ioutil"
 	"os"
@@ -19,47 +14,28 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
-	"time"
 
-	v1stat "github.com/containerd/cgroups/stats/v1"
 	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
-	"github.com/containerd/containerd/namespaces"
-	"github.com/containerd/containerd/snapshots"
+	"github.com/eriknordmark/netlink"
+	"github.com/lf-edge/eve/pkg/pillar/types"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
 )
 
 const (
-	// containerd socket
-	ctrdSocket = "/run/containerd/containerd.sock"
-	// ctrdServicesNamespace containerd namespace for running containers
-	ctrdServicesNamespace = "eve-user-apps"
-	//containerdRunTime - default runtime of containerd
-	containerdRunTime = "io.containerd.runtime.v1.linux"
-
 	// root path to all containers
 	containersRoot = types.ROContImgDirname
 	// relative path to rootfs for an individual container
 	containerRootfsPath = "rootfs/"
 	// container config file name
 	imageConfigFilename = "image-config.json"
-	// default snapshotter used by containerd
-	defaultSnapshotter = "overlayfs"
 	// default socket to connect tasks to memlogd
 	logWriteSocket = "/var/run/linuxkit-external-logging.sock"
 	// default socket to read from memlogd
 	logReadSocket = "/var/run/memlogdq.sock"
-	// default signal to kill tasks
-	defaultSignal = "SIGTERM"
-)
-
-var (
-	ctrdCtx context.Context
-	// CtrdClient is a handle to the current containerd client API
-	CtrdClient *containerd.Client
 )
 
 const (
@@ -68,64 +44,20 @@ const (
 	qemuOverHead = int64(500 * 1024 * 1024)
 )
 
-// InitContainerdClient initializes CtrdClient and ctrdCtx
-func InitContainerdClient() error {
-	var err error
-	ctrdCtx = namespaces.WithNamespace(context.Background(), ctrdServicesNamespace)
-	CtrdClient, err = containerd.New(ctrdSocket, containerd.WithDefaultRuntime(containerdRunTime))
-	if err != nil {
-		log.Errorf("could not create containerd client. %v", err.Error())
-		return fmt.Errorf("initContainerdClient: could not create containerd client. %v", err.Error())
-	}
-	return nil
-}
-
 // GetContainerPath return the path to the root of the container. This is *not*
 // necessarily the rootfs, which may be a layer below
 func GetContainerPath(containerDir string) string {
 	return path.Join(containersRoot, containerDir)
 }
 
-// containerdLoadImageTar load an image tar into the containerd content store
-func containerdLoadImageTar(filename string) (map[string]images.Image, error) {
-	// load the content into the containerd content store
-	var err error
-
-	if CtrdClient == nil {
-		return nil, fmt.Errorf("containerdLoadImageTar: Container client is nil")
-	}
-
-	if ctrdCtx == nil {
-		return nil, fmt.Errorf("containerdLoadImageTar: Container context is nil")
-	}
-
-	tarReader, err := os.Open(filename)
-	if err != nil {
-		log.Errorf("could not open tar file for reading at %s: %+s", filename, err.Error())
-		return nil, err
-	}
-
-	imgs, err := CtrdClient.Import(ctrdCtx, tarReader)
-	if err != nil {
-		log.Errorf("could not load image tar at %s into containerd: %+s", filename, err.Error())
-		return nil, err
-	}
-	// successful, so return the list of images we imported
-	names := make(map[string]images.Image)
-	for _, tag := range imgs {
-		names[tag.Name] = tag
-	}
-	return names, nil
-}
-
 // SnapshotRm removes existing snapshot. If silent is true, then operation failures are ignored and no error is returned
 func SnapshotRm(rootPath string, silent bool) error {
-	log.Infof("snapshotRm %s\n", rootPath)
+	log.Infof("SnapshotRm %s\n", rootPath)
 
 	snapshotID := filepath.Base(rootPath)
 
 	if err := syscall.Unmount(filepath.Join(rootPath, containerRootfsPath), 0); err != nil {
-		err = fmt.Errorf("snapshotRm: exception while unmounting: %v/%v. %v", rootPath, containerRootfsPath, err)
+		err = fmt.Errorf("SnapshotRm: exception while unmounting: %v/%v. %v", rootPath, containerRootfsPath, err)
 		log.Error(err.Error())
 		if !silent {
 			return err
@@ -133,16 +65,15 @@ func SnapshotRm(rootPath string, silent bool) error {
 	}
 
 	if err := os.RemoveAll(rootPath); err != nil {
-		err = fmt.Errorf("snapshotRm: exception while deleting: %v. %v", rootPath, err)
+		err = fmt.Errorf("SnapshotRm: exception while deleting: %v. %v", rootPath, err)
 		log.Error(err.Error())
 		if !silent {
 			return err
 		}
 	}
 
-	snapshotter := CtrdClient.SnapshotService(defaultSnapshotter)
-	if err := snapshotter.Remove(ctrdCtx, snapshotID); err != nil {
-		err = fmt.Errorf("snapshotRm: unable to remove snapshot: %v. %v", snapshotID, err)
+	if err := CtrRemoveSnapshot(snapshotID); err != nil {
+		err = fmt.Errorf("SnapshotRm: unable to remove snapshot: %v. %v", snapshotID, err)
 		log.Error(err.Error())
 		if !silent {
 			return err
@@ -161,23 +92,23 @@ func SnapshotRm(rootPath string, silent bool) error {
 // We also expect rootPath to end in a basename that becomes containerd's
 // snapshotID
 func SnapshotPrepare(rootPath string, ociFilename string) error {
-	log.Infof("snapshotPrepare(%s, %s)", rootPath, ociFilename)
+	log.Infof("SnapshotPrepare(%s, %s)", rootPath, ociFilename)
 	// On device restart, the existing bundle is not deleted, we need to delete the
 	// existing bundle of the container and recreate it. This is safe to run even
 	// when bundle doesn't exist
 	if SnapshotRm(rootPath, true) != nil {
-		log.Infof("snapshotPrepare: tried to clean up any existing state, hopefully it worked")
+		log.Infof("SnapshotPrepare: tried to clean up any existing state, hopefully it worked")
 	}
 
 	loadedImages, err := containerdLoadImageTar(ociFilename)
 	if err != nil {
-		log.Errorf("failed to load Image File at %s into containerd: %+s", ociFilename, err.Error())
+		log.Errorf("SnapshotPrepare: failed to load Image File at %s into containerd: %+s", ociFilename, err.Error())
 		return err
 	}
 
 	// we currently only support one image per file; will change eventually
 	if len(loadedImages) != 1 {
-		log.Errorf("loaded %d images, expected just 1", len(loadedImages))
+		log.Errorf("SnapshotPrepare: loaded %d images, expected just 1", len(loadedImages))
 	}
 	var image images.Image
 	for _, imgObj := range loadedImages {
@@ -187,47 +118,36 @@ func SnapshotPrepare(rootPath string, ociFilename string) error {
 	ctrdImage := containerd.NewImage(CtrdClient, image)
 	imageInfo, err := getImageInfo(ctrdCtx, ctrdImage)
 	if err != nil {
-		return fmt.Errorf("ctrPrepare: unable to get image: %v config: %v", ctrdImage.Name(), err)
+		return fmt.Errorf("SnapshotPrepare: unable to get image: %v config: %v", ctrdImage.Name(), err)
 	}
 	mountpoints := imageInfo.Config.Volumes
 	execpath := imageInfo.Config.Entrypoint
 	cmd := imageInfo.Config.Cmd
 	workdir := imageInfo.Config.WorkingDir
 	unProcessedEnv := imageInfo.Config.Env
-	log.Infof("mountPoints %+v execpath %+v cmd %+v workdir %+v env %+v",
+	log.Infof("SnapshotPrepare: mountPoints %+v execpath %+v cmd %+v workdir %+v env %+v",
 		mountpoints, execpath, cmd, workdir, unProcessedEnv)
 
 	// unpack the rootfs Image if needed
 	unpacked, err := ctrdImage.IsUnpacked(ctrdCtx, defaultSnapshotter)
 	if err != nil {
-		return fmt.Errorf("snapshotPrepare: unable to get image metadata: %v config: %v", ctrdImage.Name(), err)
+		return fmt.Errorf("SnapshotPrepare: unable to get image metadata: %v config: %v", ctrdImage.Name(), err)
 	}
 	if !unpacked {
 		if err := ctrdImage.Unpack(ctrdCtx, defaultSnapshotter); err != nil {
-			return fmt.Errorf("snapshotPrepare: unable to unpack image: %v config: %v", ctrdImage.Name(), err)
+			return fmt.Errorf("SnapshotPrepare: unable to unpack image: %v config: %v", ctrdImage.Name(), err)
 		}
 	}
-
-	// use rootfs unpacked image to create a writable snapshot with default snapshotter
-	diffIDs, err := ctrdImage.RootFS(ctrdCtx)
-	if err != nil {
-		log.Errorf("Could not load rootfs of image: %v. %v", ctrdImage.Name(), err)
-		return fmt.Errorf("snapshotPrepare: Could not load rootfs of image: %v. %v", ctrdImage.Name(), err)
-	}
-
-	snapshotter := CtrdClient.SnapshotService(defaultSnapshotter)
-	parent := identity.ChainID(diffIDs).String()
 	snapshotID := filepath.Base(rootPath)
-	labels := map[string]string{"containerd.io/gc.root": time.Now().UTC().Format(time.RFC3339)}
-	mounts, err := snapshotter.Prepare(ctrdCtx, snapshotID, parent, snapshots.WithLabels(labels))
+	mounts, err := CtrPrepareSnapshot(snapshotID, ctrdImage)
 	if err != nil {
-		log.Errorf("Could not create a snapshot from: %s. %v", parent, err)
-		return fmt.Errorf("snapshotPrepare: Could not create a snapshot from: %s. %v", parent, err)
+		log.Errorf("SnapshotPrepare: Could not create snapshot %s. %v", snapshotID, err)
+		return fmt.Errorf("SnapshotPrepare: Could not create snapshot: %s. %v", snapshotID, err)
 	} else {
 		if len(mounts) > 1 {
-			return fmt.Errorf("More than 1 mount-point for snapshot %v %v", rootPath, mounts)
+			return fmt.Errorf("SnapshotPrepare: More than 1 mount-point for snapshot %v %v", rootPath, mounts)
 		} else {
-			log.Infof("snapshotPrepare: preared a snapshot for %v with the following mounts: %v", snapshotID, mounts)
+			log.Infof("SnapshotPrepare: preared a snapshot for %v with the following mounts: %v", snapshotID, mounts)
 		}
 	}
 
@@ -235,373 +155,123 @@ func SnapshotPrepare(rootPath string, ociFilename string) error {
 	// image config OCI json into rootPath/imageConfigFilename
 	rootFsDir := path.Join(rootPath, containerRootfsPath)
 	if err := os.MkdirAll(rootFsDir, 0766); err != nil {
-		return fmt.Errorf("createBundle: Exception while creating rootFS dir. %v", err)
+		return fmt.Errorf("SnapshotPrepare: Exception while creating rootFS dir. %v", err)
 	}
 	if err = mounts[0].Mount(rootFsDir); err != nil {
-		return fmt.Errorf("Exception while mounting rootfs %v via %v. Error: %v", rootFsDir, mounts, err)
+		return fmt.Errorf("SnapshotPrepare: Exception while mounting rootfs %v via %v. Error: %v", rootFsDir, mounts, err)
 	}
 
 	// final step is to deposit OCI image config json
 	imageConfigJSON, err := getImageInfoJSON(ctrdCtx, ctrdImage)
 	if err != nil {
-		log.Errorf("Could not build json of image: %v. %v", ctrdImage.Name(), err.Error())
-		return fmt.Errorf("snapshotPrepare: Could not build json of image: %v. %v", ctrdImage.Name(), err.Error())
+		log.Errorf("SnapshotPrepare: Could not build json of image: %v. %v", ctrdImage.Name(), err.Error())
+		return fmt.Errorf("SnapshotPrepare: Could not build json of image: %v. %v", ctrdImage.Name(), err.Error())
 	}
 	if err := ioutil.WriteFile(filepath.Join(rootPath, imageConfigFilename), []byte(imageConfigJSON), 0666); err != nil {
-		return fmt.Errorf("createBundle: Exception while writing image info to %v/%v. %v", rootPath, imageConfigFilename, err)
+		return fmt.Errorf("SnapshotPrepare: Exception while writing image info to %v/%v. %v", rootPath, imageConfigFilename, err)
 	}
 
 	return nil
 }
 
-func loadContainer(containerID string) (containerd.Container, error) {
-	if CtrdClient == nil {
-		return nil, fmt.Errorf("loadContainer: Container client is nil")
-	}
-
-	if ctrdCtx == nil {
-		return nil, fmt.Errorf("loadContainer: Container context is nil")
-	}
-
-	container, err := CtrdClient.LoadContainer(ctrdCtx, containerID)
-	if err != nil {
-		err = fmt.Errorf("loadContainer: Exception while loading container: %v", err)
-	}
-	return container, err
-}
-
-func getImageInfo(ctrdCtx context.Context, image containerd.Image) (v1.Image, error) {
-	var ociimage v1.Image
-	ic, err := image.Config(ctrdCtx)
-	if err != nil {
-		return ociimage, fmt.Errorf("getImageConfig: ubable to fetch image: %v config. %v", image.Name(), err.Error())
-	}
-	switch ic.MediaType {
-	case v1.MediaTypeImageConfig, images.MediaTypeDockerSchema2Config:
-		p, err := content.ReadBlob(ctrdCtx, image.ContentStore(), ic)
-		if err != nil {
-			return ociimage, fmt.Errorf("getImageConfig: ubable to read cotentStore of image: %v config. %v", image.Name(), err.Error())
-		}
-
-		if err := json.Unmarshal(p, &ociimage); err != nil {
-			return ociimage, fmt.Errorf("getImageConfig: ubable to marshal cotentStore of image: %v config. %v", image.Name(), err.Error())
-
-		}
-	default:
-		return ociimage, fmt.Errorf("unknown image config media type %s", ic.MediaType)
-	}
-	return ociimage, nil
-}
-
-func getImageInfoJSON(ctrdCtx context.Context, image containerd.Image) (string, error) {
-	ociimage, err := getImageInfo(ctrdCtx, image)
-	if err != nil {
-		return "", fmt.Errorf("getImageInfoJSON: ubable to fetch image: %v. %v", image.Name(), err.Error())
-	}
-	return getJSON(ociimage)
-}
-
-// Util methods
-
-// getJSON - returns input in JSON format
-func getJSON(x interface{}) (string, error) {
-	b, err := json.MarshalIndent(x, "", "    ")
-	if err != nil {
-		return "", fmt.Errorf("getJSON: Exception while marshalling container spec JSON. %v", err)
-	}
-	return fmt.Sprint(string(b)), nil
-}
-
-func isContainerNotFound(e error) bool {
-	return strings.HasSuffix(e.Error(), ": not found")
-}
-
-// getContainerPath return the path to the root of the container. This is *not*
-// necessarily the rootfs, which may be a layer below.
-func getContainerPath(containerID string) string {
-	if filepath.IsAbs(containerID) {
-		return containerID
-	} else {
-		return path.Join(containersRoot, containerID)
-	}
-}
-
-func getSavedImageInfo(containerPath string) (v1.Image, error) {
-	var image v1.Image
-
-	appDir := getContainerPath(containerPath)
-	data, err := ioutil.ReadFile(filepath.Join(appDir, imageConfigFilename))
-	if err != nil {
-		return image, err
-	}
-	if err := json.Unmarshal(data, &image); err != nil {
-		return image, err
-	}
-	return image, nil
-}
-
-// bind mount a namespace file
-func bindNS(ns string, path string, pid int) error {
-	if path == "" {
-		return nil
-	}
-	// the path and file need to exist for the bind to succeed, so try to create
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("Cannot create leading directories %s for bind mount destination: %v", dir, err)
-	}
-	fi, err := os.Create(path)
-	if err != nil {
-		return fmt.Errorf("Cannot create a mount point for namespace bind at %s: %v", path, err)
-	}
-	if err := fi.Close(); err != nil {
-		return err
-	}
-	if err := unix.Mount(fmt.Sprintf("/proc/%d/ns/%s", pid, ns), path, "", unix.MS_BIND, ""); err != nil {
-		return fmt.Errorf("Failed to bind %s namespace at %s: %v", ns, path, err)
-	}
-	return nil
-}
-
-// prepareProcess sets up anything that needs to be done after the container process is created,
-// but before it runs (for example networking)
-func prepareProcess(pid int, VifList []types.VifInfo) error {
-	log.Infof("prepareProcess(%d, %v)", pid, VifList)
-	for _, iface := range VifList {
-		if iface.Vif == "" {
-			return fmt.Errorf("Interface requires a name")
-		}
-
-		var link netlink.Link
-		var err error
-
-		link, err = netlink.LinkByName(iface.Vif)
-		if err != nil {
-			return fmt.Errorf("Cannot find interface %s: %v", iface.Vif, err)
-		}
-
-		if err := netlink.LinkSetNsPid(link, int(pid)); err != nil {
-			return fmt.Errorf("Cannot move interface %s into namespace: %v", iface.Vif, err)
-		}
-	}
-
-	binds := []struct {
-		ns   string
-		path string
-	}{
-		{"cgroup", ""},
-		{"ipc", ""},
-		{"mnt", ""},
-		{"net", ""},
-		{"pid", ""},
-		{"user", ""},
-		{"uts", ""},
-	}
-
-	for _, b := range binds {
-		if err := bindNS(b.ns, b.path, pid); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// CtrList returns a list of all known container IDs
-func CtrList() ([]string, error) {
-	res := []string{}
-	ctrs, err := CtrdClient.Containers(ctrdCtx)
-	if err != nil {
-		return nil, err
-	}
-	for _, v := range ctrs {
-		res = append(res, v.ID())
-	}
-	return res, nil
-}
-
-// GetMetrics returns all runtime metrics associated with a container ID
-func GetMetrics(ctrID string) (*v1stat.Metrics, error) {
-	c, err := CtrdClient.LoadContainer(ctrdCtx, ctrID)
-	if err != nil {
-		return nil, err
-	}
-
-	t, err := c.Task(ctrdCtx, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	m, err := t.Metrics(ctrdCtx)
-	if err != nil {
-		return nil, err
-	}
-
-	data, err := typeurl.UnmarshalAny(m.Data)
-	if err != nil {
-		return nil, err
-	}
-
-	switch v := data.(type) {
-	case *v1stat.Metrics:
-		return v, nil
-	default:
-		return nil, fmt.Errorf("can't parse task metric %v", data)
-	}
-}
-
-// CtrInfo looks up
-func CtrInfo(name string) (int, string, error) {
-	c, err := loadContainer(name)
-	if err == nil {
-		if t, err := c.Task(ctrdCtx, nil); err == nil {
-			if stat, err := t.Status(ctrdCtx); err == nil {
-				return int(t.Pid()), string(stat.Status), nil
-			}
-		}
-	}
-	return 0, "", err
-}
-
-// CtrStart starts the default task in a pre-existing container and attaches its logging to memlogd
-func CtrStart(domainName string) (int, error) {
-	ctr, err := loadContainer(domainName)
-	if err != nil {
-		return 0, err
-	}
-
-	logger := GetLog()
-
-	io := func(id string) (cio.IO, error) {
-		stdoutFile := logger.Path(domainName + ".out")
-		stderrFile := logger.Path(domainName)
-		return &logio{
-			cio.Config{
-				Stdin:    "/dev/null",
-				Stdout:   stdoutFile,
-				Stderr:   stderrFile,
-				Terminal: false,
-			},
-		}, nil
-	}
-	task, err := ctr.NewTask(ctrdCtx, io)
-	if err != nil {
-		return 0, err
-	}
-
-	if err := prepareProcess(int(task.Pid()), nil); err != nil {
-		return 0, err
-	}
-
-	if err := task.Start(ctrdCtx); err != nil {
-		return 0, err
-	}
-
-	return int(task.Pid()), nil
-}
-
-// CtrStop stops (kills) the main task in the container
-func CtrStop(containerID string, force bool) error {
-	ctr, err := CtrdClient.LoadContainer(ctrdCtx, containerID)
-	if err != nil {
-		return fmt.Errorf("can't find cotainer %s (%v)", containerID, err)
-	}
-
-	signal, err := containerd.ParseSignal(defaultSignal)
-	if err != nil {
-		return err
-	}
-	if signal, err = containerd.GetStopSignal(ctrdCtx, ctr, signal); err != nil {
-		return err
-	}
-
-	task, err := ctr.Task(ctrdCtx, nil)
-	if err != nil {
-		return err
-	}
-
-	// it is unclear whether we have to wait after this or proceed
-	// straight away. It is also unclear whether paying any attention
-	// to the err returned is worth anything at this point
-	_ = task.Kill(ctrdCtx, signal, containerd.WithKillAll)
-
-	if force {
-		_, err = task.Delete(ctrdCtx, containerd.WithProcessKill)
-	} else {
-		_, err = task.Delete(ctrdCtx)
-	}
-
-	return err
-}
-
-// CtrDelete is a simple wrapper around container.Delete()
-func CtrDelete(containerID string) error {
-	ctr, err := loadContainer(containerID)
-	if err != nil {
-		return err
-	}
-
-	// do this just in case
-	_ = CtrStop(containerID, true)
-
-	return ctr.Delete(ctrdCtx)
-}
-
-// CtrPrepareMount creates special files for running container inside a VM
-func CtrPrepareMount(containerID uuid.UUID, containerPath string, envVars map[string]string, noOfDisks int) error {
-	log.Infof("ctrPrepareMount(%s, %s, %v, %d)", containerID, containerPath,
+// PrepareMount creates special files for running container inside a VM
+func PrepareMount(containerID uuid.UUID, containerPath string, envVars map[string]string, noOfDisks int) error {
+	log.Infof("PrepareMount(%s, %s, %v, %d)", containerID, containerPath,
 		envVars, noOfDisks)
 	imageInfo, err := getSavedImageInfo(containerPath)
 	if err != nil {
-		log.Errorf("ctrPrepareMount(%s, %s) getImageInfo failed: %s",
+		log.Errorf("PrepareMount(%s, %s) getImageInfo failed: %s",
 			containerID, containerPath, err)
 		return err
 	}
 	// inject a few files of our own into the bundle
 	mountpoints, execpath, workdir, env, err := getContainerConfigs(imageInfo, envVars)
 	if err != nil {
-		log.Errorf("ctrPrepareMount(%s, %s) getContainerConfigs failed: %s",
+		log.Errorf("PrepareMount(%s, %s) getContainerConfigs failed: %s",
 			containerID, containerPath, err)
-		return fmt.Errorf("ctrPrepare: unable to get container config: %v", err)
+		return fmt.Errorf("PrepareMount: unable to get container config: %v", err)
 	}
 
 	err = createMountPointExecEnvFiles(containerPath, mountpoints, execpath, workdir, env, noOfDisks)
 	if err != nil {
-		log.Errorf("ctrPrepareMount(%s, %s) createMountPointExecEnvFiles failed: %s",
+		log.Errorf("PrepareMount(%s, %s) createMountPointExecEnvFiles failed: %s",
 			containerID, containerPath, err)
 	}
 	return err
 }
 
-// getContainerConfigs get the container configs needed, specifically
-// - mount target paths
-// - exec path
-// - working directory
-// - env var key/value pairs
-// this can change based on the config format
-func getContainerConfigs(imageInfo v1.Image, userEnvVars map[string]string) (map[string]struct{}, []string, string, []string, error) {
+// LKTaskLaunch runs a task in a new containter created as per linuxkit runtime OCI spec
+// file and optional bundle of DomainConfig settings and command line options. Because
+// we're expecting a linuxkit produced filesystem layout we expect R/O portion of the
+// filesystem to be available under `dirname specFile`/lower and we will be mounting
+// it R/O into the container. On top of that we expect the usual suspects of /run,
+// /persist and /config to be taken care of by the OCI config that lk produced.
+func LKTaskLaunch(name, linuxkit string, domSettings *types.DomainConfig, args []string) (int, error) {
+	config := "/containers/services/" + linuxkit + "/config.json"
+	rootfs := "/containers/services/" + linuxkit + "/rootfs"
 
-	mountpoints := imageInfo.Config.Volumes
-	execpath := imageInfo.Config.Entrypoint
-	execpath = append(execpath, imageInfo.Config.Cmd...)
-	workdir := imageInfo.Config.WorkingDir
-	unProcessedEnv := imageInfo.Config.Env
-	var env []string
-	for _, e := range unProcessedEnv {
-		keyAndValueSlice := strings.Split(e, "=")
-		if len(keyAndValueSlice) == 2 {
-			//handles Key=Value case
-			env = append(env, fmt.Sprintf("%s=\"%s\"", keyAndValueSlice[0], keyAndValueSlice[1]))
-		} else {
-			//handles Key= case
-			env = append(env, e)
-		}
+	log.Infof("Starting LKTaskLaunch for %s", linuxkit)
+	f, err := os.Open("/hostfs" + config)
+	if err != nil {
+		return 0, fmt.Errorf("LKTaskLaunch: can't open spec file %s %v", config, err)
 	}
 
-	for k, v := range userEnvVars {
-		env = append(env, fmt.Sprintf("%s=\"%s\"", k, v))
+	spec, err := NewOciSpec(name)
+	if err != nil {
+		log.Errorf("LKTaskLaunch: NewOciSpec failed with error %v", err)
+		return 0, err
 	}
-	return mountpoints, execpath, workdir, env, nil
+	if err = spec.Load(f); err != nil {
+		return 0, fmt.Errorf("LKTaskLaunch: can't load spec file from %s %v", config, err)
+	}
+
+	spec.Root.Path = rootfs
+	spec.Root.Readonly = true
+	if domSettings != nil {
+		spec.UpdateFromDomain(*domSettings, false)
+		spec.AdjustMemLimit(*domSettings, qemuOverHead)
+	}
+
+	if args != nil {
+		spec.Process.Args = args
+	}
+
+	//Delete existing container, if any
+	if err := CtrDeleteContainer(name); err == nil {
+		log.Infof("LKTaskLaunch: Deleted previously existing container %s", name)
+	}
+
+	if err = spec.CreateContainer(true); err == nil {
+		log.Infof("Starting LKTaskLaunch Container %s", name)
+		return CtrStartContainer(name)
+	}
+
+	log.Errorf("LKTaskLaunch: CreateContainer failed with error %v", err)
+	return 0, err
+}
+
+// containerdLoadImageTar load an image tar into the containerd content store
+func containerdLoadImageTar(filename string) (map[string]images.Image, error) {
+	// load the content into the containerd content store
+	var err error
+
+	tarReader, err := os.Open(filename)
+	if err != nil {
+		log.Errorf("containerdLoadImageTar: could not open tar file for reading at %s: %+s", filename, err.Error())
+		return nil, err
+	}
+
+	imgs, err := CtrLoadImage(ctrdCtx, tarReader)
+	if err != nil {
+		log.Errorf("containerdLoadImageTar: could not load image tar at %s into containerd: %+s", filename, err.Error())
+		return nil, err
+	}
+	// successful, so return the list of images we imported
+	names := make(map[string]images.Image)
+	for _, tag := range imgs {
+		names[tag.Name] = tag
+	}
+	return names, nil
 }
 
 // FIXME: once we move to runX this function is going to go away
@@ -686,52 +356,170 @@ func createMountPointExecEnvFiles(containerPath string, mountpoints map[string]s
 	return nil
 }
 
-// LKTaskLaunch runs a task in a new containter created as per linuxkit runtime OCI spec
-// file and optional bundle of DomainConfig settings and command line options. Because
-// we're expecting a linuxkit produced filesystem layout we expect R/O portion of the
-// filesystem to be available under `dirname specFile`/lower and we will be mounting
-// it R/O into the container. On top of that we expect the usual suspects of /run,
-// /persist and /config to be taken care of by the OCI config that lk produced.
-func LKTaskLaunch(name, linuxkit string, domSettings *types.DomainConfig, args []string) (int, error) {
-	config := "/containers/services/" + linuxkit + "/config.json"
-	rootfs := "/containers/services/" + linuxkit + "/rootfs"
+// getContainerConfigs get the container configs needed, specifically
+// - mount target paths
+// - exec path
+// - working directory
+// - env var key/value pairs
+// this can change based on the config format
+func getContainerConfigs(imageInfo v1.Image, userEnvVars map[string]string) (map[string]struct{}, []string, string, []string, error) {
 
-	log.Infof("Starting LKTaskLaunch for %s", linuxkit)
-	f, err := os.Open("/hostfs" + config)
+	mountpoints := imageInfo.Config.Volumes
+	execpath := imageInfo.Config.Entrypoint
+	execpath = append(execpath, imageInfo.Config.Cmd...)
+	workdir := imageInfo.Config.WorkingDir
+	unProcessedEnv := imageInfo.Config.Env
+	var env []string
+	for _, e := range unProcessedEnv {
+		keyAndValueSlice := strings.Split(e, "=")
+		if len(keyAndValueSlice) == 2 {
+			//handles Key=Value case
+			env = append(env, fmt.Sprintf("%s=\"%s\"", keyAndValueSlice[0], keyAndValueSlice[1]))
+		} else {
+			//handles Key= case
+			env = append(env, e)
+		}
+	}
+
+	for k, v := range userEnvVars {
+		env = append(env, fmt.Sprintf("%s=\"%s\"", k, v))
+	}
+	return mountpoints, execpath, workdir, env, nil
+}
+
+// prepareProcess sets up anything that needs to be done after the container process is created,
+// but before it runs (for example networking)
+func prepareProcess(pid int, VifList []types.VifInfo) error {
+	log.Infof("prepareProcess(%d, %v)", pid, VifList)
+	for _, iface := range VifList {
+		if iface.Vif == "" {
+			return fmt.Errorf("Interface requires a name")
+		}
+
+		var link netlink.Link
+		var err error
+
+		link, err = netlink.LinkByName(iface.Vif)
+		if err != nil {
+			return fmt.Errorf("prepareProcess: Cannot find interface %s: %v", iface.Vif, err)
+		}
+
+		if err := netlink.LinkSetNsPid(link, int(pid)); err != nil {
+			return fmt.Errorf("prepareProcess: Cannot move interface %s into namespace: %v", iface.Vif, err)
+		}
+	}
+
+	binds := []struct {
+		ns   string
+		path string
+	}{
+		{"cgroup", ""},
+		{"ipc", ""},
+		{"mnt", ""},
+		{"net", ""},
+		{"pid", ""},
+		{"user", ""},
+		{"uts", ""},
+	}
+
+	for _, b := range binds {
+		if err := bindNS(b.ns, b.path, pid); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func getImageInfo(ctrdCtx context.Context, image containerd.Image) (v1.Image, error) {
+	var ociimage v1.Image
+	ic, err := image.Config(ctrdCtx)
 	if err != nil {
-		return 0, fmt.Errorf("can't open spec file %s %v", config, err)
+		return ociimage, fmt.Errorf("getImageConfig: ubable to fetch image: %v config. %v", image.Name(), err.Error())
 	}
+	switch ic.MediaType {
+	case v1.MediaTypeImageConfig, images.MediaTypeDockerSchema2Config:
+		p, err := content.ReadBlob(ctrdCtx, image.ContentStore(), ic)
+		if err != nil {
+			return ociimage, fmt.Errorf("getImageConfig: ubable to read cotentStore of image: %v config. %v", image.Name(), err.Error())
+		}
 
-	spec, err := NewOciSpec(name)
+		if err := json.Unmarshal(p, &ociimage); err != nil {
+			return ociimage, fmt.Errorf("getImageConfig: ubable to marshal cotentStore of image: %v config. %v", image.Name(), err.Error())
+
+		}
+	default:
+		return ociimage, fmt.Errorf("getImageInfo: unknown image config media type %s", ic.MediaType)
+	}
+	return ociimage, nil
+}
+
+func getImageInfoJSON(ctrdCtx context.Context, image containerd.Image) (string, error) {
+	ociimage, err := getImageInfo(ctrdCtx, image)
 	if err != nil {
-		log.Errorf("NewOciSpec failed with error %v", err)
-		return 0, err
+		return "", fmt.Errorf("getImageInfoJSON: ubable to fetch image: %v. %v", image.Name(), err.Error())
 	}
-	if err = spec.Load(f); err != nil {
-		return 0, fmt.Errorf("can't load spec file from %s %v", config, err)
-	}
+	return getJSON(ociimage)
+}
 
-	spec.Root.Path = rootfs
-	spec.Root.Readonly = true
-	if domSettings != nil {
-		spec.UpdateFromDomain(*domSettings, false)
-		spec.AdjustMemLimit(*domSettings, qemuOverHead)
-	}
+// Util methods
 
-	if args != nil {
-		spec.Process.Args = args
+// getJSON - returns input in JSON format
+func getJSON(x interface{}) (string, error) {
+	b, err := json.MarshalIndent(x, "", "    ")
+	if err != nil {
+		return "", fmt.Errorf("getJSON: Exception while marshalling container spec JSON. %v", err)
 	}
+	return fmt.Sprint(string(b)), nil
+}
 
-	//Delete existing container, if any
-	if err := CtrDelete(name); err == nil {
-		log.Infof("Deleted previously existing container %s", name)
+func isContainerNotFound(e error) bool {
+	return strings.HasSuffix(e.Error(), ": not found")
+}
+
+// getContainerPath return the path to the root of the container. This is *not*
+// necessarily the rootfs, which may be a layer below.
+func getContainerPath(containerID string) string {
+	if filepath.IsAbs(containerID) {
+		return containerID
+	} else {
+		return path.Join(containersRoot, containerID)
 	}
+}
 
-	if err = spec.CreateContainer(true); err == nil {
-		log.Infof("Starting LKTaskLaunch Container %s", name)
-		return CtrStart(name)
+func getSavedImageInfo(containerPath string) (v1.Image, error) {
+	var image v1.Image
+
+	appDir := getContainerPath(containerPath)
+	data, err := ioutil.ReadFile(filepath.Join(appDir, imageConfigFilename))
+	if err != nil {
+		return image, err
 	}
+	if err := json.Unmarshal(data, &image); err != nil {
+		return image, err
+	}
+	return image, nil
+}
 
-	log.Errorf("LKTaskLaunch CreateContainer failed with error %v", err)
-	return 0, err
+// bind mount a namespace file
+func bindNS(ns string, path string, pid int) error {
+	if path == "" {
+		return nil
+	}
+	// the path and file need to exist for the bind to succeed, so try to create
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("bindNS: Cannot create leading directories %s for bind mount destination: %v", dir, err)
+	}
+	fi, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("bindNS: Cannot create a mount point for namespace bind at %s: %v", path, err)
+	}
+	if err := fi.Close(); err != nil {
+		return err
+	}
+	if err := unix.Mount(fmt.Sprintf("/proc/%d/ns/%s", pid, ns), path, "", unix.MS_BIND, ""); err != nil {
+		return fmt.Errorf("bindNS: Failed to bind %s namespace at %s: %v", ns, path, err)
+	}
+	return nil
 }

--- a/pkg/pillar/containerd/containerdAPI.go
+++ b/pkg/pillar/containerd/containerdAPI.go
@@ -1,0 +1,442 @@
+package containerd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	v1stat "github.com/containerd/cgroups/stats/v1"
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/cio"
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/leases"
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/snapshots"
+	"github.com/containerd/typeurl"
+	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/identity"
+	spec "github.com/opencontainers/image-spec/specs-go/v1"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// containerd socket
+	ctrdSocket = "/run/containerd/containerd.sock"
+	// ctrdServicesNamespace containerd namespace for running containers
+	ctrdServicesNamespace = "eve-user-apps"
+	//containerdRunTime - default runtime of containerd
+	containerdRunTime = "io.containerd.runtime.v1.linux"
+
+	// default snapshotter used by containerd
+	defaultSnapshotter = "overlayfs"
+	// default signal to kill tasks
+	defaultSignal = "SIGTERM"
+)
+
+var (
+	ctrdCtx context.Context
+	// CtrdClient is a handle to the current containerd client API
+	CtrdClient   *containerd.Client
+	contentStore content.Store
+)
+
+// InitContainerdClient initializes CtrdClient and ctrdCtx
+func InitContainerdClient() error {
+	var err error
+	ctrdCtx = namespaces.WithNamespace(context.Background(), ctrdServicesNamespace)
+	CtrdClient, err = containerd.New(ctrdSocket, containerd.WithDefaultRuntime(containerdRunTime))
+	if err != nil {
+		log.Errorf("InitContainerdClient: could not create containerd client. %v", err.Error())
+		return fmt.Errorf("initContainerdClient: could not create containerd client. %v", err.Error())
+	}
+	contentStore = CtrdClient.ContentStore()
+	if err := verifyCtr(); err != nil {
+		return fmt.Errorf("InitContainerdClient: exception while verifying ctrd client: %s", err.Error())
+	}
+	return nil
+}
+
+//CtrWriteBlobWithLease reads the blob as raw data from `reader` and writes it into containerd with the given lease
+func CtrWriteBlobWithLease(blobHash, leaseID string, reader io.Reader) error {
+	if err := verifyCtr(); err != nil {
+		return fmt.Errorf("CtrWriteBlobWithLease: exception while verifying ctrd client: %s", err.Error())
+	}
+	ctrdCtx = leases.WithLease(ctrdCtx, leaseID)
+	if blobHash == "" {
+		return fmt.Errorf("CtrWriteBlobWithLease: blobHash cannot be empty")
+	}
+	expectedSha256Digest := digest.Digest(blobHash)
+	if err := content.WriteBlob(ctrdCtx, contentStore, blobHash, reader, spec.Descriptor{Digest: expectedSha256Digest}); err != nil {
+		return fmt.Errorf("CtrWriteBlobWithLease: Exception while writing blob: %s. %s", blobHash, err.Error())
+	}
+	return nil
+}
+
+//CtrReadBlob return a reader for the blob with given blobHash. Error is returned if no blob is found for the blobHash
+func CtrReadBlob(blobHash string) (io.Reader, error) {
+	if err := verifyCtr(); err != nil {
+		return nil, fmt.Errorf("CtrReadBlob: exception while verifying ctrd client: %s", err.Error())
+	}
+	shaDigest := digest.Digest(blobHash)
+	_, err := contentStore.Info(ctrdCtx, shaDigest)
+	if err != nil {
+		return nil, fmt.Errorf("CtrReadBlob: Exception getting info of blob: %s. %s", blobHash, err.Error())
+	}
+	readerAt, err := contentStore.ReaderAt(ctrdCtx, spec.Descriptor{Digest: shaDigest})
+	if err != nil {
+		return nil, fmt.Errorf("CtrReadBlob: Exception while reading blob: %s. %s", blobHash, err.Error())
+	}
+	return content.NewReader(readerAt), nil
+}
+
+//CtrGetBlobInfo returns a bolb's info as content.Info
+func CtrGetBlobInfo(blobHash string) (content.Info, error) {
+	if err := verifyCtr(); err != nil {
+		return content.Info{}, fmt.Errorf("CtrReadBlob: exception while verifying ctrd client: %s", err.Error())
+	}
+	return contentStore.Info(ctrdCtx, digest.Digest(blobHash))
+}
+
+//CtrListBlobInfo returns a list of blob infos as []content.Info
+func CtrListBlobInfo() ([]content.Info, error) {
+	if err := verifyCtr(); err != nil {
+		return nil, fmt.Errorf("CtrListBlobInfo: exception while verifying ctrd client: %s", err.Error())
+	}
+	infos := make([]content.Info, 0)
+	walkFn := func(info content.Info) error {
+		infos = append(infos, info)
+		return nil
+	}
+	if err := contentStore.Walk(ctrdCtx, walkFn); err != nil {
+		return nil, fmt.Errorf("CtrListBlobInfo: Exception while getting content list. %s", err.Error())
+	}
+	return infos, nil
+}
+
+//CtrDeleteBlob deletes blob with the given blobHash
+func CtrDeleteBlob(blobHash string) error {
+	if err := verifyCtr(); err != nil {
+		return fmt.Errorf("CtrDeleteBlob: exception while verifying ctrd client: %s", err.Error())
+	}
+	return contentStore.Delete(ctrdCtx, digest.Digest(blobHash))
+}
+
+//CtrCreateImage create an image in containerd's image store
+func CtrCreateImage(image images.Image) (images.Image, error) {
+	if err := verifyCtr(); err != nil {
+		return images.Image{}, fmt.Errorf("CtrCreateImage: exception while verifying ctrd client: %s", err.Error())
+	}
+	return CtrdClient.ImageService().Create(ctrdCtx, image)
+}
+
+//CtrLoadImage reads image as raw data from `reader` and loads it into containerd
+func CtrLoadImage(ctx context.Context, reader *os.File) ([]images.Image, error) {
+	if err := verifyCtr(); err != nil {
+		return nil, fmt.Errorf("CtrLoadImage: exception while verifying ctrd client: %s", err.Error())
+	}
+	imgs, err := CtrdClient.Import(ctx, reader)
+	if err != nil {
+		log.Errorf("CtrLoadImage: could not load image %s into containerd: %+s", reader.Name(), err.Error())
+		return nil, err
+	}
+	return imgs, nil
+}
+
+func CtrGetImage(reference string) (containerd.Image, error) {
+	if err := verifyCtr(); err != nil {
+		return nil, fmt.Errorf("CtrGetImage: exception while verifying ctrd client: %s", err.Error())
+	}
+	image, err := CtrdClient.GetImage(ctrdCtx, reference)
+	if err != nil {
+		log.Errorf("CtrGetImage: could not get image %s from containerd: %+s", reference, err.Error())
+		return nil, err
+	}
+	return image, nil
+}
+
+//CtrListImages returns a list of images object from ontainerd's image store
+func CtrListImages() ([]images.Image, error) {
+	if err := verifyCtr(); err != nil {
+		return nil, fmt.Errorf("CtrListImages: exception while verifying ctrd client: %s", err.Error())
+	}
+	return CtrdClient.ImageService().List(ctrdCtx)
+}
+
+//CtrUpdateImage updates the files provided in fieldpaths of the image in containerd'd image store
+func CtrUpdateImage(image images.Image, fieldpaths ...string) (images.Image, error) {
+	if err := verifyCtr(); err != nil {
+		return images.Image{}, fmt.Errorf("CtrUpdateImage: exception while verifying ctrd client: %s", err.Error())
+	}
+	return CtrdClient.ImageService().Update(ctrdCtx, image, fieldpaths...)
+}
+
+//CtrDeleteImage deletes an image with the given reference
+func CtrDeleteImage(reference string) error {
+	if err := verifyCtr(); err != nil {
+		return fmt.Errorf("CtrDeleteImage: exception while verifying ctrd client: %s", err.Error())
+	}
+	return CtrdClient.ImageService().Delete(ctrdCtx, reference)
+}
+
+//CtrPrepareSnapshot creates snapshot for the given image
+func CtrPrepareSnapshot(snapshotID string, image containerd.Image) ([]mount.Mount, error) {
+	if err := verifyCtr(); err != nil {
+		return nil, fmt.Errorf("CtrPrepareSnapshot: exception while verifying ctrd client: %s", err.Error())
+	}
+	// use rootfs unpacked image to create a writable snapshot with default snapshotter
+	diffIDs, err := image.RootFS(ctrdCtx)
+	if err != nil {
+		err = fmt.Errorf("CtrPrepareSnapshot: Could not load rootfs of image: %v. %v", image.Name(), err)
+		return nil, err
+	}
+
+	snapshotter := CtrdClient.SnapshotService(defaultSnapshotter)
+	parent := identity.ChainID(diffIDs).String()
+	labels := map[string]string{"containerd.io/gc.root": time.Now().UTC().Format(time.RFC3339)}
+	return snapshotter.Prepare(ctrdCtx, snapshotID, parent, snapshots.WithLabels(labels))
+}
+
+//CtrMountSnapshot mounts the snapshot with snapshotID on the given targetPath.
+func CtrMountSnapshot(snapshotID, targetPath string) error {
+	if err := verifyCtr(); err != nil {
+		return fmt.Errorf("CtrMountSnapshot: exception while verifying ctrd client: %s", err.Error())
+	}
+	snapshotter := CtrdClient.SnapshotService(defaultSnapshotter)
+	mounts, err := snapshotter.Mounts(ctrdCtx, snapshotID)
+	if err != nil {
+		return fmt.Errorf("CtrMountSnapshot: Exception while fetching mounts of snapshot: %s. %s", snapshotID, err)
+	}
+	return mounts[0].Mount(targetPath)
+}
+
+//CtrListSnapshotInfo returns a list of all snapshot's info present in containerd's snapshot store.
+func CtrListSnapshotInfo() ([]snapshots.Info, error) {
+	if err := verifyCtr(); err != nil {
+		return nil, fmt.Errorf("CtrListSnapshotInfo: exception while verifying ctrd client: %s", err.Error())
+	}
+	snapshotter := CtrdClient.SnapshotService(defaultSnapshotter)
+	snapshotInfoList := make([]snapshots.Info, 0)
+	if err := snapshotter.Walk(ctrdCtx, func(i context.Context, info snapshots.Info) error {
+		snapshotInfoList = append(snapshotInfoList, info)
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("CtrListSnapshotInfo: Execption while fetching snapshot list. %s", err.Error())
+	}
+	return snapshotInfoList, nil
+}
+
+//CtrRemoveSnapshot removed snapshot by ID from containerd
+func CtrRemoveSnapshot(snapshotID string) error {
+	if err := verifyCtr(); err != nil {
+		return fmt.Errorf("CtrRemoveSnapshot: exception while verifying ctrd client: %s", err.Error())
+	}
+	snapshotter := CtrdClient.SnapshotService(defaultSnapshotter)
+	if err := snapshotter.Remove(ctrdCtx, snapshotID); err != nil {
+		log.Errorf("CtrRemoveSnapshot: unable to remove snapshot: %v. %v", snapshotID, err)
+		return err
+	}
+	return nil
+}
+
+//CtrLoadContainer returns conatiner with the given `containerID`. Error is returned if there no container is found.
+func CtrLoadContainer(containerID string) (containerd.Container, error) {
+	if err := verifyCtr(); err != nil {
+		return nil, fmt.Errorf("CtrLoadContainer: exception while verifying ctrd client: %s", err.Error())
+	}
+	container, err := CtrdClient.LoadContainer(ctrdCtx, containerID)
+	if err != nil {
+		err = fmt.Errorf("CtrLoadContainer: Exception while loading container: %v", err)
+	}
+	return container, err
+}
+
+//CtrListContainerIds returns a list of all known container IDs
+func CtrListContainerIds() ([]string, error) {
+	if err := verifyCtr(); err != nil {
+		return nil, fmt.Errorf("CtrListContainerIds: exception while verifying ctrd client: %s", err.Error())
+	}
+	res := []string{}
+	ctrs, err := CtrListContainer()
+	if err != nil {
+		return nil, err
+	}
+	for _, v := range ctrs {
+		res = append(res, v.ID())
+	}
+	return res, nil
+}
+
+//CtrListContainer returns a list of containerd.Container ibjects
+func CtrListContainer() ([]containerd.Container, error) {
+	if err := verifyCtr(); err != nil {
+		return nil, fmt.Errorf("CtrListContainer: exception while verifying ctrd client: %s", err.Error())
+	}
+	return CtrdClient.Containers(ctrdCtx)
+}
+
+// CtrGetContainerMetrics returns all runtime metrics associated with a container ID
+func CtrGetContainerMetrics(containerID string) (*v1stat.Metrics, error) {
+	if err := verifyCtr(); err != nil {
+		return nil, fmt.Errorf("CtrGetContainerMetrics: exception while verifying ctrd client: %s", err.Error())
+	}
+	c, err := CtrLoadContainer(containerID)
+	if err != nil {
+		return nil, err
+	}
+
+	t, err := c.Task(ctrdCtx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	m, err := t.Metrics(ctrdCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := typeurl.UnmarshalAny(m.Data)
+	if err != nil {
+		return nil, err
+	}
+
+	switch v := data.(type) {
+	case *v1stat.Metrics:
+		return v, nil
+	default:
+		return nil, fmt.Errorf("can't parse task metric %v", data)
+	}
+}
+
+// CtrContainerInfo looks up container's info
+func CtrContainerInfo(name string) (int, string, error) {
+	if err := verifyCtr(); err != nil {
+		return 0, "", fmt.Errorf("CtrContainerInfo: exception while verifying ctrd client: %s", err.Error())
+	}
+	c, err := CtrLoadContainer(name)
+	if err == nil {
+		if t, err := c.Task(ctrdCtx, nil); err == nil {
+			if stat, err := t.Status(ctrdCtx); err == nil {
+				return int(t.Pid()), string(stat.Status), nil
+			}
+		}
+	}
+	return 0, "", err
+}
+
+// CtrStartContainer starts the default task in a pre-existing container and attaches its logging to memlogd
+func CtrStartContainer(domainName string) (int, error) {
+	if err := verifyCtr(); err != nil {
+		return 0, fmt.Errorf("CtrStartContainer: exception while verifying ctrd client: %s", err.Error())
+	}
+	ctr, err := CtrLoadContainer(domainName)
+	if err != nil {
+		return 0, err
+	}
+
+	logger := GetLog()
+
+	io := func(id string) (cio.IO, error) {
+		stdoutFile := logger.Path(domainName + ".out")
+		stderrFile := logger.Path(domainName)
+		return &logio{
+			cio.Config{
+				Stdin:    "/dev/null",
+				Stdout:   stdoutFile,
+				Stderr:   stderrFile,
+				Terminal: false,
+			},
+		}, nil
+	}
+	task, err := ctr.NewTask(ctrdCtx, io)
+	if err != nil {
+		return 0, err
+	}
+
+	if err := prepareProcess(int(task.Pid()), nil); err != nil {
+		return 0, err
+	}
+
+	if err := task.Start(ctrdCtx); err != nil {
+		return 0, err
+	}
+
+	return int(task.Pid()), nil
+}
+
+// CtrStopContainer stops (kills) the main task in the container
+func CtrStopContainer(containerID string, force bool) error {
+	if err := verifyCtr(); err != nil {
+		return fmt.Errorf("CtrStopContainer: exception while verifying ctrd client: %s", err.Error())
+	}
+	ctr, err := CtrLoadContainer(containerID)
+	if err != nil {
+		return fmt.Errorf("can't find cotainer %s (%v)", containerID, err)
+	}
+
+	signal, err := containerd.ParseSignal(defaultSignal)
+	if err != nil {
+		return err
+	}
+	if signal, err = containerd.GetStopSignal(ctrdCtx, ctr, signal); err != nil {
+		return err
+	}
+
+	task, err := ctr.Task(ctrdCtx, nil)
+	if err != nil {
+		return err
+	}
+
+	// it is unclear whether we have to wait after this or proceed
+	// straight away. It is also unclear whether paying any attention
+	// to the err returned is worth anything at this point
+	_ = task.Kill(ctrdCtx, signal, containerd.WithKillAll)
+
+	if force {
+		_, err = task.Delete(ctrdCtx, containerd.WithProcessKill)
+	} else {
+		_, err = task.Delete(ctrdCtx)
+	}
+
+	return err
+}
+
+// CtrDeleteContainer is a simple wrapper around container.Delete()
+func CtrDeleteContainer(containerID string) error {
+	if err := verifyCtr(); err != nil {
+		return fmt.Errorf("CtrDeleteContainer: exception while verifying ctrd client: %s", err.Error())
+	}
+	ctr, err := CtrLoadContainer(containerID)
+	if err != nil {
+		return err
+	}
+
+	// do this just in case
+	_ = CtrStopContainer(containerID, true)
+
+	return ctr.Delete(ctrdCtx)
+}
+
+//CtrCreateLease creates a lease with the given parameters
+func CtrCreateLease(leaseOpts []leases.Opt) (leases.Lease, error) {
+	if err := verifyCtr(); err != nil {
+		return leases.Lease{}, fmt.Errorf("CtrDeleteContainer: exception while verifying ctrd client: %s",
+			err.Error())
+	}
+	return CtrdClient.LeasesService().Create(ctrdCtx, leaseOpts...)
+}
+
+//verifyCtr verifies is containerd client and context.
+func verifyCtr() error {
+	if CtrdClient == nil {
+		return fmt.Errorf("verifyCtr: Container client is nil")
+	}
+
+	if ctrdCtx == nil {
+		return fmt.Errorf("verifyCtr: Container context is nil")
+	}
+	return nil
+}

--- a/pkg/pillar/containerd/containerdAPI.go
+++ b/pkg/pillar/containerd/containerdAPI.go
@@ -146,6 +146,7 @@ func CtrLoadImage(ctx context.Context, reader *os.File) ([]images.Image, error) 
 	return imgs, nil
 }
 
+//CtrGetImage returns image object for the reference. Returns error if no image is found for the reference.
 func CtrGetImage(reference string) (containerd.Image, error) {
 	if err := verifyCtr(); err != nil {
 		return nil, fmt.Errorf("CtrGetImage: exception while verifying ctrd client: %s", err.Error())

--- a/pkg/pillar/containerd/oci.go
+++ b/pkg/pillar/containerd/oci.go
@@ -83,9 +83,9 @@ func (s *ociSpec) CreateContainer(removeExisting bool) error {
 	_, err := CtrdClient.NewContainer(ctrdCtx, s.name, containerd.WithSpec(&s.Spec))
 	// if container exists, is stopped and we are asked to remove existing - try that
 	if err != nil && removeExisting {
-		_, status, err := CtrInfo(s.name)
+		_, status, err := CtrContainerInfo(s.name)
 		if err == nil && status != "running" && status != "pausing" {
-			_ = CtrDelete(s.name)
+			_ = CtrDeleteContainer(s.name)
 			_, err = CtrdClient.NewContainer(ctrdCtx, s.name, containerd.WithSpec(&s.Spec))
 		}
 	}

--- a/pkg/pillar/hypervisor/containerd.go
+++ b/pkg/pillar/hypervisor/containerd.go
@@ -77,7 +77,7 @@ func (ctx ctrdContext) Create(domainName string, cfgFilename string, config *typ
 }
 
 func (ctx ctrdContext) Start(domainName string, domainID int) error {
-	id, err := containerd.CtrStart(domainName)
+	id, err := containerd.CtrStartContainer(domainName)
 	if err != nil {
 		return logError("containerd failed to start domain %s %v", domainName, err)
 	}
@@ -86,7 +86,7 @@ func (ctx ctrdContext) Start(domainName string, domainID int) error {
 }
 
 func (ctx ctrdContext) Stop(domainName string, domainID int, force bool) error {
-	err := containerd.CtrStop(domainName, force)
+	err := containerd.CtrStopContainer(domainName, force)
 	if err == nil {
 		log.Infof("containerd stopped domain %s with PID %d (forced %v)", domainName, domainID, force)
 	} else {
@@ -96,7 +96,7 @@ func (ctx ctrdContext) Stop(domainName string, domainID int, force bool) error {
 }
 
 func (ctx ctrdContext) Delete(domainName string, domainID int) error {
-	err := containerd.CtrDelete(domainName)
+	err := containerd.CtrDeleteContainer(domainName)
 	if err == nil {
 		log.Infof("containerd deleted domain %s with PID %d", domainName, domainID)
 	} else {
@@ -106,7 +106,7 @@ func (ctx ctrdContext) Delete(domainName string, domainID int) error {
 }
 
 func (ctx ctrdContext) Info(domainName string, domainID int) error {
-	pid, status, err := containerd.CtrInfo(domainName)
+	pid, status, err := containerd.CtrContainerInfo(domainName)
 	if err == nil {
 		if pid == domainID {
 			log.Infof("containerd domain %s with PID %d is %s\n", domainName, domainID, status)
@@ -122,7 +122,7 @@ func (ctx ctrdContext) Info(domainName string, domainID int) error {
 }
 
 func (ctx ctrdContext) LookupByName(domainName string, domainID int) (int, error) {
-	pid, status, err := containerd.CtrInfo(domainName)
+	pid, status, err := containerd.CtrContainerInfo(domainName)
 	if err == nil {
 		if pid == domainID {
 			log.Infof("containerd domain %s with PID %d is %s\n", domainName, domainID, status)
@@ -160,7 +160,7 @@ func (ctx ctrdContext) PCIRelease(long string) error {
 }
 
 func (ctx ctrdContext) IsDomainPotentiallyShuttingDown(domainName string) bool {
-	_, status, err := containerd.CtrInfo(domainName)
+	_, status, err := containerd.CtrContainerInfo(domainName)
 	return err == nil && status == "pausing"
 }
 
@@ -175,7 +175,7 @@ func (ctx ctrdContext) GetHostCPUMem() (types.HostMemory, error) {
 
 func (ctx ctrdContext) GetDomsCPUMem() (map[string]types.DomainMetric, error) {
 	res := map[string]types.DomainMetric{}
-	ids, err := containerd.CtrList()
+	ids, err := containerd.CtrListContainerIds()
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (ctx ctrdContext) GetDomsCPUMem() (map[string]types.DomainMetric, error) {
 		var usedMemPerc float64
 		var cpuTotal uint64
 
-		if metric, err := containerd.GetMetrics(id); err == nil {
+		if metric, err := containerd.CtrGetContainerMetrics(id); err == nil {
 			usedMem = uint32(roundFromBytesToMbytes(metric.Memory.Usage.Usage))
 			availMem = uint32(roundFromBytesToMbytes(metric.Memory.Usage.Max))
 			if availMem != 0 {

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -292,7 +292,7 @@ func (k *KvmContainerImpl) InitContainerdClient() error {
 
 //GetMetrics implements GetMetrics interface of KvmContainerIntf
 func (k *KvmContainerImpl) GetMetrics(ctrID string) (*v1stat.Metrics, error) {
-	return containerd.GetMetrics(ctrID)
+	return containerd.CtrGetContainerMetrics(ctrID)
 }
 
 //Instantiate an object to call KvmContainerImpl methods
@@ -551,7 +551,7 @@ func (ctx kvmContext) Create(domainName string, cfgFilename string, config *type
 	if err != nil {
 		return 0, logError("starting LKTaskLaunch failed for %s, (%v)", domainName, err)
 	}
-	pid, status, err := containerd.CtrInfo(domainName)
+	pid, status, err := containerd.CtrContainerInfo(domainName)
 	if err != nil {
 		log.Errorf("Error getting status for container %s: %v", domainName, err)
 		return 0, err
@@ -610,7 +610,7 @@ func (ctx kvmContext) Delete(domainName string, domainID int) error {
 	if err := os.RemoveAll(kvmStateDir + domainName); err != nil {
 		return logError("failed to clean up domain state directory %s (%v)", domainName, err)
 	}
-	if err := containerd.CtrDelete(domainName); err != nil {
+	if err := containerd.CtrDeleteContainer(domainName); err != nil {
 		return logError("failed to delete container task for domain %s, %v",
 			domainName, err)
 	}


### PR DESCRIPTION
In the initial implementation of CAS using contained, there were few overlaps between cas/containerd.go and containerd/containerd.go.
Moved all the overlap and all interactions with contained client to a single file containerd/containerdAPI.go

Signed-off-by: adarsh-zededa <adarsh@zededa.com>