### PR TITLE
Making sure EFI partition is formatted as FAT32

### DIFF
--- a/pkg/mkimage-raw-efi/make-raw
+++ b/pkg/mkimage-raw-efi/make-raw
@@ -51,7 +51,7 @@ PARTS=${*:-"efi imga imgb conf persist"}
 PARTITION_TYPE_USR_X86_64=5dfbf5f4-2848-4bac-aa5e-0d9a20b745a6
 
 # EFI partition size in bytes 
-EFI_PART_SIZE=$((1536 * 1024))
+EFI_PART_SIZE=$((36 * 1024 * 1024))
 # rootfs partition size in bytes
 ROOTFS_PART_SIZE=$(( 300 * 1024 * 1024 ))
 # conf partition size in bytes
@@ -104,7 +104,7 @@ dir2vfat() {
   local LABEL=${3:-EVE}
   (rm -rf /tmp/data
    mkdir /tmp/data
-   mkfs.vfat -v -n "$LABEL" -C "$IMG" "$2"
+   mkfs.vfat -F32 -v -n "$LABEL" -C "$IMG" "$2"
    mcopy -i $IMG -s $1/* ::/ ) >&2
   echo $IMG
 }


### PR DESCRIPTION
Turns out EFI spec is moronic in a sense that it allows FAT12/16 partitions to be used for EFI partition BUT ONLY when on removable media. Apparently on a system disk itself it *has* to be FAT32. As per:

> EFI encompasses the use of FAT32 for a system partition, and FAT12 or FAT16 for removable media. The FAT32 system partition is identified by an OSType value other than that used to identify previous versions of FAT. This unique partition type distinguishes an EFI defined file system from a normal FAT file system. The file system supported by EFI includes support for long file names.

So far EVE has been happily surviving with FAT12 and only 2Mb of EFI partition. But now that we've ran into the first BIOS that somehow made it a point to demand FAT32 on a system disk (while still happily accepting FAT12 on an installation media) it seems we need to move to FAT32.

The problem here is that the absolute smallest possible FAT32 partition size is 33Mb (32Mb + FAT overhead). This is quite a jump from 2Mb we're currently wasting on EFI. On top of that -- various sources suggest that the plausible # is at aroun 50Mb -- but it is unclear whether it is based on older (even buggier) UEFI implementations. More details on EFI struggles and partition sizes can be found here https://www.ctrl.blog/entry/esp-size-guide.html

Finally, in addition to everything else -- this will be the first change to the size of the partitioning scheme for EVE (although because it is fixed at install time and never changed again -- it should be safe).

@nordmark @deitch -- please let me know what do you guys think