### PR TITLE
install/remove App Container Stats ACL with App Instance Config

### DIFF
--- a/pkg/pillar/cmd/zedrouter/acl.go
+++ b/pkg/pillar/cmd/zedrouter/acl.go
@@ -1707,3 +1707,34 @@ func createMarkAndAcceptChain(aclArgs types.AppNetworkACLArgs,
 	}
 	return nil
 }
+
+// insert or remove the App Container API endpoint blocking ACL
+func appConfigContainerStatsACL(appIPAddr net.IP, isRemove bool) {
+	var err error
+	action := "-I"
+	// install or remove the App Container Stats blocking ACL
+	// This ACL blocks the other Apps accessing through the same subnet to 'appIPAddr:DOCKERAPIPORT'
+	// in TCP protocol, and only allow the Dom0 process to query the App's docker stats
+	// - this blocking is only possible in the 'raw' table and 'PREROUTING' chain due to the marking
+	//   is done in the 'mangle' of 'PREROUTING'. Install to the front of the 'PREROUTING' list
+	// - this blocking ACL does not block the Dom0 access to the above TCP endpoint on the same
+	//   subnet. This is due to the IP packets from Dom0 to the internal bridge entering the linux
+	//   forwarding through the 'OUTPUT' chain
+	// - this blocking does not seem to work if further matching to the '--physdev', so the drop action
+	//   needs to be at network layer3
+	// - XXX currently the 'drop' mark of 0xffffff on the flow of internal traffic on bridge does not work,
+	//   later it may be possible to change below '-j DROP' to '-j MARK' action
+	if isRemove {
+		action = "-D"
+		err = iptables.IptableCmd("-t", "raw", action, "PREROUTING", "-d", appIPAddr.String(), "-p", "tcp",
+			"--dport", strconv.Itoa(DOCKERAPIPORT), "-j", "DROP")
+	} else {
+		err = iptables.IptableCmd("-t", "raw", action, "PREROUTING", "1", "-d", appIPAddr.String(), "-p", "tcp",
+			"--dport", strconv.Itoa(DOCKERAPIPORT), "-j", "DROP")
+	}
+	if err != nil {
+		log.Errorf("appCheckContainerStatsACL: iptableCmd err %v", err)
+	} else {
+		log.Infof("appCheckContainerStatsACL: iptableCmd %s for %s", action, appIPAddr.String())
+	}
+}

--- a/pkg/pillar/cmd/zedrouter/appcontainer.go
+++ b/pkg/pillar/cmd/zedrouter/appcontainer.go
@@ -121,3 +121,21 @@ func appChangeContainerStatsACL(newIPAddr, oldIPAddr net.IP) {
 		appConfigContainerStatsACL(newIPAddr, false)
 	}
 }
+
+// reinstall the App Container blocking ACL to place in the top
+func appStatsMayNeedReinstallACL(ctx *zedrouterContext, config types.AppNetworkConfig) {
+	sub := ctx.subAppNetworkConfig
+	items := sub.GetAll()
+	for _, item := range items {
+		cfg := item.(types.AppNetworkConfig)
+		if cfg.Key() == config.Key() {
+			log.Infof("appStatsMayNeedReinstallACL: same app, skip")
+			continue
+		}
+		if cfg.GetStatsIPAddr != nil {
+			appConfigContainerStatsACL(cfg.GetStatsIPAddr, true)
+			appConfigContainerStatsACL(cfg.GetStatsIPAddr, false)
+			log.Infof("appStatsMayNeedReinstallACL: reinstall %s\n", cfg.GetStatsIPAddr.String())
+		}
+	}
+}

--- a/pkg/pillar/cmd/zedrouter/appcontainer.go
+++ b/pkg/pillar/cmd/zedrouter/appcontainer.go
@@ -11,11 +11,16 @@ package zedrouter
 
 import (
 	"net"
+	"strconv"
 	"time"
 
+	"github.com/lf-edge/eve/pkg/pillar/iptables"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	log "github.com/sirupsen/logrus"
 )
+
+// DOCKERAPIPORT - constant define of docker API TCP port value
+const DOCKERAPIPORT int = 2375
 
 // check if we need to launch the goroutine to collect App container stats
 func appCheckStatsCollect(ctx *zedrouterContext, config types.AppNetworkConfig,
@@ -29,6 +34,7 @@ func appCheckStatsCollect(ctx *zedrouterContext, config types.AppNetworkConfig,
 		if oldIPAddr == nil && config.GetStatsIPAddr != nil {
 			ensureStatsCollectRunning(ctx)
 		}
+		appChangeContainerStatsACL(status.GetStatsIPAddr, oldIPAddr)
 	}
 }
 
@@ -100,4 +106,43 @@ func appContainerGetStats(ipAddr net.IP) (types.AppContainerMetrics, error) {
 	var acMetrics types.AppContainerMetrics
 	// XXX collect container stats for each container with the docker API endpoint ipAddr
 	return acMetrics, nil
+}
+
+func appChangeContainerStatsACL(newIPAddr, oldIPAddr net.IP) {
+	if oldIPAddr != nil {
+		// remove the previous installed blocking ACL
+		appConfigContainerStatsACL(oldIPAddr, true)
+	}
+	if newIPAddr != nil {
+		// install the App Container blocking ACL
+		appConfigContainerStatsACL(newIPAddr, false)
+	}
+}
+
+func appConfigContainerStatsACL(appIPAddr net.IP, isRemove bool) {
+	var action string
+	if isRemove {
+		action = "-D"
+	} else {
+		action = "-A"
+	}
+	// install or remove the App Container Stats blocking ACL
+	// This ACL blocks the other Apps accessing through the same subnet to 'appIPAddr:DOCKERAPIPORT'
+	// in TCP protocol, and only allow the Dom0 process to query the App's docker stats
+	// - this blocking is only possible in the 'raw' table and 'PREROUTING' chain due to the marking
+	//   is done in the 'mangle' of 'PREROUTING'
+	// - this blocking ACL does not block the Dom0 access to the above TCP endpoint on the same
+	//   subnet. This is due to the IP packets from Dom0 to the internal bridge entering the linux
+	//   forwarding through the 'OUTPUT' chain
+	// - this blocking does not seem to work if further matching to the '--physdev', so the drop action
+	//   needs to be at network layer3
+	// - XXX currently the 'drop' mark of 0xffffff on the flow of internal traffic on bridge does not work,
+	//   later it may be possible to change below '-j DROP' to '-j MARK' action
+	err := iptables.IptableCmd("-t", "raw", action, "PREROUTING", "-d", appIPAddr.String(), "-p", "tcp",
+		"--dport", strconv.Itoa(DOCKERAPIPORT), "-j", "DROP")
+	if err != nil {
+		log.Errorf("appCheckContainerStatsACL: iptableCmd err %v", err)
+	} else {
+		log.Infof("appCheckContainerStatsACL: iptableCmd %s for %s", action, appIPAddr.String())
+	}
 }

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -1545,7 +1545,7 @@ func appNetworkDoCopyNetworksToStatus(
 
 	// during doActive, copy the collect stats IP to status and
 	// check to see if need to launch the process
-	appCheckStatsCollect(ctx, config, status)
+	appCheckStatsCollect(ctx, &config, status)
 
 	olcount := len(config.OverlayNetworkList)
 	if olcount > 0 {
@@ -2015,7 +2015,7 @@ func handleAppNetworkModify(ctxArg interface{}, key string, configArg interface{
 	if status.Activated {
 		// during modify, copy the collect stats IP to status and
 		// check to see if need to launch the process
-		appCheckStatsCollect(ctx, config, status)
+		appCheckStatsCollect(ctx, &config, status)
 
 		// Look for ACL changes in overlay
 		doAppNetworkModifyAllOverlayNetworks(ctx, config, status, ipsets)
@@ -2368,6 +2368,9 @@ func doInactivateAppNetwork(ctx *zedrouterContext,
 		doInactivateAppNetworkWithMgmtLisp(ctx, status)
 		return
 	}
+
+	// remove app container stats collection items
+	appCheckStatsCollect(ctx, nil, status)
 
 	// Note that with IPv4/IPv6/LISP interfaces the domU can do
 	// dns lookups on either IPv4 and IPv6 on any interface, hence should

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -1341,6 +1341,10 @@ func appNetworkDoActivateUnderlayNetwork(
 	networkInstanceInfo.BridgeIPSets = newIpsets
 	log.Infof("set BridgeIPSets to %v for %s", newIpsets,
 		networkInstanceInfo.BridgeName)
+
+	// Check App Container Stats ACL need to be reinstalled
+	appStatsMayNeedReinstallACL(ctx, config)
+
 	publishNetworkInstanceStatus(ctx, netInstStatus)
 
 	maybeRemoveStaleIpsets(staleIpsets)


### PR DESCRIPTION
Signed-off-by: Naiming Shen <naiming@zededa.com>
- this patch will block the inter-Apps access the App's docker API endpoint on the internal bridge
- it will only allow the dom0 side access to that endpoint