### PR TITLE
types changes for object cipher

### DIFF
--- a/pkg/pillar/cmd/tpmmgr/tpmmgr.go
+++ b/pkg/pillar/cmd/tpmmgr/tpmmgr.go
@@ -927,10 +927,10 @@ func getECDHCert(certPath string) ([]byte, error) {
 	return certBytes, nil
 }
 
-func getCertHash(cert []byte, hashAlgo types.CertHashType) ([]byte, error) {
+func getCertHash(cert []byte, hashAlgo types.ZHashAlgorithm) ([]byte, error) {
 	certHash := sha256.Sum256(cert)
 	switch hashAlgo {
-	case types.CertHashTypeSha256First16:
+	case types.HASH_ALGORITHM_SH256_16BYTES:
 		return certHash[:16], nil
 	default:
 		return []byte{}, fmt.Errorf("Unsupported cert hash type: %d\n", hashAlgo)
@@ -949,16 +949,16 @@ func publishECDHCertToController(ctx *tpmMgrContext) {
 		log.Error(errStr)
 		return
 	}
-	certHash, err := getCertHash(certBytes, types.CertHashTypeSha256First16)
+	certHash, err := getCertHash(certBytes, types.HASH_ALGORITHM_SH256_16BYTES)
 	if err != nil {
 		errStr := fmt.Sprintf("publishECDHCertToController failed: %v", err)
 		log.Error(errStr)
 		return
 	}
 	attestCert := types.AttestCert{
-		HashAlgo: types.CertHashTypeSha256First16,
+		HashAlgo: types.HASH_ALGORITHM_SH256_16BYTES,
 		CertID:   certHash,
-		CertType: types.CertTypeEcdhXchange,
+		CertType: types.CERT_TYPE_DEVICE_ECDH_EXCHANGE,
 		Cert:     certBytes,
 	}
 	publishAttestCert(ctx, attestCert)

--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -14,6 +14,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/lf-edge/eve/api/go/attest"
 	zcert "github.com/lf-edge/eve/api/go/certs"
+	"github.com/lf-edge/eve/api/go/evecommon"
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
@@ -75,8 +76,8 @@ func parseControllerCerts(ctx *zedagentContext, contents []byte) {
 		if cert == nil {
 			log.Infof("parseControllerCerts: not found %s", certKey)
 			cert = &types.ControllerCert{
-				HashAlgo: cfgConfig.GetHashAlgo(),
-				Type:     cfgConfig.GetType(),
+				HashAlgo: convertApiHashToLocal(cfgConfig.GetHashAlgo()),
+				Type:     convertCertApiCertTypeToLocal(cfgConfig.GetType()),
 				Cert:     cfgConfig.GetCert(),
 				CertHash: cfgConfig.GetCertHash(),
 			}
@@ -213,5 +214,108 @@ func sendCertsProtobuf(attestReq *attest.ZAttestReq, iteration int) {
 		}
 		zedcloud.SetDeferred("attest:"+deviceUUID, buf, size, attestURL,
 			zedcloudCtx, true)
+	}
+}
+
+// conversion routines used while interfacing with controller
+// convertApiHashToLocal :
+func convertApiHashToLocal(hash evecommon.HashAlgorithm) types.ZHashAlgorithm {
+
+	switch hash {
+	case evecommon.HashAlgorithm_HASH_ALGORITHM_SHA256_16BYTES:
+		return types.HASH_ALGORITHM_SH256_16BYTES
+	case evecommon.HashAlgorithm_HASH_ALGORITHM_SHA256_32BYTES:
+		return types.HASH_ALGORITHM_SH256_32BYTES
+	default:
+		return types.HASH_ALGORITHM_NONE
+	}
+}
+
+// convertLocalToApiHash :
+func convertLocalToApiHash(hash types.ZHashAlgorithm) evecommon.HashAlgorithm {
+
+	switch hash {
+	case types.HASH_ALGORITHM_SH256_16BYTES:
+		return evecommon.HashAlgorithm_HASH_ALGORITHM_SHA256_16BYTES
+	case types.HASH_ALGORITHM_SH256_32BYTES:
+		return evecommon.HashAlgorithm_HASH_ALGORITHM_SHA256_32BYTES
+	default:
+		return evecommon.HashAlgorithm_HASH_ALGORITHM_INVALID
+	}
+}
+
+// convertCertApiCertTypeToLocal :
+func convertCertApiCertTypeToLocal(certType zcert.ZCertType) types.ZCertType {
+
+	switch certType {
+	case zcert.ZCertType_CERT_TYPE_CONTROLLER_SIGNING:
+		return types.CERT_TYPE_CONTROLLER_SIGNING
+	case zcert.ZCertType_CERT_TYPE_CONTROLLER_INTERMEDIATE:
+		return types.CERT_TYPE_CONTROLLER_INTERMEDIATE
+	case zcert.ZCertType_CERT_TYPE_CONTROLLER_ECDH_EXCHANGE:
+		return types.CERT_TYPE_CONTROLLER_ECDH_EXCHANGE
+	default:
+		return types.CERT_TYPE_NONE
+	}
+}
+
+// convertLocalToCertApiCertType :
+func convertLocalToCertApiCertType(certType types.ZCertType) zcert.ZCertType {
+
+	switch certType {
+	case types.CERT_TYPE_CONTROLLER_SIGNING:
+		return zcert.ZCertType_CERT_TYPE_CONTROLLER_SIGNING
+	case types.CERT_TYPE_CONTROLLER_INTERMEDIATE:
+		return zcert.ZCertType_CERT_TYPE_CONTROLLER_INTERMEDIATE
+	case types.CERT_TYPE_CONTROLLER_ECDH_EXCHANGE:
+		return zcert.ZCertType_CERT_TYPE_CONTROLLER_ECDH_EXCHANGE
+	default:
+		return zcert.ZCertType_CERT_TYPE_CONTROLLER_NONE
+	}
+}
+
+// convertAttestApiCertTypeToLocal :
+func convertAttestApiCertTypeToLocal(certType evecommon.ZCertType) types.ZCertType {
+
+	switch certType {
+	case evecommon.ZCertType_Z_CERT_TYPE_CONTROLLER_SIGNING:
+		return types.CERT_TYPE_CONTROLLER_SIGNING
+	case evecommon.ZCertType_Z_CERT_TYPE_CONTROLLER_INTERMEDIATE:
+		return types.CERT_TYPE_CONTROLLER_INTERMEDIATE
+	case evecommon.ZCertType_Z_CERT_TYPE_CONTROLLER_ECDH_EXCHANGE:
+		return types.CERT_TYPE_CONTROLLER_ECDH_EXCHANGE
+	case evecommon.ZCertType_Z_CERT_TYPE_DEVICE_ONBOARDING:
+		return types.CERT_TYPE_DEVICE_ONBOARDING
+	case evecommon.ZCertType_Z_CERT_TYPE_DEVICE_RESTRICTED_SIGNING:
+		return types.CERT_TYPE_DEVICE_RESTRICTED_SIGNING
+	case evecommon.ZCertType_Z_CERT_TYPE_DEVICE_ENDORSEMENT_RSA:
+		return types.CERT_TYPE_DEVICE_ENDORSEMENT_RSA
+	case evecommon.ZCertType_Z_CERT_TYPE_DEVICE_ECDH_EXCHANGE:
+		return types.CERT_TYPE_DEVICE_ECDH_EXCHANGE
+	default:
+		return types.CERT_TYPE_NONE
+	}
+}
+
+//  convertLocalToAttestApiCertType :
+func convertLocalToAttestApiCertType(certType types.ZCertType) evecommon.ZCertType {
+
+	switch certType {
+	case types.CERT_TYPE_CONTROLLER_SIGNING:
+		return evecommon.ZCertType_Z_CERT_TYPE_CONTROLLER_SIGNING
+	case types.CERT_TYPE_CONTROLLER_INTERMEDIATE:
+		return evecommon.ZCertType_Z_CERT_TYPE_CONTROLLER_INTERMEDIATE
+	case types.CERT_TYPE_CONTROLLER_ECDH_EXCHANGE:
+		return evecommon.ZCertType_Z_CERT_TYPE_CONTROLLER_ECDH_EXCHANGE
+	case types.CERT_TYPE_DEVICE_ONBOARDING:
+		return evecommon.ZCertType_Z_CERT_TYPE_DEVICE_ONBOARDING
+	case types.CERT_TYPE_DEVICE_RESTRICTED_SIGNING:
+		return evecommon.ZCertType_Z_CERT_TYPE_DEVICE_RESTRICTED_SIGNING
+	case types.CERT_TYPE_DEVICE_ENDORSEMENT_RSA:
+		return evecommon.ZCertType_Z_CERT_TYPE_DEVICE_ENDORSEMENT_RSA
+	case types.CERT_TYPE_DEVICE_ECDH_EXCHANGE:
+		return evecommon.ZCertType_Z_CERT_TYPE_DEVICE_ECDH_EXCHANGE
+	default:
+		return evecommon.ZCertType_Z_CERT_TYPE_INVALID
 	}
 }

--- a/pkg/pillar/types/attesttypes.go
+++ b/pkg/pillar/types/attesttypes.go
@@ -21,27 +21,11 @@ func (nonce AttestNonce) Key() string {
 //SigAlg denotes the Signature algorithm in use e.g. ECDSA, RSASSA
 type SigAlg uint8
 
-//CertType carries the certificate use case e.g. ek, ecdh_exchange etc
-type CertType uint8
-
-//CertHashType carries the hash algo used for compute the short hash
-type CertHashType uint8
-
 //Various certificate types published by tpmmgr
 const (
 	SigAlgNone SigAlg = iota + 0
 	EcdsaSha256
 	RsaRsassa256
-)
-
-//Needs to match api/proto/attest/attest.proto:ZEveCertType
-//Various types defined under CertType
-const (
-	CertTypeNone CertType = iota + 0 //Default
-	CertTypeOnboarding
-	CertTypeRestrictSigning
-	CertTypeEk
-	CertTypeEcdhXchange
 )
 
 //AttestQuote contains attestation quote
@@ -57,19 +41,12 @@ func (quote AttestQuote) Key() []byte {
 	return quote.nonce
 }
 
-//Needs to match api/proto/attest/attest.proto:ZEveCertHashType
-//Various CertHashType fields
-const (
-	CertHashTypeNone          = iota + 0
-	CertHashTypeSha256First16 = 1 // hash with sha256, the 1st 16 bytes of result in 'certHash'
-)
-
 //AttestCert contains attest signing certificate published by tpmmgr
 type AttestCert struct {
-	HashAlgo CertHashType //hash method used to arrive at certHash
-	CertID   []byte       //Hash of the cert, computed using hashAlgo
-	CertType CertType     //type of the certificate
-	Cert     []byte       //PEM encoded
+	HashAlgo ZHashAlgorithm //hash method used to arrive at certHash
+	CertID   []byte         //Hash of the cert, computed using hashAlgo
+	CertType ZCertType      //type of the certificate
+	Cert     []byte         //PEM encoded
 }
 
 //Key uniquely identifies an AttestCert object

--- a/pkg/pillar/types/certinfotypes.go
+++ b/pkg/pillar/types/certinfotypes.go
@@ -5,16 +5,46 @@ package types
 
 import (
 	"encoding/hex"
-
-	zcert "github.com/lf-edge/eve/api/go/certs"
-	zcommon "github.com/lf-edge/eve/api/go/evecommon"
+	"github.com/google/go-tpm/tpmutil"
 )
 
-// ControllerCert : controller certicate
+// hashing algorithm used for a payload
+type ZHashAlgorithm uint8
+
+const (
+	HASH_ALGORITHM_NONE ZHashAlgorithm = iota + 0
+	HASH_ALGORITHM_SH256_16BYTES
+	HASH_ALGORITHM_SH256_32BYTES
+)
+
+// various certificate types
+type ZCertType uint8
+
+const (
+	CERT_TYPE_NONE ZCertType = iota + 0
+	CERT_TYPE_CONTROLLER_SIGNING
+	CERT_TYPE_CONTROLLER_INTERMEDIATE
+	CERT_TYPE_CONTROLLER_ECDH_EXCHANGE
+	CERT_TYPE_DEVICE_ONBOARDING
+	CERT_TYPE_DEVICE_RESTRICTED_SIGNING
+	CERT_TYPE_DEVICE_ENDORSEMENT_RSA
+	CERT_TYPE_DEVICE_ECDH_EXCHANGE
+)
+
+// denotes source of device certificate
+type ZCertOrigin uint8
+
+const (
+	CERT_ORIGIN_NONE ZCertOrigin = iota + 0
+	CERT_ORIGIN_DEVICE_SOFTWARE
+	CERT_ORIGIN_DEVICE_TPM
+)
+
+// ControllerCert : controller certificate
 // config received from controller
 type ControllerCert struct {
-	HashAlgo zcommon.HashAlgorithm
-	Type     zcert.ZCertType
+	HashAlgo ZHashAlgorithm
+	Type     ZCertType
 	Cert     []byte
 	CertHash []byte
 	// ErrorAndTime provides SetErrorNow() and ClearError()
@@ -23,5 +53,24 @@ type ControllerCert struct {
 
 // Key :
 func (cert *ControllerCert) Key() string {
+	return hex.EncodeToString(cert.CertHash)
+}
+
+// DeviceCert : device certificate
+// device generated certificate
+type DeviceCert struct {
+	HashAlgo  ZHashAlgorithm
+	Type      ZCertType
+	Cert      []byte
+	CertHash  []byte
+	Origin    ZCertOrigin
+	PvtKey    []byte
+	TpmHandle tpmutil.Handle
+	// ErrorAndTime provides SetErrorNow() and ClearError()
+	ErrorAndTime
+}
+
+// Key :
+func (cert *DeviceCert) Key() string {
 	return hex.EncodeToString(cert.CertHash)
 }


### PR DESCRIPTION
Signed-off-by: Srinibas Maharana <srinibas@zededa.com>

types/*.go data struture hanges
1. defined  device certificate structure.
2. various enum definition in sync with API enums.
3. conversion routines.
4. modified attest cert structure for local enum types. We can use device certificate in its place. 