### PR TITLE
readSavedProtoMessage needs to take ConfigResponse wrapper into account

### DIFF
--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -418,14 +418,14 @@ func readSavedProtoMessage(staleConfigTime uint32,
 		log.Errorln("readSavedProtoMessage", err)
 		return nil, err
 	}
-	var config = &zconfig.EdgeDevConfig{}
-
-	err = proto.Unmarshal(contents, config)
+	var configResponse = &zconfig.ConfigResponse{}
+	err = proto.Unmarshal(contents, configResponse)
 	if err != nil {
 		log.Errorf("readSavedProtoMessage Unmarshalling failed: %v",
 			err)
 		return nil, err
 	}
+	config := configResponse.GetConfig()
 	return config, nil
 }
 


### PR DESCRIPTION
Once we have network fault injection in place @kalyan-nidumolu we should create a test which makes sure that apps come up when there is no network for 10 minutes after device reboot.