### PR TITLE
Publish ZInfoBlobList to controller

### DIFF
--- a/pkg/pillar/base/logobjecttypes.go
+++ b/pkg/pillar/base/logobjecttypes.go
@@ -79,6 +79,8 @@ const (
 	DevicePortConfigListLogType LogObjectType = "deviceportconfig_list"
 	// DeviceNetworkStatus :
 	DeviceNetworkStatusLogType LogObjectType = "devicenetwork_status"
+	// BlobStatus :
+	BlobStatusLogType LogObjectType = "blob_status"
 	// VolumeConfigLogType:
 	VolumeConfigLogType LogObjectType = "volume_config"
 	// VolumeStatusLogType:

--- a/pkg/pillar/cmd/zedagent/handleblob.go
+++ b/pkg/pillar/cmd/zedagent/handleblob.go
@@ -1,0 +1,29 @@
+package zedagent
+
+import "github.com/lf-edge/eve/pkg/pillar/types"
+
+func blobStatusGetAll(ctx *zedagentContext) map[string]*types.BlobStatus {
+	sub := ctx.subBlobStatus
+	blobShaAndBlobStatus := make(map[string]*types.BlobStatus)
+	for blobSha, blobStatusInt := range sub.GetAll() {
+		blobStatus := blobStatusInt.(types.BlobStatus)
+		blobShaAndBlobStatus[blobSha] = &blobStatus
+	}
+	return blobShaAndBlobStatus
+}
+
+func handleBlobStatusModify(ctxArg interface{}, key string, statusArg interface{}) {
+	status := statusArg.(types.BlobStatus)
+	ctx := ctxArg.(*zedagentContext)
+	uuidStr := status.Key()
+	PublishBlobInfoToZedCloud(ctx, uuidStr, &status, ctx.iteration)
+	ctx.iteration++
+}
+
+func handleBlobDelete(ctxArg interface{}, key string, statusArg interface{}) {
+	status := statusArg.(types.BlobStatus)
+	ctx := ctxArg.(*zedagentContext)
+	uuidStr := status.Key()
+	PublishBlobInfoToZedCloud(ctx, uuidStr, nil, ctx.iteration)
+	ctx.iteration++
+}


### PR DESCRIPTION
To keep track of all blobs present in CAS (currently containerd), `casBlobMonitor()` will run as a routine in the background of volumeMgr. 
`casBlobMonitor()` does the following:
-  Fetches the list of blobs from CAS every minute. 
- Checks if any new blob was added or any known blob was updated.
- Creates/updates `blobStatus` accordingly. 
-  Publishes the `blobStatus`. 
-  Checks if all known blob are present in CAS. 
-- if not then unpublishes the respective `blobStatus`.

zedagent is the subscriber for `blobStatus` updates from volumemgr. zedagent creates `ZInfoBlobList` from `blobStatus`. 

Currently commented out the part where zedagent will publish `ZInfoBlobList` through API. Noticed there was no code to handle delete operation on `ZInfoBlobList` in the controller.


Signed-off-by: adarsh-zededa <adarsh@zededa.com>