### PR TITLE
Upgradevolume

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -16,7 +16,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -1057,7 +1056,7 @@ func doActivate(ctx *domainContext, config types.DomainConfig,
 			continue
 		}
 
-		snapshotID := getCtrdSnapshotID(ds.FileLocation)
+		snapshotID := containerd.GetSnapshotID(ds.FileLocation)
 		if err := containerd.CtrMountSnapshot(snapshotID, getRoofFsPath(ds.FileLocation)); err != nil {
 			err := fmt.Errorf("doActivate: Failed mount snapshot: %s for %s. Error %s",
 				snapshotID, config.UUIDandVersion.UUID, err)
@@ -2449,8 +2448,4 @@ func isInUsbGroup(aa types.AssignableAdapters, ib types.IoBundle) bool {
 
 func getRoofFsPath(rootPath string) string {
 	return path.Join(rootPath, containerRootfsPath)
-}
-
-func getCtrdSnapshotID(rootPath string) string {
-	return filepath.Base(rootPath)
 }

--- a/pkg/pillar/cmd/upgradeconverter/copy.go
+++ b/pkg/pillar/cmd/upgradeconverter/copy.go
@@ -1,0 +1,134 @@
+/* MIT License
+ *
+ * Copyright (c) 2017 Roland Singer [roland.singer@desertbit.com]
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package upgradeconverter
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+// CopyFile copies the contents of the file named src to the file named
+// by dst. The file will be created if it does not already exist. If the
+// destination file exists, all it's contents will be replaced by the contents
+// of the source file. The file mode will be copied from the source and
+// the copied data is synced/flushed to stable storage.
+func CopyFile(src, dst string) (err error) {
+	in, err := os.Open(src)
+	if err != nil {
+		return
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return
+	}
+	defer func() {
+		if e := out.Close(); e != nil {
+			err = e
+		}
+	}()
+
+	_, err = io.Copy(out, in)
+	if err != nil {
+		return
+	}
+
+	err = out.Sync()
+	if err != nil {
+		return
+	}
+
+	si, err := os.Stat(src)
+	if err != nil {
+		return
+	}
+	err = os.Chmod(dst, si.Mode())
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// CopyDir recursively copies a directory tree, attempting to preserve permissions.
+// Source directory must exist, destination directory must *not* exist.
+// Symlinks are ignored and skipped.
+func CopyDir(src string, dst string) (err error) {
+	src = filepath.Clean(src)
+	dst = filepath.Clean(dst)
+
+	si, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if !si.IsDir() {
+		return fmt.Errorf("source is not a directory")
+	}
+
+	_, err = os.Stat(dst)
+	if err != nil && !os.IsNotExist(err) {
+		return
+	}
+	if err == nil {
+		return fmt.Errorf("destination already exists")
+	}
+
+	err = os.MkdirAll(dst, si.Mode())
+	if err != nil {
+		return
+	}
+
+	entries, err := ioutil.ReadDir(src)
+	if err != nil {
+		return
+	}
+
+	for _, entry := range entries {
+		srcPath := filepath.Join(src, entry.Name())
+		dstPath := filepath.Join(dst, entry.Name())
+
+		if entry.IsDir() {
+			err = CopyDir(srcPath, dstPath)
+			if err != nil {
+				return
+			}
+		} else {
+			// Skip symlinks.
+			if entry.Mode()&os.ModeSymlink != 0 {
+				continue
+			}
+
+			err = CopyFile(srcPath, dstPath)
+			if err != nil {
+				return
+			}
+		}
+	}
+
+	return
+}

--- a/pkg/pillar/cmd/upgradeconverter/inhalelatch.go
+++ b/pkg/pillar/cmd/upgradeconverter/inhalelatch.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package upgradeconverter
+
+// Inhale the persisted latch information for the app instances so we
+// can tell the sha for the OCI volumes
+// Note that we do not look at the latch in volumemgr since that is
+// only for new volumes and content trees.
+
+import (
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	uuid "github.com/satori/go.uuid"
+	log "github.com/sirupsen/logrus"
+)
+
+// All of the latches we found
+type latch struct {
+	latches []types.AppAndImageToHash
+}
+
+func inhaleLatch(ps *pubsub.PubSub) (latch, error) {
+	log.Debugf("inhaleLatch()")
+	var l latch
+
+	pub, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName:  "zedmanager",
+		Persistent: true,
+		TopicType:  types.AppAndImageToHash{},
+	})
+	if err != nil {
+		log.Error(err)
+		return l, err
+	}
+	// The persistent publication has pulled in what is already published
+	items := pub.GetAll()
+	log.Debugf("inhaleLatch found %d", len(items))
+	for _, item := range items {
+		aih := item.(types.AppAndImageToHash)
+		l.latches = append(l.latches, aih)
+	}
+	return l, err
+}
+
+// lookup returns nil if not found
+func (l *latch) lookup(appInstID uuid.UUID, imageID uuid.UUID, purgeCounter uint32) *types.AppAndImageToHash {
+	for i := range l.latches {
+		aih := &l.latches[i]
+		if aih.AppUUID == appInstID && aih.ImageID == imageID &&
+			aih.PurgeCounter == purgeCounter {
+			log.Debugf("latch.lookup found appInstID %s imageID %s purgeCounter %d",
+				appInstID, imageID, purgeCounter)
+			return aih
+		}
+	}
+	log.Debugf("latch.lookup NOT found appInstID %s imageID %s purgeCounter %d",
+		appInstID, imageID, purgeCounter)
+	return nil
+}

--- a/pkg/pillar/cmd/upgradeconverter/oldvolumes.go
+++ b/pkg/pillar/cmd/upgradeconverter/oldvolumes.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package upgradeconverter
+
+// Look for old VM and OCI volumes in /persist
+
+import (
+	"io/ioutil"
+	"os"
+	"time"
+
+	uuid "github.com/satori/go.uuid"
+	log "github.com/sirupsen/logrus"
+)
+
+// We fill in this based on the files/dirs we find on disk
+type oldVolume struct {
+	pathname     string
+	sha256       string
+	appInstID    uuid.UUID
+	purgeCounter uint32
+	format       string
+	modTime      time.Time // If we have multiple we pick latest
+}
+
+// recursive scanning for volumes
+func scanDir(dirName string, isContainer bool) []oldVolume {
+
+	log.Debugf("scanDir(%s)", dirName)
+	var old []oldVolume
+
+	locations, err := ioutil.ReadDir(dirName)
+	if err != nil {
+		log.Errorf("scanDir: read directory '%s' failed: %v",
+			dirName, err)
+		return old
+	}
+
+	for _, location := range locations {
+		filelocation := dirName + "/" + location.Name()
+		if location.IsDir() && !isContainer {
+			log.Debugf("scanDir: directory %s ignored", filelocation)
+			continue
+		}
+		info, err := os.Stat(filelocation)
+		if err != nil {
+			log.Errorf("Error in getting file information. Err: %s. "+
+				"Ignoring file %s", err, filelocation)
+			continue
+		}
+		_, sha256, appUUIDStr, purgeCounter, format := parseAppRwVolumeName(filelocation, isContainer)
+		log.Infof("scanDir: Processing sha256: %s, AppUuid: %s, "+
+			"fileLocation:%s, format:%s",
+			sha256, appUUIDStr, filelocation, format)
+
+		appUUID, err := uuid.FromString(appUUIDStr)
+		if err != nil {
+			log.Errorf("scanDir: Invalid UUIDStr(%s) in "+
+				"filename (%s). err: %s. Ignored",
+				appUUIDStr, filelocation, err)
+			continue
+		}
+		item := oldVolume{
+			sha256:       sha256,
+			appInstID:    appUUID,
+			purgeCounter: purgeCounter,
+			format:       format,
+			pathname:     filelocation,
+			modTime:      info.ModTime(),
+		}
+		old = append(old, item)
+	}
+	return old
+}

--- a/pkg/pillar/cmd/upgradeconverter/parseconfig.go
+++ b/pkg/pillar/cmd/upgradeconverter/parseconfig.go
@@ -1,0 +1,214 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package upgradeconverter
+
+// Parse the checkpointed protobuf file to determine the relationship between
+// app instances and their drives and the volumes
+
+import (
+	"io/ioutil"
+
+	"github.com/golang/protobuf/proto"
+	zconfig "github.com/lf-edge/eve/api/go/config"
+	uuid "github.com/satori/go.uuid"
+	log "github.com/sirupsen/logrus"
+)
+
+type parseResult struct {
+	volumes      []volumeInfo
+	appInsts     []driveAndVolumeRef
+	contentTrees []contentTree
+}
+
+func parseConfig(checkpointFile string) (parseResult, error) {
+	res := parseResult{}
+	config, err := readSavedProtoMessage(checkpointFile)
+	if err != nil {
+		return res, err
+	}
+	cts, err := parseContentTrees(config)
+	if err != nil {
+		return res, err
+	}
+	for i, ct := range cts {
+		log.Debugf("content tree[%d] ctID %s displayName %s relativeURL %s sha256 %s gc %d",
+			i, ct.contentTreeID, ct.displayName, ct.relativeURL,
+			ct.sha256, ct.generationCounter)
+	}
+	res.contentTrees = cts
+	volumes, err := parseVolumes(config)
+	if err != nil {
+		return res, err
+	}
+	for i, vi := range volumes {
+		log.Debugf("volume[%d] volumeID %s ctID %s imageURL %s sha256 %s gc %d",
+			i, vi.volumeID, vi.contentTreeID, vi.imageURL, vi.sha256,
+			vi.generationCounter)
+	}
+	res.volumes = volumes
+	appInsts, err := parseAppInstances(config)
+	if err != nil {
+		return res, err
+	}
+	for i, ai := range appInsts {
+		log.Debugf("app inst[%d] appInstID %s imageID %s imageName %s sha256 %s purgeCounter %d volumeID %s gc %d",
+			i, ai.appInstID, ai.imageID, ai.imageName, ai.sha256,
+			ai.purgeCounter, ai.volumeID, ai.generationCounter)
+	}
+	res.appInsts = appInsts
+
+	return res, nil
+}
+
+func readSavedProtoMessage(filename string) (*zconfig.EdgeDevConfig, error) {
+	contents, err := ioutil.ReadFile(filename)
+	if err != nil {
+		log.Errorln("readSavedProtoMessage", err)
+		return nil, err
+	}
+	var configResponse = &zconfig.ConfigResponse{}
+	err = proto.Unmarshal(contents, configResponse)
+	if err != nil {
+		log.Errorf("readSavedProtoMessage Unmarshalling failed: %v",
+			err)
+		return nil, err
+	}
+	config := configResponse.GetConfig()
+	return config, nil
+}
+
+func parseAppInstances(config *zconfig.EdgeDevConfig) ([]driveAndVolumeRef, error) {
+	var appInsts []driveAndVolumeRef
+
+	apps := config.GetApps()
+	log.Debugf("parseAppInstances %d apps", len(apps))
+	for i, cfgApp := range apps {
+		appInstID, _ := uuid.FromString(cfgApp.Uuidandversion.Uuid)
+		drives := cfgApp.GetDrives()
+		volumeRefs := cfgApp.GetVolumeRefList()
+
+		var purgeCounter uint32
+		cmd := cfgApp.GetPurge()
+		if cmd != nil {
+			purgeCounter = cmd.Counter
+		}
+		log.Infof("parseAppInstances[%d] %d drives %d volumeRefs",
+			i, len(drives), len(volumeRefs))
+
+		davr := make([]driveAndVolumeRef, len(drives))
+		for i, drive := range drives {
+			image := drive.GetImage()
+			imageID, _ := uuid.FromString(image.Uuidandversion.Uuid)
+			davr[i].appInstID = appInstID
+			davr[i].imageID = imageID
+			davr[i].imageName = image.Name
+			davr[i].sha256 = image.Sha256
+			// Just like zedagent we apply the purgeCounter to the
+			// first disk
+			if i == 0 && purgeCounter != 0 {
+				log.Infof("parseAppInstances setting purgeCounter to %d  for appInstID %s imageID %s",
+					purgeCounter, appInstID, imageID)
+				davr[i].purgeCounter = purgeCounter
+			}
+			if len(volumeRefs) > i {
+				volumeID, _ := uuid.FromString(volumeRefs[i].Uuid)
+				davr[i].volumeID = volumeID
+				davr[i].generationCounter = volumeRefs[i].GenerationCount
+			}
+		}
+		appInsts = append(appInsts, davr...)
+	}
+	return appInsts, nil
+}
+
+func parseVolumes(config *zconfig.EdgeDevConfig) ([]volumeInfo, error) {
+
+	var volumes []volumeInfo
+	vols := config.GetVolumes()
+	log.Debugf("parseVolumes %d volumes", len(vols))
+	for _, vol := range vols {
+		volumeID, _ := uuid.FromString(vol.Uuid)
+		vco := vol.GetOrigin()
+		var ctID uuid.UUID
+		if vco != nil {
+			ctID, _ = uuid.FromString(vco.DownloadContentTreeID)
+		}
+		vi := volumeInfo{
+			volumeID:      volumeID,
+			contentTreeID: ctID,
+		}
+		volumes = append(volumes, vi)
+	}
+	return volumes, nil
+}
+
+func parseContentTrees(config *zconfig.EdgeDevConfig) ([]contentTree, error) {
+
+	var cts []contentTree
+	zcts := config.GetContentInfo()
+	log.Debugf("parseContentTrees %d contentTrees", len(zcts))
+	for _, zct := range zcts {
+		ctID, _ := uuid.FromString(zct.Uuid)
+		ct := contentTree{
+			contentTreeID:     ctID,
+			relativeURL:       zct.GetURL(),
+			sha256:            zct.GetSha256(),
+			displayName:       zct.GetDisplayName(),
+			generationCounter: zct.GetGenerationCount(),
+		}
+		cts = append(cts, ct)
+	}
+	return cts, nil
+}
+
+// lookupContentTree returns nil if not found
+func (pr parseResult) lookupContentTree(ctID uuid.UUID) *contentTree {
+	for i := range pr.contentTrees {
+		ct := &pr.contentTrees[i]
+		if ct.contentTreeID == ctID {
+			log.Debugf("lookupContentTree found %s", ctID)
+			return ct
+		}
+	}
+	log.Errorf("lookupContentTree NOT found %s", ctID)
+	return nil
+}
+
+// lookupDriveAndVolumeRef returns nil if not found
+func (pr parseResult) lookupDriveAndVolumeRef(appInstID uuid.UUID, sha256 string) *driveAndVolumeRef {
+	for i := range pr.appInsts {
+		dlvr := &pr.appInsts[i]
+		if dlvr.appInstID == appInstID && dlvr.sha256 == sha256 {
+			log.Debugf("lookupAppInst found %s sha %s",
+				appInstID, sha256)
+			return dlvr
+		}
+	}
+	log.Errorf("lookupAppInst NOT found %s", appInstID)
+	return nil
+}
+
+// lookupVolume returns nil if not found
+// Note that we don't think we need compare on generationCounter, since
+// we will have different UUIDs when the generation changes for the time being.
+// Thus for the upgradeconversion we match without the generationCounter
+// but log the difference.
+func (pr parseResult) lookupVolume(volumeID uuid.UUID, generationCounter int64) *volumeInfo {
+	for i := range pr.volumes {
+		vi := &pr.volumes[i]
+		if vi.volumeID == volumeID {
+			if vi.generationCounter == generationCounter {
+				log.Infof("lookupVolume found %s#%d",
+					volumeID, generationCounter)
+			} else {
+				log.Infof("lookupVolume almost found %s#%d: gc %d",
+					volumeID, generationCounter,
+					vi.generationCounter)
+			}
+			return vi
+		}
+	}
+	log.Errorf("lookupVolume NOT found %s#%d", volumeID, generationCounter)
+	return nil
+}

--- a/pkg/pillar/cmd/upgradeconverter/persistlayout.go
+++ b/pkg/pillar/cmd/upgradeconverter/persistlayout.go
@@ -1,0 +1,284 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package upgradeconverter
+
+// Rename volumes in /persist from old format (appinst+sha) to new format (volumeID) and move to /persist/vault for both VM and OCI volumes.
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	uuid "github.com/satori/go.uuid"
+	log "github.com/sirupsen/logrus"
+)
+
+func convertPersistVolumes(ctxPtr *ucContext) error {
+	log.Infof("convertPersistVolumes()")
+	checkpointFile := ctxPtr.configCheckpointFile()
+	if !fileExists(checkpointFile) {
+		// This error always happens on first boot of a device.
+		// In that case there is nothing to convert.
+		errStr := fmt.Sprintf("No checkpoint file in %s", checkpointFile)
+		log.Errorf(errStr)
+		return errors.New(errStr)
+	}
+	latch, err := inhaleLatch(ctxPtr.ps) // XXX override dir in pubsub?
+	if err != nil {
+		log.Errorf("inhaleLatch failed: %s", err)
+		// Proceed since not all volumes depend on the latch
+	}
+	pr, err := parseConfig(checkpointFile)
+	if err != nil {
+		return err
+	}
+	pr.propagateInfo()
+	pr.applyLatch(latch)
+
+	oldVMVolumesDir := ctxPtr.imgDir()
+	oldOCIVolumesDir := ctxPtr.preparedDir()
+	newVolumesDir := ctxPtr.volumesDir()
+	newExists := dirExists(newVolumesDir)
+	oldVMExists := dirExists(oldVMVolumesDir)
+	oldOCIExists := dirExists(oldOCIVolumesDir)
+	if !newExists {
+		log.Infof("Creating new %s", newVolumesDir)
+		if err := os.MkdirAll(newVolumesDir, 0700); err != nil {
+			return err
+		}
+	}
+	log.Infof("new %t oldVM %t oldOCI %t", newExists, oldVMExists,
+		oldOCIExists)
+	var old1, old2 []oldVolume
+	if oldVMExists {
+		old1 = scanDir(oldVMVolumesDir, false)
+	}
+	if oldOCIExists {
+		old2 = scanDir(oldOCIVolumesDir, true)
+	}
+	old := append(old1, old2...)
+	log.Debugf("Found %d oldVolumes: %+v", len(old), old)
+	for i, ov := range old {
+		dlvr := pr.lookupDriveAndVolumeRef(ov.appInstID, ov.sha256)
+		if dlvr == nil {
+			log.Errorf("old %d dlvr not found for uuid %s sha %s",
+				i, ov.appInstID, ov.sha256)
+			continue
+		}
+		log.Infof("DLVR %d used by appInst %s, path %s",
+			i, ov.appInstID, ov.pathname)
+		// Note that we get the generationCounter from the volumeRef
+		// which is most likely zero even if the old volume had a
+		// non-zero purgeCounter
+		newPath := fmt.Sprintf("%s/%s#%d.%s", newVolumesDir,
+			dlvr.volumeID, dlvr.generationCounter, ov.format)
+		log.Infof("DLVR %d volumeID %s generationCounter %d, purgeCounter %d, format %s, new path %s",
+			i, dlvr.volumeID, dlvr.generationCounter,
+			dlvr.purgeCounter, ov.format, newPath)
+		if dlvr.sha256 != ov.sha256 {
+			log.Errorf("DLVR %d sha mismatch %s vs %s",
+				i, dlvr.sha256, ov.sha256)
+			continue
+		}
+		maybeMove(ov.pathname, ov.modTime, newPath, ctxPtr.noFlag)
+	}
+	return nil
+}
+
+// If newPath doesn't exist, then move.
+// Otherwise we replace/move if the old file has a more recent modtime
+// If noFlag is set we just log and no file system modifications.
+func maybeMove(oldPath string, oldModTime time.Time, newPath string, noFlag bool) {
+	info, err := os.Stat(newPath)
+	if err == nil {
+		newModTime := info.ModTime()
+		if newModTime.After(oldModTime) {
+			log.Infof("New file %s newer than old %s: %s vs. %s. Not replaced",
+				newPath, oldPath,
+				oldModTime.Format(time.RFC3339Nano),
+				newModTime.Format(time.RFC3339Nano))
+			return
+		}
+		log.Warnf("New file %s newer than old %s: %s vs. %s. Replacing %t",
+			newPath, oldPath,
+			oldModTime.Format(time.RFC3339Nano),
+			newModTime.Format(time.RFC3339Nano), !noFlag)
+		if !noFlag {
+			if err := os.RemoveAll(newPath); err != nil {
+				log.Errorf("Removing new: %s", err)
+			}
+		}
+	}
+	log.Infof("Moving %s to %s: %t", oldPath, newPath, !noFlag)
+	if !noFlag {
+		// Can not rename between vault directories so we
+		// have to copy and delete.
+		fi, err := os.Stat(oldPath)
+		if err != nil {
+			log.Errorf("stat failed: %s", err)
+			return
+		}
+		if fi.IsDir() {
+			if err := CopyDir(oldPath, newPath); err != nil {
+				log.Errorf("cp old to new failed: %s", err)
+			} else {
+				err := os.RemoveAll(oldPath)
+				if err != nil {
+					log.Errorf("Remove old failed: %s", err)
+				}
+			}
+		} else {
+			if err := CopyFile(oldPath, newPath); err != nil {
+				log.Errorf("cp old to new failed: %s", err)
+			} else {
+				err := os.Remove(oldPath)
+				if err != nil {
+					log.Errorf("Remove old failed: %s", err)
+				}
+			}
+		}
+	}
+}
+
+func cp(dst, src string) error {
+	if strings.Compare(dst, src) == 0 {
+		log.Fatalf("Same src and dst: %s", src)
+	}
+	s, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	// no need to check errors on read only file, we already got everything
+	// we need from the filesystem, so nothing can go wrong now.
+	defer s.Close()
+	d, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(d, s); err != nil {
+		d.Close()
+		return err
+	}
+	return d.Close()
+}
+
+// From the AppInstanceConfig protbuf message.
+// driveAndVolume has one entry per <app,drive> based on the old Drive API
+// thus multiple per app instance if the instance has multiple drives
+// We fill in volumeID and generationCounter from the volumeRef API
+type driveAndVolumeRef struct {
+	appInstID         uuid.UUID
+	imageID           uuid.UUID // From drive in API
+	imageName         string    // Only used in debug loh
+	sha256            string    // If not set will be picked from latch
+	purgeCounter      uint32    // Set from purge.counter for the first volume
+	volumeID          uuid.UUID // From volumeRef in API
+	generationCounter int64     // From volumeRef in API
+}
+
+// From the Volume protobuf message
+type volumeInfo struct {
+	volumeID          uuid.UUID
+	contentTreeID     uuid.UUID // Not same as ImageID?
+	generationCounter int64
+	imageURL          string // From ContentTree
+	sha256            string // From ContentTree
+}
+
+// From the ContentTree protobuf message
+type contentTree struct {
+	contentTreeID     uuid.UUID
+	relativeURL       string
+	displayName       string
+	sha256            string
+	generationCounter int64
+}
+
+// propagateInfo takes missing info from contentTree etc to fill in volumeInfo
+func (pr *parseResult) propagateInfo() {
+	for i := range pr.volumes {
+		vi := &pr.volumes[i]
+		ct := pr.lookupContentTree(vi.contentTreeID)
+		if ct == nil {
+			continue
+		}
+		if vi.sha256 == "" {
+			log.Infof("volume[%d] volumeID %s setting sha from ctID %s: %s",
+				i, vi.volumeID, vi.contentTreeID, ct.sha256)
+			vi.sha256 = ct.sha256
+		}
+		if vi.imageURL == "" {
+			log.Infof("volume[%d] volumeID %s setting imageURL from ctID %s: %s",
+				i, vi.volumeID, vi.contentTreeID, ct.relativeURL)
+			vi.imageURL = ct.relativeURL
+		}
+	}
+}
+
+// applyLatch takes missing info from contentTree etc to fill in volumeInfo
+func (pr *parseResult) applyLatch(l latch) {
+	for i := range pr.appInsts {
+		davr := &pr.appInsts[i]
+		aih := l.lookup(davr.appInstID, davr.imageID, davr.purgeCounter)
+		if aih == nil {
+			continue
+		}
+		if davr.sha256 == "" {
+			log.Infof("app inst[%d] appInstID %s imageID %s purge %d setting sha: %s",
+				i, davr.appInstID, davr.imageID,
+				davr.purgeCounter, aih.Hash)
+			davr.sha256 = aih.Hash
+		}
+	}
+}
+
+// parseAppRwVolumeName - Returns rwImgDirname, sha256, uuidStr, purgeCounter, format
+// Copied from the old one in volumemgr, but added returning of format string
+func parseAppRwVolumeName(image string, isContainer bool) (string, string, string, uint32, string) {
+	// VolumeSha is provided by the controller - it can be uppercase
+	// or lowercase.
+	var re1 *regexp.Regexp
+	var re2 *regexp.Regexp
+	var format string
+	if isContainer {
+		re1 = regexp.MustCompile(`(.+)/([0-9A-Fa-f]+)-([0-9a-fA-F\-]+)#([0-9]+)`)
+		format = "container"
+	} else {
+		re1 = regexp.MustCompile(`(.+)/([0-9A-Fa-f]+)-([0-9a-fA-F\-]+)#([0-9]+)\.(.+)`)
+	}
+	if re1.MatchString(image) {
+		// With purgeCounter
+		parsedStrings := re1.FindStringSubmatch(image)
+		count, err := strconv.ParseUint(parsedStrings[4], 10, 32)
+		if err != nil {
+			log.Error(err)
+			count = 0
+		}
+		if !isContainer {
+			format = parsedStrings[5]
+		}
+		return parsedStrings[1], parsedStrings[2], parsedStrings[3],
+			uint32(count), format
+	}
+	// Without purgeCounter
+	if isContainer {
+		re2 = regexp.MustCompile(`(.+)/([0-9A-Fa-f]+)-([0-9a-fA-F\-]+)`)
+	} else {
+		re2 = regexp.MustCompile(`(.+)/([0-9A-Fa-f]+)-([0-9a-fA-F\-]+)\.([^\.]+)`)
+	}
+	if !re2.MatchString(image) {
+		log.Errorf("AppRwVolumeName %s doesn't match pattern", image)
+		return "", "", "", 0, format
+	}
+	parsedStrings := re2.FindStringSubmatch(image)
+	if !isContainer {
+		format = parsedStrings[4]
+	}
+	return parsedStrings[1], parsedStrings[2], parsedStrings[3], 0, format
+}

--- a/pkg/pillar/cmd/upgradeconverter/persistlayout.go
+++ b/pkg/pillar/cmd/upgradeconverter/persistlayout.go
@@ -9,7 +9,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -132,6 +134,18 @@ func maybeMove(oldPath string, oldModTime time.Time, newPath string, noFlag bool
 				if err != nil {
 					log.Errorf("Remove old failed: %s", err)
 				}
+			}
+			// For containers we save the old basename in a file
+			snapshotID := filepath.Base(oldPath)
+			filename := filepath.Join(newPath, "snapshotid.txt")
+			err := ioutil.WriteFile(filename, []byte(snapshotID),
+				0644)
+			if err != nil {
+				log.Errorf("Save snapshotID %s failed: %s",
+					snapshotID, err)
+			} else {
+				log.Infof("Saved snapshotID %s in %s",
+					snapshotID, filename)
 			}
 		} else {
 			if err := CopyFile(oldPath, newPath); err != nil {

--- a/pkg/pillar/cmd/upgradeconverter/upgradeconverter.go
+++ b/pkg/pillar/cmd/upgradeconverter/upgradeconverter.go
@@ -18,15 +18,22 @@ var conversionHandlers = []ConversionHandler{
 		description: "Convert Global Settings to new format",
 		handlerFunc: convertGlobalConfig,
 	},
+	{
+		description: "Move volumes to /persist/vault",
+		handlerFunc: convertPersistVolumes,
+	},
 }
 
 type ucContext struct {
 	agentName     string
 	debugOverride bool
+	noFlag        bool
 
 	// FilePaths. These are defined here instead of consts for easier unit tests
+	persistDir       string
 	persistConfigDir string
 	varTmpDir        string
+	ps               *pubsub.PubSub
 }
 
 func (ctx ucContext) configItemValueMapDir() string {
@@ -40,6 +47,26 @@ func (ctx ucContext) globalConfigDir() string {
 }
 func (ctx ucContext) globalConfigFile() string {
 	return ctx.globalConfigDir() + "/global.json"
+}
+
+// Old location for volumes
+func (ctx ucContext) imgDir() string {
+	return ctx.persistDir + "/img/"
+}
+
+// Old location for volumes
+func (ctx ucContext) preparedDir() string {
+	return ctx.persistDir + "/runx/pods/prepared/"
+}
+
+// New location for volumes
+func (ctx ucContext) volumesDir() string {
+	return ctx.persistDir + "/vault/volumes/"
+}
+
+// checkpoint file for EdgeDevConfig
+func (ctx ucContext) configCheckpointFile() string {
+	return ctx.persistDir + "/checkpoint/lastconfig"
 }
 
 func runHandlers(ctxPtr *ucContext) {
@@ -58,11 +85,18 @@ func runHandlers(ctxPtr *ucContext) {
 func Run(ps *pubsub.PubSub) {
 	log.Infof("upgradeconverter.Run")
 	ctx := &ucContext{agentName: "upgradeconverter",
+		persistDir:       types.PersistDir,
 		persistConfigDir: types.PersistConfigDir,
-		varTmpDir:        "/var/tmp"}
+		varTmpDir:        "/var/tmp",
+		ps:               ps,
+	}
 	debugPtr := flag.Bool("d", false, "Debug flag")
+	persistPtr := flag.String("p", "/persist", "persist directory")
+	noFlagPtr := flag.Bool("n", false, "Don't do anything just log flag")
 	flag.Parse()
 	ctx.debugOverride = *debugPtr
+	ctx.persistDir = *persistPtr // XXX remove? Or use for tests?
+	ctx.noFlag = *noFlagPtr
 	if ctx.debugOverride {
 		log.SetLevel(log.DebugLevel)
 	} else {

--- a/pkg/pillar/cmd/upgradeconverter/upgradeconverter.go
+++ b/pkg/pillar/cmd/upgradeconverter/upgradeconverter.go
@@ -83,7 +83,6 @@ func runHandlers(ctxPtr *ucContext) {
 
 // Run - runs the main upgradeconverter process
 func Run(ps *pubsub.PubSub) {
-	log.Infof("upgradeconverter.Run")
 	ctx := &ucContext{agentName: "upgradeconverter",
 		persistDir:       types.PersistDir,
 		persistConfigDir: types.PersistConfigDir,

--- a/pkg/pillar/cmd/upgradeconverter/upgradeconverter_test.go
+++ b/pkg/pillar/cmd/upgradeconverter/upgradeconverter_test.go
@@ -102,6 +102,10 @@ func ucContextForTest() *ucContext {
 	//log.SetLevel(log.DebugLevel)
 	var err error
 	ctxPtr := &ucContext{}
+	ctxPtr.persistDir, err = ioutil.TempDir(".", "PersistDir")
+	if err != nil {
+		log.Fatalf("Failed to create persistDir. err: %s", err)
+	}
 	ctxPtr.persistConfigDir, err = ioutil.TempDir(".", "Converter")
 	if err != nil {
 		log.Fatalf("Failed to create persistConfigDir. err: %s", err)
@@ -114,6 +118,8 @@ func ucContextForTest() *ucContext {
 }
 
 func ucContextCleanupDirs(ctxPtr *ucContext) {
+	os.RemoveAll(ctxPtr.persistDir)
+	ctxPtr.persistDir = ""
 	os.RemoveAll(ctxPtr.persistConfigDir)
 	ctxPtr.persistConfigDir = ""
 	os.RemoveAll(ctxPtr.varTmpDir)

--- a/pkg/pillar/cmd/upgradeconverter/upgradeconverterutils.go
+++ b/pkg/pillar/cmd/upgradeconverter/upgradeconverterutils.go
@@ -22,6 +22,19 @@ func fileExists(filename string) bool {
 	return false
 }
 
+func dirExists(dirname string) bool {
+	fi, err := os.Stat(dirname)
+	if err == nil {
+		return fi.IsDir()
+	}
+	if os.IsNotExist(err) {
+		return false
+	}
+	log.Errorf("***Directory %s may or may not exist. Err: %s",
+		dirname, err)
+	return false
+}
+
 func fileTimeStamp(filename string) (time.Time, error) {
 	file, err := os.Stat(filename)
 	if err != nil {


### PR DESCRIPTION
This extracts information about the relationship between the Drive, VolumeRef, and Volumes in the API to determine how to rename the files in /persist/img and /persist/runx/pods/prepared to have names based on volumeID#generationCounter in /persist/vault/volumes/

It extracts the latch information from /persist/status/zedmanager/AppAndImageToHash for the OCI-based volumes which only specified a tag.

The third commit is some additional logic needed to preserve the snapshotID (it is the last component of the directory name, which changes from SHA-appinstUUID to volumeUUID with the volume work).

Manual upgrade passes (on top of PR 1102) for a VM and a container.