### PR TITLE
attest API support, software based ECDH Certificate and related changes.

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -251,6 +251,21 @@ func Run(ps *pubsub.PubSub) {
 	domainCtx.decryptCipherContext.SubControllerCert = subControllerCert
 	subControllerCert.Activate()
 
+	// Look for eve node certs which will be used for decryption
+	subEveNodeCert, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:   "tpmmgr",
+		TopicImpl:   types.EveNodeCert{},
+		Activate:    false,
+		Ctx:         &domainCtx,
+		WarningTime: warningTime,
+		ErrorTime:   errorTime,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	domainCtx.decryptCipherContext.SubEveNodeCert = subEveNodeCert
+	subEveNodeCert.Activate()
+
 	// Look for cipher context which will be used for decryption
 	subCipherContext, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:   "zedagent",
@@ -398,6 +413,9 @@ func Run(ps *pubsub.PubSub) {
 		select {
 		case change := <-subControllerCert.MsgChan():
 			subControllerCert.ProcessChange(change)
+
+		case change := <-subEveNodeCert.MsgChan():
+			subEveNodeCert.ProcessChange(change)
 
 		case change := <-subCipherContext.MsgChan():
 			subCipherContext.ProcessChange(change)

--- a/pkg/pillar/cmd/downloader/context.go
+++ b/pkg/pillar/cmd/downloader/context.go
@@ -52,6 +52,21 @@ func (ctx *downloaderContext) registerHandlers(ps *pubsub.PubSub) error {
 	ctx.decryptCipherContext.SubControllerCert = subControllerCert
 	subControllerCert.Activate()
 
+	// Look for eve node certs which will be used for decryption
+	subEveNodeCert, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:   "tpmmgr",
+		TopicImpl:   types.EveNodeCert{},
+		Activate:    false,
+		Ctx:         ctx,
+		WarningTime: warningTime,
+		ErrorTime:   errorTime,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	ctx.decryptCipherContext.SubEveNodeCert = subEveNodeCert
+	subEveNodeCert.Activate()
+
 	// Look for cipher context which will be used for decryption
 	subCipherContext, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:   "zedagent",

--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -143,6 +143,9 @@ func Run(ps *pubsub.PubSub) {
 		case change := <-ctx.decryptCipherContext.SubControllerCert.MsgChan():
 			ctx.decryptCipherContext.SubControllerCert.ProcessChange(change)
 
+		case change := <-ctx.decryptCipherContext.SubEveNodeCert.MsgChan():
+			ctx.decryptCipherContext.SubEveNodeCert.ProcessChange(change)
+
 		case change := <-ctx.decryptCipherContext.SubCipherContext.MsgChan():
 			ctx.decryptCipherContext.SubCipherContext.ProcessChange(change)
 

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -177,6 +177,21 @@ func Run(ps *pubsub.PubSub) {
 	nimCtx.deviceNetworkContext.DecryptCipherContext.SubControllerCert = subControllerCert
 	subControllerCert.Activate()
 
+	// Look for eve node certs which will be used for decryption
+	subEveNodeCert, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:   "tpmmgr",
+		TopicImpl:   types.EveNodeCert{},
+		Activate:    false,
+		Ctx:         &nimCtx,
+		WarningTime: warningTime,
+		ErrorTime:   errorTime,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	nimCtx.deviceNetworkContext.DecryptCipherContext.SubEveNodeCert = subEveNodeCert
+	subEveNodeCert.Activate()
+
 	// Look for cipher context which will be used for decryption
 	subCipherContext, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:   "zedagent",
@@ -555,6 +570,9 @@ func Run(ps *pubsub.PubSub) {
 		select {
 		case change := <-subControllerCert.MsgChan():
 			subControllerCert.ProcessChange(change)
+
+		case change := <-subEveNodeCert.MsgChan():
+			subEveNodeCert.ProcessChange(change)
 
 		case change := <-subCipherContext.MsgChan():
 			subCipherContext.ProcessChange(change)

--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -9,19 +9,34 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/lf-edge/eve/api/go/attest"
 	zcert "github.com/lf-edge/eve/api/go/certs"
+	zconfig "github.com/lf-edge/eve/api/go/config"
+	"github.com/lf-edge/eve/api/go/evecommon"
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 	"github.com/lf-edge/eve/pkg/pillar/zedcloud"
 	log "github.com/sirupsen/logrus"
 )
 
-var certHash []byte
+// Cipher Information Context
+type cipherContext struct {
+	zedagentCtx *zedagentContext // Cross link
+
+	// post and get certs triggers
+	triggerEveNodeCerts    chan struct{}
+	triggerControllerCerts chan struct{}
+
+	cfgControllerCertHash []byte
+	iteration             int
+}
 
 // parse and update controller certs
 func parseControllerCerts(ctx *zedagentContext, contents []byte) {
@@ -39,16 +54,16 @@ func parseControllerCerts(ctx *zedagentContext, contents []byte) {
 		computeConfigElementSha(h, cfgCert)
 	}
 	newHash := h.Sum(nil)
-	if bytes.Equal(newHash, certHash) {
+	if bytes.Equal(newHash, ctx.cipherCtx.cfgControllerCertHash) {
 		return
 	}
 	log.Infof("parseControllerCerts: Applying updated config "+
 		"Last Sha: % x, "+
 		"New  Sha: % x, "+
 		"Num of cfgCert: %d",
-		certHash, newHash, len(cfgCerts))
+		ctx.cipherCtx.cfgControllerCertHash, newHash, len(cfgCerts))
 
-	certHash = newHash
+	ctx.cipherCtx.cfgControllerCertHash = newHash
 
 	// First look for deleted ones
 	items := ctx.getconfigCtx.pubControllerCert.GetAll()
@@ -127,70 +142,172 @@ func unpublishControllerCert(ctx *getconfigContext, key string) {
 func handleEveNodeCertModify(ctxArg interface{}, key string,
 	configArg interface{}) {
 
-	// XXX TBD
+	ctx := ctxArg.(*zedagentContext)
 	status := configArg.(types.EveNodeCert)
 	log.Infof("handleEveNodeCertModify for %s", status.Key())
+	triggerEveNodeCertEvent(ctx)
 	return
 }
 
 func handleEveNodeCertDelete(ctxArg interface{}, key string,
 	configArg interface{}) {
 
-	// XXX TBD
+	ctx := ctxArg.(*zedagentContext)
 	status := configArg.(types.EveNodeCert)
 	log.Infof("handleEveNodeCertDelete for %s", status.Key())
+	triggerEveNodeCertEvent(ctx)
 	return
 }
 
 // Run a task certificate post task, on change trigger
-func certsTask(ctx *zedagentContext, triggerCerts <-chan struct{}) {
-	iteration := 0
-	log.Infoln("starting certs publish task")
-	publishCerts(ctx, iteration)
+func controllerCertsTask(ctx *zedagentContext, triggerCerts <-chan struct{}) {
+
+	log.Infoln("starting controller fetch task")
+	getCertsFromController(ctx)
 
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(25 * time.Second)
-	agentlog.StillRunning(agentName+"certs", warningTime, errorTime)
+	agentlog.StillRunning(agentName+"ccerts", warningTime, errorTime)
 
 	for {
 		select {
 		case <-triggerCerts:
 			start := time.Now()
-			iteration++
-			publishCerts(ctx, iteration)
-			pubsub.CheckMaxTimeTopic(agentName+"certs", "publishCerts", start,
+			getCertsFromController(ctx)
+			pubsub.CheckMaxTimeTopic(agentName+"ccerts", "publishCerts", start,
 				warningTime, errorTime)
 
 		case <-stillRunning.C:
 		}
-		agentlog.StillRunning(agentName+"certs", warningTime, errorTime)
+		agentlog.StillRunning(agentName+"ccerts", warningTime, errorTime)
 	}
 }
 
 // prepare the certs list proto message
-func publishCerts(ctx *zedagentContext, iteration int) {
+func getCertsFromController(ctx *zedagentContext) bool {
+	certURL := zedcloud.URLPathString(serverNameAndPort,
+		zedcloudCtx.V2API, nilUUID, "certs")
+
+	// not V2API
+	if !zedcloud.UseV2API() {
+		return false
+	}
+
+	resp, contents, rtf, err := zedcloud.SendOnAllIntf(&zedcloudCtx,
+		certURL, 0, nil, 0, false)
+	if err != nil {
+		if rtf == types.SenderStatusRemTempFail {
+			log.Infof("getCertsFromController remoteTemporaryFailure: %s", err)
+		} else {
+			log.Errorf("getCertsFromController failed: %s", err)
+		}
+		return false
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusCreated, http.StatusNotModified:
+		log.Infof("getCertsFromController: status %s", resp.Status)
+	default:
+		log.Errorf("getCertsFromController: failed, statuscode %d %s",
+			resp.StatusCode, http.StatusText(resp.StatusCode))
+		return false
+	}
+
+	err = validateProtoMessage(certURL, resp)
+	if err != nil {
+		log.Errorf("getCertsFromController: resp header error")
+		return false
+	}
+
+	// for cipher object handling
+	parseControllerCerts(ctx, contents)
+
+	// TBD:XXX needed for MITM, accordingly refactor
+	certBytes, err := zedcloud.VerifySigningCertChain(&zedcloudCtx, contents)
+	if err != nil {
+		log.Errorf("getCertsFromController: verify err %v", err)
+		return false
+	}
+	err = fileutils.WriteRename(types.ServerSigningCertFileName, certBytes)
+	if err != nil {
+		log.Errorf("getCertsFromController: file save err %v", err)
+		return false
+	}
+
+	log.Infof("getCertsFromController: success")
+	return true
+}
+
+// eve node certificate post task, on change trigger
+func eveNodeCertsTask(ctx *zedagentContext, triggerEveNodeCerts chan struct{}) {
+	log.Infoln("starting eve node certificates publish task")
+
+	publishEveNodeCertsToController(ctx)
+
+	stillRunning := time.NewTicker(25 * time.Second)
+	agentlog.StillRunning(agentName+"attest", warningTime, errorTime)
+
+	for {
+		select {
+		case <-triggerEveNodeCerts:
+			start := time.Now()
+			publishEveNodeCertsToController(ctx)
+			pubsub.CheckMaxTimeTopic(agentName+"attest",
+				"publishEveNodeCertsToController", start,
+				warningTime, errorTime)
+
+		case <-stillRunning.C:
+		}
+		agentlog.StillRunning(agentName+"attest", warningTime, errorTime)
+	}
+}
+
+// prepare the eve node certs list proto message
+func publishEveNodeCertsToController(ctx *zedagentContext) {
 	var attestReq = &attest.ZAttestReq{}
 
+	// not V2API
+	if !zedcloud.UseV2API() {
+		return
+	}
+
+	attestReq = new(attest.ZAttestReq)
+	startPubTime := time.Now()
 	attestReq.ReqType = attest.ZAttestReqType_ATTEST_REQ_CERT
 	// no quotes
 
-	// TBD:XXX, get the ECDH Certs here
+	sub := ctx.subEveNodeCert
+	items := sub.GetAll()
+	for _, item := range items {
+		config := item.(types.EveNodeCert)
+		certMsg := zcert.ZCert{
+			HashAlgo: convertLocalToApiHashAlgo(config.HashAlgo),
+			Type:     convertLocalToApiCertType(config.CertType),
+			Cert:     config.Cert,
+			CertHash: config.CertID,
+		}
+		attestReq.Certs = append(attestReq.Certs, &certMsg)
+	}
 
-	log.Debugf("publishCerts to ZedCloud, sending %s", attestReq)
-	sendCertsProtobuf(attestReq, iteration)
+	log.Debugf("publishEveNodeCertsToController, sending %s", attestReq)
+	sendEveNodeCertsProtobuf(attestReq, ctx.cipherCtx.iteration)
+	log.Debugf("publishEveNodeCertsToController: after send, total elapse sec %v",
+		time.Since(startPubTime).Seconds())
+	ctx.cipherCtx.iteration++
 }
 
 // Try all (first free, then rest) until it gets through.
 // Each iteration we try a different port for load spreading.
 // For each port we try all its local IP addresses until we get a success.
-func sendCertsProtobuf(attestReq *attest.ZAttestReq, iteration int) {
+func sendEveNodeCertsProtobuf(attestReq *attest.ZAttestReq, iteration int) {
 	data, err := proto.Marshal(attestReq)
 	if err != nil {
 		log.Fatal("SendInfoProtobufStr proto marshaling error: ", err)
 	}
 
-	deviceUUID := zcdevUUID.String()
-	zedcloud.RemoveDeferred("attest:" + deviceUUID)
+	deferKey := "attest:%s" + zcdevUUID.String()
+	zedcloud.RemoveDeferred(deferKey)
+
 	buf := bytes.NewBuffer(data)
 	size := int64(proto.Size(attestReq))
 	attestURL := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API,
@@ -199,19 +316,102 @@ func sendCertsProtobuf(attestReq *attest.ZAttestReq, iteration int) {
 	_, _, rtf, err := zedcloud.SendOnAllIntf(&zedcloudCtx, attestURL,
 		size, buf, iteration, bailOnHTTPErr)
 	if err != nil {
+		// Hopefully next timeout will be more successful
 		if rtf == types.SenderStatusRemTempFail {
-			log.Errorf("sendCertsProtobuf remoteTemporaryFailure: %s",
+			log.Errorf("sendEveNodeCertsProtobuf remoteTemporaryFailure: %s",
 				err)
 		} else {
-			log.Errorf("sendCertsProtobuf failed: %s", err)
+			log.Errorf("sendEveNodeCertsProtobuf failed: %s", err)
 		}
-		// Try sending later
-		// The buf might have been consumed
-		buf := bytes.NewBuffer(data)
-		if buf == nil {
-			log.Fatal("malloc error")
-		}
-		zedcloud.SetDeferred("attest:"+deviceUUID, buf, size, attestURL,
+		zedcloud.SetDeferred(deferKey, buf, size, attestURL,
 			zedcloudCtx, true)
+	}
+}
+
+// initialize cipher pubsub trigger handlers and channels
+func cipherModuleInitialize(ctx *zedagentContext, ps *pubsub.PubSub) {
+
+	// create the trigger channels
+	ctx.cipherCtx.triggerEveNodeCerts = make(chan struct{}, 1)
+	ctx.cipherCtx.triggerControllerCerts = make(chan struct{}, 1)
+}
+
+// start the task threads
+func cipherModuleStart(ctx *zedagentContext) {
+	if !zedcloud.UseV2API() {
+		log.Infof("V2 APIs are still not enabled")
+		// we will run the tasks for watchdog
+	}
+	// start the eve node certificate push task
+	go eveNodeCertsTask(ctx, ctx.cipherCtx.triggerEveNodeCerts)
+
+	// start the controller certificate fetch task
+	go controllerCertsTask(ctx, ctx.cipherCtx.triggerControllerCerts)
+}
+
+// Controller certificate, check whether there is a Sha mismatch
+// to trigger the post request
+func handleControllerCertsSha(ctx *zedagentContext,
+	config *zconfig.EdgeDevConfig) {
+	// still sha is not getting populated in the configuration
+	if len(ctx.cipherCtx.cfgControllerCertHash) == 0 {
+		return
+	}
+	sumHash := hex.EncodeToString(ctx.cipherCtx.cfgControllerCertHash)
+	certHash := config.GetControllercertConfighash()
+	if sumHash != certHash {
+		triggerControllerCertEvent(ctx)
+	}
+}
+
+//  controller certificate pull trigger function
+func triggerControllerCertEvent(ctxPtr *zedagentContext) {
+
+	log.Info("Trigger for Controller Certs")
+	select {
+	case ctxPtr.cipherCtx.triggerControllerCerts <- struct{}{}:
+		// Do nothing more
+	default:
+		log.Warnf("triggerControllerCertEvent(): already triggered, still not processed")
+	}
+}
+
+//  eve node certificate post trigger function
+func triggerEveNodeCertEvent(ctxPtr *zedagentContext) {
+
+	log.Info("Trigger Eve Node Certs publish")
+	select {
+	case ctxPtr.cipherCtx.triggerEveNodeCerts <- struct{}{}:
+		// Do nothing more
+	default:
+		log.Warnf("triggerEveNodeCertEvent(): already triggered, still not processed")
+	}
+}
+
+func convertLocalToApiHashAlgo(algo types.CertHashType) evecommon.HashAlgorithm {
+	switch algo {
+	case types.CertHashTypeSha256First16:
+		return evecommon.HashAlgorithm_HASH_ALGORITHM_SHA256_16BYTES
+	default:
+		errStr := fmt.Sprintf("convertLocalToApiHashAlgo(): unknown hash algorithm: %v", algo)
+		log.Fatal(errStr)
+		return evecommon.HashAlgorithm_HASH_ALGORITHM_INVALID
+	}
+}
+
+func convertLocalToApiCertType(certType types.CertType) zcert.ZCertType {
+	switch certType {
+	case types.CertTypeOnboarding:
+		return zcert.ZCertType_CERT_TYPE_DEVICE_ONBOARDING
+	case types.CertTypeRestrictSigning:
+		return zcert.ZCertType_CERT_TYPE_DEVICE_RESTRICTED_SIGNING
+	case types.CertTypeEk:
+		return zcert.ZCertType_CERT_TYPE_DEVICE_ENDORSEMENT_RSA
+	case types.CertTypeEcdhXchange:
+		return zcert.ZCertType_CERT_TYPE_DEVICE_ECDH_EXCHANGE
+	default:
+		errStr := fmt.Sprintf("convertLocalToApiCertType(): unknown certificate type: %v", certType)
+		log.Fatal(errStr)
+		return zcert.ZCertType_CERT_TYPE_CONTROLLER_NONE
 	}
 }

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -54,6 +54,7 @@ func parseConfig(config *zconfig.EdgeDevConfig, getconfigCtx *getconfigContext,
 	if getconfigCtx.rebootFlag || ctx.deviceReboot {
 		log.Debugf("parseConfig: Ignoring config as rebootFlag set")
 	} else {
+		handleControllerCertsSha(ctx, config)
 		parseCipherContext(getconfigCtx, config)
 		parseDatastoreConfig(config, getconfigCtx)
 		// DeviceIoList has some defaults for Usage and UsagePolicy

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -460,7 +460,7 @@ for AGENT in $AGENTS; do
     touch "$WATCHDOG_PID/$AGENT.pid"
     touch "$WATCHDOG_FILE/$AGENT.touch"
     if [ "$AGENT" = "zedagent" ]; then
-       touch "$WATCHDOG_FILE/${AGENT}config.touch" "$WATCHDOG_FILE/${AGENT}metrics.touch" "$WATCHDOG_FILE/${AGENT}devinfo.touch"
+       touch "$WATCHDOG_FILE/${AGENT}config.touch" "$WATCHDOG_FILE/${AGENT}metrics.touch" "$WATCHDOG_FILE/${AGENT}devinfo.touch" "$WATCHDOG_FILE/${AGENT}attest.touch" "$WATCHDOG_FILE/${AGENT}ccerts.touch"
     fi
 done
 

--- a/pkg/pillar/types/attesttypes.go
+++ b/pkg/pillar/types/attesttypes.go
@@ -71,9 +71,11 @@ type EveNodeCert struct {
 	CertType CertType     //type of the certificate
 	Cert     []byte       //PEM encoded
 	IsTpm    bool         //TPM generated or, not
+	// ErrorAndTime provides SetErrorNow() and ClearError()
+	ErrorAndTime
 }
 
-//Key uniquely identifies an AttestCert object
+//Key uniquely identifies the certificate
 func (cert EveNodeCert) Key() string {
 	return hex.EncodeToString(cert.CertID)
 }

--- a/pkg/pillar/types/cipherinfotypes.go
+++ b/pkg/pillar/types/cipherinfotypes.go
@@ -34,6 +34,11 @@ func (status *CipherContext) ControllerCertKey() string {
 	return hex.EncodeToString(status.ControllerCertHash)
 }
 
+// EveNodeCertKey :
+func (status *CipherContext) EveNodeCertKey() string {
+	return hex.EncodeToString(status.DeviceCertHash)
+}
+
 // CipherBlockStatus : Object specific encryption information
 type CipherBlockStatus struct {
 	CipherBlockID   string // constructed using individual reference


### PR DESCRIPTION
Signed-off-by: Srinibas Maharana <srinibas@zededa.com>
Please review. 
1. attest API on zedagent, for publishing the device certificates
2. rephrase cert API changes for both MITM and cipher object
3. changes in zedagent and ciper module for Ecdh Cert changes for related modules
4. Software ECDH Certificate create and signing with device key in tpmmgr
5. Publishing them to the zedagent, for controller consumption

Will be adding device certificate based signing for soft ECDH Certificate soon.