### PR TITLE
Remove Drivetype aka Devtype

### DIFF
--- a/pkg/pillar/cmd/baseosmgr/handlevolumemgr.go
+++ b/pkg/pillar/cmd/baseosmgr/handlevolumemgr.go
@@ -56,7 +56,6 @@ func AddOrRefcountVolumeConfig(ctx *baseOsMgrContext, blobSha256 string,
 			MaxVolSize:     ss.MaxVolSize,
 			ReadOnly:       ss.ReadOnly,
 			Format:         ss.Format,
-			Devtype:        ss.Devtype,
 			Target:         ss.Target,
 			RefCount:       1,
 		}

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1332,7 +1332,13 @@ func configToStatus(ctx *domainContext, config types.DomainConfig,
 		ds.ReadOnly = dc.ReadOnly
 		ds.FileLocation = dc.FileLocation
 		ds.Format = dc.Format
-		ds.Devtype = dc.Devtype
+		// Generate Devtype for hypervisor package
+		// XXX can hypervisor look at something different?
+		if dc.Format == zconfig.Format_CONTAINER {
+			ds.Devtype = "container"
+		} else {
+			ds.Devtype = "hdd"
+		}
 		var xv string
 		if status.IsContainer {
 			// map from i=1 to xvdb, 2 to xvdc etc
@@ -1889,6 +1895,9 @@ func createCloudInitISO(ctx *domainContext,
 	ds.Format = zconfig.Format_RAW
 	ds.Vdev = "hdc:cdrom"
 	ds.ReadOnly = false
+	// Generate Devtype for hypervisor package
+	// XXX can hypervisor look at something different?
+	ds.Devtype = "cdrom"
 	return ds, nil
 }
 

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -1024,7 +1024,6 @@ func parseStorageConfigList(objType string,
 		image.ReadOnly = drive.Readonly
 		image.MaxVolSize = uint64(drive.Maxsizebytes)
 		image.Target = strings.ToLower(drive.Target.String())
-		image.Devtype = strings.ToLower(drive.Drvtype.String())
 		image.ImageSha256 = drive.Image.Sha256
 		storageList[idx] = *image
 		idx++

--- a/pkg/pillar/cmd/zedmanager/handledomainmgr.go
+++ b/pkg/pillar/cmd/zedmanager/handledomainmgr.go
@@ -81,7 +81,6 @@ func MaybeAddDomainConfig(ctx *zedmanagerContext,
 			disk.FileLocation = location
 			disk.ReadOnly = sc.ReadOnly
 			disk.Format = sc.Format
-			disk.Devtype = sc.Devtype
 			dc.DiskConfigList = append(dc.DiskConfigList, disk)
 		case "kernel":
 			if dc.Kernel != "" {

--- a/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
+++ b/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
@@ -55,7 +55,6 @@ func AddOrRefcountVolumeConfig(ctx *zedmanagerContext, blobSha256 string,
 			MaxVolSize:     ss.MaxVolSize,
 			ReadOnly:       ss.ReadOnly,
 			Format:         ss.Format,
-			Devtype:        ss.Devtype,
 			Target:         ss.Target,
 			RefCount:       1,
 		}

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -830,13 +830,6 @@ func quantifyChanges(config types.AppInstanceConfig,
 				needPurge = true
 				purgeReason += str + "\n"
 			}
-			if ss.Devtype != sc.Devtype {
-				str := fmt.Sprintf("storage Devtype changed from %v to %v for %s",
-					ss.Devtype, sc.Devtype, ss.ImageID)
-				log.Infof(str)
-				needPurge = true
-				purgeReason += str + "\n"
-			}
 		}
 	}
 	// Compare networks without comparing ACLs

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -294,7 +294,6 @@ type DiskConfig struct {
 	FileLocation string    // Where to find the volume
 	ReadOnly     bool
 	Format       zconfig.Format
-	Devtype      string // Default ""; could be e.g. "cdrom"
 }
 
 type DiskStatus struct {
@@ -303,7 +302,7 @@ type DiskStatus struct {
 	ReadOnly     bool
 	FileLocation string // From DiskConfig
 	Format       zconfig.Format
-	Devtype      string // From config
+	Devtype      string // XXX used internally by hypervisor; deprecate?
 	Vdev         string // Allocated
 }
 

--- a/pkg/pillar/types/volumes.go
+++ b/pkg/pillar/types/volumes.go
@@ -105,9 +105,8 @@ type OldVolumeConfig struct {
 	Format     zconfig.Format // Default "raw"; could be raw, qcow, qcow2, vhd
 	// XXX add "directory" to format?  enum?
 
-	// XXX if these are not needed in Status they are not needed in Config
-	Devtype string // Default ""; could be e.g. "cdrom"
-	Target  string // Default "" is interpreted as "disk"
+	// XXX if this is not needed in Status it is not needed in Config
+	Target string // Default "" is interpreted as "disk"
 
 	// XXX RefCount? free handshake? Will this ever be different than 1?
 	RefCount uint

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -352,7 +352,6 @@ type StorageConfig struct {
 	ReadOnly    bool
 	MaxVolSize  uint64         // Resize filesystem to this size if set (In bytes)
 	Format      zconfig.Format // Default "raw"; could be raw, qcow, qcow2, vhd
-	Devtype     string         // Default ""; could be e.g. "cdrom"
 	Target      string         // Default "" is interpreted as "disk"
 }
 
@@ -375,7 +374,6 @@ type StorageStatus struct {
 	ReadOnly           bool
 	MaxVolSize         uint64 // Resize filesystem to this size if set (In bytes)
 	Format             zconfig.Format
-	Devtype            string
 	Target             string  // Default "" is interpreted as "disk"
 	State              SwState // DOWNLOADED etc
 	Progress           uint    // In percent i.e., 0-100
@@ -409,7 +407,6 @@ func (ss *StorageStatus) UpdateFromStorageConfig(sc StorageConfig) {
 	ss.ReadOnly = sc.ReadOnly
 	ss.MaxVolSize = sc.MaxVolSize
 	ss.Format = sc.Format
-	ss.Devtype = sc.Devtype
 	ss.Target = sc.Target
 	ss.State = 0
 	ss.Progress = 0


### PR DESCRIPTION
As @zed-rishabh noticed in the new Volume Config API we have no Devtype. However, the kvm hypervisor uses DomainStatus Devtype to tell the difference between container, cdrom, and rest (disk).

This PR preserves that code in kvm.go but removes it everywhere else. Means domainmgr fills in derived values for hypervisor to use.