### PR TITLE
generate soft ECDH cert if no TPM

### DIFF
--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -171,6 +171,11 @@ if [ -c $TPM_DEVICE_PATH ] && ! [ -f $CONFIGDIR/disable-tpm ]; then
     if ! $BINDIR/tpmmgr createCerts; then
         echo "$(date -Ins -u) device-steps: createCerts failed"
     fi
+else
+    echo "$(date -Ins -u) device-steps: NOT TPM device, creating additional security certificates"
+    if ! $BINDIR/tpmmgr createSoftCerts; then
+        echo "$(date -Ins -u) device-steps: createSoftCerts failed"
+    fi
 fi
 
 # BlinkCounter 1 means we have started; might not yet have IP addresses


### PR DESCRIPTION
This addresses a few issues:
 - generate the soft ECDH if there is no TPM (by a new tpmmgr command from device-steps)
 - sign the soft ECDH cert using the device cert (it was self-signed before these changes). Note the TPM ECDH cert was already signed by the device cert
 - make the TPM and soft ECDH cert use the same templete. For the TPM one this implies a different CN string and for both of them we have the same random serial plus the NotBefore/NotAfter copied from the device certificate.