### PR TITLE
Remove redoing SnapshotPrepare hack by moving mounting

### DIFF
--- a/pkg/pillar/cmd/volumemgr/handleconfig.go
+++ b/pkg/pillar/cmd/volumemgr/handleconfig.go
@@ -7,14 +7,9 @@
 package volumemgr
 
 import (
-	"fmt"
-	"os"
 	"time"
 
-	zconfig "github.com/lf-edge/eve/api/go/config"
-	"github.com/lf-edge/eve/pkg/pillar/containerd"
 	"github.com/lf-edge/eve/pkg/pillar/types"
-	"github.com/lf-edge/eve/pkg/pillar/utils"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -66,34 +61,6 @@ func vcCreate(ctx *volumemgrContext, objType string, key string,
 		log.Infof("vcCreate promote status from init for %s", config.Key())
 		// We are moving this from unknown to this objType
 		unpublishOldVolumeStatus(ctx, initStatus)
-
-		// XXX After device reboot, somehow files created by containerd snapshot prepare
-		// is getting deleted from /persist/runx/pods/prepared/<container-dir-name>/rootfs/
-		// So, doing a hack here for containers by calling containerd snapshot prepare again
-		// Note that this will fail if the verified image has been
-		// garbage collected, in which case we will download again.
-		if config.Format == zconfig.Format_CONTAINER {
-			ociFilename, err := utils.VerifiedImageFileLocation(config.BlobSha256)
-			if err != nil {
-				errStr := fmt.Sprintf("failed to get Image File Location. err: %+s",
-					err)
-				log.Error(errStr)
-				initStatus.SetError(errStr, time.Now())
-			} else {
-				info, err := os.Stat(ociFilename)
-				if err != nil {
-					errStr := fmt.Sprintf("Calculating size of container image failed: %v", err)
-					log.Error(errStr)
-				} else {
-					dos.MaxDownSize = uint64(info.Size())
-				}
-				if err := containerd.SnapshotPrepare(initStatus.FileLocation, ociFilename); err != nil {
-					errStr := fmt.Sprintf("Failed to create ctr bundle. Error %s", err)
-					log.Error(errStr)
-					initStatus.SetError(errStr, time.Now())
-				}
-			}
-		}
 
 		// XXX where do we put this conversion code?
 		initStatus.BlobSha256 = config.BlobSha256

--- a/pkg/pillar/containerd/containerd.go
+++ b/pkg/pillar/containerd/containerd.go
@@ -151,21 +151,14 @@ func SnapshotPrepare(rootPath string, ociFilename string) error {
 		}
 	}
 
-	// final step is to mount the snapshot into rootPath/containerRootfsPath and unpack
-	// image config OCI json into rootPath/imageConfigFilename
-	rootFsDir := path.Join(rootPath, containerRootfsPath)
-	if err := os.MkdirAll(rootFsDir, 0766); err != nil {
-		return fmt.Errorf("SnapshotPrepare: Exception while creating rootFS dir. %v", err)
-	}
-	if err = mounts[0].Mount(rootFsDir); err != nil {
-		return fmt.Errorf("SnapshotPrepare: Exception while mounting rootfs %v via %v. Error: %v", rootFsDir, mounts, err)
-	}
-
 	// final step is to deposit OCI image config json
 	imageConfigJSON, err := getImageInfoJSON(ctrdCtx, ctrdImage)
 	if err != nil {
 		log.Errorf("SnapshotPrepare: Could not build json of image: %v. %v", ctrdImage.Name(), err.Error())
 		return fmt.Errorf("SnapshotPrepare: Could not build json of image: %v. %v", ctrdImage.Name(), err.Error())
+	}
+	if err := os.MkdirAll(rootPath, 0766); err != nil {
+		return fmt.Errorf("SnapshotPrepare: Exception while creating rootPath dir. %v", err)
 	}
 	if err := ioutil.WriteFile(filepath.Join(rootPath, imageConfigFilename), []byte(imageConfigJSON), 0666); err != nil {
 		return fmt.Errorf("SnapshotPrepare: Exception while writing image info to %v/%v. %v", rootPath, imageConfigFilename, err)


### PR DESCRIPTION
On device reboot, the mounted rootfs of a container was unmounted and to solve that a fix was added in volumemgr to call SnapshotPrepare() on reboot case. This meant that just to remount the snapshot we had to do the whole snapshot prepare again. 
Instead, separated out the mount portion from SnapshotPrepare() and calling it from domainmgr's doActivate() call. 

Signed-off-by: adarsh-zededa <adarsh@zededa.com>