### PR TITLE
ErrorSourceType causes problems with pubsub

### DIFF
--- a/pkg/pillar/types/errortime.go
+++ b/pkg/pillar/types/errortime.go
@@ -61,7 +61,7 @@ func NewErrorAndTimeNow(errStr string) ErrorAndTime {
 // which is used to selectively clear errors by calling IsErrorSource before
 // calling ClearErrorWithSource. See zedmanager and volumemgr for example use.
 type ErrorAndTimeWithSource struct {
-	ErrorSourceType interface{}
+	ErrorSourceType string
 	Error           string
 	ErrorTime       time.Time
 }
@@ -72,7 +72,7 @@ func (etsPtr *ErrorAndTimeWithSource) SetError(errStr string, errTime time.Time)
 		log.Fatal("Missing error string")
 	}
 	etsPtr.Error = errStr
-	etsPtr.ErrorSourceType = nil
+	etsPtr.ErrorSourceType = ""
 	etsPtr.ErrorTime = errTime
 }
 
@@ -87,7 +87,7 @@ func (etsPtr *ErrorAndTimeWithSource) SetErrorWithSource(errStr string,
 		log.Fatal("Missing error string")
 	}
 	etsPtr.Error = errStr
-	etsPtr.ErrorSourceType = source
+	etsPtr.ErrorSourceType = reflect.TypeOf(source).String()
 	etsPtr.ErrorTime = errTime
 }
 
@@ -99,13 +99,13 @@ func (etsPtr *ErrorAndTimeWithSource) IsErrorSource(source interface{}) bool {
 	if !etsPtr.HasError() {
 		return false
 	}
-	return reflect.TypeOf(source) == reflect.TypeOf(etsPtr.ErrorSourceType)
+	return reflect.TypeOf(source).String() == etsPtr.ErrorSourceType
 }
 
 // ClearErrorWithSource - Clears error state
 func (etsPtr *ErrorAndTimeWithSource) ClearErrorWithSource() {
 	etsPtr.Error = ""
-	etsPtr.ErrorSourceType = nil
+	etsPtr.ErrorSourceType = ""
 	etsPtr.ErrorTime = time.Time{}
 }
 
@@ -130,6 +130,9 @@ func allowedSourceType(source interface{}) bool {
 	case string:
 		return false
 	case bool:
+		return false
+	}
+	if _, ok := source.(map[string]interface{}); ok {
 		return false
 	}
 	val := reflect.ValueOf(source)

--- a/pkg/pillar/types/errortime_test.go
+++ b/pkg/pillar/types/errortime_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+type simple struct {
+	ErrorAndTimeWithSource
+}
+
+func TestIsErrorSource(t *testing.T) {
+	status := simple{}
+	errStr := "test1"
+	status.SetErrorWithSource(errStr, ContentTreeStatus{}, time.Now())
+	log.Infof("set error %s", status.Error)
+	assert.True(t, status.HasError())
+	assert.True(t, status.IsErrorSource(ContentTreeStatus{}))
+	assert.False(t, status.IsErrorSource(VolumeStatus{}))
+	assert.Equal(t, errStr, status.Error)
+
+	status.ClearErrorWithSource()
+	log.Infof("cleared error %s", status.Error)
+	assert.False(t, status.IsErrorSource(ContentTreeStatus{}))
+	assert.Equal(t, "", status.Error)
+
+	errStr = "error2"
+	status.SetError(errStr, time.Now())
+	assert.Equal(t, errStr, status.Error)
+	log.Infof("type after SetError %s %T", status.ErrorSourceType, status.ErrorSourceType)
+	log.Infof("reflect %v", reflect.TypeOf(status.ErrorSourceType))
+
+	errStr = "error3"
+	status.SetErrorWithSource(errStr, ContentTreeStatus{}, time.Now())
+	log.Infof("type after SetErrorWithSource %s %T", status.ErrorSourceType, status.ErrorSourceType)
+	log.Infof("reflect %v", reflect.TypeOf(status.ErrorSourceType))
+
+	errStr = "error4"
+	status.SetError(errStr, time.Now())
+	assert.Equal(t, errStr, status.Error)
+	log.Infof("type after SetError %s %T", status.ErrorSourceType, status.ErrorSourceType)
+	log.Infof("reflect %v", reflect.TypeOf(status.ErrorSourceType))
+
+	errStr = "error5"
+	// XXX now fatals
+	// result := make(map[string]interface{})
+	// status.SetErrorWithSource(errStr, result, time.Now())
+	log.Infof("type after SetError %s %T", status.ErrorSourceType, status.ErrorSourceType)
+	log.Infof("reflect %v", reflect.TypeOf(status.ErrorSourceType))
+}


### PR DESCRIPTION
@zed-rishabh found an issue when testing volumemgr.
He called SetErrorWithSource(), published the structure, then did a Get(), and called IsErrorSource().
The ErrorSourceType had become something of type map[string]interface{}.
Don't yet know how that happens in the json serialize/deserialize, nor why we haven't run into this before.

But changing the code to record the type as a string name makes the problem go away.