### PR TITLE
Updating size of the volume in the VolumeStatus

### DIFF
--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -261,23 +261,12 @@ func doUpdateVol(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool)
 			// Work is done
 			DeleteWorkCreate(ctx, status)
 			if status.MaxVolSize == 0 {
+				var err error
 				log.Infof("doUpdateVol: MaxVolSize is 0 for %s. Filling it up.",
 					status.FileLocation)
-				if status.IsContainer() {
-					size, err := utils.DirSize(status.FileLocation)
-					if err != nil {
-						log.Errorf("doUpdateVol: Computing size of %s failed: %v",
-							status.FileLocation, err)
-					} else {
-						status.MaxVolSize = uint64(size)
-					}
-				} else {
-					info, err := os.Stat(status.FileLocation)
-					if err != nil {
-						log.Errorf("doUpdateVol: Computing size of %s failed: %v",
-							status.FileLocation, err)
-					}
-					status.MaxVolSize = uint64(info.Size())
+				_, status.MaxVolSize, err = utils.GetVolumeSize(status.FileLocation)
+				if err != nil {
+					log.Error(err)
 				}
 			}
 			return changed, true

--- a/pkg/pillar/utils/volumeutils.go
+++ b/pkg/pillar/utils/volumeutils.go
@@ -4,12 +4,16 @@
 package utils
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/lf-edge/eve/pkg/pillar/diskmetrics"
 )
 
-// DirSize returns the size of the directory
-func DirSize(path string) (uint64, error) {
+// dirSize returns the size of the directory
+func dirSize(path string) (uint64, error) {
 	var size int64
 	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -21,4 +25,30 @@ func DirSize(path string) (uint64, error) {
 		return err
 	})
 	return uint64(size), err
+}
+
+// GetVolumeSize returns the actual and maximum size of the volume
+func GetVolumeSize(name string) (uint64, uint64, error) {
+	info, err := os.Stat(name)
+	if err != nil {
+		errStr := fmt.Sprintf("GetVolumeMaxSize failed for %s: %v",
+			name, err)
+		return 0, 0, errors.New(errStr)
+	}
+	if info.IsDir() {
+		size, err := dirSize(name)
+		if err != nil {
+			errStr := fmt.Sprintf("GetVolumeMaxSize failed for %s: %v",
+				name, err)
+			return 0, 0, errors.New(errStr)
+		}
+		return size, size, nil
+	}
+	imgInfo, err := diskmetrics.GetImgInfo(name)
+	if err != nil {
+		errStr := fmt.Sprintf("GetVolumeMaxSize failed for %s: %v",
+			name, err)
+		return 0, 0, errors.New(errStr)
+	}
+	return imgInfo.ActualSize, imgInfo.VirtualSize, nil
 }


### PR DESCRIPTION
We are updating the size of the volume in the VolumeStatus if it is zero
after creating it. For containers, EVE doesn't get the volume size in device
configuration from the controller.

Signed-off-by: zed-rishabh <rgupta@zededa.com>