### PR TITLE
Propagate VolumeStatus to VolumeRefStatus; set initial state to INITIAL; logging cleanup and additions

### DIFF
--- a/pkg/pillar/cmd/volumemgr/handlecontent.go
+++ b/pkg/pillar/cmd/volumemgr/handlecontent.go
@@ -108,6 +108,7 @@ func updateContentTree(ctx *volumemgrContext, config types.ContentTreeConfig) {
 			CertificateChain:  config.CertificateChain,
 			DisplayName:       config.DisplayName,
 			ObjType:           types.AppImgObj,
+			State:             types.INITIAL,
 		}
 	}
 	publishContentTreeStatus(ctx, status)

--- a/pkg/pillar/cmd/volumemgr/handlevolume.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume.go
@@ -34,9 +34,9 @@ func handleVolumeCreate(ctxArg interface{}, key string,
 		DisplayName:             config.DisplayName,
 		RefCount:                config.RefCount,
 		LastUse:                 time.Now(),
+		State:                   types.INITIAL,
 	}
 	updateVolumeStatusRefCount(ctx, status)
-	publishVolumeStatus(ctx, status)
 	status.ContentFormat = volumeFormat[status.Key()]
 	if info, err := os.Stat(status.PathName()); err == nil {
 		status.State = types.CREATED_VOLUME
@@ -60,6 +60,7 @@ func handleVolumeCreate(ctxArg interface{}, key string,
 		updateVolumeRefStatus(ctx, status)
 		return
 	}
+	publishVolumeStatus(ctx, status)
 	if !ctx.globalConfig.GlobalValueBool(types.IgnoreDiskCheckForApps) {
 		// Check disk usage
 		remaining, volumeDiskSizeList, err := getRemainingVolumeDiskSpace(ctx)

--- a/pkg/pillar/cmd/volumemgr/handlevolume.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume.go
@@ -252,7 +252,13 @@ func updateVolumeStatusRefCount(ctx *volumemgrContext, vs *types.VolumeStatus) {
 	} else {
 		vrcRefCount = vrc.RefCount
 	}
-	vs.RefCount = vcRefCount + vrcRefCount
+	old := vs.RefCount
+	new := vcRefCount + vrcRefCount
+	if new != old {
+		vs.RefCount = new
+		log.Infof("updateVolumeStatusRefCount(%s) updated from %d to %d",
+			vs.Key(), old, new)
+	}
 	log.Debugf("updateVolumeStatusRefCount(%s) Done", vs.Key())
 }
 

--- a/pkg/pillar/cmd/volumemgr/handlevolume.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume.go
@@ -68,6 +68,7 @@ func handleVolumeCreate(ctxArg interface{}, key string,
 				err)
 			status.SetError(errStr, time.Now())
 			publishVolumeStatus(ctx, status)
+			updateVolumeRefStatus(ctx, status)
 			return
 		} else if remaining < status.MaxVolSize {
 			errStr := fmt.Sprintf("Remaining disk space %d volume needs %d\n"+
@@ -75,6 +76,7 @@ func handleVolumeCreate(ctxArg interface{}, key string,
 				remaining, status.MaxVolSize, volumeDiskSizeList)
 			status.SetError(errStr, time.Now())
 			publishVolumeStatus(ctx, status)
+			updateVolumeRefStatus(ctx, status)
 			return
 		}
 	}
@@ -103,6 +105,7 @@ func handleVolumeModify(ctxArg interface{}, key string,
 		log.Errorf("handleVolumeModify(%s) failed: %s", status.Key(), errStr)
 		status.SetError(errStr, time.Now())
 		publishVolumeStatus(ctx, status)
+		updateVolumeRefStatus(ctx, status)
 		return
 	}
 	if config.DisplayName != status.DisplayName {
@@ -117,6 +120,7 @@ func handleVolumeModify(ctxArg interface{}, key string,
 	}
 	status = updateVolumeStatusRefCount(ctx, status)
 	publishVolumeStatus(ctx, status)
+	updateVolumeRefStatus(ctx, status)
 	log.Infof("handleVolumeModify(%s) Done", key)
 }
 
@@ -196,6 +200,7 @@ func deleteVolume(ctx *volumemgrContext, status *types.VolumeStatus) {
 	log.Infof("deleteVolume for %v", status.Key())
 	if status.RefCount != 0 {
 		publishVolumeStatus(ctx, status)
+		updateVolumeRefStatus(ctx, status)
 		log.Infof("deleteVolume for %v Done", status.Key())
 		return
 	}

--- a/pkg/pillar/cmd/volumemgr/handlevolume.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume.go
@@ -201,7 +201,6 @@ func maybeDeleteVolume(ctx *volumemgrContext, status *types.VolumeStatus) {
 	log.Infof("maybeDeleteVolume for %v", status.Key())
 	if status.RefCount != 0 {
 		publishVolumeStatus(ctx, status)
-		updateVolumeStatusRefCount(ctx, status) // XXX needed?
 		log.Infof("maybeDeleteVolume for %v Done", status.Key())
 		return
 	}

--- a/pkg/pillar/cmd/volumemgr/handlevolumeref.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolumeref.go
@@ -20,7 +20,7 @@ func handleVolumeRefCreate(ctxArg interface{}, key string,
 	}
 	vs := lookupVolumeStatus(ctx, config.VolumeKey())
 	if vs != nil {
-		vs = updateVolumeStatusRefCount(ctx, vs)
+		updateVolumeStatusRefCount(ctx, vs)
 		publishVolumeStatus(ctx, vs)
 		status = &types.VolumeRefStatus{
 			VolumeID:           config.VolumeID,
@@ -64,7 +64,7 @@ func handleVolumeRefModify(ctxArg interface{}, key string,
 	publishVolumeRefStatus(ctx, status)
 	vs := lookupVolumeStatus(ctx, config.VolumeKey())
 	if vs != nil {
-		vs = updateVolumeStatusRefCount(ctx, vs)
+		updateVolumeStatusRefCount(ctx, vs)
 		publishVolumeStatus(ctx, vs)
 	}
 	log.Infof("handleVolumeRefModify(%s) Done", key)
@@ -79,8 +79,8 @@ func handleVolumeRefDelete(ctxArg interface{}, key string,
 	unpublishVolumeRefStatus(ctx, config.Key())
 	vs := lookupVolumeStatus(ctx, config.VolumeKey())
 	if vs != nil {
-		vs = updateVolumeStatusRefCount(ctx, vs)
-		deleteVolume(ctx, vs)
+		updateVolumeStatusRefCount(ctx, vs)
+		maybeDeleteVolume(ctx, vs)
 	}
 	log.Infof("handleVolumeRefDelete(%s) Done", key)
 }
@@ -137,7 +137,7 @@ func updateVolumeRefStatus(ctx *volumemgrContext, vs *types.VolumeStatus) {
 	for _, st := range items {
 		config := st.(types.VolumeRefConfig)
 		if config.Key() == vs.Key() {
-			vs = updateVolumeStatusRefCount(ctx, vs)
+			updateVolumeStatusRefCount(ctx, vs)
 			publishVolumeStatus(ctx, vs)
 			status := lookupVolumeRefStatus(ctx, config.Key())
 			if status != nil {

--- a/pkg/pillar/cmd/volumemgr/handlevolumeref.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolumeref.go
@@ -43,7 +43,7 @@ func handleVolumeRefCreate(ctxArg interface{}, key string,
 			VolumeID:          config.VolumeID,
 			GenerationCounter: config.GenerationCounter,
 			RefCount:          config.RefCount,
-			State:             types.INITIAL,
+			State:             types.INITIAL, // Waiting for VolumeConfig from zedagent
 		}
 	}
 	publishVolumeRefStatus(ctx, status)

--- a/pkg/pillar/cmd/volumemgr/handlevolumeref.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolumeref.go
@@ -80,6 +80,7 @@ func handleVolumeRefDelete(ctxArg interface{}, key string,
 	vs := lookupVolumeStatus(ctx, config.VolumeKey())
 	if vs != nil {
 		updateVolumeStatusRefCount(ctx, vs)
+		publishVolumeStatus(ctx, vs)
 		maybeDeleteVolume(ctx, vs)
 	}
 	log.Infof("handleVolumeRefDelete(%s) Done", key)

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -251,11 +251,13 @@ func doInstall(ctx *zedmanagerContext,
 			status.SetError(errString, time.Now())
 			return true, false
 		}
-		newVrs := types.VolumeRefStatus{}
-		newVrs.VolumeID = vrc.VolumeID
-		newVrs.GenerationCounter = vrc.GenerationCounter
-		newVrs.RefCount = vrc.RefCount
-		newVrs.PendingAdd = true
+		newVrs := types.VolumeRefStatus{
+			VolumeID:          vrc.VolumeID,
+			GenerationCounter: vrc.GenerationCounter,
+			RefCount:          vrc.RefCount,
+			PendingAdd:        true,
+			State:             types.INITIAL,
+		}
 		log.Infof("Adding new VolumeRefStatus %v", newVrs)
 		status.VolumeRefStatusList = append(status.VolumeRefStatusList, newVrs)
 		changed = true

--- a/pkg/pillar/types/contenttreetypes.go
+++ b/pkg/pillar/types/contenttreetypes.go
@@ -43,7 +43,10 @@ func (config ContentTreeConfig) LogCreate() {
 		return
 	}
 	logObject.CloneAndAddField("datastore-id", config.DatastoreID).
+		AddField("relativeURL", config.RelativeURL).
 		AddField("format", config.Format).
+		AddField("contentSha256", config.ContentSha256).
+		AddField("maxDownloadSize", config.MaxDownloadSize).
 		Infof("Content tree config create")
 }
 
@@ -81,7 +84,10 @@ func (config ContentTreeConfig) LogDelete() {
 	logObject := base.EnsureLogObject(base.ContentTreeConfigLogType, config.DisplayName,
 		config.ContentID, config.LogKey())
 	logObject.CloneAndAddField("datastore-id", config.DatastoreID).
+		AddField("relativeURL", config.RelativeURL).
 		AddField("format", config.Format).
+		AddField("contentSha256", config.ContentSha256).
+		AddField("maxDownloadSize", config.MaxDownloadSize).
 		Infof("ContentTree config delete")
 
 	base.DeleteLogObject(config.LogKey())
@@ -147,7 +153,7 @@ func (status ContentTreeStatus) LogCreate() {
 	}
 	logObject.CloneAndAddField("contentSha256", status.ContentSha256).
 		AddField("maxDownloadSize", status.MaxDownloadSize).
-		AddField("state", status.State).
+		AddField("state", status.State.String()).
 		AddField("progress", status.Progress).
 		AddField("fileLocation", status.FileLocation).
 		Infof("Content tree status create")
@@ -170,12 +176,12 @@ func (status ContentTreeStatus) LogModify(old interface{}) {
 
 		logObject.CloneAndAddField("contentSha256", status.ContentSha256).
 			AddField("maxDownloadSize", status.MaxDownloadSize).
-			AddField("state", status.State).
+			AddField("state", status.State.String()).
 			AddField("progress", status.Progress).
 			AddField("fileLocation", status.FileLocation).
 			AddField("old-contentSha256", oldStatus.ContentSha256).
 			AddField("old-maxDownloadSize", oldStatus.MaxDownloadSize).
-			AddField("old-state", oldStatus.State).
+			AddField("old-state", oldStatus.State.String()).
 			AddField("old-progress", oldStatus.Progress).
 			AddField("old-fileLocation", oldStatus.FileLocation).
 			Infof("ContentTree status modify")
@@ -188,6 +194,9 @@ func (status ContentTreeStatus) LogDelete() {
 		status.ContentID, status.LogKey())
 	logObject.CloneAndAddField("contentSha256", status.ContentSha256).
 		AddField("maxDownloadSize", status.MaxDownloadSize).
+		AddField("state", status.State.String()).
+		AddField("progress", status.Progress).
+		AddField("fileLocation", status.FileLocation).
 		Infof("ContentTree status delete")
 
 	base.DeleteLogObject(status.LogKey())

--- a/pkg/pillar/types/contenttreetypes.go
+++ b/pkg/pillar/types/contenttreetypes.go
@@ -43,10 +43,10 @@ func (config ContentTreeConfig) LogCreate() {
 		return
 	}
 	logObject.CloneAndAddField("datastore-id", config.DatastoreID).
-		AddField("relativeURL", config.RelativeURL).
+		AddField("relative-URL", config.RelativeURL).
 		AddField("format", config.Format).
-		AddField("contentSha256", config.ContentSha256).
-		AddField("maxDownloadSize", config.MaxDownloadSize).
+		AddField("content-sha256", config.ContentSha256).
+		AddField("max-download-size-int64", config.MaxDownloadSize).
 		Infof("Content tree config create")
 }
 
@@ -66,15 +66,15 @@ func (config ContentTreeConfig) LogModify(old interface{}) {
 		oldConfig.MaxDownloadSize != config.MaxDownloadSize {
 
 		logObject.CloneAndAddField("datastore-id", config.DatastoreID).
-			AddField("relativeURL", config.RelativeURL).
+			AddField("relative-URL", config.RelativeURL).
 			AddField("format", config.Format).
-			AddField("contentSha256", config.ContentSha256).
-			AddField("maxDownloadSize", config.MaxDownloadSize).
+			AddField("content-sha256", config.ContentSha256).
+			AddField("max-download-size-int64", config.MaxDownloadSize).
 			AddField("old-datastore-id", oldConfig.DatastoreID).
-			AddField("old-relativeURL", oldConfig.RelativeURL).
+			AddField("old-relative-URL", oldConfig.RelativeURL).
 			AddField("old-format", oldConfig.Format).
-			AddField("old-contentSha256", oldConfig.ContentSha256).
-			AddField("old-maxDownloadSize", oldConfig.MaxDownloadSize).
+			AddField("old-content-sha256", oldConfig.ContentSha256).
+			AddField("old-max-download-size-int64", oldConfig.MaxDownloadSize).
 			Infof("ContentTree config modify")
 	}
 }
@@ -84,10 +84,10 @@ func (config ContentTreeConfig) LogDelete() {
 	logObject := base.EnsureLogObject(base.ContentTreeConfigLogType, config.DisplayName,
 		config.ContentID, config.LogKey())
 	logObject.CloneAndAddField("datastore-id", config.DatastoreID).
-		AddField("relativeURL", config.RelativeURL).
+		AddField("relative-URL", config.RelativeURL).
 		AddField("format", config.Format).
-		AddField("contentSha256", config.ContentSha256).
-		AddField("maxDownloadSize", config.MaxDownloadSize).
+		AddField("content-sha256", config.ContentSha256).
+		AddField("max-download-size-int64", config.MaxDownloadSize).
 		Infof("ContentTree config delete")
 
 	base.DeleteLogObject(config.LogKey())
@@ -151,11 +151,11 @@ func (status ContentTreeStatus) LogCreate() {
 	if logObject == nil {
 		return
 	}
-	logObject.CloneAndAddField("contentSha256", status.ContentSha256).
-		AddField("maxDownloadSize", status.MaxDownloadSize).
+	logObject.CloneAndAddField("content-sha256", status.ContentSha256).
+		AddField("max-download-size-int64", status.MaxDownloadSize).
 		AddField("state", status.State.String()).
 		AddField("progress", status.Progress).
-		AddField("fileLocation", status.FileLocation).
+		AddField("filelocation", status.FileLocation).
 		Infof("Content tree status create")
 }
 
@@ -174,16 +174,16 @@ func (status ContentTreeStatus) LogModify(old interface{}) {
 		oldStatus.Progress != status.Progress ||
 		oldStatus.FileLocation != status.FileLocation {
 
-		logObject.CloneAndAddField("contentSha256", status.ContentSha256).
-			AddField("maxDownloadSize", status.MaxDownloadSize).
+		logObject.CloneAndAddField("content-sha256", status.ContentSha256).
+			AddField("max-download-size-int64", status.MaxDownloadSize).
 			AddField("state", status.State.String()).
 			AddField("progress", status.Progress).
-			AddField("fileLocation", status.FileLocation).
-			AddField("old-contentSha256", oldStatus.ContentSha256).
-			AddField("old-maxDownloadSize", oldStatus.MaxDownloadSize).
+			AddField("filelocation", status.FileLocation).
+			AddField("old-content-sha256", oldStatus.ContentSha256).
+			AddField("old-max-download-size-int64", oldStatus.MaxDownloadSize).
 			AddField("old-state", oldStatus.State.String()).
 			AddField("old-progress", oldStatus.Progress).
-			AddField("old-fileLocation", oldStatus.FileLocation).
+			AddField("old-filelocation", oldStatus.FileLocation).
 			Infof("ContentTree status modify")
 	}
 }
@@ -192,11 +192,11 @@ func (status ContentTreeStatus) LogModify(old interface{}) {
 func (status ContentTreeStatus) LogDelete() {
 	logObject := base.EnsureLogObject(base.ContentTreeStatusLogType, status.DisplayName,
 		status.ContentID, status.LogKey())
-	logObject.CloneAndAddField("contentSha256", status.ContentSha256).
-		AddField("maxDownloadSize", status.MaxDownloadSize).
+	logObject.CloneAndAddField("content-sha256", status.ContentSha256).
+		AddField("max-download-size-int64", status.MaxDownloadSize).
 		AddField("state", status.State.String()).
 		AddField("progress", status.Progress).
-		AddField("fileLocation", status.FileLocation).
+		AddField("filelocation", status.FileLocation).
 		Infof("ContentTree status delete")
 
 	base.DeleteLogObject(status.LogKey())

--- a/pkg/pillar/types/contenttreetypes.go
+++ b/pkg/pillar/types/contenttreetypes.go
@@ -75,7 +75,7 @@ func (config ContentTreeConfig) LogModify(old interface{}) {
 			AddField("old-format", oldConfig.Format).
 			AddField("old-content-sha256", oldConfig.ContentSha256).
 			AddField("old-max-download-size-int64", oldConfig.MaxDownloadSize).
-			Infof("ContentTree config modify")
+			Infof("Content tree config modify")
 	}
 }
 
@@ -88,7 +88,7 @@ func (config ContentTreeConfig) LogDelete() {
 		AddField("format", config.Format).
 		AddField("content-sha256", config.ContentSha256).
 		AddField("max-download-size-int64", config.MaxDownloadSize).
-		Infof("ContentTree config delete")
+		Infof("Content tree config delete")
 
 	base.DeleteLogObject(config.LogKey())
 }
@@ -184,7 +184,7 @@ func (status ContentTreeStatus) LogModify(old interface{}) {
 			AddField("old-state", oldStatus.State.String()).
 			AddField("old-progress", oldStatus.Progress).
 			AddField("old-filelocation", oldStatus.FileLocation).
-			Infof("ContentTree status modify")
+			Infof("Content tree status modify")
 	}
 }
 
@@ -197,7 +197,7 @@ func (status ContentTreeStatus) LogDelete() {
 		AddField("state", status.State.String()).
 		AddField("progress", status.Progress).
 		AddField("filelocation", status.FileLocation).
-		Infof("ContentTree status delete")
+		Infof("Content tree status delete")
 
 	base.DeleteLogObject(status.LogKey())
 }

--- a/pkg/pillar/types/volumetypes.go
+++ b/pkg/pillar/types/volumetypes.go
@@ -40,6 +40,9 @@ func (config VolumeConfig) LogCreate() {
 		return
 	}
 	logObject.CloneAndAddField("content-id", config.ContentID).
+		AddField("max-vol-size-int64", config.MaxVolSize).
+		AddField("refcount-int64", config.RefCount).
+		AddField("generation-counter-int64", config.GenerationCounter).
 		Infof("Volume config create")
 }
 
@@ -74,6 +77,9 @@ func (config VolumeConfig) LogDelete() {
 	logObject := base.EnsureLogObject(base.VolumeConfigLogType, config.DisplayName,
 		config.VolumeID, config.LogKey())
 	logObject.CloneAndAddField("content-id", config.ContentID).
+		AddField("max-vol-size-int64", config.MaxVolSize).
+		AddField("refcount-int64", config.RefCount).
+		AddField("generation-counter-int64", config.GenerationCounter).
 		Infof("Volume config delete")
 
 	base.DeleteLogObject(config.LogKey())
@@ -102,6 +108,7 @@ type VolumeStatus struct {
 	ContentFormat           zconfig.Format
 	LastUse                 time.Time
 	PreReboot               bool // Was volume last use prior to device reboot?
+	ReferenceName           string
 
 	ErrorAndTimeWithSource
 }
@@ -135,7 +142,7 @@ func (status VolumeStatus) LogCreate() {
 	}
 	logObject.CloneAndAddField("content-id", status.ContentID).
 		AddField("max-vol-size-int64", status.MaxVolSize).
-		AddField("state", status.State).
+		AddField("state", status.State.String()).
 		AddField("progress-int64", status.Progress).
 		AddField("refcount-int64", status.RefCount).
 		AddField("filelocation", status.FileLocation).
@@ -160,13 +167,13 @@ func (status VolumeStatus) LogModify(old interface{}) {
 
 		logObject.CloneAndAddField("content-id", status.ContentID).
 			AddField("max-vol-size-int64", status.MaxVolSize).
-			AddField("state", status.State).
+			AddField("state", status.State.String()).
 			AddField("progress-int64", status.Progress).
 			AddField("refcount-int64", status.RefCount).
 			AddField("filelocation", status.FileLocation).
 			AddField("old-content-id", oldStatus.ContentID).
 			AddField("old-max-vol-size-int64", oldStatus.MaxVolSize).
-			AddField("old-state", oldStatus.State).
+			AddField("old-state", oldStatus.State.String()).
 			AddField("old-progress-int64", oldStatus.Progress).
 			AddField("old-refcount-int64", oldStatus.RefCount).
 			AddField("old-filelocation", oldStatus.FileLocation).
@@ -180,6 +187,10 @@ func (status VolumeStatus) LogDelete() {
 		status.VolumeID, status.LogKey())
 	logObject.CloneAndAddField("content-id", status.ContentID).
 		AddField("max-vol-size-int64", status.MaxVolSize).
+		AddField("state", status.State.String()).
+		AddField("progress-int64", status.Progress).
+		AddField("refcount-int64", status.RefCount).
+		AddField("filelocation", status.FileLocation).
 		Infof("Volume status delete")
 
 	base.DeleteLogObject(status.LogKey())
@@ -231,7 +242,6 @@ func (config VolumeRefConfig) LogModify(old interface{}) {
 		log.Errorf("LogModify: Old object interface passed is not of VolumeRefConfig type")
 	}
 	if oldConfig.RefCount != config.RefCount {
-
 		logObject.CloneAndAddField("refcount-int64", config.RefCount).
 			AddField("old-refcount-int64", oldConfig.RefCount).
 			Infof("Volume ref config modify")
@@ -299,7 +309,7 @@ func (status VolumeRefStatus) LogCreate() {
 	}
 	logObject.CloneAndAddField("refcount-int64", status.RefCount).
 		AddField("generation-counter-int64", status.GenerationCounter).
-		AddField("state", status.State).
+		AddField("state", status.State.String()).
 		AddField("filelocation", status.ActiveFileLocation).
 		AddField("content-format", status.ContentFormat).
 		AddField("read-only-bool", status.ReadOnly).
@@ -328,7 +338,7 @@ func (status VolumeRefStatus) LogModify(old interface{}) {
 		oldStatus.PendingAdd != status.PendingAdd {
 
 		logObject.CloneAndAddField("refcount-int64", status.RefCount).
-			AddField("state", status.State).
+			AddField("state", status.State.String()).
 			AddField("filelocation", status.ActiveFileLocation).
 			AddField("content-format", status.ContentFormat).
 			AddField("read-only-bool", status.ReadOnly).
@@ -352,6 +362,14 @@ func (status VolumeRefStatus) LogDelete() {
 	logObject := base.EnsureLogObject(base.VolumeRefStatusLogType, status.DisplayName,
 		status.VolumeID, status.LogKey())
 	logObject.CloneAndAddField("refcount-int64", status.RefCount).
+		AddField("generation-counter-int64", status.GenerationCounter).
+		AddField("state", status.State.String()).
+		AddField("filelocation", status.ActiveFileLocation).
+		AddField("content-format", status.ContentFormat).
+		AddField("read-only-bool", status.ReadOnly).
+		AddField("displayname", status.DisplayName).
+		AddField("max-vol-size-int64", status.MaxVolSize).
+		AddField("pending-add-bool", status.PendingAdd).
 		Infof("Volume ref status delete")
 
 	base.DeleteLogObject(status.LogKey())


### PR DESCRIPTION
@zed-rishabh please review one commit at a time.

The first one might fix latent bugs such as not reporting errors to the app instance when the volume exceeds the size.
The last one sets the state to initial, which means we avoid seeing zero in the log but also that we shouldn't see any transient "suspect" state in the UI due to publishing with State=0.

The other commits are cleanup and additions of logging.