### PR TITLE
update VolumeStatus from ContentTreeStatus

### DIFF
--- a/pkg/pillar/cmd/volumemgr/handleresolve.go
+++ b/pkg/pillar/cmd/volumemgr/handleresolve.go
@@ -10,7 +10,7 @@ import (
 
 // MaybeAddResolveConfig will publish the resolve config for
 // container images for which resolution of tags to sha requires
-func MaybeAddResolveConfig(ctx *volumemgrContext, cs *types.ContentTreeStatus) {
+func MaybeAddResolveConfig(ctx *volumemgrContext, cs types.ContentTreeStatus) {
 
 	log.Infof("MaybeAddResolveConfig for %s", cs.ContentID)
 	resolveConfig := types.ResolveConfig{

--- a/pkg/pillar/cmd/volumemgr/latchcontenthash.go
+++ b/pkg/pillar/cmd/volumemgr/latchcontenthash.go
@@ -100,6 +100,7 @@ func lookupLatchContentTreeHash(ctx *volumemgrContext,
 	return aih.Hash
 }
 
+// Can update status
 func maybeLatchContentTreeHash(ctx *volumemgrContext, status *types.ContentTreeStatus) {
 
 	imageSha := lookupLatchContentTreeHash(ctx, status.ContentID, uint32(status.GenerationCounter))

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -32,7 +32,7 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 				log.Infof("Resolve status not found for %s",
 					status.ContentID)
 				status.HasResolverRef = true
-				MaybeAddResolveConfig(ctx, status)
+				MaybeAddResolveConfig(ctx, *status)
 				status.State = types.RESOLVING_TAG
 				changed = true
 				return changed, false
@@ -186,6 +186,11 @@ func doUpdateVol(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool)
 		}
 		if status.Progress != ctStatus.Progress {
 			status.Progress = ctStatus.Progress
+			changed = true
+		}
+		if status.State != ctStatus.State {
+			status.State = ctStatus.State
+			changed = true
 		}
 		if ctStatus.State < types.VERIFIED {
 			// Waiting for content tree to be processed


### PR DESCRIPTION
@zed-rishabh Without this it is harder to debug, as we don't see state progression.
@deitch had a case where the ContentTreeStatus stayed in RESOLVED_TAG, but this didn't propagate to VolumeStatus and up.

Other change is to make it more clear which functions can modify status.