### PR TITLE
Moving baseosmgr to start using content tree instead of volumes

### DIFF
--- a/pkg/pillar/cmd/baseosmgr/baseosmgr.go
+++ b/pkg/pillar/cmd/baseosmgr/baseosmgr.go
@@ -32,20 +32,20 @@ const (
 var Version = "No version specified"
 
 type baseOsMgrContext struct {
-	pubBaseOsStatus pubsub.Publication
+	pubBaseOsStatus      pubsub.Publication
 	pubContentTreeConfig pubsub.Publication
-	pubZbootStatus  pubsub.Publication
+	pubZbootStatus       pubsub.Publication
 
-	subGlobalConfig    pubsub.Subscription
-	globalConfig       *types.ConfigItemValueMap
-	GCInitialized      bool
-	subBaseOsConfig    pubsub.Subscription
-	subZbootConfig     pubsub.Subscription
-	subContentTreeStatus    pubsub.Subscription
-	subNodeAgentStatus pubsub.Subscription
-	rebootReason       string    // From last reboot
-	rebootTime         time.Time // From last reboot
-	rebootImage        string    // Image from which the last reboot happened
+	subGlobalConfig      pubsub.Subscription
+	globalConfig         *types.ConfigItemValueMap
+	GCInitialized        bool
+	subBaseOsConfig      pubsub.Subscription
+	subZbootConfig       pubsub.Subscription
+	subContentTreeStatus pubsub.Subscription
+	subNodeAgentStatus   pubsub.Subscription
+	rebootReason         string    // From last reboot
+	rebootTime           time.Time // From last reboot
+	rebootImage          string    // Image from which the last reboot happened
 }
 
 var debug = false
@@ -159,12 +159,12 @@ func handleBaseOsCreate(ctxArg interface{}, key string, configArg interface{}) {
 		ConfigSha256:   config.ConfigSha256,
 	}
 
-	status.StorageStatusList = make([]types.StorageStatus,
-		len(config.StorageConfigList))
+	status.ContentTreeStatusList = make([]types.ContentTreeStatus,
+		len(config.ContentTreeConfigList))
 
-	for i, sc := range config.StorageConfigList {
-		ss := &status.StorageStatusList[i]
-		ss.UpdateFromStorageConfig(sc)
+	for i, ctc := range config.ContentTreeConfigList {
+		cts := &status.ContentTreeStatusList[i]
+		cts.UpdateFromContentTreeConfig(ctc)
 	}
 	// Check image count
 	err := validateBaseOsConfig(ctx, config)

--- a/pkg/pillar/cmd/baseosmgr/baseosmgr.go
+++ b/pkg/pillar/cmd/baseosmgr/baseosmgr.go
@@ -267,9 +267,8 @@ func initializeSelfPublishHandles(ps *pubsub.PubSub, ctx *baseOsMgrContext) {
 
 	pubContentTreeConfig, err := ps.NewPublication(
 		pubsub.PublicationOptions{
-			AgentName:  agentName,
-			AgentScope: types.BaseOsObj,
-			TopicType:  types.ContentTreeConfig{},
+			AgentName: agentName,
+			TopicType: types.ContentTreeConfig{},
 		})
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/pillar/cmd/baseosmgr/handlebaseos.go
+++ b/pkg/pillar/cmd/baseosmgr/handlebaseos.go
@@ -30,8 +30,8 @@ func lookupBaseOsImageSha(ctx *baseOsMgrContext, imageSha string) *types.BaseOsC
 	items := ctx.subBaseOsConfig.GetAll()
 	for _, c := range items {
 		config := c.(types.BaseOsConfig)
-		for _, sc := range config.StorageConfigList {
-			if sc.ImageSha256 == imageSha {
+		for _, ctc := range config.ContentTreeConfigList {
+			if ctc.ContentSha256 == imageSha {
 				return &config
 			}
 		}
@@ -209,10 +209,10 @@ func doBaseOsStatusUpdate(ctx *baseOsMgrContext, uuidStr string,
 
 func setProgressDone(status *types.BaseOsStatus, state types.SwState) {
 	status.State = state
-	for i := range status.StorageStatusList {
-		ss := &status.StorageStatusList[i]
-		ss.Progress = 100
-		ss.State = state
+	for i := range status.ContentTreeStatusList {
+		cts := &status.ContentTreeStatusList[i]
+		cts.Progress = 100
+		cts.State = state
 	}
 }
 
@@ -272,7 +272,8 @@ func doBaseOsActivate(ctx *baseOsMgrContext, uuidStr string,
 	publishBaseOsStatus(ctx, status)
 
 	// install the image at proper partition; dd etc
-	if installDownloadedObjects(uuidStr, &status.StorageStatusList) {
+	if installDownloadedObjects(uuidStr, status.PartitionLabel,
+		&status.ContentTreeStatusList) {
 
 		changed = true
 		// Match the version string inside image?
@@ -337,14 +338,14 @@ func doBaseOsInstall(ctx *baseOsMgrContext, uuidStr string,
 	changed := false
 	proceed := false
 
-	for i, sc := range config.StorageConfigList {
-		ss := &status.StorageStatusList[i]
-		if ss.Name != sc.Name || !uuid.Equal(ss.ImageID, sc.ImageID) {
+	for i, ctc := range config.ContentTreeConfigList {
+		cts := &status.ContentTreeStatusList[i]
+		if cts.RelativeURL != ctc.RelativeURL || !uuid.Equal(cts.ContentID, ctc.ContentID) {
 			// Report to zedcloud
-			errString := fmt.Sprintf("%s, for %s, Storage config mismatch:\n\t%s\n\t%s\n\t%s\n\t%s\n\n", uuidStr,
+			errString := fmt.Sprintf("%s, for %s, Content tree config mismatch:\n\t%s\n\t%s\n\t%s\n\t%s\n\n", uuidStr,
 				config.BaseOsVersion,
-				sc.Name, ss.Name,
-				sc.ImageID, ss.ImageID)
+				ctc.RelativeURL, cts.RelativeURL,
+				ctc.ContentID, cts.ContentID)
 			log.Error(errString)
 			status.SetErrorNow(errString)
 			changed = true
@@ -462,11 +463,6 @@ func validateAndAssignPartition(ctx *baseOsMgrContext,
 		status.PartitionState = otherPartStatus.PartitionState
 		status.PartitionDevice = otherPartStatus.PartitionDevname
 
-		// List has only one element but ...
-		for idx := range status.StorageStatusList {
-			ss := &status.StorageStatusList[idx]
-			ss.FinalObjDir = status.PartitionLabel
-		}
 		changed = true
 	}
 	proceed = true
@@ -480,8 +476,8 @@ func checkBaseOsVolumeStatus(ctx *baseOsMgrContext, baseOsUUID uuid.UUID,
 	uuidStr := baseOsUUID.String()
 	log.Infof("checkBaseOsVolumeStatus(%s) for %s",
 		config.BaseOsVersion, uuidStr)
-	ret := checkVolumeStatus(ctx, baseOsUUID, config.StorageConfigList,
-		status.StorageStatusList)
+	ret := checkContentTreeStatus(ctx, baseOsUUID, config.ContentTreeConfigList,
+		status.ContentTreeStatusList)
 
 	status.State = ret.MinState
 
@@ -604,30 +600,17 @@ func doBaseOsUninstall(ctx *baseOsMgrContext, uuidStr string,
 		status.PartitionLabel = ""
 		changed = true
 	}
-	for i := range status.StorageStatusList {
-		ss := &status.StorageStatusList[i]
-		// Decrease refcount if we had increased it
-		if ss.HasVolumemgrRef {
-			log.Infof("doBaseOsUninstall(%s) for %s, HasVolumemgrRef %s",
-				status.BaseOsVersion, uuidStr, ss.ImageID)
+	for i := range status.ContentTreeStatusList {
+		cts := &status.ContentTreeStatusList[i]
+		log.Infof("doBaseOsUninstall(%s) for %s",
+			status.BaseOsVersion, uuidStr)
+		unpublishContentTreeConfig(ctx, cts.Key())
+		changed = true
 
-			// We use the baseos object UUID as appInstID here
-			MaybeRemoveVolumeConfig(ctx, ss.ImageSha256,
-				status.UUIDandVersion.UUID, ss.ImageID)
-			ss.HasVolumemgrRef = false
-			changed = true
-		} else {
-			log.Infof("doBaseOsUninstall(%s) for %s, NO HasVolumemgrRef",
-				status.BaseOsVersion, uuidStr)
-		}
-
-		// We use the baseos object UUID as appInstID here
-		vs := lookupVolumeStatus(ctx, ss.ImageSha256,
-			status.UUIDandVersion.UUID, ss.ImageID)
-		if vs != nil {
-			log.Infof("doBaseOsUninstall(%s) for %s, Volume %s not yet gone; RefCount %d",
-				status.BaseOsVersion, uuidStr, ss.ImageID,
-				vs.RefCount)
+		contentStatus := lookupContentTreeStatus(ctx, cts.Key())
+		if contentStatus != nil {
+			log.Infof("doBaseOsUninstall(%s) for %s, Content %s not yet gone;",
+				status.BaseOsVersion, uuidStr, cts.ContentID)
 			removedAll = false
 			continue
 		}
@@ -753,7 +736,7 @@ func unpublishBaseOsStatus(ctx *baseOsMgrContext, key string) {
 // Check the number of image in this config
 func validateBaseOsConfig(ctx *baseOsMgrContext, config types.BaseOsConfig) error {
 
-	imageCount := len(config.StorageConfigList)
+	imageCount := len(config.ContentTreeConfigList)
 	if imageCount > BaseOsImageCount {
 		errStr := fmt.Sprintf("baseOs(%s) invalid image count %d",
 			config.BaseOsVersion, imageCount)
@@ -871,12 +854,6 @@ func baseOsSetPartitionInfoInStatus(ctx *baseOsMgrContext, status *types.BaseOsS
 		status.PartitionLabel = partName
 		status.PartitionState = partStatus.PartitionState
 		status.PartitionDevice = partStatus.PartitionDevname
-
-		// List has only one element but ...
-		for idx := range status.StorageStatusList {
-			ss := &status.StorageStatusList[idx]
-			ss.FinalObjDir = status.PartitionLabel
-		}
 	}
 }
 

--- a/pkg/pillar/cmd/baseosmgr/handledownload.go
+++ b/pkg/pillar/cmd/baseosmgr/handledownload.go
@@ -17,93 +17,73 @@ import (
 // Really a constant
 var nilUUID uuid.UUID
 
-func checkVolumeStatus(ctx *baseOsMgrContext,
-	baseOsUUID uuid.UUID, config []types.StorageConfig,
-	status []types.StorageStatus) *types.RetStatus {
+func checkContentTreeStatus(ctx *baseOsMgrContext,
+	baseOsUUID uuid.UUID, config []types.ContentTreeConfig,
+	status []types.ContentTreeStatus) *types.RetStatus {
 
 	uuidStr := baseOsUUID.String()
 	ret := &types.RetStatus{}
-	log.Infof("checkVolumeStatus for %s", uuidStr)
+	log.Infof("checkContentTreeStatus for %s", uuidStr)
 
 	ret.Changed = false
 	ret.AllErrors = ""
 	ret.MinState = types.MAXSTATE
 
-	for i, sc := range config {
+	for i, ctc := range config {
 
-		ss := &status[i]
+		cts := &status[i]
 
-		imageID := sc.ImageID
+		contentID := ctc.ContentID
 
-		log.Infof("checkVolumeStatus %s, image status %v",
-			imageID, ss.State)
-		if ss.State == types.INSTALLED {
-			ret.MinState = ss.State
-			ss.Progress = 100
+		log.Infof("checkContentTreeStatus %s, content status %v",
+			contentID, cts.State)
+		if cts.State == types.INSTALLED {
+			ret.MinState = cts.State
+			cts.Progress = 100
 			ret.Changed = true
-			log.Infof("checkVolumeStatus %s is already installed",
-				imageID)
+			log.Infof("checkContentTreeStatus %s is already installed",
+				contentID)
 			continue
 		}
 
-		if !ss.HasVolumemgrRef {
-			log.Infof("checkVolumeStatus %s, !HasVolumemgrRef", sc.ImageID)
-			// We use the baseos object UUID as appInstID here
-			// XXX note that we use the ImageID for the VolumeID
-			// argument since we do not have a VolumeID
-			AddOrRefcountVolumeConfig(ctx, ss.ImageSha256,
-				baseOsUUID, ss.ImageID, *ss)
-			ss.HasVolumemgrRef = true
-			ret.Changed = true
-		}
-		// We use the baseos object UUID as appInstID here
-		vs := lookupVolumeStatus(ctx, ss.ImageSha256, baseOsUUID, ss.ImageID)
-		if vs == nil || vs.RefCount == 0 {
-			if vs == nil {
-				log.Infof("VolumeStatus not found. name: %s",
-					ss.Name)
-			} else {
-				log.Infof("VolumeStatus RefCount zero. name: %s",
-					ss.Name)
-			}
+		publishContentTreeConfig(ctx, &ctc)
+		ret.Changed = true
+		contentStatus := lookupContentTreeStatus(ctx, ctc.Key())
+		if contentStatus == nil {
+			log.Infof("Content tree status not found. name: %s", ctc.RelativeURL)
 			ret.MinState = types.DOWNLOADING
-			ss.State = types.DOWNLOADING
+			cts.State = types.DOWNLOADING
 			ret.Changed = true
 			continue
 		}
 
-		if vs.FileLocation != ss.ActiveFileLocation {
-			ss.ActiveFileLocation = vs.FileLocation
+		if contentStatus.FileLocation != cts.FileLocation {
+			cts.FileLocation = contentStatus.FileLocation
 			ret.Changed = true
-			log.Infof("checkVolumeStatus(%s) from vs set ActiveFileLocation to %s",
-				imageID, vs.FileLocation)
+			log.Infof("checkContentTreeStatus(%s) from contentStatus set FileLocation to %s",
+				contentID, contentStatus.FileLocation)
 		}
-		if ret.MinState > vs.State {
-			ret.MinState = vs.State
+		if ret.MinState > contentStatus.State {
+			ret.MinState = contentStatus.State
 		}
-		if vs.State != ss.State {
-			log.Infof("checkVolumeStatus(%s) from ds set ss.State %d",
-				imageID, vs.State)
-			ss.State = vs.State
+		if contentStatus.State != cts.State {
+			log.Infof("checkContentTreeStatus(%s) from ds set cts.State %d",
+				contentID, contentStatus.State)
+			cts.State = contentStatus.State
 			ret.Changed = true
 		}
 
-		if vs.Progress != ss.Progress {
-			ss.Progress = vs.Progress
+		if contentStatus.Progress != cts.Progress {
+			cts.Progress = contentStatus.Progress
 			ret.Changed = true
 		}
-		if vs.Pending() {
-			log.Infof("checkVolumeStatus(%s) Pending",
-				imageID)
-			continue
-		}
-		if vs.HasError() {
-			log.Errorf("checkVolumeStatus %s, volumemgr error, %s",
-				uuidStr, vs.Error)
-			ss.SetErrorWithSource(vs.Error, types.OldVolumeStatus{},
-				vs.ErrorTime)
-			ret.AllErrors = appendError(ret.AllErrors, "volumemgr", vs.Error)
-			ret.ErrorTime = ss.ErrorTime
+		if contentStatus.HasError() {
+			log.Errorf("checkContentTreeStatus %s, volumemgr error, %s",
+				uuidStr, contentStatus.Error)
+			cts.SetErrorWithSource(contentStatus.Error, types.ContentTreeStatus{},
+				contentStatus.ErrorTime)
+			ret.AllErrors = appendError(ret.AllErrors, "volumemgr", contentStatus.Error)
+			ret.ErrorTime = cts.ErrorTime
 			ret.Changed = true
 		}
 	}
@@ -118,23 +98,23 @@ func checkVolumeStatus(ctx *baseOsMgrContext,
 }
 
 // Note: can not do this in volumemgr since it is triggered by Activate=true
-func installDownloadedObjects(uuidStr string,
-	status *[]types.StorageStatus) bool {
+func installDownloadedObjects(uuidStr, FinalObjDir string,
+	status *[]types.ContentTreeStatus) bool {
 
 	ret := true
 	log.Infof("installDownloadedObjects(%s)", uuidStr)
 
 	for i := range *status {
-		ssPtr := &(*status)[i]
+		ctsPtr := &(*status)[i]
 
-		if ssPtr.State == types.CREATED_VOLUME {
-			err := installDownloadedObject(ssPtr.ImageID, ssPtr)
+		if ctsPtr.State == types.VERIFIED {
+			err := installDownloadedObject(ctsPtr.ContentID, FinalObjDir, ctsPtr)
 			if err != nil {
 				log.Error(err)
 			}
 		}
 		// if something is still not installed, mark accordingly
-		if ssPtr.State != types.INSTALLED {
+		if ctsPtr.State != types.INSTALLED {
 			ret = false
 		}
 	}
@@ -144,25 +124,25 @@ func installDownloadedObjects(uuidStr string,
 }
 
 // If the final installation directory is known, move the object there
-func installDownloadedObject(imageID uuid.UUID,
-	ssPtr *types.StorageStatus) error {
+func installDownloadedObject(contentID uuid.UUID, FinalObjDir string,
+	ctsPtr *types.ContentTreeStatus) error {
 
 	var ret error
 	var srcFilename string
 
 	log.Infof("installDownloadedObject(%s, %v)",
-		imageID, ssPtr.State)
+		contentID, ctsPtr.State)
 
-	if ssPtr.State != types.CREATED_VOLUME {
+	if ctsPtr.State != types.VERIFIED {
 		return nil
 	}
-	srcFilename = ssPtr.ActiveFileLocation
+	srcFilename = ctsPtr.FileLocation
 	if srcFilename == "" {
-		log.Fatalf("XXX no ActiveFileLocation for CREATED_VOLUME %s",
-			imageID)
+		log.Fatalf("XXX no FileLocation for VERIFIED %s",
+			contentID)
 	}
-	log.Infof("For %s ActiveFileLocation for CREATED_VOLUME: %s",
-		imageID, srcFilename)
+	log.Infof("For %s FileLocation for VERIFIED: %s",
+		contentID, srcFilename)
 
 	// ensure the file is present
 	if _, err := os.Stat(srcFilename); err != nil {
@@ -170,23 +150,22 @@ func installDownloadedObject(imageID uuid.UUID,
 	}
 
 	// Move to final installation point
-	if ssPtr.FinalObjDir != "" {
-
-		var dstFilename string = ssPtr.FinalObjDir
+	if FinalObjDir != "" {
+		var dstFilename string = FinalObjDir
 		ret = installBaseOsObject(srcFilename, dstFilename)
 	} else {
 		errStr := fmt.Sprintf("installDownloadedObject %s, final dir not set",
-			imageID)
+			contentID)
 		log.Errorln(errStr)
 		ret = errors.New(errStr)
 	}
 
 	if ret == nil {
-		ssPtr.State = types.INSTALLED
-		log.Infof("installDownloadedObject(%s) done", imageID)
+		ctsPtr.State = types.INSTALLED
+		log.Infof("installDownloadedObject(%s) done", contentID)
 	} else {
 		errStr := fmt.Sprintf("installDownloadedObject: %s", ret)
-		ssPtr.SetErrorWithSource(errStr, types.OldVolumeStatus{}, time.Now())
+		ctsPtr.SetErrorWithSource(errStr, types.ContentTreeStatus{}, time.Now())
 	}
 	return ret
 }

--- a/pkg/pillar/cmd/baseosmgr/handlevolumemgr.go
+++ b/pkg/pillar/cmd/baseosmgr/handlevolumemgr.go
@@ -10,6 +10,32 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// MaybeAddContentTreeConfig makes sure we have a ContentTreeConfig
+func MaybeAddContentTreeConfig(ctx *baseOsMgrContext, ctc *types.ContentTreeConfig) bool {
+	log.Infof("MaybeAddContentTreeConfig for %s", ctc.Key())
+	m := lookupContentTreeConfig(ctx, ctc.Key())
+	if m != nil {
+		log.Infof("Content tree config exists for %s", ctc.Key())
+		return false
+	}
+	publishContentTreeConfig(ctx, ctc)
+	log.Infof("MaybeAddContentTreeConfig for %s Done", ctc.Key())
+	return true
+}
+
+// MaybeRemoveContentTreeConfig deletes the ContentTreeConfig
+func MaybeRemoveContentTreeConfig(ctx *baseOsMgrContext, key string) bool {
+	log.Infof("MaybeRemoveContentTreeConfig for %s", key)
+	m := lookupContentTreeConfig(ctx, key)
+	if m == nil {
+		log.Infof("MaybeRemoveContentTreeConfig: config doesn't exist for %s", key)
+		return false
+	}
+	unpublishContentTreeConfig(ctx, key)
+	log.Infof("MaybeRemoveContentTreeConfig for %s Done", key)
+	return true
+}
+
 func lookupContentTreeConfig(ctx *baseOsMgrContext, key string) *types.ContentTreeConfig {
 
 	pub := ctx.pubContentTreeConfig

--- a/pkg/pillar/cmd/baseosmgr/handlevolumemgr.go
+++ b/pkg/pillar/cmd/baseosmgr/handlevolumemgr.go
@@ -11,16 +11,15 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// AddOrRefcountVolumeConfig makes sure we have a VolumeConfig with a non-zero
-// RefCount
-// We use the baseos object UUID as appInstID here
-func AddOrRefcountVolumeConfig(ctx *baseOsMgrContext, blobSha256 string,
+// AddOrRefcountContentTreeConfig makes sure we have a ContentTreeConfig
+// with a non-zero refCount
+func AddOrRefcountContentTreeConfig(ctx *baseOsMgrContext, blobSha256 string,
 	appInstID uuid.UUID, volumeID uuid.UUID, ss types.StorageStatus) {
 
 	// No PurgeCounter for baseos
 	key := types.VolumeKeyFromParts(blobSha256, appInstID, volumeID, 0)
 	log.Infof("AddOrRefcountVolumeConfig for %s", key)
-	m := lookupVolumeConfig(ctx, key)
+	m := lookupContentTreeConfig(ctx, key)
 	if m != nil {
 		m.RefCount++
 		log.Infof("VolumeConfig exists for %s to refcount %d",
@@ -93,15 +92,15 @@ func MaybeRemoveVolumeConfig(ctx *baseOsMgrContext, blobSha256 string,
 	}
 }
 
-func lookupVolumeConfig(ctx *baseOsMgrContext, key string) *types.OldVolumeConfig {
+func lookupVolumeConfig(ctx *baseOsMgrContext, key string) *types.ContentTreeConfig {
 
-	pub := ctx.pubVolumeConfig
+	pub := ctx.pubContentTreeConfig
 	c, _ := pub.Get(key)
 	if c == nil {
 		log.Infof("lookupVolumeConfig(%s) not found", key)
 		return nil
 	}
-	config := c.(types.OldVolumeConfig)
+	config := c.(types.ContentTreeConfig)
 	return &config
 }
 
@@ -127,7 +126,7 @@ func publishVolumeConfig(ctx *baseOsMgrContext,
 
 	key := status.Key()
 	log.Infof("publishVolumeConfig(%s)", key)
-	pub := ctx.pubVolumeConfig
+	pub := ctx.pubContentTreeConfig
 	pub.Publish(key, *status)
 }
 

--- a/pkg/pillar/cmd/volumemgr/context.go
+++ b/pkg/pillar/cmd/volumemgr/context.go
@@ -18,10 +18,12 @@ func (ctx *volumemgrContext) subscription(topicType interface{}, objType string)
 		log.Fatalf("subscription got a pointer type: %T", topicType)
 	}
 	switch typeName := topicType.(type) {
-	case types.OldVolumeConfig:
+	case types.ContentTreeConfig:
 		switch objType {
+		case types.AppImgObj:
+			sub = ctx.subContentTreeConfig
 		case types.BaseOsObj:
-			sub = ctx.subBaseOsVolumeConfig
+			sub = ctx.subBaseOsContentTreeConfig
 		default:
 			log.Fatalf("subscription: Unknown ObjType %s for %T",
 				objType, typeName)
@@ -66,10 +68,18 @@ func (ctx *volumemgrContext) publication(topicType interface{}, objType string) 
 		switch objType {
 		case types.AppImgObj:
 			pub = ctx.pubAppVolumeStatus
-		case types.BaseOsObj:
-			pub = ctx.pubBaseOsVolumeStatus
 		case types.UnknownObj:
 			pub = ctx.pubUnknownOldVolumeStatus
+		default:
+			log.Fatalf("publication: Unknown ObjType %s for %T",
+				objType, typeName)
+		}
+	case types.ContentTreeStatus:
+		switch objType {
+		case types.AppImgObj:
+			pub = ctx.pubContentTreeStatus
+		case types.BaseOsObj:
+			pub = ctx.pubBaseOsContentTreeStatus
 		default:
 			log.Fatalf("publication: Unknown ObjType %s for %T",
 				objType, typeName)

--- a/pkg/pillar/cmd/volumemgr/handlecontent.go
+++ b/pkg/pillar/cmd/volumemgr/handlecontent.go
@@ -45,7 +45,7 @@ func publishContentTreeStatus(ctx *volumemgrContext, status *types.ContentTreeSt
 
 	key := status.Key()
 	log.Debugf("publishContentTreeStatus(%s)", key)
-	pub := ctx.pubContentTreeStatus
+	pub := ctx.publication(types.ContentTreeStatus{}, status.ObjType)
 	pub.Publish(key, *status)
 	log.Debugf("publishContentTreeStatus(%s) Done", key)
 }
@@ -54,7 +54,7 @@ func unpublishContentTreeStatus(ctx *volumemgrContext, status *types.ContentTree
 
 	key := status.Key()
 	log.Debugf("unpublishContentTreeStatus(%s)", key)
-	pub := ctx.pubContentTreeStatus
+	pub := ctx.publication(types.ContentTreeStatus{}, status.ObjType)
 	c, _ := pub.Get(key)
 	if c == nil {
 		log.Errorf("unpublishContentTreeStatus(%s) not found", key)
@@ -65,10 +65,10 @@ func unpublishContentTreeStatus(ctx *volumemgrContext, status *types.ContentTree
 }
 
 func lookupContentTreeStatus(ctx *volumemgrContext,
-	key string) *types.ContentTreeStatus {
+	key, objType string) *types.ContentTreeStatus {
 
 	log.Infof("lookupContentTreeStatus(%s)", key)
-	pub := ctx.pubContentTreeStatus
+	pub := ctx.publication(types.ContentTreeStatus{}, objType)
 	c, _ := pub.Get(key)
 	if c == nil {
 		log.Infof("lookupContentTreeStatus(%s) not found", key)
@@ -80,10 +80,10 @@ func lookupContentTreeStatus(ctx *volumemgrContext,
 }
 
 func lookupContentTreeConfig(ctx *volumemgrContext,
-	key string) *types.ContentTreeConfig {
+	key, objType string) *types.ContentTreeConfig {
 
 	log.Infof("lookupContentTreeConfig(%s)", key)
-	sub := ctx.subContentTreeConfig
+	sub := ctx.subscription(types.ContentTreeConfig{}, objType)
 	c, _ := sub.Get(key)
 	if c == nil {
 		log.Infof("lookupContentTreeConfig(%s) not found", key)
@@ -96,7 +96,7 @@ func lookupContentTreeConfig(ctx *volumemgrContext,
 
 func updateContentTree(ctx *volumemgrContext, config types.ContentTreeConfig) {
 	log.Infof("updateContentTree for %v", config.ContentID)
-	status := lookupContentTreeStatus(ctx, config.Key())
+	status := lookupContentTreeStatus(ctx, config.Key(), config.ObjType)
 	if status == nil {
 		status = &types.ContentTreeStatus{
 			ContentID:         config.ContentID,
@@ -110,7 +110,7 @@ func updateContentTree(ctx *volumemgrContext, config types.ContentTreeConfig) {
 			SignatureKey:      config.SignatureKey,
 			CertificateChain:  config.CertificateChain,
 			DisplayName:       config.DisplayName,
-			ObjType:           types.AppImgObj,
+			ObjType:           config.ObjType,
 			State:             types.INITIAL,
 			Blobs:             []string{},
 		}
@@ -136,7 +136,7 @@ func updateContentTree(ctx *volumemgrContext, config types.ContentTreeConfig) {
 					Size:        config.MaxDownloadSize,
 					State:       types.INITIAL,
 					BlobType:    blobType,
-					ObjType:     types.AppImgObj,
+					ObjType:     config.ObjType,
 				}
 				publishBlobStatus(ctx, rootBlob)
 			}
@@ -153,7 +153,7 @@ func updateContentTree(ctx *volumemgrContext, config types.ContentTreeConfig) {
 
 func deleteContentTree(ctx *volumemgrContext, config types.ContentTreeConfig) {
 	log.Infof("deleteContentTree for %v", config.ContentID)
-	status := lookupContentTreeStatus(ctx, config.Key())
+	status := lookupContentTreeStatus(ctx, config.Key(), config.ObjType)
 	if status == nil {
 		log.Infof("deleteContentTree for %v, ContentTreeStatus not found", config.ContentID)
 		return

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -307,7 +307,7 @@ func doUpdateVol(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool)
 		changed = true
 		return changed, false
 	case zconfig.VolumeContentOriginType_VCOT_DOWNLOAD:
-		ctStatus := lookupContentTreeStatus(ctx, status.ContentID.String())
+		ctStatus := lookupContentTreeStatus(ctx, status.ContentID.String(), types.AppImgObj)
 		if ctStatus == nil {
 			// Content tree not available
 			log.Errorf("doUpdateVol(%s) name %s: waiting for content tree status %v",
@@ -442,27 +442,9 @@ func updateStatus(ctx *volumemgrContext, objType, sha string) {
 
 	log.Infof("updateStatus(%s) objType %s", sha, objType)
 	found := false
-	volPub := ctx.publication(types.OldVolumeStatus{}, objType)
-	volItems := volPub.GetAll()
-	for _, st := range volItems {
-		status := st.(types.OldVolumeStatus)
-		var hasSha bool
-		for _, blobSha := range status.Blobs {
-			if blobSha == sha {
-				log.Infof("Found blob %s on VolumeStatus %s", sha, status.Key())
-				hasSha = true
-			}
-		}
-		if hasSha {
-			found = true
-			if changed, _ := doUpdateOld(ctx, &status); changed {
-				publishOldVolumeStatus(ctx, &status)
-			}
-		}
-	}
-	ctPub := ctx.pubContentTreeStatus
-	ctItems := ctPub.GetAll()
-	for _, st := range ctItems {
+	pub := ctx.publication(types.ContentTreeStatus{}, objType)
+	items := pub.GetAll()
+	for _, st := range items {
 		status := st.(types.ContentTreeStatus)
 		var hasSha bool
 		for _, blobSha := range status.Blobs {

--- a/pkg/pillar/cmd/zedagent/handlecontent.go
+++ b/pkg/pillar/cmd/zedagent/handlecontent.go
@@ -66,6 +66,7 @@ func parseContentInfoConfig(ctx *getconfigContext,
 		contentConfig.ContentSha256 = strings.ToLower(cfgContentTree.GetSha256())
 		contentConfig.MaxDownloadSize = cfgContentTree.GetMaxSizeBytes()
 		contentConfig.DisplayName = cfgContentTree.GetDisplayName()
+		contentConfig.ObjType = types.AppImgObj
 		contentConfig.ImageSignature = cfgContentTree.Siginfo.Signature
 		contentConfig.SignatureKey = cfgContentTree.Siginfo.Signercerturl
 

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -824,9 +824,9 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 			swInfo.Status = bos.State.ZSwState()
 			swInfo.ShortVersion = bos.BaseOsVersion
 			swInfo.LongVersion = "" // XXX
-			if len(bos.StorageStatusList) > 0 {
-				// Assume one - pick first StorageStatus
-				swInfo.DownloadProgress = uint32(bos.StorageStatusList[0].Progress)
+			if len(bos.ContentTreeStatusList) > 0 {
+				// Assume one - pick first ContentTreeStatus
+				swInfo.DownloadProgress = uint32(bos.ContentTreeStatusList[0].Progress)
 			}
 			if !bos.ErrorTime.IsZero() {
 				log.Debugf("reportMetrics sending error time %v error %v for %s",
@@ -877,9 +877,9 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 		swInfo.Status = bos.State.ZSwState()
 		swInfo.ShortVersion = bos.BaseOsVersion
 		swInfo.LongVersion = "" // XXX
-		if len(bos.StorageStatusList) > 0 {
-			// Assume one - pick first StorageStatus
-			swInfo.DownloadProgress = uint32(bos.StorageStatusList[0].Progress)
+		if len(bos.ContentTreeStatusList) > 0 {
+			// Assume one - pick first ContentTreeStatus
+			swInfo.DownloadProgress = uint32(bos.ContentTreeStatusList[0].Progress)
 		}
 		if !bos.ErrorTime.IsZero() {
 			log.Debugf("reportMetrics sending error time %v error %v for %s",

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -980,9 +980,10 @@ func parseContentTreeConfigList(contentTreeList []types.ContentTreeConfig, drive
 			contentTree.DatastoreID, _ = uuid.FromString(drive.Image.DsId)
 			contentTree.RelativeURL = drive.Image.Name
 			contentTree.Format = drive.Image.Iformat
-			contentTree.ContentSha256 = drive.Image.Sha256
+			contentTree.ContentSha256 = strings.ToLower(drive.Image.Sha256)
 			contentTree.MaxDownloadSize = uint64(drive.Image.SizeBytes)
 			contentTree.DisplayName = drive.Image.Name
+			contentTree.ObjType = types.BaseOsObj
 			contentTree.ImageSignature = drive.Image.Siginfo.Signature
 			contentTree.SignatureKey = drive.Image.Siginfo.Signercerturl
 

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -164,7 +164,7 @@ func parseBaseOsConfig(getconfigCtx *getconfigContext,
 			baseOs.OsParams[jdx] = *param
 		}
 
-		baseOs.StorageConfigList = make([]types.StorageConfig,
+		baseOs.ContentTreeConfigList = make([]types.StorageConfig,
 			len(cfgOs.Drives))
 		parseStorageConfigList(types.BaseOsObj, baseOs.StorageConfigList,
 			cfgOs.Drives)

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -164,20 +164,13 @@ func parseBaseOsConfig(getconfigCtx *getconfigContext,
 			baseOs.OsParams[jdx] = *param
 		}
 
-		baseOs.ContentTreeConfigList = make([]types.StorageConfig,
+		baseOs.ContentTreeConfigList = make([]types.ContentTreeConfig,
 			len(cfgOs.Drives))
-		parseStorageConfigList(types.BaseOsObj, baseOs.StorageConfigList,
-			cfgOs.Drives)
+		parseContentTreeConfigList(baseOs.ContentTreeConfigList, cfgOs.Drives)
 
-		certInstance := getCertObjects(baseOs.UUIDandVersion,
-			baseOs.ConfigSha256, baseOs.StorageConfigList)
 		log.Debugf("parseBaseOsConfig publishing %v",
 			baseOs)
 		publishBaseOsConfig(getconfigCtx, baseOs)
-		if certInstance != nil {
-			publishCertObjConfig(getconfigCtx, certInstance,
-				baseOs.Key())
-		}
 	}
 }
 
@@ -971,27 +964,27 @@ func publishDatastoreConfig(ctx *getconfigContext,
 	}
 }
 
-func parseStorageConfigList(objType string,
-	storageList []types.StorageConfig, drives []*zconfig.Drive) {
+func parseContentTreeConfigList(contentTreeList []types.ContentTreeConfig, drives []*zconfig.Drive) {
 
 	var idx int = 0
 
 	for _, drive := range drives {
-		image := new(types.StorageConfig)
+		contentTree := new(types.ContentTreeConfig)
 		if drive.Image == nil {
 			log.Errorf("No drive.Image for drive %v",
 				drive)
 			// Pass on for error reporting
-			image.DatastoreID = nilUUID
+			contentTree.ContentID = nilUUID
 		} else {
-			id, _ := uuid.FromString(drive.Image.DsId)
-			image.DatastoreID = id
-			image.Name = drive.Image.Name
-			image.ImageID, _ = uuid.FromString(drive.Image.Uuidandversion.Uuid)
-			image.Format = drive.Image.Iformat
-			image.MaxDownSize = uint64(drive.Image.SizeBytes)
-			image.ImageSignature = drive.Image.Siginfo.Signature
-			image.SignatureKey = drive.Image.Siginfo.Signercerturl
+			contentTree.ContentID, _ = uuid.FromString(drive.Image.Uuidandversion.Uuid)
+			contentTree.DatastoreID, _ = uuid.FromString(drive.Image.DsId)
+			contentTree.RelativeURL = drive.Image.Name
+			contentTree.Format = drive.Image.Iformat
+			contentTree.ContentSha256 = drive.Image.Sha256
+			contentTree.MaxDownloadSize = uint64(drive.Image.SizeBytes)
+			contentTree.DisplayName = drive.Image.Name
+			contentTree.ImageSignature = drive.Image.Siginfo.Signature
+			contentTree.SignatureKey = drive.Image.Siginfo.Signercerturl
 
 			// XXX:FIXME certificates can be many
 			// this list, currently contains the certUrls
@@ -999,15 +992,11 @@ func parseStorageConfigList(objType string,
 			// as proper DataStore Entries
 
 			if drive.Image.Siginfo.Intercertsurl != "" {
-				image.CertificateChain = make([]string, 1)
-				image.CertificateChain[0] = drive.Image.Siginfo.Intercertsurl
+				contentTree.CertificateChain = make([]string, 1)
+				contentTree.CertificateChain[0] = drive.Image.Siginfo.Intercertsurl
 			}
 		}
-		image.ReadOnly = drive.Readonly
-		image.MaxVolSize = uint64(drive.Maxsizebytes)
-		image.Target = strings.ToLower(drive.Target.String())
-		image.ImageSha256 = strings.ToLower(drive.Image.Sha256)
-		storageList[idx] = *image
+		contentTreeList[idx] = *contentTree
 		idx++
 	}
 }

--- a/pkg/pillar/types/contenttreetypes.go
+++ b/pkg/pillar/types/contenttreetypes.go
@@ -145,6 +145,20 @@ func (status ContentTreeStatus) IsContainer() bool {
 	return false
 }
 
+func (status *ContentTreeStatus) UpdateFromContentTreeConfig(config ContentTreeConfig) {
+	status.ContentID = config.ContentID
+	status.DatastoreID = config.DatastoreID
+	status.RelativeURL = config.RelativeURL
+	status.Format = config.Format
+	status.ContentSha256 = config.ContentSha256
+	status.MaxDownloadSize = config.MaxDownloadSize
+	status.GenerationCounter = config.GenerationCounter
+	status.ImageSignature = config.ImageSignature
+	status.SignatureKey = config.SignatureKey
+	status.CertificateChain = config.CertificateChain
+	status.DisplayName = config.DisplayName
+}
+
 // LogCreate :
 func (status ContentTreeStatus) LogCreate() {
 	logObject := base.NewLogObject(base.ContentTreeStatusLogType, status.DisplayName,

--- a/pkg/pillar/types/contenttreetypes.go
+++ b/pkg/pillar/types/contenttreetypes.go
@@ -28,6 +28,7 @@ type ContentTreeConfig struct {
 	SignatureKey      string   //certificate containing public key
 	CertificateChain  []string //name of intermediate certificates
 	DisplayName       string
+	ObjType           string
 }
 
 // Key is content info UUID which will be unique
@@ -145,6 +146,7 @@ func (status ContentTreeStatus) IsContainer() bool {
 	return false
 }
 
+// UpdateFromContentTreeConfig sets up ContentTreeStatus based on ContentTreeConfig struct
 func (status *ContentTreeStatus) UpdateFromContentTreeConfig(config ContentTreeConfig) {
 	status.ContentID = config.ContentID
 	status.DatastoreID = config.DatastoreID
@@ -157,6 +159,7 @@ func (status *ContentTreeStatus) UpdateFromContentTreeConfig(config ContentTreeC
 	status.SignatureKey = config.SignatureKey
 	status.CertificateChain = config.CertificateChain
 	status.DisplayName = config.DisplayName
+	status.ObjType = config.ObjType
 }
 
 // LogCreate :

--- a/pkg/pillar/types/zedagenttypes.go
+++ b/pkg/pillar/types/zedagenttypes.go
@@ -20,18 +20,18 @@ type OsVerParams struct {
 // This is what we assume will come from the ZedControl for base OS.
 // Note that we can have different versions  configured for the
 // same UUID, hence the key is the UUIDandVersion  We assume the
-// elements in StorageConfig should be installed, but activation
+// elements in ContentTreeConfig should be installed, but activation
 // is driven by the Activate attribute.
 
 type BaseOsConfig struct {
-	UUIDandVersion    UUIDandVersion
-	BaseOsVersion     string // From GetShortVersion
-	ConfigSha256      string
-	ConfigSignature   string
-	OsParams          []OsVerParams // From GetLongVersion
-	StorageConfigList []StorageConfig
-	RetryCount        int32
-	Activate          bool
+	UUIDandVersion        UUIDandVersion
+	BaseOsVersion         string // From GetShortVersion
+	ConfigSha256          string
+	ConfigSignature       string
+	OsParams              []OsVerParams // From GetLongVersion
+	ContentTreeConfigList []ContentTreeConfig
+	RetryCount            int32
+	Activate              bool
 }
 
 func (config BaseOsConfig) Key() string {
@@ -94,17 +94,17 @@ func (config BaseOsConfig) LogKey() string {
 
 // Indexed by UUIDandVersion as above
 type BaseOsStatus struct {
-	UUIDandVersion    UUIDandVersion
-	BaseOsVersion     string
-	ConfigSha256      string
-	Activated         bool
-	Reboot            bool
-	TooEarly          bool // Failed since previous was inprogress/test
-	OsParams          []OsVerParams
-	StorageStatusList []StorageStatus
-	PartitionLabel    string
-	PartitionDevice   string // From zboot
-	PartitionState    string // From zboot
+	UUIDandVersion        UUIDandVersion
+	BaseOsVersion         string
+	ConfigSha256          string
+	Activated             bool
+	Reboot                bool
+	TooEarly              bool // Failed since previous was inprogress/test
+	OsParams              []OsVerParams
+	ContentTreeStatusList []ContentTreeStatus
+	PartitionLabel        string
+	PartitionDevice       string // From zboot
+	PartitionState        string // From zboot
 
 	// Mininum state across all steps/StorageStatus.
 	// Error* set implies error.


### PR DESCRIPTION
With these changes, ```baseosmgr``` will request for the content tree to the ```volumemgr``` instead of volumes.