### PR TITLE
Fixing /hostfs and adding debugging block to storage-init

### DIFF
--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -2,6 +2,20 @@
 
 This document describes various scenarios and how to debug them. It is a living document to which elements will be added.
 
+## Live updates of system containers
+
+In order to aid rapid edit/compile/debug cycle EVE's storage-init container can be instructed to dynamically
+substitute systems containers with a copy under `/persist/service`. This requires building a special EVE image
+with the code block at the bottom of [storage-init.sh](../pkg/storage-init/storage-init.sh) uncommented. Once
+that image is ready, content of the `/persist/service/<service name>` will be made available as a rootfs of
+the `<service name>`. For example, in order to rapidly iterate on pillar services one can:
+
+```
+cp -r /containers/services/pillar/lower /persist/service/pillar
+# edit content under /persist/service/pillar
+# reboot and enjoy updates to the pillar container
+``` 
+
 ## Reboots
 
 EVE is architected in such a way that if any service is unresponsive for a period of time, the entire device will reboot. To track

--- a/pkg/storage-init/build.yml
+++ b/pkg/storage-init/build.yml
@@ -9,7 +9,7 @@ config:
   binds:
     - /dev:/dev
     - /var:/var:rshared,rbind
-    - /:/hostfs
+    - /containers:/containers:rshared,rbind
   rootfsPropagation: shared
   net: host
   capabilities:


### PR DESCRIPTION
This is obviously a cleanup, but at the very bottom of this PR you will find "one weird trick" that may just save you a lot of debugging time. If you uncomment that block you can create a new content for any of the EVE's services containers under /persist/services/<SVC-NAME> and it will be used instead of the one in rootfs.

This is, obviously, a lifesaver when you debugging a lot of pillar code since you can simply create /persist/services/pillar and keep updating it to your heart's content without rebuilding rootfs or anything silly like that.