### PR TITLE
Avoiding un-necessary error log messages

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -1619,13 +1619,17 @@ func PublishVolumeToZedCloud(ctx *zedagentContext, uuid string,
 			ReportVolumeInfo.VolumeErr = errInfo
 		}
 
-		VolumeResourcesInfo := new(info.VolumeResources)
-		err := getVolumeResourcesInfo(volStatus, VolumeResourcesInfo)
-		if err != nil {
-			log.Errorf("getVolumeResourceInfo(%s) failed %v",
-				volStatus.VolumeID, err)
+		if volStatus.FileLocation == "" {
+			log.Infof("FileLocation is empty for %s", volStatus.Key())
 		} else {
-			ReportVolumeInfo.Resources = VolumeResourcesInfo
+			VolumeResourcesInfo := new(info.VolumeResources)
+			err := getVolumeResourcesInfo(volStatus, VolumeResourcesInfo)
+			if err != nil {
+				log.Errorf("getVolumeResourceInfo(%s) failed %v",
+					volStatus.VolumeID, err)
+			} else {
+				ReportVolumeInfo.Resources = VolumeResourcesInfo
+			}
 		}
 
 		ReportVolumeInfo.ProgressPercentage = uint32(volStatus.Progress)

--- a/pkg/pillar/cmd/zedagent/handlevolume.go
+++ b/pkg/pillar/cmd/zedagent/handlevolume.go
@@ -147,7 +147,11 @@ func createVolumeInstanceMetrics(ctx *getconfigContext, reportMetrics *metrics.Z
 		volumeMetric := new(metrics.ZMetricVolume)
 		volumeMetric.Uuid = volumeStatus.VolumeID.String()
 		volumeMetric.DisplayName = volumeStatus.DisplayName
-		getVolumeResourcesMetrics(volumeStatus.FileLocation, volumeMetric)
+		if volumeStatus.FileLocation == "" {
+			log.Infof("FileLocation is empty for %s", volumeStatus.Key())
+		} else {
+			getVolumeResourcesMetrics(volumeStatus.FileLocation, volumeMetric)
+		}
 		reportMetrics.Vm = append(reportMetrics.Vm, volumeMetric)
 	}
 	log.Debugf("Volume instance metrics done: %v", reportMetrics.Vm)


### PR DESCRIPTION
If file location is empty in ```VolumeStatus``` while downloading and creating the volume, we
shouldn't call the ```GetVolumeSize``` function.

Signed-off-by: zed-rishabh <rgupta@zededa.com>