### PR TITLE
fix progress download for blobs

### DIFF
--- a/pkg/pillar/zedUpload/datastore_oci.go
+++ b/pkg/pillar/zedUpload/datastore_oci.go
@@ -142,12 +142,9 @@ func (ep *OCITransportMethod) processDownload(req *DronaRequest) (int64, error) 
 	}
 
 	// Pull down the blob as is and save it to a file named for the hash
-	size, err = ociutil.PullBlob(ep.registry, ep.path, req.ImageSha256, req.objloc, ep.uname, ep.apiKey, ep.hClient, prgChan)
-	if err != nil {
-		return size, err
-	}
+	size, err = ociutil.PullBlob(ep.registry, ep.path, req.ImageSha256, req.objloc, ep.uname, ep.apiKey, req.sizelimit, ep.hClient, prgChan)
 	// zedUpload's job is to download a blob from an OCI registry. Done.
-	return size, nil
+	return size, err
 }
 
 // processDelete Artifact delete from OCI registry

--- a/pkg/pillar/zedUpload/ociutil/progress.go
+++ b/pkg/pillar/zedUpload/ociutil/progress.go
@@ -1,0 +1,63 @@
+package ociutil
+
+import (
+	"io"
+)
+
+// ProgressWriter is a writer which will send the download progress
+type ProgressWriter struct {
+	w              io.Writer
+	updates        chan<- Update
+	size, complete int64
+}
+
+// Write write bytes and update the progress channel.
+// Returns number of bytes written and error, if any
+func (pw *ProgressWriter) Write(p []byte) (int, error) {
+	n, err := pw.w.Write(p)
+	if err != nil {
+		return n, err
+	}
+
+	pw.complete += int64(n)
+	// if our provides total size is 0, then we allow anything, so send a "Total"
+	// of the same amount as Complete
+	totalSize := pw.size
+	if totalSize == 0 {
+		totalSize = pw.complete
+	}
+
+	pw.updates <- Update{
+		Total:    totalSize,
+		Complete: pw.complete,
+	}
+
+	return n, err
+}
+
+// Error set an error
+func (pw *ProgressWriter) Error(err error) error {
+	pw.updates <- Update{
+		Total:    pw.size,
+		Complete: pw.complete,
+		Error:    err,
+	}
+	return err
+}
+
+// Close close the writer
+func (pw *ProgressWriter) Close() error {
+	pw.updates <- Update{
+		Total:    pw.size,
+		Complete: pw.complete,
+		Error:    io.EOF,
+	}
+	return io.EOF
+}
+
+// Update represents an update to send on a channel
+type Update struct {
+	Total    int64
+	Complete int64
+	Error    error
+}


### PR DESCRIPTION
The previous PR #1110 added full support for downloading individual blobs in content trees, but lost progress beyond 0% and 100%. This restores it by sending updates with each blob.

This is a little more complex than before. The old version had a single file, so the progress was one single stream. With blobs, there can be 1, 2 or many blobs being downloaded. This restores the download progress to each blob. The logic to aggregate them to the `ContentTreeStatus` with each update already was added in #1110, but might still have issues.

As long as this adds progress updates for individual blobs without breaking anything else, this should get merged in. If we need additional fixes on how the blob progress elements get merged together in `doUpdateContentTree()`, those should be handled separately.