### PR TITLE
baseos image update did not progress; missing updatestatusold code

### DIFF
--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -122,10 +122,6 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 
 		// loop through each blob, see if it is downloaded and verified.
 		// we set the contenttree to verified when all of the blobs are verified
-		if status.State < types.DOWNLOADING {
-			status.State = types.DOWNLOADING
-			changed = true
-		}
 		leftToProcess := false
 
 		var (


### PR DESCRIPTION
The changes to not process things in the handleVerifyImageStatus and handleDownloaderStatus had accompanying changes in updateContentTreeStatus. Those changes are also needed in updateStatusOld

Brought them to match by diffing updatestatus.go and updatestatusold.go; found a piece of duplicate code in updatestatus.go as part of this.
@zed-rishabh I'll let know who when I've tested this a bit more.