### PR TITLE
create volume directories in case upgradeconverter did not

### DIFF
--- a/pkg/pillar/cmd/volumemgr/dirs.go
+++ b/pkg/pillar/cmd/volumemgr/dirs.go
@@ -66,4 +66,17 @@ func clearInProgressDownloadDirs(objTypes []string) {
 			}
 		}
 	}
+	// Our destination volume directories
+	volumeDirs := []string{
+		types.VolumeEncryptedDirName,
+		types.VolumeClearDirName,
+	}
+	for _, dirName := range volumeDirs {
+		if _, err := os.Stat(dirName); err != nil {
+			log.Infof("Create %s", dirName)
+			if err := os.MkdirAll(dirName, 0700); err != nil {
+				log.Fatal(err)
+			}
+		}
+	}
 }


### PR DESCRIPTION
Turns out that on eve upgrade (which is most of what we test) the /persist/vault/volumes is created by the upgradeconverter.
But if that has no checkpoint file (which is the case for a fresh boot) there are no volumes to consider upgrading, hence no /persist/vault/volumes and an error of the form
      "Error": "Copy failed from /persist/downloads/appImg.obj/verified/d2157a3cc854bab68867c201d62cb297920c3353f3e535325521942d58f0074f to /persist/vault/volumes/2cf8f72c-6200-4c94-a8f9-3625fbce7b94#0.qcow2: open /persist/vault/volumes/2cf8f72c-6200-4c94-a8f9-3625fbce7b94#0.qcow2: no such file or directory\n",
