### PR TITLE
Enabling ZFS kernel module

### DIFF
--- a/pkg/kernel/Dockerfile
+++ b/pkg/kernel/Dockerfile
@@ -108,8 +108,31 @@ RUN make -j "$(getconf _NPROCESSORS_ONLN)" KCFLAGS="-fno-pie" && \
 
 # Modules
 RUN make INSTALL_MOD_PATH=/tmp/kernel-modules modules_install
+
+# Out-of-tree, open source modules
+#  * ZFS on Linux
+RUN apk add --no-cache \
+    attr-dev=2.4.47-r7 \
+    autoconf=2.69-r2 \
+    file=5.36-r0 \
+    libtirpc-dev=1.0.3-r0 \
+    libtool=2.4.6-r5 \
+    util-linux-dev=2.33-r0
+ENV ZFS_VERSION=0.8.4
+ENV ZFS_COMMIT=zfs-${ZFS_VERSION}
+ENV ZFS_REPO=https://github.com/zfsonlinux/zfs.git
+
+WORKDIR /tmp/zfs
+RUN git clone --depth 1 -b ${ZFS_COMMIT} ${ZFS_REPO} .
+RUN ./autogen.sh && \
+    ./configure --with-linux=/linux && \
+    ./scripts/make_gitrev.sh && \
+    make -C module -j "$(getconf _NPROCESSORS_ONLN)" && \
+    make -C module INSTALL_MOD_PATH=/tmp/kernel-modules install # cd /lib/modules && depmod -ae *
+
 # Out-of-tree, creepy modules
 #  * Maxlinear USB (option #2 https://github.com/lipnitsk/xr/archive/master.zip)
+WORKDIR /linux
 ADD https://www.maxlinear.com/document?id=21651 /tmp/xr.zip
 RUN unzip -d /tmp /tmp/xr.zip ;\
     make -C /linux INSTALL_MOD_PATH=/tmp/kernel-modules \

--- a/pkg/new-kernel/Dockerfile
+++ b/pkg/new-kernel/Dockerfile
@@ -109,8 +109,31 @@ RUN make -j "$(getconf _NPROCESSORS_ONLN)" KCFLAGS="-fno-pie" && \
 
 # Modules
 RUN make INSTALL_MOD_PATH=/tmp/kernel-modules modules_install
+
+# Out-of-tree, open source modules
+#  * ZFS on Linux
+RUN apk add --no-cache \
+    attr-dev=2.4.47-r7 \
+    autoconf=2.69-r2 \
+    file=5.36-r0 \
+    libtirpc-dev=1.0.3-r0 \
+    libtool=2.4.6-r5 \
+    util-linux-dev=2.33-r0
+ENV ZFS_VERSION=0.8.4
+ENV ZFS_COMMIT=zfs-${ZFS_VERSION}
+ENV ZFS_REPO=https://github.com/zfsonlinux/zfs.git
+
+WORKDIR /tmp/zfs
+RUN git clone --depth 1 -b ${ZFS_COMMIT} ${ZFS_REPO} .
+RUN ./autogen.sh && \
+    ./configure --with-linux=/linux && \
+    ./scripts/make_gitrev.sh && \
+    make -C module -j "$(getconf _NPROCESSORS_ONLN)" && \
+    make -C module INSTALL_MOD_PATH=/tmp/kernel-modules install # cd /lib/modules && depmod -ae *
+
 # Out-of-tree, creepy modules
 #  * Maxlinear USB (option #2 https://github.com/lipnitsk/xr/archive/master.zip)
+WORKDIR /linux
 ADD https://www.maxlinear.com/document?id=21651 /tmp/xr.zip
 RUN unzip -d /tmp /tmp/xr.zip ;\
     make -C /linux INSTALL_MOD_PATH=/tmp/kernel-modules \

--- a/pkg/storage-init/Dockerfile
+++ b/pkg/storage-init/Dockerfile
@@ -1,9 +1,9 @@
-FROM alpine:3.10.3
+FROM alpine:3.12
 WORKDIR /
 # hadolint ignore=DL3018
 RUN apk add --no-cache bash glib squashfs-tools util-linux e2fsprogs \
-        e2fsprogs-extra keyutils dosfstools coreutils sgdisk
-COPY storage-init.sh /storage-init.sh
+        e2fsprogs-extra keyutils dosfstools coreutils sgdisk zfs
+COPY zfs.sh storage-init.sh /
 
 ENTRYPOINT []
 CMD ["/storage-init.sh"]

--- a/pkg/storage-init/zfs.sh
+++ b/pkg/storage-init/zfs.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+ctr run --mount type=bind,src=/dev,dst=/dev,options=rbind:rw:rshared    \
+        --mount type=bind,src=/proc,dst=/proc,options=rbind:rw:rshared  \
+        --mount type=bind,src=/sys,dst=/sys,options=rbind:rw:rshared    \
+        --mount type=bind,src=/run,dst=/run,options=rbind:rw:rshared    \
+        --device /dev/zfs --privileged --rm -t                          \
+        --rootfs /containers/onboot/000-storage-init/lower zfs /bin/sh


### PR DESCRIPTION
This marks the beginning of EVE's ZFS journey. This PR simply brings a kernel module in (which, luckily, is not that big of a tax on size -- ~2.5Mb of extra space). In addition to that our storage-init container is now setup to be able to work with zfs. Of course, given that storage-init is a one-shot container, we need a way to re-enter it -- and that's what the zfs.sh script allows one to do (just run `/containers/onboot/000*/lower/zfs.sh` and you'll be given a shell from which you can run zfs commands).

In the next day or so -- I plan to update zfs.sh quite a bit to be a parallel entry point into storage-init and be able to have an alternative way of building /persist filesystem. Stay tuned, but this alone allows all of us to start playin with zfs.