### PR TITLE
allow controller to calculate controllercert_confighash any way it wants

### DIFF
--- a/api/proto/config/devconfig.proto
+++ b/api/proto/config/devconfig.proto
@@ -69,9 +69,11 @@ message EdgeDevConfig {
   repeated ContentTree contentInfo = 20;
   repeated Volume volumes = 21;
 
-  // This sha256 field is a 256 bits (64 bytes) long hex string used
-  // by the device to detect when it needs to re-download the controller
-  // certs using the /certs API endpoint.
+  // This field is used by the device to detect when it needs to re-download
+  // the controller certs using the /certs API endpoint.
+  // The controller just needs to ensure this value changes when it wants the
+  // device to re-fetch the controller certs, for instance by having it
+  // be a hash of all of the controller certificates.
   string controllercert_confighash = 22;
   // deprecated 23;
 }

--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -33,9 +33,11 @@ type cipherContext struct {
 	triggerEdgeNodeCerts   chan struct{}
 	triggerControllerCerts chan struct{}
 
-	cfgControllerCertHash []byte
+	cfgControllerCertHash string // Last controllercert_confighash received from controller
 	iteration             int
 }
+
+var controllerCertHash []byte
 
 // parse and update controller certs
 func parseControllerCerts(ctx *zedagentContext, contents []byte) {
@@ -53,16 +55,16 @@ func parseControllerCerts(ctx *zedagentContext, contents []byte) {
 		computeConfigElementSha(h, cfgCert)
 	}
 	newHash := h.Sum(nil)
-	if bytes.Equal(newHash, ctx.cipherCtx.cfgControllerCertHash) {
+	if bytes.Equal(newHash, controllerCertHash) {
 		return
 	}
 	log.Infof("parseControllerCerts: Applying updated config "+
 		"Last Sha: % x, "+
 		"New  Sha: % x, "+
 		"Num of cfgCert: %d",
-		ctx.cipherCtx.cfgControllerCertHash, newHash, len(cfgCerts))
+		controllerCertHash, newHash, len(cfgCerts))
 
-	ctx.cipherCtx.cfgControllerCertHash = newHash
+	controllerCertHash = newHash
 
 	// First look for deleted ones
 	items := ctx.getconfigCtx.pubControllerCert.GetAll()
@@ -355,15 +357,10 @@ func handleControllerCertsSha(ctx *zedagentContext,
 	config *zconfig.EdgeDevConfig) {
 
 	certHash := config.GetControllercertConfighash()
-	// In case sha is not getting populated by the controller
-	if len(certHash) == 0 {
-		log.Infof("handleControllerCertsSha not set by controller")
-		return
-	}
-	sumHash := hex.EncodeToString(ctx.cipherCtx.cfgControllerCertHash)
-	if sumHash != certHash {
+	if certHash != ctx.cipherCtx.cfgControllerCertHash {
 		log.Infof("handleControllerCertsSha trigger due to controller %v vs current %v",
-			certHash, sumHash)
+			certHash, ctx.cipherCtx.cfgControllerCertHash)
+		ctx.cipherCtx.cfgControllerCertHash = certHash
 		triggerControllerCertEvent(ctx)
 	}
 }


### PR DESCRIPTION
This removes the coupling between comparing changes.
Tested that it works with current controller (which sends an empty string).