### PR TITLE
fatal if two identical publications

### DIFF
--- a/pkg/pillar/pubsub/socketdriver/driver.go
+++ b/pkg/pillar/pubsub/socketdriver/driver.go
@@ -115,6 +115,15 @@ func (s *SocketDriver) Publisher(global bool, name, topic string, persistent boo
 			}
 		}
 		if _, err := os.Stat(sockName); err == nil {
+			// This could either be a left-over in the filesystem
+			// or some other process (or ourselves) using the same
+			// name to publish. Try connect to see if it is the latter.
+			sock, err := net.Dial("unixpacket", sockName)
+			if err == nil {
+				sock.Close()
+				log.Fatalf("Can not publish %s since it it already used",
+					sockName)
+			}
 			if err := os.Remove(sockName); err != nil {
 				errStr := fmt.Sprintf("Publish(%s): %s",
 					name, err)


### PR DESCRIPTION
When working on PR 1168 I accidentally ended up with two publications from volumemgr for the DownloaderConfig topic.
That was very confusing because the Publish happens and the file is added/updated in /var/run/<agent>/<topic>, but the subscriber sees no notification. That was due to the subscriber connecting to the publisher which stole the listener socket. 

The check in this PR should avoid others taring out their hair like I did.
