### PR TITLE
create /persist/vault if not present and no TPM

### DIFF
--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -124,6 +124,11 @@ if [ -c $TPM_DEVICE_PATH ] && ! [ -f $CONFIGDIR/disable-tpm ] && [ "$P3_FS_TYPE"
     if ! $BINDIR/vaultmgr setupVaults; then
         echo "$(date -Ins -u) device-steps: vaultmgr setupVaults failed"
     fi
+else
+    if [ ! -d $PERSISTDIR/vault ]; then
+        echo "$(date -Ins -u) Creating $PERSISTDIR/vault"
+        mkdir $PERSISTDIR/vault
+    fi
 fi
 
 if [ -f $PERSISTDIR/IMGA/reboot-reason ]; then
@@ -141,8 +146,8 @@ echo "$(date -Ins -u) Current downloaded files:"
 ls -lt $PERSISTDIR/downloads/*/*
 echo
 
-echo "$(date -Ins -u) Preserved images:"
-ls -lt $PERSISTDIR/img/
+echo "$(date -Ins -u) Preserved volumes:"
+ls -lt $PERSISTDIR/vault/volumes/
 echo
 
 # Copy any GlobalConfig from /config


### PR DESCRIPTION
Plus change llisting of /persist/img/

While it isn't required to create the vault directory, it makes the layout of the system on boot more uniform hence less risk of bugs in some configurations and not others.