### PR TITLE
missing publishOldVolumeStatus resulting in fatal

### DIFF
--- a/pkg/pillar/cmd/volumemgr/handleconfig.go
+++ b/pkg/pillar/cmd/volumemgr/handleconfig.go
@@ -89,6 +89,7 @@ func vcCreate(ctx *volumemgrContext, objType string, key string,
 		initStatus.LastUse = time.Now()
 		initStatus.PreReboot = false
 		if !initStatus.HasError() {
+			publishOldVolumeStatus(ctx, initStatus)
 			log.Infof("vcCreate(%s) DONE objType %s for %s",
 				config.Key(), objType, config.DisplayName)
 			return


### PR DESCRIPTION
For some reason my manual eveimage updates result in a fatal but it doesn't appear during tests. Missing OldVolumeStatus when doing the delete of the baseos oldvolumeconfig.
We seem to have dropped this publish a while back - don't know how things worked reliably without it.
@zed-rishabh this will vanish with your PR, but I wanted to get to a known state first.