### PR TITLE
Poweroff acpid handler for initrd

### DIFF
--- a/pkg/xen-tools/Dockerfile.in
+++ b/pkg/xen-tools/Dockerfile.in
@@ -9,6 +9,7 @@ COPY initrd/base.files /etc/mkinitfs/features.d/base.files
 COPY initrd/init-initrd initrd/mount_disk.sh initrd/udhcpc_script.sh /
 COPY initrd/poweroff /sbin/poweroff
 COPY initrd/chroot2.c /tmp/
+COPY initrd/00000080 /etc/acpi/PWRF/
 RUN gcc -s -o /chroot2 /tmp/chroot2.c
 RUN mkinitfs -n -F base -i /init-initrd -o /runx-initrd
 

--- a/pkg/xen-tools/initrd/00000080
+++ b/pkg/xen-tools/initrd/00000080
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "$0"
+/bin/poweroff -f

--- a/pkg/xen-tools/initrd/base.files
+++ b/pkg/xen-tools/initrd/base.files
@@ -8,3 +8,4 @@
 /mnt
 /bin/sh
 /sbin/poweroff
+/etc/acpi/PWRF/00000080

--- a/pkg/xen-tools/initrd/init-initrd
+++ b/pkg/xen-tools/initrd/init-initrd
@@ -80,6 +80,9 @@ echo "Executing /mount_disk.sh"
 # Commence launch sequence
 source /mnt/environment
 
+echo "Run acpid daemon"
+acpid -l /proc/self/fd/1
+
 cmd=`cat /mnt/cmdline`
 echo "Executing $cmd"
 #shellcheck disable=SC2086


### PR DESCRIPTION
This fix fires `poweroff` inside initrd on acpi poweroff event.
Fix problem with killing of VMs based on containers with kvm HV.




Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>