### PR TITLE
Make image 35+M smaller

### DIFF
--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -36,8 +36,6 @@ services:
      image: WWAN_TAG
    - name: wlan
      image: WLAN_TAG
-   - name: lisp
-     image: LISP_TAG
    - name: guacd
      image: GUACD_TAG
    - name: pillar


### PR DESCRIPTION
ARM image is already above 250M and fails to build, and amd64 image is at 249M today.
Once we figure out other places to save space we can revisit this container.