### PR TITLE
Fixes for offline device reboot

### DIFF
--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -512,6 +512,11 @@ func printOutput(ctx *diagContext) {
 	if testing {
 		fmt.Fprintf(outfile, "WARNING: The configuration below is under test hence might report failures\n")
 	}
+	if ctx.DeviceNetworkStatus.State != types.DPC_SUCCESS {
+		fmt.Fprintf(outfile, "WARNING: state %s not SUCCESS\n",
+			ctx.DeviceNetworkStatus.State.String())
+	}
+
 	numPorts := len(ctx.DeviceNetworkStatus.Ports)
 	mgmtPorts := 0
 	passPorts := 0

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -281,6 +281,8 @@ func getLatestConfig(url string, iteration int,
 
 	if !changed {
 		log.Debugf("Configuration from zedcloud is unchanged")
+		// Update modification time since checked by readSavedProtoMessage
+		touchReceivedProtoMessage()
 		return false
 	}
 	writeReceivedProtoMessage(contents)
@@ -317,6 +319,11 @@ func writeReceivedProtoMessage(contents []byte) {
 	writeProtoMessage("lastconfig", contents)
 }
 
+// Update timestamp - no content changes
+func touchReceivedProtoMessage() {
+	touchProtoMessage("lastconfig")
+}
+
 // XXX for debug we track these
 func writeSentMetricsProtoMessage(contents []byte) {
 	writeProtoMessage("lastmetrics", contents)
@@ -336,8 +343,23 @@ func writeProtoMessage(filename string, contents []byte) {
 	filename = checkpointDirname + "/" + filename
 	err := ioutil.WriteFile(filename, contents, 0744)
 	if err != nil {
-		log.Fatal("writeReceiveProtoMessage", err)
+		log.Fatal("writeProtoMessage", err)
 		return
+	}
+}
+
+// Update modification time
+func touchProtoMessage(filename string) {
+	filename = checkpointDirname + "/" + filename
+	_, err := os.Stat(filename)
+	if err != nil {
+		log.Warn("touchProtoMessage", err)
+		return
+	}
+	currentTime := time.Now()
+	err = os.Chtimes(filename, currentTime, currentTime)
+	if err != nil {
+		log.Fatal("touchProtoMessage", err)
 	}
 }
 

--- a/pkg/pillar/devicenetwork/devicenetwork.go
+++ b/pkg/pillar/devicenetwork/devicenetwork.go
@@ -188,6 +188,7 @@ func MakeDeviceNetworkStatus(globalConfig types.DevicePortConfig, oldStatus type
 
 	log.Infof("MakeDeviceNetworkStatus()\n")
 	globalStatus.Version = globalConfig.Version
+	globalStatus.State = oldStatus.State
 	globalStatus.Ports = make([]types.NetworkPortStatus,
 		len(globalConfig.Ports))
 	for ix, u := range globalConfig.Ports {

--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -296,8 +296,8 @@ func VerifyPending(ctx *DeviceNetworkContext, pending *DPCPending,
 	log.Errorf("VerifyPending: %s\n", errStr)
 	pending.TestCount = MaxDPCRetestCount
 	pending.PendDPC.RecordFailure(errStr)
-	pending.PendDPC.LastIPAndDNS = time.Now()
-	return types.DPC_FAIL
+	pending.PendDPC.LastIPAndDNS = pending.PendDPC.LastFailed
+	return types.DPC_FAIL_WITH_IPANDDNS
 }
 
 // Check if all interfaces exist in the kernel
@@ -332,8 +332,9 @@ func VerifyDevicePortConfig(ctx *DeviceNetworkContext) {
 		res := VerifyPending(ctx, &ctx.Pending, ctx.AssignableAdapters,
 			ctx.TestSendTimeout)
 		dpc := &ctx.Pending.PendDPC
-		dpc.Status = res
+		dpc.State = res
 		ctx.PubDummyDevicePortConfig.Publish(dpc.PubKey(), *dpc)
+		ctx.Pending.PendDNS.State = dpc.State
 		UpdateResolvConf(ctx.Pending.PendDNS)
 		UpdatePBR(ctx.Pending.PendDNS)
 		if ctx.PubDeviceNetworkStatus != nil {
@@ -355,7 +356,7 @@ func VerifyDevicePortConfig(ctx *DeviceNetworkContext) {
 			duration := time.Duration(ctx.DPCTestDuration) * time.Second
 			pending.PendTimer = time.NewTimer(duration)
 			return
-		case types.DPC_FAIL:
+		case types.DPC_FAIL, types.DPC_FAIL_WITH_IPANDDNS:
 			// Avoid clobbering wrong entry if insert/remove after verification
 			// started
 			tested, index := lookupPortConfig(ctx, pending.PendDPC)
@@ -385,6 +386,16 @@ func VerifyDevicePortConfig(ctx *DeviceNetworkContext) {
 				ctx.NextDPCIndex+1)
 			if nextIndex == -1 {
 				log.Infof("VerifyDevicePortConfig: nothing testable")
+				if res == types.DPC_FAIL_WITH_IPANDDNS {
+					// publish what we have since applications
+					// might need it
+					ctx.DevicePortConfigList.CurrentIndex = ctx.NextDPCIndex
+					*ctx.DevicePortConfig = pending.PendDPC
+					*ctx.DeviceNetworkStatus = pending.PendDNS
+					ctx.DeviceNetworkStatus.Testing = false
+					*ctx.DevicePortConfigList = compressAndPublishDevicePortConfigList(ctx)
+					DoDNSUpdate(ctx)
+				}
 				pending.Inprogress = false
 				// Restart network test timer
 				duration := time.Duration(ctx.NetworkTestInterval) * time.Second
@@ -609,7 +620,9 @@ func HandleAssignableAdaptersModify(ctxArg interface{}, key string,
 	}
 	*ctx.AssignableAdapters = newAssignableAdapters
 	// In case a verification is in progress and is waiting for return from pciback
-	VerifyDevicePortConfig(ctx)
+	if ctx.Pending.Inprogress {
+		VerifyDevicePortConfig(ctx)
+	}
 	log.Infof("handleAssignableAdaptersModify() done\n")
 }
 

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -709,7 +709,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddIntItem(ResetIfCloudGoneTime, 7*24*3600, 120, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(FallbackIfCloudGoneTime, 300, 60, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(MintimeUpdateSuccess, 600, 30, HourInSec)
-	configItemSpecMap.AddIntItem(StaleConfigTime, 600, 0, 0xFFFFFFFF)
+	configItemSpecMap.AddIntItem(StaleConfigTime, 7*24*3600, 0, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(VdiskGCTime, 3600, 60, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(DownloadRetryTime, 600, 60, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(DomainBootRetryTime, 600, 10, 0xFFFFFFFF)

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -451,9 +451,10 @@ type TestResults struct {
 }
 
 // RecordSuccess records a success
-// Keeps the LastError and LastFailed in place as history
+// Keeps the LastFailed in place as history
 func (trPtr *TestResults) RecordSuccess() {
 	trPtr.LastSucceeded = time.Now()
+	trPtr.LastError = ""
 }
 
 // RecordFailure records a failure
@@ -483,9 +484,9 @@ func (trPtr *TestResults) Update(src TestResults) {
 		}
 	} else {
 		trPtr.LastSucceeded = src.LastSucceeded
+		trPtr.LastError = ""
 		if src.LastFailed.After(trPtr.LastFailed) {
 			trPtr.LastFailed = src.LastFailed
-			trPtr.LastError = src.LastError
 		}
 	}
 }


### PR DESCRIPTION
Please review the three commits separately. They are:

To bring up the applications using the configuration from before the reboot if it is not stale we check the timestamp on the file
and that code was broken when ConfigRequest/ConfigResponse was introduced since unchanged configuration no longer resulted in change to the file modification time.
Note that as part of this we increase the default max staleness of the received configuration from 5 minutes to 1 week.

Also, the network status (as DeviceNetworkStatus) should not become empty when we have IP+DNS even if we don't have controller connectivity. To show that we introduce a a new DPC_FAIL_WITH_IPANDDNS state and make DeviceNetworkStatus include the state (so that agents can look at the state and not the number of IP addresses since they no longer indicate lack of connectivity.)

Finally, the error string in DeviceNetworkStatus and DevicePortConfig is not cleared out when the error goes away, which is very confusing because it looks like the device does not recover after a network outage, even though the controller reports is as online and reporting metrics and info.