### PR TITLE
handle missing network interfaces

### DIFF
--- a/pkg/pillar/devicenetwork/dhcpcd.go
+++ b/pkg/pillar/devicenetwork/dhcpcd.go
@@ -23,6 +23,7 @@ import (
 
 // UpdateDhcpClient starts/modifies/deletes dhcpcd per interface
 // Assumes that the caller has checked that the interfaces exist
+// We therefor skip any interfaces which do not exist
 func UpdateDhcpClient(newConfig, oldConfig types.DevicePortConfig) {
 
 	// Look for adds or changes
@@ -73,6 +74,7 @@ func doDhcpClientActivate(nuc types.NetworkPortConfig) {
 	// Check the ifname exists to avoid waiting for a dhcpcd below
 	_, err := IfnameToIndex(nuc.IfName)
 	if err != nil {
+		// Caller intends us to proceed without this interface
 		log.Warnf("doDhcpClientActivate(%s) failed %s", nuc.IfName, err)
 		return
 	}

--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -234,7 +234,7 @@ func VerifyPending(ctx *DeviceNetworkContext, pending *DPCPending,
 			ifname, err)
 		pending.PendDPC.RecordPortFailure(ifname, err.Error())
 		pending.PendDPC.RecordFailure(err.Error())
-		return types.DPC_FAIL
+		// Proceed trying other interfaces
 	}
 	log.Infof("VerifyPending: No required ports missing. " +
 		"parsing device port config list")


### PR DESCRIPTION
Verified (using eden) that if the EVE boots with eth0+eth1 in the zedagent DPC and eth1 does not exist, it continues to use the zedagent DPC and reports a per-interface error "Port eth1 does not exist - ignored".

Prior to this fix it would fall back to the last-resort (which would only include the interfaces known to the kernel).
Note that even though it will not retry the missing eth1, this fix makes it more robust against cases where the kernel claims that eth1 (or wlan0) exists but can does not appear as an ip link (due to flaky hardware).