### PR TITLE
Bug of the month; support modify of item in subscribe handlers

### DIFF
--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -337,10 +337,12 @@ func VerifyDevicePortConfig(ctx *DeviceNetworkContext) {
 		ctx.Pending.PendDNS.State = dpc.State
 		UpdateResolvConf(ctx.Pending.PendDNS)
 		UpdatePBR(ctx.Pending.PendDNS)
+		// Publish in case we need a port back from domainmgr
 		if ctx.PubDeviceNetworkStatus != nil {
+			ctx.Pending.PendDNS.Testing = true
+			ctx.Pending.PendDNS.State = res
 			log.Infof("PublishDeviceNetworkStatus: pending %+v\n",
 				ctx.Pending.PendDNS)
-			ctx.Pending.PendDNS.Testing = true
 			ctx.PubDeviceNetworkStatus.Publish("global", ctx.Pending.PendDNS)
 		}
 		log.Infof("VerifyDevicePortConfig: %s for %d",

--- a/pkg/pillar/pubsub/subscribe.go
+++ b/pkg/pillar/pubsub/subscribe.go
@@ -219,10 +219,12 @@ func handleModify(ctxArg interface{}, key string, itemcb []byte) {
 	if log.GetLevel() == log.DebugLevel {
 		sub.dump("after handleModify")
 	}
+	// Need a copy in case the caller will modify e.g., embedded maps
+	newItem := deepCopy(item)
 	if created && sub.CreateHandler != nil {
-		(sub.CreateHandler)(sub.userCtx, key, item)
+		(sub.CreateHandler)(sub.userCtx, key, newItem)
 	} else if sub.ModifyHandler != nil {
-		(sub.ModifyHandler)(sub.userCtx, key, item)
+		(sub.ModifyHandler)(sub.userCtx, key, newItem)
 	}
 	log.Debugf("pubsub.handleModify(%s) done for key %s\n", name, key)
 }


### PR DESCRIPTION
When testing that we can disable USB keyboard/mouse and memory stick I tested booting with a USB stick which has an override.json, and also inserting it post boot, with different settings for debug.enable.usb.

The USB stick had a static IP configuration for some bogus IP subnet, hence it wasn't supposed to work.
But what I saw was that nim kept retrying the applying and testing the configuration from the USB stick every 2-3 minutes, which makes no sense; it doesn't change and the "testbetter" timer is a lot higher than that. This was very disruptive since the device would unconfigure the wlan interface and then configure it again less than a minute later, and repeat every few minutes.

Turns out that the USB stick config did not have the Logicallabel and Phylabel set, and the code in HandleDPCModify applies a DoSanitize function which sets those fields to the Ifname. No big deal, right?
Well the problem is that setting them (and any modification in a Create or Modify handler which touches slices, maps, etc inside the passed argument) actually modifies the item which is stored inside the subscription's map.
This coupled with the periodic rescan of the directory (the override.json is read from /var/tmp/zededa/DevicePortConfig/) in the watch package means that when the subscriptions handleModify is called with the identical input content, it detects a modification not because the input changed but because HandleDPCModify in devicenetwork package accidentally modifies the subscriptions internal map. That directory rescan happens every 3-10 minutes randomly.

Only way to avoid this is to do the deep copy (which uses json encode/decode) before passing the item from the internal map to the handlers. That way the subscription map can not be modified by the handlers.

Note that only file-based subscriptions (not socket IPC ones) are subject to the rescan thus other callers shouldn't see this repeated modification, but they can instead miss notifications if somehow the handler already applied that change but still wants a notification when the publisher changes it in the same way.
