### PR TITLE
skeleton implementation for remote attestation

### DIFF
--- a/pkg/pillar/cmd/zedagent/attesttask.go
+++ b/pkg/pillar/cmd/zedagent/attesttask.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package zedagent
+
+// all things related to running remote attestation with the Controller
+
+import (
+	"fmt"
+	"github.com/lf-edge/eve/pkg/pillar/agentlog"
+	zattest "github.com/lf-edge/eve/pkg/pillar/attest"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	log "github.com/sirupsen/logrus"
+)
+
+//TpmAgentImpl implements zattest.TpmAgent interface
+type TpmAgentImpl struct{}
+
+//VerifierImpl implements zattest.Verifier interface
+type VerifierImpl struct{}
+
+//WatchdogImpl implements zattest.Watchdog interface
+type WatchdogImpl struct{}
+
+// Attest Information Context
+type attestContext struct {
+	zedagentCtx  *zedagentContext
+	attestModCtx *zattest.Context
+}
+
+//SendNonceRequest implements SendNonceRequest method of zattest.Verifier
+func (server *VerifierImpl) SendNonceRequest(ctx *zattest.Context) error {
+	//XXX: Fill it in when Controller code is ready
+	return nil
+}
+
+//SendAttestQuote implements SendAttestQuote method of zattest.Verifier
+func (server *VerifierImpl) SendAttestQuote(ctx *zattest.Context) error {
+	//XXX: Fill it in when Controller code is ready
+	return nil
+}
+
+//SendAttestEscrow implements SendAttestEscrow method of zattest.Verifier
+func (server *VerifierImpl) SendAttestEscrow(ctx *zattest.Context) error {
+	//XXX: Fill it in when Controller code is ready
+	return nil
+}
+
+//SendInternalQuoteRequest implements SendInternalQuoteRequest method of zattest.TpmAgent
+func (agent *TpmAgentImpl) SendInternalQuoteRequest(ctx *zattest.Context) error {
+	//XXX: Fill it in along with the above methods
+	return nil
+}
+
+//PunchWatchdog implements PunchWatchdog method of zattest.Watchdog
+func (wd *WatchdogImpl) PunchWatchdog(ctx *zattest.Context) error {
+	log.Debug("[ATTEST] Punching watchdog")
+	agentlog.StillRunning(agentName+"attest", warningTime, errorTime)
+	return nil
+}
+
+// initialize attest pubsub trigger handlers and channels
+func attestModuleInitialize(ctx *zedagentContext, ps *pubsub.PubSub) error {
+	zattest.RegisterExternalIntf(&TpmAgentImpl{}, &VerifierImpl{}, &WatchdogImpl{})
+
+	//retryTime is 15 seconds, watchdogTime is 15 seconds
+	c, err := zattest.New(15, 15)
+	if err != nil {
+		return err
+	}
+	ctx.attestCtx.attestModCtx = c
+	return nil
+}
+
+// start the task threads
+func attestModuleStart(ctx *zedagentContext) error {
+	log.Info("[ATTEST] Starting attestation task")
+	if ctx.attestCtx == nil {
+		return fmt.Errorf("No attest module context")
+	}
+	if ctx.attestCtx.attestModCtx == nil {
+		return fmt.Errorf("No state machine context found")
+	}
+	go ctx.attestCtx.attestModCtx.EnterEventLoop()
+	return nil
+}

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -80,6 +80,7 @@ type DNSContext struct {
 type zedagentContext struct {
 	getconfigCtx              *getconfigContext // Cross link
 	cipherCtx                 *cipherContext    // Cross link
+	attestCtx                 *attestContext    // Cross link
 	assignableAdapters        *types.AssignableAdapters
 	subAssignableAdapters     pubsub.Subscription
 	iteration                 int
@@ -223,6 +224,7 @@ func Run(ps *pubsub.PubSub) {
 	// Context to pass around
 	getconfigCtx := getconfigContext{}
 	cipherCtx := cipherContext{}
+	attestCtx := attestContext{}
 
 	// Pick up (mostly static) AssignableAdapters before we report
 	// any device info
@@ -235,6 +237,9 @@ func Run(ps *pubsub.PubSub) {
 
 	cipherCtx.zedagentCtx = &zedagentCtx
 	zedagentCtx.cipherCtx = &cipherCtx
+
+	attestCtx.zedagentCtx = &zedagentCtx
+	zedagentCtx.attestCtx = &attestCtx
 
 	// Timer for deferred sends of info messages
 	deferredChan := zedcloud.InitDeferred()
@@ -733,6 +738,9 @@ func Run(ps *pubsub.PubSub) {
 	//initialize cipher processing block
 	cipherModuleInitialize(&zedagentCtx, ps)
 
+	//initialize remote attestation context
+	attestModuleInitialize(&zedagentCtx, ps)
+
 	// Pick up debug aka log level before we start real work
 
 	for !zedagentCtx.GCInitialized {
@@ -916,6 +924,9 @@ func Run(ps *pubsub.PubSub) {
 
 	// start cipher module tasks
 	cipherModuleStart(&zedagentCtx)
+
+	// start remote attestation task
+	attestModuleStart(&zedagentCtx)
 
 	for {
 		select {


### PR DESCRIPTION
Hi @eriknordmark 
This is a follow up to https://github.com/lf-edge/eve/pull/1193

For now, the task just comes up and stays up (and keeps watchdog happy), we will actually kick the FSM once Controller implements (at least a stub version of ) /attest APIs required for this feature.

Signed-off-by: Hariharasubramanian C S <cshari@zededa.com>