### PR TITLE
vfb vnc for xen PV(H)

### DIFF
--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -146,18 +146,31 @@ func (ctx xenContext) CreateDomConfig(domainName string, config types.DomainConf
 			bootLoader))
 	}
 	if config.EnableVnc {
-		file.WriteString(fmt.Sprintf("vnc = 1\n"))
-		file.WriteString(fmt.Sprintf("vnclisten = \"0.0.0.0\"\n"))
-		file.WriteString(fmt.Sprintf("usb=1\n"))
-		file.WriteString(fmt.Sprintf("usbdevice=[\"tablet\"]\n"))
+		if config.VirtualizationMode == types.PV {
+			vncParams := []string{"vnc=1", "vnclisten=0.0.0.0"}
+			if config.VncDisplay != 0 {
+				vncParams = append(vncParams, fmt.Sprintf("vncdisplay=%d",
+					config.VncDisplay))
+			}
+			if config.VncPasswd != "" {
+				vncParams = append(vncParams, fmt.Sprintf("vncpasswd=\"%s\"\n",
+					config.VncPasswd))
+			}
+			file.WriteString(fmt.Sprintf("vfb = ['%s']\n", strings.Join(vncParams, ", ")))
+		} else {
+			file.WriteString(fmt.Sprintf("vnc = 1\n"))
+			file.WriteString(fmt.Sprintf("vnclisten = \"0.0.0.0\"\n"))
+			file.WriteString(fmt.Sprintf("usb=1\n"))
+			file.WriteString(fmt.Sprintf("usbdevice=[\"tablet\"]\n"))
 
-		if config.VncDisplay != 0 {
-			file.WriteString(fmt.Sprintf("vncdisplay = %d\n",
-				config.VncDisplay))
-		}
-		if config.VncPasswd != "" {
-			file.WriteString(fmt.Sprintf("vncpasswd = \"%s\"\n",
-				config.VncPasswd))
+			if config.VncDisplay != 0 {
+				file.WriteString(fmt.Sprintf("vncdisplay = %d\n",
+					config.VncDisplay))
+			}
+			if config.VncPasswd != "" {
+				file.WriteString(fmt.Sprintf("vncpasswd = \"%s\"\n",
+					config.VncPasswd))
+			}
 		}
 	} else {
 		file.WriteString(fmt.Sprintf("vnc = 0\n"))


### PR DESCRIPTION
Fix for #1216 
`If Emulated VGA Graphics Device options are used in a PV guest configuration, xl will pick up vnc, vnclisten, vncpasswd, vncdisplay, vncunused, sdl, opengl and keymap to construct the paravirtual framebuffer device for the guest.` from [here](https://xenbits.xen.org/docs/unstable/man/xl.cfg.5.html#Devices) does not work:
```
5d3392bb-cc0d-4b39-b882-48cc3af47ff4:/# cat /var/run/domainmgr/xen/xen1.cfg |grep vnc
vnc = 1
vnclisten = "0.0.0.0"
vncdisplay = 1
5d3392bb-cc0d-4b39-b882-48cc3af47ff4:/# xl create -n /var/run/domainmgr/xen/xen1.cfg |grep vnc
Parsing config from /var/run/domainmgr/xen/xen1.cfg
```
So, I do it manually.


Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>