### PR TITLE
Solidifying task state transitions and error signaling

### DIFF
--- a/pkg/pillar/containerd/containerd.go
+++ b/pkg/pillar/containerd/containerd.go
@@ -385,15 +385,23 @@ func CtrContainerInfo(name string) (int, string, error) {
 	if err := verifyCtr(); err != nil {
 		return 0, "", fmt.Errorf("CtrContainerInfo: exception while verifying ctrd client: %s", err.Error())
 	}
+
 	c, err := CtrLoadContainer(name)
-	if err == nil {
-		if t, err := c.Task(ctrdCtx, nil); err == nil {
-			if stat, err := t.Status(ctrdCtx); err == nil {
-				return int(t.Pid()), string(stat.Status), nil
-			}
-		}
+	if err != nil {
+		return 0, "", fmt.Errorf("CtrContainerInfo: couldn't load container %s: %v", name, err)
 	}
-	return 0, "", err
+
+	t, err := c.Task(ctrdCtx, nil)
+	if err != nil {
+		return 0, "", fmt.Errorf("CtrContainerInfo: couldn't load task for container %s: %v", name, err)
+	}
+
+	stat, err := t.Status(ctrdCtx)
+	if err != nil {
+		return 0, "", fmt.Errorf("CtrContainerInfo: couldn't determine task status for container %s: %v", name, err)
+	}
+
+	return int(t.Pid()), string(stat.Status), nil
 }
 
 // CtrCreateTask creates (but doesn't start) the default task in a pre-existing container and attaches its logging to memlogd

--- a/pkg/pillar/containerd/oci.go
+++ b/pkg/pillar/containerd/oci.go
@@ -100,12 +100,8 @@ func (s *ociSpec) CreateContainer(removeExisting bool) error {
 	_, err := CtrdClient.NewContainer(ctrdCtx, s.name, containerd.WithSpec(&s.Spec))
 	// if container exists, is stopped and we are asked to remove existing - try that
 	if err != nil && removeExisting {
-		_, status, err := CtrContainerInfo(s.name)
-		if err == nil && status != "running" && status != "pausing" {
-			err = CtrDeleteContainer(s.name)
-			_, err = CtrdClient.NewContainer(ctrdCtx, s.name, containerd.WithSpec(&s.Spec))
-		}
-		return err
+		_ = CtrDeleteContainer(s.name)
+		_, err = CtrdClient.NewContainer(ctrdCtx, s.name, containerd.WithSpec(&s.Spec))
 	}
 	return err
 }


### PR DESCRIPTION
This one is a bit tricky since it tries to solidify our state transitions when it comes to tracking what state running tasks are in (task is defined as per task proposal -- in other words, anything that is a "running entity" on EVE is now associated with the task).

Each task can be in 5 basic states as signaled by the containerd https://github.com/rvs/eve/blob/tasks/pkg/pillar/hypervisor/containerd.go#L116

In addition to that, tasks that are in a RUNNING state can further clarify their status by exposing status of the entity that is running as part of the task (qemu, xl, etc.). IOW, there may be a situation where from containerd's perspective the task is very much running (the process is still alive) but from the Xen perspective the domain is very much halted.

This kind of "clarification of state" is currently hardcoded in xen and kvm implementations, but I plan to generalize this mechanism down the road to be similar to Kubernete's liveness probes https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/

One final note is on the error states. This PR makes full use of two distinct states BROKEN and UNKNOWN to signal errors (both of these states always have an error value associated with them). BROKEN means that a containerd task at least exists (although it may not be running) UNKNOWN means that we can't even say that much (we couldn't communicate with the containerd for example). Thus the difference between BROKEN and UNKNOWN is that domainmgr tries to "fix" BROKEN domains automatically by deleting them (the logic being that the least we can do is to free resources -- since remember -- from containerd perspective the task exists). UNKNOWN really requires user's attention and, more likely than not, would require deleting an app an recreating it again. Both of these MUST me explicitly done by the user (this is very much by design).