### PR TITLE
Tighter integration for ZFS POC

### DIFF
--- a/pkg/storage-init/build.yml
+++ b/pkg/storage-init/build.yml
@@ -7,10 +7,10 @@ image: eve-storage-init
 network: yes
 config:
   binds:
+    - /lib/modules:/lib/modules
     - /dev:/dev
     - /var:/var:rshared,rbind
     - /containers:/containers:rshared,rbind
   rootfsPropagation: shared
-  net: host
   capabilities:
-    - CAP_SYS_ADMIN
+    - all


### PR DESCRIPTION
This will allow us to experiment with ZFS (right now the focus is on evaluating encryption capabilities, performance and resiliency compared to ext4) much more easily.

The way this integration works is as follows: if storage-init detects P3 being part of zpool it mounts it as so. This is pretty simple and is guaranteed to NOT affect anything that we have running currently, since there's nothing that will turn P3 into zpool during the normal course of events.

But how do I do that you may ask, well, there's a hack for that. On a live, booted EVE, you simply do
```
echo "eve<3zfs" > /dev/P3DEV  ; sync ; sync ; sync ; reboot
```
and EVE will come back with P3 as a zfs pool.

Obviously, this hack is going to go away when/if we decide to move to ZFS for real (and it will become part of the installer). But for now it is super convenient and presents very little danger to our more mainstream management of storage.