### PR TITLE
vnc password for kvm

### DIFF
--- a/pkg/pillar/hypervisor/containerd.go
+++ b/pkg/pillar/hypervisor/containerd.go
@@ -124,6 +124,12 @@ func (ctx ctrdContext) Delete(domainName string, domainID int) error {
 	return ctx.ctrdClient.CtrDeleteContainer(ctrdCtx, domainName)
 }
 
+func (ctx ctrdContext) Annotations(domainName string, domainID int) (map[string]string, error) {
+	ctrdCtx, done := ctx.ctrdClient.CtrNewUserServicesCtx()
+	defer done()
+	return ctx.ctrdClient.CtrGetAnnotations(ctrdCtx, domainName)
+}
+
 func (ctx ctrdContext) Info(domainName string, domainID int) (int, types.SwState, error) {
 	ctrdCtx, done := ctx.ctrdClient.CtrNewUserServicesCtx()
 	defer done()

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -651,6 +651,18 @@ func (ctx kvmContext) Start(domainName string, domainID int) error {
 	logrus.Infof("Creating %s at %s", "qmpEventHandler", agentlog.GetMyStack())
 	go qmpEventHandler(getQmpListenerSocket(domainName), getQmpExecutorSocket(domainName))
 
+	annotations, err := ctx.ctrdContext.Annotations(domainName, domainID)
+	if err != nil {
+		logrus.Warnf("Error in get annotations for domain %s: %v", domainName, err)
+		return err
+	}
+
+	if vncPassword, ok := annotations["VncPasswd"]; ok && vncPassword != "" {
+		if err := execVNCPassword(qmpFile, vncPassword); err != nil {
+			return logError("failed to set VNC password %v", err)
+		}
+	}
+
 	if err := execContinue(qmpFile); err != nil {
 		return logError("failed to start domain that is stopped %v", err)
 	}

--- a/pkg/pillar/hypervisor/qmp.go
+++ b/pkg/pillar/hypervisor/qmp.go
@@ -2,6 +2,7 @@ package hypervisor
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/digitalocean/go-qemu/qmp"
 	"github.com/sirupsen/logrus"
 	"os"
@@ -44,6 +45,12 @@ func execShutdown(socket string) error {
 
 func execQuit(socket string) error {
 	_, err := execRawCmd(socket, `{ "execute": "quit" }`)
+	return err
+}
+
+func execVNCPassword(socket string, password string) error {
+	vncSetPwd := fmt.Sprintf(`{ "execute": "change-vnc-password", "arguments": { "password": "%s" } }`, password)
+	_, err := execRawCmd(socket, vncSetPwd)
 	return err
 }
 


### PR DESCRIPTION
Quite dirty hack, but we need to send `{ "execute": "change-vnc-password", "arguments": { "password": "%s" } }` into QMP socket to set password for VNC. Without this one we cannot connect to VNC with password in KVM HV.
Maybe there is a more elegant way to get configuration parameters (`VncPasswd`) inside `func (ctx kvmContext) Start(domainName string, domainID int) error`?

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>