### PR TITLE
Fixing BlobStatus transitioning to LOADED state

### DIFF
--- a/pkg/pillar/cas/cas.go
+++ b/pkg/pillar/cas/cas.go
@@ -100,7 +100,7 @@ type CAS interface {
 	// RemoveContainerRootDir removes contents of a container's rootPath, existing snapshot and reference.
 	RemoveContainerRootDir(rootPath string) error
 
-	// IngestBlobsAnsCreateImage is a combination of IngestBlobs and CreateImage APIs,
+	// IngestBlobsAndCreateImage is a combination of IngestBlobs and CreateImage APIs,
 	// but this API will add a lock, upload all the blobs, add reference to the blobs and release the lock.
 	// By adding a lock before uploading the blobs we prevent the unreferenced blobs from getting GCed.
 	// We will assume that the first blob in the list will be the root blob for which the reference will be created.
@@ -108,7 +108,7 @@ type CAS interface {
 	// if there is an exception while reading the blob data.
 	//NOTE: This either loads all the blobs or loads nothing. In other words, in case of error,
 	// this API will GC all blobs that were loaded until that point.
-	IngestBlobsAnsCreateImage(reference string, blobs ...*types.BlobStatus) error
+	IngestBlobsAndCreateImage(reference string, blobs ...*types.BlobStatus) ([]*types.BlobStatus, error)
 
 	//CloseClient closes the respective CAS client initialized while calling `NewCAS()`
 	CloseClient() error

--- a/pkg/pillar/cmd/volumemgr/blob.go
+++ b/pkg/pillar/cmd/volumemgr/blob.go
@@ -564,7 +564,7 @@ func populateInitBlobStatus(ctx *volumemgrContext) {
 			continue
 		}
 		if lookupBlobStatus(ctx, blobInfo.Digest) == nil {
-			log.Debugf("populateInitBlobStatus: Found blob %s in CAS", blobInfo.Digest)
+			log.Infof("populateInitBlobStatus: Found blob %s in CAS", blobInfo.Digest)
 			blobStatus := &types.BlobStatus{
 				Sha256:      strings.TrimPrefix(blobInfo.Digest, "sha256:"),
 				Size:        uint64(blobInfo.Size),

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -431,7 +431,7 @@ func Run(ps *pubsub.PubSub) {
 	// of an image we already have in place.
 	// Also we wait for zedagent to send all contentTreeConfig so that we can GC all blobs which
 	// doesn't have ConfigTree ref
-	for !ctx.verifierRestarted && !ctx.contentTreeRestarted {
+	for !(ctx.verifierRestarted && ctx.contentTreeRestarted) {
 		log.Warnf("Subject to watchdog. Waiting for verifierRestarted")
 
 		select {


### PR DESCRIPTION
Bug description: 
Blobs were not marked as LOADED after loading them into CAS.

Reason:
After loading the blob in CAS, `IngestBlobs()` marks the respective BlobStatus as LOADED but it doesn't publish it. As a result, BlobStatus.state never transitioned to LOADED. 

Fix:
After loading the blob in CAS, `IngestBlobsAnsCreateImage()` will return (only the) loaded BlobStatus which will be published by `doUpdateContentTree()`

Signed-off-by: adarsh-zededa <adarsh@zededa.com>