### PR TITLE
Adding cgroup for EVE services

### DIFF
--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -28,26 +28,37 @@ onboot:
 services:
    - name: rsyslogd
      image: RSYSLOGD_TAG
+     cgroupsPath: /eve/eve-rsyslogd
    - name: ntpd
      image: linuxkit/openntpd:v0.5
+     cgroupsPath: /eve/eve-ntpd
    - name: sshd
      image: linuxkit/sshd:v0.5
+     cgroupsPath: /eve/eve-sshd
    - name: wwan
      image: WWAN_TAG
+     cgroupsPath: /eve/eve-wwan
    - name: wlan
      image: WLAN_TAG
+     cgroupsPath: /eve/eve-wlan
    - name: lisp
      image: LISP_TAG
+     cgroupsPath: /eve/eve-lisp
    - name: guacd
      image: GUACD_TAG
+     cgroupsPath: /eve/eve-guacd
    - name: pillar
      image: PILLAR_TAG
+     cgroupsPath: /eve/eve-pillar
    - name: vtpm
      image: VTPM_TAG
+     cgroupsPath: /eve/eve-vtpm
    - name: watchdog
      image: WATCHDOG_TAG
+     cgroupsPath: /eve/eve-watchdog
    - name: xen-tools
      image: XENTOOLS_TAG
+     cgroupsPath: /eve/eve-xen-tools
 files:
    - path: /etc/eve-release
      contents: 'EVE_VERSION'

--- a/pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup
+++ b/pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+default_eve_cgroup_memory_limit=1000000000 #1GB
+default_eve_cgroup_cpus_limit='0-1'
+
+#Creating eve cgroup which will be parent cgroup for all eve services
+CGROUPS="cpuset cpu cpuacct blkio memory devices freezer net_cls perf_event net_prio hugetlb pids systemd "
+for cg in $CGROUPS; do
+  mkdir -p /sys/fs/cgroup/${cg}/eve
+done
+
+#Converts K, M, G values to Bytes
+function get_bytes {
+        if [ "${1: -1}" == "K" ]; then
+                echo $((${1%?} * 1024 ))
+        elif [ "${1: -1}" == "M" ]; then
+                echo $((${1%?} * 1024*1024 ))
+        elif [ "${1: -1}" == "G" ]; then
+                echo $((${1%?} * 1024*1024*1024 ))
+        else
+                echo $1
+        fi
+}
+
+eve_cgroup_memory_limit=$(get_bytes $(cat /proc/cmdline | grep -o '\bdom0_mem=[^, ]*' | cut -d = -f 2))
+eve_cgroup_memory_soft_limit=$(get_bytes $(cat /proc/cmdline | grep -o "\bdom0_mem=[^,]*,max:[^ ]*" | cut -d : -f 2))
+eve_cgroup_cpus_limit="0-$(cat /proc/cmdline | grep -o '\bdom0_max_vcpus=[^ ]*' | cut -d = -f 2)"
+
+if [ -z "${eve_cgroup_memory_limit}" ]; then
+        echo "Setting default value of $default_eve_cgroup_memory_limit for eve_cgroup_memory_limit"
+        eve_cgroup_memory_limit=$default_eve_cgroup_memory_limit
+fi
+
+if [ -z "${eve_cgroup_memory_soft_limit}" ]; then
+        echo "Setting value of $eve_cgroup_memory_limit for eve_cgroup_memory_soft_limit"
+        eve_cgroup_memory_soft_limit=$eve_cgroup_memory_limit
+fi
+
+if [ $eve_cgroup_cpus_limit == "0-" ]; then
+        echo "Setting default value of $default_eve_cgroup_cpus_limit for eve_cgroup_memory_limit"
+        eve_cgroup_cpus_limit=$default_eve_cgroup_cpus_limit
+fi
+
+/bin/echo $eve_cgroup_memory_limit > /sys/fs/cgroup/memory/eve/memory.limit_in_bytes
+
+/bin/echo $eve_cgroup_memory_soft_limit > /sys/fs/cgroup/memory/eve/memory.soft_limit_in_bytes
+
+/bin/echo $eve_cgroup_cpus_limit > /sys/fs/cgroup/cpuset/eve/cpuset.cpus
+
+

--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -235,7 +235,7 @@ do_if_args source $config_grub_cfg
 
 menuentry "Boot ${rootfs_title}${rootfs_title_suffix}" {
      $load_hv_cmd $hv $hv_console $hv_platform_tweaks $hv_dom0_mem_settings $hv_dom0_cpu_settings $hv_extra_args
-     $load_dom0_cmd $dom0 $dom0_console $dom0_rootfs $dom0_platform_tweaks $dom0_cmdline $dom0_extra_args
+     $load_dom0_cmd $dom0 $dom0_console $dom0_rootfs $hv_dom0_mem_settings $hv_dom0_cpu_settings $dom0_platform_tweaks $dom0_cmdline $dom0_extra_args
      do_if_args $load_devicetree_cmd $devicetree
      do_if_args $load_initrd_cmd $initrd
 }
@@ -268,7 +268,7 @@ submenu 'Set Boot Options' {
 
    menuentry 'show boot options' {
       set_global zboot1 "$load_hv_cmd $hv $hv_console $hv_platform_tweaks $hv_dom0_mem_settings $hv_dom0_cpu_settings $hv_extra_args"
-      set_global zboot2 "$load_dom0_cmd $dom0 $dom0_console $dom0_rootfs $dom0_platform_tweaks $dom0_cmdline $dom0_extra_args"
+      set_global zboot2 "$load_dom0_cmd $dom0 $dom0_console $dom0_rootfs $hv_dom0_mem_settings $hv_dom0_cpu_settings $dom0_platform_tweaks $dom0_cmdline $dom0_extra_args"
       set_global zboot3 "do_if_args $load_devicetree_cmd $devicetree"
       set_global zboot4 "do_if_args $load_initrd_cmd $initrd"
    }

--- a/pkg/pillar/containerd/containerd.go
+++ b/pkg/pillar/containerd/containerd.go
@@ -61,10 +61,6 @@ const (
 
 	// default signal to kill tasks
 	defaultSignal = "SIGTERM"
-	//containerd context lease
-	ctrdCtxLeaseID = "eve-user-apps-lease"
-	//To keep resource safe from getting GC while loading it in Ctrd
-	tempLeaseDuration = 5 * time.Minute
 )
 
 var (
@@ -629,6 +625,9 @@ func LKTaskPrepare(name, linuxkit string, domSettings *types.DomainConfig, memOv
 
 	spec.Get().Root.Path = rootfs
 	spec.Get().Root.Readonly = true
+	if spec.Get().Linux != nil {
+		spec.Get().Linux.CgroupsPath = fmt.Sprintf("/%s/%s", ctrdServicesNamespace, name)
+	}
 	if domSettings != nil {
 		spec.UpdateFromDomain(*domSettings)
 		if memOverhead > 0 {


### PR DESCRIPTION
Created a parent cgroup  `eve` with 1GB memory and 1 cpu core limitation. All eve services will be spawned as part of `eve` cgroup.

Haven't included `xen-tool` under `eve` cgroup since all AppInstance will be child process of `xen-tool` and we don't want to restrict resources for AppInstance.

Signed-off-by: adarsh-zededa <adarsh@zededa.com>