### PR TITLE
Simplifying hypervisor backed task launch sequence

### DIFF
--- a/pkg/xen-tools/Dockerfile.in
+++ b/pkg/xen-tools/Dockerfile.in
@@ -80,7 +80,7 @@ COPY --from=uefi-build /OVMF.fd /usr/lib/xen/boot/ovmf.bin
 COPY --from=uefi-build /OVMF_PVH.fd /usr/lib/xen/boot/ovmf-pvh.bin
 COPY --from=runx-build /runx-initrd /usr/lib/xen/boot/runx-initrd
 COPY init.sh /
-COPY qemu-ifup disable-vif-features /etc/xen/scripts/
+COPY qemu-ifup xen-start /etc/xen/scripts/
 
 # We need to keep a slim profile, which means removing things we don't need
 RUN rm -rf /usr/lib/libxen*.a /usr/lib/libxl*.a /usr/lib/debug /usr/lib/python*

--- a/pkg/xen-tools/xen-start
+++ b/pkg/xen-tools/xen-start
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -ex
 
-FEATURES="feature-sg feature-gso-tcpv4 feature-gso-tcpv6 feature-ipv4-csum-offload feature-ipv6-csum-offload"
+VIF_FEATURES="feature-sg feature-gso-tcpv4 feature-gso-tcpv6 feature-ipv4-csum-offload feature-ipv6-csum-offload"
 
 bail() {
    echo "$@"
@@ -9,7 +9,13 @@ bail() {
 }
 
 # pre-flight checks
-[ $# -ne 1 ] && bail "Usage: $0 <domain ID>"
+[ $# -ne 2 ] && bail "Usage: $0 <domain name> <domain config>"
+
+# FIXME: this really needs to be managed by runc
+keyctl link @u @s || :
+
+# create domain in a paused state
+xl create "$2" -p
 
 # we may need to wait for domain to come online for us to manipulate it (timing out in under 30 sec)
 for i in 1 2 3; do
@@ -20,8 +26,14 @@ done
 [ -z "$ID" ] && bail "Couldn't find domain $1"
 
 for vif in $(xenstore list /local/domain/$ID/device/vif); do
-  for f in $FEATURES; do
+  for f in $VIF_FEATURES; do
     xenstore write "/local/domain/$ID/device/vif/$vif/$f" 0
     xenstore write "/local/domain/0/backend/vif/$ID/$vif/$f" 0
   done
 done
+
+# finally unpause the domain
+xl unpause "$ID"
+
+# and start watching over the console
+exec xl console "$ID" < /dev/null


### PR DESCRIPTION
This is one of a few PRs to reduce specialization of hypervisor/{xen,kvm}.go to pretty much zero and push all relevant logic into the container itself. This one gets rid of specialized Start() in xen. KVM Start() is next.

I'm still thinking about how to generalize this all (the current thought is to use OCI Runtime hooks for pre- and post- actions that we may need to do in every hypervisor container). But this one we need sooner since it also contains setting up the keyctl for encryption.

In general, though, this is all to make our hypervisor implementations completely containerized to a point where you can actually run and test them completely independently from EVE.

I am sure @deitch will get a kick out of this