### PR TITLE
Pulling zfs tools into host filesystem

### DIFF
--- a/pkg/dom0-ztools/Dockerfile
+++ b/pkg/dom0-ztools/Dockerfile
@@ -1,2 +1,8 @@
+FROM alpine:3.12 as zfs
+RUN mkdir -p /out/etc/apk /out/boot && cp -r /etc/apk/* /out/etc/apk/
+RUN apk add --no-cache --initdb -p /out \
+    zfs=0.8.4-r0
+
 FROM scratch
+COPY --from=zfs /out/ /
 ADD rootfs/ /

--- a/pkg/dom0-ztools/build.yml
+++ b/pkg/dom0-ztools/build.yml
@@ -1,2 +1,3 @@
 org: lfedge
 image: eve-dom0-ztools
+network: yes

--- a/pkg/storage-init/Dockerfile
+++ b/pkg/storage-init/Dockerfile
@@ -2,8 +2,8 @@ FROM alpine:3.12
 WORKDIR /
 # hadolint ignore=DL3018
 RUN apk add --no-cache bash glib squashfs-tools util-linux e2fsprogs \
-        e2fsprogs-extra keyutils dosfstools coreutils sgdisk zfs
-COPY zfs.sh storage-init.sh /
+        e2fsprogs-extra keyutils dosfstools coreutils sgdisk
+COPY storage-init.sh /
 
 ENTRYPOINT []
 CMD ["/storage-init.sh"]

--- a/pkg/storage-init/build.yml
+++ b/pkg/storage-init/build.yml
@@ -7,6 +7,7 @@ image: eve-storage-init
 network: yes
 config:
   binds:
+    - /:/hostfs
     - /lib/modules:/lib/modules
     - /dev:/dev
     - /var:/var:rshared,rbind

--- a/pkg/storage-init/storage-init.sh
+++ b/pkg/storage-init/storage-init.sh
@@ -100,7 +100,7 @@ if P3=$(findfs PARTLABEL=P3) && [ -n "$P3" ]; then
     if [ "$(dd if="$P3" bs=8 count=1 2>/dev/null)" = "eve<3zfs" ]; then
         # zero out the request (regardless of whether we can convert to zfs)
         dd if=/dev/zero of="$P3" bs=8 count=1 conv=noerror,sync,notrunc
-        zpool create -f -m /var/persist -o feature@encryption=enabled persist "$P3"
+        chroot /hostfs zpool create -f -m /var/persist -o feature@encryption=enabled persist "$P3"
     fi
 
     P3_FS_TYPE=$(blkid "$P3"| tr ' ' '\012' | awk -F= '/^TYPE/{print $2;}' | sed 's/"//g')
@@ -111,7 +111,7 @@ if P3=$(findfs PARTLABEL=P3) && [ -n "$P3" ]; then
                         FSCK_FAILED=1
                     fi
                     ;;
-        zfs_member) if ! zpool import -f persist; then
+        zfs_member) if ! chroot /hostfs zpool import -f persist; then
                         FSCK_FAILED=1
                     fi
                     ;;

--- a/pkg/storage-init/zfs.sh
+++ b/pkg/storage-init/zfs.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-ctr run --mount type=bind,src=/dev,dst=/dev,options=rbind:rw:rshared    \
-        --mount type=bind,src=/proc,dst=/proc,options=rbind:rw:rshared  \
-        --mount type=bind,src=/sys,dst=/sys,options=rbind:rw:rshared    \
-        --mount type=bind,src=/run,dst=/run,options=rbind:rw:rshared    \
-        --device /dev/zfs --privileged --rm -t                          \
-        --rootfs /containers/onboot/000-storage-init/lower zfs /bin/sh


### PR DESCRIPTION
This is required for containerd zfs snapshotter to be able to use ZFS. Sadly it simply exec'ecs zfs command for all its operations.

Note that yetus issue appears to be a bug in Yetus