### PR TITLE
Prototype of encrypting ZFS dataset on EVE

### DIFF
--- a/pkg/pillar/cmd/vaultmgr/vaultmgrzfs.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgrzfs.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package vaultmgr
+
+import (
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	zfsPath              = "/usr/sbin/chroot"
+	defaultZpool         = "persist"
+	defaultSecretDataset = defaultZpool + "/vault"
+	zfsHostfsKeyFile     = "/containers/services/pillar/rootfs/var/run/TmpVaultDir2/protector.key"
+	zfsKeyFile           = zfsKeyDir + "/protector.key"
+	zfsKeyDir            = "/var/run/TmpVaultDir2"
+)
+
+func getCreateParams(vaultPath string) []string {
+	args := []string{"/hostfs", "zfs", "create", "-o", "encryption=aes-256-gcm", "-o", "keylocation=file://" + zfsHostfsKeyFile, "-o", "keyformat=raw", vaultPath}
+	return args
+}
+
+func getLoadKeyParams(vaultPath string) []string {
+	args := []string{"/hostfs", "zfs", "load-key", vaultPath}
+	return args
+}
+
+func getMountParams(vaultPath string) []string {
+	args := []string{"/hostfs", "zfs", "mount", vaultPath}
+	return args
+}
+
+func getKeyStatusParams(vaultPath string) []string {
+	args := []string{"/hostfs", "zfs", "get", "keystatus", vaultPath}
+	return args
+}
+
+//e.g. zfs load-key persist/vault followed by
+//zfs mount persist/vault
+func unlockZfsVault(vaultPath string) error {
+	//prepare key in the staging file
+	if err := stageKey(false, zfsKeyDir, zfsKeyFile); err != nil {
+		return err
+	}
+	defer unstageKey(zfsKeyDir, zfsKeyFile)
+
+	//zfs load-key
+	args := getLoadKeyParams(vaultPath)
+	if stdOut, stdErr, err := execCmd(zfsPath, args...); err != nil {
+		log.Errorf("Error loading key for vault: %v, %s, %s",
+			err, stdOut, stdErr)
+		return err
+	}
+	//zfs mount
+	args = getMountParams(vaultPath)
+	if stdOut, stdErr, err := execCmd(zfsPath, args...); err != nil {
+		log.Errorf("Error unlocking vault: %v, %s, %s", err, stdOut, stdErr)
+		return err
+	}
+	return nil
+}
+
+//e.g. zfs create -o encryption=aes-256-gcm -o keylocation=file://tmp/raw.key -o keyformat=raw perist/vault
+func createZfsVault(vaultPath string) error {
+	//prepare key in the staging file
+	if err := stageKey(false, zfsKeyDir, zfsKeyFile); err != nil {
+		return err
+	}
+	defer unstageKey(zfsKeyDir, zfsKeyFile)
+	args := getCreateParams(vaultPath)
+	if stdOut, stdErr, err := execCmd(zfsPath, args...); err != nil {
+		log.Errorf("Error creating zfs vault %s, error=%v, %s, %s",
+			vaultPath, err, stdOut, stdErr)
+		return err
+	}
+	log.Infof("Created new vault %s", vaultPath)
+	return nil
+}
+
+//e.g. zfs get keystatus persist/vault
+func checkKeyStatus(vaultPath string) error {
+	args := getKeyStatusParams(vaultPath)
+	if stdOut, stdErr, err := execCmd(zfsPath, args...); err != nil {
+		log.Debugf("keystatus query for %s results in error=%v, %s, %s",
+			vaultPath, err, stdOut, stdErr)
+		return err
+	}
+	return nil
+}
+
+func setupZfsVault(vaultPath string) error {
+	//zfs get keystatus returns success as long as vaultPath is a dataset,
+	//(even if not mounted yet), so use it to check dataset presence
+	if err := checkKeyStatus(vaultPath); err == nil {
+		//present, call unlock
+		return unlockZfsVault(vaultPath)
+	}
+	//try creating the dataset
+	return createZfsVault(vaultPath)
+}

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -119,12 +119,8 @@ fi
 
 CONFIGDEV=$(zboot partdev CONFIG)
 
-P3=$(/hostfs/sbin/findfs PARTLABEL=P3)
-P3_FS_TYPE=$(blkid "$P3"| awk '{print $3}' | sed 's/TYPE=//' | sed 's/"//g')
-if [ -c $TPM_DEVICE_PATH ] && ! [ -f $CONFIGDIR/disable-tpm ] && [ "$P3_FS_TYPE" = "ext4" ]; then
-    #It is a device with TPM, and formatted with ext4, setup fscrypt
-    echo "$(date -Ins -u) EXT4 partitioned $PERSISTDIR, enabling fscrypt"
-    #Initialize fscrypt algorithm, hash length etc
+if [ -c $TPM_DEVICE_PATH ] && ! [ -f $CONFIGDIR/disable-tpm ]; then
+#It is a device with TPM, enable disk encryption
     if ! $BINDIR/vaultmgr setupVaults; then
         echo "$(date -Ins -u) device-steps: vaultmgr setupVaults failed"
     fi

--- a/pkg/storage-init/storage-init.sh
+++ b/pkg/storage-init/storage-init.sh
@@ -110,7 +110,7 @@ if P3=$(findfs PARTLABEL=P3) && [ -n "$P3" ]; then
         chroot /hostfs zpool create -f -m /var/persist -o feature@encryption=enabled persist "$P3"
         # we immediately create a zfs dataset for containerd, since otherwise the init sequence will fail
         #   https://bugs.launchpad.net/ubuntu/+source/zfs-linux/+bug/1718761
-        chroot /hostfs zfs create -p -o mountpoint=/var/lib/containerd/io.containerd.snapshotter.v1.zfs persist/vault/snapshots
+        chroot /hostfs zfs create -p -o mountpoint=/var/lib/containerd/io.containerd.snapshotter.v1.zfs persist/snapshots
         P3_FS_TYPE=zfs_member
     fi
 


### PR DESCRIPTION
1. new file introduced(vaultmgrzfs.go) to manage encrypted datasets on ZFS
2. device-steps.sh modified to get rid of P3 file system type check
3. storage-init.sh modified to use an unencrypted dataset persist/snapshots for containerd (it is now  a common problem to solve for both fscrypt and zfs - to encrypt containerd snapshots)

tests done:
upgrade to this image and checked that fscrypt vaults are intact 
changed it to ZFS mode, rebooted, and checked that we have default datasets setup, and we have persist/vault marked for encryption, and we are no longer using fscrypt and instead using ZFS native encryption.

Signed-off-by: Hariharasubramanian C S <cshari@zededa.com>