### PR TITLE
Moving xl destroy call into xen-tools for now

### DIFF
--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -401,7 +401,7 @@ func (ctx xenContext) Stop(domainName string, domainID int, force bool) error {
 
 func (ctx xenContext) Delete(domainName string, domainID int) error {
 	log.Infof("xlDestroy %s %d\n", domainName, domainID)
-	stdOut, stdErr, err := containerd.CtrExec(domainName,
+	stdOut, stdErr, err := containerd.CtrSystemExec("xen-tools",
 		[]string{"xl", "destroy", domainName})
 	if err != nil {
 		log.Errorln("xl destroy failed ", err)


### PR DESCRIPTION
This is an unfortunate side effect of our container kernels simply crashing (instead of gracefully shutting down) when ask them to exit. We really need a proper fix here for what happens inside the VM -- but for now we at least need to make sure that domainmgr reaps the Xen domains.