### PR TITLE
Moving device model check to outside of Go code

### DIFF
--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -9,7 +9,6 @@ import (
 	zconfig "github.com/lf-edge/eve/api/go/config"
 	"github.com/lf-edge/eve/pkg/pillar/containerd"
 	"github.com/lf-edge/eve/pkg/pillar/types"
-	"github.com/lf-edge/eve/pkg/pillar/wrap"
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/mem"
 	log "github.com/sirupsen/logrus"
@@ -428,22 +427,20 @@ func (ctx xenContext) Info(domainName string, domainID int) (int, types.SwState,
 	// if task is alive, we augment task status with finer grained details from xl info
 	log.Infof("xlStatus %s %d\n", domainName, domainID)
 
-	// XXX xl list -l domainName returns json. XXX but state not included!
-	// Note that state is not very useful anyhow
 	stdOut, stdErr, err := containerd.CtrExec(domainName,
-		[]string{"xl", "list", domainName})
+		[]string{"/etc/xen/scripts/xen-info", domainName})
 	if err != nil {
-		log.Errorln("xl list failed ", err)
-		log.Errorln("xl list output ", stdOut, stdErr)
-		return effectiveDomainID, types.BROKEN, fmt.Errorf("xl list failed: %s %s", stdOut, stdErr)
+		log.Errorln("xen-info ", err)
+		log.Errorln("xen-info output ", stdOut, stdErr)
+		return effectiveDomainID, types.BROKEN, fmt.Errorf("xen-info failed: %s %s", stdOut, stdErr)
 	}
-	log.Infof("xl list done. Result %s\n", stdOut)
+	log.Infof("xen-info done. Result %s\n", stdOut)
 
 	//stdoutStderr should have 2 rows separated by '\n'. Where 1st row will be column names and 2nd row will be domain details
 	cmdResponse := strings.Split(stdOut, "\n")
 	if len(cmdResponse) < 2 {
-		log.Errorln("Info: domain not present in xl list output", stdOut)
-		return effectiveDomainID, types.BROKEN, fmt.Errorf("info: domain not present in xl list output %s", string(stdOut))
+		log.Errorln("Info: domain not present in xen-info output", stdOut)
+		return effectiveDomainID, types.BROKEN, fmt.Errorf("info: domain not present in xen-info output %s", string(stdOut))
 	}
 	//Removing all extra space between column result and split the result as array.
 	xlDomainResult := regexp.MustCompile(`\s+`).ReplaceAllString(cmdResponse[1], " ")
@@ -480,21 +477,6 @@ func (ctx xenContext) Info(domainName string, domainID int) (int, types.SwState,
 	if !matched {
 		return effectiveDomainID, types.BROKEN, fmt.Errorf("info: domain %s reported to be in unexpected state %s",
 			domainName, lastState)
-	}
-
-	// if we are in one of the states that may require a device model -- check for it
-	if effectiveDomainState == types.RUNNING || effectiveDomainState == types.PAUSED {
-		// create pgrep command to see if dataplane is running
-		match := fmt.Sprintf("name %s ", domainName)
-		cmd := wrap.Command("pgrep", "-f", match)
-
-		// pgrep returns 0 when there is atleast one matching program running
-		// cmd.Output returns nil when pgrep returns 0, otherwise pids.
-		if _, err := cmd.Output(); err != nil {
-			err = fmt.Errorf("info: device model %s process is not running: %s", match, err)
-			log.Infof(err.Error())
-			return effectiveDomainID, types.BROKEN, err
-		}
 	}
 
 	return effectiveDomainID, effectiveDomainState, nil

--- a/pkg/xen-tools/Dockerfile.in
+++ b/pkg/xen-tools/Dockerfile.in
@@ -80,7 +80,7 @@ COPY --from=uefi-build /OVMF.fd /usr/lib/xen/boot/ovmf.bin
 COPY --from=uefi-build /OVMF_PVH.fd /usr/lib/xen/boot/ovmf-pvh.bin
 COPY --from=runx-build /runx-initrd /usr/lib/xen/boot/runx-initrd
 COPY init.sh /
-COPY qemu-ifup xen-start /etc/xen/scripts/
+COPY qemu-ifup xen-start xen-info /etc/xen/scripts/
 
 # We need to keep a slim profile, which means removing things we don't need
 RUN rm -rf /usr/lib/libxen*.a /usr/lib/libxl*.a /usr/lib/debug /usr/lib/python*

--- a/pkg/xen-tools/xen-info
+++ b/pkg/xen-tools/xen-info
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+bail() {
+   echo "$@"
+   exit 1
+}
+
+# pre-flight checks
+[ $# -ne 1 ] && bail "Usage: $0 <domain name>"
+
+# find the domain
+ID=$(xl domid "$1" 2>/dev/null)
+[ -z "$ID" ] && bail "Couldn't find domain ID for domain $1"
+
+# lets see if this domain is expected to have a device model attached
+if DM_PID=$(xenstore read "/local/domain/$ID/image/device-model-pid") &&
+   ! (readlink "/proc/$DM_PID/exe" | grep -q qemu-system-) ;then
+cat <<__EOT__
+Name                                        ID   Mem VCPUs     State    Time(s)
+$1                              $ID   512     1     ----c-       0.0
+__EOT__
+else
+   xl list "$ID"
+fi

--- a/pkg/xen-tools/xen-start
+++ b/pkg/xen-tools/xen-start
@@ -19,7 +19,7 @@ xl create "$2" -p
 
 # we may need to wait for domain to come online for us to manipulate it (timing out in under 30 sec)
 for i in 1 2 3; do
-  ID=$(echo $(($(xl domid "$1") + 0))) ||:
+  ID=$(xl domid "$1" 2>/dev/null)
   sleep 8
   [ -z "$ID" ] || break
 done


### PR DESCRIPTION
This is something I've been meaning to do for quite some time (since the way device model check is currently implemented has been incorrect for quite some time). However, at the same time this is NOT a final form of this change.

At the same time -- since this is a bit of an emergency fix -- I apologize for  rushing it through.

The salient points here are:
   1. the check from Go code is gone for good -- it doesn't belong there (see below on where it belongs)
   2. the script xen-info is a quick hack (and that is the part I need to apologize for) but it is going to get removed by the end of this week with a proper fix

So what IS a proper fix -- well, something similar to Kubernetes container liveness checks -- something that would apply equally to VM-based containers and baremetal containers alike. I'll start a thread on eve-tsc@ today to discuss a few strategies there.