### PR TITLE
remove creation of /persist/img

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -42,11 +42,10 @@ import (
 )
 
 const (
-	agentName    = "domainmgr"
-	runDirname   = "/var/run/" + agentName
-	xenDirname   = runDirname + "/xen"       // We store xen cfg files here
-	ciDirname    = runDirname + "/cloudinit" // For cloud-init images
-	rwImgDirname = types.PersistDir + "/img" // We store images here
+	agentName  = "domainmgr"
+	runDirname = "/var/run/" + agentName
+	xenDirname = runDirname + "/xen"       // We store xen cfg files here
+	ciDirname  = runDirname + "/cloudinit" // For cloud-init images
 	// Time limits for event loop handlers
 	errorTime           = 3 * time.Minute
 	warningTime         = 40 * time.Second
@@ -161,11 +160,6 @@ func Run(ps *pubsub.PubSub) {
 	}
 	if _, err := os.Stat(ciDirname); err == nil {
 		if err := os.RemoveAll(ciDirname); err != nil {
-			log.Fatal(err)
-		}
-	}
-	if _, err := os.Stat(rwImgDirname); err != nil {
-		if err := os.MkdirAll(rwImgDirname, 0700); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -50,8 +50,8 @@ var reportDiskPaths = []string{
 
 // Report directory usage for these paths
 var reportDirPaths = []string{
-	types.PersistDir + "/downloads",
-	types.PersistDir + "/img",
+	types.PersistDir + "/downloads", // XXX old to be removed
+	types.PersistDir + "/img",       // XXX old to be removed
 	types.PersistDir + "/tmp",
 	types.PersistDir + "/log",
 	types.PersistDir + "/rsyslog",


### PR DESCRIPTION
Leaving the reporting of space used for /persist/img and /persist/downloads in place since old devices might have old files in there.