### PR TITLE
Allowing for containerd to use zfs snapshotter by default

### DIFF
--- a/pkg/storage-init/build.yml
+++ b/pkg/storage-init/build.yml
@@ -10,6 +10,7 @@ config:
     - /:/hostfs
     - /lib/modules:/lib/modules
     - /dev:/dev
+    - /run:/run
     - /var:/var:rshared,rbind
     - /containers:/containers:rshared,rbind
   rootfsPropagation: shared


### PR DESCRIPTION
Here's a tiny tweak to unblock further experiments with ZFS.

@cshari-zededa this is what I suggested as a way to handle similar things in vaultmgr