### PR TITLE
Avoid race causing no interfaces reported in AppInfo message

### DIFF
--- a/pkg/pillar/agentlog/agentlog.go
+++ b/pkg/pillar/agentlog/agentlog.go
@@ -145,6 +145,9 @@ func RebootReason(reason string, normal bool) {
 	if !normal {
 		reason = fmt.Sprintf("Reboot from agent %s[%d] in partition %s EVE version %s at %s: %s\n",
 			savedAgentName, savedPid, EveCurrentPartition(), EveVersion(), dateStr, reason)
+	} else {
+		reason = fmt.Sprintf("%s EVE version %s at %s\n",
+			reason, EveVersion(), dateStr)
 	}
 	err := printToFile(filename, reason)
 	if err != nil {

--- a/pkg/pillar/cmd/nodeagent/handlebaseos.go
+++ b/pkg/pillar/cmd/nodeagent/handlebaseos.go
@@ -22,7 +22,7 @@ func doZbootBaseOsInstallationComplete(ctxPtr *nodeagentContext,
 		return
 	}
 	if isZbootOtherPartitionStateUpdating(ctxPtr) && !ctxPtr.deviceReboot {
-		infoStr := fmt.Sprintf("NORMAL: baseos-update(%s) reboot\n", key)
+		infoStr := fmt.Sprintf("NORMAL: baseos-update(%s) reboot", key)
 		log.Infof(infoStr)
 		scheduleNodeReboot(ctxPtr, infoStr)
 	}

--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -557,10 +557,10 @@ func handleLastRebootReason(ctx *nodeagentContext) {
 		dateStr := ctx.rebootTime.Format(time.RFC3339Nano)
 		var reason string
 		if fileExists(firstbootFile) {
-			reason = fmt.Sprintf("NORMAL: First boot of device - at %s\n",
+			reason = fmt.Sprintf("NORMAL: First boot of device - at %s",
 				dateStr)
 		} else {
-			reason = fmt.Sprintf("Unknown reboot reason - power failure or crash - at %s\n",
+			reason = fmt.Sprintf("Unknown reboot reason - power failure or crash - at %s",
 				dateStr)
 		}
 		log.Warnf("Default RebootReason: %s", reason)

--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -749,7 +749,7 @@ func findVifAndTrigAppInfoUpload(ctx *zedagentContext, macAddr string, ipAddr ne
 		uuidStr := aiStatus.Key()
 		aiStatusPtr := &aiStatus
 		if aiStatusPtr.MaybeUpdateAppIPAddr(macAddr, ipAddr.String()) {
-			log.Debugf("findVifAndTrigAppInfoUpload: underlay %v", aiStatusPtr.UnderlayNetworks)
+			log.Infof("findVifAndTrigAppInfoUpload: underlay %v", aiStatusPtr.UnderlayNetworks)
 			PublishAppInfoToZedCloud(ctx, uuidStr, aiStatusPtr, ctx.assignableAdapters, ctx.iteration)
 			ctx.iteration++
 			break

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -1167,12 +1167,14 @@ func initializeDirs() {
 func handleAppInstanceStatusCreate(ctxArg interface{}, key string,
 	statusArg interface{}) {
 	status := statusArg.(types.AppInstanceStatus)
+	log.Infof("handleAppInstanceStatusCreate(%s)", key)
 	ctx := ctxArg.(*zedagentContext)
 	uuidStr := status.Key()
 	PublishAppInfoToZedCloud(ctx, uuidStr, &status, ctx.assignableAdapters,
 		ctx.iteration)
 	triggerPublishDevInfo(ctx)
 	ctx.iteration++
+	log.Infof("handleAppInstanceStatusCreate(%s) DONE", key)
 }
 
 // app instance event watch to capture transitions
@@ -1181,11 +1183,13 @@ func handleAppInstanceStatusCreate(ctxArg interface{}, key string,
 func handleAppInstanceStatusModify(ctxArg interface{}, key string,
 	statusArg interface{}) {
 	status := statusArg.(types.AppInstanceStatus)
+	log.Infof("handleAppInstanceStatusModify(%s)", key)
 	ctx := ctxArg.(*zedagentContext)
 	uuidStr := status.Key()
 	PublishAppInfoToZedCloud(ctx, uuidStr, &status, ctx.assignableAdapters,
 		ctx.iteration)
 	ctx.iteration++
+	log.Infof("handleAppInstanceStatusModify(%s) DONE", key)
 }
 
 func handleAppInstanceStatusDelete(ctxArg interface{}, key string,
@@ -1193,10 +1197,12 @@ func handleAppInstanceStatusDelete(ctxArg interface{}, key string,
 
 	ctx := ctxArg.(*zedagentContext)
 	uuidStr := key
+	log.Infof("handleAppInstanceStatusDelete(%s)", key)
 	PublishAppInfoToZedCloud(ctx, uuidStr, nil, ctx.assignableAdapters,
 		ctx.iteration)
 	triggerPublishDevInfo(ctx)
 	ctx.iteration++
+	log.Infof("handleAppInstanceStatusDelete(%s) DONE", key)
 }
 
 func lookupAppInstanceStatus(ctx *zedagentContext, key string) *types.AppInstanceStatus {
@@ -1435,7 +1441,7 @@ func handleNodeAgentStatusModify(ctxArg interface{}, key string,
 		updateInprogress && !status.UpdateInprogress {
 		log.Infof("TestComplete and deferred reboot")
 		ctx.rebootCmdDeferred = false
-		infoStr := fmt.Sprintf("TestComplete and deferred Reboot Cmd\n")
+		infoStr := fmt.Sprintf("TestComplete and deferred Reboot Cmd")
 		handleRebootCmd(ctx, infoStr)
 	}
 	if status.DeviceReboot {

--- a/pkg/pillar/go.mod
+++ b/pkg/pillar/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/eriknordmark/ipinfo v0.0.0-20190220084921-7ee0839158f9
 	github.com/eriknordmark/netlink v0.0.0-20190912172510-3b6b45309321
 	github.com/fsnotify/fsnotify v1.4.7
-	github.com/go-logfmt/logfmt v0.4.0 // indirect
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/gogo/googleapis v1.3.2 // indirect
 	github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0

--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -73,6 +73,7 @@ var nilUUID = uuid.UUID{}
 // Returns response for first success. Caller can not use resp.Body but can
 // use []byte contents return.
 // If bailOnHTTPErr is set we immediately return when we get a 4xx or 5xx error without trying the other interfaces.
+// XXX also 1010 from CloudFlare?
 // We return a bool remoteTemporaryFailure for the cases when we reached
 // the controller but it is overloaded, or has certificate issues.
 func SendOnAllIntf(ctx *ZedCloudContext, url string, reqlen int64, b *bytes.Buffer, iteration int, bailOnHTTPErr bool) (*http.Response, []byte, types.SenderResult, error) {


### PR DESCRIPTION
Seems like the gopsutil.net Interfaces() call might not return the nbu* interface when we want to send the App info message (not clear why if it is a race between the kernel and the EVE agents) but in any case if the IP link doesn't exist we can still report everything but the Mac address and UP flag.

The second and third commits are not related; just some cleanup and future comment.