### PR TITLE
move IP functionality from zedagent to nim

### DIFF
--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -568,7 +568,7 @@ func printOutput(ctx *diagContext) {
 		}
 
 		fmt.Fprintf(outfile, "INFO: %s: DNS servers: ", ifname)
-		for _, ds := range port.DnsServers {
+		for _, ds := range port.DNSServers {
 			fmt.Fprintf(outfile, "%s, ", ds.String())
 		}
 		fmt.Fprintf(outfile, "\n")

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -568,20 +568,22 @@ func printOutput(ctx *diagContext) {
 		}
 
 		fmt.Fprintf(outfile, "INFO: %s: DNS servers: ", ifname)
-		for _, ds := range port.NetworkXConfig.DnsServers {
+		for _, ds := range port.DnsServers {
 			fmt.Fprintf(outfile, "%s, ", ds.String())
 		}
 		fmt.Fprintf(outfile, "\n")
 		// If static print static config
-		if port.NetworkXConfig.Dhcp == types.DT_STATIC {
+		if port.Dhcp == types.DT_STATIC {
 			fmt.Fprintf(outfile, "INFO: %s: Static IP subnet: %s\n",
-				ifname, port.NetworkXConfig.Subnet.String())
-			fmt.Fprintf(outfile, "INFO: %s: Static IP router: %s\n",
-				ifname, port.NetworkXConfig.Gateway.String())
+				ifname, port.Subnet.String())
+			for _, r := range port.DefaultRouters {
+				fmt.Fprintf(outfile, "INFO: %s: Static IP router: %s\n",
+					ifname, r.String())
+			}
 			fmt.Fprintf(outfile, "INFO: %s: Static Domain Name: %s\n",
-				ifname, port.NetworkXConfig.DomainName)
+				ifname, port.DomainName)
 			fmt.Fprintf(outfile, "INFO: %s: Static NTP server: %s\n",
-				ifname, port.NetworkXConfig.NtpServer.String())
+				ifname, port.NtpServer.String())
 		}
 		printProxy(ctx, port, ifname)
 

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -773,7 +773,7 @@ func handleInterfaceChange(ctx *nimContext, ifindex int, logstr string, force bo
 	}
 	if force {
 		// The caller has already purged addresses from IfindexToAddrs
-		addrs, err := devicenetwork.GetIPAddrs(ifindex)
+		addrs, _, _, err := devicenetwork.GetIPAddrs(ifindex)
 		if err != nil {
 			addrs = nil
 		}
@@ -791,7 +791,7 @@ func handleInterfaceChange(ctx *nimContext, ifindex int, logstr string, force bo
 
 	// Compare old vs. current
 	oldAddrs, _ := devicenetwork.IfindexToAddrs(ifindex)
-	addrs, err := devicenetwork.GetIPAddrs(ifindex)
+	addrs, _, _, err := devicenetwork.GetIPAddrs(ifindex)
 	if err != nil {
 		log.Warnf("%s(%s %d) no addrs: %s",
 			logstr, ifname, ifindex, err)

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -1252,7 +1252,7 @@ func encodeNetInfo(port types.NetworkPortStatus) *info.ZInfoNetwork {
 	// fill in ZInfoDNS from what is currently used
 	networkInfo.Dns = new(info.ZInfoDNS)
 	networkInfo.Dns.DNSdomain = port.DomainName
-	for _, server := range port.DnsServers {
+	for _, server := range port.DNSServers {
 		networkInfo.Dns.DNSservers = append(networkInfo.Dns.DNSservers,
 			server.String())
 	}

--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -91,7 +91,7 @@ func checkPortAvailable(
 
 	if allowSharedPort(status) {
 		// Make sure it is configured for IP or will be
-		if portStatus.NetworkXConfig.Dhcp == types.DT_NONE {
+		if portStatus.Dhcp == types.DT_NONE {
 			errStr := fmt.Sprintf("Port %s not configured for shared use. "+
 				"Cannot be used by Switch Network Instance %s-%s\n",
 				status.CurrentUplinkIntf, status.UUID, status.DisplayName)
@@ -117,10 +117,10 @@ func checkPortAvailable(
 		}
 	} else {
 		// Make sure it will not be configured for IP
-		if portStatus.NetworkXConfig.Dhcp != types.DT_NONE {
+		if portStatus.Dhcp != types.DT_NONE {
 			errStr := fmt.Sprintf("Port %s configured for shared use with DHCP type %d. "+
 				"Cannot be used by Switch Network Instance %s-%s\n",
-				status.CurrentUplinkIntf, portStatus.NetworkXConfig.Dhcp, status.UUID, status.DisplayName)
+				status.CurrentUplinkIntf, portStatus.Dhcp, status.UUID, status.DisplayName)
 			return errors.New(errStr)
 		}
 		// Make sure it is not used by any other NetworkInstance

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -3070,24 +3070,24 @@ func isDNSServerChanged(ctx *zedrouterContext, newStatus *types.DeviceNetworkSta
 		if _, ok := ctx.dnsServers[port.IfName]; !ok {
 			// if dnsServer does not have valid server IPs, assign now
 			// and if we lose uplink connection, it will not overwrite the previous server IPs
-			if len(port.DnsServers) > 0 { // just assigned
-				ctx.dnsServers[port.IfName] = port.DnsServers
+			if len(port.DNSServers) > 0 { // just assigned
+				ctx.dnsServers[port.IfName] = port.DNSServers
 			}
 		} else {
 			// only check if we have valid new DNS server sets on the uplink
 			// valid DNS server IP changes will trigger the restart of dnsmasq.
-			if len(port.DnsServers) != 0 {
+			if len(port.DNSServers) != 0 {
 				// new one has different entries, and not the Internet disconnect case
-				if len(ctx.dnsServers[port.IfName]) != len(port.DnsServers) {
-					ctx.dnsServers[port.IfName] = port.DnsServers
+				if len(ctx.dnsServers[port.IfName]) != len(port.DNSServers) {
+					ctx.dnsServers[port.IfName] = port.DNSServers
 					dnsDiffer = true
 					continue
 				}
-				for idx, server := range port.DnsServers { // compare each one and update if changed
+				for idx, server := range port.DNSServers { // compare each one and update if changed
 					if server.Equal(ctx.dnsServers[port.IfName][idx]) == false {
 						log.Infof("isDnsServerChanged: intf %s exist %v, new %v\n",
-							port.IfName, ctx.dnsServers[port.IfName], port.DnsServers)
-						ctx.dnsServers[port.IfName] = port.DnsServers
+							port.IfName, ctx.dnsServers[port.IfName], port.DNSServers)
+						ctx.dnsServers[port.IfName] = port.DNSServers
 						dnsDiffer = true
 						break
 					}

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -3070,24 +3070,24 @@ func isDNSServerChanged(ctx *zedrouterContext, newStatus *types.DeviceNetworkSta
 		if _, ok := ctx.dnsServers[port.IfName]; !ok {
 			// if dnsServer does not have valid server IPs, assign now
 			// and if we lose uplink connection, it will not overwrite the previous server IPs
-			if len(port.NetworkXConfig.DnsServers) > 0 { // just assigned
-				ctx.dnsServers[port.IfName] = port.NetworkXConfig.DnsServers
+			if len(port.DnsServers) > 0 { // just assigned
+				ctx.dnsServers[port.IfName] = port.DnsServers
 			}
 		} else {
 			// only check if we have valid new DNS server sets on the uplink
 			// valid DNS server IP changes will trigger the restart of dnsmasq.
-			if len(port.NetworkXConfig.DnsServers) != 0 {
+			if len(port.DnsServers) != 0 {
 				// new one has different entries, and not the Internet disconnect case
-				if len(ctx.dnsServers[port.IfName]) != len(port.NetworkXConfig.DnsServers) {
-					ctx.dnsServers[port.IfName] = port.NetworkXConfig.DnsServers
+				if len(ctx.dnsServers[port.IfName]) != len(port.DnsServers) {
+					ctx.dnsServers[port.IfName] = port.DnsServers
 					dnsDiffer = true
 					continue
 				}
-				for idx, server := range port.NetworkXConfig.DnsServers { // compare each one and update if changed
+				for idx, server := range port.DnsServers { // compare each one and update if changed
 					if server.Equal(ctx.dnsServers[port.IfName][idx]) == false {
 						log.Infof("isDnsServerChanged: intf %s exist %v, new %v\n",
-							port.IfName, ctx.dnsServers[port.IfName], port.NetworkXConfig.DnsServers)
-						ctx.dnsServers[port.IfName] = port.NetworkXConfig.DnsServers
+							port.IfName, ctx.dnsServers[port.IfName], port.DnsServers)
+						ctx.dnsServers[port.IfName] = port.DnsServers
 						dnsDiffer = true
 						break
 					}

--- a/pkg/pillar/devicenetwork/devicenetwork.go
+++ b/pkg/pillar/devicenetwork/devicenetwork.go
@@ -200,7 +200,7 @@ func MakeDeviceNetworkStatus(globalConfig types.DevicePortConfig, oldStatus type
 		}
 		// Start with any statically assigned values; update below
 		globalStatus.Ports[ix].DomainName = u.DomainName
-		globalStatus.Ports[ix].DnsServers = u.DnsServers
+		globalStatus.Ports[ix].DNSServers = u.DnsServers
 
 		globalStatus.Ports[ix].NtpServer = u.NtpServer
 		globalStatus.Ports[ix].TestResults = u.TestResults

--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -924,11 +924,10 @@ func generateResolvConf(globalStatus types.DeviceNetworkStatus, destfile *os.Fil
 			continue
 		}
 		log.Infof("generateResolvConf %s has %d servers: %v",
-			us.IfName, len(us.NetworkXConfig.DnsServers),
-			us.NetworkXConfig.DnsServers)
+			us.IfName, len(us.DnsServers), us.DnsServers)
 		destfile.WriteString(fmt.Sprintf("# From %s\n", us.IfName))
 		// Avoid duplicate IP addresses for nameservers.
-		for _, server := range us.NetworkXConfig.DnsServers {
+		for _, server := range us.DnsServers {
 			duplicate := false
 			for _, a := range written {
 				if a.Equal(server) {

--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -924,10 +924,10 @@ func generateResolvConf(globalStatus types.DeviceNetworkStatus, destfile *os.Fil
 			continue
 		}
 		log.Infof("generateResolvConf %s has %d servers: %v",
-			us.IfName, len(us.DnsServers), us.DnsServers)
+			us.IfName, len(us.DNSServers), us.DNSServers)
 		destfile.WriteString(fmt.Sprintf("# From %s\n", us.IfName))
 		// Avoid duplicate IP addresses for nameservers.
-		for _, server := range us.DnsServers {
+		for _, server := range us.DNSServers {
 			duplicate := false
 			for _, a := range written {
 				if a.Equal(server) {

--- a/pkg/pillar/devicenetwork/dns.go
+++ b/pkg/pillar/devicenetwork/dns.go
@@ -21,7 +21,7 @@ import (
 func GetDhcpInfo(us *types.NetworkPortStatus) {
 
 	log.Infof("GetDhcpInfo(%s)\n", us.IfName)
-	if us.NetworkXConfig.Dhcp != types.DT_CLIENT {
+	if us.Dhcp != types.DT_CLIENT {
 		return
 	}
 	if strings.HasPrefix(us.IfName, "wwan") {
@@ -49,17 +49,6 @@ func GetDhcpInfo(us *types.NetworkPortStatus) {
 		}
 		log.Debugf("Got <%s> <%s>\n", items[0], items[1])
 		switch items[0] {
-		case "routers":
-			routers := trimQuotes(items[1])
-			log.Infof("GetDhcpInfo(%s) Gateway %s\n", us.IfName,
-				routers)
-			// XXX multiple? How separated?
-			ip := net.ParseIP(routers)
-			if ip == nil {
-				log.Errorf("Failed to parse %s\n", routers)
-				continue
-			}
-			us.NetworkXConfig.Gateway = ip
 		case "network_number":
 			network := trimQuotes(items[1])
 			log.Infof("GetDhcpInfo(%s) network_number %s\n", us.IfName,
@@ -81,14 +70,14 @@ func GetDhcpInfo(us *types.NetworkPortStatus) {
 			}
 		}
 	}
-	us.NetworkXConfig.Subnet = net.IPNet{IP: subnet, Mask: net.CIDRMask(masklen, 32)}
+	us.Subnet = net.IPNet{IP: subnet, Mask: net.CIDRMask(masklen, 32)}
 }
 
 // GetDNSInfo gets DNS info from /run files. Updates DomainName and DnsServers
 func GetDNSInfo(us *types.NetworkPortStatus) {
 
 	log.Infof("GetDNSInfo(%s)\n", us.IfName)
-	if us.NetworkXConfig.Dhcp != types.DT_CLIENT {
+	if us.Dhcp != types.DT_CLIENT {
 		return
 	}
 	filename := IfnameToResolvConf(us.IfName)
@@ -106,11 +95,11 @@ func GetDNSInfo(us *types.NetworkPortStatus) {
 			log.Errorf("Failed to parse %s\n", server)
 			continue
 		}
-		us.NetworkXConfig.DnsServers = append(us.NetworkXConfig.DnsServers, ip)
+		us.DnsServers = append(us.DnsServers, ip)
 	}
 	// XXX just pick first since have one DomainName slot
 	for _, dn := range dc.Search {
-		us.NetworkXConfig.DomainName = dn
+		us.DomainName = dn
 		break
 	}
 }

--- a/pkg/pillar/devicenetwork/dns.go
+++ b/pkg/pillar/devicenetwork/dns.go
@@ -95,7 +95,7 @@ func GetDNSInfo(us *types.NetworkPortStatus) {
 			log.Errorf("Failed to parse %s\n", server)
 			continue
 		}
-		us.DnsServers = append(us.DnsServers, ip)
+		us.DNSServers = append(us.DNSServers, ip)
 	}
 	// XXX just pick first since have one DomainName slot
 	for _, dn := range dc.Search {

--- a/pkg/pillar/devicenetwork/wpad.go
+++ b/pkg/pillar/devicenetwork/wpad.go
@@ -47,7 +47,7 @@ func CheckAndGetNetworkProxy(deviceNetworkStatus *types.DeviceNetworkStatus,
 		proxyConfig.Pacfile = pac
 		return nil
 	}
-	dn := status.NetworkXConfig.DomainName
+	dn := status.DomainName
 	if dn == "" {
 		errStr := fmt.Sprintf("NetworkProxyEnable for %s but neither a NetworkProxyURL nor a DomainName",
 			ifname)

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -805,8 +805,15 @@ type NetworkPortStatus struct {
 	Alias          string // From SystemAdapter's alias
 	IsMgmt         bool   // Used to talk to controller
 	Free           bool
-	NetworkXConfig NetworkXObjectConfig
+	Dhcp           DhcpType
+	Subnet         net.IPNet
+	NtpServer      net.IP
+	DomainName     string
+	DnsServers     []net.IP // If not set we use Gateway as DNS server
 	AddrInfoList   []AddrInfo
+	Up             bool
+	MacAddr        string
+	DefaultRouters []net.IP
 	ProxyConfig
 	// TestResults provides recording of failure and success
 	TestResults
@@ -1058,7 +1065,7 @@ func CountDNSServers(globalStatus DeviceNetworkStatus, phylabelOrIfname string) 
 		if us.IfName != ifname && ifname != "" {
 			continue
 		}
-		count += len(us.NetworkXConfig.DnsServers)
+		count += len(us.DnsServers)
 	}
 	return count
 }
@@ -1074,7 +1081,7 @@ func GetDNSServers(globalStatus DeviceNetworkStatus, ifname string) []net.IP {
 		if ifname != "" && ifname != us.IfName {
 			continue
 		}
-		for _, server := range us.NetworkXConfig.DnsServers {
+		for _, server := range us.DnsServers {
 			servers = append(servers, server)
 		}
 	}

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -809,7 +809,7 @@ type NetworkPortStatus struct {
 	Subnet         net.IPNet
 	NtpServer      net.IP
 	DomainName     string
-	DnsServers     []net.IP // If not set we use Gateway as DNS server
+	DNSServers     []net.IP // If not set we use Gateway as DNS server
 	AddrInfoList   []AddrInfo
 	Up             bool
 	MacAddr        string
@@ -1065,7 +1065,7 @@ func CountDNSServers(globalStatus DeviceNetworkStatus, phylabelOrIfname string) 
 		if us.IfName != ifname && ifname != "" {
 			continue
 		}
-		count += len(us.DnsServers)
+		count += len(us.DNSServers)
 	}
 	return count
 }
@@ -1081,7 +1081,7 @@ func GetDNSServers(globalStatus DeviceNetworkStatus, ifname string) []net.IP {
 		if ifname != "" && ifname != us.IfName {
 			continue
 		}
-		for _, server := range us.DnsServers {
+		for _, server := range us.DNSServers {
 			servers = append(servers, server)
 		}
 	}


### PR DESCRIPTION
This is just some refactoring post the logic changes in #1239 to have less logic in zedagent. Also by not using NetworkXConfig as status it makes it more obvious that the NTP servers, default routers, etc are what is currently used by the device.

@naiming-zededa if we ever see two or more default routers (I don't think DHCP would ever give us that) we should make probe targets for all of them. These changes made that more obvious since we allow multiple default routers but have only one static gateway field.