### PR TITLE
avoid DPC fallback when controller is upgrading

### DIFF
--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -451,12 +451,17 @@ func myPost(zedcloudCtx *zedcloud.ZedCloudContext, tlsConfig *tls.Config,
 	resp, contents, rtf, err := zedcloud.SendOnAllIntf(zedcloudCtx,
 		requrl, reqlen, b, retryCount, bailOnHTTPErr)
 	if err != nil {
-		if rtf == types.SenderStatusRemTempFail {
-			log.Errorf("remoteTemporaryFailure %s", err)
-		} else if rtf == types.SenderStatusCertMiss {
-			log.Infof("client myPost: Cert Miss")
-		} else {
-			log.Errorln(err)
+		switch rtf {
+		case types.SenderStatusUpgrade:
+			log.Infof("Controller upgrade in progress")
+		case types.SenderStatusRefused:
+			log.Infof("Controller returned ECONNREFUSED")
+		case types.SenderStatusCertInvalid:
+			log.Warnf("Controller certificate invalid time")
+		case types.SenderStatusCertMiss:
+			log.Infof("Controller certificate miss")
+		default:
+			log.Error(err)
 		}
 		return false, resp, rtf, contents
 	}

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -976,10 +976,20 @@ func myGet(zedcloudCtx *zedcloud.ZedCloudContext, reqURL string, ifname string,
 	resp, contents, rtf, err := zedcloud.SendOnIntf(zedcloudCtx,
 		reqURL, ifname, 0, nil, allowProxy)
 	if err != nil {
-		if rtf == types.SenderStatusRemTempFail {
-			fmt.Fprintf(outfile, "ERROR: %s: get %s remote temporary failure: %s\n",
-				ifname, reqURL, err)
-		} else {
+		switch rtf {
+		case types.SenderStatusUpgrade:
+			fmt.Fprintf(outfile, "ERROR: %s: get %s Controller upgrade in progress\n",
+				ifname, reqURL)
+		case types.SenderStatusRefused:
+			fmt.Fprintf(outfile, "ERROR: %s: get %s Controller returned ECONNREFUSED\n",
+				ifname, reqURL)
+		case types.SenderStatusCertInvalid:
+			fmt.Fprintf(outfile, "ERROR: %s: get %s Controller certificate invalid time\n",
+				ifname, reqURL)
+		case types.SenderStatusCertMiss:
+			fmt.Fprintf(outfile, "ERROR: %s: get %s Controller certificate miss\n",
+				ifname, reqURL)
+		default:
 			fmt.Fprintf(outfile, "ERROR: %s: get %s failed: %s\n",
 				ifname, reqURL, err)
 		}
@@ -1026,11 +1036,21 @@ func myPost(zedcloudCtx *zedcloud.ZedCloudContext, reqURL string, ifname string,
 	resp, contents, rtf, err := zedcloud.SendOnIntf(zedcloudCtx,
 		reqURL, ifname, reqlen, b, allowProxy)
 	if err != nil {
-		if rtf == types.SenderStatusRemTempFail {
-			fmt.Fprintf(outfile, "ERROR: %s: post %s remote temporary failure: %s\n",
-				ifname, reqURL, err)
-		} else {
-			fmt.Fprintf(outfile, "ERROR: %s: get %s failed: %s\n",
+		switch rtf {
+		case types.SenderStatusUpgrade:
+			fmt.Fprintf(outfile, "ERROR: %s: post %s Controller upgrade in progress\n",
+				ifname, reqURL)
+		case types.SenderStatusRefused:
+			fmt.Fprintf(outfile, "ERROR: %s: post %s Controller returned ECONNREFUSED\n",
+				ifname, reqURL)
+		case types.SenderStatusCertInvalid:
+			fmt.Fprintf(outfile, "ERROR: %s: post %s Controller certificate invalid time\n",
+				ifname, reqURL)
+		case types.SenderStatusCertMiss:
+			fmt.Fprintf(outfile, "ERROR: %s: post %s Controller certificate miss\n",
+				ifname, reqURL)
+		default:
+			fmt.Fprintf(outfile, "ERROR: %s: post %s failed: %s\n",
 				ifname, reqURL, err)
 		}
 		return false, nil, rtf, nil

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -1773,12 +1773,7 @@ func SendMetricsProtobuf(ReportMetrics *metrics.ZMetricMsg,
 		size, buf, iteration, bailOnHTTPErr)
 	if err != nil {
 		// Hopefully next timeout will be more successful
-		if rtf == types.SenderStatusRemTempFail {
-			log.Errorf("SendMetricsProtobuf remoteTemporaryFailure: %s",
-				err)
-		} else {
-			log.Errorf("SendMetricsProtobuf failed: %s", err)
-		}
+		log.Errorf("SendMetricsProtobuf status %d failed: %s", rtf, err)
 		return
 	} else {
 		writeSentMetricsProtoMessage(data)

--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -849,13 +849,8 @@ func sendFlowProtobuf(protoflows *flowlog.FlowMessage) {
 		_, _, rtf, err := zedcloud.SendOnAllIntf(&zedcloudCtx, flowlogURL,
 			size, buf, flowIteration, bailOnHTTPErr)
 		if err != nil {
-			if rtf == types.SenderStatusRemTempFail {
-				log.Errorf("FlowStats: sendFlowProtobuf  remoteTemporaryFailure: %s",
-					err)
-			} else {
-				log.Errorf("FlowStats: sendFlowProtobuf failed: %s",
-					err)
-			}
+			log.Errorf("FlowStats: sendFlowProtobuf status %d failed: %s",
+				rtf, err)
 			flowIteration--
 			if flowQ.Len() > 100 { // if fail to send for too long, start to drop
 				flowQ.Remove(ent)

--- a/pkg/pillar/cmd/zedrouter/probe.go
+++ b/pkg/pillar/cmd/zedrouter/probe.go
@@ -400,12 +400,9 @@ func launchHostProbe(ctx *zedrouterContext) {
 					}
 					if foundport {
 						startTime := time.Now()
-						resp, _, rtf, err := zedcloud.SendOnIntf(&zcloudCtx, remoteURL, info.IfName, 0, nil, true)
+						resp, _, _, err := zedcloud.SendOnIntf(&zcloudCtx, remoteURL, info.IfName, 0, nil, true)
 						if err != nil {
 							log.Debugf("launchHostProbe: send on intf %s, err %v\n", info.IfName, err)
-						}
-						if rtf == types.SenderStatusRemTempFail {
-							log.Debugf("launchHostProbe: remote temp failure\n")
 						}
 						if resp != nil {
 							log.Debugf("launchHostProbe: server %s status code %d\n", serverNameAndPort, resp.StatusCode)

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -18,7 +18,9 @@ type SenderResult uint8
 // Enum of http extra status for 'rtf'
 const (
 	SenderStatusNone                      SenderResult = iota
-	SenderStatusRemTempFail                            // http remote temporarilly failure
+	SenderStatusRefused                                // ECNNREFUSED
+	SenderStatusUpgrade                                // 503 indicating controller upgrade in progress
+	SenderStatusCertInvalid                            // Server cert expired or NotBefore; device might have wrong time
 	SenderStatusCertMiss                               // remote signed senderCertHash we don't have
 	SenderStatusSignVerifyFail                         // envelope signature verify failed
 	SenderStatusAlgoFail                               // hash algorithm we don't support


### PR DESCRIPTION
With the Zededa controller now returning 503 when it is down for an upgrade we should avoid switching to a different DevicePortConfig and just wait for the 503 errors to go away.

Introducing some more specific SenderStatus in the types package as part of this.