### PR TITLE
Fix `make installer-iso` error

### DIFF
--- a/pkg/mkimage-iso-efi/Dockerfile
+++ b/pkg/mkimage-iso-efi/Dockerfile
@@ -5,6 +5,7 @@ RUN apk add --no-cache --initdb -p /out \
   dosfstools \
   libarchive-tools \
   binutils \
+  busybox \
   mtools \
   xorriso
 RUN echo "mtools_skip_check=1" >> /out/etc/mtools.conf


### PR DESCRIPTION
Container `lfedge/eve-mkimage-iso-efi` was failing from `make
installer-iso` and reporting the error:

	standard_init_linux.go:211: exec user process caused "exec format error"

It was failing when entering the script `pkg/mkimage-iso-efi/make-efi`,
which is headed with `#!/bin/sh`.

Simply COPY'ing /bin/sh into the new container got past this error,
but encountered other errors when unable to found other utilities
used by the script `make-efi`.

Alpine's busybox package contains all of the depencies of `make-efi`,
so this commit simply adds that to the list of installed packages.

Busybox is about ~800KB.

An alternative approach would be to simply copy the individual binaries
and their deps, such as `cd`, `ln`, etc... used by make-efi.  This could
be resubmitted with that approach if we'd like to reduce the size further.

If interested in reproducing the error, from "MX Linux" or "Manjaro Linux":

1. `git clone path/to/eve`
2. `cd eve`
3. `make installer-iso`