### PR TITLE
Getting rid of all the screen scraping for Xen domain status

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -742,17 +742,12 @@ func verifyStatus(ctx *domainContext, status *types.DomainStatus) {
 			log.Warnln(errStr)
 			status.Activated = false
 			status.State = types.HALTED
-			// XXX
-			if false && status.IsContainer {
-				status.SetErrorNow("container exited - please restart application instance")
-			}
 
 			// check if task is in the BROKEN state and kill it (later on we may do some
 			// level of recovery or at least gather some intel on why and how it crashed)
 			// NOTE: we don't do anything for repairing tasks in the UNKNOWN state, for those
 			// the only remedy is an explicit user action (delete, restart, etc.)
 			if domainStatus == types.BROKEN {
-				// XXX old error?
 				err := fmt.Errorf("one of the %s tasks has crashed (%v)", status.Key(), err)
 				log.Errorf(err.Error())
 				status.SetErrorNow("one of the application's tasks has crashed - please restart application instance")

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -437,46 +437,16 @@ func (ctx xenContext) Info(domainName string, domainID int) (int, types.SwState,
 	log.Infof("xen-info done. Result %s\n", stdOut)
 
 	//stdoutStderr should have 2 rows separated by '\n'. Where 1st row will be column names and 2nd row will be domain details
-	cmdResponse := strings.Split(stdOut, "\n")
-	if len(cmdResponse) < 2 {
-		log.Errorln("Info: domain not present in xen-info output", stdOut)
-		return effectiveDomainID, types.BROKEN, fmt.Errorf("info: domain not present in xen-info output %s", string(stdOut))
-	}
-	//Removing all extra space between column result and split the result as array.
-	xlDomainResult := regexp.MustCompile(`\s+`).ReplaceAllString(cmdResponse[1], " ")
-	//Domain's status is 5th column in xl list <domain> result
-	domainState := strings.Split(xlDomainResult, " ")[4]
-	//Removing all unset state bits represented by "-"
-	domainState = strings.ReplaceAll(domainState, "-", "")
-	//Domain's ID is the 2nd columd in xl list <domain> result
-	effectiveDomainID, err = strconv.Atoi(strings.Split(xlDomainResult, " ")[1])
-	if len(domainState) < 1 || err != nil {
-		// for case where xl info returns ------ we assume the domain is running
-		log.Infof("Info: domain %s in ------ state with ID %d", domainName, effectiveDomainID)
-		domainState = "r"
-	} else {
-		if effectiveDomainID != domainID {
-			log.Warningf("Info: domainid changed from %d to %d for %s\n",
-				domainID, effectiveDomainID, domainName)
-		}
-	}
-	log.Debugf("Info: domain: %s domainState: %s domainID: %d", domainName, domainState, effectiveDomainID)
-	//In case of more that 1 (logically possible) domain state, will consider the last state.
-	lastState := domainState[len(domainState)-1:]
-	log.Debugf("Info: domain: %s lastState: %s", domainName, lastState)
-	// these states are taken from https://xenbits.xen.org/docs/unstable/man/xl.1.html (scroll to STATES)
 	stateMap := map[string]types.SwState{
-		"r": types.RUNNING,
-		"b": types.RUNNING,
-		"p": types.PAUSED,
-		"s": types.HALTING,
-		"c": types.BROKEN,
-		"d": types.HALTING,
+		"running": types.RUNNING,
+		"paused":  types.PAUSED,
+		"halting": types.HALTING,
+		"broken":  types.BROKEN,
 	}
-	effectiveDomainState, matched := stateMap[lastState]
+	effectiveDomainState, matched := stateMap[strings.TrimSpace(stdOut)]
 	if !matched {
 		return effectiveDomainID, types.BROKEN, fmt.Errorf("info: domain %s reported to be in unexpected state %s",
-			domainName, lastState)
+			domainName, stdOut)
 	}
 
 	return effectiveDomainID, effectiveDomainState, nil

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -430,13 +430,14 @@ func (ctx xenContext) Info(domainName string, domainID int) (int, types.SwState,
 	stdOut, stdErr, err := containerd.CtrExec(domainName,
 		[]string{"/etc/xen/scripts/xen-info", domainName})
 	if err != nil {
+		// XXX state is already stopped; can we get that state?
 		log.Errorln("xen-info ", err)
 		log.Errorln("xen-info output ", stdOut, stdErr)
-		return effectiveDomainID, types.BROKEN, fmt.Errorf("xen-info failed: %s %s", stdOut, stdErr)
+		// XXX better error return
+		return effectiveDomainID, types.BROKEN, fmt.Errorf("xen-info failed: %s", err)
 	}
 	log.Infof("xen-info done. Result %s\n", stdOut)
 
-	//stdoutStderr should have 2 rows separated by '\n'. Where 1st row will be column names and 2nd row will be domain details
 	stateMap := map[string]types.SwState{
 		"running": types.RUNNING,
 		"paused":  types.PAUSED,

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -430,10 +430,10 @@ func (ctx xenContext) Info(domainName string, domainID int) (int, types.SwState,
 	stdOut, stdErr, err := containerd.CtrExec(domainName,
 		[]string{"/etc/xen/scripts/xen-info", domainName})
 	if err != nil {
-		// XXX state is already stopped; can we get that state?
 		log.Errorln("xen-info ", err)
 		log.Errorln("xen-info output ", stdOut, stdErr)
-		// XXX better error return
+		// XXX this likely means domain has died, we need to fetch its final note
+		// and augment error reported back with it:
 		return effectiveDomainID, types.BROKEN, fmt.Errorf("xen-info failed: %s", err)
 	}
 	log.Infof("xen-info done. Result %s\n", stdOut)

--- a/pkg/xen-tools/xen-info
+++ b/pkg/xen-tools/xen-info
@@ -12,13 +12,24 @@ bail() {
 ID=$(xl domid "$1" 2>/dev/null)
 [ -z "$ID" ] && bail "Couldn't find domain ID for domain $1"
 
-# lets see if this domain is expected to have a device model attached
-if DM_PID=$(xenstore read "/local/domain/$ID/image/device-model-pid") &&
-   ! (readlink "/proc/$DM_PID/exe" | grep -q qemu-system-) ;then
-cat <<__EOT__
-Name                                        ID   Mem VCPUs     State    Time(s)
-$1                              $ID   512     1     ----c-       0.0
-__EOT__
-else
-   xl list "$ID"
+# we expect to get rbpscd where every letter can also be a dash (-)
+# Name    ID    Mem    VCPUs    State    Time(s)
+case $(xl list "$ID" | awk '{st=$5;} END {print st;}') in
+   *d) STATUS=halting ;;
+  *c*) STATUS=broken  ;;
+  *s*) STATUS=halting ;;
+  *p*) STATUS=paused  ;;
+  *b*) STATUS=running ;;
+   r*) STATUS=running ;;
+    *) STATUS=$(cat /dev/status) ;;
+esac
+
+# an additional check we do for running domains is to make sure device model is still around
+if [ "$STATUS" = running ] &&
+   DM_PID=$(xenstore read "/local/domain/$ID/image/device-model-pid") &&
+   ! (readlink "/proc/$DM_PID/exe" | grep -q qemu-system-); then
+   STATUS=broken
 fi
+
+# finally deposit the current status
+echo "$STATUS" | tee /dev/status

--- a/pkg/xen-tools/xen-start
+++ b/pkg/xen-tools/xen-start
@@ -35,5 +35,8 @@ done
 # finally unpause the domain
 xl unpause "$ID"
 
+# declare the status as running
+echo running > /dev/status
+
 # and start watching over the console
 exec xl console "$ID" < /dev/null


### PR DESCRIPTION
So admittedly this is a bit premature (since I wanted to get a bit more time to think how we can do an equivalent of kubernetes/docker liveness check across the board) but since we seem to be running into xl info screen scraping coredumping on weird xl info output -- here it is.

So on one hand -- this is exactly what it is -- just fixing all the brittle screen scraping Go code with more robust screen scraping shell code (although I haven't really tested it -- so if we decide to pull it in as-is -- I need a bit of time to run some basic sanity checks).

However, it is also an invitation for a discussion of how we can do the liveness check for all the different tasks that are running on EVE.

The proposed idea here is that just like Kubernetes with https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ or Docker with https://docs.docker.com/engine/reference/builder/#healthcheck statement in a Docker file we will allow our tasks to have a declaration of "here's how I want my fine grained state to be probed".

And therein lies the rub -- we have a choice to make. On one hand we can follow Docker/k8s example and simply make it a here's the executable -- run it and get me the result OR we can actually use the filesystem approach so that whatever is running in the container will write locally to the /dev/status file and then the EVE infrastructure will pick it up from there (likely via the bind mount).

So that's choice #1. Choice #2 is standardizing on keywords (right now we return running|paused|halting|broken) but may be we need more or less of those.

@deitch @eriknordmark lets discuss where do we take this tomorrow.