### PR TITLE
EVE image update should not fallback during 503

### DIFF
--- a/pkg/pillar/cmd/nodeagent/handleonboarded.go
+++ b/pkg/pillar/cmd/nodeagent/handleonboarded.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package nodeagent
+
+import (
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	uuid "github.com/satori/go.uuid"
+	log "github.com/sirupsen/logrus"
+)
+
+// Really a constant
+var nilUUID = uuid.UUID{}
+
+// Set onboarded if the UUID is not nil
+func handleOnboardStatusModify(ctxArg interface{}, key string, statusArg interface{}) {
+	status := statusArg.(types.OnboardingStatus)
+	ctx := ctxArg.(*nodeagentContext)
+
+	if status.DeviceUUID == nilUUID {
+		log.Infof("handleOnboardStatusModify nil UUID")
+		return
+	}
+	ctx.onboarded = true
+	log.Infof("handleOnboardStatusModify onboarded")
+}

--- a/pkg/pillar/cmd/nodeagent/handletimers.go
+++ b/pkg/pillar/cmd/nodeagent/handletimers.go
@@ -53,7 +53,7 @@ func updateTickerTime(ctxPtr *nodeagentContext) {
 // when baseos upgrade is inprogress
 // on cloud disconnect for a specified amount of time, reset the node
 func handleFallbackOnCloudDisconnect(ctxPtr *nodeagentContext) {
-	if !ctxPtr.updateInprogress || !ctxPtr.DNSinitialized {
+	if !ctxPtr.updateInprogress {
 		return
 	}
 	// apply the fallback time function,wait for fallback timeout

--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -39,8 +39,7 @@ import (
 const (
 	agentName                   = "nodeagent"
 	timeTickInterval     uint32 = 10
-	watchdogInterval     uint32 = 25
-	networkUpTimeout     uint32 = 300
+	watchdogInterval     uint32 = 25 // For StillRunning
 	maxRebootStackSize          = 1600
 	maxJSONAttributeSize        = maxRebootStackSize + 100
 	configDir                   = "/config"
@@ -61,40 +60,40 @@ const (
 var Version = "No version specified"
 
 type nodeagentContext struct {
-	agentBaseContext       agentbase.Context
-	GCInitialized          bool // Received initial GlobalConfig
-	DNSinitialized         bool // Received DeviceNetworkStatus
-	globalConfig           *types.ConfigItemValueMap
-	subGlobalConfig        pubsub.Subscription
-	subZbootStatus         pubsub.Subscription
-	subZedAgentStatus      pubsub.Subscription
-	subDeviceNetworkStatus pubsub.Subscription
-	subDomainStatus        pubsub.Subscription
-	pubZbootConfig         pubsub.Publication
-	pubNodeAgentStatus     pubsub.Publication
-	curPart                string
-	upgradeTestStartTime   uint32
-	tickerTimer            *time.Ticker
-	stillRunning           *time.Ticker
-	remainingTestTime      time.Duration
-	lastConfigReceivedTime uint32
-	configGetStatus        types.ConfigGetStatus
-	deviceNetworkStatus    *types.DeviceNetworkStatus
-	deviceRegistered       bool
-	updateInprogress       bool
-	updateComplete         bool
-	sshAccess              bool
-	testComplete           bool
-	testInprogress         bool
-	timeTickCount          uint32
-	rebootCmd              bool // Are we rebooting?
-	deviceReboot           bool
-	currentRebootReason    string    // Reason we are rebooting
-	rebootReason           string    // From last reboot
-	rebootImage            string    // Image from which the last reboot happened
-	rebootStack            string    // From last reboot
-	rebootTime             time.Time // From last reboot
-	restartCounter         uint32
+	agentBaseContext            agentbase.Context
+	GCInitialized               bool // Received initial GlobalConfig
+	DNSinitialized              bool // Received DeviceNetworkStatus
+	globalConfig                *types.ConfigItemValueMap
+	subGlobalConfig             pubsub.Subscription
+	subZbootStatus              pubsub.Subscription
+	subZedAgentStatus           pubsub.Subscription
+	subDeviceNetworkStatus      pubsub.Subscription
+	subDomainStatus             pubsub.Subscription
+	pubZbootConfig              pubsub.Publication
+	pubNodeAgentStatus          pubsub.Publication
+	curPart                     string
+	upgradeTestStartTime        uint32
+	tickerTimer                 *time.Ticker
+	stillRunning                *time.Ticker
+	remainingTestTime           time.Duration
+	lastControllerReachableTime uint32 // Got a config or some error but can reach controller
+	configGetStatus             types.ConfigGetStatus
+	deviceNetworkStatus         *types.DeviceNetworkStatus
+	deviceRegistered            bool
+	updateInprogress            bool
+	updateComplete              bool
+	sshAccess                   bool
+	testComplete                bool
+	testInprogress              bool
+	timeTickCount               uint32 // Don't get confused by NTP making time jump by tracking our own progression
+	rebootCmd                   bool   // Are we rebooting?
+	deviceReboot                bool
+	currentRebootReason         string    // Reason we are rebooting
+	rebootReason                string    // From last reboot
+	rebootImage                 string    // Image from which the last reboot happened
+	rebootStack                 string    // From last reboot
+	rebootTime                  time.Time // From last reboot
+	restartCounter              uint32
 
 	// Some contants.. Declared here as variables to enable unit tests
 	minRebootDelay          uint32

--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
-	"github.com/lf-edge/eve/pkg/pillar/iptables"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils"
@@ -78,7 +77,6 @@ type nodeagentContext struct {
 	deviceRegistered            bool
 	updateInprogress            bool
 	updateComplete              bool
-	sshAccess                   bool
 	testComplete                bool
 	testInprogress              bool
 	timeTickCount               uint32 // Don't get confused by NTP making time jump by tracking our own progression
@@ -106,7 +104,6 @@ func newNodeagentContext() nodeagentContext {
 	nodeagentCtx.maxDomainHaltTime = maxDomainHaltTime
 	nodeagentCtx.domainHaltWaitIncrement = domainHaltWaitIncrement
 
-	nodeagentCtx.sshAccess = true // Kernel default - no iptables filters
 	nodeagentCtx.globalConfig = types.DefaultConfigItemValueMap()
 
 	// start the watchdog process timer tick
@@ -328,10 +325,6 @@ func handleGlobalConfigSynchronized(ctxArg interface{}, done bool) {
 
 	log.Infof("handleGlobalConfigSynchronized(%v)", done)
 	if done {
-		first := !ctxPtr.GCInitialized
-		if first {
-			iptables.UpdateSshAccess(ctxPtr.sshAccess, first)
-		}
 		ctxPtr.GCInitialized = true
 	}
 }


### PR DESCRIPTION
We seem to have a good opportunity to test this now with all the controller updates plus I saw an image update failed due to Exceeded earlier today when the controller was sending 503.

Please review each commit separately.
Some mostly dead code removal.

Note that since this code was written @naiming-zededa added OnboardStatus and it is more robust to check for that than pgrep for zedagent.