### PR TITLE
Mangle source tag for app logs. Logmanager separates app logs using t…

### DIFF
--- a/pkg/pillar/containerd/containerd.go
+++ b/pkg/pillar/containerd/containerd.go
@@ -427,8 +427,8 @@ func CtrCreateTask(domainName string) (int, error) {
 	logger := GetLog()
 
 	io := func(id string) (cio.IO, error) {
-		stdoutFile := logger.Path(domainName + ".out")
-		stderrFile := logger.Path(domainName)
+		stdoutFile := logger.Path("guest_vm-" + domainName)
+		stderrFile := logger.Path("guest_vm-" + domainName)
 		return &logio{
 			cio.Config{
 				Stdin:    "/dev/null",


### PR DESCRIPTION
…ag name

Signed-off-by: Gopi krishna Kodali <gkodali@zededa.com>