### PR TITLE
edk update

### DIFF
--- a/pkg/uefi/Dockerfile
+++ b/pkg/uefi/Dockerfile
@@ -19,9 +19,9 @@ FROM ${BUILD_CONTAINER} as build
 # hadolint ignore=DL3018
 RUN apk add --no-cache curl make gcc g++ python libuuid iasl nasm util-linux-dev bash git util-linux
 
-RUN git clone --depth 1 -b edk2-stable201908 https://github.com/tianocore/edk2.git /ws
+RUN git clone --depth 1 -b edk2-stable202005 https://github.com/tianocore/edk2.git /ws
 WORKDIR /ws
-RUN git submodule update --init --depth 1
+RUN git submodule update --init
 COPY build.sh /ws/
 COPY patch /ws/patch
 RUN bash -c 'patch -p0 < patch/*'

--- a/pkg/uefi/patch/000.patch
+++ b/pkg/uefi/patch/000.patch
@@ -1,18 +1,6 @@
---- BaseTools/Source/C/Include/AArch64/ProcessorBind.h.orig
-+++ BaseTools/Source/C/Include/AArch64/ProcessorBind.h
-@@ -61,7 +61,9 @@
-   typedef char                CHAR8;
-   typedef signed char         INT8;
- 
-+#ifndef UINT8_MAX
-   #define UINT8_MAX 0xff
-+#endif
- #endif
- 
- ///
 --- OvmfPkg/PlatformPei/Xen.c.orig
 +++ OvmfPkg/PlatformPei/Xen.c
-@@ -137,6 +137,10 @@
+@@ -137,6 +137,10 @@ XenDetect (
        mXen = TRUE;
        return TRUE;
      }


### PR DESCRIPTION
Update of `edk2` from stable201908 to stable202005 let me to start EVE on my Linux (qemu-system-x86_64 4.2.0) with `q35 machine` mode with `intel-iommu` device without displaying of UEFI SHELL.
But this requires additional verification on Mac OS and with EVE`s rootfs updates.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>