### PR TITLE
[WIP][DO NOT MERGE]Moving containerd content and snapshots into vault

### DIFF
--- a/pkg/dom0-ztools/rootfs/etc/containerd/config.toml
+++ b/pkg/dom0-ztools/rootfs/etc/containerd/config.toml
@@ -1,0 +1,19 @@
+state = "/run/containerd"
+root = "/var/persist/containerd"
+disabled_plugins = ["cri", "btrfs", "aufs"]
+
+[grpc]
+  address = "/run/containerd/containerd.sock"
+  uid = 0
+  gid = 0
+
+[debug]
+  address = "/run/containerd/debug.sock"
+  level = "info"
+
+[metrics]
+  address = ""
+
+[plugins]
+  [plugins.content]
+    root = "/var/persist/vault/content"

--- a/pkg/pillar/cmd/vaultmgr/vaultmgrzfs.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgrzfs.go
@@ -11,13 +11,12 @@ const (
 	zfsPath              = "/usr/sbin/chroot"
 	defaultZpool         = "persist"
 	defaultSecretDataset = defaultZpool + "/vault"
-	zfsHostfsKeyFile     = "/containers/services/pillar/rootfs/var/run/TmpVaultDir2/protector.key"
 	zfsKeyFile           = zfsKeyDir + "/protector.key"
-	zfsKeyDir            = "/var/run/TmpVaultDir2"
+	zfsKeyDir            = "/run/TmpVaultDir2"
 )
 
 func getCreateParams(vaultPath string) []string {
-	args := []string{"/hostfs", "zfs", "create", "-o", "encryption=aes-256-gcm", "-o", "keylocation=file://" + zfsHostfsKeyFile, "-o", "keyformat=raw", vaultPath}
+	args := []string{"/hostfs", "zfs", "create", "-o", "encryption=aes-256-gcm", "-o", "keylocation=file://" + zfsKeyFile, "-o", "keyformat=raw", vaultPath}
 	return args
 }
 

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -130,6 +130,15 @@ else
         mkdir $PERSISTDIR/vault
     fi
 fi
+# XXX FIXME: this is an "Indiana Jones snatch" attempt at
+# swapping content and snapshotter folders undeneath containerd.
+# Just like th original Indiana Jones's move this is highly risky.
+for i in io.containerd.snapshotter.v1.overlayfs io.containerd.content.v1.content; do
+    mkdir -p "$PERSISTDIR/vault/containerd/$i"
+    ln -s "../../../containerd/$i.fallback/metadata.db" "$PERSISTDIR/vault/containerd/$i/metadata.db" || :
+    ln -s "../vault/containerd/$i" "$PERSISTDIR/containerd/$i.tmp" 
+    mv -Tf "$PERSISTDIR/containerd/$i.tmp" "$PERSISTDIR/containerd/$i"
+done
 
 if [ -f $PERSISTDIR/IMGA/reboot-reason ]; then
     echo "IMGA reboot-reason: $(cat $PERSISTDIR/IMGA/reboot-reason)"


### PR DESCRIPTION
As it turns out, we've neglected one bit during our CAS refactoring: the fact that containerd itself stores content (CAS blobs) and snapshots in the unencrypted location under /persist/containerd.

This is somewhat scary, but the good news is that at least VM images are unaffected (btw, why the heck do we NOT treat them as CAS?)

Now, fixing it is actually more tricky that I initially thought. The problem being that all the plugins of containerd tend to initialize their backing stores right away when containerd starts. This is before pillar's vaultmgr has a chance to unlock the vault with the required key. Hence a knee-jerk attempt at configuring containerd to store all its data in vault won't work (at least not until we split vaultmgr into something that may need to run before containerd -- which is a conversation @eriknordmark and @cshari-zededa need to have).

Hence, this PR attempts to pull off a few hacks that would allow containerd to come up but perhaps not have actual access to the bits stored as content (CAS) and snapshots. This should be fine (in theory!) since access to them is required only later during the domainmgr lifecycle.

So... this is very lightly tested, but if we all agree that this is the best we can do for now -- so be it and I can test it then.

One other bit of help I need from @deitch is figuring out why setting `plugins.content.root` in the `containerd/config.toml` doesn't seem to affect the setting on that plugin. Running `ctr plugins ls -d` suggested it should be tweakable.

Oh, and finally, I cleaned up zfs filenames a bit -- since `/run` is universally available everywhere. @cshari-zededa -- please take a look.