### PR TITLE
Revert "Mangle source tag for app logs. Logmanager separates app logs…

### DIFF
--- a/pkg/pillar/containerd/containerd.go
+++ b/pkg/pillar/containerd/containerd.go
@@ -431,8 +431,8 @@ func CtrCreateTask(domainName string) (int, error) {
 	logger := GetLog()
 
 	io := func(id string) (cio.IO, error) {
-		stdoutFile := logger.Path("guest_vm-" + domainName)
-		stderrFile := logger.Path("guest_vm-" + domainName)
+		stdoutFile := logger.Path(domainName + ".out")
+		stderrFile := logger.Path(domainName)
 		return &logio{
 			cio.Config{
 				Stdin:    "/dev/null",


### PR DESCRIPTION
… using tag name"

This reverts commit 709a56da4f1ed7fedc03f4736e562876de57b110.

Signed-off-by: Roman Shaposhnik <rvs@zededa.com>