### PR TITLE
Adding cgroup constrain for containerd and memlogd

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@
 1. [Runtime Lifecycle](#runtime-lifecycle)
 1. [Building EVE](#building-eve)
 1. [EVE Internals](#eve-internals)
+1. [EVE CGroups](#eve-cgroups)
 
 ## Introduction
 
@@ -337,3 +338,45 @@ For some of the details on EVE internals you may want to check out:
 
 * [Domain Manager](../pkg/pillar/docs/domainmgr.md)
 * [TPM Manager](../pkg/pillar/docs/tpmmgr.md)
+
+## EVE CGroups
+
+Resources like memory and CPU used by EVE services, containerd, memlogd and edge applications are controlled by their respective [CGroups](https://www.kernel.org/doc/Documentation/cgroup-v2.txt).
+CGroups in EVE follows the below hierarchy:
+
+```text
+Parent cgroup (/sys/fs/cgroup/<subsystems>/)
+├── eve
+│   └── services
+│   │   └── rsyslogd
+│   │   └── ntpd
+│   │   └── sshd
+│   │   └── wwan
+│   │   └── wlan
+│   │   └── lisp
+│   │   └── guacd
+│   │   └── pillar
+│   │   └── vtpm
+│   │   └── watchdog
+│   │   └── xen-tools
+│   │
+│   └── containerd
+│   └── memlogd
+│
+└── eve-user-apps
+    └── (edge applications)
+```
+
+Memory and CPU limits of `eve`, `eve/services` and `eve/containerd` cgroups can be changed via
+`hv_dom0_*`, `hv_eve_*` and `hv_ctrd_*` respectively in `/config/grup.cfg`.
+
+Example:
+
+```text
+set_global hv_dom0_mem_settings "dom0_mem=800M,max:800M"
+set_global hv_dom0_cpu_settings "dom0_max_vcpus=1 dom0_vcpus_pin"
+set_global hv_eve_mem_settings "eve_mem=500M,max:500M"
+set_global hv_eve_cpu_settings "eve_max_vcpus=1"
+set_global hv_ctrd_mem_settings "ctrd_mem=250M,max:250M"
+set_global hv_ctrd_cpu_settings "ctrd_max_vcpus=1"
+```

--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -28,34 +28,34 @@ onboot:
 services:
    - name: rsyslogd
      image: RSYSLOGD_TAG
-     cgroupsPath: /eve/eve-rsyslogd
+     cgroupsPath: /eve/services/rsyslogd
    - name: ntpd
      image: linuxkit/openntpd:v0.5
-     cgroupsPath: /eve/eve-ntpd
+     cgroupsPath: /eve/services/ntpd
    - name: sshd
      image: linuxkit/sshd:v0.5
-     cgroupsPath: /eve/eve-sshd
+     cgroupsPath: /eve/services/sshd
    - name: wwan
      image: WWAN_TAG
-     cgroupsPath: /eve/eve-wwan
+     cgroupsPath: /eve/services/wwan
    - name: wlan
      image: WLAN_TAG
-     cgroupsPath: /eve/eve-wlan
+     cgroupsPath: /eve/services/wlan
    - name: guacd
      image: GUACD_TAG
-     cgroupsPath: /eve/eve-guacd
+     cgroupsPath: /eve/services/guacd
    - name: pillar
      image: PILLAR_TAG
-     cgroupsPath: /eve/eve-pillar
+     cgroupsPath: /eve/services/pillar
    - name: vtpm
      image: VTPM_TAG
-     cgroupsPath: /eve/eve-vtpm
+     cgroupsPath: /eve/services/vtpm
    - name: watchdog
      image: WATCHDOG_TAG
-     cgroupsPath: /eve/eve-watchdog
+     cgroupsPath: /eve/services/watchdog
    - name: xen-tools
      image: XENTOOLS_TAG
-     cgroupsPath: /eve/eve-xen-tools
+     cgroupsPath: /eve/services/xen-tools
 files:
    - path: /etc/eve-release
      contents: 'EVE_VERSION'

--- a/pkg/dom0-ztools/rootfs/etc/containerd/config.toml
+++ b/pkg/dom0-ztools/rootfs/etc/containerd/config.toml
@@ -14,6 +14,9 @@ disabled_plugins = ["cri", "btrfs", "aufs"]
 [metrics]
   address = ""
 
+[cgroup]
+  path = "/eve/containerd"
+
 # [plugins]
 #  [plugins.content]
 #    root = "/var/persist/vault/content"

--- a/pkg/dom0-ztools/rootfs/etc/init.d/002-logging
+++ b/pkg/dom0-ztools/rootfs/etc/init.d/002-logging
@@ -1,3 +1,5 @@
 #!/bin/sh
 
-/usr/bin/memlogd -daemonize -max-line-len 8192
+#Starting memlogd as part as part of a cgroup
+mkdir -p /sys/fs/cgroup/memory/eve/memlogd
+sh -c 'echo $$ > /sys/fs/cgroup/memory/eve/memlogd/tasks && /usr/bin/memlogd -daemonize -max-line-len 8192'

--- a/pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup
+++ b/pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup
@@ -1,50 +1,101 @@
 #!/bin/sh
 
-default_eve_cgroup_memory_limit=1000000000 #1GB
-default_eve_cgroup_cpus_limit='0-1'
+default_cgroup_memory_limit=1000000000 #1GB
+default_cgroup_cpus_limit='0-1'
 
-#Creating eve cgroup which will be parent cgroup for all eve services
-CGROUPS="cpuset cpu cpuacct blkio memory devices freezer net_cls perf_event net_prio hugetlb pids systemd "
-for cg in $CGROUPS; do
-  mkdir -p /sys/fs/cgroup/${cg}/eve
-done
+dom0_cgroup_memory_soft_limit=$(cat /proc/cmdline | grep -o '\bdom0_mem=[^, ]*' | cut -d = -f 2)
+dom0_cgroup_memory_limit=$(cat /proc/cmdline | grep -o "\bdom0_mem=[^,]*,max:[^ ]*" | cut -d : -f 2)
+dom0_cgroup_cpus_limit="0-$(cat /proc/cmdline | grep -o '\bdom0_max_vcpus=[^ ]*' | cut -d = -f 2)"
 
-#Converts K, M, G values to Bytes
-function get_bytes {
-        if [ "${1: -1}" == "K" ]; then
-                echo $((${1%?} * 1024 ))
-        elif [ "${1: -1}" == "M" ]; then
-                echo $((${1%?} * 1024*1024 ))
-        elif [ "${1: -1}" == "G" ]; then
-                echo $((${1%?} * 1024*1024*1024 ))
-        else
-                echo $1
-        fi
-}
+eve_cgroup_memory_soft_limit=$(cat /proc/cmdline | grep -o '\beve_mem=[^, ]*' | cut -d = -f 2)
+eve_cgroup_memory_limit=$(cat /proc/cmdline | grep -o "\beve_mem=[^,]*,max:[^ ]*" | cut -d : -f 2)
+eve_cgroup_cpus_limit="0-$(cat /proc/cmdline | grep -o '\beve_max_vcpus=[^ ]*' | cut -d = -f 2)"
 
-eve_cgroup_memory_limit=$(get_bytes $(cat /proc/cmdline | grep -o '\bdom0_mem=[^, ]*' | cut -d = -f 2))
-eve_cgroup_memory_soft_limit=$(get_bytes $(cat /proc/cmdline | grep -o "\bdom0_mem=[^,]*,max:[^ ]*" | cut -d : -f 2))
-eve_cgroup_cpus_limit="0-$(cat /proc/cmdline | grep -o '\bdom0_max_vcpus=[^ ]*' | cut -d = -f 2)"
+ctrd_cgroup_memory_soft_limit=$(cat /proc/cmdline | grep -o '\bctrd_mem=[^, ]*' | cut -d = -f 2)
+ctrd_cgroup_memory_limit=$(cat /proc/cmdline | grep -o "\bctrd_mem=[^,]*,max:[^ ]*" | cut -d : -f 2)
+ctrd_cgroup_cpus_limit="0-$(cat /proc/cmdline | grep -o '\bctrd_max_vcpus=[^ ]*' | cut -d = -f 2)"
 
-if [ -z "${eve_cgroup_memory_limit}" ]; then
-        echo "Setting default value of $default_eve_cgroup_memory_limit for eve_cgroup_memory_limit"
-        eve_cgroup_memory_limit=$default_eve_cgroup_memory_limit
+if [ -z "${dom0_cgroup_memory_soft_limit}" ]; then
+    echo "Setting default value of $default_cgroup_memory_limit for dom0_cgroup_memory_soft_limit"
+    dom0_cgroup_memory_soft_limit=$default_cgroup_memory_limit
+fi
+
+if [ -z "${dom0_cgroup_memory_limit}" ]; then
+    echo "Setting value of $dom0_cgroup_memory_soft_limit for dom0_cgroup_memory_limit"
+    dom0_cgroup_memory_limit=$dom0_cgroup_memory_soft_limit
+fi
+
+if [ "$dom0_cgroup_cpus_limit" == "0-" ]; then
+    echo "Setting default value of $default_cgroup_cpus_limit for dom0_cgroup_cpus_limit"
+    dom0_cgroup_cpus_limit=$default_cgroup_cpus_limit
 fi
 
 if [ -z "${eve_cgroup_memory_soft_limit}" ]; then
-        echo "Setting value of $eve_cgroup_memory_limit for eve_cgroup_memory_soft_limit"
-        eve_cgroup_memory_soft_limit=$eve_cgroup_memory_limit
+    echo "Setting default value of $default_cgroup_memory_limit for eve_cgroup_memory_soft_limit"
+    eve_cgroup_memory_soft_limit=$default_cgroup_memory_limit
 fi
 
-if [ $eve_cgroup_cpus_limit == "0-" ]; then
-        echo "Setting default value of $default_eve_cgroup_cpus_limit for eve_cgroup_memory_limit"
-        eve_cgroup_cpus_limit=$default_eve_cgroup_cpus_limit
+if [ -z "${eve_cgroup_memory_limit}" ]; then
+    echo "Setting value of $eve_cgroup_memory_soft_limit for eve_cgroup_memory_limit"
+    eve_cgroup_memory_limit=$eve_cgroup_memory_soft_limit
 fi
 
-/bin/echo $eve_cgroup_memory_limit > /sys/fs/cgroup/memory/eve/memory.limit_in_bytes
+if [ "$eve_cgroup_cpus_limit" == "0-" ]; then
+    echo "Setting default value of $default_cgroup_cpus_limit for eve_cgroup_cpus_limit"
+    eve_cgroup_cpus_limit=$default_cgroup_cpus_limit
+fi
 
-/bin/echo $eve_cgroup_memory_soft_limit > /sys/fs/cgroup/memory/eve/memory.soft_limit_in_bytes
+if [ -z "${ctrd_cgroup_memory_soft_limit}" ]; then
+    echo "Setting default value of $default_cgroup_memory_limit for ctrd_cgroup_memory_soft_limit"
+    ctrd_cgroup_memory_soft_limit=$default_cgroup_memory_limit
+fi
 
-/bin/echo $eve_cgroup_cpus_limit > /sys/fs/cgroup/cpuset/eve/cpuset.cpus
+if [ -z "${ctrd_cgroup_memory_limit}" ]; then
+    echo "Setting value of $ctrd_cgroup_memory_soft_limit for ctrd_cgroup_memory_limit"
+    ctrd_cgroup_memory_limit=$ctrd_cgroup_memory_soft_limit
+fi
 
+if [ "$ctrd_cgroup_cpus_limit" == "0-" ]; then
+    echo "Setting default value of $default_cgroup_cpus_limit for ctrd_cgroup_cpus_limit"
+    ctrd_cgroup_cpus_limit=$default_cgroup_cpus_limit
+fi
 
+CGROUPS="cpuset cpu cpuacct blkio memory devices freezer net_cls perf_event net_prio hugetlb pids systemd "
+EVESRVICES="rsyslogd ntpd sshd wwan wlan lisp guacd pillar vtpm watchdog xen-tools "
+
+#Creating eve cgroup which will be parent/dom0 cgroup
+for cg in $CGROUPS; do
+    mkdir -p /sys/fs/cgroup/"${cg}"/eve
+done
+
+#Creating cgroup for individual eve services
+for srv in $EVESRVICES; do
+    for cg in $CGROUPS; do
+        mkdir -p /sys/fs/cgroup/"${cg}"/eve/services/"${srv}"
+    done
+done
+
+#Creating cgroup for containerd
+mkdir -p /sys/fs/cgroup/memory/eve/containerd
+
+#Creating cgroup for memlogd
+for cg in $CGROUPS; do
+    mkdir -p /sys/fs/cgroup/"${cg}"/eve/memlogd
+done
+
+/bin/echo $dom0_cgroup_memory_limit > /sys/fs/cgroup/memory/eve/memory.limit_in_bytes
+/bin/echo $dom0_cgroup_memory_soft_limit > /sys/fs/cgroup/memory/eve/memory.soft_limit_in_bytes
+/bin/echo $dom0_cgroup_cpus_limit > /sys/fs/cgroup/cpuset/eve/cpuset.cpus
+
+/bin/echo $ctrd_cgroup_memory_limit > /sys/fs/cgroup/memory/eve/containerd/memory.limit_in_bytes
+/bin/echo $ctrd_cgroup_memory_soft_limit > /sys/fs/cgroup/memory/eve/containerd/memory.soft_limit_in_bytes
+
+/bin/echo $eve_cgroup_memory_limit > /sys/fs/cgroup/memory/eve/services/memory.limit_in_bytes
+/bin/echo $eve_cgroup_memory_soft_limit > /sys/fs/cgroup/memory/eve/services/memory.soft_limit_in_bytes
+/bin/echo $eve_cgroup_cpus_limit > /sys/fs/cgroup/cpuset/eve/services/cpuset.cpus
+
+for srv in $EVESRVICES; do
+    /bin/echo $eve_cgroup_memory_limit > /sys/fs/cgroup/memory/eve/services/"${srv}"/memory.limit_in_bytes
+    /bin/echo $eve_cgroup_memory_soft_limit > /sys/fs/cgroup/memory/eve/services/"${srv}"/memory.soft_limit_in_bytes
+    /bin/echo $eve_cgroup_cpus_limit > /sys/fs/cgroup/cpuset/eve/services/"${srv}"/cpuset.cpus
+done

--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -38,6 +38,10 @@
 #  hv_platform_tweaks   any kind of platform specific (hardware/etc.) hypervisor settings
 #  hv_dom0_mem_settings Dom0 RAM settings (size, etc.)
 #  hv_dom0_cpu_settings Dom0 CPU settings (how many cores are available, etc.)
+#  hv_eve_mem_settings  EVE services RAM settings (Should be <= hv_dom0_mem_settings)
+#  hv_eve_cpu_settings  EVE services CPU settings (Should be <= hv_dom0_cpu_settings)
+#  hv_ctrd_mem_settings Containerd RAM settings (Should be <= hv_dom0_mem_settings)
+#  hv_ctrd_cpu_settings Containerd CPU settings (Should be <= hv_dom0_cpu_settings)
 #  hv_extra_args        any additional hypervisor settings
 #
 #  dom0_console         settings for having a viable Dom0 console output
@@ -137,6 +141,10 @@ function set_rootfs_title {
 function set_generic {
    set_global hv_dom0_mem_settings "dom0_mem=1024M,max:1024M"
    set_global hv_dom0_cpu_settings "dom0_max_vcpus=1 dom0_vcpus_pin"
+   set_global hv_eve_mem_settings "eve_mem=650M,max:650M"
+   set_global hv_eve_cpu_settings "eve_max_vcpus=1"
+   set_global hv_ctrd_mem_settings "ctrd_mem=300M,max:300M"
+   set_global hv_ctrd_cpu_settings "ctrd_max_vcpus=1"
    set_global hv_platform_tweaks "smt=false"
 
    set_global dom0 /boot/kernel
@@ -235,7 +243,7 @@ do_if_args source $config_grub_cfg
 
 menuentry "Boot ${rootfs_title}${rootfs_title_suffix}" {
      $load_hv_cmd $hv $hv_console $hv_platform_tweaks $hv_dom0_mem_settings $hv_dom0_cpu_settings $hv_extra_args
-     $load_dom0_cmd $dom0 $dom0_console $dom0_rootfs $hv_dom0_mem_settings $hv_dom0_cpu_settings $dom0_platform_tweaks $dom0_cmdline $dom0_extra_args
+     $load_dom0_cmd $dom0 $dom0_console $dom0_rootfs $hv_dom0_mem_settings $hv_dom0_cpu_settings $hv_eve_mem_settings $hv_eve_cpu_settings $hv_ctrd_mem_settings $hv_ctrd_cpu_settings $dom0_platform_tweaks $dom0_cmdline $dom0_extra_args
      do_if_args $load_devicetree_cmd $devicetree
      do_if_args $load_initrd_cmd $initrd
 }
@@ -268,7 +276,7 @@ submenu 'Set Boot Options' {
 
    menuentry 'show boot options' {
       set_global zboot1 "$load_hv_cmd $hv $hv_console $hv_platform_tweaks $hv_dom0_mem_settings $hv_dom0_cpu_settings $hv_extra_args"
-      set_global zboot2 "$load_dom0_cmd $dom0 $dom0_console $dom0_rootfs $hv_dom0_mem_settings $hv_dom0_cpu_settings $dom0_platform_tweaks $dom0_cmdline $dom0_extra_args"
+      set_global zboot2 "$load_dom0_cmd $dom0 $dom0_console $dom0_rootfs $hv_dom0_mem_settings $hv_dom0_cpu_settings $hv_eve_mem_settings $hv_eve_cpu_settings $hv_ctrd_mem_settings $hv_ctrd_cpu_settings $dom0_platform_tweaks $dom0_cmdline $dom0_extra_args"
       set_global zboot3 "do_if_args $load_devicetree_cmd $devicetree"
       set_global zboot4 "do_if_args $load_initrd_cmd $initrd"
    }


### PR DESCRIPTION
Added a cgroup for containerd and memlogd

Restructured cgroup hierarchy as below whose limits can be changed using respective variables in grub.cfg.

eve (parent, can be modified using `hv_dom0_mem_settings` and `hv_dom0_cpu_settings`)
- services (cgroup parent for all eve services, can be modified using `hv_eve_mem_settings` and `hv_eve_cpu_settings`)
-- rsyslogd 
-- ntpd 
-- sshd 
-- wwan 
-- wlan 
-- lisp 
-- guacd 
-- pillar 
-- vtpm 
-- watchdog 
-- xen-tools
- containerd (can be modified using `hv_ctrd_mem_settings` and `hv_ctrd_cpu_settings`)
- memlogd

Added a config var in grub to manipulate watchdog timer. 

NOTE: For testing purpose removed LISP service.

Signed-off-by: adarsh-zededa <adarsh@zededa.com>