### PR TITLE
Adding support for qcow2 volumes

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1166,7 +1166,7 @@ func doActivate(ctx *domainContext, config types.DomainConfig,
 	}
 	defer file.Close()
 
-	if err := hyper.Task(status).Setup(status, config, ctx.assignableAdapters, file); err != nil {
+	if err := hyper.Task(status).Setup(*status, config, ctx.assignableAdapters, file); err != nil {
 		log.Errorf("Failed to create DomainStatus from %v: %s",
 			config, err)
 		status.SetErrorNow(err.Error())

--- a/pkg/pillar/containerd/oci.go
+++ b/pkg/pillar/containerd/oci.go
@@ -227,7 +227,7 @@ func (s *ociSpec) updateFromImageConfig(config v1.ImageConfig) error {
 func (s *ociSpec) UpdateMounts(disks []types.DiskConfig) {
 	for i := range disks {
 		// Skipping root container disk
-		if i == 0 {
+		if i == 0 || isFile(disks[i].FileLocation) {
 			continue
 		}
 		mount := specs.Mount{}

--- a/pkg/pillar/containerd/utilAPIs.go
+++ b/pkg/pillar/containerd/utilAPIs.go
@@ -93,3 +93,13 @@ func UnpackClientImage(clientImage containerd.Image) error {
 	}
 	return nil
 }
+
+//isFile check if the given path is pointing to a file.
+func isFile(path string) bool {
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		log.Errorf("isFile(%s): %s", path, err.Error())
+		return false
+	}
+	return !fileInfo.IsDir()
+}

--- a/pkg/pillar/hypervisor/containerd.go
+++ b/pkg/pillar/hypervisor/containerd.go
@@ -46,7 +46,7 @@ func (ctx ctrdContext) Task(status *types.DomainStatus) types.Task {
 	return ctx
 }
 
-func (ctx ctrdContext) Setup(status *types.DomainStatus, config types.DomainConfig, aa *types.AssignableAdapters, file *os.File) error {
+func (ctx ctrdContext) Setup(status types.DomainStatus, config types.DomainConfig, aa *types.AssignableAdapters, file *os.File) error {
 	diskStatusList := status.DiskStatusList
 	domainName := status.DomainName
 	spec, err := containerd.NewOciSpec(domainName)

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -361,7 +361,7 @@ func (ctx kvmContext) Task(status *types.DomainStatus) types.Task {
 	}
 }
 
-func (ctx kvmContext) Setup(status *types.DomainStatus, config types.DomainConfig, aa *types.AssignableAdapters, file *os.File) error {
+func (ctx kvmContext) Setup(status types.DomainStatus, config types.DomainConfig, aa *types.AssignableAdapters, file *os.File) error {
 
 	diskStatusList := status.DiskStatusList
 	domainName := status.DomainName

--- a/pkg/pillar/hypervisor/null.go
+++ b/pkg/pillar/hypervisor/null.go
@@ -44,7 +44,7 @@ func (ctx nullContext) Task(status *types.DomainStatus) types.Task {
 	return ctx
 }
 
-func (ctx nullContext) Setup(*types.DomainStatus, types.DomainConfig, *types.AssignableAdapters, *os.File) error {
+func (ctx nullContext) Setup(types.DomainStatus, types.DomainConfig, *types.AssignableAdapters, *os.File) error {
 	return nil
 }
 

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -72,7 +72,7 @@ func (ctx xenContext) Task(status *types.DomainStatus) types.Task {
 	}
 }
 
-func (ctx xenContext) Setup(status *types.DomainStatus, config types.DomainConfig, aa *types.AssignableAdapters, file *os.File) error {
+func (ctx xenContext) Setup(status types.DomainStatus, config types.DomainConfig, aa *types.AssignableAdapters, file *os.File) error {
 
 	diskStatusList := status.DiskStatusList
 	domainName := status.DomainName

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -153,7 +153,7 @@ const (
 
 // Task represents any runnable entity on EVE
 type Task interface {
-	Setup(*DomainStatus, DomainConfig, *AssignableAdapters, *os.File) error
+	Setup(DomainStatus, DomainConfig, *AssignableAdapters, *os.File) error
 	Create(string, string, *DomainConfig) (int, error)
 	Start(string, int) error
 	Stop(string, int, bool) error


### PR DESCRIPTION
Bug: Qcow2 volume mounts were failing
Reason: Missed handling qcow2 type volumes while mounting
Fix: Handling qcow2 type volumes.

Also addressed this comment https://github.com/lf-edge/eve/pull/1270#discussion_r465324098 in this PR.

Signed-off-by: adarsh-zededa <adarsh@zededa.com>