### PR TITLE
Enabling USB ACM support

### DIFF
--- a/pkg/kernel/kernel_config-4.19.x-x86_64
+++ b/pkg/kernel/kernel_config-4.19.x-x86_64
@@ -3365,7 +3365,7 @@ CONFIG_USB_UHCI_HCD=y
 #
 # USB Device Class drivers
 #
-# CONFIG_USB_ACM is not set
+CONFIG_USB_ACM=m
 # CONFIG_USB_PRINTER is not set
 CONFIG_USB_WDM=m
 # CONFIG_USB_TMC is not set

--- a/pkg/new-kernel/kernel_config-5.4.x-x86_64
+++ b/pkg/new-kernel/kernel_config-5.4.x-x86_64
@@ -3567,7 +3567,7 @@ CONFIG_USB_UHCI_HCD=y
 #
 # USB Device Class drivers
 #
-# CONFIG_USB_ACM is not set
+CONFIG_USB_ACM=m
 # CONFIG_USB_PRINTER is not set
 CONFIG_USB_WDM=m
 # CONFIG_USB_TMC is not set


### PR DESCRIPTION
This is needed to support intel hardware that is cosplaying ARM (there's not too many of those out there, but still). More [gory] details here https://rfc1149.net/blog/2013/03/05/what-is-the-difference-between-devttyusbx-and-devttyacmx/