### PR TITLE
remove sync flag from watchdog

### DIFF
--- a/pkg/watchdog/init.sh
+++ b/pkg/watchdog/init.sh
@@ -24,7 +24,7 @@ reload_watchdog() {
     cp -f "$1" /etc/watchdog.conf
 
     # And finally re-start
-    /usr/sbin/watchdog -F -s &
+    /usr/sbin/watchdog -F &
 }
 
 log() {


### PR DESCRIPTION
If we use this flag in the watchdog`s command, watchdog starts to sync filesystems before sending notifications to hardware one. On RPi4, with the little timeout and slow SD, we faced with the problem with reboots.


Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>