### PR TITLE
Cleaning up containerd location

### DIFF
--- a/pkg/pillar/rootfs/var/persist
+++ b/pkg/pillar/rootfs/var/persist
@@ -1,0 +1,1 @@
+/persist

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -66,9 +66,6 @@ fi
 mkdir -p $TMPDIR
 export TMPDIR
 
-mkdir -p $PERSISTDIR/containerd
-ln -s $PERSISTDIR/containerd /var/lib/containerd
-
 if ! mount -o remount,flush,dirsync,noatime $CONFIGDIR; then
     echo "$(date -Ins -u) Remount $CONFIGDIR failed"
 fi


### PR DESCRIPTION
This is a follow up to statically changing containerd root in the /etc/containerd -- at some point we should really think about reconciling `/var/{persist,config} vs /{persist,config}` as seen on the host vs. inside of EVE service tasks