### PR TITLE
console tty0 for kvm container

### DIFF
--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -433,6 +433,9 @@ func (ctx kvmContext) CreateDomConfig(domainName string, config types.DomainConf
 		tmplCtx.Kernel = "/hostfs/boot/kernel"
 		tmplCtx.Ramdisk = "/usr/lib/xen/boot/runx-initrd"
 		tmplCtx.ExtraArgs = config.ExtraArgs + " console=hvc0 root=9p-kvm dhcp=1"
+		if config.EnableVnc {
+			tmplCtx.ExtraArgs = config.ExtraArgs + " console=tty0"
+		}
 	}
 
 	// render global device model settings


### PR DESCRIPTION
Moving from hvc0 to tty0 allows me to see the output in the VNC console for "containers" running on top of KVM HV.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>