### PR TITLE
kvm container volumes

### DIFF
--- a/pkg/xen-tools/initrd/mount_disk.sh
+++ b/pkg/xen-tools/initrd/mount_disk.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 mountPointLineNo=1
-ls /sys/block/ | grep xvd | while read -r disk ; do
+ls /sys/block/ | grep vd | while read -r disk ; do
   echo "Processing $disk"
   targetDir=$(sed "${mountPointLineNo}q;d" /mnt/mountPoints)
   if [ -z "$targetDir" ]


### PR DESCRIPTION
For KVM HV "containers" we need vd* pattern for grep of block devices, so lets move to it.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>