### PR TITLE
fix location of image inside tar for gcp format

### DIFF
--- a/pkg/eve/runme.sh
+++ b/pkg/eve/runme.sh
@@ -21,7 +21,8 @@ dump() {
             INAME="$INAME.qcow2"
             ONAME="$ONAME.qcow2"
             ;;
-       gcp) tar --mode=644 --owner=root --group=root -S -h -czvf "$INAME.img.tar.gz" "$INAME"
+       gcp) mv "$INAME" disk.raw
+            tar --mode=644 --owner=root --group=root -S -h -czvf "$INAME.img.tar.gz" "disk.raw"
             INAME="$INAME.img.tar.gz"
             ONAME="$ONAME.img.tar.gz"
             ;;


### PR DESCRIPTION
GCP expects `disk.raw` inside tar.

```
ERROR: (gcloud.compute.images.create) Could not fetch resource:
 - The file inside the tar archive was named ''tmp/output.img''. It should be named ''disk.raw''.
```

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>