### PR TITLE
Redirect traffic between domU behind the same network instance through dom0 routing.

### DIFF
--- a/pkg/pillar/cmd/zedrouter/dnsmasq.go
+++ b/pkg/pillar/cmd/zedrouter/dnsmasq.go
@@ -203,7 +203,7 @@ func createDnsmasqConfiglet(
 		}
 	} else if netconf.Subnet.IP != nil {
 		file.WriteString(fmt.Sprintf("dhcp-option=option:netmask,%s\n",
-			ipv4Netmask))
+			"255.255.255.255"))
 	}
 	if advertizeRouter {
 		// IPv6 XXX needs to be handled in radvd

--- a/pkg/pillar/cmd/zedrouter/dnsmasq.go
+++ b/pkg/pillar/cmd/zedrouter/dnsmasq.go
@@ -202,6 +202,8 @@ func createDnsmasqConfiglet(
 				broadcast))
 		}
 	} else if netconf.Subnet.IP != nil {
+		// Network prefix "255.255.255.255" will force packets to go through
+		// dom0 virtual router that makes the packets pass through ACLs and flow log.
 		file.WriteString(fmt.Sprintf("dhcp-option=option:netmask,%s\n",
 			"255.255.255.255"))
 	}


### PR DESCRIPTION
In a setup that has a edge-node running multiple apps attached to the same local network instance, drop rules between app instance behind the same network instance do not work as expected. Packets that are supposed to get dropped are marked with -1 but still allowed to pass through to their destination. This is because packets in this case are bridged and do not enter the virtual router in dom0. With flow logging, packet drops happen by re-routing packets marked with -1 to a special dummy interfaces. With this patch, we stop advertising link local route from dnsmasq. This is done by sending network prefix as 255.255.255.255 inside DHCP response. This forces the local network destined packets to dom0 virtual router. 


1) I can see traffic from domU reaching internet as expected.
2) I can traffic between domUs that is supposed to get dropped gets dropped. Flow marking works as expected.

Also disabled icmp redirects on bridge interface.

Signed-off-by: Gopi krishna Kodali <gkodali@zededa.com>