### PR TITLE
Send TPM eventlog entries to Controller

### DIFF
--- a/pkg/pillar/cmd/zedagent/attesttask.go
+++ b/pkg/pillar/cmd/zedagent/attesttask.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	eventlog "github.com/cshari-zededa/eve-tpm2-tools/eventlog"
 	"github.com/golang/protobuf/proto"
 	"github.com/lf-edge/eve/api/go/attest"
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
@@ -42,11 +43,17 @@ type attestContext struct {
 	InternalQuote *types.AttestQuote
 	//Iteration keeps track of retry count
 	Iteration int
+	//EventLogEntries are the TPM EventLog entries
+	EventLogEntries []eventlog.Event
+	//EventLogParseErr stores any error that happened during EventLog parsing
+	EventLogParseErr error
 }
 
 const (
 	watchdogInterval  = 15
 	retryTimeInterval = 15
+	//EventLogPath is the TPM measurement log aka TPM event log
+	EventLogPath = "/sys/kernel/security/tpm0/binary_bios_measurements"
 )
 
 //One shot send, if fails, return an error to the state machine to retry later
@@ -173,6 +180,13 @@ func (server *VerifierImpl) SendAttestQuote(ctx *zattest.Context) error {
 		return zattest.ErrControllerReqFailed
 	}
 
+	if attestCtx.EventLogParseErr == nil {
+		//On some platforms, either the kernel does not export TPM Eventlog
+		//or the TPM does not have SHA256 bank enabled for PCRs. We populate
+		//eventlog if we are able to parse eventlog successfully
+		encodeEventLog(attestCtx, quote)
+	}
+
 	attestReq.Quote = quote
 
 	//Increment Iteration for interface rotation
@@ -260,6 +274,40 @@ func (wd *WatchdogImpl) PunchWatchdog(ctx *zattest.Context) error {
 	return nil
 }
 
+//parseTpmEventLog parses TPM Event Log and stores it given attestContext
+//any error during parsing is stored in EventLogParseErr
+func parseTpmEventLog(attestCtx *attestContext) {
+	events, err := eventlog.ParseEvents(EventLogPath)
+	attestCtx.EventLogEntries = events
+	attestCtx.EventLogParseErr = err
+	if err != nil {
+		log.Errorf("[ATTEST] Eventlog parsing error %v", err)
+	}
+}
+
+func encodeEventLog(attestCtx *attestContext, quoteMsg *attest.ZAttestQuote) error {
+	quoteMsg.EventLog = make([]*attest.TpmEventLogEntry, 0)
+	for _, event := range attestCtx.EventLogEntries {
+		tpmEventLog := new(attest.TpmEventLogEntry)
+		tpmEventLog.Index = uint32(event.Sequence)
+		tpmEventLog.PcrIndex = uint32(event.Index)
+		tpmEventLog.Digest = new(attest.TpmEventDigest)
+		tpmEventLog.Digest.HashAlgo = attest.TpmHashAlgo_TPM_HASH_ALGO_SHA256
+		tpmEventLog.Digest.Digest = event.Sha256Digest()
+		tpmEventLog.EventDataBinary = event.Data
+
+		//Populate EventDataString for PCRs 8 and 9
+		//they are human readable
+		if event.Index == 8 || event.Index == 9 {
+			tpmEventLog.EventDataString = string(event.Data)
+		} else {
+			tpmEventLog.EventDataString = "Not Applicable"
+		}
+		quoteMsg.EventLog = append(quoteMsg.EventLog, tpmEventLog)
+	}
+	return nil
+}
+
 // initialize attest pubsub trigger handlers and channels
 func attestModuleInitialize(ctx *zedagentContext, ps *pubsub.PubSub) error {
 	zattest.RegisterExternalIntf(&TpmAgentImpl{}, &VerifierImpl{}, &WatchdogImpl{})
@@ -283,6 +331,7 @@ func attestModuleInitialize(ctx *zedagentContext, ps *pubsub.PubSub) error {
 		log.Fatal(err)
 	}
 	ctx.attestCtx.pubAttestNonce = pubAttestNonce
+	parseTpmEventLog(ctx.attestCtx)
 	return nil
 }
 

--- a/pkg/pillar/go.mod
+++ b/pkg/pillar/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/containerd/fifo v0.0.0-20191213151349-ff969a566b00 // indirect
 	github.com/containerd/ttrpc v0.0.0-20200121165050-0be804eadb15 // indirect
 	github.com/containerd/typeurl v0.0.0-20200205145503-b45ef1f1f737
+	github.com/cshari-zededa/eve-tpm2-tools v0.0.4
 	github.com/digitalocean/go-libvirt v0.0.0-20190715144809-7b622097a793 // indirect
 	github.com/digitalocean/go-qemu v0.0.0-20181112162955-dd7bb9c771b8
 	github.com/docker/docker v1.4.2-0.20190924003213-a8608b5b67c7

--- a/pkg/pillar/go.sum
+++ b/pkg/pillar/go.sum
@@ -118,6 +118,14 @@ github.com/cpuguy83/go-md2man v1.0.8/go.mod h1:N6JayAiVKtlHSnuTCeuLSQVs75hb8q+dY
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
+github.com/cshari-zededa/eve-tpm2-tools v0.0.1 h1:OLcWP6R6+G89WpWyGqPfvEVUH1hOphhY8CN45jAKkFA=
+github.com/cshari-zededa/eve-tpm2-tools v0.0.1/go.mod h1:eW3tBDdylgHCCLp/mPwW2woLSfPv8GwLuLEDf87HZi4=
+github.com/cshari-zededa/eve-tpm2-tools v0.0.2 h1:YkgqKxdArjymX7w9Zahf016uuCgIC7mkCdkVHjaRjq8=
+github.com/cshari-zededa/eve-tpm2-tools v0.0.2/go.mod h1:eW3tBDdylgHCCLp/mPwW2woLSfPv8GwLuLEDf87HZi4=
+github.com/cshari-zededa/eve-tpm2-tools v0.0.3 h1:6PMLmQ9KoVnsdcSJ/fC99A8N6wMsdz3XuekMaeahjZM=
+github.com/cshari-zededa/eve-tpm2-tools v0.0.3/go.mod h1:eW3tBDdylgHCCLp/mPwW2woLSfPv8GwLuLEDf87HZi4=
+github.com/cshari-zededa/eve-tpm2-tools v0.0.4 h1:Q2E2urrobW74rf/PgD0Jwj66KGZwupSTXGYmL27CCsI=
+github.com/cshari-zededa/eve-tpm2-tools v0.0.4/go.mod h1:eW3tBDdylgHCCLp/mPwW2woLSfPv8GwLuLEDf87HZi4=
 github.com/cshari-zededa/go-tpm v0.0.0-20200113112746-a8476c2d6eb3 h1:CGFBX/G+8V5NkeIK2xpEMO9A2Kme/dtAMmvqX+r2cMM=
 github.com/cshari-zededa/go-tpm v0.0.0-20200113112746-a8476c2d6eb3/go.mod h1:OGEdc1XfzTyNEQyahgeXVq+E0lMq3Vu/Y3bT9EfpRnE=
 github.com/cshari-zededa/go-tpm v0.0.0-20200701063353-bf25d5482637 h1:9MMe8VOpgRIZZMpjAQGG50XVlhnQe6RVABDt3o207Qs=

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -19,6 +19,7 @@ AGENTS0="logmanager ledmanager nim nodeagent domainmgr"
 AGENTS1="zedmanager zedrouter downloader verifier zedagent baseosmgr wstunnelclient volumemgr"
 AGENTS="$AGENTS0 $AGENTS1"
 TPM_DEVICE_PATH="/dev/tpmrm0"
+SECURITYFSPATH=/sys/kernel/security
 PATH=$BINDIR:$PATH
 
 echo "$(date -Ins -u) Starting device-steps.sh"
@@ -68,6 +69,10 @@ export TMPDIR
 
 if ! mount -o remount,flush,dirsync,noatime $CONFIGDIR; then
     echo "$(date -Ins -u) Remount $CONFIGDIR failed"
+fi
+
+if ! mount -t securityfs securityfs "$SECURITYFSPATH"; then
+    echo "$(date -Ins -u) mounting securityfs failed"
 fi
 
 DIRS="$CONFIGDIR $ZTMPDIR $CONFIGDIR/DevicePortConfig $PERSIST_CERTS $PERSIST_AGENT_DEBUG /persist/status/zedclient/OnboardingStatus"

--- a/pkg/pillar/vendor/github.com/cshari-zededa/eve-tpm2-tools/LICENSE
+++ b/pkg/pillar/vendor/github.com/cshari-zededa/eve-tpm2-tools/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkg/pillar/vendor/github.com/cshari-zededa/eve-tpm2-tools/eventlog/README.md
+++ b/pkg/pillar/vendor/github.com/cshari-zededa/eve-tpm2-tools/eventlog/README.md
@@ -1,0 +1,1 @@
+to run the tool, do `go build ./...` and the binary will be created in the same dir

--- a/pkg/pillar/vendor/github.com/cshari-zededa/eve-tpm2-tools/eventlog/efigptdata.go
+++ b/pkg/pillar/vendor/github.com/cshari-zededa/eve-tpm2-tools/eventlog/efigptdata.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package eventlog
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"unicode/utf16"
+)
+
+type efiGPTPartitionEntry struct {
+	tGuid Guid
+	uGuid Guid
+	sLBA  uint64
+	eLBA  uint64
+	attr  uint64
+	name  string
+}
+
+func (p *efiGPTPartitionEntry) String() string {
+	return fmt.Sprintf("PartitionTypeGUID: %s, UniquePartitionGUID: %s, Name: \"%s\", Attributes: 0x%X",
+		&p.tGuid, &p.uGuid, p.name, p.attr)
+}
+
+type efiGPTEventData struct {
+	data       []byte
+	diskGUID   Guid
+	partitions []efiGPTPartitionEntry
+}
+
+func (e *efiGPTEventData) String() string {
+	var builder bytes.Buffer
+	fmt.Fprintf(&builder, "UEFI_GPT_DATA{ DiskGUID: %s, Partitions: [", &e.diskGUID)
+	for i, part := range e.partitions {
+		if i > 0 {
+			fmt.Fprintf(&builder, ", ")
+		}
+		fmt.Fprintf(&builder, "{ %s }", &part)
+	}
+	fmt.Fprintf(&builder, "] }")
+	return builder.String()
+}
+
+func (e *efiGPTEventData) ImgGuid(Img string) Guid {
+	for _, part := range e.partitions {
+		if part.name == Img {
+			return part.uGuid
+		}
+	}
+	return Guid{}
+}
+
+func (e *efiGPTEventData) Bytes() []byte {
+	return e.data
+}
+
+const (
+	diskGuidOffset  = 56
+	partEntryOffset = 12 //relative to end of DiskGUID
+)
+
+func parseEventDataEFIGPT(data []byte) error {
+	if gptData, err := parseGPTData(data); err == nil {
+		fmt.Printf("%s\n", gptData.String())
+		return nil
+	} else {
+		return err
+	}
+}
+
+func parseGPTData(data []byte) (*efiGPTEventData, error) {
+	stream := bytes.NewReader(data)
+
+	// Skip to DiskGUID
+	if _, err := stream.Seek(diskGuidOffset, io.SeekCurrent); err != nil {
+		return nil, err
+	}
+
+	var diskGUID Guid
+	if err := binary.Read(stream, binary.LittleEndian, &diskGUID); err != nil {
+		return nil, err
+	}
+
+	// Skip to parseEventData
+	if _, err := stream.Seek(partEntryOffset, io.SeekCurrent); err != nil {
+		return nil, err
+	}
+
+	var partEntrySize uint32
+	if err := binary.Read(stream, binary.LittleEndian, &partEntrySize); err != nil {
+		return nil, err
+	}
+
+	if _, err := stream.Seek(4, io.SeekCurrent); err != nil {
+		return nil, err
+	}
+
+	var numberOfParts uint64
+	if err := binary.Read(stream, binary.LittleEndian, &numberOfParts); err != nil {
+		return nil, err
+	}
+
+	eventData := &efiGPTEventData{diskGUID: diskGUID, partitions: make([]efiGPTPartitionEntry, numberOfParts)}
+
+	for i := uint64(0); i < numberOfParts; i++ {
+		entryData := make([]byte, partEntrySize)
+		if _, err := io.ReadFull(stream, entryData); err != nil {
+			return nil, err
+		}
+
+		entryStream := bytes.NewReader(entryData)
+
+		var tGuid Guid
+		if err := binary.Read(entryStream, binary.LittleEndian, &tGuid); err != nil {
+			return nil, err
+		}
+
+		var uGuid Guid
+		if err := binary.Read(entryStream, binary.LittleEndian, &uGuid); err != nil {
+			return nil, err
+		}
+
+		var sLBA uint64
+		if err := binary.Read(entryStream, binary.LittleEndian, &sLBA); err != nil {
+			return nil, err
+		}
+		var eLBA uint64
+		if err := binary.Read(entryStream, binary.LittleEndian, &eLBA); err != nil {
+			return nil, err
+		}
+		var attr uint64
+		if err := binary.Read(entryStream, binary.LittleEndian, &attr); err != nil {
+			return nil, err
+		}
+
+		nameutf := make([]uint16, entryStream.Len()/2)
+		if err := binary.Read(entryStream, binary.LittleEndian, &nameutf); err != nil {
+			return nil, err
+		}
+
+		var name bytes.Buffer
+		for _, r := range utf16.Decode(nameutf) {
+			if r == rune(0) {
+				break
+			}
+			name.WriteRune(r)
+		}
+		eventData.partitions[i] = efiGPTPartitionEntry{tGuid: tGuid,
+			uGuid: uGuid,
+			sLBA:  sLBA,
+			eLBA:  eLBA,
+			attr:  attr,
+			name:  name.String()}
+	}
+
+	return eventData, nil
+}

--- a/pkg/pillar/vendor/github.com/cshari-zededa/eve-tpm2-tools/eventlog/efiimagedata.go
+++ b/pkg/pillar/vendor/github.com/cshari-zededa/eve-tpm2-tools/eventlog/efiimagedata.go
@@ -1,0 +1,352 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package eventlog
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"unicode/utf16"
+)
+
+type EFIDPathNodeType uint8
+
+const (
+	EFIDPathNodeHardware EFIDPathNodeType = 0x01
+	EFIDPathNodeACPI                      = 0x02
+	EFIDPathNodeMsg                       = 0x03
+	EFIDPathNodeMedia                     = 0x04
+	EFIDPathNodeBBS                       = 0x05
+	EFIDPathNodeEoH                       = 0x7f
+)
+
+const (
+	efiHardwareDPathNodePCI = 0x01
+
+	efiACPIDPathNodeNormal = 0x01
+
+	efiMsgDPathNodeLU   = 0x11
+	efiMsgDPathNodeSATA = 0x12
+
+	efiMediaDPathNodeHardDrive      = 0x01
+	efiMediaDPathNodeFilePath       = 0x04
+	efiMediaDPathNodeFvFile         = 0x06
+	efiMediaDPathNodeFv             = 0x07
+	efiMediaDPathNodeRelOffsetRange = 0x08
+)
+
+func firmwareDPathNodeToStringNew(data []byte, t EFIDPathNodeType, subType uint8) (string, error) {
+	stream := bytes.NewReader(data)
+
+	var name Guid
+	if err := binary.Read(stream, binary.LittleEndian, &name); err != nil {
+		return "", err
+	}
+
+	var builder bytes.Buffer
+	switch subType {
+	case efiMediaDPathNodeFvFile:
+		builder.WriteString("\\FvFile")
+	case efiMediaDPathNodeFv:
+		builder.WriteString("\\Fv")
+	default:
+		return "", fmt.Errorf("invalid sub type for firmware device path node: %d", subType)
+	}
+
+	fmt.Fprintf(&builder, "(%s)", &name)
+	return builder.String(), nil
+}
+
+func acpiDPathNodeToString(data []byte, t EFIDPathNodeType, subType uint8) (string, error) {
+	stream := bytes.NewReader(data)
+
+	var hid uint32
+	if err := binary.Read(stream, binary.LittleEndian, &hid); err != nil {
+		return "", err
+	}
+
+	var uid uint32
+	if err := binary.Read(stream, binary.LittleEndian, &uid); err != nil {
+		return "", err
+	}
+
+	if hid&0xffff == 0x41d0 {
+		switch hid >> 16 {
+		case 0x0a03:
+			return fmt.Sprintf("\\PciRoot(0x%x)", uid), nil
+		case 0x0a08:
+			return fmt.Sprintf("\\PcieRoot(0x%x)", uid), nil
+		case 0x0604:
+			return fmt.Sprintf("\\Floppy(0x%x)", uid), nil
+		default:
+			return fmt.Sprintf("\\Acpi(PNP%04x,0x%x)", hid>>16, uid), nil
+		}
+	} else {
+		return fmt.Sprintf("\\Acpi(0x%08x,0x%x)", hid, uid), nil
+	}
+}
+
+func pciDPathNodeToString(data []byte, t EFIDPathNodeType, subType uint8) (string, error) {
+	stream := bytes.NewReader(data)
+
+	var function uint8
+	if err := binary.Read(stream, binary.LittleEndian, &function); err != nil {
+		return "", err
+	}
+
+	var device uint8
+	if err := binary.Read(stream, binary.LittleEndian, &device); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("\\Pci(0x%x,0x%x)", device, function), nil
+}
+
+func luDPathNodeToString(data []byte, t EFIDPathNodeType, subType uint8) (string, error) {
+	stream := bytes.NewReader(data)
+
+	var lun uint8
+	if err := binary.Read(stream, binary.LittleEndian, &lun); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("\\Unit(0x%x)", lun), nil
+}
+
+func hardDriveDPathNodeToString(data []byte, t EFIDPathNodeType, subType uint8) (string, error) {
+	stream := bytes.NewReader(data)
+
+	var partNumber uint32
+	if err := binary.Read(stream, binary.LittleEndian, &partNumber); err != nil {
+		return "", err
+	}
+
+	var partStart uint64
+	if err := binary.Read(stream, binary.LittleEndian, &partStart); err != nil {
+		return "", err
+	}
+
+	var partSize uint64
+	if err := binary.Read(stream, binary.LittleEndian, &partSize); err != nil {
+		return "", err
+	}
+
+	var sig [16]byte
+	if _, err := io.ReadFull(stream, sig[:]); err != nil {
+		return "", err
+	}
+
+	var partFormat uint8
+	if err := binary.Read(stream, binary.LittleEndian, &partFormat); err != nil {
+		return "", err
+	}
+
+	var sigType uint8
+	if err := binary.Read(stream, binary.LittleEndian, &sigType); err != nil {
+		return "", err
+	}
+
+	var builder bytes.Buffer
+
+	switch sigType {
+	case 0x01:
+		fmt.Fprintf(&builder, "\\HD(%d,MBR,0x%08x,", partNumber, binary.LittleEndian.Uint32(sig[:]))
+	case 0x02:
+		r := bytes.NewReader(sig[:])
+		var guid Guid
+		if err := binary.Read(r, binary.LittleEndian, &guid); err != nil {
+			return "", err
+		}
+		fmt.Fprintf(&builder, "\\HD(%d,GPT,%s,", partNumber, &guid)
+	default:
+		fmt.Fprintf(&builder, "\\HD(%d,%d,0,", partNumber, sigType)
+	}
+
+	fmt.Fprintf(&builder, "0x%016x, 0x%016x)", partStart, partSize)
+	return builder.String(), nil
+}
+
+func sataDPathNodeToString(data []byte, t EFIDPathNodeType, subType uint8) (string, error) {
+	stream := bytes.NewReader(data)
+
+	var hbaPortNumber uint16
+	if err := binary.Read(stream, binary.LittleEndian, &hbaPortNumber); err != nil {
+		return "", err
+	}
+
+	var portMultiplierPortNumber uint16
+	if err := binary.Read(stream, binary.LittleEndian, &portMultiplierPortNumber); err != nil {
+		return "", err
+	}
+
+	var lun uint16
+	if err := binary.Read(stream, binary.LittleEndian, &lun); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("\\Sata(0x%x,0x%x,0x%x)", hbaPortNumber, portMultiplierPortNumber, lun), nil
+}
+
+func filePathDPathNodeToString(data []byte, t EFIDPathNodeType, subType uint8) (string, error) {
+	u16 := make([]uint16, len(data)/2)
+	stream := bytes.NewReader(data)
+	binary.Read(stream, binary.LittleEndian, &u16)
+
+	var buf bytes.Buffer
+	for _, r := range utf16.Decode(u16) {
+		buf.WriteRune(r)
+	}
+	return buf.String(), nil
+}
+
+func relOffsetRangePathNodeToString(data []byte, t EFIDPathNodeType, subType uint8) (string, error) {
+	stream := bytes.NewReader(data)
+
+	if _, err := stream.Seek(4, io.SeekCurrent); err != nil {
+		return "", err
+	}
+
+	var start uint64
+	if err := binary.Read(stream, binary.LittleEndian, &start); err != nil {
+		return "", err
+	}
+
+	var end uint64
+	if err := binary.Read(stream, binary.LittleEndian, &end); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("\\Offset(0x%x,0x%x)", start, end), nil
+}
+
+type pathDecoder func([]byte, EFIDPathNodeType, uint8) (string, error)
+type typeSubType struct {
+	t  EFIDPathNodeType
+	st uint8
+}
+
+var pathDecoders = map[typeSubType]pathDecoder{
+	{EFIDPathNodeMedia, efiMediaDPathNodeFvFile}:         firmwareDPathNodeToStringNew,
+	{EFIDPathNodeMedia, efiMediaDPathNodeFv}:             firmwareDPathNodeToStringNew,
+	{EFIDPathNodeMedia, efiMediaDPathNodeHardDrive}:      hardDriveDPathNodeToString,
+	{EFIDPathNodeMedia, efiMediaDPathNodeFilePath}:       filePathDPathNodeToString,
+	{EFIDPathNodeMedia, efiMediaDPathNodeRelOffsetRange}: relOffsetRangePathNodeToString,
+	{EFIDPathNodeACPI, efiACPIDPathNodeNormal}:           acpiDPathNodeToString,
+	{EFIDPathNodeHardware, efiHardwareDPathNodePCI}:      pciDPathNodeToString,
+	{EFIDPathNodeMsg, efiMsgDPathNodeLU}:                 luDPathNodeToString,
+	{EFIDPathNodeMsg, efiMsgDPathNodeSATA}:               sataDPathNodeToString,
+}
+
+func parseDPathNode(stream io.Reader) (string, error) {
+	var t EFIDPathNodeType
+	if err := binary.Read(stream, binary.LittleEndian, &t); err != nil {
+		return "", err
+	}
+
+	if t == EFIDPathNodeEoH {
+		return "", nil
+	}
+
+	var subType uint8
+	if err := binary.Read(stream, binary.LittleEndian, &subType); err != nil {
+		return "", err
+	}
+
+	var length uint16
+	if err := binary.Read(stream, binary.LittleEndian, &length); err != nil {
+		return "", err
+	}
+
+	if length < 4 {
+		return "", fmt.Errorf("unexpected device path node length (got %d, expected >= 4)", length)
+	}
+
+	data := make([]byte, length-4)
+	if _, err := io.ReadFull(stream, data); err != nil {
+		return "", err
+	}
+
+	pathDecoderFn, found := pathDecoders[typeSubType{t: t, st: subType}]
+	if found {
+		return pathDecoderFn(data, t, subType)
+	}
+	return fmt.Sprintf("%x", data), nil
+}
+
+func parseDevicePath(data []byte) (string, error) {
+	stream := bytes.NewReader(data)
+	var builder bytes.Buffer
+
+	for {
+		node, err := parseDPathNode(stream)
+		if err != nil {
+			return "", err
+		}
+		if node == "" {
+			return builder.String(), nil
+		}
+		fmt.Fprintf(&builder, "%s", node)
+	}
+}
+
+type efiImageLoadEventData struct {
+	data             []byte
+	locationInMemory uint64
+	lengthInMemory   uint64
+	linkTimeAddress  uint64
+	path             string
+}
+
+func (e *efiImageLoadEventData) String() string {
+	return fmt.Sprintf("UEFI_IMAGE_LOAD_EVENT{ ImageLocationInMemory: 0x%016x, ImageLengthInMemory: %d, "+
+		"ImageLinkTimeAddress: 0x%016x, DevicePath: %s }", e.locationInMemory, e.lengthInMemory,
+		e.linkTimeAddress, e.path)
+}
+
+func (e *efiImageLoadEventData) Bytes() []byte {
+	return e.data
+}
+
+func parseEventDataEFIImageLoad(data []byte) error {
+	stream := bytes.NewReader(data)
+
+	var locationInMemory uint64
+	if err := binary.Read(stream, binary.LittleEndian, &locationInMemory); err != nil {
+		return err
+	}
+
+	var lengthInMemory uint64
+	if err := binary.Read(stream, binary.LittleEndian, &lengthInMemory); err != nil {
+		return err
+	}
+
+	var linkTimeAddress uint64
+	if err := binary.Read(stream, binary.LittleEndian, &linkTimeAddress); err != nil {
+		return err
+	}
+
+	var devicePathLength uint64
+	if err := binary.Read(stream, binary.LittleEndian, &devicePathLength); err != nil {
+		return err
+	}
+
+	devicePathBuf := make([]byte, devicePathLength)
+
+	if _, err := io.ReadFull(stream, devicePathBuf); err != nil {
+		return err
+	}
+
+	path, err := parseDevicePath(devicePathBuf)
+	if err != nil {
+		return err
+	}
+
+	efiImageData := &efiImageLoadEventData{data: data,
+		locationInMemory: locationInMemory,
+		lengthInMemory:   lengthInMemory,
+		linkTimeAddress:  linkTimeAddress,
+		path:             path}
+	fmt.Printf("%s\n", efiImageData)
+	return nil
+}

--- a/pkg/pillar/vendor/github.com/cshari-zededa/eve-tpm2-tools/eventlog/efivardata.go
+++ b/pkg/pillar/vendor/github.com/cshari-zededa/eve-tpm2-tools/eventlog/efivardata.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package eventlog
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"unicode/utf16"
+	"unicode/utf8"
+)
+
+// EFIVariableEventData corresponds to the EFI_VARIABLE_DATA type.
+type EFIVariableEventData struct {
+	data         []byte
+	VariableName Guid
+	UnicodeName  string
+	VariableData []byte
+}
+
+var (
+	surr1 uint16 = 0xd800
+	surr2 uint16 = 0xdc00
+	surr3 uint16 = 0xe000
+)
+
+//Write
+func utf16ToStr(u []uint16) string {
+	var utf8Str []byte
+	for _, r := range utf16.Decode(u) {
+		utf8Char := make([]byte, utf8.RuneLen(r))
+		utf8.EncodeRune(utf8Char, r)
+		utf8Str = append(utf8Str, utf8Char...)
+	}
+	return string(utf8Str)
+}
+
+func extractUTF16Buffer(stream io.ReadSeeker, nchars uint64) ([]uint16, error) {
+	var out []uint16
+
+	for i := nchars; i > 0; i-- {
+		var c uint16
+		if err := binary.Read(stream, binary.LittleEndian, &c); err != nil {
+			return nil, err
+		}
+		out = append(out, c)
+		if c >= surr1 && c < surr2 {
+			if err := binary.Read(stream, binary.LittleEndian, &c); err != nil {
+				return nil, err
+			}
+			if c < surr2 || c >= surr3 {
+				// Invalid surrogate sequence. utf16.Decode doesn't consume this
+				// byte when inserting the replacement char
+				if _, err := stream.Seek(-1, io.SeekCurrent); err != nil {
+					return nil, err
+				}
+				continue
+			}
+			// Valid surrogate sequence
+			out = append(out, c)
+		}
+	}
+
+	return out, nil
+}
+
+func (e *EFIVariableEventData) String() string {
+	return fmt.Sprintf("UEFI_VARIABLE_DATA{ VariableName: %s, UnicodeName: \"%s\" }",
+		e.VariableName.String(), e.UnicodeName)
+}
+
+func (e *EFIVariableEventData) Bytes() []byte {
+	return e.data
+}
+
+func parseEventDataEFIVariable(data []byte, eventType EventType) error {
+	stream := bytes.NewReader(data)
+
+	var guid Guid
+	if err := binary.Read(stream, binary.LittleEndian, &guid); err != nil {
+		return err
+	}
+
+	var unicodeNameLength uint64
+	if err := binary.Read(stream, binary.LittleEndian, &unicodeNameLength); err != nil {
+		return err
+	}
+
+	var variableDataLength uint64
+	if err := binary.Read(stream, binary.LittleEndian, &variableDataLength); err != nil {
+		return err
+	}
+
+	utf16Name, err := extractUTF16Buffer(stream, unicodeNameLength)
+	if err != nil {
+		return err
+	}
+
+	variableData := make([]byte, variableDataLength)
+	if _, err := io.ReadFull(stream, variableData); err != nil {
+		return err
+	}
+
+	efivar := &EFIVariableEventData{data: data,
+		VariableName: guid,
+		UnicodeName:  utf16ToStr(utf16Name),
+		VariableData: variableData}
+	fmt.Printf("Data: %s\n", efivar.String())
+	return nil
+}

--- a/pkg/pillar/vendor/github.com/cshari-zededa/eve-tpm2-tools/eventlog/eventlog.go
+++ b/pkg/pillar/vendor/github.com/cshari-zededa/eve-tpm2-tools/eventlog/eventlog.go
@@ -1,0 +1,503 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package eventlog
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/sha256"
+	"encoding/binary"
+	//"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"reflect"
+	"strings"
+)
+
+type EventType uint32
+type HashAlg uint8
+type Algorithm uint16
+
+const eventTypeNoAction = 0x03
+
+const (
+	PrebootCert          EventType = 0x00000000
+	PostCode             EventType = 0x00000001
+	unused               EventType = 0x00000002
+	NoAction             EventType = 0x00000003
+	Separator            EventType = 0x00000004
+	Action               EventType = 0x00000005
+	EventTag             EventType = 0x00000006
+	SCRTMContents        EventType = 0x00000007
+	SCRTMVersion         EventType = 0x00000008
+	CpuMicrocode         EventType = 0x00000009
+	PlatformConfigFlags  EventType = 0x0000000A
+	TableOfDevices       EventType = 0x0000000B
+	CompactHash          EventType = 0x0000000C
+	Ipl                  EventType = 0x0000000D
+	IplPartitionData     EventType = 0x0000000E
+	NonhostCode          EventType = 0x0000000F
+	NonhostConfig        EventType = 0x00000010
+	NonhostInfo          EventType = 0x00000011
+	OmitBootDeviceEvents EventType = 0x00000012
+)
+
+const (
+	EFIEventBase               EventType = 0x80000000
+	EFIVariableDriverConfig    EventType = 0x80000001
+	EFIVariableBoot            EventType = 0x80000002
+	EFIBootServicesApplication EventType = 0x80000003
+	EFIBootServicesDriver      EventType = 0x80000004
+	EFIRuntimeServicesDriver   EventType = 0x80000005
+	EFIGPTEvent                EventType = 0x80000006
+	EFIAction                  EventType = 0x80000007
+	EFIPlatformFirmwareBlob    EventType = 0x80000008
+	EFIHandoffTables           EventType = 0x80000009
+	EFIHCRTMEvent              EventType = 0x80000010
+	EFIVariableAuthority       EventType = 0x800000e0
+)
+
+var eventTypeNames = map[EventType]string{
+	PrebootCert:          "Preboot Cert",
+	PostCode:             "POST Code",
+	unused:               "Unused",
+	NoAction:             "No Action",
+	Separator:            "Separator",
+	Action:               "Action",
+	EventTag:             "Event Tag",
+	SCRTMContents:        "S-CRTM Contents",
+	SCRTMVersion:         "S-CRTM Version",
+	CpuMicrocode:         "CPU Microcode",
+	PlatformConfigFlags:  "Platform Config Flags",
+	TableOfDevices:       "Table of Devices",
+	CompactHash:          "Compact Hash",
+	Ipl:                  "IPL",
+	IplPartitionData:     "IPL Partition Data",
+	NonhostCode:          "Non-Host Code",
+	NonhostConfig:        "Non-HostConfig",
+	NonhostInfo:          "Non-Host Info",
+	OmitBootDeviceEvents: "Omit Boot Device Events",
+
+	EFIEventBase:               "EFI Event Base",
+	EFIVariableDriverConfig:    "EFI Variable Driver Config",
+	EFIVariableBoot:            "EFI Variable Boot",
+	EFIBootServicesApplication: "EFI Boot Services Application",
+	EFIBootServicesDriver:      "EFI Boot Services Driver",
+	EFIRuntimeServicesDriver:   "EFI Runtime Services Driver",
+	EFIGPTEvent:                "EFI GPT Event",
+	EFIAction:                  "EFI Action",
+	EFIPlatformFirmwareBlob:    "EFI Platform Firmware Blob",
+	EFIVariableAuthority:       "EFI Variable Authority",
+	EFIHandoffTables:           "EFI Handoff Tables",
+	EFIHCRTMEvent:              "EFI H-CRTM Event",
+}
+
+type Digest struct {
+	Hash crypto.Hash
+	Data []byte
+}
+
+type Event struct {
+	Sequence int
+	Index    int
+	Typ      EventType
+	Data     []byte
+	Digests  []Digest
+}
+
+type rawEventHeader struct {
+	PCRIndex  uint32
+	Type      uint32
+	Digest    [20]byte
+	EventSize uint32
+}
+
+type rawEvent2Header struct {
+	PCRIndex uint32
+	Type     uint32
+}
+
+type SpecIDHdr struct {
+	Sign  [16]byte
+	Pc    uint32
+	VMi   uint8
+	VMa   uint8
+	Erta  uint8
+	Siz   uint8
+	NAlgs uint32
+}
+
+type SpecIDEvent struct {
+	algs []SpecAlgSize
+}
+
+type SpecAlgSize struct {
+	ID   Algorithm
+	Size uint16
+}
+
+const (
+	AlgSHA1   Algorithm = 0x0004
+	AlgSHA256 Algorithm = 0x000B
+)
+
+// Valid hash algorithms.
+var (
+	HashSHA1   = HashAlg(AlgSHA1)
+	HashSHA256 = HashAlg(AlgSHA256)
+)
+
+func (a HashAlg) cryptoHash() crypto.Hash {
+	switch a {
+	case HashSHA1:
+		return crypto.SHA1
+	case HashSHA256:
+		return crypto.SHA256
+	}
+	return 0
+}
+
+func (a HashAlg) goTPMAlg() Algorithm {
+	switch a {
+	case HashSHA1:
+		return AlgSHA1
+	case HashSHA256:
+		return AlgSHA256
+	}
+	return 0
+}
+
+// String returns a human-friendly representation of the hash algorithm.
+func (a HashAlg) String() string {
+	switch a {
+	case HashSHA1:
+		return "SHA1"
+	case HashSHA256:
+		return "SHA256"
+	}
+	return fmt.Sprintf("HashAlg<%d>", int(a))
+}
+
+func parseSpecIDEvent(data []byte) (SpecIDEvent, error) {
+	treader := bytes.NewReader(data)
+	var hdr SpecIDHdr
+	if err := binary.Read(treader, binary.LittleEndian, &hdr); err != nil {
+		return SpecIDEvent{}, err
+	}
+	sa := SpecAlgSize{}
+	var specID SpecIDEvent
+	for i := 0; i < int(hdr.NAlgs); i++ {
+		if err := binary.Read(treader, binary.LittleEndian, &sa); err != nil {
+			return SpecIDEvent{}, err
+		}
+		specID.algs = append(specID.algs, sa)
+	}
+	fmt.Println(specID)
+	return specID, nil
+}
+
+func getSpecIDEvent(r *bytes.Buffer) (Event, error) {
+	var h rawEventHeader
+	var event Event
+	if err := binary.Read(r, binary.LittleEndian, &h); err != nil {
+		return event, err
+	}
+	if h.EventSize == 0 {
+		return event, errors.New("event data size is 0")
+	}
+	if h.EventSize > uint32(r.Len()) {
+		return event, fmt.Errorf("Event Size error")
+	}
+
+	data := make([]byte, int(h.EventSize))
+	if _, err := io.ReadFull(r, data); err != nil {
+		return event, err
+	}
+
+	digests := []Digest{{Hash: crypto.SHA1, Data: h.Digest[:]}}
+
+	return Event{
+		Typ:     EventType(h.Type),
+		Data:    data,
+		Index:   int(h.PCRIndex),
+		Digests: digests,
+	}, nil
+}
+
+func parseEvent(r *bytes.Buffer, specID SpecIDEvent) (Event, error) {
+	var h rawEvent2Header
+
+	var event Event
+
+	if err := binary.Read(r, binary.LittleEndian, &h); err != nil {
+		return event, err
+	}
+	event.Typ = EventType(h.Type)
+	event.Index = int(h.PCRIndex)
+
+	// parse the event digests
+	var numDigests uint32
+	if err := binary.Read(r, binary.LittleEndian, &numDigests); err != nil {
+		return event, err
+	}
+
+	for i := 0; i < int(numDigests); i++ {
+		var algID Algorithm
+		if err := binary.Read(r, binary.LittleEndian, &algID); err != nil {
+			return event, err
+		}
+		var digest Digest
+
+		for _, alg := range specID.algs {
+			if alg.ID != algID {
+				continue
+			}
+			if uint16(r.Len()) < alg.Size {
+				return event, fmt.Errorf("reading digest: %v", io.ErrUnexpectedEOF)
+			}
+			digest.Data = make([]byte, alg.Size)
+			digest.Hash = HashAlg(alg.ID).cryptoHash()
+		}
+		if len(digest.Data) == 0 {
+			return event, fmt.Errorf("unknown algorithm ID %x", algID)
+		}
+		if _, err := io.ReadFull(r, digest.Data); err != nil {
+			return event, err
+		}
+		event.Digests = append(event.Digests, digest)
+	}
+
+	// parse event data
+	var eventSize uint32
+	if err := binary.Read(r, binary.LittleEndian, &eventSize); err != nil {
+		return event, err
+	}
+	if eventSize == 0 {
+		return event, errors.New("event data size is 0")
+	}
+	event.Data = make([]byte, int(eventSize))
+	if _, err := io.ReadFull(r, event.Data); err != nil {
+		return event, err
+	}
+	return event, nil
+}
+
+func isSha256Enabled(specID SpecIDEvent) bool {
+	for _, alg := range specID.algs {
+		if alg.ID == AlgSHA256 {
+			return true
+		}
+	}
+	return false
+}
+
+func (e *Event) Sha256Digest() []byte {
+	for _, digest := range e.Digests {
+		if digest.Hash == crypto.SHA256 {
+			return digest.Data
+		}
+	}
+	return []byte{}
+}
+
+func ParseEvents(eventLogFile string) ([]Event, error) {
+	eventLogBytes, err := ioutil.ReadFile(eventLogFile)
+	if err != nil {
+		return nil, err
+	}
+	r := bytes.NewBuffer(eventLogBytes)
+	event, err := getSpecIDEvent(r)
+	if err != nil {
+		return nil, err
+	}
+	specID, err := parseSpecIDEvent(event.Data)
+	if err != nil {
+		return nil, err
+	}
+	if isSha256Enabled(specID) == false {
+		return nil, fmt.Errorf("SHA256 PCR bank not enabled")
+	}
+	var events []Event
+	if event.Typ == eventTypeNoAction {
+		sequence := 1
+		for r.Len() > 0 {
+			event, err := parseEvent(r, specID)
+			if err != nil {
+				return events, err
+			}
+			event.Sequence = sequence
+			events = append(events, event)
+			sequence++
+		}
+	}
+	return events, nil
+}
+
+func EventLogIterate(events []Event) map[int][]byte {
+	pcrs := make(map[int][]byte)
+	for i := 0; i < 10; i++ {
+		pcrs[i] = make([]byte, 32)
+	}
+	for _, event := range events {
+		h := sha256.New()
+		h.Write(event.Data)
+		for _, digest := range event.Digests {
+			if digest.Hash == crypto.SHA256 {
+				extendBuf := sha256.New()
+				extendBuf.Write(pcrs[event.Index])
+				extendBuf.Write(digest.Data)
+				pcrs[event.Index] = extendBuf.Sum(nil)
+			}
+		}
+	}
+	fmt.Println("Expected PCR values, as per eventlog:")
+	for i := 0; i < 10; i++ {
+		fmt.Printf("PCR%d: %x\n", i, pcrs[i])
+	}
+	return pcrs
+}
+
+const (
+	ImgA = "IMGA"
+	ImgB = "IMGB"
+)
+
+var diskGuids = make(map[string]Guid)
+
+func ParseGPTEntries(events []Event) {
+	for _, event := range events {
+		if event.Index == 5 {
+			gptEntries, err := parseGPTData(event.Data)
+			if err == nil {
+				diskGuids[ImgA] = gptEntries.ImgGuid(ImgA)
+				diskGuids[ImgB] = gptEntries.ImgGuid(ImgB)
+			}
+		}
+	}
+}
+
+func DumpEventLog(events []Event, verbose bool) {
+	for _, event := range events {
+		fmt.Printf("----Event %d----\n", event.Sequence)
+		fmt.Printf("Type: %s\n", eventTypeNames[event.Typ])
+		fmt.Printf("PCR:  %d\n", event.Index)
+		h := sha256.New()
+		h.Write(event.Data)
+		fmt.Printf("Computed Hash: %x\n", h.Sum(nil))
+		if verbose {
+			if event.Index == 8 || event.Index == 9 {
+				fmt.Printf("Data: %s\n", event.Data)
+			}
+			if err := parseEventDataTCG(event.Typ, event.Data); err != nil {
+				fmt.Printf("Error in parseEventDataTCG: %v\n", err)
+			}
+		}
+		for _, digest := range event.Digests {
+			if digest.Hash == crypto.SHA256 {
+				fmt.Printf("Digest: %x\n", digest.Data)
+			}
+		}
+	}
+}
+
+func parseEventDataTCG(eventType EventType, data []byte) error {
+	switch eventType {
+	case NoAction, Action, Separator, EFIAction:
+		return nil
+	case EFIVariableDriverConfig, EFIVariableBoot, EFIVariableAuthority:
+		return parseEventDataEFIVariable(data, eventType)
+	case EFIBootServicesApplication, EFIBootServicesDriver, EFIRuntimeServicesDriver:
+		return parseEventDataEFIImageLoad(data)
+	case EFIGPTEvent:
+		return parseEventDataEFIGPT(data)
+	default:
+	}
+	return nil
+}
+
+// Guid corresponds to the EFI_GUID type
+type Guid struct {
+	Data1 uint32
+	Data2 uint16
+	Data3 uint16
+	Data4 [8]uint8
+}
+
+func (g *Guid) String() string {
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		g.Data1, g.Data2, g.Data3,
+		binary.BigEndian.Uint16(g.Data4[0:2]),
+		g.Data4[2:])
+}
+
+type TemplateEvent struct {
+	Data   string
+	Digest []byte
+}
+
+func PrepareMeasurements(events []Event) []TemplateEvent {
+	ParseGPTEntries(events)
+	templateEvents := make([]TemplateEvent, 0)
+	for _, event := range events {
+		if event.Index != 8 {
+			continue
+		}
+		fmt.Printf("----Event %d----\n", event.Sequence)
+		fmt.Printf("Type: %s\n", eventTypeNames[event.Typ])
+		grubData := string(event.Data)
+		if strings.HasPrefix(grubData, "grub_cmd ") {
+			grubData = strings.TrimPrefix(grubData, "grub_cmd ")
+		} else if strings.HasPrefix(string(event.Data), "grub_kernel_cmdline ") {
+			grubData = strings.TrimPrefix(grubData, "grub_kernel_cmdline ")
+			grubData = strings.TrimSuffix(grubData, "\x00")
+		}
+		imgAGuid := diskGuids[ImgA]
+		imgBGuid := diskGuids[ImgB]
+		imgAGuidStr := fmt.Sprintf("%s", &imgAGuid)
+		imgBGuidStr := fmt.Sprintf("%s", &imgBGuid)
+		grubData = strings.Replace(grubData, imgAGuidStr, "IMGGUID", -1)
+		grubData = strings.Replace(grubData, imgBGuidStr, "IMGGUID", -1)
+		grubData = strings.Replace(grubData, "hd0,gpt2", "IMGDEVID", -1)
+		grubData = strings.Replace(grubData, "hd0,gpt3", "IMGDEVID", -1)
+		grubData = strings.Replace(grubData, "hd0,gpt4", "CONFIGDEVID", -1)
+		grubData = strings.Replace(grubData, "hd0", "CONFIGDISK", -1)
+		h := sha256.New()
+		h.Write([]byte(grubData))
+		fmt.Printf("Data: %s\n", grubData)
+		computedDigest := h.Sum(nil)
+		fmt.Printf("Computed Hash: %x\n", computedDigest)
+		tEvent := TemplateEvent{Data: grubData, Digest: computedDigest}
+		templateEvents = append(templateEvents, tEvent)
+		for _, digest := range event.Digests {
+			if digest.Hash == crypto.SHA256 {
+				fmt.Printf("Digest: %x\n", digest.Data)
+			}
+		}
+	}
+	return templateEvents
+}
+
+func ValidateEventLog(events []Event, pcrs map[int][]byte, templateEvents []TemplateEvent) error {
+	//First validate that eventlog matches pcrs
+	derivedPcrs := EventLogIterate(events)
+	for i, digest := range pcrs {
+		fmt.Printf("Comparing PCRS %x and %x\n", derivedPcrs[i], digest)
+		if !reflect.DeepEqual(digest, derivedPcrs[i]) {
+			return fmt.Errorf("PCR %d does not match, have %x but want %x",
+				i, derivedPcrs[i], digest)
+		}
+	}
+
+	//All good with PCRs, now get PCR8 events from events
+	PCR8Events := PrepareMeasurements(events)
+	for i, e := range PCR8Events {
+		fmt.Printf("Comparing PCR 8 Events %s and %s\n", e.Data, templateEvents[i].Data)
+		if !reflect.DeepEqual(e.Data, templateEvents[i].Data) {
+			return fmt.Errorf("PCR8 event %s does not match",
+				e.Data)
+		}
+	}
+	return nil
+}

--- a/pkg/pillar/vendor/modules.txt
+++ b/pkg/pillar/vendor/modules.txt
@@ -143,6 +143,8 @@ github.com/containerd/fifo
 github.com/containerd/ttrpc
 # github.com/containerd/typeurl v0.0.0-20200205145503-b45ef1f1f737
 github.com/containerd/typeurl
+# github.com/cshari-zededa/eve-tpm2-tools v0.0.4
+github.com/cshari-zededa/eve-tpm2-tools/eventlog
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
 # github.com/dgrijalva/jwt-go v3.2.0+incompatible


### PR DESCRIPTION
- Vendoring a new package, eve-tpm2-tools, to parse TPM 2.0 eventlog
- Adding support in attestation task to send TPM event log entries, on platforms where it can be successfully read and parsed.

Signed-off-by: Hariharasubramanian C S <cshari@zededa.com>