### PR TITLE
Log stack trace where we spawn go routines

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -416,6 +416,7 @@ func Run(ps *pubsub.PubSub) {
 	}
 	log.Infof("processed onboarded")
 
+	log.Infof("Creating %s at %s", "metricsTimerTask", agentlog.GetMyStack())
 	go metricsTimerTask(&domainCtx, hyper)
 
 	// Wait for DeviceNetworkStatus to be init so we know the management
@@ -640,6 +641,7 @@ func handleDomainCreate(ctxArg interface{}, key string, configArg interface{}) {
 	}
 	h1 := make(chan Notify, 1)
 	handlerMap[config.Key()] = h1
+	log.Infof("Creating %s at %s", "runHandler", agentlog.GetMyStack())
 	go runHandler(ctx, key, h1)
 	h = h1
 	select {

--- a/pkg/pillar/cmd/downloader/handlers.go
+++ b/pkg/pillar/cmd/downloader/handlers.go
@@ -4,6 +4,7 @@
 package downloader
 
 import (
+	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	log "github.com/sirupsen/logrus"
 )
@@ -60,6 +61,7 @@ func (d *downloadHandler) create(ctxArg interface{},
 	}
 	h1 := make(chan Notify, 1)
 	d.handlers[config.Key()] = h1
+	log.Infof("Creating %s at %s", "runHandler", agentlog.GetMyStack())
 	go runHandler(ctx, key, h1)
 	h = h1
 	select {

--- a/pkg/pillar/cmd/downloader/resolvehandler.go
+++ b/pkg/pillar/cmd/downloader/resolvehandler.go
@@ -4,6 +4,7 @@
 package downloader
 
 import (
+	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -34,6 +35,8 @@ func (r *resolveHandler) modify(ctxArg interface{},
 	if !ok {
 		h1 := make(chan Notify, 1)
 		r.handlers[key] = h1
+		log.Infof("Creating %s at %s", "runResolveHandler",
+			agentlog.GetMyStack())
 		go runResolveHandler(ctx, key, h1)
 		h = h1
 	}

--- a/pkg/pillar/cmd/ledmanager/ledmanager.go
+++ b/pkg/pillar/cmd/ledmanager/ledmanager.go
@@ -208,6 +208,7 @@ func Run(ps *pubsub.PubSub) {
 	// Any state needed by handler functions
 	ctx := ledManagerContext{}
 	ctx.countChange = make(chan int)
+	log.Infof("Creating %s at %s", "triggerBinkOnDevice", agentlog.GetMyStack())
 	go TriggerBlinkOnDevice(ctx.countChange, blinkFunc, ledName)
 
 	subLedBlinkCounter, err := ps.NewSubscription(pubsub.SubscriptionOptions{

--- a/pkg/pillar/cmd/logmanager/logmanager.go
+++ b/pkg/pillar/cmd/logmanager/logmanager.go
@@ -319,8 +319,11 @@ func Run(ps *pubsub.PubSub) {
 		inputMetrics: &inputMetrics}
 
 	// Start sender of log events
+	log.Infof("Creating %s at %s", "processEvents", agentlog.GetMyStack())
 	go processEvents(currentPartition, loggerChan, eveVersion, &logmanagerCtx)
 
+	log.Infof("Creating %s at %s", "parseAndSendSyslogEntries",
+		agentlog.GetMyStack())
 	go parseAndSendSyslogEntries(&ctx)
 
 	for {

--- a/pkg/pillar/cmd/nodeagent/handletimers.go
+++ b/pkg/pillar/cmd/nodeagent/handletimers.go
@@ -210,6 +210,7 @@ func scheduleNodeReboot(ctxPtr *nodeagentContext, reasonStr string) {
 
 	// in any case, execute the reboot procedure
 	// with a delayed timer
+	log.Infof("Creating %s at %s", "handleNodeReboot", agentlog.GetMyStack())
 	go handleNodeReboot(ctxPtr, reasonStr)
 }
 

--- a/pkg/pillar/cmd/verifier/handlers.go
+++ b/pkg/pillar/cmd/verifier/handlers.go
@@ -6,6 +6,7 @@ package verifier
 import (
 	"fmt"
 
+	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	log "github.com/sirupsen/logrus"
 )
@@ -67,6 +68,8 @@ func (v *verifyHandler) create(ctxArg interface{},
 	v.handlers[handlerKey] = h1
 	switch typeName {
 	case "VerifyImageConfig":
+		log.Infof("Creating %s at %s", "runHandler",
+			agentlog.GetMyStack())
 		go runHandler(ctx, key, h1)
 	default:
 		log.Fatalf("Unknown type %s", typeName)

--- a/pkg/pillar/cmd/zedagent/attesttask.go
+++ b/pkg/pillar/cmd/zedagent/attesttask.go
@@ -295,6 +295,8 @@ func attestModuleStart(ctx *zedagentContext) error {
 	if ctx.attestCtx.attestFsmCtx == nil {
 		return fmt.Errorf("No state machine context found")
 	}
+	log.Infof("Creating %s at %s", "attestFsmCtx.EnterEventLoop",
+		agentlog.GetMyStack())
 	go ctx.attestCtx.attestFsmCtx.EnterEventLoop()
 	zattest.Kickstart(ctx.attestCtx.attestFsmCtx)
 	return nil

--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -363,9 +363,11 @@ func cipherModuleStart(ctx *zedagentContext) {
 		// we will run the tasks for watchdog
 	}
 	// start the edge node certificate push task
+	log.Infof("Creating %s at %s", "edgeNodeCertsTask", agentlog.GetMyStack())
 	go edgeNodeCertsTask(ctx, ctx.cipherCtx.triggerEdgeNodeCerts)
 
 	// start the controller certificate fetch task
+	log.Infof("Creating %s at %s", "controllerCertsTask", agentlog.GetMyStack())
 	go controllerCertsTask(ctx, ctx.cipherCtx.triggerControllerCerts)
 }
 

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -925,6 +925,7 @@ func Run(ps *pubsub.PubSub) {
 
 	// Use a go routine to make sure we have wait/timeout without
 	// blocking the main select loop
+	log.Infof("Creating %s at %s", "deviceInfoTask", agentlog.GetMyStack())
 	go deviceInfoTask(&zedagentCtx, triggerDeviceInfo)
 
 	// Publish initial device info.
@@ -932,11 +933,13 @@ func Run(ps *pubsub.PubSub) {
 
 	// start the metrics reporting task
 	handleChannel := make(chan interface{})
+	log.Infof("Creating %s at %s", "metricsTimerTask", agentlog.GetMyStack())
 	go metricsTimerTask(&zedagentCtx, handleChannel)
 	metricsTickerHandle := <-handleChannel
 	getconfigCtx.metricsTickerHandle = metricsTickerHandle
 
 	// start the config fetch tasks, when zboot status is ready
+	log.Infof("Creating %s at %s", "configTimerTask", agentlog.GetMyStack())
 	go configTimerTask(handleChannel, &getconfigCtx)
 	configTickerHandle := <-handleChannel
 	// XXX close handleChannels?

--- a/pkg/pillar/cmd/zedrouter/appcontainer.go
+++ b/pkg/pillar/cmd/zedrouter/appcontainer.go
@@ -22,6 +22,7 @@ import (
 	apitypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils"
 	log "github.com/sirupsen/logrus"
@@ -110,6 +111,8 @@ func ensureStatsCollectRunning(ctx *zedrouterContext) {
 	if !ctx.appCollectStatsRunning {
 		ctx.appCollectStatsRunning = true
 		ctx.appStatsMutex.Unlock()
+		log.Infof("Creating %s at %s", "appStatusAndLogCollect",
+			agentlog.GetMyStack())
 		go appStatsAndLogCollect(ctx)
 	} else {
 		ctx.appStatsMutex.Unlock()

--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/eriknordmark/netlink"
+	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/devicenetwork"
 	"github.com/lf-edge/eve/pkg/pillar/iptables"
 	"github.com/lf-edge/eve/pkg/pillar/types"
@@ -519,6 +520,7 @@ func doNetworkInstanceCreate(ctx *zedrouterContext,
 	}
 
 	// monitor the DNS and DHCP information
+	log.Infof("Creating %s at %s", "DNSMonitor", agentlog.GetMyStack())
 	go DNSMonitor(bridgeName, bridgeNum, ctx, status)
 
 	if status.IsIPv6() {

--- a/pkg/pillar/cmd/zedrouter/radvd.go
+++ b/pkg/pillar/cmd/zedrouter/radvd.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/wrap"
 	log "github.com/sirupsen/logrus"
 )
@@ -70,6 +71,7 @@ func startRadvd(cfgPathname string, olIfname string) {
 		"-p",
 		pidPathname,
 	}
+	log.Infof("Creating %s at %s", "nohup radvd", agentlog.GetMyStack())
 	go wrap.Command(cmd, args...).Output()
 }
 

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -535,6 +535,8 @@ func Run(ps *pubsub.PubSub) {
 			start := time.Now()
 			log.Debugf("FlowStatTimer at %v", time.Now())
 			// XXX why start a new go routine for each change?
+			log.Infof("Creating %s at %s", "FlowStatsCollect",
+				agentlog.GetMyStack())
 			go FlowStatsCollect(&zedrouterCtx)
 			pubsub.CheckMaxTimeTopic(agentName, "FlowStatsCollect", start,
 				warningTime, errorTime)
@@ -543,6 +545,8 @@ func Run(ps *pubsub.PubSub) {
 			start := time.Now()
 			log.Debugf("HostProbeTimer at %v", time.Now())
 			// launch the go function gateway/remote hosts probing check
+			log.Infof("Creating %s at %s", "launchHostProbe",
+				agentlog.GetMyStack())
 			go launchHostProbe(&zedrouterCtx)
 			pubsub.CheckMaxTimeTopic(agentName, "lauchHostProbe", start,
 				warningTime, errorTime)

--- a/pkg/pillar/containerd/logging.go
+++ b/pkg/pillar/containerd/logging.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -95,6 +96,7 @@ func (r *remoteLog) Path(n string) string {
 	if err := syscall.Mkfifo(path, 0600); err != nil {
 		return "/dev/null"
 	}
+	log.Infof("Creating %s at %s", "func", agentlog.GetMyStack())
 	go func() {
 		// In a goroutine because Open of the FIFO will block until
 		// containerd opens it when the task is started.

--- a/pkg/pillar/devicenetwork/dhcpcd.go
+++ b/pkg/pillar/devicenetwork/dhcpcd.go
@@ -8,6 +8,7 @@ package devicenetwork
 
 import (
 	"fmt"
+	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	log "github.com/sirupsen/logrus"
 	"io/ioutil"
@@ -224,6 +225,7 @@ func dhcpcdCmd(op string, extras []string, ifname string, background bool) bool 
 		cmd.Stderr = nil
 
 		log.Infof("Background command %s %v\n", name, args)
+		log.Infof("Creating %s at %s", "func", agentlog.GetMyStack())
 		go func() {
 			if err := cmd.Run(); err != nil {
 				log.Errorf("%s %v: failed: %s",

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -6,6 +6,7 @@ package hypervisor
 import (
 	"fmt"
 	zconfig "github.com/lf-edge/eve/api/go/config"
+	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/containerd"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	log "github.com/sirupsen/logrus"
@@ -579,6 +580,7 @@ func (ctx kvmContext) Start(domainName string, domainID int) error {
 	qmpFile := getQmpExecutorSocket(domainName)
 
 	log.Debugf("starting qmpEventHandler")
+	log.Infof("Creating %s at %s", "qmpEventHandler", agentlog.GetMyStack())
 	go qmpEventHandler(getQmpListenerSocket(domainName), getQmpExecutorSocket(domainName))
 
 	if err := execContinue(qmpFile); err != nil {

--- a/pkg/pillar/pubsub/socketdriver/publish.go
+++ b/pkg/pillar/pubsub/socketdriver/publish.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 	log "github.com/sirupsen/logrus"
@@ -107,6 +108,7 @@ func (s *Publisher) Start() error {
 	if s.listener == nil {
 		return nil
 	}
+	log.Infof("Creating %s at %s", "func", agentlog.GetMyStack())
 	go func(s *Publisher) {
 		instance := 0
 		for {
@@ -115,6 +117,7 @@ func (s *Publisher) Start() error {
 				log.Errorf("publisher(%s) failed %s\n", s.name, err)
 				continue
 			}
+			log.Infof("Creating %s at %s", "s.serveConnection", agentlog.GetMyStack())
 			go s.serveConnection(c, instance)
 			instance++
 		}

--- a/pkg/pillar/pubsub/socketdriver/subscribe.go
+++ b/pkg/pillar/pubsub/socketdriver/subscribe.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/watch"
 	log "github.com/sirupsen/logrus"
@@ -95,10 +96,16 @@ func (s *Subscriber) Start() error {
 		// format than the standard for pubsub
 		// we pass it through a translator
 		translator := make(chan string)
+		log.Infof("Creating %s at %s", "watch.WatchStatus",
+			agentlog.GetMyStack())
 		go watch.WatchStatus(s.dirName, true, translator)
+		log.Infof("Creating %s at %s", "s.Translate",
+			agentlog.GetMyStack())
 		go s.translate(translator, s.C)
 		return nil
 	} else if subscribeFromSock {
+		log.Infof("Creating %s at %s", "s.watchSock",
+			agentlog.GetMyStack())
 		go s.watchSock()
 		return nil
 	} else {

--- a/pkg/pillar/watch/waitforfile.go
+++ b/pkg/pillar/watch/waitforfile.go
@@ -8,6 +8,7 @@ package watch
 import (
 	"fmt"
 	"github.com/fsnotify/fsnotify"
+	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	log "github.com/sirupsen/logrus"
 	"os"
 	"path/filepath"
@@ -22,6 +23,7 @@ func WaitForFile(filename string) {
 
 	done := make(chan bool)
 	stop := make(chan bool)
+	log.Infof("Creating %s at %s", "func", agentlog.GetMyStack())
 	go func() {
 		for {
 			select {

--- a/pkg/pillar/watch/watchconfigstatus.go
+++ b/pkg/pillar/watch/watchconfigstatus.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
+	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/flextimer"
 	log "github.com/sirupsen/logrus"
 )
@@ -47,6 +48,7 @@ func watchConfigStatusImpl(configDir string, statusDir string,
 	defer w.Close()
 
 	done := make(chan bool)
+	log.Infof("Creating %s at %s", "func", agentlog.GetMyStack())
 	go func() {
 		for {
 			select {
@@ -200,6 +202,7 @@ func WatchStatus(statusDir string, jsonOnly bool, fileChanges chan<- string) {
 	defer w.Close()
 
 	done := make(chan bool)
+	log.Infof("Creating %s at %s", "func", agentlog.GetMyStack())
 	go func() {
 		for {
 			select {

--- a/pkg/pillar/worker/worker.go
+++ b/pkg/pillar/worker/worker.go
@@ -9,6 +9,7 @@ package worker
 import (
 	"time"
 
+	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -58,6 +59,7 @@ func NewWorker(fn WorkFunction, ctx interface{}, length int) *Worker {
 	w := new(Worker)
 	requestChan := make(chan Work, length)
 	resultChan := make(chan privateResult, length)
+	log.Infof("Creating %s at %s", "w.processWork", agentlog.GetMyStack())
 	go w.processWork(ctx, fn, requestChan, resultChan)
 	w.requestChan = requestChan
 	w.resultChan = resultChan

--- a/pkg/pillar/zedcloud/wstunnelclient.go
+++ b/pkg/pillar/zedcloud/wstunnelclient.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
@@ -69,6 +70,7 @@ func InitializeTunnelClient(serverNameAndPort string, localRelay string) *WSTunn
 // Start triggers workflow to establish the websocket
 // session with remote tunnel server
 func (t *WSTunnelClient) Start() {
+	log.Infof("Creating %s at %s", "func", agentlog.GetMyStack())
 	go func() {
 		t.startSession()
 		<-make(chan struct{}, 0)
@@ -153,6 +155,7 @@ func (t *WSTunnelClient) startSession() error {
 	t.retryOnFailCount = 0
 
 	// Keep opening websocket connections to tunnel requests
+	log.Infof("Creating %s at %s", "func", agentlog.GetMyStack())
 	go func() {
 		log.Debug("Looping through websocket connection requests")
 		for {
@@ -214,6 +217,7 @@ func (t *WSTunnelClient) Stop() {
 // a goroutine to relay the request locally and optionally
 // return the result if any.
 func (wsc *WSConnection) handleRequests() {
+	log.Infof("Creating %s at %s", "wsc.pinger", agentlog.GetMyStack())
 	go wsc.pinger()
 	for {
 		wsc.ws.SetReadDeadline(time.Time{}) // separate ping-pong routine does timeout
@@ -257,6 +261,7 @@ func (wsc *WSConnection) handleRequests() {
 
 	}
 	// delay a few seconds to allow for writes to drain and then force-close the socket
+	log.Infof("Creating %s at %s", "func", agentlog.GetMyStack())
 	go func() {
 		log.Info("Closing websocket connection")
 		time.Sleep(5 * time.Second)
@@ -321,6 +326,8 @@ func (wsc *WSConnection) processRequest(id int16, req []byte) (err error) {
 	host := wsc.tun.LocalRelayServer
 	if wsc.localConnection == nil {
 		wsc.dialLocalConnection()
+		log.Infof("Creating %s at %s", "wsc.ProcessResponse",
+			agentlog.GetMyStack())
 		go wsc.processResponses()
 	}
 


### PR DESCRIPTION
When we git a panic in a go routine we do not see where the go routine was created.
Instead we just see "created" at the beginning of the stack as in this simple example:
panic: runtime error: index out of range [2] with length 0

goroutine 43 [running]:
github.com/lf-edge/eve/pkg/pillar/cmd/diag.runCrasher()
	/home/nordmark/fixes/eve/pkg/pillar/cmd/diag/diag.go:308 +0xbe
created by github.com/lf-edge/eve/pkg/pillar/cmd/diag.Run
	/home/nordmark/fixes/eve/pkg/pillar/cmd/diag/diag.go:166 +0xcc6

As we might put several microservices in the same process (and as a result having lots more goroutines) this lack of information might cause some pain.
This PR adds a function in agentlog (1st commit), and then adds log.Infof calls where we spawn goroutines.
The result of that are log entries (for the above toy diag example) of the form:
{"file":"/home/nordmark/fixes/eve/pkg/pillar/cmd/diag/diag.go:165","func":"github.com/lf-edge/eve/pkg/pillar/cmd/diag.Run","level":"info","msg":"Creating runCrasher at goroutine:\ngithub.com/lf-edge/eve/pkg/pillar/cmd/diag.Run()\n\t/home/nordmark/fixes/eve/pkg/pillar/cmd/diag/diag.go:165\nmain.main()\n\t/home/nordmark/fixes/eve/pkg/pillar/zedbox/zedbox.go:71\n","pid":86979,"source":"diag","time":"2020-08-13T15:06:32.058272151+02:00"}

Thus the log entry plus the panic stack trace should tell the whole story.

Note that I did not touch zedUpload since that package doesn't even use the log package.
