### PR TITLE
refactor tpm and vault code so agents do not import other agents

### DIFF
--- a/pkg/pillar/cmd/tpmmgr/tpmmgr.go
+++ b/pkg/pillar/cmd/tpmmgr/tpmmgr.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/google/go-tpm/tpm2"
 	"github.com/google/go-tpm/tpmutil"
-	"github.com/lf-edge/eve/api/go/info"
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	etpm "github.com/lf-edge/eve/pkg/pillar/evetpm"
 	"github.com/lf-edge/eve/pkg/pillar/pidfile"
@@ -73,13 +72,9 @@ const (
 	//TpmDeviceCertHdl is the well known TPM NVIndex for device cert
 	TpmDeviceCertHdl tpmutil.Handle = 0x1500000
 
-	//TpmDiskKeyHdl is the handle for constructing disk encryption key
-	TpmDiskKeyHdl tpmutil.Handle = 0x1700000
-
-	emptyPassword  = ""
-	tpmLockName    = types.TmpDirname + "/tpm.lock"
-	vaultKeyLength = 32 //Bytes
-	maxPCRIndex    = 23
+	emptyPassword = ""
+	tpmLockName   = types.TmpDirname + "/tpm.lock"
+	maxPCRIndex   = 23
 
 	// Time limits for event loop handlers
 	errorTime   = 3 * time.Minute
@@ -101,7 +96,6 @@ var (
 	//on devices without a TPM
 	quoteKeyFile = types.PersistConfigDir + "/attest.key.pem"
 
-	tpmHwInfo        = ""
 	pcrSelection     = tpm2.PCRSelection{Hash: tpm2.AlgSHA1, PCRs: []int{7}}
 	pcrListForQuote  = tpm2.PCRSelection{Hash: tpm2.AlgSHA256, PCRs: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}}
 	defaultKeyParams = tpm2.Public{
@@ -200,34 +194,6 @@ var (
 	debug         = false
 	debugOverride bool // From command line arg
 )
-
-//Refer to https://trustedcomputinggroup.org/wp-content/uploads/TCG-TPM-Vendor-ID-Registry-Version-1.01-Revision-1.00.pdf
-//These byte sequences in uint32 format is actually ASCII representation of TPM
-//vendor ID. Since they are abbreviated names, we are having a map here to show
-//a more verbose form of vendor name
-var vendorRegistry = map[uint32]string{
-	0x414D4400: "AMD",
-	0x41544D4C: "Atmel",
-	0x4252434D: "Broadcom",
-	0x48504500: "HPE",
-	0x49424d00: "IBM",
-	0x49465800: "Infineon",
-	0x494E5443: "Intel",
-	0x4C454E00: "Lenovo",
-	0x4D534654: "Microsoft",
-	0x4E534D20: "National SC",
-	0x4E545A00: "Nationz",
-	0x4E544300: "Nuvoton",
-	0x51434F4D: "Qualcomm",
-	0x534D5343: "SMSC",
-	0x53544D20: "ST Microelectronics",
-	0x534D534E: "Samsung",
-	0x534E5300: "Sinosun",
-	0x54584E00: "Texas Instruments",
-	0x57454300: "Winbond",
-	0x524F4343: "Fuzhou Rockchip",
-	0x474F4F47: "Google",
-}
 
 var toGoCurve = map[tpm2.EllipticCurve]elliptic.Curve{
 	tpm2.CurveNISTP224: elliptic.P224(),
@@ -484,148 +450,8 @@ func readCredentials() error {
 	return nil
 }
 
-//FetchVaultKey retreives TPM part of the vault key
-func FetchVaultKey() ([]byte, error) {
-	//First try to read from TPM, if it was stored earlier
-	key, err := readDiskKey()
-	if err != nil {
-		key, err = etpm.GetRandom(vaultKeyLength)
-		if err != nil {
-			log.Errorf("Error in generating random number: %v", err)
-			return nil, err
-		}
-		err = writeDiskKey(key)
-		if err != nil {
-			log.Errorf("Writing Disk Key to TPM failed: %v", err)
-			return nil, err
-		}
-	}
-	return key, nil
-}
-
-func writeDiskKey(key []byte) error {
-	rw, err := tpm2.OpenTPM(etpm.TpmDevicePath)
-	if err != nil {
-		return err
-	}
-	defer rw.Close()
-
-	if err := tpm2.NVUndefineSpace(rw, emptyPassword,
-		tpm2.HandleOwner, TpmDiskKeyHdl,
-	); err != nil {
-		log.Debugf("NVUndefineSpace failed: %v", err)
-	}
-
-	// Define space in NV storage and clean up afterwards or subsequent runs will fail.
-	if err := tpm2.NVDefineSpace(rw,
-		tpm2.HandleOwner,
-		TpmDiskKeyHdl,
-		emptyPassword,
-		emptyPassword,
-		nil,
-		tpm2.AttrOwnerWrite|tpm2.AttrOwnerRead,
-		uint16(len(key)),
-	); err != nil {
-		log.Errorf("NVDefineSpace failed: %v", err)
-		return err
-	}
-
-	// Write the data
-	if err := tpm2.NVWrite(rw, tpm2.HandleOwner, TpmDiskKeyHdl,
-		emptyPassword, key, 0); err != nil {
-		log.Errorf("NVWrite failed: %v", err)
-		return err
-	}
-	return nil
-}
-
-func readDiskKey() ([]byte, error) {
-	rw, err := tpm2.OpenTPM(etpm.TpmDevicePath)
-	if err != nil {
-		return nil, err
-	}
-	defer rw.Close()
-
-	// Read all of the data with NVReadEx
-	keyBytes, err := tpm2.NVReadEx(rw, TpmDiskKeyHdl,
-		tpm2.HandleOwner, emptyPassword, 0)
-	if err != nil {
-		log.Errorf("NVReadEx failed: %v", err)
-		return nil, err
-	}
-	return keyBytes, nil
-}
-
-//till we have next version of go-tpm released, use this
-const (
-	tpmPropertyManufacturer tpm2.TPMProp = 0x105
-	tpmPropertyVendorStr1   tpm2.TPMProp = 0x106
-	tpmPropertyVendorStr2   tpm2.TPMProp = 0x107
-	tpmPropertyFirmVer1     tpm2.TPMProp = 0x10b
-	tpmPropertyFirmVer2     tpm2.TPMProp = 0x10c
-)
-
-//FetchTpmSwStatus returns states reflecting SW usage of TPM
-func FetchTpmSwStatus() info.HwSecurityModuleStatus {
-	_, err := os.Stat(etpm.TpmDevicePath)
-	if err != nil {
-		//No TPM found on this system
-		return info.HwSecurityModuleStatus_NOTFOUND
-	}
-	if etpm.IsTpmEnabled() {
-		//TPM is found and is used by software
-		return info.HwSecurityModuleStatus_ENABLED
-	}
-
-	//TPM is found but not being used by software
-	return info.HwSecurityModuleStatus_DISABLED
-}
-
-//FetchTpmHwInfo returns TPM Hardware properties in a string
-func FetchTpmHwInfo() (string, error) {
-
-	//If we had done this earlier, return the last result
-	if tpmHwInfo != "" {
-		return tpmHwInfo, nil
-	}
-
-	//Take care of non-TPM platforms
-	_, err := os.Stat(etpm.TpmDevicePath)
-	if err != nil {
-		tpmHwInfo = "Not Available"
-		return tpmHwInfo, nil
-	}
-
-	//First time. Fetch it from TPM and cache it.
-	v1, err := etpm.GetTpmProperty(tpmPropertyManufacturer)
-	if err != nil {
-		return "", err
-	}
-	v2, err := etpm.GetTpmProperty(tpmPropertyVendorStr1)
-	if err != nil {
-		return "", err
-	}
-	v3, err := etpm.GetTpmProperty(tpmPropertyVendorStr2)
-	if err != nil {
-		return "", err
-	}
-	v4, err := etpm.GetTpmProperty(tpmPropertyFirmVer1)
-	if err != nil {
-		return "", err
-	}
-	v5, err := etpm.GetTpmProperty(tpmPropertyFirmVer2)
-	if err != nil {
-		return "", err
-	}
-	tpmHwInfo = fmt.Sprintf("%s-%s, FW Version %s", vendorRegistry[v1],
-		etpm.GetModelName(v2, v3),
-		etpm.GetFirmwareVersion(v4, v5))
-
-	return tpmHwInfo, nil
-}
-
 func printCapability() {
-	hwInfoStr, err := FetchTpmHwInfo()
+	hwInfoStr, err := etpm.FetchTpmHwInfo()
 	if err != nil {
 		fmt.Println(err)
 	} else {

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -22,15 +22,15 @@ import (
 	"github.com/lf-edge/eve/api/go/metrics"
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/cipher"
-	"github.com/lf-edge/eve/pkg/pillar/cmd/tpmmgr"
-	"github.com/lf-edge/eve/pkg/pillar/cmd/vaultmgr"
 	"github.com/lf-edge/eve/pkg/pillar/diskmetrics"
+	etpm "github.com/lf-edge/eve/pkg/pillar/evetpm"
 	"github.com/lf-edge/eve/pkg/pillar/flextimer"
 	"github.com/lf-edge/eve/pkg/pillar/hardware"
 	"github.com/lf-edge/eve/pkg/pillar/netclone"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils"
+	"github.com/lf-edge/eve/pkg/pillar/vault"
 	"github.com/lf-edge/eve/pkg/pillar/zedcloud"
 	uuid "github.com/satori/go.uuid"
 	"github.com/shirou/gopsutil/disk"
@@ -1057,15 +1057,15 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 	ReportDeviceInfo.RebootConfigCounter = ctx.rebootConfigCounter
 
 	//Operational information about TPM presence/absence/usage.
-	ReportDeviceInfo.HSMStatus = tpmmgr.FetchTpmSwStatus()
-	ReportDeviceInfo.HSMInfo, _ = tpmmgr.FetchTpmHwInfo()
+	ReportDeviceInfo.HSMStatus = etpm.FetchTpmSwStatus()
+	ReportDeviceInfo.HSMInfo, _ = etpm.FetchTpmHwInfo()
 
 	//Operational information about Data Security At Rest
 	ReportDataSecAtRestInfo := getDataSecAtRestInfo(ctx)
 
 	//This will be removed after new fields propagate to Controller.
 	ReportDataSecAtRestInfo.Status, ReportDataSecAtRestInfo.Info =
-		vaultmgr.GetOperInfo()
+		vault.GetOperInfo()
 	ReportDeviceInfo.DataSecAtRestInfo = ReportDataSecAtRestInfo
 
 	ReportInfo.InfoContent = new(info.ZInfoMsg_Dinfo)

--- a/pkg/pillar/evetpm/tpm.go
+++ b/pkg/pillar/evetpm/tpm.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/google/go-tpm/tpm2"
 	"github.com/google/go-tpm/tpmutil"
+	"github.com/lf-edge/eve/api/go/info"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	log "github.com/sirupsen/logrus"
 )
@@ -37,6 +38,16 @@ const (
 
 	//MaxPasswdLength is the max length allowed for a TPM password
 	MaxPasswdLength = 7 //limit TPM password to this length
+
+	//TpmDiskKeyHdl is the handle for constructing disk encryption key
+	TpmDiskKeyHdl tpmutil.Handle = 0x1700000
+
+	emptyPassword  = ""
+	vaultKeyLength = 32 //Bytes
+)
+
+var (
+	tpmHwInfo = ""
 )
 
 //TpmPrivateKey is Custom implementation of crypto.PrivateKey interface
@@ -186,4 +197,172 @@ func GetTpmProperty(propID tpm2.TPMProp) (uint32, error) {
 		return 0, fmt.Errorf("Unable to fetch property %d", propID)
 	}
 	return prop.Value, nil
+}
+
+//FetchTpmSwStatus returns states reflecting SW usage of TPM
+func FetchTpmSwStatus() info.HwSecurityModuleStatus {
+	_, err := os.Stat(TpmDevicePath)
+	if err != nil {
+		//No TPM found on this system
+		return info.HwSecurityModuleStatus_NOTFOUND
+	}
+	if IsTpmEnabled() {
+		//TPM is found and is used by software
+		return info.HwSecurityModuleStatus_ENABLED
+	}
+
+	//TPM is found but not being used by software
+	return info.HwSecurityModuleStatus_DISABLED
+}
+
+//Refer to https://trustedcomputinggroup.org/wp-content/uploads/TCG-TPM-Vendor-ID-Registry-Version-1.01-Revision-1.00.pdf
+//These byte sequences in uint32 format is actually ASCII representation of TPM
+//vendor ID. Since they are abbreviated names, we are having a map here to show
+//a more verbose form of vendor name
+var vendorRegistry = map[uint32]string{
+	0x414D4400: "AMD",
+	0x41544D4C: "Atmel",
+	0x4252434D: "Broadcom",
+	0x48504500: "HPE",
+	0x49424d00: "IBM",
+	0x49465800: "Infineon",
+	0x494E5443: "Intel",
+	0x4C454E00: "Lenovo",
+	0x4D534654: "Microsoft",
+	0x4E534D20: "National SC",
+	0x4E545A00: "Nationz",
+	0x4E544300: "Nuvoton",
+	0x51434F4D: "Qualcomm",
+	0x534D5343: "SMSC",
+	0x53544D20: "ST Microelectronics",
+	0x534D534E: "Samsung",
+	0x534E5300: "Sinosun",
+	0x54584E00: "Texas Instruments",
+	0x57454300: "Winbond",
+	0x524F4343: "Fuzhou Rockchip",
+	0x474F4F47: "Google",
+}
+
+//till we have next version of go-tpm released, use this
+const (
+	tpmPropertyManufacturer tpm2.TPMProp = 0x105
+	tpmPropertyVendorStr1   tpm2.TPMProp = 0x106
+	tpmPropertyVendorStr2   tpm2.TPMProp = 0x107
+	tpmPropertyFirmVer1     tpm2.TPMProp = 0x10b
+	tpmPropertyFirmVer2     tpm2.TPMProp = 0x10c
+)
+
+//FetchTpmHwInfo returns TPM Hardware properties in a string
+func FetchTpmHwInfo() (string, error) {
+
+	//If we had done this earlier, return the last result
+	if tpmHwInfo != "" {
+		return tpmHwInfo, nil
+	}
+
+	//Take care of non-TPM platforms
+	_, err := os.Stat(TpmDevicePath)
+	if err != nil {
+		tpmHwInfo = "Not Available"
+		return tpmHwInfo, nil
+	}
+
+	//First time. Fetch it from TPM and cache it.
+	v1, err := GetTpmProperty(tpmPropertyManufacturer)
+	if err != nil {
+		return "", err
+	}
+	v2, err := GetTpmProperty(tpmPropertyVendorStr1)
+	if err != nil {
+		return "", err
+	}
+	v3, err := GetTpmProperty(tpmPropertyVendorStr2)
+	if err != nil {
+		return "", err
+	}
+	v4, err := GetTpmProperty(tpmPropertyFirmVer1)
+	if err != nil {
+		return "", err
+	}
+	v5, err := GetTpmProperty(tpmPropertyFirmVer2)
+	if err != nil {
+		return "", err
+	}
+	tpmHwInfo = fmt.Sprintf("%s-%s, FW Version %s", vendorRegistry[v1],
+		GetModelName(v2, v3),
+		GetFirmwareVersion(v4, v5))
+
+	return tpmHwInfo, nil
+}
+
+//FetchVaultKey retreives TPM part of the vault key
+func FetchVaultKey() ([]byte, error) {
+	//First try to read from TPM, if it was stored earlier
+	key, err := readDiskKey()
+	if err != nil {
+		key, err = GetRandom(vaultKeyLength)
+		if err != nil {
+			log.Errorf("Error in generating random number: %v", err)
+			return nil, err
+		}
+		err = writeDiskKey(key)
+		if err != nil {
+			log.Errorf("Writing Disk Key to TPM failed: %v", err)
+			return nil, err
+		}
+	}
+	return key, nil
+}
+
+func writeDiskKey(key []byte) error {
+	rw, err := tpm2.OpenTPM(TpmDevicePath)
+	if err != nil {
+		return err
+	}
+	defer rw.Close()
+
+	if err := tpm2.NVUndefineSpace(rw, emptyPassword,
+		tpm2.HandleOwner, TpmDiskKeyHdl,
+	); err != nil {
+		log.Debugf("NVUndefineSpace failed: %v", err)
+	}
+
+	// Define space in NV storage and clean up afterwards or subsequent runs will fail.
+	if err := tpm2.NVDefineSpace(rw,
+		tpm2.HandleOwner,
+		TpmDiskKeyHdl,
+		emptyPassword,
+		emptyPassword,
+		nil,
+		tpm2.AttrOwnerWrite|tpm2.AttrOwnerRead,
+		uint16(len(key)),
+	); err != nil {
+		log.Errorf("NVDefineSpace failed: %v", err)
+		return err
+	}
+
+	// Write the data
+	if err := tpm2.NVWrite(rw, tpm2.HandleOwner, TpmDiskKeyHdl,
+		emptyPassword, key, 0); err != nil {
+		log.Errorf("NVWrite failed: %v", err)
+		return err
+	}
+	return nil
+}
+
+func readDiskKey() ([]byte, error) {
+	rw, err := tpm2.OpenTPM(TpmDevicePath)
+	if err != nil {
+		return nil, err
+	}
+	defer rw.Close()
+
+	// Read all of the data with NVReadEx
+	keyBytes, err := tpm2.NVReadEx(rw, TpmDiskKeyHdl,
+		tpm2.HandleOwner, emptyPassword, 0)
+	if err != nil {
+		log.Errorf("NVReadEx failed: %v", err)
+		return nil, err
+	}
+	return keyBytes, nil
 }

--- a/pkg/pillar/vault/vault.go
+++ b/pkg/pillar/vault/vault.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2018-2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package vault
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/lf-edge/eve/api/go/info"
+	etpm "github.com/lf-edge/eve/pkg/pillar/evetpm"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// FscryptConfFile is where we keep config
+	FscryptConfFile = "/etc/fscrypt.conf"
+
+	// FscryptPath is the fscrypt binary
+	FscryptPath = "/opt/zededa/bin/fscrypt"
+
+	// ZfsPath is the zfs binary(?)
+	ZfsPath = "/usr/sbin/chroot"
+
+	// MountPoint is the root of all vaults
+	MountPoint = types.PersistDir
+
+	// DefaultZpool is used by zfs
+	DefaultZpool = "persist"
+
+	evePersistTypeFile = "/run/eve.persist_type"
+)
+
+var (
+	// StatusParams is used by fscrypt
+	StatusParams = []string{"status", MountPoint}
+)
+
+//getFscryptOperInfo returns operational status of fscrypt encryption
+func getFscryptOperInfo() (info.DataSecAtRestStatus, string) {
+	_, err := os.Stat(FscryptConfFile)
+	if err == nil {
+		if _, _, err := execCmd(FscryptPath, StatusParams...); err != nil {
+			//fscrypt is setup, but not being used
+			log.Debug("Setting status to Error")
+			return info.DataSecAtRestStatus_DATASEC_AT_REST_ERROR,
+				"Fscrypt Encryption is not setup"
+		} else {
+			//fscrypt is setup, and being used on /persist
+			log.Debug("Setting status to Enabled")
+			return info.DataSecAtRestStatus_DATASEC_AT_REST_ENABLED,
+				"Fscrypt is enabled and active"
+		}
+	} else {
+		return info.DataSecAtRestStatus_DATASEC_AT_REST_ERROR,
+			"Fscrypt is not enabled"
+
+	}
+}
+
+//getZfsOperInfo returns operational status of ZFS encryption
+func getZfsOperInfo() (info.DataSecAtRestStatus, string) {
+	//Check if default zpool (i.e. "persist" dataset) is setup
+	_, err := CheckOperStatus(DefaultZpool)
+	if err != nil {
+		log.Errorf("default zpool status returns error %v", err)
+		return info.DataSecAtRestStatus_DATASEC_AT_REST_ERROR,
+			"Default ZFS zpool is not setup"
+	}
+	return info.DataSecAtRestStatus_DATASEC_AT_REST_ENABLED,
+		"ZFS Encryption is enabled for vaults"
+
+}
+
+//GetOperInfo gets the current operational state of encryption tool
+func GetOperInfo() (info.DataSecAtRestStatus, string) {
+	if !etpm.IsTpmEnabled() {
+		//No encryption on plaforms without a (working) TPM
+		log.Debug("Setting status to disabled, TPM is not in use")
+		return info.DataSecAtRestStatus_DATASEC_AT_REST_DISABLED,
+			"TPM is either absent or not in use"
+	}
+	persistFsType := ReadPersistType()
+	switch persistFsType {
+	case "ext4":
+		return getFscryptOperInfo()
+	case "zfs":
+		return getZfsOperInfo()
+	default:
+		log.Debugf("Unsupported filesystem (%s), setting status to disabled",
+			persistFsType)
+		return info.DataSecAtRestStatus_DATASEC_AT_REST_DISABLED,
+			"Current filesystem does not support encryption"
+	}
+}
+
+func execCmd(command string, args ...string) (string, string, error) {
+	var stdout, stderr bytes.Buffer
+
+	cmd := exec.Command(command, args...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	stdoutStr, stderrStr := stdout.String(), stderr.String()
+	return stdoutStr, stderrStr, err
+}
+
+//ReadPersistType returns the persist filesystem type
+//e.g ext4, zfs, ext3 etc.
+//returns "" in case of read error
+func ReadPersistType() string {
+	persistFsType := ""
+	pBytes, err := ioutil.ReadFile(evePersistTypeFile)
+	if err == nil {
+		persistFsType = strings.TrimSpace(string(pBytes))
+	}
+	return persistFsType
+}

--- a/pkg/pillar/vault/vaultzfs.go
+++ b/pkg/pillar/vault/vaultzfs.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package vault
+
+import (
+	log "github.com/sirupsen/logrus"
+)
+
+func getOperStatusParams(vaultPath string) []string {
+	args := []string{"/hostfs", "zfs", "get", "mounted,encryption,keystatus", vaultPath}
+	return args
+}
+
+// CheckOperStatus returns ZFS status
+func CheckOperStatus(vaultPath string) (string, error) {
+	args := getOperStatusParams(vaultPath)
+	if stdOut, stdErr, err := execCmd(ZfsPath, args...); err != nil {
+		log.Errorf("oper status query for %s results in error=%v, %s, %s",
+			vaultPath, err, stdOut, stdErr)
+		return stdErr, err
+	} else {
+		return stdOut, nil
+	}
+}


### PR DESCRIPTION
With the logging changes we have a log variable (as opposed to package) in the various microservices in pkg/pillar/cmd/
With that we can't have some service include code from another; instead we should have the code in packages at the top of pkg/pillar.
Prior to this PR we had these odd imports
pkg/pillar/cmd/vaultmgr/vaultmgr.go:	"github.com/lf-edge/eve/pkg/pillar/cmd/tpmmgr"
pkg/pillar/cmd/zedagent/handlemetrics.go:	"github.com/lf-edge/eve/pkg/pillar/cmd/tpmmgr"
pkg/pillar/cmd/zedagent/handlemetrics.go:	"github.com/lf-edge/eve/pkg/pillar/cmd/vaultmgr"

This PR moves code to pkg/pillar/evetpm and creates a new pkg/pillar/vault package.

Note that the code, constants, and variables to move is the minimal set to make things compile. It could be that we should move more to make evetpm and vault packages more logical.