### PR TITLE
fix environment variables parsing

### DIFF
--- a/pkg/pillar/containerd/containerd.go
+++ b/pkg/pillar/containerd/containerd.go
@@ -786,7 +786,7 @@ func getContainerConfigs(imageInfo ocispec.Image, userEnvVars map[string]string)
 	unProcessedEnv := imageInfo.Config.Env
 	var env []string
 	for _, e := range unProcessedEnv {
-		keyAndValueSlice := strings.Split(e, "=")
+		keyAndValueSlice := strings.SplitN(e, "=", 2)
 		if len(keyAndValueSlice) == 2 {
 			//handles Key=Value case
 			env = append(env, fmt.Sprintf("%s=\"%s\"", keyAndValueSlice[0], keyAndValueSlice[1]))


### PR DESCRIPTION
For some containers we need to support ENV with nested `=` like:
`ENV PHP_CFLAGS="-fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"`