### PR TITLE
Using sync.Pool for buffer

### DIFF
--- a/pkg/pillar/pubsub/socketdriver/driver.go
+++ b/pkg/pillar/pubsub/socketdriver/driver.go
@@ -239,22 +239,6 @@ func getBuffer() (*[]byte, func()) {
 
 // check and waits till conn's fd is readable
 func connReadCheck(conn net.Conn) error {
-
-	unixConn, ok := conn.(*net.UnixConn)
-	if !ok {
-		log.Error("connReadCheck: Not UnixConn")
-		return nil
-	}
-	_, _, err := unixConn.ReadFromUnix([]byte{})
-	if err != nil && !strings.HasSuffix(err.Error(), "EOF") {
-		log.Errorf("connReadCheck: %s", err.Error())
-		return err
-	}
-	return nil
-}
-
-// check and waits till conn's fd is readable
-func connReadCheck2(conn net.Conn) error {
 	var sysErr error
 
 	sysConn, ok := conn.(syscall.Conn)

--- a/pkg/pillar/pubsub/socketdriver/publish.go
+++ b/pkg/pillar/pubsub/socketdriver/publish.go
@@ -150,7 +150,7 @@ func (s *Publisher) serveConnection(conn net.Conn, instance int) {
 	sentRestarted := false
 
 	// wait for readable conn
-	if err := connReadCheck2(conn); err != nil {
+	if err := connReadCheck(conn); err != nil {
 		log.Errorf("serveConnection(%s/%d) exception  while connReadCheck : %v", s.name, instance, err)
 		return
 	}

--- a/pkg/pillar/pubsub/socketdriver/subscribe.go
+++ b/pkg/pillar/pubsub/socketdriver/subscribe.go
@@ -166,7 +166,7 @@ func (s *Subscriber) connectAndRead() (string, string, []byte) {
 		}
 
 		// wait for readable conn
-		if err := connReadCheck2(s.sock); err != nil {
+		if err := connReadCheck(s.sock); err != nil {
 			errStr := fmt.Sprintf("connectAndRead(%s): exception  while connReadCheck%s",
 				s.name, err)
 			log.Errorln(errStr)


### PR DESCRIPTION
Instead of creating a new buffer for every request, we can use cached buffers.
 
Signed-off-by: adarsh-zededa <adarsh@zededa.com>