### PR TITLE
Reduce use of logrus; use base.LogObject instead

### DIFF
--- a/pkg/pillar/types/assignableadapters.go
+++ b/pkg/pillar/types/assignableadapters.go
@@ -87,6 +87,7 @@ var nilUUID = uuid.UUID{}
 // HasAdapterChanged - We store each Physical Adapter using the IoBundle object.
 // Compares IoBundle with Physical adapter and returns if they are the Same
 // or the Physical Adapter has changed.
+// XXX pass log argument
 func (ib IoBundle) HasAdapterChanged(phyAdapter PhysicalIOAdapter) bool {
 	if IoType(phyAdapter.Ptype) != ib.Type {
 		log.Infof("Type changed from %d to %d", ib.Type, phyAdapter.Ptype)

--- a/pkg/pillar/types/blob.go
+++ b/pkg/pillar/types/blob.go
@@ -6,7 +6,6 @@ package types
 import (
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	uuid "github.com/satori/go.uuid"
-	log "github.com/sirupsen/logrus"
 )
 
 // BlobStatus status of a downloaded blob
@@ -84,7 +83,7 @@ func (status BlobStatus) LogModify(old interface{}) {
 
 	oldStatus, ok := old.(BlobStatus)
 	if !ok {
-		log.Errorf("LogModify: Old object interface passed is not of BlobStatus type")
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of BlobStatus type")
 	}
 	if oldStatus.State != status.State ||
 		oldStatus.RefCount != status.RefCount ||

--- a/pkg/pillar/types/contenttreetypes.go
+++ b/pkg/pillar/types/contenttreetypes.go
@@ -9,7 +9,6 @@ import (
 	zconfig "github.com/lf-edge/eve/api/go/config"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	uuid "github.com/satori/go.uuid"
-	log "github.com/sirupsen/logrus"
 )
 
 // ContentTreeConfig specifies the needed information for content tree
@@ -55,7 +54,7 @@ func (config ContentTreeConfig) LogModify(old interface{}) {
 
 	oldConfig, ok := old.(ContentTreeConfig)
 	if !ok {
-		log.Errorf("LogModify: Old object interface passed is not of ContentTreeConfig type")
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of ContentTreeConfig type")
 	}
 	if oldConfig.DatastoreID != config.DatastoreID ||
 		oldConfig.RelativeURL != config.RelativeURL ||
@@ -181,7 +180,7 @@ func (status ContentTreeStatus) LogModify(old interface{}) {
 
 	oldStatus, ok := old.(ContentTreeStatus)
 	if !ok {
-		log.Errorf("LogModify: Old object interface passed is not of ContentTreeStatus type")
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of ContentTreeStatus type")
 	}
 	if oldStatus.ContentSha256 != status.ContentSha256 ||
 		oldStatus.MaxDownloadSize != status.MaxDownloadSize ||

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -9,7 +9,6 @@ import (
 
 	zconfig "github.com/lf-edge/eve/api/go/config"
 	"github.com/lf-edge/eve/pkg/pillar/base"
-	log "github.com/sirupsen/logrus"
 )
 
 // The information DomainManager needs to boot and halt domains
@@ -71,7 +70,7 @@ func (config DomainConfig) LogModify(old interface{}) {
 
 	oldConfig, ok := old.(DomainConfig)
 	if !ok {
-		log.Errorf("LogModify: Old object interface passed is not of DomainConfig type")
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of DomainConfig type")
 	}
 	if oldConfig.Activate != config.Activate ||
 		oldConfig.EnableVnc != config.EnableVnc {
@@ -217,7 +216,7 @@ func (status DomainStatus) LogModify(old interface{}) {
 
 	oldStatus, ok := old.(DomainStatus)
 	if !ok {
-		log.Errorf("LogModify: Old object interface passed is not of DomainStatus type")
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of DomainStatus type")
 	}
 	if oldStatus.State != status.State ||
 		oldStatus.Activated != status.Activated {

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -183,18 +183,6 @@ func (status DomainStatus) Key() string {
 	return status.UUIDandVersion.UUID.String()
 }
 
-func (status DomainStatus) CheckPendingAdd() bool {
-	return status.PendingAdd
-}
-
-func (status DomainStatus) CheckPendingModify() bool {
-	return status.PendingModify
-}
-
-func (status DomainStatus) CheckPendingDelete() bool {
-	return status.PendingDelete
-}
-
 func (status DomainStatus) Pending() bool {
 	return status.PendingAdd || status.PendingModify || status.PendingDelete
 }

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -42,16 +42,6 @@ func (config DomainConfig) Key() string {
 	return config.UUIDandVersion.UUID.String()
 }
 
-func (config DomainConfig) VerifyFilename(fileName string) bool {
-	expect := config.Key() + ".json"
-	ret := expect == fileName
-	if !ret {
-		log.Errorf("Mismatch between filename and contained uuid: %s vs. %s\n",
-			fileName, expect)
-	}
-	return ret
-}
-
 // VirtualizationModeOrDefault sets the default to PV
 func (config DomainConfig) VirtualizationModeOrDefault() VmMode {
 	switch config.VirtualizationMode {
@@ -191,16 +181,6 @@ type DomainStatus struct {
 
 func (status DomainStatus) Key() string {
 	return status.UUIDandVersion.UUID.String()
-}
-
-func (status DomainStatus) VerifyFilename(fileName string) bool {
-	expect := status.Key() + ".json"
-	ret := expect == fileName
-	if !ret {
-		log.Errorf("Mismatch between filename and contained uuid: %s vs. %s\n",
-			fileName, expect)
-	}
-	return ret
 }
 
 func (status DomainStatus) CheckPendingAdd() bool {

--- a/pkg/pillar/types/downloadertypes.go
+++ b/pkg/pillar/types/downloadertypes.go
@@ -28,16 +28,6 @@ func (config DownloaderConfig) Key() string {
 	return config.ImageSha256
 }
 
-func (config DownloaderConfig) VerifyFilename(fileName string) bool {
-	expect := config.Key() + ".json"
-	ret := expect == fileName
-	if !ret {
-		log.Errorf("Mismatch between filename and contained key: %s vs. %s\n",
-			fileName, expect)
-	}
-	return ret
-}
-
 // LogCreate :
 func (config DownloaderConfig) LogCreate() {
 	logObject := base.NewLogObject(base.DownloaderConfigLogType, config.Name,
@@ -131,16 +121,6 @@ type DownloaderStatus struct {
 
 func (status DownloaderStatus) Key() string {
 	return status.ImageSha256
-}
-
-func (status DownloaderStatus) VerifyFilename(fileName string) bool {
-	expect := status.Key() + ".json"
-	ret := expect == fileName
-	if !ret {
-		log.Errorf("Mismatch between filename and contained key: %s vs. %s\n",
-			fileName, expect)
-	}
-	return ret
 }
 
 func (status DownloaderStatus) CheckPendingAdd() bool {

--- a/pkg/pillar/types/downloadertypes.go
+++ b/pkg/pillar/types/downloadertypes.go
@@ -123,18 +123,6 @@ func (status DownloaderStatus) Key() string {
 	return status.ImageSha256
 }
 
-func (status DownloaderStatus) CheckPendingAdd() bool {
-	return status.PendingAdd
-}
-
-func (status DownloaderStatus) CheckPendingModify() bool {
-	return status.PendingModify
-}
-
-func (status DownloaderStatus) CheckPendingDelete() bool {
-	return status.PendingDelete
-}
-
 func (status DownloaderStatus) Pending() bool {
 	return status.PendingAdd || status.PendingModify || status.PendingDelete
 }

--- a/pkg/pillar/types/downloadertypes.go
+++ b/pkg/pillar/types/downloadertypes.go
@@ -49,7 +49,7 @@ func (config DownloaderConfig) LogModify(old interface{}) {
 
 	oldConfig, ok := old.(DownloaderConfig)
 	if !ok {
-		log.Errorf("LogModify: Old object interface passed is not of DownloaderConfig type")
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of DownloaderConfig type")
 	}
 	if oldConfig.Target != config.Target ||
 		oldConfig.DatastoreID != config.DatastoreID ||
@@ -163,7 +163,7 @@ func (status DownloaderStatus) LogModify(old interface{}) {
 
 	oldStatus, ok := old.(DownloaderStatus)
 	if !ok {
-		log.Errorf("LogModify: Old object interface passed is not of DownloaderStatus type")
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of DownloaderStatus type")
 	}
 	if oldStatus.State != status.State ||
 		oldStatus.RefCount != status.RefCount ||

--- a/pkg/pillar/types/eidtypes.go
+++ b/pkg/pillar/types/eidtypes.go
@@ -75,18 +75,6 @@ func (status EIDStatus) Key() string {
 		status.UUIDandVersion.UUID.String(), status.IID)
 }
 
-func (status EIDStatus) CheckPendingAdd() bool {
-	return status.PendingAdd
-}
-
-func (status EIDStatus) CheckPendingModify() bool {
-	return status.PendingModify
-}
-
-func (status EIDStatus) CheckPendingDelete() bool {
-	return status.PendingDelete
-}
-
 func (status EIDStatus) Pending() bool {
 	return status.PendingAdd || status.PendingModify || status.PendingDelete
 }

--- a/pkg/pillar/types/eidtypes.go
+++ b/pkg/pillar/types/eidtypes.go
@@ -8,7 +8,6 @@ package types
 
 import (
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"net"
 	"time"
 )
@@ -46,16 +45,6 @@ func (config EIDConfig) Key() string {
 		config.UUIDandVersion.UUID.String(), config.IID)
 }
 
-func (config EIDConfig) VerifyFilename(fileName string) bool {
-	expect := config.Key() + ".json"
-	ret := expect == fileName
-	if !ret {
-		log.Errorf("Mismatch between filename and contained uuid/iid: %s vs. %s\n",
-			fileName, expect)
-	}
-	return ret
-}
-
 // Indexed by UUID plus IID. Version is not part of the index.
 type EIDStatus struct {
 	UUIDandVersion UUIDandVersion
@@ -84,16 +73,6 @@ func EidKey(uuidAndVers UUIDandVersion, iid uint32) string {
 func (status EIDStatus) Key() string {
 	return fmt.Sprintf("%s:%d",
 		status.UUIDandVersion.UUID.String(), status.IID)
-}
-
-func (status EIDStatus) VerifyFilename(fileName string) bool {
-	expect := status.Key() + ".json"
-	ret := expect == fileName
-	if !ret {
-		log.Errorf("Mismatch between filename and contained uuid/iid: %s vs. %s\n",
-			fileName, expect)
-	}
-	return ret
 }
 
 func (status EIDStatus) CheckPendingAdd() bool {

--- a/pkg/pillar/types/exectypes.go
+++ b/pkg/pillar/types/exectypes.go
@@ -5,10 +5,6 @@
 
 package types
 
-import (
-	log "github.com/sirupsen/logrus"
-)
-
 // ExecConfig contains a command to be executed
 // The Caller+Sequence is assumed to be unique. When an item is added or
 // modified in Caller or Sequence, the command is executed.
@@ -28,17 +24,6 @@ func (config ExecConfig) Key() string {
 	return config.Caller
 }
 
-// VerifyFilename returns a json filename
-func (config ExecConfig) VerifyFilename(fileName string) bool {
-	expect := config.Key() + ".json"
-	ret := expect == fileName
-	if !ret {
-		log.Errorf("Mismatch between filename and contained Key: %s vs. %s\n",
-			fileName, expect)
-	}
-	return ret
-}
-
 // ExecStatus contains the results of executing a command
 // The Caller+Sequence is the unique Key
 type ExecStatus struct {
@@ -52,15 +37,4 @@ type ExecStatus struct {
 // Key returns the pubsub key
 func (status ExecStatus) Key() string {
 	return status.Caller
-}
-
-// VerifyFilename returns a json filename
-func (status ExecStatus) VerifyFilename(fileName string) bool {
-	expect := status.Key() + ".json"
-	ret := expect == fileName
-	if !ret {
-		log.Errorf("Mismatch between filename and contained Key: %s vs. %s\n",
-			fileName, expect)
-	}
-	return ret
 }

--- a/pkg/pillar/types/resolvertypes.go
+++ b/pkg/pillar/types/resolvertypes.go
@@ -28,17 +28,6 @@ func (config ResolveConfig) Key() string {
 	return fmt.Sprintf("%s+%s+%v", config.DatastoreID.String(), config.Name, config.Counter)
 }
 
-// VerifyFilename will verify the key name
-func (config ResolveConfig) VerifyFilename(fileName string) bool {
-	expect := config.Key() + ".json"
-	ret := expect == fileName
-	if !ret {
-		log.Errorf("Mismatch between filename and contained key: %s vs. %s\n",
-			fileName, expect)
-	}
-	return ret
-}
-
 // LogCreate :
 func (config ResolveConfig) LogCreate() {
 	logObject := base.NewLogObject(base.ResolveConfigLogType, config.Name,
@@ -89,17 +78,6 @@ type ResolveStatus struct {
 // to differentiate different config
 func (status ResolveStatus) Key() string {
 	return fmt.Sprintf("%s+%s+%v", status.DatastoreID.String(), status.Name, status.Counter)
-}
-
-// VerifyFilename will verify the key name
-func (status ResolveStatus) VerifyFilename(fileName string) bool {
-	expect := status.Key() + ".json"
-	ret := expect == fileName
-	if !ret {
-		log.Errorf("Mismatch between filename and contained key: %s vs. %s\n",
-			fileName, expect)
-	}
-	return ret
 }
 
 // LogCreate :

--- a/pkg/pillar/types/resolvertypes.go
+++ b/pkg/pillar/types/resolvertypes.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	uuid "github.com/satori/go.uuid"
-	log "github.com/sirupsen/logrus"
 )
 
 // ResolveConfig key/index to this is the combination of
@@ -99,7 +98,7 @@ func (status ResolveStatus) LogModify(old interface{}) {
 
 	oldStatus, ok := old.(ResolveStatus)
 	if !ok {
-		log.Errorf("LogModify: Old object interface passed is not of ResolveStatus type")
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of ResolveStatus type")
 	}
 	if oldStatus.ImageSha256 != status.ImageSha256 ||
 		oldStatus.RetryCount != status.RetryCount {

--- a/pkg/pillar/types/verifiertypes.go
+++ b/pkg/pillar/types/verifiertypes.go
@@ -7,7 +7,6 @@ package types
 
 import (
 	"github.com/lf-edge/eve/pkg/pillar/base"
-	log "github.com/sirupsen/logrus"
 )
 
 // XXX more than images; rename type and clean up comments
@@ -57,7 +56,7 @@ func (config VerifyImageConfig) LogModify(old interface{}) {
 
 	oldConfig, ok := old.(VerifyImageConfig)
 	if !ok {
-		log.Errorf("LogModify: Old object interface passed is not of VerifyImageConfig type")
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of VerifyImageConfig type")
 	}
 	if oldConfig.RefCount != config.RefCount ||
 		oldConfig.Expired != config.Expired {
@@ -130,7 +129,7 @@ func (status VerifyImageStatus) LogModify(old interface{}) {
 
 	oldStatus, ok := old.(VerifyImageStatus)
 	if !ok {
-		log.Errorf("LogModify: Old object interface passed is not of VerifyImageStatus type")
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of VerifyImageStatus type")
 	}
 	if oldStatus.State != status.State ||
 		oldStatus.RefCount != status.RefCount ||

--- a/pkg/pillar/types/verifiertypes.go
+++ b/pkg/pillar/types/verifiertypes.go
@@ -179,18 +179,6 @@ func (status VerifyImageStatus) LogKey() string {
 	return string(base.VerifyImageStatusLogType) + "-" + status.Key()
 }
 
-func (status VerifyImageStatus) CheckPendingAdd() bool {
-	return status.PendingAdd
-}
-
-func (status VerifyImageStatus) CheckPendingModify() bool {
-	return status.PendingModify
-}
-
-func (status VerifyImageStatus) CheckPendingDelete() bool {
-	return status.PendingDelete
-}
-
 func (status VerifyImageStatus) Pending() bool {
 	return status.PendingAdd || status.PendingModify || status.PendingDelete
 }

--- a/pkg/pillar/types/volumetypes.go
+++ b/pkg/pillar/types/volumetypes.go
@@ -11,7 +11,6 @@ import (
 	zconfig "github.com/lf-edge/eve/api/go/config"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	uuid "github.com/satori/go.uuid"
-	log "github.com/sirupsen/logrus"
 )
 
 // VolumeConfig specifies the needed information for volumes
@@ -53,7 +52,7 @@ func (config VolumeConfig) LogModify(old interface{}) {
 
 	oldConfig, ok := old.(VolumeConfig)
 	if !ok {
-		log.Errorf("LogModify: Old object interface passed is not of VolumeConfig type")
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of VolumeConfig type")
 	}
 	if oldConfig.ContentID != config.ContentID ||
 		oldConfig.MaxVolSize != config.MaxVolSize ||
@@ -158,7 +157,7 @@ func (status VolumeStatus) LogModify(old interface{}) {
 
 	oldStatus, ok := old.(VolumeStatus)
 	if !ok {
-		log.Errorf("LogModify: Old object interface passed is not of VolumeStatus type")
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of VolumeStatus type")
 	}
 	if oldStatus.ContentID != status.ContentID ||
 		oldStatus.MaxVolSize != status.MaxVolSize ||
@@ -242,7 +241,7 @@ func (config VolumeRefConfig) LogModify(old interface{}) {
 
 	oldConfig, ok := old.(VolumeRefConfig)
 	if !ok {
-		log.Errorf("LogModify: Old object interface passed is not of VolumeRefConfig type")
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of VolumeRefConfig type")
 	}
 	if oldConfig.RefCount != config.RefCount {
 		logObject.CloneAndAddField("refcount-int64", config.RefCount).
@@ -330,7 +329,7 @@ func (status VolumeRefStatus) LogModify(old interface{}) {
 
 	oldStatus, ok := old.(VolumeRefStatus)
 	if !ok {
-		log.Errorf("LogModify: Old object interface passed is not of VolumeRefStatus type")
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of VolumeRefStatus type")
 	}
 	if oldStatus.RefCount != status.RefCount ||
 		oldStatus.State != status.State ||

--- a/pkg/pillar/types/zboottypes.go
+++ b/pkg/pillar/types/zboottypes.go
@@ -5,7 +5,6 @@ package types
 
 import (
 	"github.com/lf-edge/eve/pkg/pillar/base"
-	log "github.com/sirupsen/logrus"
 )
 
 // ZbootConfig contains information fed from zedagent to baseosmgr.
@@ -38,7 +37,7 @@ func (config ZbootConfig) LogModify(old interface{}) {
 
 	oldConfig, ok := old.(ZbootConfig)
 	if !ok {
-		log.Errorf("LogModify: Old object interface passed is not of ZbootConfig type")
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of ZbootConfig type")
 	}
 	if oldConfig.TestComplete != config.TestComplete {
 
@@ -98,7 +97,7 @@ func (status ZbootStatus) LogModify(old interface{}) {
 
 	oldStatus, ok := old.(ZbootStatus)
 	if !ok {
-		log.Errorf("LogModify: Old object interface passed is not of ZbootStatus type")
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of ZbootStatus type")
 	}
 	if oldStatus.PartitionState != status.PartitionState ||
 		oldStatus.CurrentPartition != status.CurrentPartition ||

--- a/pkg/pillar/types/zedagenttypes.go
+++ b/pkg/pillar/types/zedagenttypes.go
@@ -38,16 +38,6 @@ func (config BaseOsConfig) Key() string {
 	return config.UUIDandVersion.UUID.String()
 }
 
-func (config BaseOsConfig) VerifyFilename(fileName string) bool {
-	expect := config.Key() + ".json"
-	ret := expect == fileName
-	if !ret {
-		log.Errorf("Mismatch between filename and contained uuid: %s vs. %s\n",
-			fileName, expect)
-	}
-	return ret
-}
-
 // LogCreate :
 func (config BaseOsConfig) LogCreate() {
 	logObject := base.NewLogObject(base.BaseOsConfigLogType, config.BaseOsVersion,
@@ -116,16 +106,6 @@ type BaseOsStatus struct {
 
 func (status BaseOsStatus) Key() string {
 	return status.UUIDandVersion.UUID.String()
-}
-
-func (status BaseOsStatus) VerifyFilename(fileName string) bool {
-	expect := status.Key() + ".json"
-	ret := expect == fileName
-	if !ret {
-		log.Errorf("Mismatch between filename and contained uuid: %s vs. %s\n",
-			fileName, expect)
-	}
-	return ret
 }
 
 func (status BaseOsStatus) CheckPendingAdd() bool {
@@ -206,16 +186,6 @@ func (config CertObjConfig) Key() string {
 	return config.UUIDandVersion.UUID.String()
 }
 
-func (config CertObjConfig) VerifyFilename(fileName string) bool {
-	expect := config.Key() + ".json"
-	ret := expect == fileName
-	if !ret {
-		log.Errorf("Mismatch between filename and contained uuid: %s vs. %s\n",
-			fileName, expect)
-	}
-	return ret
-}
-
 // Indexed by UUIDandVersion as above
 // XXX shouldn't it be keyed by safename
 type CertObjStatus struct {
@@ -230,16 +200,6 @@ type CertObjStatus struct {
 
 func (status CertObjStatus) Key() string {
 	return status.UUIDandVersion.UUID.String()
-}
-
-func (status CertObjStatus) VerifyFilename(fileName string) bool {
-	expect := status.Key() + ".json"
-	ret := expect == fileName
-	if !ret {
-		log.Errorf("Mismatch between filename and contained uuid: %s vs. %s\n",
-			fileName, expect)
-	}
-	return ret
 }
 
 func (status CertObjStatus) CheckPendingAdd() bool {

--- a/pkg/pillar/types/zedagenttypes.go
+++ b/pkg/pillar/types/zedagenttypes.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/satori/go.uuid"
-	log "github.com/sirupsen/logrus"
 )
 
 type OsVerParams struct {
@@ -56,7 +55,7 @@ func (config BaseOsConfig) LogModify(old interface{}) {
 
 	oldConfig, ok := old.(BaseOsConfig)
 	if !ok {
-		log.Errorf("LogModify: Old object interface passed is not of BaseOsConfig type")
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of BaseOsConfig type")
 	}
 	if oldConfig.Activate != config.Activate {
 
@@ -126,7 +125,7 @@ func (status BaseOsStatus) LogModify(old interface{}) {
 
 	oldStatus, ok := old.(BaseOsStatus)
 	if !ok {
-		log.Errorf("LogModify: Old object interface passed is not of BaseOsStatus type")
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of BaseOsStatus type")
 	}
 	if oldStatus.State != status.State {
 

--- a/pkg/pillar/types/zedagenttypes.go
+++ b/pkg/pillar/types/zedagenttypes.go
@@ -108,18 +108,6 @@ func (status BaseOsStatus) Key() string {
 	return status.UUIDandVersion.UUID.String()
 }
 
-func (status BaseOsStatus) CheckPendingAdd() bool {
-	return false
-}
-
-func (status BaseOsStatus) CheckPendingModify() bool {
-	return false
-}
-
-func (status BaseOsStatus) CheckPendingDelete() bool {
-	return false
-}
-
 // LogCreate :
 func (status BaseOsStatus) LogCreate() {
 	logObject := base.NewLogObject(base.BaseOsStatusLogType, status.BaseOsVersion,
@@ -200,18 +188,6 @@ type CertObjStatus struct {
 
 func (status CertObjStatus) Key() string {
 	return status.UUIDandVersion.UUID.String()
-}
-
-func (status CertObjStatus) CheckPendingAdd() bool {
-	return false
-}
-
-func (status CertObjStatus) CheckPendingModify() bool {
-	return false
-}
-
-func (status CertObjStatus) CheckPendingDelete() bool {
-	return false
 }
 
 // getCertObjStatus finds a certificate, and returns the status

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -136,16 +136,6 @@ func (config AppInstanceConfig) Key() string {
 	return config.UUIDandVersion.UUID.String()
 }
 
-func (config AppInstanceConfig) VerifyFilename(fileName string) bool {
-	expect := config.Key() + ".json"
-	ret := expect == fileName
-	if !ret {
-		log.Errorf("Mismatch between filename and contained uuid: %s vs. %s\n",
-			fileName, expect)
-	}
-	return ret
-}
-
 // Indexed by UUIDandVersion as above
 type AppInstanceStatus struct {
 	UUIDandVersion      UUIDandVersion
@@ -254,16 +244,6 @@ const (
 
 func (status AppInstanceStatus) Key() string {
 	return status.UUIDandVersion.UUID.String()
-}
-
-func (status AppInstanceStatus) VerifyFilename(fileName string) bool {
-	expect := status.Key() + ".json"
-	ret := expect == fileName
-	if !ret {
-		log.Errorf("Mismatch between filename and contained uuid: %s vs. %s\n",
-			fileName, expect)
-	}
-	return ret
 }
 
 func (status AppInstanceStatus) CheckPendingAdd() bool {

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -246,18 +246,6 @@ func (status AppInstanceStatus) Key() string {
 	return status.UUIDandVersion.UUID.String()
 }
 
-func (status AppInstanceStatus) CheckPendingAdd() bool {
-	return false
-}
-
-func (status AppInstanceStatus) CheckPendingModify() bool {
-	return false
-}
-
-func (status AppInstanceStatus) CheckPendingDelete() bool {
-	return false
-}
-
 // GetAppInterfaceList is a helper function to get all the vifnames
 func (status AppInstanceStatus) GetAppInterfaceList() []string {
 

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	uuid "github.com/satori/go.uuid"
-	log "github.com/sirupsen/logrus"
 )
 
 type UrlCloudCfg struct {
@@ -102,7 +101,7 @@ func (config AppInstanceConfig) LogModify(old interface{}) {
 
 	oldConfig, ok := old.(AppInstanceConfig)
 	if !ok {
-		log.Errorf("LogModify: Old object interface passed is not of AppInstanceConfig type")
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of AppInstanceConfig type")
 	}
 	if oldConfig.Activate != config.Activate ||
 		oldConfig.RemoteConsole != config.RemoteConsole {
@@ -188,7 +187,7 @@ func (status AppInstanceStatus) LogModify(old interface{}) {
 
 	oldStatus, ok := old.(AppInstanceStatus)
 	if !ok {
-		log.Errorf("LogModify: Old object interface passed is not of AppInstanceStatus type")
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of AppInstanceStatus type")
 	}
 	if oldStatus.State != status.State ||
 		oldStatus.RestartInprogress != status.RestartInprogress ||

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -51,18 +51,6 @@ func (config *AppNetworkConfig) IsNetworkUsed(network uuid.UUID) bool {
 	return false
 }
 
-func (status AppNetworkStatus) CheckPendingAdd() bool {
-	return status.PendingAdd
-}
-
-func (status AppNetworkStatus) CheckPendingModify() bool {
-	return status.PendingModify
-}
-
-func (status AppNetworkStatus) CheckPendingDelete() bool {
-	return status.PendingDelete
-}
-
 func (status AppNetworkStatus) Pending() bool {
 	return status.PendingAdd || status.PendingModify || status.PendingDelete
 }

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -31,16 +31,6 @@ func (config AppNetworkConfig) Key() string {
 	return config.UUIDandVersion.UUID.String()
 }
 
-func (config AppNetworkConfig) VerifyFilename(fileName string) bool {
-	expect := config.Key() + ".json"
-	ret := expect == fileName
-	if !ret {
-		log.Errorf("Mismatch between filename and contained uuid: %s vs. %s\n",
-			fileName, expect)
-	}
-	return ret
-}
-
 func (config *AppNetworkConfig) getUnderlayConfig(
 	network uuid.UUID) *UnderlayNetworkConfig {
 	for i := range config.UnderlayNetworkList {
@@ -97,17 +87,6 @@ type AppNetworkStatus struct {
 
 func (status AppNetworkStatus) Key() string {
 	return status.UUIDandVersion.UUID.String()
-}
-
-func (status AppNetworkStatus) VerifyFilename(fileName string) bool {
-	expect := status.Key() + ".json"
-	ret := expect == fileName
-	if !ret {
-		log.Errorf("Mismatch between filename and contained uuid: %s vs. %s\n",
-			fileName, expect)
-	}
-	return ret
-
 }
 
 // AppContainerMetrics - App Container Metrics

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -196,7 +196,8 @@ func (config DevicePortConfigList) LogModify(old interface{}) {
 
 	oldConfig, ok := old.(DevicePortConfigList)
 	if !ok {
-		log.Errorf("LogModify: Old object interface passed is not of DevicePortConfigList type")
+		logObject.Clone().Errorf("LogModify: Old object interface passed is not of DevicePortConfigList type")
+		return
 	}
 	if oldConfig.CurrentIndex != config.CurrentIndex ||
 		len(oldConfig.PortConfigList) != len(config.PortConfigList) {
@@ -315,7 +316,7 @@ func (config DevicePortConfig) LogModify(old interface{}) {
 
 	oldConfig, ok := old.(DevicePortConfig)
 	if !ok {
-		log.Errorf("LogModify: Old object interface passed is not of DevicePortConfig type")
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of DevicePortConfig type")
 	}
 	if len(oldConfig.Ports) != len(config.Ports) ||
 		oldConfig.LastFailed != config.LastFailed ||
@@ -810,7 +811,7 @@ func (status DeviceNetworkStatus) LogModify(old interface{}) {
 
 	oldStatus, ok := old.(DeviceNetworkStatus)
 	if !ok {
-		log.Errorf("LogModify: Old object interface passed is not of DeviceNetworkStatus type")
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of DeviceNetworkStatus type")
 	}
 	if oldStatus.Testing != status.Testing ||
 		oldStatus.State != status.State ||


### PR DESCRIPTION
This is some cleanup. Only content change is to use LogObject and a Fatal for these kind of errors:
		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of BlobStatus type")

@gkodali-zededa does that seem reasonable?