### PR TITLE
Fix publishEdgeNodeCertsToController trying to send empty list to EVC

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -287,6 +287,11 @@ func publishEdgeNodeCertsToController(ctx *zedagentContext) {
 
 	sub := ctx.subEdgeNodeCert
 	items := sub.GetAll()
+	if len(items) == 0 {
+		//Nothing to be sent
+		return
+	}
+
 	for _, item := range items {
 		config := item.(types.EdgeNodeCert)
 		certMsg := zcert.ZCert{


### PR DESCRIPTION
- publishEdgeNodeCertsToController is called once during startup
  to send any pending certs. But we should check and avoid sending
  if there are no certificates. Otherwise this will be re-attempted
  indefinitely from zedcloud/send.go, causing noise in the logs

Signed-off-by: Hariharasubramanian C S <cshari@zededa.com>