### PR TITLE
remove import of pillar/cmd/tpmmgr

### DIFF
--- a/pkg/pillar/cipher/handlecipher.go
+++ b/pkg/pillar/cipher/handlecipher.go
@@ -15,7 +15,7 @@ import (
 
 	zconfig "github.com/lf-edge/eve/api/go/config"
 	zcommon "github.com/lf-edge/eve/api/go/evecommon"
-	"github.com/lf-edge/eve/pkg/pillar/cmd/tpmmgr"
+	etpm "github.com/lf-edge/eve/pkg/pillar/evetpm"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	log "github.com/sirupsen/logrus"
@@ -175,7 +175,7 @@ func decryptCipherBlockWithECDH(ctx *DecryptCipherContext,
 			return []byte{}, errors.New("Invalid Initial value")
 		}
 		clearData := make([]byte, len(cipherBlock.CipherData))
-		err = tpmmgr.DecryptSecretWithEcdhKey(cert.X, cert.Y,
+		err = etpm.DecryptSecretWithEcdhKey(cert.X, cert.Y,
 			edgeNodeCert, cipherBlock.InitialValue, cipherBlock.CipherData, clearData)
 		if err != nil {
 			errStr := fmt.Sprintf("Decryption failed with error %v\n", err)

--- a/pkg/pillar/cmd/tpmmgr/tpmmgr_test.go
+++ b/pkg/pillar/cmd/tpmmgr/tpmmgr_test.go
@@ -13,6 +13,8 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	etpm "github.com/lf-edge/eve/pkg/pillar/evetpm"
 )
 
 const ecdhCertPem = `
@@ -95,7 +97,8 @@ const (
 func TestSoftEcdh(t *testing.T) {
 	//Redirect ECDH cert/key files to test files
 	ecdhCertFile = testEcdhCertFile
-	ecdhKeyFile = testEcdhKeyFile
+	ecdhKeyFile := testEcdhKeyFile
+	etpm.SetECDHPrivateKeyFile(ecdhKeyFile)
 
 	err := ioutil.WriteFile(ecdhCertFile, []byte(ecdhCertPem), 0644)
 	if err != nil {
@@ -120,7 +123,7 @@ func TestGetPrivateKeyFromFile(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to create test ecdh key file: %v", err)
 	}
-	defer os.Remove(ecdhKeyFile)
+	defer os.Remove(testEcdhKeyFile)
 
 	err = ioutil.WriteFile(testDeviceKeyFile, []byte(deviceKeyPem), 0644)
 	if err != nil {
@@ -128,11 +131,11 @@ func TestGetPrivateKeyFromFile(t *testing.T) {
 	}
 	defer os.Remove(testDeviceKeyFile)
 
-	if _, err = getPrivateKeyFromFile(testEcdhKeyFile); err != nil {
+	if _, err = etpm.GetPrivateKeyFromFile(testEcdhKeyFile); err != nil {
 		t.Errorf("%v", err)
 	}
 
-	if _, err = getPrivateKeyFromFile(testDeviceKeyFile); err != nil {
+	if _, err = etpm.GetPrivateKeyFromFile(testDeviceKeyFile); err != nil {
 		t.Errorf("%v", err)
 	}
 }

--- a/pkg/pillar/evetpm/decrypt.go
+++ b/pkg/pillar/evetpm/decrypt.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package evetpm
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/elliptic"
+	"crypto/sha256"
+	"errors"
+	"math/big"
+
+	"github.com/google/go-tpm/tpm2"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	log "github.com/sirupsen/logrus"
+)
+
+//DecryptSecretWithEcdhKey recovers plaintext from the given ciphertext
+//X, Y are the Z point co-ordinates in Ellyptic Curve Diffie Hellman(ECDH) Exchange
+//edgeNodeCert points to the certificate that Controller used to calculate the shared secret
+//iv is the Initial Value used in the ECDH exchange.
+//Sha256FromECPoint() is used as KDF on the shared secret, and the derived key is used
+//in aesDecrypt(), to apply the cipher on ciphertext, and recover plaintext
+func DecryptSecretWithEcdhKey(X, Y *big.Int, edgeNodeCert *types.EdgeNodeCert,
+	iv, ciphertext, plaintext []byte) error {
+	if (X == nil) || (Y == nil) || (edgeNodeCert == nil) {
+		return errors.New("DecryptSecretWithEcdhKey needs non-empty X, Y and edgeNodeCert")
+	}
+	decryptKey, err := getDecryptKey(X, Y, edgeNodeCert)
+	if err != nil {
+		log.Errorf("getDecryptKey failed: %v", err)
+		return err
+	}
+	return aesDecrypt(plaintext, ciphertext, decryptKey[:], iv)
+}
+
+//getDecryptKey : uses the given params to construct the AES decryption Key
+func getDecryptKey(X, Y *big.Int, edgeNodeCert *types.EdgeNodeCert) ([32]byte, error) {
+	if !IsTpmEnabled() || !edgeNodeCert.IsTpm {
+		//Either TPM is not enabled, or for some reason we are not using TPM for ECDH
+		//Look for soft cert/key
+		privateKey, err := getECDHPrivateKey()
+		if err != nil {
+			log.Errorf("getECDHPrivateKey failed: %v", err)
+			return [32]byte{}, err
+		}
+		X, Y := elliptic.P256().Params().ScalarMult(X, Y, privateKey.D.Bytes())
+		decryptKey := Sha256FromECPoint(X, Y)
+		return decryptKey, nil
+	}
+	rw, err := tpm2.OpenTPM(TpmDevicePath)
+	if err != nil {
+		log.Errorf("TPM open failed: %v", err)
+		return [32]byte{}, err
+	}
+	defer rw.Close()
+
+	p := tpm2.ECPoint{XRaw: X.Bytes(), YRaw: Y.Bytes()}
+
+	//Recover the key, and decrypt the message
+	z, err := tpm2.RecoverSharedECCSecret(rw, TpmEcdhKeyHdl, "", p)
+	if err != nil {
+		log.Errorf("recovering Shared Secret failed: %v", err)
+		return [32]byte{}, err
+	}
+	decryptKey := Sha256FromECPoint(z.X(), z.Y())
+	return decryptKey, nil
+}
+
+func aesDecrypt(plaintext, ciphertext, key, iv []byte) error {
+	aesBlockDecrypter, err := aes.NewCipher([]byte(key))
+	if err != nil {
+		log.Errorf("creating aes new cipher failed: %v", err)
+		return err
+	}
+	aesDecrypter := cipher.NewCFBDecrypter(aesBlockDecrypter, iv)
+	aesDecrypter.XORKeyStream(plaintext, ciphertext)
+	return nil
+}
+
+// Sha256FromECPoint is the KDF
+func Sha256FromECPoint(X, Y *big.Int) [32]byte {
+	var bytes = make([]byte, 0)
+	bytes = append(bytes, X.Bytes()...)
+	bytes = append(bytes, Y.Bytes()...)
+	return sha256.Sum256(bytes)
+}

--- a/pkg/pillar/evetpm/keys.go
+++ b/pkg/pillar/evetpm/keys.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package evetpm
+
+import (
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"io/ioutil"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// GetDevicePrivateKey is for a device with no TPM and get the file-based
+// device key
+func GetDevicePrivateKey() (*ecdsa.PrivateKey, error) {
+	return GetPrivateKeyFromFile(types.DeviceKeyName)
+}
+
+// device with no TPM, get the file based ECDH key
+func getECDHPrivateKey() (*ecdsa.PrivateKey, error) {
+	return GetPrivateKeyFromFile(EcdhKeyFile)
+}
+
+// SetECDHPrivateKeyFile is used by tpmmgr_test.go
+func SetECDHPrivateKeyFile(filename string) {
+	EcdhKeyFile = filename
+}
+
+// GetPrivateKeyFromFile reads a private key file on a device with no TPM
+func GetPrivateKeyFromFile(keyFile string) (*ecdsa.PrivateKey, error) {
+	keyPEMBlock, err := ioutil.ReadFile(keyFile)
+	if err != nil {
+		return nil, err
+	}
+	var keyDERBlock *pem.Block
+	keyDERBlock, keyPEMBlock = pem.Decode(keyPEMBlock)
+	if keyDERBlock == nil {
+		return nil, errors.New("No valid private key found")
+	}
+	//Expect it to be "EC PRIVATE KEY" format
+	privateKey, err := x509.ParseECPrivateKey(keyDERBlock.Bytes)
+	if err == nil {
+		return privateKey, nil
+	}
+	//Try "PRIVATE KEY" format, as a fallback
+	parsedKey, err := x509.ParsePKCS8PrivateKey(keyDERBlock.Bytes)
+	if err == nil {
+		var pkey *ecdsa.PrivateKey
+		var ok bool
+		if pkey, ok = parsedKey.(*ecdsa.PrivateKey); !ok {
+			return nil, errors.New("Private key is not ecdsa type")
+		}
+		return pkey, nil
+	}
+	return nil, err
+}

--- a/pkg/pillar/evetpm/tpm.go
+++ b/pkg/pillar/evetpm/tpm.go
@@ -33,6 +33,9 @@ const (
 	//TpmPasswdHdl is the well known TPM NVIndex for TPM Credentials
 	TpmPasswdHdl tpmutil.Handle = 0x1600000
 
+	//TpmEcdhKeyHdl is the well known TPM permanent handle for ECDH key
+	TpmEcdhKeyHdl tpmutil.Handle = 0x81000005
+
 	//TpmCredentialsFileName is the file that holds the dynamically created TPM credentials
 	TpmCredentialsFileName = types.IdentityDirname + "/tpm_credential"
 
@@ -47,6 +50,10 @@ const (
 )
 
 var (
+	//EcdhKeyFile is the location of the ecdh private key
+	//on devices without a TPM. It is not a constant due to test usage
+	EcdhKeyFile = types.PersistConfigDir + "/ecdh.key.pem"
+
 	tpmHwInfo = ""
 )
 


### PR DESCRIPTION
One more location does this import.

I suspect that logically the tpmmgr_test code for the ECDH decryption should really be part of evetpm package (and that would remove the need for the Set function I had to introduce for test usage.