### PR TITLE
Temporarily reverting USB_STORAGE as a module since it breaks installer

### DIFF
--- a/pkg/new-kernel/kernel_config-5.4.x-x86_64
+++ b/pkg/new-kernel/kernel_config-5.4.x-x86_64
@@ -3579,7 +3579,7 @@ CONFIG_USB_WDM=m
 #
 # also be needed; see USB_STORAGE Help for more info
 #
-CONFIG_USB_STORAGE=m
+CONFIG_USB_STORAGE=y
 # CONFIG_USB_STORAGE_DEBUG is not set
 # CONFIG_USB_STORAGE_REALTEK is not set
 # CONFIG_USB_STORAGE_DATAFAB is not set


### PR DESCRIPTION
Signed-off-by: Roman Shaposhnik <rvs@zededa.com>