### PR TITLE
Running EVE from a single binary.

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -139,11 +139,11 @@ function set_rootfs_title {
 }
 
 function set_generic {
-   set_global hv_dom0_mem_settings "dom0_mem=1024M,max:1024M"
+   set_global hv_dom0_mem_settings "dom0_mem=650M,max:650M"
    set_global hv_dom0_cpu_settings "dom0_max_vcpus=1 dom0_vcpus_pin"
-   set_global hv_eve_mem_settings "eve_mem=650M,max:650M"
+   set_global hv_eve_mem_settings "eve_mem=350M,max:500M"
    set_global hv_eve_cpu_settings "eve_max_vcpus=1"
-   set_global hv_ctrd_mem_settings "ctrd_mem=300M,max:300M"
+   set_global hv_ctrd_mem_settings "ctrd_mem=250M,max:350M"
    set_global hv_ctrd_cpu_settings "ctrd_max_vcpus=1"
    set_global hv_platform_tweaks "smt=false"
 

--- a/pkg/pillar/base/logobjecttypes.go
+++ b/pkg/pillar/base/logobjecttypes.go
@@ -85,6 +85,8 @@ const (
 	VolumeRefConfigLogType LogObjectType = "volume_ref_config"
 	// VolumeRefStatusLogType:
 	VolumeRefStatusLogType LogObjectType = "volume_ref_status"
+	// ServiceInitType:
+	ServiceInitLogType LogObjectType = "service_init"
 )
 
 // RelationObjectType :

--- a/pkg/pillar/cmd/baseosmgr/baseosmgr.go
+++ b/pkg/pillar/cmd/baseosmgr/baseosmgr.go
@@ -53,7 +53,7 @@ var debug = false
 var debugOverride bool // From command line arg
 var log *base.LogObject
 
-func Run(ps *pubsub.PubSub) {
+func Run(ps *pubsub.PubSub) int {
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")
 	flag.Parse()
@@ -66,7 +66,7 @@ func Run(ps *pubsub.PubSub) {
 	}
 	if *versionPtr {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
-		return
+		return 0
 	}
 	// XXX Make logrus record a noticable global source
 	agentlog.Init("xyzzy-" + agentName)

--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -84,7 +84,7 @@ var (
 	log               *base.LogObject
 )
 
-func Run(ps *pubsub.PubSub) { //nolint:gocyclo
+func Run(ps *pubsub.PubSub) int { //nolint:gocyclo
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")
 	noPidPtr := flag.Bool("p", false, "Do not check for running client")
@@ -104,7 +104,7 @@ func Run(ps *pubsub.PubSub) { //nolint:gocyclo
 	args := flag.Args()
 	if versionFlag {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
-		return
+		return 0
 	}
 	// Sending json log format to stdout
 	// XXX Make logrus record a noticable global source
@@ -338,7 +338,7 @@ func Run(ps *pubsub.PubSub) { //nolint:gocyclo
 			if maxRetries != 0 && retryCount > maxRetries {
 				log.Errorf("Exceeded %d retries",
 					maxRetries)
-				os.Exit(1)
+				return 1
 			}
 
 		case <-t1.C:
@@ -443,6 +443,7 @@ func Run(ps *pubsub.PubSub) { //nolint:gocyclo
 	if err != nil {
 		log.Errorln(err)
 	}
+	return 0
 }
 
 // Post something without a return type.

--- a/pkg/pillar/cmd/command/command.go
+++ b/pkg/pillar/cmd/command/command.go
@@ -60,7 +60,7 @@ var (
 )
 
 // Run is the main aka only entrypoint
-func Run(ps *pubsub.PubSub) {
+func Run(ps *pubsub.PubSub) int {
 	// Report nano timestamps
 	formatter := logrus.JSONFormatter{
 		TimestampFormat: time.RFC3339Nano,
@@ -110,6 +110,7 @@ func Run(ps *pubsub.PubSub) {
 		}
 		execute(hdl, tokens[0], tokens[1:])
 	}
+	return 0
 }
 
 func execute(hdl *execlib.ExecuteHandle, command string, args []string) {

--- a/pkg/pillar/cmd/conntrack/conntrack.go
+++ b/pkg/pillar/cmd/conntrack/conntrack.go
@@ -14,7 +14,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func Run(ps *pubsub.PubSub) {
+func Run(ps *pubsub.PubSub) int {
 	delFlow := flag.Bool("D", false, "Delete flow")
 	delSrcIP := flag.String("s", "", "Delete flow with Srouce IP")
 	delProto := flag.Int("p", 0, "Delete flow with protocol ID")
@@ -58,10 +58,10 @@ func Run(ps *pubsub.PubSub) {
 			} else {
 				fmt.Printf("ConntrackDeleteIPSrc: deleted %d flow\n", number)
 			}
-			return
+			return 0
 		}
 		fmt.Println("Usage: Conntrack -D <-s IP-Address> [-p Protocol][-P port][-m Mark][-mask MarkMask][-f ipv6]")
-		return
+		return 1
 	}
 	// XXX args := flag.Args()
 	res, err := netlink.ConntrackTableList(netlink.ConntrackTable, syscall.AF_INET)
@@ -88,4 +88,5 @@ func Run(ps *pubsub.PubSub) {
 				entry.Reverse.Packets, entry.Reverse.Bytes)
 		}
 	}
+	return 0
 }

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -79,7 +79,7 @@ var outfile = os.Stdout
 var nilUUID uuid.UUID
 var log *base.LogObject
 
-func Run(ps *pubsub.PubSub) {
+func Run(ps *pubsub.PubSub) int {
 	var err error
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")
@@ -101,7 +101,7 @@ func Run(ps *pubsub.PubSub) {
 	outputFile := *outputFilePtr
 	if *versionPtr {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
-		return
+		return 0
 	}
 	// XXX Make logrus record a noticable global source
 	agentlog.Init("xyzzy-" + agentName)
@@ -188,7 +188,7 @@ func Run(ps *pubsub.PubSub) {
 	} else {
 		fmt.Fprintf(outfile, "ERROR: no device cert and no onboarding cert at %v\n",
 			time.Now().Format(time.RFC3339Nano))
-		os.Exit(1)
+		return 1
 	}
 	ctx.zedcloudCtx = &zedcloudCtx
 
@@ -295,6 +295,7 @@ func Run(ps *pubsub.PubSub) {
 			ctx.usingOnboardCert = false
 		}
 	}
+	return 0
 }
 
 func fileExists(filename string) bool {

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -110,7 +110,7 @@ var debugOverride bool          // From command line arg
 var hyper hypervisor.Hypervisor // Current hypervisor
 var log *base.LogObject
 
-func Run(ps *pubsub.PubSub) {
+func Run(ps *pubsub.PubSub) int {
 	var err error
 	handlersInit()
 	allHypervisors, enabledHypervisors := hypervisor.GetAvailableHypervisors()
@@ -127,7 +127,7 @@ func Run(ps *pubsub.PubSub) {
 	}
 	if *versionPtr {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
-		return
+		return 0
 	}
 	// XXX Make logrus record a noticable global source
 	agentlog.Init("xyzzy-" + agentName)

--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -46,7 +46,7 @@ var (
 	log           *base.LogObject
 )
 
-func Run(ps *pubsub.PubSub) {
+func Run(ps *pubsub.PubSub) int {
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")
 	flag.Parse()
@@ -59,7 +59,7 @@ func Run(ps *pubsub.PubSub) {
 	}
 	if *versionPtr {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
-		return
+		return 0
 	}
 	// XXX Make logrus record a noticable global source
 	agentlog.Init("xyzzy-" + agentName)

--- a/pkg/pillar/cmd/executor/exec.go
+++ b/pkg/pillar/cmd/executor/exec.go
@@ -53,7 +53,7 @@ type executorContext struct {
 var log *base.LogObject
 
 // Run is the main aka only entrypoint
-func Run(ps *pubsub.PubSub) {
+func Run(ps *pubsub.PubSub) int {
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")
 	timeLimitPtr := flag.Uint("t", 120, "Maximum time to wait for command")
@@ -74,7 +74,7 @@ func Run(ps *pubsub.PubSub) {
 
 	if *versionPtr {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
-		return
+		return 0
 	}
 	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
 		log.Fatal(err)

--- a/pkg/pillar/cmd/hardwaremodel/hardwaremodel.go
+++ b/pkg/pillar/cmd/hardwaremodel/hardwaremodel.go
@@ -59,7 +59,7 @@ func hwFp(log *base.LogObject, outputFile string) {
 	enc.Encode(infos)
 }
 
-func Run(ps *pubsub.PubSub) {
+func Run(ps *pubsub.PubSub) int {
 	pid := os.Getpid()
 	basename := filepath.Base(os.Args[0])
 	log := base.NewSourceLogObject(basename, pid)
@@ -71,11 +71,11 @@ func Run(ps *pubsub.PubSub) {
 	outputFile := *outputFilePtr
 	if *versionPtr {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
-		return
+		return 0
 	}
 	if *hwPtr {
 		hwFp(log, outputFile)
-		return
+		return 0
 	}
 	model := hardware.GetHardwareModelNoOverride(log)
 	if *cPtr {
@@ -92,4 +92,5 @@ func Run(ps *pubsub.PubSub) {
 			log.Fatal("WriteFile", err, outputFile)
 		}
 	}
+	return 0
 }

--- a/pkg/pillar/cmd/ipcmonitor/ipcmonitor.go
+++ b/pkg/pillar/cmd/ipcmonitor/ipcmonitor.go
@@ -30,7 +30,7 @@ import (
 
 var debugOverride bool // From command line arg
 
-func Run(ps *pubsub.PubSub) {
+func Run(ps *pubsub.PubSub) int {
 	agentNamePtr := flag.String("a", "zedrouter",
 		"Agent name")
 	agentScopePtr := flag.String("s", "", "agentScope")
@@ -51,7 +51,7 @@ func Run(ps *pubsub.PubSub) {
 	}
 	if *persistentPtr {
 		testPersistent(ps, agentName, agentScope, topic)
-		return
+		return 0
 	}
 	format := *formatPtr
 

--- a/pkg/pillar/cmd/ledmanager/ledmanager.go
+++ b/pkg/pillar/cmd/ledmanager/ledmanager.go
@@ -168,7 +168,7 @@ var log *base.LogObject
 // Set from Makefile
 var Version = "No version specified"
 
-func Run(ps *pubsub.PubSub) {
+func Run(ps *pubsub.PubSub) int {
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug")
 	fatalPtr := flag.Bool("F", false, "Cause log.Fatal fault injection")
@@ -185,7 +185,7 @@ func Run(ps *pubsub.PubSub) {
 	}
 	if *versionPtr {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
-		return
+		return 0
 	}
 	// XXX Make logrus record a noticable global source
 	agentlog.Init("xyzzy-" + agentName)

--- a/pkg/pillar/cmd/logmanager/logmanager.go
+++ b/pkg/pillar/cmd/logmanager/logmanager.go
@@ -147,7 +147,7 @@ type inputLogMetrics struct {
 }
 
 // Run is an entry point into running logmanager
-func Run(ps *pubsub.PubSub) {
+func Run(ps *pubsub.PubSub) int {
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug")
 	forcePtr := flag.Bool("f", false, "Force")
@@ -166,7 +166,7 @@ func Run(ps *pubsub.PubSub) {
 	force := *forcePtr
 	if *versionPtr {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
-		return
+		return 0
 	}
 	// XXX Make logrus record a noticable global source
 	agentlog.Init("xyzzy-" + agentName)

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -83,7 +83,7 @@ func (ctx *nimContext) processArgs() {
 }
 
 // Run - Main function - invoked from zedbox.go
-func Run(ps *pubsub.PubSub) {
+func Run(ps *pubsub.PubSub) int {
 	nimCtx := nimContext{
 		fallbackPortMap:  make(map[string]bool),
 		filteredFallback: make(map[string]bool),
@@ -96,7 +96,7 @@ func Run(ps *pubsub.PubSub) {
 	nimCtx.processArgs()
 	if nimCtx.version {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
-		return
+		return 0
 	}
 	// XXX Make logrus record a noticable global source
 	agentlog.Init("xyzzy-" + agentName)

--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -141,7 +141,7 @@ func (ctxPtr *nodeagentContext) ProcessAgentSpecificCLIFlags() {
 }
 
 // Run : nodeagent run entry function
-func Run(ps *pubsub.PubSub) {
+func Run(ps *pubsub.PubSub) int {
 	nodeagentCtx := newNodeagentContext(ps)
 
 	log = agentbase.Run(&nodeagentCtx)

--- a/pkg/pillar/cmd/upgradeconverter/upgradeconverter.go
+++ b/pkg/pillar/cmd/upgradeconverter/upgradeconverter.go
@@ -89,7 +89,7 @@ func runHandlers(ctxPtr *ucContext) {
 var log *base.LogObject
 
 // Run - runs the main upgradeconverter process
-func Run(ps *pubsub.PubSub) {
+func Run(ps *pubsub.PubSub) int {
 	ctx := &ucContext{agentName: "upgradeconverter",
 		persistDir:       types.PersistDir,
 		persistConfigDir: types.PersistConfigDir,
@@ -118,6 +118,7 @@ func Run(ps *pubsub.PubSub) {
 	}
 	log.Infof("Starting %s\n", ctx.agentName)
 	runHandlers(ctx)
+	return 0
 }
 
 // HandlerFunc - defines functions to handle each conversion

--- a/pkg/pillar/cmd/verifier/verifier.go
+++ b/pkg/pillar/cmd/verifier/verifier.go
@@ -67,7 +67,7 @@ var debug = false
 var debugOverride bool // From command line arg
 var log *base.LogObject
 
-func Run(ps *pubsub.PubSub) {
+func Run(ps *pubsub.PubSub) int {
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")
 	flag.Parse()
@@ -85,7 +85,7 @@ func Run(ps *pubsub.PubSub) {
 
 	if *versionPtr {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
-		return
+		return 0
 	}
 	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
 		log.Fatal(err)

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -90,7 +90,7 @@ var debugOverride bool // From command line arg
 var log *base.LogObject
 
 // Run - the main function invoked by zedbox
-func Run(ps *pubsub.PubSub) {
+func Run(ps *pubsub.PubSub) int {
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")
 	flag.Parse()
@@ -103,7 +103,7 @@ func Run(ps *pubsub.PubSub) {
 	}
 	if *versionPtr {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
-		return
+		return 0
 	}
 	// XXX Make logrus record a noticable global source
 	agentlog.Init("xyzzy-" + agentName)

--- a/pkg/pillar/cmd/waitforaddr/waitforaddr.go
+++ b/pkg/pillar/cmd/waitforaddr/waitforaddr.go
@@ -43,7 +43,7 @@ var debug = false
 var debugOverride bool // From command line arg
 var log *base.LogObject
 
-func Run(ps *pubsub.PubSub) {
+func Run(ps *pubsub.PubSub) int {
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")
 	noPidPtr := flag.Bool("p", false, "Do not check for running agent")
@@ -58,7 +58,7 @@ func Run(ps *pubsub.PubSub) {
 	noPidFlag := *noPidPtr
 	if *versionPtr {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
-		return
+		return 0
 	}
 	// XXX Make logrus record a noticable global source
 	agentlog.Init("xyzzy-" + agentName)
@@ -113,6 +113,7 @@ func Run(ps *pubsub.PubSub) {
 		}
 		ps.StillRunning(agentName, warningTime, errorTime)
 	}
+	return 0
 }
 
 // Handles both create and modify events

--- a/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
+++ b/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
@@ -56,7 +56,7 @@ var debug = false
 var debugOverride bool // From command line arg
 var log *base.LogObject
 
-func Run(ps *pubsub.PubSub) {
+func Run(ps *pubsub.PubSub) int {
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")
 	flag.Parse()
@@ -69,7 +69,7 @@ func Run(ps *pubsub.PubSub) {
 	}
 	if *versionPtr {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
-		return
+		return 0
 	}
 	// XXX Make logrus record a noticable global source
 	agentlog.Init("xyzzy-" + agentName)

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -134,7 +134,7 @@ var flowQ *list.List
 var log *base.LogObject
 var zedcloudCtx *zedcloud.ZedCloudContext
 
-func Run(ps *pubsub.PubSub) {
+func Run(ps *pubsub.PubSub) int {
 	var err error
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")
@@ -156,28 +156,28 @@ func Run(ps *pubsub.PubSub) {
 	validate := *validatePtr
 	if *versionPtr {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
-		return
+		return 0
 	}
 	if validate && parse == "" {
 		fmt.Printf("Setting -V requires -p\n")
-		os.Exit(1)
+		return 1
 	}
 	if parse != "" {
 		res, config := readValidateConfig(
 			types.DefaultConfigItemValueMap().GlobalValueInt(types.StaleConfigTime), parse)
 		if !res {
 			fmt.Printf("Failed to parse %s\n", parse)
-			os.Exit(1)
+			return 1
 		}
 		fmt.Printf("parsed proto <%v>\n", config)
 		if validate {
 			valid := validateConfigUTF8(config)
 			if !valid {
 				fmt.Printf("Found some invalid UTF-8\n")
-				os.Exit(1)
+				return 1
 			}
 		}
-		return
+		return 0
 	}
 	// XXX Make logrus record a noticable global source
 	agentlog.Init("xyzzy-" + agentName)

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -53,7 +53,7 @@ var debug = false
 var debugOverride bool // From command line arg
 var log *base.LogObject
 
-func Run(ps *pubsub.PubSub) {
+func Run(ps *pubsub.PubSub) int {
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")
 	flag.Parse()
@@ -66,7 +66,7 @@ func Run(ps *pubsub.PubSub) {
 	}
 	if *versionPtr {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
-		return
+		return 0
 	}
 	// XXX Make logrus record a noticable global source
 	agentlog.Init("xyzzy-" + agentName)

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -91,7 +91,7 @@ var debug = false
 var debugOverride bool // From command line arg
 var log *base.LogObject
 
-func Run(ps *pubsub.PubSub) {
+func Run(ps *pubsub.PubSub) int {
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")
 	flag.Parse()
@@ -104,7 +104,7 @@ func Run(ps *pubsub.PubSub) {
 	}
 	if *versionPtr {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
-		return
+		return 0
 	}
 	// XXX Make logrus record a noticable global source
 	agentlog.Init("xyzzy-" + agentName)
@@ -408,7 +408,7 @@ func Run(ps *pubsub.PubSub) {
 	// First wait for restarted from zedmanager to
 	// reduce the number of LISP-RESTARTs
 	for !subAppNetworkConfig.Restarted() {
-		log.Infof("Waiting for zedmanager to report restarted\n")
+		log.Infof("Waiting for zedrouter to report restarted")
 		select {
 		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
@@ -441,7 +441,7 @@ func Run(ps *pubsub.PubSub) {
 				warningTime, errorTime)
 		}
 	}
-	log.Infof("Zedmanager has restarted. Entering main Select loop\n")
+	log.Infof("Zedrouter has restarted. Entering main Select loop")
 
 	for {
 		select {

--- a/pkg/pillar/types/zedbox.go
+++ b/pkg/pillar/types/zedbox.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"github.com/lf-edge/eve/pkg/pillar/base"
+)
+
+// ServiceInitStatus used to track/notify service init in zedbox
+type ServiceInitStatus struct {
+	ServiceName string
+	CmdArgs     []string
+}
+
+// Key returns the pubsub Key
+func (s ServiceInitStatus) Key() string {
+	return s.ServiceName
+}
+
+// LogCreate :
+func (s ServiceInitStatus) LogCreate(logBase *base.LogObject) {
+	logObject := base.NewLogObject(logBase, base.ServiceInitLogType, s.ServiceName, nilUUID, s.LogKey())
+	if logObject == nil {
+		return
+	}
+	logObject.CloneAndAddField("servicename", s.ServiceName).
+		AddField("cmdargs", s.CmdArgs).
+		Infof("ServiceInitStatus create")
+}
+
+// LogModify :
+func (s ServiceInitStatus) LogModify(old interface{}) {
+	logObject := base.EnsureLogObject(nil, base.ServiceInitLogType, s.ServiceName, nilUUID, s.LogKey())
+
+	if _, ok := old.(ServiceInitStatus); !ok {
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of ServiceInitStatus type")
+	}
+
+	logObject.CloneAndAddField("servicename", s.ServiceName).
+		AddField("cmdargs", s.CmdArgs).
+		Infof("ServiceInitStatus modify")
+}
+
+// LogDelete :
+func (s ServiceInitStatus) LogDelete() {
+	logObject := base.EnsureLogObject(nil, base.ServiceInitLogType, s.ServiceName, nilUUID, s.LogKey())
+	logObject.CloneAndAddField("servicename", s.ServiceName).
+		AddField("cmdargs", s.CmdArgs).
+		Infof("ServiceInitStatus modify")
+
+	base.DeleteLogObject(s.LogKey())
+}
+
+// LogKey :
+func (s ServiceInitStatus) LogKey() string {
+	return string(base.ServiceInitLogType) + "-" + s.Key()
+}

--- a/pkg/pillar/zedbox/zedbox.go
+++ b/pkg/pillar/zedbox/zedbox.go
@@ -4,10 +4,18 @@
 package main
 
 import (
+	"encoding/json"
+	"flag"
 	"fmt"
+	"io/ioutil"
+	"net"
 	"os"
+	"path"
 	"path/filepath"
+	"strings"
+	"time"
 
+	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/cmd/baseosmgr"
 	"github.com/lf-edge/eve/pkg/pillar/cmd/client"
@@ -33,46 +41,237 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/cmd/zedagent"
 	"github.com/lf-edge/eve/pkg/pillar/cmd/zedmanager"
 	"github.com/lf-edge/eve/pkg/pillar/cmd/zedrouter"
+	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub/socketdriver"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/sirupsen/logrus"
 )
 
-var entrypoints = map[string]func(*pubsub.PubSub){
-	"client":           client.Run,
-	"command":          command.Run,
-	"diag":             diag.Run,
-	"domainmgr":        domainmgr.Run,
-	"downloader":       downloader.Run,
-	"executor":         executor.Run,
-	"hardwaremodel":    hardwaremodel.Run,
-	"ledmanager":       ledmanager.Run,
-	"logmanager":       logmanager.Run,
-	"nim":              nim.Run,
-	"nodeagent":        nodeagent.Run,
-	"verifier":         verifier.Run,
-	"volumemgr":        volumemgr.Run,
-	"waitforaddr":      waitforaddr.Run,
-	"zedagent":         zedagent.Run,
-	"zedmanager":       zedmanager.Run,
-	"zedrouter":        zedrouter.Run,
-	"ipcmonitor":       ipcmonitor.Run,
-	"baseosmgr":        baseosmgr.Run,
-	"wstunnelclient":   wstunnelclient.Run,
-	"conntrack":        conntrack.Run,
-	"tpmmgr":           tpmmgr.Run,
-	"vaultmgr":         vaultmgr.Run,
-	"upgradeconverter": upgradeconverter.Run,
-}
+const (
+	agentName        = "zedbox"
+	agentRunBasePath = "/var/run"
+	errorTime        = 3 * time.Minute
+	warningTime      = 40 * time.Second
+)
+
+var (
+	debugOverride = false
+	//Version Set from Makefile
+	Version     = "No version specified"
+	entrypoints = map[string]func(*pubsub.PubSub){
+		"client":           client.Run,
+		"command":          command.Run,
+		"diag":             diag.Run,
+		"domainmgr":        domainmgr.Run,
+		"downloader":       downloader.Run,
+		"executor":         executor.Run,
+		"hardwaremodel":    hardwaremodel.Run,
+		"ledmanager":       ledmanager.Run,
+		"logmanager":       logmanager.Run,
+		"nim":              nim.Run,
+		"nodeagent":        nodeagent.Run,
+		"verifier":         verifier.Run,
+		"volumemgr":        volumemgr.Run,
+		"waitforaddr":      waitforaddr.Run,
+		"zedagent":         zedagent.Run,
+		"zedmanager":       zedmanager.Run,
+		"zedrouter":        zedrouter.Run,
+		"ipcmonitor":       ipcmonitor.Run,
+		"baseosmgr":        baseosmgr.Run,
+		"wstunnelclient":   wstunnelclient.Run,
+		"conntrack":        conntrack.Run,
+		"tpmmgr":           tpmmgr.Run,
+		"vaultmgr":         vaultmgr.Run,
+		"upgradeconverter": upgradeconverter.Run,
+	}
+	log *base.LogObject
+)
 
 func main() {
-	pid := os.Getpid()
-	basename := filepath.Base(os.Args[0])
-	log := base.NewSourceLogObject(basename, pid)
-	ps := pubsub.New(&socketdriver.SocketDriver{Log: log}, log)
-	if entrypoint, ok := entrypoints[basename]; ok {
-		entrypoint(ps)
+	versionPtr := flag.Bool("v", false, "Version")
+	debugPtr := flag.Bool("d", false, "Debug flag")
+	debugOverride = *debugPtr
+	if *versionPtr {
+		fmt.Printf("%s: %s\n", os.Args[0], Version)
+		return
+	}
+
+	log = agentlog.Init(agentName)
+
+	if debugOverride {
+		logrus.SetLevel(logrus.DebugLevel)
 	} else {
-		fmt.Printf("Unknown package: %s\n", basename)
+		logrus.SetLevel(logrus.InfoLevel)
+	}
+
+	// Check what service we are intending to start.
+	basename := filepath.Base(os.Args[0])
+	if _, ok := entrypoints[basename]; ok {
+		// If its a known child service, the notify zedbox binary to start that
+		sericeInitStatus := types.ServiceInitStatus{
+			ServiceName: basename,
+			CmdArgs:     os.Args,
+		}
+		log.Infof("Notifying zedbox to start service %s with args %v",
+			sericeInitStatus.ServiceName, sericeInitStatus.CmdArgs)
+		if err := publish(agentName, &sericeInitStatus); err != nil {
+			log.Fatalf(err.Error())
+		}
+		return
+	} else if basename != agentName { // If its unknown child service, check if we intend to start zedbox
+		fmt.Printf("zedbox: Unknown package: %s\n", basename)
 		os.Exit(1)
+	}
+
+	//Start zedbox
+	var sktData string
+	sktChan := make(chan string)
+	stillRunning := time.NewTicker(15 * time.Second)
+	pid := os.Getpid()
+	logObj := base.NewSourceLogObject(agentName, pid)
+	ps := pubsub.New(&socketdriver.SocketDriver{Log: logObj}, logObj)
+
+	log.Infof("Starting %s", agentName)
+	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
+		log.Fatal(err)
+	}
+
+	go startSubscriber(agentName, types.ServiceInitStatus{}, sktChan)
+	for {
+		select {
+		case sktData = <-sktChan:
+			sktData = strings.TrimSpace(sktData)
+			var serviceInitStatus types.ServiceInitStatus
+			if err := json.Unmarshal([]byte(sktData), &serviceInitStatus); err != nil {
+				err := fmt.Errorf("zedbox: exception while unmarshalling data %s. %s",
+					sktData, err.Error())
+				log.Errorf(err.Error())
+				break
+			}
+
+			log.Infof("zedbox: Received command = %s agrs = %v",
+				serviceInitStatus.ServiceName, serviceInitStatus.CmdArgs)
+			srvLogObj := base.NewSourceLogObject(serviceInitStatus.ServiceName, pid)
+			srvPs := pubsub.New(&socketdriver.SocketDriver{Log: srvLogObj}, srvLogObj)
+			if _, ok := entrypoints[serviceInitStatus.ServiceName]; ok {
+				log.Infof("zedbox: Starting %s", serviceInitStatus.ServiceName)
+				flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+				os.Args = serviceInitStatus.CmdArgs
+				go startAgentAndDone(serviceInitStatus.ServiceName, srvPs)
+				log.Infof("zedbox: Started %s", serviceInitStatus.ServiceName)
+			} else {
+				fmt.Printf("zedbox: Unknown package: %s\n", serviceInitStatus.ServiceName)
+				os.Exit(1)
+			}
+		case <-stillRunning.C:
+			ps.StillRunning(agentName, warningTime, errorTime)
+		}
+	}
+}
+
+//startSubscriber Creates a socket for he agent and start listening
+func startSubscriber(agent string, topic interface{}, subSkt chan string) {
+	log.Infof("startSubscriber(%s)", agent)
+	sockName := getSocketName(agent, topic)
+	dir := path.Dir(sockName)
+	if _, err := os.Stat(dir); err != nil {
+		log.Infof("startSubscriber(%s): Create %s\n", agent, dir)
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			log.Fatalf("startSubscriber(%s): Exception while creating %s. %s",
+				agent, dir, err)
+		}
+	}
+	if _, err := os.Stat(sockName); err == nil {
+		// This could either be a left-over in the filesystem
+		// or some other process (or ourselves) using the same
+		// name to publish. Try connect to see if it is the latter.
+		_, err := net.Dial("unix", sockName)
+		if err == nil {
+			log.Fatalf("connectAndRead(%s): Can not publish %s since its already used",
+				agent, sockName)
+		}
+		if err := os.Remove(sockName); err != nil {
+			log.Fatalf("connectAndRead(%s): Exception while removing pre-existing sock %s. %s",
+				agent, sockName, err)
+		}
+	}
+	listener, err := net.Listen("unix", sockName)
+	if err != nil {
+		log.Fatalf("connectAndRead(%s): Exception while listening at sock %s. %s",
+			agent, sockName, err)
+	}
+	defer listener.Close()
+	for {
+		c, err := listener.Accept()
+		if err != nil {
+			log.Errorf("connectAndRead(%s) failed %s\n", sockName, err)
+			continue
+		}
+		go serveConnection(c, subSkt)
+	}
+}
+
+//publish publishes data to an already opened socket.
+func publish(agent string, data interface{}) error {
+	log.Infof("publish(%s)", agent)
+	sockName := getSocketName(agent, data)
+
+	if _, err := os.Stat(sockName); err != nil {
+		err := fmt.Errorf("publish(%s): exception while check socket. %s", sockName, err.Error())
+		log.Errorf(err.Error())
+		return err
+	}
+
+	byteData, err := json.Marshal(data)
+	if err != nil {
+		err := fmt.Errorf("publish(%s): exception while marshalling data. %s",
+			sockName, err.Error())
+		log.Errorf(err.Error())
+		return err
+	}
+
+	conn, err := net.Dial("unix", sockName)
+	if err != nil {
+		err := fmt.Errorf("publish(%s): exception while dialing socket. %s",
+			sockName, err.Error())
+		log.Errorf(err.Error())
+		return err
+	}
+
+	if _, err := conn.Write(byteData); err != nil {
+		err := fmt.Errorf("publish(%s): exception while writing data to the socket. %s",
+			sockName, err.Error())
+		log.Errorf(err.Error())
+		return err
+	}
+	return nil
+}
+
+func serveConnection(conn net.Conn, retChan chan string) {
+
+	for {
+		buf := make([]byte, 2048)
+		count, err := conn.Read(buf)
+		if err != nil {
+			log.Errorf("serveConnection: Error on read: %s", err)
+			break
+		}
+		retChan <- string(buf[:count])
+
+	}
+}
+
+func getSocketName(agent string, topic interface{}) string {
+	return path.Join(agentRunBasePath, agent, fmt.Sprintf("%s.sock", pubsub.TypeToName(topic)))
+}
+
+//startAgentAndDone start the given agent. Touches a <agentName>.done file once the agent returns.
+func startAgentAndDone(agentName string, srvPs *pubsub.PubSub) {
+	serviceEntrypoint, _ := entrypoints[agentName]
+	serviceEntrypoint(srvPs)
+
+	if err := ioutil.WriteFile(fmt.Sprintf("%s/%s.done", agentRunBasePath, agentName), make([]byte, 0), 0700); err != nil {
+		log.Fatalf("Error creating done_file: %v", err)
 	}
 }


### PR DESCRIPTION
Instead of spawning each EVE services with its own binary, we'll be starting EVE using a single binary zedbox.

TODO:
Fix log source.

Open question:
Do we need `/run/<service>.pid` file? Since all the service will have the same PIDs.

Signed-off-by: adarsh-zededa <adarsh@zededa.com>