### PR TITLE
tmp mount

### DIFF
--- a/pkg/xen-tools/initrd/init-initrd
+++ b/pkg/xen-tools/initrd/init-initrd
@@ -31,7 +31,8 @@ mount -o bind /dev /mnt/rootfs/dev
 mount -o bind /sys /mnt/rootfs/sys
 mount -o bind /proc /mnt/rootfs/proc
 mount -t devpts -o gid=5,mode=0620,noexec,nosuid devpts /mnt/rootfs/dev/pts
-mount -t tmpfs -o nodev,nosuid,noexec shm /mnt/rootfs/dev/shm
+mount -t tmpfs -o nodev,nosuid,noexec,size=20% shm /mnt/rootfs/dev/shm
+mount -t tmpfs -o nodev,nosuid,noexec,size=20% tmp /mnt/rootfs/tmp
 
 ip=`cat /proc/cmdline | grep -o '\bip=[^ ]*' | cut -d = -f 2`
 gw=`cat /proc/cmdline | grep -o '\bgw=[^ ]*' | cut -d = -f 2`
@@ -69,6 +70,9 @@ then
 elif test "$dhcp"
 then
     ip link set dev lo up
+    mkdir -p /mnt/rootfs/etc
+    echo "127.0.0.1 localhost" > /mnt/rootfs/etc/hosts
+    echo "::1 localhost" >> /mnt/rootfs/etc/hosts
     for i in $(cd /sys/class/net && echo eth*); do
         ip link set dev "$i" up
         udhcpc --interface="$i" --script=/udhcpc_script.sh -O staticroutes


### PR DESCRIPTION
As I recognize using strace, bash needs /tmp mount for things [like](https://github.com/docker-library/wordpress/blob/d447e82d5e847f0b06d53214b0119f9f9f67340a/docker-entrypoint.sh#L87).
We need to set properly `/etc/hosts` and `/etc/hostname` for network apps (like apache).
Also, after #1292 we need to run `ip route add ${router%% *} dev $interface`

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>