### PR TITLE
Use a static fscrypt.conf common to all platforms

### DIFF
--- a/.yetus-excludes
+++ b/.yetus-excludes
@@ -1,6 +1,7 @@
 ^tests/integration/config.yml
 ^pkg/mkimage-raw-efi/initramfs-init
 ^pkg/mkimage-raw-efi/nlplug-findfs.c
+^pkg/pillar/rootfs/fscrypt.conf
 ^pkg/fw/
 ^build-tools/src/linuxkit/
 ^build-tools/src/manifest-tool/

--- a/pkg/pillar/cmd/vaultmgr/vaultmgr.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgr.go
@@ -56,7 +56,6 @@ var (
 	keyctlParams      = []string{"link", "@u", "@s"}
 	mntPointParams    = []string{"setup", vault.MountPoint, "--quiet"}
 	vaultStatusParams = []string{"status"}
-	setupParams       = []string{"setup", "--quiet"}
 	debug             = false
 	debugOverride     bool // From command line arg
 	log               *base.LogObject
@@ -391,10 +390,6 @@ func setupVault(vaultPath string, deprecated bool) error {
 }
 
 func setupFscryptEnv() error {
-	//setup fscrypt.conf, if not done already
-	if _, _, err := execCmd(vault.FscryptPath, setupParams...); err != nil {
-		return fmt.Errorf("Error setting up fscrypt.conf: %v", err)
-	}
 	//Check if /persist is already setup for encryption
 	if _, _, err := execCmd(vault.FscryptPath, vault.StatusParams...); err != nil {
 		//Not yet setup, set it up for the first use

--- a/pkg/pillar/rootfs/fscrypt.conf
+++ b/pkg/pillar/rootfs/fscrypt.conf
@@ -1,0 +1,14 @@
+{
+	"source": "custom_passphrase",
+	"hash_costs": {
+		"time": "1",
+		"memory": "131072",
+		"parallelism": "2"
+	},
+	"compatibility": "legacy",
+	"options": {
+		"padding": "32",
+		"contents": "AES_256_XTS",
+		"filenames": "AES_256_CTS"
+	}
+}

--- a/pkg/pillar/rootfs/init.sh
+++ b/pkg/pillar/rootfs/init.sh
@@ -5,6 +5,9 @@
 # Start with a default content for resolv.conf
 echo 'nameserver 8.8.8.8' > /etc/resolv.conf
 
+#Copy pre-defined fscrypt.conf
+cp fscrypt.conf /etc/fscrypt.conf
+
 # Need to disable H/W TCP offload since it seems to mess us up
 for i in $(cd /sys/class/net || return ; echo eth*) ; do
   ethtool -K "$i" gro off


### PR DESCRIPTION
- We need not re-generate fscrypt.conf on every boot
- on low memory platforms, hash difficulty customization
  for "custom_passphrase" is taking forever(possibly there is a bug in fscrypt)
- since "custom_passphrase" is not applicable to EVE(we use raw key)
  it doesn't make sense to do the estimation in the first place
- hence the static file

Signed-off-by: Hariharasubramanian C S <cshari@zededa.com>