### PR TITLE
Monster of a workaround for Xen on Dell 300x boot issues

### DIFF
--- a/pkg/kernel/patches-4.19.x/0048-dell-xen-hack.patch
+++ b/pkg/kernel/patches-4.19.x/0048-dell-xen-hack.patch
@@ -1,0 +1,20 @@
+diff --git a/drivers/pinctrl/intel/pinctrl-baytrail.c b/drivers/pinctrl/intel/pinctrl-baytrail.c
+index f38d596..1e15abc 100644
+--- a/drivers/pinctrl/intel/pinctrl-baytrail.c
++++ b/drivers/pinctrl/intel/pinctrl-baytrail.c
+@@ -1723,6 +1723,7 @@ static int byt_gpio_probe(struct byt_gpio *vg)
+ 		return ret;
+ 	}
+ 
++#if 0
+ 	/* set up interrupts  */
+ 	irq_rc = platform_get_resource(vg->pdev, IORESOURCE_IRQ, 0);
+ 	if (irq_rc && irq_rc->start) {
+@@ -1738,6 +1739,7 @@ static int byt_gpio_probe(struct byt_gpio *vg)
+ 					     (unsigned)irq_rc->start,
+ 					     byt_gpio_irq_handler);
+ 	}
++#endif	
+ 
+ 	return ret;
+ }


### PR DESCRIPTION
This is one of those things that may get my Linux developer card suspended by Linus, but it is blunt and at least easy to remove. In addition, this seems to only affect Dell boxes, since nothing else in our support matrix has the need for pinctrl-baytrail