### PR TITLE
Workaround for low-memory container boot issues

### DIFF
--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -402,7 +402,12 @@ func (ctx kvmContext) CreateDomConfig(domainName string, config types.DomainConf
 	tmplCtx.Memory = (config.Memory + 1023) / 1024
 	tmplCtx.DisplayName = domainName
 	if config.VirtualizationMode == types.FML || config.VirtualizationMode == types.PV {
-		tmplCtx.BootLoader = "/usr/lib/xen/boot/ovmf.bin"
+		// FIXME XXX hack to reuce memory pressure of UEFI when we run containers on x86
+		if config.IsContainer && runtime.GOARCH == "amd64" {
+			tmplCtx.BootLoader = "/usr/lib/xen/boot/seabios.bin"
+		} else {
+			tmplCtx.BootLoader = "/usr/lib/xen/boot/ovmf.bin"
+		}
 	} else {
 		tmplCtx.BootLoader = ""
 	}


### PR DESCRIPTION
This is a quick hack to reduce the memory pressure on the containers that we run on x86. This is more complicated than it has to be because seabios is obviously not available on ARM AND because I am actually refactoring that whole area to allow for PCI assignments to containers. So it is a FIXME hack for now -- expect it to go away 'real soon'.

Btw, here's the EFI error message that we're seeing:
   EFI stub: ERROR: Failed to allocate usable memory for kernel.
   efi_relocate_kernel() failed!
   efi_main() failed!

Signed-off-by: Roman Shaposhnik <rvs@zededa.com>