### PR TITLE
Increase watchdog timer

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -42,6 +42,7 @@
 #  hv_eve_cpu_settings  EVE services CPU settings (Should be <= hv_dom0_cpu_settings)
 #  hv_ctrd_mem_settings Containerd RAM settings (Should be <= hv_dom0_mem_settings)
 #  hv_ctrd_cpu_settings Containerd CPU settings (Should be <= hv_dom0_cpu_settings)
+#  hv_watchdog_timer    Sets EVE watchdog timer to monitor services
 #  hv_extra_args        any additional hypervisor settings
 #
 #  dom0_console         settings for having a viable Dom0 console output
@@ -146,6 +147,7 @@ function set_generic {
    set_global hv_ctrd_mem_settings "ctrd_mem=250M,max:350M"
    set_global hv_ctrd_cpu_settings "ctrd_max_vcpus=1"
    set_global hv_platform_tweaks "smt=false"
+   set_global hv_watchdog_timer "change=500"
 
    set_global dom0 /boot/kernel
    set_global dom0_rootfs "root=$rootfs_root"
@@ -243,7 +245,7 @@ do_if_args source $config_grub_cfg
 
 menuentry "Boot ${rootfs_title}${rootfs_title_suffix}" {
      $load_hv_cmd $hv $hv_console $hv_platform_tweaks $hv_dom0_mem_settings $hv_dom0_cpu_settings $hv_extra_args
-     $load_dom0_cmd $dom0 $dom0_console $dom0_rootfs $hv_dom0_mem_settings $hv_dom0_cpu_settings $hv_eve_mem_settings $hv_eve_cpu_settings $hv_ctrd_mem_settings $hv_ctrd_cpu_settings $dom0_platform_tweaks $dom0_cmdline $dom0_extra_args
+     $load_dom0_cmd $dom0 $dom0_console $dom0_rootfs $hv_dom0_mem_settings $hv_dom0_cpu_settings $hv_eve_mem_settings $hv_eve_cpu_settings $hv_ctrd_mem_settings $hv_ctrd_cpu_settings $hv_watchdog_timer $dom0_platform_tweaks $dom0_cmdline $dom0_extra_args
      do_if_args $load_devicetree_cmd $devicetree
      do_if_args $load_initrd_cmd $initrd
 }
@@ -276,7 +278,7 @@ submenu 'Set Boot Options' {
 
    menuentry 'show boot options' {
       set_global zboot1 "$load_hv_cmd $hv $hv_console $hv_platform_tweaks $hv_dom0_mem_settings $hv_dom0_cpu_settings $hv_extra_args"
-      set_global zboot2 "$load_dom0_cmd $dom0 $dom0_console $dom0_rootfs $hv_dom0_mem_settings $hv_dom0_cpu_settings $hv_eve_mem_settings $hv_eve_cpu_settings $hv_ctrd_mem_settings $hv_ctrd_cpu_settings $dom0_platform_tweaks $dom0_cmdline $dom0_extra_args"
+      set_global zboot2 "$load_dom0_cmd $dom0 $dom0_console $dom0_rootfs $hv_dom0_mem_settings $hv_dom0_cpu_settings $hv_eve_mem_settings $hv_eve_cpu_settings $hv_ctrd_mem_settings $hv_ctrd_cpu_settings $hv_watchdog_timer $dom0_platform_tweaks $dom0_cmdline $dom0_extra_args"
       set_global zboot3 "do_if_args $load_devicetree_cmd $devicetree"
       set_global zboot4 "do_if_args $load_initrd_cmd $initrd"
    }

--- a/pkg/watchdog/init.sh
+++ b/pkg/watchdog/init.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
 USE_HW_WATCHDOG=1
+DEFAULT_WATCHDOG_CHANGE_TIME=300
+WATCHDOG_CHANGE_TIME=$(cat /proc/cmdline | grep -o '\bchange=[^ ]*' | cut -d = -f 2)
+
 
 reload_watchdog() {
     # Firs thinsg first: kill it!
@@ -36,7 +39,7 @@ run_watchdog() {
       # Now lets see if we need to rebuild the configuration file
       (cat /etc/watchdog.conf.seed
        find /run/watchdog -type f | sed -e 's#/run/watchdog/pid#pidfile = /run#' \
-          -e '/\/run\/watchdog\/file/a change = 300'                             \
+          -e "/\/run\/watchdog\/file/a change = $WATCHDOG_CHANGE_TIME"                             \
           -e 's#/run/watchdog/file#file = /run#') > /etc/watchdog.conf.latest
 
       # If the configuration changed: reload watchdog


### PR DESCRIPTION
Increased default watchdog timer to 500s, also added a hook for that in grub.cfg.

This was needed because when EVE services were starving for memory, few operations like `exec()` calls became drastically slow which led to the services begin slow to update their respective `touch` file.
This led to Watchdog error in some cases. 

Signed-off-by: adarsh-zededa <adarsh@zededa.com>