### PR TITLE
Increase watchdog timer

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -42,6 +42,7 @@
 #  hv_eve_cpu_settings  EVE services CPU settings (Should be <= hv_dom0_cpu_settings)
 #  hv_ctrd_mem_settings Containerd RAM settings (Should be <= hv_dom0_mem_settings)
 #  hv_ctrd_cpu_settings Containerd CPU settings (Should be <= hv_dom0_cpu_settings)
+#  hv_watchdog_timer    Sets EVE watchdog timer to monitor services
 #  hv_extra_args        any additional hypervisor settings
 #
 #  dom0_console         settings for having a viable Dom0 console output
@@ -139,13 +140,14 @@ function set_rootfs_title {
 }
 
 function set_generic {
-   set_global hv_dom0_mem_settings "dom0_mem=650M,max:650M"
+   set_global hv_dom0_mem_settings "dom0_mem=750M,max:750M"
    set_global hv_dom0_cpu_settings "dom0_max_vcpus=1 dom0_vcpus_pin"
-   set_global hv_eve_mem_settings "eve_mem=350M,max:500M"
+   set_global hv_eve_mem_settings "eve_mem=600M,max:600M"
    set_global hv_eve_cpu_settings "eve_max_vcpus=1"
-   set_global hv_ctrd_mem_settings "ctrd_mem=250M,max:350M"
+   set_global hv_ctrd_mem_settings "ctrd_mem=350M,max:350M"
    set_global hv_ctrd_cpu_settings "ctrd_max_vcpus=1"
    set_global hv_platform_tweaks "smt=false"
+   set_global hv_watchdog_timer "change=500"
 
    set_global dom0 /boot/kernel
    set_global dom0_rootfs "root=$rootfs_root"
@@ -243,7 +245,7 @@ do_if_args source $config_grub_cfg
 
 menuentry "Boot ${rootfs_title}${rootfs_title_suffix}" {
      $load_hv_cmd $hv $hv_console $hv_platform_tweaks $hv_dom0_mem_settings $hv_dom0_cpu_settings $hv_extra_args
-     $load_dom0_cmd $dom0 $dom0_console $dom0_rootfs $hv_dom0_mem_settings $hv_dom0_cpu_settings $hv_eve_mem_settings $hv_eve_cpu_settings $hv_ctrd_mem_settings $hv_ctrd_cpu_settings $dom0_platform_tweaks $dom0_cmdline $dom0_extra_args
+     $load_dom0_cmd $dom0 $dom0_console $dom0_rootfs $hv_dom0_mem_settings $hv_dom0_cpu_settings $hv_eve_mem_settings $hv_eve_cpu_settings $hv_ctrd_mem_settings $hv_ctrd_cpu_settings $hv_watchdog_timer $dom0_platform_tweaks $dom0_cmdline $dom0_extra_args
      do_if_args $load_devicetree_cmd $devicetree
      do_if_args $load_initrd_cmd $initrd
 }
@@ -276,7 +278,7 @@ submenu 'Set Boot Options' {
 
    menuentry 'show boot options' {
       set_global zboot1 "$load_hv_cmd $hv $hv_console $hv_platform_tweaks $hv_dom0_mem_settings $hv_dom0_cpu_settings $hv_extra_args"
-      set_global zboot2 "$load_dom0_cmd $dom0 $dom0_console $dom0_rootfs $hv_dom0_mem_settings $hv_dom0_cpu_settings $hv_eve_mem_settings $hv_eve_cpu_settings $hv_ctrd_mem_settings $hv_ctrd_cpu_settings $dom0_platform_tweaks $dom0_cmdline $dom0_extra_args"
+      set_global zboot2 "$load_dom0_cmd $dom0 $dom0_console $dom0_rootfs $hv_dom0_mem_settings $hv_dom0_cpu_settings $hv_eve_mem_settings $hv_eve_cpu_settings $hv_ctrd_mem_settings $hv_ctrd_cpu_settings $hv_watchdog_timer $dom0_platform_tweaks $dom0_cmdline $dom0_extra_args"
       set_global zboot3 "do_if_args $load_devicetree_cmd $devicetree"
       set_global zboot4 "do_if_args $load_initrd_cmd $initrd"
    }

--- a/pkg/watchdog/init.sh
+++ b/pkg/watchdog/init.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
 USE_HW_WATCHDOG=1
+DEFAULT_WATCHDOG_CHANGE_TIME=300
+WATCHDOG_CHANGE_TIME=$(</proc/cmdline grep -o '\bchange=[^ ]*' | cut -d = -f 2)
+
 
 reload_watchdog() {
     # Firs thinsg first: kill it!
@@ -36,7 +39,7 @@ run_watchdog() {
       # Now lets see if we need to rebuild the configuration file
       (cat /etc/watchdog.conf.seed
        find /run/watchdog -type f | sed -e 's#/run/watchdog/pid#pidfile = /run#' \
-          -e '/\/run\/watchdog\/file/a change = 300'                             \
+          -e "/\/run\/watchdog\/file/a change = $WATCHDOG_CHANGE_TIME"                             \
           -e 's#/run/watchdog/file#file = /run#') > /etc/watchdog.conf.latest
 
       # If the configuration changed: reload watchdog
@@ -47,6 +50,11 @@ run_watchdog() {
 }
 
 # Lets get this party started
+
+if [ -z "${WATCHDOG_CHANGE_TIME}" ]; then
+    log "Setting value of $DEFAULT_WATCHDOG_CHANGE_TIME for WATCHDOG_CHANGE_TIME"
+    WATCHDOG_CHANGE_TIME=$DEFAULT_WATCHDOG_CHANGE_TIME
+fi
 
 if [ -c /dev/watchdog ]; then
     if [ $USE_HW_WATCHDOG = 0 ]; then


### PR DESCRIPTION
Increased default watchdog timer to 500s, also added a hook for that in grub.cfg.

This was needed because when EVE services were starving for memory, few operations like exec() calls became drastically slow which led to the services begin slow to update their respective touch file.
This led to Watchdog error in some cases.

Example:
In the below logs, we can see that `zedrouter` is very slow for `AppNetworkConfig` handler. One of the root cause is the exec call at https://github.com/lf-edge/eve/blob/53ff40edfe5c04bd576ec184500515ea146d8783/pkg/pillar/cmd/zedrouter/dnsmasq.go#L346
zedrouter is stuck for a very long time for this call to complete. 
One option is to add timeout for the exec calls, but there might be some exec calls which has to succeed in order for EVE to run properly, in such cases even if we timeout, we have to reboot EVE.
So in such cases, we need to increase the Watchdog timer so that we can wait for it to complete without triggering reboot.

```
(ns: pillar) 0e4e23a3-1517-47dc-af4d-89a15357f018:/# cat /persist/rsyslog/syslog
.prev.txt | grep 'XXX took a long time:'
2020-08-24T21:23:33.109336+00:00 linuxkit-14b31f08f98c pillar.out {"file":"/pillar/pubsub/checkmaxtime.go:74","func":"github.com/lf-edge/eve/pkg/pillar/pubsub.(*PubSub).CheckMaxTimeTopic","level":"error","msg":"AppNetworkConfig handler in zedmanager XXX took a long time: 327","pid":1348,"source":"zedrouter","time":"2020-08-24T21:23:33.105689775Z"}
2020-08-24T21:23:33.142607+00:00 linuxkit-14b31f08f98c pillar.out {"file":"/pillar/pubsub/checkmaxtime.go:35","func":"github.com/lf-edge/eve/pkg/pillar/pubsub.(*PubSub).StillRunning","level":"error","msg":"StillRunning(zedrouter) XXX took a long time: 327","pid":1348,"source":"zedrouter","time":"2020-08-24T21:23:33.1099146Z"}
2020-08-24T21:28:52.794473+00:00 linuxkit-14b31f08f98c pillar.out {"file":"/pillar/pubsub/checkmaxtime.go:74","func":"github.com/lf-edge/eve/pkg/pillar/pubsub.(*PubSub).CheckMaxTimeTopic","level":"error","msg":"AppNetworkConfig handler in zedmanager XXX took a long time: 319","pid":1348,"source":"zedrouter","time":"2020-08-24T21:28:52.780543465Z"}
2020-08-24T21:28:53.087620+00:00 linuxkit-14b31f08f98c pillar.out {"file":"/pillar/pubsub/checkmaxtime.go:35","func":"github.com/lf-edge/eve/pkg/pillar/pubsub.(*PubSub).StillRunning","level":"error","msg":"StillRunning(zedrouter) XXX took a long time: 319","pid":1348,"source":"zedrouter","time":"2020-08-24T21:28:52.898080916Z"}
```

Signed-off-by: adarsh-zededa <adarsh@zededa.com>