### PR TITLE
[WIP] [DO NOT MERGE] Removing use of GetTime() on x86 UEFI platforms

### DIFF
--- a/pkg/xen/arch/x86_64/0001-gettime-considered-harmful.patch
+++ b/pkg/xen/arch/x86_64/0001-gettime-considered-harmful.patch
@@ -1,0 +1,35 @@
+From: Roman Shaposhnik <rvs@zededa.com>
+Date: Mon, 24 Aug 2020 12:04:57 +0530
+Subject: [PATCH] UEFI GetTime() is considered harmful
+
+As per thread here: https://lists.archive.carbon60.com/xen/devel/408709
+it is best to avoid calling GetTime()
+
+Please follow Xen upstream discussion here:
+   https://lists.xenproject.org/archives/html/xen-devel/2020-08/msg01018.html
+
+diff --git a/arch/x86/time.c b/xen/arch/x86/time.c
+index 4723f5d..311e8a5 100644
+--- a/arch/x86/time.c
++++ b/arch/x86/time.c
+@@ -1040,19 +1040,12 @@
+ 
+ static unsigned long get_cmos_time(void)
+ {
+-    unsigned long res, flags;
++    unsigned long flags;
+     struct rtc_time rtc;
+     unsigned int seconds = 60;
+     static bool __read_mostly cmos_rtc_probe;
+     boolean_param("cmos-rtc-probe", cmos_rtc_probe);
+ 
+-    if ( efi_enabled(EFI_RS) )
+-    {
+-        res = efi_get_time();
+-        if ( res )
+-            return res;
+-    }
+-
+     if ( likely(!(acpi_gbl_FADT.boot_flags & ACPI_FADT_NO_CMOS_RTC)) )
+         cmos_rtc_probe = false;
+     else if ( system_state < SYS_STATE_smp_boot && !cmos_rtc_probe )


### PR DESCRIPTION
Additional tweaks specifically for Dell 300x platform, but in general the consensus seems to be that it is a good idea across the board on x86 UEFI