### PR TITLE
Fix 'echo: write error: Invalid argument' on EVE boot

### DIFF
--- a/pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup
+++ b/pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup
@@ -1,19 +1,19 @@
 #!/bin/sh
 
-default_cgroup_memory_limit=1000000000 #1GB
-default_cgroup_cpus_limit='0-1'
+default_cgroup_memory_limit=786432000 #750M
+default_cgroup_cpus_limit=1
 
-dom0_cgroup_memory_soft_limit=$(cat /proc/cmdline | grep -o '\bdom0_mem=[^, ]*' | cut -d = -f 2)
-dom0_cgroup_memory_limit=$(cat /proc/cmdline | grep -o "\bdom0_mem=[^,]*,max:[^ ]*" | cut -d : -f 2)
-dom0_cgroup_cpus_limit="0-$(cat /proc/cmdline | grep -o '\bdom0_max_vcpus=[^ ]*' | cut -d = -f 2)"
+dom0_cgroup_memory_soft_limit=$(</proc/cmdline grep -o '\bdom0_mem=[^, ]*' | cut -d = -f 2)
+dom0_cgroup_memory_limit=$(</proc/cmdline grep -o "\bdom0_mem=[^,]*,max:[^ ]*" | cut -d : -f 2)
+dom0_cgroup_cpus_limit=$(</proc/cmdline grep -o '\bdom0_max_vcpus=[^ ]*' | cut -d = -f 2)
 
-eve_cgroup_memory_soft_limit=$(cat /proc/cmdline | grep -o '\beve_mem=[^, ]*' | cut -d = -f 2)
-eve_cgroup_memory_limit=$(cat /proc/cmdline | grep -o "\beve_mem=[^,]*,max:[^ ]*" | cut -d : -f 2)
-eve_cgroup_cpus_limit="0-$(cat /proc/cmdline | grep -o '\beve_max_vcpus=[^ ]*' | cut -d = -f 2)"
+eve_cgroup_memory_soft_limit=$(</proc/cmdline grep -o '\beve_mem=[^, ]*' | cut -d = -f 2)
+eve_cgroup_memory_limit=$(</proc/cmdline grep -o "\beve_mem=[^,]*,max:[^ ]*" | cut -d : -f 2)
+eve_cgroup_cpus_limit=$(</proc/cmdline grep -o '\beve_max_vcpus=[^ ]*' | cut -d = -f 2)
 
-ctrd_cgroup_memory_soft_limit=$(cat /proc/cmdline | grep -o '\bctrd_mem=[^, ]*' | cut -d = -f 2)
-ctrd_cgroup_memory_limit=$(cat /proc/cmdline | grep -o "\bctrd_mem=[^,]*,max:[^ ]*" | cut -d : -f 2)
-ctrd_cgroup_cpus_limit="0-$(cat /proc/cmdline | grep -o '\bctrd_max_vcpus=[^ ]*' | cut -d = -f 2)"
+ctrd_cgroup_memory_soft_limit=$(</proc/cmdline grep -o '\bctrd_mem=[^, ]*' | cut -d = -f 2)
+ctrd_cgroup_memory_limit=$(</proc/cmdline grep -o "\bctrd_mem=[^,]*,max:[^ ]*" | cut -d : -f 2)
+ctrd_cgroup_cpus_limit=$(</proc/cmdline grep -o '\bctrd_max_vcpus=[^ ]*' | cut -d = -f 2)
 
 if [ -z "${dom0_cgroup_memory_soft_limit}" ]; then
     echo "Setting default value of $default_cgroup_memory_limit for dom0_cgroup_memory_soft_limit"
@@ -25,7 +25,7 @@ if [ -z "${dom0_cgroup_memory_limit}" ]; then
     dom0_cgroup_memory_limit=$dom0_cgroup_memory_soft_limit
 fi
 
-if [ "$dom0_cgroup_cpus_limit" == "0-" ]; then
+if [ -z "${dom0_cgroup_cpus_limit}" ]; then
     echo "Setting default value of $default_cgroup_cpus_limit for dom0_cgroup_cpus_limit"
     dom0_cgroup_cpus_limit=$default_cgroup_cpus_limit
 fi
@@ -40,7 +40,7 @@ if [ -z "${eve_cgroup_memory_limit}" ]; then
     eve_cgroup_memory_limit=$eve_cgroup_memory_soft_limit
 fi
 
-if [ "$eve_cgroup_cpus_limit" == "0-" ]; then
+if [ -z "${eve_cgroup_cpus_limit}" ]; then
     echo "Setting default value of $default_cgroup_cpus_limit for eve_cgroup_cpus_limit"
     eve_cgroup_cpus_limit=$default_cgroup_cpus_limit
 fi
@@ -55,7 +55,7 @@ if [ -z "${ctrd_cgroup_memory_limit}" ]; then
     ctrd_cgroup_memory_limit=$ctrd_cgroup_memory_soft_limit
 fi
 
-if [ "$ctrd_cgroup_cpus_limit" == "0-" ]; then
+if [ -z "${ctrd_cgroup_cpus_limit}" ]; then
     echo "Setting default value of $default_cgroup_cpus_limit for ctrd_cgroup_cpus_limit"
     ctrd_cgroup_cpus_limit=$default_cgroup_cpus_limit
 fi
@@ -83,19 +83,31 @@ for cg in $CGROUPS; do
     mkdir -p /sys/fs/cgroup/"${cg}"/eve/memlogd
 done
 
+existingCPULimit=$(</sys/fs/cgroup/cpuset/cpuset.cpus grep -o '0-[1-9]*' | cut -d '-' -f 2)
+if [ -z "${existingCPULimit}" ]; then
+    existingCPULimit=$(cat /sys/fs/cgroup/cpuset/cpuset.cpus)
+fi
+
 /bin/echo $dom0_cgroup_memory_limit > /sys/fs/cgroup/memory/eve/memory.limit_in_bytes
 /bin/echo $dom0_cgroup_memory_soft_limit > /sys/fs/cgroup/memory/eve/memory.soft_limit_in_bytes
-/bin/echo $dom0_cgroup_cpus_limit > /sys/fs/cgroup/cpuset/eve/cpuset.cpus
+#Value that we are trying to update should not be greater than the existing value in cgroup system.
+if [ -n "${existingCPULimit}" ] && [ "$existingCPULimit" -ge "$dom0_cgroup_cpus_limit" ]; then
+    /bin/echo "0-$dom0_cgroup_cpus_limit" > /sys/fs/cgroup/cpuset/eve/cpuset.cpus
+fi
 
 /bin/echo $ctrd_cgroup_memory_limit > /sys/fs/cgroup/memory/eve/containerd/memory.limit_in_bytes
 /bin/echo $ctrd_cgroup_memory_soft_limit > /sys/fs/cgroup/memory/eve/containerd/memory.soft_limit_in_bytes
 
 /bin/echo $eve_cgroup_memory_limit > /sys/fs/cgroup/memory/eve/services/memory.limit_in_bytes
 /bin/echo $eve_cgroup_memory_soft_limit > /sys/fs/cgroup/memory/eve/services/memory.soft_limit_in_bytes
-/bin/echo $eve_cgroup_cpus_limit > /sys/fs/cgroup/cpuset/eve/services/cpuset.cpus
+if [ -n "${existingCPULimit}" ] && [ "$existingCPULimit" -ge "$eve_cgroup_cpus_limit" ]; then
+    /bin/echo "0-$eve_cgroup_cpus_limit" > /sys/fs/cgroup/cpuset/eve/services/cpuset.cpus
+fi
 
 for srv in $EVESRVICES; do
     /bin/echo $eve_cgroup_memory_limit > /sys/fs/cgroup/memory/eve/services/"${srv}"/memory.limit_in_bytes
     /bin/echo $eve_cgroup_memory_soft_limit > /sys/fs/cgroup/memory/eve/services/"${srv}"/memory.soft_limit_in_bytes
-    /bin/echo $eve_cgroup_cpus_limit > /sys/fs/cgroup/cpuset/eve/services/"${srv}"/cpuset.cpus
+    if [ -n "${existingCPULimit}" ] && [ "$existingCPULimit" -ge "$eve_cgroup_cpus_limit" ]; then
+        /bin/echo "0-$eve_cgroup_cpus_limit" > /sys/fs/cgroup/cpuset/eve/services/"${srv}"/cpuset.cpus
+    fi
 done


### PR DESCRIPTION
On EVE boot when we assigned cpu limits, the limit that we wanted to assign (0-1) was greater than the cpu limit of parent cgroup (0).
This caused `echo: write error: Invalid argument` error when we attempted to write our cpu limit to the cgroup.

Fixed this by adding the below check:
First, get the cpu limit of parent cgroup (/sys/fs/cgroup/cpuset/cpuset.cps) and write our limits to the cgroup only if its <= to the parent cpu limit. 
Signed-off-by: adarsh-zededa <adarsh@zededa.com>