### PR TITLE
get blob type

### DIFF
--- a/pkg/pillar/cas/cas.go
+++ b/pkg/pillar/cas/cas.go
@@ -31,6 +31,10 @@ type CAS interface {
 	GetBlobInfo(blobHash string) (*BlobInfo, error)
 	//ListBlobInfo: returns list of BlobInfo for all the blob present in CAS
 	ListBlobInfo() ([]*BlobInfo, error)
+	// ListBlobsMediaTypes get a map of all blobs and their media types.
+	// If a blob does not have a media type, it is not returned here.
+	// If you want *all* blobs, whether or not it has a type, use ListBlobInfo
+	ListBlobsMediaTypes() (map[string]string, error)
 	// IngestBlob: parses the given one or more `blobs` (BlobStatus) and for each blob reads the blob data from
 	// BlobStatus.Path and ingests it into CAS's blob store.
 	// Returns a list of loaded BlobStatus and an error is thrown if the read blob's hash does not match with the

--- a/pkg/pillar/cmd/downloader/syncop.go
+++ b/pkg/pillar/cmd/downloader/syncop.go
@@ -198,7 +198,7 @@ func handleSyncOp(ctx *downloaderContext, key string,
 			ctx:    ctx,
 			status: status,
 		}
-		err = download(ctx, trType, st, syncOp, serverURL, auth,
+		contentType, err := download(ctx, trType, st, syncOp, serverURL, auth,
 			dsCtx.Dpath, dsCtx.Region,
 			config.Size, ifname, ipSrc, remoteName, locFilename)
 		if err != nil {
@@ -215,6 +215,7 @@ func handleSyncOp(ctx *downloaderContext, key string,
 			size = info.Size()
 		}
 		status.Size = uint64(size)
+		status.ContentType = contentType
 		zedcloud.ZedCloudSuccess(ifname,
 			metricsUrl, 1024, size)
 		handleSyncOpResponse(ctx, config, status,

--- a/pkg/pillar/cmd/volumemgr/handlecontent.go
+++ b/pkg/pillar/cmd/volumemgr/handlecontent.go
@@ -180,8 +180,15 @@ func createContentTreeStatus(ctx *volumemgrContext, config types.ContentTreeConf
 				CertificateChain: config.CertificateChain,
 			}
 			if lookupOrCreateBlobStatus(ctx, sv, config.ContentSha256) == nil {
+				// the blobType is binary unless we are dealing with OCI
+				// in reality, this is not determined by the *format* but by the source,
+				// i.e. an OCI registry may have other formats, no matter what the
+				// image format is. This will do for now, though.
 				blobType := types.BlobBinary
 				if config.Format == zconfig.Format_CONTAINER {
+					// when first creating the root, the type is unknown,
+					// but will be updated from the mediatype passed by the
+					// Content-Type http header
 					blobType = types.BlobUnknown
 				}
 				rootBlob := &types.BlobStatus{

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -100,7 +100,7 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 					Sha256:      status.ContentSha256,
 					Size:        status.MaxDownloadSize,
 					State:       types.INITIAL,
-					BlobType:    types.BlobUnknown,
+					BlobType:    types.BlobUnknown, // our initial type is unknown, but it will be set by the Content-Type http header
 				}
 				log.Infof("doUpdateContentTree: publishing new root BlobStatus (%s) for content tree (%s)",
 					status.ContentSha256, status.ContentID)
@@ -172,19 +172,6 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 			} else {
 				log.Infof("doUpdateContentTree: blob sha %s download state VERIFIED", blob.Sha256)
 				// if verified, check for any children and start them off
-				// resolve any unknown types and get manifests of index, or children of manifest
-				blobType, err := resolveBlobType(ctx, blob)
-				if blobType != blob.BlobType || err != nil {
-					blob.BlobType = blobType
-					publishBlobStatus(ctx, blob)
-					changed = true
-				}
-				if err != nil {
-					log.Infof("doUpdateContentTree(%s): error resolving blob type: %v", blob.Sha256, err)
-					blob.SetError(err.Error(), time.Now())
-					publishBlobStatus(ctx, blob)
-					changed = true
-				}
 				blobChildren := blobsNotInList(getBlobChildren(ctx, sv, blob), status.Blobs)
 				if len(blobChildren) > 0 {
 					log.Infof("doUpdateContentTree: adding %d children", len(blobChildren))

--- a/pkg/pillar/types/downloadertypes.go
+++ b/pkg/pillar/types/downloadertypes.go
@@ -114,6 +114,7 @@ type DownloaderStatus struct {
 	CurrentSize      int64   // current total downloaded size as reported by the downloader
 	Progress         uint    // In percent i.e., 0-100, given by CurrentSize/ExpectedSize
 	ModTime          time.Time
+	ContentType      string // content-type header, if provided
 	// ErrorAndTime provides SetErrorNow() and ClearError()
 	ErrorAndTime
 	RetryCount int

--- a/pkg/pillar/zedUpload/datastore_req.go
+++ b/pkg/pillar/zedUpload/datastore_req.go
@@ -49,6 +49,9 @@ type DronaRequest struct {
 	// Filled by Drona, images list
 	imgList []string
 
+	// Filled by Drona, download metadata
+	contentType string
+
 	// Filled by Drona, uploaded blob content length
 	contentLength int64
 
@@ -182,6 +185,14 @@ func (req *DronaRequest) GetRemoteFileMD5() string {
 	req.Lock()
 	defer req.Unlock()
 	return req.remoteFileMD5
+}
+
+// GetContentType return the content type if available. If not, return
+// an empty string.
+func (req *DronaRequest) GetContentType() string {
+	req.Lock()
+	defer req.Unlock()
+	return req.contentType
 }
 
 // Update the actual size


### PR DESCRIPTION
This PR is a prerequisite for VM images in containers, but it stands on its own. The phrases "media type" and "content type" are used almost interchangeably in these comments.

It does several things:

* Provides a method to `type CAS` that lets one get the media types of the various content blobs. This is necessary to determine what type each blob is. This cannot be determined from the blob itself, as its content type is in the upper wrapping layer. E.g. a layer's type or a config's type is in the manifest, the manifest's type is in the index (if it exists), the index's type (or manifest's type, if no index) is in the tag on the image entry
* Provides a containerd implementation of the previous method
* Replaces the attempt to parse each downloaded blob (when doing OCI downloads) to determine the type, with reading the type from the wrapping layer, as above. For the root, uses the `Content-Type` http header. This is per the OCI [Image](http://github.com/opencontainers/image-spec) and [Distribution](https://github.com/opencontainers/distribution-spec) specs. I never really liked the implementation for what we did anyways; this makes it much cleaner.
* For boot time, when `BlobStatus` is created from content in containerd, uses the appropriate methods from above to determine the content type.

As above, this is a prerequisite to using VM images in OCI containers.