### PR TITLE
Major rework of the kernel build process

### DIFF
--- a/pkg/kernel/patches-4.19.x/0048-dell-xen-hack.patch
+++ b/pkg/kernel/patches-4.19.x/0048-dell-xen-hack.patch
@@ -1,5 +1,16 @@
+From b3dd9ae416e8dfa516faadf91e7d0aefe57aa376 Mon Sep 17 00:00:00 2001
+From: Roman Shaposhnik <rvs@zededa.com>
+Date: Tue, 25 Aug 2020 08:49:21 +0530
+Subject: [PATCH] Monster of a workaround for Xen on Dell 300x boot issues
+
+This change is pulled in from the eve.git commit:
+794721419fa1886d9b628803b5fa8 ("Monster of a workaround for Xen on Dell 300x boot issues")
+---
+ drivers/pinctrl/intel/pinctrl-baytrail.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
 diff --git a/drivers/pinctrl/intel/pinctrl-baytrail.c b/drivers/pinctrl/intel/pinctrl-baytrail.c
-index f38d596..1e15abc 100644
+index f38d596e..516e8b0b 100644
 --- a/drivers/pinctrl/intel/pinctrl-baytrail.c
 +++ b/drivers/pinctrl/intel/pinctrl-baytrail.c
 @@ -1723,6 +1723,7 @@ static int byt_gpio_probe(struct byt_gpio *vg)
@@ -14,7 +25,10 @@ index f38d596..1e15abc 100644
  					     (unsigned)irq_rc->start,
  					     byt_gpio_irq_handler);
  	}
-+#endif	
++#endif
  
  	return ret;
  }
+-- 
+2.17.1
+


### PR DESCRIPTION
Two major changes:

A. 
Kernel build process is now performed by an independent shell script. We use kernel git repo as opposed to a tarball for pulling in the tree. Important changes are described in the git log here:
- The build steps has been removed from Dockerfile and a new bash script
  has been written to build the kernel, in tree and out of tree kernel
  modules. The bash script is more readable and can be improved upon in
  subsequent iterations. The bash script also logs it's build output to
  a log file.
- The bash script cam be run in the context of the container as well as
  outside the container within a server.
- The kernel is no longer pulled from a tarball but cloned from the upstream
  git repo. The patches are not applied using "patch" command but by using
  "git am". This creates a clean history of all the patches applied and the
  files they touches. The git clone is a shallow clone for quick build but
  it can be easily converted to a full clone using "git fetch --unshallow"
  command.
- The USB serial driver is no longer downloaded but a copy of the driver is
  kept locally. This prevents build failures in case the upstream driver is
  no longer provided by the vendor for download or it's location is changed.
- The bash script defines various variables for various build directories. It
  cleans up after the build process completes.
- The script generates a tarball containing the final build output which is then
  copied over to /out in the final container.

B. 
All kernel patches except one were in mbox format. I have fixed the newly added patch to conform to mbox format so that "git am" can be used.
