### PR TITLE
zedcloud metrics was broken due to shared data across zedbox

### DIFF
--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -135,7 +135,7 @@ func Run(ps *pubsub.PubSub) int { //nolint:gocyclo
 	enterpriseFileName := types.IdentityDirname + "/enterprise"
 	nameFileName := types.IdentityDirname + "/name"
 
-	cms := zedcloud.GetCloudMetrics() // Need type of data
+	cms := zedcloud.GetCloudMetrics(log) // Need type of data
 	pub, err := ps.NewPublication(pubsub.PublicationOptions{
 		AgentName: agentName,
 		TopicType: cms,
@@ -439,7 +439,7 @@ func Run(ps *pubsub.PubSub) int { //nolint:gocyclo
 		log.Debugf("Wrote name %s", name)
 	}
 
-	err = pub.Publish("global", zedcloud.GetCloudMetrics())
+	err = pub.Publish("global", zedcloud.GetCloudMetrics(log))
 	if err != nil {
 		log.Errorln(err)
 	}

--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -75,7 +75,7 @@ func Run(ps *pubsub.PubSub) int {
 	stillRunning := time.NewTicker(25 * time.Second)
 	ps.StillRunning(agentName, warningTime, errorTime)
 
-	cms := zedcloud.GetCloudMetrics() // Need type of data
+	cms := zedcloud.GetCloudMetrics(log) // Need type of data
 	metricsPub, err := ps.NewPublication(pubsub.PublicationOptions{
 		AgentName: agentName,
 		TopicType: cms,
@@ -179,7 +179,7 @@ func Run(ps *pubsub.PubSub) int {
 
 		case <-publishTimer.C:
 			start := time.Now()
-			err := metricsPub.Publish("global", zedcloud.GetCloudMetrics())
+			err := metricsPub.Publish("global", zedcloud.GetCloudMetrics(log))
 			if err != nil {
 				log.Errorln(err)
 			}

--- a/pkg/pillar/cmd/downloader/syncop.go
+++ b/pkg/pillar/cmd/downloader/syncop.go
@@ -215,7 +215,7 @@ func handleSyncOp(ctx *downloaderContext, key string,
 			size = info.Size()
 		}
 		status.Size = uint64(size)
-		zedcloud.ZedCloudSuccess(ifname,
+		zedcloud.ZedCloudSuccess(log, ifname,
 			metricsUrl, 1024, size)
 		handleSyncOpResponse(ctx, config, status,
 			locFilename, key, "")
@@ -315,7 +315,7 @@ func constructDatastoreContext(ctx *downloaderContext, configName string, NameIs
 
 func sourceFailureError(ip, ifname, url string, err error) {
 	log.Errorf("Source IP %s failed: %s", ip, err)
-	zedcloud.ZedCloudFailure(ifname, url, 1024, 0, false)
+	zedcloud.ZedCloudFailure(log, ifname, url, 1024, 0, false)
 }
 
 func getDatastoreCredential(ctx *downloaderContext,

--- a/pkg/pillar/cmd/logmanager/logmanager.go
+++ b/pkg/pillar/cmd/logmanager/logmanager.go
@@ -181,7 +181,7 @@ func Run(ps *pubsub.PubSub) int {
 	stillRunning := time.NewTicker(25 * time.Second)
 	ps.StillRunning(agentName, warningTime, errorTime)
 
-	cms := zedcloud.GetCloudMetrics() // Need type of data
+	cms := zedcloud.GetCloudMetrics(log) // Need type of data
 	pub, err := ps.NewPublication(
 		pubsub.PublicationOptions{
 			AgentName: agentName,
@@ -345,7 +345,7 @@ func Run(ps *pubsub.PubSub) int {
 		case <-publishTimer.C:
 			start := time.Now()
 			log.Debugln("publishTimer at", time.Now())
-			err := pub.Publish("global", zedcloud.GetCloudMetrics())
+			err := pub.Publish("global", zedcloud.GetCloudMetrics(log))
 			if err != nil {
 				log.Errorln(err)
 			}

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -303,7 +303,7 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 	log.Debugln("log metrics: ", ReportDeviceMetric.Log)
 
 	// Collect zedcloud metrics from ourselves and other agents
-	cms := zedcloud.GetCloudMetrics()
+	cms := zedcloud.GetCloudMetrics(log)
 	if clientMetrics != nil {
 		cms = zedcloud.Append(cms, clientMetrics)
 	}
@@ -313,6 +313,12 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 	if downloaderMetrics != nil {
 		cms = zedcloud.Append(cms, downloaderMetrics)
 	}
+	// XXX for debug purposes we publish total
+	err = ctx.pubMetrics.Publish("total", cms)
+	if err != nil {
+		log.Errorln(err)
+	}
+
 	for ifname, cm := range cms {
 		metric := metrics.ZedcloudMetric{IfName: ifname,
 			Failures:          cm.FailureCount,

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -303,7 +303,11 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 	log.Debugln("log metrics: ", ReportDeviceMetric.Log)
 
 	// Collect zedcloud metrics from ourselves and other agents
-	cms := zedcloud.GetCloudMetrics(log)
+	cms := types.MetricsMap{} // Start empty
+	zedagentMetrics := zedcloud.GetCloudMetrics(log)
+	if zedagentMetrics != nil {
+		cms = zedcloud.Append(cms, zedagentMetrics)
+	}
 	if clientMetrics != nil {
 		cms = zedcloud.Append(cms, clientMetrics)
 	}

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -313,12 +313,6 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 	if downloaderMetrics != nil {
 		cms = zedcloud.Append(cms, downloaderMetrics)
 	}
-	// XXX for debug purposes we publish total
-	err = ctx.pubMetrics.Publish("total", cms)
-	if err != nil {
-		log.Errorln(err)
-	}
-
 	for ifname, cm := range cms {
 		metric := metrics.ZedcloudMetric{IfName: ifname,
 			Failures:          cm.FailureCount,

--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -33,8 +33,8 @@ import (
 type ZedCloudContext struct {
 	DeviceNetworkStatus *types.DeviceNetworkStatus
 	TlsConfig           *tls.Config
-	FailureFunc         func(intf string, url string, reqLen int64, respLen int64, authFail bool)
-	SuccessFunc         func(intf string, url string, reqLen int64, respLen int64)
+	FailureFunc         func(log *base.LogObject, intf string, url string, reqLen int64, respLen int64, authFail bool)
+	SuccessFunc         func(log *base.LogObject, intf string, url string, reqLen int64, respLen int64)
 	NoLedManager        bool // Don't call UpdateLedManagerConfig
 	DevUUID             uuid.UUID
 	DevSerial           string
@@ -287,7 +287,7 @@ func SendOnIntf(ctx *ZedCloudContext, destURL string, intf string, reqlen int64,
 
 	if addrCount == 0 {
 		if ctx.FailureFunc != nil {
-			ctx.FailureFunc(intf, reqUrl, 0, 0, false)
+			ctx.FailureFunc(log, intf, reqUrl, 0, 0, false)
 		}
 		// Determine a specific failure for intf
 		link, err := netlink.LinkByName(intf)
@@ -312,7 +312,7 @@ func SendOnIntf(ctx *ZedCloudContext, destURL string, intf string, reqlen int64,
 	numDNSServers := types.CountDNSServers(*ctx.DeviceNetworkStatus, intf)
 	if numDNSServers == 0 {
 		if ctx.FailureFunc != nil {
-			ctx.FailureFunc(intf, reqUrl, 0, 0, false)
+			ctx.FailureFunc(log, intf, reqUrl, 0, 0, false)
 		}
 		errStr := fmt.Sprintf("No DNS servers to connect to %s using intf %s",
 			reqUrl, intf)
@@ -507,7 +507,7 @@ func SendOnIntf(ctx *ZedCloudContext, destURL string, intf string, reqlen int64,
 					utils.UpdateLedManagerConfig(log, 12)
 				}
 				if ctx.FailureFunc != nil {
-					ctx.FailureFunc(intf, reqUrl, reqlen,
+					ctx.FailureFunc(log, intf, reqUrl, reqlen,
 						resplen, false)
 				}
 				continue
@@ -533,7 +533,7 @@ func SendOnIntf(ctx *ZedCloudContext, destURL string, intf string, reqlen int64,
 						utils.UpdateLedManagerConfig(log, 13)
 					}
 					if ctx.FailureFunc != nil {
-						ctx.FailureFunc(intf, reqUrl,
+						ctx.FailureFunc(log, intf, reqUrl,
 							reqlen, resplen, false)
 					}
 					err = errors.New(errStr)
@@ -546,7 +546,7 @@ func SendOnIntf(ctx *ZedCloudContext, destURL string, intf string, reqlen int64,
 		// Even if we got e.g., a 404 we consider the connection a
 		// success since we care about the connectivity to the cloud.
 		if ctx.SuccessFunc != nil {
-			ctx.SuccessFunc(intf, reqUrl, reqlen, resplen)
+			ctx.SuccessFunc(log, intf, reqUrl, reqlen, resplen)
 		}
 
 		switch resp.StatusCode {
@@ -568,7 +568,7 @@ func SendOnIntf(ctx *ZedCloudContext, destURL string, intf string, reqlen int64,
 						log.Errorf("SendOnIntf verify auth error %v, V2 %v, content len %d, url %s, extraStatus %v\n",
 							err, !envelopeErr, len(contents), reqUrl, rtf) // XXX change to debug later
 						if ctx.FailureFunc != nil {
-							ctx.FailureFunc(intf, reqUrl, 0, 0, true)
+							ctx.FailureFunc(log, intf, reqUrl, 0, 0, true)
 						}
 						return nil, nil, rtf, err
 					}
@@ -595,7 +595,7 @@ func SendOnIntf(ctx *ZedCloudContext, destURL string, intf string, reqlen int64,
 		}
 	}
 	if ctx.FailureFunc != nil {
-		ctx.FailureFunc(intf, reqUrl, 0, 0, false)
+		ctx.FailureFunc(log, intf, reqUrl, 0, 0, false)
 	}
 	errStr := fmt.Sprintf("All attempts to connect to %s using intf %s failed: %v",
 		reqUrl, intf, errorList)

--- a/pkg/pillar/zedcloud/zedcloudmetric.go
+++ b/pkg/pillar/zedcloud/zedcloudmetric.go
@@ -58,7 +58,7 @@ func updateAgentIfnameMetrics(log *base.LogObject, ifname string, m types.Zedclo
 }
 
 func ZedCloudFailure(log *base.LogObject, ifname string, url string, reqLen int64, respLen int64, authenFail bool) {
-	log.Infof("XXX ZedCloudFailure(%s, %s) %d %d",
+	log.Debugf("ZedCloudFailure(%s, %s) %d %d",
 		ifname, url, reqLen, respLen)
 	mutex.Lock()
 	m := getAgentIfnameMetrics(log, ifname)
@@ -87,7 +87,7 @@ func ZedCloudFailure(log *base.LogObject, ifname string, url string, reqLen int6
 }
 
 func ZedCloudSuccess(log *base.LogObject, ifname string, url string, reqLen int64, respLen int64) {
-	log.Infof("XXX ZedCloudSuccess(%s, %s) %d %d",
+	log.Debugf("ZedCloudSuccess(%s, %s) %d %d",
 		ifname, url, reqLen, respLen)
 	mutex.Lock()
 	m := getAgentIfnameMetrics(log, ifname)


### PR DESCRIPTION
This makes the raw metrics usable - without this fix they increase (perhaps double?) every time zedagent sends the metrics message to zedcloud.

The third commit is an older bug which also caused incorrect metrics reporting.

