### PR TITLE
Adding a wrapper for exec calls.

### DIFF
--- a/pkg/pillar/base/execwrapper.go
+++ b/pkg/pillar/base/execwrapper.go
@@ -1,0 +1,215 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Exec call wrapper for pillar agents.
+
+package base
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime/debug"
+	"strings"
+	"time"
+)
+
+const (
+	// Will wait for 1000s max for a call instead of waiting forever
+	maxTimeOutLimit = 1000
+	timeOutLimit    = 100
+)
+
+//Command holds the necessary data to execute command
+type Command struct {
+	command   *exec.Cmd
+	log       *LogObject
+	agentName string
+	timeout   time.Duration
+	buffer    *bytes.Buffer
+}
+
+// Output runs the command and returns its standard output.
+// Any returned error will usually be of type *ExitError.
+// Waits for the exec call to finish for `maxTimeOutLimit` after which timeout error is returned
+func (c *Command) Output() ([]byte, error) {
+	var buf bytes.Buffer
+	c.command.Stdout = &buf
+	c.buffer = &buf
+	c.timeout = maxTimeOutLimit
+	return c.execCommand()
+}
+
+// CombinedOutput runs the command and returns its combined standard output and standard error.
+// Waits for the exec call to finish for `maxTimeOutLimit` after which timeout error is returned
+func (c *Command) CombinedOutput() ([]byte, error) {
+	var buf bytes.Buffer
+	c.command.Stdout = &buf
+	c.command.Stderr = &buf
+	c.buffer = &buf
+	c.timeout = maxTimeOutLimit
+	return c.execCommand()
+}
+
+// OutputWithTimeout waits for the exec call to finish for `timeOutLimit`
+// after which timeout error is returned
+func (c *Command) OutputWithTimeout() ([]byte, error) {
+	var buf bytes.Buffer
+	c.command.Stdout = &buf
+	c.buffer = &buf
+	c.timeout = timeOutLimit
+	return c.execCommand()
+}
+
+// CombinedOutputWithTimeout waits for the exec call to finish for `timeOutLimit`
+// after which timeout error is returned
+func (c *Command) CombinedOutputWithTimeout() ([]byte, error) {
+	var buf bytes.Buffer
+	c.command.Stdout = &buf
+	c.command.Stderr = &buf
+	c.buffer = &buf
+	c.timeout = timeOutLimit
+	return c.execCommand()
+}
+
+// OutputWithCustomTimeout accepts a custom timeout limit to wait for the exec call.
+func (c *Command) OutputWithCustomTimeout(timeout uint) ([]byte, error) {
+	var buf bytes.Buffer
+	c.command.Stdout = &buf
+	c.buffer = &buf
+	c.timeout = time.Duration(timeout)
+	return c.execCommand()
+}
+
+// CombinedOutputWithCustomTimeout accepts a custom timeout limit to wait for the exec call.
+func (c *Command) CombinedOutputWithCustomTimeout(timeout uint) ([]byte, error) {
+	var buf bytes.Buffer
+	c.command.Stdout = &buf
+	c.command.Stderr = &buf
+	c.buffer = &buf
+	c.timeout = time.Duration(timeout)
+	return c.execCommand()
+}
+
+func (c *Command) execCommand() ([]byte, error) {
+	if c.log != nil {
+		c.log.Debugf("execCommand(%v)", c.command.Args)
+	}
+	if err := c.command.Start(); err != nil {
+		return nil, fmt.Errorf("execCommand(%v): error while starting command: %s", c.command.Args, err.Error())
+	}
+
+	// Use a channel to signal completion so we can use a select statement
+	done := make(chan error)
+	go func() { done <- c.command.Wait() }()
+	stillRunning := time.NewTicker(25 * time.Second)
+	defer stillRunning.Stop()
+
+	timer := time.After(c.timeout * time.Second)
+	for {
+		select {
+		case <-timer:
+			// Timeout happened first, kill the process.
+			c.command.Process.Kill()
+			return nil, fmt.Errorf("execCommand(%v): command timed out", c.command.Args)
+		case err := <-done:
+			// Command completed before timeout.
+			return c.buffer.Bytes(), err
+		case <-stillRunning.C:
+		}
+		updateAgentTouchFile(c.log, c.agentName)
+	}
+}
+
+//Exec returns Command object
+func Exec(log *LogObject, command string, arg ...string) *Command {
+	return &Command{
+		command:   exec.Command(command, arg...),
+		log:       log,
+		agentName: getAgentName(),
+	}
+}
+
+//updateAgentTouchFile updates agent's touch file under /var/run/
+func updateAgentTouchFile(log *LogObject, agentName string) {
+	if agentName == "" {
+		if log != nil {
+			log.Warnf("updateAgentTouchFile: agentName is empty")
+		}
+		return
+	}
+	filename := fmt.Sprintf("/var/run/%s.touch", agentName)
+	_, err := os.Stat(filename)
+	if err != nil {
+		file, err := os.Create(filename)
+		if err != nil {
+			if log != nil {
+				log.Infof("updateAgentTouchFile: %s\n", err)
+			}
+			return
+		}
+		file.Close()
+	}
+	_, err = os.Stat(filename)
+	if err != nil {
+		if log != nil {
+			log.Errorf("updateAgentTouchFile: %s\n", err)
+		}
+		return
+	}
+	now := time.Now()
+	err = os.Chtimes(filename, now, now)
+	if err != nil {
+		if log != nil {
+			log.Errorf("updateAgentTouchFile: %s\n", err)
+		}
+		return
+	}
+}
+
+//getAgentName parses stacktrace and returns involved agent under /pillar/cmd.
+func getAgentName() string {
+	stackTrace := strings.Split(string(debug.Stack()), "\n")
+	var methodName, file, agent, resultAgentName string
+	for i, trace := range stackTrace {
+		if strings.HasPrefix(trace, "github.com/lf-edge/eve/pkg/pillar/cmd/") {
+			trace = strings.TrimPrefix(trace, "github.com/lf-edge/eve/pkg/pillar/cmd/")
+			start := strings.Index(trace, ".")
+			end := strings.Index(trace, "(")
+			if start > -1 && end > -1 {
+				methodName = strings.TrimSpace(trace[start+1 : end])
+				agent = strings.TrimSpace(trace[:start])
+			}
+			filePath := strings.TrimSpace(stackTrace[i+1])
+			start = strings.LastIndex(filePath, "/")
+			end = strings.Index(filePath, ":")
+			if start > -1 && end > -1 {
+				file = strings.TrimSpace(filePath[start+1 : end])
+			}
+			break
+		}
+	}
+	switch agent {
+	case "zedagent":
+		switch file {
+		case "handlecertconfig.go":
+			if methodName == "getCertsFromController" || methodName == "parseControllerCerts" {
+				resultAgentName = "zedagentccerts"
+			} else {
+				resultAgentName = "zedagentattest"
+			}
+		case "reportinfo.go":
+			resultAgentName = "zedagentdevinfo"
+		case "handlemetrics.go":
+			resultAgentName = "zedagentmetrics"
+		case "handleconfig.go":
+			resultAgentName = "zedagentconfig"
+		default:
+			resultAgentName = "zedagent"
+		}
+	default:
+		resultAgentName = agent
+	}
+	return resultAgentName
+}

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path"
 	"runtime"
 	"strconv"
@@ -1552,7 +1551,7 @@ func configAdapters(ctx *domainContext, config types.DomainConfig) error {
 // by comparing the output from 'qemu-img info' and the format passed
 // in object in config
 func checkDiskFormat(diskStatus types.DiskStatus) error {
-	imgInfo, err := diskmetrics.GetImgInfo(diskStatus.FileLocation)
+	imgInfo, err := diskmetrics.GetImgInfo(log, diskStatus.FileLocation)
 	if err != nil {
 		return err
 	}
@@ -2087,7 +2086,7 @@ func mkisofs(output string, dir string) error {
 		dir,
 	}
 	log.Infof("Calling command %s %v\n", cmd, args)
-	stdoutStderr, err := exec.Command(cmd, args...).CombinedOutput()
+	stdoutStderr, err := base.Exec(log, cmd, args...).CombinedOutput()
 	if err != nil {
 		errStr := fmt.Sprintf("mkisofs failed: %s",
 			string(stdoutStderr))
@@ -2589,7 +2588,7 @@ func doModprobe(driver string, add bool) error {
 	}
 	args = append(args, driver)
 	log.Infof("Calling command %s %v\n", cmd, args)
-	stdoutStderr, err := exec.Command(cmd, args...).CombinedOutput()
+	stdoutStderr, err := base.Exec(log, cmd, args...).CombinedOutput()
 	if err != nil {
 		log.Error(err)
 		log.Errorf("modprobe output: %s", stdoutStderr)

--- a/pkg/pillar/cmd/ledmanager/ledmanager.go
+++ b/pkg/pillar/cmd/ledmanager/ledmanager.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -451,9 +450,8 @@ func ExecuteDDCmd(ledName string) {
 }
 
 func doDD(count int) {
-	cmd := exec.Command("dd", "if="+diskDevice, "of=/dev/null", "bs=4M",
-		fmt.Sprintf("count=%d", count), "iflag=nocache")
-	stdout, err := cmd.Output()
+	stdout, err := base.Exec(log, "dd", "if="+diskDevice, "of=/dev/null", "bs=4M",
+		fmt.Sprintf("count=%d", count), "iflag=nocache").Output()
 	if err != nil {
 		if printOnce {
 			log.Errorln("dd error: ", err)

--- a/pkg/pillar/cmd/tpmmgr/tpmmgr.go
+++ b/pkg/pillar/cmd/tpmmgr/tpmmgr.go
@@ -19,7 +19,6 @@ import (
 	"io"
 	"io/ioutil"
 	"math/big"
-	"os/exec"
 	"reflect"
 	"time"
 
@@ -31,6 +30,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 )
 
@@ -353,13 +353,8 @@ func genCredentials() error {
 	//First try to read from TPM, if it was stored earlier
 	err := readCredentials()
 	if err != nil {
-		// Generate a new uuid
-		out, err := exec.Command("uuidgen").Output()
-		if err != nil {
-			return fmt.Errorf("Error in generating uuid, %v", err)
-		}
 		//Write uuid to credentials file for faster access
-		err = ioutil.WriteFile(etpm.TpmCredentialsFileName, out, 0644)
+		err = ioutil.WriteFile(etpm.TpmCredentialsFileName, []byte(uuid.NewV4().String()), 0644)
 		if err != nil {
 			log.Errorf("Writing to credentials file failed: %v", err)
 			return err

--- a/pkg/pillar/cmd/volumemgr/create.go
+++ b/pkg/pillar/cmd/volumemgr/create.go
@@ -184,7 +184,7 @@ func maybeResizeDisk(diskfile string, maxsizebytes uint64) error {
 	if maxsizebytes == 0 {
 		return nil
 	}
-	currentSize, err := diskmetrics.GetDiskVirtualSize(diskfile)
+	currentSize, err := diskmetrics.GetDiskVirtualSize(log, diskfile)
 	if err != nil {
 		return err
 	}
@@ -195,6 +195,6 @@ func maybeResizeDisk(diskfile string, maxsizebytes uint64) error {
 			diskfile, maxsizebytes, currentSize)
 		return nil
 	}
-	err = diskmetrics.ResizeImg(diskfile, maxsizebytes)
+	err = diskmetrics.ResizeImg(log, diskfile, maxsizebytes)
 	return err
 }

--- a/pkg/pillar/cmd/volumemgr/handlevolume.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume.go
@@ -44,7 +44,7 @@ func handleVolumeCreate(ctxArg interface{}, key string,
 		status.VolumeCreated = true
 		if status.MaxVolSize == 0 {
 			var err error
-			_, status.MaxVolSize, err = utils.GetVolumeSize(status.FileLocation)
+			_, status.MaxVolSize, err = utils.GetVolumeSize(log, status.FileLocation)
 			if err != nil {
 				log.Error(err)
 			}

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -423,7 +423,7 @@ func doUpdateVol(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool)
 				var err error
 				log.Infof("doUpdateVol: MaxVolSize is 0 for %s. Filling it up.",
 					status.FileLocation)
-				_, status.MaxVolSize, err = utils.GetVolumeSize(status.FileLocation)
+				_, status.MaxVolSize, err = utils.GetVolumeSize(log, status.FileLocation)
 				if err != nil {
 					log.Error(err)
 				}

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -640,7 +640,7 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 }
 
 func getDiskInfo(vrs types.VolumeRefStatus, appDiskDetails *metrics.AppDiskMetric) error {
-	actualSize, maxSize, err := utils.GetVolumeSize(vrs.ActiveFileLocation)
+	actualSize, maxSize, err := utils.GetVolumeSize(log, vrs.ActiveFileLocation)
 	if err != nil {
 		return err
 	}
@@ -651,7 +651,7 @@ func getDiskInfo(vrs types.VolumeRefStatus, appDiskDetails *metrics.AppDiskMetri
 		appDiskDetails.DiskType = "CONTAINER"
 		return nil
 	}
-	imgInfo, err := diskmetrics.GetImgInfo(vrs.ActiveFileLocation)
+	imgInfo, err := diskmetrics.GetImgInfo(log, vrs.ActiveFileLocation)
 	if err != nil {
 		return err
 	}
@@ -663,7 +663,7 @@ func getDiskInfo(vrs types.VolumeRefStatus, appDiskDetails *metrics.AppDiskMetri
 func getVolumeResourcesInfo(volStatus *types.VolumeStatus,
 	volumeResourcesDetails *info.VolumeResources) error {
 
-	actualSize, maxSize, err := utils.GetVolumeSize(volStatus.FileLocation)
+	actualSize, maxSize, err := utils.GetVolumeSize(log, volStatus.FileLocation)
 	if err != nil {
 		return err
 	}
@@ -1245,7 +1245,7 @@ func createVolumeInstanceMetrics(ctx *getconfigContext, reportMetrics *metrics.Z
 
 func getVolumeResourcesMetrics(name string, volumeMetric *metrics.ZMetricVolume) error {
 
-	actualSize, maxSize, err := utils.GetVolumeSize(name)
+	actualSize, maxSize, err := utils.GetVolumeSize(log, name)
 	if err != nil {
 		return err
 	}

--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -8,8 +8,8 @@ package zedagent
 import (
 	"bytes"
 	"fmt"
+	"github.com/lf-edge/eve/pkg/pillar/base"
 	"os"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -75,7 +75,7 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 	ReportDeviceInfo := new(info.ZInfoDevice)
 
 	var machineArch string
-	stdout, err := exec.Command("uname", "-m").Output()
+	stdout, err := base.Exec(log, "uname", "-m").Output()
 	if err != nil {
 		log.Errorf("uname -m failed %s", err)
 	} else {
@@ -83,7 +83,7 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 		ReportDeviceInfo.MachineArch = *proto.String(strings.TrimSpace(machineArch))
 	}
 
-	stdout, err = exec.Command("uname", "-p").Output()
+	stdout, err = base.Exec(log, "uname", "-p").Output()
 	if err != nil {
 		log.Errorf("uname -p failed %s", err)
 	} else {
@@ -91,7 +91,7 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 		ReportDeviceInfo.CpuArch = *proto.String(strings.TrimSpace(cpuArch))
 	}
 
-	stdout, err = exec.Command("uname", "-i").Output()
+	stdout, err = base.Exec(log, "uname", "-i").Output()
 	if err != nil {
 		log.Errorf("uname -i failed %s", err)
 	} else {

--- a/pkg/pillar/cmd/zedrouter/dnsmasq.go
+++ b/pkg/pillar/cmd/zedrouter/dnsmasq.go
@@ -8,11 +8,11 @@ package zedrouter
 import (
 	"bufio"
 	"fmt"
+	"github.com/lf-edge/eve/pkg/pillar/base"
 	"io"
 	"io/ioutil"
 	"net"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 	"syscall"
@@ -385,9 +385,8 @@ func startDnsmasq(bridgeName string) {
 		"-C",
 		cfgPathname,
 	}
-	cmd := exec.Command(name, args...)
 	log.Infof("Calling command %s %v\n", name, args)
-	out, err := cmd.CombinedOutput()
+	out, err := base.Exec(log, name, args...).CombinedOutput()
 	if err != nil {
 		log.Errorf("startDnsmasq: Failed starting dnsmasq for bridge %s (%s)",
 			bridgeName, err)

--- a/pkg/pillar/cmd/zedrouter/ipset.go
+++ b/pkg/pillar/cmd/zedrouter/ipset.go
@@ -8,9 +8,9 @@ package zedrouter
 import (
 	"errors"
 	"fmt"
+	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"net"
-	"os/exec"
 )
 
 // Create a pair of local ipsets called "ipv6.local" and "ipv4.local"
@@ -200,7 +200,7 @@ func ipsetCreate(ipsetName string, setType string, ipVer int) error {
 	}
 	args := []string{"create", ipsetName, setType, "family", family}
 	log.Infof("Calling command %s %v\n", cmd, args)
-	if _, err := exec.Command(cmd, args...).CombinedOutput(); err != nil {
+	if _, err := base.Exec(log, cmd, args...).CombinedOutput(); err != nil {
 		return err
 	}
 	return nil
@@ -210,7 +210,7 @@ func ipsetDestroy(ipsetName string) error {
 	cmd := "ipset"
 	args := []string{"destroy", ipsetName}
 	log.Infof("Calling command %s %v\n", cmd, args)
-	if res, err := exec.Command(cmd, args...).CombinedOutput(); err != nil {
+	if res, err := base.Exec(log, cmd, args...).CombinedOutput(); err != nil {
 		errStr := fmt.Sprintf("ipset destroy %s failed %s: %s",
 			ipsetName, res, err)
 		return errors.New(errStr)
@@ -222,7 +222,7 @@ func ipsetFlush(ipsetName string) error {
 	cmd := "ipset"
 	args := []string{"flush", ipsetName}
 	log.Infof("Calling command %s %v\n", cmd, args)
-	if res, err := exec.Command(cmd, args...).CombinedOutput(); err != nil {
+	if res, err := base.Exec(log, cmd, args...).CombinedOutput(); err != nil {
 		errStr := fmt.Sprintf("ipset flush %s failed %s: %s",
 			ipsetName, res, err)
 		return errors.New(errStr)
@@ -234,7 +234,7 @@ func ipsetAdd(ipsetName string, member string) error {
 	cmd := "ipset"
 	args := []string{"add", ipsetName, member}
 	log.Infof("Calling command %s %v\n", cmd, args)
-	if res, err := exec.Command(cmd, args...).CombinedOutput(); err != nil {
+	if res, err := base.Exec(log, cmd, args...).CombinedOutput(); err != nil {
 		errStr := fmt.Sprintf("ipset add %s failed %s: %s",
 			ipsetName, res, err)
 		return errors.New(errStr)
@@ -246,7 +246,7 @@ func ipsetDel(ipsetName string, member string) error {
 	cmd := "ipset"
 	args := []string{"del", ipsetName, member}
 	log.Infof("Calling command %s %v\n", cmd, args)
-	if res, err := exec.Command(cmd, args...).CombinedOutput(); err != nil {
+	if res, err := base.Exec(log, cmd, args...).CombinedOutput(); err != nil {
 		errStr := fmt.Sprintf("ipset del %s failed %s: %s",
 			ipsetName, res, err)
 		return errors.New(errStr)
@@ -258,7 +258,7 @@ func ipsetExists(ipsetName string) bool {
 	cmd := "ipset"
 	args := []string{"list", ipsetName}
 	log.Infof("Calling command %s %v\n", cmd, args)
-	if _, err := exec.Command(cmd, args...).Output(); err != nil {
+	if _, err := base.Exec(log, cmd, args...).Output(); err != nil {
 		return false
 	}
 	return true

--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -10,9 +10,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/lf-edge/eve/pkg/pillar/base"
 	uuid "github.com/satori/go.uuid"
 	"net"
-	"os/exec"
 	"strconv"
 	"strings"
 
@@ -144,7 +144,7 @@ func disableIcmpRedirects(bridgeName string) {
 	sysctlSetting := fmt.Sprintf("net.ipv4.conf.%s.send_redirects=0", bridgeName)
 	args := []string{"-w", sysctlSetting}
 	log.Infof("Calling command %s %v\n", "sysctl", args)
-	out, err := exec.Command("sysctl", args...).CombinedOutput()
+	out, err := base.Exec(log, "sysctl", args...).CombinedOutput()
 	if err != nil {
 		errStr := fmt.Sprintf("sysctl command %s failed %s output %s",
 			args, err, out)

--- a/pkg/pillar/cmd/zedrouter/stats.go
+++ b/pkg/pillar/cmd/zedrouter/stats.go
@@ -8,9 +8,9 @@ package zedrouter
 import (
 	"encoding/json"
 	"errors"
+	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"net"
-	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -34,8 +34,7 @@ type readBlock struct {
 }
 
 func ipSecStatusCmdGet(vpnStatus *types.VpnStatus) error {
-	cmd := exec.Command("ipsec", "statusall")
-	bytes, err := cmd.Output()
+	bytes, err := base.Exec(log, "ipsec", "statusall").Output()
 	if err != nil {
 		log.Errorf("%s for %s statusall\n", err.Error(), "ipsec")
 		return err
@@ -50,8 +49,7 @@ func ipSecStatusCmdGet(vpnStatus *types.VpnStatus) error {
 }
 
 func swanCtlCmdGet(vpnStatus *types.VpnStatus) error {
-	cmd := exec.Command("swanctl", "-l")
-	bytes, err := cmd.Output()
+	bytes, err := base.Exec(log, "swanctl", "-l").Output()
 	if err != nil {
 		log.Errorf("%s for %s -l\n", err.Error(), "swanctl")
 		return err

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/exec"
 	"strconv"
 	"sync"
 	"time"
@@ -1547,7 +1546,7 @@ func pkillUserArgs(userName string, match string, printOnError bool) {
 	var out []byte
 	for i := 0; i < 3; i++ {
 		log.Infof("Calling command %s %v\n", cmd, args)
-		out, err = exec.Command(cmd, args...).CombinedOutput()
+		out, err = base.Exec(log, cmd, args...).CombinedOutput()
 		if err == nil {
 			break
 		}

--- a/pkg/pillar/devicenetwork/dhcpcd.go
+++ b/pkg/pillar/devicenetwork/dhcpcd.go
@@ -234,7 +234,7 @@ func dhcpcdCmd(log *base.LogObject, op string, extras []string, ifname string, b
 		}()
 	} else {
 		log.Infof("Calling command %s %v\n", name, args)
-		out, err := exec.Command(name, args...).CombinedOutput()
+		out, err := base.Exec(log, name, args...).CombinedOutput()
 		if err != nil {
 			errStr := fmt.Sprintf("dhcpcd command %s failed %s output %s",
 				args, err, out)

--- a/pkg/pillar/devicenetwork/dns.go
+++ b/pkg/pillar/devicenetwork/dns.go
@@ -10,7 +10,6 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"net"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 )
@@ -30,8 +29,7 @@ func GetDhcpInfo(log *base.LogObject, us *types.NetworkPortStatus) {
 	// XXX get error -1 unless we have -4
 	// XXX add IPv6 support
 	log.Infof("Calling dhcpcd -U -4 %s\n", us.IfName)
-	cmd := exec.Command("dhcpcd", "-U", "-4", us.IfName)
-	stdoutStderr, err := cmd.CombinedOutput()
+	stdoutStderr, err := base.Exec(log, "dhcpcd", "-U", "-4", us.IfName).CombinedOutput()
 	if err != nil {
 		errStr := fmt.Sprintf("dhcpcd -U failed %s: %s",
 			string(stdoutStderr), err)

--- a/pkg/pillar/diskmetrics/diskmetrics.go
+++ b/pkg/pillar/diskmetrics/diskmetrics.go
@@ -8,7 +8,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
 )
 
 // Matches the json output of qemu-img info
@@ -21,14 +22,14 @@ type ImgInfo struct {
 	DirtyFlag   bool   `json:"dirty-flag"`
 }
 
-func GetImgInfo(diskfile string) (*ImgInfo, error) {
+func GetImgInfo(log *base.LogObject, diskfile string) (*ImgInfo, error) {
 	var imgInfo ImgInfo
 
 	if _, err := os.Stat(diskfile); err != nil {
 		return nil, err
 	}
-	output, err := exec.Command("/usr/bin/qemu-img",
-		"info", "-U", "--output=json", diskfile).CombinedOutput()
+	output, err := base.Exec(log, "/usr/bin/qemu-img", "info", "-U", "--output=json",
+		diskfile).CombinedOutput()
 	if err != nil {
 		errStr := fmt.Sprintf("qemu-img failed: %s, %s\n",
 			err, output)
@@ -41,21 +42,21 @@ func GetImgInfo(diskfile string) (*ImgInfo, error) {
 }
 
 // GetDiskVirtualSize - returns VirtualSize of the image
-func GetDiskVirtualSize(diskfile string) (uint64, error) {
-	imgInfo, err := GetImgInfo(diskfile)
+func GetDiskVirtualSize(log *base.LogObject, diskfile string) (uint64, error) {
+	imgInfo, err := GetImgInfo(log, diskfile)
 	if err != nil {
 		return 0, err
 	}
 	return imgInfo.VirtualSize, nil
 }
 
-func ResizeImg(diskfile string, newsize uint64) error {
+func ResizeImg(log *base.LogObject, diskfile string, newsize uint64) error {
 
 	if _, err := os.Stat(diskfile); err != nil {
 		return err
 	}
-	output, err := exec.Command("/usr/bin/qemu-img",
-		"resize", diskfile, fmt.Sprintf("%d", newsize)).CombinedOutput()
+	output, err := base.Exec(log, "/usr/bin/qemu-img", "resize", diskfile,
+		fmt.Sprintf("%d", newsize)).CombinedOutput()
 	if err != nil {
 		errStr := fmt.Sprintf("qemu-img failed: %s, %s\n",
 			err, output)

--- a/pkg/pillar/diskmetrics/usage.go
+++ b/pkg/pillar/diskmetrics/usage.go
@@ -5,7 +5,6 @@ package diskmetrics
 
 import (
 	"io/ioutil"
-	"os/exec"
 	"strconv"
 	"strings"
 
@@ -38,7 +37,7 @@ func SizeFromDir(log *base.LogObject, dirname string) uint64 {
 // PartitionSize - Given "sdb1" return the size of the partition; "sdb"
 // to size of disk. Returns size and a bool to indicate that it is a partition.
 func PartitionSize(log *base.LogObject, part string) (uint64, bool) {
-	out, err := exec.Command("lsblk", "-nbdo", "SIZE", "/dev/"+part).Output()
+	out, err := base.Exec(log, "lsblk", "-nbdo", "SIZE", "/dev/"+part).Output()
 	if err != nil {
 		log.Errorf("lsblk -nbdo SIZE %s failed %s\n", "/dev/"+part, err)
 		return 0, false
@@ -55,7 +54,7 @@ func PartitionSize(log *base.LogObject, part string) (uint64, bool) {
 
 // diskType returns a string like "disk", "part", "loop"
 func diskType(log *base.LogObject, part string) string {
-	out, err := exec.Command("lsblk", "-nbdo", "TYPE", "/dev/"+part).Output()
+	out, err := base.Exec(log, "lsblk", "-nbdo", "TYPE", "/dev/"+part).Output()
 	if err != nil {
 		log.Errorf("lsblk -nbdo TYPE %s failed %s\n", "/dev/"+part, err)
 		return ""
@@ -66,7 +65,7 @@ func diskType(log *base.LogObject, part string) string {
 // FindDisksPartitions returns the names of all disks and all partitions
 // Return an array of names like "sda", "sdb1"
 func FindDisksPartitions(log *base.LogObject) []string {
-	out, err := exec.Command("lsblk", "-nlo", "NAME").Output()
+	out, err := base.Exec(log, "lsblk", "-nlo", "NAME").Output()
 	if err != nil {
 		log.Errorf("lsblk -nlo NAME failed %s", err)
 		return nil

--- a/pkg/pillar/hardware/model.go
+++ b/pkg/pillar/hardware/model.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"regexp"
 	"strings"
 
@@ -53,15 +52,13 @@ func GetHardwareModelNoOverride(log *base.LogObject) string {
 	product := ""
 	manufacturer := ""
 
-	cmd := exec.Command("dmidecode", "-s", "system-product-name")
-	pname, err := cmd.Output()
+	pname, err := base.Exec(log, "dmidecode", "-s", "system-product-name").Output()
 	if err != nil {
 		log.Errorln("dmidecode system-product-name:", err)
 	} else {
 		product = string(pname)
 	}
-	cmd = exec.Command("dmidecode", "-s", "system-manufacturer")
-	manu, err := cmd.Output()
+	manu, err := base.Exec(log, "dmidecode", "-s", "system-manufacturer").Output()
 	if err != nil {
 		log.Errorln("dmidecode system-manufacturer:", err)
 	} else {
@@ -165,8 +162,7 @@ func GetSoftSerial(log *base.LogObject) string {
 }
 
 func GetProductSerial(log *base.LogObject) string {
-	cmd := exec.Command("dmidecode", "-s", "system-serial-number")
-	serial, err := cmd.Output()
+	serial, err := base.Exec(log, "dmidecode", "-s", "system-serial-number").Output()
 	if err != nil {
 		log.Errorf("GetProductSerial system-serial-number failed %s\n",
 			err)
@@ -181,29 +177,25 @@ func GetProductSerial(log *base.LogObject) string {
 
 // Returns productManufacturer, productName, productVersion, productSerial, productUuid
 func GetDeviceManufacturerInfo(log *base.LogObject) (string, string, string, string, string) {
-	cmd := exec.Command("dmidecode", "-s", "system-product-name")
-	pname, err := cmd.Output()
+	pname, err := base.Exec(log, "dmidecode", "-s", "system-product-name").Output()
 	if err != nil {
 		log.Errorf("GetDeviceManufacturerInfo system-product-name failed %s\n",
 			err)
 		pname = []byte{}
 	}
-	cmd = exec.Command("dmidecode", "-s", "system-manufacturer")
-	manufacturer, err := cmd.Output()
+	manufacturer, err := base.Exec(log, "dmidecode", "-s", "system-manufacturer").Output()
 	if err != nil {
 		log.Errorf("GetDeviceManufacturerInfo system-manufacturer failed %s\n",
 			err)
 		manufacturer = []byte{}
 	}
-	cmd = exec.Command("dmidecode", "-s", "system-version")
-	version, err := cmd.Output()
+	version, err := base.Exec(log, "dmidecode", "-s", "system-version").Output()
 	if err != nil {
 		log.Errorf("GetDeviceManufacturerInfo system-version failed %s\n",
 			err)
 		version = []byte{}
 	}
-	cmd = exec.Command("dmidecode", "-s", "system-uuid")
-	uuid, err := cmd.Output()
+	uuid, err := base.Exec(log, "dmidecode", "-s", "system-uuid").Output()
 	if err != nil {
 		log.Errorf("GetDeviceManufacturerInfo system-uuid failed %s\n",
 			err)
@@ -219,22 +211,19 @@ func GetDeviceManufacturerInfo(log *base.LogObject) (string, string, string, str
 
 // Returns BIOS vendor, version, release-date
 func GetDeviceBios(log *base.LogObject) (string, string, string) {
-	cmd := exec.Command("dmidecode", "-s", "bios-vendor")
-	vendor, err := cmd.Output()
+	vendor, err := base.Exec(log, "dmidecode", "-s", "bios-vendor").Output()
 	if err != nil {
 		log.Errorf("GetDeviceBios bios-vendor failed %s\n",
 			err)
 		vendor = []byte{}
 	}
-	cmd = exec.Command("dmidecode", "-s", "bios-version")
-	version, err := cmd.Output()
+	version, err := base.Exec(log, "dmidecode", "-s", "bios-version").Output()
 	if err != nil {
 		log.Errorf("GetDeviceBios bios-version failed %s\n",
 			err)
 		version = []byte{}
 	}
-	cmd = exec.Command("dmidecode", "-s", "bios-release-date")
-	releaseDate, err := cmd.Output()
+	releaseDate, err := base.Exec(log, "dmidecode", "-s", "bios-release-date").Output()
 	if err != nil {
 		log.Errorf("GetDeviceBios bios-release-date failed %s\n",
 			err)

--- a/pkg/pillar/iptables/iptables.go
+++ b/pkg/pillar/iptables/iptables.go
@@ -8,7 +8,6 @@ package iptables
 import (
 	"errors"
 	"fmt"
-	"os/exec"
 	"strconv"
 	"strings"
 
@@ -28,9 +27,9 @@ func IptableCmdOut(log *base.LogObject, args ...string) (string, error) {
 	args[1] = "5"
 	if log != nil {
 		log.Infof("Calling command %s %v\n", cmd, args)
-		out, err = exec.Command(cmd, args...).CombinedOutput()
+		out, err = base.Exec(log, cmd, args...).CombinedOutput()
 	} else {
-		out, err = exec.Command(cmd, args...).Output()
+		out, err = base.Exec(log, cmd, args...).Output()
 	}
 	if err != nil {
 		errStr := fmt.Sprintf("iptables command %s failed %s output %s",
@@ -60,9 +59,9 @@ func Ip6tableCmdOut(log *base.LogObject, args ...string) (string, error) {
 	args[1] = "5"
 	if log != nil {
 		log.Infof("Calling command %s %v\n", cmd, args)
-		out, err = exec.Command(cmd, args...).CombinedOutput()
+		out, err = base.Exec(log, cmd, args...).CombinedOutput()
 	} else {
-		out, err = exec.Command(cmd, args...).Output()
+		out, err = base.Exec(log, cmd, args...).Output()
 	}
 	if err != nil {
 		errStr := fmt.Sprintf("ip6tables command %s failed %s output %s",

--- a/pkg/pillar/utils/volumeutils.go
+++ b/pkg/pillar/utils/volumeutils.go
@@ -6,6 +6,7 @@ package utils
 import (
 	"errors"
 	"fmt"
+	"github.com/lf-edge/eve/pkg/pillar/base"
 	"os"
 	"path/filepath"
 
@@ -28,7 +29,7 @@ func dirSize(path string) (uint64, error) {
 }
 
 // GetVolumeSize returns the actual and maximum size of the volume
-func GetVolumeSize(name string) (uint64, uint64, error) {
+func GetVolumeSize(log *base.LogObject, name string) (uint64, uint64, error) {
 	info, err := os.Stat(name)
 	if err != nil {
 		errStr := fmt.Sprintf("GetVolumeMaxSize failed for %s: %v",
@@ -44,7 +45,7 @@ func GetVolumeSize(name string) (uint64, uint64, error) {
 		}
 		return size, size, nil
 	}
-	imgInfo, err := diskmetrics.GetImgInfo(name)
+	imgInfo, err := diskmetrics.GetImgInfo(log, name)
 	if err != nil {
 		errStr := fmt.Sprintf("GetVolumeMaxSize failed for %s: %v",
 			name, err)

--- a/pkg/pillar/zboot/zboot.go
+++ b/pkg/pillar/zboot/zboot.go
@@ -333,9 +333,8 @@ func WriteToPartition(log *base.LogObject, srcFilename string, partName string) 
 
 	log.Infof("WriteToPartition %s, %s: %v\n", partName, devName, srcFilename)
 
-	ddCmd := exec.Command("dd", "if="+srcFilename, "of="+devName, "bs=8M")
 	zbootMutex.Lock()
-	_, err := ddCmd.Output()
+	_, err := base.Exec(log, "dd", "if="+srcFilename, "of="+devName, "bs=8M").Output()
 	zbootMutex.Unlock()
 	if err != nil {
 		errStr := fmt.Sprintf("WriteToPartition %s failed %v\n", partName, err)

--- a/pkg/pillar/zedcloud/tls.go
+++ b/pkg/pillar/zedcloud/tls.go
@@ -19,7 +19,6 @@ import (
 	"golang.org/x/crypto/ocsp"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -348,9 +347,8 @@ func updateEtcSSLforProxyCerts(ctx *ZedCloudContext, dns *types.DeviceNetworkSta
 	}
 
 	cmdName := "/usr/sbin/update-ca-certificates"
-	cmd := exec.Command(cmdName)
 	log.Infof("updateEtcSSLforProxyCerts: Calling command %s", cmdName)
-	out, err := cmd.CombinedOutput()
+	out, err := base.Exec(log, cmdName).CombinedOutput()
 	if err != nil {
 		log.Errorf("updateEtcSSLforProxyCerts: update-ca-certificates, certs num %d, (%s)", len(newCerts), err)
 	} else {


### PR DESCRIPTION
Issue:
When there is a memory shortage on the device, few agents like zedagentmetric and zedrouter were stuck on exec calls.
Meanwhile, the service's touch file was not updated while the services were waiting for the exec call to finish. This eventually led to Watchdog reboots.

Fix:
Added a wrapper on exec call which along with the command, also accepts the agentName and while waiting for the exec call to finish, the wrapper method will keep punching the agent's touch file. 

Rearranged few method so that caller and callee methods are in the same file. This was needed to help with figuring out zedagent's subagent name from the stacktrace. 