### PR TITLE
Fix "0048-dell-xen-hack.patch" to make it compatible with mbox format

### DIFF
--- a/pkg/kernel/patches-4.19.x/0048-dell-xen-hack.patch
+++ b/pkg/kernel/patches-4.19.x/0048-dell-xen-hack.patch
@@ -1,5 +1,16 @@
+From b3dd9ae416e8dfa516faadf91e7d0aefe57aa376 Mon Sep 17 00:00:00 2001
+From: Roman Shaposhnik <rvs@zededa.com>
+Date: Tue, 25 Aug 2020 08:49:21 +0530
+Subject: [PATCH] Monster of a workaround for Xen on Dell 300x boot issues
+
+This change is pulled in from the eve.git commit:
+794721419fa1886d9b628803b5fa8 ("Monster of a workaround for Xen on Dell 300x boot issues")
+---
+ drivers/pinctrl/intel/pinctrl-baytrail.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
 diff --git a/drivers/pinctrl/intel/pinctrl-baytrail.c b/drivers/pinctrl/intel/pinctrl-baytrail.c
-index f38d596..1e15abc 100644
+index f38d596e..516e8b0b 100644
 --- a/drivers/pinctrl/intel/pinctrl-baytrail.c
 +++ b/drivers/pinctrl/intel/pinctrl-baytrail.c
 @@ -1723,6 +1723,7 @@ static int byt_gpio_probe(struct byt_gpio *vg)
@@ -14,7 +25,10 @@ index f38d596..1e15abc 100644
  					     (unsigned)irq_rc->start,
  					     byt_gpio_irq_handler);
  	}
-+#endif	
++#endif
  
  	return ret;
  }
+-- 
+2.17.1
+


### PR DESCRIPTION
The patch "0048-dell-xen-hack.patch" is currently in raw form which works
perfectly with "patch" command but does not work with "git am". This change
fixes the patch so that it complies properly with mbox format so that git am
can consume it. All other patches are already in mbox format.

Signed-off-by: Ani Sinha <ani@anisinha.ca>