### PR TITLE
Adding a 50M memory cap for rsyslog

### DIFF
--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -29,6 +29,10 @@ services:
    - name: rsyslogd
      image: RSYSLOGD_TAG
      cgroupsPath: /eve/services/rsyslogd
+     resources:
+       memory:
+         limit: 52428800 #50M
+         reservation: 52428800
    - name: ntpd
      image: linuxkit/openntpd:v0.5
      cgroupsPath: /eve/services/ntpd


### PR DESCRIPTION
This is needed if we choose to store the logs (that are in transit) in memory. 

Signed-off-by: adarsh-zededa <adarsh@zededa.com>