### PR TITLE
disable zedclient watchdog earlier in device-steps.sh

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -298,6 +298,7 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 		deviceLogMetric.NumAppEventErrors = logMetrics.NumAppEventErrors
 		deviceLogMetric.NumDeviceBundleProtoBytesSent = logMetrics.NumDeviceBundleProtoBytesSent
 		deviceLogMetric.NumAppBundleProtoBytesSent = logMetrics.NumAppBundleProtoBytesSent
+		deviceLogMetric.InputSources = make(map[string]uint64)
 		for source, val := range logMetrics.DeviceLogInput {
 			deviceLogMetric.InputSources[source] = val
 		}

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -409,6 +409,10 @@ if [ $SELF_REGISTER = 1 ]; then
         echo "$(date -Ins -u) client selfRegister failed with $?"
         exit 1
     fi
+
+    # Remove zedclient.pid from watchdog
+    rm "$WATCHDOG_PID/zedclient.pid"
+
     rm -f $CONFIGDIR/self-register-pending
     sync
     blockdev --flushbufs "$CONFIGDEV"
@@ -432,6 +436,10 @@ else
     echo "$(date -Ins -u) Get UUID in in case device was deleted and recreated with same device cert"
     echo "$(date -Ins -u) Starting client getUuid"
     $BINDIR/client getUuid
+
+    # Remove zedclient.pid from watchdog
+    rm "$WATCHDOG_PID/zedclient.pid"
+
     if [ ! -f $CONFIGDIR/hardwaremodel ]; then
         echo "$(date -Ins -u) XXX /config/hardwaremodel missing; creating"
         $BINDIR/hardwaremodel -c -o $CONFIGDIR/hardwaremodel
@@ -457,9 +465,6 @@ size=$(df -B1 --output=size $PERSISTDIR | tail -1)
 space=$((size / 2048))
 mkdir -p /var/tmp/zededa/GlobalDownloadConfig/
 echo \{\"MaxSpace\":"$space"\} >/var/tmp/zededa/GlobalDownloadConfig/global.json
-
-# Remove zedclient.pid from watchdog
-rm "$WATCHDOG_PID/zedclient.pid"
 
 #If logmanager is already running we don't have to start it.
 if ! pgrep logmanager >/dev/null; then


### PR DESCRIPTION
Watching a device boot I saw watchdog complaining about zedclient.pid process no longer existing (for 10-30 seconds). Turns out zedclient aka client had succeeded, but watchdog didn't yet know it was done.

This PR is reducing that possibility.

(cherry picked from commit 5cffab0363e6416f240caf11b15614ad3813ffa4)

Also this PR got an emergency fix to handlemetrics.go