### PR TITLE
Use actual media type on BlobStatus

### DIFF
--- a/pkg/pillar/cas/cas.go
+++ b/pkg/pillar/cas/cas.go
@@ -62,7 +62,7 @@ type CAS interface {
 	//CreateImage: creates a reference which points to a blob with 'blobHash'. 'blobHash' must belong to a index blob
 	//Arg 'blobHash' should be of format <algo>:<hash> (currently supporting only sha256:<hash>).
 	//Returns error if no blob is found matching the given 'blobHash' or if the given 'blobHash' does not belong to an index.
-	CreateImage(reference, blobHash string) error
+	CreateImage(reference, mediaType, blobHash string) error
 	//GetImageHash: returns a blob hash of format <algo>:<hash> (currently supporting only sha256:<hash>) which the given 'reference' is pointing to.
 	// Returns error if the given 'reference' is not found.
 	GetImageHash(reference string) (string, error)
@@ -75,7 +75,7 @@ type CAS interface {
 	//Returns error if the given 'reference' or a blob matching the given arg 'blobHash' is not found.
 	//Returns if the given 'blobHash' does not belong to an index.
 	//Arg 'blobHash' should be of format <algo>:<hash> (currently supporting only sha256:<hash>).
-	ReplaceImage(reference, blobHash string) error
+	ReplaceImage(reference, mediaType, blobHash string) error
 
 	//Snapshot APIs
 	//CreateSnapshotForImage: creates an snapshot with the given snapshotID for the given 'reference'

--- a/pkg/pillar/cmd/volumemgr/handlecontent.go
+++ b/pkg/pillar/cmd/volumemgr/handlecontent.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	v1types "github.com/google/go-containerregistry/pkg/v1/types"
 	zconfig "github.com/lf-edge/eve/api/go/config"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 )
@@ -184,12 +185,12 @@ func createContentTreeStatus(ctx *volumemgrContext, config types.ContentTreeConf
 				// in reality, this is not determined by the *format* but by the source,
 				// i.e. an OCI registry may have other formats, no matter what the
 				// image format is. This will do for now, though.
-				blobType := types.BlobBinary
+				mediaType := string(v1types.OCILayer)
 				if config.Format == zconfig.Format_CONTAINER {
 					// when first creating the root, the type is unknown,
 					// but will be updated from the mediatype passed by the
 					// Content-Type http header
-					blobType = types.BlobUnknown
+					mediaType = ""
 				}
 				rootBlob := &types.BlobStatus{
 					DatastoreID: config.DatastoreID,
@@ -197,7 +198,7 @@ func createContentTreeStatus(ctx *volumemgrContext, config types.ContentTreeConf
 					Sha256:      strings.ToLower(config.ContentSha256),
 					Size:        config.MaxDownloadSize,
 					State:       types.INITIAL,
-					BlobType:    blobType,
+					MediaType:   mediaType,
 				}
 				publishBlobStatus(ctx, rootBlob)
 			}

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -100,7 +100,6 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 					Sha256:      status.ContentSha256,
 					Size:        status.MaxDownloadSize,
 					State:       types.INITIAL,
-					BlobType:    types.BlobUnknown, // our initial type is unknown, but it will be set by the Content-Type http header
 				}
 				log.Infof("doUpdateContentTree: publishing new root BlobStatus (%s) for content tree (%s)",
 					status.ContentSha256, status.ContentID)
@@ -183,7 +182,7 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 					publishBlobStatus(ctx, blobsNotInStatusOrCreate(ctx, sv, blobChildren)...)
 					AddBlobsToContentTreeStatus(ctx, status, addedBlobs...)
 				}
-				if blob.BlobType == types.BlobManifest {
+				if blob.IsManifest() {
 					size := resolveManifestSize(ctx, *blob)
 					if size != status.TotalSize {
 						status.TotalSize = size


### PR DESCRIPTION
Replace `BlobStatus.BlobType` with actual media type, as a string

This cleans up a lot of the confusion around what type it actually is.

Also adds `IsManifest()` and `IsIndex()` methods to `BlobStatus`, so one can easily check if it is an index, manifest, or just regular old blob.

This became necessary to pass the correct type all the way up to containerd and use it further down. Follow on to #1357 .
