### PR TITLE
Move rsyslogd back to using disk based log queues

### DIFF
--- a/pkg/rsyslog/rsyslog.conf
+++ b/pkg/rsyslog/rsyslog.conf
@@ -25,7 +25,7 @@ global(workDirectory="/persist/rsyslog")
 
 main_queue(
   queue.size="1000000"
-  queue.type="LinkedList"
+  queue.type="Disk"
   queue.fileName="main_edge_node_log_queue"
   queue.maxDiskSpace="2g"
   queue.discardSeverity="7"


### PR DESCRIPTION
Signed-off-by: Gopi krishna Kodali <gkodali@zededa.com>