### PR TITLE
reduce log volume by downgrading log.Info in lookup functions

### DIFF
--- a/pkg/pillar/cmd/volumemgr/blob.go
+++ b/pkg/pillar/cmd/volumemgr/blob.go
@@ -439,7 +439,7 @@ func lookupBlobStatus(ctx *volumemgrContext, blobSha string) *types.BlobStatus {
 	pub := ctx.pubBlobStatus
 	s, _ := pub.Get(blobSha)
 	if s == nil {
-		log.Infof("lookupBlobStatus(%s) not found", blobSha)
+		log.Debugf("lookupBlobStatus(%s) not found", blobSha)
 		return nil
 	}
 	status := s.(types.BlobStatus)
@@ -500,7 +500,7 @@ func lookupBlobStatuses(ctx *volumemgrContext, shas ...string) []*types.BlobStat
 func publishBlobStatus(ctx *volumemgrContext, blobs ...*types.BlobStatus) {
 	for _, blob := range blobs {
 		key := blob.Sha256
-		log.Infof("publishBlobStatus(%s)", key)
+		log.Debugf("publishBlobStatus(%s)", key)
 		ctx.pubBlobStatus.Publish(key, *blob)
 	}
 }

--- a/pkg/pillar/cmd/volumemgr/handlecerts.go
+++ b/pkg/pillar/cmd/volumemgr/handlecerts.go
@@ -185,7 +185,7 @@ func lookupCertObjConfig(ctx *volumemgrContext, key string) *types.CertObjConfig
 	sub := ctx.subCertObjConfig
 	c, _ := sub.Get(key)
 	if c == nil {
-		log.Infof("lookupCertObjConfig(%s) not found", key)
+		log.Debugf("lookupCertObjConfig(%s) not found", key)
 		return nil
 	}
 	config := c.(types.CertObjConfig)
@@ -197,7 +197,7 @@ func lookupCertObjStatus(ctx *volumemgrContext, key string) *types.CertObjStatus
 	pub := ctx.pubCertObjStatus
 	st, _ := pub.Get(key)
 	if st == nil {
-		log.Infof("lookupCertObjStatus(%s) not found", key)
+		log.Debugf("lookupCertObjStatus(%s) not found", key)
 		return nil
 	}
 	status := st.(types.CertObjStatus)

--- a/pkg/pillar/cmd/volumemgr/handlecontent.go
+++ b/pkg/pillar/cmd/volumemgr/handlecontent.go
@@ -121,30 +121,30 @@ func unpublishContentTreeStatus(ctx *volumemgrContext, status *types.ContentTree
 func lookupContentTreeStatus(ctx *volumemgrContext,
 	key, objType string) *types.ContentTreeStatus {
 
-	log.Infof("lookupContentTreeStatus(%s/%s)", key, objType)
+	log.Debugf("lookupContentTreeStatus(%s/%s)", key, objType)
 	pub := ctx.publication(types.ContentTreeStatus{}, objType)
 	c, _ := pub.Get(key)
 	if c == nil {
-		log.Infof("lookupContentTreeStatus(%s/%s) not found", key, objType)
+		log.Debugf("lookupContentTreeStatus(%s/%s) not found", key, objType)
 		return nil
 	}
 	status := c.(types.ContentTreeStatus)
-	log.Infof("lookupContentTreeStatus(%s/%s) Done", key, objType)
+	log.Debugf("lookupContentTreeStatus(%s/%s) Done", key, objType)
 	return &status
 }
 
 func lookupContentTreeConfig(ctx *volumemgrContext,
 	key, objType string) *types.ContentTreeConfig {
 
-	log.Infof("lookupContentTreeConfig(%s/%s)", key, objType)
+	log.Debugf("lookupContentTreeConfig(%s/%s)", key, objType)
 	sub := ctx.subscription(types.ContentTreeConfig{}, objType)
 	c, _ := sub.Get(key)
 	if c == nil {
-		log.Infof("lookupContentTreeConfig(%s/%s) not found", key, objType)
+		log.Debugf("lookupContentTreeConfig(%s/%s) not found", key, objType)
 		return nil
 	}
 	config := c.(types.ContentTreeConfig)
-	log.Infof("lookupContentTreeConfig(%s/%s) Done", key, objType)
+	log.Debugf("lookupContentTreeConfig(%s/%s) Done", key, objType)
 	return &config
 }
 

--- a/pkg/pillar/cmd/volumemgr/handledownloader.go
+++ b/pkg/pillar/cmd/volumemgr/handledownloader.go
@@ -153,7 +153,7 @@ func lookupDownloaderConfig(ctx *volumemgrContext,
 	pub := ctx.pubDownloaderConfig
 	c, _ := pub.Get(key)
 	if c == nil {
-		log.Infof("lookupDownloaderConfig(%s) not found", key)
+		log.Debugf("lookupDownloaderConfig(%s) not found", key)
 		return nil
 	}
 	config := c.(types.DownloaderConfig)
@@ -167,7 +167,7 @@ func lookupDownloaderStatus(ctx *volumemgrContext,
 	sub := ctx.subDownloaderStatus
 	c, _ := sub.Get(key)
 	if c == nil {
-		log.Infof("lookupDownloaderStatus(%s) not found", key)
+		log.Debugf("lookupDownloaderStatus(%s) not found", key)
 		return nil
 	}
 	status := c.(types.DownloaderStatus)

--- a/pkg/pillar/cmd/volumemgr/handleresolve.go
+++ b/pkg/pillar/cmd/volumemgr/handleresolve.go
@@ -46,30 +46,30 @@ func unpublishResolveConfig(ctx *volumemgrContext,
 func lookupResolveConfig(ctx *volumemgrContext,
 	key string) *types.ResolveConfig {
 
-	log.Infof("lookupResolveConfig(%s)", key)
+	log.Debugf("lookupResolveConfig(%s)", key)
 	pub := ctx.pubResolveConfig
 	c, _ := pub.Get(key)
 	if c == nil {
-		log.Infof("lookupResolveConfig(%s) not found", key)
+		log.Debugf("lookupResolveConfig(%s) not found", key)
 		return nil
 	}
 	config := c.(types.ResolveConfig)
-	log.Infof("lookupResolveConfig(%s) Done", key)
+	log.Debugf("lookupResolveConfig(%s) Done", key)
 	return &config
 }
 
 func lookupResolveStatus(ctx *volumemgrContext,
 	key string) *types.ResolveStatus {
 
-	log.Infof("lookupResolveStatus(%s)", key)
+	log.Debugf("lookupResolveStatus(%s)", key)
 	sub := ctx.subResolveStatus
 	c, _ := sub.Get(key)
 	if c == nil {
-		log.Infof("lookupResolveStatus(%s) not found", key)
+		log.Debugf("lookupResolveStatus(%s) not found", key)
 		return nil
 	}
 	status := c.(types.ResolveStatus)
-	log.Infof("lookupResolveStatus(%s) Done", key)
+	log.Debugf("lookupResolveStatus(%s) Done", key)
 	return &status
 }
 

--- a/pkg/pillar/cmd/volumemgr/handleverifier.go
+++ b/pkg/pillar/cmd/volumemgr/handleverifier.go
@@ -15,7 +15,7 @@ func lookupVerifyImageConfig(ctx *volumemgrContext,
 	pub := ctx.pubVerifyImageConfig
 	c, _ := pub.Get(key)
 	if c == nil {
-		log.Infof("lookupVerifyImageConfig(%s) not found", key)
+		log.Debugf("lookupVerifyImageConfig(%s) not found", key)
 		return nil
 	}
 	config := c.(types.VerifyImageConfig)
@@ -222,7 +222,7 @@ func lookupVerifyImageStatus(ctx *volumemgrContext,
 	sub := ctx.subVerifyImageStatus
 	s, _ := sub.Get(key)
 	if s == nil {
-		log.Infof("lookupVerifyImageStatus(%s) not found", key)
+		log.Debugf("lookupVerifyImageStatus(%s) not found", key)
 		return nil
 	}
 	status := s.(types.VerifyImageStatus)

--- a/pkg/pillar/cmd/volumemgr/handlevolume.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume.go
@@ -162,30 +162,30 @@ func unpublishVolumeStatus(ctx *volumemgrContext,
 func lookupVolumeStatus(ctx *volumemgrContext,
 	key string) *types.VolumeStatus {
 
-	log.Infof("lookupVolumeStatus(%s)", key)
+	log.Debugf("lookupVolumeStatus(%s)", key)
 	pub := ctx.pubVolumeStatus
 	c, _ := pub.Get(key)
 	if c == nil {
-		log.Infof("lookupVolumeStatus(%s) not found", key)
+		log.Debugf("lookupVolumeStatus(%s) not found", key)
 		return nil
 	}
 	status := c.(types.VolumeStatus)
-	log.Infof("lookupVolumeStatus(%s) Done", key)
+	log.Debugf("lookupVolumeStatus(%s) Done", key)
 	return &status
 }
 
 func lookupVolumeConfig(ctx *volumemgrContext,
 	key string) *types.VolumeConfig {
 
-	log.Infof("lookupVolumeConfig(%s)", key)
+	log.Debugf("lookupVolumeConfig(%s)", key)
 	sub := ctx.subVolumeConfig
 	c, _ := sub.Get(key)
 	if c == nil {
-		log.Infof("lookupVolumeConfig(%s) not found", key)
+		log.Debugf("lookupVolumeConfig(%s) not found", key)
 		return nil
 	}
 	config := c.(types.VolumeConfig)
-	log.Infof("lookupVolumeConfig(%s) Done", key)
+	log.Debugf("lookupVolumeConfig(%s) Done", key)
 	return &config
 }
 

--- a/pkg/pillar/cmd/volumemgr/handlevolumeref.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolumeref.go
@@ -91,7 +91,7 @@ func lookupVolumeRefConfig(ctx *volumemgrContext, key string) *types.VolumeRefCo
 	sub := ctx.subVolumeRefConfig
 	c, _ := sub.Get(key)
 	if c == nil {
-		log.Infof("lookupVolumeRefConfig(%s) not found", key)
+		log.Debugf("lookupVolumeRefConfig(%s) not found", key)
 		return nil
 	}
 	config := c.(types.VolumeRefConfig)
@@ -103,7 +103,7 @@ func lookupVolumeRefStatus(ctx *volumemgrContext, key string) *types.VolumeRefSt
 	pub := ctx.pubVolumeRefStatus
 	c, _ := pub.Get(key)
 	if c == nil {
-		log.Infof("lookupVolumeRefStatus(%s) not found", key)
+		log.Debugf("lookupVolumeRefStatus(%s) not found", key)
 		return nil
 	}
 	status := c.(types.VolumeRefStatus)

--- a/pkg/pillar/cmd/volumemgr/latchcontenthash.go
+++ b/pkg/pillar/cmd/volumemgr/latchcontenthash.go
@@ -82,19 +82,19 @@ func purgeLatchContentTreeHash(ctx *volumemgrContext, contentID uuid.UUID) {
 func lookupLatchContentTreeHash(ctx *volumemgrContext,
 	contentID uuid.UUID, generationCounter uint32) string {
 
-	log.Infof("lookupLatchContentTreeHash(%s, %d)", contentID, generationCounter)
+	log.Debugf("lookupLatchContentTreeHash(%s, %d)", contentID, generationCounter)
 	temp := types.AppAndImageToHash{
 		ImageID:      contentID,
 		PurgeCounter: generationCounter,
 	}
 	item, _ := ctx.pubContentTreeToHash.Get(temp.Key())
 	if item == nil {
-		log.Infof("lookupLatchContentTreeHash(%s, %d) not found",
+		log.Debugf("lookupLatchContentTreeHash(%s, %d) not found",
 			contentID, generationCounter)
 		return ""
 	}
 	aih := item.(types.AppAndImageToHash)
-	log.Infof("lookupLatchContentTreeHash(%s, %d) found %s",
+	log.Debugf("lookupLatchContentTreeHash(%s, %d) found %s",
 		contentID, generationCounter, aih.Hash)
 	return aih.Hash
 }

--- a/pkg/pillar/cmd/zedmanager/handledomainmgr.go
+++ b/pkg/pillar/cmd/zedmanager/handledomainmgr.go
@@ -86,7 +86,7 @@ func lookupDomainConfig(ctx *zedmanagerContext, key string) *types.DomainConfig 
 	pub := ctx.pubDomainConfig
 	c, _ := pub.Get(key)
 	if c == nil {
-		log.Infof("lookupDomainConfig(%s) not found", key)
+		log.Debugf("lookupDomainConfig(%s) not found", key)
 		return nil
 	}
 	config := c.(types.DomainConfig)
@@ -98,7 +98,7 @@ func lookupDomainStatus(ctx *zedmanagerContext, key string) *types.DomainStatus 
 	sub := ctx.subDomainStatus
 	st, _ := sub.Get(key)
 	if st == nil {
-		log.Infof("lookupDomainStatus(%s) not found", key)
+		log.Debugf("lookupDomainStatus(%s) not found", key)
 		return nil
 	}
 	status := st.(types.DomainStatus)

--- a/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
+++ b/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
@@ -76,7 +76,7 @@ func lookupVolumeRefConfig(ctx *zedmanagerContext, key string) *types.VolumeRefC
 	pub := ctx.pubVolumeRefConfig
 	c, _ := pub.Get(key)
 	if c == nil {
-		log.Infof("lookupVolumeRefConfig(%s) not found", key)
+		log.Debugf("lookupVolumeRefConfig(%s) not found", key)
 		return nil
 	}
 	config := c.(types.VolumeRefConfig)
@@ -88,7 +88,7 @@ func lookupVolumeRefStatus(ctx *zedmanagerContext, key string) *types.VolumeRefS
 	sub := ctx.subVolumeRefStatus
 	c, _ := sub.Get(key)
 	if c == nil {
-		log.Infof("lookupVolumeRefStatus(%s) not found", key)
+		log.Debugf("lookupVolumeRefStatus(%s) not found", key)
 		return nil
 	}
 	status := c.(types.VolumeRefStatus)

--- a/pkg/pillar/cmd/zedmanager/handlezedrouter.go
+++ b/pkg/pillar/cmd/zedmanager/handlezedrouter.go
@@ -73,7 +73,7 @@ func lookupAppNetworkConfig(ctx *zedmanagerContext, key string) *types.AppNetwor
 	pub := ctx.pubAppNetworkConfig
 	c, _ := pub.Get(key)
 	if c == nil {
-		log.Infof("lookupAppNetworkConfig(%s) not found", key)
+		log.Debugf("lookupAppNetworkConfig(%s) not found", key)
 		return nil
 	}
 	config := c.(types.AppNetworkConfig)
@@ -85,7 +85,7 @@ func lookupAppNetworkStatus(ctx *zedmanagerContext, key string) *types.AppNetwor
 	sub := ctx.subAppNetworkStatus
 	st, _ := sub.Get(key)
 	if st == nil {
-		log.Infof("lookupAppNetworkStatus(%s) not found", key)
+		log.Debugf("lookupAppNetworkStatus(%s) not found", key)
 		return nil
 	}
 	status := st.(types.AppNetworkStatus)

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -342,7 +342,7 @@ func lookupAppInstanceStatus(ctx *zedmanagerContext, key string) *types.AppInsta
 	pub := ctx.pubAppInstanceStatus
 	st, _ := pub.Get(key)
 	if st == nil {
-		log.Infof("lookupAppInstanceStatus(%s) not found", key)
+		log.Debugf("lookupAppInstanceStatus(%s) not found", key)
 		return nil
 	}
 	status := st.(types.AppInstanceStatus)
@@ -354,7 +354,7 @@ func lookupAppInstanceConfig(ctx *zedmanagerContext, key string) *types.AppInsta
 	sub := ctx.subAppInstanceConfig
 	c, _ := sub.Get(key)
 	if c == nil {
-		log.Infof("lookupAppInstanceConfig(%s) not found", key)
+		log.Debugf("lookupAppInstanceConfig(%s) not found", key)
 		return nil
 	}
 	config := c.(types.AppInstanceConfig)

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -683,7 +683,7 @@ func lookupAppNetworkStatus(ctx *zedrouterContext, key string) *types.AppNetwork
 	pub := ctx.pubAppNetworkStatus
 	st, _ := pub.Get(key)
 	if st == nil {
-		log.Infof("lookupAppNetworkStatus(%s) not found\n", key)
+		log.Debugf("lookupAppNetworkStatus(%s) not found\n", key)
 		return nil
 	}
 	status := st.(types.AppNetworkStatus)
@@ -698,7 +698,7 @@ func lookupAppNetworkConfig(ctx *zedrouterContext, key string) *types.AppNetwork
 		sub = ctx.subAppNetworkConfigAg
 		c, _ = sub.Get(key)
 		if c == nil {
-			log.Infof("lookupAppNetworkConfig(%s) not found\n", key)
+			log.Debugf("lookupAppNetworkConfig(%s) not found\n", key)
 			return nil
 		}
 	}


### PR DESCRIPTION
Some low-hanging fruit. volumemgr seems to have lots of these, and they carry no or little information since the callers of the lookup functions log what they are doing as a function the result of the lookup. And some periodic activity appears to cause lookups in the logs when nothing else is happenining.

(cherry picked from commit b4971898a024bdfb1a1e6c5c626788291e6bc309)