### PR TITLE
downgrade frequent and less useful volumemgr logs to debug

### DIFF
--- a/pkg/pillar/cmd/volumemgr/blob.go
+++ b/pkg/pillar/cmd/volumemgr/blob.go
@@ -35,11 +35,11 @@ func downloadBlob(ctx *volumemgrContext, objType string, sv SignatureVerifier, b
 	// the one we just created is it; set our State to DOWNLOADING and return
 	if ds == nil || ds.Expired || ds.RefCount == 0 {
 		if ds == nil {
-			log.Infof("downloadStatus not found for blob %s", blob.Sha256)
+			log.Debugf("downloadStatus not found for blob %s", blob.Sha256)
 		} else if ds.Expired {
-			log.Infof("downloadStatus Expired set for blob %s", blob.Sha256)
+			log.Debugf("downloadStatus Expired set for blob %s", blob.Sha256)
 		} else {
-			log.Infof("downloadStatus RefCount=0 for blob %s", blob.Sha256)
+			log.Debugf("downloadStatus RefCount=0 for blob %s", blob.Sha256)
 		}
 		blob.State = types.DOWNLOADING
 		return true
@@ -68,7 +68,7 @@ func downloadBlob(ctx *volumemgrContext, objType string, sv SignatureVerifier, b
 		changed = true
 	}
 	if ds.Pending() {
-		log.Infof("lookupDownloaderStatus Pending for blob %s", blob.Sha256)
+		log.Debugf("lookupDownloaderStatus Pending for blob %s", blob.Sha256)
 		return changed
 	}
 	if ds.HasError() {
@@ -225,11 +225,11 @@ func startBlobVerification(ctx *volumemgrContext, sv SignatureVerifier, blob *ty
 
 // getBlobChildren get the children of a blob
 func getBlobChildren(ctx *volumemgrContext, sv SignatureVerifier, blob *types.BlobStatus) []*types.BlobStatus {
-	log.Infof("getBlobChildren(%s)", blob.Sha256)
+	log.Debugf("getBlobChildren(%s)", blob.Sha256)
 	if blob.State < types.VERIFIED {
 		return nil
 	}
-	log.Infof("getBlobChildren(%s): VERIFIED", blob.Sha256)
+	log.Debugf("getBlobChildren(%s): VERIFIED", blob.Sha256)
 	// if verified, check for any children and start them off
 	switch blob.BlobType {
 	case types.BlobIndex:
@@ -286,7 +286,7 @@ func getBlobChildren(ctx *volumemgrContext, sv SignatureVerifier, blob *types.Bl
 				//Check if childBlob already exists
 				existingChild := lookupOrCreateBlobStatus(ctx, sv, childHash)
 				if existingChild != nil {
-					log.Infof("getBlobChildren(%s): child blob %s already exists.", blob.Sha256, childHash)
+					log.Debugf("getBlobChildren(%s): child blob %s already exists.", blob.Sha256, childHash)
 					blobChildren = append(blobChildren, existingChild)
 				} else {
 					log.Infof("getBlobChildren(%s): creating a new BlobStatus for child %s", blob.Sha256, childHash)
@@ -449,7 +449,7 @@ func lookupBlobStatus(ctx *volumemgrContext, blobSha string) *types.BlobStatus {
 // lookupOrCreateBlobStatus tries to lookup a BlobStatus. If one is not found,
 // and a VerifyImageStatus exists, use that to create the BlobStatus.
 func lookupOrCreateBlobStatus(ctx *volumemgrContext, sv SignatureVerifier, blobSha string) *types.BlobStatus {
-	log.Infof("lookupOrCreateBlobStatus(%s)", blobSha)
+	log.Debugf("lookupOrCreateBlobStatus(%s)", blobSha)
 	if blobSha == "" {
 		return nil
 	}

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -151,7 +151,7 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 			if blob.State <= types.DOWNLOADING {
 				// any state less than downloaded, we ask for download, so that we have the refcount;
 				// downloadBlob() is smart enough to look for existing references
-				log.Infof("doUpdateContentTree: blob sha %s download state %v less than DOWNLOADED", blob.Sha256, blob.State)
+				log.Debugf("doUpdateContentTree: blob sha %s download state %v less than DOWNLOADED", blob.Sha256, blob.State)
 				if downloadBlob(ctx, status.ObjType, sv, blob) {
 					publishBlobStatus(ctx, blob)
 					changed = true
@@ -167,10 +167,10 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 			}
 			if blob.State < types.VERIFIED {
 				leftToProcess = true
-				log.Errorf("doUpdateContentTree: left to process due to state '%s' for content blob %s",
+				log.Debugf("doUpdateContentTree: left to process due to state '%s' for content blob %s",
 					blob.State, blob.Sha256)
 			} else {
-				log.Infof("doUpdateContentTree: blob sha %s download state VERIFIED", blob.Sha256)
+				log.Debugf("doUpdateContentTree: blob sha %s download state VERIFIED", blob.Sha256)
 				// if verified, check for any children and start them off
 				// resolve any unknown types and get manifests of index, or children of manifest
 				blobType, err := resolveBlobType(ctx, blob)
@@ -472,7 +472,7 @@ func updateStatus(ctx *volumemgrContext, sha string) {
 			var hasSha bool
 			for _, blobSha := range status.Blobs {
 				if blobSha == sha {
-					log.Infof("Found blob %s on ContentTreeStatus %s",
+					log.Debugf("Found blob %s on ContentTreeStatus %s",
 						sha, status.Key())
 					hasSha = true
 				}
@@ -485,7 +485,7 @@ func updateStatus(ctx *volumemgrContext, sha string) {
 					publishContentTreeStatus(ctx, &status)
 				}
 				// Volume status referring to this content UUID needs to get updated
-				log.Infof("updateStatus(%s) updating volume status from content ID %v",
+				log.Debugf("updateStatus(%s) updating volume status from content ID %v",
 					status.Key(), status.ContentID)
 				updateVolumeStatusFromContentID(ctx,
 					status.ContentID)
@@ -555,14 +555,14 @@ func updateVolumeStatus(ctx *volumemgrContext, volumeID uuid.UUID) {
 // Find all the VolumeStatus which refer to this content uuid
 func updateVolumeStatusFromContentID(ctx *volumemgrContext, contentID uuid.UUID) {
 
-	log.Infof("updateVolumeStatusFromContentID for %s", contentID)
+	log.Debugf("updateVolumeStatusFromContentID for %s", contentID)
 	found := false
 	pub := ctx.pubVolumeStatus
 	items := pub.GetAll()
 	for _, st := range items {
 		status := st.(types.VolumeStatus)
 		if status.ContentID == contentID {
-			log.Infof("Found VolumeStatus %s: name %s",
+			log.Debugf("Found VolumeStatus %s: name %s",
 				status.Key(), status.DisplayName)
 			found = true
 			changed, _ := doUpdateVol(ctx, &status)


### PR DESCRIPTION
Prior to this change volumemgr will generate tons of log messages on boot. 
Even after an hour of running 6 containers LogmgrMetrics shows it is more than half:
    "volumemgr": 27857,
  "TotalDeviceLogInput": 43509,

Signed-off-by: eriknordmark <erik@zededa.com>
(cherry picked from commit 0740faa1a342ef9d268cf2bbb9fe780e4a6e48ed)