### PR TITLE
Reduce default log volume; more obj-type logs

### DIFF
--- a/pkg/pillar/base/base_test.go
+++ b/pkg/pillar/base/base_test.go
@@ -62,6 +62,7 @@ func initLog() {
 	logrus.SetFormatter(&formatter)
 	logBuffer = bytes.NewBuffer(make([]byte, 1000))
 	logrus.SetOutput(logBuffer)
+	logrus.SetLevel(logrus.TraceLevel)
 	logger := logrus.StandardLogger()
 	log = NewSourceLogObject(logger, "test", 1234)
 }
@@ -93,16 +94,16 @@ func TestSpecialAgent(t *testing.T) {
 		switch test.action {
 		case "create":
 			test.agent.LogCreate(log)
-			expected := "{\"agent_age\":30,\"agent_is_brosnan\":true,\"agent_name\":\"James Bond\",\"agent_number\":7,\"level\":\"info\",\"log_event_type\":\"log\",\"msg\":\"I am Bond, James Bond\",\"obj_key\":\"james-bond-007\",\"obj_name\":\"Pierce Brosnan\",\"obj_type\":\"secret_agent\",\"pid\":1234,\"source\":\"test\"}"
+			expected := "{\"agent_age\":30,\"agent_is_brosnan\":true,\"agent_name\":\"James Bond\",\"agent_number\":7,\"level\":\"debug\",\"log_event_type\":\"log\",\"msg\":\"I am Bond, James Bond\",\"obj_key\":\"james-bond-007\",\"obj_name\":\"Pierce Brosnan\",\"obj_type\":\"secret_agent\",\"pid\":1234,\"source\":\"test\"}"
 			assert.Equal(t, expected, strings.TrimSpace(logBuffer.String()))
 		case "modify":
 			test.agent.AgentAge = 100
 			test.agent.LogModify("old agent")
-			expected := "{\"agent_age\":100,\"agent_is_brosnan\":true,\"agent_name\":\"James Bond\",\"agent_number\":7,\"level\":\"info\",\"log_event_type\":\"log\",\"msg\":\"James Bond gets old!\",\"obj_key\":\"james-bond-007\",\"obj_name\":\"Pierce Brosnan\",\"obj_type\":\"secret_agent\",\"pid\":1234,\"source\":\"test\"}"
+			expected := "{\"agent_age\":100,\"agent_is_brosnan\":true,\"agent_name\":\"James Bond\",\"agent_number\":7,\"level\":\"debug\",\"log_event_type\":\"log\",\"msg\":\"James Bond gets old!\",\"obj_key\":\"james-bond-007\",\"obj_name\":\"Pierce Brosnan\",\"obj_type\":\"secret_agent\",\"pid\":1234,\"source\":\"test\"}"
 			assert.Equal(t, expected, strings.TrimSpace(logBuffer.String()))
 		case "kill":
 			test.agent.LogDelete()
-			expected := "{\"agent_age\":30,\"agent_is_brosnan\":true,\"agent_name\":\"James Bond\",\"agent_number\":7,\"level\":\"info\",\"log_event_type\":\"log\",\"msg\":\"James Bond dies!\",\"obj_key\":\"james-bond-007\",\"obj_name\":\"Pierce Brosnan\",\"obj_type\":\"secret_agent\",\"pid\":1234,\"source\":\"test\"}"
+			expected := "{\"agent_age\":30,\"agent_is_brosnan\":true,\"agent_name\":\"James Bond\",\"agent_number\":7,\"level\":\"debug\",\"log_event_type\":\"log\",\"msg\":\"James Bond dies!\",\"obj_key\":\"james-bond-007\",\"obj_name\":\"Pierce Brosnan\",\"obj_type\":\"secret_agent\",\"pid\":1234,\"source\":\"test\"}"
 			assert.Equal(t, expected, strings.TrimSpace(logBuffer.String()))
 		default:
 		}

--- a/pkg/pillar/base/log.go
+++ b/pkg/pillar/base/log.go
@@ -213,3 +213,32 @@ func (object *LogObject) Fatalln(args ...interface{}) {
 	}
 	object.logger.WithFields(object.Fields).Fatalln(args...)
 }
+
+// Emulate a Trace level - mapped to Warning
+
+// Trace :
+func (object *LogObject) Trace(args ...interface{}) {
+	if !object.Initialized {
+		log.Fatal("LogObject used without initialization")
+		return
+	}
+	log.WithFields(object.Fields).Warn(args...)
+}
+
+// Tracef :
+func (object *LogObject) Tracef(format string, args ...interface{}) {
+	if !object.Initialized {
+		log.Fatal("LogObject used without initialization")
+		return
+	}
+	log.WithFields(object.Fields).Warnf(format, args...)
+}
+
+// Traceln :
+func (object *LogObject) Traceln(args ...interface{}) {
+	if !object.Initialized {
+		log.Fatal("LogObject used without initialization")
+		return
+	}
+	log.WithFields(object.Fields).Warnln(args...)
+}

--- a/pkg/pillar/base/log.go
+++ b/pkg/pillar/base/log.go
@@ -215,6 +215,9 @@ func (object *LogObject) Fatalln(args ...interface{}) {
 }
 
 // Emulate a Trace level - mapped to Warning
+// XXX Current Info should be logrus.Trace with this Trace becoming Info
+// and this Metric becoming Debug.
+// XXX rename current Info to Function so we can map that to Trace
 
 // Trace :
 func (object *LogObject) Trace(args ...interface{}) {
@@ -241,4 +244,33 @@ func (object *LogObject) Traceln(args ...interface{}) {
 		return
 	}
 	log.WithFields(object.Fields).Warnln(args...)
+}
+
+// Emulate a Metric level - mapped to Info
+
+// Metric :
+func (object *LogObject) Metric(args ...interface{}) {
+	if !object.Initialized {
+		log.Fatal("LogObject used without initialization")
+		return
+	}
+	log.WithFields(object.Fields).Info(args...)
+}
+
+// Metricf :
+func (object *LogObject) Metricf(format string, args ...interface{}) {
+	if !object.Initialized {
+		log.Fatal("LogObject used without initialization")
+		return
+	}
+	log.WithFields(object.Fields).Infof(format, args...)
+}
+
+// Metricln :
+func (object *LogObject) Metricln(args ...interface{}) {
+	if !object.Initialized {
+		log.Fatal("LogObject used without initialization")
+		return
+	}
+	log.WithFields(object.Fields).Infoln(args...)
 }

--- a/pkg/pillar/base/log.go
+++ b/pkg/pillar/base/log.go
@@ -7,22 +7,25 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// We map our notions of levels to the logrus levels
+// XXX should we make this mapping configurable?
+// The Notice and Metric functions/levels are unique
+// XXX should we rename the callers of Info* and Debug* to Debug* and Trace*, respectively
+var (
+	myNoticeLevel = logrus.InfoLevel
+	myMetricLevel = logrus.DebugLevel
+	myInfoLevel   = logrus.DebugLevel
+	myDebugLevel  = logrus.TraceLevel
+	myTraceLevel  = logrus.TraceLevel
+)
+
 // Debug :
 func (object *LogObject) Debug(args ...interface{}) {
 	if !object.Initialized {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	object.logger.WithFields(object.Fields).Debug(args...)
-}
-
-// Print :
-func (object *LogObject) Print(args ...interface{}) {
-	if !object.Initialized {
-		logrus.Fatal("LogObject used without initialization")
-		return
-	}
-	object.logger.WithFields(object.Fields).Print(args...)
+	object.logger.WithFields(object.Fields).Log(myDebugLevel, args...)
 }
 
 // Info :
@@ -31,7 +34,7 @@ func (object *LogObject) Info(args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	object.logger.WithFields(object.Fields).Info(args...)
+	object.logger.WithFields(object.Fields).Log(myInfoLevel, args...)
 }
 
 // Warn :
@@ -85,7 +88,7 @@ func (object *LogObject) Debugf(format string, args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	object.logger.WithFields(object.Fields).Debugf(format, args...)
+	object.logger.WithFields(object.Fields).Logf(myDebugLevel, format, args...)
 }
 
 // Infof :
@@ -94,7 +97,7 @@ func (object *LogObject) Infof(format string, args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	object.logger.WithFields(object.Fields).Infof(format, args...)
+	object.logger.WithFields(object.Fields).Logf(myInfoLevel, format, args...)
 }
 
 // Warnf :
@@ -148,16 +151,7 @@ func (object *LogObject) Debugln(args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	object.logger.WithFields(object.Fields).Debugln(args...)
-}
-
-// Println :
-func (object *LogObject) Println(args ...interface{}) {
-	if !object.Initialized {
-		logrus.Fatal("LogObject used without initialization")
-		return
-	}
-	object.logger.WithFields(object.Fields).Println(args...)
+	object.logger.WithFields(object.Fields).Logln(myDebugLevel, args...)
 }
 
 // Infoln :
@@ -166,7 +160,7 @@ func (object *LogObject) Infoln(args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	object.logger.WithFields(object.Fields).Infoln(args...)
+	object.logger.WithFields(object.Fields).Logln(myInfoLevel, args...)
 }
 
 // Warnln :
@@ -214,64 +208,83 @@ func (object *LogObject) Fatalln(args ...interface{}) {
 	object.logger.WithFields(object.Fields).Fatalln(args...)
 }
 
-// Emulate a Notice level - mapped to Warning
-// XXX Current Info should use logrus.Debug with this Notice using logrus.Info
-// and below Metric using logrus.Debug.
-// XXX current Debug should use logrus.Trace
-// XXX rename current Info to ??? and Debug to Trace
-
 // Notice :
 func (object *LogObject) Notice(args ...interface{}) {
 	if !object.Initialized {
-		log.Fatal("LogObject used without initialization")
+		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	log.WithFields(object.Fields).Warn(args...)
+	object.logger.WithFields(object.Fields).Log(myNoticeLevel, args...)
 }
 
 // Noticef :
 func (object *LogObject) Noticef(format string, args ...interface{}) {
 	if !object.Initialized {
-		log.Fatal("LogObject used without initialization")
+		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	log.WithFields(object.Fields).Warnf(format, args...)
+	object.logger.WithFields(object.Fields).Logf(myNoticeLevel, format, args...)
 }
 
 // Noticeln :
 func (object *LogObject) Noticeln(args ...interface{}) {
 	if !object.Initialized {
-		log.Fatal("LogObject used without initialization")
+		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	log.WithFields(object.Fields).Warnln(args...)
+	object.logger.WithFields(object.Fields).Logln(myNoticeLevel, args...)
 }
-
-// Emulate a Metric level - mapped to Info
 
 // Metric :
 func (object *LogObject) Metric(args ...interface{}) {
 	if !object.Initialized {
-		log.Fatal("LogObject used without initialization")
+		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	log.WithFields(object.Fields).Info(args...)
+	object.logger.WithFields(object.Fields).Log(myMetricLevel, args...)
 }
 
 // Metricf :
 func (object *LogObject) Metricf(format string, args ...interface{}) {
 	if !object.Initialized {
-		log.Fatal("LogObject used without initialization")
+		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	log.WithFields(object.Fields).Infof(format, args...)
+	object.logger.WithFields(object.Fields).Logf(myMetricLevel, format, args...)
 }
 
 // Metricln :
 func (object *LogObject) Metricln(args ...interface{}) {
 	if !object.Initialized {
-		log.Fatal("LogObject used without initialization")
+		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	log.WithFields(object.Fields).Infoln(args...)
+	object.logger.WithFields(object.Fields).Logln(myMetricLevel, args...)
+}
+
+// Trace :
+func (object *LogObject) Trace(args ...interface{}) {
+	if !object.Initialized {
+		logrus.Fatal("LogObject used without initialization")
+		return
+	}
+	object.logger.WithFields(object.Fields).Log(myTraceLevel, args...)
+}
+
+// Tracef :
+func (object *LogObject) Tracef(format string, args ...interface{}) {
+	if !object.Initialized {
+		logrus.Fatal("LogObject used without initialization")
+		return
+	}
+	object.logger.WithFields(object.Fields).Logf(myTraceLevel, format, args...)
+}
+
+// Traceln :
+func (object *LogObject) Traceln(args ...interface{}) {
+	if !object.Initialized {
+		logrus.Fatal("LogObject used without initialization")
+		return
+	}
+	object.logger.WithFields(object.Fields).Logln(myTraceLevel, args...)
 }

--- a/pkg/pillar/base/log.go
+++ b/pkg/pillar/base/log.go
@@ -214,13 +214,14 @@ func (object *LogObject) Fatalln(args ...interface{}) {
 	object.logger.WithFields(object.Fields).Fatalln(args...)
 }
 
-// Emulate a Trace level - mapped to Warning
-// XXX Current Info should be logrus.Trace with this Trace becoming Info
-// and this Metric becoming Debug.
-// XXX rename current Info to Function so we can map that to Trace
+// Emulate a Notice level - mapped to Warning
+// XXX Current Info should use logrus.Debug with this Notice using logrus.Info
+// and below Metric using logrus.Debug.
+// XXX current Debug should use logrus.Trace
+// XXX rename current Info to ??? and Debug to Trace
 
-// Trace :
-func (object *LogObject) Trace(args ...interface{}) {
+// Notice :
+func (object *LogObject) Notice(args ...interface{}) {
 	if !object.Initialized {
 		log.Fatal("LogObject used without initialization")
 		return
@@ -228,8 +229,8 @@ func (object *LogObject) Trace(args ...interface{}) {
 	log.WithFields(object.Fields).Warn(args...)
 }
 
-// Tracef :
-func (object *LogObject) Tracef(format string, args ...interface{}) {
+// Noticef :
+func (object *LogObject) Noticef(format string, args ...interface{}) {
 	if !object.Initialized {
 		log.Fatal("LogObject used without initialization")
 		return
@@ -237,8 +238,8 @@ func (object *LogObject) Tracef(format string, args ...interface{}) {
 	log.WithFields(object.Fields).Warnf(format, args...)
 }
 
-// Traceln :
-func (object *LogObject) Traceln(args ...interface{}) {
+// Noticeln :
+func (object *LogObject) Noticeln(args ...interface{}) {
 	if !object.Initialized {
 		log.Fatal("LogObject used without initialization")
 		return

--- a/pkg/pillar/base/logobjecttypes.go
+++ b/pkg/pillar/base/logobjecttypes.go
@@ -31,24 +31,30 @@ const (
 	UnknownLogType LogObjectType = ""
 	// ImageLogType :
 	ImageLogType LogObjectType = "image"
-	// NetworkInstanceLogType :
-	NetworkInstanceLogType LogObjectType = "network_instance"
 	// AppInstanceStatusLogType :
 	AppInstanceStatusLogType LogObjectType = "app_instance_status"
 	// AppInstanceConfigLogType :
 	AppInstanceConfigLogType LogObjectType = "app_instance_config"
-	// OldVolumeConfigLogType :
-	OldVolumeConfigLogType LogObjectType = "old_volume_config"
-	// OldVolumeStatusLogType :
-	OldVolumeStatusLogType LogObjectType = "old_volume_status"
+	// AppNetworkStatusLogType :
+	AppNetworkStatusLogType LogObjectType = "app_network_status"
+	// AppNetworkConfigLogType :
+	AppNetworkConfigLogType LogObjectType = "app_network_config"
+	// DatastoreConfigLogType :
+	DatastoreConfigLogType LogObjectType = "datastore_config"
 	// DomainConfigLogType :
 	DomainConfigLogType LogObjectType = "domain_config"
 	// DomainStatusLogType :
 	DomainStatusLogType LogObjectType = "domain_status"
+	// DomainMetricLogType :
+	DomainMetricLogType LogObjectType = "domain_metric"
 	// BaseOsConfigLogType :
 	BaseOsConfigLogType LogObjectType = "baseos_config"
 	// BaseOsStatusLogType :
 	BaseOsStatusLogType LogObjectType = "baseos_status"
+	// NodeAgentStatusLogType :
+	NodeAgentStatusLogType LogObjectType = "nodeagent_status"
+	// ZedAgentStatusLogType :
+	ZedAgentStatusLogType LogObjectType = "zedagent_status"
 	// ZbootConfigLogType :
 	ZbootConfigLogType LogObjectType = "zboot_config"
 	// ZbootStatusLogType :
@@ -87,6 +93,50 @@ const (
 	VolumeRefStatusLogType LogObjectType = "volume_ref_status"
 	// ServiceInitType:
 	ServiceInitLogType LogObjectType = "service_init"
+	// AppAndImageToHashLogType:
+	AppAndImageToHashLogType LogObjectType = "app_and_image_to_hash"
+	// AppContainerMetricsLogType:
+	AppContainerMetricsLogType LogObjectType = "app_container_metric"
+	// AssignableAdaptersLogType:
+	AssignableAdaptersLogType LogObjectType = "assignable_adapters"
+	// PhysicalIOAdapterListLogType:
+	PhysicalIOAdapterListLogType LogObjectType = "physical_io_adapter_list"
+	// AttestNonceLogType:
+	AttestNonceLogType LogObjectType = "attest_nonce"
+	// AttestQuoteLogType:
+	AttestQuoteLogType LogObjectType = "attest_quote"
+	// VaultStatusLogType:
+	VaultStatusLogType LogObjectType = "vault_status"
+	// CipherBlockStatusLogType:
+	CipherBlockStatusLogType LogObjectType = "cipher_block_status"
+	// CipherContextLogType:
+	CipherContextLogType LogObjectType = "cipher_context"
+	// CipherMetricsLogType:
+	CipherMetricsLogType LogObjectType = "cipher_metric"
+	// ControllerCertLogType:
+	ControllerCertLogType LogObjectType = "controller_cert"
+	// EdgeNodeCertLogType:
+	EdgeNodeCertLogType LogObjectType = "edge_node_cert"
+	// HostMemoryLogType:
+	HostMemoryLogType LogObjectType = "host_memory"
+	// IPFlowLogType:
+	IPFlowLogType LogObjectType = "ip_flow"
+	// VifIPTrigLogType:
+	VifIPTrigLogType LogObjectType = "vif_ip_trig"
+	// OnboardingStatusLogType:
+	OnboardingStatusLogType LogObjectType = "onboarding_status"
+	// NetworkInstanceConfigLogType:
+	NetworkInstanceConfigLogType LogObjectType = "network_instance_config"
+	// NetworkInstanceStatusLogType:
+	NetworkInstanceStatusLogType LogObjectType = "network_instance_status"
+	// NetworkInstanceMetricsLogType:
+	NetworkInstanceMetricsLogType LogObjectType = "network_instance_metrics"
+	// NetworkMetricsLogType:
+	NetworkMetricsLogType LogObjectType = "network_metrics"
+	// NetworkXObjectConfigLogType:
+	NetworkXObjectConfigLogType LogObjectType = "network_x_object"
+	// UUIDToNumLogType:
+	UUIDToNumLogType LogObjectType = "uuid_to_num"
 )
 
 // RelationObjectType :

--- a/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
+++ b/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
@@ -37,7 +37,7 @@ func MaybeAddVolumeRefConfig(ctx *zedmanagerContext, appInstID uuid.UUID,
 		publishVolumeRefConfig(ctx, &vrc)
 	}
 	base.NewRelationObject(log, base.AddRelationType, base.AppInstanceConfigLogType, appInstID.String(),
-		base.VolumeRefConfigLogType, key).Tracef("App instance to volume relation.")
+		base.VolumeRefConfigLogType, key).Noticef("App instance to volume relation.")
 	log.Infof("MaybeAddVolumeRefConfig done for %s", key)
 }
 
@@ -67,7 +67,7 @@ func MaybeRemoveVolumeRefConfig(ctx *zedmanagerContext, appInstID uuid.UUID,
 		publishVolumeRefConfig(ctx, m)
 	}
 	base.NewRelationObject(log, base.DeleteRelationType, base.AppInstanceConfigLogType, appInstID.String(),
-		base.VolumeRefConfigLogType, key).Tracef("App instance to volume relation.")
+		base.VolumeRefConfigLogType, key).Noticef("App instance to volume relation.")
 	log.Infof("MaybeRemoveVolumeRefConfig done for %s", key)
 }
 

--- a/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
+++ b/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
@@ -37,7 +37,7 @@ func MaybeAddVolumeRefConfig(ctx *zedmanagerContext, appInstID uuid.UUID,
 		publishVolumeRefConfig(ctx, &vrc)
 	}
 	base.NewRelationObject(log, base.AddRelationType, base.AppInstanceConfigLogType, appInstID.String(),
-		base.VolumeRefConfigLogType, key).Infof("App instance to volume relation.")
+		base.VolumeRefConfigLogType, key).Tracef("App instance to volume relation.")
 	log.Infof("MaybeAddVolumeRefConfig done for %s", key)
 }
 
@@ -67,7 +67,7 @@ func MaybeRemoveVolumeRefConfig(ctx *zedmanagerContext, appInstID uuid.UUID,
 		publishVolumeRefConfig(ctx, m)
 	}
 	base.NewRelationObject(log, base.DeleteRelationType, base.AppInstanceConfigLogType, appInstID.String(),
-		base.VolumeRefConfigLogType, key).Infof("App instance to volume relation.")
+		base.VolumeRefConfigLogType, key).Tracef("App instance to volume relation.")
 	log.Infof("MaybeRemoveVolumeRefConfig done for %s", key)
 }
 

--- a/pkg/pillar/types/assignableadapters.go
+++ b/pkg/pillar/types/assignableadapters.go
@@ -208,7 +208,7 @@ func (aa AssignableAdapters) LogCreate(logBase *base.LogObject) {
 	if logObject == nil {
 		return
 	}
-	logObject.Tracef("Assignable adapters create")
+	logObject.Noticef("Assignable adapters create")
 }
 
 // LogModify :
@@ -222,14 +222,14 @@ func (aa AssignableAdapters) LogModify(old interface{}) {
 	}
 	// XXX remove? XXX huge?
 	logObject.CloneAndAddField("diff", cmp.Diff(oldAa, aa)).
-		Tracef("Assignable adapters modify")
+		Noticef("Assignable adapters modify")
 }
 
 // LogDelete :
 func (aa AssignableAdapters) LogDelete() {
 	logObject := base.EnsureLogObject(nil, base.AssignableAdaptersLogType, "",
 		nilUUID, aa.LogKey())
-	logObject.Tracef("Assignable adapters delete")
+	logObject.Noticef("Assignable adapters delete")
 
 	base.DeleteLogObject(aa.LogKey())
 }

--- a/pkg/pillar/types/assignableadapters.go
+++ b/pkg/pillar/types/assignableadapters.go
@@ -196,6 +196,49 @@ func (ioType IoType) IsNet() bool {
 	}
 }
 
+// Key is used with pubsub
+func (aa AssignableAdapters) Key() string {
+	return "global"
+}
+
+// LogCreate :
+func (aa AssignableAdapters) LogCreate(logBase *base.LogObject) {
+	logObject := base.NewLogObject(logBase, base.AssignableAdaptersLogType, "",
+		nilUUID, aa.LogKey())
+	if logObject == nil {
+		return
+	}
+	logObject.Tracef("Assignable adapters create")
+}
+
+// LogModify :
+func (aa AssignableAdapters) LogModify(old interface{}) {
+	logObject := base.EnsureLogObject(nil, base.AssignableAdaptersLogType, "",
+		nilUUID, aa.LogKey())
+
+	oldAa, ok := old.(AssignableAdapters)
+	if !ok {
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of AssignableAdapters type")
+	}
+	// XXX remove? XXX huge?
+	logObject.CloneAndAddField("diff", cmp.Diff(oldAa, aa)).
+		Tracef("Assignable adapters modify")
+}
+
+// LogDelete :
+func (aa AssignableAdapters) LogDelete() {
+	logObject := base.EnsureLogObject(nil, base.AssignableAdaptersLogType, "",
+		nilUUID, aa.LogKey())
+	logObject.Tracef("Assignable adapters delete")
+
+	base.DeleteLogObject(aa.LogKey())
+}
+
+// LogKey :
+func (aa AssignableAdapters) LogKey() string {
+	return string(base.AssignableAdaptersLogType) + "-" + aa.Key()
+}
+
 // AddOrUpdateIoBundle - Add an Io bundle to AA. If the bundle already exists,
 // the function updates it, while preserving the most specific information.
 // The information we preserve are of two kinds:

--- a/pkg/pillar/types/attesttypes.go
+++ b/pkg/pillar/types/attesttypes.go
@@ -5,6 +5,9 @@ package types
 
 import (
 	"encoding/hex"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/lf-edge/eve/pkg/pillar/base"
 )
 
 //AttestNonce carries nonce published by requester
@@ -16,6 +19,44 @@ type AttestNonce struct {
 //Key returns nonce content, which is the key as well
 func (nonce AttestNonce) Key() string {
 	return hex.EncodeToString(nonce.Nonce)
+}
+
+// LogCreate :
+func (nonce AttestNonce) LogCreate(logBase *base.LogObject) {
+	logObject := base.NewLogObject(logBase, base.AttestNonceLogType, "",
+		nilUUID, nonce.LogKey())
+	if logObject == nil {
+		return
+	}
+	logObject.Tracef("Attest nonce create")
+}
+
+// LogModify :
+func (nonce AttestNonce) LogModify(old interface{}) {
+	logObject := base.EnsureLogObject(nil, base.AttestNonceLogType, "",
+		nilUUID, nonce.LogKey())
+
+	oldNonce, ok := old.(AttestNonce)
+	if !ok {
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of AttestNonce type")
+	}
+	// XXX remove?
+	logObject.CloneAndAddField("diff", cmp.Diff(oldNonce, nonce)).
+		Tracef("Attest nonce modify")
+}
+
+// LogDelete :
+func (nonce AttestNonce) LogDelete() {
+	logObject := base.EnsureLogObject(nil, base.AttestNonceLogType, "",
+		nilUUID, nonce.LogKey())
+	logObject.Tracef("Attest nonce delete")
+
+	base.DeleteLogObject(nonce.LogKey())
+}
+
+// LogKey :
+func (nonce AttestNonce) LogKey() string {
+	return string(base.AttestNonceLogType) + "-" + nonce.Key()
 }
 
 //SigAlg denotes the Signature algorithm in use e.g. ECDSA, RSASSA
@@ -75,6 +116,44 @@ func (quote AttestQuote) Key() string {
 	return hex.EncodeToString(quote.Nonce)
 }
 
+// LogCreate :
+func (quote AttestQuote) LogCreate(logBase *base.LogObject) {
+	logObject := base.NewLogObject(logBase, base.AttestQuoteLogType, "",
+		nilUUID, quote.LogKey())
+	if logObject == nil {
+		return
+	}
+	logObject.Tracef("Attest quote create")
+}
+
+// LogModify :
+func (quote AttestQuote) LogModify(old interface{}) {
+	logObject := base.EnsureLogObject(nil, base.AttestQuoteLogType, "",
+		nilUUID, quote.LogKey())
+
+	oldQuote, ok := old.(AttestQuote)
+	if !ok {
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of AttestQuote type")
+	}
+	// XXX remove?
+	logObject.CloneAndAddField("diff", cmp.Diff(oldQuote, quote)).
+		Tracef("Attest quote modify")
+}
+
+// LogDelete :
+func (quote AttestQuote) LogDelete() {
+	logObject := base.EnsureLogObject(nil, base.AttestQuoteLogType, "",
+		nilUUID, quote.LogKey())
+	logObject.Tracef("Attest quote delete")
+
+	base.DeleteLogObject(quote.LogKey())
+}
+
+// LogKey :
+func (quote AttestQuote) LogKey() string {
+	return string(base.AttestQuoteLogType) + "-" + quote.Key()
+}
+
 //Needs to match api/proto/attest/attest.proto:ZEveCertHashType
 //Various CertHashType fields
 const (
@@ -96,4 +175,42 @@ type EdgeNodeCert struct {
 //Key uniquely identifies the certificate
 func (cert EdgeNodeCert) Key() string {
 	return hex.EncodeToString(cert.CertID)
+}
+
+// LogCreate :
+func (cert EdgeNodeCert) LogCreate(logBase *base.LogObject) {
+	logObject := base.NewLogObject(logBase, base.EdgeNodeCertLogType, "",
+		nilUUID, cert.LogKey())
+	if logObject == nil {
+		return
+	}
+	logObject.Tracef("Edge node cert create")
+}
+
+// LogModify :
+func (cert EdgeNodeCert) LogModify(old interface{}) {
+	logObject := base.EnsureLogObject(nil, base.EdgeNodeCertLogType, "",
+		nilUUID, cert.LogKey())
+
+	oldCert, ok := old.(EdgeNodeCert)
+	if !ok {
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of EdgeNodeCert type")
+	}
+	// XXX remove?
+	logObject.CloneAndAddField("diff", cmp.Diff(oldCert, cert)).
+		Tracef("Edge node cert modify")
+}
+
+// LogDelete :
+func (cert EdgeNodeCert) LogDelete() {
+	logObject := base.EnsureLogObject(nil, base.EdgeNodeCertLogType, "",
+		nilUUID, cert.LogKey())
+	logObject.Tracef("Edge node cert delete")
+
+	base.DeleteLogObject(cert.LogKey())
+}
+
+// LogKey :
+func (cert EdgeNodeCert) LogKey() string {
+	return string(base.EdgeNodeCertLogType) + "-" + cert.Key()
 }

--- a/pkg/pillar/types/attesttypes.go
+++ b/pkg/pillar/types/attesttypes.go
@@ -28,7 +28,7 @@ func (nonce AttestNonce) LogCreate(logBase *base.LogObject) {
 	if logObject == nil {
 		return
 	}
-	logObject.Tracef("Attest nonce create")
+	logObject.Noticef("Attest nonce create")
 }
 
 // LogModify :
@@ -42,14 +42,14 @@ func (nonce AttestNonce) LogModify(old interface{}) {
 	}
 	// XXX remove?
 	logObject.CloneAndAddField("diff", cmp.Diff(oldNonce, nonce)).
-		Tracef("Attest nonce modify")
+		Noticef("Attest nonce modify")
 }
 
 // LogDelete :
 func (nonce AttestNonce) LogDelete() {
 	logObject := base.EnsureLogObject(nil, base.AttestNonceLogType, "",
 		nilUUID, nonce.LogKey())
-	logObject.Tracef("Attest nonce delete")
+	logObject.Noticef("Attest nonce delete")
 
 	base.DeleteLogObject(nonce.LogKey())
 }
@@ -123,7 +123,7 @@ func (quote AttestQuote) LogCreate(logBase *base.LogObject) {
 	if logObject == nil {
 		return
 	}
-	logObject.Tracef("Attest quote create")
+	logObject.Noticef("Attest quote create")
 }
 
 // LogModify :
@@ -137,14 +137,14 @@ func (quote AttestQuote) LogModify(old interface{}) {
 	}
 	// XXX remove?
 	logObject.CloneAndAddField("diff", cmp.Diff(oldQuote, quote)).
-		Tracef("Attest quote modify")
+		Noticef("Attest quote modify")
 }
 
 // LogDelete :
 func (quote AttestQuote) LogDelete() {
 	logObject := base.EnsureLogObject(nil, base.AttestQuoteLogType, "",
 		nilUUID, quote.LogKey())
-	logObject.Tracef("Attest quote delete")
+	logObject.Noticef("Attest quote delete")
 
 	base.DeleteLogObject(quote.LogKey())
 }
@@ -184,7 +184,7 @@ func (cert EdgeNodeCert) LogCreate(logBase *base.LogObject) {
 	if logObject == nil {
 		return
 	}
-	logObject.Tracef("Edge node cert create")
+	logObject.Noticef("Edge node cert create")
 }
 
 // LogModify :
@@ -198,14 +198,14 @@ func (cert EdgeNodeCert) LogModify(old interface{}) {
 	}
 	// XXX remove?
 	logObject.CloneAndAddField("diff", cmp.Diff(oldCert, cert)).
-		Tracef("Edge node cert modify")
+		Noticef("Edge node cert modify")
 }
 
 // LogDelete :
 func (cert EdgeNodeCert) LogDelete() {
 	logObject := base.EnsureLogObject(nil, base.EdgeNodeCertLogType, "",
 		nilUUID, cert.LogKey())
-	logObject.Tracef("Edge node cert delete")
+	logObject.Noticef("Edge node cert delete")
 
 	base.DeleteLogObject(cert.LogKey())
 }

--- a/pkg/pillar/types/blob.go
+++ b/pkg/pillar/types/blob.go
@@ -80,7 +80,7 @@ func (status BlobStatus) LogCreate(logBase *base.LogObject) {
 		AddField("size-int64", status.Size).
 		AddField("blobtype-string", status.MediaType).
 		AddField("refcount-int64", status.RefCount).
-		Tracef("Blob status create")
+		Noticef("Blob status create")
 }
 
 // LogModify :
@@ -102,11 +102,11 @@ func (status BlobStatus) LogModify(old interface{}) {
 			AddField("old-state", oldStatus.State.String()).
 			AddField("old-refcount-int64", oldStatus.RefCount).
 			AddField("old-size-int64", oldStatus.Size).
-			Tracef("Blob status modify")
+			Noticef("Blob status modify")
 	} else {
 		// XXX remove?
 		logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
-			Tracef("Blob status modify other change")
+			Noticef("Blob status modify other change")
 	}
 
 	if status.HasError() {
@@ -124,7 +124,7 @@ func (status BlobStatus) LogDelete() {
 	logObject.CloneAndAddField("state", status.State.String()).
 		AddField("refcount-int64", status.RefCount).
 		AddField("size-int64", status.Size).
-		Tracef("Blob status delete")
+		Noticef("Blob status delete")
 
 	base.DeleteLogObject(status.LogKey())
 }

--- a/pkg/pillar/types/blob.go
+++ b/pkg/pillar/types/blob.go
@@ -4,6 +4,7 @@
 package types
 
 import (
+	"github.com/google/go-cmp/cmp"
 	v1types "github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	uuid "github.com/satori/go.uuid"
@@ -79,7 +80,7 @@ func (status BlobStatus) LogCreate(logBase *base.LogObject) {
 		AddField("size-int64", status.Size).
 		AddField("blobtype-string", status.MediaType).
 		AddField("refcount-int64", status.RefCount).
-		Infof("Blob status create")
+		Tracef("Blob status create")
 }
 
 // LogModify :
@@ -101,7 +102,11 @@ func (status BlobStatus) LogModify(old interface{}) {
 			AddField("old-state", oldStatus.State.String()).
 			AddField("old-refcount-int64", oldStatus.RefCount).
 			AddField("old-size-int64", oldStatus.Size).
-			Infof("Blob status modify")
+			Tracef("Blob status modify")
+	} else {
+		// XXX remove?
+		logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
+			Tracef("Blob status modify other change")
 	}
 
 	if status.HasError() {
@@ -119,7 +124,7 @@ func (status BlobStatus) LogDelete() {
 	logObject.CloneAndAddField("state", status.State.String()).
 		AddField("refcount-int64", status.RefCount).
 		AddField("size-int64", status.Size).
-		Infof("Blob status delete")
+		Tracef("Blob status delete")
 
 	base.DeleteLogObject(status.LogKey())
 }

--- a/pkg/pillar/types/certinfotypes.go
+++ b/pkg/pillar/types/certinfotypes.go
@@ -33,7 +33,7 @@ func (cert ControllerCert) LogCreate(logBase *base.LogObject) {
 	if logObject == nil {
 		return
 	}
-	logObject.Tracef("Controller cert create")
+	logObject.Noticef("Controller cert create")
 }
 
 // LogModify :
@@ -47,14 +47,14 @@ func (cert ControllerCert) LogModify(old interface{}) {
 	}
 	// XXX remove?
 	logObject.CloneAndAddField("diff", cmp.Diff(oldCert, cert)).
-		Tracef("Controller cert modify")
+		Noticef("Controller cert modify")
 }
 
 // LogDelete :
 func (cert ControllerCert) LogDelete() {
 	logObject := base.EnsureLogObject(nil, base.ControllerCertLogType, "",
 		nilUUID, cert.LogKey())
-	logObject.Tracef("Controller cert delete")
+	logObject.Noticef("Controller cert delete")
 
 	base.DeleteLogObject(cert.LogKey())
 }

--- a/pkg/pillar/types/certinfotypes.go
+++ b/pkg/pillar/types/certinfotypes.go
@@ -6,8 +6,10 @@ package types
 import (
 	"encoding/hex"
 
+	"github.com/google/go-cmp/cmp"
 	zcert "github.com/lf-edge/eve/api/go/certs"
 	zcommon "github.com/lf-edge/eve/api/go/evecommon"
+	"github.com/lf-edge/eve/pkg/pillar/base"
 )
 
 // ControllerCert : controller certicate
@@ -22,4 +24,42 @@ type ControllerCert struct {
 // Key :
 func (cert *ControllerCert) Key() string {
 	return hex.EncodeToString(cert.CertHash)
+}
+
+// LogCreate :
+func (cert ControllerCert) LogCreate(logBase *base.LogObject) {
+	logObject := base.NewLogObject(logBase, base.ControllerCertLogType, "",
+		nilUUID, cert.LogKey())
+	if logObject == nil {
+		return
+	}
+	logObject.Tracef("Controller cert create")
+}
+
+// LogModify :
+func (cert ControllerCert) LogModify(old interface{}) {
+	logObject := base.EnsureLogObject(nil, base.ControllerCertLogType, "",
+		nilUUID, cert.LogKey())
+
+	oldCert, ok := old.(ControllerCert)
+	if !ok {
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of ControllerCert type")
+	}
+	// XXX remove?
+	logObject.CloneAndAddField("diff", cmp.Diff(oldCert, cert)).
+		Tracef("Controller cert modify")
+}
+
+// LogDelete :
+func (cert ControllerCert) LogDelete() {
+	logObject := base.EnsureLogObject(nil, base.ControllerCertLogType, "",
+		nilUUID, cert.LogKey())
+	logObject.Tracef("Controller cert delete")
+
+	base.DeleteLogObject(cert.LogKey())
+}
+
+// LogKey :
+func (cert ControllerCert) LogKey() string {
+	return string(base.ControllerCertLogType) + "-" + cert.Key()
 }

--- a/pkg/pillar/types/cipherinfotypes.go
+++ b/pkg/pillar/types/cipherinfotypes.go
@@ -48,7 +48,7 @@ func (status CipherContext) LogCreate(logBase *base.LogObject) {
 	if logObject == nil {
 		return
 	}
-	logObject.Tracef("Cipher block status create")
+	logObject.Noticef("Cipher block status create")
 }
 
 // LogModify :
@@ -62,14 +62,14 @@ func (status CipherContext) LogModify(old interface{}) {
 	}
 	// XXX remove? XXX huge?
 	logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
-		Tracef("Cipher block status modify")
+		Noticef("Cipher block status modify")
 }
 
 // LogDelete :
 func (status CipherContext) LogDelete() {
 	logObject := base.EnsureLogObject(nil, base.CipherContextLogType, "",
 		nilUUID, status.LogKey())
-	logObject.Tracef("Cipher block status delete")
+	logObject.Noticef("Cipher block status delete")
 
 	base.DeleteLogObject(status.LogKey())
 }
@@ -103,7 +103,7 @@ func (status CipherBlockStatus) LogCreate(logBase *base.LogObject) {
 	if logObject == nil {
 		return
 	}
-	logObject.Tracef("Cipher block status create")
+	logObject.Noticef("Cipher block status create")
 }
 
 // LogModify :
@@ -117,14 +117,14 @@ func (status CipherBlockStatus) LogModify(old interface{}) {
 	}
 	// XXX remove? XXX huge?
 	logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
-		Tracef("Cipher block status modify")
+		Noticef("Cipher block status modify")
 }
 
 // LogDelete :
 func (status CipherBlockStatus) LogDelete() {
 	logObject := base.EnsureLogObject(nil, base.CipherBlockStatusLogType, "",
 		nilUUID, status.LogKey())
-	logObject.Tracef("Cipher block status delete")
+	logObject.Noticef("Cipher block status delete")
 
 	base.DeleteLogObject(status.LogKey())
 }

--- a/pkg/pillar/types/cipherinfotypes.go
+++ b/pkg/pillar/types/cipherinfotypes.go
@@ -6,8 +6,10 @@ package types
 import (
 	"encoding/hex"
 
+	"github.com/google/go-cmp/cmp"
 	zconfig "github.com/lf-edge/eve/api/go/config"
 	zcommon "github.com/lf-edge/eve/api/go/evecommon"
+	"github.com/lf-edge/eve/pkg/pillar/base"
 )
 
 // CipherContext : a pair of device and controller certificate
@@ -39,6 +41,44 @@ func (status *CipherContext) EdgeNodeCertKey() string {
 	return hex.EncodeToString(status.DeviceCertHash)
 }
 
+// LogCreate :
+func (status CipherContext) LogCreate(logBase *base.LogObject) {
+	logObject := base.NewLogObject(logBase, base.CipherContextLogType, "",
+		nilUUID, status.LogKey())
+	if logObject == nil {
+		return
+	}
+	logObject.Tracef("Cipher block status create")
+}
+
+// LogModify :
+func (status CipherContext) LogModify(old interface{}) {
+	logObject := base.EnsureLogObject(nil, base.CipherContextLogType, "",
+		nilUUID, status.LogKey())
+
+	oldStatus, ok := old.(CipherContext)
+	if !ok {
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of CipherContext type")
+	}
+	// XXX remove? XXX huge?
+	logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
+		Tracef("Cipher block status modify")
+}
+
+// LogDelete :
+func (status CipherContext) LogDelete() {
+	logObject := base.EnsureLogObject(nil, base.CipherContextLogType, "",
+		nilUUID, status.LogKey())
+	logObject.Tracef("Cipher block status delete")
+
+	base.DeleteLogObject(status.LogKey())
+}
+
+// LogKey :
+func (status CipherContext) LogKey() string {
+	return string(base.CipherContextLogType) + "-" + status.Key()
+}
+
 // CipherBlockStatus : Object specific encryption information
 type CipherBlockStatus struct {
 	CipherBlockID   string // constructed using individual reference
@@ -54,6 +94,44 @@ type CipherBlockStatus struct {
 // Key :
 func (status *CipherBlockStatus) Key() string {
 	return status.CipherBlockID
+}
+
+// LogCreate :
+func (status CipherBlockStatus) LogCreate(logBase *base.LogObject) {
+	logObject := base.NewLogObject(logBase, base.CipherBlockStatusLogType, "",
+		nilUUID, status.LogKey())
+	if logObject == nil {
+		return
+	}
+	logObject.Tracef("Cipher block status create")
+}
+
+// LogModify :
+func (status CipherBlockStatus) LogModify(old interface{}) {
+	logObject := base.EnsureLogObject(nil, base.CipherBlockStatusLogType, "",
+		nilUUID, status.LogKey())
+
+	oldStatus, ok := old.(CipherBlockStatus)
+	if !ok {
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of CipherBlockStatus type")
+	}
+	// XXX remove? XXX huge?
+	logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
+		Tracef("Cipher block status modify")
+}
+
+// LogDelete :
+func (status CipherBlockStatus) LogDelete() {
+	logObject := base.EnsureLogObject(nil, base.CipherBlockStatusLogType, "",
+		nilUUID, status.LogKey())
+	logObject.Tracef("Cipher block status delete")
+
+	base.DeleteLogObject(status.LogKey())
+}
+
+// LogKey :
+func (status CipherBlockStatus) LogKey() string {
+	return string(base.CipherBlockStatusLogType) + "-" + status.Key()
 }
 
 // EncryptionBlock - This is a Mirror of

--- a/pkg/pillar/types/contenttreetypes.go
+++ b/pkg/pillar/types/contenttreetypes.go
@@ -45,7 +45,7 @@ func (config ContentTreeConfig) LogCreate(logBase *base.LogObject) {
 		AddField("format", config.Format).
 		AddField("content-sha256", config.ContentSha256).
 		AddField("max-download-size-int64", config.MaxDownloadSize).
-		Tracef("Content tree config create")
+		Noticef("Content tree config create")
 }
 
 // LogModify :
@@ -73,11 +73,11 @@ func (config ContentTreeConfig) LogModify(old interface{}) {
 			AddField("old-format", oldConfig.Format).
 			AddField("old-content-sha256", oldConfig.ContentSha256).
 			AddField("old-max-download-size-int64", oldConfig.MaxDownloadSize).
-			Tracef("Content tree config modify")
+			Noticef("Content tree config modify")
 	} else {
 		// XXX remove?
 		logObject.CloneAndAddField("diff", cmp.Diff(oldConfig, config)).
-			Tracef("Content tree config modify other change")
+			Noticef("Content tree config modify other change")
 	}
 }
 
@@ -90,7 +90,7 @@ func (config ContentTreeConfig) LogDelete() {
 		AddField("format", config.Format).
 		AddField("content-sha256", config.ContentSha256).
 		AddField("max-download-size-int64", config.MaxDownloadSize).
-		Tracef("Content tree config delete")
+		Noticef("Content tree config delete")
 
 	base.DeleteLogObject(config.LogKey())
 }
@@ -175,7 +175,7 @@ func (status ContentTreeStatus) LogCreate(logBase *base.LogObject) {
 		AddField("progress", status.Progress).
 		AddField("filelocation", status.FileLocation).
 		AddField("objtype", status.ObjType).
-		Tracef("Content tree status create")
+		Noticef("Content tree status create")
 }
 
 // LogModify :
@@ -204,11 +204,11 @@ func (status ContentTreeStatus) LogModify(old interface{}) {
 			AddField("old-progress", oldStatus.Progress).
 			AddField("old-filelocation", oldStatus.FileLocation).
 			AddField("objtype", status.ObjType).
-			Tracef("Content tree status modify")
+			Noticef("Content tree status modify")
 	} else {
 		// XXX remove?
 		logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
-			Tracef("Content tree status modify other change")
+			Noticef("Content tree status modify other change")
 	}
 }
 
@@ -222,7 +222,7 @@ func (status ContentTreeStatus) LogDelete() {
 		AddField("progress", status.Progress).
 		AddField("filelocation", status.FileLocation).
 		AddField("objtype", status.ObjType).
-		Tracef("Content tree status delete")
+		Noticef("Content tree status delete")
 
 	base.DeleteLogObject(status.LogKey())
 }

--- a/pkg/pillar/types/contenttreetypes.go
+++ b/pkg/pillar/types/contenttreetypes.go
@@ -6,6 +6,7 @@ package types
 import (
 	"fmt"
 
+	"github.com/google/go-cmp/cmp"
 	zconfig "github.com/lf-edge/eve/api/go/config"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	uuid "github.com/satori/go.uuid"
@@ -44,7 +45,7 @@ func (config ContentTreeConfig) LogCreate(logBase *base.LogObject) {
 		AddField("format", config.Format).
 		AddField("content-sha256", config.ContentSha256).
 		AddField("max-download-size-int64", config.MaxDownloadSize).
-		Infof("Content tree config create")
+		Tracef("Content tree config create")
 }
 
 // LogModify :
@@ -72,7 +73,11 @@ func (config ContentTreeConfig) LogModify(old interface{}) {
 			AddField("old-format", oldConfig.Format).
 			AddField("old-content-sha256", oldConfig.ContentSha256).
 			AddField("old-max-download-size-int64", oldConfig.MaxDownloadSize).
-			Infof("Content tree config modify")
+			Tracef("Content tree config modify")
+	} else {
+		// XXX remove?
+		logObject.CloneAndAddField("diff", cmp.Diff(oldConfig, config)).
+			Tracef("Content tree config modify other change")
 	}
 }
 
@@ -85,7 +90,7 @@ func (config ContentTreeConfig) LogDelete() {
 		AddField("format", config.Format).
 		AddField("content-sha256", config.ContentSha256).
 		AddField("max-download-size-int64", config.MaxDownloadSize).
-		Infof("Content tree config delete")
+		Tracef("Content tree config delete")
 
 	base.DeleteLogObject(config.LogKey())
 }
@@ -170,7 +175,7 @@ func (status ContentTreeStatus) LogCreate(logBase *base.LogObject) {
 		AddField("progress", status.Progress).
 		AddField("filelocation", status.FileLocation).
 		AddField("objtype", status.ObjType).
-		Infof("Content tree status create")
+		Tracef("Content tree status create")
 }
 
 // LogModify :
@@ -199,7 +204,11 @@ func (status ContentTreeStatus) LogModify(old interface{}) {
 			AddField("old-progress", oldStatus.Progress).
 			AddField("old-filelocation", oldStatus.FileLocation).
 			AddField("objtype", status.ObjType).
-			Infof("Content tree status modify")
+			Tracef("Content tree status modify")
+	} else {
+		// XXX remove?
+		logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
+			Tracef("Content tree status modify other change")
 	}
 }
 
@@ -213,7 +222,7 @@ func (status ContentTreeStatus) LogDelete() {
 		AddField("progress", status.Progress).
 		AddField("filelocation", status.FileLocation).
 		AddField("objtype", status.ObjType).
-		Infof("Content tree status delete")
+		Tracef("Content tree status delete")
 
 	base.DeleteLogObject(status.LogKey())
 }

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	zconfig "github.com/lf-edge/eve/api/go/config"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 )
@@ -60,7 +61,7 @@ func (config DomainConfig) LogCreate(logBase *base.LogObject) {
 	}
 	logObject.CloneAndAddField("activate", config.Activate).
 		AddField("enable-vnc", config.EnableVnc).
-		Infof("domain config create")
+		Tracef("domain config create")
 }
 
 // LogModify :
@@ -79,9 +80,12 @@ func (config DomainConfig) LogModify(old interface{}) {
 			AddField("enable-vnc", config.EnableVnc).
 			AddField("old-activate", oldConfig.Activate).
 			AddField("old-enable-vnc", oldConfig.EnableVnc).
-			Infof("domain config modify")
+			Tracef("domain config modify")
+	} else {
+		// XXX remove?
+		logObject.CloneAndAddField("diff", cmp.Diff(oldConfig, config)).
+			Tracef("domain config modify other change")
 	}
-
 }
 
 // LogDelete :
@@ -90,7 +94,7 @@ func (config DomainConfig) LogDelete() {
 		config.UUIDandVersion.UUID, config.LogKey())
 	logObject.CloneAndAddField("activate", config.Activate).
 		AddField("enable-vnc", config.EnableVnc).
-		Infof("domain config delete")
+		Tracef("domain config delete")
 
 	base.DeleteLogObject(config.LogKey())
 }
@@ -206,7 +210,7 @@ func (status DomainStatus) LogCreate(logBase *base.LogObject) {
 	}
 	logObject.CloneAndAddField("state", status.State.String()).
 		AddField("activated", status.Activated).
-		Infof("domain status create")
+		Tracef("domain status create")
 }
 
 // LogModify :
@@ -225,7 +229,11 @@ func (status DomainStatus) LogModify(old interface{}) {
 			AddField("activated", status.Activated).
 			AddField("old-state", oldStatus.State.String()).
 			AddField("old-activated", oldStatus.Activated).
-			Infof("domain status modify")
+			Tracef("domain status modify")
+	} else {
+		// XXX remove?
+		logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
+			Tracef("domain status modify other change")
 	}
 
 	if status.HasError() {
@@ -244,7 +252,7 @@ func (status DomainStatus) LogDelete() {
 		status.UUIDandVersion.UUID, status.LogKey())
 	logObject.CloneAndAddField("state", status.State.String()).
 		AddField("activated", status.Activated).
-		Infof("domain status delete")
+		Tracef("domain status delete")
 
 	base.DeleteLogObject(status.LogKey())
 }

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -306,6 +306,44 @@ func (metric DomainMetric) Key() string {
 	return metric.UUIDandVersion.UUID.String()
 }
 
+// LogCreate :
+func (metric DomainMetric) LogCreate(logBase *base.LogObject) {
+	logObject := base.NewLogObject(logBase, base.DomainMetricLogType, "",
+		metric.UUIDandVersion.UUID, metric.LogKey())
+	if logObject == nil {
+		return
+	}
+	logObject.Metricf("Domain metric create")
+}
+
+// LogModify :
+func (metric DomainMetric) LogModify(old interface{}) {
+	logObject := base.EnsureLogObject(nil, base.DomainMetricLogType, "",
+		metric.UUIDandVersion.UUID, metric.LogKey())
+
+	oldMetric, ok := old.(DomainMetric)
+	if !ok {
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of DomainMetric type")
+	}
+	// XXX remove? XXX huge?
+	logObject.CloneAndAddField("diff", cmp.Diff(oldMetric, metric)).
+		Metricf("Domain metric modify")
+}
+
+// LogDelete :
+func (metric DomainMetric) LogDelete() {
+	logObject := base.EnsureLogObject(nil, base.DomainMetricLogType, "",
+		metric.UUIDandVersion.UUID, metric.LogKey())
+	logObject.Metricf("Domain metric delete")
+
+	base.DeleteLogObject(metric.LogKey())
+}
+
+// LogKey :
+func (metric DomainMetric) LogKey() string {
+	return string(base.DomainMetricLogType) + "-" + metric.Key()
+}
+
 // HostMemory reports global stats. Published under "global" key
 // Note that Ncpus is the set of physical CPUs which is different
 // than the set of CPUs assigned to dom0
@@ -313,4 +351,47 @@ type HostMemory struct {
 	TotalMemoryMB uint64
 	FreeMemoryMB  uint64
 	Ncpus         uint32
+}
+
+// Key returns the key for pubsub
+func (hm HostMemory) Key() string {
+	return "global"
+}
+
+// LogCreate :
+func (hm HostMemory) LogCreate(logBase *base.LogObject) {
+	logObject := base.NewLogObject(logBase, base.HostMemoryLogType, "",
+		nilUUID, hm.LogKey())
+	if logObject == nil {
+		return
+	}
+	logObject.Metricf("Host memory create")
+}
+
+// LogModify :
+func (hm HostMemory) LogModify(old interface{}) {
+	logObject := base.EnsureLogObject(nil, base.HostMemoryLogType, "",
+		nilUUID, hm.LogKey())
+
+	oldHm, ok := old.(HostMemory)
+	if !ok {
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of HostMemory type")
+	}
+	// XXX remove?
+	logObject.CloneAndAddField("diff", cmp.Diff(oldHm, hm)).
+		Metricf("Host memory modify")
+}
+
+// LogDelete :
+func (hm HostMemory) LogDelete() {
+	logObject := base.EnsureLogObject(nil, base.HostMemoryLogType, "",
+		nilUUID, hm.LogKey())
+	logObject.Metricf("Host memory delete")
+
+	base.DeleteLogObject(hm.LogKey())
+}
+
+// LogKey :
+func (hm HostMemory) LogKey() string {
+	return string(base.HostMemoryLogType) + "-" + hm.Key()
 }

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -61,7 +61,7 @@ func (config DomainConfig) LogCreate(logBase *base.LogObject) {
 	}
 	logObject.CloneAndAddField("activate", config.Activate).
 		AddField("enable-vnc", config.EnableVnc).
-		Tracef("domain config create")
+		Noticef("domain config create")
 }
 
 // LogModify :
@@ -80,11 +80,11 @@ func (config DomainConfig) LogModify(old interface{}) {
 			AddField("enable-vnc", config.EnableVnc).
 			AddField("old-activate", oldConfig.Activate).
 			AddField("old-enable-vnc", oldConfig.EnableVnc).
-			Tracef("domain config modify")
+			Noticef("domain config modify")
 	} else {
 		// XXX remove?
 		logObject.CloneAndAddField("diff", cmp.Diff(oldConfig, config)).
-			Tracef("domain config modify other change")
+			Noticef("domain config modify other change")
 	}
 }
 
@@ -94,7 +94,7 @@ func (config DomainConfig) LogDelete() {
 		config.UUIDandVersion.UUID, config.LogKey())
 	logObject.CloneAndAddField("activate", config.Activate).
 		AddField("enable-vnc", config.EnableVnc).
-		Tracef("domain config delete")
+		Noticef("domain config delete")
 
 	base.DeleteLogObject(config.LogKey())
 }
@@ -210,7 +210,7 @@ func (status DomainStatus) LogCreate(logBase *base.LogObject) {
 	}
 	logObject.CloneAndAddField("state", status.State.String()).
 		AddField("activated", status.Activated).
-		Tracef("domain status create")
+		Noticef("domain status create")
 }
 
 // LogModify :
@@ -229,11 +229,11 @@ func (status DomainStatus) LogModify(old interface{}) {
 			AddField("activated", status.Activated).
 			AddField("old-state", oldStatus.State.String()).
 			AddField("old-activated", oldStatus.Activated).
-			Tracef("domain status modify")
+			Noticef("domain status modify")
 	} else {
 		// XXX remove?
 		logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
-			Tracef("domain status modify other change")
+			Noticef("domain status modify other change")
 	}
 
 	if status.HasError() {
@@ -252,7 +252,7 @@ func (status DomainStatus) LogDelete() {
 		status.UUIDandVersion.UUID, status.LogKey())
 	logObject.CloneAndAddField("state", status.State.String()).
 		AddField("activated", status.Activated).
-		Tracef("domain status delete")
+		Noticef("domain status delete")
 
 	base.DeleteLogObject(status.LogKey())
 }

--- a/pkg/pillar/types/downloadertypes.go
+++ b/pkg/pillar/types/downloadertypes.go
@@ -6,6 +6,7 @@ package types
 import (
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus" // OK for logrus.Fatal
@@ -39,7 +40,7 @@ func (config DownloaderConfig) LogCreate(logBase *base.LogObject) {
 		AddField("datastore-id", config.DatastoreID).
 		AddField("refcount-int64", config.RefCount).
 		AddField("size-int64", config.Size).
-		Infof("Download config create")
+		Tracef("Download config create")
 }
 
 // LogModify :
@@ -64,7 +65,11 @@ func (config DownloaderConfig) LogModify(old interface{}) {
 			AddField("old-datastore-id", oldConfig.DatastoreID).
 			AddField("old-refcount-int64", oldConfig.RefCount).
 			AddField("old-size-int64", oldConfig.Size).
-			Infof("Download config modify")
+			Tracef("Download config modify")
+	} else {
+		// XXX remove?
+		logObject.CloneAndAddField("diff", cmp.Diff(oldConfig, config)).
+			Tracef("Download config modify other change")
 	}
 }
 
@@ -76,7 +81,7 @@ func (config DownloaderConfig) LogDelete() {
 		AddField("datastore-id", config.DatastoreID).
 		AddField("refcount-int64", config.RefCount).
 		AddField("size-int64", config.Size).
-		Infof("Download config delete")
+		Tracef("Download config delete")
 
 	base.DeleteLogObject(config.LogKey())
 }
@@ -154,7 +159,7 @@ func (status DownloaderStatus) LogCreate(logBase *base.LogObject) {
 	logObject.CloneAndAddField("state", status.State.String()).
 		AddField("refcount-int64", status.RefCount).
 		AddField("size-int64", status.Size).
-		Infof("Download status create")
+		Tracef("Download status create")
 }
 
 // LogModify :
@@ -176,7 +181,11 @@ func (status DownloaderStatus) LogModify(old interface{}) {
 			AddField("old-state", oldStatus.State.String()).
 			AddField("old-refcount-int64", oldStatus.RefCount).
 			AddField("old-size-int64", oldStatus.Size).
-			Infof("Download status modify")
+			Tracef("Download status modify")
+	} else {
+		// XXX remove?
+		logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
+			Tracef("Download status modify other change")
 	}
 
 	if status.HasError() {
@@ -195,7 +204,7 @@ func (status DownloaderStatus) LogDelete() {
 	logObject.CloneAndAddField("state", status.State.String()).
 		AddField("refcount-int64", status.RefCount).
 		AddField("size-int64", status.Size).
-		Infof("Download status delete")
+		Tracef("Download status delete")
 
 	base.DeleteLogObject(status.LogKey())
 }

--- a/pkg/pillar/types/downloadertypes.go
+++ b/pkg/pillar/types/downloadertypes.go
@@ -40,7 +40,7 @@ func (config DownloaderConfig) LogCreate(logBase *base.LogObject) {
 		AddField("datastore-id", config.DatastoreID).
 		AddField("refcount-int64", config.RefCount).
 		AddField("size-int64", config.Size).
-		Tracef("Download config create")
+		Noticef("Download config create")
 }
 
 // LogModify :
@@ -65,11 +65,11 @@ func (config DownloaderConfig) LogModify(old interface{}) {
 			AddField("old-datastore-id", oldConfig.DatastoreID).
 			AddField("old-refcount-int64", oldConfig.RefCount).
 			AddField("old-size-int64", oldConfig.Size).
-			Tracef("Download config modify")
+			Noticef("Download config modify")
 	} else {
 		// XXX remove?
 		logObject.CloneAndAddField("diff", cmp.Diff(oldConfig, config)).
-			Tracef("Download config modify other change")
+			Noticef("Download config modify other change")
 	}
 }
 
@@ -81,7 +81,7 @@ func (config DownloaderConfig) LogDelete() {
 		AddField("datastore-id", config.DatastoreID).
 		AddField("refcount-int64", config.RefCount).
 		AddField("size-int64", config.Size).
-		Tracef("Download config delete")
+		Noticef("Download config delete")
 
 	base.DeleteLogObject(config.LogKey())
 }
@@ -159,7 +159,7 @@ func (status DownloaderStatus) LogCreate(logBase *base.LogObject) {
 	logObject.CloneAndAddField("state", status.State.String()).
 		AddField("refcount-int64", status.RefCount).
 		AddField("size-int64", status.Size).
-		Tracef("Download status create")
+		Noticef("Download status create")
 }
 
 // LogModify :
@@ -181,11 +181,11 @@ func (status DownloaderStatus) LogModify(old interface{}) {
 			AddField("old-state", oldStatus.State.String()).
 			AddField("old-refcount-int64", oldStatus.RefCount).
 			AddField("old-size-int64", oldStatus.Size).
-			Tracef("Download status modify")
+			Noticef("Download status modify")
 	} else {
 		// XXX remove?
 		logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
-			Tracef("Download status modify other change")
+			Noticef("Download status modify other change")
 	}
 
 	if status.HasError() {
@@ -204,7 +204,7 @@ func (status DownloaderStatus) LogDelete() {
 	logObject.CloneAndAddField("state", status.State.String()).
 		AddField("refcount-int64", status.RefCount).
 		AddField("size-int64", status.Size).
-		Tracef("Download status delete")
+		Noticef("Download status delete")
 
 	base.DeleteLogObject(status.LogKey())
 }

--- a/pkg/pillar/types/logmanagertypes.go
+++ b/pkg/pillar/types/logmanagertypes.go
@@ -8,6 +8,8 @@ import (
 )
 
 // LogMetrics Metrics from logmanager
+// Note that there are no LogCreate etc functions for this type
+// since we don't want to cause logs when logging
 type LogMetrics struct {
 	NumDeviceEventsSent           uint64
 	NumDeviceBundlesSent          uint64

--- a/pkg/pillar/types/physicalioadapters.go
+++ b/pkg/pillar/types/physicalioadapters.go
@@ -7,7 +7,9 @@ package types
 //  These are translated to AssignableAdapters
 
 import (
+	"github.com/google/go-cmp/cmp"
 	zcommon "github.com/lf-edge/eve/api/go/evecommon"
+	"github.com/lf-edge/eve/pkg/pillar/base"
 )
 
 // PhysicalAddress - Structure that represents various attributes related
@@ -60,6 +62,49 @@ type PhysicalIOAdapter struct {
 type PhysicalIOAdapterList struct {
 	Initialized bool
 	AdapterList []PhysicalIOAdapter
+}
+
+// Key returns the key for pubsub
+func (ioAdapterList PhysicalIOAdapterList) Key() string {
+	return "global"
+}
+
+// LogCreate :
+func (ioAdapterList PhysicalIOAdapterList) LogCreate(logBase *base.LogObject) {
+	logObject := base.NewLogObject(logBase, base.PhysicalIOAdapterListLogType, "",
+		nilUUID, ioAdapterList.LogKey())
+	if logObject == nil {
+		return
+	}
+	logObject.Metricf("Onboarding ioAdapterList create")
+}
+
+// LogModify :
+func (ioAdapterList PhysicalIOAdapterList) LogModify(old interface{}) {
+	logObject := base.EnsureLogObject(nil, base.PhysicalIOAdapterListLogType, "",
+		nilUUID, ioAdapterList.LogKey())
+
+	oldIoAdapterList, ok := old.(PhysicalIOAdapterList)
+	if !ok {
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of PhysicalIOAdapterList type")
+	}
+	// XXX remove?
+	logObject.CloneAndAddField("diff", cmp.Diff(oldIoAdapterList, ioAdapterList)).
+		Metricf("Onboarding ioAdapterList modify")
+}
+
+// LogDelete :
+func (ioAdapterList PhysicalIOAdapterList) LogDelete() {
+	logObject := base.EnsureLogObject(nil, base.PhysicalIOAdapterListLogType, "",
+		nilUUID, ioAdapterList.LogKey())
+	logObject.Metricf("Onboarding ioAdapterList delete")
+
+	base.DeleteLogObject(ioAdapterList.LogKey())
+}
+
+// LogKey :
+func (ioAdapterList PhysicalIOAdapterList) LogKey() string {
+	return string(base.PhysicalIOAdapterListLogType) + "-" + ioAdapterList.Key()
 }
 
 // LookupAdapter - look up an Adapter by its name ( phylabel )

--- a/pkg/pillar/types/resolvertypes.go
+++ b/pkg/pillar/types/resolvertypes.go
@@ -35,7 +35,7 @@ func (config ResolveConfig) LogCreate(logBase *base.LogObject) {
 	if logObject == nil {
 		return
 	}
-	logObject.Tracef("Resolve config create")
+	logObject.Noticef("Resolve config create")
 }
 
 // LogModify :
@@ -49,14 +49,14 @@ func (config ResolveConfig) LogModify(old interface{}) {
 	}
 	// Why would it change?
 	logObject.CloneAndAddField("diff", cmp.Diff(oldConfig, config)).
-		Tracef("Resolve config modify other change")
+		Noticef("Resolve config modify other change")
 }
 
 // LogDelete :
 func (config ResolveConfig) LogDelete() {
 	logObject := base.EnsureLogObject(nil, base.ResolveConfigLogType, config.Name,
 		config.DatastoreID, config.LogKey())
-	logObject.Tracef("Resolve config delete")
+	logObject.Noticef("Resolve config delete")
 
 	base.DeleteLogObject(config.LogKey())
 }
@@ -94,7 +94,7 @@ func (status ResolveStatus) LogCreate(logBase *base.LogObject) {
 	}
 	logObject.CloneAndAddField("image-sha256", status.ImageSha256).
 		AddField("retry-count-int64", status.RetryCount).
-		Tracef("Resolve status create")
+		Noticef("Resolve status create")
 }
 
 // LogModify :
@@ -113,11 +113,11 @@ func (status ResolveStatus) LogModify(old interface{}) {
 			AddField("retry-count-int64", status.RetryCount).
 			AddField("old-image-sha256", oldStatus.ImageSha256).
 			AddField("old-retry-count-int64", oldStatus.RetryCount).
-			Tracef("Resolve status modify")
+			Noticef("Resolve status modify")
 	} else {
 		// XXX remove?
 		logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
-			Tracef("Resolve status modify other change")
+			Noticef("Resolve status modify other change")
 	}
 
 	if status.HasError() {
@@ -136,7 +136,7 @@ func (status ResolveStatus) LogDelete() {
 		status.DatastoreID, status.LogKey())
 	logObject.CloneAndAddField("image-sha256", status.ImageSha256).
 		AddField("retry-count-int64", status.RetryCount).
-		Tracef("Resolve status delete")
+		Noticef("Resolve status delete")
 
 	base.DeleteLogObject(status.LogKey())
 }

--- a/pkg/pillar/types/types.go
+++ b/pkg/pillar/types/types.go
@@ -222,7 +222,7 @@ func (info UuidToNum) LogCreate(logBase *base.LogObject) {
 	if logObject == nil {
 		return
 	}
-	logObject.Tracef("UuidToNum info create")
+	logObject.Noticef("UuidToNum info create")
 }
 
 // LogModify :
@@ -236,14 +236,14 @@ func (info UuidToNum) LogModify(old interface{}) {
 	}
 	// XXX remove?
 	logObject.CloneAndAddField("diff", cmp.Diff(oldInfo, info)).
-		Tracef("UuidToNum info modify")
+		Noticef("UuidToNum info modify")
 }
 
 // LogDelete :
 func (info UuidToNum) LogDelete() {
 	logObject := base.EnsureLogObject(nil, base.UUIDToNumLogType, "",
 		info.UUID, info.LogKey())
-	logObject.Tracef("UuidToNum info delete")
+	logObject.Noticef("UuidToNum info delete")
 
 	base.DeleteLogObject(info.LogKey())
 }

--- a/pkg/pillar/types/vaultmgrtypes.go
+++ b/pkg/pillar/types/vaultmgrtypes.go
@@ -30,7 +30,7 @@ func (status VaultStatus) LogCreate(logBase *base.LogObject) {
 	if logObject == nil {
 		return
 	}
-	logObject.Tracef("Vault status create")
+	logObject.Noticef("Vault status create")
 }
 
 // LogModify :
@@ -44,7 +44,7 @@ func (status VaultStatus) LogModify(old interface{}) {
 	}
 	// XXX remove?
 	logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
-		Tracef("Vault status modify")
+		Noticef("Vault status modify")
 	if status.HasError() {
 		errAndTime := status.ErrorAndTime
 		logObject.CloneAndAddField("error", errAndTime.Error).
@@ -57,7 +57,7 @@ func (status VaultStatus) LogModify(old interface{}) {
 func (status VaultStatus) LogDelete() {
 	logObject := base.EnsureLogObject(nil, base.VaultStatusLogType, status.Name,
 		nilUUID, status.LogKey())
-	logObject.Tracef("Vault status delete")
+	logObject.Noticef("Vault status delete")
 
 	base.DeleteLogObject(status.LogKey())
 }

--- a/pkg/pillar/types/verifiertypes.go
+++ b/pkg/pillar/types/verifiertypes.go
@@ -47,7 +47,7 @@ func (config VerifyImageConfig) LogCreate(logBase *base.LogObject) {
 	}
 	logObject.CloneAndAddField("refcount-int64", config.RefCount).
 		AddField("expired-bool", config.Expired).
-		Tracef("VerifyImage config create")
+		Noticef("VerifyImage config create")
 }
 
 // LogModify :
@@ -66,11 +66,11 @@ func (config VerifyImageConfig) LogModify(old interface{}) {
 			AddField("expired-bool", config.Expired).
 			AddField("old-refcount-int64", oldConfig.RefCount).
 			AddField("old-expired-bool", oldConfig.Expired).
-			Tracef("VerifyImage config modify")
+			Noticef("VerifyImage config modify")
 	} else {
 		// XXX remove?
 		logObject.CloneAndAddField("diff", cmp.Diff(oldConfig, config)).
-			Tracef("VerifyImage config modify other change")
+			Noticef("VerifyImage config modify other change")
 	}
 }
 
@@ -80,7 +80,7 @@ func (config VerifyImageConfig) LogDelete() {
 		nilUUID, config.LogKey())
 	logObject.CloneAndAddField("refcount-int64", config.RefCount).
 		AddField("expired-bool", config.Expired).
-		Tracef("VerifyImage config delete")
+		Noticef("VerifyImage config delete")
 
 	base.DeleteLogObject(config.LogKey())
 }
@@ -124,7 +124,7 @@ func (status VerifyImageStatus) LogCreate(logBase *base.LogObject) {
 		AddField("expired-bool", status.Expired).
 		AddField("size-int64", status.Size).
 		AddField("filelocation", status.FileLocation).
-		Tracef("VerifyImage status create")
+		Noticef("VerifyImage status create")
 }
 
 // LogModify :
@@ -152,11 +152,11 @@ func (status VerifyImageStatus) LogModify(old interface{}) {
 			AddField("old-size-int64", oldStatus.Size).
 			AddField("filelocation", status.FileLocation).
 			AddField("old-filelocation", oldStatus.FileLocation).
-			Tracef("VerifyImage status modify")
+			Noticef("VerifyImage status modify")
 	} else {
 		// XXX remove?
 		logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
-			Tracef("VerifyImage status modify other change")
+			Noticef("VerifyImage status modify other change")
 	}
 
 	if status.HasError() {
@@ -177,7 +177,7 @@ func (status VerifyImageStatus) LogDelete() {
 		AddField("expired-bool", status.Expired).
 		AddField("size-int64", status.Size).
 		AddField("filelocation", status.FileLocation).
-		Tracef("VerifyImage status delete")
+		Noticef("VerifyImage status delete")
 
 	base.DeleteLogObject(status.LogKey())
 }

--- a/pkg/pillar/types/verifiertypes.go
+++ b/pkg/pillar/types/verifiertypes.go
@@ -6,6 +6,7 @@
 package types
 
 import (
+	"github.com/google/go-cmp/cmp"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 )
 
@@ -46,7 +47,7 @@ func (config VerifyImageConfig) LogCreate(logBase *base.LogObject) {
 	}
 	logObject.CloneAndAddField("refcount-int64", config.RefCount).
 		AddField("expired-bool", config.Expired).
-		Infof("VerifyImage config create")
+		Tracef("VerifyImage config create")
 }
 
 // LogModify :
@@ -65,7 +66,11 @@ func (config VerifyImageConfig) LogModify(old interface{}) {
 			AddField("expired-bool", config.Expired).
 			AddField("old-refcount-int64", oldConfig.RefCount).
 			AddField("old-expired-bool", oldConfig.Expired).
-			Infof("VerifyImage config modify")
+			Tracef("VerifyImage config modify")
+	} else {
+		// XXX remove?
+		logObject.CloneAndAddField("diff", cmp.Diff(oldConfig, config)).
+			Tracef("VerifyImage config modify other change")
 	}
 }
 
@@ -75,7 +80,7 @@ func (config VerifyImageConfig) LogDelete() {
 		nilUUID, config.LogKey())
 	logObject.CloneAndAddField("refcount-int64", config.RefCount).
 		AddField("expired-bool", config.Expired).
-		Infof("VerifyImage config delete")
+		Tracef("VerifyImage config delete")
 
 	base.DeleteLogObject(config.LogKey())
 }
@@ -119,7 +124,7 @@ func (status VerifyImageStatus) LogCreate(logBase *base.LogObject) {
 		AddField("expired-bool", status.Expired).
 		AddField("size-int64", status.Size).
 		AddField("filelocation", status.FileLocation).
-		Infof("VerifyImage status create")
+		Tracef("VerifyImage status create")
 }
 
 // LogModify :
@@ -147,7 +152,11 @@ func (status VerifyImageStatus) LogModify(old interface{}) {
 			AddField("old-size-int64", oldStatus.Size).
 			AddField("filelocation", status.FileLocation).
 			AddField("old-filelocation", oldStatus.FileLocation).
-			Infof("VerifyImage status modify")
+			Tracef("VerifyImage status modify")
+	} else {
+		// XXX remove?
+		logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
+			Tracef("VerifyImage status modify other change")
 	}
 
 	if status.HasError() {
@@ -168,7 +177,7 @@ func (status VerifyImageStatus) LogDelete() {
 		AddField("expired-bool", status.Expired).
 		AddField("size-int64", status.Size).
 		AddField("filelocation", status.FileLocation).
-		Infof("VerifyImage status delete")
+		Tracef("VerifyImage status delete")
 
 	base.DeleteLogObject(status.LogKey())
 }

--- a/pkg/pillar/types/volumetypes.go
+++ b/pkg/pillar/types/volumetypes.go
@@ -43,7 +43,7 @@ func (config VolumeConfig) LogCreate(logBase *base.LogObject) {
 		AddField("max-vol-size-int64", config.MaxVolSize).
 		AddField("refcount-int64", config.RefCount).
 		AddField("generation-counter-int64", config.GenerationCounter).
-		Tracef("Volume config create")
+		Noticef("Volume config create")
 }
 
 // LogModify :
@@ -68,11 +68,11 @@ func (config VolumeConfig) LogModify(old interface{}) {
 			AddField("old-max-vol-size-int64", oldConfig.MaxVolSize).
 			AddField("old-refcount-int64", oldConfig.RefCount).
 			AddField("old-generation-counter-int64", oldConfig.GenerationCounter).
-			Tracef("Volume config modify")
+			Noticef("Volume config modify")
 	} else {
 		// XXX remove?
 		logObject.CloneAndAddField("diff", cmp.Diff(oldConfig, config)).
-			Tracef("Volume config modify other change")
+			Noticef("Volume config modify other change")
 	}
 }
 
@@ -84,7 +84,7 @@ func (config VolumeConfig) LogDelete() {
 		AddField("max-vol-size-int64", config.MaxVolSize).
 		AddField("refcount-int64", config.RefCount).
 		AddField("generation-counter-int64", config.GenerationCounter).
-		Tracef("Volume config delete")
+		Noticef("Volume config delete")
 
 	base.DeleteLogObject(config.LogKey())
 }
@@ -152,7 +152,7 @@ func (status VolumeStatus) LogCreate(logBase *base.LogObject) {
 		AddField("progress-int64", status.Progress).
 		AddField("refcount-int64", status.RefCount).
 		AddField("filelocation", status.FileLocation).
-		Tracef("Volume status create")
+		Noticef("Volume status create")
 }
 
 // LogModify :
@@ -183,11 +183,11 @@ func (status VolumeStatus) LogModify(old interface{}) {
 			AddField("old-progress-int64", oldStatus.Progress).
 			AddField("old-refcount-int64", oldStatus.RefCount).
 			AddField("old-filelocation", oldStatus.FileLocation).
-			Tracef("Volume status modify")
+			Noticef("Volume status modify")
 	} else {
 		// XXX remove?
 		logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
-			Tracef("Volume status modify other change")
+			Noticef("Volume status modify other change")
 	}
 }
 
@@ -201,7 +201,7 @@ func (status VolumeStatus) LogDelete() {
 		AddField("progress-int64", status.Progress).
 		AddField("refcount-int64", status.RefCount).
 		AddField("filelocation", status.FileLocation).
-		Tracef("Volume status delete")
+		Noticef("Volume status delete")
 
 	base.DeleteLogObject(status.LogKey())
 }
@@ -240,7 +240,7 @@ func (config VolumeRefConfig) LogCreate(logBase *base.LogObject) {
 	}
 	logObject.CloneAndAddField("refcount-int64", config.RefCount).
 		AddField("generation-counter-int64", config.GenerationCounter).
-		Tracef("Volume ref config create")
+		Noticef("Volume ref config create")
 }
 
 // LogModify :
@@ -255,11 +255,11 @@ func (config VolumeRefConfig) LogModify(old interface{}) {
 	if oldConfig.RefCount != config.RefCount {
 		logObject.CloneAndAddField("refcount-int64", config.RefCount).
 			AddField("old-refcount-int64", oldConfig.RefCount).
-			Tracef("Volume ref config modify")
+			Noticef("Volume ref config modify")
 	} else {
 		// XXX remove?
 		logObject.CloneAndAddField("diff", cmp.Diff(oldConfig, config)).
-			Tracef("Volume ref config modify other change")
+			Noticef("Volume ref config modify other change")
 	}
 }
 
@@ -268,7 +268,7 @@ func (config VolumeRefConfig) LogDelete() {
 	logObject := base.EnsureLogObject(nil, base.VolumeRefConfigLogType, "",
 		config.VolumeID, config.LogKey())
 	logObject.CloneAndAddField("refcount-int64", config.RefCount).
-		Tracef("Volume ref config delete")
+		Noticef("Volume ref config delete")
 
 	base.DeleteLogObject(config.LogKey())
 }
@@ -332,7 +332,7 @@ func (status VolumeRefStatus) LogCreate(logBase *base.LogObject) {
 		AddField("displayname", status.DisplayName).
 		AddField("max-vol-size-int64", status.MaxVolSize).
 		AddField("pending-add-bool", status.PendingAdd).
-		Tracef("Volume ref status create")
+		Noticef("Volume ref status create")
 }
 
 // LogModify :
@@ -369,7 +369,7 @@ func (status VolumeRefStatus) LogModify(old interface{}) {
 			AddField("displayname", oldStatus.DisplayName).
 			AddField("old-max-vol-size-int64", oldStatus.MaxVolSize).
 			AddField("Pending-add-bool", oldStatus.PendingAdd).
-			Tracef("Volume ref status modify")
+			Noticef("Volume ref status modify")
 	}
 }
 
@@ -386,7 +386,7 @@ func (status VolumeRefStatus) LogDelete() {
 		AddField("displayname", status.DisplayName).
 		AddField("max-vol-size-int64", status.MaxVolSize).
 		AddField("pending-add-bool", status.PendingAdd).
-		Tracef("Volume ref status delete")
+		Noticef("Volume ref status delete")
 
 	base.DeleteLogObject(status.LogKey())
 }

--- a/pkg/pillar/types/volumetypes.go
+++ b/pkg/pillar/types/volumetypes.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	zconfig "github.com/lf-edge/eve/api/go/config"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	uuid "github.com/satori/go.uuid"
@@ -42,7 +43,7 @@ func (config VolumeConfig) LogCreate(logBase *base.LogObject) {
 		AddField("max-vol-size-int64", config.MaxVolSize).
 		AddField("refcount-int64", config.RefCount).
 		AddField("generation-counter-int64", config.GenerationCounter).
-		Infof("Volume config create")
+		Tracef("Volume config create")
 }
 
 // LogModify :
@@ -67,7 +68,11 @@ func (config VolumeConfig) LogModify(old interface{}) {
 			AddField("old-max-vol-size-int64", oldConfig.MaxVolSize).
 			AddField("old-refcount-int64", oldConfig.RefCount).
 			AddField("old-generation-counter-int64", oldConfig.GenerationCounter).
-			Infof("Volume config modify")
+			Tracef("Volume config modify")
+	} else {
+		// XXX remove?
+		logObject.CloneAndAddField("diff", cmp.Diff(oldConfig, config)).
+			Tracef("Volume config modify other change")
 	}
 }
 
@@ -79,7 +84,7 @@ func (config VolumeConfig) LogDelete() {
 		AddField("max-vol-size-int64", config.MaxVolSize).
 		AddField("refcount-int64", config.RefCount).
 		AddField("generation-counter-int64", config.GenerationCounter).
-		Infof("Volume config delete")
+		Tracef("Volume config delete")
 
 	base.DeleteLogObject(config.LogKey())
 }
@@ -147,7 +152,7 @@ func (status VolumeStatus) LogCreate(logBase *base.LogObject) {
 		AddField("progress-int64", status.Progress).
 		AddField("refcount-int64", status.RefCount).
 		AddField("filelocation", status.FileLocation).
-		Infof("Volume status create")
+		Tracef("Volume status create")
 }
 
 // LogModify :
@@ -178,7 +183,11 @@ func (status VolumeStatus) LogModify(old interface{}) {
 			AddField("old-progress-int64", oldStatus.Progress).
 			AddField("old-refcount-int64", oldStatus.RefCount).
 			AddField("old-filelocation", oldStatus.FileLocation).
-			Infof("Volume status modify")
+			Tracef("Volume status modify")
+	} else {
+		// XXX remove?
+		logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
+			Tracef("Volume status modify other change")
 	}
 }
 
@@ -192,7 +201,7 @@ func (status VolumeStatus) LogDelete() {
 		AddField("progress-int64", status.Progress).
 		AddField("refcount-int64", status.RefCount).
 		AddField("filelocation", status.FileLocation).
-		Infof("Volume status delete")
+		Tracef("Volume status delete")
 
 	base.DeleteLogObject(status.LogKey())
 }
@@ -231,7 +240,7 @@ func (config VolumeRefConfig) LogCreate(logBase *base.LogObject) {
 	}
 	logObject.CloneAndAddField("refcount-int64", config.RefCount).
 		AddField("generation-counter-int64", config.GenerationCounter).
-		Infof("Volume ref config create")
+		Tracef("Volume ref config create")
 }
 
 // LogModify :
@@ -246,7 +255,11 @@ func (config VolumeRefConfig) LogModify(old interface{}) {
 	if oldConfig.RefCount != config.RefCount {
 		logObject.CloneAndAddField("refcount-int64", config.RefCount).
 			AddField("old-refcount-int64", oldConfig.RefCount).
-			Infof("Volume ref config modify")
+			Tracef("Volume ref config modify")
+	} else {
+		// XXX remove?
+		logObject.CloneAndAddField("diff", cmp.Diff(oldConfig, config)).
+			Tracef("Volume ref config modify other change")
 	}
 }
 
@@ -255,7 +268,7 @@ func (config VolumeRefConfig) LogDelete() {
 	logObject := base.EnsureLogObject(nil, base.VolumeRefConfigLogType, "",
 		config.VolumeID, config.LogKey())
 	logObject.CloneAndAddField("refcount-int64", config.RefCount).
-		Infof("Volume ref config delete")
+		Tracef("Volume ref config delete")
 
 	base.DeleteLogObject(config.LogKey())
 }
@@ -319,7 +332,7 @@ func (status VolumeRefStatus) LogCreate(logBase *base.LogObject) {
 		AddField("displayname", status.DisplayName).
 		AddField("max-vol-size-int64", status.MaxVolSize).
 		AddField("pending-add-bool", status.PendingAdd).
-		Infof("Volume ref status create")
+		Tracef("Volume ref status create")
 }
 
 // LogModify :
@@ -356,7 +369,7 @@ func (status VolumeRefStatus) LogModify(old interface{}) {
 			AddField("displayname", oldStatus.DisplayName).
 			AddField("old-max-vol-size-int64", oldStatus.MaxVolSize).
 			AddField("Pending-add-bool", oldStatus.PendingAdd).
-			Infof("Volume ref status modify")
+			Tracef("Volume ref status modify")
 	}
 }
 
@@ -373,7 +386,7 @@ func (status VolumeRefStatus) LogDelete() {
 		AddField("displayname", status.DisplayName).
 		AddField("max-vol-size-int64", status.MaxVolSize).
 		AddField("pending-add-bool", status.PendingAdd).
-		Infof("Volume ref status delete")
+		Tracef("Volume ref status delete")
 
 	base.DeleteLogObject(status.LogKey())
 }

--- a/pkg/pillar/types/zboottypes.go
+++ b/pkg/pillar/types/zboottypes.go
@@ -28,7 +28,7 @@ func (config ZbootConfig) LogCreate(logBase *base.LogObject) {
 		return
 	}
 	logObject.CloneAndAddField("test-complete-bool", config.TestComplete).
-		Tracef("Zboot config create")
+		Noticef("Zboot config create")
 }
 
 // LogModify :
@@ -44,11 +44,11 @@ func (config ZbootConfig) LogModify(old interface{}) {
 
 		logObject.CloneAndAddField("test-complete-bool", config.TestComplete).
 			AddField("old-test-complete-bool", oldConfig.TestComplete).
-			Tracef("Zboot config modify")
+			Noticef("Zboot config modify")
 	} else {
 		// XXX remove?
 		logObject.CloneAndAddField("diff", cmp.Diff(oldConfig, config)).
-			Tracef("Zboot config modify other change")
+			Noticef("Zboot config modify other change")
 	}
 }
 
@@ -57,7 +57,7 @@ func (config ZbootConfig) LogDelete() {
 	logObject := base.EnsureLogObject(nil, base.ZbootConfigLogType, "",
 		nilUUID, config.LogKey())
 	logObject.CloneAndAddField("test-complete-bool", config.TestComplete).
-		Tracef("Zboot config delete")
+		Noticef("Zboot config delete")
 
 	base.DeleteLogObject(config.LogKey())
 }
@@ -91,7 +91,7 @@ func (status ZbootStatus) LogCreate(logBase *base.LogObject) {
 	logObject.CloneAndAddField("partition-state", status.PartitionState).
 		AddField("current-partition-bool", status.CurrentPartition).
 		AddField("test-complete-bool", status.TestComplete).
-		Tracef("Zboot status create")
+		Noticef("Zboot status create")
 }
 
 // LogModify :
@@ -113,11 +113,11 @@ func (status ZbootStatus) LogModify(old interface{}) {
 			AddField("old-current-partition-bool", oldStatus.CurrentPartition).
 			AddField("test-complete-bool", status.TestComplete).
 			AddField("old-test-complete-bool", oldStatus.TestComplete).
-			Tracef("Zboot status modify")
+			Noticef("Zboot status modify")
 	} else {
 		// XXX remove?
 		logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
-			Tracef("Zboot status modify other change")
+			Noticef("Zboot status modify other change")
 	}
 }
 
@@ -128,7 +128,7 @@ func (status ZbootStatus) LogDelete() {
 	logObject.CloneAndAddField("partition-state", status.PartitionState).
 		AddField("current-partition-bool", status.CurrentPartition).
 		AddField("test-complete-bool", status.TestComplete).
-		Tracef("Zboot status delete")
+		Noticef("Zboot status delete")
 
 	base.DeleteLogObject(status.LogKey())
 }

--- a/pkg/pillar/types/zboottypes.go
+++ b/pkg/pillar/types/zboottypes.go
@@ -4,6 +4,7 @@
 package types
 
 import (
+	"github.com/google/go-cmp/cmp"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 )
 
@@ -27,7 +28,7 @@ func (config ZbootConfig) LogCreate(logBase *base.LogObject) {
 		return
 	}
 	logObject.CloneAndAddField("test-complete-bool", config.TestComplete).
-		Infof("Zboot config create")
+		Tracef("Zboot config create")
 }
 
 // LogModify :
@@ -43,9 +44,12 @@ func (config ZbootConfig) LogModify(old interface{}) {
 
 		logObject.CloneAndAddField("test-complete-bool", config.TestComplete).
 			AddField("old-test-complete-bool", oldConfig.TestComplete).
-			Infof("Zboot config modify")
+			Tracef("Zboot config modify")
+	} else {
+		// XXX remove?
+		logObject.CloneAndAddField("diff", cmp.Diff(oldConfig, config)).
+			Tracef("Zboot config modify other change")
 	}
-
 }
 
 // LogDelete :
@@ -53,7 +57,7 @@ func (config ZbootConfig) LogDelete() {
 	logObject := base.EnsureLogObject(nil, base.ZbootConfigLogType, "",
 		nilUUID, config.LogKey())
 	logObject.CloneAndAddField("test-complete-bool", config.TestComplete).
-		Infof("Zboot config delete")
+		Tracef("Zboot config delete")
 
 	base.DeleteLogObject(config.LogKey())
 }
@@ -87,7 +91,7 @@ func (status ZbootStatus) LogCreate(logBase *base.LogObject) {
 	logObject.CloneAndAddField("partition-state", status.PartitionState).
 		AddField("current-partition-bool", status.CurrentPartition).
 		AddField("test-complete-bool", status.TestComplete).
-		Infof("Zboot status create")
+		Tracef("Zboot status create")
 }
 
 // LogModify :
@@ -109,7 +113,11 @@ func (status ZbootStatus) LogModify(old interface{}) {
 			AddField("old-current-partition-bool", oldStatus.CurrentPartition).
 			AddField("test-complete-bool", status.TestComplete).
 			AddField("old-test-complete-bool", oldStatus.TestComplete).
-			Infof("Zboot status modify")
+			Tracef("Zboot status modify")
+	} else {
+		// XXX remove?
+		logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
+			Tracef("Zboot status modify other change")
 	}
 }
 
@@ -120,7 +128,7 @@ func (status ZbootStatus) LogDelete() {
 	logObject.CloneAndAddField("partition-state", status.PartitionState).
 		AddField("current-partition-bool", status.CurrentPartition).
 		AddField("test-complete-bool", status.TestComplete).
-		Infof("Zboot status delete")
+		Tracef("Zboot status delete")
 
 	base.DeleteLogObject(status.LogKey())
 }

--- a/pkg/pillar/types/zedagenttypes.go
+++ b/pkg/pillar/types/zedagenttypes.go
@@ -260,6 +260,44 @@ func (config DatastoreConfig) Key() string {
 	return config.UUID.String()
 }
 
+// LogCreate :
+func (config DatastoreConfig) LogCreate(logBase *base.LogObject) {
+	logObject := base.NewLogObject(logBase, base.DatastoreConfigLogType, "",
+		config.UUID, config.LogKey())
+	if logObject == nil {
+		return
+	}
+	logObject.Tracef("Datastore config create")
+}
+
+// LogModify :
+func (config DatastoreConfig) LogModify(old interface{}) {
+	logObject := base.EnsureLogObject(nil, base.DatastoreConfigLogType, "",
+		config.UUID, config.LogKey())
+
+	oldConfig, ok := old.(DatastoreConfig)
+	if !ok {
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of DatastoreConfig type")
+	}
+	// XXX remove?
+	logObject.CloneAndAddField("diff", cmp.Diff(oldConfig, config)).
+		Tracef("Datastore config modify")
+}
+
+// LogDelete :
+func (config DatastoreConfig) LogDelete() {
+	logObject := base.EnsureLogObject(nil, base.DatastoreConfigLogType, "",
+		config.UUID, config.LogKey())
+	logObject.Tracef("Datastore config delete")
+
+	base.DeleteLogObject(config.LogKey())
+}
+
+// LogKey :
+func (config DatastoreConfig) LogKey() string {
+	return string(base.DatastoreConfigLogType) + "-" + config.Key()
+}
+
 // NodeAgentStatus :
 type NodeAgentStatus struct {
 	Name              string
@@ -277,6 +315,44 @@ type NodeAgentStatus struct {
 // Key :
 func (status NodeAgentStatus) Key() string {
 	return status.Name
+}
+
+// LogCreate :
+func (status NodeAgentStatus) LogCreate(logBase *base.LogObject) {
+	logObject := base.NewLogObject(logBase, base.NodeAgentStatusLogType, status.Name,
+		nilUUID, status.LogKey())
+	if logObject == nil {
+		return
+	}
+	logObject.Tracef("Nodeagent status create")
+}
+
+// LogModify :
+func (status NodeAgentStatus) LogModify(old interface{}) {
+	logObject := base.EnsureLogObject(nil, base.NodeAgentStatusLogType, status.Name,
+		nilUUID, status.LogKey())
+
+	oldStatus, ok := old.(NodeAgentStatus)
+	if !ok {
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of NodeAgentStatus type")
+	}
+	// XXX remove?
+	logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
+		Tracef("Nodeagent status modify")
+}
+
+// LogDelete :
+func (status NodeAgentStatus) LogDelete() {
+	logObject := base.EnsureLogObject(nil, base.NodeAgentStatusLogType, status.Name,
+		nilUUID, status.LogKey())
+	logObject.Tracef("Nodeagent status delete")
+
+	base.DeleteLogObject(status.LogKey())
+}
+
+// LogKey :
+func (status NodeAgentStatus) LogKey() string {
+	return string(base.NodeAgentStatusLogType) + "-" + status.Key()
 }
 
 // ConfigGetStatus : Config Get Status from Controller
@@ -301,6 +377,44 @@ type ZedAgentStatus struct {
 // Key :
 func (status ZedAgentStatus) Key() string {
 	return status.Name
+}
+
+// LogCreate :
+func (status ZedAgentStatus) LogCreate(logBase *base.LogObject) {
+	logObject := base.NewLogObject(logBase, base.ZedAgentStatusLogType, status.Name,
+		nilUUID, status.LogKey())
+	if logObject == nil {
+		return
+	}
+	logObject.Tracef("Zedagent status create")
+}
+
+// LogModify :
+func (status ZedAgentStatus) LogModify(old interface{}) {
+	logObject := base.EnsureLogObject(nil, base.ZedAgentStatusLogType, status.Name,
+		nilUUID, status.LogKey())
+
+	oldStatus, ok := old.(ZedAgentStatus)
+	if !ok {
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of ZedAgentStatus type")
+	}
+	// XXX remove?
+	logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
+		Tracef("Zedagent status modify")
+}
+
+// LogDelete :
+func (status ZedAgentStatus) LogDelete() {
+	logObject := base.EnsureLogObject(nil, base.ZedAgentStatusLogType, status.Name,
+		nilUUID, status.LogKey())
+	logObject.Tracef("Zedagent status delete")
+
+	base.DeleteLogObject(status.LogKey())
+}
+
+// LogKey :
+func (status ZedAgentStatus) LogKey() string {
+	return string(base.ZedAgentStatusLogType) + "-" + status.Key()
 }
 
 // DeviceOpsCmd - copy of zconfig.DeviceOpsCmd

--- a/pkg/pillar/types/zedagenttypes.go
+++ b/pkg/pillar/types/zedagenttypes.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/satori/go.uuid"
 )
@@ -45,7 +46,7 @@ func (config BaseOsConfig) LogCreate(logBase *base.LogObject) {
 		return
 	}
 	logObject.CloneAndAddField("activate", config.Activate).
-		Infof("BaseOs config create")
+		Tracef("BaseOs config create")
 }
 
 // LogModify :
@@ -61,7 +62,11 @@ func (config BaseOsConfig) LogModify(old interface{}) {
 
 		logObject.CloneAndAddField("activate", config.Activate).
 			AddField("old-activate", oldConfig.Activate).
-			Infof("BaseOs config modify")
+			Tracef("BaseOs config modify")
+	} else {
+		// XXX remove?
+		logObject.CloneAndAddField("diff", cmp.Diff(oldConfig, config)).
+			Tracef("BaseOs config modify other change")
 	}
 
 }
@@ -71,7 +76,7 @@ func (config BaseOsConfig) LogDelete() {
 	logObject := base.EnsureLogObject(nil, base.BaseOsConfigLogType, config.BaseOsVersion,
 		config.UUIDandVersion.UUID, config.LogKey())
 	logObject.CloneAndAddField("activate", config.Activate).
-		Infof("BaseOs config delete")
+		Tracef("BaseOs config delete")
 
 	base.DeleteLogObject(config.LogKey())
 }
@@ -115,7 +120,7 @@ func (status BaseOsStatus) LogCreate(logBase *base.LogObject) {
 		return
 	}
 	logObject.CloneAndAddField("state", status.State.String()).
-		Infof("BaseOs status create")
+		Tracef("BaseOs status create")
 }
 
 // LogModify :
@@ -131,7 +136,11 @@ func (status BaseOsStatus) LogModify(old interface{}) {
 
 		logObject.CloneAndAddField("state", status.State.String()).
 			AddField("old-state", oldStatus.State.String()).
-			Infof("BaseOs status modify")
+			Tracef("BaseOs status modify")
+	} else {
+		// XXX remove?
+		logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
+			Tracef("BaseOs status modify other change")
 	}
 
 	if status.HasError() {
@@ -148,7 +157,7 @@ func (status BaseOsStatus) LogDelete() {
 	logObject := base.EnsureLogObject(nil, base.BaseOsStatusLogType, status.BaseOsVersion,
 		status.UUIDandVersion.UUID, status.LogKey())
 	logObject.CloneAndAddField("state", status.State.String()).
-		Infof("BaseOs status delete")
+		Tracef("BaseOs status delete")
 
 	base.DeleteLogObject(status.LogKey())
 }

--- a/pkg/pillar/types/zedagenttypes.go
+++ b/pkg/pillar/types/zedagenttypes.go
@@ -46,7 +46,7 @@ func (config BaseOsConfig) LogCreate(logBase *base.LogObject) {
 		return
 	}
 	logObject.CloneAndAddField("activate", config.Activate).
-		Tracef("BaseOs config create")
+		Noticef("BaseOs config create")
 }
 
 // LogModify :
@@ -62,11 +62,11 @@ func (config BaseOsConfig) LogModify(old interface{}) {
 
 		logObject.CloneAndAddField("activate", config.Activate).
 			AddField("old-activate", oldConfig.Activate).
-			Tracef("BaseOs config modify")
+			Noticef("BaseOs config modify")
 	} else {
 		// XXX remove?
 		logObject.CloneAndAddField("diff", cmp.Diff(oldConfig, config)).
-			Tracef("BaseOs config modify other change")
+			Noticef("BaseOs config modify other change")
 	}
 
 }
@@ -76,7 +76,7 @@ func (config BaseOsConfig) LogDelete() {
 	logObject := base.EnsureLogObject(nil, base.BaseOsConfigLogType, config.BaseOsVersion,
 		config.UUIDandVersion.UUID, config.LogKey())
 	logObject.CloneAndAddField("activate", config.Activate).
-		Tracef("BaseOs config delete")
+		Noticef("BaseOs config delete")
 
 	base.DeleteLogObject(config.LogKey())
 }
@@ -120,7 +120,7 @@ func (status BaseOsStatus) LogCreate(logBase *base.LogObject) {
 		return
 	}
 	logObject.CloneAndAddField("state", status.State.String()).
-		Tracef("BaseOs status create")
+		Noticef("BaseOs status create")
 }
 
 // LogModify :
@@ -136,11 +136,11 @@ func (status BaseOsStatus) LogModify(old interface{}) {
 
 		logObject.CloneAndAddField("state", status.State.String()).
 			AddField("old-state", oldStatus.State.String()).
-			Tracef("BaseOs status modify")
+			Noticef("BaseOs status modify")
 	} else {
 		// XXX remove?
 		logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
-			Tracef("BaseOs status modify other change")
+			Noticef("BaseOs status modify other change")
 	}
 
 	if status.HasError() {
@@ -157,7 +157,7 @@ func (status BaseOsStatus) LogDelete() {
 	logObject := base.EnsureLogObject(nil, base.BaseOsStatusLogType, status.BaseOsVersion,
 		status.UUIDandVersion.UUID, status.LogKey())
 	logObject.CloneAndAddField("state", status.State.String()).
-		Tracef("BaseOs status delete")
+		Noticef("BaseOs status delete")
 
 	base.DeleteLogObject(status.LogKey())
 }
@@ -267,7 +267,7 @@ func (config DatastoreConfig) LogCreate(logBase *base.LogObject) {
 	if logObject == nil {
 		return
 	}
-	logObject.Tracef("Datastore config create")
+	logObject.Noticef("Datastore config create")
 }
 
 // LogModify :
@@ -281,14 +281,14 @@ func (config DatastoreConfig) LogModify(old interface{}) {
 	}
 	// XXX remove?
 	logObject.CloneAndAddField("diff", cmp.Diff(oldConfig, config)).
-		Tracef("Datastore config modify")
+		Noticef("Datastore config modify")
 }
 
 // LogDelete :
 func (config DatastoreConfig) LogDelete() {
 	logObject := base.EnsureLogObject(nil, base.DatastoreConfigLogType, "",
 		config.UUID, config.LogKey())
-	logObject.Tracef("Datastore config delete")
+	logObject.Noticef("Datastore config delete")
 
 	base.DeleteLogObject(config.LogKey())
 }
@@ -324,7 +324,7 @@ func (status NodeAgentStatus) LogCreate(logBase *base.LogObject) {
 	if logObject == nil {
 		return
 	}
-	logObject.Tracef("Nodeagent status create")
+	logObject.Noticef("Nodeagent status create")
 }
 
 // LogModify :
@@ -338,14 +338,14 @@ func (status NodeAgentStatus) LogModify(old interface{}) {
 	}
 	// XXX remove?
 	logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
-		Tracef("Nodeagent status modify")
+		Noticef("Nodeagent status modify")
 }
 
 // LogDelete :
 func (status NodeAgentStatus) LogDelete() {
 	logObject := base.EnsureLogObject(nil, base.NodeAgentStatusLogType, status.Name,
 		nilUUID, status.LogKey())
-	logObject.Tracef("Nodeagent status delete")
+	logObject.Noticef("Nodeagent status delete")
 
 	base.DeleteLogObject(status.LogKey())
 }
@@ -386,7 +386,7 @@ func (status ZedAgentStatus) LogCreate(logBase *base.LogObject) {
 	if logObject == nil {
 		return
 	}
-	logObject.Tracef("Zedagent status create")
+	logObject.Noticef("Zedagent status create")
 }
 
 // LogModify :
@@ -400,14 +400,14 @@ func (status ZedAgentStatus) LogModify(old interface{}) {
 	}
 	// XXX remove?
 	logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
-		Tracef("Zedagent status modify")
+		Noticef("Zedagent status modify")
 }
 
 // LogDelete :
 func (status ZedAgentStatus) LogDelete() {
 	logObject := base.EnsureLogObject(nil, base.ZedAgentStatusLogType, status.Name,
 		nilUUID, status.LogKey())
-	logObject.Tracef("Zedagent status delete")
+	logObject.Noticef("Zedagent status delete")
 
 	base.DeleteLogObject(status.LogKey())
 }

--- a/pkg/pillar/types/zedbox.go
+++ b/pkg/pillar/types/zedbox.go
@@ -26,7 +26,7 @@ func (s ServiceInitStatus) LogCreate(logBase *base.LogObject) {
 	}
 	logObject.CloneAndAddField("servicename", s.ServiceName).
 		AddField("cmdargs", s.CmdArgs).
-		Tracef("ServiceInitStatus create")
+		Noticef("ServiceInitStatus create")
 }
 
 // LogModify :
@@ -39,7 +39,7 @@ func (s ServiceInitStatus) LogModify(old interface{}) {
 
 	logObject.CloneAndAddField("servicename", s.ServiceName).
 		AddField("cmdargs", s.CmdArgs).
-		Tracef("ServiceInitStatus modify")
+		Noticef("ServiceInitStatus modify")
 }
 
 // LogDelete :
@@ -47,7 +47,7 @@ func (s ServiceInitStatus) LogDelete() {
 	logObject := base.EnsureLogObject(nil, base.ServiceInitLogType, s.ServiceName, nilUUID, s.LogKey())
 	logObject.CloneAndAddField("servicename", s.ServiceName).
 		AddField("cmdargs", s.CmdArgs).
-		Tracef("ServiceInitStatus modify")
+		Noticef("ServiceInitStatus modify")
 
 	base.DeleteLogObject(s.LogKey())
 }

--- a/pkg/pillar/types/zedbox.go
+++ b/pkg/pillar/types/zedbox.go
@@ -26,7 +26,7 @@ func (s ServiceInitStatus) LogCreate(logBase *base.LogObject) {
 	}
 	logObject.CloneAndAddField("servicename", s.ServiceName).
 		AddField("cmdargs", s.CmdArgs).
-		Infof("ServiceInitStatus create")
+		Tracef("ServiceInitStatus create")
 }
 
 // LogModify :
@@ -39,7 +39,7 @@ func (s ServiceInitStatus) LogModify(old interface{}) {
 
 	logObject.CloneAndAddField("servicename", s.ServiceName).
 		AddField("cmdargs", s.CmdArgs).
-		Infof("ServiceInitStatus modify")
+		Tracef("ServiceInitStatus modify")
 }
 
 // LogDelete :
@@ -47,7 +47,7 @@ func (s ServiceInitStatus) LogDelete() {
 	logObject := base.EnsureLogObject(nil, base.ServiceInitLogType, s.ServiceName, nilUUID, s.LogKey())
 	logObject.CloneAndAddField("servicename", s.ServiceName).
 		AddField("cmdargs", s.CmdArgs).
-		Infof("ServiceInitStatus modify")
+		Tracef("ServiceInitStatus modify")
 
 	base.DeleteLogObject(s.LogKey())
 }

--- a/pkg/pillar/types/zedcloudmetrics.go
+++ b/pkg/pillar/types/zedcloudmetrics.go
@@ -8,6 +8,9 @@ import (
 )
 
 // MetricsMap maps from an ifname string to some metrics
+// Note that there are no LogCreate etc functions for this type
+// since it is published by logmanager and we don't want to cause logs
+// when logging
 type MetricsMap map[string]ZedcloudMetric
 
 // ZedcloudMetric are metrics for one interface

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -92,7 +92,7 @@ func (config AppInstanceConfig) LogCreate(logBase *base.LogObject) {
 	}
 	logObject.CloneAndAddField("activate", config.Activate).
 		AddField("remote-console", config.RemoteConsole).
-		Tracef("App instance config create")
+		Noticef("App instance config create")
 }
 
 // LogModify :
@@ -111,11 +111,11 @@ func (config AppInstanceConfig) LogModify(old interface{}) {
 			AddField("remote-console", config.RemoteConsole).
 			AddField("old-activate", oldConfig.Activate).
 			AddField("old-remote-console", oldConfig.RemoteConsole).
-			Tracef("App instance config modify")
+			Noticef("App instance config modify")
 	} else {
 		// XXX remove?
 		logObject.CloneAndAddField("diff", cmp.Diff(oldConfig, config)).
-			Tracef("App instance config modify other change")
+			Noticef("App instance config modify other change")
 	}
 }
 
@@ -125,7 +125,7 @@ func (config AppInstanceConfig) LogDelete() {
 		config.UUIDandVersion.UUID, config.LogKey())
 	logObject.CloneAndAddField("activate", config.Activate).
 		AddField("remote-console", config.RemoteConsole).
-		Tracef("App instance config delete")
+		Noticef("App instance config delete")
 
 	base.DeleteLogObject(config.LogKey())
 }
@@ -181,7 +181,7 @@ func (status AppInstanceStatus) LogCreate(logBase *base.LogObject) {
 	logObject.CloneAndAddField("state", status.State.String()).
 		AddField("restart-in-progress", status.RestartInprogress).
 		AddField("purge-in-progress", status.PurgeInprogress).
-		Tracef("App instance status create")
+		Noticef("App instance status create")
 }
 
 // LogModify :
@@ -203,11 +203,11 @@ func (status AppInstanceStatus) LogModify(old interface{}) {
 			AddField("old-state", oldStatus.State.String()).
 			AddField("old-restart-in-progress", oldStatus.RestartInprogress).
 			AddField("old-purge-in-progress", oldStatus.PurgeInprogress).
-			Tracef("App instance status modify")
+			Noticef("App instance status modify")
 	} else {
 		// XXX remove?
 		logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
-			Tracef("App instance status modify other change")
+			Noticef("App instance status modify other change")
 	}
 
 	if status.HasError() {
@@ -228,7 +228,7 @@ func (status AppInstanceStatus) LogDelete() {
 	logObject.CloneAndAddField("state", status.State.String()).
 		AddField("restart-in-progress", status.RestartInprogress).
 		AddField("purge-in-progress", status.PurgeInprogress).
-		Tracef("App instance status delete")
+		Noticef("App instance status delete")
 
 	base.DeleteLogObject(status.LogKey())
 }
@@ -316,7 +316,7 @@ func (aih AppAndImageToHash) LogCreate(logBase *base.LogObject) {
 	logObject.CloneAndAddField("purge-counter-int64", aih.PurgeCounter).
 		AddField("image-id", aih.ImageID.String()).
 		AddField("hash", aih.Hash).
-		Tracef("App and image to hash create")
+		Noticef("App and image to hash create")
 }
 
 // LogModify :
@@ -337,11 +337,11 @@ func (aih AppAndImageToHash) LogModify(old interface{}) {
 			AddField("purge-counter-int64", aih.PurgeCounter).
 			AddField("old-hash", oldAih.Hash).
 			AddField("old-purge-counter-int64", oldAih.PurgeCounter).
-			Tracef("App and image to hash modify")
+			Noticef("App and image to hash modify")
 	} else {
 		// XXX remove?
 		logObject.CloneAndAddField("diff", cmp.Diff(oldAih, aih)).
-			Tracef("App and image to hash modify other change")
+			Noticef("App and image to hash modify other change")
 	}
 }
 
@@ -352,7 +352,7 @@ func (aih AppAndImageToHash) LogDelete() {
 	logObject.CloneAndAddField("purge-counter-int64", aih.PurgeCounter).
 		AddField("image-id", aih.ImageID.String()).
 		AddField("hash", aih.Hash).
-		Tracef("App and image to hash delete")
+		Noticef("App and image to hash delete")
 
 	base.DeleteLogObject(aih.LogKey())
 }

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	uuid "github.com/satori/go.uuid"
 )
@@ -91,7 +92,7 @@ func (config AppInstanceConfig) LogCreate(logBase *base.LogObject) {
 	}
 	logObject.CloneAndAddField("activate", config.Activate).
 		AddField("remote-console", config.RemoteConsole).
-		Infof("App instance config create")
+		Tracef("App instance config create")
 }
 
 // LogModify :
@@ -110,9 +111,12 @@ func (config AppInstanceConfig) LogModify(old interface{}) {
 			AddField("remote-console", config.RemoteConsole).
 			AddField("old-activate", oldConfig.Activate).
 			AddField("old-remote-console", oldConfig.RemoteConsole).
-			Infof("App instance config modify")
+			Tracef("App instance config modify")
+	} else {
+		// XXX remove?
+		logObject.CloneAndAddField("diff", cmp.Diff(oldConfig, config)).
+			Tracef("App instance config modify other change")
 	}
-
 }
 
 // LogDelete :
@@ -121,7 +125,7 @@ func (config AppInstanceConfig) LogDelete() {
 		config.UUIDandVersion.UUID, config.LogKey())
 	logObject.CloneAndAddField("activate", config.Activate).
 		AddField("remote-console", config.RemoteConsole).
-		Infof("App instance config delete")
+		Tracef("App instance config delete")
 
 	base.DeleteLogObject(config.LogKey())
 }
@@ -177,7 +181,7 @@ func (status AppInstanceStatus) LogCreate(logBase *base.LogObject) {
 	logObject.CloneAndAddField("state", status.State.String()).
 		AddField("restart-in-progress", status.RestartInprogress).
 		AddField("purge-in-progress", status.PurgeInprogress).
-		Infof("App instance status create")
+		Tracef("App instance status create")
 }
 
 // LogModify :
@@ -199,7 +203,11 @@ func (status AppInstanceStatus) LogModify(old interface{}) {
 			AddField("old-state", oldStatus.State.String()).
 			AddField("old-restart-in-progress", oldStatus.RestartInprogress).
 			AddField("old-purge-in-progress", oldStatus.PurgeInprogress).
-			Infof("App instance status modify")
+			Tracef("App instance status modify")
+	} else {
+		// XXX remove?
+		logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
+			Tracef("App instance status modify other change")
 	}
 
 	if status.HasError() {
@@ -220,7 +228,7 @@ func (status AppInstanceStatus) LogDelete() {
 	logObject.CloneAndAddField("state", status.State.String()).
 		AddField("restart-in-progress", status.RestartInprogress).
 		AddField("purge-in-progress", status.PurgeInprogress).
-		Infof("App instance status delete")
+		Tracef("App instance status delete")
 
 	base.DeleteLogObject(status.LogKey())
 }

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -40,7 +40,7 @@ func (config AppNetworkConfig) LogCreate(logBase *base.LogObject) {
 		return
 	}
 	logObject.CloneAndAddField("activate", config.Activate).
-		Tracef("App network config create")
+		Noticef("App network config create")
 }
 
 // LogModify :
@@ -56,11 +56,11 @@ func (config AppNetworkConfig) LogModify(old interface{}) {
 
 		logObject.CloneAndAddField("activate", config.Activate).
 			AddField("old-activate", oldConfig.Activate).
-			Tracef("App network config modify")
+			Noticef("App network config modify")
 	} else {
 		// XXX remove?
 		logObject.CloneAndAddField("diff", cmp.Diff(oldConfig, config)).
-			Tracef("App network config modify other change")
+			Noticef("App network config modify other change")
 	}
 }
 
@@ -69,7 +69,7 @@ func (config AppNetworkConfig) LogDelete() {
 	logObject := base.EnsureLogObject(nil, base.AppNetworkConfigLogType, config.DisplayName,
 		config.UUIDandVersion.UUID, config.LogKey())
 	logObject.CloneAndAddField("activate", config.Activate).
-		Tracef("App network config delete")
+		Noticef("App network config delete")
 
 	base.DeleteLogObject(config.LogKey())
 }
@@ -133,7 +133,7 @@ func (status AppNetworkStatus) LogCreate(logBase *base.LogObject) {
 		return
 	}
 	logObject.CloneAndAddField("activated", status.Activated).
-		Tracef("App network status create")
+		Noticef("App network status create")
 }
 
 // LogModify :
@@ -149,11 +149,11 @@ func (status AppNetworkStatus) LogModify(old interface{}) {
 
 		logObject.CloneAndAddField("activated", status.Activated).
 			AddField("old-activated", oldStatus.Activated).
-			Tracef("App network status modify")
+			Noticef("App network status modify")
 	} else {
 		// XXX remove?
 		logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
-			Tracef("App network status modify other change")
+			Noticef("App network status modify other change")
 	}
 
 	if status.HasError() {
@@ -170,7 +170,7 @@ func (status AppNetworkStatus) LogDelete() {
 	logObject := base.EnsureLogObject(nil, base.AppNetworkStatusLogType, status.DisplayName,
 		status.UUIDandVersion.UUID, status.LogKey())
 	logObject.CloneAndAddField("activated", status.Activated).
-		Tracef("App network status delete")
+		Noticef("App network status delete")
 
 	base.DeleteLogObject(status.LogKey())
 }
@@ -327,7 +327,7 @@ func (config DevicePortConfigList) LogCreate(logBase *base.LogObject) {
 	}
 	logObject.CloneAndAddField("current-index-int64", config.CurrentIndex).
 		AddField("num-portconfig-int64", len(config.PortConfigList)).
-		Tracef("DevicePortConfigList create")
+		Noticef("DevicePortConfigList create")
 }
 
 // LogModify :
@@ -347,11 +347,11 @@ func (config DevicePortConfigList) LogModify(old interface{}) {
 			AddField("num-portconfig-int64", len(config.PortConfigList)).
 			AddField("old-current-index-int64", oldConfig.CurrentIndex).
 			AddField("old-num-portconfig-int64", len(oldConfig.PortConfigList)).
-			Tracef("DevicePortConfigList modify")
+			Noticef("DevicePortConfigList modify")
 	} else {
 		// XXX remove?
 		logObject.CloneAndAddField("diff", cmp.Diff(oldConfig, config)).
-			Tracef("DevicePortConfigList modify other change")
+			Noticef("DevicePortConfigList modify other change")
 	}
 
 }
@@ -362,7 +362,7 @@ func (config DevicePortConfigList) LogDelete() {
 		nilUUID, config.LogKey())
 	logObject.CloneAndAddField("current-index-int64", config.CurrentIndex).
 		AddField("num-portconfig-int64", len(config.PortConfigList)).
-		Tracef("DevicePortConfigList delete")
+		Noticef("DevicePortConfigList delete")
 
 	base.DeleteLogObject(config.LogKey())
 }
@@ -443,14 +443,14 @@ func (config DevicePortConfig) LogCreate(logBase *base.LogObject) {
 		AddField("last-succeeded", config.LastSucceeded).
 		AddField("last-error", config.LastError).
 		AddField("state", config.State.String()).
-		Tracef("DevicePortConfig create")
+		Noticef("DevicePortConfig create")
 	for _, p := range config.Ports {
 		// XXX different logobject for a particular port?
 		logObject.CloneAndAddField("ifname", p.IfName).
 			AddField("last-error", p.LastError).
 			AddField("last-succeeded", p.LastSucceeded).
 			AddField("last-failed", p.LastFailed).
-			Tracef("DevicePortConfig port create")
+			Noticef("DevicePortConfig port create")
 	}
 }
 
@@ -479,11 +479,11 @@ func (config DevicePortConfig) LogModify(old interface{}) {
 			AddField("old-last-succeeded", oldConfig.LastSucceeded).
 			AddField("old-last-error", oldConfig.LastError).
 			AddField("old-state", oldConfig.State.String()).
-			Tracef("DevicePortConfig modify")
+			Noticef("DevicePortConfig modify")
 	} else {
 		// XXX remove?
 		logObject.CloneAndAddField("diff", cmp.Diff(oldConfig, config)).
-			Tracef("DevicePortConfig modify other change")
+			Noticef("DevicePortConfig modify other change")
 	}
 	// XXX which fields to compare/log?
 	for i, p := range config.Ports {
@@ -503,7 +503,7 @@ func (config DevicePortConfig) LogModify(old interface{}) {
 				AddField("old-last-error", op.LastError).
 				AddField("old-last-succeeded", op.LastSucceeded).
 				AddField("old-last-failed", op.LastFailed).
-				Tracef("DevicePortConfig port modify")
+				Noticef("DevicePortConfig port modify")
 		}
 	}
 }
@@ -517,14 +517,14 @@ func (config DevicePortConfig) LogDelete() {
 		AddField("last-succeeded", config.LastSucceeded).
 		AddField("last-error", config.LastError).
 		AddField("state", config.State.String()).
-		Tracef("DevicePortConfig delete")
+		Noticef("DevicePortConfig delete")
 	for _, p := range config.Ports {
 		// XXX different logobject for a particular port?
 		logObject.CloneAndAddField("ifname", p.IfName).
 			AddField("last-error", p.LastError).
 			AddField("last-succeeded", p.LastSucceeded).
 			AddField("last-failed", p.LastFailed).
-			Tracef("DevicePortConfig port delete")
+			Noticef("DevicePortConfig port delete")
 	}
 
 	base.DeleteLogObject(config.LogKey())
@@ -935,14 +935,14 @@ func (status DeviceNetworkStatus) LogCreate(logBase *base.LogObject) {
 	logObject.CloneAndAddField("testing-bool", status.Testing).
 		AddField("ports-int64", len(status.Ports)).
 		AddField("state", status.State.String()).
-		Tracef("DeviceNetworkStatus create")
+		Noticef("DeviceNetworkStatus create")
 	for _, p := range status.Ports {
 		// XXX different logobject for a particular port?
 		logObject.CloneAndAddField("ifname", p.IfName).
 			AddField("last-error", p.LastError).
 			AddField("last-succeeded", p.LastSucceeded).
 			AddField("last-failed", p.LastFailed).
-			Tracef("DeviceNetworkStatus port create")
+			Noticef("DeviceNetworkStatus port create")
 	}
 }
 
@@ -965,11 +965,11 @@ func (status DeviceNetworkStatus) LogModify(old interface{}) {
 			AddField("old-testing-bool", oldStatus.Testing).
 			AddField("old-ports-int64", len(oldStatus.Ports)).
 			AddField("old-state", oldStatus.State.String()).
-			Tracef("DeviceNetworkStatus modify")
+			Noticef("DeviceNetworkStatus modify")
 	} else {
 		// XXX remove?
 		logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
-			Tracef("DeviceNetworkStatus modify other change")
+			Noticef("DeviceNetworkStatus modify other change")
 	}
 	// XXX which fields to compare/log?
 	for i, p := range status.Ports {
@@ -989,7 +989,7 @@ func (status DeviceNetworkStatus) LogModify(old interface{}) {
 				AddField("old-last-error", op.LastError).
 				AddField("old-last-succeeded", op.LastSucceeded).
 				AddField("old-last-failed", op.LastFailed).
-				Tracef("DeviceNetworkStatus port modify")
+				Noticef("DeviceNetworkStatus port modify")
 		}
 	}
 }
@@ -1001,14 +1001,14 @@ func (status DeviceNetworkStatus) LogDelete() {
 	logObject.CloneAndAddField("testing-bool", status.Testing).
 		AddField("ports-int64", len(status.Ports)).
 		AddField("state", status.State.String()).
-		Tracef("DeviceNetworkStatus instance status delete")
+		Noticef("DeviceNetworkStatus instance status delete")
 	for _, p := range status.Ports {
 		// XXX different logobject for a particular port?
 		logObject.CloneAndAddField("ifname", p.IfName).
 			AddField("last-error", p.LastError).
 			AddField("last-succeeded", p.LastSucceeded).
 			AddField("last-failed", p.LastFailed).
-			Tracef("DeviceNetworkStatus port delete")
+			Noticef("DeviceNetworkStatus port delete")
 	}
 
 	base.DeleteLogObject(status.LogKey())
@@ -1745,7 +1745,7 @@ func (config NetworkXObjectConfig) LogCreate(logBase *base.LogObject) {
 	if logObject == nil {
 		return
 	}
-	logObject.Tracef("NetworkXObject config create")
+	logObject.Noticef("NetworkXObject config create")
 }
 
 // LogModify :
@@ -1759,14 +1759,14 @@ func (config NetworkXObjectConfig) LogModify(old interface{}) {
 	}
 	// XXX remove?
 	logObject.CloneAndAddField("diff", cmp.Diff(oldConfig, config)).
-		Tracef("NetworkXObject config modify")
+		Noticef("NetworkXObject config modify")
 }
 
 // LogDelete :
 func (config NetworkXObjectConfig) LogDelete() {
 	logObject := base.EnsureLogObject(nil, base.NetworkXObjectConfigLogType, "",
 		config.UUID, config.LogKey())
-	logObject.Tracef("NetworkXObject config delete")
+	logObject.Noticef("NetworkXObject config delete")
 
 	base.DeleteLogObject(config.LogKey())
 }

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/eriknordmark/ipinfo"
 	"github.com/eriknordmark/netlink"
+	"github.com/google/go-cmp/cmp"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
@@ -186,7 +187,7 @@ func (config DevicePortConfigList) LogCreate(logBase *base.LogObject) {
 	}
 	logObject.CloneAndAddField("current-index-int64", config.CurrentIndex).
 		AddField("num-portconfig-int64", len(config.PortConfigList)).
-		Infof("DevicePortConfigList create")
+		Tracef("DevicePortConfigList create")
 }
 
 // LogModify :
@@ -206,7 +207,11 @@ func (config DevicePortConfigList) LogModify(old interface{}) {
 			AddField("num-portconfig-int64", len(config.PortConfigList)).
 			AddField("old-current-index-int64", oldConfig.CurrentIndex).
 			AddField("old-num-portconfig-int64", len(oldConfig.PortConfigList)).
-			Infof("DevicePortConfigList modify")
+			Tracef("DevicePortConfigList modify")
+	} else {
+		// XXX remove?
+		logObject.CloneAndAddField("diff", cmp.Diff(oldConfig, config)).
+			Tracef("DevicePortConfigList modify other change")
 	}
 
 }
@@ -217,7 +222,7 @@ func (config DevicePortConfigList) LogDelete() {
 		nilUUID, config.LogKey())
 	logObject.CloneAndAddField("current-index-int64", config.CurrentIndex).
 		AddField("num-portconfig-int64", len(config.PortConfigList)).
-		Infof("DevicePortConfigList delete")
+		Tracef("DevicePortConfigList delete")
 
 	base.DeleteLogObject(config.LogKey())
 }
@@ -298,14 +303,14 @@ func (config DevicePortConfig) LogCreate(logBase *base.LogObject) {
 		AddField("last-succeeded", config.LastSucceeded).
 		AddField("last-error", config.LastError).
 		AddField("state", config.State.String()).
-		Infof("DevicePortConfig create")
+		Tracef("DevicePortConfig create")
 	for _, p := range config.Ports {
 		// XXX different logobject for a particular port?
 		logObject.CloneAndAddField("ifname", p.IfName).
 			AddField("last-error", p.LastError).
 			AddField("last-succeeded", p.LastSucceeded).
 			AddField("last-failed", p.LastFailed).
-			Infof("DevicePortConfig port create")
+			Tracef("DevicePortConfig port create")
 	}
 }
 
@@ -334,7 +339,11 @@ func (config DevicePortConfig) LogModify(old interface{}) {
 			AddField("old-last-succeeded", oldConfig.LastSucceeded).
 			AddField("old-last-error", oldConfig.LastError).
 			AddField("old-state", oldConfig.State.String()).
-			Infof("DevicePortConfig modify")
+			Tracef("DevicePortConfig modify")
+	} else {
+		// XXX remove?
+		logObject.CloneAndAddField("diff", cmp.Diff(oldConfig, config)).
+			Tracef("DevicePortConfig modify other change")
 	}
 	// XXX which fields to compare/log?
 	for i, p := range config.Ports {
@@ -354,7 +363,7 @@ func (config DevicePortConfig) LogModify(old interface{}) {
 				AddField("old-last-error", op.LastError).
 				AddField("old-last-succeeded", op.LastSucceeded).
 				AddField("old-last-failed", op.LastFailed).
-				Infof("DevicePortConfig port modify")
+				Tracef("DevicePortConfig port modify")
 		}
 	}
 }
@@ -368,14 +377,14 @@ func (config DevicePortConfig) LogDelete() {
 		AddField("last-succeeded", config.LastSucceeded).
 		AddField("last-error", config.LastError).
 		AddField("state", config.State.String()).
-		Infof("DevicePortConfig delete")
+		Tracef("DevicePortConfig delete")
 	for _, p := range config.Ports {
 		// XXX different logobject for a particular port?
 		logObject.CloneAndAddField("ifname", p.IfName).
 			AddField("last-error", p.LastError).
 			AddField("last-succeeded", p.LastSucceeded).
 			AddField("last-failed", p.LastFailed).
-			Infof("DevicePortConfig port delete")
+			Tracef("DevicePortConfig port delete")
 	}
 
 	base.DeleteLogObject(config.LogKey())
@@ -786,14 +795,14 @@ func (status DeviceNetworkStatus) LogCreate(logBase *base.LogObject) {
 	logObject.CloneAndAddField("testing-bool", status.Testing).
 		AddField("ports-int64", len(status.Ports)).
 		AddField("state", status.State.String()).
-		Infof("DeviceNetworkStatus create")
+		Tracef("DeviceNetworkStatus create")
 	for _, p := range status.Ports {
 		// XXX different logobject for a particular port?
 		logObject.CloneAndAddField("ifname", p.IfName).
 			AddField("last-error", p.LastError).
 			AddField("last-succeeded", p.LastSucceeded).
 			AddField("last-failed", p.LastFailed).
-			Infof("DeviceNetworkStatus port create")
+			Tracef("DeviceNetworkStatus port create")
 	}
 }
 
@@ -816,7 +825,11 @@ func (status DeviceNetworkStatus) LogModify(old interface{}) {
 			AddField("old-testing-bool", oldStatus.Testing).
 			AddField("old-ports-int64", len(oldStatus.Ports)).
 			AddField("old-state", oldStatus.State.String()).
-			Infof("DeviceNetworkStatus modify")
+			Tracef("DeviceNetworkStatus modify")
+	} else {
+		// XXX remove?
+		logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
+			Tracef("DeviceNetworkStatus modify other change")
 	}
 	// XXX which fields to compare/log?
 	for i, p := range status.Ports {
@@ -836,7 +849,7 @@ func (status DeviceNetworkStatus) LogModify(old interface{}) {
 				AddField("old-last-error", op.LastError).
 				AddField("old-last-succeeded", op.LastSucceeded).
 				AddField("old-last-failed", op.LastFailed).
-				Infof("DeviceNetworkStatus port modify")
+				Tracef("DeviceNetworkStatus port modify")
 		}
 	}
 }
@@ -848,14 +861,14 @@ func (status DeviceNetworkStatus) LogDelete() {
 	logObject.CloneAndAddField("testing-bool", status.Testing).
 		AddField("ports-int64", len(status.Ports)).
 		AddField("state", status.State.String()).
-		Infof("DeviceNetworkStatus instance status delete")
+		Tracef("DeviceNetworkStatus instance status delete")
 	for _, p := range status.Ports {
 		// XXX different logobject for a particular port?
 		logObject.CloneAndAddField("ifname", p.IfName).
 			AddField("last-error", p.LastError).
 			AddField("last-succeeded", p.LastSucceeded).
 			AddField("last-failed", p.LastFailed).
-			Infof("DeviceNetworkStatus port delete")
+			Tracef("DeviceNetworkStatus port delete")
 	}
 
 	base.DeleteLogObject(status.LogKey())


### PR DESCRIPTION
For users/debuggers, this changes the amount of EVE logging we send by default at the info log level to be the obj_type logs. The PR adds obj_type hooks for all the pubsub datatypes which didn't already have them, plus adds code to log the diffs in the LogModify calls. You can get back the current amout of logging by setting the log level to "debug". And if you want what we currently send with debug you set the level to "trace"

Later we might add a way to further reduce the EVE logging when the uplink is not free aka LTE cases. But one can manually do this by setting the level to "warning" as well.

We do this by introducing a larger set of internal log levels which we map to the limited logrus levels:
   Fatal, Error, and Warning are unchanged; hard-coded to the logrus ones
   Notice is mapped to logrus.InfoLevel. This is used for the obj_type logs for *Config and *Status types
   Metric is mapped to logrus.DebugLevel. This is used for the obj_type logs for *Metric types (those are collected and published at a constant background rate, hence even on an inactive device they add up)
   Info is mapped to logrus.DebugLevel. These are the log.Info* we have sprinked throughout the code.
   Debug is mapped to logrus.TraceLevel. These are the log.Debug* we have sprinked throughout the code.

To make this more clear it might make sense to rename the latter two, but that is about 5000 lines of change which will cause huge conflicts for anybody working on the pillar code.

Reviewing each commit by itself makes sense.