### PR TITLE
fix empty content in logs

### DIFF
--- a/pkg/pillar/cmd/logmanager/logmanager.go
+++ b/pkg/pillar/cmd/logmanager/logmanager.go
@@ -749,6 +749,7 @@ func handleAppLogEvent(event logEntry, appLogs *logs.AppInstanceLogBundle) bool 
 	}
 
 	logDetails := &logs.LogEntry{}
+	logDetails.Content = event.content
 	logDetails.Severity = event.severity
 	logDetails.Timestamp, _ = ptypes.TimestampProto(event.timestamp)
 	logDetails.Source = event.source
@@ -782,6 +783,7 @@ func handleLogEvent(event logEntry, reportLogs *logs.LogBundle) bool {
 	}
 
 	logDetails := &logs.LogEntry{}
+	logDetails.Content = event.content
 	logDetails.Severity = event.severity
 	logDetails.Timestamp, _ = ptypes.TimestampProto(event.timestamp)
 	logDetails.Source = event.source


### PR DESCRIPTION
We cannot see content of logs after https://github.com/lf-edge/eve/commit/e96d88903d6e77a32079373b333eb36ee8b9bfb6

https://github.com/lf-edge/eden/issues/242

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>