### PR TITLE
xen: Always map EfiRuntimeServicesCode and EfiRuntimeServicesData

### DIFF
--- a/pkg/xen/arch/x86_64/0003-Always-map-EfiRuntimeServicesCode-and-EfiRuntimeServ.patch
+++ b/pkg/xen/arch/x86_64/0003-Always-map-EfiRuntimeServicesCode-and-EfiRuntimeServ.patch
@@ -1,0 +1,26 @@
+From 84f05783e6932ab6d91464a5f0555480f324f266 Mon Sep 17 00:00:00 2001
+From: Sergey Temerkhanov <s.temerkhanov@gmail.com>
+Date: Sun, 23 Aug 2020 17:38:47 +0300
+Subject: [PATCH] Always map EfiRuntimeServicesCode and EfiRuntimeServicesData
+
+Signed-off-by: Sergey Temerkhanov <s.temerkhanov@gmail.com>
+---
+ common/efi/boot.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/common/efi/boot.c b/common/efi/boot.c
+index 9b7d0502d4..b6ae14b89f 100644
+--- a/common/efi/boot.c
++++ b/common/efi/boot.c
+@@ -1536,6 +1536,8 @@ void __init efi_init_memory(void)
+ 
+         if ( !efi_enabled(EFI_RS) ||
+              (!(desc->Attribute & EFI_MEMORY_RUNTIME) &&
++               (desc->Type != EfiRuntimeServicesCode &&
++                desc->Type != EfiRuntimeServicesData)) &&
+               (!map_bs ||
+                (desc->Type != EfiBootServicesCode &&
+                 desc->Type != EfiBootServicesData))) )
+-- 
+2.26.2
+


### PR DESCRIPTION
Always map the regions of the subj types despite of the
descriptor attribute field

Signed-off-by: Sergey Temerkhanov <s.temerkhanov@gmail.com>