### PR TITLE
Moving all KVM builds to NEW_KERNEL (5.4.51)

### DIFF
--- a/images/rootfs-kvm.yml.in.patch
+++ b/images/rootfs-kvm.yml.in.patch
@@ -1,0 +1,9 @@
+--- images/rootfs.yml.in	2020-04-08 18:14:23.000000000 -0700
++++ images/rootfs-kvm.yml.in	2020-04-08 18:19:53.000000000 -0700
+@@ -1,5 +1,5 @@
+ kernel:
+-  image: KERNEL_TAG
++  image: NEW_KERNEL_TAG
+   cmdline: "rootdelay=3"
+ init:
+   - linuxkit/init:v0.5


### PR DESCRIPTION
We are now getting pretty close to swapping our current kernel with 5.4.51. This is one extra step in that direction. KVM builds (regardless of the architecture) are now going to use 5.4.51 by default and that should help us start testing ASAP. Xen builds are still 4.19 based -- so the default-default doesn't change (yet).

Note, that this is likely to break our HiKey support on ARM -- but at this point I have no bandwidth to even test it (let alone fix it).