### PR TITLE
Make per-microservice/agent log levels work again

### DIFF
--- a/pkg/pillar/agentlog/loglevel.go
+++ b/pkg/pillar/agentlog/loglevel.go
@@ -109,24 +109,32 @@ func LogLevel(gc *types.ConfigItemValueMap, agentName string) string {
 	return ""
 }
 
-// Update LogLevel setting based on GlobalConfig and debugOverride
-// Return debug bool
+// HandleGlobalConfig updates the LogLevel setting in the passed in logger
+// based on GlobalConfig and debugOverride
+// Returns the debug bool
 func HandleGlobalConfig(log *base.LogObject, sub pubsub.Subscription, agentName string,
-	debugOverride bool) (bool, *types.ConfigItemValueMap) {
+	debugOverride bool, logger *logrus.Logger) (bool, *types.ConfigItemValueMap) {
 
 	log.Infof("HandleGlobalConfig(%s, %v)\n", agentName, debugOverride)
-	return handleGlobalConfigImpl(log, sub, agentName, debugOverride, true)
+	return handleGlobalConfigImpl(log, sub, agentName, debugOverride, true,
+		logger)
 }
 
+// HandleGlobalConfigNoDefault updates the LogLevel setting in the passed in logger
+// based on GlobalConfig and debugOverride
+// Returns the debug bool
+// Unlike HandleGlobalConfig it does not look at debug.default.loglevel
+// XXX Only used by logmanager since enable debug for it slows it down too much
 func HandleGlobalConfigNoDefault(log *base.LogObject, sub pubsub.Subscription, agentName string,
-	debugOverride bool) (bool, *types.ConfigItemValueMap) {
+	debugOverride bool, logger *logrus.Logger) (bool, *types.ConfigItemValueMap) {
 
 	log.Infof("HandleGlobalConfig(%s, %v)\n", agentName, debugOverride)
-	return handleGlobalConfigImpl(log, sub, agentName, debugOverride, false)
+	return handleGlobalConfigImpl(log, sub, agentName, debugOverride, false,
+		logger)
 }
 
 func handleGlobalConfigImpl(log *base.LogObject, sub pubsub.Subscription, agentName string,
-	debugOverride bool, allowDefault bool) (bool, *types.ConfigItemValueMap) {
+	debugOverride bool, allowDefault bool, logger *logrus.Logger) (bool, *types.ConfigItemValueMap) {
 	level := logrus.InfoLevel
 	debug := false
 	gcp := GetGlobalConfig(log, sub)
@@ -151,6 +159,6 @@ func handleGlobalConfigImpl(log *base.LogObject, sub pubsub.Subscription, agentN
 		log.Errorf("***handleGlobalConfigImpl: Failed to get loglevel")
 	}
 	log.Infof("handleGlobalConfigImpl: Setting loglevel to %s", level)
-	logrus.SetLevel(level)
+	logger.SetLevel(level)
 	return debug, gcp
 }

--- a/pkg/pillar/attest/attest_test.go
+++ b/pkg/pillar/attest/attest_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/sirupsen/logrus"
 )
 
 type VerifierMock struct{}
@@ -88,8 +89,9 @@ func initTest() *Context {
 	simulateITokenMismatch = false
 	simulateTpmAgentDown = false
 
-	log := base.NewSourceLogObject("test", 1234)
-	ps := pubsub.New(&pubsub.EmptyDriver{}, log)
+	logger := logrus.StandardLogger()
+	log := base.NewSourceLogObject(logger, "test", 1234)
+	ps := pubsub.New(&pubsub.EmptyDriver{}, logger, log)
 	ctx := &Context{
 		PubSub:       ps,
 		log:          log,

--- a/pkg/pillar/base/base_test.go
+++ b/pkg/pillar/base/base_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/satori/go.uuid"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -57,10 +57,10 @@ var (
 )
 
 func initLog() {
-	formatter := log.JSONFormatter{DisableTimestamp: true}
-	log.SetFormatter(&formatter)
+	formatter := logrus.JSONFormatter{DisableTimestamp: true}
+	logrus.SetFormatter(&formatter)
 	logBuffer = bytes.NewBuffer(make([]byte, 1000))
-	log.SetOutput(logBuffer)
+	logrus.SetOutput(logBuffer)
 }
 
 func TestSpecialAgent(t *testing.T) {

--- a/pkg/pillar/base/base_test.go
+++ b/pkg/pillar/base/base_test.go
@@ -54,6 +54,7 @@ var (
 		IsBrosnan:   true,
 	}
 	logBuffer *bytes.Buffer
+	log       *LogObject
 )
 
 func initLog() {
@@ -61,6 +62,8 @@ func initLog() {
 	logrus.SetFormatter(&formatter)
 	logBuffer = bytes.NewBuffer(make([]byte, 1000))
 	logrus.SetOutput(logBuffer)
+	logger := logrus.StandardLogger()
+	log = NewSourceLogObject(logger, "test", 1234)
 }
 
 func TestSpecialAgent(t *testing.T) {
@@ -83,22 +86,23 @@ func TestSpecialAgent(t *testing.T) {
 			action: "kill",
 		},
 	}
+
 	for testname, test := range testMatrix {
 		t.Logf("Running test case %s", testname)
 		logBuffer.Reset()
 		switch test.action {
 		case "create":
-			test.agent.LogCreate(nil)
-			expected := "{\"agent_age\":30,\"agent_is_brosnan\":true,\"agent_name\":\"James Bond\",\"agent_number\":7,\"level\":\"info\",\"log_event_type\":\"log\",\"msg\":\"I am Bond, James Bond\",\"obj_key\":\"james-bond-007\",\"obj_name\":\"Pierce Brosnan\",\"obj_type\":\"secret_agent\"}"
+			test.agent.LogCreate(log)
+			expected := "{\"agent_age\":30,\"agent_is_brosnan\":true,\"agent_name\":\"James Bond\",\"agent_number\":7,\"level\":\"info\",\"log_event_type\":\"log\",\"msg\":\"I am Bond, James Bond\",\"obj_key\":\"james-bond-007\",\"obj_name\":\"Pierce Brosnan\",\"obj_type\":\"secret_agent\",\"pid\":1234,\"source\":\"test\"}"
 			assert.Equal(t, expected, strings.TrimSpace(logBuffer.String()))
 		case "modify":
 			test.agent.AgentAge = 100
 			test.agent.LogModify("old agent")
-			expected := "{\"agent_age\":100,\"agent_is_brosnan\":true,\"agent_name\":\"James Bond\",\"agent_number\":7,\"level\":\"info\",\"log_event_type\":\"log\",\"msg\":\"James Bond gets old!\",\"obj_key\":\"james-bond-007\",\"obj_name\":\"Pierce Brosnan\",\"obj_type\":\"secret_agent\"}"
+			expected := "{\"agent_age\":100,\"agent_is_brosnan\":true,\"agent_name\":\"James Bond\",\"agent_number\":7,\"level\":\"info\",\"log_event_type\":\"log\",\"msg\":\"James Bond gets old!\",\"obj_key\":\"james-bond-007\",\"obj_name\":\"Pierce Brosnan\",\"obj_type\":\"secret_agent\",\"pid\":1234,\"source\":\"test\"}"
 			assert.Equal(t, expected, strings.TrimSpace(logBuffer.String()))
 		case "kill":
 			test.agent.LogDelete()
-			expected := "{\"agent_age\":30,\"agent_is_brosnan\":true,\"agent_name\":\"James Bond\",\"agent_number\":7,\"level\":\"info\",\"log_event_type\":\"log\",\"msg\":\"James Bond dies!\",\"obj_key\":\"james-bond-007\",\"obj_name\":\"Pierce Brosnan\",\"obj_type\":\"secret_agent\"}"
+			expected := "{\"agent_age\":30,\"agent_is_brosnan\":true,\"agent_name\":\"James Bond\",\"agent_number\":7,\"level\":\"info\",\"log_event_type\":\"log\",\"msg\":\"James Bond dies!\",\"obj_key\":\"james-bond-007\",\"obj_name\":\"Pierce Brosnan\",\"obj_type\":\"secret_agent\",\"pid\":1234,\"source\":\"test\"}"
 			assert.Equal(t, expected, strings.TrimSpace(logBuffer.String()))
 		default:
 		}

--- a/pkg/pillar/base/log.go
+++ b/pkg/pillar/base/log.go
@@ -4,212 +4,212 @@
 package base
 
 import (
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // Debug :
 func (object *LogObject) Debug(args ...interface{}) {
 	if !object.Initialized {
-		log.Fatal("LogObject used without initialization")
+		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	log.WithFields(object.Fields).Debug(args...)
+	logrus.WithFields(object.Fields).Debug(args...)
 }
 
 // Print :
 func (object *LogObject) Print(args ...interface{}) {
 	if !object.Initialized {
-		log.Fatal("LogObject used without initialization")
+		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	log.WithFields(object.Fields).Print(args...)
+	logrus.WithFields(object.Fields).Print(args...)
 }
 
 // Info :
 func (object *LogObject) Info(args ...interface{}) {
 	if !object.Initialized {
-		log.Fatal("LogObject used without initialization")
+		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	log.WithFields(object.Fields).Info(args...)
+	logrus.WithFields(object.Fields).Info(args...)
 }
 
 // Warn :
 func (object *LogObject) Warn(args ...interface{}) {
 	if !object.Initialized {
-		log.Fatal("LogObject used without initialization")
+		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	log.WithFields(object.Fields).Warn(args...)
+	logrus.WithFields(object.Fields).Warn(args...)
 }
 
 // Warning :
 func (object *LogObject) Warning(args ...interface{}) {
 	if !object.Initialized {
-		log.Fatal("LogObject used without initialization")
+		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	log.WithFields(object.Fields).Warning(args...)
+	logrus.WithFields(object.Fields).Warning(args...)
 }
 
 // Error :
 func (object *LogObject) Error(args ...interface{}) {
 	if !object.Initialized {
-		log.Fatal("LogObject used without initialization")
+		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	log.WithFields(object.Fields).Error(args...)
+	logrus.WithFields(object.Fields).Error(args...)
 }
 
 // Panic :
 func (object *LogObject) Panic(args ...interface{}) {
 	if !object.Initialized {
-		log.Fatal("LogObject used without initialization")
+		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	log.WithFields(object.Fields).Panic(args...)
+	logrus.WithFields(object.Fields).Panic(args...)
 }
 
 // Fatal :
 func (object *LogObject) Fatal(args ...interface{}) {
 	if !object.Initialized {
-		log.Fatal("LogObject used without initialization")
+		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	log.WithFields(object.Fields).Fatal(args...)
+	logrus.WithFields(object.Fields).Fatal(args...)
 }
 
 // Debugf :
 func (object *LogObject) Debugf(format string, args ...interface{}) {
 	if !object.Initialized {
-		log.Fatal("LogObject used without initialization")
+		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	log.WithFields(object.Fields).Debugf(format, args...)
+	logrus.WithFields(object.Fields).Debugf(format, args...)
 }
 
 // Infof :
 func (object *LogObject) Infof(format string, args ...interface{}) {
 	if !object.Initialized {
-		log.Fatal("LogObject used without initialization")
+		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	log.WithFields(object.Fields).Infof(format, args...)
+	logrus.WithFields(object.Fields).Infof(format, args...)
 }
 
 // Warnf :
 func (object *LogObject) Warnf(format string, args ...interface{}) {
 	if !object.Initialized {
-		log.Fatal("LogObject used without initialization")
+		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	log.WithFields(object.Fields).Warnf(format, args...)
+	logrus.WithFields(object.Fields).Warnf(format, args...)
 }
 
 // Warningf :
 func (object *LogObject) Warningf(format string, args ...interface{}) {
 	if !object.Initialized {
-		log.Fatal("LogObject used without initialization")
+		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	log.WithFields(object.Fields).Warningf(format, args...)
+	logrus.WithFields(object.Fields).Warningf(format, args...)
 }
 
 // Panicf :
 func (object *LogObject) Panicf(format string, args ...interface{}) {
 	if !object.Initialized {
-		log.Fatal("LogObject used without initialization")
+		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	log.WithFields(object.Fields).Panicf(format, args...)
+	logrus.WithFields(object.Fields).Panicf(format, args...)
 }
 
 // Fatalf :
 func (object *LogObject) Fatalf(format string, args ...interface{}) {
 	if !object.Initialized {
-		log.Fatal("LogObject used without initialization")
+		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	log.WithFields(object.Fields).Fatalf(format, args...)
+	logrus.WithFields(object.Fields).Fatalf(format, args...)
 }
 
 // Errorf :
 func (object *LogObject) Errorf(format string, args ...interface{}) {
 	if !object.Initialized {
-		log.Fatal("LogObject used without initialization")
+		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	log.WithFields(object.Fields).Errorf(format, args...)
+	logrus.WithFields(object.Fields).Errorf(format, args...)
 }
 
 // Debugln :
 func (object *LogObject) Debugln(args ...interface{}) {
 	if !object.Initialized {
-		log.Fatal("LogObject used without initialization")
+		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	log.WithFields(object.Fields).Debugln(args...)
+	logrus.WithFields(object.Fields).Debugln(args...)
 }
 
 // Println :
 func (object *LogObject) Println(args ...interface{}) {
 	if !object.Initialized {
-		log.Fatal("LogObject used without initialization")
+		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	log.WithFields(object.Fields).Println(args...)
+	logrus.WithFields(object.Fields).Println(args...)
 }
 
 // Infoln :
 func (object *LogObject) Infoln(args ...interface{}) {
 	if !object.Initialized {
-		log.Fatal("LogObject used without initialization")
+		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	log.WithFields(object.Fields).Infoln(args...)
+	logrus.WithFields(object.Fields).Infoln(args...)
 }
 
 // Warnln :
 func (object *LogObject) Warnln(args ...interface{}) {
 	if !object.Initialized {
-		log.Fatal("LogObject used without initialization")
+		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	log.WithFields(object.Fields).Warnln(args...)
+	logrus.WithFields(object.Fields).Warnln(args...)
 }
 
 // Warningln :
 func (object *LogObject) Warningln(args ...interface{}) {
 	if !object.Initialized {
-		log.Fatal("LogObject used without initialization")
+		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	log.WithFields(object.Fields).Warningln(args...)
+	logrus.WithFields(object.Fields).Warningln(args...)
 }
 
 // Errorln :
 func (object *LogObject) Errorln(args ...interface{}) {
 	if !object.Initialized {
-		log.Fatal("LogObject used without initialization")
+		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	log.WithFields(object.Fields).Errorln(args...)
+	logrus.WithFields(object.Fields).Errorln(args...)
 }
 
 // Panicln :
 func (object *LogObject) Panicln(args ...interface{}) {
 	if !object.Initialized {
-		log.Fatal("LogObject used without initialization")
+		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	log.WithFields(object.Fields).Panicln(args...)
+	logrus.WithFields(object.Fields).Panicln(args...)
 }
 
 // Fatalln :
 func (object *LogObject) Fatalln(args ...interface{}) {
 	if !object.Initialized {
-		log.Fatal("LogObject used without initialization")
+		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	log.WithFields(object.Fields).Fatalln(args...)
+	logrus.WithFields(object.Fields).Fatalln(args...)
 }

--- a/pkg/pillar/base/log.go
+++ b/pkg/pillar/base/log.go
@@ -13,7 +13,7 @@ func (object *LogObject) Debug(args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	logrus.WithFields(object.Fields).Debug(args...)
+	object.logger.WithFields(object.Fields).Debug(args...)
 }
 
 // Print :
@@ -22,7 +22,7 @@ func (object *LogObject) Print(args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	logrus.WithFields(object.Fields).Print(args...)
+	object.logger.WithFields(object.Fields).Print(args...)
 }
 
 // Info :
@@ -31,7 +31,7 @@ func (object *LogObject) Info(args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	logrus.WithFields(object.Fields).Info(args...)
+	object.logger.WithFields(object.Fields).Info(args...)
 }
 
 // Warn :
@@ -40,7 +40,7 @@ func (object *LogObject) Warn(args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	logrus.WithFields(object.Fields).Warn(args...)
+	object.logger.WithFields(object.Fields).Warn(args...)
 }
 
 // Warning :
@@ -49,7 +49,7 @@ func (object *LogObject) Warning(args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	logrus.WithFields(object.Fields).Warning(args...)
+	object.logger.WithFields(object.Fields).Warning(args...)
 }
 
 // Error :
@@ -58,7 +58,7 @@ func (object *LogObject) Error(args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	logrus.WithFields(object.Fields).Error(args...)
+	object.logger.WithFields(object.Fields).Error(args...)
 }
 
 // Panic :
@@ -67,7 +67,7 @@ func (object *LogObject) Panic(args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	logrus.WithFields(object.Fields).Panic(args...)
+	object.logger.WithFields(object.Fields).Panic(args...)
 }
 
 // Fatal :
@@ -76,7 +76,7 @@ func (object *LogObject) Fatal(args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	logrus.WithFields(object.Fields).Fatal(args...)
+	object.logger.WithFields(object.Fields).Fatal(args...)
 }
 
 // Debugf :
@@ -85,7 +85,7 @@ func (object *LogObject) Debugf(format string, args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	logrus.WithFields(object.Fields).Debugf(format, args...)
+	object.logger.WithFields(object.Fields).Debugf(format, args...)
 }
 
 // Infof :
@@ -94,7 +94,7 @@ func (object *LogObject) Infof(format string, args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	logrus.WithFields(object.Fields).Infof(format, args...)
+	object.logger.WithFields(object.Fields).Infof(format, args...)
 }
 
 // Warnf :
@@ -103,7 +103,7 @@ func (object *LogObject) Warnf(format string, args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	logrus.WithFields(object.Fields).Warnf(format, args...)
+	object.logger.WithFields(object.Fields).Warnf(format, args...)
 }
 
 // Warningf :
@@ -112,7 +112,7 @@ func (object *LogObject) Warningf(format string, args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	logrus.WithFields(object.Fields).Warningf(format, args...)
+	object.logger.WithFields(object.Fields).Warningf(format, args...)
 }
 
 // Panicf :
@@ -121,7 +121,7 @@ func (object *LogObject) Panicf(format string, args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	logrus.WithFields(object.Fields).Panicf(format, args...)
+	object.logger.WithFields(object.Fields).Panicf(format, args...)
 }
 
 // Fatalf :
@@ -130,7 +130,7 @@ func (object *LogObject) Fatalf(format string, args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	logrus.WithFields(object.Fields).Fatalf(format, args...)
+	object.logger.WithFields(object.Fields).Fatalf(format, args...)
 }
 
 // Errorf :
@@ -139,7 +139,7 @@ func (object *LogObject) Errorf(format string, args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	logrus.WithFields(object.Fields).Errorf(format, args...)
+	object.logger.WithFields(object.Fields).Errorf(format, args...)
 }
 
 // Debugln :
@@ -148,7 +148,7 @@ func (object *LogObject) Debugln(args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	logrus.WithFields(object.Fields).Debugln(args...)
+	object.logger.WithFields(object.Fields).Debugln(args...)
 }
 
 // Println :
@@ -157,7 +157,7 @@ func (object *LogObject) Println(args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	logrus.WithFields(object.Fields).Println(args...)
+	object.logger.WithFields(object.Fields).Println(args...)
 }
 
 // Infoln :
@@ -166,7 +166,7 @@ func (object *LogObject) Infoln(args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	logrus.WithFields(object.Fields).Infoln(args...)
+	object.logger.WithFields(object.Fields).Infoln(args...)
 }
 
 // Warnln :
@@ -175,7 +175,7 @@ func (object *LogObject) Warnln(args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	logrus.WithFields(object.Fields).Warnln(args...)
+	object.logger.WithFields(object.Fields).Warnln(args...)
 }
 
 // Warningln :
@@ -184,7 +184,7 @@ func (object *LogObject) Warningln(args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	logrus.WithFields(object.Fields).Warningln(args...)
+	object.logger.WithFields(object.Fields).Warningln(args...)
 }
 
 // Errorln :
@@ -193,7 +193,7 @@ func (object *LogObject) Errorln(args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	logrus.WithFields(object.Fields).Errorln(args...)
+	object.logger.WithFields(object.Fields).Errorln(args...)
 }
 
 // Panicln :
@@ -202,7 +202,7 @@ func (object *LogObject) Panicln(args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	logrus.WithFields(object.Fields).Panicln(args...)
+	object.logger.WithFields(object.Fields).Panicln(args...)
 }
 
 // Fatalln :
@@ -211,5 +211,5 @@ func (object *LogObject) Fatalln(args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	logrus.WithFields(object.Fields).Fatalln(args...)
+	object.logger.WithFields(object.Fields).Fatalln(args...)
 }

--- a/pkg/pillar/base/logobjecttypes.go
+++ b/pkg/pillar/base/logobjecttypes.go
@@ -6,7 +6,7 @@ package base
 import (
 	"encoding/json"
 	"github.com/satori/go.uuid"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // LogEventType : Predefined object types
@@ -130,7 +130,7 @@ type LoggableObject interface {
 // objType and objName are mandatory parameters
 func NewLogObject(logBase *LogObject, objType LogObjectType, objName string, objUUID uuid.UUID, key string) *LogObject {
 	if objType == UnknownLogType || len(key) == 0 {
-		log.Fatal("NewLogObject: objType and key parameters mandatory")
+		logrus.Fatal("NewLogObject: objType and key parameters mandatory")
 	}
 	// Check if we already have an object with the given key
 	var object *LogObject
@@ -140,7 +140,7 @@ func NewLogObject(logBase *LogObject, objType LogObjectType, objName string, obj
 		if ok {
 			return object
 		}
-		log.Fatalf("NewLogObject: Object found in key map is not of type *LogObject, found: %T", value)
+		logrus.Fatalf("NewLogObject: Object found in key map is not of type *LogObject, found: %T", value)
 	}
 
 	object = new(LogObject)
@@ -152,10 +152,10 @@ func NewLogObject(logBase *LogObject, objType LogObjectType, objName string, obj
 // InitLogObject : Initialize an already allocated LogObject
 func InitLogObject(logBase *LogObject, object *LogObject, objType LogObjectType, objName string, objUUID uuid.UUID, key string) {
 	if objType == UnknownLogType || len(key) == 0 {
-		log.Fatal("InitLogObject: objType and key parameters mandatory")
+		logrus.Fatal("InitLogObject: objType and key parameters mandatory")
 	}
 	if object == nil {
-		log.Fatal("InitLogObject: LogObject cannot be nil")
+		logrus.Fatal("InitLogObject: LogObject cannot be nil")
 	}
 	fields := make(map[string]interface{})
 	fields["log_event_type"] = LogObjectEventType
@@ -187,7 +187,7 @@ func NewSourceLogObject(agentName string, agentPid int) *LogObject {
 		if ok {
 			return object
 		}
-		log.Fatalf("NewSourceLogObject: Object found is not of type *LogObject, found: %T",
+		logrus.Fatalf("NewSourceLogObject: Object found is not of type *LogObject, found: %T",
 			value)
 	}
 
@@ -215,7 +215,7 @@ func NewRelationObject(logBase *LogObject, relationObjectType RelationObjectType
 
 	object := new(LogObject)
 	if object == nil {
-		log.Fatal("Relation object allocation failed")
+		logrus.Fatal("Relation object allocation failed")
 	}
 
 	fields := make(map[string]interface{})
@@ -244,7 +244,7 @@ func LookupLogObject(key string) *LogObject {
 	}
 	object, ok = value.(*LogObject)
 	if !ok {
-		log.Fatalf("LookupLogObject: Object found in key map is not of type *LogObject, found: %T", value)
+		logrus.Fatalf("LookupLogObject: Object found in key map is not of type *LogObject, found: %T", value)
 	}
 	return object
 }
@@ -262,7 +262,7 @@ func EnsureLogObject(logBase *LogObject, objType LogObjectType, objName string, 
 func DeleteLogObject(key string) {
 	_, ok := logObjectMap.Load(key)
 	if !ok {
-		log.Errorf("DeleteLogObject: LogObject with key %s not found in internal map", key)
+		logrus.Errorf("DeleteLogObject: LogObject with key %s not found in internal map", key)
 		return
 	}
 	logObjectMap.Delete(key)

--- a/pkg/pillar/cmd/baseosmgr/baseosmgr.go
+++ b/pkg/pillar/cmd/baseosmgr/baseosmgr.go
@@ -68,9 +68,6 @@ func Run(ps *pubsub.PubSub) int {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
 		return 0
 	}
-	// XXX Make logrus record a noticable global source
-	agentlog.Init("xyzzy-" + agentName)
-
 	log = agentlog.Init(agentName)
 	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
 		log.Fatal(err)

--- a/pkg/pillar/cmd/baseosmgr/baseosmgr.go
+++ b/pkg/pillar/cmd/baseosmgr/baseosmgr.go
@@ -51,24 +51,26 @@ type baseOsMgrContext struct {
 
 var debug = false
 var debugOverride bool // From command line arg
+var logger *logrus.Logger
 var log *base.LogObject
 
-func Run(ps *pubsub.PubSub) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) int {
+	logger = loggerArg
+	log = logArg
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")
 	flag.Parse()
 	debug = *debugPtr
 	debugOverride = debug
 	if debugOverride {
-		logrus.SetLevel(logrus.DebugLevel)
+		logger.SetLevel(logrus.DebugLevel)
 	} else {
-		logrus.SetLevel(logrus.InfoLevel)
+		logger.SetLevel(logrus.InfoLevel)
 	}
 	if *versionPtr {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
 		return 0
 	}
-	log = agentlog.Init(agentName)
 	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
 		log.Fatal(err)
 	}
@@ -233,7 +235,7 @@ func handleGlobalConfigModify(ctxArg interface{}, key string,
 	}
 	var gcp *types.ConfigItemValueMap
 	debug, gcp = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
-		debugOverride)
+		debugOverride, logger)
 	if gcp != nil {
 		ctx.globalConfig = gcp
 		ctx.GCInitialized = true
@@ -251,7 +253,7 @@ func handleGlobalConfigDelete(ctxArg interface{}, key string,
 	}
 	log.Infof("handleGlobalConfigDelete for %s", key)
 	debug, _ = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
-		debugOverride)
+		debugOverride, logger)
 	*ctx.globalConfig = *types.DefaultConfigItemValueMap()
 	log.Infof("handleGlobalConfigDelete done for %s", key)
 }

--- a/pkg/pillar/cmd/baseosmgr/baseosmgr.go
+++ b/pkg/pillar/cmd/baseosmgr/baseosmgr.go
@@ -298,6 +298,7 @@ func initializeGlobalConfigHandles(ps *pubsub.PubSub, ctx *baseOsMgrContext) {
 	subGlobalConfig, err := ps.NewSubscription(
 		pubsub.SubscriptionOptions{
 			AgentName:     "",
+			MyAgentName:   agentName,
 			TopicImpl:     types.ConfigItemValueMap{},
 			Activate:      false,
 			Ctx:           ctx,
@@ -319,6 +320,7 @@ func initializeNodeAgentHandles(ps *pubsub.PubSub, ctx *baseOsMgrContext) {
 	subNodeAgentStatus, err := ps.NewSubscription(
 		pubsub.SubscriptionOptions{
 			AgentName:     "nodeagent",
+			MyAgentName:   agentName,
 			TopicImpl:     types.NodeAgentStatus{},
 			Activate:      false,
 			Ctx:           ctx,
@@ -337,6 +339,7 @@ func initializeNodeAgentHandles(ps *pubsub.PubSub, ctx *baseOsMgrContext) {
 	subZbootConfig, err := ps.NewSubscription(
 		pubsub.SubscriptionOptions{
 			AgentName:     "nodeagent",
+			MyAgentName:   agentName,
 			TopicImpl:     types.ZbootConfig{},
 			Activate:      false,
 			Ctx:           ctx,
@@ -358,6 +361,7 @@ func initializeZedagentHandles(ps *pubsub.PubSub, ctx *baseOsMgrContext) {
 	subBaseOsConfig, err := ps.NewSubscription(
 		pubsub.SubscriptionOptions{
 			AgentName:     "zedagent",
+			MyAgentName:   agentName,
 			TopicImpl:     types.BaseOsConfig{},
 			Activate:      false,
 			Ctx:           ctx,
@@ -379,6 +383,7 @@ func initializeVolumemgrHandles(ps *pubsub.PubSub, ctx *baseOsMgrContext) {
 	subContentTreeStatus, err := ps.NewSubscription(
 		pubsub.SubscriptionOptions{
 			AgentName:     "volumemgr",
+			MyAgentName:   agentName,
 			AgentScope:    types.BaseOsObj,
 			TopicImpl:     types.ContentTreeStatus{},
 			Activate:      false,

--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -107,9 +107,6 @@ func Run(ps *pubsub.PubSub) int { //nolint:gocyclo
 		return 0
 	}
 	// Sending json log format to stdout
-	// XXX Make logrus record a noticable global source
-	agentlog.Init("xyzzy-" + agentName)
-
 	log = agentlog.Init("client")
 	if !noPidFlag {
 		if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {

--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -168,6 +168,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "",
+		MyAgentName:   agentName,
 		CreateHandler: handleGlobalConfigModify,
 		ModifyHandler: handleGlobalConfigModify,
 		DeleteHandler: handleGlobalConfigDelete,
@@ -190,6 +191,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		WarningTime:   warningTime,
 		ErrorTime:     errorTime,
 		AgentName:     "nim",
+		MyAgentName:   agentName,
 		TopicImpl:     types.DeviceNetworkStatus{},
 		Ctx:           &clientCtx,
 	})

--- a/pkg/pillar/cmd/command/command.go
+++ b/pkg/pillar/cmd/command/command.go
@@ -57,15 +57,19 @@ var (
 	combinedOutput bool
 	environ        []string
 	dontWait       bool
+	logger         *logrus.Logger
+	log            *base.LogObject
 )
 
 // Run is the main aka only entrypoint
-func Run(ps *pubsub.PubSub) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) int {
+	logger = loggerArg
+	log = logArg
 	// Report nano timestamps
 	formatter := logrus.JSONFormatter{
 		TimestampFormat: time.RFC3339Nano,
 	}
-	logrus.SetFormatter(&formatter)
+	logger.SetFormatter(&formatter)
 
 	debugPtr := flag.Bool("d", false, "Debug flag")
 	quietPtr := flag.Bool("q", false, "Quiet flag")
@@ -82,14 +86,13 @@ func Run(ps *pubsub.PubSub) int {
 		environ = append(environ, *environPtr)
 	}
 	if *quietPtr {
-		logrus.SetLevel(logrus.WarnLevel)
+		logger.SetLevel(logrus.WarnLevel)
 	} else if *debugPtr {
-		logrus.SetLevel(logrus.DebugLevel)
+		logger.SetLevel(logrus.DebugLevel)
 	} else {
-		logrus.SetLevel(logrus.InfoLevel)
+		logger.SetLevel(logrus.InfoLevel)
 	}
 
-	log := base.NewSourceLogObject(agentName, os.Getpid())
 	hdl, err := execlib.New(ps, log, agentName, "executor")
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/pillar/cmd/conntrack/conntrack.go
+++ b/pkg/pillar/cmd/conntrack/conntrack.go
@@ -10,11 +10,17 @@ import (
 	"syscall"
 
 	"github.com/eriknordmark/netlink"
+	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
-func Run(ps *pubsub.PubSub) int {
+var logger *logrus.Logger
+var log *base.LogObject
+
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) int {
+	logger = loggerArg
+	log = logArg
 	delFlow := flag.Bool("D", false, "Delete flow")
 	delSrcIP := flag.String("s", "", "Delete flow with Srouce IP")
 	delProto := flag.Int("p", 0, "Delete flow with protocol ID")
@@ -54,7 +60,7 @@ func Run(ps *pubsub.PubSub) int {
 
 			number, err := netlink.ConntrackDeleteIPSrc(netlink.ConntrackTable, family, src, proto, port, mark, mask, true)
 			if err != nil {
-				log.Println("ConntrackDeleteIPSrc error:", err)
+				logger.Println("ConntrackDeleteIPSrc error:", err)
 			} else {
 				fmt.Printf("ConntrackDeleteIPSrc: deleted %d flow\n", number)
 			}
@@ -66,7 +72,7 @@ func Run(ps *pubsub.PubSub) int {
 	// XXX args := flag.Args()
 	res, err := netlink.ConntrackTableList(netlink.ConntrackTable, syscall.AF_INET)
 	if err != nil {
-		log.Println("ContrackTableList", err)
+		logger.Println("ContrackTableList", err)
 	} else {
 		for i, entry := range res {
 			fmt.Printf("[%d]: %s\n", i, entry.String())
@@ -78,7 +84,7 @@ func Run(ps *pubsub.PubSub) int {
 	}
 	res, err = netlink.ConntrackTableList(netlink.ConntrackTable, syscall.AF_INET6)
 	if err != nil {
-		log.Println("ContrackTableList", err)
+		logger.Println("ContrackTableList", err)
 	} else {
 		for i, entry := range res {
 			fmt.Printf("[%d]: %s\n", i, entry.String())

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -77,9 +77,12 @@ var simulateDnsFailure = false
 var simulatePingFailure = false
 var outfile = os.Stdout
 var nilUUID uuid.UUID
+var logger *logrus.Logger
 var log *base.LogObject
 
-func Run(ps *pubsub.PubSub) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) int {
+	logger = loggerArg
+	log = logArg
 	var err error
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")
@@ -92,9 +95,9 @@ func Run(ps *pubsub.PubSub) int {
 	debug = *debugPtr
 	debugOverride = debug
 	if debugOverride {
-		logrus.SetLevel(logrus.DebugLevel)
+		logger.SetLevel(logrus.DebugLevel)
 	} else {
-		logrus.SetLevel(logrus.InfoLevel)
+		logger.SetLevel(logrus.InfoLevel)
 	}
 	simulateDnsFailure = *simulateDnsFailurePtr
 	simulatePingFailure = *simulatePingFailurePtr
@@ -103,7 +106,6 @@ func Run(ps *pubsub.PubSub) int {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
 		return 0
 	}
-	log = agentlog.Init(agentName)
 	if outputFile != "" {
 		outfile, err = os.OpenFile(outputFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
@@ -1088,7 +1090,7 @@ func handleGlobalConfigModify(ctxArg interface{}, key string,
 	log.Infof("handleGlobalConfigModify for %s", key)
 	var gcp *types.ConfigItemValueMap
 	debug, gcp = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
-		debugOverride)
+		debugOverride, logger)
 	if gcp != nil {
 		ctx.globalConfig = gcp
 	}
@@ -1105,7 +1107,7 @@ func handleGlobalConfigDelete(ctxArg interface{}, key string,
 	}
 	log.Infof("handleGlobalConfigDelete for %s", key)
 	debug, _ = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
-		debugOverride)
+		debugOverride, logger)
 	*ctx.globalConfig = *types.DefaultConfigItemValueMap()
 	log.Infof("handleGlobalConfigDelete done for %s", key)
 }

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -103,9 +103,6 @@ func Run(ps *pubsub.PubSub) int {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
 		return 0
 	}
-	// XXX Make logrus record a noticable global source
-	agentlog.Init("xyzzy-" + agentName)
-
 	log = agentlog.Init(agentName)
 	if outputFile != "" {
 		outfile, err = os.OpenFile(outputFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -129,6 +129,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	subGlobalConfig, err := ps.NewSubscription(
 		pubsub.SubscriptionOptions{
 			AgentName:     "",
+			MyAgentName:   agentName,
 			TopicImpl:     types.ConfigItemValueMap{},
 			Activate:      false,
 			Ctx:           &ctx,
@@ -194,6 +195,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	subLedBlinkCounter, err := ps.NewSubscription(
 		pubsub.SubscriptionOptions{
 			AgentName:     "",
+			MyAgentName:   agentName,
 			TopicImpl:     types.LedBlinkCounter{},
 			Activate:      false,
 			Ctx:           &ctx,
@@ -212,6 +214,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	subDeviceNetworkStatus, err := ps.NewSubscription(
 		pubsub.SubscriptionOptions{
 			AgentName:     "nim",
+			MyAgentName:   agentName,
 			TopicImpl:     types.DeviceNetworkStatus{},
 			Activate:      false,
 			Ctx:           &ctx,
@@ -231,6 +234,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	subDevicePortConfigList, err := ps.NewSubscription(
 		pubsub.SubscriptionOptions{
 			AgentName:     "nim",
+			MyAgentName:   agentName,
 			Persistent:    true,
 			TopicImpl:     types.DevicePortConfigList{},
 			Activate:      false,
@@ -247,6 +251,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	subOnboardStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "zedclient",
+		MyAgentName:   agentName,
 		CreateHandler: handleOnboardStatusModify,
 		ModifyHandler: handleOnboardStatusModify,
 		WarningTime:   warningTime,

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -128,9 +128,6 @@ func Run(ps *pubsub.PubSub) int {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
 		return 0
 	}
-	// XXX Make logrus record a noticable global source
-	agentlog.Init("xyzzy-" + agentName)
-
 	log = agentlog.Init(agentName)
 
 	hyper, err = hypervisor.GetHypervisor(*hypervisorPtr)

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -259,6 +259,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Look for controller certs which will be used for decryption
 	subControllerCert, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:   "zedagent",
+		MyAgentName: agentName,
 		TopicImpl:   types.ControllerCert{},
 		Activate:    false,
 		Ctx:         &domainCtx,
@@ -276,6 +277,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Look for edge node certs which will be used for decryption
 	subEdgeNodeCert, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:   "tpmmgr",
+		MyAgentName: agentName,
 		TopicImpl:   types.EdgeNodeCert{},
 		Activate:    false,
 		Ctx:         &domainCtx,
@@ -291,6 +293,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Look for cipher context which will be used for decryption
 	subCipherContext, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:   "zedagent",
+		MyAgentName: agentName,
 		TopicImpl:   types.CipherContext{},
 		Activate:    false,
 		Ctx:         &domainCtx,
@@ -308,6 +311,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	subGlobalConfig, err := ps.NewSubscription(
 		pubsub.SubscriptionOptions{
 			AgentName:     "",
+			MyAgentName:   agentName,
 			TopicImpl:     types.ConfigItemValueMap{},
 			Activate:      false,
 			Ctx:           &domainCtx,
@@ -326,6 +330,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	subOnboardStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "zedclient",
+		MyAgentName:   agentName,
 		CreateHandler: handleOnboardStatusModify,
 		ModifyHandler: handleOnboardStatusModify,
 		WarningTime:   warningTime,
@@ -343,6 +348,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	subDeviceNetworkStatus, err := ps.NewSubscription(
 		pubsub.SubscriptionOptions{
 			AgentName:     "nim",
+			MyAgentName:   agentName,
 			TopicImpl:     types.DeviceNetworkStatus{},
 			Activate:      false,
 			Ctx:           &domainCtx,
@@ -445,6 +451,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	subPhysicalIOAdapter, err := ps.NewSubscription(
 		pubsub.SubscriptionOptions{
 			AgentName:     "zedagent",
+			MyAgentName:   agentName,
 			TopicImpl:     types.PhysicalIOAdapterList{},
 			Activate:      false,
 			Ctx:           &domainCtx,
@@ -485,6 +492,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	subDomainConfig, err := ps.NewSubscription(
 		pubsub.SubscriptionOptions{
 			AgentName:      "zedmanager",
+			MyAgentName:    agentName,
 			TopicImpl:      types.DomainConfig{},
 			Activate:       false,
 			Ctx:            &domainCtx,

--- a/pkg/pillar/cmd/domainmgr/domainmgr_test.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr_test.go
@@ -9,14 +9,16 @@
 package domainmgr
 
 import (
-	"github.com/lf-edge/eve/pkg/pillar/base"
-	"github.com/lf-edge/eve/pkg/pillar/types"
 	"reflect"
 	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/sirupsen/logrus"
 )
 
 func TestFetchEnvVariablesFromCloudInit(t *testing.T) {
-	log = base.NewSourceLogObject("domainmgr", 0)
+	log = base.NewSourceLogObject(logrus.StandardLogger(), "domainmgr", 0)
 	type fetchEnvVar struct {
 		config       types.DomainConfig
 		expectOutput map[string]string

--- a/pkg/pillar/cmd/downloader/context.go
+++ b/pkg/pillar/cmd/downloader/context.go
@@ -32,6 +32,7 @@ func (ctx *downloaderContext) registerHandlers(ps *pubsub.PubSub) error {
 	// Look for controller certs which will be used for decryption
 	subControllerCert, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:   "zedagent",
+		MyAgentName: agentName,
 		TopicImpl:   types.ControllerCert{},
 		Activate:    false,
 		Ctx:         ctx,
@@ -49,6 +50,7 @@ func (ctx *downloaderContext) registerHandlers(ps *pubsub.PubSub) error {
 	// Look for edge node certs which will be used for decryption
 	subEdgeNodeCert, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:   "tpmmgr",
+		MyAgentName: agentName,
 		TopicImpl:   types.EdgeNodeCert{},
 		Activate:    false,
 		Ctx:         ctx,
@@ -64,6 +66,7 @@ func (ctx *downloaderContext) registerHandlers(ps *pubsub.PubSub) error {
 	// Look for cipher context which will be used for decryption
 	subCipherContext, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:   "zedagent",
+		MyAgentName: agentName,
 		TopicImpl:   types.CipherContext{},
 		Activate:    false,
 		Ctx:         ctx,
@@ -79,6 +82,8 @@ func (ctx *downloaderContext) registerHandlers(ps *pubsub.PubSub) error {
 
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:     "",
+		MyAgentName:   agentName,
 		CreateHandler: handleGlobalConfigModify,
 		ModifyHandler: handleGlobalConfigModify,
 		DeleteHandler: handleGlobalConfigDelete,
@@ -102,6 +107,7 @@ func (ctx *downloaderContext) registerHandlers(ps *pubsub.PubSub) error {
 		TopicImpl:     types.DeviceNetworkStatus{},
 		Ctx:           ctx,
 		AgentName:     "nim",
+		MyAgentName:   agentName,
 	})
 	if err != nil {
 		return err
@@ -119,6 +125,7 @@ func (ctx *downloaderContext) registerHandlers(ps *pubsub.PubSub) error {
 		WarningTime:   warningTime,
 		ErrorTime:     errorTime,
 		AgentName:     "zedagent",
+		MyAgentName:   agentName,
 		TopicImpl:     types.DatastoreConfig{},
 		Ctx:           ctx,
 	})
@@ -163,6 +170,7 @@ func (ctx *downloaderContext) registerHandlers(ps *pubsub.PubSub) error {
 		WarningTime:   warningTime,
 		ErrorTime:     errorTime,
 		AgentName:     "volumemgr",
+		MyAgentName:   agentName,
 		TopicImpl:     types.DownloaderConfig{},
 		Ctx:           ctx,
 	})
@@ -179,6 +187,7 @@ func (ctx *downloaderContext) registerHandlers(ps *pubsub.PubSub) error {
 		WarningTime:   warningTime,
 		ErrorTime:     errorTime,
 		AgentName:     "volumemgr",
+		MyAgentName:   agentName,
 		TopicImpl:     types.ResolveConfig{},
 		Ctx:           ctx,
 	})

--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -61,9 +61,6 @@ func Run(ps *pubsub.PubSub) int {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
 		return 0
 	}
-	// XXX Make logrus record a noticable global source
-	agentlog.Init("xyzzy-" + agentName)
-
 	log = agentlog.Init(agentName)
 
 	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {

--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/cipher"
 	"github.com/lf-edge/eve/pkg/pillar/flextimer"
@@ -43,26 +42,27 @@ var (
 	nilUUID       uuid.UUID                          // should be a const, just the default nil value of uuid.UUID
 	dHandler      = makeDownloadHandler()
 	resHandler    = makeResolveHandler()
+	logger        *logrus.Logger
 	log           *base.LogObject
 )
 
-func Run(ps *pubsub.PubSub) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) int {
+	logger = loggerArg
+	log = logArg
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")
 	flag.Parse()
 	debug = *debugPtr
 	debugOverride = debug
 	if debugOverride {
-		logrus.SetLevel(logrus.DebugLevel)
+		logger.SetLevel(logrus.DebugLevel)
 	} else {
-		logrus.SetLevel(logrus.InfoLevel)
+		logger.SetLevel(logrus.InfoLevel)
 	}
 	if *versionPtr {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
 		return 0
 	}
-	log = agentlog.Init(agentName)
-
 	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/pillar/cmd/downloader/globalconfig.go
+++ b/pkg/pillar/cmd/downloader/globalconfig.go
@@ -22,7 +22,7 @@ func handleGlobalConfigModify(ctxArg interface{}, key string,
 	log.Infof("handleGlobalConfigModify for %s", key)
 	var gcp *types.ConfigItemValueMap
 	debug, gcp = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
-		debugOverride)
+		debugOverride, logger)
 	if gcp != nil {
 		if gcp.GlobalValueInt(types.DownloadRetryTime) != 0 {
 			retryTime = time.Duration(gcp.GlobalValueInt(types.DownloadRetryTime)) * time.Second
@@ -42,6 +42,6 @@ func handleGlobalConfigDelete(ctxArg interface{}, key string,
 	}
 	log.Infof("handleGlobalConfigDelete for %s", key)
 	debug, _ = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
-		debugOverride)
+		debugOverride, logger)
 	log.Infof("handleGlobalConfigDelete done for %s", key)
 }

--- a/pkg/pillar/cmd/executor/exec.go
+++ b/pkg/pillar/cmd/executor/exec.go
@@ -67,9 +67,6 @@ func Run(ps *pubsub.PubSub) int {
 		logrus.SetLevel(logrus.InfoLevel)
 	}
 	execCtx.timeLimit = *timeLimitPtr
-	// XXX Make logrus record a noticable global source
-	agentlog.Init("xyzzy-" + agentName)
-
 	log = agentlog.Init(agentName)
 
 	if *versionPtr {

--- a/pkg/pillar/cmd/executor/exec.go
+++ b/pkg/pillar/cmd/executor/exec.go
@@ -94,6 +94,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:     "",
+		MyAgentName:   agentName,
 		TopicImpl:     types.ConfigItemValueMap{},
 		Ctx:           &execCtx,
 		CreateHandler: handleGlobalConfigModify,
@@ -121,6 +123,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	log.Infof("processed GlobalConfig")
 
 	subTmpConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:     "",
+		MyAgentName:   agentName,
 		TopicImpl:     types.ExecConfig{},
 		Ctx:           &execCtx,
 		CreateHandler: handleCreate,
@@ -137,6 +141,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	subCommandConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "command",
+		MyAgentName:   agentName,
 		Ctx:           &execCtx,
 		TopicImpl:     types.ExecConfig{},
 		CreateHandler: handleCreate,
@@ -153,6 +158,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	subVerifierConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "verifier",
+		MyAgentName:   agentName,
 		Ctx:           &execCtx,
 		TopicImpl:     types.ExecConfig{},
 		CreateHandler: handleCreate,
@@ -169,6 +175,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	subDomainConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "domainmgr",
+		MyAgentName:   agentName,
 		Ctx:           &execCtx,
 		TopicImpl:     types.ExecConfig{},
 		CreateHandler: handleCreate,

--- a/pkg/pillar/cmd/executor/exec.go
+++ b/pkg/pillar/cmd/executor/exec.go
@@ -50,10 +50,13 @@ type executorContext struct {
 	timeLimit     uint // In seconds
 }
 
+var logger *logrus.Logger
 var log *base.LogObject
 
 // Run is the main aka only entrypoint
-func Run(ps *pubsub.PubSub) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) int {
+	logger = loggerArg
+	log = logArg
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")
 	timeLimitPtr := flag.Uint("t", 120, "Maximum time to wait for command")
@@ -62,13 +65,11 @@ func Run(ps *pubsub.PubSub) int {
 	execCtx.debug = *debugPtr
 	execCtx.debugOverride = execCtx.debug
 	if execCtx.debugOverride {
-		logrus.SetLevel(logrus.DebugLevel)
+		logger.SetLevel(logrus.DebugLevel)
 	} else {
-		logrus.SetLevel(logrus.InfoLevel)
+		logger.SetLevel(logrus.InfoLevel)
 	}
 	execCtx.timeLimit = *timeLimitPtr
-	log = agentlog.Init(agentName)
-
 	if *versionPtr {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
 		return 0
@@ -347,7 +348,7 @@ func handleGlobalConfigModify(ctxArg interface{}, key string,
 	log.Infof("handleGlobalConfigModify for %s", key)
 	var gcp *types.ConfigItemValueMap
 	execCtx.debug, gcp = agentlog.HandleGlobalConfig(log, execCtx.subGlobalConfig, agentName,
-		execCtx.debugOverride)
+		execCtx.debugOverride, logger)
 	if gcp != nil {
 		execCtx.GCInitialized = true
 	}
@@ -364,6 +365,6 @@ func handleGlobalConfigDelete(ctxArg interface{}, key string,
 	}
 	log.Infof("handleGlobalConfigDelete for %s", key)
 	execCtx.debug, _ = agentlog.HandleGlobalConfig(log, execCtx.subGlobalConfig, agentName,
-		execCtx.debugOverride)
+		execCtx.debugOverride, logger)
 	log.Infof("handleGlobalConfigDelete done for %s", key)
 }

--- a/pkg/pillar/cmd/hardwaremodel/hardwaremodel.go
+++ b/pkg/pillar/cmd/hardwaremodel/hardwaremodel.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/hardware"
@@ -18,6 +17,7 @@ import (
 	"github.com/rackn/gohai/plugins/net"
 	"github.com/rackn/gohai/plugins/storage"
 	"github.com/rackn/gohai/plugins/system"
+	"github.com/sirupsen/logrus"
 )
 
 // Set from Makefile
@@ -59,16 +59,24 @@ func hwFp(log *base.LogObject, outputFile string) {
 	enc.Encode(infos)
 }
 
-func Run(ps *pubsub.PubSub) int {
-	pid := os.Getpid()
-	basename := filepath.Base(os.Args[0])
-	log := base.NewSourceLogObject(basename, pid)
+var logger *logrus.Logger
+var log *base.LogObject
+
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) int {
+	logger = loggerArg
+	log = logArg
+	debugPtr := flag.Bool("d", false, "Debug flag")
 	versionPtr := flag.Bool("v", false, "Version")
 	cPtr := flag.Bool("c", false, "No CRLF")
 	hwPtr := flag.Bool("f", false, "Fingerprint hardware")
 	outputFilePtr := flag.String("o", "/config/hardwaremodel", "file or device for output")
 	flag.Parse()
 	outputFile := *outputFilePtr
+	if *debugPtr {
+		logger.SetLevel(logrus.DebugLevel)
+	} else {
+		logger.SetLevel(logrus.InfoLevel)
+	}
 	if *versionPtr {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
 		return 0

--- a/pkg/pillar/cmd/ipcmonitor/ipcmonitor.go
+++ b/pkg/pillar/cmd/ipcmonitor/ipcmonitor.go
@@ -166,8 +166,9 @@ func nameString(agentname, agentscope, topic string) string {
 func testPersistent(ps *pubsub.PubSub, agentName string, agentScope string, topic string) {
 	ctx := 3
 	sub, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName:  agentName,
-		AgentScope: agentScope,
+		AgentName:   agentName,
+		AgentScope:  agentScope,
+		MyAgentName: agentName,
 		// XXX hard-coded; need nameToType ;-)
 		TopicImpl:     types.DevicePortConfigList{},
 		Activate:      false,

--- a/pkg/pillar/cmd/ipcmonitor/ipcmonitor.go
+++ b/pkg/pillar/cmd/ipcmonitor/ipcmonitor.go
@@ -23,14 +23,20 @@ import (
 	"net"
 	"strings"
 
+	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var debugOverride bool // From command line arg
 
-func Run(ps *pubsub.PubSub) int {
+var logger *logrus.Logger
+var log *base.LogObject
+
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) int {
+	logger = loggerArg
+	log = logArg
 	agentNamePtr := flag.String("a", "zedrouter",
 		"Agent name")
 	agentScopePtr := flag.String("s", "", "agentScope")
@@ -45,9 +51,9 @@ func Run(ps *pubsub.PubSub) int {
 	topic := *topicPtr
 	debugOverride = *debugPtr
 	if debugOverride {
-		log.SetLevel(log.DebugLevel)
+		logger.SetLevel(logrus.DebugLevel)
 	} else {
-		log.SetLevel(log.InfoLevel)
+		logger.SetLevel(logrus.InfoLevel)
 	}
 	if *persistentPtr {
 		testPersistent(ps, agentName, agentScope, topic)

--- a/pkg/pillar/cmd/ledmanager/ledmanager.go
+++ b/pkg/pillar/cmd/ledmanager/ledmanager.go
@@ -185,9 +185,6 @@ func Run(ps *pubsub.PubSub) int {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
 		return 0
 	}
-	// XXX Make logrus record a noticable global source
-	agentlog.Init("xyzzy-" + agentName)
-
 	log = agentlog.Init(agentName)
 
 	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {

--- a/pkg/pillar/cmd/ledmanager/ledmanager.go
+++ b/pkg/pillar/cmd/ledmanager/ledmanager.go
@@ -161,12 +161,15 @@ var mToF = []modelToFuncs{
 
 var debug bool
 var debugOverride bool // From command line arg
+var logger *logrus.Logger
 var log *base.LogObject
 
 // Set from Makefile
 var Version = "No version specified"
 
-func Run(ps *pubsub.PubSub) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) int {
+	logger = loggerArg
+	log = logArg
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug")
 	fatalPtr := flag.Bool("F", false, "Cause log.Fatal fault injection")
@@ -177,16 +180,14 @@ func Run(ps *pubsub.PubSub) int {
 	fatalFlag := *fatalPtr
 	hangFlag := *hangPtr
 	if debugOverride {
-		logrus.SetLevel(logrus.DebugLevel)
+		logger.SetLevel(logrus.DebugLevel)
 	} else {
-		logrus.SetLevel(logrus.InfoLevel)
+		logger.SetLevel(logrus.InfoLevel)
 	}
 	if *versionPtr {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
 		return 0
 	}
-	log = agentlog.Init(agentName)
-
 	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
 		log.Fatal(err)
 	}
@@ -573,7 +574,7 @@ func handleGlobalConfigModify(ctxArg interface{}, key string,
 	log.Infof("handleGlobalConfigModify for %s", key)
 	var gcp *types.ConfigItemValueMap
 	debug, gcp = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
-		debugOverride)
+		debugOverride, logger)
 	if gcp != nil {
 		ctx.GCInitialized = true
 	}
@@ -590,6 +591,6 @@ func handleGlobalConfigDelete(ctxArg interface{}, key string,
 	}
 	log.Infof("handleGlobalConfigDelete for %s", key)
 	debug, _ = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
-		debugOverride)
+		debugOverride, logger)
 	log.Infof("handleGlobalConfigDelete done for %s", key)
 }

--- a/pkg/pillar/cmd/ledmanager/ledmanager.go
+++ b/pkg/pillar/cmd/ledmanager/ledmanager.go
@@ -233,6 +233,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	subLedBlinkCounter, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "",
+		MyAgentName:   agentName,
 		TopicImpl:     types.LedBlinkCounter{},
 		Activate:      false,
 		Ctx:           &ctx,
@@ -250,6 +251,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	subDeviceNetworkStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "nim",
+		MyAgentName:   agentName,
 		TopicImpl:     types.DeviceNetworkStatus{},
 		Activate:      false,
 		Ctx:           &ctx,
@@ -268,6 +270,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "",
+		MyAgentName:   agentName,
 		TopicImpl:     types.ConfigItemValueMap{},
 		Activate:      false,
 		Ctx:           &ctx,

--- a/pkg/pillar/cmd/logmanager/logmanager.go
+++ b/pkg/pillar/cmd/logmanager/logmanager.go
@@ -209,6 +209,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "",
+		MyAgentName:   agentName,
 		TopicImpl:     types.ConfigItemValueMap{},
 		Activate:      false,
 		Ctx:           &logmanagerCtx,
@@ -227,6 +228,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Get DomainStatus from domainmgr
 	subDomainStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "domainmgr",
+		MyAgentName:   agentName,
 		TopicImpl:     types.DomainStatus{},
 		Activate:      false,
 		Ctx:           &logmanagerCtx,
@@ -248,6 +250,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	subDeviceNetworkStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "nim",
+		MyAgentName:   agentName,
 		TopicImpl:     types.DeviceNetworkStatus{},
 		Activate:      false,
 		Ctx:           &DNSctx,

--- a/pkg/pillar/cmd/logmanager/logmanager.go
+++ b/pkg/pillar/cmd/logmanager/logmanager.go
@@ -167,9 +167,6 @@ func Run(ps *pubsub.PubSub) int {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
 		return 0
 	}
-	// XXX Make logrus record a noticable global source
-	agentlog.Init("xyzzy-" + agentName)
-
 	log = agentlog.Init(agentName)
 
 	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -98,9 +98,6 @@ func Run(ps *pubsub.PubSub) int {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
 		return 0
 	}
-	// XXX Make logrus record a noticable global source
-	agentlog.Init("xyzzy-" + agentName)
-
 	log = agentlog.Init(agentName)
 	nimCtx.deviceNetworkContext.Log = log
 

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -63,6 +63,7 @@ type nimContext struct {
 
 // Set from Makefile
 var Version = "No version specified"
+var logger *logrus.Logger
 var log *base.LogObject
 
 func (ctx *nimContext) processArgs() {
@@ -83,7 +84,9 @@ func (ctx *nimContext) processArgs() {
 }
 
 // Run - Main function - invoked from zedbox.go
-func Run(ps *pubsub.PubSub) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) int {
+	logger = loggerArg
+	log = logArg
 	nimCtx := nimContext{
 		fallbackPortMap:  make(map[string]bool),
 		filteredFallback: make(map[string]bool),
@@ -98,7 +101,6 @@ func Run(ps *pubsub.PubSub) int {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
 		return 0
 	}
-	log = agentlog.Init(agentName)
 	nimCtx.deviceNetworkContext.Log = log
 
 	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
@@ -927,7 +929,7 @@ func handleGlobalConfigModify(ctxArg interface{}, key string,
 	log.Infof("handleGlobalConfigModify for %s", key)
 	var gcp *types.ConfigItemValueMap
 	ctx.debug, gcp = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
-		ctx.debugOverride)
+		ctx.debugOverride, logger)
 	first := !ctx.GCInitialized
 	if gcp != nil {
 		gcpSSHAccess := gcp.GlobalValueString(types.SSHAuthorizedKeys) != ""
@@ -987,7 +989,7 @@ func handleGlobalConfigDelete(ctxArg interface{}, key string,
 	}
 	log.Infof("handleGlobalConfigDelete for %s", key)
 	ctx.debug, _ = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
-		ctx.debugOverride)
+		ctx.debugOverride, logger)
 	*ctx.globalConfig = *types.DefaultConfigItemValueMap()
 	log.Infof("handleGlobalConfigDelete done for %s", key)
 }

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -185,6 +185,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Look for controller certs which will be used for decryption
 	subControllerCert, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:   "zedagent",
+		MyAgentName: agentName,
 		TopicImpl:   types.ControllerCert{},
 		Activate:    false,
 		Ctx:         &nimCtx,
@@ -202,6 +203,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Look for edge node certs which will be used for decryption
 	subEdgeNodeCert, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:   "tpmmgr",
+		MyAgentName: agentName,
 		TopicImpl:   types.EdgeNodeCert{},
 		Activate:    false,
 		Ctx:         &nimCtx,
@@ -217,6 +219,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Look for cipher context which will be used for decryption
 	subCipherContext, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:   "zedagent",
+		MyAgentName: agentName,
 		TopicImpl:   types.CipherContext{},
 		Activate:    false,
 		Ctx:         &nimCtx,
@@ -233,6 +236,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "",
+		MyAgentName:   agentName,
 		TopicImpl:     types.ConfigItemValueMap{},
 		Activate:      false,
 		Ctx:           &nimCtx,
@@ -265,6 +269,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// 3. "lastresort" derived from the set of network interfaces
 	subDevicePortConfigA, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "zedagent",
+		MyAgentName:   agentName,
 		TopicImpl:     types.DevicePortConfig{},
 		Activate:      false,
 		Ctx:           &nimCtx.deviceNetworkContext,
@@ -282,6 +287,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	subDevicePortConfigO, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "",
+		MyAgentName:   agentName,
 		TopicImpl:     types.DevicePortConfig{},
 		Activate:      false,
 		Ctx:           &nimCtx.deviceNetworkContext,
@@ -299,6 +305,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	subDevicePortConfigS, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     agentName,
+		MyAgentName:   agentName,
 		TopicImpl:     types.DevicePortConfig{},
 		Activate:      false,
 		Ctx:           &nimCtx.deviceNetworkContext,
@@ -316,6 +323,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	subAssignableAdapters, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "domainmgr",
+		MyAgentName:   agentName,
 		TopicImpl:     types.AssignableAdapters{},
 		Activate:      false,
 		Ctx:           &nimCtx.deviceNetworkContext,
@@ -333,6 +341,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	subNetworkInstanceStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "zedrouter",
+		MyAgentName:   agentName,
 		TopicImpl:     types.NetworkInstanceStatus{},
 		Activate:      false,
 		Ctx:           &nimCtx,

--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -185,6 +185,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "",
+		MyAgentName:   agentName,
 		TopicImpl:     types.ConfigItemValueMap{},
 		Activate:      false,
 		Ctx:           &nodeagentCtx,
@@ -202,6 +203,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	subOnboardStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "zedclient",
+		MyAgentName:   agentName,
 		CreateHandler: handleOnboardStatusModify,
 		ModifyHandler: handleOnboardStatusModify,
 		WarningTime:   warningTime,
@@ -227,10 +229,11 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	// Get DomainStatus from domainmgr
 	subDomainStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName: "domainmgr",
-		TopicImpl: types.DomainStatus{},
-		Activate:  false,
-		Ctx:       &nodeagentCtx,
+		AgentName:   "domainmgr",
+		MyAgentName: agentName,
+		TopicImpl:   types.DomainStatus{},
+		Activate:    false,
+		Ctx:         &nodeagentCtx,
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -295,6 +298,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// subscribe to zboot status events
 	subZbootStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "baseosmgr",
+		MyAgentName:   agentName,
 		TopicImpl:     types.ZbootStatus{},
 		Activate:      false,
 		Ctx:           &nodeagentCtx,
@@ -312,6 +316,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// subscribe to zedagent status events
 	subZedAgentStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "zedagent",
+		MyAgentName:   agentName,
 		TopicImpl:     types.ZedAgentStatus{},
 		Activate:      false,
 		Ctx:           &nodeagentCtx,

--- a/pkg/pillar/cmd/tpmmgr/tpmmgr.go
+++ b/pkg/pillar/cmd/tpmmgr/tpmmgr.go
@@ -185,6 +185,7 @@ var (
 	}
 	debug         = false
 	debugOverride bool // From command line arg
+	logger        *logrus.Logger
 	log           *base.LogObject
 )
 
@@ -1048,21 +1049,19 @@ func publishEdgeNodeCertToController(ctx *tpmMgrContext, certFile string, certTy
 	log.Infof("publishEdgeNodeCertToController Done")
 }
 
-func Run(ps *pubsub.PubSub) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) int {
+	logger = loggerArg
+	log = logArg
 	var err error
 	debugPtr := flag.Bool("d", false, "Debug flag")
 	flag.Parse()
 	debug = *debugPtr
 	debugOverride = debug
 	if debugOverride {
-		logrus.SetLevel(logrus.DebugLevel)
+		logger.SetLevel(logrus.DebugLevel)
 	} else {
-		logrus.SetLevel(logrus.InfoLevel)
+		logger.SetLevel(logrus.InfoLevel)
 	}
-
-	// Sending json log format to stdout
-	log = agentlog.Init("tpmmgr")
-
 	if len(flag.Args()) == 0 {
 		log.Error("Insufficient arguments")
 		return 1
@@ -1311,7 +1310,7 @@ func handleGlobalConfigModify(ctxArg interface{}, key string,
 	log.Infof("handleGlobalConfigModify for %s", key)
 	var gcp *types.ConfigItemValueMap
 	debug, gcp = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
-		debugOverride)
+		debugOverride, logger)
 	if gcp != nil {
 		ctx.GCInitialized = true
 	}
@@ -1328,7 +1327,7 @@ func handleGlobalConfigDelete(ctxArg interface{}, key string,
 	}
 	log.Infof("handleGlobalConfigDelete for %s", key)
 	debug, _ = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
-		debugOverride)
+		debugOverride, logger)
 	log.Infof("handleGlobalConfigDelete done for %s", key)
 }
 

--- a/pkg/pillar/cmd/tpmmgr/tpmmgr.go
+++ b/pkg/pillar/cmd/tpmmgr/tpmmgr.go
@@ -1137,6 +1137,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		// Look for global config such as log levels
 		subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 			AgentName:     "",
+			MyAgentName:   agentName,
 			TopicImpl:     types.ConfigItemValueMap{},
 			Activate:      false,
 			Ctx:           &ctx,
@@ -1154,6 +1155,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 		subNodeAgentStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 			AgentName:     "nodeagent",
+			MyAgentName:   agentName,
 			TopicImpl:     types.NodeAgentStatus{},
 			Activate:      false,
 			Ctx:           &ctx,
@@ -1179,6 +1181,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		ctx.pubAttestQuote = pubAttestQuote
 		subAttestNonce, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 			AgentName:     "zedagent",
+			MyAgentName:   agentName,
 			TopicImpl:     types.AttestNonce{},
 			Activate:      false,
 			Ctx:           &ctx,

--- a/pkg/pillar/cmd/tpmmgr/tpmmgr.go
+++ b/pkg/pillar/cmd/tpmmgr/tpmmgr.go
@@ -1060,9 +1060,6 @@ func Run(ps *pubsub.PubSub) int {
 		logrus.SetLevel(logrus.InfoLevel)
 	}
 
-	// XXX Make logrus record a noticable global source
-	agentlog.Init("xyzzy-" + agentName)
-
 	// Sending json log format to stdout
 	log = agentlog.Init("tpmmgr")
 

--- a/pkg/pillar/cmd/upgradeconverter/upgradeconverter.go
+++ b/pkg/pillar/cmd/upgradeconverter/upgradeconverter.go
@@ -109,9 +109,6 @@ func Run(ps *pubsub.PubSub) int {
 		logrus.SetLevel(logrus.InfoLevel)
 	}
 
-	// XXX Make logrus record a noticable global source
-	agentlog.Init("xyzzy-" + ctx.agentName)
-
 	log = agentlog.Init(ctx.agentName)
 	if err := pidfile.CheckAndCreatePidfile(log, ctx.agentName); err != nil {
 		log.Fatal(err)

--- a/pkg/pillar/cmd/upgradeconverter/upgradeconverter.go
+++ b/pkg/pillar/cmd/upgradeconverter/upgradeconverter.go
@@ -6,7 +6,6 @@ package upgradeconverter
 import (
 	"flag"
 
-	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
@@ -86,10 +85,13 @@ func runHandlers(ctxPtr *ucContext) {
 	}
 }
 
+var logger *logrus.Logger
 var log *base.LogObject
 
 // Run - runs the main upgradeconverter process
-func Run(ps *pubsub.PubSub) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) int {
+	logger = loggerArg
+	log = logArg
 	ctx := &ucContext{agentName: "upgradeconverter",
 		persistDir:       types.PersistDir,
 		persistConfigDir: types.PersistConfigDir,
@@ -104,12 +106,10 @@ func Run(ps *pubsub.PubSub) int {
 	ctx.persistDir = *persistPtr // XXX remove? Or use for tests?
 	ctx.noFlag = *noFlagPtr
 	if ctx.debugOverride {
-		logrus.SetLevel(logrus.DebugLevel)
+		logger.SetLevel(logrus.DebugLevel)
 	} else {
-		logrus.SetLevel(logrus.InfoLevel)
+		logger.SetLevel(logrus.InfoLevel)
 	}
-
-	log = agentlog.Init(ctx.agentName)
 	if err := pidfile.CheckAndCreatePidfile(log, ctx.agentName); err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/pillar/cmd/upgradeconverter/upgradeconverter_test.go
+++ b/pkg/pillar/cmd/upgradeconverter/upgradeconverter_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/sirupsen/logrus"
 )
 
 type testEntry struct {
@@ -49,6 +50,7 @@ func newConfigItemValueMap() types.ConfigItemValueMap {
 		types.TS_ENABLED)
 	config.SetGlobalValueString(types.DefaultLogLevel, "warn")
 	config.SetAgentSettingStringValue("zedagent", types.LogLevel, "debug")
+
 	config.SetAgentSettingStringValue("zedagent", types.RemoteLogLevel, "crit")
 	return *config
 }
@@ -101,7 +103,6 @@ func checkNoDir(t *testing.T, dir string) {
 func ucContextForTest() *ucContext {
 	//log.SetLevel(log.DebugLevel)
 	var err error
-	log = base.NewSourceLogObject("upgradeconverter", 0)
 	ctxPtr := &ucContext{}
 	ctxPtr.persistDir, err = ioutil.TempDir(".", "PersistDir")
 	if err != nil {
@@ -128,6 +129,7 @@ func ucContextCleanupDirs(ctxPtr *ucContext) {
 }
 
 func runTestMatrix(t *testing.T, testMatrix map[string]testEntry) {
+	log = base.NewSourceLogObject(logrus.StandardLogger(), "domainmgr", 0)
 	oldConfig := oldGlobalConfig()
 	newConfig := newConfigItemValueMap()
 

--- a/pkg/pillar/cmd/vaultmgr/vaultmgr.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgr.go
@@ -549,9 +549,6 @@ func Run(ps *pubsub.PubSub) int {
 		logrus.SetLevel(logrus.InfoLevel)
 	}
 
-	// XXX Make logrus record a noticable global source
-	agentlog.Init("xyzzy-" + agentName)
-
 	// Sending json log format to stdout
 	log = agentlog.Init(agentName)
 

--- a/pkg/pillar/cmd/vaultmgr/vaultmgr.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgr.go
@@ -590,6 +590,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		// Look for global config such as log levels
 		subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 			AgentName:     "",
+			MyAgentName:   agentName,
 			TopicImpl:     types.ConfigItemValueMap{},
 			Activate:      false,
 			Ctx:           &ctx,

--- a/pkg/pillar/cmd/verifier/verifier.go
+++ b/pkg/pillar/cmd/verifier/verifier.go
@@ -65,21 +65,22 @@ type verifierContext struct {
 
 var debug = false
 var debugOverride bool // From command line arg
+var logger *logrus.Logger
 var log *base.LogObject
 
-func Run(ps *pubsub.PubSub) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) int {
+	logger = loggerArg
+	log = logArg
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")
 	flag.Parse()
 	debug = *debugPtr
 	debugOverride = debug
 	if debugOverride {
-		logrus.SetLevel(logrus.DebugLevel)
+		logger.SetLevel(logrus.DebugLevel)
 	} else {
-		logrus.SetLevel(logrus.InfoLevel)
+		logger.SetLevel(logrus.InfoLevel)
 	}
-	log = agentlog.Init(agentName)
-
 	if *versionPtr {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
 		return 0
@@ -597,7 +598,7 @@ func handleGlobalConfigModify(ctxArg interface{}, key string,
 	log.Infof("handleGlobalConfigModify for %s", key)
 	var gcp *types.ConfigItemValueMap
 	debug, gcp = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
-		debugOverride)
+		debugOverride, logger)
 	if gcp != nil {
 		ctx.GCInitialized = true
 	}
@@ -614,7 +615,7 @@ func handleGlobalConfigDelete(ctxArg interface{}, key string,
 	}
 	log.Infof("handleGlobalConfigDelete for %s", key)
 	debug, _ = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
-		debugOverride)
+		debugOverride, logger)
 	log.Infof("handleGlobalConfigDelete done for %s", key)
 }
 

--- a/pkg/pillar/cmd/verifier/verifier.go
+++ b/pkg/pillar/cmd/verifier/verifier.go
@@ -78,9 +78,6 @@ func Run(ps *pubsub.PubSub) int {
 	} else {
 		logrus.SetLevel(logrus.InfoLevel)
 	}
-	// XXX Make logrus record a noticable global source
-	agentlog.Init("xyzzy-" + agentName)
-
 	log = agentlog.Init(agentName)
 
 	if *versionPtr {

--- a/pkg/pillar/cmd/verifier/verifier.go
+++ b/pkg/pillar/cmd/verifier/verifier.go
@@ -114,6 +114,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "",
+		MyAgentName:   agentName,
 		TopicImpl:     types.ConfigItemValueMap{},
 		Activate:      false,
 		Ctx:           &ctx,
@@ -131,6 +132,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	subVerifyImageConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "volumemgr",
+		MyAgentName:   agentName,
 		TopicImpl:     types.VerifyImageConfig{},
 		Activate:      false,
 		Ctx:           &ctx,

--- a/pkg/pillar/cmd/volumemgr/handlevolume_test.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume_test.go
@@ -13,10 +13,11 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/sirupsen/logrus"
 )
 
 func TestIsErrorSourceOnPubSub(t *testing.T) {
-	log = base.NewSourceLogObject("volumemgr", 0)
+	log = base.NewSourceLogObject(logrus.StandardLogger(), "volumemgr", 0)
 	status := &types.VolumeStatus{}
 	errStr := "test1"
 	status.SetErrorWithSource(errStr, types.ContentTreeStatus{}, time.Now())
@@ -39,8 +40,9 @@ func TestIsErrorSourceOnPubSub(t *testing.T) {
 
 func initStatusCtx(t *testing.T) volumemgrContext {
 	ctx := volumemgrContext{}
-	log = base.NewSourceLogObject("volumemgr", 0)
-	ps := pubsub.New(&pubsub.EmptyDriver{}, log)
+	logger := logrus.StandardLogger()
+	log = base.NewSourceLogObject(logger, "test", 1234)
+	ps := pubsub.New(&pubsub.EmptyDriver{}, logger, log)
 
 	pubVolumeStatus, err := ps.NewPublication(pubsub.PublicationOptions{
 		AgentName:  agentName,

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -105,9 +105,6 @@ func Run(ps *pubsub.PubSub) int {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
 		return 0
 	}
-	// XXX Make logrus record a noticable global source
-	agentlog.Init("xyzzy-" + agentName)
-
 	log = agentlog.Init(agentName)
 
 	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -129,6 +129,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "",
+		MyAgentName:   agentName,
 		TopicImpl:     types.ConfigItemValueMap{},
 		Activate:      false,
 		Ctx:           &ctx,
@@ -255,6 +256,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Look for global config such as log levels
 	subZedAgentStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "zedagent",
+		MyAgentName:   agentName,
 		TopicImpl:     types.ZedAgentStatus{},
 		Activate:      false,
 		Ctx:           &ctx,
@@ -272,6 +274,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Look for DownloaderStatus from downloader
 	subDownloaderStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "downloader",
+		MyAgentName:   agentName,
 		TopicImpl:     types.DownloaderStatus{},
 		Activate:      false,
 		Ctx:           &ctx,
@@ -290,6 +293,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Look for VerifyImageStatus from verifier
 	subVerifyImageStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:      "verifier",
+		MyAgentName:    agentName,
 		TopicImpl:      types.VerifyImageStatus{},
 		Activate:       false,
 		Ctx:            &ctx,
@@ -310,6 +314,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	subCertObjConfig, err := ps.NewSubscription(
 		pubsub.SubscriptionOptions{
 			AgentName:     "zedagent",
+			MyAgentName:   agentName,
 			TopicImpl:     types.CertObjConfig{},
 			Activate:      false,
 			Ctx:           &ctx,
@@ -328,6 +333,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Look for ResolveStatus from downloader
 	subResolveStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "downloader",
+		MyAgentName:   agentName,
 		TopicImpl:     types.ResolveStatus{},
 		Activate:      false,
 		Ctx:           &ctx,
@@ -350,6 +356,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		WarningTime:    warningTime,
 		ErrorTime:      errorTime,
 		AgentName:      "zedagent",
+		MyAgentName:    agentName,
 		TopicImpl:      types.ContentTreeConfig{},
 		Ctx:            &ctx,
 	})
@@ -366,6 +373,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		WarningTime:   warningTime,
 		ErrorTime:     errorTime,
 		AgentName:     "zedagent",
+		MyAgentName:   agentName,
 		TopicImpl:     types.VolumeConfig{},
 		Ctx:           &ctx,
 	})
@@ -383,6 +391,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		ErrorTime:     errorTime,
 		AgentName:     "zedmanager",
 		AgentScope:    types.AppImgObj,
+		MyAgentName:   agentName,
 		TopicImpl:     types.VolumeRefConfig{},
 		Ctx:           &ctx,
 	})
@@ -399,6 +408,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		WarningTime:   warningTime,
 		ErrorTime:     errorTime,
 		AgentName:     "baseosmgr",
+		MyAgentName:   agentName,
 		TopicImpl:     types.ContentTreeConfig{},
 		Ctx:           &ctx,
 	})

--- a/pkg/pillar/cmd/waitforaddr/waitforaddr.go
+++ b/pkg/pillar/cmd/waitforaddr/waitforaddr.go
@@ -60,9 +60,6 @@ func Run(ps *pubsub.PubSub) int {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
 		return 0
 	}
-	// XXX Make logrus record a noticable global source
-	agentlog.Init("xyzzy-" + agentName)
-
 	log = agentlog.Init(agentName)
 	if !noPidFlag {
 		if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {

--- a/pkg/pillar/cmd/waitforaddr/waitforaddr.go
+++ b/pkg/pillar/cmd/waitforaddr/waitforaddr.go
@@ -77,6 +77,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	subDeviceNetworkStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "nim",
+		MyAgentName:   agentName,
 		TopicImpl:     types.DeviceNetworkStatus{},
 		Activate:      false,
 		Ctx:           &DNSctx,

--- a/pkg/pillar/cmd/waitforaddr/waitforaddr.go
+++ b/pkg/pillar/cmd/waitforaddr/waitforaddr.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
@@ -41,9 +40,12 @@ type DNSContext struct {
 
 var debug = false
 var debugOverride bool // From command line arg
+var logger *logrus.Logger
 var log *base.LogObject
 
-func Run(ps *pubsub.PubSub) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) int {
+	logger = loggerArg
+	log = logArg
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")
 	noPidPtr := flag.Bool("p", false, "Do not check for running agent")
@@ -51,16 +53,15 @@ func Run(ps *pubsub.PubSub) int {
 	debug = *debugPtr
 	debugOverride = debug
 	if debugOverride {
-		logrus.SetLevel(logrus.DebugLevel)
+		logger.SetLevel(logrus.DebugLevel)
 	} else {
-		logrus.SetLevel(logrus.InfoLevel)
+		logger.SetLevel(logrus.InfoLevel)
 	}
 	noPidFlag := *noPidPtr
 	if *versionPtr {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
 		return 0
 	}
-	log = agentlog.Init(agentName)
 	if !noPidFlag {
 		if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
 			log.Fatal(err)

--- a/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
+++ b/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
@@ -71,9 +71,6 @@ func Run(ps *pubsub.PubSub) int {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
 		return 0
 	}
-	// XXX Make logrus record a noticable global source
-	agentlog.Init("xyzzy-" + agentName)
-
 	log = agentlog.Init(agentName)
 	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
 		log.Fatal(err)

--- a/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
+++ b/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
@@ -54,24 +54,26 @@ type wstunnelclientContext struct {
 
 var debug = false
 var debugOverride bool // From command line arg
+var logger *logrus.Logger
 var log *base.LogObject
 
-func Run(ps *pubsub.PubSub) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) int {
+	logger = loggerArg
+	log = logArg
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")
 	flag.Parse()
 	debug = *debugPtr
 	debugOverride = debug
 	if debugOverride {
-		logrus.SetLevel(logrus.DebugLevel)
+		logger.SetLevel(logrus.DebugLevel)
 	} else {
-		logrus.SetLevel(logrus.InfoLevel)
+		logger.SetLevel(logrus.InfoLevel)
 	}
 	if *versionPtr {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
 		return 0
 	}
-	log = agentlog.Init(agentName)
 	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
 		log.Fatal(err)
 	}
@@ -217,7 +219,7 @@ func handleGlobalConfigModify(ctxArg interface{}, key string,
 	log.Infof("handleGlobalConfigModify for %s\n", key)
 	var gcp *types.ConfigItemValueMap
 	debug, gcp = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
-		debugOverride)
+		debugOverride, logger)
 	if gcp != nil {
 		ctx.GCInitialized = true
 	}
@@ -234,7 +236,7 @@ func handleGlobalConfigDelete(ctxArg interface{}, key string,
 	}
 	log.Infof("handleGlobalConfigDelete for %s\n", key)
 	debug, _ = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
-		debugOverride)
+		debugOverride, logger)
 	log.Infof("handleGlobalConfigDelete done for %s\n", key)
 }
 

--- a/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
+++ b/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
@@ -93,6 +93,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "",
+		MyAgentName:   agentName,
 		TopicImpl:     types.ConfigItemValueMap{},
 		Activate:      false,
 		Ctx:           &wscCtx,
@@ -110,6 +111,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	subDeviceNetworkStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "nim",
+		MyAgentName:   agentName,
 		TopicImpl:     types.DeviceNetworkStatus{},
 		Activate:      false,
 		Ctx:           &DNSctx,
@@ -129,6 +131,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// XXX is it better to look for AppInstanceStatus from zedmanager?
 	subAppInstanceConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "zedagent",
+		MyAgentName:   agentName,
 		TopicImpl:     types.AppInstanceConfig{},
 		Activate:      false,
 		Ctx:           &wscCtx,

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -179,9 +179,6 @@ func Run(ps *pubsub.PubSub) int {
 		}
 		return 0
 	}
-	// XXX Make logrus record a noticable global source
-	agentlog.Init("xyzzy-" + agentName)
-
 	log = agentlog.Init(agentName)
 	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
 		log.Fatal(err)

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -131,10 +131,13 @@ type zedagentContext struct {
 var debug = false
 var debugOverride bool // From command line arg
 var flowQ *list.List
+var logger *logrus.Logger
 var log *base.LogObject
 var zedcloudCtx *zedcloud.ZedCloudContext
 
-func Run(ps *pubsub.PubSub) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) int {
+	logger = loggerArg
+	log = logArg
 	var err error
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")
@@ -148,9 +151,9 @@ func Run(ps *pubsub.PubSub) int {
 	fatalFlag := *fatalPtr
 	hangFlag := *hangPtr
 	if debugOverride {
-		logrus.SetLevel(logrus.DebugLevel)
+		logger.SetLevel(logrus.DebugLevel)
 	} else {
-		logrus.SetLevel(logrus.InfoLevel)
+		logger.SetLevel(logrus.InfoLevel)
 	}
 	parse := *parsePtr
 	validate := *validatePtr
@@ -179,7 +182,6 @@ func Run(ps *pubsub.PubSub) int {
 		}
 		return 0
 	}
-	log = agentlog.Init(agentName)
 	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
 		log.Fatal(err)
 	}
@@ -1357,7 +1359,7 @@ func handleGlobalConfigModify(ctxArg interface{}, key string,
 	log.Infof("handleGlobalConfigModify for %s", key)
 	var gcp *types.ConfigItemValueMap
 	debug, gcp = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
-		debugOverride)
+		debugOverride, logger)
 	if gcp != nil && !ctx.GCInitialized {
 		ctx.globalConfig = *gcp
 		ctx.GCInitialized = true
@@ -1375,7 +1377,7 @@ func handleGlobalConfigDelete(ctxArg interface{}, key string,
 	}
 	log.Infof("handleGlobalConfigDelete for %s", key)
 	debug, _ = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
-		debugOverride)
+		debugOverride, logger)
 	ctx.globalConfig = *types.DefaultConfigItemValueMap()
 	log.Infof("handleGlobalConfigDelete done for %s", key)
 }

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -259,6 +259,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	subAssignableAdapters, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "domainmgr",
+		MyAgentName:   agentName,
 		TopicImpl:     types.AssignableAdapters{},
 		Activate:      false,
 		Ctx:           &zedagentCtx,
@@ -416,6 +417,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "",
+		MyAgentName:   agentName,
 		TopicImpl:     types.ConfigItemValueMap{},
 		Activate:      false,
 		Ctx:           &zedagentCtx,
@@ -433,6 +435,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	subNetworkInstanceStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "zedrouter",
+		MyAgentName:   agentName,
 		TopicImpl:     types.NetworkInstanceStatus{},
 		Activate:      false,
 		Ctx:           &zedagentCtx,
@@ -450,6 +453,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	subNetworkInstanceMetrics, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "zedrouter",
+		MyAgentName:   agentName,
 		TopicImpl:     types.NetworkInstanceMetrics{},
 		Activate:      false,
 		Ctx:           &zedagentCtx,
@@ -467,6 +471,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	subAppFlowMonitor, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "zedrouter",
+		MyAgentName:   agentName,
 		TopicImpl:     types.IPFlow{},
 		Activate:      false,
 		Ctx:           &zedagentCtx,
@@ -485,6 +490,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	subAppVifIPTrig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "zedrouter",
+		MyAgentName:   agentName,
 		TopicImpl:     types.VifIPTrig{},
 		Activate:      false,
 		Ctx:           &zedagentCtx,
@@ -501,6 +507,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Look for AppInstanceStatus from zedmanager
 	subAppInstanceStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "zedmanager",
+		MyAgentName:   agentName,
 		TopicImpl:     types.AppInstanceStatus{},
 		Activate:      false,
 		Ctx:           &zedagentCtx,
@@ -519,6 +526,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Look for ContentTreeStatus from volumemgr
 	subContentTreeStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "volumemgr",
+		MyAgentName:   agentName,
 		AgentScope:    types.AppImgObj,
 		TopicImpl:     types.ContentTreeStatus{},
 		Activate:      false,
@@ -538,6 +546,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Look for VolumeStatus from volumemgr
 	subVolumeStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "volumemgr",
+		MyAgentName:   agentName,
 		AgentScope:    types.AppImgObj,
 		TopicImpl:     types.VolumeStatus{},
 		Activate:      false,
@@ -557,6 +566,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Look for DomainMetric from domainmgr
 	subDomainMetric, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:   "domainmgr",
+		MyAgentName: agentName,
 		TopicImpl:   types.DomainMetric{},
 		Activate:    true,
 		Ctx:         &zedagentCtx,
@@ -570,6 +580,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	subHostMemory, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:   "domainmgr",
+		MyAgentName: agentName,
 		TopicImpl:   types.HostMemory{},
 		Activate:    true,
 		Ctx:         &zedagentCtx,
@@ -584,6 +595,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Look for zboot status
 	subZbootStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:      "baseosmgr",
+		MyAgentName:    agentName,
 		TopicImpl:      types.ZbootStatus{},
 		Activate:       false,
 		Ctx:            &zedagentCtx,
@@ -603,6 +615,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// sub AppContainerMetrics from zedrouter
 	subAppContainerMetrics, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "zedrouter",
+		MyAgentName:   agentName,
 		TopicImpl:     types.AppContainerMetrics{},
 		Activate:      false,
 		Ctx:           &zedagentCtx,
@@ -619,6 +632,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	subBaseOsStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "baseosmgr",
+		MyAgentName:   agentName,
 		TopicImpl:     types.BaseOsStatus{},
 		Activate:      false,
 		Ctx:           &zedagentCtx,
@@ -636,6 +650,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	subEdgeNodeCert, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "tpmmgr",
+		MyAgentName:   agentName,
 		TopicImpl:     types.EdgeNodeCert{},
 		Activate:      false,
 		Ctx:           &zedagentCtx,
@@ -652,6 +667,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	subVaultStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "vaultmgr",
+		MyAgentName:   agentName,
 		TopicImpl:     types.VaultStatus{},
 		Activate:      false,
 		Ctx:           &zedagentCtx,
@@ -668,6 +684,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	subAttestQuote, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "tpmmgr",
+		MyAgentName:   agentName,
 		TopicImpl:     types.AttestQuote{},
 		Activate:      false,
 		Ctx:           &zedagentCtx,
@@ -685,6 +702,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Look for nodeagent status
 	subNodeAgentStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "nodeagent",
+		MyAgentName:   agentName,
 		TopicImpl:     types.NodeAgentStatus{},
 		Activate:      false,
 		Ctx:           &getconfigCtx,
@@ -702,6 +720,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	DNSctx := DNSContext{}
 	subDeviceNetworkStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "nim",
+		MyAgentName:   agentName,
 		TopicImpl:     types.DeviceNetworkStatus{},
 		Activate:      false,
 		Ctx:           &DNSctx,
@@ -718,6 +737,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	subDevicePortConfigList, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "nim",
+		MyAgentName:   agentName,
 		TopicImpl:     types.DevicePortConfigList{},
 		Activate:      false,
 		Ctx:           &zedagentCtx,
@@ -734,6 +754,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	subBlobStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "volumemgr",
+		MyAgentName:   agentName,
 		TopicImpl:     types.BlobStatus{},
 		Activate:      false,
 		Ctx:           &zedagentCtx,
@@ -751,10 +772,11 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	// Subscribe to Log metrics from logmanager
 	subLogMetrics, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName: "logmanager",
-		TopicImpl: types.LogMetrics{},
-		Activate:  false,
-		Ctx:       &zedagentCtx,
+		AgentName:   "logmanager",
+		MyAgentName: agentName,
+		TopicImpl:   types.LogMetrics{},
+		Activate:    false,
+		Ctx:         &zedagentCtx,
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -867,10 +889,11 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	// Subscribe to network metrics from zedrouter
 	subNetworkMetrics, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName: "zedrouter",
-		TopicImpl: types.NetworkMetrics{},
-		Activate:  true,
-		Ctx:       &zedagentCtx,
+		AgentName:   "zedrouter",
+		MyAgentName: agentName,
+		TopicImpl:   types.NetworkMetrics{},
+		Activate:    true,
+		Ctx:         &zedagentCtx,
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -878,56 +901,62 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Subscribe to cloud metrics from different agents
 	cms := zedcloud.GetCloudMetrics(log)
 	subClientMetrics, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName: "zedclient",
-		TopicImpl: cms,
-		Activate:  true,
-		Ctx:       &zedagentCtx,
+		AgentName:   "zedclient",
+		MyAgentName: agentName,
+		TopicImpl:   cms,
+		Activate:    true,
+		Ctx:         &zedagentCtx,
 	})
 	if err != nil {
 		log.Fatal(err)
 	}
 	subLogmanagerMetrics, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName: "logmanager",
-		TopicImpl: cms,
-		Activate:  true,
-		Ctx:       &zedagentCtx,
+		AgentName:   "logmanager",
+		MyAgentName: agentName,
+		TopicImpl:   cms,
+		Activate:    true,
+		Ctx:         &zedagentCtx,
 	})
 	if err != nil {
 		log.Fatal(err)
 	}
 	subDownloaderMetrics, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName: "downloader",
-		TopicImpl: cms,
-		Activate:  true,
-		Ctx:       &zedagentCtx,
+		AgentName:   "downloader",
+		MyAgentName: agentName,
+		TopicImpl:   cms,
+		Activate:    true,
+		Ctx:         &zedagentCtx,
 	})
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	subCipherMetricsDL, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName: "downloader",
-		TopicImpl: types.CipherMetricsMap{},
-		Activate:  true,
-		Ctx:       &zedagentCtx,
+		AgentName:   "downloader",
+		MyAgentName: agentName,
+		TopicImpl:   types.CipherMetricsMap{},
+		Activate:    true,
+		Ctx:         &zedagentCtx,
 	})
 	if err != nil {
 		log.Fatal(err)
 	}
 	subCipherMetricsDM, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName: "domainmgr",
-		TopicImpl: types.CipherMetricsMap{},
-		Activate:  true,
-		Ctx:       &zedagentCtx,
+		AgentName:   "domainmgr",
+		MyAgentName: agentName,
+		TopicImpl:   types.CipherMetricsMap{},
+		Activate:    true,
+		Ctx:         &zedagentCtx,
 	})
 	if err != nil {
 		log.Fatal(err)
 	}
 	subCipherMetricsNim, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName: "nim",
-		TopicImpl: types.CipherMetricsMap{},
-		Activate:  true,
-		Ctx:       &zedagentCtx,
+		AgentName:   "nim",
+		MyAgentName: agentName,
+		TopicImpl:   types.CipherMetricsMap{},
+		Activate:    true,
+		Ctx:         &zedagentCtx,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -139,6 +139,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "",
+		MyAgentName:   agentName,
 		TopicImpl:     types.ConfigItemValueMap{},
 		Activate:      false,
 		Ctx:           &ctx,
@@ -157,6 +158,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Get AppInstanceConfig from zedagent
 	subAppInstanceConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:      "zedagent",
+		MyAgentName:    agentName,
 		TopicImpl:      types.AppInstanceConfig{},
 		Activate:       false,
 		Ctx:            &ctx,
@@ -176,6 +178,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Look for VolumeRefStatus from volumemgr
 	subVolumeRefStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "volumemgr",
+		MyAgentName:   agentName,
 		AgentScope:    types.AppImgObj,
 		TopicImpl:     types.VolumeRefStatus{},
 		Activate:      false,
@@ -195,6 +198,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Get AppNetworkStatus from zedrouter
 	subAppNetworkStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:      "zedrouter",
+		MyAgentName:    agentName,
 		TopicImpl:      types.AppNetworkStatus{},
 		Activate:       false,
 		Ctx:            &ctx,
@@ -214,6 +218,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Get DomainStatus from domainmgr
 	subDomainStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "domainmgr",
+		MyAgentName:   agentName,
 		TopicImpl:     types.DomainStatus{},
 		Activate:      false,
 		Ctx:           &ctx,

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -51,25 +51,26 @@ type zedmanagerContext struct {
 
 var debug = false
 var debugOverride bool // From command line arg
+var logger *logrus.Logger
 var log *base.LogObject
 
-func Run(ps *pubsub.PubSub) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) int {
+	logger = loggerArg
+	log = logArg
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")
 	flag.Parse()
 	debug = *debugPtr
 	debugOverride = debug
 	if debugOverride {
-		logrus.SetLevel(logrus.DebugLevel)
+		logger.SetLevel(logrus.DebugLevel)
 	} else {
-		logrus.SetLevel(logrus.InfoLevel)
+		logger.SetLevel(logrus.InfoLevel)
 	}
 	if *versionPtr {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
 		return 0
 	}
-	log = agentlog.Init(agentName)
-
 	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
 		log.Fatal(err)
 	}
@@ -658,7 +659,7 @@ func handleGlobalConfigModify(ctxArg interface{}, key string,
 	log.Infof("handleGlobalConfigModify for %s", key)
 	var gcp *types.ConfigItemValueMap
 	debug, gcp = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
-		debugOverride)
+		debugOverride, logger)
 	if gcp != nil {
 		ctx.globalConfig = gcp
 		ctx.GCInitialized = true
@@ -676,7 +677,7 @@ func handleGlobalConfigDelete(ctxArg interface{}, key string,
 	}
 	log.Infof("handleGlobalConfigDelete for %s", key)
 	debug, _ = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
-		debugOverride)
+		debugOverride, logger)
 	*ctx.globalConfig = *types.DefaultConfigItemValueMap()
 	log.Infof("handleGlobalConfigDelete done for %s", key)
 }

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -68,9 +68,6 @@ func Run(ps *pubsub.PubSub) int {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
 		return 0
 	}
-	// XXX Make logrus record a noticable global source
-	agentlog.Init("xyzzy-" + agentName)
-
 	log = agentlog.Init(agentName)
 
 	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -88,25 +88,26 @@ type zedrouterContext struct {
 
 var debug = false
 var debugOverride bool // From command line arg
+var logger *logrus.Logger
 var log *base.LogObject
 
-func Run(ps *pubsub.PubSub) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) int {
+	logger = loggerArg
+	log = logArg
 	versionPtr := flag.Bool("v", false, "Version")
 	debugPtr := flag.Bool("d", false, "Debug flag")
 	flag.Parse()
 	debug = *debugPtr
 	debugOverride = debug
 	if debugOverride {
-		logrus.SetLevel(logrus.DebugLevel)
+		logger.SetLevel(logrus.DebugLevel)
 	} else {
-		logrus.SetLevel(logrus.InfoLevel)
+		logger.SetLevel(logrus.InfoLevel)
 	}
 	if *versionPtr {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
 		return 0
 	}
-	log = agentlog.Init(agentName)
-
 	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
 		log.Fatal(err)
 	}
@@ -1570,7 +1571,7 @@ func handleGlobalConfigModify(ctxArg interface{}, key string,
 	log.Infof("handleGlobalConfigModify for %s\n", key)
 	var gcp *types.ConfigItemValueMap
 	debug, gcp = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
-		debugOverride)
+		debugOverride, logger)
 	if gcp != nil {
 		ctx.GCInitialized = true
 		ctx.appStatsInterval = gcp.GlobalValueInt(types.AppContainerStatsInterval)
@@ -1588,7 +1589,7 @@ func handleGlobalConfigDelete(ctxArg interface{}, key string,
 	}
 	log.Infof("handleGlobalConfigDelete for %s\n", key)
 	debug, _ = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
-		debugOverride)
+		debugOverride, logger)
 	gcp := *types.DefaultConfigItemValueMap()
 	ctx.appStatsInterval = gcp.GlobalValueInt(types.AppContainerStatsInterval)
 	log.Infof("handleGlobalConfigDelete done for %s\n", key)

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -105,9 +105,6 @@ func Run(ps *pubsub.PubSub) int {
 		fmt.Printf("%s: %s\n", os.Args[0], Version)
 		return 0
 	}
-	// XXX Make logrus record a noticable global source
-	agentlog.Init("xyzzy-" + agentName)
-
 	log = agentlog.Init(agentName)
 
 	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -158,6 +158,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	subDeviceNetworkStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "nim",
+		MyAgentName:   agentName,
 		TopicImpl:     types.DeviceNetworkStatus{},
 		Activate:      false,
 		Ctx:           &zedrouterCtx,
@@ -175,6 +176,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	subAssignableAdapters, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "domainmgr",
+		MyAgentName:   agentName,
 		TopicImpl:     types.AssignableAdapters{},
 		Activate:      false,
 		Ctx:           &zedrouterCtx,
@@ -196,6 +198,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "",
+		MyAgentName:   agentName,
 		TopicImpl:     types.ConfigItemValueMap{},
 		Activate:      false,
 		Ctx:           &zedrouterCtx,
@@ -323,6 +326,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	subNetworkInstanceConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "zedagent",
+		MyAgentName:   agentName,
 		TopicImpl:     types.NetworkInstanceConfig{},
 		Activate:      false,
 		Ctx:           &zedrouterCtx,
@@ -342,6 +346,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Subscribe to AppNetworkConfig from zedmanager and from zedagent
 	subAppNetworkConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:      "zedmanager",
+		MyAgentName:    agentName,
 		TopicImpl:      types.AppNetworkConfig{},
 		Activate:       false,
 		Ctx:            &zedrouterCtx,
@@ -361,6 +366,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Subscribe to AppNetworkConfig from zedmanager
 	subAppNetworkConfigAg, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "zedagent",
+		MyAgentName:   agentName,
 		TopicImpl:     types.AppNetworkConfig{},
 		Activate:      false,
 		Ctx:           &zedrouterCtx,

--- a/pkg/pillar/devicenetwork/dnc_test.go
+++ b/pkg/pillar/devicenetwork/dnc_test.go
@@ -378,7 +378,7 @@ var testMatrix = map[string]compressDPCLTestEntry{
 
 func TestCompressDPCL(t *testing.T) {
 
-	log := base.NewSourceLogObject("test", 1234)
+	log := base.NewSourceLogObject(logrus.StandardLogger(), "test", 1234)
 	logrus.SetLevel(logrus.DebugLevel)
 
 	for testname, test := range testMatrix {

--- a/pkg/pillar/execlib/execlib.go
+++ b/pkg/pillar/execlib/execlib.go
@@ -65,6 +65,7 @@ func New(ps *pubsub.PubSub, log *base.LogObject, agentName string, executor stri
 	}
 	subExecStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "executor",
+		MyAgentName:   agentName,
 		TopicImpl:     types.ExecStatus{},
 		Ctx:           &handle,
 		CreateHandler: handleStatus,

--- a/pkg/pillar/go.mod
+++ b/pkg/pillar/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/eriknordmark/ipinfo v0.0.0-20190220084921-7ee0839158f9
 	github.com/eriknordmark/netlink v0.0.0-20190912172510-3b6b45309321
 	github.com/fsnotify/fsnotify v1.4.7
-	github.com/go-logfmt/logfmt v0.4.0 // indirect
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/gogo/googleapis v1.3.2 // indirect
 	github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0

--- a/pkg/pillar/pubsub/publish.go
+++ b/pkg/pillar/pubsub/publish.go
@@ -51,6 +51,7 @@ type PublicationImpl struct {
 	global      bool
 	defaultName string
 	updaterList *Updaters
+	logger      *logrus.Logger
 	log         *base.LogObject
 
 	driver DriverPublisher
@@ -99,7 +100,7 @@ func (pub *PublicationImpl) Publish(key string, item interface{}) error {
 	}
 	pub.km.key.Store(key, newItem)
 
-	if logrus.GetLevel() == logrus.DebugLevel {
+	if pub.logger.GetLevel() == logrus.DebugLevel {
 		pub.dump("after Publish")
 	}
 	pub.updatersNotify(name)
@@ -129,7 +130,7 @@ func (pub *PublicationImpl) Unpublish(key string) error {
 		return errors.New(errStr)
 	}
 	pub.km.key.Delete(key)
-	if logrus.GetLevel() == logrus.DebugLevel {
+	if pub.logger.GetLevel() == logrus.DebugLevel {
 		pub.dump("after Unpublish")
 	}
 	pub.updatersNotify(name)

--- a/pkg/pillar/pubsub/pubsub.go
+++ b/pkg/pillar/pubsub/pubsub.go
@@ -69,14 +69,16 @@ type keyMap struct {
 type PubSub struct {
 	driver      Driver
 	updaterList *Updaters
+	logger      *logrus.Logger
 	log         *base.LogObject
 }
 
 // New create a new `PubSub` with a given `Driver`.
-func New(driver Driver, logObj *base.LogObject) *PubSub {
+func New(driver Driver, logger *logrus.Logger, log *base.LogObject) *PubSub {
 	return &PubSub{
 		driver: driver,
-		log:    logObj,
+		logger: logger,
+		log:    log,
 	}
 }
 
@@ -110,6 +112,7 @@ func (p *PubSub) NewSubscription(options SubscriptionOptions) (Subscription, err
 		MaxProcessTimeWarn:  options.WarningTime,
 		MaxProcessTimeError: options.ErrorTime,
 		Persistent:          options.Persistent,
+		logger:              p.logger,
 		log:                 p.log,
 		myAgentName:         options.MyAgentName,
 		ps:                  p,
@@ -164,6 +167,7 @@ func (p *PubSub) NewPublication(options PublicationOptions) (Publication, error)
 		km:          keyMap{key: base.NewLockedStringMap()},
 		updaterList: p.updaterList,
 		defaultName: p.driver.DefaultName(),
+		logger:      p.logger,
 		log:         p.log,
 	}
 	// create the driver
@@ -178,8 +182,7 @@ func (p *PubSub) NewPublication(options PublicationOptions) (Publication, error)
 	pub.driver = driver
 
 	pub.populate()
-	// XXX logger vs. event question
-	if logrus.GetLevel() == logrus.DebugLevel {
+	if pub.logger.GetLevel() == logrus.DebugLevel {
 		pub.dump("after populate")
 	}
 	pub.log.Debugf("Publish(%s)\n", name)

--- a/pkg/pillar/pubsub/pubsub_test.go
+++ b/pkg/pillar/pubsub/pubsub_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -27,8 +28,9 @@ var (
 )
 
 func TestHandleModify(t *testing.T) {
-	log := base.NewSourceLogObject("test", 1234)
-	ps := New(&EmptyDriver{}, log)
+	logger := logrus.StandardLogger()
+	log := base.NewSourceLogObject(logger, "test", 1234)
+	ps := New(&EmptyDriver{}, logger, log)
 	sub, err := ps.NewSubscription(SubscriptionOptions{
 		AgentName:  agentName,
 		AgentScope: agentScope,

--- a/pkg/pillar/pubsub/smoke_test.go
+++ b/pkg/pillar/pubsub/smoke_test.go
@@ -10,11 +10,13 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub/socketdriver"
+	"github.com/sirupsen/logrus"
 )
 
 func foo() {
-	log := base.NewSourceLogObject("foo", 1234)
-	driver := socketdriver.SocketDriver{Log: log}
-	ps := pubsub.New(&driver, log)
+	logger := logrus.StandardLogger()
+	log := base.NewSourceLogObject(logger, "test", 1234)
+	driver := socketdriver.SocketDriver{Logger: logger, Log: log}
+	ps := pubsub.New(&driver, logger, log)
 	fmt.Println(ps)
 }

--- a/pkg/pillar/pubsub/socketdriver/driver.go
+++ b/pkg/pillar/pubsub/socketdriver/driver.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/sirupsen/logrus"
 )
 
 // Protocol over AF_UNIX or other IPC mechanism
@@ -55,7 +56,8 @@ const (
 
 // SocketDriver driver for pubsub using local unix-domain socket and files
 type SocketDriver struct {
-	Log *base.LogObject
+	Logger *logrus.Logger
+	Log    *base.LogObject
 }
 
 // Publisher return an implementation of `pubsub.DriverPublisher` for
@@ -149,6 +151,7 @@ func (s *SocketDriver) Publisher(global bool, name, topic string, persistent boo
 		updaters:       updaterList,
 		differ:         differ,
 		restarted:      restarted,
+		logger:         s.Logger,
 		log:            s.Log,
 	}, nil
 }
@@ -197,6 +200,7 @@ func (s *SocketDriver) Subscriber(global bool, name, topic string, persistent bo
 		topic:            topic,
 		sockName:         sockName,
 		C:                C,
+		logger:           s.Logger,
 		log:              s.Log,
 	}, nil
 }

--- a/pkg/pillar/pubsub/socketdriver/publish.go
+++ b/pkg/pillar/pubsub/socketdriver/publish.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
+	"github.com/sirupsen/logrus"
 )
 
 // Publisher implementation of `pubsub.DriverPublisher` for `SocketDriver`.
@@ -33,6 +34,7 @@ type Publisher struct {
 	updaters       *pubsub.Updaters
 	differ         pubsub.Differ
 	restarted      pubsub.Restarted
+	logger         *logrus.Logger
 	log            *base.LogObject
 }
 

--- a/pkg/pillar/pubsub/socketdriver/subscribe.go
+++ b/pkg/pillar/pubsub/socketdriver/subscribe.go
@@ -29,6 +29,7 @@ type Subscriber struct {
 	topic            string
 	dirName          string
 	C                chan<- pubsub.Change
+	logger           *logrus.Logger
 	log              *base.LogObject
 }
 
@@ -226,7 +227,7 @@ func (s *Subscriber) connectAndRead() (string, string, []byte) {
 				s.log.Errorln(errStr)
 				continue
 			}
-			if logrus.GetLevel() == logrus.DebugLevel {
+			if s.logger.GetLevel() == logrus.DebugLevel {
 				s.log.Debugf("connectAndRead(%s): delete type %s key %s\n", s.name, t, string(key))
 			}
 			return msg, string(key), nil
@@ -251,7 +252,7 @@ func (s *Subscriber) connectAndRead() (string, string, []byte) {
 				s.log.Errorln(errStr)
 				continue
 			}
-			if logrus.GetLevel() == logrus.DebugLevel {
+			if s.logger.GetLevel() == logrus.DebugLevel {
 				s.log.Debugf("connectAndRead(%s): update type %s key %s val %s\n", s.name, t, string(key), string(val))
 			}
 			return msg, string(key), val

--- a/pkg/pillar/pubsub/subscribe.go
+++ b/pkg/pillar/pubsub/subscribe.go
@@ -36,6 +36,7 @@ type SubscriptionImpl struct {
 	synchronized bool
 	driver       DriverSubscriber
 	defaultName  string
+	logger       *logrus.Logger
 	log          *base.LogObject
 	myAgentName  string // For logging
 	ps           *PubSub
@@ -219,7 +220,7 @@ func handleModify(ctxArg interface{}, key string, itemcb []byte) {
 		}
 	}
 	sub.km.key.Store(key, item)
-	if logrus.GetLevel() == logrus.DebugLevel {
+	if sub.logger.GetLevel() == logrus.DebugLevel {
 		sub.dump("after handleModify")
 	}
 	// Need a copy in case the caller will modify e.g., embedded maps
@@ -250,7 +251,7 @@ func handleDelete(ctxArg interface{}, key string) {
 	// DO NOT log Values. They may contain sensitive information.
 	sub.log.Debugf("pubsub.handleDelete(%s) key %s", name, key)
 	sub.km.key.Delete(key)
-	if logrus.GetLevel() == logrus.DebugLevel {
+	if sub.logger.GetLevel() == logrus.DebugLevel {
 		sub.dump("after handleDelete")
 	}
 	if sub.DeleteHandler != nil {

--- a/pkg/pillar/queuelock/queuelock_test.go
+++ b/pkg/pillar/queuelock/queuelock_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/sirupsen/logrus"
 )
 
 // enum values for work
@@ -37,7 +38,7 @@ func assertPanic(t *testing.T, f func()) {
 	f()
 }
 
-var log = base.NewSourceLogObject("test", 1234)
+var log = base.NewSourceLogObject(logrus.StandardLogger(), "test", 1234)
 
 func TestExtraExit(t *testing.T) {
 	h := NewQueueLock(log)

--- a/pkg/pillar/types/assignableadapters_test.go
+++ b/pkg/pillar/types/assignableadapters_test.go
@@ -8,6 +8,7 @@ import (
 
 	zcommon "github.com/lf-edge/eve/api/go/evecommon"
 	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -158,7 +159,7 @@ func TestIoBundleFromPhyAdapter(t *testing.T) {
 			FreeUplink: true,
 		},
 	}
-	log := base.NewSourceLogObject("test", 1234)
+	log := base.NewSourceLogObject(logrus.StandardLogger(), "test", 1234)
 	ibPtr := IoBundleFromPhyAdapter(log, phyAdapter)
 	assert.NotEqual(t, ibPtr, nil)
 	assert.Equal(t, IoType(phyAdapter.Ptype), ibPtr.Type)

--- a/pkg/pillar/worker/worker_test.go
+++ b/pkg/pillar/worker/worker_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/sirupsen/logrus"
 )
 
 var timestamp time.Time
@@ -48,7 +49,8 @@ func TestWork(t *testing.T) {
 		},
 	}
 	ctx := dummyContext{contextName: "testContext"}
-	worker := NewWorker(base.NewSourceLogObject("test", 1234),
+	worker := NewWorker(
+		base.NewSourceLogObject(logrus.StandardLogger(), "test", 1234),
 		dummyWorker, &ctx, 1)
 	for testname, test := range testMatrix {
 		t.Logf("Running test case %s", testname)
@@ -101,7 +103,8 @@ var sleep3 = dummyDescription{
 // TestLength verifies that the channel length causes delay
 func TestLength(t *testing.T) {
 	ctx := dummyContext{contextName: "testContext"}
-	worker := NewWorker(base.NewSourceLogObject("test", 1234),
+	worker := NewWorker(
+		base.NewSourceLogObject(logrus.StandardLogger(), "test", 1234),
 		dummyWorker, &ctx, 1)
 	testname := "testlength"
 


### PR DESCRIPTION
This stopped working when we introduced a single zedbox process since the logrus.SetLevel affects the global logrus.StandardLogger. 
So we introduce a logrus.Logger which we create per service, while still keeping the per agent base.LogObject which has the agentName and agentPid fields.

As part of this we make zedbox call agentlog.Init() for all cases, and pass that into the agent's Run() function.

The two first commits are cleanup in preparation and can be reviewed separately.