### PR TITLE
handle missing blobs more resiliently on load

### DIFF
--- a/pkg/pillar/cmd/volumemgr/blob.go
+++ b/pkg/pillar/cmd/volumemgr/blob.go
@@ -486,7 +486,12 @@ func populateInitBlobStatus(ctx *volumemgrContext) {
 	}
 	newBlobStatus := make([]*types.BlobStatus, 0)
 	for _, blobInfo := range blobInfoList {
-		mediaType := mediaMap[blobInfo.Digest]
+		mediaType, ok := mediaMap[blobInfo.Digest]
+		if !ok {
+			// if we could not find the media type, we do not know what this blob is, so we ignore it
+			log.Infof("populateInitBlobStatus: blob %s in CAS could not get mediaType", blobInfo.Digest)
+			continue
+		}
 		if lookupBlobStatus(ctx, blobInfo.Digest) == nil {
 			log.Infof("populateInitBlobStatus: Found blob %s in CAS", blobInfo.Digest)
 			blobStatus := &types.BlobStatus{


### PR DESCRIPTION
Beforehand, when we used containerd to create the hashmap of blobs to media-types, if any attempt to resolve a blob failed, the caller would error back. This doesn't make sense, since the rest of them might be very useful, and we might not even need this one.

Instead, if we cannot resolve a single blob, manifest or index, it logs an error and continues.

The consuming client, on the other hand, will not create a `BlobStatus` if it cannot find the media type in the hashmap.

cc @nordmark @zed-rishabh @adarsh-zededa 