### PR TITLE
Fix: AppInst in error state temporarily after EVE reboot.

### DIFF
--- a/pkg/xen-tools/xen-info
+++ b/pkg/xen-tools/xen-info
@@ -9,7 +9,15 @@ bail() {
 [ $# -ne 1 ] && bail "Usage: $0 <domain name>"
 
 # find the domain
+# Sometimes after EVE reboot, we called xen-info before xen-start finished executing,
+# which led to domian not found error. To prevent that, we wait for sometime for the domain to come up.
+waited=0
 ID=$(xl domid "$1" 2>/dev/null)
+while [ -z "$ID" ] && [ "$waited" -lt 60 ]; do
+        ID=$(xl domid "$1" 2>/dev/null)
+        sleep 3
+        waited=$((waited + 3))
+done
 [ -z "$ID" ] && bail "Couldn't find domain ID for domain $1"
 
 # we expect to get rbpscd where every letter can also be a dash (-)


### PR DESCRIPTION
Issue:
AppInstance we noticed to be in an error state after EVE reboot.

Cause:
Post reboot, in domainMgr.doActivaleTail() after we started the app here, the domain was not created by the time we checked that app’s info (here). Because of which xen-info was throwing this error level=error msg="xen-info output  Couldn't find domain ID for domain gcp-alpine-cont-1.3\n "
But later, in domainMgr.verifyStatus() we check again and by then the domain was created and the error goes away.

Fix:
In xen-info we wait for the domain to show-up if not found. 
We wait for 60s max and checking every 3s.

Signed-off-by: adarsh-zededa <adarsh@zededa.com>