### PR TITLE
Removing topic type appImg for VolumeRefs

### DIFF
--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -390,7 +390,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		WarningTime:   warningTime,
 		ErrorTime:     errorTime,
 		AgentName:     "zedmanager",
-		AgentScope:    types.AppImgObj,
 		MyAgentName:   agentName,
 		TopicImpl:     types.VolumeRefConfig{},
 		Ctx:           &ctx,

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -96,9 +96,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	pubAppInstanceStatus.ClearRestarted()
 
 	pubVolumeRefConfig, err := ps.NewPublication(pubsub.PublicationOptions{
-		AgentName:  agentName,
-		AgentScope: types.AppImgObj,
-		TopicType:  types.VolumeRefConfig{},
+		AgentName: agentName,
+		TopicType: types.VolumeRefConfig{},
 	})
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Removing topic type appImg from VolumeRefConfig/Status in zedmanager and
volumemgr

Signed-off-by: Rishabh Gupta <rgupta@zededa.com>