### PR TITLE
FIX: Report correct contentTree size

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -963,7 +963,7 @@ func PublishContentInfoToZedCloud(ctx *zedagentContext, uuid string,
 		}
 
 		ContentResourcesInfo := new(info.ContentResources)
-		ContentResourcesInfo.CurSizeBytes = ctStatus.MaxDownloadSize
+		ContentResourcesInfo.CurSizeBytes = uint64(ctStatus.TotalSize)
 		ReportContentInfo.Resources = ContentResourcesInfo
 
 		ReportContentInfo.Sha256 = ctStatus.ContentSha256


### PR DESCRIPTION
Issue:
ContentTree size was reported as 0 in the controller.

Reason:
After we download an image, we updated ContentTreeStatus.TotalSize but while publishing we sent ContentTreeStatus. MaxDownloadSize. 

cc @deitch @zed-rishabh 
Signed-off-by: adarsh-zededa <adarsh@zededa.com>