### PR TITLE
Have other agents wait for vault status(/persist/vault), before proceeding

### DIFF
--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/lf-edge/eve/pkg/pillar/utils"
 	"github.com/lf-edge/eve/pkg/pillar/zedUpload"
 	"github.com/lf-edge/eve/pkg/pillar/zedcloud"
 	uuid "github.com/satori/go.uuid"
@@ -117,6 +118,10 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	}
 	log.Infof("processed GlobalConfig")
 
+	if err := utils.WaitForVault(ps, agentName, warningTime, errorTime); err != nil {
+		log.Fatal(err)
+	}
+	log.Infof("processed Vault Status")
 	// First wait to have some management ports with addresses
 	// Looking at any management ports since we can do download over all
 	for types.CountLocalAddrAnyNoLinkLocal(ctx.deviceNetworkStatus) == 0 {

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -133,8 +133,8 @@ touch "$WATCHDOG_PID/zedbox.pid" "$WATCHDOG_FILE/zedbox.touch"
 
 if [ -c $TPM_DEVICE_PATH ] && ! [ -f $CONFIGDIR/disable-tpm ]; then
 #It is a device with TPM, enable disk encryption
-    if ! $BINDIR/vaultmgr setupVaults; then
-        echo "$(date -Ins -u) device-steps: vaultmgr setupVaults failed"
+    if ! $BINDIR/vaultmgr setupDeprecatedVaults; then
+        echo "$(date -Ins -u) device-steps: vaultmgr setupDeprecatedVaults failed"
     fi
 else
     if [ ! -d $PERSISTDIR/vault ]; then

--- a/pkg/pillar/utils/waitfor.go
+++ b/pkg/pillar/utils/waitfor.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	info "github.com/lf-edge/eve/api/go/info"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"time"
+)
+
+//Context is a helper struct used to pass around in pubsub handlers
+type Context struct {
+	Initialized bool
+}
+
+//WaitForVault waits till it receives types.VaultStatus msg, for types.DefaultVaultName
+//and the status does not indicate any error
+func WaitForVault(ps *pubsub.PubSub, agentName string, warningTime, errorTime time.Duration) error {
+	// Look for vault status
+	Ctx := &Context{}
+	subVaultStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:     "vaultmgr",
+		MyAgentName:   agentName,
+		TopicImpl:     types.VaultStatus{},
+		Activate:      false,
+		Ctx:           Ctx,
+		CreateHandler: handleVaultStatusModify,
+		ModifyHandler: handleVaultStatusModify,
+		WarningTime:   warningTime,
+		ErrorTime:     errorTime,
+	})
+	if err != nil {
+		return err
+	}
+
+	subVaultStatus.Activate()
+
+	// Run a periodic timer so we always update StillRunning
+	stillRunning := time.NewTicker(25 * time.Second)
+	ps.StillRunning(agentName, warningTime, errorTime)
+
+	// Wait for vault to be ready, which might be delayed due to attestation
+	for !Ctx.Initialized {
+		select {
+		case change := <-subVaultStatus.MsgChan():
+			subVaultStatus.ProcessChange(change)
+		case <-stillRunning.C:
+		}
+		ps.StillRunning(agentName, warningTime, errorTime)
+	}
+	return nil
+}
+
+func handleVaultStatusModify(ctxArg interface{}, key string,
+	statusArg interface{}) {
+
+	ctx := ctxArg.(*Context)
+	vault := statusArg.(types.VaultStatus)
+	if vault.Name == types.DefaultVaultName &&
+		vault.Status != info.DataSecAtRestStatus_DATASEC_AT_REST_ERROR {
+		ctx.Initialized = true
+	}
+}


### PR DESCRIPTION
- So far, it is driven through device-steps.sh
- This PR is in a step towards pushing that logic inside agents
- downloader/verifier/volumemgr now wait for vault status before
  starting any work
- vaultmgr is still called in device-steps twice, that is to handle
  upgrade from old images where /persist/img and /persist/config
  may be encrypted i.e. setupDeprecatedVaults will be removed once
  all the devices move to a sentinel release (with this change)
- This PR also sets up the stage, where /persist/vault may only be
  unlocked after attestation is successful

Signed-off-by: Hariharasubramanian C S <cshari@zededa.com>