### PR TITLE
Introducing a tiny black box collector

### DIFF
--- a/pkg/mkimage-raw-efi/Dockerfile
+++ b/pkg/mkimage-raw-efi/Dockerfile
@@ -4,7 +4,7 @@
 #   /EFI/BOOT/grub.cfg - Chainloads main bootloader
 #   /UsbInvocationScript.txt - Enables USB boot on Dell 3000 series
 #
-ARG BUILDER=lfedge/eve-alpine:3e3111a703366e9ac607d9c33d5fded006fa1df3
+ARG BUILDER=lfedge/eve-alpine:ac1dc159510afa61334222cedf085c7730e4583c
 FROM ${BUILDER} as initrd
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
@@ -35,7 +35,8 @@ RUN apk add --no-cache --initdb -p /out \
   e2fsprogs=1.44.5-r1       \
   util-linux=2.33-r0        \
   squashfs-tools=4.3-r5     \
-  coreutils=8.30-r0
+  coreutils=8.30-r0         \
+  tar=1.32-r0
 
 COPY make-raw install trampoline.grub.cfg grub.cfg.in UsbInvocationScript.txt /out/
 

--- a/pkg/mkimage-raw-efi/grub.cfg
+++ b/pkg/mkimage-raw-efi/grub.cfg
@@ -3,6 +3,10 @@ function installer_submenus {
       set_global dom0_extra_args "$dom0_extra_args rootdelay=30"
    }
 
+   menuentry 'do NOT install - collect black box instead' {
+      set_global dom0_cmdline "$dom0_cmdline eve_blackbox"
+   }
+
    menuentry 'pause before install' {
       set_global dom0_cmdline "$dom0_cmdline eve_pause_before_install"
    }

--- a/pkg/mkimage-raw-efi/install
+++ b/pkg/mkimage-raw-efi/install
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck shell=dash
 #
 # This script is an entry point for a standalone installer.
 # It is expected to probe for the destination installtion
@@ -17,7 +18,7 @@
 
 pause() {
    echo "Pausing before $1. Entering shell. Type 'exit' to proceed to $1"
-   exit 0
+   sh
 }
 
 bail() {
@@ -51,6 +52,20 @@ find_part() {
    for p in $PARTS ; do
       [ -f "/sys/block/$2/$p/dev" ] && echo "$p" && exit 0
    done
+}
+
+# mount_part PART_NAME DISK [mount opts]
+mount_part() {
+   local PART="$1"
+   local DISK="$2"
+   local ID
+   shift 2
+
+   ID="$(find_part "$PART" "$DISK")"
+   [ -z "$ID" ] && return 1
+
+   mkdir -p "/run/$PART"
+   mount "$@" "/dev/$ID" "/run/$PART"
 }
 
 # if we are running without a real root filesystem - we have to fake it here
@@ -107,40 +122,44 @@ mkdir -p /mnt || :
 mount -o ro /parts/rootfs.img /mnt &&
    /mnt/containers/onboot/*rngd/rootfs/sbin/rngd -1
 
-# do the install
-/make-raw "/dev/$INSTALL_DEV" || bail "Installation failed. Entering shell..."
+# do the install (unless we're only here to collect the black box)
+grep -q eve_blackbox /proc/cmdline || /make-raw "/dev/$INSTALL_DEV" || bail "Installation failed. Entering shell..."
 
-# generate a Soft Serial Number (if there isn't one)
-# SERIAL_NUM=$(uuidgen | sed -e 's#^.*-##')
-SERIAL_NUM=$(uuidgen)
-INVENTORY_PART=$(find_part INVENTORY "$(root_dev)")
-DEST_CONF_PART=$(find_part CONFIG "$INSTALL_DEV")
+# now the disk is ready - mount partitions
+mount_part P3 "$INSTALL_DEV" 2>/dev/null
+if mount_part CONFIG "$INSTALL_DEV" -t vfat -o iocharset=iso8859-1; then
+   # uuidgen | sed -e 's#^.*-##'
+   grep -q eve_blackbox /proc/cmdline || [ -f /run/CONFIG/soft_serial ] || uuidgen > /run/CONFIG/soft_serial
+fi
 
-mkdir -p /run/conf /run/inventory && \
-  mount -t vfat -o iocharset=iso8859-1 "/dev/$INVENTORY_PART" /run/inventory && \
-  mount -t vfat -o iocharset=iso8859-1 "/dev/$DEST_CONF_PART" /run/conf  && \
-  [ -f /run/conf/soft_serial ] || echo "$SERIAL_NUM" > /run/conf/soft_serial
+# finally collect information about the node (including the blackbox if found)
+if mount_part INVENTORY "$(root_dev)" -t vfat -o iocharset=iso8859-1; then
+   REPORT="/run/INVENTORY/$(cat /run/CONFIG/soft_serial 2>/dev/null)"
+   mkdir -p "$REPORT"
 
-PILLAR=/mnt/containers/services/pillar/lower
-for i in dev proc sys ; do mount --bind /$i $PILLAR/$i ; done
+   # first lets look at hardware model
+   PILLAR=/mnt/containers/services/pillar/lower
+   for i in dev proc sys ; do mount --bind /$i $PILLAR/$i ; done
+   chroot "$PILLAR" /usr/sbin/dmidecode > "$REPORT/hardwaremodel.txt"
 
-SERIAL_NUM=$(cat /run/conf/soft_serial) && \
-  mkdir "/run/inventory/$SERIAL_NUM"
-
-chroot "$PILLAR" /opt/zededa/bin/hardwaremodel -f > "/run/inventory/$SERIAL_NUM/hwfp.json"
-chroot "$PILLAR" /opt/zededa/bin/hardwaremodel > "/run/inventory/$SERIAL_NUM/hardwaremodel.txt"
-
-# lets hope this is enough to flush the caches
-sync
-umount /run/conf
-umount /run/inventory
+   # then we can collect our black box
+   if grep -q eve_blackbox /proc/cmdline; then
+      dmesg > "$REPORT/dmesg.txt"
+      tar -C /proc -cjf "$REPORT/procfs.tar.bz2" cpuinfo meminfo
+      tar -C /sys -cjf "$REPORT/sysfs.tar.bz2" .
+      tar -C /run/P3 -cjf "$REPORT/persist.tar.bz2" status rsyslog log config checkpoint certs agentdebug
+      tar -C /run/CONFIG -cjf "$REPORT/config.tar.bz2" .
+   fi 2>/dev/null
+fi
 
 # we also maybe asked to pause after
 grep -q eve_pause_after_install /proc/cmdline && pause "before shutting the node down"
 
-sync
-sleep 5
-sync
+# lets hope this is enough to flush the caches
+sync; sleep 5; sync
+for p in CONFIG INVENTORY P3; do
+   umount "/run/$p" 2>/dev/null
+done
 
 # we need a copy of these in tmpfs so that a block device with rootfs can be yanked
 cp /sbin/poweroff /bin/sleep /

--- a/pkg/mkimage-raw-efi/make-raw
+++ b/pkg/mkimage-raw-efi/make-raw
@@ -57,7 +57,7 @@ ROOTFS_PART_SIZE=$(( 300 * 1024 * 1024 ))
 # conf partition size in bytes
 CONF_PART_SIZE=$((1024 * 1024))
 # installer inventory parition size in bytes
-WIN_INVENTORY_PART_SIZE=$((10240 * 1024))
+WIN_INVENTORY_PART_SIZE=$((40240 * 1024))
 # installer system parition size in bytes
 INSTALLER_SYS_PART_SIZE=$(( 300 * 1024 * 1024 ))
 # boot partition size


### PR DESCRIPTION
So the usecase here is pretty simple: if you have a box (especially a headless one) where it is difficult to extract all the materials for off-line debugging -- you can now just run the installer with eve_blackbox option set. E.g. add the following to the grub.cfg in your installer EVE partition:

```
set_global dom0_cmdline "$dom0_cmdline eve_blackbox"
```