### PR TITLE
Avoid devicenetwork.Ifindex functions in zedrouter 

### DIFF
--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -980,12 +980,12 @@ func getPortIPv4Addr(ctx *zedrouterContext,
 
 	// Get IP address from Logicallabel
 	ifname := types.LogicallabelToIfName(ctx.deviceNetworkStatus, status.Logicallabel)
-	ifindex, err := devicenetwork.IfnameToIndex(log, ifname)
+	ifindex, err := IfnameToIndex(log, ifname)
 	if err != nil {
 		return "", err
 	}
 	// XXX Add IPv6 underlay; ignore link-locals.
-	addrs, err := devicenetwork.IfindexToAddrs(log, ifindex)
+	addrs, err := IfindexToAddrs(log, ifindex)
 	if err != nil {
 		log.Warnf("IfIndexToAddrs failed: %s\n", err)
 		addrs = nil
@@ -1206,7 +1206,7 @@ func getIfNameListForLLOrIfname(
 			//	remove this check for ifindex here when the MakeDeviceStatus
 			//	is fixed.
 			// XXX That bug has been fixed. Retest without this code?
-			ifIndex, err := devicenetwork.IfnameToIndex(log, ifName)
+			ifIndex, err := IfnameToIndex(log, ifName)
 			if err == nil {
 				log.Infof("ifName %s, ifindex: %d added to filteredList",
 					ifName, ifIndex)

--- a/pkg/pillar/cmd/zedrouter/pbr.go
+++ b/pkg/pillar/cmd/zedrouter/pbr.go
@@ -13,7 +13,6 @@ import (
 	"syscall"
 
 	"github.com/eriknordmark/netlink"
-	"github.com/lf-edge/eve/pkg/pillar/devicenetwork"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 )
 
@@ -37,7 +36,7 @@ func PbrRouteAddAll(bridgeName string, port string) error {
 		return nil
 	}
 
-	ifindex, err := devicenetwork.IfnameToIndex(log, port)
+	ifindex, err := IfnameToIndex(log, port)
 	if err != nil {
 		errStr := fmt.Sprintf("IfnameToIndex(%s) failed: %s",
 			port, err)
@@ -51,7 +50,7 @@ func PbrRouteAddAll(bridgeName string, port string) error {
 		return nil
 	}
 	// Add to ifindex specific table
-	ifindex, err = devicenetwork.IfnameToIndex(log, bridgeName)
+	ifindex, err = IfnameToIndex(log, bridgeName)
 	if err != nil {
 		errStr := fmt.Sprintf("IfnameToIndex(%s) failed: %s",
 			bridgeName, err)
@@ -105,7 +104,7 @@ func PbrRouteDeleteAll(bridgeName string, port string) error {
 		return nil
 	}
 
-	ifindex, err := devicenetwork.IfnameToIndex(log, port)
+	ifindex, err := IfnameToIndex(log, port)
 	if err != nil {
 		errStr := fmt.Sprintf("IfnameToIndex(%s) failed: %s",
 			port, err)
@@ -119,7 +118,7 @@ func PbrRouteDeleteAll(bridgeName string, port string) error {
 		return nil
 	}
 	// Remove from ifindex specific table
-	ifindex, err = devicenetwork.IfnameToIndex(log, bridgeName)
+	ifindex, err = IfnameToIndex(log, bridgeName)
 	if err != nil {
 		errStr := fmt.Sprintf("IfnameToIndex(%s) failed: %s",
 			bridgeName, err)
@@ -162,7 +161,7 @@ func PbrRouteChange(ctx *zedrouterContext,
 	} else if change.Type == getRouteUpdateTypeNEWROUTE() {
 		op = "NEWROUTE"
 	}
-	ifname, linkType, err := devicenetwork.IfindexToName(log, rt.LinkIndex)
+	ifname, linkType, err := IfindexToName(log, rt.LinkIndex)
 	if err != nil {
 		log.Errorf("PbrRouteChange IfindexToName failed for %d: %s: route %v\n",
 			rt.LinkIndex, err, rt)

--- a/pkg/pillar/cmd/zedrouter/pbr_linux.go
+++ b/pkg/pillar/cmd/zedrouter/pbr_linux.go
@@ -60,14 +60,12 @@ func PbrLinkChange(deviceNetworkStatus *types.DeviceNetworkStatus,
 		linkType)
 	switch change.Header.Type {
 	case syscall.RTM_NEWLINK:
-		relevantFlag, upFlag := devicenetwork.RelevantLastResort(log, change.Link)
-		added := devicenetwork.IfindexToNameAdd(log, ifindex, ifname, linkType,
-			relevantFlag, upFlag)
+		added := IfindexToNameAdd(log, ifindex, ifname, linkType)
 		if added {
 			changed = true
 		}
 	case syscall.RTM_DELLINK:
-		gone := devicenetwork.IfindexToNameDel(log, ifindex, ifname)
+		gone := IfindexToNameDel(log, ifindex, ifname)
 		if gone {
 			changed = true
 			MyTable := baseTableIndex + ifindex

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -810,13 +810,13 @@ func getSwitchIPv4Addr(ctx *zedrouterContext,
 	}
 
 	ifname := types.LogicallabelToIfName(ctx.deviceNetworkStatus, status.Logicallabel)
-	ifindex, err := devicenetwork.IfnameToIndex(log, ifname)
+	ifindex, err := IfnameToIndex(log, ifname)
 	if err != nil {
 		errStr := fmt.Sprintf("getSwitchIPv4Addr(%s): IfnameToIndex(%s) failed %s",
 			status.DisplayName, ifname, err)
 		return "", errors.New(errStr)
 	}
-	addrs, err := devicenetwork.IfindexToAddrs(log, ifindex)
+	addrs, err := IfindexToAddrs(log, ifindex)
 	if err != nil {
 		errStr := fmt.Sprintf("getSwitchIPv4Addr(%s): IfindexToAddrs(%s, index %d) failed %s",
 			status.DisplayName, ifname, ifindex, err)


### PR DESCRIPTION
Those use shared maps and devicenetwork.Ifindex* is also used by nim inside the same zedbox.

Plus it seems like nim is not guaranteed to have all of the links when it starts so having it always react to changes makes sense.