### PR TITLE
cache mmap for 9p container-in-VM

### DIFF
--- a/pkg/xen-tools/initrd/init-initrd
+++ b/pkg/xen-tools/initrd/init-initrd
@@ -15,9 +15,9 @@ fi
 
 mkdir /mnt >/dev/null 2>&1
 if [ "$root" = "9p-xen" ]; then
-    mount -t 9p -o msize=131072,trans=xen share_dir /mnt
+    mount -t 9p -o msize=131072,trans=xen,version=9p2000.L,cache=mmap share_dir /mnt
 elif [ "$root" = "9p-kvm" ]; then
-    mount -t 9p -o msize=131072,trans=virtio,version=9p2000.L hostshare /mnt
+    mount -t 9p -o msize=131072,trans=virtio,version=9p2000.L,cache=mmap hostshare /mnt
 else
     mount $root /mnt
 fi


### PR DESCRIPTION
We need to support mmap RW for properly work of [WAL](https://www.sqlite.org/wal.html#implementation_of_shared_memory_for_the_wal_index) of sqlite.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>