### PR TITLE
Moving metrics related exec calls from zedagent to volumemgr.

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -5,6 +5,7 @@
 | app.allow.vnc | boolean | false | allow access to the app using the VNC tcp port |
 | timer.config.interval | integer in seconds | 60 | how frequently device gets config |
 | timer.metric.interval  | integer in seconds | 60 | how frequently device reports metrics |
+| timer.metric.diskscan.interval  | integer in seconds | 300 | how frequently device should scan the disk for metrics |
 | timer.send.timeout | timer in seconds | 120 | time for each http/send |
 | timer.reboot.no.network | integer in seconds | 7 days | reboot after no cloud connectivity |
 | timer.update.fallback.no.network | integer in seconds | 300 | fallback after no cloud connectivity |

--- a/pkg/pillar/base/execwrapper.go
+++ b/pkg/pillar/base/execwrapper.go
@@ -208,6 +208,14 @@ func getAgentName() string {
 		default:
 			resultAgentName = "zedagent"
 		}
+	case "volumemgr":
+		switch file {
+		case "handlediskmetrics.go":
+			resultAgentName = "volumemgrmetrics"
+		default:
+			resultAgentName = "volumemgr"
+		}
+
 	default:
 		resultAgentName = agent
 	}

--- a/pkg/pillar/base/logobjecttypes.go
+++ b/pkg/pillar/base/logobjecttypes.go
@@ -137,6 +137,10 @@ const (
 	NetworkXObjectConfigLogType LogObjectType = "network_x_object"
 	// UUIDToNumLogType:
 	UUIDToNumLogType LogObjectType = "uuid_to_num"
+	// DiskMetricType:
+	DiskMetricType LogObjectType = "disk_metric"
+	// AppDiskMetricType:
+	AppDiskMetricType LogObjectType = "app_disk_metric"
 )
 
 // RelationObjectType :

--- a/pkg/pillar/cmd/volumemgr/create.go
+++ b/pkg/pillar/cmd/volumemgr/create.go
@@ -59,6 +59,10 @@ func createVdiskVolume(ctx *volumemgrContext, status types.VolumeStatus,
 		log.Error(err)
 		return created, filelocation, err
 	}
+	if err := createOrUpdateAppDiskMetrics(ctx, &status); err != nil {
+		log.Errorf("createVdiskVolume(%s): exception while publishing diskmetric. %s",
+			status.Key(), err.Error())
+	}
 	log.Infof("Copy DONE from %s to %s", srcLocation, status.FileLocation)
 	log.Infof("createVdiskVolume(%s) DONE", status.Key())
 	return created, filelocation, nil
@@ -92,6 +96,10 @@ func createContainerVolume(ctx *volumemgrContext, status types.VolumeStatus,
 		return created, filelocation, err
 	}
 	created = true
+	if err := createOrUpdateAppDiskMetrics(ctx, &status); err != nil {
+		log.Errorf("createContainerVolume(%s): exception while publishing diskmetric. %s",
+			status.Key(), err.Error())
+	}
 	log.Infof("createContainerVolume(%s) DONE", status.Key())
 	return created, filelocation, nil
 }
@@ -137,6 +145,10 @@ func destroyVdiskVolume(ctx *volumemgrContext, status types.VolumeStatus) (bool,
 	}
 	filelocation = ""
 	created = false
+	if err := createOrUpdateAppDiskMetrics(ctx, &status); err != nil {
+		log.Errorf("destroyVdiskVolume(%s): exception while publishing diskmetric. %s",
+			status.Key(), err.Error())
+	}
 	log.Infof("destroyVdiskVolume(%s) DONE", status.Key())
 	return created, filelocation, nil
 }
@@ -153,6 +165,10 @@ func destroyContainerVolume(ctx *volumemgrContext, status types.VolumeStatus) (b
 	}
 	filelocation = ""
 	created = false
+	if err := createOrUpdateAppDiskMetrics(ctx, &status); err != nil {
+		log.Errorf("destroyContainerVolume(%s): exception while publishing diskmetric. %s",
+			status.Key(), err.Error())
+	}
 	log.Infof("destroyContainerVolume(%s) DONE", status.Key())
 	return created, filelocation, nil
 }

--- a/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
+++ b/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2020. Zededa, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package volumemgr
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/diskmetrics"
+	"github.com/lf-edge/eve/pkg/pillar/flextimer"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/lf-edge/eve/pkg/pillar/utils"
+	"github.com/shirou/gopsutil/disk"
+)
+
+func publishDiskMetrics(ctx *volumemgrContext, statuses ...*types.DiskMetric) {
+	for _, status := range statuses {
+		key := status.Key()
+		log.Debugf("publishDiskMetrics(%s)", key)
+		pub := ctx.pubDiskMetric
+		pub.Publish(key, *status)
+		log.Debugf("publishDiskMetrics(%s) Done", key)
+	}
+}
+
+func unpublishDiskMetrics(ctx *volumemgrContext, statuses ...*types.DiskMetric) {
+	for _, status := range statuses {
+		key := status.Key()
+		log.Debugf("unpublishDiskMetrics(%s)", key)
+		pub := ctx.pubDiskMetric
+		c, _ := pub.Get(key)
+		if c == nil {
+			log.Errorf("unpublishDiskMetrics(%s) not found", key)
+			continue
+		}
+		pub.Unpublish(key)
+		log.Debugf("unpublishDiskMetrics(%s) Done", key)
+	}
+}
+
+func lookupDiskMetric(ctx *volumemgrContext, key string) *types.DiskMetric {
+	key = types.PathToKey(key)
+	log.Debugf("lookupDiskMetric(%s)", key)
+	pub := ctx.pubDiskMetric
+	c, _ := pub.Get(key)
+	if c == nil {
+		log.Debugf("lookupDiskMetric(%s) not found", key)
+		return nil
+	}
+	status := c.(types.DiskMetric)
+	log.Debugf("lookupDiskMetric(%s) Done", key)
+	return &status
+}
+
+func publishAppDiskMetrics(ctx *volumemgrContext, statuses ...*types.AppDiskMetric) {
+	for _, status := range statuses {
+		key := status.Key()
+		log.Debugf("publishAppDiskMetrics(%s)", key)
+		pub := ctx.pubAppDiskMetric
+		pub.Publish(key, *status)
+		log.Debugf("publishAppDiskMetrics(%s) Done", key)
+	}
+}
+
+func unpublishAppDiskMetrics(ctx *volumemgrContext, statuses ...*types.AppDiskMetric) {
+	for _, status := range statuses {
+		key := status.Key()
+		log.Debugf("unpublishAppDiskMetrics(%s)", key)
+		pub := ctx.pubAppDiskMetric
+		c, _ := pub.Get(key)
+		if c == nil {
+			log.Errorf("unpublishAppDiskMetrics(%s) not found", key)
+			continue
+		}
+		pub.Unpublish(key)
+		log.Debugf("unpublishAppDiskMetrics(%s) Done", key)
+	}
+}
+
+func lookupAppDiskMetric(ctx *volumemgrContext, key string) *types.AppDiskMetric {
+	key = types.PathToKey(key)
+	log.Debugf("lookupAppDiskMetric(%s)", key)
+	pub := ctx.pubAppDiskMetric
+	c, _ := pub.Get(key)
+	if c == nil {
+		log.Debugf("lookupAppDiskMetric(%s) not found", key)
+		return nil
+	}
+	status := c.(types.AppDiskMetric)
+	log.Debugf("lookupAppDiskMetric(%s) Done", key)
+	return &status
+}
+
+//diskMetricsTimerTask calculates and publishes disk metrics periodically
+func diskMetricsTimerTask(ctx *volumemgrContext, handleChannel chan interface{}) {
+	log.Infoln("starting report diskMetricsTimerTask timer task")
+	createOrUpdateDiskMetrics(ctx)
+
+	diskMetricInterval := time.Duration(ctx.globalConfig.GlobalValueInt(types.DiskScanMetricInterval)) * time.Second
+	max := float64(diskMetricInterval)
+	min := max * 0.3
+	diskMetricTicker := flextimer.NewRangeTicker(time.Duration(min), time.Duration(max))
+	// Return handle to caller
+	handleChannel <- diskMetricTicker
+
+	// Run a periodic timer so we always update StillRunning
+	stillRunning := time.NewTicker(25 * time.Second)
+	ctx.ps.StillRunning(agentName+"metrics", warningTime, errorTime)
+
+	for {
+		select {
+		case <-diskMetricTicker.C:
+			start := time.Now()
+			createOrUpdateDiskMetrics(ctx)
+			ctx.ps.CheckMaxTimeTopic(agentName+"metrics", "createOrUpdateDiskMetrics", start,
+				warningTime, errorTime)
+
+		case <-stillRunning.C:
+		}
+		ctx.ps.StillRunning(agentName+"metrics", warningTime, errorTime)
+	}
+}
+
+//createOrUpdateDiskMetrics creates or updates metrics for all disks, mountpaths and volumeStatuses
+func createOrUpdateDiskMetrics(ctx *volumemgrContext) {
+	log.Infof("createOrUpdateDiskMetrics")
+	var diskMetricList []*types.DiskMetric
+	startPubTime := time.Now()
+
+	disks := diskmetrics.FindDisksPartitions(log)
+	for _, d := range disks {
+		size, _ := diskmetrics.PartitionSize(log, d)
+		log.Debugf("createOrUpdateDiskMetrics: Disk/partition %s size %d", d, size)
+		var metric *types.DiskMetric
+		metric = lookupDiskMetric(ctx, d)
+		if metric == nil {
+			log.Infof("createOrUpdateDiskMetrics: creating new DiskMetric for %s", d)
+			metric = &(types.DiskMetric{DiskPath: d, IsDir: false})
+		} else {
+			log.Infof("createOrUpdateDiskMetrics: updating DiskMetric for %s", d)
+		}
+		metric.TotalBytes = size
+		stat, err := disk.IOCounters(d)
+		if err == nil {
+			metric.ReadBytes = stat[d].ReadBytes
+			metric.WriteBytes = stat[d].WriteBytes
+			metric.ReadCount = stat[d].ReadCount
+			metric.WriteCount = stat[d].WriteCount
+		}
+		// XXX do we have a mountpath? Combine with paths below if same?
+		diskMetricList = append(diskMetricList, metric)
+	}
+
+	var persistUsage uint64
+	for _, path := range types.ReportDiskPaths {
+		u, err := disk.Usage(path)
+		if err != nil {
+			// Happens e.g., if we don't have a /persist
+			log.Errorf("createOrUpdateDiskMetrics: disk.Usage: %s", err)
+			continue
+		}
+		// We can not run diskmetrics.SizeFromDir("/persist") below in reportDirPaths, get the usage
+		// data here for persistUsage
+		if path == types.PersistDir {
+			persistUsage = u.Used
+		}
+		log.Debugf("createOrUpdateDiskMetrics: Path %s total %d used %d free %d",
+			path, u.Total, u.Used, u.Free)
+		var metric *types.DiskMetric
+		metric = lookupDiskMetric(ctx, path)
+		if metric == nil {
+			log.Infof("createOrUpdateDiskMetrics: creating new DiskMetric for %s", path)
+			metric = &(types.DiskMetric{DiskPath: path, IsDir: true})
+		} else {
+			log.Infof("createOrUpdateDiskMetrics: updating DiskMetric for %s", path)
+		}
+		metric.TotalBytes = u.Total
+		metric.UsedBytes = u.Used
+		metric.FreeBytes = u.Free
+		diskMetricList = append(diskMetricList, metric)
+	}
+	log.Debugf("createOrUpdateDiskMetrics: persistUsage %d, elapse sec %v", persistUsage, time.Since(startPubTime).Seconds())
+
+	for _, path := range types.ReportDirPaths {
+		usage := diskmetrics.SizeFromDir(log, path)
+		log.Debugf("createOrUpdateDiskMetrics: ReportDirPath %s usage %d", path, usage)
+		var metric *types.DiskMetric
+		metric = lookupDiskMetric(ctx, path)
+		if metric == nil {
+			log.Infof("createOrUpdateDiskMetrics: creating new DiskMetric for %s", path)
+			metric = &(types.DiskMetric{DiskPath: path, IsDir: true})
+		} else {
+			log.Infof("createOrUpdateDiskMetrics: updating DiskMetric for %s", path)
+		}
+
+		metric.UsedBytes = usage
+
+		diskMetricList = append(diskMetricList, metric)
+	}
+	log.Debugf("createOrUpdateDiskMetrics: DirPaths in persist, elapse sec %v", time.Since(startPubTime).Seconds())
+
+	for _, path := range types.AppPersistPaths {
+		usage := diskmetrics.SizeFromDir(log, path)
+		log.Debugf("createOrUpdateDiskMetrics: AppPersistPath %s usage %d", path, usage)
+		var metric *types.DiskMetric
+		metric = lookupDiskMetric(ctx, path)
+		if metric == nil {
+			log.Infof("createOrUpdateDiskMetrics: creating new DiskMetric for %s", path)
+			metric = &(types.DiskMetric{DiskPath: path, IsDir: true})
+		} else {
+			log.Infof("createOrUpdateDiskMetrics: updating DiskMetric for %s", path)
+		}
+
+		metric.UsedBytes = usage
+
+		diskMetricList = append(diskMetricList, metric)
+	}
+	publishDiskMetrics(ctx, diskMetricList...)
+	for _, volumeStatus := range getAllVolumeStatus(ctx) {
+		if err := createOrUpdateAppDiskMetrics(ctx, volumeStatus); err != nil {
+			log.Errorf("CreateOrUpdateCommonDiskMetrics: exception while publishing diskmetric. %s", err.Error())
+		}
+	}
+}
+
+func createOrUpdateAppDiskMetrics(ctx *volumemgrContext, volumeStatus *types.VolumeStatus) error {
+	log.Infof("createOrUpdateAppDiskMetrics(%s, %s)", volumeStatus.VolumeID, volumeStatus.FileLocation)
+	actualSize, maxSize, err := utils.GetVolumeSize(log, volumeStatus.FileLocation)
+	if err != nil {
+		err = fmt.Errorf("createOrUpdateAppDiskMetrics(%s, %s): exception while getting volume size. %s",
+			volumeStatus.VolumeID, volumeStatus.FileLocation, err)
+		log.Error(err.Error())
+		return err
+	}
+	appDiskMetric := types.AppDiskMetric{DiskPath: volumeStatus.FileLocation,
+		ProvisionedBytes: maxSize,
+		UsedBytes:        actualSize,
+	}
+
+	if volumeStatus.IsContainer() {
+		appDiskMetric.DiskType = "CONTAINER"
+		publishAppDiskMetrics(ctx, &appDiskMetric)
+		return nil
+	}
+	imgInfo, err := diskmetrics.GetImgInfo(log, volumeStatus.FileLocation)
+	if err != nil {
+		err = fmt.Errorf("createOrUpdateAppDiskMetrics(%s, %s): exception while getting image info. %s",
+			volumeStatus.VolumeID, volumeStatus.FileLocation, err)
+		log.Error(err.Error())
+		return err
+	}
+	appDiskMetric.DiskType = imgInfo.Format
+	appDiskMetric.Dirty = imgInfo.DirtyFlag
+
+	publishAppDiskMetrics(ctx, &appDiskMetric)
+	return nil
+}

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -525,6 +525,10 @@ func updateVolumeStatus(ctx *volumemgrContext, volumeID uuid.UUID) {
 				publishVolumeStatus(ctx, &status)
 				updateVolumeRefStatus(ctx, &status)
 			}
+			if err := createOrUpdateAppDiskMetrics(ctx, &status); err != nil {
+				log.Errorf("updateVolumeStatus(%s): exception while publishing diskmetric. %s",
+					status.Key(), err.Error())
+			}
 		}
 	}
 	if !found {
@@ -549,6 +553,10 @@ func updateVolumeStatusFromContentID(ctx *volumemgrContext, contentID uuid.UUID)
 			if changed {
 				publishVolumeStatus(ctx, &status)
 				updateVolumeRefStatus(ctx, &status)
+				if err := createOrUpdateAppDiskMetrics(ctx, &status); err != nil {
+					log.Errorf("updateVolumeStatus(%s): exception while publishing diskmetric. %s",
+						status.Key(), err.Error())
+				}
 			}
 		}
 	}

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -489,6 +489,9 @@ for AGENT in $AGENTS; do
     if [ "$AGENT" = "zedagent" ]; then
        touch "$WATCHDOG_FILE/${AGENT}config.touch" "$WATCHDOG_FILE/${AGENT}metrics.touch" "$WATCHDOG_FILE/${AGENT}devinfo.touch" "$WATCHDOG_FILE/${AGENT}attest.touch" "$WATCHDOG_FILE/${AGENT}ccerts.touch"
     fi
+    if [ "$AGENT" = "volumemgr" ]; then
+       touch "$WATCHDOG_FILE/${AGENT}metrics.touch"
+    fi
 done
 
 blockdev --flushbufs "$CONFIGDEV"

--- a/pkg/pillar/types/diskmetrics.go
+++ b/pkg/pillar/types/diskmetrics.go
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2020. Zededa, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package types
+
+import (
+	"strings"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+)
+
+//ReportDiskPaths Report disk usage for these paths
+var ReportDiskPaths = []string{
+	"/",
+	IdentityDirname,
+	PersistDir,
+}
+
+//ReportDirPaths  Report directory usage for these paths
+var ReportDirPaths = []string{
+	PersistDir + "/downloads", // XXX old to be removed
+	PersistDir + "/img",       // XXX old to be removed
+	PersistDir + "/tmp",
+	PersistDir + "/log",
+	PersistDir + "/rsyslog",
+	PersistDir + "/config",
+	PersistDir + "/status",
+	PersistDir + "/certs",
+	PersistDir + "/checkpoint",
+}
+
+//AppPersistPaths  Application-related files live here
+// XXX do we need to exclude the ContentTrees used for eve image update?
+// If so how do we tell them apart
+var AppPersistPaths = []string{
+	VolumeEncryptedDirName,
+	VolumeClearDirName,
+	SealedDirName + "/downloader",
+	SealedDirName + "/verifier",
+}
+
+//DiskMetric holds metrics data per disk
+type DiskMetric struct {
+	DiskPath   string
+	ReadBytes  uint64 // Value in Bytes. Number read Bytes.
+	WriteBytes uint64 // Value in Bytes. Number written Bytes.
+	ReadCount  uint64 // Number of read operations.
+	WriteCount uint64 // Number of write operations.
+	TotalBytes uint64 // Value in Bytes. Total number of allotted Bytes for the disk.
+	UsedBytes  uint64 // Value in Bytes. Total number of used Bytes by the disk.
+	FreeBytes  uint64 // Value in Bytes. Total number of free Bytes for the disk.
+	IsDir      bool   // Will be true if DiskPath is a mountPath, will false if it's a disk.
+}
+
+// Key returns the pubsub Key.
+func (status DiskMetric) Key() string {
+	return PathToKey(status.DiskPath)
+}
+
+// LogCreate :
+func (status DiskMetric) LogCreate(logBase *base.LogObject) {
+	logObject := base.NewLogObject(logBase, base.DiskMetricType, status.DiskPath, nilUUID, status.LogKey())
+	if logObject == nil {
+		return
+	}
+	logObject.CloneAndAddField("diskpath", status.DiskPath).
+		AddField("readbytes-int64", status.ReadBytes).
+		AddField("writebytes-int64", status.WriteBytes).
+		AddField("readcount-int64", status.ReadCount).
+		AddField("writecount-int64", status.WriteCount).
+		AddField("totalbytes-int64", status.TotalBytes).
+		AddField("userbytes-int64", status.UsedBytes).
+		AddField("freebytes-int64", status.FreeBytes).
+		AddField("isdor", status.IsDir).
+		Metricf("DiskMetric status create")
+}
+
+// LogModify :
+func (status DiskMetric) LogModify(old interface{}) {
+	logObject := base.EnsureLogObject(nil, base.DiskMetricType, status.DiskPath, nilUUID, status.LogKey())
+
+	if _, ok := old.(DiskMetric); !ok {
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of DiskMetric type")
+	}
+	logObject.CloneAndAddField("diskpath", status.DiskPath).
+		AddField("old-readbytes-int64", status.ReadBytes).
+		AddField("old-writebytes-int64", status.WriteBytes).
+		AddField("old-readcount-int64", status.ReadCount).
+		AddField("old-writecount-int64", status.WriteCount).
+		AddField("totalbytes-int64", status.TotalBytes).
+		AddField("old-userbytes-int64", status.UsedBytes).
+		AddField("old-freebytes-int64", status.FreeBytes).
+		AddField("isdor", status.IsDir).
+		Metricf("DiskMetric status modify")
+}
+
+// LogDelete :
+func (status DiskMetric) LogDelete() {
+	logObject := base.EnsureLogObject(nil, base.DiskMetricType, status.DiskPath, nilUUID, status.LogKey())
+	logObject.CloneAndAddField("diskpath", status.DiskPath).
+		AddField("totalbytes-int64", status.TotalBytes).
+		AddField("userbytes-int64", status.UsedBytes).
+		AddField("freebytes-int64", status.FreeBytes).
+		AddField("isdor", status.IsDir).
+		Metricf("DiskMetric status delete")
+
+	base.DeleteLogObject(status.LogKey())
+}
+
+// LogKey :
+func (status DiskMetric) LogKey() string {
+	return string(base.DiskMetricType) + "-" + status.Key()
+}
+
+//AppDiskMetric hold metrics data per appInstance volume
+type AppDiskMetric struct {
+	DiskPath         string
+	ProvisionedBytes uint64 // Value in Bytes. Total number of allotted Bytes for the disk.
+	UsedBytes        uint64 // Value in Bytes. Total number of used Bytes by the disk.
+	DiskType         string
+	Dirty            bool
+}
+
+// Key returns the pubsub Key.
+func (status AppDiskMetric) Key() string {
+	return PathToKey(status.DiskPath)
+}
+
+// LogCreate :
+func (status AppDiskMetric) LogCreate(logBase *base.LogObject) {
+	logObject := base.NewLogObject(logBase, base.AppDiskMetricType, status.DiskPath, nilUUID, status.LogKey())
+	if logObject == nil {
+		return
+	}
+	logObject.CloneAndAddField("diskpath", status.DiskPath).
+		AddField("userbytes-int64", status.UsedBytes).
+		AddField("provisionedbytes-int64", status.ProvisionedBytes).
+		AddField("disktype", status.DiskType).
+		AddField("dirty", status.Dirty).
+		Metricf("AppDiskMetric status create")
+}
+
+// LogModify :
+func (status AppDiskMetric) LogModify(old interface{}) {
+	logObject := base.EnsureLogObject(nil, base.AppDiskMetricType, status.DiskPath, nilUUID, status.LogKey())
+
+	if _, ok := old.(AppDiskMetric); !ok {
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of AppDiskMetric type")
+	}
+	logObject.CloneAndAddField("diskpath", status.DiskPath).
+		AddField("old-userbytes-int64", status.UsedBytes).
+		AddField("provisionedbytes-int64", status.ProvisionedBytes).
+		AddField("disktype", status.DiskType).
+		AddField("dirty", status.Dirty).
+		Metricf("AppDiskMetric status modify")
+}
+
+// LogDelete :
+func (status AppDiskMetric) LogDelete() {
+	logObject := base.EnsureLogObject(nil, base.AppDiskMetricType, status.DiskPath, nilUUID, status.LogKey())
+	logObject.CloneAndAddField("diskpath", status.DiskPath).
+		AddField("provisionedbytes-int64", status.ProvisionedBytes).
+		AddField("disktype", status.DiskType).
+		AddField("dirty", status.Dirty).
+		Metricf("AppDiskMetric status delete")
+
+	base.DeleteLogObject(status.LogKey())
+}
+
+// LogKey :
+func (status AppDiskMetric) LogKey() string {
+	return string(base.AppDiskMetricType) + "-" + status.Key()
+}
+
+// PathToKey converts /path/to/dir to path-to-dir.
+func PathToKey(path string) string {
+	path = strings.TrimPrefix(path, "/")
+	key := strings.ReplaceAll(path, "/", "-")
+	return key
+}

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -115,6 +115,8 @@ const (
 	ConfigInterval GlobalSettingKey = "timer.config.interval"
 	// MetricInterval global setting key
 	MetricInterval GlobalSettingKey = "timer.metric.interval"
+	// DiskScanMetricInterval global setting key
+	DiskScanMetricInterval GlobalSettingKey = "timer.metric.diskscan.interval"
 	// ResetIfCloudGoneTime global setting key
 	ResetIfCloudGoneTime GlobalSettingKey = "timer.reboot.no.network"
 	// FallbackIfCloudGoneTime global setting key
@@ -680,7 +682,10 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	// too long to get next config and is practically unreachable for any config
 	// changes or reboot through cloud.
 	configItemSpecMap.AddIntItem(ConfigInterval, 60, 5, HourInSec)
-	// timer.metric.interval (seconds)
+	// timer.metric.diskscan.interval (seconds)
+	// Shorter interval can lead to device scanning the disk frequently which is a costly operation.
+	configItemSpecMap.AddIntItem(DiskScanMetricInterval, 300, 5, HourInSec)
+	// timer.metric.diskscan.interval (seconds)
 	// Need to be careful about max value. Controller may use metric message to
 	// update status of device (online / suspect etc ).
 	configItemSpecMap.AddIntItem(MetricInterval, 60, 5, HourInSec)

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -148,6 +148,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		// Int Items
 		ConfigInterval,
 		MetricInterval,
+		DiskScanMetricInterval,
 		ResetIfCloudGoneTime,
 		FallbackIfCloudGoneTime,
 		MintimeUpdateSuccess,


### PR DESCRIPTION
Issue:
We did a bunch of system calls every 15s to calculate diskmetrics which was to be reported to the controller. 
This caused 2 issued:
1. That many system calls, every 15s used up a lot a memory.
2. Some disk metrics doesn't change that often to be recalculated.

Solution:
Moved all disk related system call operations from zedagent to the volumemgr. Now volumemgr publishes a diskMetricStatus (for disks and mountPaths) and appDiskMetricStatus (for volumeStatuses) for every 5 min. Other than that, every time we create or update a volumeStatus, appDiskMetricStatus will be created/updated just for that volume and will be published.
On the zedagent's front, it will still send disk metrics to the controller every 15s, but instead of calculating everything, it will just take the latest list of diskMetricStatus and appDiskMetricStatus that sent by volumemgr and report that.

Note: Introduced a new subservice in volumemgr called `volumemgrmetrics`.

Signed-off-by: adarsh-zededa <adarsh@zededa.com>