### PR TITLE
Avoid pre-allocating 64kbyte buffer for every pubsub connection

### DIFF
--- a/pkg/pillar/pubsub/reverse/publish.go
+++ b/pkg/pillar/pubsub/reverse/publish.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package reverse provide a limited variant of pubsub where the subscriber
+// creates the listener and the publisher connects. Used when the publisher
+// is not a long-running agent, and there is only one subscriber.
+package reverse
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+)
+
+// Publish publishes data to
+func Publish(log *base.LogObject, agent string, data interface{}) error {
+	log.Infof("publish(%s)", agent)
+	sockName := getSocketName(agent, data)
+
+	if _, err := os.Stat(sockName); err != nil {
+		err := fmt.Errorf("publish(%s): exception while check socket. %s", sockName, err.Error())
+		log.Errorf(err.Error())
+		return err
+	}
+
+	byteData, err := json.Marshal(data)
+	if err != nil {
+		err := fmt.Errorf("publish(%s): exception while marshalling data. %s",
+			sockName, err.Error())
+		log.Errorf(err.Error())
+		return err
+	}
+
+	conn, err := net.Dial("unixpacket", sockName)
+	if err != nil {
+		err := fmt.Errorf("publish(%s): exception while dialing socket. %s",
+			sockName, err.Error())
+		log.Errorf(err.Error())
+		return err
+	}
+	defer conn.Close()
+
+	if _, err := conn.Write(byteData); err != nil {
+		err := fmt.Errorf("publish(%s): exception while writing data to the socket. %s",
+			sockName, err.Error())
+		log.Errorf(err.Error())
+		return err
+	}
+	return nil
+}
+
+func getSocketName(agent string, topic interface{}) string {
+	return path.Join("/var/run", agent,
+		fmt.Sprintf("%s.sock", pubsub.TypeToName(topic)))
+}

--- a/pkg/pillar/pubsub/reverse/subscribe.go
+++ b/pkg/pillar/pubsub/reverse/subscribe.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package reverse provide a limited variant of pubsub where the subscriber
+// creates the listener and the publisher connects. Used when the publisher
+// is not a long-running agent, and there is only one subscriber.
+package reverse
+
+import (
+	"io"
+	"net"
+	"os"
+	"path"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub/socketdriver"
+)
+
+// NewSubscriber creates a goroutine which will send strings to the channel
+// Returns the channel to the caller
+// XXX return chan?
+func NewSubscriber(log *base.LogObject, agent string, topic interface{}) <-chan string {
+	subChan := make(chan string)
+	go startSubscriber(log, agent, topic, subChan)
+	return subChan
+}
+
+// startSubscriber Creates a socket for the agent and starts listening
+// XXX return chan?
+func startSubscriber(log *base.LogObject, agent string, topic interface{}, retChan chan<- string) {
+	log.Infof("startSubscriber(%s)", agent)
+	sockName := getSocketName(agent, topic)
+	dir := path.Dir(sockName)
+	if _, err := os.Stat(dir); err != nil {
+		log.Infof("startSubscriber(%s): Create %s\n", agent, dir)
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			log.Fatalf("startSubscriber(%s): Exception while creating %s. %s",
+				agent, dir, err)
+		}
+	}
+	if _, err := os.Stat(sockName); err == nil {
+		// This could either be a left-over in the filesystem
+		// or some other process (or ourselves) using the same
+		// name to publish. Try connect to see if it is the latter.
+		_, err := net.Dial("unixpacket", sockName)
+		if err == nil {
+			log.Fatalf("connectAndRead(%s): Can not publish %s since its already used",
+				agent, sockName)
+		}
+		if err := os.Remove(sockName); err != nil {
+			log.Fatalf("connectAndRead(%s): Exception while removing pre-existing sock %s. %s",
+				agent, sockName, err)
+		}
+	}
+	listener, err := net.Listen("unixpacket", sockName)
+	if err != nil {
+		log.Fatalf("connectAndRead(%s): Exception while listening at sock %s. %s",
+			agent, sockName, err)
+	}
+	defer listener.Close()
+	for {
+		c, err := listener.Accept()
+		if err != nil {
+			log.Errorf("connectAndRead(%s) failed %s\n", sockName, err)
+			continue
+		}
+		go serveConnection(log, c, retChan, sockName)
+	}
+}
+
+// serveConnection processes a single connection and sends received
+// notifications as a string on the retChan
+func serveConnection(log *base.LogObject, conn net.Conn, retChan chan<- string, name string) {
+
+	for {
+		// wait for readable conn
+		if err := pubsub.ConnReadCheck(conn); err != nil {
+			if err != io.EOF {
+				log.Errorf("serveConnection: Error on connReadCheck: %s",
+					err)
+			}
+			break
+		}
+
+		buf, doneFunc := socketdriver.GetBuffer()
+		defer doneFunc()
+
+		count, err := conn.Read(buf)
+		if err != nil {
+			if err != io.EOF {
+				log.Errorf("serveConnection: Error on read: %s",
+					err)
+			}
+			break
+		}
+		retChan <- string(buf[:count])
+	}
+	conn.Close()
+}

--- a/pkg/pillar/pubsub/socketdriver/publish.go
+++ b/pkg/pillar/pubsub/socketdriver/publish.go
@@ -122,6 +122,7 @@ func (s *Publisher) Start() error {
 			}
 			s.log.Infof("Creating %s at %s", "s.serveConnection", agentlog.GetMyStack())
 			go s.serveConnection(c, instance)
+			maybeLogAllocated(s.log)
 			instance++
 		}
 	}(s)

--- a/pkg/pillar/pubsub/socketdriver/publish.go
+++ b/pkg/pillar/pubsub/socketdriver/publish.go
@@ -154,8 +154,17 @@ func (s *Publisher) serveConnection(conn net.Conn, instance int) {
 	// Track the set of keys/values we are sending to the peer
 	sendToPeer := make(pubsub.LocalCollection)
 	sentRestarted := false
+
+	// wait for readable conn
+	if err := connReadCheck(conn); err != nil {
+		s.log.Errorf("serveConnection(%s) connReadCheck failed: %s",
+			s.name, err)
+		return
+	}
+	buf, doneFunc := getBuffer()
+	defer doneFunc()
+
 	// Read request
-	buf := make([]byte, 65536)
 	res, err := conn.Read(buf)
 	if err != nil {
 		// Peer process could have died

--- a/pkg/pillar/pubsub/socketdriver/publish.go
+++ b/pkg/pillar/pubsub/socketdriver/publish.go
@@ -156,14 +156,8 @@ func (s *Publisher) serveConnection(conn net.Conn, instance int) {
 	sendToPeer := make(pubsub.LocalCollection)
 	sentRestarted := false
 
-	// wait for readable conn
-	if err := connReadCheck(conn); err != nil {
-		s.log.Errorf("serveConnection(%s) connReadCheck failed: %s",
-			s.name, err)
-		return
-	}
-	buf, doneFunc := getBuffer()
-	defer doneFunc()
+	// Small buffer since we only read "request <topic>"
+	buf := make([]byte, 256)
 
 	// Read request
 	res, err := conn.Read(buf)

--- a/pkg/pillar/pubsub/socketdriver/subscribe.go
+++ b/pkg/pillar/pubsub/socketdriver/subscribe.go
@@ -123,6 +123,7 @@ func (s *Subscriber) Start() error {
 func (s *Subscriber) watchSock() {
 	for {
 		msg, key, val := s.connectAndRead()
+		maybeLogAllocated(s.log)
 		switch msg {
 		case "hello":
 			// Do nothing

--- a/pkg/pillar/pubsub/socketdriver/subscribe.go
+++ b/pkg/pillar/pubsub/socketdriver/subscribe.go
@@ -177,8 +177,8 @@ func (s *Subscriber) connectAndRead() (string, string, []byte) {
 		}
 
 		// wait for readable conn
-		if err := connReadCheck(s.sock); err != nil {
-			errStr := fmt.Sprintf("connectAndRead(%s) connReadCheck failed: %s",
+		if err := pubsub.ConnReadCheck(s.sock); err != nil {
+			errStr := fmt.Sprintf("connectAndRead(%s) ConnReadCheck failed: %s",
 				s.name, err)
 			s.log.Errorln(errStr)
 			s.sock.Close()
@@ -198,7 +198,7 @@ func (s *Subscriber) connectAndRead() (string, string, []byte) {
 // msg is "" if there is nothing to process
 func (s *Subscriber) read() (string, string, []byte) {
 
-	buf, doneFunc := getBuffer()
+	buf, doneFunc := GetBuffer()
 	defer doneFunc()
 
 	res, err := s.sock.Read(buf)


### PR DESCRIPTION
Inside zedbox we can have hundreds of these, so sharing the buffers and only allocating them on the subscribe side when there is some change aks data being received will reduce memory usage.

Original sync.Pool code from @adarsh-zededa 