### PR TITLE
Calling a function Equal when it is mostly equal supresses pubsub, broke device assignment

### DIFF
--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -766,7 +766,7 @@ func handleDNSModify(ctxArg interface{}, key string, statusArg interface{}) {
 	}
 	log.Infof("handleDNSModify for %s", key)
 	// Ignore test status and timestamps
-	if ctx.deviceNetworkStatus.Equal(status) {
+	if ctx.deviceNetworkStatus.MostlyEqual(status) {
 		log.Infof("handleDNSModify no change")
 		return
 	}

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1471,6 +1471,8 @@ func configToStatus(ctx *domainContext, config types.DomainConfig,
 	}
 	// XXX could defer to Activate
 	if config.IsCipher || config.CloudInitUserData != nil {
+		// XXX only do this of the cloudinit isn't already added to
+		// diskStatusList
 		if !status.IsContainer {
 			ds, err := createCloudInitISO(ctx, config)
 			if err != nil {
@@ -1808,7 +1810,7 @@ func handleDNSModify(ctxArg interface{}, key string, statusArg interface{}) {
 	}
 	// Ignore test status and timestamps
 	// Compare Testing to save its updated value which is used by us
-	if ctx.deviceNetworkStatus.Equal(status) &&
+	if ctx.deviceNetworkStatus.MostlyEqual(status) &&
 		ctx.deviceNetworkStatus.Testing == status.Testing {
 		log.Infof("handleDNSModify unchanged")
 		ctx.DNSinitialized = true

--- a/pkg/pillar/cmd/downloader/dns.go
+++ b/pkg/pillar/cmd/downloader/dns.go
@@ -18,7 +18,7 @@ func handleDNSModify(ctxArg interface{}, key string, statusArg interface{}) {
 	}
 	log.Infof("handleDNSModify for %s", key)
 	// Ignore test status and timestamps
-	if ctx.deviceNetworkStatus.Equal(status) {
+	if ctx.deviceNetworkStatus.MostlyEqual(status) {
 		log.Infof("handleDNSModify unchanged")
 		return
 	}

--- a/pkg/pillar/cmd/ledmanager/ledmanager.go
+++ b/pkg/pillar/cmd/ledmanager/ledmanager.go
@@ -471,9 +471,9 @@ func uncachedDiskRead(count int) {
 			log.Error(err.Error())
 		}
 		syscall.Madvise(data, 4) // 4 == MADV_DONTNEED
-		log.Infof("uncachedDiskRead: size: %d", readBytes)
+		log.Debugf("uncachedDiskRead: size: %d", readBytes)
 		if int64(readBytes) < bufferLength {
-			log.Infof("uncachedDiskRead: done")
+			log.Debugf("uncachedDiskRead: done")
 			break
 		}
 		offset += bufferLength
@@ -538,7 +538,7 @@ func handleDNSModify(ctxArg interface{}, key string, statusArg interface{}) {
 	}
 	log.Infof("handleDNSModify for %s", key)
 	// Ignore test status and timestamps
-	if ctx.deviceNetworkStatus.Equal(status) {
+	if ctx.deviceNetworkStatus.MostlyEqual(status) {
 		log.Infof("handleDNSModify no change")
 		return
 	}

--- a/pkg/pillar/cmd/logmanager/logmanager.go
+++ b/pkg/pillar/cmd/logmanager/logmanager.go
@@ -471,7 +471,7 @@ func handleDNSModify(ctxArg interface{}, key string, statusArg interface{}) {
 	}
 	log.Infof("handleDNSModify for %s", key)
 	// Ignore test status and timestamps
-	if deviceNetworkStatus.Equal(status) {
+	if deviceNetworkStatus.MostlyEqual(status) {
 		log.Infof("handleDNSModify no change")
 		return
 	}

--- a/pkg/pillar/cmd/waitforaddr/waitforaddr.go
+++ b/pkg/pillar/cmd/waitforaddr/waitforaddr.go
@@ -126,7 +126,7 @@ func handleDNSModify(ctxArg interface{}, key string, statusArg interface{}) {
 	}
 	log.Infof("handleDNSModify for %s\n", key)
 	// Ignore test status and timestamps
-	if ctx.deviceNetworkStatus.Equal(status) {
+	if ctx.deviceNetworkStatus.MostlyEqual(status) {
 		log.Infof("handleDNSModify no change\n")
 		ctx.DNSinitialized = true
 		return

--- a/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
+++ b/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
@@ -254,7 +254,7 @@ func handleDNSModify(ctxArg interface{}, key string, statusArg interface{}) {
 	}
 	log.Infof("handleDNSModify for %s\n", key)
 	// Ignore test status and timestamps
-	if ctx.deviceNetworkStatus.Equal(status) {
+	if ctx.deviceNetworkStatus.MostlyEqual(status) {
 		log.Infof("handleDNSModify no change\n")
 		ctx.DNSinitialized = true
 		return

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -1616,7 +1616,7 @@ func handleDNSModify(ctxArg interface{}, key string, statusArg interface{}) {
 	}
 	log.Infof("handleDNSModify for %s\n", key)
 	// Ignore test status and timestamps
-	if ctx.deviceNetworkStatus.Equal(status) {
+	if ctx.deviceNetworkStatus.MostlyEqual(status) {
 		log.Infof("handleDNSModify no change\n")
 		return
 	}

--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -246,7 +246,7 @@ func VerifyPending(ctx *DeviceNetworkContext, pending *DPCPending,
 	log.Infof("VerifyPending: No required ports missing. " +
 		"parsing device port config list")
 
-	if !pending.PendDPC.Equal(&pending.OldDPC) {
+	if !pending.PendDPC.MostlyEqual(&pending.OldDPC) {
 		log.Infof("VerifyPending: DPC changed. check Wireless %v\n", pending.PendDPC)
 		checkAndUpdateWireless(ctx, &pending.OldDPC, &pending.PendDPC)
 
@@ -709,8 +709,8 @@ func lookupPortConfig(ctx *DeviceNetworkContext,
 	}
 	for i, port := range ctx.DevicePortConfigList.PortConfigList {
 		if port.Version == portConfig.Version &&
-			port.Equal(&portConfig) {
-			log.Infof("lookupPortConfig Equal found +%v\n",
+			port.MostlyEqual(&portConfig) {
+			log.Infof("lookupPortConfig MostlyEqual found +%v\n",
 				port)
 			return &ctx.DevicePortConfigList.PortConfigList[i], i
 		}
@@ -744,13 +744,13 @@ func (ctx *DeviceNetworkContext) doUpdatePortConfigListAndPublish(
 		// If we modify the timestamp for other than current
 		// then treat as a change since it could have moved up
 		// in the list.
-		if oldConfig.Equal(portConfig) {
+		if oldConfig.MostlyEqual(portConfig) {
 			log.Infof("doUpdatePortConfigListAndPublish: no change but timestamps %v %v\n",
 				oldConfig.TimePriority, portConfig.TimePriority)
 
 			// If this is current and current is in use (index=0)
 			// then no work needed. Otherwise we reorder
-			if current != nil && current.Equal(oldConfig) &&
+			if current != nil && current.MostlyEqual(oldConfig) &&
 				currentIndex == 0 {
 
 				log.Infof("doUpdatePortConfigListAndPublish: no change and same Ports as currentIndex=0")

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -681,11 +681,11 @@ func (config *DevicePortConfig) CountMgmtPorts() int {
 	return count
 }
 
-// Equal compares two DevicePortConfig but skips things that are
+// MostlyEqual compares two DevicePortConfig but skips things that are
 // more of status such as the timestamps and the TestResults
 // XXX Compare Version or not?
 // We compare the Ports in array order.
-func (config *DevicePortConfig) Equal(config2 *DevicePortConfig) bool {
+func (config *DevicePortConfig) MostlyEqual(config2 *DevicePortConfig) bool {
 
 	if config.Key != config2.Key {
 		return false
@@ -867,7 +867,7 @@ type WirelessConfig struct {
 // for one IfName.
 // XXX odd to have ParseErrors and/or TestResults here but we don't have
 // a corresponding Status struct.
-// Note that if fields are added the Equal function needs to be updated.
+// Note that if fields are added the MostlyEqual function needs to be updated.
 type NetworkPortConfig struct {
 	IfName       string
 	Phylabel     string // Physical name set by controller/model
@@ -1019,9 +1019,10 @@ func (status DeviceNetworkStatus) LogKey() string {
 	return string(base.DeviceNetworkStatusLogType) + "-" + status.Key()
 }
 
-// Equal compares two DeviceNetworkStatus but skips things the test status/results aspects.
+// MostlyEqual compares two DeviceNetworkStatus but skips things the test status/results aspects.
 // We compare the Ports in array order.
-func (status DeviceNetworkStatus) Equal(status2 DeviceNetworkStatus) bool {
+// XXX State and Testing?
+func (status DeviceNetworkStatus) MostlyEqual(status2 DeviceNetworkStatus) bool {
 
 	if len(status.Ports) != len(status2.Ports) {
 		return false


### PR DESCRIPTION
Rename those functions to  "MostlyEqual"

Also reduce ledmanager logging a bit so debug level doesn't get flooded with ledmanager 10x per second
