### PR TITLE
Quick hack to harmonize containerd and domainmgr filesystem view

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -44,7 +44,7 @@ import (
 
 const (
 	agentName  = "domainmgr"
-	runDirname = "/var/run/" + agentName
+	runDirname = "/run/" + agentName
 	xenDirname = runDirname + "/xen"       // We store xen cfg files here
 	ciDirname  = runDirname + "/cloudinit" // For cloud-init images
 	// Time limits for event loop handlers


### PR DESCRIPTION
Each service (including pillar) always has /run and /var/run. In fact, services are better of relying on /run since that's the one that is being explicitly bind mounted from the outside.

This, however, is just a quick hack to fix an immediate issue with cloudInit ISO creation. The proper solution should probably involve making the filesystem view one and the same between host (e.g. containerd) and all the services. Expect a longer email thread on eve-tsc@