### PR TITLE
Migrate /persist/vault to use key sealed into TPM

### DIFF
--- a/pkg/pillar/agentlog/agentlog.go
+++ b/pkg/pillar/agentlog/agentlog.go
@@ -494,23 +494,6 @@ func roundToMb(b uint64) uint64 {
 	return mb
 }
 
-func touchFile(log *base.LogObject, filename string) {
-	_, err := os.Stat(filename)
-	if os.IsNotExist(err) {
-		file, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_SYNC, 0755)
-		if err != nil {
-			log.Fatalf("touchFile: Failed touching file %s with err: %s", filename, err)
-		}
-		defer file.Close()
-	} else {
-		currentTime := time.Now()
-		err = os.Chtimes(filename, currentTime, currentTime)
-		if err != nil {
-			log.Fatalf("touchFile: Failed touching file %s with err: %s", filename, err)
-		}
-	}
-}
-
 func spoofStdFDs(log *base.LogObject, agentName string) *os.File {
 	agentDebugDir := fmt.Sprintf("%s/%s/", types.PersistDebugDir, agentName)
 	if _, err := os.Stat(agentDebugDir); os.IsNotExist(err) {
@@ -521,7 +504,7 @@ func spoofStdFDs(log *base.LogObject, agentName string) *os.File {
 		}
 	}
 	startTimeFile := agentDebugDir + "/starttime"
-	touchFile(log, startTimeFile)
+	base.TouchFile(log, startTimeFile)
 
 	stdOutFile := agentDebugDir + "/stdout"
 	stdOut, err := os.OpenFile(stdOutFile, os.O_WRONLY|os.O_CREATE|os.O_SYNC, 0755)

--- a/pkg/pillar/base/touchfile.go
+++ b/pkg/pillar/base/touchfile.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package base
+
+import (
+	"os"
+	"time"
+)
+
+//TouchFile touches the given file
+func TouchFile(log *LogObject, filename string) {
+	_, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		file, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_SYNC, 0755)
+		if err != nil {
+			log.Fatalf("TouchFile: Failed touching file %s with err: %s", filename, err)
+		}
+		defer file.Close()
+	} else {
+		currentTime := time.Now()
+		err = os.Chtimes(filename, currentTime, currentTime)
+		if err != nil {
+			log.Fatalf("TouchFile: Failed touching file %s with err: %s", filename, err)
+		}
+	}
+}

--- a/pkg/pillar/cmd/vaultmgr/vaultmgr.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgr.go
@@ -41,6 +41,7 @@ import (
 	"github.com/lf-edge/eve/api/go/info"
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/base"
+	uc "github.com/lf-edge/eve/pkg/pillar/cmd/upgradeconverter"
 	etpm "github.com/lf-edge/eve/pkg/pillar/evetpm"
 	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
@@ -56,6 +57,9 @@ type vaultMgrContext struct {
 	subVaultKeyFromController pubsub.Subscription
 	GCInitialized             bool // GlobalConfig initialized
 	defaultVaultUnlocked      bool
+	vaultUCDone               bool
+	ps                        *pubsub.PubSub
+	ucChan                    chan struct{}
 }
 
 const (
@@ -179,17 +183,37 @@ func getProtectorID(vaultPath string) ([][]string, error) {
 	return protector.FindAllStringSubmatch(stdOut, -1), nil
 }
 
+//changeProtector is used on deprecated vaults. It is used for migrating them
+//to TPM based keys, from cloudOnlyKey (which was a bug introduced in the late
+//2019). We still need to keep cloudKeyOnly for some more time, till we migrate
+//all the deprecated vaults to TPM based keys, depending on how old the image
+//from which we are getting upgraded is.
 func changeProtector(vaultPath string) error {
 	protectorID, err := getProtectorID(vaultPath)
 	if protectorID != nil {
-		if err := stageKey(true, oldKeyDir, oldKeyFile); err != nil {
+		//cloudKeyOnlyMode=true, useSealedKey=false
+		if err := stageKey(true, false, oldKeyDir, oldKeyFile); err != nil {
 			return err
 		}
 		defer unstageKey(oldKeyDir, oldKeyFile)
-		if err := stageKey(false, keyDir, keyFile); err != nil {
+		//cloudKeyOnlyMode=false, useSealedKey=false
+		if err := stageKey(false, false, keyDir, keyFile); err != nil {
 			return err
 		}
 		defer unstageKey(keyDir, keyFile)
+
+		//Note on power failure at this point:
+		//If there is a power outage after the execCmd call
+		//the key would have moved to TPM based key - which is expected
+		//
+		//If there is a power outage before the execCmd call - the key would
+		//not have moved to TPM based key - which will trigger the post-reboot
+		//session to try changeProtector again.
+		//
+		//We expect fscrypt to handle the case where there is a power outage during
+		//the execCmd call
+		//
+
 		if stdOut, stdErr, err := execCmd(vault.FscryptPath,
 			getChangeProtectorParams(protectorID[0][1])...); err != nil {
 			log.Errorf("Error changing protector key: %v", err)
@@ -226,18 +250,14 @@ func linkKeyrings() error {
 	return nil
 }
 
-func retrieveTpmKey() ([]byte, error) {
-	var tpmKey []byte
-	var err error
-	tpmKey, err = etpm.FetchVaultKey(log)
-	if err != nil {
-		log.Errorf("Error fetching TPM key: %v", err)
-		return nil, err
+func retrieveTpmKey(useSealedKey bool) ([]byte, error) {
+	if useSealedKey {
+		return etpm.FetchSealedVaultKey()
 	}
-	log.Info("Using TPM key")
-	return tpmKey, nil
+	return etpm.FetchVaultKey()
 }
 
+//retrieveCloudKey is to support pre-5.6.2 devices, remove once devices move to 5.6.2
 func retrieveCloudKey() ([]byte, error) {
 	//For now, return a dummy key, until controller support is ready.
 	cloudKey := []byte("foobarfoobarfoobarfoobarfoobarfo")
@@ -261,28 +281,27 @@ func mergeKeys(key1 []byte, key2 []byte) ([]byte, error) {
 }
 
 //cloudKeyOnlyMode is set when the key is used only from cloud, and not from TPM.
-func deriveVaultKey(cloudKeyOnlyMode bool) ([]byte, error) {
+func deriveVaultKey(cloudKeyOnlyMode, useSealedKey bool) ([]byte, error) {
 	//First fetch Cloud Key
 	cloudKey, err := retrieveCloudKey()
 	if err != nil {
 		return nil, err
 	}
+	//For pre 5.6.2 devices, remove once devices move to 5.6.2
 	if cloudKeyOnlyMode {
 		log.Infof("Using cloud key")
 		return cloudKey, nil
 	}
-	tpmKey, err := retrieveTpmKey()
-	if err == nil {
-		return mergeKeys(tpmKey, cloudKey)
-	} else {
-		//TPM is present but still error retriving the key
-		return cloudKey, err
+	tpmKey, err := retrieveTpmKey(useSealedKey)
+	if err != nil {
+		return nil, err
 	}
+	return mergeKeys(tpmKey, cloudKey)
 }
 
 //stageKey is responsible for talking to TPM and Controller
 //and preparing the key for accessing the vault
-func stageKey(cloudKeyOnlyMode bool, keyDirName string, keyFileName string) error {
+func stageKey(cloudKeyOnlyMode, useSealedKey bool, keyDirName string, keyFileName string) error {
 	//Create a tmpfs file to pass the secret to fscrypt
 	if _, _, err := execCmd("mkdir", keyDirName); err != nil {
 		return fmt.Errorf("Error creating keyDir %s %v", keyDirName, err)
@@ -292,9 +311,10 @@ func stageKey(cloudKeyOnlyMode bool, keyDirName string, keyFileName string) erro
 		return fmt.Errorf("Error mounting tmpfs on keyDir %s: %v", keyDirName, err)
 	}
 
-	vaultKey, err := deriveVaultKey(cloudKeyOnlyMode)
+	vaultKey, err := deriveVaultKey(cloudKeyOnlyMode, useSealedKey)
 	if err != nil {
 		log.Errorf("Error deriving key for accessing the vault: %v", err)
+		unstageKey(keyDirName, keyFileName)
 		return err
 	}
 	if err := ioutil.WriteFile(keyFileName, vaultKey, 0700); err != nil {
@@ -304,10 +324,13 @@ func stageKey(cloudKeyOnlyMode bool, keyDirName string, keyFileName string) erro
 }
 
 func unstageKey(keyDirName string, keyFileName string) {
-	//Shred the tmpfs file, and remove it
-	if _, _, err := execCmd("shred", "--remove", keyFileName); err != nil {
-		log.Errorf("Error shredding keyFile %s: %v", keyFileName, err)
-		return
+	_, err := os.Stat(keyFileName)
+	if !os.IsNotExist(err) {
+		//Shred the tmpfs file, and remove it
+		if _, _, err := execCmd("shred", "--remove", keyFileName); err != nil {
+			log.Errorf("Error shredding keyFile %s: %v", keyFileName, err)
+			return
+		}
 	}
 	if _, _, err := execCmd("umount", keyDirName); err != nil {
 		log.Errorf("Error unmounting %s: %v", keyDirName, err)
@@ -345,8 +368,9 @@ func handleFirstUse() error {
 	return nil
 }
 
-func unlockVault(vaultPath string, cloudKeyOnlyMode bool) error {
-	if err := stageKey(cloudKeyOnlyMode, keyDir, keyFile); err != nil {
+//cloudKeyOnlyMode and useSealedKey are passed to stageKey
+func unlockVault(vaultPath string, cloudKeyOnlyMode, useSealedKey bool) error {
+	if err := stageKey(cloudKeyOnlyMode, useSealedKey, keyDir, keyFile); err != nil {
 		return err
 	}
 	defer unstageKey(keyDir, keyFile)
@@ -361,10 +385,20 @@ func unlockVault(vaultPath string, cloudKeyOnlyMode bool) error {
 
 //createVault expects an empty, existing dir at vaultPath
 func createVault(vaultPath string) error {
+	if !etpm.IsTpmEnabled() || !etpm.PCRBankSHA256Enabled() {
+		log.Noticef("Ignoring vault create request on no-TPM(%v) or no-PCR (%v) platform",
+			!etpm.IsTpmEnabled(), !etpm.PCRBankSHA256Enabled())
+		return nil
+	}
 	if err := removeProtectorIfAny(vaultPath); err != nil {
 		return err
 	}
-	if err := stageKey(false, keyDir, keyFile); err != nil {
+	if err := etpm.WipeOutStaleSealedKeyIfAny(); err != nil {
+		return err
+	}
+	//We never create deprecated vaults, so -
+	//cloudKeyOnlyMode=false, useSealedKey=true
+	if err := stageKey(false, true, keyDir, keyFile); err != nil {
 		return err
 	}
 	defer unstageKey(keyDir, keyFile)
@@ -403,15 +437,25 @@ func setupVault(vaultPath string, deprecated bool) error {
 	}
 	//Already setup for encryption, go for unlocking
 	log.Infof("Unlocking %s", vaultPath)
-	if err := unlockVault(vaultPath, false); err != nil {
-		log.Infof("Unlocking using fallback mode: %s", vaultPath)
-		if err := unlockVault(vaultPath, true); err != nil {
+	//cloudKeyOnlyMode = false, useSealedKey=false if deprecated, true otherwise
+	if err := unlockVault(vaultPath, false, !deprecated); err != nil {
+		if !deprecated {
+			//skip any sort of fallback for non-deprecated vaults
 			return err
 		}
-		log.Infof("Migrating keys to TPM %s", vaultPath)
+		//XXX: This is to support some very old releases (< 5.6.2 )
+		//We unlock them using fallback mode, and then migrate the keys
+		//to use TPM based key
+		log.Noticef("Unlocking using fallback mode: %s", vaultPath)
+		//cloudKeyOnlyMode=true, useSealedKey=false,
+		//for fallback mode on deprecated vault
+		if err := unlockVault(vaultPath, true, false); err != nil {
+			return err
+		}
+		log.Noticef("Migrating keys to TPM %s", vaultPath)
 		return changeProtector(vaultPath)
 	}
-	log.Infof("Successfully unlocked %s", vaultPath)
+	log.Noticef("Successfully unlocked %s", vaultPath)
 	return nil
 }
 
@@ -430,6 +474,8 @@ func publishFscryptVaultStatus(ctx *vaultMgrContext,
 	fscryptError string) {
 	status := types.VaultStatus{}
 	status.Name = vaultName
+	status.ConversionComplete = ctx.vaultUCDone
+
 	if fscryptStatus != info.DataSecAtRestStatus_DATASEC_AT_REST_ENABLED {
 		status.Status = fscryptStatus
 		status.SetErrorNow(fscryptError)
@@ -437,15 +483,27 @@ func publishFscryptVaultStatus(ctx *vaultMgrContext,
 		args := getStatusParams(vaultPath)
 		if stdOut, stdErr, err := execCmd(vault.FscryptPath, args...); err != nil {
 			log.Errorf("Status failed, %v, %v, %v", err, stdOut, stdErr)
-			status.Status = info.DataSecAtRestStatus_DATASEC_AT_REST_ERROR
-			status.SetErrorNow(stdOut + stdErr)
-		} else {
-			if strings.Contains(stdOut, "Unlocked: Yes") {
-				status.Status = info.DataSecAtRestStatus_DATASEC_AT_REST_ENABLED
-				ctx.defaultVaultUnlocked = true
+			//check further on few things like PCR bank, non-empty dir etc
+			//which are not errors per se, and other agents can use vault
+			//folder in those cases
+			if !etpm.PCRBankSHA256Enabled() {
+				status.Status = info.DataSecAtRestStatus_DATASEC_AT_REST_DISABLED
+				status.SetErrorNow("No PCR-SHA256 bank available")
+			} else if !isDirEmpty(vaultPath) {
+				status.Status = info.DataSecAtRestStatus_DATASEC_AT_REST_DISABLED
+				status.SetErrorNow("Directory is not empty")
 			} else {
 				status.Status = info.DataSecAtRestStatus_DATASEC_AT_REST_ERROR
-				status.SetErrorNow("Failed to unlock vault")
+				status.SetErrorNow(stdOut + stdErr)
+			}
+		} else {
+			statusMsg := etpm.CompareLegacyandSealedKey().String()
+			status.SetErrorNow(statusMsg)
+			if strings.Contains(stdOut, "Unlocked: Yes") {
+				status.Status = info.DataSecAtRestStatus_DATASEC_AT_REST_ENABLED
+			} else {
+				status.Status = info.DataSecAtRestStatus_DATASEC_AT_REST_ERROR
+				status.SetErrorNow("Vault key unavailable")
 			}
 		}
 	}
@@ -525,7 +583,7 @@ func setupDeprecatedVaultsOnExt4(ignoreDefaultVault bool) error {
 }
 
 //setup vaults on ext4, using fscrypt
-func setupVaultOnExt4() error {
+func setupDefaultVaultOnExt4() error {
 	if err := setupVault(defaultVault, false); err != nil {
 		return fmt.Errorf("Error in setting up vault %s:%v", defaultVault, err)
 	}
@@ -533,9 +591,44 @@ func setupVaultOnExt4() error {
 }
 
 //setup vaults on zfs, using zfs native encryption support
-func setupVaultOnZfs() error {
+func setupDefaultVaultOnZfs() error {
 	if err := setupZfsVault(defaultSecretDataset); err != nil {
 		return fmt.Errorf("Error in setting up ZFS vault %s:%v", defaultSecretDataset, err)
+	}
+	return nil
+}
+
+//setupDefaultVault sets up default vault, based on the current filesystem
+//On non-TPM platforms, it just creates the directory (if absent)
+func setupDefaultVault(ctx *vaultMgrContext) error {
+	if !etpm.IsTpmEnabled() {
+		_, err := os.Stat(defaultVault)
+		if os.IsNotExist(err) {
+			return os.MkdirAll(defaultVault, 755)
+		}
+		return err
+	}
+	persistFsType := vault.ReadPersistType()
+	switch persistFsType {
+	case "ext4":
+		if err := setupDefaultVaultOnExt4(); err != nil {
+			return err
+		}
+		ctx.defaultVaultUnlocked = true
+		//Log the type of key used for unlocking default vault
+		log.Noticef("%s unlocked using key type %s", defaultVault,
+			etpm.CompareLegacyandSealedKey().String())
+	case "zfs":
+		if err := setupDefaultVaultOnZfs(); err != nil {
+			return err
+		}
+		ctx.defaultVaultUnlocked = true
+		//Log the type of key used for unlocking default vault
+		log.Noticef("%s unlocked using key type %s", defaultVault,
+			etpm.CompareLegacyandSealedKey().String())
+	default:
+		log.Noticef("unsupported %s filesystem, ignoring vault setup",
+			persistFsType)
 	}
 	return nil
 }
@@ -636,7 +729,10 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		ps.StillRunning(agentName, warningTime, errorTime)
 
 		// Context to pass around
-		ctx := vaultMgrContext{}
+		ctx := vaultMgrContext{
+			ps:     ps,
+			ucChan: make(chan struct{}),
+		}
 
 		// Look for global config such as log levels
 		subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
@@ -674,7 +770,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		}
 
 		ctx.subVaultKeyFromController = subVaultKeyFromController
-		//Enable it once we have publisher support
 		subVaultKeyFromController.Activate()
 
 		// Pick up debug aka log level before we start real work
@@ -692,28 +787,22 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		// initialize publishing handles
 		initializeSelfPublishHandles(ps, &ctx)
 
-		persistFsType := vault.ReadPersistType()
-		switch persistFsType {
-		case "ext4":
-			if err := setupVaultOnExt4(); err != nil {
-				log.Error(err)
-			}
-		case "zfs":
-			if err := setupVaultOnZfs(); err != nil {
-				log.Error(err)
-			}
-		default:
-			log.Infof("unsupported %s filesystem, ignoring vault setup",
-				persistFsType)
+		if err := setupDefaultVault(&ctx); err != nil {
+			log.Errorf("setupDefaultVault failed, err: %v", err)
+			publishVaultStatus(&ctx)
+		}
+		if ctx.defaultVaultUnlocked || !etpm.IsTpmEnabled() {
+			//Now that vault is unlocked, run any upgrade converter handler if needed
+			//In case of non-TPM platforms, we do this irrespective of
+			//defaultVaultUnlocked
+			log.Notice("Starting upgradeconverter(post-vault)")
+			go uc.RunPostVaultHandlers(agentName, ps, logger, log,
+				debugOverride, ctx.ucChan)
 		}
 
-		//Publish current status of vault
-		publishVaultStatus(&ctx)
-		if err == nil {
-			//publish vault key to Controller
-			if err := publishVaultKey(&ctx, types.DefaultVaultName); err != nil {
-				log.Errorf("Failed to publish Vault Key, %v", err)
-			}
+		//publish vault key to Controller, if required
+		if err := publishVaultKey(&ctx, types.DefaultVaultName); err != nil {
+			log.Errorf("Failed to publish Vault Key, %v", err)
 		}
 
 		for {
@@ -722,6 +811,11 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 				subVaultKeyFromController.ProcessChange(change)
 			case <-stillRunning.C:
 				ps.StillRunning(agentName, warningTime, errorTime)
+			case <-ctx.ucChan:
+				log.Notice("upgradeconverter(post-vault) Completed")
+				ctx.vaultUCDone = true
+				//Publish current status of vault
+				publishVaultStatus(&ctx)
 			}
 		}
 	default:
@@ -768,6 +862,12 @@ func handleGlobalConfigDelete(ctxArg interface{}, key string,
 func handleVaultKeyFromControllerModify(ctxArg interface{}, key string,
 	keyArg interface{}) {
 	ctx := ctxArg.(*vaultMgrContext)
+
+	if !etpm.IsTpmEnabled() {
+		log.Notice("Receiving Vault key on device without active TPM usage. Ignoring")
+		return
+	}
+
 	keyFromController, ok := keyArg.(types.EncryptedVaultKeyFromController)
 	if !ok {
 		log.Fatalf("[VAULT] Unexpected pub type %T", keyArg)
@@ -797,29 +897,51 @@ func handleVaultKeyFromControllerModify(ctxArg interface{}, key string,
 	}
 	log.Infof("Computed and provided SHA are matching")
 
-	err = etpm.SealVaultKey(decryptedKey)
-	if err != nil {
-		log.Errorf("Failed to Seal key in TPM %v", err)
-		return
-	}
-	log.Infof("Sealed key in TPM")
-
 	//Try unlocking the vault now, in case it is not yet unlocked
 	if !ctx.defaultVaultUnlocked {
-		log.Errorf("[ATTEST] Vault is still locked, trying to unlock")
-		err = unlockVault(types.DefaultVaultName, false)
+		log.Noticef("Vault is still locked, trying to unlock")
+		err = etpm.SealDiskKey(decryptedKey, etpm.DiskKeySealingPCRs)
+		if err != nil {
+			log.Errorf("Failed to Seal key in TPM %v", err)
+			return
+		}
+		log.Noticef("Sealed key in TPM, unlocking %s", types.DefaultVaultName)
+
+		//cloudKeyOnlyMode=false, useSealedKey=true
+		err = unlockVault(defaultVault, false, true)
 		if err != nil {
 			log.Errorf("Failed to unlock vault after receiving Controller key, %v",
 				err)
 			return
 		}
-		//fetch, set and publish the latest status
-		publishVaultStatus(ctx)
+
+		//Log the type of key used for unlocking default vault
+		log.Noticef("%s unlocked using key type %s", defaultVault,
+			etpm.CompareLegacyandSealedKey().String())
+
+		//Mark the default vault as unlocked
+		ctx.defaultVaultUnlocked = true
+
+		//publish vault key to Controller
+		if err := publishVaultKey(ctx, types.DefaultVaultName); err != nil {
+			log.Errorf("Failed to publish Vault Key, %v", err)
+		}
+
+		//Now that vault is unlocked, run any upgrade converter handler if needed
+		//The main select loop which is waiting on ucChan event, will publish
+		//latest status of vault(s) once RunPostVaultHandlers is complete.
+		log.Notice("Starting upgradeconverter(post-vault)")
+		go uc.RunPostVaultHandlers(agentName, ctx.ps, logger, log,
+			debugOverride, ctx.ucChan)
 	}
 }
 
 func publishVaultKey(ctx *vaultMgrContext, vaultName string) error {
-	keyBytes, err := retrieveTpmKey()
+	if !ctx.defaultVaultUnlocked {
+		log.Errorf("Vault is not yet unlocked, waiting for Controller key")
+		return nil
+	}
+	keyBytes, err := retrieveTpmKey(true)
 	if err != nil {
 		return fmt.Errorf("Failed to retrieve key from TPM %v", err)
 	}

--- a/pkg/pillar/cmd/vaultmgr/vaultmgrzfs.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgrzfs.go
@@ -39,7 +39,9 @@ func getKeyStatusParams(vaultPath string) []string {
 //zfs mount persist/vault
 func unlockZfsVault(vaultPath string) error {
 	//prepare key in the staging file
-	if err := stageKey(false, zfsKeyDir, zfsKeyFile); err != nil {
+	//we never unlock a deprecated vault in ZFS (we never created those)
+	//cloudKeyOnlyMode=false, useSealedKey=true
+	if err := stageKey(false, true, zfsKeyDir, zfsKeyFile); err != nil {
 		return err
 	}
 	defer unstageKey(zfsKeyDir, zfsKeyFile)
@@ -63,7 +65,9 @@ func unlockZfsVault(vaultPath string) error {
 //e.g. zfs create -o encryption=aes-256-gcm -o keylocation=file://tmp/raw.key -o keyformat=raw perist/vault
 func createZfsVault(vaultPath string) error {
 	//prepare key in the staging file
-	if err := stageKey(false, zfsKeyDir, zfsKeyFile); err != nil {
+	//we never create deprecated vault on ZFS
+	//cloudKeyOnlyMode=false, useSealedKey=true
+	if err := stageKey(false, true, zfsKeyDir, zfsKeyFile); err != nil {
 		return err
 	}
 	defer unstageKey(zfsKeyDir, zfsKeyFile)

--- a/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
+++ b/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
@@ -108,19 +108,19 @@ func diskMetricsTimerTask(ctx *volumemgrContext, handleChannel chan interface{})
 
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(25 * time.Second)
-	ctx.ps.StillRunning(agentName+"metrics", warningTime, errorTime)
+	ctx.ps.StillRunning(diskMetricsAgentName, warningTime, errorTime)
 
 	for {
 		select {
 		case <-diskMetricTicker.C:
 			start := time.Now()
 			createOrUpdateDiskMetrics(ctx)
-			ctx.ps.CheckMaxTimeTopic(agentName+"metrics", "createOrUpdateDiskMetrics", start,
+			ctx.ps.CheckMaxTimeTopic(diskMetricsAgentName, "createOrUpdateDiskMetrics", start,
 				warningTime, errorTime)
 
 		case <-stillRunning.C:
 		}
-		ctx.ps.StillRunning(agentName+"metrics", warningTime, errorTime)
+		ctx.ps.StillRunning(diskMetricsAgentName, warningTime, errorTime)
 	}
 }
 

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -27,6 +27,8 @@ import (
 
 const (
 	agentName              = "volumemgr"
+	diskMetricsAgentName   = agentName + "metrics"
+	diskMetricsWDTouchFile = types.WatchdogFileDir + "/" + diskMetricsAgentName + ".touch"
 	runDirname             = "/var/run/" + agentName
 	ciDirname              = runDirname + "/cloudinit"    // For cloud-init volumes XXX change?
 	volumeEncryptedDirName = types.VolumeEncryptedDirName // We store encrypted VM and OCI volumes here
@@ -480,6 +482,10 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// start the metrics reporting task
 	diskMetricsTickerHandle := make(chan interface{})
 	log.Infof("Creating %s at %s", "diskMetricsTimerTask", agentlog.GetMyStack())
+
+	//Add .touch file to watchdog config
+	base.TouchFile(log, diskMetricsWDTouchFile)
+
 	go diskMetricsTimerTask(&ctx, diskMetricsTickerHandle)
 	ctx.diskMetricsTickerHandle = <-diskMetricsTickerHandle
 

--- a/pkg/pillar/cmd/zedagent/attesttask.go
+++ b/pkg/pillar/cmd/zedagent/attesttask.go
@@ -286,7 +286,7 @@ func (server *VerifierImpl) SendAttestQuote(ctx *zattest.Context) error {
 	case attest.ZAttestResponseCode_Z_ATTEST_RESPONSE_CODE_SUCCESS:
 		//Retrieve integrity token
 		storeIntegrityToken(quoteResp.GetIntegrityToken())
-		log.Infof("[ATTEST] Attestation successful, processing keys given by Controller")
+		log.Notice("[ATTEST] Attestation successful, processing keys given by Controller")
 		if encryptedKeys := quoteResp.GetKeys(); encryptedKeys != nil {
 			for _, sk := range encryptedKeys {
 				encryptedKeyType := sk.GetKeyType()
@@ -381,7 +381,7 @@ func (server *VerifierImpl) SendAttestEscrow(ctx *zattest.Context) error {
 		log.Errorf("[ATTEST] Integrity Token Mismatch")
 		return zattest.ErrITokenMismatch
 	case attest.AttestStorageKeysResponseCode_ATTEST_STORAGE_KEYS_RESPONSE_CODE_SUCCESS:
-		log.Infof("[ATTEST] Escrow successful")
+		log.Notice("[ATTEST] Escrow successful")
 		return nil
 	default:
 		log.Errorf("[ATTEST] Unknown escrowRespCode %v", escrowRespCode)

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -136,11 +136,6 @@ if [ -c $TPM_DEVICE_PATH ] && ! [ -f $CONFIGDIR/disable-tpm ]; then
     if ! $BINDIR/vaultmgr setupDeprecatedVaults; then
         echo "$(date -Ins -u) device-steps: vaultmgr setupDeprecatedVaults failed"
     fi
-else
-    if [ ! -d $PERSISTDIR/vault ]; then
-        echo "$(date -Ins -u) Creating $PERSISTDIR/vault"
-        mkdir $PERSISTDIR/vault
-    fi
 fi
 
 if [ -f $PERSISTDIR/IMGA/reboot-reason ]; then
@@ -153,14 +148,6 @@ fi
 if [ -f $PERSISTDIR/reboot-reason ]; then
     echo "Common reboot-reason: $(cat $PERSISTDIR/reboot-reason)"
 fi
-
-echo "$(date -Ins -u) Current downloaded/verified files:"
-ls -lt $PERSISTDIR/vault/verifier/verified/
-echo
-
-echo "$(date -Ins -u) Preserved volumes:"
-ls -lt $PERSISTDIR/vault/volumes/
-echo
 
 # Copy any GlobalConfig from /config
 dir=$CONFIGDIR/GlobalConfig
@@ -181,9 +168,9 @@ if [ ! -d $PERSISTDIR/log ]; then
 fi
 
 # Run upgradeconverter
-echo "$(date -Ins -u) device-steps: Starting upgradeconverter"
-$BINDIR/upgradeconverter
-echo "$(date -Ins -u) device-steps: upgradeconverter Completed"
+echo "$(date -Ins -u) device-steps: Starting upgradeconverter (pre-vault)"
+$BINDIR/upgradeconverter pre-vault
+echo "$(date -Ins -u) device-steps: upgradeconverter (pre-vault) Completed"
 
 # BlinkCounter 1 means we have started; might not yet have IP addresses
 # client/selfRegister and zedagent update this when the found at least
@@ -488,9 +475,6 @@ for AGENT in $AGENTS; do
     touch "$WATCHDOG_FILE/$AGENT.touch"
     if [ "$AGENT" = "zedagent" ]; then
        touch "$WATCHDOG_FILE/${AGENT}config.touch" "$WATCHDOG_FILE/${AGENT}metrics.touch" "$WATCHDOG_FILE/${AGENT}devinfo.touch" "$WATCHDOG_FILE/${AGENT}attest.touch" "$WATCHDOG_FILE/${AGENT}ccerts.touch"
-    fi
-    if [ "$AGENT" = "volumemgr" ]; then
-       touch "$WATCHDOG_FILE/${AGENT}metrics.touch"
     fi
 done
 

--- a/pkg/pillar/types/locationconsts.go
+++ b/pkg/pillar/types/locationconsts.go
@@ -66,4 +66,6 @@ const (
 	EveVersionFile = "/run/eve-release"
 	//DefaultVaultName is the name of the default vault
 	DefaultVaultName = "Application Data Store"
+	//WatchdogFileDir is the dir to add .touch files for watchdog to monitor
+	WatchdogFileDir = "/run/watchdog/file"
 )

--- a/pkg/pillar/types/vaultmgrtypes.go
+++ b/pkg/pillar/types/vaultmgrtypes.go
@@ -12,8 +12,9 @@ import (
 
 //VaultStatus represents running status of a Vault
 type VaultStatus struct {
-	Name   string
-	Status info.DataSecAtRestStatus
+	Name               string
+	Status             info.DataSecAtRestStatus
+	ConversionComplete bool
 	// ErrorAndTime provides SetErrorNow() and ClearError()
 	ErrorAndTime
 }

--- a/pkg/pillar/utils/waitfor.go
+++ b/pkg/pillar/utils/waitfor.go
@@ -64,7 +64,7 @@ func handleVaultStatusModify(ctxArg interface{}, key string,
 
 	ctx := ctxArg.(*Context)
 	vault := statusArg.(types.VaultStatus)
-	if vault.Name == types.DefaultVaultName &&
+	if vault.Name == types.DefaultVaultName && vault.ConversionComplete &&
 		vault.Status != info.DataSecAtRestStatus_DATASEC_AT_REST_ERROR {
 		ctx.Initialized = true
 	}


### PR DESCRIPTION
- Change /persist/vault to use a key sealed into TPM
- If key is not available, one new key is created and sealed into TPM
- If unsealing fails, waits for Controller to release the key, and then unlocks
   vault and seals the same into TPM again
- Some temporary changes to handle deprecated vaults (/persist/config & /persist/img)

Signed-off-by: Hariharasubramanian C S <cshari@zededa.com>