### PR TITLE
Cleanup /var/tmp/zededa; move ConfigItemValueMap logic; move ConfigItemMap from /persist/config to /persist/status/zedagent

### DIFF
--- a/pkg/pillar/base/execwrapper.go
+++ b/pkg/pillar/base/execwrapper.go
@@ -131,7 +131,7 @@ func Exec(log *LogObject, command string, arg ...string) *Command {
 	}
 }
 
-//updateAgentTouchFile updates agent's touch file under /var/run/
+//updateAgentTouchFile updates agent's touch file under /run/
 func updateAgentTouchFile(log *LogObject, agentName string) {
 	if agentName == "" {
 		if log != nil {
@@ -139,7 +139,7 @@ func updateAgentTouchFile(log *LogObject, agentName string) {
 		}
 		return
 	}
-	filename := fmt.Sprintf("/var/run/%s.touch", agentName)
+	filename := fmt.Sprintf("/run/%s.touch", agentName)
 	_, err := os.Stat(filename)
 	if err != nil {
 		file, err := os.Create(filename)

--- a/pkg/pillar/base/touchfile.go
+++ b/pkg/pillar/base/touchfile.go
@@ -8,6 +8,13 @@ import (
 	"time"
 )
 
+const (
+	// WatchdogFileDir is the dir to add .touch files for watchdog to monitor
+	WatchdogFileDir = "/run/watchdog/file"
+	// WatchdogPidDir is the dir to add .pid files for watchdog to monitor
+	WatchdogPidDir = "/run/watchdog/pid"
+)
+
 //TouchFile touches the given file
 func TouchFile(log *LogObject, filename string) {
 	_, err := os.Stat(filename)

--- a/pkg/pillar/cmd/baseosmgr/baseosmgr.go
+++ b/pkg/pillar/cmd/baseosmgr/baseosmgr.go
@@ -309,6 +309,7 @@ func initializeGlobalConfigHandles(ps *pubsub.PubSub, ctx *baseOsMgrContext) {
 			AgentName:     "",
 			MyAgentName:   agentName,
 			TopicImpl:     types.ConfigItemValueMap{},
+			Persistent:    true,
 			Activate:      false,
 			Ctx:           ctx,
 			CreateHandler: handleGlobalConfigModify,

--- a/pkg/pillar/cmd/baseosmgr/baseosmgr.go
+++ b/pkg/pillar/cmd/baseosmgr/baseosmgr.go
@@ -306,7 +306,7 @@ func initializeGlobalConfigHandles(ps *pubsub.PubSub, ctx *baseOsMgrContext) {
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(
 		pubsub.SubscriptionOptions{
-			AgentName:     "",
+			AgentName:     "zedagent",
 			MyAgentName:   agentName,
 			TopicImpl:     types.ConfigItemValueMap{},
 			Persistent:    true,

--- a/pkg/pillar/cmd/baseosmgr/handlebaseos.go
+++ b/pkg/pillar/cmd/baseosmgr/handlebaseos.go
@@ -8,8 +8,6 @@ package baseosmgr
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"strings"
 	"syscall"
 	"time"
@@ -352,15 +350,6 @@ func doBaseOsActivate(ctx *baseOsMgrContext, uuidStr string,
 		return changed
 	}
 
-	// Remove any old log files for a previous instance
-	logdir := fmt.Sprintf("%s/%s/log", types.PersistDir,
-		status.PartitionLabel)
-	log.Infof("Clearing old logs in %s", logdir)
-	// Clear content but not directory since logmanager expects dir
-	if err := removeContent(logdir); err != nil {
-		log.Errorln(err)
-	}
-
 	// if it is installed, flip the activated status
 	if status.State == types.INSTALLED && !status.Reboot {
 		// trigger, zedagent to start reboot process
@@ -369,22 +358,6 @@ func doBaseOsActivate(ctx *baseOsMgrContext, uuidStr string,
 	}
 
 	return changed
-}
-
-func removeContent(dirName string) error {
-	locations, err := ioutil.ReadDir(dirName)
-	if err != nil {
-		return err
-	}
-
-	for _, location := range locations {
-		filelocation := dirName + "/" + location.Name()
-		err := os.RemoveAll(filelocation)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func doBaseOsInstall(ctx *baseOsMgrContext, uuidStr string,

--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -176,6 +176,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		ErrorTime:     errorTime,
 		Activate:      false,
 		TopicImpl:     types.ConfigItemValueMap{},
+		Persistent:    true,
 		Ctx:           &clientCtx,
 	})
 	if err != nil {

--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -167,7 +167,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName:     "",
+		AgentName:     "zedagent",
 		MyAgentName:   agentName,
 		CreateHandler: handleGlobalConfigModify,
 		ModifyHandler: handleGlobalConfigModify,

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -125,7 +125,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(
 		pubsub.SubscriptionOptions{
-			AgentName:     "",
+			AgentName:     "zedagent",
 			MyAgentName:   agentName,
 			TopicImpl:     types.ConfigItemValueMap{},
 			Persistent:    true,

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -30,7 +30,6 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/hardware"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
-	"github.com/lf-edge/eve/pkg/pillar/utils"
 	"github.com/lf-edge/eve/pkg/pillar/zedcloud"
 	"github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
@@ -54,6 +53,7 @@ type diagContext struct {
 	derivedLedCounter       int // Based on ledCounter + usableAddressCount
 	subGlobalConfig         pubsub.Subscription
 	globalConfig            *types.ConfigItemValueMap
+	GCInitialized           bool // Received initial GlobalConfig
 	subLedBlinkCounter      pubsub.Subscription
 	subDeviceNetworkStatus  pubsub.Subscription
 	subDevicePortConfigList pubsub.Subscription
@@ -122,15 +122,13 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	ctx.DeviceNetworkStatus = &types.DeviceNetworkStatus{}
 	ctx.DevicePortConfigList = &types.DevicePortConfigList{}
 
-	// Make sure we have a GlobalConfig file with defaults
-	utils.EnsureGCFile(log)
-
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(
 		pubsub.SubscriptionOptions{
 			AgentName:     "",
 			MyAgentName:   agentName,
 			TopicImpl:     types.ConfigItemValueMap{},
+			Persistent:    true,
 			Activate:      false,
 			Ctx:           &ctx,
 			CreateHandler: handleGlobalConfigModify,
@@ -144,6 +142,16 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	}
 	ctx.subGlobalConfig = subGlobalConfig
 	subGlobalConfig.Activate()
+
+	// Wait for initial GlobalConfig
+	for !ctx.GCInitialized {
+		log.Infof("Waiting for GCInitialized")
+		select {
+		case change := <-subGlobalConfig.MsgChan():
+			subGlobalConfig.ProcessChange(change)
+		}
+	}
+	log.Infof("processed GlobalConfig")
 
 	server, err := ioutil.ReadFile(types.ServerFileName)
 	if err != nil {
@@ -1097,6 +1105,7 @@ func handleGlobalConfigModify(ctxArg interface{}, key string,
 	if gcp != nil {
 		ctx.globalConfig = gcp
 	}
+	ctx.GCInitialized = true
 	log.Infof("handleGlobalConfigModify done for %s", key)
 }
 

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -323,6 +323,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 			AgentName:     "",
 			MyAgentName:   agentName,
 			TopicImpl:     types.ConfigItemValueMap{},
+			Persistent:    true,
 			Activate:      false,
 			Ctx:           &domainCtx,
 			CreateHandler: handleGlobalConfigModify,

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -320,7 +320,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(
 		pubsub.SubscriptionOptions{
-			AgentName:     "",
+			AgentName:     "zedagent",
 			MyAgentName:   agentName,
 			TopicImpl:     types.ConfigItemValueMap{},
 			Persistent:    true,

--- a/pkg/pillar/cmd/downloader/context.go
+++ b/pkg/pillar/cmd/downloader/context.go
@@ -90,6 +90,7 @@ func (ctx *downloaderContext) registerHandlers(ps *pubsub.PubSub) error {
 		WarningTime:   warningTime,
 		ErrorTime:     errorTime,
 		TopicImpl:     types.ConfigItemValueMap{},
+		Persistent:    true,
 		Ctx:           ctx,
 	})
 	if err != nil {

--- a/pkg/pillar/cmd/downloader/context.go
+++ b/pkg/pillar/cmd/downloader/context.go
@@ -82,7 +82,7 @@ func (ctx *downloaderContext) registerHandlers(ps *pubsub.PubSub) error {
 
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName:     "",
+		AgentName:     "zedagent",
 		MyAgentName:   agentName,
 		CreateHandler: handleGlobalConfigModify,
 		ModifyHandler: handleGlobalConfigModify,

--- a/pkg/pillar/cmd/executor/exec.go
+++ b/pkg/pillar/cmd/executor/exec.go
@@ -90,8 +90,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	ps.StillRunning(agentName, warningTime, errorTime)
 
 	// Add .pid and .touch file to watchdog config
-	base.TouchFile(log, types.WatchdogPidDir+"/"+agentName+".pid")
-	base.TouchFile(log, types.WatchdogFileDir+"/"+agentName+".touch")
+	ps.RegisterPidWatchdog(agentName)
+	ps.RegisterFileWatchdog(agentName)
 
 	pubExecStatus, err := ps.NewPublication(pubsub.PublicationOptions{
 		AgentName: agentName,

--- a/pkg/pillar/cmd/executor/exec.go
+++ b/pkg/pillar/cmd/executor/exec.go
@@ -107,6 +107,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		AgentName:     "",
 		MyAgentName:   agentName,
 		TopicImpl:     types.ConfigItemValueMap{},
+		Persistent:    true,
 		Ctx:           &execCtx,
 		CreateHandler: handleGlobalConfigModify,
 		ModifyHandler: handleGlobalConfigModify,

--- a/pkg/pillar/cmd/executor/exec.go
+++ b/pkg/pillar/cmd/executor/exec.go
@@ -104,7 +104,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName:     "",
+		AgentName:     "zedagent",
 		MyAgentName:   agentName,
 		TopicImpl:     types.ConfigItemValueMap{},
 		Persistent:    true,

--- a/pkg/pillar/cmd/ipcmonitor/ipcmonitor.go
+++ b/pkg/pillar/cmd/ipcmonitor/ipcmonitor.go
@@ -6,11 +6,11 @@
 //
 // Example usage: to monitor what zedmanager publishes in DomainConfig use
 // ipcmonitor -a zedmanager -t DomainConfig
-//     That corresponds to the state in /var/run/zedmanager/DomainConfig/*.json
+//     That corresponds to the state in /run/zedmanager/DomainConfig/*.json
 //     but with ongoing updates and deletes.
 // For agents with agentScope, such as downloader and verifier, use e.g.,
 // ipcmonitor -a zedmanager -s appImg.obj -t DownloaderConfiga
-//     which corresponds to /var/run/zedmanager/appImg.obj/DownloaderConfig/
+//     which corresponds to /run/zedmanager/appImg.obj/DownloaderConfig/
 
 package ipcmonitor
 
@@ -62,7 +62,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	format := *formatPtr
 
 	name := nameString(agentName, agentScope, topic)
-	sockName := fmt.Sprintf("/var/run/%s.sock", name)
+	sockName := fmt.Sprintf("/run/%s.sock", name)
 	s, err := net.Dial("unixpacket", sockName)
 	if err != nil {
 		log.Fatal("Dial:", err)

--- a/pkg/pillar/cmd/ledmanager/ledmanager.go
+++ b/pkg/pillar/cmd/ledmanager/ledmanager.go
@@ -274,6 +274,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		AgentName:     "",
 		MyAgentName:   agentName,
 		TopicImpl:     types.ConfigItemValueMap{},
+		Persistent:    true,
 		Activate:      false,
 		Ctx:           &ctx,
 		CreateHandler: handleGlobalConfigModify,

--- a/pkg/pillar/cmd/ledmanager/ledmanager.go
+++ b/pkg/pillar/cmd/ledmanager/ledmanager.go
@@ -271,7 +271,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName:     "",
+		AgentName:     "zedagent",
 		MyAgentName:   agentName,
 		TopicImpl:     types.ConfigItemValueMap{},
 		Persistent:    true,

--- a/pkg/pillar/cmd/logmanager/logmanager.go
+++ b/pkg/pillar/cmd/logmanager/logmanager.go
@@ -221,7 +221,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName:     "",
+		AgentName:     "zedagent",
 		MyAgentName:   agentName,
 		TopicImpl:     types.ConfigItemValueMap{},
 		Persistent:    true,

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -120,7 +120,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName:     "",
+		AgentName:     "zedagent",
 		MyAgentName:   agentName,
 		TopicImpl:     types.ConfigItemValueMap{},
 		Persistent:    true,

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -265,7 +265,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	// We get DevicePortConfig from three sources in this priority:
 	// 1. zedagent publishing DevicePortConfig
-	// 2. override file in /var/tmp/zededa/DevicePortConfig/*.json
+	// 2. override file in /run/global/DevicePortConfig/*.json
 	// 3. "lastresort" derived from the set of network interfaces
 	subDevicePortConfigA, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "zedagent",

--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -41,7 +41,7 @@ const (
 	maxRebootStackSize          = 1600
 	maxJSONAttributeSize        = maxRebootStackSize + 100
 	configDir                   = "/config"
-	tmpDirname                  = "/var/tmp/zededa"
+	tmpDirname                  = "/run/global"
 	firstbootFile               = tmpDirname + "/first-boot"
 	restartCounterFile          = configDir + "/restartcounter"
 	// Time limits for event loop handlers

--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -154,7 +154,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName:     "",
+		AgentName:     "zedagent",
 		MyAgentName:   agentName,
 		TopicImpl:     types.ConfigItemValueMap{},
 		Persistent:    true,

--- a/pkg/pillar/cmd/tpmmgr/tpmmgr.go
+++ b/pkg/pillar/cmd/tpmmgr/tpmmgr.go
@@ -1139,6 +1139,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 			AgentName:     "",
 			MyAgentName:   agentName,
 			TopicImpl:     types.ConfigItemValueMap{},
+			Persistent:    true,
 			Activate:      false,
 			Ctx:           &ctx,
 			CreateHandler: handleGlobalConfigModify,

--- a/pkg/pillar/cmd/tpmmgr/tpmmgr.go
+++ b/pkg/pillar/cmd/tpmmgr/tpmmgr.go
@@ -1136,7 +1136,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 		// Look for global config such as log levels
 		subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-			AgentName:     "",
+			AgentName:     "zedagent",
 			MyAgentName:   agentName,
 			TopicImpl:     types.ConfigItemValueMap{},
 			Persistent:    true,

--- a/pkg/pillar/cmd/upgradeconverter/applydefaultconfigitem.go
+++ b/pkg/pillar/cmd/upgradeconverter/applydefaultconfigitem.go
@@ -46,8 +46,6 @@ func applyDefaultConfigItem(ctxPtr *ucContext) error {
 	if err != nil {
 		log.Fatalf("Failed to Save NewConfig. err %s", err)
 	}
-	log.Infof("Saved NewConfig. data: %s", data)
-
 	log.Debugf("upgradeconverter.applyDefaultConfigItem done")
 	return nil
 }

--- a/pkg/pillar/cmd/upgradeconverter/applydefaultconfigitem.go
+++ b/pkg/pillar/cmd/upgradeconverter/applydefaultconfigitem.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package upgradeconverter
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+func applyDefaultConfigItem(ctxPtr *ucContext) error {
+	createConfigItemMapDir(ctxPtr.newConfigItemValueMapDir())
+	newConfigItemFile := ctxPtr.newConfigItemValueMapFile()
+	newExists := fileExists(newConfigItemFile)
+
+	newConfigPtr := types.DefaultConfigItemValueMap()
+	if newExists {
+		oldConfigPtr, err := parseFile(newConfigItemFile)
+		if err != nil {
+			log.Error(err)
+		} else {
+			// Apply defaults
+			newConfigPtr.UpdateItemValues(oldConfigPtr)
+			if !cmp.Equal(oldConfigPtr, newConfigPtr) {
+				log.Noticef("Updated ConfigItemValueMap with new defaults. Diff: %+v",
+					cmp.Diff(oldConfigPtr, newConfigPtr))
+			}
+		}
+	} else {
+		log.Noticef("No existing ConfigItemValueMap; creating %s with defaults",
+			newConfigItemFile)
+	}
+
+	// Save New config to file.
+	var data []byte
+	data, err := json.Marshal(newConfigPtr)
+	if err != nil {
+		log.Fatalf("Failed to marshall new global config err %s", err)
+	}
+	err = ioutil.WriteFile(newConfigItemFile, data, 0644)
+	if err != nil {
+		log.Fatalf("Failed to Save NewConfig. err %s", err)
+	}
+	log.Infof("Saved NewConfig. data: %s", data)
+
+	log.Debugf("upgradeconverter.applyDefaultConfigItem done")
+	return nil
+}
+
+func parseFile(filename string) (*types.ConfigItemValueMap, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to open file %s. Err: %s", filename, err)
+	}
+
+	byteValue, err := ioutil.ReadAll(file)
+	if err != nil {
+		return nil, fmt.Errorf("***Failed to read file %s. Err: %s",
+			filename, err)
+	}
+
+	var config types.ConfigItemValueMap
+	err = json.Unmarshal(byteValue, &config)
+	if err != nil {
+		return nil, fmt.Errorf("Could not unmarshall data in file %s. err: %s",
+			filename, err)
+	}
+	return &config, nil
+}

--- a/pkg/pillar/cmd/upgradeconverter/convertglobalconfig.go
+++ b/pkg/pillar/cmd/upgradeconverter/convertglobalconfig.go
@@ -11,13 +11,6 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/types"
 )
 
-const (
-	configItemMapDir    = types.PersistConfigDir + "/ConfigItemValueMap/"
-	newGlobalConfigFile = configItemMapDir + "global.json"
-	globalConfigDir     = types.PersistConfigDir + "/GlobalConfig"
-	oldGlobalConfigFile = globalConfigDir + "/global.json"
-)
-
 func createConfigItemMapDir(configItemMapDir string) {
 	info, err := os.Stat(configItemMapDir)
 	if err == nil {
@@ -61,8 +54,8 @@ func delOldGlobalConfigDir(ctxPtr *ucContext) error {
 }
 
 func convertGlobalConfig(ctxPtr *ucContext) error {
-	createConfigItemMapDir(ctxPtr.configItemValueMapDir())
-	newGlobalConfigFile := ctxPtr.configItemValueMapFile()
+	createConfigItemMapDir(ctxPtr.oldConfigItemValueMapDir())
+	newGlobalConfigFile := ctxPtr.oldConfigItemValueMapFile()
 	oldGlobalConfigFile := ctxPtr.globalConfigFile()
 	newExists := fileExists(newGlobalConfigFile)
 	oldExists := fileExists(oldGlobalConfigFile)

--- a/pkg/pillar/cmd/upgradeconverter/convertglobalconfig.go
+++ b/pkg/pillar/cmd/upgradeconverter/convertglobalconfig.go
@@ -9,7 +9,6 @@ import (
 	"os"
 
 	"github.com/lf-edge/eve/pkg/pillar/types"
-	"github.com/lf-edge/eve/pkg/pillar/utils"
 )
 
 const (
@@ -107,12 +106,6 @@ func convertGlobalConfig(ctxPtr *ucContext) error {
 		log.Fatalf("Failed to Save NewConfig. err %s", err)
 	}
 	log.Infof("Saved NewConfig. data: %s", data)
-
-	// Create a symlink of one doesn't currently exist
-	symLinkPath := ctxPtr.varTmpDir + "/ConfigItemValueMap"
-	utils.CreateSymlink(log, symLinkPath, ctxPtr.configItemValueMapDir())
-	log.Debugf("Created symlink %s -> %s",
-		symLinkPath, ctxPtr.configItemValueMapDir())
 
 	// Delete the OldGlobalConfig
 	delOldGlobalConfigDir(ctxPtr)

--- a/pkg/pillar/cmd/upgradeconverter/convertglobalconfig.go
+++ b/pkg/pillar/cmd/upgradeconverter/convertglobalconfig.go
@@ -121,7 +121,7 @@ func newConfigFromOld(globalConfigFile string) *types.ConfigItemValueMap {
 	}
 
 	var oldGlobalConfig types.OldGlobalConfig
-	err = json.Unmarshal([]byte(byteValue), &oldGlobalConfig)
+	err = json.Unmarshal(byteValue, &oldGlobalConfig)
 	if err != nil {
 		log.Errorf("Could not unmarshall data in file %s. err: %s",
 			globalConfigFile, err)

--- a/pkg/pillar/cmd/upgradeconverter/convertglobalconfig.go
+++ b/pkg/pillar/cmd/upgradeconverter/convertglobalconfig.go
@@ -54,11 +54,13 @@ func delOldGlobalConfigDir(ctxPtr *ucContext) error {
 }
 
 func convertGlobalConfig(ctxPtr *ucContext) error {
-	createConfigItemMapDir(ctxPtr.oldConfigItemValueMapDir())
-	newGlobalConfigFile := ctxPtr.oldConfigItemValueMapFile()
 	oldGlobalConfigFile := ctxPtr.globalConfigFile()
-	newExists := fileExists(newGlobalConfigFile)
 	oldExists := fileExists(oldGlobalConfigFile)
+	if oldExists {
+		createConfigItemMapDir(ctxPtr.oldConfigItemValueMapDir())
+	}
+	newGlobalConfigFile := ctxPtr.oldConfigItemValueMapFile()
+	newExists := fileExists(newGlobalConfigFile)
 
 	var newConfigPtr *types.ConfigItemValueMap
 
@@ -84,8 +86,8 @@ func convertGlobalConfig(ctxPtr *ucContext) error {
 		delOldGlobalConfigDir(ctxPtr)
 		return nil
 	} else {
-		log.Infof("Neither New Nor Old Configs Exist. Creating Default new Config")
-		newConfigPtr = types.DefaultConfigItemValueMap()
+		log.Infof("Neither New Nor Old Configs Exist. Do nothing")
+		return nil
 	}
 
 	// Save New config to file.
@@ -98,8 +100,6 @@ func convertGlobalConfig(ctxPtr *ucContext) error {
 	if err != nil {
 		log.Fatalf("Failed to Save NewConfig. err %s", err)
 	}
-	log.Infof("Saved NewConfig. data: %s", data)
-
 	// Delete the OldGlobalConfig
 	delOldGlobalConfigDir(ctxPtr)
 	log.Debugf("upgradeconverter.convertGlobalConfig done")

--- a/pkg/pillar/cmd/upgradeconverter/moveconfigitem.go
+++ b/pkg/pillar/cmd/upgradeconverter/moveconfigitem.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package upgradeconverter
+
+import (
+	"os"
+)
+
+func moveConfigItemValueMap(ctxPtr *ucContext) error {
+	createConfigItemMapDir(ctxPtr.newConfigItemValueMapDir())
+	newFile := ctxPtr.newConfigItemValueMapFile()
+	oldFile := ctxPtr.oldConfigItemValueMapFile()
+	newExists := fileExists(newFile)
+	oldExists := fileExists(oldFile)
+
+	if oldExists {
+		if newExists {
+			newTime, _ := fileTimeStamp(newFile)
+			oldTime, _ := fileTimeStamp(oldFile)
+			log.Debugf("moveConfigItemValueMap: newTime:%+v, oldTime: %+v",
+				newTime, oldTime)
+			if oldTime.After(newTime) {
+				log.Infof("oldFile more recent than newFile. Copy")
+			} else {
+				log.Infof("newFile more recent than oldFile. Discard old")
+				err := os.RemoveAll(ctxPtr.oldConfigItemValueMapDir())
+				if err != nil {
+					log.Error(err)
+				}
+				return nil
+			}
+		} else {
+			log.Infof("Old Config Exists. No New Config. Copy")
+		}
+	} else if newExists {
+		log.Infof("No Old Config. Only new Config Exists. No copy needed")
+		return nil
+	} else {
+		log.Infof("Neither new nor old configs exist. Bail")
+		return nil
+	}
+
+	log.Infof("Copy from %s to %s", oldFile, newFile)
+	err := CopyFile(oldFile, newFile)
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+	err = os.RemoveAll(ctxPtr.oldConfigItemValueMapDir())
+	if err != nil {
+		log.Error(err)
+	}
+	log.Debugf("upgradeconverter.moveConfigItemValueMap done")
+	return nil
+}

--- a/pkg/pillar/cmd/upgradeconverter/upgradeconverter.go
+++ b/pkg/pillar/cmd/upgradeconverter/upgradeconverter.go
@@ -30,6 +30,14 @@ var preVaultconversionHandlers = []ConversionHandler{
 		description: "Convert Global Settings to new format",
 		handlerFunc: convertGlobalConfig,
 	},
+	{
+		description: "Move ConfigItemValueMap from /persist/config to /persist/status",
+		handlerFunc: moveConfigItemValueMap,
+	},
+	{
+		description: "Apply defaults for new items in ConfigItemValueMap",
+		handlerFunc: applyDefaultConfigItem,
+	},
 }
 
 //postVaultconversionHandlers run after vault is setup
@@ -43,10 +51,6 @@ var postVaultconversionHandlers = []ConversionHandler{
 	{
 		description: "Move verified files to /persist/vault/verifier/verified",
 		handlerFunc: renameVerifiedFiles,
-	},
-	{
-		description: "Move ConfigItemValueMap to /persist/status",
-		handlerFunc: moveConfigItemValueMap,
 	},
 }
 
@@ -182,7 +186,7 @@ func RunPostVaultHandlers(moduleName string,
 	ctx := &ucContext{agentName: moduleName,
 		persistDir:       types.PersistDir,
 		persistConfigDir: types.PersistConfigDir,
-		varTmpDir:        "/var/tmp",
+		persistStatusDir: types.PersistStatusDir,
 		ps:               ps,
 	}
 	runPhase(ctx, UCPhasePostVault)
@@ -205,7 +209,7 @@ func RunPreVaultHandlers(moduleName string,
 	ctx := &ucContext{agentName: moduleName,
 		persistDir:       types.PersistDir,
 		persistConfigDir: types.PersistConfigDir,
-		varTmpDir:        "/var/tmp",
+		persistStatusDir: types.PersistStatusDir,
 		ps:               ps,
 	}
 	runPhase(ctx, UCPhasePreVault)

--- a/pkg/pillar/cmd/upgradeconverter/upgradeconverter.go
+++ b/pkg/pillar/cmd/upgradeconverter/upgradeconverter.go
@@ -54,7 +54,6 @@ type ucContext struct {
 	// FilePaths. These are defined here instead of consts for easier unit tests
 	persistDir       string
 	persistConfigDir string
-	varTmpDir        string
 	ps               *pubsub.PubSub
 }
 
@@ -113,7 +112,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	ctx := &ucContext{agentName: "upgradeconverter",
 		persistDir:       types.PersistDir,
 		persistConfigDir: types.PersistConfigDir,
-		varTmpDir:        "/var/tmp",
 		ps:               ps,
 	}
 	debugPtr := flag.Bool("d", false, "Debug flag")

--- a/pkg/pillar/cmd/upgradeconverter/upgradeconverter.go
+++ b/pkg/pillar/cmd/upgradeconverter/upgradeconverter.go
@@ -44,6 +44,10 @@ var postVaultconversionHandlers = []ConversionHandler{
 		description: "Move verified files to /persist/vault/verifier/verified",
 		handlerFunc: renameVerifiedFiles,
 	},
+	{
+		description: "Move ConfigItemValueMap to /persist/status",
+		handlerFunc: moveConfigItemValueMap,
+	},
 }
 
 type ucContext struct {
@@ -54,20 +58,27 @@ type ucContext struct {
 	// FilePaths. These are defined here instead of consts for easier unit tests
 	persistDir       string
 	persistConfigDir string
+	persistStatusDir string
 	ps               *pubsub.PubSub
 }
 
-func (ctx ucContext) configItemValueMapDir() string {
+func (ctx ucContext) oldConfigItemValueMapDir() string {
 	return ctx.persistConfigDir + "/ConfigItemValueMap/"
 }
-func (ctx ucContext) configItemValueMapFile() string {
-	return ctx.configItemValueMapDir() + "/global.json"
+func (ctx ucContext) oldConfigItemValueMapFile() string {
+	return ctx.oldConfigItemValueMapDir() + "/global.json"
 }
 func (ctx ucContext) globalConfigDir() string {
 	return ctx.persistConfigDir + "/GlobalConfig"
 }
 func (ctx ucContext) globalConfigFile() string {
 	return ctx.globalConfigDir() + "/global.json"
+}
+func (ctx ucContext) newConfigItemValueMapDir() string {
+	return ctx.persistStatusDir + "/zedagent/ConfigItemValueMap/"
+}
+func (ctx ucContext) newConfigItemValueMapFile() string {
+	return ctx.newConfigItemValueMapDir() + "/global.json"
 }
 
 // Old location for volumes
@@ -112,6 +123,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	ctx := &ucContext{agentName: "upgradeconverter",
 		persistDir:       types.PersistDir,
 		persistConfigDir: types.PersistConfigDir,
+		persistStatusDir: types.PersistStatusDir,
 		ps:               ps,
 	}
 	debugPtr := flag.Bool("d", false, "Debug flag")

--- a/pkg/pillar/cmd/upgradeconverter/upgradeconverter_test.go
+++ b/pkg/pillar/cmd/upgradeconverter/upgradeconverter_test.go
@@ -112,10 +112,6 @@ func ucContextForTest() *ucContext {
 	if err != nil {
 		log.Fatalf("Failed to create persistConfigDir. err: %s", err)
 	}
-	ctxPtr.varTmpDir, err = ioutil.TempDir(".", "ConvertvarTmp")
-	if err != nil {
-		log.Fatalf("Failed to create varTmpDir. err: %s", err)
-	}
 	return ctxPtr
 }
 
@@ -124,8 +120,6 @@ func ucContextCleanupDirs(ctxPtr *ucContext) {
 	ctxPtr.persistDir = ""
 	os.RemoveAll(ctxPtr.persistConfigDir)
 	ctxPtr.persistConfigDir = ""
-	os.RemoveAll(ctxPtr.varTmpDir)
-	ctxPtr.varTmpDir = ""
 }
 
 func runTestMatrix(t *testing.T, testMatrix map[string]testEntry) {

--- a/pkg/pillar/cmd/upgradeconverter/upgradeconverter_test.go
+++ b/pkg/pillar/cmd/upgradeconverter/upgradeconverter_test.go
@@ -188,10 +188,9 @@ func Test_ConvertGlobalConfig(t *testing.T) {
 
 	testMatrix := map[string]testEntry{
 		"Convert: Neither Old Version Nor New Version exist.": {
-			// Default ConfigItemValueMap gets creates
+			// Does notthing
 			oldVersionExists:  false,
 			newVersionExists:  false,
-			newConfigPtr:      types.DefaultConfigItemValueMap(),
 			expectNoOldCfgDir: true,
 		},
 		"Convert: Old Version Exists, No New Version - Normal Upgrade case": {

--- a/pkg/pillar/cmd/upgradeconverter/upgradeconverter_test.go
+++ b/pkg/pillar/cmd/upgradeconverter/upgradeconverter_test.go
@@ -108,9 +108,13 @@ func ucContextForTest() *ucContext {
 	if err != nil {
 		log.Fatalf("Failed to create persistDir. err: %s", err)
 	}
-	ctxPtr.persistConfigDir, err = ioutil.TempDir(".", "Converter")
+	ctxPtr.persistConfigDir, err = ioutil.TempDir(".", "PersistConfigDir")
 	if err != nil {
 		log.Fatalf("Failed to create persistConfigDir. err: %s", err)
+	}
+	ctxPtr.persistStatusDir, err = ioutil.TempDir(".", "PersistStatusDir")
+	if err != nil {
+		log.Fatalf("Failed to create persistStatusDir. err: %s", err)
 	}
 	return ctxPtr
 }
@@ -123,7 +127,8 @@ func ucContextCleanupDirs(ctxPtr *ucContext) {
 }
 
 func runTestMatrix(t *testing.T, testMatrix map[string]testEntry) {
-	log = base.NewSourceLogObject(logrus.StandardLogger(), "domainmgr", 0)
+	logrus.SetLevel(logrus.DebugLevel)
+	log = base.NewSourceLogObject(logrus.StandardLogger(), "test", 1234)
 	oldConfig := oldGlobalConfig()
 	newConfig := newConfigItemValueMap()
 
@@ -134,7 +139,7 @@ func runTestMatrix(t *testing.T, testMatrix map[string]testEntry) {
 			createJSONFile(oldConfig, ctxPtr.globalConfigFile())
 		}
 		if test.newVersionExists {
-			createJSONFile(newConfig, ctxPtr.configItemValueMapFile())
+			createJSONFile(newConfig, ctxPtr.oldConfigItemValueMapFile())
 		}
 		if test.oldVersionExists && !test.oldVersionOlder {
 			time.Sleep(2 * time.Second)
@@ -145,10 +150,10 @@ func runTestMatrix(t *testing.T, testMatrix map[string]testEntry) {
 			t.Fatalf("Unexpected Failure in GlobalConfigHandler. err: %s", err)
 		}
 		if test.newConfigPtr == nil {
-			checkNoDir(t, ctxPtr.configItemValueMapDir())
+			checkNoDir(t, ctxPtr.oldConfigItemValueMapDir())
 		} else {
 			newCfgFromFile := configItemValueMapFromFile(
-				ctxPtr.configItemValueMapFile())
+				ctxPtr.oldConfigItemValueMapFile())
 			if !cmp.Equal(test.newConfigPtr, newCfgFromFile) {
 				msg := ""
 				for key, value := range test.newConfigPtr.GlobalSettings {
@@ -174,7 +179,7 @@ func runTestMatrix(t *testing.T, testMatrix map[string]testEntry) {
 
 }
 
-func Test_UpgradeConverter_Convert(t *testing.T) {
+func Test_ConvertGlobalConfig(t *testing.T) {
 	oldConfig := oldGlobalConfig()
 	newConfig := newConfigItemValueMap()
 	convertedConfig := oldConfig.MoveBetweenConfigs()
@@ -182,34 +187,135 @@ func Test_UpgradeConverter_Convert(t *testing.T) {
 	testMatrix := map[string]testEntry{
 		"Convert: Neither Old Version Nor New Version exist.": {
 			// Default ConfigItemValueMap gets creates
-			oldVersionExists: false,
-			newVersionExists: false,
-			newConfigPtr:     types.DefaultConfigItemValueMap(),
+			oldVersionExists:  false,
+			newVersionExists:  false,
+			newConfigPtr:      types.DefaultConfigItemValueMap(),
+			expectNoOldCfgDir: true,
 		},
 		"Convert: Old Version Exists, No New Version - Normal Upgrade case": {
 			// Old Converted to New
-			oldVersionExists: true,
-			newConfigPtr:     convertedConfig,
+			oldVersionExists:  true,
+			newConfigPtr:      convertedConfig,
+			expectNoOldCfgDir: true,
 		},
 		"Convert: Old Version Older than New Version": {
+			// oldVersion Ignored. New version used.
+			oldVersionExists:  true,
+			newVersionExists:  true,
+			oldVersionOlder:   true,
+			newConfigPtr:      &newConfig,
+			expectNoOldCfgDir: true,
+		},
+		"Convert: Old Version Newer than New Version": {
+			// New Version Regenerated ( Convert Old to New)
+			oldVersionExists:  true,
+			newVersionExists:  true,
+			oldVersionOlder:   false,
+			newConfigPtr:      convertedConfig,
+			expectNoOldCfgDir: true,
+		},
+		"Convert: Only New Version exists. Upgrade from one new version to another": {
+			// New Version untouched
+			newVersionExists:  true,
+			newConfigPtr:      &newConfig,
+			expectNoOldCfgDir: true,
+		},
+	}
+	runTestMatrix(t, testMatrix)
+}
+
+func Test_MoveConfigItem(t *testing.T) {
+	oldConfig := newConfigItemValueMap()
+	newConfig := types.DefaultConfigItemValueMap()
+	newConfig.SetGlobalValueString(types.DefaultLogLevel, "trace")
+
+	type moveTestEntry struct {
+		oldVersionExists bool
+		newVersionExists bool
+		oldVersionOlder  bool
+		// newConfigPtr - If nil, verifies no NewCfgDir. If not, expect contents
+		//  to match.
+		newConfigPtr *types.ConfigItemValueMap
+		// expectOldDir - Verified old dir to still exist
+		expectOldDir bool
+	}
+
+	testMatrix := map[string]moveTestEntry{
+		"Move: Neither Old Version Nor New Version exist.": {
+			// Nothing copied/created
+			oldVersionExists: false,
+			newVersionExists: false,
+		},
+		"Move: Old Version Exists, No New Version - Normal copy case": {
+			oldVersionExists: true,
+			newConfigPtr:     &oldConfig,
+		},
+		"Move: Old Version Older than New Version": {
 			// oldVersion Ignored. New version used.
 			oldVersionExists: true,
 			newVersionExists: true,
 			oldVersionOlder:  true,
-			newConfigPtr:     &newConfig,
+			newConfigPtr:     newConfig,
 		},
-		"Convert: Old Version Newer than New Version": {
-			// New Version Regenerated ( Convert Old to New)
+		"Move: Old Version Newer than New Version": {
+			// New Version Regenerated by copying old
 			oldVersionExists: true,
 			newVersionExists: true,
 			oldVersionOlder:  false,
-			newConfigPtr:     convertedConfig,
+			newConfigPtr:     &oldConfig,
 		},
-		"Convert: Only New Version exists. Upgrade from one new version to another": {
+		"Move: Only New Version exists. Upgrade from one new version to another": {
 			// New Version untouched
 			newVersionExists: true,
-			newConfigPtr:     &newConfig,
+			newConfigPtr:     newConfig,
 		},
 	}
-	runTestMatrix(t, testMatrix)
+
+	logrus.SetLevel(logrus.DebugLevel)
+	log = base.NewSourceLogObject(logrus.StandardLogger(), "test", 1234)
+	for testname, test := range testMatrix {
+		t.Logf("Running test case %s", testname)
+		ctxPtr := ucContextForTest()
+		if test.oldVersionExists && test.oldVersionOlder {
+			createJSONFile(oldConfig, ctxPtr.oldConfigItemValueMapFile())
+		}
+		if test.newVersionExists {
+			createJSONFile(newConfig, ctxPtr.newConfigItemValueMapFile())
+		}
+		if test.oldVersionExists && !test.oldVersionOlder {
+			time.Sleep(2 * time.Second)
+			createJSONFile(oldConfig, ctxPtr.oldConfigItemValueMapFile())
+		}
+		err := moveConfigItemValueMap(ctxPtr)
+		if err != nil {
+			t.Fatalf("Unexpected Failure in convertGlobalConfig. err: %s", err)
+		}
+		if test.newConfigPtr == nil {
+			checkNoDir(t, ctxPtr.oldConfigItemValueMapDir())
+		} else {
+			newCfgFromFile := configItemValueMapFromFile(
+				ctxPtr.newConfigItemValueMapFile())
+			if !cmp.Equal(test.newConfigPtr, newCfgFromFile) {
+				msg := ""
+				for key, value := range test.newConfigPtr.GlobalSettings {
+					newVal, ok := newCfgFromFile.GlobalSettings[key]
+					if !ok {
+						msg += fmt.Sprintf("Key %s not present in newCfgFromFile",
+							key)
+						continue
+					} else if value != newVal {
+						msg += fmt.Sprintf("Key %s value != newVal\n"+
+							"Value: %+v\nnewVal: %+v\n", key, value, newVal)
+					}
+				}
+				t.Fatalf("Expected newConfig !=  Actual newConfig.\nDIFF: %s",
+					msg)
+			}
+		}
+		if !test.expectOldDir {
+			checkNoDir(t, ctxPtr.oldConfigItemValueMapDir())
+		}
+		ucContextCleanupDirs(ctxPtr)
+	}
+
 }

--- a/pkg/pillar/cmd/vaultmgr/vaultmgr.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgr.go
@@ -768,7 +768,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 		// Look for global config such as log levels
 		subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-			AgentName:     "",
+			AgentName:     "zedagent",
 			MyAgentName:   agentName,
 			TopicImpl:     types.ConfigItemValueMap{},
 			Persistent:    true,

--- a/pkg/pillar/cmd/vaultmgr/vaultmgr.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgr.go
@@ -771,6 +771,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 			AgentName:     "",
 			MyAgentName:   agentName,
 			TopicImpl:     types.ConfigItemValueMap{},
+			Persistent:    true,
 			Activate:      false,
 			Ctx:           &ctx,
 			CreateHandler: handleGlobalConfigModify,

--- a/pkg/pillar/cmd/verifier/verifier.go
+++ b/pkg/pillar/cmd/verifier/verifier.go
@@ -108,6 +108,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		AgentName:     "",
 		MyAgentName:   agentName,
 		TopicImpl:     types.ConfigItemValueMap{},
+		Persistent:    true,
 		Activate:      false,
 		Ctx:           &ctx,
 		CreateHandler: handleGlobalConfigModify,

--- a/pkg/pillar/cmd/verifier/verifier.go
+++ b/pkg/pillar/cmd/verifier/verifier.go
@@ -105,7 +105,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName:     "",
+		AgentName:     "zedagent",
 		MyAgentName:   agentName,
 		TopicImpl:     types.ConfigItemValueMap{},
 		Persistent:    true,

--- a/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
+++ b/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
@@ -106,21 +106,24 @@ func diskMetricsTimerTask(ctx *volumemgrContext, handleChannel chan interface{})
 	// Return handle to caller
 	handleChannel <- diskMetricTicker
 
+	wdName := agentName + "metrics"
+
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(25 * time.Second)
-	ctx.ps.StillRunning(diskMetricsAgentName, warningTime, errorTime)
+	ctx.ps.StillRunning(wdName, warningTime, errorTime)
+	ctx.ps.RegisterFileWatchdog(wdName)
 
 	for {
 		select {
 		case <-diskMetricTicker.C:
 			start := time.Now()
 			createOrUpdateDiskMetrics(ctx)
-			ctx.ps.CheckMaxTimeTopic(diskMetricsAgentName, "createOrUpdateDiskMetrics", start,
+			ctx.ps.CheckMaxTimeTopic(wdName, "createOrUpdateDiskMetrics", start,
 				warningTime, errorTime)
 
 		case <-stillRunning.C:
 		}
-		ctx.ps.StillRunning(diskMetricsAgentName, warningTime, errorTime)
+		ctx.ps.StillRunning(wdName, warningTime, errorTime)
 	}
 }
 

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -27,8 +27,8 @@ import (
 
 const (
 	agentName              = "volumemgr"
-	runDirname             = "/var/run/" + agentName
-	ciDirname              = runDirname + "/cloudinit"    // For cloud-init volumes XXX change?
+	runDirname             = "/run/" + agentName
+	ciDirname              = runDirname + "/cloudinit"    // For cloud-init volumes
 	volumeEncryptedDirName = types.VolumeEncryptedDirName // We store encrypted VM and OCI volumes here
 	volumeClearDirName     = types.VolumeClearDirName     // We store un-encrypted VM and OCI volumes here
 	// Time limits for event loop handlers

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -27,8 +27,6 @@ import (
 
 const (
 	agentName              = "volumemgr"
-	diskMetricsAgentName   = agentName + "metrics"
-	diskMetricsWDTouchFile = types.WatchdogFileDir + "/" + diskMetricsAgentName + ".touch"
 	runDirname             = "/var/run/" + agentName
 	ciDirname              = runDirname + "/cloudinit"    // For cloud-init volumes XXX change?
 	volumeEncryptedDirName = types.VolumeEncryptedDirName // We store encrypted VM and OCI volumes here
@@ -501,9 +499,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// start the metrics reporting task
 	diskMetricsTickerHandle := make(chan interface{})
 	log.Infof("Creating %s at %s", "diskMetricsTimerTask", agentlog.GetMyStack())
-
-	//Add .touch file to watchdog config
-	base.TouchFile(log, diskMetricsWDTouchFile)
 
 	go diskMetricsTimerTask(&ctx, diskMetricsTickerHandle)
 	ctx.diskMetricsTickerHandle = <-diskMetricsTickerHandle

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -130,7 +130,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName:     "",
+		AgentName:     "zedagent",
 		MyAgentName:   agentName,
 		TopicImpl:     types.ConfigItemValueMap{},
 		Persistent:    true,

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -133,6 +133,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		AgentName:     "",
 		MyAgentName:   agentName,
 		TopicImpl:     types.ConfigItemValueMap{},
+		Persistent:    true,
 		Activate:      false,
 		Ctx:           &ctx,
 		CreateHandler: handleGlobalConfigModify,

--- a/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
+++ b/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
@@ -92,7 +92,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName:     "",
+		AgentName:     "zedagent",
 		MyAgentName:   agentName,
 		TopicImpl:     types.ConfigItemValueMap{},
 		Persistent:    true,

--- a/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
+++ b/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
@@ -95,6 +95,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		AgentName:     "",
 		MyAgentName:   agentName,
 		TopicImpl:     types.ConfigItemValueMap{},
+		Persistent:    true,
 		Activate:      false,
 		Ctx:           &wscCtx,
 		CreateHandler: handleGlobalConfigModify,

--- a/pkg/pillar/cmd/zedagent/attesttask.go
+++ b/pkg/pillar/cmd/zedagent/attesttask.go
@@ -24,6 +24,10 @@ import (
 	"strings"
 )
 
+const (
+	attestWdName = agentName + "attest"
+)
+
 //TpmAgentImpl implements zattest.TpmAgent interface
 type TpmAgentImpl struct{}
 
@@ -412,7 +416,7 @@ func (agent *TpmAgentImpl) SendInternalQuoteRequest(ctx *zattest.Context) error 
 //PunchWatchdog implements PunchWatchdog method of zattest.Watchdog
 func (wd *WatchdogImpl) PunchWatchdog(ctx *zattest.Context) error {
 	log.Debug("[ATTEST] Punching watchdog")
-	ctx.PubSub.StillRunning(agentName+"attest", warningTime, errorTime)
+	ctx.PubSub.StillRunning(attestWdName, warningTime, errorTime)
 	return nil
 }
 
@@ -499,6 +503,9 @@ func attestModuleStart(ctx *zedagentContext) error {
 		agentlog.GetMyStack())
 	go ctx.attestCtx.attestFsmCtx.EnterEventLoop()
 	zattest.Kickstart(ctx.attestCtx.attestFsmCtx)
+
+	// Add .touch file to watchdog config
+	ctx.ps.RegisterFileWatchdog(attestWdName)
 	return nil
 }
 

--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -165,21 +165,24 @@ func controllerCertsTask(ctx *zedagentContext, triggerCerts <-chan struct{}) {
 	log.Infoln("starting controller certificate fetch task")
 	getCertsFromController(ctx)
 
+	wdName := agentName + "ccerts"
+
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(25 * time.Second)
-	ctx.ps.StillRunning(agentName+"ccerts", warningTime, errorTime)
+	ctx.ps.StillRunning(wdName, warningTime, errorTime)
+	ctx.ps.RegisterFileWatchdog(wdName)
 
 	for {
 		select {
 		case <-triggerCerts:
 			start := time.Now()
 			getCertsFromController(ctx)
-			ctx.ps.CheckMaxTimeTopic(agentName+"ccerts", "publishCerts", start,
+			ctx.ps.CheckMaxTimeTopic(wdName, "publishCerts", start,
 				warningTime, errorTime)
 
 		case <-stillRunning.C:
 		}
-		ctx.ps.StillRunning(agentName+"ccerts", warningTime, errorTime)
+		ctx.ps.StillRunning(wdName, warningTime, errorTime)
 	}
 }
 
@@ -252,21 +255,24 @@ func edgeNodeCertsTask(ctx *zedagentContext, triggerEdgeNodeCerts chan struct{})
 
 	publishEdgeNodeCertsToController(ctx)
 
+	wdName := agentName + "ecerts"
+
 	stillRunning := time.NewTicker(25 * time.Second)
-	ctx.ps.StillRunning(agentName+"attest", warningTime, errorTime)
+	ctx.ps.StillRunning(wdName, warningTime, errorTime)
+	ctx.ps.RegisterFileWatchdog(wdName)
 
 	for {
 		select {
 		case <-triggerEdgeNodeCerts:
 			start := time.Now()
 			publishEdgeNodeCertsToController(ctx)
-			ctx.ps.CheckMaxTimeTopic(agentName+"attest",
+			ctx.ps.CheckMaxTimeTopic(wdName,
 				"publishEdgeNodeCertsToController", start,
 				warningTime, errorTime)
 
 		case <-stillRunning.C:
 		}
-		ctx.ps.StillRunning(agentName+"attest", warningTime, errorTime)
+		ctx.ps.StillRunning(wdName, warningTime, errorTime)
 	}
 }
 

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -134,9 +134,12 @@ func configTimerTask(handleChannel chan interface{},
 	// Return handle to caller
 	handleChannel <- ticker
 
+	wdName := agentName + "config"
+
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(25 * time.Second)
-	ctx.ps.StillRunning(agentName+"config", warningTime, errorTime)
+	ctx.ps.StillRunning(wdName, warningTime, errorTime)
+	ctx.ps.RegisterFileWatchdog(wdName)
 
 	for {
 		select {
@@ -145,7 +148,7 @@ func configTimerTask(handleChannel chan interface{},
 			iteration += 1
 			rebootFlag := getLatestConfig(configUrl, iteration, getconfigCtx)
 			getconfigCtx.rebootFlag = getconfigCtx.rebootFlag || rebootFlag
-			ctx.ps.CheckMaxTimeTopic(agentName+"config", "getLastestConfig", start,
+			ctx.ps.CheckMaxTimeTopic(wdName, "getLastestConfig", start,
 				warningTime, errorTime)
 			publishZedAgentStatus(getconfigCtx)
 
@@ -154,7 +157,7 @@ func configTimerTask(handleChannel chan interface{},
 				log.Infof("reboot flag set")
 			}
 		}
-		ctx.ps.StillRunning(agentName+"config", warningTime, errorTime)
+		ctx.ps.StillRunning(wdName, warningTime, errorTime)
 	}
 }
 

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -148,9 +148,12 @@ func metricsTimerTask(ctx *zedagentContext, handleChannel chan interface{}) {
 	// Return handle to caller
 	handleChannel <- ticker
 
+	wdName := agentName + "metrics"
+
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(25 * time.Second)
-	ctx.ps.StillRunning(agentName+"metrics", warningTime, errorTime)
+	ctx.ps.StillRunning(wdName, warningTime, errorTime)
+	ctx.ps.RegisterFileWatchdog(wdName)
 
 	for {
 		select {
@@ -158,12 +161,12 @@ func metricsTimerTask(ctx *zedagentContext, handleChannel chan interface{}) {
 			start := time.Now()
 			iteration++
 			publishMetrics(ctx, iteration)
-			ctx.ps.CheckMaxTimeTopic(agentName+"metrics", "publishMetrics", start,
+			ctx.ps.CheckMaxTimeTopic(wdName, "publishMetrics", start,
 				warningTime, errorTime)
 
 		case <-stillRunning.C:
 		}
-		ctx.ps.StillRunning(agentName+"metrics", warningTime, errorTime)
+		ctx.ps.StillRunning(wdName, warningTime, errorTime)
 	}
 }
 

--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -8,7 +8,6 @@ package zedagent
 import (
 	"bytes"
 	"fmt"
-	"github.com/lf-edge/eve/pkg/pillar/base"
 	"os"
 	"strings"
 	"time"
@@ -18,6 +17,7 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/lf-edge/eve/api/go/evecommon"
 	"github.com/lf-edge/eve/api/go/info"
+	"github.com/lf-edge/eve/pkg/pillar/base"
 	etpm "github.com/lf-edge/eve/pkg/pillar/evetpm"
 	"github.com/lf-edge/eve/pkg/pillar/hardware"
 	"github.com/lf-edge/eve/pkg/pillar/netclone"
@@ -33,9 +33,12 @@ var (
 )
 
 func deviceInfoTask(ctxPtr *zedagentContext, triggerDeviceInfo <-chan struct{}) {
+	wdName := agentName + "devinfo"
 
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(25 * time.Second)
+	ctxPtr.ps.StillRunning(wdName, warningTime, errorTime)
+	ctxPtr.ps.RegisterFileWatchdog(wdName)
 
 	for {
 		select {
@@ -46,11 +49,11 @@ func deviceInfoTask(ctxPtr *zedagentContext, triggerDeviceInfo <-chan struct{}) 
 			PublishDeviceInfoToZedCloud(ctxPtr)
 			ctxPtr.iteration++
 			log.Info("deviceInfoTask done with message")
-			ctxPtr.ps.CheckMaxTimeTopic(agentName+"devinfo", "PublishDeviceInfo", start,
+			ctxPtr.ps.CheckMaxTimeTopic(wdName, "PublishDeviceInfo", start,
 				warningTime, errorTime)
 		case <-stillRunning.C:
 		}
-		ctxPtr.ps.StillRunning(agentName+"devinfo", warningTime, errorTime)
+		ctxPtr.ps.StillRunning(wdName, warningTime, errorTime)
 	}
 }
 

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -236,11 +236,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(25 * time.Second)
 	ps.StillRunning(agentName, warningTime, errorTime)
-	ps.StillRunning(agentName+"config", warningTime, errorTime)
-	ps.StillRunning(agentName+"metrics", warningTime, errorTime)
-	ps.StillRunning(agentName+"devinfo", warningTime, errorTime)
-	ps.StillRunning(agentName+"ccerts", warningTime, errorTime)
-	ps.StillRunning(agentName+"attest", warningTime, errorTime)
 
 	initializeDirs()
 
@@ -917,12 +912,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		} else {
 			ps.StillRunning(agentName, warningTime, errorTime)
 		}
-		// Need to tickle this since the configTimerTask is not yet started
-		ps.StillRunning(agentName+"config", warningTime, errorTime)
-		ps.StillRunning(agentName+"metrics", warningTime, errorTime)
-		ps.StillRunning(agentName+"devinfo", warningTime, errorTime)
-		ps.StillRunning(agentName+"ccerts", warningTime, errorTime)
-		ps.StillRunning(agentName+"attest", warningTime, errorTime)
 	}
 
 	log.Infof("Waiting until we have some uplinks with usable addresses")
@@ -972,12 +961,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		} else {
 			ps.StillRunning(agentName, warningTime, errorTime)
 		}
-		// Need to tickle this since the configTimerTask is not yet started
-		ps.StillRunning(agentName+"config", warningTime, errorTime)
-		ps.StillRunning(agentName+"metrics", warningTime, errorTime)
-		ps.StillRunning(agentName+"devinfo", warningTime, errorTime)
-		ps.StillRunning(agentName+"attest", warningTime, errorTime)
-		ps.StillRunning(agentName+"ccerts", warningTime, errorTime)
 	}
 
 	// Subscribe to network metrics from zedrouter

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -217,7 +217,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	zedagentCtx.physicalIoAdapterMap = make(map[string]types.PhysicalIOAdapter)
 
 	zedagentCtx.pubGlobalConfig, err = ps.NewPublication(pubsub.PublicationOptions{
-		AgentName:  "",
+		AgentName:  agentName,
 		TopicType:  types.ConfigItemValueMap{},
 		Persistent: true,
 	})
@@ -433,7 +433,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName:     "",
+		AgentName:     agentName,
 		MyAgentName:   agentName,
 		TopicImpl:     types.ConfigItemValueMap{},
 		Persistent:    true,

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -138,7 +138,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName:     "",
+		AgentName:     "zedagent",
 		MyAgentName:   agentName,
 		TopicImpl:     types.ConfigItemValueMap{},
 		Persistent:    true,

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -141,6 +141,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		AgentName:     "",
 		MyAgentName:   agentName,
 		TopicImpl:     types.ConfigItemValueMap{},
+		Persistent:    true,
 		Activate:      false,
 		Ctx:           &ctx,
 		CreateHandler: handleGlobalConfigModify,

--- a/pkg/pillar/cmd/zedrouter/dnsmasq.go
+++ b/pkg/pillar/cmd/zedrouter/dnsmasq.go
@@ -387,7 +387,6 @@ func RemoveDirContent(dir string) error {
 }
 
 // Run this:
-//    DMDIR=/opt/zededa/bin/
 //    ${DMDIR}/dnsmasq -b -C /var/run/zedrouter/dnsmasq.${BRIDGENAME}.conf
 func startDnsmasq(bridgeName string) {
 

--- a/pkg/pillar/cmd/zedrouter/dnsmasq.go
+++ b/pkg/pillar/cmd/zedrouter/dnsmasq.go
@@ -163,7 +163,7 @@ func createDnsmasqConfiglet(
 		file.WriteString(fmt.Sprintf("ipset=/%s/ipv4.%s,ipv6.%s\n",
 			ipset, ipset, ipset))
 	}
-	file.WriteString(fmt.Sprintf("pid-file=/var/run/dnsmasq.%s.pid\n",
+	file.WriteString(fmt.Sprintf("pid-file=/run/dnsmasq.%s.pid\n",
 		bridgeName))
 	file.WriteString(fmt.Sprintf("interface=%s\n", bridgeName))
 	isIPv6 := false
@@ -387,7 +387,7 @@ func RemoveDirContent(dir string) error {
 }
 
 // Run this:
-//    ${DMDIR}/dnsmasq -b -C /var/run/zedrouter/dnsmasq.${BRIDGENAME}.conf
+//    ${DMDIR}/dnsmasq -b -C /run/zedrouter/dnsmasq.${BRIDGENAME}.conf
 func startDnsmasq(bridgeName string) {
 
 	log.Infof("startDnsmasq(%s)\n", bridgeName)
@@ -412,7 +412,7 @@ func startDnsmasq(bridgeName string) {
 func stopDnsmasq(bridgeName string, printOnError bool, delConfiglet bool) {
 
 	log.Infof("stopDnsmasq(%s)\n", bridgeName)
-	pidfile := fmt.Sprintf("/var/run/dnsmasq.%s.pid", bridgeName)
+	pidfile := fmt.Sprintf("/run/dnsmasq.%s.pid", bridgeName)
 	pidByte, err := ioutil.ReadFile(pidfile)
 	if err != nil {
 		log.Errorf("stopDnsmasq: pid file read error %v\n", err)

--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -503,7 +503,7 @@ func doNetworkInstanceCreate(ctx *zedrouterContext,
 	log.Infof("IpAddress set for bridge\n")
 
 	// Create a hosts directory for the new bridge
-	// Directory is /var/run/zedrouter/hosts.${BRIDGENAME}
+	// Directory is /run/zedrouter/hosts.${BRIDGENAME}
 	hostsDirpath := runDirname + "/hosts." + bridgeName
 	deleteHostsConfiglet(hostsDirpath, false)
 	createHostsConfiglet(hostsDirpath,

--- a/pkg/pillar/cmd/zedrouter/radvd.go
+++ b/pkg/pillar/cmd/zedrouter/radvd.go
@@ -55,11 +55,11 @@ func deleteRadvdConfiglet(cfgPathname string) {
 }
 
 // Run this:
-//    radvd -u radvd -C /var/run/zedrouter/radvd.${OLIFNAME}.conf -p /var/run/radvd.${OLIFNAME}.pid
+//    radvd -u radvd -C /run/zedrouter/radvd.${OLIFNAME}.conf -p /run/radvd.${OLIFNAME}.pid
 func startRadvd(cfgPathname string, olIfname string) {
 
 	log.Debugf("startRadvd: %s\n", cfgPathname)
-	pidPathname := "/var/run/radvd." + olIfname + ".pid"
+	pidPathname := "/run/radvd." + olIfname + ".pid"
 	cmd := "nohup"
 	args := []string{
 		"radvd",

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -199,7 +199,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName:     "",
+		AgentName:     "zedagent",
 		MyAgentName:   agentName,
 		TopicImpl:     types.ConfigItemValueMap{},
 		Persistent:    true,

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -202,6 +202,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		AgentName:     "",
 		MyAgentName:   agentName,
 		TopicImpl:     types.ConfigItemValueMap{},
+		Persistent:    true,
 		Activate:      false,
 		Ctx:           &zedrouterCtx,
 		CreateHandler: handleGlobalConfigModify,

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -35,7 +35,7 @@ import (
 
 const (
 	agentName  = "zedrouter"
-	runDirname = "/var/run/zedrouter"
+	runDirname = "/run/zedrouter"
 	// DropMarkValue :
 	DropMarkValue = 0xFFFFFF
 	// Time limits for event loop handlers

--- a/pkg/pillar/containerd/containerd.go
+++ b/pkg/pillar/containerd/containerd.go
@@ -55,9 +55,9 @@ const (
 	// container config file name
 	imageConfigFilename = "image-config.json"
 	// default socket to connect tasks to memlogd
-	logWriteSocket = "/var/run/linuxkit-external-logging.sock"
+	logWriteSocket = "/run/linuxkit-external-logging.sock"
 	// default socket to read from memlogd
-	logReadSocket = "/var/run/memlogdq.sock"
+	logReadSocket = "/run/memlogdq.sock"
 
 	//TBD: Have a better way to calculate this number.
 	//For now it is based on some trial-and-error experiments

--- a/pkg/pillar/containerd/logging.go
+++ b/pkg/pillar/containerd/logging.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	fifoDir        string = "/var/run/tasks/fifos"
+	fifoDir        string = "/run/tasks/fifos"
 	logDumpCommand byte   = iota
 )
 

--- a/pkg/pillar/docs/tpmmgr.md
+++ b/pkg/pillar/docs/tpmmgr.md
@@ -27,4 +27,4 @@ Go-tpm package is hosted at <https://github.com/google/go-tpm/>. Go-tpm is licen
 ## Debugging
 
 To print TPM vendor information, use `/opt/zededa/bin/tpmmgr printCapability`
-To see logs from tpmmgr, one can find it under `/persist/<IMGA/IMGB>/log/tpmmgr.log`
+To see logs from tpmmgr, one can find recent ones with source being tpmmgr it under `/persist/rsyslog/syslog.txt` or on the controller.

--- a/pkg/pillar/docs/vaultmgr.md
+++ b/pkg/pillar/docs/vaultmgr.md
@@ -25,7 +25,6 @@ The encryption key is randomly generated during first time installation, and sto
 One can use `/opt/zededa/bin/fscrypt` command to print the status of vaults on the pillar shell prompt.
 To see logs from vaultmgr, one can find recent ones with source being vaultmgr it under `/persist/rsyslog/syslog.txt` or on the controller.
 
-
 ## Future Work
 
 There is a lot of scope for further hardening of data security at rest, at the Edge. Please refer to [https://wiki.lfedge.org/display/EVE/Security+APIs](https://wiki.lfedge.org/display/EVE/Security+APIs) for future enhancements being discussed.

--- a/pkg/pillar/docs/vaultmgr.md
+++ b/pkg/pillar/docs/vaultmgr.md
@@ -22,7 +22,9 @@ The encryption key is randomly generated during first time installation, and sto
 
 ## Troubleshooting
 
-`/persist/IMGX/log/vaultmgr.log` has logs from vaultmgr. One can also use `/opt/zededa/bin/fscrypt` command to print the status of vaults on the pillar shell prompt.
+One can use `/opt/zededa/bin/fscrypt` command to print the status of vaults on the pillar shell prompt.
+To see logs from vaultmgr, one can find recent ones with source being vaultmgr it under `/persist/rsyslog/syslog.txt` or on the controller.
+
 
 ## Future Work
 

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -303,7 +303,7 @@ const qemuUsbHostTemplate = `
   hostaddr = "{{.UsbDevAddr}}"
 `
 
-const kvmStateDir = "/var/run/hypervisor/kvm/"
+const kvmStateDir = "/run/hypervisor/kvm/"
 const sysfsPciDevices = "/sys/bus/pci/devices/"
 const sysfsVfioPciBind = "/sys/bus/pci/drivers/vfio-pci/bind"
 const sysfsPciDriversProbe = "/sys/bus/pci/drivers_probe"
@@ -311,7 +311,7 @@ const vfioDriverPath = "/sys/bus/pci/drivers/vfio-pci"
 
 // KVM domains map 1-1 to anchor device model UNIX processes (qemu or firecracker)
 // For every anchor process we maintain the following entry points in the
-// /var/run/hypervisor/kvm/DOMAIN_NAME:
+// /run/hypervisor/kvm/DOMAIN_NAME:
 //    pid - contains PID of the anchor process
 //    qmp - UNIX domain socket that allows us to talk to anchor process
 //   cons - symlink to /dev/pts/X that allows us to talk to the serial console of the domain

--- a/pkg/pillar/hypervisor/kvm_test.go
+++ b/pkg/pillar/hypervisor/kvm_test.go
@@ -144,7 +144,7 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
 
 [chardev "charmonitor"]
   backend = "socket"
-  path = "/var/run/hypervisor/kvm/test/qmp"
+  path = "/run/hypervisor/kvm/test/qmp"
   server = "on"
   wait = "off"
 
@@ -154,7 +154,7 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
 
 [chardev "charlistener"]
   backend = "socket"
-  path = "/var/run/hypervisor/kvm/test/listener.qmp"
+  path = "/run/hypervisor/kvm/test/listener.qmp"
   server = "on"
   wait = "off"
 
@@ -178,7 +178,7 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
 [chardev "charserial0"]
   backend = "socket"
   mux = "on"
-  path = "/var/run/hypervisor/kvm/test/cons"
+  path = "/run/hypervisor/kvm/test/cons"
   server = "on"
   wait = "off"
   logfile = "/dev/fd/1"
@@ -406,7 +406,7 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
 
 [chardev "charmonitor"]
   backend = "socket"
-  path = "/var/run/hypervisor/kvm/test/qmp"
+  path = "/run/hypervisor/kvm/test/qmp"
   server = "on"
   wait = "off"
 
@@ -416,7 +416,7 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
 
 [chardev "charlistener"]
   backend = "socket"
-  path = "/var/run/hypervisor/kvm/test/listener.qmp"
+  path = "/run/hypervisor/kvm/test/listener.qmp"
   server = "on"
   wait = "off"
 
@@ -440,7 +440,7 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
 [chardev "charserial0"]
   backend = "socket"
   mux = "on"
-  path = "/var/run/hypervisor/kvm/test/cons"
+  path = "/run/hypervisor/kvm/test/cons"
   server = "on"
   wait = "off"
   logfile = "/dev/fd/1"
@@ -643,7 +643,7 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
 
 [chardev "charmonitor"]
   backend = "socket"
-  path = "/var/run/hypervisor/kvm/test/qmp"
+  path = "/run/hypervisor/kvm/test/qmp"
   server = "on"
   wait = "off"
 
@@ -653,7 +653,7 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
 
 [chardev "charlistener"]
   backend = "socket"
-  path = "/var/run/hypervisor/kvm/test/listener.qmp"
+  path = "/run/hypervisor/kvm/test/listener.qmp"
   server = "on"
   wait = "off"
 
@@ -677,7 +677,7 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
 [chardev "charserial0"]
   backend = "socket"
   mux = "on"
-  path = "/var/run/hypervisor/kvm/test/cons"
+  path = "/run/hypervisor/kvm/test/cons"
   server = "on"
   wait = "off"
   logfile = "/dev/fd/1"
@@ -971,7 +971,7 @@ func TestCreateDomConfig(t *testing.T) {
 
 [chardev "charmonitor"]
   backend = "socket"
-  path = "/var/run/hypervisor/kvm/test/qmp"
+  path = "/run/hypervisor/kvm/test/qmp"
   server = "on"
   wait = "off"
 
@@ -981,7 +981,7 @@ func TestCreateDomConfig(t *testing.T) {
 
 [chardev "charlistener"]
   backend = "socket"
-  path = "/var/run/hypervisor/kvm/test/listener.qmp"
+  path = "/run/hypervisor/kvm/test/listener.qmp"
   server = "on"
   wait = "off"
 
@@ -1005,7 +1005,7 @@ func TestCreateDomConfig(t *testing.T) {
 [chardev "charserial0"]
   backend = "socket"
   mux = "on"
-  path = "/var/run/hypervisor/kvm/test/cons"
+  path = "/run/hypervisor/kvm/test/cons"
   server = "on"
   wait = "off"
   logfile = "/dev/fd/1"
@@ -1241,7 +1241,7 @@ func TestCreateDomConfig(t *testing.T) {
 
 [chardev "charmonitor"]
   backend = "socket"
-  path = "/var/run/hypervisor/kvm/test/qmp"
+  path = "/run/hypervisor/kvm/test/qmp"
   server = "on"
   wait = "off"
 
@@ -1251,7 +1251,7 @@ func TestCreateDomConfig(t *testing.T) {
 
 [chardev "charlistener"]
   backend = "socket"
-  path = "/var/run/hypervisor/kvm/test/listener.qmp"
+  path = "/run/hypervisor/kvm/test/listener.qmp"
   server = "on"
   wait = "off"
 
@@ -1275,7 +1275,7 @@ func TestCreateDomConfig(t *testing.T) {
 [chardev "charserial0"]
   backend = "socket"
   mux = "on"
-  path = "/var/run/hypervisor/kvm/test/cons"
+  path = "/run/hypervisor/kvm/test/cons"
   server = "on"
   wait = "off"
   logfile = "/dev/fd/1"
@@ -1486,7 +1486,7 @@ func TestCreateDomConfig(t *testing.T) {
 
 [chardev "charmonitor"]
   backend = "socket"
-  path = "/var/run/hypervisor/kvm/test/qmp"
+  path = "/run/hypervisor/kvm/test/qmp"
   server = "on"
   wait = "off"
 
@@ -1496,7 +1496,7 @@ func TestCreateDomConfig(t *testing.T) {
 
 [chardev "charlistener"]
   backend = "socket"
-  path = "/var/run/hypervisor/kvm/test/listener.qmp"
+  path = "/run/hypervisor/kvm/test/listener.qmp"
   server = "on"
   wait = "off"
 
@@ -1520,7 +1520,7 @@ func TestCreateDomConfig(t *testing.T) {
 [chardev "charserial0"]
   backend = "socket"
   mux = "on"
-  path = "/var/run/hypervisor/kvm/test/cons"
+  path = "/run/hypervisor/kvm/test/cons"
   server = "on"
   wait = "off"
   logfile = "/dev/fd/1"
@@ -1766,13 +1766,13 @@ func TestCreateDom(t *testing.T) {
 
 [chardev "charmonitor"]
   backend = "socket"
-  path = "/var/run/hypervisor/kvm/test/qmp"
+  path = "/run/hypervisor/kvm/test/qmp"
   server = "on"
   wait = "off"
 
 [chardev "charlistener"]
   backend = "socket"
-  path = "/var/run/hypervisor/kvm/test/listener.qmp"
+  path = "/run/hypervisor/kvm/test/listener.qmp"
   server = "on"
   wait = "off"
 

--- a/pkg/pillar/pidfile/pidfile.go
+++ b/pkg/pillar/pidfile/pidfile.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2018 Zededa, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Manage pidfile in /var/run/
+// Manage pidfile in /run/
 
 package pidfile
 
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	rundir = "/var/run"
+	rundir = "/run"
 )
 
 func writeMyPid(filename string) error {

--- a/pkg/pillar/pubsub/checkmaxtime.go
+++ b/pkg/pillar/pubsub/checkmaxtime.go
@@ -41,7 +41,7 @@ func (p *PubSub) StillRunning(agentName string, warnTime time.Duration, errTime 
 		lockedLastStillMap.Store(agentName, time.Now())
 	}
 
-	filename := fmt.Sprintf("/var/run/%s.touch", agentName)
+	filename := fmt.Sprintf("/run/%s.touch", agentName)
 	_, err := os.Stat(filename)
 	if err != nil {
 		file, err := os.Create(filename)

--- a/pkg/pillar/pubsub/checkmaxtime.go
+++ b/pkg/pillar/pubsub/checkmaxtime.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017,2018 Zededa, Inc.
+// Copyright (c) 2017,2018,2020 Zededa, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 // Provide for a pubsub mechanism for config and status which is
@@ -77,4 +77,18 @@ func (p *PubSub) CheckMaxTimeTopic(agentName string, topic string, start time.Ti
 		p.log.Warnf("%s handler in %s took a long time: %d",
 			topic, agentName, elapsed/time.Second)
 	}
+}
+
+// RegisterFileWatchdog tells the watchdog about the touch file
+func (p *PubSub) RegisterFileWatchdog(agentName string) {
+	p.log.Noticef("RegisterFileWatchdog(%s)", agentName)
+	wdFile := fmt.Sprintf("%s/%s.touch", base.WatchdogFileDir, agentName)
+	base.TouchFile(p.log, wdFile)
+}
+
+// RegisterPidWatchdog tells the watchdog about the pid file
+func (p *PubSub) RegisterPidWatchdog(agentName string) {
+	p.log.Noticef("RegisterPidWatchdog(%s)", agentName)
+	wdFile := fmt.Sprintf("%s/%s.pid", base.WatchdogPidDir, agentName)
+	base.TouchFile(p.log, wdFile)
 }

--- a/pkg/pillar/pubsub/socketdriver/driver.go
+++ b/pkg/pillar/pubsub/socketdriver/driver.go
@@ -36,7 +36,7 @@ import (
 
 // We always publish to our collection.
 // We always write to a file in order to have a checkpoint on restart
-// The special agent name "" implies always reading from the /var/run/zededa/
+// The special agent name "" implies always reading from the /run/global/
 // directory.
 const (
 	publishToSock     = true  // XXX
@@ -44,9 +44,9 @@ const (
 	subscribeFromSock = true  // XXX
 
 	// For a subscription, if the agentName is empty we interpret that as
-	// being directory in /var/tmp/zededa
-	fixedName = "zededa"
-	fixedDir  = "/var/tmp/" + fixedName
+	// being directory in /run/global
+	fixedName = "global"
+	fixedDir  = "/run/" + fixedName
 	maxsize   = 65535 // Max size for json which can be read or written
 
 	// Copied from types package to avoid cycle in package dependencies
@@ -92,7 +92,7 @@ func (s *SocketDriver) Publisher(global bool, name, topic string, persistent boo
 	case persistent && !publishToDir:
 		dirName = s.persistentDirName(name)
 	case !persistent && publishToDir:
-		// Special case for /var/tmp/zededa/
+		// Special case for /run/global
 		dirName = s.fixedDirName(name)
 	default:
 		dirName = s.pubDirName(name)
@@ -170,7 +170,7 @@ func (s *SocketDriver) Subscriber(global bool, name, topic string, persistent bo
 		subFromDir bool
 	)
 
-	// Special case for files in /var/tmp/zededa/ and also
+	// Special case for files in /run/global/ and also
 	// for zedclient going away yet metrics being read after it
 	// is gone.
 	var agentName string

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -11,7 +11,7 @@ PERSIST_CERTS=$PERSISTDIR/certs
 PERSIST_AGENT_DEBUG=$PERSISTDIR/agentdebug
 BINDIR=/opt/zededa/bin
 TMPDIR=/persist/tmp
-ZTMPDIR=/var/tmp/zededa
+ZTMPDIR=/run/global
 DPCDIR=$ZTMPDIR/DevicePortConfig
 FIRSTBOOTFILE=$ZTMPDIR/first-boot
 GCDIR=$PERSISTDIR/config/ConfigItemValueMap
@@ -180,8 +180,8 @@ echo "$(date -Ins -u) device-steps: upgradeconverter (pre-vault) Completed"
 # BlinkCounter 1 means we have started; might not yet have IP addresses
 # client/selfRegister and zedagent update this when the found at least
 # one free uplink with IP address(s)
-mkdir -p /var/tmp/zededa/LedBlinkCounter/
-echo '{"BlinkCounter": 1}' > '/var/tmp/zededa/LedBlinkCounter/ledconfig.json'
+mkdir -p "$ZTMPDIR/LedBlinkCounter"
+echo '{"BlinkCounter": 1}' > "$ZTMPDIR/LedBlinkCounter/ledconfig.json"
 
 # If ledmanager is already running we don't have to start it.
 # TBD: Should we start it earlier before wwan and wlan services?

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -458,13 +458,6 @@ else
     fi
 fi
 
-# We are onboarded so zedagent should start doing work
-touch "$WATCHDOG_FILE/zedagentconfig.touch" \
-      "$WATCHDOG_FILE/zedagentmetrics.touch" \
-      "$WATCHDOG_FILE/zedagentdevinfo.touch" \
-      "$WATCHDOG_FILE/zedagentattest.touch" \
-      "$WATCHDOG_FILE/zedagentccerts.touch"
-
 #If logmanager is already running we don't have to start it.
 if ! pgrep logmanager >/dev/null; then
     echo "$(date -Ins -u) Starting logmanager"
@@ -492,9 +485,6 @@ touch "$WATCHDOG_FILE/tpmmgr.touch"
 # Now run watchdog for all agents
 for AGENT in $AGENTS; do
     touch "$WATCHDOG_FILE/$AGENT.touch"
-    if [ "$AGENT" = "volumemgr" ]; then
-       touch "$WATCHDOG_FILE/${AGENT}metrics.touch"
-    fi
 done
 
 blockdev --flushbufs "$CONFIGDEV"

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -177,7 +177,7 @@ echo "$(date -Ins -u) device-steps: Starting upgradeconverter (pre-vault)"
 $BINDIR/upgradeconverter pre-vault
 echo "$(date -Ins -u) device-steps: upgradeconverter (pre-vault) Completed"
 
-# Start zedagent to make sure we have a ConfigItemValueMap
+# Start zedagent to make sure we have a ConfigItemValueMap publisher
 echo "$(date -Ins -u) Starting zedagent"
 $BINDIR/zedagent &
 wait_for_touch zedagent

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -42,9 +42,9 @@ while [ $# != 0 ]; do
     shift
 done
 
-# Sleep for a bit until /var/run/$1.touch exists
+# Sleep for a bit until /run/$1.touch exists
 wait_for_touch() {
-    f=/var/run/"$1".touch
+    f=/run/"$1".touch
     waited=0
     while [ ! -f "$f" ] && [ "$waited" -lt 60 ]; do
             echo "$(date -Ins -u) waiting for $f"
@@ -263,7 +263,7 @@ access_usb() {
         if [ -d /mnt/dump ]; then
             echo "$(date -Ins -u) Dumping diagnostics to USB stick"
             # Check if it fits without clobbering an existing tar file
-            if tar cf /mnt/dump/diag1.tar /persist/status/ /persist/config /var/run/ /persist/log "/persist/rsyslog"; then
+            if tar cf /mnt/dump/diag1.tar /persist/status/ /persist/config /run/ /persist/log "/persist/rsyslog"; then
                 mv /mnt/dump/diag1.tar /mnt/dump/diag.tar
             else
                 rm -f /mnt/dump/diag1.tar

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -143,15 +143,8 @@ if [ -c $TPM_DEVICE_PATH ] && ! [ -f $CONFIGDIR/disable-tpm ]; then
     fi
 fi
 
-if [ -f $PERSISTDIR/IMGA/reboot-reason ]; then
-    echo "IMGA reboot-reason: $(cat $PERSISTDIR/IMGA/reboot-reason)"
-fi
-if [ -f $PERSISTDIR/IMGB/reboot-reason ]; then
-    echo "IMGB reboot-reason: $(cat $PERSISTDIR/IMGB/reboot-reason)"
-fi
-
 if [ -f $PERSISTDIR/reboot-reason ]; then
-    echo "Common reboot-reason: $(cat $PERSISTDIR/reboot-reason)"
+    echo "Reboot-reason: $(cat $PERSISTDIR/reboot-reason)"
 fi
 
 # Copy any GlobalConfig from /config

--- a/pkg/pillar/scripts/handlezedserverconfig.sh
+++ b/pkg/pillar/scripts/handlezedserverconfig.sh
@@ -3,7 +3,7 @@
 # Copyright (c) 2018 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-TMPDIR=/var/tmp/zededa
+TMPDIR=/run/global
 
 echo "Retrieved overlay /etc/hosts with:"
 cat $TMPDIR/zedserverconfig

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -765,6 +765,23 @@ func DefaultConfigItemValueMap() *ConfigItemValueMap {
 	return valueMapPtr
 }
 
+// UpdateItemValues brings in any of the source items into the ConfigItemValueMap
+func (configPtr *ConfigItemValueMap) UpdateItemValues(source *ConfigItemValueMap) {
+
+	for key, val := range source.GlobalSettings {
+		configPtr.GlobalSettings[key] = val
+	}
+
+	for agentName, agentSettingMap := range source.AgentSettings {
+		if _, ok := configPtr.AgentSettings[agentName]; !ok {
+			configPtr.AgentSettings[agentName] = make(map[AgentSettingKey]ConfigItemValue)
+		}
+		for setting, value := range agentSettingMap {
+			configPtr.AgentSettings[agentName][setting] = value
+		}
+	}
+}
+
 func agentSettingKeyFromLegacyKey(key string) string {
 	components := strings.Split(key, ".")
 	if len(components) < 3 {

--- a/pkg/pillar/types/locationconsts.go
+++ b/pkg/pillar/types/locationconsts.go
@@ -66,8 +66,4 @@ const (
 	EveVersionFile = "/run/eve-release"
 	//DefaultVaultName is the name of the default vault
 	DefaultVaultName = "Application Data Store"
-	//WatchdogFileDir is the dir to add .touch files for watchdog to monitor
-	WatchdogFileDir = "/run/watchdog/file"
-	//WatchdogPidDir is the dir to add .pid files for watchdog to monitor
-	WatchdogPidDir = "/run/watchdog/pid"
 )

--- a/pkg/pillar/types/locationconsts.go
+++ b/pkg/pillar/types/locationconsts.go
@@ -61,7 +61,7 @@ const (
 	// BaseOsObj - name of base image type
 	BaseOsObj = "baseOs.obj"
 	//ITokenFile contains the integrity token sent in attestation response
-	ITokenFile = "/var/run/eve.integrity_token"
+	ITokenFile = "/run/eve.integrity_token"
 	//EveVersionFile contains the running version of EVE
 	EveVersionFile = "/run/eve-release"
 	//DefaultVaultName is the name of the default vault

--- a/pkg/pillar/types/locationconsts.go
+++ b/pkg/pillar/types/locationconsts.go
@@ -4,8 +4,8 @@
 package types
 
 const (
-	// TmpDirname - temporary dir. for agents to use.
-	TmpDirname = "/var/tmp/zededa"
+	// TmpDirname - used for files fed into pubsub as global subscriptions
+	TmpDirname = "/run/global"
 
 	// PersistDir - Location to store persistent files.
 	PersistDir = "/persist"

--- a/pkg/pillar/utils/globalutils.go
+++ b/pkg/pillar/utils/globalutils.go
@@ -6,75 +6,31 @@
 package utils
 
 import (
-	"os"
-
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
-	pubsublegacy "github.com/lf-edge/eve/pkg/pillar/pubsub/legacy"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 )
-
-const (
-	globalConfigDir = types.PersistConfigDir + "/ConfigItemValueMap"
-	symlinkDir      = types.TmpDirname + "/ConfigItemValueMap"
-)
-
-// EnsureGCFile is used by agents which wait for GlobalConfig to become initialized
-// on startup in order to make sure we have a GlobalConfig file.
-func EnsureGCFile(log *base.LogObject) {
-	pubGlobalConfig, err := pubsublegacy.PublishPersistent("", types.ConfigItemValueMap{})
-	if err != nil {
-		log.Fatal(err)
-	}
-	ReadAndUpdateGCFile(log, pubGlobalConfig)
-}
-
-// CreateSymlink - Creates Symbolic link:
-//  linkDir -->targetDir
-func CreateSymlink(log *base.LogObject, linkDir, targetDir string) {
-	log.Debugf("CreateSymlink")
-	info, err := os.Lstat(linkDir)
-	if err == nil {
-		if (info.Mode() & os.ModeSymlink) != 0 {
-			log.Debugf("CreateSymlink - symlink already exists")
-			return
-		}
-		log.Warnf("CreateSymlink - Removing old %s", symlinkDir)
-		if err := os.RemoveAll(linkDir); err != nil {
-			log.Fatal(err)
-		}
-	}
-	log.Debugf("CreateSymlink - Creating symlink")
-	if err := os.Symlink(targetDir, linkDir); err != nil {
-		log.Fatalf("CreateSymlink: Failed to create symlink %s -> %s . Err: %s",
-			linkDir, targetDir, err)
-	}
-}
 
 // ReadAndUpdateGCFile does the work of getting a sane or default
 // GlobalConfig based on the current definition of GlobalConfig which
 // might be different than the file stored on disk if we did an update
 // of EVE.
-func ReadAndUpdateGCFile(log *base.LogObject, pub pubsub.Publication) {
+// Returns the existing GlobalConfig otherwise the created default one
+func ReadAndUpdateGCFile(log *base.LogObject, pub pubsub.Publication) types.ConfigItemValueMap {
+	var gc types.ConfigItemValueMap
 	key := "global"
 	item, err := pub.Get(key)
 	if err == nil {
-		gc := item.(types.ConfigItemValueMap)
-		err := pub.Publish(key, gc)
-		if err != nil {
-			log.Errorf("Publish for globalConfig failed: %s",
-				err)
-		}
-
+		gc = item.(types.ConfigItemValueMap)
 	} else {
 		log.Warn("No globalConfig in /persist; creating it with defaults")
-		err := pub.Publish(key, *types.DefaultConfigItemValueMap())
-		if err != nil {
-			log.Errorf("Publish for globalConfig failed %s\n",
-				err)
-		}
+		gc = *types.DefaultConfigItemValueMap()
 	}
-	CreateSymlink(log, symlinkDir, globalConfigDir)
+	err = pub.Publish(key, gc)
+	if err != nil {
+		log.Errorf("Publish for globalConfig failed %s", err)
+	}
+	return gc
 }
 
 // RoundToMbytes - Byts convert to Mbytes with round-off

--- a/pkg/pillar/utils/globalutils.go
+++ b/pkg/pillar/utils/globalutils.go
@@ -5,34 +5,6 @@
 
 package utils
 
-import (
-	"github.com/lf-edge/eve/pkg/pillar/base"
-	"github.com/lf-edge/eve/pkg/pillar/pubsub"
-	"github.com/lf-edge/eve/pkg/pillar/types"
-)
-
-// ReadAndUpdateGCFile does the work of getting a sane or default
-// GlobalConfig based on the current definition of GlobalConfig which
-// might be different than the file stored on disk if we did an update
-// of EVE.
-// Returns the existing GlobalConfig otherwise the created default one
-func ReadAndUpdateGCFile(log *base.LogObject, pub pubsub.Publication) types.ConfigItemValueMap {
-	var gc types.ConfigItemValueMap
-	key := "global"
-	item, err := pub.Get(key)
-	if err == nil {
-		gc = item.(types.ConfigItemValueMap)
-	} else {
-		log.Warn("No globalConfig in /persist; creating it with defaults")
-		gc = *types.DefaultConfigItemValueMap()
-	}
-	err = pub.Publish(key, gc)
-	if err != nil {
-		log.Errorf("Publish for globalConfig failed %s", err)
-	}
-	return gc
-}
-
 // RoundToMbytes - Byts convert to Mbytes with round-off
 func RoundToMbytes(byteCount uint64) uint64 {
 	const mbyte = 1 << 20

--- a/pkg/pillar/utils/globalutils.go
+++ b/pkg/pillar/utils/globalutils.go
@@ -32,8 +32,6 @@ func EnsureGCFile(log *base.LogObject) {
 // CreateSymlink - Creates Symbolic link:
 //  linkDir -->targetDir
 func CreateSymlink(log *base.LogObject, linkDir, targetDir string) {
-	// Make sure we have a correct symlink from /var/tmp/zededa so
-	// others can subscribe from there
 	log.Debugf("CreateSymlink")
 	info, err := os.Lstat(linkDir)
 	if err == nil {

--- a/pkg/pillar/utils/round.go
+++ b/pkg/pillar/utils/round.go
@@ -1,7 +1,5 @@
-// Copyright (c) 2018-2019 Zededa, Inc.
+// Copyright (c) 2018-2020 Zededa, Inc.
 // SPDX-License-Identifier: Apache-2.0
-
-// Routines which operate on types.GlobalConfig
 
 package utils
 

--- a/pkg/pillar/zedbox/zedbox.go
+++ b/pkg/pillar/zedbox/zedbox.go
@@ -230,7 +230,7 @@ func startAgentAndDone(sep entrypoint, agentName string, srvPs *pubsub.PubSub,
 	retval := sep.f(srvPs, srvLogger, srvLog)
 
 	ret := strconv.Itoa(retval)
-	if err := ioutil.WriteFile(fmt.Sprintf("/var/run/%s.done", agentName),
+	if err := ioutil.WriteFile(fmt.Sprintf("/run/%s.done", agentName),
 		[]byte(ret), 0700); err != nil {
 		log.Fatalf("Error write done file: %v", err)
 	}


### PR DESCRIPTION
A set of changes related to cleaning up directory usage and making the ConfigItemValueMap simpler.
With this we still have a few ecdh keys etc in /persist/config but after those are moved that directory can be retired.

Note that we didn't seem to have any logic to make ConfigItemValueMap pick up defaults for new items until zedagent gets some config from the controller. That means that new timers would have a value of zero which is bad. Fixed in the commit called
"Make upgradeconverter ensure ConfigItemValueMap file with defaults ..."

Each commit can be reviewed independently, but they build on eachother to some extent.