### PR TITLE
Handle http.StatusForbidden (403) returned by /config

### DIFF
--- a/pkg/pillar/attest/attest.go
+++ b/pkg/pillar/attest/attest.go
@@ -241,6 +241,11 @@ func Kickstart(ctx *Context) {
 	ctx.eventTrigger <- EventInitialize
 }
 
+//RestartAttestation adds EventRestart event to the fsm
+func RestartAttestation(ctx *Context) {
+	ctx.eventTrigger <- EventRestart
+}
+
 //InternalQuoteRecvd adds EventInternalQuoteRecvd to the fsm
 func InternalQuoteRecvd(ctx *Context) {
 	ctx.eventTrigger <- EventInternalQuoteRecvd
@@ -447,6 +452,7 @@ func handleNoEscrowAtAttestEscrowWait(ctx *Context) error {
 func handleRetryTimerExpiryAtRestartWait(ctx *Context) error {
 	ctx.log.Debug("handleRetryTimerExpiryAtRestartWait")
 	ctx.state = StateNone
+	ctx.restartRequestPending = false
 	return triggerSelfEvent(ctx, EventInitialize)
 }
 

--- a/pkg/pillar/cmd/zedagent/attesttask.go
+++ b/pkg/pillar/cmd/zedagent/attesttask.go
@@ -666,3 +666,17 @@ func storeIntegrityToken(token []byte) {
 func readIntegrityToken() ([]byte, error) {
 	return ioutil.ReadFile(types.ITokenFile)
 }
+
+//trigger restart event in attesation FSM
+func restartAttestation(zedagentCtx *zedagentContext) error {
+	if zedagentCtx.attestCtx == nil {
+		log.Fatalf("[ATTEST] Uninitialized access to attestCtx")
+	}
+	attestCtx := zedagentCtx.attestCtx
+	if attestCtx.attestFsmCtx == nil {
+		log.Fatalf("[ATTEST] Uninitialized access to attestFsmCtx")
+	}
+	//Trigger event on the state machine
+	zattest.RestartAttestation(attestCtx.attestFsmCtx)
+	return nil
+}


### PR DESCRIPTION
-  On receiving such status from Controller, attestation is re-triggered (if not already running)
- Controller is yet to add support to send StatusForbidden, but adding this code
    for completing required support from EVE side
- This PR is raised to get review feedback on the changes
- We can choose to merge it later, if required.

Signed-off-by: Hariharasubramanian C S <cshari@zededa.com>