### PR TITLE
Improving error reporting in baseosmgr

### DIFF
--- a/pkg/pillar/zboot/zboot.go
+++ b/pkg/pillar/zboot/zboot.go
@@ -384,9 +384,6 @@ func MarkCurrentPartitionStateActive(log *base.LogObject) error {
 // XXX known pathnames for the version file and the zededa-tools container
 const (
 	otherPartVersionFile = "/etc/eve-release"
-	otherPrefix          = "/containers/services/pillar/lower"
-	// XXX handle baseimage-update by looking for old names
-	otherPrefixOld = "/containers/services/zededa-tools/lower"
 )
 
 func GetShortVersion(log *base.LogObject, partName string) (string, error) {


### PR DESCRIPTION
We are improving error reporting in ```baseosmgr``` with these changes. And, we observed that we are mounting base image multiple times for reading the short version which seems to be incorrect to me. I am planning to take care of it in a separate PR.