### PR TITLE
Quick hack to enable Azure IoT Runtime

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -16,7 +16,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -2026,14 +2025,13 @@ func createCloudInitISO(ctx *domainContext,
 	ds := new(types.DiskStatus)
 	ds.FileLocation = fileName
 	ds.Format = zconfig.Format_RAW
-	switch runtime.GOARCH {
-	case "arm64":
-		ds.Vdev = "xvdz"
-		ds.ReadOnly = true
-	case "amd64":
-		ds.Vdev = "hdc:cdrom"
-		ds.ReadOnly = false
-	}
+	// XXX FIXME the issue with declaring cloud init ISO xvdz is that:
+	//   1. we may have more than 26 drives (unlikely)
+	//   2. xvdz is only available via PV route
+	// Both of these don't seem to be a problem for modern Linux kernels
+	// and we can leave it be while we're looking for a more generic solution
+	ds.Vdev = "xvdz"
+	ds.ReadOnly = true
 	// Generate Devtype for hypervisor package
 	// XXX can hypervisor look at something different?
 	ds.Devtype = "cdrom"


### PR DESCRIPTION
This is a quick hack to give us some relief while I'm working on a permanent refactoring of disk assignment.

The positive side of this is that at least this has been tested on ARM somewhat and seems to work for Linux kernels quite reliably (and Linux is the only thing we care for now when it comes to cloud init).

For those curious, the issue here is that for Azure IoT Runtime we need 4 disks which currently all get represented as AHCI devices. As we all remember from the 80s you can't have more than 4 of those -- hence when the cloud init comes along and gets hooked up to the same AHCI controller -- qemu bails. A longer term solution here is to at least force SCSI interface, but that would require some additional testing and is better done in the context of a bigger change I'm working on.