### PR TITLE
Reduce/remove qemu-img invocations

### DIFF
--- a/pkg/pillar/cmd/volumemgr/create.go
+++ b/pkg/pillar/cmd/volumemgr/create.go
@@ -171,10 +171,6 @@ func destroyVdiskVolume(ctx *volumemgrContext, status types.VolumeStatus) (bool,
 	}
 	filelocation = ""
 	created = false
-	if err := createOrUpdateAppDiskMetrics(ctx, &status); err != nil {
-		log.Errorf("destroyVdiskVolume(%s): exception while publishing diskmetric. %s",
-			status.Key(), err.Error())
-	}
 	log.Infof("destroyVdiskVolume(%s) DONE", status.Key())
 	return created, filelocation, nil
 }
@@ -191,10 +187,6 @@ func destroyContainerVolume(ctx *volumemgrContext, status types.VolumeStatus) (b
 	}
 	filelocation = ""
 	created = false
-	if err := createOrUpdateAppDiskMetrics(ctx, &status); err != nil {
-		log.Errorf("destroyContainerVolume(%s): exception while publishing diskmetric. %s",
-			status.Key(), err.Error())
-	}
 	log.Infof("destroyContainerVolume(%s) DONE", status.Key())
 	return created, filelocation, nil
 }

--- a/pkg/pillar/cmd/volumemgr/handlevolume.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume.go
@@ -40,11 +40,12 @@ func handleVolumeCreate(ctxArg interface{}, key string,
 	if _, err := os.Stat(status.PathName()); err == nil {
 		status.State = types.CREATED_VOLUME
 		status.Progress = 100
+		// XXX note that TotalSize and CurrentSize are not filled in
 		status.FileLocation = status.PathName()
 		status.VolumeCreated = true
 		if status.MaxVolSize == 0 {
 			var err error
-			_, status.MaxVolSize, err = utils.GetVolumeSize(log, status.FileLocation)
+			_, status.MaxVolSize, _, _, err = utils.GetVolumeSize(log, status.FileLocation)
 			if err != nil {
 				log.Error(err)
 			}

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -429,12 +429,16 @@ func doUpdateVol(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool)
 			// Work is done
 			DeleteWorkCreate(ctx, status)
 			if status.MaxVolSize == 0 {
-				var err error
-				log.Infof("doUpdateVol: MaxVolSize is 0 for %s. Filling it up.",
-					status.FileLocation)
-				_, status.MaxVolSize, err = utils.GetVolumeSize(log, status.FileLocation)
+				_, maxVolSize, _, _, err := utils.GetVolumeSize(log, status.FileLocation)
 				if err != nil {
 					log.Error(err)
+				} else if maxVolSize != status.MaxVolSize {
+					log.Infof("doUpdateVol: MaxVolSize update from  %d to %d for %s",
+
+						status.MaxVolSize, maxVolSize,
+						status.FileLocation)
+					status.MaxVolSize = maxVolSize
+					changed = true
 				}
 			}
 			return changed, true

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -663,18 +663,6 @@ func getDiskInfo(ctx *zedagentContext, vrs types.VolumeRefStatus, appDiskDetails
 	appDiskDetails.Provisioned = utils.RoundToMbytes(appDiskMetric.ProvisionedBytes)
 	appDiskDetails.DiskType = appDiskMetric.DiskType
 	appDiskDetails.Dirty = appDiskMetric.Dirty
-
-	actualSize, maxSize, err := utils.GetVolumeSize(log, vrs.ActiveFileLocation)
-	if err != nil {
-		return err
-	}
-	if vrs.IsContainer() {
-		appDiskDetails.DiskType = "CONTAINER"
-		log.Infof("getDiskInfo: container app diskdetails: %s",
-			fmt.Sprintf("Disk: %s, actualSize: %d, Used: %d, maxSize: %d, Provisioned: %d",
-				appDiskDetails.Disk, actualSize, appDiskDetails.Used, maxSize, appDiskDetails.Provisioned))
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
We have a leftover in zedagent plus duplication in volumemgr.
Note that we do not need to do appimg reporting in volumemgr/create.go since it is done by the caller of update.go when there is a change. (@deitch found that one).
