### PR TITLE
Fix: AppInstances goes to error state after coming online.

### DIFF
--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -430,7 +430,7 @@ func (ctx xenContext) Delete(domainName string, domainID int) error {
 		log.Errorln("xl destroy output ", stdOut, stdErr)
 		return fmt.Errorf("xl destroy failed: %s %s", stdOut, stdErr)
 	}
-	log.Infof("xl destroy done\n")
+	log.Infof("xl destroy done %s %d\n", domainName, domainID)
 
 	// now lets take care of the task itself
 	if err := ctx.ctrdContext.Stop(domainName, domainID, true); err != nil {

--- a/pkg/xen-tools/xen-info
+++ b/pkg/xen-tools/xen-info
@@ -1,8 +1,42 @@
 #!/bin/sh
 
+UnknownStateThreshold=10
 bail() {
    echo "$@"
    exit 1
+}
+
+handleUnknownState() {
+  # checking if we have unknownStateCounter, if not initializing it.
+  if [ ! -e /dev/unknownStateCounter ]; then
+    echo 0 > /dev/unknownStateCounter
+  fi
+
+  unknownStateCounter=$(cat /dev/unknownStateCounter)
+
+  if [ "$unknownStateCounter" -ge "$UnknownStateThreshold" ]; then
+    # Number of times we got unknown state is > UnknownStateThreshold, so declaring the state as broken
+    echo broken > /dev/status
+  else
+    # Number of times we got unknown state is <= UnknownStateThreshold, so declaring the state as running
+    echo running > /dev/status
+  fi
+
+  unknownStateCounter=$((unknownStateCounter + 1))
+  echo $unknownStateCounter > /dev/unknownStateCounter
+}
+
+handleKnownState() {
+  # resetting unknownStateCounter
+  echo 0 > /dev/unknownStateCounter
+  echo "$1" > /dev/status
+
+  # an additional check we do for running domains is to make sure device model is still around
+  if [ "$1" = running ] &&
+     DM_PID=$(xenstore read "/local/domain/$ID/image/device-model-pid") &&
+     ! (readlink "/proc/$DM_PID/exe" | grep -q qemu-system-); then
+     echo broken > /dev/status
+  fi
 }
 
 # pre-flight checks
@@ -15,29 +49,24 @@ waited=0
 ID=$(xl domid "$1" 2>/dev/null)
 while [ -z "$ID" ] && [ "$waited" -lt 60 ]; do
         ID=$(xl domid "$1" 2>/dev/null)
-        sleep 3
-        waited=$((waited + 3))
+        if [ -z "$ID" ]; then
+          sleep 3
+          waited=$((waited + 3))
+        fi
 done
 [ -z "$ID" ] && bail "Couldn't find domain ID for domain $1"
 
 # we expect to get rbpscd where every letter can also be a dash (-)
 # Name    ID    Mem    VCPUs    State    Time(s)
 case $(xl list "$ID" | awk '{st=$5;} END {print st;}') in
-   *d) STATUS=halting ;;
-  *c*) STATUS=broken  ;;
-  *s*) STATUS=halting ;;
-  *p*) STATUS=paused  ;;
-  *b*) STATUS=running ;;
-   r*) STATUS=running ;;
-    *) STATUS=$(cat /dev/status) ;;
+   *d) handleKnownState halting ;;
+  *c*) handleKnownState broken  ;;
+  *s*) handleKnownState halting ;;
+  *p*) handleKnownState paused  ;;
+  *b*) handleKnownState running ;;
+   r*) handleKnownState running ;;
+    *) handleUnknownState ;;
 esac
 
-# an additional check we do for running domains is to make sure device model is still around
-if [ "$STATUS" = running ] &&
-   DM_PID=$(xenstore read "/local/domain/$ID/image/device-model-pid") &&
-   ! (readlink "/proc/$DM_PID/exe" | grep -q qemu-system-); then
-   STATUS=broken
-fi
-
-# finally deposit the current status
-echo "$STATUS" | tee /dev/status
+# finally print the current status
+cat /dev/status

--- a/pkg/xen-tools/xen-start
+++ b/pkg/xen-tools/xen-start
@@ -29,5 +29,8 @@ xl unpause "$ID"
 # declare the status as running
 echo running > /dev/status
 
+# initialize unknownStateCounter
+echo 0 > /dev/unknownStateCounter
+
 # and start watching over the console
 exec xl console "$ID" < /dev/null


### PR DESCRIPTION
Issue: We noticed Appinstance going to error or halted state after coming online. This behaviour was sporadic and noticed mostly after we rebooted the device or the appInstance. 

Reason: While checking status of an appInstance in [verifyStatus()](https://github.com/lf-edge/eve/blob/06b9c09cd4627f1c0b1770942275d7d88d6aaa80/pkg/pillar/cmd/domainmgr/domainmgr.go#L711), [xen-info](https://github.com/lf-edge/eve/blob/master/pkg/xen-tools/xen-info) returned empty state for the appInstance which led to `one of the 12bda8cb-1424-409b-b036-0097f5e6accc tasks has crashed (info: domain e300-da-turnstile-app-sync_capacity_data.4 reported to be in unexpected state )`

Fix: "running" will be the default state returned by xen-info in case of undetermined status. Also introduced a unknownStateCounter which will be increased everytime xen-info returns "running" state in case of unknown. If we unknownStateCounter >= unknownStateThreshold (which is 10 times), then xen-info will return "broken" state. unknownStateCounter will be reset to 0 everytime we get a known state.


Signed-off-by: adarsh-zededa <adarsh@zededa.com>