### PR TITLE
Uplink port management improvements

### DIFF
--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -686,7 +686,7 @@ func IngestPortConfigList(ctx *DeviceNetworkContext) {
 		// Clear the errors from before reboot and start fresh.
 		for i := 0; i < len(portConfig.Ports); i++ {
 			portPtr := &portConfig.Ports[i]
-			portPtr.Reset()
+			portPtr.Clear()
 		}
 		if portConfig.CountMgmtPorts() == 0 {
 			log.Warnf("Stored DevicePortConfig key %s has no management ports; ignored",

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -584,8 +584,8 @@ func (trPtr *TestResults) Update(src TestResults) {
 	}
 }
 
-// Reset test results
-func (trPtr *TestResults) Reset() {
+// Clear test results
+func (trPtr *TestResults) Clear() {
 	trPtr.LastFailed = time.Time{}
 	trPtr.LastSucceeded = time.Time{}
 	trPtr.LastError = ""
@@ -910,6 +910,20 @@ type NetworkPortStatus struct {
 	ProxyConfig
 	// TestResults provides recording of failure and success
 	TestResults
+}
+
+// HasIPAndDNS - Check if the given port has a valid unicast IP along with DNS & Gateway
+func (port NetworkPortStatus) HasIPAndDNS() bool {
+	foundUnicast := false
+	for _, addr := range port.AddrInfoList {
+		if !addr.Addr.IsLinkLocalUnicast() {
+			foundUnicast = true
+		}
+	}
+	if foundUnicast && len(port.DefaultRouters) > 0 && len(port.DNSServers) > 0 {
+		return true
+	}
+	return false
 }
 
 type AddrInfo struct {

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -584,6 +584,13 @@ func (trPtr *TestResults) Update(src TestResults) {
 	}
 }
 
+// Reset test results
+func (trPtr *TestResults) Reset() {
+	trPtr.LastFailed = time.Time{}
+	trPtr.LastSucceeded = time.Time{}
+	trPtr.LastError = ""
+}
+
 type DevicePortConfigVersion uint32
 
 // GetPortByIfName - DevicePortConfig method to get config pointer
@@ -1077,6 +1084,16 @@ func (status DeviceNetworkStatus) MostlyEqual(status2 DeviceNetworkStatus) bool 
 		}
 	}
 	return true
+}
+
+// HasErrors - Check if there are any port errors
+func (status DeviceNetworkStatus) HasErrors() bool {
+	for _, port := range status.Ports {
+		if port.HasError() {
+			return true
+		}
+	}
+	return false
 }
 
 // EqualSubnet compares two subnets; silently assumes contigious masks

--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -191,13 +191,7 @@ func VerifyAllIntf(ctx *ZedCloudContext,
 		if port.IsMgmt {
 			continue
 		}
-		foundUnicast := false
-		for _, addr := range port.AddrInfoList {
-			if !addr.Addr.IsLinkLocalUnicast() {
-				foundUnicast = true
-			}
-		}
-		if foundUnicast && len(port.DefaultRouters) > 0 && len(port.DNSServers) > 0 {
+		if port.HasIPAndDNS() {
 			intfStatusMap.RecordSuccess(port.IfName)
 		}
 	}

--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -182,6 +182,26 @@ func VerifyAllIntf(ctx *ZedCloudContext,
 		return true, remoteTemporaryFailure, intfStatusMap, nil
 	}
 
+	// For non-mgmt (i.e. app-shared) ports, the presence of a valid IP address
+	// along with DNS server and gateway is good enough for us to deem them as Success.
+	// We do not test non-mgmt ports periodically, which makes it not possible to clear
+	// any old errors on them. Here we check for presence of valid IP/DNS on non-mgmt
+	// ports and accordingly mark their status.
+	for _, port := range ctx.DeviceNetworkStatus.Ports {
+		if port.IsMgmt {
+			continue
+		}
+		foundUnicast := false
+		for _, addr := range port.AddrInfoList {
+			if !addr.Addr.IsLinkLocalUnicast() {
+				foundUnicast = true
+			}
+		}
+		if foundUnicast && len(port.DefaultRouters) > 0 && len(port.DNSServers) > 0 {
+			intfStatusMap.RecordSuccess(port.IfName)
+		}
+	}
+
 	for try := 0; try < 2; try += 1 {
 		var intfs []string
 		if try == 0 {


### PR DESCRIPTION
1) Clear old errors and timestamps from Device port configuration list after reboot.
2) Since we do not test app-shared port, mark them as success if they have a valid unicast IP with DNS and router IP addresses.
3) TestBetterTimer should also check if there are any port errors from previous tests. If there are any errors (even with current DPC at index 0 of DPCL), NIM should re-test DPC at index 0 to see if port errors go away.
4) dhcpcd start/stop should be done properly when ports that are part of the current DPC go down (unbound from driver) and come up (bound to driver) due to any transient reason.


Signed-off-by: Gopi krishna Kodali <gkodali@zededa.com>