### PR TITLE
[WIP] fix fatal inside verifier

### DIFF
--- a/pkg/pillar/cmd/volumemgr/blob.go
+++ b/pkg/pillar/cmd/volumemgr/blob.go
@@ -281,8 +281,15 @@ func getBlobChildren(ctx *volumemgrContext, blob *types.BlobStatus) []*types.Blo
 		var blobChildren []*types.BlobStatus
 		if len(children) > 0 {
 			blobChildren = make([]*types.BlobStatus, 0)
+		childrenLoop:
 			for _, child := range children {
 				childHash := strings.ToLower(child.Digest.Hex)
+				for _, existingChild := range blobChildren {
+					if existingChild.Sha256 == childHash {
+						log.Debugf("getBlobChildren(%s): child blob %s has already been added.", blob.Sha256, childHash)
+						continue childrenLoop
+					}
+				}
 				//Check if childBlob already exists
 				existingChild := lookupOrCreateBlobStatus(ctx, childHash)
 				if existingChild != nil {


### PR DESCRIPTION
I see in syslog:
```
2020-09-22T07:38:29.025975+00:00 linuxkit-525400123456 pillar.out {"file":"/pillar/agentlog/agentlog.go:208","func":"github.com/lf-edge/eve/pkg/pillar/agentlog.printStack","level":"error","msg":"goroutine 890 [running]:\ngithub.com/lf-edge/eve/pkg/pillar/agentlog.getStacks(0xc000c1eb00, 0x0, 0x0)\n\t/pillar/agentlog/agentlog.go:408 +0x78\ngithub.com/lf-edge/eve/pkg/pillar/agentlog.printStack(0xc000390120, 0x7ffeacddcf5b, 0x6, 0x4b9)\n\t/pillar/agentlog/agentlog.go:204 +0x38\ngithub.com/lf-edge/eve/pkg/pillar/agentlog.Init.func1()\n\t/pillar/agentlog/agentlog.go:566 +0x45\ngithub.com/sirupsen/logrus.runHandler(0xc0002e20c0)\n\t/pillar/vendor/github.com/sirupsen/logrus/alt_exit.go:39 +0x43\ngithub.com/sirupsen/logrus.runHandlers()\n\t/pillar/vendor/github.com/sirupsen/logrus/alt_exit.go:44 +0x4b\ngithub.com/sirupsen/logrus.(*Logger).Exit(0xc000078c60, 0x1)\n\t/pillar/vendor/github.com/sirupsen/logrus/logger.go:285 +0x22\ngithub.com/sirupsen/logrus.(*Entry).Fatalf(0xc001392fc0, 0x1a0802c, 0x67, 0xc000163ae0, 0x2, 0x2)\n\t/pillar/vendor/github.com/sirupsen/logrus/entry.go:369 +0x7f\ngithub.com/lf-edge/eve/pkg/pillar/base.(*LogObject).Fatalf(0xc0002510a0, 0x1a0802c, 0x67, 0xc000163ae0, 0x2, 0x2)\n\t/pillar/base/log.go:136 +0x81\ngithub.com/lf-edge/eve/pkg/pillar/cmd/volumemgr.MaybeRemoveVerifyImageConfig(0xc0000b5a00, 0xc000319740, 0x40)\n\t/pillar/cmd/volumemgr/handleverifier.go:88 +0x3a9\ngithub.com/lf-edge/eve/pkg/pillar/cmd/volumemgr.doUpdateContentTree(0xc0000b5a00, 0xc000165680, 0x40)\n\t/pillar/cmd/volumemgr/updatestatus.go:289 +0x10dc\ngithub.com/lf-edge/eve/pkg/pillar/cmd/volumemgr.updateStatusByBlob(0xc0000b5a00, 0xc000b8c740, 0x40)\n\t/pillar/cmd/volumemgr/updatestatus.go:482 +0x1fe\ngithub.com/lf-edge/eve/pkg/pillar/cmd/volumemgr.handleVerifyImageStatusModify(0x1773a40, 0xc0000b5a00, 0xc000b8c680, 0x40, 0x193abc0, 0xc000bfa800)\n\t/pillar/cmd/volumemgr/handleverifier.go:202 +0x342\ngithub.com/lf-edge/eve/pkg/pillar/pubsub.handleModify(0x18df780, 0xc0005c1000, 0xc000b8c680, 0x40, 0xc000acc700, 0x1b6, 0x1b6)\n\t/pillar/pubsub/subscribe.go:245 +0x687\ngithub.com/lf-edge/eve/pkg/pillar/pubsub.(*SubscriptionImpl).ProcessChange(0xc0005c1000, 0x3, 0xc000b8c680, 0x40, 0xc000acc700, 0x1b6, 0x1b6)\n\t/pillar/pubsub/subscribe.go:121 +0x322\ngithub.com/lf-edge/eve/pkg/pillar/cmd/volumemgr.Run(0xc000a66ff0, 0xc000078c60, 0xc0002510a0, 0x0)\n\t/pillar/cmd/volumemgr/volumemgr.go:519 +0x408f\nmain.startAgentAndDone(0x1a18dd0, 0xc000078e00, 0xc0009584d0, 0x9, 0xc000a66ff0, 0xc000078c60, 0xc0002510a0)\n\t/pillar/zedbox/zedbox.go:230 +0x62\ncreated by main.handleService\n\t/pillar/zedbox/zedbox.go:220 +0x390\n","pid":1209,"source":"zedbox","time":"2020-09-22T07:38:28.755503915Z"}
```
and EVE is rebooting due to zedbox crash.

It seems, that we should use Warn instead of Fatal inside Maybe function.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>