### PR TITLE
Fix: Handling nil resp in SendOnAllInt

### DIFF
--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -130,7 +130,7 @@ func SendOnAllIntf(ctx *ZedCloudContext, url string, reqlen int64, b *bytes.Buff
 					url, reqlen, resp.StatusCode)
 				return resp, nil, remoteTemporaryFailure, err
 			}
-			if resp.StatusCode == http.StatusForbidden {
+			if resp != nil && resp.StatusCode == http.StatusForbidden {
 				return resp, nil, remoteTemporaryFailure, err
 			}
 			if err != nil {


### PR DESCRIPTION
Fixes the below panic:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0xeded16]

goroutine 417 [running]:
github.com/lf-edge/eve/pkg/pillar/zedcloud.SendOnAllIntf(0x2bba440, 0xc0008b49c0, 0x58, 0x5e55, 0xc0011c29c0, 0x0, 0xc0011e6001, 0x5e55, 0x5e55, 0x0, ...)
        /pillar/zedcloud/send.go:133 +0x346
github.com/lf-edge/eve/pkg/pillar/cmd/logmanager.sendProtoStrForLogs(0xc00094d780, 0xc0001acb20, 0x4, 0x0, 0xc0002d0270, 0x28, 0xc00114cb60)
        /pillar/cmd/logmanager/logmanager.go:847 +0x642
github.com/lf-edge/eve/pkg/pillar/cmd/logmanager.processEvents(0xc0001acb20, 0x4, 0xc000f983c0, 0xc0002d0270, 0x28, 0xc000883c20)
        /pillar/cmd/logmanager/logmanager.go:636 +0x7d5
created by github.com/lf-edge/eve/pkg/pillar/cmd/logmanager.Run
        /pillar/cmd/logmanager/logmanager.go:330 +0x15c9
```
Signed-off-by: adarsh-zededa <adarsh@zededa.com>