### PR TITLE
Make SizeFromDir efficient

### DIFF
--- a/pkg/pillar/utils/volumeutils.go
+++ b/pkg/pillar/utils/volumeutils.go
@@ -6,27 +6,11 @@ package utils
 import (
 	"errors"
 	"fmt"
-	"github.com/lf-edge/eve/pkg/pillar/base"
 	"os"
-	"path/filepath"
 
+	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/diskmetrics"
 )
-
-// dirSize returns the size of the directory
-func dirSize(path string) (uint64, error) {
-	var size int64
-	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if !info.IsDir() {
-			size += info.Size()
-		}
-		return err
-	})
-	return uint64(size), err
-}
 
 // GetVolumeSize returns the actual and maximum size of the volume
 // plus a DiskType and a DirtyFlag
@@ -39,12 +23,7 @@ func GetVolumeSize(log *base.LogObject, name string) (uint64, uint64, string, bo
 	}
 	if info.IsDir() {
 		// Assume this is a container
-		size, err := dirSize(name)
-		if err != nil {
-			errStr := fmt.Sprintf("GetVolumeMaxSize failed for %s: %v",
-				name, err)
-			return 0, 0, "", false, errors.New(errStr)
-		}
+		size := diskmetrics.SizeFromDir(log, name)
 		return size, size, "CONTAINER", false, nil
 	}
 	imgInfo, err := diskmetrics.GetImgInfo(log, name)


### PR DESCRIPTION
We used filePath.Walk() and ioutil.ReadDir() to calculate size of a dir. 
Both of them sort the file from each directory [here](https://github.com/golang/go/blob/d140c357442471ca0d56615811fb4226e99fadd5/src/path/filepath/path.go#L426) and [here](https://github.com/golang/go/blob/d2bd93a01096ac6dc8061112e7a9ac62ec239627/src/io/ioutil/ioutil.go#L103) respectively.
Refactored `SizeFromDir()` to avoid the sorting. 

Signed-off-by: adarsh-zededa <adarsh@zededa.com>