### PR TITLE
ensure we always set a blob media type

### DIFF
--- a/pkg/pillar/cmd/volumemgr/blob.go
+++ b/pkg/pillar/cmd/volumemgr/blob.go
@@ -90,10 +90,6 @@ func downloadBlob(ctx *volumemgrContext, objType string, blob *types.BlobStatus)
 	case types.DOWNLOADING:
 		// Nothing to do
 	case types.DOWNLOADED:
-		// save the blob type
-		if setBlobTypeFromContentType(blob, ds.ContentType) {
-			changed = true
-		}
 		// signal verifier to start if it hasn't already; add RefCount
 		if verifyBlob(ctx, blob) {
 			changed = true
@@ -173,6 +169,14 @@ func updateBlobFromVerifyImageStatus(vs *types.VerifyImageStatus, blob *types.Bl
 // returns if the BlobStatus was changed, and thus woudl require publishing
 func verifyBlob(ctx *volumemgrContext, blob *types.BlobStatus) bool {
 	changed := false
+
+	// save the blob type if needed
+	if blob.MediaType == "" {
+		ds := lookupDownloaderStatus(ctx, blob.Sha256)
+		if ds != nil && setBlobTypeFromContentType(blob, ds.ContentType) {
+			changed = true
+		}
+	}
 
 	// A: try to use an existing VerifyImageStatus
 	vs := lookupVerifyImageStatus(ctx, blob.Sha256)


### PR DESCRIPTION
We call `verifyBlob` from 2 distinct places. One of them doesn't set the media-type correctly. This puts it idempotently inside of `verifyBlob`.

Do not merge until @adarsh-zededa says this is ok.