### PR TITLE
An OCI image with repeated shas results in in duplicate MaybeRemoveVerifierImage

### DIFF
--- a/pkg/pillar/agentlog/agentlog_test.go
+++ b/pkg/pillar/agentlog/agentlog_test.go
@@ -1,0 +1,221 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package agentlog_test checks the logging
+package agentlog_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/lf-edge/eve/pkg/pillar/agentlog"
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub/socketdriver"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/lf-edge/eve/pkg/pillar/utils/file"
+	"github.com/satori/go.uuid"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	defaultAgent    = "zedbox"
+	agentName       = "myAgent"
+	subscriberAgent = "subscriberAgent"
+	publisherAgent  = "publisherAgent"
+)
+
+// Really a constant
+var nilUUID = uuid.UUID{}
+
+const myLogType = "mylogtype"
+
+type Item struct {
+	AString string
+	ID      string
+}
+
+// Key for pubsub
+func (status Item) Key() string {
+	return status.ID
+}
+
+// LogCreate :
+func (status Item) LogCreate(logBase *base.LogObject) {
+	logObject := base.NewLogObject(logBase, myLogType, "",
+		nilUUID, status.LogKey())
+	if logObject == nil {
+		return
+	}
+	logObject.CloneAndAddField("a-string", status.AString).
+		Noticef("Item create")
+}
+
+// LogModify :
+func (status Item) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, myLogType, "",
+		nilUUID, status.LogKey())
+
+	oldStatus, ok := old.(Item)
+	if !ok {
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of Item type")
+	}
+	if oldStatus.AString != status.AString {
+		logObject.CloneAndAddField("a-string", status.AString).
+			AddField("old-a-string", oldStatus.AString).
+			Noticef("Item modify")
+	} else {
+		logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
+			Noticef("Item modify other change")
+	}
+}
+
+// LogDelete :
+func (status Item) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, myLogType, "",
+		nilUUID, status.LogKey())
+	logObject.CloneAndAddField("a-string", status.AString).
+		Noticef("Item delete")
+
+	base.DeleteLogObject(logBase, status.LogKey())
+}
+
+// LogKey :
+func (status Item) LogKey() string {
+	return myLogType + "-" + status.Key()
+}
+
+var (
+	item = Item{
+		AString: "aString",
+		ID:      "myID",
+	}
+)
+
+// TestPubsubLog verifies some agentlog+pubsub operations
+// TBD add assertions on what is logged in terms of "source"
+// This test only works if /persist and /run are writable
+func TestPubsubLog(t *testing.T) {
+	if !utils.Writable(types.PersistDir) || !utils.Writable("/run") {
+		t.Logf("Required directories not writeable; SKIP")
+		return
+	}
+	defaultLogger, defaultLog := agentlog.InitNoRedirect(defaultAgent)
+	// how do we check this appears in log?
+	defaultLogger.Infof("defaultLogger")
+	defaultLog.Noticef("defaultLog")
+	logrus.Infof("logrus")
+
+	pubLogger, pubLog := agentlog.InitNoRedirect(publisherAgent)
+	// pubLogger.SetLevel(logrus.TraceLevel)
+	pubPs := pubsub.New(
+		&socketdriver.SocketDriver{
+			Logger: pubLogger,
+			Log:    pubLog,
+		},
+		pubLogger, pubLog)
+	pub, err := pubPs.NewPublication(pubsub.PublicationOptions{
+		AgentName:  publisherAgent,
+		TopicType:  item,
+		Persistent: false,
+	})
+	if err != nil {
+		t.Fatalf("unable to publish: %v", err)
+	}
+
+	subLogger, subLog := agentlog.InitNoRedirect(subscriberAgent)
+	// subLogger.SetLevel(logrus.TraceLevel)
+	subPs := pubsub.New(
+		&socketdriver.SocketDriver{
+			Logger: subLogger,
+			Log:    subLog,
+		},
+		subLogger, subLog)
+
+	restarted := false
+	synchronized := false
+	created := false
+	modified := false
+	deleted := false
+	subRestartHandler := func(ctxArg interface{}, arg bool) {
+		t.Logf("subRestartHandler")
+		if !arg {
+			t.Fatalf("subRestartHandler called with false")
+		} else {
+			restarted = true
+		}
+	}
+	subSyncHandler := func(ctxArg interface{}, arg bool) {
+		t.Logf("subSyncHandler")
+		if !arg {
+			t.Fatalf("subSyncHandler called with false")
+		} else {
+			synchronized = true
+		}
+	}
+	subCreateHandler := func(ctxArg interface{}, key string, status interface{}) {
+		t.Logf("subCreateHandler")
+		created = true
+	}
+	subModifyHandler := func(ctxArg interface{}, key string, status interface{}) {
+		t.Logf("subModifyHandler")
+		modified = true
+	}
+	subDeleteHandler := func(ctxArg interface{}, key string, status interface{}) {
+		t.Logf("subDeleteHandler")
+		deleted = true
+	}
+
+	sub, err := subPs.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:      publisherAgent,
+		MyAgentName:    subscriberAgent,
+		RestartHandler: subRestartHandler,
+		SyncHandler:    subSyncHandler,
+		CreateHandler:  subCreateHandler,
+		ModifyHandler:  subModifyHandler,
+		DeleteHandler:  subDeleteHandler,
+		TopicImpl:      item,
+		Persistent:     false,
+		Ctx:            &item,
+		Activate:       true,
+	})
+	if err != nil {
+		t.Fatalf("unable to subscribe: %v", err)
+	}
+
+	dummyItem := Item{AString: "something to publish", ID: "mykey"}
+	t.Logf("Initial Publish")
+	pub.Publish(dummyItem.ID, dummyItem)
+	i, err := pub.Get("mykey")
+	assert.Nil(t, err)
+	i2 := i.(Item)
+	assert.Equal(t, "something to publish", i2.AString)
+	assert.Equal(t, "mykey", i2.ID)
+
+	change := <-sub.MsgChan()
+	t.Logf("ProcessChange synchronized?")
+	sub.ProcessChange(change)
+	assert.False(t, synchronized)
+	assert.False(t, restarted)
+
+	change = <-sub.MsgChan()
+	t.Logf("ProcessChange created?")
+	sub.ProcessChange(change)
+	assert.True(t, created)
+
+	dummyItem.AString = "something else"
+	t.Logf("Modify Publish")
+	pub.Publish(dummyItem.ID, dummyItem)
+	change = <-sub.MsgChan()
+	t.Logf("ProcessChange modified?")
+	sub.ProcessChange(change)
+	assert.True(t, modified)
+
+	t.Logf("Unpublish")
+	pub.Unpublish(dummyItem.ID)
+	change = <-sub.MsgChan()
+	t.Logf("ProcessChange deleted?")
+	sub.ProcessChange(change)
+	assert.True(t, deleted)
+}

--- a/pkg/pillar/cmd/volumemgr/blob_test.go
+++ b/pkg/pillar/cmd/volumemgr/blob_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package volumemgr
+
+import (
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/agentlog"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub/socketdriver"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/lf-edge/eve/pkg/pillar/utils/file"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestLookupBlobStatus checks the case when a sha is repeated
+// This test only works if /persist and /run are writable
+func TestLookupBlobStatus(t *testing.T) {
+	if !utils.Writable(types.PersistDir) || !utils.Writable("/run") {
+		t.Logf("Required directories not writeable; SKIP")
+		return
+	}
+	pubLogger, pubLog := agentlog.InitNoRedirect(agentName)
+	pubLogger.SetLevel(logrus.InfoLevel)
+	pubPs := pubsub.New(
+		&socketdriver.SocketDriver{
+			Logger: pubLogger,
+			Log:    pubLog,
+		},
+		pubLogger, pubLog)
+	pub, err := pubPs.NewPublication(pubsub.PublicationOptions{
+		AgentName:  agentName,
+		TopicType:  types.BlobStatus{},
+		Persistent: false,
+	})
+	if err != nil {
+		t.Fatalf("unable to publish: %v", err)
+	}
+	ctx := volumemgrContext{
+		pubBlobStatus: pub,
+	}
+	blob1 := types.BlobStatus{
+		Sha256:         "sha1",
+		HasVerifierRef: true,
+	}
+	blob2 := types.BlobStatus{
+		Sha256:         "sha2",
+		HasVerifierRef: true,
+	}
+	pub.Publish(blob1.Key(), blob1)
+	pub.Publish(blob2.Key(), blob2)
+
+	shas := []string{"sha0", "sha1", "sha2", "sha1", "sha3"}
+	blobPtrs := lookupBlobStatuses(&ctx, shas...)
+	assert.NotNil(t, blobPtrs)
+	for _, blobPtr := range blobPtrs {
+		assert.True(t, blobPtr.HasVerifierRef)
+	}
+	assert.Equal(t, 3, len(blobPtrs))
+	// Check that changing [0] affects [2]
+	blobPtrs[0].HasVerifierRef = false
+	assert.False(t, blobPtrs[0].HasVerifierRef)
+	assert.True(t, blobPtrs[1].HasVerifierRef)
+	assert.False(t, blobPtrs[2].HasVerifierRef)
+}

--- a/pkg/pillar/cmd/volumemgr/handlecontent.go
+++ b/pkg/pillar/cmd/volumemgr/handlecontent.go
@@ -265,6 +265,7 @@ func RemoveAllBlobsFromContentTreeStatus(ctx *volumemgrContext, status *types.Co
 			continue
 		}
 		RemoveRefFromBlobStatus(ctx, blobStatus)
+		blobStatus = nil // Potentially deleted
 	}
 	status.Blobs = make([]string, 0)
 }

--- a/pkg/pillar/types/blob.go
+++ b/pkg/pillar/types/blob.go
@@ -81,6 +81,8 @@ func (status BlobStatus) LogCreate(logBase *base.LogObject) {
 		AddField("size-int64", status.Size).
 		AddField("blobtype-string", status.MediaType).
 		AddField("refcount-int64", status.RefCount).
+		AddField("has-verifier-ref-bool", status.HasVerifierRef).
+		AddField("has-downloader-ref-bool", status.HasDownloaderRef).
 		Noticef("Blob status create")
 }
 
@@ -100,9 +102,13 @@ func (status BlobStatus) LogModify(logBase *base.LogObject, old interface{}) {
 		logObject.CloneAndAddField("state", status.State.String()).
 			AddField("refcount-int64", status.RefCount).
 			AddField("size-int64", status.Size).
+			AddField("has-verifier-ref-bool", status.HasVerifierRef).
+			AddField("has-downloader-ref-bool", status.HasDownloaderRef).
 			AddField("old-state", oldStatus.State.String()).
 			AddField("old-refcount-int64", oldStatus.RefCount).
 			AddField("old-size-int64", oldStatus.Size).
+			AddField("old-has-verifier-ref-bool", oldStatus.HasVerifierRef).
+			AddField("old-has-downloader-ref-bool", oldStatus.HasDownloaderRef).
 			Noticef("Blob status modify")
 	} else {
 		// XXX remove?
@@ -125,6 +131,8 @@ func (status BlobStatus) LogDelete(logBase *base.LogObject) {
 	logObject.CloneAndAddField("state", status.State.String()).
 		AddField("refcount-int64", status.RefCount).
 		AddField("size-int64", status.Size).
+		AddField("has-verifier-ref-bool", status.HasVerifierRef).
+		AddField("has-downloader-ref-bool", status.HasDownloaderRef).
 		Noticef("Blob status delete")
 
 	base.DeleteLogObject(logBase, status.LogKey())

--- a/pkg/pillar/utils/file/file.go
+++ b/pkg/pillar/utils/file/file.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2019,2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package utils
 
 import (
@@ -6,6 +9,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"golang.org/x/sys/unix"
 )
 
 // WriteRename write data to a fmpfile and then rename it to a desired name
@@ -37,4 +42,9 @@ func WriteRename(fileName string, b []byte) error {
 		return errors.New(errStr)
 	}
 	return nil
+}
+
+// Writable checks if the directory is writable
+func Writable(dir string) bool {
+	return unix.Access(dir, unix.W_OK) == nil
 }


### PR DESCRIPTION
@giggsoff running the eden tests as specified in #1472 now passes

The key fix in the first commit.
The dual refcount is also something we could hit in theory.

The other commits are related to the journey to get here - including some unit tests which I assume will run in jenkins (can't run on the laptop due to permissions).

