### PR TITLE
rationalize workers

### DIFF
--- a/pkg/pillar/cmd/baseosmgr/handlebaseos.go
+++ b/pkg/pillar/cmd/baseosmgr/handlebaseos.go
@@ -51,6 +51,8 @@ func lookupBaseOsStatusImageSha(ctx *baseOsMgrContext, imageSha string) *types.B
 	return nil
 }
 
+// baseOsHandleStatusUpdateImageSha find the config based on the sha,
+// and then call baseOsHandleStatusUpdate. Just a convenience function.
 func baseOsHandleStatusUpdateImageSha(ctx *baseOsMgrContext, imageSha string) {
 
 	log.Infof("baseOsHandleStatusUpdateImageSha for %s", imageSha)
@@ -75,6 +77,25 @@ func baseOsHandleStatusUpdateImageSha(ctx *baseOsMgrContext, imageSha string) {
 	}
 	log.Infof("baseOsHandleStatusUpdateImageSha(%s) found %s",
 		imageSha, uuidStr)
+
+	// handle the change event for this base os config
+	baseOsHandleStatusUpdate(ctx, config, status)
+}
+
+// baseOsHandleStatusUpdateUUID find the config based on the UUID,
+// and then call baseOsHandleStatusUpdate. Just a convenience function.
+func baseOsHandleStatusUpdateUUID(ctx *baseOsMgrContext, id string) {
+	log.Infof("baseOsHandleStatusUpdateUUID for %s", id)
+	config := lookupBaseOsConfig(ctx, id)
+	if config == nil {
+		log.Errorf("baseOsHandleStatusUpdateUUID(%s) config not found", id)
+		return
+	}
+	status := lookupBaseOsStatus(ctx, id)
+	if status == nil {
+		log.Infof("baseOsHandleStatusUpdateUUID(%s) status not found", id)
+		return
+	}
 
 	// handle the change event for this base os config
 	baseOsHandleStatusUpdate(ctx, config, status)

--- a/pkg/pillar/cmd/baseosmgr/handledownload.go
+++ b/pkg/pillar/cmd/baseosmgr/handledownload.go
@@ -171,10 +171,9 @@ func installDownloadedObject(ctx *baseOsMgrContext, contentID uuid.UUID, finalOb
 	}
 
 	// check if we have a result
-	wres := lookupInstallWorkResult(contentID.String())
+	wres := ctx.worker.Pop(contentID.String())
 	if wres != nil {
 		log.Infof("installDownloadedObject(%s): InstallWorkResult found", contentID)
-		DeleteWorkInstall(contentID.String())
 		if wres.Error != nil {
 			err := fmt.Errorf("installDownloadedObject(%s): InstallWorkResult error, exception while installing: %v", contentID, wres.Error)
 			log.Errorf(err.Error())

--- a/pkg/pillar/cmd/volumemgr/handlevolume.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume.go
@@ -235,12 +235,11 @@ func maybeDeleteVolume(ctx *volumemgrContext, status *types.VolumeStatus) {
 	}
 	if status.VolumeCreated {
 		// Asynch destruction; make sure we have a request for the work
-		MaybeAddWorkDestroy(ctx, status)
-		vr := lookupVolumeWorkResult(ctx, status.Key())
+		AddWorkDestroy(ctx, status)
+		vr := popVolumeWorkResult(ctx, status.Key())
 		if vr != nil {
 			log.Infof("VolumeWorkResult(%s) location %s, created %t",
 				status.Key(), vr.FileLocation, vr.VolumeCreated)
-			deleteVolumeWorkResult(ctx, status.Key())
 			status.VolumeCreated = vr.VolumeCreated
 			status.FileLocation = vr.FileLocation
 			if vr.Error != nil {

--- a/pkg/pillar/worker/doc.go
+++ b/pkg/pillar/worker/doc.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package worker provides utilities for creating background workers to perform tasks,
+// usually those that need to be queued up or will take a long time to run, thus potentially
+// blocking the main thread.
+//
+// You start by creating a worker with NewWorker, indicating the queue depth and a few other parameters.
+// Most important is the handlers, or actual functions that get called by the background task when a job
+// is processed. Because there are different kinds of tasks, the handlers are keyed off of a `Kind`, just an
+// arbitrary string. When creating a Worker, you pass it a map of Kind to handlers. When the Worker
+// receives tasks, it finds the appropriate request Handler to process the task, and then, when done,
+// calls the response handler, if any.
+//
+// The Worker has a func call, `C()` or `MsgChan()` that returns a channel sending completed task
+// Processors. Your main thread is responsible for calling the `Process()` function on the Processor,
+// to enable it to process the completed task. This *must* be done in your thread, so that it can be
+// handled correctly. Only work processing is done in the worker thread; response should be handled in your
+// thread.
+//
+// The Process() function will do two things. First, if you registered a response handler when
+// creating the NewWorker, it will call that response handler. Second, if the original task was given
+// a unique key, when done, it will keep the results in a cache, ready to be provided upon request.
+// You can retrieve that response by calling Peek (retrieve without removing) or Pop (retrieve and remove).
+//
+// This gives you the option to process responses asynchronously via the response handler, synchronously
+// by retrieving via key, or both.
+package worker

--- a/pkg/pillar/worker/errors.go
+++ b/pkg/pillar/worker/errors.go
@@ -1,0 +1,13 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package worker
+
+// JobInProgressError indicates a job in progress
+type JobInProgressError struct {
+	s string
+}
+
+func (e *JobInProgressError) Error() string {
+	return e.s
+}

--- a/pkg/pillar/worker/example_test.go
+++ b/pkg/pillar/worker/example_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package worker_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lf-edge/eve/pkg/pillar/worker"
+	log "github.com/sirupsen/logrus"
+)
+
+func Example_workerprocess() {
+	key := "123456"
+	kind := "install"
+	input := "25"
+	ctx := context.Background()
+	var output string
+
+	// a worker that just adds some test
+	installWorker := func(ctxPtr interface{}, w worker.Work) worker.WorkResult {
+		d := w.Description.(string)
+		result := worker.WorkResult{
+			Key:         w.Key,
+			Description: fmt.Sprintf("processed-%s", d),
+		}
+		return result
+	}
+	// a processor that just sets the var in the closure to show that it worked
+	processInstallWorkResult := func(ctxPtr interface{}, res worker.WorkResult) error {
+		d := res.Description.(string)
+		output = d
+		return nil
+	}
+
+	// create a new worker that can handle jobs of Kind "install"
+	work := worker.NewWorker(log.New(), ctx, 5, map[string]worker.Handler{
+		kind: {Request: installWorker, Response: processInstallWorkResult},
+	})
+
+	err := work.Submit(worker.Work{Key: key, Kind: kind, Description: input})
+	// what happened when we submitted?
+	if err != nil {
+		if _, ok := err.(*worker.JobInProgressError); ok {
+			log.Fatal("job already in progress")
+		}
+		log.Fatalf("unknown error: %v\n", err)
+	}
+	log.Info("job submitted")
+	// nothing to do now, wait for the result
+forloop:
+	for {
+		select {
+		case res := <-work.C():
+			res.Process(ctx, true)
+			// break out of the loop once we have a result
+			// normally, you would keep going
+			break forloop
+		}
+	}
+	// print the output, which is set to what the worker did
+	fmt.Println(output)
+
+	// see that we can retrieve it via Pop
+	wr := work.Pop(key)
+	d := wr.Description.(string)
+	fmt.Println(d)
+
+	// Output:
+	// processed-25
+	// processed-25
+}

--- a/pkg/pillar/worker/opt.go
+++ b/pkg/pillar/worker/opt.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package worker
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+)
+
+const (
+	// DefaultQueue default queue depth
+	DefaultQueue = 5
+)
+
+// Opts options when creating workers
+type Opts struct {
+	// Queue depth of queue; if you try to submit more than the depth, it will reject with an error
+	Queue int
+	// Handlers handlers by type
+	Handlers []Handler
+	// Log log handler
+	Log *base.LogObject
+}
+
+func (o *Opts) setDefaults() {
+	if o.Queue == 0 {
+		o.Queue = DefaultQueue
+	}
+}
+
+// Validate check that this is a valid set of opts for our capabilities
+func (o *Opts) Validate() error {
+	var e []string
+	if o.Queue == 0 {
+		e = append(e, "queue size must be greater than 0")
+	}
+	if len(e) > 0 {
+		return fmt.Errorf("%s", strings.Join(e, "; "))
+	}
+	return nil
+}

--- a/pkg/pillar/worker/worker.go
+++ b/pkg/pillar/worker/worker.go
@@ -7,26 +7,42 @@
 package worker
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
-	"github.com/lf-edge/eve/pkg/pillar/base"
 )
+
+// Logger basic interface to send debug messages
+type Logger interface {
+	Debugf(format string, args ...interface{})
+}
 
 // Worker captures the worker channels
 type Worker struct {
 	// Private
 	requestChan  chan<- Work
-	resultChan   <-chan privateResult
+	resultChan   <-chan Processor
 	requestCount uint // Number of work items submitted
 	resultCount  uint // Number of work results processed
+	workMap      map[string]bool
+	resultMap    map[string]WorkResult
+	handlers     map[string]Handler
 }
 
 // Work is one work item
-// Key is used to match with the WorkResult
-// The description is specific for the particular worker function
 type Work struct {
-	Key         string
+	// Kind is the unique kind of work for the worker, e.g. install something or load something.
+	// It is used to distinguish between different kinds of jobs. The specific handlers to use for the job
+	// are determined by the Kind. In the future, jobs may be grouped into queues by Kind. Kind is required.
+	Kind string
+	// Key is a key for this job. It is unique across all jobs, and may be used to retrieve the WorkResult
+	// later. Submitting two jobs with the same key results in the second one not being performed, as it already
+	// exists. If Key is blank `""`, then two jobs with the same Key always will both be executed. However,
+	// with a blank Key, there is no way to retrieve the result using Peek or Pop, and only can be retrieved
+	// during the Process phase.
+	Key string
+	// Description arbitrary structure, used to pass arbitrary data to the handler function(s).
 	Description interface{}
 }
 
@@ -43,6 +59,8 @@ type WorkResult struct {
 // Private to ensure that callers use the Process function and count the
 // number of pending
 type privateResult struct {
+	worker      *Worker
+	kind        string
 	key         string
 	error       error
 	errorTime   time.Time
@@ -53,74 +71,201 @@ type privateResult struct {
 // WorkFunction is the user's function to do the actual work
 type WorkFunction func(ctx interface{}, work Work) WorkResult
 
+// ResponseFunction is the user's function to process the response
+type ResponseFunction func(ctx interface{}, res WorkResult) error
+
+// Handler a tuple that describes what the type of request is, and what the request handler
+// and response handler should be
+type Handler struct {
+	Request  WorkFunction
+	Response ResponseFunction
+}
+
 // NewWorker creates a new function for a specific function and context
 // function takes the context and the channels
-func NewWorker(log *base.LogObject, fn WorkFunction, ctx interface{}, length int) *Worker {
-	w := new(Worker)
+func NewWorker(log Logger, ctx interface{}, length int, handlers map[string]Handler) *Worker {
 	requestChan := make(chan Work, length)
-	resultChan := make(chan privateResult, length)
-	log.Infof("Creating %s at %s", "w.processWork", agentlog.GetMyStack())
-	go w.processWork(log, ctx, fn, requestChan, resultChan)
-	w.requestChan = requestChan
-	w.resultChan = resultChan
+	resultChan := make(chan Processor, length)
+
+	w := &Worker{
+		requestChan: requestChan,
+		resultChan:  resultChan,
+		workMap:     map[string]bool{},
+		resultMap:   map[string]WorkResult{},
+		handlers:    handlers,
+	}
+
+	log.Debugf("Creating %s at %s", "w.processWork", agentlog.GetMyStack())
+	go w.processWork(log, ctx, requestChan, resultChan)
 	return w
 }
 
 // NumPending returns the number of pending work items
 // Callers should use this to check if it is less than the length specified
 // in NewWorker
-func (workerPtr Worker) NumPending() int {
-	return int(workerPtr.requestCount) - int(workerPtr.resultCount)
+func (w Worker) NumPending() int {
+	return int(w.requestCount) - int(w.resultCount)
 }
 
 // processWork calls the fn for each work until the requestChan is closed
-func (workerPtr *Worker) processWork(log *base.LogObject, ctx interface{}, fn WorkFunction, requestChan <-chan Work, resultChan chan<- privateResult) {
+func (w *Worker) processWork(log Logger, ctx interface{}, requestChan <-chan Work, resultChan chan<- Processor) {
 
-	log.Infof("processWork starting for context %T", ctx)
-	for w := range requestChan {
-		result := fn(ctx, w)
+	log.Debugf("processWork starting for context %T", ctx)
+	for work := range requestChan {
+		var result WorkResult
+		// find the correct handler for it
+		if handler, ok := w.handlers[work.Kind]; ok {
+			result = handler.Request(ctx, work)
+		} else {
+			result = WorkResult{
+				Error:     fmt.Errorf("unknown work description type: %s", work.Kind),
+				ErrorTime: time.Now(),
+			}
+		}
+
 		priv := privateResult{
+			kind:        work.Kind,
 			key:         result.Key,
 			error:       result.Error,
 			errorTime:   result.ErrorTime,
 			output:      result.Output,
 			description: result.Description,
+			worker:      w,
 		}
-		resultChan <- priv
+		resultChan <- Processor{
+			result: priv,
+		}
+		// no longer pending
+		w.deletePending(work.Key)
 	}
 	// XXX if we ever want multiple goroutines for one Worker we
 	// can't close here; would need some wait for all to finish
 	close(resultChan)
-	log.Infof("processWork done for context %T", ctx)
+	log.Debugf("processWork done for context %T", ctx)
 }
 
-// MsgChan returns a channel to be used in a select loop
-func (workerPtr *Worker) MsgChan() <-chan privateResult { //revive:disable
-	return workerPtr.resultChan
+// MsgChan returns a channel to be used in a select loop.
+// This is a duplicate of C
+func (w *Worker) MsgChan() <-chan Processor {
+	return w.resultChan
 }
 
-// Process takes the output from the channel and returns the WorkResult
-func (workerPtr *Worker) Process(priv privateResult) WorkResult {
-	workerPtr.resultCount++
-	result := WorkResult{
-		Key:         priv.key,
-		Error:       priv.error,
-		ErrorTime:   priv.errorTime,
-		Output:      priv.output,
-		Description: priv.description,
+// C returns a channel to be used in a select loop
+func (w *Worker) C() <-chan Processor {
+	return w.resultChan
+}
+
+// Submit will pass work to the worker.
+// Note that this will wait if channel is busy, hence
+// user has to pick an appropriate length of the channel and use.
+// returns nil if the new job was submitted, JobInProgressError if a job with that
+// key already ins progress, and other errors if it cannot proceed.
+func (w *Worker) Submit(work Work) error {
+	// if this Key already exists and is being processed, do nothing
+	if work.Key != "" && w.lookupPending(work.Key) {
+		return &JobInProgressError{s: work.Key}
 	}
-	return result
+	// Kind must be set to be handleable
+	if work.Kind == "" {
+		return fmt.Errorf("cannot process a job with a blank Kind")
+	}
+	if _, ok := w.handlers[work.Kind]; !ok {
+		return fmt.Errorf("no registered handlers for a job of Kind '%s'", work.Kind)
+	}
+	w.requestChan <- work
+	w.requestCount++
+	if work.Key != "" {
+		w.addPending(work.Key)
+	}
+	return nil
 }
 
-// Submit will pass work to the worker
-// Note that this will wait if channel is busy hence
-// user has to pick an appropriate length of the channel and use
-func (workerPtr *Worker) Submit(w Work) {
-	workerPtr.requestChan <- w
-	workerPtr.requestCount++
+// Cancel cancels a pending job.
+// It is idempotent, will return no errors if the job is not found,
+// which means it either never was submitted, or it already was processed.
+func (w *Worker) Cancel(key string) {
+	w.deletePending(key)
 }
 
 // Done will stop the worker
-func (workerPtr *Worker) Done() {
-	close(workerPtr.requestChan)
+func (w *Worker) Done() {
+	close(w.requestChan)
+}
+
+// Pop get a result and remove it from the list
+func (w *Worker) Pop(key string) *WorkResult {
+	res := w.Peek(key)
+	if w != nil {
+		w.deleteResult(key)
+	}
+	return res
+}
+
+// Peek get a result without removing it from the list
+func (w *Worker) Peek(key string) *WorkResult {
+	if key == "" {
+		return nil
+	}
+	return w.lookupResult(key)
+}
+
+func (w *Worker) lookupPending(key string) bool {
+	res, ok := w.workMap[key]
+	return ok && res
+}
+
+func (w *Worker) addPending(key string) {
+	w.workMap[key] = true
+}
+
+func (w *Worker) deletePending(key string) {
+	delete(w.workMap, key)
+}
+
+func (w *Worker) lookupResult(key string) *WorkResult {
+	if res, ok := w.resultMap[key]; ok {
+		return &res
+	}
+	return nil
+}
+
+func (w *Worker) addResult(key string, res WorkResult) {
+	w.resultMap[key] = res
+}
+
+func (w *Worker) deleteResult(key string) {
+	delete(w.resultMap, key)
+}
+
+// Processor struct that can process results
+type Processor struct {
+	result privateResult
+}
+
+// Process takes the output from the channel and returns the WorkResult.
+// Can pass it an arbitrary context that will be passed to the handler,
+// as well as whether to make it available for lookup afterwards via Pop/Peek.
+// If false, it is here and that is it. If true, it will be available for Pop/Peek.
+func (p Processor) Process(ctx interface{}, later bool) (err error) {
+	kind := p.result.kind
+	w := p.result.worker
+	res := WorkResult{
+		Key:         p.result.key,
+		Error:       p.result.error,
+		ErrorTime:   p.result.errorTime,
+		Output:      p.result.output,
+		Description: p.result.description,
+	}
+	w.resultCount++
+	if later {
+		w.addResult(p.result.key, res)
+	}
+	// find the correct handler for it
+	if handler, ok := w.handlers[kind]; ok {
+		if handler.Response == nil {
+			return nil
+		}
+		return handler.Response(ctx, res)
+	}
+	return fmt.Errorf("unknown work description type %s", kind)
 }


### PR DESCRIPTION
When doing #1482 I started this, to rationalize the duplication of stuff between volumemgr and baseosmgr and worker.

This captures a "will compile" state, but has not been tested. It will be once the current surge of stabilization is done and I have some more breathing room. I did want to capture the state when it was stable.
