### PR TITLE
Fix confusing pubsub logging

### DIFF
--- a/pkg/pillar/base/base_test.go
+++ b/pkg/pillar/base/base_test.go
@@ -28,22 +28,22 @@ func (agent Agent) LogCreate(logBase *LogObject) {
 	logObject := EnsureLogObject(logBase, "secret_agent", "Pierce Brosnan", uuid.UUID{}, agent.LogKey())
 	logObject.CloneAndAddField("agent_name", agent.AgentName).
 		AddField("agent_number", agent.AgentNumber).
-		AddField("agent_is_brosnan", true).AddField("agent_age", agent.AgentAge).Infof("I am Bond, James Bond")
+		AddField("agent_is_brosnan", true).AddField("agent_age", agent.AgentAge).Noticef("I am Bond, James Bond")
 }
 
-func (agent Agent) LogModify(old interface{}) {
-	logObject := EnsureLogObject(log, "secret_agent", "Pierce Brosnan", uuid.UUID{}, agent.LogKey())
+func (agent Agent) LogModify(logBase *LogObject, old interface{}) {
+	logObject := EnsureLogObject(logBase, "secret_agent", "Pierce Brosnan", uuid.UUID{}, agent.LogKey())
 	logObject.CloneAndAddField("agent_name", agent.AgentName).
 		AddField("agent_number", agent.AgentNumber).
-		AddField("agent_is_brosnan", true).AddField("agent_age", agent.AgentAge).Infof("James Bond gets old!")
+		AddField("agent_is_brosnan", true).AddField("agent_age", agent.AgentAge).Noticef("James Bond gets old!")
 }
 
-func (agent Agent) LogDelete() {
-	logObject := EnsureLogObject(log, "secret_agent", "Pierce Brosnan", uuid.UUID{}, agent.LogKey())
+func (agent Agent) LogDelete(logBase *LogObject) {
+	logObject := EnsureLogObject(logBase, "secret_agent", "Pierce Brosnan", uuid.UUID{}, agent.LogKey())
 	logObject.CloneAndAddField("agent_name", agent.AgentName).
 		AddField("agent_number", agent.AgentNumber).
-		AddField("agent_is_brosnan", true).AddField("agent_age", agent.AgentAge).Infof("James Bond dies!")
-	DeleteLogObject(agent.LogKey())
+		AddField("agent_is_brosnan", true).AddField("agent_age", agent.AgentAge).Noticef("James Bond dies!")
+	DeleteLogObject(logBase, agent.LogKey())
 }
 
 var (
@@ -94,16 +94,16 @@ func TestSpecialAgent(t *testing.T) {
 		switch test.action {
 		case "create":
 			test.agent.LogCreate(log)
-			expected := "{\"agent_age\":30,\"agent_is_brosnan\":true,\"agent_name\":\"James Bond\",\"agent_number\":7,\"level\":\"debug\",\"log_event_type\":\"log\",\"msg\":\"I am Bond, James Bond\",\"obj_key\":\"james-bond-007\",\"obj_name\":\"Pierce Brosnan\",\"obj_type\":\"secret_agent\",\"pid\":1234,\"source\":\"test\"}"
+			expected := "{\"agent_age\":30,\"agent_is_brosnan\":true,\"agent_name\":\"James Bond\",\"agent_number\":7,\"level\":\"info\",\"log_event_type\":\"log\",\"msg\":\"I am Bond, James Bond\",\"obj_key\":\"james-bond-007\",\"obj_name\":\"Pierce Brosnan\",\"obj_type\":\"secret_agent\",\"pid\":1234,\"source\":\"test\"}"
 			assert.Equal(t, expected, strings.TrimSpace(logBuffer.String()))
 		case "modify":
 			test.agent.AgentAge = 100
-			test.agent.LogModify("old agent")
-			expected := "{\"agent_age\":100,\"agent_is_brosnan\":true,\"agent_name\":\"James Bond\",\"agent_number\":7,\"level\":\"debug\",\"log_event_type\":\"log\",\"msg\":\"James Bond gets old!\",\"obj_key\":\"james-bond-007\",\"obj_name\":\"Pierce Brosnan\",\"obj_type\":\"secret_agent\",\"pid\":1234,\"source\":\"test\"}"
+			test.agent.LogModify(log, "old agent")
+			expected := "{\"agent_age\":100,\"agent_is_brosnan\":true,\"agent_name\":\"James Bond\",\"agent_number\":7,\"level\":\"info\",\"log_event_type\":\"log\",\"msg\":\"James Bond gets old!\",\"obj_key\":\"james-bond-007\",\"obj_name\":\"Pierce Brosnan\",\"obj_type\":\"secret_agent\",\"pid\":1234,\"source\":\"test\"}"
 			assert.Equal(t, expected, strings.TrimSpace(logBuffer.String()))
 		case "kill":
-			test.agent.LogDelete()
-			expected := "{\"agent_age\":30,\"agent_is_brosnan\":true,\"agent_name\":\"James Bond\",\"agent_number\":7,\"level\":\"debug\",\"log_event_type\":\"log\",\"msg\":\"James Bond dies!\",\"obj_key\":\"james-bond-007\",\"obj_name\":\"Pierce Brosnan\",\"obj_type\":\"secret_agent\",\"pid\":1234,\"source\":\"test\"}"
+			test.agent.LogDelete(log)
+			expected := "{\"agent_age\":30,\"agent_is_brosnan\":true,\"agent_name\":\"James Bond\",\"agent_number\":7,\"level\":\"info\",\"log_event_type\":\"log\",\"msg\":\"James Bond dies!\",\"obj_key\":\"james-bond-007\",\"obj_name\":\"Pierce Brosnan\",\"obj_type\":\"secret_agent\",\"pid\":1234,\"source\":\"test\"}"
 			assert.Equal(t, expected, strings.TrimSpace(logBuffer.String()))
 		default:
 		}

--- a/pkg/pillar/pubsub/publish.go
+++ b/pkg/pillar/pubsub/publish.go
@@ -88,7 +88,7 @@ func (pub *PublicationImpl) Publish(key string, item interface{}) error {
 
 		loggable, ok := newItem.(base.LoggableObject)
 		if ok {
-			loggable.LogModify(m)
+			loggable.LogModify(pub.log, m)
 		}
 	} else {
 		// DO NOT log Values. They may contain sensitive information.
@@ -121,7 +121,7 @@ func (pub *PublicationImpl) Unpublish(key string) error {
 		pub.log.Debugf("Unpublish(%s/%s) removing Item", name, key)
 		loggable, ok := m.(base.LoggableObject)
 		if ok {
-			loggable.LogDelete()
+			loggable.LogDelete(pub.log)
 		}
 	} else {
 		errStr := fmt.Sprintf("Unpublish(%s/%s): key does not exist",

--- a/pkg/pillar/pubsub/subscribe.go
+++ b/pkg/pillar/pubsub/subscribe.go
@@ -221,7 +221,7 @@ func handleModify(ctxArg interface{}, key string, itemcb []byte) {
 			name, key)
 		loggable, ok := item.(base.LoggableObject)
 		if ok {
-			loggable.LogModify(m)
+			loggable.LogModify(sub.log, m)
 		}
 	} else {
 		// DO NOT log Values. They may contain sensitive information.
@@ -260,7 +260,7 @@ func handleDelete(ctxArg interface{}, key string) {
 	}
 	loggable, ok := m.(base.LoggableObject)
 	if ok {
-		loggable.LogDelete()
+		loggable.LogDelete(sub.log)
 	}
 	// DO NOT log Values. They may contain sensitive information.
 	sub.log.Debugf("pubsub.handleDelete(%s) key %s", name, key)

--- a/pkg/pillar/types/assignableadapters.go
+++ b/pkg/pillar/types/assignableadapters.go
@@ -219,8 +219,8 @@ func (aa AssignableAdapters) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (aa AssignableAdapters) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.AssignableAdaptersLogType, "",
+func (aa AssignableAdapters) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.AssignableAdaptersLogType, "",
 		nilUUID, aa.LogKey())
 
 	oldAa, ok := old.(AssignableAdapters)
@@ -233,12 +233,12 @@ func (aa AssignableAdapters) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (aa AssignableAdapters) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.AssignableAdaptersLogType, "",
+func (aa AssignableAdapters) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.AssignableAdaptersLogType, "",
 		nilUUID, aa.LogKey())
 	logObject.Noticef("Assignable adapters delete")
 
-	base.DeleteLogObject(aa.LogKey())
+	base.DeleteLogObject(logBase, aa.LogKey())
 }
 
 // LogKey :

--- a/pkg/pillar/types/attesttypes.go
+++ b/pkg/pillar/types/attesttypes.go
@@ -32,8 +32,8 @@ func (nonce AttestNonce) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (nonce AttestNonce) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.AttestNonceLogType, "",
+func (nonce AttestNonce) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.AttestNonceLogType, "",
 		nilUUID, nonce.LogKey())
 
 	oldNonce, ok := old.(AttestNonce)
@@ -46,12 +46,12 @@ func (nonce AttestNonce) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (nonce AttestNonce) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.AttestNonceLogType, "",
+func (nonce AttestNonce) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.AttestNonceLogType, "",
 		nilUUID, nonce.LogKey())
 	logObject.Noticef("Attest nonce delete")
 
-	base.DeleteLogObject(nonce.LogKey())
+	base.DeleteLogObject(logBase, nonce.LogKey())
 }
 
 // LogKey :
@@ -127,8 +127,8 @@ func (quote AttestQuote) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (quote AttestQuote) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.AttestQuoteLogType, "",
+func (quote AttestQuote) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.AttestQuoteLogType, "",
 		nilUUID, quote.LogKey())
 
 	oldQuote, ok := old.(AttestQuote)
@@ -141,12 +141,12 @@ func (quote AttestQuote) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (quote AttestQuote) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.AttestQuoteLogType, "",
+func (quote AttestQuote) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.AttestQuoteLogType, "",
 		nilUUID, quote.LogKey())
 	logObject.Noticef("Attest quote delete")
 
-	base.DeleteLogObject(quote.LogKey())
+	base.DeleteLogObject(logBase, quote.LogKey())
 }
 
 // LogKey :
@@ -188,8 +188,8 @@ func (cert EdgeNodeCert) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (cert EdgeNodeCert) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.EdgeNodeCertLogType, "",
+func (cert EdgeNodeCert) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.EdgeNodeCertLogType, "",
 		nilUUID, cert.LogKey())
 
 	oldCert, ok := old.(EdgeNodeCert)
@@ -202,12 +202,12 @@ func (cert EdgeNodeCert) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (cert EdgeNodeCert) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.EdgeNodeCertLogType, "",
+func (cert EdgeNodeCert) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.EdgeNodeCertLogType, "",
 		nilUUID, cert.LogKey())
 	logObject.Noticef("Edge node cert delete")
 
-	base.DeleteLogObject(cert.LogKey())
+	base.DeleteLogObject(logBase, cert.LogKey())
 }
 
 // LogKey :

--- a/pkg/pillar/types/blob.go
+++ b/pkg/pillar/types/blob.go
@@ -85,8 +85,8 @@ func (status BlobStatus) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (status BlobStatus) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.BlobStatusLogType, status.RelativeURL,
+func (status BlobStatus) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.BlobStatusLogType, status.RelativeURL,
 		nilUUID, status.LogKey())
 
 	oldStatus, ok := old.(BlobStatus)
@@ -119,15 +119,15 @@ func (status BlobStatus) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (status BlobStatus) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.BlobStatusLogType, status.RelativeURL,
+func (status BlobStatus) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.BlobStatusLogType, status.RelativeURL,
 		nilUUID, status.LogKey())
 	logObject.CloneAndAddField("state", status.State.String()).
 		AddField("refcount-int64", status.RefCount).
 		AddField("size-int64", status.Size).
 		Noticef("Blob status delete")
 
-	base.DeleteLogObject(status.LogKey())
+	base.DeleteLogObject(logBase, status.LogKey())
 }
 
 // LogKey :

--- a/pkg/pillar/types/certinfotypes.go
+++ b/pkg/pillar/types/certinfotypes.go
@@ -37,8 +37,8 @@ func (cert ControllerCert) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (cert ControllerCert) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.ControllerCertLogType, "",
+func (cert ControllerCert) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.ControllerCertLogType, "",
 		nilUUID, cert.LogKey())
 
 	oldCert, ok := old.(ControllerCert)
@@ -51,12 +51,12 @@ func (cert ControllerCert) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (cert ControllerCert) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.ControllerCertLogType, "",
+func (cert ControllerCert) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.ControllerCertLogType, "",
 		nilUUID, cert.LogKey())
 	logObject.Noticef("Controller cert delete")
 
-	base.DeleteLogObject(cert.LogKey())
+	base.DeleteLogObject(logBase, cert.LogKey())
 }
 
 // LogKey :

--- a/pkg/pillar/types/cipherinfotypes.go
+++ b/pkg/pillar/types/cipherinfotypes.go
@@ -52,8 +52,8 @@ func (status CipherContext) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (status CipherContext) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.CipherContextLogType, "",
+func (status CipherContext) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.CipherContextLogType, "",
 		nilUUID, status.LogKey())
 
 	oldStatus, ok := old.(CipherContext)
@@ -66,12 +66,12 @@ func (status CipherContext) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (status CipherContext) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.CipherContextLogType, "",
+func (status CipherContext) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.CipherContextLogType, "",
 		nilUUID, status.LogKey())
 	logObject.Noticef("Cipher block status delete")
 
-	base.DeleteLogObject(status.LogKey())
+	base.DeleteLogObject(logBase, status.LogKey())
 }
 
 // LogKey :
@@ -107,8 +107,8 @@ func (status CipherBlockStatus) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (status CipherBlockStatus) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.CipherBlockStatusLogType, "",
+func (status CipherBlockStatus) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.CipherBlockStatusLogType, "",
 		nilUUID, status.LogKey())
 
 	oldStatus, ok := old.(CipherBlockStatus)
@@ -121,12 +121,12 @@ func (status CipherBlockStatus) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (status CipherBlockStatus) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.CipherBlockStatusLogType, "",
+func (status CipherBlockStatus) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.CipherBlockStatusLogType, "",
 		nilUUID, status.LogKey())
 	logObject.Noticef("Cipher block status delete")
 
-	base.DeleteLogObject(status.LogKey())
+	base.DeleteLogObject(logBase, status.LogKey())
 }
 
 // LogKey :

--- a/pkg/pillar/types/ciphermetrics.go
+++ b/pkg/pillar/types/ciphermetrics.go
@@ -58,8 +58,8 @@ func (cipherMetric CipherMetrics) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (cipherMetric CipherMetrics) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.CipherMetricsLogType, "",
+func (cipherMetric CipherMetrics) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.CipherMetricsLogType, "",
 		nilUUID, cipherMetric.LogKey())
 
 	oldAcMetric, ok := old.(CipherMetrics)
@@ -72,12 +72,12 @@ func (cipherMetric CipherMetrics) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (cipherMetric CipherMetrics) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.CipherMetricsLogType, "",
+func (cipherMetric CipherMetrics) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.CipherMetricsLogType, "",
 		nilUUID, cipherMetric.LogKey())
 	logObject.Metricf("Cipher metric delete")
 
-	base.DeleteLogObject(cipherMetric.LogKey())
+	base.DeleteLogObject(logBase, cipherMetric.LogKey())
 }
 
 // LogKey :

--- a/pkg/pillar/types/contenttreetypes.go
+++ b/pkg/pillar/types/contenttreetypes.go
@@ -46,8 +46,8 @@ func (config ContentTreeConfig) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (config ContentTreeConfig) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.ContentTreeConfigLogType, config.DisplayName,
+func (config ContentTreeConfig) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.ContentTreeConfigLogType, config.DisplayName,
 		config.ContentID, config.LogKey())
 
 	oldConfig, ok := old.(ContentTreeConfig)
@@ -79,8 +79,8 @@ func (config ContentTreeConfig) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (config ContentTreeConfig) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.ContentTreeConfigLogType, config.DisplayName,
+func (config ContentTreeConfig) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.ContentTreeConfigLogType, config.DisplayName,
 		config.ContentID, config.LogKey())
 	logObject.CloneAndAddField("datastore-id", config.DatastoreID).
 		AddField("relative-URL", config.RelativeURL).
@@ -89,7 +89,7 @@ func (config ContentTreeConfig) LogDelete() {
 		AddField("max-download-size-int64", config.MaxDownloadSize).
 		Noticef("Content tree config delete")
 
-	base.DeleteLogObject(config.LogKey())
+	base.DeleteLogObject(logObject, config.LogKey())
 }
 
 // LogKey :
@@ -183,8 +183,8 @@ func (status ContentTreeStatus) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (status ContentTreeStatus) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.ContentTreeStatusLogType, status.DisplayName,
+func (status ContentTreeStatus) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.ContentTreeStatusLogType, status.DisplayName,
 		status.ContentID, status.LogKey())
 
 	oldStatus, ok := old.(ContentTreeStatus)
@@ -217,8 +217,8 @@ func (status ContentTreeStatus) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (status ContentTreeStatus) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.ContentTreeStatusLogType, status.DisplayName,
+func (status ContentTreeStatus) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.ContentTreeStatusLogType, status.DisplayName,
 		status.ContentID, status.LogKey())
 	logObject.CloneAndAddField("content-sha256", status.ContentSha256).
 		AddField("max-download-size-int64", status.MaxDownloadSize).
@@ -228,7 +228,7 @@ func (status ContentTreeStatus) LogDelete() {
 		AddField("objtype", status.ObjType).
 		Noticef("Content tree status delete")
 
-	base.DeleteLogObject(status.LogKey())
+	base.DeleteLogObject(logBase, status.LogKey())
 }
 
 // LogKey :

--- a/pkg/pillar/types/diskmetrics.go
+++ b/pkg/pillar/types/diskmetrics.go
@@ -78,8 +78,8 @@ func (status DiskMetric) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (status DiskMetric) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.DiskMetricType, status.DiskPath, nilUUID, status.LogKey())
+func (status DiskMetric) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.DiskMetricType, status.DiskPath, nilUUID, status.LogKey())
 
 	if _, ok := old.(DiskMetric); !ok {
 		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of DiskMetric type")
@@ -97,8 +97,8 @@ func (status DiskMetric) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (status DiskMetric) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.DiskMetricType, status.DiskPath, nilUUID, status.LogKey())
+func (status DiskMetric) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.DiskMetricType, status.DiskPath, nilUUID, status.LogKey())
 	logObject.CloneAndAddField("diskpath", status.DiskPath).
 		AddField("totalbytes-int64", status.TotalBytes).
 		AddField("userbytes-int64", status.UsedBytes).
@@ -106,7 +106,7 @@ func (status DiskMetric) LogDelete() {
 		AddField("isdor", status.IsDir).
 		Metricf("DiskMetric status delete")
 
-	base.DeleteLogObject(status.LogKey())
+	base.DeleteLogObject(logBase, status.LogKey())
 }
 
 // LogKey :
@@ -143,8 +143,8 @@ func (status AppDiskMetric) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (status AppDiskMetric) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.AppDiskMetricType, status.DiskPath, nilUUID, status.LogKey())
+func (status AppDiskMetric) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.AppDiskMetricType, status.DiskPath, nilUUID, status.LogKey())
 
 	if _, ok := old.(AppDiskMetric); !ok {
 		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of AppDiskMetric type")
@@ -158,15 +158,15 @@ func (status AppDiskMetric) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (status AppDiskMetric) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.AppDiskMetricType, status.DiskPath, nilUUID, status.LogKey())
+func (status AppDiskMetric) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.AppDiskMetricType, status.DiskPath, nilUUID, status.LogKey())
 	logObject.CloneAndAddField("diskpath", status.DiskPath).
 		AddField("provisionedbytes-int64", status.ProvisionedBytes).
 		AddField("disktype", status.DiskType).
 		AddField("dirty", status.Dirty).
 		Metricf("AppDiskMetric status delete")
 
-	base.DeleteLogObject(status.LogKey())
+	base.DeleteLogObject(logBase, status.LogKey())
 }
 
 // LogKey :

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -65,8 +65,8 @@ func (config DomainConfig) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (config DomainConfig) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.DomainConfigLogType, config.DisplayName,
+func (config DomainConfig) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.DomainConfigLogType, config.DisplayName,
 		config.UUIDandVersion.UUID, config.LogKey())
 
 	oldConfig, ok := old.(DomainConfig)
@@ -89,14 +89,14 @@ func (config DomainConfig) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (config DomainConfig) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.DomainConfigLogType, config.DisplayName,
+func (config DomainConfig) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.DomainConfigLogType, config.DisplayName,
 		config.UUIDandVersion.UUID, config.LogKey())
 	logObject.CloneAndAddField("activate", config.Activate).
 		AddField("enable-vnc", config.EnableVnc).
 		Noticef("domain config delete")
 
-	base.DeleteLogObject(config.LogKey())
+	base.DeleteLogObject(logBase, config.LogKey())
 }
 
 // LogKey :
@@ -214,8 +214,8 @@ func (status DomainStatus) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (status DomainStatus) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.DomainStatusLogType, status.DisplayName,
+func (status DomainStatus) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.DomainStatusLogType, status.DisplayName,
 		status.UUIDandVersion.UUID, status.LogKey())
 
 	oldStatus, ok := old.(DomainStatus)
@@ -247,14 +247,14 @@ func (status DomainStatus) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (status DomainStatus) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.DomainStatusLogType, status.DisplayName,
+func (status DomainStatus) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.DomainStatusLogType, status.DisplayName,
 		status.UUIDandVersion.UUID, status.LogKey())
 	logObject.CloneAndAddField("state", status.State.String()).
 		AddField("activated", status.Activated).
 		Noticef("domain status delete")
 
-	base.DeleteLogObject(status.LogKey())
+	base.DeleteLogObject(logBase, status.LogKey())
 }
 
 // LogKey :
@@ -317,8 +317,8 @@ func (metric DomainMetric) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (metric DomainMetric) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.DomainMetricLogType, "",
+func (metric DomainMetric) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.DomainMetricLogType, "",
 		metric.UUIDandVersion.UUID, metric.LogKey())
 
 	oldMetric, ok := old.(DomainMetric)
@@ -331,12 +331,12 @@ func (metric DomainMetric) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (metric DomainMetric) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.DomainMetricLogType, "",
+func (metric DomainMetric) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.DomainMetricLogType, "",
 		metric.UUIDandVersion.UUID, metric.LogKey())
 	logObject.Metricf("Domain metric delete")
 
-	base.DeleteLogObject(metric.LogKey())
+	base.DeleteLogObject(logBase, metric.LogKey())
 }
 
 // LogKey :
@@ -369,8 +369,8 @@ func (hm HostMemory) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (hm HostMemory) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.HostMemoryLogType, "",
+func (hm HostMemory) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.HostMemoryLogType, "",
 		nilUUID, hm.LogKey())
 
 	oldHm, ok := old.(HostMemory)
@@ -383,12 +383,12 @@ func (hm HostMemory) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (hm HostMemory) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.HostMemoryLogType, "",
+func (hm HostMemory) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.HostMemoryLogType, "",
 		nilUUID, hm.LogKey())
 	logObject.Metricf("Host memory delete")
 
-	base.DeleteLogObject(hm.LogKey())
+	base.DeleteLogObject(logBase, hm.LogKey())
 }
 
 // LogKey :

--- a/pkg/pillar/types/downloadertypes.go
+++ b/pkg/pillar/types/downloadertypes.go
@@ -44,8 +44,8 @@ func (config DownloaderConfig) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (config DownloaderConfig) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.DownloaderConfigLogType, config.Name,
+func (config DownloaderConfig) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.DownloaderConfigLogType, config.Name,
 		nilUUID, config.LogKey())
 
 	oldConfig, ok := old.(DownloaderConfig)
@@ -74,8 +74,8 @@ func (config DownloaderConfig) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (config DownloaderConfig) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.DownloaderConfigLogType, config.Name,
+func (config DownloaderConfig) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.DownloaderConfigLogType, config.Name,
 		nilUUID, config.LogKey())
 	logObject.CloneAndAddField("target", config.Target).
 		AddField("datastore-id", config.DatastoreID).
@@ -83,7 +83,7 @@ func (config DownloaderConfig) LogDelete() {
 		AddField("size-int64", config.Size).
 		Noticef("Download config delete")
 
-	base.DeleteLogObject(config.LogKey())
+	base.DeleteLogObject(logBase, config.LogKey())
 }
 
 // LogKey :
@@ -156,8 +156,8 @@ func (status DownloaderStatus) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (status DownloaderStatus) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.DownloaderStatusLogType, status.Name,
+func (status DownloaderStatus) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.DownloaderStatusLogType, status.Name,
 		nilUUID, status.LogKey())
 
 	oldStatus, ok := old.(DownloaderStatus)
@@ -191,15 +191,15 @@ func (status DownloaderStatus) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (status DownloaderStatus) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.DownloaderStatusLogType, status.Name,
+func (status DownloaderStatus) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.DownloaderStatusLogType, status.Name,
 		nilUUID, status.LogKey())
 	logObject.CloneAndAddField("state", status.State.String()).
 		AddField("refcount-int64", status.RefCount).
 		AddField("size-int64", status.Size).
 		Noticef("Download status delete")
 
-	base.DeleteLogObject(status.LogKey())
+	base.DeleteLogObject(logBase, status.LogKey())
 }
 
 // LogKey :

--- a/pkg/pillar/types/physicalioadapters.go
+++ b/pkg/pillar/types/physicalioadapters.go
@@ -81,8 +81,8 @@ func (ioAdapterList PhysicalIOAdapterList) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (ioAdapterList PhysicalIOAdapterList) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.PhysicalIOAdapterListLogType, "",
+func (ioAdapterList PhysicalIOAdapterList) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.PhysicalIOAdapterListLogType, "",
 		nilUUID, ioAdapterList.LogKey())
 
 	oldIoAdapterList, ok := old.(PhysicalIOAdapterList)
@@ -95,12 +95,12 @@ func (ioAdapterList PhysicalIOAdapterList) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (ioAdapterList PhysicalIOAdapterList) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.PhysicalIOAdapterListLogType, "",
+func (ioAdapterList PhysicalIOAdapterList) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.PhysicalIOAdapterListLogType, "",
 		nilUUID, ioAdapterList.LogKey())
 	logObject.Metricf("Onboarding ioAdapterList delete")
 
-	base.DeleteLogObject(ioAdapterList.LogKey())
+	base.DeleteLogObject(logBase, ioAdapterList.LogKey())
 }
 
 // LogKey :

--- a/pkg/pillar/types/resolvertypes.go
+++ b/pkg/pillar/types/resolvertypes.go
@@ -39,8 +39,8 @@ func (config ResolveConfig) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (config ResolveConfig) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.ResolveConfigLogType, config.Name,
+func (config ResolveConfig) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.ResolveConfigLogType, config.Name,
 		config.DatastoreID, config.LogKey())
 
 	oldConfig, ok := old.(ResolveConfig)
@@ -53,12 +53,12 @@ func (config ResolveConfig) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (config ResolveConfig) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.ResolveConfigLogType, config.Name,
+func (config ResolveConfig) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.ResolveConfigLogType, config.Name,
 		config.DatastoreID, config.LogKey())
 	logObject.Noticef("Resolve config delete")
 
-	base.DeleteLogObject(config.LogKey())
+	base.DeleteLogObject(logBase, config.LogKey())
 }
 
 // LogKey :
@@ -98,8 +98,8 @@ func (status ResolveStatus) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (status ResolveStatus) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.ResolveStatusLogType, status.Name,
+func (status ResolveStatus) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.ResolveStatusLogType, status.Name,
 		status.DatastoreID, status.LogKey())
 
 	oldStatus, ok := old.(ResolveStatus)
@@ -131,14 +131,14 @@ func (status ResolveStatus) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (status ResolveStatus) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.ResolveStatusLogType, status.Name,
+func (status ResolveStatus) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.ResolveStatusLogType, status.Name,
 		status.DatastoreID, status.LogKey())
 	logObject.CloneAndAddField("image-sha256", status.ImageSha256).
 		AddField("retry-count-int64", status.RetryCount).
 		Noticef("Resolve status delete")
 
-	base.DeleteLogObject(status.LogKey())
+	base.DeleteLogObject(logBase, status.LogKey())
 }
 
 // LogKey :

--- a/pkg/pillar/types/types.go
+++ b/pkg/pillar/types/types.go
@@ -188,8 +188,8 @@ func (info UuidToNum) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (info UuidToNum) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.UUIDToNumLogType, "",
+func (info UuidToNum) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.UUIDToNumLogType, "",
 		info.UUID, info.LogKey())
 
 	oldInfo, ok := old.(UuidToNum)
@@ -202,12 +202,12 @@ func (info UuidToNum) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (info UuidToNum) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.UUIDToNumLogType, "",
+func (info UuidToNum) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.UUIDToNumLogType, "",
 		info.UUID, info.LogKey())
 	logObject.Noticef("UuidToNum info delete")
 
-	base.DeleteLogObject(info.LogKey())
+	base.DeleteLogObject(logBase, info.LogKey())
 }
 
 // LogKey :

--- a/pkg/pillar/types/vaultmgrtypes.go
+++ b/pkg/pillar/types/vaultmgrtypes.go
@@ -35,8 +35,8 @@ func (status VaultStatus) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (status VaultStatus) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.VaultStatusLogType, status.Name,
+func (status VaultStatus) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.VaultStatusLogType, status.Name,
 		nilUUID, status.LogKey())
 
 	oldStatus, ok := old.(VaultStatus)
@@ -55,12 +55,12 @@ func (status VaultStatus) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (status VaultStatus) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.VaultStatusLogType, status.Name,
+func (status VaultStatus) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.VaultStatusLogType, status.Name,
 		nilUUID, status.LogKey())
 	logObject.Noticef("Vault status delete")
 
-	base.DeleteLogObject(status.LogKey())
+	base.DeleteLogObject(logBase, status.LogKey())
 }
 
 // LogKey :

--- a/pkg/pillar/types/verifiertypes.go
+++ b/pkg/pillar/types/verifiertypes.go
@@ -45,8 +45,8 @@ func (config VerifyImageConfig) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (config VerifyImageConfig) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.VerifyImageConfigLogType, config.Name,
+func (config VerifyImageConfig) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.VerifyImageConfigLogType, config.Name,
 		nilUUID, config.LogKey())
 
 	oldConfig, ok := old.(VerifyImageConfig)
@@ -69,14 +69,14 @@ func (config VerifyImageConfig) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (config VerifyImageConfig) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.VerifyImageConfigLogType, config.Name,
+func (config VerifyImageConfig) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.VerifyImageConfigLogType, config.Name,
 		nilUUID, config.LogKey())
 	logObject.CloneAndAddField("refcount-int64", config.RefCount).
 		AddField("expired-bool", config.Expired).
 		Noticef("VerifyImage config delete")
 
-	base.DeleteLogObject(config.LogKey())
+	base.DeleteLogObject(logBase, config.LogKey())
 }
 
 // LogKey :
@@ -122,8 +122,8 @@ func (status VerifyImageStatus) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (status VerifyImageStatus) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.VerifyImageStatusLogType, status.Name,
+func (status VerifyImageStatus) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.VerifyImageStatusLogType, status.Name,
 		nilUUID, status.LogKey())
 
 	oldStatus, ok := old.(VerifyImageStatus)
@@ -163,8 +163,8 @@ func (status VerifyImageStatus) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (status VerifyImageStatus) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.VerifyImageStatusLogType, status.Name,
+func (status VerifyImageStatus) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.VerifyImageStatusLogType, status.Name,
 		nilUUID, status.LogKey())
 	logObject.CloneAndAddField("state", status.State.String()).
 		AddField("refcount-int64", status.RefCount).
@@ -173,7 +173,7 @@ func (status VerifyImageStatus) LogDelete() {
 		AddField("filelocation", status.FileLocation).
 		Noticef("VerifyImage status delete")
 
-	base.DeleteLogObject(status.LogKey())
+	base.DeleteLogObject(logObject, status.LogKey())
 }
 
 // LogKey :

--- a/pkg/pillar/types/volumetypes.go
+++ b/pkg/pillar/types/volumetypes.go
@@ -47,8 +47,8 @@ func (config VolumeConfig) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (config VolumeConfig) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.VolumeConfigLogType, config.DisplayName,
+func (config VolumeConfig) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.VolumeConfigLogType, config.DisplayName,
 		config.VolumeID, config.LogKey())
 
 	oldConfig, ok := old.(VolumeConfig)
@@ -77,8 +77,8 @@ func (config VolumeConfig) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (config VolumeConfig) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.VolumeConfigLogType, config.DisplayName,
+func (config VolumeConfig) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.VolumeConfigLogType, config.DisplayName,
 		config.VolumeID, config.LogKey())
 	logObject.CloneAndAddField("content-id", config.ContentID).
 		AddField("max-vol-size-int64", config.MaxVolSize).
@@ -86,7 +86,7 @@ func (config VolumeConfig) LogDelete() {
 		AddField("generation-counter-int64", config.GenerationCounter).
 		Noticef("Volume config delete")
 
-	base.DeleteLogObject(config.LogKey())
+	base.DeleteLogObject(logBase, config.LogKey())
 }
 
 // LogKey :
@@ -156,8 +156,8 @@ func (status VolumeStatus) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (status VolumeStatus) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.VolumeStatusLogType, status.DisplayName,
+func (status VolumeStatus) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.VolumeStatusLogType, status.DisplayName,
 		status.VolumeID, status.LogKey())
 
 	oldStatus, ok := old.(VolumeStatus)
@@ -192,8 +192,8 @@ func (status VolumeStatus) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (status VolumeStatus) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.VolumeStatusLogType, status.DisplayName,
+func (status VolumeStatus) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.VolumeStatusLogType, status.DisplayName,
 		status.VolumeID, status.LogKey())
 	logObject.CloneAndAddField("content-id", status.ContentID).
 		AddField("max-vol-size-int64", status.MaxVolSize).
@@ -203,7 +203,7 @@ func (status VolumeStatus) LogDelete() {
 		AddField("filelocation", status.FileLocation).
 		Noticef("Volume status delete")
 
-	base.DeleteLogObject(status.LogKey())
+	base.DeleteLogObject(logBase, status.LogKey())
 }
 
 // LogKey :
@@ -244,8 +244,8 @@ func (config VolumeRefConfig) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (config VolumeRefConfig) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.VolumeRefConfigLogType, "",
+func (config VolumeRefConfig) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.VolumeRefConfigLogType, "",
 		config.VolumeID, config.LogKey())
 
 	oldConfig, ok := old.(VolumeRefConfig)
@@ -264,13 +264,13 @@ func (config VolumeRefConfig) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (config VolumeRefConfig) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.VolumeRefConfigLogType, "",
+func (config VolumeRefConfig) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.VolumeRefConfigLogType, "",
 		config.VolumeID, config.LogKey())
 	logObject.CloneAndAddField("refcount-int64", config.RefCount).
 		Noticef("Volume ref config delete")
 
-	base.DeleteLogObject(config.LogKey())
+	base.DeleteLogObject(logBase, config.LogKey())
 }
 
 // LogKey :
@@ -336,8 +336,8 @@ func (status VolumeRefStatus) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (status VolumeRefStatus) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.VolumeRefStatusLogType, status.DisplayName,
+func (status VolumeRefStatus) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.VolumeRefStatusLogType, status.DisplayName,
 		status.VolumeID, status.LogKey())
 
 	oldStatus, ok := old.(VolumeRefStatus)
@@ -374,8 +374,8 @@ func (status VolumeRefStatus) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (status VolumeRefStatus) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.VolumeRefStatusLogType, status.DisplayName,
+func (status VolumeRefStatus) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.VolumeRefStatusLogType, status.DisplayName,
 		status.VolumeID, status.LogKey())
 	logObject.CloneAndAddField("refcount-int64", status.RefCount).
 		AddField("generation-counter-int64", status.GenerationCounter).
@@ -388,7 +388,7 @@ func (status VolumeRefStatus) LogDelete() {
 		AddField("pending-add-bool", status.PendingAdd).
 		Noticef("Volume ref status delete")
 
-	base.DeleteLogObject(status.LogKey())
+	base.DeleteLogObject(logBase, status.LogKey())
 }
 
 // LogKey :

--- a/pkg/pillar/types/zboottypes.go
+++ b/pkg/pillar/types/zboottypes.go
@@ -32,8 +32,8 @@ func (config ZbootConfig) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (config ZbootConfig) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.ZbootConfigLogType, "",
+func (config ZbootConfig) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.ZbootConfigLogType, "",
 		nilUUID, config.LogKey())
 
 	oldConfig, ok := old.(ZbootConfig)
@@ -53,13 +53,13 @@ func (config ZbootConfig) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (config ZbootConfig) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.ZbootConfigLogType, "",
+func (config ZbootConfig) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.ZbootConfigLogType, "",
 		nilUUID, config.LogKey())
 	logObject.CloneAndAddField("test-complete-bool", config.TestComplete).
 		Noticef("Zboot config delete")
 
-	base.DeleteLogObject(config.LogKey())
+	base.DeleteLogObject(logBase, config.LogKey())
 }
 
 // LogKey : XXX note that this only the IMGx, while Status includes ShortVersion for logs
@@ -95,8 +95,8 @@ func (status ZbootStatus) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (status ZbootStatus) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.ZbootStatusLogType, "",
+func (status ZbootStatus) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.ZbootStatusLogType, "",
 		nilUUID, status.LogKey())
 
 	oldStatus, ok := old.(ZbootStatus)
@@ -122,15 +122,15 @@ func (status ZbootStatus) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (status ZbootStatus) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.ZbootStatusLogType, "",
+func (status ZbootStatus) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.ZbootStatusLogType, "",
 		nilUUID, status.LogKey())
 	logObject.CloneAndAddField("partition-state", status.PartitionState).
 		AddField("current-partition-bool", status.CurrentPartition).
 		AddField("test-complete-bool", status.TestComplete).
 		Noticef("Zboot status delete")
 
-	base.DeleteLogObject(status.LogKey())
+	base.DeleteLogObject(logBase, status.LogKey())
 }
 
 // LogKey : XXX note that this includes the ShortVersion, while Status only the PartitionLabel

--- a/pkg/pillar/types/zedagenttypes.go
+++ b/pkg/pillar/types/zedagenttypes.go
@@ -49,8 +49,8 @@ func (config BaseOsConfig) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (config BaseOsConfig) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.BaseOsConfigLogType, config.BaseOsVersion,
+func (config BaseOsConfig) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.BaseOsConfigLogType, config.BaseOsVersion,
 		config.UUIDandVersion.UUID, config.LogKey())
 
 	oldConfig, ok := old.(BaseOsConfig)
@@ -71,13 +71,13 @@ func (config BaseOsConfig) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (config BaseOsConfig) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.BaseOsConfigLogType, config.BaseOsVersion,
+func (config BaseOsConfig) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.BaseOsConfigLogType, config.BaseOsVersion,
 		config.UUIDandVersion.UUID, config.LogKey())
 	logObject.CloneAndAddField("activate", config.Activate).
 		Noticef("BaseOs config delete")
 
-	base.DeleteLogObject(config.LogKey())
+	base.DeleteLogObject(logBase, config.LogKey())
 }
 
 // LogKey :
@@ -123,8 +123,8 @@ func (status BaseOsStatus) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (status BaseOsStatus) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.BaseOsStatusLogType, status.BaseOsVersion,
+func (status BaseOsStatus) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.BaseOsStatusLogType, status.BaseOsVersion,
 		status.UUIDandVersion.UUID, status.LogKey())
 
 	oldStatus, ok := old.(BaseOsStatus)
@@ -152,13 +152,13 @@ func (status BaseOsStatus) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (status BaseOsStatus) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.BaseOsStatusLogType, status.BaseOsVersion,
+func (status BaseOsStatus) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.BaseOsStatusLogType, status.BaseOsVersion,
 		status.UUIDandVersion.UUID, status.LogKey())
 	logObject.CloneAndAddField("state", status.State.String()).
 		Noticef("BaseOs status delete")
 
-	base.DeleteLogObject(status.LogKey())
+	base.DeleteLogObject(logBase, status.LogKey())
 }
 
 // LogKey :
@@ -227,8 +227,8 @@ func (config DatastoreConfig) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (config DatastoreConfig) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.DatastoreConfigLogType, "",
+func (config DatastoreConfig) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.DatastoreConfigLogType, "",
 		config.UUID, config.LogKey())
 
 	oldConfig, ok := old.(DatastoreConfig)
@@ -241,12 +241,12 @@ func (config DatastoreConfig) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (config DatastoreConfig) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.DatastoreConfigLogType, "",
+func (config DatastoreConfig) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.DatastoreConfigLogType, "",
 		config.UUID, config.LogKey())
 	logObject.Noticef("Datastore config delete")
 
-	base.DeleteLogObject(config.LogKey())
+	base.DeleteLogObject(logBase, config.LogKey())
 }
 
 // LogKey :
@@ -284,8 +284,8 @@ func (status NodeAgentStatus) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (status NodeAgentStatus) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.NodeAgentStatusLogType, status.Name,
+func (status NodeAgentStatus) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.NodeAgentStatusLogType, status.Name,
 		nilUUID, status.LogKey())
 
 	oldStatus, ok := old.(NodeAgentStatus)
@@ -298,12 +298,12 @@ func (status NodeAgentStatus) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (status NodeAgentStatus) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.NodeAgentStatusLogType, status.Name,
+func (status NodeAgentStatus) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.NodeAgentStatusLogType, status.Name,
 		nilUUID, status.LogKey())
 	logObject.Noticef("Nodeagent status delete")
 
-	base.DeleteLogObject(status.LogKey())
+	base.DeleteLogObject(logBase, status.LogKey())
 }
 
 // LogKey :
@@ -346,8 +346,8 @@ func (status ZedAgentStatus) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (status ZedAgentStatus) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.ZedAgentStatusLogType, status.Name,
+func (status ZedAgentStatus) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.ZedAgentStatusLogType, status.Name,
 		nilUUID, status.LogKey())
 
 	oldStatus, ok := old.(ZedAgentStatus)
@@ -360,12 +360,12 @@ func (status ZedAgentStatus) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (status ZedAgentStatus) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.ZedAgentStatusLogType, status.Name,
+func (status ZedAgentStatus) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.ZedAgentStatusLogType, status.Name,
 		nilUUID, status.LogKey())
 	logObject.Noticef("Zedagent status delete")
 
-	base.DeleteLogObject(status.LogKey())
+	base.DeleteLogObject(logBase, status.LogKey())
 }
 
 // LogKey :

--- a/pkg/pillar/types/zedbox.go
+++ b/pkg/pillar/types/zedbox.go
@@ -30,8 +30,8 @@ func (s ServiceInitStatus) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (s ServiceInitStatus) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.ServiceInitLogType, s.ServiceName, nilUUID, s.LogKey())
+func (s ServiceInitStatus) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.ServiceInitLogType, s.ServiceName, nilUUID, s.LogKey())
 
 	if _, ok := old.(ServiceInitStatus); !ok {
 		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of ServiceInitStatus type")
@@ -43,13 +43,13 @@ func (s ServiceInitStatus) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (s ServiceInitStatus) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.ServiceInitLogType, s.ServiceName, nilUUID, s.LogKey())
+func (s ServiceInitStatus) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.ServiceInitLogType, s.ServiceName, nilUUID, s.LogKey())
 	logObject.CloneAndAddField("servicename", s.ServiceName).
 		AddField("cmdargs", s.CmdArgs).
 		Noticef("ServiceInitStatus modify")
 
-	base.DeleteLogObject(s.LogKey())
+	base.DeleteLogObject(logBase, s.LogKey())
 }
 
 // LogKey :

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -96,8 +96,8 @@ func (config AppInstanceConfig) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (config AppInstanceConfig) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.AppInstanceConfigLogType, config.DisplayName,
+func (config AppInstanceConfig) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.AppInstanceConfigLogType, config.DisplayName,
 		config.UUIDandVersion.UUID, config.LogKey())
 
 	oldConfig, ok := old.(AppInstanceConfig)
@@ -120,14 +120,14 @@ func (config AppInstanceConfig) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (config AppInstanceConfig) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.AppInstanceConfigLogType, config.DisplayName,
+func (config AppInstanceConfig) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.AppInstanceConfigLogType, config.DisplayName,
 		config.UUIDandVersion.UUID, config.LogKey())
 	logObject.CloneAndAddField("activate", config.Activate).
 		AddField("remote-console", config.RemoteConsole).
 		Noticef("App instance config delete")
 
-	base.DeleteLogObject(config.LogKey())
+	base.DeleteLogObject(logBase, config.LogKey())
 }
 
 // LogKey :
@@ -185,8 +185,8 @@ func (status AppInstanceStatus) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (status AppInstanceStatus) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.AppInstanceStatusLogType, status.DisplayName,
+func (status AppInstanceStatus) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.AppInstanceStatusLogType, status.DisplayName,
 		status.UUIDandVersion.UUID, status.LogKey())
 
 	oldStatus, ok := old.(AppInstanceStatus)
@@ -222,15 +222,15 @@ func (status AppInstanceStatus) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (status AppInstanceStatus) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.AppInstanceStatusLogType, status.DisplayName,
+func (status AppInstanceStatus) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.AppInstanceStatusLogType, status.DisplayName,
 		status.UUIDandVersion.UUID, status.LogKey())
 	logObject.CloneAndAddField("state", status.State.String()).
 		AddField("restart-in-progress", status.RestartInprogress).
 		AddField("purge-in-progress", status.PurgeInprogress).
 		Noticef("App instance status delete")
 
-	base.DeleteLogObject(status.LogKey())
+	base.DeleteLogObject(logBase, status.LogKey())
 }
 
 // LogKey :
@@ -313,8 +313,8 @@ func (aih AppAndImageToHash) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (aih AppAndImageToHash) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.AppAndImageToHashLogType, "",
+func (aih AppAndImageToHash) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.AppAndImageToHashLogType, "",
 		aih.AppUUID, aih.LogKey())
 
 	oldAih, ok := old.(AppAndImageToHash)
@@ -339,15 +339,15 @@ func (aih AppAndImageToHash) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (aih AppAndImageToHash) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.AppAndImageToHashLogType, "",
+func (aih AppAndImageToHash) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.AppAndImageToHashLogType, "",
 		aih.AppUUID, aih.LogKey())
 	logObject.CloneAndAddField("purge-counter-int64", aih.PurgeCounter).
 		AddField("image-id", aih.ImageID.String()).
 		AddField("hash", aih.Hash).
 		Noticef("App and image to hash delete")
 
-	base.DeleteLogObject(aih.LogKey())
+	base.DeleteLogObject(logBase, aih.LogKey())
 }
 
 // LogKey :

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -44,8 +44,8 @@ func (config AppNetworkConfig) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (config AppNetworkConfig) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.AppNetworkConfigLogType, config.DisplayName,
+func (config AppNetworkConfig) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.AppNetworkConfigLogType, config.DisplayName,
 		config.UUIDandVersion.UUID, config.LogKey())
 
 	oldConfig, ok := old.(AppNetworkConfig)
@@ -65,13 +65,13 @@ func (config AppNetworkConfig) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (config AppNetworkConfig) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.AppNetworkConfigLogType, config.DisplayName,
+func (config AppNetworkConfig) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.AppNetworkConfigLogType, config.DisplayName,
 		config.UUIDandVersion.UUID, config.LogKey())
 	logObject.CloneAndAddField("activate", config.Activate).
 		Noticef("App network config delete")
 
-	base.DeleteLogObject(config.LogKey())
+	base.DeleteLogObject(logBase, config.LogKey())
 }
 
 // LogKey :
@@ -137,8 +137,8 @@ func (status AppNetworkStatus) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (status AppNetworkStatus) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.AppNetworkStatusLogType, status.DisplayName,
+func (status AppNetworkStatus) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.AppNetworkStatusLogType, status.DisplayName,
 		status.UUIDandVersion.UUID, status.LogKey())
 
 	oldStatus, ok := old.(AppNetworkStatus)
@@ -166,13 +166,13 @@ func (status AppNetworkStatus) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (status AppNetworkStatus) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.AppNetworkStatusLogType, status.DisplayName,
+func (status AppNetworkStatus) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.AppNetworkStatusLogType, status.DisplayName,
 		status.UUIDandVersion.UUID, status.LogKey())
 	logObject.CloneAndAddField("activated", status.Activated).
 		Noticef("App network status delete")
 
-	base.DeleteLogObject(status.LogKey())
+	base.DeleteLogObject(logBase, status.LogKey())
 }
 
 // LogKey :
@@ -224,8 +224,8 @@ func (acMetric AppContainerMetrics) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (acMetric AppContainerMetrics) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.AppContainerMetricsLogType, "",
+func (acMetric AppContainerMetrics) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.AppContainerMetricsLogType, "",
 		acMetric.UUIDandVersion.UUID, acMetric.LogKey())
 
 	oldAcMetric, ok := old.(AppContainerMetrics)
@@ -238,12 +238,12 @@ func (acMetric AppContainerMetrics) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (acMetric AppContainerMetrics) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.AppContainerMetricsLogType, "",
+func (acMetric AppContainerMetrics) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.AppContainerMetricsLogType, "",
 		acMetric.UUIDandVersion.UUID, acMetric.LogKey())
 	logObject.Metricf("App container metric delete")
 
-	base.DeleteLogObject(acMetric.LogKey())
+	base.DeleteLogObject(logBase, acMetric.LogKey())
 }
 
 // LogKey :
@@ -331,8 +331,8 @@ func (config DevicePortConfigList) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (config DevicePortConfigList) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.DevicePortConfigListLogType, "",
+func (config DevicePortConfigList) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.DevicePortConfigListLogType, "",
 		nilUUID, config.LogKey())
 
 	oldConfig, ok := old.(DevicePortConfigList)
@@ -357,14 +357,14 @@ func (config DevicePortConfigList) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (config DevicePortConfigList) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.DevicePortConfigListLogType, "",
+func (config DevicePortConfigList) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.DevicePortConfigListLogType, "",
 		nilUUID, config.LogKey())
 	logObject.CloneAndAddField("current-index-int64", config.CurrentIndex).
 		AddField("num-portconfig-int64", len(config.PortConfigList)).
 		Noticef("DevicePortConfigList delete")
 
-	base.DeleteLogObject(config.LogKey())
+	base.DeleteLogObject(logBase, config.LogKey())
 }
 
 // LogKey :
@@ -455,8 +455,8 @@ func (config DevicePortConfig) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (config DevicePortConfig) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.DevicePortConfigLogType, "",
+func (config DevicePortConfig) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.DevicePortConfigLogType, "",
 		nilUUID, config.LogKey())
 
 	oldConfig, ok := old.(DevicePortConfig)
@@ -509,8 +509,8 @@ func (config DevicePortConfig) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (config DevicePortConfig) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.DevicePortConfigLogType, "",
+func (config DevicePortConfig) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.DevicePortConfigLogType, "",
 		nilUUID, config.LogKey())
 	logObject.CloneAndAddField("ports-int64", len(config.Ports)).
 		AddField("last-failed", config.LastFailed).
@@ -527,7 +527,7 @@ func (config DevicePortConfig) LogDelete() {
 			Noticef("DevicePortConfig port delete")
 	}
 
-	base.DeleteLogObject(config.LogKey())
+	base.DeleteLogObject(logBase, config.LogKey())
 }
 
 // LogKey :
@@ -947,8 +947,8 @@ func (status DeviceNetworkStatus) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (status DeviceNetworkStatus) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.DeviceNetworkStatusLogType, "",
+func (status DeviceNetworkStatus) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.DeviceNetworkStatusLogType, "",
 		nilUUID, status.LogKey())
 
 	oldStatus, ok := old.(DeviceNetworkStatus)
@@ -995,8 +995,8 @@ func (status DeviceNetworkStatus) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (status DeviceNetworkStatus) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.DeviceNetworkStatusLogType, "",
+func (status DeviceNetworkStatus) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.DeviceNetworkStatusLogType, "",
 		nilUUID, status.LogKey())
 	logObject.CloneAndAddField("testing-bool", status.Testing).
 		AddField("ports-int64", len(status.Ports)).
@@ -1011,7 +1011,7 @@ func (status DeviceNetworkStatus) LogDelete() {
 			Noticef("DeviceNetworkStatus port delete")
 	}
 
-	base.DeleteLogObject(status.LogKey())
+	base.DeleteLogObject(logBase, status.LogKey())
 }
 
 // LogKey :
@@ -1750,8 +1750,8 @@ func (config NetworkXObjectConfig) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (config NetworkXObjectConfig) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.NetworkXObjectConfigLogType, "",
+func (config NetworkXObjectConfig) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.NetworkXObjectConfigLogType, "",
 		config.UUID, config.LogKey())
 
 	oldConfig, ok := old.(NetworkXObjectConfig)
@@ -1764,12 +1764,12 @@ func (config NetworkXObjectConfig) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (config NetworkXObjectConfig) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.NetworkXObjectConfigLogType, "",
+func (config NetworkXObjectConfig) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.NetworkXObjectConfigLogType, "",
 		config.UUID, config.LogKey())
 	logObject.Noticef("NetworkXObject config delete")
 
-	base.DeleteLogObject(config.LogKey())
+	base.DeleteLogObject(logBase, config.LogKey())
 }
 
 // LogKey :
@@ -1915,8 +1915,8 @@ func (metrics NetworkInstanceMetrics) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (metrics NetworkInstanceMetrics) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.NetworkInstanceMetricsLogType, "",
+func (metrics NetworkInstanceMetrics) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.NetworkInstanceMetricsLogType, "",
 		metrics.UUIDandVersion.UUID, metrics.LogKey())
 
 	oldMetrics, ok := old.(NetworkInstanceMetrics)
@@ -1929,12 +1929,12 @@ func (metrics NetworkInstanceMetrics) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (metrics NetworkInstanceMetrics) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.NetworkInstanceMetricsLogType, "",
+func (metrics NetworkInstanceMetrics) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.NetworkInstanceMetricsLogType, "",
 		metrics.UUIDandVersion.UUID, metrics.LogKey())
 	logObject.Metricf("Network instance metrics delete")
 
-	base.DeleteLogObject(metrics.LogKey())
+	base.DeleteLogObject(logBase, metrics.LogKey())
 }
 
 // LogKey :
@@ -1964,8 +1964,8 @@ func (nms NetworkMetrics) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (nms NetworkMetrics) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.NetworkMetricsLogType, "",
+func (nms NetworkMetrics) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.NetworkMetricsLogType, "",
 		nilUUID, nms.LogKey())
 
 	oldNms, ok := old.(NetworkMetrics)
@@ -1978,12 +1978,12 @@ func (nms NetworkMetrics) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (nms NetworkMetrics) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.NetworkMetricsLogType, "",
+func (nms NetworkMetrics) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.NetworkMetricsLogType, "",
 		nilUUID, nms.LogKey())
 	logObject.Metricf("Network metrics delete")
 
-	base.DeleteLogObject(nms.LogKey())
+	base.DeleteLogObject(logBase, nms.LogKey())
 }
 
 // LogKey :
@@ -2087,8 +2087,8 @@ func (config NetworkInstanceConfig) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (config NetworkInstanceConfig) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.NetworkInstanceConfigLogType, "",
+func (config NetworkInstanceConfig) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.NetworkInstanceConfigLogType, "",
 		config.UUIDandVersion.UUID, config.LogKey())
 
 	oldConfig, ok := old.(NetworkInstanceConfig)
@@ -2101,12 +2101,12 @@ func (config NetworkInstanceConfig) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (config NetworkInstanceConfig) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.NetworkInstanceConfigLogType, "",
+func (config NetworkInstanceConfig) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.NetworkInstanceConfigLogType, "",
 		config.UUIDandVersion.UUID, config.LogKey())
 	logObject.Metricf("Network instance config delete")
 
-	base.DeleteLogObject(config.LogKey())
+	base.DeleteLogObject(logBase, config.LogKey())
 }
 
 // LogKey :
@@ -2164,8 +2164,8 @@ func (status NetworkInstanceStatus) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (status NetworkInstanceStatus) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.NetworkInstanceStatusLogType, "",
+func (status NetworkInstanceStatus) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.NetworkInstanceStatusLogType, "",
 		status.UUIDandVersion.UUID, status.LogKey())
 
 	oldStatus, ok := old.(NetworkInstanceStatus)
@@ -2178,12 +2178,12 @@ func (status NetworkInstanceStatus) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (status NetworkInstanceStatus) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.NetworkInstanceStatusLogType, "",
+func (status NetworkInstanceStatus) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.NetworkInstanceStatusLogType, "",
 		status.UUIDandVersion.UUID, status.LogKey())
 	logObject.Metricf("Network instance status delete")
 
-	base.DeleteLogObject(status.LogKey())
+	base.DeleteLogObject(logBase, status.LogKey())
 }
 
 // LogKey :
@@ -2614,8 +2614,8 @@ func (flows IPFlow) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (flows IPFlow) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.IPFlowLogType, "",
+func (flows IPFlow) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.IPFlowLogType, "",
 		flows.DevID, flows.LogKey())
 
 	oldFlows, ok := old.(IPFlow)
@@ -2628,12 +2628,12 @@ func (flows IPFlow) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (flows IPFlow) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.IPFlowLogType, "",
+func (flows IPFlow) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.IPFlowLogType, "",
 		flows.DevID, flows.LogKey())
 	logObject.Metricf("IP flow delete")
 
-	base.DeleteLogObject(flows.LogKey())
+	base.DeleteLogObject(logBase, flows.LogKey())
 }
 
 // LogKey :
@@ -2663,8 +2663,8 @@ func (vifIP VifIPTrig) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (vifIP VifIPTrig) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.VifIPTrigLogType, "",
+func (vifIP VifIPTrig) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.VifIPTrigLogType, "",
 		nilUUID, vifIP.LogKey())
 
 	oldVifIP, ok := old.(VifIPTrig)
@@ -2677,12 +2677,12 @@ func (vifIP VifIPTrig) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (vifIP VifIPTrig) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.VifIPTrigLogType, "",
+func (vifIP VifIPTrig) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.VifIPTrigLogType, "",
 		nilUUID, vifIP.LogKey())
 	logObject.Metricf("Vif IP trig delete")
 
-	base.DeleteLogObject(vifIP.LogKey())
+	base.DeleteLogObject(logBase, vifIP.LogKey())
 }
 
 // LogKey :
@@ -2711,8 +2711,8 @@ func (status OnboardingStatus) LogCreate(logBase *base.LogObject) {
 }
 
 // LogModify :
-func (status OnboardingStatus) LogModify(old interface{}) {
-	logObject := base.EnsureLogObject(nil, base.OnboardingStatusLogType, "",
+func (status OnboardingStatus) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.OnboardingStatusLogType, "",
 		nilUUID, status.LogKey())
 
 	oldStatus, ok := old.(OnboardingStatus)
@@ -2725,12 +2725,12 @@ func (status OnboardingStatus) LogModify(old interface{}) {
 }
 
 // LogDelete :
-func (status OnboardingStatus) LogDelete() {
-	logObject := base.EnsureLogObject(nil, base.OnboardingStatusLogType, "",
+func (status OnboardingStatus) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.OnboardingStatusLogType, "",
 		nilUUID, status.LogKey())
 	logObject.Metricf("Onboarding status delete")
 
-	base.DeleteLogObject(status.LogKey())
+	base.DeleteLogObject(logBase, status.LogKey())
 }
 
 // LogKey :


### PR DESCRIPTION
I'm been puzzled why both the subscriber  and publisher obj_type logs appears with source being the publisher.
Turns out the map we maintain for the base.LogObject is keyed by the pubsub object, and since they are the same and the publisher and subscriber now runs in the same zedbox process the second (and third) base.NewLogObject() will return the same LogObject, which has been initialized with the source by the first caller.

So here I'm taking the address aka %p string of the logObject into account and that keeps them separate.

Three separat commits.
Last one is somewhat unrelated but some packages use logrus directly and not a base.LogObject. Setting those up to produce json logs makes sense.