### PR TITLE
Unmounting baseos partition before writing to it

### DIFF
--- a/pkg/pillar/zboot/zboot.go
+++ b/pkg/pillar/zboot/zboot.go
@@ -339,6 +339,12 @@ func WriteToPartition(log *base.LogObject, image string, partName string) error 
 		log.Errorf("WriteToPartition failed %s\n", errStr)
 		return errors.New(errStr)
 	}
+	err := syscall.Unmount(devName, syscall.MNT_FORCE)
+	for err != nil {
+		errStr := fmt.Sprintf("Unmount of %s failed: %s", devname, err)
+		log.Errorf(errStr)
+		err := syscall.Unmount(devName, syscall.MNT_FORCE)
+	}
 
 	log.Infof("WriteToPartition %s, %s: %v\n", partName, devName, image)
 
@@ -453,7 +459,6 @@ func getVersion(log *base.LogObject, part string, verFilename string) (string, e
 	} else {
 		verFilename = otherPartVersionFile
 		devname := GetPartitionDevname(part)
-		syscall.Unmount(devname, syscall.MNT_FORCE)
 		target, err := ioutil.TempDir("/var/run", "tmpmnt")
 		if err != nil {
 			log.Errorln(err)

--- a/pkg/pillar/zboot/zboot.go
+++ b/pkg/pillar/zboot/zboot.go
@@ -339,6 +339,7 @@ func WriteToPartition(log *base.LogObject, image string, partName string) error 
 		log.Errorf("WriteToPartition failed %s\n", errStr)
 		return errors.New(errStr)
 	}
+	syscall.Unmount(devName, 0)
 
 	log.Infof("WriteToPartition %s, %s: %v\n", partName, devName, image)
 


### PR DESCRIPTION
For version mismatch error, my observations so far
1. I logged in to the device in the error state.
2. Checked ```etc/eve-release``` file, it was pointing to old baseos string
3. Then, I remounted the partition and after that ```etc/eve-release``` pointed to the correct baseos version

So, my understanding is that we need to unmount the partition before writing to it. And, while checking the version in ```baseosmgr``` we will mount it again.