### PR TITLE
The DPC_REMOTE_WAIT needs a fix in client.go

### DIFF
--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -290,7 +290,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 		case <-ticker.C:
 			if clientCtx.networkState != types.DPC_SUCCESS &&
-				clientCtx.networkState != types.DPC_FAIL_WITH_IPANDDNS {
+				clientCtx.networkState != types.DPC_FAIL_WITH_IPANDDNS &&
+				clientCtx.networkState != types.DPC_REMOTE_WAIT {
 				log.Infof("ticker and networkState %s usableAddressCount %d",
 					clientCtx.networkState.String(),
 					clientCtx.usableAddressCount)


### PR DESCRIPTION
The recent fix to handle 1970 (no real-time clock - #1456 ) means that client.go needs to proceed to fetch the server signing cert when DPC_REMOTE_WAIT is set.