### PR TITLE
Fix: Postpone gcUnusedInitObjects in volumeMgr to fix missing blobs.

### DIFF
--- a/pkg/pillar/cmd/volumemgr/handlecontent.go
+++ b/pkg/pillar/cmd/volumemgr/handlecontent.go
@@ -294,12 +294,10 @@ func updateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus) {
 func deleteContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus) {
 	log.Infof("deleteContentTree for %v", status.ContentID)
 	RemoveAllBlobsFromContentTreeStatus(ctx, status, status.Blobs...)
-	if status.Format == zconfig.Format_CONTAINER {
-		//We create a reference when we load the blobs. We should remove that reference when we delete the contentTree.
-		if err := ctx.casClient.RemoveImage(status.ReferenceID()); err != nil {
-			log.Errorf("deleteContentTree: exception while deleting image %s: %s",
-				status.RelativeURL, err.Error())
-		}
+	//We create a reference when we load the blobs. We should remove that reference when we delete the contentTree.
+	if err := ctx.casClient.RemoveImage(status.ReferenceID()); err != nil {
+		log.Errorf("deleteContentTree: exception while deleting image %s: %s",
+			status.RelativeURL, err.Error())
 	}
 	unpublishContentTreeStatus(ctx, status)
 	deleteLatchContentTreeHash(ctx, status.ContentID, uint32(status.GenerationCounter))


### PR DESCRIPTION
Issue: Blob not found after reboot.

Reason: The bare blobs are protected from containerd's GC by the manifest blob that we add. But on reboot, [gcBlobStatus()](https://github.com/lf-edge/eve/blob/b521a9498dfb743caf1a543194020a30a0e68d0b/pkg/pillar/cmd/volumemgr/blob.go#L549) was called before EVE incremented Refcount for the manifest blob, which led to EVE deleting the manifest blob, which opened up the bare blob for containerd's GC and was deleted. 
Here is the flow that led to this issue:

1. We loaded a bare blob, let's call it sha256:123
2. We created manifest blob sha256:456 and a config blob sha256:789 for the bare blob and loaded it into ctrd
3. Rebooted the device
4. After the device rebooted, new BlobStatus was created for sha256:123, sha256:456 and sha256:789 with RefCount = 0
4. Volumemgr receives the contentTreeStatus for the bare blob sha256:123 and increments it's RefCount to 1
5. [gcBlobStatus()](https://github.com/lf-edge/eve/blob/b521a9498dfb743caf1a543194020a30a0e68d0b/pkg/pillar/cmd/volumemgr/blob.go#L549) was called and volumemgr deletes sha256:456 and sha256:789 because they have  RefCount = 0
6. [getManifestsForBareBlob()](https://github.com/lf-edge/eve/blob/b521a9498dfb743caf1a543194020a30a0e68d0b/pkg/pillar/cmd/volumemgr/artifact.go#L19) was called for sha256:123 and we see that it doesn't have a manifest and config (because it was deleted in the previous step) and we create it.

So at this point, we have BlobStatus for all 3 blobs (bare, manifest and config) but the bare blob is deleted from containerd. So if any appInstance using that contentTreeStatus is purged or is created newly, then we will see blob not found error.

Fix: We need to postpone [gcBlobStatus()](https://github.com/lf-edge/eve/blob/b521a9498dfb743caf1a543194020a30a0e68d0b/pkg/pillar/cmd/volumemgr/blob.go#L549) to the point where after reboot we have handled all bare blobs along with it's manifest and config blob.

Also, fixed the issue where in case if we find manifest blob to be present, we weren't checking for config blob which led to config blob being GC'd by EVE because of Refcounf = 0. And we deleted images from containerd only if contentTreeStatus belonged to a container image, fixed that as well. 

cc @deitch 
Signed-off-by: adarsh-zededa <adarsh@zededa.com>