### PR TITLE
rsyslogd memory usage seems to be directly proportional to the dequeue batch size

### DIFF
--- a/pkg/rsyslog/rsyslog.conf
+++ b/pkg/rsyslog/rsyslog.conf
@@ -33,7 +33,7 @@ main_queue(
   queue.syncqueuefiles="on"
   queue.saveOnShutdown="on"
   queue.maxFileSize="100m"
-  queue.dequeueBatchSize="10000"
+  queue.dequeueBatchSize="1000"
 )
 
 template(name="nonJsonOutput" type="list" option.jsonf="on") {


### PR DESCRIPTION
I have seen cases where zedbox was killed (oom reaped) during device bootup. With a debug image, I saw rsyslogd consuminng >50MB of ram along with zedbox (>70MB) during device startup process. Reducing dequeue batch size reduced rsyslogd memory usage.

Signed-off-by: Gopi krishna Kodali <gkodali@zededa.com>