### PR TITLE
Less version mounts

### DIFF
--- a/pkg/pillar/cmd/baseosmgr/baseosmgr.go
+++ b/pkg/pillar/cmd/baseosmgr/baseosmgr.go
@@ -98,8 +98,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	initializeZedagentHandles(ps, &ctx)
 	initializeVolumemgrHandles(ps, &ctx)
 
-	// publish zboot partition status
-	publishZbootPartitionStatusAll(&ctx)
+	// publish initial zboot partition status
+	updateAndPublishZbootStatusAll(&ctx)
 
 	// for background work
 	ctx.worker = worker.NewWorker(log, WorkerHandler, ctx, 5)

--- a/pkg/pillar/zboot/zboot.go
+++ b/pkg/pillar/zboot/zboot.go
@@ -484,23 +484,6 @@ func getVersion(log *base.LogObject, part string, verFilename string) (string, e
 			if err != nil {
 				errStr := fmt.Sprintf("Unmount of %s failed: %s", target, err)
 				logrus.Error(errStr)
-				log.Noticef("Unmount(%s)", devname)
-				err := syscall.Unmount(devname, 0)
-				if err != nil {
-					errStr := fmt.Sprintf("Unmount of %s failed: %s", devname, err)
-					logrus.Error(errStr)
-					time.Sleep(10 * time.Second)
-					log.Noticef("Unmount(%s) again", devname)
-					err := syscall.Unmount(devname, 0)
-					if err != nil {
-						errStr := fmt.Sprintf("Unmount of %s failed: %s", devname, err)
-						logrus.Error(errStr)
-					} else {
-						log.Noticef("Unmounted %s", devname)
-					}
-				} else {
-					log.Noticef("Unmounted %s", devname)
-				}
 			} else {
 				log.Noticef("Unmounted %s", target)
 			}


### PR DESCRIPTION
baseosmgr is mounting the other partition to read its version quite often when there are unrelated baseos changes.
Turns out it only needs to mount it twice: on boot to determine the initial ZbootStatus and after it has copied a new image to a partition to extract its version. These fixes do that, and then elsewhere extract the version string from ZbootStatus.

Running tests on this to see if we still get checkInstalledVersion errors.

Also cleaning up some of the speculative unmount try code as a separate commit.