### PR TITLE
restart dnsmasq during removehostDnsmasq

### DIFF
--- a/pkg/pillar/cmd/zedrouter/dnsmasq.go
+++ b/pkg/pillar/cmd/zedrouter/dnsmasq.go
@@ -313,9 +313,7 @@ func removehostDnsmasq(bridgeName string, appMac string, appIPAddr string) {
 
 	log.Infof("removehostDnsmasq(%s, %s, %s)\n",
 		bridgeName, appMac, appIPAddr)
-	if dnsmasqStopStart {
-		stopDnsmasq(bridgeName, true, false)
-	}
+	stopDnsmasq(bridgeName, true, false)
 	ip := net.ParseIP(appIPAddr)
 	if ip == nil {
 		log.Fatalf("removehostDnsmasq failed to parse IP %s", appIPAddr)
@@ -339,9 +337,7 @@ func removehostDnsmasq(bridgeName string, appMac string, appIPAddr string) {
 			log.Errorln(errStr)
 		}
 	}
-	if dnsmasqStopStart {
-		startDnsmasq(bridgeName)
-	}
+	startDnsmasq(bridgeName)
 }
 
 func deleteDnsmasqConfiglet(bridgeName string) {
@@ -370,7 +366,7 @@ func RemoveDirContent(dir string) error {
 	}
 	for _, file := range files {
 		filename := dir + "/" + file.Name()
-		log.Infoln("RemoveDirConent found ", filename)
+		log.Infoln("RemoveDirContent found ", filename)
 		err = os.RemoveAll(filename)
 		if err != nil {
 			return err


### PR DESCRIPTION
Seems that we need to restart dnsmasq during remove of dhcp-hosts files: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=798653#35

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>