### PR TITLE
Fix: Containerd context cancelled because of expired lease

### DIFF
--- a/pkg/pillar/cas/cas.go
+++ b/pkg/pillar/cas/cas.go
@@ -1,6 +1,7 @@
 package cas
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -38,10 +39,11 @@ type CAS interface {
 	ListBlobsMediaTypes() (map[string]string, error)
 	// IngestBlob: parses the given one or more `blobs` (BlobStatus) and for each blob reads the blob data from
 	// BlobStatus.Path and ingests it into CAS's blob store.
+	// Accepts a custom context. If ctx is nil, then default context will be used.
 	// Returns a list of loaded BlobStatus and an error is thrown if the read blob's hash does not match with the
 	// respective BlobStatus.Sha256 or if there is an exception while reading the blob data.
 	// In case of exception, the returned list of loaded blob will contain all the blob that were loaded until that point.
-	IngestBlob(blobs ...*types.BlobStatus) ([]*types.BlobStatus, error)
+	IngestBlob(ctx context.Context, blobs ...*types.BlobStatus) ([]*types.BlobStatus, error)
 	//UpdateBlobInfo updates BlobInfo of a blob in CAS.
 	//Arg is BlobInfo type struct in which BlobInfo.Digest is mandatory, and other field to be fill only if need to be updated
 	//Returns error is no blob is found match blobInfo.Digest


### PR DESCRIPTION
Issue: Often we saw this error while creating lease `CtrCreateLease: exception while creating lease: grpc: the client connection is closing: context canceled`

Cause: While uploading blobs to containerd, we attached lease to the main ctrdCtx [here](https://github.com/lf-edge/eve/blob/8b5a29ce2d702cd7cf6543a302c45c5d5c007d70/pkg/pillar/cas/containerd.go#L632), and after we have uploaded all the blobs and created an image, we deleted that lease and recreated ctrdCtx.

 if there was an issue while deleting the lease [here](https://github.com/lf-edge/eve/blob/8b5a29ce2d702cd7cf6543a302c45c5d5c007d70/pkg/pillar/containerd/containerd.go#L690), we never recreated ctrdCtx. Or if there’s a race condition where  2 loadWorkers are trying to load blobs into containerd, if the first worker just deleted lease from ctrdCtx and at the same time if the second worker tries to attach a lease to ctrdCtx, it’ll notice that ctrdCtx already has a lease but its expired/invalid.

Fix: Create a new context with lease and use that new lease with uploading the blobs and discard it once we have uploaded all the blobs and created an image. By this, we keep the main ctrcCtx undisturbed and we do not attach any lease to it.

WIP because still some testing need to be done.

Note: As discussed with @deitch, there will be a follow up story to remove the common context (ctrdCtx) and use new ctx everytime we make a containerd call. Except for Create and Update APIs which needs to be handled differently.  

Signed-off-by: adarsh-zededa <adarsh@zededa.com>