### PR TITLE
avoid reboot after first boot

### DIFF
--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -205,11 +205,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	zedagentCtx.globalStatus.UnknownConfigItems = make(
 		map[string]types.ConfigItemStatus)
 
-	rebootConfig := readRebootConfig()
-	zedagentCtx.rebootConfigCounter = rebootConfig.Counter
-	log.Infof("Zedagent Run - rebootConfigCounter at init is %d",
-		zedagentCtx.rebootConfigCounter)
-
 	zedagentCtx.physicalIoAdapterMap = make(map[string]types.PhysicalIOAdapter)
 
 	zedagentCtx.pubGlobalConfig, err = ps.NewPublication(pubsub.PublicationOptions{


### PR DESCRIPTION
The current behavior is annoying when running eden, and it also results in an unneeded reboot after an initial USB install since we have no /config/rebootConfig in that case.