### PR TITLE
move version check after proceed

### DIFF
--- a/pkg/pillar/cmd/baseosmgr/handlebaseos.go
+++ b/pkg/pillar/cmd/baseosmgr/handlebaseos.go
@@ -285,9 +285,9 @@ func doBaseOsActivate(ctx *baseOsMgrContext, uuidStr string,
 		changed = true
 		return changed
 	}
-	// Update version etc
-	updateAndPublishZbootStatus(ctx, status.PartitionLabel, true)
 	if proceed {
+		// Update version etc
+		updateAndPublishZbootStatus(ctx, status.PartitionLabel, true)
 		changed = true
 		// Match the version string inside image
 		if errString := checkInstalledVersion(ctx, *status); errString != "" {


### PR DESCRIPTION
Seems that we broke new image during call of `updateAndPublishZbootStatus` on non-installed partition.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>