### PR TITLE
Protecting EVE services from OOM

### DIFF
--- a/images/rootfs-acrn.yml.in.patch
+++ b/images/rootfs-acrn.yml.in.patch
@@ -16,13 +16,3 @@
    - GPTTOOLS_TAG
    - DOM0ZTOOLS_TAG
  onboot:
-@@ -56,9 +56,6 @@
-    - name: watchdog
-      image: WATCHDOG_TAG
-      cgroupsPath: /eve/eve-watchdog
--   - name: xen-tools
--     image: XENTOOLS_TAG
--     cgroupsPath: /eve/eve-xen-tools
- files:
-    - path: /etc/eve-release
-      contents: 'EVE_VERSION'

--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -29,33 +29,43 @@ services:
    - name: rsyslogd
      image: RSYSLOGD_TAG
      cgroupsPath: /eve/services/rsyslogd
+     oomScoreAdj: -999
    - name: ntpd
      image: linuxkit/openntpd:v0.5
      cgroupsPath: /eve/services/ntpd
+     oomScoreAdj: -999
    - name: sshd
      image: linuxkit/sshd:v0.5
      cgroupsPath: /eve/services/sshd
+     oomScoreAdj: -999
    - name: wwan
      image: WWAN_TAG
      cgroupsPath: /eve/services/wwan
+     oomScoreAdj: -999
    - name: wlan
      image: WLAN_TAG
      cgroupsPath: /eve/services/wlan
+     oomScoreAdj: -999
    - name: guacd
      image: GUACD_TAG
      cgroupsPath: /eve/services/guacd
+     oomScoreAdj: -999
    - name: pillar
      image: PILLAR_TAG
      cgroupsPath: /eve/services/pillar
+     oomScoreAdj: -999
    - name: vtpm
      image: VTPM_TAG
      cgroupsPath: /eve/services/vtpm
+     oomScoreAdj: -999
    - name: watchdog
      image: WATCHDOG_TAG
      cgroupsPath: /eve/services/watchdog
+     oomScoreAdj: -999
    - name: xen-tools
      image: XENTOOLS_TAG
      cgroupsPath: /eve/services/xen-tools
+     oomScoreAdj: -999
 files:
    - path: /etc/eve-release
      contents: 'EVE_VERSION'

--- a/pkg/dom0-ztools/rootfs/etc/init.d/999-eve-oomscore
+++ b/pkg/dom0-ztools/rootfs/etc/init.d/999-eve-oomscore
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+for p in /proc/*/exe; do
+   case "$(ls -l "$p" 2>/dev/null)" in
+     *memlogd|*containerd) echo -999 > "${p/exe/oom_score_adj}"
+                           ;;
+   esac
+done


### PR DESCRIPTION
Based on @cshari-zededa research -- this is a simple hack to make sure that EVE services themselves are the last ones to get killed by OOM killer (among them zedbox is going to get killed first anyway since it consumes most memory -- which is really for the better since then watchdog is going to reboot the box).

We still need a corresponding change on the user side of things -- making sure that when user starts app N, all previous apps don't run the risk of getting killed by OOM.

Finally, one may ask whether we need it at all if we happen to do proper memory accounting. Well, turns out -- yes, yes we do. Linux kernel has way too many corner cases when that accounting doesn't quite work -- so for now we're just bluntly sacrificing user domains if something is off.