### PR TITLE
avoid reboot after first boot try 2

### DIFF
--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -205,6 +205,13 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	zedagentCtx.globalStatus.UnknownConfigItems = make(
 		map[string]types.ConfigItemStatus)
 
+	rebootConfig := readRebootConfig()
+	if rebootConfig != nil {
+		zedagentCtx.rebootConfigCounter = rebootConfig.Counter
+		log.Infof("Zedagent Run - rebootConfigCounter at init is %d",
+			zedagentCtx.rebootConfigCounter)
+	}
+
 	zedagentCtx.physicalIoAdapterMap = make(map[string]types.PhysicalIOAdapter)
 
 	zedagentCtx.pubGlobalConfig, err = ps.NewPublication(pubsub.PublicationOptions{


### PR DESCRIPTION
Turns out the test infra assumes the rebootConfigCounter is always reported in the device info message.
Thus need to tweak yesterday's PR wiith this.