### PR TITLE
Fix baseos remove when content needs to be removed

### DIFF
--- a/pkg/pillar/cmd/baseosmgr/handlebaseos.go
+++ b/pkg/pillar/cmd/baseosmgr/handlebaseos.go
@@ -38,13 +38,32 @@ func lookupBaseOsImageSha(ctx *baseOsMgrContext, imageSha string) *types.BaseOsC
 	return nil
 }
 
+func lookupBaseOsStatusImageSha(ctx *baseOsMgrContext, imageSha string) *types.BaseOsStatus {
+	items := ctx.pubBaseOsStatus.GetAll()
+	for _, c := range items {
+		status := c.(types.BaseOsStatus)
+		for _, ctc := range status.ContentTreeStatusList {
+			if ctc.ContentSha256 == imageSha {
+				return &status
+			}
+		}
+	}
+	return nil
+}
+
 func baseOsHandleStatusUpdateImageSha(ctx *baseOsMgrContext, imageSha string) {
 
 	log.Infof("baseOsHandleStatusUpdateImageSha for %s", imageSha)
 	config := lookupBaseOsImageSha(ctx, imageSha)
 	if config == nil {
-		log.Infof("baseOsHandleStatusUpdateImageSha(%s) not found",
+		log.Infof("baseOsHandleStatusUpdateImageSha(%s) config not found",
 			imageSha)
+		status := lookupBaseOsStatusImageSha(ctx, imageSha)
+		if status != nil {
+			log.Infof("baseOsHandleStatusUpdateImageSha(%s) found status",
+				imageSha)
+			removeBaseOsStatus(ctx, status.Key())
+		}
 		return
 	}
 	uuidStr := config.Key()


### PR DESCRIPTION
I could reproduce the issue by doing a eveimage-update (without activating), waiting for the content to be downloaded and verified, and then doing a eveimage-remove. In that case the BaseOsConfig is deleted, but the BaseOsStatus is never deleted.
That means one can't retry updating to the same image unless the device is rebooted first.