### PR TITLE
Watchdog shouldn't be kiiled by OOM; make debug logs work for hypervisor code

### DIFF
--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -61,7 +61,7 @@ services:
    - name: watchdog
      image: WATCHDOG_TAG
      cgroupsPath: /eve/services/watchdog
-     oomScoreAdj: -999
+     oomScoreAdj: -1000
    - name: xen-tools
      image: XENTOOLS_TAG
      cgroupsPath: /eve/services/xen-tools


### PR DESCRIPTION
and make the loglevel apply to hypervisor/containerd code which uses the logrus system logger

Forced OOM using
 eve enter
 fallocate -l 100M /tmp/file1
 with several files until it runs out of memory

In those cases I never got watchdog to be killed with these diffs, so this should help.
Note that I never got zedbox to be killed either; random processes (like device-steps.sh, dnsmasq, the shell, the fallocate) get killed and isn't noticed.After trying several times ntpd got killed, and then the watchdog rebooted.
Further note that once applications are running on the box the containerd-shim processes have a non-zero oom_score after the adjustment, hence they are most likely to be killed.

I actually think we need to sacrifice zedbox before dnsmasq etc or add pid watchdogs for the dnsmasq, dhcpcd, etc processes, but that will be a separate PR.

