### PR TITLE
check loading status for ingestblobs

### DIFF
--- a/pkg/pillar/cas/cas.go
+++ b/pkg/pillar/cas/cas.go
@@ -43,7 +43,7 @@ type CAS interface {
 	// Returns a list of loaded BlobStatus and an error is thrown if the read blob's hash does not match with the
 	// respective BlobStatus.Sha256 or if there is an exception while reading the blob data.
 	// In case of exception, the returned list of loaded blob will contain all the blob that were loaded until that point.
-	IngestBlob(ctx context.Context, blobs ...*types.BlobStatus) ([]*types.BlobStatus, error)
+	IngestBlob(ctx context.Context, blobs ...types.BlobStatus) ([]types.BlobStatus, error)
 	//UpdateBlobInfo updates BlobInfo of a blob in CAS.
 	//Arg is BlobInfo type struct in which BlobInfo.Digest is mandatory, and other field to be fill only if need to be updated
 	//Returns error is no blob is found match blobInfo.Digest
@@ -115,7 +115,7 @@ type CAS interface {
 	// if there is an exception while reading the blob data.
 	//NOTE: This either loads all the blobs or loads nothing. In other words, in case of error,
 	// this API will GC all blobs that were loaded until that point.
-	IngestBlobsAndCreateImage(reference string, blobs ...*types.BlobStatus) ([]*types.BlobStatus, error)
+	IngestBlobsAndCreateImage(reference string, root types.BlobStatus, blobs ...types.BlobStatus) ([]types.BlobStatus, error)
 
 	// Resolver get an interface that satisfies resolver.ResolverCloser to communicate directly with a generic CAS
 	Resolver() (resolver.ResolverCloser, error)

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -330,14 +330,6 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 				changed = true
 				return changed, false
 			}
-			// find any blob statuses and update them to LOADED
-			blobStatuses := lookupBlobStatuses(ctx, wres.loaded...)
-			for _, blob := range blobStatuses {
-				if blob.State < types.LOADED {
-					blob.State = types.LOADED
-					publishBlobStatus(ctx, blob)
-				}
-			}
 		}
 
 		leftToProcess := 0


### PR DESCRIPTION
This completes the discussion with @eriknordmark [here](https://github.com/lf-edge/eve/pull/1517#discussion_r498177174)

The prior one looked at two things:

* if the blob was `State == types.LOADED`, it did not try to load it
* if the blob was loaded in containerd, it did not try to load it

As @eriknordmark pointed out in the comment linked above, we miss if it is in LOADING state from some other loop. 

With this change, we still check for LOADED. But we pass to `IngestBlobsAndCreateImage` _only_ blobs that are `< LOADING`, and also check for duplicates. We also explicitly tell it what the root is.

In addition, we move all of the checking of blob status and publishing it based on the `IngestBlobs` results into the work handler, which makes the updatestatus loop easier to work with.

cc @eriknordmark 
cc @vignesh-zededa , who verified the specific issue this solves in #1517 