### PR TITLE
app-container log with customized logger and bugfix

### DIFF
--- a/pkg/pillar/agentlog/agentlog.go
+++ b/pkg/pillar/agentlog/agentlog.go
@@ -606,3 +606,14 @@ func getOtherIMGdir(inprogressCheck bool) string {
 	otherIMGdir = fmt.Sprintf("%s/%s", types.PersistDir, partName)
 	return otherIMGdir
 }
+
+// CustomLogInit - allow pillar services and containers to use customized logging
+func CustomLogInit(level logrus.Level) *logrus.Logger {
+	logger := logrus.New()
+	formatter := logrus.JSONFormatter{
+		TimestampFormat: time.RFC3339Nano,
+	}
+	logger.SetFormatter(&formatter)
+	logger.SetLevel(level)
+	return logger
+}

--- a/pkg/pillar/cmd/logmanager/logmanager.go
+++ b/pkg/pillar/cmd/logmanager/logmanager.go
@@ -685,6 +685,8 @@ func processEvents(image string, logChan <-chan logEntry,
 							image, event.source)
 						break
 					}
+				} else {
+					appUUID = event.appUUID
 				}
 				var ok bool
 				appLogBundle, ok = appLogBundles[appUUID]

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -84,6 +84,7 @@ type zedrouterContext struct {
 	appCollectStatsRunning    bool
 	appStatsMutex             sync.Mutex // to protect the changing appNetworkStatus & appCollectStatsRunning
 	appStatsInterval          uint32
+	aclog                     *logrus.Logger // App Container logger
 }
 
 var debug = false
@@ -152,6 +153,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		assignableAdapters: &aa,
 		agentStartTime:     time.Now(),
 		dnsServers:         make(map[string][]net.IP),
+		aclog:              agentlog.CustomLogInit(logrus.InfoLevel),
 	}
 	zedrouterCtx.networkInstanceStatusMap =
 		make(map[uuid.UUID]*types.NetworkInstanceStatus)


### PR DESCRIPTION
Signed-off-by: Naiming Shen <naiming@zededa.com>
- allow app-container logging to use customized logger
- bugfix on app-container log, accidentally found the app-container log may be randomly sent to a wrong app in the cloud if there are multiple apps deployed on the device