### PR TITLE
Introducing GitHub actions for EVE (PR only for now)

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -1,3 +1,4 @@
+---
 name: Eden
 on:
   pull_request_review:

--- a/.github/workflows/eve.yml
+++ b/.github/workflows/eve.yml
@@ -1,7 +1,8 @@
+---
 name: EVE
 on:
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   test:

--- a/.github/workflows/eve.yml
+++ b/.github/workflows/eve.yml
@@ -24,30 +24,6 @@ jobs:
           name: 'test-report'
           path: ${{ github.workspace }}/dist
 
-  yetus:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          path: src
-          fetch-depth: 0
-
-      - name: Yetus
-        uses: apache/yetus-test-patch-action@main
-        with:
-          basedir: ./src
-          patchdir: ./out
-          buildtool: nobuild
-          continuousimprovement: true
-
-      - name: Store Yetus artifacts
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: apacheyetuspatchdir
-          path: ${{ github.workspace }}/out
-
   build:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,10 +4,69 @@ on:
     branches: [ master ]
 
 jobs:
+  test:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Test
+        run: |
+          make test
+      - name: Report test results as Annotations
+        if: ${{ always() }}
+        uses: guyarb/golang-test-annoations@v0.1
+        with:
+          test-results: dist/amd64/results.json
+      - name: Store raw test results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: 'test-report'
+          path: ${{ github.workspace }}/dist
+
+  yetus:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: src
+          fetch-depth: 0
+
+      - name: Yetus
+        uses: apache/yetus-test-patch-action@main
+        with:
+          basedir: ./src
+          patchdir: ./out
+          buildtool: nobuild
+          continuousimprovement: true
+
+      - name: Store Yetus artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: apacheyetuspatchdir
+          path: ${{ github.workspace }}/out
+
   build:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+
+      - name: Build packages
+        run: |
+          make pkgs
+      - name: Build EVE
+        run: |
+          make eve
+      - name: Build KVM rootfs
+        run: |
+          make HV=kvm rootfs
+      - name: Store rootfs
+        uses: actions/upload-artifact@v2
+        with:
+          name: rootfs
+          path: ${{ github.workspace }}/dist/*/installer/rootfs-*.squash
 
 # If all else fails, you may find solace here
 #  https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions

--- a/.github/workflows/yetus.yml
+++ b/.github/workflows/yetus.yml
@@ -1,13 +1,13 @@
 # NOTE that this is the only workflow that requires access to the
-# GitHub token. However, it is safe since in EVE repo itself we 
+# GitHub token. However, it is safe since in EVE repo itself we
 # only trigger this workflow on pull requests and as such making
 # it effectively read-only.
 #   https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token
-
+---
 name: Apache Yetus
 on:
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   yetus:

--- a/.github/workflows/yetus.yml
+++ b/.github/workflows/yetus.yml
@@ -1,0 +1,36 @@
+# NOTE that this is the only workflow that requires access to the
+# GitHub token. However, it is safe since in EVE repo itself we 
+# only trigger this workflow on pull requests and as such making
+# it effectively read-only.
+#   https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token
+
+name: Apache Yetus
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  yetus:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: src
+          fetch-depth: 0
+
+      - name: Yetus
+        uses: apache/yetus-test-patch-action@main
+        with:
+          basedir: ./src
+          patchdir: ./out
+          buildtool: nobuild
+          continuousimprovement: true
+          githubtoken: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Store Yetus artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: 'yetus-scan'
+          path: ${{ github.workspace }}/out

--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ all: help
 
 test: $(GOBUILDER) | $(DIST)
 	@echo Running tests on $(GOMODULE)
-	@$(DOCKER_GO) "gotestsum --junitfile $(DOCKER_DIST)/results.xml" $(GOTREE) $(GOMODULE)
+	@$(DOCKER_GO) "gotestsum --jsonfile $(DOCKER_DIST)/results.json --junitfile $(DOCKER_DIST)/results.xml" $(GOTREE) $(GOMODULE)
 
 itest: $(GOBUILDER) run-proxy | $(DIST)
 	@echo Running integration tests


### PR DESCRIPTION
For now this is a pretty faithful rendition of our CircleCI workflow. The idea here is that we will run both in parallel on PRs and if we like this new one -- we will discontinue CircleCI at some point.

Of course, this is just the beginning. The really big idea here is to kick off Eden integration tests via GitHub actions as well.

Summoning @aw-was-here -- 'cuz he has the most experience with GH actions for now. Allen, please let us know WDYT.