### PR TITLE
Introducing Eden integration test run via GitHub actions

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -1,0 +1,45 @@
+name: Eden
+on:
+  pull_request_review:
+    branches: [master]
+    types: [submitted]
+
+jobs:
+  integration:
+    runs-on: ubuntu-20.04
+    if: ${{ github.event.review.state == 'approved' }}
+    steps:
+      - name: setup
+        run: |
+          sudo apt update
+          sudo apt install -y qemu-utils qemu-system-x86
+      - name: get eden
+        uses: actions/checkout@v2
+        with:
+          repository: 'lf-edge/eden'
+      - name: build eden
+        run: |
+          make clean
+          make build
+          make build-tests
+      - name: get eve
+        uses: actions/checkout@v2
+        with:
+          path: 'eve'
+      - name: build eve
+        run: |
+          make -C eve HV=kvm eve
+      - name: run
+        run: |
+          ./eden config add default
+          ./eden config set default --key eve.tag --value=$(make -C eve version)
+          ./eden config set default --key=eve.accel --value=false
+          echo > tests/workflow/testdata/eden_stop.txt
+          ./eden test ./tests/workflow
+          ./eden log --format json > trace.log
+      - name: Store raw test results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: 'eden-report'
+          path: ${{ github.workspace }}/trace.log


### PR DESCRIPTION
This one is pretty interesting -- the workflow itself only gets triggered when a PR gets approved which creates a nice two-stage system between running quick checks like Yetus and unit tests first and then, after a round back-n-forth perhaps approving the PR and having the integration tests kick-in.

Integration tests are currently running under 30min which is pretty great.

Also @aw-was-here @deitch  and @kalyan-nidumolu  please take a look