### PR TITLE
exploring containerd client state cleanup

### DIFF
--- a/pkg/pillar/cmd/volumemgr/create.go
+++ b/pkg/pillar/cmd/volumemgr/create.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/lf-edge/edge-containers/pkg/registry"
+	"github.com/lf-edge/eve/pkg/pillar/cas"
 	"github.com/lf-edge/eve/pkg/pillar/diskmetrics"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 )
@@ -45,7 +46,15 @@ func createVdiskVolume(ctx *volumemgrContext, status types.VolumeStatus,
 	puller := registry.Puller{
 		Image: ref,
 	}
-	resolver, err := ctx.casClient.Resolver()
+	// XXX try with a local casClient for this call
+	casClient, err := cas.NewCAS(casClientType)
+	if err != nil {
+		err = fmt.Errorf("Run: exception while initializing CAS client: %s", err.Error())
+		return created, "", err
+	}
+	defer casClient.CloseClient()
+
+	resolver, err := casClient.Resolver()
 	if err != nil {
 		errStr := fmt.Sprintf("error getting CAS resolver: %v", err)
 		log.Error(errStr)

--- a/pkg/pillar/containerd/oci_test.go
+++ b/pkg/pillar/containerd/oci_test.go
@@ -57,11 +57,14 @@ const imageConfig = `
 `
 
 func TestOciSpec(t *testing.T) {
-	if err := InitContainerdClient(); err != nil {
-		t.Logf("failed to init containerd client %v", err)
+	// Do not create a client since containerd isn't running for test
+	client, err := NewContainerdClient(false)
+	if err != nil {
+		t.Errorf("failed to create containerd client %v", err)
+		return
 	}
 
-	spec, err := NewOciSpec("test")
+	spec, err := client.NewOciSpec("test")
 	if err != nil {
 		t.Errorf("failed to create default OCI spec %v", err)
 	}

--- a/pkg/pillar/containerd/utilAPIs.go
+++ b/pkg/pillar/containerd/utilAPIs.go
@@ -80,14 +80,14 @@ func GetSnapshotID(rootpath string) string {
 }
 
 //UnpackClientImage unpacks given client image into containerd.
-func UnpackClientImage(clientImage containerd.Image) error {
+func (client *Client) UnpackClientImage(clientImage containerd.Image) error {
 	log.Infof("UnpackClientImage: for image :%s", clientImage.Name())
-	unpacked, err := clientImage.IsUnpacked(ctrdCtx, defaultSnapshotter)
+	unpacked, err := clientImage.IsUnpacked(client.ctrdCtx, defaultSnapshotter)
 	if err != nil {
 		return fmt.Errorf("UnpackClientImage: unable to get image metadata: %v config: %v", clientImage.Name(), err)
 	}
 	if !unpacked {
-		if err := clientImage.Unpack(ctrdCtx, defaultSnapshotter); err != nil {
+		if err := clientImage.Unpack(client.ctrdCtx, defaultSnapshotter); err != nil {
 			return fmt.Errorf("UnpackClientImage: unable to unpack image: %v: %v", clientImage.Name(), err)
 		}
 	}

--- a/pkg/pillar/hypervisor/containerd_test.go
+++ b/pkg/pillar/hypervisor/containerd_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestGetDomsCPUMem(t *testing.T) {
-	ctx, err := initContainerd()
+	ctx, err := initContainerd(true)
 	if err != nil {
 		t.Skipf("test must be run on a system with a functional containerd")
 	}

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	zconfig "github.com/lf-edge/eve/api/go/config"
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
-	"github.com/lf-edge/eve/pkg/pillar/containerd"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	log "github.com/sirupsen/logrus"
 	"io/ioutil"
@@ -330,7 +329,7 @@ type kvmContext struct {
 }
 
 func newKvm() Hypervisor {
-	ctrdCtx, err := initContainerd()
+	ctrdCtx, err := initContainerd(true)
 	if err != nil {
 		log.Fatalf("couldn't initialize containerd (this should not happen): %v. Exiting.", err)
 		return nil // it really never returns on account of above
@@ -398,7 +397,7 @@ func (ctx kvmContext) Setup(status types.DomainStatus, config types.DomainConfig
 		"-readconfig", file.Name(),
 		"-pidfile", kvmStateDir+domainName+"/pid")
 
-	if err := containerd.LKTaskPrepare(domainName, "xen-tools", &config, &status, qemuOverHead, args); err != nil {
+	if err := ctx.ctrdClient.LKTaskPrepare(domainName, "xen-tools", &config, &status, qemuOverHead, args); err != nil {
 		return logError("LKTaskPrepare failed for %s, (%v)", domainName, err)
 	}
 

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -6,7 +6,6 @@ package hypervisor
 import (
 	"errors"
 	"fmt"
-	"github.com/lf-edge/eve/pkg/pillar/containerd"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/mem"
@@ -52,7 +51,7 @@ type xenContext struct {
 }
 
 func newXen() Hypervisor {
-	ctrdCtx, err := initContainerd()
+	ctrdCtx, err := initContainerd(true)
 	if err != nil {
 		log.Fatalf("couldn't initialize containerd (this should not happen): %v. Exiting.", err)
 		return nil // it really never returns on account of above
@@ -82,7 +81,7 @@ func (ctx xenContext) Setup(status types.DomainStatus, config types.DomainConfig
 	}
 
 	args := []string{"/etc/xen/scripts/xen-start", domainName, file.Name()}
-	if err := containerd.LKTaskPrepare(domainName, "xen-tools", &config, &status, 0, args); err != nil {
+	if err := ctx.ctrdClient.LKTaskPrepare(domainName, "xen-tools", &config, &status, 0, args); err != nil {
 		return logError("LKTaskPrepare failed for %s, (%v)", domainName, err)
 	}
 
@@ -412,7 +411,7 @@ func (ctx xenContext) Stop(domainName string, domainID int, force bool) error {
 	if force {
 		args = append(args, "-F")
 	}
-	stdOut, stdErr, err := containerd.CtrExec(domainName, args)
+	stdOut, stdErr, err := ctx.ctrdClient.CtrExec(domainName, args)
 	if err != nil {
 		log.Errorln("xl shutdown failed ", err)
 		log.Errorln("xl shutdown output ", stdOut, stdErr)
@@ -424,7 +423,7 @@ func (ctx xenContext) Stop(domainName string, domainID int, force bool) error {
 
 func (ctx xenContext) Delete(domainName string, domainID int) error {
 	log.Infof("xlDestroy %s %d\n", domainName, domainID)
-	stdOut, stdErr, err := containerd.CtrSystemExec("xen-tools",
+	stdOut, stdErr, err := ctx.ctrdClient.CtrSystemExec("xen-tools",
 		[]string{"xl", "destroy", domainName})
 	if err != nil {
 		log.Errorln("xl destroy failed ", err)
@@ -474,7 +473,7 @@ func (ctx xenContext) Info(domainName string, domainID int) (int, types.SwState,
 
 func (ctx xenContext) PCIReserve(long string) error {
 	log.Infof("pciAssignableAdd %s\n", long)
-	stdOut, stdErr, err := containerd.CtrSystemExec("xen-tools",
+	stdOut, stdErr, err := ctx.ctrdClient.CtrSystemExec("xen-tools",
 		[]string{"xl", "pci-assignable-add", long})
 	if err != nil {
 		errStr := fmt.Sprintf("xl pci-assignable-add failed: %s %s", stdOut, stdErr)
@@ -487,7 +486,7 @@ func (ctx xenContext) PCIReserve(long string) error {
 
 func (ctx xenContext) PCIRelease(long string) error {
 	log.Infof("pciAssignableRemove %s\n", long)
-	stdOut, stdErr, err := containerd.CtrSystemExec("xen-tools",
+	stdOut, stdErr, err := ctx.ctrdClient.CtrSystemExec("xen-tools",
 		[]string{"xl", "pci-assignable-rem", "-r", long})
 	if err != nil {
 		errStr := fmt.Sprintf("xl pci-assignable-rem failed: %s %s", stdOut, stdErr)
@@ -499,7 +498,7 @@ func (ctx xenContext) PCIRelease(long string) error {
 }
 
 func (ctx xenContext) GetHostCPUMem() (types.HostMemory, error) {
-	xlInfo, stderr, err := containerd.CtrSystemExec("xen-tools",
+	xlInfo, stderr, err := ctx.ctrdClient.CtrSystemExec("xen-tools",
 		[]string{"xl", "info"})
 	if err != nil {
 		log.Errorf("xl info failed %s %s falling back on Dom0 stats: %v", xlInfo, stderr, err)
@@ -549,7 +548,7 @@ func (ctx xenContext) GetHostCPUMem() (types.HostMemory, error) {
 func (ctx xenContext) GetDomsCPUMem() (map[string]types.DomainMetric, error) {
 	count := 0
 	counter := 0
-	xentopInfo, _, _ := containerd.CtrSystemExec("xen-tools",
+	xentopInfo, _, _ := ctx.ctrdClient.CtrSystemExec("xen-tools",
 		[]string{"xentop", "-b", "-d", "1", "-i", "2", "-f"})
 
 	splitXentopInfo := strings.Split(xentopInfo, "\n")


### PR DESCRIPTION
To save on memory usage it make sense to try a separate CAS client for the Puller code so that any associated grpc goroutines and state can hopefully be cleaned up when we call CloseClient on that CAS client. That might help with the 40000 goroutines in grpc.

However, as a result of that simple change failing spectacularely I realized that when we introduced the single zedbox binary we ended up with code in pkg/pillar/cas and hypervisor which assume they are alone and they manipulate the global variables in the containerd package as if they are alone. That results in one CloseClient for one CAS client blowing away the state for other client. This is already a potential problem because when baseosmgr/zboot copies the image to the partition it uses its own CAS client and calls CloseClient when done. However, that normally doesn't cause problems because after that CloseClient we are going to reboot into the new baseos image and not do other interactions with containerd.

This is passing basic testing but we need to recover some hardware devices to run full tests, and get some data on whether it reduces the number of goroutines in containerd/grpc.