### PR TITLE
Allowing for side-loading of /persist content + silly fix for exit status of linuxkit

### DIFF
--- a/pkg/mkimage-raw-efi/install
+++ b/pkg/mkimage-raw-efi/install
@@ -100,7 +100,7 @@ if [ -n "$CONFIG_PART" ] ; then
    ln -s /dev/$CONFIG_PART /parts/config.img
 fi
 
-for i in config.img rootfs.img EFI ; do
+for i in persist.img config.img rootfs.img EFI ; do
    SOURCE="/bits/$i"
    [ -e "$SOURCE" ] || SOURCE=/dev/null
    [ -L /parts/$i ] || ln -s "$SOURCE" /parts/$i
@@ -108,8 +108,7 @@ done
 # finally lets see if we were given any overrides
 grep -q eve_install_skip_rootfs /proc/cmdline && trunc /parts/rootfs.img
 grep -q eve_install_skip_config /proc/cmdline && trunc /parts/config.img
-# 1M of zeroes should be enough to trigger ext3 filesystem wipe
-grep -q eve_install_skip_persist /proc/cmdline || dd if=/dev/zero of=/parts/persist.img bs=1M count=1 2>/dev/null
+grep -q eve_install_skip_config /proc/cmdline && trunc /parts/persist.img
 
 # we may be asked to pause before install procedure
 grep -q eve_pause_before_install /proc/cmdline && pause "formatting the /dev/$INSTALL_DEV"

--- a/tools/makerootfs.sh
+++ b/tools/makerootfs.sh
@@ -1,9 +1,10 @@
-#!/bin/sh
+#!/bin/bash
 # Usage:
 #
 #     ./makerootfs.sh <image.yml> <output rootfs image>  [<fs>]
 
 set -e
+set -o pipefail
 
 EVE="$(cd "$(dirname "$0")" && pwd)/../"
 PATH="$EVE/build-tools/bin:$PATH"


### PR DESCRIPTION
This change allows for content of the /persist partition to be specified upfront (the default is still 1M of 0s). In addition just got to fixing the fact that a failing linuxkit (before pipe) wouldn't fail the build. Sad!