### PR TITLE
Fixing instance intermediate error state

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1526,7 +1526,8 @@ func configAdapters(ctx *domainContext, config types.DomainConfig) error {
 			if ibp == nil {
 				continue
 			}
-			if ibp.UsedByUUID != nilUUID {
+			if ibp.UsedByUUID != config.UUIDandVersion.UUID &&
+				ibp.UsedByUUID != nilUUID {
 				return fmt.Errorf("adapter %d %s used by %s",
 					adapter.Type, adapter.Name, ibp.UsedByUUID)
 			}


### PR DESCRIPTION
Issue: We are seeing instances going in momentarily error state after doing stop and start.

The issue is adapter UsedByUUID won't be nil if we are doing stop/start. We just need to check that whether the adapter is used by the same instance or not.