### PR TITLE
Fix another 'concurrent map iteration and map write' in logmanager

### DIFF
--- a/pkg/pillar/cmd/logmanager/logmanager.go
+++ b/pkg/pillar/cmd/logmanager/logmanager.go
@@ -549,6 +549,7 @@ func parseAndSendSyslogEntries(ctx *loggerContext) {
 		if appLog {
 			ctx.inputMetrics.totalAppLogInput++
 		} else {
+			metricsLock.Lock()
 			ctx.inputMetrics.totalDeviceLogInput++
 			c, ok := ctx.inputMetrics.deviceLogInput[logSource]
 			if !ok {
@@ -556,6 +557,7 @@ func parseAndSendSyslogEntries(ctx *loggerContext) {
 			}
 			c++
 			ctx.inputMetrics.deviceLogInput[logSource] = c
+			metricsLock.Unlock()
 		}
 	}
 }


### PR DESCRIPTION
Got this panic randomly:
fatal error: concurrent map iteration and map write

goroutine 821 [running]:
runtime.throw(0x19dce6f, 0x26)
/usr/local/go/src/runtime/panic.go:617 +0x72 fp=0xc0014018f0 sp=0xc0014018c0 pc
=0x42ce72
runtime.mapiternext(0xc0014019c8)
/usr/local/go/src/runtime/map.go:860 +0x597 fp=0xc001401978 sp=0xc0014018f0 pc=
0x40ec47
github.com/lf-edge/eve/pkg/pillar/cmd/logmanager.publishLogMetrics(0xc00165d680, 0xc001
401e18)
/pillar/cmd/logmanager/logmanager.go:785 +0x13e fp=0xc001401a38 sp=0xc001401978
pc=0x12ed1ce
github.com/lf-edge/eve/pkg/pillar/cmd/logmanager.processEvents(0xc00023cac0, 0x4, 0xc00
15a6b40, 0xc0000a8c40, 0x35, 0xc00165d680)
/pillar/cmd/logmanager/logmanager.go:771 +0xcd7 fp=0xc001401fb0 sp=0xc001401a38
pc=0x12ec907
runtime.goexit()
/usr/local/go/src/runtime/asm_amd64.s:1337 +0x1 fp=0xc001401fb8 sp=0xc001401fb0
pc=0x459721
created by github.com/lf-edge/eve/pkg/pillar/cmd/logmanager.Run
/pillar/cmd/logmanager/logmanager.go:348 +0x182a

