### PR TITLE
Dumbing down Eden workflow since artifact caching is now working

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -29,6 +29,7 @@ jobs:
           path: 'eve'
       - name: build eve
         run: |
+          make -C eve pkgs
           make -C eve HV=kvm eve
       - name: run
         run: |

--- a/.github/workflows/eve.yml
+++ b/.github/workflows/eve.yml
@@ -39,11 +39,6 @@ jobs:
       - name: Build KVM rootfs
         run: |
           make HV=kvm rootfs
-      - name: Store rootfs
-        uses: actions/upload-artifact@v2
-        with:
-          name: rootfs
-          path: ${{ github.workspace }}/dist/*/installer/rootfs-*.squash
 
 # If all else fails, you may find solace here
 #  https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions


### PR DESCRIPTION
All the experiments with artifact caching are not panning out for now (it seems that we may be forced to use a hammer and implement that kind of caching using GitHub Packages registry -- more on that later this week).

For now -- I'm simply dumbing the pipeline down to not use any kind of caching and always rebuild. This will add an additional 10 min or so to the execution time but it should be acceptable for now.