### PR TITLE
Cache PR builds as evebuild/danger:0.0.0-pr-XXX docker images

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -27,15 +27,25 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: 'eve'
-      - name: build eve
+      - name: fetch or build eve
+        env:
+          TAG: 0.0.0-pr-${{ github.event.pull_request.number }}
+          CACHE: evebuild/danger
         run: |
-          make -C eve pkgs
-          make -C eve HV=kvm eve
+          if docker pull "$CACHE:$TAG-kvm"; then
+             docker tag  "$CACHE:$TAG-kvm" "lfedge/eve:$TAG-kvm"
+             docker tag  "$CACHE:$TAG-kvm" "lfedge/eve:$TAG-kvm-amd64"
+          else
+             make -C eve pkgs
+             make -C eve ROOTFS_VERSION="$TAG" HV=kvm eve
+          fi
+          echo "TAG=$TAG" >> $GITHUB_ENV
       - name: run
         run: |
           ./eden config add default
-          ./eden config set default --key eve.tag --value=$(make -s -C eve version)
+          ./eden config set default --key eve.tag --value="$TAG"
           ./eden config set default --key=eve.accel --value=false
+          EDITOR=cat ./eden config edit default
           echo > tests/workflow/testdata/eden_stop.txt
           ./eden test ./tests/workflow -v debug
       - name: Collect logs

--- a/.github/workflows/eve.yml
+++ b/.github/workflows/eve.yml
@@ -1,14 +1,17 @@
 ---
 name: EVE
 on:
-  pull_request:
-    branches: [master]
+  pull_request_target:
+    branches:
+      - master
 
 jobs:
   test:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Test
         run: |
@@ -29,16 +32,68 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Build packages
+        env:
+          PR_ID: ${{ github.event.pull_request.number  }}
         run: |
           make pkgs
+          echo "VERSION=0.0.0-pr-$PR_ID" >> $GITHUB_ENV
       - name: Build EVE
         run: |
-          make eve
-      - name: Build KVM rootfs
+          make ROOTFS_VERSION="$VERSION" eve
+      - name: Build EVE for KVM
         run: |
-          make HV=kvm rootfs
+          rm -rf dist
+          make ROOTFS_VERSION="$VERSION" HV=kvm eve
+      - name: Export docker container
+        run: |
+          for i in xen kvm; do
+             docker tag "lfedge/eve:$VERSION-$i" "evebuild/danger:$VERSION-$i"
+             IMGS="$IMGS evebuild/danger:$VERSION-$i"
+          done
+          docker save $IMGS > eve.tar
+      - name: Upload EVE
+        uses: actions/upload-artifact@v2
+        with:
+          name: eve
+          path: eve.tar
+
+  publish:
+    needs: build
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Download EVE
+        uses: actions/download-artifact@v2
+        with:
+          name: eve
+      - name: Publish EVE
+        run: |
+          echo "${{ secrets.DOCKERHUB_TOKEN }}" |\
+             docker login -u evebuild --password-stdin
+          for i in `docker load < eve.tar | sed -e 's#^Loaded image:##'`; do
+             docker push "$i"
+          done
+
+  cleanup:
+    needs: build
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Wait for publish
+        run: |
+          # Ideally we would find an API to call and make sure that 'publish'
+          # completed. NOTE that we don't care whether publish succeedeed or
+          # failed -- just completed. Waiting for 60 seconds is the next best
+          # thing since it works most of the time and on a very rare occasion
+          # that 'publish' doesn't complete fetching the artifact in 60 seconds
+          # we can always re-publish later.
+          sleep 60
+      - uses: geekyeggo/delete-artifact@v1
+        with:
+          name: eve
+          failOnError: false
 
 # If all else fails, you may find solace here
 #  https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions


### PR DESCRIPTION
This is a tricky one and the one where I need lots of your feedback around risk assessment (in particular very much looking at @aw-was-here for that). Here's the deal: because of the asinine nature of GH Actions artifact caching I finally bit the bullet and decided to cache them as proper Docker container (this is something that we should've done long time ago since it is much easier to use them that way anyway).

Here's how it works: every PR submitted by a trusted set of developers (this set includes only me and @eriknordmark for now) will trigger a stage that logs into Docker hub and also change LINUXKIT_PKG_TARGET in later steps from build to push. Thus we will end up with PR builds deposited into DockerHUB proper under the account evebuild. This will enable anything further down the pipeline (including manual steps) to simply do `docker pull evebuild/eve:0.0.0-pr-XXX` and use the artifact produced by the build.

This appears to be safe, because:
   * evebuild is a throw-away account on DockerHUB that we can agree to trust as little as possible. Even if it gets compromised it seems like we won't lose much
   * a consistent name for these artifacts guarantees that we will forever only have as many of these containers on DockerHUB as we have total # of PRs in EVE repo -- hence no spamming
   * we are running this workflow with `pull_request_target` and hence updates to the workflow file itself can NOT be used to steal our DockerHUB token

In fact, this looks safe enough to actually drop this restriction that only the PRs coming from a trusted set of developers should push to DockerHUB -- but I'll leave it there for now.