### PR TITLE
New client per NewCAS() and new context per API

### DIFF
--- a/pkg/pillar/cas/cas.go
+++ b/pkg/pillar/cas/cas.go
@@ -52,7 +52,7 @@ type CAS interface {
 	//ReadBlob: returns a reader to consume the raw data of the blob which matches the given arg 'blobHash'.
 	//Returns error if no blob is found for the given 'blobHash'.
 	//Arg 'blobHash' should be of format <algo>:<hash> (currently supporting only sha256:<hash>).
-	ReadBlob(blobHash string) (io.Reader, error)
+	ReadBlob(ctx context.Context, blobHash string) (io.Reader, error)
 	//RemoveBlob: removes a blob which matches the given arg 'blobHash'.
 	//To keep this method idempotent, no error is returned if the given arg 'blobHash' does not match any blob.
 	//Arg 'blobHash' should be of format <algo>:<hash> (currently supporting only sha256:<hash>).
@@ -119,7 +119,10 @@ type CAS interface {
 	IngestBlobsAndCreateImage(reference string, root types.BlobStatus, blobs ...types.BlobStatus) ([]types.BlobStatus, error)
 
 	// Resolver get an interface that satisfies resolver.ResolverCloser to communicate directly with a generic CAS
-	Resolver() (resolver.ResolverCloser, error)
+	Resolver(ctx context.Context) (resolver.ResolverCloser, error)
+
+	// CtrNewUserServicesCtx() returns a context and a cancel function
+	CtrNewUserServicesCtx() (context.Context, context.CancelFunc)
 
 	// CloseClient closes (only) the respective CAS client initialized while calling `NewCAS()`.
 	CloseClient() error

--- a/pkg/pillar/cas/cas.go
+++ b/pkg/pillar/cas/cas.go
@@ -21,7 +21,8 @@ type BlobInfo struct {
 	Labels map[string]string
 }
 
-//CAS  provides methods to interact with CAS clients
+// CAS provides methods to interact with CAS clients
+// Context handling should be taken care by the underlying implementor.
 type CAS interface {
 	//Blob APIs
 	//CheckBlobExists: returns true if the blob exists.
@@ -120,7 +121,7 @@ type CAS interface {
 	// Resolver get an interface that satisfies resolver.ResolverCloser to communicate directly with a generic CAS
 	Resolver() (resolver.ResolverCloser, error)
 
-	//CloseClient closes the respective CAS client initialized while calling `NewCAS()`
+	// CloseClient closes (only) the respective CAS client initialized while calling `NewCAS()`.
 	CloseClient() error
 }
 
@@ -132,7 +133,8 @@ var knownCASHandlers = map[string]casDesc{
 	"containerd": {constructor: newContainerdCAS},
 }
 
-//NewCAS  returns selectedCAS object
+// NewCAS returns new CAS object with a new client of underlying implementor(selectedCAS).
+// It's the caller/user's responsibility to close the respective client after use by calling CAS.CloseClient().
 func NewCAS(selectedCAS string) (CAS, error) {
 	if _, found := knownCASHandlers[selectedCAS]; !found {
 		return nil, fmt.Errorf("Unknown CAS handler %s", selectedCAS)

--- a/pkg/pillar/cmd/volumemgr/create.go
+++ b/pkg/pillar/cmd/volumemgr/create.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/lf-edge/edge-containers/pkg/registry"
+	"github.com/lf-edge/eve/pkg/pillar/cas"
 	"github.com/lf-edge/eve/pkg/pillar/diskmetrics"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 )
@@ -45,7 +46,15 @@ func createVdiskVolume(ctx *volumemgrContext, status types.VolumeStatus,
 	puller := registry.Puller{
 		Image: ref,
 	}
-	resolver, err := ctx.casClient.Resolver()
+	// XXX try with a local casClient for this call
+	casClient, err := cas.NewCAS(casClientType)
+	if err != nil {
+		err = fmt.Errorf("Run: exception while initializing CAS client: %s", err.Error())
+		return created, "", err
+	}
+	defer casClient.CloseClient()
+
+	resolver, err := casClient.Resolver()
 	if err != nil {
 		errStr := fmt.Sprintf("error getting CAS resolver: %v", err)
 		log.Error(errStr)

--- a/pkg/pillar/cmd/volumemgr/create.go
+++ b/pkg/pillar/cmd/volumemgr/create.go
@@ -53,8 +53,10 @@ func createVdiskVolume(ctx *volumemgrContext, status types.VolumeStatus,
 		return created, "", err
 	}
 	defer casClient.CloseClient()
+	ctrdCtx, done := casClient.CtrNewUserServicesCtx()
+	defer done()
 
-	resolver, err := casClient.Resolver()
+	resolver, err := casClient.Resolver(ctrdCtx)
 	if err != nil {
 		errStr := fmt.Sprintf("error getting CAS resolver: %v", err)
 		log.Error(errStr)

--- a/pkg/pillar/cmd/volumemgr/create.go
+++ b/pkg/pillar/cmd/volumemgr/create.go
@@ -46,7 +46,7 @@ func createVdiskVolume(ctx *volumemgrContext, status types.VolumeStatus,
 	puller := registry.Puller{
 		Image: ref,
 	}
-	// XXX try with a local casClient for this call
+
 	casClient, err := cas.NewCAS(casClientType)
 	if err != nil {
 		err = fmt.Errorf("Run: exception while initializing CAS client: %s", err.Error())

--- a/pkg/pillar/cmd/volumemgr/oci.go
+++ b/pkg/pillar/cmd/volumemgr/oci.go
@@ -16,12 +16,15 @@ import (
 
 // resolveIndex get the manifest for our platform from the index
 func resolveIndex(ctx *volumemgrContext, blob *types.BlobStatus) (*v1.Descriptor, error) {
+	ctrdCtx, done := ctx.casClient.CtrNewUserServicesCtx()
+	defer done()
+
 	var index *v1.IndexManifest
 	//If the blob is loaded, then read the blob from CAS else read the verified image of the blob
 	if blob.State == types.LOADED {
 		blobHash := checkAndCorrectBlobHash(blob.Sha256)
 		// try it as an index and as a straight manifest
-		reader, err := ctx.casClient.ReadBlob(blobHash)
+		reader, err := ctx.casClient.ReadBlob(ctrdCtx, blobHash)
 		if err != nil {
 			err = fmt.Errorf("resolveIndex(%s): Exception while reading blob: %v", blob.Sha256, err)
 			log.Errorf(err.Error())
@@ -66,11 +69,14 @@ func resolveIndex(ctx *volumemgrContext, blob *types.BlobStatus) (*v1.Descriptor
 func resolveManifestChildren(ctx *volumemgrContext, blob *types.BlobStatus) (int64, []v1.Descriptor, error) {
 	var manifest *v1.Manifest
 
+	ctrdCtx, done := ctx.casClient.CtrNewUserServicesCtx()
+	defer done()
+
 	//If the blob is loaded, then read the blob from CAS else read the verified image of the blob
 	if blob.State == types.LOADED {
 		blobHash := checkAndCorrectBlobHash(blob.Sha256)
 		// try it as an index and as a straight manifest
-		reader, err := ctx.casClient.ReadBlob(blobHash)
+		reader, err := ctx.casClient.ReadBlob(ctrdCtx, blobHash)
 		if err != nil {
 			err = fmt.Errorf("resolveManifestChildren(%s): Exception while reading blob: %v", blob.Sha256, err)
 			log.Errorf(err.Error())

--- a/pkg/pillar/containerd/oci_test.go
+++ b/pkg/pillar/containerd/oci_test.go
@@ -57,11 +57,14 @@ const imageConfig = `
 `
 
 func TestOciSpec(t *testing.T) {
-	if err := InitContainerdClient(); err != nil {
-		t.Logf("failed to init containerd client %v", err)
+	// Do not create a client since containerd isn't running for test
+	client, err := NewContainerdClient(false)
+	if err != nil {
+		t.Errorf("failed to create containerd client %v", err)
+		return
 	}
 
-	spec, err := NewOciSpec("test")
+	spec, err := client.NewOciSpec("test")
 	if err != nil {
 		t.Errorf("failed to create default OCI spec %v", err)
 	}

--- a/pkg/pillar/containerd/oci_test.go
+++ b/pkg/pillar/containerd/oci_test.go
@@ -60,8 +60,7 @@ func TestOciSpec(t *testing.T) {
 	// Do not create a client since containerd isn't running for test
 	client, err := NewContainerdClient(false)
 	if err != nil {
-		t.Errorf("failed to create containerd client %v", err)
-		return
+		t.Skipf("test must be run on a system with a functional containerd")
 	}
 
 	spec, err := client.NewOciSpec("test")

--- a/pkg/pillar/containerd/oci_test.go
+++ b/pkg/pillar/containerd/oci_test.go
@@ -57,12 +57,8 @@ const imageConfig = `
 `
 
 func TestOciSpec(t *testing.T) {
-	// Do not create a client since containerd isn't running for test
-	client, err := NewContainerdClient(false)
-	if err != nil {
-		t.Skipf("test must be run on a system with a functional containerd")
-	}
 
+	client := &Client{}
 	spec, err := client.NewOciSpec("test")
 	if err != nil {
 		t.Errorf("failed to create default OCI spec %v", err)
@@ -74,12 +70,14 @@ func TestOciSpec(t *testing.T) {
 	} else {
 		defer os.Remove(tmpfile.Name())
 	}
+
 	tmpdir, err := ioutil.TempDir("/tmp", "volume")
 	if err != nil {
 		t.Errorf("failed to create tmpdir %v", err)
 	} else {
 		defer os.RemoveAll(tmpdir)
 	}
+
 	if ioutil.WriteFile(tmpdir+"/image-config.json", []byte(imageConfig), 0777) != nil {
 		t.Errorf("failed to write to temp file %s", tmpdir+"/image-config.json")
 	}

--- a/pkg/pillar/containerd/utilAPIs.go
+++ b/pkg/pillar/containerd/utilAPIs.go
@@ -82,12 +82,14 @@ func GetSnapshotID(rootpath string) string {
 //UnpackClientImage unpacks given client image into containerd.
 func (client *Client) UnpackClientImage(clientImage containerd.Image) error {
 	log.Infof("UnpackClientImage: for image :%s", clientImage.Name())
-	unpacked, err := clientImage.IsUnpacked(client.ctrdCtx, defaultSnapshotter)
+	ctrdCtx, done := client.CtrNewUserServicesCtx()
+	defer done()
+	unpacked, err := clientImage.IsUnpacked(ctrdCtx, defaultSnapshotter)
 	if err != nil {
 		return fmt.Errorf("UnpackClientImage: unable to get image metadata: %v config: %v", clientImage.Name(), err)
 	}
 	if !unpacked {
-		if err := clientImage.Unpack(client.ctrdCtx, defaultSnapshotter); err != nil {
+		if err := clientImage.Unpack(ctrdCtx, defaultSnapshotter); err != nil {
 			return fmt.Errorf("UnpackClientImage: unable to unpack image: %v: %v", clientImage.Name(), err)
 		}
 	}

--- a/pkg/pillar/containerd/utilAPIs.go
+++ b/pkg/pillar/containerd/utilAPIs.go
@@ -80,14 +80,14 @@ func GetSnapshotID(rootpath string) string {
 }
 
 //UnpackClientImage unpacks given client image into containerd.
-func UnpackClientImage(clientImage containerd.Image) error {
+func (client *Client) UnpackClientImage(clientImage containerd.Image) error {
 	log.Infof("UnpackClientImage: for image :%s", clientImage.Name())
-	unpacked, err := clientImage.IsUnpacked(ctrdCtx, defaultSnapshotter)
+	unpacked, err := clientImage.IsUnpacked(client.ctrdCtx, defaultSnapshotter)
 	if err != nil {
 		return fmt.Errorf("UnpackClientImage: unable to get image metadata: %v config: %v", clientImage.Name(), err)
 	}
 	if !unpacked {
-		if err := clientImage.Unpack(ctrdCtx, defaultSnapshotter); err != nil {
+		if err := clientImage.Unpack(client.ctrdCtx, defaultSnapshotter); err != nil {
 			return fmt.Errorf("UnpackClientImage: unable to unpack image: %v: %v", clientImage.Name(), err)
 		}
 	}

--- a/pkg/pillar/hypervisor/containerd.go
+++ b/pkg/pillar/hypervisor/containerd.go
@@ -22,8 +22,8 @@ type ctrdContext struct {
 	ctrdClient *containerd.Client
 }
 
-func initContainerd(createClient bool) (*ctrdContext, error) {
-	ctrdClient, err := containerd.NewContainerdClient(createClient)
+func initContainerd() (*ctrdContext, error) {
+	ctrdClient, err := containerd.NewContainerdClient()
 	if err != nil {
 		return nil, err
 	}
@@ -35,7 +35,7 @@ func initContainerd(createClient bool) (*ctrdContext, error) {
 }
 
 func newContainerd() Hypervisor {
-	if ret, err := initContainerd(true); err != nil {
+	if ret, err := initContainerd(); err != nil {
 		log.Fatalf("couldn't initialize containerd (this should not happen): %v. Exiting.", err)
 		return nil // it really never returns on account of above
 	} else {

--- a/pkg/pillar/hypervisor/containerd_test.go
+++ b/pkg/pillar/hypervisor/containerd_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestGetDomsCPUMem(t *testing.T) {
-	ctx, err := initContainerd(true)
+	ctx, err := initContainerd()
 	if err != nil {
 		t.Skipf("test must be run on a system with a functional containerd")
 	}

--- a/pkg/pillar/hypervisor/containerd_test.go
+++ b/pkg/pillar/hypervisor/containerd_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestGetDomsCPUMem(t *testing.T) {
-	ctx, err := initContainerd()
+	ctx, err := initContainerd(true)
 	if err != nil {
 		t.Skipf("test must be run on a system with a functional containerd")
 	}

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	zconfig "github.com/lf-edge/eve/api/go/config"
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
-	"github.com/lf-edge/eve/pkg/pillar/containerd"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	log "github.com/sirupsen/logrus"
 	"io/ioutil"
@@ -330,7 +329,7 @@ type kvmContext struct {
 }
 
 func newKvm() Hypervisor {
-	ctrdCtx, err := initContainerd()
+	ctrdCtx, err := initContainerd(true)
 	if err != nil {
 		log.Fatalf("couldn't initialize containerd (this should not happen): %v. Exiting.", err)
 		return nil // it really never returns on account of above
@@ -398,7 +397,7 @@ func (ctx kvmContext) Setup(status types.DomainStatus, config types.DomainConfig
 		"-readconfig", file.Name(),
 		"-pidfile", kvmStateDir+domainName+"/pid")
 
-	if err := containerd.LKTaskPrepare(domainName, "xen-tools", &config, &status, qemuOverHead, args); err != nil {
+	if err := ctx.ctrdClient.LKTaskPrepare(domainName, "xen-tools", &config, &status, qemuOverHead, args); err != nil {
 		return logError("LKTaskPrepare failed for %s, (%v)", domainName, err)
 	}
 

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -329,7 +329,7 @@ type kvmContext struct {
 }
 
 func newKvm() Hypervisor {
-	ctrdCtx, err := initContainerd(true)
+	ctrdCtx, err := initContainerd()
 	if err != nil {
 		log.Fatalf("couldn't initialize containerd (this should not happen): %v. Exiting.", err)
 		return nil // it really never returns on account of above

--- a/pkg/pillar/hypervisor/kvm_test.go
+++ b/pkg/pillar/hypervisor/kvm_test.go
@@ -22,7 +22,7 @@ func initTest(t *testing.T) {
 		return
 	}
 	var err error
-	ctrdClient, err = containerd.NewContainerdClient(true)
+	ctrdClient, err = containerd.NewContainerdClient()
 	if err != nil {
 		t.Skipf("test must be run on a system with a functional containerd")
 	}

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -51,7 +51,7 @@ type xenContext struct {
 }
 
 func newXen() Hypervisor {
-	ctrdCtx, err := initContainerd(true)
+	ctrdCtx, err := initContainerd()
 	if err != nil {
 		log.Fatalf("couldn't initialize containerd (this should not happen): %v. Exiting.", err)
 		return nil // it really never returns on account of above

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -6,7 +6,6 @@ package hypervisor
 import (
 	"errors"
 	"fmt"
-	"github.com/lf-edge/eve/pkg/pillar/containerd"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/mem"
@@ -52,7 +51,7 @@ type xenContext struct {
 }
 
 func newXen() Hypervisor {
-	ctrdCtx, err := initContainerd()
+	ctrdCtx, err := initContainerd(true)
 	if err != nil {
 		log.Fatalf("couldn't initialize containerd (this should not happen): %v. Exiting.", err)
 		return nil // it really never returns on account of above
@@ -82,7 +81,7 @@ func (ctx xenContext) Setup(status types.DomainStatus, config types.DomainConfig
 	}
 
 	args := []string{"/etc/xen/scripts/xen-start", domainName, file.Name()}
-	if err := containerd.LKTaskPrepare(domainName, "xen-tools", &config, &status, 0, args); err != nil {
+	if err := ctx.ctrdClient.LKTaskPrepare(domainName, "xen-tools", &config, &status, 0, args); err != nil {
 		return logError("LKTaskPrepare failed for %s, (%v)", domainName, err)
 	}
 
@@ -412,7 +411,7 @@ func (ctx xenContext) Stop(domainName string, domainID int, force bool) error {
 	if force {
 		args = append(args, "-F")
 	}
-	stdOut, stdErr, err := containerd.CtrExec(domainName, args)
+	stdOut, stdErr, err := ctx.ctrdClient.CtrExec(domainName, args)
 	if err != nil {
 		log.Errorln("xl shutdown failed ", err)
 		log.Errorln("xl shutdown output ", stdOut, stdErr)
@@ -424,7 +423,7 @@ func (ctx xenContext) Stop(domainName string, domainID int, force bool) error {
 
 func (ctx xenContext) Delete(domainName string, domainID int) error {
 	log.Infof("xlDestroy %s %d\n", domainName, domainID)
-	stdOut, stdErr, err := containerd.CtrSystemExec("xen-tools",
+	stdOut, stdErr, err := ctx.ctrdClient.CtrSystemExec("xen-tools",
 		[]string{"xl", "destroy", domainName})
 	if err != nil {
 		log.Errorln("xl destroy failed ", err)
@@ -474,7 +473,7 @@ func (ctx xenContext) Info(domainName string, domainID int) (int, types.SwState,
 
 func (ctx xenContext) PCIReserve(long string) error {
 	log.Infof("pciAssignableAdd %s\n", long)
-	stdOut, stdErr, err := containerd.CtrSystemExec("xen-tools",
+	stdOut, stdErr, err := ctx.ctrdClient.CtrSystemExec("xen-tools",
 		[]string{"xl", "pci-assignable-add", long})
 	if err != nil {
 		errStr := fmt.Sprintf("xl pci-assignable-add failed: %s %s", stdOut, stdErr)
@@ -487,7 +486,7 @@ func (ctx xenContext) PCIReserve(long string) error {
 
 func (ctx xenContext) PCIRelease(long string) error {
 	log.Infof("pciAssignableRemove %s\n", long)
-	stdOut, stdErr, err := containerd.CtrSystemExec("xen-tools",
+	stdOut, stdErr, err := ctx.ctrdClient.CtrSystemExec("xen-tools",
 		[]string{"xl", "pci-assignable-rem", "-r", long})
 	if err != nil {
 		errStr := fmt.Sprintf("xl pci-assignable-rem failed: %s %s", stdOut, stdErr)
@@ -499,7 +498,7 @@ func (ctx xenContext) PCIRelease(long string) error {
 }
 
 func (ctx xenContext) GetHostCPUMem() (types.HostMemory, error) {
-	xlInfo, stderr, err := containerd.CtrSystemExec("xen-tools",
+	xlInfo, stderr, err := ctx.ctrdClient.CtrSystemExec("xen-tools",
 		[]string{"xl", "info"})
 	if err != nil {
 		log.Errorf("xl info failed %s %s falling back on Dom0 stats: %v", xlInfo, stderr, err)
@@ -549,7 +548,7 @@ func (ctx xenContext) GetHostCPUMem() (types.HostMemory, error) {
 func (ctx xenContext) GetDomsCPUMem() (map[string]types.DomainMetric, error) {
 	count := 0
 	counter := 0
-	xentopInfo, _, _ := containerd.CtrSystemExec("xen-tools",
+	xentopInfo, _, _ := ctx.ctrdClient.CtrSystemExec("xen-tools",
 		[]string{"xentop", "-b", "-d", "1", "-i", "2", "-f"})
 
 	splitXentopInfo := strings.Split(xentopInfo, "\n")

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -411,7 +411,9 @@ func (ctx xenContext) Stop(domainName string, domainID int, force bool) error {
 	if force {
 		args = append(args, "-F")
 	}
-	stdOut, stdErr, err := ctx.ctrdClient.CtrExec(domainName, args)
+	ctrdCtx, done := ctx.ctrdClient.CtrNewUserServicesCtx()
+	defer done()
+	stdOut, stdErr, err := ctx.ctrdClient.CtrExec(ctrdCtx, domainName, args)
 	if err != nil {
 		log.Errorln("xl shutdown failed ", err)
 		log.Errorln("xl shutdown output ", stdOut, stdErr)
@@ -423,7 +425,9 @@ func (ctx xenContext) Stop(domainName string, domainID int, force bool) error {
 
 func (ctx xenContext) Delete(domainName string, domainID int) error {
 	log.Infof("xlDestroy %s %d\n", domainName, domainID)
-	stdOut, stdErr, err := ctx.ctrdClient.CtrSystemExec("xen-tools",
+	ctrdSystemCtx, done := ctx.ctrdClient.CtrNewSystemServicesCtx()
+	defer done()
+	stdOut, stdErr, err := ctx.ctrdClient.CtrSystemExec(ctrdSystemCtx, "xen-tools",
 		[]string{"xl", "destroy", domainName})
 	if err != nil {
 		log.Errorln("xl destroy failed ", err)
@@ -473,7 +477,9 @@ func (ctx xenContext) Info(domainName string, domainID int) (int, types.SwState,
 
 func (ctx xenContext) PCIReserve(long string) error {
 	log.Infof("pciAssignableAdd %s\n", long)
-	stdOut, stdErr, err := ctx.ctrdClient.CtrSystemExec("xen-tools",
+	ctrdSystemCtx, done := ctx.ctrdClient.CtrNewSystemServicesCtx()
+	defer done()
+	stdOut, stdErr, err := ctx.ctrdClient.CtrSystemExec(ctrdSystemCtx, "xen-tools",
 		[]string{"xl", "pci-assignable-add", long})
 	if err != nil {
 		errStr := fmt.Sprintf("xl pci-assignable-add failed: %s %s", stdOut, stdErr)
@@ -486,7 +492,9 @@ func (ctx xenContext) PCIReserve(long string) error {
 
 func (ctx xenContext) PCIRelease(long string) error {
 	log.Infof("pciAssignableRemove %s\n", long)
-	stdOut, stdErr, err := ctx.ctrdClient.CtrSystemExec("xen-tools",
+	ctrdSystemCtx, done := ctx.ctrdClient.CtrNewSystemServicesCtx()
+	defer done()
+	stdOut, stdErr, err := ctx.ctrdClient.CtrSystemExec(ctrdSystemCtx, "xen-tools",
 		[]string{"xl", "pci-assignable-rem", "-r", long})
 	if err != nil {
 		errStr := fmt.Sprintf("xl pci-assignable-rem failed: %s %s", stdOut, stdErr)
@@ -498,7 +506,9 @@ func (ctx xenContext) PCIRelease(long string) error {
 }
 
 func (ctx xenContext) GetHostCPUMem() (types.HostMemory, error) {
-	xlInfo, stderr, err := ctx.ctrdClient.CtrSystemExec("xen-tools",
+	ctrdSystemCtx, done := ctx.ctrdClient.CtrNewSystemServicesCtx()
+	defer done()
+	xlInfo, stderr, err := ctx.ctrdClient.CtrSystemExec(ctrdSystemCtx, "xen-tools",
 		[]string{"xl", "info"})
 	if err != nil {
 		log.Errorf("xl info failed %s %s falling back on Dom0 stats: %v", xlInfo, stderr, err)
@@ -548,7 +558,9 @@ func (ctx xenContext) GetHostCPUMem() (types.HostMemory, error) {
 func (ctx xenContext) GetDomsCPUMem() (map[string]types.DomainMetric, error) {
 	count := 0
 	counter := 0
-	xentopInfo, _, _ := ctx.ctrdClient.CtrSystemExec("xen-tools",
+	ctrdSystemCtx, done := ctx.ctrdClient.CtrNewSystemServicesCtx()
+	defer done()
+	xentopInfo, _, _ := ctx.ctrdClient.CtrSystemExec(ctrdSystemCtx, "xen-tools",
 		[]string{"xentop", "-b", "-d", "1", "-i", "2", "-f"})
 
 	splitXentopInfo := strings.Split(xentopInfo, "\n")

--- a/pkg/pillar/zboot/zboot.go
+++ b/pkg/pillar/zboot/zboot.go
@@ -353,7 +353,10 @@ func WriteToPartition(log *base.LogObject, image string, partName string) error 
 
 	defer casClient.CloseClient()
 
-	resolver, err := casClient.Resolver()
+	ctrdCtx, done := casClient.CtrNewUserServicesCtx()
+	defer done()
+
+	resolver, err := casClient.Resolver(ctrdCtx)
 	if err != nil {
 		errStr := fmt.Sprintf("error getting CAS resolver: %v", err)
 		log.Error(errStr)


### PR DESCRIPTION
Changes that are done as part of this PR are on top of #1535
Issue 1: A common/global containerd client was shared among all instances of CAS objects. This led to CAS objects unable to access containerd APIs if one of those objects closed the containerd client.

Fix 1 (done as part of #1535): Creating new containerd client for each CAS objects so that each CAS object can close their respective containerd clients without affecting other CAS objects. 

Issue 2: We used a common containerd context for all containerd API calls. This led to "context cancelled" errors while calling few containerd APIs.

Fix 2: All containerd APIs will expect a context to be passed to it by the caller and it's the responsibility of the caller to create new context -> call containerd APIs with that new context -> cancel the context after use. 
