### PR TITLE
containerd 1.4.1 ; linuxkit/init update

### DIFF
--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -2,9 +2,9 @@ kernel:
   image: KERNEL_TAG
   cmdline: "rootdelay=3"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
-  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
+  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
   - linuxkit/getty:v0.5
   - linuxkit/memlogd:v0.5
   - GRUB_TAG


### PR DESCRIPTION
Two changes:

* bumps the `linuxkit/sshd` version to the latest. The only real difference is that this one includes `openssh-client` package, so you can `ssh` from within the device, as well as `scp` from and to the device
* bumps the `linuxkit/containerd` version to the latest. This bumps the containerd version to 1.4.1, which has better memory management (among other things)

Unclear if this will resolve the "many goroutines" question, but it is something we have wanted to do anyways.