### PR TITLE
Fixing size mismatch issue while loading in CAS

### DIFF
--- a/pkg/pillar/cmd/volumemgr/blob.go
+++ b/pkg/pillar/cmd/volumemgr/blob.go
@@ -55,7 +55,10 @@ func downloadBlob(ctx *volumemgrContext, objType string, blob *types.BlobStatus)
 		blob.State = ds.State
 		changed = true
 	}
-	if blob.TotalSize != ds.TotalSize || blob.CurrentSize != ds.CurrentSize {
+	if blob.TotalSize != ds.TotalSize ||
+		blob.CurrentSize != ds.CurrentSize ||
+		blob.Size != ds.Size {
+		blob.Size = ds.Size
 		blob.TotalSize = ds.TotalSize
 		blob.CurrentSize = ds.CurrentSize
 		if blob.TotalSize > 0 {


### PR DESCRIPTION
Need to update ```Size``` in ```BlobStatus``` from ```DownloaderStatus```

Issue is ```CtrWriteBlob: Exception while writing blob: sha256:aa9c8a29b7f5610407e782b5d9497743c7dd17f258fdbcc2c96496bcec5d4785. failed commit on ref \"sha256:aa9c8a29b7f5610407e782b5d9497743c7dd17f258fdbcc2c96496bcec5d4785\": commit failed: \"sha256:aa9c8a29b7f5610407e782b5d9497743c7dd17f258fdbcc2c96496bcec5d4785\" failed size validation: 346816512 != 367788032: failed precondition```