### PR TITLE
Fixing content tree state in info message

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -964,6 +964,9 @@ func PublishContentInfoToZedCloud(ctx *zedagentContext, uuid string,
 	if ctStatus != nil {
 		ReportContentInfo.DisplayName = ctStatus.DisplayName
 		ReportContentInfo.State = ctStatus.State.ZSwState()
+		if ctStatus.Error != "" && ctStatus.State == types.LOADING {
+			ReportContentInfo.State = info.ZSwState_DOWNLOADED
+		}
 
 		if !ctStatus.ErrorTime.IsZero() {
 			errInfo := encodeErrorInfo(

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -964,9 +964,6 @@ func PublishContentInfoToZedCloud(ctx *zedagentContext, uuid string,
 	if ctStatus != nil {
 		ReportContentInfo.DisplayName = ctStatus.DisplayName
 		ReportContentInfo.State = ctStatus.State.ZSwState()
-		if ctStatus.Error != "" && ctStatus.State == types.LOADING {
-			ReportContentInfo.State = info.ZSwState_DOWNLOADED
-		}
 
 		if !ctStatus.ErrorTime.IsZero() {
 			errInfo := encodeErrorInfo(

--- a/pkg/pillar/types/types.go
+++ b/pkg/pillar/types/types.go
@@ -111,9 +111,9 @@ func (state SwState) ZSwState() info.ZSwState {
 		return info.ZSwState_RESOLVED_TAG
 	case DOWNLOADING:
 		return info.ZSwState_DOWNLOAD_STARTED
-	case DOWNLOADED, VERIFYING:
+	case DOWNLOADED, VERIFYING, VERIFIED, LOADING:
 		return info.ZSwState_DOWNLOADED
-	case VERIFIED, LOADING, LOADED:
+	case LOADED:
 		return info.ZSwState_DELIVERED
 	case CREATING_VOLUME:
 		return info.ZSwState_CREATING_VOLUME


### PR DESCRIPTION
EVE shouldn't report state ```Delivered``` if we get an error while loading the content tree in CAS.