### PR TITLE
fix version output and enable debugging

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -34,10 +34,10 @@ jobs:
       - name: run
         run: |
           ./eden config add default
-          ./eden config set default --key eve.tag --value=$(make -C eve version)
+          ./eden config set default --key eve.tag --value=$(make -s -C eve version)
           ./eden config set default --key=eve.accel --value=false
           echo > tests/workflow/testdata/eden_stop.txt
-          ./eden test ./tests/workflow
+          ./eden test ./tests/workflow -v debug || (./eden log --format json > trace.log; exit 1)
           ./eden log --format json > trace.log
       - name: Store raw test results
         if: ${{ always() }}

--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -37,8 +37,10 @@ jobs:
           ./eden config set default --key eve.tag --value=$(make -s -C eve version)
           ./eden config set default --key=eve.accel --value=false
           echo > tests/workflow/testdata/eden_stop.txt
-          ./eden test ./tests/workflow -v debug || (./eden log --format json > trace.log; exit 1)
-          ./eden log --format json > trace.log
+          ./eden test ./tests/workflow -v debug 
+      - name: Collect logs
+         if: ${{ always() }}
+         run: ./eden log --format json > trace.log
       - name: Store raw test results
         if: ${{ always() }}
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Seems, that `make -C eve version` provides additional output:
```
giggsoff@giggsoff-PC:~/go/src$ make -C eve version
make: Entering directory '/home/giggsoff/go/src/eve'
0.0.0-actions-test-10ab1e58
make: Leaving directory '/home/giggsoff/go/src/eve'
```

Also, I add `debug` flag for verbosity and add logs in case of errors inside tests.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>