### PR TITLE
Switching to the Kernel 5.4.x across the board

### DIFF
--- a/images/rootfs-acrn.yml.in.patch
+++ b/images/rootfs-acrn.yml.in.patch
@@ -2,7 +2,7 @@
 +++ images/rootfs-acrn.yml.in	2020-04-08 18:22:10.000000000 -0700
 @@ -1,5 +1,5 @@
  kernel:
--  image: KERNEL_TAG
+-  image: NEW_KERNEL_TAG
 +  image: ACRN_KERNEL_TAG
    cmdline: "rootdelay=3"
  init:

--- a/images/rootfs-kvm-rpi.yml.in.patch
+++ b/images/rootfs-kvm-rpi.yml.in.patch
@@ -1,1 +1,0 @@
-rootfs-rpi-kvm.yml.in.patch

--- a/images/rootfs-kvm.yml.in.patch
+++ b/images/rootfs-kvm.yml.in.patch
@@ -1,9 +1,0 @@
---- images/rootfs.yml.in	2020-04-08 18:14:23.000000000 -0700
-+++ images/rootfs-kvm.yml.in	2020-04-08 18:19:53.000000000 -0700
-@@ -1,5 +1,5 @@
- kernel:
--  image: KERNEL_TAG
-+  image: NEW_KERNEL_TAG
-   cmdline: "rootdelay=3"
- init:
-   - linuxkit/init:v0.5

--- a/images/rootfs-rpi-kvm.yml.in.patch
+++ b/images/rootfs-rpi-kvm.yml.in.patch
@@ -1,9 +1,0 @@
---- images/rootfs.yml.in	2020-04-08 18:14:23.000000000 -0700
-+++ images/rootfs-rpi.yml.in	2020-04-08 18:19:53.000000000 -0700
-@@ -1,5 +1,5 @@
- kernel:
--  image: KERNEL_TAG
-+  image: NEW_KERNEL_TAG
-   cmdline: "rootdelay=3"
- init:
-   - linuxkit/init:v0.5

--- a/images/rootfs-rpi-xen.yml.in.patch
+++ b/images/rootfs-rpi-xen.yml.in.patch
@@ -1,1 +1,0 @@
-rootfs-rpi.yml.in.patch

--- a/images/rootfs-rpi.yml.in.patch
+++ b/images/rootfs-rpi.yml.in.patch
@@ -1,9 +1,0 @@
---- images/rootfs.yml.in	2020-04-08 18:14:23.000000000 -0700
-+++ images/rootfs-rpi.yml.in	2020-04-08 18:19:53.000000000 -0700
-@@ -1,5 +1,5 @@
- kernel:
--  image: KERNEL_TAG
-+  image: NEW_KERNEL_TAG
-   cmdline: "rootdelay=3"
- init:
-   - linuxkit/init:v0.5

--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -1,5 +1,5 @@
 kernel:
-  image: KERNEL_TAG
+  image: NEW_KERNEL_TAG
   cmdline: "rootdelay=3"
 init:
   - linuxkit/init:v0.5


### PR DESCRIPTION
We've always wanted to switch to 5.4.x across the board at some point in October 2020, but it looks like that point is now. Keep in mind that we've already been running tests for at least a mont with 5.4.x being the default kernel in KVM mode, this PR simply makes it so in Xen mode as well.

The biggest driving factor to bite the bullet and do it now are:
   * we have a blocking issues with ext4/fscrypt that can only be reproduced in 4.19 kernel
   * we need newer kernel to enable qemu disk direct mapping qemu backend for disk performance