### PR TITLE
4M buffer in ledmanager is the largest single allocation

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -373,6 +373,22 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
 
+		case <-publishTimer.C:
+			start := time.Now()
+			metrics, pids := gatherProcessMetricList(&domainCtx)
+			for _, m := range metrics {
+				publishProcessMetric(&domainCtx, &m)
+			}
+			unpublishRemovedPids(&domainCtx, domainCtx.pids, pids)
+			domainCtx.pids = pids
+			ps.CheckMaxTimeTopic(agentName, "publishProcesses", start,
+				warningTime, errorTime)
+			// XXX temporary until controller reports metrics
+			switch logger.GetLevel() {
+			case logrus.TraceLevel, logrus.DebugLevel:
+				dumpProcessMetricList(metrics)
+			}
+
 		case <-stillRunning.C:
 		}
 		ps.StillRunning(agentName, warningTime, errorTime)
@@ -393,6 +409,22 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		select {
 		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
+
+		case <-publishTimer.C:
+			start := time.Now()
+			metrics, pids := gatherProcessMetricList(&domainCtx)
+			for _, m := range metrics {
+				publishProcessMetric(&domainCtx, &m)
+			}
+			unpublishRemovedPids(&domainCtx, domainCtx.pids, pids)
+			domainCtx.pids = pids
+			ps.CheckMaxTimeTopic(agentName, "publishProcesses", start,
+				warningTime, errorTime)
+			// XXX temporary until controller reports metrics
+			switch logger.GetLevel() {
+			case logrus.TraceLevel, logrus.DebugLevel:
+				dumpProcessMetricList(metrics)
+			}
 
 		case <-stillRunning.C:
 		}
@@ -420,6 +452,22 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 		case change := <-subDeviceNetworkStatus.MsgChan():
 			subDeviceNetworkStatus.ProcessChange(change)
+
+		case <-publishTimer.C:
+			start := time.Now()
+			metrics, pids := gatherProcessMetricList(&domainCtx)
+			for _, m := range metrics {
+				publishProcessMetric(&domainCtx, &m)
+			}
+			unpublishRemovedPids(&domainCtx, domainCtx.pids, pids)
+			domainCtx.pids = pids
+			ps.CheckMaxTimeTopic(agentName, "publishProcesses", start,
+				warningTime, errorTime)
+			// XXX temporary until controller reports metrics
+			switch logger.GetLevel() {
+			case logrus.TraceLevel, logrus.DebugLevel:
+				dumpProcessMetricList(metrics)
+			}
 
 		case <-stillRunning.C:
 		}
@@ -458,6 +506,22 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 		case change := <-subPhysicalIOAdapter.MsgChan():
 			subPhysicalIOAdapter.ProcessChange(change)
+
+		case <-publishTimer.C:
+			start := time.Now()
+			metrics, pids := gatherProcessMetricList(&domainCtx)
+			for _, m := range metrics {
+				publishProcessMetric(&domainCtx, &m)
+			}
+			unpublishRemovedPids(&domainCtx, domainCtx.pids, pids)
+			domainCtx.pids = pids
+			ps.CheckMaxTimeTopic(agentName, "publishProcesses", start,
+				warningTime, errorTime)
+			// XXX temporary until controller reports metrics
+			switch logger.GetLevel() {
+			case logrus.TraceLevel, logrus.DebugLevel:
+				dumpProcessMetricList(metrics)
+			}
 
 		// Run stillRunning since we waiting for zedagent to deliver
 		// PhysicalIO which depends on cloud connectivity

--- a/pkg/pillar/cmd/ledmanager/ledmanager.go
+++ b/pkg/pillar/cmd/ledmanager/ledmanager.go
@@ -414,7 +414,7 @@ func InitDellCmd(ledName string) {
 
 // Keep avoid allocation and GC by keeping one buffer
 var (
-	bufferLength = int64(4194304) //4M buffer length
+	bufferLength = int64(256 * 1024) //256k buffer length
 	readBuffer   []byte
 )
 
@@ -428,7 +428,7 @@ func InitDDCmd(ledName string) {
 	log.Infof("InitDDCmd using disk %s", disk)
 	readBuffer = make([]byte, bufferLength)
 	diskDevice = "/dev/" + disk
-	count := 100
+	count := 100 * 16
 	// Prime before measuring
 	uncachedDiskRead(count)
 	uncachedDiskRead(count)
@@ -445,7 +445,7 @@ func InitDDCmd(ledName string) {
 	if count == 0 {
 		count = 1
 	}
-	log.Infof("Measured %v; count %d", elapsed, count)
+	log.Noticef("Measured %v; count %d", elapsed, count)
 	ddCount = count
 }
 

--- a/pkg/pillar/cmd/ledmanager/ledmanager.go
+++ b/pkg/pillar/cmd/ledmanager/ledmanager.go
@@ -412,6 +412,12 @@ func InitDellCmd(ledName string) {
 	log.Warnf("Failed to enable Dell Cloud LED: %v", err)
 }
 
+// Keep avoid allocation and GC by keeping one buffer
+var (
+	bufferLength = int64(4194304) //4M buffer length
+	readBuffer   []byte
+)
+
 // InitDDCmd determines the disk (using the largest disk) and measures
 // the repetition count to get to 200ms dd time.
 func InitDDCmd(ledName string) {
@@ -420,6 +426,7 @@ func InitDDCmd(ledName string) {
 		return
 	}
 	log.Infof("InitDDCmd using disk %s", disk)
+	readBuffer = make([]byte, bufferLength)
 	diskDevice = "/dev/" + disk
 	count := 100
 	// Prime before measuring
@@ -453,9 +460,7 @@ func ExecuteDDCmd(ledName string) {
 }
 
 func uncachedDiskRead(count int) {
-	bufferLength := int64(4194304) //4M buffer length
 	offset := int64(0)
-	data := make([]byte, bufferLength) //4M buffer
 	handler, err := os.Open(diskDevice)
 	if err != nil {
 		err = fmt.Errorf("uncachedDiskRead: Failed on open: %s", err)
@@ -465,12 +470,12 @@ func uncachedDiskRead(count int) {
 	defer handler.Close()
 	for i := 0; i < count; i++ {
 		unix.Fadvise(int(handler.Fd()), offset, bufferLength, 4) // 4 == POSIX_FADV_DONTNEED
-		readBytes, err := handler.Read(data)
+		readBytes, err := handler.Read(readBuffer)
 		if err != nil {
 			err = fmt.Errorf("uncachedDiskRead: Failed on read: %s", err)
 			log.Error(err.Error())
 		}
-		syscall.Madvise(data, 4) // 4 == MADV_DONTNEED
+		syscall.Madvise(readBuffer, 4) // 4 == MADV_DONTNEED
 		log.Debugf("uncachedDiskRead: size: %d", readBytes)
 		if int64(readBytes) < bufferLength {
 			log.Debugf("uncachedDiskRead: done")


### PR DESCRIPTION
so let's make it smaller.

Need to verify the blinking on an actual device with a disk LED.