### PR TITLE
Restoring installer's ability to offer an emergency *interactive* shell

### DIFF
--- a/pkg/mkimage-raw-efi/install
+++ b/pkg/mkimage-raw-efi/install
@@ -75,6 +75,18 @@ if [ ! -e /dev/root ]; then
    DEV_INIT="$(cd /media || exit 1 ; echo */rootfs.img | sed -e 's#/.*$##')"
    ln -s "/media/$DEV_INIT" /bits
    ln -s "/dev/$DEV_INIT" /dev/root
+
+   # FIXME: we need to run one thing from the install image to seed
+   # the random generator for sgdisk invocatin via make-raw. We also
+   # use this opportunity to make sure that USB keyboard is functional
+   # for any kind of debugging we may need to do. This needs to go away
+   # soon as part of the overall restructuring of
+   # /install vs. make-raw vs. /init
+   mkdir -p /mnt || :
+   mount -o ro /bits/rootfs.img /mnt &&
+      /mnt/containers/onboot/*rngd/rootfs/sbin/rngd -1
+   mount --bind /mnt/lib/modules /lib/modules &&
+      modprobe usbhid && modprobe usbkbd
 fi
 
 # lets see if we're told on which disk to install...
@@ -112,14 +124,6 @@ grep -q eve_install_skip_config /proc/cmdline && trunc /parts/persist.img
 
 # we may be asked to pause before install procedure
 grep -q eve_pause_before_install /proc/cmdline && pause "formatting the /dev/$INSTALL_DEV"
-
-# FIXME: we need to run one thing from the install image to seed
-# the random generator for sgdisk invocatin via make-raw. This
-# needs to go away soon as part of the overall restructuring of
-# /install vs. make-raw vs. /init
-mkdir -p /mnt || :
-mount -o ro /parts/rootfs.img /mnt &&
-   /mnt/containers/onboot/*rngd/rootfs/sbin/rngd -1
 
 # do the install (unless we're only here to collect the black box)
 grep -q eve_blackbox /proc/cmdline || /make-raw "/dev/$INSTALL_DEV" || bail "Installation failed. Entering shell..."


### PR DESCRIPTION
This is a pretty mechanical change in our installer that makes it possible to have an interactive shell on a box for the installer.

This, of course, is very useful if your installer fails, etc.