### PR TITLE
Adding birth version ID to /config partition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,7 +307,7 @@ $(SSH_KEY):
 	mv $@.pub $(CONF_DIR)/authorized_keys
 
 $(CONFIG_IMG): $(CONF_FILES) | $(INSTALLER)
-	./tools/makeconfig.sh $@ $(CONF_FILES)
+	./tools/makeconfig.sh $@ "$(ROOTFS_VERSION)" $(CONF_FILES)
 
 $(PERSIST_IMG): | $(INSTALLER)
 	# 1M of zeroes should be enough to trigger filesystem wipe on first boot

--- a/pkg/mkconf/make-config
+++ b/pkg/mkconf/make-config
@@ -13,6 +13,9 @@ CONFIG_SIZE_KB=1024
 # Traverse /conf to a point where we either see multiple files or no subdirectories
 (cd /conf; while cd "$(echo ./*)" >/dev/null 2>&1 ; do true ; done ; cp -r ./* /conf ; rm -rf /conf/raw)
 
+# Add a version ID
+touch "/conf/origin.$(date +'%Y-%m-%d').$ROOTFS_VERSION"
+
 #
 # Create Config image
 #

--- a/tools/makeconfig.sh
+++ b/tools/makeconfig.sh
@@ -1,22 +1,23 @@
 #!/bin/sh
 # Usage:
 #
-#      ./makeconfig.sh <output.img> [list of config files]
+#      ./makeconfig.sh <output.img> <version> [list of config files]
 #
 EVE="$(cd "$(dirname "$0")" && pwd)/../"
 PATH="$EVE/build-tools/bin:$PATH"
 MKCONFIG_TAG="$(linuxkit pkg show-tag "$EVE/pkg/mkconf")"
 IMAGE="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+ROOTFS_VERSION="$2"
 
-if [ $# -lt 2 ]; then
-   echo "Usage: $0 <output.img> [list of config files]"
+if [ $# -lt 3 ]; then
+   echo "Usage: $0 <output.img> <version> [list of config files]"
    exit 1
 fi
 
-shift
+shift 2
 
 : > "$IMAGE"
-(tar -chf - "$@") | docker run -i -e ZARCH -v "$IMAGE:/config.img" "${MKCONFIG_TAG}" /config.img
+(tar -chf - "$@") | docker run -i -e ROOTFS_VERSION="$ROOTFS_VERSION" -e ZARCH="$ZARCH" -v "$IMAGE:/config.img" "${MKCONFIG_TAG}" /config.img
 
 if [ ! -s "$IMAGE" ]; then
    echo "$IMAGE was not written."


### PR DESCRIPTION
This add a subtle but very useful (at least at times!) functionality of tagging /config partition with a *birth* version of EVE. Note that this *birth* version is what an installer would use and stamp it into /config on the device. Since /config is mostly readonly (well not really 100% yet -- but we're working on it) this version is never going to change regardless of how many baseOS updates you do. This, in turn, helps you get at least a basic idea of what release things like /persist originated from (and that in turn helps a great deal with debugging when /persist gets into a weird state).

I feel this is pretty useful, but I couldn't come up with a better name than `version` for the file. Any suggestions that would communicate that it is a birth version would be appreciated.