### PR TITLE
Introduce /config/server.override; commit to it if/when test complete 

### DIFF
--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -226,11 +226,11 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	ticker := flextimer.NewExpTicker(time.Second, maxDelay, 0.0)
 
 	// XXX redo in ticker case to handle change to servername?
-	server, err := ioutil.ReadFile(types.ServerFileName)
+	snp, err := zedcloud.GetServerNameAndPort(log)
 	if err != nil {
 		log.Fatal(err)
 	}
-	serverNameAndPort = strings.TrimSpace(string(server))
+	serverNameAndPort = snp
 	serverName := strings.Split(serverNameAndPort, ":")[0]
 
 	var onboardCert tls.Certificate

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -12,7 +12,6 @@ import (
 	"encoding/base64"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"mime"
 	"net"
 	"net/http"
@@ -145,11 +144,11 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	ctx.subGlobalConfig = subGlobalConfig
 	subGlobalConfig.Activate()
 
-	server, err := ioutil.ReadFile(types.ServerFileName)
+	snp, err := zedcloud.GetServerNameAndPort(log)
 	if err != nil {
 		log.Fatal(err)
 	}
-	ctx.serverNameAndPort = strings.TrimSpace(string(server))
+	ctx.serverNameAndPort = snp
 	ctx.serverName = strings.Split(ctx.serverNameAndPort, ":")[0]
 
 	zedcloudCtx := zedcloud.NewContext(log, zedcloud.ContextOptions{

--- a/pkg/pillar/cmd/logmanager/logmanager.go
+++ b/pkg/pillar/cmd/logmanager/logmanager.go
@@ -1017,13 +1017,10 @@ func sendProtoStrForAppLogs(appUUID string, appLogs *logs.AppInstanceLogBundle,
 		appLogURL = fmt.Sprintf("apps/instances/id/%s/logs", appUUID)
 	}
 	//get server name
-	serverBytes, err := ioutil.ReadFile(types.ServerFileName)
+	serverNameAndPort, err := zedcloud.GetServerNameAndPort(log)
 	if err != nil {
-		log.Fatalf("Failed to read ServerFileName (%s). Err: %s",
-			types.ServerFileName, err)
+		log.Fatal(err)
 	}
-	// Preserve port
-	serverNameAndPort := strings.TrimSpace(string(serverBytes))
 	appLogsURL := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API,
 		devUUID, appLogURL)
 
@@ -1084,14 +1081,10 @@ func isResp4xx(code int) bool {
 }
 
 func sendCtxInit(ctx *logmanagerContext, dnsCtx *DNSContext) {
-	//get server name
-	bytes, err := ioutil.ReadFile(types.ServerFileName)
+	serverNameAndPort, err := zedcloud.GetServerNameAndPort(log)
 	if err != nil {
-		log.Fatalf("sendCtxInit: Failed to read ServerFileName(%s). Err: %s",
-			types.ServerFileName, err)
+		log.Fatalf("sendCtxInit: %s", err)
 	}
-	// Preserve port
-	serverNameAndPort := strings.TrimSpace(string(bytes))
 	serverName = strings.Split(serverName, ":")[0]
 
 	//set log url

--- a/pkg/pillar/cmd/nodeagent/handlebaseos.go
+++ b/pkg/pillar/cmd/nodeagent/handlebaseos.go
@@ -7,7 +7,9 @@ package nodeagent
 
 import (
 	"fmt"
+
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/lf-edge/eve/pkg/pillar/zedcloud"
 )
 
 // baseos upgrade installation path
@@ -67,6 +69,8 @@ func doZbootBaseOsTestValidationComplete(ctxPtr *nodeagentContext,
 		log.Debugf("%s: not TestComplete", key)
 		return
 	}
+	// In case we were using an override server file, commit to it
+	zedcloud.CommitServerNameAndPort(log)
 	config := lookupZbootConfig(ctxPtr, status.PartitionLabel)
 	if config == nil || ctxPtr.updateComplete {
 		return

--- a/pkg/pillar/cmd/nodeagent/handletimers.go
+++ b/pkg/pillar/cmd/nodeagent/handletimers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/zboot"
+	"github.com/lf-edge/eve/pkg/pillar/zedcloud"
 )
 
 // node health timer funcions
@@ -63,6 +64,8 @@ func handleFallbackOnCloudDisconnect(ctxPtr *nodeagentContext) {
 		errStr := fmt.Sprintf("Exceeded fallback outage for cloud connectivity %d by %d seconds; rebooting\n",
 			fallbackLimit, timePassed-fallbackLimit)
 		log.Errorf(errStr)
+		// In case we were using an override server file, abandon it
+		zedcloud.AbandonServerNameAndPort(log)
 		scheduleNodeReboot(ctxPtr, errStr)
 	} else {
 		log.Infof("handleFallbackOnCloudDisconnect %d seconds remaining",

--- a/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
+++ b/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
@@ -146,12 +146,11 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	}
 	wscCtx.subAppInstanceConfig = subAppInstanceConfig
 
-	//get server name
-	bytes, err := ioutil.ReadFile(types.ServerFileName)
+	snp, err := zedcloud.GetServerNameAndPort(log)
 	if err != nil {
 		log.Fatal(err)
 	}
-	wscCtx.serverNameAndPort = strings.TrimSpace(string(bytes))
+	wscCtx.serverNameAndPort = snp
 
 	subAppInstanceConfig.Activate()
 

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -73,11 +73,11 @@ var nilUUID uuid.UUID
 func handleConfigInit(networkSendTimeout uint32) *zedcloud.ZedCloudContext {
 
 	// get the server name
-	bytes, err := ioutil.ReadFile(types.ServerFileName)
+	snp, err := zedcloud.GetServerNameAndPort(log)
 	if err != nil {
 		log.Fatal(err)
 	}
-	serverNameAndPort = strings.TrimSpace(string(bytes))
+	serverNameAndPort = snp
 	serverName = strings.Split(serverNameAndPort, ":")[0]
 
 	zedcloudCtx := zedcloud.NewContext(log, zedcloud.ContextOptions{

--- a/pkg/pillar/cmd/zedrouter/probe.go
+++ b/pkg/pillar/cmd/zedrouter/probe.go
@@ -8,7 +8,6 @@ package zedrouter
 import (
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"strings"
 	"sync"
@@ -591,10 +590,7 @@ func infoUpCount(info types.ProbeInfo) int {
 func getSystemURL() string {
 	var remoteURL string
 	if serverNameAndPort == "" {
-		server, err := ioutil.ReadFile(types.ServerFileName)
-		if err == nil {
-			serverNameAndPort = strings.TrimSpace(string(server))
-		}
+		serverNameAndPort, _ = zedcloud.GetServerNameAndPort(log)
 	}
 	if serverNameAndPort != "" {
 		remoteURL = serverNameAndPort

--- a/pkg/pillar/devicenetwork/devicenetwork.go
+++ b/pkg/pillar/devicenetwork/devicenetwork.go
@@ -96,11 +96,10 @@ func VerifyDeviceNetworkStatus(log *base.LogObject, status types.DeviceNetworkSt
 	// Map of per-interface errors
 	intfStatusMap := *types.NewIntfStatusMap()
 
-	server, err := ioutil.ReadFile(types.ServerFileName)
+	serverNameAndPort, err := zedcloud.GetServerNameAndPort(log)
 	if err != nil {
 		log.Fatal(err)
 	}
-	serverNameAndPort := strings.TrimSpace(string(server))
 	serverName := strings.Split(serverNameAndPort, ":")[0]
 
 	zedcloudCtx := zedcloud.NewContext(log, zedcloud.ContextOptions{

--- a/pkg/pillar/types/locationconsts.go
+++ b/pkg/pillar/types/locationconsts.go
@@ -30,8 +30,6 @@ const (
 	IdentityDirname = "/config"
 	// SelfRegFile - name of self-register-filed file
 	SelfRegFile = IdentityDirname + "/self-register-failed"
-	// ServerFileName - server file
-	ServerFileName = IdentityDirname + "/server"
 	// DeviceCertName - device certificate
 	DeviceCertName = IdentityDirname + "/device.cert.pem"
 	// DeviceKeyName - device private key (if not in TPM)

--- a/pkg/pillar/zedcloud/tls.go
+++ b/pkg/pillar/zedcloud/tls.go
@@ -105,6 +105,12 @@ func CommitServerNameAndPort(log *base.LogObject) {
 	}
 }
 
+// AbandonServerNameAndPort checks if we have a /config/server.override
+// and deletes it so it doesn't cause confusion down the road
+func AbandonServerNameAndPort(log *base.LogObject) {
+	os.Remove(overrideServerFileName)
+}
+
 // GetTlsConfig creates and returns a TlsConfig based on current root CA certificates
 // If a server arg is specified it overrides the serverFilename content.
 // If a clientCert is specified it overrides the device*Name files.


### PR DESCRIPTION
In the near future we will have some zedcloud redirection service to handle the case that an edge-node might need to point at different controller over time. That will be the subject of a larger discussion.

However, in the meantime we need to manually move deployed edge-nodes to use a different controller/server. This PR provides a way to do that without having ssh access to the device (hence a manual change of /config/server is not possible) and also provides fallback should the change edge-node not be able to reach the new specified controller/server.

Approach
To perform the move one needs to build a special image and update the edge-node to run that special EVE image.
That image has (in addition to the code in this PR) code e.g., in device-steps.sh to write the new server to the /config/server.override file.

Theedge-node then goes through a two-phase commit:
1. The various EVE services are modified by this PR to look for the /config/server.override and prefer that over /config/server. 
2. Once nodeagent commits to the new image (meaning it could communicate to the controller and didn't crash or hang) this PR adds code to rename /config/server.override to /config/server. But if it fails to do that code in nodeagent deletes /config/server.override before doing the fallback to the other image.

Thus if the device fails to reach the new controller, then the normal EVE fallback of not being able to reach zedcloud in 10 minutes will kick in and the edge-node will revert back to the old image. Otherwise it will continue with the new image and can be updated to any other image since /config/server now contains the new clontroller.

Example of how to build the special image:
Put code like this code at the top of device-steps.sh:
echo "$(date -Ins -u) Try switching to different server"
echo "zedcloud.xyzzy.zededa.net" >/config/server.override
