### PR TITLE
liburing that is recently pulled into xen-tools seems to require libuuid

### DIFF
--- a/pkg/xen-tools/Dockerfile.in
+++ b/pkg/xen-tools/Dockerfile.in
@@ -99,7 +99,8 @@ RUN apk add --no-cache \
     yajl=2.1.0-r1      \
     keyutils=1.6.1-r1 \
     libusb=1.0.23-r0   \
-    xz-libs=5.2.5-r0
+    xz-libs=5.2.5-r0 \
+    libuuid=2.35.2-r0
 RUN if [ "$(uname -m)" = "aarch64" ]; then apk add --no-cache libfdt=1.6.0-r0 ;fi
 COPY --from=kernel-build /out/ /
 COPY --from=uefi-build /OVMF.fd /usr/lib/xen/boot/ovmf.bin


### PR DESCRIPTION

This is the failure seen in this case.

Error loading shared library libuuid.so.1: No such file or directory (needed by /usr/lib/libxenlight.so.4.14)
Error relocating /usr/lib/libxenlight.so.4.14: uuid_generate: symbol not found
Error relocating /usr/lib/libxenlight.so.4.14: uuid_is_null: symbol not found
Error relocating /usr/lib/libxenlight.so.4.14: uuid_clear: symbol not found
Error relocating /usr/lib/libxenlight.so.4.14: uuid_parse: symbol not found
Error relocating /usr/lib/libxenlight.so.4.14: uuid_compare: symbol not found
Error relocating /usr/lib/libxenlight.so.4.14: uuid_copy: symbol not found

Signed-off-by: Gopi krishna Kodali <gkodali@zededa.com>