### PR TITLE
pv for container

### DIFF
--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -120,6 +120,9 @@ func (ctx xenContext) CreateDomConfig(domainName string, config types.DomainConf
 	}
 
 	if config.IsContainer {
+		if config.VirtualizationMode == types.PV {
+			xen_type = "pv"
+		}
 		kernel = "/hostfs/boot/kernel"
 		ramdisk = "/usr/lib/xen/boot/runx-initrd"
 		extra = extra + " root=9p-xen dhcp=1"


### PR DESCRIPTION
Seems that we cannot run pvh on EVE without acceleration.
```
linuxkit-525400123456:/# xl info|grep virt_caps
virt_caps              : pv shadow
```

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>