### PR TITLE
App and App's network stability improvement.

### DIFF
--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -469,7 +469,7 @@ func (ctx xenContext) Info(domainName string, domainID int) (int, types.SwState,
 	effectiveDomainState, matched := stateMap[strings.TrimSpace(string(status))]
 	if !matched {
 		return effectiveDomainID, types.BROKEN, fmt.Errorf("info: domain %s reported to be in unexpected state %v",
-			domainName, status)
+			domainName, string(status))
 	}
 
 	return effectiveDomainID, effectiveDomainState, nil

--- a/pkg/xen-tools/initrd/udhcpc_script.sh
+++ b/pkg/xen-tools/initrd/udhcpc_script.sh
@@ -17,6 +17,7 @@ mkdir -p /mnt/rootfs/etc
 CFG="/mnt/rootfs/etc/udhcpc.${interface}.cfg"
 
 RESOLV_CONF='/mnt/rootfs/etc/resolv.conf'
+RESOLV_OPTIONS="rotate timeout:10 attempts:5"
 
 # interface for which DNS is to be configured
 PEERDNS_IF=eth0
@@ -84,10 +85,13 @@ case "$1" in
     [ -n "$router" ] && [ -n "$staticroutes" ] && install_classless_routes $staticroutes
     # setup dns
     if [ "$interface" == "$PEERDNS_IF" ] ; then
+      # remove previous dns
+      rm -f $RESOLV_CONF
       [ -n "$domain" ] && echo search $domain > $RESOLV_CONF
       for i in $dns ; do
         echo nameserver $i >> $RESOLV_CONF
       done
+      echo "options ${RESOLV_OPTIONS}" >> $RESOLV_CONF
     fi
     update_hosts
     ;;
@@ -134,6 +138,7 @@ case "$1" in
       for i in $dns ; do
         echo nameserver $i >> $RESOLV_CONF
       done
+      echo "options ${RESOLV_OPTIONS}" >> $RESOLV_CONF
     fi
     if [ -n "$REDO_HOSTNAME" ]; then
       update_hosts


### PR DESCRIPTION
Issue: DA container were often noticed to be in an error state with `one of the application's tasks has crashed - please restart application instance` message. 

Reasons:
socket.gaierror: [Errno -3] Try again: The name server returned a temporary failure indication

Fix:
Increased timeout value and added retries in app's `resolv.conf`

Also, fixed the case where EVE was appending the same dns config in `/mnt/rootfs/etc/resolv.conf` every time the AppInstance rebooted. 

cc: @gkodali-zededa 
Signed-off-by: adarsh-zededa <adarsh@zededa.com>