### PR TITLE
Avoid reporting unknown state for app instance before VolumeRefStatus exists

### DIFF
--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -419,6 +419,7 @@ func handleCreate(ctxArg interface{}, key string,
 		vrs.RefCount = vrc.RefCount
 		vrs.MountDir = vrc.MountDir
 		vrs.PendingAdd = true
+		vrs.State = types.INITIAL
 	}
 
 	allErrors := ""

--- a/pkg/pillar/go.mod
+++ b/pkg/pillar/go.mod
@@ -41,7 +41,6 @@ require (
 	github.com/shirou/gopsutil v0.0.0-20190323131628-2cbc9195c892
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.4.0
-	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 // indirect
 	github.com/tatsushid/go-fastping v0.0.0-20160109021039-d7bb493dee3e
 	github.com/vishvananda/netlink v1.0.1-0.20190823182904-a1c9a648f744 // indirect
 	github.com/vishvananda/netns v0.0.0-20190625233234-7109fa855b0f // indirect

--- a/pkg/pillar/types/types.go
+++ b/pkg/pillar/types/types.go
@@ -161,12 +161,6 @@ func (state SwState) ZSwState() info.ZSwState {
 	return info.ZSwState_INITIAL
 }
 
-// NoHash should XXX deprecate?
-const (
-	// NoHash constant to indicate that we have no real hash
-	NoHash = "sha"
-)
-
 // Used to retain UUID to integer maps across reboots.
 // Used for appNum and bridgeNum
 type UuidToNum struct {

--- a/pkg/pillar/types/types.go
+++ b/pkg/pillar/types/types.go
@@ -89,12 +89,12 @@ func (state SwState) String() string {
 		return "HALTED"
 	case RESTARTING:
 		return "RESTARTING"
+	case PURGING:
+		return "PURGING"
 	case BROKEN:
 		return "BROKEN"
 	case UNKNOWN:
 		return "UNKNOWN"
-	case PURGING:
-		return "PURGING"
 	default:
 		return fmt.Sprintf("Unknown state %d", state)
 	}
@@ -123,12 +123,6 @@ func (state SwState) ZSwState() info.ZSwState {
 		return info.ZSwState_CREATED_VOLUME
 	case INSTALLED:
 		return info.ZSwState_INSTALLED
-	// for now we're treating PAUSED as a subset
-	// of INSTALLED simply because controllers don't
-	// support resumable paused tasks just yet (see
-	// how PAUSING maps to RUNNING below)
-	case PAUSED:
-		return info.ZSwState_INSTALLED
 	case BOOTING:
 		return info.ZSwState_BOOTING
 	case RUNNING:
@@ -138,12 +132,13 @@ func (state SwState) ZSwState() info.ZSwState {
 	// paused tasks yet
 	case PAUSING:
 		return info.ZSwState_RUNNING
+	// for now we're treating PAUSED as a subset
+	// of INSTALLED simply because controllers don't
+	// support resumable paused tasks just yet (see
+	// how PAUSING maps to RUNNING below)
+	case PAUSED:
+		return info.ZSwState_INSTALLED
 	case HALTING:
-		return info.ZSwState_HALTING
-	// we map BROKEN to HALTING to indicate that EVE has an active
-	// role in reaping BROKEN domains and transitioning them to
-	// a final HALTED state
-	case BROKEN:
 		return info.ZSwState_HALTING
 	case HALTED:
 		return info.ZSwState_HALTED
@@ -151,6 +146,15 @@ func (state SwState) ZSwState() info.ZSwState {
 		return info.ZSwState_RESTARTING
 	case PURGING:
 		return info.ZSwState_PURGING
+	// we map BROKEN to HALTING to indicate that EVE has an active
+	// role in reaping BROKEN domains and transitioning them to
+	// a final HALTED state
+	case BROKEN:
+		return info.ZSwState_HALTING
+	// If we ever see UNKNOWN we return RUNNING assuming the state will change to something
+	// known soon.
+	case UNKNOWN:
+		return info.ZSwState_RUNNING
 	default:
 		logrus.Fatalf("Unknown state %d", state)
 	}

--- a/pkg/pillar/types/types.go
+++ b/pkg/pillar/types/types.go
@@ -83,6 +83,8 @@ func (state SwState) String() string {
 		return "PAUSING"
 	case PAUSED:
 		return "PAUSED"
+	case HALTING:
+		return "HALTING"
 	case HALTED:
 		return "HALTED"
 	case RESTARTING:


### PR DESCRIPTION
First commit takes care of a user-visible confusing event.

Second and third is about incomplete and reordered states. Note I assume that UNKNOWN state isn't used since it prior to this change it resulted in a log.Fatal.

Last is a cleanup of a dead function which I stumbled on just after the functions I fixed.