### PR TITLE
Reduce risk of volumemgr watchdog by longer channel

### DIFF
--- a/pkg/pillar/cmd/baseosmgr/baseosmgr.go
+++ b/pkg/pillar/cmd/baseosmgr/baseosmgr.go
@@ -101,7 +101,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// publish initial zboot partition status
 	updateAndPublishZbootStatusAll(&ctx)
 
-	ctx.worker = worker.NewWorker(log, &ctx, 5, map[string]worker.Handler{
+	ctx.worker = worker.NewWorker(log, &ctx, 20, map[string]worker.Handler{
 		workInstall: {Request: installWorker, Response: processInstallWorkResult},
 	})
 

--- a/pkg/pillar/cmd/baseosmgr/worker.go
+++ b/pkg/pillar/cmd/baseosmgr/worker.go
@@ -29,7 +29,8 @@ func AddWorkInstall(ctx *baseOsMgrContext, key, ref, target string) {
 		ref:       ref,
 		target:    target,
 	}
-	// we do not care about the errors much
+	// Don't check errors to make idempotent (Submit returns an error if
+	// the work was already submitted)
 	_ = ctx.worker.Submit(worker.Work{Key: key, Kind: workInstall, Description: d})
 	log.Infof("AddWorkInstall(%s) done", key)
 }

--- a/pkg/pillar/cmd/volumemgr/handlework.go
+++ b/pkg/pillar/cmd/volumemgr/handlework.go
@@ -56,8 +56,9 @@ func AddWorkCreate(ctx *volumemgrContext, status *types.VolumeStatus) {
 		status: *status,
 	}
 	w := worker.Work{Kind: workCreate, Key: status.Key(), Description: d}
-	// XXX could check a return and not add...
-	ctx.worker.Submit(w)
+	// Don't check errors to make idempotent (Submit returns an error if
+	// the work was already submitted)
+	_ = ctx.worker.Submit(w)
 }
 
 // AddWorkLoad adds a Work job to load an image and blobs into CAS
@@ -66,8 +67,9 @@ func AddWorkLoad(ctx *volumemgrContext, status *types.ContentTreeStatus) {
 		status: *status,
 	}
 	w := worker.Work{Kind: workIngest, Key: status.Key(), Description: d}
-	// XXX could check a return and not add...
-	ctx.worker.Submit(w)
+	// Don't check errors to make idempotent (Submit returns an error if
+	// the work was already submitted)
+	_ = ctx.worker.Submit(w)
 }
 
 // DeleteWorkCreate is called by user when work is done
@@ -87,8 +89,9 @@ func AddWorkDestroy(ctx *volumemgrContext, status *types.VolumeStatus) {
 		status:  *status,
 	}
 	w := worker.Work{Kind: workCreate, Key: status.Key(), Description: d}
-	// XXX could check a return and not add...
-	ctx.worker.Submit(w)
+	// Don't check errors to make idempotent (Submit returns an error if
+	// the work was already submitted)
+	_ = ctx.worker.Submit(w)
 }
 
 // DeleteWorkDestroy cancels a job to destroy a volume

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -147,7 +147,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	subGlobalConfig.Activate()
 
 	// Create the background worker
-	ctx.worker = worker.NewWorker(log, &ctx, 5, map[string]worker.Handler{
+	ctx.worker = worker.NewWorker(log, &ctx, 20, map[string]worker.Handler{
 		workCreate: {Request: volumeWorker, Response: processVolumeWorkResult},
 		workIngest: {Request: casIngestWorker, Response: processCasIngestWorkResult},
 	})


### PR DESCRIPTION
When having a multi-volume app-instance and manually doing create, purge, delete and one of the volumes is huge, everything will block behind the create of the large volume. After 5 queued the main goroutine in volumemgr blocks, and can remain blocked for minutes resulting in a watchdog.

This reduces the probability, plus an explicit fatal should we hit it again.

Separately the plan is to have a dynamic pool of goroutines run work in parallel to avoid small work being delayed by huge work.