### PR TITLE
Avoid head-of-line blocking when handling large volumes

### DIFF
--- a/pkg/pillar/cmd/baseosmgr/baseosmgr.go
+++ b/pkg/pillar/cmd/baseosmgr/baseosmgr.go
@@ -49,7 +49,7 @@ type baseOsMgrContext struct {
 	rebootTime           time.Time // From last reboot
 	rebootImage          string    // Image from which the last reboot happened
 
-	worker *worker.Worker // For background work
+	worker *worker.Pool // For background work
 }
 
 var debug = false
@@ -101,7 +101,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// publish initial zboot partition status
 	updateAndPublishZbootStatusAll(&ctx)
 
-	ctx.worker = worker.NewWorker(log, &ctx, 20, map[string]worker.Handler{
+	ctx.worker = worker.NewPool(log, &ctx, 20, map[string]worker.Handler{
 		workInstall: {Request: installWorker, Response: processInstallWorkResult},
 	})
 

--- a/pkg/pillar/cmd/baseosmgr/worker.go
+++ b/pkg/pillar/cmd/baseosmgr/worker.go
@@ -29,9 +29,15 @@ func AddWorkInstall(ctx *baseOsMgrContext, key, ref, target string) {
 		ref:       ref,
 		target:    target,
 	}
-	// Don't check errors to make idempotent (Submit returns an error if
+	// Don't fail on errors to make idempotent (Submit returns an error if
 	// the work was already submitted)
-	_ = ctx.worker.Submit(worker.Work{Key: key, Kind: workInstall, Description: d})
+	done, err := ctx.worker.TrySubmit(worker.Work{Key: key, Kind: workInstall,
+		Description: d})
+	if err != nil {
+		log.Errorf("TrySubmit %s failed: %s", key, err)
+	} else if !done {
+		log.Fatalf("Failed to submit work due to queue length for %s", key)
+	}
 	log.Infof("AddWorkInstall(%s) done", key)
 }
 

--- a/pkg/pillar/cmd/volumemgr/handlevolume_test.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume_test.go
@@ -3,8 +3,6 @@
 
 package volumemgr
 
-// Interface to worker to run the create and destroy in separate goroutines
-
 import (
 	"github.com/stretchr/testify/assert"
 	"testing"

--- a/pkg/pillar/cmd/volumemgr/handlework.go
+++ b/pkg/pillar/cmd/volumemgr/handlework.go
@@ -56,9 +56,15 @@ func AddWorkCreate(ctx *volumemgrContext, status *types.VolumeStatus) {
 		status: *status,
 	}
 	w := worker.Work{Kind: workCreate, Key: status.Key(), Description: d}
-	// Don't check errors to make idempotent (Submit returns an error if
+	// Don't fail on errors to make idempotent (Submit returns an error if
 	// the work was already submitted)
-	_ = ctx.worker.Submit(w)
+	done, err := ctx.worker.TrySubmit(w)
+	if err != nil {
+		log.Errorf("TrySubmit %s failed: %s", status.Key(), err)
+	} else if !done {
+		log.Fatalf("Failed to submit work due to queue length for %s",
+			status.Key())
+	}
 }
 
 // AddWorkLoad adds a Work job to load an image and blobs into CAS
@@ -67,9 +73,15 @@ func AddWorkLoad(ctx *volumemgrContext, status *types.ContentTreeStatus) {
 		status: *status,
 	}
 	w := worker.Work{Kind: workIngest, Key: status.Key(), Description: d}
-	// Don't check errors to make idempotent (Submit returns an error if
+	// Don't fail on errors to make idempotent (Submit returns an error if
 	// the work was already submitted)
-	_ = ctx.worker.Submit(w)
+	done, err := ctx.worker.TrySubmit(w)
+	if err != nil {
+		log.Errorf("TrySubmit %s failed: %s", status.Key(), err)
+	} else if !done {
+		log.Fatalf("Failed to submit work due to queue length for %s",
+			status.Key())
+	}
 }
 
 // DeleteWorkCreate is called by user when work is done
@@ -89,9 +101,15 @@ func AddWorkDestroy(ctx *volumemgrContext, status *types.VolumeStatus) {
 		status:  *status,
 	}
 	w := worker.Work{Kind: workCreate, Key: status.Key(), Description: d}
-	// Don't check errors to make idempotent (Submit returns an error if
+	// Don't fail on errors to make idempotent (Submit returns an error if
 	// the work was already submitted)
-	_ = ctx.worker.Submit(w)
+	done, err := ctx.worker.TrySubmit(w)
+	if err != nil {
+		log.Errorf("TrySubmit %s failed: %s", status.Key(), err)
+	} else if !done {
+		log.Fatalf("Failed to submit work due to queue length for %s",
+			status.Key())
+	}
 }
 
 // DeleteWorkDestroy cancels a job to destroy a volume

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -70,7 +70,7 @@ type volumemgrContext struct {
 	diskMetricsTickerHandle interface{}
 	gc                      *time.Ticker
 
-	worker *worker.Worker // For background work
+	worker *worker.Pool // For background work
 
 	verifierRestarted    bool // Wait for verifier to restart
 	contentTreeRestarted bool // Wait to receive all contentTree after restart
@@ -147,7 +147,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	subGlobalConfig.Activate()
 
 	// Create the background worker
-	ctx.worker = worker.NewWorker(log, &ctx, 20, map[string]worker.Handler{
+	ctx.worker = worker.NewPool(log, &ctx, 20, map[string]worker.Handler{
 		workCreate: {Request: volumeWorker, Response: processVolumeWorkResult},
 		workIngest: {Request: casIngestWorker, Response: processCasIngestWorkResult},
 	})

--- a/pkg/pillar/worker/worker_test.go
+++ b/pkg/pillar/worker/worker_test.go
@@ -69,12 +69,12 @@ func TestWork(t *testing.T) {
 			w := Work{Kind: "test", Key: testname, Description: d}
 			timestamp = time.Now() // In case we ask for sleep
 			worker.Submit(w)
-			assert.Equal(t, worker.NumPending(), 1)
+			assert.Equal(t, 1, worker.NumPending())
 			proc := <-worker.MsgChan()
 			proc.Process(ctx, true)
-			assert.Equal(t, worker.NumPending(), 0)
-			assert.Equal(t, res.Key, testname)
-			assert.Equal(t, res.Output, d.generateOutput)
+			assert.Equal(t, 0, worker.NumPending())
+			assert.Equal(t, testname, res.Key)
+			assert.Equal(t, d.generateOutput, res.Output)
 			if d.sleepTime != 0 {
 				minDuration := time.Duration(d.sleepTime) * time.Second
 				maxDuration := minDuration + 100*time.Millisecond
@@ -84,14 +84,14 @@ func TestWork(t *testing.T) {
 			}
 			if d.generateError {
 				assert.NotNil(t, res.Error)
-				assert.Equal(t, res.ErrorTime, timestamp)
+				assert.Equal(t, timestamp, res.ErrorTime)
 			}
 			dout := res.Description.(dummyDescription)
-			assert.Equal(t, dout.generateOutput, d.generateOutput)
+			assert.Equal(t, d.generateOutput, dout.generateOutput)
 			assert.True(t, dout.done)
 		})
 	}
-	assert.Equal(t, worker.NumPending(), 0)
+	assert.Equal(t, 0, worker.NumPending())
 	worker.Done()
 	_, ok := <-worker.MsgChan()
 	done := !ok
@@ -132,7 +132,7 @@ func TestLength(t *testing.T) {
 	submit1start := timestamp
 	done, _ := worker.TrySubmit(w1)
 	assert.True(t, done)
-	assert.Equal(t, worker.NumPending(), 1)
+	assert.Equal(t, 1, worker.NumPending())
 	submit1time := time.Since(submit1start)
 	log.Printf("Submit1 took %v", submit1time)
 	minDuration := time.Duration(0)
@@ -143,7 +143,7 @@ func TestLength(t *testing.T) {
 	w2 := Work{Kind: "test", Key: testname + "2", Description: sleep2}
 	submit2start := time.Now()
 	worker.Submit(w2)
-	assert.Equal(t, worker.NumPending(), 2)
+	assert.Equal(t, 2, worker.NumPending())
 	submit2time := time.Since(submit2start)
 	log.Printf("Submit2 took %v", submit2time)
 	assert.GreaterOrEqual(t, int64(submit2time), int64(minDuration))
@@ -152,7 +152,7 @@ func TestLength(t *testing.T) {
 	w3 := Work{Kind: "test", Key: testname + "3", Description: sleep3}
 	submit3start := time.Now()
 	worker.Submit(w3)
-	assert.Equal(t, worker.NumPending(), 3)
+	assert.Equal(t, 3, worker.NumPending())
 	submit3time := time.Since(submit3start)
 	log.Printf("Submit3 took %v", submit3time)
 	// With channel length 1 have to wait for w1 to complete
@@ -168,9 +168,9 @@ func TestLength(t *testing.T) {
 
 	proc1 := <-worker.MsgChan()
 	proc1.Process(ctx, true)
-	assert.Equal(t, worker.NumPending(), 2)
-	assert.Equal(t, res.Key, testname+"1")
-	assert.Equal(t, res.Output, sleep1.generateOutput)
+	assert.Equal(t, 2, worker.NumPending())
+	assert.Equal(t, testname+"1", res.Key)
+	assert.Equal(t, sleep1.generateOutput, res.Output)
 	if sleep1.sleepTime != 0 {
 		minDuration := time.Duration(sleep1.sleepTime)*time.Second + submit1time
 		maxDuration := minDuration + 100*time.Millisecond
@@ -180,9 +180,9 @@ func TestLength(t *testing.T) {
 	}
 	proc2 := <-worker.MsgChan()
 	proc2.Process(ctx, true)
-	assert.Equal(t, worker.NumPending(), 1)
-	assert.Equal(t, res.Key, testname+"2")
-	assert.Equal(t, res.Output, sleep2.generateOutput)
+	assert.Equal(t, 1, worker.NumPending())
+	assert.Equal(t, testname+"2", res.Key)
+	assert.Equal(t, sleep2.generateOutput, res.Output)
 	if sleep2.sleepTime != 0 {
 		// Single worker processing serially
 		secs := sleep1.sleepTime + sleep2.sleepTime
@@ -198,9 +198,9 @@ func TestLength(t *testing.T) {
 	proc3.Process(ctx, true)
 	// this one uses the Pop, so we exercise it
 	res3 := worker.Pop(testname + "3")
-	assert.Equal(t, worker.NumPending(), 0)
-	assert.Equal(t, res3.Key, testname+"3")
-	assert.Equal(t, res3.Output, sleep3.generateOutput)
+	assert.Equal(t, 0, worker.NumPending())
+	assert.Equal(t, testname+"3", res3.Key)
+	assert.Equal(t, sleep3.generateOutput, res3.Output)
 	if sleep3.sleepTime != 0 {
 		minDuration := time.Duration(sleep3.sleepTime)*time.Second + submit1time + submit2time + submit3time
 		maxDuration := minDuration + 100*time.Millisecond
@@ -209,7 +209,7 @@ func TestLength(t *testing.T) {
 		assert.Less(t, int64(took), int64(maxDuration))
 	}
 
-	assert.Equal(t, worker.NumPending(), 0)
+	assert.Equal(t, 0, worker.NumPending())
 	worker.Done()
 	_, ok := <-worker.MsgChan()
 	done = !ok

--- a/pkg/pillar/worker/worker_test.go
+++ b/pkg/pillar/worker/worker_test.go
@@ -130,7 +130,8 @@ func TestLength(t *testing.T) {
 	w1 := Work{Kind: "test", Key: testname + "1", Description: sleep1}
 	timestamp = time.Now() // In case we ask for sleep
 	submit1start := timestamp
-	worker.Submit(w1)
+	done, _ := worker.TrySubmit(w1)
+	assert.True(t, done)
 	assert.Equal(t, worker.NumPending(), 1)
 	submit1time := time.Since(submit1start)
 	log.Printf("Submit1 took %v", submit1time)
@@ -160,6 +161,10 @@ func TestLength(t *testing.T) {
 	minDuration -= 100 * time.Millisecond
 	assert.GreaterOrEqual(t, int64(submit3time), int64(minDuration))
 	assert.Less(t, int64(submit3time), int64(maxDuration))
+
+	w4 := Work{Kind: "test", Key: testname + "4", Description: sleep3}
+	done, _ = worker.TrySubmit(w4)
+	assert.False(t, done)
 
 	proc1 := <-worker.MsgChan()
 	proc1.Process(ctx, true)
@@ -207,7 +212,7 @@ func TestLength(t *testing.T) {
 	assert.Equal(t, worker.NumPending(), 0)
 	worker.Done()
 	_, ok := <-worker.MsgChan()
-	done := !ok
+	done = !ok
 	assert.True(t, done)
 }
 

--- a/pkg/pillar/worker/workerpool.go
+++ b/pkg/pillar/worker/workerpool.go
@@ -1,0 +1,221 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// worker provides a dynamic set of workers so that work can be
+// spawned without head-of-line blocking
+
+package worker
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/agentlog"
+)
+
+const (
+	defaultPeriodicGCSeconds = 300
+	defaultSubmitGCSeconds   = 60
+)
+
+// Pool captures the workers in the pool
+type Pool struct {
+	// Private
+	maxWorkers     int
+	maxWorkersUsed int
+	periodicGCTime time.Duration
+	submitGCTime   time.Duration
+	workers        []myworker
+	numChan        int // Number of result channels from workers
+	resultChan     chan Processor
+	log            Logger
+	ctx            interface{}
+	handlers       map[string]Handler
+	stopTimer      chan struct{}
+}
+
+type myworker struct {
+	worker   *Worker
+	lastUsed time.Time // Last successful submit
+}
+
+// NewPool constructs a pool
+// If maxWorkers is set to zero it means unlimited
+func NewPool(log Logger, ctx interface{}, maxWorkers int, handlers map[string]Handler) *Pool {
+	return NewPoolWithGC(log, ctx, maxWorkers, handlers,
+		defaultPeriodicGCSeconds, defaultSubmitGCSeconds)
+}
+
+// NewPoolWithGC constructs a pool with non-default GC timers
+// If maxWorkers is set to zero it means unlimited
+func NewPoolWithGC(log Logger, ctx interface{}, maxWorkers int, handlers map[string]Handler, periodicGCSeconds int, submitGCSeconds int) *Pool {
+	length := maxWorkers
+	if length == 0 {
+		length = 10
+	}
+	resultChan := make(chan Processor, length)
+	wp := &Pool{
+		resultChan:     resultChan,
+		maxWorkers:     maxWorkers,
+		maxWorkersUsed: 1,
+		log:            log,
+		ctx:            ctx,
+		handlers:       handlers,
+		stopTimer:      make(chan struct{}),
+		periodicGCTime: time.Duration(periodicGCSeconds) * time.Second,
+		submitGCTime:   time.Duration(submitGCSeconds) * time.Second,
+	}
+	go wp.periodicGC()
+	return wp
+}
+
+func (wp *Pool) periodicGC() {
+	wp.log.Debugf("periodicGC starting")
+	t := time.NewTicker(wp.periodicGCTime)
+	done := false
+	for !done {
+		select {
+		case <-t.C:
+			wp.purgeOld(0)
+
+		case _, ok := <-wp.stopTimer:
+			if !ok {
+				done = true
+			}
+		}
+	}
+	wp.log.Debugf("periodicGC done")
+}
+
+func (wp *Pool) mergeResult(w *Worker) {
+	wp.log.Debugf("mergeResult starting")
+	ch := w.MsgChan()
+	for res := range ch {
+		wp.log.Debugf("mergeResult got %+v", res)
+		wp.resultChan <- res
+	}
+	wp.numChan--
+	// Are all the mergeResults done?
+	if wp.numChan == 0 {
+		close(wp.resultChan)
+	}
+	wp.log.Debugf("mergeResult done")
+}
+
+// NumPending returns the current number work items
+func (wp *Pool) NumPending() int {
+	total := 0
+	for _, w := range wp.workers {
+		total += w.worker.NumPending()
+	}
+	return total
+}
+
+// NumWorkers returns the current number of workers
+func (wp *Pool) NumWorkers() int {
+	return len(wp.workers)
+}
+
+// TrySubmit returns false if the number of workers is already at the max
+// returns JobInProgressError if a job with that key already in progress
+func (wp *Pool) TrySubmit(work Work) (bool, error) {
+	for i, w := range wp.workers {
+		done, err := w.worker.TrySubmit(work)
+		if err != nil {
+			wp.log.Debugf("failed TrySubmit for %d", i)
+			return done, err
+		} else if done {
+			wp.log.Debugf("succeeded TrySubmit for %d", i)
+			w.lastUsed = time.Now()
+			wp.purgeOld(i + 1)
+			return done, nil
+		}
+	}
+	// Used all of them; can we create a new one?
+	if wp.maxWorkers == 0 || len(wp.workers) < wp.maxWorkers {
+		wp.log.Debugf("Creating new worker")
+		w := NewWorker(wp.log, wp.ctx, 0, wp.handlers)
+		neww := myworker{worker: w, lastUsed: time.Now()}
+		wp.workers = append(wp.workers, neww)
+		if len(wp.workers) > wp.maxWorkersUsed {
+			wp.maxWorkersUsed = len(wp.workers)
+			wp.log.Debugf("maxWorkersUsed %d", wp.maxWorkersUsed)
+		}
+		wp.numChan++
+		wp.log.Debugf("Creating %s at %s", "wp.mergeResult",
+			agentlog.GetMyStack())
+		go wp.mergeResult(w)
+		err := w.Submit(work)
+		if err != nil {
+			wp.log.Debugf("new worker yet failed: %s", err)
+			return false, err
+		}
+		wp.log.Debugf("succeeded Submit for %d", len(wp.workers))
+		return true, nil
+	}
+	wp.log.Debugf("Would exceed maxWorkers of %d", wp.maxWorkers)
+	return false, fmt.Errorf("Would exceed maxWorkers of %d", wp.maxWorkers)
+}
+
+// MsgChan returns a channel to be used in a select loop.
+// This is a duplicate of C
+func (wp *Pool) MsgChan() <-chan Processor {
+	return wp.resultChan
+}
+
+// Cancel cancels a pending job.
+// It is idempotent, will return no errors if the job is not found,
+// which means it either never was submitted, or it already was processed.
+func (wp *Pool) Cancel(key string) {
+	for _, w := range wp.workers {
+		w.worker.Cancel(key)
+	}
+}
+
+// Done will stop the workers
+func (wp *Pool) Done() {
+	for _, w := range wp.workers {
+		w.worker.Done()
+	}
+	wp.workers = nil
+	close(wp.stopTimer)
+}
+
+// Pop get a result and remove it from the list
+func (wp *Pool) Pop(key string) *WorkResult {
+	for _, w := range wp.workers {
+		res := w.worker.Pop(key)
+		if res != nil {
+			return res
+		}
+	}
+	return nil
+}
+
+// Peek get a result without removing it from the list
+func (wp *Pool) Peek(key string) *WorkResult {
+	for _, w := range wp.workers {
+		res := w.worker.Peek(key)
+		if res != nil {
+			return res
+		}
+	}
+	return nil
+}
+
+// purgeOld removes old workers from the pool
+func (wp *Pool) purgeOld(startIndex int) {
+
+	wp.log.Debugf("purgeOld(%d) have %d", startIndex, len(wp.workers))
+	var newWorkers []myworker
+	for i, w := range wp.workers {
+		if i <= startIndex || time.Since(w.lastUsed) < wp.submitGCTime {
+			newWorkers = append(newWorkers, w)
+		} else {
+			wp.log.Debugf("purgeOld GC %d", i)
+			w.worker.Done()
+		}
+	}
+	wp.workers = newWorkers
+	wp.log.Debugf("purgeOld post GC have %d", len(wp.workers))
+}

--- a/pkg/pillar/worker/workerpool_test.go
+++ b/pkg/pillar/worker/workerpool_test.go
@@ -1,0 +1,426 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// worker provides a dynamic set of workers so that work can be
+// spawned without head-of-line blocking
+
+package worker_test
+
+import (
+	"errors"
+	"log"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/worker"
+	"github.com/sirupsen/logrus"
+)
+
+var sleep1 = dummyDescription{
+	sleepTime:      1,
+	generateOutput: "sleep1",
+}
+var sleep2 = dummyDescription{
+	sleepTime:      2,
+	generateOutput: "sleep2",
+}
+
+var sleep3 = dummyDescription{
+	sleepTime:      3,
+	generateOutput: "sleep3",
+}
+
+var sleep4 = dummyDescription{
+	sleepTime:      4,
+	generateOutput: "sleep4",
+}
+
+var sleep20 = dummyDescription{
+	sleepTime:      20,
+	generateOutput: "sleep20",
+}
+
+func setupPool(maxPool int) (*dummyContext, *worker.Pool, *worker.WorkResult) {
+	ctx := dummyContext{contextName: "testContext"}
+	var res worker.WorkResult
+	dummyResponse := func(ctx interface{}, r worker.WorkResult) error {
+		res = r
+		return nil
+	}
+	logger := logrus.StandardLogger()
+	// logger.SetLevel(logrus.TraceLevel)
+	wp := worker.NewPoolWithGC(
+		base.NewSourceLogObject(logger, "test", 1234),
+		&ctx, maxPool, map[string]worker.Handler{
+			"test": {Request: dummyWorker, Response: dummyResponse},
+		},
+		1, 10)
+	return &ctx, wp, &res
+}
+
+// TestInOrder verifies that workers are spawned and return in order
+func TestInOrder(t *testing.T) {
+	numGoroutines := runtime.NumGoroutine()
+	origStacks := getStacks(true)
+	ctx, wp, res := setupPool(3)
+	testname := "testinorder"
+
+	t.Logf("Running test case %s", testname)
+	start := time.Now()
+	w1 := worker.Work{Kind: "test", Key: testname + "1", Description: sleep1}
+	done, err := wp.TrySubmit(w1)
+	assert.True(t, done)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, wp.NumWorkers())
+	assert.Equal(t, 1, wp.NumPending())
+
+	w2 := worker.Work{Kind: "test", Key: testname + "2", Description: sleep2}
+	done, err = wp.TrySubmit(w2)
+	assert.True(t, done)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, wp.NumWorkers())
+	assert.Equal(t, 2, wp.NumPending())
+
+	w3 := worker.Work{Kind: "test", Key: testname + "3", Description: sleep3}
+	done, err = wp.TrySubmit(w3)
+	assert.True(t, done)
+	assert.Nil(t, err)
+	assert.Equal(t, 3, wp.NumWorkers())
+	assert.Equal(t, 3, wp.NumPending())
+
+	// This one will fail
+	w4 := worker.Work{Kind: "test", Key: testname + "4", Description: sleep4}
+	done, err = wp.TrySubmit(w4)
+	assert.False(t, done)
+	assert.NotNil(t, err)
+	logrus.Error(err)
+	assert.Equal(t, 3, wp.NumWorkers())
+	assert.Equal(t, 3, wp.NumPending())
+
+	proc1 := <-wp.MsgChan()
+	proc1.Process(ctx, true)
+	assert.Equal(t, 2, wp.NumPending())
+	assert.Equal(t, testname+"1", res.Key)
+	assert.Equal(t, sleep1.generateOutput, res.Output)
+
+	proc2 := <-wp.MsgChan()
+	proc2.Process(ctx, true)
+	assert.Equal(t, 1, wp.NumPending())
+	assert.Equal(t, testname+"2", res.Key)
+	assert.Equal(t, sleep2.generateOutput, res.Output)
+
+	proc3 := <-wp.MsgChan()
+	proc3.Process(ctx, true)
+	// this one uses the Pop, so we exercise it
+	res3 := wp.Pop(testname + "3")
+	assert.Equal(t, testname+"3", res3.Key)
+	assert.Equal(t, sleep3.generateOutput, res3.Output)
+	assert.Equal(t, 0, wp.NumPending())
+
+	// Should have completed in parallel i.e., more than max (3) and less
+	// than sum (1+2+3) of sleeptime
+	took := time.Since(start)
+	assert.GreaterOrEqual(t, int64(took), int64(3*time.Second))
+	assert.LessOrEqual(t, int64(took), int64(6*time.Second))
+
+	wp.Done()
+	_, ok := <-wp.MsgChan()
+	done = !ok
+	assert.True(t, done)
+	// Check that goroutines are gone
+	assert.Equal(t, numGoroutines, runtime.NumGoroutine())
+	if numGoroutines != runtime.NumGoroutine() {
+		t.Logf("All goroutine stacks on entry: %v",
+			origStacks)
+		t.Logf("All goroutine stacks on exit: %v",
+			getStacks(true))
+	}
+}
+
+// TestNoLimit verifies that zero means no limit
+func TestNoLimit(t *testing.T) {
+	numGoroutines := runtime.NumGoroutine()
+	origStacks := getStacks(true)
+	ctx, wp, res := setupPool(0)
+	testname := "testnolimit"
+
+	t.Logf("Running test case %s", testname)
+	start := time.Now()
+	w1 := worker.Work{Kind: "test", Key: testname + "1", Description: sleep1}
+	done, err := wp.TrySubmit(w1)
+	assert.True(t, done)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, wp.NumWorkers())
+	assert.Equal(t, 1, wp.NumPending())
+
+	w2 := worker.Work{Kind: "test", Key: testname + "2", Description: sleep2}
+	done, err = wp.TrySubmit(w2)
+	assert.True(t, done)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, wp.NumWorkers())
+	assert.Equal(t, 2, wp.NumPending())
+
+	w3 := worker.Work{Kind: "test", Key: testname + "3", Description: sleep3}
+	done, err = wp.TrySubmit(w3)
+	assert.True(t, done)
+	assert.Nil(t, err)
+	assert.Equal(t, 3, wp.NumWorkers())
+	assert.Equal(t, 3, wp.NumPending())
+
+	w4 := worker.Work{Kind: "test", Key: testname + "4", Description: sleep4}
+	done, err = wp.TrySubmit(w4)
+	assert.True(t, done)
+	assert.Nil(t, err)
+	assert.Equal(t, 4, wp.NumWorkers())
+	assert.Equal(t, 4, wp.NumPending())
+
+	proc1 := <-wp.MsgChan()
+	proc1.Process(ctx, true)
+	assert.Equal(t, 3, wp.NumPending())
+	assert.Equal(t, testname+"1", res.Key)
+	assert.Equal(t, sleep1.generateOutput, res.Output)
+
+	proc2 := <-wp.MsgChan()
+	proc2.Process(ctx, true)
+	assert.Equal(t, 2, wp.NumPending())
+	assert.Equal(t, testname+"2", res.Key)
+	assert.Equal(t, sleep2.generateOutput, res.Output)
+
+	proc3 := <-wp.MsgChan()
+	proc3.Process(ctx, true)
+	// this one uses the Pop, so we exercise it
+	res3 := wp.Pop(testname + "3")
+	assert.Equal(t, testname+"3", res3.Key)
+	assert.Equal(t, sleep3.generateOutput, res3.Output)
+	assert.Equal(t, 1, wp.NumPending())
+
+	proc4 := <-wp.MsgChan()
+	proc4.Process(ctx, true)
+	res4 := wp.Pop(testname + "4")
+	assert.Equal(t, testname+"4", res4.Key)
+	assert.Equal(t, sleep4.generateOutput, res4.Output)
+	assert.Equal(t, 0, wp.NumPending())
+
+	// Should have completed in parallel i.e., more than max (4) and less
+	// than sum (1+2+3+4) of sleeptime
+	took := time.Since(start)
+	assert.GreaterOrEqual(t, int64(took), int64(4*time.Second))
+	assert.LessOrEqual(t, int64(took), int64(10*time.Second))
+
+	wp.Done()
+	_, ok := <-wp.MsgChan()
+	done = !ok
+	assert.True(t, done)
+	// Check that goroutines are gone
+	assert.Equal(t, numGoroutines, runtime.NumGoroutine())
+	if numGoroutines != runtime.NumGoroutine() {
+		t.Logf("All goroutine stacks on entry: %v",
+			origStacks)
+		t.Logf("All goroutine stacks on exit: %v",
+			getStacks(true))
+	}
+}
+
+// TestNoblocking verifies that a short after a long completes first
+func TestNoblocking(t *testing.T) {
+	numGoroutines := runtime.NumGoroutine()
+	origStacks := getStacks(true)
+	ctx, wp, res := setupPool(3)
+	testname := "testnoblocking"
+
+	t.Logf("Running test case %s", testname)
+	start := time.Now()
+	w1 := worker.Work{Kind: "test", Key: testname + "1", Description: sleep4}
+	done, err := wp.TrySubmit(w1)
+	assert.True(t, done)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, wp.NumWorkers())
+	assert.Equal(t, 1, wp.NumPending())
+
+	w2 := worker.Work{Kind: "test", Key: testname + "2", Description: sleep1}
+	done, err = wp.TrySubmit(w2)
+	assert.True(t, done)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, wp.NumWorkers())
+	assert.Equal(t, 2, wp.NumPending())
+
+	proc1 := <-wp.MsgChan()
+	proc1.Process(ctx, true)
+	assert.Equal(t, 1, wp.NumPending())
+	assert.Equal(t, testname+"2", res.Key)
+	assert.Equal(t, sleep1.generateOutput, res.Output)
+
+	proc2 := <-wp.MsgChan()
+	proc2.Process(ctx, true)
+	assert.Equal(t, 0, wp.NumPending())
+	assert.Equal(t, testname+"1", res.Key)
+	assert.Equal(t, sleep4.generateOutput, res.Output)
+
+	// Should have completed in parallel i.e., more than max (4) and less
+	// than sum (1+4) of sleeptime
+	took := time.Since(start)
+	assert.GreaterOrEqual(t, int64(took), int64(4*time.Second))
+	assert.LessOrEqual(t, int64(took), int64(5*time.Second))
+
+	wp.Done()
+	_, ok := <-wp.MsgChan()
+	done = !ok
+	assert.True(t, done)
+	// Check that goroutines are gone
+	assert.Equal(t, numGoroutines, runtime.NumGoroutine())
+	if numGoroutines != runtime.NumGoroutine() {
+		t.Logf("All goroutine stacks on entry: %v",
+			origStacks)
+		t.Logf("All goroutine stacks on exit: %v",
+			getStacks(true))
+	}
+}
+
+// TestGC verifies that unused workers are deleted
+func TestGC(t *testing.T) {
+	numGoroutines := runtime.NumGoroutine()
+	origStacks := getStacks(true)
+	ctx, wp, res := setupPool(0)
+	testname := "testgc"
+
+	t.Logf("Running test case %s", testname)
+	w1 := worker.Work{Kind: "test", Key: testname + "1", Description: sleep20}
+	done, err := wp.TrySubmit(w1)
+	assert.True(t, done)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, wp.NumWorkers())
+	assert.Equal(t, 1, wp.NumPending())
+
+	w2 := worker.Work{Kind: "test", Key: testname + "2", Description: sleep1}
+	done, err = wp.TrySubmit(w2)
+	assert.True(t, done)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, wp.NumWorkers())
+	assert.Equal(t, 2, wp.NumPending())
+
+	w3 := worker.Work{Kind: "test", Key: testname + "3", Description: sleep3}
+	done, err = wp.TrySubmit(w3)
+	assert.True(t, done)
+	assert.Nil(t, err)
+	assert.Equal(t, 3, wp.NumWorkers())
+	assert.Equal(t, 3, wp.NumPending())
+
+	w4 := worker.Work{Kind: "test", Key: testname + "4", Description: sleep4}
+	done, err = wp.TrySubmit(w4)
+	assert.True(t, done)
+	assert.Nil(t, err)
+	assert.Equal(t, 4, wp.NumWorkers())
+	assert.Equal(t, 4, wp.NumPending())
+
+	// Pick up 1 second one and two second one
+	proc2 := <-wp.MsgChan()
+	proc2.Process(ctx, true)
+	assert.Equal(t, 3, wp.NumPending())
+	assert.Equal(t, testname+"2", res.Key)
+	assert.Equal(t, sleep1.generateOutput, res.Output)
+
+	proc3 := <-wp.MsgChan()
+	proc3.Process(ctx, true)
+	assert.Equal(t, 2, wp.NumPending())
+	assert.Equal(t, testname+"3", res.Key)
+	assert.Equal(t, sleep3.generateOutput, res.Output)
+
+	assert.Equal(t, 4, wp.NumWorkers())
+	// Wait for GC timer
+	time.Sleep(10 * time.Second)
+
+	w5 := worker.Work{Kind: "test", Key: testname + "5", Description: sleep1}
+	done, err = wp.TrySubmit(w5)
+	assert.True(t, done)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, wp.NumWorkers())
+	assert.Equal(t, 2, wp.NumPending())
+
+	proc4 := <-wp.MsgChan()
+	proc4.Process(ctx, true)
+	assert.Equal(t, 2, wp.NumPending())
+	assert.Equal(t, testname+"4", res.Key)
+	assert.Equal(t, sleep4.generateOutput, res.Output)
+
+	proc5 := <-wp.MsgChan()
+	proc5.Process(ctx, true)
+	assert.Equal(t, 1, wp.NumPending())
+	assert.Equal(t, testname+"5", res.Key)
+	assert.Equal(t, sleep1.generateOutput, res.Output)
+
+	proc1 := <-wp.MsgChan()
+	proc1.Process(ctx, true)
+	assert.Equal(t, 0, wp.NumPending())
+	assert.Equal(t, testname+"1", res.Key)
+	assert.Equal(t, sleep20.generateOutput, res.Output)
+	assert.Equal(t, 2, wp.NumWorkers())
+
+	wp.Done()
+	_, ok := <-wp.MsgChan()
+	done = !ok
+	assert.True(t, done)
+	assert.Equal(t, 0, wp.NumWorkers())
+
+	// Check that goroutines are gone
+	assert.Equal(t, numGoroutines, runtime.NumGoroutine())
+	if numGoroutines != runtime.NumGoroutine() {
+		t.Logf("All goroutine stacks on entry: %v",
+			origStacks)
+		t.Logf("All goroutine stacks on exit: %v",
+			getStacks(true))
+	}
+}
+
+type dummyContext struct {
+	contextName string
+}
+
+type dummyDescription struct {
+	sleepTime      int
+	generateOutput string
+	generateError  bool
+	done           bool
+}
+
+func dummyWorker(ctxPtr interface{}, w worker.Work) worker.WorkResult {
+	ctx := ctxPtr.(*dummyContext)
+	if ctx.contextName != "testContext" {
+		panic("contextName mismatch")
+	}
+	d := w.Description.(dummyDescription)
+	if d.sleepTime != 0 {
+		log.Printf("dummyWorker sleeping for %d seconds", d.sleepTime)
+		time.Sleep(time.Duration(d.sleepTime) * time.Second)
+	}
+	result := worker.WorkResult{
+		Key:    w.Key,
+		Output: d.generateOutput,
+	}
+	if d.generateError {
+		result.Error = errors.New("generated error")
+		result.ErrorTime = time.Now()
+	}
+	d.done = true
+	result.Description = d
+	log.Printf("dummyWorker returning (sleep time %d)", d.sleepTime)
+	return result
+}
+
+func getStacks(all bool) string {
+	var (
+		buf       []byte
+		stackSize int
+	)
+	bufferLen := 16384
+	for stackSize == len(buf) {
+		buf = make([]byte, bufferLen)
+		stackSize = runtime.Stack(buf, all)
+		bufferLen *= 2
+	}
+	buf = buf[:stackSize]
+	return string(buf)
+}


### PR DESCRIPTION
Separated across a few PRs.

This introduces a new worker.Pool which provides the same API as the existing worker, but runs separate workers in parallel based on the load. The count argument is the max number of workers it will run concurrently.
Note that should we exceed that number we explicitly log.Fatal. We could run this with an unbounded upper limit instead of 20, but that will consume more memory and potentially cause thrashing if we are doing that many volumes and/or CAS operations in parallel.

The changes to cmd/baseosmgr and cmd/volumemgr are quite small since the API (once we have the TrySubmit API) are basically identical.