### PR TITLE
Making installer more robust in finding media

### DIFF
--- a/pkg/mkimage-iso-efi/make-efi
+++ b/pkg/mkimage-iso-efi/make-efi
@@ -25,6 +25,9 @@ else
    bsdtar xzf -
 fi
 
+# for installer we need to add a uid
+[ -f initrd.img ] && od -An -x -N 16 /dev/random | tr -d ' ' > installer.uid
+
 # create a ISO with a EFI boot partition
 # Stuff it into a FAT filesystem, making it as small as possible.  511KiB
 # headroom seems to be enough; (x+31)/32*32 rounds up to multiple of 32.

--- a/pkg/mkimage-raw-efi/Dockerfile
+++ b/pkg/mkimage-raw-efi/Dockerfile
@@ -49,6 +49,7 @@ COPY --from=build /out/ /
 COPY --from=initrd /initrd.gz /
 COPY grub.stage1 /usr/lib/grub/i386-pc/boot.img
 RUN gzip -d < /initrd.gz | cpio -id && \
+    rm /etc/mtab /dev/null && \
     find . -xdev | grep -v initrd.gz | sort | cpio --quiet -o -H newc | gzip > /initrd.gz && \
     mv /initrd.gz /initrd.img
 

--- a/pkg/mkimage-raw-efi/grub.cfg
+++ b/pkg/mkimage-raw-efi/grub.cfg
@@ -39,11 +39,12 @@ function set_global {
 
 install_part="$cmddevice"
 if [ -n "$install_part" -a -f "($install_part)/rootfs.img" -a -f "($install_part)/initrd.img" ]; then
+   cat -s installer_uid "($install_part)/installer.uid"
    set_global rootfs_root "($install_part)/rootfs.img"
    set_global initrd "($install_part)/initrd.img"
    set_global rootfs_title_suffix "-installer"
    set_global do_extra_submenus "installer_submenus"
-   set_global dom0_extra_args "setup_loops eve_installer"
+   set_global dom0_extra_args "setup_loops=$installer_uid eve_installer"
    set_global root "loop0"
 
    loopback loop0 "$rootfs_root"

--- a/pkg/mkimage-raw-efi/initramfs-init
+++ b/pkg/mkimage-raw-efi/initramfs-init
@@ -309,7 +309,8 @@ export PATH=/usr/bin:/bin:/usr/sbin:/sbin
 # mounting the devtmpfs will create it implicitly as an file with the "2>" redirection.
 # The -c check is required to deal with initramfs with pre-seeded device nodes without
 # error message.
-[ -c /dev/null ] || mknod -m 666 /dev/null c 1 3
+umask 0000
+[ -c /dev/null ] || mknod /dev/null c 1 3
 
 mount -t proc -o noexec,nosuid,nodev proc /proc
 mount -t sysfs -o noexec,nosuid,nodev sysfs /sys
@@ -473,24 +474,33 @@ ln -s /proc/mounts /etc/mtab
 # check if setup_loops=... was set
 if [ -n "$KOPT_setup_loops" ]; then
 	# locate boot media and mount it
-	ebegin "Mounting boot media"
-	nlplug-findfs $cryptopts -p /sbin/mdev ${KOPT_debug_init:+-d} \
-		${KOPT_usbdelay:+-t $(( $KOPT_usbdelay * 1000 ))} \
-		-n -r /tmp/rootfs
-	eend $?
+	# NOTE that we may require up to 3 tries with
+	# 30 seconds pauses between them to accomodate
+	# really slow controllers (such as bad USB sticks)
+	for i in 1 2 3; do
+           ebegin "Attempt $i to find and mount boot media"
+           nlplug-findfs $cryptopts -p /sbin/mdev ${KOPT_debug_init:+-d} \
+                ${KOPT_usbdelay:+-t $(( $KOPT_usbdelay * 1000 ))} \
+                -n -r /tmp/rootfs
+	   eend $?
+	   for i in $(cat /tmp/rootfs 2>/dev/null); do
+              if grep -q "$KOPT_setup_loops" "${i%/*}/installer.uid"; then
+                 LOOP_IMG="$i"
+	         break 2
+	      fi
+           done
+	   sleep 30
+        done
 
-        # see if we found anything
-        if [ ! -e /tmp/rootfs ]; then
-           echo "Failed to find rootfs (which is weird). Try to re-run nlplug-findfs manually to see what's wrong:"
+        # now add loop
+	ebegin "Setting up loopback block device"
+        if losetup -r -f "$LOOP_IMG"; then
+           ln -s "${LOOP_IMG%/*}" /media/boot
+        else
+           echo "Failed to find rootfs from boot media. Try to re-run nlplug-findfs manually to see what's wrong:"
            echo "  nlplug-findfs -p /sbin/mdev -d -t 30000 -n -r /tmp/rootfs.txt ; cat /tmp/rootfs.txt"
            sh
         fi
-
-        # now add loops
-	ebegin "Setting up loopback block devices"
-	for l in $(cat /tmp/rootfs); do
-		losetup -r -f "$l"
-	done
 	eend $?
 fi
 

--- a/pkg/mkimage-raw-efi/install
+++ b/pkg/mkimage-raw-efi/install
@@ -22,6 +22,9 @@ pause() {
 }
 
 bail() {
+   if mount_part INVENTORY "$(root_dev)" -t vfat -o iocharset=iso8859-1; then
+      collect_black_box /run/INVENTORY 2>/dev/null
+   fi
    echo "$*"
    exit 1
 }
@@ -43,7 +46,7 @@ root_dev() {
       MINOR=$(( 0x$(stat -c '%T' $DEV) + 0 ))
    fi
    DEV_MM="$MAJOR:$MINOR"
-   echo $(grep -l '^'$DEV_MM'$' /sys/block/*/dev /sys/block/*/*/dev | cut -f4 -d/)
+   echo $(grep -l '^'$DEV_MM'$' /sys/block/*/dev /sys/block/*/*/dev 2>/dev/null | cut -f4 -d/)
 }
 
 # find_part LABEL BLOCK_DEV
@@ -68,13 +71,39 @@ mount_part() {
    mount "$@" "/dev/$ID" "/run/$PART"
 }
 
+# collect_black_box FOLDER_TO_PUT_BLACK_BOX
+collect_black_box() {
+   lsblk > "$1/lsblk.txt"
+   dmesg > "$1/dmesg.txt"
+   tar -C /proc -cjf "$1/procfs.tar.bz2" cpuinfo meminfo
+   tar -C /sys -cjf "$1/sysfs.tar.bz2" .
+   tar -C /run/CONFIG -cjf "$1/config.tar.bz2" .
+   tar -C /run/P3 -cjf "$1/persist.tar.bz2" status rsyslog log config checkpoint certs agentdebug
+}
+
+# measure of last resort: we nuke all partition tables
+# so that we can get to a blank state. NOTE that this
+# may damage installer image itself, but we don't really
+# care since that is trivial to re-create
+if grep -q eve_nuke_all_disks /proc/cmdline; then
+   echo -n "Nuking partition tables on:"
+   for i in $(lsblk -anlb -o "TYPE,NAME,SIZE" | grep "^disk" | awk '$3 { print $2;}'); do
+      echo -n " $i"
+      dd if=/dev/zero of="/dev/$i" bs=512 count=34 >/dev/null 2>&1
+   done
+   sync; sleep 5; sync
+   echo " done!"
+   poweroff -f
+fi
+
 # if we are running without a real root filesystem - we have to fake it here
 if [ ! -e /dev/root ]; then
    # we are running off of an initrd or initramfs
    # relying on init setting up mount points for us under /media
-   DEV_INIT="$(cd /media || exit 1 ; echo */rootfs.img | sed -e 's#/.*$##')"
-   ln -s "/media/$DEV_INIT" /bits
-   ln -s "/dev/$DEV_INIT" /dev/root
+   [ -d /media/boot ] || bail "FATAL: can't find installation artifacts"
+
+   ln -s /media/boot /bits
+   ln -s "/dev/$(basename "$(readlink /media/boot)")" /dev/root
 
    # FIXME: we need to run one thing from the install image to seed
    # the random generator for sgdisk invocatin via make-raw. We also
@@ -146,13 +175,7 @@ if mount_part INVENTORY "$(root_dev)" -t vfat -o iocharset=iso8859-1; then
    chroot "$PILLAR" /usr/sbin/dmidecode > "$REPORT/hardwaremodel.txt"
 
    # then we can collect our black box
-   if grep -q eve_blackbox /proc/cmdline; then
-      dmesg > "$REPORT/dmesg.txt"
-      tar -C /proc -cjf "$REPORT/procfs.tar.bz2" cpuinfo meminfo
-      tar -C /sys -cjf "$REPORT/sysfs.tar.bz2" .
-      tar -C /run/P3 -cjf "$REPORT/persist.tar.bz2" status rsyslog log config checkpoint certs agentdebug
-      tar -C /run/CONFIG -cjf "$REPORT/config.tar.bz2" .
-   fi 2>/dev/null
+   grep -q eve_blackbox /proc/cmdline && collect_black_box "$REPORT" 2>/dev/null
 fi
 
 # we also maybe asked to pause after

--- a/pkg/mkimage-raw-efi/make-raw
+++ b/pkg/mkimage-raw-efi/make-raw
@@ -149,6 +149,7 @@ do_boot() {
 do_installer() {
   mkefifs
   cp "$PERSIST_FILE" "$INITRD_IMG" "$ROOTFS_IMG" /UsbInvocationScript.txt /efifs
+  od -An -x -N 16 /dev/random | tr -d ' ' > /efifs/installer.uid
   do_system_vfat_part "$1" "$INSTALLER_SYS_PART_SIZE"
 }
 


### PR DESCRIPTION
Based on a few recent installer failures we are making it more robust when it comes to:
   * re-trying 3 times to discover installation media
   * validating installation media via a random "nonce" stored in installer.uid (nonce has to match what GRUB saw)
   * attempting to collect black box on installation failures

Plus a few random cosmetic nits AKA `2>/dev/null`
