### PR TITLE
Avoid showing app in transient error state when AppNetworkConfig is processed before network instances get created

### DIFF
--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -405,9 +405,9 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 		log.Infof("Waiting for AppNetworkStatus !Pending for %s", uuidStr)
 		return changed
 	}
-	if ns.MissingNetwork {
+	if ns.AwaitNetworkInstance {
 		log.Infof("Waiting for required network instances to arrive for %s", uuidStr)
-		status.State = types.AWAITNETWORK
+		status.State = types.AWAITNETWORKINSTANCE
 		changed = true
 		return changed
 	}

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -405,8 +405,7 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 		log.Infof("Waiting for AppNetworkStatus !Pending for %s", uuidStr)
 		return changed
 	}
-	status.AwaitNetwork = ns.AwaitNetwork
-	if ns.AwaitingNetwork() {
+	if ns.MissingNetwork {
 		log.Infof("Waiting for required network instances to arrive for %s", uuidStr)
 		status.State = types.AWAITNETWORK
 		changed = true

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -405,6 +405,13 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 		log.Infof("Waiting for AppNetworkStatus !Pending for %s", uuidStr)
 		return changed
 	}
+	status.AwaitNetwork = ns.AwaitNetwork
+	if ns.AwaitingNetwork() {
+		log.Infof("Waiting for required network instances to arrive for %s", uuidStr)
+		status.State = types.AWAITNETWORK
+		changed = true
+		return changed
+	}
 	if ns.HasError() {
 		log.Errorf("Received error from zedrouter for %s: %s",
 			uuidStr, ns.Error)

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -752,17 +752,17 @@ func doActivate(ctx *zedrouterContext, config types.AppNetworkConfig,
 		config.DisplayName, config.UUIDandVersion)
 
 	// Check that Network exists for all underlays.
-	// We look for MissingNetwork when a NetworkInstance is added
+	// We look for AwaitNetworkInstance when a NetworkInstance is added
 	allNetworksExist := appNetworkCheckAllNetworksExist(ctx, config, status)
 	if !allNetworksExist {
 		// XXX error or not?
-		status.MissingNetwork = true
+		status.AwaitNetworkInstance = true
 		log.Infof("doActivate(%v) for %s: missing networks\n",
 			config.UUIDandVersion, config.DisplayName)
 		publishAppNetworkStatus(ctx, status)
 		return
-	} else if status.MissingNetwork {
-		status.MissingNetwork = false
+	} else if status.AwaitNetworkInstance {
+		status.AwaitNetworkInstance = false
 		publishAppNetworkStatus(ctx, status)
 	}
 	appNetworkDoCopyNetworksToStatus(ctx, config, status)
@@ -1034,14 +1034,14 @@ func appNetworkCheckAllNetworksExist(
 		// configuration finally arrives.
 		// In such cases it is less confusing to put the app network in network wait state
 		// rather than in error state.
-		// We use the MissingNework in AppNetworkStatus that is already present.
+		// We use the AwaitNetworkInstance in AppNetworkStatus that is already present.
 		return false
 	}
 	return true
 }
 
 // Called when a NetworkInstance is added
-// Walk all AppNetworkStatus looking for MissingNetwork, then
+// Walk all AppNetworkStatus looking for AwaitNetworkInstance, then
 // check if network UUID is there.
 func checkAndRecreateAppNetwork(
 	ctx *zedrouterContext, network uuid.UUID) {
@@ -1051,7 +1051,7 @@ func checkAndRecreateAppNetwork(
 	items := pub.GetAll()
 	for _, st := range items {
 		status := st.(types.AppNetworkStatus)
-		if !status.MissingNetwork {
+		if !status.AwaitNetworkInstance {
 			continue
 		}
 		log.Infof("checkAndRecreateAppNetwork(%s) missing for %s\n",
@@ -1268,7 +1268,7 @@ func doAppNetworkSanityCheckForModify(ctx *zedrouterContext,
 		return false
 	}
 	// Wait for all network instances to arrive if they have not already.
-	if status.MissingNetwork {
+	if status.AwaitNetworkInstance {
 		log.Errorf("Still waiting for all network instances to arrive for %s",
 			config.UUIDandVersion)
 		return false

--- a/pkg/pillar/types/types.go
+++ b/pkg/pillar/types/types.go
@@ -35,7 +35,7 @@ const (
 	CREATING_VOLUME // Volume create in progress
 	CREATED_VOLUME  // Volume create done or failed
 	INSTALLED       // Available to be activated
-	AWAITNETWORK
+	AWAITNETWORKINSTANCE
 	BOOTING
 	RUNNING
 	PAUSING
@@ -76,8 +76,8 @@ func (state SwState) String() string {
 		return "CREATED_VOLUME"
 	case INSTALLED:
 		return "INSTALLED"
-	case AWAITNETWORK:
-		return "AWAITNETWORK"
+	case AWAITNETWORKINSTANCE:
+		return "AWAITNETWORKINSTANCE"
 	case BOOTING:
 		return "BOOTING"
 	case RUNNING:
@@ -127,7 +127,7 @@ func (state SwState) ZSwState() info.ZSwState {
 	case INSTALLED:
 		return info.ZSwState_INSTALLED
 	// XXX We should later have a new proto state that we can map AWAITNETWORK to
-	case AWAITNETWORK:
+	case AWAITNETWORKINSTANCE:
 		return info.ZSwState_INSTALLED
 	case BOOTING:
 		return info.ZSwState_BOOTING

--- a/pkg/pillar/types/types.go
+++ b/pkg/pillar/types/types.go
@@ -35,6 +35,7 @@ const (
 	CREATING_VOLUME // Volume create in progress
 	CREATED_VOLUME  // Volume create done or failed
 	INSTALLED       // Available to be activated
+	AWAITNETWORK
 	BOOTING
 	RUNNING
 	PAUSING
@@ -75,6 +76,8 @@ func (state SwState) String() string {
 		return "CREATED_VOLUME"
 	case INSTALLED:
 		return "INSTALLED"
+	case AWAITNETWORK:
+		return "AWAITNETWORK"
 	case BOOTING:
 		return "BOOTING"
 	case RUNNING:
@@ -122,6 +125,9 @@ func (state SwState) ZSwState() info.ZSwState {
 	case CREATED_VOLUME:
 		return info.ZSwState_CREATED_VOLUME
 	case INSTALLED:
+		return info.ZSwState_INSTALLED
+	// XXX We should later have a new proto state that we can map AWAITNETWORK to
+	case AWAITNETWORK:
 		return info.ZSwState_INSTALLED
 	case BOOTING:
 		return info.ZSwState_BOOTING

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -145,8 +145,7 @@ type AppInstanceStatus struct {
 	DisplayName         string
 	DomainName          string // Once booted
 	Activated           bool
-	ActivateInprogress  bool // Needed for cleanup after failure
-	AwaitNetwork        bool
+	ActivateInprogress  bool     // Needed for cleanup after failure
 	FixedResources      VmConfig // CPU etc
 	VolumeRefStatusList []VolumeRefStatus
 	EIDList             []EIDStatusDetails

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -145,7 +145,8 @@ type AppInstanceStatus struct {
 	DisplayName         string
 	DomainName          string // Once booted
 	Activated           bool
-	ActivateInprogress  bool     // Needed for cleanup after failure
+	ActivateInprogress  bool // Needed for cleanup after failure
+	AwaitNetwork        bool
 	FixedResources      VmConfig // CPU etc
 	VolumeRefStatusList []VolumeRefStatus
 	EIDList             []EIDStatusDetails

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -103,8 +103,9 @@ func (status AppNetworkStatus) Pending() bool {
 	return status.PendingAdd || status.PendingModify || status.PendingDelete
 }
 
+// AwaitingNetwork - Is the app waiting for network?
 func (status AppNetworkStatus) AwaitingNetwork() bool {
-	return status.AwaitNetwork
+	return status.MissingNetwork
 }
 
 // Indexed by UUID
@@ -115,7 +116,6 @@ type AppNetworkStatus struct {
 	PendingAdd     bool
 	PendingModify  bool
 	PendingDelete  bool
-	AwaitNetwork   bool
 	DisplayName    string
 	// Copy from the AppNetworkConfig; used to delete when config is gone.
 	GetStatsIPAddr      net.IP

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -105,7 +105,7 @@ func (status AppNetworkStatus) Pending() bool {
 
 // AwaitingNetwork - Is the app waiting for network?
 func (status AppNetworkStatus) AwaitingNetwork() bool {
-	return status.MissingNetwork
+	return status.AwaitNetworkInstance
 }
 
 // Indexed by UUID
@@ -118,9 +118,9 @@ type AppNetworkStatus struct {
 	PendingDelete  bool
 	DisplayName    string
 	// Copy from the AppNetworkConfig; used to delete when config is gone.
-	GetStatsIPAddr      net.IP
-	UnderlayNetworkList []UnderlayNetworkStatus
-	MissingNetwork      bool // If any Missing flag is set in the networks
+	GetStatsIPAddr       net.IP
+	UnderlayNetworkList  []UnderlayNetworkStatus
+	AwaitNetworkInstance bool // If any Missing flag is set in the networks
 	// Any errros from provisioning the network
 	// ErrorAndTime provides SetErrorNow() and ClearError()
 	ErrorAndTime

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -103,6 +103,10 @@ func (status AppNetworkStatus) Pending() bool {
 	return status.PendingAdd || status.PendingModify || status.PendingDelete
 }
 
+func (status AppNetworkStatus) AwaitingNetwork() bool {
+	return status.AwaitNetwork
+}
+
 // Indexed by UUID
 type AppNetworkStatus struct {
 	UUIDandVersion UUIDandVersion
@@ -111,6 +115,7 @@ type AppNetworkStatus struct {
 	PendingAdd     bool
 	PendingModify  bool
 	PendingDelete  bool
+	AwaitNetwork   bool
 	DisplayName    string
 	// Copy from the AppNetworkConfig; used to delete when config is gone.
 	GetStatsIPAddr      net.IP


### PR DESCRIPTION
Some times, AppNetworkConfig arrives at zedrouter before NetworkInstanceConfig does. With current code, AppNetworkStatus goes into error state stating that the required underlay network instance is absent. Later, when the required network instance configuration is received at zedrouter, app network processing resumes and the errors get cleared subsequently. This shows the app in error state for a brief duration.

This code fix puts such apps in AWAITINGNETWORKINSTANCE state instead of error state.