### PR TITLE
Fix: downloader deleted downloaded file before verifying

### DIFF
--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -370,6 +370,8 @@ func handleModify(ctx *downloaderContext, key string,
 		log.Infof("handleModify installing %s", config.Name)
 		handleCreate(ctx, config, status, key)
 	} else if status.RefCount != config.RefCount {
+		log.Infof("handleModify RefCount change %s from %d to %d",
+			config.Name, status.RefCount, config.RefCount)
 		status.RefCount = config.RefCount
 	}
 	status.LastUse = time.Now()


### PR DESCRIPTION
Issue: Verifier  failed with `stat /persist/vault/downloader/pending/<downloaded-file>: no such file or directory` error.

Reason: Downloader deleted the downloaded file before verifier was initiated. Below were the sequence of events which led to the error:
1. Deployed an app which created DownloadConfigA and DownloadStatusA
2. Deleted the app while it was in the downloading stage, so volumeMgr deleted DownloadConfigA
3. Downloader received request to delete DownloadStatusA but is waiting for DownloadStatusA to finish downloading
4. Deployed the same app immediately which created DownloadConfigB
5. VolumeMgr checks for a DownloadStatus progress and finds DownloadStatusA
6. DownloadStatusA finishes downloading and moves to DOWNLOADED state
7. VolumeMgr proceeded to verify the downloaded Blob by DownloadStatusA as it was waiting for a DownloadStatus response from Downloader. At the same time, Downloader notices that it has a request to delete DownloadStatusA and deletes DownloadStatusA along with the downloaded file
8. Verifier fails with stat /persist/vault/downloader/pending/<downloaded-file>: no such file or directory

Fix: volumeMgr will wait for Expired DownloadStatus from downloader before deleting  DownloadConfig. By doing this, if an app was deleted and deployed immediately, then volumeMgr will reuse the same DownloadConfg by incrementing it's Refcount instead of deleting and recreating it. 
   
Signed-off-by: adarsh-zededa <adarsh@zededa.com>