### PR TITLE
Move and slight reconfigure of .golangci.yaml

### DIFF
--- a/pkg/lisp/.golangci.yml
+++ b/pkg/lisp/.golangci.yml
@@ -7,11 +7,11 @@ linters:
   disable:
     - gochecknoglobals  # unreliable
     - golint            # covered by revive
+    - interfacer        # deprecated
     - lll               # line length check
+    - stylecheck        # covered by revive
     - typecheck         # See golangci/golangci-lint#419
-    - unused            # deprecated
     - varcheck          # unreliable
-    - interfacer        # unreliable
 
 issues:
   max-issues-per-linter: 0

--- a/pkg/pillar/.golangci.yml
+++ b/pkg/pillar/.golangci.yml
@@ -1,0 +1,18 @@
+---
+run:
+  deadline: 30m
+
+linters:
+  enable-all: true
+  disable:
+    - gochecknoglobals  # unreliable
+    - golint            # covered by revive
+    - interfacer        # deprecated
+    - lll               # line length check
+    - stylecheck        # covered by revive
+    - typecheck         # See golangci/golangci-lint#419
+    - varcheck          # unreliable
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/tests/integration/.golangci.yml
+++ b/tests/integration/.golangci.yml
@@ -1,0 +1,18 @@
+---
+run:
+  deadline: 30m
+
+linters:
+  enable-all: true
+  disable:
+    - gochecknoglobals  # unreliable
+    - golint            # covered by revive
+    - interfacer        # deprecated
+    - lll               # line length check
+    - stylecheck        # covered by revive
+    - typecheck         # See golangci/golangci-lint#419
+    - varcheck          # unreliable
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0


### PR DESCRIPTION
- Move .golangci.yml where golangci-lint can find them
  (need to be same dir as go.mod)
- Add versions for lisp and tests integration

Signed-off-by: Allen Wittenauer <aw@apache.org>