### PR TITLE
remove temporary dumpProcessMetricList

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -384,11 +384,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 			domainCtx.pids = pids
 			ps.CheckMaxTimeTopic(agentName, "publishProcesses", start,
 				warningTime, errorTime)
-			// XXX temporary until controller reports metrics
-			switch logger.GetLevel() {
-			case logrus.TraceLevel, logrus.DebugLevel:
-				dumpProcessMetricList(metrics)
-			}
 
 		case <-stillRunning.C:
 		}
@@ -421,11 +416,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 			domainCtx.pids = pids
 			ps.CheckMaxTimeTopic(agentName, "publishProcesses", start,
 				warningTime, errorTime)
-			// XXX temporary until controller reports metrics
-			switch logger.GetLevel() {
-			case logrus.TraceLevel, logrus.DebugLevel:
-				dumpProcessMetricList(metrics)
-			}
 
 		case <-stillRunning.C:
 		}
@@ -464,11 +454,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 			domainCtx.pids = pids
 			ps.CheckMaxTimeTopic(agentName, "publishProcesses", start,
 				warningTime, errorTime)
-			// XXX temporary until controller reports metrics
-			switch logger.GetLevel() {
-			case logrus.TraceLevel, logrus.DebugLevel:
-				dumpProcessMetricList(metrics)
-			}
 
 		case <-stillRunning.C:
 		}
@@ -518,11 +503,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 			domainCtx.pids = pids
 			ps.CheckMaxTimeTopic(agentName, "publishProcesses", start,
 				warningTime, errorTime)
-			// XXX temporary until controller reports metrics
-			switch logger.GetLevel() {
-			case logrus.TraceLevel, logrus.DebugLevel:
-				dumpProcessMetricList(metrics)
-			}
 
 		// Run stillRunning since we waiting for zedagent to deliver
 		// PhysicalIO which depends on cloud connectivity
@@ -593,11 +573,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 			domainCtx.pids = pids
 			ps.CheckMaxTimeTopic(agentName, "publishProcesses", start,
 				warningTime, errorTime)
-			// XXX temporary until controller reports metrics
-			switch logger.GetLevel() {
-			case logrus.TraceLevel, logrus.DebugLevel:
-				dumpProcessMetricList(metrics)
-			}
 
 		case <-stillRunning.C:
 		}

--- a/pkg/pillar/cmd/domainmgr/processes.go
+++ b/pkg/pillar/cmd/domainmgr/processes.go
@@ -7,10 +7,7 @@ package domainmgr
 // and their memory, thread, FD, etc usage
 
 import (
-	"encoding/json"
-	"fmt"
 	"io/ioutil"
-	"os"
 	"path"
 	"strconv"
 	"strings"
@@ -166,26 +163,4 @@ func unpublishProcessMetric(ctx *domainContext, pid uint32) {
 	log.Debugf("unpublishProcessMetric(%s)", key)
 	pub := ctx.pubProcessMetric
 	pub.Unpublish(key)
-}
-
-// XXX temporary until we have controller handle ProcessMetric
-func dumpProcessMetricList(metrics []types.ProcessMetric) {
-	const dumpFile = "/persist/log/ProcessMetrics.log"
-	file, err := os.OpenFile(dumpFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE,
-		0600)
-	if err != nil {
-		log.Errorf("dumpProcessMetricList failed: %s", err)
-		return
-	}
-	defer file.Close()
-
-	dateStr := time.Now().Format(time.RFC3339Nano)
-	file.WriteString(fmt.Sprintf("{\"time\": \"%s\"}\n", dateStr))
-	for _, m := range metrics {
-		b, err := json.Marshal(m)
-		if err != nil {
-			log.Fatal("json Marshal", err)
-		}
-		file.WriteString(fmt.Sprintf("%s\n", string(b)))
-	}
 }


### PR DESCRIPTION
Now we have the API in the commercial controler does a zcli edge-node show --raw will display the process metrics.