### PR TITLE
state machine of doUpdateVol fix

### DIFF
--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -419,7 +419,7 @@ func doUpdateVol(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool)
 			status.CurrentSize = ctStatus.CurrentSize
 			changed = true
 		}
-		if status.State != ctStatus.State {
+		if status.State != ctStatus.State && status.State < types.CREATING_VOLUME {
 			status.State = ctStatus.State
 			changed = true
 		}


### PR DESCRIPTION
Seems, that we must not sync the State of volume with state of the contentTree if we already went into CREATING_VOLUME.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>