### PR TITLE
Fixing domain stop/delete in xen hypervisor

### DIFF
--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -440,7 +440,6 @@ func (ctx xenContext) Delete(domainName string, domainID int) error {
 	if err := ctx.ctrdContext.Stop(domainName, domainID, true); err != nil {
 		return err
 	}
-
 	return ctx.ctrdContext.Delete(domainName, domainID)
 }
 


### PR DESCRIPTION
The task is not getting stopped/deleted after deactivating/deleting the app instance. Things are working fine (wrt EVE config/status) because we are giving up if wait time exceeds while waiting for the domain going away [here](https://github.com/lf-edge/eve/blob/06025b46ef0557efb9f20535f539b949f30ae81c/pkg/pillar/cmd/domainmgr/domainmgr.go#L1789).

This fix will also improve the instance bootup time on low specification devices.

In the latest master, we are waiting for 10 minutes for VM's and 1 minute for Containers while moving the state from ```Halting``` to ```Halted```