### PR TITLE
report volumerefs in app info message

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -912,6 +912,11 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 			ReportAppInfo.Network = append(ReportAppInfo.Network,
 				networkInfo)
 		}
+
+		for _, vr := range aiStatus.VolumeRefStatusList {
+			ReportAppInfo.VolumeRefs = append(ReportAppInfo.VolumeRefs,
+				vr.VolumeID.String())
+		}
 	}
 
 	ReportInfo.InfoContent = new(info.ZInfoMsg_Ainfo)


### PR DESCRIPTION
This was missing when we moved from reporting softwarelist. Controller doesn't yet depend on it which is why we didn't notice. 