### PR TITLE
Consider 5xx response from cloud as remote temporary failure. Clear old errors in DPC during start up.

### DIFF
--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -923,10 +923,10 @@ func tryDeviceConnectivityToCloud(ctx *devicenetwork.DeviceNetworkContext) bool 
 			log.Warnf("tryDeviceConnectivityToCloud: remoteTemporaryFailure: %s", err)
 		} else {
 			log.Infof("tryDeviceConnectivityToCloud: Device cloud connectivity test restart timer due to %s", err)
+			ctx.CloudConnectivityWorks = false
 		}
 		// Restart network test timer for next slot.
 		ctx.NetworkTestTimer = time.NewTimer(time.Duration(ctx.NetworkTestInterval) * time.Second)
-		ctx.CloudConnectivityWorks = false
 	}
 	return false
 }
@@ -988,7 +988,7 @@ func handleGlobalConfigModify(ctxArg interface{}, key string,
 			} else {
 				log.Infof("Starting TestBetterTimer: %d",
 					gcpNetworkTestBetterInterval)
-				networkTestBetterInterval := time.Duration(ctx.deviceNetworkContext.NetworkTestBetterInterval) * time.Second
+				networkTestBetterInterval := time.Duration(gcpNetworkTestBetterInterval) * time.Second
 				networkTestBetterTimer := time.NewTimer(networkTestBetterInterval)
 				ctx.deviceNetworkContext.NetworkTestBetterTimer = networkTestBetterTimer
 			}

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -919,14 +919,19 @@ func tryDeviceConnectivityToCloud(ctx *devicenetwork.DeviceNetworkContext) bool 
 			devicenetwork.RestartVerify(ctx, "tryDeviceConnectivityToCloud")
 		}
 	} else {
+		// Restart network test timer for next slot.
+		ctx.NetworkTestTimer = time.NewTimer(time.Duration(ctx.NetworkTestInterval) * time.Second)
 		if rtf {
+			// The fact that cloud replied with a status code shows that the cloud is UP, but not functioning
+			// fully at this time. So, we mark the cloud connectivity as UP for now.
 			log.Warnf("tryDeviceConnectivityToCloud: remoteTemporaryFailure: %s", err)
+			ctx.CloudConnectivityWorks = true
+
+			return true
 		} else {
 			log.Infof("tryDeviceConnectivityToCloud: Device cloud connectivity test restart timer due to %s", err)
 			ctx.CloudConnectivityWorks = false
 		}
-		// Restart network test timer for next slot.
-		ctx.NetworkTestTimer = time.NewTimer(time.Duration(ctx.NetworkTestInterval) * time.Second)
 	}
 	return false
 }

--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -682,6 +682,7 @@ func IngestPortConfigList(ctx *DeviceNetworkContext) {
 			portPtr := &portConfig.Ports[i]
 			portPtr.Clear()
 		}
+
 		if portConfig.CountMgmtPorts() == 0 {
 			log.Warnf("Stored DevicePortConfig key %s has no management ports; ignored",
 				portConfig.Key)

--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -677,6 +677,11 @@ func IngestPortConfigList(ctx *DeviceNetworkContext) {
 	log.Infof("Initial DPCL %v", storedDpcl)
 	var dpcl types.DevicePortConfigList
 	for _, portConfig := range storedDpcl.PortConfigList {
+		// Clear the errors from before reboot and start fresh.
+		for i := 0; i < len(portConfig.Ports); i++ {
+			portPtr := &portConfig.Ports[i]
+			portPtr.Clear()
+		}
 		if portConfig.CountMgmtPorts() == 0 {
 			log.Warnf("Stored DevicePortConfig key %s has no management ports; ignored",
 				portConfig.Key)

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -608,6 +608,13 @@ func (trPtr *TestResults) Update(src TestResults) {
 	}
 }
 
+// Clear test results.
+func (trPtr *TestResults) Clear() {
+	trPtr.LastFailed = time.Time{}
+	trPtr.LastSucceeded = time.Time{}
+	trPtr.LastError = ""
+}
+
 type DevicePortConfigVersion uint32
 
 // GetPortByIfName - DevicePortConfig method to get config pointer
@@ -927,6 +934,21 @@ type NetworkPortStatus struct {
 	ProxyConfig
 	// TestResults provides recording of failure and success
 	TestResults
+}
+
+// HasIPAndDNS - Check if the given port has a valid unicast IP along with DNS & Gateway.
+func (port NetworkPortStatus) HasIPAndDNS() bool {
+	foundUnicast := false
+	for _, addr := range port.AddrInfoList {
+		if !addr.Addr.IsLinkLocalUnicast() {
+			foundUnicast = true
+		}
+	}
+	if foundUnicast && len(port.DefaultRouters) > 0 && len(port.DNSServers) > 0 {
+		return true
+	}
+
+	return false
 }
 
 type AddrInfo struct {

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -939,11 +939,13 @@ type NetworkPortStatus struct {
 // HasIPAndDNS - Check if the given port has a valid unicast IP along with DNS & Gateway.
 func (port NetworkPortStatus) HasIPAndDNS() bool {
 	foundUnicast := false
+
 	for _, addr := range port.AddrInfoList {
 		if !addr.Addr.IsLinkLocalUnicast() {
 			foundUnicast = true
 		}
 	}
+
 	if foundUnicast && len(port.DefaultRouters) > 0 && len(port.DNSServers) > 0 {
 		return true
 	}

--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -191,6 +191,7 @@ func VerifyAllIntf(ctx *ZedCloudContext,
 		if port.IsMgmt {
 			continue
 		}
+
 		if port.HasIPAndDNS() {
 			intfStatusMap.RecordSuccess(port.IfName)
 		}


### PR DESCRIPTION
1) Cloud some times responds with 5xx response codes (ex: during upgrade) for device ping. Consider 5xx as temporary remote failure and not tear down current network.
2) Clear out old DPC errors during start up. Consider app-shared ports with working IP/DNS/Gateway as SUCCESS during DeviceNetworkStatus verification.
3) Timer interval was not set properly during the setup of NetworkTestBetterTimer

Signed-off-by: Gopi krishna Kodali <gkodali@zededa.com>