### PR TITLE
Temporarily lifting cgroup enforcements for KVM-based VMs

### DIFF
--- a/pkg/pillar/containerd/containerd.go
+++ b/pkg/pillar/containerd/containerd.go
@@ -619,8 +619,9 @@ func (client *Client) LKTaskPrepare(name, linuxkit string, domSettings *types.Do
 		if memOverhead > 0 {
 			spec.AdjustMemLimit(*domSettings, memOverhead)
 		}
-		spec.UpdateMountsNested(domStatus.DiskStatusList)
 	}
+
+	spec.UpdateMountsNested(domStatus.DiskStatusList)
 
 	if args != nil {
 		spec.Get().Process.Args = args


### PR DESCRIPTION
This temporary fix is done to increase disk performance of
guest VMs on KVM on EVE. We need to revisit this and fix it
properly in such a way that we can handle both disk performance
as well as resource partitioning together effectively.

Signed-off-by: Hariharasubramanian C S <cshari@zededa.com>