### PR TITLE
Decouple the ACLRules from the AppNetworkStatus for smaller messages

### DIFF
--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -309,13 +309,7 @@ func publishAppInstanceStatus(ctx *zedmanagerContext,
 	key := status.Key()
 	log.Debugf("publishAppInstanceStatus(%s)", key)
 	pub := ctx.pubAppInstanceStatus
-	// zedmanager AppInstanceStatus include UnderlayNetworkConfig twice, remove one
-	// in the UnderlayNetworks from []UnderlayNetworkStatus for publication
-	aiStatus := *status
-	for idx := range aiStatus.UnderlayNetworks {
-		aiStatus.UnderlayNetworks[idx].ACLs = []types.ACE{}
-	}
-	pub.Publish(key, aiStatus)
+	pub.Publish(key, *status)
 }
 
 func unpublishAppInstanceStatus(ctx *zedmanagerContext,

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -309,7 +309,13 @@ func publishAppInstanceStatus(ctx *zedmanagerContext,
 	key := status.Key()
 	log.Debugf("publishAppInstanceStatus(%s)", key)
 	pub := ctx.pubAppInstanceStatus
-	pub.Publish(key, *status)
+	// zedmanager AppInstanceStatus include UnderlayNetworkConfig twice, remove one
+	// in the UnderlayNetworks from []UnderlayNetworkStatus for publication
+	aiStatus := *status
+	for idx := range aiStatus.UnderlayNetworks {
+		aiStatus.UnderlayNetworks[idx].ACLs = []types.ACE{}
+	}
+	pub.Publish(key, aiStatus)
 }
 
 func unpublishAppInstanceStatus(ctx *zedmanagerContext,

--- a/pkg/pillar/cmd/zedrouter/flowstats.go
+++ b/pkg/pillar/cmd/zedrouter/flowstats.go
@@ -557,11 +557,8 @@ func checkAppAndACL(ctx *zedrouterContext, instData *networkAttrs) {
 				tmpMap := make(map[int]aclAttr)
 				instData.ipaclattr[status.AppNum] = tmpMap
 			}
-			if _, ok := ctx.NLaclMap[appID][ulStatus.Name]; !ok {
-				ctx.NLaclMap[appID][ulStatus.Name] = types.ULNetworkACLs{}
-			}
-			rlist := ctx.NLaclMap[appID][ulStatus.Name].ACLRules
-			for _, rule := range rlist {
+			rules := getNetworkACLRules(ctx, appID, ulStatus.Name)
+			for _, rule := range rules.ACLRules {
 				if (rule.IsUserConfigured == false || rule.IsMarkingRule == true) &&
 					rule.IsDefaultDrop == false {
 					// only include user defined rules and default drop rules

--- a/pkg/pillar/cmd/zedrouter/flowstats.go
+++ b/pkg/pillar/cmd/zedrouter/flowstats.go
@@ -515,6 +515,7 @@ func checkAppAndACL(ctx *zedrouterContext, instData *networkAttrs) {
 	items := pub.GetAll()
 	for _, st := range items {
 		status := st.(types.AppNetworkStatus)
+		appID := status.UUIDandVersion.UUID
 		for i, ulStatus := range status.UnderlayNetworkList {
 			log.Debugf("===FlowStats: (index %d) AppNum %d, VifInfo %v, IP addr %v, Hostname %s\n",
 				i, status.AppNum, ulStatus.VifInfo, ulStatus.AllocatedIPAddr, ulStatus.HostName)
@@ -556,7 +557,11 @@ func checkAppAndACL(ctx *zedrouterContext, instData *networkAttrs) {
 				tmpMap := make(map[int]aclAttr)
 				instData.ipaclattr[status.AppNum] = tmpMap
 			}
-			for _, rule := range ulStatus.ACLRules {
+			if _, ok := ctx.NLaclMap[appID][ulStatus.Name]; !ok {
+				ctx.NLaclMap[appID][ulStatus.Name] = types.ULNetworkACLs{}
+			}
+			rlist := ctx.NLaclMap[appID][ulStatus.Name].ACLRules
+			for _, rule := range rlist {
 				if (rule.IsUserConfigured == false || rule.IsMarkingRule == true) &&
 					rule.IsDefaultDrop == false {
 					// only include user defined rules and default drop rules

--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -379,6 +379,11 @@ func getNetworkACLRules(ctx *zedrouterContext, appID uuid.UUID, intf string) typ
 }
 
 func setNetworkACLRules(ctx *zedrouterContext, appID uuid.UUID, intf string, rulelist types.IPTablesRuleList) {
+	tmpMap := ctx.NLaclMap[appID]
+	if tmpMap == nil {
+		ctx.NLaclMap[appID] = make(map[string]types.ULNetworkACLs)
+	}
+
 	if len(rulelist) == 0 {
 		delete(ctx.NLaclMap[appID], intf)
 	} else {

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -953,7 +953,6 @@ func appNetworkDoActivateUnderlayNetwork(
 		addError(ctx, status, "createACL", err)
 	}
 	appID := status.UUIDandVersion.UUID
-	getNetworkACLRules(ctx, appID, ulStatus.Name)
 	setNetworkACLRules(ctx, appID, ulStatus.Name, ruleList)
 
 	if appIPAddr != "" {

--- a/pkg/pillar/go.sum
+++ b/pkg/pillar/go.sum
@@ -693,6 +693,7 @@ golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190209173611-3b5209105503/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190405154228-4b34438f7a67/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190410235845-0ad05ae3009d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -1721,6 +1721,7 @@ type UnderlayNetworkStatus struct {
 }
 
 // ULNetworkACLs - Underlay Network ACLRules
+// moved out from UnderlayNetowrkStatus, and now ACLRules are kept in zedrouterContext 2D-map NLaclMap
 type ULNetworkACLs struct {
 	ACLRules IPTablesRuleList
 }

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -1718,7 +1718,11 @@ type UnderlayNetworkStatus struct {
 	Assigned        bool   // Set to true once DHCP has assigned it to domU
 	IPAddrMisMatch  bool
 	HostName        string
-	ACLRules        IPTablesRuleList
+}
+
+// ULNetworkACLs - Underlay Network ACLRules
+type ULNetworkACLs struct {
+	ACLRules IPTablesRuleList
 }
 
 type NetworkType uint8


### PR DESCRIPTION
Signed-off-by: Naiming Shen <naiming@zededa.com>
- Will do a integration test in app/network area on this change
- remove ACLRules from UnderlayNetworkStatus{} and add a 2D map for app-uuid/intf-name for ACLRules
- zero out the ACLs in zedmanager pub in AppInstanceStatus, since it has it in configure portion
- tested in production device, the json file size reduced from 47K to about 6K, observed that when adding one more ACL that json file size increase about 256bytes, so we'll have room for 1000 more ACLs to go