### PR TITLE
Hack to enable floating tags for other branches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,11 @@ FORCE_BUILD=--force
 
 ifeq ($(LINUXKIT_PKG_TARGET),push)
   EVE_REL:=$(REPO_TAG)
-  ifneq ($(EVE_REL),snapshot)
+  ifeq ($(EVE_REL),snapshot)
+    ifneq ($(REPO_BRANCH),master)
+      EVE_REL=$(REPO_BRANCH)
+    endif
+  else
     EVE_HASH:=$(EVE_REL)
     EVE_REL:=$(shell [ "`git tag | grep -E '[0-9]*\.[0-9]*\.[0-9]*' | sort -t. -n -k1,1 -k2,2 -k3,3 | tail -1`" = $(EVE_HASH) ] && echo latest)
   endif


### PR DESCRIPTION
So hear me out @eriknordmark @kalyan-nidumolu @deitch -- this quick hack enables us to have floating Docker HUB tags for branches. This means that if you have a branch `foobar` -- whatever you push into it will get deposited in docker containers with a tag `foobar`. The only exception to that rules is branch `master` -- at this point I'd rather call the floading Docker HUB tag `master` as well, but since we've been running for quite some time using `snapshot` as that floating tag instead -- I'm keeping it for compatibility purposes.

However, if y'all think that consistency is more desirable here -- we can start calling it `master` as well.

Long story short: from now on `docker pull lfedge/eve:snapshot` and `docker pull lfedge/eve:foobar` will do the right thing. However `docker pull lfedge/eve:master` won't work since we're still using `snapshot` for that tag's name.