### PR TITLE
Making release jobs runs to completion (or failure) on all builders

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ARM64, ubuntu-20.04]
     steps:


### PR DESCRIPTION
Signed-off-by: Roman Shaposhnik <rvs@zededa.com>