### PR TITLE
Avoid hung downloads using TCP keepalive

### DIFF
--- a/pkg/dom0-ztools/rootfs/etc/sysctl.d/02-eve.conf
+++ b/pkg/dom0-ztools/rootfs/etc/sysctl.d/02-eve.conf
@@ -20,6 +20,9 @@ net.netfilter.nf_conntrack_timestamp = 1
 net.ipv4.conf.all.log_martians = 1
 net.ipv4.conf.default.log_martians = 1
 
+# For reliable downloads need less than 2 hour keepalive timer
+net.ipv4.tcp_keepalive_time = 60
+
 # flowstats settings
 # Adjust the conntrack flow session timeout values
 # by adding 150 seconds on top of default seconds


### PR DESCRIPTION
We run zedUpload with TCP keepalive enabled, but that is currently not very useful since the kernel default keepalive timer is 2 hours hence no connection will be reset in less than 2 hours due to a keepalive.
So let's lower than time and have the connections clean up faster.