### PR TITLE
Reduce tracking old state by passing old to Modify handler

### DIFF
--- a/pkg/pillar/agentlog/agentlog_test.go
+++ b/pkg/pillar/agentlog/agentlog_test.go
@@ -158,7 +158,7 @@ func TestPubsubLog(t *testing.T) {
 		t.Logf("subCreateHandler")
 		created = true
 	}
-	subModifyHandler := func(ctxArg interface{}, key string, status interface{}) {
+	subModifyHandler := func(ctxArg interface{}, key string, status interface{}, oldStatus interface{}) {
 		t.Logf("subModifyHandler")
 		modified = true
 	}

--- a/pkg/pillar/agentlog/loglevel.go
+++ b/pkg/pillar/agentlog/loglevel.go
@@ -152,7 +152,7 @@ func handleGlobalConfigImpl(log *base.LogObject, sub pubsub.Subscription, agentN
 			log.Errorf("***ParseLevel %s failed: %s\n", loglevel, err)
 		} else {
 			level = l
-			log.Infof("handleGlobalConfigModify: level %v\n",
+			log.Infof("HandleGlobalConfigImpl: level %v\n",
 				level)
 		}
 		if level == logrus.TraceLevel {

--- a/pkg/pillar/cmd/baseosmgr/handlevolumemgr.go
+++ b/pkg/pillar/cmd/baseosmgr/handlevolumemgr.go
@@ -79,18 +79,29 @@ func unpublishContentTreeConfig(ctx *baseOsMgrContext, key string) {
 	pub.Unpublish(key)
 }
 
-func handleContentTreeStatusModify(ctxArg interface{}, key string,
+func handleContentTreeStatusCreate(ctxArg interface{}, key string,
 	statusArg interface{}) {
+	handleContentTreeStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleContentTreeStatusModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleContentTreeStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleContentTreeStatusImpl(ctxArg interface{}, key string,
+	statusArg interface{}) {
+
 	status := statusArg.(types.ContentTreeStatus)
 	ctx := ctxArg.(*baseOsMgrContext)
-	log.Infof("handleContentTreeStatusModify: key:%s, name:%s",
+	log.Infof("handleContentTreeStatusImpl: key:%s, name:%s",
 		key, status.DisplayName)
 	if status.ContentSha256 != "" {
 		baseOsHandleStatusUpdateImageSha(ctx, status.ContentSha256)
 	} else {
 		log.Warnf("Unknown content tree: %s", status.ContentID.String())
 	}
-	log.Infof("handleContentTreeStatusModify done for %s", key)
+	log.Infof("handleContentTreeStatusImpl done for %s", key)
 }
 
 func handleContentTreeStatusDelete(ctxArg interface{}, key string,

--- a/pkg/pillar/cmd/downloader/context.go
+++ b/pkg/pillar/cmd/downloader/context.go
@@ -84,7 +84,7 @@ func (ctx *downloaderContext) registerHandlers(ps *pubsub.PubSub) error {
 	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "zedagent",
 		MyAgentName:   agentName,
-		CreateHandler: handleGlobalConfigModify,
+		CreateHandler: handleGlobalConfigCreate,
 		ModifyHandler: handleGlobalConfigModify,
 		DeleteHandler: handleGlobalConfigDelete,
 		WarningTime:   warningTime,
@@ -100,7 +100,7 @@ func (ctx *downloaderContext) registerHandlers(ps *pubsub.PubSub) error {
 	subGlobalConfig.Activate()
 
 	subDeviceNetworkStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		CreateHandler: handleDNSModify,
+		CreateHandler: handleDNSCreate,
 		ModifyHandler: handleDNSModify,
 		DeleteHandler: handleDNSDelete,
 		WarningTime:   warningTime,
@@ -120,7 +120,7 @@ func (ctx *downloaderContext) registerHandlers(ps *pubsub.PubSub) error {
 	// before any download config. Without DataStore Config,
 	// Image Downloads will run into errors, which requires retries
 	subDatastoreConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		CreateHandler: handleDatastoreConfigModify,
+		CreateHandler: handleDatastoreConfigCreate,
 		ModifyHandler: handleDatastoreConfigModify,
 		DeleteHandler: handleDatastoreConfigDelete,
 		WarningTime:   warningTime,
@@ -182,7 +182,7 @@ func (ctx *downloaderContext) registerHandlers(ps *pubsub.PubSub) error {
 	subDownloaderConfig.Activate()
 
 	subResolveConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		CreateHandler: handleResolveModify,
+		CreateHandler: handleResolveCreate,
 		ModifyHandler: handleResolveModify,
 		DeleteHandler: handleResolveDelete,
 		WarningTime:   warningTime,

--- a/pkg/pillar/cmd/downloader/datastoreconfig.go
+++ b/pkg/pillar/cmd/downloader/datastoreconfig.go
@@ -7,15 +7,24 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/types"
 )
 
-// Handles both create and modify events
+func handleDatastoreConfigCreate(ctxArg interface{}, key string,
+	configArg interface{}) {
+	handleDatastoreConfigImpl(ctxArg, key, configArg)
+}
+
 func handleDatastoreConfigModify(ctxArg interface{}, key string,
+	configArg interface{}, oldConfigArg interface{}) {
+	handleDatastoreConfigImpl(ctxArg, key, configArg)
+}
+
+func handleDatastoreConfigImpl(ctxArg interface{}, key string,
 	configArg interface{}) {
 
 	ctx := ctxArg.(*downloaderContext)
 	config := configArg.(types.DatastoreConfig)
-	log.Infof("handleDatastoreConfigModify for %s", key)
+	log.Infof("handleDatastoreConfigImpl for %s", key)
 	checkAndUpdateDownloadableObjects(ctx, config.UUID)
-	log.Infof("handleDatastoreConfigModify for %s, done", key)
+	log.Infof("handleDatastoreConfigImpl for %s, done", key)
 }
 
 func handleDatastoreConfigDelete(ctxArg interface{}, key string,

--- a/pkg/pillar/cmd/downloader/dns.go
+++ b/pkg/pillar/cmd/downloader/dns.go
@@ -7,27 +7,37 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/types"
 )
 
-// Handles both create and modify events
-func handleDNSModify(ctxArg interface{}, key string, statusArg interface{}) {
+func handleDNSCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleDNSImpl(ctxArg, key, statusArg)
+}
+
+func handleDNSModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleDNSImpl(ctxArg, key, statusArg)
+}
+
+func handleDNSImpl(ctxArg interface{}, key string,
+	statusArg interface{}) {
 
 	ctx := ctxArg.(*downloaderContext)
 	status := statusArg.(types.DeviceNetworkStatus)
 	if key != "global" {
-		log.Infof("handleDNSModify: ignoring %s", key)
+		log.Infof("handleDNSImpl: ignoring %s", key)
 		return
 	}
-	log.Infof("handleDNSModify for %s", key)
+	log.Infof("handleDNSImpl for %s", key)
 	// Ignore test status and timestamps
 	if ctx.deviceNetworkStatus.MostlyEqual(status) {
-		log.Infof("handleDNSModify unchanged")
+		log.Infof("handleDNSImpl unchanged")
 		return
 	}
 	ctx.deviceNetworkStatus = status
-	log.Infof("handleDNSModify %d free management ports addresses; %d any",
+	log.Infof("handleDNSImpl %d free management ports addresses; %d any",
 		types.CountLocalAddrFreeNoLinkLocal(ctx.deviceNetworkStatus),
 		types.CountLocalAddrAnyNoLinkLocal(ctx.deviceNetworkStatus))
 
-	log.Infof("handleDNSModify done for %s", key)
+	log.Infof("handleDNSImpl done for %s", key)
 }
 
 func handleDNSDelete(ctxArg interface{}, key string, statusArg interface{}) {

--- a/pkg/pillar/cmd/downloader/globalconfig.go
+++ b/pkg/pillar/cmd/downloader/globalconfig.go
@@ -10,16 +10,25 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/types"
 )
 
-// Handles both create and modify events
+func handleGlobalConfigCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleGlobalConfigImpl(ctxArg, key, statusArg)
+}
+
 func handleGlobalConfigModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleGlobalConfigImpl(ctxArg, key, statusArg)
+}
+
+func handleGlobalConfigImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
 	ctx := ctxArg.(*downloaderContext)
 	if key != "global" {
-		log.Infof("handleGlobalConfigModify: ignoring %s", key)
+		log.Infof("handleGlobalConfigImpl: ignoring %s", key)
 		return
 	}
-	log.Infof("handleGlobalConfigModify for %s", key)
+	log.Infof("handleGlobalConfigImpl for %s", key)
 	var gcp *types.ConfigItemValueMap
 	debug, gcp = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
 		debugOverride, logger)
@@ -29,7 +38,7 @@ func handleGlobalConfigModify(ctxArg interface{}, key string,
 		}
 		ctx.GCInitialized = true
 	}
-	log.Infof("handleGlobalConfigModify done for %s", key)
+	log.Infof("handleGlobalConfigImpl done for %s", key)
 }
 
 func handleGlobalConfigDelete(ctxArg interface{}, key string,

--- a/pkg/pillar/cmd/downloader/handleconfig.go
+++ b/pkg/pillar/cmd/downloader/handleconfig.go
@@ -4,7 +4,7 @@
 package downloader
 
 func handleDownloaderConfigModify(ctxArg interface{}, key string,
-	configArg interface{}) {
+	configArg interface{}, oldConfigArg interface{}) {
 
 	dHandler.modify(ctxArg, key, configArg)
 }

--- a/pkg/pillar/cmd/downloader/resolveimg.go
+++ b/pkg/pillar/cmd/downloader/resolveimg.go
@@ -4,11 +4,19 @@
 package downloader
 
 // for function name consistency
-func handleResolveModify(ctxArg interface{}, key string,
+func handleResolveCreate(ctxArg interface{}, key string,
 	configArg interface{}) {
 
+	log.Infof("handleResolveCreate for %s", key)
+	resHandler.create(ctxArg, key, configArg)
+	log.Infof("handleResolveCreate for %s, done", key)
+}
+
+func handleResolveModify(ctxArg interface{}, key string,
+	configArg interface{}, oldConfigArg interface{}) {
+
 	log.Infof("handleResolveModify for %s", key)
-	resHandler.modify(ctxArg, key, configArg)
+	resHandler.modify(ctxArg, key, configArg, oldConfigArg)
 	log.Infof("handleResolveModify for %s, done", key)
 }
 

--- a/pkg/pillar/cmd/executor/exec.go
+++ b/pkg/pillar/cmd/executor/exec.go
@@ -109,7 +109,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		TopicImpl:     types.ConfigItemValueMap{},
 		Persistent:    true,
 		Ctx:           &execCtx,
-		CreateHandler: handleGlobalConfigModify,
+		CreateHandler: handleGlobalConfigCreate,
 		ModifyHandler: handleGlobalConfigModify,
 		DeleteHandler: handleGlobalConfigDelete,
 		WarningTime:   warningTime,
@@ -252,7 +252,7 @@ func handleCreate(ctxArg interface{}, key string,
 }
 
 func handleModify(ctxArg interface{}, key string,
-	configArg interface{}) {
+	configArg interface{}, oldConfigArg interface{}) {
 
 	execCtx := ctxArg.(*executorContext)
 	config := configArg.(types.ExecConfig)
@@ -366,23 +366,32 @@ func launchCmd(execCtx *executorContext, config types.ExecConfig) *types.ExecSta
 	return &status
 }
 
-// Handles both create and modify events
+func handleGlobalConfigCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleGlobalConfigImpl(ctxArg, key, statusArg)
+}
+
 func handleGlobalConfigModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleGlobalConfigImpl(ctxArg, key, statusArg)
+}
+
+func handleGlobalConfigImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
 	execCtx := ctxArg.(*executorContext)
 	if key != "global" {
-		log.Infof("handleGlobalConfigModify: ignoring %s", key)
+		log.Infof("handleGlobalConfigImpl: ignoring %s", key)
 		return
 	}
-	log.Infof("handleGlobalConfigModify for %s", key)
+	log.Infof("handleGlobalConfigImpl for %s", key)
 	var gcp *types.ConfigItemValueMap
 	execCtx.debug, gcp = agentlog.HandleGlobalConfig(log, execCtx.subGlobalConfig, agentName,
 		execCtx.debugOverride, logger)
 	if gcp != nil {
 		execCtx.GCInitialized = true
 	}
-	log.Infof("handleGlobalConfigModify done for %s", key)
+	log.Infof("handleGlobalConfigImpl done for %s", key)
 }
 
 func handleGlobalConfigDelete(ctxArg interface{}, key string,

--- a/pkg/pillar/cmd/ipcmonitor/ipcmonitor.go
+++ b/pkg/pillar/cmd/ipcmonitor/ipcmonitor.go
@@ -196,7 +196,7 @@ func handleCreate(ctxArg interface{}, key string,
 }
 
 func handleModify(ctxArg interface{}, key string,
-	statusArg interface{}) {
+	statusArg interface{}, oldStatusArg interface{}) {
 
 	log.Infof("handleModify(%s) type %T\n", key, statusArg)
 	switch statusArg.(type) {

--- a/pkg/pillar/cmd/logmanager/domainstatus.go
+++ b/pkg/pillar/cmd/logmanager/domainstatus.go
@@ -21,19 +21,29 @@ func lookupDomainName(ctxArg interface{}, domainName string) string {
 // Map from domainName to the UUID
 var domainUuid map[string]string = make(map[string]string)
 
+func handleDomainStatusCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleDomainStatusImpl(ctxArg, key, statusArg)
+}
+
 func handleDomainStatusModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleDomainStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleDomainStatusImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
 	ctx := ctxArg.(*logmanagerContext)
 	ctx.Lock()
 	defer ctx.Unlock()
-	log.Infof("handleDomainStatusModify for %s", key)
+	log.Infof("handleDomainStatusImpl for %s", key)
 	status := statusArg.(types.DomainStatus)
 	// Record the domainName even if Pending* is set
-	log.Infof("handleDomainStatusModify add %s to %s",
+	log.Infof("handleDomainStatusImpl add %s to %s",
 		status.DomainName, status.UUIDandVersion.UUID.String())
 	domainUuid[status.DomainName] = status.UUIDandVersion.UUID.String()
-	log.Infof("handleDomainStatusModify done for %s", key)
+	log.Infof("handleDomainStatusImpl done for %s", key)
 }
 
 func handleDomainStatusDelete(ctxArg interface{}, key string,

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -126,7 +126,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		Persistent:    true,
 		Activate:      false,
 		Ctx:           &nimCtx,
-		CreateHandler: handleGlobalConfigModify,
+		CreateHandler: handleGlobalConfigCreate,
 		ModifyHandler: handleGlobalConfigModify,
 		DeleteHandler: handleGlobalConfigDelete,
 		SyncHandler:   handleGlobalConfigSynchronized,
@@ -280,7 +280,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		TopicImpl:     types.DevicePortConfig{},
 		Activate:      false,
 		Ctx:           &nimCtx.deviceNetworkContext,
-		CreateHandler: devicenetwork.HandleDPCModify,
+		CreateHandler: devicenetwork.HandleDPCCreate,
 		ModifyHandler: devicenetwork.HandleDPCModify,
 		DeleteHandler: devicenetwork.HandleDPCDelete,
 		WarningTime:   warningTime,
@@ -298,7 +298,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		TopicImpl:     types.DevicePortConfig{},
 		Activate:      false,
 		Ctx:           &nimCtx.deviceNetworkContext,
-		CreateHandler: devicenetwork.HandleDPCModify,
+		CreateHandler: devicenetwork.HandleDPCCreate,
 		ModifyHandler: devicenetwork.HandleDPCModify,
 		DeleteHandler: devicenetwork.HandleDPCDelete,
 		WarningTime:   warningTime,
@@ -316,7 +316,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		TopicImpl:     types.DevicePortConfig{},
 		Activate:      false,
 		Ctx:           &nimCtx.deviceNetworkContext,
-		CreateHandler: devicenetwork.HandleDPCModify,
+		CreateHandler: devicenetwork.HandleDPCCreate,
 		ModifyHandler: devicenetwork.HandleDPCModify,
 		DeleteHandler: devicenetwork.HandleDPCDelete,
 		WarningTime:   warningTime,
@@ -334,7 +334,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		TopicImpl:     types.AssignableAdapters{},
 		Activate:      false,
 		Ctx:           &nimCtx.deviceNetworkContext,
-		CreateHandler: devicenetwork.HandleAssignableAdaptersModify,
+		CreateHandler: devicenetwork.HandleAssignableAdaptersCreate,
 		ModifyHandler: devicenetwork.HandleAssignableAdaptersModify,
 		DeleteHandler: devicenetwork.HandleAssignableAdaptersDelete,
 		WarningTime:   warningTime,
@@ -352,7 +352,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		TopicImpl:     types.NetworkInstanceStatus{},
 		Activate:      false,
 		Ctx:           &nimCtx,
-		CreateHandler: handleNetworkInstanceModify,
+		CreateHandler: handleNetworkInstanceCreate,
 		ModifyHandler: handleNetworkInstanceModify,
 		DeleteHandler: handleNetworkInstanceDelete,
 		WarningTime:   warningTime,
@@ -947,16 +947,25 @@ func publishDeviceNetworkStatus(ctx *nimContext) {
 	ctx.deviceNetworkContext.PubDeviceNetworkStatus.Publish("global", *ctx.deviceNetworkContext.DeviceNetworkStatus)
 }
 
-// Handles both create and modify events
+func handleGlobalConfigCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleGlobalConfigImpl(ctxArg, key, statusArg)
+}
+
 func handleGlobalConfigModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleGlobalConfigImpl(ctxArg, key, statusArg)
+}
+
+func handleGlobalConfigImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
 	ctx := ctxArg.(*nimContext)
 	if key != "global" {
-		log.Infof("handleGlobalConfigModify: ignoring %s", key)
+		log.Infof("handleGlobalConfigImpl: ignoring %s", key)
 		return
 	}
-	log.Infof("handleGlobalConfigModify for %s", key)
+	log.Infof("handleGlobalConfigImpl for %s", key)
 	var gcp *types.ConfigItemValueMap
 	ctx.debug, gcp = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
 		ctx.debugOverride, logger)
@@ -1006,7 +1015,7 @@ func handleGlobalConfigModify(ctxArg interface{}, key string,
 		dnc.TestSendTimeout = ctx.globalConfig.GlobalValueInt(types.NetworkTestTimeout)
 	}
 	ctx.GCInitialized = true
-	log.Infof("handleGlobalConfigModify done for %s", key)
+	log.Infof("handleGlobalConfigImpl done for %s", key)
 }
 
 func handleGlobalConfigDelete(ctxArg interface{}, key string,
@@ -1038,14 +1047,24 @@ func handleGlobalConfigSynchronized(ctxArg interface{}, done bool) {
 	}
 }
 
-// Handles both create and modify events
-func handleNetworkInstanceModify(ctxArg interface{}, key string, statusArg interface{}) {
+func handleNetworkInstanceCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleNetworkInstanceImpl(ctxArg, key, statusArg)
+}
 
-	log.Infof("handleNetworkInstanceStatusModify(%s)", key)
+func handleNetworkInstanceModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleNetworkInstanceImpl(ctxArg, key, statusArg)
+}
+
+func handleNetworkInstanceImpl(ctxArg interface{}, key string,
+	statusArg interface{}) {
+
+	log.Infof("handleNetworkInstanceStatusImpl(%s)", key)
 	ctx := ctxArg.(*nimContext)
 	// Hard to check if any switch NI was added, deleted, or changed
 	updateFilteredFallback(ctx)
-	log.Infof("handleNetworkInstanceModify(%s) done", key)
+	log.Infof("handleNetworkInstanceImpl(%s) done", key)
 }
 
 func handleNetworkInstanceDelete(ctxArg interface{}, key string,

--- a/pkg/pillar/cmd/verifier/handleconfig.go
+++ b/pkg/pillar/cmd/verifier/handleconfig.go
@@ -3,8 +3,8 @@
 
 package verifier
 
-func handleVerifyImageConfigModify(ctxArg interface{}, key string, configArg interface{}) {
-	vHandler.modify(ctxArg, key, configArg)
+func handleVerifyImageConfigModify(ctxArg interface{}, key string, configArg interface{}, oldConfigArg interface{}) {
+	vHandler.modify(ctxArg, key, configArg, oldConfigArg)
 }
 
 func handleVerifyImageConfigCreate(ctxArg interface{}, key string, configArg interface{}) {

--- a/pkg/pillar/cmd/verifier/handlers.go
+++ b/pkg/pillar/cmd/verifier/handlers.go
@@ -33,7 +33,7 @@ func makeVerifyHandler() *verifyHandler {
 
 // Determine whether it is an create or modify
 func (v *verifyHandler) modify(ctxArg interface{},
-	key string, configArg interface{}) {
+	key string, configArg interface{}, oldConfigArg interface{}) {
 
 	typeName := pubsub.TypeToName(configArg)
 	handlerKey := fmt.Sprintf("%s+%s", typeName, key)

--- a/pkg/pillar/cmd/verifier/verifier.go
+++ b/pkg/pillar/cmd/verifier/verifier.go
@@ -111,7 +111,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		Persistent:    true,
 		Activate:      false,
 		Ctx:           &ctx,
-		CreateHandler: handleGlobalConfigModify,
+		CreateHandler: handleGlobalConfigCreate,
 		ModifyHandler: handleGlobalConfigModify,
 		DeleteHandler: handleGlobalConfigDelete,
 		WarningTime:   warningTime,
@@ -446,23 +446,32 @@ func handleDelete(ctx *verifierContext, status *types.VerifyImageStatus) {
 	log.Infof("handleDelete done for %s", status.ImageSha256)
 }
 
-// Handles both create and modify events
+func handleGlobalConfigCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleGlobalConfigImpl(ctxArg, key, statusArg)
+}
+
 func handleGlobalConfigModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleGlobalConfigImpl(ctxArg, key, statusArg)
+}
+
+func handleGlobalConfigImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
 	ctx := ctxArg.(*verifierContext)
 	if key != "global" {
-		log.Infof("handleGlobalConfigModify: ignoring %s", key)
+		log.Infof("handleGlobalConfigImpl: ignoring %s", key)
 		return
 	}
-	log.Infof("handleGlobalConfigModify for %s", key)
+	log.Infof("handleGlobalConfigImpl for %s", key)
 	var gcp *types.ConfigItemValueMap
 	debug, gcp = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
 		debugOverride, logger)
 	if gcp != nil {
 		ctx.GCInitialized = true
 	}
-	log.Infof("handleGlobalConfigModify done for %s", key)
+	log.Infof("handleGlobalConfigImpl done for %s", key)
 }
 
 func handleGlobalConfigDelete(ctxArg interface{}, key string,

--- a/pkg/pillar/cmd/volumemgr/handlecontent.go
+++ b/pkg/pillar/cmd/volumemgr/handlecontent.go
@@ -25,9 +25,9 @@ func handleContentTreeCreateAppImg(ctxArg interface{}, key string,
 }
 
 func handleContentTreeModifyAppImg(ctxArg interface{}, key string,
-	configArg interface{}) {
+	configArg interface{}, oldConfigArg interface{}) {
 
-	log.Infof("handleContentTreeModify(%s)", key)
+	log.Infof("handleContentTreeModifyAppImg(%s)", key)
 	config := configArg.(types.ContentTreeConfig)
 	ctx := ctxArg.(*volumemgrContext)
 	status := lookupContentTreeStatus(ctx, config.Key(), types.AppImgObj)
@@ -35,13 +35,13 @@ func handleContentTreeModifyAppImg(ctxArg interface{}, key string,
 		log.Fatalf("Missing ContentTreeStatus for %s", config.Key())
 	}
 	updateContentTree(ctx, status)
-	log.Infof("handleContentTreeModify(%s) Done", key)
+	log.Infof("handleContentTreeAppImg(%s) Done", key)
 }
 
 func handleContentTreeDeleteAppImg(ctxArg interface{}, key string,
 	configArg interface{}) {
 
-	log.Infof("handleContentTreeDelete(%s)", key)
+	log.Infof("handleContentTreeDeleteAppImg(%s)", key)
 	config := configArg.(types.ContentTreeConfig)
 	ctx := ctxArg.(*volumemgrContext)
 	status := lookupContentTreeStatus(ctx, config.Key(), types.AppImgObj)
@@ -49,7 +49,7 @@ func handleContentTreeDeleteAppImg(ctxArg interface{}, key string,
 		log.Fatalf("Missing ContentTreeStatus for %s", config.Key())
 	}
 	deleteContentTree(ctx, status)
-	log.Infof("handleContentTreeModify(%s) Done", key)
+	log.Infof("handleContentTreeDeleteAppImg(%s) Done", key)
 }
 
 func handleContentTreeCreateBaseOs(ctxArg interface{}, key string,
@@ -64,9 +64,9 @@ func handleContentTreeCreateBaseOs(ctxArg interface{}, key string,
 }
 
 func handleContentTreeModifyBaseOs(ctxArg interface{}, key string,
-	configArg interface{}) {
+	configArg interface{}, oldConfigArg interface{}) {
 
-	log.Infof("handleContentTreeModify(%s)", key)
+	log.Infof("handleContentTreeModifyBaseOs(%s)", key)
 	config := configArg.(types.ContentTreeConfig)
 	ctx := ctxArg.(*volumemgrContext)
 	status := lookupContentTreeStatus(ctx, config.Key(), types.BaseOsObj)
@@ -74,13 +74,13 @@ func handleContentTreeModifyBaseOs(ctxArg interface{}, key string,
 		log.Fatalf("Missing ContentTreeStatus for %s", config.Key())
 	}
 	updateContentTree(ctx, status)
-	log.Infof("handleContentTreeModify(%s) Done", key)
+	log.Infof("handleContentTreeModifyBaseOs(%s) Done", key)
 }
 
 func handleContentTreeDeleteBaseOs(ctxArg interface{}, key string,
 	configArg interface{}) {
 
-	log.Infof("handleContentTreeDelete(%s)", key)
+	log.Infof("handleContentTreeDeleteBaseOs(%s)", key)
 	config := configArg.(types.ContentTreeConfig)
 	ctx := ctxArg.(*volumemgrContext)
 	status := lookupContentTreeStatus(ctx, config.Key(), types.BaseOsObj)
@@ -88,7 +88,7 @@ func handleContentTreeDeleteBaseOs(ctxArg interface{}, key string,
 		log.Fatalf("Missing ContentTreeStatus for %s", config.Key())
 	}
 	deleteContentTree(ctx, status)
-	log.Infof("handleContentTreeModify(%s) Done", key)
+	log.Infof("handleContentTreeDeleteBaseOs(%s) Done", key)
 }
 
 func handleContentTreeRestart(ctxArg interface{}, done bool) {

--- a/pkg/pillar/cmd/volumemgr/handledatastore.go
+++ b/pkg/pillar/cmd/volumemgr/handledatastore.go
@@ -7,13 +7,22 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/types"
 )
 
-// Handles both create and modify events
+func handleDatastoreConfigCreate(ctxArg interface{}, key string,
+	configArg interface{}) {
+	handleDatastoreConfigImpl(ctxArg, key, configArg)
+}
+
 func handleDatastoreConfigModify(ctxArg interface{}, key string,
+	configArg interface{}, oldConfigArg interface{}) {
+	handleDatastoreConfigImpl(ctxArg, key, configArg)
+}
+
+func handleDatastoreConfigImpl(ctxArg interface{}, key string,
 	configArg interface{}) {
 
 	ctx := ctxArg.(*volumemgrContext)
 	config := configArg.(types.DatastoreConfig)
-	log.Infof("handleDatastoreConfigModify for %s", key)
+	log.Infof("handleDatastoreConfigImpl for %s", key)
 	updateStatusByDatastore(ctx, config)
-	log.Infof("handleDatastoreConfigModify for %s, done", key)
+	log.Infof("handleDatastoreConfigImpl for %s, done", key)
 }

--- a/pkg/pillar/cmd/volumemgr/handledownloader.go
+++ b/pkg/pillar/cmd/volumemgr/handledownloader.go
@@ -126,11 +126,22 @@ func unpublishDownloaderConfig(ctx *volumemgrContext,
 	log.Debugf("unpublishDownloaderConfig(%s) Done", key)
 }
 
-func handleDownloaderStatusModify(ctxArg interface{}, key string,
+func handleDownloaderStatusCreate(ctxArg interface{}, key string,
 	statusArg interface{}) {
+	handleDownloaderStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleDownloaderStatusModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleDownloaderStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleDownloaderStatusImpl(ctxArg interface{}, key string,
+	statusArg interface{}) {
+
 	status := statusArg.(types.DownloaderStatus)
 	ctx := ctxArg.(*volumemgrContext)
-	log.Infof("handleDownloaderStatusModify for %s status.RefCount %d "+
+	log.Infof("handleDownloaderStatusImpl for %s status.RefCount %d "+
 		"status.Expired: %+v ENTIRE: %+v",
 		status.ImageSha256, status.RefCount, status.Expired, status)
 
@@ -145,19 +156,19 @@ func handleDownloaderStatusModify(ctxArg interface{}, key string,
 
 	config := lookupDownloaderConfig(ctx, status.ImageSha256)
 	if config != nil && config.RefCount == 0 && status.Expired {
-		log.Infof("handleDownloaderStatusModify expired - deleting config %s",
+		log.Infof("handleDownloaderStatusImpl expired - deleting config %s",
 			key)
 		unpublishDownloaderConfig(ctx, config)
 
 		return
 	} else if status.Expired {
-		log.Infof("handleDownloaderStatusModify ignore expired DownloaderStatus; "+
+		log.Infof("handleDownloaderStatusImpl ignore expired DownloaderStatus; "+
 			"config still has reference for %s", key)
 	}
 
 	// Normal update case
 	updateStatusByBlob(ctx, status.ImageSha256)
-	log.Infof("handleDownloaderStatusModify done for %s", status.ImageSha256)
+	log.Infof("handleDownloaderStatusImpl done for %s", status.ImageSha256)
 }
 
 func lookupDownloaderConfig(ctx *volumemgrContext,

--- a/pkg/pillar/cmd/volumemgr/handleresolve.go
+++ b/pkg/pillar/cmd/volumemgr/handleresolve.go
@@ -83,10 +83,20 @@ func deleteResolveConfig(ctx *volumemgrContext, key string) {
 	log.Infof("deleteResolveConfig for %s Done", key)
 }
 
+func handleResolveStatusCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleResolveStatusImpl(ctxArg, key, statusArg)
+}
+
 func handleResolveStatusModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleResolveStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleResolveStatusImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
-	log.Infof("handleResolveStatusModify for %s", key)
+	log.Infof("handleResolveStatusImpl for %s", key)
 	ctx := ctxArg.(*volumemgrContext)
 	rs := statusArg.(types.ResolveStatus)
 	pub := ctx.pubContentTreeStatus
@@ -102,11 +112,11 @@ func handleResolveStatusModify(ctxArg interface{}, key string,
 			status.ContentID)
 		changed, _ := doUpdateContentTree(ctx, &status)
 		if changed {
-			log.Infof("ContentTree(Name:%s, UUID:%s): handleResolveStatusModify status change.",
+			log.Infof("ContentTree(Name:%s, UUID:%s): handleResolveStatusImpl status change.",
 				status.DisplayName, status.ContentID)
 			publishContentTreeStatus(ctx, &status)
 		}
 		updateVolumeStatusFromContentID(ctx, status.ContentID)
 	}
-	log.Infof("handleResolveStatusModify done for %s", key)
+	log.Infof("handleResolveStatusImpl done for %s", key)
 }

--- a/pkg/pillar/cmd/volumemgr/handlevolume.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume.go
@@ -100,7 +100,7 @@ func handleVolumeCreate(ctxArg interface{}, key string,
 }
 
 func handleVolumeModify(ctxArg interface{}, key string,
-	configArg interface{}) {
+	configArg interface{}, oldConfigArg interface{}) {
 
 	log.Infof("handleVolumeModify(%s)", key)
 	config := configArg.(types.VolumeConfig)

--- a/pkg/pillar/cmd/volumemgr/handlevolumeref.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolumeref.go
@@ -52,7 +52,7 @@ func handleVolumeRefCreate(ctxArg interface{}, key string,
 }
 
 func handleVolumeRefModify(ctxArg interface{}, key string,
-	configArg interface{}) {
+	configArg interface{}, oldConfigArg interface{}) {
 
 	log.Infof("handleVolumeRefModify(%s)", key)
 	config := configArg.(types.VolumeRefConfig)

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -134,7 +134,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		Persistent:    true,
 		Activate:      false,
 		Ctx:           &ctx,
-		CreateHandler: handleGlobalConfigModify,
+		CreateHandler: handleGlobalConfigCreate,
 		ModifyHandler: handleGlobalConfigModify,
 		DeleteHandler: handleGlobalConfigDelete,
 		WarningTime:   warningTime,
@@ -270,7 +270,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		TopicImpl:     types.ZedAgentStatus{},
 		Activate:      false,
 		Ctx:           &ctx,
-		CreateHandler: handleZedAgentStatusModify,
+		CreateHandler: handleZedAgentStatusCreate,
 		ModifyHandler: handleZedAgentStatusModify,
 		WarningTime:   warningTime,
 		ErrorTime:     errorTime,
@@ -288,7 +288,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		TopicImpl:     types.DownloaderStatus{},
 		Activate:      false,
 		Ctx:           &ctx,
-		CreateHandler: handleDownloaderStatusModify,
+		CreateHandler: handleDownloaderStatusCreate,
 		ModifyHandler: handleDownloaderStatusModify,
 		DeleteHandler: handleDownloaderStatusDelete,
 		WarningTime:   warningTime,
@@ -307,7 +307,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		TopicImpl:      types.VerifyImageStatus{},
 		Activate:       false,
 		Ctx:            &ctx,
-		CreateHandler:  handleVerifyImageStatusModify,
+		CreateHandler:  handleVerifyImageStatusCreate,
 		ModifyHandler:  handleVerifyImageStatusModify,
 		DeleteHandler:  handleVerifyImageStatusDelete,
 		RestartHandler: handleVerifierRestarted,
@@ -327,7 +327,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		TopicImpl:     types.ResolveStatus{},
 		Activate:      false,
 		Ctx:           &ctx,
-		CreateHandler: handleResolveStatusModify,
+		CreateHandler: handleResolveStatusCreate,
 		ModifyHandler: handleResolveStatusModify,
 		WarningTime:   warningTime,
 		ErrorTime:     errorTime,
@@ -409,7 +409,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	subBaseOsContentTreeConfig.Activate()
 
 	subDatastoreConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		CreateHandler: handleDatastoreConfigModify,
+		CreateHandler: handleDatastoreConfigCreate,
 		ModifyHandler: handleDatastoreConfigModify,
 		WarningTime:   warningTime,
 		ErrorTime:     errorTime,
@@ -572,15 +572,25 @@ func handleVerifierRestarted(ctxArg interface{}, done bool) {
 	}
 }
 
+func handleGlobalConfigCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleGlobalConfigImpl(ctxArg, key, statusArg)
+}
+
 func handleGlobalConfigModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleGlobalConfigImpl(ctxArg, key, statusArg)
+}
+
+func handleGlobalConfigImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
 	ctx := ctxArg.(*volumemgrContext)
 	if key != "global" {
-		log.Infof("handleGlobalConfigModify: ignoring %s", key)
+		log.Infof("handleGlobalConfigImpl: ignoring %s", key)
 		return
 	}
-	log.Infof("handleGlobalConfigModify for %s", key)
+	log.Infof("handleGlobalConfigImpl for %s", key)
 	var gcp *types.ConfigItemValueMap
 	debug, gcp = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
 		debugOverride, logger)
@@ -589,7 +599,7 @@ func handleGlobalConfigModify(ctxArg interface{}, key string,
 		ctx.globalConfig = gcp
 		ctx.GCInitialized = true
 	}
-	log.Infof("handleGlobalConfigModify done for %s", key)
+	log.Infof("handleGlobalConfigImpl done for %s", key)
 }
 
 func handleGlobalConfigDelete(ctxArg interface{}, key string,
@@ -607,7 +617,17 @@ func handleGlobalConfigDelete(ctxArg interface{}, key string,
 	log.Infof("handleGlobalConfigDelete done for %s", key)
 }
 
+func handleZedAgentStatusCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleZedAgentStatusImpl(ctxArg, key, statusArg)
+}
+
 func handleZedAgentStatusModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleZedAgentStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleZedAgentStatusImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
 	ctx := ctxArg.(*volumemgrContext)

--- a/pkg/pillar/cmd/zedagent/attesttask.go
+++ b/pkg/pillar/cmd/zedagent/attesttask.go
@@ -510,7 +510,18 @@ func attestModuleStart(ctx *zedagentContext) error {
 }
 
 // pubsub functions
-func handleAttestQuoteModify(ctxArg interface{}, key string, quoteArg interface{}) {
+func handleAttestQuoteCreate(ctxArg interface{}, key string,
+	quoteArg interface{}) {
+	handleAttestQuoteImpl(ctxArg, key, quoteArg)
+}
+
+func handleAttestQuoteModify(ctxArg interface{}, key string,
+	quoteArg interface{}, oldQuoteArg interface{}) {
+	handleAttestQuoteImpl(ctxArg, key, quoteArg)
+}
+
+func handleAttestQuoteImpl(ctxArg interface{}, key string,
+	quoteArg interface{}) {
 
 	//Store quote received in state machine
 	ctx, ok := ctxArg.(*zedagentContext)
@@ -539,7 +550,7 @@ func handleAttestQuoteModify(ctxArg interface{}, key string, quoteArg interface{
 	//Trigger event on the state machine
 	zattest.InternalQuoteRecvd(attestCtx.attestFsmCtx)
 
-	log.Infof("handleAttestQuoteModify done for %s", quote.Key())
+	log.Infof("handleAttestQuoteImpl done for %s", quote.Key())
 	return
 }
 
@@ -579,7 +590,23 @@ func handleAttestQuoteDelete(ctxArg interface{}, key string, quoteArg interface{
 	return
 }
 
-func handleEncryptedKeyFromDeviceModify(ctxArg interface{}, key string, vaultKeyArg interface{}) {
+func handleEncryptedKeyFromDeviceCreate(ctxArg interface{}, key string,
+	vaultKeyArg interface{}) {
+	handleEncryptedKeyFromDeviceImpl(ctxArg, key, vaultKeyArg)
+}
+
+func handleEncryptedKeyFromDeviceModify(ctxArg interface{}, key string,
+	vaultKeyArg interface{}, oldStatusArg interface{}) {
+	handleEncryptedKeyFromDeviceImpl(ctxArg, key, vaultKeyArg)
+}
+
+func handleEncryptedKeyFromDeviceDelete(ctxArg interface{}, key string,
+	vaultKeyArg interface{}) {
+	handleEncryptedKeyFromDeviceImpl(ctxArg, key, vaultKeyArg)
+}
+
+func handleEncryptedKeyFromDeviceImpl(ctxArg interface{}, key string,
+	vaultKeyArg interface{}) {
 
 	//Store quote received in state machine
 	ctx, ok := ctxArg.(*zedagentContext)

--- a/pkg/pillar/cmd/zedagent/handleblob.go
+++ b/pkg/pillar/cmd/zedagent/handleblob.go
@@ -12,7 +12,19 @@ func blobStatusGetAll(ctx *zedagentContext) map[string]*types.BlobStatus {
 	return blobShaAndBlobStatus
 }
 
-func handleBlobStatusModify(ctxArg interface{}, key string, statusArg interface{}) {
+func handleBlobStatusCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleBlobStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleBlobStatusModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleBlobStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleBlobStatusImpl(ctxArg interface{}, key string,
+	statusArg interface{}) {
+
 	status := statusArg.(types.BlobStatus)
 	ctx := ctxArg.(*zedagentContext)
 	uuidStr := status.Key()

--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -139,14 +139,23 @@ func unpublishControllerCert(ctx *getconfigContext, key string) {
 	pub.Unpublish(key)
 }
 
+func handleEdgeNodeCertCreate(ctxArg interface{}, key string,
+	configArg interface{}) {
+	handleEdgeNodeCertImpl(ctxArg, key, configArg)
+}
+
 func handleEdgeNodeCertModify(ctxArg interface{}, key string,
+	configArg interface{}, oldConfigArg interface{}) {
+	handleEdgeNodeCertImpl(ctxArg, key, configArg)
+}
+
+func handleEdgeNodeCertImpl(ctxArg interface{}, key string,
 	configArg interface{}) {
 
 	ctx := ctxArg.(*zedagentContext)
 	status := configArg.(types.EdgeNodeCert)
-	log.Infof("handleEdgeNodeCertModify for %s", status.Key())
+	log.Infof("handleEdgeNodeCertImpl for %s", status.Key())
 	triggerEdgeNodeCertEvent(ctx)
-	return
 }
 
 func handleEdgeNodeCertDelete(ctxArg interface{}, key string,
@@ -156,7 +165,6 @@ func handleEdgeNodeCertDelete(ctxArg interface{}, key string,
 	status := configArg.(types.EdgeNodeCert)
 	log.Infof("handleEdgeNodeCertDelete for %s", status.Key())
 	triggerEdgeNodeCertEvent(ctx)
-	return
 }
 
 // Run a task certificate post task, on change trigger

--- a/pkg/pillar/cmd/zedagent/handlecontent.go
+++ b/pkg/pillar/cmd/zedagent/handlecontent.go
@@ -94,9 +94,19 @@ func unpublishContentTreeConfig(ctx *getconfigContext, key string) {
 
 // content tree event watch to capture transitions
 // and publish to zedCloud
-// Handles both create and modify events
-func handleContentTreeStatusModify(ctxArg interface{}, key string,
+func handleContentTreeStatusCreate(ctxArg interface{}, key string,
 	statusArg interface{}) {
+	handleContentTreeStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleContentTreeStatusModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleContentTreeStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleContentTreeStatusImpl(ctxArg interface{}, key string,
+	statusArg interface{}) {
+
 	status := statusArg.(types.ContentTreeStatus)
 	ctx := ctxArg.(*zedagentContext)
 	uuidStr := status.Key()

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -30,12 +30,24 @@ import (
 	"github.com/shirou/gopsutil/host"
 )
 
-func handleDiskMetricModify(ctxArg interface{}, key string, statusArg interface{}) {
+func handleDiskMetricCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleDiskMetricImpl(ctxArg, key, statusArg)
+}
+
+func handleDiskMetricModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleDiskMetricImpl(ctxArg, key, statusArg)
+}
+
+func handleDiskMetricImpl(ctxArg interface{}, key string,
+	statusArg interface{}) {
+
 	status := statusArg.(types.DiskMetric)
 	ctx := ctxArg.(*zedagentContext)
 	ctx.iteration++
 	path := status.DiskPath
-	log.Infof("handleDiskMetricModify: %s", path)
+	log.Infof("handleDiskMetricImpl: %s", path)
 }
 
 func handleDiskMetricDelete(ctxArg interface{}, key string, statusArg interface{}) {
@@ -68,20 +80,6 @@ func getAllDiskMetrics(ctx *zedagentContext) []*types.DiskMetric {
 	}
 	log.Debugf("getAllDiskMetrics: Done")
 	return retList
-}
-
-func handleAppDiskMetricModify(ctxArg interface{}, key string, statusArg interface{}) {
-	status := statusArg.(types.AppDiskMetric)
-	ctx := ctxArg.(*zedagentContext)
-	ctx.iteration++
-	log.Infof("handleAppDiskMetricModify: Received %s", status.DiskPath)
-}
-
-func handleAppDiskMetricDelete(ctxArg interface{}, key string, statusArg interface{}) {
-	status := statusArg.(types.AppDiskMetric)
-	ctx := ctxArg.(*zedagentContext)
-	ctx.iteration++
-	log.Infof("handleAppDiskMetricDelete: %s", status.DiskPath)
 }
 
 func lookupAppDiskMetric(ctx *zedagentContext, diskPath string) *types.AppDiskMetric {

--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -25,8 +25,20 @@ import (
 
 var flowIteration int
 
-func handleNetworkInstanceModify(ctxArg interface{}, key string, statusArg interface{}) {
-	log.Infof("handleNetworkInstanceStatusModify(%s)", key)
+func handleNetworkInstanceCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleNetworkInstanceImpl(ctxArg, key, statusArg)
+}
+
+func handleNetworkInstanceModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleNetworkInstanceImpl(ctxArg, key, statusArg)
+}
+
+func handleNetworkInstanceImpl(ctxArg interface{}, key string,
+	statusArg interface{}) {
+
+	log.Infof("handleNetworkInstanceStatusImpl(%s)", key)
 	ctx := ctxArg.(*zedagentContext)
 	status := statusArg.(types.NetworkInstanceStatus)
 	if !status.ErrorTime.IsZero() {
@@ -34,7 +46,7 @@ func handleNetworkInstanceModify(ctxArg interface{}, key string, statusArg inter
 			status.Error)
 	}
 	prepareAndPublishNetworkInstanceInfoMsg(ctx, status, false)
-	log.Infof("handleNetworkInstanceModify(%s) done", key)
+	log.Infof("handleNetworkInstanceImpl(%s) done", key)
 }
 
 func handleNetworkInstanceDelete(ctxArg interface{}, key string,
@@ -198,18 +210,6 @@ func fillVpnInfo(info *zinfo.ZInfoNetworkInstance, vpnStatus *types.VpnStatus) {
 	if x, ok := info.GetInfoContent().(*zinfo.ZInfoNetworkInstance_Vinfo); ok {
 		x.Vinfo = vpnInfo
 	}
-}
-
-func handleNetworkInstanceMetricsModify(ctxArg interface{}, key string,
-	statusArg interface{}) {
-
-	log.Debugf("handleNetworkInstanceMetricsModify(%s)", key)
-}
-
-func handleNetworkInstanceMetricsDelete(ctxArg interface{}, key string,
-	statusArg interface{}) {
-
-	log.Infof("handleNetworkInstanceMetricsDelete(%s)", key)
 }
 
 func protoEncodeGenericInstanceMetric(status types.NetworkInstanceMetrics,
@@ -430,10 +430,20 @@ func publishInfoToZedCloud(UUID string, infoMsg *zinfo.ZInfoMsg, iteration int) 
 	}
 }
 
+func handleAppFlowMonitorCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleAppFlowMonitorImpl(ctxArg, key, statusArg)
+}
+
 func handleAppFlowMonitorModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleAppFlowMonitorImpl(ctxArg, key, statusArg)
+}
+
+func handleAppFlowMonitorImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
-	log.Infof("handleAppFlowMonitorModify(%s)", key)
+	log.Infof("handleAppFlowMonitorImpl(%s)", key)
 	flows := statusArg.(types.IPFlow)
 
 	// encoding the flows with protobuf format
@@ -449,10 +459,20 @@ func handleAppFlowMonitorDelete(ctxArg interface{}, key string,
 	log.Infof("handleAppFlowMonitorDelete(%s)", key)
 }
 
+func handleAppVifIPTrigCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleAppVifIPTrigImpl(ctxArg, key, statusArg)
+}
+
 func handleAppVifIPTrigModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleAppVifIPTrigImpl(ctxArg, key, statusArg)
+}
+
+func handleAppVifIPTrigImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
-	log.Infof("handleAppVifIPTrigModify(%s)", key)
+	log.Infof("handleAppVifIPTrigImpl(%s)", key)
 	ctx := ctxArg.(*zedagentContext)
 	trig := statusArg.(types.VifIPTrig)
 	findVifAndTrigAppInfoUpload(ctx, trig.MacAddr, trig.IPAddr)
@@ -594,9 +614,20 @@ func writeSentFlowProtoMessage(contents []byte) {
 	writeProtoMessage("lastflowlog", contents)
 }
 
+func handleAppContainerMetricsCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleAppContainerMetricsImpl(ctxArg, key, statusArg)
+}
+
 func handleAppContainerMetricsModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleAppContainerMetricsImpl(ctxArg, key, statusArg)
+}
+
+func handleAppContainerMetricsImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
 	acMetrics := statusArg.(types.AppContainerMetrics)
-	log.Debugf("handleAppContainerMetricsModify(%s), num containers %d", key, len(acMetrics.StatsList))
+	log.Debugf("handleAppContainerMetricsImpl(%s), num containers %d",
+		key, len(acMetrics.StatsList))
 }

--- a/pkg/pillar/cmd/zedagent/handlevolume.go
+++ b/pkg/pillar/cmd/zedagent/handlevolume.go
@@ -111,9 +111,18 @@ func unpublishVolumeConfig(ctx *getconfigContext,
 
 // volume event watch to capture transitions
 // and publish to zedCloud
-// Handles both create and modify events
-func handleVolumeStatusModify(ctxArg interface{},
-	key string, statusArg interface{}) {
+func handleVolumeStatusCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleVolumeStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleVolumeStatusModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleVolumeStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleVolumeStatusImpl(ctxArg interface{}, key string,
+	statusArg interface{}) {
 
 	status := statusArg.(types.VolumeStatus)
 	ctx := ctxArg.(*zedagentContext)

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -277,7 +277,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		TopicImpl:     types.AssignableAdapters{},
 		Activate:      false,
 		Ctx:           &zedagentCtx,
-		CreateHandler: handleAAModify,
+		CreateHandler: handleAACreate,
 		ModifyHandler: handleAAModify,
 		DeleteHandler: handleAADelete,
 		WarningTime:   warningTime,
@@ -436,7 +436,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		Persistent:    true,
 		Activate:      false,
 		Ctx:           &zedagentCtx,
-		CreateHandler: handleGlobalConfigModify,
+		CreateHandler: handleGlobalConfigCreate,
 		ModifyHandler: handleGlobalConfigModify,
 		DeleteHandler: handleGlobalConfigDelete,
 		WarningTime:   warningTime,
@@ -454,7 +454,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		TopicImpl:     types.NetworkInstanceStatus{},
 		Activate:      false,
 		Ctx:           &zedagentCtx,
-		CreateHandler: handleNetworkInstanceModify,
+		CreateHandler: handleNetworkInstanceCreate,
 		ModifyHandler: handleNetworkInstanceModify,
 		DeleteHandler: handleNetworkInstanceDelete,
 		WarningTime:   warningTime,
@@ -467,16 +467,13 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	subNetworkInstanceStatus.Activate()
 
 	subNetworkInstanceMetrics, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName:     "zedrouter",
-		MyAgentName:   agentName,
-		TopicImpl:     types.NetworkInstanceMetrics{},
-		Activate:      false,
-		Ctx:           &zedagentCtx,
-		CreateHandler: handleNetworkInstanceMetricsModify,
-		ModifyHandler: handleNetworkInstanceMetricsModify,
-		DeleteHandler: handleNetworkInstanceMetricsDelete,
-		WarningTime:   warningTime,
-		ErrorTime:     errorTime,
+		AgentName:   "zedrouter",
+		MyAgentName: agentName,
+		TopicImpl:   types.NetworkInstanceMetrics{},
+		Activate:    false,
+		Ctx:         &zedagentCtx,
+		WarningTime: warningTime,
+		ErrorTime:   errorTime,
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -490,7 +487,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		TopicImpl:     types.IPFlow{},
 		Activate:      false,
 		Ctx:           &zedagentCtx,
-		CreateHandler: handleAppFlowMonitorModify,
+		CreateHandler: handleAppFlowMonitorCreate,
 		ModifyHandler: handleAppFlowMonitorModify,
 		DeleteHandler: handleAppFlowMonitorDelete,
 		WarningTime:   warningTime,
@@ -509,7 +506,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		TopicImpl:     types.VifIPTrig{},
 		Activate:      false,
 		Ctx:           &zedagentCtx,
-		CreateHandler: handleAppVifIPTrigModify,
+		CreateHandler: handleAppVifIPTrigCreate,
 		ModifyHandler: handleAppVifIPTrigModify,
 		WarningTime:   warningTime,
 		ErrorTime:     errorTime,
@@ -526,7 +523,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		TopicImpl:     types.AppInstanceStatus{},
 		Activate:      false,
 		Ctx:           &zedagentCtx,
-		CreateHandler: handleAppInstanceStatusModify,
+		CreateHandler: handleAppInstanceStatusCreate,
 		ModifyHandler: handleAppInstanceStatusModify,
 		DeleteHandler: handleAppInstanceStatusDelete,
 		WarningTime:   warningTime,
@@ -546,7 +543,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		TopicImpl:     types.ContentTreeStatus{},
 		Activate:      false,
 		Ctx:           &zedagentCtx,
-		CreateHandler: handleContentTreeStatusModify,
+		CreateHandler: handleContentTreeStatusCreate,
 		ModifyHandler: handleContentTreeStatusModify,
 		DeleteHandler: handleContentTreeStatusDelete,
 		WarningTime:   warningTime,
@@ -566,7 +563,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		TopicImpl:     types.VolumeStatus{},
 		Activate:      false,
 		Ctx:           &zedagentCtx,
-		CreateHandler: handleVolumeStatusModify,
+		CreateHandler: handleVolumeStatusCreate,
 		ModifyHandler: handleVolumeStatusModify,
 		DeleteHandler: handleVolumeStatusDelete,
 		WarningTime:   warningTime,
@@ -629,7 +626,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		TopicImpl:      types.ZbootStatus{},
 		Activate:       false,
 		Ctx:            &zedagentCtx,
-		CreateHandler:  handleZbootStatusModify,
+		CreateHandler:  handleZbootStatusCreate,
 		ModifyHandler:  handleZbootStatusModify,
 		DeleteHandler:  handleZbootStatusDelete,
 		RestartHandler: handleZbootRestarted,
@@ -649,7 +646,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		TopicImpl:     types.AppContainerMetrics{},
 		Activate:      false,
 		Ctx:           &zedagentCtx,
-		CreateHandler: handleAppContainerMetricsModify,
+		CreateHandler: handleAppContainerMetricsCreate,
 		ModifyHandler: handleAppContainerMetricsModify,
 		WarningTime:   warningTime,
 		ErrorTime:     errorTime,
@@ -666,7 +663,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		TopicImpl:     types.BaseOsStatus{},
 		Activate:      false,
 		Ctx:           &zedagentCtx,
-		CreateHandler: handleBaseOsStatusModify,
+		CreateHandler: handleBaseOsStatusCreate,
 		ModifyHandler: handleBaseOsStatusModify,
 		DeleteHandler: handleBaseOsStatusDelete,
 		WarningTime:   warningTime,
@@ -684,6 +681,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		TopicImpl:     types.EdgeNodeCert{},
 		Activate:      false,
 		Ctx:           &zedagentCtx,
+		CreateHandler: handleEdgeNodeCertCreate,
 		ModifyHandler: handleEdgeNodeCertModify,
 		DeleteHandler: handleEdgeNodeCertDelete,
 		WarningTime:   warningTime,
@@ -701,6 +699,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		TopicImpl:     types.VaultStatus{},
 		Activate:      false,
 		Ctx:           &zedagentCtx,
+		CreateHandler: handleVaultStatusCreate,
 		ModifyHandler: handleVaultStatusModify,
 		DeleteHandler: handleVaultStatusDelete,
 		WarningTime:   warningTime,
@@ -718,6 +717,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		TopicImpl:     types.AttestQuote{},
 		Activate:      false,
 		Ctx:           &zedagentCtx,
+		CreateHandler: handleAttestQuoteCreate,
 		ModifyHandler: handleAttestQuoteModify,
 		DeleteHandler: handleAttestQuoteDelete,
 		WarningTime:   warningTime,
@@ -735,8 +735,9 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		TopicImpl:     types.EncryptedVaultKeyFromDevice{},
 		Activate:      false,
 		Ctx:           &zedagentCtx,
+		CreateHandler: handleEncryptedKeyFromDeviceCreate,
 		ModifyHandler: handleEncryptedKeyFromDeviceModify,
-		DeleteHandler: handleEncryptedKeyFromDeviceModify,
+		DeleteHandler: handleEncryptedKeyFromDeviceDelete,
 		WarningTime:   warningTime,
 		ErrorTime:     errorTime,
 	})
@@ -753,6 +754,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		TopicImpl:     types.NodeAgentStatus{},
 		Activate:      false,
 		Ctx:           &getconfigCtx,
+		CreateHandler: handleNodeAgentStatusCreate,
 		ModifyHandler: handleNodeAgentStatusModify,
 		DeleteHandler: handleNodeAgentStatusDelete,
 		WarningTime:   warningTime,
@@ -771,6 +773,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		TopicImpl:     types.DeviceNetworkStatus{},
 		Activate:      false,
 		Ctx:           &DNSctx,
+		CreateHandler: handleDNSCreate,
 		ModifyHandler: handleDNSModify,
 		DeleteHandler: handleDNSDelete,
 		WarningTime:   warningTime,
@@ -788,6 +791,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		TopicImpl:     types.DevicePortConfigList{},
 		Activate:      false,
 		Ctx:           &zedagentCtx,
+		CreateHandler: handleDPCLCreate,
 		ModifyHandler: handleDPCLModify,
 		DeleteHandler: handleDPCLDelete,
 		WarningTime:   warningTime,
@@ -805,7 +809,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		TopicImpl:     types.BlobStatus{},
 		Activate:      false,
 		Ctx:           &zedagentCtx,
-		CreateHandler: handleBlobStatusModify,
+		CreateHandler: handleBlobStatusCreate,
 		ModifyHandler: handleBlobStatusModify,
 		DeleteHandler: handleBlobDelete,
 		WarningTime:   warningTime,
@@ -837,7 +841,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		TopicImpl:     types.DiskMetric{},
 		Activate:      false,
 		Ctx:           &zedagentCtx,
-		CreateHandler: handleDiskMetricModify,
+		CreateHandler: handleDiskMetricCreate,
 		ModifyHandler: handleDiskMetricModify,
 		DeleteHandler: handleDiskMetricDelete,
 		WarningTime:   warningTime,
@@ -850,16 +854,13 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	subDiskMetric.Activate()
 
 	subAppDiskMetric, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName:     "volumemgr",
-		MyAgentName:   agentName,
-		TopicImpl:     types.AppDiskMetric{},
-		Activate:      false,
-		Ctx:           &zedagentCtx,
-		CreateHandler: handleAppDiskMetricModify,
-		ModifyHandler: handleAppDiskMetricModify,
-		DeleteHandler: handleAppDiskMetricDelete,
-		WarningTime:   warningTime,
-		ErrorTime:     errorTime,
+		AgentName:   "volumemgr",
+		MyAgentName: agentName,
+		TopicImpl:   types.AppDiskMetric{},
+		Activate:    false,
+		Ctx:         &zedagentCtx,
+		WarningTime: warningTime,
+		ErrorTime:   errorTime,
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -1310,7 +1311,8 @@ func handleAppInstanceStatusCreate(ctxArg interface{}, key string,
 // and publish to zedCloud
 // Handles both create and modify events
 func handleAppInstanceStatusModify(ctxArg interface{}, key string,
-	statusArg interface{}) {
+	statusArg interface{}, oldStatusArg interface{}) {
+
 	status := statusArg.(types.AppInstanceStatus)
 	log.Infof("handleAppInstanceStatusModify(%s)", key)
 	ctx := ctxArg.(*zedagentContext)
@@ -1346,22 +1348,33 @@ func lookupAppInstanceStatus(ctx *zedagentContext, key string) *types.AppInstanc
 	return &status
 }
 
-func handleDNSModify(ctxArg interface{}, key string, statusArg interface{}) {
+func handleDNSCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleDNSImpl(ctxArg, key, statusArg)
+}
+
+func handleDNSModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleDNSImpl(ctxArg, key, statusArg)
+}
+
+func handleDNSImpl(ctxArg interface{}, key string,
+	statusArg interface{}) {
 
 	status := statusArg.(types.DeviceNetworkStatus)
 	ctx := ctxArg.(*DNSContext)
 	if key != "global" {
-		log.Infof("handleDNSModify: ignoring %s", key)
+		log.Infof("handleDNSImpl: ignoring %s", key)
 		return
 	}
-	log.Infof("handleDNSModify for %s", key)
+	log.Infof("handleDNSImpl for %s", key)
 	// Since we report the TestResults we compare the whole struct
 	if cmp.Equal(*deviceNetworkStatus, status) {
-		log.Infof("handleDNSModify no change")
+		log.Infof("handleDNSImpl no change")
 		ctx.DNSinitialized = true
 		return
 	}
-	log.Infof("handleDNSModify: changed %v",
+	log.Infof("handleDNSImpl: changed %v",
 		cmp.Diff(*deviceNetworkStatus, status))
 	*deviceNetworkStatus = status
 	ctx.DNSinitialized = true
@@ -1370,7 +1383,7 @@ func handleDNSModify(ctxArg interface{}, key string, statusArg interface{}) {
 	if zedcloudCtx.V2API {
 		zedcloud.UpdateTLSProxyCerts(zedcloudCtx)
 	}
-	log.Infof("handleDNSModify done for %s", key)
+	log.Infof("handleDNSImpl done for %s", key)
 }
 
 func handleDNSDelete(ctxArg interface{}, key string,
@@ -1388,21 +1401,32 @@ func handleDNSDelete(ctxArg interface{}, key string,
 	log.Infof("handleDNSDelete done for %s", key)
 }
 
-func handleDPCLModify(ctxArg interface{}, key string, statusArg interface{}) {
+func handleDPCLCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleDPCLImpl(ctxArg, key, statusArg)
+}
+
+func handleDPCLModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleDPCLImpl(ctxArg, key, statusArg)
+}
+
+func handleDPCLImpl(ctxArg interface{}, key string,
+	statusArg interface{}) {
 
 	status := statusArg.(types.DevicePortConfigList)
 	ctx := ctxArg.(*zedagentContext)
 	if key != "global" {
-		log.Infof("handleDPCLModify: ignoring %s", key)
+		log.Infof("handleDPCLImpl: ignoring %s", key)
 		return
 	}
 	if cmp.Equal(ctx.devicePortConfigList, status) {
-		log.Infof("handleDPCLModify no change")
+		log.Infof("handleDPCLImpl no change")
 		return
 	}
 	// Note that lastSucceeded will increment a lot; ignore it but compare
 	// lastFailed/lastError?? XXX how?
-	log.Infof("handleDPCLModify: changed %v",
+	log.Infof("handleDPCLImpl: changed %v",
 		cmp.Diff(ctx.devicePortConfigList, status))
 	ctx.devicePortConfigList = status
 	triggerPublishDevInfo(ctx)
@@ -1422,11 +1446,22 @@ func handleDPCLDelete(ctxArg interface{}, key string, statusArg interface{}) {
 
 // base os status event handlers
 // Report BaseOsStatus to zedcloud
-// Handles both create and modify events
-func handleBaseOsStatusModify(ctxArg interface{}, key string, statusArg interface{}) {
+func handleBaseOsStatusCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleBaseOsStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleBaseOsStatusModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleBaseOsStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleBaseOsStatusImpl(ctxArg interface{}, key string,
+	statusArg interface{}) {
+
 	ctx := ctxArg.(*zedagentContext)
 	triggerPublishDevInfo(ctx)
-	log.Infof("handleBaseOsStatusModify(%s) done", key)
+	log.Infof("handleBaseOsStatusImpl(%s) done", key)
 }
 
 func handleBaseOsStatusDelete(ctxArg interface{}, key string,
@@ -1440,10 +1475,22 @@ func handleBaseOsStatusDelete(ctxArg interface{}, key string,
 
 // vault status event handlers
 // Report VaultStatus to zedcloud
-func handleVaultStatusModify(ctxArg interface{}, key string, statusArg interface{}) {
+func handleVaultStatusCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleVaultStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleVaultStatusModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleVaultStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleVaultStatusImpl(ctxArg interface{}, key string,
+	statusArg interface{}) {
+
 	ctx := ctxArg.(*zedagentContext)
 	triggerPublishDevInfo(ctx)
-	log.Infof("handleVaultStatusModify(%s) done", key)
+	log.Infof("handleVaultStatusImpl(%s) done", key)
 }
 
 func handleVaultStatusDelete(ctxArg interface{}, key string,
@@ -1459,16 +1506,25 @@ func appendError(allErrors string, prefix string, lasterr string) string {
 	return fmt.Sprintf("%s%s: %s\n\n", allErrors, prefix, lasterr)
 }
 
-// Handles both create and modify events
+func handleGlobalConfigCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleGlobalConfigImpl(ctxArg, key, statusArg)
+}
+
 func handleGlobalConfigModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleGlobalConfigImpl(ctxArg, key, statusArg)
+}
+
+func handleGlobalConfigImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
 	ctx := ctxArg.(*zedagentContext)
 	if key != "global" {
-		log.Infof("handleGlobalConfigModify: ignoring %s", key)
+		log.Infof("handleGlobalConfigImpl: ignoring %s", key)
 		return
 	}
-	log.Infof("handleGlobalConfigModify for %s", key)
+	log.Infof("handleGlobalConfigImpl for %s", key)
 	var gcp *types.ConfigItemValueMap
 	debug, gcp = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
 		debugOverride, logger)
@@ -1476,7 +1532,7 @@ func handleGlobalConfigModify(ctxArg interface{}, key string,
 		ctx.globalConfig = *gcp
 		ctx.GCInitialized = true
 	}
-	log.Infof("handleGlobalConfigModify done for %s", key)
+	log.Infof("handleGlobalConfigImpl done for %s", key)
 }
 
 func handleGlobalConfigDelete(ctxArg interface{}, key string,
@@ -1494,20 +1550,29 @@ func handleGlobalConfigDelete(ctxArg interface{}, key string,
 	log.Infof("handleGlobalConfigDelete done for %s", key)
 }
 
-// Handles both create and modify events
+func handleAACreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleAAImpl(ctxArg, key, statusArg)
+}
+
 func handleAAModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleAAImpl(ctxArg, key, statusArg)
+}
+
+func handleAAImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
 	ctx := ctxArg.(*zedagentContext)
 	status := statusArg.(types.AssignableAdapters)
 	if key != "global" {
-		log.Infof("handleAAModify: ignoring %s", key)
+		log.Infof("handleAAImpl: ignoring %s", key)
 		return
 	}
-	log.Infof("handleAAModify() %+v", status)
+	log.Infof("handleAAImpl() %+v", status)
 	*ctx.assignableAdapters = status
 	triggerPublishDevInfo(ctx)
-	log.Infof("handleAAModify() done")
+	log.Infof("handleAAImpl() done")
 }
 
 func handleAADelete(ctxArg interface{}, key string,
@@ -1524,16 +1589,25 @@ func handleAADelete(ctxArg interface{}, key string,
 	log.Infof("handleAADelete() done")
 }
 
-// Handles both create and modify events
+func handleZbootStatusCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleZbootStatusImpl(ctxArg, key, statusArg)
+}
+
 func handleZbootStatusModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleZbootStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleZbootStatusImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
 	ctx := ctxArg.(*zedagentContext)
 	if !isZbootValidPartitionLabel(key) {
-		log.Errorf("handleZbootStatusModify: invalid key %s", key)
+		log.Errorf("handleZbootStatusImpl: invalid key %s", key)
 		return
 	}
-	log.Infof("handleZbootStatusModify: for %s", key)
+	log.Infof("handleZbootStatusImpl: for %s", key)
 	// nothing to do
 	triggerPublishDevInfo(ctx)
 }
@@ -1548,12 +1622,22 @@ func handleZbootStatusDelete(ctxArg interface{}, key string,
 	// Nothing to do
 }
 
+func handleNodeAgentStatusCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleNodeAgentStatusImpl(ctxArg, key, statusArg)
+}
+
 func handleNodeAgentStatusModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleNodeAgentStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleNodeAgentStatusImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
 	getconfigCtx := ctxArg.(*getconfigContext)
 	status := statusArg.(types.NodeAgentStatus)
-	log.Infof("handleNodeAgentStatusModify: updateInProgress %t rebootReason %s bootReason %s",
+	log.Infof("handleNodeAgentStatusImpl: updateInProgress %t rebootReason %s bootReason %s",
 		status.UpdateInprogress, status.RebootReason,
 		status.BootReason.String())
 	updateInprogress := getconfigCtx.updateInprogress
@@ -1579,7 +1663,7 @@ func handleNodeAgentStatusModify(ctxArg interface{}, key string,
 		handleDeviceReboot(ctx)
 	}
 	triggerPublishDevInfo(ctx)
-	log.Infof("handleNodeAgentStatusModify: done.")
+	log.Infof("handleNodeAgentStatusImpl: done.")
 }
 
 func handleNodeAgentStatusDelete(ctxArg interface{}, key string,

--- a/pkg/pillar/cmd/zedmanager/handledomainmgr.go
+++ b/pkg/pillar/cmd/zedmanager/handledomainmgr.go
@@ -128,16 +128,26 @@ func unpublishDomainConfig(ctx *zedmanagerContext, uuidStr string) {
 	pub.Unpublish(key)
 }
 
+func handleDomainStatusCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleDomainStatusImpl(ctxArg, key, statusArg)
+}
+
 func handleDomainStatusModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleDomainStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleDomainStatusImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
 	status := statusArg.(types.DomainStatus)
 	ctx := ctxArg.(*zedmanagerContext)
-	log.Infof("handleDomainStatusModify for %s", key)
+	log.Infof("handleDomainStatusImpl for %s", key)
 	// Record DomainStatus.State even if Pending() to capture HALTING
 
 	updateAIStatusUUID(ctx, status.Key())
-	log.Infof("handleDomainStatusModify done for %s", key)
+	log.Infof("handleDomainStatusImpl done for %s", key)
 }
 
 func handleDomainStatusDelete(ctxArg interface{}, key string,

--- a/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
+++ b/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
@@ -117,12 +117,22 @@ func unpublishVolumeRefConfig(ctx *zedmanagerContext, key string) {
 	log.Debugf("unpublishVolumeRefConfig(%s) Done", key)
 }
 
+func handleVolumeRefStatusCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleVolumeRefStatusImpl(ctxArg, key, statusArg)
+}
+
 func handleVolumeRefStatusModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleVolumeRefStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleVolumeRefStatusImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
 	status := statusArg.(types.VolumeRefStatus)
 	ctx := ctxArg.(*zedmanagerContext)
-	log.Infof("handleVolumeRefStatusModify: key:%s, name:%s",
+	log.Infof("handleVolumeRefStatusImpl: key:%s, name:%s",
 		key, status.DisplayName)
 	pub := ctx.pubAppInstanceStatus
 	items := pub.GetAll()
@@ -136,7 +146,7 @@ func handleVolumeRefStatusModify(ctxArg interface{}, key string,
 			}
 		}
 	}
-	log.Infof("handleVolumeRefStatusModify done for %s", key)
+	log.Infof("handleVolumeRefStatusImpl done for %s", key)
 }
 
 func handleVolumeRefStatusDelete(ctxArg interface{}, key string,

--- a/pkg/pillar/cmd/zedmanager/handlezedrouter.go
+++ b/pkg/pillar/cmd/zedmanager/handlezedrouter.go
@@ -114,8 +114,19 @@ func unpublishAppNetworkConfig(ctx *zedmanagerContext, uuidStr string) {
 	pub.Unpublish(key)
 }
 
-func handleAppNetworkStatusModify(ctxArg interface{}, key string,
+func handleAppNetworkStatusCreate(ctxArg interface{}, key string,
 	statusArg interface{}) {
+	handleAppNetworkStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleAppNetworkStatusModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleAppNetworkStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleAppNetworkStatusImpl(ctxArg interface{}, key string,
+	statusArg interface{}) {
+
 	status := statusArg.(types.AppNetworkStatus)
 	ctx := ctxArg.(*zedmanagerContext)
 	log.Infof("handleAppNetworkStatusModify: key:%s, name:%s",

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -613,7 +613,7 @@ func purgeCmdDone(ctx *zedmanagerContext, config types.AppInstanceConfig,
 	// Update persistent counter
 	uuidtonum.UuidToNumAllocate(log, ctx.pubUuidToNum,
 		status.UUIDandVersion.UUID,
-		int(status.PurgeCmd.Counter),
+		int(config.PurgeCmd.Counter),
 		false, "purgeCmdCounter")
 	return changed
 }

--- a/pkg/pillar/cmd/zedrouter/acl.go
+++ b/pkg/pillar/cmd/zedrouter/acl.go
@@ -150,23 +150,23 @@ func compileNetworkIpsetsStatus(ctx *zedrouterContext,
 	if netconfig == nil {
 		return ipsets
 	}
-	// walk all of netconfig - find all hosts which use this network
-	pub := ctx.pubAppNetworkStatus
-	items := pub.GetAll()
-	for _, st := range items {
-		status := st.(types.AppNetworkStatus)
-		if skipKey != "" && status.Key() == skipKey {
+	// walk all app instances to find all which use this network
+	sub := ctx.subAppNetworkConfig
+	items := sub.GetAll()
+	for _, c := range items {
+		config := c.(types.AppNetworkConfig)
+		if skipKey != "" && config.Key() == skipKey {
 			log.Debugf("compileNetworkIpsetsStatus skipping %s\n",
 				skipKey)
 			continue
 		}
 
-		for _, ulStatus := range status.UnderlayNetworkList {
-			if ulStatus.Network != netconfig.UUID {
+		for _, ulConfig := range config.UnderlayNetworkList {
+			if ulConfig.Network != netconfig.UUID {
 				continue
 			}
 			ipsets = append(ipsets,
-				compileAceIpsets(ulStatus.ACLs)...)
+				compileAceIpsets(ulConfig.ACLs)...)
 		}
 	}
 	return ipsets

--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -1807,8 +1807,9 @@ func doNetworkInstanceFallback(
 					ulConfig := &config.UnderlayNetworkList[i]
 					// This should take care of re-programming any ACL rules that
 					// use input match on uplinks.
+					// XXX no change in config
 					doAppNetworkModifyUnderlayNetwork(
-						ctx, &appNetworkStatus, ulConfig, ulStatus, ipsets, true)
+						ctx, &appNetworkStatus, ulConfig, ulConfig, ulStatus, ipsets, true)
 				}
 			}
 			publishAppNetworkStatus(ctx, &appNetworkStatus)
@@ -1858,8 +1859,9 @@ func doNetworkInstanceFallback(
 					ulConfig := &config.UnderlayNetworkList[i]
 					// This should take care of re-programming any ACL rules that
 					// use input match on uplinks.
+					// XXX no change in config
 					doAppNetworkModifyUnderlayNetwork(
-						ctx, &appNetworkStatus, ulConfig, ulStatus, ipsets, true)
+						ctx, &appNetworkStatus, ulConfig, ulConfig, ulStatus, ipsets, true)
 				}
 			}
 			publishAppNetworkStatus(ctx, &appNetworkStatus)

--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -395,7 +395,8 @@ func setNetworkACLRules(ctx *zedrouterContext, appID uuid.UUID, intf string, rul
 func handleNetworkInstanceModify(
 	ctxArg interface{},
 	key string,
-	configArg interface{}) {
+	configArg interface{},
+	oldConfigArg interface{}) {
 
 	ctx := ctxArg.(*zedrouterContext)
 	pub := ctx.pubNetworkInstanceStatus
@@ -411,14 +412,17 @@ func handleNetworkInstanceModify(
 		publishNetworkInstanceStatus(ctx, status)
 		log.Infof("handleNetworkInstanceModify(%s) done\n", key)
 	} else {
-		handleNetworkInstanceCreate(ctx, key, config)
+		log.Fatalf("handleNetworkInstanceModify(%s) no status", key)
 	}
 }
 
 func handleNetworkInstanceCreate(
-	ctx *zedrouterContext,
+	ctxArg interface{},
 	key string,
-	config types.NetworkInstanceConfig) {
+	configArg interface{}) {
+
+	ctx := ctxArg.(*zedrouterContext)
+	config := configArg.(types.NetworkInstanceConfig)
 
 	log.Infof("handleNetworkInstanceCreate: (UUID: %s, name:%s)\n",
 		key, config.DisplayName)

--- a/pkg/pillar/execlib/execlib.go
+++ b/pkg/pillar/execlib/execlib.go
@@ -68,8 +68,8 @@ func New(ps *pubsub.PubSub, log *base.LogObject, agentName string, executor stri
 		MyAgentName:   agentName,
 		TopicImpl:     types.ExecStatus{},
 		Ctx:           &handle,
-		CreateHandler: handleStatus,
-		ModifyHandler: handleStatus,
+		CreateHandler: handleStatusCreate,
+		ModifyHandler: handleStatusModify,
 	})
 	if err != nil {
 		return nil, err
@@ -124,11 +124,21 @@ func (hdl *ExecuteHandle) Execute(args ExecuteArgs) (string, error) {
 	return status.Output, nil
 }
 
-func handleStatus(ctxArg interface{}, key string,
+func handleStatusCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleStatusModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleStatusImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
 	hdl := ctxArg.(*ExecuteHandle)
-	hdl.log.Infof("handleStatus %s", key)
+	hdl.log.Infof("handleStatusImpl %s", key)
 	if key != hdl.caller {
 		hdl.log.Infof("Mismatched key %s vs %s\n", key, hdl.caller)
 		return

--- a/pkg/pillar/pubsub/pubsub.go
+++ b/pkg/pillar/pubsub/pubsub.go
@@ -17,9 +17,9 @@ import (
 
 // SubscriptionOptions options to pass when creating a Subscription
 type SubscriptionOptions struct {
-	CreateHandler  SubHandler
-	ModifyHandler  SubHandler
-	DeleteHandler  SubHandler
+	CreateHandler  SubCreateHandler
+	ModifyHandler  SubModifyHandler
+	DeleteHandler  SubDeleteHandler
 	RestartHandler SubRestartHandler
 	SyncHandler    SubRestartHandler
 	WarningTime    time.Duration
@@ -33,22 +33,16 @@ type SubscriptionOptions struct {
 	MyAgentName    string // For logging
 }
 
-// SubHandler is a generic handler to handle create, modify and delete
-// Usage:
-//  s1 := pubsublegacy.Subscribe("foo", fooStruct{}, true, &myctx)
-// Or
-//  s1 := pubsublegacy.Subscribe("foo", fooStruct{}, false, &myctx)
-//  s1.ModifyHandler = func(...), // Optional
-//  s1.DeleteHandler = func(...), // Optional
-//  s1.RestartHandler = func(...), // Optional
-//  [ Initialize myctx ]
-//  s1.Activate()
-//  ...
-//  select {
-//     case change := <- s1.C:
-//         s1.ProcessChange(change, ctx)
-//  }
-type SubHandler func(ctx interface{}, key string, status interface{})
+// SubCreateHandler is a handler to handle creates
+type SubCreateHandler func(ctx interface{}, key string, status interface{})
+
+// SubModifyHandler is a handler for modify notifications which carries
+// the oldStatus
+type SubModifyHandler func(ctx interface{}, key string, status interface{},
+	oldStatus interface{})
+
+// SubDeleteHandler is a handler to handle delete
+type SubDeleteHandler func(ctx interface{}, key string, status interface{})
 
 // SubRestartHandler generic handler for restarts
 type SubRestartHandler func(ctx interface{}, restarted bool)
@@ -94,6 +88,12 @@ func (p *PubSub) NewSubscription(options SubscriptionOptions) (Subscription, err
 
 	topic := TypeToName(options.TopicImpl)
 	topicType := reflect.TypeOf(options.TopicImpl)
+
+	if options.ModifyHandler != nil && options.CreateHandler == nil {
+		return nil, fmt.Errorf("ModifyHandler but no CreateHandler for topic %s",
+			topic)
+	}
+
 	// Need some buffering to make sure that when we Close the subscription
 	// the goroutines exit
 	changes := make(chan Change, 3)

--- a/pkg/pillar/pubsub/pubsub_test.go
+++ b/pkg/pillar/pubsub/pubsub_test.go
@@ -51,7 +51,7 @@ func TestHandleModify(t *testing.T) {
 	subCreateHandler := func(ctxArg interface{}, key string, status interface{}) {
 		created = true
 	}
-	subModifyHandler := func(ctxArg interface{}, key string, status interface{}) {
+	subModifyHandler := func(ctxArg interface{}, key string, status interface{}, oldStatus interface{}) {
 		modified = true
 	}
 
@@ -59,8 +59,8 @@ func TestHandleModify(t *testing.T) {
 		ctxArg         *SubscriptionImpl
 		key            string
 		item           interface{}
-		modifyHandler  SubHandler
-		createHandler  SubHandler
+		modifyHandler  SubModifyHandler
+		createHandler  SubCreateHandler
 		expectedCreate bool
 		expectedModify bool
 	}{
@@ -80,7 +80,7 @@ func TestHandleModify(t *testing.T) {
 			modifyHandler:  subModifyHandler,
 			createHandler:  nil,
 			expectedCreate: false,
-			expectedModify: true,
+			expectedModify: false,
 		},
 		"Create Handler and Modify Handler are nil": {
 			ctxArg:         subImpl,
@@ -89,6 +89,15 @@ func TestHandleModify(t *testing.T) {
 			modifyHandler:  nil,
 			createHandler:  nil,
 			expectedCreate: false,
+			expectedModify: false,
+		},
+		"Both Handlers are set": {
+			ctxArg:         subImpl,
+			key:            "key_3",
+			item:           item,
+			modifyHandler:  subModifyHandler,
+			createHandler:  subCreateHandler,
+			expectedCreate: true,
 			expectedModify: false,
 		},
 	}

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -145,17 +145,12 @@ type AppInstanceStatus struct {
 	DisplayName         string
 	DomainName          string // Once booted
 	Activated           bool
-	ActivateInprogress  bool     // Needed for cleanup after failure
-	FixedResources      VmConfig // CPU etc
+	ActivateInprogress  bool // Needed for cleanup after failure
 	VolumeRefStatusList []VolumeRefStatus
-	EIDList             []EIDStatusDetails
+	EIDList             []EIDStatusDetails // XXX remove?
 	UnderlayNetworks    []UnderlayNetworkStatus
-	// Copies of config to determine diffs
-	UnderlayNetworkList []UnderlayNetworkConfig
 	BootTime            time.Time
-	IoAdapterList       []IoAdapter
-	RestartCmd          AppInstanceOpsCmd
-	PurgeCmd            AppInstanceOpsCmd
+	IoAdapterList       []IoAdapter // Report what was actually used
 	RestartInprogress   Inprogress
 	PurgeInprogress     Inprogress
 

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -1735,6 +1735,7 @@ type UnderlayNetworkConfig struct {
 
 type UnderlayNetworkStatus struct {
 	UnderlayNetworkConfig
+	ACLs int // drop ACLs field from UnderlayNetworkConfig
 	VifInfo
 	BridgeMac       net.HardwareAddr
 	BridgeIPAddr    string // The address for DNS/DHCP service in zedrouter

--- a/pkg/pillar/utils/waitfor.go
+++ b/pkg/pillar/utils/waitfor.go
@@ -29,7 +29,7 @@ func WaitForVault(ps *pubsub.PubSub, log *base.LogObject, agentName string, warn
 		TopicImpl:     types.VaultStatus{},
 		Activate:      false,
 		Ctx:           Ctx,
-		CreateHandler: handleVaultStatusModify,
+		CreateHandler: handleVaultStatusCreate,
 		ModifyHandler: handleVaultStatusModify,
 		WarningTime:   warningTime,
 		ErrorTime:     errorTime,
@@ -59,7 +59,17 @@ func WaitForVault(ps *pubsub.PubSub, log *base.LogObject, agentName string, warn
 	return nil
 }
 
+func handleVaultStatusCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleVaultStatusImpl(ctxArg, key, statusArg)
+}
+
 func handleVaultStatusModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleVaultStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleVaultStatusImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
 	ctx := ctxArg.(*Context)
@@ -82,7 +92,7 @@ func WaitForOnboarded(ps *pubsub.PubSub, log *base.LogObject, agentName string, 
 		Activate:      true,
 		Persistent:    true,
 		Ctx:           Ctx,
-		CreateHandler: handleOnboardStatusModify,
+		CreateHandler: handleOnboardStatusCreate,
 		ModifyHandler: handleOnboardStatusModify,
 		WarningTime:   warningTime,
 		ErrorTime:     errorTime,
@@ -114,7 +124,19 @@ func WaitForOnboarded(ps *pubsub.PubSub, log *base.LogObject, agentName string, 
 var nilUUID = uuid.UUID{}
 
 // Set Initialized if the UUID is not nil
-func handleOnboardStatusModify(ctxArg interface{}, key string, statusArg interface{}) {
+func handleOnboardStatusCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleOnboardStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleOnboardStatusModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleOnboardStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleOnboardStatusImpl(ctxArg interface{}, key string,
+	statusArg interface{}) {
+
 	status := statusArg.(types.OnboardingStatus)
 	ctx := ctxArg.(*Context)
 


### PR DESCRIPTION
We have some code in zedmanager and zedrouter which stores some old AppInstanceConfig/AppNetworkConfig state in the corresponding Status so that the Modify handler can determine what changed.

However, that results in additional memory usage e.g., for ACLs, and the pubsub infrastructure already knows the old value.
Thus in the first (quite large) commit in this PR we add that to pubsub (which means a bunch of mechanical changes to add the argument to all of the agents).
The second and third commit does the changes in zedmanager and zedrouter to reduce the config/status duplication.