### PR TITLE
Cancel downloads which make no progress

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -13,6 +13,7 @@
 | timer.use.config.checkpoint | integer in seconds | 600 | use checkpointed config if no cloud connectivity |
 | timer.gc.vdisk | integer in seconds | 1 hour | garbage collect unused instance virtual disk |
 | timer.download.retry | integer in seconds | 600 | retry a failed download |
+| timer.download.stalled | integer in seconds | 600 | cancel a stalled download |
 | timer.boot.retry | integer in seconds | 600 | retry a failed domain boot |
 | timer.port.georedo | integer in seconds | 1 hour | redo IP geolocation |
 | timer.port.georetry | integer in seconds | 600 | retry geolocation after failure |

--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -36,14 +36,15 @@ const (
 
 // Go doesn't like this as a constant
 var (
-	debug         = false
-	debugOverride bool                               // From command line arg
-	retryTime     = time.Duration(600) * time.Second // Unless from GlobalConfig
-	Version       = "No version specified"           // Set from Makefile
-	dHandler      = makeDownloadHandler()
-	resHandler    = makeResolveHandler()
-	logger        *logrus.Logger
-	log           *base.LogObject
+	debug          = false
+	debugOverride  bool                               // From command line arg
+	retryTime      = time.Duration(600) * time.Second // Unless from GlobalConfig
+	maxStalledTime = time.Duration(600) * time.Second // Unless from GlobalConfig
+	Version        = "No version specified"           // Set from Makefile
+	dHandler       = makeDownloadHandler()
+	resHandler     = makeResolveHandler()
+	logger         *logrus.Logger
+	log            *base.LogObject
 )
 
 func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) int {

--- a/pkg/pillar/cmd/downloader/globalconfig.go
+++ b/pkg/pillar/cmd/downloader/globalconfig.go
@@ -27,6 +27,9 @@ func handleGlobalConfigModify(ctxArg interface{}, key string,
 		if gcp.GlobalValueInt(types.DownloadRetryTime) != 0 {
 			retryTime = time.Duration(gcp.GlobalValueInt(types.DownloadRetryTime)) * time.Second
 		}
+		if gcp.GlobalValueInt(types.DownloadStalledTime) != 0 {
+			maxStalledTime = time.Duration(gcp.GlobalValueInt(types.DownloadStalledTime)) * time.Second
+		}
 		ctx.GCInitialized = true
 	}
 	log.Infof("handleGlobalConfigModify done for %s", key)

--- a/pkg/pillar/cmd/downloader/status.go
+++ b/pkg/pillar/cmd/downloader/status.go
@@ -9,7 +9,8 @@ import (
 
 // Status provides a struct that can be called to update download progress
 type Status interface {
-	Progress(uint, int64, int64)
+	// Progress report progress; returns false if no change
+	Progress(uint, int64, int64) bool
 }
 
 // PublishStatus practical implementation of Status
@@ -21,9 +22,15 @@ type PublishStatus struct {
 }
 
 // Progress report progress as a percentage of completeness
-func (d *PublishStatus) Progress(p uint, currentSize, totalSize int64) {
+// Returns true if there was a change to the recorded values
+func (d *PublishStatus) Progress(p uint, currentSize, totalSize int64) bool {
+	if d.status.Progress == p && d.status.CurrentSize == currentSize &&
+		d.status.TotalSize == totalSize {
+		return false
+	}
 	d.status.Progress = p
 	d.status.CurrentSize = currentSize
 	d.status.TotalSize = totalSize
 	publishDownloaderStatus(d.ctx, d.status)
+	return true
 }

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -129,6 +129,8 @@ const (
 	VdiskGCTime GlobalSettingKey = "timer.gc.vdisk"
 	// DownloadRetryTime global setting key
 	DownloadRetryTime GlobalSettingKey = "timer.download.retry"
+	// DownloadStalledTime global setting key
+	DownloadStalledTime GlobalSettingKey = "timer.download.stalled"
 	// DomainBootRetryTime global setting key
 	DomainBootRetryTime GlobalSettingKey = "timer.boot.retry"
 	// NetworkGeoRedoTime global setting key
@@ -700,6 +702,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddIntItem(StaleConfigTime, 7*24*3600, 0, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(VdiskGCTime, 3600, 60, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(DownloadRetryTime, 600, 60, 0xFFFFFFFF)
+	configItemSpecMap.AddIntItem(DownloadStalledTime, 600, 20, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(DomainBootRetryTime, 600, 10, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(NetworkGeoRedoTime, 3600, 60, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(NetworkGeoRetryTime, 600, 5, 0xFFFFFFFF)

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -155,6 +155,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		StaleConfigTime,
 		VdiskGCTime,
 		DownloadRetryTime,
+		DownloadStalledTime,
 		DomainBootRetryTime,
 		NetworkGeoRedoTime,
 		NetworkGeoRetryTime,

--- a/pkg/pillar/zedUpload/awsutil/s3api.go
+++ b/pkg/pillar/zedUpload/awsutil/s3api.go
@@ -4,6 +4,7 @@
 package awsutil
 
 import (
+	"context"
 	"log"
 	"net/http"
 	"time"
@@ -26,6 +27,7 @@ type S3ctx struct {
 	ss3 *s3.S3
 	dn  *s3manager.Downloader
 	up  *s3manager.Uploader
+	ctx context.Context
 }
 
 type S3CredProvider struct {
@@ -43,7 +45,10 @@ func (p *S3CredProvider) IsExpired() bool {
 }
 
 func NewAwsCtx(id, secret, region string, hctx *http.Client) *S3ctx {
-	ctx := S3ctx{p: S3CredProvider{id: id, secret: secret}}
+	ctx := S3ctx{
+		p:   S3CredProvider{id: id, secret: secret},
+		ctx: aws.BackgroundContext(),
+	}
 	cred := credentials.NewCredentials(&ctx.p)
 
 	cfg := aws.NewConfig()
@@ -68,6 +73,12 @@ func NewAwsCtx(id, secret, region string, hctx *http.Client) *S3ctx {
 	})
 
 	return &ctx
+}
+
+// WithContext can be used to pass a context e.g., for cancellation
+func (s *S3ctx) WithContext(cancelContext context.Context) *S3ctx {
+	s.ctx = cancelContext
+	return s
 }
 
 func (s *S3ctx) CreateBucket(bname string) error {

--- a/pkg/pillar/zedUpload/awsutil/s3sync.go
+++ b/pkg/pillar/zedUpload/awsutil/s3sync.go
@@ -154,7 +154,7 @@ func (s *S3ctx) UploadFile(fname, bname, bkey string, compression bool, prgNotif
 		}()
 	}
 
-	result, err := s.up.Upload(&s3manager.UploadInput{
+	result, err := s.up.UploadWithContext(s.ctx, &s3manager.UploadInput{
 		Body: reader, Bucket: aws.String(bname),
 		Key: aws.String(bkey)})
 	if err != nil {
@@ -183,7 +183,7 @@ func (s *S3ctx) DownloadFile(fname, bname, bkey string,
 	}
 
 	defer fd.Close()
-	_, err = s.dn.Download(cWriter, &s3.GetObjectInput{Bucket: aws.String(bname),
+	_, err = s.dn.DownloadWithContext(s.ctx, cWriter, &s3.GetObjectInput{Bucket: aws.String(bname),
 		Key: aws.String(bkey)})
 	if err != nil {
 		return err
@@ -198,7 +198,7 @@ func (s *S3ctx) DownloadFileByChunks(fname, bname, bkey string) (io.ReadCloser, 
 		return nil, 0, err
 	}
 	fmt.Println("size,", bsize)
-	req, err := s.ss3.GetObject(&s3.GetObjectInput{Bucket: aws.String(bname),
+	req, err := s.ss3.GetObjectWithContext(s.ctx, &s3.GetObjectInput{Bucket: aws.String(bname),
 		Key: aws.String(bkey)})
 	if err != nil {
 		return nil, 0, err
@@ -212,7 +212,7 @@ func (s *S3ctx) ListImages(bname string, prgNotify NotifChan) ([]string, error) 
 		Bucket: aws.String(bname),
 	}
 
-	result, err := s.ss3.ListObjects(input)
+	result, err := s.ss3.ListObjectsWithContext(s.ctx, input)
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
 			switch aerr.Code() {

--- a/pkg/pillar/zedUpload/datastore_aws.go
+++ b/pkg/pillar/zedUpload/datastore_aws.go
@@ -133,6 +133,9 @@ func (ep *AwsTransportMethod) processS3Upload(req *DronaRequest) (error, int) {
 	if sc == nil {
 		return fmt.Errorf("unable to create S3 context"), 0
 	}
+	if req.cancelContext != nil {
+		sc = sc.WithContext(req.cancelContext)
+	}
 
 	location, err := sc.UploadFile(req.objloc, ep.bucket, req.name, false, prgChan)
 	if len(location) > 0 {
@@ -148,6 +151,9 @@ func (ep *AwsTransportMethod) processS3Download(req *DronaRequest) (error, int) 
 	pwd := strings.TrimSuffix(ep.apiKey, "\n")
 	if req.ackback {
 		s := zedAWS.NewAwsCtx(ep.token, pwd, ep.region, ep.hClient)
+		if req.cancelContext != nil {
+			s = s.WithContext(req.cancelContext)
+		}
 		if s != nil {
 			err, length := s.GetObjectSize(ep.bucket, req.name)
 			if err == nil {
@@ -180,7 +186,9 @@ func (ep *AwsTransportMethod) processS3Download(req *DronaRequest) (error, int) 
 	if sc == nil {
 		return fmt.Errorf("unable to create S3 context"), 0
 	}
-
+	if req.cancelContext != nil {
+		sc = sc.WithContext(req.cancelContext)
+	}
 	err := sc.DownloadFile(req.objloc, ep.bucket, req.name, req.sizelimit, prgChan)
 	if err != nil {
 		return err, 0
@@ -201,6 +209,9 @@ func (ep *AwsTransportMethod) processS3DownloadByChunks(req *DronaRequest) error
 	if sc == nil {
 		return fmt.Errorf("unable to create S3 context")
 	}
+	if req.cancelContext != nil {
+		sc = sc.WithContext(req.cancelContext)
+	}
 	readCloser, size, err := sc.DownloadFileByChunks(req.objloc, ep.bucket, req.name)
 	if err != nil {
 		return err
@@ -220,6 +231,9 @@ func (ep *AwsTransportMethod) processS3Delete(req *DronaRequest) error {
 	var err error
 	s3ctx := zedAWS.NewAwsCtx(ep.token, ep.apiKey, ep.region, ep.hClient)
 	if s3ctx != nil {
+		if req.cancelContext != nil {
+			s3ctx = s3ctx.WithContext(req.cancelContext)
+		}
 		err = s3ctx.DeleteObject(ep.bucket, req.name)
 	} else {
 		return fmt.Errorf("no s3 context")
@@ -261,6 +275,9 @@ func (ep *AwsTransportMethod) processS3List(req *DronaRequest) ([]string, error,
 	if sc == nil {
 		return s, fmt.Errorf("unable to create S3 context"), 0
 	}
+	if req.cancelContext != nil {
+		sc = sc.WithContext(req.cancelContext)
+	}
 
 	list, err := sc.ListImages(ep.bucket, prgChan)
 	if err != nil {
@@ -278,6 +295,9 @@ func (ep *AwsTransportMethod) processS3ObjectMetaData(req *DronaRequest) (int64,
 	sc := zedAWS.NewAwsCtx(ep.token, pwd, ep.region, ep.hClient)
 	if sc == nil {
 		return 0, "", fmt.Errorf("unable to create S3 context")
+	}
+	if req.cancelContext != nil {
+		sc = sc.WithContext(req.cancelContext)
 	}
 
 	size, remoteFileMD5, err := sc.GetObjectMetaData(ep.bucket, req.name)
@@ -314,17 +334,26 @@ func (ep *AwsTransportMethod) getContext() *DronaCtx {
 
 func (ep *AwsTransportMethod) processMultipartUpload(req *DronaRequest) (string, string, error) {
 	s3ctx := zedAWS.NewAwsCtx(ep.token, ep.apiKey, ep.region, ep.hClient)
+	if req.cancelContext != nil {
+		s3ctx = s3ctx.WithContext(req.cancelContext)
+	}
 	return s3ctx.UploadPart(ep.bucket, req.localName, req.Adata, req.PartID, req.UploadID)
 
 }
 
 func (ep *AwsTransportMethod) completeMultipartUpload(req *DronaRequest) error {
 	s3ctx := zedAWS.NewAwsCtx(ep.token, ep.apiKey, ep.region, ep.hClient)
+	if req.cancelContext != nil {
+		s3ctx = s3ctx.WithContext(req.cancelContext)
+	}
 	return s3ctx.CompleteUploadedParts(ep.bucket, req.localName, req.UploadID, req.Blocks)
 }
 
 func (ep *AwsTransportMethod) generateSignedURL(req *DronaRequest) (string, error) {
 	s3ctx := zedAWS.NewAwsCtx(ep.token, ep.apiKey, ep.region, ep.hClient)
+	if req.cancelContext != nil {
+		s3ctx = s3ctx.WithContext(req.cancelContext)
+	}
 	return s3ctx.GetSignedURL(ep.bucket, req.localName, req.Duration)
 }
 


### PR DESCRIPTION
That way downloader will retry them.

With the AVS S3 downloads we see it hang (with goroutines stuck in the S3 aws library) if the network goes out for a few minutes.
With these changes we cancel it based on a timer (default 10 minutes; setable using timer.downloader.stalled) if there is no progress in the number of downloaded bytes. Also using the same timer to cancel any tag resolutions.

The first commit are changes in zedUpload to pass around a context.Context for AWS, and the second commit is downloader using that plus lack of progress detection.

Not clear whether the Azure API can do this (it doesn't have a context.Context but just a timeout and we need to be patient if we download huge objects over slow links as long as they make some progress.)
Not using with http either - TBD.
@chethan-zededa what can we do for Azure?