### PR TITLE
Add fault injection binary and documentation

### DIFF
--- a/docs/FAULT-INJECTION.md
+++ b/docs/FAULT-INJECTION.md
@@ -1,0 +1,22 @@
+# Fault injection in EVE
+
+EVE is detecting and recovering from a multitude of faults such as
+
+- failure to boot (using hardware watchdog)
+- hangs post boot (using hardware watchdog)
+- device driver issues which result in loss of communication with the controller (using the timer.reboot.no.network timer to reboot)
+- processes crashing (using the Linux watchdog daemon and pid files)
+- key goroutines in the pillar services getting stuck (using the Linux watchdog daemon and touch files)
+- the above failures during an update of the EVE image (when the resulting reboot results in a fallback to the previous image)
+- failure to reach the controller after a change to the systemAdapterList [config API](../api/proto/config/devconfig.proto) which results in a fallback to the old systemAdapterList
+
+For some of the above we can explicitly inject faults.
+For instance, one can unplug the network cable to cause network failures or run an iptables setup which drops all communication to the controller.
+
+There is also an application called /opt/zededa/bin/faultinjection which can cause various failures in the zedbox process and verify that the Linux watchdog daemon detects it and also reports it to the controller.
+
+The options for faultinjection are:
+
+- F: cause a log.Fatal which will make zedbox exit after logging the error
+- P: cause a golang runtime panic which will make zedbox exit (the watchdog-report.sh script tries to extract the panic info and save it)
+- H: cause the faultinjection service, after registering its touch file with the Linux watchdog daemon, to never touch that file. This will result in the Linux watchdog daemon rebooting the system after recording the stack traces in /persist/agentdebug/.

--- a/pkg/pillar/cmd/faultinjection/run.go
+++ b/pkg/pillar/cmd/faultinjection/run.go
@@ -1,0 +1,168 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// A application which exists solely to inject faults
+
+package faultinjection
+
+import (
+	"flag"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/agentlog"
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/pidfile"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	agentName = "fault-injection"
+	// Time limits for event loop handlers
+	errorTime   = 3 * time.Minute
+	warningTime = 40 * time.Second
+)
+
+// Any state used by handlers goes here
+type faultContext struct {
+	subGlobalConfig pubsub.Subscription
+	GCInitialized   bool
+
+	// CLI args
+	debug         bool
+	debugOverride bool // From command line arg
+	timeLimit     uint // In seconds
+}
+
+var logger *logrus.Logger
+var log *base.LogObject
+
+// Run is the main aka only entrypoint
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) int {
+	logger = loggerArg
+	log = logArg
+	ctx := faultContext{}
+	debugPtr := flag.Bool("d", false, "Debug flag")
+	fatalPtr := flag.Bool("F", false, "Cause log.Fatal fault injection")
+	panicPtr := flag.Bool("P", false, "Cause golang panic fault injection")
+	hangPtr := flag.Bool("H", false, "Cause watchdog .touch fault injection")
+	flag.Parse()
+	fatalFlag := *fatalPtr
+	panicFlag := *panicPtr
+	hangFlag := *hangPtr
+	ctx.debug = *debugPtr
+	ctx.debugOverride = *debugPtr
+	if ctx.debugOverride {
+		logger.SetLevel(logrus.TraceLevel)
+	} else {
+		logger.SetLevel(logrus.InfoLevel)
+	}
+	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
+		log.Fatal(err)
+	}
+	log.Infof("Starting %s", agentName)
+
+	// Run a periodic timer so we always update StillRunning
+	stillRunning := time.NewTicker(25 * time.Second)
+	ps.StillRunning(agentName, warningTime, errorTime)
+
+	// Add .pid and .touch file to watchdog config
+	ps.RegisterPidWatchdog(agentName)
+	ps.RegisterFileWatchdog(agentName)
+
+	// Look for global config such as log levels
+	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:     "zedagent",
+		MyAgentName:   agentName,
+		TopicImpl:     types.ConfigItemValueMap{},
+		Persistent:    true,
+		Ctx:           &ctx,
+		CreateHandler: handleGlobalConfigCreate,
+		ModifyHandler: handleGlobalConfigModify,
+		DeleteHandler: handleGlobalConfigDelete,
+		WarningTime:   warningTime,
+		ErrorTime:     errorTime,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	ctx.subGlobalConfig = subGlobalConfig
+	subGlobalConfig.Activate()
+
+	// Pick up debug aka log level before we start real work
+	for !ctx.GCInitialized {
+		log.Infof("waiting for GCInitialized")
+		select {
+		case change := <-subGlobalConfig.MsgChan():
+			subGlobalConfig.ProcessChange(change)
+		case <-stillRunning.C:
+		}
+		ps.StillRunning(agentName, warningTime, errorTime)
+	}
+	log.Infof("processed GlobalConfig")
+
+	for {
+		select {
+		case change := <-subGlobalConfig.MsgChan():
+			subGlobalConfig.ProcessChange(change)
+
+		case <-stillRunning.C:
+			// Fault injection
+			if fatalFlag {
+				log.Fatal("Requested fault injection to cause watchdog")
+			} else if panicFlag {
+				log.Warnf("Requested fault injection panic to cause watchdog")
+				var panicBuf []int
+				panicBuf[99] = 1
+			}
+		}
+		if hangFlag {
+			log.Warnf("Requested to not touch to cause watchdog")
+		} else {
+			ps.StillRunning(agentName, warningTime, errorTime)
+		}
+	}
+}
+
+func handleGlobalConfigCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleGlobalConfigImpl(ctxArg, key, statusArg)
+}
+
+func handleGlobalConfigModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleGlobalConfigImpl(ctxArg, key, statusArg)
+}
+
+func handleGlobalConfigImpl(ctxArg interface{}, key string,
+	statusArg interface{}) {
+
+	ctx := ctxArg.(*faultContext)
+	if key != "global" {
+		log.Infof("handleGlobalConfigImpl: ignoring %s", key)
+		return
+	}
+	log.Infof("handleGlobalConfigImpl for %s", key)
+	var gcp *types.ConfigItemValueMap
+	ctx.debug, gcp = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
+		ctx.debugOverride, logger)
+	if gcp != nil {
+		ctx.GCInitialized = true
+	}
+	log.Infof("handleGlobalConfigImpl done for %s", key)
+}
+
+func handleGlobalConfigDelete(ctxArg interface{}, key string,
+	statusArg interface{}) {
+
+	ctx := ctxArg.(*faultContext)
+	if key != "global" {
+		log.Infof("handleGlobalConfigDelete: ignoring %s", key)
+		return
+	}
+	log.Infof("handleGlobalConfigDelete for %s", key)
+	ctx.debug, _ = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
+		ctx.debugOverride, logger)
+	log.Infof("handleGlobalConfigDelete done for %s", key)
+}

--- a/pkg/pillar/zedbox/zedbox.go
+++ b/pkg/pillar/zedbox/zedbox.go
@@ -24,6 +24,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/cmd/domainmgr"
 	"github.com/lf-edge/eve/pkg/pillar/cmd/downloader"
 	"github.com/lf-edge/eve/pkg/pillar/cmd/executor"
+	"github.com/lf-edge/eve/pkg/pillar/cmd/faultinjection"
 	"github.com/lf-edge/eve/pkg/pillar/cmd/hardwaremodel"
 	"github.com/lf-edge/eve/pkg/pillar/cmd/ipcmonitor"
 	"github.com/lf-edge/eve/pkg/pillar/cmd/ledmanager"
@@ -76,6 +77,7 @@ var (
 		"domainmgr":        {f: domainmgr.Run},
 		"downloader":       {f: downloader.Run},
 		"executor":         {f: executor.Run},
+		"faultinjection":   {f: faultinjection.Run},
 		"hardwaremodel":    {f: hardwaremodel.Run, inline: inlineAlways},
 		"ledmanager":       {f: ledmanager.Run},
 		"logmanager":       {f: logmanager.Run},


### PR DESCRIPTION
Later we can remove the code (from executor, logmanager, etc) which has similar arguments.