### PR TITLE
Import logrus as logrus to avoid confusion

### DIFF
--- a/pkg/pillar/containerd/utilAPIs.go
+++ b/pkg/pillar/containerd/utilAPIs.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/containerd/containerd"
 	uuid "github.com/satori/go.uuid"
-	log "github.com/sirupsen/logrus" // XXX add log argument
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -21,25 +21,25 @@ const (
 
 // PrepareMount creates special files for running container inside a VM
 func PrepareMount(containerID uuid.UUID, containerPath string, envVars map[string]string, noOfDisks int) error {
-	log.Infof("PrepareMount(%s, %s, %v, %d)", containerID, containerPath,
+	logrus.Infof("PrepareMount(%s, %s, %v, %d)", containerID, containerPath,
 		envVars, noOfDisks)
 	imageInfo, err := getSavedImageInfo(containerPath)
 	if err != nil {
-		log.Errorf("PrepareMount(%s, %s) getImageInfo failed: %s",
+		logrus.Errorf("PrepareMount(%s, %s) getImageInfo failed: %s",
 			containerID, containerPath, err)
 		return err
 	}
 	// inject a few files of our own into the bundle
 	mountpoints, execpath, workdir, env, err := getContainerConfigs(imageInfo, envVars)
 	if err != nil {
-		log.Errorf("PrepareMount(%s, %s) getContainerConfigs failed: %s",
+		logrus.Errorf("PrepareMount(%s, %s) getContainerConfigs failed: %s",
 			containerID, containerPath, err)
 		return fmt.Errorf("PrepareMount: unable to get container config: %v", err)
 	}
 
 	err = createMountPointExecEnvFiles(containerPath, mountpoints, execpath, workdir, env, noOfDisks)
 	if err != nil {
-		log.Errorf("PrepareMount(%s, %s) createMountPointExecEnvFiles failed: %s",
+		logrus.Errorf("PrepareMount(%s, %s) createMountPointExecEnvFiles failed: %s",
 			containerID, containerPath, err)
 	}
 	return err
@@ -51,10 +51,10 @@ func SaveSnapshotID(oldRootpath, newRootpath string) error {
 	filename := filepath.Join(newRootpath, snapshotIDFile)
 	if err := ioutil.WriteFile(filename, []byte(snapshotID), 0644); err != nil {
 		err = fmt.Errorf("SaveSnapshotID: Save snapshotID %s failed: %s", snapshotID, err)
-		log.Error(err.Error())
+		logrus.Error(err.Error())
 		return err
 	}
-	log.Infof("SaveSnapshotID: Saved snapshotID %s in %s",
+	logrus.Infof("SaveSnapshotID: Saved snapshotID %s in %s",
 		snapshotID, filename)
 	return nil
 }
@@ -68,20 +68,20 @@ func GetSnapshotID(rootpath string) string {
 		cont, err := ioutil.ReadFile(filename)
 		if err == nil {
 			snapshotID := string(cont)
-			log.Infof("GetSnapshotID read %s from %s",
+			logrus.Infof("GetSnapshotID read %s from %s",
 				snapshotID, filename)
 			return snapshotID
 		}
-		log.Errorf("GetSnapshotID read %s failed: %s", filename, err)
+		logrus.Errorf("GetSnapshotID read %s failed: %s", filename, err)
 	}
 	snapshotID := filepath.Base(rootpath)
-	log.Infof("GetSnapshotID basename %s from %s", snapshotID, rootpath)
+	logrus.Infof("GetSnapshotID basename %s from %s", snapshotID, rootpath)
 	return snapshotID
 }
 
 //UnpackClientImage unpacks given client image into containerd.
 func (client *Client) UnpackClientImage(clientImage containerd.Image) error {
-	log.Infof("UnpackClientImage: for image :%s", clientImage.Name())
+	logrus.Infof("UnpackClientImage: for image :%s", clientImage.Name())
 	ctrdCtx, done := client.CtrNewUserServicesCtx()
 	defer done()
 	unpacked, err := clientImage.IsUnpacked(ctrdCtx, defaultSnapshotter)
@@ -100,7 +100,7 @@ func (client *Client) UnpackClientImage(clientImage containerd.Image) error {
 func isFile(path string) bool {
 	fileInfo, err := os.Stat(path)
 	if err != nil {
-		log.Errorf("isFile(%s): %s", path, err.Error())
+		logrus.Errorf("isFile(%s): %s", path, err.Error())
 		return false
 	}
 	return !fileInfo.IsDir()

--- a/pkg/pillar/hardware/model_test.go
+++ b/pkg/pillar/hardware/model_test.go
@@ -6,11 +6,11 @@ package hardware
 import (
 	"testing"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 func TestCompatible(t *testing.T) {
-	log.Infof("TestCompatible: START\n")
+	logrus.Infof("TestCompatible: START\n")
 
 	fromProc := []byte("hisilicon,hi6220-hikey\x00hisilicon,hi6220\x00")
 	expected := "hisilicon,hi6220-hikey.hisilicon,hi6220"
@@ -19,5 +19,5 @@ func TestCompatible(t *testing.T) {
 		t.Errorf("Test Failed: Expected %v, Actual: %v\n",
 			expected, actual)
 	}
-	log.Infof("TestCompatible: DONE\n")
+	logrus.Infof("TestCompatible: DONE\n")
 }

--- a/pkg/pillar/hypervisor/containerd.go
+++ b/pkg/pillar/hypervisor/containerd.go
@@ -12,11 +12,10 @@ import (
 	"os"
 	"time"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 type ctrdContext struct {
-	// XXX add log?
 	domCounter int
 	PCI        map[string]bool
 	ctrdClient *containerd.Client
@@ -36,7 +35,7 @@ func initContainerd() (*ctrdContext, error) {
 
 func newContainerd() Hypervisor {
 	if ret, err := initContainerd(); err != nil {
-		log.Fatalf("couldn't initialize containerd (this should not happen): %v. Exiting.", err)
+		logrus.Fatalf("couldn't initialize containerd (this should not happen): %v. Exiting.", err)
 		return nil // it really never returns on account of above
 	} else {
 		return ret
@@ -138,7 +137,7 @@ func (ctx ctrdContext) Info(domainName string, domainID int) (int, types.SwState
 	}
 
 	if effectiveDomainID != domainID {
-		log.Warnf("containerd domain %s with PID %d (different from expected %d) is %s",
+		logrus.Warnf("containerd domain %s with PID %d (different from expected %d) is %s",
 			domainName, effectiveDomainID, domainID, status)
 	}
 
@@ -211,7 +210,7 @@ func (ctx ctrdContext) GetDomsCPUMem() (map[string]types.DomainMetric, error) {
 			}
 			cpuTotal = metric.CPU.Usage.Total / nanoSecToSec / clockTicks
 		} else {
-			log.Errorf("GetDomsCPUMem failed with error %v", err)
+			logrus.Errorf("GetDomsCPUMem failed with error %v", err)
 		}
 
 		res[id] = types.DomainMetric{

--- a/pkg/pillar/hypervisor/hypervisor.go
+++ b/pkg/pillar/hypervisor/hypervisor.go
@@ -8,7 +8,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/mem"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"os"
 )
 
@@ -93,6 +93,6 @@ func roundFromKbytesToMbytes(byteCount uint64) uint64 {
 }
 
 func logError(format string, a ...interface{}) error {
-	log.Errorf(format, a...)
+	logrus.Errorf(format, a...)
 	return fmt.Errorf(format, a...)
 }

--- a/pkg/pillar/hypervisor/null.go
+++ b/pkg/pillar/hypervisor/null.go
@@ -9,7 +9,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 type domState struct {
@@ -107,10 +107,10 @@ func (ctx nullContext) Delete(domainName string, domainID int) error {
 
 func (ctx nullContext) Info(domainName string, domainID int) (int, types.SwState, error) {
 	if dom, found := ctx.doms[domainName]; found {
-		log.Infof("Null Domain %s is %v and has the following config %s\n", domainName, dom.state, dom.config)
+		logrus.Infof("Null Domain %s is %v and has the following config %s\n", domainName, dom.state, dom.config)
 		return dom.id, dom.state, nil
 	} else {
-		log.Errorf("Null Domain %s doesn't exist", domainName)
+		logrus.Errorf("Null Domain %s doesn't exist", domainName)
 		return 0, types.UNKNOWN, fmt.Errorf("null domain %s doesn't exist", domainName)
 	}
 }

--- a/pkg/pillar/hypervisor/qmp.go
+++ b/pkg/pillar/hypervisor/qmp.go
@@ -3,7 +3,7 @@ package hypervisor
 import (
 	"encoding/json"
 	"github.com/digitalocean/go-qemu/qmp"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"os"
 	"time"
 )
@@ -67,39 +67,39 @@ func getQemuStatus(socket string) (string, error) {
 func qmpEventHandler(listenerSocket, executorSocket string) {
 	monitor, err := qmp.NewSocketMonitor("unix", listenerSocket, sockTimeout)
 	if err != nil {
-		log.Errorf("qmpEventHandler: Exception while getting monitor of listenerSocket: %s. %s", listenerSocket, err.Error())
+		logrus.Errorf("qmpEventHandler: Exception while getting monitor of listenerSocket: %s. %s", listenerSocket, err.Error())
 		return
 	}
 	if err := monitor.Connect(); err != nil {
-		log.Errorf("qmpEventHandler: Exception while connecting listenerSocket: %s. %s", listenerSocket, err.Error())
+		logrus.Errorf("qmpEventHandler: Exception while connecting listenerSocket: %s. %s", listenerSocket, err.Error())
 		return
 	}
 	defer monitor.Disconnect()
 
 	eventChan, err := monitor.Events()
 	if err != nil {
-		log.Errorf("qmpEventHandler: Exception while getting event channel from listenerSocket: %s. %s", listenerSocket, err.Error())
+		logrus.Errorf("qmpEventHandler: Exception while getting event channel from listenerSocket: %s. %s", listenerSocket, err.Error())
 		return
 	}
 	for {
 		if _, err := os.Stat(listenerSocket); err != nil {
-			log.Errorf("qmpEventHandler: Exception while accessing listenerSocket: %s. %s", listenerSocket, err.Error())
+			logrus.Errorf("qmpEventHandler: Exception while accessing listenerSocket: %s. %s", listenerSocket, err.Error())
 			return
 		}
 		select {
 		case event := <-eventChan:
 			switch event.Event {
 			case "SHUTDOWN":
-				log.Infof("qmpEventHandler: Received event: %s event details: %v. Calling quit on socket: %s", event.Event, event.Data, executorSocket)
+				logrus.Infof("qmpEventHandler: Received event: %s event details: %v. Calling quit on socket: %s", event.Event, event.Data, executorSocket)
 				if err := execStop(executorSocket); err != nil {
-					log.Errorf("qmpEventHandler: Exception while stopping domain with socket: %s. %s", executorSocket, err.Error())
+					logrus.Errorf("qmpEventHandler: Exception while stopping domain with socket: %s. %s", executorSocket, err.Error())
 				}
 				if err := execQuit(executorSocket); err != nil {
-					log.Errorf("qmpEventHandler: Exception while quitting domain with socket: %s. %s", executorSocket, err.Error())
+					logrus.Errorf("qmpEventHandler: Exception while quitting domain with socket: %s. %s", executorSocket, err.Error())
 				}
 			default:
 				//Not handling the following events: RESUME, NIC_RX_FILTER_CHANGED, RTC_CHANGE, POWERDOWN, STOP
-				log.Debugf("qmpEventHandler: Unhandled event: %s from listenerSocket: %s", event.Event, listenerSocket)
+				logrus.Debugf("qmpEventHandler: Unhandled event: %s from listenerSocket: %s", event.Event, listenerSocket)
 			}
 		}
 	}

--- a/pkg/pillar/types/errortime_test.go
+++ b/pkg/pillar/types/errortime_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,38 +20,38 @@ func TestIsErrorSource(t *testing.T) {
 	status := simple{}
 	errStr := "test1"
 	status.SetErrorWithSource(errStr, ContentTreeStatus{}, time.Now())
-	log.Infof("set error %s", status.Error)
+	logrus.Infof("set error %s", status.Error)
 	assert.True(t, status.HasError())
 	assert.True(t, status.IsErrorSource(ContentTreeStatus{}))
 	assert.False(t, status.IsErrorSource(VolumeStatus{}))
 	assert.Equal(t, errStr, status.Error)
 
 	status.ClearErrorWithSource()
-	log.Infof("cleared error %s", status.Error)
+	logrus.Infof("cleared error %s", status.Error)
 	assert.False(t, status.IsErrorSource(ContentTreeStatus{}))
 	assert.Equal(t, "", status.Error)
 
 	errStr = "error2"
 	status.SetError(errStr, time.Now())
 	assert.Equal(t, errStr, status.Error)
-	log.Infof("type after SetError %s %T", status.ErrorSourceType, status.ErrorSourceType)
-	log.Infof("reflect %v", reflect.TypeOf(status.ErrorSourceType))
+	logrus.Infof("type after SetError %s %T", status.ErrorSourceType, status.ErrorSourceType)
+	logrus.Infof("reflect %v", reflect.TypeOf(status.ErrorSourceType))
 
 	errStr = "error3"
 	status.SetErrorWithSource(errStr, ContentTreeStatus{}, time.Now())
-	log.Infof("type after SetErrorWithSource %s %T", status.ErrorSourceType, status.ErrorSourceType)
-	log.Infof("reflect %v", reflect.TypeOf(status.ErrorSourceType))
+	logrus.Infof("type after SetErrorWithSource %s %T", status.ErrorSourceType, status.ErrorSourceType)
+	logrus.Infof("reflect %v", reflect.TypeOf(status.ErrorSourceType))
 
 	errStr = "error4"
 	status.SetError(errStr, time.Now())
 	assert.Equal(t, errStr, status.Error)
-	log.Infof("type after SetError %s %T", status.ErrorSourceType, status.ErrorSourceType)
-	log.Infof("reflect %v", reflect.TypeOf(status.ErrorSourceType))
+	logrus.Infof("type after SetError %s %T", status.ErrorSourceType, status.ErrorSourceType)
+	logrus.Infof("reflect %v", reflect.TypeOf(status.ErrorSourceType))
 
 	errStr = "error5"
 	// XXX now fatals
 	// result := make(map[string]interface{})
 	// status.SetErrorWithSource(errStr, result, time.Now())
-	log.Infof("type after SetError %s %T", status.ErrorSourceType, status.ErrorSourceType)
-	log.Infof("reflect %v", reflect.TypeOf(status.ErrorSourceType))
+	logrus.Infof("type after SetError %s %T", status.ErrorSourceType, status.ErrorSourceType)
+	logrus.Infof("reflect %v", reflect.TypeOf(status.ErrorSourceType))
 }

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -130,7 +130,7 @@ func TestAddStringItem(t *testing.T) {
 }
 
 func TestNewConfigItemSpecMap(t *testing.T) {
-	// log.SetLevel(log.TraceLevel)
+	// logrus.SetLevel(logrus.TraceLevel)
 	specMap := NewConfigItemSpecMap()
 
 	// Verify none of the Global key have agent as prefix
@@ -256,7 +256,7 @@ func (testPtr *parseItemTestEntry) configItemValue(
 	case ConfigItemTypeTriState:
 		val.TriStateValue, _ = ParseTriState(valueStr)
 	default:
-		log.Fatalf("Invalid inteType %d in testPtr %+v",
+		logrus.Fatalf("Invalid inteType %d in testPtr %+v",
 			testPtr.itemType, *testPtr)
 	}
 	return val
@@ -282,7 +282,7 @@ func (testPtr *parseItemTestEntry) verifyEntry(t *testing.T, testname string,
 }
 
 func TestParseGlobalItem(t *testing.T) {
-	// log.SetLevel(log.TraceLevel)
+	// logrus.SetLevel(logrus.TraceLevel)
 	specMap := NewConfigItemSpecMap()
 	testMatrix := map[string]parseItemTestEntry{
 		"Global String Setting": {
@@ -372,7 +372,7 @@ func TestParseGlobalItem(t *testing.T) {
 //  Verify Unknown settings ( New and Legacy ) are rejected
 //  Verify Invalid Values for known settings are rejected and old value retained
 func TestParseAgentItem(t *testing.T) {
-	// log.SetLevel(log.TraceLevel)
+	// logrus.SetLevel(logrus.TraceLevel)
 	specMap := NewConfigItemSpecMap()
 
 	testMatrix := map[string]parseItemTestEntry{
@@ -434,7 +434,7 @@ func TestParseAgentItem(t *testing.T) {
 		if test.oldValue != "" {
 			agentName, asKey, err := parseAgentSettingKey(test.item.key)
 			if err != nil {
-				log.Fatalf("Invalid Agent Key. Key: %s, err: %s",
+				logrus.Fatalf("Invalid Agent Key. Key: %s, err: %s",
 					test.item.key, err)
 			}
 			// Set old value in globalConfig
@@ -447,7 +447,7 @@ func TestParseAgentItem(t *testing.T) {
 		}
 		agentName, asKey, err := parseAgentSettingKey(test.item.key)
 		if err != nil {
-			log.Fatalf("Unexpected Error in parsing key(%s). err: %s",
+			logrus.Fatalf("Unexpected Error in parsing key(%s). err: %s",
 				test.item.key, err)
 		}
 		newGlobalConfig := DefaultConfigItemValueMap()
@@ -459,7 +459,7 @@ func TestParseAgentItem(t *testing.T) {
 				t.Fatalf("TEST FAILED: %s - Expected Error. But did not get one",
 					testname)
 			} else {
-				log.Debugf("Test %s - received Error as expected: %s",
+				logrus.Debugf("Test %s - received Error as expected: %s",
 					testname, err)
 				if test.oldValue != "" {
 					// Value Error. Verify the Old value has been retained

--- a/pkg/pillar/types/globalconfigold.go
+++ b/pkg/pillar/types/globalconfigold.go
@@ -8,7 +8,7 @@
 package types
 
 import (
-	log "github.com/sirupsen/logrus" // OK in this old code
+	"github.com/sirupsen/logrus"
 )
 
 // OldGlobalConfig - Legacy version of global config. Kept for upgradeconverter
@@ -234,42 +234,42 @@ var GlobalConfigMinimums = OldGlobalConfig{
 func EnforceGlobalConfigMinimums(newgc OldGlobalConfig) OldGlobalConfig {
 
 	if newgc.ConfigInterval < GlobalConfigMinimums.ConfigInterval {
-		log.Warnf("Enforce minimum ConfigInterval received %d; using %d",
+		logrus.Warnf("Enforce minimum ConfigInterval received %d; using %d",
 			newgc.ConfigInterval, GlobalConfigMinimums.ConfigInterval)
 		newgc.ConfigInterval = GlobalConfigMinimums.ConfigInterval
 	}
 	if newgc.MetricInterval < GlobalConfigMinimums.MetricInterval {
-		log.Warnf("Enforce minimum MetricInterval received %d; using %d",
+		logrus.Warnf("Enforce minimum MetricInterval received %d; using %d",
 			newgc.MetricInterval, GlobalConfigMinimums.MetricInterval)
 		newgc.MetricInterval = GlobalConfigMinimums.MetricInterval
 	}
 	if newgc.ResetIfCloudGoneTime < GlobalConfigMinimums.ResetIfCloudGoneTime {
-		log.Warnf("Enforce minimum XXX received %d; using %d",
+		logrus.Warnf("Enforce minimum XXX received %d; using %d",
 			newgc.ResetIfCloudGoneTime, GlobalConfigMinimums.ResetIfCloudGoneTime)
 		newgc.ResetIfCloudGoneTime = GlobalConfigMinimums.ResetIfCloudGoneTime
 	}
 	if newgc.FallbackIfCloudGoneTime < GlobalConfigMinimums.FallbackIfCloudGoneTime {
-		log.Warnf("Enforce minimum FallbackIfCloudGoneTime received %d; using %d",
+		logrus.Warnf("Enforce minimum FallbackIfCloudGoneTime received %d; using %d",
 			newgc.FallbackIfCloudGoneTime, GlobalConfigMinimums.FallbackIfCloudGoneTime)
 		newgc.FallbackIfCloudGoneTime = GlobalConfigMinimums.FallbackIfCloudGoneTime
 	}
 	if newgc.MintimeUpdateSuccess < GlobalConfigMinimums.MintimeUpdateSuccess {
-		log.Warnf("Enforce minimum MintimeUpdateSuccess received %d; using %d",
+		logrus.Warnf("Enforce minimum MintimeUpdateSuccess received %d; using %d",
 			newgc.MintimeUpdateSuccess, GlobalConfigMinimums.MintimeUpdateSuccess)
 		newgc.MintimeUpdateSuccess = GlobalConfigMinimums.MintimeUpdateSuccess
 	}
 	if newgc.NetworkGeoRedoTime < GlobalConfigMinimums.NetworkGeoRedoTime {
-		log.Warnf("Enforce minimum NetworkGeoRedoTime received %d; using %d",
+		logrus.Warnf("Enforce minimum NetworkGeoRedoTime received %d; using %d",
 			newgc.NetworkGeoRedoTime, GlobalConfigMinimums.NetworkGeoRedoTime)
 		newgc.NetworkGeoRedoTime = GlobalConfigMinimums.NetworkGeoRedoTime
 	}
 	if newgc.NetworkGeoRetryTime < GlobalConfigMinimums.NetworkGeoRetryTime {
-		log.Warnf("Enforce minimum NetworkGeoRetryTime received %d; using %d",
+		logrus.Warnf("Enforce minimum NetworkGeoRetryTime received %d; using %d",
 			newgc.NetworkGeoRetryTime, GlobalConfigMinimums.NetworkGeoRetryTime)
 		newgc.NetworkGeoRetryTime = GlobalConfigMinimums.NetworkGeoRetryTime
 	}
 	if newgc.NetworkTestDuration < GlobalConfigMinimums.NetworkTestDuration {
-		log.Warnf("Enforce minimum NetworkTestDuration received %d; using %d",
+		logrus.Warnf("Enforce minimum NetworkTestDuration received %d; using %d",
 			newgc.NetworkTestDuration, GlobalConfigMinimums.NetworkTestDuration)
 		newgc.NetworkTestDuration = GlobalConfigMinimums.NetworkTestDuration
 	}
@@ -277,38 +277,38 @@ func EnforceGlobalConfigMinimums(newgc OldGlobalConfig) OldGlobalConfig {
 		newgc.NetworkTestInterval = GlobalConfigMinimums.NetworkTestInterval
 	}
 	if newgc.NetworkTestBetterInterval < GlobalConfigMinimums.NetworkTestBetterInterval {
-		log.Warnf("Enforce minimum NetworkTestInterval received %d; using %d",
+		logrus.Warnf("Enforce minimum NetworkTestInterval received %d; using %d",
 			newgc.NetworkTestBetterInterval, GlobalConfigMinimums.NetworkTestBetterInterval)
 		newgc.NetworkTestBetterInterval = GlobalConfigMinimums.NetworkTestBetterInterval
 	}
 
 	if newgc.StaleConfigTime < GlobalConfigMinimums.StaleConfigTime {
-		log.Warnf("Enforce minimum StaleConfigTime received %d; using %d",
+		logrus.Warnf("Enforce minimum StaleConfigTime received %d; using %d",
 			newgc.StaleConfigTime, GlobalConfigMinimums.StaleConfigTime)
 		newgc.StaleConfigTime = GlobalConfigMinimums.StaleConfigTime
 	}
 	if newgc.DownloadGCTime < GlobalConfigMinimums.DownloadGCTime {
-		log.Warnf("Enforce minimum DownloadGCTime received %d; using %d",
+		logrus.Warnf("Enforce minimum DownloadGCTime received %d; using %d",
 			newgc.DownloadGCTime, GlobalConfigMinimums.DownloadGCTime)
 		newgc.DownloadGCTime = GlobalConfigMinimums.DownloadGCTime
 	}
 	if newgc.VdiskGCTime < GlobalConfigMinimums.VdiskGCTime {
-		log.Warnf("Enforce minimum VdiskGCTime received %d; using %d",
+		logrus.Warnf("Enforce minimum VdiskGCTime received %d; using %d",
 			newgc.VdiskGCTime, GlobalConfigMinimums.VdiskGCTime)
 		newgc.VdiskGCTime = GlobalConfigMinimums.VdiskGCTime
 	}
 	if newgc.DownloadRetryTime < GlobalConfigMinimums.DownloadRetryTime {
-		log.Warnf("Enforce minimum DownloadRetryTime received %d; using %d",
+		logrus.Warnf("Enforce minimum DownloadRetryTime received %d; using %d",
 			newgc.DownloadRetryTime, GlobalConfigMinimums.DownloadRetryTime)
 		newgc.DownloadRetryTime = GlobalConfigMinimums.DownloadRetryTime
 	}
 	if newgc.DomainBootRetryTime < GlobalConfigMinimums.DomainBootRetryTime {
-		log.Warnf("Enforce minimum DomainBootRetryTime received %d; using %d",
+		logrus.Warnf("Enforce minimum DomainBootRetryTime received %d; using %d",
 			newgc.DomainBootRetryTime, GlobalConfigMinimums.DomainBootRetryTime)
 		newgc.DomainBootRetryTime = GlobalConfigMinimums.DomainBootRetryTime
 	}
 	if newgc.Dom0MinDiskUsagePercent < GlobalConfigMinimums.Dom0MinDiskUsagePercent {
-		log.Warnf("Enforce minimum Dom0MinDiskUsagePercent received %d; using %d",
+		logrus.Warnf("Enforce minimum Dom0MinDiskUsagePercent received %d; using %d",
 			newgc.Dom0MinDiskUsagePercent, GlobalConfigMinimums.Dom0MinDiskUsagePercent)
 		newgc.Dom0MinDiskUsagePercent = GlobalConfigMinimums.Dom0MinDiskUsagePercent
 	}

--- a/pkg/pillar/utils/pubsub.go
+++ b/pkg/pillar/utils/pubsub.go
@@ -7,7 +7,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	uuid "github.com/satori/go.uuid"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // LookupDatastoreConfig get a datastore config based on uuid
@@ -15,14 +15,14 @@ func LookupDatastoreConfig(sub pubsub.Subscription, dsID uuid.UUID) (*types.Data
 
 	if dsID == nilUUID {
 		err := fmt.Errorf("lookupDatastoreConfig(%s): No datastore ID", dsID.String())
-		log.Errorln(err)
+		logrus.Errorln(err)
 		return nil, err
 	}
 	cfg, err := sub.Get(dsID.String())
 	if err != nil {
 		err2 := fmt.Errorf("lookupDatastoreConfig(%s) error: %v",
 			dsID.String(), err)
-		log.Errorln(err2)
+		logrus.Errorln(err2)
 		return nil, err2
 	}
 	dst := cfg.(types.DatastoreConfig)

--- a/pkg/pillar/worker/example_test.go
+++ b/pkg/pillar/worker/example_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	"github.com/lf-edge/eve/pkg/pillar/worker"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 func Example_workerprocess() {
@@ -35,7 +35,7 @@ func Example_workerprocess() {
 	}
 
 	// create a new worker that can handle jobs of Kind "install"
-	work := worker.NewWorker(log.New(), ctx, 5, map[string]worker.Handler{
+	work := worker.NewWorker(logrus.New(), ctx, 5, map[string]worker.Handler{
 		kind: {Request: installWorker, Response: processInstallWorkResult},
 	})
 
@@ -43,11 +43,11 @@ func Example_workerprocess() {
 	// what happened when we submitted?
 	if err != nil {
 		if _, ok := err.(*worker.JobInProgressError); ok {
-			log.Fatal("job already in progress")
+			logrus.Fatal("job already in progress")
 		}
-		log.Fatalf("unknown error: %v\n", err)
+		logrus.Fatalf("unknown error: %v\n", err)
 	}
-	log.Info("job submitted")
+	logrus.Info("job submitted")
 	// nothing to do now, wait for the result
 forloop:
 	for {

--- a/pkg/pillar/zedUpload/ociutil/common.go
+++ b/pkg/pillar/zedUpload/ociutil/common.go
@@ -9,7 +9,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	v1tarball "github.com/google/go-containerregistry/pkg/v1/tarball"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 func manifestsDescImg(image string, options []remote.Option) (name.Reference, *remote.Descriptor, v1.Image, []byte, []byte, int64, error) {
@@ -21,7 +21,7 @@ func manifestsDescImg(image string, options []remote.Option) (name.Reference, *r
 		err                              error
 		ref                              name.Reference
 	)
-	log.Infof("manifestsDescImg(%s)", image)
+	logrus.Infof("manifestsDescImg(%s)", image)
 
 	// FIXME tar archive size is 1024 bytes greater than the sizes of
 	// the underlying file. Currently, it has been added purely on the
@@ -31,16 +31,16 @@ func manifestsDescImg(image string, options []remote.Option) (name.Reference, *r
 
 	ref, err = name.ParseReference(image)
 	if err != nil {
-		log.Errorf("error parsing image (%s): %v", image, err)
+		logrus.Errorf("error parsing image (%s): %v", image, err)
 		return ref, desc, img, manifestDirect, manifestResolved, size, fmt.Errorf("parsing reference %q: %v", image, err)
 	}
 
 	// resolve our platform
 	options = append(options, remote.WithPlatform(v1.Platform{Architecture: runtime.GOARCH, OS: runtime.GOOS}))
-	log.Debugf("options %#v", options)
+	logrus.Debugf("options %#v", options)
 
 	// first get the root manifest. This might be an index or a manifest
-	log.Infof("manifestsDescImg(%s) getting image ref %#v", image, ref)
+	logrus.Infof("manifestsDescImg(%s) getting image ref %#v", image, ref)
 	desc, err = remote.Get(ref, options...)
 	if err != nil {
 		return ref, desc, img, manifestDirect, manifestResolved, size, fmt.Errorf("error getting manifest: %v", err)

--- a/pkg/pillar/zedUpload/ociutil/oci.go
+++ b/pkg/pillar/zedUpload/ociutil/oci.go
@@ -17,7 +17,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -82,7 +82,7 @@ func Manifest(registry, repo, username, apiKey string, client *http.Client, prgc
 
 // PullBlob downloads a blob from a registry and save it as a file as-is.
 func PullBlob(registry, repo, hash, localFile, username, apiKey string, maxsize int64, client *http.Client, prgchan NotifChan) (int64, string, error) {
-	log.Infof("PullBlob(%s, %s, %s) to %s", registry, repo, hash, localFile)
+	logrus.Infof("PullBlob(%s, %s, %s) to %s", registry, repo, hash, localFile)
 
 	var (
 		w           io.Writer
@@ -113,7 +113,7 @@ func PullBlob(registry, repo, hash, localFile, username, apiKey string, maxsize 
 	if hash != "" {
 		hash = checkAndCorrectHash(hash)
 		if _, ok := ref.(name.Tag); ok {
-			log.Infof("PullBlob: Adding hash %s to image %s", hash, image)
+			logrus.Infof("PullBlob: Adding hash %s to image %s", hash, image)
 			image = fmt.Sprintf("%s@%s", image, hash)
 			ref, err = name.ParseReference(image)
 			if err != nil {
@@ -133,7 +133,7 @@ func PullBlob(registry, repo, hash, localFile, username, apiKey string, maxsize 
 
 	// if we have only a tag, we know it is a manifest
 	if _, ok := ref.(name.Tag); ok {
-		log.Infof("PullBlob: requested manifest or had tag without hash, so just pulling root for %s", image)
+		logrus.Infof("PullBlob: requested manifest or had tag without hash, so just pulling root for %s", image)
 		r, contentType, err = ociGetManifest(ref, opts)
 		if err != nil {
 			return 0, "", err
@@ -144,7 +144,7 @@ func PullBlob(registry, repo, hash, localFile, username, apiKey string, maxsize 
 		if !ok {
 			return 0, "", fmt.Errorf("ref %s wasn't a tag or digest", image)
 		}
-		log.Infof("PullBlob: had hash, so pulling blob for %s", image)
+		logrus.Infof("PullBlob: had hash, so pulling blob for %s", image)
 		layer, err := remote.Layer(d, opts...)
 		if err != nil {
 			return 0, "", fmt.Errorf("could not pull layer %s: %v", ref.String(), err)
@@ -195,7 +195,7 @@ func PullBlob(registry, repo, hash, localFile, username, apiKey string, maxsize 
 		// copy all of the data
 		size, err := io.Copy(pw, r)
 		if err != nil && err != io.EOF {
-			log.Errorf("could not write to local file %s from %s: %v", localFile, ref.String(), err)
+			logrus.Errorf("could not write to local file %s from %s: %v", localFile, ref.String(), err)
 		}
 		if err == nil {
 			err = io.EOF
@@ -216,10 +216,10 @@ func PullBlob(registry, repo, hash, localFile, username, apiKey string, maxsize 
 		if update.Error != nil {
 			// EOF means we are at the end cleanly
 			if update.Error == io.EOF {
-				log.Infof("PullBlob(%s): download complete to %s size %d", image, localFile, size)
+				logrus.Infof("PullBlob(%s): download complete to %s size %d", image, localFile, size)
 				finalErr = nil
 			} else {
-				log.Errorf("PullBlob(%s): error saving to %s: %v", image, localFile, update.Error)
+				logrus.Errorf("PullBlob(%s): error saving to %s: %v", image, localFile, update.Error)
 				finalErr = update.Error
 			}
 			break
@@ -256,7 +256,7 @@ func Pull(registry, repo, localFile, username, apiKey string, client *http.Clien
 		image                            = fmt.Sprintf("%s/%s", registry, repo)
 	)
 
-	log.Infof("Pull(%s, %s) to %s", registry, repo, localFile)
+	logrus.Infof("Pull(%s, %s) to %s", registry, repo, localFile)
 
 	opts := options(username, apiKey, client)
 


### PR DESCRIPTION
In some pillar code log.Infof means to log at the logrus.InfoLevel when log is the logrus package, while in other pillar code log is a base.LogObject hence log.Infof is mapped to logrus.Debuglevel (using the code in pkg/pillar/base/log.go)

As a first step to reduce the confusion this PR changes all of the imports of the form
import log "github.com/sirupsen/logrus"
to be 
import "github.com/sirupsen/logrus"

With that change the first form of calls will now be logrus.Infof hence easier to tell apart.

Note that the diffs themselves are not very interesting; just that form of rename.
