### PR TITLE
Fix loglevel confusion

### DIFF
--- a/docs/LOG-LEVELS.md
+++ b/docs/LOG-LEVELS.md
@@ -4,28 +4,28 @@ The various services in EVE use logging with levels and a specified source which
 
 There are settings specified in [config properties](./CONFIG-PROPERTIES.md) to set the minimum log level which is reported over the API. This currently defaults to the info level.
 
-In addition, much of the code in pkg/pillar directories use additional internal "levels" with associated functions such as Notice and Metric plus a mapping from Notice, Metric, Info, and Debug.
+In addition, much of the code in pkg/pillar directories use additional internal "levels" with associated functions such as Notice, Metric, and Function with a mapping from those to the logrus levels.
 The reason for the additional levels is to:
 
-- distinguish between different forms logs e.g., separate functions to log changes to periodically reported metrics
-- handle the fact that there is no Notice level in the log packages
-
-The current mapping is confusing since the log.Info set of functions are mapped to logrus.DebugLevel and the log.Debug functions are mapped to logrus.TraceLevel. This will be rectified soon.
+- Distinguish between different forms logs e.g., use separate calls to log changes to periodically reported metrics, since those are quite voluminous.
+- Handle the fact that there is no Notice level in the log packages.
 
 The mapping is compiled into the code - see [base/log.go](../pkg/pillar/base/log.go).
 
 ## Log level conventions
 
-The conventions in pkg/pillar code for log levels is as follows:
+The current conventions in pkg/pillar code for log levels is as follows:
 
-- Fatal - cases where we really need to restart the agent
-- Error - some cases of errors with the objects to be deployed but also internal errors which are not reported using the API
-- Warning - could be resource-related issues
-- Notice - all of the pubsub object type logging except for periodic metrics plus additional noticable events. Mapped to logrus.InfoLevel
-- Metric - the pubsub object type logs for periodic metric changes. Mapped to logrus.DebugLevel
-- Info (currently mapped to logrus.DebugLevel) for internal function-level logs.
-- Debug (currently mapped to logrus.TraceLevel) for more voluminous function-level logs.
+- Fatal - cases where we really need to restart the agent.
+- Error - some cases of errors with the objects to be deployed but also internal errors which are not reported using the API.
+- Warning - could be resource-related issues.
+- Notice - all of the pubsub object type logging except for periodic metrics plus additional noticable events. Mapped to logrus.InfoLevel.
+- Metric - the pubsub object type logs for periodic metric changes. Mapped to logrus.DebugLevel.
+- Function for internal function-level logs. Mapped to logrus.DebugLevel.
+- Trace for more voluminous function-level logs.
 
 ## Future cleanup
 
-The plan is to reduce the confusion by introducing a new Function pseudo-level and then replace the use of log.Info with log.Function and also replace the log.Debug with log.Trace.
+Once we do not have any pending PRs it makes sense to rename the odd "Function" functions to "Debug" and remove that mapping. However, we'd still have the pseudo-levels "Notice" and "Metric".
+
+In some case one might desire the Debug and even Trace entries without the voluminous and periodic Metric ones. TBD whether we need to be able to control that using an API.

--- a/pkg/pillar/agentbase/agent.go
+++ b/pkg/pillar/agentbase/agent.go
@@ -61,7 +61,7 @@ func Run(agentSpecificContext AgentBase) {
 	if err := pidfile.CheckAndCreatePidfile(log, ctx.AgentName); err != nil {
 		log.Fatal(err)
 	}
-	log.Infof("Starting %s\n", ctx.AgentName)
+	log.Functionf("Starting %s\n", ctx.AgentName)
 	if ctx.NeedWatchdog {
 		ctx.PubSub.StillRunning(ctx.AgentName, ctx.WarningTime, ctx.ErrorTime)
 	}

--- a/pkg/pillar/agentlog/agentlog.go
+++ b/pkg/pillar/agentlog/agentlog.go
@@ -153,7 +153,7 @@ func handleSignals(log *base.LogObject, agentName string, agentPid int, sigs cha
 	for {
 		select {
 		case sig := <-sigs:
-			log.Infof("handleSignals: received %v\n", sig)
+			log.Functionf("handleSignals: received %v\n", sig)
 			switch sig {
 			case syscall.SIGUSR1:
 				stacks := getStacks(true)
@@ -477,7 +477,7 @@ func logGCStats(log *base.LogObject) {
 	var m dbg.GCStats
 
 	dbg.ReadGCStats(&m)
-	log.Infof("GCStats %+v\n", m)
+	log.Functionf("GCStats %+v\n", m)
 }
 
 // Print in sorted order based on top bytes
@@ -511,7 +511,7 @@ func logMemUsage(log *base.LogObject, file *os.File) {
 	var m runtime.MemStats
 
 	runtime.ReadMemStats(&m)
-	log.Infof("Alloc %d Mb, TotalAlloc %d Mb, Sys %d Mb, NumGC %d",
+	log.Functionf("Alloc %d Mb, TotalAlloc %d Mb, Sys %d Mb, NumGC %d",
 		roundToMb(m.Alloc), roundToMb(m.TotalAlloc), roundToMb(m.Sys), m.NumGC)
 
 	if file != nil {
@@ -621,7 +621,7 @@ func initImpl(agentName string, redirect bool) (*logrus.Logger, *base.LogObject)
 		sigs := make(chan os.Signal, 1)
 		signal.Notify(sigs, syscall.SIGUSR1)
 		signal.Notify(sigs, syscall.SIGUSR2)
-		log.Infof("Creating %s at %s", "handleSignals", GetMyStack())
+		log.Functionf("Creating %s at %s", "handleSignals", GetMyStack())
 		go handleSignals(log, agentName, agentPid, sigs)
 		eh := func() { printStack(log, agentName, agentPid) }
 		logrus.RegisterExitHandler(eh)

--- a/pkg/pillar/agentlog/loglevel.go
+++ b/pkg/pillar/agentlog/loglevel.go
@@ -46,17 +46,17 @@ func getLogLevelImpl(log *base.LogObject, sub pubsub.Subscription, agentName str
 	// Do we have an entry for this agent?
 	loglevel := gc.AgentSettingStringValue(agentName, types.LogLevel)
 	if loglevel != "" {
-		log.Debugf("getLogLevelImpl: loglevel=%s", loglevel)
+		log.Tracef("getLogLevelImpl: loglevel=%s", loglevel)
 		return loglevel, true, false
 	}
 	if !allowDefault {
-		log.Debugf("getLogLevelImpl: loglevel not found. allowDefault False")
+		log.Tracef("getLogLevelImpl: loglevel not found. allowDefault False")
 		return "", false, false
 	}
 	// Agent specific setting  not available. Get it from Global Setting
 	loglevel = gc.GlobalValueString(types.DefaultLogLevel)
 	if loglevel != "" {
-		log.Debugf("getLogLevelImpl: returning DefaultLogLevel (%s)", loglevel)
+		log.Tracef("getLogLevelImpl: returning DefaultLogLevel (%s)", loglevel)
 		return loglevel, true, true
 	}
 	log.Errorf("***getLogLevelImpl: DefaultLogLevel not found. returning info")
@@ -84,17 +84,17 @@ func getRemoteLogLevelImpl(log *base.LogObject, sub pubsub.Subscription, agentNa
 	// Do we have an entry for this agent?
 	loglevel := gc.AgentSettingStringValue(agentName, types.RemoteLogLevel)
 	if loglevel != "" {
-		log.Debugf("getRemoteLogLevelImpl: loglevel=%s", loglevel)
+		log.Tracef("getRemoteLogLevelImpl: loglevel=%s", loglevel)
 		return loglevel, true
 	}
 	if !allowDefault {
-		log.Debugf("getRemoteLogLevelImpl: loglevel not found. allowDefault False")
+		log.Tracef("getRemoteLogLevelImpl: loglevel not found. allowDefault False")
 		return "", false
 	}
 	// Agent specific setting  not available. Get it from Global Setting
 	loglevel = gc.GlobalValueString(types.DefaultRemoteLogLevel)
 	if loglevel != "" {
-		log.Debugf("getRemoteLogLevelImpl: returning DefaultRemoteLogLevel (%s)",
+		log.Tracef("getRemoteLogLevelImpl: returning DefaultRemoteLogLevel (%s)",
 			loglevel)
 		return loglevel, true
 	}
@@ -118,7 +118,7 @@ func LogLevel(gc *types.ConfigItemValueMap, agentName string) string {
 func HandleGlobalConfig(log *base.LogObject, sub pubsub.Subscription, agentName string,
 	debugOverride bool, logger *logrus.Logger) (bool, *types.ConfigItemValueMap) {
 
-	log.Infof("HandleGlobalConfig(%s, %v)\n", agentName, debugOverride)
+	log.Functionf("HandleGlobalConfig(%s, %v)\n", agentName, debugOverride)
 	return handleGlobalConfigImpl(log, sub, agentName, debugOverride, true,
 		logger)
 }
@@ -131,7 +131,7 @@ func HandleGlobalConfig(log *base.LogObject, sub pubsub.Subscription, agentName 
 func HandleGlobalConfigNoDefault(log *base.LogObject, sub pubsub.Subscription, agentName string,
 	debugOverride bool, logger *logrus.Logger) (bool, *types.ConfigItemValueMap) {
 
-	log.Infof("HandleGlobalConfig(%s, %v)\n", agentName, debugOverride)
+	log.Functionf("HandleGlobalConfig(%s, %v)\n", agentName, debugOverride)
 	return handleGlobalConfigImpl(log, sub, agentName, debugOverride, false,
 		logger)
 }
@@ -141,18 +141,18 @@ func handleGlobalConfigImpl(log *base.LogObject, sub pubsub.Subscription, agentN
 	level := logrus.InfoLevel
 	debug := false
 	gcp := GetGlobalConfig(log, sub)
-	log.Infof("handleGlobalConfigImpl: gcp %+v\n", gcp)
+	log.Functionf("handleGlobalConfigImpl: gcp %+v\n", gcp)
 	if debugOverride {
 		debug = true
 		level = logrus.TraceLevel
-		log.Infof("handleGlobalConfigImpl: debugOverride set. set loglevel to debug")
+		log.Functionf("handleGlobalConfigImpl: debugOverride set. set loglevel to debug")
 	} else if loglevel, ok, def := getLogLevelImpl(log, sub, agentName, allowDefault); ok {
 		l, err := logrus.ParseLevel(loglevel)
 		if err != nil {
 			log.Errorf("***ParseLevel %s failed: %s\n", loglevel, err)
 		} else {
 			level = l
-			log.Infof("HandleGlobalConfigImpl: level %v\n",
+			log.Functionf("HandleGlobalConfigImpl: level %v\n",
 				level)
 		}
 		if level == logrus.TraceLevel {
@@ -165,7 +165,7 @@ func handleGlobalConfigImpl(log *base.LogObject, sub pubsub.Subscription, agentN
 	} else {
 		log.Errorf("***handleGlobalConfigImpl: Failed to get loglevel")
 	}
-	log.Infof("handleGlobalConfigImpl: Setting loglevel to %s", level)
+	log.Functionf("handleGlobalConfigImpl: Setting loglevel to %s", level)
 	logger.SetLevel(level)
 	return debug, gcp
 }

--- a/pkg/pillar/attest/attest.go
+++ b/pkg/pillar/attest/attest.go
@@ -260,7 +260,7 @@ func startNewRetryTimer(ctx *Context) error {
 	if ctx.restartTimer != nil {
 		ctx.restartTimer.Stop()
 	}
-	ctx.log.Debugf("Starting retry timer at %v\n", time.Now())
+	ctx.log.Tracef("Starting retry timer at %v\n", time.Now())
 	if ctx.retryTime == 0 {
 		return fmt.Errorf("retryTime not initialized")
 	}
@@ -270,7 +270,7 @@ func startNewRetryTimer(ctx *Context) error {
 
 //The event handlers
 func handleInitializeAtNone(ctx *Context) error {
-	ctx.log.Debug("handleInitializeAtNone")
+	ctx.log.Trace("handleInitializeAtNone")
 	ctx.state = StateNonceWait
 	err := verifier.SendNonceRequest(ctx)
 	if err == nil {
@@ -292,14 +292,14 @@ func handleInitializeAtNone(ctx *Context) error {
 }
 
 func handleRestartAtNone(ctx *Context) error {
-	ctx.log.Debug("handleRestartAtNone")
+	ctx.log.Trace("handleRestartAtNone")
 
 	//same handling as EventRestart
 	return handleInitializeAtNone(ctx)
 }
 
 func handleNonceRecvdAtNonceWait(ctx *Context) error {
-	ctx.log.Debug("handleNonceRecvdAtNonceWait")
+	ctx.log.Trace("handleNonceRecvdAtNonceWait")
 	ctx.state = StateInternalQuoteWait
 	err := tpmAgent.SendInternalQuoteRequest(ctx)
 	if err == nil {
@@ -315,7 +315,7 @@ func handleNonceRecvdAtNonceWait(ctx *Context) error {
 }
 
 func handleInternalQuoteRecvdAtInternalQuoteWait(ctx *Context) error {
-	ctx.log.Debug("handleInternalQuoteRecvdAtInternalQuoteWait")
+	ctx.log.Trace("handleInternalQuoteRecvdAtInternalQuoteWait")
 	ctx.state = StateAttestWait
 	err := verifier.SendAttestQuote(ctx)
 	if err == nil {
@@ -345,7 +345,7 @@ func handleInternalQuoteRecvdAtInternalQuoteWait(ctx *Context) error {
 }
 
 func handleAttestSuccessfulAtAttestWait(ctx *Context) error {
-	ctx.log.Debug("handleAttestSuccessfulAtAttestWait")
+	ctx.log.Trace("handleAttestSuccessfulAtAttestWait")
 	ctx.state = StateAttestEscrowWait
 	err := verifier.SendAttestEscrow(ctx)
 	if err == nil {
@@ -373,7 +373,7 @@ func handleAttestSuccessfulAtAttestWait(ctx *Context) error {
 }
 
 func handleAttestEscrowRecordedAtAttestEscrowWait(ctx *Context) error {
-	ctx.log.Debug("handleAttestEscrowRecordedAtAttestEscrowWait")
+	ctx.log.Trace("handleAttestEscrowRecordedAtAttestEscrowWait")
 	ctx.state = StateComplete
 	if ctx.restartRequestPending {
 		ctx.state = StateRestartWait
@@ -383,41 +383,41 @@ func handleAttestEscrowRecordedAtAttestEscrowWait(ctx *Context) error {
 }
 
 func handleRestartAtStateComplete(ctx *Context) error {
-	ctx.log.Debug("handleRestartAtStateComplete")
+	ctx.log.Trace("handleRestartAtStateComplete")
 	ctx.state = StateRestartWait
 	return startNewRetryTimer(ctx)
 }
 
 func handleRestart(ctx *Context) error {
-	ctx.log.Debug("handleRestart")
+	ctx.log.Trace("handleRestart")
 	ctx.restartRequestPending = true
 	return nil
 }
 
 func handleNonceMismatchAtAttestWait(ctx *Context) error {
-	ctx.log.Debug("handleNonceMismatchAtAttestWait")
+	ctx.log.Trace("handleNonceMismatchAtAttestWait")
 	ctx.state = StateRestartWait
 	return startNewRetryTimer(ctx)
 }
 
 func handleQuoteMismatchAtAttestWait(ctx *Context) error {
-	ctx.log.Debug("handleQuoteMismatchAtAttestWait")
+	ctx.log.Trace("handleQuoteMismatchAtAttestWait")
 	return handleNonceMismatchAtAttestWait(ctx)
 }
 
 func handleNoQuoteCertRcvdAtAttestWait(ctx *Context) error {
-	ctx.log.Debug("handleNoQuoteCertRcvdAtAttestWait")
+	ctx.log.Trace("handleNoQuoteCertRcvdAtAttestWait")
 	return handleNonceMismatchAtAttestWait(ctx)
 }
 
 func handleAttestEscrowFailedAtAttestEscrowWait(ctx *Context) error {
-	ctx.log.Debug("handleAttestEscrowFailedAtAttestEscrowWait")
+	ctx.log.Trace("handleAttestEscrowFailedAtAttestEscrowWait")
 	ctx.state = StateRestartWait
 	return startNewRetryTimer(ctx)
 }
 
 func handleInternalEscrowRecvdAtInternalEscrowWait(ctx *Context) error {
-	ctx.log.Debug("handleInternalEscrowRecvdAtInternalEscrowWait")
+	ctx.log.Trace("handleInternalEscrowRecvdAtInternalEscrowWait")
 	//try sending escrow data now
 	return handleAttestSuccessfulAtAttestWait(ctx)
 }
@@ -426,7 +426,7 @@ func handleInternalEscrowRecvdAtInternalEscrowWait(ctx *Context) error {
 //at any other state, other than StateInternalQuoteWait.
 //for StateInternalQuoteWait, we have handleInternalEscrowRecvdAtInternalEscrowWait
 func handleInternalEscrowRecvdAtAnyOther(ctx *Context) error {
-	ctx.log.Debug("handleInternalEscrowRecvdAtAnyOther")
+	ctx.log.Trace("handleInternalEscrowRecvdAtAnyOther")
 	switch ctx.state {
 	case StateInternalEscrowWait:
 		//We should not have reached here since there is an explicit
@@ -443,39 +443,39 @@ func handleInternalEscrowRecvdAtAnyOther(ctx *Context) error {
 }
 
 func handleNoEscrowAtAttestEscrowWait(ctx *Context) error {
-	ctx.log.Debug("handleNoEscrowAtAttestEscrowWait")
+	ctx.log.Trace("handleNoEscrowAtAttestEscrowWait")
 	//Wait till we get escrow data published
 	ctx.state = StateInternalEscrowWait
 	return nil
 }
 
 func handleRetryTimerExpiryAtRestartWait(ctx *Context) error {
-	ctx.log.Debug("handleRetryTimerExpiryAtRestartWait")
+	ctx.log.Trace("handleRetryTimerExpiryAtRestartWait")
 	ctx.state = StateNone
 	ctx.restartRequestPending = false
 	return triggerSelfEvent(ctx, EventInitialize)
 }
 
 func handleRetryTimerExpiryAtNonceWait(ctx *Context) error {
-	ctx.log.Debug("handleRetryTimerExpiryAtNonceWait")
+	ctx.log.Trace("handleRetryTimerExpiryAtNonceWait")
 	ctx.state = StateNone
 	return triggerSelfEvent(ctx, EventInitialize)
 }
 
 func handleRetryTimerExpiryAtAttestWait(ctx *Context) error {
 	//try re-sending quote
-	ctx.log.Debug("handleRetryTimerExpiryAtAttestWait")
+	ctx.log.Trace("handleRetryTimerExpiryAtAttestWait")
 	return handleInternalQuoteRecvdAtInternalQuoteWait(ctx)
 }
 
 func handleRetryTimerExpiryWhileAttestEscrowWait(ctx *Context) error {
 	//try re-sending escrow info
-	ctx.log.Debug("handleRetryTimerExpiryWhileAttestEscrowWait")
+	ctx.log.Trace("handleRetryTimerExpiryWhileAttestEscrowWait")
 	return handleAttestSuccessfulAtAttestWait(ctx)
 }
 
 func handleRetryTimerExpiryAtInternalQuoteWait(ctx *Context) error {
-	ctx.log.Debug("handleRetryTimerExpiryAtInternalQuoteWait")
+	ctx.log.Trace("handleRetryTimerExpiryAtInternalQuoteWait")
 	return handleNonceRecvdAtNonceWait(ctx)
 }
 
@@ -518,15 +518,15 @@ func (ctx *Context) EnterEventLoop() {
 	for {
 		select {
 		case ctx.event = <-ctx.eventTrigger:
-			ctx.log.Debug("[ATTEST] despatching event")
+			ctx.log.Trace("[ATTEST] despatching event")
 			if err := despatchEvent(ctx.event, ctx.state, ctx); err != nil {
 				ctx.log.Errorf("%v", err)
 			}
 		case <-ctx.restartTimer.C:
-			ctx.log.Debug("[ATTEST] EventRetryTimerExpiry event")
+			ctx.log.Trace("[ATTEST] EventRetryTimerExpiry event")
 			triggerSelfEvent(ctx, EventRetryTimerExpiry)
 		case <-stillRunning.C:
-			ctx.log.Debug("[ATTEST] stillRunning event")
+			ctx.log.Trace("[ATTEST] stillRunning event")
 			punchWatchdog(ctx)
 		}
 	}

--- a/pkg/pillar/base/execwrapper.go
+++ b/pkg/pillar/base/execwrapper.go
@@ -94,7 +94,7 @@ func (c *Command) CombinedOutputWithCustomTimeout(timeout uint) ([]byte, error) 
 
 func (c *Command) execCommand() ([]byte, error) {
 	if c.log != nil {
-		c.log.Debugf("execCommand(%v)", c.command.Args)
+		c.log.Tracef("execCommand(%v)", c.command.Args)
 	}
 	if err := c.command.Start(); err != nil {
 		return nil, fmt.Errorf("execCommand(%v): error while starting command: %s", c.command.Args, err.Error())
@@ -145,7 +145,7 @@ func updateAgentTouchFile(log *LogObject, agentName string) {
 		file, err := os.Create(filename)
 		if err != nil {
 			if log != nil {
-				log.Infof("updateAgentTouchFile: %s\n", err)
+				log.Functionf("updateAgentTouchFile: %s\n", err)
 			}
 			return
 		}

--- a/pkg/pillar/base/log.go
+++ b/pkg/pillar/base/log.go
@@ -8,33 +8,21 @@ import (
 )
 
 // We map our notions of levels to the logrus levels
-// XXX should we make this mapping configurable?
-// The Notice and Metric functions/levels are unique
-// XXX should we rename the callers of Info* and Debug* to Debug* and Trace*, respectively
+// The Notice, Metric, and Function functions/levels are unique to enable
+// more flexibility during EVE development.
 var (
-	myNoticeLevel = logrus.InfoLevel
-	myMetricLevel = logrus.DebugLevel
-	myInfoLevel   = logrus.DebugLevel
-	myDebugLevel  = logrus.TraceLevel
-	myTraceLevel  = logrus.TraceLevel
+	myNoticeLevel   = logrus.InfoLevel
+	myMetricLevel   = logrus.DebugLevel
+	myFunctionLevel = logrus.DebugLevel
 )
 
-// Debug :
-func (object *LogObject) Debug(args ...interface{}) {
+// Function :
+func (object *LogObject) Function(args ...interface{}) {
 	if !object.Initialized {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	object.logger.WithFields(object.Fields).Log(myDebugLevel, args...)
-}
-
-// Info :
-func (object *LogObject) Info(args ...interface{}) {
-	if !object.Initialized {
-		logrus.Fatal("LogObject used without initialization")
-		return
-	}
-	object.logger.WithFields(object.Fields).Log(myInfoLevel, args...)
+	object.logger.WithFields(object.Fields).Log(myFunctionLevel, args...)
 }
 
 // Warn :
@@ -82,22 +70,13 @@ func (object *LogObject) Fatal(args ...interface{}) {
 	object.logger.WithFields(object.Fields).Fatal(args...)
 }
 
-// Debugf :
-func (object *LogObject) Debugf(format string, args ...interface{}) {
+// Functionf :
+func (object *LogObject) Functionf(format string, args ...interface{}) {
 	if !object.Initialized {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	object.logger.WithFields(object.Fields).Logf(myDebugLevel, format, args...)
-}
-
-// Infof :
-func (object *LogObject) Infof(format string, args ...interface{}) {
-	if !object.Initialized {
-		logrus.Fatal("LogObject used without initialization")
-		return
-	}
-	object.logger.WithFields(object.Fields).Logf(myInfoLevel, format, args...)
+	object.logger.WithFields(object.Fields).Logf(myFunctionLevel, format, args...)
 }
 
 // Warnf :
@@ -145,22 +124,13 @@ func (object *LogObject) Errorf(format string, args ...interface{}) {
 	object.logger.WithFields(object.Fields).Errorf(format, args...)
 }
 
-// Debugln :
-func (object *LogObject) Debugln(args ...interface{}) {
+// Functionln :
+func (object *LogObject) Functionln(args ...interface{}) {
 	if !object.Initialized {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	object.logger.WithFields(object.Fields).Logln(myDebugLevel, args...)
-}
-
-// Infoln :
-func (object *LogObject) Infoln(args ...interface{}) {
-	if !object.Initialized {
-		logrus.Fatal("LogObject used without initialization")
-		return
-	}
-	object.logger.WithFields(object.Fields).Logln(myInfoLevel, args...)
+	object.logger.WithFields(object.Fields).Logln(myFunctionLevel, args...)
 }
 
 // Warnln :
@@ -268,7 +238,7 @@ func (object *LogObject) Trace(args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	object.logger.WithFields(object.Fields).Log(myTraceLevel, args...)
+	object.logger.WithFields(object.Fields).Trace(args...)
 }
 
 // Tracef :
@@ -277,7 +247,7 @@ func (object *LogObject) Tracef(format string, args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	object.logger.WithFields(object.Fields).Logf(myTraceLevel, format, args...)
+	object.logger.WithFields(object.Fields).Tracef(format, args...)
 }
 
 // Traceln :
@@ -286,5 +256,5 @@ func (object *LogObject) Traceln(args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	object.logger.WithFields(object.Fields).Logln(myTraceLevel, args...)
+	object.logger.WithFields(object.Fields).Traceln(args...)
 }

--- a/pkg/pillar/cipher/cipher.go
+++ b/pkg/pillar/cipher/cipher.go
@@ -39,7 +39,7 @@ func GetCipherCredentials(ctx *DecryptCipherContext, agentName string,
 		return handleCipherBlockCredError(agentName, cipherBlock,
 			decBlock, nil, types.Invalid)
 	}
-	ctx.Log.Infof("%s, cipherblock decryption, using cipher-context: %s\n",
+	ctx.Log.Functionf("%s, cipherblock decryption, using cipher-context: %s\n",
 		cipherBlock.Key(), cipherBlock.CipherContextID)
 	if len(cipherBlock.Error) != 0 {
 		errStr := fmt.Sprintf("%s, cipherblock is not ready, %s",
@@ -65,7 +65,7 @@ func GetCipherCredentials(ctx *DecryptCipherContext, agentName string,
 		return handleCipherBlockCredError(agentName, cipherBlock,
 			decBlock, err, types.UnmarshalFailed)
 	}
-	ctx.Log.Infof("%s, cipherblock decryption successful", cipherBlock.Key())
+	ctx.Log.Functionf("%s, cipherblock decryption successful", cipherBlock.Key())
 	decBlock = getEncryptionBlock(&zconfigDecBlock)
 	RecordSuccess(agentName)
 	return *cipherBlock, decBlock, err
@@ -79,7 +79,7 @@ func GetCipherData(ctx *DecryptCipherContext, agentName string, status types.Cip
 	if !cipherBlock.IsCipher {
 		return handleCipherBlockError(agentName, cipherBlock, data, nil)
 	}
-	ctx.Log.Infof("%s, cipherblock decryption, using cipher-context: %s\n",
+	ctx.Log.Functionf("%s, cipherblock decryption, using cipher-context: %s\n",
 		cipherBlock.Key(), cipherBlock.CipherContextID)
 	if len(cipherBlock.Error) != 0 {
 		errStr := fmt.Sprintf("%s, cipherblock is not ready, %s",

--- a/pkg/pillar/cipher/handlecipher.go
+++ b/pkg/pillar/cipher/handlecipher.go
@@ -32,7 +32,7 @@ type DecryptCipherContext struct {
 
 // look up controller cert
 func lookupControllerCert(ctx *DecryptCipherContext, key string) *types.ControllerCert {
-	ctx.Log.Infof("lookupControllerCert(%s)\n", key)
+	ctx.Log.Functionf("lookupControllerCert(%s)\n", key)
 	sub := ctx.SubControllerCert
 	item, err := sub.Get(key)
 	if err != nil {
@@ -40,13 +40,13 @@ func lookupControllerCert(ctx *DecryptCipherContext, key string) *types.Controll
 		return nil
 	}
 	status := item.(types.ControllerCert)
-	ctx.Log.Infof("lookupControllerCert(%s) Done\n", key)
+	ctx.Log.Functionf("lookupControllerCert(%s) Done\n", key)
 	return &status
 }
 
 // look up cipher context
 func lookupCipherContext(ctx *DecryptCipherContext, key string) *types.CipherContext {
-	ctx.Log.Infof("lookupCipherContext(%s)\n", key)
+	ctx.Log.Functionf("lookupCipherContext(%s)\n", key)
 	sub := ctx.SubCipherContext
 	item, err := sub.Get(key)
 	if err != nil {
@@ -54,13 +54,13 @@ func lookupCipherContext(ctx *DecryptCipherContext, key string) *types.CipherCon
 		return nil
 	}
 	status := item.(types.CipherContext)
-	ctx.Log.Infof("lookupCipherContext(%s) done\n", key)
+	ctx.Log.Functionf("lookupCipherContext(%s) done\n", key)
 	return &status
 }
 
 // look up edge node cert
 func lookupEdgeNodeCert(ctx *DecryptCipherContext, key string) *types.EdgeNodeCert {
-	ctx.Log.Infof("lookupEdgeNodeCert(%s)\n", key)
+	ctx.Log.Functionf("lookupEdgeNodeCert(%s)\n", key)
 	sub := ctx.SubEdgeNodeCert
 	item, err := sub.Get(key)
 	if err != nil {
@@ -68,14 +68,14 @@ func lookupEdgeNodeCert(ctx *DecryptCipherContext, key string) *types.EdgeNodeCe
 		return nil
 	}
 	status := item.(types.EdgeNodeCert)
-	ctx.Log.Infof("lookupEdgeNodeCert(%s) Done\n", key)
+	ctx.Log.Functionf("lookupEdgeNodeCert(%s) Done\n", key)
 	return &status
 }
 
 func getDeviceCert(ctx *DecryptCipherContext,
 	cipherBlock types.CipherBlockStatus) ([]byte, error) {
 
-	ctx.Log.Infof("getDeviceCert for %s\n", cipherBlock.CipherBlockID)
+	ctx.Log.Functionf("getDeviceCert for %s\n", cipherBlock.CipherBlockID)
 	cipherContext := lookupCipherContext(ctx, cipherBlock.CipherContextID)
 	if cipherContext == nil {
 		errStr := fmt.Sprintf("cipher context %s not found\n",
@@ -93,7 +93,7 @@ func getDeviceCert(ctx *DecryptCipherContext,
 	}
 	if computeAndMatchHash(certBytes, cipherContext.DeviceCertHash,
 		cipherContext.HashScheme) {
-		ctx.Log.Infof("getDeviceCert for %s Done\n", cipherBlock.CipherBlockID)
+		ctx.Log.Functionf("getDeviceCert for %s Done\n", cipherBlock.CipherBlockID)
 		return certBytes, nil
 	}
 	errStr := fmt.Sprintf("getDeviceCert for %s not found\n",

--- a/pkg/pillar/cmd/baseosmgr/baseosmgr.go
+++ b/pkg/pillar/cmd/baseosmgr/baseosmgr.go
@@ -78,7 +78,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		log.Fatal(err)
 	}
 
-	log.Infof("Starting %s", agentName)
+	log.Functionf("Starting %s", agentName)
 
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(25 * time.Second)
@@ -110,7 +110,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	// Pick up debug aka log level before we start real work
 	for !ctx.GCInitialized {
-		log.Infof("waiting for GCInitialized")
+		log.Functionf("waiting for GCInitialized")
 		select {
 		case change := <-ctx.subGlobalConfig.MsgChan():
 			ctx.subGlobalConfig.ProcessChange(change)
@@ -118,7 +118,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		}
 		ps.StillRunning(agentName, warningTime, errorTime)
 	}
-	log.Infof("processed GlobalConfig")
+	log.Functionf("processed GlobalConfig")
 
 	// start the forever loop for event handling
 	for {
@@ -150,21 +150,21 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 func handleBaseOsConfigDelete(ctxArg interface{}, key string,
 	configArg interface{}) {
 
-	log.Infof("handleBaseOsConfigDelete(%s)", key)
+	log.Functionf("handleBaseOsConfigDelete(%s)", key)
 	ctx := ctxArg.(*baseOsMgrContext)
 	status := lookupBaseOsStatus(ctx, key)
 	if status == nil {
-		log.Infof("handleBaseOsConfigDelete: unknown %s", key)
+		log.Functionf("handleBaseOsConfigDelete: unknown %s", key)
 		return
 	}
 	handleBaseOsDelete(ctx, key, status)
-	log.Infof("handleBaseOsConfigDelete(%s) done", key)
+	log.Functionf("handleBaseOsConfigDelete(%s) done", key)
 }
 
 // base os config modify event
 func handleBaseOsCreate(ctxArg interface{}, key string, configArg interface{}) {
 
-	log.Infof("handleBaseOsCreate(%s)", key)
+	log.Functionf("handleBaseOsCreate(%s)", key)
 	ctx := ctxArg.(*baseOsMgrContext)
 	config := configArg.(types.BaseOsConfig)
 	status := types.BaseOsStatus{
@@ -195,7 +195,7 @@ func handleBaseOsCreate(ctxArg interface{}, key string, configArg interface{}) {
 func handleBaseOsModify(ctxArg interface{}, key string, configArg interface{},
 	oldConfigArg interface{}) {
 
-	log.Infof("handleBaseOsModify(%s)", key)
+	log.Functionf("handleBaseOsModify(%s)", key)
 	ctx := ctxArg.(*baseOsMgrContext)
 	config := configArg.(types.BaseOsConfig)
 	status := lookupBaseOsStatus(ctx, key)
@@ -204,7 +204,7 @@ func handleBaseOsModify(ctxArg interface{}, key string, configArg interface{},
 		return
 	}
 
-	log.Infof("handleBaseOsModify(%s) for %s Activate %v",
+	log.Functionf("handleBaseOsModify(%s) for %s Activate %v",
 		config.Key(), config.BaseOsVersion, config.Activate)
 
 	// Check image count
@@ -226,7 +226,7 @@ func handleBaseOsModify(ctxArg interface{}, key string, configArg interface{},
 func handleBaseOsDelete(ctx *baseOsMgrContext, key string,
 	status *types.BaseOsStatus) {
 
-	log.Infof("handleBaseOsDelete for %s", status.BaseOsVersion)
+	log.Functionf("handleBaseOsDelete for %s", status.BaseOsVersion)
 	removeBaseOsConfig(ctx, status.Key())
 }
 
@@ -249,7 +249,7 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 
 	ctx := ctxArg.(*baseOsMgrContext)
 	if key != "global" {
-		log.Infof("handleGlobalConfigImpl: ignoring %s", key)
+		log.Functionf("handleGlobalConfigImpl: ignoring %s", key)
 		return
 	}
 	var gcp *types.ConfigItemValueMap
@@ -259,7 +259,7 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 		ctx.globalConfig = gcp
 		ctx.GCInitialized = true
 	}
-	log.Infof("handleGlobalConfigImpl done for %s", key)
+	log.Functionf("handleGlobalConfigImpl done for %s", key)
 }
 
 func handleGlobalConfigDelete(ctxArg interface{}, key string,
@@ -267,14 +267,14 @@ func handleGlobalConfigDelete(ctxArg interface{}, key string,
 
 	ctx := ctxArg.(*baseOsMgrContext)
 	if key != "global" {
-		log.Infof("handleGlobalConfigDelete: ignoring %s", key)
+		log.Functionf("handleGlobalConfigDelete: ignoring %s", key)
 		return
 	}
-	log.Infof("handleGlobalConfigDelete for %s", key)
+	log.Functionf("handleGlobalConfigDelete for %s", key)
 	debug, _ = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
 		debugOverride, logger)
 	*ctx.globalConfig = *types.DefaultConfigItemValueMap()
-	log.Infof("handleGlobalConfigDelete done for %s", key)
+	log.Functionf("handleGlobalConfigDelete done for %s", key)
 }
 
 func initializeSelfPublishHandles(ps *pubsub.PubSub, ctx *baseOsMgrContext) {
@@ -441,13 +441,13 @@ func handleNodeAgentStatusImpl(ctxArg interface{}, key string,
 	ctx.rebootReason = status.RebootReason
 	ctx.rebootImage = status.RebootImage
 	updateBaseOsStatusOnReboot(ctx)
-	log.Infof("handleNodeAgentStatusImpl(%s) done", key)
+	log.Functionf("handleNodeAgentStatusImpl(%s) done", key)
 }
 
 func handleNodeAgentStatusDelete(ctxArg interface{}, key string,
 	statusArg interface{}) {
 	// do nothing
-	log.Infof("handleNodeAgentStatusDelete(%s) done", key)
+	log.Functionf("handleNodeAgentStatusDelete(%s) done", key)
 }
 
 func handleZbootConfigCreate(ctxArg interface{}, key string,
@@ -467,30 +467,30 @@ func handleZbootConfigImpl(ctxArg interface{}, key string,
 	config := configArg.(types.ZbootConfig)
 	status := getZbootStatus(ctx, key)
 	if status == nil {
-		log.Infof("handleZbootConfigImpl: unknown %s", key)
+		log.Functionf("handleZbootConfigImpl: unknown %s", key)
 		return
 	}
-	log.Infof("handleZbootImpl for %s TestComplete %v",
+	log.Functionf("handleZbootImpl for %s TestComplete %v",
 		config.Key(), config.TestComplete)
 
 	if config.TestComplete != status.TestComplete {
 		handleZbootTestComplete(ctx, config, *status)
 	}
 
-	log.Infof("handleZbootConfigImpl(%s) done", key)
+	log.Functionf("handleZbootConfigImpl(%s) done", key)
 }
 
 func handleZbootConfigDelete(ctxArg interface{}, key string,
 	configArg interface{}) {
 
-	log.Infof("handleZbootConfigDelete(%s)", key)
+	log.Functionf("handleZbootConfigDelete(%s)", key)
 	ctx := ctxArg.(*baseOsMgrContext)
 	status := getZbootStatus(ctx, key)
 	if status == nil {
-		log.Infof("handleZbootConfigDelete: unknown %s", key)
+		log.Functionf("handleZbootConfigDelete: unknown %s", key)
 		return
 	}
 	// Nothing to do. We report ZbootStatus for the IMG* partitions
 	// in any case
-	log.Infof("handleZbootConfigDelete(%s) done", key)
+	log.Functionf("handleZbootConfigDelete(%s) done", key)
 }

--- a/pkg/pillar/cmd/baseosmgr/handlebaseos.go
+++ b/pkg/pillar/cmd/baseosmgr/handlebaseos.go
@@ -52,14 +52,14 @@ func lookupBaseOsStatusImageSha(ctx *baseOsMgrContext, imageSha string) *types.B
 // and then call baseOsHandleStatusUpdate. Just a convenience function.
 func baseOsHandleStatusUpdateImageSha(ctx *baseOsMgrContext, imageSha string) {
 
-	log.Infof("baseOsHandleStatusUpdateImageSha for %s", imageSha)
+	log.Functionf("baseOsHandleStatusUpdateImageSha for %s", imageSha)
 	config := lookupBaseOsImageSha(ctx, imageSha)
 	if config == nil {
-		log.Infof("baseOsHandleStatusUpdateImageSha(%s) config not found",
+		log.Functionf("baseOsHandleStatusUpdateImageSha(%s) config not found",
 			imageSha)
 		status := lookupBaseOsStatusImageSha(ctx, imageSha)
 		if status != nil {
-			log.Infof("baseOsHandleStatusUpdateImageSha(%s) found status",
+			log.Functionf("baseOsHandleStatusUpdateImageSha(%s) found status",
 				imageSha)
 			removeBaseOsStatus(ctx, status.Key())
 		}
@@ -68,11 +68,11 @@ func baseOsHandleStatusUpdateImageSha(ctx *baseOsMgrContext, imageSha string) {
 	uuidStr := config.Key()
 	status := lookupBaseOsStatus(ctx, uuidStr)
 	if status == nil {
-		log.Infof("baseOsHandleStatusUpdateImageSha(%s) no status",
+		log.Functionf("baseOsHandleStatusUpdateImageSha(%s) no status",
 			imageSha)
 		return
 	}
-	log.Infof("baseOsHandleStatusUpdateImageSha(%s) found %s",
+	log.Functionf("baseOsHandleStatusUpdateImageSha(%s) found %s",
 		imageSha, uuidStr)
 
 	// handle the change event for this base os config
@@ -82,7 +82,7 @@ func baseOsHandleStatusUpdateImageSha(ctx *baseOsMgrContext, imageSha string) {
 // baseOsHandleStatusUpdateUUID find the config based on the UUID,
 // and then call baseOsHandleStatusUpdate. Just a convenience function.
 func baseOsHandleStatusUpdateUUID(ctx *baseOsMgrContext, id string) {
-	log.Infof("baseOsHandleStatusUpdateUUID for %s", id)
+	log.Functionf("baseOsHandleStatusUpdateUUID for %s", id)
 	config := lookupBaseOsConfig(ctx, id)
 	if config == nil {
 		log.Errorf("baseOsHandleStatusUpdateUUID(%s) config not found", id)
@@ -90,7 +90,7 @@ func baseOsHandleStatusUpdateUUID(ctx *baseOsMgrContext, id string) {
 	}
 	status := lookupBaseOsStatus(ctx, id)
 	if status == nil {
-		log.Infof("baseOsHandleStatusUpdateUUID(%s) status not found", id)
+		log.Functionf("baseOsHandleStatusUpdateUUID(%s) status not found", id)
 		return
 	}
 
@@ -102,7 +102,7 @@ func baseOsHandleStatusUpdateUUID(ctx *baseOsMgrContext, id string) {
 func baseOsGetActivationStatus(ctx *baseOsMgrContext,
 	status *types.BaseOsStatus) bool {
 
-	log.Infof("baseOsGetActivationStatus(%s): partitionLabel %s",
+	log.Functionf("baseOsGetActivationStatus(%s): partitionLabel %s",
 		status.BaseOsVersion, status.PartitionLabel)
 
 	changed := false
@@ -154,7 +154,7 @@ func baseOsHandleStatusUpdate(ctx *baseOsMgrContext, config *types.BaseOsConfig,
 	status *types.BaseOsStatus) {
 
 	uuidStr := config.Key()
-	log.Infof("baseOsHandleStatusUpdate(%s)", uuidStr)
+	log.Functionf("baseOsHandleStatusUpdate(%s)", uuidStr)
 
 	changed := baseOsGetActivationStatus(ctx, status)
 
@@ -162,7 +162,7 @@ func baseOsHandleStatusUpdate(ctx *baseOsMgrContext, config *types.BaseOsConfig,
 	changed = changed || c
 
 	if changed {
-		log.Infof("baseOsHandleStatusUpdate(%s) for %s, Status changed",
+		log.Functionf("baseOsHandleStatusUpdate(%s) for %s, Status changed",
 			config.BaseOsVersion, uuidStr)
 		publishBaseOsStatus(ctx, status)
 	}
@@ -171,7 +171,7 @@ func baseOsHandleStatusUpdate(ctx *baseOsMgrContext, config *types.BaseOsConfig,
 func doBaseOsStatusUpdate(ctx *baseOsMgrContext, uuidStr string,
 	config types.BaseOsConfig, status *types.BaseOsStatus) bool {
 
-	log.Infof("doBaseOsStatusUpdate(%s) Activate %v for %s",
+	log.Functionf("doBaseOsStatusUpdate(%s) Activate %v for %s",
 		config.BaseOsVersion, config.Activate, uuidStr)
 
 	changed := false
@@ -187,7 +187,7 @@ func doBaseOsStatusUpdate(ctx *baseOsMgrContext, uuidStr string,
 		shortVerCurPart = partStatus.ShortVersion
 	}
 	if status.BaseOsVersion == shortVerCurPart {
-		log.Infof("doBaseOsStatusUpdate(%s) for %s found in current %s",
+		log.Functionf("doBaseOsStatusUpdate(%s) for %s found in current %s",
 			config.BaseOsVersion, uuidStr, curPartName)
 		baseOsSetPartitionInfoInStatus(ctx, status, curPartName)
 		setProgressDone(status, types.INSTALLED)
@@ -208,7 +208,7 @@ func doBaseOsStatusUpdate(ctx *baseOsMgrContext, uuidStr string,
 	}
 	if (status.PartitionLabel == "" || status.PartitionLabel == otherPartName) &&
 		status.BaseOsVersion == shortVerOtherPart {
-		log.Infof("doBaseOsStatusUpdate(%s) for %s found in other %s",
+		log.Functionf("doBaseOsStatusUpdate(%s) for %s found in other %s",
 			config.BaseOsVersion, uuidStr, otherPartName)
 		baseOsSetPartitionInfoInStatus(ctx, status, otherPartName)
 		if !config.Activate {
@@ -227,7 +227,7 @@ func doBaseOsStatusUpdate(ctx *baseOsMgrContext, uuidStr string,
 	}
 
 	if !config.Activate {
-		log.Infof("doBaseOsStatusUpdate(%s) for %s, Activate is not set",
+		log.Functionf("doBaseOsStatusUpdate(%s) for %s, Activate is not set",
 			config.BaseOsVersion, uuidStr)
 		if status.Activated {
 			c := doBaseOsInactivate(uuidStr, status)
@@ -237,7 +237,7 @@ func doBaseOsStatusUpdate(ctx *baseOsMgrContext, uuidStr string,
 	}
 
 	if status.Activated {
-		log.Infof("doBaseOsStatusUpdate(%s) for %s, is already activated",
+		log.Functionf("doBaseOsStatusUpdate(%s) for %s, is already activated",
 			config.BaseOsVersion, uuidStr)
 		return changed
 	}
@@ -248,7 +248,7 @@ func doBaseOsStatusUpdate(ctx *baseOsMgrContext, uuidStr string,
 		return changed
 	}
 	changed = doBaseOsActivate(ctx, uuidStr, config, status)
-	log.Infof("doBaseOsStatusUpdate(%s) done for %s",
+	log.Functionf("doBaseOsStatusUpdate(%s) done for %s",
 		config.BaseOsVersion, uuidStr)
 	return changed
 }
@@ -271,11 +271,11 @@ func doBaseOsActivate(ctx *baseOsMgrContext, uuidStr string,
 		proceed bool
 		err     error
 	)
-	log.Infof("doBaseOsActivate(%s) uuid %s",
+	log.Functionf("doBaseOsActivate(%s) uuid %s",
 		config.BaseOsVersion, uuidStr)
 
 	if status.PartitionLabel == "" {
-		log.Infof("doBaseOsActivate(%s) for %s, unassigned partition",
+		log.Functionf("doBaseOsActivate(%s) for %s, unassigned partition",
 			config.BaseOsVersion, uuidStr)
 		return changed
 	}
@@ -288,19 +288,19 @@ func doBaseOsActivate(ctx *baseOsMgrContext, uuidStr string,
 	}
 	partStatus := getZbootStatus(ctx, status.PartitionLabel)
 	if partStatus == nil {
-		log.Infof("doBaseOsActivate(%s) for %s, partition status %s not found",
+		log.Functionf("doBaseOsActivate(%s) for %s, partition status %s not found",
 			config.BaseOsVersion, uuidStr, status.PartitionLabel)
 		return changed
 	}
 	switch partStatus.PartitionState {
 	case "unused":
-		log.Infof("Installing %s over unused",
+		log.Functionf("Installing %s over unused",
 			config.BaseOsVersion)
 	case "inprogress":
-		log.Infof("Installing %s over inprogress",
+		log.Functionf("Installing %s over inprogress",
 			config.BaseOsVersion)
 	case "updating":
-		log.Infof("Installing %s over updating",
+		log.Functionf("Installing %s over updating",
 			config.BaseOsVersion)
 	default:
 		errString := fmt.Sprintf("Wrong partition state %s for %s",
@@ -311,7 +311,7 @@ func doBaseOsActivate(ctx *baseOsMgrContext, uuidStr string,
 		return changed
 	}
 
-	log.Infof("doBaseOsActivate: %s activating", uuidStr)
+	log.Functionf("doBaseOsActivate: %s activating", uuidStr)
 
 	// install the image at proper partition; dd etc
 	changed, proceed, err = installDownloadedObjects(ctx, uuidStr, status.PartitionLabel,
@@ -346,7 +346,7 @@ func doBaseOsActivate(ctx *baseOsMgrContext, uuidStr string,
 			status.PartitionLabel)
 		publishBaseOsStatus(ctx, status)
 	} else {
-		log.Infof("Waiting for image to be mounted")
+		log.Functionf("Waiting for image to be mounted")
 		return changed
 	}
 
@@ -363,7 +363,7 @@ func doBaseOsActivate(ctx *baseOsMgrContext, uuidStr string,
 func doBaseOsInstall(ctx *baseOsMgrContext, uuidStr string,
 	config types.BaseOsConfig, status *types.BaseOsStatus) (bool, bool) {
 
-	log.Infof("doBaseOsInstall(%s) %s", uuidStr, config.BaseOsVersion)
+	log.Functionf("doBaseOsInstall(%s) %s", uuidStr, config.BaseOsVersion)
 	changed := false
 	proceed := false
 
@@ -392,7 +392,7 @@ func doBaseOsInstall(ctx *baseOsMgrContext, uuidStr string,
 		config, status)
 	changed = changed || c
 	if !done {
-		log.Infof(" %s, volume still not done", config.BaseOsVersion)
+		log.Functionf(" %s, volume still not done", config.BaseOsVersion)
 		return changed, false
 	}
 
@@ -400,7 +400,7 @@ func doBaseOsInstall(ctx *baseOsMgrContext, uuidStr string,
 	// XXX requires loopback mounting the image; not part of syscall.Mount
 	// Note that we XXX dd as part of the installDownloadedObjects call
 	// in doBaseOsActivate
-	log.Infof("doBaseOsInstall(%s), Done", config.BaseOsVersion)
+	log.Functionf("doBaseOsInstall(%s), Done", config.BaseOsVersion)
 	return changed, true
 }
 
@@ -418,7 +418,7 @@ func validatePartition(ctx *baseOsMgrContext,
 	config types.BaseOsConfig, status *types.BaseOsStatus) (bool, bool) {
 	var otherPartVersion string
 
-	log.Infof("validatePartition(%s) for %s",
+	log.Functionf("validatePartition(%s) for %s",
 		config.Key(), config.BaseOsVersion)
 	changed := false
 	otherPartName := zboot.GetOtherPartition()
@@ -449,7 +449,7 @@ func validateAndAssignPartition(ctx *baseOsMgrContext,
 	config types.BaseOsConfig, status *types.BaseOsStatus) (bool, bool) {
 	var curPartState, curPartVersion, otherPartVersion string
 
-	log.Infof("validateAndAssignPartition(%s) for %s",
+	log.Functionf("validateAndAssignPartition(%s) for %s",
 		config.Key(), config.BaseOsVersion)
 	changed := false
 	proceed := false
@@ -474,7 +474,7 @@ func validateAndAssignPartition(ctx *baseOsMgrContext,
 		errStr := fmt.Sprintf("Attempt to install baseOs update %s while testing is in progress for %s: deferred",
 			config.BaseOsVersion, curPartVersion)
 		if otherPartVersion == config.BaseOsVersion {
-			log.Infoln(errStr)
+			log.Functionln(errStr)
 		} else {
 			log.Error(errStr)
 			status.SetErrorNow(errStr)
@@ -486,7 +486,7 @@ func validateAndAssignPartition(ctx *baseOsMgrContext,
 	// XXX should we check that this is the only one marked as Activate?
 	// XXX or check that other isn't marked as updating?
 	if config.Activate && status.PartitionLabel == "" {
-		log.Infof("validateAndAssignPartition(%s) assigning with partition %s",
+		log.Functionf("validateAndAssignPartition(%s) assigning with partition %s",
 			config.BaseOsVersion, otherPartName)
 		status.PartitionLabel = otherPartName
 		status.PartitionState = otherPartStatus.PartitionState
@@ -502,7 +502,7 @@ func checkBaseOsVolumeStatus(ctx *baseOsMgrContext, baseOsUUID uuid.UUID,
 	status *types.BaseOsStatus) (bool, bool) {
 
 	uuidStr := baseOsUUID.String()
-	log.Infof("checkBaseOsVolumeStatus(%s) for %s",
+	log.Functionf("checkBaseOsVolumeStatus(%s) for %s",
 		config.BaseOsVersion, uuidStr)
 	ret := checkContentTreeStatus(ctx, baseOsUUID, config.ContentTreeConfigList,
 		status.ContentTreeStatusList)
@@ -517,50 +517,50 @@ func checkBaseOsVolumeStatus(ctx *baseOsMgrContext, baseOsUUID uuid.UUID,
 	}
 
 	if ret.MinState < types.LOADED {
-		log.Infof("checkBaseOsVolumeStatus(%s) for %s, Waiting for volumemgr",
+		log.Functionf("checkBaseOsVolumeStatus(%s) for %s, Waiting for volumemgr",
 			config.BaseOsVersion, uuidStr)
 		return ret.Changed, false
 	}
-	log.Infof("checkBaseOsVolumeStatus(%s) for %s, done",
+	log.Functionf("checkBaseOsVolumeStatus(%s) for %s, done",
 		config.BaseOsVersion, uuidStr)
 	return ret.Changed, true
 }
 
 func removeBaseOsConfig(ctx *baseOsMgrContext, uuidStr string) {
 
-	log.Infof("removeBaseOsConfig for %s", uuidStr)
+	log.Functionf("removeBaseOsConfig for %s", uuidStr)
 	removeBaseOsStatus(ctx, uuidStr)
-	log.Infof("removeBaseOSConfig for %s, done", uuidStr)
+	log.Functionf("removeBaseOSConfig for %s, done", uuidStr)
 }
 
 func removeBaseOsStatus(ctx *baseOsMgrContext, uuidStr string) {
 
-	log.Infof("removeBaseOsStatus for %s", uuidStr)
+	log.Functionf("removeBaseOsStatus for %s", uuidStr)
 	status := lookupBaseOsStatus(ctx, uuidStr)
 	if status == nil {
-		log.Infof("removeBaseOsStatus: no status")
+		log.Functionf("removeBaseOsStatus: no status")
 		return
 	}
 
 	changed, del := doBaseOsRemove(ctx, uuidStr, status)
 	if changed {
-		log.Infof("removeBaseOsStatus for %s, Status change", uuidStr)
+		log.Functionf("removeBaseOsStatus for %s, Status change", uuidStr)
 		publishBaseOsStatus(ctx, status)
 	}
 
 	if del {
-		log.Infof("removeBaseOsStatus %s, Deleting", uuidStr)
+		log.Functionf("removeBaseOsStatus %s, Deleting", uuidStr)
 
 		// Write out what we modified to BaseOsStatus aka delete
 		unpublishBaseOsStatus(ctx, status.Key())
 	}
-	log.Infof("removeBaseOsStatus %s, Done", uuidStr)
+	log.Functionf("removeBaseOsStatus %s, Done", uuidStr)
 }
 
 func doBaseOsRemove(ctx *baseOsMgrContext, uuidStr string,
 	status *types.BaseOsStatus) (bool, bool) {
 
-	log.Infof("doBaseOsRemove(%s) for %s", status.BaseOsVersion, uuidStr)
+	log.Functionf("doBaseOsRemove(%s) for %s", status.BaseOsVersion, uuidStr)
 
 	changed := false
 	del := false
@@ -569,13 +569,13 @@ func doBaseOsRemove(ctx *baseOsMgrContext, uuidStr string,
 
 	changed, del = doBaseOsUninstall(ctx, uuidStr, status)
 
-	log.Infof("doBaseOsRemove(%s) for %s, Done",
+	log.Functionf("doBaseOsRemove(%s) for %s, Done",
 		status.BaseOsVersion, uuidStr)
 	return changed, del
 }
 
 func doBaseOsInactivate(uuidStr string, status *types.BaseOsStatus) bool {
-	log.Infof("doBaseOsInactivate(%s) %v",
+	log.Functionf("doBaseOsInactivate(%s) %v",
 		status.BaseOsVersion, status.Activated)
 
 	// nothing to be done, flip will happen on reboot
@@ -585,7 +585,7 @@ func doBaseOsInactivate(uuidStr string, status *types.BaseOsStatus) bool {
 func doBaseOsUninstall(ctx *baseOsMgrContext, uuidStr string,
 	status *types.BaseOsStatus) (bool, bool) {
 
-	log.Infof("doBaseOsUninstall(%s) for %s",
+	log.Functionf("doBaseOsUninstall(%s) for %s",
 		status.BaseOsVersion, uuidStr)
 
 	del := false
@@ -599,18 +599,18 @@ func doBaseOsUninstall(ctx *baseOsMgrContext, uuidStr string,
 		partName := status.PartitionLabel
 		partStatus := getZbootStatus(ctx, partName)
 		if partStatus == nil {
-			log.Infof("doBaseOsUninstall(%s) for %s, partitionStatus not found",
+			log.Functionf("doBaseOsUninstall(%s) for %s, partitionStatus not found",
 				status.BaseOsVersion, uuidStr)
 			return changed, del
 		}
 		if status.BaseOsVersion == partStatus.ShortVersion &&
 			!partStatus.CurrentPartition {
-			log.Infof("doBaseOsUninstall(%s) for %s, currently on other %s",
+			log.Functionf("doBaseOsUninstall(%s) for %s, currently on other %s",
 				status.BaseOsVersion, uuidStr, partName)
 			curPartState := getPartitionState(ctx,
 				zboot.GetCurrentPartition())
 			if curPartState == "active" {
-				log.Infof("Mark other partition %s, unused", partName)
+				log.Functionf("Mark other partition %s, unused", partName)
 				zboot.SetOtherPartitionStateUnused(log)
 				updateAndPublishZbootStatus(ctx,
 					status.PartitionLabel, false)
@@ -627,7 +627,7 @@ func doBaseOsUninstall(ctx *baseOsMgrContext, uuidStr string,
 	}
 	for i := range status.ContentTreeStatusList {
 		cts := &status.ContentTreeStatusList[i]
-		log.Infof("doBaseOsUninstall(%s) for %s",
+		log.Functionf("doBaseOsUninstall(%s) for %s",
 			status.BaseOsVersion, uuidStr)
 		c := MaybeRemoveContentTreeConfig(ctx, cts.Key())
 		if c {
@@ -636,7 +636,7 @@ func doBaseOsUninstall(ctx *baseOsMgrContext, uuidStr string,
 
 		contentStatus := lookupContentTreeStatus(ctx, cts.Key())
 		if contentStatus != nil {
-			log.Infof("doBaseOsUninstall(%s) for %s, Content %s not yet gone;",
+			log.Functionf("doBaseOsUninstall(%s) for %s, Content %s not yet gone;",
 				status.BaseOsVersion, uuidStr, cts.ContentID)
 			removedAll = false
 			continue
@@ -644,13 +644,13 @@ func doBaseOsUninstall(ctx *baseOsMgrContext, uuidStr string,
 	}
 
 	if !removedAll {
-		log.Infof("doBaseOsUninstall(%s) for %s, Waiting for volumemgr purge",
+		log.Functionf("doBaseOsUninstall(%s) for %s, Waiting for volumemgr purge",
 			status.BaseOsVersion, uuidStr)
 		return changed, del
 	}
 
 	del = true
-	log.Infof("doBaseOsUninstall(%s), Done", status.BaseOsVersion)
+	log.Functionf("doBaseOsUninstall(%s), Done", status.BaseOsVersion)
 	return changed, del
 }
 
@@ -658,7 +658,7 @@ func doBaseOsUninstall(ctx *baseOsMgrContext, uuidStr string,
 // config version string
 func checkInstalledVersion(ctx *baseOsMgrContext, status types.BaseOsStatus) string {
 
-	log.Infof("checkInstalledVersion(%s) %s %s",
+	log.Functionf("checkInstalledVersion(%s) %s %s",
 		status.UUIDandVersion.UUID.String(), status.PartitionLabel,
 		status.BaseOsVersion)
 
@@ -674,7 +674,7 @@ func checkInstalledVersion(ctx *baseOsMgrContext, status types.BaseOsStatus) str
 	if partStatus != nil {
 		shortVer = partStatus.ShortVersion
 	}
-	log.Infof("checkInstalledVersion: Cfg baseVer %s, Image shortVer %s",
+	log.Functionf("checkInstalledVersion: Cfg baseVer %s, Image shortVer %s",
 		status.BaseOsVersion, shortVer)
 	if status.BaseOsVersion != shortVer {
 		errString := fmt.Sprintf("checkInstalledVersion: image name not match. config %s, image ver %s\n",
@@ -689,7 +689,7 @@ func lookupBaseOsConfig(ctx *baseOsMgrContext, key string) *types.BaseOsConfig {
 	sub := ctx.subBaseOsConfig
 	c, _ := sub.Get(key)
 	if c == nil {
-		log.Infof("lookupBaseOsConfig(%s) not found", key)
+		log.Functionf("lookupBaseOsConfig(%s) not found", key)
 		return nil
 	}
 	config := c.(types.BaseOsConfig)
@@ -700,7 +700,7 @@ func lookupBaseOsStatus(ctx *baseOsMgrContext, key string) *types.BaseOsStatus {
 	pub := ctx.pubBaseOsStatus
 	st, _ := pub.Get(key)
 	if st == nil {
-		log.Infof("lookupBaseOsStatus(%s) not found", key)
+		log.Functionf("lookupBaseOsStatus(%s) not found", key)
 		return nil
 	}
 	status := st.(types.BaseOsStatus)
@@ -711,7 +711,7 @@ func lookupBaseOsStatusByPartLabel(ctx *baseOsMgrContext, partLabel string) *typ
 	pub := ctx.pubBaseOsStatus
 	st, _ := pub.Get(partLabel)
 	if st == nil {
-		log.Infof("lookupBaseOsStatusByPartLabel(%s) not found", partLabel)
+		log.Functionf("lookupBaseOsStatusByPartLabel(%s) not found", partLabel)
 		return nil
 	}
 	status := st.(types.BaseOsStatus)
@@ -726,14 +726,14 @@ func lookupBaseOsStatusByPartLabel(ctx *baseOsMgrContext, partLabel string) *typ
 func publishBaseOsStatus(ctx *baseOsMgrContext, status *types.BaseOsStatus) {
 
 	key := status.Key()
-	log.Debugf("Publishing BaseOsStatus %s", key)
+	log.Tracef("Publishing BaseOsStatus %s", key)
 	pub := ctx.pubBaseOsStatus
 	pub.Publish(key, *status)
 }
 
 func unpublishBaseOsStatus(ctx *baseOsMgrContext, key string) {
 
-	log.Debugf("Unpublishing BaseOsStatus %s", key)
+	log.Tracef("Unpublishing BaseOsStatus %s", key)
 	pub := ctx.pubBaseOsStatus
 	st, _ := pub.Get(key)
 	if st == nil {
@@ -759,17 +759,17 @@ func validateBaseOsConfig(ctx *baseOsMgrContext, config types.BaseOsConfig) erro
 func handleZbootTestComplete(ctx *baseOsMgrContext, config types.ZbootConfig,
 	status types.ZbootStatus) {
 
-	log.Infof("handleZbootTestComplete(%s)", config.Key())
+	log.Functionf("handleZbootTestComplete(%s)", config.Key())
 	if config.TestComplete == status.TestComplete {
 		// nothing to do
-		log.Infof("handleZbootTestComplete(%s) nothing to do",
+		log.Functionf("handleZbootTestComplete(%s) nothing to do",
 			config.Key())
 		return
 	}
 	if config.TestComplete {
 		curPart := zboot.GetCurrentPartition()
 		if curPart != config.Key() {
-			log.Infof("handleZbootTestComplete(%s) not current partition; current %s",
+			log.Functionf("handleZbootTestComplete(%s) not current partition; current %s",
 				config.Key(), curPart)
 			return
 		}
@@ -791,7 +791,7 @@ func handleZbootTestComplete(ctx *baseOsMgrContext, config types.ZbootConfig,
 			publishBaseOsStatus(ctx, bs)
 			// publish the updated partition information
 			updateAndPublishZbootStatusAll(ctx)
-			log.Infof("handleZbootTestComplete(%s) to True failed",
+			log.Functionf("handleZbootTestComplete(%s) to True failed",
 				config.Key())
 			return
 		}
@@ -806,13 +806,13 @@ func handleZbootTestComplete(ctx *baseOsMgrContext, config types.ZbootConfig,
 		// Check if we have a failed update which needs a kick
 		maybeRetryInstall(ctx)
 
-		log.Infof("handleZbootTestComplete(%s) to True done",
+		log.Functionf("handleZbootTestComplete(%s) to True done",
 			config.Key())
 		return
 	}
 
 	// completed state transition, mark TestComplete as false
-	log.Infof("handleZbootTestComplete(%s) to False done", config.Key())
+	log.Functionf("handleZbootTestComplete(%s) to False done", config.Key())
 	status.TestComplete = false
 	publishZbootStatus(ctx, status)
 	updateAndPublishBaseOsStatusAll(ctx)
@@ -837,18 +837,18 @@ func maybeRetryInstall(ctx *baseOsMgrContext) {
 	for _, st := range items {
 		status := st.(types.BaseOsStatus)
 		if !status.TooEarly {
-			log.Infof("maybeRetryInstall(%s) skipped",
+			log.Functionf("maybeRetryInstall(%s) skipped",
 				status.Key())
 			continue
 		}
 		config := lookupBaseOsConfig(ctx, status.Key())
 		if config == nil {
-			log.Infof("maybeRetryInstall(%s) no config",
+			log.Functionf("maybeRetryInstall(%s) no config",
 				status.Key())
 			continue
 		}
 
-		log.Infof("maybeRetryInstall(%s) redoing after %s %v",
+		log.Functionf("maybeRetryInstall(%s) redoing after %s %v",
 			status.Key(), status.Error, status.ErrorTime)
 		status.TooEarly = false
 		status.ClearError()
@@ -860,7 +860,7 @@ func baseOsSetPartitionInfoInStatus(ctx *baseOsMgrContext, status *types.BaseOsS
 
 	partStatus := getZbootStatus(ctx, partName)
 	if partStatus != nil {
-		log.Infof("baseOsSetPartitionInfoInStatus(%s) %s found %+v",
+		log.Functionf("baseOsSetPartitionInfoInStatus(%s) %s found %+v",
 			status.Key(), partName, partStatus)
 		status.PartitionLabel = partName
 		status.PartitionState = partStatus.PartitionState
@@ -872,7 +872,7 @@ func baseOsSetPartitionInfoInStatus(ctx *baseOsMgrContext, status *types.BaseOsS
 // and if so updates the current and state. Otherwise it creates from
 // scratch
 func updateAndPublishZbootStatusAll(ctx *baseOsMgrContext) {
-	log.Infof("updateAndPublishZbootStatusAll")
+	log.Functionf("updateAndPublishZbootStatusAll")
 	partitionNames := []string{"IMGA", "IMGB"}
 	for _, partName := range partitionNames {
 		status := getZbootStatus(ctx, partName)

--- a/pkg/pillar/cmd/baseosmgr/handledownload.go
+++ b/pkg/pillar/cmd/baseosmgr/handledownload.go
@@ -20,7 +20,7 @@ func checkContentTreeStatus(ctx *baseOsMgrContext,
 
 	uuidStr := baseOsUUID.String()
 	ret := &types.RetStatus{}
-	log.Infof("checkContentTreeStatus for %s", uuidStr)
+	log.Functionf("checkContentTreeStatus for %s", uuidStr)
 
 	ret.Changed = false
 	ret.AllErrors = ""
@@ -32,14 +32,14 @@ func checkContentTreeStatus(ctx *baseOsMgrContext,
 
 		contentID := ctc.ContentID
 
-		log.Infof("checkContentTreeStatus %s, content status %v",
+		log.Functionf("checkContentTreeStatus %s, content status %v",
 			contentID, cts.State)
 		if cts.State == types.INSTALLED {
 			ret.MinState = cts.State
 			cts.Progress = 100
 			// XXX TotalSize and CurrentSize?
 			ret.Changed = true
-			log.Infof("checkContentTreeStatus %s is already installed",
+			log.Functionf("checkContentTreeStatus %s is already installed",
 				contentID)
 			continue
 		}
@@ -50,7 +50,7 @@ func checkContentTreeStatus(ctx *baseOsMgrContext,
 		}
 		contentStatus := lookupContentTreeStatus(ctx, ctc.Key())
 		if contentStatus == nil {
-			log.Infof("Content tree status not found. name: %s", ctc.RelativeURL)
+			log.Functionf("Content tree status not found. name: %s", ctc.RelativeURL)
 			ret.MinState = types.DOWNLOADING
 			cts.State = types.DOWNLOADING
 			ret.Changed = true
@@ -60,14 +60,14 @@ func checkContentTreeStatus(ctx *baseOsMgrContext,
 		if contentStatus.FileLocation != cts.FileLocation {
 			cts.FileLocation = contentStatus.FileLocation
 			ret.Changed = true
-			log.Infof("checkContentTreeStatus(%s) from contentStatus set FileLocation to %s",
+			log.Functionf("checkContentTreeStatus(%s) from contentStatus set FileLocation to %s",
 				contentID, contentStatus.FileLocation)
 		}
 		if ret.MinState > contentStatus.State {
 			ret.MinState = contentStatus.State
 		}
 		if contentStatus.State != cts.State {
-			log.Infof("checkContentTreeStatus(%s) from ds set cts.State %d",
+			log.Functionf("checkContentTreeStatus(%s) from ds set cts.State %d",
 				contentID, contentStatus.State)
 			cts.State = contentStatus.State
 			ret.Changed = true
@@ -114,7 +114,7 @@ func installDownloadedObjects(ctx *baseOsMgrContext, uuidStr, finalObjDir string
 		proceed bool
 		err     error
 	)
-	log.Infof("installDownloadedObjects(%s)", uuidStr)
+	log.Functionf("installDownloadedObjects(%s)", uuidStr)
 
 	for i := range *status {
 		ctsPtr := &(*status)[i]
@@ -131,7 +131,7 @@ func installDownloadedObjects(ctx *baseOsMgrContext, uuidStr, finalObjDir string
 			proceed = true
 		}
 	}
-	log.Infof("installDownloadedObjects(%s) done %v", uuidStr, proceed)
+	log.Functionf("installDownloadedObjects(%s) done %v", uuidStr, proceed)
 	return changed, proceed, nil
 }
 
@@ -146,7 +146,7 @@ func installDownloadedObject(ctx *baseOsMgrContext, contentID uuid.UUID, finalOb
 		proceed bool
 	)
 
-	log.Infof("installDownloadedObject(%s, %v)",
+	log.Functionf("installDownloadedObject(%s, %v)",
 		contentID, ctsPtr.State)
 
 	if ctsPtr.State != types.LOADED {
@@ -157,7 +157,7 @@ func installDownloadedObject(ctx *baseOsMgrContext, contentID uuid.UUID, finalOb
 		log.Fatalf("XXX no image ID for LOADED %s",
 			contentID)
 	}
-	log.Infof("For %s reference ID for LOADED: %s",
+	log.Functionf("For %s reference ID for LOADED: %s",
 		contentID, refID)
 
 	// make sure we have a proper final destination point
@@ -173,7 +173,7 @@ func installDownloadedObject(ctx *baseOsMgrContext, contentID uuid.UUID, finalOb
 	// check if we have a result
 	wres := ctx.worker.Pop(contentID.String())
 	if wres != nil {
-		log.Infof("installDownloadedObject(%s): InstallWorkResult found", contentID)
+		log.Functionf("installDownloadedObject(%s): InstallWorkResult found", contentID)
 		if wres.Error != nil {
 			err := fmt.Errorf("installDownloadedObject(%s): InstallWorkResult error, exception while installing: %v", contentID, wres.Error)
 			log.Errorf(err.Error())
@@ -192,6 +192,6 @@ func installDownloadedObject(ctx *baseOsMgrContext, contentID uuid.UUID, finalOb
 	// do this as a background task
 	// XXX called twice!
 	AddWorkInstall(ctx, contentID.String(), refID, finalObjDir)
-	log.Infof("installDownloadedObject(%s) worker started", contentID)
+	log.Functionf("installDownloadedObject(%s) worker started", contentID)
 	return changed, proceed, nil
 }

--- a/pkg/pillar/cmd/baseosmgr/handlevolumemgr.go
+++ b/pkg/pillar/cmd/baseosmgr/handlevolumemgr.go
@@ -11,27 +11,27 @@ import (
 
 // MaybeAddContentTreeConfig makes sure we have a ContentTreeConfig
 func MaybeAddContentTreeConfig(ctx *baseOsMgrContext, ctc *types.ContentTreeConfig) bool {
-	log.Infof("MaybeAddContentTreeConfig for %s", ctc.Key())
+	log.Functionf("MaybeAddContentTreeConfig for %s", ctc.Key())
 	m := lookupContentTreeConfig(ctx, ctc.Key())
 	if m != nil {
-		log.Infof("Content tree config exists for %s", ctc.Key())
+		log.Functionf("Content tree config exists for %s", ctc.Key())
 		return false
 	}
 	publishContentTreeConfig(ctx, ctc)
-	log.Infof("MaybeAddContentTreeConfig for %s Done", ctc.Key())
+	log.Functionf("MaybeAddContentTreeConfig for %s Done", ctc.Key())
 	return true
 }
 
 // MaybeRemoveContentTreeConfig deletes the ContentTreeConfig
 func MaybeRemoveContentTreeConfig(ctx *baseOsMgrContext, key string) bool {
-	log.Infof("MaybeRemoveContentTreeConfig for %s", key)
+	log.Functionf("MaybeRemoveContentTreeConfig for %s", key)
 	m := lookupContentTreeConfig(ctx, key)
 	if m == nil {
-		log.Infof("MaybeRemoveContentTreeConfig: config doesn't exist for %s", key)
+		log.Functionf("MaybeRemoveContentTreeConfig: config doesn't exist for %s", key)
 		return false
 	}
 	unpublishContentTreeConfig(ctx, key)
-	log.Infof("MaybeRemoveContentTreeConfig for %s Done", key)
+	log.Functionf("MaybeRemoveContentTreeConfig for %s Done", key)
 	return true
 }
 
@@ -40,7 +40,7 @@ func lookupContentTreeConfig(ctx *baseOsMgrContext, key string) *types.ContentTr
 	pub := ctx.pubContentTreeConfig
 	c, _ := pub.Get(key)
 	if c == nil {
-		log.Infof("lookupContentTreeConfig(%s) not found", key)
+		log.Functionf("lookupContentTreeConfig(%s) not found", key)
 		return nil
 	}
 	config := c.(types.ContentTreeConfig)
@@ -52,7 +52,7 @@ func lookupContentTreeStatus(ctx *baseOsMgrContext, key string) *types.ContentTr
 	sub := ctx.subContentTreeStatus
 	st, _ := sub.Get(key)
 	if st == nil {
-		log.Infof("lookupContentTreeStatus(%s) not found", key)
+		log.Functionf("lookupContentTreeStatus(%s) not found", key)
 		return nil
 	}
 	status := st.(types.ContentTreeStatus)
@@ -62,14 +62,14 @@ func lookupContentTreeStatus(ctx *baseOsMgrContext, key string) *types.ContentTr
 func publishContentTreeConfig(ctx *baseOsMgrContext, config *types.ContentTreeConfig) {
 
 	key := config.Key()
-	log.Infof("publishContentTreeConfig(%s)", key)
+	log.Functionf("publishContentTreeConfig(%s)", key)
 	pub := ctx.pubContentTreeConfig
 	pub.Publish(key, *config)
 }
 
 func unpublishContentTreeConfig(ctx *baseOsMgrContext, key string) {
 
-	log.Infof("unpublishContentTreeConfig(%s)", key)
+	log.Functionf("unpublishContentTreeConfig(%s)", key)
 	pub := ctx.pubContentTreeConfig
 	c, _ := pub.Get(key)
 	if c == nil {
@@ -94,20 +94,20 @@ func handleContentTreeStatusImpl(ctxArg interface{}, key string,
 
 	status := statusArg.(types.ContentTreeStatus)
 	ctx := ctxArg.(*baseOsMgrContext)
-	log.Infof("handleContentTreeStatusImpl: key:%s, name:%s",
+	log.Functionf("handleContentTreeStatusImpl: key:%s, name:%s",
 		key, status.DisplayName)
 	if status.ContentSha256 != "" {
 		baseOsHandleStatusUpdateImageSha(ctx, status.ContentSha256)
 	} else {
 		log.Warnf("Unknown content tree: %s", status.ContentID.String())
 	}
-	log.Infof("handleContentTreeStatusImpl done for %s", key)
+	log.Functionf("handleContentTreeStatusImpl done for %s", key)
 }
 
 func handleContentTreeStatusDelete(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
-	log.Infof("handleContentTreeStatusDelete for %s", key)
+	log.Functionf("handleContentTreeStatusDelete for %s", key)
 	ctx := ctxArg.(*baseOsMgrContext)
 	status := statusArg.(types.ContentTreeStatus)
 	if status.ContentSha256 != "" {
@@ -115,5 +115,5 @@ func handleContentTreeStatusDelete(ctxArg interface{}, key string,
 	} else {
 		log.Warnf("Unknown content tree: %s", status.ContentID.String())
 	}
-	log.Infof("handleContentTreeStatusDelete done for %s", key)
+	log.Functionf("handleContentTreeStatusDelete done for %s", key)
 }

--- a/pkg/pillar/cmd/baseosmgr/worker.go
+++ b/pkg/pillar/cmd/baseosmgr/worker.go
@@ -38,7 +38,7 @@ func AddWorkInstall(ctx *baseOsMgrContext, key, ref, target string) {
 	} else if !done {
 		log.Fatalf("Failed to submit work due to queue length for %s", key)
 	}
-	log.Infof("AddWorkInstall(%s) done", key)
+	log.Functionf("AddWorkInstall(%s) done", key)
 }
 
 // installWorker implementation of work.WorkFunction that installs an image to a particular location
@@ -56,9 +56,9 @@ func installWorker(ctxPtr interface{}, w worker.Work) worker.WorkResult {
 		return result
 	}
 
-	log.Infof("installWorker to install %s to %s", d.ref, d.target)
+	log.Functionf("installWorker to install %s to %s", d.ref, d.target)
 	err := zboot.WriteToPartition(log, d.ref, d.target)
-	log.Infof("installWorker DONE install %s to %s: err %s",
+	log.Functionf("installWorker DONE install %s to %s: err %s",
 		d.ref, d.target, err)
 
 	if err != nil {

--- a/pkg/pillar/cmd/client/parseuuid.go
+++ b/pkg/pillar/cmd/client/parseuuid.go
@@ -48,7 +48,7 @@ func parseConfig(configUrl string, resp *http.Response, contents []byte) (uuid.U
 	var name string
 
 	if resp.StatusCode == http.StatusNotModified {
-		log.Debugf("StatusNotModified len %d", len(contents))
+		log.Tracef("StatusNotModified len %d", len(contents))
 		// Return as error since we are not returning any useful values.
 		return devUUID, hardwaremodel, enterprise, name,
 			fmt.Errorf("Unchanged StatusNotModified")
@@ -66,12 +66,12 @@ func parseConfig(configUrl string, resp *http.Response, contents []byte) (uuid.U
 	}
 	hash := configResponse.GetConfigHash()
 	if hash == prevConfigHash {
-		log.Debugf("Same ConfigHash %s len %d", hash, len(contents))
+		log.Tracef("Same ConfigHash %s len %d", hash, len(contents))
 		// Return as error since we are not returning any useful values.
 		return devUUID, hardwaremodel, enterprise, name,
 			fmt.Errorf("Unchanged config hash")
 	}
-	log.Infof("Change in ConfigHash from %s to %s", prevConfigHash, hash)
+	log.Functionf("Change in ConfigHash from %s to %s", prevConfigHash, hash)
 	prevConfigHash = hash
 	config := configResponse.GetConfig()
 
@@ -131,7 +131,7 @@ func readConfigResponseProtoMessage(contents []byte) (*zconfig.ConfigResponse, e
 var prevConfigHash string
 
 func generateConfigRequest() ([]byte, error) {
-	log.Debugf("generateConfigRequest() sending hash %s", prevConfigHash)
+	log.Tracef("generateConfigRequest() sending hash %s", prevConfigHash)
 	configRequest := &zconfig.ConfigRequest{
 		ConfigHash: prevConfigHash,
 	}

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -112,7 +112,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 			log.Fatal(err)
 		}
 	}
-	log.Infof("Starting %s", agentName)
+	log.Functionf("Starting %s", agentName)
 	ctx := diagContext{
 		forever:      *foreverPtr,
 		pacContents:  *pacContentsPtr,
@@ -145,13 +145,13 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	// Wait for initial GlobalConfig
 	for !ctx.GCInitialized {
-		log.Infof("Waiting for GCInitialized")
+		log.Functionf("Waiting for GCInitialized")
 		select {
 		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
 		}
 	}
-	log.Infof("processed GlobalConfig")
+	log.Functionf("processed GlobalConfig")
 
 	server, err := ioutil.ReadFile(types.ServerFileName)
 	if err != nil {
@@ -168,12 +168,12 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		SoftSerial:       hardware.GetSoftSerial(log),
 		AgentName:        agentName,
 	})
-	log.Infof("Diag Get Device Serial %s, Soft Serial %s", zedcloudCtx.DevSerial,
+	log.Functionf("Diag Get Device Serial %s, Soft Serial %s", zedcloudCtx.DevSerial,
 		zedcloudCtx.DevSoftSerial)
 
 	// XXX move to later for Get UUID if available
 
-	log.Infof("diag Run: Use V2 API %v", zedcloudCtx.V2API)
+	log.Functionf("diag Run: Use V2 API %v", zedcloudCtx.V2API)
 
 	if fileExists(types.DeviceCertName) {
 		// Load device cert
@@ -342,7 +342,7 @@ func handleLedBlinkImpl(ctxArg interface{}, key string,
 	ctx.ledCounter = config.BlinkCounter
 	ctx.derivedLedCounter = types.DeriveLedCounter(ctx.ledCounter,
 		ctx.UsableAddressCount)
-	log.Infof("counter %d usableAddr %d, derived %d",
+	log.Functionf("counter %d usableAddr %d, derived %d",
 		ctx.ledCounter, ctx.UsableAddressCount, ctx.derivedLedCounter)
 	// XXX wait in case we get another handle call?
 	// XXX set output sched in ctx; print one second later?
@@ -365,26 +365,26 @@ func handleDNSImpl(ctxArg interface{}, key string,
 	status := statusArg.(types.DeviceNetworkStatus)
 	ctx := ctxArg.(*diagContext)
 	if key != "global" {
-		log.Infof("handleDNSImpl: ignoring %s", key)
+		log.Functionf("handleDNSImpl: ignoring %s", key)
 		return
 	}
-	log.Infof("handleDNSImpl for %s", key)
+	log.Functionf("handleDNSImpl for %s", key)
 	// Since we report test status we compare all fields
 	if cmp.Equal(ctx.DeviceNetworkStatus, status) {
-		log.Infof("handleDNSImpl unchanged")
+		log.Functionf("handleDNSImpl unchanged")
 		return
 	}
-	log.Infof("handleDNSImpl: changed %v",
+	log.Functionf("handleDNSImpl: changed %v",
 		cmp.Diff(ctx.DeviceNetworkStatus, status))
 	*ctx.DeviceNetworkStatus = status
 	newAddrCount := types.CountLocalAddrAnyNoLinkLocal(*ctx.DeviceNetworkStatus)
-	log.Infof("handleDNSImpl %d usable addresses", newAddrCount)
+	log.Functionf("handleDNSImpl %d usable addresses", newAddrCount)
 	if (ctx.UsableAddressCount == 0 && newAddrCount != 0) ||
 		(ctx.UsableAddressCount != 0 && newAddrCount == 0) {
 		ctx.UsableAddressCount = newAddrCount
 		ctx.derivedLedCounter = types.DeriveLedCounter(ctx.ledCounter,
 			ctx.UsableAddressCount)
-		log.Infof("counter %d usableAddr %d, derived %d",
+		log.Functionf("counter %d usableAddr %d, derived %d",
 			ctx.ledCounter, ctx.UsableAddressCount, ctx.derivedLedCounter)
 	}
 
@@ -396,34 +396,34 @@ func handleDNSImpl(ctxArg interface{}, key string,
 	// XXX wait in case we get another handle call?
 	// XXX set output sched in ctx; print one second later?
 	printOutput(ctx)
-	log.Infof("handleDNSImpl done for %s", key)
+	log.Functionf("handleDNSImpl done for %s", key)
 }
 
 func handleDNSDelete(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
-	log.Infof("handleDNSDelete for %s", key)
+	log.Functionf("handleDNSDelete for %s", key)
 	ctx := ctxArg.(*diagContext)
 
 	if key != "global" {
-		log.Infof("handleDNSDelete: ignoring %s", key)
+		log.Functionf("handleDNSDelete: ignoring %s", key)
 		return
 	}
 	*ctx.DeviceNetworkStatus = types.DeviceNetworkStatus{}
 	newAddrCount := types.CountLocalAddrAnyNoLinkLocal(*ctx.DeviceNetworkStatus)
-	log.Infof("handleDNSDelete %d usable addresses", newAddrCount)
+	log.Functionf("handleDNSDelete %d usable addresses", newAddrCount)
 	if (ctx.UsableAddressCount == 0 && newAddrCount != 0) ||
 		(ctx.UsableAddressCount != 0 && newAddrCount == 0) {
 		ctx.UsableAddressCount = newAddrCount
 		ctx.derivedLedCounter = types.DeriveLedCounter(ctx.ledCounter,
 			ctx.UsableAddressCount)
-		log.Infof("counter %d usableAddr %d, derived %d",
+		log.Functionf("counter %d usableAddr %d, derived %d",
 			ctx.ledCounter, ctx.UsableAddressCount, ctx.derivedLedCounter)
 	}
 	// XXX wait in case we get another handle call?
 	// XXX set output sched in ctx; print one second later?
 	printOutput(ctx)
-	log.Infof("handleDNSDelete done for %s", key)
+	log.Functionf("handleDNSDelete done for %s", key)
 }
 
 func handleDPCCreate(ctxArg interface{}, key string,
@@ -442,20 +442,20 @@ func handleDPCImpl(ctxArg interface{}, key string,
 	status := statusArg.(types.DevicePortConfigList)
 	ctx := ctxArg.(*diagContext)
 	if key != "global" {
-		log.Infof("handleDPCImpl: ignoring %s", key)
+		log.Functionf("handleDPCImpl: ignoring %s", key)
 		return
 	}
-	log.Infof("handleDPCImpl for %s", key)
+	log.Functionf("handleDPCImpl for %s", key)
 	if ctx.DevicePortConfigList.MostlyEqual(status) {
 		return
 	}
-	log.Infof("handleDPCImpl: changed %v",
+	log.Functionf("handleDPCImpl: changed %v",
 		cmp.Diff(ctx.DevicePortConfigList, status))
 	*ctx.DevicePortConfigList = status
 	// XXX wait in case we get another handle call?
 	// XXX set output sched in ctx; print one second later?
 	printOutput(ctx)
-	log.Infof("handleDPCImpl done for %s", key)
+	log.Functionf("handleDPCImpl done for %s", key)
 }
 
 // Handles UUID change from process client
@@ -475,11 +475,11 @@ func handleOnboardStatusImpl(ctxArg interface{}, key string,
 	status := statusArg.(types.OnboardingStatus)
 	ctx := ctxArg.(*diagContext)
 	if cmp.Equal(ctx.devUUID, status.DeviceUUID) {
-		log.Infof("handleOnboardStatusImpl no change to %v", ctx.devUUID)
+		log.Functionf("handleOnboardStatusImpl no change to %v", ctx.devUUID)
 		return
 	}
 	ctx.devUUID = status.DeviceUUID
-	log.Infof("handleOnboardStatusImpl changed to %v", ctx.devUUID)
+	log.Functionf("handleOnboardStatusImpl changed to %v", ctx.devUUID)
 	printOutput(ctx)
 }
 
@@ -799,9 +799,9 @@ func tryLookupIP(ctx *diagContext, ifname string) bool {
 			return false
 		}
 		localUDPAddr := net.UDPAddr{IP: localAddr}
-		log.Debugf("tryLookupIP: using intf %s source %v", ifname, localUDPAddr)
+		log.Tracef("tryLookupIP: using intf %s source %v", ifname, localUDPAddr)
 		resolverDial := func(ctx context.Context, network, address string) (net.Conn, error) {
-			log.Debugf("resolverDial %v %v", network, address)
+			log.Tracef("resolverDial %v %v", network, address)
 			d := net.Dialer{LocalAddr: &localUDPAddr}
 			return d.Dial(network, address)
 		}
@@ -813,7 +813,7 @@ func tryLookupIP(ctx *diagContext, ifname string) bool {
 				ifname, ctx.serverName, err)
 			continue
 		}
-		log.Debugf("tryLookupIP: got %d addresses", len(ips))
+		log.Tracef("tryLookupIP: got %d addresses", len(ips))
 		if len(ips) == 0 {
 			fmt.Fprintf(outfile, "ERROR: %s: DNS lookup of %s returned no answers\n",
 				ifname, ctx.serverName)
@@ -887,7 +887,7 @@ var prevConfigHash string
 
 func tryPostUUID(ctx *diagContext, ifname string) bool {
 
-	log.Debugf("tryPostUUID() sending hash %s", prevConfigHash)
+	log.Tracef("tryPostUUID() sending hash %s", prevConfigHash)
 	configRequest := &zconfig.ConfigRequest{
 		ConfigHash: prevConfigHash,
 	}
@@ -946,7 +946,7 @@ func tryPostUUID(ctx *diagContext, ifname string) bool {
 
 func parsePrint(configURL string, resp *http.Response, contents []byte) {
 	if resp.StatusCode == http.StatusNotModified {
-		log.Debugf("StatusNotModified len %d", len(contents))
+		log.Tracef("StatusNotModified len %d", len(contents))
 		return
 	}
 
@@ -962,14 +962,14 @@ func parsePrint(configURL string, resp *http.Response, contents []byte) {
 	}
 	hash := configResponse.GetConfigHash()
 	if hash == prevConfigHash {
-		log.Debugf("Same ConfigHash len %d", len(contents))
+		log.Tracef("Same ConfigHash len %d", len(contents))
 		return
 	}
-	log.Infof("Change in ConfigHash from %s to %s", prevConfigHash, hash)
+	log.Functionf("Change in ConfigHash from %s to %s", prevConfigHash, hash)
 	prevConfigHash = hash
 	config := configResponse.GetConfig()
 	uuidStr := strings.TrimSpace(config.GetId().Uuid)
-	log.Infof("Changed ConfigResponse with uuid %s", uuidStr)
+	log.Functionf("Changed ConfigResponse with uuid %s", uuidStr)
 }
 
 // From zedagent/handleconfig.go
@@ -1145,10 +1145,10 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 
 	ctx := ctxArg.(*diagContext)
 	if key != "global" {
-		log.Infof("handleGlobalConfigImpl: ignoring %s", key)
+		log.Functionf("handleGlobalConfigImpl: ignoring %s", key)
 		return
 	}
-	log.Infof("handleGlobalConfigImpl for %s", key)
+	log.Functionf("handleGlobalConfigImpl for %s", key)
 	var gcp *types.ConfigItemValueMap
 	debug, gcp = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
 		debugOverride, logger)
@@ -1156,7 +1156,7 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 		ctx.globalConfig = gcp
 	}
 	ctx.GCInitialized = true
-	log.Infof("handleGlobalConfigImpl done for %s", key)
+	log.Functionf("handleGlobalConfigImpl done for %s", key)
 }
 
 func handleGlobalConfigDelete(ctxArg interface{}, key string,
@@ -1164,12 +1164,12 @@ func handleGlobalConfigDelete(ctxArg interface{}, key string,
 
 	ctx := ctxArg.(*diagContext)
 	if key != "global" {
-		log.Infof("handleGlobalConfigDelete: ignoring %s", key)
+		log.Functionf("handleGlobalConfigDelete: ignoring %s", key)
 		return
 	}
-	log.Infof("handleGlobalConfigDelete for %s", key)
+	log.Functionf("handleGlobalConfigDelete for %s", key)
 	debug, _ = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
 		debugOverride, logger)
 	*ctx.globalConfig = *types.DefaultConfigItemValueMap()
-	log.Infof("handleGlobalConfigDelete done for %s", key)
+	log.Functionf("handleGlobalConfigDelete done for %s", key)
 }

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -99,7 +99,7 @@ type domainContext struct {
 }
 
 func (ctx *domainContext) publishAssignableAdapters() {
-	log.Infof("Publishing %v", *ctx.assignableAdapters)
+	log.Functionf("Publishing %v", *ctx.assignableAdapters)
 	ctx.pubAssignableAdapters.Publish("global", *ctx.assignableAdapters)
 }
 
@@ -138,7 +138,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
 		log.Fatal(err)
 	}
-	log.Infof("Starting %s with %s hypervisor backend", agentName, hyper.Name())
+	log.Functionf("Starting %s with %s hypervisor backend", agentName, hyper.Name())
 
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(25 * time.Second)
@@ -152,7 +152,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		time.Duration(max))
 
 	if _, err := os.Stat(runDirname); err != nil {
-		log.Debugf("Create %s", runDirname)
+		log.Tracef("Create %s", runDirname)
 		if err := os.MkdirAll(runDirname, 0700); err != nil {
 			log.Fatal(err)
 		}
@@ -369,7 +369,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Parse any existing ConfigIntemValueMap but continue if there
 	// is none
 	for !domainCtx.GCComplete {
-		log.Infof("waiting for GCComplete")
+		log.Functionf("waiting for GCComplete")
 		select {
 		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
@@ -389,10 +389,10 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		}
 		ps.StillRunning(agentName, warningTime, errorTime)
 	}
-	log.Infof("processed GCComplete")
+	log.Functionf("processed GCComplete")
 
 	if !domainCtx.setInitialUsbAccess {
-		log.Infof("GCComplete but not setInitialUsbAccess => first boot")
+		log.Functionf("GCComplete but not setInitialUsbAccess => first boot")
 		// Enable USB keyboard and storage
 		domainCtx.usbAccess = true
 		updateUsbAccess(&domainCtx)
@@ -401,7 +401,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	// Pick up debug aka log level before we start real work
 	for !domainCtx.GCInitialized {
-		log.Infof("waiting for GCInitialized")
+		log.Functionf("waiting for GCInitialized")
 		select {
 		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
@@ -421,22 +421,22 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		}
 		ps.StillRunning(agentName, warningTime, errorTime)
 	}
-	log.Infof("processed GlobalConfig")
+	log.Functionf("processed GlobalConfig")
 
 	// Wait until we have been onboarded aka know our own UUID
 	if err := utils.WaitForOnboarded(ps, log, agentName, warningTime, errorTime); err != nil {
 		log.Fatal(err)
 	}
-	log.Infof("processed onboarded")
+	log.Functionf("processed onboarded")
 
-	log.Infof("Creating %s at %s", "metricsTimerTask", agentlog.GetMyStack())
+	log.Functionf("Creating %s at %s", "metricsTimerTask", agentlog.GetMyStack())
 	go metricsTimerTask(&domainCtx, hyper)
 
 	// Wait for DeviceNetworkStatus to be init so we know the management
 	// ports and then wait for assignableAdapters.
 	for !domainCtx.DNSinitialized {
 
-		log.Infof("Waiting for DeviceNetworkStatus init")
+		log.Functionf("Waiting for DeviceNetworkStatus init")
 		select {
 		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
@@ -482,7 +482,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	// Wait for PhysicalIOAdapters to be initialized.
 	for !domainCtx.assignableAdapters.Initialized {
-		log.Infof("Waiting for AssignableAdapters")
+		log.Functionf("Waiting for AssignableAdapters")
 		select {
 		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
@@ -510,7 +510,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		}
 		ps.StillRunning(agentName, warningTime, errorTime)
 	}
-	log.Infof("Have %d assignable adapters", len(aa.IoBundleList))
+	log.Functionf("Have %d assignable adapters", len(aa.IoBundleList))
 
 	// Subscribe to DomainConfig from zedmanager
 	subDomainConfig, err := ps.NewSubscription(
@@ -581,10 +581,10 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 }
 
 func handleRestart(ctxArg interface{}, done bool) {
-	log.Infof("handleRestart(%v)", done)
+	log.Functionf("handleRestart(%v)", done)
 	ctx := ctxArg.(*domainContext)
 	if done {
-		log.Infof("handleRestart: avoid cleanup")
+		log.Functionf("handleRestart: avoid cleanup")
 		ctx.pubDomainStatus.SignalRestarted()
 		return
 	}
@@ -593,7 +593,7 @@ func handleRestart(ctxArg interface{}, done bool) {
 func publishDomainStatus(ctx *domainContext, status *types.DomainStatus) {
 
 	key := status.Key()
-	log.Debugf("publishDomainStatus(%s)", key)
+	log.Tracef("publishDomainStatus(%s)", key)
 	pub := ctx.pubDomainStatus
 	pub.Publish(key, *status)
 }
@@ -601,7 +601,7 @@ func publishDomainStatus(ctx *domainContext, status *types.DomainStatus) {
 func unpublishDomainStatus(ctx *domainContext, status *types.DomainStatus) {
 
 	key := status.Key()
-	log.Debugf("unpublishDomainStatus(%s)", key)
+	log.Tracef("unpublishDomainStatus(%s)", key)
 	pub := ctx.pubDomainStatus
 	st, _ := pub.Get(key)
 	if st == nil {
@@ -617,7 +617,7 @@ func publishCipherBlockStatus(ctx *domainContext,
 	if ctx == nil || len(status.Key()) == 0 {
 		return
 	}
-	log.Debugf("publishCipherBlockStatus(%s)", key)
+	log.Tracef("publishCipherBlockStatus(%s)", key)
 	pub := ctx.pubCipherBlockStatus
 	pub.Publish(key, status)
 }
@@ -626,7 +626,7 @@ func unpublishCipherBlockStatus(ctx *domainContext, key string) {
 	if ctx == nil || len(key) == 0 {
 		return
 	}
-	log.Debugf("unpublishCipherBlockStatus(%s)", key)
+	log.Tracef("unpublishCipherBlockStatus(%s)", key)
 	pub := ctx.pubCipherBlockStatus
 	st, _ := pub.Get(key)
 	if st == nil {
@@ -662,7 +662,7 @@ func handlersInit() {
 func handleDomainModify(ctxArg interface{}, key string, configArg interface{},
 	oldConfigArg interface{}) {
 
-	log.Infof("handleDomainModify(%s)", key)
+	log.Functionf("handleDomainModify(%s)", key)
 	config := configArg.(types.DomainConfig)
 	h, ok := handlerMap[config.Key()]
 	if !ok {
@@ -670,7 +670,7 @@ func handleDomainModify(ctxArg interface{}, key string, configArg interface{},
 	}
 	select {
 	case h <- Notify{}:
-		log.Infof("handleDomainModify(%s) sent notify", key)
+		log.Functionf("handleDomainModify(%s) sent notify", key)
 	default:
 		// handler is slow
 		log.Warnf("handleDomainModify(%s) NOT sent notify. Slow handler?", key)
@@ -679,7 +679,7 @@ func handleDomainModify(ctxArg interface{}, key string, configArg interface{},
 
 func handleDomainCreate(ctxArg interface{}, key string, configArg interface{}) {
 
-	log.Infof("handleDomainCreate(%s)", key)
+	log.Functionf("handleDomainCreate(%s)", key)
 	ctx := ctxArg.(*domainContext)
 	config := configArg.(types.DomainConfig)
 	h, ok := handlerMap[config.Key()]
@@ -688,12 +688,12 @@ func handleDomainCreate(ctxArg interface{}, key string, configArg interface{}) {
 	}
 	h1 := make(chan Notify, 1)
 	handlerMap[config.Key()] = h1
-	log.Infof("Creating %s at %s", "runHandler", agentlog.GetMyStack())
+	log.Functionf("Creating %s at %s", "runHandler", agentlog.GetMyStack())
 	go runHandler(ctx, key, h1)
 	h = h1
 	select {
 	case h <- Notify{}:
-		log.Infof("handleDomainCreate(%s) sent notify", key)
+		log.Functionf("handleDomainCreate(%s) sent notify", key)
 	default:
 		// Shouldn't happen since we just created channel
 		log.Fatalf("handleDomainCreate(%s) NOT sent notify", key)
@@ -703,7 +703,7 @@ func handleDomainCreate(ctxArg interface{}, key string, configArg interface{}) {
 func handleDomainDelete(ctxArg interface{}, key string,
 	configArg interface{}) {
 
-	log.Infof("handleDomainDelete(%s)", key)
+	log.Functionf("handleDomainDelete(%s)", key)
 	// delete the specific cipher block status
 	ctx := ctxArg.(*domainContext)
 	config := configArg.(types.DomainConfig)
@@ -714,21 +714,21 @@ func handleDomainDelete(ctxArg interface{}, key string,
 	// Do we have a channel/goroutine?
 	h, ok := handlerMap[key]
 	if ok {
-		log.Infof("Closing channel")
+		log.Functionf("Closing channel")
 		close(h)
 		delete(handlerMap, key)
 	} else {
-		log.Debugf("handleDomainDelete: unknown %s", key)
+		log.Tracef("handleDomainDelete: unknown %s", key)
 		return
 	}
-	log.Infof("handleDomainDelete(%s) done", key)
+	log.Functionf("handleDomainDelete(%s) done", key)
 }
 
 // Server for each domU
 // Runs timer every 30 seconds to update status
 func runHandler(ctx *domainContext, key string, c <-chan Notify) {
 
-	log.Infof("runHandler starting")
+	log.Functionf("runHandler starting")
 
 	interval := 30 * time.Second
 	max := float64(interval)
@@ -763,7 +763,7 @@ func runHandler(ctx *domainContext, key string, c <-chan Notify) {
 				closed = true
 			}
 		case <-ticker.C:
-			log.Debugf("runHandler(%s) timer", key)
+			log.Tracef("runHandler(%s) timer", key)
 			status := lookupDomainStatus(ctx, key)
 			if status != nil {
 				verifyStatus(ctx, status)
@@ -771,7 +771,7 @@ func runHandler(ctx *domainContext, key string, c <-chan Notify) {
 			}
 		}
 	}
-	log.Infof("runHandler(%s) DONE", key)
+	log.Functionf("runHandler(%s) DONE", key)
 }
 
 // Check if it is still running
@@ -814,7 +814,7 @@ func verifyStatus(ctx *domainContext, status *types.DomainStatus) {
 			status.ClearError()
 			status.DomainId = domainID
 			status.BootTime = time.Now()
-			log.Infof("Update domainId %d bootTime %s for %s",
+			log.Functionf("Update domainId %d bootTime %s for %s",
 				status.DomainId, status.BootTime.Format(time.RFC3339Nano),
 				status.Key())
 			status.Activated = true
@@ -826,7 +826,7 @@ func verifyStatus(ctx *domainContext, status *types.DomainStatus) {
 				status.Key(), status.DomainId, domainID)
 			status.DomainId = domainID
 			status.BootTime = time.Now()
-			log.Infof("Update domainId %d bootTime %s for %s",
+			log.Functionf("Update domainId %d bootTime %s for %s",
 				status.DomainId, status.BootTime.Format(time.RFC3339Nano),
 				status.Key())
 			publishDomainStatus(ctx, status)
@@ -847,7 +847,7 @@ func maybeRetryBoot(ctx *domainContext, status *types.DomainStatus) {
 		return
 	}
 	if status.Activated && status.BootFailed {
-		log.Infof("maybeRetryBoot(%s) clearing bootFailed since Activated",
+		log.Functionf("maybeRetryBoot(%s) clearing bootFailed since Activated",
 			status.Key())
 		status.BootFailed = false
 		publishDomainStatus(ctx, status)
@@ -872,12 +872,12 @@ func maybeRetryBoot(ctx *domainContext, status *types.DomainStatus) {
 	elapsed := t.Sub(status.ErrorTime)
 	timeLimit := time.Duration(ctx.domainBootRetryTime) * time.Second
 	if elapsed < timeLimit {
-		log.Infof("maybeRetryBoot(%s) %d remaining",
+		log.Functionf("maybeRetryBoot(%s) %d remaining",
 			status.Key(),
 			(timeLimit-elapsed)/time.Second)
 		return
 	}
-	log.Infof("maybeRetryBoot(%s) after %s at %v",
+	log.Functionf("maybeRetryBoot(%s) after %s at %v",
 		status.Key(), status.Error, status.ErrorTime)
 
 	status.ClearError()
@@ -897,7 +897,7 @@ func maybeRetryBoot(ctx *domainContext, status *types.DomainStatus) {
 	status.BootFailed = false
 	doActivateTail(ctx, status, domainID)
 	publishDomainStatus(ctx, status)
-	log.Infof("maybeRetryBoot(%s) DONE for %s",
+	log.Functionf("maybeRetryBoot(%s) DONE for %s",
 		status.Key(), status.DisplayName)
 }
 
@@ -908,7 +908,7 @@ func maybeRetryAdapters(ctx *domainContext, status *types.DomainStatus) {
 		return
 	}
 	if status.Activated && status.AdaptersFailed {
-		log.Infof("maybeRetryAdapters(%s) clearing adaptersFailed since Activated",
+		log.Functionf("maybeRetryAdapters(%s) clearing adaptersFailed since Activated",
 			status.Key())
 		status.AdaptersFailed = false
 		publishDomainStatus(ctx, status)
@@ -921,7 +921,7 @@ func maybeRetryAdapters(ctx *domainContext, status *types.DomainStatus) {
 			status.Key())
 		return
 	}
-	log.Infof("maybeRetryAdapters(%s) after %s at %v",
+	log.Functionf("maybeRetryAdapters(%s) after %s at %v",
 		status.Key(), status.Error, status.ErrorTime)
 
 	if err := configAdapters(ctx, *config); err != nil {
@@ -948,7 +948,7 @@ func maybeRetryAdapters(ctx *domainContext, status *types.DomainStatus) {
 	}
 	// work done
 	publishDomainStatus(ctx, status)
-	log.Infof("maybeRetryAdapters(%s) DONE for %s",
+	log.Functionf("maybeRetryAdapters(%s) DONE for %s",
 		status.Key(), status.DisplayName)
 }
 
@@ -958,7 +958,7 @@ func lookupDomainStatus(ctx *domainContext, key string) *types.DomainStatus {
 	pub := ctx.pubDomainStatus
 	st, _ := pub.Get(key)
 	if st == nil {
-		log.Infof("lookupDomainStatus(%s) not found", key)
+		log.Functionf("lookupDomainStatus(%s) not found", key)
 		return nil
 	}
 	status := st.(types.DomainStatus)
@@ -970,7 +970,7 @@ func lookupDomainConfig(ctx *domainContext, key string) *types.DomainConfig {
 	sub := ctx.subDomainConfig
 	c, _ := sub.Get(key)
 	if c == nil {
-		log.Infof("lookupDomainConfig(%s) not found", key)
+		log.Functionf("lookupDomainConfig(%s) not found", key)
 		return nil
 	}
 	config := c.(types.DomainConfig)
@@ -979,9 +979,9 @@ func lookupDomainConfig(ctx *domainContext, key string) *types.DomainConfig {
 
 func handleCreate(ctx *domainContext, key string, config *types.DomainConfig) {
 
-	log.Infof("handleCreate(%v) for %s",
+	log.Functionf("handleCreate(%v) for %s",
 		config.UUIDandVersion, config.DisplayName)
-	log.Debugf("DomainConfig %+v", config)
+	log.Tracef("DomainConfig %+v", config)
 	// Name of Xen domain must be unique; uniqify AppNum
 	name := config.DisplayName + "." + strconv.Itoa(config.AppNum)
 
@@ -1005,7 +1005,7 @@ func handleCreate(ctx *domainContext, key string, config *types.DomainConfig) {
 	status.VifList = checkIfEmu(status.VifList)
 
 	publishDomainStatus(ctx, &status)
-	log.Infof("handleCreate(%v) set domainName %s for %s",
+	log.Functionf("handleCreate(%v) set domainName %s for %s",
 		config.UUIDandVersion, status.DomainName,
 		config.DisplayName)
 
@@ -1043,7 +1043,7 @@ func handleCreate(ctx *domainContext, key string, config *types.DomainConfig) {
 	// work done
 	status.PendingAdd = false
 	publishDomainStatus(ctx, &status)
-	log.Infof("handleCreate(%v) DONE for %s",
+	log.Functionf("handleCreate(%v) DONE for %s",
 		config.UUIDandVersion, config.DisplayName)
 }
 
@@ -1054,7 +1054,7 @@ func cleanupAdapters(ctx *domainContext, ioAdapterList []types.IoAdapter,
 	publishAssignableAdapters := false
 	// Look for any adapters used by us and clear UsedByUUID
 	for _, adapter := range ioAdapterList {
-		log.Debugf("cleanupAdapters processing adapter %d %s",
+		log.Tracef("cleanupAdapters processing adapter %d %s",
 			adapter.Type, adapter.Name)
 		list := ctx.assignableAdapters.LookupIoBundleAny(adapter.Name)
 		if len(list) == 0 {
@@ -1064,7 +1064,7 @@ func cleanupAdapters(ctx *domainContext, ioAdapterList []types.IoAdapter,
 			if ib.UsedByUUID != myUuid {
 				continue
 			}
-			log.Infof("cleanupAdapters clearing uuid for adapter %d %s member %s",
+			log.Functionf("cleanupAdapters clearing uuid for adapter %d %s member %s",
 				adapter.Type, adapter.Name, ib.Phylabel)
 			ib.UsedByUUID = nilUUID
 			publishAssignableAdapters = true
@@ -1084,7 +1084,7 @@ func doAssignIoAdaptersToDomain(ctx *domainContext, config types.DomainConfig,
 	var assignmentsPci []string
 	var assignmentsUsb []string
 	for _, adapter := range config.IoAdapterList {
-		log.Debugf("doAssignIoAdaptersToDomain processing adapter %d %s",
+		log.Tracef("doAssignIoAdaptersToDomain processing adapter %d %s",
 			adapter.Type, adapter.Name)
 
 		aa := ctx.assignableAdapters
@@ -1112,11 +1112,11 @@ func doAssignIoAdaptersToDomain(ctx *domainContext, config types.DomainConfig,
 				continue
 			}
 			if ib.UsbAddr != "" {
-				log.Infof("Assigning %s (%s) to %s",
+				log.Functionf("Assigning %s (%s) to %s",
 					ib.Phylabel, ib.UsbAddr, status.DomainName)
 				assignmentsUsb = addNoDuplicate(assignmentsUsb, ib.UsbAddr)
 			} else if ib.PciLong != "" && ctx.usbAccess && !ib.IsPCIBack {
-				log.Infof("Assigning %s (%s) to %s",
+				log.Functionf("Assigning %s (%s) to %s",
 					ib.Phylabel, ib.PciLong, status.DomainName)
 				assignmentsPci = addNoDuplicate(assignmentsPci, ib.PciLong)
 				ib.IsPCIBack = true
@@ -1148,7 +1148,7 @@ func doAssignIoAdaptersToDomain(ctx *domainContext, config types.DomainConfig,
 func doActivate(ctx *domainContext, config types.DomainConfig,
 	status *types.DomainStatus) {
 
-	log.Infof("doActivate(%v) for %s",
+	log.Functionf("doActivate(%v) for %s",
 		config.UUIDandVersion, config.DisplayName)
 	if status.AdaptersFailed || status.PendingModify {
 		if err := configAdapters(ctx, config); err != nil {
@@ -1280,10 +1280,10 @@ func doActivate(ctx *domainContext, config types.DomainConfig,
 func doActivateTail(ctx *domainContext, status *types.DomainStatus,
 	domainID int) {
 
-	log.Infof("created domainID %d for %s", domainID, status.DomainName)
+	log.Functionf("created domainID %d for %s", domainID, status.DomainName)
 	status.DomainId = domainID
 	status.BootTime = time.Now()
-	log.Infof("Set domainId %d bootTime %s for %s",
+	log.Functionf("Set domainId %d bootTime %s for %s",
 		status.DomainId, status.BootTime.Format(time.RFC3339Nano),
 		status.Key())
 	status.State = types.BOOTING
@@ -1312,32 +1312,32 @@ func doActivateTail(ctx *domainContext, status *types.DomainStatus,
 		status.State = state
 		status.Activated = false
 		status.SetErrorNow(err.Error())
-		log.Infof("doActivateTail(%v) failed for %s: %s",
+		log.Functionf("doActivateTail(%v) failed for %s: %s",
 			status.UUIDandVersion, status.DisplayName, err)
 		return
 	}
 	if err == nil && domainID != status.DomainId {
 		status.DomainId = domainID
 		status.BootTime = time.Now()
-		log.Infof("Update domainId %d bootTime %s for %s",
+		log.Functionf("Update domainId %d bootTime %s for %s",
 			status.DomainId, status.BootTime.Format(time.RFC3339Nano),
 			status.Key())
 	}
 	status.Activated = true
-	log.Infof("doActivateTail(%v) done for %s",
+	log.Functionf("doActivateTail(%v) done for %s",
 		status.UUIDandVersion, status.DisplayName)
 }
 
 // shutdown and wait for the domain to go away; if that fails destroy and wait
 func doInactivate(ctx *domainContext, status *types.DomainStatus, impatient bool) {
 
-	log.Infof("doInactivate(%v) for %s",
+	log.Functionf("doInactivate(%v) for %s",
 		status.UUIDandVersion, status.DisplayName)
 	domainID, _, err := hyper.Task(status).Info(status.DomainName, status.DomainId)
 	if err == nil && domainID != status.DomainId {
 		status.DomainId = domainID
 		status.BootTime = time.Now()
-		log.Infof("Update domainId %d bootTime %s for %s",
+		log.Functionf("Update domainId %d bootTime %s for %s",
 			status.DomainId, status.BootTime.Format(time.RFC3339Nano),
 			status.Key())
 	}
@@ -1369,7 +1369,7 @@ func doInactivate(ctx *domainContext, status *types.DomainStatus, impatient bool
 					status.DomainName, err)
 			} else {
 				// Wait for the domain to go away
-				log.Infof("doInactivate(%v) for %s: waiting for domain to shutdown",
+				log.Functionf("doInactivate(%v) for %s: waiting for domain to shutdown",
 					status.UUIDandVersion, status.DisplayName)
 			}
 			gone := waitForDomainGone(*status, shortDelay)
@@ -1382,7 +1382,7 @@ func doInactivate(ctx *domainContext, status *types.DomainStatus, impatient bool
 					status.DomainName, err)
 			} else {
 				// Wait for the domain to go away
-				log.Infof("doInactivate(%v) for %s: waiting for domain to poweroff",
+				log.Functionf("doInactivate(%v) for %s: waiting for domain to poweroff",
 					status.UUIDandVersion, status.DisplayName)
 			}
 			gone = waitForDomainGone(*status, maxDelay)
@@ -1397,7 +1397,7 @@ func doInactivate(ctx *domainContext, status *types.DomainStatus, impatient bool
 					status.DomainName, err)
 			} else {
 				// Wait for the domain to go away
-				log.Infof("doInactivate(%v) for %s: waiting for domain to shutdown",
+				log.Functionf("doInactivate(%v) for %s: waiting for domain to shutdown",
 					status.UUIDandVersion, status.DisplayName)
 			}
 			gone := waitForDomainGone(*status, maxDelay)
@@ -1410,7 +1410,7 @@ func doInactivate(ctx *domainContext, status *types.DomainStatus, impatient bool
 					status.DomainName, err)
 			} else {
 				// Wait for the domain to go away
-				log.Infof("doInactivate(%v) for %s: waiting for domain to poweroff",
+				log.Functionf("doInactivate(%v) for %s: waiting for domain to poweroff",
 					status.UUIDandVersion, status.DisplayName)
 			}
 			gone = waitForDomainGone(*status, maxDelay)
@@ -1429,7 +1429,7 @@ func doInactivate(ctx *domainContext, status *types.DomainStatus, impatient bool
 			log.Errorf("Failed to delete domain %s (%v)", status.DomainName, err)
 		}
 		// Even if destroy failed we wait again
-		log.Infof("doInactivate(%v) for %s: waiting for domain to be destroyed",
+		log.Functionf("doInactivate(%v) for %s: waiting for domain to be destroyed",
 			status.UUIDandVersion, status.DisplayName)
 
 		gone := waitForDomainGone(*status, maxDelay)
@@ -1451,7 +1451,7 @@ func doInactivate(ctx *domainContext, status *types.DomainStatus, impatient bool
 
 	pciUnassign(ctx, status, false)
 
-	log.Infof("doInactivate(%v) done for %s",
+	log.Functionf("doInactivate(%v) done for %s",
 		status.UUIDandVersion, status.DisplayName)
 }
 
@@ -1459,13 +1459,13 @@ func doInactivate(ctx *domainContext, status *types.DomainStatus, impatient bool
 func pciUnassign(ctx *domainContext, status *types.DomainStatus,
 	ignoreErrors bool) {
 
-	log.Infof("pciUnassign(%v, %v) for %s",
+	log.Functionf("pciUnassign(%v, %v) for %s",
 		status.UUIDandVersion, ignoreErrors, status.DisplayName)
 
 	// Unassign any pci devices but keep UsedByUUID set and keep in status
 	var assignments []string
 	for _, adapter := range status.IoAdapterList {
-		log.Debugf("doInactivate processing adapter %d %s",
+		log.Tracef("doInactivate processing adapter %d %s",
 			adapter.Type, adapter.Name)
 		aa := ctx.assignableAdapters
 		list := aa.LookupIoBundleAny(adapter.Name)
@@ -1479,7 +1479,7 @@ func pciUnassign(ctx *domainContext, status *types.DomainStatus,
 				continue
 			}
 			if ib.UsedByUUID != status.UUIDandVersion.UUID {
-				log.Infof("doInactivate IoBundle not ours by %s: %d %s for %s",
+				log.Functionf("doInactivate IoBundle not ours by %s: %d %s for %s",
 					ib.UsedByUUID, adapter.Type, adapter.Name,
 					status.DomainName)
 				continue
@@ -1492,7 +1492,7 @@ func pciUnassign(ctx *domainContext, status *types.DomainStatus,
 				log.Warnf("doInactivate lookup missing: %d %s for %s",
 					adapter.Type, adapter.Name, status.DomainName)
 			} else if ctx.usbAccess && ib.IsPCIBack {
-				log.Infof("Removing %s (%s) from %s",
+				log.Functionf("Removing %s (%s) from %s",
 					ib.Phylabel, ib.PciLong, status.DomainName)
 				assignments = addNoDuplicate(assignments, ib.PciLong)
 
@@ -1515,7 +1515,7 @@ func pciUnassign(ctx *domainContext, status *types.DomainStatus,
 func configToStatus(ctx *domainContext, config types.DomainConfig,
 	status *types.DomainStatus) error {
 
-	log.Infof("configToStatus(%v) for %s",
+	log.Functionf("configToStatus(%v) for %s",
 		config.UUIDandVersion, config.DisplayName)
 	status.DiskStatusList = make([]types.DiskStatus,
 		len(config.DiskConfigList))
@@ -1563,13 +1563,13 @@ func configToStatus(ctx *domainContext, config types.DomainConfig,
 // XXX rename to reserveAdapters?
 func configAdapters(ctx *domainContext, config types.DomainConfig) error {
 
-	log.Infof("configAdapters(%v) for %s",
+	log.Functionf("configAdapters(%v) for %s",
 		config.UUIDandVersion, config.DisplayName)
 
 	defer ctx.publishAssignableAdapters()
 
 	for _, adapter := range config.IoAdapterList {
-		log.Debugf("configAdapters processing adapter %d %s",
+		log.Tracef("configAdapters processing adapter %d %s",
 			adapter.Type, adapter.Name)
 		// Lookup to make sure adapter exists on this device
 		list := ctx.assignableAdapters.LookupIoBundleAny(adapter.Name)
@@ -1596,7 +1596,7 @@ func configAdapters(ctx *domainContext, config types.DomainConfig) error {
 			if ibp == nil {
 				continue
 			}
-			log.Debugf("configAdapters setting uuid %s for adapter %d %s member %s",
+			log.Tracef("configAdapters setting uuid %s for adapter %d %s member %s",
 				config.Key(), adapter.Type, adapter.Name, ibp.Phylabel)
 			ibp.UsedByUUID = config.UUIDandVersion.UUID
 		}
@@ -1621,7 +1621,7 @@ func addNoDuplicate(list []string, add string) []string {
 func handleModify(ctx *domainContext, key string,
 	config *types.DomainConfig, status *types.DomainStatus) {
 
-	log.Infof("handleModify(%v) activate %t for %s",
+	log.Functionf("handleModify(%v) activate %t for %s",
 		config.UUIDandVersion, config.Activate, config.DisplayName)
 
 	status.PendingModify = true
@@ -1629,14 +1629,14 @@ func handleModify(ctx *domainContext, key string,
 
 	changed := false
 	if config.Activate && !status.Activated {
-		log.Infof("handleModify(%v) activating for %s",
+		log.Functionf("handleModify(%v) activating for %s",
 			config.UUIDandVersion, config.DisplayName)
 		// AppNum could have changed if we did not already Activate
 		name := config.DisplayName + "." + strconv.Itoa(config.AppNum)
 		if status.DomainName != name {
 			status.DomainName = name
 			status.AppNum = config.AppNum
-			log.Infof("handleModify(%v) set domainName %s for %s",
+			log.Functionf("handleModify(%v) set domainName %s for %s",
 				config.UUIDandVersion, status.DomainName,
 				config.DisplayName)
 		}
@@ -1646,7 +1646,7 @@ func handleModify(ctx *domainContext, key string,
 		// This has the effect of trying a boot again for any
 		// handleModify after an error.
 		if status.HasError() {
-			log.Infof("handleModify(%v) ignoring existing error for %s",
+			log.Functionf("handleModify(%v) ignoring existing error for %s",
 				config.UUIDandVersion, config.DisplayName)
 			status.ClearError()
 			publishDomainStatus(ctx, status)
@@ -1665,10 +1665,10 @@ func handleModify(ctx *domainContext, key string,
 		doActivate(ctx, *config, status)
 		changed = true
 	} else if !config.Activate {
-		log.Infof("handleModify(%v) NOT activating for %s",
+		log.Functionf("handleModify(%v) NOT activating for %s",
 			config.UUIDandVersion, config.DisplayName)
 		if status.HasError() {
-			log.Infof("handleModify(%v) clearing existing error for %s",
+			log.Functionf("handleModify(%v) clearing existing error for %s",
 				config.UUIDandVersion, config.DisplayName)
 			status.ClearError()
 			publishDomainStatus(ctx, status)
@@ -1700,7 +1700,7 @@ func handleModify(ctx *domainContext, key string,
 		// in handleDelete
 		status.PendingModify = false
 		publishDomainStatus(ctx, status)
-		log.Infof("handleModify(%v) DONE for %s",
+		log.Functionf("handleModify(%v) DONE for %s",
 			config.UUIDandVersion, config.DisplayName)
 		return
 	}
@@ -1711,7 +1711,7 @@ func handleModify(ctx *domainContext, key string,
 	// before activation.
 
 	if config.UUIDandVersion.Version == status.UUIDandVersion.Version {
-		log.Infof("Same version %s for %s",
+		log.Functionf("Same version %s for %s",
 			config.UUIDandVersion.Version, key)
 		status.PendingModify = false
 		publishDomainStatus(ctx, status)
@@ -1727,7 +1727,7 @@ func handleModify(ctx *domainContext, key string,
 	status.PendingModify = false
 	status.UUIDandVersion = config.UUIDandVersion
 	publishDomainStatus(ctx, status)
-	log.Infof("handleModify(%v) DONE for %s",
+	log.Functionf("handleModify(%v) DONE for %s",
 		config.UUIDandVersion, config.DisplayName)
 }
 
@@ -1747,7 +1747,7 @@ func checkIfEmu(vifList []types.VifInfo) []types.VifInfo {
 		emuIfname := net.Vif + "-emu"
 		_, err := netlink.LinkByName(emuIfname)
 		if err == nil && net.VifUsed != emuIfname {
-			log.Infof("Found EMU %s and update %s", emuIfname, net.VifUsed)
+			log.Functionf("Found EMU %s and update %s", emuIfname, net.VifUsed)
 			net.VifUsed = emuIfname
 		}
 		retList = append(retList, net)
@@ -1761,7 +1761,7 @@ func waitForDomainGone(status types.DomainStatus, maxDelay time.Duration) bool {
 	delay := time.Second
 	var waited time.Duration
 	for {
-		log.Infof("waitForDomainGone(%v) for %s: waiting for %v",
+		log.Functionf("waitForDomainGone(%v) for %s: waiting for %v",
 			status.UUIDandVersion, status.DisplayName, delay)
 		if delay != 0 {
 			time.Sleep(delay)
@@ -1769,7 +1769,7 @@ func waitForDomainGone(status types.DomainStatus, maxDelay time.Duration) bool {
 		}
 		_, state, err := hyper.Task(&status).Info(status.DomainName, status.DomainId)
 		if err != nil || state == types.HALTED {
-			log.Infof("waitForDomainGone(%v) for %s: domain is gone",
+			log.Functionf("waitForDomainGone(%v) for %s: domain is gone",
 				status.UUIDandVersion, status.DisplayName)
 			gone = true
 			break
@@ -1791,7 +1791,7 @@ func waitForDomainGone(status types.DomainStatus, maxDelay time.Duration) bool {
 
 func handleDelete(ctx *domainContext, key string, status *types.DomainStatus) {
 
-	log.Infof("handleDelete(%v) for %s",
+	log.Functionf("handleDelete(%v) for %s",
 		status.UUIDandVersion, status.DisplayName)
 
 	status.PendingDelete = true
@@ -1823,7 +1823,7 @@ func handleDelete(ctx *domainContext, key string, status *types.DomainStatus) {
 	publishDomainStatus(ctx, status)
 	// Write out what we modified to DomainStatus aka delete
 	unpublishDomainStatus(ctx, status)
-	log.Infof("handleDelete(%v) DONE for %s",
+	log.Functionf("handleDelete(%v) DONE for %s",
 		status.UUIDandVersion, status.DisplayName)
 }
 
@@ -1837,10 +1837,10 @@ func DomainCreate(ctx *domainContext, status types.DomainStatus) (int, error) {
 	)
 
 	filename := xenCfgFilename(status.AppNum)
-	log.Infof("DomainCreate %s ... xenCfgFilename - %s", status.DomainName, filename)
+	log.Functionf("DomainCreate %s ... xenCfgFilename - %s", status.DomainName, filename)
 
 	// Now create a domain
-	log.Infof("Creating domain with the config - %s", filename)
+	log.Functionf("Creating domain with the config - %s", filename)
 	config := lookupDomainConfig(ctx, status.Key())
 	if config == nil {
 		// Odd to have status but no config
@@ -1856,10 +1856,10 @@ func DomainCreate(ctx *domainContext, status types.DomainStatus) (int, error) {
 func DomainShutdown(status types.DomainStatus, force bool) error {
 
 	var err error
-	log.Infof("DomainShutdown force-%v %s %d", force, status.DomainName, status.DomainId)
+	log.Functionf("DomainShutdown force-%v %s %d", force, status.DomainName, status.DomainId)
 
 	// Stop the domain
-	log.Infof("Stopping domain - %s", status.DomainName)
+	log.Functionf("Stopping domain - %s", status.DomainName)
 	err = hyper.Task(&status).Stop(status.DomainName, status.DomainId, force)
 
 	return err
@@ -1881,39 +1881,39 @@ func handleDNSImpl(ctxArg interface{}, key string,
 	status := statusArg.(types.DeviceNetworkStatus)
 	ctx := ctxArg.(*domainContext)
 	if key != "global" {
-		log.Infof("handleDNSImpl: ignoring %s", key)
+		log.Functionf("handleDNSImpl: ignoring %s", key)
 		return
 	}
 	// Ignore test status and timestamps
 	// Compare Testing to save its updated value which is used by us
 	if ctx.deviceNetworkStatus.MostlyEqual(status) &&
 		ctx.deviceNetworkStatus.Testing == status.Testing {
-		log.Infof("handleDNSImpl unchanged")
+		log.Functionf("handleDNSImpl unchanged")
 		ctx.DNSinitialized = true
 		return
 	}
-	log.Infof("handleDNSImpl: changed %v",
+	log.Functionf("handleDNSImpl: changed %v",
 		cmp.Diff(ctx.deviceNetworkStatus, status))
 	// Even if Testing is set we look at it for pciback transitions to
 	// bring things out of pciback (but not to add to pciback)
 	ctx.deviceNetworkStatus = status
 	checkAndSetIoBundleAll(ctx)
 	ctx.DNSinitialized = true
-	log.Infof("handleDNSImpl done for %s", key)
+	log.Functionf("handleDNSImpl done for %s", key)
 }
 
 func handleDNSDelete(ctxArg interface{}, key string, statusArg interface{}) {
 
 	ctx := ctxArg.(*domainContext)
 	if key != "global" {
-		log.Infof("handleDNSDelete: ignoring %s", key)
+		log.Functionf("handleDNSDelete: ignoring %s", key)
 		return
 	}
-	log.Infof("handleDNSDelete for %s", key)
+	log.Functionf("handleDNSDelete for %s", key)
 	ctx.deviceNetworkStatus = types.DeviceNetworkStatus{}
 	ctx.DNSinitialized = false
 	checkAndSetIoBundleAll(ctx)
-	log.Infof("handleDNSDelete done for %s", key)
+	log.Functionf("handleDNSDelete done for %s", key)
 }
 
 func handleGlobalConfigCreate(ctxArg interface{}, key string,
@@ -1931,10 +1931,10 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 
 	ctx := ctxArg.(*domainContext)
 	if key != "global" {
-		log.Infof("handleGlobalConfigImpl: ignoring %s", key)
+		log.Functionf("handleGlobalConfigImpl: ignoring %s", key)
 		return
 	}
-	log.Infof("handleGlobalConfigImpl for %s", key)
+	log.Functionf("handleGlobalConfigImpl for %s", key)
 	var gcp *types.ConfigItemValueMap
 	debug, gcp = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
 		debugOverride, logger)
@@ -1955,7 +1955,7 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 		}
 		ctx.GCInitialized = true
 	}
-	log.Infof("handleGlobalConfigImpl done for %s. "+
+	log.Functionf("handleGlobalConfigImpl done for %s. "+
 		"DomainBootRetryTime: %d, usbAccess: %t, metricInterval: %d",
 		key, ctx.domainBootRetryTime, ctx.usbAccess,
 		ctx.metricInterval)
@@ -1966,13 +1966,13 @@ func handleGlobalConfigDelete(ctxArg interface{}, key string,
 
 	ctx := ctxArg.(*domainContext)
 	if key != "global" {
-		log.Infof("handleGlobalConfigDelete: ignoring %s", key)
+		log.Functionf("handleGlobalConfigDelete: ignoring %s", key)
 		return
 	}
-	log.Infof("handleGlobalConfigDelete for %s", key)
+	log.Functionf("handleGlobalConfigDelete for %s", key)
 	debug, _ = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
 		debugOverride, logger)
-	log.Infof("handleGlobalConfigDelete done for %s", key)
+	log.Functionf("handleGlobalConfigDelete done for %s", key)
 }
 
 // This gets called once the GlobalConfig subscription/directory has been
@@ -1982,7 +1982,7 @@ func handleGlobalConfigDelete(ctxArg interface{}, key string,
 func handleGlobalConfigSync(ctxArg interface{}, done bool) {
 
 	ctx := ctxArg.(*domainContext)
-	log.Infof("handleGlobalConfigSync %t", done)
+	log.Functionf("handleGlobalConfigSync %t", done)
 	if done {
 		ctx.GCComplete = true
 	}
@@ -2011,10 +2011,10 @@ func getCloudInitUserData(ctx *domainContext,
 			}
 			return decBlock, nil
 		}
-		log.Infof("%s, domain config cipherblock decryption successful", dc.Key())
+		log.Functionf("%s, domain config cipherblock decryption successful", dc.Key())
 		return decBlock, nil
 	}
-	log.Infof("%s, domain config cipherblock not present", dc.Key())
+	log.Functionf("%s, domain config cipherblock not present", dc.Key())
 	decBlock := types.EncryptionBlock{}
 	decBlock.ProtectedUserData = *dc.CloudInitUserData
 	if decBlock.ProtectedUserData != "" {
@@ -2131,7 +2131,7 @@ func createCloudInitISO(ctx *domainContext,
 
 // mkisofs -output %s -volid cidata -joliet -rock %s, fileName, dir
 func mkisofs(output string, dir string) error {
-	log.Infof("mkisofs(%s, %s)", output, dir)
+	log.Functionf("mkisofs(%s, %s)", output, dir)
 
 	cmd := "mkisofs"
 	args := []string{
@@ -2143,7 +2143,7 @@ func mkisofs(output string, dir string) error {
 		"-rock",
 		dir,
 	}
-	log.Infof("Calling command %s %v\n", cmd, args)
+	log.Functionf("Calling command %s %v\n", cmd, args)
 	stdoutStderr, err := base.Exec(log, cmd, args...).CombinedOutput()
 	if err != nil {
 		errStr := fmt.Sprintf("mkisofs failed: %s",
@@ -2151,7 +2151,7 @@ func mkisofs(output string, dir string) error {
 		log.Errorln(errStr)
 		return errors.New(errStr)
 	}
-	log.Infof("mkisofs done")
+	log.Functionf("mkisofs done")
 	return nil
 }
 
@@ -2171,7 +2171,7 @@ func handlePhysicalIOAdapterListImpl(ctxArg interface{}, key string,
 	ctx := ctxArg.(*domainContext)
 	phyIOAdapterList := configArg.(types.PhysicalIOAdapterList)
 	aa := ctx.assignableAdapters
-	log.Infof("handlePhysicalIOAdapterListImpl: current len %d, update %+v",
+	log.Functionf("handlePhysicalIOAdapterListImpl: current len %d, update %+v",
 		len(aa.IoBundleList), phyIOAdapterList)
 
 	if !aa.Initialized {
@@ -2184,15 +2184,15 @@ func handlePhysicalIOAdapterListImpl(ctxArg interface{}, key string,
 		}
 		// Now initialize each entry
 		for _, ib := range aa.IoBundleList {
-			log.Infof("handlePhysicalIOAdapterListImpl: new Adapter: %+v",
+			log.Functionf("handlePhysicalIOAdapterListImpl: new Adapter: %+v",
 				ib)
 			handleIBCreate(ctx, ib)
 		}
-		log.Infof("handlePhysicalIOAdapterListImpl: initialized to get len %d",
+		log.Functionf("handlePhysicalIOAdapterListImpl: initialized to get len %d",
 			len(aa.IoBundleList))
 		aa.Initialized = true
 		ctx.publishAssignableAdapters()
-		log.Infof("handlePhysicalIOAdapterListImpl() done len %d",
+		log.Functionf("handlePhysicalIOAdapterListImpl() done len %d",
 			len(aa.IoBundleList))
 		return
 	}
@@ -2216,21 +2216,21 @@ func handlePhysicalIOAdapterListImpl(ctxArg interface{}, key string,
 		ib := *types.IoBundleFromPhyAdapter(log, phyAdapter)
 		currentIbPtr := aa.LookupIoBundlePhylabel(phyAdapter.Phylabel)
 		if currentIbPtr == nil {
-			log.Infof("handlePhysicalIOAdapterListImpl: Adapter %s "+
+			log.Functionf("handlePhysicalIOAdapterListImpl: Adapter %s "+
 				"added. %+v", phyAdapter.Phylabel, ib)
 			handleIBCreate(ctx, ib)
 		} else if currentIbPtr.HasAdapterChanged(log, phyAdapter) {
-			log.Infof("handlePhysicalIOAdapterListImpl: Adapter %s "+
+			log.Functionf("handlePhysicalIOAdapterListImpl: Adapter %s "+
 				"changed. Current: %+v, New: %+v", phyAdapter.Phylabel,
 				*currentIbPtr, ib)
 			handleIBModify(ctx, ib)
 		} else {
-			log.Infof("handlePhysicalIOAdapterListImpl: Adapter %s "+
+			log.Functionf("handlePhysicalIOAdapterListImpl: Adapter %s "+
 				"- No Change", phyAdapter.Phylabel)
 		}
 	}
 	ctx.publishAssignableAdapters()
-	log.Infof("handlePhysicalIOAdapterListImpl() done len %d",
+	log.Functionf("handlePhysicalIOAdapterListImpl() done len %d",
 		len(aa.IoBundleList))
 }
 
@@ -2239,17 +2239,17 @@ func handlePhysicalIOAdapterListDelete(ctxArg interface{},
 
 	phyAdapterList := value.(types.PhysicalIOAdapterList)
 	ctx := ctxArg.(*domainContext)
-	log.Infof("handlePhysicalIOAdapterListDelete: ALL PhysicalIoAdapters " +
+	log.Functionf("handlePhysicalIOAdapterListDelete: ALL PhysicalIoAdapters " +
 		"deleted")
 
 	for indx := range phyAdapterList.AdapterList {
 		phylabel := phyAdapterList.AdapterList[indx].Phylabel
-		log.Infof("handlePhysicalIOAdapterListDelete: Deleting Adapter %s",
+		log.Functionf("handlePhysicalIOAdapterListDelete: Deleting Adapter %s",
 			phylabel)
 		handleIBDelete(ctx, phylabel)
 	}
 	ctx.publishAssignableAdapters()
-	log.Infof("handlePhysicalIOAdapterListDelete done")
+	log.Functionf("handlePhysicalIOAdapterListDelete done")
 }
 
 // Process new IoBundles. Check if PCI device exists, and check that not
@@ -2257,7 +2257,7 @@ func handlePhysicalIOAdapterListDelete(ctxArg interface{},
 // Assign to pciback
 func handleIBCreate(ctx *domainContext, ib types.IoBundle) {
 
-	log.Infof("handleIBCreate(%d %s %s)", ib.Type, ib.Phylabel, ib.AssignmentGroup)
+	log.Functionf("handleIBCreate(%d %s %s)", ib.Type, ib.Phylabel, ib.AssignmentGroup)
 	aa := ctx.assignableAdapters
 	if err := checkAndSetIoBundle(ctx, &ib, false); err != nil {
 		log.Warnf("Not reporting non-existent PCI device %d %s: %v",
@@ -2282,7 +2282,7 @@ func checkAndSetIoBundleAll(ctx *domainContext) {
 func checkAndSetIoBundle(ctx *domainContext, ib *types.IoBundle,
 	publish bool) error {
 
-	log.Infof("checkAndSetIoBundle(%d %s %s) publish %t",
+	log.Functionf("checkAndSetIoBundle(%d %s %s) publish %t",
 		ib.Type, ib.Phylabel, ib.AssignmentGroup, publish)
 	aa := ctx.assignableAdapters
 	var list []*types.IoBundle
@@ -2299,7 +2299,7 @@ func checkAndSetIoBundle(ctx *domainContext, ib *types.IoBundle,
 			isPort = true
 		}
 	}
-	log.Infof("checkAndSetIoBundle(%d %s %s) isPort %t members %d",
+	log.Functionf("checkAndSetIoBundle(%d %s %s) isPort %t members %d",
 		ib.Type, ib.Phylabel, ib.AssignmentGroup, isPort, len(list))
 	for _, ib := range list {
 		err := checkAndSetIoMember(ctx, ib, isPort, publish)
@@ -2313,7 +2313,7 @@ func checkAndSetIoBundle(ctx *domainContext, ib *types.IoBundle,
 
 func checkAndSetIoMember(ctx *domainContext, ib *types.IoBundle, isPort bool, publish bool) error {
 
-	log.Infof("checkAndSetIoMember(%d %s %s) isPort %t publish %t",
+	log.Functionf("checkAndSetIoMember(%d %s %s) isPort %t publish %t",
 		ib.Type, ib.Phylabel, ib.AssignmentGroup, isPort, publish)
 	aa := ctx.assignableAdapters
 	// Check if part of DevicePortConfig
@@ -2330,10 +2330,10 @@ func checkAndSetIoMember(ctx *domainContext, ib *types.IoBundle, isPort bool, pu
 				ib.UsedByUUID.String())
 
 		} else if ib.IsPCIBack {
-			log.Infof("checkAndSetIoMember(%d %s %s) take back from pciback",
+			log.Functionf("checkAndSetIoMember(%d %s %s) take back from pciback",
 				ib.Type, ib.Phylabel, ib.AssignmentGroup)
 			if ib.PciLong != "" {
-				log.Infof("Removing %s (%s) from pciback",
+				log.Functionf("Removing %s (%s) from pciback",
 					ib.Phylabel, ib.PciLong)
 				err := hyper.PCIRelease(ib.PciLong)
 				if err != nil {
@@ -2367,7 +2367,7 @@ func checkAndSetIoMember(ctx *domainContext, ib *types.IoBundle, isPort bool, pu
 	if ib.Type.IsNet() && ib.MacAddr == "" {
 		ib.MacAddr = getMacAddr(ib.Ifname)
 		changed = true
-		log.Infof("checkAndSetIoMember(%d %s %s) long %s macaddr %s",
+		log.Functionf("checkAndSetIoMember(%d %s %s) long %s macaddr %s",
 			ib.Type, ib.Ifname, ib.AssignmentGroup, ib.PciLong, ib.MacAddr)
 	}
 
@@ -2386,7 +2386,7 @@ func checkAndSetIoMember(ctx *domainContext, ib *types.IoBundle, isPort bool, pu
 	if long != "" {
 		ib.PciLong = long
 		changed = true
-		log.Infof("checkAndSetIoMember(%d %s %s) found %s",
+		log.Functionf("checkAndSetIoMember(%d %s %s) found %s",
 			ib.Type, ib.Phylabel, ib.AssignmentGroup, long)
 
 		// Save somewhat Unique string for debug
@@ -2398,20 +2398,20 @@ func checkAndSetIoMember(ctx *domainContext, ib *types.IoBundle, isPort bool, pu
 		} else {
 			ib.Unique = unique
 			changed = true
-			log.Infof("checkAndSetIoMember(%d %s %s) %s unique %s",
+			log.Functionf("checkAndSetIoMember(%d %s %s) %s unique %s",
 				ib.Type, ib.Phylabel, ib.AssignmentGroup, long, unique)
 		}
 	}
 
 	if !ib.IsPort && !ib.IsPCIBack {
 		if ctx.deviceNetworkStatus.Testing && ib.Type.IsNet() {
-			log.Infof("Not assigning %s (%s) to pciback due to Testing",
+			log.Functionf("Not assigning %s (%s) to pciback due to Testing",
 				ib.Phylabel, ib.PciLong)
 		} else if ctx.usbAccess && isInUsbGroup(*aa, *ib) {
-			log.Infof("Not assigning %s (%s) to pciback due to usbAccess",
+			log.Functionf("Not assigning %s (%s) to pciback due to usbAccess",
 				ib.Phylabel, ib.PciLong)
 		} else if ib.PciLong != "" {
-			log.Infof("Assigning %s (%s) to pciback",
+			log.Functionf("Assigning %s (%s) to pciback",
 				ib.Phylabel, ib.PciLong)
 			err := hyper.PCIReserve(ib.PciLong)
 			if err != nil {
@@ -2496,7 +2496,7 @@ func checkIoBundle(ctx *domainContext, ib *types.IoBundle) error {
 // XXX should we have a separate knob for HID and for usb-storage?
 func updateUsbAccess(ctx *domainContext) {
 
-	log.Infof("updateUsbAccess(%t)", ctx.usbAccess)
+	log.Functionf("updateUsbAccess(%t)", ctx.usbAccess)
 	if !ctx.usbAccess {
 		if removeUSBfromKernel() {
 			maybeAssignableAddUSB(ctx)
@@ -2513,7 +2513,7 @@ func updateUsbAccess(ctx *domainContext) {
 // Returns success/failure
 func maybeAssignableAddUSB(ctx *domainContext) bool {
 
-	log.Infof("maybeAssignableAddUSB()")
+	log.Functionf("maybeAssignableAddUSB()")
 	var assignments []string
 	ret := true
 	aa := ctx.assignableAdapters
@@ -2526,7 +2526,7 @@ func maybeAssignableAddUSB(ctx *domainContext) bool {
 			continue
 		}
 		if !ib.IsPort && !ib.IsPCIBack {
-			log.Infof("maybeAssignableAddUSB: Assigning %s (%s) to pciback",
+			log.Functionf("maybeAssignableAddUSB: Assigning %s (%s) to pciback",
 				ib.Phylabel, ib.PciLong)
 			assignments = addNoDuplicate(assignments, ib.PciLong)
 			ib.IsPCIBack = true
@@ -2549,7 +2549,7 @@ func maybeAssignableAddUSB(ctx *domainContext) bool {
 // Returns success/failure based on current usage
 func maybeAssignableRemUSB(ctx *domainContext) bool {
 
-	log.Infof("maybeAssignableAddUSB()")
+	log.Functionf("maybeAssignableAddUSB()")
 	var assignments []string
 	ret := true
 	aa := ctx.assignableAdapters
@@ -2563,7 +2563,7 @@ func maybeAssignableRemUSB(ctx *domainContext) bool {
 		}
 		if ib.IsPCIBack {
 			if ib.UsedByUUID == nilUUID {
-				log.Infof("Removing %s (%s) from pciback",
+				log.Functionf("Removing %s (%s) from pciback",
 					ib.Phylabel, ib.PciLong)
 				assignments = addNoDuplicate(assignments, ib.PciLong)
 				ib.IsPCIBack = false
@@ -2605,7 +2605,7 @@ var usbDrivers = []loadedDriver{
 // Enable the above drivers; record which ones loaded
 func addUSBtoKernel() {
 
-	log.Infof("addUSBtoKernel()")
+	log.Functionf("addUSBtoKernel()")
 	for i := range usbDrivers {
 		drv := &usbDrivers[i]
 		if drv.loaded == types.TS_ENABLED {
@@ -2626,12 +2626,12 @@ func addUSBtoKernel() {
 // Disable usbhid etc
 func removeUSBfromKernel() bool {
 
-	log.Infof("removeUSBfromKernel()")
+	log.Functionf("removeUSBfromKernel()")
 	ret := true
 	for i := range usbDrivers {
 		drv := &usbDrivers[i]
 		if drv.loaded == types.TS_DISABLED {
-			log.Infof("driver %s not loaded; no unload",
+			log.Functionf("driver %s not loaded; no unload",
 				drv.driverName)
 			continue
 		}
@@ -2653,7 +2653,7 @@ func doModprobe(driver string, add bool) error {
 		args = append(args, "-r")
 	}
 	args = append(args, driver)
-	log.Infof("Calling command %s %v\n", cmd, args)
+	log.Functionf("Calling command %s %v\n", cmd, args)
 	stdoutStderr, err := base.Exec(log, cmd, args...).CombinedOutput()
 	if err != nil {
 		log.Error(err)
@@ -2665,17 +2665,17 @@ func doModprobe(driver string, add bool) error {
 
 func handleIBDelete(ctx *domainContext, phylabel string) {
 
-	log.Infof("handleIBDelete(%s)", phylabel)
+	log.Functionf("handleIBDelete(%s)", phylabel)
 	aa := ctx.assignableAdapters
 
 	ib := aa.LookupIoBundlePhylabel(phylabel)
 	if ib == nil {
-		log.Infof("handleIBDelete: Adapter ( %s ) not found", phylabel)
+		log.Functionf("handleIBDelete: Adapter ( %s ) not found", phylabel)
 		return
 	}
 
 	if ib.IsPCIBack {
-		log.Infof("handleIBDelete: Assigning %s (%s) back",
+		log.Functionf("handleIBDelete: Assigning %s (%s) back",
 			ib.Phylabel, ib.PciLong)
 		if ib.PciLong != "" {
 			err := hyper.PCIRelease(ib.PciLong)
@@ -2708,7 +2708,7 @@ func handleIBModify(ctx *domainContext, newIb types.IoBundle) {
 		return
 	}
 
-	log.Infof("handleIBModify(%d %s %s) from %v to %v",
+	log.Functionf("handleIBModify(%d %s %s) from %v to %v",
 		currentIbPtr.Type, currentIbPtr.Phylabel, currentIbPtr.AssignmentGroup,
 		*currentIbPtr, newIb)
 
@@ -2736,7 +2736,7 @@ func isInUsbGroup(aa types.AssignableAdapters, ib types.IoBundle) bool {
 	list := aa.LookupIoBundleGroup(ib.AssignmentGroup)
 	for _, m := range list {
 		if m.Type == types.IoUSB {
-			log.Infof("isInUsbGroup for %s found USB for %s",
+			log.Functionf("isInUsbGroup for %s found USB for %s",
 				ib.Phylabel, m.Phylabel)
 			return true
 		}

--- a/pkg/pillar/cmd/domainmgr/metric.go
+++ b/pkg/pillar/cmd/domainmgr/metric.go
@@ -20,7 +20,7 @@ const (
 
 // Run a periodic post of the metrics
 func metricsTimerTask(ctx *domainContext, hyper hypervisor.Hypervisor) {
-	log.Infoln("starting metrics timer task")
+	log.Functionln("starting metrics timer task")
 	getAndPublishMetrics(ctx, hyper)
 
 	// Publish 4X more often than zedagent publishes to controller
@@ -103,7 +103,7 @@ func formatAndPublishHostCPUMem(ctx *domainContext, hm types.HostMemory) {
 		AvailableMemory:   uint32(hm.FreeMemoryMB),
 		UsedMemoryPercent: usedPerc,
 	}
-	log.Debugf("formatAndPublishHostCPUMem: hostcpu, dm %+v, CPU num %d", dm, CPUnum)
+	log.Tracef("formatAndPublishHostCPUMem: hostcpu, dm %+v, CPU num %d", dm, CPUnum)
 	ctx.pubDomainMetric.Publish(dm.Key(), dm)
 }
 

--- a/pkg/pillar/cmd/domainmgr/processes.go
+++ b/pkg/pillar/cmd/domainmgr/processes.go
@@ -28,7 +28,7 @@ func gatherProcessMetricList(ctx *domainContext) ([]types.ProcessMetric, map[int
 		log.Errorf("process.Processes failed: %s", err)
 		return ret, reportedPids
 	}
-	log.Debugf("watchedPids: %+v", watchedPids)
+	log.Tracef("watchedPids: %+v", watchedPids)
 	processes, err := process.Processes()
 	if err != nil {
 		log.Errorf("process.Processes failed: %s", err)
@@ -153,14 +153,14 @@ func unpublishRemovedPids(ctx *domainContext, oldPids, newPids map[int32]bool) {
 
 func publishProcessMetric(ctx *domainContext, status *types.ProcessMetric) {
 	key := status.Key()
-	log.Debugf("publishProcessMetric(%s)", key)
+	log.Tracef("publishProcessMetric(%s)", key)
 	pub := ctx.pubProcessMetric
 	pub.Publish(key, *status)
 }
 
 func unpublishProcessMetric(ctx *domainContext, pid uint32) {
 	key := strconv.Itoa(int(pid))
-	log.Debugf("unpublishProcessMetric(%s)", key)
+	log.Tracef("unpublishProcessMetric(%s)", key)
 	pub := ctx.pubProcessMetric
 	pub.Unpublish(key)
 }

--- a/pkg/pillar/cmd/downloader/datastoreconfig.go
+++ b/pkg/pillar/cmd/downloader/datastoreconfig.go
@@ -22,9 +22,9 @@ func handleDatastoreConfigImpl(ctxArg interface{}, key string,
 
 	ctx := ctxArg.(*downloaderContext)
 	config := configArg.(types.DatastoreConfig)
-	log.Infof("handleDatastoreConfigImpl for %s", key)
+	log.Functionf("handleDatastoreConfigImpl for %s", key)
 	checkAndUpdateDownloadableObjects(ctx, config.UUID)
-	log.Infof("handleDatastoreConfigImpl for %s, done", key)
+	log.Functionf("handleDatastoreConfigImpl for %s, done", key)
 }
 
 func handleDatastoreConfigDelete(ctxArg interface{}, key string,
@@ -33,5 +33,5 @@ func handleDatastoreConfigDelete(ctxArg interface{}, key string,
 	config := configArg.(types.DatastoreConfig)
 	cipherBlock := config.CipherBlockStatus
 	ctx.pubCipherBlockStatus.Unpublish(cipherBlock.Key())
-	log.Infof("handleDatastoreConfigDelete for %s", key)
+	log.Functionf("handleDatastoreConfigDelete for %s", key)
 }

--- a/pkg/pillar/cmd/downloader/dirs.go
+++ b/pkg/pillar/cmd/downloader/dirs.go
@@ -16,7 +16,7 @@ func createDownloadDirs() {
 	// now create the download dirs
 	for _, dirName := range workingDirTypes {
 		if _, err := os.Stat(dirName); err != nil {
-			log.Debugf("Create %s", dirName)
+			log.Tracef("Create %s", dirName)
 			if err := os.MkdirAll(dirName, 0700); err != nil {
 				log.Fatal(err)
 			}

--- a/pkg/pillar/cmd/downloader/dns.go
+++ b/pkg/pillar/cmd/downloader/dns.go
@@ -23,31 +23,31 @@ func handleDNSImpl(ctxArg interface{}, key string,
 	ctx := ctxArg.(*downloaderContext)
 	status := statusArg.(types.DeviceNetworkStatus)
 	if key != "global" {
-		log.Infof("handleDNSImpl: ignoring %s", key)
+		log.Functionf("handleDNSImpl: ignoring %s", key)
 		return
 	}
-	log.Infof("handleDNSImpl for %s", key)
+	log.Functionf("handleDNSImpl for %s", key)
 	// Ignore test status and timestamps
 	if ctx.deviceNetworkStatus.MostlyEqual(status) {
-		log.Infof("handleDNSImpl unchanged")
+		log.Functionf("handleDNSImpl unchanged")
 		return
 	}
 	ctx.deviceNetworkStatus = status
-	log.Infof("handleDNSImpl %d free management ports addresses; %d any",
+	log.Functionf("handleDNSImpl %d free management ports addresses; %d any",
 		types.CountLocalAddrFreeNoLinkLocal(ctx.deviceNetworkStatus),
 		types.CountLocalAddrAnyNoLinkLocal(ctx.deviceNetworkStatus))
 
-	log.Infof("handleDNSImpl done for %s", key)
+	log.Functionf("handleDNSImpl done for %s", key)
 }
 
 func handleDNSDelete(ctxArg interface{}, key string, statusArg interface{}) {
 
 	ctx := ctxArg.(*downloaderContext)
-	log.Infof("handleDNSDelete for %s", key)
+	log.Functionf("handleDNSDelete for %s", key)
 	if key != "global" {
-		log.Infof("handleDNSDelete: ignoring %s", key)
+		log.Functionf("handleDNSDelete: ignoring %s", key)
 		return
 	}
 	ctx.deviceNetworkStatus = types.DeviceNetworkStatus{}
-	log.Infof("handleDNSDelete done for %s", key)
+	log.Functionf("handleDNSDelete done for %s", key)
 }

--- a/pkg/pillar/cmd/downloader/download.go
+++ b/pkg/pillar/cmd/downloader/download.go
@@ -46,7 +46,7 @@ func download(ctx *downloaderContext, trType zedUpload.SyncTransportType,
 	proxyLookupURL := zedcloud.IntfLookupProxyCfg(log, &ctx.deviceNetworkStatus, ifname, downloadURL)
 	proxyURL, err := zedcloud.LookupProxy(log, &ctx.deviceNetworkStatus, ifname, proxyLookupURL)
 	if err == nil && proxyURL != nil {
-		log.Infof("%s: Using proxy %s", trType, proxyURL.String())
+		log.Functionf("%s: Using proxy %s", trType, proxyURL.String())
 		dEndPoint.WithSrcIPAndProxySelection(ipSrc, proxyURL)
 	} else {
 		dEndPoint.WithSrcIPSelection(ipSrc)
@@ -54,7 +54,7 @@ func download(ctx *downloaderContext, trType zedUpload.SyncTransportType,
 
 	var respChan = make(chan *zedUpload.DronaRequest)
 
-	log.Infof("%s syncOp for dpath:<%s>, region: <%s>, filename: <%s>, "+
+	log.Functionf("%s syncOp for dpath:<%s>, region: <%s>, filename: <%s>, "+
 		"downloadURL: <%s>, maxsize: %d, ifname: %s, ipSrc: %+v, locFilename: %s",
 		trType, dpath, region, filename, downloadURL, maxsize, ifname, ipSrc,
 		locFilename)
@@ -74,7 +74,7 @@ func download(ctx *downloaderContext, trType zedUpload.SyncTransportType,
 	for resp := range respChan {
 		if resp.IsDnUpdate() {
 			currentSize, totalSize, progress := resp.Progress()
-			log.Infof("Update progress for %v: %v/%v",
+			log.Functionf("Update progress for %v: %v/%v",
 				resp.GetLocalName(), currentSize, totalSize)
 			// sometime, the download goes to an infinite loop,
 			// showing it has downloaded, more than it is supposed to
@@ -111,7 +111,7 @@ func download(ctx *downloaderContext, trType zedUpload.SyncTransportType,
 			return "", err
 		}
 		asize, osize := resp.GetAsize(), resp.GetOsize()
-		log.Infof("Done for %v: size %v/%v",
+		log.Functionf("Done for %v: size %v/%v",
 			resp.GetLocalName(),
 			asize, osize)
 		status.Progress(100, osize, asize)
@@ -149,7 +149,7 @@ func objectMetadata(ctx *downloaderContext, trType zedUpload.SyncTransportType,
 
 	proxyURL, err := zedcloud.LookupProxy(log, &ctx.deviceNetworkStatus, ifname, proxyLookupURL)
 	if err == nil && proxyURL != nil {
-		log.Infof("%s: Using proxy %s", trType, proxyURL.String())
+		log.Functionf("%s: Using proxy %s", trType, proxyURL.String())
 		dEndPoint.WithSrcIPAndProxySelection(ipSrc, proxyURL)
 	} else {
 		dEndPoint.WithSrcIPSelection(ipSrc)
@@ -157,7 +157,7 @@ func objectMetadata(ctx *downloaderContext, trType zedUpload.SyncTransportType,
 
 	var respChan = make(chan *zedUpload.DronaRequest)
 
-	log.Infof("%s syncOp for dpath:<%s>, region: <%s>, filename: <%s>, "+
+	log.Functionf("%s syncOp for dpath:<%s>, region: <%s>, filename: <%s>, "+
 		"downloadURL: <%s>, ifname: %s, ipSrc: %+v",
 		trType, dpath, region, filename, downloadURL, ifname, ipSrc)
 	// create Request
@@ -194,7 +194,7 @@ func objectMetadata(ctx *downloaderContext, trType zedUpload.SyncTransportType,
 		if resp.IsError() {
 			return sha256, err
 		}
-		log.Infof("Resolve config Done for %v: sha %v",
+		log.Functionf("Resolve config Done for %v: sha %v",
 			filename, resp.GetSha256())
 		return sha256, nil
 	}

--- a/pkg/pillar/cmd/downloader/globalconfig.go
+++ b/pkg/pillar/cmd/downloader/globalconfig.go
@@ -25,10 +25,10 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 
 	ctx := ctxArg.(*downloaderContext)
 	if key != "global" {
-		log.Infof("handleGlobalConfigImpl: ignoring %s", key)
+		log.Functionf("handleGlobalConfigImpl: ignoring %s", key)
 		return
 	}
-	log.Infof("handleGlobalConfigImpl for %s", key)
+	log.Functionf("handleGlobalConfigImpl for %s", key)
 	var gcp *types.ConfigItemValueMap
 	debug, gcp = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
 		debugOverride, logger)
@@ -41,7 +41,7 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 		}
 		ctx.GCInitialized = true
 	}
-	log.Infof("handleGlobalConfigImpl done for %s", key)
+	log.Functionf("handleGlobalConfigImpl done for %s", key)
 }
 
 func handleGlobalConfigDelete(ctxArg interface{}, key string,
@@ -49,11 +49,11 @@ func handleGlobalConfigDelete(ctxArg interface{}, key string,
 
 	ctx := ctxArg.(*downloaderContext)
 	if key != "global" {
-		log.Infof("handleGlobalConfigDelete: ignoring %s", key)
+		log.Functionf("handleGlobalConfigDelete: ignoring %s", key)
 		return
 	}
-	log.Infof("handleGlobalConfigDelete for %s", key)
+	log.Functionf("handleGlobalConfigDelete for %s", key)
 	debug, _ = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
 		debugOverride, logger)
-	log.Infof("handleGlobalConfigDelete done for %s", key)
+	log.Functionf("handleGlobalConfigDelete done for %s", key)
 }

--- a/pkg/pillar/cmd/downloader/handlers.go
+++ b/pkg/pillar/cmd/downloader/handlers.go
@@ -33,7 +33,7 @@ func makeDownloadHandler() *downloadHandler {
 func (d *downloadHandler) modify(ctxArg interface{},
 	key string, configArg interface{}) {
 
-	log.Infof("downloadHandler.modify(%s)", key)
+	log.Functionf("downloadHandler.modify(%s)", key)
 	config := configArg.(types.DownloaderConfig)
 	h, ok := d.handlers[config.Key()]
 	if !ok {
@@ -41,7 +41,7 @@ func (d *downloadHandler) modify(ctxArg interface{},
 	}
 	select {
 	case h <- Notify{}:
-		log.Infof("downloadHandler.modify(%s) sent notify", key)
+		log.Functionf("downloadHandler.modify(%s) sent notify", key)
 	default:
 		// handler is slow
 		log.Warnf("downloadHandler.modify(%s) NOT sent notify. Slow handler?", key)
@@ -51,7 +51,7 @@ func (d *downloadHandler) modify(ctxArg interface{},
 func (d *downloadHandler) create(ctxArg interface{},
 	key string, configArg interface{}) {
 
-	log.Infof("downloadHandler.create(%s)", key)
+	log.Functionf("downloadHandler.create(%s)", key)
 	ctx := ctxArg.(*downloaderContext)
 	config := configArg.(types.DownloaderConfig)
 	h, ok := d.handlers[config.Key()]
@@ -60,12 +60,12 @@ func (d *downloadHandler) create(ctxArg interface{},
 	}
 	h1 := make(chan Notify, 1)
 	d.handlers[config.Key()] = h1
-	log.Infof("Creating %s at %s", "runHandler", agentlog.GetMyStack())
+	log.Functionf("Creating %s at %s", "runHandler", agentlog.GetMyStack())
 	go runHandler(ctx, key, h1)
 	h = h1
 	select {
 	case h <- Notify{}:
-		log.Infof("downloadHandler.create(%s) sent notify", key)
+		log.Functionf("downloadHandler.create(%s) sent notify", key)
 	default:
 		// Shouldn't happen since we just created channel
 		log.Fatalf("downloadHandler.create(%s) NOT sent notify", key)
@@ -75,16 +75,16 @@ func (d *downloadHandler) create(ctxArg interface{},
 func (d *downloadHandler) delete(ctxArg interface{}, key string,
 	configArg interface{}) {
 
-	log.Infof("downloadHandler.delete(%s)", key)
+	log.Functionf("downloadHandler.delete(%s)", key)
 	// Do we have a channel/goroutine?
 	h, ok := d.handlers[key]
 	if ok {
-		log.Debugf("Closing channel")
+		log.Tracef("Closing channel")
 		close(h)
 		delete(d.handlers, key)
 	} else {
-		log.Debugf("downloadHandler.delete: unknown %s", key)
+		log.Tracef("downloadHandler.delete: unknown %s", key)
 		return
 	}
-	log.Infof("downloadHandler.delete(%s) done", key)
+	log.Functionf("downloadHandler.delete(%s) done", key)
 }

--- a/pkg/pillar/cmd/downloader/resolveconfig.go
+++ b/pkg/pillar/cmd/downloader/resolveconfig.go
@@ -19,7 +19,7 @@ import (
 
 func runResolveHandler(ctx *downloaderContext, key string, c <-chan Notify) {
 
-	log.Infof("runResolveHandler starting")
+	log.Functionf("runResolveHandler starting")
 
 	max := float64(retryTime)
 	min := max * 0.3
@@ -43,14 +43,14 @@ func runResolveHandler(ctx *downloaderContext, key string, c <-chan Notify) {
 				// XXX stop timer
 			}
 		case <-ticker.C:
-			log.Debugf("runResolveHandler(%s) timer", key)
+			log.Tracef("runResolveHandler(%s) timer", key)
 			rs := lookupResolveStatus(ctx, key)
 			if rs != nil {
 				maybeRetryResolve(ctx, rs)
 			}
 		}
 	}
-	log.Infof("runResolveHandler(%s) DONE", key)
+	log.Functionf("runResolveHandler(%s) DONE", key)
 }
 
 func maybeRetryResolve(ctx *downloaderContext, status *types.ResolveStatus) {
@@ -63,17 +63,17 @@ func maybeRetryResolve(ctx *downloaderContext, status *types.ResolveStatus) {
 	t := time.Now()
 	elapsed := t.Sub(status.ErrorTime)
 	if elapsed < retryTime {
-		log.Infof("maybeRetryResolve(%s) %d remaining",
+		log.Functionf("maybeRetryResolve(%s) %d remaining",
 			status.Key(),
 			(retryTime-elapsed)/time.Second)
 		return
 	}
-	log.Infof("maybeRetryResolve(%s) after %s at %v",
+	log.Functionf("maybeRetryResolve(%s) after %s at %v",
 		status.Key(), status.Error, status.ErrorTime)
 
 	config := lookupResolveConfig(ctx, status.Key())
 	if config == nil {
-		log.Infof("maybeRetryResolve(%s) no config",
+		log.Functionf("maybeRetryResolve(%s) no config",
 			status.Key())
 		return
 	}
@@ -90,20 +90,20 @@ func publishResolveStatus(ctx *downloaderContext,
 	status *types.ResolveStatus) {
 
 	key := status.Key()
-	log.Debugf("publishResolveStatus(%s)", key)
+	log.Tracef("publishResolveStatus(%s)", key)
 	pub := ctx.pubResolveStatus
 	pub.Publish(key, *status)
-	log.Debugf("publishResolveStatus(%s) Done", key)
+	log.Tracef("publishResolveStatus(%s) Done", key)
 }
 
 func unpublishResolveStatus(ctx *downloaderContext,
 	status *types.ResolveStatus) {
 
 	key := status.Key()
-	log.Debugf("unpublishResolveStatus(%s)", key)
+	log.Tracef("unpublishResolveStatus(%s)", key)
 	pub := ctx.pubResolveStatus
 	pub.Unpublish(key)
-	log.Debugf("unpublishResolveStatus(%s) Done", key)
+	log.Tracef("unpublishResolveStatus(%s) Done", key)
 }
 
 func lookupResolveConfig(ctx *downloaderContext, key string) *types.ResolveConfig {
@@ -111,7 +111,7 @@ func lookupResolveConfig(ctx *downloaderContext, key string) *types.ResolveConfi
 	sub := ctx.subResolveConfig
 	c, _ := sub.Get(key)
 	if c == nil {
-		log.Infof("lookupResolveConfig(%s) not found", key)
+		log.Functionf("lookupResolveConfig(%s) not found", key)
 		return nil
 	}
 	config := c.(types.ResolveConfig)
@@ -124,7 +124,7 @@ func lookupResolveStatus(ctx *downloaderContext,
 	pub := ctx.pubResolveStatus
 	c, _ := pub.Get(key)
 	if c == nil {
-		log.Infof("lookupResolveStatus(%s) not found", key)
+		log.Functionf("lookupResolveStatus(%s) not found", key)
 		return nil
 	}
 	status := c.(types.ResolveStatus)
@@ -163,7 +163,7 @@ func resolveTagsToHash(ctx *downloaderContext, rc types.ResolveConfig) {
 		publishResolveStatus(ctx, rs)
 		return
 	}
-	log.Debugf("Found datastore(%s) for %s", rc.DatastoreID.String(), rc.Name)
+	log.Tracef("Found datastore(%s) for %s", rc.DatastoreID.String(), rc.Name)
 
 	// construct the datastore context
 	dsCtx, err := constructDatastoreContext(ctx, rc.Name, false, *dst)
@@ -174,17 +174,17 @@ func resolveTagsToHash(ctx *downloaderContext, rc types.ResolveConfig) {
 		return
 	}
 
-	log.Infof("Resolving config <%s> using %v allow non-free port",
+	log.Functionf("Resolving config <%s> using %v allow non-free port",
 		rc.Name, rc.AllowNonFreePort)
 
 	var addrCount int
 	if !rc.AllowNonFreePort {
 		addrCount = types.CountLocalAddrFreeNoLinkLocal(ctx.deviceNetworkStatus)
-		log.Infof("Have %d free management port addresses", addrCount)
+		log.Functionf("Have %d free management port addresses", addrCount)
 		err = errors.New("No free IP management port addresses for download")
 	} else {
 		addrCount = types.CountLocalAddrAnyNoLinkLocal(ctx.deviceNetworkStatus)
-		log.Infof("Have %d any management port addresses", addrCount)
+		log.Functionf("Have %d any management port addresses", addrCount)
 		err = errors.New("No IP management port addresses for download")
 	}
 	if addrCount == 0 {
@@ -239,7 +239,7 @@ func resolveTagsToHash(ctx *downloaderContext, rc types.ResolveConfig) {
 			continue
 		}
 		ifname := types.GetMgmtPortFromAddr(ctx.deviceNetworkStatus, ipSrc)
-		log.Infof("Using IP source %v if %s transport %v",
+		log.Functionf("Using IP source %v if %s transport %v",
 			ipSrc, ifname, dsCtx.TransportMethod)
 
 		sha256, err := objectMetadata(ctx, trType, syncOp, serverURL, auth,

--- a/pkg/pillar/cmd/downloader/resolvehandler.go
+++ b/pkg/pillar/cmd/downloader/resolvehandler.go
@@ -28,7 +28,7 @@ func makeResolveHandler() *resolveHandler {
 func (r *resolveHandler) create(ctxArg interface{},
 	key string, configArg interface{}) {
 
-	log.Infof("resolveHandler.modify(%s)", key)
+	log.Functionf("resolveHandler.modify(%s)", key)
 	ctx := ctxArg.(*downloaderContext)
 	h, ok := r.handlers[key]
 	if ok {
@@ -36,14 +36,14 @@ func (r *resolveHandler) create(ctxArg interface{},
 	}
 	h1 := make(chan Notify, 1)
 	r.handlers[key] = h1
-	log.Infof("Creating %s at %s", "runResolveHandler",
+	log.Functionf("Creating %s at %s", "runResolveHandler",
 		agentlog.GetMyStack())
 	go runResolveHandler(ctx, key, h1)
 	h = h1
 
 	select {
 	case h <- Notify{}:
-		log.Infof("resolveHandler.modify(%s) sent notify", key)
+		log.Functionf("resolveHandler.modify(%s) sent notify", key)
 	default:
 		// handler is slow
 		log.Warnf("resolveHandler.modify(%s) NOT sent notify. Slow handler?", key)
@@ -53,14 +53,14 @@ func (r *resolveHandler) create(ctxArg interface{},
 func (r *resolveHandler) modify(ctxArg interface{},
 	key string, configArg interface{}, oldConfigArg interface{}) {
 
-	log.Infof("resolveHandler.modify(%s)", key)
+	log.Functionf("resolveHandler.modify(%s)", key)
 	h, ok := r.handlers[key]
 	if !ok {
 		log.Fatalf("resolveHandler.modify called on config that does not exist")
 	}
 	select {
 	case h <- Notify{}:
-		log.Infof("resolveHandler.modify(%s) sent notify", key)
+		log.Functionf("resolveHandler.modify(%s) sent notify", key)
 	default:
 		// handler is slow
 		log.Warnf("resolveHandler.modify(%s) NOT sent notify. Slow handler?", key)
@@ -70,16 +70,16 @@ func (r *resolveHandler) modify(ctxArg interface{},
 func (r *resolveHandler) delete(ctxArg interface{},
 	key string, configArg interface{}) {
 
-	log.Infof("resolveHandler.delete(%s)", key)
+	log.Functionf("resolveHandler.delete(%s)", key)
 	// Do we have a channel/goroutine?
 	h, ok := r.handlers[key]
 	if ok {
-		log.Debugf("Closing channel")
+		log.Tracef("Closing channel")
 		close(h)
 		delete(r.handlers, key)
 	} else {
-		log.Debugf("resolveHandler.delete: unknown %s", key)
+		log.Tracef("resolveHandler.delete: unknown %s", key)
 		return
 	}
-	log.Infof("resolveHandler.delete(%s) done", key)
+	log.Functionf("resolveHandler.delete(%s) done", key)
 }

--- a/pkg/pillar/cmd/downloader/resolveimg.go
+++ b/pkg/pillar/cmd/downloader/resolveimg.go
@@ -7,23 +7,23 @@ package downloader
 func handleResolveCreate(ctxArg interface{}, key string,
 	configArg interface{}) {
 
-	log.Infof("handleResolveCreate for %s", key)
+	log.Functionf("handleResolveCreate for %s", key)
 	resHandler.create(ctxArg, key, configArg)
-	log.Infof("handleResolveCreate for %s, done", key)
+	log.Functionf("handleResolveCreate for %s, done", key)
 }
 
 func handleResolveModify(ctxArg interface{}, key string,
 	configArg interface{}, oldConfigArg interface{}) {
 
-	log.Infof("handleResolveModify for %s", key)
+	log.Functionf("handleResolveModify for %s", key)
 	resHandler.modify(ctxArg, key, configArg, oldConfigArg)
-	log.Infof("handleResolveModify for %s, done", key)
+	log.Functionf("handleResolveModify for %s, done", key)
 }
 
 func handleResolveDelete(ctxArg interface{}, key string,
 	configArg interface{}) {
 
-	log.Infof("handleResolveDelete for %s", key)
+	log.Functionf("handleResolveDelete for %s", key)
 	resHandler.delete(ctxArg, key, configArg)
-	log.Infof("handleResolveDelete for %s, done", key)
+	log.Functionf("handleResolveDelete for %s, done", key)
 }

--- a/pkg/pillar/cmd/downloader/syncop.go
+++ b/pkg/pillar/cmd/downloader/syncop.go
@@ -63,23 +63,23 @@ func handleSyncOp(ctx *downloaderContext, key string,
 
 	// make sure the directory exists - just a safety check
 	if _, err := os.Stat(locDirname); err != nil {
-		log.Debugf("Create %s", locDirname)
+		log.Tracef("Create %s", locDirname)
 		if err = os.MkdirAll(locDirname, 0755); err != nil {
 			log.Fatal(err)
 		}
 	}
 
-	log.Infof("Downloading <%s> to <%s> using %v allow non-free port",
+	log.Functionf("Downloading <%s> to <%s> using %v allow non-free port",
 		config.Name, locFilename, config.AllowNonFreePort)
 
 	var addrCount int
 	if !config.AllowNonFreePort {
 		addrCount = types.CountLocalAddrFreeNoLinkLocal(ctx.deviceNetworkStatus)
-		log.Infof("Have %d free management port addresses", addrCount)
+		log.Functionf("Have %d free management port addresses", addrCount)
 		err = errors.New("No free IP management port addresses for download")
 	} else {
 		addrCount = types.CountLocalAddrAnyNoLinkLocal(ctx.deviceNetworkStatus)
-		log.Infof("Have %d any management port addresses", addrCount)
+		log.Functionf("Have %d any management port addresses", addrCount)
 		err = errors.New("No IP management port addresses for download")
 	}
 	if addrCount == 0 {
@@ -190,7 +190,7 @@ func handleSyncOp(ctx *downloaderContext, key string,
 			continue
 		}
 		ifname := types.GetMgmtPortFromAddr(ctx.deviceNetworkStatus, ipSrc)
-		log.Infof("Using IP source %v if %s transport %v",
+		log.Functionf("Using IP source %v if %s transport %v",
 			ipSrc, ifname, dsCtx.TransportMethod)
 
 		// do the download
@@ -273,7 +273,7 @@ func handleSyncOpResponse(ctx *downloaderContext, config types.DownloaderConfig,
 		return
 	}
 
-	log.Infof("handleSyncOpResponse(%s): successful <%s>",
+	log.Functionf("handleSyncOpResponse(%s): successful <%s>",
 		config.Name, locFilename)
 	// We do not clear any status.RetryCount, Error, etc. The caller
 	// should look at State == DOWNLOADED to determine it is done.
@@ -344,10 +344,10 @@ func getDatastoreCredential(ctx *downloaderContext,
 			}
 			return decBlock, nil
 		}
-		log.Infof("%s, datastore config cipherblock decryption successful", dst.Key())
+		log.Functionf("%s, datastore config cipherblock decryption successful", dst.Key())
 		return decBlock, nil
 	}
-	log.Infof("%s, datastore config cipherblock not present", dst.Key())
+	log.Functionf("%s, datastore config cipherblock not present", dst.Key())
 	decBlock := types.EncryptionBlock{}
 	decBlock.DsAPIKey = dst.ApiKey
 	decBlock.DsPassword = dst.Password

--- a/pkg/pillar/cmd/executor/exec.go
+++ b/pkg/pillar/cmd/executor/exec.go
@@ -83,7 +83,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
 		log.Fatal(err)
 	}
-	log.Infof("Starting %s", agentName)
+	log.Functionf("Starting %s", agentName)
 
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(25 * time.Second)
@@ -123,7 +123,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	// Pick up debug aka log level before we start real work
 	for !execCtx.GCInitialized {
-		log.Infof("waiting for GCInitialized")
+		log.Functionf("waiting for GCInitialized")
 		select {
 		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
@@ -131,7 +131,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		}
 		ps.StillRunning(agentName, warningTime, errorTime)
 	}
-	log.Infof("processed GlobalConfig")
+	log.Functionf("processed GlobalConfig")
 
 	subTmpConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "",
@@ -238,12 +238,12 @@ func handleCreate(ctxArg interface{}, key string,
 
 	execCtx := ctxArg.(*executorContext)
 	config := configArg.(types.ExecConfig)
-	log.Infof("handleCreate(%s.%d) %s",
+	log.Functionf("handleCreate(%s.%d) %s",
 		config.Caller, config.Sequence, config.Command)
 	status := launchCmd(execCtx, config)
 	if status != nil {
 		execCtx.pubExecStatus.Publish(status.Key(), *status)
-		log.Infof("handleCreate(%s.%d) Done",
+		log.Functionf("handleCreate(%s.%d) Done",
 			config.Caller, config.Sequence)
 	} else {
 		log.Warnf("handleCreate(%s.%d) No status",
@@ -258,24 +258,24 @@ func handleModify(ctxArg interface{}, key string,
 	config := configArg.(types.ExecConfig)
 	status := lookupExecStatus(execCtx, key)
 	if config.Sequence == status.Sequence {
-		log.Infof("handleModify(%s.%d) no change",
+		log.Functionf("handleModify(%s.%d) no change",
 			config.Caller, config.Sequence)
 		return
 	}
-	log.Infof("handleModify(%s.%d) %s",
+	log.Functionf("handleModify(%s.%d) %s",
 		config.Caller, config.Sequence, config.Command)
 	status = launchCmd(execCtx, config)
 	if status != nil {
 		if config.DontWait {
-			log.Infof("handleModify(%s.%d) Done with DontWait",
+			log.Functionf("handleModify(%s.%d) Done with DontWait",
 				config.Caller, config.Sequence)
 		} else {
 			execCtx.pubExecStatus.Publish(status.Key(), *status)
-			log.Infof("handleModify(%s.%d) Done",
+			log.Functionf("handleModify(%s.%d) Done",
 				config.Caller, config.Sequence)
 		}
 	} else {
-		log.Infof("handleModify(%s.%d) No status",
+		log.Functionf("handleModify(%s.%d) No status",
 			config.Caller, config.Sequence)
 	}
 }
@@ -285,12 +285,12 @@ func handleDelete(ctxArg interface{}, key string,
 
 	execCtx := ctxArg.(*executorContext)
 	config := configArg.(types.ExecConfig)
-	log.Infof("handleDelete(%s.%d) %s",
+	log.Functionf("handleDelete(%s.%d) %s",
 		config.Caller, config.Sequence, config.Command)
 	status := lookupExecStatus(execCtx, key)
 	if status != nil {
 		execCtx.pubExecStatus.Unpublish(status.Key())
-		log.Infof("handleDelete(%s.%d) Done",
+		log.Functionf("handleDelete(%s.%d) Done",
 			config.Caller, config.Sequence)
 	} else {
 		log.Warnf("handleDelete(%s.%d) No status",
@@ -308,7 +308,7 @@ func lookupExecStatus(execCtx *executorContext, key string) *types.ExecStatus {
 }
 
 func launchCmd(execCtx *executorContext, config types.ExecConfig) *types.ExecStatus {
-	log.Infof("launchCmd %+v", config)
+	log.Functionf("launchCmd %+v", config)
 	status := types.ExecStatus{
 		Caller:   config.Caller,
 		Sequence: config.Sequence,
@@ -341,7 +341,7 @@ func launchCmd(execCtx *executorContext, config types.ExecConfig) *types.ExecSta
 		if exiterr, ok := err.(*exec.ExitError); ok {
 			// The program has exited with an exit code != 0
 			if exitStatus, ok := exiterr.Sys().(syscall.WaitStatus); ok {
-				log.Infof("Exit code: %d", exitStatus.ExitStatus())
+				log.Functionf("Exit code: %d", exitStatus.ExitStatus())
 				status.ExitValue = exitStatus.ExitStatus()
 			} else {
 				log.Warnf("No exitStatus but %T: %s",
@@ -362,7 +362,7 @@ func launchCmd(execCtx *executorContext, config types.ExecConfig) *types.ExecSta
 		return &status
 	}
 	status.Output = string(out)
-	log.Infof("Succeeded %+v", status)
+	log.Functionf("Succeeded %+v", status)
 	return &status
 }
 
@@ -381,17 +381,17 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 
 	execCtx := ctxArg.(*executorContext)
 	if key != "global" {
-		log.Infof("handleGlobalConfigImpl: ignoring %s", key)
+		log.Functionf("handleGlobalConfigImpl: ignoring %s", key)
 		return
 	}
-	log.Infof("handleGlobalConfigImpl for %s", key)
+	log.Functionf("handleGlobalConfigImpl for %s", key)
 	var gcp *types.ConfigItemValueMap
 	execCtx.debug, gcp = agentlog.HandleGlobalConfig(log, execCtx.subGlobalConfig, agentName,
 		execCtx.debugOverride, logger)
 	if gcp != nil {
 		execCtx.GCInitialized = true
 	}
-	log.Infof("handleGlobalConfigImpl done for %s", key)
+	log.Functionf("handleGlobalConfigImpl done for %s", key)
 }
 
 func handleGlobalConfigDelete(ctxArg interface{}, key string,
@@ -399,11 +399,11 @@ func handleGlobalConfigDelete(ctxArg interface{}, key string,
 
 	execCtx := ctxArg.(*executorContext)
 	if key != "global" {
-		log.Infof("handleGlobalConfigDelete: ignoring %s", key)
+		log.Functionf("handleGlobalConfigDelete: ignoring %s", key)
 		return
 	}
-	log.Infof("handleGlobalConfigDelete for %s", key)
+	log.Functionf("handleGlobalConfigDelete for %s", key)
 	execCtx.debug, _ = agentlog.HandleGlobalConfig(log, execCtx.subGlobalConfig, agentName,
 		execCtx.debugOverride, logger)
-	log.Infof("handleGlobalConfigDelete done for %s", key)
+	log.Functionf("handleGlobalConfigDelete done for %s", key)
 }

--- a/pkg/pillar/cmd/faultinjection/run.go
+++ b/pkg/pillar/cmd/faultinjection/run.go
@@ -61,7 +61,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
 		log.Fatal(err)
 	}
-	log.Infof("Starting %s", agentName)
+	log.Functionf("Starting %s", agentName)
 
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(25 * time.Second)
@@ -92,7 +92,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	// Pick up debug aka log level before we start real work
 	for !ctx.GCInitialized {
-		log.Infof("waiting for GCInitialized")
+		log.Functionf("waiting for GCInitialized")
 		select {
 		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
@@ -100,7 +100,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		}
 		ps.StillRunning(agentName, warningTime, errorTime)
 	}
-	log.Infof("processed GlobalConfig")
+	log.Functionf("processed GlobalConfig")
 
 	for {
 		select {
@@ -140,17 +140,17 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 
 	ctx := ctxArg.(*faultContext)
 	if key != "global" {
-		log.Infof("handleGlobalConfigImpl: ignoring %s", key)
+		log.Functionf("handleGlobalConfigImpl: ignoring %s", key)
 		return
 	}
-	log.Infof("handleGlobalConfigImpl for %s", key)
+	log.Functionf("handleGlobalConfigImpl for %s", key)
 	var gcp *types.ConfigItemValueMap
 	ctx.debug, gcp = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
 		ctx.debugOverride, logger)
 	if gcp != nil {
 		ctx.GCInitialized = true
 	}
-	log.Infof("handleGlobalConfigImpl done for %s", key)
+	log.Functionf("handleGlobalConfigImpl done for %s", key)
 }
 
 func handleGlobalConfigDelete(ctxArg interface{}, key string,
@@ -158,11 +158,11 @@ func handleGlobalConfigDelete(ctxArg interface{}, key string,
 
 	ctx := ctxArg.(*faultContext)
 	if key != "global" {
-		log.Infof("handleGlobalConfigDelete: ignoring %s", key)
+		log.Functionf("handleGlobalConfigDelete: ignoring %s", key)
 		return
 	}
-	log.Infof("handleGlobalConfigDelete for %s", key)
+	log.Functionf("handleGlobalConfigDelete for %s", key)
 	ctx.debug, _ = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
 		ctx.debugOverride, logger)
-	log.Infof("handleGlobalConfigDelete done for %s", key)
+	log.Functionf("handleGlobalConfigDelete done for %s", key)
 }

--- a/pkg/pillar/cmd/ipcmonitor/ipcmonitor.go
+++ b/pkg/pillar/cmd/ipcmonitor/ipcmonitor.go
@@ -96,7 +96,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 		switch msg {
 		case "hello", "restarted", "complete":
-			log.Infof("Got message %s type %s\n", msg, t)
+			log.Functionf("Got message %s type %s\n", msg, t)
 
 		case "delete":
 			if count < 3 {
@@ -109,7 +109,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 			if err != nil {
 				log.Errorf("base64: %s\n", err)
 			}
-			log.Infof("delete type %s key %s\n", t, key)
+			log.Functionf("delete type %s key %s\n", t, key)
 
 		case "update":
 			if count < 4 {
@@ -137,14 +137,14 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 				if err := json.Unmarshal(val, &output); err != nil {
 					log.Fatal(err, "json Unmarshal")
 				}
-				log.Infof("update type %s key %s val %+v\n",
+				log.Functionf("update type %s key %s val %+v\n",
 					t, key, output)
 			case "json":
 				var out bytes.Buffer
 				if err = json.Indent(&out, val, "", "\t"); err != nil {
 					log.Fatalf("unable to indent json: %v", err)
 				}
-				log.Infof("update type %s key %s: %s\n", t, key, out.String())
+				log.Functionf("update type %s key %s: %s\n", t, key, out.String())
 			default:
 				log.Fatalf("unsupported format: %s", format)
 			}
@@ -187,32 +187,32 @@ func testPersistent(ps *pubsub.PubSub, agentName string, agentScope string, topi
 func handleCreate(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
-	log.Infof("handleCreate(%s) type %T\n", key, statusArg)
+	log.Functionf("handleCreate(%s) type %T\n", key, statusArg)
 	switch statusArg.(type) {
 	case types.DevicePortConfigList:
 		dpcl := statusArg.(types.DevicePortConfigList)
-		log.Infof("DPCL %+v\n", dpcl)
+		log.Functionf("DPCL %+v\n", dpcl)
 	}
 }
 
 func handleModify(ctxArg interface{}, key string,
 	statusArg interface{}, oldStatusArg interface{}) {
 
-	log.Infof("handleModify(%s) type %T\n", key, statusArg)
+	log.Functionf("handleModify(%s) type %T\n", key, statusArg)
 	switch statusArg.(type) {
 	case types.DevicePortConfigList:
 		dpcl := statusArg.(types.DevicePortConfigList)
-		log.Infof("DPCL %+v\n", dpcl)
+		log.Functionf("DPCL %+v\n", dpcl)
 	}
 }
 
 func handleDelete(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
-	log.Infof("handleDelete(%s) type %T\n", key, statusArg)
+	log.Functionf("handleDelete(%s) type %T\n", key, statusArg)
 	switch statusArg.(type) {
 	case types.DevicePortConfigList:
 		dpcl := statusArg.(types.DevicePortConfigList)
-		log.Infof("DPCL %+v\n", dpcl)
+		log.Functionf("DPCL %+v\n", dpcl)
 	}
 }

--- a/pkg/pillar/cmd/logmanager/domainstatus.go
+++ b/pkg/pillar/cmd/logmanager/domainstatus.go
@@ -37,13 +37,13 @@ func handleDomainStatusImpl(ctxArg interface{}, key string,
 	ctx := ctxArg.(*logmanagerContext)
 	ctx.Lock()
 	defer ctx.Unlock()
-	log.Infof("handleDomainStatusImpl for %s", key)
+	log.Functionf("handleDomainStatusImpl for %s", key)
 	status := statusArg.(types.DomainStatus)
 	// Record the domainName even if Pending* is set
-	log.Infof("handleDomainStatusImpl add %s to %s",
+	log.Functionf("handleDomainStatusImpl add %s to %s",
 		status.DomainName, status.UUIDandVersion.UUID.String())
 	domainUuid[status.DomainName] = status.UUIDandVersion.UUID.String()
-	log.Infof("handleDomainStatusImpl done for %s", key)
+	log.Functionf("handleDomainStatusImpl done for %s", key)
 }
 
 func handleDomainStatusDelete(ctxArg interface{}, key string,
@@ -52,15 +52,15 @@ func handleDomainStatusDelete(ctxArg interface{}, key string,
 	ctx := ctxArg.(*logmanagerContext)
 	ctx.Lock()
 	defer ctx.Unlock()
-	log.Infof("handleDomainStatusDelete for %s", key)
+	log.Functionf("handleDomainStatusDelete for %s", key)
 	status := statusArg.(types.DomainStatus)
 	if _, ok := domainUuid[status.DomainName]; !ok {
 		log.Errorf("handleDomainStatusDelete UUID %s not in map",
 			status.UUIDandVersion.UUID.String())
 		return
 	}
-	log.Infof("handleDomainStatusDomain remove %s",
+	log.Functionf("handleDomainStatusDomain remove %s",
 		status.DomainName)
 	delete(domainUuid, status.DomainName)
-	log.Infof("handleDomainStatusDelete done for %s", key)
+	log.Functionf("handleDomainStatusDelete done for %s", key)
 }

--- a/pkg/pillar/cmd/logmanager/parsetime.go
+++ b/pkg/pillar/cmd/logmanager/parsetime.go
@@ -71,7 +71,7 @@ func parseTime(ts string) (time.Time, bool) {
 	}
 	err = t.UnmarshalText([]byte(ts))
 	if err != nil {
-		log.Debugln(err)
+		log.Traceln(err)
 		return t, false
 	}
 	return t, true
@@ -98,7 +98,7 @@ func parseOldTime(date, timeStr string) (time.Time, bool) {
 	///convert newDateAndTime type string to type time.time
 	dt, err := time.Parse(layout, newDateAndTime)
 	if err != nil {
-		log.Debugln(err)
+		log.Traceln(err)
 		return t, false
 	} else {
 		return dt, true

--- a/pkg/pillar/cmd/nodeagent/handlebaseos.go
+++ b/pkg/pillar/cmd/nodeagent/handlebaseos.go
@@ -22,7 +22,7 @@ func doZbootBaseOsInstallationComplete(ctxPtr *nodeagentContext,
 	}
 	if isZbootOtherPartitionStateUpdating(ctxPtr) && !ctxPtr.deviceReboot {
 		infoStr := fmt.Sprintf("NORMAL: baseos-update(%s) reboot", key)
-		log.Infof(infoStr)
+		log.Functionf(infoStr)
 		scheduleNodeReboot(ctxPtr, infoStr, types.BootReasonUpdate)
 	}
 }
@@ -34,7 +34,7 @@ func initiateBaseOsZedCloudTestComplete(ctxPtr *nodeagentContext) {
 	if !ctxPtr.updateInprogress {
 		return
 	}
-	log.Infof("initiateBaseOsZedCloudTestComplete(%s)", ctxPtr.curPart)
+	log.Functionf("initiateBaseOsZedCloudTestComplete(%s)", ctxPtr.curPart)
 	// get the current partition zboot config and status
 	zbootConfig := lookupZbootConfig(ctxPtr, ctxPtr.curPart)
 	zbootStatus := lookupZbootStatus(ctxPtr, ctxPtr.curPart)
@@ -46,7 +46,7 @@ func initiateBaseOsZedCloudTestComplete(ctxPtr *nodeagentContext) {
 		log.Errorf("zboot(%s) testComplete is already set", ctxPtr.curPart)
 		return
 	}
-	log.Infof("baseOs(%s) upgrade validation testComplete, in %s",
+	log.Functionf("baseOs(%s) upgrade validation testComplete, in %s",
 		zbootStatus.ShortVersion, ctxPtr.curPart)
 	ctxPtr.testComplete = true
 	zbootConfig.TestComplete = true
@@ -64,14 +64,14 @@ func doZbootBaseOsTestValidationComplete(ctxPtr *nodeagentContext,
 	}
 	// nothing to be done
 	if !status.TestComplete {
-		log.Debugf("%s: not TestComplete", key)
+		log.Tracef("%s: not TestComplete", key)
 		return
 	}
 	config := lookupZbootConfig(ctxPtr, status.PartitionLabel)
 	if config == nil || ctxPtr.updateComplete {
 		return
 	}
-	log.Infof("baseOs(%s) upgrade validation is acknowledged, Partition %s",
+	log.Functionf("baseOs(%s) upgrade validation is acknowledged, Partition %s",
 		status.ShortVersion, status.PartitionLabel)
 	config.TestComplete = false
 	ctxPtr.updateComplete = true

--- a/pkg/pillar/cmd/nodeagent/handletimers.go
+++ b/pkg/pillar/cmd/nodeagent/handletimers.go
@@ -66,7 +66,7 @@ func handleFallbackOnCloudDisconnect(ctxPtr *nodeagentContext) {
 		log.Errorf(errStr)
 		scheduleNodeReboot(ctxPtr, errStr, types.BootReasonFallback)
 	} else {
-		log.Infof("handleFallbackOnCloudDisconnect %d seconds remaining",
+		log.Functionf("handleFallbackOnCloudDisconnect %d seconds remaining",
 			fallbackLimit-timePassed)
 	}
 }
@@ -82,7 +82,7 @@ func handleResetOnCloudDisconnect(ctxPtr *nodeagentContext) {
 		log.Errorf(errStr)
 		scheduleNodeReboot(ctxPtr, errStr, types.BootReasonDisconnect)
 	} else {
-		log.Debugf("handleResetOnCloudDisconnect %d seconds remaining",
+		log.Tracef("handleResetOnCloudDisconnect %d seconds remaining",
 			resetLimit-timePassed)
 	}
 }
@@ -94,7 +94,7 @@ func handleUpgradeTestValidation(ctxPtr *nodeagentContext) {
 		return
 	}
 	if checkUpgradeValidationTestTimeExpiry(ctxPtr) {
-		log.Infof("CurPart: %s, Upgrade Validation Test Complete",
+		log.Functionf("CurPart: %s, Upgrade Validation Test Complete",
 			ctxPtr.curPart)
 		resetTestStartTime(ctxPtr)
 		initiateBaseOsZedCloudTestComplete(ctxPtr)
@@ -116,7 +116,7 @@ func handleRebootOnVaultLocked(ctxPtr *nodeagentContext) {
 		log.Errorf(errStr)
 		scheduleNodeReboot(ctxPtr, errStr, types.BootReasonVaultFailure)
 	} else {
-		log.Infof("handleRebootOnVaultLocked %d seconds remaining",
+		log.Functionf("handleRebootOnVaultLocked %d seconds remaining",
 			vaultCutOffTime-timePassed)
 	}
 }
@@ -128,7 +128,7 @@ func checkUpgradeValidationTestTimeExpiry(ctxPtr *nodeagentContext) bool {
 	if timePassed < successLimit {
 		ctxPtr.remainingTestTime = time.Second *
 			time.Duration(successLimit-timePassed)
-		log.Infof("CurPart: %s inprogress, waiting for %d seconds",
+		log.Functionf("CurPart: %s inprogress, waiting for %d seconds",
 			ctxPtr.curPart, ctxPtr.remainingTestTime/time.Second)
 		publishNodeAgentStatus(ctxPtr)
 		return false
@@ -147,7 +147,7 @@ func setTestStartTime(ctxPtr *nodeagentContext) {
 		return
 	}
 	mintimeUpdateSuccess := ctxPtr.globalConfig.GlobalValueInt(types.MintimeUpdateSuccess)
-	log.Infof("Starting upgrade validation for %d seconds", mintimeUpdateSuccess)
+	log.Functionf("Starting upgrade validation for %d seconds", mintimeUpdateSuccess)
 	ctxPtr.testInprogress = true
 	ctxPtr.upgradeTestStartTime = ctxPtr.timeTickCount
 	successLimit := mintimeUpdateSuccess
@@ -159,7 +159,7 @@ func resetTestStartTime(ctxPtr *nodeagentContext) {
 	if !ctxPtr.testInprogress {
 		return
 	}
-	log.Infof("Resetting upgrade validation")
+	log.Functionf("Resetting upgrade validation")
 	ctxPtr.testInprogress = false
 	ctxPtr.remainingTestTime = time.Second * time.Duration(0)
 }
@@ -168,7 +168,7 @@ func resetTestStartTime(ctxPtr *nodeagentContext) {
 func updateZedagentCloudConnectStatus(ctxPtr *nodeagentContext,
 	status types.ZedAgentStatus) {
 
-	log.Infof("updateZedagentCloudConnectStatus from %d to %d",
+	log.Functionf("updateZedagentCloudConnectStatus from %d to %d",
 		ctxPtr.configGetStatus, status.ConfigGetStatus)
 
 	// config Get Status has not changed
@@ -178,12 +178,12 @@ func updateZedagentCloudConnectStatus(ctxPtr *nodeagentContext,
 	ctxPtr.configGetStatus = status.ConfigGetStatus
 	switch ctxPtr.configGetStatus {
 	case types.ConfigGetSuccess:
-		log.Infof("Config get from controller, is successful")
+		log.Functionf("Config get from controller, is successful")
 		ctxPtr.lastControllerReachableTime = ctxPtr.timeTickCount
 		setTestStartTime(ctxPtr)
 
 	case types.ConfigGetTemporaryFail:
-		log.Infof("Config get from controller, has temporarily failed")
+		log.Functionf("Config get from controller, has temporarily failed")
 		// We know it is reachable even though it is not (yet) giving
 		// us a config
 		ctxPtr.lastControllerReachableTime = ctxPtr.timeTickCount
@@ -194,10 +194,10 @@ func updateZedagentCloudConnectStatus(ctxPtr *nodeagentContext,
 		setTestStartTime(ctxPtr)
 
 	case types.ConfigGetReadSaved:
-		log.Infof("Config is read from saved config")
+		log.Functionf("Config is read from saved config")
 
 	case types.ConfigGetFail:
-		log.Infof("Config get from controller has failed")
+		log.Functionf("Config get from controller has failed")
 	}
 }
 
@@ -206,7 +206,7 @@ func handleRebootCmd(ctxPtr *nodeagentContext, status types.ZedAgentStatus) {
 	if !status.RebootCmd || ctxPtr.rebootCmd {
 		return
 	}
-	log.Infof("handleRebootCmd reason %s bootReason %s",
+	log.Functionf("handleRebootCmd reason %s bootReason %s",
 		status.RebootReason, status.BootReason.String())
 	ctxPtr.rebootCmd = true
 	scheduleNodeReboot(ctxPtr, status.RebootReason, status.BootReason)
@@ -214,10 +214,10 @@ func handleRebootCmd(ctxPtr *nodeagentContext, status types.ZedAgentStatus) {
 
 func scheduleNodeReboot(ctxPtr *nodeagentContext, reasonStr string, bootReason types.BootReason) {
 	if ctxPtr.deviceReboot {
-		log.Infof("reboot flag is already set")
+		log.Functionf("reboot flag is already set")
 		return
 	}
-	log.Infof("scheduleNodeReboot(): current RebootReason: %s BootReason %s",
+	log.Functionf("scheduleNodeReboot(): current RebootReason: %s BootReason %s",
 		reasonStr, bootReason.String())
 
 	// publish, for zedagent to pick up the reboot event
@@ -232,7 +232,7 @@ func scheduleNodeReboot(ctxPtr *nodeagentContext, reasonStr string, bootReason t
 
 	// in any case, execute the reboot procedure
 	// with a delayed timer
-	log.Infof("Creating %s at %s", "handleNodeReboot", agentlog.GetMyStack())
+	log.Functionf("Creating %s at %s", "handleNodeReboot", agentlog.GetMyStack())
 	go handleNodeReboot(ctxPtr)
 }
 
@@ -242,14 +242,14 @@ func allDomainsHalted(ctxPtr *nodeagentContext) bool {
 	for _, c := range items {
 		ds := c.(types.DomainStatus)
 		if ds.Activated {
-			log.Debugf("allDomainsHalted: Domain (UUID: %s, name: %s) "+
+			log.Tracef("allDomainsHalted: Domain (UUID: %s, name: %s) "+
 				"not halted. State: %d",
 				ds.UUIDandVersion.UUID.String(), ds.DisplayName, ds.State)
 			return false
 		}
-		log.Debugf("allDomainsHalted: %s is deactivated", ds.DisplayName)
+		log.Tracef("allDomainsHalted: %s is deactivated", ds.DisplayName)
 	}
-	log.Infof("allDomainsHalted: All Domains Halted.")
+	log.Functionf("allDomainsHalted: All Domains Halted.")
 	return true
 
 }
@@ -267,12 +267,12 @@ func waitForAllDomainsHalted(ctxPtr *nodeagentContext) {
 
 		duration := time.Second * time.Duration(ctxPtr.domainHaltWaitIncrement)
 		domainHaltWaitTimer := time.NewTimer(duration)
-		log.Debugf("waitForAllDomainsHalted: Waiting for all domains to be halted. "+
+		log.Tracef("waitForAllDomainsHalted: Waiting for all domains to be halted. "+
 			"totalWaitTime: %d sec, domainHaltWaitIncrement: %d sec",
 			totalWaitTime, domainHaltWaitIncrement)
 		<-domainHaltWaitTimer.C
 	}
-	log.Infof("waitForAllDomainsHalted: Max waittime for DomainsHalted."+
+	log.Functionf("waitForAllDomainsHalted: Max waittime for DomainsHalted."+
 		"totalWaitTime: %d sec, maxDomainHaltTime: %d sec. Proceeding "+
 		"with reboot", totalWaitTime, maxDomainHaltTime)
 }
@@ -281,7 +281,7 @@ func handleNodeReboot(ctxPtr *nodeagentContext) {
 	// Wait for MinRebootDelay time
 	duration := time.Second * time.Duration(minRebootDelay)
 	rebootTimer := time.NewTimer(duration)
-	log.Infof("handleNodeReboot: minRebootDelay timer %d seconds",
+	log.Functionf("handleNodeReboot: minRebootDelay timer %d seconds",
 		duration/time.Second)
 	<-rebootTimer.C
 
@@ -293,16 +293,16 @@ func handleNodeReboot(ctxPtr *nodeagentContext) {
 	waitForAllDomainsHalted(ctxPtr)
 
 	// do a sync
-	log.Infof("Doing a sync..")
+	log.Functionf("Doing a sync..")
 	syscall.Sync()
-	log.Infof("Rebooting... Starting timer for Duration(secs): %d",
+	log.Functionf("Rebooting... Starting timer for Duration(secs): %d",
 		duration/time.Second)
 
 	rebootTimer = time.NewTimer(duration)
-	log.Infof("Timer started. Wait to expire")
+	log.Functionf("Timer started. Wait to expire")
 	<-rebootTimer.C
 	rebootTimer = time.NewTimer(1)
-	log.Infof("Timer Expired.. Zboot.Reset()")
+	log.Functionf("Timer Expired.. Zboot.Reset()")
 	syscall.Sync()
 	<-rebootTimer.C
 	zboot.Reset(log)

--- a/pkg/pillar/cmd/nodeagent/handlezboot.go
+++ b/pkg/pillar/cmd/nodeagent/handlezboot.go
@@ -71,13 +71,13 @@ func publishZbootConfig(ctx *nodeagentContext, config types.ZbootConfig) {
 		return
 	}
 	pub := ctx.pubZbootConfig
-	log.Debugf("publishZbootConfig: %v", config)
+	log.Tracef("publishZbootConfig: %v", config)
 	pub.Publish(config.PartitionLabel, config)
 	syscall.Sync()
 }
 
 func publishZbootConfigAll(ctx *nodeagentContext) {
-	log.Debugf("publishZbootConfigAll")
+	log.Tracef("publishZbootConfigAll")
 	partitionNames := []string{"IMGA", "IMGB"}
 	for _, partName := range partitionNames {
 		config := types.ZbootConfig{}
@@ -92,7 +92,7 @@ func getZbootOtherPartition(ctx *nodeagentContext) string {
 	items := getZbootStatusAll(ctx)
 	for _, status := range items {
 		if !status.CurrentPartition {
-			log.Debugf("getZbootOtherPartition:%s", status.PartitionLabel)
+			log.Tracef("getZbootOtherPartition:%s", status.PartitionLabel)
 			return status.PartitionLabel
 		}
 	}

--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -180,7 +180,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	// Pick up debug aka log level before we start real work
 	for !ctxPtr.GCInitialized {
-		log.Infof("Waiting for GCInitialized")
+		log.Functionf("Waiting for GCInitialized")
 		select {
 		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
@@ -192,7 +192,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		}
 		ps.StillRunning(agentName, warningTime, errorTime)
 	}
-	log.Infof("processed GlobalConfig")
+	log.Functionf("processed GlobalConfig")
 
 	// get the last reboot reason
 	handleLastRebootReason(ctxPtr)
@@ -258,7 +258,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	// access the zboot APIs directly, baseosmgr is still not ready
 	ctxPtr.updateInprogress = zboot.IsCurrentPartitionStateInProgress()
-	log.Infof("Current partition: %s, inProgress: %v", ctxPtr.curPart,
+	log.Functionf("Current partition: %s, inProgress: %v", ctxPtr.curPart,
 		ctxPtr.updateInprogress)
 	publishNodeAgentStatus(ctxPtr)
 
@@ -280,7 +280,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	if err := utils.WaitForOnboarded(ps, log, agentName, warningTime, errorTime); err != nil {
 		log.Fatal(err)
 	}
-	log.Infof("Device is onboarded")
+	log.Functionf("Device is onboarded")
 
 	// if current partition state is not in-progress,
 	// nothing much to do. Zedcloud connectivity is tracked,
@@ -338,7 +338,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	ctxPtr.subZedAgentStatus = subZedAgentStatus
 	subZedAgentStatus.Activate()
 
-	log.Infof("zedbox event loop")
+	log.Functionf("zedbox event loop")
 	for {
 		select {
 		case change := <-subGlobalConfig.MsgChan():
@@ -369,7 +369,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 func handleGlobalConfigSynchronized(ctxArg interface{}, done bool) {
 	ctxPtr := ctxArg.(*nodeagentContext)
 
-	log.Infof("handleGlobalConfigSynchronized(%v)", done)
+	log.Functionf("handleGlobalConfigSynchronized(%v)", done)
 	if done {
 		ctxPtr.GCInitialized = true
 	}
@@ -390,10 +390,10 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 
 	ctxPtr := ctxArg.(*nodeagentContext)
 	if key != "global" {
-		log.Infof("handleGlobalConfigImpl: ignoring %s", key)
+		log.Functionf("handleGlobalConfigImpl: ignoring %s", key)
 		return
 	}
-	log.Infof("handleGlobalConfigImpl for %s", key)
+	log.Functionf("handleGlobalConfigImpl for %s", key)
 	var gcp *types.ConfigItemValueMap
 	debug, gcp = agentlog.HandleGlobalConfig(log, ctxPtr.subGlobalConfig, agentName,
 		debugOverride, ctxPtr.agentBaseContext.Logger)
@@ -401,7 +401,7 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 		ctxPtr.globalConfig = gcp
 		ctxPtr.GCInitialized = true
 	}
-	log.Infof("handleGlobalConfigImpl(%s): done", key)
+	log.Functionf("handleGlobalConfigImpl(%s): done", key)
 }
 
 func handleGlobalConfigDelete(ctxArg interface{},
@@ -409,14 +409,14 @@ func handleGlobalConfigDelete(ctxArg interface{},
 
 	ctxPtr := ctxArg.(*nodeagentContext)
 	if key != "global" {
-		log.Infof("handleGlobalConfigDelete: ignoring %s", key)
+		log.Functionf("handleGlobalConfigDelete: ignoring %s", key)
 		return
 	}
-	log.Infof("handleGlobalConfigDelete for %s", key)
+	log.Functionf("handleGlobalConfigDelete for %s", key)
 	debug, _ = agentlog.HandleGlobalConfig(log, ctxPtr.subGlobalConfig, agentName,
 		debugOverride, ctxPtr.agentBaseContext.Logger)
 	ctxPtr.globalConfig = types.DefaultConfigItemValueMap()
-	log.Infof("handleGlobalConfigDelete done for %s", key)
+	log.Functionf("handleGlobalConfigDelete done for %s", key)
 }
 
 // handle zedagent status events, for cloud connectivity
@@ -437,13 +437,13 @@ func handleZedAgentStatusImpl(ctxArg interface{}, key string,
 	status := statusArg.(types.ZedAgentStatus)
 	handleRebootCmd(ctxPtr, status)
 	updateZedagentCloudConnectStatus(ctxPtr, status)
-	log.Infof("handleZedAgentStatusImpl(%s) done", key)
+	log.Functionf("handleZedAgentStatusImpl(%s) done", key)
 }
 
 func handleZedAgentStatusDelete(ctxArg interface{}, key string,
 	statusArg interface{}) {
 	// do nothing
-	log.Infof("handleZedAgentStatusDelete(%s) done", key)
+	log.Functionf("handleZedAgentStatusDelete(%s) done", key)
 }
 
 // zboot status event handlers
@@ -464,7 +464,7 @@ func handleZbootStatusImpl(ctxArg interface{}, key string,
 	status := statusArg.(types.ZbootStatus)
 	if status.CurrentPartition && ctxPtr.updateInprogress &&
 		status.PartitionState == "active" {
-		log.Infof("CurPart(%s) transitioned to \"active\" state",
+		log.Functionf("CurPart(%s) transitioned to \"active\" state",
 			status.PartitionLabel)
 		ctxPtr.updateInprogress = false
 		ctxPtr.testComplete = false
@@ -473,7 +473,7 @@ func handleZbootStatusImpl(ctxArg interface{}, key string,
 	}
 	doZbootBaseOsInstallationComplete(ctxPtr, key, status)
 	doZbootBaseOsTestValidationComplete(ctxPtr, key, status)
-	log.Debugf("handleZbootStatusImpl(%s) done", key)
+	log.Tracef("handleZbootStatusImpl(%s) done", key)
 }
 
 func handleZbootStatusDelete(ctxArg interface{},
@@ -481,10 +481,10 @@ func handleZbootStatusDelete(ctxArg interface{},
 
 	ctxPtr := ctxArg.(*nodeagentContext)
 	if status := lookupZbootStatus(ctxPtr, key); status == nil {
-		log.Infof("handleZbootStatusDelete: unknown %s", key)
+		log.Functionf("handleZbootStatusDelete: unknown %s", key)
 		return
 	}
-	log.Infof("handleZbootStatusDelete(%s) done", key)
+	log.Functionf("handleZbootStatusDelete(%s) done", key)
 }
 
 // If we have a reboot reason from this or the other partition
@@ -575,7 +575,7 @@ func incrementRestartCounter() uint32 {
 				log.Errorf("incrementRestartCounter: %s", err)
 			} else {
 				restartCounter = uint32(c)
-				log.Infof("incrementRestartCounter: read %d", restartCounter)
+				log.Functionf("incrementRestartCounter: read %d", restartCounter)
 			}
 		}
 	}

--- a/pkg/pillar/cmd/tpmmgr/tpmmgr.go
+++ b/pkg/pillar/cmd/tpmmgr/tpmmgr.go
@@ -218,7 +218,7 @@ func createKey(keyHandle, ownerHandle tpmutil.Handle, template tpm2.Public, over
 		tpm2.HandleOwner,
 		keyHandle,
 		keyHandle); err != nil {
-		log.Debugf("EvictControl failed: %v", err)
+		log.Tracef("EvictControl failed: %v", err)
 	}
 	if err := tpm2.EvictControl(rw, etpm.EmptyPassword,
 		tpm2.HandleOwner, handle,
@@ -287,7 +287,7 @@ func writeDeviceCert() error {
 	if err := tpm2.NVUndefineSpace(rw, etpm.EmptyPassword,
 		tpm2.HandleOwner, etpm.TpmDeviceCertHdl,
 	); err != nil {
-		log.Debugf("NVUndefineSpace failed: %v", err)
+		log.Tracef("NVUndefineSpace failed: %v", err)
 	}
 
 	deviceCertBytes, err := ioutil.ReadFile(TpmDeviceCertFileName)
@@ -375,7 +375,7 @@ func writeCredentials() error {
 	if err := tpm2.NVUndefineSpace(rw, etpm.EmptyPassword,
 		tpm2.HandleOwner, etpm.TpmPasswdHdl,
 	); err != nil {
-		log.Debugf("NVUndefineSpace failed: %v", err)
+		log.Tracef("NVUndefineSpace failed: %v", err)
 	}
 
 	tpmCredentialBytes, err := ioutil.ReadFile(etpm.TpmCredentialsFileName)
@@ -1099,10 +1099,10 @@ func writeEcdhCertToFile(certBytes, keyBytes []byte) error {
 
 func publishEdgeNodeCert(ctx *tpmMgrContext, config types.EdgeNodeCert) {
 	key := config.Key()
-	log.Debugf("publishEdgeNodeCert %s", key)
+	log.Tracef("publishEdgeNodeCert %s", key)
 	pub := ctx.pubEdgeNodeCert
 	pub.Publish(key, config)
-	log.Debugf("publishEdgeNodeCert %s Done", key)
+	log.Tracef("publishEdgeNodeCert %s Done", key)
 }
 
 func readEdgeNodeCert(certPath string) ([]byte, error) {
@@ -1124,7 +1124,7 @@ func getCertHash(cert []byte, hashAlgo types.CertHashType) ([]byte, error) {
 }
 
 func publishEdgeNodeCertToController(ctx *tpmMgrContext, certFile string, certType types.CertType, isTpm bool, metaDataItems []types.CertMetaData) {
-	log.Infof("publishEdgeNodeCertToController started")
+	log.Functionf("publishEdgeNodeCertToController started")
 	if !etpm.FileExists(certFile) {
 		log.Errorf("publishEdgeNodeCertToController failed: no cert file")
 		return
@@ -1156,7 +1156,7 @@ func publishEdgeNodeCertToController(ctx *tpmMgrContext, certFile string, certTy
 		}
 	}
 	publishEdgeNodeCert(ctx, cert)
-	log.Infof("publishEdgeNodeCertToController Done")
+	log.Functionf("publishEdgeNodeCertToController Done")
 }
 
 func getEkCertMetaData() ([]types.CertMetaData, error) {
@@ -1282,7 +1282,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 			log.Errorf("saveTpmInfo failed: %v", err)
 		}
 	case "runAsService":
-		log.Infof("Starting %s", agentName)
+		log.Functionf("Starting %s", agentName)
 
 		if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
 			log.Fatal(err)
@@ -1388,7 +1388,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 		// Pick up debug aka log level before we start real work
 		for !ctx.GCInitialized {
-			log.Infof("waiting for GCInitialized")
+			log.Functionf("waiting for GCInitialized")
 			select {
 			case change := <-subGlobalConfig.MsgChan():
 				subGlobalConfig.ProcessChange(change)
@@ -1398,7 +1398,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 			}
 			ps.StillRunning(agentName, warningTime, errorTime)
 		}
-		log.Infof("processed GlobalConfig")
+		log.Functionf("processed GlobalConfig")
 
 		if etpm.IsTpmEnabled() && !etpm.FileExists(etpm.TpmCredentialsFileName) {
 			err := readCredentials()
@@ -1497,17 +1497,17 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 
 	ctx := ctxArg.(*tpmMgrContext)
 	if key != "global" {
-		log.Infof("handleGlobalConfigImpl: ignoring %s", key)
+		log.Functionf("handleGlobalConfigImpl: ignoring %s", key)
 		return
 	}
-	log.Infof("handleGlobalConfigImpl for %s", key)
+	log.Functionf("handleGlobalConfigImpl for %s", key)
 	var gcp *types.ConfigItemValueMap
 	debug, gcp = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
 		debugOverride, logger)
 	if gcp != nil {
 		ctx.GCInitialized = true
 	}
-	log.Infof("handleGlobalConfigImpl done for %s", key)
+	log.Functionf("handleGlobalConfigImpl done for %s", key)
 }
 
 func handleGlobalConfigDelete(ctxArg interface{}, key string,
@@ -1515,13 +1515,13 @@ func handleGlobalConfigDelete(ctxArg interface{}, key string,
 
 	ctx := ctxArg.(*tpmMgrContext)
 	if key != "global" {
-		log.Infof("handleGlobalConfigDelete: ignoring %s", key)
+		log.Functionf("handleGlobalConfigDelete: ignoring %s", key)
 		return
 	}
-	log.Infof("handleGlobalConfigDelete for %s", key)
+	log.Functionf("handleGlobalConfigDelete for %s", key)
 	debug, _ = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
 		debugOverride, logger)
-	log.Infof("handleGlobalConfigDelete done for %s", key)
+	log.Functionf("handleGlobalConfigDelete done for %s", key)
 }
 
 func handleNodeAgentStatusCreate(ctxArg interface{}, key string,
@@ -1540,25 +1540,25 @@ func handleNodeAgentStatusImpl(ctxArg interface{}, key string,
 	status := statusArg.(types.NodeAgentStatus)
 	ctx := ctxArg.(*tpmMgrContext)
 	if key != "nodeagent" {
-		log.Infof("handleNodeAgentStatusImpl: ignoring %s", key)
+		log.Functionf("handleNodeAgentStatusImpl: ignoring %s", key)
 		return
 	}
 	ctx.DeviceReboot = status.DeviceReboot
-	log.Infof("handleNodeAgentStatusImpl done for %s: %v", key, ctx.DeviceReboot)
+	log.Functionf("handleNodeAgentStatusImpl done for %s: %v", key, ctx.DeviceReboot)
 }
 
 func handleNodeAgentStatusDelete(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
-	log.Infof("handleNodeAgentStatusDelete for %s", key)
+	log.Functionf("handleNodeAgentStatusDelete for %s", key)
 	ctx := ctxArg.(*tpmMgrContext)
 
 	if key != "nodeagent" {
-		log.Infof("handleNodeAgentStatusDelete: ignoring %s", key)
+		log.Functionf("handleNodeAgentStatusDelete: ignoring %s", key)
 		return
 	}
 	ctx.DeviceReboot = false
-	log.Infof("handleNodeAgentStatusDelete done for %s: %v", key, ctx.DeviceReboot)
+	log.Functionf("handleNodeAgentStatusDelete done for %s: %v", key, ctx.DeviceReboot)
 }
 
 func readNodeAgentStatus(ctx *tpmMgrContext) (bool, error) {
@@ -1583,10 +1583,10 @@ func handleAttestNonceModify(ctxArg interface{}, key string,
 func handleAttestNonceImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
-	log.Infof("handleAttestNonceImpl received")
+	log.Functionf("handleAttestNonceImpl received")
 	ctx := ctxArg.(*tpmMgrContext)
 	nonceReq := statusArg.(types.AttestNonce)
-	log.Infof("Received quote request from %s", nonceReq.Requester)
+	log.Functionf("Received quote request from %s", nonceReq.Requester)
 	quote, signature, pcrs, err := getQuote(nonceReq.Nonce)
 	if err != nil {
 		log.Errorf("Error in fetching quote %v", err)
@@ -1599,21 +1599,21 @@ func handleAttestNonceImpl(ctxArg interface{}, key string,
 		PCRs:      pcrs,
 	}
 	pubKey := attestQuote.Key()
-	log.Debugf("publishing quote for nonce %x", pubKey)
+	log.Tracef("publishing quote for nonce %x", pubKey)
 	pub := ctx.pubAttestQuote
 	pub.Publish(pubKey, attestQuote)
-	log.Debugf("handleAttestNonceImpl done")
+	log.Tracef("handleAttestNonceImpl done")
 }
 
 func handleAttestNonceDelete(ctxArg interface{}, key string, statusArg interface{}) {
-	log.Infof("handleAttestNonceDelete received")
+	log.Functionf("handleAttestNonceDelete received")
 	ctx := ctxArg.(*tpmMgrContext)
 	pub := ctx.pubAttestQuote
 	st, _ := pub.Get(key)
 	if st != nil {
-		log.Infof("Unpublishing quote for nonce %x", key)
+		log.Functionf("Unpublishing quote for nonce %x", key)
 		pub := ctx.pubAttestQuote
 		pub.Unpublish(key)
 	}
-	log.Infof("handleAttestNonceDelete done")
+	log.Functionf("handleAttestNonceDelete done")
 }

--- a/pkg/pillar/cmd/upgradeconverter/applydefaultconfigitem.go
+++ b/pkg/pillar/cmd/upgradeconverter/applydefaultconfigitem.go
@@ -46,7 +46,7 @@ func applyDefaultConfigItem(ctxPtr *ucContext) error {
 	if err != nil {
 		log.Fatalf("Failed to Save NewConfig. err %s", err)
 	}
-	log.Debugf("upgradeconverter.applyDefaultConfigItem done")
+	log.Tracef("upgradeconverter.applyDefaultConfigItem done")
 	return nil
 }
 

--- a/pkg/pillar/cmd/upgradeconverter/convertglobalconfig.go
+++ b/pkg/pillar/cmd/upgradeconverter/convertglobalconfig.go
@@ -16,7 +16,7 @@ func createConfigItemMapDir(configItemMapDir string) {
 	if err == nil {
 		// Dir Exists.. Make sure it is a Dir
 		if info.IsDir() {
-			log.Debugf("createConfigItemMapDir: Dir %s Exists", configItemMapDir)
+			log.Tracef("createConfigItemMapDir: Dir %s Exists", configItemMapDir)
 			return
 		}
 		log.Errorf("***createConfigItemMapDir: %s not a directory. Info: %+v\n"+
@@ -27,7 +27,7 @@ func createConfigItemMapDir(configItemMapDir string) {
 				configItemMapDir, err)
 		}
 	} else if os.IsNotExist(err) {
-		log.Debugf("createConfigItemMapDir: Dir %s Doesn't Exist. Creating it.",
+		log.Tracef("createConfigItemMapDir: Dir %s Doesn't Exist. Creating it.",
 			configItemMapDir)
 	} else {
 		log.Fatalf("***createConfigItemMapDir: Failed to get Info for file %s. Err: %s",
@@ -46,7 +46,7 @@ func delOldGlobalConfigDir(ctxPtr *ucContext) error {
 	globalConfigDir := ctxPtr.globalConfigDir()
 	err := os.RemoveAll(globalConfigDir)
 	if err == nil {
-		log.Debugf("delOldGlobalConfigDir: Removed %s", globalConfigDir)
+		log.Tracef("delOldGlobalConfigDir: Removed %s", globalConfigDir)
 		return nil
 	}
 	log.Errorf("delOldGlobalConfigDir: Failed to remove %s", globalConfigDir)
@@ -68,25 +68,25 @@ func convertGlobalConfig(ctxPtr *ucContext) error {
 		if newExists {
 			newTime, _ := fileTimeStamp(newGlobalConfigFile)
 			oldTime, _ := fileTimeStamp(oldGlobalConfigFile)
-			log.Debugf("convertGlobalConfig: newTime:%+v, oldTime: %+v",
+			log.Tracef("convertGlobalConfig: newTime:%+v, oldTime: %+v",
 				newTime, oldTime)
 			if oldTime.After(newTime) {
-				log.Infof("OldConfig Newer than NewConfig. Need Conversion")
+				log.Functionf("OldConfig Newer than NewConfig. Need Conversion")
 			} else {
-				log.Infof("convertGlobalConfig: NewConfig Newer than OldConfig")
+				log.Functionf("convertGlobalConfig: NewConfig Newer than OldConfig")
 				delOldGlobalConfigDir(ctxPtr)
 				return nil
 			}
 		} else {
-			log.Infof("OldConfig Exists. NO NewConfig. Need Conversion")
+			log.Functionf("OldConfig Exists. NO NewConfig. Need Conversion")
 		}
 		newConfigPtr = newConfigFromOld(oldGlobalConfigFile)
 	} else if newExists {
-		log.Infof("No Old Config. Only new Config Exists. No conversion needed")
+		log.Functionf("No Old Config. Only new Config Exists. No conversion needed")
 		delOldGlobalConfigDir(ctxPtr)
 		return nil
 	} else {
-		log.Infof("Neither New Nor Old Configs Exist. Do nothing")
+		log.Functionf("Neither New Nor Old Configs Exist. Do nothing")
 		return nil
 	}
 
@@ -102,7 +102,7 @@ func convertGlobalConfig(ctxPtr *ucContext) error {
 	}
 	// Delete the OldGlobalConfig
 	delOldGlobalConfigDir(ctxPtr)
-	log.Debugf("upgradeconverter.convertGlobalConfig done")
+	log.Tracef("upgradeconverter.convertGlobalConfig done")
 	return nil
 }
 
@@ -133,6 +133,6 @@ func newConfigFromOld(globalConfigFile string) *types.ConfigItemValueMap {
 func convert(ctxPtr *ucContext) error {
 	// Any any conversions we need here.
 	err := convertGlobalConfig(ctxPtr)
-	log.Debugf("upgradeconverter.convert done")
+	log.Tracef("upgradeconverter.convert done")
 	return err
 }

--- a/pkg/pillar/cmd/upgradeconverter/inhalelatch.go
+++ b/pkg/pillar/cmd/upgradeconverter/inhalelatch.go
@@ -20,7 +20,7 @@ type latch struct {
 }
 
 func inhaleLatch(ps *pubsub.PubSub) (latch, error) {
-	log.Debugf("inhaleLatch()")
+	log.Tracef("inhaleLatch()")
 	var l latch
 
 	pub, err := ps.NewPublication(pubsub.PublicationOptions{
@@ -34,7 +34,7 @@ func inhaleLatch(ps *pubsub.PubSub) (latch, error) {
 	}
 	// The persistent publication has pulled in what is already published
 	items := pub.GetAll()
-	log.Debugf("inhaleLatch found %d", len(items))
+	log.Tracef("inhaleLatch found %d", len(items))
 	for _, item := range items {
 		aih := item.(types.AppAndImageToHash)
 		l.latches = append(l.latches, aih)
@@ -48,12 +48,12 @@ func (l *latch) lookup(appInstID uuid.UUID, imageID uuid.UUID, purgeCounter uint
 		aih := &l.latches[i]
 		if aih.AppUUID == appInstID && aih.ImageID == imageID &&
 			aih.PurgeCounter == purgeCounter {
-			log.Debugf("latch.lookup found appInstID %s imageID %s purgeCounter %d",
+			log.Tracef("latch.lookup found appInstID %s imageID %s purgeCounter %d",
 				appInstID, imageID, purgeCounter)
 			return aih
 		}
 	}
-	log.Debugf("latch.lookup NOT found appInstID %s imageID %s purgeCounter %d",
+	log.Tracef("latch.lookup NOT found appInstID %s imageID %s purgeCounter %d",
 		appInstID, imageID, purgeCounter)
 	return nil
 }

--- a/pkg/pillar/cmd/upgradeconverter/moveconfigitem.go
+++ b/pkg/pillar/cmd/upgradeconverter/moveconfigitem.go
@@ -18,12 +18,12 @@ func moveConfigItemValueMap(ctxPtr *ucContext) error {
 		if newExists {
 			newTime, _ := fileTimeStamp(newFile)
 			oldTime, _ := fileTimeStamp(oldFile)
-			log.Debugf("moveConfigItemValueMap: newTime:%+v, oldTime: %+v",
+			log.Tracef("moveConfigItemValueMap: newTime:%+v, oldTime: %+v",
 				newTime, oldTime)
 			if oldTime.After(newTime) {
-				log.Infof("oldFile more recent than newFile. Copy")
+				log.Functionf("oldFile more recent than newFile. Copy")
 			} else {
-				log.Infof("newFile more recent than oldFile. Discard old")
+				log.Functionf("newFile more recent than oldFile. Discard old")
 				err := os.RemoveAll(ctxPtr.oldConfigItemValueMapDir())
 				if err != nil {
 					log.Error(err)
@@ -31,17 +31,17 @@ func moveConfigItemValueMap(ctxPtr *ucContext) error {
 				return nil
 			}
 		} else {
-			log.Infof("Old Config Exists. No New Config. Copy")
+			log.Functionf("Old Config Exists. No New Config. Copy")
 		}
 	} else if newExists {
-		log.Infof("No Old Config. Only new Config Exists. No copy needed")
+		log.Functionf("No Old Config. Only new Config Exists. No copy needed")
 		return nil
 	} else {
-		log.Infof("Neither new nor old configs exist. Bail")
+		log.Functionf("Neither new nor old configs exist. Bail")
 		return nil
 	}
 
-	log.Infof("Copy from %s to %s", oldFile, newFile)
+	log.Functionf("Copy from %s to %s", oldFile, newFile)
 	err := CopyFile(oldFile, newFile)
 	if err != nil {
 		log.Error(err)
@@ -51,6 +51,6 @@ func moveConfigItemValueMap(ctxPtr *ucContext) error {
 	if err != nil {
 		log.Error(err)
 	}
-	log.Debugf("upgradeconverter.moveConfigItemValueMap done")
+	log.Tracef("upgradeconverter.moveConfigItemValueMap done")
 	return nil
 }

--- a/pkg/pillar/cmd/upgradeconverter/oldvolumes.go
+++ b/pkg/pillar/cmd/upgradeconverter/oldvolumes.go
@@ -26,7 +26,7 @@ type oldVolume struct {
 // recursive scanning for volumes
 func scanDir(dirName string, isContainer bool) []oldVolume {
 
-	log.Debugf("scanDir(%s)", dirName)
+	log.Tracef("scanDir(%s)", dirName)
 	var old []oldVolume
 
 	locations, err := ioutil.ReadDir(dirName)
@@ -39,7 +39,7 @@ func scanDir(dirName string, isContainer bool) []oldVolume {
 	for _, location := range locations {
 		filelocation := dirName + "/" + location.Name()
 		if location.IsDir() && !isContainer {
-			log.Debugf("scanDir: directory %s ignored", filelocation)
+			log.Tracef("scanDir: directory %s ignored", filelocation)
 			continue
 		}
 		info, err := os.Stat(filelocation)
@@ -49,7 +49,7 @@ func scanDir(dirName string, isContainer bool) []oldVolume {
 			continue
 		}
 		_, sha256, appUUIDStr, purgeCounter, format := parseAppRwVolumeName(filelocation, isContainer)
-		log.Infof("scanDir: Processing sha256: %s, AppUuid: %s, "+
+		log.Functionf("scanDir: Processing sha256: %s, AppUuid: %s, "+
 			"fileLocation:%s, format:%s",
 			sha256, appUUIDStr, filelocation, format)
 

--- a/pkg/pillar/cmd/upgradeconverter/parseconfig.go
+++ b/pkg/pillar/cmd/upgradeconverter/parseconfig.go
@@ -31,7 +31,7 @@ func parseConfig(checkpointFile string) (parseResult, error) {
 		return res, err
 	}
 	for i, ct := range cts {
-		log.Debugf("content tree[%d] ctID %s displayName %s relativeURL %s sha256 %s gc %d",
+		log.Tracef("content tree[%d] ctID %s displayName %s relativeURL %s sha256 %s gc %d",
 			i, ct.contentTreeID, ct.displayName, ct.relativeURL,
 			ct.sha256, ct.generationCounter)
 	}
@@ -41,7 +41,7 @@ func parseConfig(checkpointFile string) (parseResult, error) {
 		return res, err
 	}
 	for i, vi := range volumes {
-		log.Debugf("volume[%d] volumeID %s ctID %s imageURL %s sha256 %s gc %d",
+		log.Tracef("volume[%d] volumeID %s ctID %s imageURL %s sha256 %s gc %d",
 			i, vi.volumeID, vi.contentTreeID, vi.imageURL, vi.sha256,
 			vi.generationCounter)
 	}
@@ -51,7 +51,7 @@ func parseConfig(checkpointFile string) (parseResult, error) {
 		return res, err
 	}
 	for i, ai := range appInsts {
-		log.Debugf("app inst[%d] appInstID %s imageID %s imageName %s sha256 %s purgeCounter %d volumeID %s gc %d",
+		log.Tracef("app inst[%d] appInstID %s imageID %s imageName %s sha256 %s purgeCounter %d volumeID %s gc %d",
 			i, ai.appInstID, ai.imageID, ai.imageName, ai.sha256,
 			ai.purgeCounter, ai.volumeID, ai.generationCounter)
 	}
@@ -81,7 +81,7 @@ func parseAppInstances(config *zconfig.EdgeDevConfig) ([]driveAndVolumeRef, erro
 	var appInsts []driveAndVolumeRef
 
 	apps := config.GetApps()
-	log.Debugf("parseAppInstances %d apps", len(apps))
+	log.Tracef("parseAppInstances %d apps", len(apps))
 	for i, cfgApp := range apps {
 		appInstID, _ := uuid.FromString(cfgApp.Uuidandversion.Uuid)
 		drives := cfgApp.GetDrives()
@@ -92,7 +92,7 @@ func parseAppInstances(config *zconfig.EdgeDevConfig) ([]driveAndVolumeRef, erro
 		if cmd != nil {
 			purgeCounter = cmd.Counter
 		}
-		log.Infof("parseAppInstances[%d] %d drives %d volumeRefs",
+		log.Functionf("parseAppInstances[%d] %d drives %d volumeRefs",
 			i, len(drives), len(volumeRefs))
 
 		davr := make([]driveAndVolumeRef, len(drives))
@@ -106,7 +106,7 @@ func parseAppInstances(config *zconfig.EdgeDevConfig) ([]driveAndVolumeRef, erro
 			// Just like zedagent we apply the purgeCounter to the
 			// first disk
 			if i == 0 && purgeCounter != 0 {
-				log.Infof("parseAppInstances setting purgeCounter to %d  for appInstID %s imageID %s",
+				log.Functionf("parseAppInstances setting purgeCounter to %d  for appInstID %s imageID %s",
 					purgeCounter, appInstID, imageID)
 				davr[i].purgeCounter = purgeCounter
 			}
@@ -125,7 +125,7 @@ func parseVolumes(config *zconfig.EdgeDevConfig) ([]volumeInfo, error) {
 
 	var volumes []volumeInfo
 	vols := config.GetVolumes()
-	log.Debugf("parseVolumes %d volumes", len(vols))
+	log.Tracef("parseVolumes %d volumes", len(vols))
 	for _, vol := range vols {
 		volumeID, _ := uuid.FromString(vol.Uuid)
 		vco := vol.GetOrigin()
@@ -146,7 +146,7 @@ func parseContentTrees(config *zconfig.EdgeDevConfig) ([]contentTree, error) {
 
 	var cts []contentTree
 	zcts := config.GetContentInfo()
-	log.Debugf("parseContentTrees %d contentTrees", len(zcts))
+	log.Tracef("parseContentTrees %d contentTrees", len(zcts))
 	for _, zct := range zcts {
 		ctID, _ := uuid.FromString(zct.Uuid)
 		ct := contentTree{
@@ -166,7 +166,7 @@ func (pr parseResult) lookupContentTree(ctID uuid.UUID) *contentTree {
 	for i := range pr.contentTrees {
 		ct := &pr.contentTrees[i]
 		if ct.contentTreeID == ctID {
-			log.Debugf("lookupContentTree found %s", ctID)
+			log.Tracef("lookupContentTree found %s", ctID)
 			return ct
 		}
 	}
@@ -179,7 +179,7 @@ func (pr parseResult) lookupDriveAndVolumeRef(appInstID uuid.UUID, sha256 string
 	for i := range pr.appInsts {
 		dlvr := &pr.appInsts[i]
 		if dlvr.appInstID == appInstID && dlvr.sha256 == sha256 {
-			log.Debugf("lookupAppInst found %s sha %s",
+			log.Tracef("lookupAppInst found %s sha %s",
 				appInstID, sha256)
 			return dlvr
 		}
@@ -198,10 +198,10 @@ func (pr parseResult) lookupVolume(volumeID uuid.UUID, generationCounter int64) 
 		vi := &pr.volumes[i]
 		if vi.volumeID == volumeID {
 			if vi.generationCounter == generationCounter {
-				log.Infof("lookupVolume found %s#%d",
+				log.Functionf("lookupVolume found %s#%d",
 					volumeID, generationCounter)
 			} else {
-				log.Infof("lookupVolume almost found %s#%d: gc %d",
+				log.Functionf("lookupVolume almost found %s#%d: gc %d",
 					volumeID, generationCounter,
 					vi.generationCounter)
 			}

--- a/pkg/pillar/cmd/upgradeconverter/persistlayout.go
+++ b/pkg/pillar/cmd/upgradeconverter/persistlayout.go
@@ -19,7 +19,7 @@ import (
 )
 
 func convertPersistVolumes(ctxPtr *ucContext) error {
-	log.Infof("convertPersistVolumes()")
+	log.Functionf("convertPersistVolumes()")
 	checkpointFile := ctxPtr.configCheckpointFile()
 	if !fileExists(checkpointFile) {
 		// This error always happens on first boot of a device.
@@ -47,12 +47,12 @@ func convertPersistVolumes(ctxPtr *ucContext) error {
 	oldVMExists := dirExists(oldVMVolumesDir)
 	oldOCIExists := dirExists(oldOCIVolumesDir)
 	if !newExists {
-		log.Infof("Creating new %s", newVolumesDir)
+		log.Functionf("Creating new %s", newVolumesDir)
 		if err := os.MkdirAll(newVolumesDir, 0700); err != nil {
 			return err
 		}
 	}
-	log.Infof("new %t oldVM %t oldOCI %t", newExists, oldVMExists,
+	log.Functionf("new %t oldVM %t oldOCI %t", newExists, oldVMExists,
 		oldOCIExists)
 	var old1, old2 []oldVolume
 	if oldVMExists {
@@ -62,7 +62,7 @@ func convertPersistVolumes(ctxPtr *ucContext) error {
 		old2 = scanDir(oldOCIVolumesDir, true)
 	}
 	old := append(old1, old2...)
-	log.Debugf("Found %d oldVolumes: %+v", len(old), old)
+	log.Tracef("Found %d oldVolumes: %+v", len(old), old)
 	for i, ov := range old {
 		dlvr := pr.lookupDriveAndVolumeRef(ov.appInstID, ov.sha256)
 		if dlvr == nil {
@@ -70,14 +70,14 @@ func convertPersistVolumes(ctxPtr *ucContext) error {
 				i, ov.appInstID, ov.sha256)
 			continue
 		}
-		log.Infof("DLVR %d used by appInst %s, path %s",
+		log.Functionf("DLVR %d used by appInst %s, path %s",
 			i, ov.appInstID, ov.pathname)
 		// Note that we get the generationCounter from the volumeRef
 		// which is most likely zero even if the old volume had a
 		// non-zero purgeCounter
 		newPath := fmt.Sprintf("%s/%s#%d.%s", newVolumesDir,
 			dlvr.volumeID, dlvr.generationCounter, ov.format)
-		log.Infof("DLVR %d volumeID %s generationCounter %d, purgeCounter %d, format %s, new path %s",
+		log.Functionf("DLVR %d volumeID %s generationCounter %d, purgeCounter %d, format %s, new path %s",
 			i, dlvr.volumeID, dlvr.generationCounter,
 			dlvr.purgeCounter, ov.format, newPath)
 		if dlvr.sha256 != ov.sha256 {
@@ -104,7 +104,7 @@ func maybeMove(oldPath string, oldModTime time.Time, newPath string, noFlag bool
 	if err == nil {
 		newModTime := info.ModTime()
 		if newModTime.After(oldModTime) {
-			log.Infof("New file %s newer than old %s: %s vs. %s. Not replaced",
+			log.Functionf("New file %s newer than old %s: %s vs. %s. Not replaced",
 				newPath, oldPath,
 				oldModTime.Format(time.RFC3339Nano),
 				newModTime.Format(time.RFC3339Nano))
@@ -119,10 +119,10 @@ func maybeMove(oldPath string, oldModTime time.Time, newPath string, noFlag bool
 		return
 	}
 	if noFlag {
-		log.Infof("Persist layout dryrun from %s to %s",
+		log.Functionf("Persist layout dryrun from %s to %s",
 			oldPath, newPath)
 	} else {
-		log.Infof("Moving %s to %s: %t", oldPath, newPath, !noFlag)
+		log.Functionf("Moving %s to %s: %t", oldPath, newPath, !noFlag)
 		// Can not rename between vault directories so we
 		// have to copy and delete.
 		fi, err := os.Stat(oldPath)
@@ -192,12 +192,12 @@ func (pr *parseResult) propagateInfo() {
 			continue
 		}
 		if vi.sha256 == "" {
-			log.Infof("volume[%d] volumeID %s setting sha from ctID %s: %s",
+			log.Functionf("volume[%d] volumeID %s setting sha from ctID %s: %s",
 				i, vi.volumeID, vi.contentTreeID, ct.sha256)
 			vi.sha256 = ct.sha256
 		}
 		if vi.imageURL == "" {
-			log.Infof("volume[%d] volumeID %s setting imageURL from ctID %s: %s",
+			log.Functionf("volume[%d] volumeID %s setting imageURL from ctID %s: %s",
 				i, vi.volumeID, vi.contentTreeID, ct.relativeURL)
 			vi.imageURL = ct.relativeURL
 		}
@@ -213,7 +213,7 @@ func (pr *parseResult) applyLatch(l latch) {
 			continue
 		}
 		if davr.sha256 == "" {
-			log.Infof("app inst[%d] appInstID %s imageID %s purge %d setting sha: %s",
+			log.Functionf("app inst[%d] appInstID %s imageID %s purge %d setting sha: %s",
 				i, davr.appInstID, davr.imageID,
 				davr.purgeCounter, aih.Hash)
 			davr.sha256 = aih.Hash

--- a/pkg/pillar/cmd/upgradeconverter/renameverifiedfiles.go
+++ b/pkg/pillar/cmd/upgradeconverter/renameverifiedfiles.go
@@ -20,7 +20,7 @@ const (
 // to /persist/vault/verifier/verified/<lower case sha>
 
 func renameVerifiedFiles(ctxPtr *ucContext) error {
-	log.Infof("renameVerifiedFiles()")
+	log.Functionf("renameVerifiedFiles()")
 	if _, err := os.Stat(dstDir); err != nil {
 		if err := os.MkdirAll(dstDir, 0700); err != nil {
 			log.Error(err)
@@ -31,14 +31,14 @@ func renameVerifiedFiles(ctxPtr *ucContext) error {
 		ctxPtr.noFlag)
 	renameFiles(srcDirRoot+"/"+types.BaseOsObj+"/verified", dstDir,
 		ctxPtr.noFlag)
-	log.Infof("renameVerifiedFiles() DONE")
+	log.Functionf("renameVerifiedFiles() DONE")
 	return nil
 }
 
 // If noFlag is set we just log and no file system modifications.
 func renameFiles(srcDir string, dstDir string, noFlag bool) {
 
-	log.Infof("renameFiles(%s, %s, %t)", srcDir, dstDir, noFlag)
+	log.Functionf("renameFiles(%s, %s, %t)", srcDir, dstDir, noFlag)
 	if _, err := os.Stat(dstDir); err != nil {
 		if err := os.MkdirAll(dstDir, 0700); err != nil {
 			log.Error(err)
@@ -84,7 +84,7 @@ func renameFiles(srcDir string, dstDir string, noFlag bool) {
 			continue
 		}
 		if noFlag {
-			log.Infof("renameFiles: dryrun from %s to %s",
+			log.Functionf("renameFiles: dryrun from %s to %s",
 				srcFile, dstFile)
 		} else {
 			// Must copy due to fscrypt

--- a/pkg/pillar/cmd/upgradeconverter/upgradeconverter.go
+++ b/pkg/pillar/cmd/upgradeconverter/upgradeconverter.go
@@ -107,7 +107,7 @@ func (ctx ucContext) configCheckpointFile() string {
 
 func runHandlers(ctxPtr *ucContext, handlers []ConversionHandler) {
 	for _, handler := range handlers {
-		log.Infof("upgradeconverter.Run: Running Conversion handler: %s",
+		log.Functionf("upgradeconverter.Run: Running Conversion handler: %s",
 			handler.description)
 		err := handler.handlerFunc(ctxPtr)
 		if err != nil {
@@ -145,7 +145,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	if err := pidfile.CheckAndCreatePidfile(log, ctx.agentName); err != nil {
 		log.Fatal(err)
 	}
-	log.Infof("Starting %s\n", ctx.agentName)
+	log.Functionf("Starting %s\n", ctx.agentName)
 
 	phase := UCPhasePreVault
 	if len(flag.Args()) != 0 {

--- a/pkg/pillar/cmd/upgradeconverter/upgradeconverter_test.go
+++ b/pkg/pillar/cmd/upgradeconverter/upgradeconverter_test.go
@@ -63,7 +63,7 @@ func createJSONFile(config interface{}, file string) {
 		if err != nil {
 			log.Fatalf("Failed to create Dir: %s", parentDir)
 		}
-		log.Debugf("Created Dir: %s", parentDir)
+		log.Tracef("Created Dir: %s", parentDir)
 	}
 	configJSON, err := json.Marshal(config)
 	if err != nil {

--- a/pkg/pillar/cmd/upgradeconverter/upgradeconverterutils.go
+++ b/pkg/pillar/cmd/upgradeconverter/upgradeconverterutils.go
@@ -36,7 +36,7 @@ func dirExists(dirname string) bool {
 func fileTimeStamp(filename string) (time.Time, error) {
 	file, err := os.Stat(filename)
 	if err != nil {
-		log.Infof("failed to get a timestamp for file %s err %s", filename, err)
+		log.Functionf("failed to get a timestamp for file %s err %s", filename, err)
 		return time.Time{}, err
 	}
 	return file.ModTime(), nil
@@ -45,7 +45,7 @@ func fileTimeStamp(filename string) (time.Time, error) {
 func deleteFile(filename string) error {
 	var err = os.Remove(filename)
 	if err == nil {
-		log.Infof("Removed file %s", filename)
+		log.Functionf("Removed file %s", filename)
 		return nil
 	}
 	return err

--- a/pkg/pillar/cmd/vaultmgr/vaultmgr.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgr.go
@@ -154,7 +154,7 @@ func removeProtectorIfAny(vaultPath string) error {
 		return nil
 	}
 	if err == nil {
-		log.Infof("Removing protectorID %s for vaultPath %s", protectorID[0][1], vaultPath)
+		log.Functionf("Removing protectorID %s for vaultPath %s", protectorID[0][1], vaultPath)
 		args := getRemoveProtectorParams(protectorID[0][1])
 		if stdOut, stdErr, err := execCmd(vault.FscryptPath, args...); err != nil {
 			log.Errorf("Error changing protector key: %v, %v, %v", err, stdOut, stdErr)
@@ -162,7 +162,7 @@ func removeProtectorIfAny(vaultPath string) error {
 		}
 		policyID, err := getPolicyIDByProtectorID(protectorID[0][1])
 		if err == nil {
-			log.Infof("Removing policyID %s for vaultPath %s", policyID[0][1], vaultPath)
+			log.Functionf("Removing policyID %s for vaultPath %s", policyID[0][1], vaultPath)
 			args := getRemovePolicyParams(policyID[0][1])
 			if stdOut, stdErr, err := execCmd(vault.FscryptPath, args...); err != nil {
 				log.Errorf("Error changing policy key: %v, %v, %v", err, stdOut, stdErr)
@@ -217,11 +217,11 @@ func changeProtector(vaultPath string) error {
 		if stdOut, stdErr, err := execCmd(vault.FscryptPath,
 			getChangeProtectorParams(protectorID[0][1])...); err != nil {
 			log.Errorf("Error changing protector key: %v", err)
-			log.Debug(stdOut)
-			log.Debug(stdErr)
+			log.Trace(stdOut)
+			log.Trace(stdErr)
 			return err
 		}
-		log.Infof("Changed key for protector %s", (protectorID[0][1]))
+		log.Functionf("Changed key for protector %s", (protectorID[0][1]))
 	}
 	return err
 }
@@ -276,7 +276,7 @@ func mergeKeys(key1 []byte, key2 []byte) ([]byte, error) {
 	mergedKey := []byte("")
 	mergedKey = append(mergedKey, key1[0:v1]...)
 	mergedKey = append(mergedKey, key2[v1:v2]...)
-	log.Info("Merging keys")
+	log.Function("Merging keys")
 	return mergedKey, nil
 }
 
@@ -289,7 +289,7 @@ func deriveVaultKey(cloudKeyOnlyMode, useSealedKey bool) ([]byte, error) {
 	}
 	//For pre 5.6.2 devices, remove once devices move to 5.6.2
 	if cloudKeyOnlyMode {
-		log.Infof("Using cloud key")
+		log.Functionf("Using cloud key")
 		return cloudKey, nil
 	}
 	tpmKey, err := retrieveTpmKey(useSealedKey)
@@ -351,11 +351,11 @@ func isDirEmpty(path string) bool {
 			return false
 		}
 		if len(files) == 0 {
-			log.Debugf("No files in %s", path)
+			log.Tracef("No files in %s", path)
 			return true
 		}
 	}
-	log.Debugf("Dir is not empty at %s", path)
+	log.Tracef("Dir is not empty at %s", path)
 	return false
 }
 
@@ -422,7 +422,7 @@ func isFscryptEnabled(vaultPath string) bool {
 func setupVault(vaultPath string, deprecated bool) error {
 	_, err := os.Stat(vaultPath)
 	if os.IsNotExist(err) && deprecated {
-		log.Infof("vault %s is marked deprecated, so not creating a new vault", vaultPath)
+		log.Functionf("vault %s is marked deprecated, so not creating a new vault", vaultPath)
 		return nil
 	}
 	if err != nil && !deprecated {
@@ -433,17 +433,17 @@ func setupVault(vaultPath string, deprecated bool) error {
 	}
 	args := getStatusParams(vaultPath)
 	if stdOut, stdErr, err := execCmd(vault.FscryptPath, args...); err != nil {
-		log.Infof("%v, %v, %v", stdOut, stdErr, err)
+		log.Functionf("%v, %v, %v", stdOut, stdErr, err)
 		if !isDirEmpty(vaultPath) || deprecated {
 			//Don't disturb existing installations
-			log.Infof("Not disturbing non-empty or deprecated vault(%s), deprecated=%v",
+			log.Functionf("Not disturbing non-empty or deprecated vault(%s), deprecated=%v",
 				vaultPath, deprecated)
 			return nil
 		}
 		return createVault(vaultPath)
 	}
 	//Already setup for encryption, go for unlocking
-	log.Infof("Unlocking %s", vaultPath)
+	log.Functionf("Unlocking %s", vaultPath)
 	//cloudKeyOnlyMode = false, useSealedKey=false if deprecated, true otherwise
 	if err := unlockVault(vaultPath, false, !deprecated); err != nil {
 		if !deprecated {
@@ -484,7 +484,7 @@ func publishUnknownVaultStatus(ctx *vaultMgrContext, vaultName string) {
 	status.SetErrorNow("Unsupported filesystem")
 
 	key := status.Key()
-	log.Debugf("Publishing VaultStatus %s\n", key)
+	log.Tracef("Publishing VaultStatus %s\n", key)
 	pub := ctx.pubVaultStatus
 	pub.Publish(key, status)
 }
@@ -529,7 +529,7 @@ func publishFscryptVaultStatus(ctx *vaultMgrContext,
 		}
 	}
 	key := status.Key()
-	log.Debugf("Publishing VaultStatus %s\n", key)
+	log.Tracef("Publishing VaultStatus %s\n", key)
 	pub := ctx.pubVaultStatus
 	pub.Publish(key, status)
 }
@@ -539,24 +539,24 @@ func fetchFscryptStatus() (info.DataSecAtRestStatus, string) {
 	if err == nil {
 		if _, _, err := execCmd(vault.FscryptPath, vault.StatusParams...); err != nil {
 			//fscrypt is setup, but not being used
-			log.Debug("Setting status to Error")
+			log.Trace("Setting status to Error")
 			return info.DataSecAtRestStatus_DATASEC_AT_REST_ERROR,
 				"Initialization failure"
 		} else {
 			//fscrypt is setup , and being used on /persist
-			log.Debug("Setting status to Enabled")
+			log.Trace("Setting status to Enabled")
 			return info.DataSecAtRestStatus_DATASEC_AT_REST_ENABLED, ""
 		}
 	} else {
 		_, err := os.Stat(etpm.TpmDevicePath)
 		if err != nil {
 			//This is due to lack of TPM
-			log.Debug("Setting status to disabled, TPM is not in use")
+			log.Trace("Setting status to disabled, TPM is not in use")
 			return info.DataSecAtRestStatus_DATASEC_AT_REST_DISABLED,
 				"No active TPM found, but needed for key generation"
 		} else {
 			//This is due to ext3 partition
-			log.Debug("setting status to disabled, ext3 partition")
+			log.Trace("setting status to disabled, ext3 partition")
 			return info.DataSecAtRestStatus_DATASEC_AT_REST_DISABLED,
 				"File system is incompatible, needs a disruptive upgrade"
 		}
@@ -688,7 +688,7 @@ func publishZfsVaultStatus(ctx *vaultMgrContext, vaultName, vaultPath string) {
 	} else {
 		datasetStatus, err := vault.CheckOperStatus(log, vaultPath)
 		if err == nil {
-			log.Infof("checkOperStatus returns %s for %s", datasetStatus, vaultPath)
+			log.Functionf("checkOperStatus returns %s for %s", datasetStatus, vaultPath)
 			datasetStatus = processOperStatus(datasetStatus)
 		}
 		if datasetStatus != "" {
@@ -700,7 +700,7 @@ func publishZfsVaultStatus(ctx *vaultMgrContext, vaultName, vaultPath string) {
 		}
 	}
 	key := status.Key()
-	log.Debugf("Publishing VaultStatus %s\n", key)
+	log.Tracef("Publishing VaultStatus %s\n", key)
 	pub := ctx.pubVaultStatus
 	pub.Publish(key, status)
 }
@@ -748,10 +748,10 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 			}
 			//We don't have deprecated vaults on ZFS
 		default:
-			log.Infof("Ignoring request to setup vaults on unsupported %s filesystem", persistFsType)
+			log.Functionf("Ignoring request to setup vaults on unsupported %s filesystem", persistFsType)
 		}
 	case "runAsService":
-		log.Infof("Starting %s\n", agentName)
+		log.Functionf("Starting %s\n", agentName)
 
 		if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
 			log.Fatal(err)
@@ -807,7 +807,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 		// Pick up debug aka log level before we start real work
 		for !ctx.GCInitialized {
-			log.Infof("waiting for GCInitialized")
+			log.Functionf("waiting for GCInitialized")
 			select {
 			case change := <-subGlobalConfig.MsgChan():
 				subGlobalConfig.ProcessChange(change)
@@ -815,7 +815,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 			}
 			ps.StillRunning(agentName, warningTime, errorTime)
 		}
-		log.Infof("processed GlobalConfig")
+		log.Functionf("processed GlobalConfig")
 
 		// initialize publishing handles
 		initializeSelfPublishHandles(ps, &ctx)
@@ -873,17 +873,17 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 
 	ctx := ctxArg.(*vaultMgrContext)
 	if key != "global" {
-		log.Infof("handleGlobalConfigImpl: ignoring %s\n", key)
+		log.Functionf("handleGlobalConfigImpl: ignoring %s\n", key)
 		return
 	}
-	log.Infof("handleGlobalConfigImpl for %s\n", key)
+	log.Functionf("handleGlobalConfigImpl for %s\n", key)
 	var gcp *types.ConfigItemValueMap
 	debug, gcp = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
 		debugOverride, logger)
 	if gcp != nil {
 		ctx.GCInitialized = true
 	}
-	log.Infof("handleGlobalConfigImpl done for %s\n", key)
+	log.Functionf("handleGlobalConfigImpl done for %s\n", key)
 }
 
 func handleGlobalConfigDelete(ctxArg interface{}, key string,
@@ -891,13 +891,13 @@ func handleGlobalConfigDelete(ctxArg interface{}, key string,
 
 	ctx := ctxArg.(*vaultMgrContext)
 	if key != "global" {
-		log.Infof("handleGlobalConfigDelete: ignoring %s\n", key)
+		log.Functionf("handleGlobalConfigDelete: ignoring %s\n", key)
 		return
 	}
-	log.Infof("handleGlobalConfigDelete for %s\n", key)
+	log.Functionf("handleGlobalConfigDelete for %s\n", key)
 	debug, _ = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
 		debugOverride, logger)
-	log.Infof("handleGlobalConfigDelete done for %s\n", key)
+	log.Functionf("handleGlobalConfigDelete done for %s\n", key)
 }
 
 func handleVaultKeyFromControllerCreate(ctxArg interface{}, key string,
@@ -927,7 +927,7 @@ func handleVaultKeyFromControllerImpl(ctxArg interface{}, key string,
 		log.Warnf("Ignoring unknown vault %s", keyFromController.Name)
 		return
 	}
-	log.Debugf("Processing EncryptedVaultKeyFromController %s\n", key)
+	log.Tracef("Processing EncryptedVaultKeyFromController %s\n", key)
 	keyData := &attest.AttestVolumeKeyData{}
 	if err := proto.Unmarshal(keyFromController.EncryptedVaultKey, keyData); err != nil {
 		log.Errorf("Failed to unmarshal keyData %v", err)
@@ -946,7 +946,7 @@ func handleVaultKeyFromControllerImpl(ctxArg interface{}, key string,
 		log.Errorf("Computed SHA is not matching provided SHA")
 		return
 	}
-	log.Infof("Computed and provided SHA are matching")
+	log.Functionf("Computed and provided SHA are matching")
 
 	//Try unlocking the vault now, in case it is not yet unlocked
 	if !ctx.defaultVaultUnlocked {
@@ -1019,7 +1019,7 @@ func publishVaultKey(ctx *vaultMgrContext, vaultName string) error {
 	keyFromDevice.Name = vaultName
 	keyFromDevice.EncryptedVaultKey = b
 	key := keyFromDevice.Key()
-	log.Debugf("Publishing EncryptedVaultKeyFromDevice %s\n", key)
+	log.Tracef("Publishing EncryptedVaultKeyFromDevice %s\n", key)
 	pub := ctx.pubVaultKeyFromDevice
 	pub.Publish(key, keyFromDevice)
 	return nil

--- a/pkg/pillar/cmd/vaultmgr/vaultmgrzfs.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgrzfs.go
@@ -77,7 +77,7 @@ func createZfsVault(vaultPath string) error {
 			vaultPath, err, stdOut, stdErr)
 		return err
 	}
-	log.Infof("Created new vault %s", vaultPath)
+	log.Functionf("Created new vault %s", vaultPath)
 	return nil
 }
 
@@ -85,7 +85,7 @@ func createZfsVault(vaultPath string) error {
 func checkKeyStatus(vaultPath string) error {
 	args := getKeyStatusParams(vaultPath)
 	if stdOut, stdErr, err := execCmd(vault.ZfsPath, args...); err != nil {
-		log.Debugf("keystatus query for %s results in error=%v, %s, %s",
+		log.Tracef("keystatus query for %s results in error=%v, %s, %s",
 			vaultPath, err, stdOut, stdErr)
 		return err
 	}

--- a/pkg/pillar/cmd/verifier/dirs.go
+++ b/pkg/pillar/cmd/verifier/dirs.go
@@ -20,7 +20,7 @@ func createDownloadDirs() {
 	workingDirTypes := []string{getVerifierDir(), getVerifiedDir()}
 	for _, dirName := range workingDirTypes {
 		if _, err := os.Stat(dirName); err != nil {
-			log.Infof("Create %s", dirName)
+			log.Functionf("Create %s", dirName)
 			if err := os.MkdirAll(dirName, 0700); err != nil {
 				log.Fatal(err)
 			}

--- a/pkg/pillar/cmd/verifier/handlers.go
+++ b/pkg/pillar/cmd/verifier/handlers.go
@@ -37,19 +37,19 @@ func (v *verifyHandler) modify(ctxArg interface{},
 
 	typeName := pubsub.TypeToName(configArg)
 	handlerKey := fmt.Sprintf("%s+%s", typeName, key)
-	log.Infof("verifyHandler.modify(%s)", handlerKey)
+	log.Functionf("verifyHandler.modify(%s)", handlerKey)
 	h, ok := v.handlers[handlerKey]
 	if !ok {
 		log.Fatalf("verifyHandler.modify called on config that does not exist")
 	}
 	select {
 	case h <- Notify{}:
-		log.Infof("verifyHandler.modify(%s) sent notify", handlerKey)
+		log.Functionf("verifyHandler.modify(%s) sent notify", handlerKey)
 	default:
 		// handler is slow
 		log.Warnf("verifyHandler.modify(%s) NOT sent notify. Slow handler?", handlerKey)
 	}
-	log.Infof("verifyHandler.modify(%s) done", handlerKey)
+	log.Functionf("verifyHandler.modify(%s) done", handlerKey)
 }
 
 func (v *verifyHandler) create(ctxArg interface{},
@@ -57,7 +57,7 @@ func (v *verifyHandler) create(ctxArg interface{},
 
 	typeName := pubsub.TypeToName(configArg)
 	handlerKey := fmt.Sprintf("%s+%s", typeName, key)
-	log.Infof("verifyHandler.create(%s)", handlerKey)
+	log.Functionf("verifyHandler.create(%s)", handlerKey)
 	ctx := ctxArg.(*verifierContext)
 	h, ok := v.handlers[handlerKey]
 	if ok {
@@ -67,7 +67,7 @@ func (v *verifyHandler) create(ctxArg interface{},
 	v.handlers[handlerKey] = h1
 	switch typeName {
 	case "VerifyImageConfig":
-		log.Infof("Creating %s at %s", "runHandler",
+		log.Functionf("Creating %s at %s", "runHandler",
 			agentlog.GetMyStack())
 		go runHandler(ctx, key, h1)
 	default:
@@ -76,12 +76,12 @@ func (v *verifyHandler) create(ctxArg interface{},
 	h = h1
 	select {
 	case h <- Notify{}:
-		log.Infof("verifyHandler.create(%s) sent notify", handlerKey)
+		log.Functionf("verifyHandler.create(%s) sent notify", handlerKey)
 	default:
 		// Shouldn't happen since we just created channel
 		log.Fatalf("verifyHandler.create(%s) NOT sent notify", handlerKey)
 	}
-	log.Infof("verifyHandler.create(%s) done", handlerKey)
+	log.Functionf("verifyHandler.create(%s) done", handlerKey)
 }
 
 func (v *verifyHandler) delete(ctxArg interface{}, key string,
@@ -89,16 +89,16 @@ func (v *verifyHandler) delete(ctxArg interface{}, key string,
 
 	typeName := pubsub.TypeToName(configArg)
 	handlerKey := fmt.Sprintf("%s+%s", typeName, key)
-	log.Infof("verifyHandler.delete(%s)", handlerKey)
+	log.Functionf("verifyHandler.delete(%s)", handlerKey)
 	// Do we have a channel/goroutine?
 	h, ok := v.handlers[handlerKey]
 	if ok {
-		log.Debugf("Closing channel")
+		log.Tracef("Closing channel")
 		close(h)
 		delete(v.handlers, handlerKey)
 	} else {
-		log.Debugf("verifyHandler.delete: unknown %s", handlerKey)
+		log.Tracef("verifyHandler.delete: unknown %s", handlerKey)
 		return
 	}
-	log.Infof("verifyHandler.delete(%s) done", handlerKey)
+	log.Functionf("verifyHandler.delete(%s) done", handlerKey)
 }

--- a/pkg/pillar/cmd/volumemgr/artifact.go
+++ b/pkg/pillar/cmd/volumemgr/artifact.go
@@ -18,7 +18,7 @@ import (
 // image name that wraps the blob, or create one
 func getManifestsForBareBlob(ctx *volumemgrContext, image, rootHash string, size int64) ([]*types.BlobStatus, error) {
 	// at least one decriptor must match ours
-	log.Infof("getManifestsForBareBlob(%s, %s, %d)", image, rootHash, size)
+	log.Functionf("getManifestsForBareBlob(%s, %s, %d)", image, rootHash, size)
 	rootHashFull := fmt.Sprintf("%s:%s", "sha256", rootHash)
 	artifact := &registry.Artifact{
 		Root: &registry.Disk{

--- a/pkg/pillar/cmd/volumemgr/create.go
+++ b/pkg/pillar/cmd/volumemgr/create.go
@@ -19,10 +19,10 @@ import (
 func createVolume(ctx *volumemgrContext, status types.VolumeStatus) (bool, string, error) {
 
 	if status.IsContainer() {
-		log.Infof("createVolume(%s) from container %s", status.Key(), status.ReferenceName)
+		log.Functionf("createVolume(%s) from container %s", status.Key(), status.ReferenceName)
 		return createContainerVolume(ctx, status, status.ReferenceName)
 	}
-	log.Infof("createVolume(%s) from disk %s", status.Key(), status.ReferenceName)
+	log.Functionf("createVolume(%s) from disk %s", status.Key(), status.ReferenceName)
 	return createVdiskVolume(ctx, status, status.ReferenceName)
 }
 
@@ -84,9 +84,9 @@ func createVdiskVolume(ctx *volumemgrContext, status types.VolumeStatus,
 		return created, "", err
 	}
 
-	log.Infof("Extract DONE from %s to %s", ref, filelocation)
+	log.Functionf("Extract DONE from %s to %s", ref, filelocation)
 
-	log.Infof("createVdiskVolume(%s) DONE", status.Key())
+	log.Functionf("createVdiskVolume(%s) DONE", status.Key())
 	return true, filelocation, nil
 }
 
@@ -117,7 +117,7 @@ func createContainerVolume(ctx *volumemgrContext, status types.VolumeStatus,
 		log.Errorf("Failed to create ctr bundle. Error %s", err)
 		return created, filelocation, err
 	}
-	log.Infof("createContainerVolume(%s) DONE", status.Key())
+	log.Functionf("createContainerVolume(%s) DONE", status.Key())
 	return true, filelocation, nil
 }
 
@@ -125,14 +125,14 @@ func createContainerVolume(ctx *volumemgrContext, status types.VolumeStatus,
 // new values for VolumeCreated, FileLocation, and error
 func destroyVolume(ctx *volumemgrContext, status types.VolumeStatus) (bool, string, error) {
 
-	log.Infof("destroyVolume(%s)", status.Key())
+	log.Functionf("destroyVolume(%s)", status.Key())
 	if !status.VolumeCreated {
-		log.Infof("destroyVolume(%s) nothing was created", status.Key())
+		log.Functionf("destroyVolume(%s) nothing was created", status.Key())
 		return false, status.FileLocation, nil
 	}
 
 	if status.ReadOnly {
-		log.Infof("destroyVolume(%s) ReadOnly", status.Key())
+		log.Functionf("destroyVolume(%s) ReadOnly", status.Key())
 		return false, "", nil
 	}
 
@@ -154,7 +154,7 @@ func destroyVdiskVolume(ctx *volumemgrContext, status types.VolumeStatus) (bool,
 
 	created := status.VolumeCreated
 	filelocation := status.FileLocation
-	log.Infof("Delete copy at %s", filelocation)
+	log.Functionf("Delete copy at %s", filelocation)
 	if err := os.RemoveAll(filelocation); err != nil {
 		log.Error(err)
 		filelocation = ""
@@ -162,7 +162,7 @@ func destroyVdiskVolume(ctx *volumemgrContext, status types.VolumeStatus) (bool,
 	}
 	filelocation = ""
 	created = false
-	log.Infof("destroyVdiskVolume(%s) DONE", status.Key())
+	log.Functionf("destroyVdiskVolume(%s) DONE", status.Key())
 	return created, filelocation, nil
 }
 
@@ -172,13 +172,13 @@ func destroyContainerVolume(ctx *volumemgrContext, status types.VolumeStatus) (b
 
 	created := status.VolumeCreated
 	filelocation := status.FileLocation
-	log.Infof("Removing container volume %s", filelocation)
+	log.Functionf("Removing container volume %s", filelocation)
 	if err := ctx.casClient.RemoveContainerRootDir(filelocation); err != nil {
 		return created, filelocation, err
 	}
 	filelocation = ""
 	created = false
-	log.Infof("destroyContainerVolume(%s) DONE", status.Key())
+	log.Functionf("destroyContainerVolume(%s) DONE", status.Key())
 	return created, filelocation, nil
 }
 
@@ -191,7 +191,7 @@ func maybeResizeDisk(diskfile string, maxsizebytes uint64) error {
 	if err != nil {
 		return err
 	}
-	log.Infof("maybeResizeDisk(%s) current %d to %d",
+	log.Functionf("maybeResizeDisk(%s) current %d to %d",
 		diskfile, currentSize, maxsizebytes)
 	if maxsizebytes < currentSize {
 		log.Warnf("maybeResizeDisk(%s) already above maxsize  %d vs. %d",

--- a/pkg/pillar/cmd/volumemgr/dirs.go
+++ b/pkg/pillar/cmd/volumemgr/dirs.go
@@ -13,7 +13,7 @@ func initializeDirs() {
 
 	// first the certs directory
 	if _, err := os.Stat(types.CertificateDirname); err != nil {
-		log.Debugf("initializeDirs: Create %s", types.CertificateDirname)
+		log.Tracef("initializeDirs: Create %s", types.CertificateDirname)
 		if err := os.MkdirAll(types.CertificateDirname, 0700); err != nil {
 			log.Fatal(err)
 		}
@@ -25,7 +25,7 @@ func initializeDirs() {
 	}
 	for _, dirName := range volumeDirs {
 		if _, err := os.Stat(dirName); err != nil {
-			log.Infof("Create %s", dirName)
+			log.Functionf("Create %s", dirName)
 			if err := os.MkdirAll(dirName, 0700); err != nil {
 				log.Fatal(err)
 			}

--- a/pkg/pillar/cmd/volumemgr/handlecontent.go
+++ b/pkg/pillar/cmd/volumemgr/handlecontent.go
@@ -16,18 +16,18 @@ import (
 func handleContentTreeCreateAppImg(ctxArg interface{}, key string,
 	configArg interface{}) {
 
-	log.Infof("handleContentTreeCreateAppImg(%s)", key)
+	log.Functionf("handleContentTreeCreateAppImg(%s)", key)
 	config := configArg.(types.ContentTreeConfig)
 	ctx := ctxArg.(*volumemgrContext)
 	status := createContentTreeStatus(ctx, config, types.AppImgObj)
 	updateContentTree(ctx, status)
-	log.Infof("handleContentTreeCreateAppImg(%s) Done", key)
+	log.Functionf("handleContentTreeCreateAppImg(%s) Done", key)
 }
 
 func handleContentTreeModifyAppImg(ctxArg interface{}, key string,
 	configArg interface{}, oldConfigArg interface{}) {
 
-	log.Infof("handleContentTreeModifyAppImg(%s)", key)
+	log.Functionf("handleContentTreeModifyAppImg(%s)", key)
 	config := configArg.(types.ContentTreeConfig)
 	ctx := ctxArg.(*volumemgrContext)
 	status := lookupContentTreeStatus(ctx, config.Key(), types.AppImgObj)
@@ -35,13 +35,13 @@ func handleContentTreeModifyAppImg(ctxArg interface{}, key string,
 		log.Fatalf("Missing ContentTreeStatus for %s", config.Key())
 	}
 	updateContentTree(ctx, status)
-	log.Infof("handleContentTreeAppImg(%s) Done", key)
+	log.Functionf("handleContentTreeAppImg(%s) Done", key)
 }
 
 func handleContentTreeDeleteAppImg(ctxArg interface{}, key string,
 	configArg interface{}) {
 
-	log.Infof("handleContentTreeDeleteAppImg(%s)", key)
+	log.Functionf("handleContentTreeDeleteAppImg(%s)", key)
 	config := configArg.(types.ContentTreeConfig)
 	ctx := ctxArg.(*volumemgrContext)
 	status := lookupContentTreeStatus(ctx, config.Key(), types.AppImgObj)
@@ -49,24 +49,24 @@ func handleContentTreeDeleteAppImg(ctxArg interface{}, key string,
 		log.Fatalf("Missing ContentTreeStatus for %s", config.Key())
 	}
 	deleteContentTree(ctx, status)
-	log.Infof("handleContentTreeDeleteAppImg(%s) Done", key)
+	log.Functionf("handleContentTreeDeleteAppImg(%s) Done", key)
 }
 
 func handleContentTreeCreateBaseOs(ctxArg interface{}, key string,
 	configArg interface{}) {
 
-	log.Infof("handleContentTreeCreateBaseOs(%s)", key)
+	log.Functionf("handleContentTreeCreateBaseOs(%s)", key)
 	config := configArg.(types.ContentTreeConfig)
 	ctx := ctxArg.(*volumemgrContext)
 	status := createContentTreeStatus(ctx, config, types.BaseOsObj)
 	updateContentTree(ctx, status)
-	log.Infof("handleContentTreeCreateBaseOs(%s) Done", key)
+	log.Functionf("handleContentTreeCreateBaseOs(%s) Done", key)
 }
 
 func handleContentTreeModifyBaseOs(ctxArg interface{}, key string,
 	configArg interface{}, oldConfigArg interface{}) {
 
-	log.Infof("handleContentTreeModifyBaseOs(%s)", key)
+	log.Functionf("handleContentTreeModifyBaseOs(%s)", key)
 	config := configArg.(types.ContentTreeConfig)
 	ctx := ctxArg.(*volumemgrContext)
 	status := lookupContentTreeStatus(ctx, config.Key(), types.BaseOsObj)
@@ -74,13 +74,13 @@ func handleContentTreeModifyBaseOs(ctxArg interface{}, key string,
 		log.Fatalf("Missing ContentTreeStatus for %s", config.Key())
 	}
 	updateContentTree(ctx, status)
-	log.Infof("handleContentTreeModifyBaseOs(%s) Done", key)
+	log.Functionf("handleContentTreeModifyBaseOs(%s) Done", key)
 }
 
 func handleContentTreeDeleteBaseOs(ctxArg interface{}, key string,
 	configArg interface{}) {
 
-	log.Infof("handleContentTreeDeleteBaseOs(%s)", key)
+	log.Functionf("handleContentTreeDeleteBaseOs(%s)", key)
 	config := configArg.(types.ContentTreeConfig)
 	ctx := ctxArg.(*volumemgrContext)
 	status := lookupContentTreeStatus(ctx, config.Key(), types.BaseOsObj)
@@ -88,11 +88,11 @@ func handleContentTreeDeleteBaseOs(ctxArg interface{}, key string,
 		log.Fatalf("Missing ContentTreeStatus for %s", config.Key())
 	}
 	deleteContentTree(ctx, status)
-	log.Infof("handleContentTreeDeleteBaseOs(%s) Done", key)
+	log.Functionf("handleContentTreeDeleteBaseOs(%s) Done", key)
 }
 
 func handleContentTreeRestart(ctxArg interface{}, done bool) {
-	log.Infof("handleContentTreeRestart(%v)", done)
+	log.Functionf("handleContentTreeRestart(%v)", done)
 	ctx := ctxArg.(*volumemgrContext)
 	ctx.contentTreeRestarted = true
 }
@@ -100,16 +100,16 @@ func handleContentTreeRestart(ctxArg interface{}, done bool) {
 func publishContentTreeStatus(ctx *volumemgrContext, status *types.ContentTreeStatus) {
 
 	key := status.Key()
-	log.Debugf("publishContentTreeStatus(%s)", key)
+	log.Tracef("publishContentTreeStatus(%s)", key)
 	pub := ctx.publication(types.ContentTreeStatus{}, status.ObjType)
 	pub.Publish(key, *status)
-	log.Debugf("publishContentTreeStatus(%s) Done", key)
+	log.Tracef("publishContentTreeStatus(%s) Done", key)
 }
 
 func unpublishContentTreeStatus(ctx *volumemgrContext, status *types.ContentTreeStatus) {
 
 	key := status.Key()
-	log.Debugf("unpublishContentTreeStatus(%s)", key)
+	log.Tracef("unpublishContentTreeStatus(%s)", key)
 	pub := ctx.publication(types.ContentTreeStatus{}, status.ObjType)
 	c, _ := pub.Get(key)
 	if c == nil {
@@ -117,21 +117,21 @@ func unpublishContentTreeStatus(ctx *volumemgrContext, status *types.ContentTree
 		return
 	}
 	pub.Unpublish(key)
-	log.Debugf("unpublishContentTreeStatus(%s) Done", key)
+	log.Tracef("unpublishContentTreeStatus(%s) Done", key)
 }
 
 func lookupContentTreeStatus(ctx *volumemgrContext,
 	key, objType string) *types.ContentTreeStatus {
 
-	log.Debugf("lookupContentTreeStatus(%s/%s)", key, objType)
+	log.Tracef("lookupContentTreeStatus(%s/%s)", key, objType)
 	pub := ctx.publication(types.ContentTreeStatus{}, objType)
 	c, _ := pub.Get(key)
 	if c == nil {
-		log.Debugf("lookupContentTreeStatus(%s/%s) not found", key, objType)
+		log.Tracef("lookupContentTreeStatus(%s/%s) not found", key, objType)
 		return nil
 	}
 	status := c.(types.ContentTreeStatus)
-	log.Debugf("lookupContentTreeStatus(%s/%s) Done", key, objType)
+	log.Tracef("lookupContentTreeStatus(%s/%s) Done", key, objType)
 	return &status
 }
 
@@ -149,7 +149,7 @@ func lookupContentTreeStatusAny(ctx *volumemgrContext, key string) *types.Conten
 }
 
 func getAllAppContentTreeStatus(ctx *volumemgrContext) map[string]*types.ContentTreeStatus {
-	log.Debugf("getAllAppContentTreeStatus")
+	log.Tracef("getAllAppContentTreeStatus")
 	pub := ctx.publication(types.ContentTreeStatus{}, types.AppImgObj)
 	contentIDAndContentTreeStatusIntf := pub.GetAll()
 	contentIDAndContentTreeStatus := make(map[string]*types.ContentTreeStatus)
@@ -157,29 +157,29 @@ func getAllAppContentTreeStatus(ctx *volumemgrContext) map[string]*types.Content
 		contentTreeStatus := contentTreeStatusIntf.(types.ContentTreeStatus)
 		contentIDAndContentTreeStatus[contentIDKey] = &contentTreeStatus
 	}
-	log.Debugf("getAllAppContentTreeStatus")
+	log.Tracef("getAllAppContentTreeStatus")
 	return contentIDAndContentTreeStatus
 }
 
 func lookupContentTreeConfig(ctx *volumemgrContext,
 	key, objType string) *types.ContentTreeConfig {
 
-	log.Debugf("lookupContentTreeConfig(%s/%s)", key, objType)
+	log.Tracef("lookupContentTreeConfig(%s/%s)", key, objType)
 	sub := ctx.subscription(types.ContentTreeConfig{}, objType)
 	c, _ := sub.Get(key)
 	if c == nil {
-		log.Debugf("lookupContentTreeConfig(%s/%s) not found", key, objType)
+		log.Tracef("lookupContentTreeConfig(%s/%s) not found", key, objType)
 		return nil
 	}
 	config := c.(types.ContentTreeConfig)
-	log.Debugf("lookupContentTreeConfig(%s/%s) Done", key, objType)
+	log.Tracef("lookupContentTreeConfig(%s/%s) Done", key, objType)
 	return &config
 }
 
 func createContentTreeStatus(ctx *volumemgrContext, config types.ContentTreeConfig,
 	objType string) *types.ContentTreeStatus {
 
-	log.Infof("createContentTreeStatus for %v objType %s", config.ContentID, objType)
+	log.Functionf("createContentTreeStatus for %v objType %s", config.ContentID, objType)
 	status := lookupContentTreeStatus(ctx, config.Key(), objType)
 	if status == nil {
 		// need to save the datastore type
@@ -188,7 +188,7 @@ func createContentTreeStatus(ctx *volumemgrContext, config types.ContentTreeConf
 		if datastoreConfig == nil {
 			log.Errorf("createContentTreeStatus(%s): datastoreConfig for %s not found %v", config.Key(), config.DatastoreID, err)
 		} else {
-			log.Debugf("Found datastore(%s) for %s", config.DatastoreID.String(), config.Key())
+			log.Tracef("Found datastore(%s) for %s", config.DatastoreID.String(), config.Key())
 			datastoreType = datastoreConfig.DsType
 		}
 
@@ -236,14 +236,14 @@ func createContentTreeStatus(ctx *volumemgrContext, config types.ContentTreeConf
 		}
 	}
 	publishContentTreeStatus(ctx, status)
-	log.Infof("createContentTreeStatus for %v Done", config.ContentID)
+	log.Functionf("createContentTreeStatus for %v Done", config.ContentID)
 	return status
 }
 
 //AddBlobsToContentTreeStatus adds blob to ContentTreeStatus.Blobs also increments RefCount of the respective BlobStatus.
 //NOTE: This should be the only method to add blobs into ContentTreeStatus.Blobs
 func AddBlobsToContentTreeStatus(ctx *volumemgrContext, status *types.ContentTreeStatus, blobShas ...string) error {
-	log.Infof("AddBlobsToContentTreeStatus(%s): for blobs %v", status.ContentID, blobShas)
+	log.Functionf("AddBlobsToContentTreeStatus(%s): for blobs %v", status.ContentID, blobShas)
 	for _, blobSha := range blobShas {
 		blobStatus := lookupBlobStatus(ctx, blobSha)
 		if blobStatus == nil {
@@ -268,7 +268,7 @@ func AddBlobsToContentTreeStatus(ctx *volumemgrContext, status *types.ContentTre
 // respective BlobStatus.
 //NOTE: This should be the only method to remove blobs from ContentTreeStatus.Blobs
 func RemoveAllBlobsFromContentTreeStatus(ctx *volumemgrContext, status *types.ContentTreeStatus, blobShas ...string) {
-	log.Infof("RemoveAllBlobsFromContentTreeStatus(%s): for blobs %v", status.ContentID, blobShas)
+	log.Functionf("RemoveAllBlobsFromContentTreeStatus(%s): for blobs %v", status.ContentID, blobShas)
 	for _, blobSha := range status.Blobs {
 		blobStatus := lookupBlobStatus(ctx, blobSha)
 		if blobStatus == nil {
@@ -295,17 +295,17 @@ func updateContentTreeByID(ctx *volumemgrContext, id string) {
 
 func updateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus) {
 
-	log.Infof("updateContentTree for %v", status.ContentID)
+	log.Functionf("updateContentTree for %v", status.ContentID)
 	if changed, _ := doUpdateContentTree(ctx, status); changed {
 		publishContentTreeStatus(ctx, status)
 	}
 	updateVolumeStatusFromContentID(ctx, status.ContentID)
 
-	log.Infof("updateContentTree for %v Done", status.ContentID)
+	log.Functionf("updateContentTree for %v Done", status.ContentID)
 }
 
 func deleteContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus) {
-	log.Infof("deleteContentTree for %v", status.ContentID)
+	log.Functionf("deleteContentTree for %v", status.ContentID)
 	RemoveAllBlobsFromContentTreeStatus(ctx, status, status.Blobs...)
 	//We create a reference when we load the blobs. We should remove that reference when we delete the contentTree.
 	if err := ctx.casClient.RemoveImage(status.ReferenceID()); err != nil {
@@ -314,5 +314,5 @@ func deleteContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus) {
 	}
 	unpublishContentTreeStatus(ctx, status)
 	deleteLatchContentTreeHash(ctx, status.ContentID, uint32(status.GenerationCounter))
-	log.Infof("deleteContentTree for %v Done", status.ContentID)
+	log.Functionf("deleteContentTree for %v Done", status.ContentID)
 }

--- a/pkg/pillar/cmd/volumemgr/handledatastore.go
+++ b/pkg/pillar/cmd/volumemgr/handledatastore.go
@@ -22,7 +22,7 @@ func handleDatastoreConfigImpl(ctxArg interface{}, key string,
 
 	ctx := ctxArg.(*volumemgrContext)
 	config := configArg.(types.DatastoreConfig)
-	log.Infof("handleDatastoreConfigImpl for %s", key)
+	log.Functionf("handleDatastoreConfigImpl for %s", key)
 	updateStatusByDatastore(ctx, config)
-	log.Infof("handleDatastoreConfigImpl for %s, done", key)
+	log.Functionf("handleDatastoreConfigImpl for %s, done", key)
 }

--- a/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
+++ b/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
@@ -19,17 +19,17 @@ import (
 func publishDiskMetrics(ctx *volumemgrContext, statuses ...*types.DiskMetric) {
 	for _, status := range statuses {
 		key := status.Key()
-		log.Debugf("publishDiskMetrics(%s)", key)
+		log.Tracef("publishDiskMetrics(%s)", key)
 		pub := ctx.pubDiskMetric
 		pub.Publish(key, *status)
-		log.Debugf("publishDiskMetrics(%s) Done", key)
+		log.Tracef("publishDiskMetrics(%s) Done", key)
 	}
 }
 
 func unpublishDiskMetrics(ctx *volumemgrContext, statuses ...*types.DiskMetric) {
 	for _, status := range statuses {
 		key := status.Key()
-		log.Debugf("unpublishDiskMetrics(%s)", key)
+		log.Tracef("unpublishDiskMetrics(%s)", key)
 		pub := ctx.pubDiskMetric
 		c, _ := pub.Get(key)
 		if c == nil {
@@ -37,38 +37,38 @@ func unpublishDiskMetrics(ctx *volumemgrContext, statuses ...*types.DiskMetric) 
 			continue
 		}
 		pub.Unpublish(key)
-		log.Debugf("unpublishDiskMetrics(%s) Done", key)
+		log.Tracef("unpublishDiskMetrics(%s) Done", key)
 	}
 }
 
 func lookupDiskMetric(ctx *volumemgrContext, key string) *types.DiskMetric {
 	key = types.PathToKey(key)
-	log.Debugf("lookupDiskMetric(%s)", key)
+	log.Tracef("lookupDiskMetric(%s)", key)
 	pub := ctx.pubDiskMetric
 	c, _ := pub.Get(key)
 	if c == nil {
-		log.Debugf("lookupDiskMetric(%s) not found", key)
+		log.Tracef("lookupDiskMetric(%s) not found", key)
 		return nil
 	}
 	status := c.(types.DiskMetric)
-	log.Debugf("lookupDiskMetric(%s) Done", key)
+	log.Tracef("lookupDiskMetric(%s) Done", key)
 	return &status
 }
 
 func publishAppDiskMetrics(ctx *volumemgrContext, statuses ...*types.AppDiskMetric) {
 	for _, status := range statuses {
 		key := status.Key()
-		log.Debugf("publishAppDiskMetrics(%s)", key)
+		log.Tracef("publishAppDiskMetrics(%s)", key)
 		pub := ctx.pubAppDiskMetric
 		pub.Publish(key, *status)
-		log.Debugf("publishAppDiskMetrics(%s) Done", key)
+		log.Tracef("publishAppDiskMetrics(%s) Done", key)
 	}
 }
 
 func unpublishAppDiskMetrics(ctx *volumemgrContext, statuses ...*types.AppDiskMetric) {
 	for _, status := range statuses {
 		key := status.Key()
-		log.Debugf("unpublishAppDiskMetrics(%s)", key)
+		log.Tracef("unpublishAppDiskMetrics(%s)", key)
 		pub := ctx.pubAppDiskMetric
 		c, _ := pub.Get(key)
 		if c == nil {
@@ -76,27 +76,27 @@ func unpublishAppDiskMetrics(ctx *volumemgrContext, statuses ...*types.AppDiskMe
 			continue
 		}
 		pub.Unpublish(key)
-		log.Debugf("unpublishAppDiskMetrics(%s) Done", key)
+		log.Tracef("unpublishAppDiskMetrics(%s) Done", key)
 	}
 }
 
 func lookupAppDiskMetric(ctx *volumemgrContext, key string) *types.AppDiskMetric {
 	key = types.PathToKey(key)
-	log.Debugf("lookupAppDiskMetric(%s)", key)
+	log.Tracef("lookupAppDiskMetric(%s)", key)
 	pub := ctx.pubAppDiskMetric
 	c, _ := pub.Get(key)
 	if c == nil {
-		log.Debugf("lookupAppDiskMetric(%s) not found", key)
+		log.Tracef("lookupAppDiskMetric(%s) not found", key)
 		return nil
 	}
 	status := c.(types.AppDiskMetric)
-	log.Debugf("lookupAppDiskMetric(%s) Done", key)
+	log.Tracef("lookupAppDiskMetric(%s) Done", key)
 	return &status
 }
 
 //diskMetricsTimerTask calculates and publishes disk metrics periodically
 func diskMetricsTimerTask(ctx *volumemgrContext, handleChannel chan interface{}) {
-	log.Infoln("starting report diskMetricsTimerTask timer task")
+	log.Functionln("starting report diskMetricsTimerTask timer task")
 	createOrUpdateDiskMetrics(ctx)
 
 	diskMetricInterval := time.Duration(ctx.globalConfig.GlobalValueInt(types.DiskScanMetricInterval)) * time.Second
@@ -129,21 +129,21 @@ func diskMetricsTimerTask(ctx *volumemgrContext, handleChannel chan interface{})
 
 //createOrUpdateDiskMetrics creates or updates metrics for all disks, mountpaths and volumeStatuses
 func createOrUpdateDiskMetrics(ctx *volumemgrContext) {
-	log.Infof("createOrUpdateDiskMetrics")
+	log.Functionf("createOrUpdateDiskMetrics")
 	var diskMetricList []*types.DiskMetric
 	startPubTime := time.Now()
 
 	disks := diskmetrics.FindDisksPartitions(log)
 	for _, d := range disks {
 		size, _ := diskmetrics.PartitionSize(log, d)
-		log.Debugf("createOrUpdateDiskMetrics: Disk/partition %s size %d", d, size)
+		log.Tracef("createOrUpdateDiskMetrics: Disk/partition %s size %d", d, size)
 		var metric *types.DiskMetric
 		metric = lookupDiskMetric(ctx, d)
 		if metric == nil {
-			log.Infof("createOrUpdateDiskMetrics: creating new DiskMetric for %s", d)
+			log.Functionf("createOrUpdateDiskMetrics: creating new DiskMetric for %s", d)
 			metric = &(types.DiskMetric{DiskPath: d, IsDir: false})
 		} else {
-			log.Infof("createOrUpdateDiskMetrics: updating DiskMetric for %s", d)
+			log.Functionf("createOrUpdateDiskMetrics: updating DiskMetric for %s", d)
 		}
 		metric.TotalBytes = size
 		stat, err := disk.IOCounters(d)
@@ -170,51 +170,51 @@ func createOrUpdateDiskMetrics(ctx *volumemgrContext) {
 		if path == types.PersistDir {
 			persistUsage = u.Used
 		}
-		log.Debugf("createOrUpdateDiskMetrics: Path %s total %d used %d free %d",
+		log.Tracef("createOrUpdateDiskMetrics: Path %s total %d used %d free %d",
 			path, u.Total, u.Used, u.Free)
 		var metric *types.DiskMetric
 		metric = lookupDiskMetric(ctx, path)
 		if metric == nil {
-			log.Infof("createOrUpdateDiskMetrics: creating new DiskMetric for %s", path)
+			log.Functionf("createOrUpdateDiskMetrics: creating new DiskMetric for %s", path)
 			metric = &(types.DiskMetric{DiskPath: path, IsDir: true})
 		} else {
-			log.Infof("createOrUpdateDiskMetrics: updating DiskMetric for %s", path)
+			log.Functionf("createOrUpdateDiskMetrics: updating DiskMetric for %s", path)
 		}
 		metric.TotalBytes = u.Total
 		metric.UsedBytes = u.Used
 		metric.FreeBytes = u.Free
 		diskMetricList = append(diskMetricList, metric)
 	}
-	log.Debugf("createOrUpdateDiskMetrics: persistUsage %d, elapse sec %v", persistUsage, time.Since(startPubTime).Seconds())
+	log.Tracef("createOrUpdateDiskMetrics: persistUsage %d, elapse sec %v", persistUsage, time.Since(startPubTime).Seconds())
 
 	for _, path := range types.ReportDirPaths {
 		usage := diskmetrics.SizeFromDir(log, path)
-		log.Debugf("createOrUpdateDiskMetrics: ReportDirPath %s usage %d", path, usage)
+		log.Tracef("createOrUpdateDiskMetrics: ReportDirPath %s usage %d", path, usage)
 		var metric *types.DiskMetric
 		metric = lookupDiskMetric(ctx, path)
 		if metric == nil {
-			log.Infof("createOrUpdateDiskMetrics: creating new DiskMetric for %s", path)
+			log.Functionf("createOrUpdateDiskMetrics: creating new DiskMetric for %s", path)
 			metric = &(types.DiskMetric{DiskPath: path, IsDir: true})
 		} else {
-			log.Infof("createOrUpdateDiskMetrics: updating DiskMetric for %s", path)
+			log.Functionf("createOrUpdateDiskMetrics: updating DiskMetric for %s", path)
 		}
 
 		metric.UsedBytes = usage
 
 		diskMetricList = append(diskMetricList, metric)
 	}
-	log.Debugf("createOrUpdateDiskMetrics: DirPaths in persist, elapse sec %v", time.Since(startPubTime).Seconds())
+	log.Tracef("createOrUpdateDiskMetrics: DirPaths in persist, elapse sec %v", time.Since(startPubTime).Seconds())
 
 	for _, path := range types.AppPersistPaths {
 		usage := diskmetrics.SizeFromDir(log, path)
-		log.Debugf("createOrUpdateDiskMetrics: AppPersistPath %s usage %d", path, usage)
+		log.Tracef("createOrUpdateDiskMetrics: AppPersistPath %s usage %d", path, usage)
 		var metric *types.DiskMetric
 		metric = lookupDiskMetric(ctx, path)
 		if metric == nil {
-			log.Infof("createOrUpdateDiskMetrics: creating new DiskMetric for %s", path)
+			log.Functionf("createOrUpdateDiskMetrics: creating new DiskMetric for %s", path)
 			metric = &(types.DiskMetric{DiskPath: path, IsDir: true})
 		} else {
-			log.Infof("createOrUpdateDiskMetrics: updating DiskMetric for %s", path)
+			log.Functionf("createOrUpdateDiskMetrics: updating DiskMetric for %s", path)
 		}
 
 		metric.UsedBytes = usage
@@ -230,7 +230,7 @@ func createOrUpdateDiskMetrics(ctx *volumemgrContext) {
 }
 
 func createOrUpdateAppDiskMetrics(ctx *volumemgrContext, volumeStatus *types.VolumeStatus) error {
-	log.Infof("createOrUpdateAppDiskMetrics(%s, %s)", volumeStatus.VolumeID, volumeStatus.FileLocation)
+	log.Functionf("createOrUpdateAppDiskMetrics(%s, %s)", volumeStatus.VolumeID, volumeStatus.FileLocation)
 	if volumeStatus.FileLocation == "" {
 		// Nothing we can do? XXX can we retrieve size from CAS?
 		return nil

--- a/pkg/pillar/cmd/volumemgr/handleresolve.go
+++ b/pkg/pillar/cmd/volumemgr/handleresolve.go
@@ -11,7 +11,7 @@ import (
 // container images for which resolution of tags to sha requires
 func MaybeAddResolveConfig(ctx *volumemgrContext, cs types.ContentTreeStatus) {
 
-	log.Infof("MaybeAddResolveConfig for %s", cs.ContentID)
+	log.Functionf("MaybeAddResolveConfig for %s", cs.ContentID)
 	resolveConfig := types.ResolveConfig{
 		DatastoreID: cs.DatastoreID,
 		Name:        cs.RelativeURL,
@@ -20,67 +20,67 @@ func MaybeAddResolveConfig(ctx *volumemgrContext, cs types.ContentTreeStatus) {
 		Counter: uint32(cs.GenerationCounter),
 	}
 	publishResolveConfig(ctx, &resolveConfig)
-	log.Infof("MaybeAddResolveConfig for %s Done", cs.ContentID)
+	log.Functionf("MaybeAddResolveConfig for %s Done", cs.ContentID)
 }
 
 func publishResolveConfig(ctx *volumemgrContext,
 	config *types.ResolveConfig) {
 
 	key := config.Key()
-	log.Debugf("publishResolveConfig(%s)", key)
+	log.Tracef("publishResolveConfig(%s)", key)
 	pub := ctx.pubResolveConfig
 	pub.Publish(key, *config)
-	log.Debugf("publishResolveConfig(%s) Done", key)
+	log.Tracef("publishResolveConfig(%s) Done", key)
 }
 
 func unpublishResolveConfig(ctx *volumemgrContext,
 	config *types.ResolveConfig) {
 
 	key := config.Key()
-	log.Debugf("unpublishResolveConfig(%s)", key)
+	log.Tracef("unpublishResolveConfig(%s)", key)
 	pub := ctx.pubResolveConfig
 	pub.Unpublish(key)
-	log.Debugf("unpublishResolveConfig(%s) Done", key)
+	log.Tracef("unpublishResolveConfig(%s) Done", key)
 }
 
 func lookupResolveConfig(ctx *volumemgrContext,
 	key string) *types.ResolveConfig {
 
-	log.Debugf("lookupResolveConfig(%s)", key)
+	log.Tracef("lookupResolveConfig(%s)", key)
 	pub := ctx.pubResolveConfig
 	c, _ := pub.Get(key)
 	if c == nil {
-		log.Debugf("lookupResolveConfig(%s) not found", key)
+		log.Tracef("lookupResolveConfig(%s) not found", key)
 		return nil
 	}
 	config := c.(types.ResolveConfig)
-	log.Debugf("lookupResolveConfig(%s) Done", key)
+	log.Tracef("lookupResolveConfig(%s) Done", key)
 	return &config
 }
 
 func lookupResolveStatus(ctx *volumemgrContext,
 	key string) *types.ResolveStatus {
 
-	log.Debugf("lookupResolveStatus(%s)", key)
+	log.Tracef("lookupResolveStatus(%s)", key)
 	sub := ctx.subResolveStatus
 	c, _ := sub.Get(key)
 	if c == nil {
-		log.Debugf("lookupResolveStatus(%s) not found", key)
+		log.Tracef("lookupResolveStatus(%s) not found", key)
 		return nil
 	}
 	status := c.(types.ResolveStatus)
-	log.Debugf("lookupResolveStatus(%s) Done", key)
+	log.Tracef("lookupResolveStatus(%s) Done", key)
 	return &status
 }
 
 func deleteResolveConfig(ctx *volumemgrContext, key string) {
-	log.Infof("deleteResolveConfig for %s", key)
+	log.Functionf("deleteResolveConfig for %s", key)
 	rc := lookupResolveConfig(ctx, key)
 	if rc != nil {
-		log.Infof("deleteResolveConfig for %s found", key)
+		log.Functionf("deleteResolveConfig for %s found", key)
 		unpublishResolveConfig(ctx, rc)
 	}
-	log.Infof("deleteResolveConfig for %s Done", key)
+	log.Functionf("deleteResolveConfig for %s Done", key)
 }
 
 func handleResolveStatusCreate(ctxArg interface{}, key string,
@@ -96,7 +96,7 @@ func handleResolveStatusModify(ctxArg interface{}, key string,
 func handleResolveStatusImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
-	log.Infof("handleResolveStatusImpl for %s", key)
+	log.Functionf("handleResolveStatusImpl for %s", key)
 	ctx := ctxArg.(*volumemgrContext)
 	rs := statusArg.(types.ResolveStatus)
 	pub := ctx.pubContentTreeStatus
@@ -108,15 +108,15 @@ func handleResolveStatusImpl(ctxArg interface{}, key string,
 			status.DatastoreID != rs.DatastoreID {
 			continue
 		}
-		log.Infof("Updating SHA for content tree: %v",
+		log.Functionf("Updating SHA for content tree: %v",
 			status.ContentID)
 		changed, _ := doUpdateContentTree(ctx, &status)
 		if changed {
-			log.Infof("ContentTree(Name:%s, UUID:%s): handleResolveStatusImpl status change.",
+			log.Functionf("ContentTree(Name:%s, UUID:%s): handleResolveStatusImpl status change.",
 				status.DisplayName, status.ContentID)
 			publishContentTreeStatus(ctx, &status)
 		}
 		updateVolumeStatusFromContentID(ctx, status.ContentID)
 	}
-	log.Infof("handleResolveStatusImpl done for %s", key)
+	log.Functionf("handleResolveStatusImpl done for %s", key)
 }

--- a/pkg/pillar/cmd/volumemgr/handleverifier.go
+++ b/pkg/pillar/cmd/volumemgr/handleverifier.go
@@ -15,7 +15,7 @@ func lookupVerifyImageConfig(ctx *volumemgrContext,
 	pub := ctx.pubVerifyImageConfig
 	c, _ := pub.Get(key)
 	if c == nil {
-		log.Debugf("lookupVerifyImageConfig(%s) not found", key)
+		log.Tracef("lookupVerifyImageConfig(%s) not found", key)
 		return nil
 	}
 	config := c.(types.VerifyImageConfig)
@@ -26,14 +26,14 @@ func publishVerifyImageConfig(ctx *volumemgrContext,
 	config *types.VerifyImageConfig) {
 
 	key := config.Key()
-	log.Debugf("publishVerifyImageConfig(%s)", key)
+	log.Tracef("publishVerifyImageConfig(%s)", key)
 	pub := ctx.pubVerifyImageConfig
 	pub.Publish(key, *config)
 }
 
 func unpublishVerifyImageConfig(ctx *volumemgrContext, key string) {
 
-	log.Debugf("unpublishVerifyImageConfig(%s)", key)
+	log.Tracef("unpublishVerifyImageConfig(%s)", key)
 	pub := ctx.pubVerifyImageConfig
 	c, _ := pub.Get(key)
 	if c == nil {
@@ -46,7 +46,7 @@ func unpublishVerifyImageConfig(ctx *volumemgrContext, key string) {
 // MaybeAddVerifyImageConfigBlob publishes the verifier config
 func MaybeAddVerifyImageConfigBlob(ctx *volumemgrContext, blob types.BlobStatus) (bool, types.ErrorAndTime) {
 
-	log.Infof("MaybeAddVerifyImageConfigBlob for %s", blob.Sha256)
+	log.Functionf("MaybeAddVerifyImageConfigBlob for %s", blob.Sha256)
 
 	var vic *types.VerifyImageConfig
 	vic = lookupVerifyImageConfig(ctx, blob.Sha256)
@@ -54,7 +54,7 @@ func MaybeAddVerifyImageConfigBlob(ctx *volumemgrContext, blob types.BlobStatus)
 	// See delete handshake comment below.
 	if vic != nil && !vic.Expired {
 		vic.RefCount++
-		log.Infof("MaybeAddVerifyImageConfigBlob: refcnt to %d for %s",
+		log.Functionf("MaybeAddVerifyImageConfigBlob: refcnt to %d for %s",
 			vic.RefCount, blob.Sha256)
 	} else {
 		// If Expired this will overwrite the VerifyImageConfig
@@ -65,17 +65,17 @@ func MaybeAddVerifyImageConfigBlob(ctx *volumemgrContext, blob types.BlobStatus)
 			refcount = vic.RefCount
 		}
 		refcount++
-		log.Infof("MaybeAddVerifyImageConfigBlob: add for %s", blob.Sha256)
+		log.Functionf("MaybeAddVerifyImageConfigBlob: add for %s", blob.Sha256)
 		vic = &types.VerifyImageConfig{
 			FileLocation: blob.Path,   // the source of the file to verify
 			ImageSha256:  blob.Sha256, // the sha to verify
 			Name:         blob.Sha256, // we are just going to use the sha for the verifier display
 			RefCount:     refcount,
 		}
-		log.Debugf("MaybeAddVerifyImageConfigBlob - config: %+v", vic)
+		log.Tracef("MaybeAddVerifyImageConfigBlob - config: %+v", vic)
 	}
 	publishVerifyImageConfig(ctx, vic)
-	log.Infof("MaybeAddVerifyImageConfigBlob done for %s", blob.Sha256)
+	log.Functionf("MaybeAddVerifyImageConfigBlob done for %s", blob.Sha256)
 	return true, types.ErrorAndTime{}
 }
 
@@ -87,11 +87,11 @@ func MaybeAddVerifyImageConfigBlob(ctx *volumemgrContext, blob types.BlobStatus)
 // VerifyImageConfig is unpublished
 func MaybeRemoveVerifyImageConfig(ctx *volumemgrContext, imageSha string) {
 
-	log.Infof("MaybeRemoveVerifyImageConfig(%s)", imageSha)
+	log.Functionf("MaybeRemoveVerifyImageConfig(%s)", imageSha)
 
 	m := lookupVerifyImageConfig(ctx, imageSha)
 	if m == nil {
-		log.Infof("MaybeRemoveVerifyImageConfig: config missing for %s",
+		log.Functionf("MaybeRemoveVerifyImageConfig: config missing for %s",
 			imageSha)
 		return
 	}
@@ -100,16 +100,16 @@ func MaybeRemoveVerifyImageConfig(ctx *volumemgrContext, imageSha string) {
 			"0 RefCount. ImageSha256: %s", m.ImageSha256)
 	}
 	m.RefCount -= 1
-	log.Infof("MaybeRemoveVerifyImageConfig: RefCount to %d for %s",
+	log.Functionf("MaybeRemoveVerifyImageConfig: RefCount to %d for %s",
 		m.RefCount, imageSha)
 
 	if m.RefCount == 0 {
-		log.Infof("MaybeRemoveVerifyImageConfig(%s): marking VerifyImageConfig as expired", imageSha)
+		log.Functionf("MaybeRemoveVerifyImageConfig(%s): marking VerifyImageConfig as expired", imageSha)
 		deleteVerifyImageConfig(ctx, m)
 	} else {
 		publishVerifyImageConfig(ctx, m)
 	}
-	log.Infof("MaybeRemoveVerifyImageConfig done for %s", imageSha)
+	log.Functionf("MaybeRemoveVerifyImageConfig done for %s", imageSha)
 }
 
 // deleteVerifyImageConfig checks the refcount and if it is zero it
@@ -135,7 +135,7 @@ func MaybeRemoveVerifyImageConfig(ctx *volumemgrContext, imageSha string) {
 // 7. handleVerifyImageStatusDelete will the unpublish the VIC if it has Expired set (if it was recreated it will not have Expired set)
 func deleteVerifyImageConfig(ctx *volumemgrContext, config *types.VerifyImageConfig) {
 
-	log.Infof("deleteVerifyImageConfig(%s)", config.ImageSha256)
+	log.Functionf("deleteVerifyImageConfig(%s)", config.ImageSha256)
 	if config.Expired {
 		log.Fatalf("deleteVerifyImageConfig: already Expired for %s",
 			config.ImageSha256)
@@ -147,7 +147,7 @@ func deleteVerifyImageConfig(ctx *volumemgrContext, config *types.VerifyImageCon
 	}
 	config.Expired = true
 	publishVerifyImageConfig(ctx, config)
-	log.Infof("deleteVerifyImageConfig done for %s", config.ImageSha256)
+	log.Functionf("deleteVerifyImageConfig done for %s", config.ImageSha256)
 }
 
 func handleVerifyImageStatusCreate(ctxArg interface{}, key string,
@@ -165,7 +165,7 @@ func handleVerifyImageStatusImpl(ctxArg interface{}, key string,
 
 	status := statusArg.(types.VerifyImageStatus)
 	ctx := ctxArg.(*volumemgrContext)
-	log.Infof("handleVerifyImageStatusImpl for ImageSha256: %s, "+
+	log.Functionf("handleVerifyImageStatusImpl for ImageSha256: %s, "+
 		" RefCount %d Expired %t", status.ImageSha256, status.RefCount,
 		status.Expired)
 
@@ -179,7 +179,7 @@ func handleVerifyImageStatusImpl(ctxArg interface{}, key string,
 
 	config := lookupVerifyImageConfig(ctx, status.ImageSha256)
 	if config == nil && status.RefCount == 0 {
-		log.Infof("handleVerifyImageStatusImpl adding RefCount=0 config %s",
+		log.Functionf("handleVerifyImageStatusImpl adding RefCount=0 config %s",
 			key)
 
 		// Note: signature-related fields are filled in when
@@ -199,21 +199,21 @@ func handleVerifyImageStatusImpl(ctxArg interface{}, key string,
 	// If config is not Expired it means it was recreated and we
 	// ignore the Expired status
 	if status.Expired && config != nil && config.RefCount == 0 && config.Expired {
-		log.Infof("handleVerifyImageStatusImpl delete config for %s",
+		log.Functionf("handleVerifyImageStatusImpl delete config for %s",
 			key)
 		unpublishVerifyImageConfig(ctx, config.Key())
 	} else if status.Expired {
-		log.Infof("handleVerifyImageStatusImpl ignore expired VerifyImageStatus; config not Expired for %s",
+		log.Functionf("handleVerifyImageStatusImpl ignore expired VerifyImageStatus; config not Expired for %s",
 			key)
 	}
 	// Ignore if any Pending* flag is set
 	if status.Pending() {
-		log.Infof("handleVerifyImageStatusImpl skipped due to Pending* for"+
+		log.Functionf("handleVerifyImageStatusImpl skipped due to Pending* for"+
 			" ImageSha256: %s", status.ImageSha256)
 		return
 	}
 	updateStatusByBlob(ctx, status.ImageSha256)
-	log.Infof("handleVerifyImageStatusImpl done for %s", status.ImageSha256)
+	log.Functionf("handleVerifyImageStatusImpl done for %s", status.ImageSha256)
 }
 
 // Note that this function returns the entry even if Pending* or Expired is set.
@@ -224,7 +224,7 @@ func lookupVerifyImageStatus(ctx *volumemgrContext,
 	sub := ctx.subVerifyImageStatus
 	s, _ := sub.Get(key)
 	if s == nil {
-		log.Debugf("lookupVerifyImageStatus(%s) not found", key)
+		log.Tracef("lookupVerifyImageStatus(%s) not found", key)
 		return nil
 	}
 	status := s.(types.VerifyImageStatus)
@@ -235,10 +235,10 @@ func handleVerifyImageStatusDelete(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
 	status := statusArg.(types.VerifyImageStatus)
-	log.Infof("handleVerifyImageStatusDelete for %s", key)
+	log.Functionf("handleVerifyImageStatusDelete for %s", key)
 	ctx := ctxArg.(*volumemgrContext)
 	updateStatusByBlob(ctx, status.ImageSha256)
-	log.Infof("handleVerifyImageStatusDelete done for %s", key)
+	log.Functionf("handleVerifyImageStatusDelete done for %s", key)
 }
 
 //gcVerifyImageConfig marks all VerifyImageConfig with refCount = 0 as expired
@@ -248,7 +248,7 @@ func gcVerifyImageConfig(ctx *volumemgrContext) {
 	for _, verifyImageConfigIntf := range verifyImageConfigMap {
 		verifyImageConfig := verifyImageConfigIntf.(types.VerifyImageConfig)
 		if verifyImageConfig.RefCount == 0 && !verifyImageConfig.Expired {
-			log.Infof("gcVerifyImageConfig(%s): marking VerifyImageConfig as expired", verifyImageConfig.Key())
+			log.Functionf("gcVerifyImageConfig(%s): marking VerifyImageConfig as expired", verifyImageConfig.Key())
 			deleteVerifyImageConfig(ctx, &verifyImageConfig)
 		}
 	}

--- a/pkg/pillar/cmd/volumemgr/handlevolume.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume.go
@@ -15,7 +15,7 @@ import (
 func handleVolumeCreate(ctxArg interface{}, key string,
 	configArg interface{}) {
 
-	log.Infof("handleVolumeCreate(%s)", key)
+	log.Functionf("handleVolumeCreate(%s)", key)
 	config := configArg.(types.VolumeConfig)
 	ctx := ctxArg.(*volumemgrContext)
 	status := lookupVolumeStatus(ctx, config.Key())
@@ -96,13 +96,13 @@ func handleVolumeCreate(ctxArg interface{}, key string,
 	if err := createOrUpdateAppDiskMetrics(ctx, status); err != nil {
 		log.Errorf("handleVolumeCreate(%s): exception while publishing diskmetric. %s", key, err.Error())
 	}
-	log.Infof("handleVolumeCreate(%s) Done", key)
+	log.Functionf("handleVolumeCreate(%s) Done", key)
 }
 
 func handleVolumeModify(ctxArg interface{}, key string,
 	configArg interface{}, oldConfigArg interface{}) {
 
-	log.Infof("handleVolumeModify(%s)", key)
+	log.Functionf("handleVolumeModify(%s)", key)
 	config := configArg.(types.VolumeConfig)
 	ctx := ctxArg.(*volumemgrContext)
 	status := lookupVolumeStatus(ctx, config.Key())
@@ -123,12 +123,12 @@ func handleVolumeModify(ctxArg interface{}, key string,
 		return
 	}
 	if config.DisplayName != status.DisplayName {
-		log.Infof("DisplayName changed from %s to %s for %s",
+		log.Functionf("DisplayName changed from %s to %s for %s",
 			status.DisplayName, config.DisplayName, config.VolumeID)
 		status.DisplayName = config.DisplayName
 	}
 	if config.RefCount != status.RefCount {
-		log.Infof("RefCount changed from %d to %d for %s",
+		log.Functionf("RefCount changed from %d to %d for %s",
 			status.RefCount, config.RefCount, config.DisplayName)
 		status.RefCount = config.RefCount
 	}
@@ -138,40 +138,40 @@ func handleVolumeModify(ctxArg interface{}, key string,
 	if err := createOrUpdateAppDiskMetrics(ctx, status); err != nil {
 		log.Errorf("handleVolumeModify(%s): exception while publishing diskmetric. %s", key, err.Error())
 	}
-	log.Infof("handleVolumeModify(%s) Done", key)
+	log.Functionf("handleVolumeModify(%s) Done", key)
 }
 
 func handleVolumeDelete(ctxArg interface{}, key string,
 	configArg interface{}) {
 
-	log.Infof("handleVolumeDelete(%s)", key)
+	log.Functionf("handleVolumeDelete(%s)", key)
 	config := configArg.(types.VolumeConfig)
 	ctx := ctxArg.(*volumemgrContext)
 	status := lookupVolumeStatus(ctx, config.Key())
 	if status == nil {
-		log.Infof("handleVolumeDelete for %v, VolumeStatus not found", key)
+		log.Functionf("handleVolumeDelete for %v, VolumeStatus not found", key)
 		return
 	}
 	updateVolumeStatusRefCount(ctx, status)
 	maybeDeleteVolume(ctx, status)
-	log.Infof("handleVolumeDelete(%s) Done", key)
+	log.Functionf("handleVolumeDelete(%s) Done", key)
 }
 
 func publishVolumeStatus(ctx *volumemgrContext,
 	status *types.VolumeStatus) {
 
 	key := status.Key()
-	log.Debugf("publishVolumeStatus(%s)", key)
+	log.Tracef("publishVolumeStatus(%s)", key)
 	pub := ctx.pubVolumeStatus
 	pub.Publish(key, *status)
-	log.Debugf("publishVolumeStatus(%s) Done", key)
+	log.Tracef("publishVolumeStatus(%s) Done", key)
 }
 
 func unpublishVolumeStatus(ctx *volumemgrContext,
 	status *types.VolumeStatus) {
 
 	key := status.Key()
-	log.Debugf("unpublishVolumeStatus(%s)", key)
+	log.Tracef("unpublishVolumeStatus(%s)", key)
 	pub := ctx.pubVolumeStatus
 	c, _ := pub.Get(key)
 	if c == nil {
@@ -179,58 +179,58 @@ func unpublishVolumeStatus(ctx *volumemgrContext,
 		return
 	}
 	pub.Unpublish(key)
-	log.Debugf("unpublishVolumeStatus(%s) Done", key)
+	log.Tracef("unpublishVolumeStatus(%s) Done", key)
 }
 
 func lookupVolumeStatus(ctx *volumemgrContext,
 	key string) *types.VolumeStatus {
 
-	log.Debugf("lookupVolumeStatus(%s)", key)
+	log.Tracef("lookupVolumeStatus(%s)", key)
 	pub := ctx.pubVolumeStatus
 	c, _ := pub.Get(key)
 	if c == nil {
-		log.Debugf("lookupVolumeStatus(%s) not found", key)
+		log.Tracef("lookupVolumeStatus(%s) not found", key)
 		return nil
 	}
 	status := c.(types.VolumeStatus)
-	log.Debugf("lookupVolumeStatus(%s) Done", key)
+	log.Tracef("lookupVolumeStatus(%s) Done", key)
 	return &status
 }
 
 func getAllVolumeStatus(ctx *volumemgrContext) []*types.VolumeStatus {
 	var retList []*types.VolumeStatus
-	log.Debugf("getAllVolumeStatus")
+	log.Tracef("getAllVolumeStatus")
 	pub := ctx.pubVolumeStatus
 	items := pub.GetAll()
 	for _, st := range items {
 		status := st.(types.VolumeStatus)
 		retList = append(retList, &status)
 	}
-	log.Debugf("getAllVolumeStatus: Done")
+	log.Tracef("getAllVolumeStatus: Done")
 	return retList
 }
 
 func lookupVolumeConfig(ctx *volumemgrContext,
 	key string) *types.VolumeConfig {
 
-	log.Debugf("lookupVolumeConfig(%s)", key)
+	log.Tracef("lookupVolumeConfig(%s)", key)
 	sub := ctx.subVolumeConfig
 	c, _ := sub.Get(key)
 	if c == nil {
-		log.Debugf("lookupVolumeConfig(%s) not found", key)
+		log.Tracef("lookupVolumeConfig(%s) not found", key)
 		return nil
 	}
 	config := c.(types.VolumeConfig)
-	log.Debugf("lookupVolumeConfig(%s) Done", key)
+	log.Tracef("lookupVolumeConfig(%s) Done", key)
 	return &config
 }
 
 func maybeDeleteVolume(ctx *volumemgrContext, status *types.VolumeStatus) {
 
-	log.Infof("maybeDeleteVolume for %v", status.Key())
+	log.Functionf("maybeDeleteVolume for %v", status.Key())
 	if status.RefCount != 0 {
 		publishVolumeStatus(ctx, status)
-		log.Infof("maybeDeleteVolume for %v Done", status.Key())
+		log.Functionf("maybeDeleteVolume for %v Done", status.Key())
 		return
 	}
 	if status.VolumeCreated {
@@ -238,7 +238,7 @@ func maybeDeleteVolume(ctx *volumemgrContext, status *types.VolumeStatus) {
 		AddWorkDestroy(ctx, status)
 		vr := popVolumeWorkResult(ctx, status.Key())
 		if vr != nil {
-			log.Infof("VolumeWorkResult(%s) location %s, created %t",
+			log.Functionf("VolumeWorkResult(%s) location %s, created %t",
 				status.Key(), vr.FileLocation, vr.VolumeCreated)
 			status.VolumeCreated = vr.VolumeCreated
 			status.FileLocation = vr.FileLocation
@@ -246,7 +246,7 @@ func maybeDeleteVolume(ctx *volumemgrContext, status *types.VolumeStatus) {
 				status.SetErrorWithSource(vr.Error.Error(),
 					types.VolumeStatus{}, vr.ErrorTime)
 			} else if status.IsErrorSource(types.VolumeStatus{}) {
-				log.Infof("Clearing volume error %s",
+				log.Functionf("Clearing volume error %s",
 					status.Error)
 				status.ClearErrorWithSource()
 			}
@@ -254,7 +254,7 @@ func maybeDeleteVolume(ctx *volumemgrContext, status *types.VolumeStatus) {
 				DeleteWorkDestroy(ctx, status)
 			}
 		} else {
-			log.Infof("VolumeWorkResult(%s) not found", status.Key())
+			log.Functionf("VolumeWorkResult(%s) not found", status.Key())
 			// XXX what happens when VolumeWork is done?
 		}
 	}
@@ -263,23 +263,23 @@ func maybeDeleteVolume(ctx *volumemgrContext, status *types.VolumeStatus) {
 	if appDiskMetric := lookupAppDiskMetric(ctx, status.FileLocation); appDiskMetric != nil {
 		unpublishAppDiskMetrics(ctx, appDiskMetric)
 	}
-	log.Infof("maybeDeleteVolume for %v Done", status.Key())
+	log.Functionf("maybeDeleteVolume for %v Done", status.Key())
 }
 
 // updateVolumeStatusRefCount updates the refcount in volume status
 // Refcount in volume status is sum of refount in volume config and volume ref config
 func updateVolumeStatusRefCount(ctx *volumemgrContext, vs *types.VolumeStatus) {
-	log.Debugf("updateVolumeStatusRefCount(%s)", vs.Key())
+	log.Tracef("updateVolumeStatusRefCount(%s)", vs.Key())
 	var vcRefCount, vrcRefCount uint
 	vc := lookupVolumeConfig(ctx, vs.Key())
 	if vc == nil {
-		log.Infof("updateVolumeStatusRefCount: VolumeConfig not present for %s", vs.Key())
+		log.Functionf("updateVolumeStatusRefCount: VolumeConfig not present for %s", vs.Key())
 	} else {
 		vcRefCount = vc.RefCount
 	}
 	vrc := lookupVolumeRefConfig(ctx, vs.Key())
 	if vrc == nil {
-		log.Infof("updateVolumeStatusRefCount: VolumeRefConfig not present for %s", vs.Key())
+		log.Functionf("updateVolumeStatusRefCount: VolumeRefConfig not present for %s", vs.Key())
 	} else {
 		vrcRefCount = vrc.RefCount
 	}
@@ -287,10 +287,10 @@ func updateVolumeStatusRefCount(ctx *volumemgrContext, vs *types.VolumeStatus) {
 	newRefCount := vcRefCount + vrcRefCount
 	if newRefCount != oldRefCount {
 		vs.RefCount = newRefCount
-		log.Infof("updateVolumeStatusRefCount(%s) updated from %d to %d",
+		log.Functionf("updateVolumeStatusRefCount(%s) updated from %d to %d",
 			vs.Key(), oldRefCount, newRefCount)
 	}
-	log.Debugf("updateVolumeStatusRefCount(%s) Done", vs.Key())
+	log.Tracef("updateVolumeStatusRefCount(%s) Done", vs.Key())
 }
 
 // Returns needRegeneration, plus a reason string.
@@ -299,38 +299,38 @@ func quantifyChanges(config types.VolumeConfig,
 
 	needRegeneration := false
 	var regenerationReason string
-	log.Infof("quantifyChanges for %s %s",
+	log.Functionf("quantifyChanges for %s %s",
 		config.Key(), config.DisplayName)
 	if config.ContentID != status.ContentID {
 		str := fmt.Sprintf("ContentID changed from %s to %s for %s",
 			status.ContentID, config.ContentID, config.DisplayName)
-		log.Infof(str)
+		log.Functionf(str)
 		needRegeneration = true
 		regenerationReason += str + "\n"
 	}
 	if config.VolumeContentOriginType != status.VolumeContentOriginType {
 		str := fmt.Sprintf("VolumeContentOriginType changed from %v to %v for %s",
 			status.VolumeContentOriginType, config.VolumeContentOriginType, config.DisplayName)
-		log.Infof(str)
+		log.Functionf(str)
 		needRegeneration = true
 		regenerationReason += str + "\n"
 	}
 	if config.MaxVolSize != status.MaxVolSize {
 		str := fmt.Sprintf("MaxVolSize changed from %d to %d for %s",
 			status.MaxVolSize, config.MaxVolSize, config.DisplayName)
-		log.Infof(str)
+		log.Functionf(str)
 		needRegeneration = true
 		regenerationReason += str + "\n"
 	}
 	if config.ReadOnly != status.ReadOnly {
 		str := fmt.Sprintf("ReadOnly changed from %v to %v for %s",
 			status.ReadOnly, config.ReadOnly, config.DisplayName)
-		log.Infof(str)
+		log.Functionf(str)
 		needRegeneration = true
 		regenerationReason += str + "\n"
 	}
 
-	log.Infof("quantifyChanges for %s %s returns %v, %s",
+	log.Functionf("quantifyChanges for %s %s returns %v, %s",
 		config.Key(), config.DisplayName, needRegeneration, regenerationReason)
 	return needRegeneration, regenerationReason
 }

--- a/pkg/pillar/cmd/volumemgr/handlevolume_test.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume_test.go
@@ -19,7 +19,7 @@ func TestIsErrorSourceOnPubSub(t *testing.T) {
 	status := &types.VolumeStatus{}
 	errStr := "test1"
 	status.SetErrorWithSource(errStr, types.ContentTreeStatus{}, time.Now())
-	log.Infof("set error %s", status.Error)
+	log.Functionf("set error %s", status.Error)
 	ctx := initStatusCtx(t)
 	publishVolumeStatus(&ctx, status)
 	status = lookupVolumeStatus(&ctx, status.Key())
@@ -30,7 +30,7 @@ func TestIsErrorSourceOnPubSub(t *testing.T) {
 		"Pubsub error source type: %T", status.ErrorSourceType)
 	assert.Equal(t, errStr, status.Error)
 	status.ClearErrorWithSource()
-	log.Infof("cleared error %s", status.Error)
+	log.Functionf("cleared error %s", status.Error)
 	assert.False(t, status.IsErrorSource(types.ContentTreeStatus{}),
 		"Pubsub error source type: %T", status.ErrorSourceType)
 	assert.Equal(t, "", status.Error)

--- a/pkg/pillar/cmd/volumemgr/handlevolumeref.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolumeref.go
@@ -10,7 +10,7 @@ import (
 func handleVolumeRefCreate(ctxArg interface{}, key string,
 	configArg interface{}) {
 
-	log.Infof("handleVolumeRefCreate(%s)", key)
+	log.Functionf("handleVolumeRefCreate(%s)", key)
 	config := configArg.(types.VolumeRefConfig)
 	ctx := ctxArg.(*volumemgrContext)
 	status := lookupVolumeRefStatus(ctx, key)
@@ -48,13 +48,13 @@ func handleVolumeRefCreate(ctxArg interface{}, key string,
 		}
 	}
 	publishVolumeRefStatus(ctx, status)
-	log.Infof("handleVolumeRefCreate(%s) Done", key)
+	log.Functionf("handleVolumeRefCreate(%s) Done", key)
 }
 
 func handleVolumeRefModify(ctxArg interface{}, key string,
 	configArg interface{}, oldConfigArg interface{}) {
 
-	log.Infof("handleVolumeRefModify(%s)", key)
+	log.Functionf("handleVolumeRefModify(%s)", key)
 	config := configArg.(types.VolumeRefConfig)
 	ctx := ctxArg.(*volumemgrContext)
 	status := lookupVolumeRefStatus(ctx, config.Key())
@@ -68,13 +68,13 @@ func handleVolumeRefModify(ctxArg interface{}, key string,
 		updateVolumeStatusRefCount(ctx, vs)
 		publishVolumeStatus(ctx, vs)
 	}
-	log.Infof("handleVolumeRefModify(%s) Done", key)
+	log.Functionf("handleVolumeRefModify(%s) Done", key)
 }
 
 func handleVolumeRefDelete(ctxArg interface{}, key string,
 	configArg interface{}) {
 
-	log.Infof("handleVolumeRefDelete(%s)", key)
+	log.Functionf("handleVolumeRefDelete(%s)", key)
 	config := configArg.(types.VolumeRefConfig)
 	ctx := ctxArg.(*volumemgrContext)
 	unpublishVolumeRefStatus(ctx, config.Key())
@@ -84,7 +84,7 @@ func handleVolumeRefDelete(ctxArg interface{}, key string,
 		publishVolumeStatus(ctx, vs)
 		maybeDeleteVolume(ctx, vs)
 	}
-	log.Infof("handleVolumeRefDelete(%s) Done", key)
+	log.Functionf("handleVolumeRefDelete(%s) Done", key)
 }
 
 func lookupVolumeRefConfig(ctx *volumemgrContext, key string) *types.VolumeRefConfig {
@@ -92,7 +92,7 @@ func lookupVolumeRefConfig(ctx *volumemgrContext, key string) *types.VolumeRefCo
 	sub := ctx.subVolumeRefConfig
 	c, _ := sub.Get(key)
 	if c == nil {
-		log.Debugf("lookupVolumeRefConfig(%s) not found", key)
+		log.Tracef("lookupVolumeRefConfig(%s) not found", key)
 		return nil
 	}
 	config := c.(types.VolumeRefConfig)
@@ -104,7 +104,7 @@ func lookupVolumeRefStatus(ctx *volumemgrContext, key string) *types.VolumeRefSt
 	pub := ctx.pubVolumeRefStatus
 	c, _ := pub.Get(key)
 	if c == nil {
-		log.Debugf("lookupVolumeRefStatus(%s) not found", key)
+		log.Tracef("lookupVolumeRefStatus(%s) not found", key)
 		return nil
 	}
 	status := c.(types.VolumeRefStatus)
@@ -114,15 +114,15 @@ func lookupVolumeRefStatus(ctx *volumemgrContext, key string) *types.VolumeRefSt
 func publishVolumeRefStatus(ctx *volumemgrContext, status *types.VolumeRefStatus) {
 
 	key := status.Key()
-	log.Debugf("publishVolumeRefStatus(%s)", key)
+	log.Tracef("publishVolumeRefStatus(%s)", key)
 	pub := ctx.pubVolumeRefStatus
 	pub.Publish(key, *status)
-	log.Debugf("publishVolumeRefStatus(%s) Done", key)
+	log.Tracef("publishVolumeRefStatus(%s) Done", key)
 }
 
 func unpublishVolumeRefStatus(ctx *volumemgrContext, key string) {
 
-	log.Debugf("unpublishVolumeRefStatus(%s)", key)
+	log.Tracef("unpublishVolumeRefStatus(%s)", key)
 	pub := ctx.pubVolumeRefStatus
 	c, _ := pub.Get(key)
 	if c == nil {
@@ -130,7 +130,7 @@ func unpublishVolumeRefStatus(ctx *volumemgrContext, key string) {
 		return
 	}
 	pub.Unpublish(key)
-	log.Debugf("unpublishVolumeRefStatus(%s) Done", key)
+	log.Tracef("unpublishVolumeRefStatus(%s) Done", key)
 }
 
 func updateVolumeRefStatus(ctx *volumemgrContext, vs *types.VolumeStatus) {

--- a/pkg/pillar/cmd/volumemgr/handlework.go
+++ b/pkg/pillar/cmd/volumemgr/handlework.go
@@ -148,7 +148,7 @@ func casIngestWorker(ctxPtr interface{}, w worker.Work) worker.WorkResult {
 	d := w.Description.(casIngestWorkDescription)
 	status := d.status
 
-	log.Infof("casIngestWorker has blobs: %v", status.Blobs)
+	log.Functionf("casIngestWorker has blobs: %v", status.Blobs)
 	blobStatuses := lookupBlobStatuses(ctx, status.Blobs...)
 
 	// find the blobs we need to load and indicate that they are being loaded

--- a/pkg/pillar/cmd/volumemgr/initialvolumestatus.go
+++ b/pkg/pillar/cmd/volumemgr/initialvolumestatus.go
@@ -22,7 +22,7 @@ import (
 // from the name of the volume and prepares map of it
 func populateExistingVolumesFormat(dirName string) {
 
-	log.Infof("populateExistingVolumesFormat(%s)", dirName)
+	log.Functionf("populateExistingVolumesFormat(%s)", dirName)
 	locations, err := ioutil.ReadDir(dirName)
 	if err != nil {
 		log.Errorf("populateExistingVolumesFormat: read directory '%s' failed: %v",
@@ -37,14 +37,14 @@ func populateExistingVolumesFormat(dirName string) {
 		}
 		volumeFormat[key] = zconfig.Format(zconfig.Format_value[format])
 	}
-	log.Infof("populateExistingVolumesFormat(%s) Done", dirName)
+	log.Functionf("populateExistingVolumesFormat(%s) Done", dirName)
 }
 
 // Periodic garbage collection looking at RefCount=0 files in the unknown
 // Others have their delete handler.
 func gcObjects(ctx *volumemgrContext, dirName string) {
 
-	log.Debugf("gcObjects(%s)", dirName)
+	log.Tracef("gcObjects(%s)", dirName)
 	locations, err := ioutil.ReadDir(dirName)
 	if err != nil {
 		log.Errorf("gcObjects: read directory '%s' failed: %v",
@@ -61,7 +61,7 @@ func gcObjects(ctx *volumemgrContext, dirName string) {
 		}
 		vs := lookupVolumeStatus(ctx, key)
 		if vs == nil {
-			log.Infof("gcObjects: Found unused volume %s. Deleting it.",
+			log.Functionf("gcObjects: Found unused volume %s. Deleting it.",
 				filelocation)
 			if format == "CONTAINER" {
 				_ = ctx.casClient.RemoveContainerRootDir(filelocation)
@@ -69,7 +69,7 @@ func gcObjects(ctx *volumemgrContext, dirName string) {
 			deleteFile(filelocation)
 		}
 	}
-	log.Debugf("gcObjects(%s) Done", dirName)
+	log.Tracef("gcObjects(%s) Done", dirName)
 }
 
 func getVolumeKeyAndFormat(dirName, name string) (key string, format string, tmp bool, err error) {
@@ -89,7 +89,7 @@ func getVolumeKeyAndFormat(dirName, name string) (key string, format string, tmp
 }
 
 func deleteFile(filelocation string) {
-	log.Infof("deleteFile: Deleting %s", filelocation)
+	log.Functionf("deleteFile: Deleting %s", filelocation)
 	if err := os.RemoveAll(filelocation); err != nil {
 		log.Errorf("Failed to delete file %s. Error: %s",
 			filelocation, err.Error())

--- a/pkg/pillar/cmd/volumemgr/latchcontenthash.go
+++ b/pkg/pillar/cmd/volumemgr/latchcontenthash.go
@@ -17,7 +17,7 @@ import (
 func latchContentTreeHash(ctx *volumemgrContext, contentID uuid.UUID,
 	hash string, generationCounter uint32) {
 
-	log.Infof("latchContentTreeHash(%s, %s, %d)", contentID, hash, generationCounter)
+	log.Functionf("latchContentTreeHash(%s, %s, %d)", contentID, hash, generationCounter)
 	if hash == "" {
 		log.Errorf("latchContentTreeHash(%s, %d) empty hash",
 			contentID, generationCounter)
@@ -40,14 +40,14 @@ func latchContentTreeHash(ctx *volumemgrContext, contentID uuid.UUID,
 			contentID, generationCounter, old.Hash, aih.Hash)
 	}
 	ctx.pubContentTreeToHash.Publish(aih.Key(), aih)
-	log.Infof("latchContentTreeHash(%s, %s, %d) done", contentID, hash, generationCounter)
+	log.Functionf("latchContentTreeHash(%s, %s, %d) done", contentID, hash, generationCounter)
 }
 
 // Delete for a specific content tree
 func deleteLatchContentTreeHash(ctx *volumemgrContext,
 	contentID uuid.UUID, generationCounter uint32) {
 
-	log.Infof("deleteLatchContentTreeHash(%s, %d)", contentID, generationCounter)
+	log.Functionf("deleteLatchContentTreeHash(%s, %d)", contentID, generationCounter)
 	aih := types.AppAndImageToHash{
 		ImageID:      contentID,
 		PurgeCounter: generationCounter,
@@ -59,13 +59,13 @@ func deleteLatchContentTreeHash(ctx *volumemgrContext,
 		return
 	}
 	ctx.pubContentTreeToHash.Unpublish(aih.Key())
-	log.Infof("deleteLatchContentTreeHash(%s, %d) done", contentID, generationCounter)
+	log.Functionf("deleteLatchContentTreeHash(%s, %d) done", contentID, generationCounter)
 }
 
 // Purge all for contentID
 func purgeLatchContentTreeHash(ctx *volumemgrContext, contentID uuid.UUID) {
 
-	log.Infof("purgeLatchContentTreeHash(%s)", contentID)
+	log.Functionf("purgeLatchContentTreeHash(%s)", contentID)
 	items := ctx.pubContentTreeToHash.GetAll()
 	for _, a := range items {
 		aih := a.(types.AppAndImageToHash)
@@ -75,26 +75,26 @@ func purgeLatchContentTreeHash(ctx *volumemgrContext, contentID uuid.UUID) {
 			ctx.pubContentTreeToHash.Unpublish(aih.Key())
 		}
 	}
-	log.Infof("purgeLatchContentTreeHash(%s) done", contentID)
+	log.Functionf("purgeLatchContentTreeHash(%s) done", contentID)
 }
 
 // Returns "" string if not found
 func lookupLatchContentTreeHash(ctx *volumemgrContext,
 	contentID uuid.UUID, generationCounter uint32) string {
 
-	log.Debugf("lookupLatchContentTreeHash(%s, %d)", contentID, generationCounter)
+	log.Tracef("lookupLatchContentTreeHash(%s, %d)", contentID, generationCounter)
 	temp := types.AppAndImageToHash{
 		ImageID:      contentID,
 		PurgeCounter: generationCounter,
 	}
 	item, _ := ctx.pubContentTreeToHash.Get(temp.Key())
 	if item == nil {
-		log.Debugf("lookupLatchContentTreeHash(%s, %d) not found",
+		log.Tracef("lookupLatchContentTreeHash(%s, %d) not found",
 			contentID, generationCounter)
 		return ""
 	}
 	aih := item.(types.AppAndImageToHash)
-	log.Debugf("lookupLatchContentTreeHash(%s, %d) found %s",
+	log.Tracef("lookupLatchContentTreeHash(%s, %d) found %s",
 		contentID, generationCounter, aih.Hash)
 	return aih.Hash
 }
@@ -105,19 +105,19 @@ func maybeLatchContentTreeHash(ctx *volumemgrContext, status *types.ContentTreeS
 	imageSha := lookupLatchContentTreeHash(ctx, status.ContentID, uint32(status.GenerationCounter))
 	if imageSha == "" {
 		if status.IsContainer() && status.ContentSha256 == "" {
-			log.Infof("ContentTree(%s) %s has not (yet) latched sha",
+			log.Functionf("ContentTree(%s) %s has not (yet) latched sha",
 				status.ContentID, status.DisplayName)
 		}
 		return
 	}
 	if status.ContentSha256 == "" {
-		log.Infof("Latching ContentTree(%s) %s to sha %s",
+		log.Functionf("Latching ContentTree(%s) %s to sha %s",
 			status.ContentID, status.DisplayName, imageSha)
 		status.ContentSha256 = imageSha
 		if status.IsContainer() {
 			newName := maybeInsertSha(status.RelativeURL, imageSha)
 			if newName != status.RelativeURL {
-				log.Infof("Changing content tree name from %s to %s",
+				log.Functionf("Changing content tree name from %s to %s",
 					status.RelativeURL, newName)
 				status.RelativeURL = newName
 			}

--- a/pkg/pillar/cmd/volumemgr/sizemgmt.go
+++ b/pkg/pillar/cmd/volumemgr/sizemgmt.go
@@ -23,7 +23,7 @@ func getRemainingVolumeDiskSpace(ctxPtr *volumemgrContext) (uint64, string, erro
 	for _, iterStatusJSON := range items {
 		iterStatus := iterStatusJSON.(types.VolumeStatus)
 		if iterStatus.State < types.CREATED_VOLUME {
-			log.Debugf("Volume %s State %d < CREATED_VOLUME",
+			log.Tracef("Volume %s State %d < CREATED_VOLUME",
 				iterStatus.Key(), iterStatus.State)
 			continue
 		}
@@ -62,7 +62,7 @@ func dom0DiskReservedSize(ctxPtr *volumemgrContext, deviceDiskSize uint64) uint6
 	maxDom0DiskSize := uint64(ctxPtr.globalConfig.GlobalValueInt(
 		types.Dom0DiskUsageMaxBytes))
 	if diskReservedForDom0 > maxDom0DiskSize {
-		log.Debugf("diskSizeReservedForDom0 - diskReservedForDom0 adjusted to "+
+		log.Tracef("diskSizeReservedForDom0 - diskReservedForDom0 adjusted to "+
 			"maxDom0DiskSize (%d)", maxDom0DiskSize)
 		diskReservedForDom0 = maxDom0DiskSize
 	}

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -20,14 +20,14 @@ import (
 // XXX remove "done" boolean return?
 func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus) (bool, bool) {
 
-	log.Infof("doUpdateContentTree(%s) name %s state %s", status.Key(), status.DisplayName, status.State)
+	log.Functionf("doUpdateContentTree(%s) name %s state %s", status.Key(), status.DisplayName, status.State)
 
 	changed := false
 	addedBlobs := []string{}
 
 	if status.State < types.VERIFIED {
 		if status.DatastoreType == "" {
-			log.Infof("contentTreeStatus(%s) does not have a datastore type yet, deferring", status.ContentID)
+			log.Functionf("contentTreeStatus(%s) does not have a datastore type yet, deferring", status.ContentID)
 			return false, false
 		}
 
@@ -36,7 +36,7 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 			if status.ContentSha256 == "" {
 				rs := lookupResolveStatus(ctx, status.ResolveKey())
 				if rs == nil {
-					log.Infof("Resolve status not found for %s",
+					log.Functionf("Resolve status not found for %s",
 						status.ContentID)
 					status.HasResolverRef = true
 					MaybeAddResolveConfig(ctx, *status)
@@ -44,7 +44,7 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 					changed = true
 					return changed, false
 				}
-				log.Infof("Processing ResolveStatus for content tree (%v)", status.ContentID)
+				log.Functionf("Processing ResolveStatus for content tree (%v)", status.ContentID)
 				changed = true
 				if rs.HasError() {
 					errStr := fmt.Sprintf("Received error from resolver for %s, SHA (%s): %s",
@@ -63,12 +63,12 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 					changed = true
 					return changed, false
 				} else if status.IsErrorSource(types.ResolveStatus{}) {
-					log.Infof("Clearing resolver error %s", status.Error)
+					log.Functionf("Clearing resolver error %s", status.Error)
 					status.ClearErrorWithSource()
 					changed = true
 				}
 				foundSha := strings.ToLower(rs.ImageSha256)
-				log.Infof("Added Image SHA (%s) for content tree (%s)",
+				log.Functionf("Added Image SHA (%s) for content tree (%s)",
 					foundSha, status.ContentID)
 				status.State = types.RESOLVED_TAG
 				status.ContentSha256 = foundSha
@@ -99,7 +99,7 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 					Size:        status.MaxDownloadSize,
 					State:       types.INITIAL,
 				}
-				log.Infof("doUpdateContentTree: publishing new root BlobStatus (%s) for content tree (%s)",
+				log.Functionf("doUpdateContentTree: publishing new root BlobStatus (%s) for content tree (%s)",
 					status.ContentSha256, status.ContentID)
 				publishBlobStatus(ctx, rootBlob)
 			} else if rootBlob.State == types.LOADED {
@@ -107,7 +107,7 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 				// because if any child blob is not downloaded, then we would need the below data.
 				rootBlob.DatastoreID = status.DatastoreID
 				rootBlob.RelativeURL = status.RelativeURL
-				log.Infof("doUpdateContentTree: publishing loaded root BlobStatus (%s) for content tree (%s)",
+				log.Functionf("doUpdateContentTree: publishing loaded root BlobStatus (%s) for content tree (%s)",
 					status.ContentSha256, status.ContentID)
 				publishBlobStatus(ctx, rootBlob)
 			}
@@ -148,7 +148,7 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 			if blob.State <= types.DOWNLOADING {
 				// any state less than downloaded, we ask for download, so that we have the refcount;
 				// downloadBlob() is smart enough to look for existing references
-				log.Debugf("doUpdateContentTree: blob sha %s download state %v less than DOWNLOADED", blob.Sha256, blob.State)
+				log.Tracef("doUpdateContentTree: blob sha %s download state %v less than DOWNLOADED", blob.Sha256, blob.State)
 				if downloadBlob(ctx, status.ObjType, blob) {
 					publishBlobStatus(ctx, blob)
 					changed = true
@@ -156,7 +156,7 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 			}
 			if blob.State == types.DOWNLOADED || blob.State == types.VERIFYING {
 				// downloaded: kick off verifier for this blob
-				log.Infof("doUpdateContentTree: blob sha %s download state %v less than VERIFIED", blob.Sha256, blob.State)
+				log.Functionf("doUpdateContentTree: blob sha %s download state %v less than VERIFIED", blob.Sha256, blob.State)
 				if verifyBlob(ctx, blob) {
 					publishBlobStatus(ctx, blob)
 					changed = true
@@ -164,14 +164,14 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 			}
 			if blob.State < types.VERIFIED {
 				leftToProcess = true
-				log.Debugf("doUpdateContentTree: left to process due to state '%s' for content blob %s",
+				log.Tracef("doUpdateContentTree: left to process due to state '%s' for content blob %s",
 					blob.State, blob.Sha256)
 			} else {
-				log.Debugf("doUpdateContentTree: blob sha %s download state VERIFIED", blob.Sha256)
+				log.Tracef("doUpdateContentTree: blob sha %s download state VERIFIED", blob.Sha256)
 				// if verified, check for any children and start them off
 				blobChildren := blobsNotInList(getBlobChildren(ctx, blob), status.Blobs)
 				if len(blobChildren) > 0 {
-					log.Infof("doUpdateContentTree: adding %d children", len(blobChildren))
+					log.Functionf("doUpdateContentTree: adding %d children", len(blobChildren))
 					// add all of the children
 					for _, blob := range blobChildren {
 						addedBlobs = append(addedBlobs, blob.Sha256)
@@ -211,7 +211,7 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 			if status.TotalSize > 0 {
 				status.Progress = uint(100 * status.CurrentSize / status.TotalSize)
 			}
-			log.Infof("doUpdateContentTree: updating CurrentSize/TotalSize/Progress %d/%d/%d",
+			log.Functionf("doUpdateContentTree: updating CurrentSize/TotalSize/Progress %d/%d/%d",
 				currentSize, totalSize, status.Progress)
 		}
 
@@ -222,7 +222,7 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 			return changed, false
 		}
 		if status.FileLocation != rootBlob.Path {
-			log.Infof("doUpdateContentTree(%s) name %s: updating file location to %s",
+			log.Functionf("doUpdateContentTree(%s) name %s: updating file location to %s",
 				status.Key(), status.DisplayName, rootBlob.Path)
 			status.FileLocation = rootBlob.Path
 			changed = true
@@ -231,17 +231,17 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 		// update errors from blobs to status
 		if len(blobErrors) != 0 {
 			status.SetError(strings.Join(blobErrors, " / "), blobErrorTime)
-			log.Infof("doUpdateContentTree(%s) had errors: %v", status.Key(), status.Error)
+			log.Functionf("doUpdateContentTree(%s) had errors: %v", status.Key(), status.Error)
 			changed = true
 		} else if status.HasError() {
-			log.Infof("doUpdateContentTree(%s) clearing errors", status.Key())
+			log.Functionf("doUpdateContentTree(%s) clearing errors", status.Key())
 			status.ClearErrorWithSource()
 			changed = true
 		}
 
 		// if we added any blobs, we need to reprocess this
 		if len(addedBlobs) > 0 {
-			log.Infof("doUpdateContentTree(%s) rerunning with added blobs: %v", status.Key(), addedBlobs)
+			log.Functionf("doUpdateContentTree(%s) rerunning with added blobs: %v", status.Key(), addedBlobs)
 			return doUpdateContentTree(ctx, status)
 		}
 
@@ -249,7 +249,7 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 		// the rest of this flow should happen only when every part of the content tree
 		// is downloaded and verified
 		if leftToProcess {
-			log.Infof("doUpdateContentTree(%s) leftToProcess=true, so returning `true,false`", status.Key())
+			log.Functionf("doUpdateContentTree(%s) leftToProcess=true, so returning `true,false`", status.Key())
 			return true, false
 		}
 
@@ -258,7 +258,7 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 
 		// if we just had an image pointing to a single blob that is not index or manifest, we need
 		// to add a manifest to it.
-		log.Infof("doUpdateContentTree(%s) checking if we need to add a manifest, have %d blobs", status.Key(), len(blobStatuses))
+		log.Functionf("doUpdateContentTree(%s) checking if we need to add a manifest, have %d blobs", status.Key(), len(blobStatuses))
 		if len(blobStatuses) == 1 && !blobStatuses[0].IsManifest() && !blobStatuses[0].IsIndex() {
 			blobs, err := getManifestsForBareBlob(ctx, refID, blobStatuses[0].Sha256, int64(blobStatuses[0].Size))
 			if err != nil {
@@ -295,14 +295,14 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 
 		// if we made it this far, the entire tree has been verified
 		// we can mark the tree as verified, but still have to load it into the CAS store
-		log.Infof("doUpdateContentTree(%s): all blobs verified %v, setting ContentTree state to VERIFIED", status.Key(), status.Blobs)
+		log.Functionf("doUpdateContentTree(%s): all blobs verified %v, setting ContentTree state to VERIFIED", status.Key(), status.Blobs)
 		status.State = types.VERIFIED
 		publishContentTreeStatus(ctx, status)
 	}
 
 	// at this point, the image is VERIFIED or higher
 	if status.State == types.VERIFIED {
-		log.Infof("doUpdateContentTree(%s): ContentTree state is VERIFIED, starting LOADING", status.Key())
+		log.Functionf("doUpdateContentTree(%s): ContentTree state is VERIFIED, starting LOADING", status.Key())
 
 		// now we start loading
 		// it is a bit silly to publish twice, but it is important that we keep the audit
@@ -317,11 +317,11 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 
 	// if it is LOADING, check each blob until all are loaded
 	if status.State == types.LOADING {
-		log.Infof("doUpdateContentTree(%s): ContentTree status is LOADING", status.Key())
+		log.Functionf("doUpdateContentTree(%s): ContentTree status is LOADING", status.Key())
 		// get the work result - see if it succeeded
 		wres := popCasIngestWorkResult(ctx, status.Key())
 		if wres != nil {
-			log.Infof("doUpdateContentTree(%s): IngestWorkResult found", status.Key())
+			log.Functionf("doUpdateContentTree(%s): IngestWorkResult found", status.Key())
 			if wres.Error != nil {
 				err := fmt.Errorf("doUpdateContentTree(%s): IngestWorkResult error, exception while loading blobs into CAS: %v", status.Key(), wres.Error)
 				log.Errorf(err.Error())
@@ -336,20 +336,20 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 		for _, blob := range blobStatuses {
 			// if the blob was not yet loaded, we ignore it
 			if blob.State != types.LOADED {
-				log.Infof("doUpdateContentTree(%s): blob %s not yet loaded", status.Key(), blob.Sha256)
+				log.Functionf("doUpdateContentTree(%s): blob %s not yet loaded", status.Key(), blob.Sha256)
 				leftToProcess++
 				continue
 			}
 
-			log.Infof("doUpdateContentTree(%s): Successfully loaded blob: %s", status.Key(), blob.Sha256)
+			log.Functionf("doUpdateContentTree(%s): Successfully loaded blob: %s", status.Key(), blob.Sha256)
 			if blob.HasDownloaderRef {
-				log.Infof("doUpdateContentTree(%s): removing downloaderRef from Blob %s",
+				log.Functionf("doUpdateContentTree(%s): removing downloaderRef from Blob %s",
 					status.Key(), blob.Sha256)
 				MaybeRemoveDownloaderConfig(ctx, blob.Sha256)
 				blob.HasDownloaderRef = false
 			}
 			if blob.HasVerifierRef {
-				log.Infof("doUpdateContentTree(%s): removing verifyRef from Blob %s",
+				log.Functionf("doUpdateContentTree(%s): removing verifyRef from Blob %s",
 					status.Key(), blob.Sha256)
 				MaybeRemoveVerifyImageConfig(ctx, blob.Sha256)
 				// Set the path to "" as we delete the verifier path
@@ -359,13 +359,13 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 			publishBlobStatus(ctx, blob)
 		}
 		if leftToProcess > 0 {
-			log.Infof("doUpdateContentTree(%s): Still have %d blobs left to load", status.Key(), leftToProcess)
+			log.Functionf("doUpdateContentTree(%s): Still have %d blobs left to load", status.Key(), leftToProcess)
 			return changed, false
 		}
-		log.Infof("doUpdateContentTree(%s): all blobs LOADED", status.Key())
+		log.Functionf("doUpdateContentTree(%s): all blobs LOADED", status.Key())
 
 		// if we made it here, then all blobs were loaded
-		log.Infof("doUpdateContentTree(%s) successfully loaded all blobs into CAS", status.Key())
+		log.Functionf("doUpdateContentTree(%s) successfully loaded all blobs into CAS", status.Key())
 		status.State = types.LOADED
 		// ContentTreeStatus.FileLocation has no meaning once everything is loaded
 		status.FileLocation = ""
@@ -380,11 +380,11 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 // XXX remove "done" boolean return?
 func doUpdateVol(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool) {
 
-	log.Infof("doUpdateVol(%s) name %s", status.Key(), status.DisplayName)
+	log.Functionf("doUpdateVol(%s) name %s", status.Key(), status.DisplayName)
 
 	// Anything to do?
 	if status.State == types.CREATED_VOLUME {
-		log.Infof("doUpdateVol(%s) name %s nothing to do",
+		log.Functionf("doUpdateVol(%s) name %s nothing to do",
 			status.Key(), status.DisplayName)
 		return false, true
 	}
@@ -407,7 +407,7 @@ func doUpdateVol(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool)
 			return changed, false
 		}
 		if status.IsErrorSource(types.ContentTreeStatus{}) {
-			log.Infof("doUpdate: Clearing volume error %s", status.Error)
+			log.Functionf("doUpdate: Clearing volume error %s", status.Error)
 			status.ClearErrorWithSource()
 			changed = true
 		}
@@ -434,7 +434,7 @@ func doUpdateVol(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool)
 				changed = true
 				return changed, false
 			}
-			log.Infof("doUpdateVol(%s) name %s: waiting for content tree status %v to be LOADED",
+			log.Functionf("doUpdateVol(%s) name %s: waiting for content tree status %v to be LOADED",
 				status.Key(), status.DisplayName, ctStatus.DisplayName)
 			return changed, false
 		}
@@ -456,23 +456,23 @@ func doUpdateVol(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool)
 			AddWorkCreate(ctx, status)
 		}
 		if status.IsErrorSource(types.ContentTreeStatus{}) {
-			log.Infof("doUpdate: Clearing volume error %s", status.Error)
+			log.Functionf("doUpdate: Clearing volume error %s", status.Error)
 			status.ClearErrorWithSource()
 			changed = true
 		}
 		if status.State == types.CREATING_VOLUME && !status.VolumeCreated {
 			vr := popVolumeWorkResult(ctx, status.Key())
 			if vr != nil {
-				log.Infof("doUpdateVol: VolumeWorkResult(%s) location %s, created %t",
+				log.Functionf("doUpdateVol: VolumeWorkResult(%s) location %s, created %t",
 					status.Key(), vr.FileLocation, vr.VolumeCreated)
 				if status.VolumeCreated != vr.VolumeCreated {
-					log.Infof("From vr set VolumeCreated to %s for %s",
+					log.Functionf("From vr set VolumeCreated to %s for %s",
 						vr.FileLocation, status.VolumeID)
 					status.VolumeCreated = vr.VolumeCreated
 					changed = true
 				}
 				if status.FileLocation != vr.FileLocation && vr.Error == nil {
-					log.Infof("doUpdateContentTree: From vr set FileLocation to %s for %s",
+					log.Functionf("doUpdateContentTree: From vr set FileLocation to %s for %s",
 						vr.FileLocation, status.VolumeID)
 					status.FileLocation = vr.FileLocation
 					changed = true
@@ -485,12 +485,12 @@ func doUpdateVol(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool)
 					changed = true
 					return changed, false
 				} else if status.IsErrorSource(types.VolumeStatus{}) {
-					log.Infof("doUpdateContentTree: Clearing volume error %s", status.Error)
+					log.Functionf("doUpdateContentTree: Clearing volume error %s", status.Error)
 					status.ClearErrorWithSource()
 					changed = true
 				}
 			} else {
-				log.Infof("doUpdateVol: VolumeWorkResult(%s) not found", status.Key())
+				log.Functionf("doUpdateVol: VolumeWorkResult(%s) not found", status.Key())
 			}
 		}
 		if status.State == types.CREATING_VOLUME && status.VolumeCreated {
@@ -505,7 +505,7 @@ func doUpdateVol(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool)
 				if err != nil {
 					log.Error(err)
 				} else if maxVolSize != status.MaxVolSize {
-					log.Infof("doUpdateVol: MaxVolSize update from  %d to %d for %s",
+					log.Functionf("doUpdateVol: MaxVolSize update from  %d to %d for %s",
 
 						status.MaxVolSize, maxVolSize,
 						status.FileLocation)
@@ -534,7 +534,7 @@ var ctObjTypes = []string{types.AppImgObj, types.BaseOsObj}
 // that has this Sha256
 func updateStatusByBlob(ctx *volumemgrContext, sha string) {
 
-	log.Infof("updateStatusByBlob(%s)", sha)
+	log.Functionf("updateStatusByBlob(%s)", sha)
 	found := false
 	for _, objType := range ctObjTypes {
 		pub := ctx.publication(types.ContentTreeStatus{}, objType)
@@ -544,7 +544,7 @@ func updateStatusByBlob(ctx *volumemgrContext, sha string) {
 			var hasSha bool
 			for _, blobSha := range status.Blobs {
 				if blobSha == sha {
-					log.Debugf("Found blob %s on ContentTreeStatus %s",
+					log.Tracef("Found blob %s on ContentTreeStatus %s",
 						sha, status.Key())
 					hasSha = true
 				}
@@ -552,12 +552,12 @@ func updateStatusByBlob(ctx *volumemgrContext, sha string) {
 			if hasSha {
 				found = true
 				if changed, _ := doUpdateContentTree(ctx, &status); changed {
-					log.Infof("updateStatusByBlob(%s) publishing ContentTreeStatus",
+					log.Functionf("updateStatusByBlob(%s) publishing ContentTreeStatus",
 						status.Key())
 					publishContentTreeStatus(ctx, &status)
 				}
 				// Volume status referring to this content UUID needs to get updated
-				log.Infof("updateStatusByBlob(%s) updating volume status from content ID %v",
+				log.Functionf("updateStatusByBlob(%s) updating volume status from content ID %v",
 					status.Key(), status.ContentID)
 				updateVolumeStatusFromContentID(ctx,
 					status.ContentID)
@@ -571,7 +571,7 @@ func updateStatusByBlob(ctx *volumemgrContext, sha string) {
 
 // updateStatusByDatastore update any datastore missing status
 func updateStatusByDatastore(ctx *volumemgrContext, datastore types.DatastoreConfig) {
-	log.Infof("updateStatusByDatastore(%s)", datastore.UUID)
+	log.Functionf("updateStatusByDatastore(%s)", datastore.UUID)
 	for _, objType := range ctObjTypes {
 		pub := ctx.publication(types.ContentTreeStatus{}, objType)
 		items := pub.GetAll()
@@ -583,16 +583,16 @@ func updateStatusByDatastore(ctx *volumemgrContext, datastore types.DatastoreCon
 				continue
 			}
 			// set the type
-			log.Infof("Setting datastore type %s for datastore %s on ContentTreeStatus %s",
+			log.Functionf("Setting datastore type %s for datastore %s on ContentTreeStatus %s",
 				datastore.DsType, datastore.UUID, status.Key())
 			status.DatastoreType = datastore.DsType
 			if changed, _ := doUpdateContentTree(ctx, &status); changed {
-				log.Infof("updateStatusByDatastore(%s) publishing ContentTreeStatus",
+				log.Functionf("updateStatusByDatastore(%s) publishing ContentTreeStatus",
 					status.Key())
 				publishContentTreeStatus(ctx, &status)
 			}
 			// Volume status referring to this content UUID needs to get updated
-			log.Infof("updateStatusByDatastore(%s) updating volume status from content ID %v",
+			log.Functionf("updateStatusByDatastore(%s) updating volume status from content ID %v",
 				status.Key(), status.ContentID)
 			updateVolumeStatusFromContentID(ctx,
 				status.ContentID)
@@ -602,7 +602,7 @@ func updateStatusByDatastore(ctx *volumemgrContext, datastore types.DatastoreCon
 
 func updateContentTreeStatus(ctx *volumemgrContext, contentSha256 string, contentID uuid.UUID) {
 
-	log.Infof("updateContentTreeStatus(%s)", contentID)
+	log.Functionf("updateContentTreeStatus(%s)", contentID)
 	found := false
 	for _, objType := range ctObjTypes {
 		pub := ctx.publication(types.ContentTreeStatus{}, objType)
@@ -610,7 +610,7 @@ func updateContentTreeStatus(ctx *volumemgrContext, contentSha256 string, conten
 		for _, st := range items {
 			status := st.(types.ContentTreeStatus)
 			if status.ContentSha256 == contentSha256 {
-				log.Infof("Found ContentTreeStatus %s",
+				log.Functionf("Found ContentTreeStatus %s",
 					status.Key())
 				found = true
 				changed, _ := doUpdateContentTree(ctx, &status)
@@ -618,7 +618,7 @@ func updateContentTreeStatus(ctx *volumemgrContext, contentSha256 string, conten
 					publishContentTreeStatus(ctx, &status)
 				}
 				// Volume status referring to this content UUID needs to get updated
-				log.Infof("updateContentTreeStatus(%s) updating volume status from content ID %v",
+				log.Functionf("updateContentTreeStatus(%s) updating volume status from content ID %v",
 					status.Key(), status.ContentID)
 				updateVolumeStatusFromContentID(ctx,
 					status.ContentID)
@@ -633,14 +633,14 @@ func updateContentTreeStatus(ctx *volumemgrContext, contentSha256 string, conten
 // Find all the VolumeStatus which refer to this volume uuid
 func updateVolumeStatus(ctx *volumemgrContext, volumeID uuid.UUID) {
 
-	log.Infof("updateVolumeStatus for %s", volumeID)
+	log.Functionf("updateVolumeStatus for %s", volumeID)
 	found := false
 	pub := ctx.pubVolumeStatus
 	items := pub.GetAll()
 	for _, st := range items {
 		status := st.(types.VolumeStatus)
 		if status.VolumeID == volumeID {
-			log.Infof("Found VolumeStatus %s: name %s",
+			log.Functionf("Found VolumeStatus %s: name %s",
 				status.Key(), status.DisplayName)
 			found = true
 			changed, _ := doUpdateVol(ctx, &status)
@@ -662,14 +662,14 @@ func updateVolumeStatus(ctx *volumemgrContext, volumeID uuid.UUID) {
 // Find all the VolumeStatus which refer to this content uuid
 func updateVolumeStatusFromContentID(ctx *volumemgrContext, contentID uuid.UUID) {
 
-	log.Debugf("updateVolumeStatusFromContentID for %s", contentID)
+	log.Tracef("updateVolumeStatusFromContentID for %s", contentID)
 	found := false
 	pub := ctx.pubVolumeStatus
 	items := pub.GetAll()
 	for _, st := range items {
 		status := st.(types.VolumeStatus)
 		if status.ContentID == contentID {
-			log.Debugf("Found VolumeStatus %s: name %s",
+			log.Tracef("Found VolumeStatus %s: name %s",
 				status.Key(), status.DisplayName)
 			found = true
 			changed, _ := doUpdateVol(ctx, &status)

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -120,7 +120,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		globalConfig: types.DefaultConfigItemValueMap(),
 	}
 
-	log.Infof("Starting %s", agentName)
+	log.Functionf("Starting %s", agentName)
 
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(25 * time.Second)
@@ -425,7 +425,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	// Pick up debug aka log level before we start real work
 	for !ctx.GCInitialized {
-		log.Infof("waiting for GCInitialized")
+		log.Functionf("waiting for GCInitialized")
 		select {
 		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
@@ -433,12 +433,12 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		}
 		ps.StillRunning(agentName, warningTime, errorTime)
 	}
-	log.Infof("processed GlobalConfig")
+	log.Functionf("processed GlobalConfig")
 
 	if err := utils.WaitForVault(ps, log, agentName, warningTime, errorTime); err != nil {
 		log.Fatal(err)
 	}
-	log.Infof("processed Vault Status")
+	log.Functionf("processed Vault Status")
 
 	// create the directories
 	initializeDirs()
@@ -482,7 +482,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		}
 		ps.StillRunning(agentName, warningTime, errorTime)
 	}
-	log.Infof("Handling all inputs. Updating .touch file")
+	log.Functionf("Handling all inputs. Updating .touch file")
 
 	// We will cleanup zero RefCount volumes which were present at boot
 	// after a while.
@@ -498,7 +498,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	// start the metrics reporting task
 	diskMetricsTickerHandle := make(chan interface{})
-	log.Infof("Creating %s at %s", "diskMetricsTimerTask", agentlog.GetMyStack())
+	log.Functionf("Creating %s at %s", "diskMetricsTimerTask", agentlog.GetMyStack())
 
 	go diskMetricsTimerTask(&ctx, diskMetricsTickerHandle)
 	ctx.diskMetricsTickerHandle = <-diskMetricsTickerHandle
@@ -557,7 +557,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 //gcUnusedInitObjects this method will garbage collect all unused resource during init
 func gcUnusedInitObjects(ctx *volumemgrContext) {
-	log.Infof("gcUnusedInitObjects")
+	log.Functionf("gcUnusedInitObjects")
 	gcBlobStatus(ctx)
 	gcVerifyImageConfig(ctx)
 	gcImagesFromCAS(ctx)
@@ -566,7 +566,7 @@ func gcUnusedInitObjects(ctx *volumemgrContext) {
 func handleVerifierRestarted(ctxArg interface{}, done bool) {
 	ctx := ctxArg.(*volumemgrContext)
 
-	log.Infof("handleVerifierRestarted(%v)", done)
+	log.Functionf("handleVerifierRestarted(%v)", done)
 	if done {
 		ctx.verifierRestarted = true
 	}
@@ -587,10 +587,10 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 
 	ctx := ctxArg.(*volumemgrContext)
 	if key != "global" {
-		log.Infof("handleGlobalConfigImpl: ignoring %s", key)
+		log.Functionf("handleGlobalConfigImpl: ignoring %s", key)
 		return
 	}
-	log.Infof("handleGlobalConfigImpl for %s", key)
+	log.Functionf("handleGlobalConfigImpl for %s", key)
 	var gcp *types.ConfigItemValueMap
 	debug, gcp = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
 		debugOverride, logger)
@@ -599,7 +599,7 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 		ctx.globalConfig = gcp
 		ctx.GCInitialized = true
 	}
-	log.Infof("handleGlobalConfigImpl done for %s", key)
+	log.Functionf("handleGlobalConfigImpl done for %s", key)
 }
 
 func handleGlobalConfigDelete(ctxArg interface{}, key string,
@@ -607,14 +607,14 @@ func handleGlobalConfigDelete(ctxArg interface{}, key string,
 
 	ctx := ctxArg.(*volumemgrContext)
 	if key != "global" {
-		log.Infof("handleGlobalConfigDelete: ignoring %s", key)
+		log.Functionf("handleGlobalConfigDelete: ignoring %s", key)
 		return
 	}
-	log.Infof("handleGlobalConfigDelete for %s", key)
+	log.Functionf("handleGlobalConfigDelete for %s", key)
 	debug, _ = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
 		debugOverride, logger)
 	*ctx.globalConfig = *types.DefaultConfigItemValueMap()
-	log.Infof("handleGlobalConfigDelete done for %s", key)
+	log.Functionf("handleGlobalConfigDelete done for %s", key)
 }
 
 func handleZedAgentStatusCreate(ctxArg interface{}, key string,
@@ -641,13 +641,13 @@ func handleZedAgentStatusImpl(ctxArg interface{}, key string,
 }
 
 func maybeUpdateConfigItems(ctx *volumemgrContext, newConfigItemValueMap *types.ConfigItemValueMap) {
-	log.Infof("maybeUpdateConfigItems")
+	log.Functionf("maybeUpdateConfigItems")
 	oldConfigItemValueMap := ctx.globalConfig
 
 	if newConfigItemValueMap.GlobalValueInt(types.VdiskGCTime) != 0 &&
 		newConfigItemValueMap.GlobalValueInt(types.VdiskGCTime) !=
 			oldConfigItemValueMap.GlobalValueInt(types.VdiskGCTime) {
-		log.Infof("maybeUpdateConfigItems: Updating vdiskGCTime from %d to %d",
+		log.Functionf("maybeUpdateConfigItems: Updating vdiskGCTime from %d to %d",
 			oldConfigItemValueMap.GlobalValueInt(types.VdiskGCTime),
 			newConfigItemValueMap.GlobalValueInt(types.VdiskGCTime))
 		ctx.vdiskGCTime = newConfigItemValueMap.GlobalValueInt(types.VdiskGCTime)
@@ -656,7 +656,7 @@ func maybeUpdateConfigItems(ctx *volumemgrContext, newConfigItemValueMap *types.
 	if newConfigItemValueMap.GlobalValueInt(types.DiskScanMetricInterval) != 0 &&
 		newConfigItemValueMap.GlobalValueInt(types.DiskScanMetricInterval) !=
 			oldConfigItemValueMap.GlobalValueInt(types.DiskScanMetricInterval) {
-		log.Infof("maybeUpdateConfigItems: Updating DiskScanMetricInterval from %d to %d",
+		log.Functionf("maybeUpdateConfigItems: Updating DiskScanMetricInterval from %d to %d",
 			oldConfigItemValueMap.GlobalValueInt(types.DiskScanMetricInterval),
 			newConfigItemValueMap.GlobalValueInt(types.DiskScanMetricInterval))
 		if ctx.diskMetricsTickerHandle == nil {

--- a/pkg/pillar/cmd/waitforaddr/waitforaddr.go
+++ b/pkg/pillar/cmd/waitforaddr/waitforaddr.go
@@ -67,7 +67,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 			log.Fatal(err)
 		}
 	}
-	log.Infof("Starting %s\n", agentName)
+	log.Functionf("Starting %s\n", agentName)
 
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(25 * time.Second)
@@ -99,13 +99,13 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	done := false
 	for DNSctx.usableAddressCount == 0 && !done {
-		log.Infof("Waiting for usable address(es)\n")
+		log.Functionf("Waiting for usable address(es)\n")
 		select {
 		case change := <-subDeviceNetworkStatus.MsgChan():
 			subDeviceNetworkStatus.ProcessChange(change)
 
 		case <-timer.C:
-			log.Infoln("Exit since we got timeout")
+			log.Functionln("Exit since we got timeout")
 			done = true
 
 		case <-stillRunning.C:
@@ -131,38 +131,38 @@ func handleDNSImpl(ctxArg interface{}, key string,
 	status := statusArg.(types.DeviceNetworkStatus)
 	ctx := ctxArg.(*DNSContext)
 	if key != "global" {
-		log.Infof("handleDNSImpl: ignoring %s\n", key)
+		log.Functionf("handleDNSImpl: ignoring %s\n", key)
 		return
 	}
-	log.Infof("handleDNSImpl for %s\n", key)
+	log.Functionf("handleDNSImpl for %s\n", key)
 	// Ignore test status and timestamps
 	if ctx.deviceNetworkStatus.MostlyEqual(status) {
-		log.Infof("handleDNSImpl no change\n")
+		log.Functionf("handleDNSImpl no change\n")
 		ctx.DNSinitialized = true
 		return
 	}
-	log.Infof("handleDNSImpl: changed %v",
+	log.Functionf("handleDNSImpl: changed %v",
 		cmp.Diff(ctx.deviceNetworkStatus, status))
 	ctx.deviceNetworkStatus = status
 	newAddrCount := types.CountLocalAddrAnyNoLinkLocal(ctx.deviceNetworkStatus)
 	ctx.DNSinitialized = true
 	ctx.usableAddressCount = newAddrCount
-	log.Infof("handleDNSImpl done for %s\n", key)
+	log.Functionf("handleDNSImpl done for %s\n", key)
 }
 
 func handleDNSDelete(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
-	log.Infof("handleDNSDelete for %s\n", key)
+	log.Functionf("handleDNSDelete for %s\n", key)
 	ctx := ctxArg.(*DNSContext)
 
 	if key != "global" {
-		log.Infof("handleDNSDelete: ignoring %s\n", key)
+		log.Functionf("handleDNSDelete: ignoring %s\n", key)
 		return
 	}
 	ctx.deviceNetworkStatus = types.DeviceNetworkStatus{}
 	newAddrCount := types.CountLocalAddrAnyNoLinkLocal(ctx.deviceNetworkStatus)
 	ctx.DNSinitialized = false
 	ctx.usableAddressCount = newAddrCount
-	log.Infof("handleDNSDelete done for %s\n", key)
+	log.Functionf("handleDNSDelete done for %s\n", key)
 }

--- a/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
+++ b/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
@@ -78,7 +78,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		log.Fatal(err)
 	}
 
-	log.Infof("Starting %s\n", agentName)
+	log.Functionf("Starting %s\n", agentName)
 
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(25 * time.Second)
@@ -166,12 +166,12 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		if err != nil {
 			log.Fatal(err)
 		}
-		log.Infof("Read devUUID %s\n", wscCtx.devUUID.String())
+		log.Functionf("Read devUUID %s\n", wscCtx.devUUID.String())
 	}
 
 	// Pick up debug aka log level before we start real work
 	for !wscCtx.GCInitialized {
-		log.Infof("waiting for GCInitialized")
+		log.Functionf("waiting for GCInitialized")
 		select {
 		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
@@ -179,12 +179,12 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		}
 		ps.StillRunning(agentName, warningTime, errorTime)
 	}
-	log.Infof("processed GlobalConfig")
+	log.Functionf("processed GlobalConfig")
 
 	wscCtx.dnsContext = &DNSctx
 	// Wait for knowledge about IP addresses. XXX needed?
 	for !DNSctx.DNSinitialized {
-		log.Infof("Waiting for DeviceNetworkStatus\n")
+		log.Functionf("Waiting for DeviceNetworkStatus\n")
 		select {
 		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
@@ -226,17 +226,17 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 
 	ctx := ctxArg.(*wstunnelclientContext)
 	if key != "global" {
-		log.Infof("handleGlobalConfigImpl: ignoring %s\n", key)
+		log.Functionf("handleGlobalConfigImpl: ignoring %s\n", key)
 		return
 	}
-	log.Infof("handleGlobalConfigImpl for %s\n", key)
+	log.Functionf("handleGlobalConfigImpl for %s\n", key)
 	var gcp *types.ConfigItemValueMap
 	debug, gcp = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
 		debugOverride, logger)
 	if gcp != nil {
 		ctx.GCInitialized = true
 	}
-	log.Infof("handleGlobalConfigImpl done for %s\n", key)
+	log.Functionf("handleGlobalConfigImpl done for %s\n", key)
 }
 
 func handleGlobalConfigDelete(ctxArg interface{}, key string,
@@ -244,13 +244,13 @@ func handleGlobalConfigDelete(ctxArg interface{}, key string,
 
 	ctx := ctxArg.(*wstunnelclientContext)
 	if key != "global" {
-		log.Infof("handleGlobalConfigDelete: ignoring %s\n", key)
+		log.Functionf("handleGlobalConfigDelete: ignoring %s\n", key)
 		return
 	}
-	log.Infof("handleGlobalConfigDelete for %s\n", key)
+	log.Functionf("handleGlobalConfigDelete for %s\n", key)
 	debug, _ = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
 		debugOverride, logger)
-	log.Infof("handleGlobalConfigDelete done for %s\n", key)
+	log.Functionf("handleGlobalConfigDelete done for %s\n", key)
 }
 
 func handleDNSCreate(ctxArg interface{}, key string,
@@ -269,44 +269,44 @@ func handleDNSImpl(ctxArg interface{}, key string,
 	status := statusArg.(types.DeviceNetworkStatus)
 	ctx := ctxArg.(*DNSContext)
 	if key != "global" {
-		log.Infof("handleDNSImpl: ignoring %s\n", key)
+		log.Functionf("handleDNSImpl: ignoring %s\n", key)
 		return
 	}
-	log.Infof("handleDNSImpl for %s\n", key)
+	log.Functionf("handleDNSImpl for %s\n", key)
 	// Ignore test status and timestamps
 	if ctx.deviceNetworkStatus.MostlyEqual(status) {
-		log.Infof("handleDNSImpl no change\n")
+		log.Functionf("handleDNSImpl no change\n")
 		ctx.DNSinitialized = true
 		return
 	}
-	log.Infof("handleDNSImpl: changed %v",
+	log.Functionf("handleDNSImpl: changed %v",
 		cmp.Diff(*ctx.deviceNetworkStatus, status))
 	*ctx.deviceNetworkStatus = status
 	newAddrCount := types.CountLocalAddrAnyNoLinkLocal(*ctx.deviceNetworkStatus)
 	if newAddrCount != 0 && ctx.usableAddressCount == 0 {
-		log.Infof("DeviceNetworkStatus from %d to %d addresses\n",
+		log.Functionf("DeviceNetworkStatus from %d to %d addresses\n",
 			ctx.usableAddressCount, newAddrCount)
 		// XXX do we need to trigger something like a reconnect?
 	}
 	ctx.DNSinitialized = true
 	ctx.usableAddressCount = newAddrCount
-	log.Infof("handleDNSImpl done for %s\n", key)
+	log.Functionf("handleDNSImpl done for %s\n", key)
 }
 
 func handleDNSDelete(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
-	log.Infof("handleDNSDelete for %s\n", key)
+	log.Functionf("handleDNSDelete for %s\n", key)
 	ctx := ctxArg.(*DNSContext)
 	if key != "global" {
-		log.Infof("handleDNSDelete: ignoring %s\n", key)
+		log.Functionf("handleDNSDelete: ignoring %s\n", key)
 		return
 	}
 	*ctx.deviceNetworkStatus = types.DeviceNetworkStatus{}
 	newAddrCount := types.CountLocalAddrAnyNoLinkLocal(*ctx.deviceNetworkStatus)
 	ctx.DNSinitialized = false
 	ctx.usableAddressCount = newAddrCount
-	log.Infof("handleDNSDelete done for %s\n", key)
+	log.Functionf("handleDNSDelete done for %s\n", key)
 }
 
 func handleAppInstanceConfigCreate(ctxArg interface{}, key string,
@@ -322,21 +322,21 @@ func handleAppInstanceConfigModify(ctxArg interface{}, key string,
 func handleAppInstanceConfigImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
-	log.Infof("handleAppInstanceConfigImpl for %s\n", key)
+	log.Functionf("handleAppInstanceConfigImpl for %s\n", key)
 	// XXX config := configArg.(types.AppInstanceConfig)
 	ctx := ctxArg.(*wstunnelclientContext)
 	scanAIConfigs(ctx)
-	log.Infof("handleAppInstanceConfigImpl done for %s\n", key)
+	log.Functionf("handleAppInstanceConfigImpl done for %s\n", key)
 }
 
 func handleAppInstanceConfigDelete(ctxArg interface{}, key string,
 	configArg interface{}) {
 
-	log.Infof("handleAppInstanceConfigDelete for %s\n", key)
+	log.Functionf("handleAppInstanceConfigDelete for %s\n", key)
 	// XXX config := configArg).(types.AppInstanceConfig)
 	ctx := ctxArg.(*wstunnelclientContext)
 	scanAIConfigs(ctx)
-	log.Infof("handleAppInstanceConfigDelete done for %s\n", key)
+	log.Functionf("handleAppInstanceConfigDelete done for %s\n", key)
 }
 
 // walk over all instances to determine new value
@@ -347,11 +347,11 @@ func scanAIConfigs(ctx *wstunnelclientContext) {
 	items := sub.GetAll()
 	for _, c := range items {
 		config := c.(types.AppInstanceConfig)
-		log.Debugf("Remote console status for app-instance: %s: %t\n",
+		log.Tracef("Remote console status for app-instance: %s: %t\n",
 			config.DisplayName, config.RemoteConsole)
 		isTunnelRequired = config.RemoteConsole || isTunnelRequired
 	}
-	log.Infof("Tunnel check status after checking app-instance configs: %t\n",
+	log.Functionf("Tunnel check status after checking app-instance configs: %t\n",
 		isTunnelRequired)
 
 	if !isTunnelRequired {
@@ -368,7 +368,7 @@ func scanAIConfigs(ctx *wstunnelclientContext) {
 	for _, port := range deviceNetworkStatus.Ports {
 		ifname := port.IfName
 		if !types.IsMgmtPort(*deviceNetworkStatus, ifname) {
-			log.Debugf("Skipping connection using non-mangement intf %s\n",
+			log.Tracef("Skipping connection using non-mangement intf %s\n",
 				ifname)
 			continue
 		}
@@ -376,13 +376,13 @@ func scanAIConfigs(ctx *wstunnelclientContext) {
 		destURL := wstunnelclient.Tunnel
 
 		addrCount := types.CountLocalAddrAnyNoLinkLocalIf(*deviceNetworkStatus, ifname)
-		log.Infof("Connecting to %s using intf %s #sources %d\n",
+		log.Functionf("Connecting to %s using intf %s #sources %d\n",
 			destURL, ifname, addrCount)
 
 		if addrCount == 0 {
 			errStr := fmt.Sprintf("No IP addresses to connect to %s using intf %s",
 				destURL, ifname)
-			log.Infoln(errStr)
+			log.Functionln(errStr)
 			continue
 		}
 
@@ -391,14 +391,14 @@ func scanAIConfigs(ctx *wstunnelclientContext) {
 			localAddr, err := types.GetLocalAddrAnyNoLinkLocal(*deviceNetworkStatus,
 				retryCount, ifname)
 			if err != nil {
-				log.Info(err)
+				log.Function(err)
 				continue
 			}
 
 			proxyURL, _ := zedcloud.LookupProxy(log, deviceNetworkStatus,
 				ifname, destURL)
 			if err := wstunnelclient.TestConnection(deviceNetworkStatus, proxyURL, localAddr, ctx.devUUID); err != nil {
-				log.Info(err)
+				log.Function(err)
 				continue
 			}
 			connected = true
@@ -409,6 +409,6 @@ func scanAIConfigs(ctx *wstunnelclientContext) {
 			ctx.wstunnelclient = wstunnelclient
 			break
 		}
-		log.Infof("Could not connect to %s using intf %s\n", destURL, ifname)
+		log.Functionf("Could not connect to %s using intf %s\n", destURL, ifname)
 	}
 }

--- a/pkg/pillar/cmd/zedagent/attesttask.go
+++ b/pkg/pillar/cmd/zedagent/attesttask.go
@@ -105,7 +105,7 @@ func (server *VerifierImpl) SendNonceRequest(ctx *zattest.Context) error {
 
 	//Increment Iteration for interface rotation
 	attestCtx.Iteration++
-	log.Debugf("Sending Nonce request %v", attestReq)
+	log.Tracef("Sending Nonce request %v", attestReq)
 
 	_, contents, senderStatus, err := trySendToController(attestReq, attestCtx.Iteration)
 	if err != nil || senderStatus != types.SenderStatusNone {
@@ -183,7 +183,7 @@ func encodeVersions(quoteMsg *attest.ZAttestQuote) error {
 		uefiVersion.VersionType = attest.AttestVersionType_ATTEST_VERSION_TYPE_FIRMWARE
 		uefiVersion.Version = biosStr
 		quoteMsg.Versions = append(quoteMsg.Versions, uefiVersion)
-		log.Infof("quoteMsg.Versions %s %s", eveVersion.Version, uefiVersion.Version)
+		log.Functionf("quoteMsg.Versions %s %s", eveVersion.Version, uefiVersion.Version)
 	}
 	return nil
 }
@@ -255,7 +255,7 @@ func (server *VerifierImpl) SendAttestQuote(ctx *zattest.Context) error {
 
 	//Increment Iteration for interface rotation
 	attestCtx.Iteration++
-	log.Debugf("Sending Quote request")
+	log.Tracef("Sending Quote request")
 
 	_, contents, senderStatus, err := trySendToController(attestReq, attestCtx.Iteration)
 	if err != nil || senderStatus != types.SenderStatusNone {
@@ -297,7 +297,7 @@ func (server *VerifierImpl) SendAttestQuote(ctx *zattest.Context) error {
 				encryptedKey := sk.GetKey()
 				if encryptedKeyType == attest.AttestVolumeKeyType_ATTEST_VOLUME_KEY_TYPE_VSK {
 					publishEncryptedKeyFromController(attestCtx, encryptedKey)
-					log.Infof("[ATTEST] published Controller-given encrypted key")
+					log.Functionf("[ATTEST] published Controller-given encrypted key")
 				}
 			}
 		}
@@ -350,7 +350,7 @@ func (server *VerifierImpl) SendAttestEscrow(ctx *zattest.Context) error {
 
 	//Increment Iteration for interface rotation
 	attestCtx.Iteration++
-	log.Debugf("Sending Escrow data")
+	log.Tracef("Sending Escrow data")
 
 	_, contents, senderStatus, err := trySendToController(attestReq, attestCtx.Iteration)
 	if err != nil || senderStatus != types.SenderStatusNone {
@@ -406,7 +406,7 @@ func (agent *TpmAgentImpl) SendInternalQuoteRequest(ctx *zattest.Context) error 
 
 	//Clear existing quote before requesting a new one
 	if attestCtx.InternalQuote != nil {
-		log.Infof("[ATTEST] Clearing current quote, before requesting a new one")
+		log.Functionf("[ATTEST] Clearing current quote, before requesting a new one")
 		attestCtx.InternalQuote = nil
 	}
 	publishAttestNonce(attestCtx)
@@ -415,7 +415,7 @@ func (agent *TpmAgentImpl) SendInternalQuoteRequest(ctx *zattest.Context) error 
 
 //PunchWatchdog implements PunchWatchdog method of zattest.Watchdog
 func (wd *WatchdogImpl) PunchWatchdog(ctx *zattest.Context) error {
-	log.Debug("[ATTEST] Punching watchdog")
+	log.Trace("[ATTEST] Punching watchdog")
 	ctx.PubSub.StillRunning(attestWdName, warningTime, errorTime)
 	return nil
 }
@@ -492,14 +492,14 @@ func attestModuleInitialize(ctx *zedagentContext, ps *pubsub.PubSub) error {
 
 // start the task threads
 func attestModuleStart(ctx *zedagentContext) error {
-	log.Info("[ATTEST] Starting attestation task")
+	log.Function("[ATTEST] Starting attestation task")
 	if ctx.attestCtx == nil {
 		return fmt.Errorf("No attest module context")
 	}
 	if ctx.attestCtx.attestFsmCtx == nil {
 		return fmt.Errorf("No state machine context found")
 	}
-	log.Infof("Creating %s at %s", "attestFsmCtx.EnterEventLoop",
+	log.Functionf("Creating %s at %s", "attestFsmCtx.EnterEventLoop",
 		agentlog.GetMyStack())
 	go ctx.attestCtx.attestFsmCtx.EnterEventLoop()
 	zattest.Kickstart(ctx.attestCtx.attestFsmCtx)
@@ -550,7 +550,7 @@ func handleAttestQuoteImpl(ctxArg interface{}, key string,
 	//Trigger event on the state machine
 	zattest.InternalQuoteRecvd(attestCtx.attestFsmCtx)
 
-	log.Infof("handleAttestQuoteImpl done for %s", quote.Key())
+	log.Functionf("handleAttestQuoteImpl done for %s", quote.Key())
 	return
 }
 
@@ -586,7 +586,7 @@ func handleAttestQuoteDelete(ctxArg interface{}, key string, quoteArg interface{
 	} else {
 		log.Warnf("[ATTEST] Nonce didn't match, ignoring incoming delete")
 	}
-	log.Infof("handleAttestQuoteDelete done for %s", quote.Key())
+	log.Functionf("handleAttestQuoteDelete done for %s", quote.Key())
 	return
 }
 
@@ -643,10 +643,10 @@ func publishAttestNonce(ctx *attestContext) {
 		Requester: agentName,
 	}
 	key := nonce.Key()
-	log.Debugf("[ATTEST] publishAttestNonce %s", key)
+	log.Tracef("[ATTEST] publishAttestNonce %s", key)
 	pub := ctx.pubAttestNonce
 	pub.Publish(key, nonce)
-	log.Debugf("[ATTEST] publishAttestNonce done for %s", key)
+	log.Tracef("[ATTEST] publishAttestNonce done for %s", key)
 }
 
 func publishEncryptedKeyFromController(ctx *attestContext, encryptedVaultKey []byte) {
@@ -655,10 +655,10 @@ func publishEncryptedKeyFromController(ctx *attestContext, encryptedVaultKey []b
 		EncryptedVaultKey: encryptedVaultKey,
 	}
 	key := sK.Key()
-	log.Debugf("[ATTEST] publishEncryptedKeyFromController %s", key)
+	log.Tracef("[ATTEST] publishEncryptedKeyFromController %s", key)
 	pub := ctx.pubEncryptedKeyFromController
 	pub.Publish(key, sK)
-	log.Debugf("[ATTEST] publishEncryptedKeyFromController done for %s", key)
+	log.Tracef("[ATTEST] publishEncryptedKeyFromController done for %s", key)
 }
 
 func unpublishAttestNonce(ctx *attestContext) {
@@ -682,7 +682,7 @@ func unpublishAttestNonce(ctx *attestContext) {
 		}
 		log.Fatal("[ATTEST] Stale nonce items found after unpublishing")
 	}
-	log.Debugf("[ATTEST] unpublishAttestNonce done for %s", key)
+	log.Tracef("[ATTEST] unpublishAttestNonce done for %s", key)
 }
 
 //helper to set IntegrityToken

--- a/pkg/pillar/cmd/zedagent/handlebaseos.go
+++ b/pkg/pillar/cmd/zedagent/handlebaseos.go
@@ -49,7 +49,7 @@ func getZbootCurrentPartition(ctx *zedagentContext) string {
 	for _, st := range items {
 		status := st.(types.ZbootStatus)
 		if status.CurrentPartition {
-			log.Debugf("getZbootCurrentPartition:%s", status.PartitionLabel)
+			log.Tracef("getZbootCurrentPartition:%s", status.PartitionLabel)
 			return status.PartitionLabel
 		}
 	}
@@ -63,7 +63,7 @@ func getZbootOtherPartition(ctx *zedagentContext) string {
 	for _, st := range items {
 		status := st.(types.ZbootStatus)
 		if !status.CurrentPartition {
-			log.Debugf("getZbootOtherPartition:%s", status.PartitionLabel)
+			log.Tracef("getZbootOtherPartition:%s", status.PartitionLabel)
 			return status.PartitionLabel
 		}
 	}

--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -40,7 +40,7 @@ var controllerCertHash []byte
 
 // parse and update controller certs
 func parseControllerCerts(ctx *zedagentContext, contents []byte) {
-	log.Infof("Started parsing controller certs")
+	log.Functionf("Started parsing controller certs")
 	cfgConfig := &zcert.ZControllerCert{}
 	err := proto.Unmarshal(contents, cfgConfig)
 	if err != nil {
@@ -57,7 +57,7 @@ func parseControllerCerts(ctx *zedagentContext, contents []byte) {
 	if bytes.Equal(newHash, controllerCertHash) {
 		return
 	}
-	log.Infof("parseControllerCerts: Applying updated config "+
+	log.Functionf("parseControllerCerts: Applying updated config "+
 		"Last Sha: % x, "+
 		"New  Sha: % x, "+
 		"Num of cfgCert: %d",
@@ -79,7 +79,7 @@ func parseControllerCerts(ctx *zedagentContext, contents []byte) {
 			}
 		}
 		if !found {
-			log.Infof("parseControllerCerts: deleting %s", config.Key())
+			log.Functionf("parseControllerCerts: deleting %s", config.Key())
 			unpublishControllerCert(ctx.getconfigCtx, config.Key())
 		}
 	}
@@ -88,7 +88,7 @@ func parseControllerCerts(ctx *zedagentContext, contents []byte) {
 		certKey := hex.EncodeToString(cfgConfig.GetCertHash())
 		cert := lookupControllerCert(ctx.getconfigCtx, certKey)
 		if cert == nil {
-			log.Infof("parseControllerCerts: not found %s", certKey)
+			log.Functionf("parseControllerCerts: not found %s", certKey)
 			cert = &types.ControllerCert{
 				HashAlgo: cfgConfig.GetHashAlgo(),
 				Type:     cfgConfig.GetType(),
@@ -98,13 +98,13 @@ func parseControllerCerts(ctx *zedagentContext, contents []byte) {
 			publishControllerCert(ctx.getconfigCtx, *cert)
 		}
 	}
-	log.Infof("parsing controller certs done")
+	log.Functionf("parsing controller certs done")
 }
 
 // look up controller cert
 func lookupControllerCert(ctx *getconfigContext,
 	key string) *types.ControllerCert {
-	log.Infof("lookupControllerCert(%s)", key)
+	log.Functionf("lookupControllerCert(%s)", key)
 	pub := ctx.pubControllerCert
 	item, err := pub.Get(key)
 	if err != nil {
@@ -112,7 +112,7 @@ func lookupControllerCert(ctx *getconfigContext,
 		return nil
 	}
 	status := item.(types.ControllerCert)
-	log.Infof("lookupControllerCert(%s) Done", key)
+	log.Functionf("lookupControllerCert(%s) Done", key)
 	return &status
 }
 
@@ -121,21 +121,21 @@ func lookupControllerCert(ctx *getconfigContext,
 func publishControllerCert(ctx *getconfigContext,
 	config types.ControllerCert) {
 	key := config.Key()
-	log.Debugf("publishControllerCert %s", key)
+	log.Tracef("publishControllerCert %s", key)
 	pub := ctx.pubControllerCert
 	pub.Publish(key, config)
-	log.Debugf("publishControllerCert %s Done", key)
+	log.Tracef("publishControllerCert %s Done", key)
 }
 
 func unpublishControllerCert(ctx *getconfigContext, key string) {
-	log.Debugf("unpublishControllerCert %s", key)
+	log.Tracef("unpublishControllerCert %s", key)
 	pub := ctx.pubControllerCert
 	c, _ := pub.Get(key)
 	if c == nil {
 		log.Errorf("unpublishControllerCert(%s) not found", key)
 		return
 	}
-	log.Debugf("unpublishControllerCert %s Done", key)
+	log.Tracef("unpublishControllerCert %s Done", key)
 	pub.Unpublish(key)
 }
 
@@ -154,7 +154,7 @@ func handleEdgeNodeCertImpl(ctxArg interface{}, key string,
 
 	ctx := ctxArg.(*zedagentContext)
 	status := configArg.(types.EdgeNodeCert)
-	log.Infof("handleEdgeNodeCertImpl for %s", status.Key())
+	log.Functionf("handleEdgeNodeCertImpl for %s", status.Key())
 	triggerEdgeNodeCertEvent(ctx)
 }
 
@@ -163,14 +163,14 @@ func handleEdgeNodeCertDelete(ctxArg interface{}, key string,
 
 	ctx := ctxArg.(*zedagentContext)
 	status := configArg.(types.EdgeNodeCert)
-	log.Infof("handleEdgeNodeCertDelete for %s", status.Key())
+	log.Functionf("handleEdgeNodeCertDelete for %s", status.Key())
 	triggerEdgeNodeCertEvent(ctx)
 }
 
 // Run a task certificate post task, on change trigger
 func controllerCertsTask(ctx *zedagentContext, triggerCerts <-chan struct{}) {
 
-	log.Infoln("starting controller certificate fetch task")
+	log.Functionln("starting controller certificate fetch task")
 	getCertsFromController(ctx)
 
 	wdName := agentName + "ccerts"
@@ -209,13 +209,13 @@ func getCertsFromController(ctx *zedagentContext) bool {
 	if err != nil {
 		switch rtf {
 		case types.SenderStatusUpgrade:
-			log.Infof("getCertsFromController: Controller upgrade in progress")
+			log.Functionf("getCertsFromController: Controller upgrade in progress")
 		case types.SenderStatusRefused:
-			log.Infof("getCertsFromController: Controller returned ECONNREFUSED")
+			log.Functionf("getCertsFromController: Controller returned ECONNREFUSED")
 		case types.SenderStatusCertInvalid:
 			log.Warnf("getCertsFromController: Controller certificate invalid time")
 		case types.SenderStatusCertMiss:
-			log.Infof("getCertsFromController: Controller certificate miss")
+			log.Functionf("getCertsFromController: Controller certificate miss")
 		default:
 			log.Errorf("getCertsFromController failed: %s", err)
 		}
@@ -224,7 +224,7 @@ func getCertsFromController(ctx *zedagentContext) bool {
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		log.Infof("getCertsFromController: status %s", resp.Status)
+		log.Functionf("getCertsFromController: status %s", resp.Status)
 	default:
 		log.Errorf("getCertsFromController: failed, statuscode %d %s",
 			resp.StatusCode, http.StatusText(resp.StatusCode))
@@ -253,13 +253,13 @@ func getCertsFromController(ctx *zedagentContext) bool {
 	// manage the certificates through pubsub
 	parseControllerCerts(ctx, contents)
 
-	log.Infof("getCertsFromController: success")
+	log.Functionf("getCertsFromController: success")
 	return true
 }
 
 // edge node certificate post task, on change trigger
 func edgeNodeCertsTask(ctx *zedagentContext, triggerEdgeNodeCerts chan struct{}) {
-	log.Infoln("starting edge node certificates publish task")
+	log.Functionln("starting edge node certificates publish task")
 
 	publishEdgeNodeCertsToController(ctx)
 
@@ -322,9 +322,9 @@ func publishEdgeNodeCertsToController(ctx *zedagentContext) {
 		attestReq.Certs = append(attestReq.Certs, &certMsg)
 	}
 
-	log.Debugf("publishEdgeNodeCertsToController, sending %s", attestReq)
+	log.Tracef("publishEdgeNodeCertsToController, sending %s", attestReq)
 	sendAttestReqProtobuf(attestReq, ctx.cipherCtx.iteration)
-	log.Debugf("publishEdgeNodeCertsToController: after send, total elapse sec %v",
+	log.Tracef("publishEdgeNodeCertsToController: after send, total elapse sec %v",
 		time.Since(startPubTime).Seconds())
 	ctx.cipherCtx.iteration++
 }
@@ -352,13 +352,13 @@ func sendAttestReqProtobuf(attestReq *attest.ZAttestReq, iteration int) {
 		// Hopefully next timeout will be more successful
 		switch rtf {
 		case types.SenderStatusUpgrade:
-			log.Infof("sendAttestReqProtobuf: Controller upgrade in progress")
+			log.Functionf("sendAttestReqProtobuf: Controller upgrade in progress")
 		case types.SenderStatusRefused:
-			log.Infof("sendAttestReqProtobuf: Controller returned ECONNREFUSED")
+			log.Functionf("sendAttestReqProtobuf: Controller returned ECONNREFUSED")
 		case types.SenderStatusCertInvalid:
 			log.Warnf("sendAttestReqProtobuf: Controller certificate invalid time")
 		case types.SenderStatusCertMiss:
-			log.Infof("sendAttestReqProtobuf: Controller certificate miss")
+			log.Functionf("sendAttestReqProtobuf: Controller certificate miss")
 		default:
 			log.Errorf("sendAttestReqProtobuf failed: %s", err)
 		}
@@ -378,15 +378,15 @@ func cipherModuleInitialize(ctx *zedagentContext, ps *pubsub.PubSub) {
 // start the task threads
 func cipherModuleStart(ctx *zedagentContext) {
 	if !zedcloud.UseV2API() {
-		log.Infof("V2 APIs are still not enabled")
+		log.Functionf("V2 APIs are still not enabled")
 		// we will run the tasks for watchdog
 	}
 	// start the edge node certificate push task
-	log.Infof("Creating %s at %s", "edgeNodeCertsTask", agentlog.GetMyStack())
+	log.Functionf("Creating %s at %s", "edgeNodeCertsTask", agentlog.GetMyStack())
 	go edgeNodeCertsTask(ctx, ctx.cipherCtx.triggerEdgeNodeCerts)
 
 	// start the controller certificate fetch task
-	log.Infof("Creating %s at %s", "controllerCertsTask", agentlog.GetMyStack())
+	log.Functionf("Creating %s at %s", "controllerCertsTask", agentlog.GetMyStack())
 	go controllerCertsTask(ctx, ctx.cipherCtx.triggerControllerCerts)
 }
 
@@ -397,7 +397,7 @@ func handleControllerCertsSha(ctx *zedagentContext,
 
 	certHash := config.GetControllercertConfighash()
 	if certHash != ctx.cipherCtx.cfgControllerCertHash {
-		log.Infof("handleControllerCertsSha trigger due to controller %v vs current %v",
+		log.Functionf("handleControllerCertsSha trigger due to controller %v vs current %v",
 			certHash, ctx.cipherCtx.cfgControllerCertHash)
 		ctx.cipherCtx.cfgControllerCertHash = certHash
 		triggerControllerCertEvent(ctx)
@@ -407,7 +407,7 @@ func handleControllerCertsSha(ctx *zedagentContext,
 //  controller certificate pull trigger function
 func triggerControllerCertEvent(ctxPtr *zedagentContext) {
 
-	log.Info("Trigger for Controller Certs")
+	log.Function("Trigger for Controller Certs")
 	select {
 	case ctxPtr.cipherCtx.triggerControllerCerts <- struct{}{}:
 		// Do nothing more
@@ -419,7 +419,7 @@ func triggerControllerCertEvent(ctxPtr *zedagentContext) {
 //  edge node certificate post trigger function
 func triggerEdgeNodeCertEvent(ctxPtr *zedagentContext) {
 
-	log.Info("Trigger Edge Node Certs publish")
+	log.Function("Trigger Edge Node Certs publish")
 	select {
 	case ctxPtr.cipherCtx.triggerEdgeNodeCerts <- struct{}{}:
 		// Do nothing more

--- a/pkg/pillar/cmd/zedagent/handlecipherconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecipherconfig.go
@@ -20,7 +20,7 @@ var cipherCtxHash []byte
 func parseCipherContext(ctx *getconfigContext,
 	config *zconfig.EdgeDevConfig) {
 
-	log.Infof("Started parsing cipher context")
+	log.Functionf("Started parsing cipher context")
 	cfgCipherContextList := config.GetCipherContexts()
 	h := sha256.New()
 	for _, cfgCipherContext := range cfgCipherContextList {
@@ -30,7 +30,7 @@ func parseCipherContext(ctx *getconfigContext,
 	if bytes.Equal(newHash, cipherCtxHash) {
 		return
 	}
-	log.Infof("parseCipherContext: Applying updated config "+
+	log.Functionf("parseCipherContext: Applying updated config "+
 		"Last Sha: % x, "+
 		"New  Sha: % x, "+
 		"Num of cfgCipherContext: %d",
@@ -50,14 +50,14 @@ func parseCipherContext(ctx *getconfigContext,
 		}
 		// cipherContext not found, delete
 		if !found {
-			log.Infof("parseCipherContext: deleting %s", idStr)
+			log.Functionf("parseCipherContext: deleting %s", idStr)
 			unpublishCipherContext(ctx, idStr)
 		}
 	}
 
 	for _, cfgCipherContext := range cfgCipherContextList {
 		if cfgCipherContext.GetContextId() == "" {
-			log.Debugf("parseCipherContext ignoring empty")
+			log.Tracef("parseCipherContext ignoring empty")
 			continue
 		}
 		context := types.CipherContext{
@@ -70,7 +70,7 @@ func parseCipherContext(ctx *getconfigContext,
 		}
 		publishCipherContext(ctx, context)
 	}
-	log.Infof("parsing cipher context done")
+	log.Functionf("parsing cipher context done")
 }
 
 // parseCipherBlock : will collate all the relevant information
@@ -78,9 +78,9 @@ func parseCipherContext(ctx *getconfigContext,
 func parseCipherBlock(ctx *getconfigContext, key string,
 	cfgCipherBlock *zconfig.CipherBlock) types.CipherBlockStatus {
 
-	log.Infof("parseCipherBlock(%s) started", key)
+	log.Functionf("parseCipherBlock(%s) started", key)
 	if cfgCipherBlock == nil {
-		log.Infof("parseCipherBlock(%s) nil cipher block", key)
+		log.Functionf("parseCipherBlock(%s) nil cipher block", key)
 		return types.CipherBlockStatus{CipherBlockID: key}
 	}
 	cipherBlock := types.CipherBlockStatus{
@@ -99,24 +99,24 @@ func parseCipherBlock(ctx *getconfigContext, key string,
 		cipherBlock.SetErrorNow(errStr)
 		return cipherBlock
 	}
-	log.Infof("%s, marking cipher as true", key)
+	log.Functionf("%s, marking cipher as true", key)
 	cipherBlock.IsCipher = true
 
-	log.Infof("parseCipherBlock(%s) done", key)
+	log.Functionf("parseCipherBlock(%s) done", key)
 	return cipherBlock
 }
 
 func publishCipherContext(ctx *getconfigContext,
 	status types.CipherContext) {
 	key := status.Key()
-	log.Debugf("publishCipherContext(%s)", key)
+	log.Tracef("publishCipherContext(%s)", key)
 	pub := ctx.pubCipherContext
 	pub.Publish(key, status)
-	log.Debugf("publishCipherContext(%s) done", key)
+	log.Tracef("publishCipherContext(%s) done", key)
 }
 
 func unpublishCipherContext(ctx *getconfigContext, key string) {
-	log.Debugf("unpublishCipherContext(%s)", key)
+	log.Tracef("unpublishCipherContext(%s)", key)
 	pub := ctx.pubCipherContext
 	c, _ := pub.Get(key)
 	if c == nil {
@@ -124,5 +124,5 @@ func unpublishCipherContext(ctx *getconfigContext, key string) {
 		return
 	}
 	pub.Unpublish(key)
-	log.Debugf("unpublishCipherContext(%s) done", key)
+	log.Tracef("unpublishCipherContext(%s) done", key)
 }

--- a/pkg/pillar/cmd/zedagent/handlecontent.go
+++ b/pkg/pillar/cmd/zedagent/handlecontent.go
@@ -21,7 +21,7 @@ var contentInfoHash []byte
 func parseContentInfoConfig(ctx *getconfigContext,
 	config *zconfig.EdgeDevConfig) {
 
-	log.Debugf("Started parsing content info config")
+	log.Tracef("Started parsing content info config")
 	cfgContentTreeList := config.GetContentInfo()
 	h := sha256.New()
 	for _, cfgContentTree := range cfgContentTreeList {
@@ -31,7 +31,7 @@ func parseContentInfoConfig(ctx *getconfigContext,
 	if bytes.Equal(newHash, contentInfoHash) {
 		return
 	}
-	log.Infof("parseContentInfo: Applying updated config "+
+	log.Functionf("parseContentInfo: Applying updated config "+
 		"Last Sha: % x, "+
 		"New  Sha: % x, "+
 		"Num of cfgContentInfo: %d",
@@ -51,7 +51,7 @@ func parseContentInfoConfig(ctx *getconfigContext,
 		}
 		// content tree not found, delete
 		if !found {
-			log.Infof("parseContentInfo: deleting %s\n", idStr)
+			log.Functionf("parseContentInfo: deleting %s\n", idStr)
 			unpublishContentTreeConfig(ctx, idStr)
 		}
 	}
@@ -68,20 +68,20 @@ func parseContentInfoConfig(ctx *getconfigContext,
 		publishContentTreeConfig(ctx, *contentConfig)
 	}
 	ctx.pubContentTreeConfig.SignalRestarted()
-	log.Infof("parsing content info config done\n")
+	log.Functionf("parsing content info config done\n")
 }
 
 func publishContentTreeConfig(ctx *getconfigContext,
 	config types.ContentTreeConfig) {
 	key := config.Key()
-	log.Debugf("publishContentTreeConfig(%s)\n", key)
+	log.Tracef("publishContentTreeConfig(%s)\n", key)
 	pub := ctx.pubContentTreeConfig
 	pub.Publish(key, config)
-	log.Debugf("publishContentTreeConfig(%s) done\n", key)
+	log.Tracef("publishContentTreeConfig(%s) done\n", key)
 }
 
 func unpublishContentTreeConfig(ctx *getconfigContext, key string) {
-	log.Debugf("unpublishContentTreeConfig(%s)\n", key)
+	log.Tracef("unpublishContentTreeConfig(%s)\n", key)
 	pub := ctx.pubContentTreeConfig
 	config, _ := pub.Get(key)
 	if config == nil {
@@ -89,7 +89,7 @@ func unpublishContentTreeConfig(ctx *getconfigContext, key string) {
 		return
 	}
 	pub.Unpublish(key)
-	log.Debugf("unpublishContentTreeConfig(%s) done\n", key)
+	log.Tracef("unpublishContentTreeConfig(%s) done\n", key)
 }
 
 // content tree event watch to capture transitions

--- a/pkg/pillar/cmd/zedagent/handlelookupparam.go
+++ b/pkg/pillar/cmd/zedagent/handlelookupparam.go
@@ -23,14 +23,14 @@ func publishAppNetworkConfig(getconfigCtx *getconfigContext,
 	config types.AppNetworkConfig) {
 
 	key := config.Key()
-	log.Debugf("publishAppNetworkConfig %s", key)
+	log.Tracef("publishAppNetworkConfig %s", key)
 	pub := getconfigCtx.pubAppNetworkConfig
 	pub.Publish(key, config)
 }
 
 func unpublishAppNetworkConfig(getconfigCtx *getconfigContext, key string) {
 
-	log.Debugf("unpublishAppNetworkConfig %s", key)
+	log.Tracef("unpublishAppNetworkConfig %s", key)
 	pub := getconfigCtx.pubAppNetworkConfig
 	c, _ := pub.Get(key)
 	if c == nil {

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -47,7 +47,7 @@ func handleDiskMetricImpl(ctxArg interface{}, key string,
 	ctx := ctxArg.(*zedagentContext)
 	ctx.iteration++
 	path := status.DiskPath
-	log.Infof("handleDiskMetricImpl: %s", path)
+	log.Functionf("handleDiskMetricImpl: %s", path)
 }
 
 func handleDiskMetricDelete(ctxArg interface{}, key string, statusArg interface{}) {
@@ -55,7 +55,7 @@ func handleDiskMetricDelete(ctxArg interface{}, key string, statusArg interface{
 	ctx := ctxArg.(*zedagentContext)
 	ctx.iteration++
 	path := status.DiskPath
-	log.Infof("handleDiskMetricModify: %s", path)
+	log.Functionf("handleDiskMetricModify: %s", path)
 }
 
 func lookupDiskMetric(ctx *zedagentContext, diskPath string) *types.DiskMetric {
@@ -71,14 +71,14 @@ func lookupDiskMetric(ctx *zedagentContext, diskPath string) *types.DiskMetric {
 
 func getAllDiskMetrics(ctx *zedagentContext) []*types.DiskMetric {
 	var retList []*types.DiskMetric
-	log.Debugf("getAllDiskMetrics")
+	log.Tracef("getAllDiskMetrics")
 	sub := ctx.subDiskMetric
 	items := sub.GetAll()
 	for _, st := range items {
 		status := st.(types.DiskMetric)
 		retList = append(retList, &status)
 	}
-	log.Debugf("getAllDiskMetrics: Done")
+	log.Tracef("getAllDiskMetrics: Done")
 	return retList
 }
 
@@ -136,7 +136,7 @@ func encodeTestResults(tr types.TestResults) *info.ErrorInfo {
 // Run a periodic post of the metrics
 func metricsTimerTask(ctx *zedagentContext, handleChannel chan interface{}) {
 	iteration := 0
-	log.Infoln("starting report metrics timer task")
+	log.Functionln("starting report metrics timer task")
 	publishMetrics(ctx, iteration)
 
 	interval := time.Duration(ctx.globalConfig.GlobalValueInt(types.MetricInterval)) * time.Second
@@ -177,7 +177,7 @@ func updateMetricsTimer(metricInterval uint32, tickerHandle interface{}) {
 		return
 	}
 	interval := time.Duration(metricInterval) * time.Second
-	log.Infof("updateMetricsTimer() change to %v", interval)
+	log.Functionf("updateMetricsTimer() change to %v", interval)
 	max := float64(interval)
 	min := max * 0.3
 	flextimer.UpdateRangeTicker(tickerHandle,
@@ -192,7 +192,7 @@ func lookupDomainMetric(ctx *zedagentContext, uuidStr string) *types.DomainMetri
 	sub := ctx.getconfigCtx.subDomainMetric
 	m, _ := sub.Get(uuidStr)
 	if m == nil {
-		log.Infof("lookupDomainMetric(%s) not found", uuidStr)
+		log.Functionf("lookupDomainMetric(%s) not found", uuidStr)
 		return nil
 	}
 	metric := m.(types.DomainMetric)
@@ -229,9 +229,9 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 	if err != nil {
 		log.Fatalf("host.Info(): %s", err)
 	}
-	log.Debugf("uptime %d = %d days",
+	log.Tracef("uptime %d = %d days",
 		info.Uptime, info.Uptime/(3600*24))
-	log.Debugf("Booted at %v", time.Unix(int64(info.BootTime), 0).UTC())
+	log.Tracef("Booted at %v", time.Unix(int64(info.BootTime), 0).UTC())
 
 	// Note that uptime is seconds we've been up. We're converting
 	// to a timestamp. That better not be interpreted as a time since
@@ -259,7 +259,7 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 	}
 	ReportDeviceMetric.Memory.UsedPercentage = usedPercent
 	ReportDeviceMetric.Memory.AvailPercentage = 100.0 - (usedPercent)
-	log.Debugf("Device Memory from xl info: %v %v %v %v",
+	log.Tracef("Device Memory from xl info: %v %v %v %v",
 		ReportDeviceMetric.Memory.UsedMem,
 		ReportDeviceMetric.Memory.AvailMem,
 		ReportDeviceMetric.Memory.UsedPercentage,
@@ -336,7 +336,7 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 		}
 		ReportDeviceMetric.Log = deviceLogMetric
 	}
-	log.Debugln("log metrics: ", ReportDeviceMetric.Log)
+	log.Traceln("log metrics: ", ReportDeviceMetric.Log)
 
 	// Collect zedcloud metrics from ourselves and other agents
 	cms := types.MetricsMap{} // Start empty
@@ -368,7 +368,7 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 			metric.LastSuccess = ls
 		}
 		for url, um := range cm.URLCounters {
-			log.Debugf("CloudMetrics[%s] url %s %v",
+			log.Tracef("CloudMetrics[%s] url %s %v",
 				ifname, url, um)
 			urlMet := new(metrics.UrlcloudMetric)
 			urlMet.Url = url
@@ -398,7 +398,7 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 		cipherMetrics = cipher.Append(cipherMetrics, cipherMetricsNim)
 	}
 	for agentName, cm := range cipherMetrics {
-		log.Debugf("Cipher metrics for %s: %+v", agentName, cm)
+		log.Tracef("Cipher metrics for %s: %+v", agentName, cm)
 		metric := metrics.CipherMetric{AgentName: agentName,
 			FailureCount: cm.FailureCount,
 			SuccessCount: cm.SuccessCount,
@@ -446,7 +446,7 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 			persistUsage = diskMetric.UsedBytes
 		}
 	}
-	log.Debugf("DirPaths in persist, elapse sec %v", time.Since(startPubTime).Seconds())
+	log.Tracef("DirPaths in persist, elapse sec %v", time.Since(startPubTime).Seconds())
 
 	// Determine how much we use in /persist and how much of it is
 	// for the benefits of applications
@@ -457,13 +457,13 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 			persistAppUsage += diskMetric.UsedBytes
 		}
 	}
-	log.Debugf("persistAppUsage %d, elapse sec %v", persistAppUsage, time.Since(startPubTime).Seconds())
+	log.Tracef("persistAppUsage %d, elapse sec %v", persistAppUsage, time.Since(startPubTime).Seconds())
 
 	persistOverhead := persistUsage - persistAppUsage
 	// Convert to MB
 	runtimeStorageOverhead := types.RoundupToKB(types.RoundupToKB(persistOverhead))
 	appRunTimeStorage := types.RoundupToKB(types.RoundupToKB(persistAppUsage))
-	log.Debugf("runtimeStorageOverhead %d MB, appRunTimeStorage %d MB",
+	log.Tracef("runtimeStorageOverhead %d MB, appRunTimeStorage %d MB",
 		runtimeStorageOverhead, appRunTimeStorage)
 	ReportDeviceMetric.RuntimeStorageOverheadMB = runtimeStorageOverhead
 	ReportDeviceMetric.AppRunTimeStorageMB = appRunTimeStorage
@@ -482,7 +482,7 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 	// Get device info using nil UUID
 	dm := lookupDomainMetric(ctx, nilUUID.String())
 	if dm != nil {
-		log.Debugf("host CPU: %d, percent used %d",
+		log.Tracef("host CPU: %d, percent used %d",
 			dm.CPUTotal, (100*dm.CPUTotal)/uint64(info.Uptime))
 		ReportDeviceMetric.CpuMetric.Total = *proto.Uint64(dm.CPUTotal)
 
@@ -491,7 +491,7 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 		ReportDeviceMetric.SystemServicesMemoryMB.AvailMem = dm.AvailableMemory
 		ReportDeviceMetric.SystemServicesMemoryMB.UsedPercentage = dm.UsedMemoryPercent
 		ReportDeviceMetric.SystemServicesMemoryMB.AvailPercentage = 100.0 - (dm.UsedMemoryPercent)
-		log.Debugf("host Memory: %v %v %v %v",
+		log.Tracef("host Memory: %v %v %v %v",
 			ReportDeviceMetric.SystemServicesMemoryMB.UsedMem,
 			ReportDeviceMetric.SystemServicesMemoryMB.AvailMem,
 			ReportDeviceMetric.SystemServicesMemoryMB.UsedPercentage,
@@ -523,7 +523,7 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 
 		dm := lookupDomainMetric(ctx, aiStatus.Key())
 		if dm != nil {
-			log.Debugf("metrics for %s CPU %d, usedMem %v, availMem %v, availMemPercent %v",
+			log.Tracef("metrics for %s CPU %d, usedMem %v, availMem %v, availMemPercent %v",
 				aiStatus.DomainName, dm.CPUTotal, dm.UsedMemory,
 				dm.AvailableMemory, dm.UsedMemoryPercent)
 			ReportAppMetric.Cpu.Total = *proto.Uint64(dm.CPUTotal)
@@ -535,7 +535,7 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 		}
 
 		appInterfaceList := aiStatus.GetAppInterfaceList()
-		log.Debugf("ReportMetrics: domainName %s ifs %v",
+		log.Tracef("ReportMetrics: domainName %s ifs %v",
 			aiStatus.DomainName, appInterfaceList)
 		// Use the network metrics from zedrouter subscription
 		for _, ifName := range appInterfaceList {
@@ -551,7 +551,7 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 			}
 			networkDetails := new(metrics.NetworkMetric)
 			name := appIfnameToName(&aiStatus, metric.IfName)
-			log.Debugf("app %s/%s localname %s name %s",
+			log.Tracef("app %s/%s localname %s name %s",
 				aiStatus.Key(), aiStatus.DisplayName,
 				metric.IfName, name)
 			networkDetails.IName = name
@@ -595,7 +595,7 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 		for _, vrs := range aiStatus.VolumeRefStatusList {
 			appDiskDetails := new(metrics.AppDiskMetric)
 			if vrs.ActiveFileLocation == "" {
-				log.Infof("ActiveFileLocation is empty for %s", vrs.Key())
+				log.Functionf("ActiveFileLocation is empty for %s", vrs.Key())
 			} else {
 				err := getDiskInfo(ctx, vrs, appDiskDetails)
 				if err != nil {
@@ -652,9 +652,9 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 	createVolumeInstanceMetrics(ctx, ReportMetrics)
 	createProcessMetrics(ctx, ReportMetrics)
 
-	log.Debugf("PublishMetricsToZedCloud sending %s", ReportMetrics)
+	log.Tracef("PublishMetricsToZedCloud sending %s", ReportMetrics)
 	SendMetricsProtobuf(ReportMetrics, iteration)
-	log.Debugf("publishMetrics: after send, total elapse sec %v", time.Since(startPubTime).Seconds())
+	log.Tracef("publishMetrics: after send, total elapse sec %v", time.Since(startPubTime).Seconds())
 }
 
 func getDiskInfo(ctx *zedagentContext, vrs types.VolumeRefStatus, appDiskDetails *metrics.AppDiskMetric) error {
@@ -713,7 +713,7 @@ func getSecurityInfo(ctx *zedagentContext) *info.SecurityInfo {
 			si.ShaTlsRootCa = sha
 		}
 	}
-	log.Debugf("getSecurityInfo returns %+v", si)
+	log.Tracef("getSecurityInfo returns %+v", si)
 	return si
 }
 
@@ -772,7 +772,7 @@ func encodeProxyStatus(proxyConfig *types.ProxyConfig) *info.ProxyStatus {
 	status.NetworkProxyURL = proxyConfig.NetworkProxyURL
 	status.WpadURL = proxyConfig.WpadURL
 	// XXX add? status.ProxyCertPEM = proxyConfig.ProxyCertPEM
-	log.Debugf("encodeProxyStatus: %+v", status)
+	log.Tracef("encodeProxyStatus: %+v", status)
 	return status
 }
 
@@ -830,7 +830,7 @@ func encodeNetworkPortConfig(ctx *zedagentContext,
 func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 	aiStatus *types.AppInstanceStatus,
 	aa *types.AssignableAdapters, iteration int) {
-	log.Infof("PublishAppInfoToZedCloud uuid %s", uuid)
+	log.Functionf("PublishAppInfoToZedCloud uuid %s", uuid)
 	var ReportInfo = &info.ZInfoMsg{}
 
 	appType := new(info.ZInfoTypes)
@@ -857,7 +857,7 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 
 		if aiStatus.BootTime.IsZero() {
 			// If never booted
-			log.Infoln("BootTime is empty")
+			log.Functionln("BootTime is empty")
 		} else {
 			bootTime, _ := ptypes.TimestampProto(aiStatus.BootTime)
 			ReportAppInfo.BootTime = bootTime
@@ -880,7 +880,7 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 					reportAA.IoAddressList = append(reportAA.IoAddressList,
 						reportMac)
 				}
-				log.Debugf("AssignableAdapters for %s macs %v",
+				log.Tracef("AssignableAdapters for %s macs %v",
 					reportAA.Name, reportAA.IoAddressList)
 			}
 			ReportAppInfo.AssignedAdapters = append(ReportAppInfo.AssignedAdapters,
@@ -890,7 +890,7 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 		// Mostly reporting the UP status
 		// We extract the appIP from the dnsmasq assignment
 		ifNames := (*aiStatus).GetAppInterfaceList()
-		log.Debugf("ReportAppInfo: domainName %s ifs %v",
+		log.Tracef("ReportAppInfo: domainName %s ifs %v",
 			aiStatus.DomainName, ifNames)
 		for _, ifname := range ifNames {
 			networkInfo := new(info.ZInfoNetwork)
@@ -903,7 +903,7 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 			networkInfo.Up = allocated
 			networkInfo.IpAddrMisMatch = ipAddrMismatch
 			name := appIfnameToName(aiStatus, ifname)
-			log.Debugf("app %s/%s localName %s devName %s",
+			log.Tracef("app %s/%s localName %s devName %s",
 				aiStatus.Key(), aiStatus.DisplayName,
 				ifname, name)
 			networkInfo.DevName = *proto.String(name)
@@ -922,7 +922,7 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 		x.Ainfo = ReportAppInfo
 	}
 
-	log.Infof("PublishAppInfoToZedCloud sending %v", ReportInfo)
+	log.Functionf("PublishAppInfoToZedCloud sending %v", ReportInfo)
 
 	data, err := proto.Marshal(ReportInfo)
 	if err != nil {
@@ -958,7 +958,7 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 func PublishContentInfoToZedCloud(ctx *zedagentContext, uuid string,
 	ctStatus *types.ContentTreeStatus, iteration int) {
 
-	log.Infof("PublishContentInfoToZedCloud uuid %s", uuid)
+	log.Functionf("PublishContentInfoToZedCloud uuid %s", uuid)
 	var ReportInfo = &info.ZInfoMsg{}
 
 	contentType := new(info.ZInfoTypes)
@@ -995,7 +995,7 @@ func PublishContentInfoToZedCloud(ctx *zedagentContext, uuid string,
 		x.Cinfo = ReportContentInfo
 	}
 
-	log.Infof("PublishContentInfoToZedCloud sending %v", ReportInfo)
+	log.Functionf("PublishContentInfoToZedCloud sending %v", ReportInfo)
 
 	data, err := proto.Marshal(ReportInfo)
 	if err != nil {
@@ -1029,7 +1029,7 @@ func PublishContentInfoToZedCloud(ctx *zedagentContext, uuid string,
 func PublishVolumeToZedCloud(ctx *zedagentContext, uuid string,
 	volStatus *types.VolumeStatus, iteration int) {
 
-	log.Infof("PublishVolumeToZedCloud uuid %s", uuid)
+	log.Functionf("PublishVolumeToZedCloud uuid %s", uuid)
 	var ReportInfo = &info.ZInfoMsg{}
 
 	volumeType := new(info.ZInfoTypes)
@@ -1053,7 +1053,7 @@ func PublishVolumeToZedCloud(ctx *zedagentContext, uuid string,
 		}
 
 		if volStatus.FileLocation == "" {
-			log.Infof("FileLocation is empty for %s", volStatus.Key())
+			log.Functionf("FileLocation is empty for %s", volStatus.Key())
 		} else {
 			VolumeResourcesInfo := new(info.VolumeResources)
 			err := getVolumeResourcesInfo(ctx, volStatus, VolumeResourcesInfo)
@@ -1074,7 +1074,7 @@ func PublishVolumeToZedCloud(ctx *zedagentContext, uuid string,
 		x.Vinfo = ReportVolumeInfo
 	}
 
-	log.Infof("PublishVolumeToZedCloud sending %v", ReportInfo)
+	log.Functionf("PublishVolumeToZedCloud sending %v", ReportInfo)
 
 	data, err := proto.Marshal(ReportInfo)
 	if err != nil {
@@ -1106,7 +1106,7 @@ func PublishVolumeToZedCloud(ctx *zedagentContext, uuid string,
 // When blob Status is nil it means a delete and we send a message
 // containing only the UUID to inform zedcloud about the delete.
 func PublishBlobInfoToZedCloud(ctx *zedagentContext, blobSha string, blobStatus *types.BlobStatus, iteration int) {
-	log.Infof("PublishBlobInfoToZedCloud blobSha %v", blobSha)
+	log.Functionf("PublishBlobInfoToZedCloud blobSha %v", blobSha)
 	var ReportInfo = &info.ZInfoMsg{}
 
 	contentType := new(info.ZInfoTypes)
@@ -1132,7 +1132,7 @@ func PublishBlobInfoToZedCloud(ctx *zedagentContext, blobSha string, blobStatus 
 		blobInfoList.Binfo = ReportBlobInfoList
 	}
 
-	log.Infof("PublishBlobInfoToZedCloud sending %v", ReportInfo)
+	log.Functionf("PublishBlobInfoToZedCloud sending %v", ReportInfo)
 
 	data, err := proto.Marshal(ReportInfo)
 	if err != nil {
@@ -1190,7 +1190,7 @@ func SendProtobuf(url string, buf *bytes.Buffer, size int64,
 		case http.StatusNotFound, http.StatusGone:
 			// Assume the resource is gone in the controller
 
-			log.Infof("SendProtoBuf: %s silently ignore code %d %s",
+			log.Functionf("SendProtoBuf: %s silently ignore code %d %s",
 				url, resp.StatusCode, http.StatusText(resp.StatusCode))
 			return nil
 		}
@@ -1228,12 +1228,12 @@ func SendMetricsProtobuf(ReportMetrics *metrics.ZMetricMsg,
 func getAppIP(ctx *zedagentContext, aiStatus *types.AppInstanceStatus,
 	vifname string) (string, bool, string, bool) {
 
-	log.Debugf("getAppIP(%s, %s)", aiStatus.Key(), vifname)
+	log.Tracef("getAppIP(%s, %s)", aiStatus.Key(), vifname)
 	for _, ulStatus := range aiStatus.UnderlayNetworks {
 		if ulStatus.VifUsed != vifname {
 			continue
 		}
-		log.Debugf("getAppIP(%s, %s) found underlay %s assigned %v mac %s",
+		log.Tracef("getAppIP(%s, %s) found underlay %s assigned %v mac %s",
 			aiStatus.Key(), vifname, ulStatus.AllocatedIPAddr, ulStatus.Assigned, ulStatus.Mac)
 		return ulStatus.AllocatedIPAddr, ulStatus.Assigned, ulStatus.Mac, ulStatus.IPAddrMisMatch
 	}
@@ -1241,7 +1241,7 @@ func getAppIP(ctx *zedagentContext, aiStatus *types.AppInstanceStatus,
 }
 
 func createVolumeInstanceMetrics(ctx *zedagentContext, reportMetrics *metrics.ZMetricMsg) {
-	log.Debugf("Volume instance metrics started")
+	log.Tracef("Volume instance metrics started")
 	sub := ctx.getconfigCtx.subVolumeStatus
 	volumelist := sub.GetAll()
 	if volumelist == nil || len(volumelist) == 0 {
@@ -1253,13 +1253,13 @@ func createVolumeInstanceMetrics(ctx *zedagentContext, reportMetrics *metrics.ZM
 		volumeMetric.Uuid = volumeStatus.VolumeID.String()
 		volumeMetric.DisplayName = volumeStatus.DisplayName
 		if volumeStatus.FileLocation == "" {
-			log.Infof("FileLocation is empty for %s", volumeStatus.Key())
+			log.Functionf("FileLocation is empty for %s", volumeStatus.Key())
 		} else {
 			getVolumeResourcesMetrics(ctx, volumeStatus.FileLocation, volumeMetric)
 		}
 		reportMetrics.Vm = append(reportMetrics.Vm, volumeMetric)
 	}
-	log.Debugf("Volume instance metrics done: %v", reportMetrics.Vm)
+	log.Tracef("Volume instance metrics done: %v", reportMetrics.Vm)
 }
 
 func getVolumeResourcesMetrics(ctx *zedagentContext, name string, volumeMetric *metrics.ZMetricVolume) error {
@@ -1276,7 +1276,7 @@ func getVolumeResourcesMetrics(ctx *zedagentContext, name string, volumeMetric *
 }
 
 func createProcessMetrics(ctx *zedagentContext, reportMetrics *metrics.ZMetricMsg) {
-	log.Debugf("Process metrics started")
+	log.Tracef("Process metrics started")
 	sub := ctx.getconfigCtx.subProcessMetric
 	items := sub.GetAll()
 	for _, item := range items {
@@ -1300,7 +1300,7 @@ func createProcessMetrics(ctx *zedagentContext, reportMetrics *metrics.ZMetricMs
 		processMetric.MemoryPercent = p.MemoryPercent
 		reportMetrics.Pr = append(reportMetrics.Pr, processMetric)
 	}
-	log.Debugf("Process metrics done: %v", reportMetrics.Pr)
+	log.Tracef("Process metrics done: %v", reportMetrics.Pr)
 }
 
 func createNetworkInstanceMetrics(ctx *zedagentContext, reportMetrics *zmet.ZMetricMsg) {
@@ -1315,7 +1315,7 @@ func createNetworkInstanceMetrics(ctx *zedagentContext, reportMetrics *zmet.ZMet
 		metricInstance := protoEncodeNetworkInstanceMetricProto(metrics)
 		reportMetrics.Nm = append(reportMetrics.Nm, metricInstance)
 	}
-	log.Debugln("network instance metrics: ", reportMetrics.Nm)
+	log.Traceln("network instance metrics: ", reportMetrics.Nm)
 }
 
 func protoEncodeNetworkInstanceMetricProto(status types.NetworkInstanceMetrics) *zmet.ZMetricNetworkInstance {

--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -38,7 +38,7 @@ func handleNetworkInstanceModify(ctxArg interface{}, key string,
 func handleNetworkInstanceImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
-	log.Infof("handleNetworkInstanceStatusImpl(%s)", key)
+	log.Functionf("handleNetworkInstanceStatusImpl(%s)", key)
 	ctx := ctxArg.(*zedagentContext)
 	status := statusArg.(types.NetworkInstanceStatus)
 	if !status.ErrorTime.IsZero() {
@@ -46,17 +46,17 @@ func handleNetworkInstanceImpl(ctxArg interface{}, key string,
 			status.Error)
 	}
 	prepareAndPublishNetworkInstanceInfoMsg(ctx, status, false)
-	log.Infof("handleNetworkInstanceImpl(%s) done", key)
+	log.Functionf("handleNetworkInstanceImpl(%s) done", key)
 }
 
 func handleNetworkInstanceDelete(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
-	log.Infof("handleNetworkInstanceDelete(%s)", key)
+	log.Functionf("handleNetworkInstanceDelete(%s)", key)
 	status := statusArg.(types.NetworkInstanceStatus)
 	ctx := ctxArg.(*zedagentContext)
 	prepareAndPublishNetworkInstanceInfoMsg(ctx, status, true)
-	log.Infof("handleNetworkInstanceDelete(%s) done", key)
+	log.Functionf("handleNetworkInstanceDelete(%s) done", key)
 }
 
 func prepareAndPublishNetworkInstanceInfoMsg(ctx *zedagentContext,
@@ -139,7 +139,7 @@ func prepareAndPublishNetworkInstanceInfoMsg(ctx *zedagentContext,
 					reportAA.IoAddressList = append(reportAA.IoAddressList,
 						reportMac)
 				}
-				log.Debugf("AssignableAdapters for %s macs %v",
+				log.Tracef("AssignableAdapters for %s macs %v",
 					reportAA.Name, reportAA.IoAddressList)
 			}
 			info.AssignedAdapters = append(info.AssignedAdapters,
@@ -156,7 +156,7 @@ func prepareAndPublishNetworkInstanceInfoMsg(ctx *zedagentContext,
 	if x, ok := infoMsg.GetInfoContent().(*zinfo.ZInfoMsg_Niinfo); ok {
 		x.Niinfo = info
 	}
-	log.Debugf("Publish NetworkInstance Info message to zedcloud: %v",
+	log.Tracef("Publish NetworkInstance Info message to zedcloud: %v",
 		infoMsg)
 	publishInfo(ctx, uuid, infoMsg)
 }
@@ -402,7 +402,7 @@ func publishInfo(ctx *zedagentContext, UUID string, infoMsg *zinfo.ZInfoMsg) {
 
 func publishInfoToZedCloud(UUID string, infoMsg *zinfo.ZInfoMsg, iteration int) {
 
-	log.Infof("publishInfoToZedCloud sending %v", infoMsg)
+	log.Functionf("publishInfoToZedCloud sending %v", infoMsg)
 	data, err := proto.Marshal(infoMsg)
 	if err != nil {
 		log.Fatal("publishInfoToZedCloud proto marshaling error: ", err)
@@ -443,7 +443,7 @@ func handleAppFlowMonitorModify(ctxArg interface{}, key string,
 func handleAppFlowMonitorImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
-	log.Infof("handleAppFlowMonitorImpl(%s)", key)
+	log.Functionf("handleAppFlowMonitorImpl(%s)", key)
 	flows := statusArg.(types.IPFlow)
 
 	// encoding the flows with protobuf format
@@ -456,7 +456,7 @@ func handleAppFlowMonitorImpl(ctxArg interface{}, key string,
 func handleAppFlowMonitorDelete(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
-	log.Infof("handleAppFlowMonitorDelete(%s)", key)
+	log.Functionf("handleAppFlowMonitorDelete(%s)", key)
 }
 
 func handleAppVifIPTrigCreate(ctxArg interface{}, key string,
@@ -472,7 +472,7 @@ func handleAppVifIPTrigModify(ctxArg interface{}, key string,
 func handleAppVifIPTrigImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
-	log.Infof("handleAppVifIPTrigImpl(%s)", key)
+	log.Functionf("handleAppVifIPTrigImpl(%s)", key)
 	ctx := ctxArg.(*zedagentContext)
 	trig := statusArg.(types.VifIPTrig)
 	findVifAndTrigAppInfoUpload(ctx, trig.MacAddr, trig.IPAddr)
@@ -484,11 +484,11 @@ func findVifAndTrigAppInfoUpload(ctx *zedagentContext, macAddr string, ipAddr ne
 
 	for _, st := range items {
 		aiStatus := st.(types.AppInstanceStatus)
-		log.Debugf("findVifAndTrigAppInfoUpload: mac address %s match, ip %v, publish the info to cloud", macAddr, ipAddr)
+		log.Tracef("findVifAndTrigAppInfoUpload: mac address %s match, ip %v, publish the info to cloud", macAddr, ipAddr)
 		uuidStr := aiStatus.Key()
 		aiStatusPtr := &aiStatus
 		if aiStatusPtr.MaybeUpdateAppIPAddr(macAddr, ipAddr.String()) {
-			log.Infof("findVifAndTrigAppInfoUpload: underlay %v", aiStatusPtr.UnderlayNetworks)
+			log.Functionf("findVifAndTrigAppInfoUpload: underlay %v", aiStatusPtr.UnderlayNetworks)
 			PublishAppInfoToZedCloud(ctx, uuidStr, aiStatusPtr, ctx.assignableAdapters, ctx.iteration)
 			ctx.iteration++
 			break
@@ -597,7 +597,7 @@ func sendFlowProtobuf(protoflows *flowlog.FlowMessage) {
 			return
 		}
 
-		log.Debugf("Send Flow protobuf out on all intfs, message size %d, flowQ size %d",
+		log.Tracef("Send Flow protobuf out on all intfs, message size %d, flowQ size %d",
 			size, flowQ.Len())
 		writeSentFlowProtoMessage(data)
 
@@ -628,6 +628,6 @@ func handleAppContainerMetricsImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
 	acMetrics := statusArg.(types.AppContainerMetrics)
-	log.Debugf("handleAppContainerMetricsImpl(%s), num containers %d",
+	log.Tracef("handleAppContainerMetricsImpl(%s), num containers %d",
 		key, len(acMetrics.StatsList))
 }

--- a/pkg/pillar/cmd/zedagent/handlevolume.go
+++ b/pkg/pillar/cmd/zedagent/handlevolume.go
@@ -26,7 +26,7 @@ func volumeKey(volumeID string, generationCounter int64) string {
 func parseVolumeConfig(ctx *getconfigContext,
 	config *zconfig.EdgeDevConfig) {
 
-	log.Debugf("Started parsing volume config")
+	log.Tracef("Started parsing volume config")
 	cfgVolumeList := config.GetVolumes()
 	h := sha256.New()
 	for _, cfgVolume := range cfgVolumeList {
@@ -36,7 +36,7 @@ func parseVolumeConfig(ctx *getconfigContext,
 	if bytes.Equal(newHash, volumeHash) {
 		return
 	}
-	log.Infof("parseVolumeConfig: Applying updated config "+
+	log.Functionf("parseVolumeConfig: Applying updated config "+
 		"Last Sha: % x, "+
 		"New  Sha: % x, "+
 		"Num of cfgContentInfo: %d",
@@ -57,7 +57,7 @@ func parseVolumeConfig(ctx *getconfigContext,
 		}
 		// content tree not found, delete
 		if !found {
-			log.Infof("parseVolumeConfig: deleting %s\n", idStr)
+			log.Functionf("parseVolumeConfig: deleting %s\n", idStr)
 			unpublishVolumeConfig(ctx, idStr)
 		}
 	}
@@ -82,23 +82,23 @@ func parseVolumeConfig(ctx *getconfigContext,
 		volumeConfig.RefCount = 1
 		publishVolumeConfig(ctx, *volumeConfig)
 	}
-	log.Debugf("parsing volume config done\n")
+	log.Tracef("parsing volume config done\n")
 }
 
 func publishVolumeConfig(ctx *getconfigContext,
 	config types.VolumeConfig) {
 
 	key := config.Key()
-	log.Debugf("publishVolumeConfig(%s)\n", key)
+	log.Tracef("publishVolumeConfig(%s)\n", key)
 	pub := ctx.pubVolumeConfig
 	pub.Publish(key, config)
-	log.Debugf("publishVolumeConfig(%s) done\n", key)
+	log.Tracef("publishVolumeConfig(%s) done\n", key)
 }
 
 func unpublishVolumeConfig(ctx *getconfigContext,
 	key string) {
 
-	log.Debugf("unpublishVolumeConfig(%s)\n", key)
+	log.Tracef("unpublishVolumeConfig(%s)\n", key)
 	pub := ctx.pubVolumeConfig
 	config, _ := pub.Get(key)
 	if config == nil {
@@ -106,7 +106,7 @@ func unpublishVolumeConfig(ctx *getconfigContext,
 		return
 	}
 	pub.Unpublish(key)
-	log.Debugf("unpublishVolumeConfig(%s) done\n", key)
+	log.Tracef("unpublishVolumeConfig(%s) done\n", key)
 }
 
 // volume event watch to capture transitions

--- a/pkg/pillar/cmd/zedagent/lte.go
+++ b/pkg/pillar/cmd/zedagent/lte.go
@@ -46,7 +46,7 @@ func readLTE(filename string, verbatim string) []types.MetricItem {
 	}
 	if verbatim != "" {
 		// Just return file content as a single string
-		log.Debugf("readLTE verbatim %s: %s",
+		log.Tracef("readLTE verbatim %s: %s",
 			verbatim, string(bytes))
 		info := types.MetricItem{Key: verbatim, Value: string(bytes)}
 		info.Type = types.MetricItemOther

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -37,13 +37,13 @@ func parseConfig(config *zconfig.EdgeDevConfig, getconfigCtx *getconfigContext,
 
 	// XXX can this happen when usingSaved is set?
 	if parseOpCmds(config, getconfigCtx) {
-		log.Infoln("Reboot flag set, skipping config processing")
+		log.Functionln("Reboot flag set, skipping config processing")
 		return true
 	}
 	ctx := getconfigCtx.zedagentCtx
 
 	// XXX - DO NOT LOG entire config till secrets are in encrypted blobs
-	//log.Debugf("parseConfig: EdgeDevConfig: %v", *config)
+	//log.Tracef("parseConfig: EdgeDevConfig: %v", *config)
 
 	// Look for timers and other settings in configItems
 	// Process Config items even when rebootFlag is set.. Allows us to
@@ -51,7 +51,7 @@ func parseConfig(config *zconfig.EdgeDevConfig, getconfigCtx *getconfigContext,
 	parseConfigItems(config, getconfigCtx)
 
 	if getconfigCtx.rebootFlag || ctx.deviceReboot {
-		log.Debugf("parseConfig: Ignoring config as rebootFlag set")
+		log.Tracef("parseConfig: Ignoring config as rebootFlag set")
 	} else {
 		handleControllerCertsSha(ctx, config)
 		parseCipherContext(getconfigCtx, config)
@@ -84,7 +84,7 @@ func shutdownApps(getconfigCtx *getconfigContext) {
 	for _, c := range items {
 		config := c.(types.AppInstanceConfig)
 		if config.Activate {
-			log.Infof("shutdownApps: clearing Activate for %s uuid %s",
+			log.Functionf("shutdownApps: clearing Activate for %s uuid %s",
 				config.DisplayName, config.Key())
 			config.Activate = false
 			pub.Publish(config.Key(), config)
@@ -111,7 +111,7 @@ func parseBaseOsConfig(getconfigCtx *getconfigContext,
 	if same {
 		return
 	}
-	log.Infof("parseBaseOsConfig: Applying updated config "+
+	log.Functionf("parseBaseOsConfig: Applying updated config "+
 		"prevSha: % x, "+
 		"NewSha : % x, "+
 		"cfgOsList: %v",
@@ -131,7 +131,7 @@ func parseBaseOsConfig(getconfigCtx *getconfigContext,
 		}
 		// baseOS instance not found, delete
 		if !found {
-			log.Infof("parseBaseOsConfig: deleting %s", uuidStr)
+			log.Functionf("parseBaseOsConfig: deleting %s", uuidStr)
 			getconfigCtx.pubBaseOsConfig.Unpublish(uuidStr)
 		}
 	}
@@ -139,7 +139,7 @@ func parseBaseOsConfig(getconfigCtx *getconfigContext,
 	for _, cfgOs := range cfgOsList {
 		if cfgOs.GetBaseOSVersion() == "" {
 			// Empty slot - silently ignore
-			log.Debugf("parseBaseOsConfig ignoring empty %s",
+			log.Tracef("parseBaseOsConfig ignoring empty %s",
 				cfgOs.Uuidandversion.Uuid)
 			continue
 		}
@@ -153,7 +153,7 @@ func parseBaseOsConfig(getconfigCtx *getconfigContext,
 			len(cfgOs.Drives))
 		parseContentTreeConfigList(baseOs.ContentTreeConfigList, cfgOs.Drives)
 
-		log.Debugf("parseBaseOsConfig publishing %v",
+		log.Tracef("parseBaseOsConfig publishing %v",
 			baseOs)
 		publishBaseOsConfig(getconfigCtx, baseOs)
 	}
@@ -174,7 +174,7 @@ func parseNetworkXObjectConfig(config *zconfig.EdgeDevConfig,
 	if same {
 		return false
 	}
-	log.Infof("parseNetworkXObjectConfig: Applying updated config "+
+	log.Functionf("parseNetworkXObjectConfig: Applying updated config "+
 		"prevSha: % x, "+
 		"NewSha : % x, "+
 		"networks: %v",
@@ -198,13 +198,13 @@ func unpublishDeletedNetworkInstanceConfig(ctx *getconfigContext,
 		networkInstanceEntry := lookupNetworkInstanceById(key, networkInstances)
 		if networkInstanceEntry != nil {
 			// Entry not deleted.
-			log.Infof("NetworkInstance %s (Name: %s) still exists",
+			log.Functionf("NetworkInstance %s (Name: %s) still exists",
 				key, networkInstanceEntry.Displayname)
 			continue
 		}
 
 		config := entry.(types.NetworkInstanceConfig)
-		log.Infof("unpublishing NetworkInstance %s (Name: %s)",
+		log.Functionf("unpublishing NetworkInstance %s (Name: %s)",
 			key, config.DisplayName)
 		if err := ctx.pubNetworkInstanceConfig.Unpublish(key); err != nil {
 			log.Fatalf("Network Instance UnPublish (key:%s, name:%s) FAILED: %s",
@@ -249,7 +249,7 @@ func parseDnsNameToIpList(
 func publishNetworkInstanceConfig(ctx *getconfigContext,
 	networkInstances []*zconfig.NetworkInstanceConfig) {
 
-	log.Infof("Publish NetworkInstance Config: %+v", networkInstances)
+	log.Functionf("Publish NetworkInstance Config: %+v", networkInstances)
 
 	unpublishDeletedNetworkInstanceConfig(ctx, networkInstances)
 	// check we do not have more than one VPN network instance
@@ -290,7 +290,7 @@ func publishNetworkInstanceConfig(ctx *getconfigContext,
 			Type:           types.NetworkInstanceType(apiConfigEntry.InstType),
 			Activate:       apiConfigEntry.Activate,
 		}
-		log.Infof("publishNetworkInstanceConfig: processing %s %s type %d activate %v",
+		log.Functionf("publishNetworkInstanceConfig: processing %s %s type %d activate %v",
 			networkInstanceConfig.UUID.String(), networkInstanceConfig.DisplayName,
 			networkInstanceConfig.Type, networkInstanceConfig.Activate)
 
@@ -374,7 +374,7 @@ func parseNetworkInstanceConfig(config *zconfig.EdgeDevConfig,
 	if same {
 		return
 	}
-	log.Infof("parseNetworkInstanceConfig: Applying updated config "+
+	log.Functionf("parseNetworkInstanceConfig: Applying updated config "+
 		"prevSha: % x, "+
 		"NewSha : % x, "+
 		"networkInstances: %v",
@@ -399,7 +399,7 @@ func parseAppInstanceConfig(config *zconfig.EdgeDevConfig,
 	if same {
 		return
 	}
-	log.Infof("parseAppInstanceConfig: Applying updated config "+
+	log.Functionf("parseAppInstanceConfig: Applying updated config "+
 		"prevSha: % x, "+
 		"NewSha : % x, "+
 		"Apps: %v",
@@ -417,7 +417,7 @@ func parseAppInstanceConfig(config *zconfig.EdgeDevConfig,
 			}
 		}
 		if !found {
-			log.Infof("Remove app config %s", uuidStr)
+			log.Functionf("Remove app config %s", uuidStr)
 			getconfigCtx.pubAppInstanceConfig.Unpublish(uuidStr)
 		}
 	}
@@ -425,7 +425,7 @@ func parseAppInstanceConfig(config *zconfig.EdgeDevConfig,
 	for _, cfgApp := range Apps {
 		// Note that we repeat this even if the app config didn't
 		// change but something else in the EdgeDeviceConfig did
-		log.Debugf("New/updated app instance %v", cfgApp)
+		log.Tracef("New/updated app instance %v", cfgApp)
 		var appInstance types.AppInstanceConfig
 
 		appInstance.UUIDandVersion.UUID, _ = uuid.FromString(cfgApp.Uuidandversion.Uuid)
@@ -459,13 +459,13 @@ func parseAppInstanceConfig(config *zconfig.EdgeDevConfig,
 		// I/O adapters
 		appInstance.IoAdapterList = nil
 		for _, adapter := range cfgApp.Adapters {
-			log.Debugf("Processing adapter type %d name %s",
+			log.Tracef("Processing adapter type %d name %s",
 				adapter.Type, adapter.Name)
 			appInstance.IoAdapterList = append(appInstance.IoAdapterList,
 				types.IoAdapter{Type: types.IoType(adapter.Type),
 					Name: adapter.Name})
 		}
-		log.Infof("Got adapters %v", appInstance.IoAdapterList)
+		log.Functionf("Got adapters %v", appInstance.IoAdapterList)
 
 		cmd := cfgApp.GetRestart()
 		if cmd != nil {
@@ -507,7 +507,7 @@ func parseSystemAdapterConfig(config *zconfig.EdgeDevConfig,
 	}
 	// XXX secrets like wifi credentials in here
 	if false {
-		log.Infof("parseSystemAdapterConfig: Applying updated config "+
+		log.Functionf("parseSystemAdapterConfig: Applying updated config "+
 			"prevSha: % x, "+
 			"NewSha : % x, "+
 			"sysAdapters: %v, "+
@@ -535,7 +535,7 @@ func parseSystemAdapterConfig(config *zconfig.EdgeDevConfig,
 		}
 	}
 	if len(newPorts) == 0 {
-		log.Infof("parseSystemAdapterConfig: No Port configuration present")
+		log.Functionf("parseSystemAdapterConfig: No Port configuration present")
 		return
 	}
 	portConfig := &types.DevicePortConfig{}
@@ -547,11 +547,11 @@ func parseSystemAdapterConfig(config *zconfig.EdgeDevConfig,
 	// the change can be sent back to the controller using ctx.devicePortConfigList
 	if cmp.Equal(getconfigCtx.devicePortConfig.Ports, portConfig.Ports) &&
 		getconfigCtx.devicePortConfig.Version == portConfig.Version {
-		log.Infof("parseSystemAdapterConfig: DevicePortConfig - " +
+		log.Functionf("parseSystemAdapterConfig: DevicePortConfig - " +
 			"Done with no change")
 		return
 	}
-	log.Infof("parseSystemAdapterConfig: version %d/%d differs",
+	log.Functionf("parseSystemAdapterConfig: version %d/%d differs",
 		getconfigCtx.devicePortConfig.Version, portConfig.Version)
 
 	// This is suboptimal after a reboot since the config will be the same
@@ -561,7 +561,7 @@ func parseSystemAdapterConfig(config *zconfig.EdgeDevConfig,
 
 	getconfigCtx.pubDevicePortConfig.Publish("zedagent", *portConfig)
 
-	log.Infof("parseSystemAdapterConfig: Done")
+	log.Functionf("parseSystemAdapterConfig: Done")
 }
 
 // Returns a port if it should be added to the list; some errors result in
@@ -571,7 +571,7 @@ func parseOneSystemAdapterConfig(getconfigCtx *getconfigContext,
 	version types.DevicePortConfigVersion) *types.NetworkPortConfig {
 	var isMgmt, isFree bool = false, false
 
-	log.Infof("XXX parseOneSystemAdapterConfig name %s lowerLayerName %s",
+	log.Functionf("XXX parseOneSystemAdapterConfig name %s lowerLayerName %s",
 		sysAdapter.Name, sysAdapter.LowerLayerName)
 	port := new(types.NetworkPortConfig)
 
@@ -620,7 +620,7 @@ func parseOneSystemAdapterConfig(getconfigCtx *getconfigContext,
 			}
 		}
 		isFree = phyio.UsagePolicy.FreeUplink
-		log.Infof("Found phyio for %s: isFree: %t",
+		log.Functionf("Found phyio for %s: isFree: %t",
 			sysAdapter.Name, isFree)
 	}
 	if version < types.DPCIsMgmt {
@@ -631,7 +631,7 @@ func parseOneSystemAdapterConfig(getconfigCtx *getconfigContext,
 		version = types.DPCIsMgmt
 	} else {
 		isMgmt = sysAdapter.Uplink
-		log.Infof("System adapter %s, isMgmt: %t", sysAdapter.Name, isMgmt)
+		log.Functionf("System adapter %s, isMgmt: %t", sysAdapter.Name, isMgmt)
 		// Either one can set isFree; both need to clear
 		if sysAdapter.FreeUplink && !isFree {
 			log.Warnf("Free flag forced by system adapter for %s",
@@ -757,7 +757,7 @@ func parseDeviceIoListConfig(config *zconfig.EdgeDevConfig,
 	}
 	// XXX secrets like wifi credentials in here
 	if false {
-		log.Infof("parseDeviceIoListConfig: Applying updated config "+
+		log.Functionf("parseDeviceIoListConfig: Applying updated config "+
 			"prevSha: % x, "+
 			"NewSha : % x, "+
 			"deviceIoList: %v",
@@ -814,7 +814,7 @@ func parseDeviceIoListConfig(config *zconfig.EdgeDevConfig,
 	phyIoAdapterList.Initialized = true
 	getconfigCtx.pubPhysicalIOAdapters.Publish("zedagent", phyIoAdapterList)
 
-	log.Infof("parseDeviceIoListConfig: Done")
+	log.Functionf("parseDeviceIoListConfig: Done")
 	return true
 }
 
@@ -867,7 +867,7 @@ func parseDatastoreConfig(config *zconfig.EdgeDevConfig,
 	// individual fields. The next commit should separate the sensitive
 	// information into a separate structure - linked by a reference. That
 	//  way, accidental print / log statements won't expose the secrets.
-	log.Infof("parseDatastoreConfig: Applying updated datastore config "+
+	log.Functionf("parseDatastoreConfig: Applying updated datastore config "+
 		"prevSha: % x, "+
 		"NewSha : % x, "+
 		"Num Stores: %d",
@@ -886,7 +886,7 @@ func publishDatastoreConfig(ctx *getconfigContext,
 		if ds != nil {
 			continue
 		}
-		log.Debugf("publishDatastoresConfig: unpublishing %s", k)
+		log.Tracef("publishDatastoresConfig: unpublishing %s", k)
 		ctx.pubDatastoreConfig.Unpublish(k)
 	}
 	for _, ds := range cfgDatastores {
@@ -989,7 +989,7 @@ func publishNetworkXObjectConfig(ctx *getconfigContext,
 		if netEnt != nil {
 			continue
 		}
-		log.Debugf("publishNetworkXObjectConfig: unpublishing %s", k)
+		log.Tracef("publishNetworkXObjectConfig: unpublishing %s", k)
 		ctx.pubNetworkXObjectConfig.Unpublish(k)
 	}
 
@@ -1019,16 +1019,16 @@ func parseOneNetworkXObjectConfig(ctx *getconfigContext, netEnt *zconfig.Network
 	}
 	config.UUID = id
 
-	log.Infof("parseOneNetworkXObjectConfig: processing %s type %d",
+	log.Functionf("parseOneNetworkXObjectConfig: processing %s type %d",
 		config.Key(), config.Type)
 
 	// proxy configuration from cloud network configuration
 	netProxyConfig := netEnt.GetEntProxy()
 	if netProxyConfig == nil {
-		log.Infof("parseOneNetworkXObjectConfig: EntProxy of network %s is nil",
+		log.Functionf("parseOneNetworkXObjectConfig: EntProxy of network %s is nil",
 			netEnt.Id)
 	} else {
-		log.Infof("parseOneNetworkXObjectConfig: Proxy configuration present in %s",
+		log.Functionf("parseOneNetworkXObjectConfig: Proxy configuration present in %s",
 			netEnt.Id)
 
 		proxyConfig := types.ProxyConfig{
@@ -1057,7 +1057,7 @@ func parseOneNetworkXObjectConfig(ctx *getconfigContext, netEnt *zconfig.Network
 			default:
 			}
 			proxyConfig.Proxies = append(proxyConfig.Proxies, proxyEntry)
-			log.Debugf("parseOneNetworkXObjectConfig: Adding proxy entry %s:%d in %s",
+			log.Tracef("parseOneNetworkXObjectConfig: Adding proxy entry %s:%d in %s",
 				proxyEntry.Server, proxyEntry.Port, netEnt.Id)
 		}
 
@@ -1148,7 +1148,7 @@ func parseNetworkWirelessConfig(ctx *getconfigContext, key string, netEnt *zconf
 	if netWireless == nil {
 		return wconfig
 	}
-	log.Infof("parseNetworkWirelessConfig: Wireless of network present in %s, config %v", netEnt.Id, netWireless)
+	log.Functionf("parseNetworkWirelessConfig: Wireless of network present in %s, config %v", netEnt.Id, netWireless)
 
 	wType := netWireless.GetType()
 	switch wType {
@@ -1161,7 +1161,7 @@ func parseNetworkWirelessConfig(ctx *getconfigContext, key string, netEnt *zconf
 			wcell.APN = cellular.GetAPN()
 			wconfig.Cellular = append(wconfig.Cellular, wcell)
 		}
-		log.Infof("parseNetworkWirelessConfig: Wireless of network Cellular, %v", wconfig.Cellular)
+		log.Functionf("parseNetworkWirelessConfig: Wireless of network Cellular, %v", wconfig.Cellular)
 	case zconfig.WirelessType_WiFi:
 		//
 		wconfig.WType = types.WirelessTypeWifi
@@ -1184,7 +1184,7 @@ func parseNetworkWirelessConfig(ctx *getconfigContext, key string, netEnt *zconf
 
 			wconfig.Wifi = append(wconfig.Wifi, wifi)
 		}
-		log.Infof("parseNetworkWirelessConfig: Wireless of network Wifi, %v", wconfig.Wifi)
+		log.Functionf("parseNetworkWirelessConfig: Wireless of network Wifi, %v", wconfig.Wifi)
 	default:
 		log.Errorf("parseNetworkWirelessConfig: unsupported wireless configure type %d", wType)
 	}
@@ -1315,7 +1315,7 @@ func parseUnderlayNetworkConfig(appInstance *types.AppInstanceConfig,
 		ulCfg := parseUnderlayNetworkConfigEntry(
 			cfgApp, cfgNetworks, cfgNetworkInstances, intfEnt)
 		if ulCfg == nil {
-			log.Infof("Nil underlay config for Interface %s", intfEnt.Name)
+			log.Functionf("Nil underlay config for Interface %s", intfEnt.Name)
 			continue
 		}
 		appInstance.UnderlayNetworkList = append(appInstance.UnderlayNetworkList,
@@ -1329,7 +1329,7 @@ func parseUnderlayNetworkConfig(appInstance *types.AppInstanceConfig,
 	// sort based on intfOrder
 	// XXX remove? Debug?
 	if len(appInstance.UnderlayNetworkList) > 1 {
-		log.Infof("XXX pre sort %+v", appInstance.UnderlayNetworkList)
+		log.Functionf("XXX pre sort %+v", appInstance.UnderlayNetworkList)
 	}
 	sort.Slice(appInstance.UnderlayNetworkList[:],
 		func(i, j int) bool {
@@ -1338,7 +1338,7 @@ func parseUnderlayNetworkConfig(appInstance *types.AppInstanceConfig,
 		})
 	// XXX remove? Debug?
 	if len(appInstance.UnderlayNetworkList) > 1 {
-		log.Infof("XXX post sort %+v", appInstance.UnderlayNetworkList)
+		log.Functionf("XXX post sort %+v", appInstance.UnderlayNetworkList)
 	}
 }
 
@@ -1386,13 +1386,13 @@ func parseUnderlayNetworkConfigEntry(
 		log.Errorf("%s", ulCfg.Error)
 		return ulCfg
 	}
-	log.Infof("NetworkInstance(%s-%s): InstType %v",
+	log.Functionf("NetworkInstance(%s-%s): InstType %v",
 		cfgApp.Displayname, cfgApp.Uuidandversion.Uuid,
 		networkInstanceEntry.InstType)
 
 	ulCfg.Network = uuid
 	if intfEnt.MacAddress != "" {
-		log.Infof("parseUnderlayNetworkConfig: got static MAC %s",
+		log.Functionf("parseUnderlayNetworkConfig: got static MAC %s",
 			intfEnt.MacAddress)
 		ulCfg.AppMacAddr, err = net.ParseMAC(intfEnt.MacAddress)
 		if err != nil {
@@ -1404,7 +1404,7 @@ func parseUnderlayNetworkConfigEntry(
 		}
 	}
 	if intfEnt.Addr != "" {
-		log.Infof("parseUnderlayNetworkConfig: got static IP %s",
+		log.Functionf("parseUnderlayNetworkConfig: got static IP %s",
 			intfEnt.Addr)
 		ulCfg.AppIPAddr = net.ParseIP(intfEnt.Addr)
 		if ulCfg.AppIPAddr == nil {
@@ -1480,7 +1480,7 @@ func parseConfigItems(config *zconfig.EdgeDevConfig, ctx *getconfigContext) {
 	if same {
 		return
 	}
-	log.Infof("parseConfigItems: Applying updated config "+
+	log.Functionf("parseConfigItems: Applying updated config "+
 		"prevSha: % x, "+
 		"NewSha : % x, "+
 		"items: %v",
@@ -1511,10 +1511,10 @@ func parseConfigItems(config *zconfig.EdgeDevConfig, ctx *getconfigContext) {
 			Err:   err,
 			Value: itemValue.StringValue(),
 		}
-		log.Debugf("Processed ConfigItem: key: %s, Value: %s, itemValue: %+v",
+		log.Tracef("Processed ConfigItem: key: %s, Value: %s, itemValue: %+v",
 			item.Key, item.Value, itemValue)
 	}
-	log.Debugf("Done with Parsing ConfigItems. globalStatus: %+v",
+	log.Tracef("Done with Parsing ConfigItems. globalStatus: %+v",
 		*newGlobalStatus)
 	ctx.zedagentCtx.globalStatus = *newGlobalStatus
 	// XXX - Should we also not call EnforceGlobalConfigMinimums on
@@ -1522,7 +1522,7 @@ func parseConfigItems(config *zconfig.EdgeDevConfig, ctx *getconfigContext) {
 	// Also - if we changed the Config Value based on Min / Max, we should
 	// report it to the user.
 	if !cmp.Equal(*gcPtr, newGlobalConfig) {
-		log.Infof("parseConfigItems: change %v",
+		log.Functionf("parseConfigItems: change %v",
 			cmp.Diff(*gcPtr, newGlobalConfig))
 		oldGlobalConfig := *gcPtr
 		*gcPtr = *newGlobalConfig
@@ -1538,17 +1538,17 @@ func parseConfigItems(config *zconfig.EdgeDevConfig, ctx *getconfigContext) {
 		newSSHAuthorizedKeys := newGlobalConfig.GlobalValueString(types.SSHAuthorizedKeys)
 
 		if newConfigInterval != oldConfigInterval {
-			log.Infof("parseConfigItems: %s change from %d to %d",
+			log.Functionf("parseConfigItems: %s change from %d to %d",
 				"ConfigInterval", oldConfigInterval, newConfigInterval)
 			updateConfigTimer(newConfigInterval, ctx.configTickerHandle)
 		}
 		if newMetricInterval != oldMetricInterval {
-			log.Infof("parseConfigItems: %s change from %d to %d",
+			log.Functionf("parseConfigItems: %s change from %d to %d",
 				"MetricInterval", oldMetricInterval, newMetricInterval)
 			updateMetricsTimer(newMetricInterval, ctx.metricsTickerHandle)
 		}
 		if newSSHAuthorizedKeys != oldSSHAuthorizedKeys {
-			log.Infof("parseConfigItems: %s changed from %v to %v",
+			log.Functionf("parseConfigItems: %s changed from %v to %v",
 				"SshAuthorizedKeys", oldSSHAuthorizedKeys, newSSHAuthorizedKeys)
 			ssh.UpdateSshAuthorizedKeys(log, newSSHAuthorizedKeys)
 		}
@@ -1567,7 +1567,7 @@ func publishAppInstanceConfig(getconfigCtx *getconfigContext,
 	config types.AppInstanceConfig) {
 
 	key := config.Key()
-	log.Debugf("publishAppInstanceConfig UUID %s", key)
+	log.Tracef("publishAppInstanceConfig UUID %s", key)
 	pub := getconfigCtx.pubAppInstanceConfig
 	pub.Publish(key, config)
 }
@@ -1576,7 +1576,7 @@ func publishBaseOsConfig(getconfigCtx *getconfigContext,
 	config *types.BaseOsConfig) {
 
 	key := config.Key()
-	log.Debugf("publishBaseOsConfig UUID %s, %s, activate %v",
+	log.Tracef("publishBaseOsConfig UUID %s, %s, activate %v",
 		key, config.BaseOsVersion, config.Activate)
 	pub := getconfigCtx.pubBaseOsConfig
 	pub.Publish(key, *config)
@@ -1614,7 +1614,7 @@ func parseOpCmds(config *zconfig.EdgeDevConfig,
 
 // Returns the cmd if the file exists
 func readRebootConfig() *types.DeviceOpsCmd {
-	log.Debugf("readRebootConfigCounter - reading %s", rebootConfigFilename)
+	log.Tracef("readRebootConfigCounter - reading %s", rebootConfigFilename)
 
 	bytes, err := ioutil.ReadFile(rebootConfigFilename)
 	if err == nil {
@@ -1625,13 +1625,13 @@ func readRebootConfig() *types.DeviceOpsCmd {
 		}
 		return &rebootConfig
 	}
-	log.Infof("readRebootConfigCounter - %s doesn't exist",
+	log.Functionf("readRebootConfigCounter - %s doesn't exist",
 		rebootConfigFilename)
 	return nil
 }
 
 func saveRebootConfig(reboot types.DeviceOpsCmd) {
-	log.Infof("saveRebootConfig - reboot.Counter: %d", reboot.Counter)
+	log.Functionf("saveRebootConfig - reboot.Counter: %d", reboot.Counter)
 	bytes, err := json.Marshal(reboot)
 	if err != nil {
 		log.Fatal(err)
@@ -1649,7 +1649,7 @@ var rebootPrevReturn bool
 func scheduleReboot(reboot *zconfig.DeviceOpsCmd,
 	getconfigCtx *getconfigContext) bool {
 	if reboot == nil {
-		log.Infof("scheduleReboot - removing %s",
+		log.Functionf("scheduleReboot - removing %s",
 			rebootConfigFilename)
 		// remove the existing file
 		os.Remove(rebootConfigFilename)
@@ -1663,7 +1663,7 @@ func scheduleReboot(reboot *zconfig.DeviceOpsCmd,
 		return rebootPrevReturn
 	}
 
-	log.Infof("scheduleReboot: Applying updated config %v", reboot)
+	log.Functionf("scheduleReboot: Applying updated config %v", reboot)
 	rebootConfig := readRebootConfig()
 	if rebootConfig != nil && rebootConfig.Counter == reboot.Counter {
 		rebootPrevReturn = false
@@ -1720,7 +1720,7 @@ func scheduleBackup(backup *zconfig.DeviceOpsCmd) {
 	if same {
 		return
 	}
-	log.Infof("scheduleBackup: Applying updated config %v", backup)
+	log.Functionf("scheduleBackup: Applying updated config %v", backup)
 	log.Errorf("XXX handle Backup Config: %v", backup)
 }
 
@@ -1739,7 +1739,7 @@ func handleRebootCmd(ctxPtr *zedagentContext, infoStr string) {
 	ctxPtr.currentBootReason = types.BootReasonRebootCmd
 
 	publishZedAgentStatus(getconfigCtx)
-	log.Infof(infoStr)
+	log.Functionf(infoStr)
 }
 
 // nodeagent has initiated a node reboot,

--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -44,11 +44,11 @@ func deviceInfoTask(ctxPtr *zedagentContext, triggerDeviceInfo <-chan struct{}) 
 		select {
 		case <-triggerDeviceInfo:
 			start := time.Now()
-			log.Info("deviceInfoTask got message")
+			log.Function("deviceInfoTask got message")
 
 			PublishDeviceInfoToZedCloud(ctxPtr)
 			ctxPtr.iteration++
-			log.Info("deviceInfoTask done with message")
+			log.Function("deviceInfoTask done with message")
 			ctxPtr.ps.CheckMaxTimeTopic(wdName, "PublishDeviceInfo", start,
 				warningTime, errorTime)
 		case <-stillRunning.C:
@@ -71,7 +71,7 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 	deviceUUID := zcdevUUID.String()
 	ReportInfo.DevId = *proto.String(deviceUUID)
 	ReportInfo.AtTimeStamp = ptypes.TimestampNow()
-	log.Infof("PublishDeviceInfoToZedCloud uuid %s", deviceUUID)
+	log.Functionf("PublishDeviceInfoToZedCloud uuid %s", deviceUUID)
 
 	ReportDeviceInfo := new(info.ZInfoDevice)
 
@@ -175,7 +175,7 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 				swInfo.DownloadProgress = uint32(bos.ContentTreeStatusList[0].Progress)
 			}
 			if !bos.ErrorTime.IsZero() {
-				log.Debugf("reportMetrics sending error time %v error %v for %s",
+				log.Tracef("reportMetrics sending error time %v error %v for %s",
 					bos.ErrorTime, bos.Error,
 					bos.BaseOsVersion)
 				swInfo.SwErr = encodeErrorInfo(bos.ErrorAndTime)
@@ -217,7 +217,7 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 			// Already reported above
 			continue
 		}
-		log.Debugf("reportMetrics sending unattached bos for %s",
+		log.Tracef("reportMetrics sending unattached bos for %s",
 			bos.BaseOsVersion)
 		swInfo := new(info.ZInfoDevSW)
 		swInfo.Status = bos.State.ZSwState()
@@ -228,7 +228,7 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 			swInfo.DownloadProgress = uint32(bos.ContentTreeStatusList[0].Progress)
 		}
 		if !bos.ErrorTime.IsZero() {
-			log.Debugf("reportMetrics sending error time %v error %v for %s",
+			log.Tracef("reportMetrics sending error time %v error %v for %s",
 				bos.ErrorTime, bos.Error, bos.BaseOsVersion)
 			swInfo.SwErr = encodeErrorInfo(bos.ErrorAndTime)
 		}
@@ -254,8 +254,8 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 	// Note that "domain" is returned in search, hence DNSdomain is
 	// not filled in.
 	dc := netclone.DnsReadConfig("/etc/resolv.conf")
-	log.Debugf("resolv.conf servers %v", dc.Servers)
-	log.Debugf("resolv.conf search %v", dc.Search)
+	log.Tracef("resolv.conf servers %v", dc.Servers)
+	log.Tracef("resolv.conf search %v", dc.Search)
 
 	ReportDeviceInfo.Dns = new(info.ZInfoDNS)
 	ReportDeviceInfo.Dns.DNSservers = dc.Servers
@@ -288,7 +288,7 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 		list := aa.LookupIoBundleGroup(ib.AssignmentGroup)
 		if len(list) == 0 {
 			if ib.AssignmentGroup != "" {
-				log.Infof("Nothing to report for %d %s",
+				log.Functionf("Nothing to report for %d %s",
 					ib.Type, ib.AssignmentGroup)
 				continue
 			}
@@ -313,7 +313,7 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 		} else if ib.UsedByUUID != nilUUID {
 			reportAA.UsedByAppUUID = ib.UsedByUUID.String()
 		}
-		log.Debugf("AssignableAdapters for %s macs %v",
+		log.Tracef("AssignableAdapters for %s macs %v",
 			reportAA.Name, reportAA.IoAddressList)
 		ReportDeviceInfo.AssignableAdapters = append(ReportDeviceInfo.AssignableAdapters,
 			reportAA)
@@ -323,9 +323,9 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 	if err != nil {
 		log.Fatalf("host.Info(): %s", err)
 	}
-	log.Debugf("uptime %d = %d days",
+	log.Tracef("uptime %d = %d days",
 		hinfo.Uptime, hinfo.Uptime/(3600*24))
-	log.Debugf("Booted at %v", time.Unix(int64(hinfo.BootTime), 0).UTC())
+	log.Tracef("Booted at %v", time.Unix(int64(hinfo.BootTime), 0).UTC())
 
 	bootTime, _ := ptypes.TimestampProto(
 		time.Unix(int64(hinfo.BootTime), 0).UTC())
@@ -356,8 +356,8 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 	ReportDeviceInfo.LastBootReason = info.BootReason(ctx.bootReason)
 	if ctx.bootReason != types.BootReasonNone {
 		// XXX Remove?
-		log.Debugf("Reporting BootReason %s", ctx.bootReason.String())
-		log.Debugf("Reporting RebootReason %s", ctx.rebootReason)
+		log.Tracef("Reporting BootReason %s", ctx.bootReason.String())
+		log.Tracef("Reporting RebootReason %s", ctx.rebootReason)
 	}
 
 	ReportDeviceInfo.LastRebootStack = ctx.rebootStack
@@ -399,7 +399,7 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 	// is deleted.
 	createAppInstances(ctx, ReportDeviceInfo)
 
-	log.Debugf("PublishDeviceInfoToZedCloud sending %v", ReportInfo)
+	log.Tracef("PublishDeviceInfoToZedCloud sending %v", ReportInfo)
 	data, err := proto.Marshal(ReportInfo)
 	if err != nil {
 		log.Fatal("PublishDeviceInfoToZedCloud proto marshaling error: ", err)
@@ -587,7 +587,7 @@ func encodeSystemAdapterInfo(ctx *zedagentContext) *info.SystemAdapterInfo {
 		}
 		sainfo.Status[i] = dps
 	}
-	log.Debugf("encodeSystemAdapterInfo: %+v", sainfo)
+	log.Tracef("encodeSystemAdapterInfo: %+v", sainfo)
 	return sainfo
 }
 

--- a/pkg/pillar/cmd/zedmanager/handledomainmgr.go
+++ b/pkg/pillar/cmd/zedmanager/handledomainmgr.go
@@ -18,15 +18,15 @@ func MaybeAddDomainConfig(ctx *zedmanagerContext,
 
 	key := aiConfig.Key()
 	displayName := aiConfig.DisplayName
-	log.Infof("MaybeAddDomainConfig for %s displayName %s", key,
+	log.Functionf("MaybeAddDomainConfig for %s displayName %s", key,
 		displayName)
 
 	m := lookupDomainConfig(ctx, key)
 	if m != nil {
 		// Always update to pick up new disks, vifs, Activate etc
-		log.Infof("Domain config already exists for %s", key)
+		log.Functionf("Domain config already exists for %s", key)
 	} else {
-		log.Infof("Domain config add for %s", key)
+		log.Functionf("Domain config add for %s", key)
 	}
 	AppNum := 0
 	if ns != nil {
@@ -78,7 +78,7 @@ func MaybeAddDomainConfig(ctx *zedmanagerContext,
 	}
 	publishDomainConfig(ctx, &dc)
 
-	log.Infof("MaybeAddDomainConfig done for %s", key)
+	log.Functionf("MaybeAddDomainConfig done for %s", key)
 	return nil
 }
 
@@ -87,7 +87,7 @@ func lookupDomainConfig(ctx *zedmanagerContext, key string) *types.DomainConfig 
 	pub := ctx.pubDomainConfig
 	c, _ := pub.Get(key)
 	if c == nil {
-		log.Debugf("lookupDomainConfig(%s) not found", key)
+		log.Tracef("lookupDomainConfig(%s) not found", key)
 		return nil
 	}
 	config := c.(types.DomainConfig)
@@ -99,7 +99,7 @@ func lookupDomainStatus(ctx *zedmanagerContext, key string) *types.DomainStatus 
 	sub := ctx.subDomainStatus
 	st, _ := sub.Get(key)
 	if st == nil {
-		log.Debugf("lookupDomainStatus(%s) not found", key)
+		log.Tracef("lookupDomainStatus(%s) not found", key)
 		return nil
 	}
 	status := st.(types.DomainStatus)
@@ -110,7 +110,7 @@ func publishDomainConfig(ctx *zedmanagerContext,
 	status *types.DomainConfig) {
 
 	key := status.Key()
-	log.Debugf("publishDomainConfig(%s)", key)
+	log.Tracef("publishDomainConfig(%s)", key)
 	pub := ctx.pubDomainConfig
 	pub.Publish(key, *status)
 }
@@ -118,7 +118,7 @@ func publishDomainConfig(ctx *zedmanagerContext,
 func unpublishDomainConfig(ctx *zedmanagerContext, uuidStr string) {
 
 	key := uuidStr
-	log.Debugf("unpublishDomainConfig(%s)", key)
+	log.Tracef("unpublishDomainConfig(%s)", key)
 	pub := ctx.pubDomainConfig
 	c, _ := pub.Get(key)
 	if c == nil {
@@ -143,18 +143,18 @@ func handleDomainStatusImpl(ctxArg interface{}, key string,
 
 	status := statusArg.(types.DomainStatus)
 	ctx := ctxArg.(*zedmanagerContext)
-	log.Infof("handleDomainStatusImpl for %s", key)
+	log.Functionf("handleDomainStatusImpl for %s", key)
 	// Record DomainStatus.State even if Pending() to capture HALTING
 
 	updateAIStatusUUID(ctx, status.Key())
-	log.Infof("handleDomainStatusImpl done for %s", key)
+	log.Functionf("handleDomainStatusImpl done for %s", key)
 }
 
 func handleDomainStatusDelete(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
-	log.Infof("handleDomainStatusDelete for %s", key)
+	log.Functionf("handleDomainStatusDelete for %s", key)
 	ctx := ctxArg.(*zedmanagerContext)
 	removeAIStatusUUID(ctx, key)
-	log.Infof("handleDomainStatusDelete done for %s", key)
+	log.Functionf("handleDomainStatusDelete done for %s", key)
 }

--- a/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
+++ b/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
@@ -19,15 +19,15 @@ func MaybeAddVolumeRefConfig(ctx *zedmanagerContext, appInstID uuid.UUID,
 	volumeID uuid.UUID, generationCounter int64, mountDir string) {
 
 	key := fmt.Sprintf("%s#%d", volumeID.String(), generationCounter)
-	log.Infof("MaybeAddVolumeRefConfig for %s", key)
+	log.Functionf("MaybeAddVolumeRefConfig for %s", key)
 	m := lookupVolumeRefConfig(ctx, key)
 	if m != nil {
 		m.RefCount++
-		log.Infof("VolumeRefConfig exists for %s to refcount %d",
+		log.Functionf("VolumeRefConfig exists for %s to refcount %d",
 			key, m.RefCount)
 		publishVolumeRefConfig(ctx, m)
 	} else {
-		log.Debugf("MaybeAddVolumeRefConfig: add for %s", key)
+		log.Tracef("MaybeAddVolumeRefConfig: add for %s", key)
 		vrc := types.VolumeRefConfig{
 			VolumeID:          volumeID,
 			GenerationCounter: generationCounter,
@@ -38,7 +38,7 @@ func MaybeAddVolumeRefConfig(ctx *zedmanagerContext, appInstID uuid.UUID,
 	}
 	base.NewRelationObject(log, base.AddRelationType, base.AppInstanceConfigLogType, appInstID.String(),
 		base.VolumeRefConfigLogType, key).Noticef("App instance to volume relation.")
-	log.Infof("MaybeAddVolumeRefConfig done for %s", key)
+	log.Functionf("MaybeAddVolumeRefConfig done for %s", key)
 }
 
 // MaybeRemoveVolumeRefConfig decreases the RefCount and deletes the VolumeRefConfig
@@ -47,10 +47,10 @@ func MaybeRemoveVolumeRefConfig(ctx *zedmanagerContext, appInstID uuid.UUID,
 	volumeID uuid.UUID, generationCounter int64) {
 
 	key := fmt.Sprintf("%s#%d", volumeID.String(), generationCounter)
-	log.Infof("MaybeRemoveVolumeRefConfig for %s", key)
+	log.Functionf("MaybeRemoveVolumeRefConfig for %s", key)
 	m := lookupVolumeRefConfig(ctx, key)
 	if m == nil {
-		log.Infof("MaybeRemoveVolumeRefConfig: config missing for %s", key)
+		log.Functionf("MaybeRemoveVolumeRefConfig: config missing for %s", key)
 		return
 	}
 	if m.RefCount == 0 {
@@ -59,16 +59,16 @@ func MaybeRemoveVolumeRefConfig(ctx *zedmanagerContext, appInstID uuid.UUID,
 	}
 	m.RefCount--
 	if m.RefCount == 0 {
-		log.Infof("MaybeRemoveVolumeRefConfig deleting %s", key)
+		log.Functionf("MaybeRemoveVolumeRefConfig deleting %s", key)
 		unpublishVolumeRefConfig(ctx, key)
 	} else {
-		log.Infof("MaybeRemoveVolumeRefConfig remaining RefCount %d for %s",
+		log.Functionf("MaybeRemoveVolumeRefConfig remaining RefCount %d for %s",
 			m.RefCount, key)
 		publishVolumeRefConfig(ctx, m)
 	}
 	base.NewRelationObject(log, base.DeleteRelationType, base.AppInstanceConfigLogType, appInstID.String(),
 		base.VolumeRefConfigLogType, key).Noticef("App instance to volume relation.")
-	log.Infof("MaybeRemoveVolumeRefConfig done for %s", key)
+	log.Functionf("MaybeRemoveVolumeRefConfig done for %s", key)
 }
 
 func lookupVolumeRefConfig(ctx *zedmanagerContext, key string) *types.VolumeRefConfig {
@@ -76,7 +76,7 @@ func lookupVolumeRefConfig(ctx *zedmanagerContext, key string) *types.VolumeRefC
 	pub := ctx.pubVolumeRefConfig
 	c, _ := pub.Get(key)
 	if c == nil {
-		log.Debugf("lookupVolumeRefConfig(%s) not found", key)
+		log.Tracef("lookupVolumeRefConfig(%s) not found", key)
 		return nil
 	}
 	config := c.(types.VolumeRefConfig)
@@ -88,7 +88,7 @@ func lookupVolumeRefStatus(ctx *zedmanagerContext, key string) *types.VolumeRefS
 	sub := ctx.subVolumeRefStatus
 	c, _ := sub.Get(key)
 	if c == nil {
-		log.Debugf("lookupVolumeRefStatus(%s) not found", key)
+		log.Tracef("lookupVolumeRefStatus(%s) not found", key)
 		return nil
 	}
 	status := c.(types.VolumeRefStatus)
@@ -98,15 +98,15 @@ func lookupVolumeRefStatus(ctx *zedmanagerContext, key string) *types.VolumeRefS
 func publishVolumeRefConfig(ctx *zedmanagerContext, config *types.VolumeRefConfig) {
 
 	key := config.Key()
-	log.Debugf("publishVolumeRefConfig(%s)", key)
+	log.Tracef("publishVolumeRefConfig(%s)", key)
 	pub := ctx.pubVolumeRefConfig
 	pub.Publish(key, *config)
-	log.Debugf("publishVolumeRefConfig(%s) Done", key)
+	log.Tracef("publishVolumeRefConfig(%s) Done", key)
 }
 
 func unpublishVolumeRefConfig(ctx *zedmanagerContext, key string) {
 
-	log.Debugf("unpublishVolumeRefConfig(%s)", key)
+	log.Tracef("unpublishVolumeRefConfig(%s)", key)
 	pub := ctx.pubVolumeRefConfig
 	c, _ := pub.Get(key)
 	if c == nil {
@@ -114,7 +114,7 @@ func unpublishVolumeRefConfig(ctx *zedmanagerContext, key string) {
 		return
 	}
 	pub.Unpublish(key)
-	log.Debugf("unpublishVolumeRefConfig(%s) Done", key)
+	log.Tracef("unpublishVolumeRefConfig(%s) Done", key)
 }
 
 func handleVolumeRefStatusCreate(ctxArg interface{}, key string,
@@ -132,7 +132,7 @@ func handleVolumeRefStatusImpl(ctxArg interface{}, key string,
 
 	status := statusArg.(types.VolumeRefStatus)
 	ctx := ctxArg.(*zedmanagerContext)
-	log.Infof("handleVolumeRefStatusImpl: key:%s, name:%s",
+	log.Functionf("handleVolumeRefStatusImpl: key:%s, name:%s",
 		key, status.DisplayName)
 	pub := ctx.pubAppInstanceStatus
 	items := pub.GetAll()
@@ -146,7 +146,7 @@ func handleVolumeRefStatusImpl(ctxArg interface{}, key string,
 			}
 		}
 	}
-	log.Infof("handleVolumeRefStatusImpl done for %s", key)
+	log.Functionf("handleVolumeRefStatusImpl done for %s", key)
 }
 
 func handleVolumeRefStatusDelete(ctxArg interface{}, key string,
@@ -154,7 +154,7 @@ func handleVolumeRefStatusDelete(ctxArg interface{}, key string,
 
 	status := statusArg.(types.VolumeRefStatus)
 	ctx := ctxArg.(*zedmanagerContext)
-	log.Infof("handleVolumeRefStatusDelete: key:%s, name:%s",
+	log.Functionf("handleVolumeRefStatusDelete: key:%s, name:%s",
 		key, status.DisplayName)
 	pub := ctx.pubAppInstanceStatus
 	items := pub.GetAll()
@@ -168,37 +168,37 @@ func handleVolumeRefStatusDelete(ctxArg interface{}, key string,
 			}
 		}
 	}
-	log.Infof("handleVolumeRefStatusDelete done for %s", key)
+	log.Functionf("handleVolumeRefStatusDelete done for %s", key)
 }
 
 func getVolumeRefStatusFromAIStatus(status *types.AppInstanceStatus,
 	vrc types.VolumeRefConfig) *types.VolumeRefStatus {
 
-	log.Debugf("getVolumeRefStatusFromAIStatus(%v)", vrc.Key())
+	log.Tracef("getVolumeRefStatusFromAIStatus(%v)", vrc.Key())
 	for i := range status.VolumeRefStatusList {
 		vrs := &status.VolumeRefStatusList[i]
 		if vrs.VolumeID == vrc.VolumeID && vrs.GenerationCounter == vrc.GenerationCounter {
-			log.Debugf("getVolumeRefStatusFromAIStatus(%v) found %s generationCounter %d",
+			log.Tracef("getVolumeRefStatusFromAIStatus(%v) found %s generationCounter %d",
 				vrs.Key(), vrs.DisplayName, vrs.GenerationCounter)
 			return vrs
 		}
 	}
-	log.Debugf("getVolumeRefStatusFromAIStatus(%v) Done", vrc.Key())
+	log.Tracef("getVolumeRefStatusFromAIStatus(%v) Done", vrc.Key())
 	return nil
 }
 
 func getVolumeRefConfigFromAIConfig(config *types.AppInstanceConfig,
 	vrs types.VolumeRefStatus) *types.VolumeRefConfig {
 
-	log.Debugf("getVolumeRefConfigFromAIConfig(%v)", vrs.Key())
+	log.Tracef("getVolumeRefConfigFromAIConfig(%v)", vrs.Key())
 	for i := range config.VolumeRefConfigList {
 		vrc := &config.VolumeRefConfigList[i]
 		if vrc.VolumeID == vrs.VolumeID && vrc.GenerationCounter == vrs.GenerationCounter {
-			log.Debugf("getVolumeRefConfigFromAIConfig(%v) found %s generationCounter %d",
+			log.Tracef("getVolumeRefConfigFromAIConfig(%v) found %s generationCounter %d",
 				vrs.Key(), vrs.DisplayName, vrs.GenerationCounter)
 			return vrc
 		}
 	}
-	log.Debugf("getVolumeRefConfigFromAIConfig(%v) Done", vrs.Key())
+	log.Tracef("getVolumeRefConfigFromAIConfig(%v) Done", vrs.Key())
 	return nil
 }

--- a/pkg/pillar/cmd/zedmanager/handlezedrouter.go
+++ b/pkg/pillar/cmd/zedmanager/handlezedrouter.go
@@ -15,39 +15,39 @@ func MaybeAddAppNetworkConfig(ctx *zedmanagerContext,
 
 	key := aiConfig.Key()
 	displayName := aiConfig.DisplayName
-	log.Infof("MaybeAddAppNetworkConfig for %s displayName %s", key,
+	log.Functionf("MaybeAddAppNetworkConfig for %s displayName %s", key,
 		displayName)
 
 	changed := false
 	m := lookupAppNetworkConfig(ctx, key)
 	if m != nil {
-		log.Infof("appNetwork config already exists for %s", key)
+		log.Functionf("appNetwork config already exists for %s", key)
 		if len(aiConfig.UnderlayNetworkList) != len(m.UnderlayNetworkList) {
 			log.Errorln("Unsupported: Changed number of underlays for ",
 				aiConfig.UUIDandVersion)
 			return
 		}
 		if m.Activate != aiConfig.Activate {
-			log.Infof("MaybeAddAppNetworkConfig Activate changed from %v to %v",
+			log.Functionf("MaybeAddAppNetworkConfig Activate changed from %v to %v",
 				m.Activate, aiConfig.Activate)
 			changed = true
 		}
 		if !m.GetStatsIPAddr.Equal(aiConfig.CollectStatsIPAddr) {
-			log.Infof("MaybeAddAppNetworkConfig: stats ip changed from  %s to %s",
+			log.Functionf("MaybeAddAppNetworkConfig: stats ip changed from  %s to %s",
 				m.GetStatsIPAddr.String(), aiConfig.CollectStatsIPAddr.String())
 			changed = true
 		}
 		for i, new := range aiConfig.UnderlayNetworkList {
 			old := m.UnderlayNetworkList[i]
 			if !reflect.DeepEqual(new.ACLs, old.ACLs) {
-				log.Infof("Under ACLs changed from %v to %v",
+				log.Functionf("Under ACLs changed from %v to %v",
 					old.ACLs, new.ACLs)
 				changed = true
 				break
 			}
 		}
 	} else {
-		log.Debugf("appNetwork config add for %s", key)
+		log.Tracef("appNetwork config add for %s", key)
 		changed = true
 	}
 	if changed {
@@ -65,7 +65,7 @@ func MaybeAddAppNetworkConfig(ctx *zedmanagerContext,
 		}
 		publishAppNetworkConfig(ctx, &nc)
 	}
-	log.Infof("MaybeAddAppNetworkConfig done for %s", key)
+	log.Functionf("MaybeAddAppNetworkConfig done for %s", key)
 }
 
 func lookupAppNetworkConfig(ctx *zedmanagerContext, key string) *types.AppNetworkConfig {
@@ -73,7 +73,7 @@ func lookupAppNetworkConfig(ctx *zedmanagerContext, key string) *types.AppNetwor
 	pub := ctx.pubAppNetworkConfig
 	c, _ := pub.Get(key)
 	if c == nil {
-		log.Debugf("lookupAppNetworkConfig(%s) not found", key)
+		log.Tracef("lookupAppNetworkConfig(%s) not found", key)
 		return nil
 	}
 	config := c.(types.AppNetworkConfig)
@@ -85,7 +85,7 @@ func lookupAppNetworkStatus(ctx *zedmanagerContext, key string) *types.AppNetwor
 	sub := ctx.subAppNetworkStatus
 	st, _ := sub.Get(key)
 	if st == nil {
-		log.Debugf("lookupAppNetworkStatus(%s) not found", key)
+		log.Tracef("lookupAppNetworkStatus(%s) not found", key)
 		return nil
 	}
 	status := st.(types.AppNetworkStatus)
@@ -96,7 +96,7 @@ func publishAppNetworkConfig(ctx *zedmanagerContext,
 	status *types.AppNetworkConfig) {
 
 	key := status.Key()
-	log.Infof("publishAppNetworkConfig(%s)", key)
+	log.Functionf("publishAppNetworkConfig(%s)", key)
 	pub := ctx.pubAppNetworkConfig
 	pub.Publish(key, *status)
 }
@@ -104,7 +104,7 @@ func publishAppNetworkConfig(ctx *zedmanagerContext,
 func unpublishAppNetworkConfig(ctx *zedmanagerContext, uuidStr string) {
 
 	key := uuidStr
-	log.Infof("unpublishAppNetworkConfig(%s)", key)
+	log.Functionf("unpublishAppNetworkConfig(%s)", key)
 	pub := ctx.pubAppNetworkConfig
 	c, _ := pub.Get(key)
 	if c == nil {
@@ -129,26 +129,26 @@ func handleAppNetworkStatusImpl(ctxArg interface{}, key string,
 
 	status := statusArg.(types.AppNetworkStatus)
 	ctx := ctxArg.(*zedmanagerContext)
-	log.Infof("handleAppNetworkStatusModify: key:%s, name:%s",
+	log.Functionf("handleAppNetworkStatusModify: key:%s, name:%s",
 		key, status.DisplayName)
 	// Ignore if any Pending* flag is set
 	if status.Pending() {
-		log.Infof("skipped AppNetworkConfigModify due to Pending* "+
+		log.Functionf("skipped AppNetworkConfigModify due to Pending* "+
 			"(Add:%t, Modify:%t, Del:%t) for %s:%s", status.PendingAdd,
 			status.PendingModify, status.PendingDelete, status.DisplayName, key)
 		return
 	}
 	updateAIStatusUUID(ctx, status.Key())
-	log.Infof("handleAppNetworkStatusModify done for %s", key)
+	log.Functionf("handleAppNetworkStatusModify done for %s", key)
 }
 
 func handleAppNetworkStatusDelete(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
-	log.Infof("handleAppNetworkStatusDelete for %s", key)
+	log.Functionf("handleAppNetworkStatusDelete for %s", key)
 	ctx := ctxArg.(*zedmanagerContext)
 	removeAIStatusUUID(ctx, key)
-	log.Infof("handleAppNetworkStatusDelete done for %s", key)
+	log.Functionf("handleAppNetworkStatusDelete done for %s", key)
 }
 
 func updateAppNetworkStatus(aiStatus *types.AppInstanceStatus,

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -16,10 +16,10 @@ import (
 // the microservices
 func updateAIStatusUUID(ctx *zedmanagerContext, uuidStr string) {
 
-	log.Infof("updateAIStatusUUID(%s)", uuidStr)
+	log.Functionf("updateAIStatusUUID(%s)", uuidStr)
 	status := lookupAppInstanceStatus(ctx, uuidStr)
 	if status == nil {
-		log.Infof("updateAIStatusUUID for %s: Missing AppInstanceStatus",
+		log.Functionf("updateAIStatusUUID for %s: Missing AppInstanceStatus",
 			uuidStr)
 		return
 	}
@@ -30,7 +30,7 @@ func updateAIStatusUUID(ctx *zedmanagerContext, uuidStr string) {
 	}
 	changed := doUpdate(ctx, *config, status)
 	if changed {
-		log.Infof("updateAIStatusUUID status change %d for %s",
+		log.Functionf("updateAIStatusUUID status change %d for %s",
 			status.State, uuidStr)
 		publishAppInstanceStatus(ctx, status)
 	}
@@ -40,10 +40,10 @@ func updateAIStatusUUID(ctx *zedmanagerContext, uuidStr string) {
 // the microservices
 func removeAIStatusUUID(ctx *zedmanagerContext, uuidStr string) {
 
-	log.Infof("removeAIStatusUUID(%s)", uuidStr)
+	log.Functionf("removeAIStatusUUID(%s)", uuidStr)
 	status := lookupAppInstanceStatus(ctx, uuidStr)
 	if status == nil {
-		log.Infof("removeAIStatusUUID for %s: Missing AppInstanceStatus",
+		log.Functionf("removeAIStatusUUID for %s: Missing AppInstanceStatus",
 			uuidStr)
 		return
 	}
@@ -55,28 +55,28 @@ func removeAIStatus(ctx *zedmanagerContext, status *types.AppInstanceStatus) {
 	uninstall := (status.PurgeInprogress != types.BringDown)
 	changed, done := doRemove(ctx, status, uninstall)
 	if changed {
-		log.Infof("removeAIStatus status change for %s",
+		log.Functionf("removeAIStatus status change for %s",
 			uuidStr)
 		publishAppInstanceStatus(ctx, status)
 	}
 	if !done {
 		if uninstall {
-			log.Infof("removeAIStatus(%s) waiting for removal",
+			log.Functionf("removeAIStatus(%s) waiting for removal",
 				status.Key())
 		} else {
-			log.Infof("removeAIStatus(%s): PurgeInprogress waiting for removal",
+			log.Functionf("removeAIStatus(%s): PurgeInprogress waiting for removal",
 				status.Key())
 		}
 		return
 	}
 
 	if uninstall {
-		log.Infof("removeAIStatus(%s) remove done", uuidStr)
+		log.Functionf("removeAIStatus(%s) remove done", uuidStr)
 		// Write out what we modified to AppInstanceStatus aka delete
 		unpublishAppInstanceStatus(ctx, status)
 		return
 	}
-	log.Infof("removeAIStatus(%s): PurgeInprogress bringing it up",
+	log.Functionf("removeAIStatus(%s): PurgeInprogress bringing it up",
 		status.Key())
 	status.PurgeInprogress = types.BringUp
 	publishAppInstanceStatus(ctx, status)
@@ -98,7 +98,7 @@ func doUpdate(ctx *zedmanagerContext,
 
 	uuidStr := status.Key()
 
-	log.Infof("doUpdate: UUID:%s, Name", uuidStr)
+	log.Functionf("doUpdate: UUID:%s, Name", uuidStr)
 
 	// The existence of Config is interpreted to mean the
 	// AppInstance should be INSTALLED. Activate is checked separately.
@@ -109,18 +109,18 @@ func doUpdate(ctx *zedmanagerContext,
 
 	// Are we doing a purge?
 	if status.PurgeInprogress == types.RecreateVolumes {
-		log.Infof("PurgeInprogress(%s) volumemgr done",
+		log.Functionf("PurgeInprogress(%s) volumemgr done",
 			status.Key())
 		status.PurgeInprogress = types.BringDown
 		changed = true
 		// Keep the old volumes in place
 		_, done := doRemove(ctx, status, false)
 		if !done {
-			log.Infof("PurgeInprogress(%s) waiting for removal",
+			log.Functionf("PurgeInprogress(%s) waiting for removal",
 				status.Key())
 			return changed
 		}
-		log.Infof("PurgeInprogress(%s) bringing it up",
+		log.Functionf("PurgeInprogress(%s) bringing it up",
 			status.Key())
 	}
 	c, done := doPrepare(ctx, config, status)
@@ -144,13 +144,13 @@ func doUpdate(ctx *zedmanagerContext,
 				changed = true
 			}
 		}
-		log.Infof("Waiting for config.Activate for %s", uuidStr)
+		log.Functionf("Waiting for config.Activate for %s", uuidStr)
 		return changed
 	}
-	log.Infof("Have config.Activate for %s", uuidStr)
+	log.Functionf("Have config.Activate for %s", uuidStr)
 	c = doActivate(ctx, uuidStr, config, status)
 	changed = changed || c
-	log.Infof("doUpdate done for %s", uuidStr)
+	log.Functionf("doUpdate done for %s", uuidStr)
 	return changed
 }
 
@@ -160,7 +160,7 @@ func doInstall(ctx *zedmanagerContext,
 
 	uuidStr := status.Key()
 
-	log.Infof("doInstall: UUID: %s", uuidStr)
+	log.Functionf("doInstall: UUID: %s", uuidStr)
 	allErrors := ""
 	var errorSource interface{}
 	var errorTime time.Time
@@ -190,10 +190,10 @@ func doInstall(ctx *zedmanagerContext,
 				newVrs = append(newVrs, *vrs)
 				continue
 			}
-			log.Infof("Removing potentially bad VolumeRefStatus %v",
+			log.Functionf("Removing potentially bad VolumeRefStatus %v",
 				vrs)
 			if status.IsErrorSource(vrs.ErrorSourceType) {
-				log.Infof("Removing error %s", status.Error)
+				log.Functionf("Removing error %s", status.Error)
 				status.ClearErrorWithSource()
 			}
 			MaybeRemoveVolumeRefConfig(ctx, config.UUIDandVersion.UUID,
@@ -206,11 +206,11 @@ func doInstall(ctx *zedmanagerContext,
 				removed = true
 			}
 		}
-		log.Infof("purge inactive (%s) volumeRefStatus from %d to %d",
+		log.Functionf("purge inactive (%s) volumeRefStatus from %d to %d",
 			config.Key(), len(status.VolumeRefStatusList), len(newVrs))
 		status.VolumeRefStatusList = newVrs
 		if removed {
-			log.Infof("Waiting for bad VolumeRefStatus to go away for AppInst %s",
+			log.Functionf("Waiting for bad VolumeRefStatus to go away for AppInst %s",
 				status.Key())
 			return removed, false
 		}
@@ -238,7 +238,7 @@ func doInstall(ctx *zedmanagerContext,
 			PendingAdd:        true,
 			State:             types.INITIAL,
 		}
-		log.Infof("Adding new VolumeRefStatus %v", newVrs)
+		log.Functionf("Adding new VolumeRefStatus %v", newVrs)
 		status.VolumeRefStatusList = append(status.VolumeRefStatusList, newVrs)
 		changed = true
 	}
@@ -288,11 +288,11 @@ func doInstall(ctx *zedmanagerContext,
 	}
 
 	if minState < types.CREATED_VOLUME {
-		log.Infof("Waiting for all volumes for %s", uuidStr)
+		log.Functionf("Waiting for all volumes for %s", uuidStr)
 		return changed, false
 	}
-	log.Infof("Done with volumes for %s", uuidStr)
-	log.Infof("doInstall done for %s", uuidStr)
+	log.Functionf("Done with volumes for %s", uuidStr)
+	log.Functionf("doInstall done for %s", uuidStr)
 	return changed, true
 }
 
@@ -307,25 +307,25 @@ func doInstallVolumeRef(ctx *zedmanagerContext, config types.AppInstanceConfig,
 		vrs.PendingAdd = false
 		changed = true
 	}
-	log.Infof("doInstallVolumeRef: VolumeRefStatus volumeID %s, generationCounter %d",
+	log.Functionf("doInstallVolumeRef: VolumeRefStatus volumeID %s, generationCounter %d",
 		vrs.VolumeID, vrs.GenerationCounter)
 
 	// VolumeRefStatus in app instance status is updated with the volume
 	// ref status published from the volumemgr if status gets changed
 	pubsubVrs := lookupVolumeRefStatus(ctx, vrs.Key())
 	if pubsubVrs == nil {
-		log.Infof("doInstallVolumeRef: Volumemgr VolumeRefStatus not found. key: %s", vrs.Key())
+		log.Functionf("doInstallVolumeRef: Volumemgr VolumeRefStatus not found. key: %s", vrs.Key())
 		return changed
 	}
 	if *pubsubVrs != *vrs {
 		*vrs = *pubsubVrs
 		changed = true
-		log.Infof("VolumeRefStatus updated for %s", vrs.Key())
+		log.Functionf("VolumeRefStatus updated for %s", vrs.Key())
 	}
 	if vrs.IsContainer() && !status.IsContainer {
 		status.IsContainer = true
 		changed = true
-		log.Infof("doInstallVolumeRef: Updated IsContainer flag in app instance status to %v",
+		log.Functionf("doInstallVolumeRef: Updated IsContainer flag in app instance status to %v",
 			status.IsContainer)
 	}
 	return changed
@@ -335,7 +335,7 @@ func doPrepare(ctx *zedmanagerContext,
 	config types.AppInstanceConfig, status *types.AppInstanceStatus) (bool, bool) {
 
 	uuidStr := status.Key()
-	log.Infof("doPrepare for %s", uuidStr)
+	log.Functionf("doPrepare for %s", uuidStr)
 	changed := false
 
 	// Automatically move from VERIFIED to INSTALLED
@@ -346,7 +346,7 @@ func doPrepare(ctx *zedmanagerContext,
 		changed = true
 	}
 	changed = true
-	log.Infof("doPrepare done for %s", uuidStr)
+	log.Functionf("doPrepare done for %s", uuidStr)
 	return changed, true
 }
 
@@ -355,7 +355,7 @@ func doPrepare(ctx *zedmanagerContext,
 func doActivate(ctx *zedmanagerContext, uuidStr string,
 	config types.AppInstanceConfig, status *types.AppInstanceStatus) bool {
 
-	log.Infof("doActivate for %s", uuidStr)
+	log.Functionf("doActivate for %s", uuidStr)
 	changed := false
 
 	// Are we doing a restart and it came down?
@@ -370,7 +370,7 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 				changed = true
 			}
 			if status.BootTime != ds.BootTime {
-				log.Infof("Update boottime to %s for %s",
+				log.Functionf("Update boottime to %s for %s",
 					ds.BootTime.Format(time.RFC3339Nano),
 					status.Key())
 				status.BootTime = ds.BootTime
@@ -381,7 +381,7 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 				changed = true
 			}
 			if !ds.Activated && !ds.HasError() {
-				log.Infof("RestartInprogress(%s) came down - set bring up",
+				log.Functionf("RestartInprogress(%s) came down - set bring up",
 					status.Key())
 				status.RestartInprogress = types.BringUp
 				changed = true
@@ -398,15 +398,15 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 	// Check AppNetworkStatus
 	ns := lookupAppNetworkStatus(ctx, uuidStr)
 	if ns == nil {
-		log.Infof("Waiting for AppNetworkStatus for %s", uuidStr)
+		log.Functionf("Waiting for AppNetworkStatus for %s", uuidStr)
 		return changed
 	}
 	if ns.Pending() {
-		log.Infof("Waiting for AppNetworkStatus !Pending for %s", uuidStr)
+		log.Functionf("Waiting for AppNetworkStatus !Pending for %s", uuidStr)
 		return changed
 	}
 	if ns.AwaitNetworkInstance {
-		log.Infof("Waiting for required network instances to arrive for %s", uuidStr)
+		log.Functionf("Waiting for required network instances to arrive for %s", uuidStr)
 		status.State = types.AWAITNETWORKINSTANCE
 		changed = true
 		return changed
@@ -421,15 +421,15 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 	}
 	updateAppNetworkStatus(status, ns)
 	if !ns.Activated {
-		log.Infof("Waiting for AppNetworkStatus Activated for %s", uuidStr)
+		log.Functionf("Waiting for AppNetworkStatus Activated for %s", uuidStr)
 		return changed
 	}
 	if status.IsErrorSource(types.AppNetworkStatus{}) {
-		log.Infof("Clearing zedrouter error %s", status.Error)
+		log.Functionf("Clearing zedrouter error %s", status.Error)
 		status.ClearErrorWithSource()
 		changed = true
 	}
-	log.Debugf("Done with AppNetworkStatus for %s", uuidStr)
+	log.Tracef("Done with AppNetworkStatus for %s", uuidStr)
 
 	// Make sure we have a DomainConfig
 	err := MaybeAddDomainConfig(ctx, config, *status, ns)
@@ -439,7 +439,7 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 		status.SetErrorWithSource(err.Error(), types.DomainStatus{},
 			time.Now())
 		changed = true
-		log.Infof("Waiting for DomainStatus Activated for %s",
+		log.Functionf("Waiting for DomainStatus Activated for %s",
 			uuidStr)
 		return changed
 	}
@@ -447,7 +447,7 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 	// Check DomainStatus; update AppInstanceStatus if error
 	ds := lookupDomainStatus(ctx, uuidStr)
 	if ds == nil {
-		log.Infof("Waiting for DomainStatus for %s", uuidStr)
+		log.Functionf("Waiting for DomainStatus for %s", uuidStr)
 		return changed
 	}
 	if status.DomainName != ds.DomainName {
@@ -455,7 +455,7 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 		changed = true
 	}
 	if status.BootTime != ds.BootTime {
-		log.Infof("Update boottime to %s for %s",
+		log.Functionf("Update boottime to %s for %s",
 			ds.BootTime.Format(time.RFC3339Nano), status.Key())
 		status.BootTime = ds.BootTime
 		changed = true
@@ -471,19 +471,19 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 			log.Errorf("RestartInprogress(%s) No DomainConfig",
 				status.Key())
 		} else if dc.Activate {
-			log.Infof("RestartInprogress(%s) Clear Activate",
+			log.Functionf("RestartInprogress(%s) Clear Activate",
 				status.Key())
 			dc.Activate = false
 			publishDomainConfig(ctx, dc)
 		} else if !ds.Activated {
-			log.Infof("RestartInprogress(%s) Set Activate",
+			log.Functionf("RestartInprogress(%s) Set Activate",
 				status.Key())
 			status.RestartInprogress = types.BringUp
 			changed = true
 			dc.Activate = true
 			publishDomainConfig(ctx, dc)
 		} else {
-			log.Infof("RestartInprogress(%s) waiting for domain down",
+			log.Functionf("RestartInprogress(%s) waiting for domain down",
 				status.Key())
 		}
 	}
@@ -496,7 +496,7 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 				ds.ErrorTime)
 			changed = true
 		} else if status.IsErrorSource(types.DomainStatus{}) {
-			log.Infof("Clearing domainmgr error %s", status.Error)
+			log.Functionf("Clearing domainmgr error %s", status.Error)
 			status.ClearErrorWithSource()
 			changed = true
 		}
@@ -506,7 +506,7 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 				uuidStr, ds.Error)
 		}
 		if status.IsErrorSource(types.DomainStatus{}) {
-			log.Infof("Clearing domainmgr error %s", status.Error)
+			log.Functionf("Clearing domainmgr error %s", status.Error)
 			status.ClearErrorWithSource()
 			changed = true
 		}
@@ -516,7 +516,7 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 		case types.RESTARTING, types.PURGING:
 			// Leave unchanged
 		default:
-			log.Infof("Set State from DomainStatus from %d to %d",
+			log.Functionf("Set State from DomainStatus from %d to %d",
 				status.State, ds.State)
 			status.State = ds.State
 			changed = true
@@ -526,15 +526,15 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 	status.IoAdapterList = ds.IoAdapterList
 	changed = true
 	if ds.State < types.BOOTING {
-		log.Infof("Waiting for DomainStatus to BOOTING for %s",
+		log.Functionf("Waiting for DomainStatus to BOOTING for %s",
 			uuidStr)
 		return changed
 	}
 	if ds.Pending() {
-		log.Infof("Waiting for DomainStatus !Pending for %s", uuidStr)
+		log.Functionf("Waiting for DomainStatus !Pending for %s", uuidStr)
 		return changed
 	}
-	log.Infof("Done with DomainStatus for %s", uuidStr)
+	log.Functionf("Done with DomainStatus for %s", uuidStr)
 
 	if !status.Activated {
 		status.Activated = true
@@ -544,30 +544,30 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 	// Are we doing a restart?
 	if status.RestartInprogress == types.BringUp {
 		if ds.Activated {
-			log.Infof("RestartInprogress(%s) activated",
+			log.Functionf("RestartInprogress(%s) activated",
 				status.Key())
 			status.RestartInprogress = types.NotInprogress
 			status.State = types.RUNNING
 			changed = true
 		} else {
-			log.Infof("RestartInprogress(%s) waiting for Activated",
+			log.Functionf("RestartInprogress(%s) waiting for Activated",
 				status.Key())
 		}
 	}
 	if status.PurgeInprogress == types.BringUp {
 		if ds.Activated {
-			log.Infof("PurgeInprogress(%s) activated",
+			log.Functionf("PurgeInprogress(%s) activated",
 				status.Key())
 			status.PurgeInprogress = types.NotInprogress
 			status.State = types.RUNNING
 			_ = purgeCmdDone(ctx, config, status)
 			changed = true
 		} else {
-			log.Infof("PurgeInprogress(%s) waiting for Activated",
+			log.Functionf("PurgeInprogress(%s) waiting for Activated",
 				status.Key())
 		}
 	}
-	log.Infof("doActivate done for %s", uuidStr)
+	log.Functionf("doActivate done for %s", uuidStr)
 	return changed
 }
 
@@ -578,7 +578,7 @@ func updateVifUsed(statusPtr *types.AppInstanceStatus, ds types.DomainStatus) bo
 		ulStatus := &statusPtr.UnderlayNetworks[i]
 		net := ds.VifInfoByVif(ulStatus.Vif)
 		if net != nil && net.VifUsed != ulStatus.VifUsed {
-			log.Infof("Found VifUsed %s for Vif %s", net.VifUsed, ulStatus.Vif)
+			log.Functionf("Found VifUsed %s for Vif %s", net.VifUsed, ulStatus.Vif)
 			ulStatus.VifUsed = net.VifUsed
 			changed = true
 		}
@@ -589,7 +589,7 @@ func updateVifUsed(statusPtr *types.AppInstanceStatus, ds types.DomainStatus) bo
 func purgeCmdDone(ctx *zedmanagerContext, config types.AppInstanceConfig,
 	status *types.AppInstanceStatus) bool {
 
-	log.Infof("purgeCmdDone(%s) for %s", config.Key(), config.DisplayName)
+	log.Functionf("purgeCmdDone(%s) for %s", config.Key(), config.DisplayName)
 
 	changed := false
 	// Process the StorageStatusList items which are not in StorageConfigList
@@ -601,13 +601,13 @@ func purgeCmdDone(ctx *zedmanagerContext, config types.AppInstanceConfig,
 			newVrs = append(newVrs, *vrs)
 			continue
 		}
-		log.Infof("purgeCmdDone(%s) unused volume ref %s generationCounter %d",
+		log.Functionf("purgeCmdDone(%s) unused volume ref %s generationCounter %d",
 			config.Key(), vrs.VolumeID, vrs.GenerationCounter)
 		MaybeRemoveVolumeRefConfig(ctx, config.UUIDandVersion.UUID,
 			vrs.VolumeID, vrs.GenerationCounter)
 		changed = true
 	}
-	log.Infof("purgeCmdDone(%s) volumeRefStatus from %d to %d",
+	log.Functionf("purgeCmdDone(%s) volumeRefStatus from %d to %d",
 		config.Key(), len(status.VolumeRefStatusList), len(newVrs))
 	status.VolumeRefStatusList = newVrs
 	// Update persistent counter
@@ -623,14 +623,14 @@ func doRemove(ctx *zedmanagerContext,
 
 	appInstID := status.UUIDandVersion.UUID
 	uuidStr := appInstID.String()
-	log.Infof("doRemove for %s uninstall %t", appInstID, uninstall)
+	log.Functionf("doRemove for %s uninstall %t", appInstID, uninstall)
 
 	changed := false
 	done := false
 	c, done := doInactivate(ctx, appInstID, status)
 	changed = changed || c
 	if !done {
-		log.Infof("doRemove waiting for inactivate for %s", uuidStr)
+		log.Functionf("doRemove waiting for inactivate for %s", uuidStr)
 		return changed, done
 	}
 	if !status.Activated {
@@ -644,7 +644,7 @@ func doRemove(ctx *zedmanagerContext,
 			done = true
 		}
 	}
-	log.Infof("doRemove done for %s", uuidStr)
+	log.Functionf("doRemove done for %s", uuidStr)
 	return changed, done
 }
 
@@ -652,27 +652,27 @@ func doInactivate(ctx *zedmanagerContext, appInstID uuid.UUID,
 	status *types.AppInstanceStatus) (bool, bool) {
 
 	uuidStr := appInstID.String()
-	log.Infof("doInactivate for %s", uuidStr)
+	log.Functionf("doInactivate for %s", uuidStr)
 	changed := false
 	done := false
 	uninstall := (status.PurgeInprogress != types.BringDown)
 
 	if uninstall {
-		log.Infof("doInactivate uninstall for %s", uuidStr)
+		log.Functionf("doInactivate uninstall for %s", uuidStr)
 		// First halt the domain by deleting
 		if lookupDomainConfig(ctx, uuidStr) != nil {
 			unpublishDomainConfig(ctx, uuidStr)
 		}
 
 	} else {
-		log.Infof("doInactivate NOT uninstall for %s", uuidStr)
+		log.Functionf("doInactivate NOT uninstall for %s", uuidStr)
 		// First half the domain by clearing Activate
 		dc := lookupDomainConfig(ctx, uuidStr)
 		if dc == nil {
 			log.Warnf("doInactivate: No DomainConfig for %s",
 				uuidStr)
 		} else if dc.Activate {
-			log.Infof("doInactivate: Clearing Activate for DomainConfig for %s",
+			log.Functionf("doInactivate: Clearing Activate for DomainConfig for %s",
 				uuidStr)
 			dc.Activate = false
 			publishDomainConfig(ctx, dc)
@@ -682,10 +682,10 @@ func doInactivate(ctx *zedmanagerContext, appInstID uuid.UUID,
 	ds := lookupDomainStatus(ctx, uuidStr)
 	if ds != nil && (uninstall || ds.Activated) {
 		if uninstall {
-			log.Infof("Waiting for DomainStatus removal for %s",
+			log.Functionf("Waiting for DomainStatus removal for %s",
 				uuidStr)
 		} else {
-			log.Infof("Waiting for DomainStatus !Activated for %s",
+			log.Functionf("Waiting for DomainStatus !Activated for %s",
 				uuidStr)
 		}
 		// Update state
@@ -694,7 +694,7 @@ func doInactivate(ctx *zedmanagerContext, appInstID uuid.UUID,
 			changed = true
 		}
 		if status.BootTime != ds.BootTime {
-			log.Infof("Update boottime to %v for %s",
+			log.Functionf("Update boottime to %v for %s",
 				ds.BootTime.Format(time.RFC3339Nano),
 				status.Key())
 			status.BootTime = ds.BootTime
@@ -712,14 +712,14 @@ func doInactivate(ctx *zedmanagerContext, appInstID uuid.UUID,
 				ds.ErrorTime)
 			changed = true
 		} else if status.IsErrorSource(types.DomainStatus{}) {
-			log.Infof("Clearing domainmgr error %s",
+			log.Functionf("Clearing domainmgr error %s",
 				status.Error)
 			status.ClearErrorWithSource()
 			changed = true
 		}
 		return changed, done
 	}
-	log.Infof("Done with DomainStatus removal/deactivate for %s", uuidStr)
+	log.Functionf("Done with DomainStatus removal/deactivate for %s", uuidStr)
 
 	if uninstall {
 		if lookupAppNetworkConfig(ctx, uuidStr) != nil {
@@ -731,7 +731,7 @@ func doInactivate(ctx *zedmanagerContext, appInstID uuid.UUID,
 			log.Warnf("doInactivate: No AppNetworkConfig for %s",
 				uuidStr)
 		} else if m.Activate {
-			log.Infof("doInactivate: Clearing Activate for AppNetworkConfig for %s",
+			log.Functionf("doInactivate: Clearing Activate for AppNetworkConfig for %s",
 				uuidStr)
 			m.Activate = false
 			publishAppNetworkConfig(ctx, m)
@@ -741,10 +741,10 @@ func doInactivate(ctx *zedmanagerContext, appInstID uuid.UUID,
 	ns := lookupAppNetworkStatus(ctx, uuidStr)
 	if ns != nil && (uninstall || ns.Activated) {
 		if uninstall {
-			log.Infof("Waiting for AppNetworkStatus removal for %s",
+			log.Functionf("Waiting for AppNetworkStatus removal for %s",
 				uuidStr)
 		} else {
-			log.Infof("Waiting for AppNetworkStatus !Activated for %s",
+			log.Functionf("Waiting for AppNetworkStatus !Activated for %s",
 				uuidStr)
 		}
 		if ns.HasError() {
@@ -754,34 +754,34 @@ func doInactivate(ctx *zedmanagerContext, appInstID uuid.UUID,
 				ns.ErrorTime)
 			changed = true
 		} else if status.IsErrorSource(types.AppNetworkStatus{}) {
-			log.Infof("Clearing zedrouter error %s", status.Error)
+			log.Functionf("Clearing zedrouter error %s", status.Error)
 			status.ClearErrorWithSource()
 			changed = true
 		}
 		return changed, done
 	}
-	log.Infof("Done with AppNetworkStatus removal/deactivaye for %s", uuidStr)
+	log.Functionf("Done with AppNetworkStatus removal/deactivaye for %s", uuidStr)
 	done = true
 	status.Activated = false
 	status.ActivateInprogress = false
-	log.Infof("doInactivate done for %s", uuidStr)
+	log.Functionf("doInactivate done for %s", uuidStr)
 	return changed, done
 }
 
 func doUnprepare(ctx *zedmanagerContext, uuidStr string,
 	status *types.AppInstanceStatus) bool {
 
-	log.Infof("doUnprepare for %s", uuidStr)
+	log.Functionf("doUnprepare for %s", uuidStr)
 	changed := false
 
-	log.Infof("doUnprepare done for %s", uuidStr)
+	log.Functionf("doUnprepare done for %s", uuidStr)
 	return changed
 }
 
 func doUninstall(ctx *zedmanagerContext, appInstID uuid.UUID,
 	status *types.AppInstanceStatus) (bool, bool) {
 
-	log.Infof("doUninstall for %s", appInstID)
+	log.Functionf("doUninstall for %s", appInstID)
 	changed := false
 	del := false
 
@@ -791,11 +791,11 @@ func doUninstall(ctx *zedmanagerContext, appInstID uuid.UUID,
 			vrs.VolumeID, vrs.GenerationCounter)
 		changed = true
 	}
-	log.Debugf("Done with all volume refs removes for %s",
+	log.Tracef("Done with all volume refs removes for %s",
 		appInstID)
 
 	del = true
-	log.Infof("doUninstall done for %s", appInstID)
+	log.Functionf("doUninstall done for %s", appInstID)
 	return changed, del
 }
 
@@ -806,18 +806,18 @@ func doInactivateHalt(ctx *zedmanagerContext,
 	config types.AppInstanceConfig, status *types.AppInstanceStatus) bool {
 
 	uuidStr := status.Key()
-	log.Infof("doInactivateHalt for %s", uuidStr)
+	log.Functionf("doInactivateHalt for %s", uuidStr)
 	changed := false
 
 	// Check AppNetworkStatus
 	ns := lookupAppNetworkStatus(ctx, uuidStr)
 	if ns == nil {
-		log.Infof("Waiting for AppNetworkStatus for %s", uuidStr)
+		log.Functionf("Waiting for AppNetworkStatus for %s", uuidStr)
 		return changed
 	}
 	updateAppNetworkStatus(status, ns)
 	if ns.Pending() {
-		log.Infof("Waiting for AppNetworkStatus !Pending for %s", uuidStr)
+		log.Functionf("Waiting for AppNetworkStatus !Pending for %s", uuidStr)
 		return changed
 	}
 	// XXX should we make it not Activated?
@@ -829,11 +829,11 @@ func doInactivateHalt(ctx *zedmanagerContext,
 		changed = true
 		return changed
 	} else if status.IsErrorSource(types.AppNetworkStatus{}) {
-		log.Infof("Clearing zedrouter error %s", status.Error)
+		log.Functionf("Clearing zedrouter error %s", status.Error)
 		status.ClearErrorWithSource()
 		changed = true
 	}
-	log.Debugf("Done with AppNetworkStatus for %s", uuidStr)
+	log.Tracef("Done with AppNetworkStatus for %s", uuidStr)
 
 	// Make sure we have a DomainConfig. Clears dc.Activate based
 	// on the AppInstanceConfig's Activate
@@ -843,7 +843,7 @@ func doInactivateHalt(ctx *zedmanagerContext,
 			uuidStr, err)
 		status.SetError(err.Error(), time.Now())
 		changed = true
-		log.Infof("Waiting for DomainStatus Activated for %s",
+		log.Functionf("Waiting for DomainStatus Activated for %s",
 			uuidStr)
 		return changed
 	}
@@ -851,7 +851,7 @@ func doInactivateHalt(ctx *zedmanagerContext,
 	// Check DomainStatus; update AppInstanceStatus if error
 	ds := lookupDomainStatus(ctx, uuidStr)
 	if ds == nil {
-		log.Infof("Waiting for DomainStatus for %s", uuidStr)
+		log.Functionf("Waiting for DomainStatus for %s", uuidStr)
 		return changed
 	}
 	if status.DomainName != ds.DomainName {
@@ -859,7 +859,7 @@ func doInactivateHalt(ctx *zedmanagerContext,
 		changed = true
 	}
 	if status.BootTime != ds.BootTime {
-		log.Infof("Update boottime to %v for %s",
+		log.Functionf("Update boottime to %v for %s",
 			ds.BootTime.Format(time.RFC3339Nano), status.Key())
 		status.BootTime = ds.BootTime
 		changed = true
@@ -873,7 +873,7 @@ func doInactivateHalt(ctx *zedmanagerContext,
 		case types.RESTARTING, types.PURGING:
 			// Leave unchanged
 		default:
-			log.Infof("Set State from DomainStatus from %d to %d",
+			log.Functionf("Set State from DomainStatus from %d to %d",
 				status.State, ds.State)
 			status.State = ds.State
 			changed = true
@@ -885,7 +885,7 @@ func doInactivateHalt(ctx *zedmanagerContext,
 			uuidStr, ds.Error)
 	}
 	if status.IsErrorSource(types.DomainStatus{}) {
-		log.Infof("Clearing domainmgr error %s", status.Error)
+		log.Functionf("Clearing domainmgr error %s", status.Error)
 		status.ClearErrorWithSource()
 		changed = true
 	}
@@ -893,11 +893,11 @@ func doInactivateHalt(ctx *zedmanagerContext,
 	status.IoAdapterList = ds.IoAdapterList
 	changed = true
 	if ds.Pending() {
-		log.Infof("Waiting for DomainStatus !Pending for %s", uuidStr)
+		log.Functionf("Waiting for DomainStatus !Pending for %s", uuidStr)
 		return changed
 	}
 	if ds.Activated {
-		log.Infof("Waiting for Not Activated for DomainStatus %s",
+		log.Functionf("Waiting for Not Activated for DomainStatus %s",
 			uuidStr)
 		return changed
 	}
@@ -906,7 +906,7 @@ func doInactivateHalt(ctx *zedmanagerContext,
 	status.Activated = false
 	status.ActivateInprogress = false
 	changed = true
-	log.Infof("doInactivateHalt done for %s", uuidStr)
+	log.Functionf("doInactivateHalt done for %s", uuidStr)
 	return changed
 }
 

--- a/pkg/pillar/cmd/zedrouter/acl.go
+++ b/pkg/pillar/cmd/zedrouter/acl.go
@@ -156,7 +156,7 @@ func compileNetworkIpsetsStatus(ctx *zedrouterContext,
 	for _, c := range items {
 		config := c.(types.AppNetworkConfig)
 		if skipKey != "" && config.Key() == skipKey {
-			log.Debugf("compileNetworkIpsetsStatus skipping %s\n",
+			log.Tracef("compileNetworkIpsetsStatus skipping %s\n",
 				skipKey)
 			continue
 		}
@@ -232,7 +232,7 @@ func compileOldAppInstanceIpsets(ctx *zedrouterContext,
 func createACLConfiglet(aclArgs types.AppNetworkACLArgs,
 	ACLs []types.ACE) (types.IPTablesRuleList, error) {
 
-	log.Infof("createACLConfiglet: ifname %s, vifName %s, IP %s/%s, ACLs %v\n",
+	log.Functionf("createACLConfiglet: ifname %s, vifName %s, IP %s/%s, ACLs %v\n",
 		aclArgs.BridgeName, aclArgs.VifName, aclArgs.BridgeIP, aclArgs.AppIP, ACLs)
 	aclArgs.IPVer = determineIPVer(aclArgs.IsMgmt, aclArgs.BridgeIP)
 	rules, err := aclToRules(aclArgs, ACLs)
@@ -271,7 +271,7 @@ func applyACLRules(aclArgs types.AppNetworkACLArgs,
 	rules types.IPTablesRuleList) (types.IPTablesRuleList, error) {
 	var err error
 	var activeRules types.IPTablesRuleList
-	log.Debugf("applyACLRules: ipVer %d, bridgeName %s appIP %s with %d rules\n",
+	log.Tracef("applyACLRules: ipVer %d, bridgeName %s appIP %s with %d rules\n",
 		aclArgs.IPVer, aclArgs.BridgeName, aclArgs.AppIP, len(rules))
 
 	// the catch all log/drop rules are towards the end of the rule list
@@ -284,9 +284,9 @@ func applyACLRules(aclArgs types.AppNetworkACLArgs,
 	for numRules > 0 {
 		numRules--
 		rule := rules[numRules]
-		log.Debugf("createACLConfiglet: add rule %v\n", rule)
+		log.Tracef("createACLConfiglet: add rule %v\n", rule)
 		if err := rulePrefix(aclArgs, &rule); err != nil {
-			log.Debugf("createACLConfiglet: skipping rule %v\n", rule)
+			log.Tracef("createACLConfiglet: skipping rule %v\n", rule)
 			continue
 		}
 		err = executeIPTablesRule("-I", rule)
@@ -303,7 +303,7 @@ func applyACLRules(aclArgs types.AppNetworkACLArgs,
 func aclToRules(aclArgs types.AppNetworkACLArgs, ACLs []types.ACE) (types.IPTablesRuleList, error) {
 
 	var rulesList types.IPTablesRuleList
-	log.Debugf("aclToRules(%s, %s, %d, %s, %s, %v\n",
+	log.Tracef("aclToRules(%s, %s, %d, %s, %s, %v\n",
 		aclArgs.BridgeName, aclArgs.VifName, aclArgs.IPVer,
 		aclArgs.BridgeIP, aclArgs.AppIP, ACLs)
 
@@ -535,7 +535,7 @@ func aclToRules(aclArgs types.AppNetworkACLArgs, ACLs []types.ACE) (types.IPTabl
 		}
 		rulesList = append(rulesList, rules...)
 	}
-	log.Debugf("aclToRules(%v)\n", rulesList)
+	log.Tracef("aclToRules(%v)\n", rulesList)
 	return rulesList, nil
 }
 
@@ -548,7 +548,7 @@ func aclDropRules(aclArgs types.AppNetworkACLArgs) (types.IPTablesRuleList, erro
 	aclRule3.IPVer = aclArgs.IPVer
 	aclRule4.IPVer = aclArgs.IPVer
 
-	log.Debugf("aclDropRules: bridgeName %s, vifName %s\n",
+	log.Tracef("aclDropRules: bridgeName %s, vifName %s\n",
 		aclArgs.BridgeName, aclArgs.VifName)
 
 	// Always match on interface. Note that rulePrefix adds physdev-in
@@ -779,7 +779,7 @@ func aceToRules(aclArgs types.AppNetworkACLArgs, ace types.ACE) (types.IPTablesR
 			// These rules are applied on the upLink interfaces and port number.
 			// loop through the uplink interfaces
 			for _, upLink := range aclArgs.UpLinks {
-				log.Debugf("PortMap - upLink %s\n", upLink)
+				log.Tracef("PortMap - upLink %s\n", upLink)
 				// The DNAT/SNAT rules do not compare fport and ipset
 				// Make sure packets are returned to zedrouter and not
 				// e.g., out a directly attached interface in the domU
@@ -961,8 +961,8 @@ func aceToRules(aclArgs types.AppNetworkACLArgs, ace types.ACE) (types.IPTablesR
 		// Add separate DROP without the limit to count the excess
 		unlimitedOutActions := []string{"-j", "DROP"}
 		unlimitedInActions := []string{"-j", "DROP"}
-		log.Debugf("unlimitedOutArgs %v\n", unlimitedOutArgs)
-		log.Debugf("unlimitedInArgs %v\n", unlimitedInArgs)
+		log.Tracef("unlimitedOutArgs %v\n", unlimitedOutArgs)
+		log.Tracef("unlimitedInArgs %v\n", unlimitedInArgs)
 		aclRule5.Rule = unlimitedInArgs
 		aclRule5.Action = unlimitedInActions
 		aclRule5.IsLimitDropRule = true
@@ -974,7 +974,7 @@ func aceToRules(aclArgs types.AppNetworkACLArgs, ace types.ACE) (types.IPTablesR
 		aclRule6.IsUserConfigured = true
 		rulesList = append(rulesList, aclRule5, aclRule6)
 	}
-	log.Infof("rulesList %v\n", rulesList)
+	log.Functionf("rulesList %v\n", rulesList)
 	return rulesList, nil
 }
 
@@ -1132,7 +1132,7 @@ func diffIpsets(newIpsets, oldIpsets []string) ([]string, []string, bool) {
 	if (len(newIpsets) != len(oldIpsets)) || (len(staleIpsets) != 0) {
 		restartDnsmasq = true
 	}
-	log.Infof("diffIpsets: restart %v, new %v, stale %v",
+	log.Functionf("diffIpsets: restart %v, new %v, stale %v",
 		restartDnsmasq, newIpsets, staleIpsets)
 	return newIpsets, staleIpsets, restartDnsmasq
 }
@@ -1145,19 +1145,19 @@ func diffIpsets(newIpsets, oldIpsets []string) ([]string, []string, bool) {
 func updateACLConfiglet(aclArgs types.AppNetworkACLArgs, oldACLs []types.ACE, ACLs []types.ACE,
 	oldRules types.IPTablesRuleList, force bool) (types.IPTablesRuleList, error) {
 
-	log.Infof("updateACLConfiglet: bridgeName %s, vifName %s, appIP %s\n",
+	log.Functionf("updateACLConfiglet: bridgeName %s, vifName %s, appIP %s\n",
 		aclArgs.BridgeName, aclArgs.VifName, aclArgs.AppIP)
 
 	aclArgs.IPVer = determineIPVer(aclArgs.IsMgmt, aclArgs.BridgeIP)
 	if compareACLs(oldACLs, ACLs) == true && !force {
-		log.Infof("updateACLConfiglet: bridgeName %s, vifName %s, appIP %s: no change\n",
+		log.Functionf("updateACLConfiglet: bridgeName %s, vifName %s, appIP %s: no change\n",
 			aclArgs.BridgeName, aclArgs.VifName, aclArgs.AppIP)
 		return oldRules, nil
 	}
 
 	rules, err := deleteACLConfiglet(aclArgs, oldRules)
 	if err != nil {
-		log.Infof("updateACLConfiglet: bridgeName %s, vifName %s, appIP %s: delete fail\n",
+		log.Functionf("updateACLConfiglet: bridgeName %s, vifName %s, appIP %s: delete fail\n",
 			aclArgs.BridgeName, aclArgs.VifName, aclArgs.AppIP)
 		return rules, err
 	}
@@ -1187,7 +1187,7 @@ func updateACLConfiglet(aclArgs types.AppNetworkACLArgs, oldACLs []types.ACE, AC
 		if err != nil {
 			log.Errorf("updateACLConfiglet: Error clearing flows before update - %s", err)
 		} else {
-			log.Infof("updateACLConfiglet: Cleared %d flows before updating ACLs for app num %d",
+			log.Functionf("updateACLConfiglet: Cleared %d flows before updating ACLs for app num %d",
 				number, aclArgs.AppNum)
 		}
 	}
@@ -1199,11 +1199,11 @@ func deleteACLConfiglet(aclArgs types.AppNetworkACLArgs,
 	rules types.IPTablesRuleList) (types.IPTablesRuleList, error) {
 	var err error
 	var activeRules types.IPTablesRuleList
-	log.Infof("deleteACLConfiglet: ifname %s vifName %s ACLs %v\n",
+	log.Functionf("deleteACLConfiglet: ifname %s vifName %s ACLs %v\n",
 		aclArgs.BridgeName, aclArgs.VifName, rules)
 
 	for _, rule := range rules {
-		log.Debugf("deleteACLConfiglet: rule %v\n", rule)
+		log.Tracef("deleteACLConfiglet: rule %v\n", rule)
 		if err != nil {
 			activeRules = append(activeRules, rule)
 		} else {
@@ -1364,7 +1364,7 @@ func checkForMatchCondition(ace types.ACE, ace1 types.ACE, matchTypes []string) 
 		value1 := valueList1[idx]
 		if value == "" || value1 == "" ||
 			value != value1 {
-			log.Infof("difference for %d: value %s value1 %s",
+			log.Functionf("difference for %d: value %s value1 %s",
 				idx, value, value1)
 			return false
 		}
@@ -1412,7 +1412,7 @@ func executeIPTablesRule(operation string, rule types.IPTablesRule) error {
 // Network Instance Level ACL rule handling routines
 func handleNetworkInstanceACLConfiglet(op string, aclArgs types.AppNetworkACLArgs) error {
 
-	log.Infof("bridge(%s, %v) iptables op: %v\n", aclArgs.BridgeName, aclArgs.BridgeIP, op)
+	log.Functionf("bridge(%s, %v) iptables op: %v\n", aclArgs.BridgeName, aclArgs.BridgeIP, op)
 	rulesList := networkInstanceBridgeRules(aclArgs)
 	// For Network instance, we are going to do a "-A" operation
 	// so that, the rules, will at the end of the rule chain
@@ -1475,7 +1475,7 @@ func networkInstanceBridgeRules(aclArgs types.AppNetworkACLArgs) types.IPTablesR
 	default:
 	}
 
-	log.Debugf("bridge(%s, %v) attach iptable rules:%v\n",
+	log.Tracef("bridge(%s, %v) attach iptable rules:%v\n",
 		aclArgs.BridgeName, aclArgs.BridgeIP, rulesList)
 	return rulesList
 }
@@ -1485,7 +1485,7 @@ func createFlowMonDummyInterface(fwmark uint32) {
 	dummyIntfName := "flow-mon-dummy"
 	link, err := netlink.LinkByName(dummyIntfName)
 	if link != nil {
-		log.Infof("createFlowMonDummyInterface: %s already present", dummyIntfName)
+		log.Functionf("createFlowMonDummyInterface: %s already present", dummyIntfName)
 		return
 	}
 
@@ -1581,7 +1581,7 @@ func createMarkAndAcceptChain(aclArgs types.AppNetworkACLArgs,
 	}
 
 	newChain := []string{"-t", "mangle", "-N", name}
-	log.Infof("createMarkAndAcceptChain: Creating new chain (%s)", name)
+	log.Functionf("createMarkAndAcceptChain: Creating new chain (%s)", name)
 	err := iptables.IptableCmd(log, newChain...)
 	if err != nil {
 		log.Errorf("createMarkAndAcceptChain: New chain (%s) creation failed: %s",
@@ -1677,6 +1677,6 @@ func appConfigContainerStatsACL(appIPAddr net.IP, isRemove bool) {
 	if err != nil {
 		log.Errorf("appCheckContainerStatsACL: iptableCmd err %v", err)
 	} else {
-		log.Infof("appCheckContainerStatsACL: iptableCmd %s for %s", action, appIPAddr.String())
+		log.Functionf("appCheckContainerStatsACL: iptableCmd %s for %s", action, appIPAddr.String())
 	}
 }

--- a/pkg/pillar/cmd/zedrouter/appcontainer.go
+++ b/pkg/pillar/cmd/zedrouter/appcontainer.go
@@ -50,7 +50,7 @@ func appCheckStatsCollect(ctx *zedrouterContext, config *types.AppNetworkConfig,
 	publishAppNetworkStatus(ctx, status)
 	if status.GetStatsIPAddr == nil && oldIPAddr != nil ||
 		status.GetStatsIPAddr != nil && !status.GetStatsIPAddr.Equal(oldIPAddr) {
-		log.Infof("appCheckStatsCollect: config ip %v, status ip %v", status.GetStatsIPAddr, oldIPAddr)
+		log.Functionf("appCheckStatsCollect: config ip %v, status ip %v", status.GetStatsIPAddr, oldIPAddr)
 		if oldIPAddr == nil && status.GetStatsIPAddr != nil {
 			ensureStatsCollectRunning(ctx)
 		}
@@ -60,7 +60,7 @@ func appCheckStatsCollect(ctx *zedrouterContext, config *types.AppNetworkConfig,
 
 // goroutine for App container stats collection
 func appStatsAndLogCollect(ctx *zedrouterContext) {
-	log.Infof("appStatsAndLogCollect: containerStats, started")
+	log.Functionf("appStatsAndLogCollect: containerStats, started")
 	// cache the container last timestamp of log entries of the batch
 	lastLogTime := make(map[string]time.Time)
 	appStatsCollectTimer := time.NewTimer(time.Duration(ctx.appStatsInterval) * time.Second)
@@ -99,7 +99,7 @@ func appStatsAndLogCollect(ctx *zedrouterContext) {
 				}
 			}
 			// log output every 5 min, see this goroutine running status and number of containers from App
-			log.Infof("appStatsAndLogCollect: containerStats, %d processed. total log entries %d, reset timer", acNum, numlogs)
+			log.Functionf("appStatsAndLogCollect: containerStats, %d processed. total log entries %d, reset timer", acNum, numlogs)
 
 			appStatsCollectTimer = time.NewTimer(time.Duration(ctx.appStatsInterval) * time.Second)
 		}
@@ -111,7 +111,7 @@ func ensureStatsCollectRunning(ctx *zedrouterContext) {
 	if !ctx.appCollectStatsRunning {
 		ctx.appCollectStatsRunning = true
 		ctx.appStatsMutex.Unlock()
-		log.Infof("Creating %s at %s", "appStatusAndLogCollect",
+		log.Functionf("Creating %s at %s", "appStatusAndLogCollect",
 			agentlog.GetMyStack())
 		go appStatsAndLogCollect(ctx)
 	} else {
@@ -131,7 +131,7 @@ func checkAppStopStatsCollect(ctx *zedrouterContext) (map[string]interface{}, bo
 		}
 	}
 	if numStatsIP == 0 {
-		log.Infof("checkAppStopStatsCollect: no stats IP anymore. stop and exit out")
+		log.Functionf("checkAppStopStatsCollect: no stats IP anymore. stop and exit out")
 		ctx.appCollectStatsRunning = false
 		ctx.appStatsMutex.Unlock()
 		return items, true
@@ -163,7 +163,7 @@ func getAppContainerStats(status types.AppNetworkStatus, cli *client.Client, con
 			log.Errorf("getAppContainerStats: process stats for %s, error %v\n", container.Names[0], err)
 			continue
 		}
-		log.Debugf("getAppContainerStats: container stats %v", acStats)
+		log.Tracef("getAppContainerStats: container stats %v", acStats)
 		acMetrics.StatsList = append(acMetrics.StatsList, acStats)
 	}
 
@@ -235,13 +235,13 @@ func appStatsMayNeedReinstallACL(ctx *zedrouterContext, config types.AppNetworkC
 	for _, item := range items {
 		cfg := item.(types.AppNetworkConfig)
 		if cfg.Key() == config.Key() {
-			log.Infof("appStatsMayNeedReinstallACL: same app, skip")
+			log.Functionf("appStatsMayNeedReinstallACL: same app, skip")
 			continue
 		}
 		if cfg.GetStatsIPAddr != nil {
 			appConfigContainerStatsACL(cfg.GetStatsIPAddr, true)
 			appConfigContainerStatsACL(cfg.GetStatsIPAddr, false)
-			log.Infof("appStatsMayNeedReinstallACL: reinstall %s\n", cfg.GetStatsIPAddr.String())
+			log.Functionf("appStatsMayNeedReinstallACL: reinstall %s\n", cfg.GetStatsIPAddr.String())
 		}
 	}
 }
@@ -270,7 +270,7 @@ func getAppContainerLogs(ctx *zedrouterContext, status types.AppNetworkStatus, l
 		stdcopy.StdCopy(&buf, &buf, io.LimitReader(out, 100000))
 		logLines := strings.Split(buf.String(), "\n")
 		numlogs += len(logLines)
-		log.Debugf("getAppContainerLogs: container %s, lasttime %s, lines %d", containerName, lasttime, len(logLines))
+		log.Tracef("getAppContainerLogs: container %s, lasttime %s, lines %d", containerName, lasttime, len(logLines))
 		for _, line := range logLines {
 			sline := strings.SplitN(line, " ", 2)
 			time := sline[0]

--- a/pkg/pillar/cmd/zedrouter/appnumallocator.go
+++ b/pkg/pillar/cmd/zedrouter/appnumallocator.go
@@ -40,7 +40,7 @@ func appNumAllocatorInit(ctx *zedrouterContext) {
 		if status.NumType != "appNum" {
 			continue
 		}
-		log.Infof("appNumAllocatorInit found %v\n", status)
+		log.Functionf("appNumAllocatorInit found %v\n", status)
 		appNum := status.Number
 		uuid := status.UUID
 
@@ -53,7 +53,7 @@ func appNumAllocatorInit(ctx *zedrouterContext) {
 				uuid.String(), appNum)
 			continue
 		}
-		log.Infof("Reserving appNum %d for %s\n", appNum, uuid)
+		log.Functionf("Reserving appNum %d for %s\n", appNum, uuid)
 		AllocReservedAppNumBits.Set(appNum)
 		// Clear InUse
 		uuidtonum.UuidToNumFree(log, ctx.pubUuidToNum, uuid)
@@ -75,7 +75,7 @@ func appNumAllocatorInit(ctx *zedrouterContext) {
 				uuid.String(), appNum)
 			continue
 		}
-		log.Infof("Marking InUse appNum %d for %s\n", appNum, uuid)
+		log.Functionf("Marking InUse appNum %d for %s\n", appNum, uuid)
 		// Set InUse
 		uuidtonum.UuidToNumAllocate(log, ctx.pubUuidToNum, uuid, appNum,
 			false, "appNum")
@@ -88,7 +88,7 @@ func appNumAllocatorGC(ctx *zedrouterContext) {
 
 	pubUuidToNum := ctx.pubUuidToNum
 
-	log.Infof("appNumAllocatorGC")
+	log.Functionf("appNumAllocatorGC")
 	freedCount := 0
 	items := pubUuidToNum.GetAll()
 	for _, st := range items {
@@ -102,11 +102,11 @@ func appNumAllocatorGC(ctx *zedrouterContext) {
 		if status.CreateTime.After(ctx.agentStartTime) {
 			continue
 		}
-		log.Infof("appNumAllocatorGC: freeing %+v", status)
+		log.Functionf("appNumAllocatorGC: freeing %+v", status)
 		appNumFree(ctx, status.UUID)
 		freedCount++
 	}
-	log.Infof("appNumAllocatorGC freed %d", freedCount)
+	log.Functionf("appNumAllocatorGC freed %d", freedCount)
 }
 
 func appNumAllocate(ctx *zedrouterContext,
@@ -115,7 +115,7 @@ func appNumAllocate(ctx *zedrouterContext,
 	// Do we already have a number?
 	appNum, err := uuidtonum.UuidToNumGet(log, ctx.pubUuidToNum, uuid, "appNum")
 	if err == nil {
-		log.Infof("Found allocated appNum %d for %s\n", appNum, uuid)
+		log.Functionf("Found allocated appNum %d for %s\n", appNum, uuid)
 		if !AllocReservedAppNumBits.IsSet(appNum) {
 			log.Fatalf("AllocReservedAppNumBits not set for %d\n",
 				appNum)
@@ -129,7 +129,7 @@ func appNumAllocate(ctx *zedrouterContext,
 	// Find a free number in bitmap; look for zero if isZedmanager
 	if isZedmanager && !AllocReservedAppNumBits.IsSet(0) {
 		appNum = 0
-		log.Infof("Allocating appNum %d for %s isZedmanager\n",
+		log.Functionf("Allocating appNum %d for %s isZedmanager\n",
 			appNum, uuid)
 	} else {
 		// XXX could look for non-0xFF bytes first for efficiency
@@ -137,19 +137,19 @@ func appNumAllocate(ctx *zedrouterContext,
 		for i := 1; i < 256; i++ {
 			if !AllocReservedAppNumBits.IsSet(i) {
 				appNum = i
-				log.Infof("Allocating appNum %d for %s\n",
+				log.Functionf("Allocating appNum %d for %s\n",
 					appNum, uuid)
 				break
 			}
 		}
 		if appNum == 0 {
-			log.Infof("Failed to find free appNum for %s. Reusing!\n",
+			log.Functionf("Failed to find free appNum for %s. Reusing!\n",
 				uuid)
 			oldUuid, oldAppNum, err := uuidtonum.UuidToNumGetOldestUnused(log, ctx.pubUuidToNum, "appNum")
 			if err != nil {
 				log.Fatal("All 255 appNums are in use!")
 			}
-			log.Infof("Reuse found appNum %d for %s. Reusing!\n",
+			log.Functionf("Reuse found appNum %d for %s. Reusing!\n",
 				oldAppNum, oldUuid)
 			uuidtonum.UuidToNumDelete(log, ctx.pubUuidToNum, oldUuid)
 			AllocReservedAppNumBits.Clear(oldAppNum)

--- a/pkg/pillar/cmd/zedrouter/bridgenumallocator.go
+++ b/pkg/pillar/cmd/zedrouter/bridgenumallocator.go
@@ -30,7 +30,7 @@ func bridgeNumAllocatorInit(ctx *zedrouterContext) {
 		if status.NumType != "bridgeNum" {
 			continue
 		}
-		log.Infof("bridgeNumAllocatorInit found %v\n", status)
+		log.Functionf("bridgeNumAllocatorInit found %v\n", status)
 		bridgeNum := status.Number
 		uuid := status.UUID
 		// If we have a config for the UUID we should mark it as
@@ -42,7 +42,7 @@ func bridgeNumAllocatorInit(ctx *zedrouterContext) {
 				bridgeNum)
 			continue
 		}
-		log.Infof("Reserving bridgeNum %d for %s\n", bridgeNum, uuid)
+		log.Functionf("Reserving bridgeNum %d for %s\n", bridgeNum, uuid)
 		AllocReservedBridgeNumBits.Set(bridgeNum)
 		// Clear InUse
 		uuidtonum.UuidToNumFree(log, ctx.pubUuidToNum, uuid)
@@ -64,7 +64,7 @@ func bridgeNumAllocatorInit(ctx *zedrouterContext) {
 				uuid.String(), bridgeNum)
 			continue
 		}
-		log.Infof("Marking InUse bridgeNum %d for %s\n", bridgeNum, uuid)
+		log.Functionf("Marking InUse bridgeNum %d for %s\n", bridgeNum, uuid)
 		// Set InUse
 		uuidtonum.UuidToNumAllocate(log, ctx.pubUuidToNum, uuid, bridgeNum,
 			false, "bridgeNum")
@@ -77,7 +77,7 @@ func bridgeNumAllocatorGC(ctx *zedrouterContext) {
 
 	pubUuidToNum := ctx.pubUuidToNum
 
-	log.Infof("bridgeNumAllocatorGC")
+	log.Functionf("bridgeNumAllocatorGC")
 	freedCount := 0
 	items := pubUuidToNum.GetAll()
 	for _, st := range items {
@@ -91,11 +91,11 @@ func bridgeNumAllocatorGC(ctx *zedrouterContext) {
 		if status.CreateTime.After(ctx.agentStartTime) {
 			continue
 		}
-		log.Infof("bridgeNumAllocatorGC: freeing %+v", status)
+		log.Functionf("bridgeNumAllocatorGC: freeing %+v", status)
 		bridgeNumFree(ctx, status.UUID)
 		freedCount++
 	}
-	log.Infof("bridgeNumAllocatorGC freed %d", freedCount)
+	log.Functionf("bridgeNumAllocatorGC freed %d", freedCount)
 }
 
 func bridgeNumAllocate(ctx *zedrouterContext, uuid uuid.UUID) int {
@@ -104,7 +104,7 @@ func bridgeNumAllocate(ctx *zedrouterContext, uuid uuid.UUID) int {
 	bridgeNum, err := uuidtonum.UuidToNumGet(log, ctx.pubUuidToNum, uuid,
 		"bridgeNum")
 	if err == nil {
-		log.Infof("Found allocated bridgeNum %d for %s\n",
+		log.Functionf("Found allocated bridgeNum %d for %s\n",
 			bridgeNum, uuid)
 		if !AllocReservedBridgeNumBits.IsSet(bridgeNum) {
 			log.Fatalf("AllocReservedBridgeNumBits not set for %d\n",
@@ -122,19 +122,19 @@ func bridgeNumAllocate(ctx *zedrouterContext, uuid uuid.UUID) int {
 	for i := 1; i < 256; i++ {
 		if !AllocReservedBridgeNumBits.IsSet(i) {
 			bridgeNum = i
-			log.Infof("Allocating bridgeNum %d for %s\n",
+			log.Functionf("Allocating bridgeNum %d for %s\n",
 				bridgeNum, uuid)
 			break
 		}
 	}
 	if bridgeNum == 0 {
-		log.Infof("Failed to find free bridgeNum for %s. Reusing!\n",
+		log.Functionf("Failed to find free bridgeNum for %s. Reusing!\n",
 			uuid)
 		oldUuid, oldBridgeNum, err := uuidtonum.UuidToNumGetOldestUnused(log, ctx.pubUuidToNum, "bridgeNum")
 		if err != nil {
 			log.Fatal("All 255 bridgeNums are in use!")
 		}
-		log.Infof("Reuse found bridgeNum %d for %s. Reusing!\n",
+		log.Functionf("Reuse found bridgeNum %d for %s. Reusing!\n",
 			oldBridgeNum, oldUuid)
 		uuidtonum.UuidToNumDelete(log, ctx.pubUuidToNum, oldUuid)
 		AllocReservedBridgeNumBits.Clear(oldBridgeNum)

--- a/pkg/pillar/cmd/zedrouter/dnsmasq.go
+++ b/pkg/pillar/cmd/zedrouter/dnsmasq.go
@@ -72,7 +72,7 @@ func dnsmasqBridgeNames() []string {
 
 func dnsmasqInitDirs() {
 	if _, err := os.Stat(dnsmasqLeaseDir); err != nil {
-		log.Infof("Create %s\n", dnsmasqLeaseDir)
+		log.Functionf("Create %s\n", dnsmasqLeaseDir)
 		if err := os.Mkdir(dnsmasqLeaseDir, 0755); err != nil {
 			log.Fatal(err)
 		}
@@ -108,7 +108,7 @@ func createDnsmasqConfiglet(
 	netconf *types.NetworkInstanceConfig, hostsDir string,
 	ipsets []string, Ipv4Eid bool, uplink string, dnsServers []net.IP) {
 
-	log.Infof("createDnsmasqConfiglet(%s, %s) netconf %v, ipsets %v uplink %s dnsServers %v",
+	log.Functionf("createDnsmasqConfiglet(%s, %s) netconf %v, ipsets %v uplink %s dnsServers %v",
 		bridgeName, bridgeIPAddr, netconf, ipsets, uplink, dnsServers)
 
 	cfgPathname := dnsmasqConfigPath(bridgeName)
@@ -195,7 +195,7 @@ func createDnsmasqConfiglet(
 	var router string
 
 	if netconf.Logicallabel == "" {
-		log.Infof("Internal switch without external port case, dnsmasq suppress router advertize\n")
+		log.Functionf("Internal switch without external port case, dnsmasq suppress router advertize\n")
 		advertizeRouter = false
 	} else if Ipv4Eid {
 		advertizeRouter = false
@@ -257,7 +257,7 @@ func createDnsmasqConfiglet(
 				netconf.Subnet.String(), router))
 		}
 	} else {
-		log.Infof("createDnsmasqConfiglet: no router\n")
+		log.Functionf("createDnsmasqConfiglet: no router\n")
 		if !isIPv6 {
 			file.WriteString(fmt.Sprintf("dhcp-option=option:router\n"))
 		}
@@ -265,7 +265,7 @@ func createDnsmasqConfiglet(
 			// Handle isolated network by making sure
 			// we are not a DNS server. Can be overridden
 			// with the DnsServers above
-			log.Infof("createDnsmasqConfiglet: no DNS server\n")
+			log.Functionf("createDnsmasqConfiglet: no DNS server\n")
 			file.WriteString(fmt.Sprintf("dhcp-option=option:dns-server\n"))
 		}
 	}
@@ -283,7 +283,7 @@ func createDnsmasqConfiglet(
 func addhostDnsmasq(bridgeName string, appMac string, appIPAddr string,
 	hostname string) {
 
-	log.Infof("addhostDnsmasq(%s, %s, %s, %s)\n", bridgeName, appMac,
+	log.Functionf("addhostDnsmasq(%s, %s, %s, %s)\n", bridgeName, appMac,
 		appIPAddr, hostname)
 	if dnsmasqStopStart {
 		stopDnsmasq(bridgeName, true, false)
@@ -322,7 +322,7 @@ func addhostDnsmasq(bridgeName string, appMac string, appIPAddr string,
 
 func removehostDnsmasq(bridgeName string, appMac string, appIPAddr string) {
 
-	log.Infof("removehostDnsmasq(%s, %s, %s)\n",
+	log.Functionf("removehostDnsmasq(%s, %s, %s)\n",
 		bridgeName, appMac, appIPAddr)
 	stopDnsmasq(bridgeName, true, false)
 	ip := net.ParseIP(appIPAddr)
@@ -340,7 +340,7 @@ func removehostDnsmasq(bridgeName string, appMac string, appIPAddr string) {
 
 	cfgPathname := dhcphostsDir + "/" + appMac + suffix
 	if _, err := os.Stat(cfgPathname); err != nil {
-		log.Infof("removehostDnsmasq(%s, %s) failed: %s\n",
+		log.Functionf("removehostDnsmasq(%s, %s) failed: %s\n",
 			bridgeName, appMac, err)
 	} else {
 		if err := os.Remove(cfgPathname); err != nil {
@@ -353,7 +353,7 @@ func removehostDnsmasq(bridgeName string, appMac string, appIPAddr string) {
 
 func deleteDnsmasqConfiglet(bridgeName string) {
 
-	log.Infof("deleteDnsmasqConfiglet(%s)\n", bridgeName)
+	log.Functionf("deleteDnsmasqConfiglet(%s)\n", bridgeName)
 	cfgPathname := dnsmasqConfigPath(bridgeName)
 	if _, err := os.Stat(cfgPathname); err == nil {
 		if err := os.Remove(cfgPathname); err != nil {
@@ -377,7 +377,7 @@ func RemoveDirContent(dir string) error {
 	}
 	for _, file := range files {
 		filename := dir + "/" + file.Name()
-		log.Infoln("RemoveDirContent found ", filename)
+		log.Functionln("RemoveDirContent found ", filename)
 		err = os.RemoveAll(filename)
 		if err != nil {
 			return err
@@ -390,7 +390,7 @@ func RemoveDirContent(dir string) error {
 //    ${DMDIR}/dnsmasq -b -C /run/zedrouter/dnsmasq.${BRIDGENAME}.conf
 func startDnsmasq(bridgeName string) {
 
-	log.Infof("startDnsmasq(%s)\n", bridgeName)
+	log.Functionf("startDnsmasq(%s)\n", bridgeName)
 	cfgPathname := dnsmasqConfigPath(bridgeName)
 	name := "nohup"
 	args := []string{
@@ -398,20 +398,20 @@ func startDnsmasq(bridgeName string) {
 		"-C",
 		cfgPathname,
 	}
-	log.Infof("Calling command %s %v\n", name, args)
+	log.Functionf("Calling command %s %v\n", name, args)
 	out, err := base.Exec(log, name, args...).CombinedOutput()
 	if err != nil {
 		log.Errorf("startDnsmasq: Failed starting dnsmasq for bridge %s (%s)",
 			bridgeName, err)
 	} else {
-		log.Infof("startDnsmasq: Started dnsmasq with output: %s", out)
+		log.Functionf("startDnsmasq: Started dnsmasq with output: %s", out)
 	}
 }
 
 //    pkill -u nobody -f dnsmasq.${BRIDGENAME}.conf
 func stopDnsmasq(bridgeName string, printOnError bool, delConfiglet bool) {
 
-	log.Infof("stopDnsmasq(%s)\n", bridgeName)
+	log.Functionf("stopDnsmasq(%s)\n", bridgeName)
 	pidfile := fmt.Sprintf("/run/dnsmasq.%s.pid", bridgeName)
 	pidByte, err := ioutil.ReadFile(pidfile)
 	if err != nil {
@@ -437,10 +437,10 @@ func stopDnsmasq(bridgeName string, printOnError bool, delConfiglet bool) {
 		if err == nil {
 			err = p.Signal(syscall.Signal(0))
 			if err != nil {
-				log.Infof("stopDnsmasq: kill process done for %d\n", pid)
+				log.Functionf("stopDnsmasq: kill process done for %d\n", pid)
 				break
 			} else {
-				log.Infof("stopDnsmasq: wait for %d to finish\n", pid)
+				log.Functionf("stopDnsmasq: wait for %d to finish\n", pid)
 			}
 			if time.Since(startCheckTime).Seconds() > 60 {
 				log.Errorf("stopDnsmasq: kill dnsmasq on %s pid %d not finish in 60 seconds\n", bridgeName, pid)
@@ -448,7 +448,7 @@ func stopDnsmasq(bridgeName string, printOnError bool, delConfiglet bool) {
 			}
 			time.Sleep(1 * time.Second)
 		} else {
-			log.Infof("stopDnsmasq: find dnsmasq process %s error %v\n", pidStr, err)
+			log.Functionf("stopDnsmasq: find dnsmasq process %s error %v\n", pidStr, err)
 			break
 		}
 	}
@@ -481,7 +481,7 @@ func checkAndPublishDhcpLeases(ctx *zedrouterContext) {
 			l := findLease(ctx, status.Key(), ulStatus.Mac, true)
 			assigned := (l != nil)
 			if ulStatus.Assigned != assigned {
-				log.Infof("Changing(%s) %s mac %s to %t",
+				log.Functionf("Changing(%s) %s mac %s to %t",
 					status.Key(), status.DisplayName,
 					ulStatus.Mac, assigned)
 				ulStatus.Assigned = assigned
@@ -530,10 +530,10 @@ func findLease(ctx *zedrouterContext, hostname string, mac string, ignoreExpired
 			log.Warnf("Ignoring expired lease: %v", *l)
 			return nil
 		}
-		log.Debugf("Found %v", *l)
+		log.Tracef("Found %v", *l)
 		return l
 	}
-	log.Debugf("Not found %s/%s", hostname, mac)
+	log.Tracef("Not found %s/%s", hostname, mac)
 	return nil
 }
 
@@ -542,10 +542,10 @@ func addOrUpdateLease(ctx *zedrouterContext, lease dnsmasqLease) bool {
 	l := findLease(ctx, lease.Hostname, lease.MacAddr, false)
 	if l == nil {
 		ctx.dhcpLeases = append(ctx.dhcpLeases, lease)
-		log.Infof("Adding lease %v", lease)
+		log.Functionf("Adding lease %v", lease)
 		return true
 	} else if !cmp.Equal(*l, lease) {
-		log.Infof("Updating lease %v with %v", *l, lease)
+		log.Functionf("Updating lease %v with %v", *l, lease)
 		*l = lease
 		return true
 	} else {
@@ -560,7 +560,7 @@ func markRemoveLease(ctx *zedrouterContext, hostname string, mac string) {
 	if l == nil {
 		log.Fatalf("Lease not found %s/%s", hostname, mac)
 	}
-	log.Infof("Removing lease %v", l)
+	log.Functionf("Removing lease %v", l)
 	l.Remove = true
 }
 
@@ -576,9 +576,9 @@ func purgeRemovedLeases(ctx *zedrouterContext) {
 		newLeases = append(newLeases, lease)
 	}
 	ctx.dhcpLeases = newLeases
-	log.Infof("purgeRemovedLeases removed %d", removed)
-	// XXX change to log.Debugf
-	log.Infof("XXX after purgeRemovedLeases %v", ctx.dhcpLeases)
+	log.Functionf("purgeRemovedLeases removed %d", removed)
+	// XXX change to log.Tracef
+	log.Functionf("XXX after purgeRemovedLeases %v", ctx.dhcpLeases)
 }
 
 type dnsmasqLease struct {
@@ -603,14 +603,14 @@ const leaseGCTime = 5 * time.Minute
 func updateAllLeases(ctx *zedrouterContext) bool {
 	changed := false
 	bridgeNames := dnsmasqBridgeNames()
-	log.Debugf("bridgeNames: %v", bridgeNames)
+	log.Tracef("bridgeNames: %v", bridgeNames)
 	for _, bridgeName := range bridgeNames {
 		leases, err := readLeases(bridgeName)
 		if err != nil {
 			log.Warnf("readLeases(%s) failed: %s", bridgeName, err)
 			continue
 		}
-		log.Debugf("read leases(%s) %v", bridgeName, leases)
+		log.Tracef("read leases(%s) %v", bridgeName, leases)
 		// Add any new ones
 		for _, l := range leases {
 			if addOrUpdateLease(ctx, l) {
@@ -627,7 +627,7 @@ func updateAllLeases(ctx *zedrouterContext) bool {
 			time.Since(l.LeaseTime) <= leaseGCTime {
 			continue
 		}
-		log.Infof("lease %v garbage collected: lastSeen %v ago, lease expiry %v ago",
+		log.Functionf("lease %v garbage collected: lastSeen %v ago, lease expiry %v ago",
 			l, time.Since(l.LastSeen), time.Since(l.LeaseTime))
 		markRemoveLease(ctx, l.Hostname, l.MacAddr)
 		changed = true
@@ -699,7 +699,7 @@ func readLeases(bridgeName string) ([]dnsmasqLease, error) {
 // that has the IP address allotment information.
 func deleteOnlyDnsmasqConfiglet(bridgeName string) {
 
-	log.Infof("deleteOnlyDnsmasqConfiglet(%s)\n", bridgeName)
+	log.Functionf("deleteOnlyDnsmasqConfiglet(%s)\n", bridgeName)
 	cfgPathname := dnsmasqConfigPath(bridgeName)
 	if _, err := os.Stat(cfgPathname); err == nil {
 		if err := os.Remove(cfgPathname); err != nil {

--- a/pkg/pillar/cmd/zedrouter/flowstats.go
+++ b/pkg/pillar/cmd/zedrouter/flowstats.go
@@ -149,7 +149,7 @@ func FlowStatsCollect(ctx *zedrouterContext) {
 			return
 		}
 
-		log.Debugf("***FlowStats(%d): device=%v, size of the flows %d\n", proto, devUUID, len(connT))
+		log.Tracef("***FlowStats(%d): device=%v, size of the flows %d\n", proto, devUUID, len(connT))
 
 		for _, entry := range connT { // loop through and process current timedout flow collection
 
@@ -164,7 +164,7 @@ func FlowStatsCollect(ctx *zedrouterContext) {
 		}
 	}
 
-	log.Debugf("FlowStats ++ Total timedout flows %d, loopcount debug %d\n", totalFlow, loopcount)
+	log.Tracef("FlowStats ++ Total timedout flows %d, loopcount debug %d\n", totalFlow, loopcount)
 	loopcount++
 
 	// per app/bridge packing flow stats to be uploaded
@@ -185,7 +185,7 @@ func FlowStatsCollect(ctx *zedrouterContext) {
 				Scope: scope,
 			}
 
-			log.Debugf("FlowStats: bnx=%s, appidx %d\n", bnx, appIdx)
+			log.Tracef("FlowStats: bnx=%s, appidx %d\n", bnx, appIdx)
 			// temp print out the flow "tuple" and stats per app/bridge
 			for i, tuple := range timeOutTuples { // search for flowstats by bridge
 				var aclattr aclAttr
@@ -195,7 +195,7 @@ func FlowStatsCollect(ctx *zedrouterContext) {
 
 				appN := tuple.appNum
 				if int(appN) != appIdx { // allow non-App flows to be uploaded
-					//log.Infof("FlowStats: appN %d, appIdx %d not match", appN, appIdx)
+					//log.Functionf("FlowStats: appN %d, appIdx %d not match", appN, appIdx)
 					continue
 				}
 
@@ -203,25 +203,25 @@ func FlowStatsCollect(ctx *zedrouterContext) {
 					tmpMap := instData.ipaclattr[int(appN)]
 					if tmpMap != nil {
 						if _, ok := tmpMap[int(tuple.aclNum)]; !ok {
-							log.Debugf("FlowStats: == can not get acl map with aclN, should not happen appN %d, aclN %d; %s\n",
+							log.Tracef("FlowStats: == can not get acl map with aclN, should not happen appN %d, aclN %d; %s\n",
 								appN, tuple.aclNum, tuple.String())
 							continue
 						}
 						aclattr = tmpMap[int(tuple.aclNum)]
 					} else {
-						log.Debugf("FlowStats: == can't get acl map with appN, should not happen, appN %d, aclN %d; %s\n",
+						log.Tracef("FlowStats: == can't get acl map with appN, should not happen, appN %d, aclN %d; %s\n",
 							appN, tuple.aclNum, tuple.String())
 						continue
 					}
 					if aclattr.aclNum == 0 {
-						log.Debugf("FlowStats: == aclN zero in attr, appN %d, aclN %d; %s\n", appN, tuple.aclNum, tuple.String())
+						log.Tracef("FlowStats: == aclN zero in attr, appN %d, aclN %d; %s\n", appN, tuple.aclNum, tuple.String())
 						// some debug info
 						continue
 					}
 
 					bridgeName = aclattr.bridge
 					if strings.Compare(bnx, bridgeName) != 0 {
-						log.Debugf("FlowStats: == bridge name not match %s, %s\n", bnx, bridgeName)
+						log.Tracef("FlowStats: == bridge name not match %s, %s\n", bnx, bridgeName)
 						continue
 					}
 					scope.Intf = aclattr.intfname // App side DomU internal interface name
@@ -244,7 +244,7 @@ func FlowStatsCollect(ctx *zedrouterContext) {
 					continue
 				}
 				// temp print out log for the flow
-				log.Debugf("FlowStats [%d]: on bn%d %s\n", i, bnNum, tuple.String()) // just print for now
+				log.Tracef("FlowStats [%d]: on bn%d %s\n", i, bnNum, tuple.String()) // just print for now
 
 				flowtuple := types.IPTuple{
 					Src:     tuple.SrcIP,
@@ -298,7 +298,7 @@ func FlowStatsCollect(ctx *zedrouterContext) {
 			for idx := range dnsrec {
 				for _, dnsRec := range dnsrec[idx] {
 					// temp print out all unique dns replies for the bridge
-					log.Debugf("!!FlowStats: DNS time %v, domain %s, appIP %v, count %d, Answers %v",
+					log.Tracef("!!FlowStats: DNS time %v, domain %s, appIP %v, count %d, Answers %v",
 						dnsRec.TimeStamp, dnsRec.DomainName, dnsRec.AppIP, dnsRec.ANCount, dnsRec.Answers)
 
 					dnsrec := types.DNSReq{
@@ -330,7 +330,7 @@ func FlowStatsCollect(ctx *zedrouterContext) {
 				continue
 			}
 			dnssys[bnNum].Snoop = nil
-			log.Debugf("!!FlowStats: clear dns record for bn%d", bnNum)
+			log.Tracef("!!FlowStats: clear dns record for bn%d", bnNum)
 		}
 	}
 }
@@ -446,7 +446,7 @@ func flowMergeProcess(entry *netlink.ConntrackFlow, instData networkAttrs) flowS
 		ipFlow.AppInitiate = true
 	} else { // if we can not find our App endpoint is part of the flow, something is wrong
 		ipFlow.dbg2 = 5
-		log.Debugf("FlowStats: flow entry can not locate app IP address, appNum %d, %s", AppNum, entry.String())
+		log.Tracef("FlowStats: flow entry can not locate app IP address, appNum %d, %s", AppNum, entry.String())
 		return ipFlow
 	}
 
@@ -517,7 +517,7 @@ func checkAppAndACL(ctx *zedrouterContext, instData *networkAttrs) {
 		status := st.(types.AppNetworkStatus)
 		appID := status.UUIDandVersion.UUID
 		for i, ulStatus := range status.UnderlayNetworkList {
-			log.Debugf("===FlowStats: (index %d) AppNum %d, VifInfo %v, IP addr %v, Hostname %s\n",
+			log.Tracef("===FlowStats: (index %d) AppNum %d, VifInfo %v, IP addr %v, Hostname %s\n",
 				i, status.AppNum, ulStatus.VifInfo, ulStatus.AllocatedIPAddr, ulStatus.HostName)
 
 			ulconfig := ulStatus.UnderlayNetworkConfig
@@ -532,7 +532,7 @@ func checkAppAndACL(ctx *zedrouterContext, instData *networkAttrs) {
 				if netstatus.Type == types.NetworkInstanceTypeSwitch {
 					if _, ok := netstatus.IPAssignments[ulStatus.Mac]; ok {
 						tmpAppInfo.ipaddr = netstatus.IPAssignments[ulStatus.Mac]
-						log.Debugf("===FlowStats: switchnet, get ip %v\n", tmpAppInfo.ipaddr)
+						log.Tracef("===FlowStats: switchnet, get ip %v\n", tmpAppInfo.ipaddr)
 					}
 				}
 			}
@@ -548,7 +548,7 @@ func checkAppAndACL(ctx *zedrouterContext, instData *networkAttrs) {
 			// build an App list cache, used for loop through all the Apps
 			if instData.appNet[status.AppNum] == nilUUID {
 				instData.appNet[status.AppNum] = status.UUIDandVersion.UUID
-				log.Debugf("===FlowStats: appNet appNum %d, uuid %v\n", status.AppNum, instData.appNet[status.AppNum])
+				log.Tracef("===FlowStats: appNet appNum %d, uuid %v\n", status.AppNum, instData.appNet[status.AppNum])
 			}
 
 			// build an acl cache indexed by app/aclnum, from flow MARK, we can get this aclAttr info
@@ -595,7 +595,7 @@ func flowPublish(ctx *zedrouterContext, flowdata *types.IPFlow, seq, idx *int) {
 	}
 	flowKey = scope.UUID.String() + scope.NetUUID.String() + scope.Sequence
 	ctx.pubAppFlowMonitor.Publish(flowKey, *flowdata)
-	log.Infof("FlowStats: publish to zedagent: total records %d, sequence %d\n", *idx, *seq)
+	log.Functionf("FlowStats: publish to zedagent: total records %d, sequence %d\n", *idx, *seq)
 	*seq++
 	flowdata.Flows = nil
 	flowdata.DNSReqs = nil
@@ -622,7 +622,7 @@ func DNSMonitor(bn string, bnNum int, ctx *zedrouterContext, status *types.Netwo
 		switched = true
 		filter = "udp and (port 53 or port 67)"
 	}
-	log.Infof("(FlowStats) DNS Monitor on %s(bridge-num %d) swithced=%v, filter=%s", bn, bnNum, switched, filter)
+	log.Functionf("(FlowStats) DNS Monitor on %s(bridge-num %d) swithced=%v, filter=%s", bn, bnNum, switched, filter)
 
 	handle, err := pcap.OpenLive(bn, snapshotLen, promiscuous, timeout, false)
 	if err != nil {
@@ -645,7 +645,7 @@ func DNSMonitor(bn string, bnNum int, ctx *zedrouterContext, status *types.Netwo
 		var packet gopacket.Packet
 		select {
 		case <-dnssys[bnNum].Done:
-			log.Infof("(FlowStats) DNS Monitor exit on %s(bridge-num %d)", bn, bnNum)
+			log.Functionf("(FlowStats) DNS Monitor exit on %s(bridge-num %d)", bn, bnNum)
 			dnssys[bnNum].channelOpen = false
 			dnssys[bnNum].Lock()
 			dnsDataRemove(bnNum)
@@ -670,7 +670,7 @@ func DNSMonitor(bn string, bnNum int, ctx *zedrouterContext, status *types.Netwo
 
 // DNSStopMonitor : Stop DNS Query monitoring
 func DNSStopMonitor(bnNum int) {
-	log.Infof("(FlowStats) Stop DNS Monitor on bridge-num %d", bnNum)
+	log.Functionf("(FlowStats) Stop DNS Monitor on bridge-num %d", bnNum)
 	if dnssys[bnNum].channelOpen {
 		dnssys[bnNum].Done <- true
 	}
@@ -716,7 +716,7 @@ func checkDHCPPacketInfo(bnNum int, packet gopacket.Packet, ctx *zedrouterContex
 		}
 	}
 	if !foundDstMac && !isBroadcast { // dhcp packet not for this bridge App ports
-		log.Debugf("checkDHCPPacketInfo: pkt no dst mac for us\n")
+		log.Tracef("checkDHCPPacketInfo: pkt no dst mac for us\n")
 		return
 	}
 
@@ -738,17 +738,17 @@ func checkDHCPPacketInfo(bnNum int, packet gopacket.Packet, ctx *zedrouterContex
 				}
 			}
 			if isReplyAck {
-				log.Debugf("checkDHCPPacketInfo: bn%d, Xid %d, clientip %s, yourclientip %s, clienthw %v, options %v\n",
+				log.Tracef("checkDHCPPacketInfo: bn%d, Xid %d, clientip %s, yourclientip %s, clienthw %v, options %v\n",
 					bnNum, dhcpv4.Xid, dhcpv4.ClientIP.String(), dhcpv4.YourClientIP.String(), dhcpv4.ClientHWAddr, dhcpv4.Options)
 				for _, vif := range vifInfo {
 					if strings.Compare(vif.MacAddr, dhcpv4.ClientHWAddr.String()) == 0 {
 						if _, ok := netstatus.IPAssignments[vif.MacAddr]; !ok {
-							log.Infof("checkDHCPPacketInfo: mac %v assign new IP %v\n", vif.MacAddr, dhcpv4.YourClientIP)
+							log.Functionf("checkDHCPPacketInfo: mac %v assign new IP %v\n", vif.MacAddr, dhcpv4.YourClientIP)
 							netstatus.IPAssignments[vif.MacAddr] = dhcpv4.YourClientIP
 							needUpdate = true
 						} else {
 							if netstatus.IPAssignments[vif.MacAddr].Equal(dhcpv4.YourClientIP) == false {
-								log.Infof("checkDHCPPacketInfo: update mac %v, prev %v, now %v\n",
+								log.Functionf("checkDHCPPacketInfo: update mac %v, prev %v, now %v\n",
 									vif.MacAddr, netstatus.IPAssignments[vif.MacAddr], dhcpv4.YourClientIP)
 								netstatus.IPAssignments[vif.MacAddr] = dhcpv4.YourClientIP
 								needUpdate = true
@@ -761,7 +761,7 @@ func checkDHCPPacketInfo(bnNum int, packet gopacket.Packet, ctx *zedrouterContex
 				}
 			}
 		} else {
-			log.Debugf("checkDHCPPacketInfo: no dhcp layer\n")
+			log.Tracef("checkDHCPPacketInfo: no dhcp layer\n")
 		}
 	} else {
 		// XXX need to come back to handle ipv6 properly, including:
@@ -772,13 +772,13 @@ func checkDHCPPacketInfo(bnNum int, packet gopacket.Packet, ctx *zedrouterContex
 		dhcpLayer := packet.Layer(layers.LayerTypeDHCPv6)
 		if dhcpLayer != nil {
 			dhcpv6, _ := dhcpLayer.(*layers.DHCPv6)
-			log.Debugf("DHCPv6: Msgtype %v, LinkAddr %s, PeerAddr %s, Options %v\n",
+			log.Tracef("DHCPv6: Msgtype %v, LinkAddr %s, PeerAddr %s, Options %v\n",
 				dhcpv6.MsgType, dhcpv6.LinkAddr.String(), dhcpv6.PeerAddr.String(), dhcpv6.Options)
 		}
 	}
 
 	if needUpdate {
-		log.Infof("checkDHCPPacketInfo: need update %v, %v\n", vifInfo, netstatus.IPAssignments)
+		log.Functionf("checkDHCPPacketInfo: need update %v, %v\n", vifInfo, netstatus.IPAssignments)
 		pub := ctx.pubNetworkInstanceStatus
 		pub.Publish(netstatus.Key(), netstatus)
 		// trigger the AppInfo update to cloud
@@ -826,7 +826,7 @@ func checkDNSPacketInfo(bnNum int, packet gopacket.Packet, dnsLayer gopacket.Lay
 				}
 				if haveAN {
 					dnssys[bnNum].Snoop = append(dnssys[bnNum].Snoop, dnsentry)
-					log.Debugf("!!--FlowStats: DNS collected for %s, bridge Number %d", string(dnsQ.Name), bnNum)
+					log.Tracef("!!--FlowStats: DNS collected for %s, bridge Number %d", string(dnsQ.Name), bnNum)
 					break
 				}
 			}

--- a/pkg/pillar/cmd/zedrouter/hostsdir.go
+++ b/pkg/pillar/cmd/zedrouter/hostsdir.go
@@ -17,7 +17,7 @@ import (
 // Would be more polite to return an error then to Fatal
 func createHostsConfiglet(cfgDirname string, nameToIPList []types.DnsNameToIP) {
 
-	log.Infof("createHostsConfiglet: dir %s nameToIPList %v\n",
+	log.Functionf("createHostsConfiglet: dir %s nameToIPList %v\n",
 		cfgDirname, nameToIPList)
 	ensureDir(cfgDirname)
 
@@ -27,10 +27,10 @@ func createHostsConfiglet(cfgDirname string, nameToIPList []types.DnsNameToIP) {
 }
 
 func ensureDir(dirname string) {
-	log.Infof("ensureDir(%s)\n", dirname)
+	log.Functionf("ensureDir(%s)\n", dirname)
 	st, err := os.Stat(dirname)
 	if err != nil {
-		log.Infof("ensureDir creating %s\n", dirname)
+		log.Functionf("ensureDir creating %s\n", dirname)
 		err := os.MkdirAll(dirname, 0755)
 		if err != nil {
 			log.Fatalf("ensureDir failed %s\n", err)
@@ -42,13 +42,13 @@ func ensureDir(dirname string) {
 	if ok {
 		inode = stat.Ino
 	}
-	log.Infof("ensureDir(%s) DONE inode %d\n", dirname, inode)
+	log.Functionf("ensureDir(%s) DONE inode %d\n", dirname, inode)
 }
 
 // Create one file per hostname
 func addIPToHostsConfiglet(cfgDirname string, hostname string, addrs []net.IP) {
 
-	log.Infof("addIPToHostsConfiglet(%s, %s, %v)\n", cfgDirname, hostname,
+	log.Functionf("addIPToHostsConfiglet(%s, %s, %v)\n", cfgDirname, hostname,
 		addrs)
 	ensureDir(cfgDirname)
 	cfgPathname := cfgDirname + "/" + hostname
@@ -67,7 +67,7 @@ func addIPToHostsConfiglet(cfgDirname string, hostname string, addrs []net.IP) {
 // Create one file per hostname
 func addToHostsConfiglet(cfgDirname string, hostname string, addrs []string) {
 
-	log.Infof("addToHostsConfiglet(%s, %s, %v)\n", cfgDirname, hostname,
+	log.Functionf("addToHostsConfiglet(%s, %s, %v)\n", cfgDirname, hostname,
 		addrs)
 	ensureDir(cfgDirname)
 	cfgPathname := cfgDirname + "/" + hostname
@@ -83,7 +83,7 @@ func addToHostsConfiglet(cfgDirname string, hostname string, addrs []string) {
 }
 
 func removeFromHostsConfiglet(cfgDirname string, hostname string) {
-	log.Infof("removeFromHostsConfiglet(%s, %s)\n", cfgDirname, hostname)
+	log.Functionf("removeFromHostsConfiglet(%s, %s)\n", cfgDirname, hostname)
 	cfgPathname := cfgDirname + "/" + hostname
 	if err := os.Remove(cfgPathname); err != nil {
 		log.Errorln("removeFromHostsConfiglet: ", err)
@@ -113,13 +113,13 @@ func containsIP(nameToIPList []types.DnsNameToIP, ip net.IP) bool {
 func updateHostsConfiglet(cfgDirname string,
 	oldList []types.DnsNameToIP, newList []types.DnsNameToIP) {
 
-	log.Infof("updateHostsConfiglet: dir %s old %v, new %v\n",
+	log.Functionf("updateHostsConfiglet: dir %s old %v, new %v\n",
 		cfgDirname, oldList, newList)
 	ensureDir(cfgDirname)
 	// Look for hosts which should be deleted
 	for _, ne := range oldList {
 		if !containsHostName(newList, ne.HostName) {
-			log.Infof("updateHostsConfiglet removing %s\n",
+			log.Functionf("updateHostsConfiglet removing %s\n",
 				ne.HostName)
 			cfgPathname := cfgDirname + "/" + ne.HostName
 			if err := os.Remove(cfgPathname); err != nil {
@@ -130,10 +130,10 @@ func updateHostsConfiglet(cfgDirname string,
 
 	for _, ne := range newList {
 		if !containsHostName(oldList, ne.HostName) {
-			log.Infof("updateHostsConfiglet adding %s %v\n",
+			log.Functionf("updateHostsConfiglet adding %s %v\n",
 				ne.HostName, ne.IPs)
 		} else {
-			log.Infof("updateHostsConfiglet updating %s %v\n",
+			log.Functionf("updateHostsConfiglet updating %s %v\n",
 				ne.HostName, ne.IPs)
 		}
 		cfgPathname := cfgDirname + "/" + ne.HostName
@@ -152,7 +152,7 @@ func updateHostsConfiglet(cfgDirname string,
 
 func deleteHostsConfiglet(cfgDirname string, printOnError bool) {
 
-	log.Infof("deleteHostsConfiglet: dir %s\n", cfgDirname)
+	log.Functionf("deleteHostsConfiglet: dir %s\n", cfgDirname)
 	ensureDir(cfgDirname)
 	err := RemoveDirContent(cfgDirname)
 	if err != nil && printOnError {

--- a/pkg/pillar/cmd/zedrouter/ifindex.go
+++ b/pkg/pillar/cmd/zedrouter/ifindex.go
@@ -30,26 +30,26 @@ func IfindexToNameAdd(log *base.LogObject, index int, linkName string, linkType 
 	if !ok {
 		// Note that we get RTM_NEWLINK even for link changes
 		// hence we don't print unless the entry is new
-		log.Infof("IfindexToNameAdd index %d name %s type %s\n",
+		log.Functionf("IfindexToNameAdd index %d name %s type %s\n",
 			index, linkName, linkType)
 		ifindexToName[index] = linkNameType{
 			linkName: linkName,
 			linkType: linkType,
 		}
 		ifindexMaybeRemoveOld(log, index, linkName)
-		// log.Debugf("ifindexToName post add %v\n", ifindexToName)
+		// log.Tracef("ifindexToName post add %v\n", ifindexToName)
 		return true
 	} else if m.linkName != linkName {
 		// We get this when the vifs are created with "vif*" names
 		// and then changed to "bu*" etc.
-		log.Infof("IfindexToNameAdd name mismatch %s vs %s for %d\n",
+		log.Functionf("IfindexToNameAdd name mismatch %s vs %s for %d\n",
 			m.linkName, linkName, index)
 		ifindexToName[index] = linkNameType{
 			linkName: linkName,
 			linkType: linkType,
 		}
 		ifindexMaybeRemoveOld(log, index, linkName)
-		// log.Debugf("ifindexToName post add %v\n", ifindexToName)
+		// log.Tracef("ifindexToName post add %v\n", ifindexToName)
 		return false
 	} else {
 		return false
@@ -60,7 +60,7 @@ func IfindexToNameAdd(log *base.LogObject, index int, linkName string, linkType 
 func ifindexMaybeRemoveOld(log *base.LogObject, newIndex int, ifname string) {
 	for index, lnt := range ifindexToName {
 		if lnt.linkName == ifname && index != newIndex {
-			log.Infof("Found old ifindex %d for new %d for %s",
+			log.Functionf("Found old ifindex %d for new %d for %s",
 				index, newIndex, ifname)
 			delete(ifindexToName, index)
 			return
@@ -80,13 +80,13 @@ func IfindexToNameDel(log *base.LogObject, index int, linkName string) bool {
 		log.Errorf("IfindexToNameDel name mismatch %s vs %s for %d\n",
 			m.linkName, linkName, index)
 		delete(ifindexToName, index)
-		// log.Debugf("ifindexToName post delete %v\n", ifindexToName)
+		// log.Tracef("ifindexToName post delete %v\n", ifindexToName)
 		return true
 	} else {
-		log.Debugf("IfindexToNameDel index %d name %s\n",
+		log.Tracef("IfindexToNameDel index %d name %s\n",
 			index, linkName)
 		delete(ifindexToName, index)
-		// log.Debugf("ifindexToName post delete %v\n", ifindexToName)
+		// log.Tracef("ifindexToName post delete %v\n", ifindexToName)
 		return true
 	}
 }
@@ -154,7 +154,7 @@ func RelevantLastResort(log *base.LogObject, link netlink.Link) (bool, bool) {
 	if linkType == "device" && !loopbackFlag && broadcastFlag &&
 		attrs.MasterIndex == 0 && !isVif {
 
-		log.Infof("Relevant %s adminUp %t operState %s\n",
+		log.Functionf("Relevant %s adminUp %t operState %s\n",
 			ifname, adminUpFlag, attrs.OperState.String())
 		return true, upFlag
 	} else {
@@ -170,12 +170,12 @@ var ifindexToAddrs = make(map[int][]net.IP)
 // if it doesn't already exist
 // Returns true if added
 func IfindexToAddrsAdd(log *base.LogObject, index int, addr net.IP) bool {
-	log.Debugf("IfindexToAddrsAdd(%d, %s)", index, addr.String())
+	log.Tracef("IfindexToAddrsAdd(%d, %s)", index, addr.String())
 	addrs, ok := ifindexToAddrs[index]
 	if !ok {
-		log.Debugf("IfindexToAddrsAdd add %v for %d\n", addr, index)
+		log.Tracef("IfindexToAddrsAdd add %v for %d\n", addr, index)
 		ifindexToAddrs[index] = append(ifindexToAddrs[index], addr)
-		// log.Debugf("ifindexToAddrs post add %v\n", ifindexToAddrs)
+		// log.Tracef("ifindexToAddrs post add %v\n", ifindexToAddrs)
 		return true
 	}
 	found := false
@@ -186,9 +186,9 @@ func IfindexToAddrsAdd(log *base.LogObject, index int, addr net.IP) bool {
 		}
 	}
 	if !found {
-		log.Debugf("IfindexToAddrsAdd add %v for %d\n", addr, index)
+		log.Tracef("IfindexToAddrsAdd add %v for %d\n", addr, index)
 		ifindexToAddrs[index] = append(ifindexToAddrs[index], addr)
-		// log.Debugf("ifindexToAddrs post add %v\n", ifindexToAddrs)
+		// log.Tracef("ifindexToAddrs post add %v\n", ifindexToAddrs)
 	}
 	return !found
 }
@@ -196,7 +196,7 @@ func IfindexToAddrsAdd(log *base.LogObject, index int, addr net.IP) bool {
 // IfindexToAddrsDel removes from the map based on the ifindex and address
 // Returns true if deleted
 func IfindexToAddrsDel(log *base.LogObject, index int, addr net.IP) bool {
-	log.Debugf("IfindexToAddrsDel(%d, %s)", index, addr.String())
+	log.Tracef("IfindexToAddrsDel(%d, %s)", index, addr.String())
 	addrs, ok := ifindexToAddrs[index]
 	if !ok {
 		log.Warnf("IfindexToAddrsDel unknown index %d\n", index)
@@ -204,7 +204,7 @@ func IfindexToAddrsDel(log *base.LogObject, index int, addr net.IP) bool {
 	}
 	for i, a := range addrs {
 		if a.Equal(addr) {
-			log.Debugf("IfindexToAddrsDel del %v for %d\n",
+			log.Tracef("IfindexToAddrsDel del %v for %d\n",
 				addr, index)
 			if i+1 == len(addrs) {
 				ifindexToAddrs[index] = ifindexToAddrs[index][:i]
@@ -212,7 +212,7 @@ func IfindexToAddrsDel(log *base.LogObject, index int, addr net.IP) bool {
 				ifindexToAddrs[index] = append(ifindexToAddrs[index][:i],
 					ifindexToAddrs[index][i+1:]...)
 			}
-			// log.Debugf("ifindexToAddrs post remove %v\n", ifindexToAddrs)
+			// log.Tracef("ifindexToAddrs post remove %v\n", ifindexToAddrs)
 			// XXX should we check for zero and remove ifindex?
 			return true
 		}
@@ -238,7 +238,7 @@ func IfindexToAddrsFlush(log *base.LogObject, index int) {
 		log.Warnf("IfindexToAddrsFlush: Unknown ifindex %d", index)
 		return
 	}
-	log.Infof("IfindexToAddrsFlush(%d) removing %v",
+	log.Functionf("IfindexToAddrsFlush(%d) removing %v",
 		index, ifindexToAddrs[index])
 	var addrs []net.IP
 	ifindexToAddrs[index] = addrs
@@ -246,7 +246,7 @@ func IfindexToAddrsFlush(log *base.LogObject, index int) {
 
 // IfnameToAddrsFlush does the above flush but based on ifname
 func IfnameToAddrsFlush(log *base.LogObject, ifname string) {
-	log.Infof("IfNameToAddrsFlush(%s)", ifname)
+	log.Functionf("IfNameToAddrsFlush(%s)", ifname)
 	index, err := IfnameToIndex(log, ifname)
 	if err != nil {
 		log.Warnf("IfnameToAddrsFlush: Unknown ifname %s: %s", ifname, err)

--- a/pkg/pillar/cmd/zedrouter/ipsec.go
+++ b/pkg/pillar/cmd/zedrouter/ipsec.go
@@ -112,7 +112,7 @@ func ipSecActivate(vpnConfig types.VpnConfig) error {
 		log.Errorf("%s for %s start\n", err.Error(), "ipsec")
 		return err
 	}
-	log.Infof("ipSec(%s) start OK\n", tunnelConfig.Name)
+	log.Functionf("ipSec(%s) start OK\n", tunnelConfig.Name)
 	return nil
 }
 
@@ -121,7 +121,7 @@ func ipSecInactivate(vpnConfig types.VpnConfig) error {
 		log.Errorf("%s for %s stop\n", err.Error(), "ipsec")
 		return err
 	}
-	log.Infof("ipSec stop OK\n")
+	log.Functionf("ipSec stop OK\n")
 	return nil
 }
 
@@ -131,7 +131,7 @@ func ipSecStatus() (string, error) {
 		log.Errorf("%s for %s status\n", err.Error(), "ipsec")
 		return "", err
 	}
-	log.Infof("ipSec() status %s\n", string(out))
+	log.Functionf("ipSec() status %s\n", string(out))
 	return string(out), nil
 }
 
@@ -140,7 +140,7 @@ func ipSecTunnelStateCheck(vpnRole string, tunnelName string) error {
 	if err := checkIpSecStatusCmd(tunnelName); err != nil {
 		return err
 	}
-	log.Infof("%s IpSec Tunnel State OK\n", tunnelName)
+	log.Functionf("%s IpSec Tunnel State OK\n", tunnelName)
 	return nil
 }
 
@@ -211,7 +211,7 @@ func ipTablesAwsClientRulesSet(tunnelName string,
 		return err
 	}
 
-	log.Infof("ipTablesAwsClientRuleSet(%s) OK\n", tunnelName)
+	log.Functionf("ipTablesAwsClientRuleSet(%s) OK\n", tunnelName)
 	return nil
 }
 
@@ -236,7 +236,7 @@ func ipTablesAwsClientRulesReset(tunnelName string,
 			err.Error(), "iptables", tunnelName)
 		return err
 	}
-	log.Infof("ipTablesAwsClientRulesReset(%s) OK\n", tunnelName)
+	log.Functionf("ipTablesAwsClientRulesReset(%s) OK\n", tunnelName)
 	return nil
 }
 
@@ -248,7 +248,7 @@ func ipTablesCounterRulesSet(policyBased bool,
 			return err
 		}
 	}
-	log.Infof("ipTablesCounterRuleSet(%s) OK\n", tunnelName)
+	log.Functionf("ipTablesCounterRuleSet(%s) OK\n", tunnelName)
 	return nil
 }
 
@@ -260,7 +260,7 @@ func ipTablesCounterRulesReset(policyBased bool,
 			return err
 		}
 	}
-	log.Infof("ipTablesCounterRulesReset(%s) OK\n", tunnelName)
+	log.Functionf("ipTablesCounterRulesReset(%s) OK\n", tunnelName)
 	return nil
 }
 
@@ -389,13 +389,13 @@ func ipTablesRuleCheck(vpnConfig types.VpnConfig) error {
 			"INPUT", gatewayConfig.IpAddr+"/32"); err != nil {
 			return err
 		}
-		log.Infof("pTable(%s) check OK\n", tunnelConfig.Name)
+		log.Functionf("pTable(%s) check OK\n", tunnelConfig.Name)
 	case AzureVpnClient:
-		log.Infof("ipTable(%s) check OK\n", tunnelConfig.Name)
+		log.Functionf("ipTable(%s) check OK\n", tunnelConfig.Name)
 	case OnPremVpnClient:
-		log.Infof("ipTable(%s) check OK\n", tunnelConfig.Name)
+		log.Functionf("ipTable(%s) check OK\n", tunnelConfig.Name)
 	case OnPremVpnServer:
-		log.Infof("ipTable(%s) check OK\n", tunnelConfig.Name)
+		log.Functionf("ipTable(%s) check OK\n", tunnelConfig.Name)
 	}
 	return nil
 }
@@ -451,7 +451,7 @@ func ipRouteCreate(vpnConfig types.VpnConfig) error {
 				err.Error(), "iproute", gatewayConfig.SubnetBlock)
 			return err
 		}
-		log.Infof("ipRoute(%s) add OK\n", tunnelConfig.Name)
+		log.Functionf("ipRoute(%s) add OK\n", tunnelConfig.Name)
 	} else {
 		// for server config, create all client subnet block routes
 		for _, clientConfig := range vpnConfig.ClientConfigList {
@@ -462,7 +462,7 @@ func ipRouteCreate(vpnConfig types.VpnConfig) error {
 					err.Error(), "iproute", clientConfig.SubnetBlock)
 				return err
 			}
-			log.Infof("ipRoute(%s) %s add OK\n",
+			log.Functionf("ipRoute(%s) %s add OK\n",
 				tunnelConfig.Name, clientConfig.SubnetBlock)
 		}
 	}
@@ -486,7 +486,7 @@ func ipRouteDelete(vpnConfig types.VpnConfig) error {
 					err.Error(), "iproute", gatewayConfig.SubnetBlock)
 				return err
 			}
-			log.Infof("ipRoute(%s) %s delete OK\n", tunnelConfig.Name,
+			log.Functionf("ipRoute(%s) %s delete OK\n", tunnelConfig.Name,
 				gatewayConfig.SubnetBlock)
 		}
 	} else {
@@ -499,7 +499,7 @@ func ipRouteDelete(vpnConfig types.VpnConfig) error {
 					err.Error(), "iproute", clientConfig.SubnetBlock)
 				return err
 			}
-			log.Infof("ipRoute(%s) %s delete OK\n",
+			log.Functionf("ipRoute(%s) %s delete OK\n",
 				tunnelConfig.Name, clientConfig.SubnetBlock)
 		}
 	}
@@ -528,7 +528,7 @@ func ipRouteCheck(vpnConfig types.VpnConfig) error {
 			log.Errorf("%s for ipRoute(%s) check fail\n", err, tunnelConfig.Name)
 			return err
 		}
-		log.Infof("ipRoute(%s) check OK\n", tunnelConfig.Name)
+		log.Functionf("ipRoute(%s) check OK\n", tunnelConfig.Name)
 	} else {
 		// for server config, check all client subnet block routes
 		for _, clientConfig := range vpnConfig.ClientConfigList {
@@ -545,7 +545,7 @@ func ipRouteCheck(vpnConfig types.VpnConfig) error {
 					err, tunnelConfig.Name)
 				return err
 			}
-			log.Infof("ipRoute(%s) %s check OK\n",
+			log.Functionf("ipRoute(%s) %s check OK\n",
 				tunnelConfig.Name, clientConfig.SubnetBlock)
 		}
 	}
@@ -575,7 +575,7 @@ func ipLinkTunnelCreate(vpnConfig types.VpnConfig) error {
 	tunnelConfig := clientConfig.TunnelConfig
 	portConfig := vpnConfig.PortConfig
 
-	log.Infof("%s: %s %s %s\n", tunnelConfig.Name, "ip link add",
+	log.Functionf("%s: %s %s %s\n", tunnelConfig.Name, "ip link add",
 		portConfig.IpAddr, gatewayConfig.IpAddr)
 	if vpnConfig.IsClient {
 		if _, err := base.Exec(log, "ip", "link", "add",
@@ -597,7 +597,7 @@ func ipLinkTunnelCreate(vpnConfig types.VpnConfig) error {
 	}
 
 	if vpnConfig.VpnRole == AwsVpnClient {
-		log.Infof("%s: %s %s %s\n", tunnelConfig.Name, "ip link addr",
+		log.Functionf("%s: %s %s %s\n", tunnelConfig.Name, "ip link addr",
 			tunnelConfig.LocalIpAddr, tunnelConfig.RemoteIpAddr)
 		if _, err := base.Exec(log, "ip", "addr", "add",
 			tunnelConfig.LocalIpAddr, "remote", tunnelConfig.RemoteIpAddr,
@@ -609,7 +609,7 @@ func ipLinkTunnelCreate(vpnConfig types.VpnConfig) error {
 		}
 	}
 
-	log.Infof("%s: %s %s\n", tunnelConfig.Name, "ip link mtu",
+	log.Functionf("%s: %s %s\n", tunnelConfig.Name, "ip link mtu",
 		tunnelConfig.Mtu)
 	if _, err := base.Exec(log, "ip", "link", "set",
 		tunnelConfig.Name, "up", "mtu", tunnelConfig.Mtu).Output(); err != nil {
@@ -618,7 +618,7 @@ func ipLinkTunnelCreate(vpnConfig types.VpnConfig) error {
 		return err
 	}
 
-	log.Infof("ipLink(%s) add OK\n", tunnelConfig.Name)
+	log.Functionf("ipLink(%s) add OK\n", tunnelConfig.Name)
 	return nil
 }
 
@@ -639,7 +639,7 @@ func ipLinkTunnelDelete(vpnConfig types.VpnConfig) error {
 			err.Error(), "ip link", tunnelConfig.Name)
 		return err
 	}
-	log.Infof("ipLink(%s) delete OK\n", tunnelConfig.Name)
+	log.Functionf("ipLink(%s) delete OK\n", tunnelConfig.Name)
 	return nil
 }
 
@@ -665,7 +665,7 @@ func ipLinkIntfStateCheck(tunnelName string) error {
 	if err := checkIntfStateCmd(tunnelName); err != nil {
 		return err
 	}
-	log.Infof("ipLink(%s) check OK\n", tunnelName)
+	log.Functionf("ipLink(%s) check OK\n", tunnelName)
 	return nil
 }
 
@@ -717,7 +717,7 @@ func ipSecConfigCreate(vpnConfig types.VpnConfig) error {
 		wildMatch := false
 		for _, clientConfig := range clientConfigList {
 			if match := isClientWildCard(clientConfig); match {
-				log.Infof("wildCard Client %s\n", clientConfig.IpAddr)
+				log.Functionf("wildCard Client %s\n", clientConfig.IpAddr)
 				if wildMatch {
 					continue
 				}
@@ -742,7 +742,7 @@ func ipSecConfigCreate(vpnConfig types.VpnConfig) error {
 		log.Errorf("%s for %s %s\n", err.Error(), "chmod", filename)
 		return err
 	}
-	log.Infof("ipSecConfigWrite(%s) OK\n", gatewayConfig.IpAddr)
+	log.Functionf("ipSecConfigWrite(%s) OK\n", gatewayConfig.IpAddr)
 	return nil
 }
 
@@ -761,7 +761,7 @@ func ipSecSecretConfigCreate(vpnConfig types.VpnConfig) error {
 	wildMatch := false
 	for _, clientConfig := range clientConfigList {
 		if match := isClientWildCard(clientConfig); match {
-			log.Infof("wildCard Client %s\n", clientConfig.IpAddr)
+			log.Functionf("wildCard Client %s\n", clientConfig.IpAddr)
 			// contains the preshared key
 			if clientConfig.PreSharedKey == "" ||
 				wildMatch {
@@ -789,7 +789,7 @@ func ipSecSecretConfigCreate(vpnConfig types.VpnConfig) error {
 		log.Errorf("%s for %s %s\n", err.Error(), "chmod", filename)
 		return err
 	}
-	log.Infof("ipSecSecretWrite(%s) OK\n", gatewayConfig.IpAddr)
+	log.Functionf("ipSecSecretWrite(%s) OK\n", gatewayConfig.IpAddr)
 	return nil
 }
 
@@ -815,7 +815,7 @@ func charonConfigReset() error {
 func sysctlConfigCreate(vpnConfig types.VpnConfig) error {
 
 	portConfig := vpnConfig.PortConfig
-	log.Infof("%s: %s config\n", portConfig.IfName, "sysctl")
+	log.Functionf("%s: %s config\n", portConfig.IfName, "sysctl")
 
 	writeStr := ""
 	if vpnConfig.PolicyBased {
@@ -826,7 +826,7 @@ func sysctlConfigCreate(vpnConfig types.VpnConfig) error {
 		writeStr = writeStr + "\n net.ipv4.conf." + portConfig.IfName + ".disable_policy=1\n"
 		for _, clientConfig := range vpnConfig.ClientConfigList {
 			tunnelConfig := clientConfig.TunnelConfig
-			log.Infof("%s: %s config\n", tunnelConfig.Name, "sysctl")
+			log.Functionf("%s: %s config\n", tunnelConfig.Name, "sysctl")
 			writeStr = writeStr + "\n net.ipv4.conf." + tunnelConfig.Name + ".rp_filter=2"
 			writeStr = writeStr + "\n net.ipv4.conf." + tunnelConfig.Name + ".disable_policy=1"
 		}
@@ -836,7 +836,7 @@ func sysctlConfigCreate(vpnConfig types.VpnConfig) error {
 		log.Errorf("sysctlConfigWrite() Fail\n")
 		return err
 	}
-	log.Infof("sysctlConfigWrite() OK\n")
+	log.Functionf("sysctlConfigWrite() OK\n")
 	return nil
 }
 
@@ -850,7 +850,7 @@ func sysctlConfigSet() error {
 		log.Errorf("%s for %s set \n", err.Error(), "sysctl")
 		return err
 	}
-	log.Infof("sysctlConfigSet() OK\n")
+	log.Functionf("sysctlConfigSet() OK\n")
 	return nil
 }
 

--- a/pkg/pillar/cmd/zedrouter/ipset.go
+++ b/pkg/pillar/cmd/zedrouter/ipset.go
@@ -17,7 +17,7 @@ import (
 // XXX should we add 169.254.0.0/16 as well?
 func createDefaultIpset() {
 
-	log.Debugf("createDefaultIpset()\n")
+	log.Tracef("createDefaultIpset()\n")
 	ipsetName := "local"
 	err := ipsetCreatePair(ipsetName, "hash:net")
 	if err != nil {
@@ -48,7 +48,7 @@ func createDefaultIpset() {
 func createDefaultIpsetConfiglet(vifname string, nameToIPList []types.DnsNameToIP,
 	appIPAddr string) {
 
-	log.Debugf("createDefaultIpsetConfiglet: olifName %s nameToIPList %v appIPAddr %s\n",
+	log.Tracef("createDefaultIpsetConfiglet: olifName %s nameToIPList %v appIPAddr %s\n",
 		vifname, nameToIPList, appIPAddr)
 	ipsetName := "eids." + vifname
 	err := ipsetCreatePair(ipsetName, "hash:ip")
@@ -103,7 +103,7 @@ func createDefaultIpsetConfiglet(vifname string, nameToIPList []types.DnsNameToI
 func updateDefaultIpsetConfiglet(vifname string,
 	oldList []types.DnsNameToIP, newList []types.DnsNameToIP) {
 
-	log.Debugf("updateDefaultIpsetConfiglet: vifname %s old %v, new %v\n",
+	log.Tracef("updateDefaultIpsetConfiglet: vifname %s old %v, new %v\n",
 		vifname, oldList, newList)
 	ipsetName := "eids." + vifname
 	set4 := "ipv4." + ipsetName
@@ -150,7 +150,7 @@ func updateDefaultIpsetConfiglet(vifname string,
 
 func deleteDefaultIpsetConfiglet(vifname string, printOnError bool) {
 
-	log.Debugf("deleteDefaultIpsetConfiglet: vifname %s\n", vifname)
+	log.Tracef("deleteDefaultIpsetConfiglet: vifname %s\n", vifname)
 	ipsetName := "eids." + vifname
 	set4 := "ipv4." + ipsetName
 	set6 := "ipv6." + ipsetName
@@ -199,7 +199,7 @@ func ipsetCreate(ipsetName string, setType string, ipVer int) error {
 		family = "inet6"
 	}
 	args := []string{"create", ipsetName, setType, "family", family}
-	log.Infof("Calling command %s %v\n", cmd, args)
+	log.Functionf("Calling command %s %v\n", cmd, args)
 	if _, err := base.Exec(log, cmd, args...).CombinedOutput(); err != nil {
 		return err
 	}
@@ -209,7 +209,7 @@ func ipsetCreate(ipsetName string, setType string, ipVer int) error {
 func ipsetDestroy(ipsetName string) error {
 	cmd := "ipset"
 	args := []string{"destroy", ipsetName}
-	log.Infof("Calling command %s %v\n", cmd, args)
+	log.Functionf("Calling command %s %v\n", cmd, args)
 	if res, err := base.Exec(log, cmd, args...).CombinedOutput(); err != nil {
 		errStr := fmt.Sprintf("ipset destroy %s failed %s: %s",
 			ipsetName, res, err)
@@ -221,7 +221,7 @@ func ipsetDestroy(ipsetName string) error {
 func ipsetFlush(ipsetName string) error {
 	cmd := "ipset"
 	args := []string{"flush", ipsetName}
-	log.Infof("Calling command %s %v\n", cmd, args)
+	log.Functionf("Calling command %s %v\n", cmd, args)
 	if res, err := base.Exec(log, cmd, args...).CombinedOutput(); err != nil {
 		errStr := fmt.Sprintf("ipset flush %s failed %s: %s",
 			ipsetName, res, err)
@@ -233,7 +233,7 @@ func ipsetFlush(ipsetName string) error {
 func ipsetAdd(ipsetName string, member string) error {
 	cmd := "ipset"
 	args := []string{"add", ipsetName, member}
-	log.Infof("Calling command %s %v\n", cmd, args)
+	log.Functionf("Calling command %s %v\n", cmd, args)
 	if res, err := base.Exec(log, cmd, args...).CombinedOutput(); err != nil {
 		errStr := fmt.Sprintf("ipset add %s failed %s: %s",
 			ipsetName, res, err)
@@ -245,7 +245,7 @@ func ipsetAdd(ipsetName string, member string) error {
 func ipsetDel(ipsetName string, member string) error {
 	cmd := "ipset"
 	args := []string{"del", ipsetName, member}
-	log.Infof("Calling command %s %v\n", cmd, args)
+	log.Functionf("Calling command %s %v\n", cmd, args)
 	if res, err := base.Exec(log, cmd, args...).CombinedOutput(); err != nil {
 		errStr := fmt.Sprintf("ipset del %s failed %s: %s",
 			ipsetName, res, err)
@@ -257,7 +257,7 @@ func ipsetDel(ipsetName string, member string) error {
 func ipsetExists(ipsetName string) bool {
 	cmd := "ipset"
 	args := []string{"list", ipsetName}
-	log.Infof("Calling command %s %v\n", cmd, args)
+	log.Functionf("Calling command %s %v\n", cmd, args)
 	if _, err := base.Exec(log, cmd, args...).Output(); err != nil {
 		return false
 	}

--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -58,18 +58,18 @@ func checkPortAvailable(
 	ctx *zedrouterContext,
 	status *types.NetworkInstanceStatus) error {
 
-	log.Infof("NetworkInstance(%s-%s), logicallabel: %s, currentUplinkIntf: %s",
+	log.Functionf("NetworkInstance(%s-%s), logicallabel: %s, currentUplinkIntf: %s",
 		status.DisplayName, status.UUID, status.Logicallabel,
 		status.CurrentUplinkIntf)
 
 	if status.CurrentUplinkIntf == "" {
-		log.Infof("CurrentUplinkIntf not specified\n")
+		log.Functionf("CurrentUplinkIntf not specified\n")
 		return nil
 	}
 
 	if allowSharedPort(status) {
 		if isSharedPortLabel(status.CurrentUplinkIntf) {
-			log.Infof("allowSharedPort: %t, isSharedPortLabel:%t",
+			log.Functionf("allowSharedPort: %t, isSharedPortLabel:%t",
 				allowSharedPort(status), isSharedPortLabel(status.CurrentUplinkIntf))
 			return nil
 		}
@@ -142,7 +142,7 @@ func checkPortAvailable(
 func disableIcmpRedirects(bridgeName string) {
 	sysctlSetting := fmt.Sprintf("net.ipv4.conf.%s.send_redirects=0", bridgeName)
 	args := []string{"-w", sysctlSetting}
-	log.Infof("Calling command %s %v\n", "sysctl", args)
+	log.Functionf("Calling command %s %v\n", "sysctl", args)
 	out, err := base.Exec(log, "sysctl", args...).CombinedOutput()
 	if err != nil {
 		errStr := fmt.Sprintf("sysctl command %s failed %s output %s",
@@ -349,7 +349,7 @@ func doBridgeAclsDelete(
 			if ulStatus.Bridge == "" {
 				continue
 			}
-			log.Infof("NetworkInstance - deleting Acls for UL Interface(%s)",
+			log.Functionf("NetworkInstance - deleting Acls for UL Interface(%s)",
 				ulStatus.Name)
 			aclArgs := types.AppNetworkACLArgs{IsMgmt: false, BridgeName: ulStatus.Bridge,
 				VifName: ulStatus.Vif, BridgeIP: ulStatus.BridgeIPAddr, AppIP: ulStatus.AllocatedIPAddr,
@@ -403,14 +403,14 @@ func handleNetworkInstanceModify(
 	config := configArg.(types.NetworkInstanceConfig)
 	status := lookupNetworkInstanceStatus(ctx, key)
 	if status != nil {
-		log.Infof("handleNetworkInstanceModify(%s)\n", key)
+		log.Functionf("handleNetworkInstanceModify(%s)\n", key)
 		status.ChangeInProgress = types.ChangeInProgressTypeModify
 		pub.Publish(status.Key(), *status)
 		doNetworkInstanceModify(ctx, config, status)
 		niUpdateNIprobing(ctx, status)
 		status.ChangeInProgress = types.ChangeInProgressTypeNone
 		publishNetworkInstanceStatus(ctx, status)
-		log.Infof("handleNetworkInstanceModify(%s) done\n", key)
+		log.Functionf("handleNetworkInstanceModify(%s) done\n", key)
 	} else {
 		log.Fatalf("handleNetworkInstanceModify(%s) no status", key)
 	}
@@ -424,7 +424,7 @@ func handleNetworkInstanceCreate(
 	ctx := ctxArg.(*zedrouterContext)
 	config := configArg.(types.NetworkInstanceConfig)
 
-	log.Infof("handleNetworkInstanceCreate: (UUID: %s, name:%s)\n",
+	log.Functionf("handleNetworkInstanceCreate: (UUID: %s, name:%s)\n",
 		key, config.DisplayName)
 
 	pub := ctx.pubNetworkInstanceStatus
@@ -456,14 +456,14 @@ func handleNetworkInstanceCreate(
 	pub.Publish(status.Key(), status)
 
 	if config.Activate {
-		log.Infof("handleNetworkInstanceCreate: Activating network instance")
+		log.Functionf("handleNetworkInstanceCreate: Activating network instance")
 		err := doNetworkInstanceActivate(ctx, &status)
 		if err != nil {
 			log.Errorf("doNetworkInstanceActivate(%s) failed: %s\n", key, err)
 			log.Error(err)
 			status.SetErrorNow(err.Error())
 		} else {
-			log.Infof("Activated network instance %s %s", status.UUID, status.DisplayName)
+			log.Functionf("Activated network instance %s %s", status.UUID, status.DisplayName)
 			status.Activated = true
 		}
 	}
@@ -472,18 +472,18 @@ func handleNetworkInstanceCreate(
 	publishNetworkInstanceStatus(ctx, &status)
 	// Hooks for updating dependent objects
 	checkAndRecreateAppNetwork(ctx, config.UUID)
-	log.Infof("handleNetworkInstanceCreate(%s) done\n", key)
+	log.Functionf("handleNetworkInstanceCreate(%s) done\n", key)
 }
 
 func handleNetworkInstanceDelete(ctxArg interface{}, key string,
 	configArg interface{}) {
 
-	log.Infof("handleNetworkInstanceDelete(%s)\n", key)
+	log.Functionf("handleNetworkInstanceDelete(%s)\n", key)
 	ctx := ctxArg.(*zedrouterContext)
 	pub := ctx.pubNetworkInstanceStatus
 	status := lookupNetworkInstanceStatus(ctx, key)
 	if status == nil {
-		log.Infof("handleNetworkInstanceDelete: unknown %s\n", key)
+		log.Functionf("handleNetworkInstanceDelete: unknown %s\n", key)
 		return
 	}
 	status.ChangeInProgress = types.ChangeInProgressTypeDelete
@@ -496,13 +496,13 @@ func handleNetworkInstanceDelete(ctxArg interface{}, key string,
 	pub.Unpublish(status.Key())
 
 	deleteNetworkInstanceMetrics(ctx, status.Key())
-	log.Infof("handleNetworkInstanceDelete(%s) done\n", key)
+	log.Functionf("handleNetworkInstanceDelete(%s) done\n", key)
 }
 
 func doNetworkInstanceCreate(ctx *zedrouterContext,
 	status *types.NetworkInstanceStatus) error {
 
-	log.Infof("NetworkInstance(%s-%s): NetworkType: %d, IpType: %d\n",
+	log.Functionf("NetworkInstance(%s-%s): NetworkType: %d, IpType: %d\n",
 		status.DisplayName, status.UUID, status.Type, status.IpType)
 
 	if err := doNetworkInstanceSanityCheck(ctx, status); err != nil {
@@ -526,12 +526,12 @@ func doNetworkInstanceCreate(ctx *zedrouterContext,
 	status.BridgeMac = bridgeMac
 	publishNetworkInstanceStatus(ctx, status)
 
-	log.Infof("bridge created. BridgeMac: %s\n", bridgeMac)
+	log.Functionf("bridge created. BridgeMac: %s\n", bridgeMac)
 
 	if err := setBridgeIPAddr(ctx, status); err != nil {
 		return err
 	}
-	log.Infof("IpAddress set for bridge\n")
+	log.Functionf("IpAddress set for bridge\n")
 
 	// Create a hosts directory for the new bridge
 	// Directory is /run/zedrouter/hosts.${BRIDGENAME}
@@ -561,7 +561,7 @@ func doNetworkInstanceCreate(ctx *zedrouterContext,
 	}
 
 	// monitor the DNS and DHCP information
-	log.Infof("Creating %s at %s", "DNSMonitor", agentlog.GetMyStack())
+	log.Functionf("Creating %s at %s", "DNSMonitor", agentlog.GetMyStack())
 	go DNSMonitor(bridgeName, bridgeNum, ctx, status)
 
 	if status.IsIPv6() {
@@ -586,7 +586,7 @@ func doNetworkInstanceSanityCheck(
 	ctx *zedrouterContext,
 	status *types.NetworkInstanceStatus) error {
 
-	log.Infof("Sanity Checking NetworkInstance(%s-%s): type:%d, IpType:%d\n",
+	log.Functionf("Sanity Checking NetworkInstance(%s-%s): type:%d, IpType:%d\n",
 		status.DisplayName, status.UUID, status.Type, status.IpType)
 
 	err := checkNIphysicalPort(ctx, status)
@@ -725,9 +725,9 @@ func doNetworkInstanceModify(ctx *zedrouterContext,
 	config types.NetworkInstanceConfig,
 	status *types.NetworkInstanceStatus) {
 
-	log.Infof("doNetworkInstanceModify: key %s\n", config.UUID)
+	log.Functionf("doNetworkInstanceModify: key %s\n", config.UUID)
 	if config.Type != status.Type {
-		log.Infof("doNetworkInstanceModify: key %s\n", config.UUID)
+		log.Functionf("doNetworkInstanceModify: key %s\n", config.UUID)
 		// We do not allow Type to change.
 
 		err := fmt.Errorf("Changing Type of NetworkInstance from %d to %d is not supported", status.Type, config.Type)
@@ -796,20 +796,20 @@ func getSwitchNetworkInstanceUsingIfname(
 		ifname2 := types.LogicallabelToIfName(ctx.deviceNetworkStatus,
 			status.Logicallabel)
 		if ifname2 != ifname {
-			log.Infof("maybeUpdateBridgeIPAddr - NI (%s) not using %s\n",
+			log.Functionf("maybeUpdateBridgeIPAddr - NI (%s) not using %s\n",
 				status.DisplayName, ifname)
 			continue
 		}
 
 		// Found Status using the Port.
-		log.Infof("getSwitchNetworkInstanceUsingIfname: networkInstance (%s) using "+
+		log.Functionf("getSwitchNetworkInstanceUsingIfname: networkInstance (%s) using "+
 			"logicallabel: %s, ifname: %s, type: %d\n",
 			status.DisplayName, status.Logicallabel, ifname, status.Type)
 
 		if status.Type == types.NetworkInstanceTypeSwitch {
 			return &status
 		}
-		log.Infof("getSwitchNetworkInstanceUsingIfname: networkInstance (%s) "+
+		log.Functionf("getSwitchNetworkInstanceUsingIfname: networkInstance (%s) "+
 			"not of type (%d) switch\n",
 			status.DisplayName, status.Type)
 		break
@@ -819,7 +819,7 @@ func getSwitchNetworkInstanceUsingIfname(
 
 func restartDnsmasq(ctx *zedrouterContext, status *types.NetworkInstanceStatus) {
 
-	log.Infof("restartDnsmasq(%s) ipsets %v\n",
+	log.Functionf("restartDnsmasq(%s) ipsets %v\n",
 		status.BridgeName, status.BridgeIPSets)
 	bridgeName := status.BridgeName
 	stopDnsmasq(bridgeName, false, true)
@@ -850,7 +850,7 @@ func createHostDnsmasqFile(ctx *zedrouterContext, bridge string) {
 			}
 			addhostDnsmasq(bridge, ulStatus.Mac,
 				ulStatus.AllocatedIPAddr, status.UUIDandVersion.UUID.String())
-			log.Infof("createHostDnsmasqFile:(%s) mac=%s, IP=%s\n", bridge, ulStatus.Mac, ulStatus.AllocatedIPAddr)
+			log.Functionf("createHostDnsmasqFile:(%s) mac=%s, IP=%s\n", bridge, ulStatus.Mac, ulStatus.AllocatedIPAddr)
 		}
 	}
 }
@@ -861,22 +861,22 @@ func lookupOrAllocateIPv4(
 	status *types.NetworkInstanceStatus,
 	mac net.HardwareAddr) (string, error) {
 
-	log.Infof("lookupOrAllocateIPv4(%s-%s): mac:%s\n",
+	log.Functionf("lookupOrAllocateIPv4(%s-%s): mac:%s\n",
 		status.DisplayName, status.Key(), mac.String())
 	// Lookup to see if it exists
 	if ip, ok := status.IPAssignments[mac.String()]; ok {
-		log.Infof("found Ip addr ( %s) for mac(%s)\n",
+		log.Functionf("found Ip addr ( %s) for mac(%s)\n",
 			ip.String(), mac.String())
 		return ip.String(), nil
 	}
 
-	log.Infof("bridgeName %s Subnet %v range %v-%v\n",
+	log.Functionf("bridgeName %s Subnet %v range %v-%v\n",
 		status.BridgeName, status.Subnet,
 		status.DhcpRange.Start, status.DhcpRange.End)
 
 	if status.DhcpRange.Start == nil {
 		if status.Type == types.NetworkInstanceTypeSwitch {
-			log.Infof("%s-%s switch means no bridgeIpAddr",
+			log.Functionf("%s-%s switch means no bridgeIpAddr",
 				status.DisplayName, status.Key())
 			return "", nil
 		}
@@ -898,13 +898,13 @@ func lookupOrAllocateIPv4(
 	for status.DhcpRange.End == nil ||
 		bytes.Compare(a, status.DhcpRange.End) <= 0 {
 
-		log.Infof("lookupOrAllocateIPv4(%s) testing %s\n",
+		log.Functionf("lookupOrAllocateIPv4(%s) testing %s\n",
 			mac.String(), a.String())
 		if status.IsIpAssigned(a) {
 			a = addToIP(a, 1)
 			continue
 		}
-		log.Infof("lookupOrAllocateIPv4(%s) found free %s\n",
+		log.Functionf("lookupOrAllocateIPv4(%s) found free %s\n",
 			mac.String(), a.String())
 
 		recordIPAssignment(ctx, status, a, mac.String())
@@ -946,7 +946,7 @@ func releaseIPv4FromNetworkInstance(ctx *zedrouterContext,
 	status *types.NetworkInstanceStatus,
 	mac net.HardwareAddr) error {
 
-	log.Infof("releaseIPv4(%s)\n", mac.String())
+	log.Functionf("releaseIPv4(%s)\n", mac.String())
 	// Lookup to see if it exists
 	if _, ok := status.IPAssignments[mac.String()]; !ok {
 		errStr := fmt.Sprintf("releaseIPv4: not found %s for %s",
@@ -1001,11 +1001,11 @@ func doConfigureIpAddrOnInterface(
 func getPortIPv4Addr(ctx *zedrouterContext,
 	status *types.NetworkInstanceStatus) (string, error) {
 	// Find any service which is associated with the appLink UUID
-	log.Infof("NetworkInstance UUID:%s, Name: %s, LogicalLabel: %s\n",
+	log.Functionf("NetworkInstance UUID:%s, Name: %s, LogicalLabel: %s\n",
 		status.UUID, status.DisplayName, status.Logicallabel)
 
 	if status.Logicallabel == "" {
-		log.Infof("no Logicallabel\n")
+		log.Functionf("no Logicallabel\n")
 		return "", nil
 	}
 
@@ -1022,12 +1022,12 @@ func getPortIPv4Addr(ctx *zedrouterContext,
 		addrs = nil
 	}
 	for _, addr := range addrs {
-		log.Infof("found addr %s\n", addr.String())
+		log.Functionf("found addr %s\n", addr.String())
 		if addr.To4() != nil {
 			return addr.String(), nil
 		}
 	}
-	log.Infof("No IPv4 address on %s yet\n", status.Logicallabel)
+	log.Functionf("No IPv4 address on %s yet\n", status.Logicallabel)
 	return "", nil
 }
 
@@ -1035,12 +1035,12 @@ func setBridgeIPAddr(
 	ctx *zedrouterContext,
 	status *types.NetworkInstanceStatus) error {
 
-	log.Infof("setBridgeIPAddr(%s-%s)\n",
+	log.Functionf("setBridgeIPAddr(%s-%s)\n",
 		status.DisplayName, status.Key())
 
 	if status.BridgeName == "" {
 		// Called too early
-		log.Infof("setBridgeIPAddr: don't yet have a bridgeName for %s\n",
+		log.Functionf("setBridgeIPAddr: don't yet have a bridgeName for %s\n",
 			status.UUID)
 		return nil
 	}
@@ -1053,7 +1053,7 @@ func setBridgeIPAddr(
 		errStr := fmt.Sprintf("Failed to get link for Bridge %s", status.BridgeName)
 		return errors.New(errStr)
 	}
-	log.Infof("Bridge: %s, Link: %+v\n", status.BridgeName, link)
+	log.Functionf("Bridge: %s, Link: %+v\n", status.BridgeName, link)
 
 	var ipAddr string
 	var err error
@@ -1066,7 +1066,7 @@ func setBridgeIPAddr(
 				err)
 			return err
 		}
-		log.Infof("Bridge: %s, Link: %s, ipAddr: %s\n",
+		log.Functionf("Bridge: %s, Link: %s, ipAddr: %s\n",
 			status.BridgeName, link, ipAddr)
 	}
 
@@ -1090,16 +1090,16 @@ func setBridgeIPAddr(
 			ipAddr = status.Gateway.String()
 			status.IPAssignments[bridgeMac.String()] = status.Gateway
 		}
-		log.Infof("BridgeMac: %s, ipAddr: %s\n",
+		log.Functionf("BridgeMac: %s, ipAddr: %s\n",
 			bridgeMac.String(), ipAddr)
 	}
 	status.BridgeIPAddr = ipAddr
 	publishNetworkInstanceStatus(ctx, status)
-	log.Infof("Published NetworkStatus. BridgeIpAddr: %s\n",
+	log.Functionf("Published NetworkStatus. BridgeIpAddr: %s\n",
 		status.BridgeIPAddr)
 
 	if status.BridgeIPAddr == "" {
-		log.Infof("Does not yet have a bridge IP address for %s\n",
+		log.Functionf("Does not yet have a bridge IP address for %s\n",
 			status.Key())
 		return nil
 	}
@@ -1112,7 +1112,7 @@ func setBridgeIPAddr(
 
 	// Create new radvd configuration and restart radvd if ipv6
 	if status.IsIPv6() {
-		log.Infof("Restart Radvd\n")
+		log.Functionf("Restart Radvd\n")
 		restartRadvdWithNewConfig(status.BridgeName)
 	}
 	return nil
@@ -1124,16 +1124,16 @@ func updateBridgeIPAddr(
 	ctx *zedrouterContext,
 	status *types.NetworkInstanceStatus) {
 
-	log.Infof("updateBridgeIPAddr(%s)\n", status.Key())
+	log.Functionf("updateBridgeIPAddr(%s)\n", status.Key())
 
 	old := status.BridgeIPAddr
 	err := setBridgeIPAddr(ctx, status)
 	if err != nil {
-		log.Infof("updateBridgeIPAddr: %s\n", err)
+		log.Functionf("updateBridgeIPAddr: %s\n", err)
 		return
 	}
 	if status.BridgeIPAddr != old && status.BridgeIPAddr != "" {
-		log.Infof("updateBridgeIPAddr(%s) restarting dnsmasq\n",
+		log.Functionf("updateBridgeIPAddr(%s) restarting dnsmasq\n",
 			status.Key())
 		restartDnsmasq(ctx, status)
 	}
@@ -1149,7 +1149,7 @@ func maybeUpdateBridgeIPAddr(
 	if status == nil {
 		return
 	}
-	log.Infof("maybeUpdateBridgeIPAddr: found "+
+	log.Functionf("maybeUpdateBridgeIPAddr: found "+
 		"NetworkInstance %s", status.DisplayName)
 
 	if !status.Activated {
@@ -1165,7 +1165,7 @@ func maybeUpdateBridgeIPAddr(
 func doNetworkInstanceActivate(ctx *zedrouterContext,
 	status *types.NetworkInstanceStatus) error {
 
-	log.Infof("doNetworkInstanceActivate NetworkInstance key %s type %d\n",
+	log.Functionf("doNetworkInstanceActivate NetworkInstance key %s type %d\n",
 		status.UUID, status.Type)
 
 	// Check that Port is either "uplink", "freeuplink", or
@@ -1186,7 +1186,7 @@ func doNetworkInstanceActivate(ctx *zedrouterContext,
 	} else {
 		status.IfNameList = getIfNameListForLLOrIfname(ctx, status.CurrentUplinkIntf)
 	}
-	log.Infof("IfNameList: %+v", status.IfNameList)
+	log.Functionf("IfNameList: %+v", status.IfNameList)
 
 	switch status.Type {
 	case types.NetworkInstanceTypeSwitch:
@@ -1226,7 +1226,7 @@ func getIfNameListForLLOrIfname(
 	llOrIfname string) []string {
 
 	ifNameList := labelToIfNames(ctx, llOrIfname)
-	log.Infof("ifNameList: %+v", ifNameList)
+	log.Functionf("ifNameList: %+v", ifNameList)
 
 	filteredList := make([]string, 0)
 	for _, ifName := range ifNameList {
@@ -1239,23 +1239,23 @@ func getIfNameListForLLOrIfname(
 			// XXX That bug has been fixed. Retest without this code?
 			ifIndex, err := IfnameToIndex(log, ifName)
 			if err == nil {
-				log.Infof("ifName %s, ifindex: %d added to filteredList",
+				log.Functionf("ifName %s, ifindex: %d added to filteredList",
 					ifName, ifIndex)
 				filteredList = append(filteredList, ifName)
 			} else {
-				log.Infof("ifIndex not found for ifName(%s) - err: %s",
+				log.Functionf("ifIndex not found for ifName(%s) - err: %s",
 					ifName, err.Error())
 			}
 		} else {
-			log.Infof("DeviceNetworkStatus not found for ifName(%s)",
+			log.Functionf("DeviceNetworkStatus not found for ifName(%s)",
 				ifName)
 		}
 	}
 	if len(filteredList) > 0 {
-		log.Infof("filteredList: %+v", filteredList)
+		log.Functionf("filteredList: %+v", filteredList)
 		return filteredList
 	}
-	log.Infof("ifname or ifindex not found for any interface for logicallabel(%s)."+
+	log.Functionf("ifname or ifindex not found for any interface for logicallabel(%s)."+
 		"Returning the unfiltered list: %+v", llOrIfname, ifNameList)
 	return ifNameList
 }
@@ -1264,7 +1264,7 @@ func doNetworkInstanceInactivate(
 	ctx *zedrouterContext,
 	status *types.NetworkInstanceStatus) {
 
-	log.Infof("doNetworkInstanceInactivate NetworkInstance key %s type %d\n",
+	log.Functionf("doNetworkInstanceInactivate NetworkInstance key %s type %d\n",
 		status.UUID, status.Type)
 
 	bridgeInactivateforNetworkInstance(ctx, status)
@@ -1282,7 +1282,7 @@ func doNetworkInstanceDelete(
 	ctx *zedrouterContext,
 	status *types.NetworkInstanceStatus) {
 
-	log.Infof("doNetworkInstanceDelete NetworkInstance key %s type %d\n",
+	log.Functionf("doNetworkInstanceDelete NetworkInstance key %s type %d\n",
 		status.UUID, status.Type)
 
 	// Anything to do except the inactivate already done?
@@ -1411,7 +1411,7 @@ func publishNetworkInstanceMetrics(ctx *zedrouterContext,
 func bridgeActivate(ctx *zedrouterContext,
 	status *types.NetworkInstanceStatus) error {
 
-	log.Infof("bridgeActivate(%s)\n", status.DisplayName)
+	log.Functionf("bridgeActivate(%s)\n", status.DisplayName)
 
 	bridgeLink, err := findBridge(status.BridgeName)
 	if err != nil {
@@ -1440,7 +1440,7 @@ func bridgeActivate(ctx *zedrouterContext,
 			status.Logicallabel, ifname, status.BridgeName, err)
 		return errors.New(errStr)
 	}
-	log.Infof("bridgeActivate: added %s ifname %s to bridge %s\n",
+	log.Functionf("bridgeActivate: added %s ifname %s to bridge %s\n",
 		status.Logicallabel, ifname, status.BridgeName)
 	return nil
 }
@@ -1448,7 +1448,7 @@ func bridgeActivate(ctx *zedrouterContext,
 func bridgeInactivateforNetworkInstance(ctx *zedrouterContext,
 	status *types.NetworkInstanceStatus) {
 
-	log.Infof("bridgeInactivateforNetworkInstance(%s)\n", status.DisplayName)
+	log.Functionf("bridgeInactivateforNetworkInstance(%s)\n", status.DisplayName)
 	// Find logicallabel
 	ifname := types.LogicallabelToIfName(ctx.deviceNetworkStatus, status.Logicallabel)
 	alink, _ := netlink.LinkByName(ifname)
@@ -1462,10 +1462,10 @@ func bridgeInactivateforNetworkInstance(ctx *zedrouterContext,
 	if err := netlink.LinkSetNoMaster(alink); err != nil {
 		errStr := fmt.Sprintf("LinkSetNoMaster %s ifname %s failed: %s",
 			status.Logicallabel, ifname, err)
-		log.Infoln(errStr)
+		log.Functionln(errStr)
 		return
 	}
-	log.Infof("bridgeInactivateforNetworkInstance: removed %s ifname %s from bridge\n",
+	log.Functionf("bridgeInactivateforNetworkInstance: removed %s ifname %s from bridge\n",
 		status.Logicallabel, ifname)
 }
 
@@ -1475,7 +1475,7 @@ func bridgeInactivateforNetworkInstance(ctx *zedrouterContext,
 func natActivate(ctx *zedrouterContext,
 	status *types.NetworkInstanceStatus) error {
 
-	log.Infof("natActivate(%s)\n", status.DisplayName)
+	log.Functionf("natActivate(%s)\n", status.DisplayName)
 	subnetStr := status.Subnet.String()
 
 	// status.IfNameList should not have more than one interface name.
@@ -1489,7 +1489,7 @@ func natActivate(ctx *zedrouterContext,
 		return err
 	}
 	for _, a := range status.IfNameList {
-		log.Infof("Adding iptables rules for %s \n", a)
+		log.Functionf("Adding iptables rules for %s \n", a)
 		err := iptables.IptableCmd(log, "-t", "nat", "-A", "POSTROUTING", "-o", a,
 			"-s", subnetStr, "-j", "MASQUERADE")
 		if err != nil {
@@ -1510,7 +1510,7 @@ func natActivate(ctx *zedrouterContext,
 func natInactivate(ctx *zedrouterContext,
 	status *types.NetworkInstanceStatus, inActivateOld bool) {
 
-	log.Infof("natInactivate(%s)\n", status.DisplayName)
+	log.Functionf("natInactivate(%s)\n", status.DisplayName)
 	subnetStr := status.Subnet.String()
 	var oldUplinkIntf string
 	if inActivateOld {
@@ -1533,7 +1533,7 @@ func natInactivate(ctx *zedrouterContext,
 
 func natDelete(status *types.NetworkInstanceStatus) {
 
-	log.Infof("natDelete(%s)\n", status.DisplayName)
+	log.Functionf("natDelete(%s)\n", status.DisplayName)
 }
 
 func lookupNetworkInstanceStatusByBridgeName(ctx *zedrouterContext,
@@ -1597,7 +1597,7 @@ func vpnDelete(ctx *zedrouterContext,
 func strongswanNetworkInstanceCreate(ctx *zedrouterContext,
 	status *types.NetworkInstanceStatus) error {
 
-	log.Infof("Vpn network instance create: %s\n", status.DisplayName)
+	log.Functionf("Vpn network instance create: %s\n", status.DisplayName)
 
 	// parse and structure the config
 	vpnConfig, err := strongSwanConfigGet(ctx, status)
@@ -1624,7 +1624,7 @@ func strongswanNetworkInstanceCreate(ctx *zedrouterContext,
 func strongswanNetworkInstanceDestroy(ctx *zedrouterContext,
 	status *types.NetworkInstanceStatus) {
 
-	log.Infof("Vpn network instance delete: %s\n", status.DisplayName)
+	log.Functionf("Vpn network instance delete: %s\n", status.DisplayName)
 	vpnConfig, err := strongSwanVpnStatusParse(status.OpaqueStatus)
 	if err != nil {
 		log.Warnf("Vpn network instance delete: %v\n", err.Error())
@@ -1638,7 +1638,7 @@ func strongswanNetworkInstanceDestroy(ctx *zedrouterContext,
 func strongswanNetworkInstanceActivate(ctx *zedrouterContext,
 	status *types.NetworkInstanceStatus) error {
 
-	log.Infof("Vpn network instance activate: %s\n", status.DisplayName)
+	log.Functionf("Vpn network instance activate: %s\n", status.DisplayName)
 	vpnConfig, err := strongSwanVpnStatusParse(status.OpaqueStatus)
 	if err != nil {
 		log.Warnf("Vpn network instance activate: %v\n", err.Error())
@@ -1655,7 +1655,7 @@ func strongswanNetworkInstanceActivate(ctx *zedrouterContext,
 func strongswanNetworkInstanceInactivate(ctx *zedrouterContext,
 	status *types.NetworkInstanceStatus) {
 
-	log.Infof("Vpn network instance inactivate: %s\n", status.DisplayName)
+	log.Functionf("Vpn network instance inactivate: %s\n", status.DisplayName)
 	vpnConfig, err := strongSwanVpnStatusParse(status.OpaqueStatus)
 	if err != nil {
 		log.Warnf("Vpn network instance inactivate: %v\n", err.Error())
@@ -1738,13 +1738,13 @@ func checkAndReprogramNetworkInstances(ctx *zedrouterContext) {
 			continue
 		}
 		if status.ProgUplinkIntf == status.CurrentUplinkIntf {
-			log.Infof("checkAndReprogramNetworkInstances: Uplink (%s) has not changed"+
+			log.Functionf("checkAndReprogramNetworkInstances: Uplink (%s) has not changed"+
 				" for network instance %s",
 				status.CurrentUplinkIntf, status.DisplayName)
 			continue
 		}
 
-		log.Infof("checkAndReprogramNetworkInstances: Changing Uplink to %s from %s for "+
+		log.Functionf("checkAndReprogramNetworkInstances: Changing Uplink to %s from %s for "+
 			"network instance %s", status.CurrentUplinkIntf, status.PrevUplinkIntf,
 			status.DisplayName)
 		doNetworkInstanceFallback(ctx, &status)
@@ -1755,14 +1755,14 @@ func doNetworkInstanceFallback(
 	ctx *zedrouterContext,
 	status *types.NetworkInstanceStatus) error {
 
-	log.Infof("doNetworkInstanceFallback NetworkInstance key %s type %d\n",
+	log.Functionf("doNetworkInstanceFallback NetworkInstance key %s type %d\n",
 		status.UUID, status.Type)
 
 	var err error
 	// Get a list of IfNames to the ones we have an ifIndex for.
 	status.IfNameList = getIfNameListForLLOrIfname(ctx, status.CurrentUplinkIntf)
 	publishNetworkInstanceStatus(ctx, status)
-	log.Infof("IfNameList: %+v", status.IfNameList)
+	log.Functionf("IfNameList: %+v", status.IfNameList)
 
 	switch status.Type {
 	case types.NetworkInstanceTypeLocal:

--- a/pkg/pillar/cmd/zedrouter/pbr_linux.go
+++ b/pkg/pillar/cmd/zedrouter/pbr_linux.go
@@ -23,14 +23,14 @@ func getAllIPv4Routes(ifindex int) []netlink.Route {
 	filter := netlink.Route{Table: table, LinkIndex: ifindex}
 	fflags := netlink.RT_FILTER_TABLE
 	fflags |= netlink.RT_FILTER_OIF
-	log.Infof("getAllIPv4Routes(%d) filter %v\n", ifindex, filter)
+	log.Functionf("getAllIPv4Routes(%d) filter %v\n", ifindex, filter)
 	routes, err := netlink.RouteListFiltered(syscall.AF_INET,
 		&filter, fflags)
 	if err != nil {
 		log.Errorf("getAllIPv4Routes: ifindex %d failed, error %v", ifindex, err)
 		return nil
 	}
-	log.Debugf("getAllIPv4Routes(%d) - got %d matches\n",
+	log.Tracef("getAllIPv4Routes(%d) - got %d matches\n",
 		ifindex, len(routes))
 	return routes
 }
@@ -56,7 +56,7 @@ func PbrLinkChange(deviceNetworkStatus *types.DeviceNetworkStatus,
 	ifindex := change.Attrs().Index
 	ifname := change.Attrs().Name
 	linkType := change.Link.Type()
-	log.Infof("PbrLinkChange: index %d name %s type %s\n", ifindex, ifname,
+	log.Functionf("PbrLinkChange: index %d name %s type %s\n", ifindex, ifname,
 		linkType)
 	switch change.Header.Type {
 	case syscall.RTM_NEWLINK:

--- a/pkg/pillar/cmd/zedrouter/radvd.go
+++ b/pkg/pillar/cmd/zedrouter/radvd.go
@@ -37,7 +37,7 @@ interface %s {
 //	olIfname - Overlay Interface Name
 func createRadvdConfiglet(cfgPathname string, olIfname string) {
 
-	log.Debugf("createRadvdConfiglet: %s\n", olIfname)
+	log.Tracef("createRadvdConfiglet: %s\n", olIfname)
 	file, err := os.Create(cfgPathname)
 	if err != nil {
 		log.Fatal("createRadvdConfiglet failed ", err)
@@ -48,7 +48,7 @@ func createRadvdConfiglet(cfgPathname string, olIfname string) {
 
 func deleteRadvdConfiglet(cfgPathname string) {
 
-	log.Debugf("createRadvdConfiglet: %s\n", cfgPathname)
+	log.Tracef("createRadvdConfiglet: %s\n", cfgPathname)
 	if err := os.Remove(cfgPathname); err != nil {
 		log.Errorln(err)
 	}
@@ -58,7 +58,7 @@ func deleteRadvdConfiglet(cfgPathname string) {
 //    radvd -u radvd -C /run/zedrouter/radvd.${OLIFNAME}.conf -p /run/radvd.${OLIFNAME}.pid
 func startRadvd(cfgPathname string, olIfname string) {
 
-	log.Debugf("startRadvd: %s\n", cfgPathname)
+	log.Tracef("startRadvd: %s\n", cfgPathname)
 	pidPathname := "/run/radvd." + olIfname + ".pid"
 	cmd := "nohup"
 	args := []string{
@@ -70,8 +70,8 @@ func startRadvd(cfgPathname string, olIfname string) {
 		"-p",
 		pidPathname,
 	}
-	log.Infof("Creating %s at %s", "nohup radvd", agentlog.GetMyStack())
-	log.Infof("Calling command %s %v\n", cmd, args)
+	log.Functionf("Creating %s at %s", "nohup radvd", agentlog.GetMyStack())
+	log.Functionf("Calling command %s %v\n", cmd, args)
 	go exec.Command(cmd, args...).Output()
 }
 
@@ -85,7 +85,7 @@ func getBridgeRadvdCfgFileName(bridgeName string) (string, string) {
 func stopRadvd(bridgeName string, printOnError bool) {
 	cfgFilename, cfgPathname := getBridgeRadvdCfgFileName(bridgeName)
 
-	log.Debugf("stopRadvd: cfgFileName:%s, cfgPathName:%s\n",
+	log.Tracef("stopRadvd: cfgFileName:%s, cfgPathName:%s\n",
 		cfgFilename, cfgPathname)
 	pkillUserArgs("radvd", cfgFilename, printOnError)
 	deleteRadvdConfiglet(cfgPathname)

--- a/pkg/pillar/cmd/zedrouter/stats.go
+++ b/pkg/pillar/cmd/zedrouter/stats.go
@@ -57,7 +57,7 @@ func swanCtlCmdGet(vpnStatus *types.VpnStatus) error {
 	tunCount := swanCtlCmdParse(vpnStatus, string(bytes))
 	totalTunCount := vpnStatus.ActiveTunCount + vpnStatus.ConnectingTunCount
 	if totalTunCount != tunCount {
-		log.Infof("Tunnel count mismatch (%d, %d)\n",
+		log.Functionf("Tunnel count mismatch (%d, %d)\n",
 			vpnStatus.ActiveTunCount, tunCount)
 		return errors.New("active tunnel count mismatch")
 	}
@@ -140,7 +140,7 @@ func ipSecCmdParse(outStr string) ipSecCmdOut {
 			}
 		}
 	}
-	log.Debugf("ipSecCmdParse:%v\n", ipSecCmdOut)
+	log.Tracef("ipSecCmdParse:%v\n", ipSecCmdOut)
 	return ipSecCmdOut
 }
 
@@ -165,7 +165,7 @@ func swanCtlCmdParse(vpnStatus *types.VpnStatus, outStr string) uint32 {
 	}
 	if logrus.GetLevel() == logrus.TraceLevel {
 		if bytes, err := json.Marshal(vpnStatus); err == nil {
-			log.Debugf("swanCtlCmdParse(): %s\n", string(bytes))
+			log.Tracef("swanCtlCmdParse(): %s\n", string(bytes))
 		}
 	}
 	return cmdOut.childCount
@@ -262,7 +262,7 @@ func swanCtlCmdOutPrint(cb *readBlock, depth int) {
 	if cb == nil {
 		return
 	}
-	log.Debugf("%d-%d:%d,%d\n", depth, cb.childCount, cb.startLine, cb.endLine)
+	log.Tracef("%d-%d:%d,%d\n", depth, cb.childCount, cb.startLine, cb.endLine)
 	for _, childBlock := range cb.childBlocks {
 		swanCtlCmdOutPrint(childBlock, depth+1)
 	}

--- a/pkg/pillar/cmd/zedrouter/strongswan.go
+++ b/pkg/pillar/cmd/zedrouter/strongswan.go
@@ -26,7 +26,7 @@ const (
 )
 
 func strongSwanVpnConfigParse(opaqueConfig string) (types.VpnConfig, error) {
-	log.Infof("strongSwanVpnConfigParse(): parsing %s\n", opaqueConfig)
+	log.Functionf("strongSwanVpnConfigParse(): parsing %s\n", opaqueConfig)
 	vpnConfig := types.VpnConfig{}
 
 	cb := []byte(opaqueConfig)
@@ -203,7 +203,7 @@ func strongSwanVpnConfigParse(opaqueConfig string) (types.VpnConfig, error) {
 		return vpnConfig, errors.New("invalid vpn role: " + strongSwanConfig.VpnRole)
 	}
 
-	log.Debugln("strongSwanVpnConfigParse: ", strongSwanConfig)
+	log.Traceln("strongSwanVpnConfigParse: ", strongSwanConfig)
 
 	// fill up our structure
 	vpnConfig.VpnRole = strongSwanConfig.VpnRole
@@ -239,7 +239,7 @@ func strongSwanVpnConfigParse(opaqueConfig string) (types.VpnConfig, error) {
 
 	if logrus.GetLevel() == logrus.TraceLevel {
 		if bytes, err := json.Marshal(vpnConfig); err == nil {
-			log.Debugf("strongSwanConfigParse(): %s\n",
+			log.Tracef("strongSwanConfigParse(): %s\n",
 				string(bytes))
 		}
 	}
@@ -248,7 +248,7 @@ func strongSwanVpnConfigParse(opaqueConfig string) (types.VpnConfig, error) {
 
 func strongSwanVpnStatusParse(opaqueStatus string) (types.VpnConfig, error) {
 
-	log.Debugf("strongSwanVpnStatusParse: parsing %s\n", opaqueStatus)
+	log.Tracef("strongSwanVpnStatusParse: parsing %s\n", opaqueStatus)
 
 	cb := []byte(opaqueStatus)
 	vpnConfig := types.VpnConfig{}
@@ -316,7 +316,7 @@ func strongSwanVpnDelete(vpnConfig types.VpnConfig) error {
 
 	gatewayConfig := vpnConfig.GatewayConfig
 
-	log.Infof("strongSwan IpSec Vpn Delete %s:%t, %s, %s\n",
+	log.Functionf("strongSwan IpSec Vpn Delete %s:%t, %s, %s\n",
 		vpnConfig.VpnRole, vpnConfig.PolicyBased,
 		gatewayConfig.IpAddr, gatewayConfig.SubnetBlock)
 
@@ -464,7 +464,7 @@ func checkForClientDups(config types.StrongSwanConfig) error {
 }
 
 func isClientWildCard(client types.VpnClientConfig) bool {
-	log.Infof("isClientWildCard %s\n", client.IpAddr)
+	log.Functionf("isClientWildCard %s\n", client.IpAddr)
 	if client.IpAddr == "" || client.IpAddr == AnyIpAddr ||
 		client.IpAddr == PortIpAddrType {
 		return true
@@ -808,7 +808,7 @@ func strongSwanConfigGet(ctx *zedrouterContext,
 	}
 	if logrus.GetLevel() == logrus.TraceLevel {
 		if bytes, err := json.Marshal(vpnConfig); err == nil {
-			log.Debugf("strongSwanVpnConfigGet(): %s\n",
+			log.Tracef("strongSwanVpnConfigGet(): %s\n",
 				string(bytes))
 		}
 	}
@@ -823,7 +823,7 @@ func strongSwanVpnStatusGet(ctx *zedrouterContext,
 	}
 	vpnConfig, err := strongSwanVpnStatusParse(status.OpaqueStatus)
 	if err != nil {
-		log.Infof("StrongSwanVpn config absent\n")
+		log.Functionf("StrongSwanVpn config absent\n")
 		return change
 	}
 	vpnStatus := new(types.VpnStatus)
@@ -838,7 +838,7 @@ func strongSwanVpnStatusGet(ctx *zedrouterContext,
 
 	// if tunnel state have changed, update
 	if change = isVpnStatusChanged(status.VpnStatus, vpnStatus); change {
-		log.Debugf("vpn state change:%v\n", vpnStatus)
+		log.Tracef("vpn state change:%v\n", vpnStatus)
 		status.VpnStatus = vpnStatus
 	}
 	// push the vpnMetrics here

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -113,14 +113,14 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
 		log.Fatal(err)
 	}
-	log.Infof("Starting %s\n", agentName)
+	log.Functionf("Starting %s\n", agentName)
 
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(25 * time.Second)
 	ps.StillRunning(agentName, warningTime, errorTime)
 
 	if _, err := os.Stat(runDirname); err != nil {
-		log.Infof("Create %s\n", runDirname)
+		log.Functionf("Create %s\n", runDirname)
 		if err := os.Mkdir(runDirname, 0755); err != nil {
 			log.Fatal(err)
 		}
@@ -292,7 +292,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	// Pick up debug aka log level before we start real work
 	for !zedrouterCtx.GCInitialized {
-		log.Infof("waiting for GCInitialized")
+		log.Functionf("waiting for GCInitialized")
 		select {
 		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
@@ -300,7 +300,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		}
 		ps.StillRunning(agentName, warningTime, errorTime)
 	}
-	log.Infof("processed GlobalConfig")
+	log.Functionf("processed GlobalConfig")
 
 	appNumAllocatorInit(&zedrouterCtx)
 	bridgeNumAllocatorInit(&zedrouterCtx)
@@ -309,7 +309,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Before we process any NetworkInstances we want to know the
 	// assignable adapters.
 	for !zedrouterCtx.assignableAdapters.Initialized {
-		log.Infof("Waiting for AssignableAdapters\n")
+		log.Functionf("Waiting for AssignableAdapters\n")
 		select {
 		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
@@ -327,7 +327,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		}
 		ps.StillRunning(agentName, warningTime, errorTime)
 	}
-	log.Infof("Have %d assignable adapters\n", len(aa.IoBundleList))
+	log.Functionf("Have %d assignable adapters\n", len(aa.IoBundleList))
 
 	subNetworkInstanceConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "zedagent",
@@ -346,7 +346,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	}
 	zedrouterCtx.subNetworkInstanceConfig = subNetworkInstanceConfig
 	subNetworkInstanceConfig.Activate()
-	log.Infof("Subscribed to NetworkInstanceConfig")
+	log.Functionf("Subscribed to NetworkInstanceConfig")
 
 	// Subscribe to AppNetworkConfig from zedmanager and from zedagent
 	subAppNetworkConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
@@ -411,12 +411,12 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	zedrouterCtx.appNetCreateTimer.Stop()
 
 	zedrouterCtx.ready = true
-	log.Infof("zedrouterCtx.ready\n")
+	log.Functionf("zedrouterCtx.ready\n")
 
 	// First wait for restarted from zedmanager to
 	// reduce the number of LISP-RESTARTs
 	for !subAppNetworkConfig.Restarted() {
-		log.Infof("Waiting for zedrouter to report restarted")
+		log.Functionf("Waiting for zedrouter to report restarted")
 		select {
 		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
@@ -433,7 +433,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 			subDeviceNetworkStatus.ProcessChange(change)
 
 		case change := <-subNetworkInstanceConfig.MsgChan():
-			log.Infof("AppNetworkConfig - waiting to Restart - "+
+			log.Functionf("AppNetworkConfig - waiting to Restart - "+
 				"InstanceConfig change at %+v", time.Now())
 			subNetworkInstanceConfig.ProcessChange(change)
 		}
@@ -449,7 +449,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 				warningTime, errorTime)
 		}
 	}
-	log.Infof("Zedrouter has restarted. Entering main Select loop")
+	log.Functionf("Zedrouter has restarted. Entering main Select loop")
 
 	for {
 		select {
@@ -482,7 +482,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 			if ifname != "" &&
 				!types.IsMgmtPort(*zedrouterCtx.deviceNetworkStatus,
 					ifname) {
-				log.Debugf("linkChange(%s) not mgmt port\n", ifname)
+				log.Tracef("linkChange(%s) not mgmt port\n", ifname)
 				// Even if ethN isn't individually assignable, it
 				// could be used for a bridge.
 				maybeUpdateBridgeIPAddr(
@@ -505,7 +505,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 		case <-publishTimer.C:
 			start := time.Now()
-			log.Debugln("publishTimer at", time.Now())
+			log.Traceln("publishTimer at", time.Now())
 			err := pub.Publish("global",
 				getNetworkMetrics(&zedrouterCtx))
 			if err != nil {
@@ -525,9 +525,9 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 		case <-flowStatTimer.C:
 			start := time.Now()
-			log.Debugf("FlowStatTimer at %v", time.Now())
+			log.Tracef("FlowStatTimer at %v", time.Now())
 			// XXX why start a new go routine for each change?
-			log.Infof("Creating %s at %s", "FlowStatsCollect",
+			log.Functionf("Creating %s at %s", "FlowStatsCollect",
 				agentlog.GetMyStack())
 			go FlowStatsCollect(&zedrouterCtx)
 			ps.CheckMaxTimeTopic(agentName, "FlowStatsCollect", start,
@@ -535,9 +535,9 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 		case <-zedrouterCtx.hostProbeTimer.C:
 			start := time.Now()
-			log.Debugf("HostProbeTimer at %v", time.Now())
+			log.Tracef("HostProbeTimer at %v", time.Now())
 			// launch the go function gateway/remote hosts probing check
-			log.Infof("Creating %s at %s", "launchHostProbe",
+			log.Functionf("Creating %s at %s", "launchHostProbe",
 				agentlog.GetMyStack())
 			go launchHostProbe(&zedrouterCtx)
 			ps.CheckMaxTimeTopic(agentName, "lauchHostProbe", start,
@@ -545,20 +545,20 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 		case <-zedrouterCtx.appNetCreateTimer.C:
 			start := time.Now()
-			log.Debugf("appNetCreateTimer: at %v", time.Now())
+			log.Tracef("appNetCreateTimer: at %v", time.Now())
 			scanAppNetworkStatusInErrorAndUpdate(&zedrouterCtx)
 			ps.CheckMaxTimeTopic(agentName, "scanAppNetworkStatus", start,
 				warningTime, errorTime)
 
 		case <-zedrouterCtx.checkNIUplinks:
 			start := time.Now()
-			log.Infof("checkNIUplinks channel signal\n")
+			log.Functionf("checkNIUplinks channel signal\n")
 			checkAndReprogramNetworkInstances(&zedrouterCtx)
 			ps.CheckMaxTimeTopic(agentName, "checkAndReprogram", start,
 				warningTime, errorTime)
 
 		case change := <-subNetworkInstanceConfig.MsgChan():
-			log.Infof("NetworkInstanceConfig change at %+v", time.Now())
+			log.Functionf("NetworkInstanceConfig change at %+v", time.Now())
 			subNetworkInstanceConfig.ProcessChange(change)
 
 		case <-stillRunning.C:
@@ -581,10 +581,10 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 func checkAndProcessNetworkInstanceConfig(ctx *zedrouterContext) {
 	select {
 	case change := <-ctx.subNetworkInstanceConfig.MsgChan():
-		log.Infof("Processing NetworkInstanceConfig before AppNetworkConfig")
+		log.Functionf("Processing NetworkInstanceConfig before AppNetworkConfig")
 		ctx.subNetworkInstanceConfig.ProcessChange(change)
 	default:
-		log.Infof("NO NetworkInstanceConfig before AppNetworkConfig")
+		log.Functionf("NO NetworkInstanceConfig before AppNetworkConfig")
 	}
 }
 
@@ -598,7 +598,7 @@ func maybeHandleDNS(ctx *zedrouterContext) {
 
 func handleRestart(ctxArg interface{}, done bool) {
 
-	log.Debugf("handleRestart(%v)\n", done)
+	log.Tracef("handleRestart(%v)\n", done)
 	ctx := ctxArg.(*zedrouterContext)
 	if done {
 		// Since all work is done inline we can immediately say that
@@ -628,7 +628,7 @@ func publishAppNetworkStatus(ctx *zedrouterContext,
 	status *types.AppNetworkStatus) {
 
 	key := status.Key()
-	log.Infof("publishAppNetworkStatus(%s-%s)\n", status.DisplayName, key)
+	log.Functionf("publishAppNetworkStatus(%s-%s)\n", status.DisplayName, key)
 	pub := ctx.pubAppNetworkStatus
 	pub.Publish(key, *status)
 }
@@ -637,7 +637,7 @@ func unpublishAppNetworkStatus(ctx *zedrouterContext,
 	status *types.AppNetworkStatus) {
 
 	key := status.Key()
-	log.Debugf("unpublishAppNetworkStatus(%s)\n", key)
+	log.Tracef("unpublishAppNetworkStatus(%s)\n", key)
 	pub := ctx.pubAppNetworkStatus
 	st, _ := pub.Get(key)
 	if st == nil {
@@ -650,15 +650,15 @@ func unpublishAppNetworkStatus(ctx *zedrouterContext,
 func handleAppNetworkConfigDelete(ctxArg interface{}, key string,
 	configArg interface{}) {
 
-	log.Infof("handleAppNetworkConfigDelete(%s)\n", key)
+	log.Functionf("handleAppNetworkConfigDelete(%s)\n", key)
 	ctx := ctxArg.(*zedrouterContext)
 	status := lookupAppNetworkStatus(ctx, key)
 	if status == nil {
-		log.Infof("handleAppNetworkConfigDelete: unknown %s\n", key)
+		log.Functionf("handleAppNetworkConfigDelete: unknown %s\n", key)
 		return
 	}
 	handleDelete(ctx, key, status)
-	log.Infof("handleAppNetworkConfigDelete(%s) done\n", key)
+	log.Functionf("handleAppNetworkConfigDelete(%s) done\n", key)
 	// on resource release, check whether any one else
 	// needs it
 	checkAppNetworkErrorAndStartTimer(ctx)
@@ -670,7 +670,7 @@ func lookupAppNetworkStatus(ctx *zedrouterContext, key string) *types.AppNetwork
 	pub := ctx.pubAppNetworkStatus
 	st, _ := pub.Get(key)
 	if st == nil {
-		log.Debugf("lookupAppNetworkStatus(%s) not found\n", key)
+		log.Tracef("lookupAppNetworkStatus(%s) not found\n", key)
 		return nil
 	}
 	status := st.(types.AppNetworkStatus)
@@ -685,7 +685,7 @@ func lookupAppNetworkConfig(ctx *zedrouterContext, key string) *types.AppNetwork
 		sub = ctx.subAppNetworkConfigAg
 		c, _ = sub.Get(key)
 		if c == nil {
-			log.Debugf("lookupAppNetworkConfig(%s) not found\n", key)
+			log.Tracef("lookupAppNetworkConfig(%s) not found\n", key)
 			return nil
 		}
 	}
@@ -707,16 +707,16 @@ var additionalInfoDevice *types.AdditionalInfoDevice
 func handleAppNetworkCreate(ctxArg interface{}, key string, configArg interface{}) {
 	ctx := ctxArg.(*zedrouterContext)
 	config := configArg.(types.AppNetworkConfig)
-	log.Infof("handleAppNetworkCreate(%s-%s)\n", config.DisplayName, key)
+	log.Functionf("handleAppNetworkCreate(%s-%s)\n", config.DisplayName, key)
 
 	// If this is the first time, update the timer for GC
 	if ctx.receivedConfigTime.IsZero() {
-		log.Infof("triggerNumGC")
+		log.Functionf("triggerNumGC")
 		ctx.receivedConfigTime = time.Now()
 		ctx.triggerNumGC = true
 	}
 
-	log.Infof("handleAppAppNetworkCreate(%v) for %s\n",
+	log.Functionf("handleAppAppNetworkCreate(%v) for %s\n",
 		config.UUIDandVersion, config.DisplayName)
 
 	// Pick a local number to identify the application instance
@@ -737,11 +737,11 @@ func handleAppNetworkCreate(ctxArg interface{}, key string, configArg interface{
 	}
 	status.PendingAdd = false
 	publishAppNetworkStatus(ctx, &status)
-	log.Infof("handleAppNetworkCreate done for %s\n", config.DisplayName)
+	log.Functionf("handleAppNetworkCreate done for %s\n", config.DisplayName)
 	if status.HasError() && config.Activate && !status.Activated {
 		releaseAppNetworkResources(ctx, key, &status)
 	}
-	log.Infof("handleAppNetworkCreate(%s) done\n", key)
+	log.Functionf("handleAppNetworkCreate(%s) done\n", key)
 	// on resource release, check whether any one else
 	// needs it
 	checkAppNetworkErrorAndStartTimer(ctx)
@@ -750,7 +750,7 @@ func handleAppNetworkCreate(ctxArg interface{}, key string, configArg interface{
 func doActivate(ctx *zedrouterContext, config types.AppNetworkConfig,
 	status *types.AppNetworkStatus) {
 
-	log.Infof("%s-%s\n",
+	log.Functionf("%s-%s\n",
 		config.DisplayName, config.UUIDandVersion)
 
 	// Check that Network exists for all underlays.
@@ -759,7 +759,7 @@ func doActivate(ctx *zedrouterContext, config types.AppNetworkConfig,
 	if !allNetworksExist {
 		// XXX error or not?
 		status.AwaitNetworkInstance = true
-		log.Infof("doActivate(%v) for %s: missing networks\n",
+		log.Functionf("doActivate(%v) for %s: missing networks\n",
 			config.UUIDandVersion, config.DisplayName)
 		publishAppNetworkStatus(ctx, status)
 		return
@@ -784,7 +784,7 @@ func doActivate(ctx *zedrouterContext, config types.AppNetworkConfig,
 
 	status.Activated = true
 	publishAppNetworkStatus(ctx, status)
-	log.Infof("doActivate done for %s\n", config.DisplayName)
+	log.Functionf("doActivate done for %s\n", config.DisplayName)
 }
 
 func appNetworkDoActivateAllUnderlayNetworks(
@@ -794,7 +794,7 @@ func appNetworkDoActivateAllUnderlayNetworks(
 	ipsets []string) {
 	for i, ulConfig := range config.UnderlayNetworkList {
 		ulNum := i + 1
-		log.Debugf("ulNum %d network %s ACLs %v\n",
+		log.Tracef("ulNum %d network %s ACLs %v\n",
 			ulNum, ulConfig.Network.String(), ulConfig.ACLs)
 		appNetworkDoActivateUnderlayNetwork(
 			ctx, config, status, ipsets, &ulConfig, ulNum)
@@ -806,14 +806,14 @@ func appNetworkDoActivateAllUnderlayNetworks(
 func getSwitchIPv4Addr(ctx *zedrouterContext,
 	status *types.NetworkInstanceStatus) (string, error) {
 	// Find any service which is associated with the appLink UUID
-	log.Infof("getSwitchIPv4Addr(%s-%s)\n",
+	log.Functionf("getSwitchIPv4Addr(%s-%s)\n",
 		status.DisplayName, status.UUID.String())
 	if status.Type != types.NetworkInstanceTypeSwitch {
 		errStr := fmt.Sprintf("NI not a switch. Type: %d", status.Type)
 		return "", errors.New(errStr)
 	}
 	if status.Logicallabel == "" {
-		log.Infof("SwitchType, but no LogicalLabel\n")
+		log.Functionf("SwitchType, but no LogicalLabel\n")
 		return "", nil
 	}
 
@@ -831,14 +831,14 @@ func getSwitchIPv4Addr(ctx *zedrouterContext,
 		return "", errors.New(errStr)
 	}
 	for _, addr := range addrs {
-		log.Infof("getSwitchIPv4Addr(%s): found addr %s\n",
+		log.Functionf("getSwitchIPv4Addr(%s): found addr %s\n",
 			status.DisplayName, addr.String())
 		// XXX Add IPv6 underlay; ignore link-locals.
 		if addr.To4() != nil {
 			return addr.String(), nil
 		}
 	}
-	log.Infof("getSwitchIPv4Addr(%s): no IPv4 address on %s yet\n",
+	log.Functionf("getSwitchIPv4Addr(%s): no IPv4 address on %s yet\n",
 		status.DisplayName, status.Logicallabel)
 	return "", nil
 }
@@ -882,12 +882,12 @@ func appNetworkDoActivateUnderlayNetwork(
 	uLink, err := findBridge(bridgeName)
 	if err != nil {
 		addError(ctx, status, "findBridge", err)
-		log.Infof("doActivate done for %s\n",
+		log.Functionf("doActivate done for %s\n",
 			config.DisplayName)
 		return
 	}
 	bridgeMac := uLink.HardwareAddr
-	log.Infof("bridgeName %s MAC %s\n",
+	log.Functionf("bridgeName %s MAC %s\n",
 		bridgeName, bridgeMac.String())
 
 	var appMac string // Handed to domU
@@ -898,11 +898,11 @@ func appNetworkDoActivateUnderlayNetwork(
 		appMac = fmt.Sprintf("00:16:3e:00:%02x:%02x",
 			ulNum, status.AppNum)
 	}
-	log.Infof("appMac %s\n", appMac)
+	log.Functionf("appMac %s\n", appMac)
 
 	// Record what we have so far
 	ulStatus := &status.UnderlayNetworkList[ulNum-1]
-	log.Infof("doActivate ulNum %d: %v\n", ulNum, ulStatus)
+	log.Functionf("doActivate ulNum %d: %v\n", ulNum, ulStatus)
 	ulStatus.Name = ulConfig.Name
 	ulStatus.Bridge = bridgeName
 	ulStatus.BridgeMac = bridgeMac
@@ -922,12 +922,12 @@ func appNetworkDoActivateUnderlayNetwork(
 	// Check if we have a bridge service with an address
 	bridgeIP, err := getSwitchIPv4Addr(ctx, netInstStatus)
 	if err != nil {
-		log.Infof("doActivate: %s\n", err)
+		log.Functionf("doActivate: %s\n", err)
 	} else if bridgeIP != "" {
-		log.Infof("bridgeIp: %s\n", bridgeIP)
+		log.Functionf("bridgeIp: %s\n", bridgeIP)
 		bridgeIPAddr = bridgeIP
 	}
-	log.Infof("bridgeIPAddr %s appIPAddr %s\n", bridgeIPAddr, appIPAddr)
+	log.Functionf("bridgeIPAddr %s appIPAddr %s\n", bridgeIPAddr, appIPAddr)
 	ulStatus.BridgeIPAddr = bridgeIPAddr
 	// XXX appIPAddr is "" if bridge service
 	ulStatus.AllocatedIPAddr = appIPAddr
@@ -979,7 +979,7 @@ func appNetworkDoActivateUnderlayNetwork(
 	networkInstanceInfo.AddVif(log, vifName, appMac,
 		config.UUIDandVersion.UUID)
 	networkInstanceInfo.BridgeIPSets = newIpsets
-	log.Infof("set BridgeIPSets to %v for %s", newIpsets,
+	log.Functionf("set BridgeIPSets to %v for %s", newIpsets,
 		networkInstanceInfo.BridgeName)
 
 	// Check App Container Stats ACL need to be reinstalled
@@ -1026,7 +1026,7 @@ func appNetworkCheckAllNetworksExist(
 			ulConfig.Network.String(),
 			config.UUIDandVersion, config.DisplayName)
 		log.Errorf(errStr)
-		log.Infof("doActivate failed: %s\n", errStr)
+		log.Functionf("doActivate failed: %s\n", errStr)
 
 		// App network configuration that has underlays pointing to non-existant
 		// network instances is invalid. Such, configuration should never come to
@@ -1049,7 +1049,7 @@ func appNetworkCheckAllNetworksExist(
 func checkAndRecreateAppNetwork(
 	ctx *zedrouterContext, network uuid.UUID) {
 
-	log.Infof("checkAndRecreateAppNetwork(%s)\n", network.String())
+	log.Functionf("checkAndRecreateAppNetwork(%s)\n", network.String())
 	pub := ctx.pubAppNetworkStatus
 	items := pub.GetAll()
 	for _, st := range items {
@@ -1057,7 +1057,7 @@ func checkAndRecreateAppNetwork(
 		if !status.AwaitNetworkInstance {
 			continue
 		}
-		log.Infof("checkAndRecreateAppNetwork(%s) missing for %s\n",
+		log.Functionf("checkAndRecreateAppNetwork(%s) missing for %s\n",
 			network.String(), status.DisplayName)
 
 		config := lookupAppNetworkConfig(ctx, status.Key())
@@ -1069,16 +1069,16 @@ func checkAndRecreateAppNetwork(
 		if !config.IsNetworkUsed(network) {
 			continue
 		}
-		log.Infof("checkAndRecreateAppNetwork(%s) recreating for %s\n",
+		log.Functionf("checkAndRecreateAppNetwork(%s) recreating for %s\n",
 			network.String(), status.DisplayName)
 		if status.HasError() {
-			log.Infof("checkAndRecreateAppNetwork(%s) remove error %s for %s\n",
+			log.Functionf("checkAndRecreateAppNetwork(%s) remove error %s for %s\n",
 				network.String(), status.Error,
 				status.DisplayName)
 			status.ClearError()
 		}
 		doActivate(ctx, *config, &status)
-		log.Infof("checkAndRecreateAppNetwork done for %s\n",
+		log.Functionf("checkAndRecreateAppNetwork done for %s\n",
 			config.DisplayName)
 	}
 }
@@ -1112,13 +1112,13 @@ func getUlAddrs(ctx *zedrouterContext,
 	status *types.UnderlayNetworkStatus,
 	netInstStatus *types.NetworkInstanceStatus) (string, string, error) {
 
-	log.Infof("getUlAddrs(%d/%d)\n", ifnum, appNum)
+	log.Functionf("getUlAddrs(%d/%d)\n", ifnum, appNum)
 
 	bridgeIPAddr := ""
 	appIPAddr := ""
 
 	// Allocate bridgeIPAddr based on BridgeMac
-	log.Infof("getUlAddrs(%d/%d for %s) bridgeMac %s\n",
+	log.Functionf("getUlAddrs(%d/%d for %s) bridgeMac %s\n",
 		ifnum, appNum, netInstStatus.UUID.String(),
 		status.BridgeMac.String())
 	var err error
@@ -1147,7 +1147,7 @@ func getUlAddrs(ctx *zedrouterContext,
 		if err != nil {
 			log.Fatal("ParseMAC failed: ", status.Mac, err)
 		}
-		log.Infof("getUlAddrs(%d/%d for %s) app Mac %s\n",
+		log.Functionf("getUlAddrs(%d/%d for %s) app Mac %s\n",
 			ifnum, appNum, netInstStatus.UUID.String(), mac.String())
 		addr, err = lookupOrAllocateIPv4(ctx, netInstStatus, mac)
 		if err != nil {
@@ -1157,7 +1157,7 @@ func getUlAddrs(ctx *zedrouterContext,
 			appIPAddr = addr
 		}
 	}
-	log.Infof("getUlAddrs(%d/%d) done %s/%s\n",
+	log.Functionf("getUlAddrs(%d/%d) done %s/%s\n",
 		ifnum, appNum, bridgeIPAddr, appIPAddr)
 	return bridgeIPAddr, appIPAddr, err
 }
@@ -1188,7 +1188,7 @@ func handleAppNetworkModify(ctxArg interface{}, key string,
 	config := configArg.(types.AppNetworkConfig)
 	oldConfig := oldConfigArg.(types.AppNetworkConfig)
 	status := lookupAppNetworkStatus(ctx, key)
-	log.Infof("handleAppNetworkModify(%v) for %s\n",
+	log.Functionf("handleAppNetworkModify(%v) for %s\n",
 		config.UUIDandVersion, config.DisplayName)
 	// reset error status and mark pending modify as true
 	status.ClearError()
@@ -1204,7 +1204,7 @@ func handleAppNetworkModify(ctxArg interface{}, key string,
 
 	// No check for version numbers since the ACLs etc might change
 	// even for the same version.
-	log.Debugf("handleAppNetworkModify appNum %d\n", status.AppNum)
+	log.Tracef("handleAppNetworkModify appNum %d\n", status.AppNum)
 
 	// Check for unsupported changes
 	status.UUIDandVersion = config.UUIDandVersion
@@ -1246,13 +1246,13 @@ func handleAppNetworkModify(ctxArg interface{}, key string,
 
 	status.PendingModify = false
 	publishAppNetworkStatus(ctx, status)
-	log.Infof("handleAppNetworkModify done for %s\n", config.DisplayName)
+	log.Functionf("handleAppNetworkModify done for %s\n", config.DisplayName)
 
 	if status != nil && status.HasError() &&
 		config.Activate && !status.Activated {
 		releaseAppNetworkResources(ctx, key, status)
 	}
-	log.Infof("handleAppNetworkModify(%s) done\n", key)
+	log.Functionf("handleAppNetworkModify(%s) done\n", key)
 	// on resource release, check whether any one else
 	// needs it
 	checkAppNetworkErrorAndStartTimer(ctx)
@@ -1271,7 +1271,7 @@ func doAppNetworkSanityCheckForModify(ctx *zedrouterContext,
 		errStr := fmt.Sprintf("Unsupported: Changed number of underlays for %s",
 			config.UUIDandVersion)
 		addError(ctx, status, "handleModify", errors.New(errStr))
-		log.Infof("handleModify done for %s\n", config.DisplayName)
+		log.Functionf("handleModify done for %s\n", config.DisplayName)
 		return false
 	}
 	// Wait for all network instances to arrive if they have not already.
@@ -1320,7 +1320,7 @@ func doAppNetworkModifyAllUnderlayNetworks(
 	ipsets []string) {
 
 	for i := range config.UnderlayNetworkList {
-		log.Debugf("handleModify ulNum %d\n", i)
+		log.Tracef("handleModify ulNum %d\n", i)
 		ulConfig := &config.UnderlayNetworkList[i]
 		oldulConfig := &oldConfig.UnderlayNetworkList[i]
 		ulStatus := &status.UnderlayNetworkList[i]
@@ -1376,7 +1376,7 @@ func doAppNetworkModifyUnderlayNetwork(
 		startDnsmasq(bridgeName)
 	}
 	netstatus.BridgeIPSets = newIpsets
-	log.Infof("set BridgeIPSets to %v for %s", newIpsets, netstatus.Key())
+	log.Functionf("set BridgeIPSets to %v for %s", newIpsets, netstatus.Key())
 	publishNetworkInstanceStatus(ctx, netstatus)
 
 	maybeRemoveStaleIpsets(staleIpsets)
@@ -1402,7 +1402,7 @@ func maybeRemoveStaleIpsets(staleIpsets []string) {
 func handleDelete(ctx *zedrouterContext, key string,
 	status *types.AppNetworkStatus) {
 
-	log.Infof("handleDelete(%v) for %s\n",
+	log.Functionf("handleDelete(%v) for %s\n",
 		status.UUIDandVersion, status.DisplayName)
 
 	status.PendingDelete = true
@@ -1418,13 +1418,13 @@ func handleDelete(ctx *zedrouterContext, key string,
 	unpublishAppNetworkStatus(ctx, status)
 
 	appNumFree(ctx, status.UUIDandVersion.UUID)
-	log.Infof("handleDelete done for %s\n", status.DisplayName)
+	log.Functionf("handleDelete done for %s\n", status.DisplayName)
 }
 
 func doInactivateAppNetwork(ctx *zedrouterContext,
 	status *types.AppNetworkStatus) {
 
-	log.Infof("doInactivate(%v) for %s\n",
+	log.Functionf("doInactivate(%v) for %s\n",
 		status.UUIDandVersion, status.DisplayName)
 
 	// remove app container stats collection items
@@ -1441,7 +1441,7 @@ func doInactivateAppNetwork(ctx *zedrouterContext,
 
 	status.Activated = false
 	publishAppNetworkStatus(ctx, status)
-	log.Infof("doInactivate done for %s\n", status.DisplayName)
+	log.Functionf("doInactivate done for %s\n", status.DisplayName)
 }
 
 func appNetworkDoInactivateAllUnderlayNetworks(
@@ -1451,7 +1451,7 @@ func appNetworkDoInactivateAllUnderlayNetworks(
 
 	for ulNum := 0; ulNum < len(status.UnderlayNetworkList); ulNum++ {
 		ulStatus := &status.UnderlayNetworkList[ulNum]
-		log.Infof("doInactivate ulNum %d: %v\n", ulNum, ulStatus)
+		log.Functionf("doInactivate ulNum %d: %v\n", ulNum, ulStatus)
 		appNetworkDoInactivateUnderlayNetwork(
 			ctx, status, ulStatus, ipsets)
 	}
@@ -1546,7 +1546,7 @@ func appNetworkDoInactivateUnderlayNetwork(
 	}
 	netstatus.RemoveVif(log, ulStatus.Vif)
 	netstatus.BridgeIPSets = newIpsets
-	log.Infof("set BridgeIPSets to %v for %s", newIpsets, netstatus.Key())
+	log.Functionf("set BridgeIPSets to %v for %s", newIpsets, netstatus.Key())
 	maybeRemoveStaleIpsets(staleIpsets)
 
 	// publish the changes to network instance status
@@ -1565,7 +1565,7 @@ func pkillUserArgs(userName string, match string, printOnError bool) {
 	var err error
 	var out []byte
 	for i := 0; i < 3; i++ {
-		log.Infof("Calling command %s %v\n", cmd, args)
+		log.Functionf("Calling command %s %v\n", cmd, args)
 		out, err = base.Exec(log, cmd, args...).CombinedOutput()
 		if err == nil {
 			break
@@ -1597,10 +1597,10 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 
 	ctx := ctxArg.(*zedrouterContext)
 	if key != "global" {
-		log.Infof("handleGlobalConfigImpl: ignoring %s\n", key)
+		log.Functionf("handleGlobalConfigImpl: ignoring %s\n", key)
 		return
 	}
-	log.Infof("handleGlobalConfigImpl for %s\n", key)
+	log.Functionf("handleGlobalConfigImpl for %s\n", key)
 	var gcp *types.ConfigItemValueMap
 	debug, gcp = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
 		debugOverride, logger)
@@ -1608,7 +1608,7 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 		ctx.GCInitialized = true
 		ctx.appStatsInterval = gcp.GlobalValueInt(types.AppContainerStatsInterval)
 	}
-	log.Infof("handleGlobalConfigImpl done for %s\n", key)
+	log.Functionf("handleGlobalConfigImpl done for %s\n", key)
 }
 
 func handleGlobalConfigDelete(ctxArg interface{}, key string,
@@ -1616,15 +1616,15 @@ func handleGlobalConfigDelete(ctxArg interface{}, key string,
 
 	ctx := ctxArg.(*zedrouterContext)
 	if key != "global" {
-		log.Infof("handleGlobalConfigDelete: ignoring %s\n", key)
+		log.Functionf("handleGlobalConfigDelete: ignoring %s\n", key)
 		return
 	}
-	log.Infof("handleGlobalConfigDelete for %s\n", key)
+	log.Functionf("handleGlobalConfigDelete for %s\n", key)
 	debug, _ = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
 		debugOverride, logger)
 	gcp := *types.DefaultConfigItemValueMap()
 	ctx.appStatsInterval = gcp.GlobalValueInt(types.AppContainerStatsInterval)
-	log.Infof("handleGlobalConfigDelete done for %s\n", key)
+	log.Functionf("handleGlobalConfigDelete done for %s\n", key)
 }
 
 func handleAACreate(ctxArg interface{}, key string,
@@ -1643,12 +1643,12 @@ func handleAAImpl(ctxArg interface{}, key string,
 	ctx := ctxArg.(*zedrouterContext)
 	status := statusArg.(types.AssignableAdapters)
 	if key != "global" {
-		log.Infof("handleAAImpl: ignoring %s\n", key)
+		log.Functionf("handleAAImpl: ignoring %s\n", key)
 		return
 	}
-	log.Infof("handleAAImpl() %+v\n", status)
+	log.Functionf("handleAAImpl() %+v\n", status)
 	*ctx.assignableAdapters = status
-	log.Infof("handleAAImpl() done\n")
+	log.Functionf("handleAAImpl() done\n")
 }
 
 func handleAADelete(ctxArg interface{}, key string,
@@ -1656,12 +1656,12 @@ func handleAADelete(ctxArg interface{}, key string,
 
 	ctx := ctxArg.(*zedrouterContext)
 	if key != "global" {
-		log.Infof("handleAADelete: ignoring %s\n", key)
+		log.Functionf("handleAADelete: ignoring %s\n", key)
 		return
 	}
-	log.Infof("handleAADelete()\n")
+	log.Functionf("handleAADelete()\n")
 	ctx.assignableAdapters.Initialized = false
-	log.Infof("handleAADelete() done\n")
+	log.Functionf("handleAADelete() done\n")
 }
 
 func handleDNSCreate(ctxArg interface{}, key string,
@@ -1680,16 +1680,16 @@ func handleDNSImpl(ctxArg interface{}, key string,
 	status := statusArg.(types.DeviceNetworkStatus)
 	ctx := ctxArg.(*zedrouterContext)
 	if key != "global" {
-		log.Infof("handleDNSImpl: ignoring %s\n", key)
+		log.Functionf("handleDNSImpl: ignoring %s\n", key)
 		return
 	}
-	log.Infof("handleDNSImpl for %s\n", key)
+	log.Functionf("handleDNSImpl for %s\n", key)
 	// Ignore test status and timestamps
 	if ctx.deviceNetworkStatus.MostlyEqual(status) {
-		log.Infof("handleDNSImpl no change\n")
+		log.Functionf("handleDNSImpl no change\n")
 		return
 	}
-	log.Infof("handleDNSImpl: changed %v",
+	log.Functionf("handleDNSImpl: changed %v",
 		cmp.Diff(ctx.deviceNetworkStatus, status))
 
 	if isDNSServerChanged(ctx, &status) {
@@ -1701,27 +1701,27 @@ func handleDNSImpl(ctxArg interface{}, key string,
 
 	deviceUpdateNIprobing(ctx, &status)
 
-	log.Infof("handleDNSImpl done for %s\n", key)
+	log.Functionf("handleDNSImpl done for %s\n", key)
 }
 
 func handleDNSDelete(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
-	log.Infof("handleDNSDelete for %s\n", key)
+	log.Functionf("handleDNSDelete for %s\n", key)
 	ctx := ctxArg.(*zedrouterContext)
 
 	if key != "global" {
-		log.Infof("handleDNSDelete: ignoring %s\n", key)
+		log.Functionf("handleDNSDelete: ignoring %s\n", key)
 		return
 	}
 	*ctx.deviceNetworkStatus = types.DeviceNetworkStatus{}
 	maybeHandleDNS(ctx)
-	log.Infof("handleDNSDelete done for %s\n", key)
+	log.Functionf("handleDNSDelete done for %s\n", key)
 }
 
 func validateAppNetworkConfig(ctx *zedrouterContext, appNetConfig types.AppNetworkConfig,
 	appNetStatus *types.AppNetworkStatus) bool {
-	log.Infof("AppNetwork(%s), check for duplicate port map acls", appNetConfig.DisplayName)
+	log.Functionf("AppNetwork(%s), check for duplicate port map acls", appNetConfig.DisplayName)
 	// For App Networks, check for common port map rules
 	ulCfgList0 := appNetConfig.UnderlayNetworkList
 	if len(ulCfgList0) == 0 {
@@ -1800,7 +1800,7 @@ func checkUnderlayNetworkForPortMapOverlap(ctx *zedrouterContext,
 			network1 := ulCfg1.Network.String()
 			if network == network1 || checkUplinkPortOverlap(ctx, network, network1) {
 				if matchACLsForPortMap(ulCfg.ACLs, ulCfg1.ACLs) {
-					log.Infof("ACL PortMap overlaps for %s, %s\n", network, network1)
+					log.Functionf("ACL PortMap overlaps for %s, %s\n", network, network1)
 					log.Errorf("app Network(%s) have overlapping portmap rule in %s\n",
 						network, network1)
 					errStr := fmt.Sprintf("duplicate portmap in %s", network1)
@@ -1819,26 +1819,26 @@ func checkUplinkPortOverlap(ctx *zedrouterContext, network string, network1 stri
 	netInstStatus := lookupNetworkInstanceStatus(ctx, network)
 	netInstStatus1 := lookupNetworkInstanceStatus(ctx, network1)
 	if netInstStatus == nil || netInstStatus1 == nil {
-		log.Debugf("non-existent network-instance status\n")
+		log.Tracef("non-existent network-instance status\n")
 		return false
 	}
 	// check the interface list for overlap
 	for _, ifName := range netInstStatus.IfNameList {
 		for _, ifName1 := range netInstStatus1.IfNameList {
 			if ifName == ifName1 {
-				log.Debugf("uplink(%s) overlaps for (%s, %s)\n", ifName, network, network1)
+				log.Tracef("uplink(%s) overlaps for (%s, %s)\n", ifName, network, network1)
 				return true
 			}
 		}
 	}
-	log.Debugf("no uplink overlaps for (%s, %s)\n", network, network1)
+	log.Tracef("no uplink overlaps for (%s, %s)\n", network, network1)
 	return false
 }
 
 // scan through existing AppNetworkStatus list and set a timer
 // to retry later
 func checkAppNetworkErrorAndStartTimer(ctx *zedrouterContext) {
-	log.Infof("checkAppNetworkErrorAndStartTimer()\n")
+	log.Functionf("checkAppNetworkErrorAndStartTimer()\n")
 	pub := ctx.pubAppNetworkStatus
 	items := pub.GetAll()
 	for _, st := range items {
@@ -1853,7 +1853,7 @@ func checkAppNetworkErrorAndStartTimer(ctx *zedrouterContext) {
 		// allocated will be used this time also, since the app UUID
 		// does not change.
 		// When hit error while creating, set a timer for 60 sec and come back to retry
-		log.Infof("checkAppNetworkErrorAndStartTimer: set timer\n")
+		log.Functionf("checkAppNetworkErrorAndStartTimer: set timer\n")
 		ctx.appNetCreateTimer = time.NewTimer(60 * time.Second)
 	}
 }
@@ -1862,7 +1862,7 @@ func checkAppNetworkErrorAndStartTimer(ctx *zedrouterContext) {
 // up any AppNetwork struck in error state, while
 // contending for resource
 func scanAppNetworkStatusInErrorAndUpdate(ctx *zedrouterContext) {
-	log.Infof("scanAppNetworkStatusInErrorAndUpdate()\n")
+	log.Functionf("scanAppNetworkStatusInErrorAndUpdate()\n")
 	pub := ctx.pubAppNetworkStatus
 	items := pub.GetAll()
 	for _, st := range items {
@@ -1872,7 +1872,7 @@ func scanAppNetworkStatusInErrorAndUpdate(ctx *zedrouterContext) {
 			continue
 		}
 		// called from the timer, run the AppNetworkCreate to retry
-		log.Infof("scanAppNetworkStatusInErrorAndUpdate: retry the AppNetworkCreate\n")
+		log.Functionf("scanAppNetworkStatusInErrorAndUpdate: retry the AppNetworkCreate\n")
 		handleAppNetworkCreate(ctx, status.Key(), *config)
 	}
 }
@@ -1881,7 +1881,7 @@ func scanAppNetworkStatusInErrorAndUpdate(ctx *zedrouterContext) {
 // of ip rules, created by this app network
 func releaseAppNetworkResources(ctx *zedrouterContext, key string,
 	status *types.AppNetworkStatus) {
-	log.Infof("relaseAppNetworkResources(%s)\n", key)
+	log.Functionf("relaseAppNetworkResources(%s)\n", key)
 	appID := status.UUIDandVersion.UUID
 	for _, ulStatus := range status.UnderlayNetworkList {
 		aclArgs := types.AppNetworkACLArgs{BridgeName: ulStatus.Bridge,
@@ -1917,7 +1917,7 @@ func isDNSServerChanged(ctx *zedrouterContext, newStatus *types.DeviceNetworkSta
 				}
 				for idx, server := range port.DNSServers { // compare each one and update if changed
 					if server.Equal(ctx.dnsServers[port.IfName][idx]) == false {
-						log.Infof("isDnsServerChanged: intf %s exist %v, new %v\n",
+						log.Functionf("isDnsServerChanged: intf %s exist %v, new %v\n",
 							port.IfName, ctx.dnsServers[port.IfName], port.DNSServers)
 						ctx.dnsServers[port.IfName] = port.DNSServers
 						dnsDiffer = true
@@ -1940,7 +1940,7 @@ func doDnsmasqRestart(ctx *zedrouterContext) {
 			continue
 		}
 		if status.Activated {
-			log.Infof("restart dnsmasq on bridgename %s\n", status.BridgeName)
+			log.Functionf("restart dnsmasq on bridgename %s\n", status.BridgeName)
 			restartDnsmasq(ctx, &status)
 		}
 	}
@@ -1954,7 +1954,7 @@ func deleteAppInstaneOverlayRoute(
 	oLink, err := findBridge(bridgeName)
 	if err != nil {
 		addError(ctx, status, "findBridge", err)
-		log.Infof("deleteAppInstaneOverlayRoute done for %s\n",
+		log.Functionf("deleteAppInstaneOverlayRoute done for %s\n",
 			status.DisplayName)
 		return
 	}
@@ -1973,7 +1973,7 @@ func deleteAppInstaneOverlayRoute(
 			EID.String()+subnetSuffix, err)
 		addError(ctx, status, "deleteAppInstaneOverlayRoute",
 			errors.New(errStr))
-		log.Infof("deleteAppInstaneOverlayRoute done for %s\n",
+		log.Functionf("deleteAppInstaneOverlayRoute done for %s\n",
 			status.DisplayName)
 		return
 	}
@@ -1983,7 +1983,7 @@ func deleteAppInstaneOverlayRoute(
 			EID, err)
 		addError(ctx, status, "deleteAppInstaneOverlayRoute",
 			errors.New(errStr))
-		log.Infof("deleteAppInstaneOverlayRoute done for %s\n",
+		log.Functionf("deleteAppInstaneOverlayRoute done for %s\n",
 			status.DisplayName)
 	}
 }
@@ -1996,7 +1996,7 @@ func addAppInstanceOverlayRoute(
 	oLink, err := findBridge(bridgeName)
 	if err != nil {
 		addError(ctx, status, "findBridge", err)
-		log.Infof("addAppInstaneOverlayRoute done for %s\n",
+		log.Functionf("addAppInstaneOverlayRoute done for %s\n",
 			status.DisplayName)
 		return
 	}
@@ -2015,7 +2015,7 @@ func addAppInstanceOverlayRoute(
 			EID.String()+subnetSuffix, err)
 		addError(ctx, status, "addAppInstaneOverlayRoute",
 			errors.New(errStr))
-		log.Infof("addAppInstaneOverlayRoute done for %s\n",
+		log.Functionf("addAppInstaneOverlayRoute done for %s\n",
 			status.DisplayName)
 		return
 	}
@@ -2025,7 +2025,7 @@ func addAppInstanceOverlayRoute(
 			EID, err)
 		addError(ctx, status, "addAppInstaneOverlayRoute",
 			errors.New(errStr))
-		log.Infof("addAppInstaneOverlayRoute done for %s\n",
+		log.Functionf("addAppInstaneOverlayRoute done for %s\n",
 			status.DisplayName)
 	}
 }

--- a/pkg/pillar/devicenetwork/addrchange.go
+++ b/pkg/pillar/devicenetwork/addrchange.go
@@ -20,7 +20,7 @@ import (
 //
 func AddrChangeInit(log *base.LogObject) chan netlink.AddrUpdate {
 
-	log.Infof("AddrChangeInit()\n")
+	log.Functionf("AddrChangeInit()\n")
 
 	addrchan := make(chan netlink.AddrUpdate)
 	donechan := make(chan struct{})
@@ -36,7 +36,7 @@ func AddrChangeInit(log *base.LogObject) chan netlink.AddrUpdate {
 		addropt); err != nil {
 		log.Fatal(err)
 	}
-	log.Infof("AddrChangeInit() DONE\n")
+	log.Functionf("AddrChangeInit() DONE\n")
 	return addrchan
 }
 
@@ -67,9 +67,9 @@ func AddrChange(ctx DeviceNetworkContext, change netlink.AddrUpdate) (bool, int)
 				DelSourceRule(log, change.LinkIndex, change.LinkAddress, false)
 			}
 		}
-		log.Infof("AddrChange: changed, %d %s", change.LinkIndex, change.LinkAddress.String())
+		log.Functionf("AddrChange: changed, %d %s", change.LinkIndex, change.LinkAddress.String())
 	} else {
-		log.Debugf("AddrChange: no change, %d %s", change.LinkIndex, change.LinkAddress.String())
+		log.Tracef("AddrChange: no change, %d %s", change.LinkIndex, change.LinkAddress.String())
 	}
 	return changed, change.LinkIndex
 }
@@ -81,7 +81,7 @@ func AddrChange(ctx DeviceNetworkContext, change netlink.AddrUpdate) (bool, int)
 //
 func LinkChangeInit(log *base.LogObject) chan netlink.LinkUpdate {
 
-	log.Infof("LinkChangeInit()\n")
+	log.Functionf("LinkChangeInit()\n")
 
 	// Need links to get name to ifindex? Or lookup each time?
 	linkchan := make(chan netlink.LinkUpdate)
@@ -97,7 +97,7 @@ func LinkChangeInit(log *base.LogObject) chan netlink.LinkUpdate {
 		linkopt); err != nil {
 		log.Fatal(err)
 	}
-	log.Infof("LinkChangeInit() DONE\n")
+	log.Functionf("LinkChangeInit() DONE\n")
 	return linkchan
 }
 
@@ -108,7 +108,7 @@ func LinkChangeInit(log *base.LogObject) chan netlink.LinkUpdate {
 //
 func RouteChangeInit(log *base.LogObject) chan netlink.RouteUpdate {
 
-	log.Infof("RouteChangeInit()\n")
+	log.Functionf("RouteChangeInit()\n")
 
 	routechan := make(chan netlink.RouteUpdate)
 	donechan := make(chan struct{})
@@ -123,7 +123,7 @@ func RouteChangeInit(log *base.LogObject) chan netlink.RouteUpdate {
 		rtopt); err != nil {
 		log.Fatal(err)
 	}
-	log.Infof("RouteChangeInit() DONE\n")
+	log.Functionf("RouteChangeInit() DONE\n")
 	return routechan
 }
 
@@ -133,19 +133,19 @@ func checkIfMgmtPortsHaveIPandDNS(log *base.LogObject, status types.DeviceNetwor
 
 	mgmtPorts := types.GetMgmtPortsAny(status, 0)
 	if len(mgmtPorts) == 0 {
-		log.Infof("XXX no management ports")
+		log.Functionf("XXX no management ports")
 		return false
 	}
 
 	for _, port := range mgmtPorts {
 		numAddrs := types.CountLocalIPv4AddrAnyNoLinkLocalIf(status, port)
 		if numAddrs < 1 {
-			log.Debugf("No addresses on %s", port)
+			log.Tracef("No addresses on %s", port)
 			continue
 		}
 		numDNSServers := types.CountDNSServers(status, port)
 		if numDNSServers < 1 {
-			log.Debugf("Have addresses but no DNS on %s", port)
+			log.Tracef("Have addresses but no DNS on %s", port)
 			continue
 		}
 		return true
@@ -159,7 +159,7 @@ func HandleAddressChange(ctx *DeviceNetworkContext) {
 	// Check if we have more or less addresses
 	var dnStatus types.DeviceNetworkStatus
 
-	log.Infof("HandleAddressChange Pending.Inprogress %v",
+	log.Functionf("HandleAddressChange Pending.Inprogress %v",
 		ctx.Pending.Inprogress)
 	if !ctx.Pending.Inprogress {
 		dnStatus = *ctx.DeviceNetworkStatus
@@ -167,29 +167,29 @@ func HandleAddressChange(ctx *DeviceNetworkContext) {
 			dnStatus)
 
 		if !reflect.DeepEqual(*ctx.DeviceNetworkStatus, status) {
-			log.Infof("HandleAddressChange: change from %v to %v\n",
+			log.Functionf("HandleAddressChange: change from %v to %v\n",
 				*ctx.DeviceNetworkStatus, status)
 			*ctx.DeviceNetworkStatus = status
 			DoDNSUpdate(ctx)
 		} else {
-			log.Infof("HandleAddressChange: No change\n")
+			log.Functionf("HandleAddressChange: No change\n")
 		}
 	} else {
 		dnStatus = MakeDeviceNetworkStatus(log, *ctx.DevicePortConfig,
 			ctx.Pending.PendDNS)
 
 		if !reflect.DeepEqual(ctx.Pending.PendDNS, dnStatus) {
-			log.Infof("HandleAddressChange pending: change from %v to %v\n",
+			log.Functionf("HandleAddressChange pending: change from %v to %v\n",
 				ctx.Pending.PendDNS, dnStatus)
 			pingTestDNS := checkIfMgmtPortsHaveIPandDNS(log, dnStatus)
 			if pingTestDNS {
 				// We have a suitable candiate for running our cloud ping test.
-				log.Infof("HandleAddressChange: Running cloud ping test now, " +
+				log.Functionf("HandleAddressChange: Running cloud ping test now, " +
 					"Since we have suitable addresses already.")
 				VerifyDevicePortConfig(ctx)
 			}
 		} else {
-			log.Infof("HandleAddressChange pending: No change\n")
+			log.Functionf("HandleAddressChange pending: No change\n")
 		}
 	}
 }
@@ -220,7 +220,7 @@ func RouteChange(ctx DeviceNetworkContext, change netlink.RouteUpdate) (bool, in
 	if !isPort {
 		return false, 0
 	}
-	log.Infof("RouteChange(%d/%s) %s %+v", rt.LinkIndex, ifname, op, rt)
+	log.Functionf("RouteChange(%d/%s) %s %+v", rt.LinkIndex, ifname, op, rt)
 	MyTable := baseTableIndex + rt.LinkIndex
 	// Apply to ifindex specific table
 	myrt := rt
@@ -230,13 +230,13 @@ func RouteChange(ctx DeviceNetworkContext, change netlink.RouteUpdate) (bool, in
 		myrt.Flags = 0
 	}
 	if change.Type == getRouteUpdateTypeDELROUTE() {
-		log.Infof("Received route del %v\n", rt)
+		log.Functionf("Received route del %v\n", rt)
 		if err := netlink.RouteDel(&myrt); err != nil {
 			log.Errorf("Failed to remove %v from %d: %s\n",
 				myrt, myrt.Table, err)
 		}
 	} else if change.Type == getRouteUpdateTypeNEWROUTE() {
-		log.Infof("Received route add %v\n", rt)
+		log.Functionf("Received route add %v\n", rt)
 		if err := netlink.RouteAdd(&myrt); err != nil {
 			log.Errorf("Failed to add %v to %d: %s\n",
 				myrt, myrt.Table, err)
@@ -255,7 +255,7 @@ var ifnameHasPBR = make(map[string][]net.IP)
 // or if the set of IP addresses change
 func UpdatePBR(log *base.LogObject, status types.DeviceNetworkStatus) {
 
-	log.Infof("UpdatePBR: %d ports", len(status.Ports))
+	log.Functionf("UpdatePBR: %d ports", len(status.Ports))
 	// Track any ifnames which need to have PBR deleted
 	ifnameFound := make(map[string]bool)
 
@@ -268,11 +268,11 @@ func UpdatePBR(log *base.LogObject, status types.DeviceNetworkStatus) {
 		}
 		if oldAddrs, ok := ifnameHasPBR[u.IfName]; ok {
 			if reflect.DeepEqual(oldAddrs, addrs) {
-				log.Infof("Ifname %s already has PBR",
+				log.Functionf("Ifname %s already has PBR",
 					u.IfName)
 				continue
 			}
-			log.Infof("Ifname %s PBR changed from %v to %v",
+			log.Functionf("Ifname %s PBR changed from %v to %v",
 				u.IfName, oldAddrs, addrs)
 			delPBR(log, status, u.IfName)
 			addPBR(log, status, u.IfName, addrs)
@@ -292,7 +292,7 @@ func UpdatePBR(log *base.LogObject, status types.DeviceNetworkStatus) {
 }
 
 func addPBR(log *base.LogObject, status types.DeviceNetworkStatus, ifname string, addrs []net.IP) {
-	log.Infof("addPBR(%s) addrs %v", ifname, addrs)
+	log.Functionf("addPBR(%s) addrs %v", ifname, addrs)
 	ifindex, err := IfnameToIndex(log, ifname)
 	if err != nil {
 		log.Errorf("addPBR can't find ifindex for %s", ifname)
@@ -310,7 +310,7 @@ func addPBR(log *base.LogObject, status types.DeviceNetworkStatus, ifname string
 }
 
 func delPBR(log *base.LogObject, status types.DeviceNetworkStatus, ifname string) {
-	log.Infof("delPBR(%s)", ifname)
+	log.Functionf("delPBR(%s)", ifname)
 	ifindex, err := IfnameToIndex(log, ifname)
 	if err != nil {
 		log.Errorf("delPBR can't find ifindex for %s", ifname)

--- a/pkg/pillar/devicenetwork/addrchange_linux.go
+++ b/pkg/pillar/devicenetwork/addrchange_linux.go
@@ -37,22 +37,22 @@ func LinkChange(log *base.LogObject, change netlink.LinkUpdate) (bool, int) {
 	switch change.Header.Type {
 	case syscall.RTM_NEWLINK:
 		relevantFlag, upFlag := RelevantLastResort(log, change.Link)
-		log.Infof("LinkChange: NEWLINK index %d name %s type %s\n",
+		log.Functionf("LinkChange: NEWLINK index %d name %s type %s\n",
 			ifindex, ifname, linkType)
 		changed = IfindexToNameAdd(log, ifindex, ifname, linkType, relevantFlag, upFlag)
-		log.Infof("LinkChange: changed %t index %d name %s type %s\n",
+		log.Functionf("LinkChange: changed %t index %d name %s type %s\n",
 			changed, ifindex, ifname, linkType)
 		if changed && relevantFlag && !upFlag {
 			setLinkUp(log, ifname)
 		}
 	case syscall.RTM_DELLINK:
-		log.Infof("LinkChange: DELLINK index %d name %s type %s\n",
+		log.Functionf("LinkChange: DELLINK index %d name %s type %s\n",
 			ifindex, ifname, linkType)
 		// Drop all cached addresses
 		IfindexToAddrsFlush(log, ifindex)
 
 		changed = IfindexToNameDel(log, ifindex, ifname)
-		log.Infof("LinkChange: changed %t index %d name %s type %s\n",
+		log.Functionf("LinkChange: changed %t index %d name %s type %s\n",
 			changed, ifindex, ifname, linkType)
 	}
 	return changed, ifindex
@@ -60,7 +60,7 @@ func LinkChange(log *base.LogObject, change netlink.LinkUpdate) (bool, int) {
 
 // Set up to be able to see LOWER-UP and NO-CARRIER in operStatus later
 func setLinkUp(log *base.LogObject, ifname string) {
-	log.Infof("setLinkUp(%s)", ifname)
+	log.Functionf("setLinkUp(%s)", ifname)
 	link, err := netlink.LinkByName(ifname)
 	if link == nil {
 		log.Warnf("Can't find link %s: %s\n", ifname, err)

--- a/pkg/pillar/devicenetwork/devicenetwork.go
+++ b/pkg/pillar/devicenetwork/devicenetwork.go
@@ -90,7 +90,7 @@ func IsProxyConfigEmpty(proxyConfig types.ProxyConfig) bool {
 func VerifyDeviceNetworkStatus(log *base.LogObject, status types.DeviceNetworkStatus,
 	successCount uint, iteration int, timeout uint32) (bool, types.IntfStatusMap, error) {
 
-	log.Debugf("VerifyDeviceNetworkStatus() successCount %d, iteration %d",
+	log.Tracef("VerifyDeviceNetworkStatus() successCount %d, iteration %d",
 		successCount, iteration)
 
 	// Map of per-interface errors
@@ -110,23 +110,23 @@ func VerifyDeviceNetworkStatus(log *base.LogObject, status types.DeviceNetworkSt
 		SoftSerial:       hardware.GetSoftSerial(log),
 		AgentName:        "devicenetwork",
 	})
-	log.Infof("VerifyDeviceNetworkStatus: Use V2 API %v\n", zedcloud.UseV2API())
+	log.Functionf("VerifyDeviceNetworkStatus: Use V2 API %v\n", zedcloud.UseV2API())
 	testURL := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, nilUUID, "ping")
 
-	log.Debugf("NIM Get Device Serial %s, Soft Serial %s\n", zedcloudCtx.DevSerial,
+	log.Tracef("NIM Get Device Serial %s, Soft Serial %s\n", zedcloudCtx.DevSerial,
 		zedcloudCtx.DevSoftSerial)
 
 	tlsConfig, err := zedcloud.GetTlsConfig(zedcloudCtx.DeviceNetworkStatus, serverName,
 		nil, &zedcloudCtx)
 	if err != nil {
-		log.Infof("VerifyDeviceNetworkStatus: " +
+		log.Functionf("VerifyDeviceNetworkStatus: " +
 			"Device certificate not found, looking for Onboarding certificate")
 
 		onboardingCert, err := tls.LoadX509KeyPair(types.OnboardCertName,
 			types.OnboardKeyName)
 		if err != nil {
 			errStr := "Onboarding certificate cannot be found"
-			log.Infof("VerifyDeviceNetworkStatus: %s\n", errStr)
+			log.Functionf("VerifyDeviceNetworkStatus: %s\n", errStr)
 			return false, intfStatusMap, errors.New(errStr)
 		}
 		clientCert := &onboardingCert
@@ -134,7 +134,7 @@ func VerifyDeviceNetworkStatus(log *base.LogObject, status types.DeviceNetworkSt
 			serverName, clientCert, &zedcloudCtx)
 		if err != nil {
 			errStr := fmt.Sprintf("TLS configuration for talking to Zedcloud cannot be found: %s", err)
-			log.Infof("VerifyDeviceNetworkStatus: %s\n", errStr)
+			log.Functionf("VerifyDeviceNetworkStatus: %s\n", errStr)
 			return false, intfStatusMap, errors.New(errStr)
 		}
 	}
@@ -153,7 +153,7 @@ func VerifyDeviceNetworkStatus(log *base.LogObject, status types.DeviceNetworkSt
 	cloudReachable, rtf, tempIntfStatusMap, err := zedcloud.VerifyAllIntf(
 		&zedcloudCtx, testURL, successCount, iteration)
 	intfStatusMap.SetOrUpdateFromMap(tempIntfStatusMap)
-	log.Debugf("VerifyDeviceNetworkStatus: intfStatusMap - %+v", intfStatusMap)
+	log.Tracef("VerifyDeviceNetworkStatus: intfStatusMap - %+v", intfStatusMap)
 	if err != nil {
 		if rtf {
 			log.Errorf("VerifyDeviceNetworkStatus: VerifyAllIntf remoteTemporaryFailure %s",
@@ -166,7 +166,7 @@ func VerifyDeviceNetworkStatus(log *base.LogObject, status types.DeviceNetworkSt
 	}
 
 	if cloudReachable {
-		log.Infof("Uplink test SUCCESS to URL: %s", testURL)
+		log.Functionf("Uplink test SUCCESS to URL: %s", testURL)
 		return false, intfStatusMap, nil
 	}
 	errStr := fmt.Sprintf("Uplink test FAIL to URL: %s", testURL)
@@ -179,7 +179,7 @@ func VerifyDeviceNetworkStatus(log *base.LogObject, status types.DeviceNetworkSt
 func MakeDeviceNetworkStatus(log *base.LogObject, globalConfig types.DevicePortConfig, oldStatus types.DeviceNetworkStatus) types.DeviceNetworkStatus {
 	var globalStatus types.DeviceNetworkStatus
 
-	log.Infof("MakeDeviceNetworkStatus()\n")
+	log.Functionf("MakeDeviceNetworkStatus()\n")
 	globalStatus.Version = globalConfig.Version
 	globalStatus.State = oldStatus.State
 	globalStatus.Ports = make([]types.NetworkPortStatus,
@@ -223,7 +223,7 @@ func MakeDeviceNetworkStatus(log *base.LogObject, globalConfig types.DevicePortC
 		globalStatus.Ports[ix].AddrInfoList = make([]types.AddrInfo,
 			len(addrs))
 		if len(addrs) == 0 {
-			log.Infof("PortAddrs(%s) found NO addresses",
+			log.Functionf("PortAddrs(%s) found NO addresses",
 				u.IfName)
 		}
 		for i, addr := range addrs {
@@ -231,7 +231,7 @@ func MakeDeviceNetworkStatus(log *base.LogObject, globalConfig types.DevicePortC
 			if addr.To4() == nil {
 				v = "IPv6"
 			}
-			log.Infof("PortAddrs(%s) found %s %v\n",
+			log.Functionf("PortAddrs(%s) found %s %v\n",
 				u.IfName, v, addr)
 			globalStatus.Ports[ix].AddrInfoList[i].Addr = addr
 		}
@@ -276,7 +276,7 @@ func MakeDeviceNetworkStatus(log *base.LogObject, globalConfig types.DevicePortC
 	UpdatePBR(log, globalStatus)
 	// Immediate check
 	UpdateDeviceNetworkGeo(log, time.Second, &globalStatus)
-	log.Infof("MakeDeviceNetworkStatus() DONE\n")
+	log.Functionf("MakeDeviceNetworkStatus() DONE\n")
 	return globalStatus
 }
 
@@ -314,7 +314,7 @@ func devPortInstallAPname(log *base.LogObject, ifname string, wconfig types.Wire
 		break // only handle the first APN for now utill we know how to handle multiple of APNs
 	}
 	file.Close()
-	log.Infof("devPortInstallAPname: write file %s for name %v", filepath, wconfig.Cellular)
+	log.Functionf("devPortInstallAPname: write file %s for name %v", filepath, wconfig.Cellular)
 }
 
 func devPortInstallWifiConfig(ctx *DeviceNetworkContext,
@@ -338,7 +338,7 @@ func devPortInstallWifiConfig(ctx *DeviceNetworkContext,
 	defer os.Remove(tmpfile.Name())
 	tmpfile.Chmod(0600)
 
-	log.Infof("devPortInstallWifiConfig: write file %s for wifi params %v, size %d", wpaFilename, wconfig.Wifi, len(wconfig.Wifi))
+	log.Functionf("devPortInstallWifiConfig: write file %s for wifi params %v, size %d", wpaFilename, wconfig.Wifi, len(wconfig.Wifi))
 	if len(wconfig.Wifi) == 0 {
 		// generate dummy wpa_supplicant.conf
 		tmpfile.WriteString("# Fill in the networks and their passwords\nnetwork={\n")
@@ -426,10 +426,10 @@ func getWifiCredential(ctx *DeviceNetworkContext,
 			}
 			return decBlock, nil
 		}
-		log.Infof("%s, wifi config cipherblock decryption successful\n", wifi.SSID)
+		log.Functionf("%s, wifi config cipherblock decryption successful\n", wifi.SSID)
 		return decBlock, nil
 	}
-	log.Infof("%s, wifi config cipherblock not present\n", wifi.SSID)
+	log.Functionf("%s, wifi config cipherblock not present\n", wifi.SSID)
 	decBlock := types.EncryptionBlock{}
 	decBlock.WifiUserName = wifi.Identity
 	decBlock.WifiPassword = wifi.Password
@@ -449,7 +449,7 @@ func CheckDNSUpdate(ctx *DeviceNetworkContext) {
 	// Check if we have more or less addresses
 	var dnStatus types.DeviceNetworkStatus
 
-	log.Infof("CheckDnsUpdate Pending.Inprogress %v",
+	log.Functionf("CheckDnsUpdate Pending.Inprogress %v",
 		ctx.Pending.Inprogress)
 	if !ctx.Pending.Inprogress {
 		dnStatus = *ctx.DeviceNetworkStatus
@@ -457,29 +457,29 @@ func CheckDNSUpdate(ctx *DeviceNetworkContext) {
 			dnStatus)
 
 		if !reflect.DeepEqual(*ctx.DeviceNetworkStatus, status) {
-			log.Infof("CheckDNSUpdate: change from %v to %v\n",
+			log.Functionf("CheckDNSUpdate: change from %v to %v\n",
 				*ctx.DeviceNetworkStatus, status)
 			*ctx.DeviceNetworkStatus = status
 			DoDNSUpdate(ctx)
 		} else {
-			log.Infof("CheckDNSUpdate: No change\n")
+			log.Functionf("CheckDNSUpdate: No change\n")
 		}
 	} else {
 		dnStatus = MakeDeviceNetworkStatus(log, *ctx.DevicePortConfig,
 			ctx.Pending.PendDNS)
 
 		if !reflect.DeepEqual(ctx.Pending.PendDNS, dnStatus) {
-			log.Infof("CheckDNSUpdate pending: change from %v to %v\n",
+			log.Functionf("CheckDNSUpdate pending: change from %v to %v\n",
 				ctx.Pending.PendDNS, dnStatus)
 			pingTestDNS := checkIfMgmtPortsHaveIPandDNS(log, dnStatus)
 			if pingTestDNS {
 				// We have a suitable candiate for running our cloud ping test.
-				log.Infof("CheckDNSUpdate: Running cloud ping test now, " +
+				log.Functionf("CheckDNSUpdate: Running cloud ping test now, " +
 					"Since we have suitable addresses already.")
 				VerifyDevicePortConfig(ctx)
 			}
 		} else {
-			log.Infof("CheckDNSUpdate pending: No change\n")
+			log.Functionf("CheckDNSUpdate pending: No change\n")
 		}
 	}
 }
@@ -519,7 +519,7 @@ func GetIPAddrs(log *base.LogObject, ifindex int) ([]net.IP, bool, net.HardwareA
 		macAddr = attrs.HardwareAddr
 	}
 
-	log.Infof("GetIPAddrs(%d) found %v and %v", ifindex, addrs4, addrs6)
+	log.Functionf("GetIPAddrs(%d) found %v and %v", ifindex, addrs4, addrs6)
 	IfindexToAddrsFlush(log, ifindex)
 	for _, a := range addrs4 {
 		if a.IP == nil {
@@ -556,7 +556,7 @@ func getDefaultRouters(log *base.LogObject, ifindex int) []net.IP {
 			ifindex, err)
 		return res
 	}
-	// log.Debugf("getDefaultRouters(%s) - got %d", ifname, len(routes))
+	// log.Tracef("getDefaultRouters(%s) - got %d", ifname, len(routes))
 	for _, rt := range routes {
 		if rt.Table != table {
 			continue
@@ -564,7 +564,7 @@ func getDefaultRouters(log *base.LogObject, ifindex int) []net.IP {
 		if ifindex != 0 && rt.LinkIndex != ifindex {
 			continue
 		}
-		// log.Debugf("getDefaultRouters route dest %v", rt.Dst)
+		// log.Tracef("getDefaultRouters route dest %v", rt.Dst)
 		res = append(res, rt.Gw)
 	}
 	return res
@@ -618,7 +618,7 @@ func UpdateDeviceNetworkGeo(log *base.LogObject, timelimit time.Duration, global
 			info, err := ipinfo.MyIPWithOptions(opt)
 			if err != nil {
 				// Ignore error
-				log.Infof("UpdateDeviceNetworkGeo MyIPInfo failed %s\n", err)
+				log.Functionf("UpdateDeviceNetworkGeo MyIPInfo failed %s\n", err)
 				continue
 			}
 			// Note that if the global IP is unchanged we don't
@@ -626,7 +626,7 @@ func UpdateDeviceNetworkGeo(log *base.LogObject, timelimit time.Duration, global
 			if info.IP == ai.Geo.IP {
 				continue
 			}
-			log.Infof("UpdateDeviceNetworkGeo MyIPInfo changed from %v to %v\n",
+			log.Functionf("UpdateDeviceNetworkGeo MyIPInfo changed from %v to %v\n",
 				ai.Geo, *info)
 			ai.Geo = *info
 			ai.LastGeoTimestamp = time.Now()

--- a/pkg/pillar/devicenetwork/dhcpcd.go
+++ b/pkg/pillar/devicenetwork/dhcpcd.go
@@ -28,19 +28,19 @@ import (
 func UpdateDhcpClient(log *base.LogObject, newConfig, oldConfig types.DevicePortConfig) {
 
 	// Look for adds or changes
-	log.Infof("updateDhcpClient: new %v old %v\n",
+	log.Functionf("updateDhcpClient: new %v old %v\n",
 		newConfig, oldConfig)
 	for _, newU := range newConfig.Ports {
 		oldU := lookupOnIfname(oldConfig, newU.IfName)
 		if oldU == nil || oldU.Dhcp == types.DT_NONE {
-			log.Infof("updateDhcpClient: new %s\n", newU.IfName)
+			log.Functionf("updateDhcpClient: new %s\n", newU.IfName)
 			// Inactivate in case a dhcpcd is running
 			doDhcpClientActivate(log, newU)
 		} else {
-			log.Infof("updateDhcpClient: found old %v\n",
+			log.Functionf("updateDhcpClient: found old %v\n",
 				oldU)
 			if !reflect.DeepEqual(newU.DhcpConfig, oldU.DhcpConfig) {
-				log.Infof("updateDhcpClient: changed %s\n",
+				log.Functionf("updateDhcpClient: changed %s\n",
 					newU.IfName)
 				doDhcpClientInactivate(log, *oldU)
 				doDhcpClientActivate(log, newU)
@@ -51,11 +51,11 @@ func UpdateDhcpClient(log *base.LogObject, newConfig, oldConfig types.DevicePort
 	for _, oldU := range oldConfig.Ports {
 		newU := lookupOnIfname(newConfig, oldU.IfName)
 		if newU == nil || newU.Dhcp == types.DT_NONE {
-			log.Infof("updateDhcpClient: deleted %s\n",
+			log.Functionf("updateDhcpClient: deleted %s\n",
 				oldU.IfName)
 			doDhcpClientInactivate(log, oldU)
 		} else {
-			log.Infof("updateDhcpClient: found new %v\n",
+			log.Functionf("updateDhcpClient: found new %v\n",
 				newU)
 		}
 	}
@@ -63,11 +63,11 @@ func UpdateDhcpClient(log *base.LogObject, newConfig, oldConfig types.DevicePort
 
 func doDhcpClientActivate(log *base.LogObject, nuc types.NetworkPortConfig) {
 
-	log.Infof("doDhcpClientActivate(%s) dhcp %v addr %s gateway %s\n",
+	log.Functionf("doDhcpClientActivate(%s) dhcp %v addr %s gateway %s\n",
 		nuc.IfName, nuc.Dhcp, nuc.AddrSubnet,
 		nuc.Gateway.String())
 	if strings.HasPrefix(nuc.IfName, "wwan") {
-		log.Infof("doDhcpClientActivate: skipping %s\n",
+		log.Functionf("doDhcpClientActivate: skipping %s\n",
 			nuc.IfName)
 		return
 	}
@@ -81,7 +81,7 @@ func doDhcpClientActivate(log *base.LogObject, nuc types.NetworkPortConfig) {
 	}
 	switch nuc.Dhcp {
 	case types.DT_NONE:
-		log.Infof("doDhcpClientActivate(%s) DT_NONE is a no-op\n",
+		log.Functionf("doDhcpClientActivate(%s) DT_NONE is a no-op\n",
 			nuc.IfName)
 		return
 	case types.DT_CLIENT:
@@ -89,7 +89,7 @@ func doDhcpClientActivate(log *base.LogObject, nuc types.NetworkPortConfig) {
 			log.Warnf("dhcpcd %s already exists", nuc.IfName)
 			time.Sleep(10 * time.Second)
 		}
-		log.Infof("dhcpcd %s not running", nuc.IfName)
+		log.Functionf("dhcpcd %s not running", nuc.IfName)
 		extras := []string{"-f", "/dhcpcd.conf", "--noipv4ll", "-b", "-t", "0"}
 		if nuc.Gateway != nil && nuc.Gateway.String() == "0.0.0.0" {
 			extras = append(extras, "--nogateway")
@@ -112,7 +112,7 @@ func doDhcpClientActivate(log *base.LogObject, nuc types.NetworkPortConfig) {
 			time.Sleep(10 * time.Second)
 		}
 		if !failed {
-			log.Infof("dhcpcd %s is running", nuc.IfName)
+			log.Functionf("dhcpcd %s is running", nuc.IfName)
 		}
 
 	case types.DT_STATIC:
@@ -132,7 +132,7 @@ func doDhcpClientActivate(log *base.LogObject, nuc types.NetworkPortConfig) {
 			log.Warnf("dhcpcd %s already exists", nuc.IfName)
 			time.Sleep(10 * time.Second)
 		}
-		log.Infof("dhcpcd %s not running", nuc.IfName)
+		log.Functionf("dhcpcd %s not running", nuc.IfName)
 		args := []string{fmt.Sprintf("ip_address=%s", nuc.AddrSubnet)}
 
 		extras := []string{"-f", "/dhcpcd.conf", "-b", "-t", "0"}
@@ -176,7 +176,7 @@ func doDhcpClientActivate(log *base.LogObject, nuc types.NetworkPortConfig) {
 			time.Sleep(10 * time.Second)
 		}
 		if !failed {
-			log.Infof("dhcpcd %s is running", nuc.IfName)
+			log.Functionf("dhcpcd %s is running", nuc.IfName)
 		}
 	default:
 		log.Errorf("doDhcpClientActivate: unsupported dhcp %v\n",
@@ -186,17 +186,17 @@ func doDhcpClientActivate(log *base.LogObject, nuc types.NetworkPortConfig) {
 
 func doDhcpClientInactivate(log *base.LogObject, nuc types.NetworkPortConfig) {
 
-	log.Infof("doDhcpClientInactivate(%s) dhcp %v addr %s gateway %s\n",
+	log.Functionf("doDhcpClientInactivate(%s) dhcp %v addr %s gateway %s\n",
 		nuc.IfName, nuc.Dhcp, nuc.AddrSubnet,
 		nuc.Gateway.String())
 	if strings.HasPrefix(nuc.IfName, "wwan") {
-		log.Infof("doDhcpClientInactivate: skipping %s\n",
+		log.Functionf("doDhcpClientInactivate: skipping %s\n",
 			nuc.IfName)
 		return
 	}
 	switch nuc.Dhcp {
 	case types.DT_NONE:
-		log.Infof("doDhcpClientInactivate(%s) DT_NONE is a no-op\n",
+		log.Functionf("doDhcpClientInactivate(%s) DT_NONE is a no-op\n",
 			nuc.IfName)
 	case types.DT_STATIC, types.DT_CLIENT:
 		extras := []string{}
@@ -208,7 +208,7 @@ func doDhcpClientInactivate(log *base.LogObject, nuc types.NetworkPortConfig) {
 			log.Warnf("dhcpcd %s still running", nuc.IfName)
 			time.Sleep(10 * time.Second)
 		}
-		log.Infof("dhcpcd %s gone", nuc.IfName)
+		log.Functionf("dhcpcd %s gone", nuc.IfName)
 	default:
 		log.Errorf("doDhcpClientInactivate: unsupported dhcp %v\n",
 			nuc.Dhcp)
@@ -224,8 +224,8 @@ func dhcpcdCmd(log *base.LogObject, op string, extras []string, ifname string, b
 		cmd.Stdout = nil
 		cmd.Stderr = nil
 
-		log.Infof("Background command %s %v\n", name, args)
-		log.Infof("Creating %s at %s", "func", agentlog.GetMyStack())
+		log.Functionf("Background command %s %v\n", name, args)
+		log.Functionf("Creating %s at %s", "func", agentlog.GetMyStack())
 		go func() {
 			if err := cmd.Run(); err != nil {
 				log.Errorf("%s %v: failed: %s",
@@ -233,7 +233,7 @@ func dhcpcdCmd(log *base.LogObject, op string, extras []string, ifname string, b
 			}
 		}()
 	} else {
-		log.Infof("Calling command %s %v\n", name, args)
+		log.Functionf("Calling command %s %v\n", name, args)
 		out, err := base.Exec(log, name, args...).CombinedOutput()
 		if err != nil {
 			errStr := fmt.Sprintf("dhcpcd command %s failed %s output %s",
@@ -247,15 +247,15 @@ func dhcpcdCmd(log *base.LogObject, op string, extras []string, ifname string, b
 
 func dhcpcdExists(log *base.LogObject, ifname string) bool {
 
-	log.Infof("dhcpcdExists(%s)", ifname)
+	log.Functionf("dhcpcdExists(%s)", ifname)
 	// XXX should we use dhcpcd -P <ifname> to get name of pidfile? Hardcoded path here
 	pidfileName := fmt.Sprintf("/run/dhcpcd-%s.pid", ifname)
 	val, t := statAndRead(pidfileName)
 	if val == "" {
-		log.Infof("dhcpcdExists(%s) not exist", ifname)
+		log.Functionf("dhcpcdExists(%s) not exist", ifname)
 		return false
 	}
-	log.Infof("dhcpcdExists(%s) found modtime %v", ifname, t)
+	log.Functionf("dhcpcdExists(%s) found modtime %v", ifname, t)
 
 	pid, err := strconv.Atoi(strings.TrimSpace(val))
 	if err != nil {
@@ -265,7 +265,7 @@ func dhcpcdExists(log *base.LogObject, ifname string) bool {
 	// Does the pid exist?
 	p, err := os.FindProcess(pid)
 	if err != nil {
-		log.Infof("dhcpcdExists(%s) pid %d not found: %s", ifname, pid,
+		log.Functionf("dhcpcdExists(%s) pid %d not found: %s", ifname, pid,
 			err)
 		return false
 	}
@@ -274,7 +274,7 @@ func dhcpcdExists(log *base.LogObject, ifname string) bool {
 		log.Errorf("dhcpcdExists(%s) Signal failed %s", ifname, err)
 		return false
 	}
-	log.Infof("dhcpcdExists(%s) Signal 0 OK for %d", ifname, pid)
+	log.Functionf("dhcpcdExists(%s) Signal 0 OK for %d", ifname, pid)
 	return true
 }
 

--- a/pkg/pillar/devicenetwork/dnc_test.go
+++ b/pkg/pillar/devicenetwork/dnc_test.go
@@ -383,7 +383,7 @@ func TestCompressDPCL(t *testing.T) {
 
 	for testname, test := range testMatrix {
 		t.Logf("TESTCASE: %s - Running", testname)
-		log.Debugf("======================TESTCASE: %s - Running============",
+		log.Tracef("======================TESTCASE: %s - Running============",
 			testname)
 		ctx := DeviceNetworkContext{
 			DevicePortConfigList: &test.dpcl,
@@ -394,11 +394,11 @@ func TestCompressDPCL(t *testing.T) {
 		}
 		dpcl := compressDPCL(&ctx)
 		passed := test.checkDpclEqual(t, testname, dpcl)
-		log.Debugf("======================TESTCASE: %s - DONE - Passed: %t "+
+		log.Tracef("======================TESTCASE: %s - DONE - Passed: %t "+
 			"===============", testname, passed)
 		t.Logf("TESTCASE: %s - Done", testname)
 		if !passed {
-			log.Debugf("Test Failed.. Stopping")
+			log.Tracef("Test Failed.. Stopping")
 			break
 		}
 	}

--- a/pkg/pillar/devicenetwork/dns.go
+++ b/pkg/pillar/devicenetwork/dns.go
@@ -19,7 +19,7 @@ import (
 // XXX add IPv6 support?
 func GetDhcpInfo(log *base.LogObject, us *types.NetworkPortStatus) {
 
-	log.Infof("GetDhcpInfo(%s)\n", us.IfName)
+	log.Functionf("GetDhcpInfo(%s)\n", us.IfName)
 	if us.Dhcp != types.DT_CLIENT {
 		return
 	}
@@ -28,7 +28,7 @@ func GetDhcpInfo(log *base.LogObject, us *types.NetworkPortStatus) {
 	}
 	// XXX get error -1 unless we have -4
 	// XXX add IPv6 support
-	log.Infof("Calling dhcpcd -U -4 %s\n", us.IfName)
+	log.Functionf("Calling dhcpcd -U -4 %s\n", us.IfName)
 	stdoutStderr, err := base.Exec(log, "dhcpcd", "-U", "-4", us.IfName).CombinedOutput()
 	if err != nil {
 		errStr := fmt.Sprintf("dhcpcd -U failed %s: %s",
@@ -36,7 +36,7 @@ func GetDhcpInfo(log *base.LogObject, us *types.NetworkPortStatus) {
 		log.Errorln(errStr)
 		return
 	}
-	log.Debugf("dhcpcd -U got %v\n", string(stdoutStderr))
+	log.Tracef("dhcpcd -U got %v\n", string(stdoutStderr))
 	lines := strings.Split(string(stdoutStderr), "\n")
 	masklen := 0
 	var subnet net.IP
@@ -45,11 +45,11 @@ func GetDhcpInfo(log *base.LogObject, us *types.NetworkPortStatus) {
 		if len(items) != 2 {
 			continue
 		}
-		log.Debugf("Got <%s> <%s>\n", items[0], items[1])
+		log.Tracef("Got <%s> <%s>\n", items[0], items[1])
 		switch items[0] {
 		case "network_number":
 			network := trimQuotes(items[1])
-			log.Infof("GetDhcpInfo(%s) network_number %s\n", us.IfName,
+			log.Functionf("GetDhcpInfo(%s) network_number %s\n", us.IfName,
 				network)
 			ip := net.ParseIP(network)
 			if ip == nil {
@@ -59,7 +59,7 @@ func GetDhcpInfo(log *base.LogObject, us *types.NetworkPortStatus) {
 			subnet = ip
 		case "subnet_cidr":
 			str := trimQuotes(items[1])
-			log.Infof("GetDhcpInfo(%s) subnet_cidr %s\n", us.IfName,
+			log.Functionf("GetDhcpInfo(%s) subnet_cidr %s\n", us.IfName,
 				str)
 			masklen, err = strconv.Atoi(str)
 			if err != nil {
@@ -74,7 +74,7 @@ func GetDhcpInfo(log *base.LogObject, us *types.NetworkPortStatus) {
 // GetDNSInfo gets DNS info from /run files. Updates DomainName and DnsServers
 func GetDNSInfo(log *base.LogObject, us *types.NetworkPortStatus) {
 
-	log.Infof("GetDNSInfo(%s)\n", us.IfName)
+	log.Functionf("GetDNSInfo(%s)\n", us.IfName)
 	if us.Dhcp != types.DT_CLIENT {
 		return
 	}
@@ -84,7 +84,7 @@ func GetDNSInfo(log *base.LogObject, us *types.NetworkPortStatus) {
 		return
 	}
 	dc := netclone.DnsReadConfig(filename)
-	log.Infof("%s servers %v, search %v\n", filename, dc.Servers, dc.Search)
+	log.Functionf("%s servers %v, search %v\n", filename, dc.Servers, dc.Search)
 	for _, server := range dc.Servers {
 		// Might have port number
 		s := strings.Split(server, ":")

--- a/pkg/pillar/devicenetwork/ifindex.go
+++ b/pkg/pillar/devicenetwork/ifindex.go
@@ -32,7 +32,7 @@ func IfindexToNameAdd(log *base.LogObject, index int, linkName string, linkType 
 	if !ok {
 		// Note that we get RTM_NEWLINK even for link changes
 		// hence we don't print unless the entry is new
-		log.Infof("IfindexToNameAdd index %d name %s type %s\n",
+		log.Functionf("IfindexToNameAdd index %d name %s type %s\n",
 			index, linkName, linkType)
 		ifindexToName[index] = linkNameType{
 			linkName:     linkName,
@@ -41,12 +41,12 @@ func IfindexToNameAdd(log *base.LogObject, index int, linkName string, linkType 
 			upFlag:       upFlag,
 		}
 		ifindexMaybeRemoveOld(log, index, linkName)
-		// log.Debugf("ifindexToName post add %v\n", ifindexToName)
+		// log.Tracef("ifindexToName post add %v\n", ifindexToName)
 		return true
 	} else if m.linkName != linkName {
 		// We get this when the vifs are created with "vif*" names
 		// and then changed to "bu*" etc.
-		log.Infof("IfindexToNameAdd name mismatch %s vs %s for %d\n",
+		log.Functionf("IfindexToNameAdd name mismatch %s vs %s for %d\n",
 			m.linkName, linkName, index)
 		ifindexToName[index] = linkNameType{
 			linkName:     linkName,
@@ -55,10 +55,10 @@ func IfindexToNameAdd(log *base.LogObject, index int, linkName string, linkType 
 			upFlag:       upFlag,
 		}
 		ifindexMaybeRemoveOld(log, index, linkName)
-		// log.Debugf("ifindexToName post add %v\n", ifindexToName)
+		// log.Tracef("ifindexToName post add %v\n", ifindexToName)
 		return false
 	} else if m.relevantFlag != relevantFlag || m.upFlag != upFlag {
-		log.Infof("IfindexToNameAdd flag(s) changed to %v/%v for %s\n",
+		log.Functionf("IfindexToNameAdd flag(s) changed to %v/%v for %s\n",
 			relevantFlag, upFlag, linkName)
 		ifindexToName[index] = linkNameType{
 			linkName:     linkName,
@@ -67,7 +67,7 @@ func IfindexToNameAdd(log *base.LogObject, index int, linkName string, linkType 
 			upFlag:       upFlag,
 		}
 		ifindexMaybeRemoveOld(log, index, linkName)
-		// log.Debugf("ifindexToName post add %v\n", ifindexToName)
+		// log.Tracef("ifindexToName post add %v\n", ifindexToName)
 		return true
 	} else {
 		return false
@@ -78,7 +78,7 @@ func IfindexToNameAdd(log *base.LogObject, index int, linkName string, linkType 
 func ifindexMaybeRemoveOld(log *base.LogObject, newIndex int, ifname string) {
 	for index, lnt := range ifindexToName {
 		if lnt.linkName == ifname && index != newIndex {
-			log.Infof("Found old ifindex %d for new %d for %s",
+			log.Functionf("Found old ifindex %d for new %d for %s",
 				index, newIndex, ifname)
 			delete(ifindexToName, index)
 			return
@@ -98,13 +98,13 @@ func IfindexToNameDel(log *base.LogObject, index int, linkName string) bool {
 		log.Errorf("IfindexToNameDel name mismatch %s vs %s for %d\n",
 			m.linkName, linkName, index)
 		delete(ifindexToName, index)
-		// log.Debugf("ifindexToName post delete %v\n", ifindexToName)
+		// log.Tracef("ifindexToName post delete %v\n", ifindexToName)
 		return true
 	} else {
-		log.Debugf("IfindexToNameDel index %d name %s\n",
+		log.Tracef("IfindexToNameDel index %d name %s\n",
 			index, linkName)
 		delete(ifindexToName, index)
-		// log.Debugf("ifindexToName post delete %v\n", ifindexToName)
+		// log.Tracef("ifindexToName post delete %v\n", ifindexToName)
 		return true
 	}
 }
@@ -174,7 +174,7 @@ func RelevantLastResort(log *base.LogObject, link netlink.Link) (bool, bool) {
 	if linkType == "device" && !loopbackFlag && broadcastFlag &&
 		attrs.MasterIndex == 0 && !isVif {
 
-		log.Infof("Relevant %s adminUp %t operState %s\n",
+		log.Functionf("Relevant %s adminUp %t operState %s\n",
 			ifname, adminUpFlag, attrs.OperState.String())
 		return true, upFlag
 	} else {
@@ -201,12 +201,12 @@ var ifindexToAddrs = make(map[int][]net.IP)
 // if it doesn't already exist
 // Returns true if added
 func IfindexToAddrsAdd(log *base.LogObject, index int, addr net.IP) bool {
-	log.Debugf("IfindexToAddrsAdd(%d, %s)", index, addr.String())
+	log.Tracef("IfindexToAddrsAdd(%d, %s)", index, addr.String())
 	addrs, ok := ifindexToAddrs[index]
 	if !ok {
-		log.Debugf("IfindexToAddrsAdd add %v for %d\n", addr, index)
+		log.Tracef("IfindexToAddrsAdd add %v for %d\n", addr, index)
 		ifindexToAddrs[index] = append(ifindexToAddrs[index], addr)
-		// log.Debugf("ifindexToAddrs post add %v\n", ifindexToAddrs)
+		// log.Tracef("ifindexToAddrs post add %v\n", ifindexToAddrs)
 		return true
 	}
 	found := false
@@ -217,9 +217,9 @@ func IfindexToAddrsAdd(log *base.LogObject, index int, addr net.IP) bool {
 		}
 	}
 	if !found {
-		log.Debugf("IfindexToAddrsAdd add %v for %d\n", addr, index)
+		log.Tracef("IfindexToAddrsAdd add %v for %d\n", addr, index)
 		ifindexToAddrs[index] = append(ifindexToAddrs[index], addr)
-		// log.Debugf("ifindexToAddrs post add %v\n", ifindexToAddrs)
+		// log.Tracef("ifindexToAddrs post add %v\n", ifindexToAddrs)
 	}
 	return !found
 }
@@ -227,7 +227,7 @@ func IfindexToAddrsAdd(log *base.LogObject, index int, addr net.IP) bool {
 // IfindexToAddrsDel removes from the map based on the ifindex and address
 // Returns true if deleted
 func IfindexToAddrsDel(log *base.LogObject, index int, addr net.IP) bool {
-	log.Debugf("IfindexToAddrsDel(%d, %s)", index, addr.String())
+	log.Tracef("IfindexToAddrsDel(%d, %s)", index, addr.String())
 	addrs, ok := ifindexToAddrs[index]
 	if !ok {
 		log.Warnf("IfindexToAddrsDel unknown index %d\n", index)
@@ -235,7 +235,7 @@ func IfindexToAddrsDel(log *base.LogObject, index int, addr net.IP) bool {
 	}
 	for i, a := range addrs {
 		if a.Equal(addr) {
-			log.Debugf("IfindexToAddrsDel del %v for %d\n",
+			log.Tracef("IfindexToAddrsDel del %v for %d\n",
 				addr, index)
 			if i+1 == len(addrs) {
 				ifindexToAddrs[index] = ifindexToAddrs[index][:i]
@@ -243,7 +243,7 @@ func IfindexToAddrsDel(log *base.LogObject, index int, addr net.IP) bool {
 				ifindexToAddrs[index] = append(ifindexToAddrs[index][:i],
 					ifindexToAddrs[index][i+1:]...)
 			}
-			// log.Debugf("ifindexToAddrs post remove %v\n", ifindexToAddrs)
+			// log.Tracef("ifindexToAddrs post remove %v\n", ifindexToAddrs)
 			// XXX should we check for zero and remove ifindex?
 			return true
 		}
@@ -269,7 +269,7 @@ func IfindexToAddrsFlush(log *base.LogObject, index int) {
 		log.Warnf("IfindexToAddrsFlush: Unknown ifindex %d", index)
 		return
 	}
-	log.Infof("IfindexToAddrsFlush(%d) removing %v",
+	log.Functionf("IfindexToAddrsFlush(%d) removing %v",
 		index, ifindexToAddrs[index])
 	var addrs []net.IP
 	ifindexToAddrs[index] = addrs
@@ -277,7 +277,7 @@ func IfindexToAddrsFlush(log *base.LogObject, index int) {
 
 // IfnameToAddrsFlush does the above flush but based on ifname
 func IfnameToAddrsFlush(log *base.LogObject, ifname string) {
-	log.Infof("IfNameToAddrsFlush(%s)", ifname)
+	log.Functionf("IfNameToAddrsFlush(%s)", ifname)
 	index, err := IfnameToIndex(log, ifname)
 	if err != nil {
 		log.Warnf("IfnameToAddrsFlush: Unknown ifname %s: %s", ifname, err)

--- a/pkg/pillar/devicenetwork/pbr.go
+++ b/pkg/pillar/devicenetwork/pbr.go
@@ -31,7 +31,7 @@ func FlushRoutesTable(log *base.LogObject, table int, ifindex int) {
 		log.Errorf("FlushRoutesTable: for table %d, ifindex %d failed, error %v", table, ifindex, err)
 		return
 	}
-	log.Debugf("FlushRoutesTable(%d, %d) - got %d",
+	log.Tracef("FlushRoutesTable(%d, %d) - got %d",
 		table, ifindex, len(routes))
 	for _, rt := range routes {
 		if rt.Table != table {
@@ -40,7 +40,7 @@ func FlushRoutesTable(log *base.LogObject, table int, ifindex int) {
 		if ifindex != 0 && rt.LinkIndex != ifindex {
 			continue
 		}
-		log.Infof("FlushRoutesTable(%d, %d) deleting %v",
+		log.Functionf("FlushRoutesTable(%d, %d) deleting %v",
 			table, ifindex, rt)
 		if err := netlink.RouteDel(&rt); err != nil {
 			log.Errorf("FlushRoutesTable - RouteDel %v failed %s",
@@ -58,12 +58,12 @@ func FlushRules(log *base.LogObject, ifindex int) {
 		log.Errorf("FlushRules: for ifindex %d failed, error %v", ifindex, err)
 		return
 	}
-	log.Debugf("FlushRules(%d) - got %d", ifindex, len(rules))
+	log.Tracef("FlushRules(%d) - got %d", ifindex, len(rules))
 	for _, r := range rules {
 		if r.Table != baseTableIndex+ifindex {
 			continue
 		}
-		log.Infof("FlushRules: RuleDel %v", r)
+		log.Functionf("FlushRules: RuleDel %v", r)
 		if err := netlink.RuleDel(&r); err != nil {
 			log.Errorf("FlushRules - RuleDel %v failed %s",
 				r, err)
@@ -92,9 +92,9 @@ func makeNetlinkRule(ifindex int, p net.IPNet, addForSubnet bool) *netlink.Rule 
 // specific table for the ifindex.
 func AddSourceRule(log *base.LogObject, ifindex int, p net.IPNet, addForSubnet bool) {
 
-	log.Infof("AddSourceRule(%d, %v, %v)", ifindex, p.String(), addForSubnet)
+	log.Functionf("AddSourceRule(%d, %v, %v)", ifindex, p.String(), addForSubnet)
 	r := makeNetlinkRule(ifindex, p, addForSubnet)
-	log.Debugf("AddSourceRule: RuleAdd %v", r)
+	log.Tracef("AddSourceRule: RuleAdd %v", r)
 	// Avoid duplicate rules
 	_ = netlink.RuleDel(r)
 	if err := netlink.RuleAdd(r); err != nil {
@@ -107,9 +107,9 @@ func AddSourceRule(log *base.LogObject, ifindex int, p net.IPNet, addForSubnet b
 // specific table for the ifindex.
 func DelSourceRule(log *base.LogObject, ifindex int, p net.IPNet, addForSubnet bool) {
 
-	log.Infof("DelSourceRule(%d, %v, %v)", ifindex, p.String(), addForSubnet)
+	log.Functionf("DelSourceRule(%d, %v, %v)", ifindex, p.String(), addForSubnet)
 	r := makeNetlinkRule(ifindex, p, addForSubnet)
-	log.Debugf("DelSourceRule: RuleDel %v", r)
+	log.Tracef("DelSourceRule: RuleDel %v", r)
 	if err := netlink.RuleDel(r); err != nil {
 		log.Errorf("RuleDel %v failed with %s", r, err)
 		return

--- a/pkg/pillar/devicenetwork/pbr_linux.go
+++ b/pkg/pillar/devicenetwork/pbr_linux.go
@@ -34,7 +34,7 @@ func CopyRoutesTable(log *base.LogObject, srcTable int, ifindex int, dstTable in
 		log.Errorf("CopyRoutesTable: for src table %d, ifindex %d failed, error %v", srcTable, ifindex, err)
 		return
 	}
-	log.Infof("CopyRoutesTable(%d, %d, %d) - got %d",
+	log.Functionf("CopyRoutesTable(%d, %d, %d) - got %d",
 		srcTable, ifindex, dstTable, len(routes))
 	for _, rt := range routes {
 		if rt.Table != srcTable {
@@ -49,7 +49,7 @@ func CopyRoutesTable(log *base.LogObject, srcTable int, ifindex int, dstTable in
 		// table unless the Priority differs. Different
 		// LinkIndex, Src, Scope doesn't matter.
 		if rt.Dst != nil && rt.Dst.IP.IsLinkLocalUnicast() {
-			log.Debugf("Forcing IPv6 priority to %v",
+			log.Tracef("Forcing IPv6 priority to %v",
 				rt.LinkIndex)
 			// Hack to make the kernel routes not appear identical
 			art.Priority = rt.LinkIndex
@@ -59,7 +59,7 @@ func CopyRoutesTable(log *base.LogObject, srcTable int, ifindex int, dstTable in
 		if rt.Flags != 0 {
 			art.Flags = 0
 		}
-		log.Infof("CopyRoutesTable(%d, %d, %d) adding %v",
+		log.Functionf("CopyRoutesTable(%d, %d, %d) adding %v",
 			srcTable, ifindex, dstTable, art)
 		if err := netlink.RouteAdd(&art); err != nil {
 			log.Errorf("CopyRoutesTable failed to add %v to %d: %s",

--- a/pkg/pillar/devicenetwork/wpad.go
+++ b/pkg/pillar/devicenetwork/wpad.go
@@ -21,17 +21,17 @@ func CheckAndGetNetworkProxy(log *base.LogObject, deviceNetworkStatus *types.Dev
 	ifname := status.IfName
 	proxyConfig := &status.ProxyConfig
 
-	log.Debugf("CheckAndGetNetworkProxy(%s): enable %v, url %s\n",
+	log.Tracef("CheckAndGetNetworkProxy(%s): enable %v, url %s\n",
 		ifname, proxyConfig.NetworkProxyEnable,
 		proxyConfig.NetworkProxyURL)
 
 	if proxyConfig.Pacfile != "" {
-		log.Debugf("CheckAndGetNetworkProxy(%s): already have Pacfile\n",
+		log.Tracef("CheckAndGetNetworkProxy(%s): already have Pacfile\n",
 			ifname)
 		return nil
 	}
 	if !proxyConfig.NetworkProxyEnable {
-		log.Debugf("CheckAndGetNetworkProxy(%s): not enabled\n",
+		log.Tracef("CheckAndGetNetworkProxy(%s): not enabled\n",
 			ifname)
 		return nil
 	}
@@ -54,7 +54,7 @@ func CheckAndGetNetworkProxy(log *base.LogObject, deviceNetworkStatus *types.Dev
 		log.Errorln(errStr)
 		return errors.New(errStr)
 	}
-	log.Infof("CheckAndGetNetworkProxy(%s): DomainName %s\n",
+	log.Functionf("CheckAndGetNetworkProxy(%s): DomainName %s\n",
 		ifname, dn)
 	// Try http://wpad.%s/wpad.dat", dn where we the leading labels
 	// in DomainName until we succeed
@@ -71,7 +71,7 @@ func CheckAndGetNetworkProxy(log *base.LogObject, deviceNetworkStatus *types.Dev
 		log.Warnln(errStr)
 		i := strings.Index(dn, ".")
 		if i == -1 {
-			log.Infof("CheckAndGetNetworkProxy(%s): no dots in DomainName %s\n",
+			log.Functionf("CheckAndGetNetworkProxy(%s): no dots in DomainName %s\n",
 				ifname, dn)
 			log.Errorln(errStr)
 			return errors.New(errStr)
@@ -82,7 +82,7 @@ func CheckAndGetNetworkProxy(log *base.LogObject, deviceNetworkStatus *types.Dev
 		// since wpad.com isn't a useful place to look
 		count := strings.Count(dn, ".")
 		if count == 0 {
-			log.Infof("CheckAndGetNetworkProxy(%s): reached TLD in DomainName %s\n",
+			log.Functionf("CheckAndGetNetworkProxy(%s): reached TLD in DomainName %s\n",
 				ifname, dn)
 			log.Errorln(errStr)
 			return errors.New(errStr)
@@ -118,7 +118,7 @@ func getPacFile(log *base.LogObject, status *types.DeviceNetworkStatus, url stri
 	}
 	switch mimeType {
 	case "application/x-ns-proxy-autoconfig":
-		log.Infof("getPacFile(%s): fetched from URL %s: %s\n",
+		log.Functionf("getPacFile(%s): fetched from URL %s: %s\n",
 			ifname, url, string(contents))
 		encoded := base64.StdEncoding.EncodeToString(contents)
 		return encoded, nil

--- a/pkg/pillar/diskmetrics/usage.go
+++ b/pkg/pillar/diskmetrics/usage.go
@@ -32,18 +32,18 @@ func SizeFromDir(log *base.LogObject, dirname string) uint64 {
 	locations, err := f.Readdir(-1)
 	f.Close()
 	if err != nil {
-		//log.Debugf("Exception while reading dirs %s. Set the size to zero\n", err.Error(), dirname)
+		//log.Tracef("Exception while reading dirs %s. Set the size to zero\n", err.Error(), dirname)
 		return totalUsed
 	}
 	for _, location := range locations {
 		filename := dirname + "/" + location.Name()
-		log.Debugf("Looking in %s\n", filename)
+		log.Tracef("Looking in %s\n", filename)
 		if location.IsDir() {
 			size := SizeFromDir(log, filename)
-			log.Debugf("Dir %s size %d\n", filename, size)
+			log.Tracef("Dir %s size %d\n", filename, size)
 			totalUsed += size
 		} else {
-			log.Debugf("File %s Size %d\n", filename, location.Size())
+			log.Tracef("File %s Size %d\n", filename, location.Size())
 			totalUsed += uint64(location.Size())
 		}
 	}

--- a/pkg/pillar/execlib/execlib.go
+++ b/pkg/pillar/execlib/execlib.go
@@ -93,7 +93,7 @@ func (hdl *ExecuteHandle) Execute(args ExecuteArgs) (string, error) {
 		Combined:  args.CombinedOutput,
 		DontWait:  args.DontWait,
 	}
-	hdl.log.Infof("publish %+v", config)
+	hdl.log.Functionf("publish %+v", config)
 	hdl.pubExecConfig.Publish(config.Key(), config)
 	if args.DontWait {
 		return "", nil
@@ -138,14 +138,14 @@ func handleStatusImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
 	hdl := ctxArg.(*ExecuteHandle)
-	hdl.log.Infof("handleStatusImpl %s", key)
+	hdl.log.Functionf("handleStatusImpl %s", key)
 	if key != hdl.caller {
-		hdl.log.Infof("Mismatched key %s vs %s\n", key, hdl.caller)
+		hdl.log.Functionf("Mismatched key %s vs %s\n", key, hdl.caller)
 		return
 	}
 	status := statusArg.(types.ExecStatus)
 	if status.Sequence != hdl.sequence {
-		hdl.log.Infof("Mismatched sequence %d vs %d\n",
+		hdl.log.Functionf("Mismatched sequence %d vs %d\n",
 			status.Sequence, hdl.sequence)
 		return
 	}

--- a/pkg/pillar/iptables/iptables.go
+++ b/pkg/pillar/iptables/iptables.go
@@ -26,7 +26,7 @@ func IptableCmdOut(log *base.LogObject, args ...string) (string, error) {
 	args[0] = "-w"
 	args[1] = "5"
 	if log != nil {
-		log.Infof("Calling command %s %v\n", cmd, args)
+		log.Functionf("Calling command %s %v\n", cmd, args)
 		out, err = base.Exec(log, cmd, args...).CombinedOutput()
 	} else {
 		out, err = base.Exec(log, cmd, args...).Output()
@@ -60,7 +60,7 @@ func Ip6tableCmdOut(log *base.LogObject, args ...string) (string, error) {
 	args[0] = "-w"
 	args[1] = "5"
 	if log != nil {
-		log.Infof("Calling command %s %v\n", cmd, args)
+		log.Functionf("Calling command %s %v\n", cmd, args)
 		out, err = base.Exec(log, cmd, args...).CombinedOutput()
 	} else {
 		out, err = base.Exec(log, cmd, args...).Output()
@@ -159,7 +159,7 @@ func getIpRuleCounters(log *base.LogObject, counters []AclCounters, match *AclCo
 		if c.Piif != match.Piif || c.Poif != match.Poif {
 			continue
 		}
-		log.Debugf("getIpRuleCounters: matched counters %+v\n",
+		log.Tracef("getIpRuleCounters: matched counters %+v\n",
 			&counters[i])
 		// accumulate counter across matching ACLs
 		match.Bytes += counters[i].Bytes
@@ -282,7 +282,7 @@ type AclCounters struct {
 func parseline(log *base.LogObject, line string, table string, ipVer int) *AclCounters {
 	items := strings.Split(line, " ")
 	if len(items) < 4 {
-		// log.Debugf("Too short: %s\n", line)
+		// log.Tracef("Too short: %s\n", line)
 		return nil
 	}
 	if items[0] != "-A" {
@@ -304,7 +304,7 @@ func parseline(log *base.LogObject, line string, table string, ipVer int) *AclCo
 		}
 		// Mark RateLimit flag
 		if items[i] == "-m" && items[i+1] == "limit" {
-			// log.Debugf("Marking RateLimit: true\n")
+			// log.Tracef("Marking RateLimit: true\n")
 			ac.Limit = true
 			i += 2
 			continue
@@ -374,7 +374,7 @@ func parseline(log *base.LogObject, line string, table string, ipVer int) *AclCo
 			continue
 		}
 
-		// log.Debugf("Got more items %d %s\n", i, items[i])
+		// log.Tracef("Got more items %d %s\n", i, items[i])
 		ac.More = true
 		i += 1
 	}

--- a/pkg/pillar/iptables/ssh.go
+++ b/pkg/pillar/iptables/ssh.go
@@ -38,7 +38,7 @@ var ControlProtocolMarkingIDMap = map[string]string{
 
 func UpdateSshAccess(log *base.LogObject, enable bool, first bool) {
 
-	log.Infof("updateSshAccess(enable %v first %v)\n",
+	log.Functionf("updateSshAccess(enable %v first %v)\n",
 		enable, first)
 
 	if first {
@@ -57,7 +57,7 @@ func UpdateSshAccess(log *base.LogObject, enable bool, first bool) {
 
 func UpdateVncAccess(log *base.LogObject, enable bool) {
 
-	log.Infof("updateVncAccess(enable %v\n", enable)
+	log.Functionf("updateVncAccess(enable %v\n", enable)
 
 	if enable {
 		allowPortRange(log, 5900, 5999)
@@ -67,7 +67,7 @@ func UpdateVncAccess(log *base.LogObject, enable bool) {
 }
 
 func allowPortRange(log *base.LogObject, startPort int, endPort int) {
-	log.Infof("allowPortRange(%d, %d)\n", startPort, endPort)
+	log.Functionf("allowPortRange(%d, %d)\n", startPort, endPort)
 	// Delete these rules
 	// iptables -D INPUT -p tcp --dport 22 -j REJECT --reject-with tcp-reset
 	// ip6tables -D INPUT -p tcp --dport 22 -j REJECT --reject-with tcp-reset
@@ -83,7 +83,7 @@ func allowPortRange(log *base.LogObject, startPort int, endPort int) {
 
 // Like above but allow for 127.0.0.1 to 127.0.0.1 and block for other IPs
 func allowLocalPortRange(log *base.LogObject, startPort int, endPort int) {
-	log.Infof("allowLocalPortRange(%d, %d)\n", startPort, endPort)
+	log.Functionf("allowLocalPortRange(%d, %d)\n", startPort, endPort)
 	// Add these rules
 	// iptables -A INPUT -p tcp -s 127.0.0.1 -d 127.0.0.1 --dport 22 -j ACCEPT
 	// iptables -A INPUT -p tcp --dport 22 -j REJECT --reject-with tcp-reset
@@ -106,7 +106,7 @@ func allowLocalPortRange(log *base.LogObject, startPort int, endPort int) {
 }
 
 func dropPortRange(log *base.LogObject, startPort int, endPort int) {
-	log.Infof("dropPortRange(%d, %d)\n", startPort, endPort)
+	log.Functionf("dropPortRange(%d, %d)\n", startPort, endPort)
 	// Add these rules
 	// iptables -A INPUT -p tcp --dport 22 -j REJECT --reject-with tcp-reset
 	// ip6tables -A INPUT -p tcp --dport 22 -j REJECT --reject-with tcp-reset

--- a/pkg/pillar/pidfile/pidfile.go
+++ b/pkg/pillar/pidfile/pidfile.go
@@ -36,7 +36,7 @@ func CheckAndCreatePidfile(log *base.LogObject, agentName string) error {
 		}
 		return nil
 	}
-	log.Infof("checkAndCreatePidfile: found %s\n", filename)
+	log.Functionf("checkAndCreatePidfile: found %s\n", filename)
 	// Check if process still exists
 	b, err := ioutil.ReadFile(filename)
 	if err != nil {

--- a/pkg/pillar/pubsub/checkmaxtime.go
+++ b/pkg/pillar/pubsub/checkmaxtime.go
@@ -21,7 +21,7 @@ var lockedLastStillMap = base.NewLockedStringMap()
 // Those files are observed by the watchdog
 func (p *PubSub) StillRunning(agentName string, warnTime time.Duration, errTime time.Duration) {
 	log := p.log
-	log.Debugf("StillRunning(%s)\n", agentName)
+	log.Tracef("StillRunning(%s)\n", agentName)
 
 	if lsValue, found := lockedLastStillMap.Load(agentName); !found {
 		lockedLastStillMap.Store(agentName, time.Now())
@@ -46,7 +46,7 @@ func (p *PubSub) StillRunning(agentName string, warnTime time.Duration, errTime 
 	if err != nil {
 		file, err := os.Create(filename)
 		if err != nil {
-			log.Infof("StillRunning: %s\n", err)
+			log.Functionf("StillRunning: %s\n", err)
 			return
 		}
 		file.Close()

--- a/pkg/pillar/pubsub/legacy/legacy.go
+++ b/pkg/pillar/pubsub/legacy/legacy.go
@@ -38,7 +38,7 @@ func Publish(agentName string, topicType interface{}) (pubsub.Publication, error
 	if once() {
 		initialize(agentName)
 	}
-	log.Debugf("legacy.Publish agentName(%s)", agentName)
+	log.Tracef("legacy.Publish agentName(%s)", agentName)
 	return defaultPubsub.NewPublication(pubsub.PublicationOptions{
 		AgentName: agentName,
 		TopicType: topicType,
@@ -52,7 +52,7 @@ func PublishPersistent(agentName string, topicType interface{}) (pubsub.Publicat
 	if once() {
 		initialize(agentName)
 	}
-	log.Infof("legacy.PublishPersistent agentName(%s)", agentName)
+	log.Functionf("legacy.PublishPersistent agentName(%s)", agentName)
 	return defaultPubsub.NewPublication(pubsub.PublicationOptions{
 		AgentName:  agentName,
 		TopicType:  topicType,

--- a/pkg/pillar/pubsub/pubsub.go
+++ b/pkg/pillar/pubsub/pubsub.go
@@ -127,7 +127,7 @@ func (p *PubSub) NewSubscription(options SubscriptionOptions) (Subscription, err
 	}
 	sub.driver = driver
 
-	sub.log.Infof("Subscribe(%s)\n", name)
+	sub.log.Functionf("Subscribe(%s)\n", name)
 	if options.Activate {
 		if err := sub.Activate(); err != nil {
 			return sub, err
@@ -175,7 +175,7 @@ func (p *PubSub) NewPublication(options PublicationOptions) (Publication, error)
 	// create the driver
 	name := pub.nameString()
 	global := options.AgentName == ""
-	pub.log.Debugf("publishImpl agentName(%s), agentScope(%s), topic(%s), nameString(%s), global(%v), persistent(%v)\n",
+	pub.log.Tracef("publishImpl agentName(%s), agentScope(%s), topic(%s), nameString(%s), global(%v), persistent(%v)\n",
 		options.AgentName, options.AgentScope, topic, name, global, options.Persistent)
 	driver, err := p.driver.Publisher(global, name, topic, options.Persistent, p.updaterList, pub, pub)
 	if err != nil {
@@ -187,7 +187,7 @@ func (p *PubSub) NewPublication(options PublicationOptions) (Publication, error)
 	if pub.logger.GetLevel() == logrus.TraceLevel {
 		pub.dump("after populate")
 	}
-	pub.log.Debugf("Publish(%s)\n", name)
+	pub.log.Tracef("Publish(%s)\n", name)
 
 	pub.publisher()
 

--- a/pkg/pillar/pubsub/reverse/publish.go
+++ b/pkg/pillar/pubsub/reverse/publish.go
@@ -19,7 +19,7 @@ import (
 
 // Publish publishes data to
 func Publish(log *base.LogObject, agent string, data interface{}) error {
-	log.Infof("publish(%s)", agent)
+	log.Functionf("publish(%s)", agent)
 	sockName := getSocketName(agent, data)
 
 	if _, err := os.Stat(sockName); err != nil {

--- a/pkg/pillar/pubsub/reverse/subscribe.go
+++ b/pkg/pillar/pubsub/reverse/subscribe.go
@@ -28,11 +28,11 @@ func NewSubscriber(log *base.LogObject, agent string, topic interface{}) <-chan 
 
 // startSubscriber Creates a socket for the agent and starts listening
 func startSubscriber(log *base.LogObject, agent string, topic interface{}, retChan chan<- string) {
-	log.Infof("startSubscriber(%s)", agent)
+	log.Functionf("startSubscriber(%s)", agent)
 	sockName := getSocketName(agent, topic)
 	dir := path.Dir(sockName)
 	if _, err := os.Stat(dir); err != nil {
-		log.Infof("startSubscriber(%s): Create %s\n", agent, dir)
+		log.Functionf("startSubscriber(%s): Create %s\n", agent, dir)
 		if err := os.MkdirAll(dir, 0700); err != nil {
 			log.Fatalf("startSubscriber(%s): Exception while creating %s. %s",
 				agent, dir, err)

--- a/pkg/pillar/pubsub/socketdriver/driver.go
+++ b/pkg/pillar/pubsub/socketdriver/driver.go
@@ -99,7 +99,7 @@ func (s *SocketDriver) Publisher(global bool, name, topic string, persistent boo
 	}
 
 	if _, err := os.Stat(dirName); err != nil {
-		s.Log.Infof("Publish Create %s\n", dirName)
+		s.Log.Functionf("Publish Create %s\n", dirName)
 		if err := os.MkdirAll(dirName, 0700); err != nil {
 			errStr := fmt.Sprintf("Publish(%s): %s",
 				name, err)
@@ -114,7 +114,7 @@ func (s *SocketDriver) Publisher(global bool, name, topic string, persistent boo
 		sockName = s.sockName(name)
 		dir := path.Dir(sockName)
 		if _, err := os.Stat(dir); err != nil {
-			s.Log.Infof("Publish Create %s\n", dir)
+			s.Log.Functionf("Publish Create %s\n", dir)
 			if err := os.MkdirAll(dir, 0700); err != nil {
 				errStr := fmt.Sprintf("Publish(%s): %s",
 					name, err)

--- a/pkg/pillar/pubsub/subscribe.go
+++ b/pkg/pillar/pubsub/subscribe.go
@@ -60,7 +60,7 @@ func (sub *SubscriptionImpl) Close() error {
 	sub.driver.Stop()
 	items := sub.GetAll()
 	for key := range items {
-		sub.log.Infof("Close(%s) unloading key %s",
+		sub.log.Functionf("Close(%s) unloading key %s",
 			sub.nameString(), key)
 		handleDelete(sub, key)
 	}
@@ -83,7 +83,7 @@ func (sub *SubscriptionImpl) Close() error {
 func (sub *SubscriptionImpl) populate() {
 	name := sub.nameString()
 
-	sub.log.Infof("populate(%s)", name)
+	sub.log.Functionf("populate(%s)", name)
 
 	pairs, restarted, err := sub.driver.Load()
 	if err != nil {
@@ -92,13 +92,13 @@ func (sub *SubscriptionImpl) populate() {
 		return
 	}
 	for key, itemB := range pairs {
-		sub.log.Infof("populate(%s) key %s", name, key)
+		sub.log.Functionf("populate(%s) key %s", name, key)
 		handleModify(sub, key, itemB)
 	}
 	if restarted {
 		handleRestart(sub, true)
 	}
-	sub.log.Infof("populate(%s) done", name)
+	sub.log.Functionf("populate(%s) done", name)
 }
 
 // ProcessChange process a single change and its parameters. It
@@ -108,7 +108,7 @@ func (sub *SubscriptionImpl) populate() {
 //   fooAll := s1.GetAll()
 func (sub *SubscriptionImpl) ProcessChange(change Change) {
 	start := time.Now()
-	sub.log.Debugf("ProcessChange agentName(%s) agentScope(%s) topic(%s): %#v", sub.agentName, sub.agentScope, sub.topic, change)
+	sub.log.Tracef("ProcessChange agentName(%s) agentScope(%s) topic(%s): %#v", sub.agentName, sub.agentScope, sub.topic, change)
 
 	switch change.Operation {
 	case Restart:
@@ -182,26 +182,26 @@ func (sub *SubscriptionImpl) nameString() string {
 
 func (sub *SubscriptionImpl) dump(infoStr string) {
 	name := sub.nameString()
-	sub.log.Debugf("dump(%s) %s\n", name, infoStr)
+	sub.log.Tracef("dump(%s) %s\n", name, infoStr)
 	dumper := func(key string, val interface{}) bool {
 		_, err := json.Marshal(val)
 		if err != nil {
 			sub.log.Fatal("json Marshal in dump", err)
 		}
 		// DO NOT log Values. They may contain sensitive information.
-		sub.log.Debugf("\tkey %s", key)
+		sub.log.Tracef("\tkey %s", key)
 		return true
 	}
 	sub.km.key.Range(dumper)
-	sub.log.Debugf("\trestarted %t\n", sub.km.restarted)
-	sub.log.Debugf("\tsynchronized %t\n", sub.synchronized)
+	sub.log.Tracef("\trestarted %t\n", sub.km.restarted)
+	sub.log.Tracef("\tsynchronized %t\n", sub.synchronized)
 }
 
 // handlers
 func handleModify(ctxArg interface{}, key string, itemcb []byte) {
 	sub := ctxArg.(*SubscriptionImpl)
 	name := sub.nameString()
-	sub.log.Debugf("pubsub.handleModify(%s) key %s\n", name, key)
+	sub.log.Tracef("pubsub.handleModify(%s) key %s\n", name, key)
 	item, err := parseTemplate(sub.log, itemcb, sub.topicType)
 	if err != nil {
 		errStr := fmt.Sprintf("handleModify(%s): json failed %s",
@@ -213,11 +213,11 @@ func handleModify(ctxArg interface{}, key string, itemcb []byte) {
 	m, ok := sub.km.key.Load(key)
 	if ok {
 		if cmp.Equal(m, item) {
-			sub.log.Debugf("pubsub.handleModify(%s/%s) unchanged\n",
+			sub.log.Tracef("pubsub.handleModify(%s/%s) unchanged\n",
 				name, key)
 			return
 		}
-		sub.log.Debugf("pubsub.handleModify(%s/%s) replacing due to diff",
+		sub.log.Tracef("pubsub.handleModify(%s/%s) replacing due to diff",
 			name, key)
 		loggable, ok := item.(base.LoggableObject)
 		if ok {
@@ -225,7 +225,7 @@ func handleModify(ctxArg interface{}, key string, itemcb []byte) {
 		}
 	} else {
 		// DO NOT log Values. They may contain sensitive information.
-		sub.log.Debugf("pubsub.handleModify(%s) add for key %s\n",
+		sub.log.Tracef("pubsub.handleModify(%s) add for key %s\n",
 			name, key)
 		created = true
 		loggable, ok := item.(base.LoggableObject)
@@ -248,13 +248,13 @@ func handleModify(ctxArg interface{}, key string, itemcb []byte) {
 			(sub.ModifyHandler)(sub.userCtx, key, newItem, m)
 		}
 	}
-	sub.log.Debugf("pubsub.handleModify(%s) done for key %s\n", name, key)
+	sub.log.Tracef("pubsub.handleModify(%s) done for key %s\n", name, key)
 }
 
 func handleDelete(ctxArg interface{}, key string) {
 	sub := ctxArg.(*SubscriptionImpl)
 	name := sub.nameString()
-	sub.log.Debugf("pubsub.handleDelete(%s) key %s\n", name, key)
+	sub.log.Tracef("pubsub.handleDelete(%s) key %s\n", name, key)
 
 	m, ok := sub.km.key.Load(key)
 	if !ok {
@@ -267,7 +267,7 @@ func handleDelete(ctxArg interface{}, key string) {
 		loggable.LogDelete(sub.log)
 	}
 	// DO NOT log Values. They may contain sensitive information.
-	sub.log.Debugf("pubsub.handleDelete(%s) key %s", name, key)
+	sub.log.Tracef("pubsub.handleDelete(%s) key %s", name, key)
 	sub.km.key.Delete(key)
 	if sub.logger.GetLevel() == logrus.TraceLevel {
 		sub.dump("after handleDelete")
@@ -275,37 +275,37 @@ func handleDelete(ctxArg interface{}, key string) {
 	if sub.DeleteHandler != nil {
 		(sub.DeleteHandler)(sub.userCtx, key, m)
 	}
-	sub.log.Debugf("pubsub.handleDelete(%s) done for key %s\n", name, key)
+	sub.log.Tracef("pubsub.handleDelete(%s) done for key %s\n", name, key)
 }
 
 func handleRestart(ctxArg interface{}, restarted bool) {
 	sub := ctxArg.(*SubscriptionImpl)
 	name := sub.nameString()
-	sub.log.Debugf("pubsub.handleRestart(%s) restarted %v\n", name, restarted)
+	sub.log.Tracef("pubsub.handleRestart(%s) restarted %v\n", name, restarted)
 	if restarted == sub.km.restarted {
-		sub.log.Debugf("pubsub.handleRestart(%s) value unchanged\n", name)
+		sub.log.Tracef("pubsub.handleRestart(%s) value unchanged\n", name)
 		return
 	}
 	sub.km.restarted = restarted
 	if sub.RestartHandler != nil {
 		(sub.RestartHandler)(sub.userCtx, restarted)
 	}
-	sub.log.Debugf("pubsub.handleRestart(%s) done for restarted %v\n",
+	sub.log.Tracef("pubsub.handleRestart(%s) done for restarted %v\n",
 		name, restarted)
 }
 
 func handleSynchronized(ctxArg interface{}, synchronized bool) {
 	sub := ctxArg.(*SubscriptionImpl)
 	name := sub.nameString()
-	sub.log.Debugf("pubsub.handleSynchronized(%s) synchronized %v\n", name, synchronized)
+	sub.log.Tracef("pubsub.handleSynchronized(%s) synchronized %v\n", name, synchronized)
 	if synchronized == sub.synchronized {
-		sub.log.Debugf("pubsub.handleSynchronized(%s) value unchanged\n", name)
+		sub.log.Tracef("pubsub.handleSynchronized(%s) value unchanged\n", name)
 		return
 	}
 	sub.synchronized = synchronized
 	if sub.SynchronizedHandler != nil {
 		(sub.SynchronizedHandler)(sub.userCtx, synchronized)
 	}
-	sub.log.Debugf("pubsub.handleSynchronized(%s) done for synchronized %v\n",
+	sub.log.Tracef("pubsub.handleSynchronized(%s) done for synchronized %v\n",
 		name, synchronized)
 }

--- a/pkg/pillar/pubsub/unsubscribe_test.go
+++ b/pkg/pillar/pubsub/unsubscribe_test.go
@@ -88,12 +88,12 @@ func TestUnsubscribe(t *testing.T) {
 				t.Fatalf("unable to publish: %v", err)
 			}
 			item1 := item{FieldA: "item1"}
-			log.Infof("Publishing key1")
+			log.Functionf("Publishing key1")
 			pub.Publish("key1", item1)
-			log.Infof("SignalRestarted")
+			log.Functionf("SignalRestarted")
 			pub.SignalRestarted()
 
-			log.Infof("NewSubscription")
+			log.Functionf("NewSubscription")
 			sub, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 				AgentName:  test.agentName,
 				AgentScope: test.agentScope,
@@ -104,35 +104,35 @@ func TestUnsubscribe(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unable to subscribe: %v", err)
 			}
-			log.Infof("Activate")
+			log.Functionf("Activate")
 			sub.Activate()
 			// Process subscription to populate
 			for !sub.Synchronized() || !sub.Restarted() {
 				select {
 				case change := <-sub.MsgChan():
-					log.Infof("ProcessChange")
+					log.Functionf("ProcessChange")
 					sub.ProcessChange(change)
 				}
 			}
 			items := sub.GetAll()
 			assert.Equal(t, 1, len(items))
 
-			log.Infof("sub.Close")
+			log.Functionf("sub.Close")
 			sub.Close()
 			assert.Equal(t, 1, len(items))
 
 			for sub.Synchronized() {
 				select {
 				case change := <-sub.MsgChan():
-					log.Infof("ProcessChange")
+					log.Functionf("ProcessChange")
 					sub.ProcessChange(change)
 				}
 			}
 			items = sub.GetAll()
 			assert.Equal(t, 0, len(items))
-			log.Infof("pub.Close")
+			log.Functionf("pub.Close")
 			pub.Close()
-			log.Infof("Waiting to end test case pub %s", testname)
+			log.Functionf("Waiting to end test case pub %s", testname)
 			// Wait for fsnotify to go away
 			time.Sleep(time.Second)
 

--- a/pkg/pillar/queuelock/queuelock.go
+++ b/pkg/pillar/queuelock/queuelock.go
@@ -29,7 +29,7 @@ type Handle struct {
 
 // NewQueueLock creates a lock
 func NewQueueLock(log *base.LogObject) *Handle {
-	log.Infof("NewQueueLock()")
+	log.Functionf("NewQueueLock()")
 	handle := Handle{
 		next: make(chan uint, 1),
 		log:  log,
@@ -50,12 +50,12 @@ func (hdl *Handle) Enter(work uint) bool {
 	defer hdl.Unlock()
 	if hdl.isRunning {
 		hdl.enqueue(work)
-		hdl.log.Infof("Enter(%d) queued", work)
+		hdl.log.Functionf("Enter(%d) queued", work)
 		return false
 	}
 	hdl.isRunning = true
 	hdl.running = work
-	hdl.log.Infof("Enter(%d) ok", work)
+	hdl.log.Functionf("Enter(%d) ok", work)
 	return true
 }
 
@@ -74,14 +74,14 @@ func (hdl *Handle) Exit(work uint) {
 	hdl.isRunning = false
 	hdl.running = 0
 	if len(hdl.waiting) == 0 {
-		hdl.log.Infof("Exit(%d) no waiting", work)
+		hdl.log.Functionf("Exit(%d) no waiting", work)
 		return
 	}
-	hdl.log.Infof("Exit(%d) %d waiting", work, len(hdl.waiting))
+	hdl.log.Functionf("Exit(%d) %d waiting", work, len(hdl.waiting))
 	next := hdl.dequeue()
 	select {
 	case hdl.next <- next:
-		hdl.log.Infof("Exit() sent %d", next)
+		hdl.log.Functionf("Exit() sent %d", next)
 	default:
 		hdl.log.Panicf("Exit channel busy")
 	}
@@ -107,27 +107,27 @@ func (hdl *Handle) NumWaiters() int {
 // Caller must hold lock
 // Supress duplicates when adding
 func (hdl *Handle) enqueue(work uint) {
-	hdl.log.Infof("enqueue(%d) %d waiting", work, len(hdl.waiting))
+	hdl.log.Functionf("enqueue(%d) %d waiting", work, len(hdl.waiting))
 	for i := range hdl.waiting {
 		if hdl.waiting[i] == work {
-			hdl.log.Infof("queue(%d) duplicate at %d, %d waiting",
+			hdl.log.Functionf("queue(%d) duplicate at %d, %d waiting",
 				work, i, len(hdl.waiting))
 			return
 		}
 	}
 	hdl.waiting = append(hdl.waiting, work)
-	hdl.log.Infof("queue(%d) done, %d waiting", work, len(hdl.waiting))
+	hdl.log.Functionf("queue(%d) done, %d waiting", work, len(hdl.waiting))
 }
 
 // Caller must hold lock
 // Panic if empty
 func (hdl *Handle) dequeue() uint {
-	hdl.log.Infof("dequeue() %d waiting", len(hdl.waiting))
+	hdl.log.Functionf("dequeue() %d waiting", len(hdl.waiting))
 	if len(hdl.waiting) == 0 {
 		hdl.log.Panicf("dequeue empty waiting")
 	}
 	work := hdl.waiting[0]
 	hdl.waiting = hdl.waiting[1:]
-	hdl.log.Infof("dequeue -> %d, %d waiting", work, len(hdl.waiting))
+	hdl.log.Functionf("dequeue -> %d, %d waiting", work, len(hdl.waiting))
 	return work
 }

--- a/pkg/pillar/sema/sema.go
+++ b/pkg/pillar/sema/sema.go
@@ -17,7 +17,7 @@ type Semaphore struct {
 
 // New returns a Semaphore object
 func New(log *base.LogObject, n int) *Semaphore {
-	log.Infof("sema.New()")
+	log.Functionf("sema.New()")
 	return &Semaphore{
 		c:   make(chan empty, n),
 		log: log,
@@ -27,19 +27,19 @@ func New(log *base.LogObject, n int) *Semaphore {
 
 // Acquire n resources
 func (s *Semaphore) P(n int) {
-	s.log.Infof("sema.P(%d)", n)
+	s.log.Functionf("sema.P(%d)", n)
 	var e empty
 	for i := 0; i < n; i++ {
 		s.c <- e
 	}
-	s.log.Infof("sema.P(%d) done", n)
+	s.log.Functionf("sema.P(%d) done", n)
 }
 
 // Release n resources
 func (s *Semaphore) V(n int) {
-	s.log.Infof("sema.V(%d)", n)
+	s.log.Functionf("sema.V(%d)", n)
 	for i := 0; i < n; i++ {
 		<-s.c
 	}
-	s.log.Infof("sema.V(%d) done", n)
+	s.log.Functionf("sema.V(%d) done", n)
 }

--- a/pkg/pillar/ssh/ssh.go
+++ b/pkg/pillar/ssh/ssh.go
@@ -33,7 +33,7 @@ const (
 
 func UpdateSshAuthorizedKeys(log *base.LogObject, authorizedKeys string) {
 
-	log.Infof("UpdateSshAuthorizedKeys: %s", authorizedKeys)
+	log.Functionf("UpdateSshAuthorizedKeys: %s", authorizedKeys)
 	tmpfile, err := ioutil.TempFile(runDir, "ak")
 	if err != nil {
 		log.Errorln("TempFile ", err)
@@ -51,7 +51,7 @@ func UpdateSshAuthorizedKeys(log *base.LogObject, authorizedKeys string) {
 		for {
 			line, err := reader.ReadString('\n')
 			if err != nil {
-				log.Debugln(err)
+				log.Traceln(err)
 				if err != io.EOF {
 					log.Errorln("ReadString ", err)
 					return
@@ -92,5 +92,5 @@ func UpdateSshAuthorizedKeys(log *base.LogObject, authorizedKeys string) {
 		log.Errorln(err)
 		return
 	}
-	log.Infof("UpdateSshAuthorizedKey done")
+	log.Functionf("UpdateSshAuthorizedKey done")
 }

--- a/pkg/pillar/types/assignableadapters.go
+++ b/pkg/pillar/types/assignableadapters.go
@@ -90,58 +90,58 @@ var nilUUID = uuid.UUID{}
 // or the Physical Adapter has changed.
 func (ib IoBundle) HasAdapterChanged(log *base.LogObject, phyAdapter PhysicalIOAdapter) bool {
 	if IoType(phyAdapter.Ptype) != ib.Type {
-		log.Infof("Type changed from %d to %d", ib.Type, phyAdapter.Ptype)
+		log.Functionf("Type changed from %d to %d", ib.Type, phyAdapter.Ptype)
 		return true
 	}
 	if phyAdapter.Phylabel != ib.Phylabel {
-		log.Infof("Name changed from %s to %s", ib.Phylabel, phyAdapter.Phylabel)
+		log.Functionf("Name changed from %s to %s", ib.Phylabel, phyAdapter.Phylabel)
 		return true
 	}
 	if phyAdapter.Phyaddr.PciLong != ib.PciLong {
-		log.Infof("PciLong changed from %s to %s",
+		log.Functionf("PciLong changed from %s to %s",
 			ib.PciLong, phyAdapter.Phyaddr.PciLong)
 		return true
 	}
 	if phyAdapter.Phyaddr.Ifname != ib.Ifname {
-		log.Infof("Ifname changed from %s to %s",
+		log.Functionf("Ifname changed from %s to %s",
 			ib.Ifname, phyAdapter.Phyaddr.Ifname)
 		return true
 	}
 	if phyAdapter.Phyaddr.Serial != ib.Serial {
-		log.Infof("Serial changed from %s to %s",
+		log.Functionf("Serial changed from %s to %s",
 			ib.Serial, phyAdapter.Phyaddr.Serial)
 		return true
 	}
 	if phyAdapter.Phyaddr.UsbAddr != ib.UsbAddr {
-		log.Infof("USB address changed from %s to %s",
+		log.Functionf("USB address changed from %s to %s",
 			ib.UsbAddr, phyAdapter.Phyaddr.UsbAddr)
 		return true
 	}
 	if phyAdapter.Phyaddr.Irq != ib.Irq {
-		log.Infof("Irq changed from %s to %s", ib.Irq, phyAdapter.Phyaddr.Irq)
+		log.Functionf("Irq changed from %s to %s", ib.Irq, phyAdapter.Phyaddr.Irq)
 		return true
 	}
 	if phyAdapter.Phyaddr.Ioports != ib.Ioports {
-		log.Infof("Ioports changed from %s to %s",
+		log.Functionf("Ioports changed from %s to %s",
 			ib.Ioports, phyAdapter.Phyaddr.Ioports)
 		return true
 	}
 	if phyAdapter.Logicallabel != ib.Logicallabel {
-		log.Infof("Logicallabel changed from %s to %s",
+		log.Functionf("Logicallabel changed from %s to %s",
 			ib.Logicallabel, phyAdapter.Logicallabel)
 		return true
 	}
 	if phyAdapter.Assigngrp != ib.AssignmentGroup {
-		log.Infof("Ifname changed from %s to %s",
+		log.Functionf("Ifname changed from %s to %s",
 			ib.AssignmentGroup, phyAdapter.Assigngrp)
 		return true
 	}
 	if phyAdapter.Usage != ib.Usage {
-		log.Infof("Usage changed from %d to %d", ib.Usage, phyAdapter.Usage)
+		log.Functionf("Usage changed from %d to %d", ib.Usage, phyAdapter.Usage)
 		return true
 	}
 	if phyAdapter.UsagePolicy.FreeUplink != ib.FreeUplink {
-		log.Infof("FreeUplink changed from %t to %t",
+		log.Functionf("FreeUplink changed from %t to %t",
 			ib.FreeUplink, phyAdapter.UsagePolicy.FreeUplink)
 		return true
 	}
@@ -254,38 +254,38 @@ func (aa AssignableAdapters) LogKey() string {
 func (aa *AssignableAdapters) AddOrUpdateIoBundle(log *base.LogObject, ib IoBundle) {
 	curIbPtr := aa.LookupIoBundlePhylabel(ib.Phylabel)
 	if curIbPtr == nil {
-		log.Infof("AddOrUpdateIoBundle(%d %s %s) New bundle",
+		log.Functionf("AddOrUpdateIoBundle(%d %s %s) New bundle",
 			ib.Type, ib.Phylabel, ib.AssignmentGroup)
 		aa.IoBundleList = append(aa.IoBundleList, ib)
 		return
 	}
-	log.Infof("AddOrUpdateIoBundle(%d %s %s) Update bundle; diff %+v",
+	log.Functionf("AddOrUpdateIoBundle(%d %s %s) Update bundle; diff %+v",
 		ib.Type, ib.Phylabel, ib.AssignmentGroup,
 		cmp.Diff(*curIbPtr, ib))
 
 	// We preserve the most specific
 	if curIbPtr.UsedByUUID != nilUUID {
-		log.Infof("AddOrUpdateIoBundle(%d %s %s) preserve UsedByUUID %v",
+		log.Functionf("AddOrUpdateIoBundle(%d %s %s) preserve UsedByUUID %v",
 			ib.Type, ib.Phylabel, ib.AssignmentGroup, curIbPtr.UsedByUUID)
 		ib.UsedByUUID = curIbPtr.UsedByUUID
 	}
 	if curIbPtr.IsPort {
-		log.Infof("AddOrUpdateIoBundle(%d %s %s) preserve IsPort %t",
+		log.Functionf("AddOrUpdateIoBundle(%d %s %s) preserve IsPort %t",
 			ib.Type, ib.Phylabel, ib.AssignmentGroup, curIbPtr.IsPort)
 		ib.IsPort = curIbPtr.IsPort
 	}
 	if curIbPtr.IsPCIBack {
-		log.Infof("AddOrUpdateIoBundle(%d %s %s) preserve IsPCIBack %t",
+		log.Functionf("AddOrUpdateIoBundle(%d %s %s) preserve IsPCIBack %t",
 			ib.Type, ib.Phylabel, ib.AssignmentGroup, curIbPtr.IsPCIBack)
 		ib.IsPCIBack = curIbPtr.IsPCIBack
 	}
 	if curIbPtr.Unique != "" {
-		log.Infof("AddOrUpdateIoBundle(%d %s %s) preserve Unique %v",
+		log.Functionf("AddOrUpdateIoBundle(%d %s %s) preserve Unique %v",
 			ib.Type, ib.Phylabel, ib.AssignmentGroup, curIbPtr.Unique)
 		ib.Unique = curIbPtr.Unique
 	}
 	if curIbPtr.MacAddr != "" {
-		log.Infof("AddOrUpdateIoBundle(%d %s %s) preserve MacAddr %v",
+		log.Functionf("AddOrUpdateIoBundle(%d %s %s) preserve MacAddr %v",
 			ib.Type, ib.Phylabel, ib.AssignmentGroup, curIbPtr.MacAddr)
 		ib.MacAddr = curIbPtr.MacAddr
 	}

--- a/pkg/pillar/types/ifnametopci.go
+++ b/pkg/pillar/types/ifnametopci.go
@@ -115,7 +115,7 @@ func PciLongToIfname(log *base.LogObject, long string) (bool, string) {
 		return false, ""
 	}
 	ifname := locations[0].Name()
-	log.Infof("PciLongToIfname(%s) %s", long, ifname)
+	log.Functionf("PciLongToIfname(%s) %s", long, ifname)
 	return true, ifname
 }
 
@@ -170,7 +170,7 @@ func IoBundleToPci(log *base.LogObject, ib *IoBundle) (string, error) {
 // IfRename brings down the interface, renames it, and brings it back up
 func IfRename(log *base.LogObject, ifname string, newIfname string) error {
 
-	log.Infof("IfRename %s to %s", ifname, newIfname)
+	log.Functionf("IfRename %s to %s", ifname, newIfname)
 	link, err := netlink.LinkByName(ifname)
 	if link == nil {
 		log.Errorf("LinkByname on %s failed: %s", ifname, err)

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -669,14 +669,14 @@ func (config *DevicePortConfig) DoSanitize(log *base.LogObject,
 			} else {
 				config.TimePriority = time.Unix(0, 0)
 			}
-			log.Infof("DoSanitize: Forcing TimePriority for %s to %v\n",
+			log.Functionf("DoSanitize: Forcing TimePriority for %s to %v\n",
 				key, config.TimePriority)
 		}
 	}
 	if sanitizeKey {
 		if config.Key == "" {
 			config.Key = key
-			log.Infof("DoSanitize: Forcing Key for %s TS %v\n",
+			log.Functionf("DoSanitize: Forcing Key for %s TS %v\n",
 				key, config.TimePriority)
 		}
 	}
@@ -687,12 +687,12 @@ func (config *DevicePortConfig) DoSanitize(log *base.LogObject,
 			port := &config.Ports[i]
 			if port.Phylabel == "" {
 				port.Phylabel = port.IfName
-				log.Infof("XXX DoSanitize: Forcing Phylabel for %s ifname %s\n",
+				log.Functionf("XXX DoSanitize: Forcing Phylabel for %s ifname %s\n",
 					key, port.IfName)
 			}
 			if port.Logicallabel == "" {
 				port.Logicallabel = port.IfName
-				log.Infof("XXX DoSanitize: Forcing Logicallabel for %s ifname %s\n",
+				log.Functionf("XXX DoSanitize: Forcing Logicallabel for %s ifname %s\n",
 					key, port.IfName)
 			}
 		}
@@ -1624,10 +1624,10 @@ func LogicallabelToIfName(deviceNetworkStatus *DeviceNetworkStatus,
 func (config *DevicePortConfig) IsAnyPortInPciBack(
 	log *base.LogObject, aa *AssignableAdapters) (bool, string, uuid.UUID) {
 	if aa == nil {
-		log.Infof("IsAnyPortInPciBack: nil aa")
+		log.Functionf("IsAnyPortInPciBack: nil aa")
 		return false, "", uuid.UUID{}
 	}
-	log.Infof("IsAnyPortInPciBack: aa init %t, %d bundles, %d ports",
+	log.Functionf("IsAnyPortInPciBack: aa init %t, %d bundles, %d ports",
 		aa.Initialized, len(aa.IoBundleList), len(config.Ports))
 	for _, port := range config.Ports {
 		ioBundle := aa.LookupIoBundleIfName(port.IfName)
@@ -1635,7 +1635,7 @@ func (config *DevicePortConfig) IsAnyPortInPciBack(
 			// It is not guaranteed that all Ports are part of Assignable Adapters
 			// If not found, the adapter is not capable of being assigned at
 			// PCI level. So it cannot be in PCI back.
-			log.Infof("IsAnyPortInPciBack: ifname %s not found",
+			log.Functionf("IsAnyPortInPciBack: ifname %s not found",
 				port.IfName)
 			continue
 		}
@@ -1879,7 +1879,7 @@ func (instanceInfo *NetworkInstanceInfo) IsVifInBridge(
 
 func (instanceInfo *NetworkInstanceInfo) RemoveVif(log *base.LogObject,
 	vifName string) {
-	log.Infof("DelVif(%s, %s)\n", instanceInfo.BridgeName, vifName)
+	log.Functionf("DelVif(%s, %s)\n", instanceInfo.BridgeName, vifName)
 
 	var vifs []VifNameMac
 	for _, vif := range instanceInfo.Vifs {
@@ -1893,7 +1893,7 @@ func (instanceInfo *NetworkInstanceInfo) RemoveVif(log *base.LogObject,
 func (instanceInfo *NetworkInstanceInfo) AddVif(log *base.LogObject,
 	vifName string, appMac string, appID uuid.UUID) {
 
-	log.Infof("addVifToBridge(%s, %s, %s, %s)\n",
+	log.Functionf("addVifToBridge(%s, %s, %s, %s)\n",
 		instanceInfo.BridgeName, vifName, appMac, appID.String())
 	// XXX Should we just overwrite it? There is a lookup function
 	//	anyways if the caller wants "check and add" semantics
@@ -2302,7 +2302,7 @@ func (status *NetworkInstanceStatus) UpdateNetworkMetrics(log *base.LogObject,
 	for _, vif := range status.Vifs {
 		metric, found := nms.LookupNetworkMetrics(vif.Name)
 		if !found {
-			log.Debugf("No metrics found for interface %s",
+			log.Tracef("No metrics found for interface %s",
 				vif.Name)
 			continue
 		}
@@ -2337,7 +2337,7 @@ func (status *NetworkInstanceStatus) UpdateBridgeMetrics(log *base.LogObject,
 	// Get bridge metrics
 	bridgeMetric, found := nms.LookupNetworkMetrics(status.BridgeName)
 	if !found {
-		log.Debugf("No metrics found for Bridge %s",
+		log.Tracef("No metrics found for Bridge %s",
 			status.BridgeName)
 	} else {
 		netMetric.TxErrors += bridgeMetric.TxErrors

--- a/pkg/pillar/utils/ledmanagerutils.go
+++ b/pkg/pillar/utils/ledmanagerutils.go
@@ -26,14 +26,14 @@ func UpdateLedManagerConfig(log *base.LogObject, count int) {
 	if err == nil {
 		bc := item.(types.LedBlinkCounter)
 		if bc.BlinkCounter == count {
-			log.Debugf("UpdateLedManagerConfig: unchanged at %d",
+			log.Tracef("UpdateLedManagerConfig: unchanged at %d",
 				count)
 			return
 		}
-		log.Infof("UpdateLedManagerConfig: set %d was %d", count,
+		log.Functionf("UpdateLedManagerConfig: set %d was %d", count,
 			bc.BlinkCounter)
 	} else {
-		log.Infof("UpdateLedManagerConfig: set to %d", count)
+		log.Functionf("UpdateLedManagerConfig: set to %d", count)
 	}
 	err = pub.Publish(ledConfigKey, blinkCount)
 	if err != nil {

--- a/pkg/pillar/utils/waitfor.go
+++ b/pkg/pillar/utils/waitfor.go
@@ -46,7 +46,7 @@ func WaitForVault(ps *pubsub.PubSub, log *base.LogObject, agentName string, warn
 
 	// Wait for vault to be ready, which might be delayed due to attestation
 	for !Ctx.Initialized {
-		log.Infof("Waiting for VaultStatus initialized")
+		log.Functionf("Waiting for VaultStatus initialized")
 		select {
 		case change := <-subVaultStatus.MsgChan():
 			subVaultStatus.ProcessChange(change)
@@ -107,7 +107,7 @@ func WaitForOnboarded(ps *pubsub.PubSub, log *base.LogObject, agentName string, 
 
 	// Wait for Onboarding to be done by client
 	for !Ctx.Initialized {
-		log.Infof("Waiting for OnboardStatus initialized")
+		log.Functionf("Waiting for OnboardStatus initialized")
 		select {
 		case change := <-subOnboardStatus.MsgChan():
 			subOnboardStatus.ProcessChange(change)

--- a/pkg/pillar/uuidtonum/uuidtonum.go
+++ b/pkg/pillar/uuidtonum/uuidtonum.go
@@ -21,7 +21,7 @@ import (
 func UuidToNumAllocate(log *base.LogObject, pub pubsub.Publication, uuid uuid.UUID,
 	number int, mustCreate bool, numType string) {
 
-	log.Infof("UuidToNumAllocate(%s, %d, %v)\n", uuid.String(), number,
+	log.Functionf("UuidToNumAllocate(%s, %d, %v)\n", uuid.String(), number,
 		mustCreate)
 	i, err := pub.Get(uuid.String())
 	if err != nil {
@@ -33,7 +33,7 @@ func UuidToNumAllocate(log *base.LogObject, pub pubsub.Publication, uuid uuid.UU
 			NumType:     numType,
 			Number:      number,
 		}
-		log.Infof("UuidToNumAllocate(%s) publishing created %v\n",
+		log.Functionf("UuidToNumAllocate(%s) publishing created %v\n",
 			uuid.String(), u)
 		pub.Publish(u.Key(), u)
 		return
@@ -59,7 +59,7 @@ func UuidToNumAllocate(log *base.LogObject, pub pubsub.Publication, uuid uuid.UU
 	u.InUse = true
 	u.LastUseTime = time.Now()
 	// XXX note that nothing but lastusetime might be updated! Improve log?
-	log.Infof("UuidToNumAllocate(%s) publishing updated %v\n",
+	log.Functionf("UuidToNumAllocate(%s) publishing updated %v\n",
 		uuid.String(), u)
 	if err := pub.Publish(u.Key(), u); err != nil {
 		log.Fatalf("UuidToNumAllocate(%s) publish failed %v\n",
@@ -70,7 +70,7 @@ func UuidToNumAllocate(log *base.LogObject, pub pubsub.Publication, uuid uuid.UU
 // Clear InUse
 func UuidToNumFree(log *base.LogObject, pub pubsub.Publication, uuid uuid.UUID) {
 
-	log.Infof("UuidToNumFree(%s)\n", uuid.String())
+	log.Functionf("UuidToNumFree(%s)\n", uuid.String())
 	i, err := pub.Get(uuid.String())
 	if err != nil {
 		log.Fatalf("UuidToNumFree(%s) does not exist\n", uuid.String())
@@ -78,7 +78,7 @@ func UuidToNumFree(log *base.LogObject, pub pubsub.Publication, uuid uuid.UUID) 
 	u := i.(types.UuidToNum)
 	u.InUse = false
 	u.LastUseTime = time.Now()
-	log.Infof("UuidToNumFree(%s) publishing updated %v\n",
+	log.Functionf("UuidToNumFree(%s) publishing updated %v\n",
 		uuid.String(), u)
 	if err := pub.Publish(u.Key(), u); err != nil {
 		log.Fatalf("UuidToNumFree(%s) publish failed %v\n",
@@ -88,7 +88,7 @@ func UuidToNumFree(log *base.LogObject, pub pubsub.Publication, uuid uuid.UUID) 
 
 func UuidToNumDelete(log *base.LogObject, pub pubsub.Publication, uuid uuid.UUID) {
 
-	log.Infof("UuidToNumDelete(%s)\n", uuid.String())
+	log.Functionf("UuidToNumDelete(%s)\n", uuid.String())
 	_, err := pub.Get(uuid.String())
 	if err != nil {
 		log.Fatalf("UuidToNumDelete(%s) does not exist\n",
@@ -104,20 +104,20 @@ func UuidToNumGet(log *base.LogObject, pub pubsub.Publication, uuid uuid.UUID,
 	numType string) (int, error) {
 
 	key := uuid.String()
-	log.Infof("UuidToNumGet(%s, %s)\n", key, numType)
+	log.Functionf("UuidToNumGet(%s, %s)\n", key, numType)
 	i, err := pub.Get(key)
 	if err != nil {
 		return 0, err
 	}
 	u := i.(types.UuidToNum)
-	log.Infof("UuidToNumGet(%s, %s) found %v\n", key, numType, u)
+	log.Functionf("UuidToNumGet(%s, %s) found %v\n", key, numType, u)
 	return u.Number, nil
 }
 
 func UuidToNumGetOldestUnused(log *base.LogObject, pub pubsub.Publication,
 	numType string) (uuid.UUID, int, error) {
 
-	log.Infof("UuidToNumGetOldestUnused(%s)\n", numType)
+	log.Functionf("UuidToNumGetOldestUnused(%s)\n", numType)
 
 	// Will have a LastUseTime of zero
 	oldest := new(types.UuidToNum)
@@ -128,7 +128,7 @@ func UuidToNumGetOldestUnused(log *base.LogObject, pub pubsub.Publication,
 			continue
 		}
 		if oldest.LastUseTime.Before(status.LastUseTime) {
-			log.Infof("UuidToNumGetOldestUnused(%s) found older %v\n",
+			log.Functionf("UuidToNumGetOldestUnused(%s) found older %v\n",
 				numType, status)
 			oldest = &status
 		}
@@ -138,6 +138,6 @@ func UuidToNumGetOldestUnused(log *base.LogObject, pub pubsub.Publication,
 			numType)
 		return uuid.UUID{}, 0, errors.New(errStr)
 	}
-	log.Infof("UuidToNumGetOldestUnused(%s) found %v\n", numType, oldest)
+	log.Functionf("UuidToNumGetOldestUnused(%s) found %v\n", numType, oldest)
 	return oldest.UUID, oldest.Number, nil
 }

--- a/pkg/pillar/vault/vault.go
+++ b/pkg/pillar/vault/vault.go
@@ -46,12 +46,12 @@ func getFscryptOperInfo(log *base.LogObject) (info.DataSecAtRestStatus, string) 
 	if err == nil {
 		if _, _, err := execCmd(FscryptPath, StatusParams...); err != nil {
 			//fscrypt is setup, but not being used
-			log.Debug("Setting status to Error")
+			log.Trace("Setting status to Error")
 			return info.DataSecAtRestStatus_DATASEC_AT_REST_ERROR,
 				"Fscrypt Encryption is not setup"
 		} else {
 			//fscrypt is setup, and being used on /persist
-			log.Debug("Setting status to Enabled")
+			log.Trace("Setting status to Enabled")
 			return info.DataSecAtRestStatus_DATASEC_AT_REST_ENABLED,
 				"Fscrypt is enabled and active"
 		}
@@ -80,7 +80,7 @@ func getZfsOperInfo(log *base.LogObject) (info.DataSecAtRestStatus, string) {
 func GetOperInfo(log *base.LogObject) (info.DataSecAtRestStatus, string) {
 	if !etpm.IsTpmEnabled() {
 		//No encryption on plaforms without a (working) TPM
-		log.Debug("Setting status to disabled, TPM is not in use")
+		log.Trace("Setting status to disabled, TPM is not in use")
 		return info.DataSecAtRestStatus_DATASEC_AT_REST_DISABLED,
 			"TPM is either absent or not in use"
 	}
@@ -91,7 +91,7 @@ func GetOperInfo(log *base.LogObject) (info.DataSecAtRestStatus, string) {
 	case "zfs":
 		return getZfsOperInfo(log)
 	default:
-		log.Debugf("Unsupported filesystem (%s), setting status to disabled",
+		log.Tracef("Unsupported filesystem (%s), setting status to disabled",
 			persistFsType)
 		return info.DataSecAtRestStatus_DATASEC_AT_REST_DISABLED,
 			"Current filesystem does not support encryption"

--- a/pkg/pillar/watch/watchconfigstatus.go
+++ b/pkg/pillar/watch/watchconfigstatus.go
@@ -50,15 +50,15 @@ func watchReadDir(log *base.LogObject, configDir string, fileChanges chan<- stri
 			}
 		}
 		if retry {
-			log.Debugln("watchReadDir retry modified",
+			log.Traceln("watchReadDir retry modified",
 				configDir, file.Name())
 		} else {
-			log.Infoln("watchReadDir modified", file.Name())
+			log.Functionln("watchReadDir modified", file.Name())
 		}
 		fileChanges <- "M " + file.Name()
 	}
 	if !retry {
-		log.Infof("watchReadDir done for %s\n", configDir)
+		log.Functionf("watchReadDir done for %s\n", configDir)
 	}
 	return foundRestart, foundRestarted
 }
@@ -74,7 +74,7 @@ func WatchStatus(log *base.LogObject, statusDir string, jsonOnly bool, doneChan 
 	defer w.Close()
 
 	funcDone := make(chan struct{})
-	log.Infof("Creating %s at %s", "func", agentlog.GetMyStack())
+	log.Functionf("Creating %s at %s", "func", agentlog.GetMyStack())
 	go func() {
 		done := false
 		for !done {
@@ -88,20 +88,20 @@ func WatchStatus(log *base.LogObject, statusDir string, jsonOnly bool, doneChan 
 
 			case event := <-w.Events:
 				baseName := path.Base(event.Name)
-				// log.Debugln("WatchStatus event:", event)
+				// log.Traceln("WatchStatus event:", event)
 
 				// We get create events when file is moved into
 				// the watched directory.
 				if event.Op&
 					(fsnotify.Write|fsnotify.Create) != 0 {
-					// log.Debugln("WatchStatus modified", baseName)
+					// log.Traceln("WatchStatus modified", baseName)
 					fileChanges <- "M " + baseName
 				} else if event.Op&fsnotify.Chmod != 0 {
-					// log.Debugln("WatchStatus chmod", baseName)
+					// log.Traceln("WatchStatus chmod", baseName)
 					fileChanges <- "M " + baseName
 				} else if event.Op&
 					(fsnotify.Rename|fsnotify.Remove) != 0 {
-					// log.Debugln("WatchStatus deleted", baseName)
+					// log.Traceln("WatchStatus deleted", baseName)
 					fileChanges <- "D " + baseName
 				} else {
 					log.Errorln("WatchStatus unknown", event, baseName)
@@ -120,7 +120,7 @@ func WatchStatus(log *base.LogObject, statusDir string, jsonOnly bool, doneChan 
 		log.Error(err, " Inintial Add: ", statusDir)
 		// Check again when timer fires
 	}
-	// log.Debugln("WatchStatus added", statusDir)
+	// log.Traceln("WatchStatus added", statusDir)
 
 	foundRestart, foundRestarted := watchReadDir(log, statusDir, fileChanges,
 		false, jsonOnly)
@@ -154,7 +154,7 @@ func WatchStatus(log *base.LogObject, statusDir string, jsonOnly bool, doneChan 
 		case <-ticker.C:
 			// Remove and re-add
 			// XXX do we also need to re-scan?
-			// log.Debugln("WatchStatus remove/re-add", statusDir)
+			// log.Traceln("WatchStatus remove/re-add", statusDir)
 			err = w.Remove(statusDir)
 			if err != nil {
 				log.Error(err, " Remove: ", statusDir)

--- a/pkg/pillar/worker/worker.go
+++ b/pkg/pillar/worker/worker.go
@@ -13,9 +13,9 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 )
 
-// Logger basic interface to send debug messages
+// Logger basic interface to send trace messages
 type Logger interface {
-	Debugf(format string, args ...interface{})
+	Tracef(format string, args ...interface{})
 }
 
 // Worker captures the worker channels
@@ -97,7 +97,7 @@ func NewWorker(log Logger, ctx interface{}, length int, handlers map[string]Hand
 		log:         log,
 	}
 
-	log.Debugf("Creating %s at %s", "w.processWork", agentlog.GetMyStack())
+	log.Tracef("Creating %s at %s", "w.processWork", agentlog.GetMyStack())
 	go w.processWork(log, ctx, requestChan, resultChan)
 	return w
 }
@@ -112,7 +112,7 @@ func (w Worker) NumPending() int {
 // processWork calls the fn for each work until the requestChan is closed
 func (w *Worker) processWork(log Logger, ctx interface{}, requestChan <-chan Work, resultChan chan<- Processor) {
 
-	log.Debugf("processWork starting for context %T", ctx)
+	log.Tracef("processWork starting for context %T", ctx)
 	for work := range requestChan {
 		var result WorkResult
 		// find the correct handler for it
@@ -141,7 +141,7 @@ func (w *Worker) processWork(log Logger, ctx interface{}, requestChan <-chan Wor
 		w.deletePending(work.Key)
 	}
 	close(resultChan)
-	log.Debugf("processWork done for context %T", ctx)
+	log.Tracef("processWork done for context %T", ctx)
 }
 
 // MsgChan returns a channel to be used in a select loop.

--- a/pkg/pillar/zboot/zboot.go
+++ b/pkg/pillar/zboot/zboot.go
@@ -78,12 +78,12 @@ func execWithTimeout(log *base.LogObject, command string, args ...string) ([]byt
 	cmd := exec.CommandContext(ctx, command, args...)
 
 	if log != nil {
-		log.Infof("Waiting for zbootMutex.lock for %s %+v\n",
+		log.Functionf("Waiting for zbootMutex.lock for %s %+v\n",
 			command, args)
 	}
 	zbootMutex.Lock()
 	if log != nil {
-		log.Infof("Got zbootMutex.lock. Executing %s %+v\n",
+		log.Functionf("Got zbootMutex.lock. Executing %s %+v\n",
 			command, args)
 	}
 
@@ -91,7 +91,7 @@ func execWithTimeout(log *base.LogObject, command string, args ...string) ([]byt
 
 	zbootMutex.Unlock()
 	if log != nil {
-		log.Infof("Released zbootMutex.lock for %s %+v\n",
+		log.Functionf("Released zbootMutex.lock for %s %+v\n",
 			command, args)
 	}
 
@@ -197,7 +197,7 @@ func IsPartitionState(partName string, partState string) bool {
 
 func setPartitionState(log *base.LogObject, partName string, partState string) {
 
-	log.Infof("setPartitionState(%s, %s)\n", partName, partState)
+	log.Functionf("setPartitionState(%s, %s)\n", partName, partState)
 	validatePartitionName(partName)
 	validatePartitionState(partState)
 
@@ -340,7 +340,7 @@ func WriteToPartition(log *base.LogObject, image string, partName string) error 
 		return errors.New(errStr)
 	}
 
-	log.Infof("WriteToPartition %s, %s: %v\n", partName, devName, image)
+	log.Functionf("WriteToPartition %s, %s: %v\n", partName, devName, image)
 
 	// use the edge-containers library to extract the data we need
 	puller := registry.Puller{
@@ -396,17 +396,17 @@ func MarkCurrentPartitionStateActive(log *base.LogObject) error {
 	curPart := GetCurrentPartition()
 	otherPart := GetOtherPartition()
 
-	log.Infof("Check current partition %s, for inProgress state\n", curPart)
+	log.Functionf("Check current partition %s, for inProgress state\n", curPart)
 	if ret := IsCurrentPartitionStateInProgress(); ret == false {
 		errStr := fmt.Sprintf("Current partition %s, is not inProgress",
 			curPart)
 		return errors.New(errStr)
 	}
 
-	log.Infof("Mark the current partition %s, active\n", curPart)
+	log.Functionf("Mark the current partition %s, active\n", curPart)
 	setCurrentPartitionStateActive(log)
 
-	log.Infof("Check other partition %s for active state or inprogress\n",
+	log.Functionf("Check other partition %s for active state or inprogress\n",
 		otherPart)
 	state := GetPartitionState(otherPart)
 	switch state {
@@ -420,7 +420,7 @@ func MarkCurrentPartitionStateActive(log *base.LogObject) error {
 		return errors.New(errStr)
 	}
 
-	log.Infof("Mark other partition %s, unused\n", otherPart)
+	log.Functionf("Mark other partition %s, unused\n", otherPart)
 	SetOtherPartitionStateUnused(log)
 	return nil
 }
@@ -454,7 +454,7 @@ func getVersion(log *base.LogObject, part string, verFilename string) (string, e
 		}
 		versionStr := string(version)
 		versionStr = strings.TrimSpace(versionStr)
-		log.Infof("%s, readCurVersion %s\n", part, versionStr)
+		log.Functionf("%s, readCurVersion %s\n", part, versionStr)
 		return versionStr, nil
 	} else {
 		verFilename = otherPartVersionFile
@@ -500,7 +500,7 @@ func getVersion(log *base.LogObject, part string, verFilename string) (string, e
 		}
 		versionStr := string(version)
 		versionStr = strings.TrimSpace(versionStr)
-		log.Infof("%s, readOtherVersion %s\n", part, versionStr)
+		log.Functionf("%s, readOtherVersion %s\n", part, versionStr)
 		return versionStr, nil
 	}
 }

--- a/pkg/pillar/zedbox/zedbox.go
+++ b/pkg/pillar/zedbox/zedbox.go
@@ -113,7 +113,7 @@ func main() {
 			inline = true
 			for _, arg := range os.Args {
 				if arg == "runAsService" {
-					log.Infof("Found runAsService for %s",
+					log.Functionf("Found runAsService for %s",
 						basename)
 					inline = false
 					break
@@ -138,7 +138,7 @@ func main() {
 
 func runService(serviceName string, sep entrypoint, inline bool) int {
 	if inline {
-		log.Infof("Running inline command %s args: %+v",
+		log.Functionf("Running inline command %s args: %+v",
 			serviceName, os.Args[1:])
 		ps := pubsub.New(
 			&socketdriver.SocketDriver{Logger: logger, Log: log},
@@ -150,7 +150,7 @@ func runService(serviceName string, sep entrypoint, inline bool) int {
 		ServiceName: serviceName,
 		CmdArgs:     os.Args,
 	}
-	log.Infof("Notifying zedbox to start service %s with args %v",
+	log.Functionf("Notifying zedbox to start service %s with args %v",
 		sericeInitStatus.ServiceName, sericeInitStatus.CmdArgs)
 	if err := reverse.Publish(log, agentName, &sericeInitStatus); err != nil {
 		log.Fatalf(err.Error())
@@ -171,7 +171,7 @@ func runZedbox(ps *pubsub.PubSub, logger *logrus.Logger, log *base.LogObject) in
 	}
 	stillRunning := time.NewTicker(15 * time.Second)
 
-	log.Infof("Starting %s", agentName)
+	log.Functionf("Starting %s", agentName)
 	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
 		log.Fatal(err)
 	}
@@ -203,7 +203,7 @@ func runZedbox(ps *pubsub.PubSub, logger *logrus.Logger, log *base.LogObject) in
 // that serviceName
 func handleService(serviceName string, cmdArgs []string) {
 
-	log.Infof("zedbox: Received command = %s args = %v", serviceName, cmdArgs)
+	log.Functionf("zedbox: Received command = %s args = %v", serviceName, cmdArgs)
 	srvLogger, srvLog := agentlog.Init(serviceName)
 	srvPs := pubsub.New(
 		&socketdriver.SocketDriver{
@@ -216,11 +216,11 @@ func handleService(serviceName string, cmdArgs []string) {
 		log.Fatalf("zedbox: Unknown package: %s",
 			serviceName)
 	}
-	log.Infof("zedbox: Starting %s", serviceName)
+	log.Functionf("zedbox: Starting %s", serviceName)
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	os.Args = cmdArgs
 	go startAgentAndDone(sep, serviceName, srvPs, srvLogger, srvLog)
-	log.Infof("zedbox: Started %s",
+	log.Functionf("zedbox: Started %s",
 		serviceName)
 }
 

--- a/pkg/pillar/zedcloud/deferred.go
+++ b/pkg/pillar/zedcloud/deferred.go
@@ -67,11 +67,11 @@ func HandleDeferred(zedcloudCtx *ZedCloudContext, event time.Time, spacing time.
 func (ctx *DeferredContext) handleDeferred(log *base.LogObject, event time.Time,
 	spacing time.Duration) bool {
 
-	log.Infof("HandleDeferred(%v, %v) map %d\n",
+	log.Functionf("HandleDeferred(%v, %v) map %d\n",
 		event, spacing, len(ctx.deferredItems))
 	iteration := 0 // Do some load spreading
 	for key, l := range ctx.deferredItems {
-		log.Infof("Trying to send for %s items %d\n", key, len(l.list))
+		log.Functionf("Trying to send for %s items %d\n", key, len(l.list))
 		failed := false
 		for i, item := range l.list {
 			if item.buf == nil {
@@ -82,16 +82,16 @@ func (ctx *DeferredContext) handleDeferred(log *base.LogObject, event time.Time,
 					key)
 				continue
 			}
-			log.Infof("Trying to send for %s item %d data size %d\n",
+			log.Functionf("Trying to send for %s item %d data size %d\n",
 				key, i, item.size)
 			resp, _, _, err := SendOnAllIntf(item.zedcloudCtx, item.url,
 				item.size, item.buf, iteration, item.bailOnHTTPErr)
 			if item.bailOnHTTPErr && resp != nil &&
 				resp.StatusCode >= 400 && resp.StatusCode < 600 {
-				log.Infof("HandleDeferred: for %s ignore code %d\n",
+				log.Functionf("HandleDeferred: for %s ignore code %d\n",
 					key, resp.StatusCode)
 			} else if err != nil {
-				log.Infof("HandleDeferred: for %s failed %s\n",
+				log.Functionf("HandleDeferred: for %s failed %s\n",
 					key, err)
 				failed = true
 				break
@@ -105,7 +105,7 @@ func (ctx *DeferredContext) handleDeferred(log *base.LogObject, event time.Time,
 			iteration += 1
 			// XXX sleeping in main thread
 			if len(ctx.deferredItems) != 0 && spacing != 0 {
-				log.Infof("HandleDeferred sleeping %v\n",
+				log.Functionf("HandleDeferred sleeping %v\n",
 					spacing)
 				time.Sleep(spacing)
 			}
@@ -114,7 +114,7 @@ func (ctx *DeferredContext) handleDeferred(log *base.LogObject, event time.Time,
 	if len(ctx.deferredItems) == 0 {
 		stopTimer(log, ctx)
 	}
-	log.Infof("HandleDeferred() done map %d\n", len(ctx.deferredItems))
+	log.Functionf("HandleDeferred() done map %d\n", len(ctx.deferredItems))
 	return len(ctx.deferredItems) == 0
 }
 
@@ -125,7 +125,7 @@ func HasDeferred(zedcloudCtx *ZedCloudContext, key string) bool {
 
 func (ctx *DeferredContext) hasDeferred(log *base.LogObject, key string) bool {
 
-	log.Debugf("HasDeferred(%s) map %d\n", key, len(ctx.deferredItems))
+	log.Tracef("HasDeferred(%s) map %d\n", key, len(ctx.deferredItems))
 	_, ok := ctx.deferredItems[key]
 	return ok
 }
@@ -137,14 +137,14 @@ func RemoveDeferred(zedcloudCtx *ZedCloudContext, key string) {
 
 func (ctx *DeferredContext) removeDeferred(log *base.LogObject, key string) {
 
-	log.Debugf("RemoveDeferred(%s) map %d\n", key, len(ctx.deferredItems))
+	log.Tracef("RemoveDeferred(%s) map %d\n", key, len(ctx.deferredItems))
 	_, ok := ctx.deferredItems[key]
 	if !ok {
 		// Normal case
-		log.Debugf("removeDeferred: Non-existing key %s\n", key)
+		log.Tracef("removeDeferred: Non-existing key %s\n", key)
 		return
 	}
-	log.Debugf("Deleting key %s\n", key)
+	log.Tracef("Deleting key %s\n", key)
 	delete(ctx.deferredItems, key)
 
 	if len(ctx.deferredItems) == 0 {
@@ -167,16 +167,16 @@ func (ctx *DeferredContext) setDeferred(zedcloudCtx *ZedCloudContext,
 	key string, buf *bytes.Buffer, size int64, url string, bailOnHTTPErr bool) {
 
 	log := zedcloudCtx.log
-	log.Infof("SetDeferred(%s) size %d map %d\n",
+	log.Functionf("SetDeferred(%s) size %d map %d\n",
 		key, size, len(ctx.deferredItems))
 	if len(ctx.deferredItems) == 0 {
 		startTimer(log, ctx)
 	}
 	_, ok := ctx.deferredItems[key]
 	if ok {
-		log.Debugf("Replacing key %s\n", key)
+		log.Tracef("Replacing key %s\n", key)
 	} else {
-		log.Debugf("Adding key %s\n", key)
+		log.Tracef("Adding key %s\n", key)
 	}
 	item := deferredItem{
 		buf:           buf,
@@ -201,16 +201,16 @@ func (ctx *DeferredContext) addDeferred(zedcloudCtx *ZedCloudContext,
 	key string, buf *bytes.Buffer, size int64, url string, bailOnHTTPErr bool) {
 
 	log := zedcloudCtx.log
-	log.Infof("AddDeferred(%s) size %d map %d\n", key,
+	log.Functionf("AddDeferred(%s) size %d map %d\n", key,
 		size, len(ctx.deferredItems))
 	if len(ctx.deferredItems) == 0 {
 		startTimer(log, ctx)
 	}
 	l, ok := ctx.deferredItems[key]
 	if ok {
-		log.Debugf("Appending to key %s have %d\n", key, len(l.list))
+		log.Tracef("Appending to key %s have %d\n", key, len(l.list))
 	} else {
-		log.Debugf("Adding key %s\n", key)
+		log.Tracef("Adding key %s\n", key)
 	}
 	item := deferredItem{
 		buf:           buf,
@@ -226,7 +226,7 @@ func (ctx *DeferredContext) addDeferred(zedcloudCtx *ZedCloudContext,
 // Try every minute backoff to every 15 minutes
 func startTimer(log *base.LogObject, ctx *DeferredContext) {
 
-	log.Infof("startTimer()\n")
+	log.Functionf("startTimer()\n")
 	min := 1 * time.Minute
 	max := 15 * time.Minute
 	ctx.ticker.UpdateExpTicker(min, max, 0.3)
@@ -234,6 +234,6 @@ func startTimer(log *base.LogObject, ctx *DeferredContext) {
 
 func stopTimer(log *base.LogObject, ctx *DeferredContext) {
 
-	log.Infof("stopTimer()\n")
+	log.Functionf("stopTimer()\n")
 	ctx.ticker.UpdateRangeTicker(longTime1, longTime2)
 }

--- a/pkg/pillar/zedcloud/lookupproxy.go
+++ b/pkg/pillar/zedcloud/lookupproxy.go
@@ -18,12 +18,12 @@ func LookupProxy(log *base.LogObject, status *types.DeviceNetworkStatus, ifname 
 	rawUrl string) (*url.URL, error) {
 
 	for _, port := range status.Ports {
-		log.Debugf("LookupProxy: Looking for proxy config on port %s",
+		log.Tracef("LookupProxy: Looking for proxy config on port %s",
 			port.IfName)
 		if port.IfName != ifname {
 			continue
 		}
-		log.Debugf("LookupProxy: Port configuration found for %s", ifname)
+		log.Tracef("LookupProxy: Port configuration found for %s", ifname)
 		proxyConfig := port.ProxyConfig
 
 		// Check if the URL is present in exception list
@@ -77,7 +77,7 @@ func LookupProxy(log *base.LogObject, status *types.DeviceNetworkStatus, ifname 
 				log.Errorf(errStr)
 				return nil, errors.New(errStr)
 			}
-			log.Debugf("LookupProxy: PAC proxy being used is %s", proxy0)
+			log.Tracef("LookupProxy: PAC proxy being used is %s", proxy0)
 			return proxy, err
 		}
 
@@ -92,7 +92,7 @@ func LookupProxy(log *base.LogObject, status *types.DeviceNetworkStatus, ifname 
 					httpProxy = fmt.Sprintf("%s", proxy.Server)
 				}
 				config.HTTPProxy = httpProxy
-				log.Debugf("LookupProxy: Adding HTTP proxy %s for port %s",
+				log.Tracef("LookupProxy: Adding HTTP proxy %s for port %s",
 					config.HTTPProxy, ifname)
 			case types.NPT_HTTPS:
 				var httpsProxy string
@@ -102,7 +102,7 @@ func LookupProxy(log *base.LogObject, status *types.DeviceNetworkStatus, ifname 
 					httpsProxy = fmt.Sprintf("%s", proxy.Server)
 				}
 				config.HTTPSProxy = httpsProxy
-				log.Debugf("LookupProxy: Adding HTTPS proxy %s for port %s",
+				log.Tracef("LookupProxy: Adding HTTPS proxy %s for port %s",
 					config.HTTPSProxy, ifname)
 			default:
 				// XXX We should take care of Socks proxy, FTP proxy also in future
@@ -118,7 +118,7 @@ func LookupProxy(log *base.LogObject, status *types.DeviceNetworkStatus, ifname 
 		}
 		return proxy, err
 	}
-	log.Infof("LookupProxy: No proxy configured for port %s", ifname)
+	log.Functionf("LookupProxy: No proxy configured for port %s", ifname)
 	return nil, nil
 }
 

--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -93,7 +93,7 @@ func SendOnAllIntf(ctx *ZedCloudContext, url string, reqlen int64, b *bytes.Buff
 		if try == 0 {
 			intfs = types.GetMgmtPortsFree(*ctx.DeviceNetworkStatus,
 				iteration)
-			log.Debugf("sendOnAllIntf trying free %v\n", intfs)
+			log.Tracef("sendOnAllIntf trying free %v\n", intfs)
 			numFreeIntf = len(intfs)
 			if len(intfs) == 0 {
 				err := errors.New("No free management interfaces")
@@ -102,7 +102,7 @@ func SendOnAllIntf(ctx *ZedCloudContext, url string, reqlen int64, b *bytes.Buff
 		} else {
 			intfs = types.GetMgmtPortsNonFree(*ctx.DeviceNetworkStatus,
 				iteration)
-			log.Debugf("sendOnAllIntf non-free %v\n", intfs)
+			log.Tracef("sendOnAllIntf non-free %v\n", intfs)
 			if len(intfs) == 0 {
 				if numFreeIntf == 0 {
 					err := errors.New("No management interfaces")
@@ -126,7 +126,7 @@ func SendOnAllIntf(ctx *ZedCloudContext, url string, reqlen int64, b *bytes.Buff
 
 			if bailOnHTTPErr && resp != nil &&
 				resp.StatusCode >= 400 && resp.StatusCode < 600 {
-				log.Infof("sendOnAllIntf: for %s reqlen %d ignore code %d\n",
+				log.Functionf("sendOnAllIntf: for %s reqlen %d ignore code %d\n",
 					url, reqlen, resp.StatusCode)
 				return resp, nil, remoteTemporaryFailure, err
 			}
@@ -202,11 +202,11 @@ func VerifyAllIntf(ctx *ZedCloudContext,
 		if try == 0 {
 			intfs = types.GetMgmtPortsFree(*ctx.DeviceNetworkStatus,
 				iteration)
-			log.Debugf("VerifyAllIntf: trying free %v\n", intfs)
+			log.Tracef("VerifyAllIntf: trying free %v\n", intfs)
 		} else {
 			intfs = types.GetMgmtPortsNonFree(*ctx.DeviceNetworkStatus,
 				iteration)
-			log.Debugf("VerifyAllIntf: non-free %v\n", intfs)
+			log.Tracef("VerifyAllIntf: non-free %v\n", intfs)
 		}
 		for _, intf := range intfs {
 			if intfSuccessCount >= successCount {
@@ -234,7 +234,7 @@ func VerifyAllIntf(ctx *ZedCloudContext,
 			}
 			switch resp.StatusCode {
 			case http.StatusOK, http.StatusCreated:
-				log.Debugf("VerifyAllIntf: Zedcloud reachable via interface %s", intf)
+				log.Tracef("VerifyAllIntf: Zedcloud reachable via interface %s", intf)
 				intfStatusMap.RecordSuccess(intf)
 				intfSuccessCount += 1
 			default:
@@ -262,7 +262,7 @@ func VerifyAllIntf(ctx *ZedCloudContext,
 		log.Errorln(errStr)
 		return false, remoteTemporaryFailure, intfStatusMap, errors.New(errStr)
 	}
-	log.Debugf("VerifyAllIntf: Verify done. intfStatusMap: %+v", intfStatusMap)
+	log.Tracef("VerifyAllIntf: Verify done. intfStatusMap: %+v", intfStatusMap)
 	return true, remoteTemporaryFailure, intfStatusMap, nil
 }
 
@@ -305,7 +305,7 @@ func SendOnIntf(ctx *ZedCloudContext, destURL string, intf string, reqlen int64,
 	}
 
 	addrCount := types.CountLocalAddrAnyNoLinkLocalIf(*ctx.DeviceNetworkStatus, intf)
-	log.Debugf("Connecting to %s using intf %s #sources %d reqlen %d\n",
+	log.Tracef("Connecting to %s using intf %s #sources %d reqlen %d\n",
 		reqUrl, intf, addrCount, reqlen)
 
 	if addrCount == 0 {
@@ -317,19 +317,19 @@ func SendOnIntf(ctx *ZedCloudContext, destURL string, intf string, reqlen int64,
 		if err != nil {
 			errStr := fmt.Sprintf("Link not found to connect to %s using intf %s: %s",
 				reqUrl, intf, err)
-			log.Debugln(errStr)
+			log.Traceln(errStr)
 			return nil, nil, senderStatus, errors.New(errStr)
 		}
 		attrs := link.Attrs()
 		if attrs.OperState != netlink.OperUp {
 			errStr := fmt.Sprintf("Link not up to connect to %s using intf %s: %s",
 				reqUrl, intf, attrs.OperState.String())
-			log.Debugln(errStr)
+			log.Traceln(errStr)
 			return nil, nil, senderStatus, errors.New(errStr)
 		}
 		errStr := fmt.Sprintf("No IP addresses to connect to %s using intf %s",
 			reqUrl, intf)
-		log.Debugln(errStr)
+		log.Traceln(errStr)
 		return nil, nil, senderStatus, errors.New(errStr)
 	}
 	numDNSServers := types.CountDNSServers(*ctx.DeviceNetworkStatus, intf)
@@ -339,7 +339,7 @@ func SendOnIntf(ctx *ZedCloudContext, destURL string, intf string, reqlen int64,
 		}
 		errStr := fmt.Sprintf("No DNS servers to connect to %s using intf %s",
 			reqUrl, intf)
-		log.Debugln(errStr)
+		log.Traceln(errStr)
 		return nil, nil, senderStatus, errors.New(errStr)
 	}
 
@@ -348,7 +348,7 @@ func SendOnIntf(ctx *ZedCloudContext, destURL string, intf string, reqlen int64,
 	var transport *http.Transport
 	var usedProxy bool
 	if err == nil && proxyUrl != nil && allowProxy {
-		log.Debugf("sendOnIntf: For input URL %s, proxy found is %s",
+		log.Tracef("sendOnIntf: For input URL %s, proxy found is %s",
 			reqUrl, proxyUrl.String())
 		usedProxy = true
 		transport = &http.Transport{
@@ -376,10 +376,10 @@ func SendOnIntf(ctx *ZedCloudContext, destURL string, intf string, reqlen int64,
 		}
 		localTCPAddr := net.TCPAddr{IP: localAddr}
 		localUDPAddr := net.UDPAddr{IP: localAddr}
-		log.Debugf("Connecting to %s using intf %s source %v\n",
+		log.Tracef("Connecting to %s using intf %s source %v\n",
 			reqUrl, intf, localTCPAddr)
 		resolverDial := func(ctx context.Context, network, address string) (net.Conn, error) {
-			log.Debugf("resolverDial %v %v", network, address)
+			log.Tracef("resolverDial %v %v", network, address)
 			// XXX can we fallback to TCP? Would get a mismatched address if we do
 			d := net.Dialer{LocalAddr: &localUDPAddr}
 			return d.Dial(network, address)
@@ -402,7 +402,7 @@ func SendOnIntf(ctx *ZedCloudContext, destURL string, intf string, reqlen int64,
 				log.Errorf("SendOnIntf: auth error %v\n", err)
 				return nil, nil, senderStatus, err
 			}
-			log.Debugf("SendOnIntf: add auth for %s\n", reqUrl)
+			log.Tracef("SendOnIntf: add auth for %s\n", reqUrl)
 		} else {
 			b2 = b
 		}
@@ -435,26 +435,26 @@ func SendOnIntf(ctx *ZedCloudContext, destURL string, intf string, reqlen int64,
 			if devSoftSerial != "" {
 				req.Header.Add("X-Soft-Serial", devSoftSerial)
 			}
-			log.Debugf("Serial-Numbers, serial: %s, soft-serial %s",
+			log.Tracef("Serial-Numbers, serial: %s, soft-serial %s",
 				devSerialNum, devSoftSerial)
 		}
 
 		trace := &httptrace.ClientTrace{
 			GotConn: func(connInfo httptrace.GotConnInfo) {
-				log.Debugf("Got RemoteAddr: %+v, LocalAddr: %+v\n",
+				log.Tracef("Got RemoteAddr: %+v, LocalAddr: %+v\n",
 					connInfo.Conn.RemoteAddr(),
 					connInfo.Conn.LocalAddr())
 			},
 			DNSDone: func(dnsInfo httptrace.DNSDoneInfo) {
-				log.Debugf("DNS Info: %+v\n", dnsInfo)
+				log.Tracef("DNS Info: %+v\n", dnsInfo)
 			},
 			DNSStart: func(dnsInfo httptrace.DNSStartInfo) {
-				log.Debugf("DNS start: %+v\n", dnsInfo)
+				log.Tracef("DNS start: %+v\n", dnsInfo)
 			},
 		}
 		req = req.WithContext(httptrace.WithClientTrace(req.Context(),
 			trace))
-		log.Debugf("SendOnIntf: req method %s, isget %v, url %s",
+		log.Tracef("SendOnIntf: req method %s, isget %v, url %s",
 			req.Method, isGet, reqUrl)
 		apiCallStartTime := time.Now()
 		resp, err := client.Do(req)
@@ -542,7 +542,7 @@ func SendOnIntf(ctx *ZedCloudContext, destURL string, intf string, reqlen int64,
 
 				if connState.OCSPResponse == nil {
 					// XXX remove debug check
-					log.Debugf("no OCSP response for %s\n",
+					log.Tracef("no OCSP response for %s\n",
 						reqUrl)
 				}
 				errStr := fmt.Sprintf("OCSP stapled check failed for %s",
@@ -564,7 +564,7 @@ func SendOnIntf(ctx *ZedCloudContext, destURL string, intf string, reqlen int64,
 					errorList = append(errorList, err)
 					continue
 				}
-				log.Debugln(errStr)
+				log.Traceln(errStr)
 			}
 		}
 		// Even if we got e.g., a 404 we consider the connection a
@@ -576,7 +576,7 @@ func SendOnIntf(ctx *ZedCloudContext, destURL string, intf string, reqlen int64,
 
 		switch resp.StatusCode {
 		case http.StatusOK, http.StatusCreated, http.StatusNotModified:
-			log.Debugf("SendOnIntf to %s, response %s\n", reqUrl, resp.Status)
+			log.Tracef("SendOnIntf to %s, response %s\n", reqUrl, resp.Status)
 
 			var contents2 []byte
 			var err error
@@ -597,7 +597,7 @@ func SendOnIntf(ctx *ZedCloudContext, destURL string, intf string, reqlen int64,
 						}
 						return nil, nil, rtf, err
 					}
-					log.Debugf("SendOnIntf verify auth ok, len content/content2 %d/%d, url %s",
+					log.Tracef("SendOnIntf verify auth ok, len content/content2 %d/%d, url %s",
 						len(contents), len(contents2), reqUrl)
 				} else {
 					contents2 = contents
@@ -614,7 +614,7 @@ func SendOnIntf(ctx *ZedCloudContext, destURL string, intf string, reqlen int64,
 			if resp.StatusCode != http.StatusNotFound || ctx.AgentName != "zedrouter" {
 				log.Errorln(errStr)
 			}
-			log.Debugf("received response %v\n", resp)
+			log.Tracef("received response %v\n", resp)
 			// Get caller to schedule a retry based on StatusCode
 			return resp, nil, types.SenderStatusNone, errors.New(errStr)
 		}

--- a/pkg/pillar/zedcloud/tls.go
+++ b/pkg/pillar/zedcloud/tls.go
@@ -249,7 +249,7 @@ func UpdateTLSProxyCerts(ctx *ZedCloudContext) bool {
 			log.Errorf(errStr)
 			return false
 		}
-		log.Infof("UpdateTLSProxyCerts: rebuild root CA\n")
+		log.Functionf("UpdateTLSProxyCerts: rebuild root CA\n")
 	} else {
 		// we don't have proxy certs, add them if any exist
 		caCertPool = tlsCfg.RootCAs
@@ -268,7 +268,7 @@ func UpdateTLSProxyCerts(ctx *ZedCloudContext) bool {
 	// May updating the /etc/ssl/certs for proxy certs in /usr/local/share/ca-certificates directory
 	updateEtcSSLforProxyCerts(ctx, devNS)
 
-	log.Infof("UpdateTLSProxyCerts: root CA updated")
+	log.Functionf("UpdateTLSProxyCerts: root CA updated")
 	ctx.TlsConfig.RootCAs = caCertPool
 	// save the new proxy Certs, or null it out
 	ctx.PrevCertPEM = cacheProxyCerts(devNS)
@@ -294,13 +294,13 @@ func stapledCheck(log *base.LogObject, connState *tls.ConnectionState) bool {
 	now := time.Now()
 	age := now.Unix() - resp.ProducedAt.Unix()
 	remain := resp.NextUpdate.Unix() - now.Unix()
-	log.Debugf("OCSP age %d, remain %d\n", age, remain)
+	log.Tracef("OCSP age %d, remain %d\n", age, remain)
 	if remain < 0 {
 		log.Errorln("OCSP expired.")
 		return false
 	}
 	if resp.Status == ocsp.Good {
-		log.Debugln("Certificate Status Good.")
+		log.Traceln("Certificate Status Good.")
 	} else if resp.Status == ocsp.Unknown {
 		log.Errorln("Certificate Status Unknown")
 	} else {
@@ -313,7 +313,7 @@ func updateEtcSSLforProxyCerts(ctx *ZedCloudContext, dns *types.DeviceNetworkSta
 	log := ctx.log
 	// Only zedagent is to update the host ca-certificates
 	if !ctx.V2API || ctx.AgentName != "zedagent" {
-		log.Infof("updateEtcSSLforProxyCerts: skip agent %s", ctx.AgentName)
+		log.Functionf("updateEtcSSLforProxyCerts: skip agent %s", ctx.AgentName)
 		return
 	}
 
@@ -327,7 +327,7 @@ func updateEtcSSLforProxyCerts(ctx *ZedCloudContext, dns *types.DeviceNetworkSta
 			return filepath.SkipDir
 		}
 		if strings.HasPrefix(path, proxyCertDirFile) {
-			log.Infof("updateEtcSSLforProxyCerts: remove file %s", path)
+			log.Functionf("updateEtcSSLforProxyCerts: remove file %s", path)
 			os.Remove(path)
 		}
 		return err
@@ -343,15 +343,15 @@ func updateEtcSSLforProxyCerts(ctx *ZedCloudContext, dns *types.DeviceNetworkSta
 		if err != nil {
 			log.Errorf("updateEtcSSLforProxyCerts: file %s save err %v", proxyFilename, err)
 		}
-		log.Infof("updateEtcSSLforProxyCerts: file saved to %s", proxyFilename)
+		log.Functionf("updateEtcSSLforProxyCerts: file saved to %s", proxyFilename)
 	}
 
 	cmdName := "/usr/sbin/update-ca-certificates"
-	log.Infof("updateEtcSSLforProxyCerts: Calling command %s", cmdName)
+	log.Functionf("updateEtcSSLforProxyCerts: Calling command %s", cmdName)
 	out, err := base.Exec(log, cmdName).CombinedOutput()
 	if err != nil {
 		log.Errorf("updateEtcSSLforProxyCerts: update-ca-certificates, certs num %d, (%s)", len(newCerts), err)
 	} else {
-		log.Infof("updateEtcSSLforProxyCerts: update-ca-certificates %s, certs num %d", out, len(newCerts))
+		log.Functionf("updateEtcSSLforProxyCerts: update-ca-certificates %s, certs num %d", out, len(newCerts))
 	}
 }

--- a/pkg/pillar/zedcloud/wstunnelclient.go
+++ b/pkg/pillar/zedcloud/wstunnelclient.go
@@ -73,7 +73,7 @@ func InitializeTunnelClient(log *base.LogObject, serverNameAndPort string, local
 // session with remote tunnel server
 func (t *WSTunnelClient) Start() {
 	log := t.log
-	log.Infof("Creating %s at %s", "func", agentlog.GetMyStack())
+	log.Functionf("Creating %s at %s", "func", agentlog.GetMyStack())
 	go func() {
 		t.startSession()
 		<-make(chan struct{}, 0)
@@ -102,8 +102,8 @@ func (t *WSTunnelClient) TestConnection(devNetStatus *types.DeviceNetworkStatus,
 	}
 	t.LocalRelayServer = strings.TrimSuffix(t.LocalRelayServer, "/")
 
-	log.Debugf("Testing connection to %s on local address: %v, proxy: %v", t.Tunnel, localAddr, proxyURL)
-	log.Infof("Testing connection to %s on local address: %v, proxy: %v", t.Tunnel, localAddr, proxyURL)
+	log.Tracef("Testing connection to %s on local address: %v, proxy: %v", t.Tunnel, localAddr, proxyURL)
+	log.Functionf("Testing connection to %s on local address: %v, proxy: %v", t.Tunnel, localAddr, proxyURL)
 
 	serverName := strings.Split(t.TunnelServerNameAndPort, ":")[0]
 
@@ -132,16 +132,16 @@ func (t *WSTunnelClient) TestConnection(devNetStatus *types.DeviceNetworkStatus,
 	pingURL := URLPathString(t.Tunnel, zedcloudCtx.V2API, devUUID, "connection/ping")
 	_, resp, err := dialer.Dial(pingURL, nil)
 	if resp == nil { // this can get error, but with resp code is still 200
-		log.Infof("TestConnection: url %s, resp %v, err %v", pingURL, resp, err)
+		log.Functionf("TestConnection: url %s, resp %v, err %v", pingURL, resp, err)
 		return err
 	}
-	log.Debugf("Read ping response status code: %v for ping url: %s", resp.StatusCode, pingURL)
+	log.Tracef("Read ping response status code: %v for ping url: %s", resp.StatusCode, pingURL)
 
 	if resp.StatusCode == http.StatusOK {
 		url := URLPathString(t.Tunnel, zedcloudCtx.V2API, devUUID, "connection/tunnel")
 		t.DestURL = url
 		t.Dialer = dialer
-		log.Infof("Connection test succeeded for url: %s on local address: %v, proxy: %v", url, localAddr, proxyURL)
+		log.Functionf("Connection test succeeded for url: %s on local address: %v, proxy: %v", url, localAddr, proxyURL)
 		return nil
 	}
 	return err
@@ -160,9 +160,9 @@ func (t *WSTunnelClient) startSession() error {
 	t.retryOnFailCount = 0
 
 	// Keep opening websocket connections to tunnel requests
-	log.Infof("Creating %s at %s", "func", agentlog.GetMyStack())
+	log.Functionf("Creating %s at %s", "func", agentlog.GetMyStack())
 	go func() {
-		log.Debug("Looping through websocket connection requests")
+		log.Trace("Looping through websocket connection requests")
 		for {
 			if t.retryOnFailCount == maxRetryAttempts {
 				log.Errorf("Shutting down tunnel client after %d failed attempts.", maxRetryAttempts)
@@ -171,7 +171,7 @@ func (t *WSTunnelClient) startSession() error {
 			// Retry timer of 30 seconds between attempts.
 			timer := time.NewTimer(30 * time.Second)
 
-			log.Debugf("Attempting WS connection to url: %s", t.DestURL)
+			log.Tracef("Attempting WS connection to url: %s", t.DestURL)
 
 			ws, resp, err := t.Dialer.Dial(t.DestURL, nil)
 			if err != nil {
@@ -214,7 +214,7 @@ func (t *WSTunnelClient) startSession() error {
 
 // Stop tunnel client
 func (t *WSTunnelClient) Stop() {
-	t.log.Info("Shutting down WS tunnel client and exiting.")
+	t.log.Function("Shutting down WS tunnel client and exiting.")
 	t.exitChan <- struct{}{}
 }
 
@@ -223,17 +223,17 @@ func (t *WSTunnelClient) Stop() {
 // return the result if any.
 func (wsc *WSConnection) handleRequests() {
 	log := wsc.tun.log
-	log.Infof("Creating %s at %s", "wsc.pinger", agentlog.GetMyStack())
+	log.Functionf("Creating %s at %s", "wsc.pinger", agentlog.GetMyStack())
 	go wsc.pinger()
 	for {
 		wsc.ws.SetReadDeadline(time.Time{}) // separate ping-pong routine does timeout
 		messageType, reader, err := wsc.ws.NextReader()
 		if err != nil {
-			log.Debugf("WS ReadMessage Error: %s", err.Error())
+			log.Tracef("WS ReadMessage Error: %s", err.Error())
 			break
 		}
 		if messageType != websocket.BinaryMessage {
-			log.Debugf("WS ReadMessage Invalid message type: %d", messageType)
+			log.Tracef("WS ReadMessage Invalid message type: %d", messageType)
 			break
 		}
 		// give the sender a minute to produce the request
@@ -242,7 +242,7 @@ func (wsc *WSConnection) handleRequests() {
 		var id int16
 		_, err = fmt.Fscanf(io.LimitReader(reader, 4), "%04x", &id)
 		if err != nil {
-			log.Debugf("WS cannot read request ID Error: %s", err.Error())
+			log.Tracef("WS cannot read request ID Error: %s", err.Error())
 			break
 		}
 		// read the whole message, this is bounded (to something large) by the
@@ -251,10 +251,10 @@ func (wsc *WSConnection) handleRequests() {
 		// websocket doesn't allow us to have multiple goroutines reading...
 		request, err := ioutil.ReadAll(reader)
 		if err != nil {
-			log.Debugf("[id=%d] WS cannot read request message Error: %s", id, err.Error())
+			log.Tracef("[id=%d] WS cannot read request message Error: %s", id, err.Error())
 			break
 		}
-		log.Debugf("[id=%d] WS processing request payload: %v", id, string(request))
+		log.Tracef("[id=%d] WS processing request payload: %v", id, string(request))
 
 		// Finish off while we read the next request
 		if len(request) > 0 {
@@ -262,14 +262,14 @@ func (wsc *WSConnection) handleRequests() {
 				log.Error(err)
 			}
 		} else {
-			log.Debugf("[id=%d] Encountered WS request to process with no payload", id)
+			log.Tracef("[id=%d] Encountered WS request to process with no payload", id)
 		}
 
 	}
 	// delay a few seconds to allow for writes to drain and then force-close the socket
-	log.Infof("Creating %s at %s", "func", agentlog.GetMyStack())
+	log.Functionf("Creating %s at %s", "func", agentlog.GetMyStack())
 	go func() {
-		log.Info("Closing websocket connection")
+		log.Function("Closing websocket connection")
 		time.Sleep(5 * time.Second)
 		wsc.ws.Close()
 	}()
@@ -285,7 +285,7 @@ func (wsc *WSConnection) pinger() {
 			log.Errorf("Panic in pinger: %s", x)
 		}
 	}()
-	log.Infof("pinger starting for websocket connection to: %s", wsc.tun.DestURL)
+	log.Functionf("pinger starting for websocket connection to: %s", wsc.tun.DestURL)
 	tunTimeout := wsc.tun.Timeout
 
 	// timeout handler sends a close message, waits a few seconds, then kills the socket
@@ -294,7 +294,7 @@ func (wsc *WSConnection) pinger() {
 			return
 		}
 		wsc.ws.WriteControl(websocket.CloseMessage, nil, time.Now().Add(1*time.Second))
-		log.Infof("ping timeout, closing websocket connection to: %s", wsc.tun.DestURL)
+		log.Functionf("ping timeout, closing websocket connection to: %s", wsc.tun.DestURL)
 		time.Sleep(15 * time.Second)
 		if wsc.ws != nil {
 			wsc.ws.Close()
@@ -321,7 +321,7 @@ func (wsc *WSConnection) pinger() {
 		}
 		time.Sleep(tunTimeout / 3)
 	}
-	log.Infof("pinger ending (WS errored or closed) for destination: %s", wsc.tun.DestURL)
+	log.Functionf("pinger ending (WS errored or closed) for destination: %s", wsc.tun.DestURL)
 	wsc.ws.Close()
 }
 
@@ -334,20 +334,20 @@ func (wsc *WSConnection) processRequest(id int16, req []byte) (err error) {
 	host := wsc.tun.LocalRelayServer
 	if wsc.localConnection == nil {
 		wsc.dialLocalConnection()
-		log.Infof("Creating %s at %s", "wsc.ProcessResponse",
+		log.Functionf("Creating %s at %s", "wsc.ProcessResponse",
 			agentlog.GetMyStack())
 		go wsc.processResponses()
 	}
 
-	log.Debugf("[id=%d] Forwarding request: %v to local connection: %s", id, string(req), host)
+	log.Tracef("[id=%d] Forwarding request: %v to local connection: %s", id, string(req), host)
 	for tries := 1; tries <= 3; tries++ {
 		_, err := wsc.localConnection.Write(req)
 		if err == nil {
-			log.Debugf("[id=%d] Completed writing request: \"%s\" to local connection",
+			log.Tracef("[id=%d] Completed writing request: \"%s\" to local connection",
 				id, string(req))
 			break
 		} else {
-			log.Debugf("[id=%d] Error encountered while writing request to local connection : %s",
+			log.Tracef("[id=%d] Error encountered while writing request to local connection : %s",
 				id, err.Error())
 			if err := wsc.refreshLocalConnection(true); err != nil {
 				return err
@@ -376,7 +376,7 @@ func (wsc *WSConnection) refreshLocalConnection(forceCreate bool) (err error) {
 			if err == io.EOF ||
 				err == io.ErrClosedPipe ||
 				err == io.ErrUnexpectedEOF {
-				log.Debug("Lost local server connection, reconnecting...")
+				log.Trace("Lost local server connection, reconnecting...")
 				if err := wsc.dialLocalConnection(); err != nil {
 					return err
 				}
@@ -400,14 +400,14 @@ func (wsc *WSConnection) dialLocalConnection() (err error) {
 		return
 	}
 
-	log.Debugf("Initializing local server connection: %s", host)
+	log.Tracef("Initializing local server connection: %s", host)
 	localConnection, err := net.Dial("tcp", host)
 	if err != nil {
 		log.Errorf("Could not connect to local server: %s, error: %s", host, err.Error())
 		return err
 	}
 	wsc.localConnection = localConnection
-	log.Debugf("Successfully connected to local server: %s", host)
+	log.Tracef("Successfully connected to local server: %s", host)
 	return nil
 }
 
@@ -417,7 +417,7 @@ func (wsc *WSConnection) processResponses() {
 
 	log := wsc.tun.log
 	host := wsc.tun.LocalRelayServer
-	log.Infof("Processing responses from local relay: %s", host)
+	log.Functionf("Processing responses from local relay: %s", host)
 
 	var id int64
 	ticker := time.NewTicker(100 * time.Millisecond)
@@ -427,7 +427,7 @@ func (wsc *WSConnection) processResponses() {
 		num, _ := wsc.localConnection.Read(responseBuffer)
 		if num > 0 {
 			response := responseBuffer[:num]
-			log.Debugf("[id=%d] Read local connection payload: %s", id, string(response))
+			log.Tracef("[id=%d] Read local connection payload: %s", id, string(response))
 
 			wsc.writeResponseMessage(id, bytes.NewBuffer(response))
 			id++
@@ -473,7 +473,7 @@ func (wsc *WSConnection) writeResponseMessage(id int64, resp *bytes.Buffer) {
 		wsc.ws.Close()
 		return
 	}
-	log.Debugf("[id=%d] Completed writing response of length: %d", id, num)
+	log.Tracef("[id=%d] Completed writing response of length: %d", id, num)
 
 	// done
 	err = writer.Close()

--- a/pkg/pillar/zedcloud/zedcloudmetric.go
+++ b/pkg/pillar/zedcloud/zedcloudmetric.go
@@ -58,7 +58,7 @@ func updateAgentIfnameMetrics(log *base.LogObject, ifname string, m types.Zedclo
 }
 
 func ZedCloudFailure(log *base.LogObject, ifname string, url string, reqLen int64, respLen int64, authenFail bool) {
-	log.Debugf("ZedCloudFailure(%s, %s) %d %d",
+	log.Tracef("ZedCloudFailure(%s, %s) %d %d",
 		ifname, url, reqLen, respLen)
 	mutex.Lock()
 	m := getAgentIfnameMetrics(log, ifname)
@@ -87,7 +87,7 @@ func ZedCloudFailure(log *base.LogObject, ifname string, url string, reqLen int6
 }
 
 func ZedCloudSuccess(log *base.LogObject, ifname string, url string, reqLen int64, respLen int64, timeSpent int64) {
-	log.Debugf("ZedCloudSuccess(%s, %s) %d %d",
+	log.Tracef("ZedCloudSuccess(%s, %s) %d %d",
 		ifname, url, reqLen, respLen)
 	mutex.Lock()
 	m := getAgentIfnameMetrics(log, ifname)


### PR DESCRIPTION
*PLEASE* review only the first commit (which is tiny).

The second commit is generated automatically by running these commands across the pillar directories:
sed -i'' 's/log.Info/log.Function/' *.go
sed -i'' 's/log.Debug/log.Trace/' *.go
sed -i'' 's/Log.Info/Log.Function/' *.go
sed -i'' 's/Log.Debug/Log.Trace/' *.go

Plus the second commit has one line manually changed from Debug to Trace at
https://github.com/eriknordmark/eve/blob/39dcc0a3578e91806c807c32c7d75532e2a57792/pkg/pillar/worker/worker.go#L18

As log-level documentation #1634 is pulled to master I'll update it (in this PR or a separate one) to make it match this implementation. This addresses the "future changes" in that PR.
