### PR TITLE
Restore ability to run diag manually

### DIFF
--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -302,7 +302,7 @@ wait_for_touch nim
 touch "$WATCHDOG_FILE/nim.touch"
 
 # Print diag output forever on changes
-$BINDIR/diag -f -o /dev/console &
+$BINDIR/diag -f -o /dev/console runAsService &
 
 # Wait for having IP addresses for a few minutes
 # so that we are likely to have an address when we run ntp

--- a/pkg/pillar/zedbox/zedbox.go
+++ b/pkg/pillar/zedbox/zedbox.go
@@ -73,7 +73,7 @@ var (
 	entrypoints = map[string]entrypoint{
 		"client":           {f: client.Run, inline: inlineAlways},
 		"command":          {f: command.Run},
-		"diag":             {f: diag.Run},
+		"diag":             {f: diag.Run, inline: inlineUnlessService},
 		"domainmgr":        {f: domainmgr.Run},
 		"downloader":       {f: downloader.Run},
 		"executor":         {f: executor.Run},


### PR DESCRIPTION
We lost that ability when the long-running diag was made into a goroutine in zedbox.
This keeps the long running one in zedbox, but if a user needs to debug one can run /opt/zededa/bin/diag -o /dev/tty
