### PR TITLE
Fix a corner case where device does not fallback to lastest DPC. Avoid data synchronization issue beteen go-routines while sending adapter status to cloud.

### DIFF
--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -561,7 +561,11 @@ func encodeNetInfo(port types.NetworkPortStatus) *info.ZInfoNetwork {
 }
 
 func encodeSystemAdapterInfo(ctx *zedagentContext) *info.SystemAdapterInfo {
-	dpcl := ctx.devicePortConfigList
+	dpcl := types.DevicePortConfigList{}
+	item, err := ctx.subDevicePortConfigList.Get("global")
+	if err == nil {
+		dpcl = item.(types.DevicePortConfigList)
+	}
 	sainfo := new(info.SystemAdapterInfo)
 	sainfo.CurrentIndex = uint32(dpcl.CurrentIndex)
 	sainfo.Status = make([]*info.DevicePortStatus, len(dpcl.PortConfigList))

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -124,7 +124,6 @@ type zedagentContext struct {
 	// outstanding reboot commands from cloud.
 	rebootConfigCounter     uint32
 	subDevicePortConfigList pubsub.Subscription
-	devicePortConfigList    types.DevicePortConfigList
 	remainingTestTime       time.Duration
 	physicalIoAdapterMap    map[string]types.PhysicalIOAdapter
 	globalConfig            types.ConfigItemValueMap
@@ -1413,22 +1412,11 @@ func handleDPCLModify(ctxArg interface{}, key string,
 
 func handleDPCLImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
-
-	status := statusArg.(types.DevicePortConfigList)
 	ctx := ctxArg.(*zedagentContext)
 	if key != "global" {
 		log.Functionf("handleDPCLImpl: ignoring %s", key)
 		return
 	}
-	if cmp.Equal(ctx.devicePortConfigList, status) {
-		log.Functionf("handleDPCLImpl no change")
-		return
-	}
-	// Note that lastSucceeded will increment a lot; ignore it but compare
-	// lastFailed/lastError?? XXX how?
-	log.Functionf("handleDPCLImpl: changed %v",
-		cmp.Diff(ctx.devicePortConfigList, status))
-	ctx.devicePortConfigList = status
 	triggerPublishDevInfo(ctx)
 }
 
@@ -1440,7 +1428,6 @@ func handleDPCLDelete(ctxArg interface{}, key string, statusArg interface{}) {
 		return
 	}
 	log.Functionf("handleDPCLDelete for %s", key)
-	ctx.devicePortConfigList = types.DevicePortConfigList{}
 	triggerPublishDevInfo(ctx)
 }
 

--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -443,6 +443,9 @@ func VerifyDevicePortConfig(ctx *DeviceNetworkContext) {
 					// Look for a better choice in a while
 					duration := time.Duration(ctx.NetworkTestBetterInterval) * time.Second
 					ctx.NetworkTestBetterTimer = time.NewTimer(duration)
+					log.Infof("VerifyDevicePortConfig: Kick started NetworkTestBetterTimer to try and get back to DPC at Index 0")
+				} else {
+					log.Warnf("VerifyDevicePortConfig: Did not start NetworkTestBetterTimer since timer interval is configured to be zero")
 				}
 			}
 		}


### PR DESCRIPTION
There are two commits as part of this PR
1) Zedagent should get device port config list from pubsub rather than reading from shared location.
2) Second commit for the corner case described below.

Say we have two DPCs in our DPCL.
- zedagent DPC at index 0, lastresort at index 1
- Device has eth0 (carrier UP) as mgmt and eth1 (carrier DOWN - no cable connected).
- zedagent DPC has eth0 mgmt, eth1 app-direct.
- Initially eth0 works fine and device network is UP with DPC at index 0.
- Let’s say there are some DNS issues in the network and DPC at index 0 fails periodic network tests.
- Device moves to lastresort. Gets IP addresses (lastresort uses eth0 and eth1 both) on eth0.
- But the connectivity tests will still fail. Network DNS has still not been fixed.
- So the current DPC (lastresort) fails with DPC_FAIL_WITH_IPANDDNS
- getNextTestableDPCIndex returns ‘-1’ since the DPC at index 0 has failed not long ago.
- So the testing stops with DPC at index 1 (lastresort), but the network tests better timer is not setup by current code in VerifyDevicePortConfig

Next…
- DNS starts working before the next NetworkTestTimer kicks.
- Next network test will pass and device comes online with lastresort, but we never try DPC at index 0.

Signed-off-by: Gopi krishna Kodali <gkodali@zededa.com>