### PR TITLE
Handle port state transitions and delay in port creation inside kernel

### DIFF
--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -594,7 +594,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 			start := time.Now()
 			if !ok {
 				log.Functionf("Network testBetterTimer stopped?")
-			} else if dnc.NextDPCIndex == 0 {
+			} else if dnc.NextDPCIndex == 0 && !dnc.DeviceNetworkStatus.HasErrors() {
 				log.Tracef("Network testBetterTimer at zero ignored")
 			} else {
 				log.Functionf("Network testBetterTimer at index %d",
@@ -671,6 +671,14 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 					handleLinkChange(&nimCtx)
 					handleInterfaceChange(&nimCtx, ifindex,
 						"LinkChange", true)
+					ifname, _, _ := devicenetwork.IfindexToName(log, ifindex)
+					if ifname != "" {
+						portStatus := nimCtx.deviceNetworkContext.DevicePortConfigList.PortConfigList[0].GetPortByIfName(ifname)
+						if !nimCtx.deviceNetworkContext.Pending.Inprogress && portStatus != nil {
+							log.Functionf("Start network connectivity verfication because ifname %s port of DPC at index 0 changed", ifname)
+							devicenetwork.RestartVerify(&nimCtx.deviceNetworkContext, "HandleLinkChange")
+						}
+					}
 				}
 			}
 			ps.CheckMaxTimeTopic(agentName, "linkChanges", start,
@@ -735,7 +743,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 			start := time.Now()
 			if !ok {
 				log.Functionf("Network testBetterTimer stopped?")
-			} else if dnc.NextDPCIndex == 0 {
+			} else if dnc.NextDPCIndex == 0 && !dnc.DeviceNetworkStatus.HasErrors() {
 				log.Tracef("Network testBetterTimer at zero ignored")
 			} else {
 				log.Functionf("Network testBetterTimer at index %d",

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -671,7 +671,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 					handleLinkChange(&nimCtx)
 					handleInterfaceChange(&nimCtx, ifindex,
 						"LinkChange", true)
-					ifname, _, _ := devicenetwork.IfindexToName(log, ifindex)
+					ifname := change.Attrs().Name
 					if ifname != "" {
 						portStatus := nimCtx.deviceNetworkContext.DevicePortConfigList.PortConfigList[0].GetPortByIfName(ifname)
 						if !nimCtx.deviceNetworkContext.Pending.Inprogress && portStatus != nil {

--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -257,7 +257,7 @@ func VerifyPending(ctx *DeviceNetworkContext, pending *DPCPending,
 		log.Functionf("VerifyPending: DPC changed. update DhcpClient.\n")
 		UpdateDhcpClient(log, runnableDPC, pending.RunningDPC)
 		pending.RunningDPC = runnableDPC
-		// XXX Does it make sense to publish RunningDPC for debug?
+		log.Functionf("Running with DPC %v", pending.RunningDPC)
 	}
 	pend2 := MakeDeviceNetworkStatus(log, pending.PendDPC, pending.PendDNS)
 	pending.PendDNS = pend2
@@ -318,15 +318,10 @@ type portError struct {
 }
 
 // Check if all interfaces exist in the kernel
-// Returns the ifname for the first missing if there is an error
+// Returns a list of port errors if any and a DPC that we should run next.
 func checkInterfacesExists(log *base.LogObject, dpc types.DevicePortConfig) ([]portError, types.DevicePortConfig) {
-	runnableDPC := types.DevicePortConfig{}
-	runnableDPC.Version = dpc.Version
-	runnableDPC.Key = dpc.Key
-	runnableDPC.TimePriority = dpc.TimePriority
-	runnableDPC.State = types.DPC_NONE
-	runnableDPC.TestResults = dpc.TestResults
-	runnableDPC.LastIPAndDNS = dpc.LastIPAndDNS
+	runnableDPC := dpc
+	runnableDPC.Ports = []types.NetworkPortConfig{}
 
 	portErrors := []portError{}
 

--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -244,9 +244,11 @@ func VerifyPending(ctx *DeviceNetworkContext, pending *DPCPending,
 			pending.PendDPC.RecordFailure(portError.err.Error())
 		}
 		// Proceed trying other interfaces
+		log.Warnf("VerifyPending: Some required ports are missing. Continuing verification process with remaining ports")
+	} else {
+		log.Functionf("VerifyPending: No required ports missing. " +
+			"parsing device port config list")
 	}
-	log.Functionf("VerifyPending: No required ports missing. " +
-		"parsing device port config list")
 
 	if !runnableDPC.MostlyEqual(&pending.RunningDPC) {
 		log.Functionf("VerifyPending: DPC changed. check Wireless %v\n", pending.PendDPC)
@@ -255,6 +257,7 @@ func VerifyPending(ctx *DeviceNetworkContext, pending *DPCPending,
 		log.Functionf("VerifyPending: DPC changed. update DhcpClient.\n")
 		UpdateDhcpClient(log, runnableDPC, pending.RunningDPC)
 		pending.RunningDPC = runnableDPC
+		// XXX Does it make sense to publish RunningDPC for debug?
 	}
 	pend2 := MakeDeviceNetworkStatus(log, pending.PendDPC, pending.PendDNS)
 	pending.PendDNS = pend2

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -1159,6 +1159,15 @@ func (status *DeviceNetworkStatus) GetPortByLogicallabel(
 	return nil
 }
 
+func (status DeviceNetworkStatus) HasErrors() bool {
+	for _, port := range status.Ports {
+		if port.HasError() {
+			return true
+		}
+	}
+	return false
+}
+
 func rotate(arr []string, amount int) []string {
 	if len(arr) == 0 {
 		return []string{}

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -1159,6 +1159,7 @@ func (status *DeviceNetworkStatus) GetPortByLogicallabel(
 	return nil
 }
 
+// HasErrors - DeviceNetworkStatus has errors on any of it's ports?
 func (status DeviceNetworkStatus) HasErrors() bool {
 	for _, port := range status.Ports {
 		if port.HasError() {


### PR DESCRIPTION
1) Instead of storing the entire DPC (including ports with errors) to track running DPC, we only store the ports that can be used and with out errors. The next time when we re-trigger verification process and have ports cleared of previous errors, VerifyPending will see that we have a difference in ports and start/stop dhcp on ports as required.
2) Port link transitions should re-trigger RestartVerify if they are part of DPC at index 0
3) If the latest DNS that we have port related errors, we should create test better timer to come back and see if the ports errors are gone.