### PR TITLE
Size metrics is off; Progress stops below 50%

### DIFF
--- a/pkg/pillar/cmd/downloader/download.go
+++ b/pkg/pillar/cmd/downloader/download.go
@@ -110,11 +110,8 @@ func download(ctx *downloaderContext, trType zedUpload.SyncTransportType,
 		if resp.IsError() {
 			return "", err
 		}
-		asize, osize := resp.GetAsize(), resp.GetOsize()
-		log.Functionf("Done for %v: size %v/%v",
-			resp.GetLocalName(),
-			asize, osize)
-		status.Progress(100, osize, asize)
+		log.Functionf("Done for %v size %d",
+			resp.GetLocalName(), resp.GetAsize())
 		return req.GetContentType(), nil
 	}
 	// if we got here, channel was closed

--- a/pkg/pillar/cmd/downloader/syncop.go
+++ b/pkg/pillar/cmd/downloader/syncop.go
@@ -220,6 +220,10 @@ func handleSyncOp(ctx *downloaderContext, key string,
 		status.ContentType = contentType
 		zedcloud.ZedCloudSuccess(log, ifname,
 			metricsUrl, 1024, size, downloadTime)
+		if st.Progress(100, size, size) {
+			log.Noticef("updated sizes at end to %d/%d",
+				size, size)
+		}
 		handleSyncOpResponse(ctx, config, status,
 			locFilename, key, "")
 		return

--- a/pkg/pillar/cmd/volumemgr/artifact.go
+++ b/pkg/pillar/cmd/volumemgr/artifact.go
@@ -106,12 +106,17 @@ func createManifestsForBareBlob(artifact *registry.Artifact) ([]*types.BlobStatu
 		return nil, fmt.Errorf("getManifestsForBlob: Exception while reading config bytes: %s",
 			err.Error())
 	}
+	blen := int64(len(configBytes))
 	// and the config file which was in the manifest
 	blobStatuses = append(blobStatuses, &types.BlobStatus{
-		Content:   configBytes,
-		State:     types.VERIFIED,
-		MediaType: string(v1types.OCIConfigJSON),
-		Sha256:    manifest.Config.Digest.Encoded(),
+		Content:     configBytes,
+		State:       types.VERIFIED,
+		Size:        uint64(blen),
+		CurrentSize: blen,
+		TotalSize:   blen,
+		Progress:    100,
+		MediaType:   string(v1types.OCIConfigJSON),
+		Sha256:      manifest.Config.Digest.Encoded(),
 	})
 	return blobStatuses, nil
 }

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -127,9 +127,9 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 		leftToProcess := false
 
 		var (
-			currentSize, totalSize int64
-			blobErrors             = []string{}
-			blobErrorTime          time.Time
+			currentSize, totalSize, manifestTotalSize int64
+			blobErrors                                = []string{}
+			blobErrorTime                             time.Time
 		)
 		for _, blobSha := range status.Blobs {
 			// get the actual blobStatus
@@ -181,12 +181,7 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 					AddBlobsToContentTreeStatus(ctx, status, addedBlobs...)
 				}
 				if blob.IsManifest() {
-					size := resolveManifestSize(ctx, *blob)
-					if size != blob.TotalSize {
-						blob.TotalSize = size
-						publishBlobStatus(ctx, blob)
-						changed = true
-					}
+					manifestTotalSize = resolveManifestSize(ctx, *blob)
 				}
 			}
 			// if any errors, catch them
@@ -203,6 +198,13 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 			}
 		}
 
+		// The manifestTotalSize does not include the size of the
+		// manifest itself but we set it as an initial approximation
+		if totalSize < manifestTotalSize {
+			log.Functionf("doUpdateContentTree: manifestTotal %d total %d",
+				manifestTotalSize, totalSize)
+			totalSize = manifestTotalSize
+		}
 		// Check if sizes changed before setting changed
 		if status.CurrentSize != currentSize || status.TotalSize != totalSize {
 			changed = true


### PR DESCRIPTION
I noticed a few issues with the size and progress flowing from downloader to blobs, content tree, and volume status:
 -  a OCI content tree stopped below 50% progress (this was due to the adding the manifest size)
 - small OCI containers report CurrentSize hence Progress as zero. That was due to the CurrentSize not being updated correctly
when the download was done
 - some VM images had the TotalSize drop to zero at the end (due to the downloader getting a zero Osize)
 - the Blobs with inline content (using the Content slice) report Progress as zero since their sizes are zero. More logical to set their size to the number of bytes in Content so they are reported as 100%

Note that setting the TotalSize to manifestTotalSize (see diffs) actually makes the CurrentSize not identical to TotalSize at the end of an OCI download. Thus we use manifestTotalSize as a lower bound.