### PR TITLE
[WIP] [NO NOT MERGE] Need locking for worker

### DIFF
--- a/pkg/pillar/base/log.go
+++ b/pkg/pillar/base/log.go
@@ -13,7 +13,8 @@ import (
 var (
 	myNoticeLevel   = logrus.InfoLevel
 	myMetricLevel   = logrus.DebugLevel
-	myFunctionLevel = logrus.DebugLevel
+	myFunctionLevel = logrus.InfoLevel
+	myTraceLevel    = logrus.InfoLevel
 )
 
 // Function :
@@ -238,7 +239,7 @@ func (object *LogObject) Trace(args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	object.logger.WithFields(object.Fields).Trace(args...)
+	object.logger.WithFields(object.Fields).Log(myTraceLevel, args...)
 }
 
 // Tracef :
@@ -247,7 +248,7 @@ func (object *LogObject) Tracef(format string, args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	object.logger.WithFields(object.Fields).Tracef(format, args...)
+	object.logger.WithFields(object.Fields).Logf(myTraceLevel, format, args...)
 }
 
 // Traceln :
@@ -256,5 +257,5 @@ func (object *LogObject) Traceln(args ...interface{}) {
 		logrus.Fatal("LogObject used without initialization")
 		return
 	}
-	object.logger.WithFields(object.Fields).Traceln(args...)
+	object.logger.WithFields(object.Fields).Logln(myTraceLevel, args...)
 }

--- a/pkg/pillar/cmd/baseosmgr/baseosmgr.go
+++ b/pkg/pillar/cmd/baseosmgr/baseosmgr.go
@@ -139,7 +139,10 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 			ctx.subNodeAgentStatus.ProcessChange(change)
 
 		case res := <-ctx.worker.MsgChan():
-			res.Process(&ctx, true)
+			log.Functionf("Process worker")
+			if err := res.Process(log, &ctx, true); err != nil {
+				log.Error(err)
+			}
 
 		case <-stillRunning.C:
 		}

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -476,7 +476,10 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 			ctx.subContentTreeConfig.ProcessChange(change)
 
 		case res := <-ctx.worker.MsgChan():
-			res.Process(&ctx, true)
+			log.Functionf("Process worker")
+			if err := res.Process(log, &ctx, true); err != nil {
+				log.Error(err)
+			}
 
 		case <-stillRunning.C:
 		}
@@ -547,7 +550,10 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 				warningTime, errorTime)
 
 		case res := <-ctx.worker.MsgChan():
-			res.Process(&ctx, true)
+			log.Functionf("Process worker")
+			if err := res.Process(log, &ctx, true); err != nil {
+				log.Error(err)
+			}
 
 		case <-stillRunning.C:
 		}

--- a/pkg/pillar/worker/example_test.go
+++ b/pkg/pillar/worker/example_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/worker"
 	"github.com/sirupsen/logrus"
 )
@@ -35,7 +36,8 @@ func Example_workerprocess() {
 	}
 
 	// create a new worker that can handle jobs of Kind "install"
-	work := worker.NewWorker(logrus.New(), ctx, 5, map[string]worker.Handler{
+	logObject := base.NewSourceLogObject(logrus.StandardLogger(), "test", 1234)
+	work := worker.NewWorker(logObject, ctx, 5, map[string]worker.Handler{
 		kind: {Request: installWorker, Response: processInstallWorkResult},
 	})
 
@@ -53,7 +55,7 @@ forloop:
 	for {
 		select {
 		case res := <-work.C():
-			res.Process(ctx, true)
+			res.Process(logObject, ctx, true)
 			// break out of the loop once we have a result
 			// normally, you would keep going
 			break forloop

--- a/pkg/pillar/worker/workerpool_test.go
+++ b/pkg/pillar/worker/workerpool_test.go
@@ -44,6 +44,8 @@ var sleep20 = dummyDescription{
 	generateOutput: "sleep20",
 }
 
+var logObject *base.LogObject
+
 func setupPool(maxPool int) (*dummyContext, *worker.Pool, *worker.WorkResult) {
 	ctx := dummyContext{contextName: "testContext"}
 	var res worker.WorkResult
@@ -53,8 +55,9 @@ func setupPool(maxPool int) (*dummyContext, *worker.Pool, *worker.WorkResult) {
 	}
 	logger := logrus.StandardLogger()
 	// logger.SetLevel(logrus.TraceLevel)
+	logObject = base.NewSourceLogObject(logger, "test", 1234)
 	wp := worker.NewPoolWithGC(
-		base.NewSourceLogObject(logger, "test", 1234),
+		logObject,
 		&ctx, maxPool, map[string]worker.Handler{
 			"test": {Request: dummyWorker, Response: dummyResponse},
 		},
@@ -102,19 +105,19 @@ func TestInOrder(t *testing.T) {
 	assert.Equal(t, 3, wp.NumPending())
 
 	proc1 := <-wp.MsgChan()
-	proc1.Process(ctx, true)
+	proc1.Process(nil, ctx, true)
 	assert.Equal(t, 2, wp.NumPending())
 	assert.Equal(t, testname+"1", res.Key)
 	assert.Equal(t, sleep1.generateOutput, res.Output)
 
 	proc2 := <-wp.MsgChan()
-	proc2.Process(ctx, true)
+	proc2.Process(nil, ctx, true)
 	assert.Equal(t, 1, wp.NumPending())
 	assert.Equal(t, testname+"2", res.Key)
 	assert.Equal(t, sleep2.generateOutput, res.Output)
 
 	proc3 := <-wp.MsgChan()
-	proc3.Process(ctx, true)
+	proc3.Process(nil, ctx, true)
 	// this one uses the Pop, so we exercise it
 	res3 := wp.Pop(testname + "3")
 	assert.Equal(t, testname+"3", res3.Key)
@@ -179,19 +182,19 @@ func TestNoLimit(t *testing.T) {
 	assert.Equal(t, 4, wp.NumPending())
 
 	proc1 := <-wp.MsgChan()
-	proc1.Process(ctx, true)
+	proc1.Process(nil, ctx, true)
 	assert.Equal(t, 3, wp.NumPending())
 	assert.Equal(t, testname+"1", res.Key)
 	assert.Equal(t, sleep1.generateOutput, res.Output)
 
 	proc2 := <-wp.MsgChan()
-	proc2.Process(ctx, true)
+	proc2.Process(nil, ctx, true)
 	assert.Equal(t, 2, wp.NumPending())
 	assert.Equal(t, testname+"2", res.Key)
 	assert.Equal(t, sleep2.generateOutput, res.Output)
 
 	proc3 := <-wp.MsgChan()
-	proc3.Process(ctx, true)
+	proc3.Process(nil, ctx, true)
 	// this one uses the Pop, so we exercise it
 	res3 := wp.Pop(testname + "3")
 	assert.Equal(t, testname+"3", res3.Key)
@@ -199,7 +202,7 @@ func TestNoLimit(t *testing.T) {
 	assert.Equal(t, 1, wp.NumPending())
 
 	proc4 := <-wp.MsgChan()
-	proc4.Process(ctx, true)
+	proc4.Process(nil, ctx, true)
 	res4 := wp.Pop(testname + "4")
 	assert.Equal(t, testname+"4", res4.Key)
 	assert.Equal(t, sleep4.generateOutput, res4.Output)
@@ -249,13 +252,13 @@ func TestNoblocking(t *testing.T) {
 	assert.Equal(t, 2, wp.NumPending())
 
 	proc1 := <-wp.MsgChan()
-	proc1.Process(ctx, true)
+	proc1.Process(nil, ctx, true)
 	assert.Equal(t, 1, wp.NumPending())
 	assert.Equal(t, testname+"2", res.Key)
 	assert.Equal(t, sleep1.generateOutput, res.Output)
 
 	proc2 := <-wp.MsgChan()
-	proc2.Process(ctx, true)
+	proc2.Process(nil, ctx, true)
 	assert.Equal(t, 0, wp.NumPending())
 	assert.Equal(t, testname+"1", res.Key)
 	assert.Equal(t, sleep4.generateOutput, res.Output)
@@ -318,13 +321,13 @@ func TestGC(t *testing.T) {
 
 	// Pick up 1 second one and two second one
 	proc2 := <-wp.MsgChan()
-	proc2.Process(ctx, true)
+	proc2.Process(nil, ctx, true)
 	assert.Equal(t, 3, wp.NumPending())
 	assert.Equal(t, testname+"2", res.Key)
 	assert.Equal(t, sleep1.generateOutput, res.Output)
 
 	proc3 := <-wp.MsgChan()
-	proc3.Process(ctx, true)
+	proc3.Process(nil, ctx, true)
 	assert.Equal(t, 2, wp.NumPending())
 	assert.Equal(t, testname+"3", res.Key)
 	assert.Equal(t, sleep3.generateOutput, res.Output)
@@ -341,19 +344,19 @@ func TestGC(t *testing.T) {
 	assert.Equal(t, 2, wp.NumPending())
 
 	proc4 := <-wp.MsgChan()
-	proc4.Process(ctx, true)
+	proc4.Process(nil, ctx, true)
 	assert.Equal(t, 2, wp.NumPending())
 	assert.Equal(t, testname+"4", res.Key)
 	assert.Equal(t, sleep4.generateOutput, res.Output)
 
 	proc5 := <-wp.MsgChan()
-	proc5.Process(ctx, true)
+	proc5.Process(nil, ctx, true)
 	assert.Equal(t, 1, wp.NumPending())
 	assert.Equal(t, testname+"5", res.Key)
 	assert.Equal(t, sleep1.generateOutput, res.Output)
 
 	proc1 := <-wp.MsgChan()
-	proc1.Process(ctx, true)
+	proc1.Process(nil, ctx, true)
 	assert.Equal(t, 0, wp.NumPending())
 	assert.Equal(t, testname+"1", res.Key)
 	assert.Equal(t, sleep20.generateOutput, res.Output)


### PR DESCRIPTION
@giggsoff is seeing some occasional failures where there are no worker results hence the volume is stuck at Creating Volume.
We recently switched from worker to workerpool so we can see more concurrency in accessing the maps in the worker package and they are access from multiple goroutines.

Adding the locks in the second commit should help.
The first commit will be dropped before pulling this.
Also WIP since some worker unit tests fail with the additional logging in the worker package, so will probably remove that once we now this helps.