### PR TITLE
Need lock around maps in worker

### DIFF
--- a/pkg/pillar/worker/example_test.go
+++ b/pkg/pillar/worker/example_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/worker"
 	"github.com/sirupsen/logrus"
 )
@@ -35,7 +36,8 @@ func Example_workerprocess() {
 	}
 
 	// create a new worker that can handle jobs of Kind "install"
-	work := worker.NewWorker(logrus.New(), ctx, 5, map[string]worker.Handler{
+	logObject := base.NewSourceLogObject(logrus.StandardLogger(), "test", 1234)
+	work := worker.NewWorker(logObject, ctx, 5, map[string]worker.Handler{
 		kind: {Request: installWorker, Response: processInstallWorkResult},
 	})
 

--- a/pkg/pillar/worker/worker.go
+++ b/pkg/pillar/worker/worker.go
@@ -243,7 +243,7 @@ func (w *Worker) Pop(key string) *WorkResult {
 	w.Lock()
 	defer w.Unlock()
 	res := w.lookupResultLocked(key)
-	if w != nil {
+	if res != nil {
 		w.deleteResultLocked(key)
 	}
 	return res

--- a/pkg/pillar/worker/worker_test.go
+++ b/pkg/pillar/worker/worker_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 var timestamp time.Time
+var logObject *base.LogObject
 
 func TestWork(t *testing.T) {
 	testMatrix := map[string]struct {
@@ -57,8 +58,11 @@ func TestWork(t *testing.T) {
 		return nil
 	}
 
+	logger := logrus.StandardLogger()
+	// logger.SetLevel(logrus.TraceLevel)
+	logObject = base.NewSourceLogObject(logger, "test", 1234)
 	worker := NewWorker(
-		base.NewSourceLogObject(logrus.StandardLogger(), "test", 1234),
+		logObject,
 		&ctx, 1, map[string]Handler{
 			"test": {Request: dummyWorker, Response: dummyResponse},
 		})
@@ -119,8 +123,11 @@ func TestLength(t *testing.T) {
 		res = r
 		return nil
 	}
+	logger := logrus.StandardLogger()
+	// logger.SetLevel(logrus.TraceLevel)
+	logObject = base.NewSourceLogObject(logger, "test", 1234)
 	worker := NewWorker(
-		base.NewSourceLogObject(logrus.StandardLogger(), "test", 1234),
+		logObject,
 		&ctx, 1, map[string]Handler{
 			"test": {Request: dummyWorker, Response: dummyResponse},
 		})

--- a/pkg/pillar/worker/workerpool_test.go
+++ b/pkg/pillar/worker/workerpool_test.go
@@ -54,7 +54,7 @@ func setupPool(maxPool int) (*dummyContext, *worker.Pool, *worker.WorkResult) {
 		return nil
 	}
 	logger := logrus.StandardLogger()
-	// logger.SetLevel(logrus.TraceLevel)
+	logger.SetLevel(logrus.TraceLevel)
 	logObject = base.NewSourceLogObject(logger, "test", 1234)
 	wp := worker.NewPoolWithGC(
 		logObject,
@@ -67,8 +67,8 @@ func setupPool(maxPool int) (*dummyContext, *worker.Pool, *worker.WorkResult) {
 
 // TestInOrder verifies that workers are spawned and return in order
 func TestInOrder(t *testing.T) {
-	numGoroutines := runtime.NumGoroutine()
 	origStacks := getStacks(true)
+	numGoroutines := runtime.NumGoroutine()
 	ctx, wp, res := setupPool(3)
 	testname := "testinorder"
 
@@ -135,6 +135,7 @@ func TestInOrder(t *testing.T) {
 	done = !ok
 	assert.True(t, done)
 	// Check that goroutines are gone
+	time.Sleep(time.Second)
 	newCount := runtime.NumGoroutine()
 	assert.Equal(t, numGoroutines, newCount)
 	if numGoroutines != newCount {
@@ -147,8 +148,8 @@ func TestInOrder(t *testing.T) {
 
 // TestNoLimit verifies that zero means no limit
 func TestNoLimit(t *testing.T) {
-	numGoroutines := runtime.NumGoroutine()
 	origStacks := getStacks(true)
+	numGoroutines := runtime.NumGoroutine()
 	ctx, wp, res := setupPool(0)
 	testname := "testnolimit"
 
@@ -220,6 +221,7 @@ func TestNoLimit(t *testing.T) {
 	done = !ok
 	assert.True(t, done)
 	// Check that goroutines are gone
+	time.Sleep(time.Second)
 	newCount := runtime.NumGoroutine()
 	assert.Equal(t, numGoroutines, newCount)
 	if numGoroutines != newCount {
@@ -232,8 +234,8 @@ func TestNoLimit(t *testing.T) {
 
 // TestNoblocking verifies that a short after a long completes first
 func TestNoblocking(t *testing.T) {
-	numGoroutines := runtime.NumGoroutine()
 	origStacks := getStacks(true)
+	numGoroutines := runtime.NumGoroutine()
 	ctx, wp, res := setupPool(3)
 	testname := "testnoblocking"
 
@@ -276,6 +278,7 @@ func TestNoblocking(t *testing.T) {
 	done = !ok
 	assert.True(t, done)
 	// Check that goroutines are gone
+	time.Sleep(time.Second)
 	newCount := runtime.NumGoroutine()
 	assert.Equal(t, numGoroutines, newCount)
 	if numGoroutines != newCount {
@@ -288,8 +291,8 @@ func TestNoblocking(t *testing.T) {
 
 // TestGC verifies that unused workers are deleted
 func TestGC(t *testing.T) {
-	numGoroutines := runtime.NumGoroutine()
 	origStacks := getStacks(true)
+	numGoroutines := runtime.NumGoroutine()
 	ctx, wp, res := setupPool(0)
 	testname := "testgc"
 
@@ -372,6 +375,7 @@ func TestGC(t *testing.T) {
 	assert.Equal(t, 0, wp.NumWorkers())
 
 	// Check that goroutines are gone
+	time.Sleep(time.Second)
 	newCount := runtime.NumGoroutine()
 	assert.Equal(t, numGoroutines, newCount)
 	if numGoroutines != newCount {

--- a/pkg/pillar/worker/workerpool_test.go
+++ b/pkg/pillar/worker/workerpool_test.go
@@ -44,6 +44,8 @@ var sleep20 = dummyDescription{
 	generateOutput: "sleep20",
 }
 
+var logObject *base.LogObject
+
 func setupPool(maxPool int) (*dummyContext, *worker.Pool, *worker.WorkResult) {
 	ctx := dummyContext{contextName: "testContext"}
 	var res worker.WorkResult
@@ -53,8 +55,9 @@ func setupPool(maxPool int) (*dummyContext, *worker.Pool, *worker.WorkResult) {
 	}
 	logger := logrus.StandardLogger()
 	// logger.SetLevel(logrus.TraceLevel)
+	logObject = base.NewSourceLogObject(logger, "test", 1234)
 	wp := worker.NewPoolWithGC(
-		base.NewSourceLogObject(logger, "test", 1234),
+		logObject,
 		&ctx, maxPool, map[string]worker.Handler{
 			"test": {Request: dummyWorker, Response: dummyResponse},
 		},
@@ -132,8 +135,9 @@ func TestInOrder(t *testing.T) {
 	done = !ok
 	assert.True(t, done)
 	// Check that goroutines are gone
-	assert.Equal(t, numGoroutines, runtime.NumGoroutine())
-	if numGoroutines != runtime.NumGoroutine() {
+	newCount := runtime.NumGoroutine()
+	assert.Equal(t, numGoroutines, newCount)
+	if numGoroutines != newCount {
 		t.Logf("All goroutine stacks on entry: %v",
 			origStacks)
 		t.Logf("All goroutine stacks on exit: %v",
@@ -216,8 +220,9 @@ func TestNoLimit(t *testing.T) {
 	done = !ok
 	assert.True(t, done)
 	// Check that goroutines are gone
-	assert.Equal(t, numGoroutines, runtime.NumGoroutine())
-	if numGoroutines != runtime.NumGoroutine() {
+	newCount := runtime.NumGoroutine()
+	assert.Equal(t, numGoroutines, newCount)
+	if numGoroutines != newCount {
 		t.Logf("All goroutine stacks on entry: %v",
 			origStacks)
 		t.Logf("All goroutine stacks on exit: %v",
@@ -271,8 +276,9 @@ func TestNoblocking(t *testing.T) {
 	done = !ok
 	assert.True(t, done)
 	// Check that goroutines are gone
-	assert.Equal(t, numGoroutines, runtime.NumGoroutine())
-	if numGoroutines != runtime.NumGoroutine() {
+	newCount := runtime.NumGoroutine()
+	assert.Equal(t, numGoroutines, newCount)
+	if numGoroutines != newCount {
 		t.Logf("All goroutine stacks on entry: %v",
 			origStacks)
 		t.Logf("All goroutine stacks on exit: %v",
@@ -366,8 +372,9 @@ func TestGC(t *testing.T) {
 	assert.Equal(t, 0, wp.NumWorkers())
 
 	// Check that goroutines are gone
-	assert.Equal(t, numGoroutines, runtime.NumGoroutine())
-	if numGoroutines != runtime.NumGoroutine() {
+	newCount := runtime.NumGoroutine()
+	assert.Equal(t, numGoroutines, newCount)
+	if numGoroutines != newCount {
 		t.Logf("All goroutine stacks on entry: %v",
 			origStacks)
 		t.Logf("All goroutine stacks on exit: %v",


### PR DESCRIPTION
We see cases with multiple goroutines in the workerpool running concurrently when one worker finishes and adds to the result map, but then main goroutine in volumemgr goes and looks for the result there is nothing there.
This could be due to having no locks around the Worker state, and we haven't seen this hard-to-reproduce failure once we've added the locks in this PR.

Also making the 'number of goroutine' asserts less likely to fire; the count seems to change between the assert and the if statement immediately following.