### PR TITLE
Fixing spurious build failures

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,9 @@ jobs:
         run: |
           # FIXME: this needs to be updated in the build image
           if [ "$(uname -m)" = aarch64 ]; then
-             sudo apt install -y jq
+             sudo apt install -y jq || :
+             docker rmi -f `docker image ls -q` || :
+             docker system prune -f || :
           fi
           # GH Actions convert our annotated tags into plain ones,
           # so we need to convert it back (but only if it exists).

--- a/pkg/fw/Dockerfile
+++ b/pkg/fw/Dockerfile
@@ -12,9 +12,9 @@ RUN apk add --no-cache \
 FROM scratch
 ENTRYPOINT []
 WORKDIR /
-COPY --from=build /lib/firmware/mrvl /lib/firmware/mrvl
+COPY --from=build /lib/firmware/mrvl/*.bin /lib/firmware/mrvl/
 COPY --from=build /lib/firmware/rt2870.bin /lib/firmware/rt2870.bin
-COPY --from=build /lib/firmware/rtlwifi /lib/firmware/rtlwifi
+COPY --from=build /lib/firmware/rtlwifi/*.bin /lib/firmware/rtlwifi/
 COPY --from=build /lib/firmware/iwlwifi-8265* /lib/firmware/
 COPY --from=build /lib/firmware/iwlwifi-7260* /lib/firmware/
 # Dell Edge Gateway 300x firmware


### PR DESCRIPTION
Two fixes in here that made our release build fail:
   1. turns out alpine also silently updates firmware blob packages -- we need to be more specific as to what we pick
   2. ARM build server runs out of storage since we still don't have an on-demand one