### PR TITLE
move state transition from cas

### DIFF
--- a/pkg/pillar/cas/containerd.go
+++ b/pkg/pillar/cas/containerd.go
@@ -178,12 +178,6 @@ func (c *containerdCAS) IngestBlob(ctx context.Context, blobs ...types.BlobStatu
 			continue
 		}
 
-		// Process the blob only if it isn't already loaded. It might be loaded but not
-		// yet marked in the blobstatus, so we wait
-		if blob.State == types.LOADING {
-			logrus.Infof("IngestBlob(%s): Not loading blob as it is marked as loading from a different thread", blob.Sha256)
-			continue
-		}
 		logrus.Infof("IngestBlob(%s): Attempting to load blob", blob.Sha256)
 
 		//Step 1.1: Read the blob from verified dir or provided content

--- a/pkg/pillar/cmd/volumemgr/handlework.go
+++ b/pkg/pillar/cmd/volumemgr/handlework.go
@@ -171,13 +171,8 @@ func casIngestWorker(ctxPtr interface{}, w worker.Work) worker.WorkResult {
 			continue
 		}
 		found[blob.Sha256] = true
-		if blob.State == types.VERIFIED {
-			// Pay close attention: we copy the blob *before* changing it to loading.
-			// We want everything else to know that it is LOADING, but not the routine to
-			// ingest that we are about to call.
+		if blob.State == types.LOADING {
 			loadBlobs = append(loadBlobs, *blob)
-			blob.State = types.LOADING
-			publishBlobStatus(ctx, blob)
 		}
 	}
 


### PR DESCRIPTION
As we discussed with @deitch and @eriknordmark, we need to check the state of the root blob in the contentTree and move state transition from cas into the main thread.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>