### PR TITLE
convert Worker to an interface

### DIFF
--- a/pkg/pillar/cmd/baseosmgr/baseosmgr.go
+++ b/pkg/pillar/cmd/baseosmgr/baseosmgr.go
@@ -49,7 +49,7 @@ type baseOsMgrContext struct {
 	rebootTime           time.Time // From last reboot
 	rebootImage          string    // Image from which the last reboot happened
 
-	worker *worker.Pool // For background work
+	worker worker.Worker // For background work
 }
 
 var debug = false

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -70,7 +70,7 @@ type volumemgrContext struct {
 	diskMetricsTickerHandle interface{}
 	gc                      *time.Ticker
 
-	worker *worker.Pool // For background work
+	worker worker.Worker // For background work
 
 	verifierRestarted    bool // Wait for verifier to restart
 	contentTreeRestarted bool // Wait to receive all contentTree after restart

--- a/pkg/pillar/worker/workerpool.go
+++ b/pkg/pillar/worker/workerpool.go
@@ -35,20 +35,20 @@ type Pool struct {
 }
 
 type myworker struct {
-	worker   *Worker
+	worker   Worker
 	lastUsed time.Time // Last successful submit
 }
 
 // NewPool constructs a pool
 // If maxWorkers is set to zero it means unlimited
-func NewPool(log Logger, ctx interface{}, maxWorkers int, handlers map[string]Handler) *Pool {
+func NewPool(log Logger, ctx interface{}, maxWorkers int, handlers map[string]Handler) Worker {
 	return NewPoolWithGC(log, ctx, maxWorkers, handlers,
 		defaultPeriodicGCSeconds, defaultSubmitGCSeconds)
 }
 
 // NewPoolWithGC constructs a pool with non-default GC timers
 // If maxWorkers is set to zero it means unlimited
-func NewPoolWithGC(log Logger, ctx interface{}, maxWorkers int, handlers map[string]Handler, periodicGCSeconds int, submitGCSeconds int) *Pool {
+func NewPoolWithGC(log Logger, ctx interface{}, maxWorkers int, handlers map[string]Handler, periodicGCSeconds int, submitGCSeconds int) Worker {
 	length := maxWorkers
 	if length == 0 {
 		length = 10
@@ -87,7 +87,7 @@ func (wp *Pool) periodicGC() {
 	wp.log.Tracef("periodicGC done")
 }
 
-func (wp *Pool) mergeResult(w *Worker) {
+func (wp *Pool) mergeResult(w Worker) {
 	wp.log.Tracef("mergeResult starting")
 	ch := w.MsgChan()
 	for res := range ch {
@@ -125,8 +125,30 @@ func (wp *Pool) NumWorkers() int {
 	return len(wp.workers)
 }
 
-// TrySubmit returns false if the number of workers is already at the max
-// returns JobInProgressError if a job with that key already in progress
+// Submit submits jobs to the WorkerPool. If it cannot find a worker in the pool
+// that can service it - i.e. both the number of workers is at the maximum and the
+// queues of all workers are full - then it waits one second and tries all available
+// workers again, in an infinite loop until it finds an available worker.
+// Returns nil if the new job was submitted, JobInProgressError if a job with that
+// key already ins progress, and other errors if it cannot proceed.
+func (wp *Pool) Submit(work Work) error {
+	for {
+		submitted, err := wp.TrySubmit(work)
+		if err != nil {
+			return err
+		}
+		// simple success case
+		if submitted {
+			return nil
+		}
+		time.Sleep(1 * time.Second)
+	}
+}
+
+// TrySubmit submits jobs to the WorkerPool. If it cannot find a worker in the pool
+// that can service it - i.e. both the number of workers is at the maximum and the
+// queues of all workers are full - returns false.
+// returns JobInProgressError if a job with that key already in progress.
 func (wp *Pool) TrySubmit(work Work) (bool, error) {
 	for i, w := range wp.workers {
 		done, err := w.worker.TrySubmit(work)
@@ -169,6 +191,12 @@ func (wp *Pool) TrySubmit(work Work) (bool, error) {
 // MsgChan returns a channel to be used in a select loop.
 // This is a duplicate of C
 func (wp *Pool) MsgChan() <-chan Processor {
+	return wp.resultChan
+}
+
+// C returns a channel to be used in a select loop.
+// This is a duplicate of MsgChan
+func (wp *Pool) C() <-chan Processor {
 	return wp.resultChan
 }
 

--- a/pkg/pillar/worker/workerpool_test.go
+++ b/pkg/pillar/worker/workerpool_test.go
@@ -62,7 +62,7 @@ func setupPool(maxPool int) (*dummyContext, *worker.Pool, *worker.WorkResult) {
 			"test": {Request: dummyWorker, Response: dummyResponse},
 		},
 		1, 2)
-	return &ctx, wp, &res
+	return &ctx, wp.(*worker.Pool), &res
 }
 
 // TestInOrder verifies that workers are spawned and return in order


### PR DESCRIPTION
Follow on from the conversation in #1666 

This does not change anything in how the pools work. It just abstracts the results of both `worker.NewWorker()` and `worker.NewPool()` into a single `worker.Worker interface`.

This simplifies the view from the outside. Whether you use a `Pool` or a single `Worker`, the semantics are guaranteed to be the same.

The goal is eventually to simplify some of the `Pool` implementation, garbage collection (which #1666 is dealing with), and provide a simpler overall model.

cc @eriknordmark @giggsoff 