### PR TITLE
resolveConfig notify on new datastore

### DIFF
--- a/pkg/pillar/cmd/downloader/datastoreconfig.go
+++ b/pkg/pillar/cmd/downloader/datastoreconfig.go
@@ -24,6 +24,7 @@ func handleDatastoreConfigImpl(ctxArg interface{}, key string,
 	config := configArg.(types.DatastoreConfig)
 	log.Functionf("handleDatastoreConfigImpl for %s", key)
 	checkAndUpdateDownloadableObjects(ctx, config.UUID)
+	checkAndUpdateResolveConfig(ctx, config.UUID)
 	log.Functionf("handleDatastoreConfigImpl for %s, done", key)
 }
 


### PR DESCRIPTION
Seems, that we have race between volumemgr and downloader in DatastoreConfig.
I can see:
```
NAME    IMAGE                   UUID                                    INTERNAL        EXTERNAL        STATE(ADAM)     LAST_STATE(EVE)
t1      library/nginx:latest    c7256722-90a1-43f3-a1ff-6ceb50712243    -:80            127.0.0.1:8027  IN_CONFIG       RESOLVING_TAG: [description:"Found error in content tree library/nginx:latest attached to volume t1_0_m_0: Received error from resolver for 1487f42e-3c4f-4aaa-bf0b-9cf9f4e5cdcf+library/nginx:latest+0, SHA (): lookupDatastoreConfig(1487f42e-3c4f-4aaa-bf0b-9cf9f4e5cdcf) error: Get(zedagent/DatastoreConfig) unknown key 1487f42e-3c4f-4aaa-bf0b-9cf9f4e5cdcf\n\n"  timestamp:{seconds:1605803440  nanos:722411583}]
t2      library/nginx:latest    0ccef3bc-2fcc-47a4-9cf4-321ca96fca47    -:80            127.0.0.1:8028  IN_CONFIG       INITIAL: [description:"Found error in content tree library/nginx:latest attached to volume t2_0_m_0: Received error from resolver for 1487f42e-3c4f-4aaa-bf0b-9cf9f4e5cdcf+library/nginx:latest+0, SHA (): lookupDatastoreConfig(1487f42e-3c4f-4aaa-bf0b-9cf9f4e5cdcf) error: Get(zedagent/DatastoreConfig) unknown key 1487f42e-3c4f-4aaa-bf0b-9cf9f4e5cdcf\n\n"  timestamp:{seconds:1605803442  nanos:977309022}]
```
[syslog_resolve_1.txt](https://github.com/lf-edge/eve/files/5569419/syslog_resolve_1.txt)

So, we need to fire `resolveHandler` again in case of new `DatastoreConfig` object created after `ResolveConfig` object with defined `DatastoreID`.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>