### PR TITLE
q35 no dd

### DIFF
--- a/pkg/pillar/cmd/ledmanager/ledmanager.go
+++ b/pkg/pillar/cmd/ledmanager/ledmanager.go
@@ -142,6 +142,10 @@ var mToF = []modelToFuncs{
 		// No dd disk light blinking on QEMU
 	},
 	{
+		model: "QEMU Standard PC (Q35 + ICH9, 2009)",
+		// No dd disk light blinking on QEMU
+	},
+	{
 		model:     "raspberrypi.rpi.raspberrypi,4-model-b.brcm,bcm2711",
 		initFunc:  InitLedCmd,
 		blinkFunc: ExecuteLedCmd,


### PR DESCRIPTION
We need to add check for Q35 into ledmanager.

Another question: do we need dd by default?

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>