### PR TITLE
Adding debug-optimized musl to debug container

### DIFF
--- a/.yetus-excludes
+++ b/.yetus-excludes
@@ -3,6 +3,7 @@
 ^pkg/mkimage-raw-efi/nlplug-findfs.c
 ^pkg/pillar/rootfs/fscrypt.conf
 ^pkg/fw/
+^pkg/debug/abuild/
 ^build-tools/src/linuxkit/
 ^build-tools/src/manifest-tool/
 ^pkg/pillar/zedpac/

--- a/.yetus/excludes.txt
+++ b/.yetus/excludes.txt
@@ -3,6 +3,7 @@
 ^pkg/mkimage-raw-efi/nlplug-findfs.c
 ^pkg/pillar/rootfs/fscrypt.conf
 ^pkg/fw/
+^pkg/debug/abuild/
 ^build-tools/src/linuxkit/
 ^build-tools/src/manifest-tool/
 ^pkg/pillar/zedpac/

--- a/pkg/debug/Dockerfile
+++ b/pkg/debug/Dockerfile
@@ -1,6 +1,32 @@
+# for debug container we need to build our own copy of musl
+# with -fno-omit-frame-pointer to make sure that perf(1)
+# has a fast path for stack unwinding. This also happens
+# to be a perfect place to put any other kind of debug info
+# into the package: see abuild/etc/abuild.conf.
+FROM alpine:3.12 as musl-build
+
+# setting up building account
+# hadolint ignore=DL3019
+RUN apk add abuild
+RUN adduser -G abuild -D builder
+RUN su builder -c 'abuild-keygen -a -n'
+
+COPY --chown=builder:abuild abuild/ /
+RUN su builder -c 'cd /musl && abuild checksum && abuild -r'
+
+# now install it locally so we can pick it up later on below
+# hadolint ignore=DL3019,DL3018
+RUN apk add --allow-untrusted /home/builder/packages/*/musl-*.apk
+
 FROM linuxkit/sshd:666b4a1a323140aa1f332826164afba506abf597
+
+COPY ssh.sh /usr/bin/ssh.sh
+
+# get the rebuilt musl from above
+COPY --from=musl-build /lib/ld-musl-*.so.1 /lib/
 
 # Feel free to add additional packages here, but be aware that
 # EVE's rootfs image can be no larger than 300Mb
 # RUN apk add --no-cache gdb valgrind
+# hadolint ignore=DL3018
 RUN apk add --no-cache pciutils usbutils vim tcpdump perf strace

--- a/pkg/debug/abuild/README.md
+++ b/pkg/debug/abuild/README.md
@@ -1,0 +1,3 @@
+# Origin of abuild
+
+Content of abuild/ folder came [from](https://git.alpinelinux.org/aports/tree/main/musl?h=3.12-stable)

--- a/pkg/debug/abuild/etc/abuild.conf
+++ b/pkg/debug/abuild/etc/abuild.conf
@@ -1,0 +1,32 @@
+export CFLAGS="-Os -fno-omit-frame-pointer"
+export CXXFLAGS="$CFLAGS"
+export CPPFLAGS="$CFLAGS"
+export LDFLAGS="-Wl,--as-needed"
+export GOFLAGS="-buildmode=pie"
+
+export JOBS="$(getconf _NPROCESSORS_ONLN)"
+export MAKEFLAGS=-j$JOBS
+
+# remove line below to disable colors
+USE_COLORS=1
+
+# uncomment line below to enable ccache support.
+#USE_CCACHE=1
+
+SRCDEST=/var/cache/distfiles
+
+# uncomment line below to store built packages in other location
+# The package will be stored as $REPODEST/$repo/$pkgname-$pkgver-r$pkgrel.apk
+# where $repo is the name of the parent directory of $startdir.
+REPODEST=$HOME/packages/
+
+# PACKAGER and MAINTAINER are used by newapkbuild when creating new aports for
+# the APKBUILD's "Contributor:" and "Maintainer:" comments, respectively.
+#PACKAGER="Your Name <your@email.address>"
+#MAINTAINER="$PACKAGER"
+
+# what to clean up after a successful build
+CLEANUP="srcdir bldroot pkgdir deps"
+
+# what to cleanup after a failed build
+ERROR_CLEANUP="bldroot deps"

--- a/pkg/debug/abuild/musl/0001-add-thumb2-support-to-arm-assembler-memcpy.patch
+++ b/pkg/debug/abuild/musl/0001-add-thumb2-support-to-arm-assembler-memcpy.patch
@@ -1,0 +1,68 @@
+From 91e662d1d941215eb024787db5e910dbfb5b169f Mon Sep 17 00:00:00 2001
+From: Andre McCurdy <armccurdy@gmail.com>
+Date: Fri, 13 Sep 2019 11:44:31 -0700
+Subject: [PATCH] add thumb2 support to arm assembler memcpy
+
+For Thumb2 compatibility, replace two instances of a single
+instruction "orr with a variable shift" with the two instruction
+equivalent. Neither of the replacements are in a performance critical
+loop.
+---
+ src/string/arm/memcpy.c    |  2 +-
+ src/string/arm/memcpy_le.S | 13 ++++++++-----
+ 2 files changed, 9 insertions(+), 6 deletions(-)
+
+diff --git a/src/string/arm/memcpy.c b/src/string/arm/memcpy.c
+index f703c9bd..041614f4 100644
+--- a/src/string/arm/memcpy.c
++++ b/src/string/arm/memcpy.c
+@@ -1,3 +1,3 @@
+-#if __ARMEB__ || __thumb__
++#if __ARMEB__
+ #include "../memcpy.c"
+ #endif
+diff --git a/src/string/arm/memcpy_le.S b/src/string/arm/memcpy_le.S
+index 9cfbcb2a..7b35d305 100644
+--- a/src/string/arm/memcpy_le.S
++++ b/src/string/arm/memcpy_le.S
+@@ -1,4 +1,4 @@
+-#if !__ARMEB__ && !__thumb__
++#if !__ARMEB__
+ 
+ /*
+  * Copyright (C) 2008 The Android Open Source Project
+@@ -40,8 +40,9 @@
+  * This file has been modified from the original for use in musl libc.
+  * The main changes are: addition of .type memcpy,%function to make the
+  * code safely callable from thumb mode, adjusting the return
+- * instructions to be compatible with pre-thumb ARM cpus, and removal
+- * of prefetch code that is not compatible with older cpus.
++ * instructions to be compatible with pre-thumb ARM cpus, removal of
++ * prefetch code that is not compatible with older cpus and support for
++ * building as thumb 2.
+  */
+ 
+ .syntax unified
+@@ -241,7 +242,8 @@ non_congruent:
+ 	beq     2f
+ 	ldr     r5, [r1], #4
+ 	sub     r2, r2, #4
+-	orr     r4, r3, r5,             lsl lr
++	mov     r4, r5,                 lsl lr
++	orr     r4, r4, r3
+ 	mov     r3, r5,                 lsr r12
+ 	str     r4, [r0], #4
+ 	cmp     r2, #4
+@@ -348,7 +350,8 @@ less_than_thirtytwo:
+ 
+ 1:      ldr     r5, [r1], #4
+ 	sub     r2, r2, #4
+-	orr     r4, r3, r5,             lsl lr
++	mov     r4, r5,                 lsl lr
++	orr     r4, r4, r3
+ 	mov     r3,     r5,                     lsr r12
+ 	str     r4, [r0], #4
+ 	cmp     r2, #4
+-- 
+2.24.1
+

--- a/pkg/debug/abuild/musl/0001-reorder-thread-list-unlink-in-pthread_exit-after-all.patch
+++ b/pkg/debug/abuild/musl/0001-reorder-thread-list-unlink-in-pthread_exit-after-all.patch
@@ -1,0 +1,56 @@
+From 4d5aa20a94a2d3fae3e69289dc23ecafbd0c16c4 Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Fri, 22 May 2020 17:35:14 -0400
+Subject: [PATCH 1/4] reorder thread list unlink in pthread_exit after all
+ locks
+
+since the backend for LOCK() skips locking if single-threaded, it's
+unsafe to make the process appear single-threaded before the last use
+of lock.
+
+this fixes potential unsynchronized access to a linked list via
+__dl_thread_cleanup.
+---
+ src/thread/pthread_create.c | 19 +++++++++++--------
+ 1 file changed, 11 insertions(+), 8 deletions(-)
+
+diff --git a/src/thread/pthread_create.c b/src/thread/pthread_create.c
+index 5f491092..6a3b0c21 100644
+--- a/src/thread/pthread_create.c
++++ b/src/thread/pthread_create.c
+@@ -90,14 +90,7 @@ _Noreturn void __pthread_exit(void *result)
+ 		exit(0);
+ 	}
+ 
+-	/* At this point we are committed to thread termination. Unlink
+-	 * the thread from the list. This change will not be visible
+-	 * until the lock is released, which only happens after SYS_exit
+-	 * has been called, via the exit futex address pointing at the lock. */
+-	libc.threads_minus_1--;
+-	self->next->prev = self->prev;
+-	self->prev->next = self->next;
+-	self->prev = self->next = self;
++	/* At this point we are committed to thread termination. */
+ 
+ 	/* Process robust list in userspace to handle non-pshared mutexes
+ 	 * and the detached thread case where the robust list head will
+@@ -121,6 +114,16 @@ _Noreturn void __pthread_exit(void *result)
+ 	__do_orphaned_stdio_locks();
+ 	__dl_thread_cleanup();
+ 
++	/* Last, unlink thread from the list. This change will not be visible
++	 * until the lock is released, which only happens after SYS_exit
++	 * has been called, via the exit futex address pointing at the lock.
++	 * This needs to happen after any possible calls to LOCK() that might
++	 * skip locking if libc.threads_minus_1 is zero. */
++	libc.threads_minus_1--;
++	self->next->prev = self->prev;
++	self->prev->next = self->next;
++	self->prev = self->next = self;
++
+ 	/* This atomic potentially competes with a concurrent pthread_detach
+ 	 * call; the loser is responsible for freeing thread resources. */
+ 	int state = a_cas(&self->detach_state, DT_JOINABLE, DT_EXITING);
+-- 
+2.21.0
+

--- a/pkg/debug/abuild/musl/0002-don-t-use-libc.threads_minus_1-as-relaxed-atomic-for.patch
+++ b/pkg/debug/abuild/musl/0002-don-t-use-libc.threads_minus_1-as-relaxed-atomic-for.patch
@@ -1,0 +1,78 @@
+From e01b5939b38aea5ecbe41670643199825874b26c Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Thu, 21 May 2020 23:32:45 -0400
+Subject: [PATCH 2/4] don't use libc.threads_minus_1 as relaxed atomic for
+ skipping locks
+
+after all but the last thread exits, the next thread to observe
+libc.threads_minus_1==0 and conclude that it can skip locking fails to
+synchronize with any changes to memory that were made by the
+last-exiting thread. this can produce data races.
+
+on some archs, at least x86, memory synchronization is unlikely to be
+a problem; however, with the inline locks in malloc, skipping the lock
+also eliminated the compiler barrier, and caused code that needed to
+re-check chunk in-use bits after obtaining the lock to reuse a stale
+value, possibly from before the process became single-threaded. this
+in turn produced corruption of the heap state.
+
+some uses of libc.threads_minus_1 remain, especially for allocation of
+new TLS in the dynamic linker; otherwise, it could be removed
+entirely. it's made non-volatile to reflect that the remaining
+accesses are only made under lock on the thread list.
+
+instead of libc.threads_minus_1, libc.threaded is now used for
+skipping locks. the difference is that libc.threaded is permanently
+true once an additional thread has been created. this will produce
+some performance regression in processes that are mostly
+single-threaded but occasionally creating threads. in the future it
+may be possible to bring back the full lock-skipping, but more care
+needs to be taken to produce a safe design.
+---
+ src/internal/libc.h | 2 +-
+ src/malloc/malloc.c | 2 +-
+ src/thread/__lock.c | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/internal/libc.h b/src/internal/libc.h
+index ac97dc7e..c0614852 100644
+--- a/src/internal/libc.h
++++ b/src/internal/libc.h
+@@ -21,7 +21,7 @@ struct __libc {
+ 	int can_do_threads;
+ 	int threaded;
+ 	int secure;
+-	volatile int threads_minus_1;
++	int threads_minus_1;
+ 	size_t *auxv;
+ 	struct tls_module *tls_head;
+ 	size_t tls_size, tls_align, tls_cnt;
+diff --git a/src/malloc/malloc.c b/src/malloc/malloc.c
+index 96982596..2553a62e 100644
+--- a/src/malloc/malloc.c
++++ b/src/malloc/malloc.c
+@@ -26,7 +26,7 @@ int __malloc_replaced;
+ 
+ static inline void lock(volatile int *lk)
+ {
+-	if (libc.threads_minus_1)
++	if (libc.threaded)
+ 		while(a_swap(lk, 1)) __wait(lk, lk+1, 1, 1);
+ }
+ 
+diff --git a/src/thread/__lock.c b/src/thread/__lock.c
+index 45557c88..5b9b144e 100644
+--- a/src/thread/__lock.c
++++ b/src/thread/__lock.c
+@@ -18,7 +18,7 @@
+ 
+ void __lock(volatile int *l)
+ {
+-	if (!libc.threads_minus_1) return;
++	if (!libc.threaded) return;
+ 	/* fast path: INT_MIN for the lock, +1 for the congestion */
+ 	int current = a_cas(l, 0, INT_MIN + 1);
+ 	if (!current) return;
+-- 
+2.21.0
+

--- a/pkg/debug/abuild/musl/0003-cut-down-size-of-some-libc-struct-members.patch
+++ b/pkg/debug/abuild/musl/0003-cut-down-size-of-some-libc-struct-members.patch
@@ -1,0 +1,30 @@
+From f12888e9eb9eed60cc266b899dcafecb4752964a Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Fri, 22 May 2020 17:25:38 -0400
+Subject: [PATCH 3/4] cut down size of some libc struct members
+
+these are all flags that can be single-byte values.
+---
+ src/internal/libc.h | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/internal/libc.h b/src/internal/libc.h
+index c0614852..d47f58e0 100644
+--- a/src/internal/libc.h
++++ b/src/internal/libc.h
+@@ -18,9 +18,9 @@ struct tls_module {
+ };
+ 
+ struct __libc {
+-	int can_do_threads;
+-	int threaded;
+-	int secure;
++	char can_do_threads;
++	char threaded;
++	char secure;
+ 	int threads_minus_1;
+ 	size_t *auxv;
+ 	struct tls_module *tls_head;
+-- 
+2.21.0
+

--- a/pkg/debug/abuild/musl/0004-restore-lock-skipping-for-processes-that-return-to-s.patch
+++ b/pkg/debug/abuild/musl/0004-restore-lock-skipping-for-processes-that-return-to-s.patch
@@ -1,0 +1,101 @@
+From 8d81ba8c0bc6fe31136cb15c9c82ef4c24965040 Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Fri, 22 May 2020 17:45:47 -0400
+Subject: [PATCH 4/4] restore lock-skipping for processes that return to
+ single-threaded state
+
+the design used here relies on the barrier provided by the first lock
+operation after the process returns to single-threaded state to
+synchronize with actions by the last thread that exited. by storing
+the intent to change modes in the same object used to detect whether
+locking is needed, it's possible to avoid an extra (possibly costly)
+memory load after the lock is taken.
+---
+ src/internal/libc.h         | 1 +
+ src/malloc/malloc.c         | 5 ++++-
+ src/thread/__lock.c         | 4 +++-
+ src/thread/pthread_create.c | 8 ++++----
+ 4 files changed, 12 insertions(+), 6 deletions(-)
+
+diff --git a/src/internal/libc.h b/src/internal/libc.h
+index d47f58e0..619bba86 100644
+--- a/src/internal/libc.h
++++ b/src/internal/libc.h
+@@ -21,6 +21,7 @@ struct __libc {
+ 	char can_do_threads;
+ 	char threaded;
+ 	char secure;
++	volatile signed char need_locks;
+ 	int threads_minus_1;
+ 	size_t *auxv;
+ 	struct tls_module *tls_head;
+diff --git a/src/malloc/malloc.c b/src/malloc/malloc.c
+index 2553a62e..a803d4c9 100644
+--- a/src/malloc/malloc.c
++++ b/src/malloc/malloc.c
+@@ -26,8 +26,11 @@ int __malloc_replaced;
+ 
+ static inline void lock(volatile int *lk)
+ {
+-	if (libc.threaded)
++	int need_locks = libc.need_locks;
++	if (need_locks) {
+ 		while(a_swap(lk, 1)) __wait(lk, lk+1, 1, 1);
++		if (need_locks < 0) libc.need_locks = 0;
++	}
+ }
+ 
+ static inline void unlock(volatile int *lk)
+diff --git a/src/thread/__lock.c b/src/thread/__lock.c
+index 5b9b144e..60eece49 100644
+--- a/src/thread/__lock.c
++++ b/src/thread/__lock.c
+@@ -18,9 +18,11 @@
+ 
+ void __lock(volatile int *l)
+ {
+-	if (!libc.threaded) return;
++	int need_locks = libc.need_locks;
++	if (!need_locks) return;
+ 	/* fast path: INT_MIN for the lock, +1 for the congestion */
+ 	int current = a_cas(l, 0, INT_MIN + 1);
++	if (need_locks < 0) libc.need_locks = 0;
+ 	if (!current) return;
+ 	/* A first spin loop, for medium congestion. */
+ 	for (unsigned i = 0; i < 10; ++i) {
+diff --git a/src/thread/pthread_create.c b/src/thread/pthread_create.c
+index 6a3b0c21..6bdfb44f 100644
+--- a/src/thread/pthread_create.c
++++ b/src/thread/pthread_create.c
+@@ -118,8 +118,8 @@ _Noreturn void __pthread_exit(void *result)
+ 	 * until the lock is released, which only happens after SYS_exit
+ 	 * has been called, via the exit futex address pointing at the lock.
+ 	 * This needs to happen after any possible calls to LOCK() that might
+-	 * skip locking if libc.threads_minus_1 is zero. */
+-	libc.threads_minus_1--;
++	 * skip locking if process appears single-threaded. */
++	if (!--libc.threads_minus_1) libc.need_locks = -1;
+ 	self->next->prev = self->prev;
+ 	self->prev->next = self->next;
+ 	self->prev = self->next = self;
+@@ -339,7 +339,7 @@ int __pthread_create(pthread_t *restrict res, const pthread_attr_t *restrict att
+ 		~(1UL<<((SIGCANCEL-1)%(8*sizeof(long))));
+ 
+ 	__tl_lock();
+-	libc.threads_minus_1++;
++	if (!libc.threads_minus_1++) libc.need_locks = 1;
+ 	ret = __clone((c11 ? start_c11 : start), stack, flags, args, &new->tid, TP_ADJ(new), &__thread_list_lock);
+ 
+ 	/* All clone failures translate to EAGAIN. If explicit scheduling
+@@ -363,7 +363,7 @@ int __pthread_create(pthread_t *restrict res, const pthread_attr_t *restrict att
+ 		new->next->prev = new;
+ 		new->prev->next = new;
+ 	} else {
+-		libc.threads_minus_1--;
++		if (!--libc.threads_minus_1) libc.need_locks = 0;
+ 	}
+ 	__tl_unlock();
+ 	__restore_sigs(&set);
+-- 
+2.21.0
+

--- a/pkg/debug/abuild/musl/APKBUILD
+++ b/pkg/debug/abuild/musl/APKBUILD
@@ -1,0 +1,205 @@
+# Contributor:
+# Maintainer: Timo Teräs <timo.teras@iki.fi>
+pkgname=musl
+pkgver=1.1.24
+pkgrel=9
+pkgdesc="the musl c library (libc) implementation"
+url="https://musl.libc.org/"
+arch="all"
+license="MIT"
+subpackages="$pkgname-libintl:libintl:noarch
+	$pkgname-dev
+	$pkgname-dbg
+	libc6-compat:compat:noarch
+	"
+case "$BOOTSTRAP" in
+nocc)	pkgname="musl-dev"; subpackages="";;
+nolibc) ;;
+*)	subpackages="$subpackages $pkgname-utils";;
+esac
+source="https://musl.libc.org/releases/musl-$pkgver.tar.gz
+	handle-aux-at_base.patch
+	0001-add-thumb2-support-to-arm-assembler-memcpy.patch
+	fix-wcwidth-wrongly-returning-0-for-most-of-planes-4.patch
+	add-missing-case-mapping-between-U-03F3-and-U-037F.patch
+	fix-cacosh-results-for-arguments-with-negative-imagi.patch
+	fix-incorrect-results-for-catanf-and-catanl-with-som.patch
+	fix-return-value-of-ungetc-when-argument-is-outside-.patch
+	fix-errno-for-posix_openpt-with-no-free-ptys-availab.patch
+	improve-strerror-speed.patch
+	ppc-pt_regs.patch
+	ppc64-fpregset_t.patch
+	fix-remaining-direct-use-of-stat-syscalls-outside.patch
+	set-AD-bit-in-dns-queries-suppress-for-internal-use.patch
+
+	0001-reorder-thread-list-unlink-in-pthread_exit-after-all.patch
+	0002-don-t-use-libc.threads_minus_1-as-relaxed-atomic-for.patch
+	0003-cut-down-size-of-some-libc-struct-members.patch
+	0004-restore-lock-skipping-for-processes-that-return-to-s.patch
+
+	ldconfig
+	__stack_chk_fail_local.c
+	getconf.c
+	getent.c
+	iconv.c
+	"
+
+# secfixes:
+#   1.1.23-r2:
+#     - CVE-2019-14697
+#   1.1.15-r4:
+#     - CVE-2016-8859
+
+builddir="$srcdir"/musl-$pkgver
+
+build() {
+	cd "$builddir"
+
+	[ "$BOOTSTRAP" = "nocc" ] && return 0
+
+	# provide minimal libssp_nonshared.a so we don't need libssp from gcc
+	${CROSS_COMPILE}gcc $CPPFLAGS $CFLAGS -c "$srcdir"/__stack_chk_fail_local.c -o __stack_chk_fail_local.o
+	${CROSS_COMPILE}ar r libssp_nonshared.a __stack_chk_fail_local.o
+
+	if [ "$BOOTSTRAP" != "nolibc" ]; then
+		# getconf/getent/iconv
+		local i
+		for i in getconf getent iconv ; do
+			${CROSS_COMPILE}gcc $CPPFLAGS $CFLAGS "$srcdir"/$i.c -o $i
+		done
+	fi
+
+        # drop -fomit-frame-pointer
+        sed -ie 's/omit-frame-pointer/no-omit-frame-pointer/' configure
+
+	# note: not autotools
+	LDFLAGS="$LDFLAGS -Wl,-soname,libc.musl-${CARCH}.so.1" \
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--mandir=/usr/share/man \
+		--infodir=/usr/share/info \
+		--localstatedir=/var \
+		--enable-debug
+	make
+}
+
+package() {
+	cd "$builddir"
+
+	case "$CARCH" in
+	aarch64*)	ARCH="aarch64" ;;
+	arm*)		ARCH="arm" ;;
+	x86)		ARCH="i386" ;;
+	x86_64)		ARCH="x86_64" ;;
+	ppc)		ARCH="powerpc" ;;
+	ppc64*)		ARCH="powerpc64" ;;
+	s390*)		ARCH="s390x" ;;
+	mips64*)	ARCH="mips64" ;;
+	mips*)		ARCH="mips" ;;
+	esac
+
+	if [ "$BOOTSTRAP" = "nocc" ]; then
+		make ARCH="$ARCH" prefix=/usr DESTDIR="$pkgdir" install-headers
+	else
+		make DESTDIR="$pkgdir" install
+
+		cp libssp_nonshared.a "$pkgdir"/usr/lib
+
+		# make LDSO the be the real file, and libc the symlink
+		local LDSO=$(make -f Makefile --eval "$(echo -e 'print-ldso:\n\t@echo $$(basename $(LDSO_PATHNAME))')" print-ldso)
+		mv -f "$pkgdir"/usr/lib/libc.so "$pkgdir"/lib/"$LDSO"
+		ln -sf "$LDSO" "$pkgdir"/lib/libc.musl-${CARCH}.so.1
+		ln -sf ../../lib/"$LDSO" "$pkgdir"/usr/lib/libc.so
+		mkdir -p "$pkgdir"/usr/bin
+
+		cat >>"$pkgdir"/usr/bin/ldd <<-EOF
+		#!/bin/sh
+		exec /lib/$LDSO --list "\$@"
+		EOF
+		chmod 755 "$pkgdir"/usr/bin/ldd
+	fi
+
+}
+
+utils() {
+	depends="scanelf"
+	replaces="libiconv"
+	license="MIT BSD GPL2+"
+
+	mkdir -p "$subpkgdir"/usr "$subpkgdir"/sbin
+	mv "$pkgdir"/usr/bin "$subpkgdir"/usr/
+
+	install -D \
+		"$builddir"/getent \
+		"$builddir"/getconf \
+		"$builddir"/iconv \
+		"$subpkgdir"/usr/bin
+
+	install -D -m755 "$srcdir"/ldconfig "$subpkgdir"/sbin
+}
+
+# currently we don't want by default any NLS
+# and use GNU gettext where needed. the plan is to migrate to
+# musl gettext() later on as fully as possible.
+libintl() {
+	pkgdesc="musl libintl.h header"
+	mkdir -p "$subpkgdir"/usr/include
+	mv "$pkgdir"/usr/include/libintl.h \
+		"$subpkgdir"/usr/include/
+}
+
+compat() {
+	pkgdesc="compatibility libraries for glibc"
+
+	mkdir -p "$subpkgdir"/lib
+	# definitive source is https://sourceware.org/glibc/wiki/ABIList
+	case "$CARCH" in
+	aarch64)	_ld="lib/ld-linux-aarch64.so.1" ;;
+	armel)		_ld="lib/ld-linux.so.3" ;;
+	armhf)		_ld="lib/ld-linux-armhf.so.3" ;;
+	armv7)		_ld="lib/ld-linux-armhf.so.3" ;;
+	mips)		_ld="lib/ld.so.1" ;;
+	mips64)		_ld="lib64/ld.so.1" ;;
+	mipsel)		_ld="lib/ld.so.1" ;;
+	mips64el)	_ld="lib64/ld.so.1" ;;
+	ppc)		_ld="lib/ld.so.1" ;;
+	ppc64)		_ld="lib64/ld64.so.1" ;;
+	ppc64le)	_ld="lib64/ld64.so.2" ;;
+	s390x)		_ld="lib/ld64.so.1" ;;
+	x86)		_ld="lib/ld-linux.so.2" ;;
+	x86_64)		_ld="lib64/ld-linux-x86-64.so.2";;
+	esac
+	mkdir -p "$subpkgdir/${_ld%/*}"
+	ln -sf "/lib/libc.musl-${CARCH}.so.1" "$subpkgdir/$_ld"
+
+	for i in libc.so.6 libcrypt.so.1 libm.so.6 libpthread.so.0 librt.so.1 libutil.so.1; do
+		ln -sf "/lib/libc.musl-${CARCH}.so.1" "$subpkgdir/lib/$i"
+	done
+}
+
+sha512sums="8987f1e194ea616f34f4f21fe9def28fb7f81d7060e38619206c6349f79db3bbb76bae8b711f5f9b8ed038799c9aea1a4cbec69e0bc4131e246203e133149e77  musl-1.1.24.tar.gz
+6a7ff16d95b5d1be77e0a0fbb245491817db192176496a57b22ab037637d97a185ea0b0d19da687da66c2a2f5578e4343d230f399d49fe377d8f008410974238  handle-aux-at_base.patch
+2b26c20112e3984a2501bc6c2f5162c6e60d4a521d9367dc7721ec66c974986e9f98a67e9f4f4c1510e82a0ac47de783317ab254786837c2e86a54122efcc1dd  0001-add-thumb2-support-to-arm-assembler-memcpy.patch
+7a9d7f16461d1e7906764cc5366af057d9402556d7bb1d022016faa8a250947c0d901f84cf02200ebc2e153d572104529097fb6f3a65f67695912d0ea40eb2d4  fix-wcwidth-wrongly-returning-0-for-most-of-planes-4.patch
+402b663b5ff77bdde6f5ea9ccec60a16971e5e7881c29259273a167b5b4d9f81734751b7375e5cb856c1e3db86fc46ee2084a244a74ed3bd47a8f97b37e40fd9  add-missing-case-mapping-between-U-03F3-and-U-037F.patch
+40c369ca393970461f19371542fa5881d0745abaaf99d1f71a3093605a306ccbc1dc120c41a8cea1542be79a82918807749ede786f836406f6c1b3dc4ec2de32  fix-cacosh-results-for-arguments-with-negative-imagi.patch
+41934951bbc16f155d40824abf30d818b4c124f668f74f5a13674b5251650bb9d9bf9fde0b75462bb2a4b80dc00871ba122960fa027998e71970d533df1cb987  fix-incorrect-results-for-catanf-and-catanl-with-som.patch
+81bddb171fc2171a7aa86e74bf674e3a99508d27416dfc1cfcf2824f17b33ee7dda7c5968a8a69a542fdd6eecded5b8e3973e81079d9a061aa80142d08fc1a90  fix-return-value-of-ungetc-when-argument-is-outside-.patch
+144b4525483cbc97f0414955b7e5ce42c9ff69580e5be714b56330da30b0687911bd6019aef3c8611bd0a5bd7671d690b66b4920ae47cf3442a1c982ed000e22  fix-errno-for-posix_openpt-with-no-free-ptys-availab.patch
+4875efd7249613f696b4c470fb0aedf9968f1260cf35ef640666897d9ef2f3032588ac4c37659928ed45c1c010848ec2b19414ba5406f3bd7d745288b8b105d4  improve-strerror-speed.patch
+e7133ce2f0b172e2da03567e41f03bef58b6ff8eaac614494751228bcc102c39cbe312f0beb567c5f1c47c76feeff1e8d3b16284842c599029add4ad6d1d70ec  ppc-pt_regs.patch
+3de8e50519e33a55d2cc737b56011a7178d1c83230477d46e11e67195e08e74bff735c6013de6ff170bb2390e89bfca9919cc8728c064b3eeaab2035dd7e5c08  ppc64-fpregset_t.patch
+d277e45af78ed2bd9f556ae30636783fc401b4d0a339d6e37b77f18ed1486f48fc631e3455f8764ddbc7d9aba41a270ab345ec3495955dfd22b27a306441ba2a  fix-remaining-direct-use-of-stat-syscalls-outside.patch
+dd46ef77b71d34b6207611be59dd4555b4e53fd7169732b9e5ee9a66f1e8da69fcca6634f895b9d34d8861d37ac0eaa86618f5f3f3a81cf9c47321d1c5d37ee5  set-AD-bit-in-dns-queries-suppress-for-internal-use.patch
+0bb30198e92d26058f98f28be31bb8cee89a699e9fa9377315c9a86f504708ddb432d579bebfd4429da3fd5e6832e4166aa80d4d3f08658702206474fd1a8ffe  0001-reorder-thread-list-unlink-in-pthread_exit-after-all.patch
+c6cd692359961c382b7382c6eb819bf93ca8d687b7bd71e4d992acabc7003bd8388b22898059b6ac5abdf08c07020c8cbd2a5f908802258418079e096cdbc058  0002-don-t-use-libc.threads_minus_1-as-relaxed-atomic-for.patch
+416aa17d4211ebbca97b4ce47eea8d8375ac5e0b602a4806175bc172be21b8291ac08fdaf39203e3a083a067bbbfa999cfb875f739d5fa07871885ac02eba75a  0003-cut-down-size-of-some-libc-struct-members.patch
+f0e5ab79a793152c5e6c1c560b409ef062c8f9232c893b36c58b9667e5e0e86969555d8e2e9e17b59835ec7ed3c926a6ccce453824561ad82e47364c44374549  0004-restore-lock-skipping-for-processes-that-return-to-s.patch
+8d3a2d5315fc56fee7da9abb8b89bb38c6046c33d154c10d168fb35bfde6b0cf9f13042a3bceee34daf091bc409d699223735dcf19f382eeee1f6be34154f26f  ldconfig
+062bb49fa54839010acd4af113e20f7263dde1c8a2ca359b5fb2661ef9ed9d84a0f7c3bc10c25dcfa10bb3c5a4874588dff636ac43d5dbb3d748d75400756d0b  __stack_chk_fail_local.c
+0d80f37b34a35e3d14b012257c50862dfeb9d2c81139ea2dfa101d981d093b009b9fa450ba27a708ac59377a48626971dfc58e20a3799084a65777a0c32cbc7d  getconf.c
+378d70e65bcc65bb4e1415354cecfa54b0c1146dfb24474b69e418cdbf7ad730472cd09f6f103e1c99ba6c324c9560bccdf287f5889bbc3ef0bdf0e08da47413  getent.c
+9d42d66fb1facce2b85dad919be5be819ee290bd26ca2db00982b2f8e055a0196290a008711cbe2b18ec9eee8d2270e3b3a4692c5a1b807013baa5c2b70a2bbf  iconv.c"

--- a/pkg/debug/abuild/musl/__stack_chk_fail_local.c
+++ b/pkg/debug/abuild/musl/__stack_chk_fail_local.c
@@ -1,0 +1,2 @@
+extern void __stack_chk_fail(void);
+void __attribute__((visibility ("hidden"))) __stack_chk_fail_local(void) { __stack_chk_fail(); }

--- a/pkg/debug/abuild/musl/add-missing-case-mapping-between-U-03F3-and-U-037F.patch
+++ b/pkg/debug/abuild/musl/add-missing-case-mapping-between-U-03F3-and-U-037F.patch
@@ -1,0 +1,27 @@
+From e8aba58ab19a18f83d7f78e80d5e4f51e7e4e8a9 Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Fri, 25 Oct 2019 12:20:22 -0400
+Subject: [PATCH] add missing case mapping between U+03F3 and U+037F
+
+somehow this seems to have been overlooked. add it now so that
+subsequent overhaul of case mapping implementation will not introduce
+a functional change at the same time.
+---
+ src/ctype/towctrans.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/ctype/towctrans.c b/src/ctype/towctrans.c
+index 8f681018..9b91b2de 100644
+--- a/src/ctype/towctrans.c
++++ b/src/ctype/towctrans.c
+@@ -176,6 +176,7 @@ static const unsigned short pairs[][2] = {
+ 	{ 0x243, 0x180 },
+ 	{ 0x244, 0x289 },
+ 	{ 0x245, 0x28c },
++	{ 0x37f, 0x3f3 },
+ 	{ 0x3f4, 0x3b8 },
+ 	{ 0x3f9, 0x3f2 },
+ 	{ 0x3fd, 0x37b },
+-- 
+2.24.1
+

--- a/pkg/debug/abuild/musl/fix-cacosh-results-for-arguments-with-negative-imagi.patch
+++ b/pkg/debug/abuild/musl/fix-cacosh-results-for-arguments-with-negative-imagi.patch
@@ -1,0 +1,60 @@
+From aa2d23e57c9c95f0ffeb80cb035e5a5be52d8ef0 Mon Sep 17 00:00:00 2001
+From: Michael Morrell <mmorrell@tachyum.com>
+Date: Mon, 14 Oct 2019 09:07:31 -0400
+Subject: [PATCH] fix cacosh results for arguments with negative imaginary part
+
+---
+ src/complex/cacosh.c  | 5 ++++-
+ src/complex/cacoshf.c | 5 ++++-
+ src/complex/cacoshl.c | 5 ++++-
+ 3 files changed, 12 insertions(+), 3 deletions(-)
+
+diff --git a/src/complex/cacosh.c b/src/complex/cacosh.c
+index 8e42f1ae..76127f75 100644
+--- a/src/complex/cacosh.c
++++ b/src/complex/cacosh.c
+@@ -4,6 +4,9 @@
+ 
+ double complex cacosh(double complex z)
+ {
++	int zineg = signbit(cimag(z));
++
+ 	z = cacos(z);
+-	return CMPLX(-cimag(z), creal(z));
++	if (zineg) return CMPLX(cimag(z), -creal(z));
++	else       return CMPLX(-cimag(z), creal(z));
+ }
+diff --git a/src/complex/cacoshf.c b/src/complex/cacoshf.c
+index d7e6b545..8bd80581 100644
+--- a/src/complex/cacoshf.c
++++ b/src/complex/cacoshf.c
+@@ -2,6 +2,9 @@
+ 
+ float complex cacoshf(float complex z)
+ {
++	int zineg = signbit(cimagf(z));
++
+ 	z = cacosf(z);
+-	return CMPLXF(-cimagf(z), crealf(z));
++	if (zineg) return CMPLXF(cimagf(z), -crealf(z));
++	else       return CMPLXF(-cimagf(z), crealf(z));
+ }
+diff --git a/src/complex/cacoshl.c b/src/complex/cacoshl.c
+index d3eaee20..3a284be9 100644
+--- a/src/complex/cacoshl.c
++++ b/src/complex/cacoshl.c
+@@ -8,7 +8,10 @@ long double complex cacoshl(long double complex z)
+ #else
+ long double complex cacoshl(long double complex z)
+ {
++	int zineg = signbit(cimagl(z));
++
+ 	z = cacosl(z);
+-	return CMPLXL(-cimagl(z), creall(z));
++	if (zineg) return CMPLXL(cimagl(z), -creall(z));
++	else       return CMPLXL(-cimagl(z), creall(z));
+ }
+ #endif
+-- 
+2.24.1
+

--- a/pkg/debug/abuild/musl/fix-errno-for-posix_openpt-with-no-free-ptys-availab.patch
+++ b/pkg/debug/abuild/musl/fix-errno-for-posix_openpt-with-no-free-ptys-availab.patch
@@ -1,0 +1,28 @@
+From 4fd0f2056082441a4503f6bfcb787a7c15754518 Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Tue, 22 Oct 2019 10:22:22 -0400
+Subject: [PATCH] fix errno for posix_openpt with no free ptys available
+
+linux fails the open with ENOSPC, but POSIX mandates EAGAIN.
+---
+ src/misc/pty.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/misc/pty.c b/src/misc/pty.c
+index b9cb5eaa..a0577147 100644
+--- a/src/misc/pty.c
++++ b/src/misc/pty.c
+@@ -7,7 +7,9 @@
+ 
+ int posix_openpt(int flags)
+ {
+-	return open("/dev/ptmx", flags);
++	int r = open("/dev/ptmx", flags);
++	if (r < 0 && errno == ENOSPC) errno = EAGAIN;
++	return r;
+ }
+ 
+ int grantpt(int fd)
+-- 
+2.24.1
+

--- a/pkg/debug/abuild/musl/fix-incorrect-results-for-catanf-and-catanl-with-som.patch
+++ b/pkg/debug/abuild/musl/fix-incorrect-results-for-catanf-and-catanl-with-som.patch
@@ -1,0 +1,87 @@
+From 11020620813b828917bc31b4636d8a142f7a564a Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Wed, 5 Feb 2020 09:40:11 -0500
+Subject: [PATCH] fix incorrect results for catanf and catanl with some inputs
+
+catan was fixed in 10e4bd3780050e75b72aac5d85c31816419bb17d but the
+same bug in catanf and catanl was overlooked. the patch is completely
+analogous.
+---
+ src/complex/catanf.c | 14 +-------------
+ src/complex/catanl.c | 14 +-------------
+ 2 files changed, 2 insertions(+), 26 deletions(-)
+
+diff --git a/src/complex/catanf.c b/src/complex/catanf.c
+index e10d9c09..ef3907a5 100644
+--- a/src/complex/catanf.c
++++ b/src/complex/catanf.c
+@@ -87,29 +87,17 @@ float complex catanf(float complex z)
+ 	x = crealf(z);
+ 	y = cimagf(z);
+ 
+-	if ((x == 0.0f) && (y > 1.0f))
+-		goto ovrf;
+-
+ 	x2 = x * x;
+ 	a = 1.0f - x2 - (y * y);
+-	if (a == 0.0f)
+-		goto ovrf;
+ 
+ 	t = 0.5f * atan2f(2.0f * x, a);
+ 	w = _redupif(t);
+ 
+ 	t = y - 1.0f;
+ 	a = x2 + (t * t);
+-	if (a == 0.0f)
+-		goto ovrf;
+ 
+ 	t = y + 1.0f;
+ 	a = (x2 + (t * t))/a;
+-	w = w + (0.25f * logf (a)) * I;
+-	return w;
+-
+-ovrf:
+-	// FIXME
+-	w = MAXNUMF + MAXNUMF * I;
++	w = CMPLXF(w, 0.25f * logf(a));
+ 	return w;
+ }
+diff --git a/src/complex/catanl.c b/src/complex/catanl.c
+index a9fc02db..e62526c0 100644
+--- a/src/complex/catanl.c
++++ b/src/complex/catanl.c
+@@ -97,30 +97,18 @@ long double complex catanl(long double complex z)
+ 	x = creall(z);
+ 	y = cimagl(z);
+ 
+-	if ((x == 0.0L) && (y > 1.0L))
+-		goto ovrf;
+-
+ 	x2 = x * x;
+ 	a = 1.0L - x2 - (y * y);
+-	if (a == 0.0L)
+-		goto ovrf;
+ 
+ 	t = atan2l(2.0L * x, a) * 0.5L;
+ 	w = redupil(t);
+ 
+ 	t = y - 1.0L;
+ 	a = x2 + (t * t);
+-	if (a == 0.0L)
+-		goto ovrf;
+ 
+ 	t = y + 1.0L;
+ 	a = (x2 + (t * t)) / a;
+-	w = w + (0.25L * logl(a)) * I;
+-	return w;
+-
+-ovrf:
+-	// FIXME
+-	w = LDBL_MAX + LDBL_MAX * I;
++	w = CMPLXF(w, 0.25L * logl(a));
+ 	return w;
+ }
+ #endif
+-- 
+2.24.1
+

--- a/pkg/debug/abuild/musl/fix-remaining-direct-use-of-stat-syscalls-outside.patch
+++ b/pkg/debug/abuild/musl/fix-remaining-direct-use-of-stat-syscalls-outside.patch
@@ -1,0 +1,118 @@
+From c9ebff4736128186121424364c1c62224b02aee3 Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Wed, 12 Feb 2020 17:23:29 -0500
+Subject: fix remaining direct use of stat syscalls outside fstatat.c
+
+because struct stat is no longer assumed to correspond to the
+structure used by the stat-family syscalls, it's not valid to make any
+of these syscalls directly using a buffer of type struct stat.
+
+commit 9493892021eac4edf1776d945bcdd3f7a96f6978 moved all logic around
+this change for stat-family functions into fstatat.c, making the
+others wrappers for it. but a few other direct uses of the syscall
+were overlooked. the ones in tmpnam/tempnam are harmless since the
+syscalls are just used to test for file existence. however, the uses
+in fchmodat and __map_file depend on getting accurate file properties,
+and these functions may actually have been broken one or more mips
+variants due to removal of conversion hacks from syscall_arch.h.
+
+as a low-risk fix, simply use struct kstat in place of struct stat in
+the affected places.
+---
+ src/stat/fchmodat.c   | 3 ++-
+ src/stdio/tempnam.c   | 5 +++--
+ src/stdio/tmpnam.c    | 5 +++--
+ src/time/__map_file.c | 3 ++-
+ 4 files changed, 10 insertions(+), 6 deletions(-)
+
+diff --git a/src/stat/fchmodat.c b/src/stat/fchmodat.c
+index be61bdf3..4ee00b0a 100644
+--- a/src/stat/fchmodat.c
++++ b/src/stat/fchmodat.c
+@@ -2,6 +2,7 @@
+ #include <fcntl.h>
+ #include <errno.h>
+ #include "syscall.h"
++#include "kstat.h"
+ 
+ int fchmodat(int fd, const char *path, mode_t mode, int flag)
+ {
+@@ -10,7 +11,7 @@ int fchmodat(int fd, const char *path, mode_t mode, int flag)
+ 	if (flag != AT_SYMLINK_NOFOLLOW)
+ 		return __syscall_ret(-EINVAL);
+ 
+-	struct stat st;
++	struct kstat st;
+ 	int ret, fd2;
+ 	char proc[15+3*sizeof(int)];
+ 
+diff --git a/src/stdio/tempnam.c b/src/stdio/tempnam.c
+index 84f91978..565df6b6 100644
+--- a/src/stdio/tempnam.c
++++ b/src/stdio/tempnam.c
+@@ -6,6 +6,7 @@
+ #include <string.h>
+ #include <stdlib.h>
+ #include "syscall.h"
++#include "kstat.h"
+ 
+ #define MAXTRIES 100
+ 
+@@ -37,10 +38,10 @@ char *tempnam(const char *dir, const char *pfx)
+ 	for (try=0; try<MAXTRIES; try++) {
+ 		__randname(s+l-6);
+ #ifdef SYS_lstat
+-		r = __syscall(SYS_lstat, s, &(struct stat){0});
++		r = __syscall(SYS_lstat, s, &(struct kstat){0});
+ #else
+ 		r = __syscall(SYS_fstatat, AT_FDCWD, s,
+-			&(struct stat){0}, AT_SYMLINK_NOFOLLOW);
++			&(struct kstat){0}, AT_SYMLINK_NOFOLLOW);
+ #endif
+ 		if (r == -ENOENT) return strdup(s);
+ 	}
+diff --git a/src/stdio/tmpnam.c b/src/stdio/tmpnam.c
+index 6c7c253a..d667a836 100644
+--- a/src/stdio/tmpnam.c
++++ b/src/stdio/tmpnam.c
+@@ -5,6 +5,7 @@
+ #include <string.h>
+ #include <stdlib.h>
+ #include "syscall.h"
++#include "kstat.h"
+ 
+ #define MAXTRIES 100
+ 
+@@ -17,10 +18,10 @@ char *tmpnam(char *buf)
+ 	for (try=0; try<MAXTRIES; try++) {
+ 		__randname(s+12);
+ #ifdef SYS_lstat
+-		r = __syscall(SYS_lstat, s, &(struct stat){0});
++		r = __syscall(SYS_lstat, s, &(struct kstat){0});
+ #else
+ 		r = __syscall(SYS_fstatat, AT_FDCWD, s,
+-			&(struct stat){0}, AT_SYMLINK_NOFOLLOW);
++			&(struct kstat){0}, AT_SYMLINK_NOFOLLOW);
+ #endif
+ 		if (r == -ENOENT) return strcpy(buf ? buf : internal, s);
+ 	}
+diff --git a/src/time/__map_file.c b/src/time/__map_file.c
+index 9d376222..d3cefa82 100644
+--- a/src/time/__map_file.c
++++ b/src/time/__map_file.c
+@@ -2,10 +2,11 @@
+ #include <fcntl.h>
+ #include <sys/stat.h>
+ #include "syscall.h"
++#include "kstat.h"
+ 
+ const char unsigned *__map_file(const char *pathname, size_t *size)
+ {
+-	struct stat st;
++	struct kstat st;
+ 	const unsigned char *map = MAP_FAILED;
+ 	int fd = sys_open(pathname, O_RDONLY|O_CLOEXEC|O_NONBLOCK);
+ 	if (fd < 0) return 0;
+-- 
+cgit v1.2.1
+

--- a/pkg/debug/abuild/musl/fix-return-value-of-ungetc-when-argument-is-outside-.patch
+++ b/pkg/debug/abuild/musl/fix-return-value-of-ungetc-when-argument-is-outside-.patch
@@ -1,0 +1,31 @@
+From f6ecd0c296181bf6a2a7f54e3406c846500e8e63 Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Fri, 18 Oct 2019 21:11:44 -0400
+Subject: [PATCH] fix return value of ungetc when argument is outside unsigned
+ char range
+
+aside from the special value EOF, ungetc is specified to accept and
+convert values outside the range of unsigned char. conversion takes
+place automatically as part of assignment when storing into the
+buffer, but the return value is also required to be the resulting
+converted value, and this requirement was not satisfied.
+
+simplified from patch by Wang Jianjian.
+---
+ src/stdio/ungetc.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/stdio/ungetc.c b/src/stdio/ungetc.c
+index 180673a4..bc629d4c 100644
+--- a/src/stdio/ungetc.c
++++ b/src/stdio/ungetc.c
+@@ -16,5 +16,5 @@ int ungetc(int c, FILE *f)
+ 	f->flags &= ~F_EOF;
+ 
+ 	FUNLOCK(f);
+-	return c;
++	return (unsigned char)c;
+ }
+-- 
+2.24.1
+

--- a/pkg/debug/abuild/musl/fix-wcwidth-wrongly-returning-0-for-most-of-planes-4.patch
+++ b/pkg/debug/abuild/musl/fix-wcwidth-wrongly-returning-0-for-most-of-planes-4.patch
@@ -1,0 +1,28 @@
+From 70d80609558153a996833392999c69cdb74e1119 Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Wed, 1 Jan 2020 20:02:51 -0500
+Subject: [PATCH] fix wcwidth wrongly returning 0 for most of planes 4 and up
+
+commit 1b0ce9af6d2aa7b92edaf3e9c631cb635bae22bd introduced this bug
+back in 2012 and it was never noticed, presumably since the affected
+planes are essentially unused in Unicode.
+---
+ src/ctype/wcwidth.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/ctype/wcwidth.c b/src/ctype/wcwidth.c
+index 49c40eea..36256a53 100644
+--- a/src/ctype/wcwidth.c
++++ b/src/ctype/wcwidth.c
+@@ -23,7 +23,7 @@ int wcwidth(wchar_t wc)
+ 		return -1;
+ 	if (wc-0x20000U < 0x20000)
+ 		return 2;
+-	if (wc == 0xe0001 || wc-0xe0020U < 0x5f || wc-0xe0100 < 0xef)
++	if (wc == 0xe0001 || wc-0xe0020U < 0x5f || wc-0xe0100U < 0xef)
+ 		return 0;
+ 	return 1;
+ }
+-- 
+2.24.1
+

--- a/pkg/debug/abuild/musl/getconf.c
+++ b/pkg/debug/abuild/musl/getconf.c
@@ -1,0 +1,338 @@
+/*-
+ * Copyright (c) 1996, 1998 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by J.T. Conklin.
+ *
+ * Mostly rewritten to be used in Alpine Linux (with musl c-library)
+ * by Timo Teräs.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <err.h>
+#include <errno.h>
+#include <values.h>
+#include <limits.h>
+#include <locale.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+
+struct conf_variable {
+	const char *name;
+	enum { SYSCONF, CONFSTR, PATHCONF, CONSTANT, UCONSTANT, NUM_TYPES } type;
+	long value;
+};
+
+static const struct conf_variable conf_table[] = {
+{ "PATH",			CONFSTR,	_CS_PATH		},
+
+/* Utility Limit Minimum Values */
+{ "POSIX2_BC_BASE_MAX",		CONSTANT,	_POSIX2_BC_BASE_MAX	},
+{ "POSIX2_BC_DIM_MAX",		CONSTANT,	_POSIX2_BC_DIM_MAX	},
+{ "POSIX2_BC_SCALE_MAX",	CONSTANT,	_POSIX2_BC_SCALE_MAX	},
+{ "POSIX2_BC_STRING_MAX",	CONSTANT,	_POSIX2_BC_STRING_MAX	},
+{ "POSIX2_COLL_WEIGHTS_MAX",	CONSTANT,	_POSIX2_COLL_WEIGHTS_MAX },
+{ "POSIX2_EXPR_NEST_MAX",	CONSTANT,	_POSIX2_EXPR_NEST_MAX	},
+{ "POSIX2_LINE_MAX",		CONSTANT,	_POSIX2_LINE_MAX	},
+{ "POSIX2_RE_DUP_MAX",		CONSTANT,	_POSIX2_RE_DUP_MAX	},
+{ "POSIX2_VERSION",		CONSTANT,	_POSIX2_VERSION		},
+
+/* POSIX.1 Minimum Values */
+{ "_POSIX_AIO_LISTIO_MAX",	CONSTANT,	_POSIX_AIO_LISTIO_MAX	},
+{ "_POSIX_AIO_MAX",		CONSTANT,       _POSIX_AIO_MAX		},
+{ "_POSIX_ARG_MAX",		CONSTANT,	_POSIX_ARG_MAX		},
+{ "_POSIX_CHILD_MAX",		CONSTANT,	_POSIX_CHILD_MAX	},
+{ "_POSIX_LINK_MAX",		CONSTANT,	_POSIX_LINK_MAX		},
+{ "_POSIX_MAX_CANON",		CONSTANT,	_POSIX_MAX_CANON	},
+{ "_POSIX_MAX_INPUT",		CONSTANT,	_POSIX_MAX_INPUT	},
+{ "_POSIX_MQ_OPEN_MAX",		CONSTANT,	_POSIX_MQ_OPEN_MAX	},
+{ "_POSIX_MQ_PRIO_MAX",		CONSTANT,	_POSIX_MQ_PRIO_MAX	},
+{ "_POSIX_NAME_MAX",		CONSTANT,	_POSIX_NAME_MAX		},
+{ "_POSIX_NGROUPS_MAX",		CONSTANT,	_POSIX_NGROUPS_MAX	},
+{ "_POSIX_OPEN_MAX",		CONSTANT,	_POSIX_OPEN_MAX		},
+{ "_POSIX_PATH_MAX",		CONSTANT,	_POSIX_PATH_MAX		},
+{ "_POSIX_PIPE_BUF",		CONSTANT,	_POSIX_PIPE_BUF		},
+{ "_POSIX_SSIZE_MAX",		CONSTANT,	_POSIX_SSIZE_MAX	},
+{ "_POSIX_STREAM_MAX",		CONSTANT,	_POSIX_STREAM_MAX	},
+{ "_POSIX_TZNAME_MAX",		CONSTANT,	_POSIX_TZNAME_MAX	},
+
+/* Symbolic Utility Limits */
+{ "BC_BASE_MAX",		SYSCONF,	_SC_BC_BASE_MAX		},
+{ "BC_DIM_MAX",			SYSCONF,	_SC_BC_DIM_MAX		},
+{ "BC_SCALE_MAX",		SYSCONF,	_SC_BC_SCALE_MAX	},
+{ "BC_STRING_MAX",		SYSCONF,	_SC_BC_STRING_MAX	},
+{ "COLL_WEIGHTS_MAX",		SYSCONF,	_SC_COLL_WEIGHTS_MAX	},
+{ "EXPR_NEST_MAX",		SYSCONF,	_SC_EXPR_NEST_MAX	},
+{ "LINE_MAX",			SYSCONF,	_SC_LINE_MAX		},
+{ "RE_DUP_MAX",			SYSCONF,	_SC_RE_DUP_MAX		},
+
+/* Optional Facility Configuration Values */
+{ "_POSIX2_C_BIND",		SYSCONF,	_SC_2_C_BIND		},
+{ "POSIX2_C_DEV",		SYSCONF,	_SC_2_C_DEV		},
+{ "POSIX2_CHAR_TERM",		SYSCONF,	_SC_2_CHAR_TERM		},
+{ "POSIX2_FORT_DEV",		SYSCONF,	_SC_2_FORT_DEV		},
+{ "POSIX2_FORT_RUN",		SYSCONF,	_SC_2_FORT_RUN		},
+{ "POSIX2_LOCALEDEF",		SYSCONF,	_SC_2_LOCALEDEF		},
+{ "POSIX2_SW_DEV",		SYSCONF,	_SC_2_SW_DEV		},
+{ "POSIX2_UPE",			SYSCONF,	_SC_2_UPE		},
+
+/* POSIX.1 Configurable System Variables */
+{ "AIO_LISTIO_MAX",		SYSCONF,	_SC_AIO_LISTIO_MAX	},
+{ "AIO_MAX",			SYSCONF,	_SC_AIO_MAX		},
+{ "ARG_MAX",			SYSCONF,	_SC_ARG_MAX 		},
+{ "CHILD_MAX",			SYSCONF,	_SC_CHILD_MAX		},
+{ "CLK_TCK",			SYSCONF,	_SC_CLK_TCK		},
+{ "MQ_OPEN_MAX",		SYSCONF,	_SC_MQ_OPEN_MAX		},
+{ "MQ_PRIO_MAX",		SYSCONF,	_SC_MQ_PRIO_MAX		},
+{ "NGROUPS_MAX",		SYSCONF,	_SC_NGROUPS_MAX		},
+{ "OPEN_MAX",			SYSCONF,	_SC_OPEN_MAX		},
+{ "STREAM_MAX",			SYSCONF,	_SC_STREAM_MAX		},
+{ "TZNAME_MAX",			SYSCONF,	_SC_TZNAME_MAX		},
+{ "_POSIX_JOB_CONTROL",		SYSCONF,	_SC_JOB_CONTROL 	},
+{ "_POSIX_SAVED_IDS",		SYSCONF,	_SC_SAVED_IDS		},
+{ "_POSIX_VERSION",		SYSCONF,	_SC_VERSION		},
+
+{ "LINK_MAX",			PATHCONF,	_PC_LINK_MAX		},
+{ "MAX_CANON",			PATHCONF,	_PC_MAX_CANON		},
+{ "MAX_INPUT",			PATHCONF,	_PC_MAX_INPUT		},
+{ "NAME_MAX",			PATHCONF,	_PC_NAME_MAX		},
+{ "PATH_MAX",			PATHCONF,	_PC_PATH_MAX		},
+{ "PIPE_BUF",			PATHCONF,	_PC_PIPE_BUF		},
+{ "_POSIX_CHOWN_RESTRICTED",	PATHCONF,	_PC_CHOWN_RESTRICTED	},
+{ "_POSIX_NO_TRUNC",		PATHCONF,	_PC_NO_TRUNC		},
+{ "_POSIX_VDISABLE",		PATHCONF,	_PC_VDISABLE		},
+
+/* POSIX.1b Configurable System Variables */
+{ "PAGESIZE",			SYSCONF,	_SC_PAGESIZE		},
+{ "_POSIX_ASYNCHRONOUS_IO",	SYSCONF,	_SC_ASYNCHRONOUS_IO	},
+{ "_POSIX_FSYNC",		SYSCONF,	_SC_FSYNC		},
+{ "_POSIX_MAPPED_FILES",	SYSCONF,	_SC_MAPPED_FILES	},
+{ "_POSIX_MEMLOCK",		SYSCONF,	_SC_MEMLOCK		},
+{ "_POSIX_MEMLOCK_RANGE",	SYSCONF,	_SC_MEMLOCK_RANGE	},
+{ "_POSIX_MEMORY_PROTECTION",	SYSCONF,	_SC_MEMORY_PROTECTION	},
+{ "_POSIX_MESSAGE_PASSING",	SYSCONF,	_SC_MESSAGE_PASSING	},
+{ "_POSIX_MONOTONIC_CLOCK",	SYSCONF,	_SC_MONOTONIC_CLOCK	},
+{ "_POSIX_PRIORITY_SCHEDULING", SYSCONF,	_SC_PRIORITY_SCHEDULING },
+{ "_POSIX_SEMAPHORES",		SYSCONF,	_SC_SEMAPHORES		},
+{ "_POSIX_SHARED_MEMORY_OBJECTS", SYSCONF,	_SC_SHARED_MEMORY_OBJECTS },
+{ "_POSIX_SYNCHRONIZED_IO",	SYSCONF,	_SC_SYNCHRONIZED_IO	},
+{ "_POSIX_TIMERS",		SYSCONF,	_SC_TIMERS		},
+
+{ "_POSIX_SYNC_IO",		PATHCONF,	_PC_SYNC_IO		},
+
+/* POSIX.1c Configurable System Variables */
+{ "LOGIN_NAME_MAX",		SYSCONF,	_SC_LOGIN_NAME_MAX	},
+{ "_POSIX_THREADS",		SYSCONF,	_SC_THREADS		},
+
+/* POSIX.1j Configurable System Variables */
+{ "_POSIX_BARRIERS",		SYSCONF,	_SC_BARRIERS		},
+{ "_POSIX_READER_WRITER_LOCKS", SYSCONF,	_SC_READER_WRITER_LOCKS	},
+{ "_POSIX_SPIN_LOCKS",		SYSCONF,	_SC_SPIN_LOCKS		},
+
+/* XPG4.2 Configurable System Variables */
+{ "IOV_MAX",			SYSCONF,	_SC_IOV_MAX		},
+{ "PAGE_SIZE",			SYSCONF,	_SC_PAGE_SIZE		},
+{ "_XOPEN_SHM",			SYSCONF,	_SC_XOPEN_SHM		},
+
+/* X/Open CAE Spec. Issue 5 Version 2 Configurable System Variables */
+{ "FILESIZEBITS",		PATHCONF,	_PC_FILESIZEBITS	},
+
+/* POSIX.1-2001 XSI Option Group Configurable System Variables */
+{ "ATEXIT_MAX",			SYSCONF,	_SC_ATEXIT_MAX		},
+
+/* POSIX.1-2001 TSF Configurable System Variables */
+{ "GETGR_R_SIZE_MAX",		SYSCONF,	_SC_GETGR_R_SIZE_MAX	},
+{ "GETPW_R_SIZE_MAX",		SYSCONF,	_SC_GETPW_R_SIZE_MAX	},
+
+/* Commonly provided extensions */
+{ "_PHYS_PAGES",		SYSCONF,	_SC_PHYS_PAGES		},
+{ "_AVPHYS_PAGES",		SYSCONF,	_SC_AVPHYS_PAGES	},
+{ "_NPROCESSORS_CONF",		SYSCONF,	_SC_NPROCESSORS_CONF	},
+{ "_NPROCESSORS_ONLN",		SYSCONF,	_SC_NPROCESSORS_ONLN	},
+
+/* Data type related extensions */
+{ "CHAR_BIT",			CONSTANT,	CHAR_BIT		},
+{ "CHAR_MAX",			CONSTANT,	CHAR_MAX		},
+{ "CHAR_MIN",			CONSTANT,	CHAR_MIN		},
+{ "INT_MAX",			CONSTANT,	INT_MAX			},
+{ "INT_MIN",			CONSTANT,	INT_MIN			},
+{ "LONG_BIT",			CONSTANT,	LONG_BIT		},
+{ "LONG_MAX",			CONSTANT,	LONG_MAX		},
+{ "LONG_MIN",			CONSTANT,	LONG_MIN		},
+{ "SCHAR_MAX",			CONSTANT,	SCHAR_MAX		},
+{ "SCHAR_MIN",			CONSTANT,	SCHAR_MIN		},
+{ "SHRT_MAX",			CONSTANT,	SHRT_MAX		},
+{ "SHRT_MIN",			CONSTANT,	SHRT_MIN		},
+{ "SSIZE_MAX",			CONSTANT,	SSIZE_MAX		},
+{ "UCHAR_MAX",			UCONSTANT,	(long) UCHAR_MAX	},
+{ "UINT_MAX",			UCONSTANT,	(long) UINT_MAX		},
+{ "ULONG_MAX",			UCONSTANT,	(long) ULONG_MAX	},
+{ "USHRT_MAX",			UCONSTANT,	(long) USHRT_MAX	},
+{ "WORD_BIT",			CONSTANT,	WORD_BIT		},
+
+{ NULL, CONSTANT, 0L }
+};
+
+static int all = 0;
+
+static void usage(const char *p)
+{
+	(void)fprintf(stderr, "Usage: %s system_var\n\t%s -a\n"
+	    "\t%s path_var pathname\n\t%s -a pathname\n", p, p, p, p);
+	exit(EXIT_FAILURE);
+}
+
+static void print_long(const char *name, long val)
+{
+	if (all) printf("%s = %ld\n", name, val);
+	else printf("%ld\n", val);
+}
+
+static void print_ulong(const char *name, unsigned long val)
+{
+	if (all) printf("%s = %lu\n", name, val);
+	else printf("%lu\n", val);
+}
+
+static void print_string(const char *name, const char *val)
+{
+	if (all) printf("%s = %s\n", name, val);
+	else printf("%s\n", val);
+}
+
+static int print_constant(const struct conf_variable *cp, const char *pathname)
+{
+	print_long(cp->name, cp->value);
+	return 0;
+}
+
+static int print_uconstant(const struct conf_variable *cp, const char *pathname)
+{
+	print_ulong(cp->name, (unsigned long) cp->value);
+	return 0;
+}
+
+static int print_sysconf(const struct conf_variable *cp, const char *pathname)
+{
+	long val;
+
+	errno = 0;
+	if ((val = sysconf((int)cp->value)) == -1) {
+		if (errno != 0) err(EXIT_FAILURE, "sysconf(%ld)", cp->value);
+		return -1;
+	}
+	print_long(cp->name, val);
+	return 0;
+}
+
+static int print_confstr(const struct conf_variable *cp, const char *pathname)
+{
+	size_t len;
+	char *val;
+
+	errno = 0;
+	if ((len = confstr((int)cp->value, NULL, 0)) == 0) goto error;
+	if ((val = malloc(len)) == NULL) err(EXIT_FAILURE, "Can't allocate %zu bytes", len);
+	errno = 0;
+	if (confstr((int)cp->value, val, len) == 0) goto error;
+	print_string(cp->name, val);
+	free(val);
+	return 0;
+error:
+	if (errno != EINVAL) err(EXIT_FAILURE, "confstr(%ld)", cp->value);
+	return -1;
+}
+
+static int print_pathconf(const struct conf_variable *cp, const char *pathname)
+{
+	long val;
+
+	errno = 0;
+	if ((val = pathconf(pathname, (int)cp->value)) == -1) {
+		if (all && errno == EINVAL) return 0;
+		if (errno != 0) err(EXIT_FAILURE, "pathconf(%s, %ld)", pathname, cp->value);
+		return -1;
+	}
+	print_long(cp->name, val);
+	return 0;
+}
+
+typedef int (*handler_t)(const struct conf_variable *cp, const char *pathname);
+static const handler_t type_handlers[NUM_TYPES] = {
+	[SYSCONF]	= print_sysconf,
+	[CONFSTR]	= print_confstr,
+	[PATHCONF]	= print_pathconf,
+	[CONSTANT]	= print_constant,
+	[UCONSTANT]	= print_uconstant,
+};
+
+int main(int argc, char **argv)
+{
+	const char *progname = argv[0];
+	const struct conf_variable *cp;
+	const char *varname, *pathname;
+	int ch, found = 0;
+
+	(void)setlocale(LC_ALL, "");
+	while ((ch = getopt(argc, argv, "a")) != -1) {
+		switch (ch) {
+		case 'a':
+			all = 1;
+			break;
+		case '?':
+		default:
+			usage(progname);
+		}
+	}
+	argc -= optind;
+	argv += optind;
+
+	if (!all) {
+		if (argc == 0)
+			usage(progname);
+		varname = argv[0];
+		argc--;
+		argv++;
+	} else
+		varname = NULL;
+
+	if (argc > 1)
+		usage(progname);
+	pathname = argv[0];	/* may be NULL */
+
+	for (cp = conf_table; cp->name != NULL; cp++) {
+		if (!all && strcmp(varname, cp->name) != 0) continue;
+		if ((cp->type == PATHCONF) == (pathname != NULL)) {
+			if (type_handlers[cp->type](cp, pathname) < 0)
+				print_string(cp->name, "undefined");
+			found = 1;
+		} else if (!all)
+			errx(EXIT_FAILURE, "%s: invalid variable type", cp->name);
+	}
+	if (!all && !found) errx(EXIT_FAILURE, "%s: unknown variable", varname);
+	(void)fflush(stdout);
+	return ferror(stdout) ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/pkg/debug/abuild/musl/getent.c
+++ b/pkg/debug/abuild/musl/getent.c
@@ -1,0 +1,511 @@
+/*-
+ * Copyright (c) 2004-2006 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Luke Mewburn.
+ * Timo Teräs cleaned up the code for use in Alpine Linux with musl libc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <sys/socket.h>
+#include <sys/param.h>
+#include <ctype.h>
+#include <errno.h>
+#include <limits.h>
+#include <netdb.h>
+#include <pwd.h>
+#include <grp.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <paths.h>
+#include <err.h>
+
+#include <arpa/inet.h>
+#include <arpa/nameser.h>
+
+#include <net/if.h>
+#include <net/ethernet.h>
+#include <netinet/ether.h>
+#include <netinet/in.h>
+
+enum {
+	RV_OK		= 0,
+	RV_USAGE	= 1,
+	RV_NOTFOUND	= 2,
+	RV_NOENUM	= 3
+};
+
+static int usage(const char *);
+
+static int parsenum(const char *word, unsigned long *result)
+{
+	unsigned long	num;
+	char		*ep;
+
+	if (!isdigit((unsigned char)word[0]))
+		return 0;
+	errno = 0;
+	num = strtoul(word, &ep, 10);
+	if (num == ULONG_MAX && errno == ERANGE)
+		return 0;
+	if (*ep != '\0')
+		return 0;
+	*result = num;
+	return 1;
+}
+
+/*
+ * printfmtstrings --
+ *	vprintf(format, ...),
+ *	then the aliases (beginning with prefix, separated by sep),
+ *	then a newline
+ */
+__attribute__ ((format (printf, 4, 5)))
+static void printfmtstrings(char *strings[], const char *prefix, const char *sep,
+	const char *fmt, ...)
+{
+	va_list		ap;
+	const char	*curpref;
+	size_t		i;
+
+	va_start(ap, fmt);
+	(void)vprintf(fmt, ap);
+	va_end(ap);
+
+	curpref = prefix;
+	for (i = 0; strings[i] != NULL; i++) {
+		(void)printf("%s%s", curpref, strings[i]);
+		curpref = sep;
+	}
+	(void)printf("\n");
+}
+
+static int ethers(int argc, char *argv[])
+{
+	char		hostname[MAXHOSTNAMELEN + 1], *hp;
+	struct ether_addr ea, *eap;
+	int		i, rv;
+
+	if (argc == 2) {
+		warnx("Enumeration not supported on ethers");
+		return RV_NOENUM;
+	}
+
+	rv = RV_OK;
+	for (i = 2; i < argc; i++) {
+		if ((eap = ether_aton(argv[i])) == NULL) {
+			eap = &ea;
+			hp = argv[i];
+			if (ether_hostton(hp, eap) != 0) {
+				rv = RV_NOTFOUND;
+				break;
+			}
+		} else {
+			hp = hostname;
+			if (ether_ntohost(hp, eap) != 0) {
+				rv = RV_NOTFOUND;
+				break;
+			}
+		}
+		(void)printf("%-17s  %s\n", ether_ntoa(eap), hp);
+	}
+	return rv;
+}
+
+static void groupprint(const struct group *gr)
+{
+	printfmtstrings(gr->gr_mem, ":", ",", "%s:%s:%u",
+			gr->gr_name, gr->gr_passwd, gr->gr_gid);
+}
+
+static int group(int argc, char *argv[])
+{
+	struct group	*gr;
+	unsigned long	id;
+	int		i, rv;
+
+	rv = RV_OK;
+	if (argc == 2) {
+		while ((gr = getgrent()) != NULL)
+			groupprint(gr);
+	} else {
+		for (i = 2; i < argc; i++) {
+			if (parsenum(argv[i], &id))
+				gr = getgrgid((gid_t)id);
+			else
+				gr = getgrnam(argv[i]);
+			if (gr == NULL) {
+				rv = RV_NOTFOUND;
+				break;
+			}
+			groupprint(gr);
+		}
+	}
+	endgrent();
+	return rv;
+}
+
+static void hostsprint(const struct hostent *he)
+{
+	char	buf[INET6_ADDRSTRLEN];
+
+	if (inet_ntop(he->h_addrtype, he->h_addr, buf, sizeof(buf)) == NULL)
+		(void)strlcpy(buf, "# unknown", sizeof(buf));
+	printfmtstrings(he->h_aliases, "  ", " ", "%-16s  %s", buf, he->h_name);
+}
+
+static int hosts(int argc, char *argv[])
+{
+	struct hostent	*he;
+	char		addr[IN6ADDRSZ];
+	int		i, rv;
+
+	sethostent(1);
+	rv = RV_OK;
+	if (argc == 2) {
+		while ((he = gethostent()) != NULL)
+			hostsprint(he);
+	} else {
+		for (i = 2; i < argc; i++) {
+			if (inet_pton(AF_INET6, argv[i], (void *)addr) > 0)
+				he = gethostbyaddr(addr, IN6ADDRSZ, AF_INET6);
+			else if (inet_pton(AF_INET, argv[i], (void *)addr) > 0)
+				he = gethostbyaddr(addr, INADDRSZ, AF_INET);
+			else if ((he = gethostbyname2(argv[i], AF_INET6)) == NULL)
+				he = gethostbyname2(argv[i], AF_INET);
+			if (he == NULL) {
+				rv = RV_NOTFOUND;
+				break;
+			}
+			hostsprint(he);
+		}
+	}
+	endhostent();
+	return rv;
+}
+
+static int ahosts_ex(int family, int flags, int argc, char *argv[])
+{
+	static const char *socktypes[] = {
+		[SOCK_STREAM]		= "STREAM",
+		[SOCK_DGRAM]		= "DGRAM",
+		[SOCK_RAW]		= "RAW",
+		[SOCK_RDM]		= "RDM",
+		[SOCK_SEQPACKET]	= "SEQPACKET",
+		[SOCK_DCCP]		= "DCCP",
+		[SOCK_PACKET]		= "PACKET",
+	};
+	const char *sockstr;
+	char sockbuf[16], buf[INET6_ADDRSTRLEN];
+	struct addrinfo *res, *r, hint;
+	void *addr;
+	int i;
+
+	if (argc == 2)
+		return hosts(argc, argv);
+
+	hint = (struct addrinfo) {
+		.ai_family = family,
+		.ai_flags = AI_ADDRCONFIG | AI_CANONNAME | flags,
+	};
+
+	for (i = 2; i < argc; i++) {
+		if (getaddrinfo(argv[i], 0, &hint, &res) != 0)
+			return RV_NOTFOUND;
+
+		for (r = res; r; r = r->ai_next) {
+			sockstr = NULL;
+			if (r->ai_socktype >= 0 && r->ai_socktype < sizeof(socktypes)/sizeof(socktypes[0]))
+				sockstr = socktypes[r->ai_socktype];
+			if (!sockstr) {
+				sprintf(buf, "%d", r->ai_socktype);
+				sockstr = sockbuf;
+			}
+			switch (r->ai_family) {
+			case AF_INET:
+				addr = &((struct sockaddr_in*) r->ai_addr)->sin_addr;
+				break;
+			case AF_INET6:
+				addr = &((struct sockaddr_in6*) r->ai_addr)->sin6_addr;
+				break;
+			default:
+				continue;
+			}
+			if (inet_ntop(r->ai_family, addr, buf, sizeof(buf)) == NULL)
+				(void)strlcpy(buf, "# unknown", sizeof(buf));
+			printf("%-15s %-6s %s\n", buf, sockstr, r->ai_canonname ?: "");
+		}
+	}
+
+	return RV_OK;
+}
+
+static int ahosts(int argc, char *argv[])
+{
+	return ahosts_ex(AF_UNSPEC, 0, argc, argv);
+}
+
+static int ahostsv4(int argc, char *argv[])
+{
+	return ahosts_ex(AF_INET, 0, argc, argv);
+}
+
+static int ahostsv6(int argc, char *argv[])
+{
+	return ahosts_ex(AF_INET6, AI_V4MAPPED, argc, argv);
+}
+
+static void networksprint(const struct netent *ne)
+{
+	char		buf[INET6_ADDRSTRLEN];
+	struct	in_addr	ianet;
+
+	ianet = inet_makeaddr(ne->n_net, 0);
+	if (inet_ntop(ne->n_addrtype, &ianet, buf, sizeof(buf)) == NULL)
+		(void)strlcpy(buf, "# unknown", sizeof(buf));
+	printfmtstrings(ne->n_aliases, "  ", " ", "%-16s  %s", ne->n_name, buf);
+}
+
+static int networks(int argc, char *argv[])
+{
+	struct netent	*ne;
+	in_addr_t	net;
+	int		i, rv;
+
+	setnetent(1);
+	rv = RV_OK;
+	if (argc == 2) {
+		while ((ne = getnetent()) != NULL)
+			networksprint(ne);
+	} else {
+		for (i = 2; i < argc; i++) {
+			net = inet_network(argv[i]);
+			if (net != INADDR_NONE)
+				ne = getnetbyaddr(net, AF_INET);
+			else
+				ne = getnetbyname(argv[i]);
+			if (ne != NULL) {
+				rv = RV_NOTFOUND;
+				break;
+			}
+			networksprint(ne);
+		}
+	}
+	endnetent();
+	return rv;
+}
+
+static void passwdprint(struct passwd *pw)
+{
+	(void)printf("%s:%s:%u:%u:%s:%s:%s\n",
+		pw->pw_name, pw->pw_passwd, pw->pw_uid,
+		pw->pw_gid, pw->pw_gecos, pw->pw_dir, pw->pw_shell);
+}
+
+static int passwd(int argc, char *argv[])
+{
+	struct passwd	*pw;
+	unsigned long	id;
+	int		i, rv;
+
+	rv = RV_OK;
+	if (argc == 2) {
+		while ((pw = getpwent()) != NULL)
+			passwdprint(pw);
+	} else {
+		for (i = 2; i < argc; i++) {
+			if (parsenum(argv[i], &id))
+				pw = getpwuid((uid_t)id);
+			else
+				pw = getpwnam(argv[i]);
+			if (pw == NULL) {
+				rv = RV_NOTFOUND;
+				break;
+			}
+			passwdprint(pw);
+		}
+	}
+	endpwent();
+	return rv;
+}
+
+static void protocolsprint(struct protoent *pe)
+{
+	printfmtstrings(pe->p_aliases, "  ", " ",
+			"%-16s  %5d", pe->p_name, pe->p_proto);
+}
+
+static int protocols(int argc, char *argv[])
+{
+	struct protoent	*pe;
+	unsigned long	id;
+	int		i, rv;
+
+	setprotoent(1);
+	rv = RV_OK;
+	if (argc == 2) {
+		while ((pe = getprotoent()) != NULL)
+			protocolsprint(pe);
+	} else {
+		for (i = 2; i < argc; i++) {
+			if (parsenum(argv[i], &id))
+				pe = getprotobynumber((int)id);
+			else
+				pe = getprotobyname(argv[i]);
+			if (pe == NULL) {
+				rv = RV_NOTFOUND;
+				break;
+			}
+			protocolsprint(pe);
+		}
+	}
+	endprotoent();
+	return rv;
+}
+
+static void servicesprint(struct servent *se)
+{
+	printfmtstrings(se->s_aliases, "  ", " ",
+			"%-16s  %5d/%s",
+			se->s_name, ntohs(se->s_port), se->s_proto);
+
+}
+
+static int services(int argc, char *argv[])
+{
+	struct servent	*se;
+	unsigned long	id;
+	char		*proto;
+	int		i, rv;
+
+	setservent(1);
+	rv = RV_OK;
+	if (argc == 2) {
+		while ((se = getservent()) != NULL)
+			servicesprint(se);
+	} else {
+		for (i = 2; i < argc; i++) {
+			proto = strchr(argv[i], '/');
+			if (proto != NULL)
+				*proto++ = '\0';
+			if (parsenum(argv[i], &id))
+				se = getservbyport(htons(id), proto);
+			else
+				se = getservbyname(argv[i], proto);
+			if (se == NULL) {
+				rv = RV_NOTFOUND;
+				break;
+			}
+			servicesprint(se);
+		}
+	}
+	endservent();
+	return rv;
+}
+
+static int shells(int argc, char *argv[])
+{
+	const char	*sh;
+	int		i, rv;
+
+	setusershell();
+	rv = RV_OK;
+	if (argc == 2) {
+		while ((sh = getusershell()) != NULL)
+			(void)printf("%s\n", sh);
+	} else {
+		for (i = 2; i < argc; i++) {
+			setusershell();
+			while ((sh = getusershell()) != NULL) {
+				if (strcmp(sh, argv[i]) == 0) {
+					(void)printf("%s\n", sh);
+					break;
+				}
+			}
+			if (sh == NULL) {
+				rv = RV_NOTFOUND;
+				break;
+			}
+		}
+	}
+	endusershell();
+	return rv;
+}
+
+static struct getentdb {
+	const char	*name;
+	int		(*callback)(int, char *[]);
+} databases[] = {
+	{	"ethers",	ethers,		},
+	{	"group",	group,		},
+	{	"hosts",	hosts,		},
+	{	"ahosts",	ahosts,		},
+	{	"ahostsv4",	ahostsv4,	},
+	{	"ahostsv6",	ahostsv6,	},
+	{	"networks",	networks,	},
+	{	"passwd",	passwd,		},
+	{	"protocols",	protocols,	},
+	{	"services",	services,	},
+	{	"shells",	shells,		},
+
+	{	NULL,		NULL,		},
+};
+
+static int usage(const char *arg0)
+{
+	struct getentdb	*curdb;
+	size_t i;
+
+	(void)fprintf(stderr, "Usage: %s database [key ...]\n", arg0);
+	(void)fprintf(stderr, "\tdatabase may be one of:");
+	for (i = 0, curdb = databases; curdb->name != NULL; curdb++, i++) {
+		if (i % 7 == 0)
+			(void)fputs("\n\t\t", stderr);
+		(void)fprintf(stderr, "%s%s", i % 7 == 0 ? "" : " ",
+		    curdb->name);
+	}
+	(void)fprintf(stderr, "\n");
+	exit(RV_USAGE);
+	/* NOTREACHED */
+}
+
+int
+main(int argc, char *argv[])
+{
+	struct getentdb	*curdb;
+
+	if (argc < 2)
+		usage(argv[0]);
+	for (curdb = databases; curdb->name != NULL; curdb++)
+		if (strcmp(curdb->name, argv[1]) == 0)
+			return (*curdb->callback)(argc, argv);
+
+	warn("Unknown database `%s'", argv[1]);
+	usage(argv[0]);
+	/* NOTREACHED */
+}

--- a/pkg/debug/abuild/musl/handle-aux-at_base.patch
+++ b/pkg/debug/abuild/musl/handle-aux-at_base.patch
@@ -1,0 +1,43 @@
+diff --git a/src/env/__init_tls.c b/src/env/__init_tls.c
+index b125eb1..616c6a6 100644
+--- a/src/env/__init_tls.c
++++ b/src/env/__init_tls.c
+@@ -66,8 +66,10 @@ void *__copy_tls(unsigned char *mem)
+ }
+ 
+ #if ULONG_MAX == 0xffffffff
++typedef Elf32_Ehdr Ehdr;
+ typedef Elf32_Phdr Phdr;
+ #else
++typedef Elf64_Ehdr Ehdr;
+ typedef Elf64_Phdr Phdr;
+ #endif
+ 
+@@ -77,15 +79,23 @@ extern const size_t _DYNAMIC[];
+ static void static_init_tls(size_t *aux)
+ {
+ 	unsigned char *p;
+-	size_t n;
++	size_t n, e;
+ 	Phdr *phdr, *tls_phdr=0;
+ 	size_t base = 0;
+ 	void *mem;
+ 
+-	for (p=(void *)aux[AT_PHDR],n=aux[AT_PHNUM]; n; n--,p+=aux[AT_PHENT]) {
++	if (aux[AT_BASE]) {
++		Ehdr *ehdr = (void *)aux[AT_BASE];
++		p = (unsigned char *)aux[AT_BASE] + ehdr->e_phoff;
++		n = ehdr->e_phnum;
++		e = ehdr->e_phentsize;
++	} else {
++		p = (void *)aux[AT_PHDR];
++		n = aux[AT_PHNUM];
++		e = aux[AT_PHENT];
++	}
++	for (; n; n--, p+=e) {
+ 		phdr = (void *)p;
+-		if (phdr->p_type == PT_PHDR)
+-			base = aux[AT_PHDR] - phdr->p_vaddr;
+ 		if (phdr->p_type == PT_DYNAMIC && _DYNAMIC)
+ 			base = (size_t)_DYNAMIC - phdr->p_vaddr;
+ 		if (phdr->p_type == PT_TLS)

--- a/pkg/debug/abuild/musl/iconv.c
+++ b/pkg/debug/abuild/musl/iconv.c
@@ -1,0 +1,110 @@
+/*
+ * iconv.c
+ * Implementation of SUSv4 XCU iconv utility
+ * Copyright © 2011 Rich Felker
+ * Licensed under the terms of the GNU General Public License, v2 or later
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <iconv.h>
+#include <locale.h>
+#include <langinfo.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+
+int main(int argc, char **argv)
+{
+	const char *from=0, *to=0;
+	int b;
+	iconv_t cd;
+	char buf[BUFSIZ];
+	char outbuf[BUFSIZ*4];
+	char *in, *out;
+	size_t inb;
+	size_t l;
+	size_t unitsize=0;
+	int err=0;
+	FILE *f;
+
+	while ((b = getopt(argc, argv, "f:t:csl")) != EOF) switch(b) {
+	case 'l':
+		puts("UTF-8, UTF-16BE, UTF-16LE, UTF-32BE, UTF32-LE, UCS-2BE, UCS-2LE, WCHAR_T,\n"
+			"US_ASCII, ISO8859-1, ISO8859-2, ISO8859-3, ISO8859-4, ISO8859-5,\n"
+			"ISO8859-6, ISO8859-7, ...");
+		exit(0);
+	case 'c': case 's': break;
+	case 'f': from=optarg; break;
+	case 't': to=optarg; break;
+	default: exit(1);
+	}
+
+	if (!from || !to) {
+		setlocale(LC_CTYPE, "");
+		if (!to) to = nl_langinfo(CODESET);
+		if (!from) from = nl_langinfo(CODESET);
+	}
+	cd = iconv_open(to, from);
+	if (cd == (iconv_t)-1) {
+		if (iconv_open(to, "WCHAR_T") == (iconv_t)-1)
+			fprintf(stderr, "iconv: destination charset %s: ", to);
+		else
+			fprintf(stderr, "iconv: source charset %s: ", from);
+		perror("");
+		exit(1);
+	}
+	if (optind == argc) argv[argc++] = "-";
+
+	for (; optind < argc; optind++) {
+		if (argv[optind][0]=='-' && !argv[optind][1]) {
+			f = stdin;
+			argv[optind] = "(stdin)";
+		} else if (!(f = fopen(argv[optind], "rb"))) {
+			fprintf(stderr, "iconv: %s: ", argv[optind]);
+			perror("");
+			err = 1;
+			continue;
+		}
+		inb = 0;
+		for (;;) {
+			in = buf;
+			out = outbuf;
+			l = fread(buf+inb, 1, sizeof(buf)-inb, f);
+			inb += l;
+			if (!inb) break;
+			if (iconv(cd, &in, &inb, &out, (size_t [1]){sizeof outbuf})==-1
+			 && errno == EILSEQ) {
+				if (!unitsize) {
+					wchar_t wc='0';
+					char dummy[4], *dummyp=dummy;
+					iconv_t cd2 = iconv_open(from, "WCHAR_T");
+					if (cd == (iconv_t)-1) {
+						unitsize = 1;
+					} else {
+						iconv(cd2,
+							(char *[1]){(char *)&wc},
+							(size_t[1]){1},
+							&dummyp, (size_t[1]){4});
+						unitsize = dummyp-dummy;
+						if (!unitsize) unitsize=1;
+					}
+				}
+				inb-=unitsize;
+				in+=unitsize;
+			}
+			if (inb && !l && errno==EINVAL) break;
+			if (out>outbuf && !fwrite(outbuf, out-outbuf, 1, stdout)) {
+				perror("iconv: write error");
+				exit(1);
+			}
+			if (inb) memmove(buf, in, inb);
+		}
+		if (ferror(f)) {
+			fprintf(stderr, "iconv: %s: ", argv[optind]);
+			perror("");
+			err = 1;
+		}
+	}
+	return err;
+}

--- a/pkg/debug/abuild/musl/improve-strerror-speed.patch
+++ b/pkg/debug/abuild/musl/improve-strerror-speed.patch
@@ -1,0 +1,101 @@
+From 8343334d7b9cd4338bdac80e17be079cbc675ec3 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Timo=20Ter=C3=A4s?= <timo.teras@iki.fi>
+Date: Wed, 4 Mar 2020 11:27:01 +0200
+Subject: [PATCH] improve strerror speed
+
+change the current O(n) lookup to O(1) based on the machinery
+described in "How To Write Shared Libraries" (Appendix B).
+---
+ src/errno/__strerror.h | 13 ++++++-------
+ src/errno/strerror.c   | 41 ++++++++++++++++++++++++++---------------
+ 2 files changed, 32 insertions(+), 22 deletions(-)
+
+diff --git a/src/errno/__strerror.h b/src/errno/__strerror.h
+index 2f04d400..2d992da5 100644
+--- a/src/errno/__strerror.h
++++ b/src/errno/__strerror.h
+@@ -1,8 +1,9 @@
+-/* This file is sorted such that 'errors' which represent exceptional
+- * conditions under which a correct program may fail come first, followed
+- * by messages that indicate an incorrect program or system failure. The
+- * macro E() along with double-inclusion is used to ensure that ordering
+- * of the strings remains synchronized. */
++/* The first entry is a catch-all for codes not enumerated here.
++ * This file is included multiple times to declare and define a structure
++ * with these messages, and then to define a lookup table translating
++ * error codes to offsets of corresponding fields in the structure. */
++
++E(0,            "No error information")
+ 
+ E(EILSEQ,       "Illegal byte sequence")
+ E(EDOM,         "Domain error")
+@@ -101,5 +102,3 @@ E(EDQUOT,       "Quota exceeded")
+ E(ENOMEDIUM,    "No medium found")
+ E(EMEDIUMTYPE,  "Wrong medium type")
+ E(EMULTIHOP,    "Multihop attempted")
+-
+-E(0,            "No error information")
+diff --git a/src/errno/strerror.c b/src/errno/strerror.c
+index e3ed771a..7f926432 100644
+--- a/src/errno/strerror.c
++++ b/src/errno/strerror.c
+@@ -1,30 +1,41 @@
+ #include <errno.h>
++#include <stddef.h>
+ #include <string.h>
+ #include "locale_impl.h"
+ 
+-#define E(a,b) ((unsigned char)a),
+-static const unsigned char errid[] = {
++/* mips has one error code outside of the 8-bit range due to a
++ * historical typo, so we just remap it. */
++#if EDQUOT==1133
++#define EDQUOT_ORIG 1133
++#undef  EDQUOT
++#define EDQUOT 109
++#endif
++
++static const struct errmsgstr_t {
++#define E(n, s) char str##n[sizeof(s)];
++#include "__strerror.h"
++#undef E
++} errmsgstr = {
++#define E(n, s) s,
+ #include "__strerror.h"
++#undef E
+ };
+ 
+-#undef E
+-#define E(a,b) b "\0"
+-static const char errmsg[] =
++static const unsigned short errmsgidx[] = {
++#define E(n, s) [n] = offsetof(struct errmsgstr_t, str##n),
+ #include "__strerror.h"
+-;
++#undef E
++};
+ 
+ char *__strerror_l(int e, locale_t loc)
+ {
+ 	const char *s;
+-	int i;
+-	/* mips has one error code outside of the 8-bit range due to a
+-	 * historical typo, so we just remap it. */
+-	if (EDQUOT==1133) {
+-		if (e==109) e=-1;
+-		else if (e==EDQUOT) e=109;
+-	}
+-	for (i=0; errid[i] && errid[i] != e; i++);
+-	for (s=errmsg; i; s++, i--) for (; *s; s++);
++#ifdef EDQUOT_ORIG
++	if (e==EDQUOT) e=0;
++	else if (e==EDQUOT_ORIG) e=EDQUOT;
++#endif
++	if (e >= sizeof errmsgidx / sizeof *errmsgidx) e = 0;
++	s = (char *)&errmsgstr + errmsgidx[e];
+ 	return (char *)LCTRANS(s, LC_MESSAGES, loc);
+ }
+ 
+-- 
+2.25.1
+

--- a/pkg/debug/abuild/musl/ldconfig
+++ b/pkg/debug/abuild/musl/ldconfig
@@ -1,0 +1,18 @@
+#!/bin/sh
+scan_dirs() {
+	scanelf -qS "$@" | while read SONAME FILE; do
+		TARGET="${FILE##*/}"
+		LINK="${FILE%/*}/$SONAME"
+		case "$FILE" in
+		/lib/*|/usr/lib/*|/usr/local/lib/*) ;;
+		*) [ -h "$LINK" -o ! -e "$LINK" ] && ln -sf "$TARGET" "$LINK"
+		esac
+	done
+	return 0
+}
+# eat ldconfig options
+while getopts "nNvXvf:C:r:" opt; do
+	:
+done
+shift $(( $OPTIND - 1 ))
+[ $# -gt 0 ] && scan_dirs "$@"

--- a/pkg/debug/abuild/musl/ppc-pt_regs.patch
+++ b/pkg/debug/abuild/musl/ppc-pt_regs.patch
@@ -1,0 +1,38 @@
+commit c2518a8efb6507f1b41c3b12e03b06f8f2317a1f
+Author: Rich Felker <dalias@aerifal.cx>
+Date:   Sat Oct 19 15:53:43 2019 -0400
+
+    use struct pt_regs * rather than void * for powerpc[64] sigcontext regs
+    
+    this is to match the kernel and glibc interfaces. here, struct pt_regs
+    is an incomplete type, but that's harmless, and if it's completed by
+    inclusion of another header then members of the struct pointed to by
+    the regs member can be accessed directly without going through a cast
+    or intermediate pointer object.
+
+diff --git a/arch/powerpc/bits/signal.h b/arch/powerpc/bits/signal.h
+index 06efb11c..c1bf3caf 100644
+--- a/arch/powerpc/bits/signal.h
++++ b/arch/powerpc/bits/signal.h
+@@ -28,7 +28,7 @@ struct sigcontext {
+ 	int signal;
+ 	unsigned long handler;
+ 	unsigned long oldmask;
+-	void *regs;
++	struct pt_regs *regs;
+ };
+ 
+ typedef struct {
+diff --git a/arch/powerpc64/bits/signal.h b/arch/powerpc64/bits/signal.h
+index 4dec22a5..d5493b18 100644
+--- a/arch/powerpc64/bits/signal.h
++++ b/arch/powerpc64/bits/signal.h
+@@ -32,7 +32,7 @@ typedef struct sigcontext {
+ 	int _pad0;
+ 	unsigned long handler;
+ 	unsigned long oldmask;
+-	void *regs;
++	struct pt_regs *regs;
+ 	gregset_t gp_regs;
+ 	fpregset_t fp_regs;
+ 	vrregset_t *v_regs;

--- a/pkg/debug/abuild/musl/ppc64-fpregset_t.patch
+++ b/pkg/debug/abuild/musl/ppc64-fpregset_t.patch
@@ -1,0 +1,31 @@
+commit c9f48cde0a22641ce3daf54596a9ecebdab91435
+Author: Rich Felker <dalias@aerifal.cx>
+Date:   Sat Oct 19 15:39:45 2019 -0400
+
+    fix fpregset_t type on powerpc64
+    
+    the userspace ucontext API has this as an array rather than a
+    structure.
+    
+    commit 3c59a868956636bc8adafb1b168d090897692532 fixed the
+    corresponding mistake for vrregset_t, namely that the original
+    powerpc64 port used a mix of types from 32-bit powerpc and powerpc64
+    rather than matching the 64-bit types.
+
+diff --git a/arch/powerpc64/bits/signal.h b/arch/powerpc64/bits/signal.h
+index 2cc0604c..4dec22a5 100644
+--- a/arch/powerpc64/bits/signal.h
++++ b/arch/powerpc64/bits/signal.h
+@@ -9,11 +9,7 @@
+ #if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
+ 
+ typedef unsigned long greg_t, gregset_t[48];
+-
+-typedef struct {
+-	double fpregs[32];
+-	double fpscr;
+-} fpregset_t;
++typedef double fpregset_t[33];
+ 
+ typedef struct {
+ #ifdef __GNUC__

--- a/pkg/debug/abuild/musl/set-AD-bit-in-dns-queries-suppress-for-internal-use.patch
+++ b/pkg/debug/abuild/musl/set-AD-bit-in-dns-queries-suppress-for-internal-use.patch
@@ -1,0 +1,67 @@
+From fd7ec068efd590c0393a612599a4fab9bb0a8633 Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Mon, 18 May 2020 21:17:34 -0400
+Subject: set AD bit in dns queries, suppress for internal use
+
+the AD (authenticated data) bit in outgoing dns queries is defined by
+rfc3655 to request that the nameserver report (via the same bit in the
+response) whether the result is authenticated by DNSSEC. while all
+results returned by a DNSSEC conforming nameserver will be either
+authenticated or cryptographically proven to lack DNSSEC protection,
+for some applications it's necessary to be able to distinguish these
+two cases. in particular, conforming and compatible handling of DANE
+(TLSA) records requires enforcing them only in signed zones.
+
+when the AD bit was first defined for queries, there were reports of
+compatibility problems with broken firewalls and nameservers dropping
+queries with it set. these problems are probably a thing of the past,
+and broken nameservers are already unsupported. however, since there
+is no use in the AD bit with the netdb.h interfaces, explicitly clear
+it in the queries they make. this ensures that, even with broken
+setups, the standard functions will work, and at most the res_*
+functions break.
+---
+ src/network/getnameinfo.c | 1 +
+ src/network/lookup_name.c | 1 +
+ src/network/res_mkquery.c | 1 +
+ 3 files changed, 3 insertions(+)
+
+diff --git a/src/network/getnameinfo.c b/src/network/getnameinfo.c
+index f77e73ad..949e1811 100644
+--- a/src/network/getnameinfo.c
++++ b/src/network/getnameinfo.c
+@@ -158,6 +158,7 @@ int getnameinfo(const struct sockaddr *restrict sa, socklen_t sl,
+ 			unsigned char query[18+PTR_MAX], reply[512];
+ 			int qlen = __res_mkquery(0, ptr, 1, RR_PTR,
+ 				0, 0, 0, query, sizeof query);
++			query[3] = 0; /* don't need AD flag */
+ 			int rlen = __res_send(query, qlen, reply, sizeof reply);
+ 			buf[0] = 0;
+ 			if (rlen > 0)
+diff --git a/src/network/lookup_name.c b/src/network/lookup_name.c
+index c93263a9..c4d994a1 100644
+--- a/src/network/lookup_name.c
++++ b/src/network/lookup_name.c
+@@ -149,6 +149,7 @@ static int name_from_dns(struct address buf[static MAXADDRS], char canon[static
+ 				0, 0, 0, qbuf[nq], sizeof *qbuf);
+ 			if (qlens[nq] == -1)
+ 				return EAI_NONAME;
++			qbuf[nq][3] = 0; /* don't need AD flag */
+ 			nq++;
+ 		}
+ 	}
+diff --git a/src/network/res_mkquery.c b/src/network/res_mkquery.c
+index 6fa04a5c..33f50cb9 100644
+--- a/src/network/res_mkquery.c
++++ b/src/network/res_mkquery.c
+@@ -20,6 +20,7 @@ int __res_mkquery(int op, const char *dname, int class, int type,
+ 	/* Construct query template - ID will be filled later */
+ 	memset(q, 0, n);
+ 	q[2] = op*8 + 1;
++	q[3] = 32; /* AD */
+ 	q[5] = 1;
+ 	memcpy((char *)q+13, dname, l);
+ 	for (i=13; q[i]; i=j+1) {
+-- 
+cgit v1.2.1
+

--- a/pkg/debug/debug-spin.sh
+++ b/pkg/debug/debug-spin.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-while true ; do
-  sleep 60
-done

--- a/pkg/debug/ssh.sh
+++ b/pkg/debug/ssh.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# setting things up for being able to access linux kernel symbols
+echo 0 >  /proc/sys/kernel/kptr_restrict
+echo -1 > /proc/sys/kernel/perf_event_paranoid
+
+KEYS=$(find /etc/ssh -name 'ssh_host_*_key')
+[ -z "$KEYS" ] && ssh-keygen -A >/dev/null 2>/dev/null
+
+exec /usr/sbin/sshd -D -e


### PR DESCRIPTION
We need to tweak musl build ever so slightly to make sure we can run observability tools like perf(1) and get reasonable stack traces. This is obviously useful inside of the debug container itself, but you can, of course, bind-mount this debug version of musl into other containers as well (such as pillar) to get the most reliable and accurate stack traces when profiling things there.

The interesting part of this PR -- is everything outside of abuild folder -- the content of abuild simply came from upstream Alpine 3.12 (see README.md at the top of that folder).

Note that we're also dropping the level of paranoia in the kernel to allow for easy event registration at the kernel level. 