### PR TITLE
Add force.fallback.counter to try fallback to other image 

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -33,6 +33,7 @@
 | timer.appcontainer.stats.interval | integer in seconds | 300 | collect application container stats |
 | timer.vault.ready.cutoff | integer in seconds | 300 | reboot after inaccessible vault |
 | maintenance.mode | "enabled" or "disabled" | "none" | don't run applications etc |
+| force.fallback.counter | integer | 0 | forces fallback to other image if counter is changed |
 
 
 In addition, there can be per-agent settings.

--- a/pkg/pillar/cmd/baseosmgr/baseosmgr.go
+++ b/pkg/pillar/cmd/baseosmgr/baseosmgr.go
@@ -45,6 +45,7 @@ type baseOsMgrContext struct {
 	subZbootConfig       pubsub.Subscription
 	subContentTreeStatus pubsub.Subscription
 	subNodeAgentStatus   pubsub.Subscription
+	subZedAgentStatus    pubsub.Subscription
 	rebootReason         string    // From last reboot
 	rebootTime           time.Time // From last reboot
 	rebootImage          string    // Image from which the last reboot happened
@@ -137,6 +138,9 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 		case change := <-ctx.subNodeAgentStatus.MsgChan():
 			ctx.subNodeAgentStatus.ProcessChange(change)
+
+		case change := <-ctx.subZedAgentStatus.MsgChan():
+			ctx.subZedAgentStatus.ProcessChange(change)
 
 		case res := <-ctx.worker.MsgChan():
 			res.Process(&ctx, true)
@@ -355,6 +359,25 @@ func initializeNodeAgentHandles(ps *pubsub.PubSub, ctx *baseOsMgrContext) {
 	}
 	ctx.subNodeAgentStatus = subNodeAgentStatus
 	subNodeAgentStatus.Activate()
+
+	// subscribe to zedagent status events
+	subZedAgentStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:     "zedagent",
+		MyAgentName:   agentName,
+		TopicImpl:     types.ZedAgentStatus{},
+		Activate:      false,
+		Ctx:           ctx,
+		CreateHandler: handleZedAgentStatusCreate,
+		ModifyHandler: handleZedAgentStatusModify,
+		DeleteHandler: handleZedAgentStatusDelete,
+		WarningTime:   warningTime,
+		ErrorTime:     errorTime,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	ctx.subZedAgentStatus = subZedAgentStatus
+	subZedAgentStatus.Activate()
 
 	// Look for ZbootConfig, from nodeagent
 	subZbootConfig, err := ps.NewSubscription(

--- a/pkg/pillar/cmd/baseosmgr/forcefallback.go
+++ b/pkg/pillar/cmd/baseosmgr/forcefallback.go
@@ -1,0 +1,170 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package baseosmgr
+
+import (
+	"bufio"
+	"io/ioutil"
+	"os"
+	"strconv"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/lf-edge/eve/pkg/pillar/zboot"
+)
+
+const (
+	// checkpointDirname - location of forcefallbackfile
+	// XXX move to locationconst.go?
+	checkpointDirname     = types.PersistDir + "/checkpoint"
+	forcefallbackFilename = checkpointDirname + "/forceFallbackCounter"
+
+	maxReadSize = 16384
+)
+
+// handle zedagent status events to look if the ForceFallbackCounter changes
+
+func handleZedAgentStatusCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleZedAgentStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleZedAgentStatusModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleZedAgentStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleZedAgentStatusImpl(ctxArg interface{}, key string,
+	statusArg interface{}) {
+
+	ctxPtr := ctxArg.(*baseOsMgrContext)
+	status := statusArg.(types.ZedAgentStatus)
+	handleForceFallback(ctxPtr, status)
+	log.Functionf("handleZedAgentStatusImpl(%s) done", key)
+}
+
+func handleZedAgentStatusDelete(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	// do nothing
+	log.Functionf("handleZedAgentStatusDelete(%s) done", key)
+}
+
+// handleForceFallback checks if we have a file with a ForceFallbackCounter
+// and if so, if the counter has changed.
+// If it has, then if the current partition is active, the other partition is
+// unused and the other partition has some non-empty EVE version string,
+// then it will mark the other partition as Updating.
+// This update to ZbootStatus will make nodeagent trigger a reboot.
+func handleForceFallback(ctxPtr *baseOsMgrContext, status types.ZedAgentStatus) {
+
+	counter, found := readForceFallbackCounter()
+	if !found {
+		// Just write the current value
+		log.Functionf("Saving initial ForceFallbackCounter %d",
+			status.ForceFallbackCounter)
+		writeForceFallbackCounter(status.ForceFallbackCounter)
+		return
+	}
+	if counter == status.ForceFallbackCounter {
+		log.Functionf("No change to ForceFallbackCounter %d", counter)
+		return
+	}
+	log.Noticef("Handle ForceFallbackCounter update from %d to %d",
+		counter, status.ForceFallbackCounter)
+
+	curPartName := zboot.GetCurrentPartition()
+	partStatus := getZbootStatus(ctxPtr, curPartName)
+	if partStatus == nil {
+		log.Warnf("No current partition status for %s; ignoring ForceFallback",
+			curPartName)
+		return
+	}
+	if partStatus.PartitionState != "active" {
+		log.Warnf("Current partition state %s not active; ignoring ForceFallback",
+			partStatus.PartitionState)
+		return
+	}
+	shortVerCurPart := partStatus.ShortVersion
+	otherPartName := zboot.GetOtherPartition()
+	partStatus = getZbootStatus(ctxPtr, otherPartName)
+	if partStatus == nil {
+		log.Warnf("No other partition status for %s; ignoring ForceFallback",
+			otherPartName)
+		return
+	}
+	shortVerOtherPart := partStatus.ShortVersion
+	if shortVerOtherPart == "" {
+		log.Warnf("Other partition has no version; ignoring ForceFallback")
+		return
+	}
+	if partStatus.PartitionState != "unused" {
+		log.Warnf("Other partition state %s not unused; ignoring ForceFallback",
+			partStatus.PartitionState)
+		return
+	}
+	log.Noticef("ForceFallback from %s to %s",
+		shortVerCurPart, shortVerOtherPart)
+
+	zboot.SetOtherPartitionStateUpdating(log)
+	updateAndPublishZbootStatus(ctxPtr,
+		partStatus.PartitionLabel, false)
+	baseOsStatus := lookupBaseOsStatusByPartLabel(ctxPtr, partStatus.PartitionLabel)
+	if baseOsStatus != nil {
+		baseOsSetPartitionInfoInStatus(ctxPtr, baseOsStatus,
+			partStatus.PartitionLabel)
+		publishBaseOsStatus(ctxPtr, baseOsStatus)
+	}
+	writeForceFallbackCounter(status.ForceFallbackCounter)
+}
+
+// readForceFallbackCounter reads the persistent file
+// If the file doesn't exist or doesn't contain an integer it returns false
+func readForceFallbackCounter() (int, bool) {
+	if _, err := os.Stat(forcefallbackFilename); err != nil {
+		return 0, false
+	}
+	s, err := read(forcefallbackFilename)
+	if err != nil {
+		return 0, false
+	}
+	c, err := strconv.Atoi(s)
+	if err != nil {
+		log.Errorf("readForceFallbackCounter parse %s failed: %s",
+			s, err)
+		return 0, false
+	}
+	return int(c), true
+}
+
+// writeForceFallbackCounter writes the persistent file
+// Errors are logged but otherwise ignored
+func writeForceFallbackCounter(fallbackCounter int) {
+	b := []byte(strconv.Itoa(fallbackCounter))
+	err := ioutil.WriteFile(forcefallbackFilename, b, 0644)
+	if err != nil {
+		log.Errorf("writeForceFallbackCounter write: %s", err)
+	}
+}
+
+// read returns the content of the file as a string
+// We limit the size we read to 16k
+func read(filename string) (string, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		if log != nil {
+			log.Errorf("read failed %s", err)
+		}
+		return "", err
+	}
+	defer f.Close()
+	r := bufio.NewReader(f)
+	content := make([]byte, maxReadSize)
+	n, err := r.Read(content)
+	if err != nil {
+		if log != nil {
+			log.Errorf("read failed %s", err)
+		}
+		return "", err
+	}
+	return string(content[0:n]), nil
+}

--- a/pkg/pillar/cmd/baseosmgr/handlebaseos.go
+++ b/pkg/pillar/cmd/baseosmgr/handlebaseos.go
@@ -349,14 +349,6 @@ func doBaseOsActivate(ctx *baseOsMgrContext, uuidStr string,
 		log.Functionf("Waiting for image to be mounted")
 		return changed
 	}
-
-	// if it is installed, flip the activated status
-	if status.State == types.INSTALLED && !status.Reboot {
-		// trigger, zedagent to start reboot process
-		status.Reboot = true
-		changed = true
-	}
-
 	return changed
 }
 

--- a/pkg/pillar/cmd/nodeagent/handlebaseos.go
+++ b/pkg/pillar/cmd/nodeagent/handlebaseos.go
@@ -20,6 +20,7 @@ func doZbootBaseOsInstallationComplete(ctxPtr *nodeagentContext,
 		log.Errorf("Partition(%s) Config not found", key)
 		return
 	}
+	// This check will also handle forced fallback
 	if isZbootOtherPartitionStateUpdating(ctxPtr) && !ctxPtr.deviceReboot {
 		infoStr := fmt.Sprintf("NORMAL: baseos-update(%s) reboot", key)
 		log.Functionf(infoStr)

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -524,12 +524,13 @@ func inhaleDeviceConfig(config *zconfig.EdgeDevConfig, getconfigCtx *getconfigCo
 func publishZedAgentStatus(getconfigCtx *getconfigContext) {
 	ctx := getconfigCtx.zedagentCtx
 	status := types.ZedAgentStatus{
-		Name:            agentName,
-		ConfigGetStatus: getconfigCtx.configGetStatus,
-		RebootCmd:       ctx.rebootCmd,
-		RebootReason:    ctx.currentRebootReason,
-		BootReason:      ctx.currentBootReason,
-		MaintenanceMode: ctx.maintenanceMode,
+		Name:                 agentName,
+		ConfigGetStatus:      getconfigCtx.configGetStatus,
+		RebootCmd:            ctx.rebootCmd,
+		RebootReason:         ctx.currentRebootReason,
+		BootReason:           ctx.currentBootReason,
+		MaintenanceMode:      ctx.maintenanceMode,
+		ForceFallbackCounter: ctx.forceFallbackCounter,
 	}
 	pub := getconfigCtx.pubZedAgentStatus
 	pub.Publish(agentName, status)

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -56,6 +56,16 @@ func parseConfig(config *zconfig.EdgeDevConfig, getconfigCtx *getconfigContext,
 		mergeMaintenanceMode(ctx)
 	}
 
+	// Did the ForceFallbackCounter change? If so we publish for
+	// baseosmgr to take a look
+	newForceFallbackCounter := int(ctx.globalConfig.GlobalValueInt(types.ForceFallbackCounter))
+	if newForceFallbackCounter != ctx.forceFallbackCounter {
+		log.Noticef("ForceFallbackCounter update from %d to %d",
+			ctx.forceFallbackCounter, newForceFallbackCounter)
+		ctx.forceFallbackCounter = newForceFallbackCounter
+		publishZedAgentStatus(ctx.getconfigCtx)
+	}
+
 	if getconfigCtx.rebootFlag || ctx.deviceReboot {
 		log.Tracef("parseConfig: Ignoring config as rebootFlag set")
 	} else if ctx.maintenanceMode {

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -1649,8 +1649,9 @@ func readRebootConfig() *types.DeviceOpsCmd {
 		rebootConfig := types.DeviceOpsCmd{}
 		err = json.Unmarshal(bytes, &rebootConfig)
 		if err != nil {
-			log.Errorf("rebootConfig json failed: %s", err)
-			return &types.DeviceOpsCmd{}
+			// Treat the same way as a missing file
+			log.Error(err)
+			return nil
 		}
 		return &rebootConfig
 	}

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -137,6 +137,9 @@ type zedagentContext struct {
 	maintenanceMode    bool
 	gcpMaintenanceMode types.TriState
 	apiMaintenanceMode bool
+
+	// Track the counter from force.fallback.counter to detect changes
+	forceFallbackCounter int
 }
 
 var debug = false

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -157,6 +157,9 @@ const (
 	// VaultReadyCutOffTime global setting key
 	VaultReadyCutOffTime GlobalSettingKey = "timer.vault.ready.cutoff"
 
+	// ForceFallbackCounter global setting key
+	ForceFallbackCounter = "force.fallback.counter"
+
 	// Bool Items
 	// UsbAccess global setting key
 	UsbAccess GlobalSettingKey = "debug.enable.usb"
@@ -719,6 +722,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	// Dom0DiskUsageMaxBytes - Default is 2GB, min is 100MB
 	configItemSpecMap.AddIntItem(Dom0DiskUsageMaxBytes, 2*1024*1024*1024,
 		100*1024*1024, 0xFFFFFFFF)
+	configItemSpecMap.AddIntItem(ForceFallbackCounter, 0, 0, 0xFFFFFFFF)
 
 	// Add Bool Items
 	configItemSpecMap.AddBoolItem(UsbAccess, true) // Controller likely default to false

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -168,6 +168,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		AppContainerStatsInterval,
 		VaultReadyCutOffTime,
 		Dom0DiskUsageMaxBytes,
+		ForceFallbackCounter,
 		// Bool Items
 		UsbAccess,
 		AllowAppVnc,

--- a/pkg/pillar/types/zedagenttypes.go
+++ b/pkg/pillar/types/zedagenttypes.go
@@ -84,7 +84,6 @@ type BaseOsStatus struct {
 	UUIDandVersion        UUIDandVersion
 	BaseOsVersion         string
 	Activated             bool
-	Reboot                bool
 	TooEarly              bool // Failed since previous was inprogress/test
 	ContentTreeStatusList []ContentTreeStatus
 	PartitionLabel        string
@@ -454,12 +453,13 @@ const (
 
 // ZedAgentStatus :
 type ZedAgentStatus struct {
-	Name            string
-	ConfigGetStatus ConfigGetStatus
-	RebootCmd       bool
-	RebootReason    string     // Current reason to reboot
-	BootReason      BootReason // Current reason to reboot
-	MaintenanceMode bool       // Don't run apps etc
+	Name                 string
+	ConfigGetStatus      ConfigGetStatus
+	RebootCmd            bool
+	RebootReason         string     // Current reason to reboot
+	BootReason           BootReason // Current reason to reboot
+	MaintenanceMode      bool       // Don't run apps etc
+	ForceFallbackCounter int        // Try image fallback when counter changes
 }
 
 // Key :


### PR DESCRIPTION
If the counter value is changed then we check if the other is unused and has a version (and current is active), and if so we mark the other partition as "updating" and save the counter value.
The change to zboot will make nodeagent reboot.

Note that the counter is stored in /persist/checkpoint/
Separately we should move /config/rebootConfig and /config/restartCounter to the same directory