### PR TITLE
remove default dd from ledmanager

### DIFF
--- a/pkg/pillar/cmd/ledmanager/ledmanager.go
+++ b/pkg/pillar/cmd/ledmanager/ledmanager.go
@@ -164,9 +164,7 @@ var mToF = []modelToFuncs{
 	},
 	{
 		// Last in table as a default
-		model:     "",
-		initFunc:  InitDDCmd,
-		blinkFunc: ExecuteDDCmd,
+		model: "",
 	},
 }
 


### PR DESCRIPTION
According to the discussion https://github.com/lf-edge/eve/pull/1683 dd inside ledmanager consumes about [5% of cpu time](https://github.com/itmo-eve/eve-performance/blob/FIO-tests-13-57-27-11-2020-0.0.0-master-2053a0b1/FIO-tests-13-57-27-11-2020-0.0.0-master-2053a0b1/flamegraph.svg). Seems, that we need to disable it by default.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>