### PR TITLE
tpmmgr should not use deprecated /persist/config

### DIFF
--- a/pkg/pillar/evetpm/tpm.go
+++ b/pkg/pillar/evetpm/tpm.go
@@ -86,7 +86,7 @@ const (
 var (
 	//EcdhKeyFile is the location of the ecdh private key
 	//on devices without a TPM. It is not a constant due to test usage
-	EcdhKeyFile = types.PersistConfigDir + "/ecdh.key.pem"
+	EcdhKeyFile = types.CertificateDirname + "/ecdh.key.pem"
 
 	tpmHwInfo        = ""
 	pcrBank256Status = PCRBank256StatusUnknown


### PR DESCRIPTION
- /persist/config is deprecated, and will not exist after fresh USB installs
- in those cases, creation of the certs will fail
- /persist/certs already exists on device, re-using that instead of /persist/config

Signed-off-by: Hariharasubramanian C S <cshari@zededa.com>