### PR TITLE
Default EVE needs to be last in the workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,4 +52,5 @@ jobs:
           make LINUXKIT_PKG_TARGET=push HV=kvm eve
       - name: Build EVE
         run: |
+          rm -rf dist
           make LINUXKIT_PKG_TARGET=push eve


### PR DESCRIPTION
Signed-off-by: Roman Shaposhnik <rvs@zededa.com>