### PR TITLE
remove the .out from the check in panic search

### DIFF
--- a/pkg/watchdog/watchdog-report.sh
+++ b/pkg/watchdog/watchdog-report.sh
@@ -66,7 +66,7 @@ if [ -n "$agent" ]; then
         # Note that panic stack trace might exist tagged with e.g. pillar.out
         # in /persist/rsyslog/syslog.txt but can't extract from other container's
         # files. Try to extract here
-        stack=$(awk '/pillar.out;panic/ {p=1} {if ($3 != "pillar.out") { p=0 }; if (p==1) {print}}' /persist/rsyslog/syslog.txt)
+        stack=$(awk '/pillar;panic/ {p=1} {if ($3 != "pillar") { p=0 }; if (p==1) {print}}' /persist/rsyslog/syslog.txt)
         if [ -n "$stack" ]; then
             echo "$stack" >>/persist/reboot-stack
         fi


### PR DESCRIPTION
Signed-off-by: Naiming Shen <naiming@zededa.com>
the panic log output now is like:
2020-12-03T03:33:10.101135+00:00 linuxkit-ac1f6b70fdaa pillar 2020-12-03T03:33:09Z,pillar;panic: runtime error: slice bounds out of range [:12] with length 10
2020-12-03T03:33:10.103606+00:00 linuxkit-ac1f6b70fdaa pillar 2020-12-03T03:33:09Z,pillar;
2020-12-03T03:33:10.106265+00:00 linuxkit-ac1f6b70fdaa pillar 2020-12-03T03:33:09Z,pillar;goroutine 1758 [running]:

it does not have the ".out" in "pillar.out".