### PR TITLE
include baseos contentTree as well before GC.

### DIFF
--- a/pkg/pillar/cas/containerd.go
+++ b/pkg/pillar/cas/containerd.go
@@ -692,15 +692,16 @@ func (c *containerdCAS) IngestBlobsAndCreateImage(reference string, root types.B
 	rootBlobSha := fmt.Sprintf("%s:%s", digest.SHA256, strings.ToLower(root.Sha256))
 	mediaType := root.MediaType
 	imageHash, err := c.GetImageHash(reference)
-	logrus.Infof("IngestBlobsAndCreateImage: creating/updating reference: %s for rootBlob %s", reference, rootBlobSha)
 	if err != nil || imageHash == "" {
+		logrus.Infof("IngestBlobsAndCreateImage: creating reference: %s for rootBlob %s", reference, rootBlobSha)
 		if err := c.CreateImage(reference, mediaType, rootBlobSha); err != nil {
-			err = fmt.Errorf("IngestBlobsAndCreateImage: could not reference %s with rootBlob %s: %v",
+			err = fmt.Errorf("IngestBlobsAndCreateImage: could not create reference %s with rootBlob %s: %v",
 				reference, rootBlobSha, err.Error())
 			logrus.Errorf(err.Error())
 			return nil, err
 		}
 	} else {
+		logrus.Infof("IngestBlobsAndCreateImage: updating reference: %s for rootBlob %s", reference, rootBlobSha)
 		if err := c.ReplaceImage(reference, mediaType, rootBlobSha); err != nil {
 			err = fmt.Errorf("IngestBlobsAndCreateImage: could not update reference %s with rootBlob %s: %v",
 				reference, rootBlobSha, err.Error())

--- a/pkg/pillar/cmd/volumemgr/blob.go
+++ b/pkg/pillar/cmd/volumemgr/blob.go
@@ -564,7 +564,7 @@ func gcBlobStatus(ctx *volumemgrContext) {
 //gcImagesFromCAS gc all unused images from CAS
 func gcImagesFromCAS(ctx *volumemgrContext) {
 	log.Functionf("gcImagesFromCAS")
-	contentIDAndContentTreeStatus := getAllAppContentTreeStatus(ctx)
+	contentIDAndContentTreeStatus := getAllContentTreeStatus(ctx)
 	referenceMap := make(map[string]interface{})
 	for _, contentTreeStatus := range contentIDAndContentTreeStatus {
 		referenceMap[contentTreeStatus.ReferenceID()] = true

--- a/pkg/pillar/cmd/volumemgr/handlecontent.go
+++ b/pkg/pillar/cmd/volumemgr/handlecontent.go
@@ -148,16 +148,20 @@ func lookupContentTreeStatusAny(ctx *volumemgrContext, key string) *types.Conten
 	return nil
 }
 
-func getAllAppContentTreeStatus(ctx *volumemgrContext) map[string]*types.ContentTreeStatus {
-	log.Tracef("getAllAppContentTreeStatus")
-	pub := ctx.publication(types.ContentTreeStatus{}, types.AppImgObj)
-	contentIDAndContentTreeStatusIntf := pub.GetAll()
+func getAllContentTreeStatus(ctx *volumemgrContext) map[string]*types.ContentTreeStatus {
+	log.Tracef("getAllContentTreeStatus")
 	contentIDAndContentTreeStatus := make(map[string]*types.ContentTreeStatus)
-	for contentIDKey, contentTreeStatusIntf := range contentIDAndContentTreeStatusIntf {
-		contentTreeStatus := contentTreeStatusIntf.(types.ContentTreeStatus)
-		contentIDAndContentTreeStatus[contentIDKey] = &contentTreeStatus
+
+	for _, objType := range ctObjTypes {
+		pub := ctx.publication(types.ContentTreeStatus{}, objType)
+		allContentTreeStatus := pub.GetAll()
+		for key, item := range allContentTreeStatus {
+			contentTreeStatus := item.(types.ContentTreeStatus)
+			contentIDAndContentTreeStatus[key] = &contentTreeStatus
+		}
 	}
-	log.Tracef("getAllAppContentTreeStatus")
+
+	log.Tracef("getAllContentTreeStatus: Done")
 	return contentIDAndContentTreeStatus
 }
 


### PR DESCRIPTION
Issue: installDownloadedObject(<content-id>): InstallWorkResult error, exception while installing: error pulling <image> from containerd: image "<image>": not found

Reason: On boot, we only prevented ctrd images associated AppImg ContentTreeStatus from getting garbage collected and didn't include baseOs ContentTreeStatus, which led to BaseOS images getting GC.

Fix: On boot include BaseOS ContentTreeStatus as well which will prevent baseOs images from getting garbage collected.

Signed-off-by: adarsh-zededa <adarsh@zededa.com>