### PR TITLE
Cleaning up app instance config structure

### DIFF
--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -46,10 +46,8 @@ type UUIDandVersion struct {
 // (advertize the EID in lisp and boot the guest) is driven by the Activate
 // attribute.
 type AppInstanceConfig struct {
-	UUIDandVersion  UUIDandVersion
-	DisplayName     string
-	ConfigSha256    string
-	ConfigSignature string
+	UUIDandVersion UUIDandVersion
+	DisplayName    string
 
 	// Error
 	//	If this is set, do not process further.. Just set the status to error


### PR DESCRIPTION
Removing ```ConfigSha256``` and ```ConfigSignature``` from the ```AppInstanceConfig``` because these fields are now part of the ```ContentTreeConfig```