### PR TITLE
Adding memory checks while deploying instances

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -35,6 +35,7 @@
 | maintenance.mode | "enabled" or "disabled" | "none" | don't run applications etc |
 | force.fallback.counter | integer | 0 | forces fallback to other image if counter is changed |
 | newlog.allow.fastupload | boolean | false | allow faster upload gzip logfiles to controller |
+| memory.apps.ignore.check | boolean | false | Ignore memory usage check for Apps|
 
 
 In addition, there can be per-agent settings.

--- a/pkg/pillar/cmd/zedmanager/memorysizemgmt.go
+++ b/pkg/pillar/cmd/zedmanager/memorysizemgmt.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2021 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package zedmanager
+
+import (
+	"fmt"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// getRemainingMemory returns how many bytes remain for app instance usage
+func getRemainingMemory(ctxPtr *zedmanagerContext) (uint64, error) {
+
+	var usedMemorySize uint64
+	pubAppInstanceStatus := ctxPtr.pubAppInstanceStatus
+	itemsAppInstanceStatus := pubAppInstanceStatus.GetAll()
+	for _, iterAppInstanceStatusJSON := range itemsAppInstanceStatus {
+		iterAppInstanceStatus := iterAppInstanceStatusJSON.(types.AppInstanceStatus)
+		usedMemorySize += uint64(iterAppInstanceStatus.FixedResources.Memory) << 10
+	}
+	memoryReservedForEve := ctxPtr.globalConfig.GlobalValueInt(types.EveMemoryLimitInBytes)
+	usedMemorySize += uint64(memoryReservedForEve)
+	deviceMemorySize, err := sysTotalMemory(ctxPtr)
+	if err != nil {
+		return 0, err
+	}
+	return deviceMemorySize - usedMemorySize, nil
+}
+
+func sysTotalMemory(ctx *zedmanagerContext) (uint64, error) {
+	sub := ctx.subHostMemory
+	m, err := sub.Get("global")
+	if err != nil {
+		return 0, err
+	}
+	if m != nil {
+		memory := m.(types.HostMemory)
+		return uint64(memory.TotalMemoryMB) << 20, nil
+	}
+	return 0, fmt.Errorf("Global host memory is empty")
+}

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -172,6 +172,8 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		// Bool Items
 		UsbAccess,
 		AllowAppVnc,
+		EveMemoryLimitInBytes,
+		IgnoreMemoryCheckForApps,
 		IgnoreDiskCheckForApps,
 		AllowLogFastupload,
 		// TriState Items

--- a/pkg/pillar/types/globalconfigold.go
+++ b/pkg/pillar/types/globalconfigold.go
@@ -62,8 +62,9 @@ type OldGlobalConfig struct {
 
 	// Dom0MinDiskUsagePercent - Percentage of available storage reserved for
 	// dom0. The rest is available for Apps.
-	Dom0MinDiskUsagePercent uint32
-	IgnoreDiskCheckForApps  bool
+	Dom0MinDiskUsagePercent  uint32
+	IgnoreMemoryCheckForApps bool
+	IgnoreDiskCheckForApps   bool
 
 	// XXX add max space for downloads?
 	// XXX add max space for running images?
@@ -123,8 +124,9 @@ var globalConfigDefaults = OldGlobalConfig{
 	DefaultLogLevel:       "info", // XXX Should we change to warning?
 	DefaultRemoteLogLevel: "info", // XXX Should we change to warning?
 
-	Dom0MinDiskUsagePercent: 20,
-	IgnoreDiskCheckForApps:  false,
+	Dom0MinDiskUsagePercent:  20,
+	IgnoreMemoryCheckForApps: false,
+	IgnoreDiskCheckForApps:   false,
 }
 
 // Check which values are set and which should come from defaults
@@ -342,6 +344,7 @@ func (config OldGlobalConfig) MoveBetweenConfigs() *ConfigItemValueMap {
 
 	newConfig.SetGlobalValueBool(AllowAppVnc, config.AllowAppVnc)
 	newConfig.SetGlobalValueBool(UsbAccess, config.UsbAccess)
+	newConfig.SetGlobalValueBool(IgnoreMemoryCheckForApps, config.IgnoreMemoryCheckForApps)
 	newConfig.SetGlobalValueBool(IgnoreDiskCheckForApps, config.IgnoreDiskCheckForApps)
 
 	newConfig.SetGlobalValueString(SSHAuthorizedKeys, config.SshAuthorizedKeys)

--- a/pkg/pillar/types/locationconsts.go
+++ b/pkg/pillar/types/locationconsts.go
@@ -75,4 +75,6 @@ const (
 	NewlogUploadDevDir = NewlogDir + "/devUpload"
 	// NewlogUploadAppDir - newlog app gzip file directory ready for upload
 	NewlogUploadAppDir = NewlogDir + "/appUpload"
+	// EveMemoryLimitFile - stores memory reserved for eve
+	EveMemoryLimitFile = "/hostfs/sys/fs/cgroup/memory/eve/memory.soft_limit_in_bytes"
 )

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -143,7 +143,8 @@ type AppInstanceStatus struct {
 	DisplayName         string
 	DomainName          string // Once booted
 	Activated           bool
-	ActivateInprogress  bool // Needed for cleanup after failure
+	ActivateInprogress  bool     // Needed for cleanup after failure
+	FixedResources      VmConfig // CPU etc
 	VolumeRefStatusList []VolumeRefStatus
 	UnderlayNetworks    []UnderlayNetworkStatus
 	BootTime            time.Time


### PR DESCRIPTION
We need to add a check for memory usage while deploying app instances to avoid containerd errors.