### PR TITLE
While updating, mark baseOs state as DEFERRED instead of throwing an error

### DIFF
--- a/pkg/pillar/cmd/baseosmgr/handlebaseos.go
+++ b/pkg/pillar/cmd/baseosmgr/handlebaseos.go
@@ -439,7 +439,7 @@ func validatePartition(ctx *baseOsMgrContext,
 // Returns changed, proceed as above
 func validateAndAssignPartition(ctx *baseOsMgrContext,
 	config types.BaseOsConfig, status *types.BaseOsStatus) (bool, bool) {
-	var curPartState, curPartVersion, otherPartVersion string
+	var curPartState, curPartVersion string
 
 	log.Functionf("validateAndAssignPartition(%s) for %s",
 		config.Key(), config.BaseOsVersion)
@@ -453,9 +453,6 @@ func validateAndAssignPartition(ctx *baseOsMgrContext,
 		curPartVersion = curPartStatus.ShortVersion
 		curPartState = curPartStatus.PartitionState
 	}
-	if otherPartStatus != nil {
-		otherPartVersion = otherPartStatus.ShortVersion
-	}
 	otherPartState := getPartitionState(ctx, otherPartName)
 	if curPartState == "inprogress" || otherPartState == "active" {
 		// Must still be testing the current version; don't overwrite
@@ -463,14 +460,9 @@ func validateAndAssignPartition(ctx *baseOsMgrContext,
 		// If there is no change to the other we don't log error
 		// but still retry later
 		status.TooEarly = true
-		errStr := fmt.Sprintf("Attempt to install baseOs update %s while testing is in progress for %s: deferred",
+		log.Errorf("Attempt to install baseOs update %s while testing is in progress for %s: deferred",
 			config.BaseOsVersion, curPartVersion)
-		if otherPartVersion == config.BaseOsVersion {
-			log.Functionln(errStr)
-		} else {
-			log.Error(errStr)
-			status.SetErrorNow(errStr)
-		}
+
 		changed = true
 		return changed, proceed
 	}

--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -467,10 +467,10 @@ func addUserSwInfo(ctx *zedagentContext, swInfo *info.ZInfoDevSW, tooEarly bool)
 		if swInfo.Activated {
 			swInfo.UserStatus = info.BaseOsStatus_DOWNLOAD_DONE
 			swInfo.SubStatusStr = "Downloaded and verified"
-			//} else if tooEarly { // To be uncommented after 'BaseOsSubStatus_UPDATE_DEFERRED' state is handled in controller
-			//	swInfo.UserStatus = info.BaseOsStatus_UPDATING
-			//	swInfo.SubStatus = info.BaseOsSubStatus_UPDATE_DEFERRED
-			//	swInfo.SubStatusStr = "Waiting for current image to finish testing before updating again"
+		} else if tooEarly {
+			swInfo.UserStatus = info.BaseOsStatus_UPDATING
+			swInfo.SubStatus = info.BaseOsSubStatus_UPDATE_DEFERRED
+			swInfo.SubStatusStr = "Waiting for current image to finish testing before updating again"
 		} else {
 			swInfo.UserStatus = info.BaseOsStatus_NONE
 		}


### PR DESCRIPTION
WIP because controller changes are yet to be deployed on alpha. 

Signed-off-by: adarsh-zededa <adarsh@zededa.com>