### PR TITLE
Fix panic when disabling nim lastresort

### DIFF
--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -73,11 +73,15 @@ func UpdateLastResortPortConfig(ctx *DeviceNetworkContext, ports []string) {
 	}
 	config := LastResortDevicePortConfig(ctx, ports)
 	config.Key = "lastresort"
-	ctx.PubDevicePortConfig.Publish("lastresort", config)
+	if ctx.PubDevicePortConfig != nil {
+		ctx.PubDevicePortConfig.Publish("lastresort", config)
+	}
 }
 
 func RemoveLastResortPortConfig(ctx *DeviceNetworkContext) {
-	ctx.PubDevicePortConfig.Unpublish("lastresort")
+	if ctx.PubDevicePortConfig != nil {
+		ctx.PubDevicePortConfig.Unpublish("lastresort")
+	}
 }
 
 func SetupVerify(ctx *DeviceNetworkContext, index int) {

--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -87,7 +87,7 @@ func RemoveLastResortPortConfig(ctx *DeviceNetworkContext) {
 func SetupVerify(ctx *DeviceNetworkContext, index int) {
 
 	log := ctx.Log
-	log.Functionf("SetupVerify: Setting up verification for DPC at index %d",
+	log.Noticef("SetupVerify: Setting up verification for DPC at index %d",
 		index)
 	ctx.NextDPCIndex = index
 	ctx.DevicePortConfigList.CurrentIndex = ctx.NextDPCIndex
@@ -127,6 +127,7 @@ func RestartVerify(ctx *DeviceNetworkContext, caller string) {
 			ctx.DeviceNetworkStatus.Testing = false
 			log.Functionf("PublishDeviceNetworkStatus: %+v\n",
 				ctx.DeviceNetworkStatus)
+			ctx.DeviceNetworkStatus.CurrentIndex = ctx.DevicePortConfigList.CurrentIndex
 			ctx.PubDeviceNetworkStatus.Publish("global",
 				*ctx.DeviceNetworkStatus)
 		}
@@ -375,7 +376,7 @@ func VerifyDevicePortConfig(ctx *DeviceNetworkContext) {
 				ctx.Pending.PendDNS)
 			ctx.PubDeviceNetworkStatus.Publish("global", ctx.Pending.PendDNS)
 		}
-		log.Functionf("VerifyDevicePortConfig: %s for %d",
+		log.Noticef("VerifyDevicePortConfig: %s for index %d",
 			res.String(), ctx.NextDPCIndex)
 		switch res {
 		case types.DPC_PCI_WAIT:

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -309,7 +309,6 @@ func NewIntfStatusMap() *IntfStatusMap {
 // It includes test results hence is misnamed - should have a separate status
 // This is only published under the key "global"
 type DevicePortConfigList struct {
-	Key            string // Assume "gobal" if empty
 	CurrentIndex   int
 	PortConfigList []DevicePortConfig
 }
@@ -335,11 +334,7 @@ func (config DevicePortConfigList) MostlyEqual(config2 DevicePortConfigList) boo
 
 // PubKey is used for pubsub
 func (config DevicePortConfigList) PubKey() string {
-	if config.Key == "" {
-		return "global"
-	} else {
-		return config.Key
-	}
+	return "global"
 }
 
 // LogCreate :


### PR DESCRIPTION
When having static IP config it is useful to be able to disable the fallback in nim to use DHCP on all Ethernet-like devices.
However, setting network.fallback.any.eth to disable results in a panic due to a null pointer.

Also, we should do Notice aka Info-level logging for the key events in nim and when the DeviceNetworkStatus changes its ports.
Adding CurrentIndex to DeviceNetworkStatus to make that logging more obvious.