### PR TITLE
Implement metadata server for app instances; provide external IP as metadata

### DIFF
--- a/pkg/pillar/cmd/zedrouter/acl.go
+++ b/pkg/pillar/cmd/zedrouter/acl.go
@@ -361,6 +361,14 @@ func aclToRules(aclArgs types.AppNetworkACLArgs, ACLs []types.ACE) (types.IPTabl
 				"-p", "tcp", "--sport", "domain"}
 			aclRule4.Action = []string{"-j", "ACCEPT"}
 			rulesList = append(rulesList, aclRule1, aclRule2, aclRule3, aclRule4)
+
+			aclRule1.Rule = []string{"-i", aclArgs.BridgeName, "-d", "169.254.169.254",
+				"-p", "tcp", "--dport", "http"}
+			aclRule1.Action = []string{"-j", "ACCEPT"}
+			aclRule2.Rule = []string{"-i", aclArgs.BridgeName, "-s", "169.254.169.254",
+				"-p", "tcp", "--sport", "http"}
+			aclRule2.Action = []string{"-j", "ACCEPT"}
+			rulesList = append(rulesList, aclRule1, aclRule2)
 		} else if aclArgs.NIType == types.NetworkInstanceTypeSwitch {
 			aclRule1.Rule = []string{"-i", aclArgs.BridgeName, "-m", "set",
 				"--match-set", "ipv6.local", "dst", "-p", "ipv6-icmp"}
@@ -409,6 +417,15 @@ func aclToRules(aclArgs types.AppNetworkACLArgs, ACLs []types.ACE) (types.IPTabl
 				"--physdev-out", aclArgs.VifName}
 			aclRule4.Action = []string{"-j", "ACCEPT"}
 			rulesList = append(rulesList, aclRule1, aclRule2, aclRule3, aclRule4)
+			aclRule1.Rule = []string{"-i", aclArgs.BridgeName,
+				"-d", "169.254.169.254",
+				"-p", "tcp", "--dport", "http"}
+			aclRule1.Action = []string{"-j", "ACCEPT"}
+			aclRule2.Rule = []string{"-i", aclArgs.BridgeName,
+				"-s", "169.254.169.254",
+				"-p", "tcp", "--sport", "http"}
+			aclRule2.Action = []string{"-j", "ACCEPT"}
+			rulesList = append(rulesList, aclRule1, aclRule2)
 		}
 	}
 	// The same rules as above for IPv4.
@@ -447,6 +464,14 @@ func aclToRules(aclArgs types.AppNetworkACLArgs, ACLs []types.ACE) (types.IPTabl
 			aclRule4.Action = []string{"-j", "ACCEPT"}
 			rulesList = append(rulesList, aclRule1, aclRule2, aclRule3, aclRule4)
 
+			aclRule1.Rule = []string{"-i", aclArgs.BridgeName, "-d", "169.254.169.254",
+				"-p", "tcp", "--dport", "http"}
+			aclRule1.Action = []string{"-j", "ACCEPT"}
+			aclRule2.Rule = []string{"-i", aclArgs.BridgeName, "-s", "169.254.169.254",
+				"-p", "tcp", "--sport", "http"}
+			aclRule2.Action = []string{"-j", "ACCEPT"}
+			rulesList = append(rulesList, aclRule1, aclRule2)
+
 			aclRule5.Table = "mangle"
 			aclRule5.Chain = "PREROUTING"
 			aclRule5.Rule = []string{"-i", aclArgs.BridgeName, "-d", aclArgs.BridgeIP,
@@ -463,6 +488,16 @@ func aclToRules(aclArgs types.AppNetworkACLArgs, ACLs []types.ACE) (types.IPTabl
 			chainName = fmt.Sprintf("proto-%s-%s-%d",
 				aclArgs.BridgeName, aclArgs.VifName, 7)
 			createMarkAndAcceptChain(aclArgs, chainName, 7)
+			aclRule5.Action = []string{"-j", chainName}
+			aclRule5.ActionChainName = chainName
+			rulesList = append(rulesList, aclRule5)
+
+			aclRule5.Rule = []string{"-i", aclArgs.BridgeName,
+				"-d", "169.254.169.254",
+				"-p", "tcp", "--dport", "http"}
+			chainName = fmt.Sprintf("proto-%s-%s-%d",
+				aclArgs.BridgeName, aclArgs.VifName, 8)
+			createMarkAndAcceptChain(aclArgs, chainName, 8)
 			aclRule5.Action = []string{"-j", chainName}
 			aclRule5.ActionChainName = chainName
 			rulesList = append(rulesList, aclRule5)
@@ -511,6 +546,16 @@ func aclToRules(aclArgs types.AppNetworkACLArgs, ACLs []types.ACE) (types.IPTabl
 			chainName = fmt.Sprintf("proto-%s-%s-%d",
 				aclArgs.BridgeName, aclArgs.VifName, 7)
 			createMarkAndAcceptChain(aclArgs, chainName, 7)
+			aclRule5.Action = []string{"-j", chainName}
+			aclRule5.ActionChainName = chainName
+			rulesList = append(rulesList, aclRule5)
+
+			aclRule5.Rule = []string{"-i", aclArgs.BridgeName,
+				"-d", "169.254.169.254",
+				"-p", "tcp", "--dport", "http"}
+			chainName = fmt.Sprintf("proto-%s-%s-%d",
+				aclArgs.BridgeName, aclArgs.VifName, 8)
+			createMarkAndAcceptChain(aclArgs, chainName, 8)
 			aclRule5.Action = []string{"-j", chainName}
 			aclRule5.ActionChainName = chainName
 			rulesList = append(rulesList, aclRule5)

--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -1569,6 +1569,22 @@ func networkInstanceAddressType(ctx *zedrouterContext, bridgeName string) int {
 	return ipVer
 }
 
+func lookupNetworkInstanceStatusByAppIP(ctx *zedrouterContext,
+	ip net.IP) *types.NetworkInstanceStatus {
+
+	pub := ctx.pubNetworkInstanceStatus
+	items := pub.GetAll()
+	for _, st := range items {
+		status := st.(types.NetworkInstanceStatus)
+		for _, a := range status.IPAssignments {
+			if ip.Equal(a) {
+				return &status
+			}
+		}
+	}
+	return nil
+}
+
 // ==== Vpn
 func vpnCreate(ctx *zedrouterContext,
 	status *types.NetworkInstanceStatus) error {

--- a/pkg/pillar/cmd/zedrouter/server.go
+++ b/pkg/pillar/cmd/zedrouter/server.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// A http server providing meta-data information to application instances
+// at http://169.254.169.254. The source IP address is used to tell
+// which app instance is sending the request
+
+package zedrouter
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/eriknordmark/netlink"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+const (
+	ifname  = "svc0"
+	ipaddr4 = "169.254.169.254"
+	ifaddr4 = ipaddr4 + "/32"
+	ipaddr6 = "fe80::a9fe:a9fe"
+	ifaddr6 = ipaddr6 + "/128"
+)
+
+// For now we run a single server. If we use network namespaces for
+// each bridge aka network instance it would make sense to run a server
+// per network instance
+// The source IP address of the caller is used to determine the app
+// instance and network instance
+
+func createServerIntf(ctx *zedrouterContext) error {
+	// ip link add name svc0 type dummy
+	// ip link set dev svc0 up
+	// ip addr add 169.254.169.254/32 dev svc0
+	// ip addr add fe80::a9fe:a9fe/128 dev svc0
+	link, err := netlink.LinkByName(ifname)
+	if link != nil {
+		log.Warnf("createServerIntf: %s already present",
+			ifname)
+		return nil
+	}
+
+	sattrs := netlink.NewLinkAttrs()
+	sattrs.Name = ifname
+
+	slink := &netlink.Dummy{LinkAttrs: sattrs}
+	if err := netlink.LinkAdd(slink); err != nil {
+		return fmt.Errorf("createServerIntf: LinkAdd on %s failed: %s",
+			ifname, err)
+	}
+
+	if err := netlink.LinkSetUp(slink); err != nil {
+		return fmt.Errorf("createServerIntf: LinkSetUp on %s failed: %s",
+			ifname, err)
+	}
+	addr4, err := netlink.ParseAddr(ifaddr4)
+	if err != nil {
+		return fmt.Errorf("createServerIntf: ParseAddr %s failed: %s", ifaddr4, err)
+	}
+	if err := netlink.AddrAdd(slink, addr4); err != nil {
+		return fmt.Errorf("createServerIntf: AddrAdd %s failed: %s", ifaddr4, err)
+	}
+	addr6, err := netlink.ParseAddr(ifaddr6)
+	if err != nil {
+		return fmt.Errorf("createServerIntf: ParseAddr %s failed: %s", ifaddr6, err)
+	}
+	if err := netlink.AddrAdd(slink, addr6); err != nil {
+		return fmt.Errorf("createServerIntf: AddrAdd %s failed: %s", ifaddr6, err)
+	}
+	return nil
+}
+
+// Provides a json file
+type networkHandler struct {
+	ctx *zedrouterContext
+}
+
+// Provides a LF-terminated text
+type externalIPHandler struct {
+	ctx *zedrouterContext
+}
+
+// Provides a LF-terminated text
+type hostnameHandler struct {
+	ctx *zedrouterContext
+}
+
+func createServer(ctx *zedrouterContext) error {
+	mux := http.NewServeMux()
+	nh := &networkHandler{ctx: ctx}
+	mux.Handle("/eve/v1/network.json", nh)
+	ipHandler := &externalIPHandler{ctx: ctx}
+	mux.Handle("/eve/v1/external_ipv4", ipHandler)
+	hostnameHandler := &hostnameHandler{ctx: ctx}
+	mux.Handle("/eve/v1/hostname", hostnameHandler)
+
+	// Need one server per local IP address
+	go runServer(mux, "tcp6", "["+ipaddr6+"%"+ifname+"]")
+	go runServer(mux, "tcp4", ipaddr4)
+	log.Noticef("started http server")
+	return nil
+}
+
+func runServer(mux http.Handler, network string, ipaddr string) {
+	l, err := net.Listen(network, ipaddr+":80")
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := http.Serve(l, mux); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// ServeHTTP for networkHandler provides a json return
+func (hdl networkHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	remoteIP := net.ParseIP(strings.Split(r.RemoteAddr, ":")[0])
+	externalIP, code := getExternalIPForApp(hdl.ctx, remoteIP)
+	var ipStr string
+	var hostname string
+	// Avoid returning the string <nil>
+	if len(externalIP) != 0 {
+		ipStr = externalIP.String()
+	}
+	anStatus := lookupAppNetworkStatusByAppIP(hdl.ctx, remoteIP)
+	if anStatus != nil {
+		hostname = anStatus.UUIDandVersion.UUID.String()
+	}
+	w.Header().Add("Content-Type", "application/json")
+	w.WriteHeader(code)
+	resp, _ := json.Marshal(map[string]string{
+		"caller-ip":     r.RemoteAddr,
+		"external-ipv4": ipStr,
+		"hostname":      hostname,
+		// TBD: add public-ipv4 when controller tells us
+	})
+	w.Write(resp)
+}
+
+// ServeHTTP for externalIPHandler provides a text IP address
+func (hdl externalIPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	remoteIP := net.ParseIP(strings.Split(r.RemoteAddr, ":")[0])
+	externalIP, code := getExternalIPForApp(hdl.ctx, remoteIP)
+	w.WriteHeader(code)
+	w.Header().Add("Content-Type", "text/plain")
+	// Avoid returning the string <nil>
+	if len(externalIP) != 0 {
+		resp := []byte(externalIP.String() + "\n")
+		w.Write(resp)
+	}
+}
+
+func getExternalIPForApp(ctx *zedrouterContext, remoteIP net.IP) (net.IP, int) {
+	netstatus := lookupNetworkInstanceStatusByAppIP(ctx, remoteIP)
+	if netstatus == nil {
+		log.Errorf("No NetworkInstanceStatus for %s",
+			remoteIP.String())
+		return net.IP{}, http.StatusNotFound
+	}
+	if netstatus.CurrentUplinkIntf == "" {
+		log.Warnf("No CurrentUplinkIntf for %s",
+			remoteIP.String())
+		// Nothing to report */
+		return net.IP{}, http.StatusNoContent
+	}
+	ip, err := types.GetLocalAddrAnyNoLinkLocal(*ctx.deviceNetworkStatus,
+		0, netstatus.CurrentUplinkIntf)
+	if err != nil {
+		log.Errorf("No externalIP for %s: %s",
+			remoteIP.String(), err)
+		return net.IP{}, http.StatusNoContent
+	}
+	return ip, http.StatusOK
+}
+
+// ServeHTTP for hostnameHandler returns text
+func (hdl hostnameHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	remoteIP := net.ParseIP(strings.Split(r.RemoteAddr, ":")[0])
+	anStatus := lookupAppNetworkStatusByAppIP(hdl.ctx, remoteIP)
+	w.Header().Add("Content-Type", "text/plain")
+	if anStatus == nil {
+		w.WriteHeader(http.StatusNoContent)
+		log.Errorf("No AppNetworkStatus for %s",
+			remoteIP.String())
+	} else {
+		w.WriteHeader(http.StatusOK)
+		resp := []byte(anStatus.UUIDandVersion.UUID.String() + "\n")
+		w.Write(resp)
+	}
+}

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -451,6 +451,13 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	}
 	log.Functionf("Zedrouter has restarted. Entering main Select loop")
 
+	if err := createServerIntf(&zedrouterCtx); err != nil {
+		log.Fatal(err)
+	}
+	if err := createServer(&zedrouterCtx); err != nil {
+		log.Fatal(err)
+	}
+
 	for {
 		select {
 		case change := <-subGlobalConfig.MsgChan():
@@ -675,6 +682,22 @@ func lookupAppNetworkStatus(ctx *zedrouterContext, key string) *types.AppNetwork
 	}
 	status := st.(types.AppNetworkStatus)
 	return &status
+}
+
+func lookupAppNetworkStatusByAppIP(ctx *zedrouterContext, ip net.IP) *types.AppNetworkStatus {
+
+	ipStr := ip.String()
+	pub := ctx.pubAppNetworkStatus
+	items := pub.GetAll()
+	for _, st := range items {
+		status := st.(types.AppNetworkStatus)
+		for _, ulStatus := range status.UnderlayNetworkList {
+			if ipStr == ulStatus.AllocatedIPAddr {
+				return &status
+			}
+		}
+	}
+	return nil
 }
 
 func lookupAppNetworkConfig(ctx *zedrouterContext, key string) *types.AppNetworkConfig {

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -1290,7 +1290,7 @@ func GetDNSServers(globalStatus DeviceNetworkStatus, ifname string) []net.IP {
 
 	var servers []net.IP
 	for _, us := range globalStatus.Ports {
-		if !us.IsMgmt {
+		if !us.IsMgmt && ifname == "" {
 			continue
 		}
 		if ifname != "" && ifname != us.IfName {
@@ -1411,7 +1411,7 @@ func getInterfaceAndAddr(globalStatus DeviceNetworkStatus, free bool, phylabelOr
 	}
 	for _, us := range globalStatus.Ports {
 		if globalStatus.Version >= DPCIsMgmt &&
-			!us.IsMgmt {
+			!us.IsMgmt && ifname == "" {
 			continue
 		}
 		if free && !us.Free {
@@ -1541,7 +1541,7 @@ func GetMgmtPortFromAddr(globalStatus DeviceNetworkStatus, addr net.IP) string {
 }
 
 // Returns addresses based on free, ifname, and whether or not we want
-// IPv6 link-locals. Only applies to management ports.
+// IPv6 link-locals. Only applies to management ports unless ifname is set.
 // If free is not set, the addresses from the free management ports are first.
 func getInterfaceAddr(globalStatus DeviceNetworkStatus, free bool,
 	phylabelOrIfname string, includeLinkLocal bool) ([]net.IP, error) {
@@ -1559,7 +1559,7 @@ func getInterfaceAddr(globalStatus DeviceNetworkStatus, free bool,
 			continue
 		}
 		if globalStatus.Version >= DPCIsMgmt &&
-			!us.IsMgmt {
+			!us.IsMgmt && ifname == "" {
 			continue
 		}
 		// If ifname is set it should match


### PR DESCRIPTION
This allows an app instance to call
    curl --interface eth0 http://169.254.169.254/eve/v1/external_ipv4 
and get the external IP address of the network instance its eth0 is attached to.

Possible to add more services; have hostname as an example, plus providing a json under eve/v1/network.json

Verified that it works from Windows (when specifying the local IP address for --interface) and from Linux app instances.
