### PR TITLE
Switch off ledmanager for GCP

### DIFF
--- a/pkg/pillar/cmd/ledmanager/ledmanager.go
+++ b/pkg/pillar/cmd/ledmanager/ledmanager.go
@@ -151,6 +151,11 @@ var mToF = []modelToFuncs{
 		// No dd disk light blinking on Parallels
 	},
 	{
+		model:  "Google.*",
+		regexp: true,
+		// No dd disk light blinking on Google
+	},
+	{
 		model:     "raspberrypi.rpi.raspberrypi,4-model-b.brcm,bcm2711",
 		initFunc:  InitLedCmd,
 		blinkFunc: ExecuteLedCmd,


### PR DESCRIPTION
Switching off Ledmanager for GCP. Anyway it does not have leds and we use gcp on Jenkins to profile the storage activity

Signed-off-by: fleandr <svfly@yandex.ru>