### PR TITLE
Provide a way to enable KVM PV features, even when kvm=off

### DIFF
--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -362,7 +362,7 @@ func newKvm() Hypervisor {
 			dmExec:       "/usr/lib/xen/bin/qemu-system-x86_64",
 			dmArgs:       []string{"-display", "none", "-S", "-no-user-config", "-nodefaults", "-no-shutdown", "-serial", "chardev:charserial0", "-no-hpet"},
 			dmCPUArgs:    []string{},
-			dmFmlCPUArgs: []string{"-cpu", "host,hv_time,hv_relaxed,hv_vendor_id=eveitis,hypervisor=off,kvm=off"},
+			dmFmlCPUArgs: []string{"-cpu", "host,hv_time,hv_relaxed,hv_vendor_id=EVEEVEEVE,kvm=off"},
 		}
 	}
 	return nil

--- a/pkg/xen-tools/patches-4.14.0/x86_64/06-kvm-spoofing.patch
+++ b/pkg/xen-tools/patches-4.14.0/x86_64/06-kvm-spoofing.patch
@@ -1,0 +1,45 @@
+diff -rc a/tools/qemu-xen/target/i386/cpu.c b/tools/qemu-xen/target/i386/cpu.c
+*** a/tools/qemu-xen/target/i386/cpu.c	Thu Jul  2 21:00:27 2020
+--- b/tools/qemu-xen/target/i386/cpu.c	Tue Dec  8 22:58:27 2020
+***************
+*** 6346,6352 ****
+          }
+      }
+  
+!     if (!kvm_enabled() || !cpu->expose_kvm) {
+          env->features[FEAT_KVM] = 0;
+      }
+  
+--- 6346,6352 ----
+          }
+      }
+  
+!     if (!kvm_enabled()) {
+          env->features[FEAT_KVM] = 0;
+      }
+  
+diff -rc a/tools/qemu-xen/target/i386/kvm.c b/tools/qemu-xen/target/i386/kvm.c
+*** a/tools/qemu-xen/target/i386/kvm.c	Thu Jul  2 21:00:27 2020
+--- b/tools/qemu-xen/target/i386/kvm.c	Tue Dec  8 22:50:03 2020
+***************
+*** 1527,1532 ****
+--- 1527,1545 ----
+          c->function = KVM_CPUID_FEATURES | kvm_base;
+          c->eax = env->features[FEAT_KVM];
+          c->edx = env->features[FEAT_KVM_HINTS];
++     } else {
++         memcpy(signature, "EVEEVEEVE\0\0\0", 12);
++         c = &cpuid_data.entries[cpuid_i++];
++         c->function = KVM_CPUID_SIGNATURE | kvm_base;
++         c->eax = KVM_CPUID_FEATURES | kvm_base;
++         c->ebx = signature[0];
++         c->ecx = signature[1];
++         c->edx = signature[2];
++ 
++         c = &cpuid_data.entries[cpuid_i++];
++         c->function = KVM_CPUID_FEATURES | kvm_base;
++         c->eax = env->features[FEAT_KVM];
++         c->edx = env->features[FEAT_KVM_HINTS];
+      }
+  
+      cpu_x86_cpuid(env, 0, 0, &limit, &unused, &unused, &unused);


### PR DESCRIPTION
- kvm=off knob disables all the KVM PV features in guest, particularly
  kvmclock, which is critical to have a decent disk performance in guest
- when kvm is ON, some guest device drivers detect KVM presence, and
  do not come up on such virtualized machines
- Therefore, provide a way where the KVM signature can be changed, but
  (with suitable modifications in guest kernel), one can still enable
  the KVM PV features, by checking for this modified signature.

Signed-off-by: Hariharasubramanian C S <cshari@zededa.com>