### PR TITLE
Enabled dmidecode based info gathering on aarch64

### DIFF
--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -129,19 +129,18 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 	}
 
 	ReportDeviceManufacturerInfo := new(info.ZInfoManufacturer)
-	if strings.Contains(machineArch, "x86") {
-		productManufacturer, productName, productVersion, productSerial, productUUID := hardware.GetDeviceManufacturerInfo(log)
-		ReportDeviceManufacturerInfo.Manufacturer = *proto.String(strings.TrimSpace(productManufacturer))
-		ReportDeviceManufacturerInfo.ProductName = *proto.String(strings.TrimSpace(productName))
-		ReportDeviceManufacturerInfo.Version = *proto.String(strings.TrimSpace(productVersion))
-		ReportDeviceManufacturerInfo.SerialNumber = *proto.String(strings.TrimSpace(productSerial))
-		ReportDeviceManufacturerInfo.UUID = *proto.String(strings.TrimSpace(productUUID))
+	productManufacturer, productName, productVersion, productSerial, productUUID := hardware.GetDeviceManufacturerInfo(log)
+	ReportDeviceManufacturerInfo.Manufacturer = *proto.String(strings.TrimSpace(productManufacturer))
+	ReportDeviceManufacturerInfo.ProductName = *proto.String(strings.TrimSpace(productName))
+	ReportDeviceManufacturerInfo.Version = *proto.String(strings.TrimSpace(productVersion))
+	ReportDeviceManufacturerInfo.SerialNumber = *proto.String(strings.TrimSpace(productSerial))
+	ReportDeviceManufacturerInfo.UUID = *proto.String(strings.TrimSpace(productUUID))
 
-		biosVendor, biosVersion, biosReleaseDate := hardware.GetDeviceBios(log)
-		ReportDeviceManufacturerInfo.BiosVendor = *proto.String(strings.TrimSpace(biosVendor))
-		ReportDeviceManufacturerInfo.BiosVersion = *proto.String(strings.TrimSpace(biosVersion))
-		ReportDeviceManufacturerInfo.BiosReleaseDate = *proto.String(strings.TrimSpace(biosReleaseDate))
-	}
+	biosVendor, biosVersion, biosReleaseDate := hardware.GetDeviceBios(log)
+	ReportDeviceManufacturerInfo.BiosVendor = *proto.String(strings.TrimSpace(biosVendor))
+	ReportDeviceManufacturerInfo.BiosVersion = *proto.String(strings.TrimSpace(biosVersion))
+	ReportDeviceManufacturerInfo.BiosReleaseDate = *proto.String(strings.TrimSpace(biosReleaseDate))
+
 	compatible := hardware.GetCompatible(log)
 	ReportDeviceManufacturerInfo.Compatible = *proto.String(compatible)
 	ReportDeviceInfo.Minfo = ReportDeviceManufacturerInfo


### PR DESCRIPTION
Trivial fix that enables dmidecode-base inquiries on aarch64. This is now possible because of how we build image for RPi4 and seems to be harmless on other types of aarch64 boards.