### PR TITLE
Enter maintenance mode on /persist/vault lockout

### DIFF
--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -95,6 +95,8 @@ type nodeagentContext struct {
 	rebootTime                  time.Time        // From last reboot
 	restartCounter              uint32
 	vaultOperational            bool
+	maintMode                   bool                        // whether Maintenance mode should be triggered
+	maintModeReason             types.MaintenanceModeReason //reason for entering Maintenance mode
 
 	// Some contants.. Declared here as variables to enable unit tests
 	minRebootDelay          uint32
@@ -599,17 +601,19 @@ func publishNodeAgentStatus(ctxPtr *nodeagentContext) {
 	pub := ctxPtr.pubNodeAgentStatus
 	ctxPtr.lastLock.Lock()
 	status := types.NodeAgentStatus{
-		Name:              agentName,
-		CurPart:           ctxPtr.curPart,
-		RemainingTestTime: ctxPtr.remainingTestTime,
-		UpdateInprogress:  ctxPtr.updateInprogress,
-		DeviceReboot:      ctxPtr.deviceReboot,
-		RebootReason:      ctxPtr.rebootReason,
-		BootReason:        ctxPtr.bootReason,
-		RebootStack:       ctxPtr.rebootStack,
-		RebootTime:        ctxPtr.rebootTime,
-		RebootImage:       ctxPtr.rebootImage,
-		RestartCounter:    ctxPtr.restartCounter,
+		Name:                       agentName,
+		CurPart:                    ctxPtr.curPart,
+		RemainingTestTime:          ctxPtr.remainingTestTime,
+		UpdateInprogress:           ctxPtr.updateInprogress,
+		DeviceReboot:               ctxPtr.deviceReboot,
+		RebootReason:               ctxPtr.rebootReason,
+		BootReason:                 ctxPtr.bootReason,
+		RebootStack:                ctxPtr.rebootStack,
+		RebootTime:                 ctxPtr.rebootTime,
+		RebootImage:                ctxPtr.rebootImage,
+		RestartCounter:             ctxPtr.restartCounter,
+		LocalMaintenanceMode:       ctxPtr.maintMode,
+		LocalMaintenanceModeReason: ctxPtr.maintModeReason,
 	}
 	ctxPtr.lastLock.Unlock()
 	pub.Publish(agentName, status)

--- a/pkg/pillar/types/zedagenttypes.go
+++ b/pkg/pillar/types/zedagenttypes.go
@@ -382,19 +382,43 @@ func BootReasonFromString(str string) BootReason {
 	}
 }
 
+// MaintenanceModeReason captures reason for entering into maintenance mode
+type MaintenanceModeReason uint8
+
+// MaintenanceModeReason codes for storing reason for getting into maintenance mode
+const (
+	MaintenanceModeReasonNone MaintenanceModeReason = iota
+	MaintenanceModeReasonUserRequested
+	MaintenanceModeReasonVaultLockedUp
+)
+
+// String returns the verbose equivalent of MaintenanceModeReason code
+func (mmr MaintenanceModeReason) String() string {
+	switch mmr {
+	case MaintenanceModeReasonNone:
+		return "MaintenanceModeReasonNone"
+	case MaintenanceModeReasonVaultLockedUp:
+		return "MaintenanceModeReasonVaultLockedUp"
+	default:
+		return fmt.Sprintf("Unknown MaintenanceModeReason %d", mmr)
+	}
+}
+
 // NodeAgentStatus :
 type NodeAgentStatus struct {
-	Name              string
-	CurPart           string
-	UpdateInprogress  bool
-	RemainingTestTime time.Duration
-	DeviceReboot      bool
-	RebootReason      string     // From last reboot
-	BootReason        BootReason // From last reboot
-	RebootStack       string     // From last reboot
-	RebootTime        time.Time  // From last reboot
-	RestartCounter    uint32
-	RebootImage       string
+	Name                       string
+	CurPart                    string
+	UpdateInprogress           bool
+	RemainingTestTime          time.Duration
+	DeviceReboot               bool
+	RebootReason               string     // From last reboot
+	BootReason                 BootReason // From last reboot
+	RebootStack                string     // From last reboot
+	RebootTime                 time.Time  // From last reboot
+	RestartCounter             uint32
+	RebootImage                string
+	LocalMaintenanceMode       bool                  //enter Maintenance Mode
+	LocalMaintenanceModeReason MaintenanceModeReason //reason for Maintenance Mode
 }
 
 // Key :


### PR DESCRIPTION
- Currently nodeagent triggeres a system reboot if vault is not
  unlocked by a cut-off time
- Instead of entering a reboot cycle, trigger the sytem to go to
  maintenance mode, on such conditions.
- To recover from the maintenance mode, device needs to pass remote attestation, followed by user reboot of the device. 
Signed-off-by: Hariharasubramanian C S <cshari@zededa.com>