### PR TITLE
Do not strip additional key/value pairs from object logging messages

### DIFF
--- a/pkg/newlog/cmd/newlogd.go
+++ b/pkg/newlog/cmd/newlogd.go
@@ -551,6 +551,7 @@ func getMemlogMsg(logChan chan inputEntry, panicFileChan chan []byte) {
 			logmetrics.AppMetrics.NumInputEvent++
 			isApp = true
 		} else {
+			logInfo.Msg = origMsg
 			logmetrics.DevMetrics.NumInputEvent++
 		}
 		if !ok {


### PR DESCRIPTION
Signed-off-by: Gopi krishna Kodali <gkodali@zededa.com>