### PR TITLE
fix a missing enum while converting MaintenanceReason to String

### DIFF
--- a/pkg/pillar/types/zedagenttypes.go
+++ b/pkg/pillar/types/zedagenttypes.go
@@ -397,6 +397,8 @@ func (mmr MaintenanceModeReason) String() string {
 	switch mmr {
 	case MaintenanceModeReasonNone:
 		return "MaintenanceModeReasonNone"
+	case MaintenanceModeReasonUserRequested:
+		return "MaintenanceModeReasonUserRequested"
 	case MaintenanceModeReasonVaultLockedUp:
 		return "MaintenanceModeReasonVaultLockedUp"
 	default:


### PR DESCRIPTION
Signed-off-by: Hariharasubramanian C S <cshari@zededa.com>