### PR TITLE
Misc. fixes for Xen domain and task sync issues

### DIFF
--- a/pkg/debug/build.yml
+++ b/pkg/debug/build.yml
@@ -21,6 +21,7 @@ config:
     - /etc/profile.d:/etc/profile.d
     - /run:/root/.ssh
     - /bin/eve:/bin/eve
+    - /usr/bin/logread:/usr/bin/logread
     - /usr/bin/ctr:/usr/bin/ctr
     - /usr/bin/runc:/usr/bin/runc
     - /var/log:/var/log

--- a/pkg/xen-tools/Dockerfile.in
+++ b/pkg/xen-tools/Dockerfile.in
@@ -8,9 +8,10 @@ RUN rm -f /sbin/poweroff /etc/mkinitfs/features.d/base.files
 COPY initrd/base.files /etc/mkinitfs/features.d/base.files
 COPY initrd/init-initrd initrd/mount_disk.sh initrd/udhcpc_script.sh /
 COPY initrd/poweroff /sbin/poweroff
-COPY initrd/chroot2.c /tmp/
+COPY initrd/chroot2.c initrd/hacf.c /tmp/
 COPY initrd/00000080 /etc/acpi/PWRF/
 RUN gcc -s -o /chroot2 /tmp/chroot2.c
+RUN gcc -s -o /hacf /tmp/hacf.c
 RUN mkinitfs -n -F base -i /init-initrd -o /runx-initrd
 
 FROM alpine:3.8 as kernel-build

--- a/pkg/xen-tools/initrd/base.files
+++ b/pkg/xen-tools/initrd/base.files
@@ -7,6 +7,7 @@
 /etc/modprobe.d/*.conf
 /etc/mdev.conf
 /chroot2
+/hacf
 /mount_disk.sh
 /udhcpc_script.sh
 /mnt

--- a/pkg/xen-tools/initrd/hacf.c
+++ b/pkg/xen-tools/initrd/hacf.c
@@ -1,0 +1,7 @@
+#include <unistd.h>
+#include <sys/reboot.h>
+
+int main() {
+    reboot(RB_POWER_OFF); /* AKA LINUX_REBOOT_CMD_POWER_OFF AKA 0x4321fedc */
+    return 0; /* this can never happen */
+}

--- a/pkg/xen-tools/initrd/init-initrd
+++ b/pkg/xen-tools/initrd/init-initrd
@@ -103,3 +103,6 @@ cmd=`cat /mnt/cmdline`
 echo "Executing $cmd"
 #shellcheck disable=SC2086
 eval /chroot2 /mnt/rootfs "${WORKDIR:-/}" $cmd <> /dev/console 2>&1
+
+# once the command exits -- the only thing left is shut everything down
+/sbin/poweroff

--- a/pkg/xen-tools/initrd/poweroff
+++ b/pkg/xen-tools/initrd/poweroff
@@ -1,24 +1,24 @@
 #!/bin/sh
 
+killit() {
+  for p in [0-9]*; do
+    # shellcheck disable=SC2086
+    [ "$p" -ne 1 ] && [ "$p" -ne "$$" ] && kill $1 "$p"
+  done
+}
+
 # when the earth is on the move, the safest place to be is /proc
-cd /proc || kill -9 1
+cd /proc || /hacf
 
 # first, try an oderly shutdown of processes
-for p in [0-9]*; do
-   [ "$p" -eq "$$" ] && continue
-   kill "$p"
-done
-
-sleep 60
-
+killit
+# grace period
+sleep 30
 # now go for an actual kill
-for p in [0-9]*; do
-   [ "$p" -eq 1 ] || [ "$p" -eq "$$" ] && continue
-   kill -9 "$p"
-done
-
+killit -9
 # unmount all disks
 /bin/umount -a -r
-
-# and finally kill the "init"
-kill -9 1
+# shutdown the system
+/hacf
+# this should never happen
+sleep 10

--- a/pkg/xen-tools/xen-info
+++ b/pkg/xen-tools/xen-info
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+DEV_PREFIX=/mnt/rootfs/dev/eve
+SC="$DEV_PREFIX/unknownStateCounter"
+STATUS="$DEV_PREFIX/status"
+
 UnknownStateThreshold=10
 bail() {
    echo "$@"
@@ -8,65 +12,63 @@ bail() {
 
 handleUnknownState() {
   # checking if we have unknownStateCounter, if not initializing it.
-  if [ ! -e /dev/unknownStateCounter ]; then
-    echo 0 > /dev/unknownStateCounter
+  if [ ! -e "$SC" ]; then
+    echo 0 > "$SC"
   fi
 
-  unknownStateCounter=$(cat /dev/unknownStateCounter)
+  unknownStateCounter=$(cat "$SC")
 
   if [ "$unknownStateCounter" -ge "$UnknownStateThreshold" ]; then
     # Number of times we got unknown state is > UnknownStateThreshold, so declaring the state as broken
-    echo broken > /dev/status
+    echo broken > "$STATUS"
   else
     # Number of times we got unknown state is <= UnknownStateThreshold, so declaring the state as running
-    echo running > /dev/status
+    echo running > "$STATUS"
   fi
 
   unknownStateCounter=$((unknownStateCounter + 1))
-  echo $unknownStateCounter > /dev/unknownStateCounter
+  echo $unknownStateCounter > "$SC"
 }
 
 handleKnownState() {
   # resetting unknownStateCounter
-  echo 0 > /dev/unknownStateCounter
-  echo "$1" > /dev/status
+  echo 0 > "$SC"
+  echo "$1" > "$STATUS"
 
   # an additional check we do for running domains is to make sure device model is still around
   if [ "$1" = running ] &&
-     DM_PID=$(xenstore read "/local/domain/$ID/image/device-model-pid") &&
+     DM_PID=$(xenstore read "/local/domain/$ID/image/device-model-pid" 2>/dev/null) &&
      ! (readlink "/proc/$DM_PID/exe" | grep -q qemu-system-); then
-     echo broken > /dev/status
+     echo broken > "$STATUS"
   fi
 }
 
 # pre-flight checks
 [ $# -ne 1 ] && bail "Usage: $0 <domain name>"
+mkdir -p "$DEV_PREFIX" 2>/dev/null || :
 
 # find the domain
 # Sometimes after EVE reboot, we called xen-info before xen-start finished executing,
 # which led to domian not found error. To prevent that, we wait for sometime for the domain to come up.
-waited=0
-ID=$(xl domid "$1" 2>/dev/null)
-while [ -z "$ID" ] && [ "$waited" -lt 60 ]; do
-        ID=$(xl domid "$1" 2>/dev/null)
-        if [ -z "$ID" ]; then
-          sleep 3
-          waited=$((waited + 3))
-        fi
+# shellcheck disable=SC2034
+for _ in 1 2 3; do
+  ID=$(xl domid "$1" 2>/dev/null)
+  [ -z "$ID" ] || break
+  sleep 3
 done
-[ -z "$ID" ] && bail "Couldn't find domain ID for domain $1"
 
 # we expect to get rbpscd where every letter can also be a dash (-)
 # Name    ID    Mem    VCPUs    State    Time(s)
-case $(xl list "$ID" | awk '{st=$5;} END {print st;}') in
-   *d) handleKnownState halting ;;
-  *c*) handleKnownState broken  ;;
-  *s*) handleKnownState halting ;;
-  *p*) handleKnownState paused  ;;
-  *b*) handleKnownState running ;;
-   r*) handleKnownState running ;;
-    *) handleUnknownState ;;
+case $(xl list "${ID:- }" 2>/dev/null | awk '{st=$5;} END {print st;}') in
+   *c*) handleKnownState broken  ;;
+    *d) handleKnownState halting ;;
+   *s*) handleKnownState halting ;;
+   *p*) handleKnownState paused  ;;
+   *b*) handleKnownState running ;;
+    r*) handleKnownState running ;;
+------) handleUnknownState ;;
+     *) handleKnownState broken  ;;
 esac
 
 # finally print the current status
-cat /dev/status
+cat "$STATUS"

--- a/pkg/xen-tools/xen-start
+++ b/pkg/xen-tools/xen-start
@@ -8,17 +8,13 @@ bail() {
 domID() {
    # we may need to wait for domain to come online for us to manipulate it (timing out in under 30 sec)
    # shellcheck disable=SC2034
-   for i in 1 2 3; do
+   for _ in 1 2 3; do
      ID=$(xl domid "$1")
      sleep 8
      [ -z "$ID" ] || break
    done >/dev/null 2>&1
 
-   if [ -z "$ID" ]; then
-      bail "Couldn't find domain $1"
-   else
-      echo "$ID"
-   fi
+   echo "$ID"
 }
 
 # pre-flight checks
@@ -49,16 +45,16 @@ xl unpause "$ID" || bail "xl unpause failed"
 
 # now star polling for domain status (11 sec interval) in the background
 # (note our use of mv to make sure file reads on the other side are atomic)
-echo 0 > /dev/unknownStateCounter
 (while true; do
    sleep 11
    /etc/xen/scripts/xen-info "$1" > "/run/tasks/$1.tmp"
    mv "/run/tasks/$1.tmp" "/run/tasks/$1"
 done) &
 
-# and start watching over the console (note that we loop forever
-# in anticipation of potential domain reboots)
+# and start watching over the console: note that we loop forever
+# in anticipation of potential domain reboots - we rely on xen-info
+# to declare domain broken if it can't be found for a long time
 while true; do
-   ID=$(domID "$1")
-   xl console "$ID" < /dev/null
+   xl console "$1" < /dev/null
+   sleep 5
 done


### PR DESCRIPTION
There's been a few issues with our tasks and Xen domains implementation that conspired to make sure the two get out of sync from time to time:
   * broken domains not reaped because error code isn't set
   * tasks not deleted because previous error codes would make the Delete() bail out mid-way
   * `/dev/status` ended up on a shared filesystem and got clobbered if more than two domains were running
   * general robustness of `xen-start` and `xen-info`
   * container domains violently dying with kernel panic on account of init(1) getting killed

Hopefully with these fixes in, general stability of Xen (and in particular Xen domain wrapped containers) will improve quite a bit and will allow us to re-enable some of the tests.