### PR TITLE
Add --rm to clean up containers after docker run

### DIFF
--- a/tools/makeconfig.sh
+++ b/tools/makeconfig.sh
@@ -17,7 +17,7 @@ fi
 shift 2
 
 : > "$IMAGE"
-(tar -chf - "$@") | docker run -i -e ROOTFS_VERSION="$ROOTFS_VERSION" -e ZARCH="$ZARCH" -v "$IMAGE:/config.img" "${MKCONFIG_TAG}" /config.img
+(tar -chf - "$@") | docker run -i --rm -e ROOTFS_VERSION="$ROOTFS_VERSION" -e ZARCH="$ZARCH" -v "$IMAGE:/config.img" "${MKCONFIG_TAG}" /config.img
 
 if [ ! -s "$IMAGE" ]; then
    echo "$IMAGE was not written."

--- a/tools/makeflash.sh
+++ b/tools/makeflash.sh
@@ -20,4 +20,4 @@ SOURCE="$(cd "$1" && pwd)"
 IMAGE="$(cd "$(dirname "$2")" && pwd)/$(basename "$2")"
 shift 2
 
-docker run -v "$SOURCE:/parts" -v "$IMAGE:/output.img" "$MKFLASH_TAG" /output.img "$@"
+docker run --rm -v "$SOURCE:/parts" -v "$IMAGE:/output.img" "$MKFLASH_TAG" /output.img "$@"

--- a/tools/makeiso.sh
+++ b/tools/makeiso.sh
@@ -11,4 +11,4 @@ if [ ! -d "$SOURCE" ] || [ $# -ne 2 ]; then
 fi
 
 : > "$ISO"
-docker run -v "$SOURCE:/bits" -v "$ISO:/output.iso" "$MKIMAGE_TAG"
+docker run --rm -v "$SOURCE:/bits" -v "$ISO:/output.iso" "$MKIMAGE_TAG"

--- a/tools/makerootfs.sh
+++ b/tools/makerootfs.sh
@@ -18,4 +18,4 @@ if [ ! -f "$YMLFILE" ] || [ $# -lt 2 ]; then
 fi
 
 : > "$IMAGE"
-linuxkit build -o - "$YMLFILE" | docker run -i -v /dev:/dev --privileged -v "$IMAGE:/rootfs.img" "${MKROOTFS_TAG}"
+linuxkit build -o - "$YMLFILE" | docker run -i --rm -v /dev:/dev --privileged -v "$IMAGE:/rootfs.img" "${MKROOTFS_TAG}"

--- a/tools/makeusbconf.sh
+++ b/tools/makeusbconf.sh
@@ -71,5 +71,5 @@ else
    IMAGE_BIND_OPT="-v"
 fi
 
-(cd "$TMPDIR" || exit 1; tar cf - ./*) | docker run -i "$IMAGE_BIND_OPT" "$IMAGE:/output.img" "${MKFLASH_TAG}" /output.img usb_conf
+(cd "$TMPDIR" || exit 1; tar cf - ./*) | docker run -i --rm "$IMAGE_BIND_OPT" "$IMAGE:/output.img" "${MKFLASH_TAG}" /output.img usb_conf
 cleanup


### PR DESCRIPTION
"make live" left 2 containers every time.
For old images:
docker container ls --all
docker container prune

Signed-off-by: Daniel P. Kionka <dkionka@github.com>