### PR TITLE
optimize sizes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -553,6 +553,7 @@ $(ROOTFS_FULL_NAME)-kvm-adam-$(ZARCH).$(ROOTFS_FORMAT): images/rootfs-%.yml $(SS
 	./tools/makerootfs.sh $< $@ $(ROOTFS_FORMAT)
 $(ROOTFS_FULL_NAME)-%-$(ZARCH).$(ROOTFS_FORMAT): images/rootfs-%.yml | $(INSTALLER)
 	./tools/makerootfs.sh $< $@ $(ROOTFS_FORMAT)
+	@echo "size of $@ is $$(wc -c < "$@")B"
 	@[ $$(wc -c < "$@") -gt $$(( 250 * 1024 * 1024 )) ] && \
           echo "ERROR: size of $@ is greater than 250MB (bigger than allocated partition)" && exit 1 || :
 

--- a/pkg/newlog/Dockerfile
+++ b/pkg/newlog/Dockerfile
@@ -1,10 +1,10 @@
-ARG GOVER=1.12.4
+ARG GOVER=1.15.3
 FROM golang:${GOVER}-alpine as build
 RUN apk add --no-cache   \
-        libc-dev=0.7.1-r0\
-        git=2.20.4-r0    \
-        gcc=8.3.0-r0     \
-        linux-headers=4.18.13-r1
+        libc-dev=0.7.2-r3\
+        git=2.26.2-r0    \
+        gcc=9.3.0-r2     \
+        linux-headers=5.4.5-r1
 
 COPY ./  /newlog/.
 WORKDIR /newlog

--- a/pkg/pillar/Makefile
+++ b/pkg/pillar/Makefile
@@ -35,7 +35,7 @@ build: $(APPS) $(APPS1)
 $(APPS): $(DISTDIR)/$(APPS)
 $(DISTDIR)/$(APPS): $(DISTDIR)
 	@echo "Building $@"
-	GO111MODULE=on GOOS=linux CGO_ENABLED=0 go build -mod=vendor -ldflags -X=main.Version=$(BUILD_VERSION) -o $@ ./$(@F)
+	GO111MODULE=on GOOS=linux CGO_ENABLED=0 go build -mod=vendor -ldflags "-s -w -X=main.Version=$(BUILD_VERSION)" -o $@ ./$(@F)
 
 $(APPS1): $(DISTDIR)
 	@echo $@


### PR DESCRIPTION
It reduces size of rootfs from 248MB to 237MB.
part of #1768 

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>