### PR TITLE
Assign default status if reading /run/tasks/<domain> fails

### DIFF
--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -465,6 +465,7 @@ func (ctx xenContext) Info(domainName string, domainID int) (int, types.SwState,
 	status, err := ioutil.ReadFile("/run/tasks/" + domainName)
 	if err != nil {
 		logrus.Errorf("couldn't read task status file: %v", err)
+		status = []byte("running") // assigning default state as we weren't able to read status file
 	}
 	logrus.Debugf("task %s has status %v\n", domainName, status)
 


### PR DESCRIPTION
While activating app instance, we sometimes try to read `/run/tasks/<domain>` file before it's created which leads to `reported to be in unexpected state` error. 
To avoid that, assigning `running` as default status if `/run/tasks/<domain>`  is not found. 
Relevant logs: https://zedcloud-logs.alpha.priv.zededa.net:5601/goto/69c36892d8f8e31a0be939f113f5181c

Signed-off-by: adarsh-zededa <adarsh@zededa.com>