### PR TITLE
Migrating to UUID as task handles

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -982,15 +982,13 @@ func handleCreate(ctx *domainContext, key string, config *types.DomainConfig) {
 	log.Functionf("handleCreate(%v) for %s",
 		config.UUIDandVersion, config.DisplayName)
 	log.Tracef("DomainConfig %+v", config)
-	// Name of Xen domain must be unique; uniqify AppNum
-	name := config.DisplayName + "." + strconv.Itoa(config.AppNum)
 
 	// Start by marking with PendingAdd
 	status := types.DomainStatus{
 		UUIDandVersion:     config.UUIDandVersion,
 		PendingAdd:         true,
 		DisplayName:        config.DisplayName,
-		DomainName:         name,
+		DomainName:         config.GetTaskName(),
 		AppNum:             config.AppNum,
 		VifList:            config.VifList,
 		VirtualizationMode: config.VirtualizationModeOrDefault(),
@@ -1599,10 +1597,9 @@ func handleModify(ctx *domainContext, key string,
 	if config.Activate && !status.Activated {
 		log.Functionf("handleModify(%v) activating for %s",
 			config.UUIDandVersion, config.DisplayName)
-		// AppNum could have changed if we did not already Activate
-		name := config.DisplayName + "." + strconv.Itoa(config.AppNum)
-		if status.DomainName != name {
-			status.DomainName = name
+
+		if status.DomainName != config.GetTaskName() {
+			status.DomainName = config.GetTaskName()
 			status.AppNum = config.AppNum
 			log.Functionf("handleModify(%v) set domainName %s for %s",
 				config.UUIDandVersion, status.DomainName,

--- a/pkg/pillar/containerd/oci.go
+++ b/pkg/pillar/containerd/oci.go
@@ -284,7 +284,7 @@ func (s *ociSpec) UpdateFromDomain(dom *types.DomainConfig) {
 		s.Linux.Resources.CPU.Period = &p
 		s.Linux.Resources.CPU.Quota = &q
 
-		s.Linux.CgroupsPath = fmt.Sprintf("/%s/%s", ctrdServicesNamespace, dom.DisplayName)
+		s.Linux.CgroupsPath = fmt.Sprintf("/%s/%s", ctrdServicesNamespace, dom.GetTaskName())
 	}
 	s.Annotations[EVEOCIVNCPasswordLabel] = dom.VncPasswd
 }

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -4,7 +4,11 @@
 package types
 
 import (
+	"fmt"
+	uuid "github.com/satori/go.uuid"
 	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -48,6 +52,29 @@ func (config DomainConfig) GetOCIConfigDir() string {
 		return config.DiskConfigList[0].FileLocation
 	} else {
 		return ""
+	}
+}
+
+// GetTaskName assigns a unique name to the task representing this domain
+// FIXME: given config.UUIDandVersion.Version part not sure config.AppNum is needed for uniqueness
+func (config DomainConfig) GetTaskName() string {
+	return config.UUIDandVersion.UUID.String() + "." +
+		config.UUIDandVersion.Version + "." +
+		strconv.Itoa(config.AppNum)
+}
+
+// DomainnameToUUID does the reverse of GetTaskName
+func DomainnameToUUID(name string) (uuid.UUID, error) {
+	// FIXME: we can likely drop this altogether
+	if name == "Domain-0" {
+		return uuid.UUID{}, nil
+	}
+
+	res := strings.Split(name, ".")
+	if len(res) == 3 {
+		return uuid.FromString(res[0])
+	} else {
+		return uuid.UUID{}, fmt.Errorf("Unknown domainname %s", name)
 	}
 }
 


### PR DESCRIPTION
This is both a clean up but also unblocking us to have domains that controller can name with characters unpalatable to containerd (and much longer).

Don't worry about missing DisplayName when debugging locally on EVE itself -- I'm working on one more refactoring that would allow for all that information to be retrieved using `eve(1)` cli.

That'll come a bit later in the week.