### PR TITLE
exclude /run directory from mounts

### DIFF
--- a/pkg/pillar/containerd/oci.go
+++ b/pkg/pillar/containerd/oci.go
@@ -167,6 +167,10 @@ func (s *ociSpec) AddLoader(volume string) error {
 			Options:     []string{"rbind", "rw"}})
 	}
 	for _, mount := range s.Mounts {
+		// /run in docker image contains information during building so we must skip it from mounting
+		if mount.Destination == "/run" {
+			continue
+		}
 		mount.Destination = "/mnt/rootfs" + mount.Destination
 		spec.Mounts = append(spec.Mounts, mount)
 	}


### PR DESCRIPTION
I am facing  launch problems with mariadb `Can't start server : Bind on unix socket: No such file or directory` and sshd `Missing privilege separation directory: /run/sshd`.
Seems, that docker image contains directories inside `/run`, so we need to exclude it from mount.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>