### PR TITLE
increase dd block size

### DIFF
--- a/pkg/eve/Dockerfile.in
+++ b/pkg/eve/Dockerfile.in
@@ -1,6 +1,6 @@
 FROM alpine:3.12 as tools
 RUN mkdir -p /out/etc/apk /out/boot && cp -r /etc/apk/* /out/etc/apk/
-RUN apk add --no-cache --initdb -p /out qemu-img=5.0.0-r2 tar=1.32-r1 uboot-tools=2020.04-r0
+RUN apk add --no-cache --initdb -p /out qemu-img=5.0.0-r2 tar=1.32-r1 uboot-tools=2020.04-r0 coreutils=8.32-r0
 # hadolint ignore=DL3006
 FROM MKISO_TAG as iso
 # hadolint ignore=DL3006

--- a/pkg/mkimage-raw-efi/Dockerfile
+++ b/pkg/mkimage-raw-efi/Dockerfile
@@ -49,7 +49,7 @@ COPY --from=build /out/ /
 COPY --from=initrd /initrd.gz /
 COPY grub.stage1 /usr/lib/grub/i386-pc/boot.img
 RUN gzip -d < /initrd.gz | cpio -id && \
-    rm /etc/mtab /dev/null && \
+    rm -f /etc/mtab /dev/null && \
     find . -xdev | grep -v initrd.gz | sort | cpio --quiet -o -H newc | gzip > /initrd.gz && \
     mv /initrd.gz /initrd.img
 

--- a/pkg/mkimage-raw-efi/make-raw
+++ b/pkg/mkimage-raw-efi/make-raw
@@ -126,7 +126,7 @@ do_system_vfat_part() {
          --attributes "$NUM_PART:set:2" "$IMGFILE"
 
   #   ...copy EFI fs to EFI partition
-  dd if="$(dir2vfat /efifs $(( (SEC_END - SEC_START) / 2)))" of="$IMGFILE" bs=512 conv=notrunc seek="$SEC_START"
+  dd if="$(dir2vfat /efifs $(( (SEC_END - SEC_START) / 2)))" of="$IMGFILE" bs=1M conv=notrunc seek="$(( SEC_START * 512 ))" oflag=seek_bytes
 
   eval "$1=$((SEC_END + 1))"
 }
@@ -165,7 +165,7 @@ do_rootfs() {
            --change-name="$NUM_PART:$LABEL" $EXTRA_ATTR "$IMGFILE"
 
     # Copy rootfs to image A
-    dd if=$IMG of=$IMGFILE bs=512 conv=notrunc seek=$SEC_START
+    dd if=$IMG of=$IMGFILE bs=1M conv=notrunc seek="$(( SEC_START * 512 ))" oflag=seek_bytes
 
     eval $1=$(( $SEC_END + 1))
 }
@@ -189,13 +189,13 @@ do_vfat() {
            --typecode=$NUM_PART:$PART_TYPE \
 	   --change-name=$NUM_PART:'CONFIG' $IMGFILE
 
-    dd if=$CONF_FILE of=$IMGFILE bs=512 conv=notrunc seek=$SEC_START
+    dd if=$CONF_FILE of=$IMGFILE bs=1M conv=notrunc seek="$(( SEC_START * 512 ))" oflag=seek_bytes
 
     eval $1=$(( $SEC_END + 1))
 }
 
 do_conf() {
-    do_vfat $1 13307e62-cd9c-4920-8f9b-91b45828b798 
+    do_vfat $1 13307e62-cd9c-4920-8f9b-91b45828b798
 }
 
 do_conf_win() {
@@ -214,7 +214,7 @@ do_inventory_win() {
            --change-name="$NUM_PART:INVENTORY" "$IMGFILE"
 
     # shellcheck disable=SC2046
-    dd if=$(dir2vfat $(mktemp -d) $(( (SEC_END - SEC_START) / 2)) INVENTORY) of="$IMGFILE" bs=512 conv=notrunc seek="$SEC_START"
+    dd if=$(dir2vfat $(mktemp -d) $(( (SEC_END - SEC_START) / 2)) INVENTORY) of="$IMGFILE" bs=1M conv=notrunc seek="$(( SEC_START * 512 ))" oflag=seek_bytes
 
     eval "$1=$(( SEC_END + 1))"
 }
@@ -231,7 +231,7 @@ do_persist() {
            --typecode=$NUM_PART:5f24425a-2dfa-11e8-a270-7b663faccc2c \
            --change-name=$NUM_PART:'P3' $IMGFILE
 
-    dd if="$PERSIST_FILE" of="$IMGFILE" bs=512 conv=notrunc seek="$SEC_START"
+    dd if="$PERSIST_FILE" of="$IMGFILE" bs=1M conv=notrunc seek="$(( SEC_START * 512 ))" oflag=seek_bytes
     
     eval $1=0
 }


### PR DESCRIPTION
Increase the block size to reduce the time it takes to create an image.
On my mac
before: `make live  10.90s user 10.36s system 6% cpu 5:18.51 total`
after: `make live  10.87s user 10.21s system 28% cpu 1:12.93 total`


Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>