### PR TITLE
Fixes for Xen

### DIFF
--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -98,7 +98,7 @@ func (ctx xenContext) CreateDomConfig(domainName string, config types.DomainConf
 	aa *types.AssignableAdapters, file *os.File) error {
 	xen_type := "pvh"
 	rootDev := ""
-	extra := ""
+	extra := config.ExtraArgs
 	bootLoader := ""
 	kernel := config.Kernel
 	ramdisk := config.Ramdisk


### PR DESCRIPTION
`extra` field inside config of xen Domain must be filled for container-in-VM, so we need to use ExtraArgs by default, not only for PV type.
We need to mount `/mnt/rootfs/dev/eve` to properly work of `xen-info` command in case of VM.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>