### PR TITLE
Makefile: add V=1 for verbose, improve readability

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,17 +17,17 @@ jobs:
         env:
           PR_ID: ${{ github.event.pull_request.number  }}
         run: |
-          make pkgs
+          make V=1 pkgs
           COMMIT_ID=$(git describe --abbrev=8 --always)
           echo "VERSION=0.0.0-pr$PR_ID-$COMMIT_ID" >> $GITHUB_ENV
           echo "TAG=evebuild/danger:pr$PR_ID" >> $GITHUB_ENV
       - name: Build EVE
         run: |
-          make ROOTFS_VERSION="$VERSION" eve
+          make V=1 ROOTFS_VERSION="$VERSION" eve
       - name: Build EVE for KVM
         run: |
           rm -rf dist
-          make ROOTFS_VERSION="$VERSION" HV=kvm eve
+          make V=1 ROOTFS_VERSION="$VERSION" HV=kvm eve
       - name: Export docker container
         run: |
           for i in xen kvm; do

--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -23,8 +23,8 @@ jobs:
       - name: build eden
         run: |
           make clean
-          make build
-          make build-tests
+          make V=1 build
+          make V=1 build-tests
       - name: get eve
         uses: actions/checkout@v2
         with:
@@ -38,8 +38,8 @@ jobs:
              docker tag  "$CACHE:$TAG-kvm" "lfedge/eve:$TAG-kvm"
              docker tag  "$CACHE:$TAG-kvm" "lfedge/eve:$TAG-kvm-amd64"
           else
-             make -C eve pkgs
-             make -C eve ROOTFS_VERSION="$TAG" HV=kvm eve
+             make -C eve V=1 pkgs
+             make -C eve V=1 ROOTFS_VERSION="$TAG" HV=kvm eve
           fi
           echo "TAG=$TAG" >> $GITHUB_ENV
       - name: run

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,7 @@ jobs:
           # sadly, our build sometimes times out on network access
           # and running out of disk space: re-trying for 3 times
           for i in 1 2 3; do
-             if make LINUXKIT_PKG_TARGET=push pkgs; then
+             if make V=1 LINUXKIT_PKG_TARGET=push pkgs; then
                 break
              else
                 # the most likely reason for 'make pkgs' to fail is
@@ -58,12 +58,12 @@ jobs:
         # build #1 without push (do not push either unless both can build)
         run: |
           rm -rf dist dist.xen
-          make eve
+          make V=1 eve
           mv -f dist dist.xen
       - name: Build and push EVE for KVM
         # since build #1 works, build and push #2
         run: |
-          make LINUXKIT_PKG_TARGET=push HV=kvm eve
+          make V=1 LINUXKIT_PKG_TARGET=push HV=kvm eve
           if [ "${{ env.TAG }}" = snapshot ]; then
              docker tag lfedge/eve:snapshot-${{ env.ARCH }} lfedge/eve:snapshot-kvm-${{ env.ARCH }}
              docker push lfedge/eve:snapshot-kvm-${{ env.ARCH }}
@@ -73,7 +73,7 @@ jobs:
         run: |
           rm -rf dist
           mv -f dist.xen dist
-          make LINUXKIT_PKG_TARGET=push eve
+          make V=1 LINUXKIT_PKG_TARGET=push eve
           if [ "${{ env.TAG }}" = snapshot ]; then
              docker tag lfedge/eve:snapshot-${{ env.ARCH }} lfedge/eve:snapshot-xen-${{ env.ARCH }}
              docker push lfedge/eve:snapshot-xen-${{ env.ARCH }}

--- a/Makefile
+++ b/Makefile
@@ -188,8 +188,18 @@ ifneq ($(ALL_PROXY),)
 DOCKER_ALL_PROXY:=--build-arg all_proxy=$(ALL_PROXY)
 endif
 
+# use "make V=1" for verbose logging
+DASH_V :=
+QUIET := @
+SET_X := :
+ifeq ($(V),1)
+  DASH_V := -v
+  QUIET :=
+  SET_X := set -x
+endif
+
 DOCKER_UNPACK= _() { C=`docker create $$1 fake` ; shift ; docker export $$C | tar -xf - "$$@" ; docker rm $$C ; } ; _
-DOCKER_GO = _() { mkdir -p $(CURDIR)/.go/src/$${3:-dummy} ; mkdir -p $(CURDIR)/.go/bin ; \
+DOCKER_GO = _() { $(SET_X); mkdir -p $(CURDIR)/.go/src/$${3:-dummy} ; mkdir -p $(CURDIR)/.go/bin ; \
     docker_go_line="docker run $$DOCKER_GO_ARGS -i --rm -u $(USER) -w /go/src/$${3:-dummy} \
     -v $(CURDIR)/.go:/go -v $$2:/go/src/$${3:-dummy} -v $${4:-$(CURDIR)/.go/bin}:/go/bin -v $(CURDIR)/:/eve -v $${HOME}:/home/$(USER) \
     -e GOOS -e GOARCH -e CGO_ENABLED -e BUILD=local $(GOBUILDER) bash --noprofile --norc -c" ; \
@@ -232,6 +242,7 @@ PKGS=$(shell ls -d pkg/* | grep -Ev "eve|test-microsvcs")
 # Top-level targets
 
 all: help
+	$(QUIET): $@: Succeeded
 
 # just reports the version, without appending qualifies like HVM or such
 version:
@@ -239,7 +250,8 @@ version:
 
 test: $(GOBUILDER) | $(DIST)
 	@echo Running tests on $(GOMODULE)
-	@$(DOCKER_GO) "gotestsum --jsonfile $(DOCKER_DIST)/results.json --junitfile $(DOCKER_DIST)/results.xml" $(GOTREE) $(GOMODULE)
+	$(QUIET)$(DOCKER_GO) "gotestsum --jsonfile $(DOCKER_DIST)/results.json --junitfile $(DOCKER_DIST)/results.xml" $(GOTREE) $(GOMODULE)
+	$(QUIET): $@: Succeeded
 
 itest: $(GOBUILDER) run-proxy | $(DIST)
 	@echo Running integration tests
@@ -263,7 +275,7 @@ $(BUILD_VM_CLOUD_INIT): build-tools/src/scripts/cloud-init.in | $(DIST)
 	@if [ -z "$(BUILD_VM_SSH_PUB_KEY)" ] || [ -z "$(BUILD_VM_GH_TOKEN)" ]; then                  \
 	    echo "Must be run as: make BUILD_VM_SSH_PUB_KEY=XXX BUILD_VM_GH_TOKEN=YYY $@" && exit 1 ;\
 	fi
-	@sed -e 's#@ZARCH@#$(subst amd64,x64,$(ZARCH))#' -e 's#@SSH_PUB_KEY@#$(BUILD_VM_SSH_PUB_KEY)#g'  \
+	$(QUIET)sed -e 's#@ZARCH@#$(subst amd64,x64,$(ZARCH))#' -e 's#@SSH_PUB_KEY@#$(BUILD_VM_SSH_PUB_KEY)#g'  \
 	     -e 's#@GH_TOKEN@#$(BUILD_VM_GH_TOKEN)#g' < $< | docker run -i alpine:edge sh -c             \
 	          'apk add cloud-utils > /dev/null 2>&1 && cloud-localds --disk-format qcow2 _ - && cat _' > $@
 
@@ -279,6 +291,7 @@ $(BUILD_VM): $(BUILD_VM_CLOUD_INIT) $(BUILD_VM).orig $(DEVICETREE_DTB) $(BIOS_IM
 
 $(BIOS_IMG): $(LINUXKIT) | $(DIST)
 	cd $| ; $(DOCKER_UNPACK) $(shell $(LINUXKIT) pkg show-tag pkg/uefi)-$(DOCKER_ARCH_TAG) $(notdir $@)
+	$(QUIET): $@: Succeeded
 
 $(IPXE_IMG): $(LINUXKIT) | $(DIST)
 	cd $| ; $(DOCKER_UNPACK) $(shell $(LINUXKIT) pkg show-tag pkg/ipxe)-$(DOCKER_ARCH_TAG) $(notdir $@)
@@ -286,15 +299,19 @@ $(IPXE_IMG): $(LINUXKIT) | $(DIST)
 $(DEVICETREE_DTB): $(BIOS_IMG) | $(DIST)
 	mkdir $(dir $@) 2>/dev/null || :
 	$(QEMU_SYSTEM) $(QEMU_OPTS) -machine dumpdtb=$@
+	$(QUIET): $@: Succeeded
 
 $(EFI_PART): $(LINUXKIT) | $(INSTALLER)
 	cd $| ; $(DOCKER_UNPACK) $(shell $(LINUXKIT) pkg show-tag pkg/grub)-$(DOCKER_ARCH_TAG) $(notdir $@)
+	$(QUIET): $@: Succeeded
 
 $(BOOT_PART): $(LINUXKIT) | $(INSTALLER)
 	cd $| ; $(DOCKER_UNPACK) $(shell $(LINUXKIT) pkg show-tag pkg/u-boot)-$(DOCKER_ARCH_TAG) $(notdir $@)
+	$(QUIET): $@: Succeeded
 
 $(INITRD_IMG): $(LINUXKIT) | $(INSTALLER)
 	cd $| ; $(DOCKER_UNPACK) $(shell $(LINUXKIT) pkg show-tag pkg/mkimage-raw-efi)-$(DOCKER_ARCH_TAG) $(notdir $@ $(EFI_PART))
+	$(QUIET): $@: Succeeded
 
 # run-installer
 #
@@ -324,10 +341,12 @@ run-target: $(BIOS_IMG) $(DEVICETREE_DTB)
 run-rootfs: $(BIOS_IMG) $(EFI_PART) $(DEVICETREE_DTB)
 	(echo 'set devicetree="(hd0,msdos1)/eve.dtb"' ; echo 'set rootfs_root=/dev/vdb' ; echo 'set root=hd1' ; echo 'export rootfs_root' ; echo 'export devicetree' ; echo 'configfile /EFI/BOOT/grub.cfg' ) > $(EFI_PART)/BOOT/grub.cfg
 	$(QEMU_SYSTEM) $(QEMU_OPTS) -drive file=$(ROOTFS_IMG),format=raw -drive file=fat:rw:$(EFI_PART)/..,label=CONFIG,format=vvfat
+	$(QUIET): $@: Succeeded
 
 run-grub: $(BIOS_IMG) $(EFI_PART) $(DEVICETREE_DTB)
 	[ -f $(EFI_PART)/BOOT/grub.cfg ] && mv $(EFI_PART)/BOOT/grub.cfg $(EFI_PART)/BOOT/grub.cfg.$(notdir $(shell mktemp))
 	$(QEMU_SYSTEM) $(QEMU_OPTS) -drive format=vvfat,label=EVE,file=fat:rw:$(EFI_PART)/..
+	$(QUIET): $@: Succeeded
 
 run-compose: images/docker-compose.yml images/version.yml
 	docker-compose -f $< run storage-init sh -c 'rm -rf /run/* /config/* ; cp -Lr /conf/* /config/ ; echo IMGA > /run/eve.id'
@@ -391,12 +410,12 @@ $(DIST) $(INSTALLER):
 # convenience targets - so you can do `make config` instead of `make dist/config.img`, and `make installer` instead of `make dist/amd64/installer.img
 build-vm: $(BUILD_VM)
 initrd: $(INITRD_IMG)
-config: $(CONFIG_IMG)
+config: $(CONFIG_IMG))		; $(QUIET): "$@: Succeeded, CONFIG_IMG=$(CONFIG_IMG)"
 ssh-key: $(SSH_KEY)
 rootfs: $(ROOTFS_IMG)
 rootfs-%: $(ROOTFS)-%.img ;
-live: $(LIVE_IMG)
-live-%: $(LIVE).% ;
+live: $(LIVE_IMG)		; $(QUIET): "$@: Succeeded, LIVE_IMG=$(LIVE_IMG)"
+live-%: $(LIVE).%		; $(QUIET): "$@: Succeeded, LIVE=$(LIVE)"
 installer: $(INSTALLER_IMG)
 installer-%: $(INSTALLER).% ;
 
@@ -407,26 +426,33 @@ $(SSH_KEY):
 
 $(CONFIG_IMG): $(CONF_FILES) | $(INSTALLER)
 	./tools/makeconfig.sh $@ "$(ROOTFS_VERSION)" $(CONF_FILES)
+	$(QUIET): $@: Succeeded
 
 $(PERSIST_IMG): | $(INSTALLER)
 	$(if $(findstring zfs,$(HV)),echo 'eve<3zfs' > $@)
 	# 1M of zeroes should be enough to trigger filesystem wipe on first boot
 	dd if=/dev/zero bs=1048576 count=1 >> $@
+	$(QUIET): $@: Succeeded
 
 $(ROOTFS)-%.img: $(ROOTFS_FULL_NAME)-%-$(ZARCH).$(ROOTFS_FORMAT)
 	@rm -f $@ && ln -s $(notdir $<) $@
+	$(QUIET): $@: Succeeded
 
 $(ROOTFS_IMG): $(ROOTFS)-$(HV).img
 	@rm -f $@ && ln -s $(notdir $<) $@
+	$(QUIET): $@: Succeeded
 
 $(LIVE).raw: $(BOOT_PART) $(EFI_PART) $(ROOTFS_IMG) $(CONFIG_IMG) $(PERSIST_IMG) | $(INSTALLER)
 	./tools/makeflash.sh -C 360 $| $@ $(PART_SPEC)
+	$(QUIET): $@: Succeeded
 
 $(INSTALLER).raw: $(EFI_PART) $(ROOTFS_IMG) $(INITRD_IMG) $(CONFIG_IMG) $(PERSIST_IMG) | $(INSTALLER)
 	./tools/makeflash.sh -C 360 $| $@ "conf_win installer inventory_win"
+	$(QUIET): $@: Succeeded
 
 $(INSTALLER).iso: $(EFI_PART) $(ROOTFS_IMG) $(INITRD_IMG) $(CONFIG_IMG) $(PERSIST_IMG) | $(INSTALLER)
 	./tools/makeiso.sh $| $@
+	$(QUIET): $@: Succeeded
 
 $(INSTALLER).net: eve
 	docker run lfedge/eve:$(ROOTFS_VERSION)-$(HV) installer_net > $@
@@ -449,20 +475,22 @@ pkgs: build-tools $(PKGS)
 	@echo Done building packages
 
 pkg/pillar: pkg/dnsmasq pkg/strongswan pkg/gpt-tools eve-pillar
-	@true
+	$(QUIET): $@: Succeeded
 pkg/xen-tools: pkg/uefi eve-xen-tools
-	@true
+	$(QUIET): $@: Succeeded
 pkg/qrexec-dom0: pkg/qrexec-lib pkg/xen-tools eve-qrexec-dom0
-	@true
+	$(QUIET): $@: Succeeded
 pkg/qrexec-lib: pkg/xen-tools eve-qrexec-lib
-	@true
+	$(QUIET): $@: Succeeded
 pkg/%: eve-% FORCE
-	@true
+	$(QUIET): $@: Succeeded
 
 eve: $(BIOS_IMG) $(EFI_PART) $(CONFIG_IMG) $(PERSIST_IMG) $(INITRD_IMG) $(ROOTFS_IMG) $(BOOT_PART) | $(DIST)
+	$(QUIET): "$@: Begin: EVE_REL=$(EVE_REL), HV=$(HV), LINUXKIT_PKG_TARGET=$(LINUXKIT_PKG_TARGET)"
 	cp pkg/eve/build.yml pkg/eve/runme.sh images/*.yml $|
 	$(PARSE_PKGS) pkg/eve/Dockerfile.in > $|/Dockerfile
-	$(LINUXKIT) pkg $(LINUXKIT_PKG_TARGET) --disable-content-trust --hash-path $(CURDIR) --hash $(ROOTFS_VERSION)-$(HV) $(if $(strip $(EVE_REL)),--release) $(EVE_REL) $(FORCE_BUILD) $|
+	$(LINUXKIT) $(DASH_V) pkg $(LINUXKIT_PKG_TARGET) --disable-content-trust --hash-path $(CURDIR) --hash $(ROOTFS_VERSION)-$(HV) $(if $(strip $(EVE_REL)),--release) $(EVE_REL) $(FORCE_BUILD) $|
+	$(QUIET): $@: Succeeded
 
 proto-vendor:
 	@$(DOCKER_GO) "cd pkg/pillar ; go mod vendor" $(CURDIR) proto
@@ -510,7 +538,7 @@ release:
 	 echo "  git push origin $$X.$$Y $$X.$$Y.$$Z"
 
 shell: $(GOBUILDER)
-	@DOCKER_GO_ARGS=-t ; $(DOCKER_GO) bash $(GOTREE) $(GOMODULE)
+	$(QUIET)DOCKER_GO_ARGS=-t ; $(DOCKER_GO) bash $(GOTREE) $(GOMODULE)
 
 #
 # Utility targets in support of our Dockerized build infrastrucutre
@@ -519,7 +547,7 @@ shell: $(GOBUILDER)
 # build linuxkit for the host OS, not the container OS
 $(LINUXKIT): GOOS=$(shell uname -s | tr '[A-Z]' '[a-z]')
 $(LINUXKIT): | $(GOBUILDER)
-	@$(DOCKER_GO) \
+	$(QUIET)$(DOCKER_GO) \
 	"unset GOFLAGS; rm -rf /tmp/linuxkit && \
 	git clone $(LINUXKIT_SOURCE) /tmp/linuxkit && \
 	cd /tmp/linuxkit && \
@@ -529,16 +557,19 @@ $(LINUXKIT): | $(GOBUILDER)
 	cd && \
 	rm -rf /tmp/linuxkit" \
 	$(GOTREE) $(GOMODULE) $(BUILDTOOLS_BIN)
+	$(QUIET): $@: Succeeded
 
 $(GOBUILDER):
+	$(QUIET): "$@: Begin: GOBUILDER=$(GOBUILDER)"
 ifneq ($(BUILD),local)
 	@echo "Creating go builder image for user $(USER)"
-	@docker build --build-arg GOVER=$(GOVER) --build-arg USER=$(USER) --build-arg GROUP=$(GROUP) \
+	$(QUIET)docker build --build-arg GOVER=$(GOVER) --build-arg USER=$(USER) --build-arg GROUP=$(GROUP) \
                       --build-arg UID=$(UID) --build-arg GID=$(GID) \
                       $(DOCKER_HTTP_PROXY) $(DOCKER_HTTPS_PROXY) $(DOCKER_NO_PROXY) $(DOCKER_ALL_PROXY) \
                       -t $@ build-tools/src/scripts > /dev/null
 	@echo "$@ docker container is ready to use"
 endif
+	$(QUIET): $@: Succeeded
 
 #
 # Common, generalized rules
@@ -553,29 +584,39 @@ endif
 %.qcow2: %.raw | $(DIST)
 	qemu-img convert -c -f raw -O qcow2 $< $@
 	qemu-img resize $@ ${MEDIA_SIZE}M
+	$(QUIET): $@: Succeeded
 
 %.yml: %.yml.in build-tools $(RESCAN_DEPS)
-	@$(PARSE_PKGS) $< > $@
+	$(QUIET)$(PARSE_PKGS) $< > $@
+	$(QUIET): $@: Succeeded
 
 %/Dockerfile: %/Dockerfile.in build-tools $(RESCAN_DEPS)
-	@$(PARSE_PKGS) $< > $@
+	$(QUIET)$(PARSE_PKGS) $< > $@
+	$(QUIET): $@: Succeeded
 
 eve-%: pkg/%/Dockerfile build-tools $(RESCAN_DEPS)
-	@$(LINUXKIT) pkg $(LINUXKIT_PKG_TARGET) $(LINUXKIT_OPTS) pkg/$*
+	$(QUIET): "$@: Begin: LINUXKIT_PKG_TARGET=$(LINUXKIT_PKG_TARGET)"
+	$(QUIET)$(LINUXKIT) $(DASH_V) pkg $(LINUXKIT_PKG_TARGET) $(LINUXKIT_OPTS) pkg/$*
+	$(QUIET): "$@: Succeeded (intermediate for pkg/%)"
 
 images/rootfs-%.yml.in: images/rootfs.yml.in FORCE
 	@if [ -e $@.patch ]; then patch -p0 -o $@.sed < $@.patch ;else cp $< $@.sed ;fi
-	@sed -e 's#EVE_VERSION#$(ROOTFS_VERSION)-$*-$(ZARCH)#' < $@.sed > $@ || rm $@ $@.sed
+	$(QUIET)sed -e 's#EVE_VERSION#$(ROOTFS_VERSION)-$*-$(ZARCH)#' < $@.sed > $@ || rm $@ $@.sed
 	@rm $@.sed
+	$(QUIET): $@: Succeeded
 
 $(ROOTFS_FULL_NAME)-adam-kvm-$(ZARCH).$(ROOTFS_FORMAT): $(ROOTFS_FULL_NAME)-kvm-adam-$(ZARCH).$(ROOTFS_FORMAT)
 $(ROOTFS_FULL_NAME)-kvm-adam-$(ZARCH).$(ROOTFS_FORMAT): images/rootfs-%.yml $(SSH_KEY) | $(INSTALLER)
+	$(QUIET): $@: Begin
 	./tools/makerootfs.sh $< $@ $(ROOTFS_FORMAT) $(ZARCH)
+	$(QUIET): $@: Succeeded
 $(ROOTFS_FULL_NAME)-%-$(ZARCH).$(ROOTFS_FORMAT): images/rootfs-%.yml | $(INSTALLER)
+	$(QUIET): $@: Begin
 	./tools/makerootfs.sh $< $@ $(ROOTFS_FORMAT) $(ZARCH)
 	@echo "size of $@ is $$(wc -c < "$@")B"
 	@[ $$(wc -c < "$@") -gt $$(( 250 * 1024 * 1024 )) ] && \
           echo "ERROR: size of $@ is greater than 250MB (bigger than allocated partition)" && exit 1 || :
+	$(QUIET): $@: Succeeded
 
 %-show-tag:
 	@$(LINUXKIT) pkg show-tag pkg/$*


### PR DESCRIPTION
Use $(QUIET) instead of @ to hide commands. Default to @ and
conditionally set QUIET= when V=1.
Also conditionally set DASH_V and SET_X to use within rules.

End all commands with "$@: Succeeded" to see which rules completed in
the log.
Start long rules with "$@: Begin" and include useful variables.
Use the colon operator to show the text unless you use make -s.
Skip quotes for simple lines.

Signed-off-by: Daniel P. Kionka <dkionka@gmail.com>