### PR TITLE
Adding regdb for wireless

### DIFF
--- a/pkg/fw/Dockerfile
+++ b/pkg/fw/Dockerfile
@@ -2,6 +2,7 @@ FROM alpine:edge as build
 
 WORKDIR /
 RUN apk add --no-cache \
+    wireless-regdb \
     linux-firmware-other \
     linux-firmware-ath10k \
     linux-firmware-mrvl \
@@ -12,6 +13,7 @@ RUN apk add --no-cache \
 FROM scratch
 ENTRYPOINT []
 WORKDIR /
+COPY --from=build /lib/firmware/regulatory* /lib/firmware/
 COPY --from=build /lib/firmware/mrvl/*.bin /lib/firmware/mrvl/
 COPY --from=build /lib/firmware/rt2870.bin /lib/firmware/rt2870.bin
 COPY --from=build /lib/firmware/rtlwifi/*.bin /lib/firmware/rtlwifi/


### PR DESCRIPTION
Turns out regdb was missing all this time. It is not that big of a deal, but in certain situations it is required for WiFi cards to function properly and it is only an extra 40Kb