### PR TITLE
Add gcp check on master merge

### DIFF
--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -1,0 +1,80 @@
+---
+name: EdenGCP
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches: [master]
+# yamllint disable rule:line-length
+jobs:
+  integration:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: get eve
+        uses: actions/checkout@v2
+        with:
+          path: 'eve'
+      - name: Public IP
+        id: ip
+        uses: haythem/public-ip@v1.2
+      - name: setup packages
+        run: |
+          sudo apt update
+          sudo apt install -y qemu-utils openvpn
+          echo "$OVPN_FILE" | base64 -d > ./config.ovpn
+        env:
+          OVPN_FILE: ${{ secrets.OVPN_FILE }}
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
+      - name: set firewall & clean
+        run: |
+          gcloud compute instances delete eve-edengcp-actions-${{github.run_number}} -q --zone=us-west1-a || echo "not exists"
+          gcloud compute images delete eve-edengcp-actions-${{github.run_number}} -q || echo "not exists"
+      - name: Connect VPN
+        id: connect_vpn
+        timeout-minutes: 1
+        run: |
+          sudo openvpn --config ./config.ovpn --daemon
+          until ip -f inet addr show tun0; do sleep 5; ip a; done
+          echo ::set-output name=tunnel_ip::$(ip -f inet addr show tun0 | sed -En -e 's/.*inet ([0-9.]+).*/\1/p')
+      - name: build eden
+        run: |
+          make build
+          make build-tests
+      - name: setup
+        run: |
+          ./eden config add default --devmodel GCP
+          ./eden config set default --key adam.eve-ip --value ${{ steps.connect_vpn.outputs.tunnel_ip }}
+          ./eden config set default --key registry.ip --value ${{ steps.connect_vpn.outputs.tunnel_ip }}
+          ./eden utils gcp firewall --source-range ${{ steps.ip.outputs.ipv4 }}/32 --name eve-eden-actions-${{github.run_number}} -k "$GOOGLE_APPLICATION_CREDENTIALS"
+          ./eden setup
+          ./eden utils gcp image --image-name eve-eden-actions-${{github.run_number}} -k "$GOOGLE_APPLICATION_CREDENTIALS" upload
+          ./eden utils gcp vm --image-name eve-eden-actions-${{github.run_number}} --vm-name eve-eden-actions-${{github.run_number}} -k "$GOOGLE_APPLICATION_CREDENTIALS" run
+          ./eden start
+          BWD=$(./eden utils gcp vm get-ip --vm-name eve-eden-actions-${{github.run_number}} -k "$GOOGLE_APPLICATION_CREDENTIALS")
+          echo "the IP is $BWD"
+          ./eden utils gcp firewall -k "$GOOGLE_APPLICATION_CREDENTIALS" --source-range $BWD --name eden-actions-${{github.run_number}}
+          ./eden eve onboard
+          echo > tests/workflow/testdata/eden_stop.txt
+      - name: Test
+        run: |
+          EDEN_TEST=gcp ./eden test tests/workflow -v debug
+      - name: Collect logs
+        if: ${{ always() }}
+        run: |
+          ./eden log --format json > trace.log
+      - name: Clean
+        if: ${{ always() }}
+        run: |
+          gcloud compute firewall-rules delete eve-eden-actions-${{github.run_number}} || echo "not exists"
+          gcloud compute firewall-rules delete eden-actions-${{github.run_number}} || echo "not exists"
+          gcloud compute instances delete eve-eden-actions-${{github.run_number}} -q --zone=us-west1-a || echo "not exists"
+          gcloud compute images delete eve-eden-actions-${{github.run_number}} -q || echo "not exists"
+      - name: Store raw test results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: 'eden-report'
+          path: ${{ github.workspace }}/trace.log

--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -4,7 +4,7 @@ on:  # yamllint disable-line rule:truthy
   workflow_run:
     workflows: ["publish"]
     branches: [main]
-    types: 
+    types:
       - completed
 # yamllint disable rule:line-length
 jobs:
@@ -41,7 +41,7 @@ jobs:
           try {
             const ipv4 = await http.getJson<IPResponse>('https://api.ipify.org?format=json');
           } catch (error) {
-            echo ("Didn't get anything") 
+            echo ("Didn't get anything")
             echo(error.message)
           }
           return ipv4

--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -7,6 +7,10 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   integration:
     runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        hv: ["kvm", "xen"]
     steps:
       - name: get eve
         uses: actions/checkout@v2
@@ -21,12 +25,12 @@ jobs:
           TAG: pr${{ github.event.pull_request.number }}
           CACHE: evebuild/danger
         run: |
-          if docker pull "$CACHE:$TAG-kvm"; then
-             docker tag  "$CACHE:$TAG-kvm" "lfedge/eve:$TAG-kvm"
-             docker tag  "$CACHE:$TAG-kvm" "lfedge/eve:$TAG-kvm-amd64"
+          if docker pull "$CACHE:$TAG-${{ matrix.hv }}"; then
+             docker tag  "$CACHE:$TAG-${{ matrix.hv }}" "lfedge/eve:$TAG-${{ matrix.hv }}"
+             docker tag  "$CACHE:$TAG-${{ matrix.hv }}" "lfedge/eve:$TAG-${{ matrix.hv }}-amd64"
           else
              make -C eve pkgs
-             make -C eve ROOTFS_VERSION="$TAG" HV=kvm eve
+             make -C eve ROOTFS_VERSION="$TAG" HV=-${{ matrix.hv }} eve
           fi
           echo "TAG=$TAG" >> $GITHUB_ENV
       - name: Public IP
@@ -47,8 +51,8 @@ jobs:
           export_default_credentials: true
       - name: set firewall & clean
         run: |
-          gcloud compute instances delete eve-edengcp-actions-${{github.run_number}} -q --zone=us-west1-a || echo "not exists"
-          gcloud compute images delete eve-edengcp-actions-${{github.run_number}} -q || echo "not exists"
+          gcloud compute instances delete eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} -q --zone=us-west1-a || echo "not exists"
+          gcloud compute images delete eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} -q || echo "not exists"
       - name: Connect VPN
         id: connect_vpn
         timeout-minutes: 1
@@ -68,12 +72,12 @@ jobs:
           ./eden config set default --key registry.ip --value ${{ steps.connect_vpn.outputs.tunnel_ip }}
           ./eden utils gcp firewall --source-range ${{ steps.ip.outputs.ipv4 }}/32 --name eve-edengcp-actions-${{github.run_number}} -k "$GOOGLE_APPLICATION_CREDENTIALS"
           ./eden setup
-          ./eden utils gcp image --image-name eve-edengcp-actions-${{github.run_number}} -k "$GOOGLE_APPLICATION_CREDENTIALS" upload
-          ./eden utils gcp vm --image-name eve-edengcp-actions-${{github.run_number}} --vm-name eve-edengcp-actions-${{github.run_number}} -k "$GOOGLE_APPLICATION_CREDENTIALS" run
+          ./eden utils gcp image --image-name eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} -k "$GOOGLE_APPLICATION_CREDENTIALS" upload
+          ./eden utils gcp vm --image-name eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} --vm-name eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} -k "$GOOGLE_APPLICATION_CREDENTIALS" run
           ./eden start
-          BWD=$(./eden utils gcp vm get-ip --vm-name eve-edengcp-actions-${{github.run_number}} -k "$GOOGLE_APPLICATION_CREDENTIALS")
+          BWD=$(./eden utils gcp vm get-ip --vm-name eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} -k "$GOOGLE_APPLICATION_CREDENTIALS")
           echo "the IP is $BWD"
-          ./eden utils gcp firewall -k "$GOOGLE_APPLICATION_CREDENTIALS" --source-range $BWD --name edengcp-actions-${{github.run_number}}
+          ./eden utils gcp firewall -k "$GOOGLE_APPLICATION_CREDENTIALS" --source-range $BWD --name edengcp-actions-${{ matrix.hv }}-${{github.run_number}}
           ./eden eve onboard
           echo > tests/workflow/testdata/eden_stop.txt
       - name: Test
@@ -86,13 +90,13 @@ jobs:
       - name: Clean
         if: ${{ always() }}
         run: |
-          gcloud compute firewall-rules delete eve-edengcp-actions-${{github.run_number}} || echo "not exists"
-          gcloud compute firewall-rules delete edengcp-actions-${{github.run_number}} || echo "not exists"
-          gcloud compute instances delete eve-edengcp-actions-${{github.run_number}} -q --zone=us-west1-a || echo "not exists"
-          gcloud compute images delete eve-edengcp-actions-${{github.run_number}} -q || echo "not exists"
+          gcloud compute firewall-rules delete eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} || echo "not exists"
+          gcloud compute firewall-rules delete edengcp-actions-${{ matrix.hv }}-${{github.run_number}} || echo "not exists"
+          gcloud compute instances delete eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} -q --zone=us-west1-a || echo "not exists"
+          gcloud compute images delete eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} -q || echo "not exists"
       - name: Store raw test results
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
-          name: 'eden-report'
+          name: eden-report-${{ matrix.hv }}
           path: ${{ github.workspace }}/trace.log

--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -30,7 +30,7 @@ jobs:
              docker tag  "$CACHE:$TAG-${{ matrix.hv }}" "lfedge/eve:$TAG-${{ matrix.hv }}-amd64"
           else
              make -C eve pkgs
-             make -C eve ROOTFS_VERSION="$TAG" HV=-${{ matrix.hv }} eve
+             make -C eve ROOTFS_VERSION="$TAG" HV=${{ matrix.hv }} eve
           fi
           echo "TAG=$TAG" >> $GITHUB_ENV
       - name: Public IP
@@ -68,6 +68,7 @@ jobs:
         run: |
           ./eden config add default --devmodel GCP
           ./eden config set default --key eve.tag --value="$TAG"
+          ./eden config set default --key eve.hv --value ${{ matrix.hv }}
           ./eden config set default --key adam.eve-ip --value ${{ steps.connect_vpn.outputs.tunnel_ip }}
           ./eden config set default --key registry.ip --value ${{ steps.connect_vpn.outputs.tunnel_ip }}
           ./eden utils gcp firewall --source-range ${{ steps.ip.outputs.ipv4 }}/32 --name eve-edengcp-actions-${{github.run_number}} -k "$GOOGLE_APPLICATION_CREDENTIALS"

--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -1,8 +1,11 @@
 ---
 name: EdenGCP
 on:  # yamllint disable-line rule:truthy
-  push:
-    branches: [master]
+  workflow_run:
+    workflows: ["publish"]
+    branches: [main]
+    types: 
+      - completed
 # yamllint disable rule:line-length
 jobs:
   integration:
@@ -12,10 +15,6 @@ jobs:
       matrix:
         hv: ["kvm", "xen"]
     steps:
-      - name: get eve
-        uses: actions/checkout@v2
-        with:
-          path: 'eve'
       - name: get eden
         uses: actions/checkout@v2
         with:
@@ -29,13 +28,23 @@ jobs:
              docker tag  "$CACHE:$TAG-${{ matrix.hv }}" "lfedge/eve:$TAG-${{ matrix.hv }}"
              docker tag  "$CACHE:$TAG-${{ matrix.hv }}" "lfedge/eve:$TAG-${{ matrix.hv }}-amd64"
           else
-             make -C eve pkgs
-             make -C eve ROOTFS_VERSION="$TAG" HV=${{ matrix.hv }} eve
+            echo "No tag $CACHE:$TAG-${{ matrix.hv }} found"
           fi
           echo "TAG=$TAG" >> $GITHUB_ENV
       - name: Public IP
         id: ip
-        uses: haythem/public-ip@v1.2
+        uses: actions/http-client
+        result-encoding: string
+        script: |
+          const maxRetries = parseInt(core.getInput('maxRetries'), 10);
+          const http = new HttpClient('haythem/public-ip', undefined, { allowRetries: true, maxRetries: maxRetries });
+          try {
+            const ipv4 = await http.getJson<IPResponse>('https://api.ipify.org?format=json');
+          } catch (error) {
+            echo ("Didn't get anything") 
+            echo(error.message)
+          }
+          return ipv4
       - name: setup packages
         run: |
           sudo apt update
@@ -49,10 +58,10 @@ jobs:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true
-      - name: set firewall & clean
+      - name: clean
         run: |
-          gcloud compute instances delete eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} -q --zone=us-west1-a || echo "not exists"
-          gcloud compute images delete eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} -q || echo "not exists"
+          gcloud compute instances delete eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} -q --zone=us-west1-a || echo "Does not exist"
+          gcloud compute images delete eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} -q || echo "Does not exist"
       - name: Connect VPN
         id: connect_vpn
         timeout-minutes: 1

--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -19,18 +19,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'lf-edge/eden'
-      - name: fetch or build eve
-        env:
-          TAG: pr${{ github.event.pull_request.number }}
-          CACHE: evebuild/danger
-        run: |
-          if docker pull "$CACHE:$TAG-${{ matrix.hv }}"; then
-             docker tag  "$CACHE:$TAG-${{ matrix.hv }}" "lfedge/eve:$TAG-${{ matrix.hv }}"
-             docker tag  "$CACHE:$TAG-${{ matrix.hv }}" "lfedge/eve:$TAG-${{ matrix.hv }}-amd64"
-          else
-            echo "No tag $CACHE:$TAG-${{ matrix.hv }} found"
-          fi
-          echo "TAG=$TAG" >> $GITHUB_ENV
       - name: Public IP
         id: ip
         uses: actions/http-client
@@ -47,7 +35,6 @@ jobs:
           return ipv4
       - name: setup packages
         run: |
-          sudo apt update
           sudo apt install -y qemu-utils openvpn
           echo "$OVPN_FILE" | base64 -d > ./config.ovpn
         env:
@@ -74,6 +61,8 @@ jobs:
           make build
           make build-tests
       - name: setup
+        env:
+          TAG: pr${{ github.event.pull_request.number }}
         run: |
           ./eden config add default --devmodel GCP
           ./eden config set default --key eve.tag --value="$TAG"

--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -61,8 +61,6 @@ jobs:
           make build
           make build-tests
       - name: setup
-        env:
-          TAG: pr${{ github.event.pull_request.number }}
         run: |
           ./eden config add default --devmodel GCP
           ./eden config set default --key eve.tag --value="lfedge/eve:snapshot"

--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -100,10 +100,10 @@ jobs:
       - name: Clean
         if: ${{ always() }}
         run: |
-          gcloud compute firewall-rules delete eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} || echo "not exists"
-          gcloud compute firewall-rules delete edengcp-actions-${{ matrix.hv }}-${{github.run_number}} || echo "not exists"
-          gcloud compute instances delete eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} -q --zone=us-west1-a || echo "not exists"
-          gcloud compute images delete eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} -q || echo "not exists"
+          gcloud compute firewall-rules delete eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} || echo "Does not exist"
+          gcloud compute firewall-rules delete edengcp-actions-${{ matrix.hv }}-${{github.run_number}} || echo "Does not exist"
+          gcloud compute instances delete eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} -q --zone=us-west1-a || echo "Does not exist"
+          gcloud compute images delete eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} -q || echo "Does not exist"
       - name: Store raw test results
         if: ${{ always() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -65,7 +65,7 @@ jobs:
           TAG: pr${{ github.event.pull_request.number }}
         run: |
           ./eden config add default --devmodel GCP
-          ./eden config set default --key eve.tag --value="$TAG"
+          ./eden config set default --key eve.tag --value="lfedge/eve:snapshot"
           ./eden config set default --key eve.hv --value ${{ matrix.hv }}
           ./eden config set default --key adam.eve-ip --value ${{ steps.connect_vpn.outputs.tunnel_ip }}
           ./eden config set default --key registry.ip --value ${{ steps.connect_vpn.outputs.tunnel_ip }}

--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -12,6 +12,23 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: 'eve'
+      - name: get eden
+        uses: actions/checkout@v2
+        with:
+          repository: 'lf-edge/eden'
+      - name: fetch or build eve
+        env:
+          TAG: pr${{ github.event.pull_request.number }}
+          CACHE: evebuild/danger
+        run: |
+          if docker pull "$CACHE:$TAG-kvm"; then
+             docker tag  "$CACHE:$TAG-kvm" "lfedge/eve:$TAG-kvm"
+             docker tag  "$CACHE:$TAG-kvm" "lfedge/eve:$TAG-kvm-amd64"
+          else
+             make -C eve pkgs
+             make -C eve ROOTFS_VERSION="$TAG" HV=kvm eve
+          fi
+          echo "TAG=$TAG" >> $GITHUB_ENV
       - name: Public IP
         id: ip
         uses: haythem/public-ip@v1.2
@@ -46,16 +63,17 @@ jobs:
       - name: setup
         run: |
           ./eden config add default --devmodel GCP
+          ./eden config set default --key eve.tag --value="$TAG"
           ./eden config set default --key adam.eve-ip --value ${{ steps.connect_vpn.outputs.tunnel_ip }}
           ./eden config set default --key registry.ip --value ${{ steps.connect_vpn.outputs.tunnel_ip }}
-          ./eden utils gcp firewall --source-range ${{ steps.ip.outputs.ipv4 }}/32 --name eve-eden-actions-${{github.run_number}} -k "$GOOGLE_APPLICATION_CREDENTIALS"
+          ./eden utils gcp firewall --source-range ${{ steps.ip.outputs.ipv4 }}/32 --name eve-edengcp-actions-${{github.run_number}} -k "$GOOGLE_APPLICATION_CREDENTIALS"
           ./eden setup
-          ./eden utils gcp image --image-name eve-eden-actions-${{github.run_number}} -k "$GOOGLE_APPLICATION_CREDENTIALS" upload
-          ./eden utils gcp vm --image-name eve-eden-actions-${{github.run_number}} --vm-name eve-eden-actions-${{github.run_number}} -k "$GOOGLE_APPLICATION_CREDENTIALS" run
+          ./eden utils gcp image --image-name eve-edengcp-actions-${{github.run_number}} -k "$GOOGLE_APPLICATION_CREDENTIALS" upload
+          ./eden utils gcp vm --image-name eve-edengcp-actions-${{github.run_number}} --vm-name eve-edengcp-actions-${{github.run_number}} -k "$GOOGLE_APPLICATION_CREDENTIALS" run
           ./eden start
-          BWD=$(./eden utils gcp vm get-ip --vm-name eve-eden-actions-${{github.run_number}} -k "$GOOGLE_APPLICATION_CREDENTIALS")
+          BWD=$(./eden utils gcp vm get-ip --vm-name eve-edengcp-actions-${{github.run_number}} -k "$GOOGLE_APPLICATION_CREDENTIALS")
           echo "the IP is $BWD"
-          ./eden utils gcp firewall -k "$GOOGLE_APPLICATION_CREDENTIALS" --source-range $BWD --name eden-actions-${{github.run_number}}
+          ./eden utils gcp firewall -k "$GOOGLE_APPLICATION_CREDENTIALS" --source-range $BWD --name edengcp-actions-${{github.run_number}}
           ./eden eve onboard
           echo > tests/workflow/testdata/eden_stop.txt
       - name: Test
@@ -68,10 +86,10 @@ jobs:
       - name: Clean
         if: ${{ always() }}
         run: |
-          gcloud compute firewall-rules delete eve-eden-actions-${{github.run_number}} || echo "not exists"
-          gcloud compute firewall-rules delete eden-actions-${{github.run_number}} || echo "not exists"
-          gcloud compute instances delete eve-eden-actions-${{github.run_number}} -q --zone=us-west1-a || echo "not exists"
-          gcloud compute images delete eve-eden-actions-${{github.run_number}} -q || echo "not exists"
+          gcloud compute firewall-rules delete eve-edengcp-actions-${{github.run_number}} || echo "not exists"
+          gcloud compute firewall-rules delete edengcp-actions-${{github.run_number}} || echo "not exists"
+          gcloud compute instances delete eve-edengcp-actions-${{github.run_number}} -q --zone=us-west1-a || echo "not exists"
+          gcloud compute images delete eve-edengcp-actions-${{github.run_number}} -q || echo "not exists"
       - name: Store raw test results
         if: ${{ always() }}
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Use Github actions to check the merge to the master. It checks running VMs, not only containers (e.g. VNC test https://github.com/lf-edge/eden/tree/master/tests/vnc) 
Currently it supports kvm and xen modes. 

This action requires the following secrets: 
OVPN_FILE - ovpn file
GCP_PROJECT_ID - GCP project 
GCP_SA_KEY - json service key for GCP

The similar script runs on lf-edge/eden 

Signed-off-by: fleandr <svfly@yandex.ru>