### PR TITLE
Moving Xen based EVE to kernel 5.10.7 (KVM stays 5.4.x for now)

### DIFF
--- a/images/rootfs-kvm.yml.in.patch
+++ b/images/rootfs-kvm.yml.in.patch
@@ -1,0 +1,9 @@
+--- images/rootfs.yml.in	2021-01-15 19:34:18.000000000 -0800
++++ images/rootfs.yml.in	2021-01-15 19:35:09.000000000 -0800
+@@ -1,5 +1,5 @@
+ kernel:
+-  image: NEW_KERNEL_TAG
++  image: KERNEL_TAG
+   cmdline: "rootdelay=3"
+ init:
+   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c

--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -1,5 +1,5 @@
 kernel:
-  image: KERNEL_TAG
+  image: NEW_KERNEL_TAG
   cmdline: "rootdelay=3"
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c


### PR DESCRIPTION
This PR starts a staggered move to a 5.10.7 kernel (the latest LTS). We move Xen based EVE first and,  after a week of observations will move KVM one as well. Note that this approach allows us to test both (since you just need to enable foce_kvm_boot on a Xen image to test a new kernel in KVM mode) while giving our KVM image some time to stew.