### PR TITLE
Rpi netboot

### DIFF
--- a/docs/BOOTING.md
+++ b/docs/BOOTING.md
@@ -147,3 +147,44 @@ decide to implement IMGA/IMGB partition selection directly in u-boot to support 
 up until this point, it seems that all the boards that are modern enough to support EVE's virtualization requirements are also modern
 enough to support UEFI environment directly (even for HiKey where we're currently using u-boot as a stop gap measure the proper
 [UEFI implementation](https://github.com/pftf/RPi4) is very much in the works).
+
+## Booting Raspberry Pi with netboot
+
+### Boot flow
+
+* board loads custom firmware blobs and `config.txt` from [tftp](#load-u-boot-with-netboot-on-raspberry-pi) or
+  from [usb](#load-u-boot-from-usb). Inside `config.txt` we define `u-boot.bin` as kernel, so, board loads it from
+  [tftp](#load-u-boot-with-netboot-on-raspberry-pi) or from [usb](#load-u-boot-from-usb).
+* u-boot loads `boot.scr.uimg` via tftp which fires script inside (load `ipxe.efi` from tftp and run `bootefi`)
+* ipxe requests dhcp option [67 Bootfile-Name](https://tools.ietf.org/html/rfc2132#section-9.5) which should point to
+  `ipxe.efi`(actually, it will use configuration from `ipxe.efi.cfg` located on tftp).
+* ipxe reads `ipxe.efi.cfg` and boots `kernel`, `initrd.img` and `initrd.bits` from locations defined inside `ipxe.efi.cfg`
+
+#### Load u-boot from usb
+
+You can load u-boot from usb. You should create FAT32 partition on your usb and put `overlays` directory, `u-boot.bin`,
+`bcm2711-rpi-4-b.dtb`, `config.txt`, `fixup4.dat` and `start4.elf` on it.
+
+#### Load u-boot with netboot on Raspberry Pi
+
+In order to boot u-boot from tftp, you should modify bootloader configuration as
+described [here](https://www.raspberrypi.org/documentation/hardware/raspberrypi/bcm2711_bootloader_config.md).
+You should modify BOOT_ORDER to one that uses NETWORK mode (for example `0xf121`):
+
+```shell
+RPI_EEPROM_VERSION=pieeprom-2021-01-16
+wget https://github.com/raspberrypi/rpi-eeprom/raw/master/firmware/beta/${RPI_EEPROM_VERSION}.bin
+sudo apt update
+sudo apt install rpi-eeprom -y
+sudo rpi-eeprom-config ${RPI_EEPROM_VERSION}.bin > bootconf.txt
+sed -i 's/BOOT_ORDER=.*/BOOT_ORDER=0xf241/g' bootconf.txt
+sudo rpi-eeprom-config --out ${RPI_EEPROM_VERSION}-netboot.bin --config bootconf.txt ${RPI_EEPROM_VERSION}.bin
+sudo rpi-eeprom-update -d -f ./${RPI_EEPROM_VERSION}-netboot.bin
+```
+
+### Files to load into tftp/http
+
+You need to extract needed files with something like `docker run lfedge/eve:latest-arm64 installer_net |tar xf -`.
+You will see a set of files in the current directory to locate into you tftp server to boot Raspberry from it. Also, you should set dhcp-boot option of your
+dhcp server to `ipxe.efi` (actually, it will use configuration from `ipxe.efi.cfg`). Files `kernel`, `initrd.img` and `initrd.bits`
+should be available via HTTP/HTTPs and you need to modify `ipxe.efi.cfg` with location of those files.

--- a/pkg/eve/Dockerfile.in
+++ b/pkg/eve/Dockerfile.in
@@ -1,8 +1,10 @@
-FROM alpine:3.9.4 as tools
+FROM alpine:3.12 as tools
 RUN mkdir -p /out/etc/apk /out/boot && cp -r /etc/apk/* /out/etc/apk/
-RUN apk add --no-cache --initdb -p /out qemu-img=3.1.0-r3 tar=1.32-r0
+RUN apk add --no-cache --initdb -p /out qemu-img=5.0.0-r2 tar=1.32-r1 uboot-tools=2020.04-r0
 # hadolint ignore=DL3006
 FROM MKISO_TAG as iso
+# hadolint ignore=DL3006
+FROM IPXE_TAG as ipxe
 # hadolint ignore=DL3006
 FROM MKRAW_TAG as raw
 # we need to get rid of embedded initrd since we will get it from outside
@@ -12,6 +14,7 @@ FROM MKCONF_TAG as conf
 
 COPY --from=iso / /
 COPY --from=raw / /
+COPY --from=ipxe / /
 COPY --from=tools /out/ /
 COPY installer /bits
 COPY OVMF* /firmware/

--- a/pkg/ipxe/0003-enable-ntp.patch
+++ b/pkg/ipxe/0003-enable-ntp.patch
@@ -1,0 +1,13 @@
+diff --git a/src/config/general.h b/src/config/general.h
+index 0c99bcbb..fcfca7c2 100644
+--- a/src/config/general.h
++++ b/src/config/general.h
+@@ -152,7 +152,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+ //#define CONSOLE_CMD		/* Console command */
+ //#define IPSTAT_CMD		/* IP statistics commands */
+ //#define PROFSTAT_CMD		/* Profiling commands */
+-//#define NTP_CMD		/* NTP commands */
++#define NTP_CMD		/* NTP commands */
+ //#define CERT_CMD		/* Certificate management commands */
+ 
+ /*

--- a/pkg/ipxe/0004-no-nap-efiarm.patch
+++ b/pkg/ipxe/0004-no-nap-efiarm.patch
@@ -1,0 +1,11 @@
+diff --git a/src/config/local/nap.h b/src/config/local/nap.h
+new file mode 100644
+index 00000000..1e345eb0
+--- /dev/null
++++ b/src/config/local/nap.h
+@@ -0,0 +1,5 @@
++/* nap.h */
++#undef NAP_EFIARM
++#if defined ( __arm__ ) || defined ( __aarch64__ )
++#define NAP_NULL
++#endif

--- a/pkg/u-boot/patches/patches-v2020.07/0003-bcmgenet-fix-DMA-buffer-management.patch
+++ b/pkg/u-boot/patches/patches-v2020.07/0003-bcmgenet-fix-DMA-buffer-management.patch
@@ -1,0 +1,102 @@
+From ac458dc823de95e05e433d7645b960f8c6088f55 Mon Sep 17 00:00:00 2001
+From: Jason Wessel <jason.wessel@windriver.com>
+Date: Fri, 17 Jul 2020 06:31:59 -0700
+Subject: [PATCH] bcmgenet: fix DMA buffer management
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This commit fixes a serious issue occurring when several network
+commands are run on a raspberry pi 4 board: for instance a "dhcp"
+command and then one or several "tftp" commands. In this case,
+packet recv callbacks were called several times on the same packets,
+and send function was failing most of the time.
+
+note: if the boot procedure is made of a single network
+command, the issue is not visible.
+
+The issue is related to management of the packet ring buffers
+(producer / consumer) and DMA.
+Each time a packet is received, the ethernet device stores it
+in the buffer and increments an index called RDMA_PROD_INDEX.
+Each time the driver outputs a received packet, it increments
+another index called RDMA_CONS_INDEX.
+
+Between each pair of network commands, as part of the driver
+'start' function, previous code tried to reset both RDMA_CONS_INDEX
+and RDMA_PROD_INDEX to 0. But RDMA_PROD_INDEX cannot be written from
+driver side, thus its value was actually not updated, and only
+RDMA_CONS_INDEX was reset to 0. This was resulting in a major
+synchronization issue between the driver and the device. Most
+visible behavior was that the driver seemed to receive again the
+packets from the previous commands (e.g. DHCP response packets
+"received" again when performing the first TFTP command).
+
+This fix consists in setting RDMA_CONS_INDEX to the same
+value as RDMA_PROD_INDEX, when resetting the driver.
+
+The same kind of fix was needed on the TX side, and a few variables
+had to be reset accordingly (c_index, tx_index, rx_index).
+
+The rx_index and tx_index have only 256 entries so the bottom 8 bits
+must be masked off.
+
+Originated-by: Etienne Dublé <etienne.duble@imag.fr>
+Signed-off-by: Jason Wessel <jason.wessel@windriver.com>
+Tested-by: Petr Tesarik <ptesarik@suse.com>
+Signed-off-by: Matthias Brugger <mbrugger@suse.com>
+---
+ drivers/net/bcmgenet.c | 17 +++++++++--------
+ 1 file changed, 9 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/net/bcmgenet.c b/drivers/net/bcmgenet.c
+index 11b6148ab6..1b7e7ba2bf 100644
+--- a/drivers/net/bcmgenet.c
++++ b/drivers/net/bcmgenet.c
+@@ -378,8 +378,6 @@ static void rx_descs_init(struct bcmgenet_eth_priv *priv)
+ 	u32 len_stat, i;
+ 	void *desc_base = priv->rx_desc_base;
+ 
+-	priv->c_index = 0;
+-
+ 	len_stat = (RX_BUF_LENGTH << DMA_BUFLENGTH_SHIFT) | DMA_OWN;
+ 
+ 	for (i = 0; i < RX_DESCS; i++) {
+@@ -403,8 +401,11 @@ static void rx_ring_init(struct bcmgenet_eth_priv *priv)
+ 	writel(RX_DESCS * DMA_DESC_SIZE / 4 - 1,
+ 	       priv->mac_reg + RDMA_RING_REG_BASE + DMA_END_ADDR);
+ 
+-	writel(0x0, priv->mac_reg + RDMA_PROD_INDEX);
+-	writel(0x0, priv->mac_reg + RDMA_CONS_INDEX);
++	/* cannot init RDMA_PROD_INDEX to 0, so align RDMA_CONS_INDEX on it instead */
++	priv->c_index = readl(priv->mac_reg + RDMA_PROD_INDEX);
++	writel(priv->c_index, priv->mac_reg + RDMA_CONS_INDEX);
++	priv->rx_index = priv->c_index;
++	priv->rx_index &= 0xFF;
+ 	writel((RX_DESCS << DMA_RING_SIZE_SHIFT) | RX_BUF_LENGTH,
+ 	       priv->mac_reg + RDMA_RING_REG_BASE + DMA_RING_BUF_SIZE);
+ 	writel(DMA_FC_THRESH_VALUE, priv->mac_reg + RDMA_XON_XOFF_THRESH);
+@@ -421,8 +422,10 @@ static void tx_ring_init(struct bcmgenet_eth_priv *priv)
+ 	writel(0x0, priv->mac_reg + TDMA_WRITE_PTR);
+ 	writel(TX_DESCS * DMA_DESC_SIZE / 4 - 1,
+ 	       priv->mac_reg + TDMA_RING_REG_BASE + DMA_END_ADDR);
+-	writel(0x0, priv->mac_reg + TDMA_PROD_INDEX);
+-	writel(0x0, priv->mac_reg + TDMA_CONS_INDEX);
++	/* cannot init TDMA_CONS_INDEX to 0, so align TDMA_PROD_INDEX on it instead */
++	priv->tx_index = readl(priv->mac_reg + TDMA_CONS_INDEX);
++	writel(priv->tx_index, priv->mac_reg + TDMA_PROD_INDEX);
++	priv->tx_index &= 0xFF;
+ 	writel(0x1, priv->mac_reg + TDMA_RING_REG_BASE + DMA_MBUF_DONE_THRESH);
+ 	writel(0x0, priv->mac_reg + TDMA_FLOW_PERIOD);
+ 	writel((TX_DESCS << DMA_RING_SIZE_SHIFT) | RX_BUF_LENGTH,
+@@ -469,8 +472,6 @@ static int bcmgenet_gmac_eth_start(struct udevice *dev)
+ 
+ 	priv->tx_desc_base = priv->mac_reg + GENET_TX_OFF;
+ 	priv->rx_desc_base = priv->mac_reg + GENET_RX_OFF;
+-	priv->tx_index = 0x0;
+-	priv->rx_index = 0x0;
+ 
+ 	bcmgenet_umac_reset(priv);
+ 
+-- 
+2.25.1

--- a/pkg/u-boot/patches/patches-v2020.07/0004-bcmgenet-Add-support-for-rgmii-rxid.patch
+++ b/pkg/u-boot/patches/patches-v2020.07/0004-bcmgenet-Add-support-for-rgmii-rxid.patch
@@ -1,0 +1,33 @@
+From 34873f46bacb039a1f7f8d8147664150bfec2a2d Mon Sep 17 00:00:00 2001
+From: Jason Wessel <jason.wessel@windriver.com>
+Date: Fri, 17 Jul 2020 06:32:00 -0700
+Subject: [PATCH] bcmgenet: Add support for rgmii-rxid
+
+The commit 57805f2270c4 ("net: bcmgenet: Don't set ID_MODE_DIS when
+not using RGMII") needed to be extended for the case of using the
+rgmii-rxid.  The latest version of the Rasbperry Pi4 dtb files for the
+5.4 now specify the rgmii-rxid.
+
+Signed-off-by: Jason Wessel <jason.wessel@windriver.com>
+Tested-by: Petr Tesarik <ptesarik@suse.com>
+Signed-off-by: Matthias Brugger <mbrugger@suse.com>
+---
+ drivers/net/bcmgenet.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/bcmgenet.c b/drivers/net/bcmgenet.c
+index 1b7e7ba2bf..ace1331362 100644
+--- a/drivers/net/bcmgenet.c
++++ b/drivers/net/bcmgenet.c
+@@ -457,7 +457,8 @@ static int bcmgenet_adjust_link(struct bcmgenet_eth_priv *priv)
+ 	clrsetbits_32(priv->mac_reg + EXT_RGMII_OOB_CTRL, OOB_DISABLE,
+ 			RGMII_LINK | RGMII_MODE_EN);
+
+-	if (phy_dev->interface == PHY_INTERFACE_MODE_RGMII)
++	if (phy_dev->interface == PHY_INTERFACE_MODE_RGMII ||
++	    phy_dev->interface == PHY_INTERFACE_MODE_RGMII_RXID)
+ 		setbits_32(priv->mac_reg + EXT_RGMII_OOB_CTRL, ID_MODE_DIS);
+
+ 	writel(speed << CMD_SPEED_SHIFT, (priv->mac_reg + UMAC_CMD));
+--
+2.25.1

--- a/tools/parse-pkgs.sh
+++ b/tools/parse-pkgs.sh
@@ -84,6 +84,7 @@ sed -e "s#CURDIR#$(pwd)#" \
     -e "s#UEFI_TAG#${UEFI_TAG}#" \
     -e "s#EVE_TAG#${EVE_TAG}#" \
     -e "s#KVMTOOLS_TAG#${KVMTOOLS_TAG}#" \
+    -e "s#IPXE_TAG#${IPXE_TAG}#" \
     ${1:-}
 }
 
@@ -130,6 +131,7 @@ DEBUG_TAG=$(linuxkit_tag pkg/debug)
 VTPM_TAG=$(linuxkit_tag pkg/vtpm)
 UEFI_TAG=$(linuxkit_tag pkg/uefi)
 KVMTOOLS_TAG=$(linuxkit_tag pkg/kvm-tools)
+IPXE_TAG=$(linuxkit_tag pkg/ipxe)
 
 # Synthetic tags: the following tags are based on hashing
 # the contents of all the Dockerfile.in that we can find.


### PR DESCRIPTION
Initial support for netboot RPi 4.

- Add patch for u-boot to fix tftpboot
- Add pathes for ipxe to work on u-boot (no nap) and to support ntp (we have no RTC on RPi
- Add boot.scr.uimg with script for u-boot to load ipxe.efi and run it
- Fix installer image to use boot instead of efi for arm64
- Export all needed files from installer for rpi (discussible)