### PR TITLE
linuxkit/containerd with stripped binaries

### DIFF
--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/getty:v0.5
   - linuxkit/memlogd:v0.5
   - GRUB_TAG


### PR DESCRIPTION
Updated linuxkit/containerd with stripped binaries helps us to reduce size from 242MB to 225MB (for kvm/amd64).

Thanks @deitch for reviewing of PR and signing of images.
part of #1768 

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>