### PR TITLE
Add metadata server to zedrouter take 2.

### DIFF
--- a/docs/ECO-METADATA.md
+++ b/docs/ECO-METADATA.md
@@ -1,0 +1,46 @@
+# EVE meta-data server for app instances
+
+EVE provides an old method to serve cloud-init meta-data in the form of a read-only CDROM disk which is created on the fly when an app instance is booted if the API specifies userData/cipherData in the [AppInstanceConfig message](../api/proto/config/appconfig.proto).
+
+However, there is also a need to provide access to meta-data which might change while the app instance is running.
+
+The first data which is needed by applications is determining the external IP address of the edge node, so that when there is a portmap ACL in place the application instance can determine which IP plus port its peers should use to connect to it.
+
+The initial meta-data service provides merely that, but over time we expect to add the rest of the cloud-init content.
+
+## Schema
+
+There is no existing industry standard schema specifying a notion of an external IP; existing schemas contain public and private IP addresses but the external IP is a different thing necessitated by the internal NAT which EVE deploys for the local network instances.
+
+Thus this particular part of the meta-data uses a EVE-unique schema, which we do not expect for other meta-data information.
+
+The API endpoint is <http://169.254.169.254/eve/v1/network.json>
+
+The returned json contains
+
+- caller-ip: a string with the IP address and TCP port of the requesting app instance
+- external-ipv4: a string with the external IPv4 address
+- hostname: a string with the UUID hostname assigned to the app instance
+
+Note that there is no need to specify the application instance identity since the meta-data server in EVE determines that from the virtual network adapter the application instance is using to communicate with EVE.
+
+## Example usage
+
+curl <http://169.254.169.254/eve/v1/network.json>
+
+{"caller-ip":"10.1.0.2:39380","external-ipv4":"192.168.1.10","hostname":"afa43e51-56b7-4021-a5fa-4272b0381913"}
+
+## Application instances with multiple network interface adapters
+
+If an application instance has multiple network adapters it needs to specify a particular one by explicitly connecting out over a given adapter.
+With curl that is done using the --interface option, e.g.,
+
+curl --interface eth0 <http://169.254.169.254/eve/v1/network.json>
+
+## Additional API endpoints
+
+The schema also provides an API endpoint to avoid parsing json, however this endpoint might be deprecated in the future.
+
+curl <http://169.254.169.254/eve/v1/external_ipv4>
+
+192.168.1.10

--- a/pkg/pillar/cmd/zedrouter/acl.go
+++ b/pkg/pillar/cmd/zedrouter/acl.go
@@ -361,6 +361,14 @@ func aclToRules(aclArgs types.AppNetworkACLArgs, ACLs []types.ACE) (types.IPTabl
 				"-p", "tcp", "--sport", "domain"}
 			aclRule4.Action = []string{"-j", "ACCEPT"}
 			rulesList = append(rulesList, aclRule1, aclRule2, aclRule3, aclRule4)
+
+			aclRule1.Rule = []string{"-i", aclArgs.BridgeName, "-d", "169.254.169.254",
+				"-p", "tcp", "--dport", "http"}
+			aclRule1.Action = []string{"-j", "ACCEPT"}
+			aclRule2.Rule = []string{"-i", aclArgs.BridgeName, "-s", "169.254.169.254",
+				"-p", "tcp", "--sport", "http"}
+			aclRule2.Action = []string{"-j", "ACCEPT"}
+			rulesList = append(rulesList, aclRule1, aclRule2)
 		} else if aclArgs.NIType == types.NetworkInstanceTypeSwitch {
 			aclRule1.Rule = []string{"-i", aclArgs.BridgeName, "-m", "set",
 				"--match-set", "ipv6.local", "dst", "-p", "ipv6-icmp"}
@@ -409,6 +417,15 @@ func aclToRules(aclArgs types.AppNetworkACLArgs, ACLs []types.ACE) (types.IPTabl
 				"--physdev-out", aclArgs.VifName}
 			aclRule4.Action = []string{"-j", "ACCEPT"}
 			rulesList = append(rulesList, aclRule1, aclRule2, aclRule3, aclRule4)
+			aclRule1.Rule = []string{"-i", aclArgs.BridgeName,
+				"-d", "169.254.169.254",
+				"-p", "tcp", "--dport", "http"}
+			aclRule1.Action = []string{"-j", "ACCEPT"}
+			aclRule2.Rule = []string{"-i", aclArgs.BridgeName,
+				"-s", "169.254.169.254",
+				"-p", "tcp", "--sport", "http"}
+			aclRule2.Action = []string{"-j", "ACCEPT"}
+			rulesList = append(rulesList, aclRule1, aclRule2)
 		}
 	}
 	// The same rules as above for IPv4.
@@ -447,6 +464,14 @@ func aclToRules(aclArgs types.AppNetworkACLArgs, ACLs []types.ACE) (types.IPTabl
 			aclRule4.Action = []string{"-j", "ACCEPT"}
 			rulesList = append(rulesList, aclRule1, aclRule2, aclRule3, aclRule4)
 
+			aclRule1.Rule = []string{"-i", aclArgs.BridgeName, "-d", "169.254.169.254",
+				"-p", "tcp", "--dport", "http"}
+			aclRule1.Action = []string{"-j", "ACCEPT"}
+			aclRule2.Rule = []string{"-i", aclArgs.BridgeName, "-s", "169.254.169.254",
+				"-p", "tcp", "--sport", "http"}
+			aclRule2.Action = []string{"-j", "ACCEPT"}
+			rulesList = append(rulesList, aclRule1, aclRule2)
+
 			aclRule5.Table = "mangle"
 			aclRule5.Chain = "PREROUTING"
 			aclRule5.Rule = []string{"-i", aclArgs.BridgeName, "-d", aclArgs.BridgeIP,
@@ -463,6 +488,16 @@ func aclToRules(aclArgs types.AppNetworkACLArgs, ACLs []types.ACE) (types.IPTabl
 			chainName = fmt.Sprintf("proto-%s-%s-%d",
 				aclArgs.BridgeName, aclArgs.VifName, 7)
 			createMarkAndAcceptChain(aclArgs, chainName, 7)
+			aclRule5.Action = []string{"-j", chainName}
+			aclRule5.ActionChainName = chainName
+			rulesList = append(rulesList, aclRule5)
+
+			aclRule5.Rule = []string{"-i", aclArgs.BridgeName,
+				"-d", "169.254.169.254",
+				"-p", "tcp", "--dport", "http"}
+			chainName = fmt.Sprintf("proto-%s-%s-%d",
+				aclArgs.BridgeName, aclArgs.VifName, 8)
+			createMarkAndAcceptChain(aclArgs, chainName, 8)
 			aclRule5.Action = []string{"-j", chainName}
 			aclRule5.ActionChainName = chainName
 			rulesList = append(rulesList, aclRule5)
@@ -511,6 +546,16 @@ func aclToRules(aclArgs types.AppNetworkACLArgs, ACLs []types.ACE) (types.IPTabl
 			chainName = fmt.Sprintf("proto-%s-%s-%d",
 				aclArgs.BridgeName, aclArgs.VifName, 7)
 			createMarkAndAcceptChain(aclArgs, chainName, 7)
+			aclRule5.Action = []string{"-j", chainName}
+			aclRule5.ActionChainName = chainName
+			rulesList = append(rulesList, aclRule5)
+
+			aclRule5.Rule = []string{"-i", aclArgs.BridgeName,
+				"-d", "169.254.169.254",
+				"-p", "tcp", "--dport", "http"}
+			chainName = fmt.Sprintf("proto-%s-%s-%d",
+				aclArgs.BridgeName, aclArgs.VifName, 8)
+			createMarkAndAcceptChain(aclArgs, chainName, 8)
 			aclRule5.Action = []string{"-j", chainName}
 			aclRule5.ActionChainName = chainName
 			rulesList = append(rulesList, aclRule5)

--- a/pkg/pillar/cmd/zedrouter/server.go
+++ b/pkg/pillar/cmd/zedrouter/server.go
@@ -1,0 +1,222 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// A http server providing meta-data information to application instances
+// at http://169.254.169.254. The source IP address is used to tell
+// which app instance is sending the request
+
+package zedrouter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/lf-edge/eve/pkg/pillar/iptables"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// Provides a json file
+type networkHandler struct {
+	ctx *zedrouterContext
+}
+
+// Provides a LF-terminated text
+type externalIPHandler struct {
+	ctx *zedrouterContext
+}
+
+// Provides a LF-terminated text
+type hostnameHandler struct {
+	ctx *zedrouterContext
+}
+
+func createServer4(ctx *zedrouterContext, bridgeIP string, bridgeName string) error {
+	mux := http.NewServeMux()
+	nh := &networkHandler{ctx: ctx}
+	mux.Handle("/eve/v1/network.json", nh)
+	ipHandler := &externalIPHandler{ctx: ctx}
+	mux.Handle("/eve/v1/external_ipv4", ipHandler)
+	hostnameHandler := &hostnameHandler{ctx: ctx}
+	mux.Handle("/eve/v1/hostname", hostnameHandler)
+
+	targetPort := 80
+	subnetStr := "169.254.169.254/32"
+	target := fmt.Sprintf("%s:%d", bridgeIP, targetPort)
+	log.Noticef("add NAT to target %s", target)
+	if err := iptables.IptableCmd(log, "-t", "nat", "-I", "PREROUTING",
+		"-i", bridgeName, "-p", "tcp", "-d", subnetStr,
+		"--dport", strconv.Itoa(targetPort),
+		"-j", "DNAT", "--to-destination", target); err != nil {
+		log.Errorf("failed to add DNAT: %s", err)
+	}
+	doneChan := make(chan struct{})
+	// Need one server per local IP address
+	// XXX once we have an IPv6 bridge IP address add:
+	// go runServer(mux, "tcp6", "["+bridgeIP6+"%"+bridgeName+"]")
+	go runServer(mux, "tcp4", bridgeIP, doneChan)
+	setDoneChan(bridgeName, bridgeIP, doneChan)
+	log.Noticef("started http server on %s/%s", bridgeName, bridgeIP)
+	return nil
+}
+
+func deleteServer4(ctx *zedrouterContext, bridgeIP string, bridgeName string) {
+	targetPort := 80
+	subnetStr := "169.254.169.254/32"
+	target := fmt.Sprintf("%s:%d", bridgeIP, targetPort)
+	log.Noticef("add NAT to target %s", target)
+	if err := iptables.IptableCmd(log, "-t", "nat", "-D", "PREROUTING",
+		"-i", bridgeName, "-p", "tcp", "-d", subnetStr,
+		"--dport", strconv.Itoa(targetPort),
+		"-j", "DNAT", "--to-destination", target); err != nil {
+		log.Errorf("failed to delete DNAT: %s", err)
+	}
+	doneChan, ok := getDoneChan(bridgeName, bridgeIP)
+	if !ok {
+		log.Errorf("no doneChan to stop server on %s/%s",
+			bridgeName, bridgeIP)
+	} else {
+		doneChan <- struct{}{}
+		// XXX should we wait for servers to exit?
+	}
+	log.Noticef("stopped http server on %s/%s", bridgeName, bridgeIP)
+}
+
+// map from bridgeName/bridgeIP to doneChan
+type doneChanKey struct {
+	bridgeName string
+	bridgeIP   string
+}
+
+var mapToDoneChan = make(map[doneChanKey]chan<- struct{})
+
+func setDoneChan(bridgeName string, bridgeIP string, doneChan chan<- struct{}) {
+	key := doneChanKey{bridgeName: bridgeName, bridgeIP: bridgeIP}
+	if _, exists := mapToDoneChan[key]; exists {
+		log.Fatalf("setDoneChan: key already exists %+v", key)
+	}
+	mapToDoneChan[key] = doneChan
+}
+
+func getDoneChan(bridgeName string, bridgeIP string) (chan<- struct{}, bool) {
+	key := doneChanKey{bridgeName: bridgeName, bridgeIP: bridgeIP}
+	doneChan, exists := mapToDoneChan[key]
+	if !exists {
+		log.Errorf("getDoneChan: key does not exist %+v", key)
+	} else {
+		delete(mapToDoneChan, key)
+	}
+	return doneChan, exists
+}
+
+func runServer(mux http.Handler, network string, ipaddr string,
+	doneChan <-chan struct{}) {
+
+	// XXX no to place to specify network. Might be an issue when we
+	// add IPv6?
+	srv := http.Server{
+		Addr:    ipaddr + ":80",
+		Handler: mux,
+	}
+	idleConnsClosed := make(chan struct{})
+	go func() {
+		<-doneChan
+
+		// We received an interrupt signal, shut down.
+		if err := srv.Shutdown(context.Background()); err != nil {
+			// Error from closing listeners, or context timeout:
+			log.Noticef("server on %s shutdown failed: %s", ipaddr, err)
+		}
+		close(idleConnsClosed)
+	}()
+
+	if err := srv.ListenAndServe(); err != nil {
+		if err == http.ErrServerClosed {
+			log.Noticef("server on %s closed", ipaddr)
+		} else {
+			log.Fatalf("server on %s failed: %s", ipaddr, err)
+		}
+	}
+	<-idleConnsClosed
+}
+
+// ServeHTTP for networkHandler provides a json return
+func (hdl networkHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	remoteIP := net.ParseIP(strings.Split(r.RemoteAddr, ":")[0])
+	externalIP, code := getExternalIPForApp(hdl.ctx, remoteIP)
+	var ipStr string
+	var hostname string
+	// Avoid returning the string <nil>
+	if len(externalIP) != 0 {
+		ipStr = externalIP.String()
+	}
+	anStatus := lookupAppNetworkStatusByAppIP(hdl.ctx, remoteIP)
+	if anStatus != nil {
+		hostname = anStatus.UUIDandVersion.UUID.String()
+	}
+	w.Header().Add("Content-Type", "application/json")
+	w.WriteHeader(code)
+	resp, _ := json.Marshal(map[string]string{
+		"caller-ip":     r.RemoteAddr,
+		"external-ipv4": ipStr,
+		"hostname":      hostname,
+		// TBD: add public-ipv4 when controller tells us
+	})
+	w.Write(resp)
+}
+
+// ServeHTTP for externalIPHandler provides a text IP address
+func (hdl externalIPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	remoteIP := net.ParseIP(strings.Split(r.RemoteAddr, ":")[0])
+	externalIP, code := getExternalIPForApp(hdl.ctx, remoteIP)
+	w.WriteHeader(code)
+	w.Header().Add("Content-Type", "text/plain")
+	// Avoid returning the string <nil>
+	if len(externalIP) != 0 {
+		resp := []byte(externalIP.String() + "\n")
+		w.Write(resp)
+	}
+}
+
+func getExternalIPForApp(ctx *zedrouterContext, remoteIP net.IP) (net.IP, int) {
+	netstatus := lookupNetworkInstanceStatusByAppIP(ctx, remoteIP)
+	if netstatus == nil {
+		log.Errorf("No NetworkInstanceStatus for %s",
+			remoteIP.String())
+		return net.IP{}, http.StatusNotFound
+	}
+	if netstatus.CurrentUplinkIntf == "" {
+		log.Warnf("No CurrentUplinkIntf for %s",
+			remoteIP.String())
+		// Nothing to report */
+		return net.IP{}, http.StatusNoContent
+	}
+	ip, err := types.GetLocalAddrAnyNoLinkLocal(*ctx.deviceNetworkStatus,
+		0, netstatus.CurrentUplinkIntf)
+	if err != nil {
+		log.Errorf("No externalIP for %s: %s",
+			remoteIP.String(), err)
+		return net.IP{}, http.StatusNoContent
+	}
+	return ip, http.StatusOK
+}
+
+// ServeHTTP for hostnameHandler returns text
+func (hdl hostnameHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	remoteIP := net.ParseIP(strings.Split(r.RemoteAddr, ":")[0])
+	anStatus := lookupAppNetworkStatusByAppIP(hdl.ctx, remoteIP)
+	w.Header().Add("Content-Type", "text/plain")
+	if anStatus == nil {
+		w.WriteHeader(http.StatusNoContent)
+		log.Errorf("No AppNetworkStatus for %s",
+			remoteIP.String())
+	} else {
+		w.WriteHeader(http.StatusOK)
+		resp := []byte(anStatus.UUIDandVersion.UUID.String() + "\n")
+		w.Write(resp)
+	}
+}

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -677,6 +677,22 @@ func lookupAppNetworkStatus(ctx *zedrouterContext, key string) *types.AppNetwork
 	return &status
 }
 
+func lookupAppNetworkStatusByAppIP(ctx *zedrouterContext, ip net.IP) *types.AppNetworkStatus {
+
+	ipStr := ip.String()
+	pub := ctx.pubAppNetworkStatus
+	items := pub.GetAll()
+	for _, st := range items {
+		status := st.(types.AppNetworkStatus)
+		for _, ulStatus := range status.UnderlayNetworkList {
+			if ipStr == ulStatus.AllocatedIPAddr {
+				return &status
+			}
+		}
+	}
+	return nil
+}
+
 func lookupAppNetworkConfig(ctx *zedrouterContext, key string) *types.AppNetworkConfig {
 
 	sub := ctx.subAppNetworkConfig

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -1290,7 +1290,7 @@ func GetDNSServers(globalStatus DeviceNetworkStatus, ifname string) []net.IP {
 
 	var servers []net.IP
 	for _, us := range globalStatus.Ports {
-		if !us.IsMgmt {
+		if !us.IsMgmt && ifname == "" {
 			continue
 		}
 		if ifname != "" && ifname != us.IfName {
@@ -1411,7 +1411,7 @@ func getInterfaceAndAddr(globalStatus DeviceNetworkStatus, free bool, phylabelOr
 	}
 	for _, us := range globalStatus.Ports {
 		if globalStatus.Version >= DPCIsMgmt &&
-			!us.IsMgmt {
+			!us.IsMgmt && ifname == "" {
 			continue
 		}
 		if free && !us.Free {
@@ -1541,7 +1541,7 @@ func GetMgmtPortFromAddr(globalStatus DeviceNetworkStatus, addr net.IP) string {
 }
 
 // Returns addresses based on free, ifname, and whether or not we want
-// IPv6 link-locals. Only applies to management ports.
+// IPv6 link-locals. Only applies to management ports unless ifname is set.
 // If free is not set, the addresses from the free management ports are first.
 func getInterfaceAddr(globalStatus DeviceNetworkStatus, free bool,
 	phylabelOrIfname string, includeLinkLocal bool) ([]net.IP, error) {
@@ -1559,7 +1559,7 @@ func getInterfaceAddr(globalStatus DeviceNetworkStatus, free bool,
 			continue
 		}
 		if globalStatus.Version >= DPCIsMgmt &&
-			!us.IsMgmt {
+			!us.IsMgmt && ifname == "" {
 			continue
 		}
 		// If ifname is set it should match


### PR DESCRIPTION
Currently implements services to return the external IP for the associated network instance and the hostname of the app instance

We had to back out the first take since it was creating an interface with the IP address 169.254.169.254 which meant all packets got routed locally to itself, whether the origin was from the application instances or from the host itself, and in GCP the host needs to be able to talk to an external DNS server at that IP address.
Thus take 2 instead runs the server on the bridgeIP address and has fixed SNAT and DNAT rules which only apply to packets coming from the application instances on the bnX bridge.