### PR TITLE
Starting to publish file assets for EVE releases on GitHub

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Determine architecture prefix
+        run: |
+          echo "ARCH=$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')" >> "$GITHUB_ENV"
       - name: Login to DockerHUB
         run: |
           echo "${{ secrets.RELEASE_DOCKERHUB_TOKEN }}" |\
@@ -64,3 +67,67 @@ jobs:
           rm -rf dist
           mv -f dist.kvm dist
           make LINUXKIT_PKG_TARGET=push HV=kvm eve
+      - name: Create a GitHub release and clean up artifacts
+        id: create-release
+        uses: actions/github-script@v3
+        with:
+          result-encoding: string
+          script: |
+            console.log(context)
+            tag = ''
+            if (context.payload.ref === 'refs/heads/main') {
+              tag = '0.0.0'
+            } else {
+              tag = context.payload.ref.split('/', 3)[2]
+            }
+
+            // first create a release -- it is OK if that fails,
+            // since it means the release is already there
+            try {
+              const raw = (await github.repos.createRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag_name: tag,
+                name: 'Release ' + tag,
+                prerelease: true,
+              })).data
+              console.log(raw)
+            } catch (e) {}
+
+            // get the release ID
+            const release = (await github.repos.getReleaseByTag({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag: tag,
+            })).data
+
+            // get assets for that ID
+            const assets = (await github.repos.listReleaseAssets({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: release.id,
+            })).data
+
+            // remove all assets (since we will be uploading new ones)
+            if (Array.isArray(assets) && assets.length > 0) {
+              for (const asset of assets) {
+                await github.repos.deleteReleaseAsset({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  asset_id: asset.id,
+                })
+              }
+            }
+
+            return release.upload_url
+
+      - name: Upload rootfs for the release
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.result }}
+          asset_path: dist/${{ env.ARCH }}/installer/rootfs.img
+          asset_name: ${{ env.ARCH }}.rootfs.img
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
This automates our release publishing AND allows us to have a place to store all the continuous snapshot builds.

For now, we're simply publishing rootfs.img for both architectures, but if this works well, I'll add all the files required to do a netboot to the artifacts as well.