### PR TITLE
fix PATH for tools

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -89,7 +89,7 @@ You must have the following installed in order to build EVE:
 
 Each "Installed as Needed" build tool will place its final executable in `${GOPATH}/bin/`, e.g. `~/go/bin/linuxkit`.
 
-To build a specific tool, you can execute `make $(go env GOPATH)/bin/<tool-name>`, e.g. `make $(go env GOPATH)/bin/linuxkit`.
+To build a specific tool, you can execute `make build-tools/bin/<tool-name>`, e.g. `make build-tools/bin/bin/linuxkit`.
 
 This target does the following:
 

--- a/tools/makeconfig.sh
+++ b/tools/makeconfig.sh
@@ -4,7 +4,7 @@
 #      ./makeconfig.sh <output.img> <version> [list of config files]
 #
 EVE="$(cd "$(dirname "$0")" && pwd)/../"
-PATH="$(go env GOPATH)/bin:$PATH"
+PATH="$EVE/build-tools/bin:$PATH"
 MKCONFIG_TAG="$(linuxkit pkg show-tag "$EVE/pkg/mkconf")"
 IMAGE="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
 ROOTFS_VERSION="$2"

--- a/tools/makeflash.sh
+++ b/tools/makeflash.sh
@@ -4,7 +4,7 @@
 #      ./makeflash.sh [-C size] <input dir> <output.img> [partitions]
 #
 EVE="$(cd "$(dirname "$0")" && pwd)/../"
-PATH="$(go env GOPATH)/bin:$PATH"
+PATH="$EVE/build-tools/bin:$PATH"
 MKFLASH_TAG="$(linuxkit pkg show-tag "$EVE/pkg/mkimage-raw-efi")"
 
 if [ "$1" = "-C" ]; then

--- a/tools/makeiso.sh
+++ b/tools/makeiso.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 EVE="$(cd "$(dirname "$0")" && pwd)/../"
-PATH="$(go env GOPATH)/bin:$PATH"
+PATH="$EVE/build-tools/bin:$PATH"
 MKIMAGE_TAG="$(linuxkit pkg show-tag "$EVE/pkg/mkimage-iso-efi")"
 SOURCE="$(cd "$1" && pwd)"
 ISO="$(cd "$(dirname "$2")" && pwd)/$(basename "$2")"

--- a/tools/makerootfs.sh
+++ b/tools/makerootfs.sh
@@ -7,7 +7,7 @@ set -e
 set -o pipefail
 
 EVE="$(cd "$(dirname "$0")" && pwd)/../"
-PATH="$(go env GOPATH)/bin:$PATH"
+PATH="$EVE/build-tools/bin:$PATH"
 MKROOTFS_TAG="$(linuxkit pkg show-tag "$EVE/pkg/mkrootfs-${3:-squash}")"
 YMLFILE="$1"
 IMAGE="$(cd "$(dirname "$2")" && pwd)/$(basename "$2")"

--- a/tools/makeusbconf.sh
+++ b/tools/makeusbconf.sh
@@ -6,7 +6,7 @@
 USAGE="Usage: $0 [-d] [-i] [-s <size in Kb>] [-f <file> ] <output.img>"
 
 EVE="$(cd "$(dirname "$0")" && pwd)/../"
-PATH="$(go env GOPATH)/bin:$PATH"
+PATH="$EVE/build-tools/bin:$PATH"
 MKFLASH_TAG="$(linuxkit pkg show-tag "$EVE/pkg/mkimage-raw-efi")"
 
 cleanup() {

--- a/tools/parse-pkgs.sh
+++ b/tools/parse-pkgs.sh
@@ -5,7 +5,7 @@
 # [1] A poor man is a man on a deadline.
 #
 EVE="$(cd "$(dirname "$0")" && pwd)/../"
-PATH="$(go env GOPATH)/bin:$PATH"
+PATH="$EVE/build-tools/bin:$PATH"
 
 get_git_tag() {
   echo ${EVE_HASH:-$(git tag -l --points-at HEAD | grep '[0-9]*\.[0-9]*\.[0-9]*' | head -1)}


### PR DESCRIPTION
The previous PR #1796 accidentally changed the PATH location for various utilities in `tools/`. Originally the newly build build tool was going to go in `GOBIN`, so all the tools were changed to point there. Then we switched it back to its original location of `build-tools/bin/`, but never switched these tools back.

This fixes (i.e. reverts the bad changes) just on `tools/` and the one doc.