### PR TITLE
linuxkit to use local docker cache

### DIFF
--- a/tools/makerootfs.sh
+++ b/tools/makerootfs.sh
@@ -18,4 +18,4 @@ if [ ! -f "$YMLFILE" ] || [ $# -lt 2 ]; then
 fi
 
 : > "$IMAGE"
-linuxkit build -o - "$YMLFILE" | docker run -i --rm -v /dev:/dev --privileged -v "$IMAGE:/rootfs.img" "${MKROOTFS_TAG}"
+linuxkit build -docker -o - "$YMLFILE" | docker run -i --rm -v /dev:/dev --privileged -v "$IMAGE:/rootfs.img" "${MKROOTFS_TAG}"


### PR DESCRIPTION
The newer version of linuxkit uses _only_ its own OCI cache, does not look in docker image cache. This creates a problem when we do builds that create images in local docker cache.

This PR adds `--docker` so that linuxkit looks locally first.

cc @giggsoff 