### PR TITLE
Add dependabot.yml for Dockerfile versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,77 @@
+---
+# .github/dependabot.yml: Config file for Dependabot
+#
+# Each pkg/* subdir must be listed separately.
+# Only configured for Dockerfiles that do not hardwire package versions.
+
+version: 2
+updates:
+  # Enable version updates for Docker
+  - package-ecosystem: "docker"
+    directory: "/pkg/alpine"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "docker"
+    directory: "/pkg/dnsmasq"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "docker"
+    directory: "/pkg/gpt-tools"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "docker"
+    directory: "/pkg/grub"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "docker"
+    directory: "/pkg/guacd"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "docker"
+    directory: "/pkg/mkimage-iso-efi"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "docker"
+    directory: "/pkg/mkrootfs-ext4"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "docker"
+    directory: "/pkg/mkrootfs-squash"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "docker"
+    directory: "/pkg/qrexec-dom0"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "docker"
+    directory: "/pkg/qrexec-lib"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "docker"
+    directory: "/pkg/rngd"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "docker"
+    directory: "/pkg/strongswan"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "docker"
+    directory: "/pkg/uefi"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "docker"
+    directory: "/pkg/watchdog"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "docker"
+    directory: "/pkg/wlan"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "docker"
+    directory: "/pkg/wwan"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "docker"
+    directory: "/pkg/xen"
+    schedule:
+      interval: "monthly"

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -93,3 +93,30 @@ local build.
 It may be marginally useful to run Yetus on updates to the master itself, but Yetus in its full
 glory will generate too much feedback and the incremental updates are already covered by Yetus
 triggering on pull request submissions.
+
+## Maintaining Dockerfile Versions
+
+The Dockerfiles get out of date because they use base OS images that are periodically updated.
+It is important to stay up-to-date in general for bug fixes and security updates,
+but sometimes the Dockerfiles must be updated immediately when the OS image
+removes a version of a package.
+
+### Dockerfile Version Updates with Dependabot
+
+GitHub provides a feature called **Dependabot** that fixes several kinds of out of date versions
+including the OS images in Dockerfiles. The limitation is that it only updates the base OS image,
+not the package versions in the apk add command, so it can only be used in EVE packages that do not
+hardwire package versions.
+
+Dependabot should not be enabled in the reference lf-edge tree.
+Instead use it in user forks and let Dependabot create its PRs there.
+Then the user can cherry-pick the version changes, test, tweak, squash, and submit
+their own PR to lf-edge.
+
+To use Dependabot in a user fork:
+
+* enable Dependabot options in: Settings -> Security & analysis
+* open: Insights -> Dependency graph -> Dependabot
+* re-run by: modify this file, push to master
+* review generated PRs
+* cherry-pick from dependabot/docker/* branches


### PR DESCRIPTION
Configures GitHub to find out of date image versions in Dockerfiles.

(Originally had the Dockerfile changes, too.)
