### PR TITLE
Taking care of asynchrnous nature of our builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -114,13 +114,18 @@ jobs:
             })).data
 
             // remove all assets (since we will be uploading new ones)
+            // note that we only consider assets coming from the same
+            // architecture we're running on -- this is because GH
+            // release assets can only be flat (no folders allowed)
             if (Array.isArray(assets) && assets.length > 0) {
               for (const asset of assets) {
-                await github.repos.deleteReleaseAsset({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  asset_id: asset.id,
-                })
+                if (asset.name.startsWith('${{ env.ARCH }}')) {
+                  await github.repos.deleteReleaseAsset({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    asset_id: asset.id,
+                  })
+                }
               }
             }
 


### PR DESCRIPTION
Since GH assets are flat set of files (no folders allowed) we emulate architecture specific folders via architecture prefixes, so that what really should've been `arm64/rootfs.img` or `amd64/rootfs.img` becomes `arm64.rootfs.img` or `amd64.rootfs.img`. And then we need to check for the prefix when we want to flush the folder that belong to the architecture for which we're re-generating assets.