### PR TITLE
make gobuilder an order-only dependency of linuxkit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -520,7 +520,7 @@ shell: $(GOBUILDER)
 
 # build linuxkit for the host OS, not the container OS
 $(LINUXKIT): GOOS=$(shell uname -s | tr '[A-Z]' '[a-z]')
-$(LINUXKIT): $(GOBUILDER)
+$(LINUXKIT): | $(GOBUILDER)
 	@$(DOCKER_GO) \
 	"unset GOFLAGS; rm -rf /tmp/linuxkit && \
 	git clone $(LINUXKIT_SOURCE) /tmp/linuxkit && \


### PR DESCRIPTION
Every time we build something that depends on `build-tools/bin/linuxkit` and on `GOBUILDER`, it always builds `GOBUILDER`. Since target `linuxkit` depends on target `GOBUILDER`, and it always rebuilds `GOBUILDER`, it _always_ will rebuild `linuxkit`, even if it already exists.

This PR solves this partially be making `GOBUILDER` an order-only dependency of `linuxkit`, rather than a normal one.

This doesn't completely solve it. Really, `GOBUILDER` _should_ be a normal dependency, but `make` should be smart enough to realize we don't need to rebuild `GOBUILDER`, hence we don't need to rebuild linuxkit. But since make _isn't_ smart enough to understand container images, only files, this is a reasonable quick solution.

We might also want to think about downloading github.com/linuxkit/linuxkit to `/go/src/github.com/linuxkit/linuxkit` in the builder container - which maps to `.go/src/github.com/linuxkit/linuxkit` - and hence would be cached locally. That requires a little more git magic, will take a bit longer, so let's get this in first to resolve quick builds.

We can deal with the other two issues later:

* caching linuxkit source in `.go/src/`
* teaching go not to rebuild the `GOBUILDER` container