### PR TITLE
cross build with linuxkit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -572,9 +572,9 @@ images/rootfs-%.yml.in: images/rootfs.yml.in FORCE
 
 $(ROOTFS_FULL_NAME)-adam-kvm-$(ZARCH).$(ROOTFS_FORMAT): $(ROOTFS_FULL_NAME)-kvm-adam-$(ZARCH).$(ROOTFS_FORMAT)
 $(ROOTFS_FULL_NAME)-kvm-adam-$(ZARCH).$(ROOTFS_FORMAT): images/rootfs-%.yml $(SSH_KEY) | $(INSTALLER)
-	./tools/makerootfs.sh $< $@ $(ROOTFS_FORMAT)
+	./tools/makerootfs.sh $< $@ $(ROOTFS_FORMAT) $(ZARCH)
 $(ROOTFS_FULL_NAME)-%-$(ZARCH).$(ROOTFS_FORMAT): images/rootfs-%.yml | $(INSTALLER)
-	./tools/makerootfs.sh $< $@ $(ROOTFS_FORMAT)
+	./tools/makerootfs.sh $< $@ $(ROOTFS_FORMAT) $(ZARCH)
 	@echo "size of $@ is $$(wc -c < "$@")B"
 	@[ $$(wc -c < "$@") -gt $$(( 250 * 1024 * 1024 )) ] && \
           echo "ERROR: size of $@ is greater than 250MB (bigger than allocated partition)" && exit 1 || :

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -158,8 +158,8 @@ For a live bootable image, named `live.img`, we create the following dependencie
 `rootfs.img` is a bootable root filesystem. To build it:
 
 1. Verify the existence of the linuxkit builder configuration file `images/rootfs.yml`. See notes on [generating yml](#generating-yml).
-2. Call `makerootfs.sh images/rootfs.yml <format> rootfs.img`, which will:
-    1. Build an image using `linuxkit` with a tar output format using `images/rootfs.yml` as the configuration file..
+2. Call `makerootfs.sh images/rootfs.yml rootfs.img <format> <arch>`, which will:
+    1. Build an image for the target architecture `<arch>` using `linuxkit` with a tar output format using `images/rootfs.yml` as the configuration file.
     2. Pipe the contents of the tar image to a docker container from either `mkrootfs-ext4` or `mkrootfs-squash`, depending on desired output format.
     3. `mkrootfs-*` takes the contents of the tar image, modifies `grub.cf`, builds it into an ext4 filesystem image, and streams it to stdout.
     4. Direct the output to the targeted filename, in this case `rootfs.img`.
@@ -244,8 +244,8 @@ For an installable image, named `installer.img`, we create the following depende
 To build `rootfs_installer.img`:
 
 1. Ensure the existence of the prerequisites: `rootfs.img`, `config.img`, `images/installer.yml`. The `yml` file is the configuration file for using linuxkit to build the `rootfs_installer.img`. See notes on [generating yml](#generating-yml).
-2. Call `makerootfs.sh images/installer.yml <format> rootfs_installer.img`, which will:
-    1. Build an image using `linuxkit` with a tar output format using `images/installer.yml` as the configuration file..
+2. Call `makerootfs.sh images/installer.yml rootfs_installer.img <format> <arch>`, which will:
+    1. Build an image for the target architecture `<arch>` using `linuxkit` with a tar output format using `images/installer.yml` as the configuration file..
     2. Pipe the contents of the tar image to a docker container from either `mkrootfs-ext4` or `mkrootfs-squash`, depending on desired output format.
     3. `mkrootfs-*` takes the contents of the tar image, modifies `grub.cf`, builds it into an ext4 filesystem image, and streams it to stdout.
     4. Direct the output to the targeted filename, in this case `rootfs_installer.img`.

--- a/tools/makerootfs.sh
+++ b/tools/makerootfs.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 # Usage:
 #
-#     ./makerootfs.sh <image.yml> <output rootfs image>  [<fs>]
+#     ./makerootfs.sh <image.yml> <output rootfs image> <fs> <arch>
+# <fs> defaults to squash
+# <arch> defaults to the current machine architecture
 
 set -e
 set -o pipefail
@@ -17,5 +19,12 @@ if [ ! -f "$YMLFILE" ] || [ $# -lt 2 ]; then
     exit 1
 fi
 
+# did we specify an architecture?
+ARCH="$4"
+ARCHARG=""
+if [ -n "$ARCH" ]; then
+  ARCHARG="-arch ${ARCH}"
+fi
+
 : > "$IMAGE"
-linuxkit build -docker -o - "$YMLFILE" | docker run -i --rm -v /dev:/dev --privileged -v "$IMAGE:/rootfs.img" "${MKROOTFS_TAG}"
+linuxkit build -docker ${ARCHARG} -o - "$YMLFILE" | docker run -i --rm -v /dev:/dev --privileged -v "$IMAGE:/rootfs.img" "${MKROOTFS_TAG}"

--- a/tools/parse-pkgs.sh
+++ b/tools/parse-pkgs.sh
@@ -50,9 +50,7 @@ synthetic_tag() {
 }
 
 resolve_tags() {
-sed -e '/-.*linuxkit\/.*:/s# *$#'${ARCH}# \
-    -e '/image:.*linuxkit\/.*:/s# *$#'${ARCH}# \
-    -e "s#CURDIR#$(pwd)#" \
+sed -e "s#CURDIR#$(pwd)#" \
     -e "s#ACRN_KERNEL_TAG#$ACRN_KERNEL_TAG#" \
     -e "s#NEW_KERNEL_TAG#$NEW_KERNEL_TAG#" \
     -e "s#KERNEL_TAG#$KERNEL_TAG#" \


### PR DESCRIPTION
Now that we are using linuxkit with cross-building support, we need to enable it:

* add `-arch ${ARCH}` argument to `linuxkit build` so that it can build for a target architecture
* stop adding `-${ARCH}` to the container images that are official images from `linuxkit/<image>`, since those are multi-arch, and we now can just use them directly. This is necessary anyways, since only the multi-arch indexes are signed.

I have done some initial testing, but CI is what counts here.