### PR TITLE
remove dead HasEncap and Ipv4Eid

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -116,7 +116,6 @@ func prepareAndPublishNetworkInstanceInfoMsg(ctx *zedagentContext,
 			vi.AppID = v.AppID.String()
 			info.Vifs = append(info.Vifs, vi)
 		}
-		info.Ipv4Eid = status.Ipv4Eid
 		for _, ifname := range status.IfNameList {
 			ia := ctx.assignableAdapters.LookupIoBundleIfName(ifname)
 			if ia == nil {

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -1087,7 +1087,7 @@ func parseOneNetworkXObjectConfig(ctx *getconfigContext, netEnt *zconfig.Network
 
 	ipspec := netEnt.GetIp()
 	switch config.Type {
-	case types.NT_CryptoEID, types.NT_IPV4, types.NT_IPV6:
+	case types.NT_IPV4, types.NT_IPV6:
 		if ipspec == nil {
 			errStr := fmt.Sprintf("parseOneNetworkXObjectConfig: Missing ipspec for %s in %v",
 				config.Key(), netEnt)

--- a/pkg/pillar/cmd/zedrouter/dnsmasq.go
+++ b/pkg/pillar/cmd/zedrouter/dnsmasq.go
@@ -106,7 +106,7 @@ func dnsmasqDhcpHostDir(bridgeName string) string {
 func createDnsmasqConfiglet(
 	bridgeName string, bridgeIPAddr string,
 	netconf *types.NetworkInstanceConfig, hostsDir string,
-	ipsets []string, Ipv4Eid bool, uplink string,
+	ipsets []string, uplink string,
 	dnsServers []net.IP, ntpServers []net.IP) {
 
 	log.Functionf("createDnsmasqConfiglet(%s, %s) netconf %v, ipsets %v uplink %s dnsServers %v ntpServers %v",
@@ -198,8 +198,6 @@ func createDnsmasqConfiglet(
 	if netconf.Logicallabel == "" {
 		log.Functionf("Internal switch without external port case, dnsmasq suppress router advertize\n")
 		advertizeRouter = false
-	} else if Ipv4Eid {
-		advertizeRouter = false
 	} else if netconf.Gateway != nil {
 		if netconf.Gateway.IsUnspecified() {
 			advertizeRouter = false
@@ -221,9 +219,6 @@ func createDnsmasqConfiglet(
 		}
 	}
 	advertizeDns := false
-	if Ipv4Eid {
-		advertizeDns = true
-	}
 	for _, ns := range netconf.DnsServers {
 		advertizeDns = true
 		file.WriteString(fmt.Sprintf("dhcp-option=option:dns-server,%s\n",

--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -454,7 +454,7 @@ func doNetworkInstanceCreate(ctx *zedrouterContext,
 			status.CurrentUplinkIntf)
 		createDnsmasqConfiglet(bridgeName,
 			status.BridgeIPAddr, &status.NetworkInstanceConfig,
-			hostsDirpath, status.BridgeIPSets, status.Ipv4Eid,
+			hostsDirpath, status.BridgeIPSets,
 			status.CurrentUplinkIntf, dnsServers, ntpServers)
 		startDnsmasq(bridgeName)
 	}
@@ -735,7 +735,7 @@ func restartDnsmasq(ctx *zedrouterContext, status *types.NetworkInstanceStatus) 
 		status.CurrentUplinkIntf)
 	createDnsmasqConfiglet(bridgeName, status.BridgeIPAddr,
 		&status.NetworkInstanceConfig, hostsDirpath, status.BridgeIPSets,
-		status.Ipv4Eid, status.CurrentUplinkIntf, dnsServers, ntpServers)
+		status.CurrentUplinkIntf, dnsServers, ntpServers)
 	createHostDnsmasqFile(ctx, bridgeName)
 	startDnsmasq(bridgeName)
 }
@@ -863,9 +863,7 @@ func releaseIPv4FromNetworkInstance(ctx *zedrouterContext,
 func getPrefixLenForBridgeIP(
 	status *types.NetworkInstanceStatus) int {
 	var prefixLen int
-	if status.Ipv4Eid {
-		prefixLen = 32
-	} else if status.Subnet.IP != nil {
+	if status.Subnet.IP != nil {
 		prefixLen, _ = status.Subnet.Mask.Size()
 	} else if status.IsIPv6() {
 		prefixLen = 128
@@ -1717,7 +1715,7 @@ func doNetworkInstanceFallback(
 				status.CurrentUplinkIntf)
 			createDnsmasqConfiglet(bridgeName,
 				status.BridgeIPAddr, &status.NetworkInstanceConfig,
-				hostsDirpath, status.BridgeIPSets, status.Ipv4Eid,
+				hostsDirpath, status.BridgeIPSets,
 				status.CurrentUplinkIntf, dnsServers, ntpServers)
 			startDnsmasq(bridgeName)
 		}
@@ -1771,7 +1769,7 @@ func doNetworkInstanceFallback(
 				status.CurrentUplinkIntf)
 			createDnsmasqConfiglet(bridgeName,
 				status.BridgeIPAddr, &status.NetworkInstanceConfig,
-				hostsDirpath, status.BridgeIPSets, status.Ipv4Eid,
+				hostsDirpath, status.BridgeIPSets,
 				status.CurrentUplinkIntf, dnsServers, ntpServers)
 			startDnsmasq(bridgeName)
 		}

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -981,7 +981,7 @@ func appNetworkDoActivateUnderlayNetwork(
 			netInstStatus.CurrentUplinkIntf)
 		createDnsmasqConfiglet(bridgeName,
 			ulStatus.BridgeIPAddr, netInstConfig, hostsDirpath,
-			newIpsets, false, netInstStatus.CurrentUplinkIntf,
+			newIpsets, netInstStatus.CurrentUplinkIntf,
 			dnsServers, ntpServers)
 		startDnsmasq(bridgeName)
 	}
@@ -1383,7 +1383,7 @@ func doAppNetworkModifyUnderlayNetwork(
 			netstatus.CurrentUplinkIntf)
 		createDnsmasqConfiglet(bridgeName,
 			ulStatus.BridgeIPAddr, netconfig, hostsDirpath,
-			newIpsets, false, netstatus.CurrentUplinkIntf,
+			newIpsets, netstatus.CurrentUplinkIntf,
 			dnsServers, ntpServers)
 		startDnsmasq(bridgeName)
 	}
@@ -1555,7 +1555,7 @@ func appNetworkDoInactivateUnderlayNetwork(
 			netstatus.CurrentUplinkIntf)
 		createDnsmasqConfiglet(bridgeName,
 			ulStatus.BridgeIPAddr, netconfig, hostsDirpath,
-			newIpsets, false, netstatus.CurrentUplinkIntf,
+			newIpsets, netstatus.CurrentUplinkIntf,
 			dnsServers, ntpServers)
 		startDnsmasq(bridgeName)
 	}

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -1780,13 +1780,9 @@ type ULNetworkACLs struct {
 type NetworkType uint8
 
 const (
-	NT_NOOP      NetworkType = 0
-	NT_IPV4                  = 4
-	NT_IPV6                  = 6
-	NT_CryptoEID             = 14 // Either IPv6 or IPv4; IP Address
-	// determines whether IPv4 EIDs are in use.
-	NT_CryptoV4 = 24 // Not used
-	NT_CryptoV6 = 26 // Not used
+	NT_NOOP NetworkType = 0
+	NT_IPV4             = 4
+	NT_IPV6             = 6
 	// XXX Do we need a NT_DUAL/NT_IPV46? Implies two subnets/dhcp ranges?
 	// XXX how do we represent a bridge? NT_L2??
 )
@@ -1876,8 +1872,6 @@ type NetworkInstanceInfo struct {
 
 	// Set of vifs on this bridge
 	Vifs []VifNameMac
-
-	Ipv4Eid bool // Track if this is a CryptoEid with IPv4 EIDs
 
 	// Any errrors from provisioning the network
 	// ErrorAndTime provides SetErrorNow() and ClearError()

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -2149,7 +2149,6 @@ type NetworkInstanceConfig struct {
 	DhcpRange       IpRange
 	DnsNameToIPList []DnsNameToIP // Used for DNS and ACL ipset
 
-	HasEncap bool // Vpn, for adjusting pMTU
 	// For other network services - Proxy / StrongSwan etc..
 	OpaqueConfig string
 }


### PR DESCRIPTION
@gkodali-zededa The comment says this was used for VPN and LISP, but I see no use of it after LISP was removed. Do you know if VPN ever used this HasEncap to reduce the MTU?

Removing unused field and associated code since only LISP ever used this.