### PR TITLE
Make switch network instance sharable

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -7,7 +7,6 @@ package zedagent
 
 import (
 	"bytes"
-	"net"
 	"strings"
 	"time"
 
@@ -456,43 +455,6 @@ func handleAppFlowMonitorDelete(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
 	log.Functionf("handleAppFlowMonitorDelete(%s)", key)
-}
-
-func handleAppVifIPTrigCreate(ctxArg interface{}, key string,
-	statusArg interface{}) {
-	handleAppVifIPTrigImpl(ctxArg, key, statusArg)
-}
-
-func handleAppVifIPTrigModify(ctxArg interface{}, key string,
-	statusArg interface{}, oldStatusArg interface{}) {
-	handleAppVifIPTrigImpl(ctxArg, key, statusArg)
-}
-
-func handleAppVifIPTrigImpl(ctxArg interface{}, key string,
-	statusArg interface{}) {
-
-	log.Functionf("handleAppVifIPTrigImpl(%s)", key)
-	ctx := ctxArg.(*zedagentContext)
-	trig := statusArg.(types.VifIPTrig)
-	findVifAndTrigAppInfoUpload(ctx, trig.MacAddr, trig.IPAddr)
-}
-
-func findVifAndTrigAppInfoUpload(ctx *zedagentContext, macAddr string, ipAddr net.IP) {
-	sub := ctx.getconfigCtx.subAppInstanceStatus
-	items := sub.GetAll()
-
-	for _, st := range items {
-		aiStatus := st.(types.AppInstanceStatus)
-		log.Tracef("findVifAndTrigAppInfoUpload: mac address %s match, ip %v, publish the info to cloud", macAddr, ipAddr)
-		uuidStr := aiStatus.Key()
-		aiStatusPtr := &aiStatus
-		if aiStatusPtr.MaybeUpdateAppIPAddr(macAddr, ipAddr.String()) {
-			log.Functionf("findVifAndTrigAppInfoUpload: underlay %v", aiStatusPtr.UnderlayNetworks)
-			PublishAppInfoToZedCloud(ctx, uuidStr, aiStatusPtr, ctx.assignableAdapters, ctx.iteration)
-			ctx.iteration++
-			break
-		}
-	}
 }
 
 func aclActionToProtoAction(action types.ACLActionType) flowlog.ACLAction {

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -96,7 +96,6 @@ type zedagentContext struct {
 	subBaseOsStatus           pubsub.Subscription
 	subNetworkInstanceMetrics pubsub.Subscription
 	subAppFlowMonitor         pubsub.Subscription
-	subAppVifIPTrig           pubsub.Subscription
 	pubGlobalConfig           pubsub.Publication
 	subGlobalConfig           pubsub.Subscription
 	subEdgeNodeCert           pubsub.Subscription
@@ -524,22 +523,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	subAppFlowMonitor.Activate()
 	flowQ = list.New()
 	log.Functionf("FlowStats: create subFlowStatus")
-
-	subAppVifIPTrig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName:     "zedrouter",
-		MyAgentName:   agentName,
-		TopicImpl:     types.VifIPTrig{},
-		Activate:      false,
-		Ctx:           &zedagentCtx,
-		CreateHandler: handleAppVifIPTrigCreate,
-		ModifyHandler: handleAppVifIPTrigModify,
-		WarningTime:   warningTime,
-		ErrorTime:     errorTime,
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
-	subAppVifIPTrig.Activate()
 
 	// Look for AppInstanceStatus from zedmanager
 	subAppInstanceStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
@@ -1244,9 +1227,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		case change := <-subAppFlowMonitor.MsgChan():
 			log.Tracef("FlowStats: change called")
 			subAppFlowMonitor.ProcessChange(change)
-
-		case change := <-subAppVifIPTrig.MsgChan():
-			subAppVifIPTrig.ProcessChange(change)
 
 		case change := <-subEdgeNodeCert.MsgChan():
 			subEdgeNodeCert.ProcessChange(change)

--- a/pkg/pillar/cmd/zedrouter/acl.go
+++ b/pkg/pillar/cmd/zedrouter/acl.go
@@ -994,6 +994,9 @@ func aceToRules(ctx *zedrouterContext, aclArgs types.AppNetworkACLArgs,
 	aclRule3.IsUserConfigured = true
 	aclRule3.RuleID = ace.RuleID
 	if aclArgs.NIType == types.NetworkInstanceTypeSwitch {
+
+		// XXX what about local-only switch network instance?
+		// XXX should skip trying to add this rule
 		if len(aclArgs.UpLinks) != 1 {
 			errStr := fmt.Sprintf("aceToRules: Switch network instance is only supported with exactly one " +
 				"uplink attached for now.")
@@ -1001,7 +1004,7 @@ func aceToRules(ctx *zedrouterContext, aclArgs types.AppNetworkACLArgs,
 			return nil, nil, errors.New(errStr)
 		} else {
 			aclRule3.Rule = append(aclRule3.Rule, "-m", "physdev",
-				"--physdev-in", aclArgs.UpLinks[0])
+				"--physdev-in", uplinkToPhysdev(aclArgs.UpLinks[0]))
 		}
 	}
 

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -946,7 +946,7 @@ func appNetworkDoActivateUnderlayNetwork(
 	}
 	log.Functionf("bridgeIPAddr %s appIPAddr %s\n", bridgeIPAddr, appIPAddr)
 	ulStatus.BridgeIPAddr = bridgeIPAddr
-	// XXX appIPAddr is "" if bridge service
+	// appIPAddr is "" for switch NI. DHCP snoop will set AllocatedIPAddr later
 	ulStatus.AllocatedIPAddr = appIPAddr
 	hostsDirpath := runDirname + "/hosts." + bridgeName
 	if appIPAddr != "" {

--- a/pkg/pillar/devicenetwork/dhcpcd.go
+++ b/pkg/pillar/devicenetwork/dhcpcd.go
@@ -24,7 +24,7 @@ import (
 
 // UpdateDhcpClient starts/modifies/deletes dhcpcd per interface
 // Assumes that the caller has checked that the interfaces exist
-// We therefor skip any interfaces which do not exist
+// We therefore skip any interfaces which do not exist
 func UpdateDhcpClient(log *base.LogObject, newConfig, oldConfig types.DevicePortConfig) {
 
 	// Look for adds or changes

--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -260,6 +260,10 @@ func VerifyPending(ctx *DeviceNetworkContext, pending *DPCPending,
 		checkAndUpdateWireless(ctx, &pending.RunningDPC, &runnableDPC)
 
 		log.Functionf("VerifyPending: DPC changed. update DhcpClient.\n")
+		// ensure we rename ethN to kethN and set up bridge called
+		// ethN; move MAC address to bridge. Reverse if removed from DPC
+		UpdateBridge(log, runnableDPC, pending.RunningDPC)
+
 		UpdateDhcpClient(log, runnableDPC, pending.RunningDPC)
 		pending.RunningDPC = runnableDPC
 		log.Functionf("Running with DPC %v", pending.RunningDPC)

--- a/pkg/pillar/devicenetwork/rename.go
+++ b/pkg/pillar/devicenetwork/rename.go
@@ -1,0 +1,207 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package devicenetwork
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/eriknordmark/netlink"
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// UpdateBridge ensures that all of the Ethernet interfaces
+// which will be used are in the form of a bridge, and all unused/pciback
+// Ethernet interfaces have no bridge
+// Assumes that the caller has checked that the interfaces exist
+// We therefore skip any interfaces which do not exist
+func UpdateBridge(log *base.LogObject, newConfig, oldConfig types.DevicePortConfig) {
+
+	// Look for adds
+	for _, newU := range newConfig.Ports {
+		oldU := lookupOnIfname(oldConfig, newU.IfName)
+		if oldU == nil {
+			addBridge(log, newU.IfName)
+		} else {
+			log.Functionf("UpdateBridge: found old %v", oldU)
+		}
+	}
+	// Look for deletes from oldConfig to newConfig
+	for _, oldU := range oldConfig.Ports {
+		newU := lookupOnIfname(newConfig, oldU.IfName)
+		if newU == nil {
+			removeBridge(log, oldU.IfName)
+		} else {
+			log.Functionf("UpdateBridge: found new %v", newU)
+		}
+	}
+}
+
+// Check if the name is an Ethernet and not a bridge
+// If so rename it to kethN and create a bridge and name it ethN
+// and move the MAC address
+func addBridge(log *base.LogObject, ifname string) error {
+	log.Noticef("addBridge(%s)", ifname)
+	if !strings.HasPrefix(ifname, "eth") {
+		log.Functionf("addBridge: skipping %s", ifname)
+		return nil
+	}
+	link, err := netlink.LinkByName(ifname)
+	if err != nil {
+		// Caller should have checked
+		err = fmt.Errorf("addBridge LinkByName(%s) failed: %v",
+			ifname, err)
+		log.Error(err)
+		return err
+	}
+	linkType := link.Type()
+	if linkType != "device" {
+		log.Noticef("addBridge: skipping %s type %s",
+			ifname, linkType)
+		return nil
+	}
+	kernIfname := "k" + ifname
+	_, err = netlink.LinkByName(kernIfname)
+	if err == nil {
+		err = fmt.Errorf("addBridge new name %s already exists",
+			kernIfname)
+		log.Error(err)
+		return err
+	}
+
+	// get macaddr and create the alternate with the group bit toggled
+	macAddr := link.Attrs().HardwareAddr
+	var altMacAddr net.HardwareAddr
+	if len(macAddr) != 0 {
+		altMacAddr = make([]byte, len(macAddr))
+		copy(altMacAddr, macAddr)
+		altMacAddr[0] = altMacAddr[0] ^ 2
+		log.Noticef("macAddr %s altMacAddr %s", macAddr, altMacAddr)
+
+		// Toggle macaddr on ifname - set to altMacAddr
+		if err := netlink.LinkSetHardwareAddr(link, altMacAddr); err != nil {
+			err = fmt.Errorf("addBridge LinkSetHardwareAddr(%s, %s) failed: %v",
+				ifname, altMacAddr, err)
+			log.Error(err)
+			return err
+		}
+	}
+	if err := types.IfRename(log, ifname, kernIfname); err != nil {
+		err = fmt.Errorf("addBridge IfRename(%s, %s) failed: %v",
+			ifname, kernIfname, err)
+		log.Error(err)
+		return err
+	}
+
+	// create bridge and name it ethN use macAddr
+	attrs := netlink.NewLinkAttrs()
+	attrs.Name = ifname
+	attrs.HardwareAddr = macAddr
+	bridge := &netlink.Bridge{LinkAttrs: attrs}
+	if err := netlink.LinkAdd(bridge); err != nil {
+		err = fmt.Errorf("addBridge LinkAdd(%s) failed: %v",
+			ifname, err)
+		log.Error(err)
+		return err
+	}
+	// Look up again after rename
+	kernLink, err := netlink.LinkByName(kernIfname)
+	if err != nil {
+		err = fmt.Errorf("addBridge LinkByName(%s) failed: %v",
+			kernIfname, err)
+		log.Error(err)
+		return err
+	}
+	// ip link set kethN master ethN
+	if err := netlink.LinkSetMaster(kernLink, bridge); err != nil {
+		err = fmt.Errorf("addBridge LinkSetMaster(%s, %s) failed: %v",
+			kernIfname, ifname, err)
+		log.Error(err)
+		return err
+	}
+	if err := netlink.LinkSetUp(bridge); err != nil {
+		err = fmt.Errorf("addBridge LinkSetUp(%s) failed: %v",
+			ifname, err)
+		log.Error(err)
+		return err
+	}
+	// update cached ifindex
+	UpdateIfnameToIndex(log, ifname)
+	return nil
+}
+
+// Check if the name is ethN and a bridge
+// If so delete it and find kethN and rename it back to ethN.
+// Also restore the Mac address on ethN
+func removeBridge(log *base.LogObject, ifname string) error {
+	log.Noticef("removeBridge(%s)", ifname)
+	if !strings.HasPrefix(ifname, "eth") {
+		log.Functionf("removeBridge: skipping %s", ifname)
+		return nil
+	}
+	link, err := netlink.LinkByName(ifname)
+	if err != nil {
+		// Caller should have checked
+		err = fmt.Errorf("removeBridge LinkByName(%s) failed: %v",
+			ifname, err)
+		log.Error(err)
+		return err
+	}
+	linkType := link.Type()
+	if linkType != "bridge" {
+		log.Noticef("removeBridge: skipping %s type %s",
+			ifname, linkType)
+		return nil
+	}
+	kernIfname := "k" + ifname
+	kernLink, err := netlink.LinkByName(kernIfname)
+	if err != nil {
+		err = fmt.Errorf("removeBridge LinkByName(%s) failed: %v",
+			kernIfname, err)
+		log.Error(err)
+		return err
+	}
+	// get macaddr and create the alternate with the group bit toggled
+	macAddr := kernLink.Attrs().HardwareAddr
+	var altMacAddr net.HardwareAddr
+	if len(macAddr) != 0 {
+		altMacAddr = make([]byte, len(macAddr))
+		copy(altMacAddr, macAddr)
+		altMacAddr[0] = altMacAddr[0] ^ 2
+		log.Noticef("macAddr %s altMacAddr %s", macAddr, altMacAddr)
+	}
+	// ip link set kethN nomaster
+	if err := netlink.LinkSetNoMaster(kernLink); err != nil {
+		err = fmt.Errorf("removeBridge LinkSetNoMaster(%s) failed: %v",
+			kernIfname, err)
+		log.Error(err)
+		return err
+	}
+	// delete bridge link
+	attrs := netlink.NewLinkAttrs()
+	attrs.Name = ifname
+	bridge := &netlink.Bridge{LinkAttrs: attrs}
+	netlink.LinkDel(bridge)
+
+	if len(altMacAddr) != 0 {
+		// Toggle macaddr on kernIfname - set to altMacAddr
+		if err := netlink.LinkSetHardwareAddr(kernLink, altMacAddr); err != nil {
+			err = fmt.Errorf("removeBridge LinkSetHardwareAddr(%s, %s) failed: %v",
+				kernIfname, altMacAddr, err)
+			log.Error(err)
+			return err
+		}
+	}
+	if err := types.IfRename(log, kernIfname, ifname); err != nil {
+		err = fmt.Errorf("removeBridge IfRename(%s, %s) failed: %v",
+			kernIfname, ifname, err)
+		log.Error(err)
+		return err
+	}
+	// update cached ifindex
+	UpdateIfnameToIndex(log, ifname)
+	return nil
+}

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -255,17 +255,6 @@ func (status AppInstanceStatus) GetAppInterfaceList() []string {
 	return viflist
 }
 
-// MaybeUpdateAppIPAddr - Check if the AI status has the underlay network with this Mac Address
-func (status *AppInstanceStatus) MaybeUpdateAppIPAddr(macAddr, ipAddr string) bool {
-	for idx, ulStatus := range status.UnderlayNetworks {
-		if ulStatus.VifInfo.Mac == macAddr {
-			status.UnderlayNetworks[idx].AllocatedIPAddr = ipAddr
-			return true
-		}
-	}
-	return false
-}
-
 func RoundupToKB(b uint64) uint64 {
 	return (b + 1023) / 1024
 }


### PR DESCRIPTION
See https://wiki.lfedge.org/display/EVE/K3S+flat+network+in+EVE

When deploying e.g., K3S on EVE it would be nice if we can avoid the NAT we get with the Local network instance by 
1. Using a switch network instance, yet having it be a management port, so that each App Instance gets its own external IP address
2. Picking MAC addresses for the app instances which are not likely to conflict with app instances running on different edge nodes

The plumbing is different in that the ethN devices managed by nim are renamed to kethN, and nim sets up ethN bridges. Then the IP configuration happens on ethN.
When a switch network instance is configured it goes and finds the ethN bridge instead of creating a bnX bridge. We still support bnX bridges for switch network instances which have no external ports, but the code seems to have grown checks elsewhere which prevent such switch NIs from being deployed.

The reporting of the AllocatedIPAddress for an app instance using a switch NI now uses the DHCP snooping and the code has moved to zedrouter to make sure we always update AppNetworkStatus correctly. @naiming-zededa 

@cshari-zededa the MAC address algorithm applies to all switch network instances, thus might help even if we run a switch network instance on eth1 for application traffic