### PR TITLE
merge do_efi and do_boot and fix installer to work with u-boot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,9 +111,7 @@ DEVICETREE_DTB_arm64=$(DIST)/dtb/eve.dtb
 DEVICETREE_DTB=$(DEVICETREE_DTB_$(ZARCH))
 
 CONF_FILES=$(shell ls -d $(CONF_DIR)/*)
-PART_SPEC_amd64=efi conf imga
-PART_SPEC_arm64=boot conf imga
-PART_SPEC=$(PART_SPEC_$(ZARCH))
+PART_SPEC=efi conf imga
 
 # parallels settings
 # https://github.com/qemu/qemu/blob/595123df1d54ed8fbab9e1a73d5a58c5bb71058f/docs/interop/prl-xml.txt
@@ -461,7 +459,7 @@ pkg/qrexec-lib: pkg/xen-tools eve-qrexec-lib
 pkg/%: eve-% FORCE
 	@true
 
-eve: $(BIOS_IMG) $(EFI_PART) $(CONFIG_IMG) $(PERSIST_IMG) $(INITRD_IMG) $(ROOTFS_IMG) $(if $(findstring arm64,$(ZARCH)),$(BOOT_PART)) | $(DIST)
+eve: $(BIOS_IMG) $(EFI_PART) $(CONFIG_IMG) $(PERSIST_IMG) $(INITRD_IMG) $(ROOTFS_IMG) $(BOOT_PART) | $(DIST)
 	cp pkg/eve/build.yml pkg/eve/runme.sh images/*.yml $|
 	$(PARSE_PKGS) pkg/eve/Dockerfile.in > $|/Dockerfile
 	$(LINUXKIT) pkg $(LINUXKIT_PKG_TARGET) --disable-content-trust --hash-path $(CURDIR) --hash $(ROOTFS_VERSION)-$(HV) $(if $(strip $(EVE_REL)),--release) $(EVE_REL) $(FORCE_BUILD) $|

--- a/pkg/eve/runme.sh
+++ b/pkg/eve/runme.sh
@@ -81,7 +81,6 @@ do_version() {
 
 do_live() {
   PART_SPEC="efi conf imga"
-  [ -d /bits/boot ] && PART_SPEC="boot conf imga"
   # each live image is expected to have a soft serial number that
   # typically gets provisioned by an installer -- since we're
   # shortcutting the installer step here we need to generate it

--- a/pkg/mkimage-raw-efi/Dockerfile
+++ b/pkg/mkimage-raw-efi/Dockerfile
@@ -38,7 +38,7 @@ RUN apk add --no-cache --initdb -p /out \
   coreutils=8.30-r0         \
   tar=1.32-r0
 
-COPY make-raw install trampoline.grub.cfg grub.cfg.in UsbInvocationScript.txt /out/
+COPY make-raw install grub.cfg.in UsbInvocationScript.txt /out/
 
 RUN echo "mtools_skip_check=1" >> etc/mtools.conf
 

--- a/pkg/mkimage-raw-efi/install
+++ b/pkg/mkimage-raw-efi/install
@@ -111,7 +111,7 @@ if [ ! -e /dev/root ]; then
    # relying on init setting up mount points for us under /media
    [ -d /media/boot ] || bail "FATAL: can't find installation artifacts"
 
-   ln -s /media/boot /bits
+   [ -d /bits ] || ln -s /media/boot /bits
    ln -s "/dev/$(basename "$(readlink /media/boot)")" /dev/root
 
    # FIXME: we need to run one thing from the install image to seed
@@ -156,11 +156,17 @@ if [ -n "$CONFIG_PART" ] ; then
    ln -s /dev/$CONFIG_PART /parts/config.img
 fi
 
-for i in persist.img config.img rootfs.img EFI ; do
+FILE_PARTS="persist.img config.img rootfs.img"
+for i in EFI boot; do
+  SOURCE="/bits/$i"
+  [ ! -e "$SOURCE" ] || FILE_PARTS="$FILE_PARTS $i"
+done
+for i in $FILE_PARTS; do
    SOURCE="/bits/$i"
    [ -e "$SOURCE" ] || SOURCE=/dev/null
-   [ -L /parts/$i ] || ln -s "$SOURCE" /parts/$i
+   [ -L "/parts/$i" ] || ln -s "$SOURCE" "/parts/$i"
 done
+
 # finally lets see if we were given any overrides
 grep -q eve_install_skip_rootfs /proc/cmdline && trunc /parts/rootfs.img
 grep -q eve_install_skip_config /proc/cmdline && trunc /parts/config.img

--- a/pkg/mkimage-raw-efi/make-raw
+++ b/pkg/mkimage-raw-efi/make-raw
@@ -60,8 +60,6 @@ CONF_PART_SIZE=$((1024 * 1024))
 WIN_INVENTORY_PART_SIZE=$((40240 * 1024))
 # installer system parition size in bytes
 INSTALLER_SYS_PART_SIZE=$(( 300 * 1024 * 1024 ))
-# boot partition size
-BOOT_PART_SIZE=$(( 20 * 1024 * 1024 ))
 # sector where the first partition starts on a blank disk
 FIRST_PART_SEC=2048
 
@@ -136,14 +134,8 @@ do_system_vfat_part() {
 do_efi() {
   mkefifs
   sed -e 's#@PATH_TO_GRUB@#'"$(cd /efifs; echo EFI/BOOT/BOOT*EFI)"'#' < /grub.cfg.in > /efifs/EFI/BOOT/grub.cfg
+  [ -d /parts/boot ] && cp -r /parts/boot/* /efifs/
   do_system_vfat_part "$1" "$EFI_PART_SIZE"
-}
-
-do_boot() {
-  mkefifs
-  cp /trampoline.grub.cfg /efifs/EFI/BOOT/grub.cfg
-  cp -r /parts/boot/* /efifs/
-  do_system_vfat_part "$1" "$BOOT_PART_SIZE"
 }
 
 do_installer() {

--- a/pkg/mkimage-raw-efi/trampoline.grub.cfg
+++ b/pkg/mkimage-raw-efi/trampoline.grub.cfg
@@ -1,4 +1,0 @@
-gptprio.next -d dev -u uuid
-
-set root=$dev
-configfile ($dev)/EFI/BOOT/grub.cfg


### PR DESCRIPTION
We need to modify installer logic to work with u-boot and blobs and we can get rid of separate do_efi and do_boot commands.

part of #1793 

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>