### PR TITLE
update Dockerfile versions from Dependabot

### DIFF
--- a/pkg/alpine/Dockerfile
+++ b/pkg/alpine/Dockerfile
@@ -1,5 +1,5 @@
 ARG ALPINE_VERSION=3.9
-FROM lfedge/eve-alpine:5.16.0 AS cache
+FROM lfedge/eve-alpine:5.19.0 AS cache
 
 FROM alpine:${ALPINE_VERSION} AS mirror
 ARG ALPINE_VERSION=3.9

--- a/pkg/guacd/Dockerfile
+++ b/pkg/guacd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8 as build
+FROM alpine:3.13.0 as build
 
 ENV GUACD_VERSION=1.0.0
 
@@ -16,7 +16,7 @@ RUN tar xzvf ${GUACD_VERSION}.tar.gz ;\
     ./configure --prefix=/usr/ --with-vnc --disable-guacenc --disable-dependency-tracking && \
      make && make install
 
-FROM alpine:3.8
+FROM alpine:3.13.0
 
 RUN apk add cairo jpeg libpng openssl libvncserver
 COPY --from=build /usr/sbin/guacd /usr/sbin/guacd

--- a/pkg/qrexec-dom0/Dockerfile.in
+++ b/pkg/qrexec-dom0/Dockerfile.in
@@ -1,6 +1,7 @@
 FROM XENTOOLS_TAG as xentools
 FROM QREXECLIB_TAG as qrexec_lib
-FROM alpine:3.6 as build
+# make error starting in alpine:3.9
+FROM alpine:3.8 as build
 
 RUN apk add --no-cache \
     gcc \
@@ -9,7 +10,11 @@ RUN apk add --no-cache \
     linux-headers \
     git
 
+# workaround for /var being symlink to /run
+RUN rm -rf /var
+
 COPY --from=xentools / /
+
 COPY --from=qrexec_lib / /
 
 RUN git clone https://github.com/QubesOS/qubes-core-qrexec qubes-core-qrexec

--- a/pkg/qrexec-lib/Dockerfile.in
+++ b/pkg/qrexec-lib/Dockerfile.in
@@ -1,6 +1,6 @@
 FROM XENTOOLS_TAG as xentools
 
-FROM alpine:3.6	as build
+FROM alpine:3.13.0 as build
 
 RUN apk add --no-cache \
     gcc \
@@ -9,6 +9,8 @@ RUN apk add --no-cache \
     linux-headers \
     git
 
+# workaround for /var being symlink to /run
+RUN rm -rf /var
 
 COPY --from=xentools / /
 

--- a/pkg/watchdog/Dockerfile
+++ b/pkg/watchdog/Dockerfile
@@ -39,7 +39,7 @@ ENV CONFIGURE_OPTS "--disable-nfs"
 RUN \
     CPPFLAGS=-I/usr/include/tirpc ./configure ${CONFIGURE_OPTS} && make && make install DESTDIR=/out
 
-FROM alpine:3.8
+FROM alpine:3.13.0
 WORKDIR /
 COPY --from=watchdog-build /out/etc /etc
 COPY --from=watchdog-build /out/usr/sbin /usr/sbin

--- a/pkg/wlan/Dockerfile
+++ b/pkg/wlan/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8 as build
+FROM alpine:3.13.0 as build
 
 WORKDIR /
 

--- a/pkg/wwan/Dockerfile
+++ b/pkg/wwan/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12 as build
+FROM alpine:3.13.0 as build
 
 RUN apk add --no-cache \
     automake \
@@ -45,7 +45,7 @@ RUN git checkout 1.26.2 && ./autogen.sh --without-udev && ./configure --prefix=/
 RUN strip /usr/bin/*cli /usr/libexec/*proxy /usr/lib/libmbim*.so.* /usr/lib/libqmi*.so.*
 
 # second stage (new-ish Docker feature) for smaller image
-FROM alpine:3.12
+FROM alpine:3.13.0
 
 RUN apk add --no-cache ppp jq glib
 

--- a/pkg/xen/Dockerfile
+++ b/pkg/xen/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7 as kernel-build
+FROM alpine:3.13.0 as kernel-build
 #linuxkit/alpine:f2f4db272c910d136380781a97e475013fabda8b AS kernel-build
 RUN apk update
 
@@ -18,7 +18,7 @@ RUN apk add \
     gnupg \
     installkernel \
     kmod \
-    libelf-dev \
+    libelf \
     libressl-dev \
     linux-headers \
     ncurses-dev \


### PR DESCRIPTION
These were generated by Dependabot PRs:
Bump lfedge/eve-alpine from 5.16.0 to 5.19.0 in /pkg/alpine
Bump alpine from 3.8 to 3.13.0 in /pkg/guacd
Bump alpine from 3.6 to 3.13.0 in /pkg/qrexec-dom0
Bump alpine from 3.6 to 3.13.0 in /pkg/qrexec-lib
Bump alpine from 3.8 to 3.13.0 in /pkg/watchdog
Bump alpine from 3.8 to 3.13.0 in /pkg/wlan
Bump alpine from 3.12 to 3.13.0 in /pkg/wwan
Bump alpine from 3.7 to 3.13.0 in /pkg/xen

Manual changes:
- downrev alpine in pkg/qrexec-dom0/Dockerfile.in
- fix COPY --from with /var symlink
- replace libelf-dev with libelf

Signed-off-by: Daniel P. Kionka <dkionka@gmail.com>