### PR TITLE
set correct initrd in generated ipxe config

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           URL="https://github.com/lf-edge/eve/releases/download/${{ env.TAG }}/${{ env.ARCH }}."
           sed -i. -e "s#^kernel #kernel $URL#" -e "s#^initrd #initrd $URL#" assets/ipxe.efi.cfg
+          sed -i. -e "s#initrd=initrd#initrd=${{ env.ARCH }}.initrd#g" assets/ipxe.efi.cfg
           sed -e 's#{mac:hexhyp}#{ip}#' < assets/ipxe.efi.cfg > assets/ipxe.efi.ip.cfg
       - name: Create a GitHub release and clean up artifacts
         id: create-release


### PR DESCRIPTION
We need to set correct initrd in kernel options inside `ipxe.efi.cfg`.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>