### PR TITLE
Adding experimental feature of matching DTB to smbinfo

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -187,15 +187,25 @@ function set_arm64 {
    set_global hv /boot/xen.efi
    set_global hv_console "console=dtuart sync_console"
    set_global hv_platform_tweaks " "
-   set_global load_devicetree_cmd devicetree
    set_global dom0_console "console=tty0 console=ttyS0,115200 console=hvc0"
 }
 
 function set_arm64_baremetal {
    set_generic
    set_arm64
-   set_global load_devicetree_cmd devicetree
    set_global dom0_platform_tweaks " "
+
+   # experimental feature where we're trying to find known device trees on ARM
+   # note that we would rather rely on UEFI providing device tree information,
+   # but sometimes this can be useful and besides it is only triggered on well
+   # known IDs of products below:
+   smbios -t 1 -s 0 --set smb_vendor
+   if [ "$smb_vendor" = "nvidia" ]; then
+      smbios -t 1 -s 5 --set smb_product
+      if [ "$smb_product" = "p3450-0000" ]; then
+         set_to_existing_file devicetree /boot/dtb/nvidia/tegra210-p3450-0000.dtb
+      fi
+   if
 }
 
 function set_arm64_qemu {


### PR DESCRIPTION
Hey @eriknordmark @deitch @gianlzed @sstabellini need your collective eyes on this -- this hack came from my work on enabling NVidia Jetson and at first I wasn't too thrilled about it -- but it sort of grew on me.

After all -- we do carry a few DTBs around and there seems to be no shame in picking them to use as a measure of last resort on a carefully curated set of systems where they can be useful.

IOW, I guess I don't see much of a downside.

Thoughts?