### PR TITLE
Skipping virtual block devices in the installer

### DIFF
--- a/pkg/mkimage-raw-efi/install
+++ b/pkg/mkimage-raw-efi/install
@@ -135,7 +135,10 @@ INSTALL_DEV=`cat /proc/cmdline | tr ' ' '\012' | sed -ne '/^eve_install_disk=/s#
 if [ -z "$INSTALL_DEV" ] ; then
    # now lets see what sources of installation material are there
    ROOT_DEV=$(root_dev)
-   FREE_DISKS=$(lsblk -anlb -o "TYPE,NAME,SIZE" | grep "^disk" | awk '$3 { print $2;}' | grep -v "${ROOT_DEV:-$^}")
+   FREE_DISKS_ALL=$(lsblk -anlb -o "TYPE,NAME,SIZE" | grep "^disk" | awk '$3 { print $2;}' | grep -v "${ROOT_DEV:-$^}")
+   for d in $FREE_DISKS_ALL; do
+      [ -e "/sys/devices/virtual/block/$d" ] || FREE_DISKS="$FREE_DISKS $d"
+   done
 
    # if there's more than one free disk, install on the first one but warn about all of them
    echo $FREE_DISKS | awk '{ if (NF > 1) { printf("WARNING: found multiple free disks %s, installing on the first one\n", $0); } }'


### PR DESCRIPTION
Make our installer a tad smarter at picking defaults