### PR TITLE
Keep tweaking asset uploading code

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Determine architecture prefix and ref
         env:
-          REF: ${{ github.ref }}
+          REF: ${{ github.event.workflow_run.head_branch }}
         run: |
           echo "ARCH=$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')" >> "$GITHUB_ENV"
           echo "TAG=$(echo "$REF" | sed -e 's#^.*/##' -e 's#master#snapshot#' -e 's#main#snapshot#')" >> "$GITHUB_ENV"
@@ -102,6 +102,16 @@ jobs:
 
             return release.upload_url
 
+      - name: Upload initrd.bits for the release
+        id: upload-initrd-bits-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.result }}
+          asset_path: assets/initrd.bits
+          asset_name: ${{ env.ARCH }}.initrd.bits
+          asset_content_type: application/octet-stream
       - name: Upload rootfs for the release
         id: upload-rootfs-asset
         uses: actions/upload-release-asset@v1
@@ -131,16 +141,6 @@ jobs:
           upload_url: ${{ steps.create-release.outputs.result }}
           asset_path: assets/initrd.img
           asset_name: ${{ env.ARCH }}.initrd.img
-          asset_content_type: application/octet-stream
-      - name: Upload initrd.bits for the release
-        id: upload-initrd-bits-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create-release.outputs.result }}
-          asset_path: assets/initrd.bits
-          asset_name: ${{ env.ARCH }}.initrd.bits
           asset_content_type: application/octet-stream
       - name: Upload ipxe.efi.cfg for the release
         id: upload-ipxe-efi-cfg-asset


### PR DESCRIPTION
Sadly we keep struggling with asset upload timeouts on GitHub (hey @deitch do you know anyone on GH side personally who can help?)

At this point I'm down to really wacky ideas -- like this one (which is re-arranging content in the decreasing order of size hoping that if we get time out it'll be at least "fail early" type of a situation).

Short of that (or @deitch helping us find the right person on GH side) I think the next step may actually be rewriting upload action JavaScript code (which I REALLY would like to avoid) :-(