### PR TITLE
remove noise from logs due to process exit

### DIFF
--- a/pkg/pillar/cmd/domainmgr/processes.go
+++ b/pkg/pillar/cmd/domainmgr/processes.go
@@ -37,7 +37,8 @@ func gatherProcessMetricList(ctx *domainContext) ([]types.ProcessMetric, map[int
 	for _, p := range processes {
 		pi, err := getProcessMetric(p)
 		if err != nil {
-			log.Errorf("getProcessMetric failed: %s", err)
+			// Process might have just exited
+			log.Functionf("getProcessMetric failed: %s", err)
 			continue
 		}
 		if pi.UserProcess {


### PR DESCRIPTION
We have lots of these in the logs at the error level and they appear normally since we have short lived processes which exit while func.keyword: github.com/lf-edge/eve/pkg/pillar/cmd/domainmgr.gatherProcessMetricList is retrieving their info.