### PR TITLE
Enable hairpin connections to match portmap rule

### DIFF
--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -955,7 +955,7 @@ func appNetworkDoActivateUnderlayNetwork(
 		AppNum: int32(status.AppNum)}
 
 	// Set up ACLs
-	ruleList, err := createACLConfiglet(aclArgs, ulConfig.ACLs)
+	ruleList, err := createACLConfiglet(ctx, aclArgs, ulConfig.ACLs)
 	if err != nil {
 		addError(ctx, status, "createACL", err)
 	}
@@ -1391,7 +1391,7 @@ func doAppNetworkModifyUnderlayNetwork(
 	// XXX Could ulStatus.Vif not be set? Means we didn't add
 	appID := status.UUIDandVersion.UUID
 	rules := getNetworkACLRules(ctx, appID, ulStatus.Name)
-	ruleList, err := updateACLConfiglet(aclArgs,
+	ruleList, err := updateACLConfiglet(ctx, aclArgs,
 		oldulConfig.ACLs, ulConfig.ACLs, rules.ACLRules, force)
 	if err != nil {
 		addError(ctx, status, "updateACL", err)

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -1540,6 +1540,17 @@ func GetMgmtPortFromAddr(globalStatus DeviceNetworkStatus, addr net.IP) string {
 	return ""
 }
 
+// GetInterfaceAddrs returns all IP addresses on the phylabelOrIfName except
+// link local
+func GetInterfaceAddrs(globalStatus DeviceNetworkStatus,
+	phylabelOrIfname string) ([]net.IP, error) {
+
+	if phylabelOrIfname == "" {
+		return []net.IP{}, fmt.Errorf("ifname not specified")
+	}
+	return getInterfaceAddr(globalStatus, false, phylabelOrIfname, false)
+}
+
 // Returns addresses based on free, ifname, and whether or not we want
 // IPv6 link-locals. Only applies to management ports unless ifname is set.
 // If free is not set, the addresses from the free management ports are first.


### PR DESCRIPTION
The DNAT we create for a portmap ACL are only applied on the uplink port for the network instance.
This PR adds a DNAT rule with the input interface being the bnX bridge so that an app instance can connect to another using the external IP + port just like an external application can do.