### PR TITLE
sleep to relax loop with xen_info

### DIFF
--- a/pkg/xen-tools/xen-start
+++ b/pkg/xen-tools/xen-start
@@ -93,6 +93,7 @@ xl unpause "$ID" || bail "xl unpause failed"
 # now star polling for domain status (11 sec interval) in the background
 # (note our use of mv to make sure file reads on the other side are atomic)
 (while true; do
+   sleep 11
    xen_info "$(domID "$1")" > "/run/tasks/$1.tmp"
    mv "/run/tasks/$1.tmp" "/run/tasks/$1"
 done) &


### PR DESCRIPTION
Seems, that we lost `sleep` in the loop with `xen_info`.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>