### PR TITLE
Handle appInst broken state

### DIFF
--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -473,6 +473,7 @@ func (ctx xenContext) Info(domainName string, domainID int) (int, types.SwState,
 		"running": types.RUNNING,
 		"paused":  types.PAUSED,
 		"halting": types.HALTING,
+		"broken":  types.BROKEN,
 	}
 	effectiveDomainState, matched := stateMap[strings.TrimSpace(string(status))]
 	if !matched {

--- a/pkg/xen-tools/xen-start
+++ b/pkg/xen-tools/xen-start
@@ -29,8 +29,10 @@ handleUnknownState() {
   else
     # Number of times we got unknown state is <= UnknownStateThreshold, so declaring the state as running
     echo running
-  fi
 
+    # Waiting for 5sec before checking domain status again in order to recover from unknown state
+    sleep 5
+  fi
   unknownStateCounter=$((unknownStateCounter + 1))
 }
 
@@ -90,7 +92,7 @@ ID=$(domID "$1")
 # finally unpause the domain
 xl unpause "$ID" || bail "xl unpause failed"
 
-# now star polling for domain status (11 sec interval) in the background
+# now star polling for domain status in the background
 # (note our use of mv to make sure file reads on the other side are atomic)
 (while true; do
    xen_info "$(domID "$1")" > "/run/tasks/$1.tmp"


### PR DESCRIPTION
Sporadically `xen-start` script returned `broken` status for the domain. 
Since `broken` state was not handeled for xen hypervison (in xen.go) we got the below error:
```
one of the 9b4cc163-c951-478e-936f-7573f8ae404c tasks has crashed (info: domain 9b4cc163-c951-478e-936f-7573f8ae404c.1.2 reported to be in unexpected state broken )
```

While checking for domain status in `xen-start` if we get an unknown state (`-----`)  from `xl list`, we returned the default (running) state. There is a threshold(10) on how many times we can return the default state continuously and if that threshold is crossed, then we will return `broken` state.
When we get an unknown state, we might have to wait for a few sec before we check again to get an actual state.
Since in the current code there was no wait between each check when the domain reported an unknown state, the threshold was reached before we get an actual state and this lead to verifyStatus() assuming that the domain is broken and triggered a domain delete. 
So to avoid that, added a 5sec wait between domain status check if we get unknown state. 

Signed-off-by: adarsh-zededa <adarsh@zededa.com>