### PR TITLE
generate error of host or eidset on switch network instance

### DIFF
--- a/pkg/pillar/cmd/zedrouter/acl.go
+++ b/pkg/pillar/cmd/zedrouter/acl.go
@@ -701,6 +701,12 @@ func aceToRules(ctx *zedrouterContext, aclArgs types.AppNetworkACLArgs,
 				ip = match.Value
 				break
 			}
+			if aclArgs.NIType == types.NetworkInstanceTypeSwitch {
+				errStr := fmt.Sprintf("ACE with host not supported on switch network instance: %+v",
+					ace)
+				log.Errorln(errStr)
+				return nil, nil, errors.New(errStr)
+			}
 			if ipsetName != "" {
 				errStr := fmt.Sprintf("ACE with eidset and host not supported: %+v",
 					ace)
@@ -721,6 +727,12 @@ func aceToRules(ctx *zedrouterContext, aclArgs types.AppNetworkACLArgs,
 				ipsetName = "ipv6." + match.Value
 			}
 		case "eidset":
+			if aclArgs.NIType == types.NetworkInstanceTypeSwitch {
+				errStr := fmt.Sprintf("ACE with host not supported on switch network instance: %+v",
+					ace)
+				log.Errorln(errStr)
+				return nil, nil, errors.New(errStr)
+			}
 			if ipsetName != "" {
 				errStr := fmt.Sprintf("ACE with eidset and host not supported: %+v",
 					ace)


### PR DESCRIPTION
If someone has a "host" "www.google.com" or "host" "" ACL it will silently not work on a switch network instance.
The wildcard has to instead be "ip" "0.0.0.0/0".

This PR generates errors for the ones we do not support.
If we later add support (through DNS snooping and adding those to the ipset) then we will remove these checks.