### PR TITLE
Enable BuildKit for faster builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,9 @@ GOMODULE=$(PKGBASE)/pkg/pillar
 GOTREE=$(CURDIR)/pkg/pillar
 BUILDTOOLS_BIN=$(CURDIR)/build-tools/bin
 PATH:=$(BUILDTOOLS_BIN):$(PATH)
+DOCKER_BUILDKIT = 1
 
-export CGO_ENABLED GOOS GOARCH PATH
+export CGO_ENABLED DOCKER_BUILDKIT GOOS GOARCH PATH
 
 # A set of tweakable knobs for our build needs (tweak at your risk!)
 # Which version to assign to snapshot builds (0.0.0 if built locally, 0.0.0-snapshot if on CI/CD)


### PR DESCRIPTION
Instead of docker build generating lines like:
Step 1/23 : FROM lfedge/eve-alpine:...
you get lines like
 #1 DONE 0.0s
with some steps running in parallel.

See: https://docs.docker.com/develop/develop-images/build_enhancements/

Signed-off-by: Daniel P. Kionka <dkionka@gmail.com>