### PR TITLE
Introduce timer.defer.content.delete to make tests faster

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -12,6 +12,7 @@
 | timer.test.baseimage.update | integer in seconds | 600 | commit to update |
 | timer.use.config.checkpoint | integer in seconds | 600 | use checkpointed config if no cloud connectivity |
 | timer.gc.vdisk | integer in seconds | 1 hour | garbage collect unused instance virtual disk |
+| timer.defer.content.delete | integer in seconds | zero | if set, keep content trees around for reuse after they have been deleted |
 | timer.download.retry | integer in seconds | 600 | retry a failed download |
 | timer.download.stalled | integer in seconds | 600 | cancel a stalled download |
 | timer.boot.retry | integer in seconds | 600 | retry a failed domain boot |

--- a/pkg/pillar/agentlog/agentlog.go
+++ b/pkg/pillar/agentlog/agentlog.go
@@ -241,10 +241,10 @@ func RebootReason(reason string, bootReason types.BootReason, agentName string,
 	filename := fmt.Sprintf("%s/%s", types.PersistDir, reasonFile)
 	dateStr := time.Now().Format(time.RFC3339Nano)
 	if !normal {
-		reason = fmt.Sprintf("Reboot from agent %s[%d] in partition %s EVE version %s at %s: %s\n",
+		reason = fmt.Sprintf("Reboot from agent %s[%d] in partition %s at EVE version %s at %s: %s\n",
 			agentName, agentPid, EveCurrentPartition(), EveVersion(), dateStr, reason)
 	} else {
-		reason = fmt.Sprintf("%s EVE version %s at %s\n",
+		reason = fmt.Sprintf("%s at EVE version %s at %s\n",
 			reason, EveVersion(), dateStr)
 	}
 	// If we already wrote a bootReason file we append to

--- a/pkg/pillar/cmd/nodeagent/handlebaseos.go
+++ b/pkg/pillar/cmd/nodeagent/handlebaseos.go
@@ -22,7 +22,17 @@ func doZbootBaseOsInstallationComplete(ctxPtr *nodeagentContext,
 	}
 	// This check will also handle forced fallback
 	if isZbootOtherPartitionStateUpdating(ctxPtr) && !ctxPtr.deviceReboot {
-		infoStr := fmt.Sprintf("NORMAL: baseos-update(%s) reboot", key)
+		var newVersion string
+
+		partName := getZbootOtherPartition(ctxPtr)
+		zbootStatus := lookupZbootStatus(ctxPtr, partName)
+		if zbootStatus != nil {
+			newVersion = zbootStatus.ShortVersion
+		} else {
+			newVersion = "(unknown)"
+		}
+		infoStr := fmt.Sprintf("NORMAL: baseos-update(%s) to EVE version %s reboot",
+			key, newVersion)
 		log.Functionf(infoStr)
 		scheduleNodeReboot(ctxPtr, infoStr, types.BootReasonUpdate)
 	}

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -140,6 +140,8 @@ const (
 	StaleConfigTime GlobalSettingKey = "timer.use.config.checkpoint"
 	// VdiskGCTime global setting key
 	VdiskGCTime GlobalSettingKey = "timer.gc.vdisk"
+	// DeferContentDelete global setting key
+	DeferContentDelete GlobalSettingKey = "timer.defer.content.delete"
 	// DownloadRetryTime global setting key
 	DownloadRetryTime GlobalSettingKey = "timer.download.retry"
 	// DownloadStalledTime global setting key
@@ -729,6 +731,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddIntItem(MintimeUpdateSuccess, 600, 30, HourInSec)
 	configItemSpecMap.AddIntItem(StaleConfigTime, 7*24*3600, 0, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(VdiskGCTime, 3600, 60, 0xFFFFFFFF)
+	configItemSpecMap.AddIntItem(DeferContentDelete, 0, 0, 24*3600)
 	configItemSpecMap.AddIntItem(DownloadRetryTime, 600, 60, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(DownloadStalledTime, 600, 20, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(DomainBootRetryTime, 600, 10, 0xFFFFFFFF)

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -154,6 +154,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		MintimeUpdateSuccess,
 		StaleConfigTime,
 		VdiskGCTime,
+		DeferContentDelete,
 		DownloadRetryTime,
 		DownloadStalledTime,
 		DomainBootRetryTime,


### PR DESCRIPTION
Currently a content tree is deleted by the controller when the app instance is deleted. This means that all of the content is removed from containerd's CAS.
That is fine as a default, but when running tests which reuse the same images/containers it would be nice if we didn't have to wait for the same images/containers to be redownloaded for every test.

This adds a knob called timer.defer.content.delete which can be set to the number of seconds to keep the content tree around after the controller has deleted it. If a new content tree (new UUID) is created which uses the same content it will find the content in CAS and use it. Thus when the defered deleting of the original content tree object takes place the content stays around.