### PR TITLE
Need a /config/uuid to be able to downgrade EVE

### DIFF
--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -477,6 +477,17 @@ else
     fi
 fi
 
+# XXX to handle a downgrade we need a /config/uuid file to boot old EVE
+if [ ! -f $CONFIGDIR/uuid ]; then
+    echo "$(date -Ins -u) cp -p $PERSISTDIR/status/uuid $CONFIGDIR/uuid"
+    cp -p $PERSISTDIR/status/uuid $CONFIGDIR/uuid
+elif ! diff $PERSISTDIR/status/uuid $CONFIGDIR/uuid >/dev/null; then
+    echo "$(date -Ins -u) rm -f $CONFIGDIR/uuid"
+    rm -f $CONFIGDIR/uuid
+    echo "$(date -Ins -u) cp -p $PERSISTDIR/status/uuid $CONFIGDIR/uuid"
+    cp -p $PERSISTDIR/status/uuid $CONFIGDIR/uuid
+fi
+
 if ! pgrep loguploader >/dev/null; then
     echo "$(date -Ins -u) Starting loguploader"
     $BINDIR/loguploader &


### PR DESCRIPTION
The recent /config/uuid removal (with a snapshot in /persist/status/uuid to set the shell prompt) means that a downgrade of a freshly installed device to an old EVE version will fatal due to zedagent and other agents in the old EVE assuming there is a /config/uuid if the device has an OnboardingStatus.

Thus we need to keep the /config/uuid file for a file. Can't make it be a symlink to /persist/status/uuid since the /config is a FAT32 filesystem.