### PR TITLE
fix vnc config for PV

### DIFF
--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -155,7 +155,7 @@ func (ctx xenContext) CreateDomConfig(domainName string, config types.DomainConf
 					config.VncDisplay))
 			}
 			if config.VncPasswd != "" {
-				vncParams = append(vncParams, fmt.Sprintf("vncpasswd=\"%s\"\n",
+				vncParams = append(vncParams, fmt.Sprintf("vncpasswd=%s",
 					config.VncPasswd))
 			}
 			file.WriteString(fmt.Sprintf("vfb = ['%s']\n", strings.Join(vncParams, ", ")))


### PR DESCRIPTION
Seems, we add unneeded double quotes and new line sign to PV config of vfb. They break our applications with VNC on arm64/xen.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>