### PR TITLE
Avoid referencing into Readfile buffer

### DIFF
--- a/pkg/pillar/Dockerfile.in
+++ b/pkg/pillar/Dockerfile.in
@@ -20,7 +20,7 @@ RUN patch -p1 < patch01-no-pam.diff && \
 ARG GOVER=1.15.3
 FROM golang:${GOVER}-alpine as build
 RUN apk update
-RUN apk add --no-cache git gcc linux-headers libc-dev util-linux make
+RUN apk add --no-cache git gcc linux-headers libc-dev util-linux make patch
 
 # These three are supporting rudimentary cross-build capabilities.
 # The only one supported so far is cross compiling for aarch64 on x86
@@ -35,6 +35,13 @@ ADD ./  /pillar/
 
 # go vet/format and go install
 WORKDIR /pillar
+
+COPY pillar-patches/* /patches/
+RUN set -e && for patch in ../patches/*.patch; do \
+        echo "Applying $patch"; \
+        patch -p1 < "$patch"; \
+    done
+
 RUN [ -z "$GOARCH" ] || export CC=$(echo /*-cross/bin/*-gcc) ;\
     echo "Running go vet" && go vet ./... && \
     echo "Running go fmt" && ERR=$(gofmt -e -l -s $(find . -name \*.go | grep -v /vendor/)) && \

--- a/pkg/pillar/pillar-patches/002-gopsutil-process-memory.patch
+++ b/pkg/pillar/pillar-patches/002-gopsutil-process-memory.patch
@@ -1,0 +1,17 @@
+diff --git a/pkg/pillar/vendor/github.com/shirou/gopsutil/process/process_linux.go b/pkg/pillar/vendor/github.com/shirou/gopsutil/process/process_linux.go
+index 8ae99ff29..709bf8172 100644
+--- a/pkg/pillar/vendor/github.com/shirou/gopsutil/process/process_linux.go
++++ /vendor/github.com/shirou/gopsutil/process/process_linux.go
+@@ -1051,8 +1051,12 @@ func (p *Process) fillFromStatusWithContext(ctx context.Context) error {
+ 					}
+ 				}
+ 			}
++			// Ensure we have a copy and not reference into slice
++			p.name = string([]byte(p.name))
+ 		case "State":
+ 			p.status = value[0:1]
++			// Ensure we have a copy and not reference into slice
++			p.status = string([]byte(p.status))
+ 		case "PPid", "Ppid":
+ 			pval, err := strconv.ParseInt(value, 10, 32)
+ 			if err != nil {

--- a/pkg/pillar/vendor/github.com/shirou/gopsutil/process/process_linux.go
+++ b/pkg/pillar/vendor/github.com/shirou/gopsutil/process/process_linux.go
@@ -1051,12 +1051,8 @@ func (p *Process) fillFromStatusWithContext(ctx context.Context) error {
 					}
 				}
 			}
-			// Ensure we have a copy and not reference into slice
-			p.name = string([]byte(p.name))
 		case "State":
 			p.status = value[0:1]
-			// Ensure we have a copy and not reference into slice
-			p.status = string([]byte(p.status))
 		case "PPid", "Ppid":
 			pval, err := strconv.ParseInt(value, 10, 32)
 			if err != nil {

--- a/pkg/pillar/vendor/github.com/shirou/gopsutil/process/process_linux.go
+++ b/pkg/pillar/vendor/github.com/shirou/gopsutil/process/process_linux.go
@@ -1051,8 +1051,12 @@ func (p *Process) fillFromStatusWithContext(ctx context.Context) error {
 					}
 				}
 			}
+			// Ensure we have a copy and not reference into slice
+			p.name = string([]byte(p.name))
 		case "State":
 			p.status = value[0:1]
+			// Ensure we have a copy and not reference into slice
+			p.status = string([]byte(p.status))
 		case "PPid", "Ppid":
 			pval, err := strconv.ParseInt(value, 10, 32)
 			if err != nil {


### PR DESCRIPTION
This causes high memory usage because the large buffer returned by Readfile can not be freed due to a slice pointing into the buffer.