### PR TITLE
Moving to Linux kernel 5.10.x

### DIFF
--- a/images/rootfs-kvm.yml.in.patch
+++ b/images/rootfs-kvm.yml.in.patch
@@ -1,9 +1,0 @@
---- images/rootfs.yml.in	2021-01-15 19:34:18.000000000 -0800
-+++ images/rootfs.yml.in	2021-01-15 19:35:09.000000000 -0800
-@@ -1,5 +1,5 @@
- kernel:
--  image: NEW_KERNEL_TAG
-+  image: KERNEL_TAG
-   cmdline: "rootdelay=3"
- init:
-   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c


### PR DESCRIPTION
As you all know 5.10.x kernel has been stewing for at least a month in the Xen image. We haven't seen any major issues with it and hence pulling the plug on KVM image being based on 5.10.x.

The only tiny outstanding issue is RaspberyPi 4 efi frame-buffer -- but it is mostly cosmetic and hence will be deal with ASAP in a patch release.