### PR TITLE
Addressing #1869 comments and error when broken state for xen domain

### DIFF
--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -479,6 +479,10 @@ func (ctx xenContext) Info(domainName string, domainID int) (int, types.SwState,
 	if !matched {
 		return effectiveDomainID, types.BROKEN, fmt.Errorf("info: domain %s reported to be in unexpected state %v",
 			domainName, string(status))
+	} else if effectiveDomainState == types.BROKEN {
+		return effectiveDomainID, types.BROKEN, fmt.Errorf("info: domain %s reported to be in broken state",
+			domainName)
+
 	}
 
 	return effectiveDomainID, effectiveDomainState, nil

--- a/pkg/xen-tools/xen-start
+++ b/pkg/xen-tools/xen-start
@@ -29,10 +29,8 @@ handleUnknownState() {
   else
     # Number of times we got unknown state is <= UnknownStateThreshold, so declaring the state as running
     echo running
-
-    # Waiting for 5sec before checking domain status again in order to recover from unknown state
-    sleep 5
   fi
+
   unknownStateCounter=$((unknownStateCounter + 1))
 }
 
@@ -61,7 +59,8 @@ xen_info() {
       *p*) handleKnownState paused  ;;
       *b*) handleKnownState running ;;
        r*) handleKnownState running ;;
-   ------) handleUnknownState ;;
+     # Waiting for 5sec before checking domain status again in order to recover from unknown state
+   ------) handleUnknownState; sleep 5 ;;
         *) handleKnownState broken  ;;
    esac
 }
@@ -92,8 +91,9 @@ ID=$(domID "$1")
 # finally unpause the domain
 xl unpause "$ID" || bail "xl unpause failed"
 
-# now star polling for domain status in the background
-# (note our use of mv to make sure file reads on the other side are atomic)
+# now start polling for domain status in the background
+# (note: our use of mv to make sure file reads on the other side are atomic)
+# (note: there will be a 5sec wait before the next xen_info() call in case if we get a nondeterministic domain state)
 (while true; do
    xen_info "$(domID "$1")" > "/run/tasks/$1.tmp"
    mv "/run/tasks/$1.tmp" "/run/tasks/$1"


### PR DESCRIPTION
Issue: After `broken` start was handled as part of #1869, `waitForDomainGone()` method in domainmgr never returned properly and always timed out. This led to 20min delay for Stop and Restart operation.

Fix: returning an appropriate error if the domain status is `broken`
Signed-off-by: adarsh-zededa <adarsh@zededa.com>