### PR TITLE
timer recovery by GC

### DIFF
--- a/pkg/pillar/base/execwrapper.go
+++ b/pkg/pillar/base/execwrapper.go
@@ -106,10 +106,11 @@ func (c *Command) execCommand() ([]byte, error) {
 	stillRunning := time.NewTicker(25 * time.Second)
 	defer stillRunning.Stop()
 
-	timer := time.After(c.timeout * time.Second)
+	waitTimer := time.NewTimer(c.timeout * time.Second)
+	defer waitTimer.Stop()
 	for {
 		select {
-		case <-timer:
+		case <-waitTimer.C:
 			// Timeout happened first, kill the process.
 			c.command.Process.Kill()
 			return nil, fmt.Errorf("execCommand(%v): command timed out", c.command.Args)

--- a/pkg/pillar/zedcloud/wstunnelclient.go
+++ b/pkg/pillar/zedcloud/wstunnelclient.go
@@ -302,6 +302,7 @@ func (wsc *WSConnection) pinger() {
 	}
 	// timeout timer
 	timer := time.AfterFunc(tunTimeout, timeout)
+	defer timer.Stop()
 	// pong handler resets last pong time
 	ph := func(message string) error {
 		timer.Reset(tunTimeout)


### PR DESCRIPTION
We should use NewTimer insted of After so that GC does not wait for the timer (https://golang.org/pkg/time/#After).

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>