### PR TITLE
avoid hung listener goroutine in qmp code

### DIFF
--- a/pkg/pillar/pillar-patches/003-go-qemu-qmp-hung-listener.patch
+++ b/pkg/pillar/pillar-patches/003-go-qemu-qmp-hung-listener.patch
@@ -1,0 +1,21 @@
+diff --git a/pkg/pillar/vendor/github.com/digitalocean/go-qemu/qmp/socket.go b/pkg/pillar/vendor/github.com/digitalocean/go-qemu/qmp/socket.go
+index 4dd052944..4a936cc8e 100644
+--- a/pkg/pillar/vendor/github.com/digitalocean/go-qemu/qmp/socket.go
++++ /vendor/github.com/digitalocean/go-qemu/qmp/socket.go
+@@ -185,7 +185,15 @@ func (mon *SocketMonitor) listen(r io.Reader, events chan<- Event, stream chan<-
+ 	}
+ 
+ 	if err := scanner.Err(); err != nil {
+-		stream <- streamResponse{err: err}
++		// In case stream reader went away we wait for a bit
++		waitTimer := time.NewTimer(3 * time.Second)
++		defer waitTimer.Stop()
++		select {
++		case <-waitTimer.C:
++			// Do nothing
++		case stream <- streamResponse{err: err}:
++			// Done
++		}
+ 	}
+ }
+ 


### PR DESCRIPTION
The example code in https://github.com/digitalocean/go-qemu/tree/master/qmp of the form
monitor.Connect()
defer monitor.Disconnect()

cmd := []byte(`{ "execute": "query-status" }`)
raw, _ := monitor.Run(cmd)

results in a goroutine hung in the listener blocked sending an error (due to the Disconnect closing the socket it seems) hence the listener goroutine never exits. 

Submitted upstream in https://github.com/digitalocean/go-qemu/pull/170
Upstream issue https://github.com/digitalocean/go-qemu/issues/171