### PR TITLE
Enabling -cpu host for KVM across the board

### DIFF
--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -371,7 +371,7 @@ func newKvm() Hypervisor {
 			devicemodel:  "pc-q35-3.1",
 			dmExec:       "/usr/lib/xen/bin/qemu-system-x86_64",
 			dmArgs:       []string{"-display", "none", "-S", "-no-user-config", "-nodefaults", "-no-shutdown", "-serial", "chardev:charserial0", "-no-hpet"},
-			dmCPUArgs:    []string{},
+			dmCPUArgs:    []string{"-cpu", "host"},
 			dmFmlCPUArgs: []string{"-cpu", "host,hv_time,hv_relaxed,hv_vendor_id=eveitis,hypervisor=off,kvm=off"},
 		}
 	}


### PR DESCRIPTION
At this point there seems to be no downside to enabling `-cpu host` for all our KVM workloads on amd64. We've been running like that on arm64 and in FML mode for a few months and there seems to be no observable issues.

Lets enable it wholesale now.