### PR TITLE
Allowing netboot to specify controller's hostname

### DIFF
--- a/pkg/eve/runme.sh
+++ b/pkg/eve/runme.sh
@@ -122,7 +122,9 @@ do_installer_net() {
 # :retry_ntp
 # ntp pool.ntp.org || goto retry_ntp
 #
-# you should set eve_install_disk argument to mmcblk0 if you need
+# you may want to add the following to the kernel command line arguments:
+#   * eve_install_disk=XXX (e.g. XXX=mmcblk0)
+#   * eve_install_server=XXX (e.g. XXX=zedcloud.hummingbird.zededa.net)
 #
 # chain --autofree https://github.com/lf-edge/eve/releases/download/1.2.3/ipxe.efi.cfg
 kernel kernel eve_installer=\${mac:hexhyp} eve_reboot_after_install fastboot console=ttyS0 console=ttyS1 console=ttyS2 console=ttyAMA0 console=ttyAMA1 console=tty0 initrd=initrd.img initrd=initrd.bits

--- a/pkg/mkimage-raw-efi/install
+++ b/pkg/mkimage-raw-efi/install
@@ -8,6 +8,7 @@
 # in /bits, some will be constructed on the fly depending
 # on settings that were passed via kernel command line:
 #   eve_install_disk
+#   eve_install_server
 #   eve_pause_before_install
 #   eve_pause_after_install
 #   eve_reboot_after_install
@@ -156,8 +157,11 @@ INSTALL_PERSIST=${INSTALL_PERSIST:-$INSTALL_DEV}
 # now lets figure out whether we have installation material
 mkdir /parts || :
 CONFIG_PART=$(find_part CONFIG "$(root_dev)")
-if [ -n "$CONFIG_PART" ] ; then
-   ln -s /dev/$CONFIG_PART /parts/config.img
+CONFIG_PART="${CONFIG_PART:+"/dev/"}${CONFIG_PART:-"/bits/config.img"}"
+if [ -e "$CONFIG_PART" ]; then
+   dd if="$CONFIG_PART" of=/parts/config.img bs=1M
+   tr ' ' '\012' < /proc/cmdline | sed -ne '/^eve_install_server=/s#^.*=##p' > /tmp/eve_install_server
+   [ ! -s /tmp/eve_install_server ] || mcopy -i /parts/config.img -o /tmp/eve_install_server ::/server
 fi
 
 FILE_PARTS="persist.img config.img rootfs.img"
@@ -168,7 +172,7 @@ done
 for i in $FILE_PARTS; do
    SOURCE="/bits/$i"
    [ -e "$SOURCE" ] || SOURCE=/dev/null
-   [ -L "/parts/$i" ] || ln -s "$SOURCE" "/parts/$i"
+   [ -e "/parts/$i" ] || ln -s "$SOURCE" "/parts/$i"
 done
 
 # finally lets see if we were given any overrides


### PR DESCRIPTION
This simple change allow netboot pxe scripts to configure controller hostname by specifying eve_install_server=XXX on the kernel command line.

@giggsoff -- please take a look -- this maybe useful for your work with Adam/Eden as well.