### PR TITLE
Adding Xen workaround for ProLiant DL360 Gen10

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -168,6 +168,18 @@ function set_x86_64_baremetal {
    set_global hv_platform_tweaks "$hv_platform_tweaks efi=attr=uc"
    set_global dom0_platform_tweaks " "
    set_global dom0_console "console=tty0"
+
+   # experimental feature where we're trying to provide workarounds based
+   # on well known vendor/product pairs from SMBIOS. This may appear harmless
+   # but we need to make sure that we don't see coredumps on weird SMBIOS
+   # implementations
+   smbios -t 1 -s 0 --set smb_vendor
+   if [ "$smb_vendor" = "HPE" ]; then
+      smbios -t 1 -s 5 --set smb_product
+      if [ "$smb_product" = "ProLiant DL360 Gen10" ]; then
+         set_global hv_platform_tweaks "$hv_platform_tweaks cmos-rtc-probe=1"
+      fi
+   fi
 }
 
 function set_x86_64_qemu {


### PR DESCRIPTION
OK folks, this is a fun one -- this is our first step on a long road of accounting for workaround when it comes to booting various pieces of hardware. We've obviously done it on ARM to account for DTBs in a few cases, but this is a first one on x86.

On one hand -- I'm not that much in love with an idea of of keeping those workaround around. On the other hand -- those types of things have to be mentioned/documented someplace -- and that place may as well be executable code.

Note that the implementation appears to be relatively safe since `smbios -t 1 -s 0 --set smb_vendor` gets executed anyway on every single boot and we haven't seen much problems with it lately. The reason that the product part `smbios -t 1 -s 5 --set smb_product` is under the conditional is b/c IIRC I had cases where it would coredump GRUB -- but again -- since it is only ever executed when we see a vendor we recognize any potential damage seems to be somewhat limited.

So... what do you think @deitch @nordmark @giggsoff @gianlzed ?