### PR TITLE
Bad model can brick device; add sanity checks 

### DIFF
--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -400,6 +400,17 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 		} else if ib.UsedByUUID != nilUUID {
 			reportAA.UsedByAppUUID = ib.UsedByUUID.String()
 		}
+		if ib.Error != "" {
+			errInfo := new(info.ErrorInfo)
+			errInfo.Description = ib.Error
+			if !ib.ErrorTime.IsZero() {
+				protoTime, err := ptypes.TimestampProto(ib.ErrorTime)
+				if err == nil {
+					errInfo.Timestamp = protoTime
+				}
+			}
+			reportAA.Err = errInfo
+		}
 		log.Tracef("AssignableAdapters for %s macs %v",
 			reportAA.Name, reportAA.IoAddressList)
 		ReportDeviceInfo.AssignableAdapters = append(ReportDeviceInfo.AssignableAdapters,

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -630,7 +630,7 @@ func waitForQmp(domainName string) error {
 			if waited > maxDelay {
 				// Give up
 				logrus.Warnf("waitForQmp for %s: giving up", domainName)
-				return logError("Qmp not found")
+				return logError("Qmp not found: error %v", err)
 			}
 			delay = 2 * delay
 			if delay > time.Minute {

--- a/pkg/pillar/types/assignableadapters.go
+++ b/pkg/pillar/types/assignableadapters.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Zededa, Inc.
+// Copyright (c) 2018,2021 Zededa, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 package types
@@ -12,7 +12,9 @@ package types
 // file on boot.
 
 import (
+	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	zcommon "github.com/lf-edge/eve/api/go/evecommon"
@@ -55,7 +57,9 @@ type IoBundle struct {
 	// a device, and also to configure it.
 	// XXX TBD: Add PciClass, PciVendor and PciDevice strings as well
 	// for matching
-	Ifname  string // Matching for network PCI devices e.g., "eth1"
+	Ifname string // Matching for network PCI devices e.g., "eth1"
+
+	// Attributes from controller but can also be set locally.
 	PciLong string // Specific PCI bus address in Domain:Bus:Device.Funcion syntax
 	// For non-PCI devices such as the ISA serial ports we have:
 	// XXX: Why is IRQ a string?? Should convert it into Int.
@@ -80,6 +84,8 @@ type IoBundle struct {
 	//  If the device is ( or to be ) managed by DomU, this is True
 	IsPCIBack bool // Assigned to pciback
 	IsPort    bool // Whole or part of the bundle is a zedrouter port
+	Error     string
+	ErrorTime time.Time
 }
 
 // Really a constant
@@ -132,7 +138,7 @@ func (ib IoBundle) HasAdapterChanged(log *base.LogObject, phyAdapter PhysicalIOA
 		return true
 	}
 	if phyAdapter.Assigngrp != ib.AssignmentGroup {
-		log.Functionf("Ifname changed from %s to %s",
+		log.Functionf("AssignmentGroup changed from %s to %s",
 			ib.AssignmentGroup, phyAdapter.Assigngrp)
 		return true
 	}
@@ -250,6 +256,7 @@ func (aa AssignableAdapters) LogKey() string {
 // the function updates it, while preserving the most specific information.
 // The information we preserve are of two kinds:
 // - IsPort/IsPCIBack/UsedByUUID which come from interaction with nim
+// - PciLong, UsbAddr, etc which come from controller but might be filled in by domainmgr
 // - Unique/MacAddr which come from the PhysicalIoAdapter
 func (aa *AssignableAdapters) AddOrUpdateIoBundle(log *base.LogObject, ib IoBundle) {
 	curIbPtr := aa.LookupIoBundlePhylabel(ib.Phylabel)
@@ -278,6 +285,31 @@ func (aa *AssignableAdapters) AddOrUpdateIoBundle(log *base.LogObject, ib IoBund
 		log.Functionf("AddOrUpdateIoBundle(%d %s %s) preserve IsPCIBack %t",
 			ib.Type, ib.Phylabel, ib.AssignmentGroup, curIbPtr.IsPCIBack)
 		ib.IsPCIBack = curIbPtr.IsPCIBack
+	}
+	if curIbPtr.PciLong != "" {
+		log.Functionf("AddOrUpdateIoBundle(%d %s %s) preserve PciLong %v",
+			ib.Type, ib.Phylabel, ib.AssignmentGroup, curIbPtr.PciLong)
+		ib.PciLong = curIbPtr.PciLong
+	}
+	if curIbPtr.Irq != "" {
+		log.Functionf("AddOrUpdateIoBundle(%d %s %s) preserve Irq %v",
+			ib.Type, ib.Phylabel, ib.AssignmentGroup, curIbPtr.Irq)
+		ib.Irq = curIbPtr.Irq
+	}
+	if curIbPtr.Ioports != "" {
+		log.Functionf("AddOrUpdateIoBundle(%d %s %s) preserve Ioports %v",
+			ib.Type, ib.Phylabel, ib.AssignmentGroup, curIbPtr.Ioports)
+		ib.Ioports = curIbPtr.Ioports
+	}
+	if curIbPtr.Serial != "" {
+		log.Functionf("AddOrUpdateIoBundle(%d %s %s) preserve Serial %v",
+			ib.Type, ib.Phylabel, ib.AssignmentGroup, curIbPtr.Serial)
+		ib.Serial = curIbPtr.Serial
+	}
+	if curIbPtr.UsbAddr != "" {
+		log.Functionf("AddOrUpdateIoBundle(%d %s %s) preserve UsbAddr %v",
+			ib.Type, ib.Phylabel, ib.AssignmentGroup, curIbPtr.UsbAddr)
+		ib.UsbAddr = curIbPtr.UsbAddr
 	}
 	if curIbPtr.Unique != "" {
 		log.Functionf("AddOrUpdateIoBundle(%d %s %s) preserve Unique %v",
@@ -350,4 +382,62 @@ func (aa *AssignableAdapters) LookupIoBundleIfName(ifname string) *IoBundle {
 		}
 	}
 	return nil
+}
+
+// CheckBadAssignmentGroups sets ib.Error/ErrorTime if two IoBundles in different
+// assignment groups have the same PCI ID (ignoring the PCI function number)
+// Returns true if there was a modification so caller can publish.
+func (aa *AssignableAdapters) CheckBadAssignmentGroups(log *base.LogObject) bool {
+	changed := false
+	for i := range aa.IoBundleList {
+		ib := &aa.IoBundleList[i]
+		for _, ib2 := range aa.IoBundleList {
+			if ib2.Phylabel == ib.Phylabel {
+				continue
+			}
+			if ib.AssignmentGroup != "" && ib2.AssignmentGroup == ib.AssignmentGroup {
+				continue
+			}
+			if PCISameController(ib.PciLong, ib2.PciLong) {
+				err := fmt.Errorf("CheckBadAssignmentGroup: %s same PCI controller as %s; pci long %s vs %s",
+					ib2.Ifname, ib.Ifname, ib2.PciLong, ib.PciLong)
+				log.Error(err)
+				ib.Error = err.Error()
+				ib.ErrorTime = time.Now()
+				changed = true
+			}
+		}
+	}
+	return changed
+}
+
+// ExpandControllers expands the list to include other PCI functions on the same PCI controller
+// (while ignoring the function number). The output might have duplicate entries.
+func (aa *AssignableAdapters) ExpandControllers(log *base.LogObject, list []*IoBundle) []*IoBundle {
+	var elist []*IoBundle
+
+	elist = list
+	for _, ib := range list {
+		for i := range aa.IoBundleList {
+			ib2 := &aa.IoBundleList[i]
+			already := false
+			for _, ib3 := range elist {
+				if ib2.Phylabel == ib3.Phylabel {
+					already = true
+					break
+				}
+			}
+			if already {
+				log.Tracef("ExpandController already %s long %s",
+					ib2.Phylabel, ib2.PciLong)
+				continue
+			}
+			if PCISameController(ib.PciLong, ib2.PciLong) {
+				log.Warnf("ExpandController found %s matching %s; long %s long %s",
+					ib2.Phylabel, ib.Phylabel, ib2.PciLong, ib.PciLong)
+				elist = append(elist, ib2)
+			}
+		}
+	}
+	return elist
 }

--- a/pkg/pillar/types/assignableadapters_test.go
+++ b/pkg/pillar/types/assignableadapters_test.go
@@ -1,9 +1,10 @@
-// Copyright (c) 2019 Zededa, Inc.
+// Copyright (c) 2019,2021 Zededa, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 package types
 
 import (
+	"fmt"
 	"testing"
 
 	zcommon "github.com/lf-edge/eve/api/go/evecommon"
@@ -35,25 +36,25 @@ var aa AssignableAdapters = AssignableAdapters{
 		},
 		{
 			Type:            IoNetEth,
-			AssignmentGroup: "eTH4-7",
+			AssignmentGroup: "eth4-7",
 			Phylabel:        "eth4",
 			Ifname:          "eth4",
 		},
 		{
 			Type:            IoNetEth,
-			AssignmentGroup: "eTH4-7",
+			AssignmentGroup: "eth4-7",
 			Phylabel:        "eth5",
 			Ifname:          "eth5",
 		},
 		{
 			Type:            IoNetEth,
-			AssignmentGroup: "eTH4-7",
+			AssignmentGroup: "eth4-7",
 			Phylabel:        "eth6",
 			Ifname:          "eth6",
 		},
 		{
 			Type:            IoNetEth,
-			AssignmentGroup: "eTH4-7",
+			AssignmentGroup: "eth4-7",
 			Phylabel:        "eth7",
 			Ifname:          "eth7",
 		},
@@ -84,7 +85,7 @@ func TestLookupIoBundleGroup(t *testing.T) {
 		"IoType: IoNetEth LookupName: eth4-7": {
 			ioType:             IoNetEth,
 			lookupName:         "eth4-7",
-			expectedBundleName: "eTH4-7",
+			expectedBundleName: "eth4-7",
 		},
 	}
 
@@ -173,4 +174,282 @@ func TestIoBundleFromPhyAdapter(t *testing.T) {
 	assert.Equal(t, phyAdapter.Phyaddr.Serial, ibPtr.Serial)
 	assert.Equal(t, phyAdapter.Usage, ibPtr.Usage)
 	assert.Equal(t, phyAdapter.UsagePolicy.FreeUplink, ibPtr.FreeUplink)
+}
+
+var aa2 AssignableAdapters = AssignableAdapters{
+	Initialized: true,
+	IoBundleList: []IoBundle{
+		{
+			Type:            IoNetEth,
+			AssignmentGroup: "eth0-1",
+			Phylabel:        "eth0",
+			Ifname:          "eth0",
+			PciLong:         "0000:02:00.0",
+		},
+		{
+			Type:            IoNetEth,
+			AssignmentGroup: "eth0-1",
+			Phylabel:        "eth1",
+			Ifname:          "eth1",
+			PciLong:         "0000:02:00.0",
+		},
+		{
+			Type:            IoNetEth,
+			AssignmentGroup: "eth2",
+			Phylabel:        "eth2",
+			Ifname:          "eth2",
+			PciLong:         "0000:02:00.0",
+		},
+		{
+			Type:            IoNetEth,
+			AssignmentGroup: "eth3",
+			Phylabel:        "eth3",
+			Ifname:          "eth3",
+			PciLong:         "0000:02:00.1",
+		},
+		{
+			Type:            IoNetEth,
+			AssignmentGroup: "eth4-7",
+			Phylabel:        "eth4",
+			Ifname:          "eth4",
+			PciLong:         "0000:04:00.0",
+		},
+		{
+			Type:            IoNetEth,
+			AssignmentGroup: "eth4-7",
+			Phylabel:        "eth5",
+			Ifname:          "eth5",
+			PciLong:         "0000:04:00.1",
+		},
+		{
+			Type:            IoNetEth,
+			AssignmentGroup: "eth4-7",
+			Phylabel:        "eth6",
+			Ifname:          "eth6",
+			PciLong:         "0000:04:00.2",
+		},
+		{
+			Type:            IoNetEth,
+			AssignmentGroup: "eth4-7",
+			Phylabel:        "eth7",
+			Ifname:          "eth7",
+			PciLong:         "0000:04:00.3",
+		},
+		{
+			Type:            IoNetEth,
+			AssignmentGroup: "eth8",
+			Phylabel:        "eth8",
+			Ifname:          "eth8",
+			PciLong:         "0000:08:00.0",
+		},
+		{
+			Type:            IoNetEth,
+			AssignmentGroup: "eth9",
+			Phylabel:        "eth9",
+			Ifname:          "eth9",
+			PciLong:         "0000:08:00.1",
+		},
+		{
+			Type:            IoUSB,
+			Phylabel:        "USB0",
+			Logicallabel:    "USB0",
+			AssignmentGroup: "USB-A",
+			Ifname:          "",
+			PciLong:         "0000:00:15.0",
+		},
+		{
+			Type:            IoUSB,
+			Phylabel:        "USB1",
+			Logicallabel:    "USB1",
+			AssignmentGroup: "USB-A",
+			Ifname:          "",
+			PciLong:         "0000:00:15.0",
+		},
+		{
+			Type:            IoUSB,
+			Phylabel:        "USB2",
+			Logicallabel:    "USB2",
+			AssignmentGroup: "USB-A",
+			Ifname:          "",
+			PciLong:         "0000:00:15.0",
+		},
+		{
+			Type:            IoUSB,
+			Phylabel:        "USB3",
+			Logicallabel:    "USB3",
+			AssignmentGroup: "USB-A",
+			Ifname:          "",
+			PciLong:         "0000:00:15.0",
+		},
+		{
+			Type:            IoUSB,
+			Phylabel:        "USB4",
+			Logicallabel:    "USB4",
+			AssignmentGroup: "USB-A",
+			Ifname:          "",
+			PciLong:         "0000:00:15.0",
+		},
+		{
+			Type:            IoUSB,
+			Phylabel:        "USB5",
+			Logicallabel:    "USB5",
+			AssignmentGroup: "USB-A",
+			Ifname:          "",
+			PciLong:         "0000:00:15.0",
+		},
+		{
+			Type:            IoUSB,
+			Phylabel:        "USB-C",
+			Logicallabel:    "USB6",
+			AssignmentGroup: "USB-C",
+			Ifname:          "",
+			PciLong:         "0000:05:00.0",
+		},
+		{
+			Type:            IoCom,
+			Phylabel:        "COM1",
+			Logicallabel:    "COM1",
+			AssignmentGroup: "COM1",
+			Ifname:          "",
+			PciLong:         "",
+			Serial:          "/dev/ttyS0",
+		},
+		{
+			Type:            IoCom,
+			Phylabel:        "COM2",
+			Logicallabel:    "COM2",
+			AssignmentGroup: "COM2",
+			Ifname:          "",
+			PciLong:         "",
+			Serial:          "/dev/ttyS1",
+		},
+		{
+			Type:            IoCom,
+			Phylabel:        "COM3",
+			Logicallabel:    "COM3",
+			AssignmentGroup: "COM34",
+			Ifname:          "",
+			PciLong:         "",
+			Serial:          "/dev/ttyS2",
+		},
+		{
+			Type:            IoCom,
+			Phylabel:        "COM4",
+			Logicallabel:    "COM4",
+			AssignmentGroup: "COM34",
+			Ifname:          "",
+			PciLong:         "",
+			Serial:          "/dev/ttyS3",
+		},
+	},
+}
+
+// Same indices as above
+var aa2Errors = []string{
+	"CheckBadAssignmentGroup: eth3 same PCI controller as eth0; pci long 0000:02:00.1 vs 0000:02:00.0",
+	"CheckBadAssignmentGroup: eth3 same PCI controller as eth1; pci long 0000:02:00.1 vs 0000:02:00.0",
+	"CheckBadAssignmentGroup: eth3 same PCI controller as eth2; pci long 0000:02:00.1 vs 0000:02:00.0",
+	"CheckBadAssignmentGroup: eth2 same PCI controller as eth3; pci long 0000:02:00.0 vs 0000:02:00.1",
+	"",
+	"",
+	"",
+	"",
+	"CheckBadAssignmentGroup: eth9 same PCI controller as eth8; pci long 0000:08:00.1 vs 0000:08:00.0",
+	"CheckBadAssignmentGroup: eth8 same PCI controller as eth9; pci long 0000:08:00.0 vs 0000:08:00.1",
+	"",
+	"",
+	"",
+	"",
+	"",
+	"",
+	"",
+	"",
+	"",
+	"",
+	"",
+}
+
+func TestCheckBadAssignmentGroups(t *testing.T) {
+	log := base.NewSourceLogObject(logrus.StandardLogger(), "test", 1234)
+	changed := aa2.CheckBadAssignmentGroups(log)
+	assert.True(t, changed)
+	assert.Equal(t, len(aa2.IoBundleList), len(aa2Errors))
+	for i, ib := range aa2.IoBundleList {
+		t.Logf("Running test case TestCheckBadAssignmentGroups[%d]", i)
+		assert.Equal(t, aa2Errors[i], ib.Error)
+	}
+}
+
+type expandControllersTestEntry struct {
+	assignmentGroup string
+	preLen          int
+	postLen         int
+	postMembers     []string
+}
+
+func TestExpandControllers(t *testing.T) {
+	var testMatrix = map[string]expandControllersTestEntry{
+		"eth0-3": {
+			assignmentGroup: "eth0-1",
+			preLen:          2,
+			postLen:         4,
+			postMembers:     []string{"eth0", "eth1", "eth2", "eth3"},
+		},
+		"eth0-3 from eth2": {
+			assignmentGroup: "eth2",
+			preLen:          1,
+			postLen:         4,
+			postMembers:     []string{"eth0", "eth1", "eth2", "eth3"},
+		},
+		"eth8-9 from eth8": {
+			assignmentGroup: "eth8",
+			preLen:          1,
+			postLen:         2,
+			postMembers:     []string{"eth8", "eth9"},
+		},
+		"com1": {
+			assignmentGroup: "COM1",
+			preLen:          1,
+			postLen:         1,
+			postMembers:     []string{"COM1"},
+		},
+		"com34": {
+			assignmentGroup: "COM34",
+			preLen:          2,
+			postLen:         2,
+			postMembers:     []string{"COM3", "COM4"},
+		},
+		"USB-A": {
+			assignmentGroup: "USB-A",
+			preLen:          6,
+			postLen:         6,
+			postMembers:     []string{"USB0", "USB1", "USB2", "USB3", "USB4", "USB5"},
+		},
+		"USB-C": {
+			assignmentGroup: "USB-C",
+			preLen:          1,
+			postLen:         1,
+			postMembers:     []string{"USB-C"},
+		},
+	}
+
+	log := base.NewSourceLogObject(logrus.StandardLogger(), "test", 1234)
+	for testname, test := range testMatrix {
+		t.Logf("TESTCASE: %s - Running", testname)
+		preList := aa2.LookupIoBundleGroup(test.assignmentGroup)
+		preLen := len(preList)
+		postList := aa2.ExpandControllers(log, preList)
+		postLen := len(postList)
+		assert.Equal(t, test.preLen, preLen)
+		assert.Equal(t, test.postLen, postLen)
+		for _, m := range test.postMembers {
+			found := false
+			for _, ib := range postList {
+				if ib.Phylabel == m {
+					found = true
+				}
+			}
+			assert.True(t, found, fmt.Sprintf("Expected %s in postList", m))
+		}
+	}
 }

--- a/pkg/pillar/types/ifnametopci.go
+++ b/pkg/pillar/types/ifnametopci.go
@@ -69,6 +69,16 @@ func PCILongToShort(long string) string {
 	return strings.SplitAfterN(long, ":", 2)[1]
 }
 
+// PCISameController compares the PCI-ID without comparing the controller
+func PCISameController(long1 string, long2 string) bool {
+	if long1 == "" || long2 == "" {
+		return false
+	}
+	ctrl1 := strings.SplitAfter(long1, ".")[0]
+	ctrl2 := strings.SplitAfter(long2, ".")[0]
+	return ctrl1 == ctrl2
+}
+
 // Check if an ID like 0000:03:00.0 exists
 func pciLongExists(long string) bool {
 	path := pciPath + "/" + long

--- a/pkg/pillar/zedbox/zedbox.go
+++ b/pkg/pillar/zedbox/zedbox.go
@@ -153,7 +153,12 @@ func runService(serviceName string, sep entrypoint, inline bool) int {
 	log.Functionf("Notifying zedbox to start service %s with args %v",
 		sericeInitStatus.ServiceName, sericeInitStatus.CmdArgs)
 	if err := reverse.Publish(log, agentName, &sericeInitStatus); err != nil {
-		log.Fatalf(err.Error())
+		// When we hit this it is most likely due to zedbox having hit a panic
+		// or fatal. Don't hide that as the reboot reason.
+		// If that is not the case, then watchdog will soon detect that this service
+		// is not running.
+		log.Errorf(err.Error())
+		return 1
 	}
 	return 0
 }


### PR DESCRIPTION
Three separate commits; the first one is the key one. Others are to make it easier to debug which were useful as part of tracking down these issues.

When deploying a device with an incorrect phyio description from the controller we can end up stuck.
One example is when eth0 and eth1 are the same PCI controller and PCI function, and the systemadapters says that one of them should be app-direct. In that case we assign the PCI ID away, thereby loosing the use of the other ethernet.

The fallback to lastresort can't fix that because of the confusion with the same PCI-ID.

This PR makes that not happen by treating this as an error and also treating everything with the same PCI ID (except for function) as having IsPort=true if one of them has IsPort true, thereby avoiding assigning away the Ethernet port used to talk to the controller.

Basically the EVE API has an explicit assignmentGroup in the PhysicalIO, but in addition we treat things with the same PCI ID (and different which only differ in the function number) as being in the same group.
That required finding and fixing some old bugs where we don't check the IsPort boolean but call the IsPort function (latter only checks the specific ifname).

But the particular test case was one where the controller sends a PhysicalIO without any PCI-IDs, and we have domainmgr determine the PCI-ID. That wasn't robust enough and the error checks vs extracting PCI-ID, MacAddr, etc was interwined with assigment to/from pciback. Hence some cleanup in domainmgr was needed.

Running with these bits and the server where eth0 and eth1 are on the identical PCI controller we see this coming back in the info message:
ERROR: rvs-139.178.89.249 adapter error 0 at 2021-02-17T11:35:44.197159493Z:
ERROR: CheckBadAssignmentGroup: eth1 same PCI controller as eth0; pci long 0000:02:00.0 vs 0000:02:00.0
ERROR: rvs-139.178.89.249 adapter error 1 at 2021-02-17T11:35:44.197216763Z:
ERROR: CheckBadAssignmentGroup: eth0 same PCI controller as eth1; pci long 0000:02:00.0 vs 0000:02:00.0
ERROR: rvs-139.178.89.249 network eth1/eth1 error at 2021-02-17T11:40:19.194911587Z:
ERROR: No IP addresses to connect to https://zedcloud.alpha.zededa.net/api/v2/edgedevice/ping using intf eth1
ERROR: rvs-139.178.89.249 system adapter eth1 status failed at 2021-02-17T11:40:19.194911587Z: No IP addresses to connect to https://zedcloud.alpha.zededa.net/api/v2/edgedevice/ping using intf eth1

The CheckBadAssignmentGroup are new; the no IP on eth1 is because eth1 is not connected.
