### PR TITLE
restructure image builds

### DIFF
--- a/pkg/eve/Dockerfile.in
+++ b/pkg/eve/Dockerfile.in
@@ -17,9 +17,15 @@ COPY --from=raw / /
 COPY --from=ipxe / /
 COPY --from=tools /out/ /
 COPY installer /bits
-COPY OVMF* /firmware/
 COPY runme.sh /
 RUN mkdir /in /out
+
+
+# These labels indicate where each component type is.
+# These must be updated if we change filenames or locations.
+# The annotations to be used are available at https://github.com/lf-edge/edge-containers/blob/master/docs/annotations.md
+LABEL org.lfedge.eci.artifact.root="/bits/rootfs.img"
+LABEL org.lfedge.eci.artifact.initrd="/bits/initrd.img"
 
 WORKDIR /bits
 ENTRYPOINT ["/runme.sh"]


### PR DESCRIPTION
Does two things:

* adds `LABEL`s to the dockerfile `lfedge/eve` indicating where the rootfs and initrd are, so they can be found later
* instead of copying `installer/` in toto, copy each file/dir as desired

The first part is important for allowing anything to look at the `lfedge/eve` container and, just by inspecting its config, discover where the artifacts are. It lays more groundwork for baseos in OCI images.

The second part helps keep containers clean, and is a longstanding issue. `make` for various kinds of images dumps everything - with a filename that reflects the build hash - in `dist/<arch>/installer/`. 

The image we build includes the following components. Here is an example from looking at the tree on my test amd64 env:

```
~/go/src/github.com/lf-edge/eve$ tree dist/amd64/
dist/amd64/
├── Dockerfile
├── OVMF.fd
├── OVMF_CODE.fd
├── OVMF_VARS.fd
├── build.yml
├── installer
│   ├── EFI
│   │   └── BOOT
│   │       ├── BOOT.pc
│   │       ├── BOOTX64.EFI
│   │       └── grub.cfg
│   ├── boot
│   │   └── u-boot.bin
│   ├── config.img
│   ├── initrd.img
│   ├── persist.img
│   ├── rootfs-0.0.0-master-a8c5dddf-xen-amd64.squash
│   ├── rootfs-0.0.0-volumemgr-all-contenttree-021dbb95-kvm-amd64.squash
│   ├── rootfs-0.0.0-volumemgr-all-contenttree-68a5970b-kvm-amd64.squash
│   ├── rootfs-0.0.0-remove-hash-check-bd3809aa-kvm-amd64.squash
│   ├── rootfs-0.0.0-remove-hash-check-bad19db4-kvm-amd64.squash
│   ├── rootfs-xen.img -> rootfs-0.0.0-master-a8c5dddf-xen-amd64.squash
│   └── rootfs.img -> rootfs-xen.img
├── live.qcow2
├── live.raw
├── rootfs-kvm.yml
├── rootfs-xen.yml
└── runme.sh
```

This is a first step to cleaning it up, by explicitly adding to the image only those things we need:

* OVMF files
* EFI
* boot
* config.img
* persist.img
* initrd.img
* rootfs.img

In the future, we might want to think about having a per-build installer, so that it would be even cleaner. It would look something like this:

```
~/go/src/github.com/lf-edge/eve$ tree dist/amd64/
dist/amd64/
├── Dockerfile
├── build.yml
├── installer
  ├── master-a8c5dddf-xen-amd64
      ├── EFI
          └── BOOT
            ├── BOOT.pc
            ├── BOOTX64.EFI
            └── grub.cfg
      ├── boot
           └── u-boot.bin
      ├── firmware
            ├── OVMF.fd
            ├── OVMF_CODE.fd
            └── OVMF_VARS.fd
      ├── config.img
      ├── initrd.img
      ├── persist.img
      ├── runme.sh
      └── rootfs.img
  ├── volumemgr-all-contenttree-021dbb95-kvm-amd64
      ├── EFI
          └── BOOT
            ├── BOOT.pc
            ├── BOOTX64.EFI
            └── grub.cfg
      ├── boot
           └── u-boot.bin
      ├── firmware
            ├── OVMF.fd
            ├── OVMF_CODE.fd
            └── OVMF_VARS.fd
      ├── config.img
      ├── initrd.img
      ├── runme.sh
      └── rootfs.img
├── rootfs-kvm.yml
└── rootfs-xen.yml
```

Is this duplicative? Sure it is. But it duplicates everything in the git-ignored `dist/` tree, and shows very clearly everything you build that gets installed. It also has the benefit of sending docker context only the necessary files, not every single image that is there, making the builds slower as time goes on.

If people think this is better day one, I am happy to rework this PR to arrange the above.