### PR TITLE
Allow portmap access between apps connected to different network instances

### DIFF
--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -612,6 +612,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		ps.StillRunning(agentName, warningTime, errorTime)
 	}
 	log.Noticef("AA initialized")
+	devicenetwork.MoveDownLocalIPRule(log, devicenetwork.PbrLocalDestPrio)
 
 	for {
 		select {
@@ -846,7 +847,7 @@ func handleInterfaceChange(ctx *nimContext, ifindex int, logstr string, force bo
 		// Do not have a baseline to delete from
 		devicenetwork.FlushRules(log, ifindex)
 		for _, a := range addrs {
-			devicenetwork.AddSourceRule(log, ifindex, devicenetwork.HostSubnet(a), false)
+			devicenetwork.AddSourceRule(log, ifindex, devicenetwork.HostSubnet(a), false, devicenetwork.PbrLocalOrigPrio)
 		}
 		devicenetwork.HandleAddressChange(&ctx.deviceNetworkContext)
 		// XXX should we trigger restarting testing?
@@ -869,10 +870,10 @@ func handleInterfaceChange(ctx *nimContext, ifindex int, logstr string, force bo
 		log.Functionf("%s(%s) changed from %v to %v",
 			logstr, ifname, oldAddrs, addrs)
 		for _, a := range oldAddrs {
-			devicenetwork.DelSourceRule(log, ifindex, devicenetwork.HostSubnet(a), false)
+			devicenetwork.DelSourceRule(log, ifindex, devicenetwork.HostSubnet(a), false, devicenetwork.PbrLocalOrigPrio)
 		}
 		for _, a := range addrs {
-			devicenetwork.AddSourceRule(log, ifindex, devicenetwork.HostSubnet(a), false)
+			devicenetwork.AddSourceRule(log, ifindex, devicenetwork.HostSubnet(a), false, devicenetwork.PbrLocalOrigPrio)
 		}
 
 		devicenetwork.HandleAddressChange(&ctx.deviceNetworkContext)

--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -1407,7 +1407,10 @@ func natActivate(ctx *zedrouterContext,
 				"Err: %s", status.BridgeName, a, err)
 			return err
 		}
-		devicenetwork.AddSourceRule(log, status.BridgeIfindex, status.Subnet, true)
+		devicenetwork.AddGatewaySourceRule(log, status.Subnet,
+			net.ParseIP(status.BridgeIPAddr), devicenetwork.PbrNatOutGatewayPrio)
+		devicenetwork.AddSourceRule(log, status.BridgeIfindex, status.Subnet, true, devicenetwork.PbrNatOutPrio)
+		devicenetwork.AddInwardSourceRule(log, status.BridgeIfindex, status.Subnet, true, devicenetwork.PbrNatInPrio)
 	}
 	return nil
 }
@@ -1429,7 +1432,10 @@ func natInactivate(ctx *zedrouterContext,
 	if err != nil {
 		log.Errorf("natInactivate: iptableCmd failed %s\n", err)
 	}
-	devicenetwork.DelSourceRule(log, status.BridgeIfindex, status.Subnet, true)
+	devicenetwork.DelGatewaySourceRule(log, status.Subnet,
+		net.ParseIP(status.BridgeIPAddr), devicenetwork.PbrNatOutGatewayPrio)
+	devicenetwork.DelSourceRule(log, status.BridgeIfindex, status.Subnet, true, devicenetwork.PbrNatOutPrio)
+	devicenetwork.DelInwardSourceRule(log, status.BridgeIfindex, status.Subnet, true, devicenetwork.PbrNatInPrio)
 	err = PbrRouteDeleteAll(status.BridgeName, oldUplinkIntf)
 	if err != nil {
 		log.Errorf("natInactivate: PbrRouteDeleteAll failed %s\n", err)

--- a/pkg/pillar/devicenetwork/addrchange.go
+++ b/pkg/pillar/devicenetwork/addrchange.go
@@ -62,9 +62,9 @@ func AddrChange(ctx DeviceNetworkContext, change netlink.AddrUpdate) (bool, int)
 		isPort := types.IsMgmtPort(*ctx.DeviceNetworkStatus, ifname)
 		if isPort {
 			if change.NewAddr {
-				AddSourceRule(log, change.LinkIndex, change.LinkAddress, false)
+				AddSourceRule(log, change.LinkIndex, change.LinkAddress, false, PbrLocalOrigPrio)
 			} else {
-				DelSourceRule(log, change.LinkIndex, change.LinkAddress, false)
+				DelSourceRule(log, change.LinkIndex, change.LinkAddress, false, PbrLocalOrigPrio)
 			}
 		}
 		log.Functionf("AddrChange: changed, %d %s", change.LinkIndex, change.LinkAddress.String())
@@ -300,7 +300,7 @@ func addPBR(log *base.LogObject, status types.DeviceNetworkStatus, ifname string
 	}
 	FlushRules(log, ifindex)
 	for _, a := range addrs {
-		AddSourceRule(log, ifindex, HostSubnet(a), false)
+		AddSourceRule(log, ifindex, HostSubnet(a), false, PbrLocalOrigPrio)
 	}
 	// Flush then copy all routes for this interface to the table
 	// for this ifindex


### PR DESCRIPTION
1) When apps send out packets destined to one of the IP addresses owned by edge-node (mgmt/app-shared interfaces), they will first hit the local table and get punted to local path. We want these packets to be served by network instance specific routes. This necessitates movement of local table rule below network instance specific rules.
2) Even the ip rules created by EVE for locally generated packets (EVE services) should move below the network instance rules.
3) When packets get hairpinned between two interfaces of the same edge-node, they come with one the the edge-node local IP addresses as source IP address. For such packets we should create new IP rules that match on their destination to see if they belong to any of the network instances and use network instance specific route tables for lookups.
4) With the local table rule moved down below network instance rules, we should also create explicit ip rules that match on the network instance specific source prefix, bridge address for destination address and make such packets use local table for lookups. Otherwise local communication between apps and EVE hosted services will not work.

Signed-off-by: Gopi krishna Kodali <gkodali@zededa.com>