### PR TITLE
Missing logs for http server goroutine done 

### DIFF
--- a/pkg/pillar/cmd/zedrouter/server.go
+++ b/pkg/pillar/cmd/zedrouter/server.go
@@ -68,7 +68,7 @@ func deleteServer4(ctx *zedrouterContext, bridgeIP string, bridgeName string) {
 	targetPort := 80
 	subnetStr := "169.254.169.254/32"
 	target := fmt.Sprintf("%s:%d", bridgeIP, targetPort)
-	log.Noticef("add NAT to target %s", target)
+	log.Noticef("delete NAT from target %s", target)
 	if err := iptables.IptableCmd(log, "-t", "nat", "-D", "PREROUTING",
 		"-i", bridgeName, "-p", "tcp", "-d", subnetStr,
 		"--dport", strconv.Itoa(targetPort),
@@ -141,7 +141,9 @@ func runServer(mux http.Handler, network string, ipaddr string,
 			log.Fatalf("server on %s failed: %s", ipaddr, err)
 		}
 	}
+	log.Noticef("Waiting for idleConnsClosed on %s", ipaddr)
 	<-idleConnsClosed
+	log.Noticef("Done waiting for idleConnsClosed on %s", ipaddr)
 }
 
 // ServeHTTP for networkHandler provides a json return

--- a/pkg/pillar/types/physicalioadapters.go
+++ b/pkg/pillar/types/physicalioadapters.go
@@ -77,7 +77,7 @@ func (ioAdapterList PhysicalIOAdapterList) LogCreate(logBase *base.LogObject) {
 	if logObject == nil {
 		return
 	}
-	logObject.Metricf("Onboarding ioAdapterList create")
+	logObject.Noticef("Onboarding ioAdapterList create")
 }
 
 // LogModify :
@@ -91,14 +91,14 @@ func (ioAdapterList PhysicalIOAdapterList) LogModify(logBase *base.LogObject, ol
 	}
 	// XXX remove?
 	logObject.CloneAndAddField("diff", cmp.Diff(oldIoAdapterList, ioAdapterList)).
-		Metricf("Onboarding ioAdapterList modify")
+		Noticef("Onboarding ioAdapterList modify")
 }
 
 // LogDelete :
 func (ioAdapterList PhysicalIOAdapterList) LogDelete(logBase *base.LogObject) {
 	logObject := base.EnsureLogObject(logBase, base.PhysicalIOAdapterListLogType, "",
 		nilUUID, ioAdapterList.LogKey())
-	logObject.Metricf("Onboarding ioAdapterList delete")
+	logObject.Noticef("Onboarding ioAdapterList delete")
 
 	base.DeleteLogObject(logBase, ioAdapterList.LogKey())
 }

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -2056,7 +2056,7 @@ func (nms NetworkMetrics) LogCreate(logBase *base.LogObject) {
 	if logObject == nil {
 		return
 	}
-	logObject.Metricf("Network nms create")
+	logObject.Metricf("Network metrics create")
 }
 
 // LogModify :
@@ -2178,7 +2178,7 @@ func (config NetworkInstanceConfig) LogCreate(logBase *base.LogObject) {
 	if logObject == nil {
 		return
 	}
-	logObject.Metricf("Network instance config create")
+	logObject.Noticef("Network instance config create")
 }
 
 // LogModify :
@@ -2192,14 +2192,14 @@ func (config NetworkInstanceConfig) LogModify(logBase *base.LogObject, old inter
 	}
 	// XXX remove?
 	logObject.CloneAndAddField("diff", cmp.Diff(oldConfig, config)).
-		Metricf("Network instance config modify")
+		Noticef("Network instance config modify")
 }
 
 // LogDelete :
 func (config NetworkInstanceConfig) LogDelete(logBase *base.LogObject) {
 	logObject := base.EnsureLogObject(logBase, base.NetworkInstanceConfigLogType, "",
 		config.UUIDandVersion.UUID, config.LogKey())
-	logObject.Metricf("Network instance config delete")
+	logObject.Noticef("Network instance config delete")
 
 	base.DeleteLogObject(logBase, config.LogKey())
 }
@@ -2255,7 +2255,7 @@ func (status NetworkInstanceStatus) LogCreate(logBase *base.LogObject) {
 	if logObject == nil {
 		return
 	}
-	logObject.Metricf("Network instance status create")
+	logObject.Noticef("Network instance status create")
 }
 
 // LogModify :
@@ -2269,14 +2269,14 @@ func (status NetworkInstanceStatus) LogModify(logBase *base.LogObject, old inter
 	}
 	// XXX remove?
 	logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
-		Metricf("Network instance status modify")
+		Noticef("Network instance status modify")
 }
 
 // LogDelete :
 func (status NetworkInstanceStatus) LogDelete(logBase *base.LogObject) {
 	logObject := base.EnsureLogObject(logBase, base.NetworkInstanceStatusLogType, "",
 		status.UUIDandVersion.UUID, status.LogKey())
-	logObject.Metricf("Network instance status delete")
+	logObject.Noticef("Network instance status delete")
 
 	base.DeleteLogObject(logBase, status.LogKey())
 }
@@ -2754,7 +2754,7 @@ func (vifIP VifIPTrig) LogCreate(logBase *base.LogObject) {
 	if logObject == nil {
 		return
 	}
-	logObject.Metricf("Vif IP trig create")
+	logObject.Noticef("Vif IP trig create")
 }
 
 // LogModify :
@@ -2768,14 +2768,14 @@ func (vifIP VifIPTrig) LogModify(logBase *base.LogObject, old interface{}) {
 	}
 	// XXX remove?
 	logObject.CloneAndAddField("diff", cmp.Diff(oldVifIP, vifIP)).
-		Metricf("Vif IP trig modify")
+		Noticef("Vif IP trig modify")
 }
 
 // LogDelete :
 func (vifIP VifIPTrig) LogDelete(logBase *base.LogObject) {
 	logObject := base.EnsureLogObject(logBase, base.VifIPTrigLogType, "",
 		nilUUID, vifIP.LogKey())
-	logObject.Metricf("Vif IP trig delete")
+	logObject.Noticef("Vif IP trig delete")
 
 	base.DeleteLogObject(logBase, vifIP.LogKey())
 }
@@ -2803,7 +2803,7 @@ func (status OnboardingStatus) LogCreate(logBase *base.LogObject) {
 	if logObject == nil {
 		return
 	}
-	logObject.Metricf("Onboarding status create")
+	logObject.Noticef("Onboarding status create")
 }
 
 // LogModify :
@@ -2817,14 +2817,14 @@ func (status OnboardingStatus) LogModify(logBase *base.LogObject, old interface{
 	}
 	// XXX remove?
 	logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
-		Metricf("Onboarding status modify")
+		Noticef("Onboarding status modify")
 }
 
 // LogDelete :
 func (status OnboardingStatus) LogDelete(logBase *base.LogObject) {
 	logObject := base.EnsureLogObject(logBase, base.OnboardingStatusLogType, "",
 		nilUUID, status.LogKey())
-	logObject.Metricf("Onboarding status delete")
+	logObject.Noticef("Onboarding status delete")
 
 	base.DeleteLogObject(logBase, status.LogKey())
 }


### PR DESCRIPTION
The current default logs doesn't tell us why the http server starts and stops (whether network instances are activated/inactivated or created/deleted), nor whether how long the server goroutine waits for existing connections to go away.

We've seen a failure with the log
"file":"/pillar/cmd/zedrouter/server.go:141","func":"github.com/lf-edge/eve/pkg/pillar/cmd/zedrouter.runServer","image":"IMGA","msg":"server on 172.168.1.1 failed: listen tcp 172.168.1.1:80: bind: address already in use"

when running stress tests which create and delete network instances.