### PR TITLE
Waiting for reboot to complete needs wait

### DIFF
--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -1732,10 +1732,12 @@ func scheduleReboot(reboot *zconfig.DeviceOpsCmd,
 			OpsTime:      reboot.OpsTime,
 		}
 		saveRebootConfig(rebootCmd)
-		getconfigCtx.zedagentCtx.rebootConfigCounter = reboot.Counter
+		// We read this into zedagentCtx.rebootConfigCounter and report that
+		// value to the controller once we have rebooted
 	}
 	if rebootConfig == nil {
 		// First boot - skip the reboot but report to cloud
+		getconfigCtx.zedagentCtx.rebootConfigCounter = reboot.Counter
 		triggerPublishDevInfo(getconfigCtx.zedagentCtx)
 		rebootPrevReturn = false
 		return false


### PR DESCRIPTION
@kalyan-nidumolu I discovered this when using Eden to check that a reboot wasn't pending. This might explain why checks in ztest aren't capable of detecting a reboot in progress, hence we sometimes get the "unexpected reboot" failures.