### PR TITLE
Working around smb_product containing non-printable chars

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -226,7 +226,9 @@ function set_arm64_baremetal {
    fi
    if [ "$smb_vendor" = "Huawei" ]; then
       smbios -t 1 -s 5 --set smb_product
-      if [ "$smb_product" = "XR320" ]; then
+      # turns out smb_product contains non-printable characters
+      # this makes grepping for XR320 our best option
+      if regexp -- "XR320" "$smb_product"; then
          set_global dom0_console "console=ttyAMA0,115200n8"
          set_global dom0_platform_tweaks "pcie_aspm=off pci=pcie_bus_perf crashkernel=auto"
       fi


### PR DESCRIPTION
Who says hardware isn't fun?

Turns out smb_product contains non-printable characters: this makes grepping for substrings our best option.