### PR TITLE
ARM: efi dt fixup protocol

### DIFF
--- a/pkg/grub/patches/0009-add-dt-fixup-efi-protocol.patch
+++ b/pkg/grub/patches/0009-add-dt-fixup-efi-protocol.patch
@@ -1,0 +1,130 @@
+From 843f93185060ca0ce1053a9edbd8ba0214e5d3b3 Mon Sep 17 00:00:00 2001
+From: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>
+Date: Sat, 20 Feb 2021 23:27:22 +0300
+Subject: [PATCH] Add dt-fixup efi protocol
+
+Signed-off-by: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>
+---
+ grub-core/loader/efi/fdt.c | 41 ++++++++++++++++++++++++++++++++++++--
+ include/grub/efi/api.h     | 22 ++++++++++++++++++++
+ 2 files changed, 61 insertions(+), 2 deletions(-)
+
+diff --git a/grub-core/loader/efi/fdt.c b/grub-core/loader/efi/fdt.c
+index c0c6800f7..8e8a7b500 100644
+--- a/grub-core/loader/efi/fdt.c
++++ b/grub-core/loader/efi/fdt.c
+@@ -25,9 +25,43 @@
+ #include <grub/efi/efi.h>
+ #include <grub/efi/fdtload.h>
+ #include <grub/efi/memory.h>
++#include <grub/cpu/efi/memory.h>
+ 
+ static void *loaded_fdt;
+ static void *fdt;
++static grub_efi_guid_t dt_fixup_guid = GRUB_EFI_DT_FIXUP_PROTOCOL_GUID;
++
++static void *grub_fdt_fixup (void)
++{
++  grub_efi_dt_fixup_t *dt_fixup_prot;
++  grub_efi_uintn_t size = 0;
++  grub_efi_status_t status;
++  void *fixup_fdt;
++
++  dt_fixup_prot = grub_efi_locate_protocol (&dt_fixup_guid, 0);
++  if (! dt_fixup_prot)
++    return loaded_fdt;
++
++  grub_dprintf ("linux", "EFI_DT_FIXUP_PROTOCOL available\n");
++
++  status = efi_call_4 (dt_fixup_prot->fixup, dt_fixup_prot, loaded_fdt, &size,
++		       GRUB_EFI_DT_APPLY_FIXUPS | GRUB_EFI_DT_RESERVE_MEMORY);
++  if (status != GRUB_EFI_BUFFER_TOO_SMALL)
++    return loaded_fdt;
++
++  fixup_fdt = grub_realloc (loaded_fdt, size);
++  if (!fixup_fdt)
++    return loaded_fdt;
++  loaded_fdt = fixup_fdt;
++
++  status = efi_call_4 (dt_fixup_prot->fixup, dt_fixup_prot, loaded_fdt, &size,
++		       GRUB_EFI_DT_APPLY_FIXUPS | GRUB_EFI_DT_RESERVE_MEMORY);
++
++  if (status == GRUB_EFI_SUCCESS)
++    grub_dprintf ("linux", "Device tree fixed up via EFI_DT_FIXUP_PROTOCOL\n");
++
++  return loaded_fdt;
++}
+ 
+ void *
+ grub_fdt_load (grub_size_t additional_size)
+@@ -42,7 +76,7 @@ grub_fdt_load (grub_size_t additional_size)
+     }
+ 
+   if (loaded_fdt)
+-    raw_fdt = loaded_fdt;
++    raw_fdt = grub_fdt_fixup();
+   else
+     raw_fdt = grub_efi_get_firmware_fdt();
+ 
+@@ -51,7 +85,10 @@ grub_fdt_load (grub_size_t additional_size)
+   size += additional_size;
+ 
+   grub_dprintf ("linux", "allocating %d bytes for fdt\n", size);
+-  fdt = grub_efi_allocate_any_pages (GRUB_EFI_BYTES_TO_PAGES (size));
++  fdt = grub_efi_allocate_pages_real (GRUB_EFI_MAX_USABLE_ADDRESS,
++				      GRUB_EFI_BYTES_TO_PAGES (size),
++				      GRUB_EFI_ALLOCATE_MAX_ADDRESS,
++				      GRUB_EFI_ACPI_RECLAIM_MEMORY);
+   if (!fdt)
+     return NULL;
+ 
+diff --git a/include/grub/efi/api.h b/include/grub/efi/api.h
+index 356d855e2..65b0c9184 100644
+--- a/include/grub/efi/api.h
++++ b/include/grub/efi/api.h
+@@ -334,6 +334,11 @@
+       { 0x83, 0x0b, 0xd9, 0x15, 0x2c, 0x69, 0xaa, 0xe0 } \
+   }
+ 
++#define GRUB_EFI_DT_FIXUP_PROTOCOL_GUID \
++  { 0xe617d64c, 0xfe08, 0x46da, \
++    { 0xf4, 0xdc, 0xbb, 0xd5, 0x87, 0x0c, 0x73, 0x00 } \
++  }
++
+ #define GRUB_EFI_VENDOR_APPLE_GUID \
+   { 0x2B0585EB, 0xD8B8, 0x49A9,	\
+       { 0x8B, 0x8C, 0xE2, 0x1B, 0x01, 0xAE, 0xF2, 0xB7 } \
+@@ -1627,6 +1632,13 @@ enum
+     GRUB_EFI_SIMPLE_NETWORK_RECEIVE_PROMISCUOUS_MULTICAST = 0x10,
+   };
+ 
++enum
++  {
++    GRUB_EFI_DT_APPLY_FIXUPS		= 0x01,
++    GRUB_EFI_DT_RESERVE_MEMORY		= 0x02,
++    GRUB_EFI_EFI_DT_INSTALL_TABLE	= 0x04,
++  };
++
+ struct grub_efi_simple_network
+ {
+   grub_uint64_t revision;
+@@ -1690,6 +1702,16 @@ struct grub_efi_block_io
+ };
+ typedef struct grub_efi_block_io grub_efi_block_io_t;
+ 
++struct grub_efi_dt_fixup
++{
++  grub_efi_uint64_t revision;
++  grub_efi_status_t (*fixup) (struct grub_efi_dt_fixup *this,
++			      void *fdt,
++			      grub_efi_uintn_t *buffer_size,
++			      grub_uint32_t flags);
++};
++typedef struct grub_efi_dt_fixup grub_efi_dt_fixup_t;
++
+ #if (GRUB_TARGET_SIZEOF_VOID_P == 4) || defined (__ia64__) \
+   || defined (__aarch64__) || defined (__MINGW64__) || defined (__CYGWIN__)
+ 
+-- 
+2.25.1
+

--- a/pkg/u-boot/patches/patches-v2020.07/0007-efi_loader-implement-EFI_DT_FIXUP_PROTOCOL.patch
+++ b/pkg/u-boot/patches/patches-v2020.07/0007-efi_loader-implement-EFI_DT_FIXUP_PROTOCOL.patch
@@ -1,0 +1,381 @@
+From 2321a54fa4417394c95f10bea6de73604ddc24b8 Mon Sep 17 00:00:00 2001
+From: Heinrich Schuchardt <xypron.glpk@gmx.de>
+Date: Sun, 13 Dec 2020 10:30:24 +0100
+Subject: [PATCH] efi_loader: implement EFI_DT_FIXUP_PROTOCOL
+
+A boot manager like GRUB can use the protocol to
+
+* apply U-Boot's fix-ups to the a device-tree
+* let U-Boot make memory reservations according to the device-tree
+* install the device-tree as a configuration table
+
+Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>
+---
+ cmd/bootefi.c                  |  58 ------------
+ cmd/efidebug.c                 |   5 ++
+ include/efi_dt_fixup.h         |  39 ++++++++
+ include/efi_loader.h           |   2 +
+ lib/efi_loader/Makefile        |   3 +
+ lib/efi_loader/efi_dt_fixup.c  | 160 +++++++++++++++++++++++++++++++++
+ lib/efi_loader/efi_root_node.c |   6 ++
+ 7 files changed, 215 insertions(+), 58 deletions(-)
+ create mode 100644 include/efi_dt_fixup.h
+ create mode 100644 lib/efi_loader/efi_dt_fixup.c
+
+diff --git a/cmd/bootefi.c b/cmd/bootefi.c
+index 57552f99fc..5781af7cea 100644
+--- a/cmd/bootefi.c
++++ b/cmd/bootefi.c
+@@ -150,64 +150,6 @@ done:
+ 	return ret;
+ }
+ 
+-static void efi_reserve_memory(u64 addr, u64 size)
+-{
+-	/* Convert from sandbox address space. */
+-	addr = (uintptr_t)map_sysmem(addr, 0);
+-	if (efi_add_memory_map(addr, size,
+-			       EFI_RESERVED_MEMORY_TYPE) != EFI_SUCCESS)
+-		printf("Reserved memory mapping failed addr %llx size %llx\n",
+-		       addr, size);
+-}
+-
+-/**
+- * efi_carve_out_dt_rsv() - Carve out DT reserved memory ranges
+- *
+- * The mem_rsv entries of the FDT are added to the memory map. Any failures are
+- * ignored because this is not critical and we would rather continue to try to
+- * boot.
+- *
+- * @fdt: Pointer to device tree
+- */
+-static void efi_carve_out_dt_rsv(void *fdt)
+-{
+-	int nr_rsv, i;
+-	u64 addr, size;
+-	int nodeoffset, subnode;
+-
+-	nr_rsv = fdt_num_mem_rsv(fdt);
+-
+-	/* Look for an existing entry and add it to the efi mem map. */
+-	for (i = 0; i < nr_rsv; i++) {
+-		if (fdt_get_mem_rsv(fdt, i, &addr, &size) != 0)
+-			continue;
+-		efi_reserve_memory(addr, size);
+-	}
+-
+-	/* process reserved-memory */
+-	nodeoffset = fdt_subnode_offset(fdt, 0, "reserved-memory");
+-	if (nodeoffset >= 0) {
+-		subnode = fdt_first_subnode(fdt, nodeoffset);
+-		while (subnode >= 0) {
+-			fdt_addr_t fdt_addr;
+-			fdt_size_t fdt_size;
+-
+-			/* check if this subnode has a reg property */
+-			fdt_addr = fdtdec_get_addr_size_auto_parent(
+-						fdt, nodeoffset, subnode,
+-						"reg", 0, &fdt_size, false);
+-			/*
+-			 * The /reserved-memory node may have children with
+-			 * a size instead of a reg property.
+-			 */
+-			if (fdt_addr != FDT_ADDR_T_NONE &&
+-			    fdtdec_get_is_enabled(fdt, subnode))
+-				efi_reserve_memory(fdt_addr, fdt_size);
+-			subnode = fdt_next_subnode(fdt, subnode);
+-		}
+-	}
+-}
+-
+ /**
+  * get_config_table() - get configuration table
+  *
+diff --git a/cmd/efidebug.c b/cmd/efidebug.c
+index 58018f700c..431ffc3cc4 100644
+--- a/cmd/efidebug.c
++++ b/cmd/efidebug.c
+@@ -8,6 +8,7 @@
+ #include <charset.h>
+ #include <common.h>
+ #include <command.h>
++#include <efi_dt_fixup.h>
+ #include <efi_loader.h>
+ #include <exports.h>
+ #include <hexdump.h>
+@@ -256,6 +257,10 @@ static const struct {
+ 		"PXE Base Code",
+ 		EFI_PXE_BASE_CODE_PROTOCOL_GUID,
+ 	},
++	{
++		"Device-Tree Fixup",
++		EFI_DT_FIXUP_PROTOCOL_GUID,
++	},
+ 	/* Configuration table GUIDs */
+ 	{
+ 		"ACPI table",
+diff --git a/include/efi_dt_fixup.h b/include/efi_dt_fixup.h
+new file mode 100644
+index 0000000000..9066e8dd8e
+--- /dev/null
++++ b/include/efi_dt_fixup.h
+@@ -0,0 +1,39 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * EFI_DT_FIXUP_PROTOCOL
++ *
++ * Copyright (c) 2020 Heinrich Schuchardt
++ */
++
++#include <efi_api.h>
++
++#define EFI_DT_FIXUP_PROTOCOL_GUID \
++	EFI_GUID(0xe617d64c, 0xfe08, 0x46da, 0xf4, 0xdc, \
++		 0xbb, 0xd5, 0x87, 0x0c, 0x73, 0x00)
++
++#define EFI_DT_FIXUP_PROTOCOL_REVISION 0x00010000
++
++/* Add nodes and update properties */
++#define EFI_DT_APPLY_FIXUPS    0x00000001
++/*
++ * Reserve memory according to the /reserved-memory node
++ * and the memory reservation block
++ */
++#define EFI_DT_RESERVE_MEMORY  0x00000002
++/* Install the device-tree as configuration table */
++#define EFI_DT_INSTALL_TABLE   0x00000004
++
++#define EFI_DT_ALL (EFI_DT_APPLY_FIXUPS | \
++		    EFI_DT_RESERVE_MEMORY | \
++		    EFI_DT_INSTALL_TABLE)
++
++struct efi_dt_fixup_protocol {
++	u64 revision;
++	efi_status_t (EFIAPI *fixup) (struct efi_dt_fixup_protocol *this,
++				      void *dtb,
++				      efi_uintn_t *buffer_size,
++				      u32 flags);
++};
++
++extern struct efi_dt_fixup_protocol efi_dt_fixup_prot;
++extern const efi_guid_t efi_guid_dt_fixup_protocol;
+diff --git a/include/efi_loader.h b/include/efi_loader.h
+index c2cae814b6..63179885a3 100644
+--- a/include/efi_loader.h
++++ b/include/efi_loader.h
+@@ -394,6 +394,8 @@ efi_status_t efi_root_node_register(void);
+ efi_status_t efi_initialize_system_table(void);
+ /* efi_runtime_detach() - detach unimplemented runtime functions */
+ void efi_runtime_detach(void);
++/* Carve out DT reserved memory ranges */
++void efi_carve_out_dt_rsv(void *fdt);
+ /* Called by bootefi to make console interface available */
+ efi_status_t efi_console_register(void);
+ /* Called by bootefi to make all disk storage accessible as EFI objects */
+diff --git a/lib/efi_loader/Makefile b/lib/efi_loader/Makefile
+index 57c7e66ea0..b829295611 100644
+--- a/lib/efi_loader/Makefile
++++ b/lib/efi_loader/Makefile
+@@ -27,6 +27,9 @@ obj-y += efi_console.o
+ obj-y += efi_device_path.o
+ obj-$(CONFIG_EFI_DEVICE_PATH_TO_TEXT) += efi_device_path_to_text.o
+ obj-y += efi_device_path_utilities.o
++ifeq ($(CONFIG_GENERATE_ACPI_TABLE),)
++obj-y += efi_dt_fixup.o
++endif
+ obj-y += efi_file.o
+ obj-$(CONFIG_EFI_LOADER_HII) += efi_hii.o efi_hii_config.o
+ obj-y += efi_image_loader.o
+diff --git a/lib/efi_loader/efi_dt_fixup.c b/lib/efi_loader/efi_dt_fixup.c
+new file mode 100644
+index 0000000000..5f0ae5c338
+--- /dev/null
++++ b/lib/efi_loader/efi_dt_fixup.c
+@@ -0,0 +1,160 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * EFI_DT_FIXUP_PROTOCOL
++ *
++ * Copyright (c) 2020 Heinrich Schuchardt
++ */
++
++#include <common.h>
++#include <efi_dt_fixup.h>
++#include <efi_loader.h>
++#include <mapmem.h>
++
++static efi_status_t EFIAPI efi_dt_fixup(struct efi_dt_fixup_protocol *this,
++					void *dtb,
++					efi_uintn_t *buffer_size,
++					u32 flags);
++
++struct efi_dt_fixup_protocol efi_dt_fixup_prot = {
++	.revision = EFI_DT_FIXUP_PROTOCOL_REVISION,
++	.fixup = efi_dt_fixup
++};
++
++const efi_guid_t efi_guid_dt_fixup_protocol = EFI_DT_FIXUP_PROTOCOL_GUID;
++
++/**
++ * efi_reserve_memory() - add reserved memory to memory map
++ *
++ * @addr:	start address of the reserved memory range
++ * @size:	size of the reserved memory range
++ * @nomap:	indicates that the memory range shall not be accessed by the
++ *		UEFI payload
++ */
++static void efi_reserve_memory(u64 addr, u64 size, bool nomap)
++{
++	int type;
++	efi_uintn_t ret;
++
++	/* Convert from sandbox address space. */
++	addr = (uintptr_t)map_sysmem(addr, 0);
++
++	if (nomap)
++		type = EFI_RESERVED_MEMORY_TYPE;
++	else
++		type = EFI_BOOT_SERVICES_DATA;
++
++	ret = efi_add_memory_map(addr, size, type);
++	if (ret != EFI_SUCCESS)
++		log_err("Reserved memory mapping failed addr %llx size %llx\n",
++			addr, size);
++}
++
++/**
++ * efi_carve_out_dt_rsv() - Carve out DT reserved memory ranges
++ *
++ * The mem_rsv entries of the FDT are added to the memory map. Any failures are
++ * ignored because this is not critical and we would rather continue to try to
++ * boot.
++ *
++ * @fdt: Pointer to device tree
++ */
++void efi_carve_out_dt_rsv(void *fdt)
++{
++	int nr_rsv, i;
++	u64 addr, size;
++	int nodeoffset, subnode;
++
++	nr_rsv = fdt_num_mem_rsv(fdt);
++
++	/* Look for an existing entry and add it to the efi mem map. */
++	for (i = 0; i < nr_rsv; i++) {
++		if (fdt_get_mem_rsv(fdt, i, &addr, &size) != 0)
++			continue;
++		efi_reserve_memory(addr, size, false);
++	}
++
++	/* process reserved-memory */
++	nodeoffset = fdt_subnode_offset(fdt, 0, "reserved-memory");
++	if (nodeoffset >= 0) {
++		subnode = fdt_first_subnode(fdt, nodeoffset);
++		while (subnode >= 0) {
++			fdt_addr_t fdt_addr;
++			fdt_size_t fdt_size;
++
++			/* check if this subnode has a reg property */
++			fdt_addr = fdtdec_get_addr_size_auto_parent(
++						fdt, nodeoffset, subnode,
++						"reg", 0, &fdt_size, false);
++			/*
++			 * The /reserved-memory node may have children with
++			 * a size instead of a reg property.
++			 */
++			if (fdt_addr != FDT_ADDR_T_NONE &&
++			    fdtdec_get_is_enabled(fdt, subnode)) {
++				bool nomap;
++
++				nomap = !!fdt_getprop(fdt, subnode, "no-map",
++						      NULL);
++				efi_reserve_memory(fdt_addr, fdt_size, nomap);
++			}
++			subnode = fdt_next_subnode(fdt, subnode);
++		}
++	}
++}
++
++static efi_status_t EFIAPI efi_dt_fixup(struct efi_dt_fixup_protocol *this,
++					void *dtb,
++					efi_uintn_t *buffer_size,
++					u32 flags)
++{
++	efi_status_t ret;
++	size_t required_size;
++	bootm_headers_t img = { 0 };
++
++	EFI_ENTRY("%p, %p, %p, %d", this, dtb, buffer_size, flags);
++
++	if (this != &efi_dt_fixup_prot || !dtb || !buffer_size ||
++	    !flags || (flags & ~EFI_DT_ALL)) {
++		ret = EFI_INVALID_PARAMETER;
++		goto out;
++	}
++	if (fdt_check_header(dtb)) {
++		ret = EFI_INVALID_PARAMETER;
++		goto out;
++	}
++	if (flags & EFI_DT_APPLY_FIXUPS) {
++		required_size = fdt_off_dt_strings(dtb) +
++				fdt_size_dt_strings(dtb) +
++				0x3000;
++	} else {
++		required_size = fdt_totalsize(dtb);
++	}
++	if (required_size > *buffer_size) {
++		*buffer_size = required_size;
++		ret = EFI_BUFFER_TOO_SMALL;
++		goto out;
++	}
++	fdt_set_totalsize(dtb, *buffer_size);
++
++	if (flags & EFI_DT_APPLY_FIXUPS) {
++		if (image_setup_libfdt(&img, dtb, 0, NULL)) {
++			log_err("failed to process device tree\n");
++			ret = EFI_INVALID_PARAMETER;
++			goto out;
++		}
++	}
++	if (flags & EFI_DT_RESERVE_MEMORY)
++		efi_carve_out_dt_rsv(dtb);
++
++	if (EFI_DT_INSTALL_TABLE) {
++		ret = efi_install_configuration_table(&efi_guid_fdt, dtb);
++		if (ret != EFI_SUCCESS) {
++			log_err("ERROR: failed to install device tree\n");
++			goto out;
++		}
++	}
++
++	ret = EFI_SUCCESS;
++out:
++	return EFI_EXIT(ret);
++}
+diff --git a/lib/efi_loader/efi_root_node.c b/lib/efi_loader/efi_root_node.c
+index 76d18fb1a4..be13790c19 100644
+--- a/lib/efi_loader/efi_root_node.c
++++ b/lib/efi_loader/efi_root_node.c
+@@ -7,6 +7,7 @@
+ 
+ #include <common.h>
+ #include <malloc.h>
++#include <efi_dt_fixup.h>
+ #include <efi_loader.h>
+ 
+ const efi_guid_t efi_u_boot_guid = U_BOOT_GUID;
+@@ -60,6 +61,11 @@ efi_status_t efi_root_node_register(void)
+ 			 /* Device path utilities protocol */
+ 			 &efi_guid_device_path_utilities_protocol,
+ 			 (void *)&efi_device_path_utilities,
++#if !CONFIG_IS_ENABLED(GENERATE_ACPI_TABLE)
++			 /* Device-tree fix-up protocol */
++			 &efi_guid_dt_fixup_protocol,
++			 (void *)&efi_dt_fixup_prot,
++#endif
+ #if CONFIG_IS_ENABLED(EFI_UNICODE_COLLATION_PROTOCOL2)
+ #if CONFIG_IS_ENABLED(EFI_UNICODE_COLLATION_PROTOCOL)
+ 			 /* Deprecated Unicode collation protocol */
+-- 
+2.25.1
+

--- a/pkg/u-boot/patches/patches-v2020.07/0008-efi_loader-fixup-protocol-avoid-forward-declaration.patch
+++ b/pkg/u-boot/patches/patches-v2020.07/0008-efi_loader-fixup-protocol-avoid-forward-declaration.patch
@@ -1,0 +1,66 @@
+From b3888ae7ee701ebc616c8230d7f53b2472bb3cb5 Mon Sep 17 00:00:00 2001
+From: Heinrich Schuchardt <xypron.glpk@gmx.de>
+Date: Sat, 16 Jan 2021 08:50:10 +0100
+Subject: [PATCH] efi_loader: fixup protocol, avoid forward declaration
+
+Avoid a forward declaration.
+
+Add a missing function description.
+
+Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>
+---
+ lib/efi_loader/efi_dt_fixup.c | 27 +++++++++++++++++----------
+ 1 file changed, 17 insertions(+), 10 deletions(-)
+
+diff --git a/lib/efi_loader/efi_dt_fixup.c b/lib/efi_loader/efi_dt_fixup.c
+index 5f0ae5c338..c2f2daef33 100644
+--- a/lib/efi_loader/efi_dt_fixup.c
++++ b/lib/efi_loader/efi_dt_fixup.c
+@@ -10,16 +10,6 @@
+ #include <efi_loader.h>
+ #include <mapmem.h>
+ 
+-static efi_status_t EFIAPI efi_dt_fixup(struct efi_dt_fixup_protocol *this,
+-					void *dtb,
+-					efi_uintn_t *buffer_size,
+-					u32 flags);
+-
+-struct efi_dt_fixup_protocol efi_dt_fixup_prot = {
+-	.revision = EFI_DT_FIXUP_PROTOCOL_REVISION,
+-	.fixup = efi_dt_fixup
+-};
+-
+ const efi_guid_t efi_guid_dt_fixup_protocol = EFI_DT_FIXUP_PROTOCOL_GUID;
+ 
+ /**
+@@ -102,6 +92,18 @@ void efi_carve_out_dt_rsv(void *fdt)
+ 	}
+ }
+ 
++/**
++ * efi_dt_fixup() - fix up device tree
++ *
++ * This function implements the Fixup() service of the
++ * EFI Device Tree Fixup Protocol.
++ *
++ * @this:		instance of the protocol
++ * @dtb:		device tree provided by caller
++ * @buffer_size:	size of buffer for the device tree including free space
++ * @flags:		bit field designating action to be performed
++ * Return:		status code
++ */
+ static efi_status_t EFIAPI efi_dt_fixup(struct efi_dt_fixup_protocol *this,
+ 					void *dtb,
+ 					efi_uintn_t *buffer_size,
+@@ -158,3 +160,8 @@ static efi_status_t EFIAPI efi_dt_fixup(struct efi_dt_fixup_protocol *this,
+ out:
+ 	return EFI_EXIT(ret);
+ }
++
++struct efi_dt_fixup_protocol efi_dt_fixup_prot = {
++	.revision = EFI_DT_FIXUP_PROTOCOL_REVISION,
++	.fixup = efi_dt_fixup
++};
+-- 
+2.25.1
+


### PR DESCRIPTION
Some arm devices get some changes in the device tree when booting the bootloader. After assigning a new kernel-correct dtb via grub, we lose those changes.

We can use EFI_DT_FIXUP_PROTOCOL as a solution to this problem.

Description: https://github.com/U-Boot-EFI/EFI_DT_FIXUP_PROTOCOL
This patches for U-boot are already merged in U-Boot v2021.04

This protocol, and its implementation in grub, allows load the correct dtb for kernel from grub and applied to it the changes that u-boot should make, i.e memory-reservations and assignment of mac addresses for Internet devices, adding devices nodes, etc.

This PR was sent by me as the previous one was rejected(https://github.com/lf-edge/eve/pull/1920), it solves the problems raised in that PR, and takes into account all the nuances.