### PR TITLE
bump alpine to 3.13 across the board

### DIFF
--- a/pkg/alpine/Dockerfile
+++ b/pkg/alpine/Dockerfile
@@ -1,8 +1,8 @@
-ARG ALPINE_VERSION=3.9
+ARG ALPINE_VERSION=3.13
 FROM lfedge/eve-alpine:5.16.0 AS cache
 
 FROM alpine:${ALPINE_VERSION} AS mirror
-ARG ALPINE_VERSION=3.9
+ARG ALPINE_VERSION=3.13
 
 # pull packages from a *previous* mirror
 COPY --from=cache /mirror /mirror
@@ -16,7 +16,7 @@ COPY mirrors /tmp/mirrors/
 COPY build-cache.sh /bin/
 
 # install abuild for signing (which requires gcc as well)
-RUN apk add --no-cache abuild gcc
+RUN apk add --no-cache abuild gcc sudo
 
 # install a new key into /etc/apk/keys
 RUN abuild-keygen -a -i -n

--- a/pkg/debug/Dockerfile
+++ b/pkg/debug/Dockerfile
@@ -3,7 +3,7 @@
 # has a fast path for stack unwinding. This also happens
 # to be a perfect place to put any other kind of debug info
 # into the package: see abuild/etc/abuild.conf.
-FROM alpine:3.12 as musl-build
+FROM alpine:3.13 as musl-build
 
 # setting up building account
 # hadolint ignore=DL3019
@@ -18,7 +18,7 @@ RUN su builder -c 'cd /musl && abuild checksum && abuild -r'
 # hadolint ignore=DL3019,DL3018
 RUN apk add --allow-untrusted /home/builder/packages/*/musl-*.apk
 
-FROM alpine:3.12 as lshw-build
+FROM alpine:3.13 as lshw-build
 
 ENV LSHW_VERSION 02.19.2
 

--- a/pkg/dom0-ztools/Dockerfile
+++ b/pkg/dom0-ztools/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12 as zfs
+FROM alpine:3.13 as zfs
 RUN mkdir -p /out/etc/apk /out/boot && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     zfs=0.8.4-r0

--- a/pkg/eve/Dockerfile.in
+++ b/pkg/eve/Dockerfile.in
@@ -1,4 +1,4 @@
-FROM alpine:3.12 as tools
+FROM alpine:3.13 as tools
 RUN mkdir -p /out/etc/apk /out/boot && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out qemu-img=5.0.0-r2 tar=1.32-r1 uboot-tools=2020.04-r0 coreutils=8.32-r0
 # hadolint ignore=DL3006

--- a/pkg/fw/Dockerfile
+++ b/pkg/fw/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge as build
+FROM alpine:3.13 as build
 
 WORKDIR /
 RUN apk add --no-cache \

--- a/pkg/guacd/Dockerfile
+++ b/pkg/guacd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8 as build
+FROM alpine:3.13 as build
 
 ENV GUACD_VERSION=1.0.0
 
@@ -16,7 +16,7 @@ RUN tar xzvf ${GUACD_VERSION}.tar.gz ;\
     ./configure --prefix=/usr/ --with-vnc --disable-guacenc --disable-dependency-tracking && \
      make && make install
 
-FROM alpine:3.8
+FROM alpine:3.13
 
 RUN apk add cairo jpeg libpng openssl libvncserver
 COPY --from=build /usr/sbin/guacd /usr/sbin/guacd

--- a/pkg/kvm-tools/Dockerfile
+++ b/pkg/kvm-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12 as build
+FROM alpine:3.13 as build
 
 ENV KVMTOOL_VERSION=90b2d3adadf218dfc6bdfdfcefe269843360223c
 
@@ -82,7 +82,7 @@ RUN mkdir /bios ; if [ $(uname -m) = x86_64 ]; then                             
       cp build/pc-bios/optionrom/linuxboot_dma.bin build/pc-bios/bios-microvm.bin /bios ;\
     fi
 
-FROM alpine:3.12
+FROM alpine:3.13
 
 # libgcc, pixman and glib are required for qemu
 # it maybe possible to get rid of libgcc & pixman

--- a/pkg/lisp/Dockerfile
+++ b/pkg/lisp/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /lisp
 RUN go build -mod=vendor -o lisp-ztr ./cmd/lisp-ztr
 RUN strip lisp-ztr
 
-FROM alpine:3.11 AS lisp
+FROM alpine:3.13 AS lisp
 ENV LISP_VERSION=release-0.488
 
 ADD https://github.com/farinacci/lispers.net/archive/${LISP_VERSION}.tar.gz /tmp/
@@ -41,7 +41,7 @@ RUN pip install --upgrade pip && pip install -r /lisp/pip-requirements.txt
 RUN apk del py2-pip
 
 # Putting it all together
-FROM alpine:3.11
+FROM alpine:3.13
 
 RUN apk add --no-cache     \
         libffi=3.2.1-r6    \

--- a/pkg/newlog/Dockerfile
+++ b/pkg/newlog/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /newlog
 RUN GO111MODULE=on CGO_ENABLED=1 go build -mod=vendor -o newlogd ./cmd
 RUN strip newlogd
 
-FROM alpine:3.8
+FROM alpine:3.13
 COPY --from=build /newlog/newlogd /usr/bin
 COPY newlogd-init.sh /newlogd-init.sh
 

--- a/pkg/pillar/Dockerfile.in
+++ b/pkg/pillar/Dockerfile.in
@@ -55,7 +55,7 @@ FROM STRONGSWAN_TAG as strongswan
 # hadolint ignore=DL3006
 FROM GPTTOOLS_TAG as gpttools
 
-FROM alpine:3.8
+FROM alpine:3.13
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
 RUN apk add --no-cache \

--- a/pkg/qrexec-dom0/Dockerfile.in
+++ b/pkg/qrexec-dom0/Dockerfile.in
@@ -1,6 +1,6 @@
 FROM XENTOOLS_TAG as xentools
 FROM QREXECLIB_TAG as qrexec_lib
-FROM alpine:3.6 as build
+FROM alpine:3.13 as build
 
 RUN apk add --no-cache \
     gcc \

--- a/pkg/qrexec-lib/Dockerfile.in
+++ b/pkg/qrexec-lib/Dockerfile.in
@@ -1,6 +1,6 @@
 FROM XENTOOLS_TAG as xentools
 
-FROM alpine:3.6	as build
+FROM alpine:3.13 as build
 
 RUN apk add --no-cache \
     gcc \

--- a/pkg/storage-init/Dockerfile
+++ b/pkg/storage-init/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.13
 WORKDIR /
 # hadolint ignore=DL3018
 RUN apk add --no-cache bash glib squashfs-tools util-linux e2fsprogs \

--- a/pkg/vtpm/Dockerfile
+++ b/pkg/vtpm/Dockerfile
@@ -51,7 +51,7 @@ WORKDIR /vtpm_server
 RUN make
 
 #Pull a selected set of artifacts into the final stage.
-FROM alpine:3.9
+FROM alpine:3.13
 
 COPY --from=build /usr/lib/libstdc++.so.6 /usr/lib
 COPY --from=build /usr/lib/libgcc_s.so.1 /usr/lib

--- a/pkg/watchdog/Dockerfile
+++ b/pkg/watchdog/Dockerfile
@@ -39,7 +39,7 @@ ENV CONFIGURE_OPTS "--disable-nfs"
 RUN \
     CPPFLAGS=-I/usr/include/tirpc ./configure ${CONFIGURE_OPTS} && make && make install DESTDIR=/out
 
-FROM alpine:3.8
+FROM alpine:3.13
 WORKDIR /
 COPY --from=watchdog-build /out/etc /etc
 COPY --from=watchdog-build /out/usr/sbin /usr/sbin

--- a/pkg/wlan/Dockerfile
+++ b/pkg/wlan/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8 as build
+FROM alpine:3.13 as build
 
 WORKDIR /
 

--- a/pkg/wwan/Dockerfile
+++ b/pkg/wwan/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12 as build
+FROM alpine:3.13 as build
 
 RUN apk add --no-cache \
     automake \
@@ -45,7 +45,7 @@ RUN git checkout 1.26.2 && ./autogen.sh --without-udev && ./configure --prefix=/
 RUN strip /usr/bin/*cli /usr/libexec/*proxy /usr/lib/libmbim*.so.* /usr/lib/libqmi*.so.*
 
 # second stage (new-ish Docker feature) for smaller image
-FROM alpine:3.12
+FROM alpine:3.13
 
 RUN apk add --no-cache ppp jq glib
 

--- a/pkg/xen-tools/Dockerfile.in
+++ b/pkg/xen-tools/Dockerfile.in
@@ -14,7 +14,7 @@ RUN gcc -s -o /chroot2 /tmp/chroot2.c
 RUN gcc -s -o /hacf /tmp/hacf.c
 RUN mkinitfs -n -F base -i /init-initrd -o /runx-initrd
 
-FROM alpine:3.12 as kernel-build
+FROM alpine:3.13 as kernel-build
 ENV GIT_HTTP=y
 # hadolint ignore=DL3018
 RUN apk add --no-cache \
@@ -90,7 +90,7 @@ WORKDIR /out/usr/lib/xen/bin/
 RUN strip * || :
 RUN if [ "$(uname -m)" = "x86_64" ]; then rm -f qemu-system-i386 && ln -s "qemu-system-$(uname -m)" qemu-system-i386 ;fi
 
-FROM alpine:3.12
+FROM alpine:3.13
 RUN apk add --no-cache \
     bash=5.0.17-r0     \
     libaio=0.3.112-r1  \

--- a/pkg/xen/Dockerfile
+++ b/pkg/xen/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7 as kernel-build
+FROM alpine:3.13 as kernel-build
 #linuxkit/alpine:f2f4db272c910d136380781a97e475013fabda8b AS kernel-build
 RUN apk update
 


### PR DESCRIPTION
As discussed with @rvs 

No code per se is changed, but going to the latest alpine is likely to change some downstream dependency versions, which may or may not affect other things. 

Best bet here probably is to let full CI run. 