### PR TITLE
Exclude physdev name match for switch network instance

### DIFF
--- a/pkg/pillar/cmd/zedrouter/acl.go
+++ b/pkg/pillar/cmd/zedrouter/acl.go
@@ -1080,18 +1080,7 @@ func aceToRules(ctx *zedrouterContext, aclArgs types.AppNetworkACLArgs,
 	aclRule3.IsUserConfigured = true
 	aclRule3.RuleID = ace.RuleID
 	if aclArgs.NIType == types.NetworkInstanceTypeSwitch {
-
-		// XXX what about local-only switch network instance?
-		// XXX should skip trying to add this rule
-		if len(aclArgs.UpLinks) != 1 {
-			errStr := fmt.Sprintf("aceToRules: Switch network instance is only supported with exactly one " +
-				"uplink attached for now.")
-			log.Errorln(errStr)
-			return nil, nil, errors.New(errStr)
-		} else {
-			aclRule3.Rule = append(aclRule3.Rule, "-m", "physdev",
-				"--physdev-in", uplinkToPhysdev(aclArgs.UpLinks[0]))
-		}
+		aclRule3.Rule = append(aclRule3.Rule, "-i", aclArgs.BridgeName)
 	}
 
 	aclRule4.Rule = outArgs


### PR DESCRIPTION
Packets can ingress from any interface and egress out of any other interface in case of switch network instance. Matching for ingress physdev interface for the configured uplink prevents app instances from being able to talk to each other. Checking for the input as bridge interface suffices for filtering packets in the case of switch network instances.

Signed-off-by: Gopi krishna Kodali <gkodali@zededa.com>