### PR TITLE
Allowing for a vanity tag for a default hypervisor

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,18 +63,10 @@ jobs:
       - name: Build and push EVE for Xen
         # since build #1 works, build and push #2
         run: |
-          make V=1 LINUXKIT_PKG_TARGET=push HV=xen eve
-          if [ "${{ env.TAG }}" = snapshot ]; then
-             docker tag lfedge/eve:snapshot-${{ env.ARCH }} lfedge/eve:snapshot-xen-${{ env.ARCH }}
-             docker push lfedge/eve:snapshot-xen-${{ env.ARCH }}
-          fi
+          make V=1 HV=xen LINUXKIT_PKG_TARGET=push eve
       - name: Build and push EVE for KVM
         # redo build #1 with push
         run: |
           rm -rf dist
           mv -f dist.xen dist
           make V=1 HV=kvm LINUXKIT_PKG_TARGET=push eve
-          if [ "${{ env.TAG }}" = snapshot ]; then
-             docker tag lfedge/eve:snapshot-${{ env.ARCH }} lfedge/eve:snapshot-kvm-${{ env.ARCH }}
-             docker push lfedge/eve:snapshot-kvm-${{ env.ARCH }}
-          fi


### PR DESCRIPTION
From now on, for every release that we actually push to DockerHUB we're going to create the following tags:
   * `<release tag>-<kvm|xen>`
   * `<snapshot|latest>-<kvm|xen>`
   * `<snapshot|latest>`

Note that the last tag is only going to get created for the "default" hypervisor build -- the first two will always be created

@kalyan-nidumolu I think this covers all your usecases