### PR TITLE
More robustness for bad config and avoiding removing bridge

### DIFF
--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -1221,7 +1221,7 @@ func parseIpspecNetworkXObject(ipspec *zconfig.Ipspec, config *types.NetworkXObj
 	if s := ipspec.GetSubnet(); s != "" {
 		_, subnet, err := net.ParseCIDR(s)
 		if err != nil {
-			return errors.New(fmt.Sprintf("parseIpspec: bad subnet %s: %s",
+			return errors.New(fmt.Sprintf("bad subnet %s: %s",
 				s, err))
 		}
 		config.Subnet = *subnet
@@ -1229,21 +1229,21 @@ func parseIpspecNetworkXObject(ipspec *zconfig.Ipspec, config *types.NetworkXObj
 	if g := ipspec.GetGateway(); g != "" {
 		config.Gateway = net.ParseIP(g)
 		if config.Gateway == nil {
-			return errors.New(fmt.Sprintf("parseIpspec: bad gateway IP %s",
+			return errors.New(fmt.Sprintf("bad gateway IP %s",
 				g))
 		}
 	}
 	if n := ipspec.GetNtp(); n != "" {
 		config.NtpServer = net.ParseIP(n)
 		if config.NtpServer == nil {
-			return errors.New(fmt.Sprintf("parseIpspec: bad ntp IP %s",
+			return errors.New(fmt.Sprintf("bad ntp IP %s",
 				n))
 		}
 	}
 	for _, dsStr := range ipspec.GetDns() {
 		ds := net.ParseIP(dsStr)
 		if ds == nil {
-			return errors.New(fmt.Sprintf("parseIpspec: bad dns IP %s",
+			return errors.New(fmt.Sprintf("bad dns IP %s",
 				dsStr))
 		}
 		config.DnsServers = append(config.DnsServers, ds)
@@ -1251,12 +1251,12 @@ func parseIpspecNetworkXObject(ipspec *zconfig.Ipspec, config *types.NetworkXObj
 	if dr := ipspec.GetDhcpRange(); dr != nil && dr.GetStart() != "" {
 		start := net.ParseIP(dr.GetStart())
 		if start == nil {
-			return errors.New(fmt.Sprintf("parseIpspec: bad start IP %s",
+			return errors.New(fmt.Sprintf("bad start IP %s",
 				dr.GetStart()))
 		}
 		end := net.ParseIP(dr.GetEnd())
 		if end == nil && dr.GetEnd() != "" {
-			return errors.New(fmt.Sprintf("parseIpspec: bad end IP %s",
+			return errors.New(fmt.Sprintf("bad end IP %s",
 				dr.GetEnd()))
 		}
 		config.DhcpRange.Start = start
@@ -1273,7 +1273,7 @@ func parseIpspec(ipspec *zconfig.Ipspec,
 	if s := ipspec.GetSubnet(); s != "" {
 		_, subnet, err := net.ParseCIDR(s)
 		if err != nil {
-			return errors.New(fmt.Sprintf("parseIpspec: bad subnet %s: %s",
+			return errors.New(fmt.Sprintf("bad subnet %s: %s",
 				s, err))
 		}
 		config.Subnet = *subnet
@@ -1282,7 +1282,7 @@ func parseIpspec(ipspec *zconfig.Ipspec,
 	if g := ipspec.GetGateway(); g != "" {
 		config.Gateway = net.ParseIP(g)
 		if config.Gateway == nil {
-			return errors.New(fmt.Sprintf("parseIpspec: bad gateway IP %s",
+			return errors.New(fmt.Sprintf("bad gateway IP %s",
 				g))
 		}
 	}
@@ -1290,7 +1290,7 @@ func parseIpspec(ipspec *zconfig.Ipspec,
 	if n := ipspec.GetNtp(); n != "" {
 		config.NtpServer = net.ParseIP(n)
 		if config.NtpServer == nil {
-			return errors.New(fmt.Sprintf("parseIpspec: bad ntp IP %s",
+			return errors.New(fmt.Sprintf("bad ntp IP %s",
 				n))
 		}
 	}
@@ -1298,7 +1298,7 @@ func parseIpspec(ipspec *zconfig.Ipspec,
 	for _, dsStr := range ipspec.GetDns() {
 		ds := net.ParseIP(dsStr)
 		if ds == nil {
-			return errors.New(fmt.Sprintf("parseIpspec: bad dns IP %s",
+			return errors.New(fmt.Sprintf("bad dns IP %s",
 				dsStr))
 		}
 		config.DnsServers = append(config.DnsServers, ds)
@@ -1307,12 +1307,12 @@ func parseIpspec(ipspec *zconfig.Ipspec,
 	if dr := ipspec.GetDhcpRange(); dr != nil && dr.GetStart() != "" {
 		start := net.ParseIP(dr.GetStart())
 		if start == nil {
-			return errors.New(fmt.Sprintf("parseIpspec: bad start IP %s",
+			return errors.New(fmt.Sprintf("bad start IP %s",
 				dr.GetStart()))
 		}
 		end := net.ParseIP(dr.GetEnd())
 		if end == nil && dr.GetEnd() != "" {
-			return errors.New(fmt.Sprintf("parseIpspec: bad end IP %s",
+			return errors.New(fmt.Sprintf("bad end IP %s",
 				dr.GetEnd()))
 		}
 		config.DhcpRange.Start = start

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -364,8 +364,14 @@ func publishNetworkInstanceConfig(ctx *getconfigContext,
 		// other than switch-type(l2)
 		// if ip type is l3, do the needful
 		if networkInstanceConfig.IpType != types.AddressTypeNone {
-			parseIpspec(apiConfigEntry.Ip,
-				&networkInstanceConfig)
+			err := parseIpspec(apiConfigEntry.Ip, &networkInstanceConfig)
+			if err != nil {
+				errStr := fmt.Sprintf("Network Instance %s parameter parse failed: %s",
+					networkInstanceConfig.Key(), err)
+				log.Error(errStr)
+				networkInstanceConfig.SetErrorNow(errStr)
+				continue
+			}
 
 			parseDnsNameToIpList(apiConfigEntry,
 				&networkInstanceConfig)
@@ -1097,7 +1103,7 @@ func parseOneNetworkXObjectConfig(ctx *getconfigContext, netEnt *zconfig.Network
 		}
 		err := parseIpspecNetworkXObject(ipspec, config)
 		if err != nil {
-			errStr := fmt.Sprintf("parseOneNetworkXObjectConfig: parseIpspec failed for %s: %s",
+			errStr := fmt.Sprintf("Network parameter parse for %s failed: %s",
 				config.Key(), err)
 			log.Error(errStr)
 			config.SetErrorNow(errStr)
@@ -1110,7 +1116,7 @@ func parseOneNetworkXObjectConfig(ctx *getconfigContext, netEnt *zconfig.Network
 				config.Key(), ipspec)
 			err := parseIpspecNetworkXObject(ipspec, config)
 			if err != nil {
-				errStr := fmt.Sprintf("parseOneNetworkXObjectConfig: parseIpspec ignored for %s: %s",
+				errStr := fmt.Sprintf("Network parameter parse for %s failed: %s",
 					config.Key(), err)
 				log.Error(errStr)
 				config.SetErrorNow(errStr)

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -1234,9 +1234,6 @@ func parseIpspecNetworkXObject(ipspec *zconfig.Ipspec, config *types.NetworkXObj
 		}
 	}
 	if n := ipspec.GetNtp(); n != "" {
-		if n == "255.255.255.255" {
-			n = "pool2.ntp.org"
-		}
 		config.NtpServer = net.ParseIP(n)
 		if config.NtpServer == nil {
 			return errors.New(fmt.Sprintf("parseIpspec: bad ntp IP %s",
@@ -1291,9 +1288,6 @@ func parseIpspec(ipspec *zconfig.Ipspec,
 	}
 	// Parse NTP Server
 	if n := ipspec.GetNtp(); n != "" {
-		if n == "255.255.255.255" {
-			n = "pool2.ntp.org"
-		}
 		config.NtpServer = net.ParseIP(n)
 		if config.NtpServer == nil {
 			return errors.New(fmt.Sprintf("parseIpspec: bad ntp IP %s",

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -370,7 +370,7 @@ func publishNetworkInstanceConfig(ctx *getconfigContext,
 					networkInstanceConfig.Key(), err)
 				log.Error(errStr)
 				networkInstanceConfig.SetErrorNow(errStr)
-				continue
+				// Proceed to send error back to controller
 			}
 
 			parseDnsNameToIpList(apiConfigEntry,
@@ -1234,6 +1234,9 @@ func parseIpspecNetworkXObject(ipspec *zconfig.Ipspec, config *types.NetworkXObj
 		}
 	}
 	if n := ipspec.GetNtp(); n != "" {
+		if n == "255.255.255.255" {
+			n = "pool2.ntp.org"
+		}
 		config.NtpServer = net.ParseIP(n)
 		if config.NtpServer == nil {
 			return errors.New(fmt.Sprintf("parseIpspec: bad ntp IP %s",
@@ -1288,6 +1291,9 @@ func parseIpspec(ipspec *zconfig.Ipspec,
 	}
 	// Parse NTP Server
 	if n := ipspec.GetNtp(); n != "" {
+		if n == "255.255.255.255" {
+			n = "pool2.ntp.org"
+		}
 		config.NtpServer = net.ParseIP(n)
 		if config.NtpServer == nil {
 			return errors.New(fmt.Sprintf("parseIpspec: bad ntp IP %s",

--- a/pkg/pillar/cmd/zedrouter/server.go
+++ b/pkg/pillar/cmd/zedrouter/server.go
@@ -36,6 +36,11 @@ type hostnameHandler struct {
 }
 
 func createServer4(ctx *zedrouterContext, bridgeIP string, bridgeName string) error {
+	if bridgeIP == "" {
+		err := fmt.Errorf("Can't run server on %s: no bridgeIP", bridgeName)
+		log.Error(err)
+		return err
+	}
 	mux := http.NewServeMux()
 	nh := &networkHandler{ctx: ctx}
 	mux.Handle("/eve/v1/network.json", nh)

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -1893,10 +1893,6 @@ type NetworkInstanceInfo struct {
 	// Set of vifs on this bridge
 	Vifs []VifNameMac
 
-	// Any errrors from provisioning the network
-	// ErrorAndTime provides SetErrorNow() and ClearError()
-	ErrorAndTime
-
 	// Vif metric map. This should have a union of currently existing
 	// vifs and previously deleted vifs.
 	// XXX When a vif is removed from bridge (app instance delete case),
@@ -2165,6 +2161,10 @@ type NetworkInstanceConfig struct {
 
 	// For other network services - Proxy / StrongSwan etc..
 	OpaqueConfig string
+
+	// Any errrors from the parser
+	// ErrorAndTime provides SetErrorNow() and ClearError()
+	ErrorAndTime
 }
 
 func (config *NetworkInstanceConfig) Key() string {


### PR DESCRIPTION
If the IPSpec is bad (e.g., has a bad NTP server IP address), the code used to just drive on and not parse the DNS servers etc.
Thant meant a failure detected by nim and a fallback to last resort.
But the fallback to last resort could trip on leftover isSwitch check in nim which would cause the ethN bridge to be removed if ethN is a port for a switch network instance. 
These two PRs take care of the error check and return, and remove tbe isSwitch check.