### PR TITLE
Don't use ifname in adapter assignment errors

### DIFF
--- a/pkg/debug/spec.sh
+++ b/pkg/debug/spec.sh
@@ -5,6 +5,10 @@
 # it does not form any assignment groups but merely checks whether there are
 # multiple functions on the same controller, and in that case the assignment
 # group is set to empty.
+# Note that the generated USB configuration does not include each USB port
+# aka receptacle, since that is not known to software; only the controllers
+# can be seen. Those can be manually added after determining which USB controller
+# handles the different USB ports.
 
 if [ "$(uname -m)" = x86_64 ]; then
    ARCH=2

--- a/pkg/pillar/types/ifnametopci.go
+++ b/pkg/pillar/types/ifnametopci.go
@@ -184,8 +184,8 @@ func IoBundleToPci(log *base.LogObject, ib *IoBundle) (string, error) {
 		return "", nil
 	}
 	if !pciLongExists(long) {
-		errStr := fmt.Sprintf("PCI device ifname %s long %s does not exist",
-			ib.Ifname, long)
+		errStr := fmt.Sprintf("PCI device %s long %s does not exist",
+			ib.Phylabel, long)
 		return long, errors.New(errStr)
 	}
 	return long, nil


### PR DESCRIPTION
Two unrelated fixes for the price of one:
ifname logging statement
fix to spec.sh to extract Audio and handle multi-function PCI devices