### PR TITLE
improved client logging; handle change to /config/server

### DIFF
--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -307,6 +307,17 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 			ctx.cert = &cert
 			ctx.usingOnboardCert = false
 		}
+		// Check in case /config/server changes while running
+		nserver, err := ioutil.ReadFile(types.ServerFileName)
+		if err != nil {
+			log.Error(err)
+		} else if len(nserver) != 0 && string(server) != string(nserver) {
+			log.Warnf("/config/server changed from %s to %s",
+				server, nserver)
+			server = nserver
+			ctx.serverNameAndPort = strings.TrimSpace(string(server))
+			ctx.serverName = strings.Split(ctx.serverNameAndPort, ":")[0]
+		}
 	}
 	return 0
 }

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -427,8 +427,7 @@ if [ $SELF_REGISTER = 1 ]; then
     fi
     echo "$(date -Ins -u) Starting client selfRegister getUuid"
     if ! $BINDIR/client selfRegister getUuid; then
-        # XXX $? is always zero
-        echo "$(date -Ins -u) client selfRegister failed with $?"
+        echo "$(date -Ins -u) client selfRegister failed"
         exit 1
     fi
 
@@ -452,7 +451,10 @@ if [ $SELF_REGISTER = 1 ]; then
 else
     echo "$(date -Ins -u) Get UUID in in case device was deleted and recreated with same device cert"
     echo "$(date -Ins -u) Starting client getUuid"
-    $BINDIR/client getUuid
+    if ! $BINDIR/client getUuid; then
+        echo "$(date -Ins -u) client getUuid failed"
+        exit 1
+    fi
 
     # Remove zedclient.pid from watchdog
     rm "$WATCHDOG_PID/zedclient.pid"


### PR DESCRIPTION
Put some higher-level logging messages in client.go to make it easier to see where it might be retrying.

And for debug/manual deployment, make it so that one can edit /config/server while client and diag are running and they will pick up the change.

As part of debugging this code I realized that if client.go hits a panic, we just drive on. Made device-steps.sh check exit value.