### PR TITLE
[WIP] fix build and run for dirty source tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -434,7 +434,7 @@ config: $(CONFIG_IMG))		; $(QUIET): "$@: Succeeded, CONFIG_IMG=$(CONFIG_IMG)"
 ssh-key: $(SSH_KEY)
 rootfs: $(ROOTFS_IMG) current
 rootfs-%: $(ROOTFS)-%.img ;
-live: $(LIVE_IMG)	current	; $(QUIET): "$@: Succeeded, LIVE_IMG=$(LIVE_IMG)"
+live: $(LIVE_IMG) $(BIOS_IMG) current	; $(QUIET): "$@: Succeeded, LIVE_IMG=$(LIVE_IMG)"
 live-%: $(LIVE).%		; $(QUIET): "$@: Succeeded, LIVE=$(LIVE)"
 installer: $(INSTALLER_IMG)
 installer-%: $(INSTALLER).% ;


### PR DESCRIPTION
With https://github.com/lf-edge/eve/pull/1913 I cannot build and run EVE with dirty source tree. 
```
make live&&make run
...
Could not open '/home/giggsoff/eve/dist/amd64/current/installer/firmware/OVMF_CODE.fd': No such file or directory
```
It produced because in this case our directories for `$(BIOS_IMG)` recreated with new timestamp:
```
drwxrwxr-x 3 giggsoff giggsoff 4096 мар  2 17:18 0.0.0-master-5654e704-dirty-2021-03-02.14.17
drwxrwxr-x 3 giggsoff giggsoff 4096 мар  2 17:18 0.0.0-master-5654e704-dirty-2021-03-02.14.18
lrwxrwxrwx 1 giggsoff giggsoff   81 мар  2 17:18 current -> /home/giggsoff/eve/dist/amd64/0.0.0-master-5654e704-dirty-2021-03-02.14.17
```

So, I think we should move away from `INSTALLER_FIRMWARE_DIR` in favor of `CURRENT_FIRMWARE_DIR`.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>