### PR TITLE
IoBundleList can grow forever  plus some log cleanup

### DIFF
--- a/pkg/dom0-ztools/rootfs/etc/sysctl.d/02-eve.conf
+++ b/pkg/dom0-ztools/rootfs/etc/sysctl.d/02-eve.conf
@@ -17,8 +17,8 @@ net.bridge.bridge-nf-call-arptables = 1
 net.ipv4.conf.all.rp_filter = 2
 net.netfilter.nf_conntrack_acct = 1
 net.netfilter.nf_conntrack_timestamp = 1
-net.ipv4.conf.all.log_martians = 1
-net.ipv4.conf.default.log_martians = 1
+net.ipv4.conf.all.log_martians = 0
+net.ipv4.conf.default.log_martians = 0
 
 # For reliable downloads need less than 2 hour keepalive timer
 net.ipv4.tcp_keepalive_time = 60

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -401,7 +401,7 @@ func handleDNSImpl(ctxArg interface{}, key string,
 	}
 
 	// update proxy certs if configured
-	if ctx.zedcloudCtx != nil && ctx.zedcloudCtx.V2API {
+	if ctx.zedcloudCtx != nil && ctx.zedcloudCtx.V2API && ctx.zedcloudCtx.TlsConfig != nil {
 		zedcloud.UpdateTLSProxyCerts(ctx.zedcloudCtx)
 	}
 	// XXX can we limit to interfaces which changed?

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -2693,7 +2693,8 @@ func doModprobe(driver string, add bool) error {
 
 func handleIBDelete(ctx *domainContext, phylabel string) {
 
-	log.Functionf("handleIBDelete(%s)", phylabel)
+	log.Noticef("handleIBDelete(%s) len %d", phylabel,
+		len(ctx.assignableAdapters.IoBundleList))
 	aa := ctx.assignableAdapters
 
 	ib := aa.LookupIoBundlePhylabel(phylabel)
@@ -2716,7 +2717,7 @@ func handleIBDelete(ctx *domainContext, phylabel string) {
 	}
 	// Create a new list with everything but "ib" included
 	replace := types.AssignableAdapters{Initialized: true,
-		IoBundleList: make([]types.IoBundle, len(aa.IoBundleList)-1)}
+		IoBundleList: make([]types.IoBundle, 0, len(aa.IoBundleList)-1)}
 	for _, e := range aa.IoBundleList {
 		if e.Type == ib.Type && e.Phylabel == ib.Phylabel {
 			continue
@@ -2724,6 +2725,8 @@ func handleIBDelete(ctx *domainContext, phylabel string) {
 		replace.IoBundleList = append(replace.IoBundleList, e)
 	}
 	*ctx.assignableAdapters = replace
+	log.Noticef("handleIBDelete(%s) done len %d", phylabel,
+		len(ctx.assignableAdapters.IoBundleList))
 	checkIoBundleAll(ctx)
 }
 

--- a/pkg/pillar/cmd/domainmgr/metric.go
+++ b/pkg/pillar/cmd/domainmgr/metric.go
@@ -82,13 +82,16 @@ func formatAndPublishHostCPUMem(ctx *domainContext, hm types.HostMemory) {
 	}
 
 	CPUnum, err := cpu.Counts(false)
-	if err != nil || CPUnum == 0 {
-		log.Errorf("getAndPublishMetrics: cpu count %d, error %v", CPUnum, err)
-
+	if err != nil {
+		log.Errorf("getAndPublishMetrics: cpu.Counts failed: %v", err)
 		return
 	}
-
-	busy /= float64(CPUnum)
+	if CPUnum == 0 {
+		// Assume 1 i.e. don't scale busy
+		log.Warnf("getAndPublishMetrics: cpu count zero")
+	} else {
+		busy /= float64(CPUnum)
+	}
 
 	dm := types.DomainMetric{
 		UUIDandVersion:    hostUUID,

--- a/pkg/pillar/cmd/upgradeconverter/renameverifiedfiles.go
+++ b/pkg/pillar/cmd/upgradeconverter/renameverifiedfiles.go
@@ -47,8 +47,11 @@ func renameFiles(srcDir string, dstDir string, noFlag bool) {
 	}
 	locations, err := ioutil.ReadDir(srcDir)
 	if err != nil {
-		log.Errorf("renameFiles read: directory '%s' failed: %v",
-			srcDir, err)
+		// Some old directories might not exist
+		if !os.IsNotExist(err) {
+			log.Errorf("renameFiles read: directory '%s' failed: %v",
+				srcDir, err)
+		}
 		return
 	}
 	for _, location := range locations {

--- a/pkg/pillar/cmd/vaultmgr/vaultmgr.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgr.go
@@ -667,14 +667,25 @@ func publishAllFscryptVaultStatus(ctx *vaultMgrContext) {
 	fscryptStatus, fscryptErr := vault.GetOperInfo(log)
 	publishFscryptVaultStatus(ctx, types.DefaultVaultName, defaultVault,
 		fscryptStatus, fscryptErr)
+
+	// Don't try if it isn't there
+	_, err := os.Stat(deprecatedCfgVault)
+	if os.IsNotExist(err) {
+		return
+	}
 	publishFscryptVaultStatus(ctx, deprecatedCfgVaultName, deprecatedCfgVault,
 		fscryptStatus, fscryptErr)
 }
 
 func publishAllZfsVaultStatus(ctx *vaultMgrContext) {
 	//XXX: till Controller deprecates handling status of persist/config, keep sending
-	publishZfsVaultStatus(ctx, deprecatedCfgVaultName, defaultCfgSecretDataset)
 	publishZfsVaultStatus(ctx, types.DefaultVaultName, defaultSecretDataset)
+	// Don't try if it isn't there
+	_, err := os.Stat(deprecatedCfgVault)
+	if os.IsNotExist(err) {
+		return
+	}
+	publishZfsVaultStatus(ctx, deprecatedCfgVaultName, defaultCfgSecretDataset)
 }
 
 func publishZfsVaultStatus(ctx *vaultMgrContext, vaultName, vaultPath string) {

--- a/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
+++ b/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
@@ -188,8 +188,12 @@ func createOrUpdateDiskMetrics(ctx *volumemgrContext) {
 	log.Tracef("createOrUpdateDiskMetrics: persistUsage %d, elapse sec %v", persistUsage, time.Since(startPubTime).Seconds())
 
 	for _, path := range types.ReportDirPaths {
-		usage := diskmetrics.SizeFromDir(log, path)
-		log.Tracef("createOrUpdateDiskMetrics: ReportDirPath %s usage %d", path, usage)
+		usage, err := diskmetrics.SizeFromDir(log, path)
+		log.Tracef("createOrUpdateDiskMetrics: ReportDirPath %s usage %d err %v", path, usage, err)
+		if err != nil {
+			// Do not report
+			continue
+		}
 		var metric *types.DiskMetric
 		metric = lookupDiskMetric(ctx, path)
 		if metric == nil {
@@ -206,8 +210,12 @@ func createOrUpdateDiskMetrics(ctx *volumemgrContext) {
 	log.Tracef("createOrUpdateDiskMetrics: DirPaths in persist, elapse sec %v", time.Since(startPubTime).Seconds())
 
 	for _, path := range types.AppPersistPaths {
-		usage := diskmetrics.SizeFromDir(log, path)
-		log.Tracef("createOrUpdateDiskMetrics: AppPersistPath %s usage %d", path, usage)
+		usage, err := diskmetrics.SizeFromDir(log, path)
+		log.Tracef("createOrUpdateDiskMetrics: AppPersistPath %s usage %d err %v", path, usage, err)
+		if err != nil {
+			// Do not report
+			continue
+		}
 		var metric *types.DiskMetric
 		metric = lookupDiskMetric(ctx, path)
 		if metric == nil {

--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -535,7 +535,7 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 
 // Convert the implementation details to the user-friendly userStatus and subStatus*
 func addUserSwInfo(ctx *zedagentContext, swInfo *info.ZInfoDevSW, tooEarly bool) {
-	log.Errorf("Device swInfo: %s", swInfo.String())
+	log.Functionf("Device swInfo: %s", swInfo.String())
 	switch swInfo.Status {
 	case info.ZSwState_INITIAL:
 		// If Unused and partitionLabel is set them it

--- a/pkg/pillar/types/blob.go
+++ b/pkg/pillar/types/blob.go
@@ -120,7 +120,7 @@ func (status BlobStatus) LogModify(logBase *base.LogObject, old interface{}) {
 		logObject.CloneAndAddField("state", status.State.String()).
 			AddField("error", status.Error).
 			AddField("error-time", status.ErrorTime).
-			Errorf("Blob status modify")
+			Noticef("Blob status modify")
 	}
 }
 

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -283,7 +283,7 @@ func (status DomainStatus) LogModify(logBase *base.LogObject, old interface{}) {
 			AddField("activated", status.Activated).
 			AddField("error", errAndTime.Error).
 			AddField("error-time", errAndTime.ErrorTime).
-			Errorf("domain status modify")
+			Noticef("domain status modify")
 	}
 }
 

--- a/pkg/pillar/types/downloadertypes.go
+++ b/pkg/pillar/types/downloadertypes.go
@@ -185,7 +185,7 @@ func (status DownloaderStatus) LogModify(logBase *base.LogObject, old interface{
 		logObject.CloneAndAddField("state", status.State.String()).
 			AddField("error", errAndTime.Error).
 			AddField("error-time", errAndTime.ErrorTime).
-			Errorf("Download status modify")
+			Noticef("Download status modify")
 	}
 }
 

--- a/pkg/pillar/types/resolvertypes.go
+++ b/pkg/pillar/types/resolvertypes.go
@@ -126,7 +126,7 @@ func (status ResolveStatus) LogModify(logBase *base.LogObject, old interface{}) 
 			AddField("retry-count-int64", status.RetryCount).
 			AddField("error", errAndTime.Error).
 			AddField("error-time", errAndTime.ErrorTime).
-			Errorf("Resolve status modify")
+			Noticef("Resolve status modify")
 	}
 }
 

--- a/pkg/pillar/types/vaultmgrtypes.go
+++ b/pkg/pillar/types/vaultmgrtypes.go
@@ -50,7 +50,7 @@ func (status VaultStatus) LogModify(logBase *base.LogObject, old interface{}) {
 		errAndTime := status.ErrorAndTime
 		logObject.CloneAndAddField("error", errAndTime.Error).
 			AddField("error-time", errAndTime.ErrorTime).
-			Errorf("Vault status modify")
+			Noticef("Vault status modify")
 	}
 }
 

--- a/pkg/pillar/types/verifiertypes.go
+++ b/pkg/pillar/types/verifiertypes.go
@@ -158,7 +158,7 @@ func (status VerifyImageStatus) LogModify(logBase *base.LogObject, old interface
 		logObject.CloneAndAddField("state", status.State.String()).
 			AddField("error", errAndTime.Error).
 			AddField("error-time", errAndTime.ErrorTime).
-			Errorf("VerifyImage status modify")
+			Noticef("VerifyImage status modify")
 	}
 }
 

--- a/pkg/pillar/types/zedagenttypes.go
+++ b/pkg/pillar/types/zedagenttypes.go
@@ -137,7 +137,7 @@ func (status BaseOsStatus) LogModify(logBase *base.LogObject, old interface{}) {
 		logObject.CloneAndAddField("state", status.State.String()).
 			AddField("error", errAndTime.Error).
 			AddField("error-time", errAndTime.ErrorTime).
-			Errorf("BaseOs status modify")
+			Noticef("BaseOs status modify")
 	}
 }
 

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -207,7 +207,7 @@ func (status AppInstanceStatus) LogModify(logBase *base.LogObject, old interface
 			AddField("purge-in-progress", status.PurgeInprogress).
 			AddField("error", errAndTime.Error).
 			AddField("error-time", errAndTime.ErrorTime).
-			Errorf("App instance status modify")
+			Noticef("App instance status modify")
 	}
 }
 

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -58,9 +58,9 @@ func (config AppNetworkConfig) LogModify(logBase *base.LogObject, old interface{
 			AddField("old-activate", oldConfig.Activate).
 			Noticef("App network config modify")
 	} else {
-		// XXX remove?
+		// Log at Function level
 		logObject.CloneAndAddField("diff", cmp.Diff(oldConfig, config)).
-			Noticef("App network config modify other change")
+			Functionf("App network config modify other change")
 	}
 }
 
@@ -156,9 +156,9 @@ func (status AppNetworkStatus) LogModify(logBase *base.LogObject, old interface{
 			AddField("old-activated", oldStatus.Activated).
 			Noticef("App network status modify")
 	} else {
-		// XXX remove?
+		// Log at Function level
 		logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
-			Noticef("App network status modify other change")
+			Functionf("App network status modify other change")
 	}
 
 	if status.HasError() {
@@ -368,9 +368,9 @@ func (config DevicePortConfigList) LogModify(logBase *base.LogObject, old interf
 			AddField("old-num-portconfig-int64", len(oldConfig.PortConfigList)).
 			Noticef("DevicePortConfigList modify")
 	} else {
-		// XXX remove?
+		// Log at Trace level - most likely just a timestamp change
 		logObject.CloneAndAddField("diff", cmp.Diff(oldConfig, config)).
-			Noticef("DevicePortConfigList modify other change")
+			Tracef("DevicePortConfigList modify other change")
 	}
 
 }
@@ -499,10 +499,6 @@ func (config DevicePortConfig) LogModify(logBase *base.LogObject, old interface{
 			AddField("old-last-error", oldConfig.LastError).
 			AddField("old-state", oldConfig.State.String()).
 			Noticef("DevicePortConfig modify")
-	} else {
-		// XXX remove?
-		logObject.CloneAndAddField("diff", cmp.Diff(oldConfig, config)).
-			Noticef("DevicePortConfig modify other change")
 	}
 	// XXX which fields to compare/log?
 	for i, p := range config.Ports {
@@ -1035,10 +1031,6 @@ func (status DeviceNetworkStatus) LogModify(logBase *base.LogObject, old interfa
 				AddField("old-last-succeeded", op.LastSucceeded).
 				AddField("old-last-failed", op.LastFailed).
 				Noticef("DeviceNetworkStatus port modify")
-		} else {
-			logObject.CloneAndAddField("ifname", p.IfName).
-				AddField("diff", cmp.Diff(op, p)).
-				Noticef("DeviceNetworkStatus port modify other change")
 		}
 	}
 }

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -166,7 +166,7 @@ func (status AppNetworkStatus) LogModify(logBase *base.LogObject, old interface{
 		logObject.CloneAndAddField("activated", status.Activated).
 			AddField("error", errAndTime.Error).
 			AddField("error-time", errAndTime.ErrorTime).
-			Errorf("App network status modify")
+			Noticef("App network status modify")
 	}
 }
 

--- a/pkg/pillar/utils/volumeutils.go
+++ b/pkg/pillar/utils/volumeutils.go
@@ -23,8 +23,8 @@ func GetVolumeSize(log *base.LogObject, name string) (uint64, uint64, string, bo
 	}
 	if info.IsDir() {
 		// Assume this is a container
-		size := diskmetrics.SizeFromDir(log, name)
-		return size, size, "CONTAINER", false, nil
+		size, err := diskmetrics.SizeFromDir(log, name)
+		return size, size, "CONTAINER", false, err
 	}
 	imgInfo, err := diskmetrics.GetImgInfo(log, name)
 	if err != nil {


### PR DESCRIPTION
A few separate commits. The most important one is "IoBundleList can grow forever". Note that we don't have a reproducible test case for this, but we've seen cases where breadcrumbs in the error log indicate that the list can double in size. The most likely culprit is the array handling where we start with size N-1 and then append N-1 elements to the array.

The others are to reduce error logs for cases that are not actual errors, and downgrade/remove some logs which are useless.