### PR TITLE
more logging for checkDHCPPacketInfo

### DIFF
--- a/pkg/pillar/cmd/zedrouter/flowstats.go
+++ b/pkg/pillar/cmd/zedrouter/flowstats.go
@@ -610,7 +610,7 @@ func DNSMonitor(bn string, bnNum int, ctx *zedrouterContext, status *types.Netwo
 		switched = true
 		filter = "udp and (port 53 or port 67)"
 	}
-	log.Functionf("(FlowStats) DNS Monitor on %s(bridge-num %d) swithced=%v, filter=%s", bn, bnNum, switched, filter)
+	log.Functionf("(FlowStats) DNS Monitor on %s(bridge-num %d) switched=%v, filter=%s", bn, bnNum, switched, filter)
 
 	handle, err := pcap.OpenLive(bn, snapshotLen, promiscuous, timeout, false)
 	if err != nil {
@@ -693,6 +693,7 @@ func checkDHCPPacketInfo(bnNum int, packet gopacket.Packet, ctx *zedrouterContex
 		break
 	}
 	if len(vifInfo) == 0 { // there is no Mac on the bridge
+		log.Tracef("checkDHCPPacketInfo: no mac on the bridge")
 		return
 	}
 

--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -722,8 +722,8 @@ func getSwitchNetworkInstanceUsingIfname(
 		ifname2 := types.LogicallabelToIfName(ctx.deviceNetworkStatus,
 			status.Logicallabel)
 		if ifname2 != ifname {
-			log.Functionf("getSwitchNetworkInstanceUsingIfname: NI (%s) not using %s",
-				status.DisplayName, ifname)
+			log.Functionf("getSwitchNetworkInstanceUsingIfname: NI (%s) not using %s; using %s",
+				status.DisplayName, ifname, ifname2)
 			continue
 		}
 


### PR DESCRIPTION
We've had a hard time, even with trace level logging, do look for delays in filling in the IP address from DHCP snooping (on a switch network instance). These minor tweaks hopefully make it a bit easier next time.