### PR TITLE
do not assume anything about mounts

### DIFF
--- a/pkg/pillar/containerd/oci_test.go
+++ b/pkg/pillar/containerd/oci_test.go
@@ -6,12 +6,6 @@ package containerd
 import (
 	"encoding/json"
 	"fmt"
-	zconfig "github.com/lf-edge/eve/api/go/config"
-	"github.com/lf-edge/eve/pkg/pillar/types"
-	. "github.com/onsi/gomega"
-	"github.com/opencontainers/runtime-spec/specs-go"
-	uuid "github.com/satori/go.uuid"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"log"
 	"os"
@@ -19,6 +13,13 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	zconfig "github.com/lf-edge/eve/api/go/config"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	. "github.com/onsi/gomega"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
 )
 
 const loaderRuntimeSpec = `
@@ -520,7 +521,7 @@ func TestCreateMountPointExecEnvFiles(t *testing.T) {
 	}
 
 	mountFile := path.Join(rootDir, "mountPoints")
-	mountExpected := "/myvol" + "\n"
+	mountExpected := ""
 	mounts, err := ioutil.ReadFile(mountFile)
 	if err != nil {
 		t.Errorf("createMountPointExecEnvFiles failed to create mountPoints file %s %v", mountFile, err)
@@ -704,7 +705,7 @@ func TestPrepareMount(t *testing.T) {
 				}
 
 				mountFile := path.Join(tt.args.containerPath, "mountPoints")
-				expectedMounts := "/myvol" + "\n"
+				expectedMounts := ""
 				mounts, err := ioutil.ReadFile(mountFile)
 				if err != nil {
 					t.Errorf("TestPrepareMount: exception while reading mountPoints file %s %v", mountFile, err)
@@ -750,14 +751,13 @@ func TestUpdateMounts(t *testing.T) {
 		{MountDir: "/override", Format: zconfig.Format_QCOW2, FileLocation: "/foo/bam.qcow2", ReadOnly: true},
 	}
 
-	g.Expect(spec.UpdateMounts([]types.DiskStatus{})).To(HaveOccurred())
-	g.Expect(spec.UpdateMounts([]types.DiskStatus{{MountDir: "/", Format: zconfig.Format_CONTAINER}})).To(HaveOccurred())
+	g.Expect(spec.UpdateMounts([]types.DiskStatus{})).ToNot(HaveOccurred())
+	g.Expect(spec.UpdateMounts([]types.DiskStatus{{MountDir: "/", Format: zconfig.Format_CONTAINER}})).ToNot(HaveOccurred())
 
 	g.Expect(spec.UpdateMounts(tresAmigos)).ToNot(HaveOccurred())
 	g.Expect(spec.Mounts).To(ConsistOf([]specs.Mount{
 		{Destination: "/test", Source: "/test", Type: "bind", Options: []string{"ro"}},
 		{Destination: "/dev/eve/volumes/by-id/1", Type: "bind", Source: "/foo/baz/rootfs", Options: []string{"rbind", "rw"}},
-		{Destination: "/myvol", Type: "bind", Source: "/foo/baz/rootfs", Options: []string{"rbind", "rw"}},
 		{Destination: "/dev/eve/volumes/by-id/2", Type: "bind", Source: "/foo/bam.qcow2", Options: []string{"rbind", "ro"}},
 		{Destination: "/override/2", Type: "bind", Source: "/foo/bam.qcow2", Options: []string{"rbind", "ro"}},
 	}))


### PR DESCRIPTION
The current build tries to "match up" volumes provided in the eve config with volumes in the OCI image config. For example, if the OCI image config has this:

```json
Volumes: {
  "/foo": {},
  "/bar": {}
},
```

and the eve config includes, in addition to the root mount, 2 volumes without any target on them, e.g. 

```go
				{FileLocation: "/someplace/funny"},
				{FileLocation: "/someplace/serious"},
```

note that there is a source (`FileLocation`) but no destination (`MountDir`), then it will try to match them up as:

```
"/someplace/funny" -> "/foo"
"/someplace/serious" -> "/bar"
```

This doesn't work because age volumes in the OCI image config are a _map_ not an ordered _list_. The order has no meaning. This, in turn, is because there isn't supposed to be a default or order you can rely on. The volumes in the OCI image config are just indicative and informative. What you choose to do with them if no mount is provided is up to you.

This was discussed in the eve TSC, with the basic options being to adopt what other container management systems do:

* containerd: ignore it. If there is a `Volume` in the OCI image config, it doesn't mean much
* docker: create a mount from a random host dir.
* error: treat a volume in the OCI image config that doesn't have a mount provided to that `MountDir` in eve config as an error.

The docker option does us no good, the error option is too harsh, so we elected to go down the containerd path.

This PR fixes it so that our mounts behave like containerd.

The open question is, does this create any unexpected side effects, e.g. do controllers (and especially their users) use the assumed ordering to make things happen? Even if they do, it should _not_ stop us from merging this in, but we should warn customers in a notice for next major release.