### PR TITLE
taking into account purgeable space on volume creation

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlevolume.go
+++ b/pkg/pillar/cmd/zedagent/handlevolume.go
@@ -82,7 +82,17 @@ func parseVolumeConfig(ctx *getconfigContext,
 		volumeConfig.RefCount = 1
 		publishVolumeConfig(ctx, *volumeConfig)
 	}
+
+	//signal publisher restarted to apply deferred changes inside volumemgr
+	signalVolumeConfigRestarted(ctx)
 	log.Tracef("parsing volume config done\n")
+}
+
+func signalVolumeConfigRestarted(ctx *getconfigContext) {
+	log.Trace("signalVolumeConfigRestarted")
+	pub := ctx.pubVolumeConfig
+	pub.SignalRestarted()
+	log.Trace("signalVolumeConfigRestarted done")
 }
 
 func publishVolumeConfig(ctx *getconfigContext,

--- a/pkg/pillar/types/volumetypes.go
+++ b/pkg/pillar/types/volumetypes.go
@@ -25,6 +25,7 @@ type VolumeConfig struct {
 	GenerationCounter       int64
 	VolumeDir               string
 	DisplayName             string
+	HasNoAppReferences      bool
 }
 
 // Key is volume UUID which will be unique


### PR DESCRIPTION
We should add an ability to calculate remaining space based on CurrentSize of volume of particular app we try to purge/update inside volumemgr.
On step of volume creation inside volumemgr we do not now for which application it was created (or it is not linked to any application). So, it seems reasonable to add ApplicationID field into Volume Status/Config to have opportunity to determinate for which app we use it.

There are open questions for me:

- may the same volume be linked to the several AppInstances at the same time
- what to do in the situation when we add new volume (not the first one) to the existing application. Now it is quite difficult to determinate where we are on the step of Volume creation inside volumemgr. We do not know anything about expected state of app inside this step.

cc @zed-rishabh 

Signed-off-by: Petr Fedchenkov <petr@zededa.com>