### PR TITLE
fix unknown datastore key

### DIFF
--- a/pkg/pillar/cmd/downloader/resolveconfig.go
+++ b/pkg/pillar/cmd/downloader/resolveconfig.go
@@ -276,7 +276,7 @@ func checkAndUpdateResolveConfig(ctx *downloaderContext, dsID uuid.UUID) {
 	for _, v := range resolveStatuses {
 		status := v.(types.ResolveStatus)
 		if status.DatastoreID == dsID {
-			config := lookupDownloaderConfig(ctx, status.Key())
+			config := lookupResolveConfig(ctx, status.Key())
 			if config != nil {
 				resHandler.modify(ctx, status.Key(), *config, *config)
 			}


### PR DESCRIPTION
Inside tests I see [errors](https://github.com/lf-edge/eve/runs/2026886598?check_suite_focus=true#step:9:2109):
```
INITIAL: [description:"Found error in content tree itmoeve/eclient:0.3 attached to volume pong_0_m_0: Received error from resolver for 91175112-3312-4ff6-9275-0d1fbb7ee9dc+itmoeve/eclient:0.3+0, SHA (): lookupDatastoreConfig(91175112-3312-4ff6-9275-0d1fbb7ee9dc) error: Get(zedagent/DatastoreConfig) unknown key 91175112-3312-4ff6-9275-0d1fbb7ee9dc\n\n"  timestamp:***seconds:1614818685  nanos:410611700***]
```
I already try to solve it before https://github.com/lf-edge/eve/pull/1681, but I see, that from point of [caller](https://github.com/lf-edge/eve/blob/c8350d52e560701bb37a692bcbaad1e847837d50/pkg/pillar/cmd/volumemgr/updatestatus.go#L50) on this step we have ResolveConfig, not DownloaderConfig.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>