### PR TITLE
Adding hosted ARM runner for ARM64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,13 +34,15 @@ jobs:
           make V=1 ROOTFS_VERSION="$VERSION" HV=kvm eve
       - name: Export docker container
         run: |
+          ARCH=$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')
+          echo "ARCH=$ARCH" >> "$GITHUB_ENV"
           for i in xen kvm; do
-             docker tag "lfedge/eve:$VERSION-$i" "$TAG-$i"
-             IMGS="$IMGS $TAG-$i"
+             docker tag "lfedge/eve:$VERSION-$i" "$TAG-$i-$ARCH"
+             IMGS="$IMGS $TAG-$i-$ARCH"
           done
           docker save $IMGS > eve.tar
       - name: Upload EVE
         uses: actions/upload-artifact@v2
         with:
-          name: eve
+          name: eve-${{ env.ARCH }}
           path: eve.tar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [arm64-dirty, ubuntu-20.04]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -11,8 +11,8 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-      - name: Find PR build artifact
-        id: find-pr-artifact
+      - name: Find PR build artifact for amd64
+        id: find-pr-artifact-amd64
         uses: actions/github-script@v3
         with:
           result-encoding: string
@@ -26,7 +26,33 @@ jobs:
             })).data
             if (artifacts.hasOwnProperty('total_count') && artifacts.total_count > 0) {
               for (const artifact of artifacts.artifacts) {
-                if (artifact.name === 'eve') {
+                if (artifact.name === 'eve-amd64') {
+                  return (await github.actions.downloadArtifact({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    artifact_id: artifact.id,
+                    archive_format: 'zip',
+                  })).url
+                }
+              }
+            } else {
+              throw 'No artifacts to publish'
+            }
+
+      - name: Find PR build artifact for arm64
+        id: find-pr-artifact-arm64
+        uses: actions/github-script@v3
+        with:
+          result-encoding: string
+          script: |
+            artifacts = (await github.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            })).data
+            if (artifacts.hasOwnProperty('total_count') && artifacts.total_count > 0) {
+              for (const artifact of artifacts.artifacts) {
+                if (artifact.name === 'eve-arm64') {
                   return (await github.actions.downloadArtifact({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
@@ -41,13 +67,18 @@ jobs:
 
       - name: Publish EVE
         run: |
-          [ -z "${{steps.find-pr-artifact.outputs.result}}" ] && exit 1
-
-          wget -O eve.zip "${{steps.find-pr-artifact.outputs.result}}"
-          unzip eve.zip
+          wget -O eve-amd64.zip "${{steps.find-pr-artifact-amd64.outputs.result}}"
+          wget -O eve-arm64.zip "${{steps.find-pr-artifact-arm64.outputs.result}}"
 
           echo "${{ secrets.DOCKERHUB_TOKEN }}" |\
              docker login -u evebuild --password-stdin
-          for i in `docker load < eve.tar | sed -e 's#^Loaded image:##'`; do
-             docker push "$i"
+
+          for arch in amd64 arm64; do
+             rm -f eve.tar
+             unzip "eve-$arch.zip"
+             for i in `docker load < eve.tar | sed -e 's#^Loaded image:##'`; do
+                docker push "$i"
+             done
           done
+
+          docker manifest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ARM64, ubuntu-20.04]
+        os: [arm64-secure, ubuntu-20.04]
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
This add an extra hosted ARM64 runner called arm64-dirty so we can run PR builds there, note that we now need to be extra careful to run everything else on arm64-secure only -- since that is a protected environment and arm64-dirty could be running on a botnet for all y'all know.