### PR TITLE
save some files for debug

### DIFF
--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -104,6 +104,13 @@ if [ -d /persist/checkpoint ]; then
     cp -rp /persist/checkpoint $PERSIST_AGENT_DEBUG/
 fi
 
+# Save any existing /persist/status directory for debugging
+rm -rf $PERSIST_AGENT_DEBUG/status
+if [ -d /persist/status ]; then
+    echo "$(date -Ins -u) Saving copy of /persist/status in /persist/agentdebug"
+    cp -rp /persist/status $PERSIST_AGENT_DEBUG/
+fi
+
 echo "$(date -Ins -u) Configuration from factory/install:"
 (cd $CONFIGDIR || return; ls -l)
 echo

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -97,6 +97,13 @@ for d in $DIRS; do
     fi
 done
 
+# Save any existing checkpoint directory for debugging
+rm -rf $PERSIST_AGENT_DEBUG/checkpoint
+if [ -d /persist/checkpoint ]; then
+    echo "$(date -Ins -u) Saving copy of /persist/checkpoint in /persist/agentdebug"
+    cp -rp /persist/checkpoint $PERSIST_AGENT_DEBUG/
+fi
+
 echo "$(date -Ins -u) Configuration from factory/install:"
 (cd $CONFIGDIR || return; ls -l)
 echo


### PR DESCRIPTION
Should we have an issue with getting the device to apply e.g., changes to loglevel and reboot commands, in that case we either wait for a watchdog (might take a week by default if the only issue is that the network driver/card is hosed), or we manually power cycle the box. 
In the latter case we loose whatever state there was; saving /persist/checkpoint before it is overwritten (and also saving /persist/status in case) might be help to see what config the device had last seen.