### PR TITLE
Fix brokenness with Xen task management

### DIFF
--- a/pkg/pillar/cmd/zedmanager/handledomainmgr.go
+++ b/pkg/pillar/cmd/zedmanager/handledomainmgr.go
@@ -12,10 +12,12 @@ import (
 )
 
 // MaybeAddDomainConfig makes sure we have a DomainConfig
+// Note that it does not publish it since caller often tweaks it; caller must
+// call publishDomainConfig() when done with tweaks.
 func MaybeAddDomainConfig(ctx *zedmanagerContext,
 	aiConfig types.AppInstanceConfig,
 	aiStatus types.AppInstanceStatus,
-	ns *types.AppNetworkStatus) error {
+	ns *types.AppNetworkStatus) (*types.DomainConfig, error) {
 
 	key := aiConfig.Key()
 	displayName := aiConfig.DisplayName
@@ -58,7 +60,7 @@ func MaybeAddDomainConfig(ctx *zedmanagerContext,
 		if location == "" {
 			errStr := fmt.Sprintf("No ActiveFileLocation for %s", vrs.DisplayName)
 			log.Error(errStr)
-			return errors.New(errStr)
+			return nil, errors.New(errStr)
 		}
 		disk := types.DiskConfig{}
 		disk.FileLocation = location
@@ -112,10 +114,8 @@ func MaybeAddDomainConfig(ctx *zedmanagerContext,
 			dc.VifList[i] = ul.VifInfo
 		}
 	}
-	publishDomainConfig(ctx, &dc)
-
 	log.Functionf("MaybeAddDomainConfig done for %s", key)
-	return nil
+	return &dc, nil
 }
 
 func lookupDomainConfig(ctx *zedmanagerContext, key string) *types.DomainConfig {

--- a/pkg/pillar/containerd/containerd.go
+++ b/pkg/pillar/containerd/containerd.go
@@ -700,7 +700,7 @@ func (client *Client) ctrExec(ctx context.Context, domainName string, args []str
 	}
 
 	st, ee := process.Status(ctx)
-	logrus.Debugf("ctrExec process exited with: %v %v %d %d %d %d", st, ee, stdOut.Cap(), stdOut.Len(), stdErr.Cap(), stdErr.Len())
+	logrus.Debugf("ctrExec process exited with: %v %v %d %d %d %d stdout: %s stderr: %s, err: %v", st, ee, stdOut.Cap(), stdOut.Len(), stdErr.Cap(), stdErr.Len(), stdOut.String(), stdErr.String(), err)
 	return stdOut.String(), stdErr.String(), err
 }
 

--- a/pkg/pillar/hypervisor/containerd.go
+++ b/pkg/pillar/hypervisor/containerd.go
@@ -162,8 +162,10 @@ func (ctx ctrdContext) Info(domainName string, domainID int) (int, types.SwState
 		"stopped": types.HALTED,
 	}
 	if effectiveDomainState, matched := stateMap[status]; !matched {
-		return effectiveDomainID, types.BROKEN, fmt.Errorf("task %s happens to be in an unexpected state %s",
+		err := fmt.Errorf("task %s happens to be in an unexpected state %s",
 			domainName, status)
+		logrus.Error(err)
+		return effectiveDomainID, types.BROKEN, err
 	} else {
 		return effectiveDomainID, effectiveDomainState, nil
 	}

--- a/pkg/xen-tools/xen-start
+++ b/pkg/xen-tools/xen-start
@@ -40,10 +40,15 @@ handleKnownState() {
   STATUS="$1"
 
   # an additional check we do for running domains is to make sure device model is still around
-  if [ "$1" = running ] &&
-     DM_PID=$(xenstore read "/local/domain/$ID/image/device-model-pid" 2>/dev/null) &&
-     ! (readlink "/proc/$DM_PID/exe" | grep -q qemu-system-); then
-     STATUS=broken
+  # Note that when the domU is rebooted from inside the DM_PID changes and for
+  # a short time device-model-pid is empty, and for a short time we might have
+  # a DM_PID in xenstore but the qemu process is not running.
+  # Thus the caller has to handle a transient broken state
+  if [ "$1" = running ] || [ "$1" = paused ]; then
+    if DM_PID=$(xenstore read "/local/domain/$ID/image/device-model-pid" 2>/dev/null) &&
+       ! (readlink "/proc/$DM_PID/exe" | grep -q qemu-system-); then
+        STATUS=broken
+    fi
   fi
 
   echo "$STATUS"
@@ -87,15 +92,25 @@ xl create "$2" -p $EXTRA_ARGS || bail "xl created failed"
 
 # we may need to wait for domain to come online for us to manipulate it (timing out in under 30 sec)
 ID=$(domID "$1")
-
-# finally unpause the domain
-xl unpause "$ID" || bail "xl unpause failed"
+# check it timed out
+if [ -z "$ID" ]; then
+  echo broken > "/run/tasks/$1"
+else
+  # finally unpause the domain
+  xl unpause "$ID" || bail "xl unpause failed"
+fi
 
 # now start polling for domain status in the background
 # (note: our use of mv to make sure file reads on the other side are atomic)
 # (note: there will be a 5sec wait before the next xen_info() call in case if we get a nondeterministic domain state)
+# We wait and retry if we see a broken state to handle transients due to reboot
+# from inside the domU
 (while true; do
    xen_info "$(domID "$1")" > "/run/tasks/$1.tmp"
+   if grep -q broken "/run/tasks/$1.tmp"; then
+     sleep 10
+     xen_info "$(domID "$1")" > "/run/tasks/$1.tmp"
+   fi
    mv "/run/tasks/$1.tmp" "/run/tasks/$1"
 done) &
 


### PR DESCRIPTION
This was drive by a few observations:
1. When doing a reboot from inside a domU sometimes (maybe every other time) it looks like the domU doesn't come back up
2. If the qemu device model process dies we post an error ("please restart your application instance") but that error is often immediately cleared showing the app instance in halted state.
3. We have various errors from xl destroy and xl shutdown in the logs - maybe it is just noise?

The first issue is due to the reboot from inside resulting in the qemu DM process stopping and a new qemu DM process starting, and as part of that domainmgr/hypervisor code concludes the thing is BROKEN since there is no process corresponding to the DM_PID in the xenstore. (That state seems to last for a second or so and then the DM_PID in xenstore is cleared and then the new device model pid is set in xenstore.)
When domainmgr sees it as being broken it calls the Delete function in the hypervisor to ensure it will never come back up.

The second issue (which can be tested by a kill -9 to the device model qemu process) is due to the interaction between domainmgr and zedmanager after the error resulting in a modification to the VifList in DomainConfig. When domainmgr's handleModify processes that change it clears the error. But fixing that sometimes makes the domain eligible  for a retry of the boot, which we don't want it we want to report the "please restart the application instance" and wait for the user to observe the error and do the restart. (We could alternatively report an error and trigger the retry all the time if we want that behavior now that we understand this behavior.) To fix that we set the state to BROKEN and check for that state to avoid calling doActivate.

Finally the xl destroy and xl shutdown errors are due to doInactivate trying to ensure that is dead and gone. But this code is calling Delete even when the domainId is zero which means it is gone. Furthermore, after such a failure it will wait for it to be gone (even though it was already gone) resulting in a stop or delete of an app instance taking a lot longer than needed.

As part of this I'm changing some log.Function calls to log.Notice to make it easier to observe should we have future issues in this area.

Tested with both Xen and KVM with manual fault injection (kill -9 to the qemu process) and the usual restart, purge, etc.
As part of that found some unneeded chatty interaction from zedmanager where it published DomainStatus several times as part of the restart/purge flows.