### PR TITLE
separate resolve.conf for no-hyper

### DIFF
--- a/pkg/pillar/containerd/oci.go
+++ b/pkg/pillar/containerd/oci.go
@@ -275,7 +275,7 @@ func (s *ociSpec) UpdateVifList(vifs []types.VifInfo) {
 		s.Hooks.Prestart = append(s.Hooks.Prestart, specs.Hook{
 			Env:     vifSpec,
 			Path:    eveScript,
-			Args:    append(vethScript, "up", v.Vif, v.Bridge, v.Mac),
+			Args:    append(vethScript, "up", s.name, v.Vif, v.Bridge, v.Mac),
 			Timeout: &timeout,
 		})
 		s.Hooks.Poststop = append(s.Hooks.Poststop, specs.Hook{

--- a/pkg/pillar/containerd/oci_test.go
+++ b/pkg/pillar/containerd/oci_test.go
@@ -411,7 +411,7 @@ func TestOciSpec(t *testing.T) {
 	assert.Equal(t, []string{"VIF_NAME=vif1", "VIF_BRIDGE=br0", "VIF_MAC=52:54:00:12:34:57"}, s.Hooks.Prestart[1].Env)
 	assert.Equal(t, []string{"VIF_NAME=vif0", "VIF_BRIDGE=br0", "VIF_MAC=52:54:00:12:34:56"}, s.Hooks.Poststop[0].Env)
 	assert.Equal(t, "/bin/eve", s.Hooks.Poststop[1].Path)
-	assert.Equal(t, []string{"eve", "exec", "pillar", "/opt/zededa/bin/veth.sh", "up", "vif0", "br0", "52:54:00:12:34:56"}, s.Hooks.Prestart[0].Args)
+	assert.Equal(t, []string{"eve", "exec", "pillar", "/opt/zededa/bin/veth.sh", "up", "test", "vif0", "br0", "52:54:00:12:34:56"}, s.Hooks.Prestart[0].Args)
 	assert.Equal(t, []string{"eve", "exec", "pillar", "/opt/zededa/bin/veth.sh", "down", "vif1"}, s.Hooks.Poststop[1].Args)
 	assert.Equal(t, 60, *s.Hooks.Poststop[1].Timeout)
 }

--- a/pkg/pillar/scripts/veth.sh
+++ b/pkg/pillar/scripts/veth.sh
@@ -17,12 +17,13 @@ case $1 in
    down) ip link del "$2"
          exit $?
          ;;
-     up) VIF_NAME="$2"
-         VIF_CTR="$2".1
-         VIF_BRIDGE="$3"
-         VIF_MAC="$4"
+     up) TASK="$2"
+         VIF_NAME="$3"
+         VIF_CTR="$3".1
+         VIF_BRIDGE="$4"
+         VIF_MAC="$5"
          ;;
-      *) echo "ERROR: correct use is $0 up|down VIF_NAME VIF_BRIDGE [VIF_MAC]"
+      *) echo "ERROR: correct use is $0 up TASK VIF_NAME VIF_BRIDGE [VIF_MAC] or $0 down VIF_NAME"
          exit 2
 esac
 
@@ -38,4 +39,17 @@ try brctl addif "$VIF_BRIDGE" "$VIF_NAME"
 try nsenter -t "$VIF_NS" -n ip link set "$VIF_CTR" up
 try ip link set "$VIF_NAME" up
 
-try nsenter -t "$VIF_NS" -n dhcpcd "$VIF_CTR"
+VIF_TASK=/run/tasks/vifs/"$TASK"
+
+mkdir -p "$VIF_TASK"
+mkdir -p "$VIF_TASK"/var/lib/dhcpcd
+mkdir -p "$VIF_TASK"/etc
+mkdir -p "$VIF_TASK"/run/dhcpcd/resolv.conf
+touch "$VIF_TASK"/etc/resolv.conf
+
+# we use patched version of dhcpcd with /etc/resolv.conf.new
+MOUNTS="mount --bind $VIF_TASK/run/dhcpcd/resolv.conf /run/dhcpcd/resolv.conf &&\
+ mount --bind $VIF_TASK/var/lib/dhcpcd /var/lib/dhcpcd &&\
+ mount --bind $VIF_TASK/etc/resolv.conf /etc/resolv.conf.new"
+
+try nsenter -t "$VIF_NS" -n unshare --mount sh -c "$MOUNTS && dhcpcd $VIF_CTR"


### PR DESCRIPTION
In order to implement access only to particular hosts inside Eden https://github.com/lf-edge/eden/pull/555 I noticed, that we have different behavior for container-in-VM and container (no-hyper) in aspect of talking with dns server. Seems, we should provide separate resolve.conf to no-hyper apps (not from [EVE](https://github.com/lf-edge/eve/blob/16f51c1b9f330cc890c62ae123ed800b906f30c9/pkg/pillar/hypervisor/containerd.go#L77-L81)) to force app communication with dnsmasq.

Signed-off-by: Petr Fedchenkov <petr@zededa.com>