### PR TITLE
Moving acrn packages to eve-alpine

### DIFF
--- a/pkg/acrn-kernel/Dockerfile
+++ b/pkg/acrn-kernel/Dockerfile
@@ -1,37 +1,11 @@
-FROM lfedge/eve-alpine:9cf408427ca05cd7795e92ca827cc678e3c295cc as kernel-build
+FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as kernel-build
 
-RUN apk --no-cache add \
-    argp-standalone=1.3-r3 \
-    automake=1.16.1-r0 \
-    bash=4.4.19-r1 \
-    bc=1.07.1-r0 \
-    binutils-dev=2.31.1-r2 \
-    bison=3.0.5-r0 \
-    build-base=0.5-r1 \
-    curl=7.64.0-r3 \
-    diffutils=3.7-r0 \
-    flex=2.6.4-r1 \
-    git=2.20.2-r0 \
-    gmp-dev=6.1.2-r1 \
-    gnupg=2.2.19-r0 \
-    installkernel=3.5-r0 \
-    kmod=24-r1 \
-    libressl-dev=2.7.5-r0 \
-    linux-headers=4.18.13-r1 \
-    ncurses-dev=6.1_p20190105-r0 \
-    python2=2.7.16-r2 \
-    findutils=4.6.0-r1 \
-    sed=4.5-r0 \
-    squashfs-tools=4.3-r5 \
-    tar=1.32-r0 \
-    xz=5.2.4-r0 \
-    xz-dev=5.2.4-r0 \
-    zlib-dev=1.2.11-r1 \
-    openssl=1.1.1d-r2 \
-    lz4=1.8.3-r2 \
-    lz4-libs=1.8.3-r2 \
-    elfutils-libelf=0.168-r2 \
-    elfutils-dev=0.168-r2
+ENV BUILD_PKGS \
+    argp-standalone automake bash bc binutils-dev bison build-base curl \
+    diffutils flex git gmp-dev gnupg installkernel kmod libressl-dev    \
+    linux-headers ncurses-dev python3 findutils sed squashfs-tools tar  \
+    xz xz-dev zlib-dev openssl lz4 lz4-libs elfutils-libelf elfutils-dev
+RUN eve-alpine-deploy.sh
 
 
 # Download acrn-kernel
@@ -51,7 +25,7 @@ RUN set -e && for patch in /patches/*.patch; do \
     done
 
 # build acrn-kernel
-RUN mkdir /out
+RUN rm -rf /out && mkdir /out
 RUN if [ "$(uname -m)" = "x86_64" ] ; then \
     cp kernel_config_uefi_sos .config && \
     make olddefconfig && \

--- a/pkg/acrn-kernel/patches-acrn-2019w39.3-150000p/0006-Define-__force_order-only-when-CONFIG_RANDOMIZE_BASE-is-unset.patch
+++ b/pkg/acrn-kernel/patches-acrn-2019w39.3-150000p/0006-Define-__force_order-only-when-CONFIG_RANDOMIZE_BASE-is-unset.patch
@@ -1,0 +1,24 @@
+From 9b9f5cf01e6d52c7ec6898c2c674e11e5b281bd6 Mon Sep 17 00:00:00 2001
+From: Roman Shaposhnik <rvs@zededa.com>
+Date: Fri, 18 Oct 2019 22:49:08 +0000
+Subject: Define __force_order only when CONFIG_RANDOMIZE_BASE is unset
+
+Signed-off-by: Roman Shaposhnik <rvs@zededa.com>
+---
+ arch/x86/boot/compressed/pgtable_64.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/arch/x86/boot/compressed/pgtable_64.c b/arch/x86/boot/compressed/pgtable_64.c
+index 3e9b2d9..6a7da1f 100644
+--- a/arch/x86/boot/compressed/pgtable_64.c
++++ b/arch/x86/boot/compressed/pgtable_64.c
+@@ -12,7 +12,9 @@
+  * It is not referenced from the code, but GCC < 5 with -fPIE would fail
+  * due to an undefined symbol. Define it to make these ancient GCCs work.
+  */
++#ifndef CONFIG_RANDOMIZE_BASE
+ unsigned long __force_order;
++#endif
+ 
+ #define BIOS_START_MIN		0x20000U	/* 128K, less than this is insane */
+ #define BIOS_START_MAX		0x9f000U	/* 640K, absolute maximum */

--- a/pkg/acrn/Dockerfile
+++ b/pkg/acrn/Dockerfile
@@ -1,44 +1,13 @@
-FROM lfedge/eve-alpine:9cf408427ca05cd7795e92ca827cc678e3c295cc as kernel-build
+FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as kernel-build
 
-RUN apk add --no-cache \
-    gcc=8.3.0-r0 \
-    make=4.2.1-r2 \
-    libc-dev=0.7.1-r0 \
-    dev86=0.16.21-r0 \
-    xz-dev=5.2.4-r0 \
-    perl=5.26.3-r0 \
-    bash=4.4.19-r1 \
-    python2-dev=2.7.16-r2 \
-    gettext=0.19.8.1-r4 \
-    iasl=20181213-r0 \
-    util-linux-dev=2.33-r0 \
-    ncurses-dev=6.1_p20190105-r0 \
-    glib-dev=2.58.1-r3 \
-    pixman-dev=0.34.0-r6 \
-    libaio-dev=0.3.111-r0 \
-    yajl-dev=2.1.0-r0 \
-    argp-standalone=1.3-r3 \
-    linux-headers=4.18.13-r1 \
-    git=2.20.2-r0 \
-    patch=2.7.6-r6 \
-    texinfo=6.5-r1 \
-    curl=7.64.0-r3 \
-    tar=1.32-r0 \
-    bash=4.4.19-r1 \
-    socat=1.7.3.2-r5 \
-    openssh=7.9_p1-r6 \
-    python3=3.6.9-r2 \
-    libc-dev=0.7.1-r0 \
-    openssl-dev=1.1.1d-r2 \
-    openssl=1.1.1d-r2 \
-    libpciaccess=0.14-r0 \
-    libpciaccess-dev=0.14-r0 \
-    bsd-compat-headers=0.7.1-r0 \
-    libusb=1.0.22-r0 \
-    libusb-dev=1.0.22-r0 \
-    gnu-efi-dev=3.0.4-r1
+ENV BUILD_PKGS \
+    gcc make libc-dev dev86 xz-dev perl bash python3-dev gettext iasl         \
+    util-linux-dev ncurses-dev glib-dev pixman-dev libaio-dev yajl-dev        \
+    argp-standalone linux-headers git patch texinfo curl tar bash socat       \
+    openssh python3 libc-dev openssl-dev openssl libpciaccess libpciaccess-dev\
+    bsd-compat-headers libusb libusb-dev gnu-efi-dev py3-pip
+RUN eve-alpine-deploy.sh
 
-RUN if [ ! -e /usr/bin/python ]; then ln -sf python3 /usr/bin/python ; fi
 RUN pip3 install kconfiglib==12.14.1
 
 ENV ACRN_VERSION 1.3

--- a/pkg/acrn/patches-1.3/0007-fix-PHDR-segment-not-covered-by-LOAD-segment.patch
+++ b/pkg/acrn/patches-1.3/0007-fix-PHDR-segment-not-covered-by-LOAD-segment.patch
@@ -1,0 +1,24 @@
+From 51bd91a7cb355db7d8bcdabeb1948e23e0647c88 Mon Sep 17 00:00:00 2001
+From: Roman Shaposhnik <rvs@zededa.com>
+Date: Thu, 17 Oct 2019 05:34:30 +0800
+Subject: fix PHDR segment not covered by LOAD segment
+
+Signed-off-by: Roman Shaposhnik <rvs@zededa.com>
+---
+ hypervisor/Makefile | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/hypervisor/Makefile b/hypervisor/Makefile
+index 44c8da4..140e662 100644
+--- a/hypervisor/Makefile
++++ b/hypervisor/Makefile
+@@ -466,8 +466,8 @@
+ 
+ $(HV_OBJDIR)/$(HV_FILE).out: $(MODULES)
+ 	${BASH} ${LD_IN_TOOL} $(ARCH_LDSCRIPT_IN) $(ARCH_LDSCRIPT) ${HV_OBJDIR}/.config
+-	$(CC) -Wl,-Map=$(HV_OBJDIR)/$(HV_FILE).map -o $@ $(LDFLAGS) $(ARCH_LDFLAGS) -T$(ARCH_LDSCRIPT) \
++	$(CC) -Wl,--no-dynamic-linker -Wl,-Map=$(HV_OBJDIR)/$(HV_FILE).map -o $@ $(LDFLAGS) $(ARCH_LDFLAGS) -T$(ARCH_LDSCRIPT) \
+ 		-Wl,--start-group $^ -Wl,--end-group
+ 
+ .PHONY: clean
+ clean:


### PR DESCRIPTION
This moves acrn packages to our latest eve-alpine. Notice that gcc 10 that we're now using is more picky and thus requires a few additional patches to make sure warnings don't break our builds.

Arguably we should bump our ACRN dependency to the latest ACRN version (where those are fixed) -- but that'd be a separate PR.