### PR TITLE
Moving ipxe k3s lisp qrexec-dom0 qrexec-lib u-boot uefi to the latest eve-alpine

### DIFF
--- a/pkg/ipxe/Dockerfile
+++ b/pkg/ipxe/Dockerfile
@@ -1,18 +1,8 @@
-FROM lfedge/eve-alpine:5.16.0 as build
+FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
 
-RUN apk add --no-cache       \
-    patch=2.7.6-r6           \
-    curl=7.64.0-r3           \
-    make=4.2.1-r2            \
-    gcc=8.3.0-r0             \
-    perl=5.26.3-r0           \
-    util-linux-dev=2.33-r0   \
-    git=2.20.2-r0            \
-    mtools=4.0.23-r0         \
-    linux-headers=4.18.13-r1 \
-    musl-dev=1.1.20-r5       \
-    xz-dev=5.2.4-r0
+ENV BUILD_PKGS patch curl make gcc perl util-linux-dev git mtools linux-headers musl-dev xz-dev
 # bash xorriso coreutils syslinux
+RUN eve-alpine-deploy.sh
 
 WORKDIR /ws
 RUN git clone --depth 1 -b v1.21.1 https://github.com/ipxe/ipxe.git .

--- a/pkg/k3s/0001-go-mod.patch
+++ b/pkg/k3s/0001-go-mod.patch
@@ -1,0 +1,21 @@
+--- a/scripts/build
++++ b/scripts/build
+@@ -120,15 +120,15 @@
+ # CGO_ENABLED=0 "${GO}" build -tags "$TAGS" -ldflags "$VERSIONFLAGS $LDFLAGS $STATIC" -o bin/containerd ./cmd/containerd/
+ echo Building runc
+ rm -f ./vendor/github.com/opencontainers/runc/runc
+-make EXTRA_LDFLAGS="-w -s" BUILDTAGS="$RUNC_TAGS" -C ./vendor/github.com/opencontainers/runc $RUNC_STATIC
++make EXTRA_LDFLAGS="-w -s" EXTRA_FLAGS='-mod=vendor' BUILDTAGS="$RUNC_TAGS" -C ./vendor/github.com/opencontainers/runc $RUNC_STATIC
+ cp -f ./vendor/github.com/opencontainers/runc/runc ./bin/runc
+ 
+ echo Building containerd-shim
+ rm -f ./vendor/github.com/containerd/containerd/bin/containerd-shim
+-make -C ./vendor/github.com/containerd/containerd bin/containerd-shim
++make GO_BUILD_FLAGS='-mod=vendor' -C ./vendor/github.com/containerd/containerd bin/containerd-shim
+ cp -f ./vendor/github.com/containerd/containerd/bin/containerd-shim ./bin/containerd-shim
+ 
+ echo Building containerd-shim-runc-v2
+ rm -f ./vendor/github.com/containerd/containerd/bin/containerd-shim-runc-v2
+-make -C ./vendor/github.com/containerd/containerd bin/containerd-shim-runc-v2
++make GO_BUILD_FLAGS='-mod=vendor' -C ./vendor/github.com/containerd/containerd bin/containerd-shim-runc-v2
+ cp -f ./vendor/github.com/containerd/containerd/bin/containerd-shim-runc-v2 ./bin/containerd-shim-runc-v2

--- a/pkg/k3s/Dockerfile
+++ b/pkg/k3s/Dockerfile
@@ -1,26 +1,14 @@
 ARG GOVER=1.14.4
-FROM lfedge/eve-alpine:e308c3ab4360639365e6084a75727ce5bf488adb as cache
+FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+ENV BUILD_PKGS make gcc git musl-dev linux-headers curl bash pkgconf libseccomp-dev go patch
+RUN eve-alpine-deploy.sh
 
-ARG GOVER=1.14.4
-FROM golang:${GOVER}-alpine as build
 ARG K3SVER=v1.18.4+k3s1
 
-COPY --from=cache /mirror/3.12 /mirror/3.12
-COPY --from=cache /mirror/3.12/rootfs/etc/apk/ /etc/apk/
-
-RUN apk add --no-cache --initdb \
-        make=4.3-r0 \
-        gcc=9.3.0-r2 \
-        musl-dev=1.1.24-r10 \
-        git=2.26.2-r0 \
-        linux-headers=5.4.5-r1 \
-        curl=7.69.1-r1 \
-        bash=5.0.17-r0 \
-        pkgconf=1.7.2-r0 \
-        libseccomp-dev=2.4.3-r0
-
 WORKDIR /k3s
+COPY 0001-go-mod.patch /tmp/
 RUN git clone -b ${K3SVER} --depth 1 https://github.com/rancher/k3s.git .
+RUN patch -p1 < /tmp/0001-go-mod.patch
 RUN scripts/download
 RUN scripts/build
 RUN scripts/package-cli

--- a/pkg/lisp/Dockerfile
+++ b/pkg/lisp/Dockerfile
@@ -1,65 +1,46 @@
-ARG GOVER=1.12.4
-FROM golang:${GOVER}-alpine as build
-RUN apk add --no-cache           \
-        gcc=8.3.0-r0             \
-        linux-headers=4.18.13-r1 \
-        libc-dev=0.7.1-r0        \
-        libpcap-dev=1.9.0-r1
+FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 AS build
+ENV BUILD_PKGS gcc linux-headers libc-dev libpcap-dev go python2-dev libffi-dev openssl-dev patch
+ENV PKGS libffi libpcap python2 openssl iproute2 keyutils tini
+RUN eve-alpine-deploy.sh
+
+ENV LISP_VERSION=release-0.488
+ENV BUILD_DIR=/lispers.net-${LISP_VERSION}
+
+ADD https://github.com/farinacci/lispers.net/archive/${LISP_VERSION}.tar.gz /tmp/
+ADD https://bootstrap.pypa.io/pip/2.7/get-pip.py /tmp/
+COPY patches /tmp/patches
+COPY pyfakes /usr/bin/pyflakes
+
+WORKDIR ${BUILD_DIR}
+RUN tar -C ${BUILD_DIR}/.. -xzvf "/tmp/${LISP_VERSION}.tar.gz"
+RUN for p in /tmp/patches/* ; do patch -p1 < "$p" ; done
+WORKDIR ${BUILD_DIR}/build
+RUN python make-release.py dev
+WORKDIR /lisp
+RUN tar -xzvf ${BUILD_DIR}/build/latest/lispers.net.tgz
+
+RUN python /tmp/get-pip.py
+RUN pip install -r /lisp/pip-requirements.txt
 
 ENV GOFLAGS=-mod=vendor
 ENV GO111MODULE=on
 ENV CGO_ENABLED=1
 
-COPY ./  /lisp/
-WORKDIR /lisp
-RUN go build -mod=vendor -o lisp-ztr ./cmd/lisp-ztr
-RUN strip lisp-ztr
+COPY ./  /lisp-go/
+WORKDIR /lisp-go
+RUN go build -mod=vendor -o /lisp/lisp-ztr ./cmd/lisp-ztr
+RUN strip /lisp/lisp-ztr
 
-FROM alpine:3.11 AS lisp
-ENV LISP_VERSION=release-0.488
+WORKDIR /out
+RUN mv /lisp .
+RUN mv /usr/bin/pydoc /usr/bin/smtpd.py usr/bin/
+RUN mv /usr/lib/python2.7/site-packages usr/lib/python2.7/site-packages
 
-ADD https://github.com/farinacci/lispers.net/archive/${LISP_VERSION}.tar.gz /tmp/
-ADD patches /tmp/patches
-ADD pyfakes /usr/bin/pyflakes
-
-RUN apk add --no-cache           \
-        py2-pip=18.1-r0          \
-        gcc=9.3.0-r0             \
-        linux-headers=4.19.36-r0 \
-        libc-dev=0.7.2-r0        \
-        python2-dev=2.7.18-r0    \
-        libffi-dev=3.2.1-r6      \
-        openssl-dev=1.1.1j-r0    \
-        libpcap-dev=1.9.1-r0
-RUN tar -C /tmp -xzvf /tmp/${LISP_VERSION}.tar.gz && \
-    cd /tmp/lispers.net-${LISP_VERSION} && \
-    for p in /tmp/patches/* ; do patch -p1 < $p ; done && \
-    cd build ; python make-release.py dev && \
-    mkdir /lisp ; tar -C /lisp -xzvf latest/lispers.net.tgz
-
-RUN pip install --upgrade pip && pip install -r /lisp/pip-requirements.txt
-RUN apk del py2-pip
+COPY rootfs/ ./
 
 # Putting it all together
-FROM alpine:3.11
-
-RUN apk add --no-cache     \
-        libffi=3.2.1-r6    \
-        libpcap=1.9.1-r0   \
-        python2=2.7.18-r0  \
-        openssl=1.1.1j-r0  \
-        iproute2=5.4.0-r1  \
-        keyutils=1.6.1-r0  \
-        tini=0.18.0-r0
-
-COPY --from=lisp /lisp /lisp/
-COPY --from=lisp /usr/bin/pydoc /usr/bin/smtpd.py /usr/bin/
-RUN echo workaround for https://github.com/moby/moby/issues/37965
-COPY --from=lisp /usr/lib/python2.7/site-packages /usr/lib/python2.7/site-packages 
-
-COPY --from=build /lisp/lisp-ztr /lisp/
-
-ADD rootfs/ /
+FROM scratch
+COPY --from=build /out/ /
 
 EXPOSE 8080
 

--- a/pkg/qrexec-dom0/Dockerfile.in
+++ b/pkg/qrexec-dom0/Dockerfile.in
@@ -1,13 +1,8 @@
 FROM XENTOOLS_TAG as xentools
 FROM QREXECLIB_TAG as qrexec_lib
-FROM alpine:3.6 as build
-
-RUN apk add --no-cache \
-    gcc \
-    make \
-    libc-dev \
-    linux-headers \
-    git
+FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+ENV BUILD_PKGS gcc make libc-dev linux-headers git pkgconf
+RUN eve-alpine-deploy.sh
 
 COPY --from=xentools / /
 COPY --from=qrexec_lib / /

--- a/pkg/qrexec-lib/Dockerfile.in
+++ b/pkg/qrexec-lib/Dockerfile.in
@@ -1,25 +1,16 @@
 FROM XENTOOLS_TAG as xentools
 
-FROM alpine:3.6	as build
-
-RUN apk add --no-cache \
-    gcc \
-    make \
-    libc-dev \
-    linux-headers \
-    git
-
+FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+ENV BUILD_PKGS gcc make libc-dev linux-headers git pkgconf
+ENV PKGS libc-dev
+RUN eve-alpine-deploy.sh
+RUN mkdir -p /out/usr/share/pkgconfig
 
 COPY --from=xentools / /
 
 RUN git clone https://github.com/QubesOS/qubes-core-vchan-xen qubes-core-vchan-xen
 RUN git clone https://github.com/QubesOS/qubes-linux-utils qubes-util-linux
 RUN git clone https://github.com/QubesOS/qubes-core-qrexec qubes-core-qrexec
-
-RUN mkdir /out
-RUN mkdir -p /out/usr/lib
-RUN mkdir -p /out/usr/include
-RUN mkdir -p /out/usr/share/pkgconfig
 
 WORKDIR /qubes-core-vchan-xen/u2mfn
 RUN git checkout 51c9221e0b904001a59d2dac910c28fdc31e18f7
@@ -37,11 +28,11 @@ RUN cp libvchan.h /out/usr/include
 
 WORKDIR /qubes-core-qrexec/libqrexec
 RUN sed -i. -e 's#-Wall##' -e 's#-Wextra##' -e 's#-Werror##'  `find . -name Makefile`
-RUN make BACKEND_VMM=xen DESTDIR=out/ INCLUDEDIR=/usr/include LIBDIR=/usr/lib
+RUN make BACKEND_VMM=xen DESTDIR=/out/ INCLUDEDIR=/usr/include LIBDIR=/usr/lib
 RUN make install BACKEND_VMM=xen DESTDIR=/out/ INCLUDEDIR=/usr/include LIBDIR=/usr/lib
 
 
 FROM scratch
 ENTRYPOINT []
 CMD []
-COPY --from=build /out /
+COPY --from=build /out/ /

--- a/pkg/u-boot/Dockerfile
+++ b/pkg/u-boot/Dockerfile
@@ -1,4 +1,7 @@
-FROM linuxkit/alpine:3fdc49366257e53276c6f363956a4353f95d9a81 as build
+FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+ENV BUILD_PKGS binutils-dev build-base bc curl bison flex openssl-dev python3 swig
+ENV BUILD_PKGS_amd64 python3-dev
+RUN eve-alpine-deploy.sh
 
 ENV VERSION v2020.07
 ENV SOURCE_URL https://github.com/u-boot/u-boot/archive/${VERSION}.tar.gz
@@ -7,26 +10,11 @@ ENV RAPBERRY_FIRMWARE_BLOBS https://github.com/raspberrypi/firmware/raw/${RAPBER
 ENV TARGET_x86_64 qemu-x86_defconfig
 ENV TARGET_aarch64 rpi_4_defconfig
 
-RUN apk add --no-cache     \
-    binutils-dev=2.31.1-r2 \
-    build-base=0.5-r1      \
-    bc=1.07.1-r0           \
-    curl=7.64.0-r2         \
-    bison=3.0.5-r0         \
-    flex=2.6.4-r1          \
-    openssl-dev=1.1.1b-r1  \
-    python3                \
-    swig
-
 RUN curl -fsSL ${SOURCE_URL} | tar -C / -xzf - && mv /u-boot* /u-boot
 
 WORKDIR /u-boot
 # FIXME: we need to get to the bottom of this weird workaround on x86/Alpine
-RUN if [ "$(uname -m)" = x86_64 ]; then                                              \
-       cp /etc/apk/repositories.upstream /etc/apk/repositories                     &&\
-       apk add --no-cache python3-dev=3.6.9-r3                                     &&\
-       sed -ie 's#CONFIG_IS_ENABLED(X86_64)#1#' ./arch/x86/include/asm/byteorder.h  ;\
-    fi
+RUN [ "$(uname -m)" != x86_64 ] || sed -ie 's#CONFIG_IS_ENABLED(X86_64)#1#' ./arch/x86/include/asm/byteorder.h
 COPY patches /tmp/patches
 RUN if [ "$(uname -m)" = aarch64 ]; then\
        for p in /tmp/patches/patches-"${VERSION}"/*.patch ; do patch -p1 < "$p" || exit 1 ; done;\

--- a/pkg/uefi/Dockerfile
+++ b/pkg/uefi/Dockerfile
@@ -9,15 +9,9 @@
 #   git clone https://git.linaro.org/uefi/uefi-tools.git
 #   ./uefi-tools/edk2-build.sh -b DEBUG -b RELEASE all
 #
-# It is possible to do a docker-based aarch64 build on x86.
-# If you want to do that -- make sure to pass the following
-# argument to the docker build:
-#   --build-arg BUILD_CONTAINER=alpine@sha256:286be1c7f84de7cbae6cf8aa4e13b3ce2f2512353b3e734336e47e92de4a881e
-ARG BUILD_CONTAINER=alpine:3.7
-FROM ${BUILD_CONTAINER} as build
-
-# hadolint ignore=DL3018
-RUN apk add --no-cache curl make gcc g++ python libuuid iasl nasm util-linux-dev bash git util-linux
+FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+ENV BUILD_PKGS curl make gcc g++ python3 libuuid iasl nasm util-linux-dev bash git util-linux patch
+RUN eve-alpine-deploy.sh
 
 RUN git clone --depth 1 -b edk2-stable202005 https://github.com/tianocore/edk2.git /ws
 WORKDIR /ws
@@ -25,11 +19,12 @@ RUN git submodule update --init
 COPY build.sh /ws/
 COPY patch /ws/patch
 RUN bash -c 'patch -p0 < patch/*'
+RUN ln -s python3 /usr/bin/python
 RUN make -C BaseTools
 RUN ./build.sh
 
 # now create an out dir for all the artifacts
-RUN mkdir /out && cp /ws/OVMF*.fd /out
+RUN rm -rf /out && mkdir /out && cp /ws/OVMF*.fd /out
 
 # FIXME: we should be building Raspbery Pi 4 UEFI implementations
 COPY rpi /tmp/rpi


### PR DESCRIPTION
This is really pretty self-explanatory. Btw, this last batch is moving all the packages that don't actually RUN as part of EVE but rather just build various binary artifacts in support of EVE. Next batch of packages will tackle the ones that comprise EVE's running image.