### PR TITLE
Moving runtime packages to the latest eve-alpine

### DIFF
--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -7,11 +7,11 @@ init:
   - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/getty:v0.5
   - linuxkit/memlogd:v0.5
+  - DOM0ZTOOLS_TAG
   - GRUB_TAG
   - FW_TAG
   - XEN_TAG
   - GPTTOOLS_TAG
-  - DOM0ZTOOLS_TAG
 onboot:
    - name: storage-init
      image: STORAGE_INIT_TAG

--- a/pkg/acrn-kernel/Dockerfile
+++ b/pkg/acrn-kernel/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as kernel-build
+FROM lfedge/eve-alpine:6.2.0 as kernel-build
 
 ENV BUILD_PKGS \
     argp-standalone automake bash bc binutils-dev bison build-base curl \

--- a/pkg/acrn/Dockerfile
+++ b/pkg/acrn/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as kernel-build
+FROM lfedge/eve-alpine:6.2.0 as kernel-build
 
 ENV BUILD_PKGS \
     gcc make libc-dev dev86 xz-dev perl bash python3-dev gettext iasl         \

--- a/pkg/alpine/Dockerfile
+++ b/pkg/alpine/Dockerfile
@@ -1,5 +1,5 @@
 ARG ALPINE_VERSION=3.13
-FROM lfedge/eve-alpine:7f21d503268e4b1b36c9fe35039ae88c32325aa5 AS cache
+FROM lfedge/eve-alpine:6.2.0 AS cache
 
 FROM alpine:${ALPINE_VERSION} AS mirror
 ARG ALPINE_VERSION=3.13

--- a/pkg/alpine/Dockerfile
+++ b/pkg/alpine/Dockerfile
@@ -1,5 +1,5 @@
 ARG ALPINE_VERSION=3.13
-FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 AS cache
+FROM lfedge/eve-alpine:7f21d503268e4b1b36c9fe35039ae88c32325aa5 AS cache
 
 FROM alpine:${ALPINE_VERSION} AS mirror
 ARG ALPINE_VERSION=3.13

--- a/pkg/debug/Dockerfile
+++ b/pkg/debug/Dockerfile
@@ -3,11 +3,17 @@
 # has a fast path for stack unwinding. This also happens
 # to be a perfect place to put any other kind of debug info
 # into the package: see abuild/etc/abuild.conf.
-FROM alpine:3.12 as musl-build
+FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+ENV BUILD_PKGS abuild curl tar make linux-headers patch g++
+# Feel free to add additional packages here, but be aware that
+# EVE's rootfs image can be no larger than 300Mb
+# RUN apk add --no-cache gdb valgrind
+ENV PKGS openssh-client openssh-server tini util-linux ca-certificates pciutils usbutils vim tcpdump perf strace
+RUN eve-alpine-deploy.sh
+
+ENV LSHW_VERSION 02.19.2
 
 # setting up building account
-# hadolint ignore=DL3019
-RUN apk add abuild
 RUN adduser -G abuild -D builder
 RUN su builder -c 'abuild-keygen -a -n'
 
@@ -16,13 +22,7 @@ RUN su builder -c 'cd /musl && abuild checksum && abuild -r'
 
 # now install it locally so we can pick it up later on below
 # hadolint ignore=DL3019,DL3018
-RUN apk add --allow-untrusted /home/builder/packages/*/musl-*.apk
-
-FROM alpine:3.12 as lshw-build
-
-ENV LSHW_VERSION 02.19.2
-
-RUN apk add --no-cache curl=7.69.1-r3 tar=1.32-r1 make=4.3-r0 linux-headers=5.4.5-r1 patch=2.7.6-r6 g++=9.3.0-r2
+RUN apk add -p /out --allow-untrusted /home/builder/packages/*/musl-*.apk
 
 # hadolint ignore=DL4006
 RUN curl -L https://www.ezix.org/software/files/lshw-B.${LSHW_VERSION}.tar.gz | tar xzvf -
@@ -35,18 +35,9 @@ WORKDIR /lshw-B.${LSHW_VERSION}
 RUN for patch in fix-musl-sc_long_bit.patch wrapper-for-basename.patch 15565229509455527de9ce7cbb9530e2b31d043b.patch\
  2b1c730b493d647bbab4854713571458e82a81e7.patch; do patch -p1 < $patch; done &&\
  make -C src RPM_OPT_FLAGS=-DNONLS static &&\
- cp src/lshw-static /lshw && strip /lshw
+ cp src/lshw-static /out/usr/bin/lshw && strip /out/usr/bin/lshw
 
 FROM linuxkit/sshd:666b4a1a323140aa1f332826164afba506abf597
 
 COPY ssh.sh spec.sh /usr/bin/
-# get the rebuilt musl from above
-COPY --from=musl-build /lib/ld-musl-*.so.1 /lib/
-
-# Feel free to add additional packages here, but be aware that
-# EVE's rootfs image can be no larger than 300Mb
-# RUN apk add --no-cache gdb valgrind
-# hadolint ignore=DL3018
-RUN apk add --no-cache pciutils usbutils vim tcpdump perf strace
-
-COPY --from=lshw-build /lshw /usr/bin/lshw
+COPY --from=build /out/ /

--- a/pkg/debug/Dockerfile
+++ b/pkg/debug/Dockerfile
@@ -6,7 +6,9 @@
 FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
 ENV BUILD_PKGS abuild curl tar make linux-headers patch g++
 # Feel free to add additional packages here, but be aware that
-# EVE's rootfs image can be no larger than 300Mb
+# EVE's rootfs image can be no larger than 300Mb (and don't
+# forget to check on all supported architectures: e.g. arm64
+# binaries are typically larger and amd64 ones).
 # RUN apk add --no-cache gdb valgrind
 ENV PKGS openssh-client openssh-server tini util-linux ca-certificates pciutils usbutils vim tcpdump perf strace
 RUN eve-alpine-deploy.sh

--- a/pkg/debug/Dockerfile
+++ b/pkg/debug/Dockerfile
@@ -3,7 +3,7 @@
 # has a fast path for stack unwinding. This also happens
 # to be a perfect place to put any other kind of debug info
 # into the package: see abuild/etc/abuild.conf.
-FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+FROM lfedge/eve-alpine:6.2.0 as build
 ENV BUILD_PKGS abuild curl tar make linux-headers patch g++ git
 # Feel free to add additional packages here, but be aware that
 # EVE's rootfs image can be no larger than 300Mb (and don't

--- a/pkg/debug/Dockerfile
+++ b/pkg/debug/Dockerfile
@@ -4,13 +4,13 @@
 # to be a perfect place to put any other kind of debug info
 # into the package: see abuild/etc/abuild.conf.
 FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
-ENV BUILD_PKGS abuild curl tar make linux-headers patch g++
+ENV BUILD_PKGS abuild curl tar make linux-headers patch g++ git
 # Feel free to add additional packages here, but be aware that
 # EVE's rootfs image can be no larger than 300Mb (and don't
 # forget to check on all supported architectures: e.g. arm64
 # binaries are typically larger and amd64 ones).
 # RUN apk add --no-cache gdb valgrind
-ENV PKGS openssh-client openssh-server tini util-linux ca-certificates pciutils usbutils vim tcpdump perf strace
+ENV PKGS openssh-client openssh-server tini util-linux ca-certificates pciutils usbutils vim tcpdump perf strace iproute2-minimal
 RUN eve-alpine-deploy.sh
 
 ENV LSHW_VERSION 02.19.2
@@ -24,7 +24,7 @@ RUN su builder -c 'cd /musl && abuild checksum && abuild -r'
 
 # now install it locally so we can pick it up later on below
 # hadolint ignore=DL3019,DL3018
-RUN apk add -p /out --allow-untrusted /home/builder/packages/*/musl-*.apk
+RUN apk add -p /out --allow-untrusted /home/builder/packages/*/musl-1.2*.apk
 
 # hadolint ignore=DL4006
 RUN curl -L https://www.ezix.org/software/files/lshw-B.${LSHW_VERSION}.tar.gz | tar xzvf -

--- a/pkg/debug/abuild/README.md
+++ b/pkg/debug/abuild/README.md
@@ -1,3 +1,3 @@
 # Origin of abuild
 
-Content of abuild/ folder came [from](https://git.alpinelinux.org/aports/tree/main/musl?h=3.12-stable)
+Content of abuild/ folder came [from](https://git.alpinelinux.org/aports/tree/main/musl?h=3.13-stable)

--- a/pkg/debug/abuild/musl/APKBUILD
+++ b/pkg/debug/abuild/musl/APKBUILD
@@ -1,41 +1,29 @@
-# Contributor:
+# Contributor: Ariadne Conill <ariadne@dereferenced.org>
 # Maintainer: Timo Teräs <timo.teras@iki.fi>
 pkgname=musl
-pkgver=1.1.24
-pkgrel=9
+pkgver=1.2.2
+pkgrel=0
 pkgdesc="the musl c library (libc) implementation"
 url="https://musl.libc.org/"
 arch="all"
 license="MIT"
+options="lib64"
 subpackages="$pkgname-libintl:libintl:noarch
 	$pkgname-dev
 	$pkgname-dbg
 	libc6-compat:compat:noarch
 	"
+options="lib64"
 case "$BOOTSTRAP" in
 nocc)	pkgname="musl-dev"; subpackages="";;
 nolibc) ;;
 *)	subpackages="$subpackages $pkgname-utils";;
 esac
-source="https://musl.libc.org/releases/musl-$pkgver.tar.gz
+commit="v1.2.2"
+source="musl-$commit.tar.gz::https://git.musl-libc.org/cgit/musl/snapshot/$commit.tar.gz
 	handle-aux-at_base.patch
-	0001-add-thumb2-support-to-arm-assembler-memcpy.patch
-	fix-wcwidth-wrongly-returning-0-for-most-of-planes-4.patch
-	add-missing-case-mapping-between-U-03F3-and-U-037F.patch
-	fix-cacosh-results-for-arguments-with-negative-imagi.patch
-	fix-incorrect-results-for-catanf-and-catanl-with-som.patch
-	fix-return-value-of-ungetc-when-argument-is-outside-.patch
-	fix-errno-for-posix_openpt-with-no-free-ptys-availab.patch
-	improve-strerror-speed.patch
-	ppc-pt_regs.patch
-	ppc64-fpregset_t.patch
-	fix-remaining-direct-use-of-stat-syscalls-outside.patch
-	set-AD-bit-in-dns-queries-suppress-for-internal-use.patch
 
-	0001-reorder-thread-list-unlink-in-pthread_exit-after-all.patch
-	0002-don-t-use-libc.threads_minus_1-as-relaxed-atomic-for.patch
-	0003-cut-down-size-of-some-libc-struct-members.patch
-	0004-restore-lock-skipping-for-processes-that-return-to-s.patch
+	revert-faccessat2.patch
 
 	ldconfig
 	__stack_chk_fail_local.c
@@ -45,12 +33,14 @@ source="https://musl.libc.org/releases/musl-$pkgver.tar.gz
 	"
 
 # secfixes:
+#   1.2.2_pre2-r0:
+#     - CVE-2020-28928
 #   1.1.23-r2:
 #     - CVE-2019-14697
 #   1.1.15-r4:
 #     - CVE-2016-8859
 
-builddir="$srcdir"/musl-$pkgver
+builddir="$srcdir"/$commit
 
 build() {
 	cd "$builddir"
@@ -68,9 +58,6 @@ build() {
 			${CROSS_COMPILE}gcc $CPPFLAGS $CFLAGS "$srcdir"/$i.c -o $i
 		done
 	fi
-
-        # drop -fomit-frame-pointer
-        sed -ie 's/omit-frame-pointer/no-omit-frame-pointer/' configure
 
 	# note: not autotools
 	LDFLAGS="$LDFLAGS -Wl,-soname,libc.musl-${CARCH}.so.1" \
@@ -180,24 +167,9 @@ compat() {
 	done
 }
 
-sha512sums="8987f1e194ea616f34f4f21fe9def28fb7f81d7060e38619206c6349f79db3bbb76bae8b711f5f9b8ed038799c9aea1a4cbec69e0bc4131e246203e133149e77  musl-1.1.24.tar.gz
-6a7ff16d95b5d1be77e0a0fbb245491817db192176496a57b22ab037637d97a185ea0b0d19da687da66c2a2f5578e4343d230f399d49fe377d8f008410974238  handle-aux-at_base.patch
-2b26c20112e3984a2501bc6c2f5162c6e60d4a521d9367dc7721ec66c974986e9f98a67e9f4f4c1510e82a0ac47de783317ab254786837c2e86a54122efcc1dd  0001-add-thumb2-support-to-arm-assembler-memcpy.patch
-7a9d7f16461d1e7906764cc5366af057d9402556d7bb1d022016faa8a250947c0d901f84cf02200ebc2e153d572104529097fb6f3a65f67695912d0ea40eb2d4  fix-wcwidth-wrongly-returning-0-for-most-of-planes-4.patch
-402b663b5ff77bdde6f5ea9ccec60a16971e5e7881c29259273a167b5b4d9f81734751b7375e5cb856c1e3db86fc46ee2084a244a74ed3bd47a8f97b37e40fd9  add-missing-case-mapping-between-U-03F3-and-U-037F.patch
-40c369ca393970461f19371542fa5881d0745abaaf99d1f71a3093605a306ccbc1dc120c41a8cea1542be79a82918807749ede786f836406f6c1b3dc4ec2de32  fix-cacosh-results-for-arguments-with-negative-imagi.patch
-41934951bbc16f155d40824abf30d818b4c124f668f74f5a13674b5251650bb9d9bf9fde0b75462bb2a4b80dc00871ba122960fa027998e71970d533df1cb987  fix-incorrect-results-for-catanf-and-catanl-with-som.patch
-81bddb171fc2171a7aa86e74bf674e3a99508d27416dfc1cfcf2824f17b33ee7dda7c5968a8a69a542fdd6eecded5b8e3973e81079d9a061aa80142d08fc1a90  fix-return-value-of-ungetc-when-argument-is-outside-.patch
-144b4525483cbc97f0414955b7e5ce42c9ff69580e5be714b56330da30b0687911bd6019aef3c8611bd0a5bd7671d690b66b4920ae47cf3442a1c982ed000e22  fix-errno-for-posix_openpt-with-no-free-ptys-availab.patch
-4875efd7249613f696b4c470fb0aedf9968f1260cf35ef640666897d9ef2f3032588ac4c37659928ed45c1c010848ec2b19414ba5406f3bd7d745288b8b105d4  improve-strerror-speed.patch
-e7133ce2f0b172e2da03567e41f03bef58b6ff8eaac614494751228bcc102c39cbe312f0beb567c5f1c47c76feeff1e8d3b16284842c599029add4ad6d1d70ec  ppc-pt_regs.patch
-3de8e50519e33a55d2cc737b56011a7178d1c83230477d46e11e67195e08e74bff735c6013de6ff170bb2390e89bfca9919cc8728c064b3eeaab2035dd7e5c08  ppc64-fpregset_t.patch
-d277e45af78ed2bd9f556ae30636783fc401b4d0a339d6e37b77f18ed1486f48fc631e3455f8764ddbc7d9aba41a270ab345ec3495955dfd22b27a306441ba2a  fix-remaining-direct-use-of-stat-syscalls-outside.patch
-dd46ef77b71d34b6207611be59dd4555b4e53fd7169732b9e5ee9a66f1e8da69fcca6634f895b9d34d8861d37ac0eaa86618f5f3f3a81cf9c47321d1c5d37ee5  set-AD-bit-in-dns-queries-suppress-for-internal-use.patch
-0bb30198e92d26058f98f28be31bb8cee89a699e9fa9377315c9a86f504708ddb432d579bebfd4429da3fd5e6832e4166aa80d4d3f08658702206474fd1a8ffe  0001-reorder-thread-list-unlink-in-pthread_exit-after-all.patch
-c6cd692359961c382b7382c6eb819bf93ca8d687b7bd71e4d992acabc7003bd8388b22898059b6ac5abdf08c07020c8cbd2a5f908802258418079e096cdbc058  0002-don-t-use-libc.threads_minus_1-as-relaxed-atomic-for.patch
-416aa17d4211ebbca97b4ce47eea8d8375ac5e0b602a4806175bc172be21b8291ac08fdaf39203e3a083a067bbbfa999cfb875f739d5fa07871885ac02eba75a  0003-cut-down-size-of-some-libc-struct-members.patch
-f0e5ab79a793152c5e6c1c560b409ef062c8f9232c893b36c58b9667e5e0e86969555d8e2e9e17b59835ec7ed3c926a6ccce453824561ad82e47364c44374549  0004-restore-lock-skipping-for-processes-that-return-to-s.patch
+sha512sums="7240550ab45cb6b410d65013c92f1f1de0f274322e7ba10e3cf9ce0464a1a833337c2fde39d2fc8c25af1d60599a5bb0ec0d9fb3723c098df3a72e82251bb3eb  musl-v1.2.2.tar.gz
+a76f79b801497ad994746cf82bb6eaf86f9e1ae646e6819fbae8532a7f4eee53a96ac1d4e789ec8f66aea2a68027b0597f7a579b3369e01258da8accfce41370  handle-aux-at_base.patch
+76de7511fa1ae44aa513a11d306a691172342c04cdd524bcc2f70d0e646744de832ef3254cdd3d409efa4581d601eee7e02a70af11f5530f6bacd59f1e65a979  revert-faccessat2.patch
 8d3a2d5315fc56fee7da9abb8b89bb38c6046c33d154c10d168fb35bfde6b0cf9f13042a3bceee34daf091bc409d699223735dcf19f382eeee1f6be34154f26f  ldconfig
 062bb49fa54839010acd4af113e20f7263dde1c8a2ca359b5fb2661ef9ed9d84a0f7c3bc10c25dcfa10bb3c5a4874588dff636ac43d5dbb3d748d75400756d0b  __stack_chk_fail_local.c
 0d80f37b34a35e3d14b012257c50862dfeb9d2c81139ea2dfa101d981d093b009b9fa450ba27a708ac59377a48626971dfc58e20a3799084a65777a0c32cbc7d  getconf.c

--- a/pkg/debug/abuild/musl/handle-aux-at_base.patch
+++ b/pkg/debug/abuild/musl/handle-aux-at_base.patch
@@ -1,3 +1,6 @@
+This is required to make the gcompat ELF interpreter stub work with some
+packed binaries.
+
 diff --git a/src/env/__init_tls.c b/src/env/__init_tls.c
 index b125eb1..616c6a6 100644
 --- a/src/env/__init_tls.c

--- a/pkg/debug/abuild/musl/revert-faccessat2.patch
+++ b/pkg/debug/abuild/musl/revert-faccessat2.patch
@@ -1,0 +1,41 @@
+From 6c7fb5f32ad0fb2558d50cdaa39ff7fb0e95c58b Mon Sep 17 00:00:00 2001
+From: Ariadne Conill <ariadne@dereferenced.org>
+Date: Sat, 31 Oct 2020 06:26:46 -0600
+Subject: [PATCH] Revert "use new SYS_faccessat2 syscall to implement faccessat
+ with flags"
+
+This reverts commit 55fb9a177316aa46c639d93dd0323d9a9a8c160c.
+
+Causes too many problems on Alpine right now due to seccomp.
+---
+ src/unistd/faccessat.c | 11 +++--------
+ 1 file changed, 3 insertions(+), 8 deletions(-)
+
+diff --git a/src/unistd/faccessat.c b/src/unistd/faccessat.c
+index 557503eb..76bbd4c7 100644
+--- a/src/unistd/faccessat.c
++++ b/src/unistd/faccessat.c
+@@ -25,17 +25,12 @@ static int checker(void *p)
+ 
+ int faccessat(int fd, const char *filename, int amode, int flag)
+ {
+-	if (flag) {
+-		int ret = __syscall(SYS_faccessat2, fd, filename, amode, flag);
+-		if (ret != -ENOSYS) return __syscall_ret(ret);
+-	}
++	if (!flag || (flag==AT_EACCESS && getuid()==geteuid() && getgid()==getegid()))
++		return syscall(SYS_faccessat, fd, filename, amode, flag);
+ 
+-	if (flag & ~AT_EACCESS)
++	if (flag != AT_EACCESS)
+ 		return __syscall_ret(-EINVAL);
+ 
+-	if (!flag || (getuid()==geteuid() && getgid()==getegid()))
+-		return syscall(SYS_faccessat, fd, filename, amode);
+-
+ 	char stack[1024];
+ 	sigset_t set;
+ 	pid_t pid;
+-- 
+2.29.2
+

--- a/pkg/dnsmasq/Dockerfile
+++ b/pkg/dnsmasq/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+FROM lfedge/eve-alpine:6.2.0 as build
 ENV BUILD_PKGS gcc make patch libc-dev linux-headers tar
 RUN eve-alpine-deploy.sh
 

--- a/pkg/dnsmasq/Dockerfile
+++ b/pkg/dnsmasq/Dockerfile
@@ -1,15 +1,8 @@
-# derived from Alpine 3.8
-FROM linuxkit/alpine:4d13c6209a679fc7c4e850f144b7aef879914d01 as build
+FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+ENV BUILD_PKGS gcc make patch libc-dev linux-headers tar
+RUN eve-alpine-deploy.sh
 
 ENV DNSMASQ_VERSION 2.84
-
-RUN apk add --no-cache \
-    gcc \
-    make \
-    patch \
-    libc-dev \
-    linux-headers \
-    tar
 
 RUN mkdir -p /dnsmasq/patches
 

--- a/pkg/dnsmasq/Dockerfile
+++ b/pkg/dnsmasq/Dockerfile
@@ -18,7 +18,8 @@ RUN set -e && for patch in ../patches/*.patch; do \
         patch -p1 < "$patch"; \
     done
 
-RUN make
+RUN rm -rf /out
+RUN make  -j "$(getconf _NPROCESSORS_ONLN)"
 RUN make install DESTDIR=/out PREFIX=/usr
 
 FROM scratch

--- a/pkg/dom0-ztools/Dockerfile
+++ b/pkg/dom0-ztools/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as zfs
+FROM lfedge/eve-alpine:6.2.0 as zfs
 ENV PKGS zfs ca-certificates util-linux
 RUN eve-alpine-deploy.sh
 

--- a/pkg/dom0-ztools/Dockerfile
+++ b/pkg/dom0-ztools/Dockerfile
@@ -1,5 +1,5 @@
 FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as zfs
-ENV PKGS zfs
+ENV PKGS zfs ca-certificates util-linux
 RUN eve-alpine-deploy.sh
 
 FROM scratch

--- a/pkg/dom0-ztools/Dockerfile
+++ b/pkg/dom0-ztools/Dockerfile
@@ -1,7 +1,6 @@
-FROM alpine:3.12 as zfs
-RUN mkdir -p /out/etc/apk /out/boot && cp -r /etc/apk/* /out/etc/apk/
-RUN apk add --no-cache --initdb -p /out \
-    zfs=0.8.4-r0
+FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as zfs
+ENV PKGS zfs
+RUN eve-alpine-deploy.sh
 
 FROM scratch
 COPY --from=zfs /out/ /

--- a/pkg/eve/Dockerfile.in
+++ b/pkg/eve/Dockerfile.in
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:ce776885c43588292126c2fcc7300b77a494faf3 as tools
+FROM lfedge/eve-alpine:6.2.0 as tools
 ENV PKGS qemu-img tar uboot-tools coreutils
 RUN eve-alpine-deploy.sh
 

--- a/pkg/gpt-tools/Dockerfile
+++ b/pkg/gpt-tools/Dockerfile
@@ -1,4 +1,3 @@
-# derived from Alpine 3.8
 FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
 ENV BUILD_PKGS gcc make file patch libc-dev util-linux-dev linux-headers openssl-dev g++ tar
 RUN eve-alpine-deploy.sh

--- a/pkg/gpt-tools/Dockerfile
+++ b/pkg/gpt-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+FROM lfedge/eve-alpine:6.2.0 as build
 ENV BUILD_PKGS gcc make file patch libc-dev util-linux-dev linux-headers openssl-dev g++ tar
 RUN eve-alpine-deploy.sh
 

--- a/pkg/gpt-tools/Dockerfile
+++ b/pkg/gpt-tools/Dockerfile
@@ -1,23 +1,12 @@
 # derived from Alpine 3.8
-FROM linuxkit/alpine:4d13c6209a679fc7c4e850f144b7aef879914d01 as build
+FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+ENV BUILD_PKGS gcc make file patch libc-dev util-linux-dev linux-headers openssl-dev g++ tar
+RUN eve-alpine-deploy.sh
 
 ENV POPT_VERSION 1.16
 ENV GPTFDISK_VERSION 1.0.3
 ENV VBOOT_REPO https://chromium.googlesource.com/chromiumos/platform/vboot_reference
 ENV VBOOT_COMMIT e0b3841863281a3fc3b188bfbab55d401fabdc73
-
-RUN apk add --no-cache \
-    gcc \
-    make \
-    patch \
-    libc-dev \
-    util-linux-dev \
-    linux-headers \
-    openssl-dev \
-    g++ \
-    tar
-
-RUN mkdir /out
 
 #
 # Step 1: Install SGDISK
@@ -62,7 +51,7 @@ COPY vboot_reference-${VBOOT_COMMIT}.tar.gz /
 RUN tar xvzf vboot_reference-${VBOOT_COMMIT}.tar.gz
 
 WORKDIR /vboot_reference
-RUN make cgpt LDFLAGS=-static
+RUN make cgpt LDFLAGS=-static CFLAGS=-Wno-error=address-of-packed-member
 RUN cp build/cgpt/cgpt /out/cgpt
 
 FROM scratch

--- a/pkg/guacd/Dockerfile
+++ b/pkg/guacd/Dockerfile
@@ -1,12 +1,13 @@
-FROM alpine:3.8 as build
+FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+ENV BUILD_PKGS cairo-dev jpeg-dev libpng-dev gcc make libc-dev openssl-dev libvncserver-dev file
+ENV PKGS cairo jpeg libpng openssl libvncserver
+RUN eve-alpine-deploy.sh
 
 ENV GUACD_VERSION=1.0.0
 
 ADD http://apache.org/dyn/closer.cgi?action=download&filename=guacamole/1.0.0/source/guacamole-server-${GUACD_VERSION}.tar.gz /${GUACD_VERSION}.tar.gz 
 ADD 0001-alpine-stacksize-fix.patch /
 ADD uuid-1.6.2.tar.gz /
-
-RUN apk add cairo-dev jpeg-dev libpng-dev gcc make libc-dev openssl-dev libvncserver-dev file
 
 RUN cd /uuid-1.6.2 ; ./configure --prefix=/usr/ && make && make install
 
@@ -16,9 +17,9 @@ RUN tar xzvf ${GUACD_VERSION}.tar.gz ;\
     ./configure --prefix=/usr/ --with-vnc --disable-guacenc --disable-dependency-tracking && \
      make && make install
 
-FROM alpine:3.8
+FROM scratch
 
-RUN apk add cairo jpeg libpng openssl libvncserver
+COPY --from=build /out/ /
 COPY --from=build /usr/sbin/guacd /usr/sbin/guacd
 COPY --from=build /usr/lib/libguac.so.* /usr/lib/libuuid.so.* /usr/lib/libguac-client-vnc* /usr/lib/
 

--- a/pkg/guacd/Dockerfile
+++ b/pkg/guacd/Dockerfile
@@ -1,5 +1,5 @@
 FROM lfedge/eve-alpine:067cf626c97b9bf0aa84843b84bb8a6a681a936f as build
-ENV BUILD_PKGS cairo-dev jpeg-dev libpng-dev gcc make libc-dev openssl-dev libvncserver-dev file
+ENV BUILD_PKGS cairo-dev jpeg-dev libpng-dev gcc make libc-dev openssl-dev libvncserver-dev file patch
 ENV PKGS alpine-baselayout musl-utils libtasn1-progs p11-kit cairo jpeg libpng openssl libvncserver
 RUN eve-alpine-deploy.sh
 

--- a/pkg/guacd/Dockerfile
+++ b/pkg/guacd/Dockerfile
@@ -1,6 +1,6 @@
-FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+FROM lfedge/eve-alpine:067cf626c97b9bf0aa84843b84bb8a6a681a936f as build
 ENV BUILD_PKGS cairo-dev jpeg-dev libpng-dev gcc make libc-dev openssl-dev libvncserver-dev file
-ENV PKGS cairo jpeg libpng openssl libvncserver
+ENV PKGS alpine-baselayout musl-utils libtasn1-progs p11-kit cairo jpeg libpng openssl libvncserver
 RUN eve-alpine-deploy.sh
 
 ENV GUACD_VERSION=1.0.0

--- a/pkg/guacd/Dockerfile
+++ b/pkg/guacd/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:067cf626c97b9bf0aa84843b84bb8a6a681a936f as build
+FROM lfedge/eve-alpine:6.2.0 as build
 ENV BUILD_PKGS cairo-dev jpeg-dev libpng-dev gcc make libc-dev openssl-dev libvncserver-dev file patch
 ENV PKGS alpine-baselayout musl-utils libtasn1-progs p11-kit cairo jpeg libpng openssl libvncserver
 RUN eve-alpine-deploy.sh

--- a/pkg/ipxe/Dockerfile
+++ b/pkg/ipxe/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+FROM lfedge/eve-alpine:6.2.0 as build
 
 ENV BUILD_PKGS patch curl make gcc perl util-linux-dev git mtools linux-headers musl-dev xz-dev
 # bash xorriso coreutils syslinux

--- a/pkg/k3s/Dockerfile
+++ b/pkg/k3s/Dockerfile
@@ -1,5 +1,5 @@
 ARG GOVER=1.14.4
-FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+FROM lfedge/eve-alpine:6.2.0 as build
 ENV BUILD_PKGS make gcc git musl-dev linux-headers curl bash pkgconf libseccomp-dev go patch
 RUN eve-alpine-deploy.sh
 

--- a/pkg/kernel/Dockerfile
+++ b/pkg/kernel/Dockerfile
@@ -1,5 +1,5 @@
 # This file must be kept as much in sync with pkg/new-kernel/Dockerfile as posisble
-FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 AS kernel-build
+FROM lfedge/eve-alpine:6.2.0 AS kernel-build
 
 ENV BUILD_PKGS \
     argp-standalone automake bash bc binutils-dev bison build-base curl \

--- a/pkg/lisp/Dockerfile
+++ b/pkg/lisp/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 AS build
+FROM lfedge/eve-alpine:6.2.0 AS build
 ENV BUILD_PKGS gcc linux-headers libc-dev libpcap-dev go python2-dev libffi-dev openssl-dev patch
 ENV PKGS libffi libpcap python2 openssl iproute2 keyutils tini
 RUN eve-alpine-deploy.sh

--- a/pkg/mkconf/Dockerfile
+++ b/pkg/mkconf/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 AS build
+FROM lfedge/eve-alpine:6.2.0 AS build
 
 ENV PKGS mtools dosfstools
 RUN eve-alpine-deploy.sh

--- a/pkg/mkimage-iso-efi/Dockerfile
+++ b/pkg/mkimage-iso-efi/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 AS build
+FROM lfedge/eve-alpine:6.2.0 AS build
 
 ENV PKGS dosfstools libarchive-tools binutils mtools xorriso
 RUN eve-alpine-deploy.sh

--- a/pkg/mkimage-raw-efi/Dockerfile
+++ b/pkg/mkimage-raw-efi/Dockerfile
@@ -4,49 +4,26 @@
 #   /EFI/BOOT/grub.cfg - Chainloads main bootloader
 #   /UsbInvocationScript.txt - Enables USB boot on Dell 3000 series
 #
-ARG BUILDER=lfedge/eve-alpine:ac1dc159510afa61334222cedf085c7730e4583c
-FROM ${BUILDER} as initrd
+FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
+ENV BUILD_PKGS mkinitfs gcc musl-dev linux-headers kmod-dev util-linux-dev cryptsetup-dev
+ENV PKGS mtools dosfstools libarchive-tools sgdisk e2fsprogs util-linux squashfs-tools coreutils tar
+RUN eve-alpine-deploy.sh
 
 COPY nlplug-findfs.c initramfs-init /tmp/
-RUN apk add --no-cache         \
-      mkinitfs=3.4.1-r1        \
-      gcc=8.3.0-r0             \
-      musl-dev=1.1.20-r5       \
-      linux-headers=4.18.13-r1 \
-      kmod-dev=24-r1           \
-      util-linux-dev=2.33-r0   \
-      cryptsetup1-dev=1.7.5-r4
 RUN cc -Wall -Werror -g -D_GNU_SOURCE -DDEBUG -I/usr/include/blkid -I/usr/include/uuid /tmp/nlplug-findfs.c -lblkid  -lkmod  -L/lib -lcryptsetup -o /sbin/nlplug-findfs
 RUN mkinitfs -n -i /tmp/initramfs-init -o /initrd.gz
 
-FROM ${BUILDER} as build
-SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
-
 WORKDIR /out
-
-RUN mkdir -p /out/etc/apk /out/boot && cp -r /etc/apk/* /out/etc/apk/
-RUN apk add --no-cache --initdb -p /out \
-  busybox=1.29.3-r10        \
-  mtools=4.0.23-r0          \
-  dosfstools=4.1-r1         \
-  libarchive-tools=3.3.3-r1 \
-  sgdisk=1.0.4-r0           \
-  e2fsprogs=~1.44.5         \
-  util-linux=2.33-r0        \
-  squashfs-tools=4.3-r5     \
-  coreutils=8.30-r0         \
-  tar=1.32-r0
-
-COPY make-raw install grub.cfg.in UsbInvocationScript.txt /out/
-
+RUN mkdir -p boot
 RUN echo "mtools_skip_check=1" >> etc/mtools.conf
+COPY make-raw install grub.cfg.in UsbInvocationScript.txt ./
 
 FROM scratch
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
 COPY --from=build /out/ /
-COPY --from=initrd /initrd.gz /
+COPY --from=build /initrd.gz /
 COPY grub.stage1 /usr/lib/grub/i386-pc/boot.img
 RUN gzip -d < /initrd.gz | cpio -id && \
     rm -f /etc/mtab /dev/null && \

--- a/pkg/mkimage-raw-efi/Dockerfile
+++ b/pkg/mkimage-raw-efi/Dockerfile
@@ -4,7 +4,7 @@
 #   /EFI/BOOT/grub.cfg - Chainloads main bootloader
 #   /UsbInvocationScript.txt - Enables USB boot on Dell 3000 series
 #
-FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+FROM lfedge/eve-alpine:6.2.0 as build
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 ENV BUILD_PKGS mkinitfs gcc musl-dev linux-headers kmod-dev util-linux-dev cryptsetup-dev
 ENV PKGS mtools dosfstools libarchive-tools sgdisk e2fsprogs util-linux squashfs-tools coreutils tar

--- a/pkg/mkrootfs-ext4/Dockerfile
+++ b/pkg/mkrootfs-ext4/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 AS build
+FROM lfedge/eve-alpine:6.2.0 AS build
 
 ENV PKGS dosfstools libarchive-tools binutils mtools sfdisk sgdisk xfsprogs \
          e2fsprogs util-linux coreutils multipath-tools squashfs-tools

--- a/pkg/mkrootfs-squash/Dockerfile
+++ b/pkg/mkrootfs-squash/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 AS build
+FROM lfedge/eve-alpine:6.2.0 AS build
 
 ENV PKGS dosfstools libarchive-tools binutils mtools sfdisk sgdisk \
     xfsprogs e2fsprogs util-linux coreutils multipath-tools squashfs-tools

--- a/pkg/new-kernel/Dockerfile
+++ b/pkg/new-kernel/Dockerfile
@@ -1,5 +1,5 @@
 # This file must be kept as much in sync with pkg/kernel/Dockerfile as posisble
-FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 AS kernel-build
+FROM lfedge/eve-alpine:6.2.0 AS kernel-build
 
 ENV BUILD_PKGS \
     argp-standalone automake bash bc binutils-dev bison build-base curl \

--- a/pkg/newlog/Dockerfile
+++ b/pkg/newlog/Dockerfile
@@ -1,19 +1,16 @@
-ARG GOVER=1.15.3
-FROM golang:${GOVER}-alpine as build
-RUN apk add --no-cache   \
-        libc-dev=0.7.2-r3\
-        git=2.26.2-r0    \
-        gcc=9.3.0-r2     \
-        linux-headers=5.4.5-r1
+FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+ENV BUILD_PKGS libc-dev git gcc linux-headers go
+RUN eve-alpine-deploy.sh
 
 COPY ./  /newlog/.
 WORKDIR /newlog
 
 RUN GO111MODULE=on CGO_ENABLED=1 go build -mod=vendor -o newlogd ./cmd
 RUN strip newlogd
+RUN cp newlogd /out/usr/bin
 
-FROM alpine:3.8
-COPY --from=build /newlog/newlogd /usr/bin
+FROM scratch
+COPY --from=build /out/ /
 COPY newlogd-init.sh /newlogd-init.sh
 
 WORKDIR /newlog

--- a/pkg/newlog/Dockerfile
+++ b/pkg/newlog/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+FROM lfedge/eve-alpine:6.2.0 as build
 ENV BUILD_PKGS libc-dev git gcc linux-headers go
 ENV PKGS alpine-baselayout musl-utils
 RUN eve-alpine-deploy.sh

--- a/pkg/newlog/Dockerfile
+++ b/pkg/newlog/Dockerfile
@@ -1,5 +1,6 @@
 FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
 ENV BUILD_PKGS libc-dev git gcc linux-headers go
+ENV PKGS alpine-baselayout musl-utils
 RUN eve-alpine-deploy.sh
 
 COPY ./  /newlog/.

--- a/pkg/pillar/Dockerfile.in
+++ b/pkg/pillar/Dockerfile.in
@@ -1,8 +1,8 @@
 # Copyright (c) 2018 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+FROM lfedge/eve-alpine:067cf626c97b9bf0aa84843b84bb8a6a681a936f as build
 ENV BUILD_PKGS git gcc linux-headers libc-dev make linux-pam-dev m4 findutils go util-linux make patch wget
-ENV PKGS yajl xz bash openssl iptables ip6tables iproute2 dhcpcd coreutils dmidecode libbz2 libuuid ipset curl radvd ethtool util-linux e2fsprogs libcrypto1.1 xorriso qemu-img jq e2fsprogs-extra keyutils ca-certificates
+ENV PKGS alpine-baselayout musl-utils libtasn1-progs pciutils yajl xz bash openssl iptables ip6tables iproute2 dhcpcd coreutils dmidecode libbz2 libuuid ipset curl radvd ethtool util-linux e2fsprogs libcrypto1.1 xorriso qemu-img jq e2fsprogs-extra keyutils ca-certificates ip6tables-openrc iptables-openrc ipset-openrc hdparm
 RUN eve-alpine-deploy.sh
 
 RUN mkdir -p /go/src/github.com/google

--- a/pkg/pillar/Dockerfile.in
+++ b/pkg/pillar/Dockerfile.in
@@ -34,7 +34,7 @@ WORKDIR /pillar
 COPY pillar-patches/* /patches/
 RUN set -e && for patch in ../patches/*.patch; do \
         echo "Applying $patch"; \
-        patch -p1 < "$patch"; \
+        patch -p1 --no-backup-if-mismatch -r /tmp/deleteme.rej < "$patch"; \
     done
 
 RUN [ -z "$GOARCH" ] || export CC=$(echo /*-cross/bin/*-gcc) ;\

--- a/pkg/pillar/Dockerfile.in
+++ b/pkg/pillar/Dockerfile.in
@@ -1,6 +1,6 @@
 # Copyright (c) 2018 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:067cf626c97b9bf0aa84843b84bb8a6a681a936f as build
+FROM lfedge/eve-alpine:6.2.0 as build
 ENV BUILD_PKGS git gcc linux-headers libc-dev make linux-pam-dev m4 findutils go util-linux make patch wget
 ENV PKGS alpine-baselayout musl-utils libtasn1-progs pciutils yajl xz bash openssl iptables ip6tables iproute2 dhcpcd coreutils dmidecode libbz2 libuuid ipset curl radvd ethtool util-linux e2fsprogs libcrypto1.1 xorriso qemu-img jq e2fsprogs-extra keyutils ca-certificates ip6tables-openrc iptables-openrc ipset-openrc hdparm
 RUN eve-alpine-deploy.sh

--- a/pkg/pillar/Dockerfile.in
+++ b/pkg/pillar/Dockerfile.in
@@ -1,11 +1,9 @@
 # Copyright (c) 2018 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-ARG GOVER=1.15.3
-FROM lfedge/eve-alpine:ac1dc159510afa61334222cedf085c7730e4583c as fscrypt-build
-
-RUN apk add --no-cache git=2.20.2-r0 gcc=8.3.0-r0 linux-headers=4.18.13-r1 \
-                       libc-dev=0.7.1-r0 make=4.2.1-r2 linux-pam-dev=1.3.0-r0 \
-                       m4=1.4.18-r1 findutils=4.6.0-r1 go=1.11.5-r0
+FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+ENV BUILD_PKGS git gcc linux-headers libc-dev make linux-pam-dev m4 findutils go util-linux make patch wget
+ENV PKGS yajl xz bash openssl iptables ip6tables iproute2 dhcpcd coreutils dmidecode libbz2 libuuid ipset curl radvd ethtool util-linux e2fsprogs libcrypto1.1 xorriso qemu-img jq e2fsprogs-extra keyutils ca-certificates
+RUN eve-alpine-deploy.sh
 
 RUN mkdir -p /go/src/github.com/google
 WORKDIR /go/src/github.com/google
@@ -15,12 +13,9 @@ RUN git reset --hard b41569d397d3e66099cde07d8eef36b2f42dd0ec
 COPY fscrypt/* ./
 RUN patch -p1 < patch01-no-pam.diff && \
     patch -p1 < patch02-rotate-raw-key.diff && \
-    make && make install
-
-ARG GOVER=1.15.3
-FROM golang:${GOVER}-alpine as build
-RUN apk update
-RUN apk add --no-cache git gcc linux-headers libc-dev util-linux make patch
+    patch -p1 < patch03-vendor.diff && \
+    patch -p1 < patch04-goConv.diff && \
+    make && make DESTDIR=/out/opt/zededa/bin install
 
 # These three are supporting rudimentary cross-build capabilities.
 # The only one supported so far is cross compiling for aarch64 on x86
@@ -29,7 +24,7 @@ ENV GO111MODULE=on
 ENV CGO_ENABLED=1
 ARG GOARCH=
 ARG CROSS_GCC=https://musl.cc/aarch64-linux-musleabi-cross.tgz
-RUN [ -z "$GOARCH" ] || (cd / ; apk add --no-cache wget && wget -O - $CROSS_GCC | tar xzvf -)
+RUN [ -z "$GOARCH" ] || wget -O - $CROSS_GCC | tar -C / -xzvf -
 
 ADD ./  /pillar/
 
@@ -46,7 +41,15 @@ RUN [ -z "$GOARCH" ] || export CC=$(echo /*-cross/bin/*-gcc) ;\
     echo "Running go vet" && go vet ./... && \
     echo "Running go fmt" && ERR=$(gofmt -e -l -s $(find . -name \*.go | grep -v /vendor/)) && \
        if [ -n "$ERR" ] ; then echo "go fmt Failed - ERR: "$ERR ; exit 1 ; fi && \
-    make DISTDIR=/dist build
+    make DISTDIR=/out/opt/zededa/bin build
+
+WORKDIR /
+COPY patches/* /sys-patches/
+# hadolint ignore=SC1097
+RUN set -e && for patch in /sys-patches/*.patch; do \
+        echo "Applying $patch"; \
+        patch -p0 < "$patch"; \
+    done
 
 # hadolint ignore=DL3006
 FROM DNSMASQ_TAG as dnsmasq
@@ -55,15 +58,13 @@ FROM STRONGSWAN_TAG as strongswan
 # hadolint ignore=DL3006
 FROM GPTTOOLS_TAG as gpttools
 
-FROM alpine:3.8
+FROM scratch
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
-RUN apk add --no-cache \
-    yajl xz bash openssl iptables ip6tables iproute2 dhcpcd      \
-    coreutils dmidecode libbz2 libuuid ipset       \
-    curl radvd ethtool \
-    util-linux e2fsprogs libcrypto1.0 xorriso qemu-img \
-    jq e2fsprogs-extra keyutils ca-certificates
+COPY --from=build /out/ /
+COPY --from=gpttools / /
+COPY --from=dnsmasq /usr/sbin/dnsmasq /opt/zededa/bin/dnsmasq
+COPY --from=strongswan / /
 
 # We have to make sure configs survive in some location, but they don't pollute
 # the default /config (since that is expected to be an empty mount point)
@@ -76,24 +77,12 @@ ADD scripts/device-steps.sh \
   /opt/zededa/bin/
 ADD conf/lisp.config.base /var/tmp/zededa/lisp.config.base
 
-COPY patches/* /patches/
-RUN set -e && for patch in ../patches/*.patch; do \
-        echo "Applying $patch"; \
-        patch -p1 < "$patch"; \
-    done
-
-COPY --from=build /dist /opt/zededa/bin
-COPY --from=gpttools / /
-COPY --from=dnsmasq /usr/sbin/dnsmasq /opt/zededa/bin/dnsmasq
-COPY --from=strongswan / /
-COPY --from=fscrypt-build /usr/local/bin/fscrypt /opt/zededa/bin/fscrypt
-
 # And now a few local tweaks
 COPY rootfs/ /
 
 # We will start experimenting with stripping go binaries on ARM only for now
 RUN if [ "$(uname -m)" = "aarch64" ] ; then                                             \
-       apk add --no-cache findutils=4.6.0-r1 binutils=2.30-r6 file=5.32-r2             ;\
+       apk add --no-cache findutils binutils file                                      ;\
        find / -type f -executable -exec file {} \; | grep 'not stripped' | cut -f1 -d: |\
        xargs strip                                                                     ;\
        apk del findutils binutils file                                                 ;\
@@ -103,4 +92,4 @@ SHELL ["/bin/sh", "-c"]
 
 # FIXME: replace with tini+monit ASAP
 WORKDIR /
-CMD /init.sh
+CMD ["/init.sh"]

--- a/pkg/pillar/fscrypt/patch03-vendor.diff
+++ b/pkg/pillar/fscrypt/patch03-vendor.diff
@@ -1,0 +1,35 @@
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index 60e0f7e..6b43261 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -1,17 +1,26 @@
+ # github.com/golang/protobuf v1.2.0
+-github.com/golang/protobuf/proto
++## explicit
+ github.com/golang/protobuf/jsonpb
++github.com/golang/protobuf/proto
+ github.com/golang/protobuf/ptypes/struct
+ # github.com/pkg/errors v0.8.0
++## explicit
+ github.com/pkg/errors
+ # github.com/urfave/cli v1.20.0
++## explicit
+ github.com/urfave/cli
+ # golang.org/x/crypto v0.0.0-20180820150726-614d502a4dac
+-golang.org/x/crypto/ssh/terminal
++## explicit
+ golang.org/x/crypto/argon2
+-golang.org/x/crypto/hkdf
+ golang.org/x/crypto/blake2b
++golang.org/x/crypto/hkdf
++golang.org/x/crypto/ssh/terminal
++# golang.org/x/net v0.0.0-20180826012351-8a410e7b638d
++## explicit
++# golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f
++## explicit
+ # golang.org/x/sys v0.0.0-20180828065106-d99a578cf41b
++## explicit
++golang.org/x/sys/cpu
+ golang.org/x/sys/unix
+ golang.org/x/sys/windows
+-golang.org/x/sys/cpu

--- a/pkg/pillar/fscrypt/patch04-goConv.diff
+++ b/pkg/pillar/fscrypt/patch04-goConv.diff
@@ -1,0 +1,13 @@
+diff --git a/pam/pam.h b/pam/pam.h
+index 09afb2e..d1e190b 100644
+--- a/pam/pam.h
++++ b/pam/pam.h
+@@ -23,7 +23,7 @@
+ #include <security/pam_appl.h>
+ 
+ // Conversation that will call back into Go code when appropriate.
+-const struct pam_conv *goConv;
++extern const struct pam_conv *goConv;
+ 
+ // CleaupFuncs are used to cleanup specific PAM data.
+ typedef void (*CleanupFunc)(pam_handle_t *pamh, void *data, int error_status);

--- a/pkg/pillar/patches/001-dhcpcd-no-resolv-conf.patch
+++ b/pkg/pillar/patches/001-dhcpcd-no-resolv-conf.patch
@@ -1,5 +1,5 @@
---- /usr/lib/dhcpcd/dhcpcd-hooks/20-resolv.conf
-+++ /usr/lib/dhcpcd/dhcpcd-hooks/20-resolv.conf
+--- out/usr/lib/dhcpcd/dhcpcd-hooks/20-resolv.conf
++++ out/usr/lib/dhcpcd/dhcpcd-hooks/20-resolv.conf
 @@ -62,8 +62,8 @@
  	else
  		echo "# /etc/resolv.conf.tail can replace this line" >> "$cf"

--- a/pkg/pillar/patches/001-dhcpcd-no-resolv-conf.patch
+++ b/pkg/pillar/patches/001-dhcpcd-no-resolv-conf.patch
@@ -1,6 +1,6 @@
 --- out/usr/lib/dhcpcd/dhcpcd-hooks/20-resolv.conf
 +++ out/usr/lib/dhcpcd/dhcpcd-hooks/20-resolv.conf
-@@ -62,8 +62,8 @@
+@@ -63,8 +63,8 @@
  	else
  		echo "# /etc/resolv.conf.tail can replace this line" >> "$cf"
  	fi

--- a/pkg/qrexec-dom0/Dockerfile.in
+++ b/pkg/qrexec-dom0/Dockerfile.in
@@ -1,6 +1,6 @@
 FROM XENTOOLS_TAG as xentools
 FROM QREXECLIB_TAG as qrexec_lib
-FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+FROM lfedge/eve-alpine:6.2.0 as build
 ENV BUILD_PKGS gcc make libc-dev linux-headers git pkgconf
 RUN eve-alpine-deploy.sh
 

--- a/pkg/qrexec-lib/Dockerfile.in
+++ b/pkg/qrexec-lib/Dockerfile.in
@@ -1,6 +1,6 @@
 FROM XENTOOLS_TAG as xentools
 
-FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+FROM lfedge/eve-alpine:6.2.0 as build
 ENV BUILD_PKGS gcc make libc-dev linux-headers git pkgconf
 ENV PKGS libc-dev
 RUN eve-alpine-deploy.sh

--- a/pkg/rngd/Dockerfile
+++ b/pkg/rngd/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 AS build
+FROM lfedge/eve-alpine:6.2.0 AS build
 ENV BUILD_PKGS go gcc musl-dev linux-headers
 RUN eve-alpine-deploy.sh
 

--- a/pkg/storage-init/Dockerfile
+++ b/pkg/storage-init/Dockerfile
@@ -1,5 +1,5 @@
 FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
-ENV PKGS bash glib squashfs-tools util-linux e2fsprogs e2fsprogs-extra keyutils dosfstools coreutils sgdisk smartmontools
+ENV PKGS alpine-baselayout musl-utils bash glib squashfs-tools util-linux e2fsprogs e2fsprogs-extra keyutils dosfstools coreutils sgdisk smartmontools
 RUN eve-alpine-deploy.sh
 
 FROM scratch

--- a/pkg/storage-init/Dockerfile
+++ b/pkg/storage-init/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+FROM lfedge/eve-alpine:6.2.0 as build
 ENV PKGS alpine-baselayout musl-utils bash glib squashfs-tools util-linux e2fsprogs e2fsprogs-extra keyutils dosfstools coreutils sgdisk smartmontools
 RUN eve-alpine-deploy.sh
 

--- a/pkg/storage-init/Dockerfile
+++ b/pkg/storage-init/Dockerfile
@@ -1,9 +1,11 @@
-FROM alpine:3.12
-WORKDIR /
-# hadolint ignore=DL3018
-RUN apk add --no-cache bash glib squashfs-tools util-linux e2fsprogs \
-        e2fsprogs-extra keyutils dosfstools coreutils sgdisk smartmontools=7.1-r2
+FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+ENV PKGS bash glib squashfs-tools util-linux e2fsprogs e2fsprogs-extra keyutils dosfstools coreutils sgdisk smartmontools
+RUN eve-alpine-deploy.sh
+
+FROM scratch
+COPY --from=build /out/ /
 COPY storage-init.sh /
 
+WORKDIR /
 ENTRYPOINT []
 CMD ["/storage-init.sh"]

--- a/pkg/strongswan/Dockerfile
+++ b/pkg/strongswan/Dockerfile
@@ -2,7 +2,6 @@
 # StrongSwan VPN + Alpine Linux
 #
 
-# derived from Alpine 3.8
 FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
 ENV BUILD_PKGS gcc make patch libc-dev linux-headers tar build-base ca-certificates iptables iproute2 openssl openssl-dev
 RUN eve-alpine-deploy.sh

--- a/pkg/strongswan/Dockerfile
+++ b/pkg/strongswan/Dockerfile
@@ -3,7 +3,9 @@
 #
 
 # derived from Alpine 3.8
-FROM linuxkit/alpine:4d13c6209a679fc7c4e850f144b7aef879914d01 as build
+FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+ENV BUILD_PKGS gcc make patch libc-dev linux-headers tar build-base ca-certificates iptables iproute2 openssl openssl-dev
+RUN eve-alpine-deploy.sh
 
 ENV STRONGSWAN_RELEASE https://download.strongswan.org/strongswan.tar.bz2
 ENV CONFIGURE_OPTS_x86_64 --enable-aesni
@@ -41,24 +43,9 @@ ENV CONFIGURE_OPTS --prefix=/usr \
             --enable-sha2 \
             --disable-static
 
-RUN apk add --no-cache \
-    gcc \
-    make \
-    patch \
-    libc-dev \
-    linux-headers \
-    tar
-
 WORKDIR /tmp/strongswan
 RUN mkdir -p /tmp/strongswan
 RUN mkdir -p /out
-
-RUN apk --update add build-base \
-            ca-certificates \
-            iptables \
-            iproute2 \
-	    openssl \
-            openssl-dev
 
 # FIXME: two reasons to build it instead of using the
 # stock one:

--- a/pkg/strongswan/Dockerfile
+++ b/pkg/strongswan/Dockerfile
@@ -2,7 +2,7 @@
 # StrongSwan VPN + Alpine Linux
 #
 
-FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+FROM lfedge/eve-alpine:6.2.0 as build
 ENV BUILD_PKGS gcc make patch libc-dev linux-headers tar build-base ca-certificates iptables iproute2 openssl openssl-dev
 RUN eve-alpine-deploy.sh
 

--- a/pkg/strongswan/Dockerfile
+++ b/pkg/strongswan/Dockerfile
@@ -43,20 +43,19 @@ ENV CONFIGURE_OPTS --prefix=/usr \
             --disable-static
 
 WORKDIR /tmp/strongswan
-RUN mkdir -p /tmp/strongswan
-RUN mkdir -p /out
+RUN rm -rf /out && mkdir /out
 
 # FIXME: two reasons to build it instead of using the
 # stock one:
 #    1. alpine 3.6+ now has a conflict with libressl for curl-dev
 #    2. linuxkit alpine image doesn't have curl-dev (because of #1?)
 COPY curl-7.61.1.tar.bz2 /tmp/curl-7.61.1.tar.bz2
-RUN tar -C /tmp -xjvf /tmp/curl-7.61.1.tar.bz2 ; cd /tmp/curl-7.61.1 ; ./configure --prefix=/usr ; make install
+RUN tar -C /tmp -xjvf /tmp/curl-7.61.1.tar.bz2 ; cd /tmp/curl-7.61.1 ; ./configure --prefix=/usr ; make  -j "$(getconf _NPROCESSORS_ONLN)" install
 
 COPY strongswan.tar.bz2 /tmp/strongswan/strongswan.tar.bz2 
 RUN  tar --strip-components=1 -C /tmp/strongswan -xjf /tmp/strongswan/strongswan.tar.bz2
 RUN  eval ./configure $CONFIGURE_OPTS \$CONFIGURE_OPTS_`uname -m`
-RUN    make 
+RUN    make  -j "$(getconf _NPROCESSORS_ONLN)"
 RUN    make install DESTDIR=/out
 
 FROM scratch

--- a/pkg/u-boot/Dockerfile
+++ b/pkg/u-boot/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+FROM lfedge/eve-alpine:6.2.0 as build
 ENV BUILD_PKGS binutils-dev build-base bc curl bison flex openssl-dev python3 swig
 ENV BUILD_PKGS_amd64 python3-dev
 RUN eve-alpine-deploy.sh

--- a/pkg/uefi/Dockerfile
+++ b/pkg/uefi/Dockerfile
@@ -9,7 +9,7 @@
 #   git clone https://git.linaro.org/uefi/uefi-tools.git
 #   ./uefi-tools/edk2-build.sh -b DEBUG -b RELEASE all
 #
-FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+FROM lfedge/eve-alpine:6.2.0 as build
 ENV BUILD_PKGS curl make gcc g++ python3 libuuid iasl nasm util-linux-dev bash git util-linux patch
 RUN eve-alpine-deploy.sh
 

--- a/pkg/vtpm/Dockerfile
+++ b/pkg/vtpm/Dockerfile
@@ -9,6 +9,7 @@
 FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
 ENV BUILD_PKGS linux-headers git gcc g++ autoconf automake libtool doxygen make \
                openssl-dev protobuf-dev gnupg curl-dev patch
+ENV PKGS alpine-baselayout musl-utils
 RUN eve-alpine-deploy.sh
 
 WORKDIR /

--- a/pkg/vtpm/Dockerfile
+++ b/pkg/vtpm/Dockerfile
@@ -51,6 +51,7 @@ RUN make && cp vtpm_server /out/usr/bin/
 # install dependencies
 WORKDIR /usr/lib
 RUN cp libstdc++.so.6 libgcc_s.so.1 libprotobuf.so.24.0.0 /out/usr/lib/
+RUN ln -s libprotobuf.so.24.0.0 /out/usr/lib/libprotobuf.so.24
 WORKDIR /usr/local/lib
 RUN cp libtss2-tctildr.so.0 libtss2-rc.so.0 libtss2-mu.so.0 libtss2-esys.so.0 \
        libtss2-sys.so.0.0.0 libtss2-sys.so.0 libtss2-tcti-device.so.0 /out/usr/local/lib/

--- a/pkg/vtpm/Dockerfile
+++ b/pkg/vtpm/Dockerfile
@@ -6,7 +6,7 @@
 #    and the server
 
 #Build TPM2-TSS and TPM2-TOOLS
-FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+FROM lfedge/eve-alpine:6.2.0 as build
 ENV BUILD_PKGS linux-headers git gcc g++ autoconf automake libtool doxygen make \
                openssl-dev protobuf-dev gnupg curl-dev patch
 ENV PKGS alpine-baselayout musl-utils

--- a/pkg/vtpm/Dockerfile
+++ b/pkg/vtpm/Dockerfile
@@ -6,13 +6,10 @@
 #    and the server
 
 #Build TPM2-TSS and TPM2-TOOLS
-FROM lfedge/eve-alpine:7f9eb149210025d124027b8c31d6e72fae726da9 as build
-RUN apk add --no-cache linux-headers=4.18.13-r1 git=2.20.2-r0 \
-                          gcc=8.3.0-r0 g++=8.3.0-r0 autoconf=2.69-r2 \
-                          automake=1.16.1-r0 libtool=2.4.6-r5 \
-                          doxygen=1.8.15-r0 make=4.2.1-r2 \
-                          openssl-dev=1.1.1d-r2 protobuf-dev=3.6.1-r1 \
-                          gnupg=2.2.19-r0 curl-dev=7.64.0-r3
+FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+ENV BUILD_PKGS linux-headers git gcc g++ autoconf automake libtool doxygen make \
+               openssl-dev protobuf-dev gnupg curl-dev patch
+RUN eve-alpine-deploy.sh
 
 WORKDIR /
 RUN wget https://ftpmirror.gnu.org/autoconf-archive/autoconf-archive-2019.01.06.tar.xz && \
@@ -41,57 +38,26 @@ COPY patch-tpm2-tools.diff .
 RUN patch -p1 < patch-tpm2-tools.diff && \
     ./bootstrap && ./configure && make
 
-RUN mkdir /out
-RUN cp lib/.libs/libcommon.so* /out/
-RUN cp tools/.libs/tpm2_* /out/
+RUN mkdir -p /out/usr/local/lib
+RUN cp lib/.libs/libcommon.so* /out/usr/local/lib/
+RUN cp tools/.libs/tpm2_* /out/usr/bin/
 
 #The vTPM server
 COPY ./ /vtpm_server
 WORKDIR /vtpm_server
-RUN make
+RUN make && cp vtpm_server /out/usr/bin/
+
+# install dependencies
+WORKDIR /usr/lib
+RUN cp libstdc++.so.6 libgcc_s.so.1 libprotobuf.so.24.0.0 /out/usr/lib/
+WORKDIR /usr/local/lib
+RUN cp libtss2-tctildr.so.0 libtss2-rc.so.0 libtss2-mu.so.0 libtss2-esys.so.0 \
+       libtss2-sys.so.0.0.0 libtss2-sys.so.0 libtss2-tcti-device.so.0 /out/usr/local/lib/
 
 #Pull a selected set of artifacts into the final stage.
-FROM alpine:3.9
+FROM scratch
 
-COPY --from=build /usr/lib/libstdc++.so.6 /usr/lib
-COPY --from=build /usr/lib/libgcc_s.so.1 /usr/lib
-COPY --from=build /usr/lib/libprotobuf.so.17  /usr/lib/
-COPY --from=build /usr/lib/libprotobuf.so.17.0.0 /usr/lib/
-COPY --from=build /usr/local/lib/libtss2-tctildr.so.0 /usr/local/lib
-COPY --from=build /usr/local/lib/libtss2-rc.so.0 /usr/local/lib
-COPY --from=build /usr/local/lib/libtss2-mu.so.0 /usr/local/lib
-COPY --from=build /usr/local/lib/libtss2-esys.so.0 /usr/local/lib
-COPY --from=build /usr/local/lib/libtss2-sys.so.0.0.0 /usr/local/lib
-COPY --from=build /usr/local/lib/libtss2-sys.so.0 /usr/local/lib
-COPY --from=build /usr/local/lib/libtss2-tcti-device.so.0 /usr/local/lib
-COPY --from=build /out/libcommon.so.0.0.0 /usr/local/lib
-COPY --from=build /out/libcommon.so.0 /usr/local/lib
-COPY --from=build /out/libcommon.so /usr/local/lib
-COPY --from=build /out/tpm2_createek /usr/bin/
-COPY --from=build /out/tpm2_createak /usr/bin/
-COPY --from=build /out/tpm2_createprimary /usr/bin/
-COPY --from=build /out/tpm2_getcap /usr/bin/
-COPY --from=build /out/tpm2_sign /usr/bin/
-COPY --from=build /out/tpm2_verifysignature /usr/bin/
-COPY --from=build /out/tpm2_evictcontrol /usr/bin/
-COPY --from=build /out/tpm2_import /usr/bin/
-COPY --from=build /out/tpm2_load /usr/bin/
-COPY --from=build /out/tpm2_hmac /usr/bin/
-COPY --from=build /out/tpm2_hash /usr/bin/
-COPY --from=build /out/tpm2_readpublic /usr/bin/
-COPY --from=build /out/tpm2_activatecredential /usr/bin
-COPY --from=build /out/tpm2_makecredential /usr/bin
-COPY --from=build /out/tpm2_dictionarylockout /usr/bin
-COPY --from=build /out/tpm2_startauthsession /usr/bin
-COPY --from=build /out/tpm2_policysecret /usr/bin
-COPY --from=build /out/tpm2_policypassword /usr/bin
-COPY --from=build /out/tpm2_policycommandcode /usr/bin
-COPY --from=build /out/tpm2_create /usr/bin
-COPY --from=build /out/tpm2_loadexternal /usr/bin
-COPY --from=build /out/tpm2_duplicate /usr/bin
-COPY --from=build /out/tpm2_flushcontext /usr/bin
-COPY --from=build /out/tpm2_rsadecrypt /usr/bin
-COPY --from=build /vtpm_server/vtpm_server /usr/bin/
+COPY --from=build /out/ /
 COPY init.sh /usr/bin/
 ENTRYPOINT []
 WORKDIR /

--- a/pkg/watchdog/Dockerfile
+++ b/pkg/watchdog/Dockerfile
@@ -2,6 +2,7 @@
 
 FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 AS watchdog-build
 ENV BUILD_PKGS build-base file libtirpc-dev linux-headers tar
+ENV PKGS alpine-baselayout musl-utils
 RUN eve-alpine-deploy.sh
 
 # Version 5.15

--- a/pkg/watchdog/Dockerfile
+++ b/pkg/watchdog/Dockerfile
@@ -1,13 +1,9 @@
 # Build watchdogd for alpine
 
 # derived from Alpine 3.8
-FROM linuxkit/alpine:4d13c6209a679fc7c4e850f144b7aef879914d01 AS watchdog-build
-RUN apk add \
-    build-base \
-    file \
-    libtirpc-dev \
-    linux-headers \
-    tar
+FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 AS watchdog-build
+ENV BUILD_PKGS build-base file libtirpc-dev linux-headers tar
+RUN eve-alpine-deploy.sh
 
 # Version 5.15
 ENV WATCHDOGD_VERSION 5.15
@@ -39,11 +35,9 @@ ENV CONFIGURE_OPTS "--disable-nfs"
 RUN \
     CPPFLAGS=-I/usr/include/tirpc ./configure ${CONFIGURE_OPTS} && make && make install DESTDIR=/out
 
-FROM alpine:3.8
+FROM scratch
 WORKDIR /
-COPY --from=watchdog-build /out/etc /etc
-COPY --from=watchdog-build /out/usr/sbin /usr/sbin
-COPY --from=watchdog-build /out/usr/share /usr/share
+COPY --from=watchdog-build /out/ /
 COPY init.sh /
 COPY watchdog.conf.seed /etc/
 COPY watchdog-report.sh /sbin/

--- a/pkg/watchdog/Dockerfile
+++ b/pkg/watchdog/Dockerfile
@@ -1,6 +1,6 @@
 # Build watchdogd for alpine
 
-FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 AS watchdog-build
+FROM lfedge/eve-alpine:6.2.0 AS watchdog-build
 ENV BUILD_PKGS build-base file libtirpc-dev linux-headers tar
 ENV PKGS alpine-baselayout musl-utils
 RUN eve-alpine-deploy.sh

--- a/pkg/watchdog/Dockerfile
+++ b/pkg/watchdog/Dockerfile
@@ -1,6 +1,5 @@
 # Build watchdogd for alpine
 
-# derived from Alpine 3.8
 FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 AS watchdog-build
 ENV BUILD_PKGS build-base file libtirpc-dev linux-headers tar
 RUN eve-alpine-deploy.sh

--- a/pkg/wlan/Dockerfile
+++ b/pkg/wlan/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+FROM lfedge/eve-alpine:6.2.0 as build
 ENV PKGS alpine-baselayout musl-utils wireless-tools wpa_supplicant
 RUN eve-alpine-deploy.sh
 

--- a/pkg/wlan/Dockerfile
+++ b/pkg/wlan/Dockerfile
@@ -1,12 +1,11 @@
-FROM alpine:3.8 as build
-
-WORKDIR /
-
-RUN apk add --no-cache \
-    wireless-tools \
-    wpa_supplicant 
+FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+ENV PKGS wireless-tools wpa_supplicant
+RUN eve-alpine-deploy.sh
 
 COPY init.sh /init.sh
+
+FROM scratch
+COPY --from=build /out/ /
 
 ENTRYPOINT []
 CMD ["/init.sh"]

--- a/pkg/wlan/Dockerfile
+++ b/pkg/wlan/Dockerfile
@@ -1,11 +1,10 @@
 FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
-ENV PKGS wireless-tools wpa_supplicant
+ENV PKGS alpine-baselayout musl-utils wireless-tools wpa_supplicant
 RUN eve-alpine-deploy.sh
-
-COPY init.sh /init.sh
 
 FROM scratch
 COPY --from=build /out/ /
+COPY init.sh /init.sh
 
 ENTRYPOINT []
 CMD ["/init.sh"]

--- a/pkg/wwan/Dockerfile
+++ b/pkg/wwan/Dockerfile
@@ -1,21 +1,9 @@
-FROM alpine:3.12 as build
-
-RUN apk add --no-cache \
-    automake \
-    autoconf \
-    gettext \
-    gettext-dev \
-    git \
-    pkgconfig \
-    libtool \
-    libc-dev \
-    linux-headers \
-    gcc \
-    make \
-    glib-dev \
-    autoconf-archive \
-    patch \
-    cmake
+FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+ENV BUILD_PKGS automake autoconf gettext gettext-dev git pkgconfig \
+               libtool libc-dev linux-headers gcc make glib-dev \
+               autoconf-archive patch cmake
+ENV PKGS ppp jq glib
+RUN eve-alpine-deploy.sh
 
 WORKDIR /
 RUN git clone https://git.openwrt.org/project/uqmi.git
@@ -45,12 +33,11 @@ RUN git checkout 1.26.2 && ./autogen.sh --without-udev && ./configure --prefix=/
 RUN strip /usr/bin/*cli /usr/libexec/*proxy /usr/lib/libmbim*.so.* /usr/lib/libqmi*.so.*
 
 # second stage (new-ish Docker feature) for smaller image
-FROM alpine:3.12
-
-RUN apk add --no-cache ppp jq glib
+FROM scratch
 
 ENTRYPOINT []
 WORKDIR /
+COPY --from=build /out/ /
 COPY --from=build /uqmi/uqmi /usr/bin/qmicli /usr/bin/mbimcli /bin/
 COPY --from=build /usr/lib/libmbim*.so.[0-9] /usr/lib/libqmi*.so.[0-9] /usr/lib/
 COPY --from=build /usr/libexec/*proxy /usr/libexec/

--- a/pkg/wwan/Dockerfile
+++ b/pkg/wwan/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
+FROM lfedge/eve-alpine:6.2.0 as build
 ENV BUILD_PKGS automake autoconf gettext gettext-dev git pkgconfig \
                libtool libc-dev linux-headers gcc make glib-dev \
                autoconf-archive patch cmake

--- a/pkg/wwan/Dockerfile
+++ b/pkg/wwan/Dockerfile
@@ -2,7 +2,7 @@ FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as build
 ENV BUILD_PKGS automake autoconf gettext gettext-dev git pkgconfig \
                libtool libc-dev linux-headers gcc make glib-dev \
                autoconf-archive patch cmake
-ENV PKGS ppp jq glib
+ENV PKGS alpine-baselayout musl-utils ppp jq glib
 RUN eve-alpine-deploy.sh
 
 WORKDIR /

--- a/pkg/xen-tools/Dockerfile.in
+++ b/pkg/xen-tools/Dockerfile.in
@@ -24,7 +24,7 @@ ENV BUILD_PKGS \
     attr-dev flex bison cmake libusb-dev
 ENV BUILD_PKGS_arm64 dtc-dev
 
-ENV PKGS bash libaio libbz2 glib pixman yajl keyutils libusb xz-libs libuuid sudo
+ENV PKGS alpine-baselayout musl-utils bash libaio libbz2 glib pixman yajl keyutils libusb xz-libs libuuid sudo
 ENV PKGS_arm64 libfdt
 
 RUN eve-alpine-deploy.sh

--- a/pkg/xen-tools/Dockerfile.in
+++ b/pkg/xen-tools/Dockerfile.in
@@ -100,7 +100,7 @@ COPY qemu-ifup xen-start /etc/xen/scripts/
 RUN rm -rf /usr/lib/libxen*.a /usr/lib/libxl*.a /usr/lib/debug /usr/lib/python*
 
 # Adjust /var/run, /var/lib and /var/lock to be shared
-RUN mv /var /var.template && ln -s /run /var
+RUN mv /var /var.template && ln -s /run /var && ln -s /run /var.template/run
 
 # Add a few mountpoints so we can use lowerfs in R/O mode
 RUN mkdir /persist /hostfs

--- a/pkg/xen-tools/Dockerfile.in
+++ b/pkg/xen-tools/Dockerfile.in
@@ -1,8 +1,9 @@
 # hadolint ignore=DL3006
 FROM UEFI_TAG as uefi-build
 
-FROM lfedge/eve-alpine:3e3111a703366e9ac607d9c33d5fded006fa1df3 as runx-build
-RUN apk add --no-cache mkinitfs=3.4.1-r1 gcc=8.3.0-r0 musl-dev=1.1.20-r5 e2fsprogs=1.44.5-r1
+FROM lfedge/eve-alpine:ce776885c43588292126c2fcc7300b77a494faf3 as runx-build
+ENV BUILD_PKGS mkinitfs gcc musl-dev e2fsprogs
+RUN eve-alpine-deploy.sh
 
 RUN rm -f /sbin/poweroff /etc/mkinitfs/features.d/base.files
 COPY initrd/base.files /etc/mkinitfs/features.d/base.files
@@ -14,18 +15,20 @@ RUN gcc -s -o /chroot2 /tmp/chroot2.c
 RUN gcc -s -o /hacf /tmp/hacf.c
 RUN mkinitfs -n -F base -i /init-initrd -o /runx-initrd
 
-FROM alpine:3.12 as kernel-build
-ENV GIT_HTTP=y
-# hadolint ignore=DL3018
-RUN apk add --no-cache \
+FROM lfedge/eve-alpine:ce776885c43588292126c2fcc7300b77a494faf3 as build
+ENV BUILD_PKGS \
     gcc make libc-dev dev86 xz-dev perl bash python3-dev \
     gettext iasl util-linux-dev ncurses-dev glib-dev \
     pixman-dev libaio-dev yajl-dev argp-standalone \
     linux-headers git patch texinfo curl tar libcap-ng-dev \
     attr-dev flex bison cmake libusb-dev
+ENV BUILD_PKGS_arm64 dtc-dev
 
-# FIXME: this is really ugly -- we need to figure out xen tools dependencies
-RUN [ "$(uname -m)" = "aarch64" ] && apk add --no-cache dtc-dev || :
+ENV PKGS bash libaio libbz2 glib pixman yajl keyutils libusb xz-libs libuuid sudo
+ENV PKGS_arm64 libfdt
+
+ENV GIT_HTTP=y
+RUN eve-alpine-deploy.sh
 
 # Alpine linux defines all 64bit integer types as long. Patch
 # /usr/include/bits/alltypes.h to fix compilation with -m32
@@ -40,10 +43,6 @@ ENV LIBURING_SOURCE=https://git.kernel.dk/cgit/liburing/snapshot/liburing-${LIBU
 RUN \
     [ -f "$(basename ${LIBURING_SOURCE})" ] || curl -fsSLO "${LIBURING_SOURCE}" && \
     tar --absolute-names -xj < "$(basename ${LIBURING_SOURCE})" && mv "/liburing-${LIBURING_VERSION}" /liburing
-
-WORKDIR /liburing
-
-RUN mkdir -p /out
 
 WORKDIR /liburing
 RUN ./configure --prefix=/usr
@@ -90,21 +89,8 @@ WORKDIR /out/usr/lib/xen/bin/
 RUN strip * || :
 RUN if [ "$(uname -m)" = "x86_64" ]; then rm -f qemu-system-i386 && ln -s "qemu-system-$(uname -m)" qemu-system-i386 ;fi
 
-FROM alpine:3.12
-RUN apk add --no-cache \
-    bash=5.0.17-r0     \
-    libaio=0.3.112-r1  \
-    libbz2=1.0.8-r1    \
-    glib=2.64.6-r0     \
-    pixman=0.40.0-r2   \
-    yajl=2.1.0-r1      \
-    keyutils=1.6.1-r1  \
-    libusb=1.0.23-r0   \
-    xz-libs=5.2.5-r0   \
-    libuuid=2.35.2-r0  \
-    sudo=1.9.5p2-r0
-RUN if [ "$(uname -m)" = "aarch64" ]; then apk add --no-cache libfdt=1.6.0-r0 ;fi
-COPY --from=kernel-build /out/ /
+FROM scratch
+COPY --from=build /out/ /
 COPY --from=uefi-build /OVMF.fd /usr/lib/xen/boot/ovmf.bin
 COPY --from=uefi-build /OVMF_PVH.fd /usr/lib/xen/boot/ovmf-pvh.bin
 COPY --from=runx-build /runx-initrd /usr/lib/xen/boot/runx-initrd

--- a/pkg/xen-tools/Dockerfile.in
+++ b/pkg/xen-tools/Dockerfile.in
@@ -1,7 +1,7 @@
 # hadolint ignore=DL3006
 FROM UEFI_TAG as uefi-build
 
-FROM lfedge/eve-alpine:ce776885c43588292126c2fcc7300b77a494faf3 as runx-build
+FROM lfedge/eve-alpine:6.2.0 as runx-build
 ENV BUILD_PKGS mkinitfs gcc musl-dev e2fsprogs
 RUN eve-alpine-deploy.sh
 
@@ -15,7 +15,7 @@ RUN gcc -s -o /chroot2 /tmp/chroot2.c
 RUN gcc -s -o /hacf /tmp/hacf.c
 RUN mkinitfs -n -F base -i /init-initrd -o /runx-initrd
 
-FROM lfedge/eve-alpine:ce776885c43588292126c2fcc7300b77a494faf3 as build
+FROM lfedge/eve-alpine:6.2.0 as build
 ENV BUILD_PKGS \
     gcc make libc-dev dev86 xz-dev perl bash python3-dev \
     gettext iasl util-linux-dev ncurses-dev glib-dev \

--- a/pkg/xen-tools/Dockerfile.in
+++ b/pkg/xen-tools/Dockerfile.in
@@ -27,7 +27,6 @@ ENV BUILD_PKGS_arm64 dtc-dev
 ENV PKGS bash libaio libbz2 glib pixman yajl keyutils libusb xz-libs libuuid sudo
 ENV PKGS_arm64 libfdt
 
-ENV GIT_HTTP=y
 RUN eve-alpine-deploy.sh
 
 # Alpine linux defines all 64bit integer types as long. Patch

--- a/pkg/xen/Dockerfile
+++ b/pkg/xen/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 as kernel-build
+FROM lfedge/eve-alpine:6.2.0 as kernel-build
 
 ENV BUILD_PKGS argp-standalone automake bash bc binutils-dev bison build-base \
                curl diffutils flex git gmp-dev gnupg installkernel kmod \


### PR DESCRIPTION
This moves all runtime packages to be based off of the latest eve-alpine (mostly update to Dockerfiles with a few patches required for the gcc 10.x becoming more picky in detecting warnings/errors).