### PR TITLE
Updating eve-alpine cache and documenting the process for posterity

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -412,6 +412,8 @@ Packages are built within a docker container as defined by the `Dockerfile` with
 
 Packages are meant to be the building blocks for [reproducible builds](https://reproducible-builds.org/). Currently, however, the builds are not strictly speaking reproducible, but rather guaranteed. EVE build system is not bootstrapping everything from the source up, instead it uses [Alpine Linux](https://pkgs.alpinelinux.org/packages) as the source of binary artifacts. All of the Alpine binary packages that are consumed by EVE are collected in the Docker image archive and published under `lfedge/eve-alpine` name. That way, EVE build system *pins* all Alpine packages that it needs and can guarantee that they won't change until the archive is updated. All of the packages in the archive are listed under [mirrors](../pkg/alpine/mirrors) folder and the archive can be updated by updating that list. While currently re-building of the archive image is done by fetching required packages from the official Alpine mirrors, we can always add an additional step of bootstrapping all the same packages from source (which will give EVE true reproducible builds).
 
+Since updating content of the `lfedge/eve-alpine` package is a bit of an unusual process -- it is described in details in the [How to update eve-alpine package](#how-to-update-eve-alpine-package) section below.
+
 Reliance on `lfedge/eve-alpine` archive enforces a particular structure on individual Dockerfile from EVE packages. For one, they always start with `FROM lfedge/eve-alpine:TAG` and they always produce the final output in the `FROM scratch` step (to avoid layer dependency on the large `lfedge/eve-alpine` package). In addition, `lfedge/eve-alpine` archive package defines a helper script `eve-alpine-deploy.sh` that provides and easy entry point for setting up of the build environment and the final, Alpine-based output of the build. This helper script is driven by looking up the following environment variable (which are very similar to [Requires](https://docs.fedoraproject.org/en-US/packaging-guidelines/#_dependency_types) and [BuildRequires](https://docs.fedoraproject.org/en-US/packaging-guidelines/#buildrequires) in RPMs):
 
 * PKGS, PKGS_amd64, PKGS_arm64: used to list packages required for the final binary output of the build
@@ -627,3 +629,16 @@ Last but not least, is this completely necessary?
 
 * `images/*.yml`: The need to update `images/*.yml` is understood, as these packages change a lot. Even so, the utilities might be better structured as a separate external utility that is run manually. Most of the time, you just build from a static `rootfs.yml` or `installer.yml`. When you want to update them, you run `update-images` (or similar) and it updates them. Finally, you commit when a good build is ready.
 * `pkg/*/Dockerfile`: The need to generate `Dockerfile` for many of the packages may mean too much cross-dependency, which can be brittle. It is possible that this is necessary, and there is no other way around it. However, we should explore how we can simplify dependencies.
+
+## How to update eve-alpine package
+
+Unlike a lot of other Linux distributions, Alpine Linux doesn't provide historical versions of all its packages. In fact, Alpine Linux reserves the right to update packages with security patches behind the scenes resulting in content of Alpine x.y.z repositories shifting slightly from time to time. This, obviously, goes against the principle of reproducible builds and makes our `lfedge/eve-alpine` cache serve a double function: not only it is used to speed up the build, but it also may end up being the only place on the Internet where a certain Alpine Linux package version x.y.z could be available from.
+
+The latter aspect makes maintaining `lfedge/eve-alpine` a bit tricky, even though at its core it is simply driven by the list of packages recorded in the manifest files under [pkg/alpine/mirrors](../pkg/alpine/mirrors). Removing packages from the cache is not advisable (and should really only be done during major EVE version updates). Adding packages to the cache consists of two steps:
+
+1. adding new package names to the the right manifest file (under `pkg/alpine/mirrors/<BASE ALPINE VERSION>/[main|community]`)
+2. updating `FROM ... AS cache` line in [pkg/alpine/Dockerfile](../pkg/alpine/Dockerfile) to point to the last version of the cache
+
+Step #2 guarantees that all *existing* packages will simply be re-used from the previous version of the cache and *NOT* re-downloaded from the Alpine http mirrors (remember that re-downloading always runs the risk of getting a different version of the same package). Step #1, of course, will download new packages and pin them in the new version of the cache.
+
+If the above seems a bit confusing, don't despair: here's an [actual example](../../../commit/1340c1b6981ed3219f78a7a0209ff9222a0dacdf) of adding 4 new packages `libfdt`, `dtc`, `dtc-dev` and `uboot-tools` to the `lfedge/eve-alpine` cache.

--- a/pkg/alpine/Dockerfile
+++ b/pkg/alpine/Dockerfile
@@ -1,11 +1,11 @@
 ARG ALPINE_VERSION=3.13
-# FROM lfedge/eve-alpine:5.16.0 AS cache
+FROM lfedge/eve-alpine:99db0c3af59a9656315c9d7a0ad8a24f631134b0 AS cache
 
 FROM alpine:${ALPINE_VERSION} AS mirror
 ARG ALPINE_VERSION=3.13
 
 # pull packages from a *previous* mirror
-# COPY --from=cache /mirror /mirror
+COPY --from=cache /mirror /mirror
 
 # update base image
 RUN apk update && apk upgrade -a

--- a/pkg/alpine/mirrors/3.13/main
+++ b/pkg/alpine/mirrors/3.13/main
@@ -1,4 +1,3 @@
-
 abuild
 alpine-baselayout
 alpine-keys
@@ -31,6 +30,8 @@ diffutils
 dmidecode
 dosfstools
 doxygen
+dtc
+dtc-dev
 e2fsprogs
 e2fsprogs-extra
 elfutils-dev
@@ -69,6 +70,7 @@ libcap-ng-dev
 libcrypto1.1
 libestr-dev
 libfastjson-dev
+libfdt
 libgcrypt-dev
 libice-dev
 liblogging-dev
@@ -148,6 +150,7 @@ swig
 tar
 tcpdump
 texinfo
+uboot-tools
 usbutils
 util-linux
 util-linux-dev

--- a/pkg/eve/Dockerfile.in
+++ b/pkg/eve/Dockerfile.in
@@ -1,6 +1,7 @@
-FROM alpine:3.12 as tools
-RUN mkdir -p /out/etc/apk /out/boot && cp -r /etc/apk/* /out/etc/apk/
-RUN apk add --no-cache --initdb -p /out qemu-img=5.0.0-r2 tar=1.32-r1 uboot-tools=2020.04-r0 coreutils=8.32-r0
+FROM lfedge/eve-alpine:ce776885c43588292126c2fcc7300b77a494faf3 as tools
+ENV PKGS qemu-img tar uboot-tools coreutils
+RUN eve-alpine-deploy.sh
+
 # hadolint ignore=DL3006
 FROM MKISO_TAG as iso
 # hadolint ignore=DL3006


### PR DESCRIPTION
This updates the cache with `uboot-tools libfdt dtc-dev dtc` and also provided documentation around how to do that again in the future.