### PR TITLE
network overlap check; log gcp console; remove unneeded images

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -12,6 +12,14 @@ jobs:
     runs-on: ubuntu-20.04
     if: ${{ github.event.review.state == 'approved' || github.ref == 'refs/heads/master' }}
     steps:
+      - name: Check
+        run: |
+          for addr in $(ip addr list|sed -En -e 's/.*inet ([0-9.]+).*/\1/p')
+          do
+              if echo "$addr" | grep -q -E "10.11.(12|13).[0-9]+"; then
+                echo "$addr overlaps with test"; exit 1
+              fi
+          done
       - name: setup
         run: |
           sudo apt update
@@ -40,6 +48,7 @@ jobs:
           else
              make -C eve V=1 pkgs
              make -C eve V=1 ROOTFS_VERSION="$TAG" HV=kvm eve
+             docker rmi -f $(docker images --filter=reference="lfedge/eve-*" -q)||echo "skip conflicts"
           fi
           echo "TAG=$TAG" >> $GITHUB_ENV
       - name: run

--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -19,6 +19,17 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'lf-edge/eden'
+      - name: Check
+        run: |
+          for addr in $(ip addr list|sed -En -e 's/.*inet ([0-9.]+).*/\1/p')
+          do
+              if echo "$addr" | grep -q -E "10.11.(12|13).[0-9]+"; then
+                echo "$addr overlaps with test"; exit 1
+              fi
+              if echo "$addr" | grep -q -E "10.8.0.[0-9]+"; then
+                echo "$addr overlaps with vpn"; exit 1
+              fi
+          done
       - name: setup packages
         run: |
           sudo apt update
@@ -75,6 +86,7 @@ jobs:
           ./eden log --format json > trace.log
           ./eden info > info.log
           docker logs eden_adam > adam.log 2>&1
+          ./eden utils gcp vm log --vm-name eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} -k "$GOOGLE_APPLICATION_CREDENTIALS" > console.log
       - name: Clean
         if: ${{ always() }}
         run: |
@@ -91,3 +103,4 @@ jobs:
             ${{ github.workspace }}/trace.log
             ${{ github.workspace }}/info.log
             ${{ github.workspace }}/adam.log
+            ${{ github.workspace }}/console.log


### PR DESCRIPTION
Add checks for networks overlap inside hosted VM and Eden.
Remove unneeded images to save space inside VM.
Add GCP console to log.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>