### PR TITLE
Make pubsub SignalRestart more useful by carrying a counter

### DIFF
--- a/pkg/pillar/agentlog/agentlog_test.go
+++ b/pkg/pillar/agentlog/agentlog_test.go
@@ -138,10 +138,10 @@ func TestPubsubLog(t *testing.T) {
 	created := false
 	modified := false
 	deleted := false
-	subRestartHandler := func(ctxArg interface{}, arg bool) {
-		t.Logf("subRestartHandler")
-		if !arg {
-			t.Fatalf("subRestartHandler called with false")
+	subRestartHandler := func(ctxArg interface{}, restartCounter int) {
+		t.Logf("subRestartHandler %d", restartCounter)
+		if restartCounter == 0 {
+			t.Fatalf("subRestartHandler called with zero")
 		} else {
 			restarted = true
 		}

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -580,10 +580,10 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	}
 }
 
-func handleRestart(ctxArg interface{}, done bool) {
-	log.Functionf("handleRestart(%v)", done)
+func handleRestart(ctxArg interface{}, restartCounter int) {
+	log.Functionf("handleRestart(%d)", restartCounter)
 	ctx := ctxArg.(*domainContext)
-	if done {
+	if restartCounter != 0 {
 		log.Functionf("handleRestart: avoid cleanup")
 		ctx.pubDomainStatus.SignalRestarted()
 		return

--- a/pkg/pillar/cmd/volumemgr/handlecontent.go
+++ b/pkg/pillar/cmd/volumemgr/handlecontent.go
@@ -53,10 +53,12 @@ func handleContentTreeDelete(ctxArg interface{}, key string,
 	log.Functionf("handleContentTreeDelete(%s) Done", key)
 }
 
-func handleContentTreeRestart(ctxArg interface{}, done bool) {
-	log.Functionf("handleContentTreeRestart(%v)", done)
+func handleContentTreeRestart(ctxArg interface{}, restartCounter int) {
+	log.Functionf("handleContentTreeRestart(%d)", restartCounter)
 	ctx := ctxArg.(*volumemgrContext)
-	ctx.contentTreeRestarted = true
+	if restartCounter != 0 {
+		ctx.contentTreeRestarted = true
+	}
 }
 
 func publishContentTreeStatus(ctx *volumemgrContext, status *types.ContentTreeStatus) {

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -563,11 +563,11 @@ func gcUnusedInitObjects(ctx *volumemgrContext) {
 	gcImagesFromCAS(ctx)
 }
 
-func handleVerifierRestarted(ctxArg interface{}, done bool) {
+func handleVerifierRestarted(ctxArg interface{}, restartCounter int) {
 	ctx := ctxArg.(*volumemgrContext)
 
-	log.Functionf("handleVerifierRestarted(%v)", done)
-	if done {
+	log.Functionf("handleVerifierRestarted(%d)", restartCounter)
+	if restartCounter != 0 {
 		ctx.verifierRestarted = true
 	}
 }

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -1322,10 +1322,10 @@ func triggerPublishAllInfo(ctxPtr *zedagentContext) {
 	}()
 }
 
-func handleZbootRestarted(ctxArg interface{}, done bool) {
+func handleZbootRestarted(ctxArg interface{}, restartCounter int) {
 	ctx := ctxArg.(*zedagentContext)
-	log.Functionf("handleZbootRestarted(%v)", done)
-	if done {
+	log.Functionf("handleZbootRestarted(%d)", restartCounter)
+	if restartCounter != 0 {
 		ctx.zbootRestarted = true
 	}
 }

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -295,28 +295,28 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 // and finally from zedrouter to domainmgr.
 // XXX is that sequence still needed with volumemgr in place?
 // Need EIDs before zedrouter ...
-func handleConfigRestart(ctxArg interface{}, done bool) {
+func handleConfigRestart(ctxArg interface{}, restartCounter int) {
 	ctx := ctxArg.(*zedmanagerContext)
-	log.Functionf("handleConfigRestart(%v)", done)
-	if done {
+	log.Functionf("handleConfigRestart(%d)", restartCounter)
+	if restartCounter != 0 {
 		ctx.pubAppNetworkConfig.SignalRestarted()
 	}
 }
 
-func handleIdentitymgrRestarted(ctxArg interface{}, done bool) {
+func handleIdentitymgrRestarted(ctxArg interface{}, restartCounter int) {
 	ctx := ctxArg.(*zedmanagerContext)
 
-	log.Functionf("handleIdentitymgrRestarted(%v)", done)
-	if done {
+	log.Functionf("handleIdentitymgrRestarted(%d)", restartCounter)
+	if restartCounter != 0 {
 		ctx.pubAppNetworkConfig.SignalRestarted()
 	}
 }
 
-func handleZedrouterRestarted(ctxArg interface{}, done bool) {
+func handleZedrouterRestarted(ctxArg interface{}, restartCounter int) {
 	ctx := ctxArg.(*zedmanagerContext)
 
-	log.Functionf("handleZedrouterRestarted(%v)", done)
-	if done {
+	log.Functionf("handleZedrouterRestarted(%d)", restartCounter)
+	if restartCounter != 0 {
 		ctx.pubDomainConfig.SignalRestarted()
 	}
 }

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -608,11 +608,11 @@ func maybeHandleDNS(ctx *zedrouterContext) {
 	// XXX do a NatInactivate/NatActivate if management ports changed?
 }
 
-func handleRestart(ctxArg interface{}, done bool) {
+func handleRestart(ctxArg interface{}, restartCounter int) {
 
-	log.Tracef("handleRestart(%v)\n", done)
+	log.Tracef("handleRestart(%d)", restartCounter)
 	ctx := ctxArg.(*zedrouterContext)
-	if done {
+	if restartCounter != 0 {
 		// Since all work is done inline we can immediately say that
 		// we have restarted.
 		ctx.pubAppNetworkStatus.SignalRestarted()

--- a/pkg/pillar/pubsub/change.go
+++ b/pkg/pillar/pubsub/change.go
@@ -6,8 +6,8 @@ type Operation byte
 const (
 	// Restart operation is a restart
 	Restart Operation = iota
-	// Create operation is create a new key XXX rename to "Sync"
-	Create
+	// Sync operation is a complete/sync of the initial content
+	Sync
 	// Delete operation is delete an existing key
 	Delete
 	// Modify operation is modify the value of an existing key

--- a/pkg/pillar/pubsub/change.go
+++ b/pkg/pillar/pubsub/change.go
@@ -6,7 +6,7 @@ type Operation byte
 const (
 	// Restart operation is a restart
 	Restart Operation = iota
-	// Create operation is create a new key
+	// Create operation is create a new key XXX rename to "Sync"
 	Create
 	// Delete operation is delete an existing key
 	Delete

--- a/pkg/pillar/pubsub/doc.go
+++ b/pkg/pillar/pubsub/doc.go
@@ -67,7 +67,7 @@
 // The `DriverPublisher` publishes messages and, optionally, persists them.
 // It also can `Unpublish` messages, as well as `Load` all messages from
 // persistence store. Finally, it must be able to set and clear a `restarted`
-// flag.
+// flag/counter.
 //
 // The actual interface is key-value pairs, where it either is requested to
 // publish a key (string) and value (`interface{}`), or unpublish a key.

--- a/pkg/pillar/pubsub/driver.go
+++ b/pkg/pillar/pubsub/driver.go
@@ -37,7 +37,7 @@ type DriverSubscriber interface {
 	// anything. The caller has no knowledge of where the persistent state was
 	// stored: disk, databases, or vellum. All it cares about is that it gets
 	// a key-value list.
-	Load() (map[string][]byte, bool, error)
+	Load() (map[string][]byte, int, error)
 
 	// Stop subscribing to a name and topic
 	// This is expected to return immediately.
@@ -57,14 +57,13 @@ type DriverPublisher interface {
 	// anything. The caller has no knowledge of where the persistent state was
 	// stored: disk, databases, or vellum. All it cares about is that it gets
 	// a key-value list.
-	Load() (map[string][]byte, bool, error)
+	Load() (map[string][]byte, int, error)
 	// Publish a key-value pair to all subscribers and optionally persistence
 	Publish(key string, item []byte) error
 	// Unpublish a key, i.e. delete it and publish its deletion to all subscribers
 	Unpublish(key string) error
-	// Restart set the state of the topic to restarted, or cancel the restarted
-	// state
-	Restart(restarted bool) error
+	// Restart set the restartCounter for the topic. Zero implies no restart
+	Restart(restartCounter int) error
 
 	// Stop publishing
 	// This is expected to return immediately.
@@ -72,8 +71,10 @@ type DriverPublisher interface {
 }
 
 // Restarted interface that lets you determine if a Publication has been restarted
+// Returns zero if not; the count indicates the number of times it has restarted.
 type Restarted interface {
 	IsRestarted() bool
+	RestartCounter() int
 }
 
 // Differ interface that updates a LocalCollection from previous state to current state,

--- a/pkg/pillar/pubsub/emptydriver.go
+++ b/pkg/pillar/pubsub/emptydriver.go
@@ -32,8 +32,8 @@ func (e *EmptyDriverPublisher) Start() error {
 }
 
 // Load function
-func (e *EmptyDriverPublisher) Load() (map[string][]byte, bool, error) {
-	return make(map[string][]byte), false, nil
+func (e *EmptyDriverPublisher) Load() (map[string][]byte, int, error) {
+	return make(map[string][]byte), 0, nil
 }
 
 // Publish function
@@ -47,7 +47,7 @@ func (e *EmptyDriverPublisher) Unpublish(key string) error {
 }
 
 // Restart function
-func (e *EmptyDriverPublisher) Restart(restarted bool) error {
+func (e *EmptyDriverPublisher) Restart(restartCounter int) error {
 	return nil
 }
 
@@ -65,9 +65,9 @@ func (e *EmptyDriverSubscriber) Start() error {
 }
 
 // Load function
-func (e *EmptyDriverSubscriber) Load() (map[string][]byte, bool, error) {
+func (e *EmptyDriverSubscriber) Load() (map[string][]byte, int, error) {
 	res := make(map[string][]byte)
-	return res, false, nil
+	return res, 0, nil
 }
 
 // Stop function

--- a/pkg/pillar/pubsub/pubsub.go
+++ b/pkg/pillar/pubsub/pubsub.go
@@ -21,7 +21,7 @@ type SubscriptionOptions struct {
 	ModifyHandler  SubModifyHandler
 	DeleteHandler  SubDeleteHandler
 	RestartHandler SubRestartHandler
-	SyncHandler    SubRestartHandler
+	SyncHandler    SubSyncHandler
 	WarningTime    time.Duration
 	ErrorTime      time.Duration
 	AgentName      string
@@ -45,14 +45,17 @@ type SubModifyHandler func(ctx interface{}, key string, status interface{},
 type SubDeleteHandler func(ctx interface{}, key string, status interface{})
 
 // SubRestartHandler generic handler for restarts
-type SubRestartHandler func(ctx interface{}, restarted bool)
+type SubRestartHandler func(ctx interface{}, restartCount int)
+
+// SubSyncHandler generic handler for synchronized
+type SubSyncHandler func(ctx interface{}, synchronized bool)
 
 // Maintain a collection which is used to handle the restart of a subscriber
 // map of agentname, key to get a json string
 // We use StringMap with a RWlock to allow concurrent access.
 type keyMap struct {
-	restarted bool
-	key       *base.LockedStringMap
+	restartCounter int
+	key            *base.LockedStringMap
 }
 
 // PubSub is a system for publishing and subscribing to messages

--- a/pkg/pillar/pubsub/pubsubintf.go
+++ b/pkg/pillar/pubsub/pubsubintf.go
@@ -15,7 +15,7 @@ type Publication interface {
 	Publish(key string, item interface{}) error
 	// Unpublish - Delete / UnPublish an object
 	Unpublish(key string) error
-	// SignalRestarted - Signal the publisher has started.
+	// SignalRestarted - Signal the publisher has started one more time
 	SignalRestarted() error
 	// ClearRestarted clear the restarted flag
 	ClearRestarted() error
@@ -39,6 +39,8 @@ type Subscription interface {
 	Iterate(function base.StrMapFunc)
 	// Restarted report if this subscription has been marked as restarted
 	Restarted() bool
+	// RestartCounter reports how many times this subscription has been restarted
+	RestartCounter() int
 	// Synchronized report if this subscription has received initial items
 	Synchronized() bool
 	// ProcessChange - Invoked on the string msg from Subscription Channel

--- a/pkg/pillar/pubsub/restarted_test.go
+++ b/pkg/pillar/pubsub/restarted_test.go
@@ -1,0 +1,230 @@
+// Copyright (c) 2020-2021 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package pubsub_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub/socketdriver"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRestarted(t *testing.T) {
+	// Run in a unique directory
+	rootPath, err := ioutil.TempDir("", "restarted_test")
+	if err != nil {
+		t.Fatalf("TempDir failed: %s", err)
+	}
+
+	logger := logrus.StandardLogger()
+	logger.SetLevel(logrus.InfoLevel)
+	formatter := logrus.JSONFormatter{
+		TimestampFormat: time.RFC3339Nano,
+	}
+	logger.SetFormatter(&formatter)
+	logger.SetReportCaller(true)
+	log := base.NewSourceLogObject(logger, "test", 1234)
+	driver := socketdriver.SocketDriver{
+		Logger:  logger,
+		Log:     log,
+		RootDir: rootPath,
+	}
+	ps := pubsub.New(&driver, logger, log)
+
+	myCtx := context{}
+	testMatrix := map[string]struct {
+		agentName  string
+		agentScope string
+		persistent bool
+	}{
+		"File": {
+			agentName: "",
+			//			agentScope: "testscope1",
+		},
+		"File with persistent": {
+			agentName: "",
+			//			agentScope: "testscope2",
+			persistent: true,
+		},
+		"IPC": {
+			agentName: "testagent1",
+			//			agentScope: "testscope",
+		},
+		"IPC with persistent": {
+			agentName: "testagent2",
+			//			agentScope: "testscope",
+			persistent: true,
+		},
+	}
+
+	var events []string
+	events = nil
+	subCreateHandler := func(ctxArg interface{}, key string, status interface{}) {
+		log.Functionf("subCreateHandler %s", key)
+		events = append(events, "create "+key)
+	}
+	subModifyHandler := func(ctxArg interface{}, key string, status interface{}, oldStatus interface{}) {
+		log.Functionf("subModifyHandler %s", key)
+		events = append(events, "modify "+key)
+	}
+	subDeleteHandler := func(ctxArg interface{}, key string, status interface{}) {
+		log.Functionf("subDeleteHandler %s", key)
+		events = append(events, "delete "+key)
+
+	}
+	subRestartHandler := func(ctxArg interface{}, restartCounter int) {
+		str := fmt.Sprintf("%d", restartCounter)
+		log.Functionf("subRestartHandler %s", str)
+		events = append(events, "restarted "+str)
+	}
+	subSynchronizedHandler := func(ctxArg interface{}, synchronized bool) {
+		str := fmt.Sprintf("%t", synchronized)
+		log.Functionf("subSynchronizedHandler %s", str)
+		events = append(events, "synchronized "+str)
+	}
+
+	for testname, test := range testMatrix {
+		t.Logf("Running test case %s", testname)
+		t.Run(testname, func(t *testing.T) {
+			pub, err := ps.NewPublication(
+				pubsub.PublicationOptions{
+					AgentName:  test.agentName,
+					AgentScope: test.agentScope,
+					Persistent: test.persistent,
+					TopicType:  item{},
+				})
+			if err != nil {
+				t.Fatalf("unable to publish: %v", err)
+			}
+			item1 := item{FieldA: "item1"}
+			log.Functionf("Publishing key1")
+			pub.Publish("key1", item1)
+			log.Functionf("SignalRestarted")
+			pub.SignalRestarted()
+
+			log.Functionf("NewSubscription")
+			sub, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+				AgentName:      test.agentName,
+				AgentScope:     test.agentScope,
+				Persistent:     test.persistent,
+				TopicImpl:      item{},
+				CreateHandler:  subCreateHandler,
+				ModifyHandler:  subModifyHandler,
+				DeleteHandler:  subDeleteHandler,
+				RestartHandler: subRestartHandler,
+				SyncHandler:    subSynchronizedHandler,
+				Ctx:            &myCtx,
+			})
+			if err != nil {
+				t.Fatalf("unable to subscribe: %v", err)
+			}
+			assert.Equal(t, 0, len(events))
+			log.Functionf("Activate")
+			sub.Activate()
+			// Process subscription to populate
+			for !sub.Synchronized() || !sub.Restarted() {
+				select {
+				case change := <-sub.MsgChan():
+					log.Functionf("ProcessChange")
+					sub.ProcessChange(change)
+				}
+			}
+			items := sub.GetAll()
+			assert.Equal(t, 1, len(items))
+			assert.Equal(t, 3, len(events))
+			if len(events) == 3 {
+				assert.Equal(t, "create key1", events[0])
+				// Could be in either order
+				if events[1] == "restarted 1" {
+					assert.Equal(t, "synchronized true", events[2])
+				} else {
+					assert.Equal(t, "synchronized true", events[1])
+					assert.Equal(t, "restarted 1", events[2])
+				}
+			}
+			events = nil
+
+			item1modified := item{FieldA: "item1modified"}
+			log.Functionf("Publishing key1")
+			pub.Publish("key1", item1modified)
+			item2 := item{FieldA: "item2"}
+			log.Functionf("Publishing key2")
+			pub.Publish("key2", item2)
+			log.Functionf("SignalRestarted")
+			pub.SignalRestarted()
+
+			timer := time.NewTimer(10 * time.Second)
+			done := false
+			for !done {
+				select {
+				case change := <-sub.MsgChan():
+					log.Functionf("ProcessChange")
+					sub.ProcessChange(change)
+					if len(events) == 3 {
+						done = true
+						break
+					}
+				case <-timer.C:
+					log.Errorf("Timed out for three: got %d: %+v",
+						len(events), events)
+					done = true
+					break
+				}
+			}
+			items = sub.GetAll()
+			assert.Equal(t, 2, len(items))
+			assert.Equal(t, 3, len(events))
+			if len(events) == 3 {
+				// modify and create in any order
+				if events[0] == "modify key1" {
+					assert.Equal(t, "create key2", events[1])
+				} else {
+					assert.Equal(t, "create key2", events[0])
+					assert.Equal(t, "modify key1", events[1])
+				}
+				assert.Equal(t, "restarted 2", events[2])
+			}
+			events = nil
+
+			pub.Unpublish("key1")
+			log.Functionf("SignalRestarted")
+			pub.SignalRestarted()
+
+			timer = time.NewTimer(10 * time.Second)
+			done = false
+			for !done {
+				select {
+				case change := <-sub.MsgChan():
+					log.Functionf("ProcessChange")
+					sub.ProcessChange(change)
+					if len(events) == 2 {
+						done = true
+						break
+					}
+				case <-timer.C:
+					log.Errorf("Timed out for two: got %d: %+v",
+						len(events), events)
+					done = true
+					break
+				}
+			}
+			items = sub.GetAll()
+			assert.Equal(t, 1, len(items))
+			assert.Equal(t, 2, len(events))
+			if len(events) == 2 {
+				assert.Equal(t, "delete key1", events[0])
+				assert.Equal(t, "restarted 3", events[1])
+			}
+			events = nil
+		})
+	}
+	os.RemoveAll(rootPath)
+}

--- a/pkg/pillar/pubsub/socketdriver/driver.go
+++ b/pkg/pillar/pubsub/socketdriver/driver.go
@@ -22,7 +22,7 @@ import (
 // "request" from client after connect to sanity check subject.
 // Server sends the other messages; "update" for initial values.
 // "complete" once all initial keys/values in collection have been sent.
-// "restarted" if/when pub.km.restarted is set.
+// "restarted" if/when pub.km.restartCounter is set.
 // Ongoing we send "update" and "delete" messages.
 // They keys and values are base64-encoded since they might contain spaces.
 // We include typeName after command word for sanity checks.
@@ -32,7 +32,7 @@ import (
 //	"update" topic key json-val
 //	"delete" topic key
 //	"complete" topic (aka synchronized)
-//	"restarted" topic
+//	"restarted" topic count
 
 // We always publish to our collection.
 // We always write to a file in order to have a checkpoint on restart

--- a/pkg/pillar/pubsub/socketdriver/publish.go
+++ b/pkg/pillar/pubsub/socketdriver/publish.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -62,9 +63,9 @@ func (s *Publisher) Unpublish(key string) error {
 }
 
 // Load load entire persisted data set into a map
-func (s *Publisher) Load() (map[string][]byte, bool, error) {
+func (s *Publisher) Load() (map[string][]byte, int, error) {
 	dirName := s.dirName
-	foundRestarted := false
+	restartCounter := 0
 	items := make(map[string][]byte)
 
 	s.log.Tracef("Load(%s)\n", s.name)
@@ -73,12 +74,24 @@ func (s *Publisher) Load() (map[string][]byte, bool, error) {
 	if err != nil {
 		// Drive on?
 		s.log.Error(err)
-		return items, foundRestarted, err
+		return items, restartCounter, err
 	}
 	for _, file := range files {
 		if !strings.HasSuffix(file.Name(), ".json") {
 			if file.Name() == "restarted" {
-				foundRestarted = true
+				statusFile := dirName + "/" + file.Name()
+				sb, err := ioutil.ReadFile(statusFile)
+				if err != nil {
+					s.log.Errorf("Load: %s for %s\n", err, statusFile)
+					continue
+				}
+				restartCounter, err = strconv.Atoi(string(sb))
+				// Treat present but empty file as "1" to
+				// handle old file in /persist
+				if err != nil {
+					s.log.Warnf("Load: %s for %s; treat as 1", err, statusFile)
+					restartCounter = 1
+				}
 			}
 			continue
 		}
@@ -102,7 +115,7 @@ func (s *Publisher) Load() (map[string][]byte, bool, error) {
 		}
 		items[key] = sb
 	}
-	return items, foundRestarted, err
+	return items, restartCounter, err
 }
 
 // Start start publishing on the socket
@@ -153,16 +166,17 @@ func (s *Publisher) Stop() error {
 	return nil
 }
 
-// Restart indicate that the topic is restarted, or clear it
-func (s *Publisher) Restart(restarted bool) error {
+// Restart indicate that the topic is restarted if counter is non-zero
+func (s *Publisher) Restart(restartCounter int) error {
 	restartFile := s.dirName + "/" + "restarted"
-	if restarted {
-		f, err := os.OpenFile(restartFile, os.O_RDONLY|os.O_CREATE, 0600)
+	if restartCounter != 0 {
+		str := strconv.Itoa(restartCounter)
+		cb := []byte(str)
+		err := fileutils.WriteRename(restartFile, cb)
 		if err != nil {
 			errStr := fmt.Sprintf("pub.restartImpl(%s): openfile failed %s", s.name, err)
 			return errors.New(errStr)
 		}
-		f.Close()
 	} else {
 		if err := os.Remove(restartFile); err != nil {
 			errStr := fmt.Sprintf("pub.restartImpl(%s): remove failed %s", s.name, err)
@@ -178,7 +192,7 @@ func (s *Publisher) serveConnection(conn net.Conn, instance int) {
 
 	// Track the set of keys/values we are sending to the peer
 	sendToPeer := make(pubsub.LocalCollection)
-	sentRestarted := false
+	sentRestartCounter := 0
 
 	// Small buffer since we only read "request <topic>"
 	buf := make([]byte, 256)
@@ -230,13 +244,13 @@ func (s *Publisher) serveConnection(conn net.Conn, instance int) {
 		s.log.Errorf("serveConnection(%s/%d) sendComplete failed %s\n", s.name, instance, err)
 		return
 	}
-	if s.restarted.IsRestarted() && !sentRestarted {
-		err = s.sendRestarted(conn)
+	if s.restarted.RestartCounter() != sentRestartCounter {
+		err = s.sendRestarted(conn, s.restarted.RestartCounter())
 		if err != nil {
 			s.log.Errorf("serveConnection(%s/%d) sendRestarted failed %s\n", s.name, instance, err)
 			return
 		}
-		sentRestarted = true
+		sentRestartCounter = s.restarted.RestartCounter()
 	}
 
 	// Handle any changes
@@ -256,6 +270,8 @@ func (s *Publisher) serveConnection(conn net.Conn, instance int) {
 		}
 		waitTime := time.Since(startWait)
 		s.log.Tracef("serveConnection(%s/%d) received notification waited %d seconds\n", s.name, instance, waitTime/time.Second)
+		// Grab any change to restartCounter before we determine diffs
+		newRestartCounter := s.restarted.RestartCounter()
 
 		// Update and determine which keys changed
 		keys := s.differ.DetermineDiffs(sendToPeer)
@@ -267,13 +283,13 @@ func (s *Publisher) serveConnection(conn net.Conn, instance int) {
 			return
 		}
 
-		if s.restarted.IsRestarted() && !sentRestarted {
-			err = s.sendRestarted(conn)
+		if newRestartCounter != sentRestartCounter {
+			err = s.sendRestarted(conn, newRestartCounter)
 			if err != nil {
 				s.log.Errorf("serveConnection(%s/%d) sendRestarted failed %s\n", s.name, instance, err)
 				return
 			}
-			sentRestarted = true
+			sentRestartCounter = newRestartCounter
 		}
 	}
 	s.log.Warnf("serveConnection(%s) goroutine exiting", s.name)
@@ -332,9 +348,9 @@ func (s *Publisher) sendDelete(sock net.Conn, key string) error {
 	return err
 }
 
-func (s *Publisher) sendRestarted(sock net.Conn) error {
+func (s *Publisher) sendRestarted(sock net.Conn, restartCounter int) error {
 	s.log.Functionf("sendRestarted(%s)\n", s.name)
-	buf := fmt.Sprintf("restarted %s", s.topic)
+	buf := fmt.Sprintf("restarted %s %d", s.topic, restartCounter)
 	if len(buf) >= maxsize {
 		s.log.Fatalf("Too large message (%d bytes) sent to %s topic %s",
 			len(buf), s.name, s.topic)

--- a/pkg/pillar/pubsub/socketdriver/subscribe.go
+++ b/pkg/pillar/pubsub/socketdriver/subscribe.go
@@ -11,10 +11,12 @@ import (
 	"net"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/flextimer"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	logutils "github.com/lf-edge/eve/pkg/pillar/utils/logging"
 	"github.com/lf-edge/eve/pkg/pillar/watch"
@@ -38,9 +40,9 @@ type Subscriber struct {
 }
 
 // Load load entire persisted data set into a map
-func (s *Subscriber) Load() (map[string][]byte, bool, error) {
+func (s *Subscriber) Load() (map[string][]byte, int, error) {
 	dirName := s.dirName
-	foundRestarted := false
+	restartCounter := 0
 	items := make(map[string][]byte)
 
 	s.log.Tracef("Load(%s)\n", s.name)
@@ -49,12 +51,24 @@ func (s *Subscriber) Load() (map[string][]byte, bool, error) {
 	if err != nil {
 		// Drive on?
 		s.log.Error(err)
-		return items, foundRestarted, err
+		return items, restartCounter, err
 	}
 	for _, file := range files {
 		if !strings.HasSuffix(file.Name(), ".json") {
 			if file.Name() == "restarted" {
-				foundRestarted = true
+				statusFile := dirName + "/" + file.Name()
+				sb, err := ioutil.ReadFile(statusFile)
+				if err != nil {
+					s.log.Errorf("Load: %s for %s\n", err, statusFile)
+					continue
+				}
+				restartCounter, err = strconv.Atoi(string(sb))
+				// Treat present but empty file as "1" to
+				// handle old file in /persist
+				if err != nil {
+					s.log.Warnf("Load: %s for %s; treat as 1", err, statusFile)
+					restartCounter = 1
+				}
 			}
 			continue
 		}
@@ -78,7 +92,7 @@ func (s *Subscriber) Load() (map[string][]byte, bool, error) {
 		}
 		items[key] = sb
 	}
-	return items, foundRestarted, err
+	return items, restartCounter, err
 }
 
 // Start start the subscriber listening on the given name and topic
@@ -156,13 +170,14 @@ func (s *Subscriber) watchSock() {
 		case "hello":
 			// Do nothing
 		case "complete":
-			// XXX to handle restart we need to handle "complete"
+			// XXX to handle connection/process restart we need to handle "sync"
 			// by doing a sweep across the KeyMap to handleDelete
 			// what we didn't see before the "complete"
 			s.C <- pubsub.Change{Operation: pubsub.Create, Key: "done"}
 
 		case "restarted":
-			s.C <- pubsub.Change{Operation: pubsub.Restart, Key: "done"}
+			s.C <- pubsub.Change{Operation: pubsub.Restart,
+				Key: key}
 
 		case "delete":
 			s.C <- pubsub.Change{Operation: pubsub.Delete, Key: key}
@@ -286,9 +301,19 @@ func (s *Subscriber) read() (string, string, []byte) {
 	// XXX are there error cases where we should Close and
 	// continue aka reconnect?
 	switch msg {
-	case "hello", "restarted", "complete":
+	case "hello", "complete":
 		s.log.Tracef("connectAndRead(%s) Got message %s type %s\n", s.name, msg, t)
 		return msg, "", nil
+
+	case "restarted":
+		if count < 3 {
+			errStr := fmt.Sprintf("connectAndRead(%s): too short restarted", s.name)
+			s.log.Errorln(errStr)
+			return "", "", nil
+		}
+		counter := string(reply[2])
+		s.log.Tracef("connectAndRead(%s) Got message %s type %s counter %s", s.name, msg, t, counter)
+		return msg, counter, nil
 
 	case "delete":
 		if count < 3 {
@@ -341,42 +366,115 @@ func (s *Subscriber) read() (string, string, []byte) {
 	}
 }
 
+// translate takes file notifications from a file watcher and converts them
+// pubsub operations. Normally this is 1-1 but since the file watcher can not
+// ensure ordering for the restarted file we delay those until a bit to ensure
+// they are delivered after any notifictions for other files.
 func (s *Subscriber) translate(in <-chan string, out chan<- pubsub.Change) {
 	statusDirName := s.dirName
-	for change := range in {
-		s.log.Tracef("translate received message '%s'", change)
-		operation := string(change[0])
-		fileName := string(change[2:])
-		// Remove .json from name */
-		name := strings.Split(fileName, ".json")
-		switch {
-		case operation == "R":
-			s.log.Functionf("Received restart <%s>\n", fileName)
-			// I do not know why, but the "R" operation from the file watcher
-			// historically called the Complete operation, leading to the
-			// "Synchronized" handler being called.
-			out <- pubsub.Change{Operation: pubsub.Create}
-		case operation == "M" && fileName == "restarted":
-			s.log.Tracef("Found restarted file\n")
-			out <- pubsub.Change{Operation: pubsub.Restart}
-		case !strings.HasSuffix(fileName, ".json"):
-			// s.log.Tracef("Ignoring file <%s> operation %s\n",
-			//	fileName, operation)
-			continue
-		case operation == "D":
-			out <- pubsub.Change{Operation: pubsub.Delete, Key: name[0]}
-		case operation == "M":
-			statusFile := path.Join(statusDirName, fileName)
-			cb, err := ioutil.ReadFile(statusFile)
-			if err != nil {
-				s.log.Errorf("%s for %s\n", err, statusFile)
-				continue
+	gotRestarted := false
+	var restartedValue string
+
+	// Delay sending restarted until we have seen other changes
+	interval := 3 * time.Second
+	max := float64(interval)
+	min := max / 3
+	ticker := flextimer.NewRangeTicker(time.Duration(1000*min),
+		time.Duration(1000*max))
+	ticker.StopTicker()
+
+	for {
+		select {
+		case e, ok := <-ticker.C:
+			if !ok {
+				// We get some spurious indications with e being zero
+				break
 			}
-			out <- pubsub.Change{Operation: pubsub.Modify, Key: name[0], Value: cb}
-		default:
-			s.log.Fatal("Unknown operation from Watcher: ", operation)
+
+			if !gotRestarted {
+				s.log.Fatalf("ticker without gotRestarted val %s, e %v",
+					restartedValue, e)
+			}
+			out <- pubsub.Change{Operation: pubsub.Restart, Key: restartedValue}
+			s.log.Functionf("sent restarted file with %s",
+				restartedValue)
+			gotRestarted = false
+			restartedValue = ""
+			ticker.StopTicker()
+
+		case change, ok := <-in:
+			if !ok {
+				if gotRestarted {
+					out <- pubsub.Change{Operation: pubsub.Restart, Key: restartedValue}
+					s.log.Warnf("translate goroutine exiting flushed restarted %s",
+						restartedValue)
+					gotRestarted = false
+					restartedValue = ""
+					ticker.StopTicker()
+				} else {
+					s.log.Warnf("translate goroutine exiting")
+				}
+				close(out)
+				ticker.StopTicker()
+				return
+			}
+			s.log.Tracef("translate received message '%s'", change)
+			operation := string(change[0])
+			fileName := string(change[2:])
+			// Remove .json from name */
+			name := strings.Split(fileName, ".json")
+			switch {
+			case operation == "R":
+				s.log.Functionf("Received restart <%s>", fileName)
+				// I do not know why, but the "R" operation from the file watcher
+				// historically called the Complete operation, leading to the
+				// "Synchronized" handler being called.
+				out <- pubsub.Change{Operation: pubsub.Create}
+			case operation == "M" && fileName == "restarted":
+				statusFile := path.Join(statusDirName, fileName)
+				cb, err := ioutil.ReadFile(statusFile)
+				if err != nil {
+					s.log.Errorf("%s for %s\n", err, statusFile)
+					continue
+				}
+				// Should we send a previous restarted?
+				if gotRestarted {
+					out <- pubsub.Change{Operation: pubsub.Restart, Key: restartedValue}
+					s.log.Functionf("flush restarted queued %s new %s",
+						restartedValue, string(cb))
+					gotRestarted = false
+					restartedValue = ""
+					ticker.StopTicker()
+				}
+				gotRestarted = true
+				restartedValue = string(cb)
+				s.log.Functionf("Starting timer restarted %s for %v %v",
+					restartedValue,
+					time.Duration(min), time.Duration(max))
+				ticker = flextimer.NewRangeTicker(time.Duration(min),
+					time.Duration(max))
+
+			case !strings.HasSuffix(fileName, ".json"):
+				// s.log.Tracef("Ignoring file <%s> operation %s\n",
+				//	fileName, operation)
+				continue
+			case operation == "D":
+				out <- pubsub.Change{Operation: pubsub.Delete, Key: name[0]}
+				s.log.Tracef("sent delete file for %s",
+					name[0])
+			case operation == "M":
+				statusFile := path.Join(statusDirName, fileName)
+				cb, err := ioutil.ReadFile(statusFile)
+				if err != nil {
+					s.log.Errorf("%s for %s\n", err, statusFile)
+					continue
+				}
+				out <- pubsub.Change{Operation: pubsub.Modify, Key: name[0], Value: cb}
+				s.log.Tracef("sent modify file for %s",
+					name[0])
+			default:
+				s.log.Fatal("Unknown operation from Watcher: ", operation)
+			}
 		}
 	}
-	s.log.Warnf("translate goroutine exiting")
-	close(out)
 }

--- a/pkg/pillar/pubsub/socketdriver/subscribe.go
+++ b/pkg/pillar/pubsub/socketdriver/subscribe.go
@@ -173,7 +173,7 @@ func (s *Subscriber) watchSock() {
 			// XXX to handle connection/process restart we need to handle "sync"
 			// by doing a sweep across the KeyMap to handleDelete
 			// what we didn't see before the "complete"
-			s.C <- pubsub.Change{Operation: pubsub.Create, Key: "done"}
+			s.C <- pubsub.Change{Operation: pubsub.Sync, Key: "done"}
 
 		case "restarted":
 			s.C <- pubsub.Change{Operation: pubsub.Restart,
@@ -429,7 +429,7 @@ func (s *Subscriber) translate(in <-chan string, out chan<- pubsub.Change) {
 				// I do not know why, but the "R" operation from the file watcher
 				// historically called the Complete operation, leading to the
 				// "Synchronized" handler being called.
-				out <- pubsub.Change{Operation: pubsub.Create}
+				out <- pubsub.Change{Operation: pubsub.Sync}
 			case operation == "M" && fileName == "restarted":
 				statusFile := path.Join(statusDirName, fileName)
 				cb, err := ioutil.ReadFile(statusFile)

--- a/pkg/pillar/pubsub/subscribe.go
+++ b/pkg/pillar/pubsub/subscribe.go
@@ -124,7 +124,7 @@ func (sub *SubscriptionImpl) ProcessChange(change Change) {
 		sub.log.Tracef("Restart(%s) key %s counter %d",
 			name, change.Key, restartCounter)
 		handleRestart(sub, restartCounter)
-	case Create:
+	case Sync:
 		handleSynchronized(sub, true)
 	case Delete:
 		handleDelete(sub, change.Key)

--- a/pkg/pillar/pubsub/subscribe.go
+++ b/pkg/pillar/pubsub/subscribe.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -21,7 +22,7 @@ type SubscriptionImpl struct {
 	ModifyHandler       SubModifyHandler
 	DeleteHandler       SubDeleteHandler
 	RestartHandler      SubRestartHandler
-	SynchronizedHandler SubRestartHandler
+	SynchronizedHandler SubSyncHandler
 	MaxProcessTimeWarn  time.Duration // If set generate warning if ProcessChange
 	MaxProcessTimeError time.Duration // If set generate warning if ProcessChange
 	Persistent          bool
@@ -64,7 +65,7 @@ func (sub *SubscriptionImpl) Close() error {
 			sub.nameString(), key)
 		handleDelete(sub, key)
 	}
-	handleRestart(sub, false)
+	handleRestart(sub, 0)
 	handleSynchronized(sub, false)
 	return nil
 }
@@ -72,7 +73,7 @@ func (sub *SubscriptionImpl) Close() error {
 // populate is used when activating a persistent subscription to read
 // from the json files. This ensures that even if the publisher hasn't started
 // yet, the subscriber will be notified with the initial content.
-// This sets restarted if the restarted file was found.
+// This sets restartCounter if the restarted file exists and contains an integer.
 // Note that this directly calls handleModify thus unlike subsequent
 // changes the agent's handler will be called without going through
 // a select on the MsgChan and ProcessChange call.
@@ -85,7 +86,7 @@ func (sub *SubscriptionImpl) populate() {
 
 	sub.log.Functionf("populate(%s)", name)
 
-	pairs, restarted, err := sub.driver.Load()
+	pairs, restartCounter, err := sub.driver.Load()
 	if err != nil {
 		// Could be a truncated or empty file
 		sub.log.Error(err)
@@ -95,8 +96,8 @@ func (sub *SubscriptionImpl) populate() {
 		sub.log.Functionf("populate(%s) key %s", name, key)
 		handleModify(sub, key, itemB)
 	}
-	if restarted {
-		handleRestart(sub, true)
+	if restartCounter != 0 {
+		handleRestart(sub, restartCounter)
 	}
 	sub.log.Functionf("populate(%s) done", name)
 }
@@ -112,7 +113,17 @@ func (sub *SubscriptionImpl) ProcessChange(change Change) {
 
 	switch change.Operation {
 	case Restart:
-		handleRestart(sub, true)
+		name := sub.nameString()
+		restartCounter, err := strconv.Atoi(change.Key)
+		// Treat present but empty file as "1" to handle old file
+		// in /persist
+		if err != nil {
+			sub.log.Warnf("Load: %s for %s; read %s treat as 1",
+				err, name, change.Key)
+		}
+		sub.log.Tracef("Restart(%s) key %s counter %d",
+			name, change.Key, restartCounter)
+		handleRestart(sub, restartCounter)
 	case Create:
 		handleSynchronized(sub, true)
 	case Delete:
@@ -153,7 +164,12 @@ func (sub *SubscriptionImpl) Iterate(function base.StrMapFunc) {
 
 // Restarted - Check if the Publisher has Restarted
 func (sub *SubscriptionImpl) Restarted() bool {
-	return sub.km.restarted
+	return sub.km.restartCounter != 0
+}
+
+// RestartCounter - Check how many times the Publisher has Restarted
+func (sub *SubscriptionImpl) RestartCounter() int {
+	return sub.km.restartCounter
 }
 
 // Synchronized -
@@ -193,7 +209,7 @@ func (sub *SubscriptionImpl) dump(infoStr string) {
 		return true
 	}
 	sub.km.key.Range(dumper)
-	sub.log.Tracef("\trestarted %t\n", sub.km.restarted)
+	sub.log.Tracef("\trestarted %d\n", sub.km.restartCounter)
 	sub.log.Tracef("\tsynchronized %t\n", sub.synchronized)
 }
 
@@ -278,20 +294,21 @@ func handleDelete(ctxArg interface{}, key string) {
 	sub.log.Tracef("pubsub.handleDelete(%s) done for key %s\n", name, key)
 }
 
-func handleRestart(ctxArg interface{}, restarted bool) {
+func handleRestart(ctxArg interface{}, restartCounter int) {
 	sub := ctxArg.(*SubscriptionImpl)
 	name := sub.nameString()
-	sub.log.Tracef("pubsub.handleRestart(%s) restarted %v\n", name, restarted)
-	if restarted == sub.km.restarted {
+	sub.log.Tracef("pubsub.handleRestart(%s) restartCounter %d",
+		name, restartCounter)
+	if restartCounter == sub.km.restartCounter {
 		sub.log.Tracef("pubsub.handleRestart(%s) value unchanged\n", name)
 		return
 	}
-	sub.km.restarted = restarted
+	sub.km.restartCounter = restartCounter
 	if sub.RestartHandler != nil {
-		(sub.RestartHandler)(sub.userCtx, restarted)
+		(sub.RestartHandler)(sub.userCtx, restartCounter)
 	}
-	sub.log.Tracef("pubsub.handleRestart(%s) done for restarted %v\n",
-		name, restarted)
+	sub.log.Tracef("pubsub.handleRestart(%s) done for restartCounter %d",
+		name, restartCounter)
 }
 
 func handleSynchronized(ctxArg interface{}, synchronized bool) {

--- a/pkg/pillar/watch/watchconfigstatus.go
+++ b/pkg/pillar/watch/watchconfigstatus.go
@@ -66,6 +66,10 @@ func watchReadDir(log *base.LogObject, configDir string, fileChanges chan<- stri
 // Generates 'M' events for all existing and all creates/modify.
 // Generates 'D' events for all deletes.
 // Generates a 'R' event when the initial directories have been processed
+// This assumes that the caller ensures that the restart and restarted files
+// are handled last in a set of changes close in time, since
+// the directory can see multiple modifications (content and attributes) and in
+// different order.
 func WatchStatus(log *base.LogObject, statusDir string, jsonOnly bool, doneChan <-chan struct{}, fileChanges chan<- string) {
 	w, err := fsnotify.NewWatcher()
 	if err != nil {
@@ -135,7 +139,8 @@ func WatchStatus(log *base.LogObject, statusDir string, jsonOnly bool, doneChan 
 		fileChanges <- "M " + "restarted"
 	}
 
-	// Watch for changes or timeout
+	// Watch for changes or timeout. This is to any issues where fsnotify
+	// fails to deliver some notification.
 	interval := 10 * time.Minute
 	max := float64(interval)
 	min := max * 0.3
@@ -153,7 +158,8 @@ func WatchStatus(log *base.LogObject, statusDir string, jsonOnly bool, doneChan 
 
 		case <-ticker.C:
 			// Remove and re-add
-			// XXX do we also need to re-scan?
+			// We also re-scan the directory for any changed we
+			// missed.
 			// log.Traceln("WatchStatus remove/re-add", statusDir)
 			err = w.Remove(statusDir)
 			if err != nil {


### PR DESCRIPTION
This makes SignalRestart into a barrier in pubsub; prior to these changes it is only useful as an initial barrier once by the subscriber but with these changes it can be used to signal that a set of create/modify/delete go together before the barrier.

@petr-zededa can benefit from using SignalRestarted to have zedagent indicate to volumemgr when it has processed all of the VolumeConfig changes as part of a change to EdgeDevConfig from the controller.

The new unit test ( pkg/pillar/pubsub/restarted_test.go) shows that the restart handler is called with a new counter value for each call to SignalRestarted() in the publisher, and that this happens after the modifications (add, modify, delete) to the keys/items in the subscription.