### PR TITLE
add cli flag debug.disable.dhcp.all-ones.netmask to control using all ones netmasks for DHCP

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -2119,11 +2119,6 @@ func createCloudInitISO(ctx *domainContext,
 		config.UUIDandVersion.UUID.String()))
 	metafile.Close()
 
-	userfile, err := os.Create(dir + "/user-data")
-	if err != nil {
-		log.Fatalf("createCloudInitISO failed %s", err)
-	}
-
 	decBlock, err := getCloudInitUserData(ctx, config)
 	if err != nil {
 		return nil, err
@@ -2132,6 +2127,14 @@ func createCloudInitISO(ctx *domainContext,
 	if err != nil {
 		errStr := fmt.Sprintf("createCloudInitISO failed %s", err)
 		return nil, errors.New(errStr)
+	}
+	userFileName := "/user-data"
+	if strings.Contains(string(ud), "#junos-config") {
+		userFileName = "/juniper.conf"
+	}
+	userfile, err := os.Create(dir + userFileName)
+	if err != nil {
+		log.Fatalf("createCloudInitISO failed %s", err)
 	}
 	userfile.WriteString(string(ud))
 	userfile.Close()

--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -479,7 +479,7 @@ func doNetworkInstanceCreate(ctx *zedrouterContext,
 			status.CurrentUplinkIntf)
 		ntpServers := types.GetNTPServers(*ctx.deviceNetworkStatus,
 			status.CurrentUplinkIntf)
-		createDnsmasqConfiglet(bridgeName,
+		createDnsmasqConfiglet(ctx, bridgeName,
 			status.BridgeIPAddr, &status.NetworkInstanceConfig,
 			hostsDirpath, status.BridgeIPSets,
 			status.CurrentUplinkIntf, dnsServers, ntpServers)
@@ -775,7 +775,7 @@ func restartDnsmasq(ctx *zedrouterContext, status *types.NetworkInstanceStatus) 
 		status.CurrentUplinkIntf)
 	ntpServers := types.GetNTPServers(*ctx.deviceNetworkStatus,
 		status.CurrentUplinkIntf)
-	createDnsmasqConfiglet(bridgeName, status.BridgeIPAddr,
+	createDnsmasqConfiglet(ctx, bridgeName, status.BridgeIPAddr,
 		&status.NetworkInstanceConfig, hostsDirpath, status.BridgeIPSets,
 		status.CurrentUplinkIntf, dnsServers, ntpServers)
 	createHostDnsmasqFile(ctx, bridgeName)
@@ -815,7 +815,7 @@ func lookupOrAllocateIPv4(
 
 	log.Functionf("bridgeName %s Subnet %v range %v-%v\n",
 		status.BridgeName, status.Subnet,
-		status.DhcpRange.Start, status.DhcpRange.End)
+		status.DhcpRange.Start.String(), status.DhcpRange.End.String())
 
 	if status.DhcpRange.Start == nil {
 		if status.Type == types.NetworkInstanceTypeSwitch {
@@ -1737,7 +1737,7 @@ func doNetworkInstanceFallback(
 				status.CurrentUplinkIntf)
 			ntpServers := types.GetNTPServers(*ctx.deviceNetworkStatus,
 				status.CurrentUplinkIntf)
-			createDnsmasqConfiglet(bridgeName,
+			createDnsmasqConfiglet(ctx, bridgeName,
 				status.BridgeIPAddr, &status.NetworkInstanceConfig,
 				hostsDirpath, status.BridgeIPSets,
 				status.CurrentUplinkIntf, dnsServers, ntpServers)
@@ -1792,7 +1792,7 @@ func doNetworkInstanceFallback(
 				status.CurrentUplinkIntf)
 			ntpServers := types.GetNTPServers(*ctx.deviceNetworkStatus,
 				status.CurrentUplinkIntf)
-			createDnsmasqConfiglet(bridgeName,
+			createDnsmasqConfiglet(ctx, bridgeName,
 				status.BridgeIPAddr, &status.NetworkInstanceConfig,
 				hostsDirpath, status.BridgeIPSets,
 				status.CurrentUplinkIntf, dnsServers, ntpServers)

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -88,6 +88,7 @@ type zedrouterContext struct {
 	appStatsMutex             sync.Mutex // to protect the changing appNetworkStatus & appCollectStatsRunning
 	appStatsInterval          uint32
 	aclog                     *logrus.Logger // App Container logger
+	disableDHCPAllOnesNetMask bool
 }
 
 var debug = false
@@ -940,7 +941,7 @@ func appNetworkDoActivateUnderlayNetwork(
 			netInstStatus.CurrentUplinkIntf)
 		ntpServers := types.GetNTPServers(*ctx.deviceNetworkStatus,
 			netInstStatus.CurrentUplinkIntf)
-		createDnsmasqConfiglet(bridgeName,
+		createDnsmasqConfiglet(ctx, bridgeName,
 			ulStatus.BridgeIPAddr, netInstConfig, hostsDirpath,
 			newIpsets, netInstStatus.CurrentUplinkIntf,
 			dnsServers, ntpServers)
@@ -1372,7 +1373,7 @@ func doAppNetworkModifyUnderlayNetwork(
 			netstatus.CurrentUplinkIntf)
 		ntpServers := types.GetNTPServers(*ctx.deviceNetworkStatus,
 			netstatus.CurrentUplinkIntf)
-		createDnsmasqConfiglet(bridgeName,
+		createDnsmasqConfiglet(ctx, bridgeName,
 			ulStatus.BridgeIPAddr, netconfig, hostsDirpath,
 			newIpsets, netstatus.CurrentUplinkIntf,
 			dnsServers, ntpServers)
@@ -1544,7 +1545,7 @@ func appNetworkDoInactivateUnderlayNetwork(
 			netstatus.CurrentUplinkIntf)
 		ntpServers := types.GetNTPServers(*ctx.deviceNetworkStatus,
 			netstatus.CurrentUplinkIntf)
-		createDnsmasqConfiglet(bridgeName,
+		createDnsmasqConfiglet(ctx, bridgeName,
 			ulStatus.BridgeIPAddr, netconfig, hostsDirpath,
 			newIpsets, netstatus.CurrentUplinkIntf,
 			dnsServers, ntpServers)
@@ -1613,6 +1614,7 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 	if gcp != nil {
 		ctx.GCInitialized = true
 		ctx.appStatsInterval = gcp.GlobalValueInt(types.AppContainerStatsInterval)
+		ctx.disableDHCPAllOnesNetMask = gcp.GlobalValueBool(types.DisableDHCPAllOnesNetMask)
 	}
 	log.Functionf("handleGlobalConfigImpl done for %s\n", key)
 }

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -206,6 +206,9 @@ const (
 	DefaultLogLevel GlobalSettingKey = "debug.default.loglevel"
 	// DefaultRemoteLogLevel global setting key
 	DefaultRemoteLogLevel GlobalSettingKey = "debug.default.remote.loglevel"
+
+	// XXX Temporary flag to disable RFC 3442 classless static route usage
+	DisableDHCPAllOnesNetMask GlobalSettingKey = "debug.disable.dhcp.all-ones.netmask"
 )
 
 // AgentSettingKey - keys for per-agent settings
@@ -760,6 +763,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddBoolItem(IgnoreMemoryCheckForApps, false)
 	configItemSpecMap.AddBoolItem(IgnoreDiskCheckForApps, false)
 	configItemSpecMap.AddBoolItem(AllowLogFastupload, false)
+	configItemSpecMap.AddBoolItem(DisableDHCPAllOnesNetMask, false)
 
 	// Add TriState Items
 	configItemSpecMap.AddTriStateItem(NetworkFallbackAnyEth, TS_ENABLED)

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -186,6 +186,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		SSHAuthorizedKeys,
 		DefaultLogLevel,
 		DefaultRemoteLogLevel,
+		DisableDHCPAllOnesNetMask,
 	}
 	if len(specMap.GlobalSettings) != len(gsKeys) {
 		t.Errorf("GlobalSettings has more (%d) than expected keys (%d)",


### PR DESCRIPTION
1) Add new flag "debug.disable.dhcp.all-ones.netmask" to turn on/off the all ones netmask setting in DHCP
2) For the case of Junos (VSRX), we need to name cloud-config file as juniper.conf instead of user-data

The above flag debug.disable.dhcp.all-ones.netmask will not change the netmask behavior of apps created before changing the flag itself.
This flag will have to be changed to the desired value before creating app new apps on the device.

Signed-off-by: Gopi krishna Kodali <gkodali@zededa.com>