### PR TITLE
skip unsuccessful logs in eden workflow

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -63,10 +63,10 @@ jobs:
       - name: Collect logs
         if: ${{ always() }}
         run: |
-          ./eden log --format json > trace.log
-          ./eden info > info.log
-          cp dist/default-eve.log console.log
-          docker logs eden_adam > adam.log 2>&1
+          ./eden log --format json > trace.log || echo "no log"
+          ./eden info > info.log || echo "no info"
+          cp dist/default-eve.log console.log || echo "no device log"
+          docker logs eden_adam > adam.log 2>&1 || echo "no adam log"
       - name: Store raw test results
         if: ${{ always() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -83,10 +83,10 @@ jobs:
       - name: Collect logs
         if: ${{ always() }}
         run: |
-          ./eden log --format json > trace.log
-          ./eden info > info.log
-          docker logs eden_adam > adam.log 2>&1
-          ./eden utils gcp vm log --vm-name eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} -k "$GOOGLE_APPLICATION_CREDENTIALS" > console.log
+          ./eden log --format json > trace.log || echo "no log"
+          ./eden info > info.log || echo "no info"
+          docker logs eden_adam > adam.log 2>&1 || echo "no adam log"
+          ./eden utils gcp vm log --vm-name eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} -k "$GOOGLE_APPLICATION_CREDENTIALS" > console.log || echo "no device log"
       - name: Clean
         if: ${{ always() }}
         run: |


### PR DESCRIPTION
In case of problems with onboarding we should omit exit codes from logging inside eden workflow to obtain the following artifacts.

Signed-off-by: Petr Fedchenkov <petr@zededa.com>