### PR TITLE
Adding a few additional packages to Alpine cache

### DIFF
--- a/pkg/alpine/mirrors/3.13/main
+++ b/pkg/alpine/mirrors/3.13/main
@@ -49,11 +49,17 @@ gmp-dev
 gnu-efi-dev
 gnupg
 gnutls
+grep
+hdparm
 iasl
 installkernel
 ip6tables
+ip6tables-openrc
+iptables-openrc
 iproute2
+iproute2-minimal
 ipset
+ipset-openrc
 iptables
 jpeg
 jpeg-dev
@@ -63,6 +69,7 @@ kmod
 kmod-dev
 libaio-dev
 libarchive-tools
+libtasn1-progs
 libbz2
 libc-dev
 libc-utils
@@ -117,6 +124,7 @@ nettle
 openssh
 openssl
 openssl-dev
+p11-kit
 patch
 pciutils
 perl


### PR DESCRIPTION
This should be pretty self-explanatory. The only comment here is that we may end up not needing some of these packages down the road (if/when we proceed to de-cruft our packages) but they are a tiny bump in size and shouldn't be too controversial.