### PR TITLE
Allowing for EVE flavor boot sequence tweaks in either direction (Xen or KVM)

### DIFF
--- a/conf/grub.cfg
+++ b/conf/grub.cfg
@@ -1,3 +1,5 @@
 # You can put your GRUB overrides here
-# E.g. to force booting int KVM mode, uncomment the following
-# set_kvm_boot
+# E.g. to force booting int KVM mode, uncomment the following:
+#   set_global eve_flavor kvm
+# to force booting in Xen mode, uncomment:
+#   set_global eve_flavor xen

--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -250,10 +250,17 @@ function set_kvm_boot {
    set_global load_dom0_cmd linux
    set_global load_initrd_cmd initrd
    set_global dom0_extra_args "$dom0_extra_args pcie_acs_override=downstream,multifunction"
+   # this may strike readers as circular, but it really isn't
+   # the reason we have to also set eve_flavor to kvm here is
+   # that it used to be that set_kvm_boot was a sanctioned way
+   # to flip to KVM boot sequence. IOW, it used to be an elaborate
+   # way to setup the value of eve_flavor and we need to keep it
+   # like that for now.
    set_global eve_flavor kvm
 }
 
 function set_xen_boot {
+   # see the set_global eve_flavor kvm comment in set_kvm_boot
    set_global eve_flavor xen
 }
 

--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -59,6 +59,7 @@
 # what kind of control external context will have over this config file).
 #
 # Input variables (can NOT be longer than 20 characters)
+#  eve_flavor           can set to be either xen or kvm to indicated required boot sequence
 #  rootfs_root          name of a rootfilesystem recognizable by Dom0, if not set in the
 #                       outer context, the default value will be dynamically discovered
 #                       by running a partprobe command with an EVE rootfs UUID.
@@ -249,13 +250,22 @@ function set_kvm_boot {
    set_global load_dom0_cmd linux
    set_global load_initrd_cmd initrd
    set_global dom0_extra_args "$dom0_extra_args pcie_acs_override=downstream,multifunction"
+   set_global eve_flavor kvm
+}
+
+function set_xen_boot {
+   set_global eve_flavor xen
 }
 
 function set_eve_flavor {
-   if regexp -- '-kvm$' $rootfs_title ; then
-      set_kvm_boot
-   elif regexp -- '-kvm-' $rootfs_title ; then
-      set_kvm_boot
+   # if eve_flavor is not set explicitly we assume it is
+   # embedded in the name of the image
+   if [ "$eve_flavor" != xen -a "$eve_flavor" != kvm ] ; then
+      if regexp -- '-xen(-|$)' $rootfs_title ; then
+         eve_flavor=xen
+      else
+         eve_flavor=kvm
+      fi
    fi
 }
 
@@ -279,6 +289,9 @@ set_to_existing_file efi_grub_cfg "/EFI/BOOT/grub-hv.cfg"
 # process the overrides
 do_if_args source $efi_grub_cfg
 do_if_args source $config_grub_cfg
+
+# setup bootflow per EVE's flavor
+set_${eve_flavor}_boot
 
 menuentry "Boot ${rootfs_title}${rootfs_title_suffix}" {
      $load_hv_cmd $hv $hv_console $hv_platform_tweaks $hv_dom0_mem_settings $hv_dom0_cpu_settings $hv_extra_args


### PR DESCRIPTION
With the recent switch to KVM as the default hypervisor, we have introduced a small annoyance that it is actually quite difficult (albeit not impossible!) to have a quick knob in `grub.cfg` in the config partition that would flip a KVM image back to Xen boot sequence.

Note that the reverse has always been the case -- one can simply add `set_kvm_boot` line to grub.cfg and have Xen image boot in a KVM sequence.

This fix adds an ability to set `eve_flavor` variable to either `xen` or `kvm` as the override.

From now on, an officially supported way to flip a boot sequence is going to be adding the following to grub.cfg:
```
set_global eve_flavor xen|kvm
```

However, in order to support legacy deployments that may still have old school direct calls to `set_kvm_boot` function we're making sure that after such call is made eve_flavor is pointing to the kvm sequence as before.