### PR TITLE
If app instance not activated, mark it as HALTED 

### DIFF
--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -134,16 +134,11 @@ func doUpdate(ctx *zedmanagerContext,
 			c := doInactivateHalt(ctx, config, status)
 			changed = changed || c
 		} else {
-			// If we have a !ReadOnly disk this will create a copy
-			dc, err := MaybeAddDomainConfig(ctx, config, *status, nil)
-			if dc != nil {
-				publishDomainConfig(ctx, dc)
-			}
-			if err != nil {
-				log.Errorf("Error from MaybeAddDomainConfig for %s: %s",
-					uuidStr, err)
-				status.SetErrorWithSource(err.Error(),
-					types.DomainStatus{}, time.Now())
+			// Since we are not activating we set the state to
+			// HALTED to indicate it is not running since it
+			// might have been halted before the device was rebooted
+			if status.State == types.INSTALLED {
+				status.State = types.HALTED
 				changed = true
 			}
 		}


### PR DESCRIPTION
If the a running app instance has its config changed to Activate=false, then it will be halted and the state set to HALTED.
But then if the device is rebooted the state will be reported as INSTALLED, which is confusing.

This PR makes it report HALTED even after the device reboot, including in cases where Activate was never set to true for the app instance.
Basically HALTED means "not running" and does not imply that it has been running.