### PR TITLE
Rearranging assest according to the new installer

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -124,16 +124,6 @@ jobs:
 
             return release.upload_url
 
-      - name: Upload initrd.bits for the release
-        id: upload-initrd-bits-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create-release.outputs.result }}
-          asset_path: assets/initrd.bits
-          asset_name: ${{ env.ARCH }}.initrd.bits
-          asset_content_type: application/octet-stream
       - name: Upload rootfs for the release
         id: upload-rootfs-asset
         uses: actions/upload-release-asset@v1
@@ -154,6 +144,16 @@ jobs:
           asset_path: assets/kernel
           asset_name: ${{ env.ARCH }}.kernel
           asset_content_type: application/octet-stream
+      - name: Upload installer.img for the release
+        id: upload-installer-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.result }}
+          asset_path: assets/installer.img
+          asset_name: ${{ env.ARCH }}.installer.img
+          asset_content_type: application/octet-stream
       - name: Upload initrd.img for the release
         id: upload-initrd-asset
         uses: actions/upload-release-asset@v1
@@ -163,6 +163,16 @@ jobs:
           upload_url: ${{ steps.create-release.outputs.result }}
           asset_path: assets/initrd.img
           asset_name: ${{ env.ARCH }}.initrd.img
+          asset_content_type: application/octet-stream
+      - name: Upload initrd.bits for the release
+        id: upload-initrd-bits-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.result }}
+          asset_path: assets/initrd.bits
+          asset_name: ${{ env.ARCH }}.initrd.bits
           asset_content_type: application/octet-stream
       - name: Upload ipxe.efi.cfg for the release
         id: upload-ipxe-efi-cfg-asset


### PR DESCRIPTION
Trivial change to make sure we still upload in the biggest-to-smallest order