### PR TITLE
make sure image exists before returning volume

### DIFF
--- a/pkg/pillar/cmd/volumemgr/blob.go
+++ b/pkg/pillar/cmd/volumemgr/blob.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/lf-edge/eve/pkg/pillar/cas"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 )
 
@@ -603,4 +604,10 @@ func gcImagesFromCAS(ctx *volumemgrContext) {
 //checkAndCorrectBlobHash checks if the blobHash has hash algo sha256 as prefix. If not then it'll prepend it.
 func checkAndCorrectBlobHash(blobHash string) string {
 	return fmt.Sprintf("sha256:%s", strings.TrimPrefix(blobHash, "sha256:"))
+}
+
+// lookupImageCAS check if an image reference exists
+func lookupImageCAS(reference string, client cas.CAS) bool {
+	hash, err := client.GetImageHash(reference)
+	return err == nil && hash != ""
 }

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -378,10 +378,16 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 			log.Functionf("doUpdateContentTree(%s): Still have %d blobs left to load", status.Key(), leftToProcess)
 			return changed, false
 		}
-		log.Functionf("doUpdateContentTree(%s): all blobs LOADED", status.Key())
 
 		// if we made it here, then all blobs were loaded
 		log.Functionf("doUpdateContentTree(%s) successfully loaded all blobs into CAS", status.Key())
+
+		// check if the image was created
+		if !lookupImageCAS(status.ReferenceID(), ctx.casClient) {
+			log.Functionf("doUpdateContentTree(%s): image does not yet exist in CAS", status.Key())
+			return changed, false
+		}
+		log.Functionf("doUpdateContentTree(%s): image exists in CAS, Content Tree load is completely LOADED", status.Key())
 		status.State = types.LOADED
 		// ContentTreeStatus.FileLocation has no meaning once everything is loaded
 		status.FileLocation = ""


### PR DESCRIPTION
Fixes https://github.com/lf-edge/eden/issues/571

Summarizing from the issue problem there.

Here is what happens:

1. We request to install the baseos from an image, e.g. `lfedge/eve:6.0.0-kvm-amd64`
2. For reasons unknown (see above), we get **two** requests for content trees based on that image: one from zedagent, the other from baseosmgr. This should **not** be happening. Nonetheless, baseosmgr should be able to handle it.
3. Both get their manifests downloaded, all of the hashes inside get created as `DownloaderConfig`. These are downloaded exactly once, due to the deduplication we have.
4. All of them eventually get downloaded, verified.
5. `updatestatus` tries to load them into containerd and create an image reference for them. This happens for _each_ of the two content trees
6. The first one (whichever that is, usually the odd one from zedagent) loads all of its blobs into containerd, creates an image in containerd named `<UUID>-lfedge/eve@sha256:<hash>`.
7. In parallel, actually just slightly later, often <200 ms or even less, the second one (usually the one from baseosmgr) loads all of its blobs into containerd, creates an image in containerd named `<UUID>-lfedge/eve@sha256:<hash>`. `<hash>` between these two is identical, but `<UUID>` is different.
8. Upon return from load, each of them calls [updateStatusByBlob](https://github.com/lf-edge/eve/blob/a8c5dddf242095210736c20f465f6fb26e23db65/pkg/pillar/cmd/volumemgr/updatestatus.go#L554). This finds _all_ of the `ContentTreeStatus` which have those blobs and updates them and publishes them
9. This in turn calls [doUpdateContentTree](https://github.com/lf-edge/eve/blob/a8c5dddf242095210736c20f465f6fb26e23db65/pkg/pillar/cmd/volumemgr/updatestatus.go#L21), the core loop, for _both_ of the `ContentTreeStatus`. 
10. In parallel, in the background, the second (as-yet-unfinished) "load and create image" may still be running, or may be complete
11. [doUpdateContentTree](https://github.com/lf-edge/eve/blob/a8c5dddf242095210736c20f465f6fb26e23db65/pkg/pillar/cmd/volumemgr/updatestatus.go#L21) runs through all of the blobs, sees that they are loaded, says, "oh, I am done!", changes `ContentTreeStatus.STATE` to "LOADED", and publishes it.
12. baseosmgr sees the update to LOADED, tries to retrieve the image based on `<UUID>-lfedge/eve@sha256:<hash>` from containerd.

Because the blobs are _identical_ for both trees, the second to last step sometimes can happen quickly enough that the second tree has not quite yet completed creating its image reference in containerd, before the last step occurs. We get "no image found".

This fixes it so that it considers the ContentTree to be LOADED when all blobs have been loaded _and_ the image exists.

Easiest way to test is just to let it run via CI. @eriknordmark if you still have "special tests", these would be good here.