### PR TITLE
Make EVE handle larger cloud-init user data - take 2

### DIFF
--- a/pkg/pillar/agentlog/agentlog.go
+++ b/pkg/pillar/agentlog/agentlog.go
@@ -306,7 +306,7 @@ func RebootReason(reason string, bootReason types.BootReason, agentName string,
 	if bootReason != types.BootReasonNone {
 		filename = "/persist/" + bootReasonFile
 		brString := bootReason.String()
-		cur, _ := fileutils.StatAndRead(nil, filename, maxReadSize)
+		cur, _, _ := fileutils.StatAndRead(nil, filename, maxReadSize)
 		if cur != "" {
 			// Note: can not use log here since we are called from a log hook!
 			fmt.Printf("not replacing BootReason %s with %s\n",
@@ -351,22 +351,22 @@ func RebootStack(log *base.LogObject, stacks string, agentName string, agentPid 
 func GetRebootReason(log *base.LogObject) (string, time.Time, string) {
 	reasonFilename := fmt.Sprintf("%s/%s", types.PersistDir, reasonFile)
 	stackFilename := fmt.Sprintf("%s/%s", types.PersistDir, stackFile)
-	reason, ts := fileutils.StatAndRead(log, reasonFilename, maxReadSize)
-	stack, _ := fileutils.StatAndRead(log, stackFilename, maxReadSize)
+	reason, ts, _ := fileutils.StatAndRead(log, reasonFilename, maxReadSize)
+	stack, _, _ := fileutils.StatAndRead(log, stackFilename, maxReadSize)
 	return reason, ts, stack
 }
 
 // GetBootReason returns the BootReason enum, which is stored as a string in /persist, together with its timestamp
 func GetBootReason(log *base.LogObject) (types.BootReason, time.Time) {
 	reasonFilename := fmt.Sprintf("%s/%s", types.PersistDir, bootReasonFile)
-	reason, ts := fileutils.StatAndRead(log, reasonFilename, maxReadSize)
+	reason, ts, _ := fileutils.StatAndRead(log, reasonFilename, maxReadSize)
 	return types.BootReasonFromString(reason), ts
 }
 
 // GetRebootImage : Image from which the reboot happened
 func GetRebootImage(log *base.LogObject) string {
 	rebootFilename := fmt.Sprintf("%s/%s", types.PersistDir, rebootImage)
-	image, _ := fileutils.StatAndRead(log, rebootFilename, maxReadSize)
+	image, _, _ := fileutils.StatAndRead(log, rebootFilename, maxReadSize)
 	return image
 }
 

--- a/pkg/pillar/cmd/domainmgr/processes.go
+++ b/pkg/pillar/cmd/domainmgr/processes.go
@@ -62,7 +62,7 @@ func gatherProcessMetricList(ctx *domainContext) ([]types.ProcessMetric, map[int
 				// We limit the total memory used for stacks for
 				// all the processes.
 				filename := fmt.Sprintf("/proc/%d/stack", pi.Pid)
-				pi.Stack, _ = fileutils.StatAndRead(log, filename, maxStackStringLen)
+				pi.Stack, _, _ = fileutils.StatAndRead(log, filename, maxStackStringLen)
 				// Apply size limit
 				if pi.Stack != "" {
 					if totalStacks+len(pi.Stack) > totalMaxStackLen {

--- a/pkg/pillar/pubsub/checkmaxsize_test.go
+++ b/pkg/pillar/pubsub/checkmaxsize_test.go
@@ -17,8 +17,8 @@ import (
 )
 
 type largeItem struct {
-	StrA   string
-	StrC   string `json:"pubsub-large-StrC"`
+	StrA string
+	StrC string `json:"pubsub-large-StrC"`
 }
 
 func TestCheckMaxSize(t *testing.T) {
@@ -43,7 +43,7 @@ func TestCheckMaxSize(t *testing.T) {
 	}
 	ps := pubsub.New(&driver, logger, log)
 
-	// The values 449000 and 49122 have been determined experimentally
+	// The values 48000 and 49122 have been determined experimentally
 	// to be what fits and not for this particular struct and string
 	// content.
 	myCtx := context{}
@@ -58,24 +58,24 @@ func TestCheckMaxSize(t *testing.T) {
 		"File small enough": {
 			agentName: "",
 			//			agentScope: "testscope1",
-			stringSize: 49000,
+			stringSize: 48000,
 		},
 		"File with persistent small enough": {
 			agentName: "",
 			//			agentScope: "testscope2",
 			persistent: true,
-			stringSize: 49000,
+			stringSize: 48000,
 		},
 		"IPC small enough": {
 			agentName: "testagent1",
 			//			agentScope: "testscope",
-			stringSize: 49000,
+			stringSize: 48000,
 		},
 		"IPC with persistent small enough": {
 			agentName: "testagent2",
 			//			agentScope: "testscope",
 			persistent: true,
-			stringSize: 49000,
+			stringSize: 48000,
 		},
 		"File too large": {
 			agentName: "",

--- a/pkg/pillar/pubsub/driver.go
+++ b/pkg/pillar/pubsub/driver.go
@@ -42,6 +42,9 @@ type DriverSubscriber interface {
 	// Stop subscribing to a name and topic
 	// This is expected to return immediately.
 	Stop() error
+
+	// LargeDirName returns the directory to be used for large fields
+	LargeDirName() string
 }
 
 // DriverPublisher interface that a driver for publishing must implement
@@ -71,6 +74,9 @@ type DriverPublisher interface {
 
 	// CheckMaxSize to see if it will fit
 	CheckMaxSize(key string, val []byte) error
+
+	// LargeDirName returns the directory to be used for large fields
+	LargeDirName() string
 }
 
 // Restarted interface that lets you determine if a Publication has been restarted

--- a/pkg/pillar/pubsub/emptydriver.go
+++ b/pkg/pillar/pubsub/emptydriver.go
@@ -61,6 +61,11 @@ func (e *EmptyDriverPublisher) Stop() error {
 	return nil
 }
 
+// LargeDirName where to put large fields
+func (e *EmptyDriverPublisher) LargeDirName() string {
+	return "/tmp"
+}
+
 // EmptyDriverSubscriber struct
 type EmptyDriverSubscriber struct{}
 
@@ -78,4 +83,9 @@ func (e *EmptyDriverSubscriber) Load() (map[string][]byte, int, error) {
 // Stop function
 func (e *EmptyDriverSubscriber) Stop() error {
 	return nil
+}
+
+// LargeDirName where to put large fields
+func (e *EmptyDriverSubscriber) LargeDirName() string {
+	return "/tmp"
 }

--- a/pkg/pillar/pubsub/large.go
+++ b/pkg/pillar/pubsub/large.go
@@ -1,0 +1,259 @@
+// Copyright (c) 2021 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package pubsub
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
+)
+
+const (
+	// maxLargeLen is the largest single file we support
+	maxLargeLen = 1024 * 1024
+	// tagLarge is the prefix in the json tag which directs us to use files
+	tagLarge = "pubsub-large-"
+	// tagFile is the internal prefix we use for the filename
+	tagFile = "pubsub-file-"
+)
+
+// The generic type for a json decode
+type jsonTree map[string]interface{}
+
+// removeLarge removes all json with the tagLarge prefix
+func removeLarge(log *base.LogObject, b []byte, rootDir string) ([]byte, error) {
+	return writeLargeImpl(log, b, "", rootDir)
+}
+
+// writeAndRemoveLarge looks for the tagLarge prefix, saves the content of those
+// fields to uniquely-named files under dirname, and inserts tagFile prefixed
+// fields in the json to specify the fileaname
+func writeAndRemoveLarge(log *base.LogObject, b []byte, dirname string) ([]byte, error) {
+	return writeLargeImpl(log, b, dirname, "")
+}
+
+// If dirname is set we write files there.
+// Otherwise we use rootDir to estimate the size of the fileTag entries
+func writeLargeImpl(log *base.LogObject, b []byte, dirname string, rootDir string) ([]byte, error) {
+	var tree jsonTree
+
+	err := json.Unmarshal(b, &tree)
+	if err != nil {
+		err := fmt.Errorf("writeLargeImpl: json.Unmarshal failed for %s: %v",
+			dirname, err)
+		return nil, err
+	}
+	tree, err = writeRemoveTree(log, tree, dirname, rootDir)
+	if err != nil {
+		return nil, err
+	}
+	log.Tracef("New tree: %+v", tree)
+	b, err = json.Marshal(tree)
+	if err != nil {
+		err := fmt.Errorf("writeLargeImpl: json.Marshal failed for %s: %v",
+			dirname, err)
+		return nil, err
+	}
+	return b, nil
+}
+
+func writeRemoveTree(log *base.LogObject,
+	tree jsonTree, dirname string, rootDir string) (jsonTree, error) {
+
+	out := make(jsonTree)
+	for k, v := range tree {
+		if !strings.HasPrefix(k, tagLarge) {
+			// descend into subtree if map
+			tree1, ok := v.(jsonTree)
+			if !ok {
+				out[k] = v
+				continue
+			}
+			log.Tracef("Descending into %s", k)
+			tree1, err := writeRemoveTree(log, tree1, dirname, rootDir)
+			if err != nil {
+				return out, err
+			}
+			out[k] = tree1
+			continue
+		}
+		oldTagLen := len(tagLarge)
+		nk := tagFile + k[oldTagLen:]
+
+		log.Tracef("tag %s type %T val %v\n", k, v, v)
+
+		// We need to have a map to marshal (with a dummy tag -
+		// we use k as the dummy), so that atoms and other values can be
+		// consistently unmarshalled in readAddLarge()
+		val := make(jsonTree)
+		val[k] = v
+		b, err := json.Marshal(val)
+		if err != nil {
+			err := fmt.Errorf("writeRemoveTree: Marshal failed for %s: %v",
+				nk, err)
+			return out, err
+		}
+		length := len(b)
+		if length >= maxLargeLen {
+			err := fmt.Errorf("too large string %d bytes for %s",
+				length, k)
+			return out, err
+		}
+		if dirname == "" {
+			// Guess how much space a filename would take
+			filename := rootDir + "0123456789012345678901234567890123456789012345678901234567890123456789"
+			b, err := json.Marshal(filename)
+			if err != nil {
+				err := fmt.Errorf("writeRemoveTree: filename Marshal failed for %s: %v",
+					filename, err)
+				return out, err
+			}
+			out[nk] = string(b)
+			continue
+		}
+		err = EnsureDir(dirname)
+		if err != nil {
+			err := fmt.Errorf("writeRemoveTree: EnsureDir failed for %s %s: %v",
+				dirname, nk, err)
+			return out, err
+		}
+		tmpfile, err := ioutil.TempFile(dirname, nk)
+		if err != nil {
+			err := fmt.Errorf("writeRemoveTree: TempFile failed for %s %s: %v",
+				dirname, nk, err)
+			return out, err
+		}
+		defer tmpfile.Close()
+		filename := tmpfile.Name()
+
+		_, err = tmpfile.Write(b)
+		if err != nil {
+			err := fmt.Errorf("writeRemoveTree: Write failed for %s %s: %v",
+				dirname, nk, err)
+			return out, err
+		}
+		tmpfile.Close()
+
+		b, err = json.Marshal(filename)
+		if err != nil {
+			err := fmt.Errorf("writeRemoveTree: filename Marshal failed for %s: %v",
+				filename, err)
+			return out, err
+		}
+		out[nk] = string(b)
+	}
+	return out, nil
+}
+
+// EnsureDir to make sure it exists
+func EnsureDir(dirname string) error {
+	_, err := os.Stat(dirname)
+	if err != nil {
+		err := os.MkdirAll(dirname, 0755)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// readAddLarge walks the json and uses readfile to fill in those fields which
+// have a tagFile prefix.
+// If there is an error it returns the input
+func readAddLarge(log *base.LogObject, b []byte) ([]byte, error) {
+	var tree jsonTree
+
+	err := json.Unmarshal(b, &tree)
+	if err != nil {
+		err := fmt.Errorf("readAddLarge: json.Unmarshal failed: %v",
+			err)
+		return b, err
+	}
+	tree, err = readAddTree(log, tree)
+	if err != nil {
+		return b, err
+	}
+	log.Tracef("New tree: %+v", tree)
+	out, err := json.Marshal(tree)
+	if err != nil {
+		err := fmt.Errorf("readAddLarge: json.Marshal failed: %v",
+			err)
+		return b, err
+	}
+	return out, nil
+}
+
+func readAddTree(log *base.LogObject, tree jsonTree) (jsonTree, error) {
+	out := make(jsonTree)
+	for k, v := range tree {
+		if !strings.HasPrefix(k, tagFile) {
+			// descend into subtree if map
+			tree1, ok := v.(jsonTree)
+			if !ok {
+				out[k] = v
+				continue
+			}
+			log.Tracef("Descending into %s", k)
+			tree1, err := readAddTree(log, tree1)
+			if err != nil {
+				return out, err
+			}
+			out[k] = tree1
+			continue
+		}
+		oldTagLen := len(tagFile)
+		nk := tagLarge + k[oldTagLen:]
+
+		str, ok := v.(string)
+		if !ok {
+			err := fmt.Errorf("readAddLarge: value not a string but %T for %s",
+				v, k)
+			return nil, err
+		}
+		log.Tracef("tag %s value: %s", k, str)
+		var filename string
+		err := json.Unmarshal([]byte(str), &filename)
+		if err != nil {
+			err := fmt.Errorf("readAddLarge: filename Unmarshal failed for %s: %v",
+				k, err)
+			return nil, err
+		}
+		str, _, err = fileutils.StatAndRead(log, filename, maxLargeLen+1)
+		if err != nil {
+			// XXX we handle not exists.
+			if !os.IsNotExist(err) && err != io.EOF {
+				err := fmt.Errorf("readAddLarge: failed for %s: %v",
+					k, err)
+				return nil, err
+			}
+		}
+		os.Remove(filename)
+		if len(str) == 0 {
+			continue
+		}
+		log.Tracef("tag %s read %s content: %s", k, filename, str)
+		var val jsonTree
+		err = json.Unmarshal([]byte(str), &val)
+		if err != nil {
+			err := fmt.Errorf("readAddLarge: file content Unmarshal failed for %s: %v",
+				filename, err)
+			return nil, err
+		}
+		if len(val) != 1 {
+			err := fmt.Errorf("readAddLarge: map read from file %s has %d keys for %s",
+				filename, len(val), k)
+			return nil, err
+		}
+		for _, v1 := range val {
+			out[nk] = v1
+		}
+	}
+	return out, nil
+}

--- a/pkg/pillar/pubsub/publish.go
+++ b/pkg/pillar/pubsub/publish.go
@@ -51,6 +51,7 @@ type PublicationImpl struct {
 	global      bool
 	defaultName string
 	updaterList *Updaters
+	persistent  bool
 	logger      *logrus.Logger
 	log         *base.LogObject
 
@@ -217,10 +218,12 @@ func (pub *PublicationImpl) Iterate(function base.StrMapFunc) {
 // Close the publisher
 func (pub *PublicationImpl) Close() error {
 	items := pub.GetAll()
-	for key := range items {
-		pub.log.Functionf("Close(%s) unloading key %s",
-			pub.nameString(), key)
-		pub.Unpublish(key)
+	if !pub.persistent {
+		for key := range items {
+			pub.log.Functionf("Close(%s) unloading key %s",
+				pub.nameString(), key)
+			pub.Unpublish(key)
+		}
 	}
 	pub.ClearRestarted()
 	pub.driver.Stop()

--- a/pkg/pillar/pubsub/pubsub.go
+++ b/pkg/pillar/pubsub/pubsub.go
@@ -172,6 +172,7 @@ func (p *PubSub) NewPublication(options PublicationOptions) (Publication, error)
 		km:          keyMap{key: base.NewLockedStringMap()},
 		updaterList: p.updaterList,
 		defaultName: p.driver.DefaultName(),
+		persistent:  options.Persistent,
 		logger:      p.logger,
 		log:         p.log,
 	}

--- a/pkg/pillar/pubsub/socketdriver/driver.go
+++ b/pkg/pillar/pubsub/socketdriver/driver.go
@@ -158,6 +158,7 @@ func (s *SocketDriver) Publisher(global bool, name, topic string, persistent boo
 		logger:         s.Logger,
 		log:            s.Log,
 		doneChan:       doneChan,
+		rootDir:        s.RootDir,
 	}, nil
 }
 
@@ -215,6 +216,7 @@ func (s *SocketDriver) Subscriber(global bool, name, topic string, persistent bo
 		logger:           s.Logger,
 		log:              s.Log,
 		doneChan:         doneChan,
+		rootDir:          s.RootDir,
 	}, nil
 }
 

--- a/pkg/pillar/pubsub/socketdriver/publish.go
+++ b/pkg/pillar/pubsub/socketdriver/publish.go
@@ -189,7 +189,7 @@ func (s *Publisher) Restart(restartCounter int) error {
 
 // LargeDirName where to put large fields
 func (s *Publisher) LargeDirName() string {
-	return fmt.Sprintf("%s/persist/vault/pubsub-large", s.rootDir)
+	return fmt.Sprintf("%s/persist/pubsub-large", s.rootDir)
 }
 
 func (s *Publisher) serveConnection(conn net.Conn, instance int) {

--- a/pkg/pillar/pubsub/socketdriver/publish.go
+++ b/pkg/pillar/pubsub/socketdriver/publish.go
@@ -38,6 +38,7 @@ type Publisher struct {
 	logger         *logrus.Logger
 	log            *base.LogObject
 	doneChan       chan struct{}
+	rootDir        string
 }
 
 // Publish publish a key-value pair
@@ -184,6 +185,11 @@ func (s *Publisher) Restart(restartCounter int) error {
 		}
 	}
 	return nil
+}
+
+// LargeDirName where to put large fields
+func (s *Publisher) LargeDirName() string {
+	return fmt.Sprintf("%s/persist/vault/pubsub-large", s.rootDir)
 }
 
 func (s *Publisher) serveConnection(conn net.Conn, instance int) {

--- a/pkg/pillar/pubsub/socketdriver/subscribe.go
+++ b/pkg/pillar/pubsub/socketdriver/subscribe.go
@@ -37,6 +37,7 @@ type Subscriber struct {
 	logger           *logrus.Logger
 	log              *base.LogObject
 	doneChan         chan struct{}
+	rootDir          string
 }
 
 // Load load entire persisted data set into a map
@@ -160,6 +161,11 @@ func (s *Subscriber) Stop() error {
 			s.name, "nowhere to stop")
 		return errors.New(errStr)
 	}
+}
+
+// LargeDirName where to put large fields
+func (s *Subscriber) LargeDirName() string {
+	return fmt.Sprintf("%s/persist/vault/pubsub-large", s.rootDir)
 }
 
 func (s *Subscriber) watchSock() {

--- a/pkg/pillar/pubsub/socketdriver/subscribe.go
+++ b/pkg/pillar/pubsub/socketdriver/subscribe.go
@@ -165,7 +165,7 @@ func (s *Subscriber) Stop() error {
 
 // LargeDirName where to put large fields
 func (s *Subscriber) LargeDirName() string {
-	return fmt.Sprintf("%s/persist/vault/pubsub-large", s.rootDir)
+	return fmt.Sprintf("%s/persist/pubsub-large", s.rootDir)
 }
 
 func (s *Subscriber) watchSock() {

--- a/pkg/pillar/pubsub/subscribe.go
+++ b/pkg/pillar/pubsub/subscribe.go
@@ -218,6 +218,14 @@ func handleModify(ctxArg interface{}, key string, itemcb []byte) {
 	sub := ctxArg.(*SubscriptionImpl)
 	name := sub.nameString()
 	sub.log.Tracef("pubsub.handleModify(%s) key %s\n", name, key)
+	// Any large items which were stored separately?
+	itemcb, err := readAddLarge(sub.log, itemcb)
+	if err != nil {
+		errStr := fmt.Sprintf("handleModify(%s): readAddLarge failed %s",
+			name, err)
+		sub.log.Errorln(errStr)
+		return
+	}
 	item, err := parseTemplate(sub.log, itemcb, sub.topicType)
 	if err != nil {
 		errStr := fmt.Sprintf("handleModify(%s): json failed %s",

--- a/pkg/pillar/types/cipherinfotypes.go
+++ b/pkg/pillar/types/cipherinfotypes.go
@@ -84,7 +84,7 @@ type CipherBlockStatus struct {
 	CipherBlockID   string // constructed using individual reference
 	CipherContextID string // cipher context id
 	InitialValue    []byte
-	CipherData      []byte
+	CipherData      []byte `json:"pubsub-large-CipherData"`
 	ClearTextHash   []byte
 	IsCipher        bool
 	// ErrorAndTime provides SetErrorNow() and ClearError()

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -61,7 +61,7 @@ type AppInstanceConfig struct {
 	RestartCmd          AppInstanceOpsCmd
 	PurgeCmd            AppInstanceOpsCmd
 	// XXX: to be deprecated, use CipherBlockStatus instead
-	CloudInitUserData *string // base64-encoded
+	CloudInitUserData *string `json:"pubsub-large-CloudInitUserData"`
 	RemoteConsole     bool
 	// Collect Stats IP Address, assume port is the default docker API for http: 2375
 	CollectStatsIPAddr net.IP

--- a/pkg/pillar/utils/file/file.go
+++ b/pkg/pillar/utils/file/file.go
@@ -53,29 +53,40 @@ func Writable(dir string) bool {
 }
 
 // StatAndRead returns the content and Modtime
-// We limit the size we read maxReadSize and silently truncate if longer
-func StatAndRead(log *base.LogObject, filename string, maxReadSize int) (string, time.Time) {
+// We limit the size we read maxReadSize and truncate if longer
+func StatAndRead(log *base.LogObject, filename string, maxReadSize int) (string, time.Time, error) {
 	fi, err := os.Stat(filename)
 	if err != nil {
 		// File doesn't exist
-		return "", time.Time{}
+		return "", time.Time{}, err
+	}
+	if fi.Size() == 0 {
+		return "", fi.ModTime(), nil
 	}
 	f, err := os.Open(filename)
 	if err != nil {
+		err = fmt.Errorf("StatAndRead %s failed: %v", filename, err)
 		if log != nil {
-			log.Errorf("StatAndRead failed %s", err)
+			log.Error(err)
 		}
-		return "", fi.ModTime()
+		return "", fi.ModTime(), err
 	}
 	defer f.Close()
 	r := bufio.NewReader(f)
 	content := make([]byte, maxReadSize)
 	n, err := r.Read(content)
 	if err != nil {
+		err = fmt.Errorf("StatAndRead %s failed: %v", filename, err)
 		if log != nil {
-			log.Errorf("StatAndRead failed %s", err)
+			log.Error(err)
 		}
-		return "", fi.ModTime()
+		return "", fi.ModTime(), err
 	}
-	return string(content[0:n]), fi.ModTime()
+	if n == maxReadSize {
+		err = fmt.Errorf("StatAndRead %s truncated after %d bytes",
+			filename, maxReadSize)
+	} else {
+		err = nil
+	}
+	return string(content[0:n]), fi.ModTime(), err
 }


### PR DESCRIPTION
As an alternative to #2000 

Instead of using a pubsub:"large" tag as in #2000  this requires that the large items use a json:"pubsub-large-X" tag, but it does not require any special hacks since it can handle those tags anywhere in the json.
Furthermore, unlike #2000 the files are unique for every change thus no semantic difference between a file and an inline delivery of the field.

The code to enable large fields for CloudInitUserData and CipherData is the last commit called "use pubsub-large- tags for cloud-init data to enable 1M max size".

The implementation is in the commit called "Add handling of pubsub-large- prefix".
Rest is tests and cleanup/restructure of existing things to facilitate the implementation.