### PR TITLE
fix config order in eden gcp

### DIFF
--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -70,6 +70,7 @@ jobs:
           ./eden config set default --key eve.hv --value ${{ matrix.hv }}
           ./eden config set default --key adam.eve-ip --value ${{ steps.connect_vpn.outputs.tunnel_ip }}
           ./eden config set default --key registry.ip --value ${{ steps.connect_vpn.outputs.tunnel_ip }}
+          ./eden config set default --key=eden.tests --value=${{ github.workspace }}/eve/tests/eden
           ./eden utils gcp firewall --source-range $ipv4/32 --name eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} -k "$GOOGLE_APPLICATION_CREDENTIALS"
           ./eden setup -v debug
           ./eden utils gcp image --image-name eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} -k "$GOOGLE_APPLICATION_CREDENTIALS" upload
@@ -81,7 +82,6 @@ jobs:
           ./eden utils gcp firewall -k "$GOOGLE_APPLICATION_CREDENTIALS" --source-range $BWD --name edengcp-actions-${{ matrix.hv }}-${{github.run_number}} || { echo "cannot set firewall"; exit 1; }
           ./eden eve onboard
           echo > tests/workflow/testdata/eden_stop.txt
-          ./eden config set default --key=eden.tests --value=${{ github.workspace }}/eve/tests/eden
       - name: Test
         run: |
           EDEN_TEST=gcp ./eden test ${{ github.workspace }}/eve/tests/eden/workflow -v debug


### PR DESCRIPTION
We should not modify config of Eden between setup and CI test to not get the [error](https://github.com/lf-edge/eve/runs/2268205998?check_suite_focus=true#step:11:34).

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>