### PR TITLE
fix bootloader and cpu for arm64

### DIFF
--- a/pkg/pillar/cmd/zedmanager/handledomainmgr.go
+++ b/pkg/pillar/cmd/zedmanager/handledomainmgr.go
@@ -102,7 +102,7 @@ func MaybeAddDomainConfig(ctx *zedmanagerContext,
 			}
 		}
 	}
-	if dc.BootLoader == "" && dc.VirtualizationModeOrDefault() == types.FML {
+	if dc.BootLoader == "" && (dc.VirtualizationModeOrDefault() == types.FML || runtime.GOARCH == "arm64") {
 		dc.BootLoader = "/usr/lib/xen/boot/ovmf.bin"
 	}
 	if ns != nil {

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -361,7 +361,7 @@ func newKvm() Hypervisor {
 			dmExec:       "/usr/lib/xen/bin/qemu-system-aarch64",
 			dmArgs:       []string{"-display", "none", "-S", "-no-user-config", "-nodefaults", "-no-shutdown", "-overcommit", "mem-lock=on", "-overcommit", "cpu-pm=on", "-serial", "chardev:charserial0"},
 			dmCPUArgs:    []string{"-cpu", "host"},
-			dmFmlCPUArgs: []string{},
+			dmFmlCPUArgs: []string{"-cpu", "host"},
 		}
 	case "amd64":
 		return kvmContext{


### PR DESCRIPTION
Seems, we should set ovmf bootloader in case of arm64.
Also we need to set cpu in FML mode for arm64, without it we get  `qemu-system-aarch64: KVM is not supported for this guest CPU type`.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>