### PR TITLE
Fixing VolumeRefStatusList in AppInstanceStatus

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1513,6 +1513,7 @@ func configToStatus(ctx *domainContext, config types.DomainConfig,
 	need9P := false
 	for i, dc := range config.DiskConfigList {
 		ds := &status.DiskStatusList[i]
+		ds.VolumeKey = dc.VolumeKey
 		ds.ReadOnly = dc.ReadOnly
 		ds.FileLocation = dc.FileLocation
 		ds.Format = dc.Format

--- a/pkg/pillar/cmd/zedmanager/handledomainmgr.go
+++ b/pkg/pillar/cmd/zedmanager/handledomainmgr.go
@@ -63,6 +63,7 @@ func MaybeAddDomainConfig(ctx *zedmanagerContext,
 			return nil, errors.New(errStr)
 		}
 		disk := types.DiskConfig{}
+		disk.VolumeKey = vrs.Key()
 		disk.FileLocation = location
 		disk.ReadOnly = vrs.ReadOnly
 		disk.Format = vrs.ContentFormat

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -316,6 +316,7 @@ type VifInfo struct {
 // Note that vdev in general can be hd[x], xvd[x], sd[x] but here we only
 // use xvd
 type DiskConfig struct {
+	VolumeKey    string
 	FileLocation string // Location of the volume
 	ReadOnly     bool
 	Format       zconfig.Format
@@ -324,6 +325,7 @@ type DiskConfig struct {
 }
 
 type DiskStatus struct {
+	VolumeKey    string
 	ReadOnly     bool
 	FileLocation string // From DiskConfig
 	Format       zconfig.Format


### PR DESCRIPTION
Bugfix: Need to update ```VolumeRefStatusList``` in ```AppInstanceStatus``` while purging in ```zedmanager```. Otherwise, ```VolumeRefStatusList``` will be out of sync from the ```VolumeRefConfigList``` in ```AppInstanceConfig```.