### PR TITLE
attempt to zero the first 5Mb of the P3 during init

### DIFF
--- a/pkg/storage-init/storage-init.sh
+++ b/pkg/storage-init/storage-init.sh
@@ -82,6 +82,11 @@ if [ -n "$IMGA" ] && [ -z "$P3" ] && [ -z "$IMGB" ]; then
    # focrce kernel to re-scan partition table
    partprobe "$DEV"
    partx -a --nr "$IMGB_ID:$P3_ID" "$DEV"
+
+   # attempt to zero the first 5Mb of the P3 (to get rid of any residual prior data)
+   if P3=$(findfs PARTLABEL=P3) && [ -n "$P3" ]; then
+      dd if=/dev/zero of="$P3" bs=512 count=10240 2>/dev/null
+   fi
 fi
 
 # We support P3 partition either formatted as ext3/4 or as part of ZFS pool


### PR DESCRIPTION
Tiny fix to make sure that when we produce live images (especially for RPi4 type of deployment) we actually wipe the data in the `/persist` partition. The problem is that we don't actually produce the entirety of the live image (that'd be wasteful) but rather rely on the first boot detecting that the live image is missing P3 and creating it on the fly. This approach, however, would create exact same partition that may already have been there, which, in turn, will make all the previous filesystem data simply show up. We don't want that since live image deployments are supposed to be all-or-nothing affairs.