### PR TITLE
Take change to network.download.max.cost into account for already started downloads

### DIFF
--- a/pkg/pillar/cmd/downloader/context.go
+++ b/pkg/pillar/cmd/downloader/context.go
@@ -4,8 +4,6 @@
 package downloader
 
 import (
-	"sync"
-
 	"github.com/lf-edge/eve/libs/zedUpload"
 	"github.com/lf-edge/eve/pkg/pillar/cipher"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
@@ -23,9 +21,9 @@ type downloaderContext struct {
 	pubCipherBlockStatus   pubsub.Publication
 	subDatastoreConfig     pubsub.Subscription
 	deviceNetworkStatus    types.DeviceNetworkStatus
-	globalStatusLock       sync.Mutex
 	subGlobalConfig        pubsub.Subscription
 	GCInitialized          bool
+	downloadMaxPortCost    uint8
 }
 
 func (ctx *downloaderContext) registerHandlers(ps *pubsub.PubSub) error {

--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -322,15 +322,14 @@ func handleCreate(ctx *downloaderContext, config types.DownloaderConfig,
 	if status == nil {
 		// Start by marking with PendingAdd
 		status0 := types.DownloaderStatus{
-			DatastoreID:         config.DatastoreID,
-			Name:                config.Name,
-			ImageSha256:         config.ImageSha256,
-			State:               types.DOWNLOADING,
-			RefCount:            config.RefCount,
-			Size:                config.Size,
-			LastUse:             time.Now(),
-			DownloadMaxPortCost: config.DownloadMaxPortCost,
-			PendingAdd:          true,
+			DatastoreID: config.DatastoreID,
+			Name:        config.Name,
+			ImageSha256: config.ImageSha256,
+			State:       types.DOWNLOADING,
+			RefCount:    config.RefCount,
+			Size:        config.Size,
+			LastUse:     time.Now(),
+			PendingAdd:  true,
 		}
 		status = &status0
 	} else {

--- a/pkg/pillar/cmd/downloader/globalconfig.go
+++ b/pkg/pillar/cmd/downloader/globalconfig.go
@@ -39,6 +39,7 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 		if gcp.GlobalValueInt(types.DownloadStalledTime) != 0 {
 			maxStalledTime = time.Duration(gcp.GlobalValueInt(types.DownloadStalledTime)) * time.Second
 		}
+		ctx.downloadMaxPortCost = uint8(gcp.GlobalValueInt(types.DownloadMaxPortCost))
 		ctx.GCInitialized = true
 	}
 	log.Functionf("handleGlobalConfigImpl done for %s", key)

--- a/pkg/pillar/cmd/downloader/resolveconfig.go
+++ b/pkg/pillar/cmd/downloader/resolveconfig.go
@@ -173,16 +173,17 @@ func resolveTagsToHash(ctx *downloaderContext, rc types.ResolveConfig) {
 		return
 	}
 
-	log.Functionf("Resolving config <%s> using %d DownloadMaxPortCost",
-		rc.Name, rc.DownloadMaxPortCost)
+	downloadMaxPortCost := ctx.downloadMaxPortCost
+	log.Functionf("Resolving config <%s> using %d downloadMaxPortCost",
+		rc.Name, downloadMaxPortCost)
 
 	addrCount := types.CountLocalAddrNoLinkLocalWithCost(ctx.deviceNetworkStatus,
-		rc.DownloadMaxPortCost)
+		downloadMaxPortCost)
 	log.Functionf("Have %d management port addresses for cost %d",
-		addrCount, rc.DownloadMaxPortCost)
+		addrCount, downloadMaxPortCost)
 	if addrCount == 0 {
 		err := fmt.Errorf("No IP management port addresses for resolve with cost %d",
-			rc.DownloadMaxPortCost)
+			downloadMaxPortCost)
 		log.Error(err.Error())
 		rs.SetErrorNow(err.Error())
 		publishResolveStatus(ctx, rs)
@@ -221,7 +222,7 @@ func resolveTagsToHash(ctx *downloaderContext, rc types.ResolveConfig) {
 	// Loop through all interfaces until a success
 	for addrIndex := 0; addrIndex < addrCount; addrIndex++ {
 		ipSrc, err := types.GetLocalAddrNoLinkLocalWithCost(ctx.deviceNetworkStatus,
-			addrIndex, "", rc.DownloadMaxPortCost)
+			addrIndex, "", downloadMaxPortCost)
 		if err != nil {
 			log.Errorf("GetLocalAddr failed: %s", err)
 			errStr = errStr + "\n" + err.Error()

--- a/pkg/pillar/cmd/downloader/syncop.go
+++ b/pkg/pillar/cmd/downloader/syncop.go
@@ -67,14 +67,15 @@ func handleSyncOp(ctx *downloaderContext, key string,
 		}
 	}
 
-	log.Functionf("Downloading <%s> to <%s> using %d DownloadMaxPortCost",
-		config.Name, locFilename, config.DownloadMaxPortCost)
+	downloadMaxPortCost := ctx.downloadMaxPortCost
+	log.Functionf("Downloading <%s> to <%s> using %d downloadMaxPortCost",
+		config.Name, locFilename, downloadMaxPortCost)
 
 	addrCount := types.CountLocalAddrNoLinkLocalWithCost(ctx.deviceNetworkStatus,
-		config.DownloadMaxPortCost)
+		downloadMaxPortCost)
 	if addrCount == 0 {
 		err := fmt.Errorf("No IP management port addresses for download with cost %d",
-			config.DownloadMaxPortCost)
+			downloadMaxPortCost)
 		log.Error(err.Error())
 		handleSyncOpResponse(ctx, config, status, locFilename,
 			key, err.Error())
@@ -163,7 +164,7 @@ func handleSyncOp(ctx *downloaderContext, key string,
 	// Loop through all interfaces until a success
 	for addrIndex := 0; addrIndex < addrCount; addrIndex++ {
 		ipSrc, err := types.GetLocalAddrNoLinkLocalWithCost(ctx.deviceNetworkStatus,
-			addrIndex, "", config.DownloadMaxPortCost)
+			addrIndex, "", downloadMaxPortCost)
 		if err != nil {
 			log.Errorf("GetLocalAddr failed: %s", err)
 			errStr = errStr + "\n" + err.Error()

--- a/pkg/pillar/cmd/volumemgr/handledownloader.go
+++ b/pkg/pillar/cmd/volumemgr/handledownloader.go
@@ -50,15 +50,13 @@ func AddOrRefcountDownloaderConfig(ctx *volumemgrContext, blob types.BlobStatus)
 
 	// try to reserve storage, must be released on error
 	size := blob.Size
-	maxCost := ctx.globalConfig.GlobalValueInt(types.DownloadMaxPortCost)
 	n := types.DownloaderConfig{
-		DatastoreID:         blob.DatastoreID,
-		Name:                blob.RelativeURL,
-		ImageSha256:         blob.Sha256,
-		DownloadMaxPortCost: uint8(maxCost),
-		Size:                size,
-		Target:              locFilename,
-		RefCount:            refCount,
+		DatastoreID: blob.DatastoreID,
+		Name:        blob.RelativeURL,
+		ImageSha256: blob.Sha256,
+		Size:        size,
+		Target:      locFilename,
+		RefCount:    refCount,
 	}
 	log.Functionf("AddOrRefcountDownloaderConfig: DownloaderConfig: %+v", n)
 	publishDownloaderConfig(ctx, &n)

--- a/pkg/pillar/cmd/volumemgr/handleresolve.go
+++ b/pkg/pillar/cmd/volumemgr/handleresolve.go
@@ -12,12 +12,10 @@ import (
 func MaybeAddResolveConfig(ctx *volumemgrContext, cs types.ContentTreeStatus) {
 
 	log.Functionf("MaybeAddResolveConfig for %s", cs.ContentID)
-	maxCost := ctx.globalConfig.GlobalValueInt(types.DownloadMaxPortCost)
 	resolveConfig := types.ResolveConfig{
-		DatastoreID:         cs.DatastoreID,
-		Name:                cs.RelativeURL,
-		DownloadMaxPortCost: uint8(maxCost),
-		Counter:             uint32(cs.GenerationCounter),
+		DatastoreID: cs.DatastoreID,
+		Name:        cs.RelativeURL,
+		Counter:     uint32(cs.GenerationCounter),
 	}
 	publishResolveConfig(ctx, &resolveConfig)
 	log.Functionf("MaybeAddResolveConfig for %s Done", cs.ContentID)

--- a/pkg/pillar/types/downloadertypes.go
+++ b/pkg/pillar/types/downloadertypes.go
@@ -18,9 +18,6 @@ type DownloaderConfig struct {
 	Name        string
 	Target      string // file path where to download the file
 	NameIsURL   bool   // If not we form URL based on datastore info
-
-	DownloadMaxPortCost uint8
-
 	Size        uint64 // In bytes
 	FinalObjDir string // final Object Store
 	RefCount    uint
@@ -105,15 +102,12 @@ type DownloaderStatus struct {
 	LastUse       time.Time // When RefCount dropped to zero
 	Expired       bool      // Handshake to client
 	NameIsURL     bool      // If not we form URL based on datastore info
-
-	DownloadMaxPortCost uint8
-
-	State         SwState // DOWNLOADED etc
-	ReservedSpace uint64  // Contribution to global ReservedSpace
-	Size          uint64  // Once DOWNLOADED; in bytes
-	TotalSize     int64   // expected size as reported by the downloader, if any
-	CurrentSize   int64   // current total downloaded size as reported by the downloader
-	Progress      uint    // In percent i.e., 0-100, given by CurrentSize/ExpectedSize
+	State         SwState   // DOWNLOADED etc
+	ReservedSpace uint64    // Contribution to global ReservedSpace
+	Size          uint64    // Once DOWNLOADED; in bytes
+	TotalSize     int64     // expected size as reported by the downloader, if any
+	CurrentSize   int64     // current total downloaded size as reported by the downloader
+	Progress      uint      // In percent i.e., 0-100, given by CurrentSize/ExpectedSize
 	ModTime       time.Time
 	ContentType   string // content-type header, if provided
 	// ErrorAndTime provides SetErrorNow() and ClearError()

--- a/pkg/pillar/types/resolvertypes.go
+++ b/pkg/pillar/types/resolvertypes.go
@@ -16,10 +16,9 @@ import (
 // and the sequence counter.
 // It will resolve the tag in name to sha256
 type ResolveConfig struct {
-	DatastoreID         uuid.UUID
-	Name                string
-	DownloadMaxPortCost uint8
-	Counter             uint32
+	DatastoreID uuid.UUID
+	Name        string
+	Counter     uint32
 }
 
 // Key : DatastoreID, name and sequence counter are used


### PR DESCRIPTION
Tested by having a port with cost 17 and starting the deployment with network.download.max.cost set to zero.
After a few download failures, I increased network.download.max.cost to 20, and then the next download retry gets through.