### PR TITLE
null backend for chardev

### DIFF
--- a/pkg/xen-tools/patches-4.15.0/11-char-socket-revert.patch
+++ b/pkg/xen-tools/patches-4.15.0/11-char-socket-revert.patch
@@ -1,0 +1,24 @@
+diff --git a/tools/qemu-xen/chardev/char-socket.c b/tools/qemu-xen/chardev/char-socket.c
+index ef62dbf..7ad180e 100644
+--- a/tools/qemu-xen/chardev/char-socket.c
++++ b/tools/qemu-xen/chardev/char-socket.c
+@@ -177,16 +177,15 @@ static int tcp_chr_write(Chardev *chr, const uint8_t *buf, int len)
+ 
+         if (ret < 0 && errno != EAGAIN) {
+             if (tcp_chr_read_poll(chr) <= 0) {
+-                /* Perform disconnect and return error. */
+                 tcp_chr_disconnect_locked(chr);
++                return len;
+             } /* else let the read handler finish it properly */
+         }
+ 
+         return ret;
+     } else {
+-        /* Indicate an error. */
+-        errno = EIO;
+-        return -1;
++        /* XXX: indicate an error ? */
++        return len;
+     }
+ }
+ 


### PR DESCRIPTION
I cannot see any logs from application under kvm with moving onto xen 4.15.0 (and qemu 5.1.0). Also, EdenGCP kvm is failing starting with https://github.com/lf-edge/eve/actions/runs/732007542. 

Trying to identify issue, I notice, that logfile updated only when socket is connected. If I correctly understand, we do not use `/cons` now. So, probably, we can move to null backend, which one allows logs to output properly.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>