### PR TITLE
downloader improvements during outages

### DIFF
--- a/pkg/pillar/cmd/downloader/download.go
+++ b/pkg/pillar/cmd/downloader/download.go
@@ -165,6 +165,7 @@ func objectMetadata(ctx *downloaderContext, trType zedUpload.SyncTransportType,
 		return sha256, errors.New("NewRequest failed")
 	}
 
+	// XXX add timer?
 	req = req.WithCancel(context.Background())
 	defer req.Cancel()
 

--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -306,9 +306,9 @@ func maybeRetryDownload(ctx *downloaderContext,
 		return
 	}
 
-	// reset Error, to start download again
+	// Increment count; we defer clearing error until success
+	// to avoid confusing the user.
 	status.RetryCount++
-	status.ClearError()
 	publishDownloaderStatus(ctx, status)
 
 	doDownload(ctx, *config, status)
@@ -409,7 +409,6 @@ func doDownload(ctx *downloaderContext, config types.DownloaderConfig, status *t
 	if config.RefCount == 0 {
 		errStr := fmt.Sprintf("RefCount==0; download deferred for %s\n",
 			config.Name)
-		status.RetryCount++
 		status.HandleDownloadFail(errStr)
 		publishDownloaderStatus(ctx, status)
 		log.Errorf("doDownload(%s): deferred with %s", config.Name, errStr)
@@ -418,7 +417,6 @@ func doDownload(ctx *downloaderContext, config types.DownloaderConfig, status *t
 
 	dst, err := utils.LookupDatastoreConfig(ctx.subDatastoreConfig, config.DatastoreID)
 	if dst == nil {
-		status.RetryCount++
 		// XXX can we have a faster retry in this case?
 		// React when DatastoreConfig changes?
 		status.HandleDownloadFail(err.Error())

--- a/pkg/pillar/cmd/downloader/resolveconfig.go
+++ b/pkg/pillar/cmd/downloader/resolveconfig.go
@@ -77,9 +77,9 @@ func maybeRetryResolve(ctx *downloaderContext, status *types.ResolveStatus) {
 		return
 	}
 
-	// reset Error, to start download again
+	// Increment count; we defer clearing error until success
+	// to avoid confusing the user.
 	status.RetryCount++
-	status.ClearError()
 	publishResolveStatus(ctx, status)
 
 	resolveTagsToHash(ctx, *config)
@@ -147,8 +147,6 @@ func resolveTagsToHash(ctx *downloaderContext, rc types.ResolveConfig) {
 			Counter:     rc.Counter,
 		}
 	}
-	rs.ClearError()
-
 	sha := maybeNameHasSha(rc.Name)
 	if sha != "" {
 		rs.ImageSha256 = sha
@@ -239,6 +237,7 @@ func resolveTagsToHash(ctx *downloaderContext, rc types.ResolveConfig) {
 			errStr = errStr + "\n" + err.Error()
 			continue
 		}
+		rs.ClearError()
 		rs.ImageSha256 = sha256
 		publishResolveStatus(ctx, rs)
 		return

--- a/pkg/pillar/cmd/downloader/syncop.go
+++ b/pkg/pillar/cmd/downloader/syncop.go
@@ -236,7 +236,6 @@ func handleSyncOpResponse(ctx *downloaderContext, config types.DownloaderConfig,
 	if errStr != "" {
 		// Delete file, and update the storage
 		doDelete(ctx, key, locFilename, status)
-		status.RetryCount++
 		status.HandleDownloadFail(errStr)
 		publishDownloaderStatus(ctx, status)
 		log.Errorf("handleSyncOpResponse(%s): failed with %s",
@@ -250,7 +249,6 @@ func handleSyncOpResponse(ctx *downloaderContext, config types.DownloaderConfig,
 		// error, so delete the file
 		doDelete(ctx, key, locFilename, status)
 		errStr := fmt.Sprintf("%v", err)
-		status.RetryCount++
 		status.HandleDownloadFail(errStr)
 		publishDownloaderStatus(ctx, status)
 		log.Errorf("handleSyncOpResponse(%s): failed with %s",
@@ -263,6 +261,7 @@ func handleSyncOpResponse(ctx *downloaderContext, config types.DownloaderConfig,
 	// We do not clear any status.RetryCount, Error, etc. The caller
 	// should look at State == DOWNLOADED to determine it is done.
 
+	status.ClearError()
 	status.ModTime = time.Now()
 	status.State = types.DOWNLOADED
 	status.Progress = 100 // Just in case

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -901,10 +901,13 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 	ReportAppInfo.AppID = uuid
 	ReportAppInfo.SystemApp = false
 	ReportAppInfo.State = info.ZSwState_HALTED
+	var state types.SwState
+	var objErr bool
 	if aiStatus != nil {
 		ReportAppInfo.AppName = aiStatus.DisplayName
 		ReportAppInfo.State = aiStatus.State.ZSwState()
-
+		state = aiStatus.State
+		objErr = aiStatus.HasError()
 		if !aiStatus.ErrorTime.IsZero() {
 			errInfo := encodeErrorInfo(
 				aiStatus.ErrorAndTimeWithSource.ErrorAndTime())
@@ -1015,6 +1018,7 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 		log.Fatal("malloc error")
 	}
 	size := int64(proto.Size(ReportInfo))
+	start := time.Now()
 	err = SendProtobuf(statusUrl, buf, size, iteration)
 	if err != nil {
 		log.Errorf("PublishAppInfoToZedCloud failed: %s", err)
@@ -1028,6 +1032,9 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 			true)
 	} else {
 		writeSentAppInfoProtoMessage(data)
+
+		log.Functionf("sent app info %s state %s err %t took %v",
+			uuid, state.String(), objErr, time.Since(start))
 	}
 }
 
@@ -1050,10 +1057,13 @@ func PublishContentInfoToZedCloud(ctx *zedagentContext, uuid string,
 
 	ReportContentInfo.Uuid = uuid
 	ReportContentInfo.State = info.ZSwState_HALTED
+	var state types.SwState
+	var objErr bool
 	if ctStatus != nil {
 		ReportContentInfo.DisplayName = ctStatus.DisplayName
 		ReportContentInfo.State = ctStatus.State.ZSwState()
-
+		state = ctStatus.State
+		objErr = ctStatus.HasError()
 		if !ctStatus.ErrorTime.IsZero() {
 			errInfo := encodeErrorInfo(
 				ctStatus.ErrorAndTimeWithSource.ErrorAndTime())
@@ -1089,6 +1099,7 @@ func PublishContentInfoToZedCloud(ctx *zedagentContext, uuid string,
 		log.Fatal("malloc error")
 	}
 	size := int64(proto.Size(ReportInfo))
+	start := time.Now()
 	err = SendProtobuf(statusURL, buf, size, iteration)
 	if err != nil {
 		log.Errorf("PublishContentInfoToZedCloud failed: %s", err)
@@ -1100,6 +1111,9 @@ func PublishContentInfoToZedCloud(ctx *zedagentContext, uuid string,
 		}
 		zedcloud.SetDeferred(zedcloudCtx, uuid, buf, size, statusURL,
 			true)
+	} else {
+		log.Functionf("sent content info %s state %s err %t took %v",
+			uuid, state.String(), objErr, time.Since(start))
 	}
 }
 
@@ -1122,10 +1136,13 @@ func PublishVolumeToZedCloud(ctx *zedagentContext, uuid string,
 
 	ReportVolumeInfo.Uuid = uuid
 	ReportVolumeInfo.State = info.ZSwState_INITIAL
+	var state types.SwState
+	var objErr bool
 	if volStatus != nil {
 		ReportVolumeInfo.DisplayName = volStatus.DisplayName
 		ReportVolumeInfo.State = volStatus.State.ZSwState()
-
+		state = volStatus.State
+		objErr = volStatus.HasError()
 		if !volStatus.ErrorTime.IsZero() {
 			errInfo := encodeErrorInfo(
 				volStatus.ErrorAndTimeWithSource.ErrorAndTime())
@@ -1168,6 +1185,7 @@ func PublishVolumeToZedCloud(ctx *zedagentContext, uuid string,
 		log.Fatal("malloc error")
 	}
 	size := int64(proto.Size(ReportInfo))
+	start := time.Now()
 	err = SendProtobuf(statusURL, buf, size, iteration)
 	if err != nil {
 		log.Errorf("PublishVolumeToZedCloud failed: %s", err)
@@ -1179,7 +1197,11 @@ func PublishVolumeToZedCloud(ctx *zedagentContext, uuid string,
 		}
 		zedcloud.SetDeferred(zedcloudCtx, uuid, buf, size, statusURL,
 			true)
+	} else {
+		log.Functionf("sent vol info %s state %s err %t took %v",
+			uuid, state.String(), objErr, time.Since(start))
 	}
+
 }
 
 // PublishBlobInfoToZedCloud is called per change, hence needs to try over all management ports
@@ -1200,8 +1222,12 @@ func PublishBlobInfoToZedCloud(ctx *zedagentContext, blobSha string, blobStatus 
 	ReportBlobInfo := new(info.ZInfoBlob)
 
 	ReportBlobInfo.Sha256 = blobSha
+	var state types.SwState
+	var objErr bool
 	if blobStatus != nil {
 		ReportBlobInfo.State = blobStatus.State.ZSwState()
+		state = blobStatus.State
+		objErr = blobStatus.HasError()
 		ReportBlobInfo.ProgressPercentage = blobStatus.GetDownloadedPercentage()
 		ReportBlobInfo.Usage = &info.UsageInfo{RefCount: uint32(blobStatus.RefCount)}
 		ReportBlobInfo.Resources = &info.ContentResources{CurSizeBytes: blobStatus.Size}
@@ -1227,6 +1253,7 @@ func PublishBlobInfoToZedCloud(ctx *zedagentContext, blobSha string, blobStatus 
 		log.Fatal("malloc error")
 	}
 	size := int64(proto.Size(ReportInfo))
+	start := time.Now()
 	err = SendProtobuf(statusURL, buf, size, iteration)
 	if err != nil {
 		log.Errorf("PublishBlobInfoToZedCloud failed: %s", err)
@@ -1238,6 +1265,9 @@ func PublishBlobInfoToZedCloud(ctx *zedagentContext, blobSha string, blobStatus 
 		}
 		zedcloud.SetDeferred(zedcloudCtx, blobSha, buf, size, statusURL,
 			true)
+	} else {
+		log.Functionf("sent blob info %s state %s err %t took %v",
+			blobSha, state.String(), objErr, time.Since(start))
 	}
 }
 

--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -521,6 +521,7 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 		log.Fatal("malloc error")
 	}
 	size := int64(proto.Size(ReportInfo))
+	start := time.Now()
 	err = SendProtobuf(statusUrl, buf, size, iteration)
 	if err != nil {
 		log.Errorf("PublishDeviceInfoToZedCloud failed: %s", err)
@@ -534,6 +535,9 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 			statusUrl, true)
 	} else {
 		writeSentDeviceInfoProtoMessage(data)
+
+		log.Functionf("sent device info %s took %v", deviceUUID,
+			time.Since(start))
 	}
 }
 

--- a/pkg/pillar/hypervisor/qmp.go
+++ b/pkg/pillar/hypervisor/qmp.go
@@ -16,7 +16,7 @@ const sockTimeout = 10 * time.Second
 
 func execRawCmd(socket, cmd string) ([]byte, error) {
 	var retry = 3
-	logrus.Infof("executing QMP command: %s", cmd)
+	logrus.Debugf("executing QMP command: %s", cmd)
 	var err error
 	var monitor *qmp.SocketMonitor
 

--- a/pkg/pillar/types/downloadertypes.go
+++ b/pkg/pillar/types/downloadertypes.go
@@ -4,6 +4,7 @@
 package types
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -113,6 +114,8 @@ type DownloaderStatus struct {
 	// ErrorAndTime provides SetErrorNow() and ClearError()
 	ErrorAndTime
 	RetryCount int
+	// We save the original error when we do a retry
+	OrigError string
 }
 
 func (status DownloaderStatus) Key() string {
@@ -134,7 +137,11 @@ func (status *DownloaderStatus) ClearPendingStatus() {
 }
 
 // HandleDownloadFail : Do Failure specific tasks
-func (status *DownloaderStatus) HandleDownloadFail(errStr string) {
+func (status *DownloaderStatus) HandleDownloadFail(errStr string, retryTime time.Duration) {
+	if retryTime != 0 {
+		errStr = fmt.Sprintf("Will retry in %v: %s",
+			retryTime, errStr)
+	}
 	status.SetErrorNow(errStr)
 	status.ClearPendingStatus()
 }

--- a/pkg/pillar/types/resolvertypes.go
+++ b/pkg/pillar/types/resolvertypes.go
@@ -76,6 +76,8 @@ type ResolveStatus struct {
 	RetryCount  int
 	// ErrorAndTime provides SetErrorNow() and ClearError()
 	ErrorAndTime
+	// We save the original error when we do a retry
+	OrigError string
 }
 
 // Key : DatastoreID, name and sequence counter are used

--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -87,7 +87,7 @@ func SendOnAllIntf(ctx *ZedCloudContext, url string, reqlen int64, b *bytes.Buff
 	var errorList []error
 	remoteTemporaryFailure := types.SenderStatusNone
 
-	intfs := types.GetMgmtPortsSortedCost(*ctx.DeviceNetworkStatus, iteration)
+	intfs := types.GetMgmtPortsSortedCostWithoutFailed(*ctx.DeviceNetworkStatus, iteration)
 	if len(intfs) == 0 {
 		err := fmt.Errorf("Can not connect to %s: No management interfaces",
 			url)

--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -89,6 +89,12 @@ func SendOnAllIntf(ctx *ZedCloudContext, url string, reqlen int64, b *bytes.Buff
 
 	intfs := types.GetMgmtPortsSortedCostWithoutFailed(*ctx.DeviceNetworkStatus, iteration)
 	if len(intfs) == 0 {
+		// This can happen during onboarding etc and the failed status
+		// might be updated infrequently by nim
+		log.Warnf("All management ports are marked failed; trying all")
+		intfs = types.GetMgmtPortsSortedCost(*ctx.DeviceNetworkStatus, iteration)
+	}
+	if len(intfs) == 0 {
 		err := fmt.Errorf("Can not connect to %s: No management interfaces",
 			url)
 		log.Error(err.Error())


### PR DESCRIPTION
If we have 100% packet loss on one interface, then we still try to use it for every POST to zedcloud. Since we are sending info messages for the device, apps, volumes, content-trees, and blobs, it means that EVE can be far behind in terms of reporting things to zedcloud.  The first commit addresses that by using the test status from nim.

As we retry the state transitions seen by the controller are confusing, since the error is cleared when a retry starts. With these changes we don't clear it until the retry has succedded. Also, the log messages include that 1) the operation will be retried in N seconds, and 2) "retry N" has started

Each commit can be reviewed separately.