### PR TITLE
[WIP; DO NOT MERGE] NUC9VXQNX support

### DIFF
--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -22,7 +22,7 @@ onboot:
         - /etc/sysctl.d:/etc/sysctl.d
    - name: modprobe
      image: linuxkit/modprobe:v0.5
-     command: ["/bin/sh", "-c", "modprobe -a nct6775 w83627hf_wdt wlcore_sdio wl18xx br_netfilter smsc75xx cp210x nicvf tpm_tis_spi rtc_rx8010 gpio_pca953x leds_siemens_ipc127 upboard-fpga pinctrl-upboard leds-upboard 2>/dev/null || :"]
+     command: ["/bin/sh", "-c", "modprobe -a nct6775 w83627hf_wdt iTCO_wdt wlcore_sdio wl18xx br_netfilter smsc75xx cp210x nicvf tpm_tis_spi rtc_rx8010 gpio_pca953x leds_siemens_ipc127 upboard-fpga pinctrl-upboard leds-upboard 2>/dev/null || :"]
    - name: storage-init
      image: STORAGE_INIT_TAG
 services:


### PR DESCRIPTION
Support for peripherals on `NUC9VXQNX`

* ~~Intel AX200 WIFI https://github.com/lf-edge/eve/pull/2035~~
* Watchdog

For the watchdog, pending review on why `iTCO_wdt` is not loaded automatically, and if this can be fixed, instead of a manual modprobe.

It seems that `NUC10i7FNH` is in a similar situation (`iTCO_wdt` module not picked up automatically).

Dump of ACPI tables

NUC9VXQNX
```
        Device (CWDT)
        {
            Name (_HID, "INTC1028")  // _HID: Hardware ID
            Name (_CID, EisaId ("PNP0C02") /* PNP Motherboard Resources */)  // _CID: Compatible ID
            Method (_STA, 0, Serialized)  // _STA: Status
            {
                Return (0x0F)
            }

            Method (_CRS, 0, NotSerialized)  // _CRS: Current Resource Settings
            {
                Name (RBUF, ResourceTemplate ()
                {
                    IO (Decode16,
                        0x0000,             // Range Minimum
                        0x0000,             // Range Maximum
                        0x04,               // Alignment
                        0x04,               // Length
                        _Y38)
                })
                CreateWordField (RBUF, \_SB.PCI0.LPCB.CWDT._CRS._Y38._MIN, OMIN)  // _MIN: Minimum Base Address
                CreateWordField (RBUF, \_SB.PCI0.LPCB.CWDT._CRS._Y38._MAX, OMAX)  // _MAX: Maximum Base Address
                OMIN = (PMBS + 0x54)
                OMAX = (PMBS + 0x54)
                Return (RBUF) /* \_SB_.PCI0.LPCB.CWDT._CRS.RBUF */
            }
        }
    }
```