### PR TITLE
Cancel download (and resolve) when controller deletes object

### DIFF
--- a/pkg/pillar/cmd/downloader/handlers.go
+++ b/pkg/pillar/cmd/downloader/handlers.go
@@ -11,25 +11,37 @@ import (
 // Notify simple struct to pass notification messages
 type Notify struct{}
 
+// CancelChannel is the type we send over a channel for the per-download cancels
+type CancelChannel chan Notify
+
 type downloadHandler struct {
 	// We have one goroutine per provisioned domU object.
-	// Channel is used to send notifications about config (add and updates)
-	// Channel is closed when the object is deleted
 	// The go-routine owns writing status for the object
 	// The key in the map is the objects Key().
 
-	handlers map[string]chan<- Notify
+	handlers map[string]*handlerChannels
+}
+
+// updateChan is used to send notifications about config (add and updates)
+// receiveChan is passed to the networking code so that it can feed
+// back a per-operation cancel channel, which we use if we need to cancel.
+// cancelChan is used when refcount goes from N->0 to cancel
+// pending downloads
+// Both update and receive channels are closed when the object is deleted
+type handlerChannels struct {
+	updateChan        chan<- Notify
+	receiveChan       chan CancelChannel
+	currentCancelChan chan<- Notify
 }
 
 func makeDownloadHandler() *downloadHandler {
 	return &downloadHandler{
-		handlers: make(map[string]chan<- Notify),
+		handlers: make(map[string]*handlerChannels),
 	}
 }
 
 // Wrappers around createObject, modifyObject, and deleteObject
 
-// Determine whether it is an create or modify
 func (d *downloadHandler) modify(ctxArg interface{},
 	key string, configArg interface{}) {
 
@@ -40,11 +52,28 @@ func (d *downloadHandler) modify(ctxArg interface{},
 		log.Fatalf("downloadHandler.modify called on config that does not exist")
 	}
 	select {
-	case h <- Notify{}:
-		log.Functionf("downloadHandler.modify(%s) sent notify", key)
+	case h.updateChan <- Notify{}:
+		log.Functionf("downloadHandler.modify(%s) sent update", key)
 	default:
 		// handler is slow
-		log.Warnf("downloadHandler.modify(%s) NOT sent notify. Slow handler?", key)
+		log.Warnf("downloadHandler.modify(%s) NOT sent update. Slow handler?", key)
+	}
+	// Cancel a download if client/user set RefCount = 0
+	if h.currentCancelChan != nil && config.RefCount == 0 {
+		select {
+		case h.currentCancelChan <- Notify{}:
+			log.Noticef("downloadHandler.modify(%s) sent cancel to %v",
+				key, h.currentCancelChan)
+		default:
+			// handler is slow
+			log.Warnf("downloadHandler.modify(%s) NOT sent cancel",
+				key)
+		}
+		// We only cancel one operation once
+		log.Noticef("downloadHandler.modify(%s) closing cancel channel %v",
+			key, h.currentCancelChan)
+		close(h.currentCancelChan)
+		h.currentCancelChan = nil
 	}
 }
 
@@ -54,17 +83,33 @@ func (d *downloadHandler) create(ctxArg interface{},
 	log.Functionf("downloadHandler.create(%s)", key)
 	ctx := ctxArg.(*downloaderContext)
 	config := configArg.(types.DownloaderConfig)
-	h, ok := d.handlers[config.Key()]
+	_, ok := d.handlers[config.Key()]
 	if ok {
 		log.Fatalf("downloadHandler.create called on config that already exists")
 	}
-	h1 := make(chan Notify, 1)
-	d.handlers[config.Key()] = h1
+	updateChan := make(chan Notify, 1)
+	receiveChan := make(chan CancelChannel, 1)
+	h := handlerChannels{
+		updateChan:  updateChan,
+		receiveChan: receiveChan,
+	}
+	d.handlers[config.Key()] = &h
+
+	// Pick up the current cancel channel from the receiveChan and save
+	// it so it can be used if there is a cancel
+	go func() {
+		for ch := range receiveChan {
+			log.Noticef("downloadHandler(%s) received cancelChan %v",
+				key, ch)
+			h.currentCancelChan = ch
+		}
+		log.Noticef("downloadHandler(%s) receiveChan func done", key)
+	}()
+
 	log.Functionf("Creating %s at %s", "runHandler", agentlog.GetMyStack())
-	go runHandler(ctx, key, h1)
-	h = h1
+	go runHandler(ctx, key, updateChan, receiveChan)
 	select {
-	case h <- Notify{}:
+	case h.updateChan <- Notify{}:
 		log.Functionf("downloadHandler.create(%s) sent notify", key)
 	default:
 		// Shouldn't happen since we just created channel
@@ -78,13 +123,31 @@ func (d *downloadHandler) delete(ctxArg interface{}, key string,
 	log.Functionf("downloadHandler.delete(%s)", key)
 	// Do we have a channel/goroutine?
 	h, ok := d.handlers[key]
-	if ok {
-		log.Tracef("Closing channel")
-		close(h)
-		delete(d.handlers, key)
-	} else {
-		log.Tracef("downloadHandler.delete: unknown %s", key)
+	if !ok {
+		log.Functionf("downloadHandler.delete: unknown %s", key)
 		return
 	}
+	if h.currentCancelChan != nil {
+		select {
+		case h.currentCancelChan <- Notify{}:
+			log.Noticef("downloadHandler.delete(%s) sent cancel to %v",
+				key, h.currentCancelChan)
+		default:
+			// handler is slow
+			log.Warnf("downloadHandler.delete(%s) NOT sent cancel. Slow handler?", key)
+		}
+		// We only cancel one operation once
+		close(h.currentCancelChan)
+		h.currentCancelChan = nil
+	}
+	log.Functionf("Closing update channel")
+	close(h.updateChan)
+	h.updateChan = nil
+
+	log.Functionf("Closing receive channel")
+	close(h.receiveChan)
+	h.receiveChan = nil
+
+	delete(d.handlers, key)
 	log.Functionf("downloadHandler.delete(%s) done", key)
 }

--- a/pkg/pillar/types/downloadertypes.go
+++ b/pkg/pillar/types/downloadertypes.go
@@ -137,8 +137,8 @@ func (status *DownloaderStatus) ClearPendingStatus() {
 }
 
 // HandleDownloadFail : Do Failure specific tasks
-func (status *DownloaderStatus) HandleDownloadFail(errStr string, retryTime time.Duration) {
-	if retryTime != 0 {
+func (status *DownloaderStatus) HandleDownloadFail(errStr string, retryTime time.Duration, cancelled bool) {
+	if retryTime != 0 && !cancelled {
 		errStr = fmt.Sprintf("Will retry in %v: %s",
 			retryTime, errStr)
 	}


### PR DESCRIPTION
Up until now, if the controller specifies a content tree, EVE will start  downloading it. If the content-tree is deleted, then the objects (ContentTreeStatus) will be deleted, but the downloader has a single goroutine per object and that will keep on running until the download succeeds or fails.

That uses bandwidth for no reason.

The approach here is a bit convoluted, since we need to make sure that we cancel the context for the current download and avoid having a late cancel of download 1 affect download 2 (recall, there is automatic retry etc). Hence when an operation starts, a channel is created and sent back to the top level handlers (sent over the receiveChan). The top level code sends a notification on that channel when it needs to cancel (and the actual code down in syncop etc does a normal cancel of the context, which causes the underlying transport code to clean up.)

Even though the resolve (of a OCI tag) doesn't download lots of bytes, it is still retrying etc. So applying the same cancel pattern there.
The difference between the two cases is that for the download there is an interlock between volumemgr and downloader (using a RefCount=0 in DownloaderConfig resulting in Expired=true in DownloaderStatus, and finally a delete/unpublish of the DownloaderConfig). Thus we also use a RefCount=0 at the top level modify handler  to also trigger a cancel.

To avoid retrying when an operation has been cancelled we return a "cancelled" boolean . That is used to have the log messages indicate vs. not a retry of the error.