### PR TITLE
Three fixes

### DIFF
--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -126,10 +126,9 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		}
 	}
 
-	cms := zedcloud.GetCloudMetrics(log) // Need type of data
 	pub, err := ps.NewPublication(pubsub.PublicationOptions{
 		AgentName: agentName,
-		TopicType: cms,
+		TopicType: types.MetricsMap{},
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -475,7 +474,9 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		}
 	}
 
-	err = pub.Publish("global", zedcloud.GetCloudMetrics(log))
+	// Transfer to a local copy in case metrics updates are done concurrently
+	cms := zedcloud.Append(types.MetricsMap{}, zedcloud.GetCloudMetrics(log))
+	err = pub.Publish("global", cms)
 	if err != nil {
 		log.Errorln(err)
 	}

--- a/pkg/pillar/cmd/volumemgr/artifact.go
+++ b/pkg/pillar/cmd/volumemgr/artifact.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2020,2021 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package volumemgr
 
 import (
@@ -6,6 +9,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"strings"
+	"time"
 
 	ctrcontent "github.com/containerd/containerd/content"
 	v1types "github.com/google/go-containerregistry/pkg/v1/types"
@@ -89,10 +93,12 @@ func createManifestsForBareBlob(artifact *registry.Artifact) ([]*types.BlobStatu
 			err.Error())
 	}
 	blobStatuses = append(blobStatuses, &types.BlobStatus{
-		Content:   manifestBytes,
-		State:     types.VERIFIED,
-		MediaType: string(v1types.OCIManifestSchema1),
-		Sha256:    digest.FromBytes(manifestBytes).Encoded(),
+		Content:                manifestBytes,
+		State:                  types.VERIFIED,
+		MediaType:              string(v1types.OCIManifestSchema1),
+		Sha256:                 digest.FromBytes(manifestBytes).Encoded(),
+		CreateTime:             time.Now(),
+		LastRefCountChangeTime: time.Now(),
 	})
 
 	configReaderAt, err := provider.ReaderAt(context.Background(), manifest.Config)
@@ -109,14 +115,16 @@ func createManifestsForBareBlob(artifact *registry.Artifact) ([]*types.BlobStatu
 	blen := int64(len(configBytes))
 	// and the config file which was in the manifest
 	blobStatuses = append(blobStatuses, &types.BlobStatus{
-		Content:     configBytes,
-		State:       types.VERIFIED,
-		Size:        uint64(blen),
-		CurrentSize: blen,
-		TotalSize:   blen,
-		Progress:    100,
-		MediaType:   string(v1types.OCIConfigJSON),
-		Sha256:      manifest.Config.Digest.Encoded(),
+		Content:                configBytes,
+		State:                  types.VERIFIED,
+		Size:                   uint64(blen),
+		CurrentSize:            blen,
+		TotalSize:              blen,
+		Progress:               100,
+		MediaType:              string(v1types.OCIConfigJSON),
+		Sha256:                 manifest.Config.Digest.Encoded(),
+		CreateTime:             time.Now(),
+		LastRefCountChangeTime: time.Now(),
 	})
 	return blobStatuses, nil
 }

--- a/pkg/pillar/cmd/volumemgr/handlecontent.go
+++ b/pkg/pillar/cmd/volumemgr/handlecontent.go
@@ -161,6 +161,7 @@ func createContentTreeStatus(ctx *volumemgrContext, config types.ContentTreeConf
 			DisplayName:       config.DisplayName,
 			State:             types.INITIAL,
 			Blobs:             []string{},
+			// LastRefCountChangeTime: time.Now(),
 		}
 
 		// we only publish the BlobStatus if we have the hash for it; this
@@ -179,12 +180,14 @@ func createContentTreeStatus(ctx *volumemgrContext, config types.ContentTreeConf
 					mediaType = ""
 				}
 				rootBlob := &types.BlobStatus{
-					DatastoreID: config.DatastoreID,
-					RelativeURL: config.RelativeURL,
-					Sha256:      strings.ToLower(config.ContentSha256),
-					Size:        config.MaxDownloadSize,
-					State:       types.INITIAL,
-					MediaType:   mediaType,
+					DatastoreID:            config.DatastoreID,
+					RelativeURL:            config.RelativeURL,
+					Sha256:                 strings.ToLower(config.ContentSha256),
+					Size:                   config.MaxDownloadSize,
+					State:                  types.INITIAL,
+					MediaType:              mediaType,
+					CreateTime:             time.Now(),
+					LastRefCountChangeTime: time.Now(),
 				}
 				publishBlobStatus(ctx, rootBlob)
 			}

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -312,8 +312,8 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 	zedboxStats.NumGoRoutines = uint32(runtime.NumGoroutine()) // number of zedbox goroutines
 	ReportDeviceMetric.Zedbox = zedboxStats
 
-	// Collect zedcloud metrics from ourselves and other agents
-	cms := types.MetricsMap{} // Start empty
+	// Transfer to a local copy in since metrics updates are done concurrently
+	cms := types.MetricsMap{}
 	zedagentMetrics := zedcloud.GetCloudMetrics(log)
 	if zedagentMetrics != nil {
 		cms = zedcloud.Append(cms, zedagentMetrics)

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -1073,7 +1073,13 @@ func PublishContentInfoToZedCloud(ctx *zedagentContext, uuid string,
 		ContentResourcesInfo := new(info.ContentResources)
 		ContentResourcesInfo.CurSizeBytes = uint64(ctStatus.TotalSize)
 		ReportContentInfo.Resources = ContentResourcesInfo
-
+		createTime, _ := ptypes.TimestampProto(ctStatus.CreateTime)
+		ReportContentInfo.Usage = &info.UsageInfo{
+			// XXX RefCount: uint32(ctStatus.RefCount),
+			RefCount:               1,
+			LastRefcountChangeTime: createTime,
+			CreateTime:             createTime,
+		}
 		ReportContentInfo.Sha256 = ctStatus.ContentSha256
 		ReportContentInfo.ProgressPercentage = uint32(ctStatus.Progress)
 		ReportContentInfo.GenerationCount = ctStatus.GenerationCounter
@@ -1161,6 +1167,13 @@ func PublishVolumeToZedCloud(ctx *zedagentContext, uuid string,
 				ReportVolumeInfo.Resources = VolumeResourcesInfo
 			}
 		}
+		createTime, _ := ptypes.TimestampProto(volStatus.CreateTime)
+		lastChangeTime, _ := ptypes.TimestampProto(volStatus.LastRefCountChangeTime)
+		ReportVolumeInfo.Usage = &info.UsageInfo{
+			RefCount:               uint32(volStatus.RefCount),
+			LastRefcountChangeTime: lastChangeTime,
+			CreateTime:             createTime,
+		}
 
 		ReportVolumeInfo.ProgressPercentage = uint32(volStatus.Progress)
 		ReportVolumeInfo.GenerationCount = volStatus.GenerationCounter
@@ -1229,7 +1242,13 @@ func PublishBlobInfoToZedCloud(ctx *zedagentContext, blobSha string, blobStatus 
 		state = blobStatus.State
 		objErr = blobStatus.HasError()
 		ReportBlobInfo.ProgressPercentage = blobStatus.GetDownloadedPercentage()
-		ReportBlobInfo.Usage = &info.UsageInfo{RefCount: uint32(blobStatus.RefCount)}
+		createTime, _ := ptypes.TimestampProto(blobStatus.CreateTime)
+		lastChangeTime, _ := ptypes.TimestampProto(blobStatus.LastRefCountChangeTime)
+		ReportBlobInfo.Usage = &info.UsageInfo{
+			RefCount:               uint32(blobStatus.RefCount),
+			LastRefcountChangeTime: lastChangeTime,
+			CreateTime:             createTime,
+		}
 		ReportBlobInfo.Resources = &info.ContentResources{CurSizeBytes: blobStatus.Size}
 	}
 	ReportBlobInfoList.Blob = append(ReportBlobInfoList.Blob, ReportBlobInfo)

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -997,11 +997,10 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		log.Fatal(err)
 	}
 	// Subscribe to cloud metrics from different agents
-	cms := zedcloud.GetCloudMetrics(log)
 	subClientMetrics, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:   "zedclient",
 		MyAgentName: agentName,
-		TopicImpl:   cms,
+		TopicImpl:   types.MetricsMap{},
 		Activate:    true,
 		Ctx:         &zedagentCtx,
 	})
@@ -1011,7 +1010,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// cloud metrics of loguploader
 	subLoguploaderMetrics, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName: "loguploader",
-		TopicImpl: cms,
+		TopicImpl: types.MetricsMap{},
 		Activate:  true,
 		Ctx:       &zedagentCtx,
 	})
@@ -1021,7 +1020,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	subDownloaderMetrics, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:   "downloader",
 		MyAgentName: agentName,
-		TopicImpl:   cms,
+		TopicImpl:   types.MetricsMap{},
 		Activate:    true,
 		Ctx:         &zedagentCtx,
 	})

--- a/pkg/pillar/types/blob.go
+++ b/pkg/pillar/types/blob.go
@@ -4,6 +4,8 @@
 package types
 
 import (
+	"time"
+
 	"github.com/google/go-cmp/cmp"
 	v1types "github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/lf-edge/eve/pkg/pillar/base"
@@ -27,7 +29,8 @@ type BlobStatus struct {
 	// Used *only* when this has data and Path is ""
 	Content []byte
 	// State of download of this blob; only supports: INITIAL, DOWNLOADING, DOWNLOADED, VERIFYING, VERIFIED
-	State SwState
+	State      SwState
+	CreateTime time.Time
 	// MediaType the actual media type string for this blob
 	MediaType string
 	// HasDownloaderRef whether or not we have started a downloader for this blob
@@ -35,9 +38,10 @@ type BlobStatus struct {
 	// HasVerifierRef whether or not we have started a verifier for this blob
 	HasVerifierRef bool
 	// RefCount number of consumers referring this object
-	RefCount    uint
-	TotalSize   int64 // expected size as reported by the downloader, if any
-	CurrentSize int64 // current total downloaded size as reported by the downloader
+	RefCount               uint
+	LastRefCountChangeTime time.Time
+	TotalSize              int64 // expected size as reported by the downloader, if any
+	CurrentSize            int64 // current total downloaded size as reported by the downloader
 	// Progress percentage downloaded 0-100, defined by CurrentSize/TotalSize
 	Progress uint
 	// ErrorAndTimeWithSource provide common error handling capabilities

--- a/pkg/pillar/types/contenttreetypes.go
+++ b/pkg/pillar/types/contenttreetypes.go
@@ -5,6 +5,7 @@ package types
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	zconfig "github.com/lf-edge/eve/api/go/config"
@@ -110,11 +111,15 @@ type ContentTreeStatus struct {
 	DisplayName       string
 	HasResolverRef    bool
 	State             SwState
-	TotalSize         int64  // expected size as reported by the downloader, if any
-	CurrentSize       int64  // current total downloaded size as reported by the downloader
-	Progress          uint   // In percent i.e., 0-100
-	FileLocation      string // Location of filestystem
-	NameIsURL         bool
+	// XXX RefCount not needed?
+	// RefCount                uint
+	// LastRefCountChangeTime  time.Time
+	CreateTime   time.Time // When LOADED
+	TotalSize    int64     // expected size as reported by the downloader, if any
+	CurrentSize  int64     // current total downloaded size as reported by the downloader
+	Progress     uint      // In percent i.e., 0-100
+	FileLocation string    // Location of filestystem
+	NameIsURL    bool
 	// Blobs the sha256 hashes of the blobs that are in this tree, the first of which always is the root
 	Blobs []string
 

--- a/pkg/pillar/types/volumetypes.go
+++ b/pkg/pillar/types/volumetypes.go
@@ -107,11 +107,13 @@ type VolumeStatus struct {
 	DisplayName             string
 	State                   SwState
 	RefCount                uint
+	LastRefCountChangeTime  time.Time
 	Progress                uint   // In percent i.e., 0-100
 	TotalSize               int64  // expected size as reported by the downloader, if any
 	CurrentSize             int64  // current total downloaded size as reported by the downloader
 	FileLocation            string // Location of filestystem
 	VolumeCreated           bool   // Done aka Activated
+	CreateTime              time.Time
 	ContentFormat           zconfig.Format
 	LastUse                 time.Time
 	PreReboot               bool // Was volume last use prior to device reboot?


### PR DESCRIPTION
Please review each commit separately (yes, our PR throughput is too low so it makes sense to put several unrelated fixes in the same PR).

1. User-visible issue for instance if the controller sends invalid DevicePortConfig where there are no management ports or all management ports are on networks with DHCP=none. Need to promote the error string to the whole DevicePortConfig so it is shown like the other errors.
2. We have fields in the API which are not filled in for createTime etc. Those are useful should a customer ask e.g., "was the volume purged" since the volume will now report when it was (re-)created.
3. Concurrent access to a map in zedcloudmetrics. Cleaned up the usage of zedcloud.GetCloudMetrics since as part of this since the types.MetricsMap has been public for quite a while.