### PR TITLE
app keep delete/add stale items cleanup

### DIFF
--- a/pkg/pillar/cmd/loguploader/loguploader.go
+++ b/pkg/pillar/cmd/loguploader/loguploader.go
@@ -454,8 +454,9 @@ func checkAppLogMetrics(ctx *loguploaderContext) {
 
 	// get the url set in the log metric-map
 	l2 := zedcloud.GetAppURLset(log)
-	if len(l) == len(l2) {
-		log.Tracef("checkAppLogMetrics: log metric url is the same length %d", len(l))
+	if len(l) >= len(l2) { // large or equal, not every app sends logs
+		log.Tracef("checkAppLogMetrics: log metric url number %d is the same or less than app %d",
+			len(l2), len(l))
 		return
 	}
 	log.Tracef("checkAppLogMetrics: app config len %d, log metrics url length %d", len(l), len(l2))
@@ -473,7 +474,7 @@ func checkAppLogMetrics(ctx *loguploaderContext) {
 		}
 		l3 = append(l3, m)
 	}
-	log.Tracef("checkAppLogMetrics: len %d, list of remove urls %v", len(l3), l3)
+	log.Tracef("checkAppLogMetrics: list of remove urls %v", l3)
 	for _, rem := range l3 {
 		zedcloud.CleanAppCloudMetrics(log, rem)
 	}

--- a/pkg/pillar/cmd/zedrouter/flowstats.go
+++ b/pkg/pillar/cmd/zedrouter/flowstats.go
@@ -586,7 +586,7 @@ func flowPublish(ctx *zedrouterContext, flowdata *types.IPFlow, seq, idx *int) {
 		scope.Sequence = strconv.Itoa(*seq)
 	}
 	flowKey = scope.UUID.String() + scope.NetUUID.String() + scope.Sequence
-	ctx.flowPublishMap[flowKey] = time.Now().Unix()
+	ctx.flowPublishMap[flowKey] = time.Now()
 
 	ctx.pubAppFlowMonitor.Publish(flowKey, *flowdata)
 	log.Functionf("FlowStats: publish to zedagent: total records %d, sequence %d\n", *idx, *seq)
@@ -597,9 +597,8 @@ func flowPublish(ctx *zedrouterContext, flowdata *types.IPFlow, seq, idx *int) {
 }
 
 func checkFlowUnpublish(ctx *zedrouterContext) {
-	now := time.Now().Unix()
 	for k, m := range ctx.flowPublishMap {
-		passed := now - m
+		passed := int64(time.Since(m) / time.Second)
 		if passed > flowStaleSec { // no update after 30 minutes, remove this flowlog
 			log.Functionf("checkFlowUnpublish: key %s, sec passed %d, remove", k, passed)
 			ctx.pubAppFlowMonitor.Unpublish(k)

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -31,7 +31,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 )
 
@@ -89,6 +89,7 @@ type zedrouterContext struct {
 	appStatsInterval          uint32
 	aclog                     *logrus.Logger // App Container logger
 	disableDHCPAllOnesNetMask bool
+	flowPublishMap            map[string]int64
 }
 
 var debug = false
@@ -160,6 +161,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		dnsServers:         make(map[string][]net.IP),
 		aclog:              agentlog.CustomLogInit(logrus.InfoLevel),
 		NLaclMap:           make(map[uuid.UUID]map[string]types.ULNetworkACLs),
+		flowPublishMap:     make(map[string]int64),
 	}
 	zedrouterCtx.networkInstanceStatusMap =
 		make(map[uuid.UUID]*types.NetworkInstanceStatus)

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -89,7 +89,7 @@ type zedrouterContext struct {
 	appStatsInterval          uint32
 	aclog                     *logrus.Logger // App Container logger
 	disableDHCPAllOnesNetMask bool
-	flowPublishMap            map[string]int64
+	flowPublishMap            map[string]time.Time
 }
 
 var debug = false
@@ -161,7 +161,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		dnsServers:         make(map[string][]net.IP),
 		aclog:              agentlog.CustomLogInit(logrus.InfoLevel),
 		NLaclMap:           make(map[uuid.UUID]map[string]types.ULNetworkACLs),
-		flowPublishMap:     make(map[string]int64),
+		flowPublishMap:     make(map[string]time.Time),
 	}
 	zedrouterCtx.networkInstanceStatusMap =
 		make(map[uuid.UUID]*types.NetworkInstanceStatus)


### PR DESCRIPTION
fixing a crash where 'logupgrader' service's MetricMap size exceeds 65k.
- cleanup the loguploader metric-map url list
- cleanup the flowlog stale entries in IPFlow publication