### PR TITLE
avoid panic on fetching image config for reference

### DIFF
--- a/pkg/pillar/cas/containerd.go
+++ b/pkg/pillar/cas/containerd.go
@@ -595,7 +595,7 @@ func (c *containerdCAS) PrepareContainerRootDir(rootPath, reference, rootBlobSha
 		err = fmt.Errorf("PrepareContainerRootDir: exception while fetching image config for reference %s: %s",
 			reference, err.Error())
 		logrus.Errorf(err.Error())
-		//return err
+		return err
 	}
 	mountpoints := clientImageSpec.Config.Volumes
 	execpath := clientImageSpec.Config.Entrypoint


### PR DESCRIPTION
Seems, we may have panics in case of error in fetching image config for reference https://github.com/lf-edge/eve/pull/1192#issuecomment-828654989

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>