### PR TITLE
Parse multipart MIME to create cloud-init ISO

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -37,7 +37,7 @@
 | newlog.allow.fastupload | boolean | false | allow faster upload gzip logfiles to controller |
 | memory.apps.ignore.check | boolean | false | Ignore memory usage check for Apps|
 | newlog.gzipfiles.ondisk.maxmegabytes | integer in Mbytes | 2048 | the quota for keepig newlog gzip files on device |
-
+| process.cloud-init.multipart" | boolean | false | help VMs which do not handle mime multi-part themselves |
 
 In addition, there can be per-agent settings.
 The Per-agent settings begin with "agent.*agentname*.*setting*"

--- a/pkg/pillar/cmd/domainmgr/multipart.go
+++ b/pkg/pillar/cmd/domainmgr/multipart.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2021 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Handle MIME multi-part messages to create cloud-init directory
+// structure
+
+package domainmgr
+
+import (
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/mail"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// handleMIMEMultipart returns true if this is a MIME multipart
+// and if so it takes it apart and writes it to dir
+// It returns errors if a filename tries to escape the dir, and also
+// errors if the MIME multi-part is malformed
+func handleMimeMultipart(dir string, ciStr string) (bool, error) {
+	r := strings.NewReader(ciStr)
+	msg, err := mail.ReadMessage(r)
+	if err != nil {
+		log.Noticef("ReadMessage failed: %v", err)
+		return false, nil
+	}
+	ct := msg.Header.Get("Content-Type")
+	mediaType, params, err := mime.ParseMediaType(ct)
+	if err != nil {
+		log.Noticef("ParseMediaType %s failed: %v", ct, err)
+		return false, nil
+	}
+	boundary, ok := params["boundary"]
+	if !ok {
+		log.Noticef("Missing boundary param in %s", ct)
+		return false, nil
+	}
+	log.Noticef("Found mediaType %s params %v", mediaType, params)
+	if !strings.HasPrefix(mediaType, "multipart/") {
+		log.Noticef("Not multipart media type: %s", mediaType)
+		return false, nil
+	}
+	mr := multipart.NewReader(msg.Body, boundary)
+	for {
+		p, err := mr.NextPart()
+		if err == io.EOF {
+			return true, nil
+		}
+		if err != nil {
+			err := fmt.Errorf("NextPart failed: %v", err)
+			log.Error(err.Error())
+			return true, err
+		}
+		filename := p.FileName()
+		if filename == "" {
+			err := fmt.Errorf("Empty filename field")
+			log.Error(err.Error())
+			return true, err
+		}
+		// Note that Join + Clean collapses any .. in path
+		// but could still end up with leading ../ in path
+		// so we check it starts with the dir.
+		filename = filepath.Clean(filepath.Join(dir, filename))
+		if !strings.HasPrefix(filename, dir) {
+			err := fmt.Errorf("Filename tried to escape: orig %s derived %s",
+				p.FileName(), filename)
+			log.Error(err.Error())
+			return true, err
+		}
+		dirname := filepath.Dir(filename)
+		err = os.MkdirAll(dirname, 0700)
+		if err != nil {
+			err := fmt.Errorf("MkdirAll failed: %v", err)
+			log.Error(err.Error())
+			return true, err
+		}
+		w, err := os.Create(filename)
+		if err != nil {
+			err := fmt.Errorf("Create(%s) failed: %v", filename, err)
+			log.Error(err.Error())
+			return true, err
+		}
+		defer w.Close()
+
+		filelen, err := io.Copy(w, p)
+		if err != nil {
+			err := fmt.Errorf("Copy(%s) failed: %v", filename, err)
+			log.Error(err.Error())
+			return true, err
+		}
+		log.Noticef("Wrote filename %s with %d bytes",
+			filename, filelen)
+	}
+}

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -213,6 +213,9 @@ const (
 
 	// XXX Temporary flag to disable RFC 3442 classless static route usage
 	DisableDHCPAllOnesNetMask GlobalSettingKey = "debug.disable.dhcp.all-ones.netmask"
+
+	// ProcessCloudInitMultiPart to help VMs which do not handle mime multi-part themselves
+	ProcessCloudInitMultiPart GlobalSettingKey = "process.cloud-init.multipart"
 )
 
 // AgentSettingKey - keys for per-agent settings
@@ -769,6 +772,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddBoolItem(IgnoreDiskCheckForApps, false)
 	configItemSpecMap.AddBoolItem(AllowLogFastupload, false)
 	configItemSpecMap.AddBoolItem(DisableDHCPAllOnesNetMask, false)
+	configItemSpecMap.AddBoolItem(ProcessCloudInitMultiPart, false)
 
 	// Add TriState Items
 	configItemSpecMap.AddTriStateItem(NetworkFallbackAnyEth, TS_ENABLED)

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -187,6 +187,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		DefaultLogLevel,
 		DefaultRemoteLogLevel,
 		DisableDHCPAllOnesNetMask,
+		ProcessCloudInitMultiPart,
 	}
 	if len(specMap.GlobalSettings) != len(gsKeys) {
 		t.Errorf("GlobalSettings has more (%d) than expected keys (%d)",


### PR DESCRIPTION
There seems to be some VM images which require a directory structure of their control in the CDROM cloud-init image, even though per the cloud-init specification they should handle the MIME multipart messages themselves.

I do not think we should do this by default, but instead be controlled by the settings introduced by #1951 once those are supported in the controllers and UI. For the time being we instead introduce a global configItem called process.cloud-init.multipart.

The code tries hard to make sure the filename parameter can not be used to escape outside of the target directory, which can benefit from another pair of eyes. The unittests has the obvious attempts to escape, and since this can only be used to create regular files in an empty TempDir, one can't create symlinks to escape.