### PR TITLE
report /persist/containerd storage use

### DIFF
--- a/pkg/pillar/types/diskmetrics.go
+++ b/pkg/pillar/types/diskmetrics.go
@@ -22,6 +22,7 @@ var ReportDiskPaths = []string{
 var ReportDirPaths = []string{
 	PersistDir + "/downloads", // XXX old to be removed
 	PersistDir + "/img",       // XXX old to be removed
+	PersistDir + "/containerd",
 	PersistDir + "/tmp",
 	PersistDir + "/log",
 	PersistDir + "/newlog",


### PR DESCRIPTION
This directory can be one of the largest, yet we don't report it in the raw metrics.