### PR TITLE
Sticky IP addresses for app instances

### DIFF
--- a/pkg/pillar/base/logobjecttypes.go
+++ b/pkg/pillar/base/logobjecttypes.go
@@ -152,6 +152,8 @@ const (
 	MemoryNotificationType = "memory_notification"
 	// DiskNotificationType
 	DiskNotificationType = "disk_notification"
+	// UUIDPairToNumLogType:
+	UUIDPairToNumLogType LogObjectType = "uuid_pair_to_num"
 )
 
 // RelationObjectType :

--- a/pkg/pillar/cmd/zedrouter/appnumonunet.go
+++ b/pkg/pillar/cmd/zedrouter/appnumonunet.go
@@ -1,0 +1,278 @@
+// Copyright (c) 2021 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Network Instance/underlay network IP Address Management,
+// App Number management Module
+
+// Allocate a small integer for each application UUID.
+// The number can not exceed 255 since we use the as IPv4 subnet numbers.
+// Persist the numbers across reboots/activation using uuidpairtonum package
+// When there are no free numbers then reuse the unused numbers.
+// We try to give the application with IsZedmanager=true appnum zero.
+
+package zedrouter
+
+import (
+	"fmt"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/lf-edge/eve/pkg/pillar/uuidpairtonum"
+	"github.com/satori/go.uuid"
+)
+
+// mapped on base UUID
+var appNumBase map[string]*types.Bitmap
+
+const (
+	appNumOnUNetType = "appNumOnUnet"
+)
+
+// Read the existing appNums out of what we published/checkpointed.
+// Also read what we have persisted before a reboot
+// Store in reserved map since we will be asked to allocate them later.
+// Set bit in bitmap.
+func appNumOnUNetInit(ctx *zedrouterContext) {
+
+	// initialize the base
+	appNumBase = make(map[string]*types.Bitmap)
+
+	pubAppNetworkStatus := ctx.pubAppNetworkStatus
+	pub := ctx.pubUUIDPairToNum
+	numType := appNumOnUNetType
+
+	items := pub.GetAll()
+	for _, item := range items {
+		appNumMap := item.(types.UUIDPairToNum)
+		if appNumMap.NumType != numType {
+			continue
+		}
+		log.Functionf("appNumOnUNetInit found %v", appNumMap)
+		appNum := appNumMap.Number
+		baseID := appNumMap.BaseID
+		appID := appNumMap.AppID
+
+		// If we have a config for the UUID Pair, we should mark it as
+		// allocated; otherwise mark it as reserved.
+		// XXX however, on startup we are not likely to have any
+		// config yet.
+		baseMap := appNumOnUNetBaseCreate(baseID)
+		if baseMap.IsSet(appNum) {
+			log.Errorf("Bitmap is already set for %s num %d",
+				types.UUIDPairToNumKey(baseID, appID), appNum)
+			continue
+		}
+		log.Functionf("Reserving appNum %d for %s",
+			appNum, types.UUIDPairToNumKey(baseID, appID))
+		baseMap.Set(appNum)
+		// Clear InUse
+		uuidpairtonum.NumFree(log, pub, baseID, appID)
+	}
+	// In case zedrouter process restarted we fill in InUse from
+	// AppNetworkStatus, underlay network entries
+	items = pubAppNetworkStatus.GetAll()
+	for _, item := range items {
+		status := item.(types.AppNetworkStatus)
+		appID := status.UUIDandVersion.UUID
+
+		// If we have a config for the UUID we should mark it as
+		// allocated; otherwise mark it as reserved.
+		// XXX however, on startup we are not likely to have any
+		// config yet.
+		for i := range status.UnderlayNetworkList {
+			ulStatus := &status.UnderlayNetworkList[i]
+			baseID := ulStatus.Network
+			baseMap := appNumOnUNetBaseGet(baseID)
+			if baseMap == nil {
+				continue
+			}
+			appNum, err := uuidpairtonum.NumGet(log, pub,
+				baseID, appID, numType)
+			if err != nil {
+				continue
+			}
+			if !baseMap.IsSet(appNum) {
+				log.Fatalf("Bitmap is not set for %s num %d",
+					types.UUIDPairToNumKey(baseID, appID), appNum)
+			}
+			log.Functionf("Marking InUse for appNum %d",
+				appNum)
+			// Set InUse
+			uuidpairtonum.NumAllocate(log, pub, baseID,
+				appID, appNum, false, numType)
+		}
+	}
+}
+
+// If an entry is not inUse and and its CreateTime were
+// before the agent started, then we free it up.
+func appNumMapOnUNetGC(ctx *zedrouterContext) {
+
+	pub := ctx.pubUUIDPairToNum
+	numType := appNumOnUNetType
+
+	log.Functionf("appNumOnUNetMapGC")
+	freedCount := 0
+	items := pub.GetAll()
+	for _, item := range items {
+		appNumMap := item.(types.UUIDPairToNum)
+		if appNumMap.NumType != numType {
+			continue
+		}
+		if appNumMap.InUse {
+			continue
+		}
+		if appNumMap.CreateTime.After(ctx.agentStartTime) {
+			continue
+		}
+		log.Functionf("appNumMapOnUNetGC: freeing %+v", appNumMap)
+		appNumOnUNetFree(ctx, appNumMap.BaseID, appNumMap.AppID)
+		freedCount++
+	}
+	log.Functionf("appNumMapOnUNetGC freed %d", freedCount)
+}
+
+func appNumOnUNetAllocate(ctx *zedrouterContext, baseID uuid.UUID,
+	appID uuid.UUID, isStatic bool, isZedmanager bool) (int, error) {
+
+	pub := ctx.pubUUIDPairToNum
+	numType := appNumOnUNetType
+	baseMap := appNumOnUNetBaseCreate(baseID)
+
+	// Do we already have a number?
+	appNum, err := uuidpairtonum.NumGet(log, pub, baseID, appID,
+		numType)
+	if err == nil {
+		log.Functionf("Found allocated appNum %d for %s", appNum,
+			types.UUIDPairToNumKey(baseID, appID))
+		if !baseMap.IsSet(appNum) {
+			log.Fatalf("Bitmap value(%d) is not set", appNum)
+		}
+		// Set InUse and update time
+		uuidpairtonum.NumAllocate(log, pub, baseID, appID, appNum,
+			false, numType)
+		return appNum, nil
+	}
+
+	// Find a free number in bitmap; look for zero if isZedmanager
+	if isZedmanager && !baseMap.IsSet(0) {
+		appNum = 0
+		log.Functionf("Allocating appNum %d for %s isZedmanager",
+			appNum, types.UUIDPairToNumKey(baseID, appID))
+	} else {
+		// XXX could look for non-0xFF bytes first for efficiency
+		appNum = -1
+		// for static we pick the topmost numbers so avoid consuming
+		// dynamic IP address from a smallish DHCP range.
+		if isStatic {
+			for i := types.BitMapMax; i >= 0; i-- {
+				if !baseMap.IsSet(i) {
+					appNum = i
+					log.Functionf("Allocating appNum %d for %s",
+						appNum, types.UUIDPairToNumKey(baseID, appID))
+					break
+				}
+			}
+		} else {
+			for i := 0; i <= types.BitMapMax; i++ {
+				if !baseMap.IsSet(i) {
+					appNum = i
+					log.Functionf("Allocating appNum %d for %s",
+						appNum, types.UUIDPairToNumKey(baseID, appID))
+					break
+				}
+			}
+		}
+		if appNum == -1 {
+			log.Functionf("Failed to find free appNum for %s. Reusing!",
+				types.UUIDPairToNumKey(baseID, appID))
+			oldAppID, oldAppNum, err :=
+				uuidpairtonum.NumGetOldestUnused(log, pub,
+					baseID, numType)
+			if err != nil {
+				return appNum, fmt.Errorf("no free appNum")
+			}
+			log.Functionf("Reuse found appNum %d for %s. Reusing!",
+				oldAppNum, types.UUIDPairToNumKey(baseID, oldAppID))
+			uuidpairtonum.NumDelete(log, pub, baseID, oldAppID)
+			baseMap.Clear(oldAppNum)
+			appNum = oldAppNum
+		}
+	}
+	if baseMap.IsSet(appNum) {
+		log.Fatalf("Bitmap is already set for %d", appNum)
+	}
+	baseMap.Set(appNum)
+	uuidpairtonum.NumAllocate(log, pub, baseID, appID, appNum, true,
+		numType)
+	return appNum, nil
+}
+
+func appNumOnUNetFree(ctx *zedrouterContext, baseID uuid.UUID,
+	appID uuid.UUID) {
+
+	pub := ctx.pubUUIDPairToNum
+	numType := appNumOnUNetType
+	appNum, err := uuidpairtonum.NumGet(log, pub, baseID, appID, numType)
+	if err != nil {
+		log.Fatalf("num not found for %s",
+			types.UUIDPairToNumKey(baseID, appID))
+	}
+	baseMap := appNumOnUNetBaseGet(baseID)
+	if baseMap == nil {
+		uuidpairtonum.NumDelete(log, pub, baseID, appID)
+		return
+	}
+	// Check that number exists in the allocated numbers
+	if !baseMap.IsSet(appNum) {
+		log.Fatalf("Bitmap is not set for %d", appNum)
+	}
+	baseMap.Clear(appNum)
+	uuidpairtonum.NumDelete(log, pub, baseID, appID)
+}
+
+func appNumOnUNetGet(ctx *zedrouterContext, baseID uuid.UUID,
+	appID uuid.UUID) (int, error) {
+	pub := ctx.pubUUIDPairToNum
+	numType := appNumOnUNetType
+	return uuidpairtonum.NumGet(log, pub, baseID, appID, numType)
+}
+
+// returns base bitMap for a given UUID
+func appNumOnUNetBaseGet(baseID uuid.UUID) *types.Bitmap {
+	if baseMap, exist := appNumBase[baseID.String()]; exist {
+		return baseMap
+	}
+	return nil
+}
+
+// Create application number Base for a given UUID
+func appNumOnUNetBaseCreate(baseID uuid.UUID) *types.Bitmap {
+	if appNumOnUNetBaseGet(baseID) == nil {
+		log.Functionf("appNumOnUNetBaseCreate (%s)", baseID.String())
+		appNumBase[baseID.String()] = new(types.Bitmap)
+	}
+	return appNumOnUNetBaseGet(baseID)
+}
+
+// Delete the application number Base for a given UUID
+func appNumOnUNetBaseDelete(ctx *zedrouterContext, baseID uuid.UUID) {
+	appNumMap := appNumOnUNetBaseGet(baseID)
+	if appNumMap == nil {
+		log.Fatalf("appNumOnUNetBaseDelete: non-existent")
+	}
+	// check whether there are still some apps on
+	// this network
+	pub := ctx.pubUUIDPairToNum
+	numType := appNumOnUNetType
+	items := pub.GetAll()
+	for _, item := range items {
+		appNumMap := item.(types.UUIDPairToNum)
+		if appNumMap.NumType != numType {
+			continue
+		}
+		if appNumMap.BaseID == baseID {
+			log.Fatalf("appNumOnUNetBaseDelete(): active persistent app nums")
+		}
+	}
+	log.Functionf("appNumOnUNetBaseDelete (%s)", baseID.String())
+	delete(appNumBase, baseID.String())
+}

--- a/pkg/pillar/cmd/zedrouter/bridgenumallocator.go
+++ b/pkg/pillar/cmd/zedrouter/bridgenumallocator.go
@@ -13,7 +13,7 @@ import (
 	"github.com/satori/go.uuid"
 )
 
-var AllocReservedBridgeNumBits Bitmap
+var AllocReservedBridgeNumBits types.Bitmap
 
 // Read the existing bridgeNums out of what we published/checkpointed.
 // Also read what we have persisted before a reboot

--- a/pkg/pillar/cmd/zedrouter/ipaddronunet.go
+++ b/pkg/pillar/cmd/zedrouter/ipaddronunet.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2021 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Network Instance underlay network Application Number Management
+
+package zedrouter
+
+import (
+	"errors"
+	"fmt"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+func appNumsOnUNetAllocate(ctx *zedrouterContext,
+	config *types.AppNetworkConfig) error {
+	for _, ulConfig := range config.UnderlayNetworkList {
+		isStatic := (ulConfig.AppIPAddr != nil)
+		appID := config.UUIDandVersion.UUID
+		networkID := ulConfig.Network
+		appNum, err := appNumOnUNetAllocate(ctx, networkID, appID,
+			isStatic, false)
+		if err != nil {
+			errStr := fmt.Sprintf("App Num get fail :%s", err)
+			log.Errorf("appNumsOnUNetAllocate(%s, %s): fail: %s",
+				networkID.String(), appID.String(), errStr)
+			return errors.New(errStr)
+		}
+		log.Functionf("appNumsOnUNetAllocate(%s, %s): allocated %d",
+			networkID.String(), appID.String(), appNum)
+	}
+	return nil
+}
+
+func appNumsOnUNetFree(ctx *zedrouterContext,
+	status *types.AppNetworkStatus) {
+	appID := status.UUIDandVersion.UUID
+	for ulNum := 0; ulNum < len(status.UnderlayNetworkList); ulNum++ {
+		ulStatus := &status.UnderlayNetworkList[ulNum]
+		networkID := ulStatus.Network
+		// release the app number
+		_, err := appNumOnUNetGet(ctx, networkID, appID)
+		if err == nil {
+			appNumOnUNetFree(ctx, networkID, appID)
+		}
+	}
+}

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -10,6 +10,7 @@
 package zedrouter
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"errors"
 	"flag"
@@ -69,6 +70,7 @@ type zedrouterContext struct {
 	GCInitialized          bool
 	pubUuidToNum           pubsub.Publication
 	dhcpLeases             []dnsmasqLease
+	pubUUIDPairToNum       pubsub.Publication
 
 	// NetworkInstance
 	subNetworkInstanceConfig  pubsub.Subscription
@@ -153,6 +155,16 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	}
 	pubUuidToNum.ClearRestarted()
 
+	pubUUIDPairToNum, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName:  agentName,
+		Persistent: true,
+		TopicType:  types.UUIDPairToNum{},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	pubUUIDPairToNum.ClearRestarted()
+
 	// Create the dummy interface used to re-direct DROP/REJECT packets.
 	createFlowMonDummyInterface()
 
@@ -231,6 +243,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	zedrouterCtx.deviceNetworkStatus = &types.DeviceNetworkStatus{}
 	zedrouterCtx.pubUuidToNum = pubUuidToNum
+	zedrouterCtx.pubUUIDPairToNum = pubUUIDPairToNum
 
 	// Create publish before subscribing and activating subscriptions
 	// Also need to do this before we wait for IP addresses since
@@ -405,6 +418,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	appNumAllocatorInit(&zedrouterCtx)
 	bridgeNumAllocatorInit(&zedrouterCtx)
 	handleInit(runDirname)
+	appNumOnUNetInit(&zedrouterCtx)
 
 	// Before we process any NetworkInstances we want to know the
 	// assignable adapters.
@@ -543,7 +557,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 			subAssignableAdapters.ProcessChange(change)
 
 		case change := <-subAppNetworkConfig.MsgChan():
-			// If we have an NetworkInstanceConfig process it first
+			// If we have NetworkInstanceConfig process it first
 			checkAndProcessNetworkInstanceConfig(&zedrouterCtx)
 			subAppNetworkConfig.ProcessChange(change)
 
@@ -562,6 +576,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 			start := time.Now()
 			bridgeNumAllocatorGC(&zedrouterCtx)
 			appNumAllocatorGC(&zedrouterCtx)
+			appNumMapOnUNetGC(&zedrouterCtx)
 			zedrouterCtx.triggerNumGC = false
 			ps.CheckMaxTimeTopic(agentName, "allocatorGC", start,
 				warningTime, errorTime)
@@ -587,7 +602,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 			subAssignableAdapters.ProcessChange(change)
 
 		case change := <-subAppNetworkConfig.MsgChan():
-			// If we have an NetworkInstanceConfig process it first
+			// If we have NetworkInstanceConfig process it first
 			checkAndProcessNetworkInstanceConfig(&zedrouterCtx)
 			subAppNetworkConfig.ProcessChange(change)
 
@@ -709,6 +724,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 			start := time.Now()
 			bridgeNumAllocatorGC(&zedrouterCtx)
 			appNumAllocatorGC(&zedrouterCtx)
+			appNumMapOnUNetGC(&zedrouterCtx)
 			zedrouterCtx.triggerNumGC = false
 			ps.CheckMaxTimeTopic(agentName, "allocatorGC", start,
 				warningTime, errorTime)
@@ -879,6 +895,12 @@ func handleAppNetworkCreate(ctxArg interface{}, key string, configArg interface{
 	}
 	publishAppNetworkStatus(ctx, &status)
 
+	// allocate application numbers on underlay network
+	if err := appNumsOnUNetAllocate(ctx, &config); err != nil {
+		addError(ctx, &status, "handleAppNetworkCreate", err)
+		return
+	}
+
 	if config.Activate {
 		doActivate(ctx, config, &status)
 	}
@@ -1012,7 +1034,6 @@ func appNetworkDoActivateAllUnderlayNetworks(
 			ulNum, ulConfig.Network.String(), ulConfig.ACLs)
 		err := appNetworkDoActivateUnderlayNetwork(
 			ctx, config, status, ipsets, &ulConfig, ulNum)
-
 		if err != nil {
 			return err
 		}
@@ -1053,12 +1074,56 @@ func appNetworkDoActivateUnderlayNetwork(
 		addError(ctx, status, "error from network instance", err)
 		return err
 	}
-	networkInstanceInfo := &netInstStatus.NetworkInstanceInfo
-
 	// Fetch the network that this underlay is attached to
-	bridgeName := networkInstanceInfo.BridgeName
 	vifName := "nbu" + strconv.Itoa(ulNum) + "x" +
 		strconv.Itoa(status.AppNum)
+
+	// appMac may not change across network transition,
+	// so only called once, on activation
+	var appMac string // Handed to domU
+	if ulConfig.AppMacAddr != nil {
+		appMac = ulConfig.AppMacAddr.String()
+	} else {
+		appMac = generateAppMac(status.UUIDandVersion.UUID,
+			ulNum, status.AppNum, netInstStatus)
+	}
+	log.Functionf("appMac %s\n", appMac)
+	ulStatus := &status.UnderlayNetworkList[ulNum-1]
+	return appNetworkUNetActivate(ctx, config, status, ulConfig,
+		ulStatus, vifName, appMac, ipsets)
+}
+
+func appNetworkUNetActivate(
+	ctx *zedrouterContext,
+	config types.AppNetworkConfig,
+	status *types.AppNetworkStatus,
+	ulConfig *types.UnderlayNetworkConfig,
+	ulStatus *types.UnderlayNetworkStatus,
+	vifName string, appMac string,
+	ipsets []string) error {
+
+	netInstStatus := lookupNetworkInstanceStatus(ctx,
+		ulConfig.Network.String())
+	if netInstStatus == nil {
+		err := fmt.Errorf("no network instance status for %s",
+			ulConfig.Network.String())
+		log.Error(err.Error())
+		// Set up to retry later
+		status.AwaitNetworkInstance = true
+		addError(ctx, status, "doActivate underlay", err)
+		return err
+	}
+	if netInstStatus.HasError() {
+		err := errors.New(netInstStatus.Error)
+		log.Error(err.Error())
+		// Set up to retry later
+		status.AwaitNetworkInstance = true
+		addError(ctx, status, "error from network instance", err)
+		return err
+	}
+	networkInstanceInfo := &netInstStatus.NetworkInstanceInfo
+	appID := status.UUIDandVersion.UUID
+	bridgeName := networkInstanceInfo.BridgeName
 	uLink, err := findBridge(bridgeName)
 	if err != nil {
 		log.Error(err.Error())
@@ -1071,18 +1136,8 @@ func appNetworkDoActivateUnderlayNetwork(
 	log.Functionf("bridgeName %s MAC %s\n",
 		bridgeName, bridgeMac.String())
 
-	var appMac string // Handed to domU
-	if ulConfig.AppMacAddr != nil {
-		appMac = ulConfig.AppMacAddr.String()
-	} else {
-		appMac = generateAppMac(status.UUIDandVersion.UUID,
-			ulNum, status.AppNum, netInstStatus)
-	}
-	log.Functionf("appMac %s\n", appMac)
-
 	// Record what we have so far
-	ulStatus := &status.UnderlayNetworkList[ulNum-1]
-	log.Functionf("doActivate ulNum %d: %v\n", ulNum, ulStatus)
+	log.Functionf("doActivate : %v", ulStatus)
 	ulStatus.Name = ulConfig.Name
 	ulStatus.Bridge = bridgeName
 	ulStatus.BridgeMac = bridgeMac
@@ -1108,15 +1163,14 @@ func appNetworkDoActivateUnderlayNetwork(
 		}
 	}
 
-	bridgeIPAddr, appIPAddr, err := getUlAddrs(ctx, ulNum-1,
-		status.AppNum, ulStatus, netInstStatus)
+	appIPAddr, err := getUlAddrs(ctx, netInstStatus, ulStatus, appID)
 	if err != nil {
-		err := fmt.Errorf("Bridge/App IP address allocation failed: %v",
-			err)
+		err := fmt.Errorf("App IP address allocation failed: %v", err)
 		log.Error(err.Error())
 		addError(ctx, status, "getUlAddrs", err)
 		return err
 	}
+	bridgeIPAddr := netInstStatus.BridgeIPAddr
 	log.Functionf("bridgeIPAddr %s appIPAddr %s\n", bridgeIPAddr, appIPAddr)
 	ulStatus.BridgeIPAddr = bridgeIPAddr
 	// appIPAddr is "" for switch NI. DHCP snoop will set AllocatedIPv4Addr later
@@ -1144,7 +1198,6 @@ func appNetworkDoActivateUnderlayNetwork(
 		addError(ctx, status, "createACL", err)
 		return err
 	}
-	appID := status.UUIDandVersion.UUID
 	setNetworkACLRules(ctx, appID, ulStatus.Name, ruleList)
 
 	if appIPAddr != "" {
@@ -1337,58 +1390,79 @@ func findBridge(bridgeName string) (*netlink.Bridge, error) {
 
 // XXX Need additional logic for IPv6 underlays.
 func getUlAddrs(ctx *zedrouterContext,
-	ifnum int, appNum int,
-	status *types.UnderlayNetworkStatus,
-	netInstStatus *types.NetworkInstanceStatus) (string, string, error) {
-
-	log.Functionf("getUlAddrs(%d/%d)\n", ifnum, appNum)
-
-	bridgeIPAddr := ""
-	appIPAddr := ""
-
-	// Allocate bridgeIPAddr based on BridgeMac
-	log.Functionf("getUlAddrs(%d/%d for %s) bridgeMac %s\n",
-		ifnum, appNum, netInstStatus.UUID.String(),
-		status.BridgeMac.String())
+	netInstStatus *types.NetworkInstanceStatus,
+	ulStatus *types.UnderlayNetworkStatus, appID uuid.UUID) (string, error) {
 	var err error
-	var addr string
-	addr, err = lookupOrAllocateIPv4(ctx, netInstStatus,
-		status.BridgeMac)
+	var mac net.HardwareAddr
+	networkID := netInstStatus.UUID
+
+	if netInstStatus.Subnet.IP == nil ||
+		netInstStatus.DhcpRange.Start == nil {
+		log.Functionf("getUlAddrs(%s): app(%s), no subnet\n",
+			networkID.String(), appID.String())
+		return "", nil
+	}
+	if ulStatus.Mac == "" {
+		log.Functionf("getUlAddrs(%s): app(%s) fail: no mac",
+			networkID.String(), appID.String())
+		return "", nil
+	}
+	log.Functionf("getUlAddrs(%s): app(%s)",
+		networkID.String(), appID.String())
+
+	// XXX or change type of VifInfo.Mac to avoid parsing?
+	mac, err = net.ParseMAC(ulStatus.Mac)
 	if err != nil {
-		log.Errorf("getUlAddrs: Bridge IP address allocation failed %s\n", err)
-		return bridgeIPAddr, appIPAddr, err
-	} else {
-		bridgeIPAddr = addr
+		errStr := fmt.Sprintf("parse Mac fail: %v\n", err)
+		log.Errorf("getUlAddrs(%s): app(%s) fail: %s\n",
+			networkID.String(), appID.String(), err)
+		return "", errors.New(errStr)
 	}
 
-	if status.AppIPAddr != nil {
-		// Static IP assignment case.
-		// Note that appIPAddr can be in a different subnet.
-		// Assumption is that the config specifies a gateway/router
-		// in the same subnet as the static address.
-		appIPAddr = status.AppIPAddr.String()
-		recordIPAssignment(ctx, netInstStatus, status.AppIPAddr,
-			status.Mac)
-	} else if status.Mac != "" {
-		// XXX or change type of VifInfo.Mac to avoid parsing?
-		var mac net.HardwareAddr
-		mac, err = net.ParseMAC(status.Mac)
-		if err != nil {
-			log.Fatal("ParseMAC failed: ", status.Mac, err)
+	ipAddr := ""
+	// for static IP Address
+	if ulStatus.AppIPAddr != nil {
+		ipAddr = ulStatus.AppIPAddr.String()
+		// the IP Address, should not be in dhcpRange
+		if netInstStatus.DhcpRange.Contains(ulStatus.AppIPAddr) {
+			errStr := fmt.Sprintf("static IP(%s) is in DhcpRange(%s, %s)",
+				ipAddr, netInstStatus.DhcpRange.Start.String(),
+				netInstStatus.DhcpRange.End.String())
+			log.Errorf("getUlAddrs(%s): app(%s) fail: %s",
+				networkID.String(), appID.String(), errStr)
+			return "", errors.New(errStr)
 		}
-		log.Functionf("getUlAddrs(%d/%d for %s) app Mac %s\n",
-			ifnum, appNum, netInstStatus.UUID.String(), mac.String())
-		addr, err = lookupOrAllocateIPv4(ctx, netInstStatus, mac)
+		// IP Address must be inside the subnet range
+		if !netInstStatus.Subnet.Contains(ulStatus.AppIPAddr) {
+			errStr := fmt.Sprintf("static IP(%s) is outside subnet range",
+				ipAddr)
+			log.Errorf("getUlAddrs(%s): app(%s) fail: %s",
+				networkID.String(), appID.String(), errStr)
+			return "", errors.New(errStr)
+		}
+	} else {
+		// get the app number for the underlay network entry
+		appNum, err := appNumOnUNetGet(ctx, networkID, appID)
 		if err != nil {
-			log.Errorf("getUlAddrs: App IP address allocation failed: %s\n", err)
-			return bridgeIPAddr, appIPAddr, err
-		} else {
-			appIPAddr = addr
+			errStr := fmt.Sprintf("App Number get failed: %v", err)
+			log.Errorf("getUlAddrs(%s): app(%s) fail: %s",
+				networkID.String(), appID.String(), errStr)
+			return "", errors.New(errStr)
+		}
+		ipAddr, err = lookupOrAllocateIPv4(netInstStatus, appID, appNum, mac)
+		if err != nil {
+			errStr := fmt.Sprintf("IP Addr get fail: %v", err)
+			log.Errorf("getUlAddrs(%s): app(%s) fail: %s",
+				networkID.String(), appID.String(), errStr)
+			return "", errors.New(errStr)
 		}
 	}
-	log.Functionf("getUlAddrs(%d/%d) done %s/%s\n",
-		ifnum, appNum, bridgeIPAddr, appIPAddr)
-	return bridgeIPAddr, appIPAddr, err
+	addr := net.ParseIP(ipAddr)
+	ulStatus.BridgeIPAddr = netInstStatus.BridgeIPAddr
+	recordIPAssignment(ctx, netInstStatus, addr, ulStatus.Mac)
+	log.Functionf("getUlAddrs(%s): App %s done, ipAddr: %s",
+		networkID.String(), appID.String(), ipAddr)
+	return ipAddr, nil
 }
 
 // Caller should clear the appropriate status.Pending* if the the caller will
@@ -1449,6 +1523,18 @@ func handleAppNetworkModify(ctxArg interface{}, key string,
 	// configure the ipsets for all the domU's interfaces/bridges.
 	ipsets := compileAppInstanceIpsets(ctx, config.UnderlayNetworkList)
 
+	// handle Network changes in underlay and
+	// collect IP Address/Name changes
+	uNetModData, err := doAppNetworkModifyUNetAppNums(ctx, config,
+		oldConfig, status, ipsets)
+	if err != nil {
+		log.Error(err.Error())
+		addError(ctx, status, "handleModify", err)
+		status.PendingModify = false
+		publishAppNetworkStatus(ctx, status)
+		return
+	}
+
 	// If we are not activated, then the doActivate below will set up
 	// the ACLs
 	if status.Activated {
@@ -1456,8 +1542,9 @@ func handleAppNetworkModify(ctxArg interface{}, key string,
 		// check to see if need to launch the process
 		appCheckStatsCollect(ctx, &config, status)
 
-		// Look for ACL changes in underlay
-		doAppNetworkModifyAllUnderlayNetworks(ctx, config, oldConfig, status, ipsets)
+		// handle Network, ACL changes in underlay
+		doAppNetworkModifyAllUnderlayNetworks(ctx, config,
+			oldConfig, status, uNetModData, ipsets)
 
 		// Write out what we modified to AppNetworkStatus
 		// Note that lengths are the same as before
@@ -1465,13 +1552,10 @@ func handleAppNetworkModify(ctxArg interface{}, key string,
 			status.UnderlayNetworkList[i].UnderlayNetworkConfig =
 				config.UnderlayNetworkList[i]
 		}
-	}
-
-	if config.Activate && !status.Activated {
-		// XXX the doAppNetworkModify calls above did
-		// an updateACL and doActivate will do a createACL resulting
-		// in duplicate (but harmless) rules.
-		doActivate(ctx, config, status)
+	} else {
+		if config.Activate {
+			doActivate(ctx, config, status)
+		}
 	}
 
 	status.PendingModify = false
@@ -1550,6 +1634,7 @@ func doAppNetworkModifyAllUnderlayNetworks(
 	config types.AppNetworkConfig,
 	oldConfig types.AppNetworkConfig,
 	status *types.AppNetworkStatus,
+	uNetModData []types.AppNetworkUNetModifyData,
 	ipsets []string) {
 
 	for i := range config.UnderlayNetworkList {
@@ -1557,28 +1642,33 @@ func doAppNetworkModifyAllUnderlayNetworks(
 		ulConfig := &config.UnderlayNetworkList[i]
 		oldulConfig := &oldConfig.UnderlayNetworkList[i]
 		ulStatus := &status.UnderlayNetworkList[i]
-		doAppNetworkModifyUnderlayNetwork(
-			ctx, status, ulConfig, oldulConfig, ulStatus, ipsets, false)
+		doAppNetworkModifyUNetAcls(ctx, status, ulConfig,
+			oldulConfig, ulStatus, uNetModData[i], ipsets, false)
 	}
 	publishAppNetworkStatus(ctx, status)
 }
 
-func doAppNetworkModifyUnderlayNetwork(
+func doAppNetworkModifyUNetAcls(
 	ctx *zedrouterContext,
 	status *types.AppNetworkStatus,
 	ulConfig *types.UnderlayNetworkConfig,
 	oldulConfig *types.UnderlayNetworkConfig,
 	ulStatus *types.UnderlayNetworkStatus,
+	uNetModData types.AppNetworkUNetModifyData,
 	ipsets []string, force bool) {
 
+	appID := status.UUIDandVersion.UUID
 	bridgeName := ulStatus.Bridge
 	appIPAddr := ulStatus.AllocatedIPv4Addr
 
 	netstatus := lookupNetworkInstanceStatus(ctx, ulConfig.Network.String())
 
 	aclArgs := types.AppNetworkACLArgs{IsMgmt: false, BridgeName: bridgeName,
-		VifName: ulStatus.Vif, BridgeIP: ulStatus.BridgeIPAddr, AppIP: appIPAddr,
-		UpLinks: netstatus.IfNameList, NIType: netstatus.Type,
+		VifName: ulStatus.Vif, BridgeIP: ulStatus.BridgeIPAddr,
+		AppIP: appIPAddr, OldAppIP: uNetModData.OldAppIP,
+		OldBridgeName: uNetModData.OldBridgeName,
+		OldBridgeIP:   uNetModData.OldBridgeIP,
+		UpLinks:       netstatus.IfNameList, NIType: netstatus.Type,
 		AppNum: int32(status.AppNum)}
 
 	// We ignore any errors in netstatus
@@ -1586,7 +1676,6 @@ func doAppNetworkModifyUnderlayNetwork(
 	// XXX could there be a change to AllocatedIPAddress?
 	// If so updateNetworkACLConfiglet needs to know old and new
 	// XXX Could ulStatus.Vif not be set? Means we didn't add
-	appID := status.UUIDandVersion.UUID
 	rules := getNetworkACLRules(ctx, appID, ulStatus.Name)
 	ruleList, dependList, err := updateACLConfiglet(ctx, aclArgs,
 		oldulConfig.ACLs, ulConfig.ACLs, rules.ACLRules,
@@ -1618,6 +1707,112 @@ func doAppNetworkModifyUnderlayNetwork(
 	publishNetworkInstanceStatus(ctx, netstatus)
 
 	maybeRemoveStaleIpsets(staleIpsets)
+}
+
+func doAppNetworkModifyUNetAppNums(
+	ctx *zedrouterContext,
+	config types.AppNetworkConfig,
+	oldConfig types.AppNetworkConfig,
+	status *types.AppNetworkStatus,
+	ipsets []string) ([]types.AppNetworkUNetModifyData, error) {
+	var uNetModData []types.AppNetworkUNetModifyData
+	for i := range config.UnderlayNetworkList {
+		log.Tracef("handleModify ulNum %d\n", i)
+		ulConfig := &config.UnderlayNetworkList[i]
+		oldulConfig := &oldConfig.UnderlayNetworkList[i]
+		ulStatus := &status.UnderlayNetworkList[i]
+		modData, err := doAppNetworkModifyUNetAppNum(ctx, config,
+			status, ulConfig, oldulConfig, ulStatus, ipsets)
+		if err != nil {
+			return uNetModData, err
+		}
+		uNetModData = append(uNetModData, modData)
+	}
+	return uNetModData, nil
+}
+
+// on network transition,
+// release the appNum and acquire appNum on the new network instance
+func doAppNetworkModifyUNetAppNum(
+	ctx *zedrouterContext,
+	config types.AppNetworkConfig,
+	status *types.AppNetworkStatus,
+	ulConfig *types.UnderlayNetworkConfig,
+	oldulConfig *types.UnderlayNetworkConfig,
+	ulStatus *types.UnderlayNetworkStatus,
+	ipsets []string) (types.AppNetworkUNetModifyData, error) {
+	appID := status.UUIDandVersion.UUID
+	networkID := ulConfig.Network
+	oldNetworkID := ulStatus.Network
+	netstatus := lookupNetworkInstanceStatus(ctx, ulConfig.Network.String())
+	if netstatus == nil {
+		errStr := fmt.Sprintf("network instance status get fail :%s",
+			networkID.String())
+		log.Errorf("doAppNetworkModifyUNetAppNum(%s, %s): fail: %s",
+			networkID.String(), appID.String(), errStr)
+		return types.AppNetworkUNetModifyData{}, errors.New(errStr)
+	}
+	oldnetstatus := lookupNetworkInstanceStatus(ctx, oldNetworkID.String())
+	if oldnetstatus == nil {
+		errStr := fmt.Sprintf("network instance status get fail :%s",
+			oldNetworkID.String())
+		log.Errorf("doAppNetworkModifyUNetAppNum(%s, %s): fail: %s",
+			networkID.String(), appID.String(), errStr)
+		return types.AppNetworkUNetModifyData{}, errors.New(errStr)
+	}
+	modData := types.AppNetworkUNetModifyData{
+		OldAppIP:      ulStatus.AllocatedIPv4Addr,
+		OldBridgeIP:   oldnetstatus.BridgeIPAddr,
+		OldBridgeName: oldnetstatus.BridgeName,
+	}
+	change := false
+	// network association change
+	if !uuid.Equal(networkID, oldNetworkID) {
+		// release the app number on old network
+		if _, err := appNumOnUNetGet(ctx, oldNetworkID, appID); err == nil {
+			appNumOnUNetFree(ctx, oldNetworkID, appID)
+		}
+		// allocate an app number on new network
+		isStatic := (ulConfig.AppIPAddr != nil)
+		if _, err := appNumOnUNetAllocate(ctx, networkID, appID,
+			isStatic, false); err != nil {
+			errStr := fmt.Sprintf("underlay network pp num allocate fail :%s",
+				err)
+			log.Errorf("appNumsOnUNetAllocate(%s, %s): fail: %s",
+				networkID.String(), appID.String(), errStr)
+			return modData, errors.New(errStr)
+		}
+		change = true
+	}
+	// Static IP Addr Change, Bridge IP Change etc
+	// TBD:XXX may be retart the qnsmasq etc. with new ids would suffice
+	if bytes.Compare(oldulConfig.AppIPAddr, ulConfig.AppIPAddr) != 0 ||
+		ulStatus.BridgeIPAddr != netstatus.BridgeIPAddr {
+		change = true
+	}
+	// if activated, deactivate the interface and release resources
+	// on the old network and try to activate the underlay interface
+	// on new network
+	if change && status.Activated {
+		appNetworkDoInactivateUnderlayNetwork(ctx, status,
+			ulStatus, ipsets)
+		if err := appNetworkUNetActivate(ctx, config, status,
+			ulConfig, ulStatus, ulStatus.Vif, ulStatus.Mac,
+			ipsets); err != nil {
+			errStr := fmt.Sprintf("Underly Network activation fail: %s",
+				err)
+			log.Errorf("doAppNetworkModifyUNetAppNum(%s, %s): fail: %s",
+				networkID.String(), appID.String(), errStr)
+			return modData, errors.New(errStr)
+		}
+		// As Acls have been cleared, new IP Address
+		// allocated, erasing old state and ACLs are recreated,
+		// assume new values
+		modData.OldAppIP = ulStatus.AllocatedIPv4Addr
+		modData.OldBridgeIP = netstatus.BridgeIPAddr
+		modData.OldBridgeName = netstatus.BridgeName
+	}
+	return modData, nil
 }
 
 func maybeRemoveStaleIpsets(staleIpsetHosts []string) {
@@ -1657,6 +1852,7 @@ func handleDelete(ctx *zedrouterContext, key string,
 	unpublishAppNetworkStatus(ctx, status)
 
 	appNumFree(ctx, status.UUIDandVersion.UUID)
+	appNumsOnUNetFree(ctx, status)
 	log.Functionf("handleDelete done for %s\n", status.DisplayName)
 }
 
@@ -1688,13 +1884,13 @@ func appNetworkDoInactivateAllUnderlayNetworks(
 	status *types.AppNetworkStatus,
 	ipsets []string) {
 
+	appID := status.UUIDandVersion.UUID
 	for ulNum := 0; ulNum < len(status.UnderlayNetworkList); ulNum++ {
 		ulStatus := &status.UnderlayNetworkList[ulNum]
 		log.Functionf("doInactivate ulNum %d: %v\n", ulNum, ulStatus)
 		appNetworkDoInactivateUnderlayNetwork(
 			ctx, status, ulStatus, ipsets)
 	}
-	appID := status.UUIDandVersion.UUID
 	delete(ctx.NLaclMap, appID)
 }
 
@@ -1737,12 +1933,12 @@ func appNetworkDoInactivateUnderlayNetwork(
 			appIPAddr)
 	}
 
+	appID := status.UUIDandVersion.UUID
 	aclArgs := types.AppNetworkACLArgs{IsMgmt: false, BridgeName: bridgeName,
 		VifName: ulStatus.Vif, BridgeIP: ulStatus.BridgeIPAddr, AppIP: appIPAddr,
 		UpLinks: netstatus.IfNameList}
 
 	// XXX Could ulStatus.Vif not be set? Means we didn't add
-	appID := status.UUIDandVersion.UUID
 	if ulStatus.Vif != "" {
 		rules := getNetworkACLRules(ctx, appID, ulStatus.Name)
 		ruleList, err := deleteACLConfiglet(aclArgs, rules.ACLRules)
@@ -2058,6 +2254,8 @@ func updateACLIPAddr(ctx *zedrouterContext, changedDepend []types.ACLDepend) {
 					i, status.Key())
 				continue
 			}
+			netstatus := lookupNetworkInstanceStatus(ctx,
+				ulStatus.Network.String())
 			match := false
 			for _, d := range ulStatus.ACLDependList {
 				// if d.Ifname in changedDepend
@@ -2082,8 +2280,13 @@ func updateACLIPAddr(ctx *zedrouterContext, changedDepend []types.ACLDepend) {
 			}
 			ipsets := compileAppInstanceIpsets(ctx,
 				config.UnderlayNetworkList)
-			doAppNetworkModifyUnderlayNetwork(ctx, &status,
-				ulConfig, ulConfig, ulStatus, ipsets, true)
+			modData := types.AppNetworkUNetModifyData{
+				OldAppIP:      ulStatus.AllocatedIPv4Addr,
+				OldBridgeIP:   ulStatus.BridgeIPAddr,
+				OldBridgeName: netstatus.BridgeName,
+			}
+			doAppNetworkModifyUNetAcls(ctx, &status,
+				ulConfig, ulConfig, ulStatus, modData, ipsets, true)
 			publishAppNetworkStatus(ctx, &status)
 		}
 	}
@@ -2317,14 +2520,14 @@ func doDnsmasqRestart(ctx *zedrouterContext) {
 }
 
 // XXX: Dead code. May be useful when we do wireguard/tailscale
-func deleteAppInstaneOverlayRoute(
+func deleteAppInstanceOverlayRoute(
 	ctx *zedrouterContext,
 	status *types.AppNetworkStatus) {
 	bridgeName := "" // XXX Fill bridge name
 	oLink, err := findBridge(bridgeName)
 	if err != nil {
 		addError(ctx, status, "findBridge", err)
-		log.Functionf("deleteAppInstaneOverlayRoute done for %s\n",
+		log.Functionf("deleteAppInstanceOverlayRoute done for %s\n",
 			status.DisplayName)
 		return
 	}
@@ -2341,9 +2544,9 @@ func deleteAppInstaneOverlayRoute(
 	if err != nil {
 		errStr := fmt.Sprintf("ParseCIDR %s failed: %v",
 			EID.String()+subnetSuffix, err)
-		addError(ctx, status, "deleteAppInstaneOverlayRoute",
+		addError(ctx, status, "deleteAppInstanceOverlayRoute",
 			errors.New(errStr))
-		log.Functionf("deleteAppInstaneOverlayRoute done for %s\n",
+		log.Functionf("deleteAppInstanceOverlayRoute done for %s\n",
 			status.DisplayName)
 		return
 	}
@@ -2351,9 +2554,9 @@ func deleteAppInstaneOverlayRoute(
 	if err := netlink.RouteDel(&rt); err != nil {
 		errStr := fmt.Sprintf("RouteDelete %s failed: %s",
 			EID, err)
-		addError(ctx, status, "deleteAppInstaneOverlayRoute",
+		addError(ctx, status, "deleteAppInstanceOverlayRoute",
 			errors.New(errStr))
-		log.Functionf("deleteAppInstaneOverlayRoute done for %s\n",
+		log.Functionf("deleteAppInstanceOverlayRoute done for %s\n",
 			status.DisplayName)
 	}
 }

--- a/pkg/pillar/types/types.go
+++ b/pkg/pillar/types/types.go
@@ -274,3 +274,62 @@ type UEvent struct {
 	Obj    string
 	Env    map[string]string
 }
+
+// UUIDPairToNum used for appNum on network instance
+type UUIDPairToNum struct {
+	BaseID      uuid.UUID
+	AppID       uuid.UUID
+	Number      int
+	NumType     string
+	CreateTime  time.Time
+	LastUseTime time.Time
+	InUse       bool
+}
+
+// Key is the key in pubsub
+func (info UUIDPairToNum) Key() string {
+	return UUIDPairToNumKey(info.BaseID, info.AppID)
+}
+
+// UUIDPairToNumKey is the index key
+func UUIDPairToNumKey(baseID, appID uuid.UUID) string {
+	return baseID.String() + "-" + appID.String()
+}
+
+// LogCreate :
+func (info UUIDPairToNum) LogCreate(logBase *base.LogObject) {
+	logObject := base.NewLogObject(logBase, base.UUIDPairToNumLogType, "",
+		info.BaseID, info.LogKey())
+	if logObject == nil {
+		return
+	}
+	logObject.Noticef("UUIDPairToNum info create")
+}
+
+// LogModify :
+func (info UUIDPairToNum) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.UUIDPairToNumLogType, "",
+		info.BaseID, info.LogKey())
+
+	oldInfo, ok := old.(UUIDPairToNum)
+	if !ok {
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of UUIDPairToNum type")
+	}
+	// XXX remove?
+	logObject.CloneAndAddField("diff", cmp.Diff(oldInfo, info)).
+		Noticef("UUIDPairToNum info modify")
+}
+
+// LogDelete :
+func (info UUIDPairToNum) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.UUIDPairToNumLogType, "",
+		info.BaseID, info.LogKey())
+	logObject.Noticef("UUIDPairToNum info delete")
+
+	base.DeleteLogObject(logBase, info.LogKey())
+}
+
+// LogKey :
+func (info UUIDPairToNum) LogKey() string {
+	return string(base.UUIDPairToNumLogType) + "-" + info.Key()
+}

--- a/pkg/pillar/uuidpairtonum/uuidpairtonum.go
+++ b/pkg/pillar/uuidpairtonum/uuidpairtonum.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2021 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package uuidpairtonum
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/satori/go.uuid"
+)
+
+// NumGet : return the number for a given UUID pair
+func NumGet(log *base.LogObject, pub pubsub.Publication,
+	baseID uuid.UUID, appID uuid.UUID, numType string) (int, error) {
+	key := types.UUIDPairToNumKey(baseID, appID)
+	log.Functionf("NumGet(%s, %s)", key, numType)
+	i, err := pub.Get(key)
+	if err != nil {
+		return -1, err
+	}
+	u := i.(types.UUIDPairToNum)
+	return u.Number, nil
+}
+
+// NumAllocate : stores the number for a given UUID pair
+func NumAllocate(log *base.LogObject, pub pubsub.Publication,
+	baseID uuid.UUID, appID uuid.UUID, appNum int, mustCreate bool,
+	numType string) {
+	log.Functionf("NumAllocate(%s, %s, %d, %v)", baseID.String(),
+		appID.String(), appNum, mustCreate)
+	now := time.Now()
+	key := types.UUIDPairToNumKey(baseID, appID)
+	i, err := pub.Get(key)
+	if err != nil {
+		u := types.UUIDPairToNum{
+			BaseID:      baseID,
+			AppID:       appID,
+			CreateTime:  now,
+			LastUseTime: now,
+			InUse:       true,
+			NumType:     numType,
+			Number:      appNum,
+		}
+		log.Functionf("NumAllocate(%s) publishing %v",
+			key, u)
+		pub.Publish(u.Key(), u)
+		return
+	}
+	u := i.(types.UUIDPairToNum)
+	if u.NumType != numType {
+		log.Fatalf("NumAllocate(%s) wrong numType %s vs. %s",
+			key, u.NumType, numType)
+	}
+	if mustCreate {
+		log.Fatalf("NumAllocate(%s) already exists %v",
+			key, u)
+	}
+	if u.Number != appNum {
+		log.Warnf("NumAllocate(%s) number changing from %d to %d",
+			key, u.Number, appNum)
+	}
+	if u.InUse {
+		log.Warnf("NumAllocate(%s) already InUse %v",
+			key, u)
+	}
+	u.Number = appNum
+	u.InUse = true
+	u.LastUseTime = time.Now()
+	// XXX note that nothing but lastusetime might be updated! Improve log?
+	log.Functionf("NumAllocate(%s) publishing updated %v",
+		key, u)
+	if err := pub.Publish(u.Key(), u); err != nil {
+		// Could be low on disk space
+		log.Errorf("NumAllocate(%s) publish failed %v",
+			key, err)
+	}
+	return
+}
+
+// NumFree : Clears InUse flag
+func NumFree(log *base.LogObject, pub pubsub.Publication,
+	baseID uuid.UUID, appID uuid.UUID) {
+	key := types.UUIDPairToNumKey(baseID, appID)
+	i, err := pub.Get(key)
+	if err != nil {
+		log.Fatalf("NumFree(%s) does not exist", key)
+	}
+	u := i.(types.UUIDPairToNum)
+	u.InUse = false
+	u.LastUseTime = time.Now()
+	log.Functionf("NumFree(%s) publishing updated %v",
+		key, u)
+	if err := pub.Publish(u.Key(), u); err != nil {
+		// Could be low on disk space
+		log.Errorf("NumFree(%s) publish failed %v",
+			key, err)
+	}
+}
+
+// NumDelete : Removes the integer map for a given UUID pair
+func NumDelete(log *base.LogObject, pub pubsub.Publication,
+	baseID uuid.UUID, appID uuid.UUID) {
+	key := types.UUIDPairToNumKey(baseID, appID)
+	_, err := pub.Get(key)
+	if err != nil {
+		log.Fatalf("NumDelete(%s) does not exist", key)
+	}
+	if err := pub.Unpublish(key); err != nil {
+		log.Fatalf("NumDelete(%s) unpublish failed %v", key, err)
+	}
+}
+
+// NumGetOldestUnused : returns a number, not recently in use
+func NumGetOldestUnused(log *base.LogObject, pub pubsub.Publication,
+	baseID uuid.UUID, numType string) (uuid.UUID, int, error) {
+	log.Functionf("NumGetOldestUnused(%s)", numType)
+	// Will have a LastUseTime of zero
+	oldest := new(types.UUIDPairToNum)
+	items := pub.GetAll()
+	for _, st := range items {
+		item := st.(types.UUIDPairToNum)
+		if item.NumType != numType || item.InUse || item.BaseID != baseID {
+			continue
+		}
+		if oldest.LastUseTime.Before(item.LastUseTime) {
+			log.Functionf("NumGetOldestUnused(%s) found older %v",
+				numType, item)
+			oldest = &item
+		}
+	}
+	if oldest.LastUseTime.IsZero() {
+		errStr := fmt.Sprintf("NumGetOldestUnused(%s) none found",
+			numType)
+		return uuid.UUID{}, 0, errors.New(errStr)
+	}
+	log.Functionf("NumGetOldestUnused(%s) found %v", numType, oldest)
+	return oldest.AppID, oldest.Number, nil
+}


### PR DESCRIPTION
Problem Statement:
   On device reboot, the IP addresses change for App Instances, it creates problem for kubernates kind of deployments. 
https://www.pivotaltracker.com/n/projects/2109992/stories/177688285

Solution:
 - Move from  "as available IP" Address allocation to a hash based IP Address assignment scheme.
 -  Global App Num is currently getting used for the the allocation, 
 -  Define a Underlay Network Instance based App Number for an App
 - The App Number for Underllay Network Instance for the App, is going to be 
    used to allocate the IP Address for the App.
 
Sticky IP:
 Moved Bitmap to types from appnumallocator.go
    - to be used for the bitmap used for network instance.
  Added the following to NetworkInstanceStatus
    - Bitmap, for maintaining IP Address assignments
    - HostIpAddressCount, for assignable IP address range
  Added, the following to UnderlayNetworkStatus (, under AppNetworkStatus)
     - AppNumOnUNet
  On Network Instance create, calculate the assignable Ip Address Count
  On AppNetworkCreate, for every underlay network,
       - get an App Num on the network (hashed App Num on the host address count), limited to 254
       - use this to calculate IP Address for the App, within the given address range