### PR TITLE
Update LinuxKit, and Go versions, to support building on Darwin/ARM64, and remove "dep"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
           ARCH=$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')
           echo "ARCH=$ARCH" >> "$GITHUB_ENV"
           for i in xen kvm; do
-             docker tag "lfedge/eve:$VERSION-$i" "$TAG-$i-$ARCH"
+             docker tag "lfedge/eve:$VERSION-$i-$ARCH" "$TAG-$i-$ARCH"
              IMGS="$IMGS $TAG-$i-$ARCH"
           done
           docker save $IMGS > eve.tar

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to EVE 
+# Contributing to EVE
 
 EVE community shares the spirit of the [Apache Way](https://apache.org/theapacheway/)
 and believes in "Community over Code". We welcome any and all types of contributions
@@ -209,7 +209,7 @@ By making a contribution to this project, I certify that:
 
 Then you just add a line to every git commit message:
 
-    Signed-off-by: Joe Smith <joe.smith@email.com>
+```Signed-off-by: Joe Smith <joe.smith@email.com>```
 
 Use your real name (sorry, no pseudonyms or anonymous contributions.)
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 # you are not supposed to tweak these variables -- they are effectively R/O
 HV_DEFAULT=kvm
-GOVER ?= 1.15.3
+GOVER ?= 1.16
 PKGBASE=github.com/lf-edge/eve
 GOMODULE=$(PKGBASE)/pkg/pillar
 GOTREE=$(CURDIR)/pkg/pillar
@@ -46,6 +46,7 @@ BUILD_VM_SRC_amd64=https://cloud-images.ubuntu.com/focal/current/focal-server-cl
 BUILD_VM_SRC=$(BUILD_VM_SRC_$(ZARCH))
 
 UNAME_S := $(shell uname -s)
+HOSTARCH:=$(subst aarch64,arm64,$(subst x86_64,amd64,$(shell uname -m)))
 
 USER         = $(shell id -u -n)
 GROUP        = $(shell id -g -n)
@@ -71,7 +72,6 @@ ROOTFS_VERSION:=$(if $(findstring snapshot,$(REPO_TAG)),$(EVE_SNAPSHOT_VERSION)-
 
 APIDIRS = $(shell find ./api/* -maxdepth 1 -type d -exec basename {} \;)
 
-HOSTARCH:=$(subst aarch64,arm64,$(subst x86_64,amd64,$(shell uname -m)))
 # by default, take the host architecture as the target architecture, but can override with `make ZARCH=foo`
 #    assuming that the toolchain supports it, of course...
 ZARCH ?= $(HOSTARCH)
@@ -83,8 +83,8 @@ CROSS = 1
 $(warning "WARNING: We are assembling an $(ZARCH) image on $(HOSTARCH). Things may break.")
 endif
 
+LINUXKIT_PLATFORM_TARGET=$(shell uname -s | tr '[A-Z]' '[a-z]')/$(ZARCH)
 DOCKER_ARCH_TAG=$(ZARCH)
-
 FULL_VERSION:=$(ROOTFS_VERSION)-$(HV)-$(ZARCH)
 
 # where we store outputs
@@ -157,6 +157,7 @@ QEMU_SYSTEM_amd64=qemu-system-x86_64
 QEMU_SYSTEM_riscv64=qemu-system-riscv64
 QEMU_SYSTEM=$(QEMU_SYSTEM_$(ZARCH))
 
+#QEMU_ACCEL_Y_Darwin_arm64=-machine virt,accel=hvf,usb=off -cpu host,kvmclock=off
 QEMU_ACCEL_Y_Darwin_amd64=-machine q35,accel=hvf,usb=off -cpu kvm64,kvmclock=off
 QEMU_ACCEL_Y_Linux_amd64=-machine q35,accel=kvm,usb=off,dump-guest-core=off -cpu host,invtsc=on,kvmclock=off -machine kernel-irqchip=split -device intel-iommu,intremap=on,caching-mode=on,aw-bits=48
 # -machine virt,gic_version=3
@@ -232,9 +233,9 @@ DOCKER_GO = _() { $(SET_X); mkdir -p $(CURDIR)/.go/src/$${3:-dummy} ; mkdir -p $
 
 PARSE_PKGS=$(if $(strip $(EVE_HASH)),EVE_HASH=)$(EVE_HASH) DOCKER_ARCH_TAG=$(DOCKER_ARCH_TAG) ./tools/parse-pkgs.sh
 LINUXKIT=$(BUILDTOOLS_BIN)/linuxkit
-LINUXKIT_VERSION=80c4edd5c54dc05fbeae932440372990fce39bd6
+LINUXKIT_VERSION=acc34e5ee343b4469b08b43ec817197d2f00bf6e
 LINUXKIT_SOURCE=https://github.com/linuxkit/linuxkit.git
-LINUXKIT_OPTS=--disable-content-trust $(if $(strip $(EVE_HASH)),--hash) $(EVE_HASH) $(if $(strip $(EVE_REL)),--release) $(EVE_REL) $(FORCE_BUILD)
+LINUXKIT_OPTS= $(if $(strip $(EVE_HASH)),--hash) $(EVE_HASH) $(if $(strip $(EVE_REL)),--release) $(EVE_REL) $(FORCE_BUILD)  --platforms $(LINUXKIT_PLATFORM_TARGET)
 LINUXKIT_PKG_TARGET=build
 RESCAN_DEPS=FORCE
 FORCE_BUILD=--force
@@ -286,7 +287,6 @@ $(CURRENT_DIR): $(BUILD_DIR)
 currentversion:
 	#echo $(shell readlink $(CURRENT) | sed -E 's/rootfs-(.*)\.[^.]*$/\1/')
 	@cat $(CURRENT_DIR)/installer/eve_version
-
 
 .PHONY: currentversion linuxkit
 
@@ -547,9 +547,11 @@ eve: $(INSTALLER) $(EVE_ARTIFACTS) current $(RUNME) $(BUILD_YML) | $(BUILD_DIR)
 	$(QUIET): "$@: Begin: EVE_REL=$(EVE_REL), HV=$(HV), LINUXKIT_PKG_TARGET=$(LINUXKIT_PKG_TARGET)"
 	cp images/*.yml $|
 	$(PARSE_PKGS) pkg/eve/Dockerfile.in > $|/Dockerfile
-	$(LINUXKIT) $(DASH_V) pkg $(LINUXKIT_PKG_TARGET) --disable-content-trust --hash-path $(CURDIR) --hash $(ROOTFS_VERSION)-$(HV) $(if $(strip $(EVE_REL)),--release) $(EVE_REL)$(if $(strip $(EVE_REL)),-$(HV)) $(FORCE_BUILD) $|
+	$(LINUXKIT) $(DASH_V) pkg $(LINUXKIT_PKG_TARGET) --platforms $(LINUXKIT_PLATFORM_TARGET) --hash-path $(CURDIR) --hash $(ROOTFS_VERSION)-$(HV) $(if $(strip $(EVE_REL)),--release) $(EVE_REL)$(if $(strip $(EVE_REL)),-$(HV)) $(FORCE_BUILD) $|
+	$(LINUXKIT) cache export --outfile - lfedge/eve:$(ROOTFS_VERSION)-$(HV)-$(ZARCH)| docker load
 	$(QUIET)if [ -n "$(EVE_REL)" ] && [ $(HV) = $(HV_DEFAULT) ]; then \
-	   $(LINUXKIT) $(DASH_V) pkg $(LINUXKIT_PKG_TARGET) --disable-content-trust --hash-path $(CURDIR) --hash $(EVE_REL)-$(HV) --release $(EVE_REL) $(FORCE_BUILD) $| ;\
+	   $(LINUXKIT) $(DASH_V) pkg $(LINUXKIT_PKG_TARGET) --platforms $(LINUXKIT_PLATFORM_TARGET) --hash-path $(CURDIR) --hash $(EVE_REL)-$(HV) --release $(EVE_REL) $(FORCE_BUILD) $| ;\
+	   $(LINUXKIT) cache export --outfile - lfedge/eve:$(EVE_REL)-$(HV)-$(ZARCH)| docker load ;\
 	fi
 	$(QUIET): $@: Succeeded
 
@@ -675,10 +677,6 @@ $(ROOTFS_FULL_NAME)-%-$(ZARCH).$(ROOTFS_FORMAT): $(ROOTFS_IMG)
 
 %-show-tag:
 	@$(LINUXKIT) pkg show-tag pkg/$*
-
-%Gopkg.lock: %Gopkg.toml | $(GOBUILDER)
-	@$(DOCKER_GO) "dep ensure -update $(GODEP_NAME)" $(dir $@)
-	@echo Done updating $@
 
 docker-old-images:
 	./tools/oldimages.sh

--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ To get its job done, EVE leverages a lot of great open source projects: [Xen Pro
 
 ## How to use
 
-You will need [QEMU 3.x+](https://www.qemu.org/), [Docker](https://www.docker.com), [Make](https://www.gnu.org/software/make/)
-and [go 1.13+](https://golang.org) installed in your system.
+You will need [QEMU 3.x+](https://www.qemu.org/), [Docker](https://www.docker.com) 20.10+, [Make](https://www.gnu.org/software/make/), and [go 1.16+](https://golang.org) installed in your system.
 
 ### Use pre-built release binaries
 
@@ -61,6 +60,10 @@ docker version
 ```sh
 $ brew install git make jq qemu
 ```
+
+#### On Apple Silicon (ARM64)
+
+QEMU 6.0.0, or later is required, to run EVE on Apple Silicon-based systems. This can be installed, using Brew, or compiled from a release source archive, from the [QEMU](https://www.qemu.org) Website.
 
 ##### On Ubuntu Linux
 
@@ -379,7 +382,7 @@ diskutil eject /dev/sdXXX
 
 Alternatively the image can be written with tools like [Balena's Etcher](https://www.balena.io/etcher/)
 
-## A quick note on linuxkit
+## A quick note on LinuxKit
 
 You may be wondering why do we have a container-based architecture for a Xen-centric environment. First of all, OCI containers are a key type of a workload for our platform. Which means having OCI environment to run them is a key requirement. We run them via:
 

--- a/build-tools/src/scripts/Dockerfile
+++ b/build-tools/src/scripts/Dockerfile
@@ -1,4 +1,4 @@
-ARG GOVER=1.15.3
+ARG GOVER=1.16
 FROM golang:${GOVER}-alpine
 ARG USER
 ARG GROUP
@@ -13,7 +13,6 @@ RUN deluser ${USER} ; delgroup ${GROUP} || :
 RUN sed -ie /:${UID}:/d /etc/passwd /etc/shadow ; sed -ie /:${GID}:/d /etc/group || :
 RUN addgroup -g ${GID} ${GROUP} && adduser -h /home/${USER} -G ${GROUP} -D -H -u ${UID} ${USER}
 RUN echo "${USER} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/${USER}
-RUN go get github.com/golang/dep/cmd/dep
 RUN go get -u github.com/golang/protobuf/protoc-gen-go
 RUN go get -u gotest.tools/gotestsum
 RUN go get -u github.com/seamia/protodot


### PR DESCRIPTION
These patches should allow for generating the build-tools, and live images, on an M1 Mac, running MacOS 11.2.3 (20D91), using Go 1.16beta1, and the latest LinuxKit. It is intended that any vestigial traces of "dep" usage be further removed, in subsequent patches.