### PR TITLE
handle broken TPM better 

### DIFF
--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -162,7 +162,7 @@ fi
 if [ -f $PERSISTDIR/reboot-reason ]; then
     echo "Reboot reason: $(cat $PERSISTDIR/reboot-reason)" > /dev/console
 elif [ -f $FIRSTBOOTFILE ]; then
-    exho "Reboot reason: NORMAL: First boot of device - at $(date -Ins -u)" > /dev/console
+    echo "Reboot reason: NORMAL: First boot of device - at $(date -Ins -u)" > /dev/console
 else
     echo "Reboot reason: UNKNOWN: reboot reason - power failure or crash - at $(date -Ins -u)" > /dev/console
 fi
@@ -413,8 +413,9 @@ if [ ! -f $CONFIGDIR/device.cert.pem ]; then
     if [ -c $TPM_DEVICE_PATH ] && ! [ -f $CONFIGDIR/disable-tpm ]; then
         echo "$(date -Ins -u) TPM device is present and allowed, creating TPM based device key"
         if ! $BINDIR/generate-device.sh -b $CONFIGDIR/device -t; then
-            echo "$(date -Ins -u) TPM is malfunctioning, falling back to software certs"
+            echo "$(date -Ins -u) TPM is malfunctioning, falling back to software certs; disabling tpm"
             $BINDIR/generate-device.sh -b $CONFIGDIR/device
+            touch $CONFIGDIR/disable-tpm
         fi
     else
         $BINDIR/generate-device.sh -b $CONFIGDIR/device


### PR DESCRIPTION
If the TPM doesn't work and we as a result generate a device cert/key using software, then continue to avoid using the TPM.

Better handles creating devices where the TPM exists but is useless.