### PR TITLE
zedagent metricsmap for debugging purpose

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -714,6 +714,11 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 	log.Tracef("PublishMetricsToZedCloud sending %s", ReportMetrics)
 	SendMetricsProtobuf(ReportMetrics, iteration)
 	log.Tracef("publishMetrics: after send, total elapse sec %v", time.Since(startPubTime).Seconds())
+
+	// publish the cloud MetricsMap for zedagent for device debugging purpose
+	if zedagentMetrics != nil {
+		ctx.pubMetricsMap.Publish("global", zedagentMetrics)
+	}
 }
 
 func getDiskInfo(ctx *zedagentContext, vrs types.VolumeRefStatus, appDiskDetails *metrics.AppDiskMetric) error {

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -98,6 +98,7 @@ type zedagentContext struct {
 	subNetworkInstanceMetrics pubsub.Subscription
 	subAppFlowMonitor         pubsub.Subscription
 	pubGlobalConfig           pubsub.Publication
+	pubMetricsMap             pubsub.Publication
 	subGlobalConfig           pubsub.Subscription
 	subEdgeNodeCert           pubsub.Subscription
 	subVaultStatus            pubsub.Subscription
@@ -239,6 +240,17 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	}
 
 	zedagentCtx.physicalIoAdapterMap = make(map[string]types.PhysicalIOAdapter)
+
+	// Publish zedagent cloud metrics
+	cloudMetricsPub, err := ps.NewPublication(
+		pubsub.PublicationOptions{
+			AgentName: agentName,
+			TopicType: types.MetricsMap{},
+		})
+	if err != nil {
+		log.Fatal(err)
+	}
+	zedagentCtx.pubMetricsMap = cloudMetricsPub
 
 	zedagentCtx.pubGlobalConfig, err = ps.NewPublication(pubsub.PublicationOptions{
 		AgentName:  agentName,


### PR DESCRIPTION
Signed-off-by: Naiming Shen <naiming@zededa.com>
although nobody will subscribe to this, it seems useful for the device debugging purpose to know those detailed url upload stats from zedagent.