### PR TITLE
Qemu overhead progressive allocation

### DIFF
--- a/pkg/pillar/hypervisor/containerd.go
+++ b/pkg/pillar/hypervisor/containerd.go
@@ -244,7 +244,7 @@ func (ctx ctrdContext) GetDomsCPUMem() (map[string]types.DomainMetric, error) {
 	}
 
 	for _, id := range ids {
-		var usedMem, availMem, totalMem uint32
+		var usedMem, maxUsedMem, availMem, totalMem uint32
 		var usedMemPerc float64
 		var cpuTotal uint64
 
@@ -253,6 +253,7 @@ func (ctx ctrdContext) GetDomsCPUMem() (map[string]types.DomainMetric, error) {
 				logrus.Errorf("GetDomsCPUMem nil returned in metric.Memory: %v", metric)
 			} else {
 				usedMem = uint32(roundFromBytesToMbytes(metric.Memory.Usage.Usage))
+				maxUsedMem = uint32(roundFromBytesToMbytes(metric.Memory.Usage.Max))
 				totalMem = uint32(roundFromBytesToMbytes(metric.Memory.HierarchicalMemoryLimit))
 				availMem = 0
 				if totalMem > usedMem {
@@ -277,6 +278,7 @@ func (ctx ctrdContext) GetDomsCPUMem() (map[string]types.DomainMetric, error) {
 			UUIDandVersion:    types.UUIDandVersion{},
 			CPUTotal:          cpuTotal,
 			UsedMemory:        usedMem,
+			MaxUsedMemory:     maxUsedMem,
 			AvailableMemory:   availMem,
 			UsedMemoryPercent: usedMemPerc,
 		}

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -21,7 +21,7 @@ import (
 
 //TBD: Have a better way to calculate this number.
 //For now it is based on some trial-and-error experiments
-const qemuOverHead = int64(600 * 1024 * 1024)
+const minQemuOverHead = int64(600 * 1024 * 1024)
 
 const minUringKernelTag = uint64((5 << 16) | (4 << 8) | (72 << 0))
 
@@ -476,6 +476,13 @@ func (ctx kvmContext) Setup(status types.DomainStatus, config types.DomainConfig
 		return logError("failed to add kvm hypervisor loader to domain %s: %v", status.DomainName, err)
 	}
 
+	/* 2.5 % of total memory */
+	qemuOverHead := int64(config.Memory) * 1024 * 25 / 1000
+	if qemuOverHead < minQemuOverHead {
+		qemuOverHead = minQemuOverHead
+	}
+
+	logrus.Debugf("Qemu overhead for domain %s is %d bytes", status.DomainName, qemuOverHead)
 	spec.AdjustMemLimit(config, qemuOverHead)
 	spec.Get().Process.Args = args
 	logrus.Infof("Hypervisor args: %v", args)

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -393,6 +393,7 @@ type DomainMetric struct {
 	UUIDandVersion    UUIDandVersion
 	CPUTotal          uint64 // Seconds since Domain boot
 	UsedMemory        uint32
+	MaxUsedMemory     uint32
 	AvailableMemory   uint32
 	UsedMemoryPercent float64
 	LastHeard         time.Time


### PR DESCRIPTION
    pillar: allocate qemu-overhead scaled to domain's memory

    Currently we have a hard-coded amount of 600MiB, for any new VM no
    matter what. That is not very flexible approach, since it could be a
    really tiny VM, with less memory then mentioned overhead.

    The proposed mechanism is not perfect. It is just a little bit better
    workaround for the problem, which allows us to be a bit more
    flexible.