### PR TITLE
set background udhcpc

### DIFF
--- a/pkg/xen-tools/initrd/init-initrd
+++ b/pkg/xen-tools/initrd/init-initrd
@@ -90,7 +90,7 @@ then
     echo "::1 localhost" >> /mnt/rootfs/etc/hosts
     for i in $(cd /sys/class/net && echo eth*); do
         ip link set dev "$i" up
-        udhcpc --interface="$i" --script=/udhcpc_script.sh -O staticroutes
+        udhcpc --interface="$i" --script=/udhcpc_script.sh -O staticroutes -b
     done
 fi
 


### PR DESCRIPTION
In case of air-gapped switch on the second interface we will wait infinite for udhcpc. So, it is reasonable to use `-b, --background  Fork to background if lease cannot be immediately negotiated`.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>