### PR TITLE
Fix ACLs with long domain names

### DIFF
--- a/pkg/pillar/cmd/zedrouter/acl_test.go
+++ b/pkg/pillar/cmd/zedrouter/acl_test.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2020 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package zedrouter
+
+import (
+	"testing"
+)
+
+// Test hostIpsetBasename function.
+func TestHostIpsetBasename(t *testing.T) {
+	tests := []struct {
+		testname         string
+		hostname         string
+		expIpsetBasename string
+	}{
+		{
+			testname:         "short hostname",
+			hostname:         "google.com",
+			expIpsetBasename: "google.com",
+		},
+		{
+			testname:         "short hostname ending with '.'",
+			hostname:         "google.com.",
+			expIpsetBasename: "google.com.",
+		},
+		{
+			testname:         "short TLD",
+			hostname:         "com",
+			expIpsetBasename: "com",
+		},
+		{
+			testname:         "short TLD ending with '.'",
+			hostname:         "com.",
+			expIpsetBasename: "com.",
+		},
+		{
+			testname:         "hostname just at the length limit",
+			hostname:         "this.host.fits.the.limit.x",
+			expIpsetBasename: "this.host.fits.the.limit.x",
+		},
+		{
+			testname:         "very long hostname",
+			hostname:         "theofficialabsolutelongestdomainnameregisteredontheworldwideweb.international",
+			expIpsetBasename: "unFy00boc2ME#international",
+		},
+		{
+			testname:         "very long hostname ending with '.'",
+			hostname:         "theofficialabsolutelongestdomainnameregisteredontheworldwideweb.international.",
+			expIpsetBasename: "josqV3v361A#international.",
+		},
+		{
+			testname:         "very long TLD",
+			hostname:         "shop.verylongcompanynamewhichmakesnosense",
+			expIpsetBasename: "jbfc_EF2sup6los19u4HLC4BN#",
+		},
+		{
+			testname:         "very long TLD ending with '.'",
+			hostname:         "shop.verylongcompanynamewhichmakesnosense.",
+			expIpsetBasename: "3dNidrrnlGggYozJoicbPPi_y#",
+		},
+		{
+			testname:         "hostname one character above the length limit",
+			hostname:         "this.host.is.over.the.limit",
+			expIpsetBasename: "rQRoWR0T#is.over.the.limit",
+		},
+		{
+			testname:         "empty hostname",
+			hostname:         "",
+			expIpsetBasename: "",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.testname, func(t *testing.T) {
+			if len(test.expIpsetBasename)+len("ipvX.") > ipsetNameLenLimit {
+				t.Errorf("expected ipset basename '%s' is unexpectedly long"+
+					" - mistake in the test?", test.expIpsetBasename)
+			}
+			ipsetBasename := hostIpsetBasename(test.hostname)
+			if ipsetBasename != test.expIpsetBasename {
+				t.Errorf("failed for: hostname=%s\n"+
+					"expected ipset basename:\n\t%q\ngot ipset basename:\n\t%q",
+					test.hostname, test.expIpsetBasename, ipsetBasename)
+			}
+		})
+	}
+}

--- a/pkg/pillar/cmd/zedrouter/dnsmasq.go
+++ b/pkg/pillar/cmd/zedrouter/dnsmasq.go
@@ -107,11 +107,11 @@ func createDnsmasqConfiglet(
 	ctx *zedrouterContext,
 	bridgeName string, bridgeIPAddr string,
 	netconf *types.NetworkInstanceConfig, hostsDir string,
-	ipsets []string, uplink string,
+	ipsetHosts []string, uplink string,
 	dnsServers []net.IP, ntpServers []net.IP) {
 
-	log.Functionf("createDnsmasqConfiglet(%s, %s) netconf %v, ipsets %v uplink %s dnsServers %v ntpServers %v",
-		bridgeName, bridgeIPAddr, netconf, ipsets, uplink, dnsServers, ntpServers)
+	log.Functionf("createDnsmasqConfiglet(%s, %s) netconf %v, ipsetHosts %v uplink %s dnsServers %v ntpServers %v",
+		bridgeName, bridgeIPAddr, netconf, ipsetHosts, uplink, dnsServers, ntpServers)
 
 	cfgPathname := dnsmasqConfigPath(bridgeName)
 	// Delete if it exists
@@ -161,9 +161,10 @@ func createDnsmasqConfiglet(
 		file.WriteString("no-resolv\n")
 	}
 
-	for _, ipset := range ipsets {
+	for _, host := range ipsetHosts {
+		ipsetBasename := hostIpsetBasename(host)
 		file.WriteString(fmt.Sprintf("ipset=/%s/ipv4.%s,ipv6.%s\n",
-			ipset, ipset, ipset))
+			host, ipsetBasename, ipsetBasename))
 	}
 	file.WriteString(fmt.Sprintf("pid-file=/run/dnsmasq.%s.pid\n",
 		bridgeName))

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -1476,19 +1476,20 @@ func doAppNetworkModifyUnderlayNetwork(
 	maybeRemoveStaleIpsets(staleIpsets)
 }
 
-func maybeRemoveStaleIpsets(staleIpsets []string) {
-	// Remove stale ipsets
+func maybeRemoveStaleIpsets(staleIpsetHosts []string) {
+	// Remove stale ipsets previously created for ACLs with the "host" match.
 	// In case if there are any references to these ipsets from other
 	// domUs, then the kernel would not remove them.
 	// The ipset destroy command would just fail.
-	for _, ipset := range staleIpsets {
-		err := ipsetDestroy(fmt.Sprintf("ipv4.%s", ipset))
+	for _, host := range staleIpsetHosts {
+		ipsetBasename := hostIpsetBasename(host)
+		err := ipsetDestroy(fmt.Sprintf("ipv4.%s", ipsetBasename))
 		if err != nil {
-			log.Errorln("ipset destroy ipv4", ipset, err)
+			log.Errorln("ipset destroy ipv4", ipsetBasename, err)
 		}
-		err = ipsetDestroy(fmt.Sprintf("ipv6.%s", ipset))
+		err = ipsetDestroy(fmt.Sprintf("ipv6.%s", ipsetBasename))
 		if err != nil {
-			log.Errorln("ipset destroy ipv6", ipset, err)
+			log.Errorln("ipset destroy ipv6", ipsetBasename, err)
 		}
 	}
 }


### PR DESCRIPTION
This PR addresses the issue of `zedrouter` failing to configure ACLs with `host` matches referencing long domain names.
`Zedrouter` currently uses domain name unchanged for ipsets and iptable rules. Netfilter, however limits the ipset name to at most 31 characters.

This PR builds a shorter ipset name for domain that would otherwise exceed the limit. It does so by preserving as much of the domain name suffix as possible (suffix of a domain name is more significant than prefix), to keep the ipset name readable and ideally also traceable to the ACL of origin (for debugging purposes), while replacing subdomains with a hash value long enough to guarantee uniqueness with a high enough probability, but shorter than the original prefix to fit the length limit. Character `#` is placed in between the hash and the preserved suffix.

Example:
For `very-very-long-subdomain.domain.com`, zedrouter will generate ipset name `<hash>#domain.com`.

The ipset name is generated deterministically to ensure that apps with the same ACL on the same network will use the same ipset.
Correctness of this implementation is verified by the eden's `acl` test extended by [this PR](https://github.com/lf-edge/eden/pull/615).

Signed-off-by: Milan Lenco <milan@zededa.com>