### PR TITLE
Remove spurious error when vault key updated

### DIFF
--- a/pkg/pillar/cmd/vaultmgr/vaultmgr.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgr.go
@@ -518,8 +518,13 @@ func publishFscryptVaultStatus(ctx *vaultMgrContext,
 				status.SetErrorNow(stdOut + stdErr)
 			}
 		} else {
-			statusMsg := etpm.CompareLegacyandSealedKey().String()
-			status.SetErrorNow(statusMsg)
+			sealedKeyType := etpm.CompareLegacyandSealedKey()
+			switch sealedKeyType {
+			case etpm.SealedKeyTypeReused, etpm.SealedKeyTypeNew:
+				status.ClearError()
+			default:
+				status.SetErrorNow(sealedKeyType.String())
+			}
 			if strings.Contains(stdOut, "Unlocked: Yes") {
 				status.Status = info.DataSecAtRestStatus_DATASEC_AT_REST_ENABLED
 			} else {


### PR DESCRIPTION
We sometimes see an error "Key is new and protected using PCRs" reported when the remote attestation is approved by the controller not at boot but after the device has been running for a while.
However, that isn't an error; it is an informational message.