### PR TITLE
Making PCI passthrough devices appear on dedicated PCI buses and fixing overzealous PCISameController

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -2270,7 +2270,7 @@ func handlePhysicalIOAdapterListImpl(ctxArg interface{}, key string,
 			len(aa.IoBundleList))
 
 		// check for mismatched PCI-ids and assignment groups and mark as errors
-		aa.CheckBadAssignmentGroups(log)
+		aa.CheckBadAssignmentGroups(log, hyper.PCISameController)
 		for i := range aa.IoBundleList {
 			ib := &aa.IoBundleList[i]
 			log.Functionf("handlePhysicalIOAdapterListImpl: new Adapter: %+v",
@@ -2315,7 +2315,7 @@ func handlePhysicalIOAdapterListImpl(ctxArg interface{}, key string,
 			aa.AddOrUpdateIoBundle(log, *ib)
 
 			// check for mismatched PCI-ids and assignment groups and mark as errors
-			aa.CheckBadAssignmentGroups(log)
+			aa.CheckBadAssignmentGroups(log, hyper.PCISameController)
 			// Lookup since it could have changed
 			ib = aa.LookupIoBundlePhylabel(ib.Phylabel)
 			updatePortAndPciBackIoBundle(ctx, ib, false)
@@ -2380,7 +2380,7 @@ func updatePortAndPciBackIoBundle(ctx *domainContext, ib *types.IoBundle,
 	// expand list to include other PCI functions on the same PCI controller
 	// since they need to be treated as part of the same bundle even if the
 	// EVE controller doesn't know it
-	list = aa.ExpandControllers(log, list)
+	list = aa.ExpandControllers(log, list, hyper.PCISameController)
 	for _, ib := range list {
 		if types.IsPort(ctx.deviceNetworkStatus, ib.Ifname) {
 			isPort = true

--- a/pkg/pillar/hypervisor/containerd.go
+++ b/pkg/pillar/hypervisor/containerd.go
@@ -222,6 +222,10 @@ func (ctx ctrdContext) PCIRelease(long string) error {
 	}
 }
 
+func (ctx ctrdContext) PCISameController(id1 string, id2 string) bool {
+	return types.PCISameController(id1, id2)
+}
+
 func (ctx ctrdContext) GetHostCPUMem() (types.HostMemory, error) {
 	return selfDomCPUMem()
 }

--- a/pkg/pillar/hypervisor/hypervisor.go
+++ b/pkg/pillar/hypervisor/hypervisor.go
@@ -19,6 +19,7 @@ type Hypervisor interface {
 
 	PCIReserve(string) error
 	PCIRelease(string) error
+	PCISameController(string, string) bool
 
 	GetHostCPUMem() (types.HostMemory, error)
 	GetDomsCPUMem() (map[string]types.DomainMetric, error)

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -604,7 +604,7 @@ func (ctx kvmContext) CreateDomConfig(domainName string, config types.DomainConf
 				return logError("can't write PCI Passthrough to config file %s (%v)", file.Name(), err)
 			}
 			pciPTContext.Xvga = false
-			pciPTContext.PCIId = pciPTContext.PCIId + 1;
+			pciPTContext.PCIId = pciPTContext.PCIId + 1
 		}
 	}
 	if len(serialAssignments) != 0 {
@@ -842,6 +842,20 @@ func (ctx kvmContext) PCIRelease(long string) error {
 	}
 
 	return nil
+}
+
+func (ctx kvmContext) PCISameController(id1 string, id2 string) bool {
+	tag1, err := types.PCIGetIOMMU(id1)
+	if err != nil {
+		return types.PCISameController(id1, id2)
+	}
+
+	tag2, err := types.PCIGetIOMMU(id2)
+	if err != nil {
+		return types.PCISameController(id1, id2)
+	}
+
+	return tag1 == tag2
 }
 
 func usbBusPort(USBAddr string) (string, string) {

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -845,12 +845,12 @@ func (ctx kvmContext) PCIRelease(long string) error {
 }
 
 func (ctx kvmContext) PCISameController(id1 string, id2 string) bool {
-	tag1, err := types.PCIGetIOMMU(id1)
+	tag1, err := types.PCIGetIOMMUGroup(id1)
 	if err != nil {
 		return types.PCISameController(id1, id2)
 	}
 
-	tag2, err := types.PCIGetIOMMU(id2)
+	tag2, err := types.PCIGetIOMMUGroup(id2)
 	if err != nil {
 		return types.PCISameController(id1, id2)
 	}

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -236,14 +236,14 @@ const qemuDiskTemplate = `
   driver = "virtio-9p-pci"
   fsdev = "fsdev{{.DiskID}}"
   mount_tag = "share_dir"
-  addr = "{{.PCIId}}"
+  addr = "{{printf "0x%x" .PCIId}}"
 {{else}}
 [device "pci.{{.PCIId}}"]
   driver = "pcie-root-port"
   port = "1{{.PCIId}}"
   chassis = "{{.PCIId}}"
   bus = "pcie.0"
-  addr = "{{.PCIId}}"
+  addr = "{{printf "0x%x" .PCIId}}"
 
 [drive "drive-virtio-disk{{.DiskID}}"]
   file = "{{.FileLocation}}"
@@ -277,7 +277,7 @@ const qemuNetTemplate = `
   chassis = "{{.PCIId}}"
   bus = "pcie.0"
   multifunction = "on"
-  addr = "{{.PCIId}}"
+  addr = "{{printf "0x%x" .PCIId}}"
 
 [netdev "hostnet{{.NetID}}"]
   type = "tap"
@@ -295,9 +295,19 @@ const qemuNetTemplate = `
 `
 
 const qemuPciPassthruTemplate = `
+[device "pci.{{.PCIId}}"]
+  driver = "pcie-root-port"
+  port = "1{{.PCIId}}"
+  chassis = "{{.PCIId}}"
+  bus = "pcie.0"
+  multifunction = "on"
+  addr = "{{printf "0x%x" .PCIId}}"
+
 [device]
   driver = "vfio-pci"
   host = "{{.PciShortAddr}}"
+  bus = "pci.{{.PCIId}}"
+  addr = "0x0"
 {{- if .Xvga }}
   x-vga = "on"
 {{- end -}}
@@ -576,9 +586,10 @@ func (ctx kvmContext) CreateDomConfig(domainName string, config types.DomainConf
 	}
 	if len(pciAssignments) != 0 {
 		pciPTContext := struct {
+			PCIId        int
 			PciShortAddr string
 			Xvga         bool
-		}{PciShortAddr: "", Xvga: false}
+		}{PCIId: netContext.PCIId, PciShortAddr: "", Xvga: false}
 
 		t, _ = template.New("qemuPciPT").Parse(qemuPciPassthruTemplate)
 		for _, pa := range pciAssignments {
@@ -593,6 +604,7 @@ func (ctx kvmContext) CreateDomConfig(domainName string, config types.DomainConf
 				return logError("can't write PCI Passthrough to config file %s (%v)", file.Name(), err)
 			}
 			pciPTContext.Xvga = false
+			pciPTContext.PCIId = pciPTContext.PCIId + 1;
 		}
 	}
 	if len(serialAssignments) != 0 {

--- a/pkg/pillar/hypervisor/kvm_test.go
+++ b/pkg/pillar/hypervisor/kvm_test.go
@@ -231,7 +231,7 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
   port = "14"
   chassis = "4"
   bus = "pcie.0"
-  addr = "4"
+  addr = "0x4"
 
 [drive "drive-virtio-disk0"]
   file = "/foo/bar.qcow2"
@@ -257,7 +257,7 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
   driver = "virtio-9p-pci"
   fsdev = "fsdev1"
   mount_tag = "share_dir"
-  addr = "5"
+  addr = "0x5"
 
 
 [device "pci.6"]
@@ -265,7 +265,7 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
   port = "16"
   chassis = "6"
   bus = "pcie.0"
-  addr = "6"
+  addr = "0x6"
 
 [drive "drive-virtio-disk2"]
   file = "/foo/bar.raw"
@@ -300,7 +300,7 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
   chassis = "7"
   bus = "pcie.0"
   multifunction = "on"
-  addr = "7"
+  addr = "0x7"
 
 [netdev "hostnet0"]
   type = "tap"
@@ -322,7 +322,7 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
   chassis = "8"
   bus = "pcie.0"
   multifunction = "on"
-  addr = "8"
+  addr = "0x8"
 
 [netdev "hostnet1"]
   type = "tap"
@@ -493,7 +493,7 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
   port = "14"
   chassis = "4"
   bus = "pcie.0"
-  addr = "4"
+  addr = "0x4"
 
 [drive "drive-virtio-disk0"]
   file = "/foo/bar.qcow2"
@@ -519,7 +519,7 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
   driver = "virtio-9p-pci"
   fsdev = "fsdev1"
   mount_tag = "share_dir"
-  addr = "5"
+  addr = "0x5"
 
 
 [device "pci.6"]
@@ -527,7 +527,7 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
   port = "16"
   chassis = "6"
   bus = "pcie.0"
-  addr = "6"
+  addr = "0x6"
 
 [drive "drive-virtio-disk2"]
   file = "/foo/bar.raw"
@@ -562,7 +562,7 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
   chassis = "7"
   bus = "pcie.0"
   multifunction = "on"
-  addr = "7"
+  addr = "0x7"
 
 [netdev "hostnet0"]
   type = "tap"
@@ -584,7 +584,7 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
   chassis = "8"
   bus = "pcie.0"
   multifunction = "on"
-  addr = "8"
+  addr = "0x8"
 
 [netdev "hostnet1"]
   type = "tap"
@@ -733,7 +733,7 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
   port = "14"
   chassis = "4"
   bus = "pcie.0"
-  addr = "4"
+  addr = "0x4"
 
 [drive "drive-virtio-disk0"]
   file = "/foo/bar.qcow2"
@@ -759,7 +759,7 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
   driver = "virtio-9p-pci"
   fsdev = "fsdev1"
   mount_tag = "share_dir"
-  addr = "5"
+  addr = "0x5"
 
 
 [device "pci.6"]
@@ -767,7 +767,7 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
   port = "16"
   chassis = "6"
   bus = "pcie.0"
-  addr = "6"
+  addr = "0x6"
 
 [drive "drive-virtio-disk2"]
   file = "/foo/bar.raw"
@@ -802,7 +802,7 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
   chassis = "7"
   bus = "pcie.0"
   multifunction = "on"
-  addr = "7"
+  addr = "0x7"
 
 [netdev "hostnet0"]
   type = "tap"
@@ -824,7 +824,7 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
   chassis = "8"
   bus = "pcie.0"
   multifunction = "on"
-  addr = "8"
+  addr = "0x8"
 
 [netdev "hostnet1"]
   type = "tap"
@@ -1067,7 +1067,7 @@ func TestCreateDomConfig(t *testing.T) {
   port = "14"
   chassis = "4"
   bus = "pcie.0"
-  addr = "4"
+  addr = "0x4"
 
 [drive "drive-virtio-disk0"]
   file = "/foo/bar.qcow2"
@@ -1093,7 +1093,7 @@ func TestCreateDomConfig(t *testing.T) {
   driver = "virtio-9p-pci"
   fsdev = "fsdev1"
   mount_tag = "share_dir"
-  addr = "5"
+  addr = "0x5"
 
 
 [device "pci.6"]
@@ -1101,7 +1101,7 @@ func TestCreateDomConfig(t *testing.T) {
   port = "16"
   chassis = "6"
   bus = "pcie.0"
-  addr = "6"
+  addr = "0x6"
 
 [drive "drive-virtio-disk2"]
   file = "/foo/bar.raw"
@@ -1136,7 +1136,7 @@ func TestCreateDomConfig(t *testing.T) {
   chassis = "7"
   bus = "pcie.0"
   multifunction = "on"
-  addr = "7"
+  addr = "0x7"
 
 [netdev "hostnet0"]
   type = "tap"
@@ -1158,7 +1158,7 @@ func TestCreateDomConfig(t *testing.T) {
   chassis = "8"
   bus = "pcie.0"
   multifunction = "on"
-  addr = "8"
+  addr = "0x8"
 
 [netdev "hostnet1"]
   type = "tap"
@@ -1174,9 +1174,19 @@ func TestCreateDomConfig(t *testing.T) {
   bus = "pci.8"
   addr = "0x0"
 
+[device "pci.9"]
+  driver = "pcie-root-port"
+  port = "19"
+  chassis = "9"
+  bus = "pcie.0"
+  multifunction = "on"
+  addr = "0x9"
+
 [device]
   driver = "vfio-pci"
   host = "03:00.0"
+  bus = "pci.9"
+  addr = "0x0"
 [chardev "charserial-usr0"]
   backend = "tty"
   path = "/dev/ttyS0"
@@ -1336,7 +1346,7 @@ func TestCreateDomConfig(t *testing.T) {
   port = "14"
   chassis = "4"
   bus = "pcie.0"
-  addr = "4"
+  addr = "0x4"
 
 [drive "drive-virtio-disk0"]
   file = "/foo/bar.qcow2"
@@ -1364,7 +1374,7 @@ func TestCreateDomConfig(t *testing.T) {
   driver = "virtio-9p-pci"
   fsdev = "fsdev1"
   mount_tag = "share_dir"
-  addr = "5"
+  addr = "0x5"
 
 
 [device "pci.6"]
@@ -1372,7 +1382,7 @@ func TestCreateDomConfig(t *testing.T) {
   port = "16"
   chassis = "6"
   bus = "pcie.0"
-  addr = "6"
+  addr = "0x6"
 
 [drive "drive-virtio-disk2"]
   file = "/foo/bar.raw"
@@ -1409,7 +1419,7 @@ func TestCreateDomConfig(t *testing.T) {
   chassis = "7"
   bus = "pcie.0"
   multifunction = "on"
-  addr = "7"
+  addr = "0x7"
 
 [netdev "hostnet0"]
   type = "tap"
@@ -1431,7 +1441,7 @@ func TestCreateDomConfig(t *testing.T) {
   chassis = "8"
   bus = "pcie.0"
   multifunction = "on"
-  addr = "8"
+  addr = "0x8"
 
 [netdev "hostnet1"]
   type = "tap"
@@ -1447,9 +1457,19 @@ func TestCreateDomConfig(t *testing.T) {
   bus = "pci.8"
   addr = "0x0"
 
+[device "pci.9"]
+  driver = "pcie-root-port"
+  port = "19"
+  chassis = "9"
+  bus = "pcie.0"
+  multifunction = "on"
+  addr = "0x9"
+
 [device]
   driver = "vfio-pci"
   host = "03:00.0"
+  bus = "pci.9"
+  addr = "0x0"
 [chardev "charserial-usr0"]
   backend = "tty"
   path = "/dev/ttyS0"
@@ -1470,9 +1490,23 @@ func TestCreateDomConfig(t *testing.T) {
 	config.VirtualizationMode = types.FML
 	t.Run("amd64-fml", func(t *testing.T) {
 		conf.Seek(0, 0)
+		config.IoAdapterList = append(config.IoAdapterList, types.IoAdapter{
+			Type: types.IoNetEth,
+			Name: "eth1",
+		})
+		aa.IoBundleList = append(aa.IoBundleList, types.IoBundle{
+			Type:            types.IoNetEth,
+			AssignmentGroup: "eth1-1",
+			Phylabel:        "eth1",
+			Ifname:          "eth1",
+			PciLong:         "0000:04:00.0",
+			UsedByUUID:      config.UUIDandVersion.UUID,
+		})
 		if err := kvmIntel.CreateDomConfig("test", config, disks, &aa, conf); err != nil {
 			t.Errorf("CreateDomConfig failed %v", err)
 		}
+		aa.IoBundleList = aa.IoBundleList[:len(aa.IoBundleList)-1]
+		config.IoAdapterList = config.IoAdapterList[:len(config.IoAdapterList)-1]
 		defer os.Truncate(conf.Name(), 0)
 
 		result, err := ioutil.ReadFile(conf.Name())
@@ -1610,7 +1644,7 @@ func TestCreateDomConfig(t *testing.T) {
   port = "14"
   chassis = "4"
   bus = "pcie.0"
-  addr = "4"
+  addr = "0x4"
 
 [drive "drive-virtio-disk0"]
   file = "/foo/bar.qcow2"
@@ -1636,7 +1670,7 @@ func TestCreateDomConfig(t *testing.T) {
   driver = "virtio-9p-pci"
   fsdev = "fsdev1"
   mount_tag = "share_dir"
-  addr = "5"
+  addr = "0x5"
 
 
 [device "pci.6"]
@@ -1644,7 +1678,7 @@ func TestCreateDomConfig(t *testing.T) {
   port = "16"
   chassis = "6"
   bus = "pcie.0"
-  addr = "6"
+  addr = "0x6"
 
 [drive "drive-virtio-disk2"]
   file = "/foo/bar.raw"
@@ -1679,7 +1713,7 @@ func TestCreateDomConfig(t *testing.T) {
   chassis = "7"
   bus = "pcie.0"
   multifunction = "on"
-  addr = "7"
+  addr = "0x7"
 
 [netdev "hostnet0"]
   type = "tap"
@@ -1701,7 +1735,7 @@ func TestCreateDomConfig(t *testing.T) {
   chassis = "8"
   bus = "pcie.0"
   multifunction = "on"
-  addr = "8"
+  addr = "0x8"
 
 [netdev "hostnet1"]
   type = "tap"
@@ -1717,9 +1751,32 @@ func TestCreateDomConfig(t *testing.T) {
   bus = "pci.8"
   addr = "0x0"
 
+[device "pci.9"]
+  driver = "pcie-root-port"
+  port = "19"
+  chassis = "9"
+  bus = "pcie.0"
+  multifunction = "on"
+  addr = "0x9"
+
 [device]
   driver = "vfio-pci"
   host = "03:00.0"
+  bus = "pci.9"
+  addr = "0x0"
+[device "pci.10"]
+  driver = "pcie-root-port"
+  port = "110"
+  chassis = "10"
+  bus = "pcie.0"
+  multifunction = "on"
+  addr = "0xa"
+
+[device]
+  driver = "vfio-pci"
+  host = "04:00.0"
+  bus = "pci.10"
+  addr = "0x0"
 [chardev "charserial-usr0"]
   backend = "tty"
   path = "/dev/ttyS0"
@@ -1858,7 +1915,7 @@ func TestCreateDomConfig(t *testing.T) {
   port = "14"
   chassis = "4"
   bus = "pcie.0"
-  addr = "4"
+  addr = "0x4"
 
 [drive "drive-virtio-disk0"]
   file = "/foo/bar.qcow2"
@@ -1884,7 +1941,7 @@ func TestCreateDomConfig(t *testing.T) {
   driver = "virtio-9p-pci"
   fsdev = "fsdev1"
   mount_tag = "share_dir"
-  addr = "5"
+  addr = "0x5"
 
 
 [device "pci.6"]
@@ -1892,7 +1949,7 @@ func TestCreateDomConfig(t *testing.T) {
   port = "16"
   chassis = "6"
   bus = "pcie.0"
-  addr = "6"
+  addr = "0x6"
 
 [drive "drive-virtio-disk2"]
   file = "/foo/bar.raw"
@@ -1927,7 +1984,7 @@ func TestCreateDomConfig(t *testing.T) {
   chassis = "7"
   bus = "pcie.0"
   multifunction = "on"
-  addr = "7"
+  addr = "0x7"
 
 [netdev "hostnet0"]
   type = "tap"
@@ -1949,7 +2006,7 @@ func TestCreateDomConfig(t *testing.T) {
   chassis = "8"
   bus = "pcie.0"
   multifunction = "on"
-  addr = "8"
+  addr = "0x8"
 
 [netdev "hostnet1"]
   type = "tap"
@@ -1965,9 +2022,19 @@ func TestCreateDomConfig(t *testing.T) {
   bus = "pci.8"
   addr = "0x0"
 
+[device "pci.9"]
+  driver = "pcie-root-port"
+  port = "19"
+  chassis = "9"
+  bus = "pcie.0"
+  multifunction = "on"
+  addr = "0x9"
+
 [device]
   driver = "vfio-pci"
   host = "03:00.0"
+  bus = "pci.9"
+  addr = "0x0"
 [chardev "charserial-usr0"]
   backend = "tty"
   path = "/dev/ttyS0"

--- a/pkg/pillar/hypervisor/null.go
+++ b/pkg/pillar/hypervisor/null.go
@@ -140,6 +140,10 @@ func (ctx nullContext) PCIRelease(long string) error {
 	}
 }
 
+func (ctx nullContext) PCISameController(id1 string, id2 string) bool {
+	return types.PCISameController(id1, id2)
+}
+
 func (ctx nullContext) GetHostCPUMem() (types.HostMemory, error) {
 	return selfDomCPUMem()
 }

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -588,6 +588,8 @@ func (ctx xenContext) PCIRelease(long string) error {
 
 func (ctx xenContext) PCISameController(id1 string, id2 string) bool {
 	// we maybe better off returning types.PCISameController(id1, id2) here
+	// but for now -- lets just warn:
+	logrus.Infof("can't validate that %s and %s can be assigned separately: trusting Xen to do the right thing", id1, id2)
 	return false
 }
 

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -587,8 +587,12 @@ func (ctx xenContext) PCIRelease(long string) error {
 }
 
 func (ctx xenContext) PCISameController(id1 string, id2 string) bool {
-	// we maybe better off returning types.PCISameController(id1, id2) here
-	// but for now -- lets just warn:
+	// We can not currently do enforcement based on iommu groups for Xen,
+	// since the hypervisor hides that from dom0. Thus we assume that initial
+	// bringup and model creation is done using KVM. That model can then be
+	// used with KVM and Xen. Note that it maybe possible to improve Xen
+	// disclosure of iommu groups (at least by interrogating it) but it would
+	// require patching Xen itself (which may be a useful TODO).
 	logrus.Infof("can't validate that %s and %s can be assigned separately: trusting Xen to do the right thing", id1, id2)
 	return false
 }

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -586,6 +586,11 @@ func (ctx xenContext) PCIRelease(long string) error {
 	return nil
 }
 
+func (ctx xenContext) PCISameController(id1 string, id2 string) bool {
+	// we maybe better off returning types.PCISameController(id1, id2) here
+	return false
+}
+
 func (ctx xenContext) GetHostCPUMem() (types.HostMemory, error) {
 	ctrdSystemCtx, done := ctx.ctrdClient.CtrNewSystemServicesCtx()
 	defer done()

--- a/pkg/pillar/types/assignableadapters_test.go
+++ b/pkg/pillar/types/assignableadapters_test.go
@@ -370,7 +370,7 @@ var aa2Errors = []string{
 
 func TestCheckBadAssignmentGroups(t *testing.T) {
 	log := base.NewSourceLogObject(logrus.StandardLogger(), "test", 1234)
-	changed := aa2.CheckBadAssignmentGroups(log)
+	changed := aa2.CheckBadAssignmentGroups(log, PCISameController)
 	assert.True(t, changed)
 	assert.Equal(t, len(aa2.IoBundleList), len(aa2Errors))
 	for i, ib := range aa2.IoBundleList {
@@ -437,7 +437,7 @@ func TestExpandControllers(t *testing.T) {
 		t.Logf("TESTCASE: %s - Running", testname)
 		preList := aa2.LookupIoBundleGroup(test.assignmentGroup)
 		preLen := len(preList)
-		postList := aa2.ExpandControllers(log, preList)
+		postList := aa2.ExpandControllers(log, preList, PCISameController)
 		postLen := len(postList)
 		assert.Equal(t, test.preLen, preLen)
 		assert.Equal(t, test.postLen, postLen)

--- a/pkg/pillar/types/ifnametopci.go
+++ b/pkg/pillar/types/ifnametopci.go
@@ -79,8 +79,8 @@ func PCISameController(long1 string, long2 string) bool {
 	return ctrl1 == ctrl2
 }
 
-// PCIGetIOMMU returns IOMMU group tag as seen by the control domain
-func PCIGetIOMMU(long string) (string, error) {
+// PCIGetIOMMUGroup returns IOMMU group tag as seen by the control domain
+func PCIGetIOMMUGroup(long string) (string, error) {
 	pathDev := pciPath + "/" + long + "/iommu_group"
 	if iommuPath, err := os.Readlink(pathDev); err != nil {
 		return "", fmt.Errorf("can't determine iommu group for %s (%v)", long, err)

--- a/pkg/pillar/types/ifnametopci.go
+++ b/pkg/pillar/types/ifnametopci.go
@@ -79,6 +79,16 @@ func PCISameController(long1 string, long2 string) bool {
 	return ctrl1 == ctrl2
 }
 
+// PCIGetIOMMU returns IOMMU group tag as seen by the control domain
+func PCIGetIOMMU(long string) (string, error) {
+	pathDev := pciPath + "/" + long + "/iommu_group"
+	if iommuPath, err := os.Readlink(pathDev); err != nil {
+		return "", fmt.Errorf("can't determine iommu group for %s (%v)", long, err)
+	} else {
+		return path.Base(iommuPath), nil
+	}
+}
+
 // Check if an ID like 0000:03:00.0 exists
 func pciLongExists(long string) bool {
 	path := pciPath + "/" + long


### PR DESCRIPTION
This PR contains two commits (best reviewed commit-by-commit). Both are pretty self-explanatory. The real fix for overzealous PCISameController currently only applies to KVM, since Xen may require additional plumbing on the xl side to get to iommu groups. For now we're trusting Xen to complain (and at least restoring EVE 5.x behaviour).