### PR TITLE
Starting a journey for EVE's support of riscv64

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [arm64-secure, ubuntu-20.04]
+        os: [arm64-secure, ubuntu-20.04, ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -24,6 +24,23 @@ jobs:
         env:
           REF: ${{ github.ref }}
         run: |
+          # we are using ubuntu-latest as our riscv64 cross build machine
+          if [ "${{ matrix.os }}" = ubuntu-latest ]; then
+             APT_INSTALL="sudo apt install -y binfmt-support qemu-user-static"
+             # the following weird statement is here to speed up the happy path
+             # if the default server is responding -- we can skip apt update
+             $APT_INSTALL || { sudo apt update && $APT_INSTALL ; }
+             # we need to build our own version of cross-enabled linuxkit, while upstream is sorting things out
+             make LINUXKIT_VERSION=master LINUXKIT_SOURCE=https://github.com/rvs/linuxkit.git linuxkit
+             # constraining environment for riscv64 builds
+             EVE_BUILDER_IMAGE=$(./build-tools/bin/linuxkit pkg show-tag pkg/alpine)-riscv64
+             echo "PKGS=pkg/alpine pkg/ipxe pkg/mkconf pkg/mkimage-iso-efi pkg/mkimage-raw-efi" >> "$GITHUB_ENV"
+             echo "ZARCH=riscv64" >> "$GITHUB_ENV"
+             echo 'LK_BUILD_ARGS={"EVE_BUILDER_IMAGE": "'$EVE_BUILDER_IMAGE'"}' >> "$GITHUB_ENV"
+             echo "EVE_ARTIFACTS=images/docker-compose.yml" >> "$GITHUB_ENV"
+             # the following is here only for one iteration of bootstrap
+             docker build --build-arg DEFAULT_USER=root -t $EVE_BUILDER_IMAGE -f build-tools/src/scripts/Dockerfile.alpine.bootstrap $(mktemp -d)
+          fi
           echo "ARCH=$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')" >> "$GITHUB_ENV"
           echo "TAG=$(echo "$REF" | sed -e 's#^.*/##' -e 's#master#snapshot#' -e 's#main#snapshot#')" >> "$GITHUB_ENV"
       - name: Login to DockerHUB
@@ -44,7 +61,7 @@ jobs:
           # sadly, our build sometimes times out on network access
           # and running out of disk space: re-trying for 3 times
           for i in 1 2 3; do
-             if make V=1 LINUXKIT_PKG_TARGET=push pkgs; then
+             if make -e V=1 LINUXKIT_PKG_TARGET=push pkgs; then
                 break
              else
                 # the most likely reason for 'make pkgs' to fail is
@@ -59,15 +76,15 @@ jobs:
         # build #1 without push (do not push either unless both can build)
         run: |
           rm -rf dist dist.xen
-          make V=1 HV=kvm eve
+          make -e V=1 HV=kvm eve
           mv -f dist dist.xen
       - name: Build and push EVE for Xen
         # since build #1 works, build and push #2
         run: |
-          make V=1 HV=xen LINUXKIT_PKG_TARGET=push eve
+          make -e V=1 HV=xen LINUXKIT_PKG_TARGET=push eve
       - name: Build and push EVE for KVM
         # redo build #1 with push
         run: |
           rm -rf dist
           mv -f dist.xen dist
-          make V=1 HV=kvm LINUXKIT_PKG_TARGET=push eve
+          make -e V=1 HV=kvm LINUXKIT_PKG_TARGET=push eve

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
              echo 'LK_BUILD_ARGS={"EVE_BUILDER_IMAGE": "'$EVE_BUILDER_IMAGE'"}' >> "$GITHUB_ENV"
              echo "EVE_ARTIFACTS=images/docker-compose.yml" >> "$GITHUB_ENV"
              # the following is here only for one iteration of bootstrap
-             docker build --build-arg DEFAULT_USER=root -t $EVE_BUILDER_IMAGE -f build-tools/src/scripts/Dockerfile.alpine.bootstrap $(mktemp -d)
+             docker build --build-arg DEFAULT_USER=root --build-arg DEFAULT_HOME=/ -t $EVE_BUILDER_IMAGE -f build-tools/src/scripts/Dockerfile.alpine.bootstrap $(mktemp -d)
           fi
           echo "ARCH=$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')" >> "$GITHUB_ENV"
           echo "TAG=$(echo "$REF" | sed -e 's#^.*/##' -e 's#master#snapshot#' -e 's#main#snapshot#')" >> "$GITHUB_ENV"

--- a/Makefile
+++ b/Makefile
@@ -267,7 +267,7 @@ version:
 
 # makes a link to current
 current: $(CURRENT_DIR)
-$(CURRENT_DIR): $(DIST)
+$(CURRENT_DIR): $(BUILD_DIR)
 	@rm -f $@ && ln -s $(BUILD_DIR) $@
 
 # reports the image version that current points to
@@ -446,6 +446,7 @@ $(INSTALLER):
 
 
 # convenience targets - so you can do `make config` instead of `make dist/config.img`, and `make installer` instead of `make dist/amd64/installer.img
+linuxkit: $(LINUXKIT)
 build-vm: $(BUILD_VM)
 initrd: $(INITRD_IMG)
 installer-img: $(INSTALLER_IMG)
@@ -531,7 +532,8 @@ pkg/%: eve-% FORCE
 $(RUNME) $(BUILD_YML):
 	cp pkg/eve/$(@F) $@
 
-eve: $(BIOS_IMG) $(EFI_PART) $(CONFIG_IMG) $(PERSIST_IMG) $(INITRD_IMG) $(INSTALLER_IMG) $(ROOTFS_IMG) fullname-rootfs $(BOOT_PART) $(RUNME) $(BUILD_YML) current | $(BUILD_DIR)
+EVE_ARTIFACTS=$(BIOS_IMG) $(EFI_PART) $(CONFIG_IMG) $(PERSIST_IMG) $(INITRD_IMG) $(INSTALLER_IMG) $(ROOTFS_IMG) fullname-rootfs $(BOOT_PART)
+eve: $(INSTALLER) $(EVE_ARTIFACTS) current $(RUNME) $(BUILD_YML) | $(BUILD_DIR)
 	$(QUIET): "$@: Begin: EVE_REL=$(EVE_REL), HV=$(HV), LINUXKIT_PKG_TARGET=$(LINUXKIT_PKG_TARGET)"
 	cp images/*.yml $|
 	$(PARSE_PKGS) pkg/eve/Dockerfile.in > $|/Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -279,7 +279,7 @@ currentversion:
 	@cat $(CURRENT_DIR)/installer/eve_version
 
 
-.PHONY: currentversion
+.PHONY: currentversion linuxkit
 
 test: $(GOBUILDER) | $(DIST)
 	@echo Running tests on $(GOMODULE)

--- a/build-tools/src/scripts/Dockerfile.alpine.bootstrap
+++ b/build-tools/src/scripts/Dockerfile.alpine.bootstrap
@@ -1,0 +1,50 @@
+# This is the skeleton of the APKBUILD file one can use to stub out stubborn packages:
+#
+# pkgname=libunwind-dev
+# pkgver=1.2.3
+# pkgrel=3
+# pkgdesc="Dummy package"
+# url="https://alpinelinux.org"
+# arch="all"
+# license="MIT"
+#
+# package() {
+#         mkdir -p "$pkgdir"
+# }
+
+FROM alpine as builder
+
+ENV ROOT_URL https://eve-alpine-packages.s3.amazonaws.com/edge
+
+WORKDIR /rootfs
+ADD ${ROOT_URL}/images/alpine-minirootfs-210509-riscv64.tar.gz /tmp/
+RUN tar xzf /tmp/*tar.gz
+ADD ${ROOT_URL}/keys/builder@projecteve.dev-608ede5d.rsa.pub etc/apk/keys/
+RUN printf "${ROOT_URL}/main\n${ROOT_URL}/community\n" > etc/apk/repositories
+
+FROM scratch
+
+# seed the root filesystem
+COPY --from=builder /rootfs/ /
+
+# construct the builder environment
+ENV APORTS /home/builder/aports
+RUN apk add abuild curl tar make linux-headers patch g++ git gcc ncurses-dev autoconf file
+RUN adduser -G abuild -D builder
+RUN su builder -c 'git config --global user.email "builder@projecteve.dev" && git config --global user.name "Project EVE"'
+RUN su builder -c 'abuild-keygen -a -n'
+RUN su builder -c 'mkdir /home/builder/packages'
+RUN cp /home/builder/.abuild/*.pub /etc/apk/keys
+
+# hook aports up to rvs for now
+RUN su builder -c 'git clone --depth 1 https://github.com/rvs/aports $APORTS'
+
+# eve-alpine hook
+RUN echo http://eve-alpine-packages.s3.amazonaws.com > /etc/apk/cache.url
+
+# set the defaults for docker run
+ARG DEFAULT_USER=builder
+ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+USER ${DEFAULT_USER}
+WORKDIR /home/builder
+CMD sh

--- a/build-tools/src/scripts/Dockerfile.alpine.bootstrap
+++ b/build-tools/src/scripts/Dockerfile.alpine.bootstrap
@@ -44,7 +44,8 @@ RUN echo http://eve-alpine-packages.s3.amazonaws.com > /etc/apk/cache.url
 
 # set the defaults for docker run
 ARG DEFAULT_USER=builder
+ARG DEFAULT_HOME=/home/builder
 ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 USER ${DEFAULT_USER}
-WORKDIR /home/builder
+WORKDIR ${DEFAULT_HOME}
 CMD sh

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -1,0 +1,40 @@
+# Bringing EVE up on a new CPU architecture
+
+EVE currently support x86 and ARM Edge Nodes. It works best when hardware assisted virtualization is available, but it can run with reduced functionality on pretty much anything supported by the Linux kernel. Most of the time, bringing EVE up on a new hardware configuration requires [peripheral hardware enablement](HARDWARE-BRINGUP.md) but in rare cases it may actually require supporting a brand new CPU model. The later consists of the following steps:
+
+1. Prerequisites
+2. Porting Alpine packages EVE depends on to the new CPU
+3. Hooking up new CPU emulation environment to Makefile and GitHub workflows
+4. Porting firmware, low-level bootloader and GRUB on the new CPU
+5. Porting Linux kernel to the new CPU
+6. Porting user-space EVE containers to the new CPU
+
+## 1. Prerequisites
+
+First of all, we are assuming that GCC and/or LLVM toolchain and Golang toolchain already provide support for the target CPU. We are also assuming that cross-compilation for both is an option (if either of these assumptions is broken -- you will have to engage in a heavy development effort bringing these toolchain up to speed with the target architecture). We are also assuming that qemu already supports the target CPU in either system or user mode.
+
+## 2. Porting Alpine packages EVE depends on to the new CPU
+
+If you're lucky, Alpine Linux may be already providing support for the new CPU architecture. If not, you need to start bootstrapping the Alpine environment yourself. This is typically done by first cross-compiling enough of Alpine environment using [aports bootstrap.sh script](https://github.com/alpinelinux/aports/blob/master/scripts/bootstrap.sh) on a commodity x86 architecture (the more CPUs you have the faster it will go) and then proceeding with building an emulation environment to compile the rest of the packages EVE depends upon. The later step is required because Alpine Linux (unlike more traditional embedded Linux distributions) doesn't actually focus on cross-compilation of most of the packages aside from the ones required from bootstrap.
+
+The full list of Alpine packages required by EVE is available under [pkg/alpine](../pkg/alpine) and while it is not long, it actually requires twice as many packages available during the build phase so your bootstrapping efforts may take some time. The most convenient way to move from a cross-compiling `bootstrap.sh` phase of Alpine bringup to bringing up the rest of the packages is to use [qemu user emulation mode](https://qemu.readthedocs.io/en/latest/user/index.html) under either Docker desktop or [proot](https://proot-me.github.io/). Both of these will require an image of a filesystem that is complete enough to run basic Unix commands. A good place to star assembling this image into a single tarball is the output packages from the `bootstrap.sh`. Note, however, that you may need to manually untar them and put everything in just the right order yourself. Taking a look at what files comprise a typical Alpine docker image `docker pull alpine:latest` will give you a hint at what's required. Here's a minimal list of packages that need to appear in that filesystem image: `abuild curl tar make linux-headers patch g++ git gcc ncurses-dev autoconf`.
+
+Once you assembled your new image and launched a shell inside of that filesystem, you can start using standard Alpine's [abuild](https://wiki.alpinelinux.org/wiki/Abuild_and_Helpers) tools with the source code from [aports](https://github.com/alpinelinux/aports) to build the remainder of the required packages. The process involves cd'ing into `{main,community,testing}/package-name` folder in the aports tree, sometimes editing APKBUILD script and running `abuild -r`. Your resulting packages will get deposited under `$HOME/packages` provided that you're using a standard Alpine build environment with a dedicated builder user. A minimal set of steps required to setup such an environment is captured in the following [Dockerfile](../build-tools/src/scripts/Dockerfile.alpine.bootstrap). That same file also contains a skeleton of a dummy APKBUILD file that one can use to stub-out packages that are required by `pkg/alpine` but are not available yet.
+
+Once you have an MVP collection of Alpine packages you need to upload them plus the tarball of your build environment to some publicly available https endpoint (AWS S3 buckets work great).
+
+## 3. Hooking up new CPU emulation environment to Makefile and GitHub workflows
+
+The rest of the porting journey will be taken step-by-step, but it helps when each step can be facilitated by the Makefile infrastructure and CI/CD workflows so that everything is fully automated. The first package that both Makefile and CI/CD infrastructure needs to know how to publish is `pkg/alpine` which will provide a build environment for the rest of EVE. Thus, you will need to tweak [publish](../.github/workflows/publish.yml) workflow one time to accomplish a bootstrapping of the `pkg/alpine` from the bits that were published in step #1. Don't hesitate to introduce a custom section that would accomplish it once and publish `pkg/alpine` package. Once that happens you can remove that section and simply rely on the fact that a seed `pkg/alpine` is now permanently available.
+
+It is typical to constrain the set of packages being produced for the new architecture and slowly grow the number of packages until all of EVE is ported. This is accomplished by setting `PKGS` environment variable in the publish workflow. Thus, the first incarnation of your new section in `publish.yml` will likely start as:
+
+```console
+             echo "PKGS=pkg/alpine pkg/ipxe pkg/mkconf pkg/mkimage-iso-efi pkg/mkimage-raw-efi" >> "$GITHUB_ENV"
+             echo "ZARCH=riscv64" >> "$GITHUB_ENV"
+             echo "EVE_ARTIFACTS=images/docker-compose.yml" >> "$GITHUB_ENV"
+```
+
+The last statement in the series is used to constrain the initial content of the 2nd package that must be available from Day 1: `pkg/eve`. That is the final package that all of EVE users interact with in order to produce various images. It is typically advised to start with the `pkg/eve` package that is effectively just `pkg/alpine` plus one static artifact `images/docker-compose.yml` to begin with.
+
+The set of the packages `PKGS` you need to make available from the get go is `pkg/alpine` plus whatever maybe required to enable `pkg/eve`. These packages are typically very easy to port and they constitute a good testcase for making sure that `pkg/alpine` is actually functional.

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -38,3 +38,10 @@ It is typical to constrain the set of packages being produced for the new archit
 The last statement in the series is used to constrain the initial content of the 2nd package that must be available from Day 1: `pkg/eve`. That is the final package that all of EVE users interact with in order to produce various images. It is typically advised to start with the `pkg/eve` package that is effectively just `pkg/alpine` plus one static artifact `images/docker-compose.yml` to begin with.
 
 The set of the packages `PKGS` you need to make available from the get go is `pkg/alpine` plus whatever maybe required to enable `pkg/eve`. These packages are typically very easy to port and they constitute a good testcase for making sure that `pkg/alpine` is actually functional.
+
+To sum it up, here's what the above variables do:
+
+* `PKGS` the list of the packages that is ready to be built for a new architecture (bare minimum is pkg/alpine and pkg/eve)
+* `ZARCH` explicit selection of the architecture to build for (unless you don't have to do a cross-build)
+* `EVE_ARTIFACTS` what artifacts to put into an `eve` container
+* `LK_BUILD_ARGS` overrides required for linuxkit

--- a/pkg/alpine/Dockerfile
+++ b/pkg/alpine/Dockerfile
@@ -1,39 +1,37 @@
+ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.2.0
+FROM ${EVE_BUILDER_IMAGE} AS cache
+
 ARG ALPINE_VERSION=3.13
-FROM lfedge/eve-alpine:6.2.0 AS cache
-
-FROM alpine:${ALPINE_VERSION} AS mirror
-ARG ALPINE_VERSION=3.13
-
-# pull packages from a *previous* mirror
-COPY --from=cache /mirror /mirror
-
-# update base image
-RUN apk update && apk upgrade -a
+# this is only needed once, when this package
+# is rebased on the new version of Alpine and
+# you have to have FROM alpine:x.y.z above:
+# RUN apk update && apk upgrade -a
 
 # Copy Dockerfile so we can include it in the hash
-COPY Dockerfile /etc/
+COPY Dockerfile abuild.conf /etc/
 COPY mirrors /tmp/mirrors/
 COPY build-cache.sh /bin/
 
 # install abuild for signing (which requires gcc as well)
-RUN apk add --no-cache abuild gcc
+RUN apk add --no-cache abuild gcc sudo
 
 # install a new key into /etc/apk/keys
 RUN abuild-keygen -a -i -n
 
 # create all the mirrors
 WORKDIR /tmp/mirrors
-RUN mv /etc/apk/repositories /etc/apk/repositories.upstream
+RUN [ -f /etc/apk/repositories.upstream ] || mv /etc/apk/repositories /etc/apk/repositories.upstream
+RUN [ -f /etc/apk/cache.url ] || echo https://dl-cdn.alpinelinux.org/alpine > /etc/apk/cache.url
 RUN for p in */*; do build-cache.sh "$p" "/mirror/$(dirname "$p")" $(cat "$p") ; done
 
 # set the default repository to use
 RUN cp /mirror/${ALPINE_VERSION}/rootfs/etc/apk/repositories /etc/apk && apk update
 
-FROM alpine:${ALPINE_VERSION}
+FROM ${EVE_BUILDER_IMAGE}
 
-COPY --from=mirror /etc/apk/repositories* /etc/apk/
-COPY --from=mirror /etc/apk/keys /etc/apk/keys/
-COPY --from=mirror /mirror /mirror/
+COPY --from=cache /etc/apk/repositories* /etc/apk/
+COPY --from=cache /etc/apk/keys /etc/apk/keys/
+COPY --from=cache /mirror /mirror/
 COPY eve-alpine-deploy.sh go-compile.sh /bin/
 
 RUN apk update && apk upgrade -a

--- a/pkg/alpine/abuild.conf
+++ b/pkg/alpine/abuild.conf
@@ -1,0 +1,36 @@
+export CFLAGS="-Os -fomit-frame-pointer"
+export CXXFLAGS="$CFLAGS"
+export CPPFLAGS="$CFLAGS"
+export LDFLAGS="-Wl,--as-needed,-O1,--sort-common"
+export GOFLAGS="-buildmode=pie"
+# Do note that these should work with at least GDC and LDC
+export DFLAGS="-Os"
+
+export JOBS=$(nproc)
+export MAKEFLAGS=-j$JOBS
+export SAMUFLAGS=-j$JOBS
+export CARGO_BUILD_JOBS=$JOBS
+
+# remove line below to disable colors
+USE_COLORS=1
+
+# uncomment line below to enable ccache support.
+#USE_CCACHE=1
+
+SRCDEST=/var/cache/distfiles
+
+# uncomment line below to store built packages in other location
+# The package will be stored as $REPODEST/$repo/$pkgname-$pkgver-r$pkgrel.apk
+# where $repo is the name of the parent directory of $startdir.
+REPODEST=$HOME/packages/
+
+# PACKAGER and MAINTAINER are used by newapkbuild when creating new aports for
+# the APKBUILD's "Contributor:" and "Maintainer:" comments, respectively.
+PACKAGER="Project EVE <builder@projecteve.dev>"
+MAINTAINER="$PACKAGER"
+
+# what to clean up after a successful build
+CLEANUP="srcdir bldroot pkgdir deps"
+
+# what to cleanup after a failed build
+ERROR_CLEANUP="bldroot deps"

--- a/pkg/alpine/abuild.conf
+++ b/pkg/alpine/abuild.conf
@@ -19,7 +19,7 @@ USE_COLORS=1
 
 SRCDEST=/var/cache/distfiles
 
-# uncomment line below to store built packages in other location
+# tweak line below to store built packages in other location
 # The package will be stored as $REPODEST/$repo/$pkgname-$pkgver-r$pkgrel.apk
 # where $repo is the name of the parent directory of $startdir.
 REPODEST=$HOME/packages/

--- a/pkg/alpine/build-cache.sh
+++ b/pkg/alpine/build-cache.sh
@@ -8,7 +8,7 @@ bail() {
 
 [ "$#" -gt 2 ] || bail "Usage: $0 <alpine version> <path to the cache> [packages...]"
 
-ALPINE_REPO="http://dl-cdn.alpinelinux.org/alpine/v$1"
+ALPINE_REPO="$(cat /etc/apk/cache.url)/v$1"
 CACHE="$2/$(apk --print-arch)"
 ROOTFS="$CACHE/../rootfs"
 shift 2

--- a/pkg/eve/Dockerfile.in
+++ b/pkg/eve/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM lfedge/eve-alpine:6.2.0 as tools
+ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.2.0
+FROM ${EVE_BUILDER_IMAGE} as tools
 ENV PKGS qemu-img tar uboot-tools coreutils
 RUN eve-alpine-deploy.sh
 

--- a/pkg/ipxe/Dockerfile
+++ b/pkg/ipxe/Dockerfile
@@ -1,4 +1,5 @@
-FROM lfedge/eve-alpine:6.2.0 as build
+ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.2.0
+FROM ${EVE_BUILDER_IMAGE} AS build
 
 ENV BUILD_PKGS patch curl make gcc perl util-linux-dev git mtools linux-headers musl-dev xz-dev
 # bash xorriso coreutils syslinux
@@ -16,8 +17,10 @@ RUN cat /tmp/*patch | patch -p1
 # bin/ipxe.iso
 ENV TARGET_x86_64  bin-x86_64-efi/ipxe.efi bin/ipxe.dsk bin/ipxe.lkrn bin/undionly.kpxe
 ENV TARGET_aarch64 bin-arm64-efi/ipxe.efi
+ENV TARGET_riscv64 clean
 
 RUN eval make -j "$(getconf _NPROCESSORS_ONLN)" -C src DOWNLOAD_PROTO_HTTPS=1 EMBED=embedded.cfg \$TARGET_`uname -m`
+RUN mkdir -p /ws/src/bin-riscv64 && touch /ws/src/bin-riscv64/ipxe.riscv64 && touch /ws/src/bin-riscv64/ipxe.riscv64.debug
 RUN mv /ws/src/bin/undionly.kpxe /ws/src/bin/ipxe.undionly 2>/dev/null || :
 RUN rm /ws/src/bin*/*.*.*
 

--- a/pkg/mkconf/Dockerfile
+++ b/pkg/mkconf/Dockerfile
@@ -1,4 +1,5 @@
-FROM lfedge/eve-alpine:6.2.0 AS build
+ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.2.0
+FROM ${EVE_BUILDER_IMAGE} AS build
 
 ENV PKGS mtools dosfstools
 RUN eve-alpine-deploy.sh

--- a/pkg/mkimage-iso-efi/Dockerfile
+++ b/pkg/mkimage-iso-efi/Dockerfile
@@ -1,4 +1,5 @@
-FROM lfedge/eve-alpine:6.2.0 AS build
+ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.2.0
+FROM ${EVE_BUILDER_IMAGE} AS build
 
 ENV PKGS dosfstools libarchive-tools binutils mtools xorriso
 RUN eve-alpine-deploy.sh

--- a/pkg/mkimage-raw-efi/Dockerfile
+++ b/pkg/mkimage-raw-efi/Dockerfile
@@ -4,7 +4,8 @@
 #   /EFI/BOOT/grub.cfg - Chainloads main bootloader
 #   /UsbInvocationScript.txt - Enables USB boot on Dell 3000 series
 #
-FROM lfedge/eve-alpine:6.2.0 as build
+ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.2.0
+FROM ${EVE_BUILDER_IMAGE} AS build
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 ENV BUILD_PKGS mkinitfs grep patch
 ENV PKGS mtools dosfstools libarchive-tools sgdisk e2fsprogs util-linux squashfs-tools coreutils tar dmidecode


### PR DESCRIPTION
This is the first step in a long journey or bringing support for riscv64 to EVE (and frankly Alpine Linux). This PR also happens to be my first example of a DDD (documentation-driven-development) since there's a doc included here that is explaining all the steps that this PR is taking.

Two things to called out are:
  1. we still need to workaround linuxkit not really doing the right thing for cross-environments (hence using my own tweaked version of it)
  2. a few lines in the GH workflow are only useful for the initial bootstrap -- once we have 6.6.0 `eve-alpine` published for riscv64 we can just keep using that without any hidden bootstrap steps

Finally, please don't mind Yetus warnings -- they are triggered by an example Dockerfile -- not something we're going to use.