### PR TITLE
Removing riscv64 bootstrap code

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,13 +33,10 @@ jobs:
              # we need to build our own version of cross-enabled linuxkit, while upstream is sorting things out
              make LINUXKIT_VERSION=master LINUXKIT_SOURCE=https://github.com/rvs/linuxkit.git linuxkit
              # constraining environment for riscv64 builds
-             EVE_BUILDER_IMAGE=$(./build-tools/bin/linuxkit pkg show-tag pkg/alpine)-riscv64
              echo "PKGS=pkg/alpine pkg/ipxe pkg/mkconf pkg/mkimage-iso-efi pkg/mkimage-raw-efi" >> "$GITHUB_ENV"
              echo "ZARCH=riscv64" >> "$GITHUB_ENV"
-             echo 'LK_BUILD_ARGS={"EVE_BUILDER_IMAGE": "'$EVE_BUILDER_IMAGE'"}' >> "$GITHUB_ENV"
+             echo 'LK_BUILD_ARGS={"EVE_BUILDER_IMAGE": "lfedge/eve-alpine:abcff574e06af277a13fe88c9f4c59407e1ba1ff-riscv64"}' >> "$GITHUB_ENV"
              echo "EVE_ARTIFACTS=images/docker-compose.yml" >> "$GITHUB_ENV"
-             # the following is here only for one iteration of bootstrap
-             docker build --build-arg DEFAULT_USER=root --build-arg DEFAULT_HOME=/ -t $EVE_BUILDER_IMAGE -f build-tools/src/scripts/Dockerfile.alpine.bootstrap $(mktemp -d)
           fi
           echo "ARCH=$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')" >> "$GITHUB_ENV"
           echo "TAG=$(echo "$REF" | sed -e 's#^.*/##' -e 's#master#snapshot#' -e 's#main#snapshot#')" >> "$GITHUB_ENV"

--- a/pkg/alpine/Dockerfile
+++ b/pkg/alpine/Dockerfile
@@ -35,3 +35,5 @@ COPY --from=cache /mirror /mirror/
 COPY eve-alpine-deploy.sh go-compile.sh /bin/
 
 RUN apk update && apk upgrade -a
+# FIXME: workaround for riscv64 package layout
+RUN [ "$(uname -m)" != riscv64 ] || ln -s python3.9 /usr/bin/python3


### PR DESCRIPTION
As was promised on the riscv64 PR -- I'm now removing some of the cruft bit-by-bit. The next de-crufting will have to wait for the linuxkit/buildx merge, tho. @deitch @eriknordmark 

I'm also including a tiny tweak to our build environment for riscv64 -- turns out the python3 package didn't have a symlink for some reason. I'm still investigating it on the Alpine side -- but for now the tiny workaround won't really hurt.