### PR TITLE
Reduce confusion for USB override key priority

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -46,6 +46,8 @@ The above build/USB file can specify multiple management interfaces, as well as
 non-management interface, and can specify static IP and DNS configuration
 (for environments where DHCP is not used), plus WiFi and cellular modem specifics. In addition it can specify proxies using several different mechanism.
 
+The build/USB file should include a TimePriority field, since this is used to determine whether the information from the file or from the controller should be applied; the more recent information is what will be used by EVE.
+
 ### Example DevicePortConfig
 
 An example file to specify using WPAD to retrieve proxy configuration on eth0 is:
@@ -53,6 +55,7 @@ An example file to specify using WPAD to retrieve proxy configuration on eth0 is
 ```json
 {
     "Version": 1,
+    "TimePriority": "2021-05-20T22:13:31.07683525Z",
     "Ports": [
         {
             "AddrSubnet": "",
@@ -135,6 +138,7 @@ An example file with eth0 being static and eth1 using dhcp is:
 ```json
 {
     "Version": 1,
+    "TimePriority": "2021-05-20T22:13:31.07683525Z",
     "Ports": [
         {
             "AddrSubnet": "38.108.181.238/24",
@@ -171,6 +175,7 @@ To specify that wwan0 should be secondary (only used if eth0 can not be used to 
 ```json
 {
     "Version": 1,
+    "TimePriority": "2021-05-20T22:13:31.07683525Z",
     "Ports": [
         {
             "Dhcp": 4,
@@ -203,6 +208,7 @@ use DHCP 0. For example,
 ```json
 {
     "Version": 1,
+    "TimePriority": "2021-05-20T22:13:31.07683525Z",
     "Ports": [
         {
             "Dhcp": 4,

--- a/docs/DEVICE-CONNECTIVITY.md
+++ b/docs/DEVICE-CONNECTIVITY.md
@@ -70,6 +70,8 @@ The nim retains the currently working configuration, plus the following in prior
 1. An override file from a USB stick (if any)
 1. The last resort if so enabled
 
+This is based on comparing the TimePriority field in the configuration, where the information receive from zedagent has a TimePriority based on when it was last received or changed, and the override file should contain an explicit TimePriority field. The last resort configuration is the lowest priority with a TimePriority of Jan 1, 1970.
+
 Once the most recent configuration received from the controller has been tested and found to be usable, then all but the (optional) last resort configuration are pruned from the above list.
 When a new configuration is received from the controller it will keep the old configuration from the controller as a fallback.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -100,6 +100,12 @@ One approach is that EVE is booted and the TPM is used to generate the device ce
 
 Another approach is that an onboarding token (in the form of a certificate and private key) is added to the EVE image, but the factory does not need to boot EVE and upload information after installing the image. When the device boots EVE the first time at the installation site it will present the onboarding certificate and its hardware serial numbers using a register API call to the controller, and the user can scan and upload the serial number to the controller. This has weaker security especially if serial numbers can be guessed by an attacker having an account on the same controller, but different devices can be given different onboarding tokens to make such attacks more difficult.
 
+The onboarding token lives in conf/onboard.*.pem in the repo, and this is used to build the config disk image which ends up in /config/ when EVE is booted. Thus the onboarding key UUID can be extracted using
+
+```shell
+openssl x509 -in conf/onboard.cert.pem -text | grep CN
+```
+
 A variant of that approach is to use a random soft serial number. When EVE is installed it generates a /config/soft_serial which is a random 128-bit UUID. If installed from a USB stick this serial number (together with the less random hardware serial number) are written to a directory on the USB installer stick.
 
 When EVE is calling the register API it will present both the hardware serial and soft serial, hence if the controller has been told of the random soft serial for the device we avoid depending on guessable hardware serial numbers.

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -655,16 +655,24 @@ func (config *DevicePortConfig) DoSanitize(log *base.LogObject,
 	if sanitizeTimePriority {
 		zeroTime := time.Time{}
 		if config.TimePriority == zeroTime {
-			// If we can stat the file use its modify time
+			// A json override file should really contain a
+			// timepriority field so we can determine whether
+			// it or the information received from the controller
+			// is more current.
+			// If we can stat the file we use 1980, otherwise
+			// we use 1970; using the modify time of the file
+			// is too unpredictable.
 			filename := fmt.Sprintf("%s/DevicePortConfig/%s.json",
 				TmpDirname, key)
-			fi, err := os.Stat(filename)
+			_, err := os.Stat(filename)
 			if err == nil {
-				config.TimePriority = fi.ModTime()
+				config.TimePriority = time.Date(1980,
+					time.January, 1, 0, 0, 0, 0, time.UTC)
 			} else {
-				config.TimePriority = time.Unix(0, 0)
+				config.TimePriority = time.Date(1970,
+					time.January, 1, 0, 0, 0, 0, time.UTC)
 			}
-			log.Functionf("DoSanitize: Forcing TimePriority for %s to %v\n",
+			log.Warnf("DoSanitize: Forcing TimePriority for %s to %v",
 				key, config.TimePriority)
 		}
 	}


### PR DESCRIPTION
Two commits; first is just a doc update based on a comment on lf-edge/eve slack.

Second is mostly about documentation; additing that the usb json should have a TimePriority field to make it more obvious its preference relative to config received from zedcloud. But there is also a code change when there is no TimePriority in the file. In that case we know assume a date of 1980; prior that was based on the timestamp of the file on the USB stick.