### PR TITLE
Release memory and adapters when app instance deactivated

### DIFF
--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -373,6 +373,8 @@ type DomainMetric struct {
 	UsedMemory        uint32
 	AvailableMemory   uint32
 	UsedMemoryPercent float64
+	LastHeard         time.Time
+	Activated         bool
 }
 
 // Key returns the key for pubsub

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -158,6 +158,7 @@ type AppInstanceStatus struct {
 	// Error* set implies error.
 	State          SwState
 	MissingNetwork bool // If some Network UUID not found
+	MissingMemory  bool // Waiting for memory
 	// All error strings across all steps and all StorageStatus
 	// ErrorAndTimeWithSource provides SetError, SetErrrorWithSource, etc
 	ErrorAndTimeWithSource


### PR DESCRIPTION
This enables having multiple app instances share the same adapter assignment and memory usage, as long as they are not both activated at the same time.

Had to add a retry check (and associated MissingMemory boolean) in zedmanager to retry after some app instance has been halted.

Also, the reporting of memory usage is adjusted in domainmgr to not report the memory for halted app instances (even if containerd might report something) to ensure that we consistently not report memory for a halted app instance. This might not be required, since containerd should not have a task if the app instance is halted, but doing it just to make sure.