### PR TITLE
Enabling installer images for riscv64

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
              # constraining environment for riscv64 builds
              TAG=lfedge/eve-alpine:66bb4bae0cf16ff2cce308ffcb329fb82f32feb1-riscv64
              echo "ZARCH=riscv64" >> "$GITHUB_ENV"
-             echo 'LK_BUILD_ARGS={"EVE_BUILDER_IMAGE":"$TAG"}' >> "$GITHUB_ENV"
+             echo 'LK_BUILD_ARGS={"EVE_BUILDER_IMAGE":"'$TAG\"} >> "$GITHUB_ENV"
           fi
           echo "ARCH=$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')" >> "$GITHUB_ENV"
           echo "TAG=$(echo "$REF" | sed -e 's#^.*/##' -e 's#master#snapshot#' -e 's#main#snapshot#')" >> "$GITHUB_ENV"

--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,8 @@ endif
 # since they are not getting published in Docker HUB
 PKGS_$(ZARCH)=$(shell ls -d pkg/* | grep -Ev "eve|test-microsvcs")
 PKGS_riscv64=pkg/alpine pkg/ipxe pkg/mkconf pkg/mkimage-iso-efi pkg/grub     \
-             pkg/mkimage-raw-efi pkg/uefi pkg/u-boot pkg/grub pkg/new-kernel
+             pkg/mkimage-raw-efi pkg/uefi pkg/u-boot pkg/grub pkg/new-kernel \
+	     pkg/debug pkg/dom0-ztools pkg/gpt-tools pkg/storage-init
 PKGS=$(PKGS_$(ZARCH))
 
 # Top-level targets
@@ -541,9 +542,7 @@ pkg/%: eve-% FORCE
 $(RUNME) $(BUILD_YML):
 	cp pkg/eve/$(@F) $@
 
-EVE_ARTIFACTS_$(ZARCH)=$(BIOS_IMG) $(EFI_PART) $(CONFIG_IMG) $(PERSIST_IMG) $(INITRD_IMG) $(INSTALLER_IMG) $(ROOTFS_IMG) fullname-rootfs $(BOOT_PART)
-EVE_ARTIFACTS_riscv64=$(BIOS_IMG) $(EFI_PART) $(CONFIG_IMG) $(PERSIST_IMG) $(INITRD_IMG)                                 fullname-rootfs $(BOOT_PART)
-EVE_ARTIFACTS=$(EVE_ARTIFACTS_$(ZARCH))
+EVE_ARTIFACTS=$(BIOS_IMG) $(EFI_PART) $(CONFIG_IMG) $(PERSIST_IMG) $(INITRD_IMG) $(INSTALLER_IMG) $(ROOTFS_IMG) fullname-rootfs $(BOOT_PART)
 eve: $(INSTALLER) $(EVE_ARTIFACTS) current $(RUNME) $(BUILD_YML) | $(BUILD_DIR)
 	$(QUIET): "$@: Begin: EVE_REL=$(EVE_REL), HV=$(HV), LINUXKIT_PKG_TARGET=$(LINUXKIT_PKG_TARGET)"
 	cp images/*.yml $|

--- a/images/rootfs-mini.yml.in.patch
+++ b/images/rootfs-mini.yml.in.patch
@@ -1,0 +1,75 @@
+--- images/rootfs.yml.in	2021-05-13 16:54:55.000000000 -0700
++++ images/rootfs.yml.in	2021-05-20 16:06:39.000000000 -0700
+@@ -1,71 +1,18 @@
+ kernel:
+-  image: KERNEL_TAG
++  image: NEW_KERNEL_TAG
+   cmdline: "rootdelay=3"
+ init:
+-  - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
+-  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+-  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
+-  - linuxkit/getty:v0.5
+-  - linuxkit/memlogd:v0.5
+   - DOM0ZTOOLS_TAG
+   - GRUB_TAG
+-  - FW_TAG
+-  - XEN_TAG
+   - GPTTOOLS_TAG
+ onboot:
+-   - name: rngd
+-     image: RNGD_TAG
+-     command: ["/sbin/rngd", "-1"]
+-   - name: sysctl
+-     image: linuxkit/sysctl:v0.5
+-     binds:
+-        - /etc/sysctl.d:/etc/sysctl.d
+-   - name: modprobe
+-     image: linuxkit/modprobe:v0.5
+-     command: ["/bin/sh", "-c", "modprobe -a nct6775 w83627hf_wdt wlcore_sdio wl18xx br_netfilter dwc3 rk808 rk808-regulator smsc75xx cp210x nicvf tpm_tis_spi rtc_rx8010 gpio_pca953x leds_siemens_ipc127 upboard-fpga pinctrl-upboard leds-upboard xhci_tegra 2>/dev/null || :"]
+    - name: storage-init
+      image: STORAGE_INIT_TAG
+ services:
+-   - name: newlogd
+-     image: NEWLOGD_TAG
+-     cgroupsPath: /eve/services/eve-newlog
+-     oomScoreAdj: -999
+-   - name: ntpd
+-     image: linuxkit/openntpd:v0.5
+-     cgroupsPath: /eve/services/ntpd
+-     oomScoreAdj: -999
+    - name: debug
+      image: DEBUG_TAG
+      cgroupsPath: /eve/services/debug
+      oomScoreAdj: -999
+-   - name: wwan
+-     image: WWAN_TAG
+-     cgroupsPath: /eve/services/wwan
+-     oomScoreAdj: -999
+-   - name: wlan
+-     image: WLAN_TAG
+-     cgroupsPath: /eve/services/wlan
+-     oomScoreAdj: -999
+-   - name: guacd
+-     image: GUACD_TAG
+-     cgroupsPath: /eve/services/guacd
+-     oomScoreAdj: -999
+-   - name: pillar
+-     image: PILLAR_TAG
+-     cgroupsPath: /eve/services/pillar
+-     oomScoreAdj: -999
+-   - name: vtpm
+-     image: VTPM_TAG
+-     cgroupsPath: /eve/services/vtpm
+-     oomScoreAdj: -999
+-   - name: watchdog
+-     image: WATCHDOG_TAG
+-     cgroupsPath: /eve/services/watchdog
+-     oomScoreAdj: -1000
+-   - name: xen-tools
+-     image: XENTOOLS_TAG
+-     cgroupsPath: /eve/services/xen-tools
+-     oomScoreAdj: -999
+ files:
+    - path: /etc/eve-release
+      contents: 'EVE_VERSION'

--- a/pkg/debug/Dockerfile
+++ b/pkg/debug/Dockerfile
@@ -3,7 +3,9 @@
 # has a fast path for stack unwinding. This also happens
 # to be a perfect place to put any other kind of debug info
 # into the package: see abuild/etc/abuild.conf.
-FROM lfedge/eve-alpine:6.2.0 as build
+ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.2.0
+# hadolint ignore=DL3006
+FROM ${EVE_BUILDER_IMAGE} as build
 ENV BUILD_PKGS abuild curl tar make linux-headers patch g++ git gcc ncurses-dev autoconf
 # Feel free to add additional packages here, but be aware that
 # EVE's rootfs image can be no larger than 300Mb (and don't
@@ -16,7 +18,7 @@ RUN eve-alpine-deploy.sh
 ENV LSHW_VERSION 02.19.2
 
 # setting up building account
-RUN adduser -G abuild -D builder
+RUN adduser -G abuild -D builder || :
 RUN su builder -c 'abuild-keygen -a -n'
 
 COPY --chown=builder:abuild abuild/ /

--- a/pkg/dom0-ztools/Dockerfile
+++ b/pkg/dom0-ztools/Dockerfile
@@ -1,4 +1,6 @@
-FROM lfedge/eve-alpine:6.2.0 as zfs
+ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.2.0
+# hadolint ignore=DL3006
+FROM ${EVE_BUILDER_IMAGE} as zfs
 ENV PKGS zfs ca-certificates util-linux
 RUN eve-alpine-deploy.sh
 

--- a/pkg/gpt-tools/Dockerfile
+++ b/pkg/gpt-tools/Dockerfile
@@ -1,4 +1,6 @@
-FROM lfedge/eve-alpine:6.2.0 as build
+ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.2.0
+# hadolint ignore=DL3006
+FROM ${EVE_BUILDER_IMAGE} as build
 ENV BUILD_PKGS gcc make file patch libc-dev util-linux-dev linux-headers openssl-dev g++ tar
 RUN eve-alpine-deploy.sh
 
@@ -50,6 +52,7 @@ COPY vboot_reference-${VBOOT_COMMIT}.tar.gz /
 RUN tar xvzf vboot_reference-${VBOOT_COMMIT}.tar.gz
 
 WORKDIR /vboot_reference
+RUN [ -d host/arch/riscv64 ] || cp -r host/arch/arm host/arch/riscv64
 RUN make cgpt LDFLAGS=-static CFLAGS=-Wno-error=address-of-packed-member
 RUN cp build/cgpt/cgpt /out/cgpt
 

--- a/pkg/storage-init/Dockerfile
+++ b/pkg/storage-init/Dockerfile
@@ -1,4 +1,6 @@
-FROM lfedge/eve-alpine:6.2.0 as build
+ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.2.0
+# hadolint ignore=DL3006
+FROM ${EVE_BUILDER_IMAGE} as build
 ENV PKGS alpine-baselayout musl-utils bash glib squashfs-tools util-linux e2fsprogs e2fsprogs-extra keyutils dosfstools coreutils sgdisk smartmontools
 RUN eve-alpine-deploy.sh
 


### PR DESCRIPTION
This enables all of our installers for riscv64 and therefore reduces Makefile clutter and special casing. The EVE that gets installed is cut down dramatically (since some of the key packages are still missing). That part will require quite a few weekends to do right. But still -- it is now at a level of an MVP where one can actually run riscv64 in qemu all the way to the kernel and userland booting up. 