### PR TITLE
Propagate errors and clear of errors from network instance to app instance

### DIFF
--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -407,17 +407,17 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 		log.Functionf("Waiting for AppNetworkStatus !Pending for %s", uuidStr)
 		return changed
 	}
-	if ns.AwaitNetworkInstance {
-		log.Functionf("Waiting for required network instances to arrive for %s", uuidStr)
-		status.State = types.AWAITNETWORKINSTANCE
-		changed = true
-		return changed
-	}
 	if ns.HasError() {
 		log.Errorf("Received error from zedrouter for %s: %s",
 			uuidStr, ns.Error)
 		status.SetErrorWithSource(ns.Error, types.AppNetworkStatus{},
 			ns.ErrorTime)
+		changed = true
+		return changed
+	}
+	if ns.AwaitNetworkInstance {
+		log.Functionf("Waiting for required network instances to arrive for %s", uuidStr)
+		status.State = types.AWAITNETWORKINSTANCE
 		changed = true
 		return changed
 	}

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -2273,6 +2273,9 @@ const (
 // 		Extracted from the protobuf NetworkInstanceConfig
 type NetworkInstanceStatus struct {
 	NetworkInstanceConfig
+	// Make sure the Activate from the config isn't exposed as a boolean
+	Activate uint64
+
 	ChangeInProgress ChangeInProgressType
 
 	// Activated


### PR DESCRIPTION
If we have get an error on a network instance e.g., due to the external port being app-direct and not app-shared, we propagate that error to the app instances using that network instance. 

But then if the adapter being fixed to be app-shared, we do not clear the network instance error nor the app instance error. This PR propagates the clear of the error, and also ensures that if an error appears after the fact (such as changing it back to app-direct) we will propagate that error to the app instance(s) as well.