### PR TITLE
Should explicitly specify what arches we want to build eve packages for

### DIFF
--- a/pkg/eve/build.yml
+++ b/pkg/eve/build.yml
@@ -1,3 +1,7 @@
 image: eve
 org: lfedge
 network: yes
+arches:
+  - amd64
+  - arm64
+


### PR DESCRIPTION
We use `make eve` in the root to call `linuxkit pkg build` with the `build.yml` from `pkg/eve/build.yml`. That does not specify explicitly which arches are supported, so a future call to `pkg build` will try to build for lots of things that might or might not suit us.

This makes it explicit.

cc @vmlemon @rvs 

Related to [this](https://github.com/lf-edge/eve/pull/2061#issuecomment-848777037)