### PR TITLE
Actual fix for python3 symlink made it to Alpine

### DIFF
--- a/pkg/alpine/Dockerfile
+++ b/pkg/alpine/Dockerfile
@@ -35,5 +35,3 @@ COPY --from=cache /mirror /mirror/
 COPY eve-alpine-deploy.sh go-compile.sh /bin/
 
 RUN apk update && apk upgrade -a
-# FIXME: workaround for riscv64 package layout
-RUN [ "$(uname -m)" != riscv64 ] || ln -s python3.9 /usr/bin/python3


### PR DESCRIPTION
One more workaround is gone now that Alpine riscv64 keeps improving