### PR TITLE
more aggressive cleanup of images in docker cache

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -49,7 +49,12 @@ jobs:
           else
              make -C eve V=1 pkgs
              make -C eve V=1 ROOTFS_VERSION="$TAG" HV=kvm eve
-             docker rmi -f $(docker images --filter=reference="lfedge/eve-*" -q)||echo "skip conflicts"
+             IMAGES="$(docker images -f reference="lfedge/eve-*" -q)"
+             IMAGES="$IMAGES $(docker images -f reference="eve-build-*" -q)"
+             IMAGES="$IMAGES $(docker images -f reference="golang" -q)"
+             IMAGES="$IMAGES $(docker images -f dangling=true -q)"
+             docker rmi -f $IMAGES||echo "skip conflicts"
+             rm -rf ~/.linuxkit
           fi
           echo "TAG=$TAG" >> $GITHUB_ENV
       - name: set debug log level


### PR DESCRIPTION
Seems, we have out of space during tests: https://github.com/lf-edge/eve/runs/2698204633?check_suite_focus=true#step:9:3828
So, we need to do more aggressive cleanup during `fetch or build eve` step

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>