### PR TITLE
Bumping build environment dependency to eve-alpine:6.7.0

### DIFF
--- a/pkg/acrn-kernel/Dockerfile
+++ b/pkg/acrn-kernel/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:6.2.0 as kernel-build
+FROM lfedge/eve-alpine:6.7.0 as kernel-build
 
 ENV BUILD_PKGS \
     argp-standalone automake bash bc binutils-dev bison build-base curl \

--- a/pkg/acrn/Dockerfile
+++ b/pkg/acrn/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:6.2.0 as kernel-build
+FROM lfedge/eve-alpine:6.7.0 as kernel-build
 
 ENV BUILD_PKGS \
     gcc make libc-dev dev86 xz-dev perl bash python3-dev gettext iasl         \

--- a/pkg/alpine/Dockerfile
+++ b/pkg/alpine/Dockerfile
@@ -1,4 +1,4 @@
-ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.2.0
+ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.7.0
 FROM ${EVE_BUILDER_IMAGE} AS cache
 
 ARG ALPINE_VERSION=3.13

--- a/pkg/debug/Dockerfile
+++ b/pkg/debug/Dockerfile
@@ -3,7 +3,7 @@
 # has a fast path for stack unwinding. This also happens
 # to be a perfect place to put any other kind of debug info
 # into the package: see abuild/etc/abuild.conf.
-ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.2.0
+ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.7.0
 # hadolint ignore=DL3006
 FROM ${EVE_BUILDER_IMAGE} as build
 ENV BUILD_PKGS abuild curl tar make linux-headers patch g++ git gcc ncurses-dev autoconf

--- a/pkg/dnsmasq/Dockerfile
+++ b/pkg/dnsmasq/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:6.2.0 as build
+FROM lfedge/eve-alpine:6.7.0 as build
 ENV BUILD_PKGS gcc make patch libc-dev linux-headers tar
 RUN eve-alpine-deploy.sh
 

--- a/pkg/dom0-ztools/Dockerfile
+++ b/pkg/dom0-ztools/Dockerfile
@@ -1,4 +1,4 @@
-ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.2.0
+ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.7.0
 # hadolint ignore=DL3006
 FROM ${EVE_BUILDER_IMAGE} as zfs
 ENV PKGS zfs ca-certificates util-linux

--- a/pkg/eve/Dockerfile.in
+++ b/pkg/eve/Dockerfile.in
@@ -1,4 +1,4 @@
-ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.2.0
+ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.7.0
 FROM ${EVE_BUILDER_IMAGE} as tools
 ENV PKGS qemu-img tar uboot-tools coreutils
 RUN eve-alpine-deploy.sh

--- a/pkg/gpt-tools/Dockerfile
+++ b/pkg/gpt-tools/Dockerfile
@@ -1,4 +1,4 @@
-ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.2.0
+ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.7.0
 # hadolint ignore=DL3006
 FROM ${EVE_BUILDER_IMAGE} as build
 ENV BUILD_PKGS gcc make file patch libc-dev util-linux-dev linux-headers openssl-dev g++ tar

--- a/pkg/guacd/Dockerfile
+++ b/pkg/guacd/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:6.2.0 as build
+FROM lfedge/eve-alpine:6.7.0 as build
 ENV BUILD_PKGS cairo-dev jpeg-dev libpng-dev gcc make libc-dev openssl-dev libvncserver-dev file patch
 ENV PKGS alpine-baselayout musl-utils libtasn1-progs p11-kit cairo jpeg libpng openssl libvncserver
 RUN eve-alpine-deploy.sh

--- a/pkg/ipxe/Dockerfile
+++ b/pkg/ipxe/Dockerfile
@@ -1,4 +1,4 @@
-ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.2.0
+ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.7.0
 FROM ${EVE_BUILDER_IMAGE} AS build
 
 ENV BUILD_PKGS patch curl make gcc perl util-linux-dev git mtools linux-headers musl-dev xz-dev

--- a/pkg/k3s/Dockerfile
+++ b/pkg/k3s/Dockerfile
@@ -1,5 +1,5 @@
 ARG GOVER=1.14.4
-FROM lfedge/eve-alpine:6.2.0 as build
+FROM lfedge/eve-alpine:6.7.0 as build
 ENV BUILD_PKGS make gcc git musl-dev linux-headers curl bash pkgconf libseccomp-dev go patch
 RUN eve-alpine-deploy.sh
 

--- a/pkg/kernel/Dockerfile
+++ b/pkg/kernel/Dockerfile
@@ -1,5 +1,5 @@
 # This file must be kept as much in sync with pkg/new-kernel/Dockerfile as posisble
-FROM lfedge/eve-alpine:6.2.0 AS kernel-build
+FROM lfedge/eve-alpine:6.7.0 AS kernel-build
 
 ENV BUILD_PKGS \
     argp-standalone automake bash bc binutils-dev bison build-base curl \

--- a/pkg/kvm-tools/Dockerfile
+++ b/pkg/kvm-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:6.2.0 as build
+FROM lfedge/eve-alpine:6.7.0 as build
 # Building qemu in strip-down mirovm only mode: curl
 # qemu 5.1 dependencies: python3 glib-dev pixman-dev
 # qemu 5.2+ dependencies: py3-setuptools bash perl

--- a/pkg/lisp/Dockerfile
+++ b/pkg/lisp/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:6.2.0 AS build
+FROM lfedge/eve-alpine:6.7.0 AS build
 ENV BUILD_PKGS gcc linux-headers libc-dev libpcap-dev go python2-dev libffi-dev openssl-dev patch
 ENV PKGS libffi libpcap python2 openssl iproute2 keyutils tini
 RUN eve-alpine-deploy.sh

--- a/pkg/mkconf/Dockerfile
+++ b/pkg/mkconf/Dockerfile
@@ -1,4 +1,4 @@
-ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.2.0
+ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.7.0
 FROM ${EVE_BUILDER_IMAGE} AS build
 
 ENV PKGS mtools dosfstools

--- a/pkg/mkimage-iso-efi/Dockerfile
+++ b/pkg/mkimage-iso-efi/Dockerfile
@@ -1,4 +1,4 @@
-ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.2.0
+ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.7.0
 FROM ${EVE_BUILDER_IMAGE} AS build
 
 ENV PKGS dosfstools libarchive-tools binutils mtools xorriso

--- a/pkg/mkimage-raw-efi/Dockerfile
+++ b/pkg/mkimage-raw-efi/Dockerfile
@@ -4,7 +4,7 @@
 #   /EFI/BOOT/grub.cfg - Chainloads main bootloader
 #   /UsbInvocationScript.txt - Enables USB boot on Dell 3000 series
 #
-ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.2.0
+ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.7.0
 FROM ${EVE_BUILDER_IMAGE} AS build
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 ENV BUILD_PKGS mkinitfs grep patch

--- a/pkg/mkrootfs-ext4/Dockerfile
+++ b/pkg/mkrootfs-ext4/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:6.2.0 AS build
+FROM lfedge/eve-alpine:6.7.0 AS build
 
 ENV PKGS dosfstools libarchive-tools binutils mtools sfdisk sgdisk xfsprogs \
          e2fsprogs util-linux coreutils multipath-tools squashfs-tools

--- a/pkg/mkrootfs-squash/Dockerfile
+++ b/pkg/mkrootfs-squash/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:6.2.0 AS build
+FROM lfedge/eve-alpine:6.7.0 AS build
 
 ENV PKGS dosfstools libarchive-tools binutils mtools sfdisk sgdisk \
     xfsprogs e2fsprogs util-linux coreutils multipath-tools squashfs-tools

--- a/pkg/new-kernel/Dockerfile
+++ b/pkg/new-kernel/Dockerfile
@@ -1,5 +1,5 @@
 # This file must be kept as much in sync with pkg/kernel/Dockerfile as posisble
-ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.2.0
+ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.7.0
 # hadolint ignore=DL3006
 FROM ${EVE_BUILDER_IMAGE} as kernel-build
 

--- a/pkg/newlog/Dockerfile
+++ b/pkg/newlog/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:6.2.0 as build
+FROM lfedge/eve-alpine:6.7.0 as build
 ENV BUILD_PKGS libc-dev git gcc linux-headers go
 ENV PKGS alpine-baselayout musl-utils
 RUN eve-alpine-deploy.sh

--- a/pkg/pillar/Dockerfile.in
+++ b/pkg/pillar/Dockerfile.in
@@ -1,6 +1,6 @@
 # Copyright (c) 2018 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:6.2.0 as build
+FROM lfedge/eve-alpine:6.7.0 as build
 ENV BUILD_PKGS git gcc linux-headers libc-dev make linux-pam-dev m4 findutils go util-linux make patch wget
 ENV PKGS alpine-baselayout musl-utils libtasn1-progs pciutils yajl xz bash openssl iptables ip6tables iproute2 dhcpcd coreutils dmidecode libbz2 libuuid ipset curl radvd ethtool util-linux e2fsprogs libcrypto1.1 xorriso qemu-img jq e2fsprogs-extra keyutils ca-certificates ip6tables-openrc iptables-openrc ipset-openrc hdparm
 RUN eve-alpine-deploy.sh

--- a/pkg/qrexec-dom0/Dockerfile.in
+++ b/pkg/qrexec-dom0/Dockerfile.in
@@ -1,6 +1,6 @@
 FROM XENTOOLS_TAG as xentools
 FROM QREXECLIB_TAG as qrexec_lib
-FROM lfedge/eve-alpine:6.2.0 as build
+FROM lfedge/eve-alpine:6.7.0 as build
 ENV BUILD_PKGS gcc make libc-dev linux-headers git pkgconf
 RUN eve-alpine-deploy.sh
 

--- a/pkg/qrexec-lib/Dockerfile.in
+++ b/pkg/qrexec-lib/Dockerfile.in
@@ -1,6 +1,6 @@
 FROM XENTOOLS_TAG as xentools
 
-FROM lfedge/eve-alpine:6.2.0 as build
+FROM lfedge/eve-alpine:6.7.0 as build
 ENV BUILD_PKGS gcc make libc-dev linux-headers git pkgconf
 ENV PKGS libc-dev
 RUN eve-alpine-deploy.sh

--- a/pkg/rngd/Dockerfile
+++ b/pkg/rngd/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:6.2.0 AS build
+FROM lfedge/eve-alpine:6.7.0 AS build
 ENV BUILD_PKGS go gcc musl-dev linux-headers
 RUN eve-alpine-deploy.sh
 

--- a/pkg/storage-init/Dockerfile
+++ b/pkg/storage-init/Dockerfile
@@ -1,4 +1,4 @@
-ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.2.0
+ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.7.0
 # hadolint ignore=DL3006
 FROM ${EVE_BUILDER_IMAGE} as build
 ENV PKGS alpine-baselayout musl-utils bash glib squashfs-tools util-linux e2fsprogs e2fsprogs-extra keyutils dosfstools coreutils sgdisk smartmontools

--- a/pkg/strongswan/Dockerfile
+++ b/pkg/strongswan/Dockerfile
@@ -2,7 +2,7 @@
 # StrongSwan VPN + Alpine Linux
 #
 
-FROM lfedge/eve-alpine:6.2.0 as build
+FROM lfedge/eve-alpine:6.7.0 as build
 ENV BUILD_PKGS gcc make patch libc-dev linux-headers tar build-base ca-certificates iptables iproute2 openssl openssl-dev
 RUN eve-alpine-deploy.sh
 

--- a/pkg/u-boot/Dockerfile
+++ b/pkg/u-boot/Dockerfile
@@ -1,4 +1,4 @@
-ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.2.0
+ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.7.0
 # hadolint ignore=DL3006
 FROM ${EVE_BUILDER_IMAGE} as build
 ENV BUILD_PKGS bash binutils-dev build-base bc curl bison flex openssl-dev python3 swig

--- a/pkg/uefi/Dockerfile
+++ b/pkg/uefi/Dockerfile
@@ -9,7 +9,7 @@
 #   git clone https://git.linaro.org/uefi/uefi-tools.git
 #   ./uefi-tools/edk2-build.sh -b DEBUG -b RELEASE all
 #
-ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.2.0
+ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.7.0
 # hadolint ignore=DL3006
 FROM ${EVE_BUILDER_IMAGE} as build
 ENV BUILD_PKGS curl make gcc g++ python3 libuuid nasm util-linux-dev bash git util-linux patch

--- a/pkg/vtpm/Dockerfile
+++ b/pkg/vtpm/Dockerfile
@@ -6,7 +6,7 @@
 #    and the server
 
 #Build TPM2-TSS and TPM2-TOOLS
-FROM lfedge/eve-alpine:6.2.0 as build
+FROM lfedge/eve-alpine:6.7.0 as build
 ENV BUILD_PKGS linux-headers git gcc g++ autoconf automake libtool doxygen make \
                openssl-dev protobuf-dev gnupg curl-dev patch
 ENV PKGS alpine-baselayout musl-utils

--- a/pkg/watchdog/Dockerfile
+++ b/pkg/watchdog/Dockerfile
@@ -1,6 +1,6 @@
 # Build watchdogd for alpine
 
-FROM lfedge/eve-alpine:6.2.0 AS watchdog-build
+FROM lfedge/eve-alpine:6.7.0 AS watchdog-build
 ENV BUILD_PKGS build-base file libtirpc-dev linux-headers tar
 ENV PKGS alpine-baselayout musl-utils
 RUN eve-alpine-deploy.sh

--- a/pkg/wlan/Dockerfile
+++ b/pkg/wlan/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:6.2.0 as build
+FROM lfedge/eve-alpine:6.7.0 as build
 ENV PKGS alpine-baselayout musl-utils wireless-tools wpa_supplicant
 RUN eve-alpine-deploy.sh
 

--- a/pkg/wwan/Dockerfile
+++ b/pkg/wwan/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:6.2.0 as build
+FROM lfedge/eve-alpine:6.7.0 as build
 ENV BUILD_PKGS automake autoconf gettext gettext-dev git pkgconfig \
                libtool libc-dev linux-headers gcc make glib-dev \
                autoconf-archive patch cmake

--- a/pkg/xen-tools/Dockerfile.in
+++ b/pkg/xen-tools/Dockerfile.in
@@ -1,7 +1,7 @@
 # hadolint ignore=DL3006
 FROM UEFI_TAG as uefi-build
 
-FROM lfedge/eve-alpine:6.2.0 as runx-build
+FROM lfedge/eve-alpine:6.7.0 as runx-build
 ENV BUILD_PKGS mkinitfs gcc musl-dev e2fsprogs
 RUN eve-alpine-deploy.sh
 
@@ -15,7 +15,7 @@ RUN gcc -s -o /chroot2 /tmp/chroot2.c
 RUN gcc -s -o /hacf /tmp/hacf.c
 RUN mkinitfs -n -F base -i /init-initrd -o /runx-initrd
 
-FROM lfedge/eve-alpine:6.2.0 as build
+FROM lfedge/eve-alpine:6.7.0 as build
 ENV BUILD_PKGS \
     gcc make libc-dev dev86 xz-dev perl bash python3-dev \
     gettext iasl util-linux-dev ncurses-dev glib-dev \

--- a/pkg/xen/Dockerfile
+++ b/pkg/xen/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:6.2.0 as kernel-build
+FROM lfedge/eve-alpine:6.7.0 as kernel-build
 
 ENV BUILD_PKGS argp-standalone automake bash bc binutils-dev bison build-base \
                curl diffutils flex git gmp-dev gnupg installkernel kmod \


### PR DESCRIPTION
This is a very mechanical update that is a no-op for x86 and aarch64, but allows us to have riscv64 as part of the eve-alpine so we can start experimenting with latest linuxkit/buildkit cross builds courtesy of @vmlemon and @deitch 