### PR TITLE
Finally re-basing grub package on eve-alpine:6.7.0

### DIFF
--- a/pkg/grub/Dockerfile
+++ b/pkg/grub/Dockerfile
@@ -1,4 +1,4 @@
-ARG EVE_BUILDER_IMAGE=linuxkit/alpine:8b53d842a47fce43464e15f65ee2f68b82542330
+ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.7.0
 # hadolint ignore=DL3006
 FROM ${EVE_BUILDER_IMAGE} as grub-build
 


### PR DESCRIPTION
Singling this one out -- since unlike #2110 it is less of a mechanical change (grub build had a few dependencies on alpine build environment that came from linuxkit).