### PR TITLE
explciitly create manifest index

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,3 +93,19 @@ jobs:
         run: |
           rm -rf dist dist.xen
           make -e V=1 HV=mini LINUXKIT_PKG_TARGET=push eve
+
+  index:
+    if: github.event.repository.full_name == 'lf-edge/eve'
+    runs-on: ubuntu-20.04
+    needs: build
+    steps:
+      - name: Login to DockerHUB
+        run: |
+          echo "${{ secrets.RELEASE_DOCKERHUB_TOKEN }}" |\
+             docker login -u "${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}" --password-stdin
+      - name: multi-arch index for pkgs
+        run: |
+          make -e V=1 pkgmanifests
+      - name: multi-arch index for eve
+        run: |
+          make -e V=1 manifest-eve


### PR DESCRIPTION
The GitHub publish process as it stands today relies on running `linuxkit pkg push` from various places, and assuming it doesn't trounce one another (e.g. two parallel builds that create the multi-arch index at precisely the same time can trounce each other; I have seen it happen).

Further, linuxkit's build process has changed, such that it just builds a manifest index locally and pushes it out, not relying on what is in the registry, so running in parallel will not work going forward. It does that because it is simpler, and one always can rely on `docker manifest` or `manifest-tool` to build indexes.

This PR does the following:

1. Add manifest build targets to `Makefile`
2. Leverage those build targets in `publish.yaml`

### Manifest build targets

The simplest is `manifest-%`, which will try to create a multi-arch index for the provided package. It tries to do it for all provided architectures (arm64, amd64,. riscv64), but is perfectly happy to ignore a missing one.

This is idempotent. You can run `make manifest-eve` a dozen times. All it does is:

1. Find all images with the right name ending in `-<arch>` in docker hub
2. Create and update a local manifest list with those it finds
3. Pushes it out

It also is very fast, as it is just reading manifests; no building or image pulling going on.

The next is `pkgmanifests`, which tries to build for _all_ packages. It does not care what platform you are on (e.g. riscv64 has a smaller set of packages than amd64). It just tries to build indexes for every possible package on every possible arch, and ignores those for which there just isn't an image for that arch.

### Leverage in publish

Adds a new job to `publish.yml` to build manifests for:

1. All packages
2. `lfedge/eve`

This new job has `needs: build`, so it waits until all of them are done.

Since the tasks are idempotent and fast, these will run perfectly fine now, and with planned linuxkit changes. It just happily looks for all arch-specific images on the registry and builds indexes for them.