### PR TITLE
move tpmmgr to publish EdgeNodeCert earlier in persist

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -301,6 +301,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		MyAgentName: agentName,
 		TopicImpl:   types.EdgeNodeCert{},
 		Activate:    false,
+		Persistent:  true,
 		Ctx:         &domainCtx,
 		WarningTime: warningTime,
 		ErrorTime:   errorTime,
@@ -507,6 +508,9 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 		case change := <-subDeviceNetworkStatus.MsgChan():
 			subDeviceNetworkStatus.ProcessChange(change)
+
+		case change := <-subEdgeNodeCert.MsgChan():
+			subEdgeNodeCert.ProcessChange(change)
 
 		case change := <-subPhysicalIOAdapter.MsgChan():
 			subPhysicalIOAdapter.ProcessChange(change)

--- a/pkg/pillar/cmd/downloader/context.go
+++ b/pkg/pillar/cmd/downloader/context.go
@@ -51,6 +51,7 @@ func (ctx *downloaderContext) registerHandlers(ps *pubsub.PubSub) error {
 		MyAgentName: agentName,
 		TopicImpl:   types.EdgeNodeCert{},
 		Activate:    false,
+		Persistent:  true,
 		Ctx:         ctx,
 		WarningTime: warningTime,
 		ErrorTime:   errorTime,

--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -134,6 +134,9 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		case change := <-ctx.subDeviceNetworkStatus.MsgChan():
 			ctx.subDeviceNetworkStatus.ProcessChange(change)
 
+		case change := <-ctx.decryptCipherContext.SubEdgeNodeCert.MsgChan():
+			ctx.decryptCipherContext.SubEdgeNodeCert.ProcessChange(change)
+
 		// This wait can take an unbounded time since we wait for IP
 		// addresses. Punch StillRunning
 		case <-stillRunning.C:

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -27,7 +27,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/ssh"
 	"github.com/lf-edge/eve/pkg/pillar/types"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 )
 
@@ -233,6 +233,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		MyAgentName: agentName,
 		TopicImpl:   types.EdgeNodeCert{},
 		Activate:    false,
+		Persistent:  true,
 		Ctx:         &nimCtx,
 		WarningTime: warningTime,
 		ErrorTime:   errorTime,
@@ -442,6 +443,9 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 			log.Noticef("Got subDevicePortConfigS: len %d",
 				len(dnc.DevicePortConfigList.PortConfigList))
 
+		case change := <-subEdgeNodeCert.MsgChan():
+			subEdgeNodeCert.ProcessChange(change)
+
 		case change, ok := <-linkChanges:
 			start := time.Now()
 			if !ok {
@@ -479,6 +483,9 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		select {
 		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
+
+		case change := <-subEdgeNodeCert.MsgChan():
+			subEdgeNodeCert.ProcessChange(change)
 
 		case change := <-subDevicePortConfigO.MsgChan():
 			subDevicePortConfigO.ProcessChange(change)

--- a/pkg/pillar/cmd/tpmmgr/tpmmgr.go
+++ b/pkg/pillar/cmd/tpmmgr/tpmmgr.go
@@ -1377,8 +1377,9 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 		pubEdgeNodeCert, err := ps.NewPublication(
 			pubsub.PublicationOptions{
-				AgentName: agentName,
-				TopicType: types.EdgeNodeCert{},
+				AgentName:  agentName,
+				Persistent: true,
+				TopicType:  types.EdgeNodeCert{},
 			})
 		if err != nil {
 			log.Fatal(err)

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -701,6 +701,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		MyAgentName:   agentName,
 		TopicImpl:     types.EdgeNodeCert{},
 		Activate:      false,
+		Persistent:    true,
 		Ctx:           &zedagentCtx,
 		CreateHandler: handleEdgeNodeCertCreate,
 		ModifyHandler: handleEdgeNodeCertModify,

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -361,6 +361,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		MyAgentName: agentName,
 		TopicImpl:   types.EdgeNodeCert{},
 		Activate:    false,
+		Persistent:  true,
 		Ctx:         &zedrouterCtx,
 		WarningTime: warningTime,
 		ErrorTime:   errorTime,

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -521,6 +521,11 @@ else
     fi
 fi
 
+echo "$(date -Ins -u) Starting tpmmgr as a service agent"
+$BINDIR/tpmmgr runAsService &
+wait_for_touch tpmmgr
+touch "$WATCHDOG_FILE/tpmmgr.touch"
+
 # XXX to handle a downgrade we need a /config/uuid file to boot old EVE
 if [ ! -f $CONFIGDIR/uuid ]; then
     echo "$(date -Ins -u) cp -p $PERSISTDIR/status/uuid $CONFIGDIR/uuid"
@@ -549,11 +554,6 @@ done
 $BINDIR/vaultmgr runAsService &
 wait_for_touch vaultmgr
 touch "$WATCHDOG_FILE/vaultmgr.touch"
-
-echo "$(date -Ins -u) Starting tpmmgr as a service agent"
-$BINDIR/tpmmgr runAsService &
-wait_for_touch tpmmgr
-touch "$WATCHDOG_FILE/tpmmgr.touch"
 
 # Now run watchdog for all agents
 for AGENT in $AGENTS; do


### PR DESCRIPTION
Signed-off-by: Naiming Shen <naiming@zededa.com>
- move the tpmmgr EdgeNodeCert publication to /persist
- have the subscription to read the EdgeNodeCert earlier
- have tested on e50 wifi device, it decrypted certblock fine at bootup time
- will see if there is any more errors after this change