### PR TITLE
Handle missing /usr/bin/sudo under container's rootfs.

### DIFF
--- a/pkg/pillar/containerd/oci.go
+++ b/pkg/pillar/containerd/oci.go
@@ -170,7 +170,12 @@ func (s *ociSpec) AddLoader(volume string) error {
 			if s.Process.User.GID != 0 {
 				groupInsert = fmt.Sprintf("-g '#%d'", s.Process.User.GID)
 			}
-			execpath = fmt.Sprintf("/usr/bin/sudo -u '#%d' %s %s %s", s.Process.User.UID, groupInsert, envInsert, execpath)
+			execpathWithUser := fmt.Sprintf("/usr/bin/sudo -u '#%d' %s %s %s", s.Process.User.UID, groupInsert,
+				envInsert, execpath)
+			if err := ioutil.WriteFile(filepath.Join(volumeRoot, "cmdline_with_user"),
+				[]byte(execpathWithUser), 0644); err != nil {
+				return err
+			}
 		}
 		if err := ioutil.WriteFile(filepath.Join(volumeRoot, "cmdline"),
 			[]byte(execpath), 0644); err != nil {

--- a/pkg/xen-tools/initrd/init-initrd
+++ b/pkg/xen-tools/initrd/init-initrd
@@ -105,6 +105,18 @@ echo "Run acpid daemon"
 acpid -l /proc/self/fd/1
 
 cmd=`cat /mnt/cmdline`
+
+if [ -f /mnt/cmdline_with_user ];
+then
+  if [ -f /mnt/rootfs/usr/bin/sudo ];
+  then
+    cmd=$(cat /mnt/cmdline_with_user)
+    echo "Rootfs has '/usr/bin/sudo'. Using '$cmd' as exec command"
+  else
+    echo "Rootfs does not have '/usr/bin/sudo'. Using '$cmd' as exec command"
+  fi
+fi
+
 echo "Executing $cmd"
 #shellcheck disable=SC2086
 eval /chroot2 /mnt/rootfs "${WORKDIR:-/}" $cmd <> /dev/console 2>&1


### PR DESCRIPTION
Issue: `nodered/node-red:latest` container failed to boot.

Cause: Since that container's config had a UID, we added `/usr/bin/sudo -u ...` prefix to the container's exec command. But in the case of nodered, `/usr/bin/sudo` was not present under the container's rootfs and that led to the init command crashing on boot. 

Proposed fix: Check if `/mnt/rootfs/usr/bin/sudo` is present if we have added the `/usr/bin/sudo -u ...` prefix. If not then use the exec command as it is without the prefix. 

Signed-off-by: adarsh-zededa <adarsh@zededa.com>