### PR TITLE
unmount rootfs of containers on doInactivate

### DIFF
--- a/pkg/pillar/cas/cas.go
+++ b/pkg/pillar/cas/cas.go
@@ -105,6 +105,9 @@ type CAS interface {
 	// The rootPath is expected to end in a basename that becomes the snapshotID
 	PrepareContainerRootDir(rootPath, reference, rootBlobSha string) error
 
+	// UnmountContainerRootDir unmounts container's rootPath.
+	UnmountContainerRootDir(rootPath string) error
+
 	// RemoveContainerRootDir removes contents of a container's rootPath, existing snapshot and reference.
 	RemoveContainerRootDir(rootPath string) error
 


### PR DESCRIPTION
In my experiments with zfs-kvm I see errors 
```
state: PURGING: [description:"doActivate: Failed mount snapshot: 07887c71-2249-4ff7-8a0d-21cb1b804f14#0.container for f416c744-e01f-4b45-8b43-fc1916e01247. Error MountSnapshot: Exception while fetching mounts of snapshot: 07887c71-2249-4ff7-8a0d-21cb1b804f14#0.container. device or resource busy" timestamp:{seconds:1622120958 nanos:489636236}] received in: 2021-05-27T13:09:18.905436106Z
```
It comes when I try to stop and restart container-in-VM.
Seems, we do mount, but do not call unmount on stop of app.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>