### PR TITLE
eden tests sync and workflow improvements

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -23,7 +23,7 @@ jobs:
       - name: setup
         run: |
           sudo apt update
-          sudo apt install -y qemu-utils qemu-system-x86
+          sudo apt install -y qemu-utils qemu-system-x86 jq
       - name: get eden
         uses: actions/checkout@v2
         with:
@@ -75,8 +75,25 @@ jobs:
         run: |
           ./eden log --format json > trace.log || echo "no log"
           ./eden info > info.log || echo "no info"
+          ./eden metric > metric.log || echo "no metric"
+          ./eden netstat > netstat.log || echo "no netstat"
           cp dist/default-eve.log console.log || echo "no device log"
           docker logs eden_adam > adam.log 2>&1 || echo "no adam log"
+      - name: Log counting
+        if: ${{ always() }}
+        run: |
+          echo "::group::Total errors"
+          echo "$(jq '.severity' trace.log|grep err|wc -l)"
+          echo "::endgroup::"
+          echo "::group::Errors by source"
+          echo "errors by source: $(jq -s 'map(select(.severity|contains("err")))|group_by(.source)|map({"source": .[0].source, "total":length})|sort_by(.total)|reverse[]' trace.log)"
+          echo "::endgroup::"
+          echo "::group::Error log content duplicates"
+          echo "$(jq -s 'map(select(.severity | contains("err")))|group_by(.content)|map(select(length>1))' trace.log)"
+          echo "::endgroup::"
+          echo "::group::Error log function filename duplicates"
+          echo "$(jq -s 'map(select(.severity | contains("err")))|group_by(.filename)|map(select(length>10))|map({"source": .[0].source, "filename": .[0].filename, "function": .[0].function, "content": [.[].content], "total":length})|sort_by(.total)| reverse[]' trace.log)"
+          echo "::endgroup::"
       - name: Store raw test results
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
@@ -85,5 +102,7 @@ jobs:
           path: |
             ${{ github.workspace }}/trace.log
             ${{ github.workspace }}/info.log
+            ${{ github.workspace }}/metric.log
+            ${{ github.workspace }}/netstat.log
             ${{ github.workspace }}/console.log
             ${{ github.workspace }}/adam.log

--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -90,8 +90,25 @@ jobs:
         run: |
           ./eden log --format json > trace.log || echo "no log"
           ./eden info > info.log || echo "no info"
+          ./eden metric > metric.log || echo "no metric"
+          ./eden netstat > netstat.log || echo "no netstat"
           docker logs eden_adam > adam.log 2>&1 || echo "no adam log"
           ./eden utils gcp vm log --vm-name eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} -k "$GOOGLE_APPLICATION_CREDENTIALS" > console.log || echo "no device log"
+      - name: Log counting
+        if: ${{ always() }}
+        run: |
+          echo "::group::Total errors"
+          echo "$(jq '.severity' trace.log|grep err|wc -l)"
+          echo "::endgroup::"
+          echo "::group::Errors by source"
+          echo "errors by source: $(jq -s 'map(select(.severity|contains("err")))|group_by(.source)|map({"source": .[0].source, "total":length})|sort_by(.total)|reverse[]' trace.log)"
+          echo "::endgroup::"
+          echo "::group::Error log content duplicates"
+          echo "$(jq -s 'map(select(.severity | contains("err")))|group_by(.content)|map(select(length>1))' trace.log)"
+          echo "::endgroup::"
+          echo "::group::Error log function filename duplicates"
+          echo "$(jq -s 'map(select(.severity | contains("err")))|group_by(.filename)|map(select(length>10))|map({"source": .[0].source, "filename": .[0].filename, "function": .[0].function, "content": [.[].content], "total":length})|sort_by(.total)| reverse[]' trace.log)"
+          echo "::endgroup::"
       - name: Clean
         if: ${{ always() }}
         run: |
@@ -108,4 +125,6 @@ jobs:
             ${{ github.workspace }}/trace.log
             ${{ github.workspace }}/info.log
             ${{ github.workspace }}/adam.log
+            ${{ github.workspace }}/netstat.log
+            ${{ github.workspace }}/metric.log
             ${{ github.workspace }}/console.log

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,7 @@
+---
+extends: default
+
+rules:
+    line-length:
+        max: 300
+        level: warning

--- a/tests/eden/eclient/testdata/acl.txt
+++ b/tests/eden/eclient/testdata/acl.txt
@@ -2,6 +2,14 @@
 
 {{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@{{end}}
 
+# source for very long domains: https://longest.domains/
+{{$long_domain := "theofficialabsolutelongestdomainnameregisteredontheworldwideweb.international"}}
+
+# non-existent domain statically assigned to an (existing public) IP address through a host file
+{{$fake_domain := "this-fake-domain-is-associated-with-zededa.com"}}
+
+{{$network_name := "n1"}}
+
 [!exec:bash] stop
 [!exec:sleep] stop
 [!exec:ssh] stop
@@ -12,26 +20,68 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 # Starting of reboot detector with a 1 reboot limit
 ! test eden.reboot.test -test.v -timewait 40m -reboot=0 -count=1 &
 
-# Define access only to github.com
-eden pod deploy -n curl-acl --memory=512MB docker://itmoeve/eclient:0.4 -p 2223:22 --acl=github.com
+message 'Resetting of EVE'
+eden eve reset
+exec sleep 20
 
-test eden.app.test -test.v -timewait 10m RUNNING curl-acl
+# use zededa.com IP address as a target for $fake_domain
+exec -t 10m bash dns_lookup.sh zededa.com
+# read the result of dns lookup (host_ip variable)
+source .env
+
+# Create network for which ACLs will be defined.
+eden network create 10.11.12.0/24 -n {{$network_name}} -s {{$fake_domain}}:$host_ip
+test eden.network.test -test.v -timewait 10m ACTIVATED {{$network_name}}
+
+# First app is only allowed to access github.com and $long_domain.
+eden pod deploy -n curl-acl1 --memory=512MB docker://itmoeve/eclient:0.4 -p 2223:22 --networks={{$network_name}} --acl={{$network_name}}:github.com --acl={{$network_name}}:{{$long_domain}}
+# Second app is only allowed to access $long_domain and $fake_domain.
+eden pod deploy -n curl-acl2 --memory=512MB docker://itmoeve/eclient:0.4 -p 2224:22 --networks={{$network_name}} --acl={{$network_name}}:{{$long_domain}} --acl={{$network_name}}:{{$fake_domain}}
+
+test eden.app.test -test.v -timewait 10m RUNNING curl-acl1 curl-acl2
 
 exec -t 10m bash wait_ssh.sh 2223
+exec -t 10m bash wait_ssh.sh 2224
 
 exec sleep 10
 
-# Try to curl host we defined
+# Try to curl hosts allowed by ACLs
 exec -t 1m bash curl.sh 2223 github.com
 stderr 'Connected to github.com'
-
-# Try to curl another host
+exec -t 1m bash curl.sh 2223 {{$long_domain}}
+stderr 'Connected to {{$long_domain}}'
+! exec -t 1m bash curl.sh 2223 {{$fake_domain}}
+! stderr 'Connected'
 ! exec -t 1m bash curl.sh 2223 google.com
 ! stderr 'Connected'
 
-eden pod delete curl-acl
+exec -t 1m bash curl.sh 2224 {{$long_domain}}
+stderr 'Connected to {{$long_domain}}'
+# TODO: ACLs + static DNS entries do not work together
+#exec -t 1m bash curl.sh 2224 {{$fake_domain}}
+#stderr 'Connected to {{$fake_domain}}'
+! exec -t 1m bash curl.sh 2224 github.com
+! stderr 'Connected'
+! exec -t 1m bash curl.sh 2224 google.com
+! stderr 'Connected'
 
-test eden.app.test -test.v -timewait 10m - curl-acl
+# Wait for network packets information
+exec -t 20m bash wait_netstat.sh {{$network_name}} google.com github.com {{$long_domain}} {{$fake_domain}}
+stdout 'google.com'
+stdout 'github.com'
+stdout '{{$long_domain}}'
+stdout '{{$fake_domain}}'
+
+# Cleanup - undeploy applications
+eden pod delete curl-acl1
+eden pod delete curl-acl2
+test eden.app.test -test.v -timewait 10m - curl-acl1 curl-acl2
+
+# Cleanup - remove network
+eden network delete {{$network_name}}
+test eden.network.test -test.v -timewait 10m - {{$network_name}}
+eden network ls
+! stdout '^{{$network_name}}\s'
 
 -- wait_ssh.sh --
 
@@ -48,6 +98,15 @@ do
   done
 done
 
+-- dns_lookup.sh --
+
+# Performs DNS lookup for a given hostname and adds host_ip=<ip> into the .env file
+# The script uses 'getent' command to avoid dependencies on tools like 'host', 'dig', etc.
+# Usage: dns_lookup.sh <hostname>
+
+IP=$(getent hosts $1 | head -n 1 | cut -d ' ' -f 1)
+echo host_ip=$IP>>.env
+
 -- curl.sh --
 
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
@@ -55,6 +114,17 @@ HOST=$($EDEN eve ip)
 
 echo {{template "ssh"}}$HOST -p $1 curl -v --max-time 30 "$2"
 {{template "ssh"}}$HOST -p $1 curl -v --max-time 30 "$2"
+
+-- wait_netstat.sh --
+#!/bin/sh
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+
+echo "Waiting for netstat results"
+for p in ${@: 2}
+do
+  until "$EDEN" network netstat $1 | grep $p; do sleep 30; done
+done
+"$EDEN" network netstat $1
 
 -- eden-config.yml --
 {{/* Test's config file */}}

--- a/tests/eden/eclient/testdata/air-gapped-switch.txt
+++ b/tests/eden/eclient/testdata/air-gapped-switch.txt
@@ -1,0 +1,120 @@
+# Test air-gapped-switch is verifying that we can use a switch network instance without uplink and communicates through it between apps.
+
+{{define "port1"}}2223{{end}}
+{{define "mac1"}}00:01:02:03:04:01{{end}}
+{{define "ip1"}}11.12.13.11{{end}}
+{{define "port2"}}2224{{end}}
+{{define "mac2"}}00:01:02:03:04:02{{end}}
+{{define "ip2"}}11.12.13.12{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@{{end}}
+
+[!exec:bash] stop
+[!exec:sleep] stop
+[!exec:ssh] stop
+[!exec:chmod] stop
+
+exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
+
+# Starting of reboot detector with 2 reboots limit
+! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+
+message 'Resetting of EVE'
+eden eve reset
+exec sleep 20
+
+message 'Creating networks: local indirect and air-gapped switch direct'
+eden network create 10.11.12.0/24 -n indirect
+eden network create --type switch --uplink none -n direct
+
+test eden.network.test -test.v -timewait 10m ACTIVATED indirect direct
+
+message 'Starting applications'
+eden pod deploy -v debug -n eclient1 docker://itmoeve/eclient:0.7 -p {{template "port1"}}:22 --networks=indirect --networks=direct:{{template "mac1"}} --memory=512MB
+eden pod deploy -v debug -n eclient2 docker://itmoeve/eclient:0.7 -p {{template "port2"}}:22 --networks=indirect --networks=direct:{{template "mac2"}} --memory=512MB
+
+message 'Waiting for running state'
+test eden.app.test -test.v -timewait 10m RUNNING eclient1 eclient2
+
+message 'Checking accessibility'
+exec -t 5m bash wait_ssh.sh {{template "port1"}} {{template "port2"}}
+
+message 'Assign address to eth1 and check mac for eclient1'
+exec -t 1m bash prepare1.sh
+stdout '{{template "mac1"}}'
+
+message 'Assign address to eth1 and check mac for eclient2'
+exec -t 1m bash prepare2.sh
+stdout '{{template "mac2"}}'
+
+message 'Testing of ping through switch'
+exec -t 1m bash ping.sh
+stdout '0% packet loss'
+
+eden pod delete eclient1
+eden pod delete eclient2
+
+test eden.app.test -test.v -timewait 10m - eclient1 eclient2
+
+eden network delete direct
+eden network delete indirect
+
+test eden.network.test -test.v -timewait 10m - direct indirect
+
+stdout 'no network with direct found'
+stdout 'no network with indirect found'
+
+eden network ls
+! stdout '^direct\s'
+! stdout '^indirect\s'
+
+-- wait_ssh.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+for p in $*
+do
+  for i in `seq 20`
+  do
+    # Test SSH-access to container
+    echo {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue
+    {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue && break
+    sleep 10
+  done
+done
+
+-- prepare1.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+echo {{template "ssh"}}$HOST -p {{template "port1"}} ip a add {{template "ip1"}}/24 dev eth1
+{{template "ssh"}}$HOST -p {{template "port1"}} ip a add {{template "ip1"}}/24 dev eth1
+
+echo {{template "ssh"}}$HOST -p {{template "port1"}} ip a
+{{template "ssh"}}$HOST -p {{template "port1"}} ip a
+
+-- prepare2.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+echo {{template "ssh"}}$HOST -p {{template "port2"}} ip a add {{template "ip2"}}/24 dev eth1
+{{template "ssh"}}$HOST -p {{template "port2"}} ip a add {{template "ip2"}}/24 dev eth1
+
+echo {{template "ssh"}}$HOST -p {{template "port2"}} ip a
+{{template "ssh"}}$HOST -p {{template "port2"}} ip a
+
+
+-- ping.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+echo {{template "ssh"}}$HOST -p {{template "port1"}} ping -I eth1 -c 10 {{template "ip2"}}
+{{template "ssh"}}$HOST -p {{template "port1"}} ping -I eth1 -c 10 {{template "ip2"}}
+
+-- eden-config.yml --
+{{/* Test's config. file */}}
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}

--- a/tests/eden/eclient/testdata/app_nonat.txt
+++ b/tests/eden/eclient/testdata/app_nonat.txt
@@ -1,0 +1,96 @@
+# Test app_nonat is verifying that we can use a switch network instance on a management port.
+
+{{define "port"}}2223{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{template "port"}} root@{{end}}
+
+[!exec:bash] stop
+[!exec:sleep] stop
+[!exec:ssh] stop
+[!exec:chmod] stop
+
+exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
+
+# Starting of reboot detector with 2 reboots limit
+! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+
+message 'Resetting of EVE'
+eden eve reset
+exec sleep 20
+
+message 'Creating networks'
+eden network create 10.11.12.0/24 -n indirect
+eden network create --type switch --uplink eth0 -n direct
+
+test eden.network.test -test.v -timewait 10m ACTIVATED indirect direct
+
+message 'Starting applications'
+eden pod deploy -v debug -n eclient docker://itmoeve/eclient:0.4 -p {{template "port"}}:22 --networks=indirect --networks=direct --memory=512MB
+
+message 'Waiting of running'
+test eden.app.test -test.v -timewait 30m RUNNING eclient
+
+message 'Checking accessibility'
+exec -t 5m bash wait_ssh.sh
+
+message 'Testing of network'
+exec sleep 20
+exec -t 1m bash ping.sh
+stdout '0% packet loss'
+
+message 'Removing ACLs from "direct" network'
+eden pod modify eclient --networks indirect --networks=direct --acl='direct:'
+test eden.app.test -test.v -timewait 30m RUNNING eclient
+
+message 'Checking accessibility'
+exec -t 5m bash wait_ssh.sh
+
+! exec -t 1m bash ping.sh
+stdout '100% packet loss'
+
+message 'Resource cleaning'
+eden pod delete eclient
+
+test eden.app.test -test.v -timewait 10m - eclient
+
+eden network delete direct
+eden network delete indirect
+
+test eden.network.test -test.v -timewait 10m - direct indirect
+
+stdout 'no network with direct found'
+stdout 'no network with indirect found'
+
+eden network ls
+! stdout '^direct\s'
+! stdout '^indirect\s'
+
+-- wait_ssh.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+for i in `seq 20`
+do
+  sleep 20
+  # Test SSH-access to container
+  echo {{template "ssh"}}$HOST grep -q Ubuntu /etc/issue
+  {{template "ssh"}}$HOST grep -q Ubuntu /etc/issue && break
+done
+
+-- ping.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+echo {{template "ssh"}}$HOST sysctl net.ipv4.conf.eth1.rp_filter=2
+{{template "ssh"}}$HOST sysctl net.ipv4.conf.eth1.rp_filter=2
+echo {{template "ssh"}}$HOST ping -I eth1 -c 50 www.google.com
+{{template "ssh"}}$HOST ping -I eth1 -c 50 www.google.com
+
+-- eden-config.yml --
+{{/* Test's config. file */}}
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}

--- a/tests/eden/eclient/testdata/com-pt_test.txt
+++ b/tests/eden/eclient/testdata/com-pt_test.txt
@@ -1,0 +1,121 @@
+# EDEN test which assumes a serial port.
+# Verifying that a reboot from the guest doesn’t disrupt the set of assigned adapters.
+# We can not test that the serial port is functional; merely that it exists.
+
+{{define "port"}}2223{{end}}
+{{define "ssh"}} ssh -oServerAliveInterval=10 -oConnectTimeout=10 -oStrictHostKeyChecking=no -oPasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{template "port"}} root@$HOST {{end}}
+
+[!exec:bash] stop
+[!exec:sleep] stop
+[!exec:ssh] stop
+[!exec:chmod] stop
+[!exec:jq] stop
+
+exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
+
+# Starting of reboot detector with a 2 reboot limit
+! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+
+eden pod deploy -n eclient --memory=512MB docker://itmoeve/eclient:0.7 -p {{template "port"}}:22
+
+test eden.app.test -test.v -timewait 20m RUNNING eclient
+
+exec -t 20m bash ssh.sh
+stdout 'Ubuntu'
+
+# COM2 not in passthrough
+exec -t 20m bash get_serial.sh /dev/ttyS1
+stdout '/dev/ttyS1, UART: unknown, Port: 0x02f8, IRQ: 3'
+
+# COM2 passthrough setup
+exec -t 20m bash set_serial.sh eclient
+stdout 'msg="Config loaded"'
+# Wait for reconfig
+exec -t 20m bash ssh.sh
+stdout 'Ubuntu'
+
+# COM2 in passthrough
+exec -t 20m bash get_serial.sh /dev/ttyS1
+stdout '/dev/ttyS1, UART: 16550A, Port: 0x02f8, IRQ: 3'
+
+exec -t 5m bash get_reboot_time.sh
+cp stdout reboot_time
+
+# Reboot application
+! exec -t 1m bash reboot.sh
+
+# Wait for reboot
+exec -t 20m bash ssh.sh
+stdout 'Ubuntu'
+
+exec -t 5m bash get_reboot_time.sh
+! cmp stdout reboot_time
+
+# COM2 in passthrough
+exec -t 20m bash get_serial.sh /dev/ttyS1
+stdout '/dev/ttyS1, UART: 16550A, Port: 0x02f8, IRQ: 3'
+
+eden pod delete eclient
+
+test eden.app.test -test.v -timewait 10m - eclient
+
+-- ssh.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+for i in `seq 20`
+do
+sleep 20
+# Test SSH-access to container
+echo $i\) {{template "ssh"}} grep Ubuntu /etc/issue
+{{template "ssh"}} grep Ubuntu /etc/issue && break
+done
+
+-- set_serial.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+CNF=eve.cfg
+
+$EDEN controller edge-node get-config --file $CNF
+
+jq '.deviceIoList += [{ "ptype": "PhyIoCOM", "phylabel": "COM2", "phyaddrs": { "Ioports": "2f8-2ff", "Irq": "3", "Serial": "/dev/ttyS1" }, "logicallabel": "COM2", "assigngrp": "COM2", "usage": "PhyIoUsageNone", "usagePolicy": { "freeUplink": false, "fallBackPriority": 0 }, "cbattr": {} }]' < $CNF | \
+jq '.apps = (.apps | map(if .displayname == "'$1'" then . + {"adapters":[{"type": "PhyIoCOM", "name": "COM2"}]} else del(.adapters) end))' | \
+jq '.apps = (.apps | map(if .displayname == "'$1'" then . + {"purge": {"counter": 1}} else . end))' > $CNF.new
+
+$EDEN controller edge-node set-config --file $CNF.new
+
+-- get_serial.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+for i in `seq 20`
+do
+sleep 20
+# Test SSH-access to container
+echo $i\) {{template "ssh"}} setserial -g $1
+{{template "ssh"}} setserial -g $1 && break
+done
+
+-- get_reboot_time.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+echo {{template "ssh"}} uptime -s
+{{template "ssh"}} uptime -s
+
+-- reboot.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+echo {{template "ssh"}} reboot
+{{template "ssh"}} reboot
+
+-- eden-config.yml --
+{{/* Test's config. file */}}
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}

--- a/tests/eden/eclient/testdata/mount.txt
+++ b/tests/eden/eclient/testdata/mount.txt
@@ -1,0 +1,51 @@
+# Test for additional disk mounted to eclient
+
+{{$port := "2223"}}
+
+[!exec:bash] stop
+[!exec:sleep] stop
+[!exec:ssh] stop
+
+exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
+
+# Starting of reboot detector with a 1 reboot limit
+! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=1 &
+
+eden pod deploy -n eclient-mount --memory=512MB docker://itmoeve/eclient:0.7 -p {{$port}}:22 --mount=src=docker://nginx:1.20.0,dst=/tst --mount=src={{EdenConfig "eden.tests"}}/eclient/testdata,dst=/dir
+
+test eden.app.test -test.v -timewait 20m RUNNING eclient-mount
+
+exec -t 5m bash ssh.sh /tst
+stdout 'docker-entrypoint.sh'
+
+exec -t 5m bash ssh.sh /dir
+stdout 'mount.txt'
+
+eden volume ls
+stdout '/dir'
+stdout '/tst'
+
+eden pod delete eclient-mount
+
+test eden.app.test -test.v -timewait 10m - eclient-mount
+
+-- eden-config.yml --
+{{/* Test's config. file */}}
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+
+-- ssh.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+for i in `seq 20`
+do
+sleep 20
+# Test SSH-access to container
+echo $i\) ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{$port}} root@$HOST ls $*
+ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{$port}} root@$HOST ls $* && break
+done

--- a/tests/eden/eclient/testdata/nw_switch.txt
+++ b/tests/eden/eclient/testdata/nw_switch.txt
@@ -50,7 +50,8 @@ stdout '100% packet loss'
 
 message 'Switching to 2st network'
 eden pod modify pong --networks n2
-test eden.app.test -test.v -timewait 20m RUNNING pong
+test eden.app.test -test.v -timewait 5m PURGING pong
+test eden.app.test -test.v -timewait 10m RUNNING pong
 eden pod ps
 cp stdout pod_ps
 exec bash pong_ip.sh
@@ -65,7 +66,8 @@ stdout '0% packet loss'
 
 message 'Switching back to 1st network'
 eden pod modify pong --networks n1
-test eden.app.test -test.v -timewait 20m RUNNING pong
+test eden.app.test -test.v -timewait 5m PURGING pong
+test eden.app.test -test.v -timewait 10m RUNNING pong
 eden pod ps
 cp stdout pod_ps
 exec bash pong_ip.sh

--- a/tests/eden/eclient/testdata/port_forward.txt
+++ b/tests/eden/eclient/testdata/port_forward.txt
@@ -1,6 +1,7 @@
 # Tests for port forward connectivity between applications
 
 {{$test_msg := "Port forward tests"}}
+{{$devmodel := EdenConfig "eve.devmodel"}}
 {{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@{{end}}
 
 [!exec:bash] stop
@@ -17,33 +18,108 @@ message 'Resetting of EVE'
 eden eve reset
 exec sleep 20
 
-message 'Creating networks'
-#exec sleep 5
+############################## TEST SCENARIO 1 ################################
+# Hairpin connectivity test between two apps connected to the same network instance
+
+message 'SCENARIO 1: Creating networks'
 eden network create 10.11.12.0/24 -n n1
-#exec sleep 5
-eden network create 10.11.13.0/24 -n n2
 
-test eden.network.test -test.v -timewait 10m ACTIVATED n1 n2
+test eden.network.test -test.v -timewait 10m ACTIVATED n1
 
-message 'Starting with both application attached to same network instance'
-eden pod deploy -v debug -n app1 docker://itmoeve/eclient:0.5 -p 2223:22 --networks=n1 --memory=512MB
-eden pod deploy -v debug -n app2 docker://itmoeve/eclient:0.5 -p 2224:22 --networks=n1 --memory=512MB
+message 'SCENARIO 1: Starting with both application attached to same network instance'
+eden pod deploy -v debug -n app1 docker://itmoeve/eclient:0.6 -p 2223:22 --networks=n1 --memory=512MB
+eden pod deploy -v debug -n app2 docker://itmoeve/eclient:0.6 -p 2224:22 --networks=n1 --memory=512MB
 
-message 'Waiting for apps to enter RUNNING state'
+message 'SCENARIO 1: Waiting for apps to enter RUNNING state'
 test eden.app.test -test.v -timewait 20m RUNNING app1 app2
 
-message 'Checking accessibility'
+message 'SCENARIO 1: Checking accessibility'
 exec -t 5m bash wait_ssh.sh 2223 2224
 
 eden eve status
 cp stdout eve_status
 
-message 'Testing port map connectivity between apps'
+message 'SCENARIO 1: Testing port map connectivity between apps'
 exec sleep 20
-exec -t 1m bash ping.sh 2223 2224
+exec -t 1m bash test_connectivity.sh 2223 2224
 stdout 'Ubuntu'
 
-message 'Resource cleanng'
+{{if or (eq $devmodel "ZedVirtual-4G") (eq $devmodel "VBox") }}
+message 'SCENARIO 1: Simulating network outage'
+eden eve link down
+# keep link down long enough for EVE to notice and un-configure port maps
+exec sleep 60
+! exec -t 1m bash check_ssh.sh 2223 2224
+eden eve link up
+# give EVE some time to recover (largely depends on the DHCP server)
+exec sleep 20
+exec -t 5m bash wait_ssh.sh 2223 2224
+exec -t 1m bash test_connectivity.sh 2223 2224
+stdout 'Ubuntu'
+{{end}}
+
+message 'SCENARIO 1: Resource cleaning'
+eden pod delete app1
+eden pod delete app2
+
+test eden.app.test -test.v -timewait 10m - app1 app2
+
+eden network delete n1
+
+test eden.network.test -test.v -timewait 10m - n1
+
+stdout 'no network with n1 found'
+
+eden network ls
+! stdout '^n1\s'
+
+############################## TEST SCENARIO 2 ################################
+# Hairpin connectivity test between two apps connected to two different network instances.
+# These two network instances have different uplink adapters attached to them. And these adapters
+# get different IP addresses from the same subnet with DHCP.
+
+{{$osruntime := EdenOSRuntime}}
+{{$allowSlirpRouting := EdenCheckSlirpSupportRouting}}
+
+{{if (eq $osruntime "linux")}}
+{{if or (and (eq $devmodel "ZedVirtual-4G") $allowSlirpRouting) (eq $devmodel "VBox") }}
+message 'SCENARIO 2: Creating networks'
+eden network create 10.11.12.0/24 -n n1
+eden network create 10.11.13.0/24 -n n2 --uplink eth1
+
+test eden.network.test -test.v -timewait 10m ACTIVATED n1 n2
+
+message 'SCENARIO 2: Starting with each application attached to a different network instance'
+eden pod deploy -v debug -n app1 docker://itmoeve/eclient:0.6 -p 2223:22 --networks=n1 --memory=512MB
+eden pod deploy -v debug -n app2 docker://itmoeve/eclient:0.6 -p 2234:22 --networks=n2 --memory=512MB
+
+message 'SCENARIO 2: Waiting for apps to enter RUNNING state'
+test eden.app.test -test.v -timewait 20m RUNNING app1 app2
+
+message 'SCENARIO 2: Checking accessibility'
+exec -t 5m bash wait_ssh.sh 2223 2234
+
+eden eve status
+cp stdout eve_status
+
+message 'SCENARIO 2: Testing port map connectivity between apps'
+exec sleep 20
+exec -t 1m bash test_connectivity.sh 2234 2223
+stdout 'Ubuntu'
+
+message 'SCENARIO 2: Simulating network outage'
+eden eve link down
+# keep link down long enough for EVE to notice and un-configure port maps
+exec sleep 60
+! exec -t 1m bash check_ssh.sh 2223 2234
+eden eve link up
+# give EVE some time to recover (largely depends on the DHCP server)
+exec sleep 20
+exec -t 5m bash wait_ssh.sh 2223 2234
+exec -t 1m bash test_connectivity.sh 2234 2223
+stdout 'Ubuntu'
+
+message 'SCENARIO 2: Resource cleaning'
 eden pod delete app1
 eden pod delete app2
 
@@ -60,6 +136,8 @@ stdout 'no network with n2 found'
 eden network ls
 ! stdout '^n1\s'
 ! stdout '^n2\s'
+{{end}}
+{{end}}
 
 -- wait_ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
@@ -76,12 +154,24 @@ do
   done
 done
 
--- ping.sh --
+-- check_ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 HOST=$($EDEN eve ip)
 
-echo {{template "ssh"}}$HOST -p $1 sh /root/portmap_test.sh -p $2
-{{template "ssh"}}$HOST -p $1 sh /root/portmap_test.sh $2
+for p in $*
+do
+  echo {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue
+  {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue || exit
+done
+
+-- test_connectivity.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+EVE_IP=$({{template "ssh"}}$HOST -p $2 sh /root/get_eve_ip.sh)
+echo "$EVE_IP"
+
+echo {{template "ssh"}}$HOST -p $1 sh /root/portmap_test.sh $EVE_IP $2
+{{template "ssh"}}$HOST -p $1 sh /root/portmap_test.sh $EVE_IP $2
 
 -- eden-config.yml --
 {{/* Test's config. file */}}

--- a/tests/eden/eclient/testdata/profile.txt
+++ b/tests/eden/eclient/testdata/profile.txt
@@ -1,0 +1,163 @@
+# Test local manager and profiles
+
+{{define "profile_server_token"}}server_token_123{{end}}
+{{define "profile_server_file"}}/mnt/profile{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@{{end}}
+
+[!exec:bash] stop
+[!exec:sleep] stop
+[!exec:ssh] stop
+[!exec:chmod] stop
+
+exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
+
+# Starting of reboot detector with a 1 reboot limit
+! test eden.reboot.test -test.v -timewait 100m -reboot=0 -count=1 &
+
+message 'Resetting of EVE'
+eden eve reset
+exec sleep 20
+
+# Define local-manager and two apps in different profiles
+# TBD: static ip in pod deploy
+eden pod deploy -n local-manager --memory=512MB docker://itmoeve/eclient:0.8 -p 2223:22
+
+test eden.app.test -test.v -timewait 10m RUNNING local-manager
+
+eden pod deploy -n app-profile-1 --memory=512MB docker://itmoeve/eclient:0.8 --profile=profile-1
+eden pod deploy -n app-profile-2 --memory=512MB docker://itmoeve/eclient:0.8 --profile=profile-2
+eden pod deploy -n app-profile-1-2 --memory=512MB docker://itmoeve/eclient:0.8 --profile=profile-1 --profile=profile-2
+
+# We have empty local_manager and empty default_profile, so apps should be in RUNNING state
+test eden.app.test -test.v -timewait 20m RUNNING app-profile-1 app-profile-2 app-profile-1-2 local-manager
+
+exec sleep 20
+
+# STEP 1: global_profile=profile-1
+
+eden controller edge-node update --device global_profile=profile-1
+
+# We set default_profile to profile-1, so app-profile-2 should be in HALTED state
+test eden.app.test -test.v -timewait 15m HALTED app-profile-2
+test eden.app.test -test.v -timewait 5m RUNNING app-profile-1 app-profile-1-2 local-manager
+
+exec sleep 20
+
+# STEP 2: global_profile=profile-2
+eden controller edge-node update --device global_profile=profile-2
+
+# We set default_profile to profile-2, so app-profile-1 should be in HALTED state
+test eden.app.test -test.v -timewait 15m HALTED app-profile-1
+test eden.app.test -test.v -timewait 5m RUNNING app-profile-2 app-profile-1-2 local-manager
+
+# STEP 3: global_profile=profile-3
+
+eden controller edge-node update --device global_profile=profile-3
+
+# We set default_profile to profile-3, so all apps against local-manager should be in HALTED state
+test eden.app.test -test.v -timewait 15m HALTED app-profile-1 app-profile-2 app-profile-1-2
+test eden.app.test -test.v -timewait 5m RUNNING local-manager
+
+exec sleep 20
+
+# STEP 4: stop app from controller with defined profile
+eden pod stop local-manager
+test eden.app.test -test.v -timewait 15m HALTED local-manager
+
+eden pod start local-manager
+test eden.app.test -test.v -timewait 5m RUNNING local-manager
+
+# Wait for ssh access
+exec -t 5m bash wait_ssh.sh 2223
+
+# start local manager application
+exec -t 1m bash local-manager-start.sh 2223
+
+# TBD: obtain IP address
+eden controller edge-node update --device profile_server_token={{template "profile_server_token"}}
+eden controller edge-node update --device local_profile_server=10.11.12.2:8888
+
+# STEP 5: overwrite with profile-1
+
+# Start local-manager.sh and wait for curl to serve response for EVE
+exec -t 1m bash local-manager-profile.sh 2223 profile-1
+
+# We set local_manager and use profile-1 in it, so app-profile-2 should be in HALTED state
+test eden.app.test -test.v -timewait 15m HALTED app-profile-2
+test eden.app.test -test.v -timewait 5m RUNNING app-profile-1 app-profile-1-2 local-manager
+
+exec sleep 20
+
+# STEP 6: overwrite with profile-2
+
+# Start local-manager.sh and wait for curl to serve response for EVE
+exec -t 1m bash local-manager-profile.sh 2223 profile-2
+
+# We set local_manager and use profile-2 in it, so app-profile-1 should be in HALTED state
+test eden.app.test -test.v -timewait 15m HALTED app-profile-1
+test eden.app.test -test.v -timewait 5m RUNNING app-profile-2 app-profile-1-2 local-manager
+
+exec sleep 20
+
+# STEP 7: overwrite with profile-3
+
+# Start local-manager.sh and wait for curl to serve response for EVE
+exec -t 1m bash local-manager-profile.sh 2223 profile-3
+
+# We set local_manager and use profile-3 in it, so all apps against local-manager should be in HALTED state
+test eden.app.test -test.v -timewait 15m HALTED app-profile-1 app-profile-2 app-profile-1-2
+test eden.app.test -test.v -timewait 5m RUNNING local-manager
+
+exec sleep 20
+
+# STEP 8: return back to empty profiles
+
+eden controller edge-node update --device global_profile=""
+eden controller edge-node update --device local_profile_server=""
+
+# We have empty local_manager and empty default_profile, so apps should come back to RUNNING state now
+test eden.app.test -test.v -timewait 5m RUNNING app-profile-1 app-profile-2 app-profile-1-2 local-manager
+
+exec sleep 20
+
+eden pod delete app-profile-1
+eden pod delete app-profile-2
+eden pod delete app-profile-1-2
+eden pod delete local-manager
+
+test eden.app.test -test.v -timewait 15m - app-profile-1 app-profile-2 app-profile-1-2 local-manager
+
+-- wait_ssh.sh --
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+for p in $*
+do
+  for i in `seq 20`
+  do
+    sleep 20
+    # Test SSH-access to container
+    echo {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue
+    {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue && break
+  done
+done
+
+-- local-manager-start.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+{{template "ssh"}}$HOST -p $1 '/root/local_manager --token={{template "profile_server_token"}} --file={{template "profile_server_file"}} &>/dev/null &'
+
+-- local-manager-profile.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+{{template "ssh"}}$HOST -p $1 "echo $2>{{template "profile_server_file"}}"
+
+-- eden-config.yml --
+{{/* Test's config file */}}
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}

--- a/tests/eden/hardware_reboot/eden.hardware_reboot.tests.txt
+++ b/tests/eden/hardware_reboot/eden.hardware_reboot.tests.txt
@@ -1,1 +1,4 @@
 eden.escript.test -test.run TestEdenScripts/hardware_usb_reboot
+eden.escript.test -test.run TestEdenScripts/hardware_2usb_reboot
+eden.escript.test -test.run TestEdenScripts/hardware_audio_reboot
+

--- a/tests/eden/hardware_reboot/testdata/hardware_2usb_reboot.txt
+++ b/tests/eden/hardware_reboot/testdata/hardware_2usb_reboot.txt
@@ -1,0 +1,98 @@
+# Simple test of 2 USB passthrough functionality after reboot of guest
+# Works only on KVM
+
+{{define "port"}}2223{{end}}
+{{define "ssh"}} ssh -oServerAliveInterval=10 -oConnectTimeout=10 -oStrictHostKeyChecking=no -oPasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{template "port"}} root@$HOST {{end}}
+
+[!exec:bash] stop
+[!exec:sleep] stop
+[!exec:ssh] stop
+
+# Starting of reboot detector with a 2 reboot limit
+! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+
+eden pod deploy -n eclient --memory=512MB docker://itmoeve/eclient:0.7 -p {{template "port"}}:22 --adapters USB2:2 --adapters USB2:3
+
+test eden.app.test -test.v -timewait 20m RUNNING eclient
+
+exec -t 20m bash ssh.sh {{template "port"}}
+stdout 'Ubuntu'
+
+# Check usb_1
+exec -t 20m bash get-lshw.sh {{template "port"}}
+stdout '1024B QEMU HARDDISK'
+
+# Check usb_2
+exec -t 20m bash get-lshw.sh {{template "port"}}
+stdout '10MB QEMU HARDDISK'
+
+exec -t 5m bash get_reboot_time.sh
+cp stdout reboot_time
+
+# Reboot application
+! exec -t 1m bash reboot.sh
+
+# Wait for reboot
+exec -t 20m bash ssh.sh
+stdout 'Ubuntu'
+
+# Check usb_1
+exec -t 20m bash get-lshw.sh {{template "port"}}
+stdout '1024B QEMU HARDDISK'
+
+# Check usb_2
+exec -t 20m bash get-lshw.sh {{template "port"}}
+stdout '10MB QEMU HARDDISK'
+
+exec -t 5m bash get_reboot_time.sh
+#! cmp stdout reboot_time
+
+# teardown applications
+eden pod delete eclient
+
+test eden.app.test -test.v -timewait 20m - eclient
+
+-- eden-config.yml --
+{{/* Test's config. file */}}
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+
+-- ssh.sh --
+port=$1
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+for i in `seq 20`
+do
+sleep 20
+# Test SSH-access to container
+echo $i\) {{template "ssh"}} grep Ubuntu /etc/issue
+{{template "ssh"}} grep Ubuntu /etc/issue && break
+done
+
+
+-- get_reboot_time.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+echo {{template "ssh"}} uptime -s
+{{template "ssh"}} uptime -s
+
+-- get-lshw.sh --
+port=$1
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+ echo {{template "ssh"}} lshw -businfo
+ {{template "ssh"}} lshw -businfo
+
+-- reboot.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+echo {{template "ssh"}} reboot
+{{template "ssh"}} reboot

--- a/tests/eden/hardware_reboot/testdata/hardware_audio_reboot.txt
+++ b/tests/eden/hardware_reboot/testdata/hardware_audio_reboot.txt
@@ -1,0 +1,134 @@
+# Simple test of Audio device after reboot of guest
+
+{{define "port"}}2223{{end}}
+{{define "ssh"}} ssh -oServerAliveInterval=10 -oConnectTimeout=10 -oStrictHostKeyChecking=no -oPasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{template "port"}} ubuntu@$HOST {{end}}
+
+[!exec:bash] stop
+[!exec:sleep] stop
+[!exec:ssh] stop
+
+# Starting of eve reboot detector with a 1 reboot limit
+! test eden.reboot.test -test.v -timewait 60m -reboot=0 -count=1 &
+
+exec -t 20m bash deploy.sh {{template "port"}}
+test eden.app.test -test.v -timewait 30m RUNNING eclient
+
+exec -t 20m bash ssh.sh {{template "port"}}
+stdout 'Ubuntu'
+
+# Audio device passthrough setup
+exec -t 20m bash set_audio.sh eclient
+stdout 'msg="Config loaded"'
+
+# Wait for reconfig
+exec -t 20m bash ssh.sh
+stdout 'Ubuntu'
+
+# Install sound drivers
+exec -t 20m bash install_drivers.sh
+
+# Reboot application
+exec -t 5m bash reboot.sh
+
+# Wait for reboot for driver installation
+exec -t 20m bash ssh.sh
+stdout 'Ubuntu'
+
+# Get info about sound card
+exec -t 20m bash get_soundcard.sh
+stdout 'CARD=Intel'
+
+exec -t 10m bash get_reboot_time.sh
+cp stdout reboot_time
+
+# Reboot application
+exec -t 5m bash reboot.sh
+
+# Wait for reboot
+exec -t 20m bash ssh.sh
+stdout 'Ubuntu'
+
+exec -t 5m bash get_reboot_time.sh
+! cmp stdout reboot_time
+
+# Get info about sound card after reboot
+exec -t 20m bash get_soundcard.sh
+stdout 'CARD=Intel'
+
+# teardown applications
+eden pod delete eclient
+
+test eden.app.test -test.v -timewait 20m - eclient
+
+-- eden-config.yml --
+{{/* Test's config. file */}}
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+
+-- deploy.sh --
+port=$1
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+
+IMG="https://cloud-images.ubuntu.com/releases/focal/release-20210510/ubuntu-20.04-server-cloudimg-amd64.img"
+PUB_KEY="$( cat {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa.pub )"
+$EDEN pod deploy -n eclient --memory=1GB  ${IMG} -p $port:22 --metadata="#cloud-config\nssh_authorized_keys:\n - $PUB_KEY mykey@host"
+
+
+-- ssh.sh --
+port=$1
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+for i in `seq 20`
+do
+sleep 20
+# Test SSH-access to VM
+echo $i\) {{template "ssh"}} grep Ubuntu /etc/issue
+{{template "ssh"}} grep Ubuntu /etc/issue && break
+done
+
+-- set_audio.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+CNF=eve.cfg
+
+$EDEN controller edge-node get-config --file $CNF
+
+jq '.deviceIoList += [{ "ptype": "PhyIoAudio", "phylabel": "Audio", "phyaddrs": { "PciLong": "0000:00:1b.0" }, "logicallabel": "Audio", "assigngrp": "Audio", "usage": "PhyIoUsageNone", "usagePolicy": {}, "cbattr": {} }]' < $CNF | \
+jq '.apps = (.apps | map(if .displayname == "'$1'" then . + {"adapters":[{"type": "PhyIoAudio", "name": "Audio"}]} else del(.adapters) end))' | \
+jq '.apps = (.apps | map(if .displayname == "'$1'" then . + {"purge": {"counter": 1}} else . end))' > $CNF.new
+$EDEN controller edge-node set-config --file $CNF.new
+
+-- get_reboot_time.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+echo {{template "ssh"}} uptime -s
+{{template "ssh"}} uptime -s
+
+-- get_soundcard.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+echo {{template "ssh"}} aplay -L
+{{template "ssh"}} aplay -L
+
+-- reboot.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+echo {{template "ssh"}} 'sudo shutdown -r +1 &>/dev/null &'
+{{template "ssh"}} 'sudo shutdown -r +1 &>/dev/null &'
+
+-- install_drivers.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+echo {{template "ssh"}} 'sudo apt update && sudo apt-get install -y linux-modules-extra-`uname -r` alsa-utils'
+{{template "ssh"}} 'sudo apt update && sudo apt-get install -y linux-modules-extra-`uname -r` alsa-utils'
+

--- a/tests/eden/hardware_reboot/testdata/hardware_usb_reboot.txt
+++ b/tests/eden/hardware_reboot/testdata/hardware_usb_reboot.txt
@@ -1,43 +1,52 @@
 # Simple test of USB passthrough functionality after reboot of guest
 
-{{$usb_dev := "2-2"}}
+{{$port := "2223"}}
 
 [!exec:bash] stop
 [!exec:sleep] stop
 [!exec:ssh] stop
 
-eden pod deploy -n n11 --memory=512MB docker://itmoeve/eclient:0.4 -p 2223:22 --adapters USB2:2
+eden pod deploy -n n11 --memory=1GB https://cloud-images.ubuntu.com/releases/groovy/release-20210108/ubuntu-20.10-server-cloudimg-amd64.img --metadata='#cloud-config\nssh_authorized_keys:\n - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDOLVxfqzHzozOOBzbgLEAU66vTztBvIyKe9NH3ILb1f2gjlAKaPCinkDNH8m2bbbsccPfNWCuAKxNPN4ZWnXkYP0BnQKVnJxtES519PgyZLk6NlTzC4lsSJxWbkLOwV/3gjqBA7u+MQ+erJLFZQRUwtDq8LY2P0pQIsEiYFJi/SUjifADnBHhb3MXTWrxbRdiga8UH5Ksbz1HTBSGx0jwiaylsgN8qKs6N7TNMIYtGO1YZE9aMEFNHIW3zC5D5bzTBBa44FHtURXhLg6lVHXaPvBAUU5Q6QH9iyVxVNRQqO5EHO1Th0h0+lgWkRDFuVSu3gl/QR1MbRvRa10i/44jSnhQtuBZGS7Av7/Ef0ESymBp+4m2wBFFJQ6PpIZ2uu9iEVGFv2EbL0/gabOgjWauLlaCSG1PKG3p64C4qNvvXbMzfvsX1+yVLPw+Q59R5y3Q66wFpCrsd2OO5Cfp3WpGH51j8C7j6UWQAhXXDv+rdsu4VoJWCk8ulnZ1PRnLFHh3tw9VkESTXVxIo8BjxsbFiUWcMoXm6Nr3QnBGISRlDDutJ0ycxgZFjpLVpHCZLpM+NsVBiLIZ8Y3AHGaxW5vtD/oJAg2fc9APf0mwTMEEjeC0QCOgl5AijWxdaJFk3sXUqPp63oFKnIv7g//bSQ20Vuqor2JV8JaGDBExsMzZO4Q== mykey@host' -p {{$port}}:22 --adapters USB2:2
+
 test eden.app.test -test.v -timewait 20m RUNNING n11
 
-exec -t 20m bash ssh.sh 2223
+exec -t 20m bash ssh.sh {{$port}}
 stdout 'Ubuntu'
 
-exec -t 20m bash get-lshw.sh 2223
+exec -t 20m bash get-lshw.sh {{$port}}
+stdout 'QEMU USB HARDDRIVE'
+
+exec -t 20m bash get-lshw.sh {{$port}}
 cp stdout before_reboot
 
-exec -t 20m bash get-usb.sh 2223
-grep 'QEMU USB HARDDRIVE' {{$usb_dev}}.usb.product
+# get last reboot time
+exec -t 20m bash get-last-reboot-time.sh {{$port}}
+cp stdout timestamp1
 
 # reboot from guest
-exec -t 20m bash reboot.sh 2223
-exec sleep 10
+exec -t 20m bash reboot.sh {{$port}}
+exec sleep 5m
 
-exec -t 20m bash ssh.sh 2223
+exec -t 20m bash ssh.sh {{$port}}
 stdout 'Ubuntu'
 
-exec -t 20m bash get-usb.sh 2223
-grep 'QEMU USB HARDDRIVE' {{$usb_dev}}.usb.product
-
-exec -t 20m bash get-lshw.sh 2223
+exec -t 20m bash get-lshw.sh {{$port}}
 cp stdout after_reboot
+
+# get last reboot time
+exec -t 20m bash get-last-reboot-time.sh {{$port}}
+cp stdout timestamp2
 
 # comparison of lshw output
 cmp before_reboot after_reboot
 
+# comparison of reboot time output
+! exec diff timestamp1 timestamp2
+
 # teardown applications
 eden pod delete n11
 
-test eden.app.test -test.v -timewait 5m - n11
+test eden.app.test -test.v -timewait 20m - n11
 
 -- eden-config.yml --
 {{/* Test's config. file */}}
@@ -57,27 +66,27 @@ for i in `seq 20`
 do
  sleep 20
  # Test SSH-access to container
- echo $i\) ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST grep Ubuntu /etc/issue
- ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST grep Ubuntu /etc/issue && break
+ echo $i\) ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p $port ubuntu@$HOST grep Ubuntu /etc/issue
+ ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p $port ubuntu@$HOST grep Ubuntu /etc/issue && break
 done
-
--- get-usb.sh --
-port=$1
-EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
- echo ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST cat /sys/bus/usb/devices/{{$usb_dev}}/product
- ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST cat /sys/bus/usb/devices/{{$usb_dev}}/product > {{$usb_dev}}.usb.product
 
 -- get-lshw.sh --
 port=$1
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 HOST=$($EDEN eve ip)
- echo ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST lshw
- ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST lshw
+ echo ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p $port ubuntu@$HOST lsusb
+ ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p $port ubuntu@$HOST lsusb
+
+-- get-last-reboot-time.sh --
+port=$1
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+ echo ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p $port ubuntu@$HOST last -n 1 --time-format iso reboot | head -1 | awk '{print $5}'
+ ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p $port ubuntu@$HOST last -n 1 --time-format iso reboot | head -1 | awk '{print $5}'
 
 -- reboot.sh --
 port=$1
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 HOST=$($EDEN eve ip)
- echo ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST 'busybox reboot -f -d 1 &>/dev/null &'
- ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST 'busybox reboot -f -d 1 &>/dev/null &'
+ echo ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p $port ubuntu@$HOST 'sudo shutdown -r +1 &>/dev/null &'
+ ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p $port ubuntu@$HOST 'sudo shutdown -r +1 &>/dev/null &'

--- a/tests/eden/io_performance/testdata/fio_tests.txt
+++ b/tests/eden/io_performance/testdata/fio_tests.txt
@@ -7,7 +7,7 @@
 {{$volume_type := EdenGetEnv "VOLUME_TYPE"}}
 
 # Deploy the application
-eden pod deploy --volume-type={{if $volume_type}}{{$volume_type}}{{else}}qcow2{{end}} --metadata='EVE_VERSION={{EdenConfig "eve.tag"}}\nGIT_BRANCH={{EdenGetEnv "GIT_BRANCH"}}\nGIT_REPO={{EdenGetEnv "GIT_REPO"}}\nGIT_FOLDER={{EdenGetEnv "GIT_FOLDER"}}\nGIT_PATH={{EdenGetEnv "GIT_PATH"}}\nGIT_LOGIN={{EdenGetEnv "GIT_LOGIN"}}\nGIT_TOKEN={{EdenGetEnv "GIT_TOKEN"}}\nFIO_TIME={{EdenGetEnv "FIO_TIME"}}\nFIO_OPTYPE={{EdenGetEnv "FIO_OPTYPE"}}\nFIO_BS={{EdenGetEnv "FIO_BS"}}\nFIO_JOBS={{EdenGetEnv "FIO_JOBS"}}\nFIO_DEPTH={{EdenGetEnv "FIO_DEPTH"}}' --name=fio_test --memory=2GB --cpus=2 docker://itmoeve/fio_tests:v.1.2.1
+eden pod deploy --volume-type={{if $volume_type}}{{$volume_type}}{{else}}qcow2{{end}} --metadata='EVE_VERSION={{EdenConfig "eve.tag"}}\nGIT_BRANCH={{EdenGetEnv "GIT_BRANCH"}}\nGIT_REPO={{EdenGetEnv "GIT_REPO"}}\nGIT_FOLDER={{EdenGetEnv "GIT_FOLDER"}}\nGIT_PATH={{EdenGetEnv "GIT_PATH"}}\nGIT_LOGIN={{EdenGetEnv "GIT_LOGIN"}}\nGIT_TOKEN={{EdenGetEnv "GIT_TOKEN"}}\nFIO_TIME={{EdenGetEnv "FIO_TIME"}}\nFIO_OPTYPE={{EdenGetEnv "FIO_OPTYPE"}}\nFIO_BS={{EdenGetEnv "FIO_BS"}}\nFIO_JOBS={{EdenGetEnv "FIO_JOBS"}}\nFIO_DEPTH={{EdenGetEnv "FIO_DEPTH"}}' --name=fio_test --memory=2GB --cpus=2 docker://itmoeve/fio_tests:v.1.2.1 --volume-size=2GB
 
 test eden.app.test -test.v -timewait 5m RUNNING fio_test
 

--- a/tests/eden/workflow/eden.workflow.tests.txt
+++ b/tests/eden/workflow/eden.workflow.tests.txt
@@ -1,5 +1,5 @@
 # Number of tests
-{{$tests := 35}}
+{{$tests := 37}}
 # EDEN_TEST env. var. -- flavour of test set: "small", "medium"(default) and "large"
 {{$workflow := EdenGetEnv "EDEN_TEST"}}
 # EDEN_TEST_SETUP env. var. -- "y"(default) performs the EDEN setup steps
@@ -8,6 +8,10 @@
 {{$stop := EdenGetEnv "EDEN_TEST_STOP"}}
 # EDEN_TEST_USB_PT -- "y" enables USB Passthrough test (disabled by default).
 {{$usb_pt := EdenGetEnv "EDEN_TEST_USB_PT"}}
+# EDEN_TEST_AUDIO_PT -- "y" enables Audio Passthrough test (disabled by default).
+{{$audio_pt := EdenGetEnv "EDEN_TEST_AUDIO_PT"}}
+# EDEN_TEST_REGISTRY env. var. -- "y"(default) performs the local EDEN registry test
+{{$registry := EdenGetEnv "EDEN_TEST_REGISTRY"}}
 
 {{$devmodel := EdenConfig "eve.devmodel"}}
 
@@ -21,6 +25,9 @@ eden.escript.test -test.run TestEdenScripts/eden_setup
 # Making some settings for test configuration if we work with QEMU
 {{if and (eq $usb_pt "y") (eq $devmodel "ZedVirtual-4G") }}
 qemu+usb.sh
+{{end}}
+{{if and (eq $audio_pt "y") (eq $devmodel "ZedVirtual-4G") }}
+qemu+audio.sh
 {{end}}
 {{if or (eq $devmodel "ZedVirtual-4G") (eq $devmodel "VBox") (eq $devmodel "parallels") }}
 eden+ports.sh 2223:2223 2224:2224 5912:5902 5911:5901 8027:8027
@@ -74,11 +81,17 @@ eden.escript.test -testdata ../network/testdata/ -test.run TestEdenScripts/netwo
 eden.escript.test -testdata ../volume/testdata/ -test.run TestEdenScripts/volumes_test
 /bin/echo Eden sftp volumes test (17.2/{{$tests}})
 eden.escript.test -testdata ../volume/testdata/ -test.run TestEdenScripts/volume_sftp
+{{if (ne $registry "n")}}
+/bin/echo Eden eclient with mounted volume (17.3/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/mount
+{{end}}
 
 /bin/echo Eden Host only ACL (18.1/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/host-only
 /bin/echo Eden ACL to particular host (18.2/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/acl
+/bin/echo Eden profile test (18.3/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/profile
 /bin/echo Eden Network light (19/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/networking_light
 /bin/echo Eden Networks switch (20/{{$tests}})
@@ -92,14 +105,22 @@ eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/port_
 /bin/echo Hardware reboot - USB (22/{{$tests}})
 eden.escript.test -testdata ../hardware_reboot/testdata/ -test.run TestEdenScripts/hardware_usb_reboot
 {{end}}
+{{if (eq $audio_pt "y")}}
+/bin/echo Hardware reboot - Audio (22.1/{{$tests}})
+eden.escript.test -testdata ../hardware_reboot/testdata/ -test.run TestEdenScripts/hardware_audio_reboot
+{{end}}
 
 {{ if or (eq $workflow "large") (eq $workflow "gcp") }}
 /bin/echo Eden VNC (23/{{$tests}})
 eden.escript.test -testdata ../vnc/testdata/ -test.run TestEdenScripts/vnc_test
+
+{{if (ne $registry "n")}}
 /bin/echo Eden registry (24/{{$tests}})
 eden.escript.test -testdata ../registry/testdata/ -test.run TestEdenScripts/registry_test
-/bin/echo Eden Network test (25/{{$tests}})
-eden.escript.test -testdata ../network/testdata/ -test.run TestEdenScripts/test_networking
+{{end}}
+
+/bin/echo Eden Networking via switch test (25/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/air-gapped-switch
 /bin/echo Eden 2 dockers test (26/{{$tests}})
 eden.escript.test -testdata ../docker/testdata/ -test.run TestEdenScripts/2dockers_test
 /bin/echo Eden 2 dockers test with app state detector (27/{{$tests}})
@@ -114,20 +135,22 @@ eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/disk
 eden.escript.test -test.run TestEdenScripts/eden_reset
 {{end}}
 {{ if  (eq $workflow "large")  }}
-/bin/echo Eden's testing the maximum application limit (32/{{$tests}})
+/bin/echo Verifying that we can use a switch network instance on a management port (32/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/app_nonat
+/bin/echo Eden's testing the maximum application limit (33/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/eclients
 {{end}}
 
-/bin/echo Eden Reboot test (33/{{$tests}})
+/bin/echo Eden Reboot test (34/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/reboot_test
 {{ if ne $workflow "small" }}
-/bin/echo Eden base OS update http (34/{{$tests}})
+/bin/echo Eden base OS update http (35/{{$tests}})
 eden.escript.test -testdata ../update_eve_image/testdata/ -test.run TestEdenScripts/update_eve_image_http
-/bin/echo Eden base OS update oci (35/{{$tests}})
+/bin/echo Eden base OS update oci (36/{{$tests}})
 eden.escript.test -testdata ../update_eve_image/testdata/ -test.run TestEdenScripts/update_eve_image_oci
 {{end}}
 
 {{if (eq $stop "y")}}
-/bin/echo Eden stop (36/{{$tests}})
+/bin/echo Eden stop (37/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/eden_stop
 {{end}}

--- a/tests/eden/workflow/testdata/eve_restart.txt
+++ b/tests/eden/workflow/testdata/eve_restart.txt
@@ -5,6 +5,8 @@ eden eve status
 ! stdout 'EVE on .* status: running'
 ! stderr .
 
+exec sleep 60
+
 eden -t 2m eve start
 ! stderr .
 

--- a/tests/eden/workflow/workflow.default.txt
+++ b/tests/eden/workflow/workflow.default.txt
@@ -8,12 +8,16 @@
 
 # EDEN_TEST_USB_PT -- "y" enables USB Passthrough test (disabled by default).
 
+# EDEN_TEST_AUDIO_PT -- "y" enables Audio Passthrough test (disabled by default).
+
+# EDEN_TEST_REGISTRY env. var. -- "y"(default) performs the local EDEN registry test
+
 
 
 
 
 #./eden config add default
-/bin/echo Eden setup (01/35)
+/bin/echo Eden setup (01/37)
 eden.escript.test -test.run TestEdenScripts/eden_setup
 #source ~/.eden/activate.sh
 
@@ -21,13 +25,14 @@ eden.escript.test -test.run TestEdenScripts/eden_setup
 # Making some settings for test configuration if we work with QEMU
 
 
+
 eden+ports.sh 2223:2223 2224:2224 5912:5902 5911:5901 8027:8027
 
 
 
-/bin/echo Eden start (02/35)
+/bin/echo Eden start (02/37)
 eden.escript.test -test.run TestEdenScripts/eden_start
-/bin/echo Eden onboard (03/35)
+/bin/echo Eden onboard (03/37)
 eden.escript.test -test.run TestEdenScripts/eden_onboard
 
 
@@ -35,52 +40,58 @@ eden.escript.test -test.run TestEdenScripts/eden_onboard
 # Just restart EVE if not using the SETUP steps
 # Is it QEMU?
 
-/bin/echo EVE restart (04/35)
+/bin/echo EVE restart (04/37)
 eden.escript.test -test.run TestEdenScripts/eve_restart
 
 
 
-/bin/echo Eden Log test (05/35)
+/bin/echo Eden Log test (05/37)
 eden.escript.test -testdata ../lim/testdata/ -test.run TestEdenScripts/log_test
-/bin/echo Eden SSH test (06/35)
+/bin/echo Eden SSH test (06/37)
 eden.escript.test -test.run TestEdenScripts/ssh
 
-/bin/echo Eden Metric test (08/35)
+/bin/echo Eden Metric test (08/37)
 eden.escript.test -testdata ../lim/testdata/ -test.run TestEdenScripts/metric_test
 
-/bin/echo Escript args test (09/35)
+/bin/echo Escript args test (09/37)
 eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/arg -args=test1=123,test2=456
-/bin/echo Escript template test (10/35)
+/bin/echo Escript template test (10/37)
 eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/template
-/bin/echo Escript message test (11/35)
+/bin/echo Escript message test (11/37)
 eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/message
-/bin/echo Escript nested scripts test (12/35)
+/bin/echo Escript nested scripts test (12/37)
 eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/nested_scripts
-/bin/echo Escript time test (13/35)
+/bin/echo Escript time test (13/37)
 eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/time
-/bin/echo Escript source test (14/35)
+/bin/echo Escript source test (14/37)
 eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/source
-/bin/echo Escript fail scenario test (15/35)
+/bin/echo Escript fail scenario test (15/37)
 eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/fail_scenario
 
-/bin/echo Eden basic network test (16/35)
+/bin/echo Eden basic network test (16/37)
 eden.escript.test -testdata ../network/testdata/ -test.run TestEdenScripts/network_test
-/bin/echo Eden basic volumes test (17.1/35)
+/bin/echo Eden basic volumes test (17.1/37)
 eden.escript.test -testdata ../volume/testdata/ -test.run TestEdenScripts/volumes_test
-/bin/echo Eden sftp volumes test (17.2/35)
+/bin/echo Eden sftp volumes test (17.2/37)
 eden.escript.test -testdata ../volume/testdata/ -test.run TestEdenScripts/volume_sftp
 
-/bin/echo Eden Host only ACL (18.1/35)
+/bin/echo Eden eclient with mounted volume (17.3/37)
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/mount
+
+
+/bin/echo Eden Host only ACL (18.1/37)
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/host-only
-/bin/echo Eden ACL to particular host (18.2/35)
+/bin/echo Eden ACL to particular host (18.2/37)
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/acl
-/bin/echo Eden Network light (19/35)
+/bin/echo Eden profile test (18.3/37)
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/profile
+/bin/echo Eden Network light (19/37)
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/networking_light
-/bin/echo Eden Networks switch (20/35)
+/bin/echo Eden Networks switch (20/37)
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/nw_switch
-/bin/echo Eden Network Ports switch (21/35)
+/bin/echo Eden Network Ports switch (21/37)
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/port_switch
-/bin/echo Eden Network portmap test (21.1/35)
+/bin/echo Eden Network portmap test (21.1/37)
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/port_forward
 
 
@@ -88,12 +99,13 @@ eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/port_
 
 
 
-/bin/echo Eden Reboot test (33/35)
+
+/bin/echo Eden Reboot test (34/37)
 eden.escript.test -test.run TestEdenScripts/reboot_test
 
-/bin/echo Eden base OS update http (34/35)
+/bin/echo Eden base OS update http (35/37)
 eden.escript.test -testdata ../update_eve_image/testdata/ -test.run TestEdenScripts/update_eve_image_http
-/bin/echo Eden base OS update oci (35/35)
+/bin/echo Eden base OS update oci (36/37)
 eden.escript.test -testdata ../update_eve_image/testdata/ -test.run TestEdenScripts/update_eve_image_oci
 
 

--- a/tests/eden/workflow/workflow.large.txt
+++ b/tests/eden/workflow/workflow.large.txt
@@ -8,12 +8,16 @@
 
 # EDEN_TEST_USB_PT -- "y" enables USB Passthrough test (disabled by default).
 
+# EDEN_TEST_AUDIO_PT -- "y" enables Audio Passthrough test (disabled by default).
+
+# EDEN_TEST_REGISTRY env. var. -- "y"(default) performs the local EDEN registry test
+
 
 
 
 
 #./eden config add default
-/bin/echo Eden setup (01/35)
+/bin/echo Eden setup (01/37)
 eden.escript.test -test.run TestEdenScripts/eden_setup
 #source ~/.eden/activate.sh
 
@@ -21,13 +25,14 @@ eden.escript.test -test.run TestEdenScripts/eden_setup
 # Making some settings for test configuration if we work with QEMU
 
 
+
 eden+ports.sh 2223:2223 2224:2224 5912:5902 5911:5901 8027:8027
 
 
 
-/bin/echo Eden start (02/35)
+/bin/echo Eden start (02/37)
 eden.escript.test -test.run TestEdenScripts/eden_start
-/bin/echo Eden onboard (03/35)
+/bin/echo Eden onboard (03/37)
 eden.escript.test -test.run TestEdenScripts/eden_onboard
 
 
@@ -35,90 +40,103 @@ eden.escript.test -test.run TestEdenScripts/eden_onboard
 # Just restart EVE if not using the SETUP steps
 # Is it QEMU?
 
-/bin/echo EVE restart (04/35)
+/bin/echo EVE restart (04/37)
 eden.escript.test -test.run TestEdenScripts/eve_restart
 
 
 
-/bin/echo Eden Log test (05/35)
+/bin/echo Eden Log test (05/37)
 eden.escript.test -testdata ../lim/testdata/ -test.run TestEdenScripts/log_test
-/bin/echo Eden SSH test (06/35)
+/bin/echo Eden SSH test (06/37)
 eden.escript.test -test.run TestEdenScripts/ssh
 
-/bin/echo Eden Info test (07/35)
+/bin/echo Eden Info test (07/37)
 eden.escript.test -testdata ../lim/testdata/ -test.run TestEdenScripts/info_test
 
-/bin/echo Eden Metric test (08/35)
+/bin/echo Eden Metric test (08/37)
 eden.escript.test -testdata ../lim/testdata/ -test.run TestEdenScripts/metric_test
 
-/bin/echo Escript args test (09/35)
+/bin/echo Escript args test (09/37)
 eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/arg -args=test1=123,test2=456
-/bin/echo Escript template test (10/35)
+/bin/echo Escript template test (10/37)
 eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/template
-/bin/echo Escript message test (11/35)
+/bin/echo Escript message test (11/37)
 eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/message
-/bin/echo Escript nested scripts test (12/35)
+/bin/echo Escript nested scripts test (12/37)
 eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/nested_scripts
-/bin/echo Escript time test (13/35)
+/bin/echo Escript time test (13/37)
 eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/time
-/bin/echo Escript source test (14/35)
+/bin/echo Escript source test (14/37)
 eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/source
-/bin/echo Escript fail scenario test (15/35)
+/bin/echo Escript fail scenario test (15/37)
 eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/fail_scenario
 
-/bin/echo Eden basic network test (16/35)
+/bin/echo Eden basic network test (16/37)
 eden.escript.test -testdata ../network/testdata/ -test.run TestEdenScripts/network_test
-/bin/echo Eden basic volumes test (17.1/35)
+/bin/echo Eden basic volumes test (17.1/37)
 eden.escript.test -testdata ../volume/testdata/ -test.run TestEdenScripts/volumes_test
-/bin/echo Eden sftp volumes test (17.2/35)
+/bin/echo Eden sftp volumes test (17.2/37)
 eden.escript.test -testdata ../volume/testdata/ -test.run TestEdenScripts/volume_sftp
 
-/bin/echo Eden Host only ACL (18.1/35)
+/bin/echo Eden eclient with mounted volume (17.3/37)
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/mount
+
+
+/bin/echo Eden Host only ACL (18.1/37)
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/host-only
-/bin/echo Eden ACL to particular host (18.2/35)
+/bin/echo Eden ACL to particular host (18.2/37)
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/acl
-/bin/echo Eden Network light (19/35)
+/bin/echo Eden profile test (18.3/37)
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/profile
+/bin/echo Eden Network light (19/37)
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/networking_light
-/bin/echo Eden Networks switch (20/35)
+/bin/echo Eden Networks switch (20/37)
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/nw_switch
-/bin/echo Eden Network Ports switch (21/35)
+/bin/echo Eden Network Ports switch (21/37)
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/port_switch
-/bin/echo Eden Network portmap test (21.1/35)
+/bin/echo Eden Network portmap test (21.1/37)
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/port_forward
 
 
 
 
-/bin/echo Eden VNC (23/35)
+
+/bin/echo Eden VNC (23/37)
 eden.escript.test -testdata ../vnc/testdata/ -test.run TestEdenScripts/vnc_test
-/bin/echo Eden registry (24/35)
+
+
+/bin/echo Eden registry (24/37)
 eden.escript.test -testdata ../registry/testdata/ -test.run TestEdenScripts/registry_test
-/bin/echo Eden Network test (25/35)
-eden.escript.test -testdata ../network/testdata/ -test.run TestEdenScripts/test_networking
-/bin/echo Eden 2 dockers test (26/35)
+
+
+/bin/echo Eden Networking via switch test (25/37)
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/air-gapped-switch
+/bin/echo Eden 2 dockers test (26/37)
 eden.escript.test -testdata ../docker/testdata/ -test.run TestEdenScripts/2dockers_test
-/bin/echo Eden 2 dockers test with app state detector (27/35)
+/bin/echo Eden 2 dockers test with app state detector (27/37)
 eden.escript.test -testdata ../app/testdata/ -test.run TestEdenScripts/2dockers_test
-/bin/echo Eden Nginx (28/35)
+/bin/echo Eden Nginx (28/37)
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/ngnix
-/bin/echo Eden Mariadb (29/35)
+/bin/echo Eden Mariadb (29/37)
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/maridb
-/bin/echo Eden eclient with disk (30/35)
+/bin/echo Eden eclient with disk (30/37)
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/disk
-/bin/echo EVE reset (31/35)
+/bin/echo EVE reset (31/37)
 eden.escript.test -test.run TestEdenScripts/eden_reset
 
 
-/bin/echo Eden's testing the maximum application limit (32/35)
+/bin/echo Verifying that we can use a switch network instance on a management port (32/37)
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/app_nonat
+/bin/echo Eden's testing the maximum application limit (33/37)
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/eclients
 
 
-/bin/echo Eden Reboot test (33/35)
+/bin/echo Eden Reboot test (34/37)
 eden.escript.test -test.run TestEdenScripts/reboot_test
 
-/bin/echo Eden base OS update http (34/35)
+/bin/echo Eden base OS update http (35/37)
 eden.escript.test -testdata ../update_eve_image/testdata/ -test.run TestEdenScripts/update_eve_image_http
-/bin/echo Eden base OS update oci (35/35)
+/bin/echo Eden base OS update oci (36/37)
 eden.escript.test -testdata ../update_eve_image/testdata/ -test.run TestEdenScripts/update_eve_image_oci
 
 

--- a/tests/eden/workflow/workflow.small.txt
+++ b/tests/eden/workflow/workflow.small.txt
@@ -8,12 +8,16 @@
 
 # EDEN_TEST_USB_PT -- "y" enables USB Passthrough test (disabled by default).
 
+# EDEN_TEST_AUDIO_PT -- "y" enables Audio Passthrough test (disabled by default).
+
+# EDEN_TEST_REGISTRY env. var. -- "y"(default) performs the local EDEN registry test
+
 
 
 
 
 #./eden config add default
-/bin/echo Eden setup (01/35)
+/bin/echo Eden setup (01/37)
 eden.escript.test -test.run TestEdenScripts/eden_setup
 #source ~/.eden/activate.sh
 
@@ -21,13 +25,14 @@ eden.escript.test -test.run TestEdenScripts/eden_setup
 # Making some settings for test configuration if we work with QEMU
 
 
+
 eden+ports.sh 2223:2223 2224:2224 5912:5902 5911:5901 8027:8027
 
 
 
-/bin/echo Eden start (02/35)
+/bin/echo Eden start (02/37)
 eden.escript.test -test.run TestEdenScripts/eden_start
-/bin/echo Eden onboard (03/35)
+/bin/echo Eden onboard (03/37)
 eden.escript.test -test.run TestEdenScripts/eden_onboard
 
 
@@ -35,52 +40,58 @@ eden.escript.test -test.run TestEdenScripts/eden_onboard
 # Just restart EVE if not using the SETUP steps
 # Is it QEMU?
 
-/bin/echo EVE restart (04/35)
+/bin/echo EVE restart (04/37)
 eden.escript.test -test.run TestEdenScripts/eve_restart
 
 
 
-/bin/echo Eden Log test (05/35)
+/bin/echo Eden Log test (05/37)
 eden.escript.test -testdata ../lim/testdata/ -test.run TestEdenScripts/log_test
-/bin/echo Eden SSH test (06/35)
+/bin/echo Eden SSH test (06/37)
 eden.escript.test -test.run TestEdenScripts/ssh
 
-/bin/echo Eden Metric test (08/35)
+/bin/echo Eden Metric test (08/37)
 eden.escript.test -testdata ../lim/testdata/ -test.run TestEdenScripts/metric_test
 
-/bin/echo Escript args test (09/35)
+/bin/echo Escript args test (09/37)
 eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/arg -args=test1=123,test2=456
-/bin/echo Escript template test (10/35)
+/bin/echo Escript template test (10/37)
 eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/template
-/bin/echo Escript message test (11/35)
+/bin/echo Escript message test (11/37)
 eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/message
-/bin/echo Escript nested scripts test (12/35)
+/bin/echo Escript nested scripts test (12/37)
 eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/nested_scripts
-/bin/echo Escript time test (13/35)
+/bin/echo Escript time test (13/37)
 eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/time
-/bin/echo Escript source test (14/35)
+/bin/echo Escript source test (14/37)
 eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/source
-/bin/echo Escript fail scenario test (15/35)
+/bin/echo Escript fail scenario test (15/37)
 eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/fail_scenario
 
-/bin/echo Eden basic network test (16/35)
+/bin/echo Eden basic network test (16/37)
 eden.escript.test -testdata ../network/testdata/ -test.run TestEdenScripts/network_test
-/bin/echo Eden basic volumes test (17.1/35)
+/bin/echo Eden basic volumes test (17.1/37)
 eden.escript.test -testdata ../volume/testdata/ -test.run TestEdenScripts/volumes_test
-/bin/echo Eden sftp volumes test (17.2/35)
+/bin/echo Eden sftp volumes test (17.2/37)
 eden.escript.test -testdata ../volume/testdata/ -test.run TestEdenScripts/volume_sftp
 
-/bin/echo Eden Host only ACL (18.1/35)
+/bin/echo Eden eclient with mounted volume (17.3/37)
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/mount
+
+
+/bin/echo Eden Host only ACL (18.1/37)
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/host-only
-/bin/echo Eden ACL to particular host (18.2/35)
+/bin/echo Eden ACL to particular host (18.2/37)
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/acl
-/bin/echo Eden Network light (19/35)
+/bin/echo Eden profile test (18.3/37)
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/profile
+/bin/echo Eden Network light (19/37)
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/networking_light
-/bin/echo Eden Networks switch (20/35)
+/bin/echo Eden Networks switch (20/37)
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/nw_switch
-/bin/echo Eden Network Ports switch (21/35)
+/bin/echo Eden Network Ports switch (21/37)
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/port_switch
-/bin/echo Eden Network portmap test (21.1/35)
+/bin/echo Eden Network portmap test (21.1/37)
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/port_forward
 
 
@@ -88,7 +99,8 @@ eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/port_
 
 
 
-/bin/echo Eden Reboot test (33/35)
+
+/bin/echo Eden Reboot test (34/37)
 eden.escript.test -test.run TestEdenScripts/reboot_test
 
 


### PR DESCRIPTION
Sync of EDEN tests:
1. air-gapped switch test
1. profile test
1. long domain names test
1. nonat test
1. mount test

Adding log counting into workflows
Add yamllint config file to not fail yetus on long lines.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>