### PR TITLE
sync nw_switch test of Eden in 6.6 branch

### DIFF
--- a/tests/eden/eclient/testdata/nw_switch.txt
+++ b/tests/eden/eclient/testdata/nw_switch.txt
@@ -50,7 +50,8 @@ stdout '100% packet loss'
 
 message 'Switching to 2st network'
 eden pod modify pong --networks n2
-test eden.app.test -test.v -timewait 20m RUNNING pong
+test eden.app.test -test.v -timewait 5m PURGING pong
+test eden.app.test -test.v -timewait 10m RUNNING pong
 eden pod ps
 cp stdout pod_ps
 exec bash pong_ip.sh
@@ -65,7 +66,8 @@ stdout '0% packet loss'
 
 message 'Switching back to 1st network'
 eden pod modify pong --networks n1
-test eden.app.test -test.v -timewait 20m RUNNING pong
+test eden.app.test -test.v -timewait 5m PURGING pong
+test eden.app.test -test.v -timewait 10m RUNNING pong
 eden pod ps
 cp stdout pod_ps
 exec bash pong_ip.sh


### PR DESCRIPTION
Due to changes on Eden side `eden.app.test` for RUNNING state after `eden pod modify` is noop now. Because of observing existing states inside before of moving to process states from new EVE`s infos.

So, we need to pull it into 6.6 for future tests on this branch.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>