### PR TITLE
fix touching of .boot_repository for iso

### DIFF
--- a/pkg/mkimage-iso-efi/make-efi
+++ b/pkg/mkimage-iso-efi/make-efi
@@ -27,7 +27,7 @@ fi
 
 # for installer we need to add a uuid and override grub.cfg
 if [ "$1" = installer ]; then
-   mkdir boot && touch boot/.boot_repository
+   mkdir -p boot && touch boot/.boot_repository
    od -An -x -N 16 /dev/random | tr -d ' ' > boot/.uuid
    cp grub.cfg EFI/BOOT/
 fi


### PR DESCRIPTION
During `docker run lfedge/eve:6.6.0-kvm-amd64 installer_iso` I see `mkdir: cannot create directory ‘boot’: File exists` so, with this exit code we do not create `.boot_repository` file.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>