### PR TITLE
latest linuxkit with manifest-tool update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,7 @@ DOCKER_GO = _() { $(SET_X); mkdir -p $(CURDIR)/.go/src/$${3:-dummy} ; mkdir -p $
 
 PARSE_PKGS=$(if $(strip $(EVE_HASH)),EVE_HASH=)$(EVE_HASH) DOCKER_ARCH_TAG=$(DOCKER_ARCH_TAG) ./tools/parse-pkgs.sh
 LINUXKIT=$(BUILDTOOLS_BIN)/linuxkit
-LINUXKIT_VERSION=acc34e5ee343b4469b08b43ec817197d2f00bf6e
+LINUXKIT_VERSION=ccece6a4889e15850dfbaf6d5170939c83edb103
 LINUXKIT_SOURCE=https://github.com/linuxkit/linuxkit.git
 LINUXKIT_OPTS= $(if $(strip $(EVE_HASH)),--hash) $(EVE_HASH) $(if $(strip $(EVE_REL)),--release) $(EVE_REL) $(FORCE_BUILD)  --platforms $(LINUXKIT_PLATFORM_TARGET)
 LINUXKIT_PKG_TARGET=build


### PR DESCRIPTION
Earlier versions of manifest-tool had a fixed list of supported arches, which did not include riscv64, which caused the push of the manifest to fail.

Latest just gets the list from go.

cc @vmlemon @rvs 