### PR TITLE
eve support datastore https certs

### DIFF
--- a/libs/zedUpload/datastore.go
+++ b/libs/zedUpload/datastore.go
@@ -58,6 +58,7 @@ type DronaEndPoint interface {
 	Action(req *DronaRequest) error
 	Close() error
 	WithSrcIPSelection(localAddr net.IP) error
+	WithSrcIPAndHTTPSCerts(localAddr net.IP, certs [][]byte) error
 	WithSrcIPAndProxySelection(localAddr net.IP, proxy *url.URL) error
 	WithBindIntf(intf string) error
 	WithLogging(onoff bool) error

--- a/libs/zedUpload/datastore_aws.go
+++ b/libs/zedUpload/datastore_aws.go
@@ -87,6 +87,12 @@ func (ep *AwsTransportMethod) WithSrcIPAndProxySelection(localAddr net.IP,
 	return nil
 }
 
+// WithSrcIPAndHTTPSCerts append certs for https datastore
+func (ep *AwsTransportMethod) WithSrcIPAndHTTPSCerts(localAddr net.IP, certs [][]byte) error {
+	return fmt.Errorf("not supported")
+}
+
+
 // bind to specific interface for this connection
 func (ep *AwsTransportMethod) WithBindIntf(intf string) error {
 	localAddr := getSrcIpFromInterface(intf)

--- a/libs/zedUpload/datastore_azure.go
+++ b/libs/zedUpload/datastore_azure.go
@@ -81,6 +81,11 @@ func (ep *AzureTransportMethod) WithSrcIPAndProxySelection(localAddr net.IP,
 	return nil
 }
 
+// WithSrcIPAndHTTPSCerts append certs for https datastore
+func (ep *AzureTransportMethod) WithSrcIPAndHTTPSCerts(localAddr net.IP, certs [][]byte) error {
+	return fmt.Errorf("not supported")
+}
+
 // bind to specific interface for this connection
 func (ep *AzureTransportMethod) WithBindIntf(intf string) error {
 	return fmt.Errorf("not supported")

--- a/libs/zedUpload/datastore_oci.go
+++ b/libs/zedUpload/datastore_oci.go
@@ -92,6 +92,11 @@ func (ep *OCITransportMethod) WithSrcIPAndProxySelection(localAddr net.IP,
 	return nil
 }
 
+// WithSrcIPAndHTTPSCerts append certs for https datastore
+func (ep *OCITransportMethod) WithSrcIPAndHTTPSCerts(localAddr net.IP, certs [][]byte) error {
+	return fmt.Errorf("not supported")
+}
+
 // WithBindIntf bind to specific interface for this connection
 func (ep *OCITransportMethod) WithBindIntf(intf string) error {
 	localAddr := getSrcIpFromInterface(intf)

--- a/libs/zedUpload/datastore_sftp.go
+++ b/libs/zedUpload/datastore_sftp.go
@@ -84,13 +84,18 @@ func (ep *SftpTransportMethod) Close() error {
 
 // WithSrcIPSelection use the specific ip as source address for this connection
 func (ep *SftpTransportMethod) WithSrcIPSelection(localAddr net.IP) error {
-	return fmt.Errorf("not supported")
+	return nil
 }
 
 // WithSrcIPAndProxySelection use the specific ip as source address for this
 // connection and connect via the provided proxy URL
 func (ep *SftpTransportMethod) WithSrcIPAndProxySelection(localAddr net.IP,
 	proxy *url.URL) error {
+	return fmt.Errorf("not supported")
+}
+
+// WithSrcIPAndHTTPSCerts append certs for https datastore
+func (ep *SftpTransportMethod) WithSrcIPAndHTTPSCerts(localAddr net.IP, certs [][]byte) error {
 	return fmt.Errorf("not supported")
 }
 

--- a/pkg/pillar/cmd/downloader/syncop.go
+++ b/pkg/pillar/cmd/downloader/syncop.go
@@ -190,6 +190,8 @@ func handleSyncOp(ctx *downloaderContext, key string,
 		} else {
 			serverURL, ifname, ipSrc, err = findDSmDNS(ctx, serverURL)
 			if err != nil {
+				log.Errorf("find datastore mDNS failed: %s", err)
+				errStr = errStr + "\n" + err.Error()
 				break
 			}
 		}
@@ -204,7 +206,7 @@ func handleSyncOp(ctx *downloaderContext, key string,
 		downloadStartTime := time.Now()
 		contentType, cancelled, err = download(ctx, trType, st, syncOp, serverURL, auth,
 			dsCtx.Dpath, dsCtx.Region,
-			config.Size, ifname, ipSrc, remoteName, locFilename,
+			config.Size, ifname, ipSrc, remoteName, locFilename, dst.DsCertPEM,
 			receiveChan)
 		if err != nil {
 			if cancelled {

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -989,6 +989,9 @@ func publishDatastoreConfig(ctx *getconfigContext,
 		if datastore.Region == "" {
 			datastore.Region = "us-west-2"
 		}
+
+		datastore.DsCertPEM = ds.GetDsCertPEM()
+
 		datastore.CipherBlockStatus = parseCipherBlock(ctx, datastore.Key(),
 			ds.GetCipherData())
 		ctx.pubDatastoreConfig.Publish(datastore.Key(), *datastore)

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore.go
@@ -58,6 +58,7 @@ type DronaEndPoint interface {
 	Action(req *DronaRequest) error
 	Close() error
 	WithSrcIPSelection(localAddr net.IP) error
+	WithSrcIPAndHTTPSCerts(localAddr net.IP, certs [][]byte) error
 	WithSrcIPAndProxySelection(localAddr net.IP, proxy *url.URL) error
 	WithBindIntf(intf string) error
 	WithLogging(onoff bool) error

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_aws.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_aws.go
@@ -87,6 +87,12 @@ func (ep *AwsTransportMethod) WithSrcIPAndProxySelection(localAddr net.IP,
 	return nil
 }
 
+// WithSrcIPAndHTTPSCerts append certs for https datastore
+func (ep *AwsTransportMethod) WithSrcIPAndHTTPSCerts(localAddr net.IP, certs [][]byte) error {
+	return fmt.Errorf("not supported")
+}
+
+
 // bind to specific interface for this connection
 func (ep *AwsTransportMethod) WithBindIntf(intf string) error {
 	localAddr := getSrcIpFromInterface(intf)

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_azure.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_azure.go
@@ -81,6 +81,11 @@ func (ep *AzureTransportMethod) WithSrcIPAndProxySelection(localAddr net.IP,
 	return nil
 }
 
+// WithSrcIPAndHTTPSCerts append certs for https datastore
+func (ep *AzureTransportMethod) WithSrcIPAndHTTPSCerts(localAddr net.IP, certs [][]byte) error {
+	return fmt.Errorf("not supported")
+}
+
 // bind to specific interface for this connection
 func (ep *AzureTransportMethod) WithBindIntf(intf string) error {
 	return fmt.Errorf("not supported")

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_oci.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_oci.go
@@ -92,6 +92,11 @@ func (ep *OCITransportMethod) WithSrcIPAndProxySelection(localAddr net.IP,
 	return nil
 }
 
+// WithSrcIPAndHTTPSCerts append certs for https datastore
+func (ep *OCITransportMethod) WithSrcIPAndHTTPSCerts(localAddr net.IP, certs [][]byte) error {
+	return fmt.Errorf("not supported")
+}
+
 // WithBindIntf bind to specific interface for this connection
 func (ep *OCITransportMethod) WithBindIntf(intf string) error {
 	localAddr := getSrcIpFromInterface(intf)

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_sftp.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_sftp.go
@@ -84,13 +84,18 @@ func (ep *SftpTransportMethod) Close() error {
 
 // WithSrcIPSelection use the specific ip as source address for this connection
 func (ep *SftpTransportMethod) WithSrcIPSelection(localAddr net.IP) error {
-	return fmt.Errorf("not supported")
+	return nil
 }
 
 // WithSrcIPAndProxySelection use the specific ip as source address for this
 // connection and connect via the provided proxy URL
 func (ep *SftpTransportMethod) WithSrcIPAndProxySelection(localAddr net.IP,
 	proxy *url.URL) error {
+	return fmt.Errorf("not supported")
+}
+
+// WithSrcIPAndHTTPSCerts append certs for https datastore
+func (ep *SftpTransportMethod) WithSrcIPAndHTTPSCerts(localAddr net.IP, certs [][]byte) error {
 	return fmt.Errorf("not supported")
 }
 


### PR DESCRIPTION
Signed-off-by: Naiming Shen <naiming@zededa.com>
- support for datastore cert chain from user configuration
- if the ds is local App based, skip verification for server cert