### PR TITLE
Prevent multiple ssh public keys being concatenated. Also precent ssh…

### DIFF
--- a/pkg/pillar/ssh/ssh.go
+++ b/pkg/pillar/ssh/ssh.go
@@ -39,38 +39,39 @@ func UpdateSshAuthorizedKeys(log *base.LogObject, authorizedKeys string) {
 	defer os.Remove(tmpfile.Name())
 	tmpfile.Chmod(0600)
 
-	fileDesc, err := os.Open(baseAuthorizedKeysFile)
-	if err != nil {
-		log.Warnln("Open ", err)
-	} else {
-		reader := bufio.NewReader(fileDesc)
-		for {
-			line, err := reader.ReadString('\n')
-			if err != nil {
-				log.Traceln(err)
-				if err != io.EOF {
-					log.Errorln("ReadString ", err)
-					return
-				}
-				break
-			}
-			// remove trailing "/n" from line
-			line = line[0 : len(line)-1]
-
-			// Is it a comment or a key?
-			if strings.HasPrefix(line, "#") {
-				continue
-			}
-			if _, err = tmpfile.WriteString(line); err != nil {
-				log.Error(err)
-				return
-			}
-		}
-	}
-	if authorizedKeys != "" {
+	if authorizedKeys != "" && authorizedKeys != "true" && authorizedKeys != "false" {
 		if _, err := tmpfile.WriteString(authorizedKeys); err != nil {
 			log.Error(err)
 			return
+		}
+	} else {
+		fileDesc, err := os.Open(baseAuthorizedKeysFile)
+		if err != nil {
+			log.Warnln("Open ", err)
+		} else {
+			reader := bufio.NewReader(fileDesc)
+			for {
+				line, err := reader.ReadString('\n')
+				if err != nil {
+					log.Traceln(err)
+					if err != io.EOF {
+						log.Errorln("ReadString ", err)
+						return
+					}
+					break
+				}
+				// remove trailing "\n" from line
+				line = line[0 : len(line)-1]
+
+				// Is it a comment or a key?
+				if strings.HasPrefix(line, "#") {
+					continue
+				}
+				if _, err = tmpfile.WriteString(line); err != nil {
+					log.Error(err)
+					return
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
… debug flag from gettig suffixed to existing keys

UpdateSshAuthorizedKeys function should either program the public key coming from cloud or the public key written to /config/authorized_keys, not both.
We already write new keys to a new tmp file and then rename it to /run/authorized_keys. So we do not write multiple keys to authorized_keys at the same time, unless /config/authorized_keys has multiple keys or configuration from cloud has multiple concatenated keys.

Next we should see how the true/false values for debug.enable.ssh should be handled.

Signed-off-by: gkodali-zededa <gkodali@zededa.com>