### PR TITLE
Make upgradeconverter read ssh authorized keys from /config/authorize…

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -25,7 +25,7 @@
 | network.fallback.any.eth | "enabled" or "disabled" | enabled | if no connectivity try any Ethernet, WiFi, or LTE |
 | network.download.max.cost | 0-255 | 0 | [max port cost for download](DEVICE-CONNECTIVITY.md) to avoid e.g., LTE ports |
 | debug.enable.usb | boolean | false | allow USB e.g. keyboards on device |
-| debug.enable.ssh | boolean, or authorized ssh key | false | allow ssh to EVE |
+| debug.enable.ssh | authorized ssh key | empty string(ssh disabled) | allow ssh to EVE |
 | debug.default.loglevel | string | info | min level saved in files on device |
 | debug.default.remote.loglevel | string | warning | min level sent to controller |
 | storage.dom0.disk.minusage.percent | integer percent | 20 | min. percent of persist partition reserved for dom0 |

--- a/pkg/pillar/cmd/upgradeconverter/applydefaultconfigitem.go
+++ b/pkg/pillar/cmd/upgradeconverter/applydefaultconfigitem.go
@@ -4,14 +4,22 @@
 package upgradeconverter
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
+)
+
+const (
+	baseAuthorizedKeysFile = types.IdentityDirname + "/authorized_keys"
+	importGlobalConfigFile = types.IdentityDirname + "/GlobalConfig/global.json"
 )
 
 func applyDefaultConfigItem(ctxPtr *ucContext) error {
@@ -58,6 +66,54 @@ func applyDefaultConfigItem(ctxPtr *ucContext) error {
 	return nil
 }
 
+func importFromConfigPartition(ctxPtr *ucContext) error {
+	var err error
+	var globalConfigPtr *types.ConfigItemValueMap
+
+	persistStatusFile := ctxPtr.newConfigItemValueMapFile()
+	globalConfigExists := fileExists(importGlobalConfigFile)
+
+	if globalConfigExists {
+		globalConfigPtr, err = parseFile(importGlobalConfigFile)
+		if err != nil {
+			log.Errorf("Error parsing configuration from file: %s, %s", importGlobalConfigFile, err)
+			return err
+		}
+	} else {
+		log.Noticef("No existing ConfigItemValueMap; creating new %s",
+			persistStatusFile)
+		globalConfigPtr = types.NewConfigItemValueMap()
+	}
+	keyData, keyDataValid := readAuthorizedKeys(baseAuthorizedKeysFile)
+	if len(keyData) != 0 {
+		log.Functionf("Found the key data in %s", baseAuthorizedKeysFile)
+		globalConfigPtr.SetGlobalValueString(types.SSHAuthorizedKeys, keyData)
+	}
+
+	// Save Global config to file.
+	var data []byte
+	data, err = json.Marshal(globalConfigPtr)
+	if err != nil {
+		log.Fatalf("Failed to marshall global config err %s", err)
+	}
+	err = fileutils.WriteRename(persistStatusFile, data)
+	if err != nil {
+		// Could be low on disk space
+		log.Errorf("Failed to Save global config in: %s, %s", persistStatusFile, err)
+		return err
+	}
+	if keyDataValid {
+		os.Remove(baseAuthorizedKeysFile)
+		log.Functionf("Deleted %s file from /config/", baseAuthorizedKeysFile)
+	}
+	if globalConfigExists {
+		os.Remove(importGlobalConfigFile)
+		log.Functionf("Deleted %s file from /config/", importGlobalConfigFile)
+	}
+	log.Tracef("upgradeconverter.applyDefaultConfigItem done")
+	return nil
+}
+
 func parseFile(filename string) (*types.ConfigItemValueMap, error) {
 	file, err := os.Open(filename)
 	if err != nil {
@@ -77,4 +133,42 @@ func parseFile(filename string) (*types.ConfigItemValueMap, error) {
 			filename, err)
 	}
 	return &config, nil
+}
+
+func readAuthorizedKeys(filename string) (string, bool) {
+	exists := fileExists(filename)
+	if !exists {
+		return "", false
+	}
+
+	fileDesc, err := os.Open(filename)
+	keyData := ""
+	if err != nil {
+		log.Warnf("readAuthorizedKeys: File (%s) open error: %s", filename, err)
+	} else {
+		reader := bufio.NewReader(fileDesc)
+		for {
+			line, err := reader.ReadString('\n')
+			if err != nil {
+				log.Traceln(err)
+				if err != io.EOF {
+					log.Errorf("readAuthorizedKeys: ReadString (%s) error: %s", filename, err)
+					return "", false
+				}
+				break
+			}
+			// remove trailing "\n" from line
+			line = line[0 : len(line)-1]
+
+			// Is it a comment or a key?
+			if strings.HasPrefix(line, "#") {
+				continue
+			}
+			keyData += string(line)
+		}
+	}
+	if len(keyData) != 0 {
+		return keyData, true
+	}
+	return keyData, false
 }

--- a/pkg/pillar/cmd/upgradeconverter/upgradeconverter.go
+++ b/pkg/pillar/cmd/upgradeconverter/upgradeconverter.go
@@ -35,6 +35,10 @@ var preVaultconversionHandlers = []ConversionHandler{
 		handlerFunc: moveConfigItemValueMap,
 	},
 	{
+		description: "Move any configuration files from /config/GlobalConfig to /persist/status",
+		handlerFunc: importFromConfigPartition,
+	},
+	{
 		description: "Apply defaults for new items in ConfigItemValueMap",
 		handlerFunc: applyDefaultConfigItem,
 	},

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	zconfig "github.com/lf-edge/eve/api/go/config"
-	"github.com/lf-edge/eve/pkg/pillar/ssh"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 	uuid "github.com/satori/go.uuid"
@@ -1622,9 +1621,6 @@ func parseConfigItems(config *zconfig.EdgeDevConfig, ctx *getconfigContext) {
 		oldMetricInterval := oldGlobalConfig.GlobalValueInt(types.MetricInterval)
 		newMetricInterval := newGlobalConfig.GlobalValueInt(types.MetricInterval)
 
-		oldSSHAuthorizedKeys := oldGlobalConfig.GlobalValueString(types.SSHAuthorizedKeys)
-		newSSHAuthorizedKeys := newGlobalConfig.GlobalValueString(types.SSHAuthorizedKeys)
-
 		if newConfigInterval != oldConfigInterval {
 			log.Functionf("parseConfigItems: %s change from %d to %d",
 				"ConfigInterval", oldConfigInterval, newConfigInterval)
@@ -1635,11 +1631,6 @@ func parseConfigItems(config *zconfig.EdgeDevConfig, ctx *getconfigContext) {
 			log.Functionf("parseConfigItems: %s change from %d to %d",
 				"MetricInterval", oldMetricInterval, newMetricInterval)
 			updateMetricsTimer(newMetricInterval, ctx.metricsTickerHandle)
-		}
-		if newSSHAuthorizedKeys != oldSSHAuthorizedKeys {
-			log.Functionf("parseConfigItems: %s changed from %v to %v",
-				"SshAuthorizedKeys", oldSSHAuthorizedKeys, newSSHAuthorizedKeys)
-			ssh.UpdateSshAuthorizedKeys(log, newSSHAuthorizedKeys)
 		}
 		oldMaintenanceMode := oldGlobalConfig.GlobalValueTriState(types.MaintenanceMode)
 		newMaintenanceMode := newGlobalConfig.GlobalValueTriState(types.MaintenanceMode)

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -14,7 +14,6 @@ TMPDIR=/persist/tmp
 ZTMPDIR=/run/global
 DPCDIR=$ZTMPDIR/DevicePortConfig
 FIRSTBOOTFILE=$ZTMPDIR/first-boot
-GCDIR=$PERSISTDIR/config/ConfigItemValueMap
 AGENTS0="zedagent ledmanager nim nodeagent domainmgr loguploader"
 AGENTS1="zedmanager zedrouter downloader verifier baseosmgr wstunnelclient volumemgr watcher"
 AGENTS="$AGENTS0 $AGENTS1"
@@ -166,19 +165,6 @@ elif [ -f $FIRSTBOOTFILE ]; then
 else
     echo "Reboot reason: UNKNOWN: reboot reason - power failure or crash - at $(date -Ins -u)" > /dev/console
 fi
-
-# Copy any GlobalConfig from /config
-dir=$CONFIGDIR/GlobalConfig
-for f in "$dir"/*.json; do
-    if [ "$f" = "$dir/*.json" ]; then
-        break
-    fi
-    if [ ! -d $GCDIR ]; then
-        mkdir -p $GCDIR
-    fi
-    echo "$(date -Ins -u) Copying from $f to $GCDIR"
-    cp -p "$f" $GCDIR
-done
 
 if [ ! -d $PERSISTDIR/log ]; then
     echo "$(date -Ins -u) Creating $PERSISTDIR/log"

--- a/pkg/pillar/ssh/ssh.go
+++ b/pkg/pillar/ssh/ssh.go
@@ -11,19 +11,14 @@
 package ssh
 
 import (
-	"bufio"
-	"io"
 	"io/ioutil"
 	"os"
-	"strings"
 
 	"github.com/lf-edge/eve/pkg/pillar/base"
-	"github.com/lf-edge/eve/pkg/pillar/types"
 )
 
 const (
 	runDir                   = "/run"
-	baseAuthorizedKeysFile   = types.IdentityDirname + "/authorized_keys"
 	targetAuthorizedKeysFile = runDir + "/authorized_keys"
 )
 
@@ -39,34 +34,6 @@ func UpdateSshAuthorizedKeys(log *base.LogObject, authorizedKeys string) {
 	defer os.Remove(tmpfile.Name())
 	tmpfile.Chmod(0600)
 
-	fileDesc, err := os.Open(baseAuthorizedKeysFile)
-	if err != nil {
-		log.Warnln("Open ", err)
-	} else {
-		reader := bufio.NewReader(fileDesc)
-		for {
-			line, err := reader.ReadString('\n')
-			if err != nil {
-				log.Traceln(err)
-				if err != io.EOF {
-					log.Errorln("ReadString ", err)
-					return
-				}
-				break
-			}
-			// remove trailing "/n" from line
-			line = line[0 : len(line)-1]
-
-			// Is it a comment or a key?
-			if strings.HasPrefix(line, "#") {
-				continue
-			}
-			if _, err = tmpfile.WriteString(line); err != nil {
-				log.Error(err)
-				return
-			}
-		}
-	}
 	if authorizedKeys != "" {
 		if _, err := tmpfile.WriteString(authorizedKeys); err != nil {
 			log.Error(err)

--- a/pkg/pillar/utils/file/file.go
+++ b/pkg/pillar/utils/file/file.go
@@ -34,6 +34,8 @@ func WriteRename(fileName string, b []byte) error {
 			fileName, err)
 		return errors.New(errStr)
 	}
+	// Make sure the file is flused from buffers onto the disk
+	tmpfile.Sync()
 	if err := tmpfile.Close(); err != nil {
 		errStr := fmt.Sprintf("WriteRename(%s): %s",
 			fileName, err)


### PR DESCRIPTION
…d_keys and write them to saved global.config file in /persist/status/zedagent/ConfigItemValueMap. This happens at every boot if there is a keys file present in /config

This eliminates the need for special code paths for ssh access during the onboard process. Users will be able to ssh into device before onboard and read device serial. This helps in automating the device onboard process.

Device will now treat the presence of ssh public key in /config/authorized_keys as user intention to allow ssh access and install the given ssh key. 

This key from configuration directory is moved into /persist/status/zedagent/ConfigItemValueMap/global.json. Then the key file from configuration directory is deleted. Rest is taken care by pubsub as usual when service come up.


Signed-off-by: gkodali-zededa <gkodali@zededa.com>