### PR TITLE
Only apply /config/DevicePortConfig/*.json once

### DIFF
--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -147,6 +147,17 @@ func compressAndPublishDevicePortConfigList(ctx *DeviceNetworkContext) types.Dev
 		log.Functionf("publishing DevicePortConfigList compressed: %+v\n", dpcl)
 		ctx.PubDevicePortConfigList.Publish("global", dpcl)
 	}
+	// Check and delete any OriginFile; might already have been deleted
+	for i, dpc := range dpcl.PortConfigList {
+		if dpc.OriginFile == "" {
+			continue
+		}
+		err := os.Remove(dpc.OriginFile)
+		if err == nil {
+			log.Noticef("Removed OriginFile %s for %d",
+				dpc.OriginFile, i)
+		}
+	}
 	return dpcl
 }
 
@@ -193,6 +204,14 @@ func compressDPCL(ctx *DeviceNetworkContext) types.DevicePortConfigList {
 				break
 			}
 			log.Functionf("compressDPCL: Ignoring - i = %d, dpc: %+v", i, dpc)
+			// Check and delete any OriginFile; might already have been deleted
+			if dpc.OriginFile != "" {
+				err := os.Remove(dpc.OriginFile)
+				if err == nil {
+					log.Noticef("Removed OriginFile %s for %d",
+						dpc.OriginFile, i)
+				}
+			}
 		}
 	}
 

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -347,15 +347,6 @@ if [ -f $CONFIGDIR/DevicePortConfig/usb.json ]; then
     echo "$(date -Ins -u) Removing old $CONFIGDIR/DevicePortConfig/usb.json"
     rm -f $CONFIGDIR/DevicePortConfig/usb.json
 fi
-# Copy any DevicePortConfig from /config
-dir=$CONFIGDIR/DevicePortConfig
-for f in "$dir"/*.json; do
-    if [ "$f" = "$dir/*.json" ]; then
-        break
-    fi
-    echo "$(date -Ins -u) Copying from $f to $DPCDIR"
-    cp -p "$f" $DPCDIR
-done
 
 # Get IP addresses
 echo "$(date -Ins -u) Starting nim"

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -442,7 +442,7 @@ type DevicePortConfig struct {
 	Key          string
 	TimePriority time.Time // All zero's is fallback lowest priority
 	State        PendDPCStatus
-
+	OriginFile   string // File to be deleted once DevicePortConfigList published
 	TestResults
 	LastIPAndDNS time.Time // Time when we got some IP addresses and DNS
 


### PR DESCRIPTION
Once it has been added to DevicePortConfigList it will be deleted from /config to avoid causing churn after a reboot.
The content will remain in DevicePortConfigList until it is no longer needed e.g., succesfully connected to controller and the DPC from the controller is working. But we avoid adding it back by copying from /config again on a subsequent reboot.