### PR TITLE
retry eve image update

### DIFF
--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -56,6 +56,7 @@ type getconfigContext struct {
 	pubAppNetworkConfig      pubsub.Publication
 	subAppNetworkStatus      pubsub.Subscription
 	pubBaseOsConfig          pubsub.Publication
+	pubBaseOs                pubsub.Publication
 	pubDatastoreConfig       pubsub.Publication
 	pubNetworkInstanceConfig pubsub.Publication
 	pubControllerCert        pubsub.Publication
@@ -75,6 +76,8 @@ type getconfigContext struct {
 	localProfileTrigger      chan Notify
 
 	callProcessLocalProfileServerChange bool //did we already call processLocalProfileServerChange
+
+	configRetryUpdateCounter uint32 // received from config
 }
 
 // devUUID is set in Run and never changed

--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -231,6 +231,8 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 	ReportDeviceManufacturerInfo.Compatible = *proto.String(compatible)
 	ReportDeviceInfo.Minfo = ReportDeviceManufacturerInfo
 
+	ReportDeviceInfo.BaseosUpdateCounter = getBaseosUpdateCounter(ctx)
+
 	// Report BaseOs Status for the two partitions
 	getBaseOsStatus := func(partLabel string) *types.BaseOsStatus {
 		// Look for a matching IMGA/IMGB in baseOsStatus
@@ -812,4 +814,14 @@ func getCapabilities(ctx *zedagentContext) *info.Capabilities {
 		HWAssistedVirtualization: capabilities.HWAssistedVirtualization,
 		IOVirtualization:         capabilities.IOVirtualization,
 	}
+}
+
+func getBaseosUpdateCounter(ctx *zedagentContext) uint32 {
+	m, err := ctx.subBaseOsMgrStatus.Get("global")
+	if err != nil {
+		log.Warnf("ctx.subBaseOsMgrStatus.Get failed: %s", err)
+		return 0
+	}
+	status := m.(types.BaseOSMgrStatus)
+	return status.CurrentRetryUpdateCounter
 }

--- a/pkg/pillar/types/zedagenttypes.go
+++ b/pkg/pillar/types/zedagenttypes.go
@@ -539,3 +539,14 @@ type DeviceOpsCmd struct {
 	DesiredState bool
 	OpsTime      string
 }
+
+// BaseOSMgrStatus : for sending from baseosmgr
+type BaseOSMgrStatus struct {
+	CurrentRetryUpdateCounter uint32 // CurrentRetryUpdateCounter from baseosmgr
+}
+
+// BaseOs : copy of zconfig.BaseOS
+type BaseOs struct {
+	ContentTreeUUID          string
+	ConfigRetryUpdateCounter uint32
+}


### PR DESCRIPTION
Possibility to retry eve image update by incrementing the counter (EdgeDevConfig->Baseos->RetryUpdate->Counter).

If the currently configured image is in FAILED state in the other partition, retry the image upgrade.
ELSE Do nothing. Just update the BaseosUpdateCounter counter in the Info message and send an Info message to zedcloud.

Need to work on understanding info message flow.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>