### PR TITLE
Empty assignment group means not assignable

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1657,6 +1657,10 @@ func reserveAdapters(ctx *domainContext, config types.DomainConfig) error {
 			}
 			log.Functionf("reserveAdapters processing adapter %d %s member %s",
 				adapter.Type, adapter.Name, ibp.Phylabel)
+			if ibp.AssignmentGroup == "" {
+				return fmt.Errorf("adapter %d %s member %s is not assignable",
+					adapter.Type, adapter.Name, ibp.Phylabel)
+			}
 			if ibp.UsedByUUID != config.UUIDandVersion.UUID &&
 				ibp.UsedByUUID != nilUUID {
 				return fmt.Errorf("adapter %d %s used by %s",

--- a/pkg/pillar/types/assignableadapters.go
+++ b/pkg/pillar/types/assignableadapters.go
@@ -45,6 +45,7 @@ type IoBundle struct {
 
 	// Assignment Group, is unique label that is applied across PhysicalIOs
 	// Entire group can be assigned to application or nothing at all
+	// If this is an empty string it means the IoBundle can not be assigned.
 	AssignmentGroup string
 
 	Usage zcommon.PhyIoMemberUsage


### PR DESCRIPTION
The manually created model files and the ones generated by spec.sh assume that an empty assignment group means that app-direct assignment is not allowed for that adapter. However, we do not have a check for this, hence we can break things if some PCI controller has some other functions.

This PR just adds the check+error.
But we also need to validate the model files to make sure we do not incorretly have empty assignGrp.