### PR TITLE
update qemu-system 4.2->5.2 and libslirp0 4.1.0->4.4.0 from backports

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -22,7 +22,7 @@ jobs:
           done
       - name: setup
         run: |
-          sudo apt update
+          sudo add-apt-repository ppa:canonical-server/server-backports
           sudo apt install -y qemu-utils qemu-system-x86 jq
       - name: get eden
         uses: actions/checkout@v2


### PR DESCRIPTION
update qemu-system 4.2->5.2 and libslirp0 4.1.0->4.4.0 from backports

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>