### PR TITLE
[WIP] Fix bug for case when ifname != logicallabel

### DIFF
--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -704,7 +704,7 @@ func checkNIphysicalPort(ctx *zedrouterContext, status *types.NetworkInstanceSta
 		ifname := types.LogicallabelToIfName(ctx.deviceNetworkStatus, label)
 		devPort := ctx.deviceNetworkStatus.GetPortByIfName(ifname)
 		if devPort == nil {
-			err := fmt.Sprintf("Network Instance port %s does not exist", label)
+			err := fmt.Sprintf("Network Instance port %s ifname %s does not exist", label, ifname)
 			return errors.New(err)
 		}
 	}

--- a/pkg/pillar/types/assignableadapters.go
+++ b/pkg/pillar/types/assignableadapters.go
@@ -328,6 +328,16 @@ func (aa *AssignableAdapters) LookupIoBundlePhylabel(phylabel string) *IoBundle 
 	return nil
 }
 
+// LookupIoBundleLogicallabel returns nil if not found
+func (aa *AssignableAdapters) LookupIoBundleLogicallabel(label string) *IoBundle {
+	for i, b := range aa.IoBundleList {
+		if strings.EqualFold(b.Logicallabel, label) {
+			return &aa.IoBundleList[i]
+		}
+	}
+	return nil
+}
+
 // LookupIoBundleGroup returns an empty slice if not found
 // Returns pointers into aa
 func (aa *AssignableAdapters) LookupIoBundleGroup(group string) []*IoBundle {
@@ -348,7 +358,7 @@ func (aa *AssignableAdapters) LookupIoBundleGroup(group string) []*IoBundle {
 }
 
 // LookupIoBundleAny returns an empty slice if not found; name can be
-// a member phylabel or a group
+// a member phylabel, logicallabel, or a group
 // Returns pointers into aa
 func (aa *AssignableAdapters) LookupIoBundleAny(name string) []*IoBundle {
 
@@ -358,7 +368,10 @@ func (aa *AssignableAdapters) LookupIoBundleAny(name string) []*IoBundle {
 	}
 	ib := aa.LookupIoBundlePhylabel(name)
 	if ib == nil {
-		return list
+		ib = aa.LookupIoBundleLogicallabel(name)
+		if ib == nil {
+			return list
+		}
 	}
 	if ib.AssignmentGroup == "" {
 		// Singleton


### PR DESCRIPTION
To test this I used a variant of a SYS-E100 model where the ifname, phylabel, and logicallabel for eth0 and eth1 are all different, and then do the assignment using ztests. There are some issues in the Zededa controller which also needs to be addressed to make this work from the Zededa UI.