### PR TITLE
Network instance cleanup for phylabel handling; report logicallabel to controller

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1109,7 +1109,7 @@ func doAssignIoAdaptersToDomain(ctx *domainContext, config types.DomainConfig,
 			if ib == nil {
 				continue
 			}
-			log.Functionf("doAssignIoAdaptersToDomain processing adapter %d %s member %s",
+			log.Functionf("doAssignIoAdaptersToDomain processing adapter %d %s phylabel %s",
 				adapter.Type, adapter.Name, ib.Phylabel)
 			if ib.UsedByUUID != config.UUIDandVersion.UUID {
 				log.Fatalf("doAssignIoAdaptersToDomain IoBundle stolen by %s: %d %s for %s",
@@ -1745,10 +1745,10 @@ func reserveAdapters(ctx *domainContext, config types.DomainConfig) *types.Error
 			if ibp == nil {
 				continue
 			}
-			log.Functionf("reserveAdapters processing adapter %d %s member %s",
+			log.Functionf("reserveAdapters processing adapter %d %s phylabel %s",
 				adapter.Type, adapter.Name, ibp.Phylabel)
 			if ibp.AssignmentGroup == "" {
-				description.Error = fmt.Sprintf("adapter %d %s member %s is not assignable",
+				description.Error = fmt.Sprintf("adapter %d %s phylabel %s is not assignable",
 					adapter.Type, adapter.Name, ibp.Phylabel)
 				return &description
 			}
@@ -1776,12 +1776,12 @@ func reserveAdapters(ctx *domainContext, config types.DomainConfig) *types.Error
 				return &description
 			}
 			if ibp.IsPort {
-				description.Error = fmt.Sprintf("adapter %d %s member %s is (part of) a zedrouter port",
+				description.Error = fmt.Sprintf("adapter %d %s phylabel %s is (part of) a zedrouter port",
 					adapter.Type, adapter.Name, ibp.Phylabel)
 				return &description
 			}
 			if ibp.Error != "" {
-				description.Error = fmt.Sprintf("adapter %d %s member %s has error: %s",
+				description.Error = fmt.Sprintf("adapter %d %s phylabel %s has error: %s",
 					adapter.Type, adapter.Name, ibp.Phylabel, ibp.Error)
 				return &description
 			}
@@ -1791,11 +1791,11 @@ func reserveAdapters(ctx *domainContext, config types.DomainConfig) *types.Error
 				continue
 			}
 			if ibp.PciLong != "" && !hasIOVirtualization {
-				description.Error = fmt.Sprintf("no I/O virtualization support: adapter %d %s member %s cannot be assigned",
+				description.Error = fmt.Sprintf("no I/O virtualization support: adapter %d %s phylabel %s cannot be assigned",
 					adapter.Type, adapter.Name, ibp.Phylabel)
 				return &description
 			}
-			log.Tracef("reserveAdapters setting uuid %s for adapter %d %s member %s",
+			log.Tracef("reserveAdapters setting uuid %s for adapter %d %s phylabel %s",
 				config.Key(), adapter.Type, adapter.Name, ibp.Phylabel)
 			ibp.UsedByUUID = config.UUIDandVersion.UUID
 		}

--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -134,14 +134,15 @@ func prepareAndPublishNetworkInstanceInfoMsg(ctx *zedagentContext,
 			}
 			reportAA := new(zinfo.ZioBundle)
 			reportAA.Type = zcommon.PhyIoType(ia.Type)
-			reportAA.Name = ia.Phylabel
+			reportAA.Name = ia.Logicallabel
+			// XXX Add Phylabel in protobuf message?
 			reportAA.UsedByAppUUID = zcdevUUID.String()
 			list := ctx.assignableAdapters.LookupIoBundleAny(ia.Phylabel)
 			for _, ib := range list {
 				if ib == nil {
 					continue
 				}
-				reportAA.Members = append(reportAA.Members, ib.Phylabel)
+				reportAA.Members = append(reportAA.Members, ib.Logicallabel)
 				if ib.MacAddr != "" {
 					reportMac := new(zinfo.IoAddresses)
 					reportMac.MacAddress = ib.MacAddr

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -671,10 +671,11 @@ func parseOneSystemAdapterConfig(getconfigCtx *getconfigContext,
 		sysAdapter.Name, sysAdapter.LowerLayerName)
 	port := new(types.NetworkPortConfig)
 
-	port.Logicallabel = sysAdapter.Name
+	port.Logicallabel = sysAdapter.Name // XXX Rename field in protobuf?
 	port.Alias = sysAdapter.Alias
 	// Look up using LowerLayerName which should match a phyio PhysicalLabel.
-	// If LowerLayerName was not set we use Name
+	// If LowerLayerName was not set we use Name i.e., assume
+	// Phylabel and Logicallabel are the same
 	if sysAdapter.LowerLayerName == "" {
 		port.Phylabel = sysAdapter.Name
 	} else {

--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -389,7 +389,7 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 				continue
 			}
 			reportAA.Members = append(reportAA.Members,
-				b.Phylabel)
+				b.Logicallabel)
 			if b.MacAddr != "" {
 				reportMac := new(info.IoAddresses)
 				reportMac.MacAddress = b.MacAddr

--- a/pkg/pillar/types/assignableadapters.go
+++ b/pkg/pillar/types/assignableadapters.go
@@ -35,12 +35,11 @@ type IoBundle struct {
 	//	Type of the IoBundle
 	Type IoType
 	// Phylabel
-	//	Short hand name such as "COM1".
-	//	Used in the API to specify that a adapter should
-	//	be assigned to an application.
+	//	Label on the outside of the enclosure
 	Phylabel string
 
-	// Logical Label assigned to the Adapter
+	// Logical Label assigned to the Adapter. Could match Phylabel
+	// or could be a user-chosen string like "shopfloor"
 	Logicallabel string
 
 	// Assignment Group, is unique label that is applied across PhysicalIOs

--- a/pkg/pillar/types/ifnametopci.go
+++ b/pkg/pillar/types/ifnametopci.go
@@ -194,8 +194,8 @@ func IoBundleToPci(log *base.LogObject, ib *IoBundle) (string, error) {
 		return "", nil
 	}
 	if !pciLongExists(long) {
-		errStr := fmt.Sprintf("PCI device %s long %s does not exist",
-			ib.Phylabel, long)
+		errStr := fmt.Sprintf("PCI device %s/%s long %s does not exist",
+			ib.Phylabel, ib.Logicallabel, long)
 		return long, errors.New(errStr)
 	}
 	return long, nil

--- a/pkg/pillar/types/physicalioadapters.go
+++ b/pkg/pillar/types/physicalioadapters.go
@@ -37,9 +37,9 @@ type PhyIOUsagePolicy struct {
 // from controller for each Adapter.
 type PhysicalIOAdapter struct {
 	Ptype        zcommon.PhyIoType // Type of IO Device
-	Phylabel     string            // Label put on the box
+	Phylabel     string            // Label printed on the enclosure
 	Phyaddr      PhysicalAddress
-	Logicallabel string
+	Logicallabel string // Label assigned by model creator
 	Assigngrp    string
 	Usage        zcommon.PhyIoMemberUsage
 	UsagePolicy  PhyIOUsagePolicy
@@ -99,12 +99,12 @@ func (ioAdapterList PhysicalIOAdapterList) LogKey() string {
 	return string(base.PhysicalIOAdapterListLogType) + "-" + ioAdapterList.Key()
 }
 
-// LookupAdapter - look up an Adapter by its name ( phylabel )
+// LookupAdapter - look up an Adapter by its phylabel
 func (ioAdapterList *PhysicalIOAdapterList) LookupAdapter(
-	name string) *PhysicalIOAdapter {
+	phylabel string) *PhysicalIOAdapter {
 	for indx := range ioAdapterList.AdapterList {
 		adapter := &ioAdapterList.AdapterList[indx]
-		if adapter.Phylabel == name {
+		if adapter.Phylabel == phylabel {
 			return adapter
 		}
 	}

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -1317,13 +1317,13 @@ func CountLocalAddrAnyNoLinkLocal(globalStatus DeviceNetworkStatus) int {
 // CountLocalAddrAnyNoLinkLocalIf return number of local IP addresses for
 // the interface excluding link-local addresses
 func CountLocalAddrAnyNoLinkLocalIf(globalStatus DeviceNetworkStatus,
-	phylabelOrIfname string) (int, error) {
+	ifname string) (int, error) {
 
-	if phylabelOrIfname == "" {
+	if ifname == "" {
 		return 0, fmt.Errorf("ifname not specified")
 	}
 	// Count the number of addresses which apply
-	addrs, err := getLocalAddrListImpl(globalStatus, phylabelOrIfname,
+	addrs, err := getLocalAddrListImpl(globalStatus, ifname,
 		PortCostMax, false, 0)
 	return len(addrs), err
 }
@@ -1352,15 +1352,9 @@ func CountLocalIPv4AddrAnyNoLinkLocal(globalStatus DeviceNetworkStatus) int {
 	return len(addrs)
 }
 
-// CountDNSServers returns the number of DNS servers; for phylabelOrIfname if set
-func CountDNSServers(globalStatus DeviceNetworkStatus, phylabelOrIfname string) int {
+// CountDNSServers returns the number of DNS servers; for ifname if set
+func CountDNSServers(globalStatus DeviceNetworkStatus, ifname string) int {
 
-	var ifname string
-	if phylabelOrIfname != "" {
-		ifname = PhylabelToIfName(&globalStatus, phylabelOrIfname)
-	} else {
-		ifname = phylabelOrIfname
-	}
 	count := 0
 	for _, us := range globalStatus.Ports {
 		if us.IfName != ifname && ifname != "" {
@@ -1407,28 +1401,28 @@ func GetNTPServers(globalStatus DeviceNetworkStatus, ifname string) []net.IP {
 // CountLocalIPv4AddrAnyNoLinkLocalIf is like CountLocalAddrAnyNoLinkLocalIf but
 // only IPv4 addresses are counted
 func CountLocalIPv4AddrAnyNoLinkLocalIf(globalStatus DeviceNetworkStatus,
-	phylabelOrIfname string) (int, error) {
+	ifname string) (int, error) {
 
-	if phylabelOrIfname == "" {
+	if ifname == "" {
 		return 0, fmt.Errorf("ifname not specified")
 	}
 	// Count the number of addresses which apply
-	addrs, err := getLocalAddrListImpl(globalStatus, phylabelOrIfname,
+	addrs, err := getLocalAddrListImpl(globalStatus, ifname,
 		PortCostMax, false, 4)
 	return len(addrs), err
 }
 
 // GetLocalAddrAnyNoLinkLocal is used to pick one address from:
-// - phylabelOrIfname if set.
+// - ifname if set.
 // - otherwise from all of the management ports
 // Excludes link-local addresses.
 // The addresses are sorted in cost order thus as the caller starts with
 // pickNum zero and increases it will use the ports in cost order.
 func GetLocalAddrAnyNoLinkLocal(globalStatus DeviceNetworkStatus, pickNum int,
-	phylabelOrIfname string) (net.IP, error) {
+	ifname string) (net.IP, error) {
 
 	includeLinkLocal := false
-	return getLocalAddrImpl(globalStatus, pickNum, phylabelOrIfname,
+	return getLocalAddrImpl(globalStatus, pickNum, ifname,
 		PortCostMax, includeLinkLocal, 0)
 }
 
@@ -1438,22 +1432,22 @@ func GetLocalAddrAnyNoLinkLocal(globalStatus DeviceNetworkStatus, pickNum int,
 // If 0 is specified it only considers local addresses on cost zero ports;
 // if 255 is specified it considers all the local addresses.
 func GetLocalAddrNoLinkLocalWithCost(globalStatus DeviceNetworkStatus, pickNum int,
-	phylabelOrIfname string, maxCost uint8) (net.IP, error) {
+	ifname string, maxCost uint8) (net.IP, error) {
 
 	includeLinkLocal := false
-	return getLocalAddrImpl(globalStatus, pickNum, phylabelOrIfname,
+	return getLocalAddrImpl(globalStatus, pickNum, ifname,
 		maxCost, includeLinkLocal, 0)
 }
 
 // getLocalAddrImpl returns an IP address based on interfaces sorted in
-// cost order. If phylabelOrIfname is set, the addresses are from that
+// cost order. If ifname is set, the addresses are from that
 // interface. Otherwise from all management interfaces up to and including maxCost.
 // af can be set to 0 (any), 4, IPv4), or 6 (IPv6) to select the family.
 func getLocalAddrImpl(globalStatus DeviceNetworkStatus, pickNum int,
-	phylabelOrIfname string, maxCost uint8, includeLinkLocal bool,
+	ifname string, maxCost uint8, includeLinkLocal bool,
 	af uint) (net.IP, error) {
 
-	addrs, err := getLocalAddrListImpl(globalStatus, phylabelOrIfname,
+	addrs, err := getLocalAddrListImpl(globalStatus, ifname,
 		maxCost, includeLinkLocal, af)
 	if err != nil {
 		return net.IP{}, err
@@ -1464,20 +1458,23 @@ func getLocalAddrImpl(globalStatus DeviceNetworkStatus, pickNum int,
 }
 
 // getLocalAddrListImpl returns a list IP addresses based on interfaces sorted
-// in cost order. If phylabelOrIfname is set, the addresses are from that
+// in cost order. If ifname is set, the addresses are from that
 // interface. Otherwise from all management interfaces up to and including maxCost
 // af can be set to 0 (any), 4, IPv4), or 6 (IPv6) to select a subset.
 func getLocalAddrListImpl(globalStatus DeviceNetworkStatus,
-	phylabelOrIfname string, maxCost uint8, includeLinkLocal bool,
+	ifname string, maxCost uint8, includeLinkLocal bool,
 	af uint) ([]net.IP, error) {
 
 	var ifnameList []string
-	if phylabelOrIfname == "" {
+	var ignoreErrors bool
+	if ifname == "" {
 		// Get interfaces in cost order
 		ifnameList = getMgmtPortsSortedCostImpl(globalStatus, 0,
 			maxCost, false)
+		// If we are looking across all interfaces, then We ignore errors
+		// since we get them if there are no addresses on a ports
+		ignoreErrors = true
 	} else {
-		ifname := PhylabelToIfName(&globalStatus, phylabelOrIfname)
 		us := GetPort(globalStatus, ifname)
 		if us == nil {
 			return []net.IP{}, fmt.Errorf("Unknown interface %s",
@@ -1493,9 +1490,7 @@ func getLocalAddrListImpl(globalStatus DeviceNetworkStatus,
 	for _, ifname := range ifnameList {
 		ifaddrs, err := getLocalAddrIf(globalStatus, ifname,
 			includeLinkLocal, af)
-		// If we are looking across all interfaces, then We ignore errors
-		// since we get them if there are no addresses on a ports
-		if err != nil && phylabelOrIfname != "" {
+		if !ignoreErrors && err != nil {
 			return addrs, err
 		}
 		addrs = append(addrs, ifaddrs...)
@@ -1532,9 +1527,9 @@ func IsPort(globalStatus DeviceNetworkStatus, ifname string) bool {
 }
 
 // Check if a physical label or ifname is a management port
-func IsMgmtPort(globalStatus DeviceNetworkStatus, phylabelOrIfname string) bool {
+func IsMgmtPort(globalStatus DeviceNetworkStatus, ifname string) bool {
 	for _, us := range globalStatus.Ports {
-		if us.Phylabel != phylabelOrIfname && us.IfName != phylabelOrIfname {
+		if us.IfName != ifname {
 			continue
 		}
 		if globalStatus.Version >= DPCIsMgmt &&
@@ -1548,9 +1543,9 @@ func IsMgmtPort(globalStatus DeviceNetworkStatus, phylabelOrIfname string) bool 
 
 // GetPortCost returns the port cost
 // Returns 0 if the ifname does not exist.
-func GetPortCost(globalStatus DeviceNetworkStatus, phylabelOrIfname string) uint8 {
+func GetPortCost(globalStatus DeviceNetworkStatus, ifname string) uint8 {
 	for _, us := range globalStatus.Ports {
-		if us.Phylabel != phylabelOrIfname && us.IfName != phylabelOrIfname {
+		if us.IfName != ifname {
 			continue
 		}
 		return us.Cost
@@ -1558,9 +1553,9 @@ func GetPortCost(globalStatus DeviceNetworkStatus, phylabelOrIfname string) uint
 	return 0
 }
 
-func GetPort(globalStatus DeviceNetworkStatus, phylabelOrIfname string) *NetworkPortStatus {
+func GetPort(globalStatus DeviceNetworkStatus, ifname string) *NetworkPortStatus {
 	for _, us := range globalStatus.Ports {
-		if us.Phylabel != phylabelOrIfname && us.IfName != phylabelOrIfname {
+		if us.IfName != ifname {
 			continue
 		}
 		if globalStatus.Version < DPCIsMgmt {
@@ -1587,15 +1582,14 @@ func GetMgmtPortFromAddr(globalStatus DeviceNetworkStatus, addr net.IP) string {
 	return ""
 }
 
-// GetLocalAddrList returns all IP addresses on the phylabelOrIfName except
+// GetLocalAddrList returns all IP addresses on the ifName except
 // the link local addresses.
 func GetLocalAddrList(globalStatus DeviceNetworkStatus,
-	phylabelOrIfname string) ([]net.IP, error) {
+	ifname string) ([]net.IP, error) {
 
-	if phylabelOrIfname == "" {
+	if ifname == "" {
 		return []net.IP{}, fmt.Errorf("ifname not specified")
 	}
-	ifname := PhylabelToIfName(&globalStatus, phylabelOrIfname)
 	return getLocalAddrIf(globalStatus, ifname, false, 0)
 }
 
@@ -1661,24 +1655,6 @@ func (status *DeviceNetworkStatus) UpdatePortStatusFromIntfStatusMap(
 		}
 		// Else - Port not tested hence no change
 	}
-}
-
-// PhylabelToIfName looks up a port Phylabel or IfName to find an existing IfName
-// If not found, return the phylabelOrIfname argument string
-func PhylabelToIfName(deviceNetworkStatus *DeviceNetworkStatus,
-	phylabelOrIfname string) string {
-
-	for _, p := range deviceNetworkStatus.Ports {
-		if p.Phylabel == phylabelOrIfname {
-			return p.IfName
-		}
-	}
-	for _, p := range deviceNetworkStatus.Ports {
-		if p.IfName == phylabelOrIfname {
-			return phylabelOrIfname
-		}
-	}
-	return phylabelOrIfname
 }
 
 // LogicallabelToIfName looks up a port Logical label to find an existing IfName
@@ -2374,7 +2350,7 @@ type AppNetworkACLArgs struct {
 	VifName    string
 	BridgeIP   string
 	AppIP      string
-	UpLinks    []string
+	UpLinks    []string // List of ifnames
 	NIType     NetworkInstanceType
 	// This is the same AppNum that comes from AppNetworkStatus
 	AppNum int32


### PR DESCRIPTION
Commit1:
Report the logicallabel for the adapters in the API so controller can correlate.
Also cleanup logs and some error messages to indicate it is the phylabel which is printed.

Commit2:
Remove unneeded checks for phylabelOrIfname since all the callers pass an ifname to these functions in zedroutertypes.go