### PR TITLE
Improve boot time in offline mode; improve error/info reporting e.g., when changing profile

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1723,8 +1723,19 @@ func reserveAdapters(ctx *domainContext, config types.DomainConfig) error {
 			}
 			if ibp.UsedByUUID != config.UUIDandVersion.UUID &&
 				ibp.UsedByUUID != nilUUID {
-				return fmt.Errorf("adapter %d %s used by %s",
-					adapter.Type, adapter.Name, ibp.UsedByUUID)
+				// Check if current user of ibp is halting
+				extraStr := ""
+				other := lookupDomainStatusByUUID(ctx, ibp.UsedByUUID)
+				if other == nil {
+					log.Warnf("UsedByUUID %s but no status",
+						ibp.UsedByUUID)
+					extraStr = "(which is missing)"
+				} else if other.State == types.HALTING {
+					extraStr = "(which is halting)"
+				}
+				return fmt.Errorf("adapter %d %s used by %s %s",
+					adapter.Type, adapter.Name,
+					ibp.UsedByUUID, extraStr)
 			}
 			if ibp.IsPort {
 				return fmt.Errorf("adapter %d %s member %s is (part of) a zedrouter port",

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -308,6 +308,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		case <-stillRunning.C:
 		}
 		ps.StillRunning(agentName, warningTime, errorTime)
+		// Did any update above make more resources available for
+		// other app instances?
 		if ctx.checkFreedResources {
 			start := time.Now()
 			checkRetry(&ctx)


### PR DESCRIPTION
Commit1: 
No need to wait for IP address unless we need ntp to generate certificate. This improves boottime by up to 5 minutes when there is no DHCP server or otherwise no network connectivity when the device boots.

Commit2: 
When we have an error (really information, since the error can be cleared later) about missing/busy resources such as I/O adapters or memory, this commit makes the error messages indicate whether the resources are likely to be freed up soon. Such transient errors appear frequently when switching profiles since that results in some app instances halting and others booting. The updated messages indicate this. (And in the future we should update the API so we can label these messages as informational.)
