### PR TITLE
making hsm, watchdog and leds as string

### DIFF
--- a/pkg/debug/spec.sh
+++ b/pkg/debug/spec.sh
@@ -62,9 +62,9 @@ cat <<__EOT__
     "memory": "${MEM}G",
     "storage": "${DISK}G",
     "Cpus": "${CPUS}",
-    "watchdog": ${WDT},
-    "hsm": ${HSM},
-    "leds": 0
+    "watchdog": "${WDT}",
+    "hsm": "${HSM}",
+    "leds": "0"
   },
   "logo": {
     "logo_back":"/workspace/spec/logo_back_.jpg",


### PR DESCRIPTION
Signed-off-by: chethan-zededa <chethan@zededa.com>

I didn't know the correct way to test this change but executed the spec.sh

<img width="553" alt="Screenshot 2021-07-13 at 9 34 53 PM" src="https://user-images.githubusercontent.com/56288604/125486574-fd67faed-16cf-474f-beb6-bb031516b8f1.png">
