### PR TITLE
Implement ACE Drop action

### DIFF
--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -1582,7 +1582,7 @@ func parseUnderlayNetworkConfigEntry(
 			actionCfg.LimitBurst = int(action.Limitburst)
 			actionCfg.PortMap = action.Portmap
 			actionCfg.TargetPort = int(action.AppPort)
-			// XXX:FIXME actionCfg.Drop = <TBD>
+			actionCfg.Drop = action.Drop
 			aclCfg.Actions[actionIdx] = *actionCfg
 		}
 		ulCfg.ACLs[aclIdx] = *aclCfg

--- a/pkg/pillar/cmd/zedrouter/pbr.go
+++ b/pkg/pillar/cmd/zedrouter/pbr.go
@@ -281,15 +281,15 @@ func AddOverlayRuleAndRoute(bridgeName string, iifIndex int,
 	return nil
 }
 
-// AddFwMarkRuleToDummy : Create a ip rule that sends packets marked with given mark
+// AddFwMarkRuleToDummy : Create an ip rule that sends packets marked by a Drop ACE
 // out of interface with given index.
-func AddFwMarkRuleToDummy(fwmark uint32, iifIndex int) error {
+func AddFwMarkRuleToDummy(iifIndex int) error {
 
 	r := netlink.NewRule()
 	myTable := baseTableIndex + iifIndex
 	r.Table = myTable
-	r.Mark = int(fwmark)
-	r.Mask = 0x00ffffff
+	r.Mark = aceDropAction
+	r.Mask = aceActionMask
 	// This rule gets added during the starting steps of service.
 	// Other ip rules corresponding to network instances get added after this
 	// and take higher priority. We want this ip rule to match before anything else.

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -39,8 +39,6 @@ import (
 const (
 	agentName  = "zedrouter"
 	runDirname = "/run/zedrouter"
-	// DropMarkValue :
-	DropMarkValue = 0xFFFFFF
 	// Time limits for event loop handlers
 	errorTime   = 3 * time.Minute
 	warningTime = 40 * time.Second
@@ -153,7 +151,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	pubUuidToNum.ClearRestarted()
 
 	// Create the dummy interface used to re-direct DROP/REJECT packets.
-	createFlowMonDummyInterface(DropMarkValue)
+	createFlowMonDummyInterface()
 
 	// Pick up (mostly static) AssignableAdapters before we process
 	// any Routes; Pbr needs to know which network adapters are assignable


### PR DESCRIPTION
This PR implements/fixes the Drop action for access control entries. Up until now, the Drop action was not implemented and without any warnings behaved as the opposite Allow action.

Instead of adding one IP rule for each drop ACE, a single bit of the connection mark is used to set and determine which of the two actions should be applied for a given flow. This bit was previously used for ACE ID, the size of which went down from 24 bits to 23 bits. Still more than enough room for any reasonable number of ACEs.

Tested in eden: https://github.com/lf-edge/eden/pull/656

Signed-off-by: Milan Lenco <milan@zededa.com>