### PR TITLE
fix the nim watchdog due to slow network

### DIFF
--- a/pkg/dom0-ztools/rootfs/etc/sysctl.d/02-eve.conf
+++ b/pkg/dom0-ztools/rootfs/etc/sysctl.d/02-eve.conf
@@ -20,6 +20,12 @@ net.netfilter.nf_conntrack_timestamp = 1
 net.ipv4.conf.all.log_martians = 0
 net.ipv4.conf.default.log_martians = 0
 
+# Avoid lots of temporary addresses; use RFC7217 instead
+net.ipv6.conf.default.addr_gen_mode = 2
+net.ipv6.conf.all.addr_gen_mode = 2
+net.ipv6.conf.default.use_tempaddr = 0
+net.ipv6.conf.all.use_tempaddr = 0
+
 # For reliable downloads need less than 2 hour keepalive timer
 net.ipv4.tcp_keepalive_time = 60
 

--- a/pkg/pillar/devicenetwork/devicenetwork.go
+++ b/pkg/pillar/devicenetwork/devicenetwork.go
@@ -268,8 +268,7 @@ func MakeDeviceNetworkStatus(log *base.LogObject, globalConfig types.DevicePortC
 	// Need to write resolv.conf for Geo
 	UpdateResolvConf(log, globalStatus)
 	UpdatePBR(log, globalStatus)
-	// Immediate check
-	UpdateDeviceNetworkGeo(log, time.Second, &globalStatus)
+
 	log.Functionf("MakeDeviceNetworkStatus() DONE\n")
 	return globalStatus
 }

--- a/pkg/pillar/devicenetwork/dhcpcd.go
+++ b/pkg/pillar/devicenetwork/dhcpcd.go
@@ -8,9 +8,6 @@ package devicenetwork
 
 import (
 	"fmt"
-	"github.com/lf-edge/eve/pkg/pillar/agentlog"
-	"github.com/lf-edge/eve/pkg/pillar/base"
-	"github.com/lf-edge/eve/pkg/pillar/types"
 	"io/ioutil"
 	"net"
 	"os"
@@ -20,6 +17,10 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/agentlog"
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/types"
 )
 
 // UpdateDhcpClient starts/modifies/deletes dhcpcd per interface
@@ -87,7 +88,7 @@ func doDhcpClientActivate(log *base.LogObject, nuc types.NetworkPortConfig) {
 	case types.DT_CLIENT:
 		for dhcpcdExists(log, nuc.IfName) {
 			log.Warnf("dhcpcd %s already exists", nuc.IfName)
-			time.Sleep(10 * time.Second)
+			time.Sleep(1 * time.Second)
 		}
 		log.Functionf("dhcpcd %s not running", nuc.IfName)
 		extras := []string{"-f", "/dhcpcd.conf", "--noipv4ll", "-b", "-t", "0"}
@@ -109,7 +110,7 @@ func doDhcpClientActivate(log *base.LogObject, nuc types.NetworkPortConfig) {
 				failed = true
 				break
 			}
-			time.Sleep(10 * time.Second)
+			time.Sleep(1 * time.Second)
 		}
 		if !failed {
 			log.Functionf("dhcpcd %s is running", nuc.IfName)
@@ -130,7 +131,7 @@ func doDhcpClientActivate(log *base.LogObject, nuc types.NetworkPortConfig) {
 		}
 		for dhcpcdExists(log, nuc.IfName) {
 			log.Warnf("dhcpcd %s already exists", nuc.IfName)
-			time.Sleep(10 * time.Second)
+			time.Sleep(1 * time.Second)
 		}
 		log.Functionf("dhcpcd %s not running", nuc.IfName)
 		args := []string{fmt.Sprintf("ip_address=%s", nuc.AddrSubnet)}
@@ -173,7 +174,7 @@ func doDhcpClientActivate(log *base.LogObject, nuc types.NetworkPortConfig) {
 				failed = true
 				break
 			}
-			time.Sleep(10 * time.Second)
+			time.Sleep(1 * time.Second)
 		}
 		if !failed {
 			log.Functionf("dhcpcd %s is running", nuc.IfName)
@@ -206,7 +207,7 @@ func doDhcpClientInactivate(log *base.LogObject, nuc types.NetworkPortConfig) {
 		}
 		for dhcpcdExists(log, nuc.IfName) {
 			log.Warnf("dhcpcd %s still running", nuc.IfName)
-			time.Sleep(10 * time.Second)
+			time.Sleep(1 * time.Second)
 		}
 		log.Functionf("dhcpcd %s gone", nuc.IfName)
 	default:

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -15,7 +15,7 @@ import (
 	"github.com/eriknordmark/ipinfo"
 	"github.com/google/go-cmp/cmp"
 	"github.com/lf-edge/eve/pkg/pillar/base"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 )
@@ -760,8 +760,10 @@ func (config DevicePortConfig) IsDPCTestable() bool {
 		return true
 	}
 	// convert time difference in nano seconds to seconds
+	// make this 5 minutes, have seen multiple intf/ipv6 addresses taking long time
+	// the the test table list
 	timeDiff := time.Since(config.LastFailed) / time.Second
-	return (timeDiff > 60)
+	return (timeDiff > 300)
 }
 
 // IsDPCUntested - returns true if this is something we might want to test now.


### PR DESCRIPTION
Signed-off-by: Naiming Shen <naiming@zededa.com>
- not to use ipv6 temp address in linux
- remove networkGeo query in MakeDeviceStatus
- doDhcpClient change timer from 10 to 1 sec
- change testable from failure 1 min to 5 mins ago