### PR TITLE
Drop rule for bridged traffic

### DIFF
--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -718,6 +718,7 @@ func handleInit(runDirname string) {
 
 	// Setup initial iptables rules
 	iptables.IptablesInit(log)
+	dropEscapedFlows()
 
 	// ipsets which are independent of config
 	createDefaultIpset()


### PR DESCRIPTION
Install iptables rule to ensure that packets marked with the drop action are indeed dropped and never sent out via downlink or uplink interfaces. Whereas routed packets marked by drop ACEs are blackholed into a dummy interface using a high-priority IP rule, packets which are only bridged and not routed by EVE (i.e. sent between apps on the same local network) escape this IP rule and would otherwise continue in their path even if marked for dropping.
Eden test which reproduces this issue: https://github.com/lf-edge/eden/pull/659

@gkodali-zededa please review

Signed-off-by: Milan Lenco <milan@zededa.com>