### PR TITLE
Fix zedrouter crash when a IPv6 network instance is configured

### DIFF
--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -1186,14 +1186,14 @@ func doNetworkInstanceActivate(ctx *zedrouterContext,
 		}
 	case types.NetworkInstanceTypeLocal:
 		err = natActivate(ctx, status)
-		if err == nil {
+		if err == nil && status.IpType == types.AddressTypeIPV4 {
 			err = createServer4(ctx, status.BridgeIPAddr,
 				status.BridgeName)
 		}
 
 	case types.NetworkInstanceTypeCloud:
 		err = vpnActivate(ctx, status)
-		if err == nil {
+		if err == nil && status.IpType == types.AddressTypeIPV4 {
 			err = createServer4(ctx, status.BridgeIPAddr,
 				status.BridgeName)
 		}


### PR DESCRIPTION
Signed-off-by: Gopi krishna Kodali <gkodali@zededa.com>