### PR TITLE
Confusing diag/LED blinking when /certs API returns bad certs

### DIFF
--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -622,8 +622,14 @@ func fetchCertChain(zedcloudCtx *zedcloud.ZedCloudContext, tlsConfig *tls.Config
 
 	// certs API is always V2, and without UUID, use https
 	requrl := zedcloud.URLPathString(serverNameAndPort, true, nilUUID, "certs")
+	// Save and restore since we don't want the fetch of /certs to
+	// appear as if the device is onboarded.
+	savedNoLedManager := zedcloudCtx.NoLedManager
+	zedcloudCtx.NoLedManager = true
+
 	// currently there is no data included for the request, same as myGet()
 	done, resp, _, contents = myPost(zedcloudCtx, tlsConfig, requrl, retryCount, 0, nil)
+	zedcloudCtx.NoLedManager = savedNoLedManager
 	if resp != nil {
 		log.Functionf("client fetchCertChain done %v, resp-code %d, content len %d", done, resp.StatusCode, len(contents))
 		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusUnauthorized ||


### PR DESCRIPTION
If we have a failure in fetching and verifying the controller certificates at the /certs API endpoint, then diag and the LED flashing will indicate that the device is onboarded when in fact it is not.

Signed-off-by: eriknordmark <erik@zededa.com>