### PR TITLE
Two fixes for spec.sh

### DIFF
--- a/pkg/debug/spec.sh
+++ b/pkg/debug/spec.sh
@@ -292,6 +292,7 @@ for ETH in /sys/class/net/*; do
       "usagePolicy": {},
       "cost": ${COST},
 __EOT__
+     # XXX shouldn't we check if on USB and use the group for the USB controller?
      BUS_ID=$(echo "$ETH" | sed -e 's#/net/.*'"${LABEL}"'##' -e 's#^.*/##')
      if echo "$BUS_ID" | grep -q '[0-9a-f][0-9a-f][0-9a-f][0-9a-f]:[0-9a-f][0-9a-f]:[0-9a-f][0-9a-f].[0-9a-f]'; then
          grp=$(get_assignmentgroup "$LABEL" "$BUS_ID")

--- a/pkg/debug/spec.sh
+++ b/pkg/debug/spec.sh
@@ -213,7 +213,7 @@ for audio in $(lspci -D  | grep Audio | cut -f1 -d\ ); do
 cat <<__EOT__
     ${COMMA}
     {
-      "ztype": 2,
+      "ztype": 4,
       "phylabel": "Audio${ID}",
       "assigngrp": "${grp}",
       "phyaddrs": {


### PR DESCRIPTION
First commit is a wrong ztype.

Second commit is to detect iommu_group overlap with devices we do not care about (to avoid disabling some random memory timing controller or whatever might sit on the PCI bus) TBD: Once PR #2181 makes it to master I'll update its description to describe this.

Second commit also has a fix for an extra "}," after the cost which produces invalid json.

Third commit is just a comment about a TBD for the networking adapters sitting on USB, which the script currently doesn't put in the same assignment group as the USB controller.