### PR TITLE
repeat http download with range support; context propagate

### DIFF
--- a/libs/zedUpload/datastore_http.go
+++ b/libs/zedUpload/datastore_http.go
@@ -132,7 +132,7 @@ func (ep *HttpTransportMethod) processHttpUpload(req *DronaRequest) (error, int)
 			}
 		}(req, prgChan)
 	}
-	resp := zedHttp.ExecCmd("post", postUrl, req.name, req.objloc, req.sizelimit, prgChan, ep.hClient)
+	resp := zedHttp.ExecCmd(req.cancelContext, "post", postUrl, req.name, req.objloc, req.sizelimit, prgChan, ep.hClient)
 	return resp.Error, resp.BodyLength
 }
 
@@ -161,7 +161,7 @@ func (ep *HttpTransportMethod) processHttpDownload(req *DronaRequest) (error, in
 			}
 		}(req, prgChan)
 	}
-	resp := zedHttp.ExecCmd("get", file, "", req.objloc, req.sizelimit, prgChan, ep.hClient)
+	resp := zedHttp.ExecCmd(req.cancelContext, "get", file, "", req.objloc, req.sizelimit, prgChan, ep.hClient)
 	if resp.Error != nil {
 		return resp.Error, resp.BodyLength
 	}
@@ -195,7 +195,7 @@ func (ep *HttpTransportMethod) processHttpList(req *DronaRequest) ([]string, err
 			}
 		}(req, prgChan)
 	}
-	resp := zedHttp.ExecCmd("ls", listUrl, "", "", req.sizelimit, prgChan, ep.hClient)
+	resp := zedHttp.ExecCmd(req.cancelContext, "ls", listUrl, "", "", req.sizelimit, prgChan, ep.hClient)
 	return resp.List, resp.Error
 }
 
@@ -224,7 +224,7 @@ func (ep *HttpTransportMethod) processHttpObjectMetaData(req *DronaRequest) (err
 			}
 		}(req, prgChan)
 	}
-	resp := zedHttp.ExecCmd("meta", file, "", req.objloc, req.sizelimit, prgChan, ep.hClient)
+	resp := zedHttp.ExecCmd(req.cancelContext, "meta", file, "", req.objloc, req.sizelimit, prgChan, ep.hClient)
 	if resp.Error != nil {
 		return resp.Error, resp.ContentLength
 	}

--- a/libs/zedUpload/datastore_http_test.go
+++ b/libs/zedUpload/datastore_http_test.go
@@ -1,9 +1,14 @@
 package zedUpload_test
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"io"
+	"net"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/lf-edge/eve/libs/zedUpload"
 )
@@ -11,10 +16,8 @@ import (
 const (
 	// parameters for HTTP datastore
 	httpPostRegion  = "http://ptsv2.com/t/httptest/post"
-	httpURL         = "http://download.cirros-cloud.net"
-	httpURL2        = "http://cloud-images.ubuntu.com/"
-	httpDir         = "0.4.0/"
-	httpDir2        = "releases"
+	httpURL         = "http://cloud-images.ubuntu.com"
+	httpDir         = "releases"
 	httpUploadFile  = uploadFile
 	httpDownloadDir = "./test/output/httpDownload/"
 )
@@ -29,9 +32,10 @@ func TestHTTPDatastore(t *testing.T) {
 	t.Run("API", testHTTPDatastoreAPI)
 	t.Run("Negative", testHTTPDatastoreNegative)
 	t.Run("Functional", testHTTPDatastoreFunctional)
+	t.Run("Repeat", testHTTPDatastoreRepeat)
 }
 
-func operationHTTP(t *testing.T, objloc string, objkey string, url, dir string, operation zedUpload.SyncOpType) (bool, string) {
+func operationHTTP(t *testing.T, objloc string, objkey string, url, dir string, operation zedUpload.SyncOpType, local bool) (bool, string) {
 	respChan := make(chan *zedUpload.DronaRequest)
 
 	httpAuth := &zedUpload.AuthInput{AuthType: "http"}
@@ -43,6 +47,17 @@ func operationHTTP(t *testing.T, objloc string, objkey string, url, dir string, 
 	// create Endpoint
 	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncHttpTr, url, dir, httpAuth)
 	if err == nil && dEndPoint != nil {
+		if local {
+			var lIP net.IP
+			err = lIP.UnmarshalText([]byte("127.0.0.1"))
+			if err != nil {
+				return true, err.Error()
+			}
+			err = dEndPoint.WithSrcIPSelection(lIP)
+			if err != nil {
+				return true, err.Error()
+			}
+		}
 		// create Request
 		req := dEndPoint.NewRequest(operation, objkey, objloc, 0, true, respChan)
 		if req != nil {
@@ -51,11 +66,24 @@ func operationHTTP(t *testing.T, objloc string, objkey string, url, dir string, 
 	}
 
 	var (
-		isErr  bool
-		status string
+		isErr           bool
+		status          string
+		lastCurrentSize int64
+		lastUpdate      = time.Now()
 	)
 	for resp := range respChan {
 		if resp.IsDnUpdate() {
+			currentSize, totalSize, _ := resp.Progress()
+			if currentSize != lastCurrentSize {
+				t.Logf("Update progress for %v: %v/%v",
+					resp.GetLocalName(), currentSize, totalSize)
+				lastCurrentSize = currentSize
+				lastUpdate = time.Now()
+			}
+			if time.Now().After(lastUpdate.Add(20 * time.Minute)) {
+				t.Errorf("No update during 20 minutes")
+				break
+			}
 			continue
 		}
 		isErr, status = resp.IsError(), resp.GetStatus()
@@ -136,7 +164,7 @@ func testHTTPObjectWithFile(t *testing.T, objloc, objkey, url, dir string) error
 	if statusMeta {
 		return fmt.Errorf(msgMeta)
 	}
-	statusDownload, msgDownload := operationHTTP(t, objloc, objkey, url, dir, zedUpload.SyncOpDownload)
+	statusDownload, msgDownload := operationHTTP(t, objloc, objkey, url, dir, zedUpload.SyncOpDownload, false)
 	if statusDownload {
 		return fmt.Errorf(msgDownload)
 	}
@@ -154,7 +182,7 @@ func testHTTPObjectWithFile(t *testing.T, objloc, objkey, url, dir string) error
 
 func testHTTPDatastoreAPI(t *testing.T) {
 	t.Run("Upload=0", func(t *testing.T) {
-		status, msg := operationHTTP(t, httpUploadFile, "httpteststuff", httpPostRegion, "", zedUpload.SyncOpUpload)
+		status, msg := operationHTTP(t, httpUploadFile, "httpteststuff", httpPostRegion, "", zedUpload.SyncOpUpload, false)
 		if status {
 			t.Errorf("%v", msg)
 		}
@@ -164,16 +192,19 @@ func testHTTPDatastoreAPI(t *testing.T) {
 	//	operationHTTP(t, httpUploadFile, "release/1.0/httpteststuff", httpPostRegion, zedUpload.SyncOpUpload)
 	//})
 	t.Run("Download=0", func(t *testing.T) {
-		operationHTTP(t, httpDownloadDir+"file0", "cirros-0.4.0-x86_64-disk.img", httpURL, httpDir, zedUpload.SyncOpDownload)
+		status, msg := operationHTTP(t, httpDownloadDir+"file0", "bionic/release-20210804/ubuntu-18.04-server-cloudimg-s390x-lxd.tar.xz", httpURL, httpDir, zedUpload.SyncOpDownload, false)
+		if status {
+			t.Errorf("%v", msg)
+		}
 	})
 	t.Run("Download=1", func(t *testing.T) {
-		status, msg := operationHTTP(t, httpDownloadDir+"file1", "buildroot_rootfs/buildroot-0.4.0-x86_64.tar.gz", httpURL, httpDir, zedUpload.SyncOpDownload)
+		status, msg := operationHTTP(t, httpDownloadDir+"file1", "minimal/releases/bionic/release-20210803/ubuntu-18.04-minimal-cloudimg-amd64-root.tar.xz", httpURL, "", zedUpload.SyncOpDownload, false)
 		if status {
 			t.Errorf("%v", msg)
 		}
 	})
 	t.Run("Download=2", func(t *testing.T) {
-		status, msg := operationHTTP(t, httpDownloadDir+"file2", "16.04/release/ubuntu-16.04-server-cloudimg-amd64-disk1.img", httpURL2, httpDir2, zedUpload.SyncOpDownload)
+		status, msg := operationHTTP(t, httpDownloadDir+"file2", "xenial/release/ubuntu-16.04-server-cloudimg-amd64-disk1.img", httpURL, httpDir, zedUpload.SyncOpDownload, false)
 		if status {
 			t.Errorf("%v", msg)
 		}
@@ -186,7 +217,7 @@ func testHTTPDatastoreAPI(t *testing.T) {
 	})
 	//t.Run("List=1", func(t *testing.T) { listHTTPFiles(t, "http://192.168.0.147:80") })
 	t.Run("List=2", func(t *testing.T) {
-		status, msg := listHTTPFiles(t, httpURL, httpDir)
+		status, msg := listHTTPFiles(t, httpURL, httpDir+"/")
 		if status {
 			t.Errorf("%v", msg)
 		}
@@ -202,13 +233,13 @@ func testHTTPDatastoreFunctional(t *testing.T) {
 	} else {
 		t.Log("Running HTTP Extended test suite.")
 		t.Run("XtraSmall=0", func(t *testing.T) {
-			err := testHTTPObjectWithFile(t, httpDownloadDir+"file1", "cirros-0.4.0-x86_64-disk.img", httpURL, httpDir)
+			err := testHTTPObjectWithFile(t, httpDownloadDir+"file1", "minimal/releases/bionic/release-20210803/ubuntu-18.04-minimal-cloudimg-amd64-lxd.tar.xz", httpURL, "")
 			if err != nil {
 				t.Errorf("%v", err)
 			}
 		})
 		t.Run("Small=0", func(t *testing.T) {
-			err := testHTTPObjectWithFile(t, httpDownloadDir+"file2", "cirros-0.4.0-ppc64le-disk.img", httpURL, httpDir)
+			err := testHTTPObjectWithFile(t, httpDownloadDir+"file2", "minimal/releases/bionic/release-20210803/ubuntu-18.04-minimal-cloudimg-amd64-root.tar.xz", httpURL, "")
 			if err != nil {
 				t.Errorf("%v", err)
 			}
@@ -218,21 +249,62 @@ func testHTTPDatastoreFunctional(t *testing.T) {
 
 func testHTTPDatastoreNegative(t *testing.T) {
 	t.Run("InvalidTransport=0", func(t *testing.T) {
-		status, _ := operationHTTP(t, httpUploadFile, "httpteststuff", httpPostRegion, "", zedUpload.SyncOpUnknown)
+		status, _ := operationHTTP(t, httpUploadFile, "httpteststuff", httpPostRegion, "", zedUpload.SyncOpUnknown, false)
 		if !status {
 			t.Errorf("Processing invalid transporter")
 		}
 	})
 	t.Run("InvalidUpload=0", func(t *testing.T) {
-		status, _ := operationHTTP(t, uploadDir+"InvalidFile", "httpteststuff", httpPostRegion, "", zedUpload.SyncOpUpload)
+		status, _ := operationHTTP(t, uploadDir+"InvalidFile", "httpteststuff", httpPostRegion, "", zedUpload.SyncOpUpload, false)
 		if !status {
 			t.Errorf("Uploading non existent file")
 		}
 	})
 	t.Run("InvalidDownload=0", func(t *testing.T) {
-		status, _ := operationHTTP(t, httpDownloadDir+"file0", "InvalidFile", httpURL, httpDir, zedUpload.SyncOpDownload)
+		status, _ := operationHTTP(t, httpDownloadDir+"file0", "InvalidFile", httpURL, httpDir, zedUpload.SyncOpDownload, false)
 		if !status {
 			t.Errorf("Downloading non existent file")
 		}
 	})
+}
+
+func testHTTPDatastoreRepeat(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping HTTP repeat test suite.")
+	} else {
+		t.Log("Running HTTP repeat test suite.")
+
+		go func() {
+			err := newUnstableProxyStart(9999, 80, "cloud-images.ubuntu.com", 1024*1024*100, 40*time.Second, 100)
+			if err != nil {
+				t.Error(err)
+			}
+		}()
+
+		status, msg := operationHTTP(t, httpDownloadDir+"repeat2", "releases/focal/release/ubuntu-20.04.2-preinstalled-server-riscv64.img.xz", "http://127.0.0.1:9999", "", zedUpload.SyncOpDownload, true)
+		if status {
+			t.Errorf("%v", msg)
+		}
+		hashSum, err := sha256File(httpDownloadDir + "repeat2")
+		if err != nil {
+			t.Errorf("%v", err)
+		} else {
+			if hashSum != "cd8d892bfff2b7167e51395f462b6096f657e61de325acd97da2272769efa761" {
+				t.Errorf("hash mismatch")
+			}
+		}
+	}
+}
+
+func sha256File(filePath string) (string, error) {
+	hasher := sha256.New()
+	f, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	if _, err := io.Copy(hasher, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hasher.Sum(nil)), nil
 }

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_http.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_http.go
@@ -132,7 +132,7 @@ func (ep *HttpTransportMethod) processHttpUpload(req *DronaRequest) (error, int)
 			}
 		}(req, prgChan)
 	}
-	resp := zedHttp.ExecCmd("post", postUrl, req.name, req.objloc, req.sizelimit, prgChan, ep.hClient)
+	resp := zedHttp.ExecCmd(req.cancelContext, "post", postUrl, req.name, req.objloc, req.sizelimit, prgChan, ep.hClient)
 	return resp.Error, resp.BodyLength
 }
 
@@ -161,7 +161,7 @@ func (ep *HttpTransportMethod) processHttpDownload(req *DronaRequest) (error, in
 			}
 		}(req, prgChan)
 	}
-	resp := zedHttp.ExecCmd("get", file, "", req.objloc, req.sizelimit, prgChan, ep.hClient)
+	resp := zedHttp.ExecCmd(req.cancelContext, "get", file, "", req.objloc, req.sizelimit, prgChan, ep.hClient)
 	if resp.Error != nil {
 		return resp.Error, resp.BodyLength
 	}
@@ -195,7 +195,7 @@ func (ep *HttpTransportMethod) processHttpList(req *DronaRequest) ([]string, err
 			}
 		}(req, prgChan)
 	}
-	resp := zedHttp.ExecCmd("ls", listUrl, "", "", req.sizelimit, prgChan, ep.hClient)
+	resp := zedHttp.ExecCmd(req.cancelContext, "ls", listUrl, "", "", req.sizelimit, prgChan, ep.hClient)
 	return resp.List, resp.Error
 }
 
@@ -224,7 +224,7 @@ func (ep *HttpTransportMethod) processHttpObjectMetaData(req *DronaRequest) (err
 			}
 		}(req, prgChan)
 	}
-	resp := zedHttp.ExecCmd("meta", file, "", req.objloc, req.sizelimit, prgChan, ep.hClient)
+	resp := zedHttp.ExecCmd(req.cancelContext, "meta", file, "", req.objloc, req.sizelimit, prgChan, ep.hClient)
 	if resp.Error != nil {
 		return resp.Error, resp.ContentLength
 	}


### PR DESCRIPTION
This PR modifies:

- context propagation into ExecCmd to handle cancel event
- add retry into get ExecCmd (with Range headers if supported to continue download)

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>