### PR TITLE
NetworkInstance delete needed work

### DIFF
--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -494,7 +494,7 @@ func doNetworkInstanceCreate(ctx *zedrouterContext,
 		ntpServers := types.GetNTPServers(*ctx.deviceNetworkStatus,
 			status.CurrentUplinkIntf)
 		createDnsmasqConfiglet(ctx, bridgeName,
-			status.BridgeIPAddr, &status.NetworkInstanceConfig,
+			status.BridgeIPAddr, status,
 			hostsDirpath, status.BridgeIPSets,
 			status.CurrentUplinkIntf, dnsServers, ntpServers)
 		startDnsmasq(bridgeName)
@@ -797,7 +797,7 @@ func restartDnsmasq(ctx *zedrouterContext, status *types.NetworkInstanceStatus) 
 	ntpServers := types.GetNTPServers(*ctx.deviceNetworkStatus,
 		status.CurrentUplinkIntf)
 	createDnsmasqConfiglet(ctx, bridgeName, status.BridgeIPAddr,
-		&status.NetworkInstanceConfig, hostsDirpath, status.BridgeIPSets,
+		status, hostsDirpath, status.BridgeIPSets,
 		status.CurrentUplinkIntf, dnsServers, ntpServers)
 	createHostDnsmasqFile(ctx, bridgeName)
 	startDnsmasq(bridgeName)
@@ -1884,7 +1884,7 @@ func doNetworkInstanceFallback(
 			ntpServers := types.GetNTPServers(*ctx.deviceNetworkStatus,
 				status.CurrentUplinkIntf)
 			createDnsmasqConfiglet(ctx, bridgeName,
-				status.BridgeIPAddr, &status.NetworkInstanceConfig,
+				status.BridgeIPAddr, status,
 				hostsDirpath, status.BridgeIPSets,
 				status.CurrentUplinkIntf, dnsServers, ntpServers)
 			startDnsmasq(bridgeName)
@@ -1939,7 +1939,7 @@ func doNetworkInstanceFallback(
 			ntpServers := types.GetNTPServers(*ctx.deviceNetworkStatus,
 				status.CurrentUplinkIntf)
 			createDnsmasqConfiglet(ctx, bridgeName,
-				status.BridgeIPAddr, &status.NetworkInstanceConfig,
+				status.BridgeIPAddr, status,
 				hostsDirpath, status.BridgeIPSets,
 				status.CurrentUplinkIntf, dnsServers, ntpServers)
 			startDnsmasq(bridgeName)

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -1690,7 +1690,6 @@ func appNetworkDoInactivateUnderlayNetwork(
 			dnsServers, ntpServers)
 		startDnsmasq(bridgeName)
 	}
-	netstatus.RemoveVif(log, ulStatus.Vif)
 	if netstatus.Type == types.NetworkInstanceTypeSwitch {
 		if ulStatus.AccessVlanID <= 1 {
 			netstatus.NumTrunkPorts--
@@ -1708,8 +1707,13 @@ func appNetworkDoInactivateUnderlayNetwork(
 	log.Functionf("set BridgeIPSets to %v for %s", newIpsets, netstatus.Key())
 	maybeRemoveStaleIpsets(staleIpsets)
 
-	// publish the changes to network instance status
-	publishNetworkInstanceStatus(ctx, netstatus)
+	netstatus.RemoveVif(log, ulStatus.Vif)
+	if maybeNetworkInstanceDelete(ctx, netstatus) {
+		log.Noticef("deleted network instance %s", netstatus.Key())
+	} else {
+		// publish the changes to network instance status
+		publishNetworkInstanceStatus(ctx, netstatus)
+	}
 }
 
 func pkillUserArgs(userName string, match string, printOnError bool) {

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -1068,7 +1068,7 @@ func appNetworkDoActivateUnderlayNetwork(
 		ntpServers := types.GetNTPServers(*ctx.deviceNetworkStatus,
 			netInstStatus.CurrentUplinkIntf)
 		createDnsmasqConfiglet(ctx, bridgeName,
-			ulStatus.BridgeIPAddr, netInstConfig, hostsDirpath,
+			ulStatus.BridgeIPAddr, netInstStatus, hostsDirpath,
 			newIpsets, netInstStatus.CurrentUplinkIntf,
 			dnsServers, ntpServers)
 		startDnsmasq(bridgeName)
@@ -1477,7 +1477,6 @@ func doAppNetworkModifyUnderlayNetwork(
 	bridgeName := ulStatus.Bridge
 	appIPAddr := ulStatus.AllocatedIPAddr
 
-	netconfig := lookupNetworkInstanceConfig(ctx, ulConfig.Network.String())
 	netstatus := lookupNetworkInstanceStatus(ctx, ulConfig.Network.String())
 
 	aclArgs := types.AppNetworkACLArgs{IsMgmt: false, BridgeName: bridgeName,
@@ -1512,7 +1511,7 @@ func doAppNetworkModifyUnderlayNetwork(
 		ntpServers := types.GetNTPServers(*ctx.deviceNetworkStatus,
 			netstatus.CurrentUplinkIntf)
 		createDnsmasqConfiglet(ctx, bridgeName,
-			ulStatus.BridgeIPAddr, netconfig, hostsDirpath,
+			ulStatus.BridgeIPAddr, netstatus, hostsDirpath,
 			newIpsets, netstatus.CurrentUplinkIntf,
 			dnsServers, ntpServers)
 		startDnsmasq(bridgeName)
@@ -1610,19 +1609,9 @@ func appNetworkDoInactivateUnderlayNetwork(
 
 	bridgeName := ulStatus.Bridge
 
-	netconfig := lookupNetworkInstanceConfig(ctx,
-		ulStatus.Network.String())
-	if netconfig == nil {
-		errStr := fmt.Sprintf("no network config for %s",
-			ulStatus.Network.String())
-		err := errors.New(errStr)
-		addError(ctx, status, "lookupNetworkInstanceConfig", err)
-		return
-	}
 	netstatus := lookupNetworkInstanceStatus(ctx,
 		ulStatus.Network.String())
 	if netstatus == nil {
-		// We had a netconfig but no status!
 		errStr := fmt.Sprintf("no network status for %s",
 			ulStatus.Network.String())
 		err := errors.New(errStr)
@@ -1685,7 +1674,7 @@ func appNetworkDoInactivateUnderlayNetwork(
 		ntpServers := types.GetNTPServers(*ctx.deviceNetworkStatus,
 			netstatus.CurrentUplinkIntf)
 		createDnsmasqConfiglet(ctx, bridgeName,
-			ulStatus.BridgeIPAddr, netconfig, hostsDirpath,
+			ulStatus.BridgeIPAddr, netstatus, hostsDirpath,
 			newIpsets, netstatus.CurrentUplinkIntf,
 			dnsServers, ntpServers)
 		startDnsmasq(bridgeName)


### PR DESCRIPTION
Basic thing we wanted was in the first commit; make sure we keep the NetworkInstanceStatus around until all of the AppNetworkStatus which are using it are gone (based on checking the Vifs).

However, turns out that the delete handling in zedrouter requires a NetworkInstanceConfig in addition to a NetworkInstanceStatus so fixed that in the second commit.