### PR TITLE
Update golang to 1.16 for pillar

### DIFF
--- a/pkg/newlog/Dockerfile
+++ b/pkg/newlog/Dockerfile
@@ -3,6 +3,10 @@ ENV BUILD_PKGS libc-dev git gcc linux-headers go
 ENV PKGS alpine-baselayout musl-utils
 RUN eve-alpine-deploy.sh
 
+# FIXME bump eve-alpine to alpine 3.14
+RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.14/community' >> /etc/apk/repositories &&\
+  apk --no-cache add -U --upgrade go && go version
+
 COPY ./  /newlog/.
 WORKDIR /newlog
 

--- a/pkg/pillar/Dockerfile.in
+++ b/pkg/pillar/Dockerfile.in
@@ -5,6 +5,10 @@ ENV BUILD_PKGS git gcc linux-headers libc-dev make linux-pam-dev m4 findutils go
 ENV PKGS alpine-baselayout musl-utils libtasn1-progs pciutils yajl xz bash openssl iptables ip6tables iproute2 dhcpcd coreutils dmidecode libbz2 libuuid ipset curl radvd ethtool util-linux e2fsprogs libcrypto1.1 xorriso qemu-img jq e2fsprogs-extra keyutils ca-certificates ip6tables-openrc iptables-openrc ipset-openrc hdparm
 RUN eve-alpine-deploy.sh
 
+# FIXME bump eve-alpine to alpine 3.14
+RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.14/community' >> /etc/apk/repositories &&\
+  apk --no-cache add -U --upgrade go && go version
+
 RUN mkdir -p /go/src/github.com/google
 WORKDIR /go/src/github.com/google
 RUN git clone https://github.com/google/fscrypt


### PR DESCRIPTION
Update golang to 1.16 to use changed default behavior of memory reclaiming: https://go-review.googlesource.com/c/go/+/267100/ which is what we need to avoid unexpected OOM.