### PR TITLE
doActivate NI in case of AwaitNetworkInstance

### DIFF
--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -1203,7 +1203,7 @@ func checkAndRecreateAppNetwork(ctx *zedrouterContext, niStatus types.NetworkIns
 		}
 		// Any error to clear?
 		// XXX better to use ErrorWithSource and check for NetworkInstanceStatus?
-		if !status.AwaitNetworkInstance || !status.HasError() {
+		if !status.AwaitNetworkInstance && !status.HasError() {
 			continue
 		}
 


### PR DESCRIPTION
We can see `Missing underlay network 8f61a8fb-5923-4314-90ef-31cb14b0d8a0 for {2480fa1e-58eb-4e47-9ce3-b7d7b101e580 1}` and app stucked in `AWAITNETWORKINSTANCE`. Seems, we should run doActivate in case of AwaitNetworkInstance **or** error.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>