### PR TITLE
Add uqmi 'sync' command call to release stalled cid

### DIFF
--- a/pkg/wwan/usr/bin/wwan-init.sh
+++ b/pkg/wwan/usr/bin/wwan-init.sh
@@ -72,6 +72,7 @@ start_network() {
      echo Y > /sys/class/net/$IFACE/qmi/raw_ip
      ip link set $IFACE up
 
+     qmi --sync
      qmi --start-network --apn "$(get_apn)" --keep-client-id wds |\
          mbus_publish pdh_$IFACE
   fi


### PR DESCRIPTION
When wwan connection gets into a broken state (e.g. due to a qmi_wwan rx/tx queue getting stuck), wwan service tries to reset modem and reconnect.
However, without calling 'uqmi --sync' to release stalled cid, the 'start-network' operation might permanently keep failing with 'POLICY MISMATCH', thus preventing the wwan connection from ever recovering.

Inspiration from OpenWrt ([link1](https://patchwork.ozlabs.org/project/lede/patch/1481174095-15924-1-git-send-email-nledovskikh@gmail.com/), [link2](https://git.openwrt.org/?p=openwrt/openwrt.git;a=blob;f=package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh;h=c0134f44dde3e5755456744c7f083013f8580ac9;hb=HEAD#l210))

Signed-off-by: Milan Lenco <milan@zededa.com>