### PR TITLE
Revert "Wait to remove network instance while in use"

### DIFF
--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -380,30 +380,12 @@ func handleNetworkInstanceDelete(ctxArg interface{}, key string,
 	if status.Activated {
 		doNetworkInstanceInactivate(ctx, status)
 	}
-	done := maybeNetworkInstanceDelete(ctx, status)
-	log.Functionf("handleNetworkInstanceDelete(%s) done %t", key, done)
-}
-
-// maybeNetworkInstanceDelete checks if the Vifs are gone and if so delete
-func maybeNetworkInstanceDelete(ctx *zedrouterContext, status *types.NetworkInstanceStatus) bool {
-	if lookupNetworkInstanceConfig(ctx, status.Key()) != nil {
-		log.Functionf("maybeNetworkInstanceDelete(%s) still config",
-			status.Key())
-		return false
-	}
-
-	if len(status.Vifs) != 0 {
-		log.Noticef("maybeNetworkInstanceDelete(%s) still %d Vifs",
-			status.Key(), len(status.Vifs))
-		return false
-	}
 	doNetworkInstanceDelete(ctx, status)
 	ctx.networkInstanceStatusMap.Delete(status.UUID)
-	ctx.pubNetworkInstanceStatus.Unpublish(status.Key())
+	pub.Unpublish(status.Key())
 
 	deleteNetworkInstanceMetrics(ctx, status.Key())
-	log.Noticef("maybeNetworkInstanceDelete(%s) done", status.Key())
-	return true
+	log.Functionf("handleNetworkInstanceDelete(%s) done\n", key)
 }
 
 func doNetworkInstanceCreate(ctx *zedrouterContext,
@@ -1289,7 +1271,6 @@ func doNetworkInstanceInactivate(
 	switch status.Type {
 	case types.NetworkInstanceTypeLocal:
 		natInactivate(ctx, status, false)
-		// XXX wait until delete and delete waits until all users gone?
 		deleteServer4(ctx, status.BridgeIPAddr, status.BridgeName)
 	case types.NetworkInstanceTypeCloud:
 		vpnInactivate(ctx, status)

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -1679,6 +1679,7 @@ func appNetworkDoInactivateUnderlayNetwork(
 			dnsServers, ntpServers)
 		startDnsmasq(bridgeName)
 	}
+	netstatus.RemoveVif(log, ulStatus.Vif)
 	if netstatus.Type == types.NetworkInstanceTypeSwitch {
 		if ulStatus.AccessVlanID <= 1 {
 			netstatus.NumTrunkPorts--
@@ -1696,13 +1697,8 @@ func appNetworkDoInactivateUnderlayNetwork(
 	log.Functionf("set BridgeIPSets to %v for %s", newIpsets, netstatus.Key())
 	maybeRemoveStaleIpsets(staleIpsets)
 
-	netstatus.RemoveVif(log, ulStatus.Vif)
-	if maybeNetworkInstanceDelete(ctx, netstatus) {
-		log.Noticef("deleted network instance %s", netstatus.Key())
-	} else {
-		// publish the changes to network instance status
-		publishNetworkInstanceStatus(ctx, netstatus)
-	}
+	// publish the changes to network instance status
+	publishNetworkInstanceStatus(ctx, netstatus)
 }
 
 func pkillUserArgs(userName string, match string, printOnError bool) {


### PR DESCRIPTION
This reverts commit 6f34363c00de5594fcd40a89941aa57323c12871.

That commit is causing test failures due to errors of the form
Received NetworkInstance error Subnet(172.168.1.0/24) SubnetAddr(172.168.1.0) overlaps with another network instance(TestCloudInit-sc-supermicro-zc2-NI-2021-08-07T05-59-55-f60fbda3-f76f-4b3b-9299-5ca80e95838b) Subnet(172.168.1.0/24)
due to some missing cleanup/delete of the network instance.

Will revert to restore master and debug that issue.