### PR TITLE
Revert revert of Wait to remove network instance while in use

### DIFF
--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -380,12 +380,30 @@ func handleNetworkInstanceDelete(ctxArg interface{}, key string,
 	if status.Activated {
 		doNetworkInstanceInactivate(ctx, status)
 	}
+	done := maybeNetworkInstanceDelete(ctx, status)
+	log.Functionf("handleNetworkInstanceDelete(%s) done %t", key, done)
+}
+
+// maybeNetworkInstanceDelete checks if the Vifs are gone and if so delete
+func maybeNetworkInstanceDelete(ctx *zedrouterContext, status *types.NetworkInstanceStatus) bool {
+	if lookupNetworkInstanceConfig(ctx, status.Key()) != nil {
+		log.Noticef("maybeNetworkInstanceDelete(%s) still config",
+			status.Key())
+		return false
+	}
+
+	if len(status.Vifs) != 0 {
+		log.Noticef("maybeNetworkInstanceDelete(%s) still %d Vifs",
+			status.Key(), len(status.Vifs))
+		return false
+	}
 	doNetworkInstanceDelete(ctx, status)
 	ctx.networkInstanceStatusMap.Delete(status.UUID)
-	pub.Unpublish(status.Key())
+	ctx.pubNetworkInstanceStatus.Unpublish(status.Key())
 
 	deleteNetworkInstanceMetrics(ctx, status.Key())
-	log.Functionf("handleNetworkInstanceDelete(%s) done\n", key)
+	log.Noticef("maybeNetworkInstanceDelete(%s) done", status.Key())
+	return true
 }
 
 func doNetworkInstanceCreate(ctx *zedrouterContext,
@@ -1271,6 +1289,7 @@ func doNetworkInstanceInactivate(
 	switch status.Type {
 	case types.NetworkInstanceTypeLocal:
 		natInactivate(ctx, status, false)
+		// XXX wait until delete and delete waits until all users gone?
 		deleteServer4(ctx, status.BridgeIPAddr, status.BridgeName)
 	case types.NetworkInstanceTypeCloud:
 		vpnInactivate(ctx, status)

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -1679,7 +1679,6 @@ func appNetworkDoInactivateUnderlayNetwork(
 			dnsServers, ntpServers)
 		startDnsmasq(bridgeName)
 	}
-	netstatus.RemoveVif(log, ulStatus.Vif)
 	if netstatus.Type == types.NetworkInstanceTypeSwitch {
 		if ulStatus.AccessVlanID <= 1 {
 			netstatus.NumTrunkPorts--
@@ -1697,8 +1696,13 @@ func appNetworkDoInactivateUnderlayNetwork(
 	log.Functionf("set BridgeIPSets to %v for %s", newIpsets, netstatus.Key())
 	maybeRemoveStaleIpsets(staleIpsets)
 
-	// publish the changes to network instance status
-	publishNetworkInstanceStatus(ctx, netstatus)
+	netstatus.RemoveVif(log, ulStatus.Vif)
+	if maybeNetworkInstanceDelete(ctx, netstatus) {
+		log.Noticef("deleted network instance %s", netstatus.Key())
+	} else {
+		// publish the changes to network instance status
+		publishNetworkInstanceStatus(ctx, netstatus)
+	}
 }
 
 func pkillUserArgs(userName string, match string, printOnError bool) {

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -1963,13 +1963,20 @@ func (instanceInfo *NetworkInstanceInfo) IsVifInBridge(
 
 func (instanceInfo *NetworkInstanceInfo) RemoveVif(log *base.LogObject,
 	vifName string) {
-	log.Functionf("DelVif(%s, %s)\n", instanceInfo.BridgeName, vifName)
+	log.Functionf("RemoveVif(%s, %s)", instanceInfo.BridgeName, vifName)
 
+	found := false
 	var vifs []VifNameMac
 	for _, vif := range instanceInfo.Vifs {
 		if vif.Name != vifName {
 			vifs = append(vifs, vif)
+		} else {
+			found = true
 		}
+	}
+	if !found {
+		log.Errorf("RemoveVif(%x, %x) not found",
+			instanceInfo.BridgeName, vifName)
 	}
 	instanceInfo.Vifs = vifs
 }
@@ -1977,12 +1984,12 @@ func (instanceInfo *NetworkInstanceInfo) RemoveVif(log *base.LogObject,
 func (instanceInfo *NetworkInstanceInfo) AddVif(log *base.LogObject,
 	vifName string, appMac string, appID uuid.UUID) {
 
-	log.Functionf("addVifToBridge(%s, %s, %s, %s)\n",
+	log.Functionf("AddVif(%s, %s, %s, %s)",
 		instanceInfo.BridgeName, vifName, appMac, appID.String())
 	// XXX Should we just overwrite it? There is a lookup function
 	//	anyways if the caller wants "check and add" semantics
 	if instanceInfo.IsVifInBridge(vifName) {
-		log.Errorf("addVifToBridge(%s, %s) exists\n",
+		log.Errorf("AddVif(%s, %s) exists",
 			instanceInfo.BridgeName, vifName)
 		return
 	}

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -2305,6 +2305,8 @@ type NetworkInstanceStatus struct {
 	//	Keeps track of current state of object - if it has been activated
 	Activated bool
 
+	Server4Running bool // Did we start the server?
+
 	NetworkInstanceInfo
 
 	OpaqueStatus string


### PR DESCRIPTION
PR #2220 needed a ztest cleanup fix (https://github.com/zededa/ztests/pull/273) to ensure that each test has finished before starting the next. That is the first commit.

The second commit is to move the deleteServer4 until we know there are no AppNetworkConfig referencing the NI, that is, the application instances have halted. That removes the risk of a slowly halting VM from invoking http://169.254.169.254 while we are tearing it down.