### PR TITLE
Fix iptables rules for accepting DHCP traffic

### DIFF
--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -2380,6 +2380,7 @@ type IPTablesRule struct {
 	IsPortMapRule    bool // Is this a port map rule?
 	IsLimitDropRule  bool // Is this a policer limit drop rule?
 	IsDefaultDrop    bool // Is this a default drop rule that forwards to dummy?
+	AnyPhysdev       bool // Apply rule irrespective of the input/output physical device.
 }
 
 // IPTablesRuleList : list of iptables rules


### PR DESCRIPTION
Communication between a DHCP client and a DHCP server
creates multiple conntrack entries (2 or 3). This is because
the source and the destination IP addresses change as the DHCP
protocol progresses.

1. Conntrack entry for the first packet is heavily recycled because
   it is always the same:
   ```
   0.0.0.0:68 -> 255.255.255.255:67
   ```
   Before this PR, this conntrack entry was incorrectly marked with
   0xFFFFFF (instead of 0x6).
   This is because the original rule for DHCP was matching only those DHCP packets
   which already use unicast destination IP address (see conntrack type "3" below).

2. Reply to a DHCP request is typically destined to an all-ones multicast
   IP address so that everyone on the network learns about the new lease:
   ```
   <dhcp-server-IP>:67 -> 255.255.255.255:68
   ```
   However, dnsmasq is configured to reply to the newly allocated IP
   address directly, therefore we only see this with switch network instances.
   PR modifies the DHCP ACEs for switch networks to ensure that
   these conntracks are properly marked (with 0x6).

3. Further communication between the client and the server
   is between their unicast IP addresses:
   ```
   <dhcp-client-IP>:68 <-> <dhcp-server-IP>:67
   ```
   This has been already properly connmark-ed (with 0x6) before.

Properly marking DHCP traffic matters, or else it could be getting dropped
which is always undesirable regardless of ACLs configured. Recently, the
drop action was reenforced to also apply to L2-only traffic (https://github.com/lf-edge/eve/pull/2192).

PR also cleans up the connection marking for DNS. Regardless of whether
the DNS runs on top of udp or tcp it will be marked 0x7 (as opposed to 0x6
used now solely for DHCP).


Implicitly created iptables rules for accepting DHCP/DNS/HTTP traffic now looks as follows:
- switch network:
```
    4  1260 proto-eth1-nbu2x1-6  udp  --  eth1   any     anywhere             anywhere             udp dpts:bootps:bootpc
    0     0 proto-eth1-nbu2x1-7  udp  --  eth1   any     anywhere             anywhere             PHYSDEV match --physdev-in nbu2x1+ udp dpt:domain
    0     0 proto-eth1-nbu2x1-7  tcp  --  eth1   any     anywhere             anywhere             PHYSDEV match --physdev-in nbu2x1+ tcp dpt:domain
    0     0 proto-eth1-nbu2x1-8  tcp  --  eth1   any     anywhere             169.254.169.254      PHYSDEV match --physdev-in nbu2x1+ tcp dpt:http

```
- local network:
```
    2   656 proto-bn1-nbu1x1-6  udp  --  bn1    any     anywhere             anywhere             PHYSDEV match --physdev-in nbu1x1+ udp dpt:bootps
    0     0 proto-bn1-nbu1x1-7  udp  --  bn1    any     anywhere             10.11.12.1           PHYSDEV match --physdev-in nbu1x1+ udp dpt:domain
    0     0 proto-bn1-nbu1x1-7  tcp  --  bn1    any     anywhere             10.11.12.1           PHYSDEV match --physdev-in nbu1x1+ tcp dpt:domain
    0     0 proto-bn1-nbu1x1-8  tcp  --  bn1    any     anywhere             169.254.169.254      PHYSDEV match --physdev-in nbu1x1+ tcp dpt:http
```

Signed-off-by: Milan Lenco <milan@zededa.com>