### PR TITLE
Fix occasional bind: address already in use from the http server on 169.254.169.254

### DIFF
--- a/pkg/pillar/agentlog/agentlog.go
+++ b/pkg/pillar/agentlog/agentlog.go
@@ -203,6 +203,30 @@ func handleSignals(log *base.LogObject, agentName string, agentPid int, sigs cha
 	}
 }
 
+// DumpAllStacks writes to file but does not log
+func DumpAllStacks(log *base.LogObject, agentName string) {
+	agentDebugDir := fmt.Sprintf("%s/%s/", types.PersistDebugDir, agentName)
+	sigUsr1FileName := agentDebugDir + "/sigusr1"
+
+	stacks := getStacks(true)
+	stackArray := strings.Split(stacks, "\n\n")
+
+	sigUsr1File, err := os.OpenFile(sigUsr1FileName,
+		os.O_WRONLY|os.O_CREATE|os.O_SYNC|os.O_TRUNC, 0755)
+	if err == nil {
+		for _, stack := range stackArray {
+			// This goes to /persist/agentdebug/<agentname>/sigusr1 file
+			sigUsr1File.WriteString(stack + "\n\n")
+		}
+		sigUsr1File.Close()
+		log.Noticef("DumpAllStacks: Wrote file %s",
+			sigUsr1FileName)
+	} else {
+		log.Errorf("DumpAllStacks: Error opening file %s with: %s",
+			sigUsr1FileName, err)
+	}
+}
+
 // PrintStacks - for newlogd log init
 func PrintStacks(log *base.LogObject) {
 	stacks := getStacks(false)


### PR DESCRIPTION
With a reproducable test case (two ztests which create and then destroy a network instance using the same IP address) it has been possible to track this down and figure out a robust workaround. Note that the can't gather sufficient data to determine whether it is golang'r runtime or net packages which have the problem, or the Linux kernel. But what I see is that the http server is shutdown (based on the recommended shutdown procedure) but the listener TCP socket remains in the kernel, sometimes for minutes after that.
One required fix (which isn't part of the golang recommendations) is to get the http servers Accept call to unblock. This PR does that but it is not sufficient; still see the kernel listen socket hanging around (about once every 24 hours running the tests).
So in addition we add a retry loop for the listener creation which forces any accept to unblock.

This has two separate commits described in their commit messages:
1. Expose the ability to dump stacks in the agentlog package
2. Fix server.go per above and add some more logging to it.