### PR TITLE
sync eden tests and use docker image of Eden

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -24,15 +24,10 @@ jobs:
         run: |
           sudo add-apt-repository ppa:canonical-server/server-backports
           sudo apt install -y qemu-utils qemu-system-x86 jq
-      - name: get eden
-        uses: actions/checkout@v2
-        with:
-          repository: 'lf-edge/eden'
-      - name: build eden
+      - name: prepare eden
         run: |
-          make clean
-          make V=1 build
-          make V=1 build-tests
+          docker run -v $PWD:/out lfedge/eden:30c8b3f cp -a /eden/. /out/
+          sudo chown -R $(whoami) .
           ./eden config add default
       - name: get eve
         uses: actions/checkout@v2

--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -15,10 +15,6 @@ jobs:
       matrix:
         hv: ["kvm", "xen"]
     steps:
-      - name: get eden
-        uses: actions/checkout@v2
-        with:
-          repository: 'lf-edge/eden'
       - name: Check
         run: |
           for addr in $(ip addr list|sed -En -e 's/.*inet ([0-9.]+).*/\1/p')
@@ -54,10 +50,11 @@ jobs:
           sudo openvpn --config ./config.ovpn --daemon
           until ip -f inet addr show tun0; do sleep 5; ip a; done
           echo ::set-output name=tunnel_ip::$(ip -f inet addr show tun0 | sed -En -e 's/.*inet ([0-9.]+).*/\1/p')
-      - name: build eden
+      - name: prepare eden
         run: |
-          make build
-          make build-tests
+          docker run -v $PWD:/out lfedge/eden:30c8b3f cp -a /eden/. /out/
+          sudo chown -R $(whoami) .
+          ./eden config add default
       - name: get eve
         uses: actions/checkout@v2
         with:

--- a/tests/eden/app/README.md
+++ b/tests/eden/app/README.md
@@ -1,0 +1,16 @@
+# Application state detector
+
+The syntax for calling this detector is:
+
+```console
+eden.app.test [options] state app_name...
+```
+
+Where "status" is the standard state of the application (for example, RUNNING)
+or "-" to detect deletion of applications.
+
+Test specific "options":
+
+* -timewait -- Timewait for waiting (1 min by default).
+
+[E-script test for 2 dockers](testdata/2dockers_test.txt).

--- a/tests/eden/app/eden-config.yml
+++ b/tests/eden/app/eden-config.yml
@@ -1,7 +1,7 @@
 ---
 eden:
     # test binary
-    test-bin: "eden.escript.test"
+    test-bin: "eden.app.test"
 
     # test scenario
     test-scenario: "eden.app.tests.txt"

--- a/tests/eden/docker/eden-config.yml
+++ b/tests/eden/docker/eden-config.yml
@@ -1,7 +1,7 @@
 ---
 eden:
     # test binary
-    test-bin: "eden.escript.test"
+    test-bin: "eden.docker.test"
 
     # test scenario
     test-scenario: "eden.docker.tests.txt"

--- a/tests/eden/eclient/README.md
+++ b/tests/eden/eclient/README.md
@@ -1,0 +1,14 @@
+# Test Description
+
+Tests described here uses docker image (Dockerfile is available [here](image/Dockerfile)) called eclient, which one
+provides SSH access on port 22 for user root with certificate available [here](image/cert/id_rsa). Container includes
+additional bash scripts for testing purposes and implementation of
+[local profile server](https://github.com/lf-edge/eve/blob/master/api/PROFILE.md).
+
+## Test structure
+
+* eden.eclient.tests.txt - escript scenario file
+* /image - a folder with eclient docker image
+* /testdata - a folder with custom escripts for a workload
+* eden+ports.sh, eden-ports.sh - modifies port forwarding configuration (`eden+ports.sh 2223:2223` - adds 2223/TCP->2223/TCP forwarding)
+* qemu+usb.sh, qemu+2usb.sh, qemu+audio.sh - add devices to qemu

--- a/tests/eden/eclient/eden+ports.sh
+++ b/tests/eden/eclient/eden+ports.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+if [ $# -eq 0 ]
+then
+  echo Usage: "$0" port1:port2...
+  exit
+fi
+
+test -n "$EDEN_CONFIG" || EDEN_CONFIG=default
+
+EDEN=eden
+DIR=$(dirname "$0")
+PATH=$DIR:$DIR/../../bin:$PATH
+
+OLD=$($EDEN config get "$EDEN_CONFIG" --key eve.hostfwd)
+NEW=$OLD
+
+for port in "$@"
+do
+  echo "$port" | grep '[0-9]\+:[0-9]\+' || continue
+  port=$(echo "$port" | sed 's/^/"/;s/:/":"/g;s/$/"/')
+  shift
+  if echo "$OLD" | grep -v "$port"
+  then
+    echo Adding "$port" port redirection to EDEN config
+    NEW=$(echo "$NEW" | sed "s/{\(.*\)}/{\1,$port}/")
+  fi
+done
+
+if [ "$OLD" != "$NEW" ]
+then
+  echo $EDEN config set "$EDEN_CONFIG" --key eve.hostfwd --value \'"$NEW"\'
+  $EDEN config set "$EDEN_CONFIG" --key eve.hostfwd --value "$NEW"
+  echo $EDEN config get "$EDEN_CONFIG" --key eve.hostfwd
+  $EDEN config get "$EDEN_CONFIG" --key eve.hostfwd
+  cat <<END
+To activate the changes in the config, you need to restart EVE:
+  $EDEN eve stop
+  $EDEN eve start
+END
+fi

--- a/tests/eden/eclient/eden-config.yml
+++ b/tests/eden/eclient/eden-config.yml
@@ -1,7 +1,5 @@
 ---
 eden:
-    # test binary
-    test-bin: "eden.escript.test"
 
     # test scenario
     test-scenario: "eden.eclient.tests.txt"

--- a/tests/eden/eclient/eden-ports.sh
+++ b/tests/eden/eclient/eden-ports.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+if [ $# -eq 0 ]
+then
+  echo Usage: "$0" port1:port2...
+  exit
+fi
+
+test -n "$EDEN_CONFIG" || EDEN_CONFIG=default
+
+EDEN=eden
+DIR=$(dirname "$0")
+PATH=$DIR:$DIR/../../bin:$PATH
+
+OLD=$($EDEN config get "$EDEN_CONFIG" --key eve.hostfwd)
+NEW=$OLD
+
+for port in "$@"
+do
+  echo "$port" | grep '[0-9]\+:[0-9]\+' || continue
+  port=$(echo "$port" | sed 's/^/"/;s/:/":"/g;s/$/"/')
+  shift
+  if echo "$OLD" | grep "$port"
+  then
+    echo Removing "$port" port redirection to EDEN config
+    NEW=$(echo "$NEW" | sed "s/{\(.*\)$port\(.*\)}/{\1,\2}/; s/\(,\)\1/\1/g; s/[, ]*}/}/; s/{[, ]\+/{/; s/\([^, ]\),[, ]\+\([^, ]\)/\1,\2/")
+  fi
+done
+
+if [ "$OLD" != "$NEW" ]
+then
+  echo $EDEN config set "$EDEN_CONFIG" --key eve.hostfwd --value \'"$NEW"\'
+  $EDEN config set "$EDEN_CONFIG" --key eve.hostfwd --value "$NEW"
+  echo $EDEN config get "$EDEN_CONFIG" --key eve.hostfwd
+  $EDEN config get "$EDEN_CONFIG" --key eve.hostfwd
+  cat <<END
+To activate the changes in the config, you need to restart EVE:
+  $EDEN eve stop
+  $EDEN eve start
+END
+fi

--- a/tests/eden/eclient/qemu+2usb.sh
+++ b/tests/eden/eclient/qemu+2usb.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+test -n "$EDEN_CONFIG" || EDEN_CONFIG=default
+
+EDEN=eden
+DIR=$(dirname "$0")
+PATH=$DIR:$DIR/../../bin:$PATH
+
+dist=$($EDEN config get "$EDEN_CONFIG" --key eden.root)
+
+dd if=/dev/zero of="$dist/stick.raw" bs=1K count=1
+
+cat >> ~/.eden/"$EDEN_CONFIG"-qemu.conf <<END
+
+[drive "stick1"]
+  if = "none"
+  file = "$dist/stick.raw"
+  format = "raw"
+
+[device]
+  driver = "usb-storage"
+  bus = "usb.0"
+  drive = "stick1"
+
+[drive "stick2"]
+  if = "none"
+  file = "$dist/empty.raw"
+  format = "raw"
+
+[device]
+  driver = "usb-storage"
+  bus = "usb.0"
+  drive = "stick2"
+END
+
+cat <<END
+To activate the changes in the config, you need to restart EVE:
+  $EDEN eve stop
+  $EDEN eve start
+END

--- a/tests/eden/eclient/qemu+audio.sh
+++ b/tests/eden/eclient/qemu+audio.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+test -n "$EDEN_CONFIG" || EDEN_CONFIG=default
+
+EDEN=eden
+DIR=$(dirname "$0")
+PATH=$DIR:$DIR/../../bin:$PATH
+
+cat >> ~/.eden/"$EDEN_CONFIG"-qemu.conf <<END
+
+
+[device "sound"]
+  driver = "ich9-intel-hda"
+  bus = "pcie.0"
+  addr = "1b.0"
+END
+
+cat <<END
+To activate the changes in the config, you need to restart EVE:
+  $EDEN eve stop
+  $EDEN eve start
+END

--- a/tests/eden/eclient/qemu+usb.sh
+++ b/tests/eden/eclient/qemu+usb.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+test -n "$EDEN_CONFIG" || EDEN_CONFIG=default
+
+EDEN=eden
+DIR=$(dirname "$0")
+PATH=$DIR:$DIR/../../bin:$PATH
+
+dist=$($EDEN config get "$EDEN_CONFIG" --key eden.root)
+
+dd if=/dev/zero of="$dist/stick.raw" bs=1K count=1
+
+cat >> ~/.eden/"$EDEN_CONFIG"-qemu.conf <<END
+
+
+[drive "stick"]
+  if = "none"
+  file = "$dist/stick.raw"
+  format = "raw"
+
+[device]
+  driver = "usb-storage"
+  bus = "usb.0"
+  drive = "stick"
+END
+
+cat <<END
+To activate the changes in the config, you need to restart EVE:
+  $EDEN eve stop
+  $EDEN eve start
+END

--- a/tests/eden/eclient/testdata/acl.txt
+++ b/tests/eden/eclient/testdata/acl.txt
@@ -22,7 +22,7 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 message 'Resetting of EVE'
 eden eve reset
-exec sleep 20
+exec sleep 30
 
 # use zededa.com IP address as a target for $fake_domain
 exec -t 10m bash dns_lookup.sh zededa.com
@@ -34,9 +34,9 @@ eden network create 10.11.12.0/24 -n {{$network_name}} -s {{$fake_domain}}:$host
 test eden.network.test -test.v -timewait 10m ACTIVATED {{$network_name}}
 
 # First app is only allowed to access github.com and $long_domain.
-eden pod deploy -n curl-acl1 --memory=512MB docker://itmoeve/eclient:0.4 -p 2223:22 --networks={{$network_name}} --acl={{$network_name}}:github.com --acl={{$network_name}}:{{$long_domain}}
+eden pod deploy -n curl-acl1 --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p 2223:22 --networks={{$network_name}} --acl={{$network_name}}:github.com --acl={{$network_name}}:{{$long_domain}}:allow --acl={{$network_name}}:google.com:drop
 # Second app is only allowed to access $long_domain and $fake_domain.
-eden pod deploy -n curl-acl2 --memory=512MB docker://itmoeve/eclient:0.4 -p 2224:22 --networks={{$network_name}} --acl={{$network_name}}:{{$long_domain}} --acl={{$network_name}}:{{$fake_domain}}
+eden pod deploy -n curl-acl2 --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p 2224:22 --networks={{$network_name}} --acl={{$network_name}}:{{$long_domain}} --acl={{$network_name}}:{{$fake_domain}}:allow --acl={{$network_name}}:ieee.org:drop
 
 test eden.app.test -test.v -timewait 10m RUNNING curl-acl1 curl-acl2
 
@@ -44,6 +44,12 @@ exec -t 10m bash wait_ssh.sh 2223
 exec -t 10m bash wait_ssh.sh 2224
 
 exec sleep 10
+
+# Check that the configured ACLs do not allow direct communication between the applications,
+# even if they are on the same local network.
+! exec -t 10m bash ping_between_apps.sh curl-acl1 curl-acl2
+stdout '100% packet loss'
+!  stdout '[1-5] received'
 
 # Try to curl hosts allowed by ACLs
 exec -t 1m bash curl.sh 2223 github.com
@@ -62,15 +68,24 @@ stderr 'Connected to {{$long_domain}}'
 #stderr 'Connected to {{$fake_domain}}'
 ! exec -t 1m bash curl.sh 2224 github.com
 ! stderr 'Connected'
+! exec -t 1m bash curl.sh 2224 ieee.org
+! stderr 'Connected'
 ! exec -t 1m bash curl.sh 2224 google.com
 ! stderr 'Connected'
 
 # Wait for network packets information
-exec -t 20m bash wait_netstat.sh {{$network_name}} google.com github.com {{$long_domain}} {{$fake_domain}}
+exec -t 10m bash wait_netstat.sh curl-acl1 google.com github.com {{$long_domain}} {{$fake_domain}}
 stdout 'google.com'
 stdout 'github.com'
 stdout '{{$long_domain}}'
 stdout '{{$fake_domain}}'
+! stdout 'ieee.org'
+exec -t 10m bash wait_netstat.sh curl-acl2 google.com github.com {{$long_domain}} ieee.org
+stdout 'google.com'
+stdout 'github.com'
+stdout '{{$long_domain}}'
+! stdout '{{$fake_domain}}'
+stdout 'ieee.org'
 
 # Cleanup - undeploy applications
 eden pod delete curl-acl1
@@ -101,10 +116,10 @@ done
 -- dns_lookup.sh --
 
 # Performs DNS lookup for a given hostname and adds host_ip=<ip> into the .env file
-# The script uses 'getent' command to avoid dependencies on tools like 'host', 'dig', etc.
+# Uses dig command which is already included by most modern Linux systems and also macOS.
 # Usage: dns_lookup.sh <hostname>
 
-IP=$(getent hosts $1 | head -n 1 | cut -d ' ' -f 1)
+IP=$(dig +short $1)
 echo host_ip=$IP>>.env
 
 -- curl.sh --
@@ -115,6 +130,44 @@ HOST=$($EDEN eve ip)
 echo {{template "ssh"}}$HOST -p $1 curl -v --max-time 30 "$2"
 {{template "ssh"}}$HOST -p $1 curl -v --max-time 30 "$2"
 
+-- ping_between_apps.sh --
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+app1=$1
+app2=$2
+app1_ssh_port=$($EDEN pod ps | grep $app1 | awk '{print $5}' | cut -d ":" -f 2)
+app2_ssh_port=$($EDEN pod ps | grep $app2 | awk '{print $5}' | cut -d ":" -f 2)
+app1_ip=$($EDEN pod ps | grep $app1 | awk '{print $4}' | cut -d ":" -f 1)
+app2_ip=$($EDEN pod ps | grep $app2 | awk '{print $4}' | cut -d ":" -f 1)
+
+echo {{template "ssh"}}$HOST -p $app1_ssh_port ping -c 5 $app2_ip
+{{template "ssh"}}$HOST -p $app1_ssh_port ping -c 5 $app2_ip      && exit
+echo {{template "ssh"}}$HOST -p $app2_ssh_port ping -c 5 $app1_ip
+{{template "ssh"}}$HOST -p $app2_ssh_port ping -c 5 $app1_ip      && exit
+
+# ping routed by EVE was blocked, but check if on the L2 layer it is blocked as well
+# (i.e. when only forwarded by EVE)...
+function configure_link_route {
+    from_ssh_port=$1
+    from_ip=$2
+    to_ip=$3
+    CMDS="
+    iface=\$(ifconfig | awk -v filter=\"inet $from_ip\" '\$0 ~ filter {print \$1}' RS=\"\n\n\" FS=\":\") &&
+    ip route add $to_ip dev \$iface
+    "
+    echo {{template "ssh"}}$HOST -p $from_ssh_port "$CMDS"
+    {{template "ssh"}}$HOST -p $from_ssh_port "$CMDS"
+}
+configure_link_route $app1_ssh_port $app1_ip $app2_ip
+configure_link_route $app2_ssh_port $app2_ip $app1_ip
+
+echo {{template "ssh"}}$HOST -p $app1_ssh_port ping -c 5 $app2_ip
+{{template "ssh"}}$HOST -p $app1_ssh_port ping -c 5 $app2_ip      && exit
+echo {{template "ssh"}}$HOST -p $app2_ssh_port ping -c 5 $app1_ip
+{{template "ssh"}}$HOST -p $app2_ssh_port ping -c 5 $app1_ip      && exit
+
 -- wait_netstat.sh --
 #!/bin/sh
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
@@ -122,9 +175,9 @@ EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "ede
 echo "Waiting for netstat results"
 for p in ${@: 2}
 do
-  until "$EDEN" network netstat $1 | grep $p; do sleep 30; done
+  until "$EDEN" pod logs --fields=netstat $1 | grep "$p"; do sleep 30; done
 done
-"$EDEN" network netstat $1
+"$EDEN" pod logs --fields=netstat $1
 
 -- eden-config.yml --
 {{/* Test's config file */}}

--- a/tests/eden/eclient/testdata/air-gapped-switch.txt
+++ b/tests/eden/eclient/testdata/air-gapped-switch.txt
@@ -20,7 +20,7 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 message 'Resetting of EVE'
 eden eve reset
-exec sleep 20
+exec sleep 30
 
 message 'Creating networks: local indirect and air-gapped switch direct'
 eden network create 10.11.12.0/24 -n indirect
@@ -29,8 +29,8 @@ eden network create --type switch --uplink none -n direct
 test eden.network.test -test.v -timewait 10m ACTIVATED indirect direct
 
 message 'Starting applications'
-eden pod deploy -v debug -n eclient1 docker://itmoeve/eclient:0.7 -p {{template "port1"}}:22 --networks=indirect --networks=direct:{{template "mac1"}} --memory=512MB
-eden pod deploy -v debug -n eclient2 docker://itmoeve/eclient:0.7 -p {{template "port2"}}:22 --networks=indirect --networks=direct:{{template "mac2"}} --memory=512MB
+eden pod deploy -v debug -n eclient1 docker://lfedge/eden-eclient:83cfe07 -p {{template "port1"}}:22 --networks=indirect --networks=direct:{{template "mac1"}} --memory=512MB
+eden pod deploy -v debug -n eclient2 docker://lfedge/eden-eclient:83cfe07 -p {{template "port2"}}:22 --networks=indirect --networks=direct:{{template "mac2"}} --memory=512MB
 
 message 'Waiting for running state'
 test eden.app.test -test.v -timewait 10m RUNNING eclient1 eclient2

--- a/tests/eden/eclient/testdata/app_nonat.txt
+++ b/tests/eden/eclient/testdata/app_nonat.txt
@@ -15,7 +15,7 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 message 'Resetting of EVE'
 eden eve reset
-exec sleep 20
+exec sleep 30
 
 message 'Creating networks'
 eden network create 10.11.12.0/24 -n indirect
@@ -24,7 +24,7 @@ eden network create --type switch --uplink eth0 -n direct
 test eden.network.test -test.v -timewait 10m ACTIVATED indirect direct
 
 message 'Starting applications'
-eden pod deploy -v debug -n eclient docker://itmoeve/eclient:0.4 -p {{template "port"}}:22 --networks=indirect --networks=direct --memory=512MB
+eden pod deploy -v debug -n eclient docker://lfedge/eden-eclient:83cfe07 -p {{template "port"}}:22 --networks=indirect --networks=direct --memory=512MB
 
 message 'Waiting of running'
 test eden.app.test -test.v -timewait 30m RUNNING eclient

--- a/tests/eden/eclient/testdata/com-pt_test.txt
+++ b/tests/eden/eclient/testdata/com-pt_test.txt
@@ -16,7 +16,7 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 # Starting of reboot detector with a 2 reboot limit
 ! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
 
-eden pod deploy -n eclient --memory=512MB docker://itmoeve/eclient:0.7 -p {{template "port"}}:22
+eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{template "port"}}:22
 
 test eden.app.test -test.v -timewait 20m RUNNING eclient
 

--- a/tests/eden/eclient/testdata/disk.txt
+++ b/tests/eden/eclient/testdata/disk.txt
@@ -12,7 +12,7 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 # Starting of reboot detector with a 2 reboot limit
 ! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
 
-eden pod deploy -n eclient-disk --memory=512MB docker://itmoeve/eclient:0.4 -p {{$port}}:22 --disks=file://{{EdenConfig "eden.root"}}/empty.qcow2
+eden pod deploy -n eclient-disk --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{$port}}:22 --disks=file://{{EdenConfig "eden.root"}}/empty.qcow2
 
 test eden.app.test -test.v -timewait 20m RUNNING eclient-disk
 

--- a/tests/eden/eclient/testdata/eclient.txt
+++ b/tests/eden/eclient/testdata/eclient.txt
@@ -12,7 +12,7 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 # Starting of reboot detector with a 2 reboot limit
 ! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
 
-eden pod deploy -n eclient --memory=512MB docker://itmoeve/eclient:0.4 -p {{$port}}:22
+eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{$port}}:22
 
 test eden.app.test -test.v -timewait 20m RUNNING eclient
 

--- a/tests/eden/eclient/testdata/eclients.txt
+++ b/tests/eden/eclient/testdata/eclients.txt
@@ -6,7 +6,7 @@
 {{$apps := EdenGetEnv "EDEN_TEST_APPS"}}
 # Time of app waiting (default -- 30 min)
 {{$time := EdenGetEnv "EDEN_TEST_TIME"}}
-# Image for app (default -- docker://itmoeve/eclient:0.4)
+# Image for app (default -- docker://lfedge/eden-eclient:83cfe07)
 {{$img := EdenGetEnv "EDEN_TEST_IMG"}}
 
 {{$devmodel := EdenConfig "eve.devmodel"}}
@@ -49,8 +49,8 @@ TAPP={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/eden.app.test
 HOST=$($EDEN eve ip)
 
 APPS="{{$apps}}"
-# Default image -- docker://itmoeve/eclient:0.4
-IMG="{{if $img}}{{$img}}{{else}}docker://itmoeve/eclient:0.4{{end}}"
+# Default image -- docker://lfedge/eden-eclient:83cfe07
+IMG="{{if $img}}{{$img}}{{else}}docker://lfedge/eden-eclient:83cfe07{{end}}"
 
 PORTS=""
 for i in `seq $APPS`
@@ -109,9 +109,9 @@ TAPP={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/eden.app.test
 HOST=$($EDEN eve ip)
 
 APPS="{{$apps}}"
-# Default image -- docker://itmoeve/eclient:0.4
-#IMG="{{if $img}}{{$img}}{{else}}docker://itmoeve/eclient:0.4{{end}}"
-IMG="{{if $img}}{{$img}}{{else}}docker://itmoeve/eclient:0.4{{end}}"
+# Default image -- docker://lfedge/eden-eclient:83cfe07
+#IMG="{{if $img}}{{$img}}{{else}}docker://lfedge/eden-eclient:83cfe07{{end}}"
+IMG="{{if $img}}{{$img}}{{else}}docker://lfedge/eden-eclient:83cfe07{{end}}"
 
 PODS=""
 for i in `seq $APPS`

--- a/tests/eden/eclient/testdata/host-only.txt
+++ b/tests/eden/eclient/testdata/host-only.txt
@@ -13,9 +13,9 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 # Starting of reboot detector with a 1 reboot limit
 ! test eden.reboot.test -test.v -timewait 40m -reboot=0 -count=1 &
 
-eden pod deploy -n ping-nw --memory=512MB docker://itmoeve/eclient:0.4 -p 2223:22
-eden pod deploy -n ping-fw --memory=512MB docker://itmoeve/eclient:0.4 -p 2224:22 --only-host=true
-eden pod deploy -n pong --memory=512MB docker://itmoeve/eclient:0.4
+eden pod deploy -n ping-nw --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p 2223:22
+eden pod deploy -n ping-fw --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p 2224:22 --only-host=true
+eden pod deploy -n pong --memory=512MB docker://lfedge/eden-eclient:83cfe07
 
 test eden.app.test -test.v -timewait 25m RUNNING ping-nw ping-fw pong
 

--- a/tests/eden/eclient/testdata/maridb.txt
+++ b/tests/eden/eclient/testdata/maridb.txt
@@ -15,7 +15,7 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 # Starting of reboot detector with a 2 reboot limit
 #! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
 
-eden pod deploy -n eclient --memory=512MB docker://itmoeve/eclient:0.4 -p {{template "port"}}:22
+eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{template "port"}}:22
 
 eden pod deploy -n {{$server}} --memory=512MB docker://mariadb:10.5.6-focal --metadata='MYSQL_ROOT_PASSWORD=adam&eve'
 

--- a/tests/eden/eclient/testdata/mount.txt
+++ b/tests/eden/eclient/testdata/mount.txt
@@ -9,11 +9,11 @@
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 # Starting of reboot detector with a 1 reboot limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=1 &
+! test eden.reboot.test -test.v -timewait 60m -reboot=0 -count=1 &
 
-eden pod deploy -n eclient-mount --memory=512MB docker://itmoeve/eclient:0.7 -p {{$port}}:22 --mount=src=docker://nginx:1.20.0,dst=/tst --mount=src={{EdenConfig "eden.tests"}}/eclient/testdata,dst=/dir
+eden pod deploy -n eclient-mount --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{$port}}:22 --mount=src=docker://nginx:1.20.0,dst=/tst --mount=src={{EdenConfig "eden.tests"}}/eclient/testdata,dst=/dir
 
-test eden.app.test -test.v -timewait 20m RUNNING eclient-mount
+test eden.app.test -test.v -timewait 21m RUNNING eclient-mount
 
 exec -t 5m bash ssh.sh /tst
 stdout 'docker-entrypoint.sh'
@@ -24,6 +24,28 @@ stdout 'mount.txt'
 eden volume ls
 stdout '/dir'
 stdout '/tst'
+
+eden volume detach eclient-mount_1_m_0
+
+test eden.app.test -test.v -timewait 15m RUNNING eclient-mount
+
+# check old mount point
+exec -t 5m bash ssh.sh /tst
+! stdout 'docker-entrypoint.sh'
+
+# mount onto another mount point
+eden volume attach eclient-mount_1_m_0 eclient-mount /dst
+
+test eden.app.test -test.v -timewait 15m RUNNING eclient-mount
+
+# check new mount point
+exec -t 5m bash ssh.sh /dst
+stdout 'docker-entrypoint.sh'
+
+eden volume ls
+stdout '/dir'
+stdout '/dst'
+! stdout '/tst'
 
 eden pod delete eclient-mount
 

--- a/tests/eden/eclient/testdata/networking_light.txt
+++ b/tests/eden/eclient/testdata/networking_light.txt
@@ -14,11 +14,11 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 # Starting of reboot detector with a 2 reboot limit
 ! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
 
-eden pod deploy -n eclient --memory=512MB docker://itmoeve/eclient:0.4 -p {{template "port"}}:22
+eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{template "port"}}:22
 #eden -t 20m pod logs eclient
 #stdout 'Executing "/usr/sbin/sshd" "-D"'
 
-eden pod deploy -v warning -n eserver --memory=512MB docker://itmoeve/eclient:0.4
+eden pod deploy -v warning -n eserver --memory=512MB docker://lfedge/eden-eclient:83cfe07
 
 test eden.app.test -test.v -timewait 20m RUNNING eclient eserver
 

--- a/tests/eden/eclient/testdata/ngnix.txt
+++ b/tests/eden/eclient/testdata/ngnix.txt
@@ -15,7 +15,7 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 # Starting of reboot detector with a 2 reboot limit
 ! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
 
-eden pod deploy -n eclient --memory=512MB docker://itmoeve/eclient:0.4 -p {{template "port"}}:22
+eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{template "port"}}:22
 
 eden pod deploy -n {{$server}} --memory=512MB docker://nginx:latest
 

--- a/tests/eden/eclient/testdata/nw_switch.txt
+++ b/tests/eden/eclient/testdata/nw_switch.txt
@@ -15,7 +15,7 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 message 'Resetting of EVE'
 eden eve reset
-exec sleep 20
+exec sleep 30
 
 message 'Creating networks'
 #exec sleep 5
@@ -26,9 +26,9 @@ eden network create 10.11.13.0/24 -n n2
 test eden.network.test -test.v -timewait 10m ACTIVATED n1 n2
 
 message 'Starting applications'
-eden pod deploy -v debug -n ping1 docker://itmoeve/eclient:0.4 -p 2223:22 --networks=n1 --memory=512MB
-eden pod deploy -v debug -n ping2 docker://itmoeve/eclient:0.4 -p 2224:22 --networks=n2 --memory=512MB
-eden pod deploy -v debug -n pong docker://itmoeve/eclient:0.4 --networks=n1 --memory=512MB
+eden pod deploy -v debug -n ping1 docker://lfedge/eden-eclient:83cfe07 -p 2223:22 --networks=n1 --memory=512MB
+eden pod deploy -v debug -n ping2 docker://lfedge/eden-eclient:83cfe07 -p 2224:22 --networks=n2 --memory=512MB
+eden pod deploy -v debug -n pong docker://lfedge/eden-eclient:83cfe07 --networks=n1 --memory=512MB
 
 message 'Waiting of running'
 test eden.app.test -test.v -timewait 20m RUNNING ping1 ping2 pong
@@ -50,8 +50,7 @@ stdout '100% packet loss'
 
 message 'Switching to 2st network'
 eden pod modify pong --networks n2
-test eden.app.test -test.v -timewait 5m PURGING pong
-test eden.app.test -test.v -timewait 10m RUNNING pong
+test eden.app.test -test.v -timewait 15m RUNNING pong
 eden pod ps
 cp stdout pod_ps
 exec bash pong_ip.sh
@@ -66,8 +65,7 @@ stdout '0% packet loss'
 
 message 'Switching back to 1st network'
 eden pod modify pong --networks n1
-test eden.app.test -test.v -timewait 5m PURGING pong
-test eden.app.test -test.v -timewait 10m RUNNING pong
+test eden.app.test -test.v -timewait 15m RUNNING pong
 eden pod ps
 cp stdout pod_ps
 exec bash pong_ip.sh

--- a/tests/eden/eclient/testdata/port_forward.txt
+++ b/tests/eden/eclient/testdata/port_forward.txt
@@ -8,6 +8,7 @@
 [!exec:sleep] stop
 [!exec:ssh] stop
 [!exec:chmod] stop
+[!exec:timeout] stop
 
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
@@ -16,7 +17,7 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 message 'Resetting of EVE'
 eden eve reset
-exec sleep 20
+exec sleep 30
 
 ############################## TEST SCENARIO 1 ################################
 # Hairpin connectivity test between two apps connected to the same network instance
@@ -25,10 +26,11 @@ message 'SCENARIO 1: Creating networks'
 eden network create 10.11.12.0/24 -n n1
 
 test eden.network.test -test.v -timewait 10m ACTIVATED n1
+exec sleep 10
 
 message 'SCENARIO 1: Starting with both application attached to same network instance'
-eden pod deploy -v debug -n app1 docker://itmoeve/eclient:0.6 -p 2223:22 --networks=n1 --memory=512MB
-eden pod deploy -v debug -n app2 docker://itmoeve/eclient:0.6 -p 2224:22 --networks=n1 --memory=512MB
+eden pod deploy -v debug -n app1 docker://lfedge/eden-eclient:83cfe07 -p 2223:22 --networks=n1 --memory=512MB
+eden pod deploy -v debug -n app2 docker://lfedge/eden-eclient:83cfe07 -p 2224:22 --networks=n1 --memory=512MB
 
 message 'SCENARIO 1: Waiting for apps to enter RUNNING state'
 test eden.app.test -test.v -timewait 20m RUNNING app1 app2
@@ -90,8 +92,8 @@ eden network create 10.11.13.0/24 -n n2 --uplink eth1
 test eden.network.test -test.v -timewait 10m ACTIVATED n1 n2
 
 message 'SCENARIO 2: Starting with each application attached to a different network instance'
-eden pod deploy -v debug -n app1 docker://itmoeve/eclient:0.6 -p 2223:22 --networks=n1 --memory=512MB
-eden pod deploy -v debug -n app2 docker://itmoeve/eclient:0.6 -p 2234:22 --networks=n2 --memory=512MB
+eden pod deploy -v debug -n app1 docker://lfedge/eden-eclient:83cfe07 -p 2223:22 --networks=n1 --memory=512MB
+eden pod deploy -v debug -n app2 docker://lfedge/eden-eclient:83cfe07 -p 2234:22 --networks=n2 --memory=512MB
 
 message 'SCENARIO 2: Waiting for apps to enter RUNNING state'
 test eden.app.test -test.v -timewait 20m RUNNING app1 app2
@@ -149,8 +151,8 @@ do
   do
     sleep 20
     # Test SSH-access to container
-    echo {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue
-    {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue && break
+    echo timeout 10s {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue
+    timeout 10s {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue && break
   done
 done
 

--- a/tests/eden/eclient/testdata/profile.txt
+++ b/tests/eden/eclient/testdata/profile.txt
@@ -16,17 +16,17 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 message 'Resetting of EVE'
 eden eve reset
-exec sleep 20
+exec sleep 30
 
 # Define local-manager and two apps in different profiles
 # TBD: static ip in pod deploy
-eden pod deploy -n local-manager --memory=512MB docker://itmoeve/eclient:0.8 -p 2223:22
+eden pod deploy -n local-manager --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p 2223:22
 
 test eden.app.test -test.v -timewait 10m RUNNING local-manager
 
-eden pod deploy -n app-profile-1 --memory=512MB docker://itmoeve/eclient:0.8 --profile=profile-1
-eden pod deploy -n app-profile-2 --memory=512MB docker://itmoeve/eclient:0.8 --profile=profile-2
-eden pod deploy -n app-profile-1-2 --memory=512MB docker://itmoeve/eclient:0.8 --profile=profile-1 --profile=profile-2
+eden pod deploy -n app-profile-1 --memory=512MB docker://lfedge/eden-eclient:83cfe07 --profile=profile-1
+eden pod deploy -n app-profile-2 --memory=512MB docker://lfedge/eden-eclient:83cfe07 --profile=profile-2
+eden pod deploy -n app-profile-1-2 --memory=512MB docker://lfedge/eden-eclient:83cfe07 --profile=profile-1 --profile=profile-2
 
 # We have empty local_manager and empty default_profile, so apps should be in RUNNING state
 test eden.app.test -test.v -timewait 20m RUNNING app-profile-1 app-profile-2 app-profile-1-2 local-manager

--- a/tests/eden/eclient/testdata/usb-pt_test.txt
+++ b/tests/eden/eclient/testdata/usb-pt_test.txt
@@ -12,8 +12,8 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 # Starting of reboot detector with a 2 reboot limit
 ! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
 
-eden pod deploy -n n1 --memory=512MB docker://itmoeve/eclient:0.4 -p 2223:22
-eden pod deploy -n n2 --memory=512MB docker://itmoeve/eclient:0.4 -p 2224:22 --adapters USB2:2
+eden pod deploy -n n1 --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p 2223:22
+eden pod deploy -n n2 --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p 2224:22 --adapters USB2:2
 
 test eden.app.test -test.v -timewait 20m RUNNING n1 n2
 

--- a/tests/eden/escript/README.md
+++ b/tests/eden/escript/README.md
@@ -1,0 +1,365 @@
+# Escrips
+
+Escripts provides support for defining filesystem-based tests by creating
+scripts in a directory.
+
+The `eden.escript.test` test-binary is an adaptation to
+[github.com/lf-edge/eden](https://github.com/lf-edge/eden) of original Go
+testscript machinery from
+[github.com/rogpeppe/go-internal/testscript](https://pkg.go.dev/github.com/rogpeppe/go-internal/testscript).
+
+The easiest way to run a script from the test's `testdata` directory is to use the '-e' option:
+
+```console
+eden test tests/escript -e message
+```
+
+This is the short form of:
+
+```console
+eden test tests/escript -p eden.escript.test -r TestEdenScripts/message
+```
+
+To invoke the tests from /tmp directory, for example, call the such command:
+
+```console
+    eden test tests/escript/ -a '-testdata /tmp/'
+```
+
+A testdata directory ([tests/escript/testdata](testdata) by default) holds test scripts
+*.txt run test-binary. Each script defines a subtest; the exact set of
+allowable commands in a script are defined by the parameters passed to the
+Run function. To run a specific script foo.txt
+
+```console
+    eden test tests/escript/ --run=TestEdenScripts/^foo$
+```
+
+where TestEdenScripts is the name of the test that Run is called from.
+
+In general script files should have short names: a few words, not whole
+sentences. The first word should be the general category of behavior being
+tested, often the name of a subcommand to be tested or a concept (vendor,
+pattern).
+
+Each script is a text archive (`go doc
+github.com/lf-edge/eden/tests/escripts/go-internal/txtar`). The script begins
+with an actual command script to run followed by the content of zero or more
+supporting files to create in the script's temporary file system before it
+starts executing.
+
+As an example:
+
+```console
+    # hello world
+    exec cat hello.text
+    stdout 'hello world\n'
+    ! stderr .
+
+    -- hello.text --
+    hello world
+```
+
+Each script runs in a fresh temporary work directory tree, available to
+scripts as $WORK. Scripts also have access to these other environment
+variables:
+
+```console
+    HOME=/no-home
+    PATH=<actual PATH>
+    TMPDIR=$WORK/tmp
+    devnull=<value of os.DevNull>
+```
+
+The environment variable $exe (lowercase) is an empty string on most
+systems, ".exe" on Windows.
+
+The script's supporting files are unpacked relative to $WORK and then the
+script begins execution in that directory as well. Thus the example above
+runs in $WORK with $WORK/hello.txt containing the listed contents.
+
+The lines at the top of the script are a sequence of commands to be executed
+by a small script engine in the testscript package (not the system shell).
+The script stops and the overall test fails if any particular command fails.
+
+Each line is parsed into a sequence of space-separated command words, with
+environment variable expansion and # marking an end-of-line comment. Adding
+single quotes around text keeps spaces in that text from being treated as
+word separators and also disables environment variable expansion. Inside a
+single-quoted block of text, a repeated single quote indicates a literal
+single quote, as in:
+
+```'Don''t communicate by sharing memory.'```
+
+A line beginning with # is a comment and conventionally explains what is
+being done or tested at the start of a new phase in the script.
+
+A special form of environment variable syntax can be used to quote regexp
+metacharacters inside environment variables. The "@R" suffix is special, and
+indicates that the variable should be quoted.
+
+```${VAR@R}```
+
+The command prefix ! indicates that the command on the rest of the line
+(typically go or a matching predicate) must fail, not succeed. Only certain
+commands support this prefix. They are indicated below by [!] in the
+synopsis.
+
+The command prefix [cond] indicates that the command on the rest of the line
+should only run when the condition is satisfied. The predefined conditions
+are:
+
+```console
+- [short] for testing.Short()
+- [net] for whether the external network can be used
+- [link] for whether the OS has hard link support
+- [symlink] for whether the OS has symbolic link support
+- [exec:prog] for whether prog is available for execution (found by exec.LookPath)
+```
+
+A condition can be negated: [!short] means to run the rest of the line when
+testing.Short() is false.
+
+Additional conditions can be added by passing a function to
+Params.Condition.
+
+The predefined commands are:
+
+* arg name env
+
+    Set environment variable (env) with value from argument (name) passed into script
+    You can define arguments in top tests file:
+    `eden.escript.test -test.run TestEdenScripts/arg -args="test1=123,test2=456"`
+
+    You can override provided args by run:
+    `./eden test tests/escript/ -v debug -a="test1=789"`
+
+* cd dir
+
+    Change to the given directory for future commands.
+
+* chmod mode file
+
+    Change the permissions of file or directory to the given octal mode (000 to 777).
+
+* [!] cmp file1 file2
+
+    Check that the named files have the same content.
+    By convention, file1 is the actual data and file2 the expected data.
+    File1 can be "stdout" or "stderr" to use the standard output or standard error
+    from the most recent exec or wait command.
+    (If the files have differing content, the failure prints a diff.)
+
+* [!] cmpenv file1 file2
+
+    Like cmp, but environment variables in file2 are substituted before the
+    comparison. For example, $GOOS is replaced by the target GOOS.
+
+* cp src... dst
+
+    Copy the listed files to the target file or existing directory.
+    src can include "stdout" or "stderr" to use the standard output or standard error
+    from the most recent exec, eden or test command.
+
+* [!] eden [args...] [&]
+
+    Run the given 'eden' executable program with the arguments.
+    Behaves the same way as an 'exec'.
+
+* env [key=value...]
+
+    With no arguments, print the environment (useful for debugging).
+    Otherwise add the listed key=value pairs to the environment.
+
+* source file...
+
+    Parse file and set environment variables from it.
+
+* [!] exec program [args...] [&]
+
+    Run the given executable program with the arguments.
+    It must (or must not) succeed.
+    Note that 'exec' does not terminate the script (unlike in Unix shells).
+
+    If the last token is '&', the program executes in the background. The standard
+    output and standard error of the previous command is cleared, but the output
+    of the background process is buffered — and checking of its exit status is
+    delayed — until the next call to 'wait', 'skip', or 'stop' or the end of the
+    test. At the end of the test, any remaining background processes are
+    terminated using os.Interrupt (if supported) or os.Kill.
+
+    Standard input can be provided using the stdin command; this will be
+    cleared after exec has been called.
+
+* [!] exists [-readonly] file...
+
+    Each of the listed files or directories must (or must not) exist.
+    If -readonly is given, the files or directories must be unwritable.
+
+* [!] grep [-count=N] pattern file
+
+    The file's content must (or must not) match the regular expression pattern.
+    For positive matches, -count=N specifies an exact number of matches to require.
+
+* message message
+
+    Print message.
+
+* mkdir path...
+
+    Create the listed directories, if they do not already exists.
+
+* unquote file...
+
+    Rewrite each file by replacing any leading ">" characters from
+    each line. This enables a file to contain substrings that look like
+    txtar file markers.
+    See also [Unquote](https://godoc.org/github.com/rogpeppe/go-internal/txtar#Unquote).
+
+* rm file...
+
+    Remove the listed files or directories.
+
+* skip [message]
+
+    Mark the test skipped, including the message if given.
+
+* stdin file
+
+    Set the standard input for the next exec command
+    to the contents of the given file.
+
+* [!] stderr [-count=N] pattern
+
+    Apply the grep command (see above) to the standard error
+    from the most recent exec or wait command.
+
+* [!] stdout [-count=N] pattern
+
+    Apply the grep command (see above) to the standard output
+    from the most recent exec or wait command.
+
+* stop [message]
+
+    Stop the test early (marking it as passing), including the message if given.
+
+* symlink file -> target
+
+    Create file as a symlink to target. The -> (like in ls -l output) is required.
+
+* [!] test [args...] [&]
+
+    Run the given 'eden' test executable program with the arguments.
+    Behaves the same way as an 'exec'.
+
+* wait
+
+    Wait for all 'exec', 'eden' and 'test' commands started in
+    the background (with the '&' token) to exit, and display success
+    or failure status for them.
+    After a call to wait, the 'stderr' and 'stdout' commands will apply to the
+    concatenation of the corresponding streams of the background commands,
+    in the order in which those commands were started.
+
+When TestEdenScripts runs a script and the script fails, by default TestEdenScripts
+shows the execution of the most recent phase of the script (since the last # comment)
+and only shows the # comments for earlier phases.
+For example, here is a multi-phase script with a bug in it:
+
+```console
+    [!exec:cat] stop
+
+    cp test.txt TEST.TXT
+
+    exec cat TOST.TXT
+    stdout 'text for bug test'
+    ! stderr .
+
+    -- test.txt --
+    text for bug test
+```
+
+The bug is that the final phase read TOST.TXT instead of TEST.TXT. The test
+failure looks like:
+
+```console
+    $ ./eden test tests/escript/ -r TestEdenScripts/bug
+    INFO[0000] testData directory: testdata
+    --- FAIL: TestEdenScripts (0.00s)
+        --- FAIL: TestEdenScripts/bug (0.02s)
+            testscript.go:382:
+                > [!exec:cat] stop
+                > cp test.txt TEST.TXT
+                > exec cat TOST.TXT
+                [stderr]
+                /bin/cat: TOST.TXT: No such file or directory
+                [exit status 1]
+                FAIL: testdata/bug.txt:5: unexpected command failure
+
+    FAIL
+    FATA[0000] Test running failed with exit status 1
+    $
+```
+
+Note that the commands in earlier phases have been hidden, so that the
+relevant commands are more easily found, and the elapsed time for a
+completed phase is shown next to the phase heading. To see the entire
+execution, use "go test -v", which also adds an initial environment dump to
+the beginning of the log.
+
+Note also that in reported output, the actual name of the per-script
+temporary directory has been consistently replaced with the literal string
+$WORK.
+
+If Params.TestWork is true, it causes each test to log the name of its $WORK
+directory and other environment variable settings and also to leave that
+directory behind when it exits, for manual debugging of failing tests:
+
+```console
+    $ ./eden test tests/escript/ -r TestEdenScripts/bug -v debug -a '-testwork'
+    DEBU[0000] DIR: tests/escript/
+    DEBU[0000] Will use config from /home/user/.eden/contexts/default.yml
+    DEBU[0000] Try to add config from /data/work/user/EVE/github/itmo-eve/eden/tests/escript/eden-config.yml
+    DEBU[0000] Merged config with /data/work/user/EVE/github/itmo-eve/eden/tests/escript/eden-config.yml
+    DEBU[0000] testApp: eden.escript.test
+    DEBU[0000] Will use config from /home/user/.eden/contexts/default.yml
+    DEBU[0000] Try to add config from /data/work/user/EVE/github/itmo-eve/eden/tests/escript/eden-config.yml
+    DEBU[0000] Merged config with /data/work/user/EVE/github/itmo-eve/eden/tests/escript/eden-config.yml
+    DEBU[0000] testProg: /home/user/work/EVE/github/itmo-eve/eden/dist/bin/eden.escript.test
+    DEBU[0000] Test: /home/user/work/EVE/github/itmo-eve/eden/dist/bin/eden.escript.test -test.run TestEdenScripts/bug -test.v -testwork
+    === RUN   TestEdenScripts
+    INFO[0000] testData directory: testdata
+    === RUN   TestEdenScripts/bug
+    === PAUSE TestEdenScripts/bug
+    === CONT  TestEdenScripts/bug
+        TestEdenScripts/bug: testscript.go:382:
+            WORK=/tmp/go-test-script884869182/script-bug
+            PATH=/home/user/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/home/user/bin:/home/user/go/bin
+            HOME=/no-home
+            TMPDIR=$WORK/tmp
+            devnull=/dev/null
+            /=/
+            :=:
+            exe=
+
+            > [!exec:cat] stop
+            > cp test.txt TEST.TXT
+            > exec cat TOST.TXT
+            [stderr]
+            /bin/cat: TOST.TXT: No such file or directory
+            [exit status 1]
+            FAIL: testdata/bug.txt:5: unexpected command failure
+
+    --- FAIL: TestEdenScripts (0.00s)
+        --- FAIL: TestEdenScripts/bug (0.01s)
+    FAIL
+    FATA[0000] Test running failed with exit status 1
+    $
+
+    $ WORK=/tmp/go-test-script884869182/script-bug
+    $ cd $WORK/
+    $ cat TEST.TXT
+    text for bug test
+
+    $
+```

--- a/tests/eden/escript/custom.fail.scenario.txt
+++ b/tests/eden/escript/custom.fail.scenario.txt
@@ -1,0 +1,1 @@
+/bin/echo Custom test fail scenario

--- a/tests/eden/escript/failScenario.txt
+++ b/tests/eden/escript/failScenario.txt
@@ -1,0 +1,19 @@
+{{$reset := EdenGetEnv "EDEN_FAIL_RESET"}}
+
+/bin/echo Default test fail scenario
+
+/bin/echo eden status
+eden status
+/bin/echo eden pod ps
+eden pod ps
+/bin/echo eden network ls
+eden network ls
+/bin/echo eden volume ls
+eden volume ls
+/bin/echo check fatal_stacks in logs
+eden log --format=json content:fatal_stacks
+
+{{ if (ne $reset "") }}
+/bin/echo EDEN's reset
+eden.escript.test -test.run TestEdenScripts/eden_reset -testdata {{EdenConfig "eden.root"}}/../tests/workflow/testdata/
+{{end}}

--- a/tests/eden/flir/README.md
+++ b/tests/eden/flir/README.md
@@ -1,0 +1,17 @@
+# Test Description
+
+This test runs a [FLEDGE](https://www.lfedge.org/projects/fledge/) project workload.
+This workload deploys a FLEDGE demo docker image, connects to
+Flir Thermal Imaging Device(AX8 and other A Series cameras), and getting data.
+
+## Requrements
+
+Set up the `CAMERA_IP` and `CAMERA_PORT` variables for running test.
+
+## Test structure
+
+eden.flir.tests.txt - escript scenario file
+
+* /image - a folder with fledge docker image
+* /testdata - a folder with custom escripts for a workload
+* test_flir.txt - main test file

--- a/tests/eden/flir/eden-config.yml
+++ b/tests/eden/flir/eden-config.yml
@@ -1,7 +1,5 @@
 ---
 eden:
-    # test binary
-    test-bin: "eden.flir.test"
 
     # test scenario
     test-scenario: "eden.flir.tests.txt"

--- a/tests/eden/flir/testdata/test_flir.txt
+++ b/tests/eden/flir/testdata/test_flir.txt
@@ -6,7 +6,7 @@
 # This test deploys fledge docker image into EVE to test Flir Camera data
 
 # deploy the application
-eden pod deploy -p 8027:80 -p 8028:8081  --name=fledge --memory=2GB --cpus=2  docker://itmoeve/fledgeeveflirdemo:1.8.2  -v debug
+eden pod deploy -p 8027:80 -p 8028:8081  --name=fledge --memory=2GB --cpus=2  docker://lfedge/eden-fledgeeveflirdemo:83cfe07  -v debug
 
 test eden.app.test -test.v -timewait 20m RUNNING fledge
 

--- a/tests/eden/hardware_reboot/README.md
+++ b/tests/eden/hardware_reboot/README.md
@@ -1,0 +1,10 @@
+# Test Description
+
+Key purpose is to verify that a reboot (sudo shutdown -r +1) from the guest doesn’t disrupt the set of assigned adapters.
+Tests is working correctly only in KVM
+
+## Test structure
+
+eden.hardware_reboot.tests.txt - escript scenario file
+
+* /testdata - a folder with custom escripts for a workload

--- a/tests/eden/hardware_reboot/eden-config.yml
+++ b/tests/eden/hardware_reboot/eden-config.yml
@@ -1,7 +1,5 @@
 ---
 eden:
-    # test binary
-    test-bin: "eden.hardware_reboot.test"
 
     # test scenario
     test-scenario: "eden.hardware_reboot.tests.txt"

--- a/tests/eden/hardware_reboot/eden.hardware_reboot.tests.txt
+++ b/tests/eden/hardware_reboot/eden.hardware_reboot.tests.txt
@@ -1,4 +1,4 @@
 eden.escript.test -test.run TestEdenScripts/hardware_usb_reboot
 eden.escript.test -test.run TestEdenScripts/hardware_2usb_reboot
 eden.escript.test -test.run TestEdenScripts/hardware_audio_reboot
-
+eden.escript.test -test.run TestEdenScripts/hardware_eth_reboot

--- a/tests/eden/hardware_reboot/testdata/hardware_2usb_reboot.txt
+++ b/tests/eden/hardware_reboot/testdata/hardware_2usb_reboot.txt
@@ -11,7 +11,7 @@
 # Starting of reboot detector with a 2 reboot limit
 ! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
 
-eden pod deploy -n eclient --memory=512MB docker://itmoeve/eclient:0.7 -p {{template "port"}}:22 --adapters USB2:2 --adapters USB2:3
+eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{template "port"}}:22 --adapters USB2:2 --adapters USB2:3
 
 test eden.app.test -test.v -timewait 20m RUNNING eclient
 

--- a/tests/eden/hardware_reboot/testdata/hardware_eth_reboot.txt
+++ b/tests/eden/hardware_reboot/testdata/hardware_eth_reboot.txt
@@ -1,0 +1,158 @@
+# Simple test of ETH passthrough functionality after reboot of a guest
+
+{{define "network"}}n1{{end}}
+{{define "port"}}2223{{end}}
+{{define "virtio_iface"}}enp3s0{{end}}
+{{define "passthrough_iface"}}enp4s0{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{template "port"}} ubuntu@{{end}}
+
+[!exec:bash] stop
+[!exec:sleep] stop
+[!exec:ssh] stop
+
+# Apply custom devmodel where usage of eth1 is PhyIoUsageNone and therefore it is available for passthrough.
+eden config set $EDEN_CONFIG --key eve.devmodelfile --value $WORK/devmodel.json
+
+# Re-generate device config
+message 'Resetting of EVE'
+eden eve reset
+
+# Make sure that if test fails mid-through, devmodelfile will be left unset.
+eden config set $EDEN_CONFIG --key eve.devmodelfile
+
+# Changes in physicalIO require reboot
+eden -t 2m eve stop
+! stderr .
+exec sleep 1m
+eden -t 2m eve start
+! stderr .
+
+# Deploy VM into network where only github.com is accessible
+eden network create 10.11.12.0/24 -n {{template "network"}}
+test eden.network.test -test.v -timewait 10m ACTIVATED {{template "network"}}
+exec -t 20m bash deploy.sh {{template "network"}} {{template "port"}}
+test eden.app.test -test.v -timewait 20m RUNNING app
+
+# Wait for VM to boot
+exec -t 20m bash ssh.sh
+stdout 'Ubuntu'
+
+# Check that passthrough interface is present and functional
+exec -t 20m bash check_passthrough.sh
+
+# reboot from guest
+exec -t 20m bash reboot.sh
+exec sleep 1m
+exec -t 20m bash ssh.sh
+stdout 'Ubuntu'
+
+# Re-check passthrough interface after reboot.
+# It also fails if there wasn't actually any reboot since the last check.
+exec -t 20m bash check_passthrough.sh
+
+# Cleanup - undeploy application
+eden pod delete app
+test eden.app.test -test.v -timewait 10m - app
+
+# Cleanup - remove network
+eden network delete {{template "network"}}
+test eden.network.test -test.v -timewait 10m - {{template "network"}}
+eden network ls
+! stdout '^{{template "network"}}\s'
+
+# Restore original devmodel (devmodelfile is already unset in the config)
+message 'Resetting of EVE'
+eden eve reset
+
+# Changes in physicalIO require reboot
+eden -t 2m eve stop
+! stderr .
+exec sleep 1m
+eden -t 2m eve start
+! stderr .
+
+-- deploy.sh --
+
+NETWORK=$1
+PORT=$2
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+
+IMG="https://cloud-images.ubuntu.com/releases/focal/release-20210510/ubuntu-20.04-server-cloudimg-amd64.img"
+PUB_KEY="$( cat {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa.pub )"
+$EDEN pod deploy -n app --networks=${NETWORK} --acl=${NETWORK}:github.com -p ${PORT}:22 --adapters eth1 --memory=1GB ${IMG} --metadata="#cloud-config\nssh_authorized_keys:\n - $PUB_KEY mykey@host"
+
+-- ssh.sh --
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+for i in `seq 20`
+do
+ sleep 20
+ # Test SSH-access to VM
+ echo $i\) {{template "ssh"}}$HOST grep Ubuntu /etc/issue
+ {{template "ssh"}}$HOST grep Ubuntu /etc/issue && break
+done
+
+-- reboot.sh --
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+echo {{template "ssh"}}$HOST 'sudo shutdown -r +1 &>/dev/null &'
+{{template "ssh"}}$HOST 'sudo shutdown -r +1 &>/dev/null &'
+
+-- check_passthrough.sh --
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+CMDS="
+uptime -s;
+sudo lshw -class network;
+ip addr;
+! ls /tmp/passthrough-checked || exit;
+sudo sysctl -w net.ipv4.conf.all.rp_filter=0;
+sudo sysctl -w net.ipv4.conf.default.rp_filter=0;
+sudo dhclient {{template "passthrough_iface"}};
+sleep 20;
+ip addr;
+ping -c 5 -I {{template "virtio_iface"}} github.com || exit;
+ping -c 5 -I {{template "passthrough_iface"}} github.com || exit;
+! ping -c 5 -I {{template "virtio_iface"}} google.com || exit;
+ping -c 5 -I {{template "passthrough_iface"}} google.com || exit;
+touch /tmp/passthrough-checked
+"
+echo {{template "ssh"}}$HOST "$CMDS"
+{{template "ssh"}}$HOST "$CMDS"
+
+-- devmodel.json --
+
+{
+  "ioMemberList": [
+    {
+      "ztype": 1,
+      "phylabel": "eth0",
+      "phyaddrs": {
+        "Ifname": "eth0"
+      },
+      "logicallabel": "eth0",
+      "assigngrp": "eth0",
+      "usage": 2,
+      "usagePolicy": {
+        "freeUplink": true
+      }
+    },
+    {
+      "ztype": 1,
+      "phylabel": "eth1",
+      "phyaddrs": {
+        "Ifname": "eth1"
+      },
+      "logicallabel": "eth1",
+      "assigngrp": "eth1",
+      "usage": 0,
+      "usagePolicy": {
+        "freeUplink": true
+      }
+    }
+  ]
+}

--- a/tests/eden/io_performance/README.md
+++ b/tests/eden/io_performance/README.md
@@ -1,0 +1,10 @@
+# Test Description
+
+This test runs a Flexible I/O tester on EVE, process and publishes results into git repo.
+
+## Test structure
+
+* eden.fio.tests.txt - escript scenario file
+* /image - a folder with fledge docker image, please see [README.md](image/README.md) for additional info
+* /testdata - a folder with custom escripts for a workload
+* fio_tests.txt - main test file

--- a/tests/eden/io_performance/eden-config.yml
+++ b/tests/eden/io_performance/eden-config.yml
@@ -1,7 +1,5 @@
 ---
 eden:
-    # test binary
-    test-bin: "eden.fio.test"
 
     # test scenario
     test-scenario: "eden.fio.tests.txt"

--- a/tests/eden/io_performance/testdata/fio_tests.txt
+++ b/tests/eden/io_performance/testdata/fio_tests.txt
@@ -7,7 +7,7 @@
 {{$volume_type := EdenGetEnv "VOLUME_TYPE"}}
 
 # Deploy the application
-eden pod deploy --volume-type={{if $volume_type}}{{$volume_type}}{{else}}qcow2{{end}} --metadata='EVE_VERSION={{EdenConfig "eve.tag"}}\nGIT_BRANCH={{EdenGetEnv "GIT_BRANCH"}}\nGIT_REPO={{EdenGetEnv "GIT_REPO"}}\nGIT_FOLDER={{EdenGetEnv "GIT_FOLDER"}}\nGIT_PATH={{EdenGetEnv "GIT_PATH"}}\nGIT_LOGIN={{EdenGetEnv "GIT_LOGIN"}}\nGIT_TOKEN={{EdenGetEnv "GIT_TOKEN"}}\nFIO_TIME={{EdenGetEnv "FIO_TIME"}}\nFIO_OPTYPE={{EdenGetEnv "FIO_OPTYPE"}}\nFIO_BS={{EdenGetEnv "FIO_BS"}}\nFIO_JOBS={{EdenGetEnv "FIO_JOBS"}}\nFIO_DEPTH={{EdenGetEnv "FIO_DEPTH"}}' --name=fio_test --memory=2GB --cpus=2 docker://itmoeve/fio_tests:v.1.2.1 --volume-size=2GB
+eden pod deploy --volume-type={{if $volume_type}}{{$volume_type}}{{else}}qcow2{{end}} --metadata='EVE_VERSION={{EdenConfig "eve.tag"}}\nGIT_BRANCH={{EdenGetEnv "GIT_BRANCH"}}\nGIT_REPO={{EdenGetEnv "GIT_REPO"}}\nGIT_FOLDER={{EdenGetEnv "GIT_FOLDER"}}\nGIT_PATH={{EdenGetEnv "GIT_PATH"}}\nGIT_LOGIN={{EdenGetEnv "GIT_LOGIN"}}\nGIT_TOKEN={{EdenGetEnv "GIT_TOKEN"}}\nFIO_TIME={{EdenGetEnv "FIO_TIME"}}\nFIO_OPTYPE={{EdenGetEnv "FIO_OPTYPE"}}\nFIO_BS={{EdenGetEnv "FIO_BS"}}\nFIO_JOBS={{EdenGetEnv "FIO_JOBS"}}\nFIO_DEPTH={{EdenGetEnv "FIO_DEPTH"}}' --name=fio_test --memory=2GB --cpus=2 docker://lfedge/eden-fio-tests:83cfe07 --volume-size=2GB
 
 test eden.app.test -test.v -timewait 5m RUNNING fio_test
 

--- a/tests/eden/lim/README.md
+++ b/tests/eden/lim/README.md
@@ -1,0 +1,19 @@
+# Log/Info/Metric detector
+
+The syntax for calling this detector is:
+
+```console
+eden.lim.test [options]
+```
+
+Test specific "options":
+
+* -number -- The number of items (0=unlimited) you need to get (1 by default)
+* -out -- Parameters for searching in out separated by ':'
+* -timewait -- Timewait for waiting (10 min by default)
+
+Testscripts:
+
+* [E-script test for logs](testdata/log_test.txt)
+* [E-script test for infos](testdata/info_test.txt)
+* [E-script test for metrics](testdata/metric_test.txt)

--- a/tests/eden/network/README.md
+++ b/tests/eden/network/README.md
@@ -1,0 +1,38 @@
+# Test Description
+
+This test creates and assigns a network to 2 applications, which communicate.
+One has nginx, the other uses curl.
+Creates 2 networks, checks internal IPs and does intercommunication
+
+[E-script test for networks](testdata/test_networking.txt).
+
+## Test structure
+
+eden.network.tests.txt - escript scenario file
+
+* /image - a folder with docker image
+* Dockerfile with nginx, dhcpcd and curl based on Debian
+* dhcpcd.conf - setup for dhcpcd
+* entrypoint.sh - entrypoint for Docker which runs required workload
+(curl, nginx, ip, dhcpcd)
+* nw\_test.go - source of networks detector
+* supervisord.conf - processing params and run strings for workloads
+* /testdata - a folder with custom escripts for a workload
+* test\_networking.txt - main test file
+
+## Network state detector
+
+The syntax for calling this detector is:
+
+```console
+eden.network.test [options] state nw_name...
+```
+
+Where "status" is the standard state of the network (for example, ACTIVATED)
+or "-" to detect deletion of network.
+
+Test specific "options":
+
+* -timewait -- Timewait for waiting (1 min by default).
+
+[E-script test for network](testdata/network_test.txt).

--- a/tests/eden/network/eden.network.tests.txt
+++ b/tests/eden/network/eden.network.tests.txt
@@ -1,1 +1,3 @@
 eden.escript.test -test.run TestEdenScripts/test_networking -test.timeout 40m
+
+eden.escript.test -test.run TestEdenScripts/vlans -test.timeout 40m

--- a/tests/eden/network/testdata/deploy_app.txt
+++ b/tests/eden/network/testdata/deploy_app.txt
@@ -2,4 +2,4 @@
 
 message {{$env_net}}
 
-eden pod deploy {{EdenGetEnv "external_port"}} --memory=300M --metadata='url={{EdenGetEnv "metadata"}}' --name='{{EdenGetEnv "name"}}' --networks={{ $env_net }} --vnc-display={{ EdenGetEnv "vnc" }} --only-host={{ EdenGetEnv "firewall" }}  docker://itmoeve/docker-test:1.2
+eden pod deploy {{EdenGetEnv "external_port"}} --memory=300M --metadata='url={{EdenGetEnv "metadata"}}' --name='{{EdenGetEnv "name"}}' --networks={{ $env_net }} --vnc-display={{ EdenGetEnv "vnc" }} --only-host={{ EdenGetEnv "firewall" }}  docker://lfedge/eden-docker-test:83cfe07

--- a/tests/eden/network/testdata/network_test.txt
+++ b/tests/eden/network/testdata/network_test.txt
@@ -1,4 +1,4 @@
-eden -t 5s network ls
+eden -t 10s network ls
 
 # Starting of reboot detector with a 1 reboot limit
 ! test eden.reboot.test -test.v -timewait 20m -reboot=0 -count=1 &

--- a/tests/eden/network/testdata/vlans.txt
+++ b/tests/eden/network/testdata/vlans.txt
@@ -1,0 +1,201 @@
+[!exec:bash] stop
+[!exec:grep] stop
+[!exec:cut] stop
+[!exec:curl] stop
+[!exec:sleep] stop
+
+# This test deploys 5 applications in total.
+# Four of those applications run the same curl and nginx services as used in "test_networking.txt".
+# All applications are connected to a NATed local network (10.1.0.0/24), used for access to HTTP endpoints from outside
+# through port-maps, but also to an air-gaped switch network split into multiple VLANs (10.2.<vid>.0/24):
+#  - app1 and app2 are connected to VLAN 100
+#  - app3 is connected to VLAN 200
+#  - app4 has initially no VLANs configured, later it is moved to VLAN 100
+#
+# The fifth application provides DHCP services separately for VLANs 100, 200 and for applications outside VLANs:
+#  - VLAN 100 uses IP range 10.2.100.0/24
+#  - VLAN 200 uses IP range 10.2.200.0/24
+#  - application interfaces without VLAN assignment get IP addresses from the range 10.2.0.0/24
+
+# The application providing DHCP services for multiple VLANs requires netadmin capabilities, otherwise
+# it is not permitted to create VLAN sub-interfaces. For security reasons, EVE does not allow to grant these
+# capabilities to native containers, therefore it is required to deploy apps as VMs-in-Containers for this test to pass.
+exec -t 2m bash check_vm_support.sh
+source .env
+[!env:with_hw_virt] skip 'Missing HW-assisted virtualization capability'
+
+{{$image := "docker://lfedge/eden-docker-test:83cfe07"}}
+
+# string to use as the testing sequence
+{{$test_data := "TEST_SEQUENCE"}}
+
+# create networks for the test
+eden network create 10.1.0.0/24 -n nat
+eden network create --type switch --uplink none -n switch
+test eden.network.test -test.v -timewait 10m ACTIVATED nat
+test eden.network.test -test.v -timewait 10m ACTIVATED switch
+
+# Deploy DHCP server
+eden pod deploy -n dhcp-server --memory=512MB --networks=nat --networks=switch -p 8027:80 --mount=src={{EdenConfig "eden.tests"}}/network/testdata/vlans/dhcp-server,dst=/app {{$image}}
+test eden.app.test -test.v -timewait 10m RUNNING dhcp-server
+exec -t 2m bash wait_and_get_ifconfig.sh dhcp-server 8027
+stdout '10.2.100.1  netmask 255.255.255.0'
+stdout '10.2.200.1  netmask 255.255.255.0'
+
+# Deploy app1 and connect it to VLAN 100
+eden pod deploy -n app1 --memory=512MB --networks=nat --networks=switch -p 8028:80 --vlan=switch:100 --metadata='url={{$test_data}}' {{$image}}
+test eden.app.test -test.v -timewait 10m RUNNING app1
+exec -t 5m bash wait_and_get_ip.sh app1 8028
+grep 'app1_ip=10.2.100.\d+' .env
+source .env
+
+# Deploy app2 and connect it to VLAN 100
+eden pod deploy -n app2 --memory=512MB --networks=nat --networks=switch -p 8029:80 --vlan=switch:100 --metadata="url=http://${app1_ip}/user-data.html" {{$image}}
+test eden.app.test -test.v -timewait 10m RUNNING app2
+exec -t 5m bash wait_and_get_ip.sh app2 8029
+grep 'app2_ip=10.2.100.\d+' .env
+source .env
+
+# Wait for app2 to obtain test_data from app1
+exec -t 5m bash wait_and_get_recv_data.sh app2 8029
+stdout '{{$test_data}}'
+
+# Deploy app3 and connect it to VLAN 200
+eden pod deploy -n app3 --memory=512MB --networks=nat --networks=switch -p 8030:80 --vlan=switch:200 --metadata="url=http://${app1_ip}/user-data.html" {{$image}}
+test eden.app.test -test.v -timewait 10m RUNNING app3
+exec -t 5m bash wait_and_get_ip.sh app3 8030
+grep 'app3_ip=10.2.200.\d+' .env
+source .env
+
+# app3 will try to obtain test_data from app1, but it should fail because they are in different VLANs
+exec -t 5m bash wait_and_get_recv_data.sh app3 8030
+! stdout '{{$test_data}}'
+
+# Deploy app4 outside of VLANs
+eden pod deploy -n app4 --memory=512MB --networks=nat --networks=switch -p 8031:80 --metadata="url=http://${app1_ip}/user-data.html" {{$image}}
+test eden.app.test -test.v -timewait 10m RUNNING app4
+exec -t 5m bash wait_and_get_ip.sh app4 8031
+grep 'app4_ip=10.2.0.\d+' .env
+source .env
+
+# app4 will try to obtain test_data from app1, but it should fail because app1 is inside VLAN while app4 is not
+exec -t 5m bash wait_and_get_recv_data.sh app4 8031
+! stdout '{{$test_data}}'
+
+# Modify app4 and move it to the VLAN 100
+eden pod modify app4 --networks=nat --networks=switch -p 8031:80 --vlan=switch:100
+exec sleep 15
+test eden.app.test -test.v -timewait 10m RUNNING app4
+exec -t 5m bash wait_and_get_ip.sh app4 8031
+grep 'app4_ip=10.2.100.\d+' .env
+source .env
+
+# app4 should now be able to obtain test_data from app1
+exec -t 5m bash wait_and_get_recv_data.sh app4 8031
+stdout '{{$test_data}}'
+
+# Cleanup - undeploy applications
+eden pod delete dhcp-server
+eden pod delete app1
+eden pod delete app2
+eden pod delete app3
+eden pod delete app4
+test eden.app.test -test.v -timewait 10m - dhcp-server app1 app2 app3 app4
+eden pod ps
+! stdout 'dhcp-server'
+! stdout 'app[1-4]'
+
+# Cleanup - remove networks
+eden network delete nat
+eden network delete switch
+test eden.network.test -test.v -timewait 10m - nat switch
+eden network ls
+! stdout 'nat'
+! stdout 'switch'
+
+-- check_vm_support.sh --
+#!/bin/sh
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+
+:>.env
+while true;
+do
+    virt=$($EDEN info --out InfoContent.dinfo.Capabilities.HWAssistedVirtualization | tail -n 1)
+    if [ -z "$virt" ]; then
+        sleep 3
+        continue
+    fi
+    [ "$virt" == "true" ] && echo "with_hw_virt=true" >>.env
+    break
+done
+
+-- wait_and_get_ifconfig.sh --
+#!/bin/sh
+
+APP=$1
+PORT=$2
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+address=http://${HOST}:${PORT}/ifconfig.html
+until curl -m 10 $address | grep -q LOOPBACK; do sleep 3; done
+curl -m 10 $address
+
+-- wait_and_get_ip.sh --
+#!/bin/sh
+
+APP=$1
+PORT=$2
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+function get_ip {
+    address=http://${HOST}:${PORT}/ifconfig.html
+    ifconfig=$(curl -m 10 $address) || return 1
+    if [ -z "$ifconfig" ]; then
+        return 1
+    fi
+    interfaces=$(echo "$ifconfig" | grep "^\w" | grep -v LOOPBACK | cut -d: -f1)
+    eth1=$(echo "$interfaces" | awk 'NR==2')
+    IP=$(echo "$ifconfig" | grep "^${eth1}: " -A 1 | awk '/inet / {print $2}' | cut -d"/" -f1)
+    if [ ! -z "$IP" ]; then
+        echo "IP address of $APP is: $IP"
+        echo "${APP}_ip=$IP" >.env
+        return 0
+    fi
+    return 1
+}
+
+until get_ip; do sleep 3; done
+
+-- wait_and_get_recv_data.sh --
+#!/bin/sh
+
+APP=$1
+PORT=$2
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+address=http://${HOST}:${PORT}/received-data.html
+
+# wait at most 1 minute for received-data.html to be available
+for i in `seq 12`
+do
+    sleep 5
+    recv_data=$(curl -m 10 $address)
+    if [ ! -z "$recv_data" ]; then
+        break
+    fi
+done
+curl -m 10 $address
+
+-- eden-config.yml --
+{{/* Test's config file */}}
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}

--- a/tests/eden/phoronix/README.md
+++ b/tests/eden/phoronix/README.md
@@ -1,0 +1,13 @@
+# Test Description
+
+This test creates and runs an application with phoronix test suite inside.
+
+[E-script test with phoronix](testdata/test_phoronix.txt).
+
+## Test structure
+
+* eden.phoronix.tests.txt - escript scenario file
+* phoronix/test_phoronix.txt - escript test, which deploys an app and waits for result served with http
+* /image - a folder with docker image
+* Dockerfile with phoronix-test-suite based on Ubuntu
+* entrypoint.sh - entrypoint for Docker which runs required test of testsuite and serve results via http

--- a/tests/eden/phoronix/eden-config.yml
+++ b/tests/eden/phoronix/eden-config.yml
@@ -1,7 +1,5 @@
 ---
 eden:
-    # test binary
-    test-bin: "eden.phoronix.test"
 
     # test scenario
     test-scenario: "eden.phoronix.tests.txt"

--- a/tests/eden/phoronix/testdata/deploy_app.txt
+++ b/tests/eden/phoronix/testdata/deploy_app.txt
@@ -1,1 +1,1 @@
-eden pod deploy {{EdenGetEnv "external_port"}} --metadata='BENCHMARK={{EdenGetEnv "benchmark"}}' --name='{{EdenGetEnv "name"}}' --memory=2GB --cpus=2 docker://itmoeve/phoronix-test:1.2
+eden pod deploy {{EdenGetEnv "external_port"}} --metadata='BENCHMARK={{EdenGetEnv "benchmark"}}' --name='{{EdenGetEnv "name"}}' --memory=2GB --cpus=2 docker://lfedge/eden-phoronix-test:83cfe07

--- a/tests/eden/reboot/README.md
+++ b/tests/eden/reboot/README.md
@@ -1,0 +1,13 @@
+# Reboot detector
+
+The syntax for calling this detector is:
+
+```console
+eden.reboot.test [options]
+```
+
+Where specific "options":
+
+* -timewait -- Timewait for waiting (1 min by default).
+* -count -- Number of reboots (1 by default).
+* -reboot -- Reboot or not reboot... ("true" by default)

--- a/tests/eden/registry/README.md
+++ b/tests/eden/registry/README.md
@@ -1,0 +1,9 @@
+# Test Description
+
+This test adds nginx image into registry of Eden and deploys apps from the local registry into EVE.
+
+## Test structure
+
+* eden.registry.tests.txt - escript scenario file
+* /testdata - a folder with custom escript for a workload
+* registry_test.txt - main test file

--- a/tests/eden/registry/eden-config.yml
+++ b/tests/eden/registry/eden-config.yml
@@ -1,7 +1,5 @@
 ---
 eden:
-    # test binary
-    test-bin: "eden.escript.test"
 
     # test scenario
     test-scenario: "eden.registry.tests.txt"

--- a/tests/eden/registry/testdata/registry_test.txt
+++ b/tests/eden/registry/testdata/registry_test.txt
@@ -3,7 +3,7 @@
 [!exec:cut] stop
 [!exec:grep] stop
 
-eden -t 5s pod ps
+eden -t 10s pod ps
 
 # Starting of reboot detector with a 3 reboots limit
 ! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=1 &

--- a/tests/eden/update_eve_image/eden-config.yml
+++ b/tests/eden/update_eve_image/eden-config.yml
@@ -1,7 +1,5 @@
 ---
 eden:
-    # test binary
-    test-bin: "eden.update_eve_image.test"
 
     # test scenario
     test-scenario: "eden.update_eve_image.tests.txt"

--- a/tests/eden/volume/README.md
+++ b/tests/eden/volume/README.md
@@ -1,0 +1,16 @@
+# Volume state detector
+
+The syntax for calling this detector is:
+
+```console
+eden.vol.test [options] state vol_name...
+```
+
+Where "status" is the standard state of the volume (for example, DELIVERED)
+or "-" to detect deletion of volume.
+
+Test specific "options":
+
+* -timewait -- Timewait for waiting (1 min by default).
+
+[E-script test for volumes](testdata/volumes_test.txt).

--- a/tests/eden/volume/eden-config.yml
+++ b/tests/eden/volume/eden-config.yml
@@ -1,7 +1,7 @@
 ---
 eden:
     # test binary
-    test-bin: "eden.escript.test"
+    test-bin: "eden.vol.test"
 
     # test scenario
     test-scenario: "eden.vol.tests.txt"

--- a/tests/eden/volume/testdata/volumes_test.txt
+++ b/tests/eden/volume/testdata/volumes_test.txt
@@ -1,11 +1,11 @@
-eden -t 5s volume ls
+eden -t 10s volume ls
 
 # Starting of reboot detector with a 1 reboots limit
 ! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=1 &
 
 # Create v1 volume
-eden -t 1m volume create -n v-docker docker://itmoeve/eclient:0.4 --disk-size=200M
-stdout 'create volume v-docker with docker://itmoeve/eclient:0.4 request sent'
+eden -t 1m volume create -n v-docker docker://lfedge/eden-eclient:83cfe07 --disk-size=200M
+stdout 'create volume v-docker with docker://lfedge/eden-eclient:83cfe07 request sent'
 eden -t 1m volume create -n v-qcow2 file://{{EdenConfig "eden.root"}}/empty.qcow2 --format=qcow2 --disk-size=200M
 stdout 'create volume v-qcow2 with file://{{EdenConfig "eden.root"}}/empty.qcow2 request sent'
 eden -t 1m volume create -n v-qcow file://{{EdenConfig "eden.root"}}/empty.qcow --format=qcow --disk-size=560
@@ -14,10 +14,11 @@ eden -t 1m volume create -n v-vmdk file://{{EdenConfig "eden.root"}}/empty.vmdk 
 stdout 'create volume v-vmdk with file://{{EdenConfig "eden.root"}}/empty.vmdk request sent'
 eden -t 1m volume create -n v-vhdx file://{{EdenConfig "eden.root"}}/empty.vhdx --format=vhdx --disk-size=8388608
 stdout 'create volume v-vhdx with file://{{EdenConfig "eden.root"}}/empty.vhdx request sent'
+eden -t 1m volume create -n blank-vol blank --disk-size=10MB
 
 # Wait for run
 test eden.vol.test -test.v -timewait 10m DELIVERED v-qcow2 v-docker v-qcow v-vmdk v-vhdx
-#test eden.vol.test -test.v -timewait 10m DELIVERED v-qcow2 v-docker v-qcow v-vmdk v-vhdx
+test eden.vol.test -test.v -timewait 1m CREATED_VOLUME blank-vol
 
 # Volume detecting
 eden -t 1m volume ls
@@ -39,16 +40,18 @@ eden -t 1m volume delete v-vmdk
 stdout 'volume v-vmdk delete done'
 eden -t 1m volume delete v-vhdx
 stdout 'volume v-vhdx delete done'
+eden -t 1m volume delete blank-vol
+stdout 'volume blank-vol delete done'
 
 # Wait for delete
-test eden.vol.test -test.v -timewait 5m - v-qcow2 v-docker v-qcow v-vmdk v-vhdx
-#test eden.vol.test -test.v -timewait 5m - v-qcow2 v-docker v-qcow v-vmdk v-vhdx
+test eden.vol.test -test.v -timewait 5m - v-qcow2 v-docker v-qcow v-vmdk v-vhdx blank-vol
 cp stdout vol_ls
 grep 'o volume with v-docker found' vol_ls
 grep 'o volume with v-qcow2 found' vol_ls
 grep 'o volume with v-qcow found' vol_ls
 grep 'o volume with v-vmdk found' vol_ls
 grep 'o volume with v-vhdx found' vol_ls
+grep 'o volume with blank-vol found' vol_ls
 
 # Volumes detecting
 eden -t 1m volume ls
@@ -58,6 +61,7 @@ cp stdout vol_ls
 ! grep '^v-qcow\s*' vol_ls
 ! grep '^v-vmdk\s*' vol_ls
 ! grep '^v-vhdx\s*' vol_ls
+! grep '^blank-vol\s*' vol_ls
 
 # Test's config. file
 -- eden-config.yml --

--- a/tests/eden/workflow/eden-config.yml
+++ b/tests/eden/workflow/eden-config.yml
@@ -1,7 +1,5 @@
 ---
 eden:
-    # test binary
-    test-bin: "eden.escript.test"
 
     # test scenario
     test-scenario: "eden.workflow.tests.txt"

--- a/tests/eden/workflow/eden.workflow.tests.txt
+++ b/tests/eden/workflow/eden.workflow.tests.txt
@@ -10,6 +10,8 @@
 {{$usb_pt := EdenGetEnv "EDEN_TEST_USB_PT"}}
 # EDEN_TEST_AUDIO_PT -- "y" enables Audio Passthrough test (disabled by default).
 {{$audio_pt := EdenGetEnv "EDEN_TEST_AUDIO_PT"}}
+# EDEN_TEST_ETH_PT -- "y" enables Ethernet Passthrough test (disabled by default).
+{{$eth_pt := EdenGetEnv "EDEN_TEST_ETH_PT"}}
 # EDEN_TEST_REGISTRY env. var. -- "y"(default) performs the local EDEN registry test
 {{$registry := EdenGetEnv "EDEN_TEST_REGISTRY"}}
 
@@ -30,7 +32,7 @@ qemu+usb.sh
 qemu+audio.sh
 {{end}}
 {{if or (eq $devmodel "ZedVirtual-4G") (eq $devmodel "VBox") (eq $devmodel "parallels") }}
-eden+ports.sh 2223:2223 2224:2224 5912:5902 5911:5901 8027:8027
+eden+ports.sh 2223:2223 2224:2224 5912:5902 5911:5901 8027:8027 8028:8028 8029:8029 8030:8030 8031:8031
 {{end}}
 
 {{if (ne $setup "n")}}
@@ -77,6 +79,8 @@ eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/fail_
 
 /bin/echo Eden basic network test (16/{{$tests}})
 eden.escript.test -testdata ../network/testdata/ -test.run TestEdenScripts/network_test
+/bin/echo Eden basic VLAN test (16.1/{{$tests}})
+eden.escript.test -testdata ../network/testdata/ -test.run TestEdenScripts/vlans
 /bin/echo Eden basic volumes test (17.1/{{$tests}})
 eden.escript.test -testdata ../volume/testdata/ -test.run TestEdenScripts/volumes_test
 /bin/echo Eden sftp volumes test (17.2/{{$tests}})
@@ -108,6 +112,10 @@ eden.escript.test -testdata ../hardware_reboot/testdata/ -test.run TestEdenScrip
 {{if (eq $audio_pt "y")}}
 /bin/echo Hardware reboot - Audio (22.1/{{$tests}})
 eden.escript.test -testdata ../hardware_reboot/testdata/ -test.run TestEdenScripts/hardware_audio_reboot
+{{end}}
+{{if (eq $eth_pt "y")}}
+/bin/echo Hardware reboot - Ethernet (22.2/{{$tests}})
+eden.escript.test -testdata ../hardware_reboot/testdata/ -test.run TestEdenScripts/hardware_eth_reboot
 {{end}}
 
 {{ if or (eq $workflow "large") (eq $workflow "gcp") }}


### PR DESCRIPTION
sync eden tests (empty volumes, VLAN test) and use docker image of Eden instead of building

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>