### PR TITLE
always delete on domain inactivate

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -46,6 +46,9 @@ const (
 	runDirname = "/run/" + agentName
 	xenDirname = runDirname + "/xen"       // We store xen cfg files here
 	ciDirname  = runDirname + "/cloudinit" // For cloud-init images
+	//dir with runtime files of containerd for eve user apps
+	ctrdAppsRunDir = "/persist/containerd/io.containerd.runtime.v1.linux/eve-user-apps"
+
 	// Time limits for event loop handlers
 	errorTime           = 3 * time.Minute
 	warningTime         = 40 * time.Second
@@ -167,6 +170,9 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		if err := os.RemoveAll(ciDirname); err != nil {
 			log.Fatal(err)
 		}
+	}
+	if err := os.RemoveAll(ctrdAppsRunDir); err != nil {
+		log.Errorf("Failed cleanup %s: %v", ctrdAppsRunDir, err)
 	}
 	if _, err := os.Stat(xenDirname); err != nil {
 		if err := os.MkdirAll(xenDirname, 0700); err != nil {
@@ -836,6 +842,9 @@ func verifyStatus(ctx *domainContext, status *types.DomainStatus) {
 				if err := hyper.Task(status).Delete(status.DomainName); err != nil {
 					log.Errorf("failed to delete domain: %s (%v)", status.DomainName, err)
 				}
+				if err := hyper.Task(status).Cleanup(status.DomainName); err != nil {
+					log.Errorf("failed to cleanup domain: %s (%v)", status.DomainName, err)
+				}
 				status.State = types.BROKEN
 			}
 		}
@@ -1281,9 +1290,13 @@ func doActivateTail(ctx *domainContext, status *types.DomainStatus,
 		log.Errorf("domain start for %s: %s", status.DomainName, err)
 		status.SetErrorNow(err.Error())
 
-		// Cleanup
+		// Delete
 		if err := hyper.Task(status).Delete(status.DomainName); err != nil {
 			log.Errorf("failed to delete domain: %s (%v)", status.DomainName, err)
+		}
+		// Cleanup
+		if err := hyper.Task(status).Cleanup(status.DomainName); err != nil {
+			log.Errorf("failed to cleanup domain: %s (%v)", status.DomainName, err)
 		}
 
 		// Set BootFailed to cause retry
@@ -1306,9 +1319,13 @@ func doActivateTail(ctx *domainContext, status *types.DomainStatus,
 		status.SetErrorNow(err.Error())
 		log.Errorf("doActivateTail(%v) failed for %s: %s",
 			status.UUIDandVersion, status.DisplayName, err)
-		// Cleanup
+		// Delete
 		if err := hyper.Task(status).Delete(status.DomainName); err != nil {
 			log.Errorf("failed to delete domain: %s (%v)", status.DomainName, err)
+		}
+		// Cleanup
+		if err := hyper.Task(status).Cleanup(status.DomainName); err != nil {
+			log.Errorf("failed to cleanup domain: %s (%v)", status.DomainName, err)
 		}
 		return
 	}
@@ -1520,6 +1537,11 @@ func doInactivate(ctx *domainContext, status *types.DomainStatus, impatient bool
 		if gone {
 			status.DomainId = 0
 		}
+	}
+
+	// Cleanup
+	if err := hyper.Task(status).Cleanup(status.DomainName); err != nil {
+		log.Errorf("failed to cleanup domain: %s (%v)", status.DomainName, err)
 	}
 
 	// If everything failed we leave it marked as Activated

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -816,7 +816,7 @@ func verifyStatus(ctx *domainContext, status *types.DomainStatus) {
 		configActivate = true
 	}
 
-	domainID, domainStatus, err := hyper.Task(status).Info(status.DomainName, status.DomainId)
+	domainID, domainStatus, err := hyper.Task(status).Info(status.DomainName)
 	if err != nil || domainStatus == types.HALTED {
 		if status.Activated && configActivate {
 			errStr := fmt.Sprintf("verifyStatus(%s) failed %s",
@@ -833,7 +833,7 @@ func verifyStatus(ctx *domainContext, status *types.DomainStatus) {
 				err := fmt.Errorf("one of the %s tasks has crashed (%v)", status.Key(), err)
 				log.Errorf(err.Error())
 				status.SetErrorNow("one of the application's tasks has crashed - please restart application instance")
-				if err := hyper.Task(status).Delete(status.DomainName, status.DomainId); err != nil {
+				if err := hyper.Task(status).Delete(status.DomainName); err != nil {
 					log.Errorf("failed to delete domain: %s (%v)", status.DomainName, err)
 				}
 				status.State = types.BROKEN
@@ -1276,13 +1276,13 @@ func doActivateTail(ctx *domainContext, status *types.DomainStatus,
 	status.State = types.BOOTING
 	publishDomainStatus(ctx, status)
 
-	err := hyper.Task(status).Start(status.DomainName, domainID)
+	err := hyper.Task(status).Start(status.DomainName)
 	if err != nil {
 		log.Errorf("domain start for %s: %s", status.DomainName, err)
 		status.SetErrorNow(err.Error())
 
 		// Cleanup
-		if err := hyper.Task(status).Delete(status.DomainName, status.DomainId); err != nil {
+		if err := hyper.Task(status).Delete(status.DomainName); err != nil {
 			log.Errorf("failed to delete domain: %s (%v)", status.DomainName, err)
 		}
 
@@ -1296,7 +1296,7 @@ func doActivateTail(ctx *domainContext, status *types.DomainStatus,
 	status.VifList = checkIfEmu(status.VifList)
 
 	status.State = types.RUNNING
-	domainID, state, err := hyper.Task(status).Info(status.DomainName, status.DomainId)
+	domainID, state, err := hyper.Task(status).Info(status.DomainName)
 
 	if err != nil {
 		// Immediate failure treat as above
@@ -1307,7 +1307,7 @@ func doActivateTail(ctx *domainContext, status *types.DomainStatus,
 		log.Errorf("doActivateTail(%v) failed for %s: %s",
 			status.UUIDandVersion, status.DisplayName, err)
 		// Cleanup
-		if err := hyper.Task(status).Delete(status.DomainName, status.DomainId); err != nil {
+		if err := hyper.Task(status).Delete(status.DomainName); err != nil {
 			log.Errorf("failed to delete domain: %s (%v)", status.DomainName, err)
 		}
 		return
@@ -1433,7 +1433,7 @@ func doInactivate(ctx *domainContext, status *types.DomainStatus, impatient bool
 
 	log.Functionf("doInactivate(%v) for %s domainId %d",
 		status.UUIDandVersion, status.DisplayName, status.DomainId)
-	domainID, _, err := hyper.Task(status).Info(status.DomainName, status.DomainId)
+	domainID, _, err := hyper.Task(status).Info(status.DomainName)
 	if err == nil && domainID != status.DomainId {
 		status.DomainId = domainID
 		status.BootTime = time.Now()
@@ -1507,7 +1507,7 @@ func doInactivate(ctx *domainContext, status *types.DomainStatus, impatient bool
 	}
 
 	if status.DomainId != 0 {
-		if err := hyper.Task(status).Delete(status.DomainName, status.DomainId); err != nil {
+		if err := hyper.Task(status).Delete(status.DomainName); err != nil {
 			log.Errorf("Failed to delete domain %s (%v)", status.DomainName, err)
 		} else {
 			log.Functionf("doInactivate(%v) for %s: Delete succeeded",
@@ -1916,7 +1916,7 @@ func waitForDomainGone(status types.DomainStatus, maxDelay time.Duration) bool {
 			time.Sleep(delay)
 			waited += delay
 		}
-		_, state, err := hyper.Task(&status).Info(status.DomainName, status.DomainId)
+		_, state, err := hyper.Task(&status).Info(status.DomainName)
 		if err != nil {
 			log.Errorf("waitForDomainGone(%v) for %s error %s state %s",
 				status.UUIDandVersion, status.DisplayName,
@@ -2014,7 +2014,7 @@ func DomainShutdown(status types.DomainStatus, force bool) error {
 
 	// Stop the domain
 	log.Functionf("Stopping domain - %s", status.DomainName)
-	err = hyper.Task(&status).Stop(status.DomainName, status.DomainId, force)
+	err = hyper.Task(&status).Stop(status.DomainName, force)
 
 	return err
 }

--- a/pkg/pillar/hypervisor/containerd.go
+++ b/pkg/pillar/hypervisor/containerd.go
@@ -164,6 +164,11 @@ func (ctx ctrdContext) Delete(domainName string) error {
 	return nil
 }
 
+//Cleanup is noop for containerd hypervisor
+func (ctx ctrdContext) Cleanup(_ string) error {
+	return nil
+}
+
 func (ctx ctrdContext) Annotations(domainName string) (map[string]string, error) {
 	ctrdCtx, done := ctx.ctrdClient.CtrNewUserServicesCtx()
 	defer done()

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -678,9 +678,9 @@ func waitForQmp(domainName string) error {
 	}
 }
 
-func (ctx kvmContext) Start(domainName string, domainID int) error {
+func (ctx kvmContext) Start(domainName string) error {
 	logrus.Infof("starting KVM domain %s", domainName)
-	if err := ctx.ctrdContext.Start(domainName, domainID); err != nil {
+	if err := ctx.ctrdContext.Start(domainName); err != nil {
 		logrus.Errorf("couldn't start task for domain %s: %v", domainName, err)
 		return err
 	}
@@ -697,7 +697,7 @@ func (ctx kvmContext) Start(domainName string, domainID int) error {
 	logrus.Infof("Creating %s at %s", "qmpEventHandler", agentlog.GetMyStack())
 	go qmpEventHandler(getQmpListenerSocket(domainName), getQmpExecutorSocket(domainName))
 
-	annotations, err := ctx.ctrdContext.Annotations(domainName, domainID)
+	annotations, err := ctx.ctrdContext.Annotations(domainName)
 	if err != nil {
 		logrus.Warnf("Error in get annotations for domain %s: %v", domainName, err)
 		return err
@@ -719,17 +719,17 @@ func (ctx kvmContext) Start(domainName string, domainID int) error {
 	return nil
 }
 
-func (ctx kvmContext) Stop(domainName string, domainID int, force bool) error {
+func (ctx kvmContext) Stop(domainName string, force bool) error {
 	if err := execShutdown(getQmpExecutorSocket(domainName)); err != nil {
 		return logError("Stop: failed to execute shutdown command %v", err)
 	}
 	return nil
 }
 
-func (ctx kvmContext) Delete(domainName string, domainID int) (result error) {
+func (ctx kvmContext) Delete(domainName string) (result error) {
 	// regardless of happens to everything else, we have to try and delete the task
 	defer func() {
-		if err := ctx.ctrdContext.Delete(domainName, domainID); err != nil {
+		if err := ctx.ctrdContext.Delete(domainName); err != nil {
 			result = fmt.Errorf("%w; couldn't delete task %s: %v", result, domainName, err)
 		}
 	}()
@@ -747,9 +747,9 @@ func (ctx kvmContext) Delete(domainName string, domainID int) (result error) {
 	return nil
 }
 
-func (ctx kvmContext) Info(domainName string, domainID int) (int, types.SwState, error) {
+func (ctx kvmContext) Info(domainName string) (int, types.SwState, error) {
 	// first we ask for the task status
-	effectiveDomainID, effectiveDomainState, err := ctx.ctrdContext.Info(domainName, domainID)
+	effectiveDomainID, effectiveDomainState, err := ctx.ctrdContext.Info(domainName)
 	if err != nil || effectiveDomainState != types.RUNNING {
 		return effectiveDomainID, effectiveDomainState, err
 	}

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -727,13 +727,6 @@ func (ctx kvmContext) Stop(domainName string, force bool) error {
 }
 
 func (ctx kvmContext) Delete(domainName string) (result error) {
-	// regardless of happens to everything else, we have to try and delete the task
-	defer func() {
-		if err := ctx.ctrdContext.Delete(domainName); err != nil {
-			result = fmt.Errorf("%w; couldn't delete task %s: %v", result, domainName, err)
-		}
-	}()
-
 	//Sending a stop signal to then domain before quitting. This is done to freeze the domain before quitting it.
 	execStop(getQmpExecutorSocket(domainName))
 	if err := execQuit(getQmpExecutorSocket(domainName)); err != nil {
@@ -781,6 +774,14 @@ func (ctx kvmContext) Info(domainName string) (int, types.SwState, error) {
 	} else {
 		return effectiveDomainID, effectiveDomainState, nil
 	}
+}
+
+func (ctx kvmContext) Cleanup(domainName string) error {
+	if err := ctx.ctrdContext.Delete(domainName); err != nil {
+		return fmt.Errorf("couldn't cleanup task %s: %v", domainName, err)
+	}
+
+	return nil
 }
 
 func (ctx kvmContext) PCIReserve(long string) error {

--- a/pkg/pillar/hypervisor/kvm_test.go
+++ b/pkg/pillar/hypervisor/kvm_test.go
@@ -2239,6 +2239,10 @@ func TestCreateDom(t *testing.T) {
 		t.Errorf("Delete domain failed %v", err)
 	}
 
+	if err := kvmIntel.Task(testDom).Cleanup("test"); err != nil {
+		t.Errorf("Cleanup domain failed %v", err)
+	}
+
 	state, err = os.Open(kvmStateDir)
 	if err != nil {
 		t.Errorf("can't open stat dir for test domain %v", err)

--- a/pkg/pillar/hypervisor/kvm_test.go
+++ b/pkg/pillar/hypervisor/kvm_test.go
@@ -2227,15 +2227,15 @@ func TestCreateDom(t *testing.T) {
 		}
 	}
 
-	if err := kvmIntel.Task(testDom).Start("test", 0); err != nil {
+	if err := kvmIntel.Task(testDom).Start("test"); err != nil {
 		t.Errorf("Start domain failed %v", err)
 	}
 
-	if err := kvmIntel.Task(testDom).Stop("test", 0, true); err != nil {
+	if err := kvmIntel.Task(testDom).Stop("test", true); err != nil {
 		t.Errorf("Stop domain failed %v", err)
 	}
 
-	if err := kvmIntel.Task(testDom).Delete("test", 0); err != nil {
+	if err := kvmIntel.Task(testDom).Delete("test"); err != nil {
 		t.Errorf("Delete domain failed %v", err)
 	}
 

--- a/pkg/pillar/hypervisor/null.go
+++ b/pkg/pillar/hypervisor/null.go
@@ -112,6 +112,11 @@ func (ctx nullContext) Delete(domainName string) error {
 	return nil
 }
 
+//Cleanup is noop for null hypervisor
+func (ctx nullContext) Cleanup(_ string) error {
+	return nil
+}
+
 func (ctx nullContext) Info(domainName string) (int, types.SwState, error) {
 	if dom, found := ctx.doms[domainName]; found {
 		logrus.Infof("Null Domain %s is %v and has the following config %s\n", domainName, dom.state, dom.config)

--- a/pkg/pillar/hypervisor/null.go
+++ b/pkg/pillar/hypervisor/null.go
@@ -87,7 +87,7 @@ func (ctx nullContext) Create(domainName string, cfgFilename string, config *typ
 	return ctx.domCounter, nil
 }
 
-func (ctx nullContext) Start(domainName string, domainID int) error {
+func (ctx nullContext) Start(domainName string) error {
 	if dom, found := ctx.doms[domainName]; found && dom.state == types.HALTED {
 		dom.state = types.RUNNING
 		return nil
@@ -96,7 +96,7 @@ func (ctx nullContext) Start(domainName string, domainID int) error {
 	}
 }
 
-func (ctx nullContext) Stop(domainName string, domainID int, force bool) error {
+func (ctx nullContext) Stop(domainName string, force bool) error {
 	if dom, found := ctx.doms[domainName]; found && dom.state == types.RUNNING {
 		dom.state = types.HALTED
 		return nil
@@ -105,14 +105,14 @@ func (ctx nullContext) Stop(domainName string, domainID int, force bool) error {
 	}
 }
 
-func (ctx nullContext) Delete(domainName string, domainID int) error {
+func (ctx nullContext) Delete(domainName string) error {
 	// calls to Delete are serialized in the consumer: no need to worry about locking
 	os.RemoveAll(ctx.tempDir + "/" + domainName)
 	delete(ctx.doms, domainName)
 	return nil
 }
 
-func (ctx nullContext) Info(domainName string, domainID int) (int, types.SwState, error) {
+func (ctx nullContext) Info(domainName string) (int, types.SwState, error) {
 	if dom, found := ctx.doms[domainName]; found {
 		logrus.Infof("Null Domain %s is %v and has the following config %s\n", domainName, dom.state, dom.config)
 		return dom.id, dom.state, nil

--- a/pkg/pillar/hypervisor/null_test.go
+++ b/pkg/pillar/hypervisor/null_test.go
@@ -76,7 +76,7 @@ serial = ['pty']
 		conf.Close()
 	}
 
-	domID, err := hyper.Task(testDom).Create("test.1", conf.Name(), &types.DomainConfig{})
+	_, err = hyper.Task(testDom).Create("test.1", conf.Name(), &types.DomainConfig{})
 	if err != nil {
 		t.Errorf("Create domain test failed %v", err)
 	}
@@ -86,35 +86,35 @@ serial = ['pty']
 		t.Errorf("Create domain didn't deposit a file %s %v", ctx.tempDir, err)
 	}
 
-	if err := hyper.Task(testDom).Stop("test.1", domID, true); err == nil {
+	if err := hyper.Task(testDom).Stop("test.1", true); err == nil {
 		t.Errorf("Stop domain should've failed for a domain that is not running")
 	}
 
-	if err := hyper.Task(testDom).Start("test.1", domID); err != nil {
+	if err := hyper.Task(testDom).Start("test.1"); err != nil {
 		t.Errorf("Couldn't start a domain %v", err)
 	}
 
-	if err := hyper.Task(testDom).Start("test.1", domID); err == nil {
+	if err := hyper.Task(testDom).Start("test.1"); err == nil {
 		t.Errorf("Start domain should've failed for a domain that is already running")
 	}
 
-	if err := hyper.Task(testDom).Stop("test.1", domID, false); err != nil {
+	if err := hyper.Task(testDom).Stop("test.1", false); err != nil {
 		t.Errorf("Couldn't stop a domain %v", err)
 	}
 
-	if _, _, err := hyper.Task(testDom).Info("", 0); err == nil {
+	if _, _, err := hyper.Task(testDom).Info(""); err == nil {
 		t.Errorf("Info domain should've failed for a domain that is empty")
 	}
 
-	if _, _, err := hyper.Task(testDom).Info("foo-bar-baz", 0); err == nil {
+	if _, _, err := hyper.Task(testDom).Info("foo-bar-baz"); err == nil {
 		t.Errorf("Info domain should've failed for a domain that is non-existent")
 	}
 
-	if _, _, err := hyper.Task(testDom).Info("test.1", domID); err != nil {
+	if _, _, err := hyper.Task(testDom).Info("test.1"); err != nil {
 		t.Errorf("Info domain failed %v", err)
 	}
 
-	if err := hyper.Task(testDom).Delete("test.1", domID); err != nil {
+	if err := hyper.Task(testDom).Delete("test.1"); err != nil {
 		t.Errorf("Delete domain failed %v", err)
 	}
 }

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -511,6 +511,14 @@ func (ctx xenContext) Delete(domainName string) (result error) {
 	return nil
 }
 
+//Cleanup removes containerd-shim
+func (ctx xenContext) Cleanup(domainName string) error {
+	if err := ctx.ctrdContext.Delete(domainName); err != nil {
+		return fmt.Errorf("couldn't cleanup task %s: %v", domainName, err)
+	}
+	return nil
+}
+
 func (ctx xenContext) Info(domainName string) (int, types.SwState, error) {
 	// first we ask for the task status
 	effectiveDomainID, effectiveDomainState, err := ctx.ctrdContext.Info(domainName)

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -234,6 +234,7 @@ type Task interface {
 	Stop(string, bool) error
 	Delete(string) error
 	Info(string) (int, SwState, error)
+	Cleanup(string) error
 }
 
 type DomainStatus struct {

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -230,10 +230,10 @@ const (
 type Task interface {
 	Setup(DomainStatus, DomainConfig, *AssignableAdapters, *os.File) error
 	Create(string, string, *DomainConfig) (int, error)
-	Start(string, int) error
-	Stop(string, int, bool) error
-	Delete(string, int) error
-	Info(string, int) (int, SwState, error)
+	Start(string) error
+	Stop(string, bool) error
+	Delete(string) error
+	Info(string) (int, SwState, error)
 }
 
 type DomainStatus struct {


### PR DESCRIPTION
In quite strange use case I can see eve-user-apps do not gone after halting/removing domain (I wait for domain to be running, send stop, kill qemu-system process(which may be killed from in side I think), wait fo halted state, but still see conatinerd-shim in process list). So, seems reasonable to delete it anyway.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>