### PR TITLE
add Red Hat.KVM to not dd in ledmanager

### DIFF
--- a/pkg/pillar/cmd/ledmanager/ledmanager.go
+++ b/pkg/pillar/cmd/ledmanager/ledmanager.go
@@ -160,6 +160,11 @@ var mToF = []modelToFuncs{
 		isDisplay: true,
 	},
 	{
+		model:  "Red Hat.KVM",
+		regexp: true,
+		// No disk light blinking on Red Hat.KVM qemu
+	},
+	{
 		model:  "Parallels.*",
 		regexp: true,
 		// No disk light blinking on Parallels


### PR DESCRIPTION
On CentOS I can see different vendor/model inside Qemu VM. Seems reasonable to add them to ledmanager to not blink.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>