### PR TITLE
adjust oom_score of containerd-shim of watchdog

### DIFF
--- a/pkg/watchdog/Dockerfile
+++ b/pkg/watchdog/Dockerfile
@@ -1,8 +1,8 @@
 # Build watchdogd for alpine
 
 FROM lfedge/eve-alpine:6.7.0 AS watchdog-build
-ENV BUILD_PKGS build-base file libtirpc-dev linux-headers tar
-ENV PKGS alpine-baselayout musl-utils
+ENV BUILD_PKGS build-base file libtirpc-dev linux-headers tar util-linux
+ENV PKGS alpine-baselayout musl-utils libsmartcols
 RUN eve-alpine-deploy.sh
 
 # Version 5.15
@@ -38,6 +38,7 @@ RUN \
 FROM scratch
 WORKDIR /
 COPY --from=watchdog-build /out/ /
+COPY --from=watchdog-build /bin/wdctl /bin/wdctl
 COPY init.sh /
 COPY watchdog.conf.seed /etc/
 COPY watchdog-report.sh /sbin/


### PR DESCRIPTION
In case of no hardware watchdog we are forced to use software one as a process with containerd.
We set oom_score_adj for workload (init.sh and child processes), but seems we do not set oom_score_adj for containerd-shim. 
```
7601d48f-084f-46e8-b7c2-8220b2c7cd6e:~# ps aux|grep watchdog
 1400 root      0:00 /usr/bin/containerd-shim-runc-v2 -namespace services.linuxkit -id watchdog -address /run/containerd/containerd.sock
 2071 root      0:00 /usr/sbin/watchdog -F
7601d48f-084f-46e8-b7c2-8220b2c7cd6e:~# cat /proc/2881/oom_score_adj 
-1000
7601d48f-084f-46e8-b7c2-8220b2c7cd6e:~# cat /proc/1400/oom_score_adj 
1
```
In this case with OOM in containerd cgroup we will hit `cleaning up dead shim` and software watchdog will be killed.

In this PR I set `oom_score_adj` for parent of `init.sh` of watchdog (it is containerd-shim) to be equal or lower than init.sh`s one to reduce probability of killing containerd-shim of watchdog.

The second commit is about adding of missed wdctl into watchdog

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>