### PR TITLE
Fix the case where EVE allocates same IP address to two different app…

### DIFF
--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -2471,9 +2471,6 @@ func (status *NetworkInstanceStatus) IsIpAssigned(ip net.IP) bool {
 		if ip.Equal(assignments.IPv4Addr) {
 			return true
 		}
-		if len(assignments.IPv6Addrs) == 0 {
-			return false
-		}
 		for _, nip := range assignments.IPv6Addrs {
 			if ip.Equal(nip) {
 				return true


### PR DESCRIPTION
… vifs connected to the same network instance

Signed-off-by: Gopi krishna Kodali <gkodali@zededa.com>