### PR TITLE
Indicate issues with controller certificate

### DIFF
--- a/docs/LED-INDICATION.md
+++ b/docs/LED-INDICATION.md
@@ -1,0 +1,24 @@
+# LED Indication
+
+As EVE-OS boots and progresses through various intermediate states, the LED (by default the disk LED) blinking
+pattern changes to indicate state transitions.
+To indicate a given state, LED blinks one or more times quickly in a row, then pauses for 1200ms and repeats continuously.
+By counting the number of successive blinks one may determine the current state of the edge device.
+
+The following table summarizes all states that LED is able to indicate. Please note that blink counts of less than 10
+are used for initial device states from booting up to the onboarding. Everything above is used for run-time errors
+that deserve user attention.
+
+| Blink count | State Description |
+| --- | --- |
+| 0   | State is unknown. Device is most likely still in early booting stages. |
+| 1   | Device is waiting for DHCP IP address(es) on management interface(s). |
+| 2   | Device is attempting to connect to the Controller. |
+| 3   | Device has connected to the Controller but it is not yet onboarded. |
+| 4   | Device is connected to the Controller and onboarded.  |
+| 5-9 | *unused* |
+| 10  | Device onboarding is failing. |
+| 11  | *unused* |
+| 12  | Controller replied without TLS connection state. |
+| 13  | Controller replied without OCSP response. |
+| 14  | Failed to fetch or verify Controller certificate. |

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -50,8 +50,8 @@ type diagContext struct {
 	DevicePortConfigList    *types.DevicePortConfigList
 	forever                 bool // Keep on reporting until ^C
 	pacContents             bool // Print PAC file contents
-	ledCounter              int
-	derivedLedCounter       int // Based on ledCounter + usableAddressCount
+	ledCounter              types.LedBlinkCount
+	derivedLedCounter       types.LedBlinkCount // Based on ledCounter + usableAddressCount
 	subGlobalConfig         pubsub.Subscription
 	globalConfig            *types.ConfigItemValueMap
 	GCInitialized           bool // Received initial GlobalConfig
@@ -528,25 +528,12 @@ func printOutput(ctx *diagContext) {
 	}
 
 	switch ctx.derivedLedCounter {
-	case 0:
-		fmt.Fprintf(outfile, "ERROR: Summary: Unknown LED counter 0\n")
-	case 1:
-		fmt.Fprintf(outfile, "ERROR: Summary: Waiting for DHCP IP address(es)\n")
-	case 2:
-		fmt.Fprintf(outfile, "ERROR: Summary: Trying to connect to EV Controller\n")
-	case 3:
-		fmt.Fprintf(outfile, "WARNING: Summary: Connected to EV Controller but not onboarded\n")
-	case 4:
-		fmt.Fprintf(outfile, "INFO: Summary: Connected to EV Controller and onboarded\n")
-	case 10:
-		fmt.Fprintf(outfile, "ERROR: Summary: Onboarding failure or conflict\n")
-	case 12:
-		fmt.Fprintf(outfile, "ERROR: Summary: Response without TLS - ignored\n")
-	case 13:
-		fmt.Fprintf(outfile, "ERROR: Summary: Response without OSCP or bad OSCP - ignored\n")
+	case types.LedBlinkOnboarded:
+		fmt.Fprintf(outfile, "INFO: Summary: %s\n", ctx.derivedLedCounter)
+	case types.LedBlinkConnectedToController:
+		fmt.Fprintf(outfile, "WARNING: Summary: %s\n", ctx.derivedLedCounter)
 	default:
-		fmt.Fprintf(outfile, "ERROR: Summary: Unsupported LED counter %d\n",
-			ctx.derivedLedCounter)
+		fmt.Fprintf(outfile, "ERROR: Summary: %s\n", ctx.derivedLedCounter)
 	}
 
 	testing := ctx.DeviceNetworkStatus.Testing

--- a/pkg/pillar/types/ledmanagertypes.go
+++ b/pkg/pillar/types/ledmanagertypes.go
@@ -3,17 +3,72 @@
 
 package types
 
+import "fmt"
+
+// LedBlinkCount is enum type summarizing all LED blinking patterns.
+type LedBlinkCount uint8
+
+const (
+	// LedBlinkUndefined - undefined/unknown LED blinking pattern.
+	LedBlinkUndefined LedBlinkCount = iota
+	// LedBlinkWaitingForIP - LED indication of device waiting to obtain management IP address.
+	LedBlinkWaitingForIP
+	// LedBlinkConnectingToController - LED indication of device trying to connect to the controller.
+	LedBlinkConnectingToController
+	// LedBlinkConnectedToController - LED indication of device being connected to the controller but not yet onboarded.
+	LedBlinkConnectedToController
+	// LedBlinkOnboarded - LED indication of device being connected to the controller and onboarded.
+	LedBlinkOnboarded
+)
+const (
+	// LedBlinkOnboardingFailure - LED indication of device failing to onboard.
+	LedBlinkOnboardingFailure LedBlinkCount = iota + 10
+	_                                       // 11 is unused
+	// LedBlinkRespWithoutTLS - LED indication or device receiving response from controller without TLS connection state.
+	LedBlinkRespWithoutTLS
+	// LedBlinkRespWithoutOSCP - LED indication or device receiving response from controller without OSCP.
+	LedBlinkRespWithoutOSCP
+	// LedBlinkInvalidControllerCert - LED indication or device failing to validate or fetch the controller certificate.
+	LedBlinkInvalidControllerCert
+)
+
+// String returns human-readable description of the state indicated by the particular LED blinking count.
+func (c LedBlinkCount) String() string {
+	switch c {
+	case LedBlinkUndefined:
+		return "Undefined LED counter"
+	case LedBlinkWaitingForIP:
+		return "Waiting for DHCP IP address(es)"
+	case LedBlinkConnectingToController:
+		return "Trying to connect to EV Controller"
+	case LedBlinkConnectedToController:
+		return "Connected to EV Controller but not onboarded"
+	case LedBlinkOnboarded:
+		return "Connected to EV Controller and onboarded"
+	case LedBlinkOnboardingFailure:
+		return "Onboarding failure or conflict"
+	case LedBlinkRespWithoutTLS:
+		return "Response without TLS - ignored"
+	case LedBlinkRespWithoutOSCP:
+		return "Response without OSCP or bad OSCP - ignored"
+	case LedBlinkInvalidControllerCert:
+		return "Failed to fetch or verify EV Controller certificate"
+	default:
+		return fmt.Sprintf("Unsupported LED counter (%d)", c)
+	}
+}
+
 type LedBlinkCounter struct {
-	BlinkCounter int
+	BlinkCounter LedBlinkCount
 }
 
 // Merge the 1/2 values based on having usable addresses or not, with
 // the value we get based on access to zedcloud or errors.
-func DeriveLedCounter(ledCounter, usableAddressCount int) int {
+func DeriveLedCounter(ledCounter LedBlinkCount, usableAddressCount int) LedBlinkCount {
 	if usableAddressCount == 0 {
-		return 1
-	} else if ledCounter < 2 {
-		return 2
+		return LedBlinkWaitingForIP
+	} else if ledCounter < LedBlinkConnectingToController {
+		return LedBlinkConnectingToController
 	} else {
 		return ledCounter
 	}

--- a/pkg/pillar/types/ledmanagertypes_test.go
+++ b/pkg/pillar/types/ledmanagertypes_test.go
@@ -8,35 +8,35 @@ import (
 func TestDeriveLedCounter(t *testing.T) {
 
 	testMatrix := map[string]struct {
-		ledCounter         int
+		ledBlinkCount      LedBlinkCount
 		usableAddressCount int
-		expectedValue      int
+		expectedValue      LedBlinkCount
 	}{
 		"usableAddressCount is 0": {
-			ledCounter:         0,
+			ledBlinkCount:      LedBlinkUndefined,
 			usableAddressCount: 0,
-			expectedValue:      1,
+			expectedValue:      LedBlinkWaitingForIP,
 		},
-		"ledCounter less than 2": {
-			ledCounter:         0,
+		"ledBlinkCount less than 2 (without IP)": {
+			ledBlinkCount:      LedBlinkUndefined,
 			usableAddressCount: 1,
-			expectedValue:      2,
+			expectedValue:      LedBlinkConnectingToController,
 		},
-		"ledCounter equals 2": {
-			ledCounter:         2,
+		"ledBlinkCount is 2 (has IP)": {
+			ledBlinkCount:      LedBlinkConnectingToController,
 			usableAddressCount: 1,
-			expectedValue:      2,
+			expectedValue:      LedBlinkConnectingToController,
 		},
-		"ledCounter greater than 2": {
-			ledCounter:         3,
+		"ledBlinkCount is greater than 2 (connected)": {
+			ledBlinkCount:      LedBlinkConnectedToController,
 			usableAddressCount: 1,
-			expectedValue:      3,
+			expectedValue:      LedBlinkConnectedToController,
 		},
 	}
 
 	for testname, test := range testMatrix {
 		t.Logf("Running test case %s", testname)
-		output := DeriveLedCounter(test.ledCounter, test.usableAddressCount)
+		output := DeriveLedCounter(test.ledBlinkCount, test.usableAddressCount)
 		assert.Equal(t, test.expectedValue, output)
 	}
 }

--- a/pkg/pillar/utils/ledmanagerutils.go
+++ b/pkg/pillar/utils/ledmanagerutils.go
@@ -14,7 +14,7 @@ const (
 )
 
 // UpdateLedManagerConfig is used by callers to change the behavior or the LED
-func UpdateLedManagerConfig(log *base.LogObject, count int) {
+func UpdateLedManagerConfig(log *base.LogObject, count types.LedBlinkCount) {
 	blinkCount := types.LedBlinkCounter{
 		BlinkCounter: count,
 	}

--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -514,7 +514,7 @@ func SendOnIntf(ctx *ZedCloudContext, destURL string, intf string, reqlen int64,
 				errorList = append(errorList, err)
 				// Inform ledmanager about broken cloud connectivity
 				if !ctx.NoLedManager {
-					utils.UpdateLedManagerConfig(log, 12)
+					utils.UpdateLedManagerConfig(log, types.LedBlinkRespWithoutTLS)
 				}
 				if ctx.FailureFunc != nil {
 					ctx.FailureFunc(log, intf, reqUrl, reqlen,
@@ -540,7 +540,7 @@ func SendOnIntf(ctx *ZedCloudContext, destURL string, intf string, reqlen int64,
 					log.Errorln(errStr)
 					// Inform ledmanager about broken cloud connectivity
 					if !ctx.NoLedManager {
-						utils.UpdateLedManagerConfig(log, 13)
+						utils.UpdateLedManagerConfig(log, types.LedBlinkRespWithoutOSCP)
 					}
 					if ctx.FailureFunc != nil {
 						ctx.FailureFunc(log, intf, reqUrl,


### PR DESCRIPTION
It might be helpful to indicate when the controller certificate is invalid (e.g. has expired) or cannot be fetched by the device for whatever reason.

This commit also summarizes all blinking patterns under an enum type and adds documention.

Signed-off-by: Milan Lenco <milan@zededa.com>