### PR TITLE
remove filter of PR tests, stabilize version of Eden for tests

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [master]
   pull_request_review:
-    branches: [master]
     types: [submitted]
 
 jobs:
@@ -24,15 +23,20 @@ jobs:
         run: |
           sudo add-apt-repository ppa:canonical-server/server-backports
           sudo apt install -y qemu-utils qemu-system-x86 jq
-      - name: prepare eden
-        run: |
-          docker run -v $PWD:/out lfedge/eden:30c8b3f cp -a /eden/. /out/
-          sudo chown -R $(whoami) .
-          ./eden config add default
       - name: get eve
         uses: actions/checkout@v2
         with:
           path: 'eve'
+      - name: prepare eden
+        run: |
+          if [ -f ${{ github.workspace }}/eve/tests/eden/eden-version ]; then
+            EDEN_VERSION=$(cat ${{ github.workspace }}/eve/tests/eden/eden-version)
+          else
+            EDEN_VERSION=lfedge/eden:30c8b3f
+          fi
+          docker run -v $PWD:/out $EDEN_VERSION cp -a /eden/. /out/
+          sudo chown -R $(whoami) .
+          ./eden config add default
       - name: fetch or build eve
         env:
           TAG: pr${{ github.event.pull_request.number }}

--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -50,15 +50,20 @@ jobs:
           sudo openvpn --config ./config.ovpn --daemon
           until ip -f inet addr show tun0; do sleep 5; ip a; done
           echo ::set-output name=tunnel_ip::$(ip -f inet addr show tun0 | sed -En -e 's/.*inet ([0-9.]+).*/\1/p')
-      - name: prepare eden
-        run: |
-          docker run -v $PWD:/out lfedge/eden:30c8b3f cp -a /eden/. /out/
-          sudo chown -R $(whoami) .
-          ./eden config add default
       - name: get eve
         uses: actions/checkout@v2
         with:
           path: 'eve'
+      - name: prepare eden
+        run: |
+          if [ -f ${{ github.workspace }}/eve/tests/eden/eden-version ]; then
+            EDEN_VERSION=$(cat ${{ github.workspace }}/eve/tests/eden/eden-version)
+          else
+            EDEN_VERSION=lfedge/eden:30c8b3f
+          fi
+          docker run -v $PWD:/out $EDEN_VERSION cp -a /eden/. /out/
+          sudo chown -R $(whoami) .
+          ./eden config add default
       - name: setup
         run: |
           export ipv4=`curl https://api.ipify.org/?format=json | jq ".ip" -r`

--- a/tests/eden/eden-version
+++ b/tests/eden/eden-version
@@ -1,0 +1,1 @@
+lfedge/eden:30c8b3f


### PR DESCRIPTION
Seems we want to run Eden tests not only for master.
Also I put file with expected version of Eden to run the tests into the file to survive changes in workflow in the future (to run tests with particular version of Eden).

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>