### PR TITLE
mark freed memory as freed in guacd

### DIFF
--- a/pkg/guacd/Dockerfile
+++ b/pkg/guacd/Dockerfile
@@ -5,15 +5,18 @@ RUN eve-alpine-deploy.sh
 
 ENV GUACD_VERSION=1.0.0
 
-ADD http://apache.org/dyn/closer.cgi?action=download&filename=guacamole/1.0.0/source/guacamole-server-${GUACD_VERSION}.tar.gz /${GUACD_VERSION}.tar.gz 
-ADD 0001-alpine-stacksize-fix.patch /
+ADD http://apache.org/dyn/closer.cgi?action=download&filename=guacamole/${GUACD_VERSION}/source/guacamole-server-${GUACD_VERSION}.tar.gz /${GUACD_VERSION}.tar.gz
 ADD uuid-1.6.2.tar.gz /
+COPY patches /patches
 
 RUN cd /uuid-1.6.2 ; ./configure --prefix=/usr/ && make && make install
 
 RUN tar xzvf ${GUACD_VERSION}.tar.gz ;\
-    patch -p0 < /0001-alpine-stacksize-fix.patch ;\
     cd /guacamole-server-${GUACD_VERSION} ;\
+    [ -d /patches/guacd-"${GUACD_VERSION}" ] && for patch in /patches/guacd-"${GUACD_VERSION}"/*.patch; do \
+            echo "Applying $patch"; \
+            patch -p1 < "$patch"; \
+        done;\
     ./configure --prefix=/usr/ --with-vnc --disable-guacenc --disable-dependency-tracking && \
      make && make install
 

--- a/pkg/guacd/patches/guacd-1.0.0/0001-alpine-stacksize-fix.patch
+++ b/pkg/guacd/patches/guacd-1.0.0/0001-alpine-stacksize-fix.patch
@@ -1,5 +1,5 @@
---- guacamole-server-1.0.0/src/guacd/daemon.c.orig	2019-02-05 10:14:52.000000000 +0100
-+++ guacamole-server-1.0.0/src/guacd/daemon.c	2019-02-05 10:16:07.000000000 +0100
+--- a/src/guacd/daemon.c.orig	2019-02-05 10:14:52.000000000 +0100
++++ b/src/guacd/daemon.c	2019-02-05 10:16:07.000000000 +0100
 @@ -17,6 +17,8 @@
   * under the License.
   */

--- a/pkg/guacd/patches/guacd-1.0.0/0002-GUACAMOLE-1263-Mark-freed-memory-as-freed-prior-to-c.patch
+++ b/pkg/guacd/patches/guacd-1.0.0/0002-GUACAMOLE-1263-Mark-freed-memory-as-freed-prior-to-c.patch
@@ -1,0 +1,56 @@
+From 612c5eba20af4a9993a7a27aa40a7ef7a884962e Mon Sep 17 00:00:00 2001
+From: Michael Jumper <mjumper@apache.org>
+Date: Fri, 15 Jan 2021 11:45:54 -0800
+Subject: [PATCH] GUACAMOLE-1263: Mark freed memory as freed prior to calling
+ rfbClientCleanup().
+
+Older versions of libvncclient did not free all memory within
+rfbClientCleanup(), but this has been corrected as of their 0.9.12
+release. As guacamole-server may well be built against older versions of
+libvncclient, we can't simply remove the manual free() calls, but we
+should be sure to set any memory that we free ourselves to NULL so that
+rfbClientCleanup() does not attempt to free it again.
+---
+ src/protocols/vnc/client.c | 25 ++++++++++++++++++++-----
+ 1 file changed, 20 insertions(+), 5 deletions(-)
+
+diff --git a/src/protocols/vnc/client.c b/src/protocols/vnc/client.c
+index 93371ee6..6efe0058 100644
+--- a/src/protocols/vnc/client.c
++++ b/src/protocols/vnc/client.c
+@@ -77,12 +77,27 @@ int guac_vnc_client_free_handler(guac_client* client) {
+         /* Wait for client thread to finish */
+         pthread_join(vnc_client->client_thread, NULL);
+ 
+-        /* Free memory not free'd by libvncclient's rfbClientCleanup() */
+-        if (rfb_client->frameBuffer != NULL) free(rfb_client->frameBuffer);
+-        if (rfb_client->raw_buffer != NULL) free(rfb_client->raw_buffer);
+-        if (rfb_client->rcSource != NULL) free(rfb_client->rcSource);
++        /* Free memory that may not be free'd by libvncclient's
++         * rfbClientCleanup() prior to libvncclient 0.9.12 */
++
++        if (rfb_client->frameBuffer != NULL) {
++            free(rfb_client->frameBuffer);
++            rfb_client->frameBuffer = NULL;
++        }
++
++        if (rfb_client->raw_buffer != NULL) {
++            free(rfb_client->raw_buffer);
++            rfb_client->raw_buffer = NULL;
++        }
++
++        if (rfb_client->rcSource != NULL) {
++            free(rfb_client->rcSource);
++            rfb_client->rcSource = NULL;
++        }
++
++        /* Free VNC rfbClientData linked list (may not be free'd by
++         * rfbClientCleanup(), depending on libvncclient version) */
+ 
+-        /* Free VNC rfbClientData linked list (not free'd by rfbClientCleanup()) */
+         while (rfb_client->clientData != NULL) {
+             rfbClientData* next = rfb_client->clientData->next;
+             free(rfb_client->clientData);
+-- 
+2.30.2
+


### PR DESCRIPTION
Running re-compiled with debug symbols guacd and libvnc under gdb gives me the [line](https://github.com/apache/guacamole-server/blob/b2ae2fdf003a6854ac42877ce0fce8e88ceb038a/src/protocols/vnc/client.c#L88) we have segfault. So, we have double-free with our library version. The patch for this is already exists in master, so I pulled it in.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>