### PR TITLE
Fix two cases in nodeagent where it read from /persist without size limit

### DIFF
--- a/pkg/pillar/agentlog/agentlog.go
+++ b/pkg/pillar/agentlog/agentlog.go
@@ -330,11 +330,11 @@ func RebootReason(reason string, bootReason types.BootReason, agentName string,
 	if bootReason != types.BootReasonNone {
 		filename = "/persist/" + bootReasonFile
 		brString := bootReason.String()
-		cur, _, _ := fileutils.StatAndRead(nil, filename, maxReadSize)
-		if cur != "" {
+		b, _ := fileutils.ReadWithMaxSize(nil, filename, maxReadSize)
+		if len(b) != 0 {
 			// Note: can not use log here since we are called from a log hook!
 			fmt.Printf("not replacing BootReason %s with %s\n",
-				cur, brString)
+				string(b), brString)
 		} else {
 			err = overWriteFile(filename, brString)
 			if err != nil {

--- a/pkg/pillar/cmd/domainmgr/processes.go
+++ b/pkg/pillar/cmd/domainmgr/processes.go
@@ -62,7 +62,12 @@ func gatherProcessMetricList(ctx *domainContext) ([]types.ProcessMetric, map[int
 				// We limit the total memory used for stacks for
 				// all the processes.
 				filename := fmt.Sprintf("/proc/%d/stack", pi.Pid)
-				pi.Stack, _, _ = fileutils.StatAndRead(log, filename, maxStackStringLen)
+				b, err := fileutils.ReadWithMaxSize(log, filename, maxStackStringLen)
+				if err != nil {
+					log.Error(err)
+					continue
+				}
+				pi.Stack = string(b)
 				// Apply size limit
 				if pi.Stack != "" {
 					if totalStacks+len(pi.Stack) > totalMaxStackLen {

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -1229,18 +1229,18 @@ func ingestDevicePortConfig(ctx *nimContext) {
 func ingestDevicePortConfigFile(ctx *nimContext, oldDirname string, newDirname string, name string) {
 	filename := path.Join(oldDirname, name)
 	log.Noticef("ingestDevicePortConfigFile(%s)", filename)
-	str, _, err := fileutils.StatAndRead(log, filename, maxReadSize)
+	b, err := fileutils.ReadWithMaxSize(log, filename, maxReadSize)
 	if err != nil {
 		log.Errorf("Failed to read file %s: %v", filename, err)
 		return
 	}
-	if str == "" {
+	if len(b) == 0 {
 		log.Errorf("Ignore empty file %s", filename)
 		return
 	}
 
 	var dpc types.DevicePortConfig
-	err = json.Unmarshal([]byte(str), &dpc)
+	err = json.Unmarshal(b, &dpc)
 	if err != nil {
 		log.Errorf("Could not parse json data in file %s: %s",
 			filename, err)

--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -33,6 +33,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils"
+	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 	"github.com/lf-edge/eve/pkg/pillar/zboot"
 	"github.com/sirupsen/logrus"
 )
@@ -55,6 +56,7 @@ const (
 	minRebootDelay          uint32 = 30
 	maxDomainHaltTime       uint32 = 300
 	domainHaltWaitIncrement uint32 = 5
+	maxReadSize                    = 16384 // From files in /persist
 )
 
 var (
@@ -590,7 +592,8 @@ func incrementRestartCounter() uint32 {
 	var restartCounter uint32
 
 	if _, err := os.Stat(restartCounterFile); err == nil {
-		b, err := ioutil.ReadFile(restartCounterFile)
+		b, err := fileutils.ReadWithMaxSize(log, restartCounterFile,
+			maxReadSize)
 		if err != nil {
 			log.Errorf("incrementRestartCounter: %s", err)
 		} else {
@@ -679,7 +682,8 @@ func parseSMARTData() {
 	currentSMARTfilename := "/persist/SMART_details.json"
 	previousSMARTfilename := "/persist/SMART_details_previous.json"
 	parseData := func(filePath string, SMARTDataObj *types.SmartData) {
-		data, err := ioutil.ReadFile(filePath)
+		data, err := fileutils.ReadWithMaxSize(log, filePath,
+			maxReadSize)
 		if err != nil {
 			log.Errorf("parseSMARTData: exception while opening %s. %s", filePath, err.Error())
 			return

--- a/pkg/pillar/pubsub/large.go
+++ b/pkg/pillar/pubsub/large.go
@@ -225,7 +225,7 @@ func readAddTree(log *base.LogObject, tree jsonTree) (jsonTree, error) {
 				k, err)
 			return nil, err
 		}
-		str, _, err = fileutils.StatAndRead(log, filename, maxLargeLen+1)
+		b, err := fileutils.ReadWithMaxSize(log, filename, maxLargeLen+1)
 		if err != nil {
 			// XXX we handle not exists.
 			if !os.IsNotExist(err) && err != io.EOF {
@@ -235,12 +235,12 @@ func readAddTree(log *base.LogObject, tree jsonTree) (jsonTree, error) {
 			}
 		}
 		os.Remove(filename)
-		if len(str) == 0 {
+		if len(b) == 0 {
 			continue
 		}
 		log.Tracef("tag %s read %s content: %s", k, filename, str)
 		var val jsonTree
-		err = json.Unmarshal([]byte(str), &val)
+		err = json.Unmarshal(b, &val)
 		if err != nil {
 			err := fmt.Errorf("readAddLarge: file content Unmarshal failed for %s: %v",
 				filename, err)


### PR DESCRIPTION
Split in three separate commits since it made sense to have a new function for these check and not reuse StatAndRead..