### PR TITLE
send cipher metrics separately for every agent

### DIFF
--- a/pkg/pillar/cipher/metrics.go
+++ b/pkg/pillar/cipher/metrics.go
@@ -46,49 +46,16 @@ func maybeInit(agentName string) {
 	}
 	if _, ok := metrics[agentName]; !ok {
 		metrics[agentName] = types.CipherMetrics{
+			AgentName:    agentName,
 			TypeCounters: make([]uint64, types.MaxCipherError),
 		}
 	}
 }
 
-// GetCipherMetrics returns the metrics for this agent
-func GetCipherMetrics() types.CipherMetricsMap {
-	return metrics
-}
-
-// Append concatenates potentially overlappping CipherMetricsMaps to
-// return a union/sum.
-func Append(cms types.CipherMetricsMap, cms1 types.CipherMetricsMap) types.CipherMetricsMap {
-	for agentName, cm1 := range cms1 {
-		cm, ok := cms[agentName]
-		if !ok {
-			// New agentName; take all
-			cms[agentName] = cm1
-			continue
-		}
-		if cm.LastFailure.IsZero() {
-			// Don't care if cm1 is zero
-			cm.LastFailure = cm1.LastFailure
-		} else if !cm1.LastFailure.IsZero() &&
-			cm1.LastFailure.Sub(cm.LastFailure) > 0 {
-			cm.LastFailure = cm1.LastFailure
-		}
-		if cm.LastSuccess.IsZero() {
-			// Don't care if cm1 is zero
-			cm.LastSuccess = cm1.LastSuccess
-		} else if !cm1.LastSuccess.IsZero() &&
-			cm1.LastSuccess.Sub(cm.LastSuccess) > 0 {
-			cm.LastSuccess = cm1.LastSuccess
-		}
-		cm.FailureCount += cm1.FailureCount
-		cm.SuccessCount += cm1.SuccessCount
-		if cm.TypeCounters == nil {
-			cm.TypeCounters = make([]uint64, types.MaxCipherError)
-		}
-		for i := range cm1.TypeCounters {
-			cm.TypeCounters[i] += cm1.TypeCounters[i]
-		}
-		cms[agentName] = cm
-	}
-	return cms
+// GetCipherMetrics returns the metrics for agentName
+func GetCipherMetrics(agentName string) types.CipherMetrics {
+	mutex.Lock()
+	defer mutex.Unlock()
+	maybeInit(agentName)
+	return metrics[agentName]
 }

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -269,7 +269,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	cipherMetricsPub, err := ps.NewPublication(pubsub.PublicationOptions{
 		AgentName: agentName,
-		TopicType: types.CipherMetricsMap{},
+		TopicType: types.CipherMetrics{},
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -586,7 +586,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 		case <-publishTimer.C:
 			start := time.Now()
-			err = cipherMetricsPub.Publish("global", cipher.GetCipherMetrics())
+			err = cipherMetricsPub.Publish(agentName, cipher.GetCipherMetrics(agentName))
 			if err != nil {
 				log.Errorln(err)
 			}

--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -84,7 +84,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	cipherMetricsPub, err := ps.NewPublication(pubsub.PublicationOptions{
 		AgentName: agentName,
-		TopicType: types.CipherMetricsMap{},
+		TopicType: types.CipherMetrics{},
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -187,7 +187,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 			if err != nil {
 				log.Errorln(err)
 			}
-			err = cipherMetricsPub.Publish("global", cipher.GetCipherMetrics())
+			err = cipherMetricsPub.Publish(agentName, cipher.GetCipherMetrics(agentName))
 			if err != nil {
 				log.Errorln(err)
 			}

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -207,7 +207,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	cipherMetricsPub, err := ps.NewPublication(pubsub.PublicationOptions{
 		AgentName: agentName,
-		TopicType: types.CipherMetricsMap{},
+		TopicType: types.CipherMetrics{},
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -775,7 +775,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 		case <-publishTimer.C:
 			start := time.Now()
-			err = cipherMetricsPub.Publish("global", cipher.GetCipherMetrics())
+			err = cipherMetricsPub.Publish(agentName, cipher.GetCipherMetrics(agentName))
 			if err != nil {
 				log.Errorln(err)
 			}

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -70,10 +70,10 @@ var loguploaderMetrics types.MetricsMap
 var newlogMetrics types.NewlogMetrics
 var downloaderMetrics types.MetricsMap
 var networkMetrics types.NetworkMetrics
-var cipherMetricsDL types.CipherMetricsMap
-var cipherMetricsDM types.CipherMetricsMap
-var cipherMetricsNim types.CipherMetricsMap
-var cipherMetricsZR types.CipherMetricsMap
+var cipherMetricsDL types.CipherMetrics
+var cipherMetricsDM types.CipherMetrics
+var cipherMetricsNim types.CipherMetrics
+var cipherMetricsZR types.CipherMetrics
 
 // Context for handleDNSModify
 type DNSContext struct {
@@ -1089,7 +1089,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	subCipherMetricsDL, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:   "downloader",
 		MyAgentName: agentName,
-		TopicImpl:   types.CipherMetricsMap{},
+		TopicImpl:   types.CipherMetrics{},
 		Activate:    true,
 		Ctx:         &zedagentCtx,
 	})
@@ -1099,7 +1099,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	subCipherMetricsDM, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:   "domainmgr",
 		MyAgentName: agentName,
-		TopicImpl:   types.CipherMetricsMap{},
+		TopicImpl:   types.CipherMetrics{},
 		Activate:    true,
 		Ctx:         &zedagentCtx,
 	})
@@ -1109,7 +1109,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	subCipherMetricsNim, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:   "nim",
 		MyAgentName: agentName,
-		TopicImpl:   types.CipherMetricsMap{},
+		TopicImpl:   types.CipherMetrics{},
 		Activate:    true,
 		Ctx:         &zedagentCtx,
 	})
@@ -1119,7 +1119,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	subCipherMetricsZR, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:   "zedrouter",
 		MyAgentName: agentName,
-		TopicImpl:   types.CipherMetricsMap{},
+		TopicImpl:   types.CipherMetrics{},
 		Activate:    true,
 		Ctx:         &zedagentCtx,
 	})
@@ -1285,42 +1285,42 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 		case change := <-subCipherMetricsDL.MsgChan():
 			subCipherMetricsDL.ProcessChange(change)
-			m, err := subCipherMetricsDL.Get("global")
+			m, err := subCipherMetricsDL.Get("downloader")
 			if err != nil {
 				log.Errorf("subCipherMetricsDL.Get failed: %s",
 					err)
 			} else {
-				cipherMetricsDL = m.(types.CipherMetricsMap)
+				cipherMetricsDL = m.(types.CipherMetrics)
 			}
 
 		case change := <-subCipherMetricsDM.MsgChan():
 			subCipherMetricsDM.ProcessChange(change)
-			m, err := subCipherMetricsDM.Get("global")
+			m, err := subCipherMetricsDM.Get("domainmgr")
 			if err != nil {
 				log.Errorf("subCipherMetricsDM.Get failed: %s",
 					err)
 			} else {
-				cipherMetricsDM = m.(types.CipherMetricsMap)
+				cipherMetricsDM = m.(types.CipherMetrics)
 			}
 
 		case change := <-subCipherMetricsNim.MsgChan():
 			subCipherMetricsNim.ProcessChange(change)
-			m, err := subCipherMetricsNim.Get("global")
+			m, err := subCipherMetricsNim.Get("nim")
 			if err != nil {
 				log.Errorf("subCipherMetricsNim.Get failed: %s",
 					err)
 			} else {
-				cipherMetricsNim = m.(types.CipherMetricsMap)
+				cipherMetricsNim = m.(types.CipherMetrics)
 			}
 
 		case change := <-subCipherMetricsZR.MsgChan():
 			subCipherMetricsZR.ProcessChange(change)
-			m, err := subCipherMetricsZR.Get("global")
+			m, err := subCipherMetricsZR.Get("zedrouter")
 			if err != nil {
 				log.Errorf("subCipherMetricsZR.Get failed: %s",
 					err)
 			} else {
-				cipherMetricsZR = m.(types.CipherMetricsMap)
+				cipherMetricsZR = m.(types.CipherMetrics)
 			}
 
 		case change := <-subNetworkInstanceStatus.MsgChan():

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -309,7 +309,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	cipherMetricsPub, err := ps.NewPublication(pubsub.PublicationOptions{
 		AgentName: agentName,
-		TopicType: types.CipherMetricsMap{},
+		TopicType: types.CipherMetrics{},
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -615,7 +615,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 			// XXX can we trigger it as part of boot? Or watch file?
 			// XXX add file watch...
 			checkAndPublishDhcpLeases(&zedrouterCtx)
-			err = cipherMetricsPub.Publish("global", cipher.GetCipherMetrics())
+			err = cipherMetricsPub.Publish(agentName, cipher.GetCipherMetrics(agentName))
 			if err != nil {
 				log.Errorln(err)
 			}

--- a/pkg/pillar/types/ciphermetrics.go
+++ b/pkg/pillar/types/ciphermetrics.go
@@ -15,6 +15,7 @@ type CipherMetricsMap map[string]CipherMetrics
 
 // CipherMetrics are metrics from one agent
 type CipherMetrics struct {
+	AgentName    string
 	FailureCount uint64
 	SuccessCount uint64
 	LastFailure  time.Time
@@ -44,7 +45,7 @@ const (
 
 // Key - key for pubsub
 func (cipherMetric CipherMetrics) Key() string {
-	return "global"
+	return cipherMetric.AgentName
 }
 
 // LogCreate :


### PR DESCRIPTION
I can see exponential grow of counters in cipher metrics:
```
cipher:{agent_name:"downloader" failure_count:2692991220776944783 last_failure:{seconds:1629394310 nanos:428869571} tc:{} tc:{error_code:CIPHER_ERROR_NOT_READY} tc:{error_code:CIPHER_ERROR_DECRYPT_FAILED} tc:{error_code:CIPHER_ERROR_UNMARSHAL_FAILED} tc:{error_code:CIPHER_ERROR_CLEARTEXT_FALLBACK} tc:{error_code:CIPHER_ERROR_MISSING_FALLBACK} tc:{error_code:CIPHER_ERROR_NO_CIPHER count:10138609964923216130} tc:{error_code:CIPHER_ERROR_NO_DATA count:5392372803064314065}}
```
Seems, it comes from the usage of the same global CipherMetricsMap in cipher/metrics.go for every agent. So, we need to split our publications to use different key and CipherMetrics for every publish.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>