### PR TITLE
Uniform use of datastore certficate

### DIFF
--- a/libs/zedUpload/datastore.go
+++ b/libs/zedUpload/datastore.go
@@ -62,6 +62,7 @@ type DronaEndPoint interface {
 	WithSrcIPSelection(localAddr net.IP) error
 	WithSrcIPAndHTTPSCerts(localAddr net.IP, certs [][]byte) error
 	WithSrcIPAndProxySelection(localAddr net.IP, proxy *url.URL) error
+	WithSrcIPAndProxyAndHTTPSCerts(localAddr net.IP, proxy *url.URL, certs [][]byte) error
 	WithBindIntf(intf string) error
 	WithLogging(onoff bool) error
 }

--- a/libs/zedUpload/datastore.go
+++ b/libs/zedUpload/datastore.go
@@ -5,6 +5,8 @@ package zedUpload
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net"
 	"net/http"
@@ -96,6 +98,20 @@ func httpClientSrcIP(localAddr net.IP, proxy *url.URL) *http.Client {
 	}
 
 	return webclient
+}
+
+func httpClientAddCerts(client *http.Client, certs [][]byte) (*http.Client, error) {
+	if client == nil || len(certs) == 0 {
+		return client, nil
+	}
+	caCertPool := x509.NewCertPool()
+	for _, pem := range certs {
+		if !caCertPool.AppendCertsFromPEM(pem) {
+			return client, fmt.Errorf("Failed to append datastore certs")
+		}
+	}
+	client.Transport.(*http.Transport).TLSClientConfig = &tls.Config{RootCAs: caCertPool}
+	return client, nil
 }
 
 // given interface get the ip

--- a/libs/zedUpload/datastore_aws.go
+++ b/libs/zedUpload/datastore_aws.go
@@ -98,6 +98,17 @@ func (ep *AwsTransportMethod) WithSrcIPAndHTTPSCerts(localAddr net.IP, certs [][
 	return nil
 }
 
+// WithSrcIPAndProxyAndHTTPSCerts takes a proxy and proxy certs
+func (ep *AwsTransportMethod) WithSrcIPAndProxyAndHTTPSCerts(localAddr net.IP, proxy *url.URL, certs [][]byte) error {
+	client := httpClientSrcIP(localAddr, proxy)
+	client, err := httpClientAddCerts(client, certs)
+	if err != nil {
+		return err
+	}
+	ep.hClient = client
+	return nil
+}
+
 // bind to specific interface for this connection
 func (ep *AwsTransportMethod) WithBindIntf(intf string) error {
 	localAddr := getSrcIpFromInterface(intf)

--- a/libs/zedUpload/datastore_aws.go
+++ b/libs/zedUpload/datastore_aws.go
@@ -87,9 +87,15 @@ func (ep *AwsTransportMethod) WithSrcIPAndProxySelection(localAddr net.IP,
 	return nil
 }
 
-// WithSrcIPAndHTTPSCerts append certs for https datastore
+// WithSrcIPAndHTTPSCerts append certs for the datastore access
 func (ep *AwsTransportMethod) WithSrcIPAndHTTPSCerts(localAddr net.IP, certs [][]byte) error {
-	return fmt.Errorf("not supported")
+	client := httpClientSrcIP(localAddr, nil)
+	client, err := httpClientAddCerts(client, certs)
+	if err != nil {
+		return err
+	}
+	ep.hClient = client
+	return nil
 }
 
 // bind to specific interface for this connection

--- a/libs/zedUpload/datastore_azure.go
+++ b/libs/zedUpload/datastore_azure.go
@@ -82,9 +82,15 @@ func (ep *AzureTransportMethod) WithSrcIPAndProxySelection(localAddr net.IP,
 	return nil
 }
 
-// WithSrcIPAndHTTPSCerts append certs for https datastore
+// WithSrcIPAndHTTPSCerts append certs for the datastore access
 func (ep *AzureTransportMethod) WithSrcIPAndHTTPSCerts(localAddr net.IP, certs [][]byte) error {
-	return fmt.Errorf("not supported")
+	client := httpClientSrcIP(localAddr, nil)
+	client, err := httpClientAddCerts(client, certs)
+	if err != nil {
+		return err
+	}
+	ep.hClient = client
+	return nil
 }
 
 // bind to specific interface for this connection

--- a/libs/zedUpload/datastore_azure.go
+++ b/libs/zedUpload/datastore_azure.go
@@ -93,6 +93,17 @@ func (ep *AzureTransportMethod) WithSrcIPAndHTTPSCerts(localAddr net.IP, certs [
 	return nil
 }
 
+// WithSrcIPAndProxyAndHTTPSCerts takes a proxy and proxy certs
+func (ep *AzureTransportMethod) WithSrcIPAndProxyAndHTTPSCerts(localAddr net.IP, proxy *url.URL, certs [][]byte) error {
+	client := httpClientSrcIP(localAddr, proxy)
+	client, err := httpClientAddCerts(client, certs)
+	if err != nil {
+		return err
+	}
+	ep.hClient = client
+	return nil
+}
+
 // bind to specific interface for this connection
 func (ep *AzureTransportMethod) WithBindIntf(intf string) error {
 	return fmt.Errorf("not supported")

--- a/libs/zedUpload/datastore_http.go
+++ b/libs/zedUpload/datastore_http.go
@@ -4,8 +4,6 @@
 package zedUpload
 
 import (
-	"crypto/tls"
-	"crypto/x509"
 	"fmt"
 	"net"
 	"net/http"
@@ -81,23 +79,14 @@ func (ep *HttpTransportMethod) WithSrcIPAndProxySelection(localAddr net.IP,
 	return nil
 }
 
-// WithSrcIPAndHTTPSCerts append certs for https datastore
+// WithSrcIPAndHTTPSCerts append certs for the datastore access
 func (ep *HttpTransportMethod) WithSrcIPAndHTTPSCerts(localAddr net.IP, certs [][]byte) error {
-	ep.hClient = httpClientSrcIP(localAddr, nil)
-	err := ep.httpClientAddCerts(certs)
-	return err
-}
-
-func (ep *HttpTransportMethod) httpClientAddCerts(certs [][]byte) error {
-	if ep.hClient != nil && len(certs) > 0 {
-		caCertPool := x509.NewCertPool()
-		for _, pem := range certs {
-			if !caCertPool.AppendCertsFromPEM(pem) {
-				return fmt.Errorf("Failed to append datastore certs")
-			}
-		}
-		ep.hClient.Transport.(*http.Transport).TLSClientConfig = &tls.Config{RootCAs: caCertPool}
+	client := httpClientSrcIP(localAddr, nil)
+	client, err := httpClientAddCerts(client, certs)
+	if err != nil {
+		return err
 	}
+	ep.hClient = client
 	return nil
 }
 

--- a/libs/zedUpload/datastore_http.go
+++ b/libs/zedUpload/datastore_http.go
@@ -90,6 +90,17 @@ func (ep *HttpTransportMethod) WithSrcIPAndHTTPSCerts(localAddr net.IP, certs []
 	return nil
 }
 
+// WithSrcIPAndProxyAndHTTPSCerts takes a proxy and proxy certs
+func (ep *HttpTransportMethod) WithSrcIPAndProxyAndHTTPSCerts(localAddr net.IP, proxy *url.URL, certs [][]byte) error {
+	client := httpClientSrcIP(localAddr, proxy)
+	client, err := httpClientAddCerts(client, certs)
+	if err != nil {
+		return err
+	}
+	ep.hClient = client
+	return nil
+}
+
 // bind to specific interface for this connection
 func (ep *HttpTransportMethod) WithBindIntf(intf string) error {
 	return fmt.Errorf("not supported")

--- a/libs/zedUpload/datastore_oci.go
+++ b/libs/zedUpload/datastore_oci.go
@@ -103,6 +103,17 @@ func (ep *OCITransportMethod) WithSrcIPAndHTTPSCerts(localAddr net.IP, certs [][
 	return nil
 }
 
+// WithSrcIPAndProxyAndHTTPSCerts append certs for the datastore access
+func (ep *OCITransportMethod) WithSrcIPAndProxyAndHTTPSCerts(localAddr net.IP, proxy *url.URL, certs [][]byte) error {
+	client := httpClientSrcIP(localAddr, proxy)
+	client, err := httpClientAddCerts(client, certs)
+	if err != nil {
+		return err
+	}
+	ep.hClient = client
+	return nil
+}
+
 // WithBindIntf bind to specific interface for this connection
 func (ep *OCITransportMethod) WithBindIntf(intf string) error {
 	localAddr := getSrcIpFromInterface(intf)

--- a/libs/zedUpload/datastore_oci.go
+++ b/libs/zedUpload/datastore_oci.go
@@ -92,9 +92,15 @@ func (ep *OCITransportMethod) WithSrcIPAndProxySelection(localAddr net.IP,
 	return nil
 }
 
-// WithSrcIPAndHTTPSCerts append certs for https datastore
+// WithSrcIPAndHTTPSCerts append certs for the datastore access
 func (ep *OCITransportMethod) WithSrcIPAndHTTPSCerts(localAddr net.IP, certs [][]byte) error {
-	return fmt.Errorf("not supported")
+	client := httpClientSrcIP(localAddr, nil)
+	client, err := httpClientAddCerts(client, certs)
+	if err != nil {
+		return err
+	}
+	ep.hClient = client
+	return nil
 }
 
 // WithBindIntf bind to specific interface for this connection

--- a/libs/zedUpload/datastore_sftp.go
+++ b/libs/zedUpload/datastore_sftp.go
@@ -99,6 +99,11 @@ func (ep *SftpTransportMethod) WithSrcIPAndHTTPSCerts(localAddr net.IP, certs []
 	return fmt.Errorf("not supported")
 }
 
+// WithSrcIPAndProxyAndHTTPSCerts takes a proxy and proxy certs
+func (ep *SftpTransportMethod) WithSrcIPAndProxyAndHTTPSCerts(localAddr net.IP, proxy *url.URL, certs [][]byte) error {
+	return fmt.Errorf("not supported")
+}
+
 // bind to specific interface for this connection
 func (ep *SftpTransportMethod) WithBindIntf(intf string) error {
 	return fmt.Errorf("not supported")

--- a/libs/zedUpload/datastore_sftp.go
+++ b/libs/zedUpload/datastore_sftp.go
@@ -94,7 +94,7 @@ func (ep *SftpTransportMethod) WithSrcIPAndProxySelection(localAddr net.IP,
 	return fmt.Errorf("not supported")
 }
 
-// WithSrcIPAndHTTPSCerts append certs for https datastore
+// WithSrcIPAndHTTPSCerts append certs for the datastore access
 func (ep *SftpTransportMethod) WithSrcIPAndHTTPSCerts(localAddr net.IP, certs [][]byte) error {
 	return fmt.Errorf("not supported")
 }

--- a/pkg/pillar/cmd/downloader/download.go
+++ b/pkg/pillar/cmd/downloader/download.go
@@ -52,7 +52,12 @@ func download(ctx *downloaderContext, trType zedUpload.SyncTransportType,
 	if err == nil {
 		if proxyURL != nil {
 			log.Functionf("%s: Using proxy %s", trType, proxyURL.String())
-			err = dEndPoint.WithSrcIPAndProxySelection(ipSrc, proxyURL)
+			if len(certs) > 0 {
+				log.Functionf("%s: Set server certs", trType)
+				err = dEndPoint.WithSrcIPAndProxyAndHTTPSCerts(ipSrc, proxyURL, certs)
+			} else {
+				err = dEndPoint.WithSrcIPAndProxySelection(ipSrc, proxyURL)
+			}
 		} else {
 			if len(certs) > 0 {
 				log.Functionf("%s: Set server certs", trType)

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_aws.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_aws.go
@@ -87,9 +87,26 @@ func (ep *AwsTransportMethod) WithSrcIPAndProxySelection(localAddr net.IP,
 	return nil
 }
 
-// WithSrcIPAndHTTPSCerts append certs for https datastore
+// WithSrcIPAndHTTPSCerts append certs for the datastore access
 func (ep *AwsTransportMethod) WithSrcIPAndHTTPSCerts(localAddr net.IP, certs [][]byte) error {
-	return fmt.Errorf("not supported")
+	client := httpClientSrcIP(localAddr, nil)
+	client, err := httpClientAddCerts(client, certs)
+	if err != nil {
+		return err
+	}
+	ep.hClient = client
+	return nil
+}
+
+// WithSrcIPAndProxyAndHTTPSCerts takes a proxy and proxy certs
+func (ep *AwsTransportMethod) WithSrcIPAndProxyAndHTTPSCerts(localAddr net.IP, proxy *url.URL, certs [][]byte) error {
+	client := httpClientSrcIP(localAddr, proxy)
+	client, err := httpClientAddCerts(client, certs)
+	if err != nil {
+		return err
+	}
+	ep.hClient = client
+	return nil
 }
 
 // bind to specific interface for this connection

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_azure.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_azure.go
@@ -82,9 +82,26 @@ func (ep *AzureTransportMethod) WithSrcIPAndProxySelection(localAddr net.IP,
 	return nil
 }
 
-// WithSrcIPAndHTTPSCerts append certs for https datastore
+// WithSrcIPAndHTTPSCerts append certs for the datastore access
 func (ep *AzureTransportMethod) WithSrcIPAndHTTPSCerts(localAddr net.IP, certs [][]byte) error {
-	return fmt.Errorf("not supported")
+	client := httpClientSrcIP(localAddr, nil)
+	client, err := httpClientAddCerts(client, certs)
+	if err != nil {
+		return err
+	}
+	ep.hClient = client
+	return nil
+}
+
+// WithSrcIPAndProxyAndHTTPSCerts takes a proxy and proxy certs
+func (ep *AzureTransportMethod) WithSrcIPAndProxyAndHTTPSCerts(localAddr net.IP, proxy *url.URL, certs [][]byte) error {
+	client := httpClientSrcIP(localAddr, proxy)
+	client, err := httpClientAddCerts(client, certs)
+	if err != nil {
+		return err
+	}
+	ep.hClient = client
+	return nil
 }
 
 // bind to specific interface for this connection

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_http.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_http.go
@@ -4,8 +4,6 @@
 package zedUpload
 
 import (
-	"crypto/tls"
-	"crypto/x509"
 	"fmt"
 	"net"
 	"net/http"
@@ -81,23 +79,25 @@ func (ep *HttpTransportMethod) WithSrcIPAndProxySelection(localAddr net.IP,
 	return nil
 }
 
-// WithSrcIPAndHTTPSCerts append certs for https datastore
+// WithSrcIPAndHTTPSCerts append certs for the datastore access
 func (ep *HttpTransportMethod) WithSrcIPAndHTTPSCerts(localAddr net.IP, certs [][]byte) error {
-	ep.hClient = httpClientSrcIP(localAddr, nil)
-	err := ep.httpClientAddCerts(certs)
-	return err
+	client := httpClientSrcIP(localAddr, nil)
+	client, err := httpClientAddCerts(client, certs)
+	if err != nil {
+		return err
+	}
+	ep.hClient = client
+	return nil
 }
 
-func (ep *HttpTransportMethod) httpClientAddCerts(certs [][]byte) error {
-	if ep.hClient != nil && len(certs) > 0 {
-		caCertPool := x509.NewCertPool()
-		for _, pem := range certs {
-			if !caCertPool.AppendCertsFromPEM(pem) {
-				return fmt.Errorf("Failed to append datastore certs")
-			}
-		}
-		ep.hClient.Transport.(*http.Transport).TLSClientConfig = &tls.Config{RootCAs: caCertPool}
+// WithSrcIPAndProxyAndHTTPSCerts takes a proxy and proxy certs
+func (ep *HttpTransportMethod) WithSrcIPAndProxyAndHTTPSCerts(localAddr net.IP, proxy *url.URL, certs [][]byte) error {
+	client := httpClientSrcIP(localAddr, proxy)
+	client, err := httpClientAddCerts(client, certs)
+	if err != nil {
+		return err
 	}
+	ep.hClient = client
 	return nil
 }
 

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_oci.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_oci.go
@@ -92,9 +92,26 @@ func (ep *OCITransportMethod) WithSrcIPAndProxySelection(localAddr net.IP,
 	return nil
 }
 
-// WithSrcIPAndHTTPSCerts append certs for https datastore
+// WithSrcIPAndHTTPSCerts append certs for the datastore access
 func (ep *OCITransportMethod) WithSrcIPAndHTTPSCerts(localAddr net.IP, certs [][]byte) error {
-	return fmt.Errorf("not supported")
+	client := httpClientSrcIP(localAddr, nil)
+	client, err := httpClientAddCerts(client, certs)
+	if err != nil {
+		return err
+	}
+	ep.hClient = client
+	return nil
+}
+
+// WithSrcIPAndProxyAndHTTPSCerts append certs for the datastore access
+func (ep *OCITransportMethod) WithSrcIPAndProxyAndHTTPSCerts(localAddr net.IP, proxy *url.URL, certs [][]byte) error {
+	client := httpClientSrcIP(localAddr, proxy)
+	client, err := httpClientAddCerts(client, certs)
+	if err != nil {
+		return err
+	}
+	ep.hClient = client
+	return nil
 }
 
 // WithBindIntf bind to specific interface for this connection

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_sftp.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_sftp.go
@@ -94,8 +94,13 @@ func (ep *SftpTransportMethod) WithSrcIPAndProxySelection(localAddr net.IP,
 	return fmt.Errorf("not supported")
 }
 
-// WithSrcIPAndHTTPSCerts append certs for https datastore
+// WithSrcIPAndHTTPSCerts append certs for the datastore access
 func (ep *SftpTransportMethod) WithSrcIPAndHTTPSCerts(localAddr net.IP, certs [][]byte) error {
+	return fmt.Errorf("not supported")
+}
+
+// WithSrcIPAndProxyAndHTTPSCerts takes a proxy and proxy certs
+func (ep *SftpTransportMethod) WithSrcIPAndProxyAndHTTPSCerts(localAddr net.IP, proxy *url.URL, certs [][]byte) error {
 	return fmt.Errorf("not supported")
 }
 


### PR DESCRIPTION
This isn't urgent, but it makes sense to use that datastore certificate chain for all the types where it makes sense and not just got https. This applies it to OCI, S3, and Azure.

Note that I'm not happy with introducing a new WithXXX() function flavor. Either we shoud replace them with a single WithOptions() function and have an option struct where different fields can be filled in, or we should have WithX() return a handle which can be passed to some WithY() function. Suggestions/recommendations are solicited.