### PR TITLE
RPi4 stuck in 1970 fix and make CipherMetrics usable

### DIFF
--- a/pkg/pillar/cipher/handlecipher.go
+++ b/pkg/pillar/cipher/handlecipher.go
@@ -25,6 +25,7 @@ import (
 // and cipher contexts for doing decryption
 type DecryptCipherContext struct {
 	Log               *base.LogObject
+	AgentName         string
 	SubControllerCert pubsub.Subscription
 	SubCipherContext  pubsub.Subscription
 	SubEdgeNodeCert   pubsub.Subscription

--- a/pkg/pillar/cipher/metrics.go
+++ b/pkg/pillar/cipher/metrics.go
@@ -6,54 +6,96 @@
 package cipher
 
 import (
+	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/sirupsen/logrus" // OK for logrus.Fatal
 	"sync"
 	"time"
 )
 
-// agentName is the key to this map hence can be used in zedbox
-var metrics = make(types.CipherMetricsMap)
+// agentMetrics has one entry per agentName aka LogObject
+// Makes it usable when multiple agents are running in the same process aka zedbox
+type agentMetrics struct {
+	metrics types.CipherMetricsMap
+}
+
+type allMetricsMap map[*base.LogObject]agentMetrics
+
+var allMetrics = make(allMetricsMap)
 var mutex = &sync.Mutex{}
 
 // RecordSuccess records that the decryption succeeded
-func RecordSuccess(agentName string) {
+func RecordSuccess(log *base.LogObject, agentName string) {
+	log.Functionf("RecordSuccess(%s)", agentName)
 	mutex.Lock()
 	defer mutex.Unlock()
-	maybeInit(agentName)
-	m := metrics[agentName]
+	m := getMetrics(log, agentName)
 	m.SuccessCount++
 	m.LastSuccess = time.Now()
-	metrics[agentName] = m
+	updateMetrics(log, agentName, m)
 }
 
 // RecordFailure records that the decryption failed or did something
 // unexpected like fall back to cleartext
-func RecordFailure(agentName string, errcode types.CipherError) {
+// If the errcode is NoData we just increment the NoData counter but
+// not record as a failure.
+func RecordFailure(log *base.LogObject, agentName string, errcode types.CipherError) {
+	log.Functionf("RecordFailure(%s, %v)", agentName, errcode)
 	mutex.Lock()
 	defer mutex.Unlock()
-	maybeInit(agentName)
-	m := metrics[agentName]
-	m.FailureCount++
-	m.LastFailure = time.Now()
+	m := getMetrics(log, agentName)
+	if errcode != types.NoData {
+		m.FailureCount++
+		m.LastFailure = time.Now()
+	}
 	m.TypeCounters[errcode]++
-	metrics[agentName] = m
+	updateMetrics(log, agentName, m)
 }
 
-func maybeInit(agentName string) {
-	if metrics == nil {
-		logrus.Fatal("no cipher map")
+func getMetrics(log *base.LogObject, agentName string) types.CipherMetrics {
+	if allMetrics == nil {
+		logrus.Fatal("no allMetrics")
 	}
+	if _, ok := allMetrics[log]; !ok {
+		allMetrics[log] = agentMetrics{metrics: make(types.CipherMetricsMap)}
+	}
+	metrics := allMetrics[log].metrics
 	if _, ok := metrics[agentName]; !ok {
+		log.Noticef("maybeInit(%s) allocate for agent", agentName)
 		metrics[agentName] = types.CipherMetrics{
 			TypeCounters: make([]uint64, types.MaxCipherError),
 		}
+		allMetrics[log] = agentMetrics{metrics: metrics}
 	}
+	return metrics[agentName]
 }
 
-// GetCipherMetrics returns the metrics for this agent
-func GetCipherMetrics() types.CipherMetricsMap {
-	return metrics
+func updateMetrics(log *base.LogObject, agentName string, m types.CipherMetrics) {
+	if allMetrics == nil {
+		logrus.Fatal("no allMetrics")
+	}
+	if _, ok := allMetrics[log]; !ok {
+		logrus.Fatal("allMetrics not initialized")
+	}
+	metrics := allMetrics[log].metrics
+	metrics[agentName] = m
+	allMetrics[log] = agentMetrics{metrics: metrics}
+}
+
+// GetCipherMetrics returns the metrics for this agent aka log pointer.
+// Note that the caller can not safely use this directly since the map
+// might be modified by other goroutines. But the output can be Append'ed to
+// a map owned by the caller.
+// Recommended usage:
+// cms := cipher.Append(types.CipherMetricsMap{}, cipher.GetCipherMetrics(log))
+func GetCipherMetrics(log *base.LogObject) types.CipherMetricsMap {
+	if allMetrics == nil {
+		logrus.Fatal("no allMetrics")
+	}
+	if _, ok := allMetrics[log]; !ok {
+		allMetrics[log] = agentMetrics{metrics: make(types.CipherMetricsMap)}
+	}
+	return allMetrics[log].metrics
 }
 
 // Append concatenates potentially overlappping CipherMetricsMaps to

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -298,6 +298,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		log.Fatal(err)
 	}
 	domainCtx.decryptCipherContext.Log = log
+	domainCtx.decryptCipherContext.AgentName = agentName
 	domainCtx.decryptCipherContext.SubControllerCert = subControllerCert
 	subControllerCert.Activate()
 
@@ -586,7 +587,11 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 		case <-publishTimer.C:
 			start := time.Now()
-			err = cipherMetricsPub.Publish("global", cipher.GetCipherMetrics())
+			// Transfer to a local copy in since updates are
+			// done concurrently
+			cmm := cipher.Append(types.CipherMetricsMap{},
+				cipher.GetCipherMetrics(log))
+			err = cipherMetricsPub.Publish("global", cmm)
 			if err != nil {
 				log.Errorln(err)
 			}
@@ -2171,7 +2176,7 @@ func getCloudInitUserData(ctx *domainContext,
 
 	if dc.CipherBlockStatus.IsCipher {
 		status, decBlock, err := cipher.GetCipherCredentials(&ctx.decryptCipherContext,
-			agentName, dc.CipherBlockStatus)
+			dc.CipherBlockStatus)
 		ctx.pubCipherBlockStatus.Publish(status.Key(), status)
 		if err != nil {
 			log.Errorf("%s, domain config cipherblock decryption unsuccessful, falling back to cleartext: %v",
@@ -2181,10 +2186,10 @@ func getCloudInitUserData(ctx *domainContext,
 			// data. Hence this is a fallback if there is
 			// some cleartext.
 			if decBlock.ProtectedUserData != "" {
-				cipher.RecordFailure(agentName,
+				cipher.RecordFailure(log, agentName,
 					types.CleartextFallback)
 			} else {
-				cipher.RecordFailure(agentName,
+				cipher.RecordFailure(log, agentName,
 					types.MissingFallback)
 			}
 			return decBlock, nil
@@ -2196,9 +2201,9 @@ func getCloudInitUserData(ctx *domainContext,
 	decBlock := types.EncryptionBlock{}
 	decBlock.ProtectedUserData = *dc.CloudInitUserData
 	if decBlock.ProtectedUserData != "" {
-		cipher.RecordFailure(agentName, types.NoCipher)
+		cipher.RecordFailure(log, agentName, types.NoCipher)
 	} else {
-		cipher.RecordFailure(agentName, types.NoData)
+		cipher.RecordFailure(log, agentName, types.NoData)
 	}
 	return decBlock, nil
 }

--- a/pkg/pillar/cmd/downloader/context.go
+++ b/pkg/pillar/cmd/downloader/context.go
@@ -43,6 +43,7 @@ func (ctx *downloaderContext) registerHandlers(ps *pubsub.PubSub) error {
 		log.Fatal(err)
 	}
 	ctx.decryptCipherContext.Log = log
+	ctx.decryptCipherContext.AgentName = agentName
 	ctx.decryptCipherContext.SubControllerCert = subControllerCert
 	subControllerCert.Activate()
 

--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -187,7 +187,11 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 			if err != nil {
 				log.Errorln(err)
 			}
-			err = cipherMetricsPub.Publish("global", cipher.GetCipherMetrics())
+			// Transfer to a local copy in since updates are
+			// done concurrently
+			cmm := cipher.Append(types.CipherMetricsMap{},
+				cipher.GetCipherMetrics(log))
+			err = cipherMetricsPub.Publish("global", cmm)
 			if err != nil {
 				log.Errorln(err)
 			}

--- a/pkg/pillar/cmd/downloader/syncop.go
+++ b/pkg/pillar/cmd/downloader/syncop.go
@@ -342,7 +342,7 @@ func getDatastoreCredential(ctx *downloaderContext,
 	dst types.DatastoreConfig) (types.EncryptionBlock, error) {
 	if dst.CipherBlockStatus.IsCipher {
 		status, decBlock, err := cipher.GetCipherCredentials(&ctx.decryptCipherContext,
-			agentName, dst.CipherBlockStatus)
+			dst.CipherBlockStatus)
 		ctx.pubCipherBlockStatus.Publish(status.Key(), status)
 		if err != nil {
 			log.Errorf("%s, datastore config cipherblock decryption unsuccessful, falling back to cleartext: %v",
@@ -353,10 +353,10 @@ func getDatastoreCredential(ctx *downloaderContext,
 			// data. Hence this is a fallback if there is
 			// some cleartext.
 			if decBlock.DsAPIKey != "" || decBlock.DsPassword != "" {
-				cipher.RecordFailure(agentName,
+				cipher.RecordFailure(log, agentName,
 					types.CleartextFallback)
 			} else {
-				cipher.RecordFailure(agentName,
+				cipher.RecordFailure(log, agentName,
 					types.MissingFallback)
 			}
 			return decBlock, nil
@@ -369,9 +369,9 @@ func getDatastoreCredential(ctx *downloaderContext,
 	decBlock.DsAPIKey = dst.ApiKey
 	decBlock.DsPassword = dst.Password
 	if decBlock.DsAPIKey != "" || decBlock.DsPassword != "" {
-		cipher.RecordFailure(agentName, types.NoCipher)
+		cipher.RecordFailure(log, agentName, types.NoCipher)
 	} else {
-		cipher.RecordFailure(agentName, types.NoData)
+		cipher.RecordFailure(log, agentName, types.NoData)
 	}
 	return decBlock, nil
 }

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -228,6 +228,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		log.Fatal(err)
 	}
 	nimCtx.deviceNetworkContext.DecryptCipherContext.Log = log
+	nimCtx.deviceNetworkContext.DecryptCipherContext.AgentName = agentName
 	nimCtx.deviceNetworkContext.DecryptCipherContext.SubControllerCert = subControllerCert
 	subControllerCert.Activate()
 
@@ -775,7 +776,11 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 		case <-publishTimer.C:
 			start := time.Now()
-			err = cipherMetricsPub.Publish("global", cipher.GetCipherMetrics())
+			// Transfer to a local copy in since updates are
+			// done concurrently
+			cmm := cipher.Append(types.CipherMetricsMap{},
+				cipher.GetCipherMetrics(log))
+			err = cipherMetricsPub.Publish("global", cmm)
 			if err != nil {
 				log.Errorln(err)
 			}
@@ -918,8 +923,8 @@ func tryDeviceConnectivityToCloud(ctx *devicenetwork.DeviceNetworkContext) bool 
 	// Start with a different port to cycle through them all over time
 	ctx.Iteration++
 	rtf, intfStatusMap, err := devicenetwork.VerifyDeviceNetworkStatus(
-		log, *ctx.DeviceNetworkStatus, successCount, ctx.Iteration,
-		ctx.TestSendTimeout)
+		log, agentName, *ctx.DeviceNetworkStatus, successCount,
+		ctx.Iteration, ctx.TestSendTimeout)
 	ctx.DevicePortConfig.UpdatePortStatusFromIntfStatusMap(intfStatusMap)
 	// Use TestResults to update the DevicePortConfigList and publish
 	// Note that the TestResults will at least have an updated timestamp

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -422,9 +422,12 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 	ReportDeviceMetric.Newlog = nlm
 	log.Tracef("publishMetrics: newlog-metrics %+v", nlm)
 
-	// collect CipherMetric from agents and report
-	// Collect zedcloud metrics from ourselves and other agents
-	cipherMetrics := cipher.GetCipherMetrics()
+	// collect CipherMetric from ourselves and agents and report
+	cipherMetrics := types.CipherMetricsMap{}
+	cipherMetricsZA := cipher.GetCipherMetrics(log)
+	if cipherMetricsZA != nil {
+		cipherMetrics = cipher.Append(cipherMetrics, cipherMetricsZA)
+	}
 	if cipherMetricsDL != nil {
 		cipherMetrics = cipher.Append(cipherMetrics, cipherMetricsDL)
 	}
@@ -438,7 +441,7 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 		cipherMetrics = cipher.Append(cipherMetrics, cipherMetricsZR)
 	}
 	for agentName, cm := range cipherMetrics {
-		log.Tracef("Cipher metrics for %s: %+v", agentName, cm)
+		log.Functionf("Cipher metrics for %s: %+v", agentName, cm)
 		metric := metrics.CipherMetric{AgentName: agentName,
 			FailureCount: cm.FailureCount,
 			SuccessCount: cm.SuccessCount,
@@ -456,7 +459,9 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 				ErrorCode: metrics.CipherError(i),
 				Count:     cm.TypeCounters[i],
 			}
-			metric.Tc = append(metric.Tc, &tc)
+			if tc.Count != 0 {
+				metric.Tc = append(metric.Tc, &tc)
+			}
 		}
 		ReportDeviceMetric.Cipher = append(ReportDeviceMetric.Cipher,
 			&metric)

--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -294,8 +294,8 @@ func VerifyPending(ctx *DeviceNetworkContext, pending *DPCPending,
 	// Hard-coded at 1 for now; at least one interface needs to work
 	const successCount uint = 1
 	ctx.Iteration++
-	rtf, intfStatusMap, err := VerifyDeviceNetworkStatus(log, pending.PendDNS,
-		successCount, ctx.Iteration, timeout)
+	rtf, intfStatusMap, err := VerifyDeviceNetworkStatus(log, ctx.AgentName,
+		pending.PendDNS, successCount, ctx.Iteration, timeout)
 	// Use TestResults to update the DevicePortConfigList and DeviceNetworkStatus
 	// Note that the TestResults will at least have an updated timestamp
 	// for one of the ports.

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -350,7 +350,16 @@ mkfifo /run/diag.pipe
 (while true; do cat; done) < /run/diag.pipe >/dev/console 2>&1 &
 $BINDIR/diag -f -o /run/diag.pipe runAsService &
 
-if [ ! -s $CONFIGDIR/device.cert.pem ]; then
+# Need a special check (and slower booting) if the device has no hardware clock
+if [ -c /dev/rtc ] || [ -c /dev/rtc0 ]; then
+    RTC=1
+else
+    RTC=0
+fi
+if [ $RTC = 0 ]; then
+    echo "$(date -Ins -u) No real-time clock"
+fi
+if [ ! -s $CONFIGDIR/device.cert.pem ] || [ $RTC = 0 ]; then
     # Wait for having IP addresses for a few minutes
     # so that we are likely to have an address when we run ntp then create cert
     echo "$(date -Ins -u) Starting waitforaddr"


### PR DESCRIPTION
Recently we optimized device-steps.sh to only wait for NTP when we were going to generate a device certificate.
However, on RPI4 and other devices without a real time clock we should wait in all cases to avoid sitting at Jan 1, 1970 (and rejecting the /persist/certs/* because they are not yet valid) until ntpd catches up.

As part of debuggig this and the certs I realized the CipherMetrics have useless noise; turns out CipherMetrics is missing fixes we made to the origin zedcloudmetrics to handle the single zedbox process with multiple agents and concurrent map access. @giggsoff somehow also ran into that today and came up with a different fix in #2244 