### PR TITLE
DownloaderStatus stucks with Progress 100

### DIFF
--- a/libs/zedUpload/datastore.go
+++ b/libs/zedUpload/datastore.go
@@ -167,7 +167,6 @@ func (ctx *DronaCtx) handleQuit() error {
 // postSize:
 //  post the progress report we haven't completed the download/upload yet
 func (ctx *DronaCtx) postSize(req *DronaRequest, size, asize int64) {
-	req.setInprogress()
 	req.updateOsize(size)
 	req.updateAsize(asize)
 	req.result <- req
@@ -184,8 +183,8 @@ func (ctx *DronaCtx) postChunk(req *DronaRequest, chunkDetail ChunkData) {
 //   make sure the reply is always sent back
 //
 func (ctx *DronaCtx) postResponse(req *DronaRequest, status error) {
-	// status is already set up by action, we just have to clear inprogress flag
-	req.clearInprogress()
+	// status is already set up by action, we just have to set processed flag
+	req.setProcessed()
 	req.result <- req
 }
 

--- a/libs/zedUpload/datastore_req.go
+++ b/libs/zedUpload/datastore_req.go
@@ -41,8 +41,8 @@ type DronaRequest struct {
 	// need size acknowledgement
 	ackback bool
 
-	// request is still in progress, this is just update
-	inprogress bool
+	// request is processed, this is just update
+	processed bool
 
 	// if size exceed this don't download
 	sizelimit int64
@@ -121,19 +121,13 @@ func (req *DronaRequest) GetUpStatus() (string, error) {
 func (req *DronaRequest) IsDnUpdate() bool {
 	req.Lock()
 	defer req.Unlock()
-	return req.inprogress
+	return !req.processed
 }
 
-func (req *DronaRequest) setInprogress() {
+func (req *DronaRequest) setProcessed() {
 	req.Lock()
 	defer req.Unlock()
-	req.inprogress = true
-}
-
-func (req *DronaRequest) clearInprogress() {
-	req.Lock()
-	defer req.Unlock()
-	req.inprogress = false
+	req.processed = true
 }
 
 // Return object actual synced down size

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore.go
@@ -167,7 +167,6 @@ func (ctx *DronaCtx) handleQuit() error {
 // postSize:
 //  post the progress report we haven't completed the download/upload yet
 func (ctx *DronaCtx) postSize(req *DronaRequest, size, asize int64) {
-	req.setInprogress()
 	req.updateOsize(size)
 	req.updateAsize(asize)
 	req.result <- req
@@ -184,8 +183,8 @@ func (ctx *DronaCtx) postChunk(req *DronaRequest, chunkDetail ChunkData) {
 //   make sure the reply is always sent back
 //
 func (ctx *DronaCtx) postResponse(req *DronaRequest, status error) {
-	// status is already set up by action, we just have to clear inprogress flag
-	req.clearInprogress()
+	// status is already set up by action, we just have to set processed flag
+	req.setProcessed()
 	req.result <- req
 }
 

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_req.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_req.go
@@ -41,8 +41,8 @@ type DronaRequest struct {
 	// need size acknowledgement
 	ackback bool
 
-	// request is still in progress, this is just update
-	inprogress bool
+	// request is processed, this is just update
+	processed bool
 
 	// if size exceed this don't download
 	sizelimit int64
@@ -121,19 +121,13 @@ func (req *DronaRequest) GetUpStatus() (string, error) {
 func (req *DronaRequest) IsDnUpdate() bool {
 	req.Lock()
 	defer req.Unlock()
-	return req.inprogress
+	return !req.processed
 }
 
-func (req *DronaRequest) setInprogress() {
+func (req *DronaRequest) setProcessed() {
 	req.Lock()
 	defer req.Unlock()
-	req.inprogress = true
-}
-
-func (req *DronaRequest) clearInprogress() {
-	req.Lock()
-	defer req.Unlock()
-	req.inprogress = false
+	req.processed = true
 }
 
 // Return object actual synced down size


### PR DESCRIPTION
I can see in the logs, that we download all needed information:
```
types.DownloaderStatus{ ... // 13 identical fields Size: 1709047808, TotalSize: 1709047808, - CurrentSize: 1225737186, + CurrentSize: 1709047808, - Progress: 71, + Progress: 100, ModTime: s"0001-01-01 00:00:00 +0000 UTC", ContentType: "", ... // 3 identical fields }
```
but I cannot see Downloaded state somewhere.

So, seems we have stuck somewhere in the loop https://github.com/lf-edge/eve/blob/ec37884f7575f62806a1805ca4a51b236c851ad5/pkg/pillar/cmd/downloader/download.go#L104.

I can see only the one reason: we check inprogress inside the loop, so probably we have concurrence with the timer https://github.com/lf-edge/eve/blob/ec37884f7575f62806a1805ca4a51b236c851ad5/libs/zedUpload/datastore_aws.go#L129 which set inprogress to true (it may be delayed after defer functions due to lock acquire inside).

It seems reasonable to not affect inprogress inside the timer. 
