### PR TITLE
fix assigning of ErrorDescription with empty Error inside

### DIFF
--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -585,7 +585,7 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 		if ds.HasError() {
 			log.Errorf("Received error from domainmgr for %s: %s",
 				uuidStr, ds.Error)
-			status.SetErrorWithSourceAndDescription(status.ErrorDescription, types.DomainStatus{})
+			status.SetErrorWithSourceAndDescription(ds.ErrorDescription, types.DomainStatus{})
 			changed = true
 		} else if status.IsErrorSource(types.DomainStatus{}) {
 			log.Functionf("Clearing domainmgr error %s", status.Error)


### PR DESCRIPTION
I mistakenly call SetErrorWithSourceAndDescription with ErrorDescription of object itself in #2223, which was fatal if the error string was empty. Thanks @eriknordmark for finding this.

Also it comes in tests: https://github.com/lf-edge/eve/runs/3419357679?check_suite_focus=true#step:10:5188

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>