### PR TITLE
Fix concurrent access to zedagent metrics

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -728,7 +728,9 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 
 	// publish the cloud MetricsMap for zedagent for device debugging purpose
 	if zedagentMetrics != nil {
-		ctx.pubMetricsMap.Publish("global", zedagentMetrics)
+		cms = types.MetricsMap{}
+		cms = zedcloud.Append(cms, zedagentMetrics)
+		ctx.pubMetricsMap.Publish("global", cms)
 	}
 }
 


### PR DESCRIPTION
Zedagent metrics can be accessed concurrently and [cause zedbox panic](https://github.com/lf-edge/eve/pull/2251/checks?check_run_id=3445344181).
This is because the [recommended usage](https://github.com/lf-edge/eve/blob/215862f097ff8800a780e316a27dead41f1da5a4/pkg/pillar/zedcloud/zedcloudmetric.go#L114-L118) for MetricsMap was not followed in one particular instance.

Signed-off-by: Milan Lenco <milan@zededa.com>