### PR TITLE
add parallelism to azure downloads

### DIFF
--- a/pkg/pillar/go.mod
+++ b/pkg/pillar/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/yvasiyarov/newrelic_platform_go v0.0.0-20160601141957-9c099fbc30e9 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a
-	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d // indirect
+	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d
 	golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e
 	google.golang.org/genproto v0.0.0-20210224155714-063164c882e6 // indirect
 	google.golang.org/grpc v1.36.0


### PR DESCRIPTION
At one point, eve had switched from the older azcopy library to the newer azblob library. The old library had given us parallelism in downloads (up to 192), whereas the new one just gave us a `io.ReadCloser`, so it was serial. This made downloads much slower, sometimes 3-10x slower.

This change uses the parallelism option in the newer azblob library. It uses 128, which @naiming-zededa estimates as a good rule of thumb; we always can tweak that one constant later.

In my own (rapid) tests, I saw a 10x speedup when using parallelism of just 64. Of course, this depends entirely on your connection bandwidth and available cpu.

cc @petr-zededa @naiming-zededa 