### PR TITLE
propagate error on maybeRetryDownload and for ResolveStatus

### DIFF
--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -331,9 +331,13 @@ func maybeRetryDownload(ctx *downloaderContext,
 	// Increment count; we defer clearing error until success
 	// to avoid confusing the user.
 	status.RetryCount++
-	errStr := fmt.Sprintf("Retry attempt %d after %s",
-		status.RetryCount, status.OrigError)
-	status.SetErrorNow(errStr)
+	severity := types.GetErrorSeverity(status.RetryCount, time.Duration(status.RetryCount)*retryTime)
+	errDescription := types.ErrorDescription{
+		Error:               status.OrigError,
+		ErrorRetryCondition: fmt.Sprintf("Retrying; attempt %d", status.RetryCount),
+		ErrorSeverity:       severity,
+	}
+	status.SetErrorDescription(errDescription)
 	publishDownloaderStatus(ctx, status)
 
 	doDownload(ctx, *config, status, receiveChan)

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -51,8 +51,7 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 					errStr := fmt.Sprintf("Received error from resolver for %s, SHA (%s): %s",
 						status.ResolveKey(), rs.ImageSha256, rs.Error)
 					log.Error(errStr)
-					status.SetErrorWithSource(errStr, types.ResolveStatus{},
-						rs.ErrorTime)
+					status.SetErrorWithSourceAndDescription(rs.ErrorDescription, types.ResolveStatus{})
 					changed = true
 					return changed, false
 				} else if rs.ImageSha256 == "" {


### PR DESCRIPTION
Seems we can miss retry condition on maybeRetryDownload before new error comes from doDownload.
Also I do propagation of ResolveStatus errors to contentTree

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>