### PR TITLE
rpi4: setup correct serial console

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -222,6 +222,7 @@ function set_arm64_baremetal {
    if [ "$smb_vendor" = "raspberrypi" ]; then
       smbios -t 1 -s 5 --set smb_product
       if [ "$smb_product" = "rpi" ]; then
+         set_global dom0_console "console=tty0 console=ttyS1,115200"
          set_to_existing_file devicetree /boot/dtb/broadcom/bcm2711-rpi-4-b.dtb
       elif [ "$smb_product" = "uno-220" ]; then
          set_to_existing_file devicetree /boot/dtb/broadcom/raspberrypi-uno-220.dtb


### PR DESCRIPTION
Setup correct serial uart console.
The serial uart console number changed with the transition to kernel 5.10.y

Signed-off-by: Insei <goodmobiledevices@gmail.com>