### PR TITLE
app CPU utilization needs to be scaled not by ticks but by cores

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1054,6 +1054,7 @@ func handleCreate(ctx *domainContext, key string, config *types.DomainConfig) {
 		VncDisplay:         config.VncDisplay,
 		VncPasswd:          config.VncPasswd,
 		State:              types.INSTALLED,
+		VmConfig:           config.VmConfig,
 	}
 	// Note that the -emu interface doesn't exist until after boot of the domU, but we
 	// initialize the VifList here with the VifUsed.

--- a/pkg/pillar/cmd/domainmgr/metric.go
+++ b/pkg/pillar/cmd/domainmgr/metric.go
@@ -105,6 +105,7 @@ func getAndPublishMetrics(ctx *domainContext, hyper hypervisor.Hypervisor) {
 		} else if dm.UUIDandVersion.UUID == nilUUID {
 			// Scale Xen Dom0 based CPUs seen by hypervisor
 			dm.CPUTotalNs /= uint64(hm.Ncpus)
+			dm.Activated = true
 		}
 		if !dm.Activated {
 			// We clear the memory so it doesn't accidentally get

--- a/pkg/pillar/cmd/domainmgr/metric.go
+++ b/pkg/pillar/cmd/domainmgr/metric.go
@@ -17,9 +17,10 @@ func metricsTimerTask(ctx *domainContext, hyper hypervisor.Hypervisor) {
 	log.Functionln("starting metrics timer task")
 	getAndPublishMetrics(ctx, hyper)
 
-	// Publish 4X more often than zedagent publishes to controller
+	// Publish 20X more often than zedagent publishes to controller
+	// to reduce effect of quantization errors
 	interval := time.Duration(ctx.metricInterval) * time.Second
-	max := float64(interval) / 4
+	max := float64(interval) / 20
 	min := max * 0.3
 	ticker := flextimer.NewRangeTicker(time.Duration(min), time.Duration(max))
 
@@ -97,6 +98,7 @@ func getAndPublishMetrics(ctx *domainContext, hyper hypervisor.Hypervisor) {
 				dm.CPUTotalNs /= uint64(status.VCpus)
 			}
 		}
+		// XXX xen nilUUID also need to be scaled?
 		if !dm.Activated {
 			// We clear the memory so it doesn't accidentally get
 			// reported.  We keep the CPUTotalNs and AvailableMemory

--- a/pkg/pillar/cmd/domainmgr/metric.go
+++ b/pkg/pillar/cmd/domainmgr/metric.go
@@ -101,10 +101,12 @@ func getAndPublishMetrics(ctx *domainContext, hyper hypervisor.Hypervisor) {
 			// Scale the CPU nanoseconds based on the number of VCpus
 			if status.VCpus != 0 {
 				dm.CPUTotalNs /= uint64(status.VCpus)
+				dm.CPUScaled = uint32(status.VCpus)
 			}
 		} else if dm.UUIDandVersion.UUID == nilUUID {
 			// Scale Xen Dom0 based CPUs seen by hypervisor
 			dm.CPUTotalNs /= uint64(hm.Ncpus)
+			dm.CPUScaled = hm.Ncpus
 			dm.Activated = true
 		}
 		if !dm.Activated {
@@ -174,6 +176,7 @@ func formatAndPublishHostCPUMem(ctx *domainContext, hm types.HostMemory, now tim
 	dm := types.DomainMetric{
 		UUIDandVersion:    hostUUID,
 		CPUTotalNs:        uint64(busy * float64(nanoSecToSec)),
+		CPUScaled:         hm.Ncpus,
 		UsedMemory:        uint32(used),
 		AvailableMemory:   uint32(hm.FreeMemoryMB),
 		UsedMemoryPercent: usedPerc,

--- a/pkg/pillar/cmd/domainmgr/metric.go
+++ b/pkg/pillar/cmd/domainmgr/metric.go
@@ -103,7 +103,7 @@ func getAndPublishMetrics(ctx *domainContext, hyper hypervisor.Hypervisor) {
 				dm.CPUTotalNs /= uint64(status.VCpus)
 				dm.CPUScaled = uint32(status.VCpus)
 			}
-		} else if dm.UUIDandVersion.UUID == nilUUID {
+		} else if dm.UUIDandVersion.UUID == nilUUID && hm.Ncpus != 0 {
 			// Scale Xen Dom0 based CPUs seen by hypervisor
 			dm.CPUTotalNs /= uint64(hm.Ncpus)
 			dm.CPUScaled = hm.Ncpus
@@ -169,8 +169,10 @@ func formatAndPublishHostCPUMem(ctx *domainContext, hm types.HostMemory, now tim
 		busy += t.User + t.System + t.Nice + t.Irq + t.Softirq
 	}
 
-	// Scale based on the CPUs seen by the hypervisor
-	busy /= float64(hm.Ncpus)
+	if hm.Ncpus != 0 {
+		// Scale based on the CPUs seen by the hypervisor
+		busy /= float64(hm.Ncpus)
+	}
 
 	const nanoSecToSec uint64 = 1000000000
 	dm := types.DomainMetric{

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -530,12 +530,16 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 		ReportDeviceMetric.MetricItems = append(ReportDeviceMetric.MetricItems, item)
 	}
 
+	const nanoSecToSec uint64 = 1000000000
+
 	// Get device info using nil UUID
 	dm := lookupDomainMetric(ctx, nilUUID.String())
 	if dm != nil {
 		log.Tracef("host CPU: %d, percent used %d",
-			dm.CPUTotal, (100*dm.CPUTotal)/uint64(info.Uptime))
-		ReportDeviceMetric.CpuMetric.Total = *proto.Uint64(dm.CPUTotal)
+			dm.CPUTotalNs, (100*dm.CPUTotalNs)/uint64(info.Uptime))
+		// XXX add field in CpuMetric so we can report with better
+		// granularity than one second
+		ReportDeviceMetric.CpuMetric.Total = *proto.Uint64(dm.CPUTotalNs / nanoSecToSec)
 
 		ReportDeviceMetric.SystemServicesMemoryMB = new(metrics.MemoryMetric)
 		ReportDeviceMetric.SystemServicesMemoryMB.UsedMem = dm.UsedMemory
@@ -594,9 +598,11 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 		dm := lookupDomainMetric(ctx, aiStatus.Key())
 		if dm != nil {
 			log.Tracef("metrics for %s CPU %d, usedMem %v, availMem %v, availMemPercent %v",
-				aiStatus.DomainName, dm.CPUTotal, dm.UsedMemory,
+				aiStatus.DomainName, dm.CPUTotalNs, dm.UsedMemory,
 				dm.AvailableMemory, dm.UsedMemoryPercent)
-			ReportAppMetric.Cpu.Total = *proto.Uint64(dm.CPUTotal)
+			// XXX add field in CpuMetric so we can report with better
+			// granularity than one second
+			ReportAppMetric.Cpu.Total = *proto.Uint64(dm.CPUTotalNs / nanoSecToSec)
 			ReportAppMetric.Memory.UsedMem = dm.UsedMemory
 			ReportAppMetric.Memory.AvailMem = dm.AvailableMemory
 			ReportAppMetric.Memory.UsedPercentage = dm.UsedMemoryPercent

--- a/pkg/pillar/hypervisor/containerd.go
+++ b/pkg/pillar/hypervisor/containerd.go
@@ -230,7 +230,6 @@ func (ctx ctrdContext) GetHostCPUMem() (types.HostMemory, error) {
 	return selfDomCPUMem()
 }
 
-const clockTicks uint64 = 100 // github.com/containerd/cgroups/ticks.go hardcoded as 100 also
 const nanoSecToSec uint64 = 1000000000
 
 func (ctx ctrdContext) GetDomsCPUMem() (map[string]types.DomainMetric, error) {
@@ -268,7 +267,7 @@ func (ctx ctrdContext) GetDomsCPUMem() (map[string]types.DomainMetric, error) {
 			if metric.CPU == nil || metric.CPU.Usage == nil {
 				logrus.Errorf("GetDomsCPUMem nil returned in metric.CPU: %v", metric)
 			} else {
-				cpuTotal = metric.CPU.Usage.Total / nanoSecToSec / clockTicks
+				cpuTotal = metric.CPU.Usage.Total
 			}
 		} else {
 			logrus.Errorf("GetDomsCPUMem failed with error %v", err)
@@ -276,7 +275,7 @@ func (ctx ctrdContext) GetDomsCPUMem() (map[string]types.DomainMetric, error) {
 
 		res[id] = types.DomainMetric{
 			UUIDandVersion:    types.UUIDandVersion{},
-			CPUTotal:          cpuTotal,
+			CPUTotalNs:        cpuTotal, // Caller will scale
 			UsedMemory:        usedMem,
 			MaxUsedMemory:     maxUsedMem,
 			AvailableMemory:   availMem,

--- a/pkg/pillar/hypervisor/containerd.go
+++ b/pkg/pillar/hypervisor/containerd.go
@@ -276,6 +276,7 @@ func (ctx ctrdContext) GetDomsCPUMem() (map[string]types.DomainMetric, error) {
 		res[id] = types.DomainMetric{
 			UUIDandVersion:    types.UUIDandVersion{},
 			CPUTotalNs:        cpuTotal, // Caller will scale
+			CPUScaled:         1,
 			UsedMemory:        usedMem,
 			MaxUsedMemory:     maxUsedMem,
 			AvailableMemory:   availMem,

--- a/pkg/pillar/hypervisor/containerd_test.go
+++ b/pkg/pillar/hypervisor/containerd_test.go
@@ -16,7 +16,7 @@ func TestGetDomsCPUMem(t *testing.T) {
 	}
 
 	for k, v := range res {
-		if v.UsedMemoryPercent < 0 || v.UsedMemoryPercent > 100 || v.CPUTotal != 0 || v.AvailableMemory < v.UsedMemory {
+		if v.UsedMemoryPercent < 0 || v.UsedMemoryPercent > 100 || v.CPUTotalNs != 0 || v.AvailableMemory < v.UsedMemory {
 			t.Errorf("result from get domain statistics doesn't make sense %s: %+v", k, v)
 		}
 	}

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -741,6 +741,21 @@ func (ctx xenContext) GetDomsCPUMem() (map[string]types.DomainMetric, error) {
 		logrus.Errorf("Calling fallbackDomainMetric")
 		dmList = fallbackDomainMetric()
 	}
+	// Need to add all of the others CPU nanoseconds into the Domain-0 entry
+	// since it represents all of the device
+	// XXX what about adding memory?
+	dom0, ok := dmList[dom0Name]
+	if !ok {
+		logrus.Errorf("No Domain-0 in CPUMemoryStat")
+	} else {
+		for d, dm := range dmList {
+			if d == dom0Name {
+				continue
+			}
+			dom0.CPUTotalNs += dm.CPUTotalNs
+		}
+		dmList[dom0Name] = dom0
+	}
 	return dmList, nil
 }
 

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -801,6 +801,7 @@ func parseCPUMemoryStat(cpuMemoryStat [][]string, dmList map[string]types.Domain
 
 		dm := types.DomainMetric{
 			CPUTotalNs:        cpuTotal * nanoSecToSec,
+			CPUScaled:         1, // Caller will scale
 			UsedMemory:        uint32(usedMemory),
 			AvailableMemory:   uint32(availableMemory),
 			UsedMemoryPercent: float64(usedMemoryPercent),
@@ -837,6 +838,7 @@ func fallbackDomainMetric() map[string]types.DomainMetric {
 	}
 	for _, cpu := range cpuStat {
 		dm.CPUTotalNs = uint64(cpu.Total() * float64(nanoSecToSec))
+		dm.CPUScaled = 1 // Caller will scale
 		break
 	}
 	dmList[dom0Name] = dm

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -785,7 +785,7 @@ func parseCPUMemoryStat(cpuMemoryStat [][]string, dmList map[string]types.Domain
 		availableMemory := float64(totalMemory) - usedMemory
 
 		dm := types.DomainMetric{
-			CPUTotal:          cpuTotal,
+			CPUTotalNs:        cpuTotal * nanoSecToSec,
 			UsedMemory:        uint32(usedMemory),
 			AvailableMemory:   uint32(availableMemory),
 			UsedMemoryPercent: float64(usedMemoryPercent),
@@ -821,7 +821,7 @@ func fallbackDomainMetric() map[string]types.DomainMetric {
 		return dmList
 	}
 	for _, cpu := range cpuStat {
-		dm.CPUTotal = uint64(cpu.Total())
+		dm.CPUTotalNs = uint64(cpu.Total() * float64(nanoSecToSec))
 		break
 	}
 	dmList[dom0Name] = dm

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -637,6 +637,8 @@ func (ctx xenContext) GetHostCPUMem() (types.HostMemory, error) {
 		} else {
 			hm.TotalMemoryMB = res
 		}
+	} else {
+		logrus.Warnf("Missing total_memory in %+v", dict)
 	}
 	if str, ok := dict["free_memory"]; ok {
 		res, err := strconv.ParseUint(str, 10, 64)
@@ -645,6 +647,8 @@ func (ctx xenContext) GetHostCPUMem() (types.HostMemory, error) {
 		} else {
 			hm.FreeMemoryMB = res
 		}
+	} else {
+		logrus.Warnf("Missing free_memory in %+v", dict)
 	}
 	if str, ok := dict["nr_cpus"]; ok {
 		// Note that this is the set of physical CPUs which is different
@@ -655,6 +659,8 @@ func (ctx xenContext) GetHostCPUMem() (types.HostMemory, error) {
 		} else {
 			hm.Ncpus = uint32(res)
 		}
+	} else {
+		logrus.Warnf("Missing nr_cpus in %+v", dict)
 	}
 	return hm, nil
 }

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -263,6 +263,7 @@ type DomainStatus struct {
 	AdaptersFailed bool
 	OCIConfigDir   string            // folder holding an OCI Image config for this domain (empty string means no config)
 	EnvVariables   map[string]string // List of environment variables to be set in container
+	VmConfig                         // From DomainConfig
 }
 
 func (status DomainStatus) Key() string {
@@ -391,7 +392,7 @@ type DiskStatus struct {
 // DomainMetric carries CPU and memory usage. UUID=devUUID for the dom0/host metrics overhead
 type DomainMetric struct {
 	UUIDandVersion    UUIDandVersion
-	CPUTotal          uint64 // Seconds since Domain boot
+	CPUTotalNs        uint64 // Nanoseconds since Domain boot scaled by #CPUs
 	UsedMemory        uint32
 	MaxUsedMemory     uint32
 	AvailableMemory   uint32

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -393,6 +393,7 @@ type DiskStatus struct {
 type DomainMetric struct {
 	UUIDandVersion    UUIDandVersion
 	CPUTotalNs        uint64 // Nanoseconds since Domain boot scaled by #CPUs
+	CPUScaled         uint32 // The scale factor which was applied
 	UsedMemory        uint32
 	MaxUsedMemory     uint32
 	AvailableMemory   uint32


### PR DESCRIPTION
99% of this is about correcting CPU reporting and making the associated timestamps in the metrics messages reasonably accurate. See individual commits for details.
One commit is fixing a recently introduced clearing of memory for Xen dom0.

Note that the Xen CPU commit makes the Xen CPU reporting match that of KVM in that the device CPU will include the CPU seconds for all of the guests.

To avoid loosing accuracy as we scale this PR is changing the local field from seconds to nanoseconds. In a future PR will pass that higher accuracy to the controller; it takes a while for a low utilization app or EVE-OS to use one CPU second resulting in jagged graphs of CPU utilization.
