### PR TITLE
Publish AppMetadata to the Controller

### DIFF
--- a/pkg/pillar/cmd/zedagent/handleappInstMetadata.go
+++ b/pkg/pillar/cmd/zedagent/handleappInstMetadata.go
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021. Zededa, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package zedagent
+
+import "github.com/lf-edge/eve/pkg/pillar/types"
+
+func handleAppInstMetaDataCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleAppInstMetaDataImpl(ctxArg, key, statusArg)
+}
+
+func handleAppInstMetaDataModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleAppInstMetaDataImpl(ctxArg, key, statusArg)
+}
+
+func handleAppInstMetaDataDelete(ctxArg interface{}, key string, statusArg interface{}) {
+	appInstMetaData := statusArg.(types.AppInstMetaData)
+	ctx := ctxArg.(*zedagentContext)
+	uuidStr := appInstMetaData.Key()
+	PublishAppInstMetaDataToZedCloud(ctx, uuidStr, nil, appInstMetaData.Type, ctx.iteration)
+	ctx.iteration++
+}
+
+func handleAppInstMetaDataImpl(ctxArg interface{}, key string, statusArg interface{}) {
+
+	appInstMetaData := statusArg.(types.AppInstMetaData)
+	ctx := ctxArg.(*zedagentContext)
+	uuidStr := appInstMetaData.Key()
+	PublishAppInstMetaDataToZedCloud(ctx, uuidStr, &appInstMetaData, appInstMetaData.Type, ctx.iteration)
+	ctx.iteration++
+}


### PR DESCRIPTION
After zedrouter publishes the received AppMetadata, zedagent must receive and publish it to the Controller. 
Also handled the case to clean up the AppMetadata after the respected app is deleted. 

cc @zed-rishabh