### PR TITLE
 [grub] Add processing of the hv_extra_args variable

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -149,6 +149,7 @@ function set_generic {
    set_global hv_ctrd_cpu_settings "ctrd_max_vcpus=1"
    set_global hv_platform_tweaks "smt=false"
    set_global hv_watchdog_timer "change=500"
+   set_global hv_extra_args "$hv_extra_args"
 
    set_global dom0 /boot/kernel
    set_global dom0_rootfs "root=$rootfs_root"


### PR DESCRIPTION
Add processing of the hv_extra_args variable to specify additional boot parameters when starting EVE.
Argument hv_extra_args was no used. If user edits /config/grub.cfg and adds
`set_global hv_extra_args “foo=bar”` nothing will happen
This commit makes grub to respect `hv_extra_args` too
