### PR TITLE
fix no memory processing

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1789,8 +1789,8 @@ func reserveAdapters(ctx *domainContext, config types.DomainConfig) *types.Error
 						extraStr = "(which is halting)"
 						description.ErrorSeverity = types.ErrorSeverityNotice
 					}
-					description.ErrorEntities = []*types.ErrorEntity{{EntityID: ibp.UsedByUUID.String(), EntityType: types.ErrorEntityAppInstance}}
-					description.ErrorRetryCondition = fmt.Sprintf("Will wait for adapter to release from app: %s", other.DisplayName)
+					description.ErrorEntities = []*types.ErrorEntity{{EntityID: other.UUIDandVersion.UUID.String(), EntityType: types.ErrorEntityAppInstance}}
+					description.ErrorRetryCondition = "Will wait for adapter to release from app"
 				}
 				description.Error = fmt.Sprintf("adapter %d %s used by %s %s",
 					adapter.Type, adapter.Name,

--- a/pkg/pillar/cmd/zedmanager/memorysizemgmt.go
+++ b/pkg/pillar/cmd/zedmanager/memorysizemgmt.go
@@ -43,11 +43,13 @@ func getRemainingMemory(ctxPtr *zedmanagerContext) (uint64, uint64, uint64, erro
 	usedMemorySize += uint64(memoryReservedForEve)
 	deviceMemorySize, err := sysTotalMemory(ctxPtr)
 	if err != nil {
-		return 0, 0, 0, err
+		ctxPtr.checkFreedResources = true
+		return 0, 0, 0, fmt.Errorf("sysTotalMemory failed: %v. Scheduling of checkRetry", err)
 	}
 	if usedMemorySize > deviceMemorySize {
-		log.Errorf("getRemainingMemory discrepancy: accounted apps: %s; usedMemorySize: %d; deviceMemorySize: %d",
+		log.Errorf("getRemainingMemory discrepancy: accounted apps: %s; usedMemorySize: %d; deviceMemorySize: %d. Scheduling of checkRetry",
 			strings.Join(accountedApps, ", "), usedMemorySize, deviceMemorySize)
+		ctxPtr.checkFreedResources = true
 		return 0, latentMemorySize, haltingMemorySize, nil
 	} else {
 		return deviceMemorySize - usedMemorySize, latentMemorySize, haltingMemorySize, nil


### PR DESCRIPTION
Fix retry condition in case of no memory (remove all domains that are not in ActivateInprogress or Activated from the description)
Schedule checkRetry in case of errors of memory info from host or  discrepancy (we hit this for Xen where we can have 0 memory provided by `xl info` occasionally and seems we need to set checkFreedResources flag in case of memorysizemanagement errors).

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>