### PR TITLE
do setup again on retry

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -937,6 +937,21 @@ func maybeRetryBoot(ctx *domainContext, status *types.DomainStatus) {
 			status.Key(), status.Error)
 		status.ClearError()
 	}
+
+	filename := xenCfgFilename(config.AppNum)
+	file, err := os.Create(filename)
+	if err != nil {
+		//it is retry, so omit error
+		log.Error("os.Create for ", filename, err)
+	}
+	defer file.Close()
+
+	if err := hyper.Task(status).Setup(*status, *config, ctx.assignableAdapters, file); err != nil {
+		//it is retry, so omit error
+		log.Errorf("Failed to create DomainStatus from %v: %s",
+			config, err)
+	}
+
 	status.TriedCount += 1
 
 	ctx.createSema.V(1)


### PR DESCRIPTION
We have errors like `maybeRetryBoot DomainCreate for d37655e4-6895-40a9-bf8c-2d9727e4f203.10.1: CtrLoadContainer: Exception while loading container: container \"d37655e4-6895-40a9-bf8c-2d9727e4f203.10.1\" in namespace \"eve-user-apps\": not found` when we try to re-start our container with broken config, seems, we miss Setup stage in `maybeRetryBoot`.  `DomainCreate` do not do Setup again, so we hit such error inside.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>