### PR TITLE
Robustness fixes for offline mode

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -388,7 +388,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Parse any existing ConfigIntemValueMap but continue if there
 	// is none
 	for !domainCtx.GCComplete {
-		log.Functionf("waiting for GCComplete")
+		log.Noticef("waiting for GCComplete")
 		select {
 		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
@@ -408,7 +408,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		}
 		ps.StillRunning(agentName, warningTime, errorTime)
 	}
-	log.Functionf("processed GCComplete")
+	log.Noticef("processed GCComplete")
 
 	if !domainCtx.setInitialUsbAccess {
 		log.Functionf("GCComplete but not setInitialUsbAccess => first boot")
@@ -420,7 +420,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	// Pick up debug aka log level before we start real work
 	for !domainCtx.GCInitialized {
-		log.Functionf("waiting for GCInitialized")
+		log.Noticef("waiting for GCInitialized")
 		select {
 		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
@@ -440,7 +440,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		}
 		ps.StillRunning(agentName, warningTime, errorTime)
 	}
-	log.Functionf("processed GlobalConfig")
+	log.Noticef("processed GlobalConfig")
 
 	capabilitiesSended := false
 	if err := getAndPublishCapabilities(capabilitiesInfoPub); err != nil {
@@ -453,7 +453,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	if _, err := utils.WaitForOnboarded(ps, log, agentName, warningTime, errorTime); err != nil {
 		log.Fatal(err)
 	}
-	log.Functionf("processed onboarded")
+	log.Noticef("processed onboarded")
 
 	log.Functionf("Creating %s at %s", "metricsTimerTask", agentlog.GetMyStack())
 	go metricsTimerTask(&domainCtx, hyper)
@@ -463,7 +463,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// "pciback", then we wait for assignableAdapters.
 	for len(domainCtx.deviceNetworkStatus.Ports) == 0 ||
 		domainCtx.deviceNetworkStatus.Testing {
-		log.Functionf("Waiting for DeviceNetworkStatus ports %d Testing %t",
+		log.Noticef("Waiting for DeviceNetworkStatus ports %d Testing %t",
 			len(domainCtx.deviceNetworkStatus.Ports),
 			domainCtx.deviceNetworkStatus.Testing)
 		select {
@@ -488,6 +488,9 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		}
 		ps.StillRunning(agentName, warningTime, errorTime)
 	}
+	log.Noticef("Got DeviceNetworkStatus ports %d Testing %t",
+		len(domainCtx.deviceNetworkStatus.Ports),
+		domainCtx.deviceNetworkStatus.Testing)
 
 	// Subscribe to PhysicalIOAdapterList from zedagent
 	subPhysicalIOAdapter, err := ps.NewSubscription(
@@ -511,7 +514,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	// Wait for PhysicalIOAdapters to be initialized.
 	for !domainCtx.assignableAdapters.Initialized {
-		log.Functionf("Waiting for AssignableAdapters")
+		log.Noticef("Waiting for AssignableAdapters")
 		select {
 		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
@@ -542,7 +545,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		}
 		ps.StillRunning(agentName, warningTime, errorTime)
 	}
-	log.Functionf("Have %d assignable adapters", len(aa.IoBundleList))
+	log.Noticef("Have %d assignable adapters", len(aa.IoBundleList))
 
 	// Subscribe to DomainConfig from zedmanager
 	subDomainConfig, err := ps.NewSubscription(
@@ -2624,13 +2627,13 @@ func updatePortAndPciBackIoMember(ctx *domainContext, ib *types.IoBundle, isPort
 			log.Warningf("Not assigning %s (%s) to pciback due to error: %s at %s",
 				ib.Phylabel, ib.PciLong, ib.Error, ib.ErrorTime)
 		} else if ctx.deviceNetworkStatus.Testing && ib.Type.IsNet() {
-			log.Functionf("Not assigning %s (%s) to pciback due to Testing",
+			log.Noticef("Not assigning %s (%s) to pciback due to Testing",
 				ib.Phylabel, ib.PciLong)
 		} else if ctx.usbAccess && isInUsbGroup(*aa, *ib) {
-			log.Functionf("Not assigning %s (%s) to pciback due to usbAccess",
+			log.Noticef("Not assigning %s (%s) to pciback due to usbAccess",
 				ib.Phylabel, ib.PciLong)
 		} else if ib.PciLong != "" {
-			log.Functionf("Assigning %s (%s) to pciback",
+			log.Noticef("Assigning %s (%s) to pciback",
 				ib.Phylabel, ib.PciLong)
 			err := hyper.PCIReserve(ib.PciLong)
 			if err != nil {

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -458,11 +458,14 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	log.Functionf("Creating %s at %s", "metricsTimerTask", agentlog.GetMyStack())
 	go metricsTimerTask(&domainCtx, hyper)
 
-	// Wait for DeviceNetworkStatus to be init so we know the management
-	// ports and then wait for assignableAdapters.
-	for !domainCtx.DNSinitialized {
-
-		log.Functionf("Waiting for DeviceNetworkStatus init")
+	// Wait for DeviceNetworkStatus to have ports and done with testing
+	// so we know the management ports and the other ports are assigned to
+	// "pciback", then we wait for assignableAdapters.
+	for len(domainCtx.deviceNetworkStatus.Ports) == 0 ||
+		domainCtx.deviceNetworkStatus.Testing {
+		log.Functionf("Waiting for DeviceNetworkStatus ports %d Testing %t",
+			len(domainCtx.deviceNetworkStatus.Ports),
+			domainCtx.deviceNetworkStatus.Testing)
 		select {
 		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)

--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -521,6 +521,7 @@ func handleLastRebootReason(ctx *nodeagentContext) {
 	bootReason, ts := agentlog.GetBootReason(log)
 	if bootReason != types.BootReasonNone {
 		rebootTime = ts
+		log.Noticef("found bootReason %s", bootReason)
 	}
 
 	agentlog.DiscardBootReason(log)
@@ -537,6 +538,9 @@ func handleLastRebootReason(ctx *nodeagentContext) {
 			}
 		} else if previousSmartData.PowerCycleCount > -1 && smartData.PowerCycleCount > -1 &&
 			bootReason == types.BootReasonNone {
+			log.Noticef("previous power cycle count %d current %d",
+				previousSmartData.PowerCycleCount,
+				smartData.PowerCycleCount)
 			if previousSmartData.PowerCycleCount < smartData.PowerCycleCount {
 				reason = fmt.Sprintf("Reboot reason - device powered off. Restarted at %s",
 					dateStr)

--- a/pkg/pillar/cmd/zedagent/handleProfile.go
+++ b/pkg/pillar/cmd/zedagent/handleProfile.go
@@ -113,14 +113,15 @@ func parseAndValidateLocalProfile(localProfileBytes []byte, getconfigCtx *getcon
 
 // read saved local profile in case of particular reboot reason
 func readSavedLocalProfile(getconfigCtx *getconfigContext, validate bool) (*profile.LocalProfile, error) {
-	localProfileMessage, err := readSavedProtoMessage(
+	localProfileMessage, ts, err := readSavedProtoMessage(
 		getconfigCtx.zedagentCtx.globalConfig.GlobalValueInt(types.StaleConfigTime),
 		filepath.Join(checkpointDirname, savedLocalProfileFile), false)
 	if err != nil {
 		return nil, fmt.Errorf("readSavedLocalProfile: %v", err)
 	}
 	if localProfileMessage != nil {
-		log.Function("Using saved local profile")
+		log.Noticef("Using saved local profile dated %s",
+			ts.Format(time.RFC3339Nano))
 		if validate {
 			return parseAndValidateLocalProfile(localProfileMessage, getconfigCtx)
 		}

--- a/pkg/pillar/cmd/zedagent/validate.go
+++ b/pkg/pillar/cmd/zedagent/validate.go
@@ -12,7 +12,7 @@ import (
 
 func readValidateConfig(staleConfigTime uint32,
 	validateFile string) (bool, *zconfig.EdgeDevConfig) {
-	config, err := readSavedProtoMessageConfig(staleConfigTime, validateFile, true)
+	config, _, err := readSavedProtoMessageConfig(staleConfigTime, validateFile, true)
 	if err != nil {
 		fmt.Printf("getconfig: %v\n", err)
 		return false, nil

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -2052,6 +2052,11 @@ func updateACLIPAddr(ctx *zedrouterContext, changedDepend []types.ACLDepend) {
 		}
 		for i := range config.UnderlayNetworkList {
 			ulConfig := &config.UnderlayNetworkList[i]
+			if len(status.UnderlayNetworkList) <= i {
+				log.Noticef("updateACLIPAddr skipping ul %d %s: no status",
+					i, config.Key())
+				continue
+			}
 			ulStatus := &status.UnderlayNetworkList[i]
 			if ulStatus.ACLDependList == nil {
 				log.Tracef("updateACLIPAddr skipping ul %d %s: ACLDependList",

--- a/pkg/pillar/types/zedagenttypes.go
+++ b/pkg/pillar/types/zedagenttypes.go
@@ -332,7 +332,7 @@ func (br BootReason) StartWithSavedConfig() bool {
 	case BootReasonWatchdogPid:
 		return false
 	case BootReasonKernel:
-		return false
+		return true // XXX get false Kernel for power cycle events?
 	case BootReasonPowerFail:
 		return true
 	case BootReasonUnknown:


### PR DESCRIPTION
While nim publishes DeviceNetworkStatus with Testing set we do not
assign away any DeviceNetworkStatus to "pciback", hence we can not
succesfully boot any domains which have app-direct network adapters.

This solves the root cause also addressed by the retry logic in #2270 (which makes sense as well).

However, the detection of BootReasonPowerFail vs. BootReasonKernel doesn't seem to be robust against short power outages, so also need to address that.

Then it makes sense to add logging and increase the log levels for key messages related to offline mode.

Finally tripped on a zedrouter crash when testing this. so fixing that one as well.