### PR TITLE
Fix - stale ip address reported in app status

### DIFF
--- a/pkg/pillar/cmd/zedrouter/dnsmasq.go
+++ b/pkg/pillar/cmd/zedrouter/dnsmasq.go
@@ -526,7 +526,8 @@ func checkAndPublishDhcpLeases(ctx *zedrouterContext) {
 					continue
 				}
 				// Pick up from VIFIPTrig on change
-				if ulStatus.AllocatedIPv4Addr == "" {
+				if ulStatus.AllocatedIPv4Addr == "" ||
+					(netconfig.Type == types.NetworkInstanceTypeSwitch && !assignedIP.Equal(leasedIPv4)) {
 					ulStatus.IPAddrMisMatch = false
 					if !isEmptyIP(leasedIPv4) {
 						ulStatus.AllocatedIPv4Addr = leasedIPv4.String()


### PR DESCRIPTION
Description:
Handle the case when external DHCP server for a switch NI changes the leased out IP address to app.
Zedrouter should update app status with this new IP address.

Signed-off-by: Gopi krishna Kodali <gkodali@zededa.com>