### PR TITLE
Simplify the handling of AppNetworkConfig modifications

### DIFF
--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -1922,13 +1922,8 @@ func doNetworkInstanceFallback(
 					// use input match on uplinks.
 					// XXX no change in config
 					// XXX forcing a change
-					modData := types.AppNetworkUNetModifyData{
-						OldAppIP:      ulStatus.AllocatedIPv4Addr,
-						OldBridgeIP:   ulStatus.BridgeIPAddr,
-						OldBridgeName: bridgeName,
-					}
 					doAppNetworkModifyUNetAcls(ctx, &appNetworkStatus,
-						ulConfig, ulConfig, ulStatus, modData, ipsets, true)
+						ulConfig, ulConfig, ulStatus, ipsets, true)
 				}
 			}
 			publishAppNetworkStatus(ctx, &appNetworkStatus)
@@ -1981,13 +1976,8 @@ func doNetworkInstanceFallback(
 					// This should take care of re-programming any ACL rules that
 					// use input match on uplinks.
 					// XXX no change in config
-					modData := types.AppNetworkUNetModifyData{
-						OldAppIP:      ulStatus.AllocatedIPv4Addr,
-						OldBridgeIP:   ulStatus.BridgeIPAddr,
-						OldBridgeName: bridgeName,
-					}
 					doAppNetworkModifyUNetAcls(ctx, &appNetworkStatus,
-						ulConfig, ulConfig, ulStatus, modData, ipsets, true)
+						ulConfig, ulConfig, ulStatus, ipsets, true)
 				}
 			}
 			publishAppNetworkStatus(ctx, &appNetworkStatus)

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -2365,10 +2365,6 @@ type AppNetworkACLArgs struct {
 	NIType     NetworkInstanceType
 	// This is the same AppNum that comes from AppNetworkStatus
 	AppNum int32
-	// On change, collect this information
-	OldAppIP      string
-	OldBridgeIP   string
-	OldBridgeName string
 }
 
 // IPTablesRule : iptables rule detail
@@ -3005,10 +3001,3 @@ const (
 	MinSubnetSize   = 8   // minimum Subnet Size
 	LargeSubnetSize = 16  // for determining default Dhcp Range
 )
-
-// AppNetworkUNetModifyData :
-type AppNetworkUNetModifyData struct {
-	OldAppIP      string
-	OldBridgeIP   string
-	OldBridgeName string
-}


### PR DESCRIPTION
This was odd before and with the addition of the appOnUnet number got
quite complex. Restructuring the top modification code to make it easier
to follow and handling the different modification cases more clearly.

This removes some of the changes in #2058 since they are no longer needed as we inactivate an UnderlayNetworkStatus before doing the change to the network, which means a lot less special ACL handling logic since the inactive+activate rebuilds the ACLs.

Signed-off-by: eriknordmark <erik@zededa.com>