### PR TITLE
Suppress the ipv6 no-suitable-address huge error

### DIFF
--- a/pkg/pillar/cmd/downloader/resolveconfig.go
+++ b/pkg/pillar/cmd/downloader/resolveconfig.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/flextimer"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils"
+	logutils "github.com/lf-edge/eve/pkg/pillar/utils/logging"
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -275,7 +276,10 @@ func resolveTagsToHash(ctx *downloaderContext, rc types.ResolveConfig,
 				errStr = "tag resolution cancelled by user"
 				break
 			}
-			errStr = errStr + "\n" + err.Error()
+			// to catch and skip the oci manifest error with the suffix of "no suitable address found"
+			if !strings.HasSuffix(err.Error(), logutils.NoSuitableAddrStr) {
+				errStr = errStr + "\n" + err.Error()
+			}
 			continue
 		}
 		rs.ClearError()

--- a/pkg/pillar/cmd/downloader/syncop.go
+++ b/pkg/pillar/cmd/downloader/syncop.go
@@ -16,6 +16,7 @@ import (
 	"github.com/lf-edge/eve/libs/zedUpload"
 	"github.com/lf-edge/eve/pkg/pillar/cipher"
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	logutils "github.com/lf-edge/eve/pkg/pillar/utils/logging"
 	"github.com/lf-edge/eve/pkg/pillar/zedcloud"
 )
 
@@ -215,7 +216,14 @@ func handleSyncOp(ctx *downloaderContext, key string,
 				break
 			}
 			sourceFailureError(ipSrc.String(), ifname, metricsURL, err)
-			errStr = errStr + "\n" + err.Error()
+			// the error with "no suitable address found" for http schemes
+			// are suppressed inside httputil library.
+			// the S3 and Azure similar error have their own private error structure
+			// and can only be handled with string search here.
+			dnError := strings.Trim(err.Error(), "\n")
+			if !strings.HasSuffix(dnError, logutils.NoSuitableAddrStr) {
+				errStr = errStr + "\n" + err.Error()
+			}
 			continue
 		}
 		// Record how much we downloaded

--- a/pkg/pillar/utils/logging/log.go
+++ b/pkg/pillar/utils/logging/log.go
@@ -4,6 +4,8 @@ package logging
 
 import (
 	"fmt"
+	"net"
+	"net/url"
 	"runtime"
 	"strings"
 )
@@ -31,4 +33,35 @@ func GetMyStack() string {
 		output += fmt.Sprintf("%s()\n\t%s:%d\n", f.Function, f.File, f.Line)
 	}
 	return output
+}
+
+// NoSuitableAddrStr - the string to be used for checking the error message
+// Since the golang net package does not export this, we have to define it here again
+const NoSuitableAddrStr string = "no suitable address found"
+
+// IsNoSuitableAddrErr - the function to check 'no suitable address' for http mainly
+func IsNoSuitableAddrErr(err error) bool {
+	e0, ok := err.(*url.Error)
+	if !ok {
+		return false
+	}
+	e1, ok := e0.Err.(*net.OpError)
+	if !ok {
+		return false
+	}
+	switch t := e1.Err.(type) {
+	case *net.DNSError:
+		// seen this in http and oci cases
+		if strings.HasSuffix(t.Err, NoSuitableAddrStr) {
+			return true
+		}
+	case *net.AddrError:
+		// this was originally in send.go
+		if t.Err == NoSuitableAddrStr {
+			return true
+		}
+	default:
+		return false
+	}
+	return false
 }

--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -25,7 +25,8 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils"
-	"github.com/satori/go.uuid"
+	logutils "github.com/lf-edge/eve/pkg/pillar/utils/logging"
+	uuid "github.com/satori/go.uuid"
 	"github.com/vishvananda/netlink"
 )
 
@@ -486,7 +487,7 @@ func SendOnIntf(ctx *ZedCloudContext, destURL string, intf string, reqlen int64,
 					senderStatus = types.SenderStatusRefused
 				}
 				errorList = append(errorList, err)
-			} else if isNoSuitableAddress(err) {
+			} else if logutils.IsNoSuitableAddrErr(err) {
 				// We get lots of these due to IPv6 link-local
 				// only address on some interfaces.
 				// Do not return as errors
@@ -784,22 +785,6 @@ func isECONNREFUSED(err error) bool {
 		return false
 	}
 	return errno == syscall.ECONNREFUSED
-}
-
-func isNoSuitableAddress(err error) bool {
-	e0, ok := err.(*url.Error)
-	if !ok {
-		return false
-	}
-	e1, ok := e0.Err.(*net.OpError)
-	if !ok {
-		return false
-	}
-	e2, ok := e1.Err.(*net.AddrError)
-	if !ok {
-		return false
-	}
-	return e2.Err == "no suitable address found"
 }
 
 // NewContext - return initialized cloud context


### PR DESCRIPTION
Signed-off-by: Naiming Shen <naiming@zededa.com>

 Fix the long download error message due to 'no suitable address found' on IPv6
 - for http download, reduce multiple error lines into one, and log will show
   the message, error reason string only has the short 'skip no suitable address' string
   even for multiple ipv6 addresses and interfaces
 - for azure, s3, and docker only handles at syncop.go and resolveconfig.go routines
   since they don't retry multiple times inside
 - tested for http, azure, s3 and docker mechanisms