### PR TITLE
Fix fatal which escapted tests of #2058 

### DIFF
--- a/pkg/pillar/cmd/zedrouter/appnumonunet.go
+++ b/pkg/pillar/cmd/zedrouter/appnumonunet.go
@@ -270,9 +270,35 @@ func appNumOnUNetBaseDelete(ctx *zedrouterContext, baseID uuid.UUID) {
 			continue
 		}
 		if appNumMap.BaseID == baseID {
-			log.Fatalf("appNumOnUNetBaseDelete(): active persistent app nums")
+			log.Fatalf("appNumOnUNetBaseDelete(%s): remaining: %v",
+				baseID, appNumMap)
 		}
 	}
 	log.Functionf("appNumOnUNetBaseDelete (%s)", baseID.String())
 	delete(appNumBase, baseID.String())
+}
+
+// appNumOnUNetRefCount returns the number of (remaining) references to the network
+func appNumOnUNetRefCount(ctx *zedrouterContext, networkID uuid.UUID) int {
+	appNumMap := appNumOnUNetBaseGet(networkID)
+	if appNumMap == nil {
+		log.Fatalf("appNumOnUNetRefCount: non map")
+	}
+	pub := ctx.pubUUIDPairToNum
+	numType := appNumOnUNetType
+	items := pub.GetAll()
+	count := 0
+	for _, item := range items {
+		appNumMap := item.(types.UUIDPairToNum)
+		if appNumMap.NumType != numType {
+			continue
+		}
+		if appNumMap.BaseID == networkID {
+			log.Functionf("appNumOnUNetRefCount(%s): found: %v",
+				networkID, appNumMap)
+			count++
+		}
+	}
+	log.Functionf("appNumOnUNetRefCount(%s) found %d", networkID, count)
+	return count
 }

--- a/pkg/pillar/cmd/zedrouter/ipaddronunet.go
+++ b/pkg/pillar/cmd/zedrouter/ipaddronunet.go
@@ -13,6 +13,9 @@ import (
 
 func appNumsOnUNetAllocate(ctx *zedrouterContext,
 	config *types.AppNetworkConfig) error {
+
+	log.Functionf("appNumsOnUNetAllocate(%v) for %s",
+		config.UUIDandVersion, config.DisplayName)
 	for _, ulConfig := range config.UnderlayNetworkList {
 		isStatic := (ulConfig.AppIPAddr != nil)
 		appID := config.UUIDandVersion.UUID
@@ -33,6 +36,9 @@ func appNumsOnUNetAllocate(ctx *zedrouterContext,
 
 func appNumsOnUNetFree(ctx *zedrouterContext,
 	status *types.AppNetworkStatus) {
+
+	log.Functionf("appNumsOnUNetFree(%v) for %s",
+		status.UUIDandVersion, status.DisplayName)
 	appID := status.UUIDandVersion.UUID
 	for ulNum := 0; ulNum < len(status.UnderlayNetworkList); ulNum++ {
 		ulStatus := &status.UnderlayNetworkList[ulNum]

--- a/pkg/pillar/uuidpairtonum/uuidpairtonum.go
+++ b/pkg/pillar/uuidpairtonum/uuidpairtonum.go
@@ -110,6 +110,7 @@ func NumDelete(log *base.LogObject, pub pubsub.Publication,
 	if err != nil {
 		log.Fatalf("NumDelete(%s) does not exist", key)
 	}
+	log.Functionf("NumDelete(%s) unpublishing", key)
 	if err := pub.Unpublish(key); err != nil {
 		log.Fatalf("NumDelete(%s) unpublish failed %v", key, err)
 	}

--- a/tests/eden/eden-version
+++ b/tests/eden/eden-version
@@ -1,1 +1,1 @@
-lfedge/eden:30c8b3f
+lfedge/eden:8457206


### PR DESCRIPTION
The tests do not check if we hit a fatal post the cleanup; in this case the delete of the network instance and app instance would sometimes result in a log fatal which the tests did not catch.

Fix fatal error in appNumOnUNetBaseDelete which escaped testing

When we introduced the deferred free of Network Instance Status by
adding maybeNetworkInstanceDelete the criteria to delete was no more
vifs. But with the appNumOnUNet additions the criteria needs to be that
there are no more appNumOnUNets which refer to the Network Instance.
