### PR TITLE
Fix non-RTC systems re-generating device-cert on boot

### DIFF
--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -390,7 +390,8 @@ if [ ! -s $CONFIGDIR/device.cert.pem ] || [ $RTC = 0 ]; then
         sleep 10
         YEAR=$(date +%Y)
     done
-
+fi
+if [ ! -s $CONFIGDIR/device.cert.pem ]; then
     echo "$(date -Ins -u) Generating a device key pair and self-signed cert (using TPM/TEE if available)"
     if [ -c $TPM_DEVICE_PATH ] && ! [ -f $CONFIGDIR/disable-tpm ]; then
         echo "$(date -Ins -u) TPM device is present and allowed, creating TPM based device key"


### PR DESCRIPTION
In https://github.com/lf-edge/eve/pull/2247 the intent was to run ntp if
there is no RTC, but accidentally that also regenerats the device cert
if there is no RTC.

Signed-off-by: eriknordmark <erik@zededa.com>