### PR TITLE
check for validity of app assigned IP.

### DIFF
--- a/pkg/pillar/cmd/zedrouter/dnsmasq.go
+++ b/pkg/pillar/cmd/zedrouter/dnsmasq.go
@@ -515,7 +515,7 @@ func checkAndPublishDhcpLeases(ctx *zedrouterContext) {
 					ipv4Assigned, leasedIPv4.String(), ulStatus.Mac)
 			}
 			assignedIP := net.ParseIP(ulStatus.AllocatedIPv4Addr)
-			if ulStatus.IPv4Assigned != ipv4Assigned || !assignedIP.Equal(leasedIPv4) {
+			if ulStatus.IPv4Assigned != ipv4Assigned || assignedIP == nil || !assignedIP.Equal(leasedIPv4) {
 				log.Functionf("Changing(%s) %s mac %s to %t",
 					status.Key(), status.DisplayName,
 					ulStatus.Mac, ipv4Assigned)
@@ -526,7 +526,7 @@ func checkAndPublishDhcpLeases(ctx *zedrouterContext) {
 					continue
 				}
 				// Pick up from VIFIPTrig on change
-				if ulStatus.AllocatedIPv4Addr == "" ||
+				if ulStatus.AllocatedIPv4Addr == "" || assignedIP == nil ||
 					(netconfig.Type == types.NetworkInstanceTypeSwitch && !assignedIP.Equal(leasedIPv4)) {
 					ulStatus.IPAddrMisMatch = false
 					if !isEmptyIP(leasedIPv4) {
@@ -537,7 +537,7 @@ func checkAndPublishDhcpLeases(ctx *zedrouterContext) {
 						leasedIPv4.String())
 					continue
 				}
-				if !assignedIP.Equal(leasedIPv4) {
+				if assignedIP != nil && !assignedIP.Equal(leasedIPv4) {
 					log.Errorf("IP address mismatch found - App: %s, Mac: %s, Allocated IP: %s, Leased IP: %s",
 						status.DisplayName, ulStatus.Mac, ulStatus.AllocatedIPv4Addr, leasedIPv4.String())
 					ulStatus.IPAddrMisMatch = true


### PR DESCRIPTION
Signed-off-by: Gopi krishna Kodali <gkodali@zededa.com>

assignedIP pointer can be nil if the IP address present in app underlay status is not valid.
Make a NULL check before comparing assignedIP with other IP addresses.