### PR TITLE
Consistently report deleted objects in API

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -936,7 +936,6 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 
 	ReportAppInfo.AppID = uuid
 	ReportAppInfo.SystemApp = false
-	ReportAppInfo.State = info.ZSwState_HALTED
 	if aiStatus != nil {
 		ReportAppInfo.AppName = aiStatus.DisplayName
 		ReportAppInfo.State = aiStatus.State.ZSwState()
@@ -1075,7 +1074,6 @@ func PublishContentInfoToZedCloud(ctx *zedagentContext, uuid string,
 	ReportContentInfo := new(info.ZInfoContentTree)
 
 	ReportContentInfo.Uuid = uuid
-	ReportContentInfo.State = info.ZSwState_HALTED
 	if ctStatus != nil {
 		ReportContentInfo.DisplayName = ctStatus.DisplayName
 		ReportContentInfo.State = ctStatus.State.ZSwState()
@@ -1146,7 +1144,6 @@ func PublishVolumeToZedCloud(ctx *zedagentContext, uuid string,
 	ReportVolumeInfo := new(info.ZInfoVolume)
 
 	ReportVolumeInfo.Uuid = uuid
-	ReportVolumeInfo.State = info.ZSwState_INITIAL
 	if volStatus != nil {
 		ReportVolumeInfo.DisplayName = volStatus.DisplayName
 		ReportVolumeInfo.State = volStatus.State.ZSwState()


### PR DESCRIPTION
Eden is unnecessarily complex since it needs to infer which objects were
deleted using different fields. With this PR we always report with
State=0 when an object is deleted. In addition, if there is a Name field
we leave that as empty.

Signed-off-by: eriknordmark <erik@zededa.com>