### PR TITLE
sync github workflows and move to defined Eden version for 6.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,3 +47,8 @@ jobs:
         with:
           name: eve-${{ env.ARCH }}
           path: eve.tar
+      - name: Clean
+        run: |
+          make clean
+          docker system prune -f -a
+          rm -rf ~/.linuxkit

--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -6,7 +6,6 @@ on:
       - "master"
       - "[0-9]+.[0-9]+"
   pull_request_review:
-    branches: [master]
     types: [submitted]
 
 jobs:
@@ -24,22 +23,22 @@ jobs:
           done
       - name: setup
         run: |
-          sudo apt update
+          sudo add-apt-repository ppa:canonical-server/server-backports
           sudo apt install -y qemu-utils qemu-system-x86 jq
-      - name: get eden
-        uses: actions/checkout@v2
-        with:
-          repository: 'lf-edge/eden'
-      - name: build eden
-        run: |
-          make clean
-          make V=1 build
-          make V=1 build-tests
-          ./eden config add default
       - name: get eve
         uses: actions/checkout@v2
         with:
           path: 'eve'
+      - name: prepare eden
+        run: |
+          if [ -f ${{ github.workspace }}/eve/tests/eden/eden-version ]; then
+            EDEN_VERSION=$(cat ${{ github.workspace }}/eve/tests/eden/eden-version)
+          else
+            EDEN_VERSION=lfedge/eden:30c8b3f
+          fi
+          docker run -v $PWD:/out $EDEN_VERSION cp -a /eden/. /out/
+          sudo chown -R $(whoami) .
+          ./eden config add default
       - name: fetch or build eve
         env:
           TAG: pr${{ github.event.pull_request.number }}

--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -15,10 +15,6 @@ jobs:
       matrix:
         hv: ["kvm", "xen"]
     steps:
-      - name: get eden
-        uses: actions/checkout@v2
-        with:
-          repository: 'lf-edge/eden'
       - name: Check
         run: |
           for addr in $(ip addr list|sed -En -e 's/.*inet ([0-9.]+).*/\1/p')
@@ -54,14 +50,20 @@ jobs:
           sudo openvpn --config ./config.ovpn --daemon
           until ip -f inet addr show tun0; do sleep 5; ip a; done
           echo ::set-output name=tunnel_ip::$(ip -f inet addr show tun0 | sed -En -e 's/.*inet ([0-9.]+).*/\1/p')
-      - name: build eden
-        run: |
-          make build
-          make build-tests
       - name: get eve
         uses: actions/checkout@v2
         with:
           path: 'eve'
+      - name: prepare eden
+        run: |
+          if [ -f ${{ github.workspace }}/eve/tests/eden/eden-version ]; then
+            EDEN_VERSION=$(cat ${{ github.workspace }}/eve/tests/eden/eden-version)
+          else
+            EDEN_VERSION=lfedge/eden:30c8b3f
+          fi
+          docker run -v $PWD:/out $EDEN_VERSION cp -a /eden/. /out/
+          sudo chown -R $(whoami) .
+          ./eden config add default
       - name: setup
         run: |
           export ipv4=`curl https://api.ipify.org/?format=json | jq ".ip" -r`

--- a/tests/eden/app/testdata/2dockers_test.txt
+++ b/tests/eden/app/testdata/2dockers_test.txt
@@ -5,8 +5,8 @@
 
 eden -t 5s pod ps
 
-# Starting of reboot detector with a 3 reboots limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=1 &
+# Starting of reboot detector with a 1 reboots limit
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 # Run t1 docker
 eden -t 1m pod deploy -p 8027:80 docker://nginx -n t1 --memory 512MB

--- a/tests/eden/eclient/testdata/acl.txt
+++ b/tests/eden/eclient/testdata/acl.txt
@@ -18,11 +18,11 @@
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 # Starting of reboot detector with a 1 reboot limit
-! test eden.reboot.test -test.v -timewait 40m -reboot=0 -count=1 &
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 message 'Resetting of EVE'
 eden eve reset
-exec sleep 20
+exec sleep 30
 
 # use zededa.com IP address as a target for $fake_domain
 exec -t 10m bash dns_lookup.sh zededa.com
@@ -34,11 +34,11 @@ eden network create 10.11.12.0/24 -n {{$network_name}} -s {{$fake_domain}}:$host
 test eden.network.test -test.v -timewait 10m ACTIVATED {{$network_name}}
 
 # First app is only allowed to access github.com and $long_domain.
-eden pod deploy -n curl-acl1 --memory=512MB docker://itmoeve/eclient:0.4 -p 2223:22 --networks={{$network_name}} --acl={{$network_name}}:github.com --acl={{$network_name}}:{{$long_domain}}
+eden pod deploy -n curl-acl1 --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p 2223:22 --networks={{$network_name}} --acl={{$network_name}}:github.com --acl={{$network_name}}:{{$long_domain}}
 # Second app is only allowed to access $long_domain and $fake_domain.
-eden pod deploy -n curl-acl2 --memory=512MB docker://itmoeve/eclient:0.4 -p 2224:22 --networks={{$network_name}} --acl={{$network_name}}:{{$long_domain}} --acl={{$network_name}}:{{$fake_domain}}
+eden pod deploy -n curl-acl2 --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p 2224:22 --networks={{$network_name}} --acl={{$network_name}}:{{$long_domain}} --acl={{$network_name}}:{{$fake_domain}}
 
-test eden.app.test -test.v -timewait 10m RUNNING curl-acl1 curl-acl2
+test eden.app.test -test.v -timewait 15m RUNNING curl-acl1 curl-acl2
 
 exec -t 10m bash wait_ssh.sh 2223
 exec -t 10m bash wait_ssh.sh 2224

--- a/tests/eden/eclient/testdata/air-gapped-switch.txt
+++ b/tests/eden/eclient/testdata/air-gapped-switch.txt
@@ -15,12 +15,12 @@
 
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
-# Starting of reboot detector with 2 reboots limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+# Starting of reboot detector with 1 reboot limit
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 message 'Resetting of EVE'
 eden eve reset
-exec sleep 20
+exec sleep 30
 
 message 'Creating networks: local indirect and air-gapped switch direct'
 eden network create 10.11.12.0/24 -n indirect
@@ -29,11 +29,11 @@ eden network create --type switch --uplink none -n direct
 test eden.network.test -test.v -timewait 10m ACTIVATED indirect direct
 
 message 'Starting applications'
-eden pod deploy -v debug -n eclient1 docker://itmoeve/eclient:0.7 -p {{template "port1"}}:22 --networks=indirect --networks=direct:{{template "mac1"}} --memory=512MB
-eden pod deploy -v debug -n eclient2 docker://itmoeve/eclient:0.7 -p {{template "port2"}}:22 --networks=indirect --networks=direct:{{template "mac2"}} --memory=512MB
+eden pod deploy -v debug -n eclient1 docker://lfedge/eden-eclient:83cfe07 -p {{template "port1"}}:22 --networks=indirect --networks=direct:{{template "mac1"}} --memory=512MB
+eden pod deploy -v debug -n eclient2 docker://lfedge/eden-eclient:83cfe07 -p {{template "port2"}}:22 --networks=indirect --networks=direct:{{template "mac2"}} --memory=512MB
 
 message 'Waiting for running state'
-test eden.app.test -test.v -timewait 10m RUNNING eclient1 eclient2
+test eden.app.test -test.v -timewait 15m RUNNING eclient1 eclient2
 
 message 'Checking accessibility'
 exec -t 5m bash wait_ssh.sh {{template "port1"}} {{template "port2"}}

--- a/tests/eden/eclient/testdata/app_nonat.txt
+++ b/tests/eden/eclient/testdata/app_nonat.txt
@@ -10,12 +10,12 @@
 
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
-# Starting of reboot detector with 2 reboots limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+# Starting of reboot detector with 1 reboot limit
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 message 'Resetting of EVE'
 eden eve reset
-exec sleep 20
+exec sleep 30
 
 message 'Creating networks'
 eden network create 10.11.12.0/24 -n indirect
@@ -24,7 +24,7 @@ eden network create --type switch --uplink eth0 -n direct
 test eden.network.test -test.v -timewait 10m ACTIVATED indirect direct
 
 message 'Starting applications'
-eden pod deploy -v debug -n eclient docker://itmoeve/eclient:0.4 -p {{template "port"}}:22 --networks=indirect --networks=direct --memory=512MB
+eden pod deploy -v debug -n eclient docker://lfedge/eden-eclient:83cfe07 -p {{template "port"}}:22 --networks=indirect --networks=direct --memory=512MB
 
 message 'Waiting of running'
 test eden.app.test -test.v -timewait 30m RUNNING eclient

--- a/tests/eden/eclient/testdata/com-pt_test.txt
+++ b/tests/eden/eclient/testdata/com-pt_test.txt
@@ -16,7 +16,7 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 # Starting of reboot detector with a 2 reboot limit
 ! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
 
-eden pod deploy -n eclient --memory=512MB docker://itmoeve/eclient:0.7 -p {{template "port"}}:22
+eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{template "port"}}:22
 
 test eden.app.test -test.v -timewait 20m RUNNING eclient
 

--- a/tests/eden/eclient/testdata/disk.txt
+++ b/tests/eden/eclient/testdata/disk.txt
@@ -9,10 +9,10 @@
 
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
-# Starting of reboot detector with a 2 reboot limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+# Starting of reboot detector with a 1 reboot limit
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
-eden pod deploy -n eclient-disk --memory=512MB docker://itmoeve/eclient:0.4 -p {{$port}}:22 --disks=file://{{EdenConfig "eden.root"}}/empty.qcow2
+eden pod deploy -n eclient-disk --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{$port}}:22 --disks=file://{{EdenConfig "eden.root"}}/empty.qcow2
 
 test eden.app.test -test.v -timewait 20m RUNNING eclient-disk
 

--- a/tests/eden/eclient/testdata/eclient.txt
+++ b/tests/eden/eclient/testdata/eclient.txt
@@ -9,10 +9,10 @@
 
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
-# Starting of reboot detector with a 2 reboot limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+# Starting of reboot detector with a 1 reboot limit
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
-eden pod deploy -n eclient --memory=512MB docker://itmoeve/eclient:0.4 -p {{$port}}:22
+eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{$port}}:22
 
 test eden.app.test -test.v -timewait 20m RUNNING eclient
 

--- a/tests/eden/eclient/testdata/eclients.txt
+++ b/tests/eden/eclient/testdata/eclients.txt
@@ -6,7 +6,7 @@
 {{$apps := EdenGetEnv "EDEN_TEST_APPS"}}
 # Time of app waiting (default -- 30 min)
 {{$time := EdenGetEnv "EDEN_TEST_TIME"}}
-# Image for app (default -- docker://itmoeve/eclient:0.4)
+# Image for app (default -- docker://lfedge/eden-eclient:83cfe07)
 {{$img := EdenGetEnv "EDEN_TEST_IMG"}}
 
 {{$devmodel := EdenConfig "eve.devmodel"}}
@@ -21,9 +21,9 @@
 
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
-# Starting of reboot detector with a 2 reboot limit
-# Default time -- 30m
-! test eden.reboot.test -test.v -timewait {{if $time}}{{$time}}{{else}}30m{{end}} -reboot=0 -count=2 &
+# Starting of reboot detector with a 1 reboot limit
+# Default time -- infinite
+! test eden.reboot.test -test.v -timewait {{if $time}}{{$time}}{{else}}0{{end}} -reboot=0 -count=1 &
 
 # Default time -- 30m
 exec -t {{if $time}}{{$time}}{{else}}30m{{end}} bash ssh.sh
@@ -49,8 +49,8 @@ TAPP={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/eden.app.test
 HOST=$($EDEN eve ip)
 
 APPS="{{$apps}}"
-# Default image -- docker://itmoeve/eclient:0.4
-IMG="{{if $img}}{{$img}}{{else}}docker://itmoeve/eclient:0.4{{end}}"
+# Default image -- docker://lfedge/eden-eclient:83cfe07
+IMG="{{if $img}}{{$img}}{{else}}docker://lfedge/eden-eclient:83cfe07{{end}}"
 
 PORTS=""
 for i in `seq $APPS`
@@ -109,9 +109,9 @@ TAPP={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/eden.app.test
 HOST=$($EDEN eve ip)
 
 APPS="{{$apps}}"
-# Default image -- docker://itmoeve/eclient:0.4
-#IMG="{{if $img}}{{$img}}{{else}}docker://itmoeve/eclient:0.4{{end}}"
-IMG="{{if $img}}{{$img}}{{else}}docker://itmoeve/eclient:0.4{{end}}"
+# Default image -- docker://lfedge/eden-eclient:83cfe07
+#IMG="{{if $img}}{{$img}}{{else}}docker://lfedge/eden-eclient:83cfe07{{end}}"
+IMG="{{if $img}}{{$img}}{{else}}docker://lfedge/eden-eclient:83cfe07{{end}}"
 
 PODS=""
 for i in `seq $APPS`

--- a/tests/eden/eclient/testdata/host-only.txt
+++ b/tests/eden/eclient/testdata/host-only.txt
@@ -11,11 +11,11 @@
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 # Starting of reboot detector with a 1 reboot limit
-! test eden.reboot.test -test.v -timewait 40m -reboot=0 -count=1 &
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
-eden pod deploy -n ping-nw --memory=512MB docker://itmoeve/eclient:0.4 -p 2223:22
-eden pod deploy -n ping-fw --memory=512MB docker://itmoeve/eclient:0.4 -p 2224:22 --only-host=true
-eden pod deploy -n pong --memory=512MB docker://itmoeve/eclient:0.4
+eden pod deploy -n ping-nw --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p 2223:22
+eden pod deploy -n ping-fw --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p 2224:22 --only-host=true
+eden pod deploy -n pong --memory=512MB docker://lfedge/eden-eclient:83cfe07
 
 test eden.app.test -test.v -timewait 25m RUNNING ping-nw ping-fw pong
 

--- a/tests/eden/eclient/testdata/maridb.txt
+++ b/tests/eden/eclient/testdata/maridb.txt
@@ -12,10 +12,10 @@
 
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
-# Starting of reboot detector with a 2 reboot limit
-#! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+# Starting of reboot detector with a 1 reboot limit
+#! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
-eden pod deploy -n eclient --memory=512MB docker://itmoeve/eclient:0.4 -p {{template "port"}}:22
+eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{template "port"}}:22
 
 eden pod deploy -n {{$server}} --memory=512MB docker://mariadb:10.5.6-focal --metadata='MYSQL_ROOT_PASSWORD=adam&eve'
 

--- a/tests/eden/eclient/testdata/mount.txt
+++ b/tests/eden/eclient/testdata/mount.txt
@@ -9,11 +9,11 @@
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 # Starting of reboot detector with a 1 reboot limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=1 &
+! test eden.reboot.test -test.v -timewait 60m -reboot=0 -count=1 &
 
-eden pod deploy -n eclient-mount --memory=512MB docker://itmoeve/eclient:0.7 -p {{$port}}:22 --mount=src=docker://nginx:1.20.0,dst=/tst --mount=src={{EdenConfig "eden.tests"}}/eclient/testdata,dst=/dir
+eden pod deploy -n eclient-mount --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{$port}}:22 --mount=src=docker://nginx:1.20.0,dst=/tst --mount=src={{EdenConfig "eden.tests"}}/eclient/testdata,dst=/dir
 
-test eden.app.test -test.v -timewait 20m RUNNING eclient-mount
+test eden.app.test -test.v -timewait 21m RUNNING eclient-mount
 
 exec -t 5m bash ssh.sh /tst
 stdout 'docker-entrypoint.sh'

--- a/tests/eden/eclient/testdata/networking_light.txt
+++ b/tests/eden/eclient/testdata/networking_light.txt
@@ -11,14 +11,14 @@
 
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
-# Starting of reboot detector with a 2 reboot limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+# Starting of reboot detector with a 1 reboot limit
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
-eden pod deploy -n eclient --memory=512MB docker://itmoeve/eclient:0.4 -p {{template "port"}}:22
+eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{template "port"}}:22
 #eden -t 20m pod logs eclient
 #stdout 'Executing "/usr/sbin/sshd" "-D"'
 
-eden pod deploy -v warning -n eserver --memory=512MB docker://itmoeve/eclient:0.4
+eden pod deploy -v warning -n eserver --memory=512MB docker://lfedge/eden-eclient:83cfe07
 
 test eden.app.test -test.v -timewait 20m RUNNING eclient eserver
 

--- a/tests/eden/eclient/testdata/ngnix.txt
+++ b/tests/eden/eclient/testdata/ngnix.txt
@@ -12,10 +12,10 @@
 
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
-# Starting of reboot detector with a 2 reboot limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+# Starting of reboot detector with a 1 reboot limit
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
-eden pod deploy -n eclient --memory=512MB docker://itmoeve/eclient:0.4 -p {{template "port"}}:22
+eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{template "port"}}:22
 
 eden pod deploy -n {{$server}} --memory=512MB docker://nginx:latest
 

--- a/tests/eden/eclient/testdata/nw_switch.txt
+++ b/tests/eden/eclient/testdata/nw_switch.txt
@@ -10,12 +10,12 @@
 
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
-# Starting of reboot detector with 2 reboots limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+# Starting of reboot detector with 1 reboots limit
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 message 'Resetting of EVE'
 eden eve reset
-exec sleep 20
+exec sleep 30
 
 message 'Creating networks'
 #exec sleep 5
@@ -26,9 +26,9 @@ eden network create 10.11.13.0/24 -n n2
 test eden.network.test -test.v -timewait 10m ACTIVATED n1 n2
 
 message 'Starting applications'
-eden pod deploy -v debug -n ping1 docker://itmoeve/eclient:0.4 -p 2223:22 --networks=n1 --memory=512MB
-eden pod deploy -v debug -n ping2 docker://itmoeve/eclient:0.4 -p 2224:22 --networks=n2 --memory=512MB
-eden pod deploy -v debug -n pong docker://itmoeve/eclient:0.4 --networks=n1 --memory=512MB
+eden pod deploy -v debug -n ping1 docker://lfedge/eden-eclient:83cfe07 -p 2223:22 --networks=n1 --memory=512MB
+eden pod deploy -v debug -n ping2 docker://lfedge/eden-eclient:83cfe07 -p 2224:22 --networks=n2 --memory=512MB
+eden pod deploy -v debug -n pong docker://lfedge/eden-eclient:83cfe07 --networks=n1 --memory=512MB
 
 message 'Waiting of running'
 test eden.app.test -test.v -timewait 20m RUNNING ping1 ping2 pong
@@ -50,8 +50,7 @@ stdout '100% packet loss'
 
 message 'Switching to 2st network'
 eden pod modify pong --networks n2
-test eden.app.test -test.v -timewait 5m PURGING pong
-test eden.app.test -test.v -timewait 10m RUNNING pong
+test eden.app.test -test.v -timewait 15m RUNNING pong
 eden pod ps
 cp stdout pod_ps
 exec bash pong_ip.sh
@@ -66,8 +65,7 @@ stdout '0% packet loss'
 
 message 'Switching back to 1st network'
 eden pod modify pong --networks n1
-test eden.app.test -test.v -timewait 5m PURGING pong
-test eden.app.test -test.v -timewait 10m RUNNING pong
+test eden.app.test -test.v -timewait 15m RUNNING pong
 eden pod ps
 cp stdout pod_ps
 exec bash pong_ip.sh

--- a/tests/eden/eclient/testdata/port_forward.txt
+++ b/tests/eden/eclient/testdata/port_forward.txt
@@ -12,8 +12,8 @@
 
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
-# Starting of reboot detector with 2 reboots limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+# Starting of reboot detector with 1 reboots limit
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 message 'Resetting of EVE'
 eden eve reset
@@ -29,8 +29,8 @@ test eden.network.test -test.v -timewait 10m ACTIVATED n1
 exec sleep 10
 
 message 'SCENARIO 1: Starting with both application attached to same network instance'
-eden pod deploy -v debug -n app1 docker://itmoeve/eclient:0.6 -p 2223:22 --networks=n1 --memory=512MB
-eden pod deploy -v debug -n app2 docker://itmoeve/eclient:0.6 -p 2224:22 --networks=n1 --memory=512MB
+eden pod deploy -v debug -n app1 docker://lfedge/eden-eclient:83cfe07 -p 2223:22 --networks=n1 --memory=512MB
+eden pod deploy -v debug -n app2 docker://lfedge/eden-eclient:83cfe07 -p 2224:22 --networks=n1 --memory=512MB
 
 message 'SCENARIO 1: Waiting for apps to enter RUNNING state'
 test eden.app.test -test.v -timewait 20m RUNNING app1 app2
@@ -92,8 +92,8 @@ eden network create 10.11.13.0/24 -n n2 --uplink eth1
 test eden.network.test -test.v -timewait 10m ACTIVATED n1 n2
 
 message 'SCENARIO 2: Starting with each application attached to a different network instance'
-eden pod deploy -v debug -n app1 docker://itmoeve/eclient:0.6 -p 2223:22 --networks=n1 --memory=512MB
-eden pod deploy -v debug -n app2 docker://itmoeve/eclient:0.6 -p 2234:22 --networks=n2 --memory=512MB
+eden pod deploy -v debug -n app1 docker://lfedge/eden-eclient:83cfe07 -p 2223:22 --networks=n1 --memory=512MB
+eden pod deploy -v debug -n app2 docker://lfedge/eden-eclient:83cfe07 -p 2234:22 --networks=n2 --memory=512MB
 
 message 'SCENARIO 2: Waiting for apps to enter RUNNING state'
 test eden.app.test -test.v -timewait 20m RUNNING app1 app2

--- a/tests/eden/eclient/testdata/port_switch.txt
+++ b/tests/eden/eclient/testdata/port_switch.txt
@@ -4,7 +4,7 @@
 [!exec:sleep] stop
 
 # Starting of reboot detector with 2 reboots limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=2 &
 
 eden pod deploy -p 8027:80 docker://nginx -v debug -n nginx --memory=512MB
 

--- a/tests/eden/eclient/testdata/profile.txt
+++ b/tests/eden/eclient/testdata/profile.txt
@@ -12,21 +12,21 @@
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 # Starting of reboot detector with a 1 reboot limit
-! test eden.reboot.test -test.v -timewait 100m -reboot=0 -count=1 &
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 message 'Resetting of EVE'
 eden eve reset
-exec sleep 20
+exec sleep 30
 
 # Define local-manager and two apps in different profiles
 # TBD: static ip in pod deploy
-eden pod deploy -n local-manager --memory=512MB docker://itmoeve/eclient:0.8 -p 2223:22
+eden pod deploy -n local-manager --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p 2223:22
 
-test eden.app.test -test.v -timewait 10m RUNNING local-manager
+test eden.app.test -test.v -timewait 15m RUNNING local-manager
 
-eden pod deploy -n app-profile-1 --memory=512MB docker://itmoeve/eclient:0.8 --profile=profile-1
-eden pod deploy -n app-profile-2 --memory=512MB docker://itmoeve/eclient:0.8 --profile=profile-2
-eden pod deploy -n app-profile-1-2 --memory=512MB docker://itmoeve/eclient:0.8 --profile=profile-1 --profile=profile-2
+eden pod deploy -n app-profile-1 --memory=512MB docker://lfedge/eden-eclient:83cfe07 --profile=profile-1
+eden pod deploy -n app-profile-2 --memory=512MB docker://lfedge/eden-eclient:83cfe07 --profile=profile-2
+eden pod deploy -n app-profile-1-2 --memory=512MB docker://lfedge/eden-eclient:83cfe07 --profile=profile-1 --profile=profile-2
 
 # We have empty local_manager and empty default_profile, so apps should be in RUNNING state
 test eden.app.test -test.v -timewait 20m RUNNING app-profile-1 app-profile-2 app-profile-1-2 local-manager

--- a/tests/eden/eclient/testdata/usb-pt_test.txt
+++ b/tests/eden/eclient/testdata/usb-pt_test.txt
@@ -10,10 +10,10 @@
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 # Starting of reboot detector with a 2 reboot limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=2 &
 
-eden pod deploy -n n1 --memory=512MB docker://itmoeve/eclient:0.4 -p 2223:22
-eden pod deploy -n n2 --memory=512MB docker://itmoeve/eclient:0.4 -p 2224:22 --adapters USB2:2
+eden pod deploy -n n1 --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p 2223:22
+eden pod deploy -n n2 --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p 2224:22 --adapters USB2:2
 
 test eden.app.test -test.v -timewait 20m RUNNING n1 n2
 

--- a/tests/eden/eden-version
+++ b/tests/eden/eden-version
@@ -1,0 +1,1 @@
+lfedge/eden:3f33a03

--- a/tests/eden/flir/testdata/test_flir.txt
+++ b/tests/eden/flir/testdata/test_flir.txt
@@ -6,7 +6,7 @@
 # This test deploys fledge docker image into EVE to test Flir Camera data
 
 # deploy the application
-eden pod deploy -p 8027:80 -p 8028:8081  --name=fledge --memory=2GB --cpus=2  docker://itmoeve/fledgeeveflirdemo:1.8.2  -v debug
+eden pod deploy -p 8027:80 -p 8028:8081  --name=fledge --memory=2GB --cpus=2  docker://lfedge/eden-fledgeeveflirdemo:83cfe07  -v debug
 
 test eden.app.test -test.v -timewait 20m RUNNING fledge
 

--- a/tests/eden/hardware_reboot/testdata/hardware_2usb_reboot.txt
+++ b/tests/eden/hardware_reboot/testdata/hardware_2usb_reboot.txt
@@ -9,9 +9,9 @@
 [!exec:ssh] stop
 
 # Starting of reboot detector with a 2 reboot limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=2 &
 
-eden pod deploy -n eclient --memory=512MB docker://itmoeve/eclient:0.7 -p {{template "port"}}:22 --adapters USB2:2 --adapters USB2:3
+eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{template "port"}}:22 --adapters USB2:2 --adapters USB2:3
 
 test eden.app.test -test.v -timewait 20m RUNNING eclient
 

--- a/tests/eden/hardware_reboot/testdata/hardware_audio_reboot.txt
+++ b/tests/eden/hardware_reboot/testdata/hardware_audio_reboot.txt
@@ -8,7 +8,7 @@
 [!exec:ssh] stop
 
 # Starting of eve reboot detector with a 1 reboot limit
-! test eden.reboot.test -test.v -timewait 60m -reboot=0 -count=1 &
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 exec -t 20m bash deploy.sh {{template "port"}}
 test eden.app.test -test.v -timewait 30m RUNNING eclient

--- a/tests/eden/io_performance/testdata/fio_tests.txt
+++ b/tests/eden/io_performance/testdata/fio_tests.txt
@@ -7,7 +7,7 @@
 {{$volume_type := EdenGetEnv "VOLUME_TYPE"}}
 
 # Deploy the application
-eden pod deploy --volume-type={{if $volume_type}}{{$volume_type}}{{else}}qcow2{{end}} --metadata='EVE_VERSION={{EdenConfig "eve.tag"}}\nGIT_BRANCH={{EdenGetEnv "GIT_BRANCH"}}\nGIT_REPO={{EdenGetEnv "GIT_REPO"}}\nGIT_FOLDER={{EdenGetEnv "GIT_FOLDER"}}\nGIT_PATH={{EdenGetEnv "GIT_PATH"}}\nGIT_LOGIN={{EdenGetEnv "GIT_LOGIN"}}\nGIT_TOKEN={{EdenGetEnv "GIT_TOKEN"}}\nFIO_TIME={{EdenGetEnv "FIO_TIME"}}\nFIO_OPTYPE={{EdenGetEnv "FIO_OPTYPE"}}\nFIO_BS={{EdenGetEnv "FIO_BS"}}\nFIO_JOBS={{EdenGetEnv "FIO_JOBS"}}\nFIO_DEPTH={{EdenGetEnv "FIO_DEPTH"}}' --name=fio_test --memory=2GB --cpus=2 docker://itmoeve/fio_tests:v.1.2.1 --volume-size=2GB
+eden pod deploy --volume-type={{if $volume_type}}{{$volume_type}}{{else}}qcow2{{end}} --metadata='EVE_VERSION={{EdenConfig "eve.tag"}}\nGIT_BRANCH={{EdenGetEnv "GIT_BRANCH"}}\nGIT_REPO={{EdenGetEnv "GIT_REPO"}}\nGIT_FOLDER={{EdenGetEnv "GIT_FOLDER"}}\nGIT_PATH={{EdenGetEnv "GIT_PATH"}}\nGIT_LOGIN={{EdenGetEnv "GIT_LOGIN"}}\nGIT_TOKEN={{EdenGetEnv "GIT_TOKEN"}}\nFIO_TIME={{EdenGetEnv "FIO_TIME"}}\nFIO_OPTYPE={{EdenGetEnv "FIO_OPTYPE"}}\nFIO_BS={{EdenGetEnv "FIO_BS"}}\nFIO_JOBS={{EdenGetEnv "FIO_JOBS"}}\nFIO_DEPTH={{EdenGetEnv "FIO_DEPTH"}}' --name=fio_test --memory=2GB --cpus=2 docker://lfedge/eden-fio-tests:83cfe07 --volume-size=2GB
 
 test eden.app.test -test.v -timewait 5m RUNNING fio_test
 

--- a/tests/eden/network/testdata/deploy_app.txt
+++ b/tests/eden/network/testdata/deploy_app.txt
@@ -2,4 +2,4 @@
 
 message {{$env_net}}
 
-eden pod deploy {{EdenGetEnv "external_port"}} --memory=300M --metadata='url={{EdenGetEnv "metadata"}}' --name='{{EdenGetEnv "name"}}' --networks={{ $env_net }} --vnc-display={{ EdenGetEnv "vnc" }} --only-host={{ EdenGetEnv "firewall" }}  docker://itmoeve/docker-test:1.2
+eden pod deploy {{EdenGetEnv "external_port"}} --memory=300M --metadata='url={{EdenGetEnv "metadata"}}' --name='{{EdenGetEnv "name"}}' --networks={{ $env_net }} --vnc-display={{ EdenGetEnv "vnc" }} --only-host={{ EdenGetEnv "firewall" }}  docker://lfedge/eden-docker-test:83cfe07

--- a/tests/eden/network/testdata/network_test.txt
+++ b/tests/eden/network/testdata/network_test.txt
@@ -1,7 +1,7 @@
-eden -t 5s network ls
+eden -t 10s network ls
 
 # Starting of reboot detector with a 1 reboot limit
-! test eden.reboot.test -test.v -timewait 20m -reboot=0 -count=1 &
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 # Create n1 network
 eden -t 1m network create 10.11.12.0/24 -n n1

--- a/tests/eden/phoronix/testdata/deploy_app.txt
+++ b/tests/eden/phoronix/testdata/deploy_app.txt
@@ -1,1 +1,1 @@
-eden pod deploy {{EdenGetEnv "external_port"}} --metadata='BENCHMARK={{EdenGetEnv "benchmark"}}' --name='{{EdenGetEnv "name"}}' --memory=2GB --cpus=2 docker://itmoeve/phoronix-test:1.2
+eden pod deploy {{EdenGetEnv "external_port"}} --metadata='BENCHMARK={{EdenGetEnv "benchmark"}}' --name='{{EdenGetEnv "name"}}' --memory=2GB --cpus=2 docker://lfedge/eden-phoronix-test:83cfe07

--- a/tests/eden/registry/testdata/registry_test.txt
+++ b/tests/eden/registry/testdata/registry_test.txt
@@ -3,10 +3,10 @@
 [!exec:cut] stop
 [!exec:grep] stop
 
-eden -t 5s pod ps
+eden -t 10s pod ps
 
-# Starting of reboot detector with a 3 reboots limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=1 &
+# Starting of reboot detector with a 1 reboot limit
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 # Upload image to registry
 eden -t 5m registry load nginx

--- a/tests/eden/vnc/testdata/vnc_test.txt
+++ b/tests/eden/vnc/testdata/vnc_test.txt
@@ -1,7 +1,7 @@
 {{$test_opts := "-test.v -name vnc-app"}}
 
 # Starting of reboot detector with a 1 reboot limit
-! test eden.reboot.test -test.v -timewait 45m -reboot=0 -count=1 &
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 #TestVNCVMStart checks if app processed by EVE, app in RUNNING state
 test eden.vnc.test {{$test_opts}} -timewait 15m -test.run TestVNCVMStart

--- a/tests/eden/volume/testdata/volume_sftp.txt
+++ b/tests/eden/volume/testdata/volume_sftp.txt
@@ -1,7 +1,7 @@
 eden -t 5s volume ls
 
 # Starting of reboot detector with a 1 reboots limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=1 &
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 # Create volume and force EVE to load it via SFTP
 eden -t 1m volume create -n v-qcow2-sftp file://{{EdenConfig "eden.root"}}/empty.qcow2 --format=qcow2 --disk-size=200M --sftp=true

--- a/tests/eden/volume/testdata/volumes_test.txt
+++ b/tests/eden/volume/testdata/volumes_test.txt
@@ -1,11 +1,11 @@
 eden -t 10s volume ls
 
 # Starting of reboot detector with a 1 reboots limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=1 &
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 # Create v1 volume
-eden -t 1m volume create -n v-docker docker://itmoeve/eclient:0.4 --disk-size=200M
-stdout 'create volume v-docker with docker://itmoeve/eclient:0.4 request sent'
+eden -t 1m volume create -n v-docker docker://lfedge/eden-eclient:83cfe07 --disk-size=200M
+stdout 'create volume v-docker with docker://lfedge/eden-eclient:83cfe07 request sent'
 eden -t 1m volume create -n v-qcow2 file://{{EdenConfig "eden.root"}}/empty.qcow2 --format=qcow2 --disk-size=200M
 stdout 'create volume v-qcow2 with file://{{EdenConfig "eden.root"}}/empty.qcow2 request sent'
 eden -t 1m volume create -n v-qcow file://{{EdenConfig "eden.root"}}/empty.qcow --format=qcow --disk-size=560

--- a/tests/eden/workflow/eden.workflow.tests.txt
+++ b/tests/eden/workflow/eden.workflow.tests.txt
@@ -3,7 +3,9 @@
 # EDEN_TEST env. var. -- flavour of test set: "small", "medium"(default) and "large"
 {{$workflow := EdenGetEnv "EDEN_TEST"}}
 # EDEN_TEST_SETUP env. var. -- "y"(default) performs the EDEN setup steps
-{{$setup := EdenGetEnv "EDEN_TEST_SETUP"}}
+{{$setup := "y"}}
+{{$setup_env := EdenGetEnv "EDEN_TEST_SETUP"}}
+{{if $setup_env}}{{$setup = $setup_env}}{{end}}
 # EDEN_TEST_STOP -- "y" stops EDEN after tests ("n" by default)
 {{$stop := EdenGetEnv "EDEN_TEST_STOP"}}
 # EDEN_TEST_USB_PT -- "y" enables USB Passthrough test (disabled by default).

--- a/tests/eden/workflow/testdata/deploy_docker_eden.txt
+++ b/tests/eden/workflow/testdata/deploy_docker_eden.txt
@@ -3,7 +3,7 @@
 [!exec:grep] stop
 
 # Fail if reboot
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=1 &
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 eden pod deploy -p 8028:80 docker://nginx
 stdout 'deploy pod .* with docker://nginx request sent'


### PR DESCRIPTION
Sync github workflows and move to defined Eden version. We need particular version to unlink Eden on release branch (6.8) from upstream.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>