### PR TITLE
Adding INVENTORY partition to the protective MBR

### DIFF
--- a/pkg/mkimage-raw-efi/make-raw
+++ b/pkg/mkimage-raw-efi/make-raw
@@ -120,6 +120,8 @@ do_system_vfat_part() {
   local SEC_END="$(grow_part "$SEC_START" "$2")"
   local NUM_PART=$(( PART_OFFSET + 1 ))
 
+  PROTECTIVE_MBR_LIST="$PROTECTIVE_MBR_LIST$NUM_PART:"
+
   # Create a partition
   sgdisk --new "$NUM_PART:$SEC_START:$SEC_END" --typecode="$NUM_PART:ef00" --change-name="$NUM_PART":'EFI System' \
          --attributes "$NUM_PART:set:2" "$IMGFILE"
@@ -214,6 +216,8 @@ do_inventory_win() {
     local NUM_PART=$(( PART_OFFSET + 5 ))
     local PART_TYPE=EBD0A0A2-B9E5-4433-87C0-68B6B72699C7
 
+    PROTECTIVE_MBR_LIST="$PROTECTIVE_MBR_LIST$(( PART_OFFSET + 4 )):$NUM_PART:"
+
     sgdisk --new "$NUM_PART:$SEC_START:$SEC_END" \
            --typecode="$NUM_PART:$PART_TYPE" \
            --change-name="$NUM_PART:INVENTORY" "$IMGFILE"
@@ -283,14 +287,23 @@ adjust_protective_mbr() {
     # order to make sone legacy BIOS implementations happy. Strictly speaking, this
     # goes against good recommendations of how to build a protective MBR for the GPT
     # but it doesn't seem to cause any troubles and it helps with compabitlity.
-    PROT_PART=$(busybox hexdump -s 446 -n 16 -v -e '"" 16/1 "\\%03o"' "$IMGFILE")
-    NULL_PART="\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
-    # we need to replace 1st byte with \200 (bootable) and 4th byte with \014 (vfat filesystem type)
-    BOOT_PART=$(busybox hexdump -s $(( 446 + 17 )) -n 3 -v -e '"\\200" 3/1 "\\%03o" "\\014"' "$IMGFILE")
-    BOOT_PART="$BOOT_PART"$(busybox hexdump -s $(( 446 + 21 )) -n 11 -v -e '"" 11/1 "\\%03o"' "$IMGFILE")
-    # sadly, busybox doesn't support xxd -r -- so make do with printf that interprets \ooo escape sequences
-    #shellcheck disable=SC2059
-    printf "${BOOT_PART}${PROT_PART}${NULL_PART}${NULL_PART}" | dd of="$IMGFILE" bs=1 seek=446 conv=noerror,sync,notrunc
+    # On top of that we need to mark 1st MBR partition bootable and vfat type to
+    # make legacy BIOSes real happy:
+    (fdisk "$IMGFILE" > /dev/null <<__EOT__
+M
+a
+1
+t
+1
+c
+w
+q
+__EOT__
+    ) || :
+    # the : above is here to make sure fdisk doesn't get too upset about us not using
+    # an actual device, but a file instead. In the ideal world, we would be able to
+    # catch other errors, but this particular usecase of fdisk is so trivial, that we
+    # shouldn't be too concerned about missing much.
 }
 
 
@@ -357,7 +370,7 @@ done
 
 # Create a hybrid MBR to allow booting on legacy BIOS PC systems and ARM boards that
 # look for bootloaders in the first entry of the MBR
-sgdisk -h$(( PART_OFFSET + 1 )) "$IMGFILE"
+sgdisk -h"${PROTECTIVE_MBR_LIST}EE" "$IMGFILE"
 
 # if we happen to be building an x86 image - deploy legacy GRUB into the GPT gap
 if [ -e /efifs/EFI/BOOT/BOOT.pc ]; then


### PR DESCRIPTION
After a lot of tweaking and trial-and-error with windows and various BIOSes here's a tweak that appears to be minimal and functional. What it is trying to address is the fact that on Windows we need to make sure INVENTORY partition is recognized by the operating system via protective MBR (otherwise it won't be visible when a USB stick is inserted into a computer runnings Windows).

With this in place, protective MBR will now have 4 elements:
   1. EFI boot partition
   2. config partition
   3. INVENTORY partition
   4. Protective MBR entry
 
Before we only had №1 and №2+4 mushed together (don't ask why it made sense -- it did at the time ;-)).

Long story short, with this now in place, both Mac OS X and Windows (including older versions) appear to be happy with reading INVENTORY partition on our USB stick.

This is also the basis for my next proposal -- which is combining №1 and №2 since it really makes much more sense to have the content of the №2 in a folder inside of №1 (hence a bit of a hacky code in this patch -- but the good news is that it is going away real soon).

Finally, given this new scheme -- it became possible to use fdisk instead of the `dd` hackery to adjust protective MBR entries.