### PR TITLE
Handle controller modifying the device UUID

### DIFF
--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -440,6 +440,17 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		} else {
 			log.Functionf("Got config with UUID %s", devUUID)
 		}
+		if doWrite {
+			// Set the kernel hostname
+			cmd := "/bin/hostname"
+			cmdArgs := []string{devUUID.String()}
+			log.Noticef("Calling command %s %v", cmd, cmdArgs)
+			out, err := base.Exec(log, cmd, cmdArgs...).CombinedOutput()
+			if err != nil {
+				log.Errorf("hostname command %s failed %s output %s",
+					cmdArgs, err, out)
+			}
+		}
 		_, err := os.Stat(uuidFileName)
 		if err != nil {
 			doWrite = true

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -908,7 +908,6 @@ func tryPostUUID(ctx *diagContext, ifname string) bool {
 	}
 	zedcloudCtx := ctx.zedcloudCtx
 
-	reqURL := zedcloud.URLPathString(ctx.serverNameAndPort, zedcloudCtx.V2API, ctx.devUUID, "config")
 	// Set the TLS config on each attempt in case it has changed due to proxies etc
 	err = zedcloud.UpdateTLSConfig(zedcloudCtx, ctx.serverName, ctx.cert)
 	if err != nil {
@@ -926,6 +925,8 @@ func tryPostUUID(ctx *diagContext, ifname string) bool {
 		time.Sleep(delay)
 		var resp *http.Response
 		var buf []byte
+		reqURL := zedcloud.URLPathString(ctx.serverNameAndPort, zedcloudCtx.V2API,
+			ctx.devUUID, "config")
 		done, resp, rtf, buf = myPost(ctx, reqURL, ifname, retryCount,
 			int64(len(b)), bytes.NewBuffer(b))
 		if done {
@@ -1056,6 +1057,9 @@ func myGet(ctx *diagContext, reqURL string, ifname string,
 				ifname, reqURL)
 		case types.SenderStatusCertMiss:
 			fmt.Fprintf(outfile, "ERROR: %s: get %s Controller certificate miss\n",
+				ifname, reqURL)
+		case types.SenderStatusNotFound:
+			fmt.Fprintf(outfile, "ERROR: %s: get %s Did controller delete the device?\n",
 				ifname, reqURL)
 		default:
 			fmt.Fprintf(outfile, "ERROR: %s: get %s failed: %s\n",

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -449,8 +449,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		capabilitiesSended = true
 	}
 
-	// Wait until we have been onboarded aka know our own UUID
-	if _, err := utils.WaitForOnboarded(ps, log, agentName, warningTime, errorTime); err != nil {
+	// Wait until we have been onboarded aka know our own UUID however we do not use the UUID
+	if err := utils.WaitForOnboarded(ps, log, agentName, warningTime, errorTime); err != nil {
 		log.Fatal(err)
 	}
 	log.Noticef("processed onboarded")

--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -291,8 +291,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	ctxPtr.subDomainStatus = subDomainStatus
 	subDomainStatus.Activate()
 
-	// Wait until we have been onboarded aka know our own UUID
-	if _, err := utils.WaitForOnboarded(ps, log, agentName, warningTime, errorTime); err != nil {
+	// Wait until we have been onboarded aka know our own UUID however we do not use the UUID
+	if err := utils.WaitForOnboarded(ps, log, agentName, warningTime, errorTime); err != nil {
 		log.Fatal(err)
 	}
 	log.Functionf("Device is onboarded")

--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -338,7 +338,7 @@ func sendAttestReqProtobuf(attestReq *attest.ZAttestReq, iteration int) {
 		log.Fatal("SendInfoProtobufStr proto marshaling error: ", err)
 	}
 
-	deferKey := "attest:" + zcdevUUID.String()
+	deferKey := "attest:" + devUUID.String()
 
 	attestURL := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API,
 		devUUID, "attest")

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -551,7 +551,6 @@ func inhaleDeviceConfig(config *zconfig.EdgeDevConfig, getconfigCtx *getconfigCo
 				devUUID.String(), id.String())
 			potentialUUIDUpdate(getconfigCtx)
 			return false
-			// XXX set the hostname in client.go instead of device-steps.sh
 		}
 		newControllerEpoch := config.GetControllerEpoch()
 		if controllerEpoch != newControllerEpoch {

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -226,7 +226,7 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 	ReportDeviceMetric.Memory = new(metrics.MemoryMetric)
 	ReportDeviceMetric.CpuMetric = new(metrics.AppCpuMetric)
 
-	ReportMetrics.DevID = *proto.String(zcdevUUID.String())
+	ReportMetrics.DevID = *proto.String(devUUID.String())
 	ReportZmetric := new(metrics.ZmetricTypes)
 	*ReportZmetric = metrics.ZmetricTypes_ZmDevice
 
@@ -929,7 +929,7 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 	appType := new(info.ZInfoTypes)
 	*appType = info.ZInfoTypes_ZiApp
 	ReportInfo.Ztype = *appType
-	ReportInfo.DevId = *proto.String(zcdevUUID.String())
+	ReportInfo.DevId = *proto.String(devUUID.String())
 	ReportInfo.AtTimeStamp = ptypes.TimestampNow()
 
 	ReportAppInfo := new(info.ZInfoApp)
@@ -1068,7 +1068,7 @@ func PublishContentInfoToZedCloud(ctx *zedagentContext, uuid string,
 	contentType := new(info.ZInfoTypes)
 	*contentType = info.ZInfoTypes_ZiContentTree
 	ReportInfo.Ztype = *contentType
-	ReportInfo.DevId = *proto.String(zcdevUUID.String())
+	ReportInfo.DevId = *proto.String(devUUID.String())
 	ReportInfo.AtTimeStamp = ptypes.TimestampNow()
 
 	ReportContentInfo := new(info.ZInfoContentTree)
@@ -1138,7 +1138,7 @@ func PublishVolumeToZedCloud(ctx *zedagentContext, uuid string,
 	volumeType := new(info.ZInfoTypes)
 	*volumeType = info.ZInfoTypes_ZiVolume
 	ReportInfo.Ztype = *volumeType
-	ReportInfo.DevId = *proto.String(zcdevUUID.String())
+	ReportInfo.DevId = *proto.String(devUUID.String())
 	ReportInfo.AtTimeStamp = ptypes.TimestampNow()
 
 	ReportVolumeInfo := new(info.ZInfoVolume)
@@ -1214,7 +1214,7 @@ func PublishBlobInfoToZedCloud(ctx *zedagentContext, blobSha string, blobStatus 
 	contentType := new(info.ZInfoTypes)
 	*contentType = info.ZInfoTypes_ZiBlobList
 	ReportInfo.Ztype = *contentType
-	ReportInfo.DevId = *proto.String(zcdevUUID.String())
+	ReportInfo.DevId = *proto.String(devUUID.String())
 	ReportInfo.AtTimeStamp = ptypes.TimestampNow()
 
 	ReportBlobInfoList := new(info.ZInfoBlobList)

--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -71,7 +71,7 @@ func prepareAndPublishNetworkInstanceInfoMsg(ctx *zedagentContext,
 	infoMsg := &zinfo.ZInfoMsg{}
 	infoType := new(zinfo.ZInfoTypes)
 	*infoType = zinfo.ZInfoTypes_ZiNetworkInstance
-	infoMsg.DevId = *proto.String(zcdevUUID.String())
+	infoMsg.DevId = *proto.String(devUUID.String())
 	infoMsg.Ztype = *infoType
 	infoMsg.AtTimeStamp = ptypes.TimestampNow()
 
@@ -133,7 +133,7 @@ func prepareAndPublishNetworkInstanceInfoMsg(ctx *zedagentContext,
 			reportAA.Type = zcommon.PhyIoType(ia.Type)
 			reportAA.Name = ia.Logicallabel
 			// XXX Add Phylabel in protobuf message?
-			reportAA.UsedByAppUUID = zcdevUUID.String()
+			reportAA.UsedByAppUUID = devUUID.String()
 			list := ctx.assignableAdapters.LookupIoBundleAny(ia.Phylabel)
 			for _, ib := range list {
 				if ib == nil {
@@ -467,7 +467,7 @@ func aclActionToProtoAction(action types.ACLActionType) flowlog.ACLAction {
 func protoEncodeAppFlowMonitorProto(ipflow types.IPFlow) *flowlog.FlowMessage {
 
 	pflows := new(flowlog.FlowMessage)
-	pflows.DevId = ipflow.DevID.String()
+	pflows.DevId = *proto.String(devUUID.String())
 
 	// ScopeInfo fill in
 	pScope := new(flowlog.ScopeInfo)

--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -161,7 +161,7 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 	deviceType := new(info.ZInfoTypes)
 	*deviceType = info.ZInfoTypes_ZiDevice
 	ReportInfo.Ztype = *deviceType
-	deviceUUID := zcdevUUID.String()
+	deviceUUID := devUUID.String()
 	ReportInfo.DevId = *proto.String(deviceUUID)
 	ReportInfo.AtTimeStamp = ptypes.TimestampNow()
 	log.Functionf("PublishDeviceInfoToZedCloud uuid %s", deviceUUID)
@@ -561,7 +561,7 @@ func PublishAppInstMetaDataToZedCloud(ctx *zedagentContext, appInstID string, ap
 	contentType := new(info.ZInfoTypes)
 	*contentType = info.ZInfoTypes_ZiAppInstMetaData
 	ReportInfo.Ztype = *contentType
-	ReportInfo.DevId = *proto.String(zcdevUUID.String())
+	ReportInfo.DevId = *proto.String(devUUID.String())
 	ReportInfo.AtTimeStamp = ptypes.TimestampNow()
 
 	ReportAppInstMetaData := new(info.ZInfoAppInstMetaData)

--- a/pkg/pillar/cmd/zedrouter/flowstats.go
+++ b/pkg/pillar/cmd/zedrouter/flowstats.go
@@ -134,7 +134,7 @@ func FlowStatsCollect(ctx *zedrouterContext) {
 			return
 		}
 
-		log.Tracef("***FlowStats(%d): device=%v, size of the flows %d\n", proto, devUUID, len(connT))
+		log.Tracef("***FlowStats(%d): size of the flows %d", proto, len(connT))
 
 		for _, entry := range connT { // loop through and process current timedout flow collection
 			flowTuple := flowMergeProcess(entry, instData)
@@ -175,7 +175,6 @@ func FlowStatsCollect(ctx *zedrouterContext) {
 				NetUUID:   instData.bnNet[bnx].netUUID,
 			}
 			flowdata := types.IPFlow{
-				DevID: devUUID,
 				Scope: scope,
 			}
 

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -103,7 +103,6 @@ var debug = false
 var debugOverride bool // From command line arg
 var logger *logrus.Logger
 var log *base.LogObject
-var devUUID uuid.UUID
 
 func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) int {
 	logger = loggerArg
@@ -406,13 +405,12 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	}
 	log.Functionf("processed GlobalConfig")
 
-	// Wait until we have been onboarded aka know our own UUID
-	onboard, err := utils.WaitForOnboarded(ps, log, agentName, warningTime, errorTime)
+	// Wait until we have been onboarded aka know our own UUID but we don't used the UUID
+	err = utils.WaitForOnboarded(ps, log, agentName, warningTime, errorTime)
 	if err != nil {
 		log.Fatal(err)
 	}
 	log.Functionf("processed onboarded")
-	devUUID = onboard.DeviceUUID
 
 	appNumAllocatorInit(&zedrouterCtx)
 	bridgeNumAllocatorInit(&zedrouterCtx)

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -460,7 +460,6 @@ fi
 rm "$WATCHDOG_PID/zedclient.pid"
 
 uuid=$(cat $PERSISTDIR/status/uuid)
-/bin/hostname "$uuid"
 /bin/hostname >/etc/hostname
 
 if ! grep -q "$uuid" /etc/hosts; then

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -28,6 +28,7 @@ const (
 	SenderStatusHashSizeError                          // senderCertHash length error
 	SenderStatusCertUnknownAuthority                   // device may miss proxy certificate for MiTM
 	SenderStatusCertUnknownAuthorityProxy              // device configed proxy, may miss proxy certificate for MiTM
+	SenderStatusNotFound                               // 404 indicating device might have been deleted in controller
 )
 
 const (

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -2767,7 +2767,6 @@ type DNSReq struct {
 
 // IPFlow :
 type IPFlow struct {
-	DevID   uuid.UUID
 	Scope   FlowScope
 	Flows   []FlowRec
 	DNSReqs []DNSReq
@@ -2781,7 +2780,7 @@ func (flows IPFlow) Key() string {
 // LogCreate : we treat IPFlow as Metrics for logging
 func (flows IPFlow) LogCreate(logBase *base.LogObject) {
 	logObject := base.NewLogObject(logBase, base.IPFlowLogType, "",
-		flows.DevID, flows.LogKey())
+		nilUUID, flows.LogKey())
 	if logObject == nil {
 		return
 	}
@@ -2791,7 +2790,7 @@ func (flows IPFlow) LogCreate(logBase *base.LogObject) {
 // LogModify :
 func (flows IPFlow) LogModify(logBase *base.LogObject, old interface{}) {
 	logObject := base.EnsureLogObject(logBase, base.IPFlowLogType, "",
-		flows.DevID, flows.LogKey())
+		nilUUID, flows.LogKey())
 
 	oldFlows, ok := old.(IPFlow)
 	if !ok {
@@ -2805,7 +2804,7 @@ func (flows IPFlow) LogModify(logBase *base.LogObject, old interface{}) {
 // LogDelete :
 func (flows IPFlow) LogDelete(logBase *base.LogObject) {
 	logObject := base.EnsureLogObject(logBase, base.IPFlowLogType, "",
-		flows.DevID, flows.LogKey())
+		nilUUID, flows.LogKey())
 	logObject.Metricf("IP flow delete")
 
 	base.DeleteLogObject(logBase, flows.LogKey())

--- a/pkg/pillar/utils/waitfor.go
+++ b/pkg/pillar/utils/waitfor.go
@@ -15,8 +15,7 @@ import (
 
 //Context is a helper struct used to pass around in pubsub handlers
 type Context struct {
-	Initialized      bool
-	OnboardingStatus types.OnboardingStatus
+	Initialized bool
 }
 
 // WaitForVault waits until it receives a types.VaultStatus msg, for types.DefaultVaultName
@@ -83,7 +82,7 @@ func handleVaultStatusImpl(ctxArg interface{}, key string,
 
 // WaitForOnboarded waits until it receives a types.OnboardingStatus msg with
 // a non-zero UUID
-func WaitForOnboarded(ps *pubsub.PubSub, log *base.LogObject, agentName string, warningTime, errorTime time.Duration) (types.OnboardingStatus, error) {
+func WaitForOnboarded(ps *pubsub.PubSub, log *base.LogObject, agentName string, warningTime, errorTime time.Duration) error {
 	// Look for vault status
 	Ctx := &Context{}
 	subOnboardStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
@@ -99,7 +98,7 @@ func WaitForOnboarded(ps *pubsub.PubSub, log *base.LogObject, agentName string, 
 		ErrorTime:     errorTime,
 	})
 	if err != nil {
-		return types.OnboardingStatus{}, err
+		return err
 	}
 
 	// Run a periodic timer so we always update StillRunning
@@ -118,7 +117,7 @@ func WaitForOnboarded(ps *pubsub.PubSub, log *base.LogObject, agentName string, 
 	}
 	stillRunning.Stop()
 	subOnboardStatus.Close()
-	return Ctx.OnboardingStatus, nil
+	return nil
 }
 
 // Really a constant
@@ -144,6 +143,5 @@ func handleOnboardStatusImpl(ctxArg interface{}, key string,
 	if status.DeviceUUID == nilUUID {
 		return
 	}
-	ctx.OnboardingStatus = status
 	ctx.Initialized = true
 }


### PR DESCRIPTION
Make sure all of the microservices which use the device UUID pick up the
change. Also detect the change when we get the config, or when we get a
404 from the /config API, and trigger the update. Should the device UUID
change we republish all info messages to the controller. Cleaned up the
misnamed RemoteTemporaryFailure variable and comments as part of
introducing the new SenderStatusNotFound.

Also making the client set the hostname (so the change can be seen in the shell) as a separate commit, and fixing a misplaced log warning as a third commit.