### PR TITLE
Creating controller model file(s) during installation

### DIFF
--- a/pkg/mkimage-raw-efi/Dockerfile
+++ b/pkg/mkimage-raw-efi/Dockerfile
@@ -13,7 +13,7 @@ RUN eve-alpine-deploy.sh
 
 WORKDIR /out
 RUN echo "mtools_skip_check=1" >> etc/mtools.conf
-RUN mkdir -p efifs parts root bits config persist opt/zededa lib/modules run sys
+RUN mkdir -p efifs parts root bits config persist opt/zededa opt/debug lib/modules run sys
 COPY make-raw install grub.cfg.in UsbInvocationScript.txt ./
 COPY grub.stage1 ./usr/lib/grub/i386-pc/boot.img
 

--- a/pkg/mkimage-raw-efi/config.json
+++ b/pkg/mkimage-raw-efi/config.json
@@ -228,6 +228,16 @@
             ]
         },
         {
+            "destination": "/opt/debug",
+            "type": "bind",
+            "source": "/containers/services/debug/lower",
+            "options": [
+                "rw",
+                "rbind",
+                "rshared"
+            ]
+        },
+        {
             "destination": "/lib/modules",
             "type": "bind",
             "source": "/lib/modules",

--- a/pkg/mkimage-raw-efi/install
+++ b/pkg/mkimage-raw-efi/install
@@ -89,6 +89,16 @@ mount_part() {
    mount "$@" "/dev/$ID" "/run/$PART"
 }
 
+# run command in a chroot with system mount points provisioned
+ctr_run() {
+   local SYS_DIRS="/sys /proc /dev"
+   local DIR="$1"
+   shift
+   for d in $SYS_DIRS; do mount --bind "$d" "$DIR/$d"; done
+   chroot "$DIR" "$@"
+   for d in $SYS_DIRS; do umount "$DIR/$d"; done
+}
+
 # collect_black_box FOLDER_TO_PUT_BLACK_BOX
 collect_black_box() {
    lsblk > "$1/lsblk.txt"
@@ -295,6 +305,10 @@ if mount_part INVENTORY "$(root_dev)" -t vfat -o iocharset=iso8859-1; then
 
    # first lets look at hardware model
    dmidecode > "$REPORT/hardwaremodel.txt"
+
+   # try to generate model json file
+   ctr_run /opt/debug spec.sh > "$REPORT/controller-model.json"
+   ctr_run /opt/debug spec.sh -v > "$REPORT/controller-model-verbose.json"
 
    # then we can collect our black box
    grep -q eve_blackbox /proc/cmdline && collect_black_box "$REPORT" 2>/dev/null


### PR DESCRIPTION
Pretty self-explanotry tiny hack that allows controller side models be generated during install. This is to help folks onboard new hardware more easily.