### PR TITLE
pass grub config file for installer

### DIFF
--- a/pkg/eve/installer/grub.cfg
+++ b/pkg/eve/installer/grub.cfg
@@ -53,5 +53,8 @@ if [ -n "$install_part" -a -f "($install_part)/rootfs.img" -a -f "($install_part
    set_global eve_flavor kvm
 
    loopback loop0 "$rootfs_root"
+   if [ -f "($install_part)/config.img" ]; then
+       loopback loop1 "($install_part)/config.img"
+   fi
    configfile (loop0)/EFI/BOOT/grub.cfg
 fi

--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -133,6 +133,9 @@ function set_config_overrides {
            set_to_existing_file devicetree "($config_part)/eve.dtb"
         fi
      fi
+  else
+     # we use the following for installer iso
+     set_to_existing_file config_grub_cfg "(loop1)/grub.cfg"
   fi
 }
 


### PR DESCRIPTION
The ability to use grub.cfg from config file in case of iso installer. For now with iso image we have no dedicated config partition, but still may want to pass override. In this PR I mount file with configuration partition and try to use grub.cfg from it.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>