### PR TITLE
[WIP] Fix AppInst reboot after manually shutting down the appInst

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -839,7 +839,6 @@ func verifyStatus(ctx *domainContext, status *types.DomainStatus) {
 			errStr := fmt.Sprintf("verifyStatus(%s) failed %s",
 				status.Key(), err)
 			log.Warnln(errStr)
-			status.Activated = false
 			status.State = types.HALTED
 
 			// check if task is in the BROKEN state and kill it (later on we may do some


### PR DESCRIPTION
Issue: After we shutdown an appInst from inside, it sporadically comes back online.

Cause: After we shutdown an appInstance, the appInst's qemu process existed and the (contained container) domain goes to `stopped` state which results in marking that domain as `HALTED`. After this in [domainmgr/domainmgr.go:verifyStatus()](https://github.com/lf-edge/eve/blob/9a433ac3aaf8e1cdf6fc9d200322860cdf2cc850/pkg/pillar/cmd/domainmgr/domainmgr.go#L828), we mark the domainStatus as Inactive ([here](https://github.com/lf-edge/eve/blob/9a433ac3aaf8e1cdf6fc9d200322860cdf2cc850/pkg/pillar/cmd/domainmgr/domainmgr.go#L842)) and update the domainStatus as `HALTED`. Now the expectation is that the appInst will stay in the `HALTED` state until the user wants it to come back online, but when we receive a domainConfig update, we notice that the domainConfig is active && domainStatus is Inactive ([here](https://github.com/lf-edge/eve/blob/9a433ac3aaf8e1cdf6fc9d200322860cdf2cc850/pkg/pillar/cmd/domainmgr/domainmgr.go#L1853)) and try to activate the domain again [here](https://github.com/lf-edge/eve/blob/9a433ac3aaf8e1cdf6fc9d200322860cdf2cc850/pkg/pillar/cmd/domainmgr/domainmgr.go#L1877). Because of this, the appInst comes back online.

Fix: When an appInst's domain goes to `stopped` state either because of manual shutdown or appInst's main process crash, we should not consider that as domain deactivate, instead just mark it as `HALTED` 