### PR TITLE
sync Eden tests

### DIFF
--- a/tests/eden/eclient/testdata/mount.txt
+++ b/tests/eden/eclient/testdata/mount.txt
@@ -27,7 +27,7 @@ stdout '/tst'
 
 eden volume detach eclient-mount_1_m_0
 
-test eden.app.test -test.v -timewait 15m RUNNING eclient-mount
+test eden.app.test -test.v -timewait 15m -check-new RUNNING eclient-mount
 
 # check old mount point
 exec -t 5m bash ssh.sh /tst
@@ -36,7 +36,7 @@ exec -t 5m bash ssh.sh /tst
 # mount onto another mount point
 eden volume attach eclient-mount_1_m_0 eclient-mount /dst
 
-test eden.app.test -test.v -timewait 15m RUNNING eclient-mount
+test eden.app.test -test.v -timewait 15m -check-new RUNNING eclient-mount
 
 # check new mount point
 exec -t 5m bash ssh.sh /dst

--- a/tests/eden/eclient/testdata/reboot_test.txt
+++ b/tests/eden/eclient/testdata/reboot_test.txt
@@ -1,0 +1,85 @@
+# Test for reboot of EVE
+# we inject network outage and check for entities to come after reboot for qemu and vbox
+
+{{$port := "2223"}}
+{{$network_name := "n1"}}
+{{$app_name := "eclient"}}
+
+[!exec:bash] stop
+[!exec:sleep] stop
+[!exec:ssh] stop
+[!exec:chmod] stop
+
+exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
+
+# Create n1 network
+eden -t 1m network create 10.11.12.0/24 -n {{$network_name}}
+
+# Wait for run
+test eden.network.test -test.v -timewait 10m ACTIVATED {{$network_name}}
+
+eden pod deploy -n {{$app_name}} --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{$port}}:22 --networks={{$network_name}}
+
+test eden.app.test -test.v -timewait 20m RUNNING {{$app_name}}
+
+exec -t 5m bash ssh.sh
+stdout 'Ubuntu'
+
+# send reboot command and wait in background
+test eden.reboot.test -test.v -timewait=20m -reboot=1 -count=1 &
+
+# wait for HALTED state which indicates that we are rebooting
+test eden.app.test -test.v -timewait 5m HALTED {{$app_name}}
+
+{{$devmodel := EdenConfig "eve.devmodel"}}
+
+{{if or (eq $devmodel "ZedVirtual-4G") (eq $devmodel "VBox") }}
+# simulate network outage
+eden eve link down
+# sleep without networks for 7 minutes
+exec sleep 7m
+{{end}}
+
+# check info messages sent correct data in background
+test eden.app.test -test.v -timewait 10m -check-new RUNNING {{$app_name}} &
+test eden.network.test -test.v -timewait 10m -check-new ACTIVATED {{$network_name}} &
+
+
+{{if or (eq $devmodel "ZedVirtual-4G") (eq $devmodel "VBox") }}
+# return networks
+eden eve link up
+{{end}}
+
+# wait for detectors
+wait
+
+# check ssh access to app after reboot
+exec -t 5m bash ssh.sh
+stdout 'Ubuntu'
+
+eden pod delete {{$app_name}}
+test eden.app.test -test.v -timewait 10m - {{$app_name}}
+
+eden network delete {{$network_name}}
+test eden.network.test -test.v -timewait 10m - {{$network_name}}
+
+-- eden-config.yml --
+{{/* Test's config. file */}}
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+
+-- ssh.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+for i in `seq 20`
+do
+sleep 20
+# Test SSH-access to container
+echo $i\) ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{$port}} root@$HOST grep Ubuntu /etc/issue
+ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{$port}} root@$HOST grep Ubuntu /etc/issue && break
+done

--- a/tests/eden/eclient/testdata/userdata.txt
+++ b/tests/eden/eclient/testdata/userdata.txt
@@ -1,0 +1,41 @@
+# Test of userdata functionality
+
+{{$port := "2223"}}
+
+{{$userdata_file := "/tmp/userdata_file_eden_test"}}
+
+[!exec:bash] stop
+[!exec:sleep] stop
+[!exec:chmod] stop
+
+exec -t 10s bash generate_file.sh
+
+exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
+
+# Starting of reboot detector with a 1 reboot limit
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
+
+eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{$port}}:22 --metadata={{$userdata_file}}
+
+test eden.app.test -test.v -timewait 20m RUNNING eclient
+
+exec sleep 10s
+
+eden pod delete eclient
+
+test eden.app.test -test.v -timewait 10m - eclient
+
+-- eden-config.yml --
+{{/* Test's config. file */}}
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+
+-- generate_file.sh --
+# allocate about 90014 of raw data
+printf 'variable=value\n%.0s' {1..6000} >{{$userdata_file}}
+printf 'variable=value' >>{{$userdata_file}}

--- a/tests/eden/eden-version
+++ b/tests/eden/eden-version
@@ -1,1 +1,1 @@
-lfedge/eden:2cc7cf9
+lfedge/eden:967d23c

--- a/tests/eden/update_eve_image/testdata/update_eve_image_http.txt
+++ b/tests/eden/update_eve_image/testdata/update_eve_image_http.txt
@@ -1,5 +1,5 @@
 # Default EVE version to update
-{{$eve_ver := "6.0.0"}}
+{{$eve_ver := "6.4.0"}}
 
 # Obtain EVE version from environment variable EVE_VERSION
 {{$env := EdenGetEnv "EVE_VERSION"}}

--- a/tests/eden/update_eve_image/testdata/update_eve_image_oci.txt
+++ b/tests/eden/update_eve_image/testdata/update_eve_image_oci.txt
@@ -1,5 +1,5 @@
 # Default EVE version to update
-{{$eve_ver := "6.0.0"}}
+{{$eve_ver := "6.5.0"}}
 
 # Obtain EVE version from environment variable EVE_VERSION
 {{$env := EdenGetEnv "EVE_VERSION"}}

--- a/tests/eden/workflow/eden.workflow.tests.txt
+++ b/tests/eden/workflow/eden.workflow.tests.txt
@@ -94,21 +94,23 @@ eden.escript.test -testdata ../volume/testdata/ -test.run TestEdenScripts/local_
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/mount
 {{end}}
 
-/bin/echo Eden Host only ACL (18.1/{{$tests}})
-eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/host-only
-/bin/echo Eden ACL to particular host (18.2/{{$tests}})
-eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/acl
-/bin/echo Eden profile test (18.3/{{$tests}})
+/bin/echo Eden profile test (18/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/profile
-/bin/echo Eden app metadata test (18.4/{{$tests}})
+
+/bin/echo Eden app metadata test (19.1/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/metadata
-/bin/echo Eden Network light (19/{{$tests}})
+/bin/echo Eden app userdata test (19.2/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/userdata
+
+/bin/echo Eden ACL to particular host (20.1/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/acl
+/bin/echo Eden Network light (20.2/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/networking_light
-/bin/echo Eden Networks switch (20/{{$tests}})
+/bin/echo Eden Networks switch (21.1/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/nw_switch
-/bin/echo Eden Network Ports switch (21/{{$tests}})
+/bin/echo Eden Network Ports switch (21.2/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/port_switch
-/bin/echo Eden Network portmap test (21.1/{{$tests}})
+/bin/echo Eden Network portmap test (21.3/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/port_forward
 
 {{if (eq $usb_pt "y")}}
@@ -156,7 +158,8 @@ eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/eclie
 {{end}}
 
 /bin/echo Eden Reboot test (34/{{$tests}})
-eden.escript.test -test.run TestEdenScripts/reboot_test
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/reboot_test
+
 {{ if ne $workflow "small" }}
 /bin/echo Eden base OS update http (35/{{$tests}})
 eden.escript.test -testdata ../update_eve_image/testdata/ -test.run TestEdenScripts/update_eve_image_http


### PR DESCRIPTION
userdata test for large userdata added;
reboot test tests objects recovery after reboot and network outage;
host-only test removed in favor of acl test;
versions of EVE to update modified to have latest kernel;
binary handle 0 states as deleted

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>