### PR TITLE
fix deleting of zfs volume which was prepared

### DIFF
--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -752,7 +752,8 @@ func updateContentTreeStatus(ctx *volumemgrContext, contentSha256 string, conten
 }
 
 // Find all the VolumeStatus which refer to this volume uuid
-func updateVolumeStatus(ctx *volumemgrContext, volumeID uuid.UUID) {
+// returns false if not found any
+func updateVolumeStatus(ctx *volumemgrContext, volumeID uuid.UUID) bool {
 
 	log.Functionf("updateVolumeStatus for %s", volumeID)
 	found := false
@@ -778,6 +779,7 @@ func updateVolumeStatus(ctx *volumemgrContext, volumeID uuid.UUID) {
 	if !found {
 		log.Warnf("XXX updateVolumeStatus(%s) NOT FOUND", volumeID)
 	}
+	return found
 }
 
 // Find all the VolumeStatus which refer to this content uuid


### PR DESCRIPTION
We can hit the problem when creation of the ZFS volume take large time and we delete the volume in parallel. In this case volume stay inside the zfs dataset until next garbage collection fired. In this PR I run garbage collection in case of no status found for the volume. Seems reasonable to collect garbage of all types here as well.
Also I observed that current garbage collection do not remove target and vhost for zfs, which lead to busy volume and no luck with destruction of dataset, fixed.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>