### PR TITLE
Accomodating console on newer qemu

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -251,6 +251,7 @@ function set_arm64_baremetal {
 function set_arm64_qemu {
    set_generic
    set_arm64
+   set_global dom0_console "$dom0_console console=ttyAMA0"
    set_global dom0_platform_tweaks "hmp-unsafe=true"
    # if running under QEMU, make sure to check dynamic partition for device trees
    search.fs_label QEMU_DTB qemu_part


### PR DESCRIPTION
Newer qemu/arm64 seem to require explicit setting of console=ttyAMA0