### PR TITLE
Increased timeout for local_datastore test

### DIFF
--- a/tests/eden/eclient/testdata/air-gapped-switch.txt
+++ b/tests/eden/eclient/testdata/air-gapped-switch.txt
@@ -26,7 +26,7 @@ message 'Creating networks: local indirect and air-gapped switch direct'
 eden network create 10.11.12.0/24 -n indirect
 eden network create --type switch --uplink none -n direct
 
-test eden.network.test -test.v -timewait 10m ACTIVATED indirect direct
+test eden.network.test -test.v -timewait 20m ACTIVATED indirect direct
 
 message 'Starting applications'
 eden pod deploy -v debug -n eclient1 docker://lfedge/eden-eclient:83cfe07 -p {{template "port1"}}:22 --networks=indirect --networks=direct:{{template "mac1"}} --memory=512MB

--- a/tests/eden/volume/testdata/local_datastore.txt
+++ b/tests/eden/volume/testdata/local_datastore.txt
@@ -19,7 +19,7 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:4558d83 -p {{$port}}:22
 
-test eden.app.test -test.v -timewait 15m RUNNING eclient
+test eden.app.test -test.v -timewait 20m RUNNING eclient
 
 exec -t 5m bash ssh.sh
 stdout 'Ubuntu'


### PR DESCRIPTION
https://github.com/lf-edge/eve/runs/3822932851?check_suite_focus=true
Timeout in 15 min is not enough to deploy the app.

Signed-off-by: Ruslan Dautov <dautov2@gmail.com>