### PR TITLE
Fix issue with Makefile while running on RISC-V

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -371,7 +371,7 @@ run-installer-net: $(BIOS_IMG) $(IPXE_IMG) $(DEVICETREE_DTB)
 
 # run MUST NOT change the current dir; it depends on the output being correct from a previous build
 run-live run: $(BIOS_IMG) $(DEVICETREE_DTB)
-	$(QEMU_SYSTEM) $(QEMU_OPTS) -drive file=$(CURRENT_IMG),format=$(IMG_FORMAT)
+	$(QEMU_SYSTEM) $(QEMU_OPTS) -drive file=$(CURRENT_IMG),format=$(IMG_FORMAT),id=uefi-disk
 
 run-target: $(BIOS_IMG) $(DEVICETREE_DTB)
 	$(QEMU_SYSTEM) $(QEMU_OPTS) -drive file=$(TARGET_IMG),format=$(IMG_FORMAT)


### PR DESCRIPTION
Need to add id=uefi-disk to run-live target in the Makefile.
Earlier running on RISC-V failed due to the missing id.

Signed-off-by: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>