### PR TITLE
remove run mount point for containerd-based apps

### DIFF
--- a/pkg/pillar/hypervisor/containerd.go
+++ b/pkg/pillar/hypervisor/containerd.go
@@ -106,6 +106,14 @@ func (ctx ctrdContext) Setup(status types.DomainStatus, config types.DomainConfi
 		Destination: "/etc/resolv.conf",
 		Options:     []string{"rbind", "ro"}})
 
+	//remove /run mount to use data from provided image
+	for i, el := range spec.Get().Mounts {
+		if el.Destination == "/run" && el.Type == "tmpfs" {
+			spec.Get().Mounts = append(spec.Get().Mounts[:i], spec.Get().Mounts[i+1:]...)
+			break
+		}
+	}
+
 	if err := spec.CreateContainer(true); err != nil {
 		return logError("Failed to create container for task %s from %v: %v", status.DomainName, config, err)
 	}


### PR DESCRIPTION
Seems we have problem with our mounts for no-hyper mode.

1. Containerd adds mount for /run: https://github.com/lf-edge/eve/blob/master/pkg/pillar/vendor/github.com/containerd/containerd/oci/spec.go#L201-L206
2. Mysql image prepare directories inside /var/run (symlink to /run): https://github.com/docker-library/mysql/blob/c506174eab8ae160f56483e8d72410f8f1e1470f/8.0/Dockerfile.debian#L82-L85
3. Docker do not do the same (no /run mount inside https://github.com/moby/moby/blob/1430d849a4fe74d601896d4bbb0134e898ef8a76/oci/defaults.go#L34). And just use files as is.
4. We override /run with tmpfs, so, I see `can't create lock file /var/run/mysqld/mysqlx.sock.lock'` and halting of app.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>