### PR TITLE
remove noexec from /tmp

### DIFF
--- a/pkg/xen-tools/initrd/init-initrd
+++ b/pkg/xen-tools/initrd/init-initrd
@@ -42,7 +42,7 @@ mount -t cgroup cgroup /mnt/rootfs/sys/fs/cgroup
 mount -o bind /proc /mnt/rootfs/proc
 mount -t devpts -o gid=5,mode=0620,noexec,nosuid devpts /mnt/rootfs/dev/pts
 mount -t tmpfs -o nodev,nosuid,noexec,size=20% shm /mnt/rootfs/dev/shm
-mount -t tmpfs -o nodev,nosuid,noexec,size=20% tmp /mnt/rootfs/tmp
+mount -t tmpfs -o nodev,nosuid,size=20% tmp /mnt/rootfs/tmp
 mount -t mqueue -o nodev,nosuid,noexec none /mnt/rootfs/dev/mqueue
 ln -s /proc/self/fd /mnt/rootfs/dev/fd
 ln -s /proc/self/fd/0 /mnt/rootfs/dev/stdin


### PR DESCRIPTION
We have an image which download executable into /tmp and try to run it with fail: https://github.com/logicmonitor/docker_lm_collector/blob/master/collector/collector.py#L226-L233

As a workaround we can allow to execute files from /tmp.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>