### PR TITLE
sync eden tests

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -67,6 +67,7 @@ jobs:
         run: |
           ./eden config set default --key eve.tag --value="$TAG"
           ./eden config set default --key=eve.accel --value=false
+          ./eden config set default --key=eve.cpu --value=2
           ./eden config set default --key=eden.tests --value=${{ github.workspace }}/eve/tests/eden
           EDITOR=cat ./eden config edit default
           echo > ${{ github.workspace }}/eve/tests/eden/workflow/testdata/eden_stop.txt

--- a/tests/eden/eclient/testdata/acl.txt
+++ b/tests/eden/eclient/testdata/acl.txt
@@ -34,9 +34,9 @@ eden network create 10.11.12.0/24 -n {{$network_name}} -s {{$fake_domain}}:$host
 test eden.network.test -test.v -timewait 10m ACTIVATED {{$network_name}}
 
 # First app is only allowed to access github.com and $long_domain.
-eden pod deploy -n curl-acl1 --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p 2223:22 --networks={{$network_name}} --acl={{$network_name}}:github.com --acl={{$network_name}}:{{$long_domain}}:allow --acl={{$network_name}}:google.com:drop
+eden pod deploy -n curl-acl1 --memory=512MB docker://lfedge/eden-eclient:d9eb23f -p 2223:22 --networks={{$network_name}} --acl={{$network_name}}:github.com --acl={{$network_name}}:{{$long_domain}}:allow --acl={{$network_name}}:google.com:drop
 # Second app is only allowed to access $long_domain and $fake_domain.
-eden pod deploy -n curl-acl2 --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p 2224:22 --networks={{$network_name}} --acl={{$network_name}}:{{$long_domain}} --acl={{$network_name}}:{{$fake_domain}}:allow --acl={{$network_name}}:ieee.org:drop
+eden pod deploy -n curl-acl2 --memory=512MB docker://lfedge/eden-eclient:d9eb23f -p 2224:22 --networks={{$network_name}} --acl={{$network_name}}:{{$long_domain}} --acl={{$network_name}}:{{$fake_domain}}:allow --acl={{$network_name}}:ieee.org:drop
 
 test eden.app.test -test.v -timewait 15m RUNNING curl-acl1 curl-acl2
 

--- a/tests/eden/eclient/testdata/air-gapped-switch.txt
+++ b/tests/eden/eclient/testdata/air-gapped-switch.txt
@@ -29,8 +29,8 @@ eden network create --type switch --uplink none -n direct
 test eden.network.test -test.v -timewait 20m ACTIVATED indirect direct
 
 message 'Starting applications'
-eden pod deploy -v debug -n eclient1 docker://lfedge/eden-eclient:83cfe07 -p {{template "port1"}}:22 --networks=indirect --networks=direct:{{template "mac1"}} --memory=512MB
-eden pod deploy -v debug -n eclient2 docker://lfedge/eden-eclient:83cfe07 -p {{template "port2"}}:22 --networks=indirect --networks=direct:{{template "mac2"}} --memory=512MB
+eden pod deploy -v debug -n eclient1 docker://lfedge/eden-eclient:d9eb23f -p {{template "port1"}}:22 --networks=indirect --networks=direct:{{template "mac1"}} --memory=512MB
+eden pod deploy -v debug -n eclient2 docker://lfedge/eden-eclient:d9eb23f -p {{template "port2"}}:22 --networks=indirect --networks=direct:{{template "mac2"}} --memory=512MB
 
 message 'Waiting for running state'
 test eden.app.test -test.v -timewait 15m RUNNING eclient1 eclient2

--- a/tests/eden/eclient/testdata/app_nonat.txt
+++ b/tests/eden/eclient/testdata/app_nonat.txt
@@ -24,7 +24,7 @@ eden network create --type switch --uplink eth0 -n direct
 test eden.network.test -test.v -timewait 10m ACTIVATED indirect direct
 
 message 'Starting applications'
-eden pod deploy -v debug -n eclient docker://lfedge/eden-eclient:83cfe07 -p {{template "port"}}:22 --networks=indirect --networks=direct --memory=512MB
+eden pod deploy -v debug -n eclient docker://lfedge/eden-eclient:d9eb23f -p {{template "port"}}:22 --networks=indirect --networks=direct --memory=512MB
 
 message 'Waiting of running'
 test eden.app.test -test.v -timewait 30m RUNNING eclient

--- a/tests/eden/eclient/testdata/com-pt_test.txt
+++ b/tests/eden/eclient/testdata/com-pt_test.txt
@@ -16,7 +16,7 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 # Starting of reboot detector with a 2 reboot limit
 ! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
 
-eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{template "port"}}:22
+eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:d9eb23f -p {{template "port"}}:22
 
 test eden.app.test -test.v -timewait 20m RUNNING eclient
 

--- a/tests/eden/eclient/testdata/disk.txt
+++ b/tests/eden/eclient/testdata/disk.txt
@@ -12,7 +12,7 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 # Starting of reboot detector with a 1 reboot limit
 ! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
-eden pod deploy -n eclient-disk --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{$port}}:22 --disks=file://{{EdenConfig "eden.root"}}/empty.qcow2
+eden pod deploy -n eclient-disk --memory=512MB docker://lfedge/eden-eclient:d9eb23f -p {{$port}}:22 --disks=file://{{EdenConfig "eden.root"}}/empty.qcow2
 
 test eden.app.test -test.v -timewait 20m RUNNING eclient-disk
 

--- a/tests/eden/eclient/testdata/eclient.txt
+++ b/tests/eden/eclient/testdata/eclient.txt
@@ -12,7 +12,7 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 # Starting of reboot detector with a 1 reboot limit
 ! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
-eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{$port}}:22
+eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:d9eb23f -p {{$port}}:22
 
 test eden.app.test -test.v -timewait 20m RUNNING eclient
 

--- a/tests/eden/eclient/testdata/eclients.txt
+++ b/tests/eden/eclient/testdata/eclients.txt
@@ -6,7 +6,7 @@
 {{$apps := EdenGetEnv "EDEN_TEST_APPS"}}
 # Time of app waiting (default -- 30 min)
 {{$time := EdenGetEnv "EDEN_TEST_TIME"}}
-# Image for app (default -- docker://lfedge/eden-eclient:83cfe07)
+# Image for app (default -- docker://lfedge/eden-eclient:d9eb23f)
 {{$img := EdenGetEnv "EDEN_TEST_IMG"}}
 
 {{$devmodel := EdenConfig "eve.devmodel"}}
@@ -49,8 +49,8 @@ TAPP={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/eden.app.test
 HOST=$($EDEN eve ip)
 
 APPS="{{$apps}}"
-# Default image -- docker://lfedge/eden-eclient:83cfe07
-IMG="{{if $img}}{{$img}}{{else}}docker://lfedge/eden-eclient:83cfe07{{end}}"
+# Default image -- docker://lfedge/eden-eclient:d9eb23f
+IMG="{{if $img}}{{$img}}{{else}}docker://lfedge/eden-eclient:d9eb23f{{end}}"
 
 PORTS=""
 for i in `seq $APPS`
@@ -109,9 +109,9 @@ TAPP={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/eden.app.test
 HOST=$($EDEN eve ip)
 
 APPS="{{$apps}}"
-# Default image -- docker://lfedge/eden-eclient:83cfe07
-#IMG="{{if $img}}{{$img}}{{else}}docker://lfedge/eden-eclient:83cfe07{{end}}"
-IMG="{{if $img}}{{$img}}{{else}}docker://lfedge/eden-eclient:83cfe07{{end}}"
+# Default image -- docker://lfedge/eden-eclient:d9eb23f
+#IMG="{{if $img}}{{$img}}{{else}}docker://lfedge/eden-eclient:d9eb23f{{end}}"
+IMG="{{if $img}}{{$img}}{{else}}docker://lfedge/eden-eclient:d9eb23f{{end}}"
 
 PODS=""
 for i in `seq $APPS`

--- a/tests/eden/eclient/testdata/host-only.txt
+++ b/tests/eden/eclient/testdata/host-only.txt
@@ -13,9 +13,9 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 # Starting of reboot detector with a 1 reboot limit
 ! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
-eden pod deploy -n ping-nw --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p 2223:22
-eden pod deploy -n ping-fw --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p 2224:22 --only-host=true
-eden pod deploy -n pong --memory=512MB docker://lfedge/eden-eclient:83cfe07
+eden pod deploy -n ping-nw --memory=512MB docker://lfedge/eden-eclient:d9eb23f -p 2223:22
+eden pod deploy -n ping-fw --memory=512MB docker://lfedge/eden-eclient:d9eb23f -p 2224:22 --only-host=true
+eden pod deploy -n pong --memory=512MB docker://lfedge/eden-eclient:d9eb23f
 
 test eden.app.test -test.v -timewait 25m RUNNING ping-nw ping-fw pong
 

--- a/tests/eden/eclient/testdata/maridb.txt
+++ b/tests/eden/eclient/testdata/maridb.txt
@@ -15,7 +15,7 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 # Starting of reboot detector with a 1 reboot limit
 #! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
-eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{template "port"}}:22
+eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:d9eb23f -p {{template "port"}}:22
 
 eden pod deploy -n {{$server}} --memory=512MB docker://mariadb:10.5.6-focal --metadata='MYSQL_ROOT_PASSWORD=adam&eve'
 

--- a/tests/eden/eclient/testdata/metadata.txt
+++ b/tests/eden/eclient/testdata/metadata.txt
@@ -9,7 +9,7 @@
 
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
-eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{$port}}:22
+eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:d9eb23f -p {{$port}}:22
 
 test eden.app.test -test.v -timewait 20m RUNNING eclient
 

--- a/tests/eden/eclient/testdata/mount.txt
+++ b/tests/eden/eclient/testdata/mount.txt
@@ -11,7 +11,7 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 # Starting of reboot detector with a 1 reboot limit
 ! test eden.reboot.test -test.v -timewait 60m -reboot=0 -count=1 &
 
-eden pod deploy -n eclient-mount --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{$port}}:22 --mount=src=docker://nginx:1.20.0,dst=/tst --mount=src={{EdenConfig "eden.tests"}}/eclient/testdata,dst=/dir
+eden pod deploy -n eclient-mount --memory=512MB docker://lfedge/eden-eclient:d9eb23f -p {{$port}}:22 --mount=src=docker://nginx:1.20.0,dst=/tst --mount=src={{EdenConfig "eden.tests"}}/eclient/testdata,dst=/dir
 
 test eden.app.test -test.v -timewait 21m RUNNING eclient-mount
 

--- a/tests/eden/eclient/testdata/networking_light.txt
+++ b/tests/eden/eclient/testdata/networking_light.txt
@@ -14,11 +14,11 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 # Starting of reboot detector with a 1 reboot limit
 ! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
-eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{template "port"}}:22
+eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:d9eb23f -p {{template "port"}}:22
 #eden -t 20m pod logs eclient
 #stdout 'Executing "/usr/sbin/sshd" "-D"'
 
-eden pod deploy -v warning -n eserver --memory=512MB docker://lfedge/eden-eclient:83cfe07
+eden pod deploy -v warning -n eserver --memory=512MB docker://lfedge/eden-eclient:d9eb23f
 
 test eden.app.test -test.v -timewait 20m RUNNING eclient eserver
 

--- a/tests/eden/eclient/testdata/ngnix.txt
+++ b/tests/eden/eclient/testdata/ngnix.txt
@@ -15,7 +15,7 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 # Starting of reboot detector with a 1 reboot limit
 ! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
-eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{template "port"}}:22
+eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:d9eb23f -p {{template "port"}}:22
 
 eden pod deploy -n {{$server}} --memory=512MB docker://nginx:latest
 

--- a/tests/eden/eclient/testdata/nw_switch.txt
+++ b/tests/eden/eclient/testdata/nw_switch.txt
@@ -26,9 +26,9 @@ eden network create 10.11.13.0/24 -n n2
 test eden.network.test -test.v -timewait 10m ACTIVATED n1 n2
 
 message 'Starting applications'
-eden pod deploy -v debug -n ping1 docker://lfedge/eden-eclient:83cfe07 -p 2223:22 --networks=n1 --memory=512MB
-eden pod deploy -v debug -n ping2 docker://lfedge/eden-eclient:83cfe07 -p 2224:22 --networks=n2 --memory=512MB
-eden pod deploy -v debug -n pong docker://lfedge/eden-eclient:83cfe07 --networks=n1 --memory=512MB
+eden pod deploy -v debug -n ping1 docker://lfedge/eden-eclient:d9eb23f -p 2223:22 --networks=n1 --memory=512MB
+eden pod deploy -v debug -n ping2 docker://lfedge/eden-eclient:d9eb23f -p 2224:22 --networks=n2 --memory=512MB
+eden pod deploy -v debug -n pong docker://lfedge/eden-eclient:d9eb23f --networks=n1 --memory=512MB
 
 message 'Waiting of running'
 test eden.app.test -test.v -timewait 20m RUNNING ping1 ping2 pong

--- a/tests/eden/eclient/testdata/port_forward.txt
+++ b/tests/eden/eclient/testdata/port_forward.txt
@@ -29,8 +29,8 @@ test eden.network.test -test.v -timewait 10m ACTIVATED n1
 exec sleep 10
 
 message 'SCENARIO 1: Starting with both application attached to same network instance'
-eden pod deploy -v debug -n app1 docker://lfedge/eden-eclient:83cfe07 -p 2223:22 --networks=n1 --memory=512MB
-eden pod deploy -v debug -n app2 docker://lfedge/eden-eclient:83cfe07 -p 2224:22 --networks=n1 --memory=512MB
+eden pod deploy -v debug -n app1 docker://lfedge/eden-eclient:d9eb23f -p 2223:22 --networks=n1 --memory=512MB
+eden pod deploy -v debug -n app2 docker://lfedge/eden-eclient:d9eb23f -p 2224:22 --networks=n1 --memory=512MB
 
 message 'SCENARIO 1: Waiting for apps to enter RUNNING state'
 test eden.app.test -test.v -timewait 20m RUNNING app1 app2
@@ -92,8 +92,8 @@ eden network create 10.11.13.0/24 -n n2 --uplink eth1
 test eden.network.test -test.v -timewait 10m ACTIVATED n1 n2
 
 message 'SCENARIO 2: Starting with each application attached to a different network instance'
-eden pod deploy -v debug -n app1 docker://lfedge/eden-eclient:83cfe07 -p 2223:22 --networks=n1 --memory=512MB
-eden pod deploy -v debug -n app2 docker://lfedge/eden-eclient:83cfe07 -p 2234:22 --networks=n2 --memory=512MB
+eden pod deploy -v debug -n app1 docker://lfedge/eden-eclient:d9eb23f -p 2223:22 --networks=n1 --memory=512MB
+eden pod deploy -v debug -n app2 docker://lfedge/eden-eclient:d9eb23f -p 2234:22 --networks=n2 --memory=512MB
 
 message 'SCENARIO 2: Waiting for apps to enter RUNNING state'
 test eden.app.test -test.v -timewait 20m RUNNING app1 app2

--- a/tests/eden/eclient/testdata/profile.txt
+++ b/tests/eden/eclient/testdata/profile.txt
@@ -20,13 +20,13 @@ exec sleep 30
 
 # Define local-manager and two apps in different profiles
 # TBD: static ip in pod deploy
-eden pod deploy -n local-manager --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p 2223:22
+eden pod deploy -n local-manager --memory=512MB docker://lfedge/eden-eclient:d9eb23f -p 2223:22
 
 test eden.app.test -test.v -timewait 15m RUNNING local-manager
 
-eden pod deploy -n app-profile-1 --memory=512MB docker://lfedge/eden-eclient:83cfe07 --profile=profile-1
-eden pod deploy -n app-profile-2 --memory=512MB docker://lfedge/eden-eclient:83cfe07 --profile=profile-2
-eden pod deploy -n app-profile-1-2 --memory=512MB docker://lfedge/eden-eclient:83cfe07 --profile=profile-1 --profile=profile-2
+eden pod deploy -n app-profile-1 --memory=512MB docker://lfedge/eden-eclient:d9eb23f --profile=profile-1
+eden pod deploy -n app-profile-2 --memory=512MB docker://lfedge/eden-eclient:d9eb23f --profile=profile-2
+eden pod deploy -n app-profile-1-2 --memory=512MB docker://lfedge/eden-eclient:d9eb23f --profile=profile-1 --profile=profile-2
 
 # We have empty local_manager and empty default_profile, so apps should be in RUNNING state
 test eden.app.test -test.v -timewait 20m RUNNING app-profile-1 app-profile-2 app-profile-1-2 local-manager

--- a/tests/eden/eclient/testdata/reboot_test.txt
+++ b/tests/eden/eclient/testdata/reboot_test.txt
@@ -18,7 +18,7 @@ eden -t 1m network create 10.11.12.0/24 -n {{$network_name}}
 # Wait for run
 test eden.network.test -test.v -timewait 10m ACTIVATED {{$network_name}}
 
-eden pod deploy -n {{$app_name}} --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{$port}}:22 --networks={{$network_name}}
+eden pod deploy -n {{$app_name}} --memory=512MB docker://lfedge/eden-eclient:d9eb23f -p {{$port}}:22 --networks={{$network_name}}
 
 test eden.app.test -test.v -timewait 20m RUNNING {{$app_name}}
 

--- a/tests/eden/eclient/testdata/usb-pt_test.txt
+++ b/tests/eden/eclient/testdata/usb-pt_test.txt
@@ -12,8 +12,8 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 # Starting of reboot detector with a 2 reboot limit
 ! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=2 &
 
-eden pod deploy -n n1 --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p 2223:22
-eden pod deploy -n n2 --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p 2224:22 --adapters USB2:2
+eden pod deploy -n n1 --memory=512MB docker://lfedge/eden-eclient:d9eb23f -p 2223:22
+eden pod deploy -n n2 --memory=512MB docker://lfedge/eden-eclient:d9eb23f -p 2224:22 --adapters USB2:2
 
 test eden.app.test -test.v -timewait 20m RUNNING n1 n2
 

--- a/tests/eden/eclient/testdata/userdata.txt
+++ b/tests/eden/eclient/testdata/userdata.txt
@@ -15,7 +15,7 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 # Starting of reboot detector with a 1 reboot limit
 ! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
-eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{$port}}:22 --metadata={{$userdata_file}}
+eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:d9eb23f -p {{$port}}:22 --metadata={{$userdata_file}}
 
 test eden.app.test -test.v -timewait 20m RUNNING eclient
 

--- a/tests/eden/eden-version
+++ b/tests/eden/eden-version
@@ -1,1 +1,1 @@
-lfedge/eden:967d23c
+lfedge/eden:23a6f33

--- a/tests/eden/hardware_reboot/testdata/hardware_2usb_reboot.txt
+++ b/tests/eden/hardware_reboot/testdata/hardware_2usb_reboot.txt
@@ -11,7 +11,7 @@
 # Starting of reboot detector with a 2 reboot limit
 ! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=2 &
 
-eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{template "port"}}:22 --adapters USB2:2 --adapters USB2:3
+eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:d9eb23f -p {{template "port"}}:22 --adapters USB2:2 --adapters USB2:3
 
 test eden.app.test -test.v -timewait 20m RUNNING eclient
 

--- a/tests/eden/volume/testdata/local_datastore.txt
+++ b/tests/eden/volume/testdata/local_datastore.txt
@@ -17,7 +17,7 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 # Starting of reboot detector with 1 reboot limit
 ! test eden.reboot.test -test.v -timewait 60m -reboot=0 -count=1 &
 
-eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:4558d83 -p {{$port}}:22
+eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:d9eb23f -p {{$port}}:22
 
 test eden.app.test -test.v -timewait 20m RUNNING eclient
 

--- a/tests/eden/volume/testdata/volumes_test.txt
+++ b/tests/eden/volume/testdata/volumes_test.txt
@@ -4,8 +4,8 @@ eden -t 10s volume ls
 ! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 # Create v1 volume
-eden -t 1m volume create -n v-docker docker://lfedge/eden-eclient:83cfe07 --disk-size=200M
-stdout 'create volume v-docker with docker://lfedge/eden-eclient:83cfe07 request sent'
+eden -t 1m volume create -n v-docker docker://lfedge/eden-eclient:d9eb23f --disk-size=200M
+stdout 'create volume v-docker with docker://lfedge/eden-eclient:d9eb23f request sent'
 eden -t 1m volume create -n v-qcow2 file://{{EdenConfig "eden.root"}}/empty.qcow2 --format=qcow2 --disk-size=200M
 stdout 'create volume v-qcow2 with file://{{EdenConfig "eden.root"}}/empty.qcow2 request sent'
 eden -t 1m volume create -n v-qcow file://{{EdenConfig "eden.root"}}/empty.qcow --format=qcow --disk-size=560


### PR DESCRIPTION
Update Eden tests to use alpine-based image of eclient, new Adam with /uuid support and changed qemu options to support watchdog.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>