### PR TITLE
fix logging after domain stop/start

### DIFF
--- a/pkg/pillar/containerd/logging.go
+++ b/pkg/pillar/containerd/logging.go
@@ -94,7 +94,7 @@ type remoteLog struct {
 // Path returns the name of a FIFO connected to the logging daemon.
 func (r *remoteLog) Path(n string) string {
 	path := filepath.Join(r.fifoDir, n+".log")
-	if err := syscall.Mkfifo(path, 0600); err != nil {
+	if err := syscall.Mkfifo(path, 0600); err != nil && err.(syscall.Errno) != syscall.EEXIST {
 		return "/dev/null"
 	}
 	logrus.Infof("Creating %s at %s", "func", logutils.GetMyStack())
@@ -103,7 +103,7 @@ func (r *remoteLog) Path(n string) string {
 		// containerd opens it when the task is started.
 		fd, err := syscall.Open(path, syscall.O_RDONLY, 0)
 		if err != nil {
-			// Should never happen: we just created the fifo
+			// Should never happen: we just checked the fifo
 			logrus.Printf("failed to open fifo %s: %s", path, err)
 		}
 		defer syscall.Close(fd)


### PR DESCRIPTION
I cannot see anything in app logs after stop/start from controller. Seems, we must suppress EEXIST error in remoteLog to do work if the fifo file exists.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>