### PR TITLE
6.12 with removed noexec for /tmp folder

### DIFF
--- a/pkg/xen-tools/initrd/init-initrd
+++ b/pkg/xen-tools/initrd/init-initrd
@@ -42,7 +42,7 @@ mount -t cgroup cgroup /mnt/rootfs/sys/fs/cgroup
 mount -o bind /proc /mnt/rootfs/proc
 mount -t devpts -o gid=5,mode=0620,noexec,nosuid devpts /mnt/rootfs/dev/pts
 mount -t tmpfs -o nodev,nosuid,noexec,size=20% shm /mnt/rootfs/dev/shm
-mount -t tmpfs -o nodev,nosuid,noexec,size=20% tmp /mnt/rootfs/tmp
+mount -t tmpfs -o nodev,nosuid,size=20% tmp /mnt/rootfs/tmp
 mount -t mqueue -o nodev,nosuid,noexec none /mnt/rootfs/dev/mqueue
 ln -s /proc/self/fd /mnt/rootfs/dev/fd
 ln -s /proc/self/fd/0 /mnt/rootfs/dev/stdin


### PR DESCRIPTION
Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>
(cherry picked from commit a75c426fcf4171d0a8e818d0965ec4e549fa1618)