### PR TITLE
rpi4: swap uart as in raspberry/linux

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -223,7 +223,6 @@ function set_arm64_baremetal {
    if [ "$smb_vendor" = "raspberrypi" ]; then
       smbios -t 1 -s 5 --set smb_product
       if [ "$smb_product" = "rpi" ]; then
-         set_global dom0_console "console=tty0 console=ttyS1,115200"
          set_to_existing_file devicetree /boot/dtb/broadcom/bcm2711-rpi-4-b.dtb
       elif [ "$smb_product" = "uno-220" ]; then
          set_to_existing_file devicetree /boot/dtb/broadcom/raspberrypi-uno-220.dtb

--- a/pkg/kernel/patches-5.10.x/0003-arm-dts-rpi4-swap-uart-as-in-raspberry-linux.patch
+++ b/pkg/kernel/patches-5.10.x/0003-arm-dts-rpi4-swap-uart-as-in-raspberry-linux.patch
@@ -1,0 +1,35 @@
+From 33886c32c250b25900f11533f04232e902f943fb Mon Sep 17 00:00:00 2001
+From: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>
+Date: Fri, 22 Oct 2021 09:41:37 +0300
+Subject: [PATCH] arm: dts: rpi4: swap uart as in raspberry/linux
+
+Signed-off-by: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>
+---
+ arch/arm/boot/dts/bcm2711-rpi-4-b.dts | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm/boot/dts/bcm2711-rpi-4-b.dts b/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
+index 09a1182c2936..c5d7353ec823 100644
+--- a/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
++++ b/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
+@@ -12,7 +12,7 @@ / {
+ 
+ 	chosen {
+ 		/* 8250 auxiliary UART instead of pl011 */
+-		stdout-path = "serial1:115200n8";
++		stdout-path = "serial0:115200n8";
+ 	};
+ 
+ 	/* Will be filled by the bootloader */
+@@ -25,6 +25,8 @@ aliases {
+ 		emmc2bus = &emmc2bus;
+ 		ethernet0 = &genet;
+ 		pcie0 = &pcie0;
++		serial0 = &uart1;
++		serial1 = &uart0;
+ 	};
+ 
+ 	leds {
+-- 
+2.25.1
+

--- a/pkg/u-boot/Dockerfile
+++ b/pkg/u-boot/Dockerfile
@@ -9,7 +9,7 @@ SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
 
 ENV VERSION v2021.10
 ENV SOURCE_URL https://github.com/u-boot/u-boot/archive/${VERSION}.tar.gz
-ENV RAPBERRY_FIRMWARE_BLOBS_VERSION 1.20200601
+ENV RAPBERRY_FIRMWARE_BLOBS_VERSION 1.20211007
 ENV RAPBERRY_FIRMWARE_BLOBS https://github.com/raspberrypi/firmware/raw/${RAPBERRY_FIRMWARE_BLOBS_VERSION}
 ENV TARGET_x86_64 qemu-x86_64_defconfig
 ENV TARGET_aarch64 rpi_4_defconfig


### PR DESCRIPTION
This fix problems with garbage on UART port after start EVE services, I think this problem has something to do with getty service and serial tty number mappings/settings.

Signed-off-by: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>