### PR TITLE
Refactor zedcloud and cipher metrics

### DIFF
--- a/pkg/pillar/cipher/cipher.go
+++ b/pkg/pillar/cipher/cipher.go
@@ -67,7 +67,7 @@ func GetCipherCredentials(ctx *DecryptCipherContext,
 	}
 	ctx.Log.Functionf("%s, cipherblock decryption successful", cipherBlock.Key())
 	decBlock = getEncryptionBlock(&zconfigDecBlock)
-	RecordSuccess(ctx.Log, ctx.AgentName)
+	ctx.AgentMetrics.RecordSuccess(ctx.Log)
 	return *cipherBlock, decBlock, err
 }
 
@@ -104,7 +104,7 @@ func GetCipherData(ctx *DecryptCipherContext, status types.CipherBlockStatus,
 func handleCipherBlockCredError(ctx *DecryptCipherContext, status *types.CipherBlockStatus,
 	decBlock types.EncryptionBlock, err error, errtype types.CipherError) (types.CipherBlockStatus, types.EncryptionBlock, error) {
 
-	RecordFailure(ctx.Log, ctx.AgentName, errtype)
+	ctx.AgentMetrics.RecordFailure(ctx.Log, errtype)
 	if err != nil {
 		status.SetErrorNow(err.Error())
 		// we have already captured the error info above

--- a/pkg/pillar/cipher/handlecipher.go
+++ b/pkg/pillar/cipher/handlecipher.go
@@ -26,6 +26,7 @@ import (
 type DecryptCipherContext struct {
 	Log               *base.LogObject
 	AgentName         string
+	AgentMetrics      *AgentMetrics
 	SubControllerCert pubsub.Subscription
 	SubCipherContext  pubsub.Subscription
 	SubEdgeNodeCert   pubsub.Subscription

--- a/pkg/pillar/cipher/metrics.go
+++ b/pkg/pillar/cipher/metrics.go
@@ -1,140 +1,70 @@
 // Copyright (c) 2020 Zededa, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Record failure and successes around object encryption
+// Record failure and successes around object encryption for a single agent.
 
 package cipher
 
 import (
 	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
-	"github.com/sirupsen/logrus" // OK for logrus.Fatal
 	"sync"
 	"time"
 )
 
-// agentMetrics has one entry per agentName aka LogObject
-// Makes it usable when multiple agents are running in the same process aka zedbox
-type agentMetrics struct {
-	metrics types.CipherMetricsMap
+// AgentMetrics stores encryption related metrics for one agent (microservice).
+// Able to properly handle concurrent access.
+type AgentMetrics struct {
+	sync.Mutex
+	metrics types.CipherMetrics
 }
 
-type allMetricsMap map[*base.LogObject]agentMetrics
-
-var allMetrics = make(allMetricsMap)
-var mutex = &sync.Mutex{}
-
-// RecordSuccess records that the decryption succeeded
-func RecordSuccess(log *base.LogObject, agentName string) {
-	log.Functionf("RecordSuccess(%s)", agentName)
-	mutex.Lock()
-	defer mutex.Unlock()
-	m := getMetrics(log, agentName)
-	m.SuccessCount++
-	m.LastSuccess = time.Now()
-	updateMetrics(log, agentName, m)
+// NewAgentMetrics creates instance of AgentMetrics.
+func NewAgentMetrics(agentName string) *AgentMetrics {
+	am := &AgentMetrics{}
+	am.metrics = types.CipherMetrics{
+		AgentName:    agentName,
+		TypeCounters: make([]uint64, types.MaxCipherError),
+	}
+	return am
 }
 
-// RecordFailure records that the decryption failed or did something
-// unexpected like fall back to cleartext
+func (am *AgentMetrics) acquire(log *base.LogObject) (release func()) {
+	if am == nil {
+		log.Fatal("undefined AgentMetrics")
+	}
+	am.Lock()
+	return func() { am.Unlock() }
+}
+
+// RecordSuccess records that a decryption succeeded.
+func (am *AgentMetrics) RecordSuccess(log *base.LogObject) {
+	release := am.acquire(log)
+	defer release()
+	log.Functionf("RecordSuccess(%s)", am.metrics.AgentName)
+	am.metrics.SuccessCount++
+	am.metrics.LastSuccess = time.Now()
+}
+
+// RecordFailure records that a decryption failed or did something
+// unexpected like fall back to cleartext.
 // If the errcode is NoData we just increment the NoData counter but
 // not record as a failure.
-func RecordFailure(log *base.LogObject, agentName string, errcode types.CipherError) {
-	log.Functionf("RecordFailure(%s, %v)", agentName, errcode)
-	mutex.Lock()
-	defer mutex.Unlock()
-	m := getMetrics(log, agentName)
+func (am *AgentMetrics) RecordFailure(log *base.LogObject, errcode types.CipherError) {
+	release := am.acquire(log)
+	defer release()
+	log.Functionf("RecordFailure(%s, %v)", am.metrics.AgentName, errcode)
 	if errcode != types.NoData {
-		m.FailureCount++
-		m.LastFailure = time.Now()
+		am.metrics.FailureCount++
+		am.metrics.LastFailure = time.Now()
 	}
-	m.TypeCounters[errcode]++
-	updateMetrics(log, agentName, m)
+	am.metrics.TypeCounters[errcode]++
 }
 
-func getMetrics(log *base.LogObject, agentName string) types.CipherMetrics {
-	if allMetrics == nil {
-		logrus.Fatal("no allMetrics")
-	}
-	if _, ok := allMetrics[log]; !ok {
-		allMetrics[log] = agentMetrics{metrics: make(types.CipherMetricsMap)}
-	}
-	metrics := allMetrics[log].metrics
-	if _, ok := metrics[agentName]; !ok {
-		log.Noticef("maybeInit(%s) allocate for agent", agentName)
-		metrics[agentName] = types.CipherMetrics{
-			TypeCounters: make([]uint64, types.MaxCipherError),
-		}
-		allMetrics[log] = agentMetrics{metrics: metrics}
-	}
-	return metrics[agentName]
-}
-
-func updateMetrics(log *base.LogObject, agentName string, m types.CipherMetrics) {
-	if allMetrics == nil {
-		logrus.Fatal("no allMetrics")
-	}
-	if _, ok := allMetrics[log]; !ok {
-		logrus.Fatal("allMetrics not initialized")
-	}
-	metrics := allMetrics[log].metrics
-	metrics[agentName] = m
-	allMetrics[log] = agentMetrics{metrics: metrics}
-}
-
-// GetCipherMetrics returns the metrics for this agent aka log pointer.
-// Note that the caller can not safely use this directly since the map
-// might be modified by other goroutines. But the output can be Append'ed to
-// a map owned by the caller.
-// Recommended usage:
-// cms := cipher.Append(types.CipherMetricsMap{}, cipher.GetCipherMetrics(log))
-func GetCipherMetrics(log *base.LogObject) types.CipherMetricsMap {
-	if allMetrics == nil {
-		logrus.Fatal("no allMetrics")
-	}
-	if _, ok := allMetrics[log]; !ok {
-		allMetrics[log] = agentMetrics{metrics: make(types.CipherMetricsMap)}
-	}
-	return allMetrics[log].metrics
-}
-
-// Append concatenates potentially overlappping CipherMetricsMaps to
-// return a union/sum.
-// Append concatenates different interfaces and URLs into a union map
-// Assumes the caller has exclusive access to cms. Uses mutex to serialize
-// access to cms1
-func Append(cms types.CipherMetricsMap, cms1 types.CipherMetricsMap) types.CipherMetricsMap {
-	mutex.Lock()
-	defer mutex.Unlock()
-	for agentName, cm1 := range cms1 {
-		cm, ok := cms[agentName]
-		if !ok {
-			// New agentName; take all but need to deepcopy
-			cm = types.CipherMetrics{}
-		}
-		if cm.LastFailure.IsZero() {
-			// Don't care if cm1 is zero
-			cm.LastFailure = cm1.LastFailure
-		} else if !cm1.LastFailure.IsZero() &&
-			cm1.LastFailure.Sub(cm.LastFailure) > 0 {
-			cm.LastFailure = cm1.LastFailure
-		}
-		if cm.LastSuccess.IsZero() {
-			// Don't care if cm1 is zero
-			cm.LastSuccess = cm1.LastSuccess
-		} else if !cm1.LastSuccess.IsZero() &&
-			cm1.LastSuccess.Sub(cm.LastSuccess) > 0 {
-			cm.LastSuccess = cm1.LastSuccess
-		}
-		cm.FailureCount += cm1.FailureCount
-		cm.SuccessCount += cm1.SuccessCount
-		if cm.TypeCounters == nil {
-			cm.TypeCounters = make([]uint64, types.MaxCipherError)
-		}
-		for i := range cm1.TypeCounters {
-			cm.TypeCounters[i] += cm1.TypeCounters[i]
-		}
-		cms[agentName] = cm
-	}
-	return cms
+// Publish the recorded metrics through the given publisher.
+func (am *AgentMetrics) Publish(log *base.LogObject, publication pubsub.Publication, key string) error {
+	release := am.acquire(log)
+	defer release()
+	return publication.Publish(key, am.metrics)
 }

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -88,6 +88,7 @@ type domainContext struct {
 	pubHostMemory          pubsub.Publication
 	pubProcessMetric       pubsub.Publication
 	pubCipherBlockStatus   pubsub.Publication
+	cipherMetrics          *cipher.AgentMetrics
 	usbAccess              bool
 	createSema             *sema.Semaphore
 	GCComplete             bool
@@ -196,6 +197,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		usbAccess:           true,
 		domainBootRetryTime: 600,
 		pids:                make(map[int32]bool),
+		cipherMetrics:       cipher.NewAgentMetrics(agentName),
 	}
 	aa := types.AssignableAdapters{}
 	domainCtx.assignableAdapters = &aa
@@ -269,7 +271,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	cipherMetricsPub, err := ps.NewPublication(pubsub.PublicationOptions{
 		AgentName: agentName,
-		TopicType: types.CipherMetricsMap{},
+		TopicType: types.CipherMetrics{},
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -299,6 +301,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	}
 	domainCtx.decryptCipherContext.Log = log
 	domainCtx.decryptCipherContext.AgentName = agentName
+	domainCtx.decryptCipherContext.AgentMetrics = domainCtx.cipherMetrics
 	domainCtx.decryptCipherContext.SubControllerCert = subControllerCert
 	subControllerCert.Activate()
 
@@ -593,11 +596,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 		case <-publishTimer.C:
 			start := time.Now()
-			// Transfer to a local copy in since updates are
-			// done concurrently
-			cmm := cipher.Append(types.CipherMetricsMap{},
-				cipher.GetCipherMetrics(log))
-			err = cipherMetricsPub.Publish("global", cmm)
+			err = domainCtx.cipherMetrics.Publish(log, cipherMetricsPub, "global")
 			if err != nil {
 				log.Errorln(err)
 			}
@@ -2218,11 +2217,9 @@ func getCloudInitUserData(ctx *domainContext,
 			// data. Hence this is a fallback if there is
 			// some cleartext.
 			if decBlock.ProtectedUserData != "" {
-				cipher.RecordFailure(log, agentName,
-					types.CleartextFallback)
+				ctx.cipherMetrics.RecordFailure(log, types.CleartextFallback)
 			} else {
-				cipher.RecordFailure(log, agentName,
-					types.MissingFallback)
+				ctx.cipherMetrics.RecordFailure(log, types.MissingFallback)
 			}
 			return decBlock, nil
 		}
@@ -2233,9 +2230,9 @@ func getCloudInitUserData(ctx *domainContext,
 	decBlock := types.EncryptionBlock{}
 	decBlock.ProtectedUserData = *dc.CloudInitUserData
 	if decBlock.ProtectedUserData != "" {
-		cipher.RecordFailure(log, agentName, types.NoCipher)
+		ctx.cipherMetrics.RecordFailure(log, types.NoCipher)
 	} else {
-		cipher.RecordFailure(log, agentName, types.NoData)
+		ctx.cipherMetrics.RecordFailure(log, types.NoData)
 	}
 	return decBlock, nil
 }

--- a/pkg/pillar/cmd/downloader/context.go
+++ b/pkg/pillar/cmd/downloader/context.go
@@ -8,6 +8,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/cipher"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/lf-edge/eve/pkg/pillar/zedcloud"
 )
 
 type downloaderContext struct {
@@ -23,6 +24,8 @@ type downloaderContext struct {
 	subNetworkInstanceStatus pubsub.Subscription
 	deviceNetworkStatus      types.DeviceNetworkStatus
 	subGlobalConfig          pubsub.Subscription
+	zedcloudMetrics          *zedcloud.AgentMetrics
+	cipherMetrics            *cipher.AgentMetrics
 	GCInitialized            bool
 	downloadMaxPortCost      uint8
 }
@@ -44,6 +47,7 @@ func (ctx *downloaderContext) registerHandlers(ps *pubsub.PubSub) error {
 	}
 	ctx.decryptCipherContext.Log = log
 	ctx.decryptCipherContext.AgentName = agentName
+	ctx.decryptCipherContext.AgentMetrics = ctx.cipherMetrics
 	ctx.decryptCipherContext.SubControllerCert = subControllerCert
 	subControllerCert.Activate()
 

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -109,7 +109,7 @@ var nilUUID uuid.UUID
 // current epoch received from controller
 var controllerEpoch int64
 
-func handleConfigInit(networkSendTimeout uint32) *zedcloud.ZedCloudContext {
+func handleConfigInit(networkSendTimeout uint32, agentMetrics *zedcloud.AgentMetrics) *zedcloud.ZedCloudContext {
 
 	// get the server name
 	bytes, err := ioutil.ReadFile(types.ServerFileName)
@@ -122,7 +122,7 @@ func handleConfigInit(networkSendTimeout uint32) *zedcloud.ZedCloudContext {
 	zedcloudCtx := zedcloud.NewContext(log, zedcloud.ContextOptions{
 		DevNetworkStatus: deviceNetworkStatus,
 		Timeout:          networkSendTimeout,
-		NeedStatsFunc:    true,
+		AgentMetrics:     agentMetrics,
 		Serial:           hardware.GetProductSerial(log),
 		SoftSerial:       hardware.GetSoftSerial(log),
 		AgentName:        agentName,

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -22,7 +22,6 @@ import (
 	"github.com/lf-edge/eve/api/go/info"
 	"github.com/lf-edge/eve/api/go/metrics"
 	zmet "github.com/lf-edge/eve/api/go/metrics" // zinfo and zmet here
-	"github.com/lf-edge/eve/pkg/pillar/cipher"
 	"github.com/lf-edge/eve/pkg/pillar/flextimer"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils"
@@ -325,28 +324,13 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 
 	// Transfer to a local copy in since metrics updates are done concurrently
 	cms := types.MetricsMap{}
-	zedagentMetrics := zedcloud.GetCloudMetrics(log)
-	if zedagentMetrics != nil {
-		cms = zedcloud.Append(cms, zedagentMetrics)
-	}
-	if clientMetrics != nil {
-		cms = zedcloud.Append(cms, clientMetrics)
-	}
-	if downloaderMetrics != nil {
-		cms = zedcloud.Append(cms, downloaderMetrics)
-	}
-	if loguploaderMetrics != nil {
-		cms = zedcloud.Append(cms, loguploaderMetrics)
-	}
-	if diagMetrics != nil {
-		cms = zedcloud.Append(cms, diagMetrics)
-	}
-	if nimMetrics != nil {
-		cms = zedcloud.Append(cms, nimMetrics)
-	}
-	if zrouterMetrics != nil {
-		cms = zedcloud.Append(cms, zrouterMetrics)
-	}
+	ctx.zedcloudMetrics.AddInto(log, cms)
+	clientMetrics.AddInto(cms)
+	downloaderMetrics.AddInto(cms)
+	loguploaderMetrics.AddInto(cms)
+	diagMetrics.AddInto(cms)
+	nimMetrics.AddInto(cms)
+	zrouterMetrics.AddInto(cms)
 	for ifname, cm := range cms {
 		metric := metrics.ZedcloudMetric{IfName: ifname,
 			Failures:          cm.FailureCount,
@@ -445,27 +429,16 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 	ReportDeviceMetric.Newlog = nlm
 	log.Tracef("publishMetrics: newlog-metrics %+v", nlm)
 
-	// collect CipherMetric from ourselves and agents and report
-	cipherMetrics := types.CipherMetricsMap{}
-	cipherMetricsZA := cipher.GetCipherMetrics(log)
-	if cipherMetricsZA != nil {
-		cipherMetrics = cipher.Append(cipherMetrics, cipherMetricsZA)
+	// combine CipherMetric from all agents and report
+	cipherMetrics := []types.CipherMetrics{
+		cipherMetricsDL,
+		cipherMetricsDM,
+		cipherMetricsNim,
+		cipherMetricsZR,
 	}
-	if cipherMetricsDL != nil {
-		cipherMetrics = cipher.Append(cipherMetrics, cipherMetricsDL)
-	}
-	if cipherMetricsDM != nil {
-		cipherMetrics = cipher.Append(cipherMetrics, cipherMetricsDM)
-	}
-	if cipherMetricsNim != nil {
-		cipherMetrics = cipher.Append(cipherMetrics, cipherMetricsNim)
-	}
-	if cipherMetricsZR != nil {
-		cipherMetrics = cipher.Append(cipherMetrics, cipherMetricsZR)
-	}
-	for agentName, cm := range cipherMetrics {
-		log.Functionf("Cipher metrics for %s: %+v", agentName, cm)
-		metric := metrics.CipherMetric{AgentName: agentName,
+	for _, cm := range cipherMetrics {
+		log.Functionf("Cipher metrics for %s: %+v", cm.AgentName, cm)
+		metric := metrics.CipherMetric{AgentName: cm.AgentName,
 			FailureCount: cm.FailureCount,
 			SuccessCount: cm.SuccessCount,
 		}
@@ -805,10 +778,8 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 	log.Tracef("publishMetrics: after send, total elapse sec %v", time.Since(startPubTime).Seconds())
 
 	// publish the cloud MetricsMap for zedagent for device debugging purpose
-	if zedagentMetrics != nil {
-		cms = types.MetricsMap{}
-		cms = zedcloud.Append(cms, zedagentMetrics)
-		ctx.pubMetricsMap.Publish("global", cms)
+	if ctx.zedcloudMetrics != nil {
+		ctx.zedcloudMetrics.Publish(log, ctx.pubMetricsMap, "global")
 	}
 }
 

--- a/pkg/pillar/cmd/zedrouter/probe.go
+++ b/pkg/pillar/cmd/zedrouter/probe.go
@@ -302,10 +302,10 @@ func launchHostProbe(ctx *zedrouterContext) {
 	ditems := dpub.GetAll()
 
 	zcloudCtx := zedcloud.NewContext(log, zedcloud.ContextOptions{
-		Timeout:       maxRemoteProbeWait,
-		TLSConfig:     &tls.Config{InsecureSkipVerify: true},
-		NeedStatsFunc: true,
-		AgentName:     agentName,
+		Timeout:      maxRemoteProbeWait,
+		TLSConfig:    &tls.Config{InsecureSkipVerify: true},
+		AgentMetrics: ctx.zedcloudMetrics,
+		AgentName:    agentName,
 	})
 
 	remoteURL := getSystemURL()

--- a/pkg/pillar/devicenetwork/devicenetwork.go
+++ b/pkg/pillar/devicenetwork/devicenetwork.go
@@ -93,7 +93,7 @@ func VerifyDeviceNetworkStatus(log *base.LogObject, ctx *DeviceNetworkContext, s
 	zedcloudCtx := zedcloud.NewContext(log, zedcloud.ContextOptions{
 		DevNetworkStatus: &status,
 		Timeout:          timeout,
-		NeedStatsFunc:    true,
+		AgentMetrics:     ctx.ZedcloudMetrics,
 		Serial:           hardware.GetProductSerial(log),
 		SoftSerial:       hardware.GetSoftSerial(log),
 		AgentName:        agentName,
@@ -132,7 +132,7 @@ func VerifyDeviceNetworkStatus(log *base.LogObject, ctx *DeviceNetworkContext, s
 	}
 	zedcloudCtx.TlsConfig = tlsConfig
 	for ix := range status.Ports {
-		err = CheckAndGetNetworkProxy(log, &status, &status.Ports[ix])
+		err = CheckAndGetNetworkProxy(ctx, &status, &status.Ports[ix])
 		if err != nil {
 			ifName := status.Ports[ix].IfName
 			errStr := fmt.Sprintf("ifName: %s. Failed to get NetworkProxy. Err:%s",
@@ -243,7 +243,7 @@ func MakeDeviceNetworkStatus(ctx *DeviceNetworkContext, globalConfig types.Devic
 		// Result is updating the Pacfile
 		// We always redo this since we don't know what has changed
 		// from the previous DeviceNetworkStatus.
-		err = CheckAndGetNetworkProxy(log, &globalStatus,
+		err = CheckAndGetNetworkProxy(ctx, &globalStatus,
 			&globalStatus.Ports[ix])
 		if err != nil {
 			errStr := fmt.Sprintf("GetNetworkProxy failed for %s: %s",

--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -57,6 +57,9 @@ type DeviceNetworkContext struct {
 	Changed                  bool
 	SubGlobalConfig          pubsub.Subscription
 
+	ZedcloudMetrics *zedcloud.AgentMetrics
+	CipherMetrics   *cipher.AgentMetrics
+
 	Pending                DPCPending
 	NetworkTestTimer       *time.Timer
 	NetworkTestBetterTimer *time.Timer
@@ -996,8 +999,7 @@ func DoDNSUpdate(ctx *DeviceNetworkContext) {
 			*ctx.DeviceNetworkStatus)
 	}
 	if ctx.PubPingMetricMap != nil {
-		cms := zedcloud.Append(types.MetricsMap{}, zedcloud.GetCloudMetrics(log))
-		ctx.PubPingMetricMap.Publish("global", cms)
+		ctx.ZedcloudMetrics.Publish(log, ctx.PubPingMetricMap, "global")
 	}
 	ctx.Changed = true
 }

--- a/pkg/pillar/devicenetwork/wlan.go
+++ b/pkg/pillar/devicenetwork/wlan.go
@@ -175,11 +175,9 @@ func getWifiCredential(ctx *DeviceNetworkContext,
 			// data. Hence this is a fallback if there is
 			// some cleartext.
 			if decBlock.WifiUserName != "" || decBlock.WifiPassword != "" {
-				cipher.RecordFailure(ctx.Log, ctx.AgentName,
-					types.CleartextFallback)
+				ctx.CipherMetrics.RecordFailure(ctx.Log, types.CleartextFallback)
 			} else {
-				cipher.RecordFailure(ctx.Log, ctx.AgentName,
-					types.MissingFallback)
+				ctx.CipherMetrics.RecordFailure(ctx.Log, types.MissingFallback)
 			}
 			return decBlock, nil
 		}
@@ -191,9 +189,9 @@ func getWifiCredential(ctx *DeviceNetworkContext,
 	decBlock.WifiUserName = wifi.Identity
 	decBlock.WifiPassword = wifi.Password
 	if decBlock.WifiUserName != "" || decBlock.WifiPassword != "" {
-		cipher.RecordFailure(ctx.Log, ctx.AgentName, types.NoCipher)
+		ctx.CipherMetrics.RecordFailure(ctx.Log, types.NoCipher)
 	} else {
-		cipher.RecordFailure(ctx.Log, ctx.AgentName, types.NoData)
+		ctx.CipherMetrics.RecordFailure(ctx.Log, types.NoData)
 	}
 	return decBlock, nil
 }

--- a/pkg/pillar/types/ciphermetrics.go
+++ b/pkg/pillar/types/ciphermetrics.go
@@ -10,11 +10,9 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/base"
 )
 
-// CipherMetricsMap maps from an agentname string to some metrics
-type CipherMetricsMap map[string]CipherMetrics
-
 // CipherMetrics are metrics from one agent
 type CipherMetrics struct {
+	AgentName    string
 	FailureCount uint64
 	SuccessCount uint64
 	LastFailure  time.Time

--- a/pkg/pillar/types/zedcloudmetrics.go
+++ b/pkg/pillar/types/zedcloudmetrics.go
@@ -34,3 +34,57 @@ type UrlcloudMetrics struct {
 	TotalTimeSpent int64
 	SessionResume  int64
 }
+
+// AddInto adds metrics from this instance of MetricsMap
+// into the metrics map referenced by toMap.
+func (m MetricsMap) AddInto(toMap MetricsMap) {
+	if m == nil {
+		return
+	}
+	for ifname, src := range m {
+		dst, ok := toMap[ifname]
+		if !ok {
+			// New ifname; take all but need to deepcopy
+			dst = ZedcloudMetric{}
+		}
+		if dst.LastFailure.IsZero() {
+			// Don't care if src is zero
+			dst.LastFailure = src.LastFailure
+		} else if !src.LastFailure.IsZero() &&
+			src.LastFailure.Sub(dst.LastFailure) > 0 {
+			dst.LastFailure = src.LastFailure
+		}
+		if dst.LastSuccess.IsZero() {
+			// Don't care if src is zero
+			dst.LastSuccess = src.LastSuccess
+		} else if !src.LastSuccess.IsZero() &&
+			src.LastSuccess.Sub(dst.LastSuccess) > 0 {
+			dst.LastSuccess = src.LastSuccess
+		}
+		dst.FailureCount += src.FailureCount
+		dst.SuccessCount += src.SuccessCount
+		dst.AuthFailCount += src.AuthFailCount
+		if dst.URLCounters == nil {
+			dst.URLCounters = make(map[string]UrlcloudMetrics)
+		}
+		dstURLs := dst.URLCounters // A pointer to the map
+		for url, srcURL := range src.URLCounters {
+			dstURL, ok := dstURLs[url]
+			if !ok {
+				// New url; take all
+				dstURLs[url] = srcURL
+				continue
+			}
+			dstURL.TryMsgCount += srcURL.TryMsgCount
+			dstURL.TryByteCount += srcURL.TryByteCount
+			dstURL.SentMsgCount += srcURL.SentMsgCount
+			dstURL.SentByteCount += srcURL.SentByteCount
+			dstURL.RecvMsgCount += srcURL.RecvMsgCount
+			dstURL.RecvByteCount += srcURL.RecvByteCount
+			dstURL.TotalTimeSpent += srcURL.TotalTimeSpent
+			dstURL.SessionResume += srcURL.SessionResume
+			dstURLs[url] = dstURL
+		}
+		toMap[ifname] = dst
+	}
+}

--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -65,7 +65,7 @@ type ZedCloudContext struct {
 type ContextOptions struct {
 	DevNetworkStatus *types.DeviceNetworkStatus
 	TLSConfig        *tls.Config
-	NeedStatsFunc    bool
+	AgentMetrics     *AgentMetrics
 	Timeout          uint32
 	Serial           string
 	SoftSerial       string
@@ -886,9 +886,9 @@ func NewContext(log *base.LogObject, opt ContextOptions) ZedCloudContext {
 		AgentName:           opt.AgentName,
 		log:                 log,
 	}
-	if opt.NeedStatsFunc {
-		ctx.FailureFunc = ZedCloudFailure
-		ctx.SuccessFunc = ZedCloudSuccess
+	if opt.AgentMetrics != nil {
+		ctx.FailureFunc = opt.AgentMetrics.RecordFailure
+		ctx.SuccessFunc = opt.AgentMetrics.RecordSuccess
 	}
 	return ctx
 }

--- a/pkg/pillar/zedcloud/zedcloudmetric.go
+++ b/pkg/pillar/zedcloud/zedcloudmetric.go
@@ -1,9 +1,9 @@
 // Copyright (c) 2018 Zededa, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Functions to maintain metrics about the connectivity to zedcloud.
+// AgentMetrics is used to maintain metrics about the connectivity to zedcloud.
 // Just success and failures.
-// Reported as device metrics
+// Reported as device metrics.
 
 package zedcloud
 
@@ -13,57 +13,51 @@ import (
 	"time"
 
 	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
-	"github.com/sirupsen/logrus" // OK for logrus.Fatal
 )
 
-// agentMetrics has one entry per agentName aka LogObject
-// Makes it usable when multiple agents are running in the same process aka zedbox
-type agentMetrics struct {
+// AgentMetrics stores zedcloud related metrics for one agent (microservice).
+// Able to properly handle concurrent access.
+type AgentMetrics struct {
+	sync.Mutex
 	metrics types.MetricsMap
 }
 
-type allMetricsMap map[*base.LogObject]agentMetrics
-
-var allMetrics = make(allMetricsMap)
-var mutex = &sync.Mutex{}
-
-// getAgentIfnameMetrics assumes the caller is holding the mutex
-// The caller needs to call updateAgentIfnameMetrics after any update
-func getAgentIfnameMetrics(log *base.LogObject, ifname string) types.ZedcloudMetric {
-	if allMetrics == nil {
-		logrus.Fatal("no allMetrics")
+// NewAgentMetrics creates instance of AgentMetrics.
+func NewAgentMetrics() *AgentMetrics {
+	return &AgentMetrics{
+		metrics: make(types.MetricsMap),
 	}
-	if _, ok := allMetrics[log]; !ok {
-		allMetrics[log] = agentMetrics{metrics: make(types.MetricsMap)}
+}
+
+func (am *AgentMetrics) acquire(log *base.LogObject) (release func()) {
+	if am == nil {
+		log.Fatal("undefined AgentMetrics")
 	}
-	metrics := allMetrics[log].metrics
-	if _, ok := metrics[ifname]; !ok {
-		metrics[ifname] = types.ZedcloudMetric{
+	am.Lock()
+	return func() { am.Unlock() }
+}
+
+// getInterfaceMetrics is an internal function returning metrics corresponding
+// to a given interface. It assumes that the caller has acquired metrics using AgentMetrics.acquire().
+func (am *AgentMetrics) getInterfaceMetrics(ifname string) types.ZedcloudMetric {
+	if _, ok := am.metrics[ifname]; !ok {
+		am.metrics[ifname] = types.ZedcloudMetric{
 			URLCounters: make(map[string]types.UrlcloudMetrics),
 		}
-		allMetrics[log] = agentMetrics{metrics: metrics}
 	}
-	return metrics[ifname]
+	return am.metrics[ifname]
 }
 
-func updateAgentIfnameMetrics(log *base.LogObject, ifname string, m types.ZedcloudMetric) {
-	if allMetrics == nil {
-		logrus.Fatal("no allMetrics")
-	}
-	if _, ok := allMetrics[log]; !ok {
-		logrus.Fatal("allMetrics not initialized")
-	}
-	metrics := allMetrics[log].metrics
-	metrics[ifname] = m
-	allMetrics[log] = agentMetrics{metrics: metrics}
-}
+// RecordFailure records failed zedcloud API request.
+func (am *AgentMetrics) RecordFailure(log *base.LogObject, ifname, url string, reqLen, respLen int64, authenFail bool) {
+	release := am.acquire(log)
+	defer release()
+	log.Tracef("RecordFailure(%s, %s, %d, %d, %t)",
+		ifname, url, reqLen, respLen, authenFail)
+	m := am.getInterfaceMetrics(ifname)
 
-func ZedCloudFailure(log *base.LogObject, ifname string, url string, reqLen int64, respLen int64, authenFail bool) {
-	log.Tracef("ZedCloudFailure(%s, %s) %d %d",
-		ifname, url, reqLen, respLen)
-	mutex.Lock()
-	m := getAgentIfnameMetrics(log, ifname)
 	// if we have authen verify failure, the network part is success
 	if authenFail {
 		m.AuthFailCount++
@@ -84,15 +78,17 @@ func ZedCloudFailure(log *base.LogObject, ifname string, url string, reqLen int6
 		}
 		m.URLCounters[url] = u
 	}
-	updateAgentIfnameMetrics(log, ifname, m)
-	mutex.Unlock()
+	am.metrics[ifname] = m
 }
 
-func ZedCloudSuccess(log *base.LogObject, ifname string, url string, reqLen int64, respLen int64, timeSpent int64, resume bool) {
-	log.Tracef("ZedCloudSuccess(%s, %s) %d %d",
-		ifname, url, reqLen, respLen)
-	mutex.Lock()
-	m := getAgentIfnameMetrics(log, ifname)
+// RecordSuccess records successful zedcloud API request.
+func (am *AgentMetrics) RecordSuccess(log *base.LogObject, ifname, url string, reqLen, respLen, timeSpent int64, resume bool) {
+	release := am.acquire(log)
+	defer release()
+	log.Tracef("RecordSuccess(%s, %s, %d, %d, %d, %t)",
+		ifname, url, reqLen, respLen, timeSpent, resume)
+	m := am.getInterfaceMetrics(ifname)
+
 	m.SuccessCount += 1
 	m.LastSuccess = time.Now()
 	var u types.UrlcloudMetrics
@@ -109,39 +105,49 @@ func ZedCloudSuccess(log *base.LogObject, ifname string, url string, reqLen int6
 		u.SessionResume++
 	}
 	m.URLCounters[url] = u
-	updateAgentIfnameMetrics(log, ifname, m)
-	mutex.Unlock()
+	am.metrics[ifname] = m
 }
 
-// GetCloudMetrics returns the metrics for an agent aka log pointer.
-// Note that the caller can not safely use this directly since the map
-// might be modified by other goroutines. But the output can be Append'ed to
-// a map owned by the caller.
-// Recommended usage:
-// cms := zedcloud.Append(types.MetricsMap{}, zedcloud.GetCloudMetrics(log))
-func GetCloudMetrics(log *base.LogObject) types.MetricsMap {
-	if allMetrics == nil {
-		logrus.Fatal("no allMetrics")
-	}
-	if _, ok := allMetrics[log]; !ok {
-		allMetrics[log] = agentMetrics{metrics: make(types.MetricsMap)}
-	}
-	return allMetrics[log].metrics
+// Publish the recorded metrics through the given publisher.
+func (am *AgentMetrics) Publish(log *base.LogObject, publication pubsub.Publication, key string) error {
+	release := am.acquire(log)
+	defer release()
+	return publication.Publish(key, am.metrics)
 }
 
-// GetAppURLset - get app url string set
-func GetAppURLset(log *base.LogObject) []string {
-	l := []string{}
-	cms1 := GetCloudMetrics(log)
-	for _, cm := range cms1 {
-		for k, m := range cm.URLCounters {
-			log.Tracef("findMetrics: %v", m)
-			if strings.Contains(k, "apps/instanceid") {
-				l = append(l, k)
+// GetURLsWithSubstr returns URLs containing the given substring.
+func (am *AgentMetrics) GetURLsWithSubstr(log *base.LogObject, substr string) (set []string) {
+	release := am.acquire(log)
+	defer release()
+	for _, cm := range am.metrics {
+		for k := range cm.URLCounters {
+			if strings.Contains(k, substr) {
+				set = append(set, k)
 			}
 		}
 	}
-	return getUniqueValues(l)
+	return getUniqueValues(set)
+}
+
+// RemoveURLMetrics removes all metrics recorded for the given URL.
+func (am *AgentMetrics) RemoveURLMetrics(log *base.LogObject, url string) {
+	release := am.acquire(log)
+	defer release()
+	for intf, m := range am.metrics {
+		if _, ok := m.URLCounters[url]; ok {
+			delete(m.URLCounters, url)
+			log.Tracef("RemoveURLMetrics: on interface %s deleted metrics for url %s", intf, url)
+			continue
+		}
+	}
+}
+
+// AddInto adds metrics from this instance of AgentMetrics
+// into the metrics map referenced by toMap.
+func (am *AgentMetrics) AddInto(log *base.LogObject, toMap types.MetricsMap) {
+	release := am.acquire(log)
+	defer release()
+	am.metrics.AddInto(toMap)
 }
 
 func getUniqueValues(inSlice []string) []string {
@@ -155,73 +161,4 @@ func getUniqueValues(inSlice []string) []string {
 		}
 	}
 	return list
-}
-
-// CleanAppCloudMetrics - remove app log metric in map by url
-func CleanAppCloudMetrics(log *base.LogObject, url string) {
-	metrics := GetCloudMetrics(log)
-	for intf, m := range metrics {
-		if _, ok := m.URLCounters[url]; ok {
-			delete(m.URLCounters, url)
-			log.Tracef("CleanAppCloudMetrics: on %s deleted metric of url %s", intf, url)
-			continue
-		}
-	}
-}
-
-// Append concatenates different interfaces and URLs into a union map
-// Assumes the caller has exclusive access to cms. Uses mutex to serialize
-// access to cms1
-func Append(cms types.MetricsMap, cms1 types.MetricsMap) types.MetricsMap {
-	mutex.Lock()
-	defer mutex.Unlock()
-
-	for ifname, cm1 := range cms1 {
-		cm, ok := cms[ifname]
-		if !ok {
-			// New ifname; take all but need to deepcopy
-			cm = types.ZedcloudMetric{}
-		}
-		if cm.LastFailure.IsZero() {
-			// Don't care if cm1 is zero
-			cm.LastFailure = cm1.LastFailure
-		} else if !cm1.LastFailure.IsZero() &&
-			cm1.LastFailure.Sub(cm.LastFailure) > 0 {
-			cm.LastFailure = cm1.LastFailure
-		}
-		if cm.LastSuccess.IsZero() {
-			// Don't care if cm1 is zero
-			cm.LastSuccess = cm1.LastSuccess
-		} else if !cm1.LastSuccess.IsZero() &&
-			cm1.LastSuccess.Sub(cm.LastSuccess) > 0 {
-			cm.LastSuccess = cm1.LastSuccess
-		}
-		cm.FailureCount += cm1.FailureCount
-		cm.SuccessCount += cm1.SuccessCount
-		cm.AuthFailCount += cm1.AuthFailCount
-		if cm.URLCounters == nil {
-			cm.URLCounters = make(map[string]types.UrlcloudMetrics)
-		}
-		cmu := cm.URLCounters // A pointer to the map
-		for url, um1 := range cm1.URLCounters {
-			um, ok := cmu[url]
-			if !ok {
-				// New url; take all
-				cmu[url] = um1
-				continue
-			}
-			um.TryMsgCount += um1.TryMsgCount
-			um.TryMsgCount += um1.TryMsgCount
-			um.TryByteCount += um1.TryByteCount
-			um.SentMsgCount += um1.SentMsgCount
-			um.SentByteCount += um1.SentByteCount
-			um.RecvMsgCount += um1.RecvMsgCount
-			um.RecvByteCount += um1.RecvByteCount
-			um.TotalTimeSpent += um1.TotalTimeSpent
-			um.SessionResume += um1.SessionResume
-			cmu[url] = um
-		}
-		cms[ifname] = cm
-	}
-	return cms
 }


### PR DESCRIPTION
Both zedcloud and cipher metrics are stored inside a global map,
which, as long as we have zedbox microservices running inside the same
process, has to be able to handle concurrent read/write access.
Additionally, even within a single microservice, thread-safety is
required because metrics collection and publication is split between
different go routines.

The solution to achieve thread-safety is currently built around a somewhat
confusing Append function and there is also a mutex as a separate global variable,
but it is only used to avoid concurrent writes, not guarding read operations.
For example, `GetCipherMetrics()` is always called with metrics unlocked,
even though the function could interleave with `RecordSuccess/Failure`
write operations. Even worse, the seemingly read-only `GetCipherMetrics()` can
happily write into the metrics map if the map is found to be uninitialized still.
Overall, the current implementation relies way too much on the user of these
metrics to do the right thing and avoid any of the many pitfalls.
As a result, we had and are [still getting occasional crashes](https://github.com/lf-edge/eve/runs/3946672769#step:8:2430) due to a concurrent
access to these global metric maps.

This PR refactors both zedcloud and cipher metrics (in the same way).
First of all, there is no need for global variables. Every microservice is already
managing its own set of zedcloud/cipher metrics and publishing them to zedagent using
pubsub. Metrics can be therefore instantiated per agent inside their contexts.
Secondly, the use of locking for thread-safety is wrapped inside these
refactored metrics (following the OOP encapsulation principle). Caller can
happily access these metrics concurrently (through exposed methods) and the locks
are automatically acquired/released as needed.

Signed-off-by: Milan Lenco <milan@zededa.com>