### PR TITLE
Fix hasWifiPortConfig to handle in-progress DPC testing

### DIFF
--- a/pkg/pillar/devicenetwork/wlan.go
+++ b/pkg/pillar/devicenetwork/wlan.go
@@ -58,7 +58,11 @@ func updateWlanConfig(ctx *DeviceNetworkContext, oldCfg *types.DevicePortConfig,
 }
 
 func hasWifiPortConfig(ctx *DeviceNetworkContext) bool {
-	for _, portCfg := range ctx.DevicePortConfig.Ports {
+	dpc := ctx.DevicePortConfig
+	if ctx.Pending.Inprogress {
+		dpc = &ctx.Pending.PendDPC
+	}
+	for _, portCfg := range dpc.Ports {
 		if portCfg.WirelessCfg.WType == types.WirelessTypeWifi {
 			return true
 		}


### PR DESCRIPTION
The original implementation of `hasWifiPortConfig()` function would not work properly if testing was in progress.
It could lead to an unintended RF-kill of all wlan devices during testing of a new DPC (typically after EVE image upgrade).

Signed-off-by: Milan Lenco <milan@zededa.com>