### PR TITLE
Config items: honour persisted config & support run-time change

### DIFF
--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -412,7 +412,7 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 	var gcp *types.ConfigItemValueMap
 	debug, gcp = agentlog.HandleGlobalConfig(log, ctxPtr.subGlobalConfig, agentName,
 		debugOverride, ctxPtr.agentBaseContext.Logger)
-	if gcp != nil && !ctxPtr.GCInitialized {
+	if gcp != nil {
 		ctxPtr.globalConfig = gcp
 		ctxPtr.GCInitialized = true
 	}

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -1881,7 +1881,7 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 	var gcp *types.ConfigItemValueMap
 	debug, gcp = agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
 		debugOverride, logger)
-	if gcp != nil && !ctx.GCInitialized {
+	if gcp != nil {
 		ctx.globalConfig = *gcp
 		ctx.GCInitialized = true
 		ctx.gcpMaintenanceMode = gcp.GlobalValueTriState(types.MaintenanceMode)


### PR DESCRIPTION
This commit addresses two issues/limitations related to global config items:
    
1. nodeagent and zedagent do not support runtime changes of global config items.
    They only apply the very first received instance of `ConfigItemValueMap`
    and ignore any subsequent changes. This for example means, that
    changing `timer.reboot.no.network` for an already onboarded and
    running device has no effect - the change is ignored.
    To support run-time change of config items is as simple as changing
    a single if condition inside the handler for `ConfigItemValueMap` subscription.
    
2. Few months ago the upgradeconverter was improved to support override
    of config items via the config partition. However, these changes
    no longer take into account potentially persisted config from a
    previous run. Currently, if config items are not overridden
    via config partition (`/config/GlobalConfig/global.json` does not exist),
    the updateconverter will immediately apply default values. This
    commits makes changes to check for persisted config items before
    restoring to defaults.

Signed-off-by: Milan Lenco <milan@zededa.com>