### PR TITLE
wwan: Update metrics/status json files atomically

### DIFF
--- a/pkg/wwan/usr/bin/wwan-init.sh
+++ b/pkg/wwan/usr/bin/wwan-init.sh
@@ -442,11 +442,15 @@ __EOT__
   if [ "$EVENT" = "METRICS" ]; then
     json_struct \
       "$(json_attr networks "$(printf "%b" "$METRICS" | json_array)")" \
-        | jq > "$METRICS_PATH"
+        | jq > "${METRICS_PATH}.tmp"
+    # update metrics atomically
+    mv "${METRICS_PATH}.tmp" "${METRICS_PATH}"
   else
     json_struct \
       "$(json_attr     networks        "$(printf "%b" "$STATUS" | json_array)")" \
       "$(json_str_attr config-checksum "$CHECKSUM")" \
-        | jq > "$STATUS_PATH"
+        | jq > "${STATUS_PATH}.tmp"
+    # update metrics atomically
+    mv "${STATUS_PATH}.tmp" "${STATUS_PATH}"
   fi
 done


### PR DESCRIPTION
We get plenty of `Failed to unmarshall ...` errors from `devicenetwork/wwan.go`.
Note that nim is now using fsnotify to watch for updates of wwan
status and metrics, which are published from the wwan service as json files.
But because the wwan status and metrics json files are being updated
in-place, this sometimes produces several WRITE notifications
(one for each `write()` syscall), already before an update is completely written out.

As a workaround, updates of wwan status and metrics are first
written into temporary files and then moved (renamed) atomically
into the proper filesystem locations, thus producing only a single
notification per file at the end of each update.

Signed-off-by: Milan Lenco <milan@zededa.com>