### PR TITLE
Meta-data server support for switch network instance

### DIFF
--- a/pkg/pillar/cmd/zedrouter/flowstats.go
+++ b/pkg/pillar/cmd/zedrouter/flowstats.go
@@ -589,8 +589,8 @@ func checkFlowUnpublish(ctx *zedrouterContext) {
 	}
 }
 
-// DNSMonitor : DNS Query and Reply monitor on bridges
-func DNSMonitor(bn string, bnNum int, ctx *zedrouterContext, status *types.NetworkInstanceStatus) {
+// DNSDhcpMonitor : DNS Query/Reply and DHCP monitor on bridges
+func DNSDhcpMonitor(bn string, bnNum int, ctx *zedrouterContext, status *types.NetworkInstanceStatus) {
 	var (
 		err         error
 		snapshotLen int32 = 1280             // draft-madi-dnsop-udp4dns-00

--- a/pkg/pillar/cmd/zedrouter/server.go
+++ b/pkg/pillar/cmd/zedrouter/server.go
@@ -67,7 +67,7 @@ const AppInstMetadataResponseSizeLimitInBytes = 35840 // 35KB
 func createServer4(ctx *zedrouterContext, bridgeIP string, bridgeName string) error {
 	if bridgeIP == "" {
 		err := fmt.Errorf("can't run server on %s: no bridgeIP", bridgeName)
-		log.Error(err)
+		log.Warn(err)
 		return err
 	}
 	mux := http.NewServeMux()

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -2078,6 +2078,7 @@ func handleDNSImpl(ctxArg interface{}, key string,
 	// Look for ports which disappeared
 	maybeRetryNetworkInstances(ctx)
 	propagateNetworkInstToAppNetwork(ctx)
+	handleMetaDataServerChange(ctx, &status)
 	log.Functionf("handleDNSImpl done for %s\n", key)
 }
 

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -2018,6 +2018,9 @@ type NetworkInstanceInfo struct {
 	VlanMap map[uint32]uint32
 	// Counts the number of trunk ports attached to this network instance
 	NumTrunkPorts uint32
+
+	// IP address on which the meta-data server listens
+	MetaDataServerIP string
 }
 
 func (instanceInfo *NetworkInstanceInfo) IsVifInBridge(


### PR DESCRIPTION
Description:
1. Start meta data server if the port to which switch network instance
is attached already has a valid IP address.
2. Look for changes in Device network status to see if any of the switch
network instances will need meta-data server related processing.
3. Add acl rule to block connection request coming to meta-data server
from external hosts.

Signed-off-by: Gopi krishna Kodali <gkodali@zededa.com>