### PR TITLE
non-templated Dockerfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ obj
 dist/
 build-tools/bin/
 images/*.yml
-pkg/pillar/Dockerfile
 pkg/qrexec-dom0/Dockerfile
 pkg/qrexec-lib/Dockerfile
 .go/

--- a/pkg/pillar/Dockerfile
+++ b/pkg/pillar/Dockerfile
@@ -56,11 +56,11 @@ RUN set -e && for patch in /sys-patches/*.patch; do \
     done
 
 # hadolint ignore=DL3006
-FROM DNSMASQ_TAG as dnsmasq
+FROM lfedge/eve-dnsmasq:cc2426e0f51538f60e82c7ffe26e6a857fdc2483 as dnsmasq
 # hadolint ignore=DL3006
-FROM STRONGSWAN_TAG as strongswan
+FROM lfedge/eve-strongswan:5b322e95477774eca6ecf2fbe10945b56ff5310b as strongswan
 # hadolint ignore=DL3006
-FROM GPTTOOLS_TAG as gpttools
+FROM lfedge/eve-gpt-tools:11cd917db4f3b5d12bec731926af2832d52f5362 as gpttools
 
 FROM scratch
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]


### PR DESCRIPTION
This is an attempt to get away from the `Dockerfile.in` templated Dockerfiles. There are five of them in our builds:

* pillar
* qrexec-dom0
* qrexec-lib
* xen-tools
* eve

This draft PR addresses 4 out of the 5, with the exception of eve.

In addition, it updates the tool `tools/update-component-sha.sh` with a new option `--pkg <dir>`

## Why

The existing system has a few shortcomings. This is a draft because I am not convinced that this approach is right, but is worthy of discussion. This came up as a direct result of extensive discussions with and ideas from @ruslan-zededa 

The issues are:

* The build system is complicated. You need to understand `tools/parse-pkgs.sh` and how it figures out all of its dependencies every time you build, even if none of the dependencies have changed in a long time.
* Provenance: it is impossible to look at the checked-in version of `pkg/pillar/Dockerfile` to see exactly what went into a given commit or release. Actually, there _is no_ checked-in version, only a template at `pkg/pillar/Dockerfile.in`
* the chained builds - build an image in one Dockerfile, then build another based on it in another Dockerfile - do not work with containerized buildkit, which linuxkit builds on

## Current Flow

The current flow is:

1. Make changes in an upstream dependency, e.g. `pkg/dnsmasq`
2. Build the downstream, e.g. `pkg/pillar`, which does the following, in a combination of `Makefile` and `parse-pkgs.sh`:
   a. Figure out the upstream tag via `lkt pkg show-tag <dir>`
   b. Build upstream to the new tag
   c. Generate `<dir>/Dockerfile.in` -> `<dir>/Dockerfile`
   d. Build downstream

## Proposed

1. Make changes in upstream
2. Build upstream
3. **Push out to registry**
4. Run `tools/update-component-sha.sh --pkg  <dir>`
5. Build downstream

## Challenges/Questions

There is a number of challenges or questions with this approach.

First, what happens if someone builds locally. E.g. they want to change dnsmasq and then update pillar. They would _have_ to push out dnsmasq just to get pillar to build. Of course, the current builder is stuck and cannot advance beyond the long-deprecated version of linuxkit because of the buildkit issues.

Second, how does the push to hub happen? Looking on Docker Hub at [pillar tags](https://hub.docker.com/r/lfedge/eve-pillar/tags), every commit (or at least commit merged to master) is there; looking at [dnsmasq tags](https://hub.docker.com/r/lfedge/eve-dnsmasq/tags) it appears only the releases are there? How is pillar pushed out on each commit but dnsmasq not?

Note: While docker is dealing with the buildkit issues, it is part of a larger suite of problems which is being addressed. They will get to it, but not necessarily soon.

Feedback needed especially from @eriknordmark and @rvs. 
