### PR TITLE
RFC: introduce conf/storage.cfg

### DIFF
--- a/conf/storage.cfg
+++ b/conf/storage.cfg
@@ -1,0 +1,6 @@
+# You can put your storgate overrides here For example you can control
+# zfs module parameters. It is possible to use multiple lines
+# separated with a backslash `\`:
+#
+#    STORAGE_ZFS_MODULE_OPTS=zfs_dirty_data_max_percent=5 \
+#    zfs_dirty_data_sync_percent=15


### PR DESCRIPTION
The file will be placed on /config partition wich persists across
reboots. The purpose of the file is to keep variables affecting
storage configuartion. Currently it allows to change zfs module
parameters.

Signed-off-by: Yuri Volchkov <yuri@zededa.com>