### PR TITLE
Fix CheckBadAssignmentGroup to handle empty assigngrp

### DIFF
--- a/pkg/pillar/types/assignableadapters.go
+++ b/pkg/pillar/types/assignableadapters.go
@@ -409,7 +409,7 @@ func (aa *AssignableAdapters) CheckBadAssignmentGroups(log *base.LogObject, PCIS
 			if ib2.Phylabel == ib.Phylabel {
 				continue
 			}
-			if ib.AssignmentGroup != "" && ib2.AssignmentGroup == ib.AssignmentGroup {
+			if ib.AssignmentGroup == "" || ib2.AssignmentGroup == ib.AssignmentGroup {
 				continue
 			}
 			if PCISameController != nil && PCISameController(ib.PciLong, ib2.PciLong) {

--- a/pkg/pillar/types/assignableadapters_test.go
+++ b/pkg/pillar/types/assignableadapters_test.go
@@ -340,6 +340,14 @@ var aa2 AssignableAdapters = AssignableAdapters{
 			PciLong:         "",
 			Serial:          "/dev/ttyS3",
 		},
+		{
+			Type:            IoAudio,
+			Phylabel:        "Audio",
+			Logicallabel:    "Audio",
+			AssignmentGroup: "",
+			Ifname:          "None",
+			PciLong:         "0000:05:01.f",
+		},
 	},
 }
 
@@ -355,6 +363,7 @@ var aa2Errors = []string{
 	"",
 	"CheckBadAssignmentGroup: eth9 same PCI controller as eth8; pci long 0000:08:00.1 vs 0000:08:00.0",
 	"CheckBadAssignmentGroup: eth8 same PCI controller as eth9; pci long 0000:08:00.0 vs 0000:08:00.1",
+	"",
 	"",
 	"",
 	"",


### PR DESCRIPTION
Empty assignment group means not assignable, thus do not need to check
if it is in the same group as some other adapter. Without this some
hardware models will see errors of the form:
CheckBadAssignmentGroup: same PCI controller as ; pci long 0000:00:14.0
vs 0000:00:14.0
