### PR TITLE
Fix SMART_details.json path in zedagent

### DIFF
--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -925,7 +925,7 @@ func createAppInstances(ctxPtr *zedagentContext,
 }
 
 func parseSMARTData() {
-	filename := "/run/SMART_details.json"
+	filename := "/persist/SMART_details.json"
 	data, err := ioutil.ReadFile(filename)
 	if err != nil {
 		log.Errorf("parseSMARTData: exception while opening %s. %s", filename, err.Error())


### PR DESCRIPTION
`SMART_details.json` was read from a wrong path in `zedagent/reportinfo.go`. Changed the path to `/persist/SMART_details.json`