### PR TITLE
Making sure that we get debug console for installer on Packet

### DIFF
--- a/pkg/eve/installer/ipxe.efi.cfg
+++ b/pkg/eve/installer/ipxe.efi.cfg
@@ -17,9 +17,10 @@ set console console=ttyS0 console=ttyS1 console=ttyS2 console=ttyAMA0 console=tt
 set eve_args eve_soft_serial=${mac:hexhyp} eve_reboot_after_install
 set installer_args root=/initrd.image find_boot=netboot overlaytmpfs fastboot
 
-# a few vendor tweaks
+# a few vendor tweaks (mostly an example, although they DO work on Packet.net servers)
 iseq ${smbios/manufacturer} Huawei && set console console=ttyAMA0,115200n8 ||
 iseq ${smbios/manufacturer} Huawei && set platform_tweaks pcie_aspm=off pci=pcie_bus_perf crashkernel=auto ||
+iseq ${smbios/manufacturer} Supermicro && set console console=ttyS1,115200n8 ||
 
 kernel ${url}kernel ${eve_args} ${installer_args} ${console} ${platform_tweaks} initrd=initrd.img initrd=installer.img initrd=initrd.bits initrd=rootfs.img
 initrd ${url}initrd.img


### PR DESCRIPTION
A very simple hack to enable debug console on Packet for our most frequently used Supermicro instance.