### PR TITLE
Avoid transient AKID failures

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -290,6 +290,7 @@ func publishEdgeNodeCertsToController(ctx *zedagentContext) {
 
 	// not V2API
 	if !zedcloud.UseV2API() {
+		ctx.publishedEdgeNodeCerts = true
 		return
 	}
 
@@ -327,6 +328,7 @@ func publishEdgeNodeCertsToController(ctx *zedagentContext) {
 	log.Tracef("publishEdgeNodeCertsToController: after send, total elapse sec %v",
 		time.Since(startPubTime).Seconds())
 	ctx.cipherCtx.iteration++
+	ctx.publishedEdgeNodeCerts = true
 }
 
 // Try all (first free, then rest) until it gets through.

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -232,6 +232,13 @@ func getLatestConfig(url string, iteration int,
 	getconfigCtx *getconfigContext) bool {
 
 	log.Tracef("getLatestConfig(%s, %d)", url, iteration)
+	// If we haven't yet published our certificates we defer to ensure
+	// that the controller has our certs and can add encrypted secrets to
+	// our config.
+	if !getconfigCtx.zedagentCtx.publishedEdgeNodeCerts {
+		log.Noticef("Defer fetching config until our EdgeNodeCerts have been published")
+		return false
+	}
 	ctx := getconfigCtx.zedagentCtx
 	const bailOnHTTPErr = false // For 4xx and 5xx HTTP errors we try other interfaces
 	// except http.StatusForbidden(which returns error

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -163,6 +163,9 @@ type zedagentContext struct {
 
 	// Track the counter from force.fallback.counter to detect changes
 	forceFallbackCounter int
+
+	// Interlock with controller to ensure we get the encrypted secrets
+	publishedEdgeNodeCerts bool
 }
 
 var debug = false


### PR DESCRIPTION
Wait to fetch config until after we have published the EdgeNodeCerts so
that the controller has a chance to encrypt the secrets including the
datastore credentials. This should avoid getting the authorinization
(AKID) errors from S3 on the first try to download immediately after
booting the device.

Signed-off-by: eriknordmark <erik@zededa.com>