### PR TITLE
Add LVM2 packaged to alpine

### DIFF
--- a/pkg/alpine/mirrors/3.13/main
+++ b/pkg/alpine/mirrors/3.13/main
@@ -106,6 +106,7 @@ libxrandr-dev
 libxtst-dev
 linux-headers
 linux-pam-dev
+lvm2
 lz4
 lz4-libs
 lzo-dev


### PR DESCRIPTION
this commit is a part of LVM2 support implementation
without this commit we cannot generate a public hash that can
be used in other packages