### PR TITLE
reduce unnecessary info messages

### DIFF
--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -805,11 +805,7 @@ func encodeCellProviders(wwanProviders []types.WwanProvider) (providers []*info.
 }
 
 func encodeSystemAdapterInfo(ctx *zedagentContext) *info.SystemAdapterInfo {
-	dpcl := types.DevicePortConfigList{}
-	item, err := ctx.subDevicePortConfigList.Get("global")
-	if err == nil {
-		dpcl = item.(types.DevicePortConfigList)
-	}
+	dpcl := *ctx.DevicePortConfigList
 	sainfo := new(info.SystemAdapterInfo)
 	sainfo.CurrentIndex = uint32(dpcl.CurrentIndex)
 	sainfo.Status = make([]*info.DevicePortStatus, len(dpcl.PortConfigList))


### PR DESCRIPTION
Signed-off-by: Naiming Shen <naiming@zededa.com>
Some of the info message updates do not reflect changes on real status of the device
they mainly due to new timestamp changes from some structure status check.
- this patch is to find the changes due to insignificant changes and suppress the upload
- but add a periodical publish of info about 10 mins to advertise the more recent timestamps