### PR TITLE
add error on nil CloudInitUserData

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -2212,6 +2212,11 @@ func getCloudInitUserData(ctx *domainContext,
 		if err != nil {
 			log.Errorf("%s, domain config cipherblock decryption unsuccessful, falling back to cleartext: %v",
 				dc.Key(), err)
+			if dc.CloudInitUserData == nil {
+				ctx.cipherMetrics.RecordFailure(log, types.MissingFallback)
+				return decBlock, fmt.Errorf("domain config cipherblock decryption unsuccessful (%s); "+
+					"no fallback data", err)
+			}
 			decBlock.ProtectedUserData = *dc.CloudInitUserData
 			// We assume IsCipher is only set when there was some
 			// data. Hence this is a fallback if there is
@@ -2228,6 +2233,10 @@ func getCloudInitUserData(ctx *domainContext,
 	}
 	log.Functionf("%s, domain config cipherblock not present", dc.Key())
 	decBlock := types.EncryptionBlock{}
+	if dc.CloudInitUserData == nil {
+		ctx.cipherMetrics.RecordFailure(log, types.NoCipher)
+		return decBlock, nil
+	}
 	decBlock.ProtectedUserData = *dc.CloudInitUserData
 	if decBlock.ProtectedUserData != "" {
 		ctx.cipherMetrics.RecordFailure(log, types.NoCipher)


### PR DESCRIPTION
We can hit nil pointer dereference in case of no plaintext UserData sended from cloud. To avoid it we must return error in case of failure from cipherblock's decryption/validation and nil plaitext UserData.