### PR TITLE
fix zedrouter no addresses

### DIFF
--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -1518,6 +1518,9 @@ func getLocalAddrImpl(globalStatus DeviceNetworkStatus, pickNum int,
 		return net.IP{}, err
 	}
 	numAddrs := len(addrs)
+	if numAddrs == 0 {
+		return net.IP{}, fmt.Errorf("no addresses")
+	}
 	pickNum = pickNum % numAddrs
 	return addrs[pickNum], nil
 }


### PR DESCRIPTION
In case of no addresses on interfaces we may hit division by zero in getLocalAddrImpl.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>