### PR TITLE
Download resume for s3 datastore

### DIFF
--- a/libs/zedUpload/awsutil/s3api.go
+++ b/libs/zedUpload/awsutil/s3api.go
@@ -18,8 +18,12 @@ import (
 )
 
 const (
-	S3_PART_SIZE        = 5 * 1024 * 1024
-	S3_PART_LEAVE_ERROR = true
+	//S3Concurrency parallels parts download limit
+	S3Concurrency = 5
+	//S3PartSize size of part to download
+	S3PartSize = 5 * 1024 * 1024
+	//S3PartLeaveError leaves parts to manual resolve errors on uploads
+	S3PartLeaveError = true
 )
 
 type S3ctx struct {
@@ -66,11 +70,13 @@ func NewAwsCtx(id, secret, region string, hctx *http.Client) *S3ctx {
 	// s3.New is deprecated.. Ignoring the lint error as this is not new code.
 	ctx.ss3 = s3.New(session.New(), cfg) // nolint
 	ctx.up = s3manager.NewUploaderWithClient(ctx.ss3, func(u *s3manager.Uploader) {
-		u.PartSize = S3_PART_SIZE
-		u.LeavePartsOnError = S3_PART_LEAVE_ERROR
+		u.PartSize = S3PartSize
+		u.LeavePartsOnError = S3PartLeaveError
+		u.Concurrency = S3Concurrency
 	})
 	ctx.dn = s3manager.NewDownloaderWithClient(ctx.ss3, func(d *s3manager.Downloader) {
-		d.PartSize = S3_PART_SIZE
+		d.PartSize = S3PartSize
+		d.Concurrency = S3Concurrency
 	})
 
 	return &ctx

--- a/libs/zedUpload/datastore.go
+++ b/libs/zedUpload/datastore.go
@@ -34,7 +34,7 @@ const (
 	SysOpDownloadByChunks       = 10
 	DefaultNumberOfHandlers     = 11
 
-	StatsUpdateTicker = 5 * time.Second // timer for updating client for stats
+	StatsUpdateTicker = 1 * time.Second // timer for updating client for stats
 	FailPostTimeout   = 2 * time.Minute
 )
 

--- a/libs/zedUpload/datastore_aws.go
+++ b/libs/zedUpload/datastore_aws.go
@@ -198,6 +198,7 @@ func (ep *AwsTransportMethod) processS3Download(req *DronaRequest) (error, int) 
 						return
 					}
 				case <-ticker.C:
+					req.doneParts = stats.DoneParts
 					ep.ctx.postSize(req, stats.Size, stats.Asize)
 				}
 			}
@@ -211,7 +212,8 @@ func (ep *AwsTransportMethod) processS3Download(req *DronaRequest) (error, int) 
 	if req.cancelContext != nil {
 		sc = sc.WithContext(req.cancelContext)
 	}
-	err := sc.DownloadFile(req.objloc, ep.bucket, req.name, req.sizelimit, prgChan)
+	doneParts, err := sc.DownloadFile(req.objloc, ep.bucket, req.name, req.sizelimit, req.doneParts, prgChan)
+	req.doneParts = doneParts
 	if err != nil {
 		return err, 0
 	}

--- a/libs/zedUpload/datastore_req.go
+++ b/libs/zedUpload/datastore_req.go
@@ -13,6 +13,8 @@ import (
 	"os"
 	"sync"
 	"time"
+
+	"github.com/lf-edge/eve/libs/zedUpload/types"
 )
 
 var (
@@ -90,6 +92,9 @@ type DronaRequest struct {
 	EtagID string
 	// chunkInfoChan used for communication of chunk details
 	chunkInfoChan chan ChunkData
+
+	//downloaded parts indexes
+	doneParts types.DownloadedParts
 }
 
 // Return object local name
@@ -337,4 +342,16 @@ func (req *DronaRequest) WithCancel(ctx context.Context) *DronaRequest {
 	req.cancelContext = cancelContext
 	req.cancelFunc = cancel
 	return req
+}
+
+// WithDoneParts can be used to set already downloaded parts indexes
+func (req *DronaRequest) WithDoneParts(doneParts types.DownloadedParts) *DronaRequest {
+
+	req.doneParts = doneParts
+	return req
+}
+
+// GetDoneParts returns already downloaded parts indexes
+func (req *DronaRequest) GetDoneParts() types.DownloadedParts {
+	return req.doneParts
 }

--- a/libs/zedUpload/types/downloadedparts.go
+++ b/libs/zedUpload/types/downloadedparts.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2021 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+)
+
+//PartDefinition keeps information about one part
+type PartDefinition struct {
+	Ind  int64 `json:"i"` // index of part
+	Size int64 `json:"s"` // current size of part
+}
+
+// DownloadedParts keeps information about downloaded parts of blob
+type DownloadedParts struct {
+	PartSize int64             // the maximum partition size
+	Parts    []*PartDefinition // definition of downloaded parts
+}
+
+// Hash returns hash of DownloadedParts struct
+func (dp *DownloadedParts) Hash() string {
+	data, err := json.Marshal(dp)
+	if err != nil {
+		return ""
+	}
+	hash := sha256.New()
+	if _, err = hash.Write(data); err != nil {
+		return ""
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+//SetPartSize search for ind in DownloadedParts and set its size.
+//If not found, append parts with ind and size
+func (dp *DownloadedParts) SetPartSize(ind, size int64) {
+	for _, p := range dp.Parts {
+		if p.Ind == ind {
+			p.Size = size
+			return
+		}
+	}
+	dp.Parts = append(dp.Parts, &PartDefinition{Ind: ind, Size: size})
+}

--- a/pkg/pillar/cmd/downloader/dirs.go
+++ b/pkg/pillar/cmd/downloader/dirs.go
@@ -6,7 +6,13 @@ package downloader
 import (
 	"os"
 	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
 )
+
+const progressFileSuffix = ".progress"
 
 // Create the object download directories we own
 func createDownloadDirs() {
@@ -25,14 +31,51 @@ func createDownloadDirs() {
 }
 
 // clear in-progress object download directories
-func clearInProgressDownloadDirs() {
+// it checks for progress files and remove objects if progress or object do not exist
+// if ctx provided it go through DownloaderConfig and prepare existingTargets map
+// to clean all files which are not inside config
+func clearInProgressDownloadDirs(ctx *downloaderContext) {
+	existingTargets := make(map[string]bool)
+	if ctx != nil {
+		dss := ctx.subDownloaderConfig.GetAll()
+		for _, ds := range dss {
+			obj := ds.(types.DownloaderConfig)
+			existingTargets[obj.Target] = true
+		}
+	}
 
 	// Now remove the in-progress dirs
 	workingDirTypes := []string{getPendingDir()}
 
 	for _, dirName := range workingDirTypes {
 		if _, err := os.Stat(dirName); err == nil {
-			if err := os.RemoveAll(dirName); err != nil {
+			err := filepath.Walk(dirName, func(walkPath string, fi os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+				if fi.IsDir() {
+					return nil
+				}
+				// if progress file
+				if strings.HasSuffix(walkPath, progressFileSuffix) {
+					//check if progress file points onto existing file
+					if _, err := os.Stat(strings.TrimSuffix(walkPath, progressFileSuffix)); err == nil {
+						return nil
+					}
+					// if not exists, remove progress file
+					return os.Remove(walkPath)
+				}
+				// skip ctx related checks if not provided
+				if ctx == nil {
+					return nil
+				}
+				//if no file in existing targets, remove it as garbage
+				if _, ok := existingTargets[walkPath]; !ok {
+					return os.Remove(walkPath)
+				}
+				return nil
+			})
+			if err != nil {
 				log.Fatal(err)
 			}
 		}

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/awsutil/s3api.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/awsutil/s3api.go
@@ -18,8 +18,12 @@ import (
 )
 
 const (
-	S3_PART_SIZE        = 5 * 1024 * 1024
-	S3_PART_LEAVE_ERROR = true
+	//S3Concurrency parallels parts download limit
+	S3Concurrency = 5
+	//S3PartSize size of part to download
+	S3PartSize = 5 * 1024 * 1024
+	//S3PartLeaveError leaves parts to manual resolve errors on uploads
+	S3PartLeaveError = true
 )
 
 type S3ctx struct {
@@ -66,11 +70,13 @@ func NewAwsCtx(id, secret, region string, hctx *http.Client) *S3ctx {
 	// s3.New is deprecated.. Ignoring the lint error as this is not new code.
 	ctx.ss3 = s3.New(session.New(), cfg) // nolint
 	ctx.up = s3manager.NewUploaderWithClient(ctx.ss3, func(u *s3manager.Uploader) {
-		u.PartSize = S3_PART_SIZE
-		u.LeavePartsOnError = S3_PART_LEAVE_ERROR
+		u.PartSize = S3PartSize
+		u.LeavePartsOnError = S3PartLeaveError
+		u.Concurrency = S3Concurrency
 	})
 	ctx.dn = s3manager.NewDownloaderWithClient(ctx.ss3, func(d *s3manager.Downloader) {
-		d.PartSize = S3_PART_SIZE
+		d.PartSize = S3PartSize
+		d.Concurrency = S3Concurrency
 	})
 
 	return &ctx

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore.go
@@ -34,7 +34,7 @@ const (
 	SysOpDownloadByChunks       = 10
 	DefaultNumberOfHandlers     = 11
 
-	StatsUpdateTicker = 5 * time.Second // timer for updating client for stats
+	StatsUpdateTicker = 1 * time.Second // timer for updating client for stats
 	FailPostTimeout   = 2 * time.Minute
 )
 

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_aws.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_aws.go
@@ -198,6 +198,7 @@ func (ep *AwsTransportMethod) processS3Download(req *DronaRequest) (error, int) 
 						return
 					}
 				case <-ticker.C:
+					req.doneParts = stats.DoneParts
 					ep.ctx.postSize(req, stats.Size, stats.Asize)
 				}
 			}
@@ -211,7 +212,8 @@ func (ep *AwsTransportMethod) processS3Download(req *DronaRequest) (error, int) 
 	if req.cancelContext != nil {
 		sc = sc.WithContext(req.cancelContext)
 	}
-	err := sc.DownloadFile(req.objloc, ep.bucket, req.name, req.sizelimit, prgChan)
+	doneParts, err := sc.DownloadFile(req.objloc, ep.bucket, req.name, req.sizelimit, req.doneParts, prgChan)
+	req.doneParts = doneParts
 	if err != nil {
 		return err, 0
 	}

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_req.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_req.go
@@ -13,6 +13,8 @@ import (
 	"os"
 	"sync"
 	"time"
+
+	"github.com/lf-edge/eve/libs/zedUpload/types"
 )
 
 var (
@@ -90,6 +92,9 @@ type DronaRequest struct {
 	EtagID string
 	// chunkInfoChan used for communication of chunk details
 	chunkInfoChan chan ChunkData
+
+	//downloaded parts indexes
+	doneParts types.DownloadedParts
 }
 
 // Return object local name
@@ -337,4 +342,16 @@ func (req *DronaRequest) WithCancel(ctx context.Context) *DronaRequest {
 	req.cancelContext = cancelContext
 	req.cancelFunc = cancel
 	return req
+}
+
+// WithDoneParts can be used to set already downloaded parts indexes
+func (req *DronaRequest) WithDoneParts(doneParts types.DownloadedParts) *DronaRequest {
+
+	req.doneParts = doneParts
+	return req
+}
+
+// GetDoneParts returns already downloaded parts indexes
+func (req *DronaRequest) GetDoneParts() types.DownloadedParts {
+	return req.doneParts
 }

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/types/downloadedparts.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/types/downloadedparts.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2021 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+)
+
+//PartDefinition keeps information about one part
+type PartDefinition struct {
+	Ind  int64 `json:"i"` // index of part
+	Size int64 `json:"s"` // current size of part
+}
+
+// DownloadedParts keeps information about downloaded parts of blob
+type DownloadedParts struct {
+	PartSize int64             // the maximum partition size
+	Parts    []*PartDefinition // definition of downloaded parts
+}
+
+// Hash returns hash of DownloadedParts struct
+func (dp *DownloadedParts) Hash() string {
+	data, err := json.Marshal(dp)
+	if err != nil {
+		return ""
+	}
+	hash := sha256.New()
+	if _, err = hash.Write(data); err != nil {
+		return ""
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+//SetPartSize search for ind in DownloadedParts and set its size.
+//If not found, append parts with ind and size
+func (dp *DownloadedParts) SetPartSize(ind, size int64) {
+	for _, p := range dp.Parts {
+		if p.Ind == ind {
+			p.Size = size
+			return
+		}
+	}
+	dp.Parts = append(dp.Parts, &PartDefinition{Ind: ind, Size: size})
+}

--- a/pkg/pillar/vendor/modules.txt
+++ b/pkg/pillar/vendor/modules.txt
@@ -397,6 +397,7 @@ github.com/lf-edge/eve/libs/zedUpload/gsutil
 github.com/lf-edge/eve/libs/zedUpload/httputil
 github.com/lf-edge/eve/libs/zedUpload/ociutil
 github.com/lf-edge/eve/libs/zedUpload/sftputil
+github.com/lf-edge/eve/libs/zedUpload/types
 # github.com/mattn/go-ieproxy v0.0.1
 github.com/mattn/go-ieproxy
 # github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369


### PR DESCRIPTION
This PR allow us to keep information about downloaded parts for s3 datastore in memory and resume download from the previous try.