### PR TITLE
Add logging for AKID and vault-related keys

### DIFF
--- a/pkg/pillar/base/logobjecttypes.go
+++ b/pkg/pillar/base/logobjecttypes.go
@@ -156,6 +156,10 @@ const (
 	DiskNotificationType = "disk_notification"
 	// UUIDPairToNumLogType:
 	UUIDPairToNumLogType LogObjectType = "uuid_pair_to_num"
+	// EncryptedVaultKeyFromDeviceLogType:
+	EncryptedVaultKeyFromDeviceLogType LogObjectType = "encrypted_vault_key_from_device"
+	// EncryptedVaultKeyFromControllerLogType:
+	EncryptedVaultKeyFromControllerLogType LogObjectType = "encrypted_vault_key_from_controller"
 )
 
 // RelationObjectType :

--- a/pkg/pillar/cmd/downloader/datastoreconfig.go
+++ b/pkg/pillar/cmd/downloader/datastoreconfig.go
@@ -25,7 +25,7 @@ func handleDatastoreConfigImpl(ctxArg interface{}, key string,
 	log.Functionf("handleDatastoreConfigImpl for %s", key)
 	checkAndUpdateDownloadableObjects(ctx, config.UUID)
 	checkAndUpdateResolveConfig(ctx, config.UUID)
-	log.Functionf("handleDatastoreConfigImpl for %s, done", key)
+	log.Noticef("handleDatastoreConfigImpl for %s, done", key)
 }
 
 func handleDatastoreConfigDelete(ctxArg interface{}, key string,
@@ -34,5 +34,5 @@ func handleDatastoreConfigDelete(ctxArg interface{}, key string,
 	config := configArg.(types.DatastoreConfig)
 	cipherBlock := config.CipherBlockStatus
 	ctx.pubCipherBlockStatus.Unpublish(cipherBlock.Key())
-	log.Functionf("handleDatastoreConfigDelete for %s", key)
+	log.Noticef("handleDatastoreConfigDelete for %s", key)
 }

--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -139,6 +139,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 		case change := <-ctx.decryptCipherContext.SubEdgeNodeCert.MsgChan():
 			ctx.decryptCipherContext.SubEdgeNodeCert.ProcessChange(change)
+			log.Noticef("Processed EdgeNodeCert")
 
 		// This wait can take an unbounded time since we wait for IP
 		// addresses. Punch StillRunning
@@ -155,12 +156,15 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		select {
 		case change := <-ctx.decryptCipherContext.SubControllerCert.MsgChan():
 			ctx.decryptCipherContext.SubControllerCert.ProcessChange(change)
+			log.Noticef("Processed ControllerCert")
 
 		case change := <-ctx.decryptCipherContext.SubEdgeNodeCert.MsgChan():
 			ctx.decryptCipherContext.SubEdgeNodeCert.ProcessChange(change)
+			log.Noticef("Processed EdgeNodeCert")
 
 		case change := <-ctx.decryptCipherContext.SubCipherContext.MsgChan():
 			ctx.decryptCipherContext.SubCipherContext.ProcessChange(change)
+			log.Noticef("Processed CipherContext")
 
 		case change := <-ctx.subGlobalConfig.MsgChan():
 			ctx.subGlobalConfig.ProcessChange(change)
@@ -179,6 +183,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 		case change := <-ctx.subDatastoreConfig.MsgChan():
 			ctx.subDatastoreConfig.ProcessChange(change)
+			log.Noticef("Processed DatastoreConfig")
 
 		case <-publishTimer.C:
 			start := time.Now()
@@ -208,6 +213,8 @@ func checkAndUpdateDownloadableObjects(ctx *downloaderContext, dsID uuid.UUID) {
 		if status.DatastoreID == dsID {
 			config := lookupDownloaderConfig(ctx, status.Key())
 			if config != nil {
+				log.Noticef("checkAndUpdateDownloadableObjects updating %s due to datastore %s",
+					status.Key(), dsID)
 				dHandler.modify(ctx, status.Key(), *config)
 			}
 		}

--- a/pkg/pillar/cmd/downloader/resolveconfig.go
+++ b/pkg/pillar/cmd/downloader/resolveconfig.go
@@ -324,6 +324,8 @@ func checkAndUpdateResolveConfig(ctx *downloaderContext, dsID uuid.UUID) {
 		if status.DatastoreID == dsID {
 			config := lookupResolveConfig(ctx, status.Key())
 			if config != nil {
+				log.Noticef("checkAndUpdateResolveConfig updating %s due to datastore %s",
+					status.Key(), dsID)
 				resHandler.modify(ctx, status.Key(), *config, *config)
 			}
 		}

--- a/pkg/pillar/cmd/downloader/syncop.go
+++ b/pkg/pillar/cmd/downloader/syncop.go
@@ -373,10 +373,12 @@ func getDatastoreCredential(ctx *downloaderContext,
 			}
 			return decBlock, nil
 		}
-		log.Functionf("%s, datastore config cipherblock decryption successful", dst.Key())
+		log.Noticef("%s, datastore config cipherblock decryption successful got %t/%t",
+			dst.Key(), len(decBlock.DsAPIKey) != 0,
+			len(decBlock.DsPassword) != 0)
 		return decBlock, nil
 	}
-	log.Functionf("%s, datastore config cipherblock not present", dst.Key())
+	log.Noticef("%s, datastore config cipherblock not present", dst.Key())
 	decBlock := types.EncryptionBlock{}
 	decBlock.DsAPIKey = dst.ApiKey
 	decBlock.DsPassword = dst.Password

--- a/pkg/pillar/cmd/zedagent/attesttask.go
+++ b/pkg/pillar/cmd/zedagent/attesttask.go
@@ -304,7 +304,7 @@ func (server *VerifierImpl) SendAttestQuote(ctx *zattest.Context) error {
 				encryptedKey := sk.GetKey()
 				if encryptedKeyType == attest.AttestVolumeKeyType_ATTEST_VOLUME_KEY_TYPE_VSK {
 					publishEncryptedKeyFromController(attestCtx, encryptedKey)
-					log.Functionf("[ATTEST] published Controller-given encrypted key")
+					log.Noticef("[ATTEST] published Controller-given encrypted key")
 				}
 			}
 		}

--- a/pkg/pillar/types/vaultmgrtypes.go
+++ b/pkg/pillar/types/vaultmgrtypes.go
@@ -81,6 +81,42 @@ func (key EncryptedVaultKeyFromDevice) Key() string {
 	return key.Name
 }
 
+// LogCreate :
+func (key EncryptedVaultKeyFromDevice) LogCreate(logBase *base.LogObject) {
+	logObject := base.NewLogObject(logBase, base.EncryptedVaultKeyFromDeviceLogType, key.Name,
+		nilUUID, key.LogKey())
+	if logObject == nil {
+		return
+	}
+	logObject.Noticef("EncryptedVaultKeyFromDevice create")
+}
+
+// LogModify :
+func (key EncryptedVaultKeyFromDevice) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.EncryptedVaultKeyFromDeviceLogType, key.Name,
+		nilUUID, key.LogKey())
+
+	_, ok := old.(EncryptedVaultKeyFromDevice)
+	if !ok {
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of EncryptedVaultKeyFromDevice type")
+	}
+	logObject.Noticef("EncryptedVaultKeyFromDevice modify")
+}
+
+// LogDelete :
+func (key EncryptedVaultKeyFromDevice) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.EncryptedVaultKeyFromDeviceLogType, key.Name,
+		nilUUID, key.LogKey())
+	logObject.Noticef("EncryptedVaultKeyFromDevice delete")
+
+	base.DeleteLogObject(logBase, key.LogKey())
+}
+
+// LogKey :
+func (key EncryptedVaultKeyFromDevice) LogKey() string {
+	return string(base.EncryptedVaultKeyFromDeviceLogType) + "-" + key.Key()
+}
+
 //EncryptedVaultKeyFromController is published from Controller to vaultmgr (through zedagent)
 type EncryptedVaultKeyFromController struct {
 	Name              string
@@ -91,4 +127,40 @@ type EncryptedVaultKeyFromController struct {
 //for now it is only the default vault i.e. "Application Volume Store"
 func (key EncryptedVaultKeyFromController) Key() string {
 	return key.Name
+}
+
+// LogCreate :
+func (key EncryptedVaultKeyFromController) LogCreate(logBase *base.LogObject) {
+	logObject := base.NewLogObject(logBase, base.EncryptedVaultKeyFromControllerLogType, key.Name,
+		nilUUID, key.LogKey())
+	if logObject == nil {
+		return
+	}
+	logObject.Noticef("EncryptedVaultKeyFromController create")
+}
+
+// LogModify :
+func (key EncryptedVaultKeyFromController) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.EncryptedVaultKeyFromControllerLogType, key.Name,
+		nilUUID, key.LogKey())
+
+	_, ok := old.(EncryptedVaultKeyFromController)
+	if !ok {
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of EncryptedVaultKeyFromController type")
+	}
+	logObject.Noticef("EncryptedVaultKeyFromController modify")
+}
+
+// LogDelete :
+func (key EncryptedVaultKeyFromController) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.EncryptedVaultKeyFromControllerLogType, key.Name,
+		nilUUID, key.LogKey())
+	logObject.Noticef("EncryptedVaultKeyFromController delete")
+
+	base.DeleteLogObject(logBase, key.LogKey())
+}
+
+// LogKey :
+func (key EncryptedVaultKeyFromController) LogKey() string {
+	return string(base.EncryptedVaultKeyFromControllerLogType) + "-" + key.Key()
 }


### PR DESCRIPTION
Add logging for AKID

We occasionally see downloads persistently failing due to no credentials
being passed to S3 when the device was just
created/provisioned/onboarded. There is some race in the handling of the
DatastoreConfig and decryption. Adding logging to track it down.

Add logging around vault-related keys

We can have issues if a device is powered off during the first boot and
the encrypted storage key is not yet backed up in the controller. Adding
logging to make this easier to observe in the logs.
