### PR TITLE
use uid and gid in chroot for non-root containers

### DIFF
--- a/docs/ECOS.md
+++ b/docs/ECOS.md
@@ -179,6 +179,23 @@ ECI Configuration is a json file with the following schema:
     * Annotations (deprecated)
     * Permissions (future work item to have local resources that have been granted access: set of entitlements that allows ECO to perform intended function)
 
+## Configuration of Docker/OCI based ECOs
+
+We use special prepared VMs to run ECOs based on Docker/OCI (if edge-node supports hardware-assistance virtualization).
+In this case we start VM with the kernel of EVE and with pre-build [initrd](../pkg/xen-tools/initrd). Inside init we
+make needed system mounts, mount rootfs (to /mnt) and block devices attached (to mount points defined in the file
+`mountPoints`). Static IP address is assigned to the network interface if the option `ip` defined in the kernel cmdline,
+otherwise dhcp is enabled.
+
+We use several files to run application comes from Docker/OCI manifest:
+
+* `environment` - all environment variables defined in Docker/OCI goes here
+* `cmdline` - it is cmd defined to run in Docker/OCI
+* `ug` - file contains user and group to run cmd under
+
+After preparation done we chroot into /mnt and run cmd from cmdline under specified user and group, output goes to
+/dev/console and is accessible from log of ECO.
+
 ## ECI Distribution Specification
 
 While ECIs are regular, self-contained binary files and can be distributed by any transport (http, ftp, etc.) in certain situations it is advantageous to define an optimized transport protocol that can be used specifically for ECI distribution.

--- a/pkg/xen-tools/initrd/base.files
+++ b/pkg/xen-tools/initrd/base.files
@@ -1,6 +1,4 @@
 /bin/busybox
-/usr/bin/sudo
-/usr/lib/sudo/libsudo_util.so.*
 /sbin/mke2fs
 /lib/libext2fs.so.2*
 /lib/libcom_err.so.2*

--- a/pkg/xen-tools/initrd/chroot2.c
+++ b/pkg/xen-tools/initrd/chroot2.c
@@ -2,11 +2,20 @@
 #include <sys/ioctl.h>
 
 int main(int argc, char **argv) {
+    uid_t uid, gid;
+    char *endptr;
+
     setsid();
     ioctl(0, TIOCSCTTY, 1);
 
     chroot(argv[1]);
     chdir(argv[2]);
 
-    return execvp(argv[3], argv + 3);
+    uid = strtol(argv[3], &endptr, 10);
+    gid = strtol(argv[4], &endptr, 10);
+
+    setgid(gid);
+    setuid(uid);
+
+    return execvp(argv[5], argv + 5);
 }

--- a/pkg/xen-tools/initrd/init-initrd
+++ b/pkg/xen-tools/initrd/init-initrd
@@ -106,8 +106,15 @@ acpid -l /proc/self/fd/1
 
 cmd=`cat /mnt/cmdline`
 echo "Executing $cmd"
+
+ug="0 0"
+if [ -f /mnt/ug ]; then
+  ug=$(cat /mnt/ug)
+fi
+echo "Executing with uid gid: $ug"
+
 #shellcheck disable=SC2086
-eval /chroot2 /mnt/rootfs "${WORKDIR:-/}" $cmd <> /dev/console 2>&1
+eval /chroot2 /mnt/rootfs "${WORKDIR:-/}" $ug $cmd <> /dev/console 2>&1
 
 # once the command exits -- the only thing left is shut everything down
 /sbin/poweroff


### PR DESCRIPTION
As described in #2119 we can have no sudo binary inside container rootfs but still need to run entrypoint under non-root user. In this PR I add `ug` file with uid gid from container manifest and update chroot2 to use that information.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>