### PR TITLE
Parse VLAN and Bond configuration

### DIFF
--- a/api/proto/config/devmodel.proto
+++ b/api/proto/config/devmodel.proto
@@ -64,7 +64,7 @@ message SystemAdapter {
   string alias = 7;
 
   // lowerLayerName - For example, if lower layer is PhysicalAdapter
-  // ( physical interface), this should point to PhyLabel of the
+  // ( physical interface), this should point to logicallabel of the
   // physicalIO.
   string lowerLayerName = 8;
 

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -928,8 +928,8 @@ func handleInterfaceChange(ctx *nimContext, ifindex int, logstr string, force bo
 	// link drops so call directly
 	ifname, _, _ := devicenetwork.IfindexToName(log, ifindex)
 	log.Functionf("%s(%s) ifindex %d force %t", logstr, ifname, ifindex, force)
-	if ifname != "" && !types.IsPort(*ctx.deviceNetworkContext.DeviceNetworkStatus, ifname) {
-		log.Tracef("%s(%s): not port", logstr, ifname)
+	if ifname != "" && !types.IsL3Port(*ctx.deviceNetworkContext.DeviceNetworkStatus, ifname) {
+		log.Tracef("%s(%s): not L3 port", logstr, ifname)
 		return
 	}
 	if force {

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -47,6 +47,13 @@ type localServerMap struct {
 	upToDate bool
 }
 
+// L2Adapter is used to represent L2 Adapter (VLAN, bond) during configuration parsing.
+type L2Adapter struct {
+	config         *types.NetworkPortConfig
+	lowerL2Ports   []*L2Adapter
+	lowerPhysPorts []*types.PhysicalIOAdapter
+}
+
 type getconfigContext struct {
 	zedagentCtx              *zedagentContext    // Cross link
 	ledBlinkCount            types.LedBlinkCount // Current count
@@ -91,6 +98,10 @@ type getconfigContext struct {
 	localProfile             string
 	localProfileTrigger      chan Notify
 	localServerMap           *localServerMap
+
+	// parsed L2 adapters
+	vlans []L2Adapter
+	bonds []L2Adapter
 
 	// radio-silence
 	radioSilence     types.RadioSilence // the intended state of radio devices

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -283,6 +283,10 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 		if p == nil {
 			continue
 		}
+		if !p.IsL3Port {
+			// metrics for ports from lower layers are not reported
+			continue
+		}
 		for _, m := range networkMetrics.MetricList {
 			if p.IfName == m.IfName {
 				metric = &m

--- a/pkg/pillar/cmd/zedagent/parseconfig_test.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig_test.go
@@ -1,0 +1,1128 @@
+// Copyright (c) 2021 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package zedagent
+
+import (
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	"sort"
+	"testing"
+
+	zconfig "github.com/lf-edge/eve/api/go/config"
+	zcommon "github.com/lf-edge/eve/api/go/evecommon"
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+func initGetConfigCtx(g *GomegaWithT) *getconfigContext {
+	logger = logrus.StandardLogger()
+	log = base.NewSourceLogObject(logger, "zedagent", 1234)
+	ps := pubsub.New(&pubsub.EmptyDriver{}, logger, log)
+	pubIOAdapters, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName: agentName,
+		TopicType: types.PhysicalIOAdapterList{},
+	})
+	g.Expect(err).To(BeNil())
+	pubDPC, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName: agentName,
+		TopicType: types.DevicePortConfig{},
+	})
+	g.Expect(err).To(BeNil())
+	pubNetworks, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName: agentName,
+		TopicType: types.NetworkXObjectConfig{},
+	})
+	getconfigCtx := &getconfigContext{
+		pubDevicePortConfig:     pubDPC,
+		pubPhysicalIOAdapters:   pubIOAdapters,
+		pubNetworkXObjectConfig: pubNetworks,
+		zedagentCtx: &zedagentContext{
+			physicalIoAdapterMap: make(map[string]types.PhysicalIOAdapter),
+		},
+	}
+	// cleanup between tests
+	deviceIoListPrevConfigHash = nil
+	bondsPrevConfigHash = nil
+	vlansPrevConfigHash = nil
+	networkConfigPrevConfigHash = nil
+	return getconfigCtx
+}
+
+// Sort DPC ports to make the port order deterministic and thus easier
+// to check for expected content.
+func sortDPCPorts(dpc *types.DevicePortConfig) {
+	sort.Slice(dpc.Ports, func(i, j int) bool {
+		return dpc.Ports[i].Logicallabel < dpc.Ports[j].Logicallabel
+	})
+}
+
+func getPortError(dpc *types.DevicePortConfig, portName string) string {
+	for _, port := range dpc.Ports {
+		if port.Logicallabel == portName {
+			if port.HasError() {
+				return port.LastError
+			}
+			break
+		}
+	}
+	return ""
+}
+
+func TestParsePhysicalNetworkAdapters(t *testing.T) {
+	g := NewGomegaWithT(t)
+	getconfigCtx := initGetConfigCtx(g)
+
+	const networkUUID = "572cd3bc-ade6-42ad-97a0-22cd24fed1a0"
+	config := &zconfig.EdgeDevConfig{
+		Networks: []*zconfig.NetworkConfig{
+			{
+				Id:   networkUUID,
+				Type: zconfig.NetworkType_V4,
+				Ip: &zconfig.Ipspec{
+					Dhcp: zconfig.DHCPType_Client,
+				},
+			},
+		},
+		DeviceIoList: []*zconfig.PhysicalIO{
+			{
+				Ptype:        zcommon.PhyIoType_PhyIoNetEth,
+				Phylabel:     "ethernet0",
+				Logicallabel: "shopfloor",
+				Assigngrp:    "eth-grp-1",
+				Phyaddrs: map[string]string{
+					"ifname":  "eth0",
+					"pcilong": "0000:04:00.0",
+				},
+				Usage: zcommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
+			},
+		},
+		SystemAdapterList: []*zconfig.SystemAdapter{
+			{
+				Name:           "adapter-shopfloor",
+				Uplink:         true,
+				NetworkUUID:    networkUUID,
+				Alias:          "shopfloor-alias",
+				LowerLayerName: "shopfloor",
+				Cost:           0,
+			},
+		},
+	}
+
+	parseDeviceIoListConfig(config, getconfigCtx)
+	parseNetworkXObjectConfig(config, getconfigCtx)
+	parseSystemAdapterConfig(config, getconfigCtx, true)
+
+	portConfig, err := getconfigCtx.pubDevicePortConfig.Get("zedagent")
+	g.Expect(err).To(BeNil())
+	dpc := portConfig.(types.DevicePortConfig)
+	g.Expect(dpc.Version).To(Equal(types.DPCIsMgmt))
+	g.Expect(dpc.HasError()).To(BeFalse())
+	g.Expect(dpc.Ports).To(HaveLen(1))
+	port := dpc.Ports[0]
+	g.Expect(port.Logicallabel).To(Equal("adapter-shopfloor"))
+	g.Expect(port.Phylabel).To(Equal("ethernet0"))
+	g.Expect(port.IfName).To(Equal("eth0"))
+	g.Expect(port.Alias).To(Equal("shopfloor-alias"))
+	g.Expect(port.IsL3Port).To(BeTrue())
+	g.Expect(port.NetworkUUID.String()).To(Equal(networkUUID))
+	g.Expect(port.Cost).To(BeZero())
+	g.Expect(port.DhcpConfig.Type).To(BeEquivalentTo(types.NT_IPV4))
+	g.Expect(port.DhcpConfig.Dhcp).To(Equal(types.DT_CLIENT))
+	g.Expect(port.DhcpConfig.DomainName).To(BeEmpty())
+	g.Expect(port.DhcpConfig.AddrSubnet).To(BeEmpty())
+	g.Expect(port.DhcpConfig.DnsServers).To(BeEmpty())
+	g.Expect(port.DhcpConfig.Gateway).To(BeNil())
+	g.Expect(port.DhcpConfig.NtpServer).To(BeNil())
+	g.Expect(port.ProxyConfig.Proxies).To(BeEmpty())
+	g.Expect(port.L2LinkConfig.L2Type).To(Equal(types.L2LinkTypeNone))
+	g.Expect(port.WirelessCfg.WType).To(Equal(types.WirelessTypeNone))
+}
+
+// Test DPC with recorded parsing error (missing network configuration)
+func TestDPCWithError(t *testing.T) {
+	g := NewGomegaWithT(t)
+	getconfigCtx := initGetConfigCtx(g)
+
+	config := &zconfig.EdgeDevConfig{
+		DeviceIoList: []*zconfig.PhysicalIO{
+			{
+				Ptype:        zcommon.PhyIoType_PhyIoNetEth,
+				Phylabel:     "ethernet0",
+				Logicallabel: "shopfloor",
+				Assigngrp:    "eth-grp-1",
+				Phyaddrs: map[string]string{
+					"ifname":  "eth0",
+					"pcilong": "0000:04:00.0",
+				},
+				Usage: zcommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
+			},
+		},
+		SystemAdapterList: []*zconfig.SystemAdapter{
+			{
+				Name:           "adapter-shopfloor",
+				Uplink:         true,
+				NetworkUUID:    "572cd3bc-ade6-42ad-97a0-22cd24fed1a0",
+				Alias:          "shopfloor-alias",
+				LowerLayerName: "shopfloor",
+				Cost:           0,
+			},
+		},
+	}
+
+	parseDeviceIoListConfig(config, getconfigCtx)
+	parseNetworkXObjectConfig(config, getconfigCtx)
+	parseSystemAdapterConfig(config, getconfigCtx, true)
+
+	portConfig, err := getconfigCtx.pubDevicePortConfig.Get("zedagent")
+	g.Expect(err).To(BeNil())
+	dpc := portConfig.(types.DevicePortConfig)
+	g.Expect(dpc.Version).To(Equal(types.DPCIsMgmt))
+	g.Expect(dpc.HasError()).To(BeTrue())
+	g.Expect(dpc.LastFailed).ToNot(BeZero())
+	g.Expect(dpc.LastSucceeded).To(BeZero())
+	g.Expect(getPortError(&dpc, "adapter-shopfloor")).
+		To(ContainSubstring("UNKNOWN Network UUID"))
+	g.Expect(dpc.Ports).To(HaveLen(1))
+	port := dpc.Ports[0]
+	g.Expect(port.Logicallabel).To(Equal("adapter-shopfloor"))
+	g.Expect(port.Phylabel).To(Equal("ethernet0"))
+	g.Expect(port.IfName).To(Equal("eth0"))
+	g.Expect(port.Alias).To(Equal("shopfloor-alias"))
+	g.Expect(port.IsL3Port).To(BeTrue())
+	g.Expect(port.NetworkUUID).To(BeZero())
+	g.Expect(port.Cost).To(BeZero())
+}
+
+func TestParseVlans(t *testing.T) {
+	g := NewGomegaWithT(t)
+	getconfigCtx := initGetConfigCtx(g)
+
+	const (
+		network1UUID = "572cd3bc-ade6-42ad-97a0-22cd24fed1a0"
+		network2UUID = "0c1a98fb-85fa-421d-943e-8d4e469bea8f"
+		network3UUID = "bd5a8c26-67ed-458e-be3b-0478d1b7c094"
+	)
+	config := &zconfig.EdgeDevConfig{
+		Networks: []*zconfig.NetworkConfig{
+			{
+				Id:   network1UUID,
+				Type: zconfig.NetworkType_V4,
+				Ip: &zconfig.Ipspec{
+					Dhcp: zconfig.DHCPType_Client,
+				},
+			},
+			{
+				Id:   network2UUID,
+				Type: zconfig.NetworkType_V6,
+				Ip: &zconfig.Ipspec{
+					Dhcp: zconfig.DHCPType_Client,
+				},
+			},
+			{
+				Id:   network3UUID,
+				Type: zconfig.NetworkType_V4,
+				Ip: &zconfig.Ipspec{
+					Dhcp:    zconfig.DHCPType_Static,
+					Subnet:  "192.168.1.0/24",
+					Gateway: "192.168.1.1",
+					DhcpRange: &zconfig.IpRange{
+						Start: "192.168.1.10",
+						End:   "192.168.1.100",
+					},
+				},
+			},
+		},
+		DeviceIoList: []*zconfig.PhysicalIO{
+			{
+				Ptype:        zcommon.PhyIoType_PhyIoNetEth,
+				Phylabel:     "ethernet0",
+				Logicallabel: "shopfloor",
+				Assigngrp:    "eth-grp-1",
+				Phyaddrs: map[string]string{
+					"ifname":  "eth0",
+					"pcilong": "0000:04:00.0",
+				},
+				Usage: zcommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
+			},
+			{
+				Ptype:        zcommon.PhyIoType_PhyIoNetEth,
+				Phylabel:     "ethernet1",
+				Logicallabel: "warehouse",
+				Assigngrp:    "eth-grp-2",
+				Phyaddrs: map[string]string{
+					"ifname":  "eth1",
+					"pcilong": "0000:05:00.0",
+				},
+				Usage: zcommon.PhyIoMemberUsage_PhyIoUsageShared,
+			},
+		},
+		Vlans: []*zconfig.VlanAdapter{
+			{
+				Logicallabel:   "shopfloor-vlan100",
+				InterfaceName:  "shopfloor.100",
+				LowerLayerName: "shopfloor",
+				VlanId:         100,
+			},
+			{
+				Logicallabel:   "shopfloor-vlan200",
+				InterfaceName:  "shopfloor.200",
+				LowerLayerName: "shopfloor",
+				VlanId:         200,
+			},
+			{
+				Logicallabel:   "warehouse-vlan100",
+				InterfaceName:  "warehouse.100",
+				LowerLayerName: "warehouse",
+				VlanId:         100,
+			},
+		},
+		SystemAdapterList: []*zconfig.SystemAdapter{
+			{
+				Name:           "adapter-shopfloor-vlan100",
+				Uplink:         true,
+				NetworkUUID:    network1UUID,
+				LowerLayerName: "shopfloor-vlan100",
+				Cost:           10,
+			},
+			{
+				Name:           "adapter-shopfloor-vlan200",
+				Uplink:         true,
+				NetworkUUID:    network2UUID,
+				LowerLayerName: "shopfloor-vlan200",
+				Cost:           20,
+			},
+			// no adapter for warehouse initially
+		},
+	}
+
+	parseDeviceIoListConfig(config, getconfigCtx)
+	parseVlans(config, getconfigCtx)
+	parseNetworkXObjectConfig(config, getconfigCtx)
+	parseSystemAdapterConfig(config, getconfigCtx, true)
+
+	portConfig, err := getconfigCtx.pubDevicePortConfig.Get("zedagent")
+	g.Expect(err).To(BeNil())
+	dpc := portConfig.(types.DevicePortConfig)
+	g.Expect(dpc.Version).To(Equal(types.DPCIsMgmt))
+	g.Expect(dpc.HasError()).To(BeFalse())
+	g.Expect(dpc.Ports).To(HaveLen(3))
+	sortDPCPorts(&dpc)
+	// VLAN shopfloor.100
+	port := dpc.Ports[0]
+	g.Expect(port.Logicallabel).To(Equal("adapter-shopfloor-vlan100"))
+	g.Expect(port.Phylabel).To(BeEmpty())
+	g.Expect(port.IsL3Port).To(BeTrue())
+	g.Expect(port.IfName).To(Equal("shopfloor.100"))
+	g.Expect(port.NetworkUUID.String()).To(Equal(network1UUID))
+	g.Expect(port.Cost).To(BeEquivalentTo(10))
+	g.Expect(port.DhcpConfig.Type).To(BeEquivalentTo(types.NT_IPV4))
+	g.Expect(port.DhcpConfig.Dhcp).To(Equal(types.DT_CLIENT))
+	g.Expect(port.L2LinkConfig.L2Type).To(Equal(types.L2LinkTypeVLAN))
+	g.Expect(port.L2LinkConfig.VLAN.ParentPort).To(Equal("shopfloor"))
+	g.Expect(port.L2LinkConfig.VLAN.ID).To(BeEquivalentTo(100))
+	g.Expect(port.WirelessCfg.WType).To(Equal(types.WirelessTypeNone))
+	// VLAN shopfloor.200
+	port = dpc.Ports[1]
+	g.Expect(port.Logicallabel).To(Equal("adapter-shopfloor-vlan200"))
+	g.Expect(port.Phylabel).To(BeEmpty())
+	g.Expect(port.IsL3Port).To(BeTrue())
+	g.Expect(port.IfName).To(Equal("shopfloor.200"))
+	g.Expect(port.NetworkUUID.String()).To(Equal(network2UUID))
+	g.Expect(port.Cost).To(BeEquivalentTo(20))
+	g.Expect(port.DhcpConfig.Type).To(BeEquivalentTo(types.NT_IPV6))
+	g.Expect(port.DhcpConfig.Dhcp).To(Equal(types.DT_CLIENT))
+	g.Expect(port.L2LinkConfig.L2Type).To(Equal(types.L2LinkTypeVLAN))
+	g.Expect(port.L2LinkConfig.VLAN.ParentPort).To(Equal("shopfloor"))
+	g.Expect(port.L2LinkConfig.VLAN.ID).To(BeEquivalentTo(200))
+	g.Expect(port.WirelessCfg.WType).To(Equal(types.WirelessTypeNone))
+	// the underlying physical "shopfloor" adapter
+	port = dpc.Ports[2]
+	g.Expect(port.Logicallabel).To(Equal("shopfloor"))
+	g.Expect(port.Phylabel).To(Equal("ethernet0"))
+	g.Expect(port.IsL3Port).To(BeFalse())
+	g.Expect(port.IfName).To(Equal("eth0"))
+	g.Expect(port.NetworkUUID).To(BeZero())
+	g.Expect(port.Cost).To(BeZero())
+	g.Expect(port.DhcpConfig.Type).To(BeEquivalentTo(types.NT_NOOP))
+	g.Expect(port.DhcpConfig.Dhcp).To(Equal(types.DT_NOOP))
+	g.Expect(port.L2LinkConfig.L2Type).To(Equal(types.L2LinkTypeNone))
+	g.Expect(port.WirelessCfg.WType).To(Equal(types.WirelessTypeNone))
+
+	// Add adapter for "warehouse-vlan100"
+	config.SystemAdapterList = append(config.SystemAdapterList, &zconfig.SystemAdapter{
+		Name:           "adapter-warehouse-vlan100",
+		Uplink:         true,
+		NetworkUUID:    network3UUID,
+		LowerLayerName: "warehouse-vlan100",
+		Cost:           30,
+		Addr:           "192.168.1.150",
+	})
+	parseSystemAdapterConfig(config, getconfigCtx, true)
+
+	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
+	g.Expect(err).To(BeNil())
+	dpc = portConfig.(types.DevicePortConfig)
+	g.Expect(dpc.HasError()).To(BeFalse())
+	// Added one physical and one VLAN adapter
+	g.Expect(dpc.Ports).To(HaveLen(5))
+	sortDPCPorts(&dpc)
+	// VLAN warehouse.100
+	port = dpc.Ports[2]
+	g.Expect(port.Logicallabel).To(Equal("adapter-warehouse-vlan100"))
+	g.Expect(port.Phylabel).To(BeEmpty())
+	g.Expect(port.IsL3Port).To(BeTrue())
+	g.Expect(port.IfName).To(Equal("warehouse.100"))
+	g.Expect(port.NetworkUUID.String()).To(Equal(network3UUID))
+	g.Expect(port.Cost).To(BeEquivalentTo(30))
+	g.Expect(port.DhcpConfig.Type).To(BeEquivalentTo(types.NT_IPV4))
+	g.Expect(port.DhcpConfig.Dhcp).To(Equal(types.DT_STATIC))
+	g.Expect(port.DhcpConfig.AddrSubnet).To(Equal("192.168.1.150/24"))
+	g.Expect(port.DhcpConfig.Gateway.String()).To(Equal("192.168.1.1"))
+	g.Expect(port.L2LinkConfig.L2Type).To(Equal(types.L2LinkTypeVLAN))
+	g.Expect(port.L2LinkConfig.VLAN.ParentPort).To(Equal("warehouse"))
+	g.Expect(port.L2LinkConfig.VLAN.ID).To(BeEquivalentTo(100))
+	g.Expect(port.WirelessCfg.WType).To(Equal(types.WirelessTypeNone))
+	// the underlying "warehouse" adapter
+	port = dpc.Ports[4]
+	g.Expect(port.Logicallabel).To(Equal("warehouse"))
+	g.Expect(port.Phylabel).To(Equal("ethernet1"))
+	g.Expect(port.IsL3Port).To(BeFalse())
+	g.Expect(port.IfName).To(Equal("eth1"))
+	g.Expect(port.NetworkUUID).To(BeZero())
+	g.Expect(port.Cost).To(BeZero())
+	g.Expect(port.DhcpConfig.Type).To(BeEquivalentTo(types.NT_NOOP))
+	g.Expect(port.DhcpConfig.Dhcp).To(Equal(types.DT_NOOP))
+	g.Expect(port.L2LinkConfig.L2Type).To(Equal(types.L2LinkTypeNone))
+	g.Expect(port.WirelessCfg.WType).To(Equal(types.WirelessTypeNone))
+}
+
+func TestParseBonds(t *testing.T) {
+	g := NewGomegaWithT(t)
+	getconfigCtx := initGetConfigCtx(g)
+
+	const networkUUID = "572cd3bc-ade6-42ad-97a0-22cd24fed1a0"
+	config := &zconfig.EdgeDevConfig{
+		Networks: []*zconfig.NetworkConfig{
+			{
+				Id:   networkUUID,
+				Type: zconfig.NetworkType_V4,
+				Ip: &zconfig.Ipspec{
+					Dhcp: zconfig.DHCPType_Client,
+				},
+			},
+		},
+		DeviceIoList: []*zconfig.PhysicalIO{
+			{
+				Ptype:        zcommon.PhyIoType_PhyIoNetEth,
+				Phylabel:     "ethernet0",
+				Logicallabel: "shopfloor0",
+				Assigngrp:    "eth-grp-1",
+				Phyaddrs: map[string]string{
+					"ifname":  "eth0",
+					"pcilong": "0000:04:00.0",
+				},
+				Usage: zcommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
+			},
+			{
+				Ptype:        zcommon.PhyIoType_PhyIoNetEth,
+				Phylabel:     "ethernet1",
+				Logicallabel: "shopfloor1",
+				Assigngrp:    "eth-grp-2",
+				Phyaddrs: map[string]string{
+					"ifname":  "eth1",
+					"pcilong": "0000:05:00.0",
+				},
+				Usage: zcommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
+			},
+		},
+		Bonds: []*zconfig.BondAdapter{
+			{
+				Logicallabel:    "bond-shopfloor",
+				InterfaceName:   "bond0",
+				LowerLayerNames: []string{"shopfloor1", "shopfloor0"}, // order matters in Active-Backup mode
+				BondMode:        zconfig.BondMode_BOND_MODE_ACTIVE_BACKUP,
+				Monitoring: &zconfig.BondAdapter_Mii{
+					Mii: &zconfig.MIIMonitor{
+						Interval:  400,
+						Updelay:   800,
+						Downdelay: 1200,
+					},
+				},
+			},
+		},
+		SystemAdapterList: []*zconfig.SystemAdapter{
+			{
+				Name:           "adapter-shopfloor",
+				Uplink:         true,
+				NetworkUUID:    networkUUID,
+				LowerLayerName: "bond-shopfloor",
+				Cost:           10,
+			},
+		},
+	}
+
+	parseDeviceIoListConfig(config, getconfigCtx)
+	parseBonds(config, getconfigCtx)
+	parseNetworkXObjectConfig(config, getconfigCtx)
+	parseSystemAdapterConfig(config, getconfigCtx, true)
+
+	portConfig, err := getconfigCtx.pubDevicePortConfig.Get("zedagent")
+	g.Expect(err).To(BeNil())
+	dpc := portConfig.(types.DevicePortConfig)
+	g.Expect(dpc.Version).To(Equal(types.DPCIsMgmt))
+	g.Expect(dpc.HasError()).To(BeFalse())
+	g.Expect(dpc.Ports).To(HaveLen(3))
+	sortDPCPorts(&dpc)
+	// System adapter for shopfloor (bond)
+	port := dpc.Ports[0]
+	g.Expect(port.Logicallabel).To(Equal("adapter-shopfloor"))
+	g.Expect(port.Phylabel).To(BeEmpty())
+	g.Expect(port.IsL3Port).To(BeTrue())
+	g.Expect(port.IfName).To(Equal("bond0"))
+	g.Expect(port.NetworkUUID.String()).To(Equal(networkUUID))
+	g.Expect(port.Cost).To(BeEquivalentTo(10))
+	g.Expect(port.DhcpConfig.Type).To(BeEquivalentTo(types.NT_IPV4))
+	g.Expect(port.DhcpConfig.Dhcp).To(Equal(types.DT_CLIENT))
+	g.Expect(port.L2LinkConfig.L2Type).To(Equal(types.L2LinkTypeBond))
+	g.Expect(port.L2LinkConfig.Bond.AggregatedPorts).To(Equal([]string{"shopfloor1", "shopfloor0"}))
+	g.Expect(port.L2LinkConfig.Bond.Mode).To(Equal(types.BondModeActiveBackup))
+	g.Expect(port.L2LinkConfig.Bond.MIIMonitor.Enabled).To(BeTrue())
+	g.Expect(port.L2LinkConfig.Bond.MIIMonitor.Interval).To(BeEquivalentTo(400))
+	g.Expect(port.L2LinkConfig.Bond.MIIMonitor.UpDelay).To(BeEquivalentTo(800))
+	g.Expect(port.L2LinkConfig.Bond.MIIMonitor.DownDelay).To(BeEquivalentTo(1200))
+	g.Expect(port.L2LinkConfig.Bond.ARPMonitor.Enabled).To(BeFalse())
+	g.Expect(port.WirelessCfg.WType).To(Equal(types.WirelessTypeNone))
+	// underlying physical "shopfloor0" adapter
+	port = dpc.Ports[1]
+	g.Expect(port.Logicallabel).To(Equal("shopfloor0"))
+	g.Expect(port.Phylabel).To(Equal("ethernet0"))
+	g.Expect(port.IsL3Port).To(BeFalse())
+	g.Expect(port.IfName).To(Equal("eth0"))
+	g.Expect(port.NetworkUUID).To(BeZero())
+	g.Expect(port.Cost).To(BeZero())
+	g.Expect(port.DhcpConfig.Type).To(BeEquivalentTo(types.NT_NOOP))
+	g.Expect(port.DhcpConfig.Dhcp).To(Equal(types.DT_NOOP))
+	g.Expect(port.L2LinkConfig.L2Type).To(Equal(types.L2LinkTypeNone))
+	g.Expect(port.WirelessCfg.WType).To(Equal(types.WirelessTypeNone))
+	// underlying physical "shopfloor1" adapter
+	port = dpc.Ports[2]
+	g.Expect(port.Logicallabel).To(Equal("shopfloor1"))
+	g.Expect(port.Phylabel).To(Equal("ethernet1"))
+	g.Expect(port.IsL3Port).To(BeFalse())
+	g.Expect(port.IfName).To(Equal("eth1"))
+	g.Expect(port.NetworkUUID).To(BeZero())
+	g.Expect(port.Cost).To(BeZero())
+	g.Expect(port.DhcpConfig.Type).To(BeEquivalentTo(types.NT_NOOP))
+	g.Expect(port.DhcpConfig.Dhcp).To(Equal(types.DT_NOOP))
+	g.Expect(port.L2LinkConfig.L2Type).To(Equal(types.L2LinkTypeNone))
+	g.Expect(port.WirelessCfg.WType).To(Equal(types.WirelessTypeNone))
+}
+
+func TestParseVlansOverBonds(t *testing.T) {
+	g := NewGomegaWithT(t)
+	getconfigCtx := initGetConfigCtx(g)
+
+	const (
+		network1UUID = "572cd3bc-ade6-42ad-97a0-22cd24fed1a0"
+		network2UUID = "0c1a98fb-85fa-421d-943e-8d4e469bea8f"
+	)
+	config := &zconfig.EdgeDevConfig{
+		Networks: []*zconfig.NetworkConfig{
+			{
+				Id:   network1UUID,
+				Type: zconfig.NetworkType_V4,
+				Ip: &zconfig.Ipspec{
+					Dhcp: zconfig.DHCPType_Client,
+				},
+			},
+			{
+				Id:   network2UUID,
+				Type: zconfig.NetworkType_V4,
+				Ip: &zconfig.Ipspec{
+					Dhcp: zconfig.DHCPType_Client,
+				},
+			},
+		},
+		DeviceIoList: []*zconfig.PhysicalIO{
+			{
+				Ptype:        zcommon.PhyIoType_PhyIoNetEth,
+				Phylabel:     "ethernet0",
+				Logicallabel: "shopfloor0",
+				Assigngrp:    "eth-grp-1",
+				Phyaddrs: map[string]string{
+					"ifname":  "eth0",
+					"pcilong": "0000:04:00.0",
+				},
+				Usage: zcommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
+			},
+			{
+				Ptype:        zcommon.PhyIoType_PhyIoNetEth,
+				Phylabel:     "ethernet1",
+				Logicallabel: "shopfloor1",
+				Assigngrp:    "eth-grp-2",
+				Phyaddrs: map[string]string{
+					"ifname":  "eth1",
+					"pcilong": "0000:05:00.0",
+				},
+				Usage: zcommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
+			},
+		},
+		Bonds: []*zconfig.BondAdapter{
+			{
+				Logicallabel:    "bond-shopfloor",
+				InterfaceName:   "bond0",
+				LowerLayerNames: []string{"shopfloor1", "shopfloor0"}, // order matters in Active-Backup mode
+				BondMode:        zconfig.BondMode_BOND_MODE_ACTIVE_BACKUP,
+				Monitoring: &zconfig.BondAdapter_Mii{
+					Mii: &zconfig.MIIMonitor{
+						Interval:  400,
+						Updelay:   800,
+						Downdelay: 1200,
+					},
+				},
+			},
+		},
+		Vlans: []*zconfig.VlanAdapter{
+			{
+				Logicallabel:   "shopfloor-vlan100",
+				InterfaceName:  "shopfloor.100",
+				LowerLayerName: "bond-shopfloor",
+				VlanId:         100,
+			},
+			{
+				Logicallabel:   "shopfloor-vlan200",
+				InterfaceName:  "shopfloor.200",
+				LowerLayerName: "bond-shopfloor",
+				VlanId:         200,
+			},
+		},
+		SystemAdapterList: []*zconfig.SystemAdapter{
+			{
+				Name:           "adapter-shopfloor-vlan100",
+				Uplink:         true,
+				NetworkUUID:    network1UUID,
+				LowerLayerName: "shopfloor-vlan100",
+				Cost:           10,
+			},
+			{
+				Name:           "adapter-shopfloor-vlan200",
+				Uplink:         true,
+				NetworkUUID:    network2UUID,
+				LowerLayerName: "shopfloor-vlan200",
+				Cost:           20,
+			},
+		},
+	}
+
+	parseDeviceIoListConfig(config, getconfigCtx)
+	parseBonds(config, getconfigCtx)
+	parseVlans(config, getconfigCtx)
+	parseNetworkXObjectConfig(config, getconfigCtx)
+	parseSystemAdapterConfig(config, getconfigCtx, true)
+
+	portConfig, err := getconfigCtx.pubDevicePortConfig.Get("zedagent")
+	g.Expect(err).To(BeNil())
+	dpc := portConfig.(types.DevicePortConfig)
+	g.Expect(dpc.Version).To(Equal(types.DPCIsMgmt))
+	g.Expect(dpc.HasError()).To(BeFalse())
+	g.Expect(dpc.Ports).To(HaveLen(5))
+	sortDPCPorts(&dpc)
+	// System adapter for shopfloor VLAN100
+	port := dpc.Ports[0]
+	g.Expect(port.Logicallabel).To(Equal("adapter-shopfloor-vlan100"))
+	g.Expect(port.Phylabel).To(BeEmpty())
+	g.Expect(port.IsL3Port).To(BeTrue())
+	g.Expect(port.IfName).To(Equal("shopfloor.100"))
+	g.Expect(port.NetworkUUID.String()).To(Equal(network1UUID))
+	g.Expect(port.Cost).To(BeEquivalentTo(10))
+	g.Expect(port.DhcpConfig.Type).To(BeEquivalentTo(types.NT_IPV4))
+	g.Expect(port.DhcpConfig.Dhcp).To(Equal(types.DT_CLIENT))
+	g.Expect(port.L2LinkConfig.L2Type).To(Equal(types.L2LinkTypeVLAN))
+	g.Expect(port.L2LinkConfig.VLAN.ParentPort).To(Equal("bond-shopfloor"))
+	g.Expect(port.L2LinkConfig.VLAN.ID).To(BeEquivalentTo(100))
+	g.Expect(port.WirelessCfg.WType).To(Equal(types.WirelessTypeNone))
+	// System adapter for shopfloor VLAN100
+	port = dpc.Ports[1]
+	g.Expect(port.Logicallabel).To(Equal("adapter-shopfloor-vlan200"))
+	g.Expect(port.Phylabel).To(BeEmpty())
+	g.Expect(port.IsL3Port).To(BeTrue())
+	g.Expect(port.IfName).To(Equal("shopfloor.200"))
+	g.Expect(port.NetworkUUID.String()).To(Equal(network2UUID))
+	g.Expect(port.Cost).To(BeEquivalentTo(20))
+	g.Expect(port.DhcpConfig.Type).To(BeEquivalentTo(types.NT_IPV4))
+	g.Expect(port.DhcpConfig.Dhcp).To(Equal(types.DT_CLIENT))
+	g.Expect(port.L2LinkConfig.L2Type).To(Equal(types.L2LinkTypeVLAN))
+	g.Expect(port.L2LinkConfig.VLAN.ParentPort).To(Equal("bond-shopfloor"))
+	g.Expect(port.L2LinkConfig.VLAN.ID).To(BeEquivalentTo(200))
+	g.Expect(port.WirelessCfg.WType).To(Equal(types.WirelessTypeNone))
+	// Bond aggregating shopfloor0 and shopfloor1
+	port = dpc.Ports[2]
+	g.Expect(port.Logicallabel).To(Equal("bond-shopfloor"))
+	g.Expect(port.Phylabel).To(BeEmpty())
+	g.Expect(port.IsL3Port).To(BeFalse())
+	g.Expect(port.IfName).To(Equal("bond0"))
+	g.Expect(port.NetworkUUID).To(BeZero())
+	g.Expect(port.Cost).To(BeZero())
+	g.Expect(port.DhcpConfig.Type).To(BeEquivalentTo(types.NT_NOOP))
+	g.Expect(port.DhcpConfig.Dhcp).To(Equal(types.DT_NOOP))
+	g.Expect(port.L2LinkConfig.L2Type).To(Equal(types.L2LinkTypeBond))
+	g.Expect(port.L2LinkConfig.Bond.AggregatedPorts).To(Equal([]string{"shopfloor1", "shopfloor0"}))
+	g.Expect(port.L2LinkConfig.Bond.Mode).To(Equal(types.BondModeActiveBackup))
+	g.Expect(port.L2LinkConfig.Bond.MIIMonitor.Enabled).To(BeTrue())
+	g.Expect(port.L2LinkConfig.Bond.MIIMonitor.Interval).To(BeEquivalentTo(400))
+	g.Expect(port.L2LinkConfig.Bond.MIIMonitor.UpDelay).To(BeEquivalentTo(800))
+	g.Expect(port.L2LinkConfig.Bond.MIIMonitor.DownDelay).To(BeEquivalentTo(1200))
+	g.Expect(port.L2LinkConfig.Bond.ARPMonitor.Enabled).To(BeFalse())
+	g.Expect(port.WirelessCfg.WType).To(Equal(types.WirelessTypeNone))
+	// underlying physical "shopfloor0" adapter
+	port = dpc.Ports[3]
+	g.Expect(port.Logicallabel).To(Equal("shopfloor0"))
+	g.Expect(port.Phylabel).To(Equal("ethernet0"))
+	g.Expect(port.IsL3Port).To(BeFalse())
+	g.Expect(port.IfName).To(Equal("eth0"))
+	g.Expect(port.NetworkUUID).To(BeZero())
+	g.Expect(port.Cost).To(BeZero())
+	g.Expect(port.DhcpConfig.Type).To(BeEquivalentTo(types.NT_NOOP))
+	g.Expect(port.DhcpConfig.Dhcp).To(Equal(types.DT_NOOP))
+	g.Expect(port.L2LinkConfig.L2Type).To(Equal(types.L2LinkTypeNone))
+	g.Expect(port.WirelessCfg.WType).To(Equal(types.WirelessTypeNone))
+	// underlying physical "shopfloor1" adapter
+	port = dpc.Ports[4]
+	g.Expect(port.Logicallabel).To(Equal("shopfloor1"))
+	g.Expect(port.Phylabel).To(Equal("ethernet1"))
+	g.Expect(port.IsL3Port).To(BeFalse())
+	g.Expect(port.IfName).To(Equal("eth1"))
+	g.Expect(port.NetworkUUID).To(BeZero())
+	g.Expect(port.Cost).To(BeZero())
+	g.Expect(port.DhcpConfig.Type).To(BeEquivalentTo(types.NT_NOOP))
+	g.Expect(port.DhcpConfig.Dhcp).To(Equal(types.DT_NOOP))
+	g.Expect(port.L2LinkConfig.L2Type).To(Equal(types.L2LinkTypeNone))
+	g.Expect(port.WirelessCfg.WType).To(Equal(types.WirelessTypeNone))
+}
+
+func TestInvalidLowerLayerReferences(t *testing.T) {
+	g := NewGomegaWithT(t)
+	getconfigCtx := initGetConfigCtx(g)
+
+	const (
+		network1UUID = "572cd3bc-ade6-42ad-97a0-22cd24fed1a0"
+		network2UUID = "0c1a98fb-85fa-421d-943e-8d4e469bea8f"
+	)
+	baseConfig := &zconfig.EdgeDevConfig{
+		Networks: []*zconfig.NetworkConfig{
+			{
+				Id:   network1UUID,
+				Type: zconfig.NetworkType_V4,
+				Ip: &zconfig.Ipspec{
+					Dhcp: zconfig.DHCPType_Client,
+				},
+			},
+			{
+				Id:   network2UUID,
+				Type: zconfig.NetworkType_V4,
+				Ip: &zconfig.Ipspec{
+					Dhcp: zconfig.DHCPType_Client,
+				},
+			},
+		},
+		DeviceIoList: []*zconfig.PhysicalIO{
+			{
+				Ptype:        zcommon.PhyIoType_PhyIoNetEth,
+				Phylabel:     "ethernet0",
+				Logicallabel: "shopfloor",
+				Assigngrp:    "eth-grp-1",
+				Phyaddrs: map[string]string{
+					"ifname":  "eth0",
+					"pcilong": "0000:04:00.0",
+				},
+				Usage: zcommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
+			},
+			{
+				Ptype:        zcommon.PhyIoType_PhyIoNetEth,
+				Phylabel:     "ethernet1",
+				Logicallabel: "warehouse",
+				Assigngrp:    "eth-grp-2",
+				Phyaddrs: map[string]string{
+					"ifname":  "eth1",
+					"pcilong": "0000:05:00.0",
+				},
+				Usage: zcommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
+			},
+		},
+	}
+
+	// IO and networks do not change between scenarios
+	parseDeviceIoListConfig(baseConfig, getconfigCtx)
+	parseNetworkXObjectConfig(baseConfig, getconfigCtx)
+
+	// Scenario 1: System adapters referencing the same underlying port
+	config := &zconfig.EdgeDevConfig{
+		SystemAdapterList: []*zconfig.SystemAdapter{
+			{
+				Name:           "adapter1",
+				Uplink:         true,
+				NetworkUUID:    network1UUID,
+				LowerLayerName: "shopfloor",
+				Cost:           10,
+			},
+			{
+				Name:           "adapter2",
+				Uplink:         true,
+				NetworkUUID:    network2UUID,
+				LowerLayerName: "shopfloor",
+				Cost:           20,
+			},
+		},
+	}
+	parseSystemAdapterConfig(config, getconfigCtx, true)
+	portConfig, err := getconfigCtx.pubDevicePortConfig.Get("zedagent")
+	g.Expect(err).To(BeNil())
+	dpc := portConfig.(types.DevicePortConfig)
+	g.Expect(dpc.HasError()).To(BeTrue())
+	g.Expect(getPortError(&dpc, "adapter1")).
+		To(ContainSubstring("Port collides with another port"))
+	g.Expect(getPortError(&dpc, "adapter2")).
+		To(ContainSubstring("Port collides with another port"))
+	g.Expect(dpc.Ports).To(HaveLen(2))
+
+	// fix:
+	config.SystemAdapterList[1].LowerLayerName = "warehouse"
+	parseSystemAdapterConfig(config, getconfigCtx, true)
+	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
+	g.Expect(err).To(BeNil())
+	dpc = portConfig.(types.DevicePortConfig)
+	g.Expect(dpc.HasError()).To(BeFalse())
+	g.Expect(dpc.Ports).To(HaveLen(2))
+
+	// Scenario 2: Lower layer reference matching multiple adapters
+	config = &zconfig.EdgeDevConfig{
+		Bonds: []*zconfig.BondAdapter{
+			{
+				Logicallabel:    "shopfloor", // collides with shopfloor from physicalIO
+				InterfaceName:   "bond0",
+				LowerLayerNames: []string{"shopfloor", "warehouse"},
+				BondMode:        zconfig.BondMode_BOND_MODE_ACTIVE_BACKUP,
+			},
+		},
+		SystemAdapterList: []*zconfig.SystemAdapter{
+			{
+				Name:           "adapter",
+				Uplink:         true,
+				NetworkUUID:    network1UUID,
+				LowerLayerName: "shopfloor", // matches bond and physical IO
+			},
+		},
+	}
+	parseBonds(config, getconfigCtx)
+	parseSystemAdapterConfig(config, getconfigCtx, true)
+	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
+	g.Expect(err).To(BeNil())
+	dpc = portConfig.(types.DevicePortConfig)
+	g.Expect(dpc.HasError()).To(BeTrue())
+	g.Expect(dpc.LastError).To(ContainSubstring("multiple lower-layer adapters match"))
+	g.Expect(dpc.Ports).To(BeEmpty())
+
+	// fix:
+	config.Bonds[0].Logicallabel = "bond-shopfloor"
+	config.SystemAdapterList[0].LowerLayerName = "bond-shopfloor"
+	parseBonds(config, getconfigCtx)
+	parseSystemAdapterConfig(config, getconfigCtx, true)
+	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
+	g.Expect(err).To(BeNil())
+	dpc = portConfig.(types.DevicePortConfig)
+	g.Expect(dpc.HasError()).To(BeFalse())
+	g.Expect(dpc.Ports).To(HaveLen(3))
+
+	// Scenario 3: Missing lower-layer adapter
+	config = &zconfig.EdgeDevConfig{
+		SystemAdapterList: []*zconfig.SystemAdapter{
+			{
+				Name:           "adapter",
+				Uplink:         true,
+				NetworkUUID:    network1UUID,
+				LowerLayerName: "bond-shopfloor", // bond is missing from config
+			},
+		},
+	}
+	parseBonds(config, getconfigCtx)
+	parseSystemAdapterConfig(config, getconfigCtx, true)
+	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
+	g.Expect(err).To(BeNil())
+	dpc = portConfig.(types.DevicePortConfig)
+	g.Expect(dpc.HasError()).To(BeTrue())
+	g.Expect(dpc.LastError).To(ContainSubstring("missing lower-layer adapter"))
+	g.Expect(dpc.Ports).To(BeEmpty())
+
+	// fix:
+	config.Bonds = []*zconfig.BondAdapter{
+		{
+			Logicallabel:    "bond-shopfloor",
+			InterfaceName:   "bond0",
+			LowerLayerNames: []string{"shopfloor", "warehouse"},
+			BondMode:        zconfig.BondMode_BOND_MODE_ACTIVE_BACKUP,
+		},
+	}
+	parseBonds(config, getconfigCtx)
+	parseSystemAdapterConfig(config, getconfigCtx, true)
+	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
+	g.Expect(err).To(BeNil())
+	dpc = portConfig.(types.DevicePortConfig)
+	g.Expect(dpc.HasError()).To(BeFalse())
+	g.Expect(dpc.Ports).To(HaveLen(3))
+
+	// Scenario 4: interface referenced by both a system adapter and a L2 object
+	config = &zconfig.EdgeDevConfig{
+		Bonds: []*zconfig.BondAdapter{
+			{
+				Logicallabel:    "bond-shopfloor",
+				InterfaceName:   "bond0",
+				LowerLayerNames: []string{"shopfloor", "warehouse"},
+				BondMode:        zconfig.BondMode_BOND_MODE_ACTIVE_BACKUP,
+			},
+		},
+		SystemAdapterList: []*zconfig.SystemAdapter{
+			{
+				Name:           "adapter-bond-shopfloor",
+				Uplink:         true,
+				NetworkUUID:    network1UUID,
+				LowerLayerName: "bond-shopfloor",
+			},
+			{
+				Name:           "adapter-warehouse", // warehouse port is already part of a LAG, cannot be L3
+				Uplink:         true,
+				NetworkUUID:    network2UUID,
+				LowerLayerName: "warehouse",
+			},
+		},
+	}
+	parseBonds(config, getconfigCtx)
+	parseSystemAdapterConfig(config, getconfigCtx, true)
+	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
+	g.Expect(err).To(BeNil())
+	dpc = portConfig.(types.DevicePortConfig)
+	g.Expect(dpc.HasError()).To(BeTrue())
+	g.Expect(getPortError(&dpc, "adapter-warehouse")).
+		To(ContainSubstring("Port collides with another port"))
+	g.Expect(getPortError(&dpc, "adapter-bond-shopfloor")).
+		To(ContainSubstring("Port collides with another port"))
+	g.Expect(dpc.Ports).To(HaveLen(4))
+
+	// fix:
+	config.Bonds[0].LowerLayerNames = []string{"shopfloor"}
+	parseBonds(config, getconfigCtx)
+	parseSystemAdapterConfig(config, getconfigCtx, true)
+	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
+	g.Expect(err).To(BeNil())
+	dpc = portConfig.(types.DevicePortConfig)
+	g.Expect(dpc.HasError()).To(BeFalse())
+	g.Expect(dpc.Ports).To(HaveLen(3))
+
+	// Scenario 5: Duplicate VLAN IDs
+	config = &zconfig.EdgeDevConfig{
+		Vlans: []*zconfig.VlanAdapter{
+			{
+				Logicallabel:   "shopfloor-vlan100",
+				InterfaceName:  "shopfloor.100",
+				LowerLayerName: "shopfloor",
+				VlanId:         100,
+			},
+			{
+				Logicallabel:   "shopfloor-vlan200",
+				InterfaceName:  "shopfloor.200",
+				LowerLayerName: "shopfloor",
+				VlanId:         100, // 100 entered instead of 200 by mistake
+			},
+		},
+		SystemAdapterList: []*zconfig.SystemAdapter{
+			{
+				Name:           "adapter-shopfloor-vlan100",
+				Uplink:         true,
+				NetworkUUID:    network1UUID,
+				LowerLayerName: "shopfloor-vlan100",
+			},
+			{
+				Name:           "adapter-shopfloor-vlan200",
+				Uplink:         true,
+				NetworkUUID:    network2UUID,
+				LowerLayerName: "shopfloor-vlan200",
+			},
+		},
+	}
+	parseBonds(config, getconfigCtx)
+	parseVlans(config, getconfigCtx)
+	parseSystemAdapterConfig(config, getconfigCtx, true)
+	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
+	g.Expect(err).To(BeNil())
+	dpc = portConfig.(types.DevicePortConfig)
+	g.Expect(dpc.HasError()).To(BeTrue())
+	g.Expect(getPortError(&dpc, "adapter-shopfloor-vlan100")).
+		To(ContainSubstring("duplicate VLAN sub-interfaces"))
+	g.Expect(getPortError(&dpc, "adapter-shopfloor-vlan200")).
+		To(ContainSubstring("duplicate VLAN sub-interfaces"))
+	g.Expect(dpc.Ports).To(HaveLen(3))
+
+	// fix:
+	config.Vlans[1].VlanId = 200
+	parseBonds(config, getconfigCtx)
+	parseVlans(config, getconfigCtx)
+	parseSystemAdapterConfig(config, getconfigCtx, true)
+	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
+	g.Expect(err).To(BeNil())
+	dpc = portConfig.(types.DevicePortConfig)
+	g.Expect(dpc.HasError()).To(BeFalse())
+	g.Expect(dpc.Ports).To(HaveLen(3))
+
+	// Scenario 6: VLAN referencing port aggregated by a bond
+	config = &zconfig.EdgeDevConfig{
+		Bonds: []*zconfig.BondAdapter{
+			{
+				Logicallabel:    "bond0",
+				InterfaceName:   "bond0",
+				LowerLayerNames: []string{"shopfloor", "warehouse"},
+				BondMode:        zconfig.BondMode_BOND_MODE_ACTIVE_BACKUP,
+			},
+		},
+		Vlans: []*zconfig.VlanAdapter{
+			{
+				Logicallabel:   "warehouse-vlan100",
+				InterfaceName:  "warehouse.100",
+				LowerLayerName: "warehouse", // warehouse referenced by both a VLAN and a bond
+				VlanId:         100,
+			},
+		},
+		SystemAdapterList: []*zconfig.SystemAdapter{
+			{
+				Name:           "adapter-bond0",
+				Uplink:         true,
+				NetworkUUID:    network1UUID,
+				LowerLayerName: "bond0",
+			},
+			{
+				Name:           "adapter-warehouse-vlan100",
+				Uplink:         true,
+				NetworkUUID:    network2UUID,
+				LowerLayerName: "warehouse-vlan100",
+			},
+		},
+	}
+	parseBonds(config, getconfigCtx)
+	parseVlans(config, getconfigCtx)
+	parseSystemAdapterConfig(config, getconfigCtx, true)
+	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
+	g.Expect(err).To(BeNil())
+	dpc = portConfig.(types.DevicePortConfig)
+	g.Expect(dpc.HasError()).To(BeTrue())
+	g.Expect(getPortError(&dpc, "adapter-bond0")).
+		To(ContainSubstring("referenced by both bond (adapter-bond0) and VLAN (adapter-warehouse-vlan100)"))
+	g.Expect(getPortError(&dpc, "adapter-warehouse-vlan100")).
+		To(ContainSubstring("referenced by both bond (adapter-bond0) and VLAN (adapter-warehouse-vlan100)"))
+	g.Expect(dpc.Ports).To(HaveLen(4))
+
+	// fix:
+	config.Bonds[0].LowerLayerNames = []string{"shopfloor"} // remove warehouse from the LAG
+	parseBonds(config, getconfigCtx)
+	parseVlans(config, getconfigCtx)
+	parseSystemAdapterConfig(config, getconfigCtx, true)
+	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
+	g.Expect(err).To(BeNil())
+	dpc = portConfig.(types.DevicePortConfig)
+	g.Expect(dpc.HasError()).To(BeFalse())
+	g.Expect(dpc.Ports).To(HaveLen(4))
+
+	// Scenario 7: overlapping LAGs
+	config = &zconfig.EdgeDevConfig{
+		Bonds: []*zconfig.BondAdapter{
+			{
+				Logicallabel:    "bond0",
+				InterfaceName:   "bond0",
+				LowerLayerNames: []string{"shopfloor", "warehouse"},
+				BondMode:        zconfig.BondMode_BOND_MODE_ACTIVE_BACKUP,
+			},
+			{
+				Logicallabel:    "bond1",
+				InterfaceName:   "bond1",
+				LowerLayerNames: []string{"shopfloor", "warehouse"},
+				BondMode:        zconfig.BondMode_BOND_MODE_ACTIVE_BACKUP,
+			},
+		},
+		SystemAdapterList: []*zconfig.SystemAdapter{
+			{
+				Name:           "adapter-bond0",
+				Uplink:         true,
+				NetworkUUID:    network1UUID,
+				LowerLayerName: "bond0",
+			},
+			{
+				Name:           "adapter-bond1",
+				Uplink:         true,
+				NetworkUUID:    network2UUID,
+				LowerLayerName: "bond1",
+			},
+		},
+	}
+	parseBonds(config, getconfigCtx)
+	parseSystemAdapterConfig(config, getconfigCtx, true)
+	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
+	g.Expect(err).To(BeNil())
+	dpc = portConfig.(types.DevicePortConfig)
+	g.Expect(dpc.HasError()).To(BeTrue())
+	g.Expect(getPortError(&dpc, "adapter-bond0")).
+		To(ContainSubstring("aggregated by multiple bond interfaces"))
+	g.Expect(getPortError(&dpc, "adapter-bond1")).
+		To(ContainSubstring("aggregated by multiple bond interfaces"))
+	g.Expect(dpc.Ports).To(HaveLen(4))
+
+	// fix
+	config.Bonds[0].LowerLayerNames = []string{"shopfloor"}
+	config.Bonds[1].LowerLayerNames = []string{"warehouse"}
+	parseBonds(config, getconfigCtx)
+	parseSystemAdapterConfig(config, getconfigCtx, true)
+	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
+	g.Expect(err).To(BeNil())
+	dpc = portConfig.(types.DevicePortConfig)
+	g.Expect(dpc.HasError()).To(BeFalse())
+	g.Expect(dpc.Ports).To(HaveLen(4))
+
+	// Scenario 9: Out-of-range VLAN ID
+	config = &zconfig.EdgeDevConfig{
+		Vlans: []*zconfig.VlanAdapter{
+			{
+				Logicallabel:   "shopfloor-vlan1000",
+				InterfaceName:  "shopfloor.1000",
+				LowerLayerName: "shopfloor",
+				VlanId:         10000, // out-of-range VLAN ID entered by mistake
+			},
+		},
+		SystemAdapterList: []*zconfig.SystemAdapter{
+			{
+				Name:           "adapter-shopfloor-vlan1000",
+				Uplink:         true,
+				NetworkUUID:    network1UUID,
+				LowerLayerName: "shopfloor-vlan1000",
+			},
+		},
+	}
+	parseBonds(config, getconfigCtx)
+	parseVlans(config, getconfigCtx)
+	parseSystemAdapterConfig(config, getconfigCtx, true)
+	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
+	g.Expect(err).To(BeNil())
+	dpc = portConfig.(types.DevicePortConfig)
+	g.Expect(dpc.HasError()).To(BeTrue())
+	g.Expect(getPortError(&dpc, "adapter-shopfloor-vlan1000")).
+		To(ContainSubstring("VLAN ID out of range: 10000"))
+	g.Expect(dpc.Ports).To(HaveLen(2))
+
+	// fix:
+	config.Vlans[0].VlanId = 1000
+	parseBonds(config, getconfigCtx)
+	parseVlans(config, getconfigCtx)
+	parseSystemAdapterConfig(config, getconfigCtx, true)
+	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
+	g.Expect(err).To(BeNil())
+	dpc = portConfig.(types.DevicePortConfig)
+	g.Expect(dpc.HasError()).To(BeFalse())
+	g.Expect(dpc.Ports).To(HaveLen(2))
+}

--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -827,6 +827,10 @@ func encodeSystemAdapterInfo(ctx *zedagentContext) *info.SystemAdapterInfo {
 
 		dps.Ports = make([]*info.DevicePort, len(dpc.Ports))
 		for j, p := range dpc.Ports {
+			if !p.IsL3Port {
+				// info for ports from lower layers is not published
+				continue
+			}
 			dps.Ports[j] = encodeNetworkPortConfig(ctx, &p)
 			if i == dpcl.CurrentIndex && p.WirelessCfg.WType == types.WirelessTypeCellular {
 				portStatus := deviceNetworkStatus.GetPortByLogicallabel(p.Logicallabel)

--- a/pkg/pillar/cmd/zedrouter/pbr.go
+++ b/pkg/pillar/cmd/zedrouter/pbr.go
@@ -182,7 +182,7 @@ func PbrRouteChange(ctx *zedrouterContext,
 			rt.LinkIndex, err, rt)
 		return
 	}
-	if linkType != "bridge" && !types.IsPort(*deviceNetworkStatus, ifname) {
+	if linkType != "bridge" && !types.IsL3Port(*deviceNetworkStatus, ifname) {
 		// Ignore
 		log.Functionf("PbrRouteChange ignore %s: neither bridge nor port. route %v\n",
 			ifname, rt)

--- a/pkg/pillar/devicenetwork/devicenetwork.go
+++ b/pkg/pillar/devicenetwork/devicenetwork.go
@@ -186,6 +186,7 @@ func MakeDeviceNetworkStatus(ctx *DeviceNetworkContext, globalConfig types.Devic
 		globalStatus.Ports[ix].Logicallabel = u.Logicallabel
 		globalStatus.Ports[ix].Alias = u.Alias
 		globalStatus.Ports[ix].IsMgmt = u.IsMgmt
+		globalStatus.Ports[ix].IsL3Port = u.IsL3Port
 		globalStatus.Ports[ix].Cost = u.Cost
 		globalStatus.Ports[ix].ProxyConfig = u.ProxyConfig
 		// Set fields from the config...


### PR DESCRIPTION
With VLANs and Bonds (LAGs) we now have a multi-layer hierarchy of network ports.
VLANS and Bonds are classified as L2 adapters and compose a new layer in-between
`SystemAdapters` and `PhysicalIO`.
For every object that is either directly referenced or transitively used
by a `SystemAdapter`, `parseSystemAdapterConfig()` adds a separate `NetworkPortConfig`
entry into `DevicePortConfig`. There is a new field `IsL3Port` inside `NetworkPortConfig`
and `NetworkPortStatus`, used to mark ports directly referenced by `SystemAdapters`
(i.e. without any higher-level ports above them). This is usefull because
configuration for IP, DHCP, Proxy, Wireless, etc. is only relevant for L3 ports.
L2 ports have labels, interface names and `L2LinkConfig` defined.
Physical ports which are below L2 objects have only labels and interface names
specified.

This commits also clears up the semantics of logical labels and cross-layer
references.
The current implementation of the reference relations between system adapters
and physical IO is confusing. EVE code does not have a uniform way of looking up
for referenced objects. It mixes up adapter names with `LowerLayerNames` for 
cross-layer references and it uses both logical and physical labels as targets
for those references.
The desired behaviour, which this commit enforces, is that controllers should
always have the upper layers reference lower layers by making the `LowerLayerName`
field of upper layers reference the `logicallabel` field of lower layers.

Signed-off-by: Milan Lenco <milan@zededa.com>