### PR TITLE
enable emulate_tpu to support scsi unmap

### DIFF
--- a/pkg/pillar/tgt/tgt.go
+++ b/pkg/pillar/tgt/tgt.go
@@ -79,6 +79,9 @@ func TargetCreateIBlock(dev, tgtName, serial string) error {
 	if err := ioutil.WriteFile(filepath.Join(targetRoot, "enable"), []byte("1"), 0660); err != nil {
 		return fmt.Errorf("error set enable: %v", err)
 	}
+	if err := ioutil.WriteFile(filepath.Join(targetRoot, "attrib", "emulate_tpu"), []byte("1"), 0660); err != nil {
+		return fmt.Errorf("error set emulate_tpu: %v", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
In order to support SCSI UNMAP we must enable emulate_tpu for target. It would allow filesystems stored in zvols (inside VM) to report unused blocks (e.g. after deletion of file) and allow the underlying zvol to shrink the data.