### PR TITLE
ntp not sufficiently robust against bad hardware clock

### DIFF
--- a/images/docker-compose.yml.in
+++ b/images/docker-compose.yml.in
@@ -62,17 +62,6 @@ services:
         networks:
             - eve
 
-    ntpd:
-        image: linuxkit/openntpd:v0.5
-        privileged: true
-        volumes:
-            - persist:/persist
-            - config:/config
-            - run:/run
-        # network_mode: host
-        networks:
-            - eve
-
     wwan:
         image: WWAN_TAG
         privileged: true

--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -30,10 +30,6 @@ services:
      image: NEWLOGD_TAG
      cgroupsPath: /eve/services/eve-newlog
      oomScoreAdj: -999
-   - name: ntpd
-     image: linuxkit/openntpd:v0.5
-     cgroupsPath: /eve/services/ntpd
-     oomScoreAdj: -999
    - name: debug
      image: DEBUG_TAG
      cgroupsPath: /eve/services/debug

--- a/pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup
+++ b/pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup
@@ -61,7 +61,7 @@ if [ -z "${ctrd_cgroup_cpus_limit}" ]; then
 fi
 
 CGROUPS="cpuset cpu cpuacct blkio memory devices freezer net_cls perf_event net_prio hugetlb pids systemd "
-EVESRVICES="ntpd sshd wwan wlan lisp guacd pillar vtpm watchdog xen-tools "
+EVESRVICES="sshd wwan wlan lisp guacd pillar vtpm watchdog xen-tools "
 
 #Creating eve cgroup which will be parent/dom0 cgroup
 for cg in $CGROUPS; do

--- a/pkg/mkimage-raw-efi/install
+++ b/pkg/mkimage-raw-efi/install
@@ -312,6 +312,9 @@ if mount_part INVENTORY "$(root_dev)" /run/INVENTORY -t vfat -o iocharset=iso885
    # try to generate model json file
    ctr_run /opt/debug spec.sh > "$REPORT/controller-model.json"
    ctr_run /opt/debug spec.sh -v > "$REPORT/controller-model-verbose.json"
+
+   # Save to help figure out if RTC is not in UTC
+   (hwclock -v -u; date -Is -u ) > "$REPORT/clock"
 fi
 
 # The creation of the 4 key pairs on the TPM below can take significant

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -400,6 +400,17 @@ if [ ! -s $CONFIGDIR/device.cert.pem ] || [ $RTC = 0 ] || [ -n "$FIRSTBOOT" ]; t
         # sane starting time. This fixes issues when the RTC was not in UTC
         hwclock -u -v --systohc
     fi
+else
+    # Start ntpd before network is up. Assumes it will synchronize later.
+    if [ -f /usr/sbin/ntpd ]; then
+        # Run ntpd to keep it in sync. Allow a large initial jump in case clock
+        # had drifted more than 1000 seconds while the device was powered off
+        /usr/sbin/ntpd -g -p pool.ntp.org
+        # Add ndpd to watchdog
+        touch "$WATCHDOG_PID/ntpd.pid"
+    else
+        echo "$(date -Ins -u) No ntpd"
+    fi
 fi
 if [ ! -s $CONFIGDIR/device.cert.pem ]; then
     echo "$(date -Ins -u) Generating a device key pair and self-signed cert (using TPM/TEE if available)"


### PR DESCRIPTION
On some servers in the lab and on equinix metal we've run into the hardware clock not being in UTC (perhaps due to someone having run Windows on the server before).

This ensures that we make ntpd synchronize on firs boot and then set the hardware clock from the ntp clock.

Three commits:
1. Fix setting clock on first boot

The previous attempt relied on a first-boot file, but nodeagent deletes
that file once it has observed its existence.

2. Handle case of bad RTC

Wait for NTP synchonization and set the RTC based on that. Handles
devices where hardware clock is not in UTC. Have install script report
hwclock as part of inventory.

3. ntpd container is not useful

If the clock is out of whack it does not slew it is in. This might be
due to it starting before the network interfaces is up and/or the -g
flag is not used by this container. In any case, this results in devices
which where the RTC is off by tens of minutes or more to not synchronize
their clock. Such an offset on the RTC appears to happen on some devices
which have been powered off for a long time, or devices which might have
had their RTC set to use some timezone other than UTC.
