### PR TITLE
Implement EVE AppStatus Led blinks

### DIFF
--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -169,6 +169,18 @@ type AppInstanceStatus struct {
 	ErrorAndTimeWithSource
 }
 
+// AppCount is uint8 and it should be sufficient for the number of apps we can support
+type AppCount uint8
+
+// AppInstanceSummary captures the running state of all apps
+type AppInstanceSummary struct {
+	UUIDandVersion UUIDandVersion
+	TotalStarting  AppCount // Total number of apps starting/booting
+	TotalRunning   AppCount // Total number of apps in running state
+	TotalStopping  AppCount // Total number of apps in halting state
+	TotalError     AppCount // Total number of apps in error state
+}
+
 // LogCreate :
 func (status AppInstanceStatus) LogCreate(logBase *base.LogObject) {
 	logObject := base.NewLogObject(logBase, base.AppInstanceStatusLogType, status.DisplayName,
@@ -247,6 +259,11 @@ const (
 )
 
 func (status AppInstanceStatus) Key() string {
+	return status.UUIDandVersion.UUID.String()
+}
+
+// Key provides a unique key
+func (status AppInstanceSummary) Key() string {
 	return status.UUIDandVersion.UUID.String()
 }
 


### PR DESCRIPTION
	This commit only supports model SIEMENS AG.SIMATIC IPC127E
	Uses LED 3 (the one labeled as L3 MAINT) for application state.
	1) If no application has even started booting that LED will be off.
	2) If one or more applications is in error state, then the LED will be solid red.
	3) If there is no error
		If EVE has moved all of the applications to the booted or running state, then solid green
		If some applications are in the halting state, then blinking orange.
		If some applications are in the init state, then blinking green.

Signed-off-by: Pramodh Pallapothu  <pramodh@zededa.com>