### PR TITLE
With proxy certs the list of DPCs can easily exceed pubsub msg size limit

### DIFF
--- a/pkg/pillar/pubsub/large_test.go
+++ b/pkg/pillar/pubsub/large_test.go
@@ -100,3 +100,134 @@ func TestRemoveAndAddLarge(t *testing.T) {
 		t.Fatalf("objects are not equal: %v %v", originalObject, newObject)
 	}
 }
+
+type EmbeddedWithLarge struct {
+	EmbeddedLargeData [][]byte `json:"pubsub-large-EmbeddedLargeData"`
+}
+
+type LargeInsideArray struct {
+	SmallData string
+	LargeData [][]byte `json:"pubsub-large-LargeData"`
+	EmbeddedWithLarge
+}
+
+type LargeWithArray struct {
+	LargeTop            []byte `json:"pubsub-large-LargeTop"`
+	ArrayWithLargeData  []LargeInsideArray
+	ArrayWithLargeData2 []LargeInsideArray
+}
+
+func TestRemoveAndAddLargeWithArray(t *testing.T) {
+	logger := logrus.StandardLogger()
+	log := base.NewSourceLogObject(logger, "test", 1234)
+	// Run in a unique directory
+	rootPath, err := ioutil.TempDir("", "remove_large_test_with_array")
+	if err != nil {
+		t.Fatalf("TempDir failed: %s", err)
+	}
+	defer os.RemoveAll(rootPath)
+
+	originalObject := LargeWithArray{
+		LargeTop: []byte{2},
+		ArrayWithLargeData: []LargeInsideArray{
+			{
+				SmallData: "test",
+				LargeData: [][]byte{{1, 2, 3}, {4, 5, 6}},
+				EmbeddedWithLarge: EmbeddedWithLarge{
+					EmbeddedLargeData: [][]byte{{7, 8, 9}},
+				},
+			},
+			{
+				SmallData: "small",
+				LargeData: [][]byte{{1, 0, 1, 0}},
+				EmbeddedWithLarge: EmbeddedWithLarge{
+					EmbeddedLargeData: [][]byte{{2}},
+				},
+			},
+		},
+		ArrayWithLargeData2: []LargeInsideArray{
+			{
+				LargeData: [][]byte{{10}},
+				EmbeddedWithLarge: EmbeddedWithLarge{
+					EmbeddedLargeData: [][]byte{{3}, {6}},
+				},
+			},
+		},
+	}
+
+	originb, err := json.Marshal(originalObject)
+	if err != nil {
+		t.Fatalf("cannot marshal %v: %s", originalObject, err)
+	}
+	originb, err = writeAndRemoveLarge(log, originb, rootPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newTree := jsonTree{}
+
+	err = json.Unmarshal(originb, &newTree)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	largeTop, ok := newTree[tagFile+"LargeTop"]
+	if !ok {
+		t.Fatalf("cannot find LargeTop after writeAndRemoveLarge: %v", newTree)
+	}
+	largeTopString, isLargeTopString := largeTop.(string)
+	if !isLargeTopString {
+		t.Fatalf("LargeTop %T is not a string", largeTop)
+	}
+	if !strings.Contains(largeTopString, rootPath) {
+		t.Errorf("cannot find directory (%s) in LargeTop %s", rootPath, largeTopString)
+	}
+
+	arrays := []string{"ArrayWithLargeData", "ArrayWithLargeData2"}
+	for _, array := range arrays {
+		arrayWithLarge, ok := newTree[array]
+		if !ok {
+			t.Fatalf("cannot find %s after writeAndRemoveLarge: %v", array, newTree)
+		}
+		arrayObj, isArray := arrayWithLarge.([]interface{})
+		if !isArray {
+			t.Fatalf("%s %T is not a list", array, arrayWithLarge)
+		}
+		for i := range arrayObj {
+			arrayEntryObj, isMap := arrayObj[i].(map[string]interface{})
+			if !isMap {
+				t.Fatalf("%s[%d] (%T) is not a map", array, i, arrayObj[i])
+			}
+			fields := []string{tagFile + "LargeData", tagFile + "EmbeddedLargeData"}
+			for _, field := range fields {
+				largeData, ok := arrayEntryObj[field]
+				if !ok {
+					t.Fatalf("cannot find %s after writeAndRemoveLarge: %v", field, arrayEntryObj)
+				}
+				largeDataFilePath, isString := largeData.(string)
+				if !isString {
+					t.Fatalf("%s %T is not a string", field, largeData)
+				}
+				if !strings.Contains(largeDataFilePath, rootPath) {
+					t.Errorf("cannot find directory (%s) in %s %s", rootPath, field, largeDataFilePath)
+				}
+			}
+		}
+	}
+
+	originb, err = readAddLarge(log, originb)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newObject := LargeWithArray{}
+
+	err = json.Unmarshal(originb, &newObject)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(originalObject, newObject) {
+		t.Fatalf("objects are not equal: %v vs. %v", originalObject, newObject)
+	}
+}

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -888,10 +888,11 @@ type ProxyConfig struct {
 	Pacfile    string
 	// If Enable is set we use WPAD. If the URL is not set we try
 	// the various DNS suffixes until we can download a wpad.dat file
-	NetworkProxyEnable bool     // Enable WPAD
-	NetworkProxyURL    string   // Complete URL i.e., with /wpad.dat
-	WpadURL            string   // The URL determined from DNS
-	ProxyCertPEM       [][]byte // List of certs which will be added to TLS trust
+	NetworkProxyEnable bool   // Enable WPAD
+	NetworkProxyURL    string // Complete URL i.e., with /wpad.dat
+	WpadURL            string // The URL determined from DNS
+	// List of certs which will be added to TLS trust
+	ProxyCertPEM [][]byte `json:"pubsub-large-ProxyCertPEM"`
 }
 
 type DhcpConfig struct {

--- a/pkg/pillar/zedcloud/tls.go
+++ b/pkg/pillar/zedcloud/tls.go
@@ -128,8 +128,15 @@ func GetTlsConfig(dns *types.DeviceNetworkStatus, serverName string, clientCert 
 		for _, port := range dns.Ports {
 			for _, pem := range port.ProxyConfig.ProxyCertPEM {
 				if !caCertPool.AppendCertsFromPEM(pem) {
+					pemStr := string(pem)
+					// Keep the error message length reasonable.
+					const maxPrintedLen = 128
+					if len(pemStr) > maxPrintedLen {
+						pemStr = pemStr[:maxPrintedLen/2] + "..." +
+							pemStr[len(pemStr)-(maxPrintedLen/2):]
+					}
 					errStr := fmt.Sprintf("Failed to append ProxyCertPEM %s for %s",
-						string(pem), port.IfName)
+						pemStr, port.IfName)
 					log.Errorf(errStr)
 					return nil, errors.New(errStr)
 				}


### PR DESCRIPTION
`DevicePortConfig` (DPC) may store one or more proxy certificates for each port.
With multiple `DevicePortConfigs`, kept in the `DevicePortConfigList` (DPCL) for
fallback purposes, this may quickly exceed the message size limit
of 64KB, as imposed by pubsub.
Normally, if the latest DPC is working (providing connectivity to the
controller), DPCL is being compressed before it is published.
The compression removes all obsolete (not latest) entries except
for lastresort. However, if the latest DPC is not working, DPCL
may just keep growing as new DPCs are being submitted from the controller.
    
A typicall scenario when this can be a problem, is when a user submits
invalid device port config (i.e. device will not use this failing latest config)
and then makes multiple unsuccessful attempts to fix the config, each time
generating a new DPC. If the port configuration contains proxy certificates,
each with the size of 1-4 KBs, this can quickly adds up and exceed the pubsub
limit.
    
This PR tries to mitigate this issue.
First, using `pubsub-large` json tag, the pubsub system is ordered to send
certificates through temporary files and not through AF-UNIX socket
connections. DPCL message published via socket will contain references
to these files instead of certificate data.
For this the pubsub had to be enhanced to support `pubsub-large` tag
for fields which are under lists.
Second, an error informing about failed certification parsing, which
is stored into `TestResults` of a DPC, is trimmed to not contain an entire
certificate content.
Lastly, it makes sense to skip persisted DPCs with wrong certificates
and not carry them across device reboots.

Signed-off-by: Milan Lenco <milan@zededa.com>