### PR TITLE
[WIP] Post inventory to server after install

### DIFF
--- a/conf/grub.cfg.tmpl
+++ b/conf/grub.cfg.tmpl
@@ -4,3 +4,7 @@
 # to force booting in Xen mode, uncomment:
 #   set_global eve_flavor xen
 set_getty
+
+# set_global dom0_cmdline "$dom0_cmdline eve_inventory_server=http://10.129.17.151:8888"
+# set_global dom0_cmdline "$dom0_cmdline eve_inventory_server=http://192.168.1.55:8888"
+set_global dom0_cmdline "$dom0_cmdline eve_inventory_server=http://192.168.1.254:8888"

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -76,6 +76,12 @@ the number in the INVENTORY partition as a newly created folder, where the folde
 that soft serial number. Simply plug the USB stick back into a computer to view the contents
 of the INVENTORY partition to read the number.
 
+In addition, if you pass in a URL in the ```eve_inventory_server``` variables,
+then the EVE-OS installer will save this inventory partition and on boot of
+EVE-OS it will attempt to do http(s) POSTs of the inventory files to that URL.
+The POSTs will be retried until all the inventory files have been successfully
+POSTED to the server.
+
 ## Deploying EVE-OS in physical environments (aka onto bare metal)
 
 Deploying EVE-OS in a physical environment assumes it will be installed to run directly on an actual,

--- a/pkg/mkimage-raw-efi/Dockerfile
+++ b/pkg/mkimage-raw-efi/Dockerfile
@@ -7,9 +7,9 @@
 #
 FROM lfedge/eve-alpine:9fb9b9cbf7d90066a70e4704d04a6fe248ff52bb AS build
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
-ENV BUILD_PKGS grep patch git make gcc linux-headers musl-dev autoconf automake pkgconfig kmod-dev util-linux-dev cryptsetup-dev lddtree libgcc
+ENV BUILD_PKGS grep patch git make gcc linux-headers musl-dev autoconf automake pkgconfig kmod-dev util-linux-dev cryptsetup-dev lddtree libgcc mkinitfs
 ENV PKGS mtools dosfstools libarchive-tools sgdisk e2fsprogs util-linux squashfs-tools coreutils tar dmidecode \
-    kmod-libs cryptsetup-libs libblkid
+    kmod-libs cryptsetup-libs libblkid curl
 RUN eve-alpine-deploy.sh
 
 # get mkinitfs source from git and build it locally

--- a/pkg/mkimage-raw-efi/config.json
+++ b/pkg/mkimage-raw-efi/config.json
@@ -228,6 +228,14 @@
             ]
         },
         {
+            "destination": "/etc",
+            "type": "tmpfs",
+            "source": "tmpfs",
+            "options": [
+                "rw"
+            ]
+        },
+        {
             "destination": "/opt/debug",
             "type": "bind",
             "source": "/containers/services/debug/lower",

--- a/pkg/mkimage-raw-efi/config.json
+++ b/pkg/mkimage-raw-efi/config.json
@@ -280,6 +280,22 @@
             ]
         },
         {
+            "destination": "/var",
+            "type": "tmpfs",
+            "source": "tmpfs",
+            "options": [
+                "rw"
+            ]
+        },
+        {
+            "destination": "/persist",
+            "type": "tmpfs",
+            "source": "tmpfs",
+            "options": [
+                "rw"
+            ]
+        },
+        {
             "destination": "/dev",
             "type": "bind",
             "source": "/dev",

--- a/pkg/mkimage-raw-efi/install
+++ b/pkg/mkimage-raw-efi/install
@@ -168,7 +168,26 @@ zfs_umount() {
   umount /root/dev ||:
 }
 
+# XXX post_inventory needs to run in background - do inside client.go?
+# XXX change to /persist/inventory
+post_inventory() {
+    if [ ! -d /config/inventory ]; then
+        return
+    fi
+    cd /config/inventory || exit
+    inventory_server=$(cat ./server)
+    files=$(find . -type f -print | grep -v ^./server)
+    for f in $files; do
+        logmsg "device-steps: posting $f to $inventory_server"
+        curl -X POST "$inventory_server/$f" -H "Content-Type: text/plain" -d "@$f" || return
+    done
+    logmsg "device-steps: done posting $inventory_server"
+    cd || exit
+    rm -rf /config/inventory
+}
+
 logmsg "EVE-OS installation started"
+
 # do this just in case
 modprobe usbhid && modprobe usbkbd
 # clean partition tables on disks defined to nuke
@@ -518,6 +537,26 @@ if [ -n "$INVENTORY_SERVER" ]; then
     mkdir /config/inventory
     echo "$INVENTORY_SERVER" >/config/inventory/server
     cp -rp "$REPORT" /config/inventory/
+    # XXX
+    ls -lR /config/inventory
+    ip link show
+    mkdir /etc/network
+    cat <<EOF >/etc/network/interfaces
+auto eth0
+iface eth0 inet dhcp
+        hostname localhost
+
+EOF
+    ifup -av
+    ls -l /etc/network/interfaces*
+    ifconfig
+    # XXX This is bogus since not from dhcpcd
+    ping -c 1 pool.ntp.org
+    # Wait until synchronized and force the clock to be set from ntp
+    /usr/sbin/ntpd -q -n -g -p pool.ntp.org
+
+    # Try once
+    post_inventory
 fi
 
 # finally check whether we are collecting a black box

--- a/pkg/mkimage-raw-efi/install
+++ b/pkg/mkimage-raw-efi/install
@@ -511,6 +511,15 @@ if [ -f $DEVICE_CERT_NAME ] && [ -n "$REPORT" ]; then
    cat $DEVICE_CERT_NAME > "$REPORT/device.cert.pem"
 fi
 
+# If we have an inventory server then save report so we can push on first
+# boot
+INVENTORY_SERVER=$(tr ' ' '\012' < /proc/cmdline | sed -n '/eve_inventory_server=/s#eve_inventory_server=##p')
+if [ -n "$INVENTORY_SERVER" ]; then
+    mkdir /config/inventory
+    echo "$INVENTORY_SERVER" >/config/inventory/server
+    cp -rp "$REPORT" /config/inventory/
+fi
+
 # finally check whether we are collecting a black box
 if [ -n "$REPORT" ]; then
    # then we can collect our black box

--- a/pkg/mkimage-raw-efi/install
+++ b/pkg/mkimage-raw-efi/install
@@ -188,6 +188,36 @@ post_inventory() {
 
 logmsg "EVE-OS installation started"
 
+# XXX remove
+ip link show
+
+# Kick off network configuration on eth0 so we can run ntpd and later post
+# inventory
+mkdir -p /var/run/
+mkdir -p /etc/network/if-up.d/
+mkdir -p /etc/network/if-pre-up.d/
+mkdir -p /etc/network/interfaces.d/
+cat <<EOF >/etc/network/interfaces
+auto eth0
+iface eth0 inet dhcp
+EOF
+mkdir -p /etc/conf.d/
+cat <<EOF >/etc/conf.d/ntpd
+NTPD_OPTS="-s"
+EOF
+ifup -av
+# XXX remove
+ls -l /etc/network/interfaces*
+ifconfig
+ip route show
+
+# XXX This is bogus since not from udhcp
+# https://www.unix.com/man-page/suse/8/udhcpc/ - ntpsrv
+ls -l /usr/share/udhcpc/default.script
+ping -c 1 pool.ntp.org
+# Wait until synchronized and force the clock to be set from ntp
+/usr/sbin/ntpd -q -n -g -p pool.ntp.org
+
 # do this just in case
 modprobe usbhid && modprobe usbkbd
 # clean partition tables on disks defined to nuke
@@ -539,23 +569,15 @@ if [ -n "$INVENTORY_SERVER" ]; then
     cp -rp "$REPORT" /config/inventory/
     # XXX
     ls -lR /config/inventory
-    ip link show
-    mkdir /etc/network
-    cat <<EOF >/etc/network/interfaces
-auto eth0
-iface eth0 inet dhcp
-        hostname localhost
-
-EOF
-    ifup -av
-    ls -l /etc/network/interfaces*
-    ifconfig
-    # XXX This is bogus since not from dhcpcd
-    ping -c 1 pool.ntp.org
-    # Wait until synchronized and force the clock to be set from ntp
-    /usr/sbin/ntpd -q -n -g -p pool.ntp.org
-
-    # Try once
+    # Try once and if this fails EVE-OS will try again on boot
+    ping -c 1 192.168.1.2
+    ping -c 1 192.168.1.55
+    post_inventory
+    # XXX sleep and try again?
+    ping -c 1 192.168.1.2
+    ping -c 1 192.168.1.254
+    ip route show
+    sleep 5
     post_inventory
 fi
 


### PR DESCRIPTION
This introduces a eve_inventory_server URL which can either be set from ipxe or in config/grub.cfg. If that is set it the EVE-OS will POST to that URL when it boots after the install is complete.
The POSTs are retried until they are all accepted by the server at that URL.

This initial implementation does not use any secure client identifier hence only makes sense with server on a locally secure network. A possible improvement is to use the /config/onboarding.key.pem to sign the payloads using the authcontainer we use for the rest of the API, but that implies a server which does authcontainer verification and protobuf decode of the payloads.