### PR TITLE
remove ntpd from the patch for rootfs-mini

### DIFF
--- a/images/rootfs-adam-kvm.yml.in.patch
+++ b/images/rootfs-adam-kvm.yml.in.patch
@@ -1,16 +1,15 @@
 --- images/rootfs.yml.in
 +++ images/rootfs-adam-kvm.yml.in
-@@ -30,6 +30,13 @@ services:
-      image: RSYSLOGD_TAG
-    - name: ntpd
-      image: linuxkit/openntpd:v0.5
+@@ -30,6 +30,12 @@
+      image: NEWLOGD_TAG
+      cgroupsPath: /eve/services/eve-newlog
+      oomScoreAdj: -999
 +   - name: adam
 +     image: lfedge/adam:latest
 +     binds:
 +        - /var/persist:/persist
 +        - /var/config:/config
 +     command: ["/bin/eve-embedded.sh"]
-+     net: host
-    - name: sshd
-      image: linuxkit/sshd:v0.5
-    - name: wwan
+    - name: debug
+      image: DEBUG_TAG
+      cgroupsPath: /eve/services/debug

--- a/images/rootfs-mini.yml.in.patch
+++ b/images/rootfs-mini.yml.in.patch
@@ -1,6 +1,6 @@
 --- images/rootfs.yml.in	2021-05-13 16:54:55.000000000 -0700
 +++ images/rootfs.yml.in	2021-05-20 16:06:39.000000000 -0700
-@@ -1,71 +1,18 @@
+@@ -1,67 +1,18 @@
  kernel:
 -  image: KERNEL_TAG
 +  image: NEW_KERNEL_TAG
@@ -33,10 +33,6 @@
 -   - name: newlogd
 -     image: NEWLOGD_TAG
 -     cgroupsPath: /eve/services/eve-newlog
--     oomScoreAdj: -999
--   - name: ntpd
--     image: linuxkit/openntpd:v0.5
--     cgroupsPath: /eve/services/ntpd
 -     oomScoreAdj: -999
     - name: debug
       image: DEBUG_TAG


### PR DESCRIPTION
remove ntpd from the patch for rootfs-mini

This breakage was introduced in #2390 (the tests on the PRs doesn't exercise the publish parts it seems)

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>