### PR TITLE
Make EVE-OS use NTP server from DHCP

### DIFF
--- a/pkg/pillar/devicenetwork/dns.go
+++ b/pkg/pillar/devicenetwork/dns.go
@@ -15,7 +15,6 @@ import (
 )
 
 // GetDhcpInfo gets info from dhcpcd. Updates Gateway and Subnet
-// XXX set NtpServer once we know what name it has
 // XXX add IPv6 support?
 func GetDhcpInfo(log *base.LogObject, us *types.NetworkPortStatus) {
 


### PR DESCRIPTION
If the DHCP server provides an NTP server we now use it. If not we
default to pool.ntp.org. This initial implementation only uses the first
NTP server; a configurable ntpd container in the future should try all
servers from all ports.
