### PR TITLE
static dependencies for Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ dist/
 build-tools/bin/
 images/*.yml
 pkg/qrexec-dom0/Dockerfile
-pkg/qrexec-lib/Dockerfile
 .go/
 tags
 tmp/

--- a/Makefile
+++ b/Makefile
@@ -301,7 +301,7 @@ itest: $(GOBUILDER) run-proxy | $(DIST)
 	@cd tests/integration ; CGO_ENABLED=0 GOOS= go test -v -run "$(ITESTS)" .
 
 clean:
-	rm -rf $(DIST) images/*.yml pkg/pillar/Dockerfile pkg/qrexec-lib/Dockerfile pkg/qrexec-dom0/Dockerfile pkg/xen-tools/Dockerfile
+	rm -rf $(DIST) images/*.yml pkg/qrexec-dom0/Dockerfile
 
 yetus:
 	@echo Running yetus

--- a/pkg/qrexec-lib/Dockerfile
+++ b/pkg/qrexec-lib/Dockerfile
@@ -1,4 +1,4 @@
-FROM XENTOOLS_TAG as xentools
+FROM lfedge/eve-xen-tools:5f5a4015f2e392b5e8afb76fbc3019d17425e029 as xentools
 
 FROM lfedge/eve-alpine:6.7.0 as build
 ENV BUILD_PKGS gcc make libc-dev linux-headers git pkgconf


### PR DESCRIPTION
Now that #2402 is in, we can depend on static xen-tools in here and avoid the templating.