### PR TITLE
static Dockerfile for qrexec-dom0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ obj
 dist/
 build-tools/bin/
 images/*.yml
-pkg/qrexec-dom0/Dockerfile
 .go/
 tags
 tmp/

--- a/Makefile
+++ b/Makefile
@@ -301,7 +301,7 @@ itest: $(GOBUILDER) run-proxy | $(DIST)
 	@cd tests/integration ; CGO_ENABLED=0 GOOS= go test -v -run "$(ITESTS)" .
 
 clean:
-	rm -rf $(DIST) images/*.yml pkg/qrexec-dom0/Dockerfile
+	rm -rf $(DIST) images/*.yml
 
 yetus:
 	@echo Running yetus

--- a/pkg/qrexec-dom0/Dockerfile
+++ b/pkg/qrexec-dom0/Dockerfile
@@ -1,5 +1,5 @@
-FROM XENTOOLS_TAG as xentools
-FROM QREXECLIB_TAG as qrexec_lib
+FROM lfedge/eve-xen-tools:5f5a4015f2e392b5e8afb76fbc3019d17425e029 as xentools
+FROM lfedge/eve-qrexec-lib:95656cc31c191bab92b113db2a18bdfa015fcbe5 as qrexec_lib
 FROM lfedge/eve-alpine:6.7.0 as build
 ENV BUILD_PKGS gcc make libc-dev linux-headers git pkgconf
 RUN eve-alpine-deploy.sh


### PR DESCRIPTION
Moves the `Dockerfile.in` template in qrexec-dom0 to statically sourced `Dockerfile`. Final part of #2353 

As discussed with @rvs 