### PR TITLE
fix path env for update-component-sha.sh

### DIFF
--- a/tools/update-component-sha.sh
+++ b/tools/update-component-sha.sh
@@ -7,6 +7,9 @@ set -e
 # see usage() for usage and functionality
 #
 
+EVE="$(cd "$(dirname "$0")" && pwd)/../"
+PATH="$EVE/build-tools/bin:$PATH"
+
 usage() {
     cat >&2 <<EOF
 $0 --<mode> <how-to-find> <new-hash>


### PR DESCRIPTION
Seems we did not add build-tools/bin to path variable:
```
$ ./tools/update-component-sha.sh --pkg ./pkg/xen-tools
./tools/update-component-sha.sh: 96: linuxkit: not found
```

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>