### PR TITLE
Add support for RISCV64 and bump pkg/grub to 2.06

### DIFF
--- a/pkg/grub/Dockerfile
+++ b/pkg/grub/Dockerfile
@@ -18,32 +18,33 @@ RUN apk add --no-cache \
   autoconf \
   pkgconf \
   patch \
-  gettext-dev
-RUN [ "$(uname -m)" != riscv64 ] || apk add coreutils
+  gettext-dev \
+  coreutils
 
 # because python is not available
 RUN ln -s python3 /usr/bin/python
 
 # list of grub modules that are portable between x86_64 and aarch64
 ENV GRUB_MODULES_PORT="part_gpt fat ext2 iso9660 squash4 gzio linux acpi normal cpio crypto disk boot crc64 gpt \
-search_disk_uuid search_part_label search_label verify xzio xfs video gfxterm serial gptprio chain probe reboot regexp smbios    \
+search_disk_uuid search_part_label search_label xzio xfs video gfxterm serial gptprio chain probe reboot regexp smbios    \
 part_msdos cat echo test configfile loopback"
 ENV GRUB_MODULES_i386_pc="multiboot multiboot2 biosdisk"
-ENV GRUB_MODULES_x86_64="multiboot multiboot2 efi_uga efi_gop linuxefi"
+ENV GRUB_MODULES_x86_64="multiboot multiboot2 efi_uga efi_gop"
 ENV GRUB_MODULES_aarch64="xen_boot efi_gop"
-ENV GRUB_MODULES_riscv64="part_gpt fat ext2 iso9660 squash4 gzio linux acpi normal cpio crypto disk boot crc64 \
-search_label xzio xfs video gfxterm serial  chain probe reboot regexp smbios part_msdos cat echo test configfile loopback"
-ENV GRUB_COMMIT=71f9e4ac44142af52c3fc1860436cf9e432bf764
+ENV GRUB_MODULES_riscv64="part_gpt fat ext2 iso9660 squash4 gzio linux acpi normal cpio crypto disk boot crc64 gptprio \
+search_label xzio xfs video gfxterm serial chain probe reboot regexp smbios part_msdos cat echo test configfile loopback"
+# grub-2.06 tag
+ENV GRUB_COMMIT=ae94b97be2b81b625d6af6654d3ed79078b50ff6
 ENV GRUB_REPO=https://git.savannah.gnu.org/git/grub.git
 
-COPY patches/* /patches/
-COPY patches.riscv64/* /riscv64/
+COPY patches.2.06/* /patches/
+COPY patches.riscv64.2.06/* /riscv64/
 RUN mkdir /grub-lib && git clone ${GRUB_REPO}
 
 WORKDIR /grub
 RUN git config --add user.email a@b.c && git config user.name a && \
     git checkout -b grub-build ${GRUB_COMMIT}
-RUN if [ "$(uname -m)" = riscv64 ]; then rm -rf /patches && mv /riscv64 /patches && git checkout grub-2.06-rc1a; fi
+RUN if [ "$(uname -m)" = riscv64 ]; then rm -rf /patches && mv /riscv64 /patches; fi
 RUN git am /patches/*
 
 ENV BUILD_GRUB="set -e && git clean -f -d -x && git reset --hard HEAD && \

--- a/pkg/grub/Dockerfile
+++ b/pkg/grub/Dockerfile
@@ -1,7 +1,7 @@
 ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.7.0
 # hadolint ignore=DL3006
 FROM ${EVE_BUILDER_IMAGE} as grub-build
-
+RUN uname -a
 # hadolint ignore=DL3018
 RUN apk add --no-cache \
   automake \
@@ -31,8 +31,8 @@ part_msdos cat echo test configfile loopback"
 ENV GRUB_MODULES_i386_pc="multiboot multiboot2 biosdisk"
 ENV GRUB_MODULES_x86_64="multiboot multiboot2 efi_uga efi_gop"
 ENV GRUB_MODULES_aarch64="xen_boot efi_gop"
-ENV GRUB_MODULES_riscv64="part_gpt fat ext2 iso9660 squash4 gzio linux acpi normal cpio crypto disk boot crc64 gptprio \
-search_label xzio xfs video gfxterm serial chain probe reboot regexp smbios part_msdos cat echo test configfile loopback"
+ENV GRUB_MODULES_riscv64="part_gpt fat ext2 iso9660 squash4 gzio linux acpi normal cpio crypto disk boot crc64 gptprio search_disk_uuid \
+search_part_label search_label xzio xfs video gfxterm serial chain probe reboot regexp smbios part_msdos cat echo test configfile loopback"
 # grub-2.06 tag
 ENV GRUB_COMMIT=ae94b97be2b81b625d6af6654d3ed79078b50ff6
 ENV GRUB_REPO=https://git.savannah.gnu.org/git/grub.git

--- a/pkg/grub/Dockerfile
+++ b/pkg/grub/Dockerfile
@@ -34,16 +34,17 @@ ENV GRUB_MODULES_aarch64="xen_boot efi_gop"
 ENV GRUB_MODULES_riscv64="part_gpt fat ext2 iso9660 squash4 gzio linux acpi normal cpio crypto disk boot crc64 gptprio search_disk_uuid \
 search_part_label search_label xzio xfs video gfxterm serial chain probe reboot regexp smbios part_msdos cat echo test configfile loopback"
 # grub-2.06 tag
-ENV GRUB_COMMIT=ae94b97be2b81b625d6af6654d3ed79078b50ff6
+ENV GRUB_COMMIT=71f9e4ac44142af52c3fc1860436cf9e432bf764
+ENV GRUB_COMMIT_riscv64=ae94b97be2b81b625d6af6654d3ed79078b50ff6
 ENV GRUB_REPO=https://git.savannah.gnu.org/git/grub.git
 
-COPY patches.2.06/* /patches/
+COPY patches/* /patches/
 COPY patches.riscv64.2.06/* /riscv64/
 RUN mkdir /grub-lib && git clone ${GRUB_REPO}
 
 WORKDIR /grub
 RUN git config --add user.email a@b.c && git config user.name a && \
-    git checkout -b grub-build ${GRUB_COMMIT}
+    git checkout -b grub-build $(if [ "$(uname -m)" == riscv64 ]; then echo ${GRUB_COMMIT_riscv64}; else echo ${GRUB_COMMIT}; fi)
 RUN if [ "$(uname -m)" = riscv64 ]; then rm -rf /patches && mv /riscv64 /patches; fi
 RUN git am /patches/*
 

--- a/pkg/grub/Dockerfile
+++ b/pkg/grub/Dockerfile
@@ -1,7 +1,6 @@
 ARG EVE_BUILDER_IMAGE=lfedge/eve-alpine:6.7.0
 # hadolint ignore=DL3006
 FROM ${EVE_BUILDER_IMAGE} as grub-build
-RUN uname -a
 # hadolint ignore=DL3018
 RUN apk add --no-cache \
   automake \

--- a/pkg/grub/Dockerfile
+++ b/pkg/grub/Dockerfile
@@ -43,7 +43,7 @@ RUN mkdir /grub-lib && git clone ${GRUB_REPO}
 
 WORKDIR /grub
 RUN git config --add user.email a@b.c && git config user.name a && \
-    git checkout -b grub-build $(if [ "$(uname -m)" = riscv64 ]; then echo ${GRUB_COMMIT_riscv64}; else echo ${GRUB_COMMIT}; fi)
+    git checkout -b grub-build "$(if [ "$(uname -m)" = riscv64 ]; then echo "${GRUB_COMMIT_riscv64}"; else echo "${GRUB_COMMIT}"; fi)"
 RUN if [ "$(uname -m)" = riscv64 ]; then rm -rf /patches && mv /riscv64 /patches; fi
 RUN git am /patches/*
 

--- a/pkg/grub/Dockerfile
+++ b/pkg/grub/Dockerfile
@@ -28,7 +28,7 @@ ENV GRUB_MODULES_PORT="part_gpt fat ext2 iso9660 squash4 gzio linux acpi normal 
 search_disk_uuid search_part_label search_label verify xzio xfs video gfxterm serial gptprio chain probe reboot regexp smbios    \
 part_msdos cat echo test configfile loopback"
 ENV GRUB_MODULES_i386_pc="multiboot multiboot2 biosdisk"
-ENV GRUB_MODULES_x86_64="multiboot multiboot2 efi_uga efi_gop"
+ENV GRUB_MODULES_x86_64="multiboot multiboot2 efi_uga efi_gop linuxefi"
 ENV GRUB_MODULES_aarch64="xen_boot efi_gop"
 ENV GRUB_MODULES_riscv64="part_gpt fat ext2 iso9660 squash4 gzio linux acpi normal cpio crypto disk boot crc64 gptprio search_disk_uuid \
 search_part_label search_label xzio xfs video gfxterm serial chain probe reboot regexp smbios part_msdos cat echo test configfile loopback"

--- a/pkg/grub/Dockerfile
+++ b/pkg/grub/Dockerfile
@@ -43,7 +43,7 @@ RUN mkdir /grub-lib && git clone ${GRUB_REPO}
 
 WORKDIR /grub
 RUN git config --add user.email a@b.c && git config user.name a && \
-    git checkout -b grub-build $(if [ "$(uname -m)" == riscv64 ]; then echo ${GRUB_COMMIT_riscv64}; else echo ${GRUB_COMMIT}; fi)
+    git checkout -b grub-build $(if [ "$(uname -m)" = riscv64 ]; then echo ${GRUB_COMMIT_riscv64}; else echo ${GRUB_COMMIT}; fi)
 RUN if [ "$(uname -m)" = riscv64 ]; then rm -rf /patches && mv /riscv64 /patches; fi
 RUN git am /patches/*
 

--- a/pkg/grub/Dockerfile
+++ b/pkg/grub/Dockerfile
@@ -17,8 +17,8 @@ RUN apk add --no-cache \
   autoconf \
   pkgconf \
   patch \
-  gettext-dev \
-  coreutils
+  gettext-dev
+RUN [ "$(uname -m)" != riscv64 ] || apk add coreutils
 
 # because python is not available
 RUN ln -s python3 /usr/bin/python

--- a/pkg/grub/Dockerfile
+++ b/pkg/grub/Dockerfile
@@ -25,7 +25,7 @@ RUN ln -s python3 /usr/bin/python
 
 # list of grub modules that are portable between x86_64 and aarch64
 ENV GRUB_MODULES_PORT="part_gpt fat ext2 iso9660 squash4 gzio linux acpi normal cpio crypto disk boot crc64 gpt \
-search_disk_uuid search_part_label search_label xzio xfs video gfxterm serial gptprio chain probe reboot regexp smbios    \
+search_disk_uuid search_part_label search_label verify xzio xfs video gfxterm serial gptprio chain probe reboot regexp smbios    \
 part_msdos cat echo test configfile loopback"
 ENV GRUB_MODULES_i386_pc="multiboot multiboot2 biosdisk"
 ENV GRUB_MODULES_x86_64="multiboot multiboot2 efi_uga efi_gop"

--- a/pkg/grub/patches.2.06/0001-Add-gpt-module.patch
+++ b/pkg/grub/patches.2.06/0001-Add-gpt-module.patch
@@ -1,0 +1,1073 @@
+From 72d3b5b4e42cfec7b6c9d11e05992d0b5b1b78b3 Mon Sep 17 00:00:00 2001
+From: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>
+Date: Thu, 14 Oct 2021 00:04:19 +0530
+Subject: [PATCH 1/8] Add gpt module
+
+Signed-off-by: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>
+---
+ grub-core/Makefile.core.def  |   5 +
+ grub-core/lib/gpt.c          | 777 +++++++++++++++++++++++++++++++++++
+ include/grub/gpt_partition.h | 213 +++++++++-
+ 3 files changed, 978 insertions(+), 17 deletions(-)
+ create mode 100644 grub-core/lib/gpt.c
+
+diff --git a/grub-core/Makefile.core.def b/grub-core/Makefile.core.def
+index 8022e1c0a..8dee4d09e 100644
+--- a/grub-core/Makefile.core.def
++++ b/grub-core/Makefile.core.def
+@@ -897,6 +897,11 @@ module = {
+   common = commands/gptsync.c;
+ };
+ 
++module = {
++  name = gpt;
++  common = lib/gpt.c;
++};
++
+ module = {
+   name = halt;
+   nopc = commands/halt.c;
+diff --git a/grub-core/lib/gpt.c b/grub-core/lib/gpt.c
+new file mode 100644
+index 000000000..ac71ba712
+--- /dev/null
++++ b/grub-core/lib/gpt.c
+@@ -0,0 +1,777 @@
++/* gpt.c - Read/Verify/Write GUID Partition Tables (GPT).  */
++/*
++ *  GRUB  --  GRand Unified Bootloader
++ *  Copyright (C) 2002,2005,2006,2007,2008  Free Software Foundation, Inc.
++ *  Copyright (C) 2014 CoreOS, Inc.
++ *
++ *  GRUB is free software: you can redistribute it and/or modify
++ *  it under the terms of the GNU General Public License as published by
++ *  the Free Software Foundation, either version 3 of the License, or
++ *  (at your option) any later version.
++ *
++ *  GRUB is distributed in the hope that it will be useful,
++ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *  GNU General Public License for more details.
++ *
++ *  You should have received a copy of the GNU General Public License
++ *  along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++#include <grub/charset.h>
++#include <grub/crypto.h>
++#include <grub/device.h>
++#include <grub/disk.h>
++#include <grub/misc.h>
++#include <grub/mm.h>
++#include <grub/dl.h>
++#include <grub/msdos_partition.h>
++#include <grub/gpt_partition.h>
++
++GRUB_MOD_LICENSE ("GPLv3+");
++
++static grub_uint8_t grub_gpt_magic[] = GRUB_GPT_HEADER_MAGIC;
++
++static grub_err_t
++grub_gpt_read_entries (grub_disk_t disk, grub_gpt_t gpt,
++		       struct grub_gpt_header *header,
++		       void **ret_entries,
++		       grub_size_t *ret_entries_size);
++
++char *
++grub_gpt_part_guid_to_str (grub_gpt_part_guid_t *guid)
++{
++  return grub_xasprintf ("%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x",
++			 grub_le_to_cpu32 (guid->data1),
++			 grub_le_to_cpu16 (guid->data2),
++			 grub_le_to_cpu16 (guid->data3),
++			 guid->data4[0], guid->data4[1],
++			 guid->data4[2], guid->data4[3],
++			 guid->data4[4], guid->data4[5],
++			 guid->data4[6], guid->data4[7]);
++}
++
++static grub_err_t
++grub_gpt_device_partentry (grub_device_t device,
++			   struct grub_gpt_partentry *entry)
++{
++  grub_disk_t disk = device->disk;
++  grub_partition_t p;
++  grub_err_t err;
++
++  if (!disk || !disk->partition)
++    return grub_error (GRUB_ERR_BUG, "not a partition");
++
++  if (grub_strcmp (disk->partition->partmap->name, "gpt"))
++    return grub_error (GRUB_ERR_BAD_ARGUMENT, "not a GPT partition");
++
++  p = disk->partition;
++  disk->partition = p->parent;
++  err = grub_disk_read (disk, p->offset, p->index, sizeof (*entry), entry);
++  disk->partition = p;
++
++  return err;
++}
++
++grub_err_t
++grub_gpt_part_label (grub_device_t device, char **label)
++{
++  struct grub_gpt_partentry entry;
++  const grub_size_t name_len = ARRAY_SIZE (entry.name);
++  const grub_size_t label_len = name_len * GRUB_MAX_UTF8_PER_UTF16 + 1;
++  grub_size_t i;
++  grub_uint8_t *end;
++
++  if (grub_gpt_device_partentry (device, &entry))
++    return grub_errno;
++
++  *label = grub_malloc (label_len);
++  if (!*label)
++    return grub_errno;
++
++  for (i = 0; i < name_len; i++)
++    entry.name[i] = grub_le_to_cpu16 (entry.name[i]);
++
++  end = grub_utf16_to_utf8 ((grub_uint8_t *) *label, entry.name, name_len);
++  *end = '\0';
++
++  return GRUB_ERR_NONE;
++}
++
++grub_err_t
++grub_gpt_part_uuid (grub_device_t device, char **uuid)
++{
++  struct grub_gpt_partentry entry;
++
++  if (grub_gpt_device_partentry (device, &entry))
++    return grub_errno;
++
++  *uuid = grub_gpt_part_guid_to_str (&entry.guid);
++  if (!*uuid)
++    return grub_errno;
++
++  return GRUB_ERR_NONE;
++}
++
++static struct grub_gpt_header *
++grub_gpt_get_header (grub_gpt_t gpt)
++{
++  if (gpt->status & GRUB_GPT_PRIMARY_HEADER_VALID)
++    return &gpt->primary;
++  else if (gpt->status & GRUB_GPT_BACKUP_HEADER_VALID)
++    return &gpt->backup;
++
++  grub_error (GRUB_ERR_BUG, "No valid GPT header");
++  return NULL;
++}
++
++grub_err_t
++grub_gpt_disk_uuid (grub_device_t device, char **uuid)
++{
++  struct grub_gpt_header *header;
++
++  grub_gpt_t gpt = grub_gpt_read (device->disk);
++  if (!gpt)
++    goto done;
++
++  header = grub_gpt_get_header (gpt);
++  if (!header)
++    goto done;
++
++  *uuid = grub_gpt_part_guid_to_str (&header->guid);
++
++done:
++  grub_gpt_free (gpt);
++  return grub_errno;
++}
++
++static grub_uint64_t
++grub_gpt_size_to_sectors (grub_gpt_t gpt, grub_size_t size)
++{
++  unsigned int sector_size;
++  grub_uint64_t sectors;
++
++  sector_size = 1U << gpt->log_sector_size;
++  sectors = size / sector_size;
++  if (size % sector_size)
++    sectors++;
++
++  return sectors;
++}
++
++/* Copied from grub-core/kern/disk_common.c grub_disk_adjust_range so we can
++ * avoid attempting to use disk->total_sectors when GRUB won't let us.
++ * TODO: Why is disk->total_sectors not set to GRUB_DISK_SIZE_UNKNOWN?  */
++static int
++grub_gpt_disk_size_valid (grub_disk_t disk)
++{
++  grub_disk_addr_t total_sectors;
++
++  /* Transform total_sectors to number of 512B blocks.  */
++  total_sectors = disk->total_sectors << (disk->log_sector_size - GRUB_DISK_SECTOR_BITS);
++
++  /* Some drivers have problems with disks above reasonable.
++     Treat unknown as 1EiB disk. While on it, clamp the size to 1EiB.
++     Just one condition is enough since GRUB_DISK_UNKNOWN_SIZE << ls is always
++     above 9EiB.
++  */
++  if (total_sectors > (1ULL << 51))
++    return 0;
++
++  return 1;
++}
++
++static void
++grub_gpt_lecrc32 (grub_uint32_t *crc, const void *data, grub_size_t len)
++{
++  grub_uint32_t crc32_val;
++
++  grub_crypto_hash (GRUB_MD_CRC32, &crc32_val, data, len);
++
++  /* GRUB_MD_CRC32 always uses big endian, gpt is always little.  */
++  *crc = grub_swap_bytes32 (crc32_val);
++}
++
++static void
++grub_gpt_header_lecrc32 (grub_uint32_t *crc, struct grub_gpt_header *header)
++{
++  grub_uint32_t old, new;
++
++  /* crc32 must be computed with the field cleared.  */
++  old = header->crc32;
++  header->crc32 = 0;
++  grub_gpt_lecrc32 (&new, header, sizeof (*header));
++  header->crc32 = old;
++
++  *crc = new;
++}
++
++/* Make sure the MBR is a protective MBR and not a normal MBR.  */
++grub_err_t
++grub_gpt_pmbr_check (struct grub_msdos_partition_mbr *mbr)
++{
++  unsigned int i;
++
++  if (mbr->signature !=
++      grub_cpu_to_le16_compile_time (GRUB_PC_PARTITION_SIGNATURE))
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "invalid MBR signature");
++
++  for (i = 0; i < sizeof (mbr->entries); i++)
++    if (mbr->entries[i].type == GRUB_PC_PARTITION_TYPE_GPT_DISK)
++      return GRUB_ERR_NONE;
++
++  return grub_error (GRUB_ERR_BAD_PART_TABLE, "invalid protective MBR");
++}
++
++static grub_uint64_t
++grub_gpt_entries_size (struct grub_gpt_header *gpt)
++{
++  return (grub_uint64_t) grub_le_to_cpu32 (gpt->maxpart) *
++         (grub_uint64_t) grub_le_to_cpu32 (gpt->partentry_size);
++}
++
++static grub_uint64_t
++grub_gpt_entries_sectors (struct grub_gpt_header *gpt,
++			  unsigned int log_sector_size)
++{
++  grub_uint64_t sector_bytes, entries_bytes;
++
++  sector_bytes = 1ULL << log_sector_size;
++  entries_bytes = grub_gpt_entries_size (gpt);
++  return grub_divmod64(entries_bytes + sector_bytes - 1, sector_bytes, NULL);
++}
++
++static int
++is_pow2 (grub_uint32_t n)
++{
++  return (n & (n - 1)) == 0;
++}
++
++grub_err_t
++grub_gpt_header_check (struct grub_gpt_header *gpt,
++		       unsigned int log_sector_size)
++{
++  grub_uint32_t crc = 0, size;
++  grub_uint64_t start, end;
++
++  if (grub_memcmp (gpt->magic, grub_gpt_magic, sizeof (grub_gpt_magic)) != 0)
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "invalid GPT signature");
++
++  if (gpt->version != GRUB_GPT_HEADER_VERSION)
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "unknown GPT version");
++
++  grub_gpt_header_lecrc32 (&crc, gpt);
++  if (gpt->crc32 != crc)
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "invalid GPT header crc32");
++
++  /* The header size "must be greater than or equal to 92 and must be less
++   * than or equal to the logical block size."  */
++  size = grub_le_to_cpu32 (gpt->headersize);
++  if (size < 92U || size > (1U << log_sector_size))
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "invalid GPT header size");
++
++  /* The partition entry size must be "a value of 128*(2^n) where n is an
++   * integer greater than or equal to zero (e.g., 128, 256, 512, etc.)."  */
++  size = grub_le_to_cpu32 (gpt->partentry_size);
++  if (size < 128U || size % 128U || !is_pow2 (size / 128U))
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "invalid GPT entry size");
++
++  /* The minimum entries table size is specified in terms of bytes,
++   * regardless of how large the individual entry size is.  */
++  if (grub_gpt_entries_size (gpt) < GRUB_GPT_DEFAULT_ENTRIES_SIZE)
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "invalid GPT entry table size");
++
++  /* And of course there better be some space for partitions!  */
++  start = grub_le_to_cpu64 (gpt->start);
++  end = grub_le_to_cpu64 (gpt->end);
++  if (start > end)
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "invalid usable sectors");
++
++  return GRUB_ERR_NONE;
++}
++
++static int
++grub_gpt_headers_equal (grub_gpt_t gpt)
++{
++  /* Assume headers passed grub_gpt_header_check so skip magic and version.
++   * Individual fields must be checked instead of just using memcmp because
++   * crc32, header, alternate, and partitions will all normally differ.  */
++
++  if (gpt->primary.headersize != gpt->backup.headersize ||
++      gpt->primary.header_lba != gpt->backup.alternate_lba ||
++      gpt->primary.alternate_lba != gpt->backup.header_lba ||
++      gpt->primary.start != gpt->backup.start ||
++      gpt->primary.end != gpt->backup.end ||
++      gpt->primary.maxpart != gpt->backup.maxpart ||
++      gpt->primary.partentry_size != gpt->backup.partentry_size ||
++      gpt->primary.partentry_crc32 != gpt->backup.partentry_crc32)
++    return 0;
++
++  return grub_memcmp(&gpt->primary.guid, &gpt->backup.guid,
++                     sizeof(grub_gpt_part_guid_t)) == 0;
++}
++
++static grub_err_t
++grub_gpt_check_primary (grub_gpt_t gpt)
++{
++  grub_uint64_t backup, primary, entries, entries_len, start, end;
++
++  primary = grub_le_to_cpu64 (gpt->primary.header_lba);
++  backup = grub_le_to_cpu64 (gpt->primary.alternate_lba);
++  entries = grub_le_to_cpu64 (gpt->primary.partitions);
++  entries_len = grub_gpt_entries_sectors(&gpt->primary, gpt->log_sector_size);
++  start = grub_le_to_cpu64 (gpt->primary.start);
++  end = grub_le_to_cpu64 (gpt->primary.end);
++
++  grub_dprintf ("gpt", "Primary GPT layout:\n"
++		"primary header = 0x%llx backup header = 0x%llx\n"
++		"entries location = 0x%llx length = 0x%llx\n"
++		"first usable = 0x%llx last usable = 0x%llx\n",
++		(unsigned long long) primary,
++		(unsigned long long) backup,
++		(unsigned long long) entries,
++		(unsigned long long) entries_len,
++		(unsigned long long) start,
++		(unsigned long long) end);
++
++  if (grub_gpt_header_check (&gpt->primary, gpt->log_sector_size))
++    return grub_errno;
++  if (primary != 1)
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "invalid primary GPT LBA");
++  if (entries <= 1 || entries+entries_len > start)
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "invalid entries location");
++  if (backup <= end)
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "invalid backup GPT LBA");
++
++  return GRUB_ERR_NONE;
++}
++
++static grub_err_t
++grub_gpt_check_backup (grub_gpt_t gpt)
++{
++  grub_uint64_t backup, primary, entries, entries_len, start, end;
++
++  backup = grub_le_to_cpu64 (gpt->backup.header_lba);
++  primary = grub_le_to_cpu64 (gpt->backup.alternate_lba);
++  entries = grub_le_to_cpu64 (gpt->backup.partitions);
++  entries_len = grub_gpt_entries_sectors(&gpt->backup, gpt->log_sector_size);
++  start = grub_le_to_cpu64 (gpt->backup.start);
++  end = grub_le_to_cpu64 (gpt->backup.end);
++
++  grub_dprintf ("gpt", "Backup GPT layout:\n"
++		"primary header = 0x%llx backup header = 0x%llx\n"
++		"entries location = 0x%llx length = 0x%llx\n"
++		"first usable = 0x%llx last usable = 0x%llx\n",
++		(unsigned long long) primary,
++		(unsigned long long) backup,
++		(unsigned long long) entries,
++		(unsigned long long) entries_len,
++		(unsigned long long) start,
++		(unsigned long long) end);
++
++  if (grub_gpt_header_check (&gpt->backup, gpt->log_sector_size))
++    return grub_errno;
++  if (primary != 1)
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "invalid primary GPT LBA");
++  if (entries <= end || entries+entries_len > backup)
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "invalid entries location");
++  if (backup <= end)
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "invalid backup GPT LBA");
++
++  /* If both primary and backup are valid but differ prefer the primary.  */
++  if ((gpt->status & GRUB_GPT_PRIMARY_HEADER_VALID) &&
++      !grub_gpt_headers_equal (gpt))
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "backup GPT out of sync");
++
++  return GRUB_ERR_NONE;
++}
++
++static grub_err_t
++grub_gpt_read_primary (grub_disk_t disk, grub_gpt_t gpt)
++{
++  grub_disk_addr_t addr;
++
++  /* TODO: The gpt partmap module searches for the primary header instead
++   * of relying on the disk's sector size. For now trust the disk driver
++   * but eventually this code should match the existing behavior.  */
++  gpt->log_sector_size = disk->log_sector_size;
++
++  grub_dprintf ("gpt", "reading primary GPT from sector 0x1\n");
++
++  addr = grub_gpt_sector_to_addr (gpt, 1);
++  if (grub_disk_read (disk, addr, 0, sizeof (gpt->primary), &gpt->primary))
++    return grub_errno;
++
++  if (grub_gpt_check_primary (gpt))
++    return grub_errno;
++
++  gpt->status |= GRUB_GPT_PRIMARY_HEADER_VALID;
++
++  if (grub_gpt_read_entries (disk, gpt, &gpt->primary,
++			     &gpt->entries, &gpt->entries_size))
++    return grub_errno;
++
++  gpt->status |= GRUB_GPT_PRIMARY_ENTRIES_VALID;
++
++  return GRUB_ERR_NONE;
++}
++
++static grub_err_t
++grub_gpt_read_backup (grub_disk_t disk, grub_gpt_t gpt)
++{
++  void *entries = NULL;
++  grub_size_t entries_size;
++  grub_uint64_t sector;
++  grub_disk_addr_t addr;
++
++  /* Assumes gpt->log_sector_size == disk->log_sector_size  */
++  if (gpt->status & GRUB_GPT_PRIMARY_HEADER_VALID)
++    {
++      sector = grub_le_to_cpu64 (gpt->primary.alternate_lba);
++      if (grub_gpt_disk_size_valid (disk) && sector >= disk->total_sectors)
++	return grub_error (GRUB_ERR_OUT_OF_RANGE,
++			   "backup GPT located at 0x%llx, "
++			   "beyond last disk sector at 0x%llx",
++			   (unsigned long long) sector,
++			   (unsigned long long) disk->total_sectors - 1);
++    }
++  else if (grub_gpt_disk_size_valid (disk))
++    sector = disk->total_sectors - 1;
++  else
++    return grub_error (GRUB_ERR_OUT_OF_RANGE,
++		       "size of disk unknown, cannot locate backup GPT");
++
++  grub_dprintf ("gpt", "reading backup GPT from sector 0x%llx\n",
++		(unsigned long long) sector);
++
++  addr = grub_gpt_sector_to_addr (gpt, sector);
++  if (grub_disk_read (disk, addr, 0, sizeof (gpt->backup), &gpt->backup))
++    return grub_errno;
++
++  if (grub_gpt_check_backup (gpt))
++    return grub_errno;
++
++  /* Ensure the backup header thinks it is located where we found it.  */
++  if (grub_le_to_cpu64 (gpt->backup.header_lba) != sector)
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "invalid backup GPT LBA");
++
++  gpt->status |= GRUB_GPT_BACKUP_HEADER_VALID;
++
++  if (grub_gpt_read_entries (disk, gpt, &gpt->backup,
++			     &entries, &entries_size))
++    return grub_errno;
++
++  if (gpt->status & GRUB_GPT_PRIMARY_ENTRIES_VALID)
++    {
++      if (entries_size != gpt->entries_size ||
++	  grub_memcmp (entries, gpt->entries, entries_size) != 0)
++	return grub_error (GRUB_ERR_BAD_PART_TABLE, "backup GPT out of sync");
++
++      grub_free (entries);
++    }
++  else
++    {
++      gpt->entries = entries;
++      gpt->entries_size = entries_size;
++    }
++
++  gpt->status |= GRUB_GPT_BACKUP_ENTRIES_VALID;
++
++  return GRUB_ERR_NONE;
++}
++
++static grub_err_t
++grub_gpt_read_entries (grub_disk_t disk, grub_gpt_t gpt,
++		       struct grub_gpt_header *header,
++		       void **ret_entries,
++		       grub_size_t *ret_entries_size)
++{
++  void *entries = NULL;
++  grub_uint32_t count, size, crc;
++  grub_uint64_t sector;
++  grub_disk_addr_t addr;
++  grub_size_t entries_size;
++
++  /* Grub doesn't include calloc, hence the manual overflow check.  */
++  count = grub_le_to_cpu32 (header->maxpart);
++  size = grub_le_to_cpu32 (header->partentry_size);
++  entries_size = count *size;
++  if (size && entries_size / size != count)
++    {
++      grub_error (GRUB_ERR_OUT_OF_MEMORY, N_("out of memory"));
++      goto fail;
++    }
++
++  /* Double check that the header was validated properly.  */
++  if (entries_size < GRUB_GPT_DEFAULT_ENTRIES_SIZE)
++    return grub_error (GRUB_ERR_BUG, "invalid GPT entries table size");
++
++  entries = grub_malloc (entries_size);
++  if (!entries)
++    goto fail;
++
++  sector = grub_le_to_cpu64 (header->partitions);
++  grub_dprintf ("gpt", "reading GPT %lu entries from sector 0x%llx\n",
++		(unsigned long) count,
++		(unsigned long long) sector);
++
++  addr = grub_gpt_sector_to_addr (gpt, sector);
++  if (grub_disk_read (disk, addr, 0, entries_size, entries))
++    goto fail;
++
++  grub_gpt_lecrc32 (&crc, entries, entries_size);
++  if (crc != header->partentry_crc32)
++    {
++      grub_error (GRUB_ERR_BAD_PART_TABLE, "invalid GPT entry crc32");
++      goto fail;
++    }
++
++  *ret_entries = entries;
++  *ret_entries_size = entries_size;
++  return GRUB_ERR_NONE;
++
++fail:
++  grub_free (entries);
++  return grub_errno;
++}
++
++grub_gpt_t
++grub_gpt_read (grub_disk_t disk)
++{
++  grub_gpt_t gpt;
++
++  grub_dprintf ("gpt", "reading GPT from %s\n", disk->name);
++
++  gpt = grub_zalloc (sizeof (*gpt));
++  if (!gpt)
++    goto fail;
++
++  if (grub_disk_read (disk, 0, 0, sizeof (gpt->mbr), &gpt->mbr))
++    goto fail;
++
++  /* Check the MBR but errors aren't reported beyond the status bit.  */
++  if (grub_gpt_pmbr_check (&gpt->mbr))
++    grub_errno = GRUB_ERR_NONE;
++  else
++    gpt->status |= GRUB_GPT_PROTECTIVE_MBR;
++
++  /* If both the primary and backup fail report the primary's error.  */
++  if (grub_gpt_read_primary (disk, gpt))
++    {
++      grub_error_push ();
++      grub_gpt_read_backup (disk, gpt);
++      grub_error_pop ();
++    }
++  else
++    grub_gpt_read_backup (disk, gpt);
++
++  /* If either succeeded clear any possible error from the other.  */
++  if (grub_gpt_primary_valid (gpt) || grub_gpt_backup_valid (gpt))
++    grub_errno = GRUB_ERR_NONE;
++  else
++    goto fail;
++
++  return gpt;
++
++fail:
++  grub_gpt_free (gpt);
++  return NULL;
++}
++
++struct grub_gpt_partentry *
++grub_gpt_get_partentry (grub_gpt_t gpt, grub_uint32_t n)
++{
++  struct grub_gpt_header *header;
++  grub_size_t offset;
++
++  header = grub_gpt_get_header (gpt);
++  if (!header)
++    return NULL;
++
++  if (n >= grub_le_to_cpu32 (header->maxpart))
++    return NULL;
++
++  offset = (grub_size_t) grub_le_to_cpu32 (header->partentry_size) * n;
++  return (struct grub_gpt_partentry *) ((char *) gpt->entries + offset);
++}
++
++grub_err_t
++grub_gpt_repair (grub_disk_t disk, grub_gpt_t gpt)
++{
++  /* Skip if there is nothing to do.  */
++  if (grub_gpt_both_valid (gpt))
++    return GRUB_ERR_NONE;
++
++  grub_dprintf ("gpt", "repairing GPT for %s\n", disk->name);
++
++  if (disk->log_sector_size != gpt->log_sector_size)
++    return grub_error (GRUB_ERR_NOT_IMPLEMENTED_YET,
++		       "GPT sector size must match disk sector size");
++
++  if (grub_gpt_primary_valid (gpt))
++    {
++      grub_uint64_t backup_header;
++
++      grub_dprintf ("gpt", "primary GPT is valid\n");
++
++      /* Relocate backup to end if disk if the disk has grown.  */
++      backup_header = grub_le_to_cpu64 (gpt->primary.alternate_lba);
++      if (grub_gpt_disk_size_valid (disk) &&
++	  disk->total_sectors - 1 > backup_header)
++	{
++	  backup_header = disk->total_sectors - 1;
++	  grub_dprintf ("gpt", "backup GPT header relocated to 0x%llx\n",
++			(unsigned long long) backup_header);
++
++	  gpt->primary.alternate_lba = grub_cpu_to_le64 (backup_header);
++	}
++
++      grub_memcpy (&gpt->backup, &gpt->primary, sizeof (gpt->backup));
++      gpt->backup.header_lba = gpt->primary.alternate_lba;
++      gpt->backup.alternate_lba = gpt->primary.header_lba;
++      gpt->backup.partitions = grub_cpu_to_le64 (backup_header -
++	  grub_gpt_size_to_sectors (gpt, gpt->entries_size));
++    }
++  else if (grub_gpt_backup_valid (gpt))
++    {
++      grub_dprintf ("gpt", "backup GPT is valid\n");
++
++      grub_memcpy (&gpt->primary, &gpt->backup, sizeof (gpt->primary));
++      gpt->primary.header_lba = gpt->backup.alternate_lba;
++      gpt->primary.alternate_lba = gpt->backup.header_lba;
++      gpt->primary.partitions = grub_cpu_to_le64_compile_time (2);
++    }
++  else
++    return grub_error (GRUB_ERR_BUG, "No valid GPT");
++
++  if (grub_gpt_update (gpt))
++    return grub_errno;
++
++  grub_dprintf ("gpt", "repairing GPT for %s successful\n", disk->name);
++
++  return GRUB_ERR_NONE;
++}
++
++grub_err_t
++grub_gpt_update (grub_gpt_t gpt)
++{
++  grub_uint32_t crc;
++
++  /* Clear status bits, require revalidation of everything.  */
++  gpt->status &= ~(GRUB_GPT_PRIMARY_HEADER_VALID |
++		   GRUB_GPT_PRIMARY_ENTRIES_VALID |
++		   GRUB_GPT_BACKUP_HEADER_VALID |
++		   GRUB_GPT_BACKUP_ENTRIES_VALID);
++
++  /* Writing headers larger than our header structure are unsupported.  */
++  gpt->primary.headersize =
++    grub_cpu_to_le32_compile_time (sizeof (gpt->primary));
++  gpt->backup.headersize =
++    grub_cpu_to_le32_compile_time (sizeof (gpt->backup));
++
++  grub_gpt_lecrc32 (&crc, gpt->entries, gpt->entries_size);
++  gpt->primary.partentry_crc32 = crc;
++  gpt->backup.partentry_crc32 = crc;
++
++  grub_gpt_header_lecrc32 (&gpt->primary.crc32, &gpt->primary);
++  grub_gpt_header_lecrc32 (&gpt->backup.crc32, &gpt->backup);
++
++  if (grub_gpt_check_primary (gpt))
++    {
++      grub_error_push ();
++      return grub_error (GRUB_ERR_BUG, "Generated invalid GPT primary header");
++    }
++
++  gpt->status |= (GRUB_GPT_PRIMARY_HEADER_VALID |
++		  GRUB_GPT_PRIMARY_ENTRIES_VALID);
++
++  if (grub_gpt_check_backup (gpt))
++    {
++      grub_error_push ();
++      return grub_error (GRUB_ERR_BUG, "Generated invalid GPT backup header");
++    }
++
++  gpt->status |= (GRUB_GPT_BACKUP_HEADER_VALID |
++		  GRUB_GPT_BACKUP_ENTRIES_VALID);
++
++  return GRUB_ERR_NONE;
++}
++
++static grub_err_t
++grub_gpt_write_table (grub_disk_t disk, grub_gpt_t gpt,
++		      struct grub_gpt_header *header)
++{
++  grub_disk_addr_t addr;
++
++  if (grub_le_to_cpu32 (header->headersize) != sizeof (*header))
++    return grub_error (GRUB_ERR_NOT_IMPLEMENTED_YET,
++		       "Header size is %u, must be %u",
++		       grub_le_to_cpu32 (header->headersize),
++		       sizeof (*header));
++
++  addr = grub_gpt_sector_to_addr (gpt, grub_le_to_cpu64 (header->header_lba));
++  if (addr == 0)
++    return grub_error (GRUB_ERR_BUG,
++		       "Refusing to write GPT header to address 0x0");
++  if (grub_disk_write (disk, addr, 0, sizeof (*header), header))
++    return grub_errno;
++
++  addr = grub_gpt_sector_to_addr (gpt, grub_le_to_cpu64 (header->partitions));
++  if (addr < 2)
++    return grub_error (GRUB_ERR_BUG,
++		       "Refusing to write GPT entries to address 0x%llx",
++		       (unsigned long long) addr);
++  if (grub_disk_write (disk, addr, 0, gpt->entries_size, gpt->entries))
++    return grub_errno;
++
++  return GRUB_ERR_NONE;
++}
++
++grub_err_t
++grub_gpt_write (grub_disk_t disk, grub_gpt_t gpt)
++{
++  grub_uint64_t backup_header;
++
++  /* TODO: update/repair protective MBRs too.  */
++
++  if (!grub_gpt_both_valid (gpt))
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "Invalid GPT data");
++
++  /* Write the backup GPT first so if writing fails the update is aborted
++   * and the primary is left intact.  However if the backup location is
++   * inaccessible we have to just skip and hope for the best, the backup
++   * will need to be repaired in the OS.  */
++  backup_header = grub_le_to_cpu64 (gpt->backup.header_lba);
++  if (grub_gpt_disk_size_valid (disk) &&
++      backup_header >= disk->total_sectors)
++    {
++      grub_printf ("warning: backup GPT located at 0x%llx, "
++		   "beyond last disk sector at 0x%llx\n",
++		   (unsigned long long) backup_header,
++		   (unsigned long long) disk->total_sectors - 1);
++      grub_printf ("warning: only writing primary GPT, "
++	           "the backup GPT must be repaired from the OS\n");
++    }
++  else
++    {
++      grub_dprintf ("gpt", "writing backup GPT to %s\n", disk->name);
++      if (grub_gpt_write_table (disk, gpt, &gpt->backup))
++	return grub_errno;
++    }
++
++  grub_dprintf ("gpt", "writing primary GPT to %s\n", disk->name);
++  if (grub_gpt_write_table (disk, gpt, &gpt->primary))
++    return grub_errno;
++
++  return GRUB_ERR_NONE;
++}
++
++void
++grub_gpt_free (grub_gpt_t gpt)
++{
++  if (!gpt)
++    return;
++
++  grub_free (gpt->entries);
++  grub_free (gpt);
++}
+diff --git a/include/grub/gpt_partition.h b/include/grub/gpt_partition.h
+index 7a93f4329..27946f471 100644
+--- a/include/grub/gpt_partition.h
++++ b/include/grub/gpt_partition.h
+@@ -21,6 +21,7 @@
+ 
+ #include <grub/types.h>
+ #include <grub/partition.h>
++#include <grub/msdos_partition.h>
+ 
+ struct grub_gpt_part_guid
+ {
+@@ -31,24 +32,43 @@ struct grub_gpt_part_guid
+ } GRUB_PACKED;
+ typedef struct grub_gpt_part_guid grub_gpt_part_guid_t;
+ 
+-#define GRUB_GPT_PARTITION_TYPE_EMPTY \
+-  { 0x0, 0x0, 0x0, \
+-    { 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 } \
++/* Format the raw little-endian GUID as a newly allocated string.  */
++char * grub_gpt_part_guid_to_str (grub_gpt_part_guid_t *guid);
++
++
++#define GRUB_GPT_GUID_INIT(a, b, c, d1, d2, d3, d4, d5, d6, d7, d8)  \
++  {					\
++    grub_cpu_to_le32_compile_time (a),	\
++    grub_cpu_to_le16_compile_time (b),	\
++    grub_cpu_to_le16_compile_time (c),	\
++    { d1, d2, d3, d4, d5, d6, d7, d8 }	\
+   }
+ 
++#define GRUB_GPT_PARTITION_TYPE_EMPTY \
++  GRUB_GPT_GUID_INIT (0x0, 0x0, 0x0,  \
++      0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
++
++#define GRUB_GPT_PARTITION_TYPE_EFI_SYSTEM \
++  GRUB_GPT_GUID_INIT (0xc12a7328, 0xf81f, 0x11d2, \
++      0xba, 0x4b, 0x00, 0xa0, 0xc9, 0x3e, 0xc9, 0x3b)
++
+ #define GRUB_GPT_PARTITION_TYPE_BIOS_BOOT \
+-  { grub_cpu_to_le32_compile_time (0x21686148), \
+-      grub_cpu_to_le16_compile_time (0x6449), \
+-      grub_cpu_to_le16_compile_time (0x6e6f),	       \
+-    { 0x74, 0x4e, 0x65, 0x65, 0x64, 0x45, 0x46, 0x49 } \
+-  }
++  GRUB_GPT_GUID_INIT (0x21686148, 0x6449, 0x6e6f, \
++      0x74, 0x4e, 0x65, 0x65, 0x64, 0x45, 0x46, 0x49)
+ 
+ #define GRUB_GPT_PARTITION_TYPE_LDM \
+-  { grub_cpu_to_le32_compile_time (0x5808C8AAU),\
+-      grub_cpu_to_le16_compile_time (0x7E8F), \
+-      grub_cpu_to_le16_compile_time (0x42E0),	       \
+-	{ 0x85, 0xD2, 0xE1, 0xE9, 0x04, 0x34, 0xCF, 0xB3 }	\
+-  }
++  GRUB_GPT_GUID_INIT (0x5808c8aa, 0x7e8f, 0x42e0, \
++      0x85, 0xd2, 0xe1, 0xe9, 0x04, 0x34, 0xcf, 0xb3)
++
++#define GRUB_GPT_PARTITION_TYPE_USR_X86_64 \
++  GRUB_GPT_GUID_INIT (0x5dfbf5f4, 0x2848, 0x4bac, \
++      0xaa, 0x5e, 0x0d, 0x9a, 0x20, 0xb7, 0x45, 0xa6)
++
++#define GRUB_GPT_HEADER_MAGIC \
++  { 0x45, 0x46, 0x49, 0x20, 0x50, 0x41, 0x52, 0x54 }
++
++#define GRUB_GPT_HEADER_VERSION	\
++  grub_cpu_to_le32_compile_time (0x00010000U)
+ 
+ struct grub_gpt_header
+ {
+@@ -57,11 +77,11 @@ struct grub_gpt_header
+   grub_uint32_t headersize;
+   grub_uint32_t crc32;
+   grub_uint32_t unused1;
+-  grub_uint64_t primary;
+-  grub_uint64_t backup;
++  grub_uint64_t header_lba;
++  grub_uint64_t alternate_lba;
+   grub_uint64_t start;
+   grub_uint64_t end;
+-  grub_uint8_t guid[16];
++  grub_gpt_part_guid_t guid;
+   grub_uint64_t partitions;
+   grub_uint32_t maxpart;
+   grub_uint32_t partentry_size;
+@@ -75,13 +95,172 @@ struct grub_gpt_partentry
+   grub_uint64_t start;
+   grub_uint64_t end;
+   grub_uint64_t attrib;
+-  char name[72];
++  grub_uint16_t name[36];
+ } GRUB_PACKED;
+ 
++enum grub_gpt_part_attr_offset
++{
++  /* Standard partition attribute bits defined by UEFI.  */
++  GRUB_GPT_PART_ATTR_OFFSET_REQUIRED			= 0,
++  GRUB_GPT_PART_ATTR_OFFSET_NO_BLOCK_IO_PROTOCOL	= 1,
++  GRUB_GPT_PART_ATTR_OFFSET_LEGACY_BIOS_BOOTABLE	= 2,
++
++  /* De facto standard attribute bits defined by Microsoft and reused by
++   * http://www.freedesktop.org/wiki/Specifications/DiscoverablePartitionsSpec */
++  GRUB_GPT_PART_ATTR_OFFSET_READ_ONLY			= 60,
++  GRUB_GPT_PART_ATTR_OFFSET_NO_AUTO			= 63,
++
++  /* Partition attributes for priority based selection,
++   * Currently only valid for PARTITION_TYPE_USR_X86_64.
++   * TRIES_LEFT and PRIORITY are 4 bit wide fields.  */
++  GRUB_GPT_PART_ATTR_OFFSET_GPTPRIO_PRIORITY		= 48,
++  GRUB_GPT_PART_ATTR_OFFSET_GPTPRIO_TRIES_LEFT		= 52,
++  GRUB_GPT_PART_ATTR_OFFSET_GPTPRIO_SUCCESSFUL		= 56,
++};
++
++/* Helpers for reading/writing partition attributes.  */
++static inline grub_uint64_t
++grub_gpt_entry_attribute (struct grub_gpt_partentry *entry,
++			  enum grub_gpt_part_attr_offset offset,
++			  unsigned int bits)
++{
++  grub_uint64_t attrib = grub_le_to_cpu64 (entry->attrib);
++
++  return (attrib >> offset) & ((1ULL << bits) - 1);
++}
++
++static inline void
++grub_gpt_entry_set_attribute (struct grub_gpt_partentry *entry,
++			      grub_uint64_t value,
++			      enum grub_gpt_part_attr_offset offset,
++			      unsigned int bits)
++{
++  grub_uint64_t attrib, mask;
++
++  mask = (((1ULL << bits) - 1) << offset);
++  attrib = grub_le_to_cpu64 (entry->attrib) & ~mask;
++  attrib |= ((value << offset) & mask);
++  entry->attrib = grub_cpu_to_le64 (attrib);
++}
++
++/* Basic GPT partmap module.  */
+ grub_err_t
+ grub_gpt_partition_map_iterate (grub_disk_t disk,
+ 				grub_partition_iterate_hook_t hook,
+ 				void *hook_data);
+ 
++/* Advanced GPT library.  */
++
++/* Status bits for the grub_gpt.status field.  */
++#define GRUB_GPT_PROTECTIVE_MBR		0x01
++#define GRUB_GPT_HYBRID_MBR		0x02
++#define GRUB_GPT_PRIMARY_HEADER_VALID	0x04
++#define GRUB_GPT_PRIMARY_ENTRIES_VALID	0x08
++#define GRUB_GPT_BACKUP_HEADER_VALID	0x10
++#define GRUB_GPT_BACKUP_ENTRIES_VALID	0x20
++
++/* UEFI requires the entries table to be at least 16384 bytes for a
++ * total of 128 entries given the standard 128 byte entry size.  */
++#define GRUB_GPT_DEFAULT_ENTRIES_SIZE	16384
++#define GRUB_GPT_DEFAULT_ENTRIES_LENGTH	\
++  (GRUB_GPT_DEFAULT_ENTRIES_SIZE / sizeof (struct grub_gpt_partentry))
++
++struct grub_gpt
++{
++  /* Bit field indicating which structures on disk are valid.  */
++  unsigned status;
++
++  /* Protective or hybrid MBR.  */
++  struct grub_msdos_partition_mbr mbr;
++
++  /* Each of the two GPT headers.  */
++  struct grub_gpt_header primary;
++  struct grub_gpt_header backup;
++
++  /* Only need one entries table, on disk both copies are identical.
++   * The on disk entry size may be larger than our partentry struct so
++   * the table cannot be indexed directly.  */
++  void *entries;
++  grub_size_t entries_size;
++
++  /* Logarithm of sector size, in case GPT and disk driver disagree.  */
++  unsigned int log_sector_size;
++};
++typedef struct grub_gpt *grub_gpt_t;
++
++/* Helpers for checking the gpt status field.  */
++static inline int
++grub_gpt_mbr_valid (grub_gpt_t gpt)
++{
++  return ((gpt->status & GRUB_GPT_PROTECTIVE_MBR) ||
++	  (gpt->status & GRUB_GPT_HYBRID_MBR));
++}
++
++static inline int
++grub_gpt_primary_valid (grub_gpt_t gpt)
++{
++  return ((gpt->status & GRUB_GPT_PRIMARY_HEADER_VALID) &&
++	  (gpt->status & GRUB_GPT_PRIMARY_ENTRIES_VALID));
++}
++
++static inline int
++grub_gpt_backup_valid (grub_gpt_t gpt)
++{
++  return ((gpt->status & GRUB_GPT_BACKUP_HEADER_VALID) &&
++	  (gpt->status & GRUB_GPT_BACKUP_ENTRIES_VALID));
++}
++
++static inline int
++grub_gpt_both_valid (grub_gpt_t gpt)
++{
++  return grub_gpt_primary_valid (gpt) && grub_gpt_backup_valid (gpt);
++}
++
++/* Translate GPT sectors to GRUB's 512 byte block addresses.  */
++static inline grub_disk_addr_t
++grub_gpt_sector_to_addr (grub_gpt_t gpt, grub_uint64_t sector)
++{
++  return (sector << (gpt->log_sector_size - GRUB_DISK_SECTOR_BITS));
++}
++
++/* Allocates and fills new grub_gpt structure, free with grub_gpt_free.  */
++grub_gpt_t grub_gpt_read (grub_disk_t disk);
++
++/* Helper for indexing into the entries table.
++ * Returns NULL when the end of the table has been reached.  */
++struct grub_gpt_partentry * grub_gpt_get_partentry (grub_gpt_t gpt,
++						    grub_uint32_t n);
++
++/* Sync and update primary and backup headers if either are invalid.  */
++grub_err_t grub_gpt_repair (grub_disk_t disk, grub_gpt_t gpt);
++
++/* Recompute checksums and revalidate everything, must be called after
++ * modifying any GPT data.  */
++grub_err_t grub_gpt_update (grub_gpt_t gpt);
++
++/* Write headers and entry tables back to disk.  */
++grub_err_t grub_gpt_write (grub_disk_t disk, grub_gpt_t gpt);
++
++void grub_gpt_free (grub_gpt_t gpt);
++
++grub_err_t grub_gpt_pmbr_check (struct grub_msdos_partition_mbr *mbr);
++grub_err_t grub_gpt_header_check (struct grub_gpt_header *gpt,
++				  unsigned int log_sector_size);
++
++
++/* Utilities for simple partition data lookups, usage is intended to
++ * be similar to fs->label and fs->uuid functions.  */
++
++/* Return the partition label of the device DEVICE in LABEL.
++ * The label is in a new buffer and should be freed by the caller.  */
++grub_err_t grub_gpt_part_label (grub_device_t device, char **label);
++
++/* Return the partition uuid of the device DEVICE in UUID.
++ * The uuid is in a new buffer and should be freed by the caller.  */
++grub_err_t grub_gpt_part_uuid (grub_device_t device, char **uuid);
++
++/* Return the disk uuid of the device DEVICE in UUID.
++ * The uuid is in a new buffer and should be freed by the caller.  */
++grub_err_t grub_gpt_disk_uuid (grub_device_t device, char **uuid);
+ 
+ #endif /* ! GRUB_GPT_PARTITION_HEADER */
+-- 
+2.25.1
+

--- a/pkg/grub/patches.2.06/0002-Add-gptprio-module.patch
+++ b/pkg/grub/patches.2.06/0002-Add-gptprio-module.patch
@@ -1,0 +1,260 @@
+From bc06c61031a552e1ef80d5fb77394322a31cfe5d Mon Sep 17 00:00:00 2001
+From: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>
+Date: Thu, 14 Oct 2021 00:41:31 +0530
+Subject: [PATCH 2/8] Add gptprio module
+
+Signed-off-by: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>
+---
+ grub-core/Makefile.core.def  |   5 +
+ grub-core/commands/gptprio.c | 223 +++++++++++++++++++++++++++++++++++
+ 2 files changed, 228 insertions(+)
+ create mode 100644 grub-core/commands/gptprio.c
+
+diff --git a/grub-core/Makefile.core.def b/grub-core/Makefile.core.def
+index 8dee4d09e..820f67c03 100644
+--- a/grub-core/Makefile.core.def
++++ b/grub-core/Makefile.core.def
+@@ -897,6 +897,11 @@ module = {
+   common = commands/gptsync.c;
+ };
+ 
++module = {
++  name = gptprio;
++  common = commands/gptprio.c;
++};
++
+ module = {
+   name = gpt;
+   common = lib/gpt.c;
+diff --git a/grub-core/commands/gptprio.c b/grub-core/commands/gptprio.c
+new file mode 100644
+index 000000000..65c4b209e
+--- /dev/null
++++ b/grub-core/commands/gptprio.c
+@@ -0,0 +1,223 @@
++/* gptprio.c - manage priority based partition selection.  */
++/*
++ *  GRUB  --  GRand Unified Bootloader
++ *  Copyright (C) 2009  Free Software Foundation, Inc.
++ *  Copyright (C) 2014  CoreOS, Inc.
++ *
++ *  GRUB is free software: you can redistribute it and/or modify
++ *  it under the terms of the GNU General Public License as published by
++ *  the Free Software Foundation, either version 3 of the License, or
++ *  (at your option) any later version.
++ *
++ *  GRUB is distributed in the hope that it will be useful,
++ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *  GNU General Public License for more details.
++ *
++ *  You should have received a copy of the GNU General Public License
++ *  along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++#include <grub/device.h>
++#include <grub/env.h>
++#include <grub/err.h>
++#include <grub/extcmd.h>
++#include <grub/gpt_partition.h>
++#include <grub/i18n.h>
++#include <grub/misc.h>
++
++GRUB_MOD_LICENSE ("GPLv3+");
++
++static const struct grub_arg_option options_next[] = {
++  {"set-device", 'd', 0,
++   N_("Set a variable to the name of selected partition."),
++   N_("VARNAME"), ARG_TYPE_STRING},
++  {"set-uuid", 'u', 0,
++   N_("Set a variable to the GPT UUID of selected partition."),
++   N_("VARNAME"), ARG_TYPE_STRING},
++  {0, 0, 0, 0, 0, 0}
++};
++
++enum options_next
++{
++  NEXT_SET_DEVICE,
++  NEXT_SET_UUID,
++};
++
++static unsigned int
++grub_gptprio_priority (struct grub_gpt_partentry *entry)
++{
++  return (unsigned int) grub_gpt_entry_attribute
++    (entry, GRUB_GPT_PART_ATTR_OFFSET_GPTPRIO_PRIORITY, 4);
++}
++
++static unsigned int
++grub_gptprio_tries_left (struct grub_gpt_partentry *entry)
++{
++  return (unsigned int) grub_gpt_entry_attribute
++    (entry, GRUB_GPT_PART_ATTR_OFFSET_GPTPRIO_TRIES_LEFT, 4);
++}
++
++static void
++grub_gptprio_set_tries_left (struct grub_gpt_partentry *entry,
++			     unsigned int tries_left)
++{
++  grub_gpt_entry_set_attribute
++    (entry, tries_left, GRUB_GPT_PART_ATTR_OFFSET_GPTPRIO_TRIES_LEFT, 4);
++}
++
++static unsigned int
++grub_gptprio_successful (struct grub_gpt_partentry *entry)
++{
++  return (unsigned int) grub_gpt_entry_attribute
++    (entry, GRUB_GPT_PART_ATTR_OFFSET_GPTPRIO_SUCCESSFUL, 1);
++}
++
++static grub_err_t
++grub_find_next (const char *disk_name,
++		const grub_gpt_part_guid_t *part_type,
++		char **part_name, char **part_guid)
++{
++  struct grub_gpt_partentry *part, *part_found = NULL;
++  grub_device_t dev = NULL;
++  grub_gpt_t gpt = NULL;
++  grub_uint32_t i, part_index;
++
++  dev = grub_device_open (disk_name);
++  if (!dev)
++    goto done;
++
++  gpt = grub_gpt_read (dev->disk);
++  if (!gpt)
++    goto done;
++
++  if (grub_gpt_repair (dev->disk, gpt))
++    goto done;
++
++  for (i = 0; (part = grub_gpt_get_partentry (gpt, i)) != NULL; i++)
++    {
++      if (grub_memcmp (part_type, &part->type, sizeof (*part_type)) == 0)
++	{
++	  unsigned int priority, tries_left, successful, old_priority = 0;
++
++	  priority = grub_gptprio_priority (part);
++	  tries_left = grub_gptprio_tries_left (part);
++	  successful = grub_gptprio_successful (part);
++
++	  if (part_found)
++	    old_priority = grub_gptprio_priority (part_found);
++
++	  if ((tries_left || successful) && priority > old_priority)
++	    {
++	      part_index = i;
++	      part_found = part;
++	    }
++	}
++    }
++
++  if (!part_found)
++    {
++      grub_error (GRUB_ERR_UNKNOWN_DEVICE, N_("no such partition"));
++      goto done;
++    }
++
++  if (grub_gptprio_tries_left (part_found))
++    {
++      unsigned int tries_left = grub_gptprio_tries_left (part_found);
++
++      grub_gptprio_set_tries_left (part_found, tries_left - 1);
++
++      if (grub_gpt_update (gpt))
++	goto done;
++
++      if (grub_gpt_write (dev->disk, gpt))
++	goto done;
++    }
++
++  *part_name = grub_xasprintf ("%s,gpt%u", disk_name, part_index + 1);
++  if (!*part_name)
++    goto done;
++
++  *part_guid = grub_gpt_part_guid_to_str (&part_found->guid);
++  if (!*part_guid)
++    goto done;
++
++  grub_errno = GRUB_ERR_NONE;
++
++done:
++  grub_gpt_free (gpt);
++
++  if (dev)
++    grub_device_close (dev);
++
++  return grub_errno;
++}
++
++
++
++static grub_err_t
++grub_cmd_next (grub_extcmd_context_t ctxt, int argc, char **args)
++{
++  struct grub_arg_list *state = ctxt->state;
++  char *p, *root = NULL, *part_name = NULL, *part_guid = NULL;
++
++  /* TODO: Add a uuid parser and a command line flag for providing type.  */
++  grub_gpt_part_guid_t part_type = GRUB_GPT_PARTITION_TYPE_USR_X86_64;
++
++  if (!state[NEXT_SET_DEVICE].set || !state[NEXT_SET_UUID].set)
++    {
++      grub_error (GRUB_ERR_INVALID_COMMAND, N_("-d and -u are required"));
++      goto done;
++    }
++
++  if (argc == 0)
++    root = grub_strdup (grub_env_get ("root"));
++  else if (argc == 1)
++    root = grub_strdup (args[0]);
++  else
++    {
++      grub_error (GRUB_ERR_BAD_ARGUMENT, N_("unexpected arguments"));
++      goto done;
++    }
++
++  if (!root)
++    goto done;
++
++  /* To make using $root practical strip off the partition name.  */
++  p = grub_strchr (root, ',');
++  if (p)
++    *p = '\0';
++
++  if (grub_find_next (root, &part_type, &part_name, &part_guid))
++    goto done;
++
++  if (grub_env_set (state[NEXT_SET_DEVICE].arg, part_name))
++    goto done;
++
++  if (grub_env_set (state[NEXT_SET_UUID].arg, part_guid))
++    goto done;
++
++  grub_errno = GRUB_ERR_NONE;
++
++done:
++  grub_free (root);
++  grub_free (part_name);
++  grub_free (part_guid);
++
++  return grub_errno;
++}
++
++static grub_extcmd_t cmd_next;
++
++GRUB_MOD_INIT(gptprio)
++{
++  cmd_next = grub_register_extcmd ("gptprio.next", grub_cmd_next, 0,
++				   N_("-d VARNAME -u VARNAME [DEVICE]"),
++				   N_("Select next partition to boot."),
++				   options_next);
++}
++
++GRUB_MOD_FINI(gptprio)
++{
++  grub_unregister_extcmd (cmd_next);
++}
+-- 
+2.25.1
+

--- a/pkg/grub/patches.2.06/0003-Add-search_part_label-module.patch
+++ b/pkg/grub/patches.2.06/0003-Add-search_part_label-module.patch
@@ -1,0 +1,87 @@
+From f3fe8743576640f65dbe2515d2bcc32e536766cf Mon Sep 17 00:00:00 2001
+From: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>
+Date: Thu, 14 Oct 2021 01:34:58 +0530
+Subject: [PATCH 3/8] Add search_part_label module
+
+Signed-off-by: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>
+---
+ grub-core/Makefile.core.def            | 5 +++++
+ grub-core/commands/search_part_label.c | 5 +++++
+ grub-core/commands/search_wrap.c       | 6 ++++++
+ include/grub/search.h                  | 3 ++-
+ 4 files changed, 18 insertions(+), 1 deletion(-)
+ create mode 100644 grub-core/commands/search_part_label.c
+
+diff --git a/grub-core/Makefile.core.def b/grub-core/Makefile.core.def
+index 820f67c03..25a274067 100644
+--- a/grub-core/Makefile.core.def
++++ b/grub-core/Makefile.core.def
+@@ -1083,6 +1083,11 @@ module = {
+   common = commands/search_label.c;
+ };
+ 
++module = {
++  name = search_part_label;
++  common = commands/search_part_label.c;
++};
++
+ module = {
+   name = setpci;
+   common = commands/setpci.c;
+diff --git a/grub-core/commands/search_part_label.c b/grub-core/commands/search_part_label.c
+new file mode 100644
+index 000000000..ca906cbd9
+--- /dev/null
++++ b/grub-core/commands/search_part_label.c
+@@ -0,0 +1,5 @@
++#define DO_SEARCH_PART_LABEL 1
++#define FUNC_NAME grub_search_part_label
++#define COMMAND_NAME "search.part_label"
++#define HELP_MESSAGE N_("Search devices by partition label. If VARIABLE is specified, the first device found is set to a variable.")
++#include "search.c"
+diff --git a/grub-core/commands/search_wrap.c b/grub-core/commands/search_wrap.c
+index 47fc8eb99..ffa349add 100644
+--- a/grub-core/commands/search_wrap.c
++++ b/grub-core/commands/search_wrap.c
+@@ -36,6 +36,8 @@ static const struct grub_arg_option options[] =
+      0, 0},
+     {"fs-uuid",		'u', 0, N_("Search devices by a filesystem UUID."),
+      0, 0},
++    {"part-label",	'L', 0, N_("Search devices by a partition label."),
++     0, 0},
+     {"set",		's', GRUB_ARG_OPTION_OPTIONAL,
+      N_("Set a variable to the first device found."), N_("VARNAME"),
+      ARG_TYPE_STRING},
+@@ -71,6 +73,7 @@ enum options
+     SEARCH_FILE,
+     SEARCH_LABEL,
+     SEARCH_FS_UUID,
++    SEARCH_PART_LABEL,
+     SEARCH_SET,
+     SEARCH_NO_FLOPPY,
+     SEARCH_HINT,
+@@ -186,6 +189,9 @@ grub_cmd_search (grub_extcmd_context_t ctxt, int argc, char **args)
+   else if (state[SEARCH_FS_UUID].set)
+     grub_search_fs_uuid (id, var, state[SEARCH_NO_FLOPPY].set,
+ 			 hints, nhints);
++  else if (state[SEARCH_PART_LABEL].set)
++    grub_search_part_label (id, var, state[SEARCH_NO_FLOPPY].set,
++			    hints, nhints);
+   else if (state[SEARCH_FILE].set)
+     grub_search_fs_file (id, var, state[SEARCH_NO_FLOPPY].set, 
+ 			 hints, nhints);
+diff --git a/include/grub/search.h b/include/grub/search.h
+index d80347df3..9b83f515c 100644
+--- a/include/grub/search.h
++++ b/include/grub/search.h
+@@ -25,5 +25,6 @@ void grub_search_fs_uuid (const char *key, const char *var, int no_floppy,
+ 			  char **hints, unsigned nhints);
+ void grub_search_label (const char *key, const char *var, int no_floppy,
+ 			char **hints, unsigned nhints);
+-
++void grub_search_part_label (const char *key, const char *var, int no_floppy,
++			     char **hints, unsigned nhints);
+ #endif
+-- 
+2.25.1
+

--- a/pkg/grub/patches.2.06/0004-Add-search_part_uuid-and-search_disk_uuid-module.patch
+++ b/pkg/grub/patches.2.06/0004-Add-search_part_uuid-and-search_disk_uuid-module.patch
@@ -1,0 +1,120 @@
+From eef0ec618956452e29f201be33388245b100f1a1 Mon Sep 17 00:00:00 2001
+From: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>
+Date: Thu, 14 Oct 2021 10:38:26 +0530
+Subject: [PATCH 4/8] Add search_part_uuid and search_disk_uuid module
+
+Signed-off-by: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>
+---
+ grub-core/Makefile.core.def           | 10 ++++++++++
+ grub-core/commands/search_disk_uuid.c |  5 +++++
+ grub-core/commands/search_part_uuid.c |  5 +++++
+ grub-core/commands/search_wrap.c      | 12 ++++++++++++
+ include/grub/search.h                 |  5 +++++
+ 5 files changed, 37 insertions(+)
+ create mode 100644 grub-core/commands/search_disk_uuid.c
+ create mode 100644 grub-core/commands/search_part_uuid.c
+
+diff --git a/grub-core/Makefile.core.def b/grub-core/Makefile.core.def
+index 25a274067..9d5736b4a 100644
+--- a/grub-core/Makefile.core.def
++++ b/grub-core/Makefile.core.def
+@@ -1083,11 +1083,21 @@ module = {
+   common = commands/search_label.c;
+ };
+ 
++module = {
++  name = search_part_uuid;
++  common = commands/search_part_uuid.c;
++};
++
+ module = {
+   name = search_part_label;
+   common = commands/search_part_label.c;
+ };
+ 
++module = {
++  name = search_disk_uuid;
++  common = commands/search_disk_uuid.c;
++};
++
+ module = {
+   name = setpci;
+   common = commands/setpci.c;
+diff --git a/grub-core/commands/search_disk_uuid.c b/grub-core/commands/search_disk_uuid.c
+new file mode 100644
+index 000000000..fba96f6b8
+--- /dev/null
++++ b/grub-core/commands/search_disk_uuid.c
+@@ -0,0 +1,5 @@
++#define DO_SEARCH_DISK_UUID 1
++#define FUNC_NAME grub_search_disk_uuid
++#define COMMAND_NAME "search.disk_uuid"
++#define HELP_MESSAGE N_("Search devices by disk UUID. If VARIABLE is specified, the first device found is set to a variable.")
++#include "search.c"
+diff --git a/grub-core/commands/search_part_uuid.c b/grub-core/commands/search_part_uuid.c
+new file mode 100644
+index 000000000..2d1d3d0d7
+--- /dev/null
++++ b/grub-core/commands/search_part_uuid.c
+@@ -0,0 +1,5 @@
++#define DO_SEARCH_PART_UUID 1
++#define FUNC_NAME grub_search_part_uuid
++#define COMMAND_NAME "search.part_uuid"
++#define HELP_MESSAGE N_("Search devices by partition UUID. If VARIABLE is specified, the first device found is set to a variable.")
++#include "search.c"
+diff --git a/grub-core/commands/search_wrap.c b/grub-core/commands/search_wrap.c
+index ffa349add..fc149cd6b 100644
+--- a/grub-core/commands/search_wrap.c
++++ b/grub-core/commands/search_wrap.c
+@@ -38,6 +38,10 @@ static const struct grub_arg_option options[] =
+      0, 0},
+     {"part-label",	'L', 0, N_("Search devices by a partition label."),
+      0, 0},
++    {"part-uuid",	'U', 0, N_("Search devices by a partition UUID."),
++     0, 0},
++    {"disk-uuid",	'U', 0, N_("Search devices by a disk UUID."),
++     0, 0},
+     {"set",		's', GRUB_ARG_OPTION_OPTIONAL,
+      N_("Set a variable to the first device found."), N_("VARNAME"),
+      ARG_TYPE_STRING},
+@@ -74,6 +78,8 @@ enum options
+     SEARCH_LABEL,
+     SEARCH_FS_UUID,
+     SEARCH_PART_LABEL,
++    SEARCH_PART_UUID,
++    SEARCH_DISK_UUID,
+     SEARCH_SET,
+     SEARCH_NO_FLOPPY,
+     SEARCH_HINT,
+@@ -192,6 +198,12 @@ grub_cmd_search (grub_extcmd_context_t ctxt, int argc, char **args)
+   else if (state[SEARCH_PART_LABEL].set)
+     grub_search_part_label (id, var, state[SEARCH_NO_FLOPPY].set,
+ 			    hints, nhints);
++  else if (state[SEARCH_PART_UUID].set)
++    grub_search_part_uuid (id, var, state[SEARCH_NO_FLOPPY].set,
++			   hints, nhints);
++  else if (state[SEARCH_DISK_UUID].set)
++    grub_search_disk_uuid (id, var, state[SEARCH_NO_FLOPPY].set,
++			   hints, nhints);
+   else if (state[SEARCH_FILE].set)
+     grub_search_fs_file (id, var, state[SEARCH_NO_FLOPPY].set, 
+ 			 hints, nhints);
+diff --git a/include/grub/search.h b/include/grub/search.h
+index 9b83f515c..7f69d25d1 100644
+--- a/include/grub/search.h
++++ b/include/grub/search.h
+@@ -25,6 +25,11 @@ void grub_search_fs_uuid (const char *key, const char *var, int no_floppy,
+ 			  char **hints, unsigned nhints);
+ void grub_search_label (const char *key, const char *var, int no_floppy,
+ 			char **hints, unsigned nhints);
++void grub_search_part_uuid (const char *key, const char *var, int no_floppy,
++			    char **hints, unsigned nhints);
+ void grub_search_part_label (const char *key, const char *var, int no_floppy,
+ 			     char **hints, unsigned nhints);
++void grub_search_disk_uuid (const char *key, const char *var, int no_floppy,
++			    char **hints, unsigned nhints);
++
+ #endif
+-- 
+2.25.1
+

--- a/pkg/grub/patches.2.06/0005-Implement-watchdog-style-menu-timeout.patch
+++ b/pkg/grub/patches.2.06/0005-Implement-watchdog-style-menu-timeout.patch
@@ -1,0 +1,51 @@
+From d782634a84e73d1a4e002c52d89194d44cdc98d2 Mon Sep 17 00:00:00 2001
+From: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>
+Date: Thu, 14 Oct 2021 11:14:22 +0530
+Subject: [PATCH 5/8] Implement watchdog style menu timeout
+
+Standard GRUB implementation cannot resist spurious keypress and stops booting.
+This change resets timeout to its initial value. Grub menutimeout
+should be set to some comfort value e.g. 5 sec
+
+Signed-off-by: Michael Malyshev <mikem@zededa.com>
+Signed-off-by: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>
+---
+ grub-core/normal/menu.c | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/grub-core/normal/menu.c b/grub-core/normal/menu.c
+index 8397886fa..c1a5d7c06 100644
+--- a/grub-core/normal/menu.c
++++ b/grub-core/normal/menu.c
+@@ -579,6 +579,7 @@ run_menu (grub_menu_t menu, int nested, int *auto_boot)
+   int default_entry, current_entry;
+   int timeout;
+   enum timeout_style timeout_style;
++  int initial_timeout_value;
+ 
+   default_entry = get_entry_number (menu, "default");
+ 
+@@ -659,6 +660,7 @@ run_menu (grub_menu_t menu, int nested, int *auto_boot)
+ 
+   current_entry = default_entry;
+ 
++  initial_timeout_value = grub_menu_get_timeout ();
+  refresh:
+   menu_init (current_entry, menu, nested);
+ 
+@@ -702,9 +704,9 @@ run_menu (grub_menu_t menu, int nested, int *auto_boot)
+ 	{
+ 	  if (timeout >= 0)
+ 	    {
+-	      grub_env_unset ("timeout");
+-	      grub_env_unset ("fallback");
+-	      clear_timeout ();
++	      /* reset timeout value if the user press any key */
++	      grub_menu_set_timeout(initial_timeout_value);
++	      menu_print_timeout (initial_timeout_value);
+ 	    }
+ 
+ 	  switch (c)
+-- 
+2.25.1
+

--- a/pkg/grub/patches.2.06/0006-Add-dt-fixup-efi-protocol.patch
+++ b/pkg/grub/patches.2.06/0006-Add-dt-fixup-efi-protocol.patch
@@ -1,0 +1,131 @@
+From 2d8f010c5308c00f394b9c66b288f4c9d79df09b Mon Sep 17 00:00:00 2001
+From: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>
+Date: Thu, 14 Oct 2021 11:44:37 +0530
+Subject: [PATCH 6/8] Add dt-fixup efi protocol
+
+Signed-off-by: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>
+Signed-off-by: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>
+---
+ grub-core/loader/efi/fdt.c | 37 ++++++++++++++++++++++++++++++++++++-
+ include/grub/efi/api.h     | 22 ++++++++++++++++++++++
+ 2 files changed, 58 insertions(+), 1 deletion(-)
+
+diff --git a/grub-core/loader/efi/fdt.c b/grub-core/loader/efi/fdt.c
+index c86f283d7..2c067c565 100644
+--- a/grub-core/loader/efi/fdt.c
++++ b/grub-core/loader/efi/fdt.c
+@@ -29,6 +29,7 @@
+ 
+ static void *loaded_fdt;
+ static void *fdt;
++static grub_efi_guid_t dt_fixup_guid = GRUB_EFI_DT_FIXUP_PROTOCOL_GUID;
+ 
+ #define FDT_ADDR_CELLS_STRING "#address-cells"
+ #define FDT_SIZE_CELLS_STRING "#size-cells"
+@@ -36,6 +37,39 @@ static void *fdt;
+                              sizeof (FDT_ADDR_CELLS_STRING) + \
+                              sizeof (FDT_SIZE_CELLS_STRING))
+ 
++
++static void *grub_fdt_fixup (void)
++{
++  grub_efi_dt_fixup_t *dt_fixup_prot;
++  grub_efi_uintn_t size = 0;
++  grub_efi_status_t status;
++  void *fixup_fdt;
++
++  dt_fixup_prot = grub_efi_locate_protocol (&dt_fixup_guid, 0);
++  if (! dt_fixup_prot)
++    return loaded_fdt;
++
++  grub_dprintf ("linux", "EFI_DT_FIXUP_PROTOCOL available\n");
++
++  status = efi_call_4 (dt_fixup_prot->fixup, dt_fixup_prot, loaded_fdt, &size,
++		       GRUB_EFI_DT_APPLY_FIXUPS | GRUB_EFI_DT_RESERVE_MEMORY);
++  if (status != GRUB_EFI_BUFFER_TOO_SMALL)
++    return loaded_fdt;
++
++  fixup_fdt = grub_realloc (loaded_fdt, size);
++  if (!fixup_fdt)
++    return loaded_fdt;
++  loaded_fdt = fixup_fdt;
++
++  status = efi_call_4 (dt_fixup_prot->fixup, dt_fixup_prot, loaded_fdt, &size,
++		       GRUB_EFI_DT_APPLY_FIXUPS | GRUB_EFI_DT_RESERVE_MEMORY);
++
++  if (status == GRUB_EFI_SUCCESS)
++    grub_dprintf ("linux", "Device tree fixed up via EFI_DT_FIXUP_PROTOCOL\n");
++
++  return loaded_fdt;
++}
++
+ void *
+ grub_fdt_load (grub_size_t additional_size)
+ {
+@@ -49,7 +83,7 @@ grub_fdt_load (grub_size_t additional_size)
+     }
+ 
+   if (loaded_fdt)
+-    raw_fdt = loaded_fdt;
++    raw_fdt = grub_fdt_fixup();
+   else
+     raw_fdt = grub_efi_get_firmware_fdt();
+ 
+@@ -65,6 +99,7 @@ grub_fdt_load (grub_size_t additional_size)
+ 				      GRUB_EFI_BYTES_TO_PAGES (size),
+ 				      GRUB_EFI_ALLOCATE_MAX_ADDRESS,
+ 				      GRUB_EFI_ACPI_RECLAIM_MEMORY);
++
+   if (!fdt)
+     return NULL;
+ 
+diff --git a/include/grub/efi/api.h b/include/grub/efi/api.h
+index f1a52210c..8a3263db9 100644
+--- a/include/grub/efi/api.h
++++ b/include/grub/efi/api.h
+@@ -339,6 +339,11 @@
+     { 0x83, 0x0b, 0xd9, 0x15, 0x2c, 0x69, 0xaa, 0xe0 } \
+   }
+ 
++#define GRUB_EFI_DT_FIXUP_PROTOCOL_GUID \
++  { 0xe617d64c, 0xfe08, 0x46da, \
++    { 0xf4, 0xdc, 0xbb, 0xd5, 0x87, 0x0c, 0x73, 0x00 } \
++  }
++
+ #define GRUB_EFI_VENDOR_APPLE_GUID \
+   { 0x2B0585EB, 0xD8B8, 0x49A9,	\
+     { 0x8B, 0x8C, 0xE2, 0x1B, 0x01, 0xAE, 0xF2, 0xB7 } \
+@@ -1646,6 +1651,13 @@ enum
+     GRUB_EFI_SIMPLE_NETWORK_RECEIVE_PROMISCUOUS_MULTICAST = 0x10,
+   };
+ 
++enum
++  {
++    GRUB_EFI_DT_APPLY_FIXUPS		= 0x01,
++    GRUB_EFI_DT_RESERVE_MEMORY		= 0x02,
++    GRUB_EFI_EFI_DT_INSTALL_TABLE	= 0x04,
++  };
++
+ struct grub_efi_simple_network
+ {
+   grub_uint64_t revision;
+@@ -1729,6 +1741,16 @@ struct grub_efi_rng_protocol
+ };
+ typedef struct grub_efi_rng_protocol grub_efi_rng_protocol_t;
+ 
++struct grub_efi_dt_fixup
++{
++  grub_efi_uint64_t revision;
++  grub_efi_status_t (*fixup) (struct grub_efi_dt_fixup *this,
++			      void *fdt,
++			      grub_efi_uintn_t *buffer_size,
++			      grub_uint32_t flags);
++};
++typedef struct grub_efi_dt_fixup grub_efi_dt_fixup_t;
++
+ #if (GRUB_TARGET_SIZEOF_VOID_P == 4) || defined (__ia64__) \
+   || defined (__aarch64__) || defined (__MINGW64__) || defined (__CYGWIN__) \
+   || defined(__riscv)
+-- 
+2.25.1
+

--- a/pkg/grub/patches.2.06/0007-Making-it-possible-to-export-variables-from-inner-co.patch
+++ b/pkg/grub/patches.2.06/0007-Making-it-possible-to-export-variables-from-inner-co.patch
@@ -1,0 +1,39 @@
+From 018f26b947f2dc03b2acbadf35edacabbff96107 Mon Sep 17 00:00:00 2001
+From: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>
+Date: Tue, 26 Oct 2021 22:18:49 +0530
+Subject: [PATCH 7/8] Making it possible to export variables from inner
+ contexts of GRUB
+
+Signed-off-by: Roman Shaposhnik <rvs@zededa.com>
+---
+ grub-core/normal/context.c | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/grub-core/normal/context.c b/grub-core/normal/context.c
+index ee53d4a68..67737b127 100644
+--- a/grub-core/normal/context.c
++++ b/grub-core/normal/context.c
+@@ -129,6 +129,20 @@ grub_env_context_close (void)
+ 
+       for (p = grub_current_context->vars[i]; p; p = q)
+ 	{
++	  if (p->global)
++	    {
++	      /* Set and export all global variables inside
++		 the calling/previous context.  */
++	      struct grub_env_context *tmp_context = grub_current_context;
++	      grub_current_context = grub_current_context->prev;
++	      if (grub_env_set (p->name, p->value) == GRUB_ERR_NONE)
++		{
++		  grub_env_export (p->name);
++		  grub_register_variable_hook (p->name, p->read_hook, p->write_hook);
++		}
++	      grub_current_context = tmp_context;
++	    }
++
+ 	  q = p->next;
+           grub_free (p->name);
+ 	  grub_free (p->value);
+-- 
+2.25.1
+

--- a/pkg/grub/patches.2.06/0008-Adding-a-capability-of-a-GRUB-cat-command-to-deposit.patch
+++ b/pkg/grub/patches.2.06/0008-Adding-a-capability-of-a-GRUB-cat-command-to-deposit.patch
@@ -1,0 +1,64 @@
+From 7118a97f119f98ab208518cc70697861287a2676 Mon Sep 17 00:00:00 2001
+From: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>
+Date: Tue, 26 Oct 2021 22:22:13 +0530
+Subject: [PATCH 8/8] Adding a capability of a GRUB cat command to deposit to a
+ var, not stdout
+
+Signed-off-by: Roman Shaposhnik <rvs@zededa.com>
+---
+ grub-core/commands/cat.c | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
+
+diff --git a/grub-core/commands/cat.c b/grub-core/commands/cat.c
+index ba5f0061a..9333667ac 100644
+--- a/grub-core/commands/cat.c
++++ b/grub-core/commands/cat.c
+@@ -20,6 +20,7 @@
+ #include <grub/dl.h>
+ #include <grub/file.h>
+ #include <grub/disk.h>
++#include <grub/env.h>
+ #include <grub/term.h>
+ #include <grub/misc.h>
+ #include <grub/extcmd.h>
+@@ -31,6 +32,7 @@ GRUB_MOD_LICENSE ("GPLv3+");
+ static const struct grub_arg_option options[] =
+   {
+     {"dos", -1, 0, N_("Accept DOS-style CR/NL line endings."), 0, 0},
++    {"set", 's', 0, N_("Read content of the file into a variable."), N_("VARNAME"), ARG_TYPE_STRING },
+     {0, 0, 0, 0, 0, 0}
+   };
+ 
+@@ -60,6 +62,20 @@ grub_cmd_cat (grub_extcmd_context_t ctxt, int argc, char **args)
+   if (! file)
+     return grub_errno;
+ 
++  if (ctxt->state[1].set) {
++    size = grub_file_read (file, buf, sizeof (buf));
++    if (size < 0 || (grub_size_t)size >= sizeof (buf)) {
++      return grub_error (GRUB_ERR_BAD_ARGUMENT, N_("can't read more than disk block size into variable"));
++    }
++    buf[size]='\0';
++    for (;size;size--) {
++      if (buf[size] == '\n' || buf[size] == '\r')
++        buf[size]=0;
++    }
++    grub_env_set(ctxt->state[1].arg, (const char *)buf);
++    goto exit;
++  }
++
+   while ((size = grub_file_read (file, buf, sizeof (buf))) > 0
+ 	 && key != GRUB_TERM_ESC)
+     {
+@@ -150,6 +166,8 @@ grub_cmd_cat (grub_extcmd_context_t ctxt, int argc, char **args)
+ 
+   grub_xputs ("\n");
+   grub_refresh ();
++
++exit:
+   grub_file_close (file);
+ 
+   return 0;
+-- 
+2.25.1
+

--- a/pkg/grub/patches.riscv64.2.06/0001-Linux-loading-on-riscv64.patch
+++ b/pkg/grub/patches.riscv64.2.06/0001-Linux-loading-on-riscv64.patch
@@ -1,7 +1,7 @@
 From 6370d7fdeedc0ccbfaf5c3cb0822f70c9c5bfcda Mon Sep 17 00:00:00 2001
 From: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>
 Date: Thu, 14 Oct 2021 14:05:14 +0530
-Subject: [PATCH 1/3] Linux loading on riscv64
+Subject: [PATCH 1/6] Linux loading on riscv64
 
 Signed-off-by: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>
 ---

--- a/pkg/grub/patches.riscv64.2.06/0001-Linux-loading-on-riscv64.patch
+++ b/pkg/grub/patches.riscv64.2.06/0001-Linux-loading-on-riscv64.patch
@@ -1,0 +1,450 @@
+From 6370d7fdeedc0ccbfaf5c3cb0822f70c9c5bfcda Mon Sep 17 00:00:00 2001
+From: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>
+Date: Thu, 14 Oct 2021 14:05:14 +0530
+Subject: [PATCH 1/3] Linux loading on riscv64
+
+Signed-off-by: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>
+---
+ grub-core/Makefile.core.def                 |   4 +-
+ grub-core/loader/{riscv => riscv32}/linux.c |   0
+ grub-core/loader/riscv64/linux.c            | 380 ++++++++++++++++++++
+ include/grub/riscv32/linux.h                |   2 +-
+ include/grub/riscv64/linux.h                |   2 +-
+ 5 files changed, 384 insertions(+), 4 deletions(-)
+ rename grub-core/loader/{riscv => riscv32}/linux.c (100%)
+ create mode 100644 grub-core/loader/riscv64/linux.c
+
+diff --git a/grub-core/Makefile.core.def b/grub-core/Makefile.core.def
+index 8022e1c0a..655a45de7 100644
+--- a/grub-core/Makefile.core.def
++++ b/grub-core/Makefile.core.def
+@@ -1809,8 +1809,8 @@ module = {
+   arm_efi = loader/arm64/linux.c;
+   arm_uboot = loader/arm/linux.c;
+   arm64 = loader/arm64/linux.c;
+-  riscv32 = loader/riscv/linux.c;
+-  riscv64 = loader/riscv/linux.c;
++  riscv32 = loader/riscv32/linux.c;
++  riscv64 = loader/riscv64/linux.c;
+   common = loader/linux.c;
+   common = lib/cmdline.c;
+   enable = noemu;
+diff --git a/grub-core/loader/riscv/linux.c b/grub-core/loader/riscv32/linux.c
+similarity index 100%
+rename from grub-core/loader/riscv/linux.c
+rename to grub-core/loader/riscv32/linux.c
+diff --git a/grub-core/loader/riscv64/linux.c b/grub-core/loader/riscv64/linux.c
+new file mode 100644
+index 000000000..630015495
+--- /dev/null
++++ b/grub-core/loader/riscv64/linux.c
+@@ -0,0 +1,380 @@
++/*
++ *  GRUB  --  GRand Unified Bootloader
++ *  Copyright (C) 2018  Free Software Foundation, Inc.
++ *
++ *  GRUB is free software: you can redistribute it and/or modify
++ *  it under the terms of the GNU General Public License as published by
++ *  the Free Software Foundation, either version 3 of the License, or
++ *  (at your option) any later version.
++ *
++ *  GRUB is distributed in the hope that it will be useful,
++ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *  GNU General Public License for more details.
++ *
++ *  You should have received a copy of the GNU General Public License
++ *  along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++#include <grub/charset.h>
++#include <grub/command.h>
++#include <grub/err.h>
++#include <grub/file.h>
++#include <grub/fdt.h>
++#include <grub/linux.h>
++#include <grub/loader.h>
++#include <grub/mm.h>
++#include <grub/types.h>
++#include <grub/cpu/linux.h>
++#include <grub/efi/efi.h>
++#include <grub/efi/fdtload.h>
++#include <grub/efi/memory.h>
++#include <grub/efi/pe32.h>
++#include <grub/i18n.h>
++#include <grub/lib/cmdline.h>
++#include <grub/verify.h>
++
++GRUB_MOD_LICENSE ("GPLv3+");
++
++static grub_dl_t my_mod;
++static int loaded;
++
++static void *kernel_addr;
++static grub_uint64_t kernel_size;
++
++static char *linux_args;
++static grub_uint32_t cmdline_size;
++
++static grub_addr_t initrd_start;
++static grub_addr_t initrd_end;
++
++grub_err_t
++grub_arch_efi_linux_check_image (struct linux_arch_kernel_header * lh)
++{
++  if (lh->magic != GRUB_LINUX_RISCV_MAGIC_SIGNATURE)
++    return grub_error(GRUB_ERR_BAD_OS, "invalid magic number");
++
++  if ((lh->code0 & 0xffff) != GRUB_PE32_MAGIC)
++    return grub_error (GRUB_ERR_NOT_IMPLEMENTED_YET,
++                       N_("plain image kernel not supported - rebuild with CONFIG_(U)EFI_STUB enabled"));
++
++  grub_dprintf ("linux", "UEFI stub kernel:\n");
++  grub_dprintf ("linux", "PE/COFF header @ %08x\n", lh->hdr_offset);
++
++  return GRUB_ERR_NONE;
++}
++
++static grub_err_t
++finalize_params_linux (void)
++{
++  int node, retval;
++
++  void *fdt;
++
++  fdt = grub_fdt_load (GRUB_EFI_LINUX_FDT_EXTRA_SPACE);
++
++  if (!fdt)
++    goto failure;
++
++  node = grub_fdt_find_subnode (fdt, 0, "chosen");
++  if (node < 0)
++    node = grub_fdt_add_subnode (fdt, 0, "chosen");
++
++  if (node < 1)
++    goto failure;
++
++  /* Set initrd info */
++  if (initrd_start && initrd_end > initrd_start)
++    {
++      grub_dprintf ("linux", "Initrd @ %p-%p\n",
++                    (void *) initrd_start, (void *) initrd_end);
++
++      retval = grub_fdt_set_prop64 (fdt, node, "linux,initrd-start",
++                                    initrd_start);
++      if (retval)
++        goto failure;
++      retval = grub_fdt_set_prop64 (fdt, node, "linux,initrd-end",
++                                    initrd_end);
++      if (retval)
++        goto failure;
++    }
++
++  if (grub_fdt_install() != GRUB_ERR_NONE)
++    goto failure;
++
++  return GRUB_ERR_NONE;
++
++failure:
++  grub_fdt_unload();
++  return grub_error(GRUB_ERR_BAD_OS, "failed to install/update FDT");
++}
++
++grub_err_t
++grub_arch_efi_linux_boot_image (grub_addr_t addr, grub_size_t size, char *args)
++{
++  grub_efi_loaded_image_t *loaded_image = NULL;
++  grub_efi_memory_mapped_device_path_t *mempath;
++  grub_efi_handle_t image_handle;
++  grub_efi_boot_services_t *b;
++  grub_efi_status_t status;
++  int len;
++
++  mempath = grub_malloc (2 * sizeof (grub_efi_memory_mapped_device_path_t));
++  if (!mempath)
++    return grub_errno;
++
++  mempath[0].header.type = GRUB_EFI_HARDWARE_DEVICE_PATH_TYPE;
++  mempath[0].header.subtype = GRUB_EFI_MEMORY_MAPPED_DEVICE_PATH_SUBTYPE;
++  mempath[0].header.length = grub_cpu_to_le16_compile_time (sizeof (*mempath));
++  mempath[0].memory_type = GRUB_EFI_LOADER_DATA;
++  mempath[0].start_address = addr;
++  mempath[0].end_address = addr + size;
++
++  mempath[1].header.type = GRUB_EFI_END_DEVICE_PATH_TYPE;
++  mempath[1].header.subtype = GRUB_EFI_END_ENTIRE_DEVICE_PATH_SUBTYPE;
++  mempath[1].header.length = sizeof (grub_efi_device_path_t);
++
++  b = grub_efi_system_table->boot_services;
++  status = b->load_image (0, grub_efi_image_handle,
++                          (grub_efi_device_path_t *) mempath,
++                          (void *) addr, size, &image_handle);
++  if (status != GRUB_EFI_SUCCESS)
++    return grub_error (GRUB_ERR_BAD_OS, "cannot load image");
++
++  grub_dprintf ("linux", "linux command line: '%s'\n", args);
++
++  /* Convert command line to UCS-2 */
++  loaded_image = grub_efi_get_loaded_image (image_handle);
++  if (!loaded_image)
++    return grub_error(GRUB_ERR_BAD_OS, "cannot get image");
++  loaded_image->load_options_size = len =
++    (grub_strlen (args) + 1) * sizeof (grub_efi_char16_t);
++  loaded_image->load_options =
++    grub_efi_allocate_any_pages (GRUB_EFI_BYTES_TO_PAGES (loaded_image->load_options_size));
++  if (!loaded_image->load_options)
++    return grub_errno;
++
++  loaded_image->load_options_size =
++    2 * grub_utf8_to_utf16 (loaded_image->load_options, len,
++                            (grub_uint8_t *) args, len, NULL);
++
++  grub_dprintf ("linux", "starting image %p\n", image_handle);
++  status = b->start_image (image_handle, 0, NULL);
++
++  /* When successful, not reached */
++  b->unload_image (image_handle);
++  grub_efi_free_pages ((grub_addr_t) loaded_image->load_options,
++                       GRUB_EFI_BYTES_TO_PAGES (loaded_image->load_options_size));
++
++  return grub_errno;
++}
++
++static grub_err_t
++grub_linux_boot (void)
++{
++  if (finalize_params_linux () != GRUB_ERR_NONE)
++    return grub_errno;
++
++  return (grub_arch_efi_linux_boot_image((grub_addr_t)kernel_addr,
++                                         kernel_size, linux_args));
++}
++
++static grub_err_t
++grub_linux_unload (void)
++{
++  grub_dl_unref (my_mod);
++  loaded = 0;
++  if (initrd_start)
++    grub_efi_free_pages ((grub_efi_physical_address_t) initrd_start,
++                         GRUB_EFI_BYTES_TO_PAGES (initrd_end - initrd_start));
++  initrd_start = initrd_end = 0;
++  grub_free (linux_args);
++  if (kernel_addr)
++    grub_efi_free_pages ((grub_addr_t) kernel_addr,
++                         GRUB_EFI_BYTES_TO_PAGES (kernel_size));
++  grub_fdt_unload ();
++  return GRUB_ERR_NONE;
++}
++
++/* According to the Linux arch/riscv/include/asm/efi.h */
++#define INITRD_MAX_ADDRESS_OFFSET (256ULL << 20)
++
++/*
++ * This function returns a pointer to a legally allocated initrd buffer,
++ * or NULL if unsuccessful
++ */
++static void *
++allocate_initrd_mem (int initrd_pages)
++{
++  grub_addr_t max_addr;
++
++  if (grub_efi_get_ram_base (&max_addr) != GRUB_ERR_NONE)
++    return NULL;
++
++  max_addr += INITRD_MAX_ADDRESS_OFFSET - 1;
++
++  return grub_efi_allocate_pages_real (max_addr, initrd_pages,
++                                       GRUB_EFI_ALLOCATE_MAX_ADDRESS,
++                                       GRUB_EFI_LOADER_DATA);
++}
++
++static grub_err_t
++grub_cmd_initrd (grub_command_t cmd __attribute__ ((unused)),
++                 int argc, char *argv[])
++{
++  struct grub_linux_initrd_context initrd_ctx = { 0, 0, 0 };
++  int initrd_size, initrd_pages;
++  void *initrd_mem = NULL;
++
++  if (argc == 0)
++    {
++      grub_error (GRUB_ERR_BAD_ARGUMENT, N_("filename expected"));
++      goto fail;
++    }
++
++  if (!loaded)
++    {
++      grub_error (GRUB_ERR_BAD_ARGUMENT,
++                  N_("you need to load the kernel first"));
++      goto fail;
++    }
++
++  if (grub_initrd_init (argc, argv, &initrd_ctx))
++    goto fail;
++
++  initrd_size = grub_get_initrd_size (&initrd_ctx);
++  grub_dprintf ("linux", "Loading initrd\n");
++
++  initrd_pages = (GRUB_EFI_BYTES_TO_PAGES (initrd_size));
++  initrd_mem = allocate_initrd_mem (initrd_pages);
++
++  if (!initrd_mem)
++    {
++      grub_error (GRUB_ERR_OUT_OF_MEMORY, N_("out of memory"));
++      goto fail;
++    }
++
++  if (grub_initrd_load (&initrd_ctx, argv, initrd_mem))
++    goto fail;
++
++  initrd_start = (grub_addr_t) initrd_mem;
++  initrd_end = initrd_start + initrd_size;
++  grub_dprintf ("linux", "[addr=%p, size=0x%x]\n",
++                (void *) initrd_start, initrd_size);
++
++fail:
++  grub_initrd_close (&initrd_ctx);
++  if (initrd_mem && !initrd_start)
++    grub_efi_free_pages ((grub_addr_t) initrd_mem, initrd_pages);
++
++  return grub_errno;
++}
++
++static grub_err_t
++grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
++                int argc, char *argv[])
++{
++  grub_file_t file = 0;
++  struct linux_arch_kernel_header lh;
++  grub_err_t err;
++
++  grub_dl_ref (my_mod);
++
++  if (argc == 0)
++    {
++      grub_error (GRUB_ERR_BAD_ARGUMENT, N_("filename expected"));
++      goto fail;
++    }
++
++  file = grub_file_open (argv[0], GRUB_FILE_TYPE_LINUX_KERNEL);
++  if (!file)
++    goto fail;
++
++  kernel_size = grub_file_size (file);
++
++  if (grub_file_read (file, &lh, sizeof (lh)) < (long) sizeof (lh))
++    return grub_errno;
++
++  if (grub_arch_efi_linux_check_image (&lh) != GRUB_ERR_NONE)
++    goto fail;
++
++  grub_loader_unset();
++
++  grub_dprintf ("linux", "kernel file size: %lld\n", (long long) kernel_size);
++  kernel_addr = grub_efi_allocate_any_pages (GRUB_EFI_BYTES_TO_PAGES (kernel_size));
++  grub_dprintf ("linux", "kernel numpages: %lld\n",
++                (long long) GRUB_EFI_BYTES_TO_PAGES (kernel_size));
++  if (!kernel_addr)
++    {
++      grub_error (GRUB_ERR_OUT_OF_MEMORY, N_("out of memory"));
++      goto fail;
++    }
++
++  grub_file_seek (file, 0);
++  if (grub_file_read (file, kernel_addr, kernel_size)
++      < (grub_int64_t) kernel_size)
++    {
++      if (!grub_errno)
++        grub_error (GRUB_ERR_BAD_OS, N_("premature end of file %s"), argv[0]);
++      goto fail;
++    }
++
++  grub_dprintf ("linux", "kernel @ %p\n", kernel_addr);
++
++  cmdline_size = grub_loader_cmdline_size (argc, argv) + sizeof (LINUX_IMAGE);
++  linux_args = grub_malloc (cmdline_size);
++  if (!linux_args)
++    {
++      grub_error (GRUB_ERR_OUT_OF_MEMORY, N_("out of memory"));
++      goto fail;
++    }
++  grub_memcpy (linux_args, LINUX_IMAGE, sizeof (LINUX_IMAGE));
++  err = grub_create_loader_cmdline (argc, argv,
++                                    linux_args + sizeof (LINUX_IMAGE) - 1,
++                                    cmdline_size,
++                                    GRUB_VERIFY_KERNEL_CMDLINE);
++  if (err)
++    goto fail;
++
++  if (grub_errno == GRUB_ERR_NONE)
++    {
++      grub_loader_set (grub_linux_boot, grub_linux_unload, 0);
++      loaded = 1;
++    }
++
++fail:
++  if (file)
++    grub_file_close (file);
++
++  if (grub_errno != GRUB_ERR_NONE)
++    {
++      grub_dl_unref (my_mod);
++      loaded = 0;
++    }
++
++  if (linux_args && !loaded)
++    grub_free (linux_args);
++
++  if (kernel_addr && !loaded)
++    grub_efi_free_pages ((grub_addr_t) kernel_addr,
++                         GRUB_EFI_BYTES_TO_PAGES (kernel_size));
++
++  return grub_errno;
++}
++
++static grub_command_t cmd_linux, cmd_initrd;
++
++GRUB_MOD_INIT (linux)
++{
++  cmd_linux = grub_register_command ("linux", grub_cmd_linux, 0,
++                                     N_("Load Linux."));
++  cmd_initrd = grub_register_command ("initrd", grub_cmd_initrd, 0,
++                                      N_("Load initrd."));
++  my_mod = mod;
++}
++
++GRUB_MOD_FINI (linux)
++{
++  grub_unregister_command (cmd_linux);
++  grub_unregister_command (cmd_initrd);
++}
+diff --git a/include/grub/riscv32/linux.h b/include/grub/riscv32/linux.h
+index 512b777c8..bb4ceb5bb 100644
+--- a/include/grub/riscv32/linux.h
++++ b/include/grub/riscv32/linux.h
+@@ -19,7 +19,7 @@
+ #ifndef GRUB_RISCV32_LINUX_HEADER
+ #define GRUB_RISCV32_LINUX_HEADER 1
+ 
+-#define GRUB_LINUX_RISCV_MAGIC_SIGNATURE 0x52534356 /* 'RSCV' */
++#define GRUB_LINUX_RISCV_MAGIC_SIGNATURE 0x05435352 /* little endian, 'RSC\x05' */
+ 
+ /* From linux/Documentation/riscv/booting.txt */
+ struct linux_riscv_kernel_header
+diff --git a/include/grub/riscv64/linux.h b/include/grub/riscv64/linux.h
+index 3630c30fb..9d9e05190 100644
+--- a/include/grub/riscv64/linux.h
++++ b/include/grub/riscv64/linux.h
+@@ -19,7 +19,7 @@
+ #ifndef GRUB_RISCV64_LINUX_HEADER
+ #define GRUB_RISCV64_LINUX_HEADER 1
+ 
+-#define GRUB_LINUX_RISCV_MAGIC_SIGNATURE 0x52534356 /* 'RSCV' */
++#define GRUB_LINUX_RISCV_MAGIC_SIGNATURE 0x05435352 /* little endian, 'RSC\x05' */
+ 
+ #define GRUB_EFI_PE_MAGIC	0x5A4D
+ 
+-- 
+2.25.1
+

--- a/pkg/grub/patches.riscv64.2.06/0002-Add-gpt-module.patch
+++ b/pkg/grub/patches.riscv64.2.06/0002-Add-gpt-module.patch
@@ -1,0 +1,1073 @@
+From 681b7079898e60e8596f7ab0b938ad2a0623a5dd Mon Sep 17 00:00:00 2001
+From: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>
+Date: Thu, 14 Oct 2021 14:39:34 +0530
+Subject: [PATCH 2/3] Add gpt module
+
+Signed-off-by: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>
+---
+ grub-core/Makefile.core.def  |   5 +
+ grub-core/lib/gpt.c          | 777 +++++++++++++++++++++++++++++++++++
+ include/grub/gpt_partition.h | 213 +++++++++-
+ 3 files changed, 978 insertions(+), 17 deletions(-)
+ create mode 100644 grub-core/lib/gpt.c
+
+diff --git a/grub-core/Makefile.core.def b/grub-core/Makefile.core.def
+index 655a45de7..672523a22 100644
+--- a/grub-core/Makefile.core.def
++++ b/grub-core/Makefile.core.def
+@@ -897,6 +897,11 @@ module = {
+   common = commands/gptsync.c;
+ };
+ 
++module = {
++  name = gpt;
++  common = lib/gpt.c;
++};
++
+ module = {
+   name = halt;
+   nopc = commands/halt.c;
+diff --git a/grub-core/lib/gpt.c b/grub-core/lib/gpt.c
+new file mode 100644
+index 000000000..ac71ba712
+--- /dev/null
++++ b/grub-core/lib/gpt.c
+@@ -0,0 +1,777 @@
++/* gpt.c - Read/Verify/Write GUID Partition Tables (GPT).  */
++/*
++ *  GRUB  --  GRand Unified Bootloader
++ *  Copyright (C) 2002,2005,2006,2007,2008  Free Software Foundation, Inc.
++ *  Copyright (C) 2014 CoreOS, Inc.
++ *
++ *  GRUB is free software: you can redistribute it and/or modify
++ *  it under the terms of the GNU General Public License as published by
++ *  the Free Software Foundation, either version 3 of the License, or
++ *  (at your option) any later version.
++ *
++ *  GRUB is distributed in the hope that it will be useful,
++ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *  GNU General Public License for more details.
++ *
++ *  You should have received a copy of the GNU General Public License
++ *  along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++#include <grub/charset.h>
++#include <grub/crypto.h>
++#include <grub/device.h>
++#include <grub/disk.h>
++#include <grub/misc.h>
++#include <grub/mm.h>
++#include <grub/dl.h>
++#include <grub/msdos_partition.h>
++#include <grub/gpt_partition.h>
++
++GRUB_MOD_LICENSE ("GPLv3+");
++
++static grub_uint8_t grub_gpt_magic[] = GRUB_GPT_HEADER_MAGIC;
++
++static grub_err_t
++grub_gpt_read_entries (grub_disk_t disk, grub_gpt_t gpt,
++		       struct grub_gpt_header *header,
++		       void **ret_entries,
++		       grub_size_t *ret_entries_size);
++
++char *
++grub_gpt_part_guid_to_str (grub_gpt_part_guid_t *guid)
++{
++  return grub_xasprintf ("%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x",
++			 grub_le_to_cpu32 (guid->data1),
++			 grub_le_to_cpu16 (guid->data2),
++			 grub_le_to_cpu16 (guid->data3),
++			 guid->data4[0], guid->data4[1],
++			 guid->data4[2], guid->data4[3],
++			 guid->data4[4], guid->data4[5],
++			 guid->data4[6], guid->data4[7]);
++}
++
++static grub_err_t
++grub_gpt_device_partentry (grub_device_t device,
++			   struct grub_gpt_partentry *entry)
++{
++  grub_disk_t disk = device->disk;
++  grub_partition_t p;
++  grub_err_t err;
++
++  if (!disk || !disk->partition)
++    return grub_error (GRUB_ERR_BUG, "not a partition");
++
++  if (grub_strcmp (disk->partition->partmap->name, "gpt"))
++    return grub_error (GRUB_ERR_BAD_ARGUMENT, "not a GPT partition");
++
++  p = disk->partition;
++  disk->partition = p->parent;
++  err = grub_disk_read (disk, p->offset, p->index, sizeof (*entry), entry);
++  disk->partition = p;
++
++  return err;
++}
++
++grub_err_t
++grub_gpt_part_label (grub_device_t device, char **label)
++{
++  struct grub_gpt_partentry entry;
++  const grub_size_t name_len = ARRAY_SIZE (entry.name);
++  const grub_size_t label_len = name_len * GRUB_MAX_UTF8_PER_UTF16 + 1;
++  grub_size_t i;
++  grub_uint8_t *end;
++
++  if (grub_gpt_device_partentry (device, &entry))
++    return grub_errno;
++
++  *label = grub_malloc (label_len);
++  if (!*label)
++    return grub_errno;
++
++  for (i = 0; i < name_len; i++)
++    entry.name[i] = grub_le_to_cpu16 (entry.name[i]);
++
++  end = grub_utf16_to_utf8 ((grub_uint8_t *) *label, entry.name, name_len);
++  *end = '\0';
++
++  return GRUB_ERR_NONE;
++}
++
++grub_err_t
++grub_gpt_part_uuid (grub_device_t device, char **uuid)
++{
++  struct grub_gpt_partentry entry;
++
++  if (grub_gpt_device_partentry (device, &entry))
++    return grub_errno;
++
++  *uuid = grub_gpt_part_guid_to_str (&entry.guid);
++  if (!*uuid)
++    return grub_errno;
++
++  return GRUB_ERR_NONE;
++}
++
++static struct grub_gpt_header *
++grub_gpt_get_header (grub_gpt_t gpt)
++{
++  if (gpt->status & GRUB_GPT_PRIMARY_HEADER_VALID)
++    return &gpt->primary;
++  else if (gpt->status & GRUB_GPT_BACKUP_HEADER_VALID)
++    return &gpt->backup;
++
++  grub_error (GRUB_ERR_BUG, "No valid GPT header");
++  return NULL;
++}
++
++grub_err_t
++grub_gpt_disk_uuid (grub_device_t device, char **uuid)
++{
++  struct grub_gpt_header *header;
++
++  grub_gpt_t gpt = grub_gpt_read (device->disk);
++  if (!gpt)
++    goto done;
++
++  header = grub_gpt_get_header (gpt);
++  if (!header)
++    goto done;
++
++  *uuid = grub_gpt_part_guid_to_str (&header->guid);
++
++done:
++  grub_gpt_free (gpt);
++  return grub_errno;
++}
++
++static grub_uint64_t
++grub_gpt_size_to_sectors (grub_gpt_t gpt, grub_size_t size)
++{
++  unsigned int sector_size;
++  grub_uint64_t sectors;
++
++  sector_size = 1U << gpt->log_sector_size;
++  sectors = size / sector_size;
++  if (size % sector_size)
++    sectors++;
++
++  return sectors;
++}
++
++/* Copied from grub-core/kern/disk_common.c grub_disk_adjust_range so we can
++ * avoid attempting to use disk->total_sectors when GRUB won't let us.
++ * TODO: Why is disk->total_sectors not set to GRUB_DISK_SIZE_UNKNOWN?  */
++static int
++grub_gpt_disk_size_valid (grub_disk_t disk)
++{
++  grub_disk_addr_t total_sectors;
++
++  /* Transform total_sectors to number of 512B blocks.  */
++  total_sectors = disk->total_sectors << (disk->log_sector_size - GRUB_DISK_SECTOR_BITS);
++
++  /* Some drivers have problems with disks above reasonable.
++     Treat unknown as 1EiB disk. While on it, clamp the size to 1EiB.
++     Just one condition is enough since GRUB_DISK_UNKNOWN_SIZE << ls is always
++     above 9EiB.
++  */
++  if (total_sectors > (1ULL << 51))
++    return 0;
++
++  return 1;
++}
++
++static void
++grub_gpt_lecrc32 (grub_uint32_t *crc, const void *data, grub_size_t len)
++{
++  grub_uint32_t crc32_val;
++
++  grub_crypto_hash (GRUB_MD_CRC32, &crc32_val, data, len);
++
++  /* GRUB_MD_CRC32 always uses big endian, gpt is always little.  */
++  *crc = grub_swap_bytes32 (crc32_val);
++}
++
++static void
++grub_gpt_header_lecrc32 (grub_uint32_t *crc, struct grub_gpt_header *header)
++{
++  grub_uint32_t old, new;
++
++  /* crc32 must be computed with the field cleared.  */
++  old = header->crc32;
++  header->crc32 = 0;
++  grub_gpt_lecrc32 (&new, header, sizeof (*header));
++  header->crc32 = old;
++
++  *crc = new;
++}
++
++/* Make sure the MBR is a protective MBR and not a normal MBR.  */
++grub_err_t
++grub_gpt_pmbr_check (struct grub_msdos_partition_mbr *mbr)
++{
++  unsigned int i;
++
++  if (mbr->signature !=
++      grub_cpu_to_le16_compile_time (GRUB_PC_PARTITION_SIGNATURE))
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "invalid MBR signature");
++
++  for (i = 0; i < sizeof (mbr->entries); i++)
++    if (mbr->entries[i].type == GRUB_PC_PARTITION_TYPE_GPT_DISK)
++      return GRUB_ERR_NONE;
++
++  return grub_error (GRUB_ERR_BAD_PART_TABLE, "invalid protective MBR");
++}
++
++static grub_uint64_t
++grub_gpt_entries_size (struct grub_gpt_header *gpt)
++{
++  return (grub_uint64_t) grub_le_to_cpu32 (gpt->maxpart) *
++         (grub_uint64_t) grub_le_to_cpu32 (gpt->partentry_size);
++}
++
++static grub_uint64_t
++grub_gpt_entries_sectors (struct grub_gpt_header *gpt,
++			  unsigned int log_sector_size)
++{
++  grub_uint64_t sector_bytes, entries_bytes;
++
++  sector_bytes = 1ULL << log_sector_size;
++  entries_bytes = grub_gpt_entries_size (gpt);
++  return grub_divmod64(entries_bytes + sector_bytes - 1, sector_bytes, NULL);
++}
++
++static int
++is_pow2 (grub_uint32_t n)
++{
++  return (n & (n - 1)) == 0;
++}
++
++grub_err_t
++grub_gpt_header_check (struct grub_gpt_header *gpt,
++		       unsigned int log_sector_size)
++{
++  grub_uint32_t crc = 0, size;
++  grub_uint64_t start, end;
++
++  if (grub_memcmp (gpt->magic, grub_gpt_magic, sizeof (grub_gpt_magic)) != 0)
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "invalid GPT signature");
++
++  if (gpt->version != GRUB_GPT_HEADER_VERSION)
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "unknown GPT version");
++
++  grub_gpt_header_lecrc32 (&crc, gpt);
++  if (gpt->crc32 != crc)
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "invalid GPT header crc32");
++
++  /* The header size "must be greater than or equal to 92 and must be less
++   * than or equal to the logical block size."  */
++  size = grub_le_to_cpu32 (gpt->headersize);
++  if (size < 92U || size > (1U << log_sector_size))
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "invalid GPT header size");
++
++  /* The partition entry size must be "a value of 128*(2^n) where n is an
++   * integer greater than or equal to zero (e.g., 128, 256, 512, etc.)."  */
++  size = grub_le_to_cpu32 (gpt->partentry_size);
++  if (size < 128U || size % 128U || !is_pow2 (size / 128U))
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "invalid GPT entry size");
++
++  /* The minimum entries table size is specified in terms of bytes,
++   * regardless of how large the individual entry size is.  */
++  if (grub_gpt_entries_size (gpt) < GRUB_GPT_DEFAULT_ENTRIES_SIZE)
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "invalid GPT entry table size");
++
++  /* And of course there better be some space for partitions!  */
++  start = grub_le_to_cpu64 (gpt->start);
++  end = grub_le_to_cpu64 (gpt->end);
++  if (start > end)
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "invalid usable sectors");
++
++  return GRUB_ERR_NONE;
++}
++
++static int
++grub_gpt_headers_equal (grub_gpt_t gpt)
++{
++  /* Assume headers passed grub_gpt_header_check so skip magic and version.
++   * Individual fields must be checked instead of just using memcmp because
++   * crc32, header, alternate, and partitions will all normally differ.  */
++
++  if (gpt->primary.headersize != gpt->backup.headersize ||
++      gpt->primary.header_lba != gpt->backup.alternate_lba ||
++      gpt->primary.alternate_lba != gpt->backup.header_lba ||
++      gpt->primary.start != gpt->backup.start ||
++      gpt->primary.end != gpt->backup.end ||
++      gpt->primary.maxpart != gpt->backup.maxpart ||
++      gpt->primary.partentry_size != gpt->backup.partentry_size ||
++      gpt->primary.partentry_crc32 != gpt->backup.partentry_crc32)
++    return 0;
++
++  return grub_memcmp(&gpt->primary.guid, &gpt->backup.guid,
++                     sizeof(grub_gpt_part_guid_t)) == 0;
++}
++
++static grub_err_t
++grub_gpt_check_primary (grub_gpt_t gpt)
++{
++  grub_uint64_t backup, primary, entries, entries_len, start, end;
++
++  primary = grub_le_to_cpu64 (gpt->primary.header_lba);
++  backup = grub_le_to_cpu64 (gpt->primary.alternate_lba);
++  entries = grub_le_to_cpu64 (gpt->primary.partitions);
++  entries_len = grub_gpt_entries_sectors(&gpt->primary, gpt->log_sector_size);
++  start = grub_le_to_cpu64 (gpt->primary.start);
++  end = grub_le_to_cpu64 (gpt->primary.end);
++
++  grub_dprintf ("gpt", "Primary GPT layout:\n"
++		"primary header = 0x%llx backup header = 0x%llx\n"
++		"entries location = 0x%llx length = 0x%llx\n"
++		"first usable = 0x%llx last usable = 0x%llx\n",
++		(unsigned long long) primary,
++		(unsigned long long) backup,
++		(unsigned long long) entries,
++		(unsigned long long) entries_len,
++		(unsigned long long) start,
++		(unsigned long long) end);
++
++  if (grub_gpt_header_check (&gpt->primary, gpt->log_sector_size))
++    return grub_errno;
++  if (primary != 1)
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "invalid primary GPT LBA");
++  if (entries <= 1 || entries+entries_len > start)
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "invalid entries location");
++  if (backup <= end)
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "invalid backup GPT LBA");
++
++  return GRUB_ERR_NONE;
++}
++
++static grub_err_t
++grub_gpt_check_backup (grub_gpt_t gpt)
++{
++  grub_uint64_t backup, primary, entries, entries_len, start, end;
++
++  backup = grub_le_to_cpu64 (gpt->backup.header_lba);
++  primary = grub_le_to_cpu64 (gpt->backup.alternate_lba);
++  entries = grub_le_to_cpu64 (gpt->backup.partitions);
++  entries_len = grub_gpt_entries_sectors(&gpt->backup, gpt->log_sector_size);
++  start = grub_le_to_cpu64 (gpt->backup.start);
++  end = grub_le_to_cpu64 (gpt->backup.end);
++
++  grub_dprintf ("gpt", "Backup GPT layout:\n"
++		"primary header = 0x%llx backup header = 0x%llx\n"
++		"entries location = 0x%llx length = 0x%llx\n"
++		"first usable = 0x%llx last usable = 0x%llx\n",
++		(unsigned long long) primary,
++		(unsigned long long) backup,
++		(unsigned long long) entries,
++		(unsigned long long) entries_len,
++		(unsigned long long) start,
++		(unsigned long long) end);
++
++  if (grub_gpt_header_check (&gpt->backup, gpt->log_sector_size))
++    return grub_errno;
++  if (primary != 1)
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "invalid primary GPT LBA");
++  if (entries <= end || entries+entries_len > backup)
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "invalid entries location");
++  if (backup <= end)
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "invalid backup GPT LBA");
++
++  /* If both primary and backup are valid but differ prefer the primary.  */
++  if ((gpt->status & GRUB_GPT_PRIMARY_HEADER_VALID) &&
++      !grub_gpt_headers_equal (gpt))
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "backup GPT out of sync");
++
++  return GRUB_ERR_NONE;
++}
++
++static grub_err_t
++grub_gpt_read_primary (grub_disk_t disk, grub_gpt_t gpt)
++{
++  grub_disk_addr_t addr;
++
++  /* TODO: The gpt partmap module searches for the primary header instead
++   * of relying on the disk's sector size. For now trust the disk driver
++   * but eventually this code should match the existing behavior.  */
++  gpt->log_sector_size = disk->log_sector_size;
++
++  grub_dprintf ("gpt", "reading primary GPT from sector 0x1\n");
++
++  addr = grub_gpt_sector_to_addr (gpt, 1);
++  if (grub_disk_read (disk, addr, 0, sizeof (gpt->primary), &gpt->primary))
++    return grub_errno;
++
++  if (grub_gpt_check_primary (gpt))
++    return grub_errno;
++
++  gpt->status |= GRUB_GPT_PRIMARY_HEADER_VALID;
++
++  if (grub_gpt_read_entries (disk, gpt, &gpt->primary,
++			     &gpt->entries, &gpt->entries_size))
++    return grub_errno;
++
++  gpt->status |= GRUB_GPT_PRIMARY_ENTRIES_VALID;
++
++  return GRUB_ERR_NONE;
++}
++
++static grub_err_t
++grub_gpt_read_backup (grub_disk_t disk, grub_gpt_t gpt)
++{
++  void *entries = NULL;
++  grub_size_t entries_size;
++  grub_uint64_t sector;
++  grub_disk_addr_t addr;
++
++  /* Assumes gpt->log_sector_size == disk->log_sector_size  */
++  if (gpt->status & GRUB_GPT_PRIMARY_HEADER_VALID)
++    {
++      sector = grub_le_to_cpu64 (gpt->primary.alternate_lba);
++      if (grub_gpt_disk_size_valid (disk) && sector >= disk->total_sectors)
++	return grub_error (GRUB_ERR_OUT_OF_RANGE,
++			   "backup GPT located at 0x%llx, "
++			   "beyond last disk sector at 0x%llx",
++			   (unsigned long long) sector,
++			   (unsigned long long) disk->total_sectors - 1);
++    }
++  else if (grub_gpt_disk_size_valid (disk))
++    sector = disk->total_sectors - 1;
++  else
++    return grub_error (GRUB_ERR_OUT_OF_RANGE,
++		       "size of disk unknown, cannot locate backup GPT");
++
++  grub_dprintf ("gpt", "reading backup GPT from sector 0x%llx\n",
++		(unsigned long long) sector);
++
++  addr = grub_gpt_sector_to_addr (gpt, sector);
++  if (grub_disk_read (disk, addr, 0, sizeof (gpt->backup), &gpt->backup))
++    return grub_errno;
++
++  if (grub_gpt_check_backup (gpt))
++    return grub_errno;
++
++  /* Ensure the backup header thinks it is located where we found it.  */
++  if (grub_le_to_cpu64 (gpt->backup.header_lba) != sector)
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "invalid backup GPT LBA");
++
++  gpt->status |= GRUB_GPT_BACKUP_HEADER_VALID;
++
++  if (grub_gpt_read_entries (disk, gpt, &gpt->backup,
++			     &entries, &entries_size))
++    return grub_errno;
++
++  if (gpt->status & GRUB_GPT_PRIMARY_ENTRIES_VALID)
++    {
++      if (entries_size != gpt->entries_size ||
++	  grub_memcmp (entries, gpt->entries, entries_size) != 0)
++	return grub_error (GRUB_ERR_BAD_PART_TABLE, "backup GPT out of sync");
++
++      grub_free (entries);
++    }
++  else
++    {
++      gpt->entries = entries;
++      gpt->entries_size = entries_size;
++    }
++
++  gpt->status |= GRUB_GPT_BACKUP_ENTRIES_VALID;
++
++  return GRUB_ERR_NONE;
++}
++
++static grub_err_t
++grub_gpt_read_entries (grub_disk_t disk, grub_gpt_t gpt,
++		       struct grub_gpt_header *header,
++		       void **ret_entries,
++		       grub_size_t *ret_entries_size)
++{
++  void *entries = NULL;
++  grub_uint32_t count, size, crc;
++  grub_uint64_t sector;
++  grub_disk_addr_t addr;
++  grub_size_t entries_size;
++
++  /* Grub doesn't include calloc, hence the manual overflow check.  */
++  count = grub_le_to_cpu32 (header->maxpart);
++  size = grub_le_to_cpu32 (header->partentry_size);
++  entries_size = count *size;
++  if (size && entries_size / size != count)
++    {
++      grub_error (GRUB_ERR_OUT_OF_MEMORY, N_("out of memory"));
++      goto fail;
++    }
++
++  /* Double check that the header was validated properly.  */
++  if (entries_size < GRUB_GPT_DEFAULT_ENTRIES_SIZE)
++    return grub_error (GRUB_ERR_BUG, "invalid GPT entries table size");
++
++  entries = grub_malloc (entries_size);
++  if (!entries)
++    goto fail;
++
++  sector = grub_le_to_cpu64 (header->partitions);
++  grub_dprintf ("gpt", "reading GPT %lu entries from sector 0x%llx\n",
++		(unsigned long) count,
++		(unsigned long long) sector);
++
++  addr = grub_gpt_sector_to_addr (gpt, sector);
++  if (grub_disk_read (disk, addr, 0, entries_size, entries))
++    goto fail;
++
++  grub_gpt_lecrc32 (&crc, entries, entries_size);
++  if (crc != header->partentry_crc32)
++    {
++      grub_error (GRUB_ERR_BAD_PART_TABLE, "invalid GPT entry crc32");
++      goto fail;
++    }
++
++  *ret_entries = entries;
++  *ret_entries_size = entries_size;
++  return GRUB_ERR_NONE;
++
++fail:
++  grub_free (entries);
++  return grub_errno;
++}
++
++grub_gpt_t
++grub_gpt_read (grub_disk_t disk)
++{
++  grub_gpt_t gpt;
++
++  grub_dprintf ("gpt", "reading GPT from %s\n", disk->name);
++
++  gpt = grub_zalloc (sizeof (*gpt));
++  if (!gpt)
++    goto fail;
++
++  if (grub_disk_read (disk, 0, 0, sizeof (gpt->mbr), &gpt->mbr))
++    goto fail;
++
++  /* Check the MBR but errors aren't reported beyond the status bit.  */
++  if (grub_gpt_pmbr_check (&gpt->mbr))
++    grub_errno = GRUB_ERR_NONE;
++  else
++    gpt->status |= GRUB_GPT_PROTECTIVE_MBR;
++
++  /* If both the primary and backup fail report the primary's error.  */
++  if (grub_gpt_read_primary (disk, gpt))
++    {
++      grub_error_push ();
++      grub_gpt_read_backup (disk, gpt);
++      grub_error_pop ();
++    }
++  else
++    grub_gpt_read_backup (disk, gpt);
++
++  /* If either succeeded clear any possible error from the other.  */
++  if (grub_gpt_primary_valid (gpt) || grub_gpt_backup_valid (gpt))
++    grub_errno = GRUB_ERR_NONE;
++  else
++    goto fail;
++
++  return gpt;
++
++fail:
++  grub_gpt_free (gpt);
++  return NULL;
++}
++
++struct grub_gpt_partentry *
++grub_gpt_get_partentry (grub_gpt_t gpt, grub_uint32_t n)
++{
++  struct grub_gpt_header *header;
++  grub_size_t offset;
++
++  header = grub_gpt_get_header (gpt);
++  if (!header)
++    return NULL;
++
++  if (n >= grub_le_to_cpu32 (header->maxpart))
++    return NULL;
++
++  offset = (grub_size_t) grub_le_to_cpu32 (header->partentry_size) * n;
++  return (struct grub_gpt_partentry *) ((char *) gpt->entries + offset);
++}
++
++grub_err_t
++grub_gpt_repair (grub_disk_t disk, grub_gpt_t gpt)
++{
++  /* Skip if there is nothing to do.  */
++  if (grub_gpt_both_valid (gpt))
++    return GRUB_ERR_NONE;
++
++  grub_dprintf ("gpt", "repairing GPT for %s\n", disk->name);
++
++  if (disk->log_sector_size != gpt->log_sector_size)
++    return grub_error (GRUB_ERR_NOT_IMPLEMENTED_YET,
++		       "GPT sector size must match disk sector size");
++
++  if (grub_gpt_primary_valid (gpt))
++    {
++      grub_uint64_t backup_header;
++
++      grub_dprintf ("gpt", "primary GPT is valid\n");
++
++      /* Relocate backup to end if disk if the disk has grown.  */
++      backup_header = grub_le_to_cpu64 (gpt->primary.alternate_lba);
++      if (grub_gpt_disk_size_valid (disk) &&
++	  disk->total_sectors - 1 > backup_header)
++	{
++	  backup_header = disk->total_sectors - 1;
++	  grub_dprintf ("gpt", "backup GPT header relocated to 0x%llx\n",
++			(unsigned long long) backup_header);
++
++	  gpt->primary.alternate_lba = grub_cpu_to_le64 (backup_header);
++	}
++
++      grub_memcpy (&gpt->backup, &gpt->primary, sizeof (gpt->backup));
++      gpt->backup.header_lba = gpt->primary.alternate_lba;
++      gpt->backup.alternate_lba = gpt->primary.header_lba;
++      gpt->backup.partitions = grub_cpu_to_le64 (backup_header -
++	  grub_gpt_size_to_sectors (gpt, gpt->entries_size));
++    }
++  else if (grub_gpt_backup_valid (gpt))
++    {
++      grub_dprintf ("gpt", "backup GPT is valid\n");
++
++      grub_memcpy (&gpt->primary, &gpt->backup, sizeof (gpt->primary));
++      gpt->primary.header_lba = gpt->backup.alternate_lba;
++      gpt->primary.alternate_lba = gpt->backup.header_lba;
++      gpt->primary.partitions = grub_cpu_to_le64_compile_time (2);
++    }
++  else
++    return grub_error (GRUB_ERR_BUG, "No valid GPT");
++
++  if (grub_gpt_update (gpt))
++    return grub_errno;
++
++  grub_dprintf ("gpt", "repairing GPT for %s successful\n", disk->name);
++
++  return GRUB_ERR_NONE;
++}
++
++grub_err_t
++grub_gpt_update (grub_gpt_t gpt)
++{
++  grub_uint32_t crc;
++
++  /* Clear status bits, require revalidation of everything.  */
++  gpt->status &= ~(GRUB_GPT_PRIMARY_HEADER_VALID |
++		   GRUB_GPT_PRIMARY_ENTRIES_VALID |
++		   GRUB_GPT_BACKUP_HEADER_VALID |
++		   GRUB_GPT_BACKUP_ENTRIES_VALID);
++
++  /* Writing headers larger than our header structure are unsupported.  */
++  gpt->primary.headersize =
++    grub_cpu_to_le32_compile_time (sizeof (gpt->primary));
++  gpt->backup.headersize =
++    grub_cpu_to_le32_compile_time (sizeof (gpt->backup));
++
++  grub_gpt_lecrc32 (&crc, gpt->entries, gpt->entries_size);
++  gpt->primary.partentry_crc32 = crc;
++  gpt->backup.partentry_crc32 = crc;
++
++  grub_gpt_header_lecrc32 (&gpt->primary.crc32, &gpt->primary);
++  grub_gpt_header_lecrc32 (&gpt->backup.crc32, &gpt->backup);
++
++  if (grub_gpt_check_primary (gpt))
++    {
++      grub_error_push ();
++      return grub_error (GRUB_ERR_BUG, "Generated invalid GPT primary header");
++    }
++
++  gpt->status |= (GRUB_GPT_PRIMARY_HEADER_VALID |
++		  GRUB_GPT_PRIMARY_ENTRIES_VALID);
++
++  if (grub_gpt_check_backup (gpt))
++    {
++      grub_error_push ();
++      return grub_error (GRUB_ERR_BUG, "Generated invalid GPT backup header");
++    }
++
++  gpt->status |= (GRUB_GPT_BACKUP_HEADER_VALID |
++		  GRUB_GPT_BACKUP_ENTRIES_VALID);
++
++  return GRUB_ERR_NONE;
++}
++
++static grub_err_t
++grub_gpt_write_table (grub_disk_t disk, grub_gpt_t gpt,
++		      struct grub_gpt_header *header)
++{
++  grub_disk_addr_t addr;
++
++  if (grub_le_to_cpu32 (header->headersize) != sizeof (*header))
++    return grub_error (GRUB_ERR_NOT_IMPLEMENTED_YET,
++		       "Header size is %u, must be %u",
++		       grub_le_to_cpu32 (header->headersize),
++		       sizeof (*header));
++
++  addr = grub_gpt_sector_to_addr (gpt, grub_le_to_cpu64 (header->header_lba));
++  if (addr == 0)
++    return grub_error (GRUB_ERR_BUG,
++		       "Refusing to write GPT header to address 0x0");
++  if (grub_disk_write (disk, addr, 0, sizeof (*header), header))
++    return grub_errno;
++
++  addr = grub_gpt_sector_to_addr (gpt, grub_le_to_cpu64 (header->partitions));
++  if (addr < 2)
++    return grub_error (GRUB_ERR_BUG,
++		       "Refusing to write GPT entries to address 0x%llx",
++		       (unsigned long long) addr);
++  if (grub_disk_write (disk, addr, 0, gpt->entries_size, gpt->entries))
++    return grub_errno;
++
++  return GRUB_ERR_NONE;
++}
++
++grub_err_t
++grub_gpt_write (grub_disk_t disk, grub_gpt_t gpt)
++{
++  grub_uint64_t backup_header;
++
++  /* TODO: update/repair protective MBRs too.  */
++
++  if (!grub_gpt_both_valid (gpt))
++    return grub_error (GRUB_ERR_BAD_PART_TABLE, "Invalid GPT data");
++
++  /* Write the backup GPT first so if writing fails the update is aborted
++   * and the primary is left intact.  However if the backup location is
++   * inaccessible we have to just skip and hope for the best, the backup
++   * will need to be repaired in the OS.  */
++  backup_header = grub_le_to_cpu64 (gpt->backup.header_lba);
++  if (grub_gpt_disk_size_valid (disk) &&
++      backup_header >= disk->total_sectors)
++    {
++      grub_printf ("warning: backup GPT located at 0x%llx, "
++		   "beyond last disk sector at 0x%llx\n",
++		   (unsigned long long) backup_header,
++		   (unsigned long long) disk->total_sectors - 1);
++      grub_printf ("warning: only writing primary GPT, "
++	           "the backup GPT must be repaired from the OS\n");
++    }
++  else
++    {
++      grub_dprintf ("gpt", "writing backup GPT to %s\n", disk->name);
++      if (grub_gpt_write_table (disk, gpt, &gpt->backup))
++	return grub_errno;
++    }
++
++  grub_dprintf ("gpt", "writing primary GPT to %s\n", disk->name);
++  if (grub_gpt_write_table (disk, gpt, &gpt->primary))
++    return grub_errno;
++
++  return GRUB_ERR_NONE;
++}
++
++void
++grub_gpt_free (grub_gpt_t gpt)
++{
++  if (!gpt)
++    return;
++
++  grub_free (gpt->entries);
++  grub_free (gpt);
++}
+diff --git a/include/grub/gpt_partition.h b/include/grub/gpt_partition.h
+index 7a93f4329..27946f471 100644
+--- a/include/grub/gpt_partition.h
++++ b/include/grub/gpt_partition.h
+@@ -21,6 +21,7 @@
+ 
+ #include <grub/types.h>
+ #include <grub/partition.h>
++#include <grub/msdos_partition.h>
+ 
+ struct grub_gpt_part_guid
+ {
+@@ -31,24 +32,43 @@ struct grub_gpt_part_guid
+ } GRUB_PACKED;
+ typedef struct grub_gpt_part_guid grub_gpt_part_guid_t;
+ 
+-#define GRUB_GPT_PARTITION_TYPE_EMPTY \
+-  { 0x0, 0x0, 0x0, \
+-    { 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 } \
++/* Format the raw little-endian GUID as a newly allocated string.  */
++char * grub_gpt_part_guid_to_str (grub_gpt_part_guid_t *guid);
++
++
++#define GRUB_GPT_GUID_INIT(a, b, c, d1, d2, d3, d4, d5, d6, d7, d8)  \
++  {					\
++    grub_cpu_to_le32_compile_time (a),	\
++    grub_cpu_to_le16_compile_time (b),	\
++    grub_cpu_to_le16_compile_time (c),	\
++    { d1, d2, d3, d4, d5, d6, d7, d8 }	\
+   }
+ 
++#define GRUB_GPT_PARTITION_TYPE_EMPTY \
++  GRUB_GPT_GUID_INIT (0x0, 0x0, 0x0,  \
++      0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
++
++#define GRUB_GPT_PARTITION_TYPE_EFI_SYSTEM \
++  GRUB_GPT_GUID_INIT (0xc12a7328, 0xf81f, 0x11d2, \
++      0xba, 0x4b, 0x00, 0xa0, 0xc9, 0x3e, 0xc9, 0x3b)
++
+ #define GRUB_GPT_PARTITION_TYPE_BIOS_BOOT \
+-  { grub_cpu_to_le32_compile_time (0x21686148), \
+-      grub_cpu_to_le16_compile_time (0x6449), \
+-      grub_cpu_to_le16_compile_time (0x6e6f),	       \
+-    { 0x74, 0x4e, 0x65, 0x65, 0x64, 0x45, 0x46, 0x49 } \
+-  }
++  GRUB_GPT_GUID_INIT (0x21686148, 0x6449, 0x6e6f, \
++      0x74, 0x4e, 0x65, 0x65, 0x64, 0x45, 0x46, 0x49)
+ 
+ #define GRUB_GPT_PARTITION_TYPE_LDM \
+-  { grub_cpu_to_le32_compile_time (0x5808C8AAU),\
+-      grub_cpu_to_le16_compile_time (0x7E8F), \
+-      grub_cpu_to_le16_compile_time (0x42E0),	       \
+-	{ 0x85, 0xD2, 0xE1, 0xE9, 0x04, 0x34, 0xCF, 0xB3 }	\
+-  }
++  GRUB_GPT_GUID_INIT (0x5808c8aa, 0x7e8f, 0x42e0, \
++      0x85, 0xd2, 0xe1, 0xe9, 0x04, 0x34, 0xcf, 0xb3)
++
++#define GRUB_GPT_PARTITION_TYPE_USR_X86_64 \
++  GRUB_GPT_GUID_INIT (0x5dfbf5f4, 0x2848, 0x4bac, \
++      0xaa, 0x5e, 0x0d, 0x9a, 0x20, 0xb7, 0x45, 0xa6)
++
++#define GRUB_GPT_HEADER_MAGIC \
++  { 0x45, 0x46, 0x49, 0x20, 0x50, 0x41, 0x52, 0x54 }
++
++#define GRUB_GPT_HEADER_VERSION	\
++  grub_cpu_to_le32_compile_time (0x00010000U)
+ 
+ struct grub_gpt_header
+ {
+@@ -57,11 +77,11 @@ struct grub_gpt_header
+   grub_uint32_t headersize;
+   grub_uint32_t crc32;
+   grub_uint32_t unused1;
+-  grub_uint64_t primary;
+-  grub_uint64_t backup;
++  grub_uint64_t header_lba;
++  grub_uint64_t alternate_lba;
+   grub_uint64_t start;
+   grub_uint64_t end;
+-  grub_uint8_t guid[16];
++  grub_gpt_part_guid_t guid;
+   grub_uint64_t partitions;
+   grub_uint32_t maxpart;
+   grub_uint32_t partentry_size;
+@@ -75,13 +95,172 @@ struct grub_gpt_partentry
+   grub_uint64_t start;
+   grub_uint64_t end;
+   grub_uint64_t attrib;
+-  char name[72];
++  grub_uint16_t name[36];
+ } GRUB_PACKED;
+ 
++enum grub_gpt_part_attr_offset
++{
++  /* Standard partition attribute bits defined by UEFI.  */
++  GRUB_GPT_PART_ATTR_OFFSET_REQUIRED			= 0,
++  GRUB_GPT_PART_ATTR_OFFSET_NO_BLOCK_IO_PROTOCOL	= 1,
++  GRUB_GPT_PART_ATTR_OFFSET_LEGACY_BIOS_BOOTABLE	= 2,
++
++  /* De facto standard attribute bits defined by Microsoft and reused by
++   * http://www.freedesktop.org/wiki/Specifications/DiscoverablePartitionsSpec */
++  GRUB_GPT_PART_ATTR_OFFSET_READ_ONLY			= 60,
++  GRUB_GPT_PART_ATTR_OFFSET_NO_AUTO			= 63,
++
++  /* Partition attributes for priority based selection,
++   * Currently only valid for PARTITION_TYPE_USR_X86_64.
++   * TRIES_LEFT and PRIORITY are 4 bit wide fields.  */
++  GRUB_GPT_PART_ATTR_OFFSET_GPTPRIO_PRIORITY		= 48,
++  GRUB_GPT_PART_ATTR_OFFSET_GPTPRIO_TRIES_LEFT		= 52,
++  GRUB_GPT_PART_ATTR_OFFSET_GPTPRIO_SUCCESSFUL		= 56,
++};
++
++/* Helpers for reading/writing partition attributes.  */
++static inline grub_uint64_t
++grub_gpt_entry_attribute (struct grub_gpt_partentry *entry,
++			  enum grub_gpt_part_attr_offset offset,
++			  unsigned int bits)
++{
++  grub_uint64_t attrib = grub_le_to_cpu64 (entry->attrib);
++
++  return (attrib >> offset) & ((1ULL << bits) - 1);
++}
++
++static inline void
++grub_gpt_entry_set_attribute (struct grub_gpt_partentry *entry,
++			      grub_uint64_t value,
++			      enum grub_gpt_part_attr_offset offset,
++			      unsigned int bits)
++{
++  grub_uint64_t attrib, mask;
++
++  mask = (((1ULL << bits) - 1) << offset);
++  attrib = grub_le_to_cpu64 (entry->attrib) & ~mask;
++  attrib |= ((value << offset) & mask);
++  entry->attrib = grub_cpu_to_le64 (attrib);
++}
++
++/* Basic GPT partmap module.  */
+ grub_err_t
+ grub_gpt_partition_map_iterate (grub_disk_t disk,
+ 				grub_partition_iterate_hook_t hook,
+ 				void *hook_data);
+ 
++/* Advanced GPT library.  */
++
++/* Status bits for the grub_gpt.status field.  */
++#define GRUB_GPT_PROTECTIVE_MBR		0x01
++#define GRUB_GPT_HYBRID_MBR		0x02
++#define GRUB_GPT_PRIMARY_HEADER_VALID	0x04
++#define GRUB_GPT_PRIMARY_ENTRIES_VALID	0x08
++#define GRUB_GPT_BACKUP_HEADER_VALID	0x10
++#define GRUB_GPT_BACKUP_ENTRIES_VALID	0x20
++
++/* UEFI requires the entries table to be at least 16384 bytes for a
++ * total of 128 entries given the standard 128 byte entry size.  */
++#define GRUB_GPT_DEFAULT_ENTRIES_SIZE	16384
++#define GRUB_GPT_DEFAULT_ENTRIES_LENGTH	\
++  (GRUB_GPT_DEFAULT_ENTRIES_SIZE / sizeof (struct grub_gpt_partentry))
++
++struct grub_gpt
++{
++  /* Bit field indicating which structures on disk are valid.  */
++  unsigned status;
++
++  /* Protective or hybrid MBR.  */
++  struct grub_msdos_partition_mbr mbr;
++
++  /* Each of the two GPT headers.  */
++  struct grub_gpt_header primary;
++  struct grub_gpt_header backup;
++
++  /* Only need one entries table, on disk both copies are identical.
++   * The on disk entry size may be larger than our partentry struct so
++   * the table cannot be indexed directly.  */
++  void *entries;
++  grub_size_t entries_size;
++
++  /* Logarithm of sector size, in case GPT and disk driver disagree.  */
++  unsigned int log_sector_size;
++};
++typedef struct grub_gpt *grub_gpt_t;
++
++/* Helpers for checking the gpt status field.  */
++static inline int
++grub_gpt_mbr_valid (grub_gpt_t gpt)
++{
++  return ((gpt->status & GRUB_GPT_PROTECTIVE_MBR) ||
++	  (gpt->status & GRUB_GPT_HYBRID_MBR));
++}
++
++static inline int
++grub_gpt_primary_valid (grub_gpt_t gpt)
++{
++  return ((gpt->status & GRUB_GPT_PRIMARY_HEADER_VALID) &&
++	  (gpt->status & GRUB_GPT_PRIMARY_ENTRIES_VALID));
++}
++
++static inline int
++grub_gpt_backup_valid (grub_gpt_t gpt)
++{
++  return ((gpt->status & GRUB_GPT_BACKUP_HEADER_VALID) &&
++	  (gpt->status & GRUB_GPT_BACKUP_ENTRIES_VALID));
++}
++
++static inline int
++grub_gpt_both_valid (grub_gpt_t gpt)
++{
++  return grub_gpt_primary_valid (gpt) && grub_gpt_backup_valid (gpt);
++}
++
++/* Translate GPT sectors to GRUB's 512 byte block addresses.  */
++static inline grub_disk_addr_t
++grub_gpt_sector_to_addr (grub_gpt_t gpt, grub_uint64_t sector)
++{
++  return (sector << (gpt->log_sector_size - GRUB_DISK_SECTOR_BITS));
++}
++
++/* Allocates and fills new grub_gpt structure, free with grub_gpt_free.  */
++grub_gpt_t grub_gpt_read (grub_disk_t disk);
++
++/* Helper for indexing into the entries table.
++ * Returns NULL when the end of the table has been reached.  */
++struct grub_gpt_partentry * grub_gpt_get_partentry (grub_gpt_t gpt,
++						    grub_uint32_t n);
++
++/* Sync and update primary and backup headers if either are invalid.  */
++grub_err_t grub_gpt_repair (grub_disk_t disk, grub_gpt_t gpt);
++
++/* Recompute checksums and revalidate everything, must be called after
++ * modifying any GPT data.  */
++grub_err_t grub_gpt_update (grub_gpt_t gpt);
++
++/* Write headers and entry tables back to disk.  */
++grub_err_t grub_gpt_write (grub_disk_t disk, grub_gpt_t gpt);
++
++void grub_gpt_free (grub_gpt_t gpt);
++
++grub_err_t grub_gpt_pmbr_check (struct grub_msdos_partition_mbr *mbr);
++grub_err_t grub_gpt_header_check (struct grub_gpt_header *gpt,
++				  unsigned int log_sector_size);
++
++
++/* Utilities for simple partition data lookups, usage is intended to
++ * be similar to fs->label and fs->uuid functions.  */
++
++/* Return the partition label of the device DEVICE in LABEL.
++ * The label is in a new buffer and should be freed by the caller.  */
++grub_err_t grub_gpt_part_label (grub_device_t device, char **label);
++
++/* Return the partition uuid of the device DEVICE in UUID.
++ * The uuid is in a new buffer and should be freed by the caller.  */
++grub_err_t grub_gpt_part_uuid (grub_device_t device, char **uuid);
++
++/* Return the disk uuid of the device DEVICE in UUID.
++ * The uuid is in a new buffer and should be freed by the caller.  */
++grub_err_t grub_gpt_disk_uuid (grub_device_t device, char **uuid);
+ 
+ #endif /* ! GRUB_GPT_PARTITION_HEADER */
+-- 
+2.25.1
+

--- a/pkg/grub/patches.riscv64.2.06/0002-Add-gpt-module.patch
+++ b/pkg/grub/patches.riscv64.2.06/0002-Add-gpt-module.patch
@@ -1,7 +1,7 @@
 From 681b7079898e60e8596f7ab0b938ad2a0623a5dd Mon Sep 17 00:00:00 2001
 From: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>
 Date: Thu, 14 Oct 2021 14:39:34 +0530
-Subject: [PATCH 2/3] Add gpt module
+Subject: [PATCH 2/6] Add gpt module
 
 Signed-off-by: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>
 ---

--- a/pkg/grub/patches.riscv64.2.06/0003-Add-gptprio-module.patch
+++ b/pkg/grub/patches.riscv64.2.06/0003-Add-gptprio-module.patch
@@ -1,0 +1,260 @@
+From aa3e4905b0d7a30b041510707ff524328f9253a4 Mon Sep 17 00:00:00 2001
+From: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>
+Date: Thu, 14 Oct 2021 14:40:00 +0530
+Subject: [PATCH 3/3] Add gptprio module
+
+Signed-off-by: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>
+---
+ grub-core/Makefile.core.def  |   5 +
+ grub-core/commands/gptprio.c | 223 +++++++++++++++++++++++++++++++++++
+ 2 files changed, 228 insertions(+)
+ create mode 100644 grub-core/commands/gptprio.c
+
+diff --git a/grub-core/Makefile.core.def b/grub-core/Makefile.core.def
+index 672523a22..07e8a5dff 100644
+--- a/grub-core/Makefile.core.def
++++ b/grub-core/Makefile.core.def
+@@ -897,6 +897,11 @@ module = {
+   common = commands/gptsync.c;
+ };
+ 
++module = {
++  name = gptprio;
++  common = commands/gptprio.c;
++};
++
+ module = {
+   name = gpt;
+   common = lib/gpt.c;
+diff --git a/grub-core/commands/gptprio.c b/grub-core/commands/gptprio.c
+new file mode 100644
+index 000000000..65c4b209e
+--- /dev/null
++++ b/grub-core/commands/gptprio.c
+@@ -0,0 +1,223 @@
++/* gptprio.c - manage priority based partition selection.  */
++/*
++ *  GRUB  --  GRand Unified Bootloader
++ *  Copyright (C) 2009  Free Software Foundation, Inc.
++ *  Copyright (C) 2014  CoreOS, Inc.
++ *
++ *  GRUB is free software: you can redistribute it and/or modify
++ *  it under the terms of the GNU General Public License as published by
++ *  the Free Software Foundation, either version 3 of the License, or
++ *  (at your option) any later version.
++ *
++ *  GRUB is distributed in the hope that it will be useful,
++ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *  GNU General Public License for more details.
++ *
++ *  You should have received a copy of the GNU General Public License
++ *  along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++#include <grub/device.h>
++#include <grub/env.h>
++#include <grub/err.h>
++#include <grub/extcmd.h>
++#include <grub/gpt_partition.h>
++#include <grub/i18n.h>
++#include <grub/misc.h>
++
++GRUB_MOD_LICENSE ("GPLv3+");
++
++static const struct grub_arg_option options_next[] = {
++  {"set-device", 'd', 0,
++   N_("Set a variable to the name of selected partition."),
++   N_("VARNAME"), ARG_TYPE_STRING},
++  {"set-uuid", 'u', 0,
++   N_("Set a variable to the GPT UUID of selected partition."),
++   N_("VARNAME"), ARG_TYPE_STRING},
++  {0, 0, 0, 0, 0, 0}
++};
++
++enum options_next
++{
++  NEXT_SET_DEVICE,
++  NEXT_SET_UUID,
++};
++
++static unsigned int
++grub_gptprio_priority (struct grub_gpt_partentry *entry)
++{
++  return (unsigned int) grub_gpt_entry_attribute
++    (entry, GRUB_GPT_PART_ATTR_OFFSET_GPTPRIO_PRIORITY, 4);
++}
++
++static unsigned int
++grub_gptprio_tries_left (struct grub_gpt_partentry *entry)
++{
++  return (unsigned int) grub_gpt_entry_attribute
++    (entry, GRUB_GPT_PART_ATTR_OFFSET_GPTPRIO_TRIES_LEFT, 4);
++}
++
++static void
++grub_gptprio_set_tries_left (struct grub_gpt_partentry *entry,
++			     unsigned int tries_left)
++{
++  grub_gpt_entry_set_attribute
++    (entry, tries_left, GRUB_GPT_PART_ATTR_OFFSET_GPTPRIO_TRIES_LEFT, 4);
++}
++
++static unsigned int
++grub_gptprio_successful (struct grub_gpt_partentry *entry)
++{
++  return (unsigned int) grub_gpt_entry_attribute
++    (entry, GRUB_GPT_PART_ATTR_OFFSET_GPTPRIO_SUCCESSFUL, 1);
++}
++
++static grub_err_t
++grub_find_next (const char *disk_name,
++		const grub_gpt_part_guid_t *part_type,
++		char **part_name, char **part_guid)
++{
++  struct grub_gpt_partentry *part, *part_found = NULL;
++  grub_device_t dev = NULL;
++  grub_gpt_t gpt = NULL;
++  grub_uint32_t i, part_index;
++
++  dev = grub_device_open (disk_name);
++  if (!dev)
++    goto done;
++
++  gpt = grub_gpt_read (dev->disk);
++  if (!gpt)
++    goto done;
++
++  if (grub_gpt_repair (dev->disk, gpt))
++    goto done;
++
++  for (i = 0; (part = grub_gpt_get_partentry (gpt, i)) != NULL; i++)
++    {
++      if (grub_memcmp (part_type, &part->type, sizeof (*part_type)) == 0)
++	{
++	  unsigned int priority, tries_left, successful, old_priority = 0;
++
++	  priority = grub_gptprio_priority (part);
++	  tries_left = grub_gptprio_tries_left (part);
++	  successful = grub_gptprio_successful (part);
++
++	  if (part_found)
++	    old_priority = grub_gptprio_priority (part_found);
++
++	  if ((tries_left || successful) && priority > old_priority)
++	    {
++	      part_index = i;
++	      part_found = part;
++	    }
++	}
++    }
++
++  if (!part_found)
++    {
++      grub_error (GRUB_ERR_UNKNOWN_DEVICE, N_("no such partition"));
++      goto done;
++    }
++
++  if (grub_gptprio_tries_left (part_found))
++    {
++      unsigned int tries_left = grub_gptprio_tries_left (part_found);
++
++      grub_gptprio_set_tries_left (part_found, tries_left - 1);
++
++      if (grub_gpt_update (gpt))
++	goto done;
++
++      if (grub_gpt_write (dev->disk, gpt))
++	goto done;
++    }
++
++  *part_name = grub_xasprintf ("%s,gpt%u", disk_name, part_index + 1);
++  if (!*part_name)
++    goto done;
++
++  *part_guid = grub_gpt_part_guid_to_str (&part_found->guid);
++  if (!*part_guid)
++    goto done;
++
++  grub_errno = GRUB_ERR_NONE;
++
++done:
++  grub_gpt_free (gpt);
++
++  if (dev)
++    grub_device_close (dev);
++
++  return grub_errno;
++}
++
++
++
++static grub_err_t
++grub_cmd_next (grub_extcmd_context_t ctxt, int argc, char **args)
++{
++  struct grub_arg_list *state = ctxt->state;
++  char *p, *root = NULL, *part_name = NULL, *part_guid = NULL;
++
++  /* TODO: Add a uuid parser and a command line flag for providing type.  */
++  grub_gpt_part_guid_t part_type = GRUB_GPT_PARTITION_TYPE_USR_X86_64;
++
++  if (!state[NEXT_SET_DEVICE].set || !state[NEXT_SET_UUID].set)
++    {
++      grub_error (GRUB_ERR_INVALID_COMMAND, N_("-d and -u are required"));
++      goto done;
++    }
++
++  if (argc == 0)
++    root = grub_strdup (grub_env_get ("root"));
++  else if (argc == 1)
++    root = grub_strdup (args[0]);
++  else
++    {
++      grub_error (GRUB_ERR_BAD_ARGUMENT, N_("unexpected arguments"));
++      goto done;
++    }
++
++  if (!root)
++    goto done;
++
++  /* To make using $root practical strip off the partition name.  */
++  p = grub_strchr (root, ',');
++  if (p)
++    *p = '\0';
++
++  if (grub_find_next (root, &part_type, &part_name, &part_guid))
++    goto done;
++
++  if (grub_env_set (state[NEXT_SET_DEVICE].arg, part_name))
++    goto done;
++
++  if (grub_env_set (state[NEXT_SET_UUID].arg, part_guid))
++    goto done;
++
++  grub_errno = GRUB_ERR_NONE;
++
++done:
++  grub_free (root);
++  grub_free (part_name);
++  grub_free (part_guid);
++
++  return grub_errno;
++}
++
++static grub_extcmd_t cmd_next;
++
++GRUB_MOD_INIT(gptprio)
++{
++  cmd_next = grub_register_extcmd ("gptprio.next", grub_cmd_next, 0,
++				   N_("-d VARNAME -u VARNAME [DEVICE]"),
++				   N_("Select next partition to boot."),
++				   options_next);
++}
++
++GRUB_MOD_FINI(gptprio)
++{
++  grub_unregister_extcmd (cmd_next);
++}
+-- 
+2.25.1
+

--- a/pkg/grub/patches.riscv64.2.06/0003-Add-gptprio-module.patch
+++ b/pkg/grub/patches.riscv64.2.06/0003-Add-gptprio-module.patch
@@ -1,7 +1,7 @@
 From aa3e4905b0d7a30b041510707ff524328f9253a4 Mon Sep 17 00:00:00 2001
 From: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>
 Date: Thu, 14 Oct 2021 14:40:00 +0530
-Subject: [PATCH 3/3] Add gptprio module
+Subject: [PATCH 3/6] Add gptprio module
 
 Signed-off-by: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>
 ---

--- a/pkg/grub/patches.riscv64.2.06/0004-Add-search_part_label-module.patch
+++ b/pkg/grub/patches.riscv64.2.06/0004-Add-search_part_label-module.patch
@@ -1,0 +1,87 @@
+From d4517a474c0a289234b24fff592777c73dd70b6d Mon Sep 17 00:00:00 2001
+From: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>
+Date: Thu, 4 Nov 2021 03:14:52 +0530
+Subject: [PATCH 4/6] Add search_part_label module
+
+Signed-off-by: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>
+---
+ grub-core/Makefile.core.def            | 5 +++++
+ grub-core/commands/search_part_label.c | 5 +++++
+ grub-core/commands/search_wrap.c       | 6 ++++++
+ include/grub/search.h                  | 3 ++-
+ 4 files changed, 18 insertions(+), 1 deletion(-)
+ create mode 100644 grub-core/commands/search_part_label.c
+
+diff --git a/grub-core/Makefile.core.def b/grub-core/Makefile.core.def
+index 07e8a5dff..bf345f988 100644
+--- a/grub-core/Makefile.core.def
++++ b/grub-core/Makefile.core.def
+@@ -1083,6 +1083,11 @@ module = {
+   common = commands/search_label.c;
+ };
+ 
++module = {
++  name = search_part_label;
++  common = commands/search_part_label.c;
++};
++
+ module = {
+   name = setpci;
+   common = commands/setpci.c;
+diff --git a/grub-core/commands/search_part_label.c b/grub-core/commands/search_part_label.c
+new file mode 100644
+index 000000000..ca906cbd9
+--- /dev/null
++++ b/grub-core/commands/search_part_label.c
+@@ -0,0 +1,5 @@
++#define DO_SEARCH_PART_LABEL 1
++#define FUNC_NAME grub_search_part_label
++#define COMMAND_NAME "search.part_label"
++#define HELP_MESSAGE N_("Search devices by partition label. If VARIABLE is specified, the first device found is set to a variable.")
++#include "search.c"
+diff --git a/grub-core/commands/search_wrap.c b/grub-core/commands/search_wrap.c
+index 47fc8eb99..ffa349add 100644
+--- a/grub-core/commands/search_wrap.c
++++ b/grub-core/commands/search_wrap.c
+@@ -36,6 +36,8 @@ static const struct grub_arg_option options[] =
+      0, 0},
+     {"fs-uuid",		'u', 0, N_("Search devices by a filesystem UUID."),
+      0, 0},
++    {"part-label",	'L', 0, N_("Search devices by a partition label."),
++     0, 0},
+     {"set",		's', GRUB_ARG_OPTION_OPTIONAL,
+      N_("Set a variable to the first device found."), N_("VARNAME"),
+      ARG_TYPE_STRING},
+@@ -71,6 +73,7 @@ enum options
+     SEARCH_FILE,
+     SEARCH_LABEL,
+     SEARCH_FS_UUID,
++    SEARCH_PART_LABEL,
+     SEARCH_SET,
+     SEARCH_NO_FLOPPY,
+     SEARCH_HINT,
+@@ -186,6 +189,9 @@ grub_cmd_search (grub_extcmd_context_t ctxt, int argc, char **args)
+   else if (state[SEARCH_FS_UUID].set)
+     grub_search_fs_uuid (id, var, state[SEARCH_NO_FLOPPY].set,
+ 			 hints, nhints);
++  else if (state[SEARCH_PART_LABEL].set)
++    grub_search_part_label (id, var, state[SEARCH_NO_FLOPPY].set,
++			    hints, nhints);
+   else if (state[SEARCH_FILE].set)
+     grub_search_fs_file (id, var, state[SEARCH_NO_FLOPPY].set, 
+ 			 hints, nhints);
+diff --git a/include/grub/search.h b/include/grub/search.h
+index d80347df3..9b83f515c 100644
+--- a/include/grub/search.h
++++ b/include/grub/search.h
+@@ -25,5 +25,6 @@ void grub_search_fs_uuid (const char *key, const char *var, int no_floppy,
+ 			  char **hints, unsigned nhints);
+ void grub_search_label (const char *key, const char *var, int no_floppy,
+ 			char **hints, unsigned nhints);
+-
++void grub_search_part_label (const char *key, const char *var, int no_floppy,
++			     char **hints, unsigned nhints);
+ #endif
+-- 
+2.25.1
+

--- a/pkg/grub/patches.riscv64.2.06/0005-Add-search_part_uuid-and-search_disk_uuid-module.patch
+++ b/pkg/grub/patches.riscv64.2.06/0005-Add-search_part_uuid-and-search_disk_uuid-module.patch
@@ -1,0 +1,120 @@
+From 3251da81687b792f389a431141b5b1a576b6cf29 Mon Sep 17 00:00:00 2001
+From: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>
+Date: Thu, 4 Nov 2021 19:36:55 +0530
+Subject: [PATCH 5/6] Add search_part_uuid and search_disk_uuid module
+
+Signed-off-by: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>
+---
+ grub-core/Makefile.core.def           | 10 ++++++++++
+ grub-core/commands/search_disk_uuid.c |  5 +++++
+ grub-core/commands/search_part_uuid.c |  5 +++++
+ grub-core/commands/search_wrap.c      | 12 ++++++++++++
+ include/grub/search.h                 |  5 +++++
+ 5 files changed, 37 insertions(+)
+ create mode 100644 grub-core/commands/search_disk_uuid.c
+ create mode 100644 grub-core/commands/search_part_uuid.c
+
+diff --git a/grub-core/Makefile.core.def b/grub-core/Makefile.core.def
+index bf345f988..6bd3af7ce 100644
+--- a/grub-core/Makefile.core.def
++++ b/grub-core/Makefile.core.def
+@@ -1083,11 +1083,21 @@ module = {
+   common = commands/search_label.c;
+ };
+ 
++module = {
++  name = search_part_uuid;
++  common = commands/search_part_uuid.c;
++};
++
+ module = {
+   name = search_part_label;
+   common = commands/search_part_label.c;
+ };
+ 
++module = {
++  name = search_disk_uuid;
++  common = commands/search_disk_uuid.c;
++};
++
+ module = {
+   name = setpci;
+   common = commands/setpci.c;
+diff --git a/grub-core/commands/search_disk_uuid.c b/grub-core/commands/search_disk_uuid.c
+new file mode 100644
+index 000000000..fba96f6b8
+--- /dev/null
++++ b/grub-core/commands/search_disk_uuid.c
+@@ -0,0 +1,5 @@
++#define DO_SEARCH_DISK_UUID 1
++#define FUNC_NAME grub_search_disk_uuid
++#define COMMAND_NAME "search.disk_uuid"
++#define HELP_MESSAGE N_("Search devices by disk UUID. If VARIABLE is specified, the first device found is set to a variable.")
++#include "search.c"
+diff --git a/grub-core/commands/search_part_uuid.c b/grub-core/commands/search_part_uuid.c
+new file mode 100644
+index 000000000..2d1d3d0d7
+--- /dev/null
++++ b/grub-core/commands/search_part_uuid.c
+@@ -0,0 +1,5 @@
++#define DO_SEARCH_PART_UUID 1
++#define FUNC_NAME grub_search_part_uuid
++#define COMMAND_NAME "search.part_uuid"
++#define HELP_MESSAGE N_("Search devices by partition UUID. If VARIABLE is specified, the first device found is set to a variable.")
++#include "search.c"
+diff --git a/grub-core/commands/search_wrap.c b/grub-core/commands/search_wrap.c
+index ffa349add..fc149cd6b 100644
+--- a/grub-core/commands/search_wrap.c
++++ b/grub-core/commands/search_wrap.c
+@@ -38,6 +38,10 @@ static const struct grub_arg_option options[] =
+      0, 0},
+     {"part-label",	'L', 0, N_("Search devices by a partition label."),
+      0, 0},
++    {"part-uuid",	'U', 0, N_("Search devices by a partition UUID."),
++     0, 0},
++    {"disk-uuid",	'U', 0, N_("Search devices by a disk UUID."),
++     0, 0},
+     {"set",		's', GRUB_ARG_OPTION_OPTIONAL,
+      N_("Set a variable to the first device found."), N_("VARNAME"),
+      ARG_TYPE_STRING},
+@@ -74,6 +78,8 @@ enum options
+     SEARCH_LABEL,
+     SEARCH_FS_UUID,
+     SEARCH_PART_LABEL,
++    SEARCH_PART_UUID,
++    SEARCH_DISK_UUID,
+     SEARCH_SET,
+     SEARCH_NO_FLOPPY,
+     SEARCH_HINT,
+@@ -192,6 +198,12 @@ grub_cmd_search (grub_extcmd_context_t ctxt, int argc, char **args)
+   else if (state[SEARCH_PART_LABEL].set)
+     grub_search_part_label (id, var, state[SEARCH_NO_FLOPPY].set,
+ 			    hints, nhints);
++  else if (state[SEARCH_PART_UUID].set)
++    grub_search_part_uuid (id, var, state[SEARCH_NO_FLOPPY].set,
++			   hints, nhints);
++  else if (state[SEARCH_DISK_UUID].set)
++    grub_search_disk_uuid (id, var, state[SEARCH_NO_FLOPPY].set,
++			   hints, nhints);
+   else if (state[SEARCH_FILE].set)
+     grub_search_fs_file (id, var, state[SEARCH_NO_FLOPPY].set, 
+ 			 hints, nhints);
+diff --git a/include/grub/search.h b/include/grub/search.h
+index 9b83f515c..7f69d25d1 100644
+--- a/include/grub/search.h
++++ b/include/grub/search.h
+@@ -25,6 +25,11 @@ void grub_search_fs_uuid (const char *key, const char *var, int no_floppy,
+ 			  char **hints, unsigned nhints);
+ void grub_search_label (const char *key, const char *var, int no_floppy,
+ 			char **hints, unsigned nhints);
++void grub_search_part_uuid (const char *key, const char *var, int no_floppy,
++			    char **hints, unsigned nhints);
+ void grub_search_part_label (const char *key, const char *var, int no_floppy,
+ 			     char **hints, unsigned nhints);
++void grub_search_disk_uuid (const char *key, const char *var, int no_floppy,
++			    char **hints, unsigned nhints);
++
+ #endif
+-- 
+2.25.1
+

--- a/pkg/grub/patches.riscv64.2.06/0006-Implement-watchdog-style-menu-timeout.patch
+++ b/pkg/grub/patches.riscv64.2.06/0006-Implement-watchdog-style-menu-timeout.patch
@@ -1,0 +1,51 @@
+From 4524bbd91e846ce4c4c61e11e297a63dcfc2ed4c Mon Sep 17 00:00:00 2001
+From: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>
+Date: Fri, 5 Nov 2021 00:00:18 +0530
+Subject: [PATCH 6/6] Implement watchdog style menu timeout
+
+Standard GRUB implementation cannot resist spurious keypress and stops booting.
+This change resets timeout to its initial value. Grub menutimeout
+should be set to some comfort value e.g. 5 sec
+
+Signed-off-by: Michael Malyshev <mikem@zededa.com>
+Signed-off-by: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>
+---
+ grub-core/normal/menu.c | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/grub-core/normal/menu.c b/grub-core/normal/menu.c
+index 8397886fa..c1a5d7c06 100644
+--- a/grub-core/normal/menu.c
++++ b/grub-core/normal/menu.c
+@@ -579,6 +579,7 @@ run_menu (grub_menu_t menu, int nested, int *auto_boot)
+   int default_entry, current_entry;
+   int timeout;
+   enum timeout_style timeout_style;
++  int initial_timeout_value;
+ 
+   default_entry = get_entry_number (menu, "default");
+ 
+@@ -659,6 +660,7 @@ run_menu (grub_menu_t menu, int nested, int *auto_boot)
+ 
+   current_entry = default_entry;
+ 
++  initial_timeout_value = grub_menu_get_timeout ();
+  refresh:
+   menu_init (current_entry, menu, nested);
+ 
+@@ -702,9 +704,9 @@ run_menu (grub_menu_t menu, int nested, int *auto_boot)
+ 	{
+ 	  if (timeout >= 0)
+ 	    {
+-	      grub_env_unset ("timeout");
+-	      grub_env_unset ("fallback");
+-	      clear_timeout ();
++	      /* reset timeout value if the user press any key */
++	      grub_menu_set_timeout(initial_timeout_value);
++	      menu_print_timeout (initial_timeout_value);
+ 	    }
+ 
+ 	  switch (c)
+-- 
+2.25.1
+

--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -114,7 +114,7 @@ function set_grub_virt {
 
 function set_rootfs_root {
    if [ -z "$rootfs_root" ]; then
-      probe --set partuuid -U $root
+      probe --set partuuid --part-uuid $root
       set_global rootfs_root "PARTUUID=$partuuid"
    fi
 }

--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -102,13 +102,18 @@ function set_to_existing_file {
 }
 
 function set_grub_virt {
-   smbios -t 1 -s 0 --set smb_vendor
-   if [ "$smb_vendor" == QEMU ]; then
-     set_global grub_virt qemu
-   elif [ "$smb_vendor" == Google ]; then
+   set arch=${grub_cpu}
+   if [ "$arch" == "riscv64"]; then
      set_global grub_virt qemu
    else
-     set_global grub_virt baremetal
+      smbios -t 1 -s 0 --set smb_vendor
+      if [ "$smb_vendor" == QEMU ]; then
+      set_global grub_virt qemu
+      elif [ "$smb_vendor" == Google ]; then
+      set_global grub_virt qemu
+      else
+      set_global grub_virt baremetal
+      fi
    fi
 }
 
@@ -257,6 +262,33 @@ function set_arm64_qemu {
    set_to_existing_file devicetree "($qemu_part)/eve.dtb"
 }
 
+function set_riscv64 {
+   set_global load_hv_cmd mini_hypervisor
+   set_global load_dom0_cmd mini_module
+   set_global load_initrd_cmd mini_module
+   set_global load_devicetree_cmd devicetree
+   set_global hv /boot/mini.efi
+   set_global hv_console "console=dtuart sync_console"
+   set_global hv_platform_tweaks " "
+   set_global dom0_console "console=tty0 console=ttyS0,115200 console=hvc0"
+}
+
+function set_riscv64_baremetal {
+   set_generic
+   set_riscv64
+   set_global dom0_platform_tweaks " "
+}
+
+function set_riscv64_qemu {
+   set_generic
+   set_riscv64
+   set_global dom0_console "$dom0_console console=ttyAMA0"
+   set_global dom0_platform_tweaks "hmp-unsafe=true"
+   # if running under QEMU, make sure to check dynamic partition for device trees
+   search.fs_label QEMU_DTB qemu_part
+   set_to_existing_file devicetree "($qemu_part)/eve.dtb"
+}
+
 function set_kvm_boot {
    set_global load_hv_cmd echo
    set_global load_dom0_cmd linux
@@ -339,6 +371,14 @@ submenu 'Set Boot Options' {
 
    menuentry 'set ARM/qemu boot options' {
       set_arm64_qemu
+   }
+
+   menuentry 'set RISCV/baremetal boot options' {
+      set_riscv64_baremetal 
+   }
+
+   menuentry 'set RISCV/qemu boot options' {
+      set_riscv64_qemu
    }
 
    menuentry 'skip hypervisor booting' {

--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -102,17 +102,16 @@ function set_to_existing_file {
 }
 
 function set_grub_virt {
-   set arch=${grub_cpu}
    if [ "$arch" == "riscv64"]; then
      set_global grub_virt qemu
    else
       smbios -t 1 -s 0 --set smb_vendor
       if [ "$smb_vendor" == QEMU ]; then
-      set_global grub_virt qemu
+         set_global grub_virt qemu
       elif [ "$smb_vendor" == Google ]; then
-      set_global grub_virt qemu
+         set_global grub_virt qemu
       else
-      set_global grub_virt baremetal
+         set_global grub_virt baremetal
       fi
    fi
 }

--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -373,7 +373,7 @@ submenu 'Set Boot Options' {
    }
 
    menuentry 'set RISCV/baremetal boot options' {
-      set_riscv64_baremetal 
+      set_riscv64_baremetal
    }
 
    menuentry 'set RISCV/qemu boot options' {


### PR DESCRIPTION
This PR does the following things:
* Bump grub version to 2.06.
* Add necessary patches to boot eve on riscv64

Signed-off-by: Vedant Paranjape 22630228+VedantParanjape@users.noreply.github.com