### PR TITLE
Fix publishedEdgeNodeCerts set too early.

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -328,7 +328,10 @@ func publishEdgeNodeCertsToController(ctx *zedagentContext) {
 	log.Tracef("publishEdgeNodeCertsToController: after send, total elapse sec %v",
 		time.Since(startPubTime).Seconds())
 	ctx.cipherCtx.iteration++
-	ctx.publishedEdgeNodeCerts = true
+	// XXX remove log?
+	log.Noticef("Maybe sent EdgeNodeCerts")
+	// The getDeferredSentHandlerFunction will set ctx.publishedEdgeNodeCerts
+	// when the message has been sent.
 }
 
 // Try all (first free, then rest) until it gets through.


### PR DESCRIPTION
Even in case messages are deferred due to failures we should not set
publishedEdgeNodeCerts until after the ZAttestReqType_ATTEST_REQ_CERT
message has been sent.

Signed-off-by: eriknordmark <erik@zededa.com>