### PR TITLE
Publish scaled dormant time back to the controller

### DIFF
--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -110,6 +110,12 @@ type getconfigContext struct {
 	callProcessLocalProfileServerChange bool //did we already call processLocalProfileServerChange
 
 	configRetryUpdateCounter uint32 // received from config
+
+	// Frequency in seconds at which metrics is published to the controller.
+	// This value can be different from 'timer.metric.interval' in the case of
+	// timer.metric.interval > currentMetricInterval, until the value of
+	// 'timer.metric.interval' has been successfully notified to the controller.
+	currentMetricInterval uint32
 }
 
 // current devUUID from OnboardingStatus

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -2194,7 +2194,7 @@ func parseConfigItems(config *zconfig.EdgeDevConfig, ctx *getconfigContext) {
 		if newMetricInterval != oldMetricInterval {
 			log.Functionf("parseConfigItems: %s change from %d to %d",
 				"MetricInterval", oldMetricInterval, newMetricInterval)
-			updateMetricsTimer(newMetricInterval, ctx.metricsTickerHandle)
+			maybeUpdateMetricsTimer(ctx, false)
 		}
 		oldMaintenanceMode := oldGlobalConfig.GlobalValueTriState(types.MaintenanceMode)
 		newMaintenanceMode := newGlobalConfig.GlobalValueTriState(types.MaintenanceMode)

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -58,6 +58,9 @@ const (
 	warningTime = 40 * time.Second
 	// Maximum allowed number of flow messages enqueued and waiting to be published.
 	flowlogQueueCap = 100
+
+	// Factor by which the dormant time needs to be scaled up.
+	dormantTimeScaleFactor = 3
 )
 
 // Set from Makefile
@@ -299,7 +302,11 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	initializeDirs()
 
 	// Context to pass around
-	getconfigCtx := getconfigContext{localServerMap: &localServerMap{}}
+	getconfigCtx := getconfigContext{
+		localServerMap: &localServerMap{},
+		// default value of currentMetricInterval
+		currentMetricInterval: zedagentCtx.globalConfig.GlobalValueInt(types.MetricInterval),
+	}
 	cipherCtx := cipherContext{}
 	attestCtx := attestContext{}
 


### PR DESCRIPTION
As part of the effort to make dormant time configurable on the controller, EVE must report its version of (scaled) dormant time. Handled below mentioned 2 scenarios:
1. Current metrics publish interval > new metrics publish interval in GlobalConfig
    For instance, if currentMetricInterval = 300s and latestMetricTickerInterval = 200s,
    the controller will be expecting a metrics every 300s. Increasing the frequency immediately 
    to 200s will not result in controller marking the edge-node as suspect in between.
2. Current metrics publish interval < new metrics publish interval in GlobalConfig
    For instance, if currentMetricInterval = 200s and latestMetricTickerInterval = 300s,
    the controller will be expecting a metrics every 200s. So decreasing the frequency to
    300s can result in controller marking the edge-node as suspect in between. To avoid this,
    we have to make sure that the controller is notified  to expect a metrics every 300s before
    updating our publish frequency.

Signed-off-by: adarsh-zededa <adarsh@zededa.com>