### PR TITLE
make RemoveContainerRootDir more robust against unmount error

### DIFF
--- a/pkg/pillar/cas/containerd.go
+++ b/pkg/pillar/cas/containerd.go
@@ -644,7 +644,7 @@ func (c *containerdCAS) RemoveContainerRootDir(rootPath string) error {
 		err = fmt.Errorf("RemoveContainerRootDir: exception while unmounting: %v/%v. %v",
 			rootPath, containerRootfsPath, err)
 		logrus.Error(err.Error())
-		return err
+		// do not stop the flow here, we need to do cleanup regardless of mounting issues
 	}
 
 	//Step 2: Clean container rootPath

--- a/pkg/pillar/cmd/volumemgr/initialvolumestatus.go
+++ b/pkg/pillar/cmd/volumemgr/initialvolumestatus.go
@@ -68,8 +68,9 @@ func gcObjects(ctx *volumemgrContext, dirName string) {
 				filelocation)
 			if format == "CONTAINER" {
 				_ = ctx.casClient.RemoveContainerRootDir(filelocation)
+			} else {
+				deleteFile(filelocation)
 			}
-			deleteFile(filelocation)
 		}
 	}
 	log.Tracef("gcObjects(%s) Done", dirName)

--- a/pkg/pillar/containerd/oci.go
+++ b/pkg/pillar/containerd/oci.go
@@ -214,7 +214,7 @@ func (s *ociSpec) Save(file *os.File) error {
 func (s *ociSpec) Load(file *os.File) error {
 	var ns *specs.Spec
 	if err := json.NewDecoder(file).Decode(&ns); err != nil {
-		return err
+		return fmt.Errorf("ociSpec.Load error: %s", err)
 	}
 	s.Spec = *ns
 	if s.Process == nil {


### PR DESCRIPTION
As described [here](https://github.com/lf-edge/eve/blob/master/pkg/pillar/cas/containerd.go#L577-L579) we want to cleanup directory with container's bundle as the first step of PrepareContainerRootDir, but RemoveContainerRootDir stops in case of problems with unmounting (for example, not mounted or not exists).