### PR TITLE
Do not allow to impose radio silence during EVE update testing

### DIFF
--- a/pkg/pillar/devicenetwork/dnc.go
+++ b/pkg/pillar/devicenetwork/dnc.go
@@ -680,7 +680,7 @@ func handleZedAgentStatusImpl(ctxArg interface{}, key string, statusArg interfac
 	log.Functionf("handleZedAgentStatusImpl() %+v\n", newStatus)
 
 	if newStatus.RadioSilence.ChangeRequestedAt.After(ctx.RadioSilence.ChangeRequestedAt) {
-		log.Noticef("The intended radio-silence state changed to: %s", ctx.RadioSilence)
+		log.Noticef("The intended radio-silence state changed to: %s", newStatus.RadioSilence)
 		updateRadioSilence(ctx, newStatus.RadioSilence)
 	}
 }


### PR DESCRIPTION
If edge node is going through EVE update and radio silence is imposed
during the 10 minutes testing period, then the access to the controller
may be lost and device will fallback to the previous release.
This is in violation with the radio silence requirements, which state that
edge node should not trigger port config or EVE image fallback during a
(temporarily) imposed radio silence.
To prevent the EVE fallback from happening, zedagent will simply return error
back to the Local profile server if radio silence is requested during EVE
update testing period.

Signed-off-by: Milan Lenco <milan@zededa.com>