### PR TITLE
Ability to modify cmdline for container and container-in-VM via special environment variables

### DIFF
--- a/docs/ECOS.md
+++ b/docs/ECOS.md
@@ -189,9 +189,16 @@ otherwise dhcp is enabled.
 
 We use several files to run application comes from Docker/OCI manifest:
 
-* `environment` - all environment variables defined in Docker/OCI goes here
-* `cmdline` - it is cmd defined to run in Docker/OCI
+* `environment` - all environment variables defined in Docker/OCI and user data from controller goes here
+* `cmdline` - it is concatenation of entrypoint and cmd defined to run in Docker/OCI manifest
 * `ug` - file contains user and group to run cmd under
+
+`cmdline` may be overridden by setting of `EVE_ECO_CMD` environment variables. Thus, if defined, `cmdline` will contain
+`EVE_ECO_CMD` value. It may help to run specific command inside application without rebuilding and redeploy of it.
+Command is executing inside the same behaviour as the command passed from Docker/OCI manifest and can access/modify
+files inside rootfs of the ECO (i.e. this way user can print some files to the logs of application or touch/download
+file needed for the application), also this way user can run entrypoint with specified arguments (i.e. debugging ones).
+Please note, that change of environment variables require restart of the application.
 
 After preparation done we chroot into /mnt and run cmd from cmdline under specified user and group, output goes to
 /dev/console and is accessible from log of ECO.

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1707,6 +1707,9 @@ func configToStatus(ctx *domainContext, config types.DomainConfig,
 		ds.Vdev = fmt.Sprintf("xvd%c", int('a')+i)
 	}
 
+	//clean environment variables
+	status.EnvVariables = nil
+
 	if config.IsCipher || config.CloudInitUserData != nil {
 		ciStr, err := fetchCloudInit(ctx, config)
 		if err != nil {

--- a/pkg/pillar/containerd/oci.go
+++ b/pkg/pillar/containerd/oci.go
@@ -30,6 +30,9 @@ import (
 
 const eveScript = "/bin/eve"
 
+// eveECOCMDOverride value overrides cmd if provided
+const eveECOCMDOverride = "EVE_ECO_CMD"
+
 var vethScript = []string{"eve", "exec", "pillar", "/opt/zededa/bin/veth.sh"}
 
 // ociSpec is kept private (with all the actions done by getters and setters
@@ -433,5 +436,11 @@ func (s *ociSpec) UpdateMounts(disks []types.DiskStatus) error {
 func (s *ociSpec) UpdateEnvVar(envVars map[string]string) {
 	for k, v := range envVars {
 		s.Process.Env = append(s.Process.Env, fmt.Sprintf("%s=%s", k, v))
+		switch k {
+		case eveECOCMDOverride:
+			if len(v) != 0 {
+				s.Process.Args = strings.Fields(v)
+			}
+		}
 	}
 }

--- a/pkg/pillar/containerd/oci_test.go
+++ b/pkg/pillar/containerd/oci_test.go
@@ -767,6 +767,27 @@ func TestUpdateMounts(t *testing.T) {
 	g.Expect(spec.UpdateMounts(tresAmigos)).To(HaveOccurred())
 }
 
+func TestEnvs(t *testing.T) {
+	g := NewGomegaWithT(t)
+	spec := ociSpec{
+		name: "test",
+		Spec: specs.Spec{
+			Annotations: map[string]string{},
+			Process:     &specs.Process{},
+		},
+	}
+
+	envVars := make(map[string]string)
+
+	envVars[eveECOCMDOverride] = "echo me"
+	spec.UpdateEnvVar(envVars)
+	g.Expect(spec.Process.Args).To(Equal([]string{"echo", "me"}))
+
+	envVars[eveECOCMDOverride] = "echo hello"
+	spec.UpdateEnvVar(envVars)
+	g.Expect(spec.Process.Args).To(Equal([]string{"echo", "hello"}))
+}
+
 func TestAddLoader(t *testing.T) {
 	g := NewGomegaWithT(t)
 	specTemplate := ociSpec{


### PR DESCRIPTION
define `EVE_ECO_CMD` environment variable to override cmdline of ECO.

With this change user can define
```
EVE_ECO_CMD=nc -l
```
in the user data field in controller and ECO will run `nc -l` as cmdline.

Motivation.

1. In case of several target commands in entrypoint, user can select one of them (or change command to have some debug/production options inside if they are not configurable via environment options).
2. It may help to run commands to affect rootfs of ECO (i.e. define some kind of one-shot commands to modify something inside, remove override and run ECO with predefined cmdline).
3. Those options may help to debug behavior inside the container. User can define cmd to extract data from inside of the container and output it in log, i.e. ls or cat something.