### PR TITLE
Reserve space to maintain performance in ZFS

### DIFF
--- a/pkg/mkimage-raw-efi/install
+++ b/pkg/mkimage-raw-efi/install
@@ -119,6 +119,7 @@ prepare_mounts_and_zfs_pool() {
   [ -e /root/run ] || mkdir /root/run && mount --rbind /run /root/run
   POOL_CREATION_COMMAND="chroot /root zpool create -f -m none -o feature@encryption=enabled -O overlay=on persist $1"
   eval "$POOL_CREATION_COMMAND"
+  chroot /root zfs create -o refreservation="$(zfs get -o value -Hp available | awk '{ print ($1/1024/1024)/5 }')"m persist/reserved
   chroot /root zfs set mountpoint="/run/P3" persist
 }
 

--- a/pkg/storage-init/storage-init.sh
+++ b/pkg/storage-init/storage-init.sh
@@ -143,6 +143,7 @@ if P3=$(findfs PARTLABEL=P3) && [ -n "$P3" ]; then
                       # note that we immediately create a zfs dataset for containerd, since otherwise the init sequence will fail
                       #   https://bugs.launchpad.net/ubuntu/+source/zfs-linux/+bug/1718761
                       chroot /hostfs zpool create -f -m none -o feature@encryption=enabled -O overlay=on persist "$P3" && \
+                      chroot /hostfs zfs create -o refreservation="$(zfs get -o value -Hp available | awk '{ print ($1/1024/1024)/5 }')"m persist/reserved && \
                       chroot /hostfs zfs set mountpoint="$PERSISTDIR" persist                                          && \
                       chroot /hostfs zfs create -p -o mountpoint="$PERSISTDIR/containerd/io.containerd.snapshotter.v1.zfs" persist/snapshots
                    fi


### PR DESCRIPTION
This solution allows,  allocate a dummy dataset with the size of 20% of available space. This will take that space from the free pool, and would not be used for other datasets/zvols. However, that space is still available for copy-on-write.

It is recommended that storage usage should not go above 80% of available space. Because:
Pool performance can degrade when a pool is very full and file systems are updated frequently, such as on a busy mail server. Full pools might cause a performance penalty. If the primary workload is immutable files, then keep the pool in the 95-96% utilization range. Even with mostly static content in the 95-96% range, write, read, and resilvering performance might suffer.