### PR TITLE
notify resolve/downloader on changes of ciphercontext/certs

### DIFF
--- a/pkg/pillar/cmd/downloader/ciphercontext.go
+++ b/pkg/pillar/cmd/downloader/ciphercontext.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2021 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package downloader
+
+import (
+	"bytes"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+func handleCipherContextCreate(ctxArg interface{}, key string,
+	configArg interface{}) {
+	handleCipherContextImpl(ctxArg, key, configArg)
+}
+
+func handleCipherContextModify(ctxArg interface{}, key string,
+	configArg interface{}, oldConfigArg interface{}) {
+	handleCipherContextImpl(ctxArg, key, configArg)
+}
+
+func handleCipherContextImpl(ctxArg interface{}, key string,
+	configArg interface{}) {
+
+	ctx := ctxArg.(*downloaderContext)
+	cipherContext := configArg.(types.CipherContext)
+	log.Functionf("handleCipherContextImpl for %s", key)
+	sub := ctx.subDatastoreConfig
+	items := sub.GetAll()
+	for _, el := range items {
+		dsConfig := el.(types.DatastoreConfig)
+		if dsConfig.CipherContextID == cipherContext.ContextID {
+			checkAndUpdateDownloadableObjects(ctx, dsConfig.UUID)
+			checkAndUpdateResolveConfig(ctx, dsConfig.UUID)
+		}
+	}
+	log.Functionf("handleCipherContextImpl for %s, done", key)
+}
+
+func handleControllerCertCreate(ctxArg interface{}, key string,
+	configArg interface{}) {
+	handleControllerCertImpl(ctxArg, key, configArg)
+}
+
+func handleControllerCertModify(ctxArg interface{}, key string,
+	configArg interface{}, oldConfigArg interface{}) {
+	handleControllerCertImpl(ctxArg, key, configArg)
+}
+
+func handleControllerCertImpl(ctxArg interface{}, key string,
+	configArg interface{}) {
+
+	ctx := ctxArg.(*downloaderContext)
+	controllerCert := configArg.(types.ControllerCert)
+	log.Functionf("handleControllerCertImpl for %s", key)
+	sub := ctx.decryptCipherContext.SubCipherContext
+	items := sub.GetAll()
+	for _, el := range items {
+		cc := el.(types.CipherContext)
+		if bytes.Equal(cc.ControllerCertHash, controllerCert.CertHash) {
+			handleCipherContextImpl(ctx, cc.Key(), cc)
+		}
+	}
+	log.Functionf("handleControllerCertImpl for %s, done", key)
+}
+
+func handleEdgeNodeCertCreate(ctxArg interface{}, key string,
+	configArg interface{}) {
+	handleEdgeNodeCertImpl(ctxArg, key, configArg)
+}
+
+func handleEdgeNodeCertModify(ctxArg interface{}, key string,
+	configArg interface{}, oldConfigArg interface{}) {
+	handleEdgeNodeCertImpl(ctxArg, key, configArg)
+}
+
+func handleEdgeNodeCertImpl(ctxArg interface{}, key string,
+	configArg interface{}) {
+
+	ctx := ctxArg.(*downloaderContext)
+	edgeNodeCert := configArg.(types.EdgeNodeCert)
+	log.Functionf("handleEdgeNodeCertImpl for %s", key)
+	sub := ctx.decryptCipherContext.SubCipherContext
+	items := sub.GetAll()
+	for _, el := range items {
+		cc := el.(types.CipherContext)
+		if bytes.Equal(cc.DeviceCertHash, edgeNodeCert.CertID) {
+			handleCipherContextImpl(ctx, cc.Key(), cc)
+		}
+	}
+	log.Functionf("handleEdgeNodeCertImpl for %s, done", key)
+}

--- a/pkg/pillar/cmd/downloader/resolveconfig.go
+++ b/pkg/pillar/cmd/downloader/resolveconfig.go
@@ -78,19 +78,9 @@ func maybeRetryResolve(ctx *downloaderContext, status *types.ResolveStatus,
 	log.Functionf("maybeRetryResolve(%s) after %s at %v",
 		status.Key(), status.Error, status.ErrorTime)
 
-	if status.RetryCount == 0 {
-		status.OrigError = status.Error
-	}
 	// Increment count; we defer clearing error until success
 	// to avoid confusing the user.
 	status.RetryCount++
-	severity := types.GetErrorSeverity(status.RetryCount, time.Duration(status.RetryCount)*retryTime)
-	errDescription := types.ErrorDescription{
-		Error:               status.OrigError,
-		ErrorRetryCondition: fmt.Sprintf("Retrying; attempt %d", status.RetryCount),
-		ErrorSeverity:       severity,
-	}
-	status.SetErrorDescription(errDescription)
 	publishResolveStatus(ctx, status)
 
 	resolveTagsToHash(ctx, *config, receiveChan)

--- a/pkg/pillar/types/downloadertypes.go
+++ b/pkg/pillar/types/downloadertypes.go
@@ -114,8 +114,6 @@ type DownloaderStatus struct {
 	// ErrorAndTime provides SetErrorNow() and ClearError()
 	ErrorAndTime
 	RetryCount int
-	// We save the original error when we do a retry
-	OrigError string
 }
 
 func (status DownloaderStatus) Key() string {

--- a/pkg/pillar/types/resolvertypes.go
+++ b/pkg/pillar/types/resolvertypes.go
@@ -76,8 +76,6 @@ type ResolveStatus struct {
 	RetryCount  int
 	// ErrorAndTime provides SetErrorNow() and ClearError()
 	ErrorAndTime
-	// We save the original error when we do a retry
-	OrigError string
 }
 
 // Key : DatastoreID, name and sequence counter are used


### PR DESCRIPTION
Seems now we rely on retry after some waiting in case of problems with decryption of datastore's cipherblock. In this PR I add notify for resolve/downloader on changes of ciphercontext/certs.