### PR TITLE
fix an issue of tlsconfig initialization in diag.go

### DIFF
--- a/pkg/pillar/zedcloud/tls.go
+++ b/pkg/pillar/zedcloud/tls.go
@@ -275,6 +275,13 @@ func UpdateTLSProxyCerts(ctx *ZedCloudContext) bool {
 		// we don't have proxy certs, add them if any exist
 		caCertPool = tlsCfg.RootCAs
 	}
+
+	if caCertPool == nil {
+		errStr := fmt.Sprintf("caCertPool is nil")
+		log.Errorf(errStr)
+		return false
+	}
+
 	// AppendCertsFromPEM checks duplicates inside
 	for _, port := range devNS.Ports {
 		for _, pem := range port.ProxyCertPEM {


### PR DESCRIPTION
the crash was something like that in release 7.2:
/pillar/zedbox/zedbox.go:241 +0x62
/pillar/pubsub/subscribe.go:132 +0x586
/pillar/cmd/diag/diag.go:437 +0x725
/pillar/zedcloud/tls.go:274 +0x2d7
github.com/lf-edge/eve/pkg/pillar/zedcloud.UpdateTLSProxyCerts(0xc0005a5800, 0x1ad653d)
/usr/lib/go/src/crypto/x509/cert_pool.go:226 +0x2d3

this crash was due to a change in PR https://github.com/lf-edge/eve/pull/2333
that added at the diag start of init tlsConfig to the session resume, but not the caroot.
this is to remove that init, and during the tryPing time to get the tlsConfig normally and add the session-resume option
