### PR TITLE
Use pid namespace for continer-in-vm and adjust cgroup

### DIFF
--- a/pkg/xen-tools/initrd/chroot2.c
+++ b/pkg/xen-tools/initrd/chroot2.c
@@ -1,9 +1,38 @@
+#define _GNU_SOURCE
+#include <sched.h>
 #include <unistd.h>
-#include <sys/ioctl.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <sys/mount.h>
+#include <signal.h>
+
+typedef struct clone_args clone_args;
+
+struct clone_args {
+    char **args;
+    char *command;
+    uid_t uid, gid;
+};
+
+#define STACK_SIZE (8 * 1024 * 1024)
+static char child_stack[STACK_SIZE];    /* Space for child's stack */
+
+static int childFunc(void *args)
+{
+    clone_args *parsed_args = (clone_args *)args;
+    mount("proc", "/proc", "proc", 0, NULL);
+
+    setgid(parsed_args->gid);
+    setuid(parsed_args->uid);
+
+    execvp(parsed_args->command, parsed_args->args);
+}
 
 int main(int argc, char **argv) {
     uid_t uid, gid;
     char *endptr;
+    pid_t child_pid;
+    struct clone_args args;
 
     setsid();
     ioctl(0, TIOCSCTTY, 1);
@@ -14,8 +43,12 @@ int main(int argc, char **argv) {
     uid = strtol(argv[3], &endptr, 10);
     gid = strtol(argv[4], &endptr, 10);
 
-    setgid(gid);
-    setuid(uid);
+    args.uid = uid;
+    args.gid = gid;
+    args.command = argv[5];
+    args.args = argv + 5;
 
-    return execvp(argv[5], argv + 5);
+    child_pid = clone(childFunc, child_stack + STACK_SIZE, CLONE_NEWPID | SIGCHLD, (void *)(&args));
+
+    waitpid(child_pid, NULL, 0);
 }

--- a/pkg/xen-tools/initrd/init-initrd
+++ b/pkg/xen-tools/initrd/init-initrd
@@ -38,7 +38,20 @@ if [ -d /mnt/rootfs/dev/eve ]; then
 fi
 mount -o rbind /dev /mnt/rootfs/dev
 mount -o bind /sys /mnt/rootfs/sys
-mount -t cgroup cgroup /mnt/rootfs/sys/fs/cgroup
+mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /mnt/rootfs/sys/fs/cgroup
+awk '!/^#/ { if ($4 == 1) print $1 }' /proc/cgroups | while IFS= read -r sys
+do
+  cgroup="/mnt/rootfs/sys/fs/cgroup/$sys"
+  mkdir -p "$cgroup"
+  if ! mountpoint -q "$cgroup"; then
+    if ! mount -n -t cgroup -o "$sys" cgroup "$cgroup"; then
+      rmdir "$cgroup" || true
+    fi
+  fi
+done
+if [ -e /mnt/rootfs/sys/fs/cgroup/memory/memory.use_hierarchy ]; then
+  echo 1 > /mnt/rootfs/sys/fs/cgroup/memory/memory.use_hierarchy
+fi
 mount -t devpts -o gid=5,mode=0620,noexec,nosuid devpts /mnt/rootfs/dev/pts
 mount -t tmpfs -o nodev,nosuid,noexec,size=20% shm /mnt/rootfs/dev/shm
 mount -t tmpfs -o nodev,nosuid,size=20% tmp /mnt/rootfs/tmp

--- a/pkg/xen-tools/initrd/init-initrd
+++ b/pkg/xen-tools/initrd/init-initrd
@@ -39,7 +39,6 @@ fi
 mount -o rbind /dev /mnt/rootfs/dev
 mount -o bind /sys /mnt/rootfs/sys
 mount -t cgroup cgroup /mnt/rootfs/sys/fs/cgroup
-mount -o bind /proc /mnt/rootfs/proc
 mount -t devpts -o gid=5,mode=0620,noexec,nosuid devpts /mnt/rootfs/dev/pts
 mount -t tmpfs -o nodev,nosuid,noexec,size=20% shm /mnt/rootfs/dev/shm
 mount -t tmpfs -o nodev,nosuid,size=20% tmp /mnt/rootfs/tmp


### PR DESCRIPTION
Using of pid namespace for continer-in-vm allow us to use systemd-based entrypoints inside container. Also I made adjustment of  cgroups mounted in rootfs to be compatible with systemd-based init.

We use `/dev/console` to output an information to logs, so it is reasonable to enable ForwardToConsole inside the container, e.g.:
`RUN sed -i 's/#ForwardToConsole=no/ForwardToConsole=yes/g' /etc/systemd/journald.conf`.