### PR TITLE
log panic and fatal stack trace

### DIFF
--- a/pkg/pillar/cmd/faultinjection/run.go
+++ b/pkg/pillar/cmd/faultinjection/run.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	agentName = "fault-injection"
+	agentName = "faultinjection"
 	// Time limits for event loop handlers
 	errorTime   = 3 * time.Minute
 	warningTime = 40 * time.Second
@@ -77,8 +77,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	stillRunning := time.NewTicker(25 * time.Second)
 	ps.StillRunning(agentName, warningTime, errorTime)
 
-	// Add .pid and .touch file to watchdog config
-	ps.RegisterPidWatchdog(agentName)
 	ps.RegisterFileWatchdog(agentName)
 
 	// Look for global config such as log levels

--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -526,7 +526,17 @@ func handleLastRebootReason(ctx *nodeagentContext) {
 	}
 
 	agentlog.DiscardBootReason(log)
-	// still nothing, fillup the default
+	// Make sure we log the reboot stack
+	if len(rebootStack) > 0 {
+		log.Warnf("Found RebootStack %d bytes", len(rebootStack))
+		lines := strings.Split(rebootStack, "\n")
+		log.Warnf("Found RebootStack %d bytes %d lines",
+			len(rebootStack), len(lines))
+		for i, l := range lines {
+			log.Warnf("[%d]: %s", i, l)
+		}
+	}
+	// still no rebootReason? set the default
 	if rebootReason == "" {
 		rebootTime = time.Now()
 		dateStr := rebootTime.Format(time.RFC3339Nano)


### PR DESCRIPTION
Log the panic and fatal stack trace

With #2431 we should reliably record a golang panic stack, and previously we have at a log.Fatal stack recorded. EVE-OS sentds the reboot stack in the lastRebootStack in the API. However, this might be overridden by the controller on the next reboot of the device. Thus here we also log those stack entries.
