### PR TITLE
workspace cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,21 @@ jobs:
       matrix:
         os: [arm64-dirty, ubuntu-20.04]
     steps:
+      - name: Workspace cleanup
+        run: |
+          # cleanup existing workspace folder if exists to not hit permission denied on checkout
+          repoName="${{ github.event.repository.name }}"
+          workspace="${{ github.workspace }}"
+          if [ -d "$workspace" ] && [ "$(ls -A $workspace)" ]; then
+            # to avoid unexpected removal of sensitive information
+            # we check that workspace variable ends with repoName/repoName sequence
+            if [ ! -z "$repoName" ] && [ -z "${workspace##*$repoName/$repoName}" ]; then
+              ls -la "$workspace"
+              docker run --rm -v "$workspace":/mnt/eve alpine find /mnt/eve -maxdepth 1 -mindepth 1 -exec rm -rvf {} \;
+              ls -la "$workspace"
+            fi
+          fi
+
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0


### PR DESCRIPTION
Not sure what exactly failed on arm64-dirty VM, but seems we cannot clean workspace folder: `rm: cannot remove '/home/eve/_work/eve/eve/dist/arm64/0.0.0-pr2426-d84a1196/installer/config.img': Permission denied`. This PR adds step to cleanup workspace using docker container.