### PR TITLE
RPi4 fix vlan management

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1407,7 +1407,7 @@ func enableVlanFiltering(bridgeName string) error {
 }
 
 func setupVlans(vifList []types.VifInfo) error {
-	deadline := time.Now().Add(10 * time.Second)
+	deadline := time.Now().Add(20 * time.Second)
 	const delay = 500 * time.Millisecond
 	for _, vif := range vifList {
 		if vif.Vlan.End == 0 {


### PR DESCRIPTION
In EVE 7.3.0 XEN on rpi4 fails VLAN test.
for advanced info: tests logs here - https://wiki.lfedge.org/display/EVE/EVE+7.3.0+on+RPI4

Problem caused by Xen taking longer to create a new domain.
I ran 5 tests, and in all 5 tests the problem was encountered. After patch, the problem is not observed (5 tests).

This PR fix this problem.

Thanks @milan-zededa

Signed-off-by: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>