### PR TITLE
send nodeagent update of testing time

### DIFF
--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -2112,8 +2112,7 @@ func handleNodeAgentStatusImpl(ctxArg interface{}, key string,
 func naHasRealChange(naOld, naNew types.NodeAgentStatus) bool {
 	dummy1 := naOld
 	dummy2 := naNew
-	dummy1.RemainingTestTime = 0
-	dummy2.RemainingTestTime = 0
+
 	return !cmp.Equal(dummy1, dummy2)
 }
 


### PR DESCRIPTION
In case of changing RemainingTestTime (we change it about every 10 seconds) we do not send any updates to the cloud after #2371.