### PR TITLE
sort disks in mount_disk.sh

### DIFF
--- a/pkg/xen-tools/initrd/mount_disk.sh
+++ b/pkg/xen-tools/initrd/mount_disk.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
 
+# we expect the same order in block device enumeration (we put them in order in VM's configuration)
+# and in /mnt/mountPoints file (where mount points defined)
+
 mountPointLineNo=1
-find /sys/block/ -maxdepth 1 -regex '.*[sv]d.*' -exec basename '{}' ';'| while read -r disk ; do
+find /sys/block/ -maxdepth 1 -regex '.*[sv]d.*' -exec basename '{}' ';'| sort | while read -r disk ; do
   echo "Processing $disk"
   targetDir=$(sed "${mountPointLineNo}q;d" /mnt/mountPoints)
   if [ -z "$targetDir" ]


### PR DESCRIPTION
Seems we must sort output of find command to be in the same order as items in the mountPoints file. In case of multiple disks we will have unordered output from find and can have swapped mounts.
I.e. we get from find:
```
vdb
vda
```
but expect
```
vda
vdb
```
as we expect this order from VM config (we rely on the same order between lines in mountPoints file and block device enumeration)
[Erik: And that order is presumably due to domainmgr+hypervisor package allocating vdX in order of the virtual disks. Correct?]