### PR TITLE
Euresys Frame Grubber Full RX doesn't work under VM

### DIFF
--- a/pkg/kernel/patches-5.10.x/0001-Quirk-for-brocken-INTx-on-Euresys-Grablink-Full-XR.patch
+++ b/pkg/kernel/patches-5.10.x/0001-Quirk-for-brocken-INTx-on-Euresys-Grablink-Full-XR.patch
@@ -1,0 +1,26 @@
+From 3e6b97c0a57a4792a643a045e006b10254ba99b2 Mon Sep 17 00:00:00 2001
+From: Mikhail Malyshev <mikem@zededa.com>
+Date: Thu, 16 Dec 2021 11:29:26 +0100
+Subject: [PATCH] Quirk for brocken INTx on Euresys Grablink Full XR
+
+Signed-off-by: Mikhail Malyshev <mikem@zededa.com>
+---
+ drivers/pci/quirks.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
+index fb1dc11e7..3e625ee41 100644
+--- a/drivers/pci/quirks.c
++++ b/drivers/pci/quirks.c
+@@ -3433,6 +3433,8 @@ DECLARE_PCI_FIXUP_FINAL(0x1814, 0x0601, /* Ralink RT2800 802.11n PCI */
+ 			quirk_broken_intx_masking);
+ DECLARE_PCI_FIXUP_FINAL(0x1b7c, 0x0004, /* Ceton InfiniTV4 */
+ 			quirk_broken_intx_masking);
++DECLARE_PCI_FIXUP_FINAL(0x1805, 0x0310, /* Euresys Grablink Full XR */
++			quirk_broken_intx_masking);
+ 
+ /*
+  * Realtek RTL8169 PCI Gigabit Ethernet Controller (rev 10)
+-- 
+2.32.0
+

--- a/pkg/new-kernel/patches-5.12.x/0001-Quirk-for-brocken-INTx-on-Euresys-Grablink-Full-XR.patch
+++ b/pkg/new-kernel/patches-5.12.x/0001-Quirk-for-brocken-INTx-on-Euresys-Grablink-Full-XR.patch
@@ -1,0 +1,26 @@
+From 3e6b97c0a57a4792a643a045e006b10254ba99b2 Mon Sep 17 00:00:00 2001
+From: Mikhail Malyshev <mikem@zededa.com>
+Date: Thu, 16 Dec 2021 11:29:26 +0100
+Subject: [PATCH] Quirk for brocken INTx on Euresys Grablink Full XR
+
+Signed-off-by: Mikhail Malyshev <mikem@zededa.com>
+---
+ drivers/pci/quirks.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
+index fb1dc11e7..3e625ee41 100644
+--- a/drivers/pci/quirks.c
++++ b/drivers/pci/quirks.c
+@@ -3433,6 +3433,8 @@ DECLARE_PCI_FIXUP_FINAL(0x1814, 0x0601, /* Ralink RT2800 802.11n PCI */
+ 			quirk_broken_intx_masking);
+ DECLARE_PCI_FIXUP_FINAL(0x1b7c, 0x0004, /* Ceton InfiniTV4 */
+ 			quirk_broken_intx_masking);
++DECLARE_PCI_FIXUP_FINAL(0x1805, 0x0310, /* Euresys Grablink Full XR */
++			quirk_broken_intx_masking);
+ 
+ /*
+  * Realtek RTL8169 PCI Gigabit Ethernet Controller (rev 10)
+-- 
+2.32.0
+


### PR DESCRIPTION
The PCIe card wors fine on bare metal but doesn't work
under VM. Neither Linux nor Windows. This is a HW and not EVE issue
See comments inside the patch file for more details