### PR TITLE
Update ZFS version to 2.1.2

### DIFF
--- a/pkg/kernel/Dockerfile
+++ b/pkg/kernel/Dockerfile
@@ -86,7 +86,7 @@ RUN make INSTALL_MOD_PATH=/tmp/kernel-modules modules_install
 
 # Out-of-tree, open source modules
 #  * ZFS on Linux
-ENV ZFS_VERSION=2.1.1
+ENV ZFS_VERSION=2.1.2
 ENV ZFS_COMMIT=zfs-${ZFS_VERSION}
 ENV ZFS_REPO=https://github.com/zfsonlinux/zfs.git
 


### PR DESCRIPTION
Move ZFS to latest release version 2.1.2 from 2.1.1

Compiled and verified that it installs properly.

Signed-off-by: Pramodh Pallapothu <pramodh@zededa.com>