### PR TITLE
check for response in deferred sending and add some logging

### DIFF
--- a/pkg/pillar/cmd/tpmmgr/tpmmgr.go
+++ b/pkg/pillar/cmd/tpmmgr/tpmmgr.go
@@ -1286,7 +1286,7 @@ func getCertHash(cert []byte, hashAlgo types.CertHashType) ([]byte, error) {
 func publishEdgeNodeCertToController(ctx *tpmMgrContext, certFile string, certType types.CertType, isTpm bool, metaDataItems []types.CertMetaData) {
 	log.Functionf("publishEdgeNodeCertToController started")
 	if !etpm.FileExists(certFile) {
-		log.Errorf("publishEdgeNodeCertToController failed: no cert file")
+		log.Errorf("publishEdgeNodeCertToController failed: no cert file of type: %v", certType)
 		return
 	}
 	certBytes, err := readEdgeNodeCert(certFile)

--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -306,6 +306,8 @@ func publishEdgeNodeCertsToController(ctx *zedagentContext) {
 		return
 	}
 
+	ecdhCertExists := false
+
 	for _, item := range items {
 		config := item.(types.EdgeNodeCert)
 		certMsg := zcert.ZCert{
@@ -321,6 +323,14 @@ func publishEdgeNodeCertsToController(ctx *zedagentContext) {
 			certMsg.MetaDataItems = append(certMsg.MetaDataItems, certMetaData)
 		}
 		attestReq.Certs = append(attestReq.Certs, &certMsg)
+		if certMsg.Type == zcert.ZCertType_CERT_TYPE_DEVICE_ECDH_EXCHANGE {
+			ecdhCertExists = true
+		}
+	}
+
+	if !ecdhCertExists {
+		//we expect it to be published first
+		log.Warn("publishEdgeNodeCertsToController: no ecdh")
 	}
 
 	log.Tracef("publishEdgeNodeCertsToController, sending %s", attestReq)

--- a/pkg/pillar/zedcloud/deferred.go
+++ b/pkg/pillar/zedcloud/deferred.go
@@ -119,7 +119,6 @@ func (ctx *DeferredContext) handleDeferred(log *base.LogObject, event time.Time,
 			}
 
 			//SenderStatusNone indicates no problems
-			result := types.SenderStatusNone
 			resp, _, result, err := SendOnAllIntf(ctx.zedcloudCtx, item.url,
 				item.size, item.buf, ctx.iteration, item.bailOnHTTPErr)
 			if item.bailOnHTTPErr && resp != nil &&
@@ -129,6 +128,10 @@ func (ctx *DeferredContext) handleDeferred(log *base.LogObject, event time.Time,
 			} else if err != nil {
 				log.Functionf("handleDeferred: for %s failed %s",
 					key, err)
+				exit = true
+			} else if result != types.SenderStatusNone {
+				log.Functionf("handleDeferred: for %s received unexpected status %d",
+					key, result)
 				exit = true
 			}
 			if ctx.sentHandler != nil {


### PR DESCRIPTION
Seems we still can have the situation when controller for some reason miss our certificates. We can check if we have cipher contexts received and retry if they are empty several times.