### PR TITLE
zfs: tuning optimisations for Eve's workload

### DIFF
--- a/docs/ZFS.md
+++ b/docs/ZFS.md
@@ -1,0 +1,40 @@
+# ZFS (highly experimental support)
+
+ZFS provides a rich set of functionality but at a cost of extra
+resource usage. Currently ARC (Adaptive Replacement Cache) size is
+limited to `256 MiB + 0.3% of total storage`, but at least 384
+MiB. Keep in mind that this memory will be taken out form the
+applications.
+
+If system does not have enough memory to satisfy the limit mentioned
+above, severe performance degradation can occur on random access
+workflows.
+
+## Performance tunings applied
+
+`primarycache=metadata` - allows to keep arc cache size low. The primary
+use-case of zfs is zvol attached to a VM. And VM already does cache
+it's data, furthermore it knows better what to cache.
+
+`recordsize=16k` - is a sweet spot between constantly having sub-blocks
+updates, and good compression ratio.
+
+`compression=zstd` - is a less cpu intencive algorithm, with not too big
+compromise on compression ratio
+
+`redundant_metadata=most` - will reduce the number of copies of the
+indirect blocks at the higher levels. This can greatly cut the amount
+of data that must be written, resulting in better performance.
+
+Multiple tunabels to better regulate how fast ZFS can accept
+requests. This along helped mediate maximum latency on parallel access
+with small ARC:
+
+```bash
+zfs_vdev_async_write_active_min_dirty_percent = 10
+zfs_vdev_async_write_active_max_dirty_percent = 30
+zfs_delay_min_dirty_percent = 40
+zfs_delay_scale = 800000
+zfs_dirty_data_max = 50% of zfs_arc_max
+zfs_dirty_data_sync_percent = 15
+```

--- a/pkg/pillar/cmd/volumemgr/prepare.go
+++ b/pkg/pillar/cmd/volumemgr/prepare.go
@@ -75,7 +75,7 @@ func prepareZVol(ctx *volumemgrContext, status types.VolumeStatus) error {
 		}
 	}
 	zVolName := status.ZVolName(types.VolumeZFSPool)
-	if stdoutStderr, err := zfs.CreateVolumeDataset(log, zVolName, size, "on"); err != nil {
+	if stdoutStderr, err := zfs.CreateVolumeDataset(log, zVolName, size, "zstd"); err != nil {
 		errStr := fmt.Sprintf("Error creating zfs zvol at %s, error=%v, output=%s",
 			zVolName, err, stdoutStderr)
 		log.Error(errStr)

--- a/pkg/pillar/zfs/zfs.go
+++ b/pkg/pillar/zfs/zfs.go
@@ -83,7 +83,11 @@ func CreateVolumeDataset(log *base.LogObject, dataset string, size uint64, compr
 		"-V", strconv.FormatUint(size, 10),
 		"-o", "volmode=dev",
 		"-o", fmt.Sprintf("compression=%s", compression),
+		"-o", "volblocksize=16k",
+		"-o", "logbias=throughput",
+		"-o", "redundant_metadata=most",
 		dataset)
+
 	stdoutStderr, err := base.Exec(log, vault.ZfsPath, args...).CombinedOutput()
 	if err != nil {
 		return string(stdoutStderr), err


### PR DESCRIPTION
This PR dramatically reduces memory consumption, without sacrafizing too much of performance. 

**primarycache=metadata** allows to keep arc cache size low. The primary use-case of zfs is zvol attached to a VM. And VM already does cache it's data, furthermore it knows better what to cache. Now once we changed cache usage to metadata-only, we can reduce the size of the ARC to the size of metadata.

**recordsize=16k** - is a sweet spot between constantly having sub-blocks
updates, and good compression ratio.

**compression=zstd** - is a less cpu intencive algorithm, with not too big compromise on compression ratio

**redundant_metadata=most** - will reduce the number of copies of the indirect blocks at the higher levels. This can greatly cut the amount of data that must be written, resulting in better performance.

Different delays are adjusted to better regulate how fast ZFS can accept requests. This along helped mediate maximum latency on parallel access with small ARC.