### PR TITLE
parse-pkgs generates all known; docker-compose standardized

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -387,9 +387,11 @@ run-grub: $(BIOS_IMG) $(UBOOT_IMG) $(EFI_PART) $(DEVICETREE_DTB)
 	$(QEMU_SYSTEM) $(QEMU_OPTS) -drive format=vvfat,id=uefi-disk,label=EVE,file=fat:rw:$(EFI_PART)/..
 	$(QUIET): $@: Succeeded
 
-run-compose: images/docker-compose.yml images/version.yml
-	docker-compose -f $< run storage-init sh -c 'rm -rf /run/* /config/* ; cp -Lr /conf/* /config/ ; echo IMGA > /run/eve.id'
-	docker-compose -f $< up
+run-compose: images/version.yml
+	# we regenerate this on every run, in case things changed
+	$(PARSE_PKGS) > tmp/images
+	docker-compose -f docker-compose.yml run storage-init sh -c 'rm -rf /run/* /config/* ; cp -Lr /conf/* /config/ ; echo IMGA > /run/eve.id'
+	docker-compose -f docker-compose.yml --env-file tmp/images up
 
 run-proxy:
 	ssh $(SSH_PROXY) -N -i $(SSH_KEY) -p $(SSH_PORT) -o StrictHostKeyChecking=no -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null root@localhost &

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ volumes:
     persist: {}
     config: {}
     run: {}
+    version: {}
 
 networks:
     # eve-host:
@@ -38,7 +39,7 @@ networks:
 services:
     # this is the only service from the onboot: section
     storage-init:
-        image: STORAGE_INIT_TAG
+        image: ${STORAGE_INIT_TAG}
         volumes:
             - persist:/persist
             - config:/config
@@ -53,7 +54,7 @@ services:
             - eve
 
     newlogd:
-        image: NEWLOGD_TAG
+        image: ${NEWLOGD_TAG}
         privileged: true
         volumes:
             - persist:/persist
@@ -63,7 +64,7 @@ services:
             - eve
 
     wwan:
-        image: WWAN_TAG
+        image: ${WWAN_TAG}
         privileged: true
         volumes:
             - persist:/persist
@@ -74,7 +75,7 @@ services:
             - eve
 
     wlan:
-        image: WLAN_TAG
+        image: ${WLAN_TAG}
         privileged: true
         volumes:
             - persist:/persist
@@ -85,7 +86,7 @@ services:
             - eve
 
     guacd:
-        image: GUACD_TAG
+        image: ${GUACD_TAG}
         privileged: true
         volumes:
             - persist:/persist
@@ -96,7 +97,7 @@ services:
             - eve
 
     vtpm:
-        image: VTPM_TAG
+        image: ${VTPM_TAG}
         privileged: true
         volumes:
             - persist:/persist
@@ -107,7 +108,7 @@ services:
             - eve
 
     watchdog:
-        image: WATCHDOG_TAG
+        image: ${WATCHDOG_TAG}
         privileged: true
         volumes:
             - persist:/persist
@@ -118,7 +119,7 @@ services:
             - eve
 
     xen-tools:
-        image: XENTOOLS_TAG
+        image: ${XENTOOLS_TAG}
         privileged: true
         volumes:
             - persist:/persist
@@ -129,7 +130,7 @@ services:
             - eve
 
     kvm-tools:
-        image: KVMTOOLS_TAG
+        image: ${KVMTOOLS_TAG}
         privileged: true
         volumes:
             - persist:/persist
@@ -139,7 +140,7 @@ services:
             - eve
 
     pillar:
-        image: PILLAR_TAG
+        image: ${PILLAR_TAG}
         # privileged: true
         volumes:
             - persist:/persist

--- a/tools/parse-pkgs.sh
+++ b/tools/parse-pkgs.sh
@@ -51,39 +51,48 @@ synthetic_tag() {
 }
 
 resolve_tags() {
-sed -e "s#CURDIR#$(pwd)#" \
-    -e "s#ACRN_KERNEL_TAG#$ACRN_KERNEL_TAG#" \
-    -e "s#NEW_KERNEL_TAG#$NEW_KERNEL_TAG#" \
-    -e "s#KERNEL_TAG#$KERNEL_TAG#" \
-    -e "s#FW_TAG#$FW_TAG#" \
-    -e "s#XENTOOLS_TAG#$XENTOOLS_TAG#" \
-    -e "s#DOM0ZTOOLS_TAG#$DOM0ZTOOLS_TAG#" \
-    -e "s#RNGD_TAG#$RNGD_TAG#" \
-    -e "s#XEN_TAG#$XEN_TAG#" \
-    -e "s#ACRN_TAG#$ACRN_TAG#" \
-    -e "s#DNSMASQ_TAG#$DNSMASQ_TAG#" \
-    -e "s#STRONGSWAN_TAG#$STRONGSWAN_TAG#" \
-    -e "s#TESTMSVCS_TAG#$TESTMSVCS_TAG#" \
-    -e "s#PILLAR_TAG#$PILLAR_TAG#" \
-    -e "s#STORAGE_INIT_TAG#$STORAGE_INIT_TAG#" \
-    -e "s#WWAN_TAG#$WWAN_TAG#" \
-    -e "s#WLAN_TAG#$WLAN_TAG#" \
-    -e "s#GUACD_TAG#$GUACD_TAG#" \
-    -e "s#GRUB_TAG#$GRUB_TAG#" \
-    -e "s#GPTTOOLS_TAG#$GPTTOOLS_TAG#" \
-    -e "s#NEWLOGD_TAG#$NEWLOGD_TAG#" \
-    -e "s#WATCHDOG_TAG#$WATCHDOG_TAG#" \
-    -e "s#MKRAW_TAG#$MKRAW_TAG#" \
-    -e "s#MKISO_TAG#$MKISO_TAG#" \
-    -e "s#MKCONF_TAG#$MKCONF_TAG#" \
-    -e "s#DEBUG_TAG#$DEBUG_TAG#" \
-    -e "s#LISP_TAG#$LISP_TAG#" \
-    -e "s#VTPM_TAG#${VTPM_TAG}#" \
-    -e "s#UEFI_TAG#${UEFI_TAG}#" \
-    -e "s#EVE_TAG#${EVE_TAG:-}#" \
-    -e "s#KVMTOOLS_TAG#${KVMTOOLS_TAG}#" \
-    -e "s#IPXE_TAG#${IPXE_TAG}#" \
-    ${1:-}
+  local tags="$1"
+  local file="$2"
+  local sedcmd
+  sedcmd=$(echo "$tags" | sed -e "s/^/s#/g" -e "s/$/#g/g" -e "s/=/#/g")
+  sed -e "$sedcmd" "${file:-}"
+}
+
+gen_tags() {
+cat <<EOF
+CURDIR=$(pwd)
+ACRN_KERNEL_TAG=${ACRN_KERNEL_TAG}
+NEW_KERNEL_TAG=${NEW_KERNEL_TAG}
+KERNEL_TAG=${KERNEL_TAG}
+FW_TAG=${FW_TAG}
+XENTOOLS_TAG=${XENTOOLS_TAG}
+DOM0ZTOOLS_TAG=${DOM0ZTOOLS_TAG}
+RNGD_TAG=${RNGD_TAG}
+XEN_TAG=${XEN_TAG}
+ACRN_TAG=${ACRN_TAG}
+DNSMASQ_TAG=${DNSMASQ_TAG}
+STRONGSWAN_TAG=${STRONGSWAN_TAG}
+TESTMSVCS_TAG=${TESTMSVCS_TAG}
+PILLAR_TAG=${PILLAR_TAG}
+STORAGE_INIT_TAG=${STORAGE_INIT_TAG}
+WWAN_TAG=${WWAN_TAG}
+WLAN_TAG=${WLAN_TAG}
+GUACD_TAG=${GUACD_TAG}
+GRUB_TAG=${GRUB_TAG}
+GPTTOOLS_TAG=${GPTTOOLS_TAG}
+NEWLOGD_TAG=${NEWLOGD_TAG}
+WATCHDOG_TAG=${WATCHDOG_TAG}
+MKRAW_TAG=${MKRAW_TAG}
+MKISO_TAG=${MKISO_TAG}
+MKCONF_TAG=${MKCONF_TAG}
+DEBUG_TAG=${DEBUG_TAG}
+LISP_TAG=${LISP_TAG}
+VTPM_TAG=${VTPM_TAG}
+UEFI_TAG=${UEFI_TAG}
+EVE_TAG=${EVE_TAG:-}
+KVMTOOLS_TAG=${KVMTOOLS_TAG}
+IPXE_TAG=${IPXE_TAG}
+EOF
 }
 
 if [ -z "$DOCKER_ARCH_TAG" ] ; then
@@ -139,4 +148,9 @@ IPXE_TAG=$(linuxkit_tag pkg/ipxe)
 # on the previous tags being already defined.
 EVE_TAG=$(synthetic_tag zededa/eve pkg/pillar/Dockerfile.in)
 
-resolve_tags $1
+TAGS=$(gen_tags)
+if [ $# -ge 1 ]; then
+  resolve_tags "$TAGS" "$1"
+else
+  echo "$TAGS"
+fi


### PR DESCRIPTION
As discussed [here](https://github.com/lf-edge/eve/issues/2406#issuecomment-1002356217) with @rvs 

A few changes:

* `tools/parse-pkgs.sh` is changed so that if no argument is provided, it simply spits out all known package tags in key-value pairs, while if one is provided, it looks at it as a file and parses it.
* `images/docker-compose.yml.in` is replaced by `docker-compose.yml` with all of the image tags set as env vars
* `Makefile` target `run-compose` calls `parse-pkgs.sh > tmp/images`, eliminates generation of `docker-compose.yml`, and simply calls `docker-compose` on the default compose yml, passing in `--env-file tmp/images`.

The primary benefit of this change is that it lets the compose file be standard. This makes it easier for editors to see and parse, people onboarding to find. It also allows a normal `docker-compose up` to simply execute it, while complaining that the env vars were not set. In short, we take advantage of standard tooling without changing functionality.

In terms of `parse-pkgs.sh`, I changed `resolve_tags` to leverage the contents of `gen_tags`, eliminating the need to have the vars defined 3 times. If I could get it down to just once, I would. I have some ideas around arrays, but I am not sure they are worth the trouble.