### PR TITLE
embed cpu microcode updates

### DIFF
--- a/pkg/fw/Dockerfile
+++ b/pkg/fw/Dockerfile
@@ -13,6 +13,12 @@ RUN apk add --no-cache \
     linux-firmware-rtl_nic \
     linux-firmware-other
 
+RUN if [ "$(uname -m)" = "x86_64" ] ; then \
+    apk add --no-cache intel-ucode amd-ucode; \
+    else \
+    mkdir -p /boot; \
+    fi
+
 # FIXME: this is a binary block firmware for Raspberry Pi4, waiting for linux-firmware-rpi4 package
 COPY rpi /lib/firmware/rpi
 
@@ -55,3 +61,5 @@ COPY --from=build /lib/firmware/rpi /lib/firmware
 COPY ath10k /lib/firmware/ath10k
 # FIXME: this is binary block firmware for HiKey
 COPY ti-connectivity /lib/firmware/ti-connectivity
+# ucode files for microcode update
+COPY --from=build /boot /boot

--- a/pkg/fw/Dockerfile
+++ b/pkg/fw/Dockerfile
@@ -13,6 +13,15 @@ RUN apk add --no-cache \
     linux-firmware-rtl_nic \
     linux-firmware-other
 
+# FIXME: this is a binary block firmware for Raspberry Pi4, waiting for linux-firmware-rpi4 package
+COPY rpi /lib/firmware/rpi
+
+# remove rpi and tegra blobs from non arm64 arch
+RUN if [ "$(uname -m)" != "aarch64" ] ; then \
+    rm -rf /lib/firmware/rpi && mkdir -p /lib/firmware/rpi/brcm &&\
+    rm -rf /lib/firmware/nvidia/tegra210 && mkdir -p /lib/firmware/nvidia/tegra210 ;\
+    fi
+
 FROM scratch
 ENTRYPOINT []
 WORKDIR /
@@ -37,8 +46,8 @@ COPY --from=build /lib/firmware/iwlwifi-cc-a0* /lib/firmware/
 COPY --from=build /lib/firmware/iwlwifi-QuZ-a0-hr-b0* /lib/firmware/
 # RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller
 COPY --from=build /lib/firmware/rtl_nic/* /lib/firmware/rtl_nic/
-# FIXME: this is a binary block firmware for Raspberry Pi4, waiting for linux-firmware-rpi4 package
-COPY rpi /lib/firmware/
+# blobs for rpi4
+COPY --from=build /lib/firmware/rpi /lib/firmware
 # FIXME: we're currently using ath10k firmware supplied
 # by Advantech. This is getting upstreamed and when it
 # does we should switch back to linux-firmware-ath10k from Alpine

--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -319,6 +319,14 @@ function set_eve_flavor {
    fi
 }
 
+function set_intel_ucode_boot {
+   set_global initrd "/boot/intel-ucode.img $initrd"
+}
+
+function set_amd_ucode_boot {
+   set_global initrd "/boot/amd-ucode.img $initrd"
+}
+
 set arch=${grub_cpu}
 if [ "$arch" = "i386" ]; then
    # grub CPU i386 means we are running in legacy BIOS mode
@@ -378,6 +386,14 @@ submenu 'Set Boot Options' {
 
    menuentry 'set RISCV/qemu boot options' {
       set_riscv64_qemu
+   }
+
+   menuentry 'use intel-ucode to update microcode' {
+      set_intel_ucode_boot
+   }
+
+   menuentry 'use amd-ucode to update microcode' {
+      set_amd_ucode_boot
    }
 
    menuentry 'skip hypervisor booting' {


### PR DESCRIPTION
We can see problems running VMs with intel microcode embedded (it is clone of Ubuntu 18.04.6 from the bare-metal installation) because of no possibility to update it from inside of VM.
If cpu microcode from inside of BIOS is outdated and have known (possible) vulnerabilities, kernel of VM tries to update it if there are needed blobs inside `/lib/firmware/intel-ucode` (i.e. installed with `intel-microcode` package in Ubuntu) integrated into initramfs. And it stuck for our trial: [stuck-ucode.txt](https://github.com/lf-edge/eve/files/7814645/stuck-ucode.txt)
Removing of `intel-microcode` or adding `dis_ucode_ldr` to the kernel options of VM helps to solve the problem. But in general we should use the latest microcode to mitigate possible vulnerabilities.
Seems we should use up-to-date microcode from host-side (EVE), so, I put intel and amd ucode initrd into /boot inside of fw package (which expand size by 5MB) and remove rpi and tegra blobs from fw for amd64 (to reduce size by 17MB).
Also I add knobs to grub to use ucode on boot `set_intel_ucode_boot` and `set_amd_ucode_boot` (it may affect booting process in some cases, so, seems, it is better to have it disabled by default).