### PR TITLE
Fix wrong permission with initrd.img

### DIFF
--- a/pkg/eve/runme.sh
+++ b/pkg/eve/runme.sh
@@ -117,7 +117,7 @@ do_installer_net() {
   ln -s /bits/* /
   unsquashfs -d /tmp/kernel rootfs.img boot/kernel
   mv /tmp/kernel/boot/kernel /
-  tar -C / -chvf /output.net ipxe.efi.cfg ipxe.efi kernel initrd.img installer.img initrd.bits rootfs.img
+  tar --mode=644 -C / -chvf /output.net ipxe.efi.cfg ipxe.efi kernel initrd.img installer.img initrd.bits rootfs.img
   if [ "$(uname -m)" = aarch64 ]
   then
   cat > /tmp/boot.scr <<__EOT__


### PR DESCRIPTION
Eve 7.4.0
docker run lfedge/eve:tag installer_net to create network installer the output file initrd.img gets 600 instead of 644

Signed-off-by: Ruslan Dautov <dautov2@gmail.com>