### PR TITLE
Reduce severity for errors with datastore in downloader and retry doInstall on errors from volumeRef

### DIFF
--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -463,7 +463,7 @@ func doDownload(ctx *downloaderContext, config types.DownloaderConfig, status *t
 	if dst == nil {
 		errStr := fmt.Sprintf("Will retry when datastore available: %s",
 			err.Error())
-		status.HandleDownloadFail(errStr, 0, false)
+		status.HandleDownloadFail(errStr, retryTime, false)
 		publishDownloaderStatus(ctx, status)
 		log.Errorf("doDownload(%s): deferred with %v", config.Name, err)
 		return

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -257,9 +257,10 @@ func doInstall(ctx *zedmanagerContext,
 		changed = true
 	}
 
-	if status.State < types.CREATED_VOLUME || status.PurgeInprogress != types.NotInprogress {
-		for i := range status.VolumeRefStatusList {
-			vrs := &status.VolumeRefStatusList[i]
+	for i := range status.VolumeRefStatusList {
+		vrs := &status.VolumeRefStatusList[i]
+		// install volume ref again if we had an error
+		if status.State < types.CREATED_VOLUME || status.PurgeInprogress != types.NotInprogress || vrs.HasError() {
 			c := doInstallVolumeRef(ctx, config, status, vrs)
 			if c {
 				changed = true


### PR DESCRIPTION
I can see `Get(zedagent/DatastoreConfig) unknown key` errors from time to time in logs and more important inside info (and in turn in states on cloud side). It comes from concurrence between DatastoreConfig subscribe and ContentTreeConfig on volumemgr side and between Downloader/Resolver Config and DatastoreConfig in downloader. Eventually this error gone (if we have all datastores in place), but the error can confuse user.
In this PR I add small delay in Downloader/Resolver/ContentTree configs (3 seconds for new batch of configs) to give a time for all needed entities to be processed and reduce probability of errors.