### PR TITLE
block sending stacks in metrics to keep the message size smaller

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -1541,7 +1541,8 @@ func createProcessMetrics(ctx *zedagentContext, reportMetrics *metrics.ZMetricMs
 		processMetric.VmBytes = p.VMBytes
 		processMetric.RssBytes = p.RssBytes
 		processMetric.MemoryPercent = p.MemoryPercent
-		processMetric.Stack = p.Stack
+		// XXX block sending stacks to reduce the size of metrics message, for now.
+		//processMetric.Stack = p.Stack
 		reportMetrics.Pr = append(reportMetrics.Pr, processMetric)
 	}
 	log.Tracef("Process metrics done: %v", reportMetrics.Pr)


### PR DESCRIPTION
Signed-off-by: Naiming Shen <naiming@zededa.com>
comment out the sending stack of process in metrics to reduce the size.

there was a bug which caused the process stack collection to be always null,
that was fixed in https://github.com/lf-edge/eve/commit/ec37884f7575f62806a1805ca4a51b236c851ad5.
but that fix caused the metrics message size to be more than doubled, e.g. on 'zc1' from 470k/hour
before to 1.23M/hour after that fix, about 20Mbytes/day increase for that device. This patch is to skip
uploading the process stack in metrics message to bring down the metrics message size to pre 6.12 release.