### PR TITLE
fix make-raw to properly handle stdin and to not adjust partitions for usbconf

### DIFF
--- a/pkg/mkimage-raw-efi/make-raw
+++ b/pkg/mkimage-raw-efi/make-raw
@@ -309,10 +309,10 @@ __EOT__
 
 
 #
-# Extract partitions from stdin or look them up in /bits
+# Extract partitions from stdin if /parts not exists or empty
 #
-if [ ! -d /parts ]; then
-   mkdir /parts
+if [ ! -d /parts ] || [ -z "$(ls -A -- /parts)" ]; then
+   mkdir -p /parts
    (cd /parts ; bsdtar xzf -)
 fi
 
@@ -367,6 +367,12 @@ esac
 for p in $PARTS ; do
   eval do_$p CUR_SEC
 done
+
+if [ "$PARTS" = usb_conf ]; then
+  # Validate the health of our creation
+  sgdisk -v "$IMGFILE"
+  exit 0
+fi
 
 # Create a hybrid MBR to allow booting on legacy BIOS PC systems and ARM boards that
 # look for bootloaders in the first entry of the MBR


### PR DESCRIPTION
`tools/makeusbconf.sh -d -i -f ./usb.json -s 8000 usb.img` 
doesn't work with defined `usb.json` and stops with empty filesystem and error `/parts/*: No such file or directory`. 
It comes from lines where we check for `/parts` and if it not exists, we extract file comes from tar in stdin. But `/parts` exists, we create it in Dockerfile. So, I add check for tty connected to stdin, if not, we assume that it is pipe from tar.
Another problem I can see is that in case of makeusbconf we create only one partition (from function do_usb_conf) and seems our logic for protective mbr is not applicable there.

cc @milan-zededa 