### PR TITLE
relaxation of check for static IP address: allow address inside dhcp range

### DIFF
--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -1986,6 +1986,20 @@ func parseUnderlayNetworkConfig(appInstance *types.AppInstanceConfig,
 			return appInstance.UnderlayNetworkList[i].IntfOrder <
 				appInstance.UnderlayNetworkList[j].IntfOrder
 		})
+
+	// calculate IfIdx field for interfaces connected to the same network
+	networkIfs := make(map[uuid.UUID]uint32)
+	for i := range appInstance.UnderlayNetworkList {
+		ulCfg := &appInstance.UnderlayNetworkList[i]
+		if ind, ok := networkIfs[ulCfg.Network]; ok {
+			ulCfg.IfIdx = ind
+			networkIfs[ulCfg.Network] = ind + 1
+			continue
+		}
+		networkIfs[ulCfg.Network] = 1
+		ulCfg.IfIdx = 0
+	}
+
 	// XXX remove? Debug?
 	if len(appInstance.UnderlayNetworkList) > 1 {
 		log.Functionf("XXX post sort %+v", appInstance.UnderlayNetworkList)

--- a/pkg/pillar/cmd/zedrouter/ipaddronunet.go
+++ b/pkg/pillar/cmd/zedrouter/ipaddronunet.go
@@ -12,18 +12,21 @@ import (
 )
 
 func appNumsOnUNetAllocate(ctx *zedrouterContext,
-	config *types.AppNetworkConfig) error {
+	config *types.AppNetworkConfig, static bool) error {
 
 	log.Functionf("appNumsOnUNetAllocate(%v) for %s",
 		config.UUIDandVersion, config.DisplayName)
 	for _, ulConfig := range config.UnderlayNetworkList {
-		isStatic := (ulConfig.AppIPAddr != nil)
+		if (ulConfig.AppIPAddr != nil) != static {
+			//skip creation based on static or not
+			continue
+		}
 		appID := config.UUIDandVersion.UUID
 		networkID := ulConfig.Network
 		appNum, err := appNumOnUNetAllocate(ctx, networkID, appID,
-			isStatic, false)
+			ulConfig.AppIPAddr, false)
 		if err != nil {
-			errStr := fmt.Sprintf("App Num get fail :%s", err)
+			errStr := fmt.Sprintf("App Num get fail: %s", err)
 			log.Errorf("appNumsOnUNetAllocate(%s, %s): fail: %s",
 				networkID.String(), appID.String(), errStr)
 			return errors.New(errStr)

--- a/pkg/pillar/cmd/zedrouter/ipaddronunet.go
+++ b/pkg/pillar/cmd/zedrouter/ipaddronunet.go
@@ -24,7 +24,7 @@ func appNumsOnUNetAllocate(ctx *zedrouterContext,
 		appID := config.UUIDandVersion.UUID
 		networkID := ulConfig.Network
 		appNum, err := appNumOnUNetAllocate(ctx, networkID, appID,
-			ulConfig.AppIPAddr, false)
+			ulConfig.AppIPAddr, ulConfig.IfIdx, false)
 		if err != nil {
 			errStr := fmt.Sprintf("App Num get fail: %s", err)
 			log.Errorf("appNumsOnUNetAllocate(%s, %s): fail: %s",
@@ -47,9 +47,6 @@ func appNumsOnUNetFree(ctx *zedrouterContext,
 		ulStatus := &status.UnderlayNetworkList[ulNum]
 		networkID := ulStatus.Network
 		// release the app number
-		_, err := appNumOnUNetGet(ctx, networkID, appID)
-		if err == nil {
-			appNumOnUNetFree(ctx, networkID, appID)
-		}
+		appNumOnUNetClean(ctx, networkID, appID)
 	}
 }

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -1422,7 +1422,7 @@ func getUlAddrs(ctx *zedrouterContext,
 		}
 	} else {
 		// get the app number for the underlay network entry
-		appNum, err := appNumOnUNetGet(ctx, networkID, appID)
+		appNum, err := appNumOnUNetGet(ctx, networkID, appID, ulStatus.IfIdx)
 		if err != nil {
 			errStr := fmt.Sprintf("App Number get failed: %v", err)
 			log.Errorf("getUlAddrs(%s): app(%s) fail: %s",
@@ -1735,12 +1735,12 @@ func doAppNetworkModifyUNetAppNum(
 	networkID := ulConfig.Network
 	oldNetworkID := ulStatus.Network
 	// release the app number on old network
-	if _, err := appNumOnUNetGet(ctx, oldNetworkID, appID); err == nil {
-		appNumOnUNetFree(ctx, oldNetworkID, appID)
+	if _, err := appNumOnUNetGet(ctx, oldNetworkID, appID, ulStatus.IfIdx); err == nil {
+		appNumOnUNetFree(ctx, oldNetworkID, appID, ulStatus.IfIdx)
 	}
 	// allocate an app number on new network
 	if _, err := appNumOnUNetAllocate(ctx, networkID, appID,
-		ulConfig.AppIPAddr, false); err != nil {
+		ulConfig.AppIPAddr, ulConfig.IfIdx, false); err != nil {
 		log.Errorf("appNumsOnUNetAllocate(%s, %s): fail: %s",
 			networkID.String(), appID.String(), err)
 		return err

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -1404,15 +1404,6 @@ func getUlAddrs(ctx *zedrouterContext,
 	// for static IP Address
 	if ulStatus.AppIPAddr != nil {
 		ipAddr = ulStatus.AppIPAddr.String()
-		// the IP Address, should not be in dhcpRange
-		if netInstStatus.DhcpRange.Contains(ulStatus.AppIPAddr) {
-			errStr := fmt.Sprintf("static IP(%s) is in DhcpRange(%s, %s)",
-				ipAddr, netInstStatus.DhcpRange.Start.String(),
-				netInstStatus.DhcpRange.End.String())
-			log.Errorf("getUlAddrs(%s): app(%s) fail: %s",
-				networkID.String(), appID.String(), errStr)
-			return "", errors.New(errStr)
-		}
 		// IP Address must be inside the subnet range
 		if !netInstStatus.Subnet.Contains(ulStatus.AppIPAddr) {
 			errStr := fmt.Sprintf("static IP(%s) is outside subnet range",

--- a/pkg/pillar/types/types.go
+++ b/pkg/pillar/types/types.go
@@ -279,6 +279,7 @@ type UEvent struct {
 type UUIDPairToNum struct {
 	BaseID      uuid.UUID
 	AppID       uuid.UUID
+	IfIdx       uint32
 	Number      int
 	NumType     string
 	CreateTime  time.Time
@@ -288,12 +289,16 @@ type UUIDPairToNum struct {
 
 // Key is the key in pubsub
 func (info UUIDPairToNum) Key() string {
-	return UUIDPairToNumKey(info.BaseID, info.AppID)
+	return UUIDPairToNumKey(info.BaseID, info.AppID, info.IfIdx)
 }
 
 // UUIDPairToNumKey is the index key
-func UUIDPairToNumKey(baseID, appID uuid.UUID) string {
-	return baseID.String() + "-" + appID.String()
+func UUIDPairToNumKey(baseID, appID uuid.UUID, ifIdx uint32) string {
+	// special case to support old versions without ifIdx
+	if ifIdx == 0 {
+		return baseID.String() + "-" + appID.String()
+	}
+	return fmt.Sprintf("%s-%s-%d", baseID.String(), appID.String(), ifIdx)
 }
 
 // LogCreate :

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -1967,6 +1967,7 @@ type UnderlayNetworkConfig struct {
 	Network      uuid.UUID // Points to a NetworkInstance.
 	ACLs         []ACE
 	AccessVlanID uint32
+	IfIdx        uint32 // If we have multiple interfaces on that network, we will increase the index
 }
 
 type UnderlayNetworkStatus struct {

--- a/pkg/pillar/uuidpairtonum/uuidpairtonum.go
+++ b/pkg/pillar/uuidpairtonum/uuidpairtonum.go
@@ -14,10 +14,10 @@ import (
 	"github.com/satori/go.uuid"
 )
 
-// NumGet : return the number for a given UUID pair
+// NumGet : return the number for a given UUID pair and interface index
 func NumGet(log *base.LogObject, pub pubsub.Publication,
-	baseID uuid.UUID, appID uuid.UUID, numType string) (int, error) {
-	key := types.UUIDPairToNumKey(baseID, appID)
+	baseID uuid.UUID, appID uuid.UUID, numType string, ifIdx uint32) (int, error) {
+	key := types.UUIDPairToNumKey(baseID, appID, ifIdx)
 	log.Functionf("NumGet(%s, %s)", key, numType)
 	i, err := pub.Get(key)
 	if err != nil {
@@ -27,19 +27,45 @@ func NumGet(log *base.LogObject, pub pubsub.Publication,
 	return u.Number, nil
 }
 
-// NumAllocate : stores the number for a given UUID pair
+// NumGetAll : return slice of the numbers for a given UUID pair
+func NumGetAll(log *base.LogObject, pub pubsub.Publication,
+	baseID uuid.UUID, appID uuid.UUID, numType string) ([]types.UUIDPairToNum, error) {
+	log.Functionf("NumGetAll(%s, %s)", baseID, appID)
+	pairs := pub.GetAll()
+	var val []types.UUIDPairToNum
+	if pairs == nil {
+		return val, nil
+	}
+	for _, el := range pairs {
+		uuidPairToNum := el.(types.UUIDPairToNum)
+		if uuidPairToNum.AppID != appID {
+			continue
+		}
+		if uuidPairToNum.BaseID != baseID {
+			continue
+		}
+		if uuidPairToNum.NumType != numType {
+			continue
+		}
+		val = append(val, uuidPairToNum)
+	}
+	return val, nil
+}
+
+// NumAllocate : stores the number for a given UUID pair and interface index
 func NumAllocate(log *base.LogObject, pub pubsub.Publication,
 	baseID uuid.UUID, appID uuid.UUID, appNum int, mustCreate bool,
-	numType string) {
-	log.Functionf("NumAllocate(%s, %s, %d, %v)", baseID.String(),
-		appID.String(), appNum, mustCreate)
+	numType string, ifIdx uint32) {
+	log.Functionf("NumAllocate(%s, %s, %d, %d, %v)", baseID.String(),
+		appID.String(), ifIdx, appNum, mustCreate)
 	now := time.Now()
-	key := types.UUIDPairToNumKey(baseID, appID)
+	key := types.UUIDPairToNumKey(baseID, appID, ifIdx)
 	i, err := pub.Get(key)
 	if err != nil {
 		u := types.UUIDPairToNum{
 			BaseID:      baseID,
 			AppID:       appID,
+			IfIdx:       ifIdx,
 			CreateTime:  now,
 			LastUseTime: now,
 			InUse:       true,
@@ -84,8 +110,8 @@ func NumAllocate(log *base.LogObject, pub pubsub.Publication,
 
 // NumFree : Clears InUse flag
 func NumFree(log *base.LogObject, pub pubsub.Publication,
-	baseID uuid.UUID, appID uuid.UUID) {
-	key := types.UUIDPairToNumKey(baseID, appID)
+	baseID uuid.UUID, appID uuid.UUID, ifIdx uint32) {
+	key := types.UUIDPairToNumKey(baseID, appID, ifIdx)
 	i, err := pub.Get(key)
 	if err != nil {
 		log.Fatalf("NumFree(%s) does not exist", key)
@@ -102,10 +128,10 @@ func NumFree(log *base.LogObject, pub pubsub.Publication,
 	}
 }
 
-// NumDelete : Removes the integer map for a given UUID pair
+// NumDelete : Removes the integer map for a given UUID pair and interface index
 func NumDelete(log *base.LogObject, pub pubsub.Publication,
-	baseID uuid.UUID, appID uuid.UUID) {
-	key := types.UUIDPairToNumKey(baseID, appID)
+	baseID uuid.UUID, appID uuid.UUID, ifIdx uint32) {
+	key := types.UUIDPairToNumKey(baseID, appID, ifIdx)
 	_, err := pub.Get(key)
 	if err != nil {
 		log.Fatalf("NumDelete(%s) does not exist", key)


### PR DESCRIPTION
When we try to deploy a Network Instance from the controller we may omit "IP Address Range" or set it to the whole subnet (except broadcast/gateway addresses). When we try to deploy an app on that NetworkInstance we cannot do it with static IP address and this behavior broke logic for automatic cluster deployment.
It seems reasonable to relax check for static IP address inside EVE to not check for IP address is inside IP Address Range or not, but to check if this address assigned to any other app or not (reasonable to check assignment for dynamic ones as well).