### PR TITLE
kernel: make patches am-able

### DIFF
--- a/pkg/kernel/patches-5.10.x/0001-This-patch-adds-the-driver-for-the-IXXAT-USB-to-CAN-.patch
+++ b/pkg/kernel/patches-5.10.x/0001-This-patch-adds-the-driver-for-the-IXXAT-USB-to-CAN-.patch
@@ -1,11 +1,10 @@
-From a40199e4f0732709e2cebccba08a8902a373a297 Mon Sep 17 00:00:00 2001
+From 646851bc091cf89a6f2a087e3ba3258a0d015194 Mon Sep 17 00:00:00 2001
 From: Florian Ferg <flfe@xxxxxxxxxxxxxxx>
 Date: Sat, 31 Oct 2020 19:50:37 -0400
-Subject: [PATCH 01/14] This patch adds the driver for the IXXAT USB-to-CAN
+Subject: [PATCH 01/12] This patch adds the driver for the IXXAT USB-to-CAN
  interfaces. There is an adapter for the older communication layer cl1 and
  another adapter for the newer communication layer cl2.
 
-Signed-off-by: Florian Ferg <flfe@xxxxxxxxxxxxxxx>
 ---
  drivers/net/can/usb/Kconfig            |    6 +
  drivers/net/can/usb/Makefile           |    1 +
@@ -24,7 +23,7 @@ Signed-off-by: Florian Ferg <flfe@xxxxxxxxxxxxxxx>
  create mode 100644 drivers/net/can/usb/ixx/ixx_usb_core.h
 
 diff --git a/drivers/net/can/usb/Kconfig b/drivers/net/can/usb/Kconfig
-index b412f7ba4f89..33c7ea4cd949 100644
+index bcb331b0c958..f786b6c6348e 100644
 --- a/drivers/net/can/usb/Kconfig
 +++ b/drivers/net/can/usb/Kconfig
 @@ -29,6 +29,12 @@ config CAN_GS_USB
@@ -39,7 +38,7 @@ index b412f7ba4f89..33c7ea4cd949 100644
 +
  config CAN_KVASER_USB
  	tristate "Kvaser CAN/USB interface"
- 	---help---
+ 	help
 diff --git a/drivers/net/can/usb/Makefile b/drivers/net/can/usb/Makefile
 index aa0f17c0b2ed..2f9052abc1b2 100644
 --- a/drivers/net/can/usb/Makefile
@@ -2481,5 +2480,5 @@ index 000000000000..e57b435dd457
 +
 +#endif /* IXXAT_USB_CORE_H */
 -- 
-2.26.2
+2.25.1
 

--- a/pkg/kernel/patches-5.10.x/0002-Xen-SMBIOS-property-add.patch
+++ b/pkg/kernel/patches-5.10.x/0002-Xen-SMBIOS-property-add.patch
@@ -1,11 +1,14 @@
-commit dd7076bed514bdc6230610d7d8e92be6264b54f9
-Author: Stefano Stabellini <sstabellini@kernel.org>
-Date:   Thu Dec 17 18:27:32 2020 -0800
+From ac641b059cbd8b324e038258ff06fabc0100a18b Mon Sep 17 00:00:00 2001
+From: Stefano Stabellini <sstabellini@kernel.org>
+Date: Thu, 17 Dec 2020 18:27:32 -0800
+Subject: [PATCH 02/12]  Xen SMBIOS property add
 
-    Xen SMBIOS property add
+---
+ arch/arm/xen/enlighten.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
 
 diff --git a/arch/arm/xen/enlighten.c b/arch/arm/xen/enlighten.c
-index 60e901cd0de6..948786d28bb3 100644
+index 8ad576ecd0f1..2a7ec6552f22 100644
 --- a/arch/arm/xen/enlighten.c
 +++ b/arch/arm/xen/enlighten.c
 @@ -33,6 +33,7 @@
@@ -37,3 +40,6 @@ index 60e901cd0de6..948786d28bb3 100644
  }
  
  static int __init xen_guest_init(void)
+-- 
+2.25.1
+

--- a/pkg/kernel/patches-5.10.x/0003-arm-dts-rpi4-swap-uart-as-in-raspberry-linux.patch
+++ b/pkg/kernel/patches-5.10.x/0003-arm-dts-rpi4-swap-uart-as-in-raspberry-linux.patch
@@ -1,7 +1,7 @@
-From 33886c32c250b25900f11533f04232e902f943fb Mon Sep 17 00:00:00 2001
+From a04dc7e9bd873234edca0d65b71a4cae046343c5 Mon Sep 17 00:00:00 2001
 From: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>
 Date: Fri, 22 Oct 2021 09:41:37 +0300
-Subject: [PATCH] arm: dts: rpi4: swap uart as in raspberry/linux
+Subject: [PATCH 03/12] arm: dts: rpi4: swap uart as in raspberry/linux
 
 Signed-off-by: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm/boot/dts/bcm2711-rpi-4-b.dts b/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
-index 09a1182c2936..c5d7353ec823 100644
+index 167538518a1e..fcd561c021ea 100644
 --- a/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
 +++ b/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
 @@ -12,7 +12,7 @@ / {

--- a/pkg/kernel/patches-5.10.x/0004-rsi91x-Check-wowlan-pointer-in-rsi_shutdown.patch
+++ b/pkg/kernel/patches-5.10.x/0004-rsi91x-Check-wowlan-pointer-in-rsi_shutdown.patch
@@ -1,29 +1,29 @@
-From e69899b984b70b90f22ef28138277e66a9ad2884 Mon Sep 17 00:00:00 2001
+From 4525c94498360d38eabbebabf9dab84ff690b2de Mon Sep 17 00:00:00 2001
 From: Sergey Temerkhanov <s.temerkhanov@gmail.com>
 Date: Wed, 26 Aug 2020 00:02:19 +0300
-Subject: [PATCH 14/14] rsi91x: Check wowlan pointer in rsi_shutdown
+Subject: [PATCH 04/12] rsi91x: Check wowlan pointer in rsi_shutdown
 
 Check wowlan pointer before calling rsi_config_wowlan to
 prevent erroneous configuration attempts
 
 Signed-off-by: Sergey Temerkhanov <s.temerkhanov@gmail.com>
 ---
- drivers/net/wireless/rsi/rsi_91x_sdio.c | 3 ++-
- 1 file changed, 2 insertions(+), 1 deletion(-)
+ drivers/net/wireless/rsi/rsi_91x_sdio.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/wireless/rsi/rsi_91x_sdio.c b/drivers/net/wireless/rsi/rsi_91x_sdio.c
-index 1bebba4e8527..1fd208bea839 100644
+index 3a243c532647..114ea93c8abf 100644
 --- a/drivers/net/wireless/rsi/rsi_91x_sdio.c
 +++ b/drivers/net/wireless/rsi/rsi_91x_sdio.c
-@@ -1473,7 +1473,7 @@
+@@ -1469,7 +1469,7 @@ static void rsi_shutdown(struct device *dev)
  	if (hw) {
  		struct cfg80211_wowlan *wowlan = hw->wiphy->wowlan_config;
-
+ 
 -		if (rsi_config_wowlan(adapter, wowlan))
 +		if (wowlan && rsi_config_wowlan(adapter, wowlan))
  			rsi_dbg(ERR_ZONE, "Failed to configure WoWLAN\n");
  	}
-
+ 
 -- 
-2.26.2
+2.25.1
 

--- a/pkg/kernel/patches-5.10.x/0005-fget-Do-not-loop-with-rcu-lock-held.patch
+++ b/pkg/kernel/patches-5.10.x/0005-fget-Do-not-loop-with-rcu-lock-held.patch
@@ -1,20 +1,18 @@
-From 59ab1a96357ccc470294663e0ceeeaab0c0b7ddd Mon Sep 17 00:00:00 2001
+From 0f0f02452a0ee5eb07126acb8d6dfd53e8502d4e Mon Sep 17 00:00:00 2001
 From: Sergey Temerkhanov <s.temerkhanov@gmail.com>
 Date: Wed, 4 Nov 2020 04:16:57 -0500
-Subject: [PATCH] fget: Do not loop with rcu lock held
+Subject: [PATCH 05/12] fget: Do not loop with rcu lock held
 
 Do not loop wint the RCU lock held
-
-Signed-off-by: Sergey Temerkhanov <s.temerkhanov@gmail.com>
 ---
  fs/file.c | 34 ++++++++++++++++++++--------------
  1 file changed, 20 insertions(+), 14 deletions(-)
 
 diff --git a/fs/file.c b/fs/file.c
-index 5a0fa61504ff..c9ac0232df20 100644
+index 21c0893f2f1d..ab12f5fbcecb 100644
 --- a/fs/file.c
 +++ b/fs/file.c
-@@ -829,21 +829,27 @@
+@@ -821,21 +821,27 @@ static struct file *__fget_files(struct files_struct *files, unsigned int fd,
  				 fmode_t mask, unsigned int refs)
  {
  	struct file *file;
@@ -22,7 +20,7 @@ index 5a0fa61504ff..c9ac0232df20 100644
  
 -	rcu_read_lock();
 -loop:
--	file = files_lookup_fd_rcu(files, fd);
+-	file = fcheck_files(files, fd);
 -	if (file) {
 -		/* File object ref couldn't be taken.
 -		 * dup2() atomicity guarantee is the reason
@@ -37,7 +35,7 @@ index 5a0fa61504ff..c9ac0232df20 100644
 +	do {
 +		rcu_read_lock();
 +
-+		file = files_lookup_fd_rcu(files, fd);
++		file = fcheck_files(files, fd);
 +		if (file) {
 +			/* File object ref couldn't be taken.
 +			* dup2() atomicity guarantee is the reason
@@ -56,3 +54,6 @@ index 5a0fa61504ff..c9ac0232df20 100644
  
  	return file;
  }
+-- 
+2.25.1
+

--- a/pkg/kernel/patches-5.10.x/0006-tpm-Rework-open-close-shutdown-to-avoid-races.patch
+++ b/pkg/kernel/patches-5.10.x/0006-tpm-Rework-open-close-shutdown-to-avoid-races.patch
@@ -1,7 +1,7 @@
-From ca319096f95ee2d269d31cad888ec19dad89d516 Mon Sep 17 00:00:00 2001
+From 0d2f60b2a86d0d92a3d5ec29ff38bddd9188b2cf Mon Sep 17 00:00:00 2001
 From: Sergey Temerkhanov <s.temerkhanov@gmail.com>
 Date: Mon, 30 Nov 2020 05:58:22 +0300
-Subject: [PATCH] tpm: Rework open/close/shutdown to avoid races
+Subject: [PATCH 06/12] tpm: Rework open/close/shutdown to avoid races
 
 Avoid race condition at shutdown by shutting downn the TPM 2.0
 devices synchronously. This eliminates the condition when the
@@ -24,7 +24,7 @@ Signed-off-by: Sergey Temerkhanov <s.temerkhanov@gmail.com>
  4 files changed, 21 insertions(+), 9 deletions(-)
 
 diff --git a/drivers/char/tpm/tpm-chip.c b/drivers/char/tpm/tpm-chip.c
-index 1838039b0333..db36c7be0c79 100644
+index ddaeceb7e109..e94148b8e180 100644
 --- a/drivers/char/tpm/tpm-chip.c
 +++ b/drivers/char/tpm/tpm-chip.c
 @@ -295,6 +295,7 @@ static int tpm_class_shutdown(struct device *dev)
@@ -117,7 +117,7 @@ index eef0fb06ea83..fb3cb7b03814 100644
  
  	return 0;
 diff --git a/include/linux/tpm.h b/include/linux/tpm.h
-index 77fdc988c610..590111bbd91c 100644
+index 804a3f69bbd9..c9733a779a99 100644
 --- a/include/linux/tpm.h
 +++ b/include/linux/tpm.h
 @@ -21,6 +21,7 @@
@@ -127,8 +127,8 @@ index 77fdc988c610..590111bbd91c 100644
 +#include <linux/atomic.h>
  #include <linux/highmem.h>
  #include <crypto/hash_info.h>
-
-@@ -125,8 +126,9 @@ struct tpm_chip {
+ 
+@@ -128,8 +129,9 @@ struct tpm_chip {
  
  	unsigned int flags;
  

--- a/pkg/kernel/patches-5.10.x/0007-add-acs-overrides-for-linux-kernel-version-5.4.51.patch
+++ b/pkg/kernel/patches-5.10.x/0007-add-acs-overrides-for-linux-kernel-version-5.4.51.patch
@@ -1,7 +1,7 @@
-From 4287c729bf39a12a138dab0d25feed43b581d891 Mon Sep 17 00:00:00 2001
+From 3221b235ce2edb767b3e724f5e6b7ac1c5865b02 Mon Sep 17 00:00:00 2001
 From: Hariharasubramanian C S <cshari@zededa.com>
 Date: Mon, 23 Nov 2020 11:21:45 +0530
-Subject: [PATCH] add acs overrides for linux kernel version 5.4.51
+Subject: [PATCH 07/12] add acs overrides for linux kernel version 5.4.51
 
 This particular patch was taken from:
 https://gitlab.com/Queuecumber/linux-acs-override/-/blob/master/workspaces/5.4/acso.patch
@@ -59,10 +59,10 @@ Signed-off-by: Hariharasubramanian C S <cshari@zededa.com>
  2 files changed, 109 insertions(+)
 
 diff --git a/Documentation/admin-guide/kernel-parameters.txt b/Documentation/admin-guide/kernel-parameters.txt
-index 7bc83f3d9bdf..3174f3bd126a 100644
+index f103667d3727..1f36d9ccc921 100644
 --- a/Documentation/admin-guide/kernel-parameters.txt
 +++ b/Documentation/admin-guide/kernel-parameters.txt
-@@ -3509,6 +3509,15 @@
+@@ -3635,6 +3635,15 @@
  		nomsi		[MSI] If the PCI_MSI kernel config parameter is
  				enabled, this kernel boot option can be used to
  				disable the use of MSI interrupts system-wide.
@@ -79,10 +79,10 @@ index 7bc83f3d9bdf..3174f3bd126a 100644
  				Safety option to keep boot IRQs enabled. This
  				should never be necessary.
 diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
-index ca9ed5774eb1..1af267d0052f 100644
+index 5d2acebc3e96..639fa0fc490c 100644
 --- a/drivers/pci/quirks.c
 +++ b/drivers/pci/quirks.c
-@@ -3544,6 +3544,105 @@ static void quirk_no_bus_reset(struct pci_dev *dev)
+@@ -3560,6 +3560,105 @@ static void quirk_no_bus_reset(struct pci_dev *dev)
  	dev->dev_flags |= PCI_DEV_FLAGS_NO_BUS_RESET;
  }
  
@@ -186,10 +186,10 @@ index ca9ed5774eb1..1af267d0052f 100644
 +	return -ENOTTY;
 +}
  /*
-  * Some Atheros AR9xxx and QCA988x chips do not behave after a bus reset.
-  * The device will throw a Link Down error on AER-capable systems and
-@@ -4796,6 +4895,7 @@ static const struct pci_dev_acs_enabled {
- 	{ PCI_VENDOR_ID_ZHAOXIN, 0x9083, pci_quirk_mf_endpoint_acs },
+  * Some NVIDIA GPU devices do not work with bus reset, SBR needs to be
+  * prevented for those affected devices.
+@@ -4923,6 +5022,7 @@ static const struct pci_dev_acs_enabled {
+ 	{ PCI_VENDOR_ID_NXP, 0x8d9b, pci_quirk_nxp_rp_acs },
  	/* Zhaoxin Root/Downstream Ports */
  	{ PCI_VENDOR_ID_ZHAOXIN, PCI_ANY_ID, pci_quirk_zhaoxin_pcie_ports_acs },
 +	{ PCI_ANY_ID, PCI_ANY_ID, pcie_acs_overrides },
@@ -197,5 +197,5 @@ index ca9ed5774eb1..1af267d0052f 100644
  };
  
 -- 
-2.20.1 (Apple Git-117)
+2.25.1
 

--- a/pkg/kernel/patches-5.10.x/0008-Add-stdout-path-overlay.patch
+++ b/pkg/kernel/patches-5.10.x/0008-Add-stdout-path-overlay.patch
@@ -1,17 +1,41 @@
-From d79a9307d61f4ec2101653059306964b27f2b51b Mon Sep 17 00:00:00 2001
+From f1100acbe759fdebba9ae5dc5c88b798d2a59538 Mon Sep 17 00:00:00 2001
 From: Roman Shaposhnik <rvs@apache.org>
 Date: Sun, 1 Nov 2020 01:41:51 -0500
-Subject: [PATCH 12/14] Add stdout path overlay
+Subject: [PATCH 08/12] Add stdout path overlay
 
 ---
- .../arm/boot/dts/pi4-64-xen-overlay.dts | 16 ++++++++++++++++
- arch/arm/boot/dts/Makefile
- arch/arm64/boot/dts/broadcom/Makefile
- 3 file changed, 16 insertions(+)
+ arch/arm/boot/dts/Makefile                    |   1 +
+ arch/arm64/boot/dts/broadcom/Makefile         |   1 +
+ .../boot/dts/broadcom/raspberrypi-uno-220.dts | 216 ++++++++++++++++++
+ 3 files changed, 218 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/broadcom/raspberrypi-uno-220.dts
 
+diff --git a/arch/arm/boot/dts/Makefile b/arch/arm/boot/dts/Makefile
+index ce66ffd5a1bb..32ea6404a345 100644
+--- a/arch/arm/boot/dts/Makefile
++++ b/arch/arm/boot/dts/Makefile
+@@ -93,6 +93,7 @@ dtb-$(CONFIG_ARCH_BCM2835) += \
+ 	bcm2837-rpi-3-b-plus.dtb \
+ 	bcm2837-rpi-cm3-io3.dtb \
+ 	bcm2711-rpi-4-b.dtb \
++       raspberrypi-uno-220.dtb \
+ 	bcm2835-rpi-zero.dtb \
+ 	bcm2835-rpi-zero-w.dtb
+ dtb-$(CONFIG_ARCH_BCM_5301X) += \
+diff --git a/arch/arm64/boot/dts/broadcom/Makefile b/arch/arm64/boot/dts/broadcom/Makefile
+index cb7de8d99223..8fb2f261750b 100644
+--- a/arch/arm64/boot/dts/broadcom/Makefile
++++ b/arch/arm64/boot/dts/broadcom/Makefile
+@@ -1,5 +1,6 @@
+ # SPDX-License-Identifier: GPL-2.0
+ dtb-$(CONFIG_ARCH_BCM2835) += bcm2711-rpi-4-b.dtb \
++			      raspberrypi-uno-220.dtb \
+ 			      bcm2837-rpi-3-a-plus.dtb \
+ 			      bcm2837-rpi-3-b.dtb \
+ 			      bcm2837-rpi-3-b-plus.dtb \
 diff --git a/arch/arm64/boot/dts/broadcom/raspberrypi-uno-220.dts b/arch/arm64/boot/dts/broadcom/raspberrypi-uno-220.dts
 new file mode 100644
-index 000000000000..b5411de59659
+index 000000000000..c3d25f522be8
 --- /dev/null
 +++ b/arch/arm64/boot/dts/broadcom/raspberrypi-uno-220.dts
 @@ -0,0 +1,216 @@
@@ -231,28 +255,6 @@ index 000000000000..b5411de59659
 +               interrupts = <10 IRQ_TYPE_LEVEL_HIGH>; */
 +       };
 +};
-diff --git a/arch/arm/boot/dts/Makefile b/arch/arm/boot/dts/Makefile
-index fa6db6eed3e2..cbca43456352 100644
---- a/arch/arm/boot/dts/Makefile	2020-12-15 19:34:59.008957000 +0000
-+++ b/arch/arm/boot/dts/Makefile	2020-12-15 19:36:47.756054000 +0000
-@@ -93,6 +93,7 @@
- 	bcm2837-rpi-3-b-plus.dtb \
- 	bcm2837-rpi-cm3-io3.dtb \
- 	bcm2711-rpi-4-b.dtb \
-+       raspberrypi-uno-220.dtb \
- 	bcm2835-rpi-zero.dtb \
- 	bcm2835-rpi-zero-w.dtb
- dtb-$(CONFIG_ARCH_BCM_5301X) += \
-diff --git a/arch/arm/boot/dts/broadcom/Makefile b/arch/arm/boot/dts/broadcom/Makefile
-index fa6db6eed3e2..cbca43456352 100644
---- a/arch/arm64/boot/dts/broadcom/Makefile	2021-04-06 04:24:06.072745079 +0000
-+++ b/arch/arm64/boot/dts/broadcom/Makefile	2021-04-06 04:24:43.729142399 +0000
-@@ -1,5 +1,6 @@
- # SPDX-License-Identifier: GPL-2.0
- dtb-$(CONFIG_ARCH_BCM2835) += bcm2711-rpi-4-b.dtb \
-+			      raspberrypi-uno-220.dtb \
- 			      bcm2837-rpi-3-a-plus.dtb \
- 			      bcm2837-rpi-3-b.dtb \
- 			      bcm2837-rpi-3-b-plus.dtb \
---
-2.26.2
+-- 
+2.25.1
+

--- a/pkg/kernel/patches-5.10.x/0009-Support-for-Siemens-IPC127-MMIO-GPIO-driven-LEDS.patch
+++ b/pkg/kernel/patches-5.10.x/0009-Support-for-Siemens-IPC127-MMIO-GPIO-driven-LEDS.patch
@@ -1,22 +1,25 @@
-From 4c0f50aaa56077957d627a79277eb0d75caca30a Thu Apr 15 00:00:00 2021
+From e5e7bc592b869c71c18c68d531c01bb001525800 Mon Sep 17 00:00:00 2001
 From: Roman Shaposhnik <rvs@apache.org>
 Date: Thu, 15 Apr 2021 16:49:37 +0000
-Subject: [PATCH] Support for Siemens IPC127 MMIO GPIO-driven LEDS
+Subject: [PATCH 09/12] Support for Siemens IPC127 MMIO GPIO-driven LEDS
 
 This simply introduces a tiny LED driver based on the MMIO GPIO
 registers described in user's manual. It would be nice to find
 a generic MMIO GPIO driver since it seems like there's a few that
 do this type of thing already (including the one for APU LEDs that
 was used as a prototype).
-
 ---
- drivers/gpio/gpiolib-acpi.c | 88 ++++++++++++++++++++++++++++++++++++---------
- 1 file changed, 71 insertions(+), 17 deletions(-)
+ drivers/leds/Kconfig               |   8 ++
+ drivers/leds/Makefile              |   1 +
+ drivers/leds/leds-siemens-ipc127.c | 203 +++++++++++++++++++++++++++++
+ 3 files changed, 212 insertions(+)
+ create mode 100644 drivers/leds/leds-siemens-ipc127.c
+
 diff --git a/drivers/leds/Kconfig b/drivers/leds/Kconfig
-index 57d157e..9ff45a3 100644
---- a/drivers/leds/Kconfig	2021-04-15 19:52:27.190000000 +0000
-+++ b/drivers/leds/Kconfig	2021-04-15 19:54:08.970000000 +0000
-@@ -315,6 +315,14 @@
+index 56e8198e13d1..deec7eed8233 100644
+--- a/drivers/leds/Kconfig
++++ b/drivers/leds/Kconfig
+@@ -316,6 +316,14 @@ config LEDS_COBALT_RAQ
  	help
  	  This option enables support for the Cobalt Raq series LEDs.
  
@@ -32,10 +35,10 @@ index 57d157e..9ff45a3 100644
  	tristate "LED support for SunFire servers."
  	depends on LEDS_CLASS
 diff --git a/drivers/leds/Makefile b/drivers/leds/Makefile
-index 57d157e..9ff45a3 100644
---- a/drivers/leds/Makefile	2021-04-15 19:50:57.140000000 +0000
-+++ b/drivers/leds/Makefile	2021-04-15 19:52:16.530000000 +0000
-@@ -84,6 +84,7 @@
+index 73e603e1727e..74db57b7b1f2 100644
+--- a/drivers/leds/Makefile
++++ b/drivers/leds/Makefile
+@@ -83,6 +83,7 @@ obj-$(CONFIG_LEDS_REGULATOR)		+= leds-regulator.o
  obj-$(CONFIG_LEDS_S3C24XX)		+= leds-s3c24xx.o
  obj-$(CONFIG_LEDS_SC27XX_BLTC)		+= leds-sc27xx-bltc.o
  obj-$(CONFIG_LEDS_SGM3140)		+= leds-sgm3140.o
@@ -44,9 +47,10 @@ index 57d157e..9ff45a3 100644
  obj-$(CONFIG_LEDS_SYSCON)		+= leds-syscon.o
  obj-$(CONFIG_LEDS_TCA6507)		+= leds-tca6507.o
 diff --git a/drivers/leds/leds-siemens-ipc127.c b/drivers/leds/leds-siemens-ipc127.c
-index 57d157e..9ff45a3 100644
---- /dev/null	2021-04-15 19:50:35.920000000 +0000
-+++ a/drivers/leds/leds-siemens-ipc127.c	2021-04-15 22:54:26.370000000 +0000
+new file mode 100644
+index 000000000000..59a474820a5b
+--- /dev/null
++++ b/drivers/leds/leds-siemens-ipc127.c
 @@ -0,0 +1,203 @@
 +/*
 + * drivers/leds/leds-siemends-ipc127.c
@@ -251,3 +255,6 @@ index 57d157e..9ff45a3 100644
 +MODULE_DESCRIPTION("Siemens IPC127 MMIO GPIO-driven LEDS");
 +MODULE_LICENSE("GPL v2");
 +MODULE_ALIAS("platform:leds_siemens_ipc127");
+-- 
+2.25.1
+

--- a/pkg/kernel/patches-5.10.x/0010-ACPI-Add-support-to-map-GPIO-resources-to-ranges.patch
+++ b/pkg/kernel/patches-5.10.x/0010-ACPI-Add-support-to-map-GPIO-resources-to-ranges.patch
@@ -1,7 +1,7 @@
-From 4c0f50aaa56077957d627a79277eb0d75caca30a Mon Sep 17 00:00:00 2001
+From 3e055892790867c4c741f2a38b602c9f8ffd5476 Mon Sep 17 00:00:00 2001
 From: Carlos Calderon <carlos.calderon@emutex.com>
 Date: Wed, 20 Feb 2019 16:49:37 +0000
-Subject: [PATCH] ACPI: Add support to map GPIO resources to ranges
+Subject: [PATCH 10/12] ACPI: Add support to map GPIO resources to ranges
 
 All of this is selectively taken from:
     https://github.com/AaeonCM/meta-up-board/tree/warrior/recipes-kernel/linux/files
@@ -44,17 +44,94 @@ manages direction and enable state for those header pins.
 ====================================================================================
 [PATCH 12/19] acpi: acpi_node_add_pin_mapping added to header file.
 ====================================================================================
-
-
 ---
- drivers/gpio/gpiolib-acpi.c | 88 ++++++++++++++++++++++++++++++++++++---------
- 1 file changed, 71 insertions(+), 17 deletions(-)
+ drivers/base/regmap/internal.h    |   5 -
+ drivers/base/regmap/regmap.c      |   5 +
+ drivers/gpio/gpiolib-acpi.c       |  88 +++-
+ drivers/leds/Kconfig              |   7 +
+ drivers/leds/Makefile             |   1 +
+ drivers/leds/leds-upboard.c       |  88 ++++
+ drivers/mfd/Kconfig               |   6 +
+ drivers/mfd/Makefile              |   1 +
+ drivers/mfd/upboard-fpga.c        | 411 +++++++++++++++
+ drivers/pinctrl/Kconfig           |  12 +
+ drivers/pinctrl/Makefile          |   1 +
+ drivers/pinctrl/core.c            | 341 +++++++------
+ drivers/pinctrl/pinctrl-upboard.c | 797 ++++++++++++++++++++++++++++++
+ include/linux/acpi.h              |  13 +
+ include/linux/mfd/upboard-fpga.h  |  52 ++
+ include/linux/regmap.h            |   6 +
+ 16 files changed, 1658 insertions(+), 176 deletions(-)
+ create mode 100644 drivers/leds/leds-upboard.c
+ create mode 100644 drivers/mfd/upboard-fpga.c
+ create mode 100644 drivers/pinctrl/pinctrl-upboard.c
+ create mode 100644 include/linux/mfd/upboard-fpga.h
 
+diff --git a/drivers/base/regmap/internal.h b/drivers/base/regmap/internal.h
+index 0097696c31de..a43309063a68 100644
+--- a/drivers/base/regmap/internal.h
++++ b/drivers/base/regmap/internal.h
+@@ -180,11 +180,6 @@ struct regcache_ops {
+ 	int (*drop)(struct regmap *map, unsigned int min, unsigned int max);
+ };
+ 
+-bool regmap_cached(struct regmap *map, unsigned int reg);
+-bool regmap_writeable(struct regmap *map, unsigned int reg);
+-bool regmap_readable(struct regmap *map, unsigned int reg);
+-bool regmap_volatile(struct regmap *map, unsigned int reg);
+-bool regmap_precious(struct regmap *map, unsigned int reg);
+ bool regmap_writeable_noinc(struct regmap *map, unsigned int reg);
+ bool regmap_readable_noinc(struct regmap *map, unsigned int reg);
+ 
+diff --git a/drivers/base/regmap/regmap.c b/drivers/base/regmap/regmap.c
+index 456a1787e18d..7d503f67b700 100644
+--- a/drivers/base/regmap/regmap.c
++++ b/drivers/base/regmap/regmap.c
+@@ -100,6 +100,7 @@ bool regmap_writeable(struct regmap *map, unsigned int reg)
+ 
+ 	return true;
+ }
++EXPORT_SYMBOL_GPL(regmap_writeable);
+ 
+ bool regmap_cached(struct regmap *map, unsigned int reg)
+ {
+@@ -123,6 +124,7 @@ bool regmap_cached(struct regmap *map, unsigned int reg)
+ 
+ 	return true;
+ }
++EXPORT_SYMBOL_GPL(regmap_cached);
+ 
+ bool regmap_readable(struct regmap *map, unsigned int reg)
+ {
+@@ -143,6 +145,7 @@ bool regmap_readable(struct regmap *map, unsigned int reg)
+ 
+ 	return true;
+ }
++EXPORT_SYMBOL_GPL(regmap_readable);
+ 
+ bool regmap_volatile(struct regmap *map, unsigned int reg)
+ {
+@@ -160,6 +163,7 @@ bool regmap_volatile(struct regmap *map, unsigned int reg)
+ 	else
+ 		return true;
+ }
++EXPORT_SYMBOL_GPL(regmap_volatile);
+ 
+ bool regmap_precious(struct regmap *map, unsigned int reg)
+ {
+@@ -174,6 +178,7 @@ bool regmap_precious(struct regmap *map, unsigned int reg)
+ 
+ 	return false;
+ }
++EXPORT_SYMBOL_GPL(regmap_precious);
+ 
+ bool regmap_writeable_noinc(struct regmap *map, unsigned int reg)
+ {
 diff --git a/drivers/gpio/gpiolib-acpi.c b/drivers/gpio/gpiolib-acpi.c
-index 57d157e..9ff45a3 100644
+index 6f11714ce023..2b8c172be7a6 100644
 --- a/drivers/gpio/gpiolib-acpi.c
 +++ b/drivers/gpio/gpiolib-acpi.c
-@@ -1213,6 +1213,32 @@ static int acpi_find_gpio_count(struct acpi_resource *ares, void *data)
+@@ -1294,6 +1294,32 @@ static int acpi_find_gpio_count(struct acpi_resource *ares, void *data)
  	return 1;
  }
  
@@ -85,9 +162,9 @@ index 57d157e..9ff45a3 100644
 +}
 +
  /**
-  * acpi_gpio_count - return the number of GPIOs associated with a
-  *		device / function or -ENOENT if no GPIO has been
-@@ -1223,10 +1249,7 @@ static int acpi_find_gpio_count(struct acpi_resource *ares, void *data)
+  * acpi_gpio_count - count the GPIOs associated with a device / function
+  * @dev:	GPIO consumer, can be %NULL for system-global GPIOs
+@@ -1306,10 +1332,7 @@ static int acpi_find_gpio_count(struct acpi_resource *ares, void *data)
  int acpi_gpio_count(struct device *dev, const char *con_id)
  {
  	struct acpi_device *adev = ACPI_COMPANION(dev);
@@ -98,7 +175,7 @@ index 57d157e..9ff45a3 100644
  	char propname[32];
  	unsigned int i;
  
-@@ -1239,20 +1262,7 @@ int acpi_gpio_count(struct device *dev, const char *con_id)
+@@ -1322,20 +1345,7 @@ int acpi_gpio_count(struct device *dev, const char *con_id)
  			snprintf(propname, sizeof(propname), "%s",
  				 gpio_suffixes[i]);
  
@@ -120,8 +197,8 @@ index 57d157e..9ff45a3 100644
  		if (count > 0)
  			break;
  	}
-@@ -1284,6 +1294,50 @@ bool acpi_can_fallback_to_crs(struct acpi_device *adev, const char *con_id)
- 	return con_id == NULL;
+@@ -1358,6 +1368,50 @@ int acpi_gpio_count(struct device *dev, const char *con_id)
+ 	return count ? count : -ENOENT;
  }
  
 +/**
@@ -169,194 +246,13 @@ index 57d157e..9ff45a3 100644
 +EXPORT_SYMBOL_GPL(acpi_node_add_pin_mapping);
 +
  /* Run deferred acpi_gpiochip_request_irqs() */
- static int acpi_gpio_handle_deferred_request_irqs(void)
+ static int __init acpi_gpio_handle_deferred_request_irqs(void)
  {
--- 
-2.7.4
-
-From 9bdaf721fd148b50439d9e1c4dbf5e5c45313944 Mon Sep 17 00:00:00 2001
-From: Carlos Calderon <carlos@emutex.com>
-Date: Mon, 8 Oct 2018 16:06:21 +0100
-Subject: [PATCH 12/19] acpi: acpi_node_add_pin_mapping added to header file.
-
----
- include/linux/acpi.h | 13 +++++++++++++
- 1 file changed, 13 insertions(+)
-
-diff --git a/include/linux/acpi.h b/include/linux/acpi.h
-index acd2b5f..20f7440 100644
---- a/include/linux/acpi.h
-+++ b/include/linux/acpi.h
-@@ -1080,6 +1080,11 @@
- bool acpi_gpio_get_irq_resource(struct acpi_resource *ares,
- 				struct acpi_resource_gpio **agpio);
- int acpi_dev_gpio_irq_get_by(struct acpi_device *adev, const char *name, int index);
-+int acpi_node_add_pin_mapping(struct fwnode_handle *fwnode,
-+			      const char *propname,
-+			      const char *pinctl_name,
-+			      unsigned int pin_offset,
-+			      unsigned int npins);
- #else
- static inline bool acpi_gpio_get_irq_resource(struct acpi_resource *ares,
- 					      struct acpi_resource_gpio **agpio)
-@@ -1021,6 +1026,14 @@ static inline int acpi_dev_gpio_irq_get(struct acpi_device *adev, int index)
- {
- 	return -ENXIO;
- }
-+static inline int acpi_node_add_pin_mapping(struct fwnode_handle *fwnode,
-+					    const char *propname,
-+					    const char *pinctl_name,
-+					    unsigned int pin_offset,
-+					    unsigned int npins)
-+{
-+	return -ENXIO;
-+}
- #endif
- 
- /* Device properties */
--- 
-2.7.4
-
-From b0ec896e741f330df18785e931537be1862ff4c8 Mon Sep 17 00:00:00 2001
-From: Nicola Lunghi <nicola.lunghi@emutex.com>
-Date: Thu, 27 Jul 2017 17:55:34 +0100
-Subject: [PATCH 05/19] regmap: Expose regmap_writable function to check if a
- register is writable
-
-Signed-off-by: Nicola Lunghi <nicola.lunghi@emutex.com>
----
- drivers/base/regmap/internal.h | 5 -----
- drivers/base/regmap/regmap.c   | 5 +++++
- include/linux/regmap.h         | 6 ++++++
- 3 files changed, 11 insertions(+), 5 deletions(-)
-
-diff --git a/drivers/base/regmap/internal.h b/drivers/base/regmap/internal.h
-index a6bf34d63..de951a1 100644
---- a/drivers/base/regmap/internal.h
-+++ b/drivers/base/regmap/internal.h
-@@ -180,11 +180,6 @@
- 	int (*drop)(struct regmap *map, unsigned int min, unsigned int max);
- };
- 
--bool regmap_cached(struct regmap *map, unsigned int reg);
--bool regmap_writeable(struct regmap *map, unsigned int reg);
--bool regmap_readable(struct regmap *map, unsigned int reg);
--bool regmap_volatile(struct regmap *map, unsigned int reg);
--bool regmap_precious(struct regmap *map, unsigned int reg);
- bool regmap_writeable_noinc(struct regmap *map, unsigned int reg);
- bool regmap_readable_noinc(struct regmap *map, unsigned int reg);
- 
-diff --git a/drivers/base/regmap/regmap.c b/drivers/base/regmap/regmap.c
-index 0360a90..f61a24c 100644
---- a/drivers/base/regmap/regmap.c
-+++ b/drivers/base/regmap/regmap.c
-@@ -93,6 +93,7 @@ bool regmap_writeable(struct regmap *map, unsigned int reg)
- 
- 	return true;
- }
-+EXPORT_SYMBOL_GPL(regmap_writeable);
- 
- bool regmap_cached(struct regmap *map, unsigned int reg)
- {
-@@ -116,6 +117,7 @@ bool regmap_cached(struct regmap *map, unsigned int reg)
- 
- 	return true;
- }
-+EXPORT_SYMBOL_GPL(regmap_cached);
- 
- bool regmap_readable(struct regmap *map, unsigned int reg)
- {
-@@ -136,6 +138,7 @@ bool regmap_readable(struct regmap *map, unsigned int reg)
- 
- 	return true;
- }
-+EXPORT_SYMBOL_GPL(regmap_readable);
- 
- bool regmap_volatile(struct regmap *map, unsigned int reg)
- {
-@@ -153,6 +156,7 @@ bool regmap_volatile(struct regmap *map, unsigned int reg)
- 	else
- 		return true;
- }
-+EXPORT_SYMBOL_GPL(regmap_volatile);
- 
- bool regmap_precious(struct regmap *map, unsigned int reg)
- {
-@@ -167,6 +171,7 @@ bool regmap_precious(struct regmap *map, unsigned int reg)
- 
- 	return false;
- }
-+EXPORT_SYMBOL_GPL(regmap_precious);
- 
- bool regmap_readable_noinc(struct regmap *map, unsigned int reg)
- {
-diff --git a/include/linux/regmap.h b/include/linux/regmap.h
-index 035129b..36bc898 100644
---- a/include/linux/regmap.h
-+++ b/include/linux/regmap.h
-@@ -1025,6 +1025,12 @@ void regcache_mark_dirty(struct regmap *map);
- bool regmap_check_range_table(struct regmap *map, unsigned int reg,
- 			      const struct regmap_access_table *table);
- 
-+bool regmap_cached(struct regmap *map, unsigned int reg);
-+bool regmap_writeable(struct regmap *map, unsigned int reg);
-+bool regmap_readable(struct regmap *map, unsigned int reg);
-+bool regmap_volatile(struct regmap *map, unsigned int reg);
-+bool regmap_precious(struct regmap *map, unsigned int reg);
-+
- int regmap_register_patch(struct regmap *map, const struct reg_sequence *regs,
- 			  int num_regs);
- int regmap_parse_val(struct regmap *map, const void *buf,
--- 
-2.7.4
-
-From bf2af81a5a93050a2b0b3feffac521c3ed177578 Mon Sep 17 00:00:00 2001
-From: Carlos Calderon <carlos@emutex.com>
-Date: Thu, 4 Oct 2018 10:40:49 +0100
-Subject: [PATCH 07/19] mfd: Add support for UP board CPLD/FPGA
-
-The UP Squared board <http://www.upboard.com> implements certain
-features (pin control, onboard LEDs or CEC) through an on-board FPGA.
-
-This mfd driver implements the line protocol to read and write registers
-from the FPGA through regmap. The register address map is also included.
-
-The UP boards come with a few FPGA-controlled onboard LEDs:
-* UP Board: yellow, green, red
-* UP Squared: blue, yellow, green, red
-
-The UP Boards provide a few I/O pin headers (for both GPIO and
-functions), including a 40-pin Raspberry Pi compatible header.
-
-This patch implements support for the FPGA-based pin controller that
-manages direction and enable state for those header pins.
-
-Signed-off-by: Javier Arteaga <javier@emutex.com>
-[merge various fixes]
-Signed-off-by: Nicola Lunghi <nicola.lunghi@emutex.com>
----
- drivers/leds/Kconfig              |   7 +
- drivers/leds/Makefile             |   1 +
- drivers/leds/leds-upboard.c       |  88 +++++
- drivers/mfd/Kconfig               |   6 +
- drivers/mfd/Makefile              |   1 +
- drivers/mfd/upboard-fpga.c        | 411 ++++++++++++++++++++
- drivers/pinctrl/Kconfig           |  12 +
- drivers/pinctrl/Makefile          |   1 +
- drivers/pinctrl/pinctrl-upboard.c | 797 ++++++++++++++++++++++++++++++++++++++
- include/linux/mfd/upboard-fpga.h  |  52 +++
- 10 files changed, 1376 insertions(+)
- create mode 100644 drivers/leds/leds-upboard.c
- create mode 100644 drivers/mfd/upboard-fpga.c
- create mode 100644 drivers/pinctrl/pinctrl-upboard.c
- create mode 100644 include/linux/mfd/upboard-fpga.h
-
-
 diff --git a/drivers/leds/Kconfig b/drivers/leds/Kconfig
-index 44097a3..554a2d9 100644
+index deec7eed8233..dae6369f71c5 100644
 --- a/drivers/leds/Kconfig
 +++ b/drivers/leds/Kconfig
-@@ -928,6 +928,13 @@
+@@ -937,6 +937,13 @@ config LEDS_ACER_A500
  	  This option enables support for the Power Button LED of
  	  Acer Iconia Tab A500.
  
@@ -371,10 +267,10 @@ index 44097a3..554a2d9 100644
  source "drivers/leds/trigger/Kconfig"
  
 diff --git a/drivers/leds/Makefile b/drivers/leds/Makefile
-index 420b5d2..fe79d1e 100644
+index 74db57b7b1f2..163ff3eeab1e 100644
 --- a/drivers/leds/Makefile
 +++ b/drivers/leds/Makefile
-@@ -68,6 +68,7 @@
+@@ -68,6 +68,7 @@ obj-$(CONFIG_LEDS_MIKROTIK_RB532)	+= leds-rb532.o
  obj-$(CONFIG_LEDS_MLXCPLD)		+= leds-mlxcpld.o
  obj-$(CONFIG_LEDS_MLXREG)		+= leds-mlxreg.o
  obj-$(CONFIG_LEDS_MT6323)		+= leds-mt6323.o
@@ -384,7 +280,7 @@ index 420b5d2..fe79d1e 100644
  obj-$(CONFIG_LEDS_NIC78BX)		+= leds-nic78bx.o
 diff --git a/drivers/leds/leds-upboard.c b/drivers/leds/leds-upboard.c
 new file mode 100644
-index 0000000..16bd1b7
+index 000000000000..16bd1b7c0a1e
 --- /dev/null
 +++ b/drivers/leds/leds-upboard.c
 @@ -0,0 +1,88 @@
@@ -478,10 +374,10 @@ index 0000000..16bd1b7
 +MODULE_ALIAS("platform:upboard-led");
 \ No newline at end of file
 diff --git a/drivers/mfd/Kconfig b/drivers/mfd/Kconfig
-index 11841f4..7164934 100644
+index b8847ae04d93..6918d53f8fe0 100644
 --- a/drivers/mfd/Kconfig
 +++ b/drivers/mfd/Kconfig
-@@ -2098,6 +2098,12 @@
+@@ -2099,6 +2099,12 @@ config MFD_KHADAS_MCU
  	  additional drivers must be enabled in order to use the functionality
  	  of the device.
  
@@ -495,10 +391,10 @@ index 11841f4..7164934 100644
  	depends on ARCH_SA1100
  
 diff --git a/drivers/mfd/Makefile b/drivers/mfd/Makefile
-index 5856a94..22553f6 100644
+index 1780019d2474..25df7b548fb9 100644
 --- a/drivers/mfd/Makefile
 +++ b/drivers/mfd/Makefile
-@@ -252,6 +252,7 @@
+@@ -252,6 +252,7 @@ obj-$(CONFIG_MFD_ALTERA_A10SR)	+= altera-a10sr.o
  obj-$(CONFIG_MFD_ALTERA_SYSMGR) += altera-sysmgr.o
  obj-$(CONFIG_MFD_STPMIC1)	+= stpmic1.o
  obj-$(CONFIG_MFD_SUN4I_GPADC)	+= sun4i-gpadc.o
@@ -506,10 +402,9 @@ index 5856a94..22553f6 100644
  
  obj-$(CONFIG_MFD_STM32_LPTIMER)	+= stm32-lptimer.o
  obj-$(CONFIG_MFD_STM32_TIMERS) 	+= stm32-timers.o
-
 diff --git a/drivers/mfd/upboard-fpga.c b/drivers/mfd/upboard-fpga.c
 new file mode 100644
-index 0000000..9f444f8
+index 000000000000..9f444f876af1
 --- /dev/null
 +++ b/drivers/mfd/upboard-fpga.c
 @@ -0,0 +1,411 @@
@@ -926,10 +821,10 @@ index 0000000..9f444f8
 +MODULE_LICENSE("GPL v2");
 \ No newline at end of file
 diff --git a/drivers/pinctrl/Kconfig b/drivers/pinctrl/Kconfig
-index e86752b..d68d3c7 100644
+index 815095326e2d..0f207d189f64 100644
 --- a/drivers/pinctrl/Kconfig
 +++ b/drivers/pinctrl/Kconfig
-@@ -362,6 +362,18 @@
+@@ -362,6 +362,18 @@ config PINCTRL_RK805
  	help
  	  This selects the pinctrl driver for RK805.
  
@@ -949,20 +844,442 @@ index e86752b..d68d3c7 100644
  	bool "Pinctrl driver for the Microsemi Ocelot and Jaguar2 SoCs"
  	depends on OF
 diff --git a/drivers/pinctrl/Makefile b/drivers/pinctrl/Makefile
-index 46ef9bd..828a6e9 100644
+index f53933b2ff02..81a059a6ca64 100644
 --- a/drivers/pinctrl/Makefile
 +++ b/drivers/pinctrl/Makefile
-@@ -45,6 +45,7 @@
+@@ -45,6 +45,7 @@ obj-$(CONFIG_PINCTRL_STMFX) 	+= pinctrl-stmfx.o
  obj-$(CONFIG_PINCTRL_ZYNQ)	+= pinctrl-zynq.o
  obj-$(CONFIG_PINCTRL_INGENIC)	+= pinctrl-ingenic.o
  obj-$(CONFIG_PINCTRL_RK805)	+= pinctrl-rk805.o
 +obj-$(CONFIG_PINCTRL_UPBOARD)   += pinctrl-upboard.o
  obj-$(CONFIG_PINCTRL_OCELOT)	+= pinctrl-ocelot.o
  obj-$(CONFIG_PINCTRL_EQUILIBRIUM)   += pinctrl-equilibrium.o
-
+ 
+diff --git a/drivers/pinctrl/core.c b/drivers/pinctrl/core.c
+index 6e6825d17a1d..b80dbb8e9420 100644
+--- a/drivers/pinctrl/core.c
++++ b/drivers/pinctrl/core.c
+@@ -266,8 +266,7 @@ static int pinctrl_register_pins(struct pinctrl_dev *pctldev,
+  * and pin list based GPIO ranges is managed correctly by this function.
+  *
+  * This function assumes the gpio is part of the specified GPIO range, use
+- * only after making sure this is the case (e.g. by calling it on the
+- * result of successful pinctrl_get_device_gpio_range calls)!
++ * only after making sure this is the case!
+  */
+ static inline int gpio_to_pin(struct pinctrl_gpio_range *range,
+ 				unsigned int gpio)
+@@ -306,92 +305,6 @@ pinctrl_match_gpio_range(struct pinctrl_dev *pctldev, unsigned gpio)
+ 	return NULL;
+ }
+ 
+-/**
+- * pinctrl_ready_for_gpio_range() - check if other GPIO pins of
+- * the same GPIO chip are in range
+- * @gpio: gpio pin to check taken from the global GPIO pin space
+- *
+- * This function is complement of pinctrl_match_gpio_range(). If the return
+- * value of pinctrl_match_gpio_range() is NULL, this function could be used
+- * to check whether pinctrl device is ready or not. Maybe some GPIO pins
+- * of the same GPIO chip don't have back-end pinctrl interface.
+- * If the return value is true, it means that pinctrl device is ready & the
+- * certain GPIO pin doesn't have back-end pinctrl device. If the return value
+- * is false, it means that pinctrl device may not be ready.
+- */
+-#ifdef CONFIG_GPIOLIB
+-static bool pinctrl_ready_for_gpio_range(unsigned gpio)
+-{
+-	struct pinctrl_dev *pctldev;
+-	struct pinctrl_gpio_range *range = NULL;
+-	struct gpio_chip *chip = gpio_to_chip(gpio);
+-
+-	if (WARN(!chip, "no gpio_chip for gpio%i?", gpio))
+-		return false;
+-
+-	mutex_lock(&pinctrldev_list_mutex);
+-
+-	/* Loop over the pin controllers */
+-	list_for_each_entry(pctldev, &pinctrldev_list, node) {
+-		/* Loop over the ranges */
+-		mutex_lock(&pctldev->mutex);
+-		list_for_each_entry(range, &pctldev->gpio_ranges, node) {
+-			/* Check if any gpio range overlapped with gpio chip */
+-			if (range->base + range->npins - 1 < chip->base ||
+-			    range->base > chip->base + chip->ngpio - 1)
+-				continue;
+-			mutex_unlock(&pctldev->mutex);
+-			mutex_unlock(&pinctrldev_list_mutex);
+-			return true;
+-		}
+-		mutex_unlock(&pctldev->mutex);
+-	}
+-
+-	mutex_unlock(&pinctrldev_list_mutex);
+-
+-	return false;
+-}
+-#else
+-static bool pinctrl_ready_for_gpio_range(unsigned gpio) { return true; }
+-#endif
+-
+-/**
+- * pinctrl_get_device_gpio_range() - find device for GPIO range
+- * @gpio: the pin to locate the pin controller for
+- * @outdev: the pin control device if found
+- * @outrange: the GPIO range if found
+- *
+- * Find the pin controller handling a certain GPIO pin from the pinspace of
+- * the GPIO subsystem, return the device and the matching GPIO range. Returns
+- * -EPROBE_DEFER if the GPIO range could not be found in any device since it
+- * may still have not been registered.
+- */
+-static int pinctrl_get_device_gpio_range(unsigned gpio,
+-					 struct pinctrl_dev **outdev,
+-					 struct pinctrl_gpio_range **outrange)
+-{
+-	struct pinctrl_dev *pctldev;
+-
+-	mutex_lock(&pinctrldev_list_mutex);
+-
+-	/* Loop over the pin controllers */
+-	list_for_each_entry(pctldev, &pinctrldev_list, node) {
+-		struct pinctrl_gpio_range *range;
+-
+-		range = pinctrl_match_gpio_range(pctldev, gpio);
+-		if (range) {
+-			*outdev = pctldev;
+-			*outrange = range;
+-			mutex_unlock(&pinctrldev_list_mutex);
+-			return 0;
+-		}
+-	}
+-
+-	mutex_unlock(&pinctrldev_list_mutex);
+-
+-	return -EPROBE_DEFER;
+-}
+-
+ /**
+  * pinctrl_add_gpio_range() - register a GPIO range for a controller
+  * @pctldev: pin controller device to add the range to
+@@ -706,6 +619,57 @@ static inline void pinctrl_generic_free_groups(struct pinctrl_dev *pctldev)
+ }
+ #endif /* CONFIG_GENERIC_PINCTRL_GROUPS */
+ 
++void pinctrl_free_gpio_locked(unsigned int gpio)
++{
++	struct pinctrl_dev *pctldev;
++
++	list_for_each_entry(pctldev, &pinctrldev_list, node) {
++		struct pinctrl_gpio_range *range =
++			pinctrl_match_gpio_range(pctldev, gpio);
++		if (range != NULL) {
++			int pin;
++
++			mutex_lock(&pctldev->mutex);
++			pin = gpio_to_pin(range, gpio);
++			pinmux_free_gpio(pctldev, pin, range);
++			mutex_unlock(&pctldev->mutex);
++		}
++	}
++}
++
++static int pinctrl_request_if_match(struct pinctrl_dev *pctldev,
++				    unsigned int gpio, int dir)
++{
++	struct pinctrl_gpio_range *range =
++		pinctrl_match_gpio_range(pctldev, gpio);
++	int ret;
++
++	if (range != NULL) {
++		int pin;
++
++		mutex_lock(&pctldev->mutex);
++		pin = gpio_to_pin(range, gpio);
++
++		ret = pinmux_request_gpio(pctldev, range, pin, gpio);
++		if (ret) {
++			mutex_unlock(&pctldev->mutex);
++			return ret;
++		}
++
++		if (dir >= 0) {
++			ret = pinmux_gpio_direction(pctldev, range, pin, dir);
++			if (ret) {
++				mutex_unlock(&pctldev->mutex);
++				return ret;
++			}
++		}
++		mutex_unlock(&pctldev->mutex);
++
++	}
++
++	return 0;
++}
++
+ /**
+  * pinctrl_get_group_selector() - returns the group selector for a group
+  * @pctldev: the pin controller handling the group
+@@ -742,25 +706,27 @@ bool pinctrl_gpio_can_use_line(unsigned gpio)
+ {
+ 	struct pinctrl_dev *pctldev;
+ 	struct pinctrl_gpio_range *range;
+-	bool result;
++	bool result = true;
+ 	int pin;
+ 
+-	/*
+-	 * Try to obtain GPIO range, if it fails
+-	 * we're probably dealing with GPIO driver
+-	 * without a backing pin controller - bail out.
+-	 */
+-	if (pinctrl_get_device_gpio_range(gpio, &pctldev, &range))
+-		return true;
+-
+-	mutex_lock(&pctldev->mutex);
+-
+-	/* Convert to the pin controllers number space */
+-	pin = gpio_to_pin(range, gpio);
++	mutex_lock(&pinctrldev_list_mutex);
+ 
+-	result = pinmux_can_be_used_for_gpio(pctldev, pin);
++        /*
++         * Try to obtain GPIO range, if it fails
++         * we're probably dealing with GPIO driver
++         * without a backing pin controller - bail out.
++         */
++	list_for_each_entry(pctldev, &pinctrldev_list, node) {
++		range = pinctrl_match_gpio_range(pctldev, gpio);
++		if (range != NULL) {
++			mutex_lock(&pctldev->mutex);
++			pin = gpio_to_pin(range, gpio);
++			result = result && pinmux_can_be_used_for_gpio(pctldev, pin);
++			mutex_unlock(&pctldev->mutex);
++		}
++	}
+ 
+-	mutex_unlock(&pctldev->mutex);
++	mutex_unlock(&pinctrldev_list_mutex);
+ 
+ 	return result;
+ }
+@@ -774,28 +740,53 @@ EXPORT_SYMBOL_GPL(pinctrl_gpio_can_use_line);
+  * as part of their gpio_request() semantics, platforms and individual drivers
+  * shall *NOT* request GPIO pins to be muxed in.
+  */
+-int pinctrl_gpio_request(unsigned gpio)
++int pinctrl_gpio_request(unsigned int gpio)
+ {
+ 	struct pinctrl_dev *pctldev;
+-	struct pinctrl_gpio_range *range;
+-	int ret;
+-	int pin;
++	struct gpio_desc *desc;
++	int dir;
++	int ret = -EPROBE_DEFER;
+ 
+-	ret = pinctrl_get_device_gpio_range(gpio, &pctldev, &range);
+-	if (ret) {
+-		if (pinctrl_ready_for_gpio_range(gpio))
+-			ret = 0;
+-		return ret;
++	desc = gpio_to_desc(gpio);
++	if (!desc) {
++		pr_err("gpio_to_desc(%d) returned NULL", gpio);
++		return -ENODEV;
+ 	}
+ 
+-	mutex_lock(&pctldev->mutex);
++	dir = gpiod_get_direction(desc);
+ 
+-	/* Convert to the pin controllers number space */
+-	pin = gpio_to_pin(range, gpio);
++	mutex_lock(&pinctrldev_list_mutex);
+ 
+-	ret = pinmux_request_gpio(pctldev, range, pin, gpio);
++	/*
++	 * NOTE: this code suppose that if we have multiple pinctrl declared for
++	 * the same gpio those are configured in series.
++	 * In this situation we need to avoid the case were momentarely
++	 * multiple pinctrl try do drive the same line to a different logic value
++	 *
++	 * (1st pinctrl) 1>-----<0 (2nd pinctrl)
++	 *
++	 * To obtain that we need to mind the order in which the multiple pinctrl
++	 * are configured depending of the desired gpio direction (input, output)
++	 */
++	if (dir == 1) {
++		list_for_each_entry(pctldev, &pinctrldev_list, node) {
++			ret = pinctrl_request_if_match(pctldev, gpio, dir);
++			if (ret) {
++				pinctrl_free_gpio_locked(gpio);
++				break;
++			}
++		}
++	} else {
++		list_for_each_entry_reverse(pctldev, &pinctrldev_list, node) {
++			ret = pinctrl_request_if_match(pctldev, gpio, dir);
++			if (ret) {
++				pinctrl_free_gpio_locked(gpio);
++				break;
++			}
++		}
++	}
+ 
+-	mutex_unlock(&pctldev->mutex);
++	mutex_unlock(&pinctrldev_list_mutex);
+ 
+ 	return ret;
+ }
+@@ -809,47 +800,64 @@ EXPORT_SYMBOL_GPL(pinctrl_gpio_request);
+  * as part of their gpio_free() semantics, platforms and individual drivers
+  * shall *NOT* request GPIO pins to be muxed out.
+  */
+-void pinctrl_gpio_free(unsigned gpio)
++void pinctrl_gpio_free(unsigned int gpio)
+ {
+-	struct pinctrl_dev *pctldev;
+-	struct pinctrl_gpio_range *range;
+-	int ret;
+-	int pin;
++	mutex_lock(&pinctrldev_list_mutex);
+ 
+-	ret = pinctrl_get_device_gpio_range(gpio, &pctldev, &range);
+-	if (ret) {
+-		return;
+-	}
+-	mutex_lock(&pctldev->mutex);
++	pinctrl_free_gpio_locked(gpio);
++
++	mutex_unlock(&pinctrldev_list_mutex);
++}
++EXPORT_SYMBOL_GPL(pinctrl_gpio_free);
+ 
+-	/* Convert to the pin controllers number space */
+-	pin = gpio_to_pin(range, gpio);
++static int pinctrl_set_dir_if_match(struct pinctrl_dev *pctldev,
++				    unsigned int gpio, bool input)
++{
++	struct pinctrl_gpio_range *range =
++		pinctrl_match_gpio_range(pctldev, gpio);
++	int ret = 0;
+ 
+-	pinmux_free_gpio(pctldev, pin, range);
++	if (range != NULL) {
++		int pin;
+ 
+-	mutex_unlock(&pctldev->mutex);
++		mutex_lock(&pctldev->mutex);
++		pin = gpio_to_pin(range, gpio);
++		ret = pinmux_gpio_direction(pctldev, range, pin, input);
++		mutex_unlock(&pctldev->mutex);
++	}
++
++	return ret;
+ }
+-EXPORT_SYMBOL_GPL(pinctrl_gpio_free);
+ 
+ static int pinctrl_gpio_direction(unsigned gpio, bool input)
+ {
+ 	struct pinctrl_dev *pctldev;
+-	struct pinctrl_gpio_range *range;
+-	int ret;
+-	int pin;
+-
+-	ret = pinctrl_get_device_gpio_range(gpio, &pctldev, &range);
+-	if (ret) {
+-		return ret;
+-	}
++	int ret = -EPROBE_DEFER;
+ 
+-	mutex_lock(&pctldev->mutex);
++	mutex_lock(&pinctrldev_list_mutex);
+ 
+-	/* Convert to the pin controllers number space */
+-	pin = gpio_to_pin(range, gpio);
+-	ret = pinmux_gpio_direction(pctldev, range, pin, input);
++	/*
++	 * FIXME UP-specific
++	 * The two pin controllers (SoC, FPGA) share the GPIO line. Avoid
++	 * getting into a situation where both are momentarily trying to drive
++	 * the line (i.e. SoC as output and FPGA as HAT-to-SoC input) by walking
++	 * the list in opposite directions for the input and output cases.
++	 */
++	if (input) {
++		list_for_each_entry(pctldev, &pinctrldev_list, node) {
++			ret = pinctrl_set_dir_if_match(pctldev, gpio, input);
++			if (ret)
++				break;
++		}
++	} else {
++		list_for_each_entry_reverse(pctldev, &pinctrldev_list, node) {
++			ret = pinctrl_set_dir_if_match(pctldev, gpio, input);
++			if (ret)
++				break;
++		}
++	}
+ 
+-	mutex_unlock(&pctldev->mutex);
++	mutex_unlock(&pinctrldev_list_mutex);
+ 
+ 	return ret;
+ }
+@@ -894,18 +902,43 @@ EXPORT_SYMBOL_GPL(pinctrl_gpio_direction_output);
+ int pinctrl_gpio_set_config(unsigned gpio, unsigned long config)
+ {
+ 	unsigned long configs[] = { config };
+-	struct pinctrl_gpio_range *range;
+ 	struct pinctrl_dev *pctldev;
+-	int ret, pin;
++	struct gpio_desc *desc;
++	int dir;
++	int ret = -EPROBE_DEFER;
+ 
+-	ret = pinctrl_get_device_gpio_range(gpio, &pctldev, &range);
+-	if (ret)
+-		return ret;
++	desc = gpio_to_desc(gpio);
++	if (!desc) {
++		pr_err("gpio_to_desc(%d) returned NULL", gpio);
++		return -ENODEV;
++	}
+ 
+-	mutex_lock(&pctldev->mutex);
+-	pin = gpio_to_pin(range, gpio);
+-	ret = pinconf_set_config(pctldev, pin, configs, ARRAY_SIZE(configs));
+-	mutex_unlock(&pctldev->mutex);
++	dir = gpiod_get_direction(desc);
++
++	mutex_lock(&pinctrldev_list_mutex);
++
++	/*
++	 * NOTE: this code suppose that if we have multiple pinctrl declared for
++	 * the same gpio those are configured in series.
++	 * In this situation we need to avoid the case were momentarely
++	 * multiple pinctrl try do drive the same line to a different logic value
++	 *
++	 * (1st pinctrl) 1>-----<0 (2nd pinctrl)
++	 *
++	 * To obtain that we need to mind the order in which the multiple pinctrl
++	 * are configured depending of the desired gpio direction (input, output)
++	 */
++	if (dir == 1) {
++		list_for_each_entry(pctldev, &pinctrldev_list, node) {
++			ret = pinconf_set_config(pctldev, gpio, configs, ARRAY_SIZE(configs));
++		}
++	} else {
++		list_for_each_entry_reverse(pctldev, &pinctrldev_list, node) {
++			ret = pinconf_set_config(pctldev, gpio, configs, ARRAY_SIZE(configs));
++		}
++	}
++
++	mutex_unlock(&pinctrldev_list_mutex);
+ 
+ 	return ret;
+ }
 diff --git a/drivers/pinctrl/pinctrl-upboard.c b/drivers/pinctrl/pinctrl-upboard.c
 new file mode 100644
-index 0000000..64899e9
+index 000000000000..64899e988bb5
 --- /dev/null
 +++ b/drivers/pinctrl/pinctrl-upboard.c
 @@ -0,0 +1,797 @@
@@ -1764,9 +2081,40 @@ index 0000000..64899e9
 +MODULE_LICENSE("GPL v2");
 +MODULE_ALIAS("platform:upboard-pinctrl");
 \ No newline at end of file
+diff --git a/include/linux/acpi.h b/include/linux/acpi.h
+index fdb1d5262ce8..dacc84699b82 100644
+--- a/include/linux/acpi.h
++++ b/include/linux/acpi.h
+@@ -1080,6 +1080,11 @@ void __acpi_handle_debug(struct _ddebug *descriptor, acpi_handle handle, const c
+ bool acpi_gpio_get_irq_resource(struct acpi_resource *ares,
+ 				struct acpi_resource_gpio **agpio);
+ int acpi_dev_gpio_irq_get_by(struct acpi_device *adev, const char *name, int index);
++int acpi_node_add_pin_mapping(struct fwnode_handle *fwnode,
++			      const char *propname,
++			      const char *pinctl_name,
++			      unsigned int pin_offset,
++			      unsigned int npins);
+ #else
+ static inline bool acpi_gpio_get_irq_resource(struct acpi_resource *ares,
+ 					      struct acpi_resource_gpio **agpio)
+@@ -1091,6 +1096,14 @@ static inline int acpi_dev_gpio_irq_get_by(struct acpi_device *adev,
+ {
+ 	return -ENXIO;
+ }
++static inline int acpi_node_add_pin_mapping(struct fwnode_handle *fwnode,
++					    const char *propname,
++					    const char *pinctl_name,
++					    unsigned int pin_offset,
++					    unsigned int npins)
++{
++	return -ENXIO;
++}
+ #endif
+ 
+ static inline int acpi_dev_gpio_irq_get(struct acpi_device *adev, int index)
 diff --git a/include/linux/mfd/upboard-fpga.h b/include/linux/mfd/upboard-fpga.h
 new file mode 100644
-index 0000000..cd7fb81
+index 000000000000..cd7fb812d3b2
 --- /dev/null
 +++ b/include/linux/mfd/upboard-fpga.h
 @@ -0,0 +1,52 @@
@@ -1823,427 +2171,23 @@ index 0000000..cd7fb81
 +
 +#endif /*  __LINUX_MFD_UPBOARD_FPGA_H */
 \ No newline at end of file
+diff --git a/include/linux/regmap.h b/include/linux/regmap.h
+index e7834d98207f..8ffd5ae8708c 100644
+--- a/include/linux/regmap.h
++++ b/include/linux/regmap.h
+@@ -1120,6 +1120,12 @@ void regcache_mark_dirty(struct regmap *map);
+ bool regmap_check_range_table(struct regmap *map, unsigned int reg,
+ 			      const struct regmap_access_table *table);
+ 
++bool regmap_cached(struct regmap *map, unsigned int reg);
++bool regmap_writeable(struct regmap *map, unsigned int reg);
++bool regmap_readable(struct regmap *map, unsigned int reg);
++bool regmap_volatile(struct regmap *map, unsigned int reg);
++bool regmap_precious(struct regmap *map, unsigned int reg);
++
+ int regmap_register_patch(struct regmap *map, const struct reg_sequence *regs,
+ 			  int num_regs);
+ int regmap_parse_val(struct regmap *map, const void *buf,
 -- 
-2.7.4
-diff --git a/drivers/pinctrl/core.c b/drivers/pinctrl/core.c
-index a3dd777..aad7a67 100644
---- a/drivers/pinctrl/core.c
-+++ b/drivers/pinctrl/core.c
-@@ -266,8 +266,7 @@
-  * and pin list based GPIO ranges is managed correctly by this function.
-  *
-  * This function assumes the gpio is part of the specified GPIO range, use
-- * only after making sure this is the case (e.g. by calling it on the
-- * result of successful pinctrl_get_device_gpio_range calls)!
-+ * only after making sure this is the case!
-  */
- static inline int gpio_to_pin(struct pinctrl_gpio_range *range,
- 				unsigned int gpio)
-@@ -307,92 +306,6 @@
- }
- 
- /**
-- * pinctrl_ready_for_gpio_range() - check if other GPIO pins of
-- * the same GPIO chip are in range
-- * @gpio: gpio pin to check taken from the global GPIO pin space
-- *
-- * This function is complement of pinctrl_match_gpio_range(). If the return
-- * value of pinctrl_match_gpio_range() is NULL, this function could be used
-- * to check whether pinctrl device is ready or not. Maybe some GPIO pins
-- * of the same GPIO chip don't have back-end pinctrl interface.
-- * If the return value is true, it means that pinctrl device is ready & the
-- * certain GPIO pin doesn't have back-end pinctrl device. If the return value
-- * is false, it means that pinctrl device may not be ready.
-- */
--#ifdef CONFIG_GPIOLIB
--static bool pinctrl_ready_for_gpio_range(unsigned gpio)
--{
--	struct pinctrl_dev *pctldev;
--	struct pinctrl_gpio_range *range = NULL;
--	struct gpio_chip *chip = gpio_to_chip(gpio);
--
--	if (WARN(!chip, "no gpio_chip for gpio%i?", gpio))
--		return false;
--
--	mutex_lock(&pinctrldev_list_mutex);
--
--	/* Loop over the pin controllers */
--	list_for_each_entry(pctldev, &pinctrldev_list, node) {
--		/* Loop over the ranges */
--		mutex_lock(&pctldev->mutex);
--		list_for_each_entry(range, &pctldev->gpio_ranges, node) {
--			/* Check if any gpio range overlapped with gpio chip */
--			if (range->base + range->npins - 1 < chip->base ||
--			    range->base > chip->base + chip->ngpio - 1)
--				continue;
--			mutex_unlock(&pctldev->mutex);
--			mutex_unlock(&pinctrldev_list_mutex);
--			return true;
--		}
--		mutex_unlock(&pctldev->mutex);
--	}
--
--	mutex_unlock(&pinctrldev_list_mutex);
--
--	return false;
--}
--#else
--static bool pinctrl_ready_for_gpio_range(unsigned gpio) { return true; }
--#endif
--
--/**
-- * pinctrl_get_device_gpio_range() - find device for GPIO range
-- * @gpio: the pin to locate the pin controller for
-- * @outdev: the pin control device if found
-- * @outrange: the GPIO range if found
-- *
-- * Find the pin controller handling a certain GPIO pin from the pinspace of
-- * the GPIO subsystem, return the device and the matching GPIO range. Returns
-- * -EPROBE_DEFER if the GPIO range could not be found in any device since it
-- * may still have not been registered.
-- */
--static int pinctrl_get_device_gpio_range(unsigned gpio,
--					 struct pinctrl_dev **outdev,
--					 struct pinctrl_gpio_range **outrange)
--{
--	struct pinctrl_dev *pctldev;
--
--	mutex_lock(&pinctrldev_list_mutex);
--
--	/* Loop over the pin controllers */
--	list_for_each_entry(pctldev, &pinctrldev_list, node) {
--		struct pinctrl_gpio_range *range;
--
--		range = pinctrl_match_gpio_range(pctldev, gpio);
--		if (range) {
--			*outdev = pctldev;
--			*outrange = range;
--			mutex_unlock(&pinctrldev_list_mutex);
--			return 0;
--		}
--	}
--
--	mutex_unlock(&pinctrldev_list_mutex);
--
--	return -EPROBE_DEFER;
--}
--
--/**
-  * pinctrl_add_gpio_range() - register a GPIO range for a controller
-  * @pctldev: pin controller device to add the range to
-  * @range: the GPIO range to add
-@@ -706,6 +619,57 @@
- }
- #endif /* CONFIG_GENERIC_PINCTRL_GROUPS */
- 
-+void pinctrl_free_gpio_locked(unsigned int gpio)
-+{
-+	struct pinctrl_dev *pctldev;
-+
-+	list_for_each_entry(pctldev, &pinctrldev_list, node) {
-+		struct pinctrl_gpio_range *range =
-+			pinctrl_match_gpio_range(pctldev, gpio);
-+		if (range != NULL) {
-+			int pin;
-+
-+			mutex_lock(&pctldev->mutex);
-+			pin = gpio_to_pin(range, gpio);
-+			pinmux_free_gpio(pctldev, pin, range);
-+			mutex_unlock(&pctldev->mutex);
-+		}
-+	}
-+}
-+
-+static int pinctrl_request_if_match(struct pinctrl_dev *pctldev,
-+				    unsigned int gpio, int dir)
-+{
-+	struct pinctrl_gpio_range *range =
-+		pinctrl_match_gpio_range(pctldev, gpio);
-+	int ret;
-+
-+	if (range != NULL) {
-+		int pin;
-+
-+		mutex_lock(&pctldev->mutex);
-+		pin = gpio_to_pin(range, gpio);
-+
-+		ret = pinmux_request_gpio(pctldev, range, pin, gpio);
-+		if (ret) {
-+			mutex_unlock(&pctldev->mutex);
-+			return ret;
-+		}
-+
-+		if (dir >= 0) {
-+			ret = pinmux_gpio_direction(pctldev, range, pin, dir);
-+			if (ret) {
-+				mutex_unlock(&pctldev->mutex);
-+				return ret;
-+			}
-+		}
-+		mutex_unlock(&pctldev->mutex);
-+
-+	}
-+
-+	return 0;
-+}
-+
- /**
-  * pinctrl_get_group_selector() - returns the group selector for a group
-  * @pctldev: the pin controller handling the group
-@@ -742,25 +706,27 @@
- {
- 	struct pinctrl_dev *pctldev;
- 	struct pinctrl_gpio_range *range;
--	bool result;
-+	bool result = true;
- 	int pin;
- 
--	/*
--	 * Try to obtain GPIO range, if it fails
--	 * we're probably dealing with GPIO driver
--	 * without a backing pin controller - bail out.
--	 */
--	if (pinctrl_get_device_gpio_range(gpio, &pctldev, &range))
--		return true;
--
--	mutex_lock(&pctldev->mutex);
--
--	/* Convert to the pin controllers number space */
--	pin = gpio_to_pin(range, gpio);
-+	mutex_lock(&pinctrldev_list_mutex);
- 
--	result = pinmux_can_be_used_for_gpio(pctldev, pin);
-+        /*
-+         * Try to obtain GPIO range, if it fails
-+         * we're probably dealing with GPIO driver
-+         * without a backing pin controller - bail out.
-+         */
-+	list_for_each_entry(pctldev, &pinctrldev_list, node) {
-+		range = pinctrl_match_gpio_range(pctldev, gpio);
-+		if (range != NULL) {
-+			mutex_lock(&pctldev->mutex);
-+			pin = gpio_to_pin(range, gpio);
-+			result = result && pinmux_can_be_used_for_gpio(pctldev, pin);
-+			mutex_unlock(&pctldev->mutex);
-+		}
-+	}
- 
--	mutex_unlock(&pctldev->mutex);
-+	mutex_unlock(&pinctrldev_list_mutex);
- 
- 	return result;
- }
-@@ -774,28 +740,53 @@
-  * as part of their gpio_request() semantics, platforms and individual drivers
-  * shall *NOT* request GPIO pins to be muxed in.
-  */
--int pinctrl_gpio_request(unsigned gpio)
-+int pinctrl_gpio_request(unsigned int gpio)
- {
- 	struct pinctrl_dev *pctldev;
--	struct pinctrl_gpio_range *range;
--	int ret;
--	int pin;
-+	struct gpio_desc *desc;
-+	int dir;
-+	int ret = -EPROBE_DEFER;
- 
--	ret = pinctrl_get_device_gpio_range(gpio, &pctldev, &range);
--	if (ret) {
--		if (pinctrl_ready_for_gpio_range(gpio))
--			ret = 0;
--		return ret;
-+	desc = gpio_to_desc(gpio);
-+	if (!desc) {
-+		pr_err("gpio_to_desc(%d) returned NULL", gpio);
-+		return -ENODEV;
- 	}
- 
--	mutex_lock(&pctldev->mutex);
-+	dir = gpiod_get_direction(desc);
- 
--	/* Convert to the pin controllers number space */
--	pin = gpio_to_pin(range, gpio);
-+	mutex_lock(&pinctrldev_list_mutex);
- 
--	ret = pinmux_request_gpio(pctldev, range, pin, gpio);
-+	/*
-+	 * NOTE: this code suppose that if we have multiple pinctrl declared for
-+	 * the same gpio those are configured in series.
-+	 * In this situation we need to avoid the case were momentarely
-+	 * multiple pinctrl try do drive the same line to a different logic value
-+	 *
-+	 * (1st pinctrl) 1>-----<0 (2nd pinctrl)
-+	 *
-+	 * To obtain that we need to mind the order in which the multiple pinctrl
-+	 * are configured depending of the desired gpio direction (input, output)
-+	 */
-+	if (dir == 1) {
-+		list_for_each_entry(pctldev, &pinctrldev_list, node) {
-+			ret = pinctrl_request_if_match(pctldev, gpio, dir);
-+			if (ret) {
-+				pinctrl_free_gpio_locked(gpio);
-+				break;
-+			}
-+		}
-+	} else {
-+		list_for_each_entry_reverse(pctldev, &pinctrldev_list, node) {
-+			ret = pinctrl_request_if_match(pctldev, gpio, dir);
-+			if (ret) {
-+				pinctrl_free_gpio_locked(gpio);
-+				break;
-+			}
-+		}
-+	}
- 
--	mutex_unlock(&pctldev->mutex);
-+	mutex_unlock(&pinctrldev_list_mutex);
- 
- 	return ret;
- }
-@@ -809,47 +800,64 @@
-  * as part of their gpio_free() semantics, platforms and individual drivers
-  * shall *NOT* request GPIO pins to be muxed out.
-  */
--void pinctrl_gpio_free(unsigned gpio)
-+void pinctrl_gpio_free(unsigned int gpio)
- {
--	struct pinctrl_dev *pctldev;
--	struct pinctrl_gpio_range *range;
--	int ret;
--	int pin;
-+	mutex_lock(&pinctrldev_list_mutex);
- 
--	ret = pinctrl_get_device_gpio_range(gpio, &pctldev, &range);
--	if (ret) {
--		return;
--	}
--	mutex_lock(&pctldev->mutex);
-+	pinctrl_free_gpio_locked(gpio);
-+
-+	mutex_unlock(&pinctrldev_list_mutex);
-+}
-+EXPORT_SYMBOL_GPL(pinctrl_gpio_free);
- 
--	/* Convert to the pin controllers number space */
--	pin = gpio_to_pin(range, gpio);
-+static int pinctrl_set_dir_if_match(struct pinctrl_dev *pctldev,
-+				    unsigned int gpio, bool input)
-+{
-+	struct pinctrl_gpio_range *range =
-+		pinctrl_match_gpio_range(pctldev, gpio);
-+	int ret = 0;
- 
--	pinmux_free_gpio(pctldev, pin, range);
-+	if (range != NULL) {
-+		int pin;
- 
--	mutex_unlock(&pctldev->mutex);
-+		mutex_lock(&pctldev->mutex);
-+		pin = gpio_to_pin(range, gpio);
-+		ret = pinmux_gpio_direction(pctldev, range, pin, input);
-+		mutex_unlock(&pctldev->mutex);
-+	}
-+
-+	return ret;
- }
--EXPORT_SYMBOL_GPL(pinctrl_gpio_free);
- 
- static int pinctrl_gpio_direction(unsigned gpio, bool input)
- {
- 	struct pinctrl_dev *pctldev;
--	struct pinctrl_gpio_range *range;
--	int ret;
--	int pin;
-+	int ret = -EPROBE_DEFER;
- 
--	ret = pinctrl_get_device_gpio_range(gpio, &pctldev, &range);
--	if (ret) {
--		return ret;
--	}
--
--	mutex_lock(&pctldev->mutex);
-+	mutex_lock(&pinctrldev_list_mutex);
- 
--	/* Convert to the pin controllers number space */
--	pin = gpio_to_pin(range, gpio);
--	ret = pinmux_gpio_direction(pctldev, range, pin, input);
-+	/*
-+	 * FIXME UP-specific
-+	 * The two pin controllers (SoC, FPGA) share the GPIO line. Avoid
-+	 * getting into a situation where both are momentarily trying to drive
-+	 * the line (i.e. SoC as output and FPGA as HAT-to-SoC input) by walking
-+	 * the list in opposite directions for the input and output cases.
-+	 */
-+	if (input) {
-+		list_for_each_entry(pctldev, &pinctrldev_list, node) {
-+			ret = pinctrl_set_dir_if_match(pctldev, gpio, input);
-+			if (ret)
-+				break;
-+		}
-+	} else {
-+		list_for_each_entry_reverse(pctldev, &pinctrldev_list, node) {
-+			ret = pinctrl_set_dir_if_match(pctldev, gpio, input);
-+			if (ret)
-+				break;
-+		}
-+	}
- 
--	mutex_unlock(&pctldev->mutex);
-+	mutex_unlock(&pinctrldev_list_mutex);
- 
- 	return ret;
- }
-@@ -894,18 +902,43 @@
- int pinctrl_gpio_set_config(unsigned gpio, unsigned long config)
- {
- 	unsigned long configs[] = { config };
--	struct pinctrl_gpio_range *range;
- 	struct pinctrl_dev *pctldev;
--	int ret, pin;
-+	struct gpio_desc *desc;
-+	int dir;
-+	int ret = -EPROBE_DEFER;
- 
--	ret = pinctrl_get_device_gpio_range(gpio, &pctldev, &range);
--	if (ret)
--		return ret;
-+	desc = gpio_to_desc(gpio);
-+	if (!desc) {
-+		pr_err("gpio_to_desc(%d) returned NULL", gpio);
-+		return -ENODEV;
-+	}
- 
--	mutex_lock(&pctldev->mutex);
--	pin = gpio_to_pin(range, gpio);
--	ret = pinconf_set_config(pctldev, pin, configs, ARRAY_SIZE(configs));
--	mutex_unlock(&pctldev->mutex);
-+	dir = gpiod_get_direction(desc);
-+
-+	mutex_lock(&pinctrldev_list_mutex);
-+
-+	/*
-+	 * NOTE: this code suppose that if we have multiple pinctrl declared for
-+	 * the same gpio those are configured in series.
-+	 * In this situation we need to avoid the case were momentarely
-+	 * multiple pinctrl try do drive the same line to a different logic value
-+	 *
-+	 * (1st pinctrl) 1>-----<0 (2nd pinctrl)
-+	 *
-+	 * To obtain that we need to mind the order in which the multiple pinctrl
-+	 * are configured depending of the desired gpio direction (input, output)
-+	 */
-+	if (dir == 1) {
-+		list_for_each_entry(pctldev, &pinctrldev_list, node) {
-+			ret = pinconf_set_config(pctldev, gpio, configs, ARRAY_SIZE(configs));
-+		}
-+	} else {
-+		list_for_each_entry_reverse(pctldev, &pinctrldev_list, node) {
-+			ret = pinconf_set_config(pctldev, gpio, configs, ARRAY_SIZE(configs));
-+		}
-+	}
-+
-+	mutex_unlock(&pinctrldev_list_mutex);
- 
- 	return ret;
- }
+2.25.1
+

--- a/pkg/kernel/patches-5.10.x/0011-Adding-rk3399-q116.dtb.patch
+++ b/pkg/kernel/patches-5.10.x/0011-Adding-rk3399-q116.dtb.patch
@@ -1,63 +1,32 @@
-From d79a9307d61f4ec2101653059306964b27f2b51b Mon Sep 17 00:00:00 2001
+From 33079caeb1a212089a041f3d3955761c6ab5a855 Mon Sep 17 00:00:00 2001
 From: Roman Shaposhnik <rvs@apache.org>
 Date: Sun, 1 Nov 2020 01:41:51 -0500
-Subject: [PATCH 1/1] Adding rk3399-q116.dtb
+Subject: [PATCH 11/12] Adding rk3399-q116.dtb
 
 ---
- .../arm64/boot/dts/rockchip/ | 16 ++++++++++++++++
- arch/arm64/boot/dts/rockchip/Makefile
- 3 file changed, 16 insertions(+)
+ arch/arm64/boot/dts/rockchip/Makefile         |    2 +
+ arch/arm64/boot/dts/rockchip/rk3399-q116.dts  | 1283 +++++++++++++++++
+ .../boot/dts/rockchip/rockchip-evb_rk3399.dts |   28 +
+ 3 files changed, 1313 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3399-q116.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/rockchip-evb_rk3399.dts
 
 diff --git a/arch/arm64/boot/dts/rockchip/Makefile b/arch/arm64/boot/dts/rockchip/Makefile
-index 57d157e..9ff45a3 100644
---- a/arch/arm64/boot/dts/rockchip/Makefile  2021-04-28 22:29:15.660000000 +0000
-+++ b/arch/arm64/boot/dts/rockchip/Makefile  2021-04-28 22:30:08.310000000 +0000
-@@ -26,6 +26,8 @@
- dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-nanopi-neo4.dtb
+index 26661c7b736b..f3ab619e1a8b 100644
+--- a/arch/arm64/boot/dts/rockchip/Makefile
++++ b/arch/arm64/boot/dts/rockchip/Makefile
+@@ -33,6 +33,8 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-nanopi-neo4.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-orangepi.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-pinebook-pro.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-puma-haikou.dtb
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-q116.dtb
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += rockchip-evb_rk3399.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-roc-pc.dtb
- dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-rock-pi-4.dtb
- dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-rock960.dtb
-diff --git a/arch/arm64/boot/dts/rockchip/rockchip-evb_rk3399.dts b/arch/arm64/boot/dts/rockchip/rockchip-evb_rk3399.dts
-new file mode 100644
-index 000000000000..b5411de59659
---- /dev/null
-+++ b/arch/arm64/boot/dts/rockchip/rockchip-evb_rk3399.dts
-@@ -0,0 +1,28 @@
-+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
-+/*
-+ * Copyright (c) 2021 ZEDEDA Inc.
-+ */
-+#include "rk3399-q116.dts"
-+#include <dt-bindings/leds/common.h>
-+
-+/ {
-+	leds {
-+                compatible = "gpio-leds"; 
-+
-+                power {
-+                        label = "power";
-+                        gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
-+                        color = <LED_COLOR_ID_MULTI>; /* RED and BLUE */
-+                        default-state = "keep";
-+                        linux,default-trigger = "default-on";
-+                };
-+
-+		eve {
-+			label = "eve";
-+			gpios = <&gpio4 3 GPIO_ACTIVE_LOW>;
-+			color = <LED_COLOR_ID_YELLOW>;
-+			default-state = "keep";
-+			linux,default-trigger = "default-on";
-+		};
-+	};
-+};
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-roc-pc-mezzanine.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-rock-pi-4a.dtb
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-q116.dts b/arch/arm64/boot/dts/rockchip/rk3399-q116.dts
 new file mode 100644
-index 000000000000..b5411de59659
+index 000000000000..6e7af76739b8
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-q116.dts
 @@ -0,0 +1,1283 @@
@@ -1344,6 +1313,40 @@ index 000000000000..b5411de59659
 +};
 +
 +
+diff --git a/arch/arm64/boot/dts/rockchip/rockchip-evb_rk3399.dts b/arch/arm64/boot/dts/rockchip/rockchip-evb_rk3399.dts
+new file mode 100644
+index 000000000000..f1474c847b47
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rockchip-evb_rk3399.dts
+@@ -0,0 +1,28 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2021 ZEDEDA Inc.
++ */
++#include "rk3399-q116.dts"
++#include <dt-bindings/leds/common.h>
++
++/ {
++	leds {
++                compatible = "gpio-leds"; 
++
++                power {
++                        label = "power";
++                        gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
++                        color = <LED_COLOR_ID_MULTI>; /* RED and BLUE */
++                        default-state = "keep";
++                        linux,default-trigger = "default-on";
++                };
++
++		eve {
++			label = "eve";
++			gpios = <&gpio4 3 GPIO_ACTIVE_LOW>;
++			color = <LED_COLOR_ID_YELLOW>;
++			default-state = "keep";
++			linux,default-trigger = "default-on";
++		};
++	};
++};
+-- 
+2.25.1
 
---
-2.26.2

--- a/pkg/kernel/patches-5.10.x/0012-Quirk-for-brocken-INTx-on-Euresys-Grablink-Full-XR.patch
+++ b/pkg/kernel/patches-5.10.x/0012-Quirk-for-brocken-INTx-on-Euresys-Grablink-Full-XR.patch
@@ -1,7 +1,7 @@
-From 3e6b97c0a57a4792a643a045e006b10254ba99b2 Mon Sep 17 00:00:00 2001
+From c7822e8d9e89b19498fd48842fd70bd1e47e7fe6 Mon Sep 17 00:00:00 2001
 From: Mikhail Malyshev <mikem@zededa.com>
 Date: Thu, 16 Dec 2021 11:29:26 +0100
-Subject: [PATCH] Quirk for brocken INTx on Euresys Grablink Full XR
+Subject: [PATCH 12/12] Quirk for brocken INTx on Euresys Grablink Full XR
 
 Signed-off-by: Mikhail Malyshev <mikem@zededa.com>
 ---
@@ -9,10 +9,10 @@ Signed-off-by: Mikhail Malyshev <mikem@zededa.com>
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
-index fb1dc11e7..3e625ee41 100644
+index 639fa0fc490c..8f982e252c42 100644
 --- a/drivers/pci/quirks.c
 +++ b/drivers/pci/quirks.c
-@@ -3433,6 +3433,8 @@ DECLARE_PCI_FIXUP_FINAL(0x1814, 0x0601, /* Ralink RT2800 802.11n PCI */
+@@ -3436,6 +3436,8 @@ DECLARE_PCI_FIXUP_FINAL(0x1814, 0x0601, /* Ralink RT2800 802.11n PCI */
  			quirk_broken_intx_masking);
  DECLARE_PCI_FIXUP_FINAL(0x1b7c, 0x0004, /* Ceton InfiniTV4 */
  			quirk_broken_intx_masking);
@@ -22,5 +22,5 @@ index fb1dc11e7..3e625ee41 100644
  /*
   * Realtek RTL8169 PCI Gigabit Ethernet Controller (rev 10)
 -- 
-2.32.0
+2.25.1
 

--- a/pkg/new-kernel/patches-5.12.x/0001-Xen-SMBIOS-property-add.patch
+++ b/pkg/new-kernel/patches-5.12.x/0001-Xen-SMBIOS-property-add.patch
@@ -1,11 +1,14 @@
-commit dd7076bed514bdc6230610d7d8e92be6264b54f9
-Author: Stefano Stabellini <sstabellini@kernel.org>
-Date:   Thu Dec 17 18:27:32 2020 -0800
+From d12cebc3ff175a8d849e561085cd4b20d406882e Mon Sep 17 00:00:00 2001
+From: Stefano Stabellini <sstabellini@kernel.org>
+Date: Thu, 17 Dec 2020 18:27:32 -0800
+Subject: [PATCH 01/11]  Xen SMBIOS property add
 
-    Xen SMBIOS property add
+---
+ arch/arm/xen/enlighten.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
 
 diff --git a/arch/arm/xen/enlighten.c b/arch/arm/xen/enlighten.c
-index 60e901cd0de6..948786d28bb3 100644
+index 8ad576ecd0f1..2a7ec6552f22 100644
 --- a/arch/arm/xen/enlighten.c
 +++ b/arch/arm/xen/enlighten.c
 @@ -33,6 +33,7 @@
@@ -37,3 +40,6 @@ index 60e901cd0de6..948786d28bb3 100644
  }
  
  static int __init xen_guest_init(void)
+-- 
+2.25.1
+

--- a/pkg/new-kernel/patches-5.12.x/0002-rsi91x-Check-wowlan-pointer-in-rsi_shutdown.patch
+++ b/pkg/new-kernel/patches-5.12.x/0002-rsi91x-Check-wowlan-pointer-in-rsi_shutdown.patch
@@ -1,29 +1,29 @@
-From e69899b984b70b90f22ef28138277e66a9ad2884 Mon Sep 17 00:00:00 2001
+From 10abd967902c63d9441bb493b254ca387423609d Mon Sep 17 00:00:00 2001
 From: Sergey Temerkhanov <s.temerkhanov@gmail.com>
 Date: Wed, 26 Aug 2020 00:02:19 +0300
-Subject: [PATCH 14/14] rsi91x: Check wowlan pointer in rsi_shutdown
+Subject: [PATCH 02/11] rsi91x: Check wowlan pointer in rsi_shutdown
 
 Check wowlan pointer before calling rsi_config_wowlan to
 prevent erroneous configuration attempts
 
 Signed-off-by: Sergey Temerkhanov <s.temerkhanov@gmail.com>
 ---
- drivers/net/wireless/rsi/rsi_91x_sdio.c | 3 ++-
- 1 file changed, 2 insertions(+), 1 deletion(-)
+ drivers/net/wireless/rsi/rsi_91x_sdio.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/wireless/rsi/rsi_91x_sdio.c b/drivers/net/wireless/rsi/rsi_91x_sdio.c
-index 1bebba4e8527..1fd208bea839 100644
+index e0c502bc4270..e646dbb39204 100644
 --- a/drivers/net/wireless/rsi/rsi_91x_sdio.c
 +++ b/drivers/net/wireless/rsi/rsi_91x_sdio.c
-@@ -1473,7 +1473,7 @@
+@@ -1469,7 +1469,7 @@ static void rsi_shutdown(struct device *dev)
  	if (hw) {
  		struct cfg80211_wowlan *wowlan = hw->wiphy->wowlan_config;
-
+ 
 -		if (rsi_config_wowlan(adapter, wowlan))
 +		if (wowlan && rsi_config_wowlan(adapter, wowlan))
  			rsi_dbg(ERR_ZONE, "Failed to configure WoWLAN\n");
  	}
-
+ 
 -- 
-2.26.2
+2.25.1
 

--- a/pkg/new-kernel/patches-5.12.x/0003-fget-Do-not-loop-with-rcu-lock-held.patch
+++ b/pkg/new-kernel/patches-5.12.x/0003-fget-Do-not-loop-with-rcu-lock-held.patch
@@ -1,7 +1,7 @@
-From 59ab1a96357ccc470294663e0ceeeaab0c0b7ddd Mon Sep 17 00:00:00 2001
+From 9e63a67dbb3effba9fc350f8c24f8a1cfbe6360c Mon Sep 17 00:00:00 2001
 From: Sergey Temerkhanov <s.temerkhanov@gmail.com>
 Date: Wed, 4 Nov 2020 04:16:57 -0500
-Subject: [PATCH] fget: Do not loop with rcu lock held
+Subject: [PATCH 03/11] fget: Do not loop with rcu lock held
 
 Do not loop wint the RCU lock held
 
@@ -11,18 +11,18 @@ Signed-off-by: Sergey Temerkhanov <s.temerkhanov@gmail.com>
  1 file changed, 20 insertions(+), 14 deletions(-)
 
 diff --git a/fs/file.c b/fs/file.c
-index 5a0fa61504ff..c9ac0232df20 100644
+index f633348029a5..417a343a52c2 100644
 --- a/fs/file.c
 +++ b/fs/file.c
-@@ -715,21 +715,27 @@ static struct file *__fget(unsigned int fd, fmode_t mask, unsigned int refs)
+@@ -829,21 +829,27 @@ static struct file *__fget_files(struct files_struct *files, unsigned int fd,
+ 				 fmode_t mask, unsigned int refs)
  {
- 	struct files_struct *files = current->files;
  	struct file *file;
 +	bool again = false;
  
 -	rcu_read_lock();
 -loop:
--	file = fcheck_files(files, fd);
+-	file = files_lookup_fd_rcu(files, fd);
 -	if (file) {
 -		/* File object ref couldn't be taken.
 -		 * dup2() atomicity guarantee is the reason
@@ -37,7 +37,7 @@ index 5a0fa61504ff..c9ac0232df20 100644
 +	do {
 +		rcu_read_lock();
 +
-+		file = fcheck_files(files, fd);
++		file = files_lookup_fd_rcu(files, fd);
 +		if (file) {
 +			/* File object ref couldn't be taken.
 +			* dup2() atomicity guarantee is the reason
@@ -57,5 +57,5 @@ index 5a0fa61504ff..c9ac0232df20 100644
  	return file;
  }
 -- 
-2.26.2
+2.25.1
 

--- a/pkg/new-kernel/patches-5.12.x/0004-tpm-Rework-open-close-shutdown-to-avoid-races.patch
+++ b/pkg/new-kernel/patches-5.12.x/0004-tpm-Rework-open-close-shutdown-to-avoid-races.patch
@@ -1,7 +1,7 @@
-From ca319096f95ee2d269d31cad888ec19dad89d516 Mon Sep 17 00:00:00 2001
+From b3b9d8c1bfe5dbb8e036c191b6bc45e502a22779 Mon Sep 17 00:00:00 2001
 From: Sergey Temerkhanov <s.temerkhanov@gmail.com>
 Date: Mon, 30 Nov 2020 05:58:22 +0300
-Subject: [PATCH] tpm: Rework open/close/shutdown to avoid races
+Subject: [PATCH 04/11] tpm: Rework open/close/shutdown to avoid races
 
 Avoid race condition at shutdown by shutting downn the TPM 2.0
 devices synchronously. This eliminates the condition when the
@@ -24,7 +24,7 @@ Signed-off-by: Sergey Temerkhanov <s.temerkhanov@gmail.com>
  4 files changed, 21 insertions(+), 9 deletions(-)
 
 diff --git a/drivers/char/tpm/tpm-chip.c b/drivers/char/tpm/tpm-chip.c
-index 1838039b0333..db36c7be0c79 100644
+index ddaeceb7e109..e94148b8e180 100644
 --- a/drivers/char/tpm/tpm-chip.c
 +++ b/drivers/char/tpm/tpm-chip.c
 @@ -295,6 +295,7 @@ static int tpm_class_shutdown(struct device *dev)
@@ -117,7 +117,7 @@ index eef0fb06ea83..fb3cb7b03814 100644
  
  	return 0;
 diff --git a/include/linux/tpm.h b/include/linux/tpm.h
-index 77fdc988c610..590111bbd91c 100644
+index 543aa3b1dedc..00914283af8d 100644
 --- a/include/linux/tpm.h
 +++ b/include/linux/tpm.h
 @@ -21,6 +21,7 @@
@@ -127,8 +127,8 @@ index 77fdc988c610..590111bbd91c 100644
 +#include <linux/atomic.h>
  #include <linux/highmem.h>
  #include <crypto/hash_info.h>
-
-@@ -125,8 +126,9 @@ struct tpm_chip {
+ 
+@@ -135,8 +136,9 @@ struct tpm_chip {
  
  	unsigned int flags;
  

--- a/pkg/new-kernel/patches-5.12.x/0005-add-acs-overrides-for-linux-kernel-version-5.4.51.patch
+++ b/pkg/new-kernel/patches-5.12.x/0005-add-acs-overrides-for-linux-kernel-version-5.4.51.patch
@@ -1,7 +1,7 @@
-From 4287c729bf39a12a138dab0d25feed43b581d891 Mon Sep 17 00:00:00 2001
+From dd9c649b07e13cbad071a0f033764c66ec5e580c Mon Sep 17 00:00:00 2001
 From: Hariharasubramanian C S <cshari@zededa.com>
 Date: Mon, 23 Nov 2020 11:21:45 +0530
-Subject: [PATCH] add acs overrides for linux kernel version 5.4.51
+Subject: [PATCH 05/11] add acs overrides for linux kernel version 5.4.51
 
 This particular patch was taken from:
 https://gitlab.com/Queuecumber/linux-acs-override/-/blob/master/workspaces/5.4/acso.patch
@@ -59,10 +59,10 @@ Signed-off-by: Hariharasubramanian C S <cshari@zededa.com>
  2 files changed, 109 insertions(+)
 
 diff --git a/Documentation/admin-guide/kernel-parameters.txt b/Documentation/admin-guide/kernel-parameters.txt
-index 7bc83f3d9bdf..3174f3bd126a 100644
+index 835f810f2f26..e031cf72f09f 100644
 --- a/Documentation/admin-guide/kernel-parameters.txt
 +++ b/Documentation/admin-guide/kernel-parameters.txt
-@@ -3509,6 +3509,15 @@
+@@ -3661,6 +3661,15 @@
  		nomsi		[MSI] If the PCI_MSI kernel config parameter is
  				enabled, this kernel boot option can be used to
  				disable the use of MSI interrupts system-wide.
@@ -79,10 +79,10 @@ index 7bc83f3d9bdf..3174f3bd126a 100644
  				Safety option to keep boot IRQs enabled. This
  				should never be necessary.
 diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
-index ca9ed5774eb1..1af267d0052f 100644
+index 653660e3ba9e..70b187edb1ce 100644
 --- a/drivers/pci/quirks.c
 +++ b/drivers/pci/quirks.c
-@@ -3544,6 +3544,105 @@ static void quirk_no_bus_reset(struct pci_dev *dev)
+@@ -3558,6 +3558,105 @@ static void quirk_no_bus_reset(struct pci_dev *dev)
  	dev->dev_flags |= PCI_DEV_FLAGS_NO_BUS_RESET;
  }
  
@@ -188,7 +188,7 @@ index ca9ed5774eb1..1af267d0052f 100644
  /*
   * Some Atheros AR9xxx and QCA988x chips do not behave after a bus reset.
   * The device will throw a Link Down error on AER-capable systems and
-@@ -4796,6 +4895,7 @@ static const struct pci_dev_acs_enabled {
+@@ -4773,6 +4872,7 @@ static const struct pci_dev_acs_enabled {
  	{ PCI_VENDOR_ID_ZHAOXIN, 0x9083, pci_quirk_mf_endpoint_acs },
  	/* Zhaoxin Root/Downstream Ports */
  	{ PCI_VENDOR_ID_ZHAOXIN, PCI_ANY_ID, pci_quirk_zhaoxin_pcie_ports_acs },
@@ -197,5 +197,5 @@ index ca9ed5774eb1..1af267d0052f 100644
  };
  
 -- 
-2.20.1 (Apple Git-117)
+2.25.1
 

--- a/pkg/new-kernel/patches-5.12.x/0006-Add-stdout-path-overlay.patch
+++ b/pkg/new-kernel/patches-5.12.x/0006-Add-stdout-path-overlay.patch
@@ -1,17 +1,41 @@
-From d79a9307d61f4ec2101653059306964b27f2b51b Mon Sep 17 00:00:00 2001
+From 7acd555b255bff281c0fea7523e1fe38c68f6fd1 Mon Sep 17 00:00:00 2001
 From: Roman Shaposhnik <rvs@apache.org>
 Date: Sun, 1 Nov 2020 01:41:51 -0500
-Subject: [PATCH 12/14] Add stdout path overlay
+Subject: [PATCH 06/11] Add stdout path overlay
 
 ---
- .../arm/boot/dts/pi4-64-xen-overlay.dts | 16 ++++++++++++++++
- arch/arm/boot/dts/Makefile
- arch/arm64/boot/dts/broadcom/Makefile
- 3 file changed, 16 insertions(+)
+ arch/arm/boot/dts/Makefile                    |   1 +
+ arch/arm64/boot/dts/broadcom/Makefile         |   1 +
+ .../boot/dts/broadcom/raspberrypi-uno-220.dts | 216 ++++++++++++++++++
+ 3 files changed, 218 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/broadcom/raspberrypi-uno-220.dts
 
+diff --git a/arch/arm/boot/dts/Makefile b/arch/arm/boot/dts/Makefile
+index 8e5d4ab4e75e..4ffa6d13505a 100644
+--- a/arch/arm/boot/dts/Makefile
++++ b/arch/arm/boot/dts/Makefile
+@@ -89,6 +89,7 @@ dtb-$(CONFIG_ARCH_BCM2835) += \
+ 	bcm2837-rpi-3-b-plus.dtb \
+ 	bcm2837-rpi-cm3-io3.dtb \
+ 	bcm2711-rpi-4-b.dtb \
++       raspberrypi-uno-220.dtb \
+ 	bcm2835-rpi-zero.dtb \
+ 	bcm2835-rpi-zero-w.dtb
+ dtb-$(CONFIG_ARCH_BCM_5301X) += \
+diff --git a/arch/arm64/boot/dts/broadcom/Makefile b/arch/arm64/boot/dts/broadcom/Makefile
+index 998e240aa698..0f907b3fb0b6 100644
+--- a/arch/arm64/boot/dts/broadcom/Makefile
++++ b/arch/arm64/boot/dts/broadcom/Makefile
+@@ -1,5 +1,6 @@
+ # SPDX-License-Identifier: GPL-2.0
+ dtb-$(CONFIG_ARCH_BCM2835) += bcm2711-rpi-4-b.dtb \
++			      raspberrypi-uno-220.dtb \
+ 			      bcm2837-rpi-3-a-plus.dtb \
+ 			      bcm2837-rpi-3-b.dtb \
+ 			      bcm2837-rpi-3-b-plus.dtb \
 diff --git a/arch/arm64/boot/dts/broadcom/raspberrypi-uno-220.dts b/arch/arm64/boot/dts/broadcom/raspberrypi-uno-220.dts
 new file mode 100644
-index 000000000000..b5411de59659
+index 000000000000..c3d25f522be8
 --- /dev/null
 +++ b/arch/arm64/boot/dts/broadcom/raspberrypi-uno-220.dts
 @@ -0,0 +1,216 @@
@@ -231,28 +255,6 @@ index 000000000000..b5411de59659
 +               interrupts = <10 IRQ_TYPE_LEVEL_HIGH>; */
 +       };
 +};
-diff --git a/arch/arm/boot/dts/Makefile b/arch/arm/boot/dts/Makefile
-index fa6db6eed3e2..cbca43456352 100644
---- a/arch/arm/boot/dts/Makefile	2020-12-15 19:34:59.008957000 +0000
-+++ b/arch/arm/boot/dts/Makefile	2020-12-15 19:36:47.756054000 +0000
-@@ -93,6 +93,7 @@
- 	bcm2837-rpi-3-b-plus.dtb \
- 	bcm2837-rpi-cm3-io3.dtb \
- 	bcm2711-rpi-4-b.dtb \
-+       raspberrypi-uno-220.dtb \
- 	bcm2835-rpi-zero.dtb \
- 	bcm2835-rpi-zero-w.dtb
- dtb-$(CONFIG_ARCH_BCM_5301X) += \
-diff --git a/arch/arm/boot/dts/broadcom/Makefile b/arch/arm/boot/dts/broadcom/Makefile
-index fa6db6eed3e2..cbca43456352 100644
---- a/arch/arm64/boot/dts/broadcom/Makefile	2021-04-06 04:24:06.072745079 +0000
-+++ b/arch/arm64/boot/dts/broadcom/Makefile	2021-04-06 04:24:43.729142399 +0000
-@@ -1,5 +1,6 @@
- # SPDX-License-Identifier: GPL-2.0
- dtb-$(CONFIG_ARCH_BCM2835) += bcm2711-rpi-4-b.dtb \
-+			      raspberrypi-uno-220.dtb \
- 			      bcm2837-rpi-3-a-plus.dtb \
- 			      bcm2837-rpi-3-b.dtb \
- 			      bcm2837-rpi-3-b-plus.dtb \
---
-2.26.2
+-- 
+2.25.1
+

--- a/pkg/new-kernel/patches-5.12.x/0007-Support-for-Siemens-IPC127-MMIO-GPIO-driven-LEDS.patch
+++ b/pkg/new-kernel/patches-5.12.x/0007-Support-for-Siemens-IPC127-MMIO-GPIO-driven-LEDS.patch
@@ -1,22 +1,25 @@
-From 4c0f50aaa56077957d627a79277eb0d75caca30a Thu Apr 15 00:00:00 2021
+From ba1314ca6e3a466c12c0eeafc2c6ca3ca341ac01 Mon Sep 17 00:00:00 2001
 From: Roman Shaposhnik <rvs@apache.org>
 Date: Thu, 15 Apr 2021 16:49:37 +0000
-Subject: [PATCH] Support for Siemens IPC127 MMIO GPIO-driven LEDS
+Subject: [PATCH 07/11] Support for Siemens IPC127 MMIO GPIO-driven LEDS
 
 This simply introduces a tiny LED driver based on the MMIO GPIO
 registers described in user's manual. It would be nice to find
 a generic MMIO GPIO driver since it seems like there's a few that
 do this type of thing already (including the one for APU LEDs that
 was used as a prototype).
-
 ---
- drivers/gpio/gpiolib-acpi.c | 88 ++++++++++++++++++++++++++++++++++++---------
- 1 file changed, 71 insertions(+), 17 deletions(-)
+ drivers/leds/Kconfig               |   8 ++
+ drivers/leds/Makefile              |   1 +
+ drivers/leds/leds-siemens-ipc127.c | 203 +++++++++++++++++++++++++++++
+ 3 files changed, 212 insertions(+)
+ create mode 100644 drivers/leds/leds-siemens-ipc127.c
+
 diff --git a/drivers/leds/Kconfig b/drivers/leds/Kconfig
-index 57d157e..9ff45a3 100644
---- a/drivers/leds/Kconfig	2021-04-15 19:52:27.190000000 +0000
-+++ b/drivers/leds/Kconfig	2021-04-15 19:54:08.970000000 +0000
-@@ -315,6 +315,14 @@
+index b6742b4231bf..f38cae8c977e 100644
+--- a/drivers/leds/Kconfig
++++ b/drivers/leds/Kconfig
+@@ -315,6 +315,14 @@ config LEDS_COBALT_RAQ
  	help
  	  This option enables support for the Cobalt Raq series LEDs.
  
@@ -32,10 +35,10 @@ index 57d157e..9ff45a3 100644
  	tristate "LED support for SunFire servers."
  	depends on LEDS_CLASS
 diff --git a/drivers/leds/Makefile b/drivers/leds/Makefile
-index 57d157e..9ff45a3 100644
---- a/drivers/leds/Makefile	2021-04-15 19:50:57.140000000 +0000
-+++ b/drivers/leds/Makefile	2021-04-15 19:52:16.530000000 +0000
-@@ -84,6 +84,7 @@
+index 2a698df9da57..d12e17d563e3 100644
+--- a/drivers/leds/Makefile
++++ b/drivers/leds/Makefile
+@@ -83,6 +83,7 @@ obj-$(CONFIG_LEDS_REGULATOR)		+= leds-regulator.o
  obj-$(CONFIG_LEDS_S3C24XX)		+= leds-s3c24xx.o
  obj-$(CONFIG_LEDS_SC27XX_BLTC)		+= leds-sc27xx-bltc.o
  obj-$(CONFIG_LEDS_SGM3140)		+= leds-sgm3140.o
@@ -44,9 +47,10 @@ index 57d157e..9ff45a3 100644
  obj-$(CONFIG_LEDS_SYSCON)		+= leds-syscon.o
  obj-$(CONFIG_LEDS_TCA6507)		+= leds-tca6507.o
 diff --git a/drivers/leds/leds-siemens-ipc127.c b/drivers/leds/leds-siemens-ipc127.c
-index 57d157e..9ff45a3 100644
---- /dev/null	2021-04-15 19:50:35.920000000 +0000
-+++ a/drivers/leds/leds-siemens-ipc127.c	2021-04-15 22:54:26.370000000 +0000
+new file mode 100644
+index 000000000000..59a474820a5b
+--- /dev/null
++++ b/drivers/leds/leds-siemens-ipc127.c
 @@ -0,0 +1,203 @@
 +/*
 + * drivers/leds/leds-siemends-ipc127.c
@@ -251,3 +255,6 @@ index 57d157e..9ff45a3 100644
 +MODULE_DESCRIPTION("Siemens IPC127 MMIO GPIO-driven LEDS");
 +MODULE_LICENSE("GPL v2");
 +MODULE_ALIAS("platform:leds_siemens_ipc127");
+-- 
+2.25.1
+

--- a/pkg/new-kernel/patches-5.12.x/0008-ACPI-Add-support-to-map-GPIO-resources-to-ranges.patch
+++ b/pkg/new-kernel/patches-5.12.x/0008-ACPI-Add-support-to-map-GPIO-resources-to-ranges.patch
@@ -1,7 +1,7 @@
-From 4c0f50aaa56077957d627a79277eb0d75caca30a Mon Sep 17 00:00:00 2001
+From 7455b4efa4c0734da8617f3504fb574cb49871c3 Mon Sep 17 00:00:00 2001
 From: Carlos Calderon <carlos.calderon@emutex.com>
 Date: Wed, 20 Feb 2019 16:49:37 +0000
-Subject: [PATCH] ACPI: Add support to map GPIO resources to ranges
+Subject: [PATCH 08/11] ACPI: Add support to map GPIO resources to ranges
 
 All of this is selectively taken from:
     https://github.com/AaeonCM/meta-up-board/tree/warrior/recipes-kernel/linux/files
@@ -44,17 +44,94 @@ manages direction and enable state for those header pins.
 ====================================================================================
 [PATCH 12/19] acpi: acpi_node_add_pin_mapping added to header file.
 ====================================================================================
-
-
 ---
- drivers/gpio/gpiolib-acpi.c | 88 ++++++++++++++++++++++++++++++++++++---------
- 1 file changed, 71 insertions(+), 17 deletions(-)
+ drivers/base/regmap/internal.h    |   5 -
+ drivers/base/regmap/regmap.c      |   5 +
+ drivers/gpio/gpiolib-acpi.c       |  88 +++-
+ drivers/leds/Kconfig              |   7 +
+ drivers/leds/Makefile             |   1 +
+ drivers/leds/leds-upboard.c       |  88 ++++
+ drivers/mfd/Kconfig               |   6 +
+ drivers/mfd/Makefile              |   1 +
+ drivers/mfd/upboard-fpga.c        | 411 +++++++++++++++
+ drivers/pinctrl/Kconfig           |  12 +
+ drivers/pinctrl/Makefile          |   1 +
+ drivers/pinctrl/core.c            | 341 +++++++------
+ drivers/pinctrl/pinctrl-upboard.c | 797 ++++++++++++++++++++++++++++++
+ include/linux/acpi.h              |  13 +
+ include/linux/mfd/upboard-fpga.h  |  52 ++
+ include/linux/regmap.h            |   6 +
+ 16 files changed, 1658 insertions(+), 176 deletions(-)
+ create mode 100644 drivers/leds/leds-upboard.c
+ create mode 100644 drivers/mfd/upboard-fpga.c
+ create mode 100644 drivers/pinctrl/pinctrl-upboard.c
+ create mode 100644 include/linux/mfd/upboard-fpga.h
 
+diff --git a/drivers/base/regmap/internal.h b/drivers/base/regmap/internal.h
+index 0097696c31de..a43309063a68 100644
+--- a/drivers/base/regmap/internal.h
++++ b/drivers/base/regmap/internal.h
+@@ -180,11 +180,6 @@ struct regcache_ops {
+ 	int (*drop)(struct regmap *map, unsigned int min, unsigned int max);
+ };
+ 
+-bool regmap_cached(struct regmap *map, unsigned int reg);
+-bool regmap_writeable(struct regmap *map, unsigned int reg);
+-bool regmap_readable(struct regmap *map, unsigned int reg);
+-bool regmap_volatile(struct regmap *map, unsigned int reg);
+-bool regmap_precious(struct regmap *map, unsigned int reg);
+ bool regmap_writeable_noinc(struct regmap *map, unsigned int reg);
+ bool regmap_readable_noinc(struct regmap *map, unsigned int reg);
+ 
+diff --git a/drivers/base/regmap/regmap.c b/drivers/base/regmap/regmap.c
+index 297e95be25b3..0a6b2ee0b5e0 100644
+--- a/drivers/base/regmap/regmap.c
++++ b/drivers/base/regmap/regmap.c
+@@ -100,6 +100,7 @@ bool regmap_writeable(struct regmap *map, unsigned int reg)
+ 
+ 	return true;
+ }
++EXPORT_SYMBOL_GPL(regmap_writeable);
+ 
+ bool regmap_cached(struct regmap *map, unsigned int reg)
+ {
+@@ -123,6 +124,7 @@ bool regmap_cached(struct regmap *map, unsigned int reg)
+ 
+ 	return true;
+ }
++EXPORT_SYMBOL_GPL(regmap_cached);
+ 
+ bool regmap_readable(struct regmap *map, unsigned int reg)
+ {
+@@ -143,6 +145,7 @@ bool regmap_readable(struct regmap *map, unsigned int reg)
+ 
+ 	return true;
+ }
++EXPORT_SYMBOL_GPL(regmap_readable);
+ 
+ bool regmap_volatile(struct regmap *map, unsigned int reg)
+ {
+@@ -160,6 +163,7 @@ bool regmap_volatile(struct regmap *map, unsigned int reg)
+ 	else
+ 		return true;
+ }
++EXPORT_SYMBOL_GPL(regmap_volatile);
+ 
+ bool regmap_precious(struct regmap *map, unsigned int reg)
+ {
+@@ -174,6 +178,7 @@ bool regmap_precious(struct regmap *map, unsigned int reg)
+ 
+ 	return false;
+ }
++EXPORT_SYMBOL_GPL(regmap_precious);
+ 
+ bool regmap_writeable_noinc(struct regmap *map, unsigned int reg)
+ {
 diff --git a/drivers/gpio/gpiolib-acpi.c b/drivers/gpio/gpiolib-acpi.c
-index 57d157e..9ff45a3 100644
+index 1aacd2a5a1fd..16d3dab2f201 100644
 --- a/drivers/gpio/gpiolib-acpi.c
 +++ b/drivers/gpio/gpiolib-acpi.c
-@@ -1213,6 +1213,32 @@ static int acpi_find_gpio_count(struct acpi_resource *ares, void *data)
+@@ -1325,6 +1325,32 @@ static int acpi_find_gpio_count(struct acpi_resource *ares, void *data)
  	return 1;
  }
  
@@ -85,9 +162,9 @@ index 57d157e..9ff45a3 100644
 +}
 +
  /**
-  * acpi_gpio_count - return the number of GPIOs associated with a
-  *		device / function or -ENOENT if no GPIO has been
-@@ -1223,10 +1249,7 @@ static int acpi_find_gpio_count(struct acpi_resource *ares, void *data)
+  * acpi_gpio_count - count the GPIOs associated with a device / function
+  * @dev:	GPIO consumer, can be %NULL for system-global GPIOs
+@@ -1337,10 +1363,7 @@ static int acpi_find_gpio_count(struct acpi_resource *ares, void *data)
  int acpi_gpio_count(struct device *dev, const char *con_id)
  {
  	struct acpi_device *adev = ACPI_COMPANION(dev);
@@ -98,7 +175,7 @@ index 57d157e..9ff45a3 100644
  	char propname[32];
  	unsigned int i;
  
-@@ -1239,20 +1262,7 @@ int acpi_gpio_count(struct device *dev, const char *con_id)
+@@ -1353,20 +1376,7 @@ int acpi_gpio_count(struct device *dev, const char *con_id)
  			snprintf(propname, sizeof(propname), "%s",
  				 gpio_suffixes[i]);
  
@@ -120,8 +197,8 @@ index 57d157e..9ff45a3 100644
  		if (count > 0)
  			break;
  	}
-@@ -1284,6 +1294,50 @@ bool acpi_can_fallback_to_crs(struct acpi_device *adev, const char *con_id)
- 	return con_id == NULL;
+@@ -1389,6 +1399,50 @@ int acpi_gpio_count(struct device *dev, const char *con_id)
+ 	return count ? count : -ENOENT;
  }
  
 +/**
@@ -169,196 +246,15 @@ index 57d157e..9ff45a3 100644
 +EXPORT_SYMBOL_GPL(acpi_node_add_pin_mapping);
 +
  /* Run deferred acpi_gpiochip_request_irqs() */
- static int acpi_gpio_handle_deferred_request_irqs(void)
+ static int __init acpi_gpio_handle_deferred_request_irqs(void)
  {
--- 
-2.7.4
-
-From 9bdaf721fd148b50439d9e1c4dbf5e5c45313944 Mon Sep 17 00:00:00 2001
-From: Carlos Calderon <carlos@emutex.com>
-Date: Mon, 8 Oct 2018 16:06:21 +0100
-Subject: [PATCH 12/19] acpi: acpi_node_add_pin_mapping added to header file.
-
----
- include/linux/acpi.h | 13 +++++++++++++
- 1 file changed, 13 insertions(+)
-
-diff --git a/include/linux/acpi.h b/include/linux/acpi.h
-index fdb1d5262ce8..dacc84699b82 100644
---- a/include/linux/acpi.h
-+++ b/include/linux/acpi.h
-@@ -1080,6 +1080,11 @@ void __acpi_handle_debug(struct _ddebug *descriptor, acpi_handle handle, const c
- bool acpi_gpio_get_irq_resource(struct acpi_resource *ares,
- 				struct acpi_resource_gpio **agpio);
- int acpi_dev_gpio_irq_get_by(struct acpi_device *adev, const char *name, int index);
-+int acpi_node_add_pin_mapping(struct fwnode_handle *fwnode,
-+			      const char *propname,
-+			      const char *pinctl_name,
-+			      unsigned int pin_offset,
-+			      unsigned int npins);
- #else
- static inline bool acpi_gpio_get_irq_resource(struct acpi_resource *ares,
- 					      struct acpi_resource_gpio **agpio)
-@@ -1091,6 +1096,14 @@ static inline int acpi_dev_gpio_irq_get_by(struct acpi_device *adev,
- {
- 	return -ENXIO;
- }
-+static inline int acpi_node_add_pin_mapping(struct fwnode_handle *fwnode,
-+					    const char *propname,
-+					    const char *pinctl_name,
-+					    unsigned int pin_offset,
-+					    unsigned int npins)
-+{
-+	return -ENXIO;
-+}
- #endif
- 
- static inline int acpi_dev_gpio_irq_get(struct acpi_device *adev, int index)
--- 
-2.25.1
-
-From b0ec896e741f330df18785e931537be1862ff4c8 Mon Sep 17 00:00:00 2001
-From: Nicola Lunghi <nicola.lunghi@emutex.com>
-Date: Thu, 27 Jul 2017 17:55:34 +0100
-Subject: [PATCH 05/19] regmap: Expose regmap_writable function to check if a
- register is writable
-
-Signed-off-by: Nicola Lunghi <nicola.lunghi@emutex.com>
----
- drivers/base/regmap/internal.h | 5 -----
- drivers/base/regmap/regmap.c   | 5 +++++
- include/linux/regmap.h         | 6 ++++++
- 3 files changed, 11 insertions(+), 5 deletions(-)
-
-diff --git a/drivers/base/regmap/internal.h b/drivers/base/regmap/internal.h
-index a6bf34d63..de951a1 100644
---- a/drivers/base/regmap/internal.h
-+++ b/drivers/base/regmap/internal.h
-@@ -180,11 +180,6 @@
- 	int (*drop)(struct regmap *map, unsigned int min, unsigned int max);
- };
- 
--bool regmap_cached(struct regmap *map, unsigned int reg);
--bool regmap_writeable(struct regmap *map, unsigned int reg);
--bool regmap_readable(struct regmap *map, unsigned int reg);
--bool regmap_volatile(struct regmap *map, unsigned int reg);
--bool regmap_precious(struct regmap *map, unsigned int reg);
- bool regmap_writeable_noinc(struct regmap *map, unsigned int reg);
- bool regmap_readable_noinc(struct regmap *map, unsigned int reg);
- 
-diff --git a/drivers/base/regmap/regmap.c b/drivers/base/regmap/regmap.c
-index 0360a90..f61a24c 100644
---- a/drivers/base/regmap/regmap.c
-+++ b/drivers/base/regmap/regmap.c
-@@ -93,6 +93,7 @@ bool regmap_writeable(struct regmap *map, unsigned int reg)
- 
- 	return true;
- }
-+EXPORT_SYMBOL_GPL(regmap_writeable);
- 
- bool regmap_cached(struct regmap *map, unsigned int reg)
- {
-@@ -116,6 +117,7 @@ bool regmap_cached(struct regmap *map, unsigned int reg)
- 
- 	return true;
- }
-+EXPORT_SYMBOL_GPL(regmap_cached);
- 
- bool regmap_readable(struct regmap *map, unsigned int reg)
- {
-@@ -136,6 +138,7 @@ bool regmap_readable(struct regmap *map, unsigned int reg)
- 
- 	return true;
- }
-+EXPORT_SYMBOL_GPL(regmap_readable);
- 
- bool regmap_volatile(struct regmap *map, unsigned int reg)
- {
-@@ -153,6 +156,7 @@ bool regmap_volatile(struct regmap *map, unsigned int reg)
- 	else
- 		return true;
- }
-+EXPORT_SYMBOL_GPL(regmap_volatile);
- 
- bool regmap_precious(struct regmap *map, unsigned int reg)
- {
-@@ -167,6 +171,7 @@ bool regmap_precious(struct regmap *map, unsigned int reg)
- 
- 	return false;
- }
-+EXPORT_SYMBOL_GPL(regmap_precious);
- 
- bool regmap_readable_noinc(struct regmap *map, unsigned int reg)
- {
-diff --git a/include/linux/regmap.h b/include/linux/regmap.h
-index 035129b..36bc898 100644
---- a/include/linux/regmap.h
-+++ b/include/linux/regmap.h
-@@ -1025,6 +1025,12 @@ void regcache_mark_dirty(struct regmap *map);
- bool regmap_check_range_table(struct regmap *map, unsigned int reg,
- 			      const struct regmap_access_table *table);
- 
-+bool regmap_cached(struct regmap *map, unsigned int reg);
-+bool regmap_writeable(struct regmap *map, unsigned int reg);
-+bool regmap_readable(struct regmap *map, unsigned int reg);
-+bool regmap_volatile(struct regmap *map, unsigned int reg);
-+bool regmap_precious(struct regmap *map, unsigned int reg);
-+
- int regmap_register_patch(struct regmap *map, const struct reg_sequence *regs,
- 			  int num_regs);
- int regmap_parse_val(struct regmap *map, const void *buf,
--- 
-2.7.4
-
-From bf2af81a5a93050a2b0b3feffac521c3ed177578 Mon Sep 17 00:00:00 2001
-From: Carlos Calderon <carlos@emutex.com>
-Date: Thu, 4 Oct 2018 10:40:49 +0100
-Subject: [PATCH 07/19] mfd: Add support for UP board CPLD/FPGA
-
-The UP Squared board <http://www.upboard.com> implements certain
-features (pin control, onboard LEDs or CEC) through an on-board FPGA.
-
-This mfd driver implements the line protocol to read and write registers
-from the FPGA through regmap. The register address map is also included.
-
-The UP boards come with a few FPGA-controlled onboard LEDs:
-* UP Board: yellow, green, red
-* UP Squared: blue, yellow, green, red
-
-The UP Boards provide a few I/O pin headers (for both GPIO and
-functions), including a 40-pin Raspberry Pi compatible header.
-
-This patch implements support for the FPGA-based pin controller that
-manages direction and enable state for those header pins.
-
-Signed-off-by: Javier Arteaga <javier@emutex.com>
-[merge various fixes]
-Signed-off-by: Nicola Lunghi <nicola.lunghi@emutex.com>
----
- drivers/leds/Kconfig              |   7 +
- drivers/leds/Makefile             |   1 +
- drivers/leds/leds-upboard.c       |  88 +++++
- drivers/mfd/Kconfig               |   6 +
- drivers/mfd/Makefile              |   1 +
- drivers/mfd/upboard-fpga.c        | 411 ++++++++++++++++++++
- drivers/pinctrl/Kconfig           |  12 +
- drivers/pinctrl/Makefile          |   1 +
- drivers/pinctrl/pinctrl-upboard.c | 797 ++++++++++++++++++++++++++++++++++++++
- include/linux/mfd/upboard-fpga.h  |  52 +++
- 10 files changed, 1376 insertions(+)
- create mode 100644 drivers/leds/leds-upboard.c
- create mode 100644 drivers/mfd/upboard-fpga.c
- create mode 100644 drivers/pinctrl/pinctrl-upboard.c
- create mode 100644 include/linux/mfd/upboard-fpga.h
-
-
 diff --git a/drivers/leds/Kconfig b/drivers/leds/Kconfig
-index 44097a3..554a2d9 100644
+index f38cae8c977e..5d0d6ffd9397 100644
 --- a/drivers/leds/Kconfig
 +++ b/drivers/leds/Kconfig
-@@ -928,6 +928,13 @@
- 	  This option enables support for the Power Button LED of
- 	  Acer Iconia Tab A500.
+@@ -939,6 +939,13 @@ config LEDS_ACER_A500
+ comment "Flash and Torch LED drivers"
+ source "drivers/leds/flash/Kconfig"
  
 +config LEDS_UPBOARD
 +        tristate "LED support for the UP board"
@@ -371,10 +267,10 @@ index 44097a3..554a2d9 100644
  source "drivers/leds/trigger/Kconfig"
  
 diff --git a/drivers/leds/Makefile b/drivers/leds/Makefile
-index 420b5d2..fe79d1e 100644
+index d12e17d563e3..3e7cdf362d48 100644
 --- a/drivers/leds/Makefile
 +++ b/drivers/leds/Makefile
-@@ -68,6 +68,7 @@
+@@ -68,6 +68,7 @@ obj-$(CONFIG_LEDS_MIKROTIK_RB532)	+= leds-rb532.o
  obj-$(CONFIG_LEDS_MLXCPLD)		+= leds-mlxcpld.o
  obj-$(CONFIG_LEDS_MLXREG)		+= leds-mlxreg.o
  obj-$(CONFIG_LEDS_MT6323)		+= leds-mt6323.o
@@ -384,7 +280,7 @@ index 420b5d2..fe79d1e 100644
  obj-$(CONFIG_LEDS_NIC78BX)		+= leds-nic78bx.o
 diff --git a/drivers/leds/leds-upboard.c b/drivers/leds/leds-upboard.c
 new file mode 100644
-index 0000000..16bd1b7
+index 000000000000..16bd1b7c0a1e
 --- /dev/null
 +++ b/drivers/leds/leds-upboard.c
 @@ -0,0 +1,88 @@
@@ -478,12 +374,12 @@ index 0000000..16bd1b7
 +MODULE_ALIAS("platform:upboard-led");
 \ No newline at end of file
 diff --git a/drivers/mfd/Kconfig b/drivers/mfd/Kconfig
-index 11841f4..7164934 100644
+index b74efa469e90..ad405da713fa 100644
 --- a/drivers/mfd/Kconfig
 +++ b/drivers/mfd/Kconfig
-@@ -2098,6 +2098,12 @@
- 	  additional drivers must be enabled in order to use the functionality
- 	  of the device.
+@@ -2087,6 +2087,12 @@ config MFD_ACER_A500_EC
+ 	  The controller itself is ENE KB930, it is running firmware
+ 	  customized for the specific needs of the Acer A500 hardware.
  
 +config MFD_UPBOARD_FPGA
 +        tristate "Support for the UP board FPGA"
@@ -495,10 +391,10 @@ index 11841f4..7164934 100644
  	depends on ARCH_SA1100
  
 diff --git a/drivers/mfd/Makefile b/drivers/mfd/Makefile
-index 5856a94..22553f6 100644
+index 834f5463af28..3aa2d50021ed 100644
 --- a/drivers/mfd/Makefile
 +++ b/drivers/mfd/Makefile
-@@ -252,6 +252,7 @@
+@@ -252,6 +252,7 @@ obj-$(CONFIG_MFD_ALTERA_A10SR)	+= altera-a10sr.o
  obj-$(CONFIG_MFD_ALTERA_SYSMGR) += altera-sysmgr.o
  obj-$(CONFIG_MFD_STPMIC1)	+= stpmic1.o
  obj-$(CONFIG_MFD_SUN4I_GPADC)	+= sun4i-gpadc.o
@@ -506,10 +402,9 @@ index 5856a94..22553f6 100644
  
  obj-$(CONFIG_MFD_STM32_LPTIMER)	+= stm32-lptimer.o
  obj-$(CONFIG_MFD_STM32_TIMERS) 	+= stm32-timers.o
-
 diff --git a/drivers/mfd/upboard-fpga.c b/drivers/mfd/upboard-fpga.c
 new file mode 100644
-index 0000000..9f444f8
+index 000000000000..9f444f876af1
 --- /dev/null
 +++ b/drivers/mfd/upboard-fpga.c
 @@ -0,0 +1,411 @@
@@ -926,10 +821,10 @@ index 0000000..9f444f8
 +MODULE_LICENSE("GPL v2");
 \ No newline at end of file
 diff --git a/drivers/pinctrl/Kconfig b/drivers/pinctrl/Kconfig
-index e86752b..d68d3c7 100644
+index b7675cce0027..841b11c81e74 100644
 --- a/drivers/pinctrl/Kconfig
 +++ b/drivers/pinctrl/Kconfig
-@@ -362,6 +362,18 @@
+@@ -339,6 +339,18 @@ config PINCTRL_RK805
  	help
  	  This selects the pinctrl driver for RK805.
  
@@ -949,20 +844,442 @@ index e86752b..d68d3c7 100644
  	bool "Pinctrl driver for the Microsemi Ocelot and Jaguar2 SoCs"
  	depends on OF
 diff --git a/drivers/pinctrl/Makefile b/drivers/pinctrl/Makefile
-index 46ef9bd..828a6e9 100644
+index 8bf459c32a76..269a1a7ef1cc 100644
 --- a/drivers/pinctrl/Makefile
 +++ b/drivers/pinctrl/Makefile
-@@ -45,6 +45,7 @@
+@@ -42,6 +42,7 @@ obj-$(CONFIG_PINCTRL_STMFX) 	+= pinctrl-stmfx.o
  obj-$(CONFIG_PINCTRL_ZYNQ)	+= pinctrl-zynq.o
  obj-$(CONFIG_PINCTRL_INGENIC)	+= pinctrl-ingenic.o
  obj-$(CONFIG_PINCTRL_RK805)	+= pinctrl-rk805.o
 +obj-$(CONFIG_PINCTRL_UPBOARD)   += pinctrl-upboard.o
  obj-$(CONFIG_PINCTRL_OCELOT)	+= pinctrl-ocelot.o
+ obj-$(CONFIG_PINCTRL_MICROCHIP_SGPIO)	+= pinctrl-microchip-sgpio.o
  obj-$(CONFIG_PINCTRL_EQUILIBRIUM)   += pinctrl-equilibrium.o
-
+diff --git a/drivers/pinctrl/core.c b/drivers/pinctrl/core.c
+index 6e6825d17a1d..b80dbb8e9420 100644
+--- a/drivers/pinctrl/core.c
++++ b/drivers/pinctrl/core.c
+@@ -266,8 +266,7 @@ static int pinctrl_register_pins(struct pinctrl_dev *pctldev,
+  * and pin list based GPIO ranges is managed correctly by this function.
+  *
+  * This function assumes the gpio is part of the specified GPIO range, use
+- * only after making sure this is the case (e.g. by calling it on the
+- * result of successful pinctrl_get_device_gpio_range calls)!
++ * only after making sure this is the case!
+  */
+ static inline int gpio_to_pin(struct pinctrl_gpio_range *range,
+ 				unsigned int gpio)
+@@ -306,92 +305,6 @@ pinctrl_match_gpio_range(struct pinctrl_dev *pctldev, unsigned gpio)
+ 	return NULL;
+ }
+ 
+-/**
+- * pinctrl_ready_for_gpio_range() - check if other GPIO pins of
+- * the same GPIO chip are in range
+- * @gpio: gpio pin to check taken from the global GPIO pin space
+- *
+- * This function is complement of pinctrl_match_gpio_range(). If the return
+- * value of pinctrl_match_gpio_range() is NULL, this function could be used
+- * to check whether pinctrl device is ready or not. Maybe some GPIO pins
+- * of the same GPIO chip don't have back-end pinctrl interface.
+- * If the return value is true, it means that pinctrl device is ready & the
+- * certain GPIO pin doesn't have back-end pinctrl device. If the return value
+- * is false, it means that pinctrl device may not be ready.
+- */
+-#ifdef CONFIG_GPIOLIB
+-static bool pinctrl_ready_for_gpio_range(unsigned gpio)
+-{
+-	struct pinctrl_dev *pctldev;
+-	struct pinctrl_gpio_range *range = NULL;
+-	struct gpio_chip *chip = gpio_to_chip(gpio);
+-
+-	if (WARN(!chip, "no gpio_chip for gpio%i?", gpio))
+-		return false;
+-
+-	mutex_lock(&pinctrldev_list_mutex);
+-
+-	/* Loop over the pin controllers */
+-	list_for_each_entry(pctldev, &pinctrldev_list, node) {
+-		/* Loop over the ranges */
+-		mutex_lock(&pctldev->mutex);
+-		list_for_each_entry(range, &pctldev->gpio_ranges, node) {
+-			/* Check if any gpio range overlapped with gpio chip */
+-			if (range->base + range->npins - 1 < chip->base ||
+-			    range->base > chip->base + chip->ngpio - 1)
+-				continue;
+-			mutex_unlock(&pctldev->mutex);
+-			mutex_unlock(&pinctrldev_list_mutex);
+-			return true;
+-		}
+-		mutex_unlock(&pctldev->mutex);
+-	}
+-
+-	mutex_unlock(&pinctrldev_list_mutex);
+-
+-	return false;
+-}
+-#else
+-static bool pinctrl_ready_for_gpio_range(unsigned gpio) { return true; }
+-#endif
+-
+-/**
+- * pinctrl_get_device_gpio_range() - find device for GPIO range
+- * @gpio: the pin to locate the pin controller for
+- * @outdev: the pin control device if found
+- * @outrange: the GPIO range if found
+- *
+- * Find the pin controller handling a certain GPIO pin from the pinspace of
+- * the GPIO subsystem, return the device and the matching GPIO range. Returns
+- * -EPROBE_DEFER if the GPIO range could not be found in any device since it
+- * may still have not been registered.
+- */
+-static int pinctrl_get_device_gpio_range(unsigned gpio,
+-					 struct pinctrl_dev **outdev,
+-					 struct pinctrl_gpio_range **outrange)
+-{
+-	struct pinctrl_dev *pctldev;
+-
+-	mutex_lock(&pinctrldev_list_mutex);
+-
+-	/* Loop over the pin controllers */
+-	list_for_each_entry(pctldev, &pinctrldev_list, node) {
+-		struct pinctrl_gpio_range *range;
+-
+-		range = pinctrl_match_gpio_range(pctldev, gpio);
+-		if (range) {
+-			*outdev = pctldev;
+-			*outrange = range;
+-			mutex_unlock(&pinctrldev_list_mutex);
+-			return 0;
+-		}
+-	}
+-
+-	mutex_unlock(&pinctrldev_list_mutex);
+-
+-	return -EPROBE_DEFER;
+-}
+-
+ /**
+  * pinctrl_add_gpio_range() - register a GPIO range for a controller
+  * @pctldev: pin controller device to add the range to
+@@ -706,6 +619,57 @@ static inline void pinctrl_generic_free_groups(struct pinctrl_dev *pctldev)
+ }
+ #endif /* CONFIG_GENERIC_PINCTRL_GROUPS */
+ 
++void pinctrl_free_gpio_locked(unsigned int gpio)
++{
++	struct pinctrl_dev *pctldev;
++
++	list_for_each_entry(pctldev, &pinctrldev_list, node) {
++		struct pinctrl_gpio_range *range =
++			pinctrl_match_gpio_range(pctldev, gpio);
++		if (range != NULL) {
++			int pin;
++
++			mutex_lock(&pctldev->mutex);
++			pin = gpio_to_pin(range, gpio);
++			pinmux_free_gpio(pctldev, pin, range);
++			mutex_unlock(&pctldev->mutex);
++		}
++	}
++}
++
++static int pinctrl_request_if_match(struct pinctrl_dev *pctldev,
++				    unsigned int gpio, int dir)
++{
++	struct pinctrl_gpio_range *range =
++		pinctrl_match_gpio_range(pctldev, gpio);
++	int ret;
++
++	if (range != NULL) {
++		int pin;
++
++		mutex_lock(&pctldev->mutex);
++		pin = gpio_to_pin(range, gpio);
++
++		ret = pinmux_request_gpio(pctldev, range, pin, gpio);
++		if (ret) {
++			mutex_unlock(&pctldev->mutex);
++			return ret;
++		}
++
++		if (dir >= 0) {
++			ret = pinmux_gpio_direction(pctldev, range, pin, dir);
++			if (ret) {
++				mutex_unlock(&pctldev->mutex);
++				return ret;
++			}
++		}
++		mutex_unlock(&pctldev->mutex);
++
++	}
++
++	return 0;
++}
++
+ /**
+  * pinctrl_get_group_selector() - returns the group selector for a group
+  * @pctldev: the pin controller handling the group
+@@ -742,25 +706,27 @@ bool pinctrl_gpio_can_use_line(unsigned gpio)
+ {
+ 	struct pinctrl_dev *pctldev;
+ 	struct pinctrl_gpio_range *range;
+-	bool result;
++	bool result = true;
+ 	int pin;
+ 
+-	/*
+-	 * Try to obtain GPIO range, if it fails
+-	 * we're probably dealing with GPIO driver
+-	 * without a backing pin controller - bail out.
+-	 */
+-	if (pinctrl_get_device_gpio_range(gpio, &pctldev, &range))
+-		return true;
+-
+-	mutex_lock(&pctldev->mutex);
+-
+-	/* Convert to the pin controllers number space */
+-	pin = gpio_to_pin(range, gpio);
++	mutex_lock(&pinctrldev_list_mutex);
+ 
+-	result = pinmux_can_be_used_for_gpio(pctldev, pin);
++        /*
++         * Try to obtain GPIO range, if it fails
++         * we're probably dealing with GPIO driver
++         * without a backing pin controller - bail out.
++         */
++	list_for_each_entry(pctldev, &pinctrldev_list, node) {
++		range = pinctrl_match_gpio_range(pctldev, gpio);
++		if (range != NULL) {
++			mutex_lock(&pctldev->mutex);
++			pin = gpio_to_pin(range, gpio);
++			result = result && pinmux_can_be_used_for_gpio(pctldev, pin);
++			mutex_unlock(&pctldev->mutex);
++		}
++	}
+ 
+-	mutex_unlock(&pctldev->mutex);
++	mutex_unlock(&pinctrldev_list_mutex);
+ 
+ 	return result;
+ }
+@@ -774,28 +740,53 @@ EXPORT_SYMBOL_GPL(pinctrl_gpio_can_use_line);
+  * as part of their gpio_request() semantics, platforms and individual drivers
+  * shall *NOT* request GPIO pins to be muxed in.
+  */
+-int pinctrl_gpio_request(unsigned gpio)
++int pinctrl_gpio_request(unsigned int gpio)
+ {
+ 	struct pinctrl_dev *pctldev;
+-	struct pinctrl_gpio_range *range;
+-	int ret;
+-	int pin;
++	struct gpio_desc *desc;
++	int dir;
++	int ret = -EPROBE_DEFER;
+ 
+-	ret = pinctrl_get_device_gpio_range(gpio, &pctldev, &range);
+-	if (ret) {
+-		if (pinctrl_ready_for_gpio_range(gpio))
+-			ret = 0;
+-		return ret;
++	desc = gpio_to_desc(gpio);
++	if (!desc) {
++		pr_err("gpio_to_desc(%d) returned NULL", gpio);
++		return -ENODEV;
+ 	}
+ 
+-	mutex_lock(&pctldev->mutex);
++	dir = gpiod_get_direction(desc);
+ 
+-	/* Convert to the pin controllers number space */
+-	pin = gpio_to_pin(range, gpio);
++	mutex_lock(&pinctrldev_list_mutex);
+ 
+-	ret = pinmux_request_gpio(pctldev, range, pin, gpio);
++	/*
++	 * NOTE: this code suppose that if we have multiple pinctrl declared for
++	 * the same gpio those are configured in series.
++	 * In this situation we need to avoid the case were momentarely
++	 * multiple pinctrl try do drive the same line to a different logic value
++	 *
++	 * (1st pinctrl) 1>-----<0 (2nd pinctrl)
++	 *
++	 * To obtain that we need to mind the order in which the multiple pinctrl
++	 * are configured depending of the desired gpio direction (input, output)
++	 */
++	if (dir == 1) {
++		list_for_each_entry(pctldev, &pinctrldev_list, node) {
++			ret = pinctrl_request_if_match(pctldev, gpio, dir);
++			if (ret) {
++				pinctrl_free_gpio_locked(gpio);
++				break;
++			}
++		}
++	} else {
++		list_for_each_entry_reverse(pctldev, &pinctrldev_list, node) {
++			ret = pinctrl_request_if_match(pctldev, gpio, dir);
++			if (ret) {
++				pinctrl_free_gpio_locked(gpio);
++				break;
++			}
++		}
++	}
+ 
+-	mutex_unlock(&pctldev->mutex);
++	mutex_unlock(&pinctrldev_list_mutex);
+ 
+ 	return ret;
+ }
+@@ -809,47 +800,64 @@ EXPORT_SYMBOL_GPL(pinctrl_gpio_request);
+  * as part of their gpio_free() semantics, platforms and individual drivers
+  * shall *NOT* request GPIO pins to be muxed out.
+  */
+-void pinctrl_gpio_free(unsigned gpio)
++void pinctrl_gpio_free(unsigned int gpio)
+ {
+-	struct pinctrl_dev *pctldev;
+-	struct pinctrl_gpio_range *range;
+-	int ret;
+-	int pin;
++	mutex_lock(&pinctrldev_list_mutex);
+ 
+-	ret = pinctrl_get_device_gpio_range(gpio, &pctldev, &range);
+-	if (ret) {
+-		return;
+-	}
+-	mutex_lock(&pctldev->mutex);
++	pinctrl_free_gpio_locked(gpio);
++
++	mutex_unlock(&pinctrldev_list_mutex);
++}
++EXPORT_SYMBOL_GPL(pinctrl_gpio_free);
+ 
+-	/* Convert to the pin controllers number space */
+-	pin = gpio_to_pin(range, gpio);
++static int pinctrl_set_dir_if_match(struct pinctrl_dev *pctldev,
++				    unsigned int gpio, bool input)
++{
++	struct pinctrl_gpio_range *range =
++		pinctrl_match_gpio_range(pctldev, gpio);
++	int ret = 0;
+ 
+-	pinmux_free_gpio(pctldev, pin, range);
++	if (range != NULL) {
++		int pin;
+ 
+-	mutex_unlock(&pctldev->mutex);
++		mutex_lock(&pctldev->mutex);
++		pin = gpio_to_pin(range, gpio);
++		ret = pinmux_gpio_direction(pctldev, range, pin, input);
++		mutex_unlock(&pctldev->mutex);
++	}
++
++	return ret;
+ }
+-EXPORT_SYMBOL_GPL(pinctrl_gpio_free);
+ 
+ static int pinctrl_gpio_direction(unsigned gpio, bool input)
+ {
+ 	struct pinctrl_dev *pctldev;
+-	struct pinctrl_gpio_range *range;
+-	int ret;
+-	int pin;
+-
+-	ret = pinctrl_get_device_gpio_range(gpio, &pctldev, &range);
+-	if (ret) {
+-		return ret;
+-	}
++	int ret = -EPROBE_DEFER;
+ 
+-	mutex_lock(&pctldev->mutex);
++	mutex_lock(&pinctrldev_list_mutex);
+ 
+-	/* Convert to the pin controllers number space */
+-	pin = gpio_to_pin(range, gpio);
+-	ret = pinmux_gpio_direction(pctldev, range, pin, input);
++	/*
++	 * FIXME UP-specific
++	 * The two pin controllers (SoC, FPGA) share the GPIO line. Avoid
++	 * getting into a situation where both are momentarily trying to drive
++	 * the line (i.e. SoC as output and FPGA as HAT-to-SoC input) by walking
++	 * the list in opposite directions for the input and output cases.
++	 */
++	if (input) {
++		list_for_each_entry(pctldev, &pinctrldev_list, node) {
++			ret = pinctrl_set_dir_if_match(pctldev, gpio, input);
++			if (ret)
++				break;
++		}
++	} else {
++		list_for_each_entry_reverse(pctldev, &pinctrldev_list, node) {
++			ret = pinctrl_set_dir_if_match(pctldev, gpio, input);
++			if (ret)
++				break;
++		}
++	}
+ 
+-	mutex_unlock(&pctldev->mutex);
++	mutex_unlock(&pinctrldev_list_mutex);
+ 
+ 	return ret;
+ }
+@@ -894,18 +902,43 @@ EXPORT_SYMBOL_GPL(pinctrl_gpio_direction_output);
+ int pinctrl_gpio_set_config(unsigned gpio, unsigned long config)
+ {
+ 	unsigned long configs[] = { config };
+-	struct pinctrl_gpio_range *range;
+ 	struct pinctrl_dev *pctldev;
+-	int ret, pin;
++	struct gpio_desc *desc;
++	int dir;
++	int ret = -EPROBE_DEFER;
+ 
+-	ret = pinctrl_get_device_gpio_range(gpio, &pctldev, &range);
+-	if (ret)
+-		return ret;
++	desc = gpio_to_desc(gpio);
++	if (!desc) {
++		pr_err("gpio_to_desc(%d) returned NULL", gpio);
++		return -ENODEV;
++	}
+ 
+-	mutex_lock(&pctldev->mutex);
+-	pin = gpio_to_pin(range, gpio);
+-	ret = pinconf_set_config(pctldev, pin, configs, ARRAY_SIZE(configs));
+-	mutex_unlock(&pctldev->mutex);
++	dir = gpiod_get_direction(desc);
++
++	mutex_lock(&pinctrldev_list_mutex);
++
++	/*
++	 * NOTE: this code suppose that if we have multiple pinctrl declared for
++	 * the same gpio those are configured in series.
++	 * In this situation we need to avoid the case were momentarely
++	 * multiple pinctrl try do drive the same line to a different logic value
++	 *
++	 * (1st pinctrl) 1>-----<0 (2nd pinctrl)
++	 *
++	 * To obtain that we need to mind the order in which the multiple pinctrl
++	 * are configured depending of the desired gpio direction (input, output)
++	 */
++	if (dir == 1) {
++		list_for_each_entry(pctldev, &pinctrldev_list, node) {
++			ret = pinconf_set_config(pctldev, gpio, configs, ARRAY_SIZE(configs));
++		}
++	} else {
++		list_for_each_entry_reverse(pctldev, &pinctrldev_list, node) {
++			ret = pinconf_set_config(pctldev, gpio, configs, ARRAY_SIZE(configs));
++		}
++	}
++
++	mutex_unlock(&pinctrldev_list_mutex);
+ 
+ 	return ret;
+ }
 diff --git a/drivers/pinctrl/pinctrl-upboard.c b/drivers/pinctrl/pinctrl-upboard.c
 new file mode 100644
-index 0000000..64899e9
+index 000000000000..64899e988bb5
 --- /dev/null
 +++ b/drivers/pinctrl/pinctrl-upboard.c
 @@ -0,0 +1,797 @@
@@ -1764,9 +2081,40 @@ index 0000000..64899e9
 +MODULE_LICENSE("GPL v2");
 +MODULE_ALIAS("platform:upboard-pinctrl");
 \ No newline at end of file
+diff --git a/include/linux/acpi.h b/include/linux/acpi.h
+index 3bdcfc4401b7..703ebb7bc430 100644
+--- a/include/linux/acpi.h
++++ b/include/linux/acpi.h
+@@ -1087,6 +1087,11 @@ void __acpi_handle_debug(struct _ddebug *descriptor, acpi_handle handle, const c
+ bool acpi_gpio_get_irq_resource(struct acpi_resource *ares,
+ 				struct acpi_resource_gpio **agpio);
+ int acpi_dev_gpio_irq_get_by(struct acpi_device *adev, const char *name, int index);
++int acpi_node_add_pin_mapping(struct fwnode_handle *fwnode,
++			      const char *propname,
++			      const char *pinctl_name,
++			      unsigned int pin_offset,
++			      unsigned int npins);
+ #else
+ static inline bool acpi_gpio_get_irq_resource(struct acpi_resource *ares,
+ 					      struct acpi_resource_gpio **agpio)
+@@ -1098,6 +1103,14 @@ static inline int acpi_dev_gpio_irq_get_by(struct acpi_device *adev,
+ {
+ 	return -ENXIO;
+ }
++static inline int acpi_node_add_pin_mapping(struct fwnode_handle *fwnode,
++					    const char *propname,
++					    const char *pinctl_name,
++					    unsigned int pin_offset,
++					    unsigned int npins)
++{
++	return -ENXIO;
++}
+ #endif
+ 
+ static inline int acpi_dev_gpio_irq_get(struct acpi_device *adev, int index)
 diff --git a/include/linux/mfd/upboard-fpga.h b/include/linux/mfd/upboard-fpga.h
 new file mode 100644
-index 0000000..cd7fb81
+index 000000000000..cd7fb812d3b2
 --- /dev/null
 +++ b/include/linux/mfd/upboard-fpga.h
 @@ -0,0 +1,52 @@
@@ -1823,427 +2171,23 @@ index 0000000..cd7fb81
 +
 +#endif /*  __LINUX_MFD_UPBOARD_FPGA_H */
 \ No newline at end of file
+diff --git a/include/linux/regmap.h b/include/linux/regmap.h
+index 2cc4ecd36298..df5d754a13fc 100644
+--- a/include/linux/regmap.h
++++ b/include/linux/regmap.h
+@@ -1160,6 +1160,12 @@ void regcache_mark_dirty(struct regmap *map);
+ bool regmap_check_range_table(struct regmap *map, unsigned int reg,
+ 			      const struct regmap_access_table *table);
+ 
++bool regmap_cached(struct regmap *map, unsigned int reg);
++bool regmap_writeable(struct regmap *map, unsigned int reg);
++bool regmap_readable(struct regmap *map, unsigned int reg);
++bool regmap_volatile(struct regmap *map, unsigned int reg);
++bool regmap_precious(struct regmap *map, unsigned int reg);
++
+ int regmap_register_patch(struct regmap *map, const struct reg_sequence *regs,
+ 			  int num_regs);
+ int regmap_parse_val(struct regmap *map, const void *buf,
 -- 
-2.7.4
-diff --git a/drivers/pinctrl/core.c b/drivers/pinctrl/core.c
-index a3dd777..aad7a67 100644
---- a/drivers/pinctrl/core.c
-+++ b/drivers/pinctrl/core.c
-@@ -266,8 +266,7 @@
-  * and pin list based GPIO ranges is managed correctly by this function.
-  *
-  * This function assumes the gpio is part of the specified GPIO range, use
-- * only after making sure this is the case (e.g. by calling it on the
-- * result of successful pinctrl_get_device_gpio_range calls)!
-+ * only after making sure this is the case!
-  */
- static inline int gpio_to_pin(struct pinctrl_gpio_range *range,
- 				unsigned int gpio)
-@@ -307,92 +306,6 @@
- }
- 
- /**
-- * pinctrl_ready_for_gpio_range() - check if other GPIO pins of
-- * the same GPIO chip are in range
-- * @gpio: gpio pin to check taken from the global GPIO pin space
-- *
-- * This function is complement of pinctrl_match_gpio_range(). If the return
-- * value of pinctrl_match_gpio_range() is NULL, this function could be used
-- * to check whether pinctrl device is ready or not. Maybe some GPIO pins
-- * of the same GPIO chip don't have back-end pinctrl interface.
-- * If the return value is true, it means that pinctrl device is ready & the
-- * certain GPIO pin doesn't have back-end pinctrl device. If the return value
-- * is false, it means that pinctrl device may not be ready.
-- */
--#ifdef CONFIG_GPIOLIB
--static bool pinctrl_ready_for_gpio_range(unsigned gpio)
--{
--	struct pinctrl_dev *pctldev;
--	struct pinctrl_gpio_range *range = NULL;
--	struct gpio_chip *chip = gpio_to_chip(gpio);
--
--	if (WARN(!chip, "no gpio_chip for gpio%i?", gpio))
--		return false;
--
--	mutex_lock(&pinctrldev_list_mutex);
--
--	/* Loop over the pin controllers */
--	list_for_each_entry(pctldev, &pinctrldev_list, node) {
--		/* Loop over the ranges */
--		mutex_lock(&pctldev->mutex);
--		list_for_each_entry(range, &pctldev->gpio_ranges, node) {
--			/* Check if any gpio range overlapped with gpio chip */
--			if (range->base + range->npins - 1 < chip->base ||
--			    range->base > chip->base + chip->ngpio - 1)
--				continue;
--			mutex_unlock(&pctldev->mutex);
--			mutex_unlock(&pinctrldev_list_mutex);
--			return true;
--		}
--		mutex_unlock(&pctldev->mutex);
--	}
--
--	mutex_unlock(&pinctrldev_list_mutex);
--
--	return false;
--}
--#else
--static bool pinctrl_ready_for_gpio_range(unsigned gpio) { return true; }
--#endif
--
--/**
-- * pinctrl_get_device_gpio_range() - find device for GPIO range
-- * @gpio: the pin to locate the pin controller for
-- * @outdev: the pin control device if found
-- * @outrange: the GPIO range if found
-- *
-- * Find the pin controller handling a certain GPIO pin from the pinspace of
-- * the GPIO subsystem, return the device and the matching GPIO range. Returns
-- * -EPROBE_DEFER if the GPIO range could not be found in any device since it
-- * may still have not been registered.
-- */
--static int pinctrl_get_device_gpio_range(unsigned gpio,
--					 struct pinctrl_dev **outdev,
--					 struct pinctrl_gpio_range **outrange)
--{
--	struct pinctrl_dev *pctldev;
--
--	mutex_lock(&pinctrldev_list_mutex);
--
--	/* Loop over the pin controllers */
--	list_for_each_entry(pctldev, &pinctrldev_list, node) {
--		struct pinctrl_gpio_range *range;
--
--		range = pinctrl_match_gpio_range(pctldev, gpio);
--		if (range) {
--			*outdev = pctldev;
--			*outrange = range;
--			mutex_unlock(&pinctrldev_list_mutex);
--			return 0;
--		}
--	}
--
--	mutex_unlock(&pinctrldev_list_mutex);
--
--	return -EPROBE_DEFER;
--}
--
--/**
-  * pinctrl_add_gpio_range() - register a GPIO range for a controller
-  * @pctldev: pin controller device to add the range to
-  * @range: the GPIO range to add
-@@ -706,6 +619,57 @@
- }
- #endif /* CONFIG_GENERIC_PINCTRL_GROUPS */
- 
-+void pinctrl_free_gpio_locked(unsigned int gpio)
-+{
-+	struct pinctrl_dev *pctldev;
-+
-+	list_for_each_entry(pctldev, &pinctrldev_list, node) {
-+		struct pinctrl_gpio_range *range =
-+			pinctrl_match_gpio_range(pctldev, gpio);
-+		if (range != NULL) {
-+			int pin;
-+
-+			mutex_lock(&pctldev->mutex);
-+			pin = gpio_to_pin(range, gpio);
-+			pinmux_free_gpio(pctldev, pin, range);
-+			mutex_unlock(&pctldev->mutex);
-+		}
-+	}
-+}
-+
-+static int pinctrl_request_if_match(struct pinctrl_dev *pctldev,
-+				    unsigned int gpio, int dir)
-+{
-+	struct pinctrl_gpio_range *range =
-+		pinctrl_match_gpio_range(pctldev, gpio);
-+	int ret;
-+
-+	if (range != NULL) {
-+		int pin;
-+
-+		mutex_lock(&pctldev->mutex);
-+		pin = gpio_to_pin(range, gpio);
-+
-+		ret = pinmux_request_gpio(pctldev, range, pin, gpio);
-+		if (ret) {
-+			mutex_unlock(&pctldev->mutex);
-+			return ret;
-+		}
-+
-+		if (dir >= 0) {
-+			ret = pinmux_gpio_direction(pctldev, range, pin, dir);
-+			if (ret) {
-+				mutex_unlock(&pctldev->mutex);
-+				return ret;
-+			}
-+		}
-+		mutex_unlock(&pctldev->mutex);
-+
-+	}
-+
-+	return 0;
-+}
-+
- /**
-  * pinctrl_get_group_selector() - returns the group selector for a group
-  * @pctldev: the pin controller handling the group
-@@ -742,25 +706,27 @@
- {
- 	struct pinctrl_dev *pctldev;
- 	struct pinctrl_gpio_range *range;
--	bool result;
-+	bool result = true;
- 	int pin;
- 
--	/*
--	 * Try to obtain GPIO range, if it fails
--	 * we're probably dealing with GPIO driver
--	 * without a backing pin controller - bail out.
--	 */
--	if (pinctrl_get_device_gpio_range(gpio, &pctldev, &range))
--		return true;
--
--	mutex_lock(&pctldev->mutex);
--
--	/* Convert to the pin controllers number space */
--	pin = gpio_to_pin(range, gpio);
-+	mutex_lock(&pinctrldev_list_mutex);
- 
--	result = pinmux_can_be_used_for_gpio(pctldev, pin);
-+        /*
-+         * Try to obtain GPIO range, if it fails
-+         * we're probably dealing with GPIO driver
-+         * without a backing pin controller - bail out.
-+         */
-+	list_for_each_entry(pctldev, &pinctrldev_list, node) {
-+		range = pinctrl_match_gpio_range(pctldev, gpio);
-+		if (range != NULL) {
-+			mutex_lock(&pctldev->mutex);
-+			pin = gpio_to_pin(range, gpio);
-+			result = result && pinmux_can_be_used_for_gpio(pctldev, pin);
-+			mutex_unlock(&pctldev->mutex);
-+		}
-+	}
- 
--	mutex_unlock(&pctldev->mutex);
-+	mutex_unlock(&pinctrldev_list_mutex);
- 
- 	return result;
- }
-@@ -774,28 +740,53 @@
-  * as part of their gpio_request() semantics, platforms and individual drivers
-  * shall *NOT* request GPIO pins to be muxed in.
-  */
--int pinctrl_gpio_request(unsigned gpio)
-+int pinctrl_gpio_request(unsigned int gpio)
- {
- 	struct pinctrl_dev *pctldev;
--	struct pinctrl_gpio_range *range;
--	int ret;
--	int pin;
-+	struct gpio_desc *desc;
-+	int dir;
-+	int ret = -EPROBE_DEFER;
- 
--	ret = pinctrl_get_device_gpio_range(gpio, &pctldev, &range);
--	if (ret) {
--		if (pinctrl_ready_for_gpio_range(gpio))
--			ret = 0;
--		return ret;
-+	desc = gpio_to_desc(gpio);
-+	if (!desc) {
-+		pr_err("gpio_to_desc(%d) returned NULL", gpio);
-+		return -ENODEV;
- 	}
- 
--	mutex_lock(&pctldev->mutex);
-+	dir = gpiod_get_direction(desc);
- 
--	/* Convert to the pin controllers number space */
--	pin = gpio_to_pin(range, gpio);
-+	mutex_lock(&pinctrldev_list_mutex);
- 
--	ret = pinmux_request_gpio(pctldev, range, pin, gpio);
-+	/*
-+	 * NOTE: this code suppose that if we have multiple pinctrl declared for
-+	 * the same gpio those are configured in series.
-+	 * In this situation we need to avoid the case were momentarely
-+	 * multiple pinctrl try do drive the same line to a different logic value
-+	 *
-+	 * (1st pinctrl) 1>-----<0 (2nd pinctrl)
-+	 *
-+	 * To obtain that we need to mind the order in which the multiple pinctrl
-+	 * are configured depending of the desired gpio direction (input, output)
-+	 */
-+	if (dir == 1) {
-+		list_for_each_entry(pctldev, &pinctrldev_list, node) {
-+			ret = pinctrl_request_if_match(pctldev, gpio, dir);
-+			if (ret) {
-+				pinctrl_free_gpio_locked(gpio);
-+				break;
-+			}
-+		}
-+	} else {
-+		list_for_each_entry_reverse(pctldev, &pinctrldev_list, node) {
-+			ret = pinctrl_request_if_match(pctldev, gpio, dir);
-+			if (ret) {
-+				pinctrl_free_gpio_locked(gpio);
-+				break;
-+			}
-+		}
-+	}
- 
--	mutex_unlock(&pctldev->mutex);
-+	mutex_unlock(&pinctrldev_list_mutex);
- 
- 	return ret;
- }
-@@ -809,47 +800,64 @@
-  * as part of their gpio_free() semantics, platforms and individual drivers
-  * shall *NOT* request GPIO pins to be muxed out.
-  */
--void pinctrl_gpio_free(unsigned gpio)
-+void pinctrl_gpio_free(unsigned int gpio)
- {
--	struct pinctrl_dev *pctldev;
--	struct pinctrl_gpio_range *range;
--	int ret;
--	int pin;
-+	mutex_lock(&pinctrldev_list_mutex);
- 
--	ret = pinctrl_get_device_gpio_range(gpio, &pctldev, &range);
--	if (ret) {
--		return;
--	}
--	mutex_lock(&pctldev->mutex);
-+	pinctrl_free_gpio_locked(gpio);
-+
-+	mutex_unlock(&pinctrldev_list_mutex);
-+}
-+EXPORT_SYMBOL_GPL(pinctrl_gpio_free);
- 
--	/* Convert to the pin controllers number space */
--	pin = gpio_to_pin(range, gpio);
-+static int pinctrl_set_dir_if_match(struct pinctrl_dev *pctldev,
-+				    unsigned int gpio, bool input)
-+{
-+	struct pinctrl_gpio_range *range =
-+		pinctrl_match_gpio_range(pctldev, gpio);
-+	int ret = 0;
- 
--	pinmux_free_gpio(pctldev, pin, range);
-+	if (range != NULL) {
-+		int pin;
- 
--	mutex_unlock(&pctldev->mutex);
-+		mutex_lock(&pctldev->mutex);
-+		pin = gpio_to_pin(range, gpio);
-+		ret = pinmux_gpio_direction(pctldev, range, pin, input);
-+		mutex_unlock(&pctldev->mutex);
-+	}
-+
-+	return ret;
- }
--EXPORT_SYMBOL_GPL(pinctrl_gpio_free);
- 
- static int pinctrl_gpio_direction(unsigned gpio, bool input)
- {
- 	struct pinctrl_dev *pctldev;
--	struct pinctrl_gpio_range *range;
--	int ret;
--	int pin;
-+	int ret = -EPROBE_DEFER;
- 
--	ret = pinctrl_get_device_gpio_range(gpio, &pctldev, &range);
--	if (ret) {
--		return ret;
--	}
--
--	mutex_lock(&pctldev->mutex);
-+	mutex_lock(&pinctrldev_list_mutex);
- 
--	/* Convert to the pin controllers number space */
--	pin = gpio_to_pin(range, gpio);
--	ret = pinmux_gpio_direction(pctldev, range, pin, input);
-+	/*
-+	 * FIXME UP-specific
-+	 * The two pin controllers (SoC, FPGA) share the GPIO line. Avoid
-+	 * getting into a situation where both are momentarily trying to drive
-+	 * the line (i.e. SoC as output and FPGA as HAT-to-SoC input) by walking
-+	 * the list in opposite directions for the input and output cases.
-+	 */
-+	if (input) {
-+		list_for_each_entry(pctldev, &pinctrldev_list, node) {
-+			ret = pinctrl_set_dir_if_match(pctldev, gpio, input);
-+			if (ret)
-+				break;
-+		}
-+	} else {
-+		list_for_each_entry_reverse(pctldev, &pinctrldev_list, node) {
-+			ret = pinctrl_set_dir_if_match(pctldev, gpio, input);
-+			if (ret)
-+				break;
-+		}
-+	}
- 
--	mutex_unlock(&pctldev->mutex);
-+	mutex_unlock(&pinctrldev_list_mutex);
- 
- 	return ret;
- }
-@@ -894,18 +902,43 @@
- int pinctrl_gpio_set_config(unsigned gpio, unsigned long config)
- {
- 	unsigned long configs[] = { config };
--	struct pinctrl_gpio_range *range;
- 	struct pinctrl_dev *pctldev;
--	int ret, pin;
-+	struct gpio_desc *desc;
-+	int dir;
-+	int ret = -EPROBE_DEFER;
- 
--	ret = pinctrl_get_device_gpio_range(gpio, &pctldev, &range);
--	if (ret)
--		return ret;
-+	desc = gpio_to_desc(gpio);
-+	if (!desc) {
-+		pr_err("gpio_to_desc(%d) returned NULL", gpio);
-+		return -ENODEV;
-+	}
- 
--	mutex_lock(&pctldev->mutex);
--	pin = gpio_to_pin(range, gpio);
--	ret = pinconf_set_config(pctldev, pin, configs, ARRAY_SIZE(configs));
--	mutex_unlock(&pctldev->mutex);
-+	dir = gpiod_get_direction(desc);
-+
-+	mutex_lock(&pinctrldev_list_mutex);
-+
-+	/*
-+	 * NOTE: this code suppose that if we have multiple pinctrl declared for
-+	 * the same gpio those are configured in series.
-+	 * In this situation we need to avoid the case were momentarely
-+	 * multiple pinctrl try do drive the same line to a different logic value
-+	 *
-+	 * (1st pinctrl) 1>-----<0 (2nd pinctrl)
-+	 *
-+	 * To obtain that we need to mind the order in which the multiple pinctrl
-+	 * are configured depending of the desired gpio direction (input, output)
-+	 */
-+	if (dir == 1) {
-+		list_for_each_entry(pctldev, &pinctrldev_list, node) {
-+			ret = pinconf_set_config(pctldev, gpio, configs, ARRAY_SIZE(configs));
-+		}
-+	} else {
-+		list_for_each_entry_reverse(pctldev, &pinctrldev_list, node) {
-+			ret = pinconf_set_config(pctldev, gpio, configs, ARRAY_SIZE(configs));
-+		}
-+	}
-+
-+	mutex_unlock(&pinctrldev_list_mutex);
- 
- 	return ret;
- }
+2.25.1
+

--- a/pkg/new-kernel/patches-5.12.x/0009-Adding-rk3399-q116.dtb.patch
+++ b/pkg/new-kernel/patches-5.12.x/0009-Adding-rk3399-q116.dtb.patch
@@ -1,63 +1,32 @@
-From d79a9307d61f4ec2101653059306964b27f2b51b Mon Sep 17 00:00:00 2001
+From acf4504915bc6e80d231f23bcb5ee897aa737fd7 Mon Sep 17 00:00:00 2001
 From: Roman Shaposhnik <rvs@apache.org>
 Date: Sun, 1 Nov 2020 01:41:51 -0500
-Subject: [PATCH 1/1] Adding rk3399-q116.dtb
+Subject: [PATCH 09/11] Adding rk3399-q116.dtb
 
 ---
- .../arm64/boot/dts/rockchip/ | 16 ++++++++++++++++
- arch/arm64/boot/dts/rockchip/Makefile
- 3 file changed, 16 insertions(+)
+ arch/arm64/boot/dts/rockchip/Makefile         |    2 +
+ arch/arm64/boot/dts/rockchip/rk3399-q116.dts  | 1283 +++++++++++++++++
+ .../boot/dts/rockchip/rockchip-evb_rk3399.dts |   28 +
+ 3 files changed, 1313 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3399-q116.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/rockchip-evb_rk3399.dts
 
 diff --git a/arch/arm64/boot/dts/rockchip/Makefile b/arch/arm64/boot/dts/rockchip/Makefile
-index 57d157e..9ff45a3 100644
---- a/arch/arm64/boot/dts/rockchip/Makefile  2021-04-28 22:29:15.660000000 +0000
-+++ b/arch/arm64/boot/dts/rockchip/Makefile  2021-04-28 22:30:08.310000000 +0000
-@@ -26,6 +26,8 @@
- dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-nanopi-neo4.dtb
+index 62d3abc17a24..590e68c95aa7 100644
+--- a/arch/arm64/boot/dts/rockchip/Makefile
++++ b/arch/arm64/boot/dts/rockchip/Makefile
+@@ -39,6 +39,8 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-nanopi-neo4.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-orangepi.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-pinebook-pro.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-puma-haikou.dtb
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-q116.dtb
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += rockchip-evb_rk3399.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-roc-pc.dtb
- dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-rock-pi-4.dtb
- dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-rock960.dtb
-diff --git a/arch/arm64/boot/dts/rockchip/rockchip-evb_rk3399.dts b/arch/arm64/boot/dts/rockchip/rockchip-evb_rk3399.dts
-new file mode 100644
-index 000000000000..b5411de59659
---- /dev/null
-+++ b/arch/arm64/boot/dts/rockchip/rockchip-evb_rk3399.dts
-@@ -0,0 +1,28 @@
-+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
-+/*
-+ * Copyright (c) 2021 ZEDEDA Inc.
-+ */
-+#include "rk3399-q116.dts"
-+#include <dt-bindings/leds/common.h>
-+
-+/ {
-+	leds {
-+                compatible = "gpio-leds"; 
-+
-+                power {
-+                        label = "power";
-+                        gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
-+                        color = <LED_COLOR_ID_MULTI>; /* RED and BLUE */
-+                        default-state = "keep";
-+                        linux,default-trigger = "default-on";
-+                };
-+
-+		eve {
-+			label = "eve";
-+			gpios = <&gpio4 3 GPIO_ACTIVE_LOW>;
-+			color = <LED_COLOR_ID_YELLOW>;
-+			default-state = "keep";
-+			linux,default-trigger = "default-on";
-+		};
-+	};
-+};
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-roc-pc-mezzanine.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-rock-pi-4a.dtb
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-q116.dts b/arch/arm64/boot/dts/rockchip/rk3399-q116.dts
 new file mode 100644
-index 000000000000..b5411de59659
+index 000000000000..6e7af76739b8
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-q116.dts
 @@ -0,0 +1,1283 @@
@@ -1344,6 +1313,40 @@ index 000000000000..b5411de59659
 +};
 +
 +
+diff --git a/arch/arm64/boot/dts/rockchip/rockchip-evb_rk3399.dts b/arch/arm64/boot/dts/rockchip/rockchip-evb_rk3399.dts
+new file mode 100644
+index 000000000000..f1474c847b47
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rockchip-evb_rk3399.dts
+@@ -0,0 +1,28 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2021 ZEDEDA Inc.
++ */
++#include "rk3399-q116.dts"
++#include <dt-bindings/leds/common.h>
++
++/ {
++	leds {
++                compatible = "gpio-leds"; 
++
++                power {
++                        label = "power";
++                        gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
++                        color = <LED_COLOR_ID_MULTI>; /* RED and BLUE */
++                        default-state = "keep";
++                        linux,default-trigger = "default-on";
++                };
++
++		eve {
++			label = "eve";
++			gpios = <&gpio4 3 GPIO_ACTIVE_LOW>;
++			color = <LED_COLOR_ID_YELLOW>;
++			default-state = "keep";
++			linux,default-trigger = "default-on";
++		};
++	};
++};
+-- 
+2.25.1
 
---
-2.26.2

--- a/pkg/new-kernel/patches-5.12.x/0010-Add-NVMe-VHost.patch
+++ b/pkg/new-kernel/patches-5.12.x/0010-Add-NVMe-VHost.patch
@@ -1,7 +1,7 @@
-From 57e8beb9fc03d00d9e4ba4f062dfbd9e50d1c86a Mon Sep 17 00:00:00 2001
+From 6c7278a2236ccbd4226356aa7ba89488346d9f67 Mon Sep 17 00:00:00 2001
 From: Ming Lin <ming.l@ssi.samsung.com>
 Date: Wed, 18 Nov 2015 13:15:20 -0800
-Subject: [PATCH] nvme-vhost: add initial commit
+Subject: [PATCH 10/11] Add NVMe VHost
 
 Signed-off-by: Ming Lin <ming.l@ssi.samsung.com>
 Signed-off-by: Sergey Temerkhanov <s.temerkhanov@gmail.com>
@@ -69,12 +69,12 @@ Signed-off-by: Sergey Temerkhanov <s.temerkhanov@gmail.com>
  create mode 100644 drivers/nvme/target/vhost.c
 
 diff --git a/drivers/nvme/target/Kconfig b/drivers/nvme/target/Kconfig
-index 8056955e652c..624cbf85a6b6 100644
+index 4be2ececbc45..637706518684 100644
 --- a/drivers/nvme/target/Kconfig
 +++ b/drivers/nvme/target/Kconfig
 @@ -85,3 +85,13 @@ config NVME_TARGET_TCP
  	  devices over TCP.
-
+ 
  	  If unsure, say N.
 +
 +config NVME_TARGET_VHOST
@@ -95,7 +95,7 @@ index ebf91fc4c72e..1b64bc41c0a3 100644
  obj-$(CONFIG_NVME_TARGET_FCLOOP)	+= nvme-fcloop.o
  obj-$(CONFIG_NVME_TARGET_TCP)		+= nvmet-tcp.o
 +obj-$(CONFIG_NVME_TARGET_VHOST)		+= nvme-vhost.o
-
+ 
  nvmet-y		+= core.o configfs.o admin-cmd.o fabrics-cmd.o \
  			discovery.o io-cmd-file.o io-cmd-bdev.o
 @@ -18,3 +19,4 @@ nvmet-fc-y	+= fc.o
@@ -104,24 +104,24 @@ index ebf91fc4c72e..1b64bc41c0a3 100644
  nvmet-$(CONFIG_TRACING)	+= trace.o
 +nvme-vhost-y	+= vhost.o
 diff --git a/drivers/nvme/target/core.c b/drivers/nvme/target/core.c
-index 957b39a82431..775724a7304e 100644
+index a027433b8be8..76a3713dbb7f 100644
 --- a/drivers/nvme/target/core.c
 +++ b/drivers/nvme/target/core.c
-@@ -1437,6 +1437,7 @@ void nvmet_ctrl_put(struct nvmet_ctrl *ctrl)
+@@ -1448,6 +1448,7 @@ void nvmet_ctrl_put(struct nvmet_ctrl *ctrl)
  {
  	kref_put(&ctrl->ref, nvmet_ctrl_free);
  }
 +EXPORT_SYMBOL_GPL(nvmet_ctrl_put);
-
+ 
  void nvmet_ctrl_fatal_error(struct nvmet_ctrl *ctrl)
  {
 diff --git a/drivers/nvme/target/nvmet.h b/drivers/nvme/target/nvmet.h
-index 559a15ccc322..e5755bab8c08 100644
+index 5aad34b106dc..2e20d047fe00 100644
 --- a/drivers/nvme/target/nvmet.h
 +++ b/drivers/nvme/target/nvmet.h
-@@ -168,7 +168,7 @@ struct nvmet_ctrl {
+@@ -167,7 +167,7 @@ struct nvmet_ctrl {
  	struct nvmet_sq		**sqs;
-
+ 
  	bool			cmd_seen;
 -
 +	struct nvmet_cq		**cqs;
@@ -1266,13 +1266,13 @@ index 000000000000..2b93f7e40850
 +MODULE_AUTHOR("Ming Lin <ming.l@ssi.samsung.com>");
 +MODULE_LICENSE("GPL v2");
 diff --git a/drivers/vhost/vhost.c b/drivers/vhost/vhost.c
-index a262e12c6dc2..62b7d6885a92 100644
+index 5ccb0705beae..26807a750ebd 100644
 --- a/drivers/vhost/vhost.c
 +++ b/drivers/vhost/vhost.c
 @@ -883,6 +883,101 @@ static int vhost_copy_from_user(struct vhost_virtqueue *vq, void *to,
  	return ret;
  }
-
+ 
 +static int translate_addr(struct vhost_dev *vdev, u64 addr, size_t len,
 +			  struct iovec iov[], int iov_size, int access)
 +{
@@ -1378,7 +1378,7 @@ index b063324c7669..a8a4b87de09f 100644
 @@ -166,6 +166,11 @@ struct vhost_dev {
  			   struct vhost_iotlb_msg *msg);
  };
-
+ 
 +int vhost_mem_copy_to_user(struct vhost_dev *vdev, void __user *to,
 +			   const void *from, unsigned size);
 +int vhost_mem_copy_from_user(struct vhost_dev *vdev, void *to,
@@ -1409,7 +1409,7 @@ index f7f6a3a28977..df0d2e9f7b5d 100644
 @@ -130,6 +130,27 @@ struct vhost_scsi_target {
  	unsigned short reserved;
  };
-
+ 
 +struct vhost_nvme_target {
 +	char vhost_wwpn[224]; /* TRANSPORT_IQN_LEN */
 +};
@@ -1432,5 +1432,8 @@ index f7f6a3a28977..df0d2e9f7b5d 100644
 +};
 +
  /* VHOST_VDPA specific definitions */
-
+ 
  struct vhost_vdpa_config {
+-- 
+2.25.1
+

--- a/pkg/new-kernel/patches-5.12.x/0011-Quirk-for-brocken-INTx-on-Euresys-Grablink-Full-XR.patch
+++ b/pkg/new-kernel/patches-5.12.x/0011-Quirk-for-brocken-INTx-on-Euresys-Grablink-Full-XR.patch
@@ -1,7 +1,7 @@
-From 3e6b97c0a57a4792a643a045e006b10254ba99b2 Mon Sep 17 00:00:00 2001
+From fb7372797aaa4068f3b917d464b786712932230f Mon Sep 17 00:00:00 2001
 From: Mikhail Malyshev <mikem@zededa.com>
 Date: Thu, 16 Dec 2021 11:29:26 +0100
-Subject: [PATCH] Quirk for brocken INTx on Euresys Grablink Full XR
+Subject: [PATCH 11/11] Quirk for brocken INTx on Euresys Grablink Full XR
 
 Signed-off-by: Mikhail Malyshev <mikem@zededa.com>
 ---
@@ -9,10 +9,10 @@ Signed-off-by: Mikhail Malyshev <mikem@zededa.com>
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
-index fb1dc11e7..3e625ee41 100644
+index 70b187edb1ce..7db563e79669 100644
 --- a/drivers/pci/quirks.c
 +++ b/drivers/pci/quirks.c
-@@ -3433,6 +3433,8 @@ DECLARE_PCI_FIXUP_FINAL(0x1814, 0x0601, /* Ralink RT2800 802.11n PCI */
+@@ -3434,6 +3434,8 @@ DECLARE_PCI_FIXUP_FINAL(0x1814, 0x0601, /* Ralink RT2800 802.11n PCI */
  			quirk_broken_intx_masking);
  DECLARE_PCI_FIXUP_FINAL(0x1b7c, 0x0004, /* Ceton InfiniTV4 */
  			quirk_broken_intx_masking);
@@ -22,5 +22,5 @@ index fb1dc11e7..3e625ee41 100644
  /*
   * Realtek RTL8169 PCI Gigabit Ethernet Controller (rev 10)
 -- 
-2.32.0
+2.25.1
 


### PR DESCRIPTION
# Context
Only few of our patches can be applied using `git am`. This commit
turns all the patches into a proper format. This makes it a bit easy
to kick-start new kernel activity. One just needs to

   git am ~/eve/pkg/kernel/patches-5.10.x/*.patch

to have a clean git repo with all the patches in the history.

I tripple checked that old and new paches do have exactly the same
effect.

# Testing done

Make sure patches are identical

```
  # Prepare linux sources for comparison
  git clone git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
  cd linux-new-patches && git checkout v5.10.76
  pushd .. && git clone linux-new-patches linux-old-patches

  # Apply new patches
  popd && git am ~/src/eve-linux/patches-5.10.x/*.patch

  # Apply old patches
  cd ../linux-old-patches
  for patch in ~/src/eve/pkg/kernel/patches-5.10.x/*.patch; do patch -p1 <  "$patch"; done
  find . -name "*.orig" | xargs rm

  # Make sure diff reports nothing
  cd ..
  diff -urNp --exclude=.git linux-new-patches linux-old-patches

  # Repeat for new-kernel
  cd linux-new-patches && git checkout v5.12.5
  git am ~/src/tmp/patches-5.12.x/*.patch
  cd ../linux-old-patches && git reset --hard &&  git clean -fdx && git checkout v5.12.5
  for patch in ~/src/eve/pkg/new-kernel/patches-5.12.x/*.patch; do patch -p1 <  "$patch"; done
  find . -name "*.orig" | xargs rm
  cd ..
  diff -urNp --exclude=.git linux-new-patches linux-old-patches
```

Make sure `pkg/kernel` and `pkg/new-kernel` still build

```
  make pkg/kernel
  make pkg/new-kernel
```

and check that patches 000*.patch were applied