### PR TITLE
fix error handling in decrypt of cipherBlock

### DIFF
--- a/pkg/pillar/cipher/handlecipher.go
+++ b/pkg/pillar/cipher/handlecipher.go
@@ -166,8 +166,9 @@ func decryptCipherBlockWithECDH(ctx *DecryptCipherContext,
 	}
 	edgeNodeCert := lookupEdgeNodeCert(ctx, cipherContext.EdgeNodeCertKey())
 	if edgeNodeCert == nil {
-		ctx.Log.Errorf("Edge Node Certificate get fail")
-		return []byte{}, err
+		errStr := fmt.Sprint("Edge Node Certificate get fail")
+		ctx.Log.Errorf(errStr)
+		return []byte{}, errors.New(errStr)
 	}
 	switch cipherContext.EncryptionScheme {
 	case zconfig.EncryptionScheme_SA_NONE:

--- a/pkg/pillar/cmd/tpmmgr/tpmmgr.go
+++ b/pkg/pillar/cmd/tpmmgr/tpmmgr.go
@@ -560,7 +560,11 @@ func testEcdhAES() error {
 	X, Y := elliptic.P256().Params().ScalarMult(publicB.X, publicB.Y, privateA)
 
 	fmt.Printf("publicAX, publicAY, X/Y = %v, %v, %v, %v\n", publicAX, publicAY, X, Y)
-	encryptKey := etpm.Sha256FromECPoint(X, Y)
+	encryptKey, err := etpm.Sha256FromECPoint(X, Y, publicB)
+	if err != nil {
+		fmt.Printf("Sha256FromECPoint failed with error: %v", err)
+		return err
+	}
 	iv := make([]byte, aes.BlockSize)
 	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
 		fmt.Printf("Unable to generate Initial Value %v\n", err)

--- a/pkg/pillar/evetpm/encryptdecypt.go
+++ b/pkg/pillar/evetpm/encryptdecypt.go
@@ -110,6 +110,9 @@ func deriveSessionKey(X, Y *big.Int) ([32]byte, error) {
 //with those ECC points
 func deriveEncryptDecryptKey() ([32]byte, error) {
 	publicKey, err := GetPublicKeyFromCert(types.DeviceCertName)
+	if err != nil {
+		return [32]byte{}, fmt.Errorf("error in GetPublicKeyFromCert: %s", err)
+	}
 	eccPublicKey, ok := publicKey.(*ecdsa.PublicKey)
 	if !ok {
 		return [32]byte{}, fmt.Errorf("Not an ECDH compatible key: %T", publicKey)

--- a/pkg/pillar/evetpm/keys.go
+++ b/pkg/pillar/evetpm/keys.go
@@ -69,8 +69,9 @@ func GetPrivateKeyFromFile(keyFile string) (*ecdsa.PrivateKey, error) {
 	}
 	if key, err := x509.ParseECPrivateKey(keyDERBlock.Bytes); err == nil {
 		return key, nil
+	} else {
+		return nil, err
 	}
-	return nil, err
 }
 
 //GetPublicKeyFromCert gets public key from a X.509 cert


### PR DESCRIPTION
Fix for two problems with error propagation:

- in case of no Edge Node certificate we return nil err and jump into "Data Validation Failed" error
- in case of error from ParseECPrivateKey we return nil error because of shadowed variable

Seems the root cause of the problem with permanent `Data Validation Failed` come from the same problem that was fixed for zedcloud module in #1020, but not fixed for evetpm, those:
```
have a bug where ecdsa sign generating R & S integers, we convert them into []byte and append them. unfortunately the size of the R & S converted into byte array is not always the same, occasionally it can be shorter. We would be ok if there is lengths associated with the API but we assume R & S in fixed length, which causes verify error whenever that shorter length is encountered.
```