### PR TITLE
limit dhcp range with BitMapMax

### DIFF
--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -1944,6 +1944,12 @@ func parseIpspec(ipspec *zconfig.Ipspec,
 		return fmt.Errorf("gateway(%s) inside Dhcp Range",
 			config.Gateway.String())
 	}
+	addressesInRange := config.DhcpRange.Size()
+	// we cannot use more than types.BitMapMax IPs for dynamic allocation
+	// and should keep some place in the end for static IPs assignment
+	if addressesInRange > types.BitMapMax {
+		config.DhcpRange.End = types.AddToIP(config.DhcpRange.Start, types.BitMapMax)
+	}
 	return nil
 }
 

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -5,6 +5,7 @@ package types
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"net"
@@ -2051,6 +2052,22 @@ func (ipRange IpRange) Contains(ipAddr net.IP) bool {
 		return true
 	}
 	return false
+}
+
+// Size returns addresses count inside IpRange
+func (ipRange IpRange) Size() uint32 {
+	//TBD:XXX, IPv6 handling
+	ip1v4 := ipRange.Start.To4()
+	ip2v4 := ipRange.End.To4()
+	if ip1v4 == nil || ip2v4 == nil {
+		return 0
+	}
+	ip1Int := binary.BigEndian.Uint32(ip1v4)
+	ip2Int := binary.BigEndian.Uint32(ip2v4)
+	if ip1Int > ip2Int {
+		return ip1Int - ip2Int
+	}
+	return ip2Int - ip1Int
 }
 
 func (config NetworkXObjectConfig) Key() string {


### PR DESCRIPTION
Solution for the problem with overlapped static IPs from inside of dhcp range inspired by https://github.com/lf-edge/eve/pull/2455#pullrequestreview-854581541.
We cannot allocate more than BitMapMax dynamic IPs so seems we can reduce the capacity of dhcp range down to it. In that case for default network instance (`/16`) we will not hit the problem with allocated static IPs from the end (and inside) of dhcp range comes from the controller.