### PR TITLE
Recover from error due to missing PCI device

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -2449,6 +2449,9 @@ func handlePhysicalIOAdapterListImpl(ctxArg interface{}, key string,
 			if err != nil {
 				ib.Error = err.Error()
 				ib.ErrorTime = time.Now()
+			} else {
+				ib.Error = ""
+				ib.ErrorTime = time.Time{}
 			}
 			// We assume AddOrUpdateIoBundle will preserve any
 			// existing IsPort/IsPCIBack/UsedByUUID
@@ -2494,6 +2497,9 @@ func handlePhysicalIOAdapterListImpl(ctxArg interface{}, key string,
 		if err != nil {
 			ib.Error = err.Error()
 			ib.ErrorTime = time.Now()
+		} else {
+			ib.Error = ""
+			ib.ErrorTime = time.Time{}
 		}
 		currentIbPtr := aa.LookupIoBundlePhylabel(phyAdapter.Phylabel)
 		if currentIbPtr == nil || currentIbPtr.HasAdapterChanged(log, phyAdapter) {
@@ -2607,6 +2613,9 @@ func updatePortAndPciBackIoBundle(ctx *domainContext, ib *types.IoBundle) (chang
 			ib.Error = err.Error()
 			ib.ErrorTime = time.Now()
 			log.Error(err)
+		} else {
+			ib.Error = ""
+			ib.ErrorTime = time.Time{}
 		}
 	}
 	return anyChanged

--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -1152,6 +1152,7 @@ func retryNetworkInstance(ctx *zedrouterContext, status *types.NetworkInstanceSt
 		if err := ensurePortName(ctx, status); err != nil {
 			log.Errorf("retryNetworkInstance(%s) failed: %v",
 				status.DisplayName, err)
+			// Keep old error assuming it is the same
 			return
 		}
 		err := doNetworkInstanceModify(ctx, *config, status)
@@ -1168,6 +1169,8 @@ func retryNetworkInstance(ctx *zedrouterContext, status *types.NetworkInstanceSt
 		if err := ensurePortName(ctx, status); err != nil {
 			log.Errorf("retryNetworkInstance(%s) failed: %v",
 				status.DisplayName, err)
+			status.SetErrorNow(err.Error())
+			publishNetworkInstanceStatus(ctx, status)
 			return
 		}
 


### PR DESCRIPTION
If we do PCI passtrhough and the device is not available (e.g., due to it being used as a management port), then we set the error in the IoBundle. However, we never clear that error hence even as EVE retries booting the guest domain/task it sees the same failure.

As a separate commit, if a network instance is using the port and we retry after a failure on the network instance, we should update the error.