### PR TITLE
Add ipxe.efi to release artifacts

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -176,6 +176,16 @@ jobs:
           asset_path: assets/initrd.bits
           asset_name: ${{ env.ARCH }}.initrd.bits
           asset_content_type: application/octet-stream
+      - name: Upload ipxe.efi for the release
+        id: upload-ipxe-efi-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.result }}
+          asset_path: assets/ipxe.efi
+          asset_name: ${{ env.ARCH }}.ipxe.efi
+          asset_content_type: application/octet-stream
       - name: Upload ipxe.efi.cfg for the release
         id: upload-ipxe-efi-cfg-asset
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
ipxe.efi will be published with ipxe.efi.cfg and ipxe.efi.ip.cfg

Signed-off-by: Ruslan Dautov <dautov2@gmail.com>