### PR TITLE
Separate dataset for encrypted volumes

### DIFF
--- a/pkg/pillar/cmd/volumemgr/create.go
+++ b/pkg/pillar/cmd/volumemgr/create.go
@@ -86,7 +86,7 @@ func createVdiskVolume(ctx *volumemgrContext, status types.VolumeStatus,
 
 	switch persistFsType {
 	case types.PersistZFS:
-		zVolName := status.ZVolName(types.VolumeZFSPool)
+		zVolName := status.ZVolName()
 		zVolDevice := zfs.GetZVolDeviceByDataset(zVolName)
 		if zVolDevice == "" {
 			errStr := fmt.Sprintf("Error finding zfs zvol %s", zVolName)
@@ -250,7 +250,7 @@ func destroyVdiskVolume(ctx *volumemgrContext, status types.VolumeStatus) (bool,
 			log.Error(errStr)
 		}
 		//Assume this is zfs device
-		zVolName := status.ZVolName(types.VolumeZFSPool)
+		zVolName := status.ZVolName()
 		if stdoutStderr, err := zfs.DestroyDataset(log, zVolName); err != nil {
 			errStr := fmt.Sprintf("Error destroying zfs zvol at %s, error=%v, output=%s",
 				zVolName, err, stdoutStderr)

--- a/pkg/pillar/cmd/volumemgr/dirs.go
+++ b/pkg/pillar/cmd/volumemgr/dirs.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/lf-edge/eve/pkg/pillar/zfs"
 )
 
 func initializeDirs() {
@@ -28,6 +29,21 @@ func initializeDirs() {
 			log.Functionf("Create %s", dirName)
 			if err := os.MkdirAll(dirName, 0700); err != nil {
 				log.Fatal(err)
+			}
+		}
+	}
+}
+
+func initializeDatasets() {
+	// Our destination volume datasets
+	volumeDatasets := []string{
+		types.VolumeClearZFSDataset,
+		types.VolumeEncryptedZFSDataset,
+	}
+	for _, datasetName := range volumeDatasets {
+		if _, err := zfs.GetDatasetOptions(log, datasetName); err != nil {
+			if output, err := zfs.CreateDataset(log, datasetName); err != nil {
+				log.Fatalf("CreateDataset failed: %s %s ", output, err)
 			}
 		}
 	}

--- a/pkg/pillar/cmd/volumemgr/handlevolume.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume.go
@@ -108,7 +108,7 @@ func handleDeferredVolumeCreate(ctx *volumemgrContext, key string, config *types
 		MaxVolSize:              config.MaxVolSize,
 		ReadOnly:                config.ReadOnly,
 		GenerationCounter:       config.GenerationCounter,
-		VolumeDir:               config.VolumeDir,
+		Encrypted:               config.Encrypted,
 		DisplayName:             config.DisplayName,
 		RefCount:                config.RefCount,
 		LastRefCountChangeTime:  time.Now(),
@@ -123,7 +123,7 @@ func handleDeferredVolumeCreate(ctx *volumemgrContext, key string, config *types
 	persistFsType := ctx.persistType
 
 	if persistFsType == types.PersistZFS {
-		zvolName := status.ZVolName(types.VolumeZFSPool)
+		zvolName := status.ZVolName()
 		if _, err := zfs.GetDatasetOptions(log, zvolName); err == nil {
 			zVolDevice := zfs.GetZVolDeviceByDataset(zvolName)
 			if zVolDevice == "" {
@@ -426,7 +426,7 @@ func handleZVolStatusCreate(ctxArg interface{}, key string, configArg interface{
 	status := configArg.(types.ZVolStatus)
 	for _, s := range ctx.pubVolumeStatus.GetAll() {
 		volumeStatus := s.(types.VolumeStatus)
-		if volumeStatus.ZVolName(types.VolumeZFSPool) == status.Dataset {
+		if volumeStatus.ZVolName() == status.Dataset {
 			updateVolumeStatus(ctx, volumeStatus.VolumeID)
 			break
 		}

--- a/pkg/pillar/cmd/volumemgr/prepare.go
+++ b/pkg/pillar/cmd/volumemgr/prepare.go
@@ -74,7 +74,7 @@ func prepareZVol(ctx *volumemgrContext, status types.VolumeStatus) error {
 			return errors.New(errStr)
 		}
 	}
-	zVolName := status.ZVolName(types.VolumeZFSPool)
+	zVolName := status.ZVolName()
 	if stdoutStderr, err := zfs.CreateVolumeDataset(log, zVolName, size, "zstd"); err != nil {
 		errStr := fmt.Sprintf("Error creating zfs zvol at %s, error=%v, output=%s",
 			zVolName, err, stdoutStderr)

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -564,7 +564,7 @@ func doUpdateVol(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool)
 	}
 	if status.State == types.CREATING_VOLUME && status.SubState == types.VolumeSubStatePreparing {
 		if ctx.persistType == types.PersistZFS && !status.IsContainer() {
-			zVolStatus := lookupZVolStatusByDataset(ctx, status.ZVolName(types.VolumeZFSPool))
+			zVolStatus := lookupZVolStatusByDataset(ctx, status.ZVolName())
 			if zVolStatus != nil {
 				wwn, err := createTargetVhost(zVolStatus.Device, status)
 				if err != nil {

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -457,8 +457,13 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	}
 	log.Functionf("processed Vault Status")
 
-	// create the directories
-	initializeDirs()
+	if ctx.persistType == types.PersistZFS {
+		// create datasets for volumes
+		initializeDatasets()
+	} else {
+		// create the directories
+		initializeDirs()
+	}
 
 	// Iterate over volume directory and prepares map of
 	// volume's content format with the volume key
@@ -563,7 +568,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 			start := time.Now()
 			gcObjects(&ctx, volumeEncryptedDirName)
 			gcObjects(&ctx, volumeClearDirName)
-			gcDatasets(&ctx, types.VolumeZFSPool)
+			gcDatasets(&ctx, types.VolumeEncryptedZFSDataset)
+			gcDatasets(&ctx, types.VolumeClearZFSDataset)
 			if !ctx.initGced {
 				gcUnusedInitObjects(&ctx)
 				ctx.initGced = true

--- a/pkg/pillar/cmd/zedagent/handlevolume.go
+++ b/pkg/pillar/cmd/zedagent/handlevolume.go
@@ -79,9 +79,9 @@ func parseVolumeConfig(ctx *getconfigContext,
 		volumeConfig.MaxVolSize = uint64(cfgVolume.GetMaxsizebytes())
 		volumeConfig.GenerationCounter = cfgVolume.GetGenerationCount()
 		if cfgVolume.GetClearText() {
-			volumeConfig.VolumeDir = types.VolumeClearDirName
+			volumeConfig.Encrypted = false
 		} else {
-			volumeConfig.VolumeDir = types.VolumeEncryptedDirName
+			volumeConfig.Encrypted = true
 		}
 		volumeConfig.DisplayName = cfgVolume.GetDisplayName()
 		volumeConfig.ReadOnly = cfgVolume.GetReadonly()

--- a/pkg/pillar/types/locationconsts.go
+++ b/pkg/pillar/types/locationconsts.go
@@ -3,6 +3,8 @@
 
 package types
 
+import "strings"
+
 const (
 	// TmpDirname - used for files fed into pubsub as global subscriptions
 	TmpDirname = "/run/global"
@@ -25,8 +27,6 @@ const (
 	VolumeClearDirName = ClearDirName + "/volumes"
 	// PersistDebugDir - Location for service specific debug/traces
 	PersistDebugDir = PersistDir + "/agentdebug"
-	//VolumeZFSPool - pool for create volumes
-	VolumeZFSPool = "persist" + "/volumes"
 
 	// IdentityDirname - Config dir
 	IdentityDirname = "/config"
@@ -86,4 +86,11 @@ const (
 
 	// ContainerdContentDir - path to containerd`s content store
 	ContainerdContentDir = PersistDir + "/containerd/io.containerd.content.v1.content"
+)
+
+var (
+	//VolumeClearZFSDataset - dataset to create volumes without encryption
+	VolumeClearZFSDataset = strings.TrimLeft(VolumeClearDirName, "/")
+	//VolumeEncryptedZFSDataset - dataset to create volumes with encryption
+	VolumeEncryptedZFSDataset = strings.TrimLeft(VolumeEncryptedDirName, "/")
 )

--- a/pkg/pillar/types/volumetypes.go
+++ b/pkg/pillar/types/volumetypes.go
@@ -23,7 +23,7 @@ type VolumeConfig struct {
 	ReadOnly                bool
 	RefCount                uint
 	GenerationCounter       int64
-	VolumeDir               string
+	Encrypted               bool
 	DisplayName             string
 	HasNoAppReferences      bool
 }
@@ -114,7 +114,7 @@ type VolumeStatus struct {
 	MaxVolSize              uint64
 	ReadOnly                bool
 	GenerationCounter       int64
-	VolumeDir               string
+	Encrypted               bool
 	DisplayName             string
 	State                   SwState
 	SubState                volumeSubState
@@ -150,7 +150,11 @@ func (status VolumeStatus) IsContainer() bool {
 
 // PathName returns the path of the volume
 func (status VolumeStatus) PathName() string {
-	return fmt.Sprintf("%s/%s#%d.%s", status.VolumeDir, status.VolumeID.String(),
+	baseDir := VolumeClearDirName
+	if status.Encrypted {
+		baseDir = VolumeEncryptedDirName
+	}
+	return fmt.Sprintf("%s/%s#%d.%s", baseDir, status.VolumeID.String(),
 		status.GenerationCounter, strings.ToLower(status.ContentFormat.String()))
 }
 

--- a/pkg/pillar/types/zfs.go
+++ b/pkg/pillar/types/zfs.go
@@ -13,8 +13,12 @@ const (
 	ZVolDevicePrefix = "/dev/zvol"
 )
 
-// ZVolName returns name of zvol for volume in defined pool
-func (status VolumeStatus) ZVolName(pool string) string {
+// ZVolName returns name of zvol for volume
+func (status VolumeStatus) ZVolName() string {
+	pool := VolumeClearZFSDataset
+	if status.Encrypted {
+		pool = VolumeEncryptedZFSDataset
+	}
 	return fmt.Sprintf("%s/%s.%d", pool, status.VolumeID.String(), status.GenerationCounter)
 }
 

--- a/pkg/pillar/zfs/zfs.go
+++ b/pkg/pillar/zfs/zfs.go
@@ -23,6 +23,13 @@ var (
 	zfsPath = []string{"/hostfs", "zfs"}
 )
 
+//CreateDataset creates an empty dataset
+func CreateDataset(log *base.LogObject, dataset string) (string, error) {
+	args := append(zfsPath, "create", "-p", dataset)
+	stdoutStderr, err := base.Exec(log, vault.ZfsPath, args...).CombinedOutput()
+	return string(stdoutStderr), err
+}
+
 //DestroyDataset removes dataset from zfs
 //it runs 3 times in case of errors (we can hit dataset is busy)
 func DestroyDataset(log *base.LogObject, dataset string) (string, error) {


### PR DESCRIPTION
To support encrypted zvols we should move them to the child of persist/vault dataset to inherit options.