### PR TITLE
Zfs performance patches

### DIFF
--- a/pkg/kernel/patches-zfs-2.1.2/0001-Introduce-write-throttle-smoothing.patch
+++ b/pkg/kernel/patches-zfs-2.1.2/0001-Introduce-write-throttle-smoothing.patch
@@ -1,0 +1,215 @@
+From 93a0762328099431ecaddabb419625aaa63ebb40 Mon Sep 17 00:00:00 2001
+From: Mariusz Zaborski <mariusz.zaborski@klarasystems.com>
+Date: Tue, 7 Dec 2021 11:49:01 +0100
+Subject: [PATCH 1/7] Introduce write throttle smoothing
+
+To avoid stalls and uneven performance during heavy write workloads,
+continue to apply write throttling even when the amount of dirty data
+has temporarily dipped below zfs_delay_min_dirty_percent for up to
+zfs_write_smoothing seconds.
+
+Signed-off-by: Allan Jude <allan@klarasystems.com>
+Signed-off-by: Mariusz Zaborski <mariusz.zaborski@klarasystems.com>
+(cherry picked from commit ad3ee4a5e15c813277c5cb9b69e4a17f009118b8)
+---
+ include/sys/dsl_pool.h |  3 +++
+ man/man4/zfs.4         | 17 ++++++++++++++++-
+ module/zfs/dmu_tx.c    | 35 +++++++++++++++++++++++++----------
+ module/zfs/dsl_pool.c  | 12 +++++++++++-
+ 4 files changed, 55 insertions(+), 12 deletions(-)
+
+diff --git a/include/sys/dsl_pool.h b/include/sys/dsl_pool.h
+index 8249bb8fc..9dd9c35f3 100644
+--- a/include/sys/dsl_pool.h
++++ b/include/sys/dsl_pool.h
+@@ -63,6 +63,8 @@ extern int zfs_dirty_data_max_percent;
+ extern int zfs_dirty_data_max_max_percent;
+ extern int zfs_delay_min_dirty_percent;
+ extern unsigned long zfs_delay_scale;
++extern unsigned long zfs_smoothing_scale;
++extern unsigned long zfs_smoothing_write;
+ 
+ /* These macros are for indexing into the zfs_all_blkstats_t. */
+ #define	DMU_OT_DEFERRED	DMU_OT_NONE
+@@ -114,6 +116,7 @@ typedef struct dsl_pool {
+ 	kcondvar_t dp_spaceavail_cv;
+ 	uint64_t dp_dirty_pertxg[TXG_SIZE];
+ 	uint64_t dp_dirty_total;
++	hrtime_t dp_last_smooth;
+ 	uint64_t dp_long_free_dirty_pertxg[TXG_SIZE];
+ 	uint64_t dp_mos_used_delta;
+ 	uint64_t dp_mos_compressed_delta;
+diff --git a/man/man4/zfs.4 b/man/man4/zfs.4
+index 20b24d898..23ce4a6cf 100644
+--- a/man/man4/zfs.4
++++ b/man/man4/zfs.4
+@@ -15,7 +15,7 @@
+ .\" own identifying information:
+ .\" Portions Copyright [yyyy] [name of copyright owner]
+ .\"
+-.Dd June 1, 2021
++.Dd January 8, 2021
+ .Dt ZFS 4
+ .Os
+ .
+@@ -928,6 +928,21 @@ This will smoothly handle between ten times and a tenth of this number.
+ .Pp
+ .Sy zfs_delay_scale * zfs_dirty_data_max Em must be smaller than Sy 2^64 .
+ .
++.It Sy zfs_smoothing_write Ns = Ns Sy 0 Ns s Pq ulong
++This controls for how many seconds smoothing should be applied.
++The smoothing mechanism is used to add additional transaction delays
++after the amount of dirty data drops below
++.Sy zfs_delay_min_dirty_percent .
++This mechanism may be used to avoid stalls and uneven performance during
++heavy write workloads
++.
++.It Sy zfs_smoothing_scale Ns = Ns Sy 100000 Pq int
++Similar to
++.Sy zfs_delay_scale ,
++but for write smoothing.
++This variable controls the scale of smoothing curve.
++Larger values cause longer delays for a given amount of dirty data.
++.
+ .It Sy zfs_disable_ivset_guid_check Ns = Ns Sy 0 Ns | Ns 1 Pq int
+ Disables requirement for IVset GUIDs to be present and match when doing a raw
+ receive of encrypted datasets.
+diff --git a/module/zfs/dmu_tx.c b/module/zfs/dmu_tx.c
+index 0beb983f9..10e26bbff 100644
+--- a/module/zfs/dmu_tx.c
++++ b/module/zfs/dmu_tx.c
+@@ -777,14 +777,16 @@ int zfs_delay_resolution_ns = 100 * 1000; /* 100 microseconds */
+  * of zfs_delay_scale to increase the steepness of the curve.
+  */
+ static void
+-dmu_tx_delay(dmu_tx_t *tx, uint64_t dirty)
++dmu_tx_delay(dmu_tx_t *tx, uint64_t dirty, hrtime_t last_smooth)
+ {
+ 	dsl_pool_t *dp = tx->tx_pool;
+ 	uint64_t delay_min_bytes =
+ 	    zfs_dirty_data_max * zfs_delay_min_dirty_percent / 100;
+-	hrtime_t wakeup, min_tx_time, now;
++	hrtime_t wakeup, min_tx_time, now, smoothing_time, delay_time;
+ 
+-	if (dirty <= delay_min_bytes)
++	now = gethrtime();
++
++	if (dirty <= delay_min_bytes && last_smooth <= now)
+ 		return;
+ 
+ 	/*
+@@ -795,11 +797,20 @@ dmu_tx_delay(dmu_tx_t *tx, uint64_t dirty)
+ 	 */
+ 	ASSERT3U(dirty, <, zfs_dirty_data_max);
+ 
+-	now = gethrtime();
+-	min_tx_time = zfs_delay_scale *
+-	    (dirty - delay_min_bytes) / (zfs_dirty_data_max - dirty);
+-	min_tx_time = MIN(min_tx_time, zfs_delay_max_ns);
+-	if (now > tx->tx_start + min_tx_time)
++	smoothing_time = 0;
++	delay_time = 0;
++
++	if (dirty > delay_min_bytes) {
++		delay_time = zfs_delay_scale *
++		    (dirty - delay_min_bytes) / (zfs_dirty_data_max - dirty);
++	}
++	if (last_smooth > now) {
++		smoothing_time = zfs_smoothing_scale * dirty /
++		    (zfs_dirty_data_max - dirty);
++	}
++
++	min_tx_time = MIN(MAX(smoothing_time, delay_time), zfs_delay_max_ns);
++	if (zfs_smoothing_write == 0 && now > tx->tx_start + min_tx_time)
+ 		return;
+ 
+ 	DTRACE_PROBE3(delay__mintime, dmu_tx_t *, tx, uint64_t, dirty,
+@@ -809,6 +820,9 @@ dmu_tx_delay(dmu_tx_t *tx, uint64_t dirty)
+ 	wakeup = MAX(tx->tx_start + min_tx_time,
+ 	    dp->dp_last_wakeup + min_tx_time);
+ 	dp->dp_last_wakeup = wakeup;
++	if (dirty > delay_min_bytes) {
++		dp->dp_last_smooth = now + zfs_smoothing_write * NANOSEC;
++	}
+ 	mutex_exit(&dp->dp_lock);
+ 
+ 	zfs_sleep_until(wakeup);
+@@ -1064,7 +1078,7 @@ dmu_tx_wait(dmu_tx_t *tx)
+ {
+ 	spa_t *spa = tx->tx_pool->dp_spa;
+ 	dsl_pool_t *dp = tx->tx_pool;
+-	hrtime_t before;
++	hrtime_t before, last_smooth;
+ 
+ 	ASSERT(tx->tx_txg == 0);
+ 	ASSERT(!dsl_pool_config_held(tx->tx_pool));
+@@ -1084,10 +1098,11 @@ dmu_tx_wait(dmu_tx_t *tx)
+ 			DMU_TX_STAT_BUMP(dmu_tx_dirty_over_max);
+ 		while (dp->dp_dirty_total >= zfs_dirty_data_max)
+ 			cv_wait(&dp->dp_spaceavail_cv, &dp->dp_lock);
++		last_smooth = dp->dp_last_smooth;
+ 		dirty = dp->dp_dirty_total;
+ 		mutex_exit(&dp->dp_lock);
+ 
+-		dmu_tx_delay(tx, dirty);
++		dmu_tx_delay(tx, dirty, last_smooth);
+ 
+ 		tx->tx_wait_dirty = B_FALSE;
+ 
+diff --git a/module/zfs/dsl_pool.c b/module/zfs/dsl_pool.c
+index e66c136a9..6d7a1e6a8 100644
+--- a/module/zfs/dsl_pool.c
++++ b/module/zfs/dsl_pool.c
+@@ -103,6 +103,7 @@ unsigned long zfs_dirty_data_max = 0;
+ unsigned long zfs_dirty_data_max_max = 0;
+ int zfs_dirty_data_max_percent = 10;
+ int zfs_dirty_data_max_max_percent = 25;
++unsigned long zfs_smoothing_write = 0;
+ 
+ /*
+  * If there's at least this much dirty data (as a percentage of
+@@ -132,6 +133,7 @@ int zfs_delay_min_dirty_percent = 60;
+  * multiply in dmu_tx_delay().
+  */
+ unsigned long zfs_delay_scale = 1000 * 1000 * 1000 / 2000;
++unsigned long zfs_smoothing_scale = 100000;
+ 
+ /*
+  * This determines the number of threads used by the dp_sync_taskq.
+@@ -904,10 +906,12 @@ dsl_pool_need_dirty_delay(dsl_pool_t *dp)
+ 
+ 	mutex_enter(&dp->dp_lock);
+ 	dirty = dp->dp_dirty_total;
++	hrtime_t last_delay = dp->dp_last_smooth;
+ 	mutex_exit(&dp->dp_lock);
+ 	if (dirty > dirty_min_bytes)
+ 		txg_kick(dp);
+-	return (dirty > delay_min_bytes);
++
++	return (dirty > delay_min_bytes || last_delay > gethrtime());
+ }
+ 
+ void
+@@ -1392,6 +1396,9 @@ ZFS_MODULE_PARAM(zfs, zfs_, delay_min_dirty_percent, INT, ZMOD_RW,
+ ZFS_MODULE_PARAM(zfs, zfs_, dirty_data_max, ULONG, ZMOD_RW,
+ 	"Determines the dirty space limit");
+ 
++ZFS_MODULE_PARAM(zfs, zfs_, smoothing_write, ULONG, ZMOD_RW,
++	"How long should we smooth write after last delay (sec)");
++
+ /* zfs_dirty_data_max_max only applied at module load in arc_init(). */
+ ZFS_MODULE_PARAM(zfs, zfs_, dirty_data_max_max, ULONG, ZMOD_RD,
+ 	"zfs_dirty_data_max upper bound in bytes");
+@@ -1402,6 +1409,9 @@ ZFS_MODULE_PARAM(zfs, zfs_, dirty_data_sync_percent, INT, ZMOD_RW,
+ ZFS_MODULE_PARAM(zfs, zfs_, delay_scale, ULONG, ZMOD_RW,
+ 	"How quickly delay approaches infinity");
+ 
++ZFS_MODULE_PARAM(zfs, zfs_, smoothing_scale, ULONG, ZMOD_RW,
++	"Delay smoothing scale");
++
+ ZFS_MODULE_PARAM(zfs, zfs_, sync_taskq_batch_pct, INT, ZMOD_RW,
+ 	"Max percent of CPUs that are used to sync dirty data");
+ 
+-- 
+2.25.1
+

--- a/pkg/kernel/patches-zfs-2.1.2/0002-Fix-TRIM-tests.patch
+++ b/pkg/kernel/patches-zfs-2.1.2/0002-Fix-TRIM-tests.patch
@@ -1,0 +1,79 @@
+From aa51482978389622abadf5c77cfe5fef0a6c5110 Mon Sep 17 00:00:00 2001
+From: Allan Jude <allan@klarasystems.com>
+Date: Tue, 21 Dec 2021 16:08:51 -0500
+Subject: [PATCH 2/7] Fix TRIM tests
+
+Do a sync before checking how much space was used
+Make sure fill_mb is at least VDEV_MAX_MB or the test will fail
+
+Signed-off-by: Allan Jude <allan@klarasystems.com>
+Sponsored-by: Zededa Inc.
+---
+ .../tests/functional/trim/autotrim_config.ksh          |  8 ++++++++
+ tests/zfs-tests/tests/functional/trim/trim_config.ksh  | 10 +++++++++-
+ 2 files changed, 17 insertions(+), 1 deletion(-)
+
+diff --git a/tests/zfs-tests/tests/functional/trim/autotrim_config.ksh b/tests/zfs-tests/tests/functional/trim/autotrim_config.ksh
+index 924b56935..5de97bd10 100755
+--- a/tests/zfs-tests/tests/functional/trim/autotrim_config.ksh
++++ b/tests/zfs-tests/tests/functional/trim/autotrim_config.ksh
+@@ -92,13 +92,21 @@ for type in "" "mirror" "raidz2" "draid"; do
+ 
+ 	typeset availspace=$(get_prop available $TESTPOOL)
+ 	typeset fill_mb=$(( floor(availspace * 0.90 / 1024 / 1024) ))
++	# We can't fill less than VDEV_MAX_MB and expect the vdev to be full
++	if [[ $fill_mb -lt $VDEV_MAX_MB ]]; then
++		fill_mb=$VDEV_MAX_MB
++	fi
+ 
+ 	# Fill the pool, verify the vdevs are no longer sparse.
+ 	file_write -o create -f /$TESTPOOL/file -b 1048576 -c $fill_mb -d R
++	sync_pool $TESTPOOL
++	sync
+ 	verify_vdevs "-ge" "$VDEV_MAX_MB" $VDEVS
+ 
+ 	# Remove the file, wait for trim, verify the vdevs are now sparse.
+ 	log_must rm /$TESTPOOL/file
++	sync_pool $TESTPOOL
++	sync
+ 	wait_trim_io $TESTPOOL "ind" 64
+ 	verify_vdevs "-le" "$VDEV_MIN_MB" $VDEVS
+ 
+diff --git a/tests/zfs-tests/tests/functional/trim/trim_config.ksh b/tests/zfs-tests/tests/functional/trim/trim_config.ksh
+index 9a6e19e1c..958e03e48 100755
+--- a/tests/zfs-tests/tests/functional/trim/trim_config.ksh
++++ b/tests/zfs-tests/tests/functional/trim/trim_config.ksh
+@@ -82,7 +82,7 @@ for type in "" "mirror" "raidz2" "draid"; do
+ 		VDEVS="$TRIM_VDEV1 $TRIM_VDEV2 $TRIM_VDEV3 $TRIM_VDEV4"
+ 
+ 		# The per-vdev utilization is lower due to the capacity
+-		# resilverd for the distributed spare.
++		# reserved for the distributed spare.
+ 		VDEV_MAX_MB=$(( floor(4 * MINVDEVSIZE * 0.50 / 1024 / 1024) ))
+ 	fi
+ 
+@@ -91,13 +91,21 @@ for type in "" "mirror" "raidz2" "draid"; do
+ 
+ 	typeset availspace=$(get_prop available $TESTPOOL)
+ 	typeset fill_mb=$(( floor(availspace * 0.90 / 1024 / 1024) ))
++	# We can't fill less than VDEV_MAX_MB and expect the vdev to be full
++	if [[ $fill_mb -lt $VDEV_MAX_MB ]]; then
++		fill_mb=$VDEV_MAX_MB
++	fi
+ 
+ 	# Fill the pool, verify the vdevs are no longer sparse.
+ 	file_write -o create -f /$TESTPOOL/file -b 1048576 -c $fill_mb -d R
++	sync_pool $TESTPOOL
++	sync
+ 	verify_vdevs "-ge" "$VDEV_MAX_MB" $VDEVS
+ 
+ 	# Remove the file, issue trim, verify the vdevs are now sparse.
+ 	log_must rm /$TESTPOOL/file
++	sync_pool $TESTPOOL
++	sync
+ 	log_must timeout 120 zpool trim -w $TESTPOOL
+ 	verify_vdevs "-le" "$VDEV_MIN_MB" $VDEVS
+ 
+-- 
+2.25.1
+

--- a/pkg/kernel/patches-zfs-2.1.2/0003-test-refquota-refquota_003_pos-sync-before-measuring.patch
+++ b/pkg/kernel/patches-zfs-2.1.2/0003-test-refquota-refquota_003_pos-sync-before-measuring.patch
@@ -1,0 +1,27 @@
+From 899f38ee41f214216a6f5a43e5dff04fea1d9786 Mon Sep 17 00:00:00 2001
+From: Allan Jude <allan@klarasystems.com>
+Date: Tue, 21 Dec 2021 16:13:00 -0500
+Subject: [PATCH 3/7] test refquota/refquota_003_pos: sync before measuring
+ space
+
+Signed-off-by: Allan Jude <allan@klarasystems.com>
+Sponsored-by: Zededa Inc.
+---
+ tests/zfs-tests/tests/functional/refquota/refquota_003_pos.ksh | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/tests/zfs-tests/tests/functional/refquota/refquota_003_pos.ksh b/tests/zfs-tests/tests/functional/refquota/refquota_003_pos.ksh
+index e4def1a0a..60c063ae1 100755
+--- a/tests/zfs-tests/tests/functional/refquota/refquota_003_pos.ksh
++++ b/tests/zfs-tests/tests/functional/refquota/refquota_003_pos.ksh
+@@ -61,6 +61,7 @@ log_must zfs create $fs/subfs
+ 
+ mntpnt=$(get_prop mountpoint $fs/subfs)
+ log_must mkfile 20M $mntpnt/$TESTFILE
++sync_pool $TESTPOOL
+ 
+ typeset -i used quota refquota
+ used=$(get_prop used $fs)
+-- 
+2.25.1
+

--- a/pkg/kernel/patches-zfs-2.1.2/0004-fault-auto_spare-tests-zpool-sync-before-zinject.patch
+++ b/pkg/kernel/patches-zfs-2.1.2/0004-fault-auto_spare-tests-zpool-sync-before-zinject.patch
@@ -1,0 +1,42 @@
+From d4af65336a52c6d72fdd157cf20b5e2d46d1f216 Mon Sep 17 00:00:00 2001
+From: Allan Jude <allan@klarasystems.com>
+Date: Tue, 21 Dec 2021 16:32:34 -0500
+Subject: [PATCH 4/7] fault/auto_spare tests: zpool sync before zinject
+
+Ensure the data has been flushed to the disk, else we read it back
+from the anonymous ARC and never encounter the zinject'd faults
+
+Signed-off-by: Allan Jude <allan@klarasystems.com>
+Sponsored-by: Zededa Inc.
+---
+ tests/zfs-tests/tests/functional/fault/auto_spare_001_pos.ksh | 1 +
+ tests/zfs-tests/tests/functional/fault/auto_spare_002_pos.ksh | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/tests/zfs-tests/tests/functional/fault/auto_spare_001_pos.ksh b/tests/zfs-tests/tests/functional/fault/auto_spare_001_pos.ksh
+index a93267185..d13ace31f 100755
+--- a/tests/zfs-tests/tests/functional/fault/auto_spare_001_pos.ksh
++++ b/tests/zfs-tests/tests/functional/fault/auto_spare_001_pos.ksh
+@@ -82,6 +82,7 @@ for type in "mirror" "raidz" "raidz2" "draid:1s"; do
+ 
+ 	# 3. Write a file to the pool to be read back
+ 	log_must dd if=/dev/urandom of=$TESTFILE bs=1M count=64
++	sync_pool $TESTPOOL
+ 
+ 	# 4. Inject IO ERRORS on read with a zinject error handler
+ 	log_must zinject -d $FAULT -e io -T read $TESTPOOL
+diff --git a/tests/zfs-tests/tests/functional/fault/auto_spare_002_pos.ksh b/tests/zfs-tests/tests/functional/fault/auto_spare_002_pos.ksh
+index e9517bad7..8555f730c 100755
+--- a/tests/zfs-tests/tests/functional/fault/auto_spare_002_pos.ksh
++++ b/tests/zfs-tests/tests/functional/fault/auto_spare_002_pos.ksh
+@@ -70,6 +70,7 @@ for type in "mirror" "raidz" "raidz2"; do
+ 
+ 	# 3. Write a file to the pool to be read back
+ 	log_must dd if=/dev/urandom of=$TESTFILE bs=1M count=64
++	sync_pool $TESTPOOL
+ 
+ 	# 4. Inject CHECKSUM ERRORS on read with a zinject error handler
+ 	log_must zinject -d $FAULT_FILE -e corrupt -f 50 -T read $TESTPOOL
+-- 
+2.25.1
+

--- a/pkg/kernel/patches-zfs-2.1.2/0005-Reduce-the-default-spa_asize_inflation-by-a-factor-o.patch
+++ b/pkg/kernel/patches-zfs-2.1.2/0005-Reduce-the-default-spa_asize_inflation-by-a-factor-o.patch
@@ -1,0 +1,38 @@
+From 507058638c521c9ea748fc43344560107d953441 Mon Sep 17 00:00:00 2001
+From: Allan Jude <allan@klarasystems.com>
+Date: Tue, 16 Nov 2021 23:11:00 +0000
+Subject: [PATCH 5/7] Reduce the default spa_asize_inflation by a factor of 2
+
+The formula included * 2 for possible dedup ditto blocks, a feature
+that was was removed in: 050d720c43b6285fc0c30e1e97591f6b796dbd68
+
+Sponsored-by: Zededa Inc.
+Sponsored-by: Klara Inc.
+Signed-off-by: Allan Jude <allan@klarasystems.com>
+---
+ module/zfs/spa_misc.c | 8 +++-----
+ 1 file changed, 3 insertions(+), 5 deletions(-)
+
+diff --git a/module/zfs/spa_misc.c b/module/zfs/spa_misc.c
+index 00515db02..d971b8a31 100644
+--- a/module/zfs/spa_misc.c
++++ b/module/zfs/spa_misc.c
+@@ -338,12 +338,10 @@ char *zfs_deadman_failmode = "wait";
+  * The worst case is single-sector max-parity RAID-Z blocks, in which
+  * case the space requirement is exactly (VDEV_RAIDZ_MAXPARITY + 1)
+  * times the size; so just assume that.  Add to this the fact that
+- * we can have up to 3 DVAs per bp, and one more factor of 2 because
+- * the block may be dittoed with up to 3 DVAs by ddt_sync().  All together,
+- * the worst case is:
+- *     (VDEV_RAIDZ_MAXPARITY + 1) * SPA_DVAS_PER_BP * 2 == 24
++ * we can have up to 3 DVAs per bp.  All together, the worst case is:
++ *     (VDEV_RAIDZ_MAXPARITY + 1) * SPA_DVAS_PER_BP == 12
+  */
+-int spa_asize_inflation = 24;
++int spa_asize_inflation = 12;
+ 
+ /*
+  * Normally, we don't allow the last 3.2% (1/(2^spa_slop_shift)) of space in
+-- 
+2.25.1
+

--- a/pkg/kernel/patches-zfs-2.1.2/0006-Calculate-the-worst-case-allocation-inflation.patch
+++ b/pkg/kernel/patches-zfs-2.1.2/0006-Calculate-the-worst-case-allocation-inflation.patch
@@ -1,0 +1,346 @@
+From 765b92c12bfbfe813c06ba23f942d64f2893156f Mon Sep 17 00:00:00 2001
+From: Allan Jude <allan@klarasystems.com>
+Date: Thu, 14 Oct 2021 15:50:49 +0000
+Subject: [PATCH 6/7] Calculate the worst case allocation inflation
+
+Instead of using a static formula of:
+  (VDEV_RAIDZ_MAXPARITY + 1) * SPA_DVAS_PER_BP == 12
+
+When adding/opening a vdev, set spa->spa_worst_alloc to the worst case
+for the worst vdev in the pool.
+
+This will lower the excessive inflation for pools that are simple
+spripes or mirror sets.
+
+Is it possible that for dRAID the static formula is not enough?
+
+Sponsored-by: Zededa Inc.
+Sponsored-by: Klara Inc.
+Signed-off-by: Allan Jude <allan@klarasystems.com>
+---
+ include/sys/spa_impl.h            |  1 +
+ include/sys/vdev_impl.h           |  3 +++
+ module/os/freebsd/zfs/vdev_file.c |  2 ++
+ module/os/freebsd/zfs/vdev_geom.c |  1 +
+ module/os/linux/zfs/vdev_disk.c   |  1 +
+ module/os/linux/zfs/vdev_file.c   |  2 ++
+ module/zfs/spa_misc.c             |  3 ++-
+ module/zfs/vdev.c                 | 22 ++++++++++++++++++++++
+ module/zfs/vdev_draid.c           | 12 ++++++++++++
+ module/zfs/vdev_indirect.c        |  1 +
+ module/zfs/vdev_mirror.c          |  3 +++
+ module/zfs/vdev_missing.c         |  2 ++
+ module/zfs/vdev_raidz.c           | 15 +++++++++++++++
+ module/zfs/vdev_root.c            |  1 +
+ 14 files changed, 68 insertions(+), 1 deletion(-)
+
+diff --git a/include/sys/spa_impl.h b/include/sys/spa_impl.h
+index cb2c49e58..ce8f4f755 100644
+--- a/include/sys/spa_impl.h
++++ b/include/sys/spa_impl.h
+@@ -249,6 +249,7 @@ struct spa {
+ 	uint64_t	spa_min_ashift;		/* of vdevs in normal class */
+ 	uint64_t	spa_max_ashift;		/* of vdevs in normal class */
+ 	uint64_t	spa_min_alloc;		/* of vdevs in normal class */
++	uint64_t	spa_worst_alloc;	/* of vdevs in normal class */
+ 	uint64_t	spa_config_guid;	/* config pool guid */
+ 	uint64_t	spa_load_guid;		/* spa_load initialized guid */
+ 	uint64_t	spa_last_synced_guid;	/* last synced guid */
+diff --git a/include/sys/vdev_impl.h b/include/sys/vdev_impl.h
+index 3cfde40a7..d51e60846 100644
+--- a/include/sys/vdev_impl.h
++++ b/include/sys/vdev_impl.h
+@@ -76,6 +76,7 @@ typedef void	vdev_close_func_t(vdev_t *vd);
+ typedef uint64_t vdev_asize_func_t(vdev_t *vd, uint64_t psize);
+ typedef uint64_t vdev_min_asize_func_t(vdev_t *vd);
+ typedef uint64_t vdev_min_alloc_func_t(vdev_t *vd);
++typedef uint64_t vdev_worst_alloc_func_t(vdev_t *vd);
+ typedef void	vdev_io_start_func_t(zio_t *zio);
+ typedef void	vdev_io_done_func_t(zio_t *zio);
+ typedef void	vdev_state_change_func_t(vdev_t *vd, int, int);
+@@ -110,6 +111,7 @@ typedef const struct vdev_ops {
+ 	vdev_asize_func_t		*vdev_op_asize;
+ 	vdev_min_asize_func_t		*vdev_op_min_asize;
+ 	vdev_min_alloc_func_t		*vdev_op_min_alloc;
++	vdev_worst_alloc_func_t		*vdev_op_worst_alloc;
+ 	vdev_io_start_func_t		*vdev_op_io_start;
+ 	vdev_io_done_func_t		*vdev_op_io_done;
+ 	vdev_state_change_func_t	*vdev_op_state_change;
+@@ -618,6 +620,7 @@ extern uint64_t vdev_default_min_asize(vdev_t *vd);
+ extern uint64_t vdev_get_min_asize(vdev_t *vd);
+ extern void vdev_set_min_asize(vdev_t *vd);
+ extern uint64_t vdev_get_min_alloc(vdev_t *vd);
++extern uint64_t vdev_get_worst_alloc(vdev_t *vd);
+ extern uint64_t vdev_get_nparity(vdev_t *vd);
+ extern uint64_t vdev_get_ndisks(vdev_t *vd);
+ 
+diff --git a/module/os/freebsd/zfs/vdev_file.c b/module/os/freebsd/zfs/vdev_file.c
+index fc04a7476..9b7f29004 100644
+--- a/module/os/freebsd/zfs/vdev_file.c
++++ b/module/os/freebsd/zfs/vdev_file.c
+@@ -300,6 +300,7 @@ vdev_ops_t vdev_file_ops = {
+ 	.vdev_op_asize = vdev_default_asize,
+ 	.vdev_op_min_asize = vdev_default_min_asize,
+ 	.vdev_op_min_alloc = NULL,
++	.vdev_op_worst_alloc = NULL,
+ 	.vdev_op_io_start = vdev_file_io_start,
+ 	.vdev_op_io_done = vdev_file_io_done,
+ 	.vdev_op_state_change = NULL,
+@@ -330,6 +331,7 @@ vdev_ops_t vdev_disk_ops = {
+ 	.vdev_op_asize = vdev_default_asize,
+ 	.vdev_op_min_asize = vdev_default_min_asize,
+ 	.vdev_op_min_alloc = NULL,
++	.vdev_op_worst_alloc = NULL,
+ 	.vdev_op_io_start = vdev_file_io_start,
+ 	.vdev_op_io_done = vdev_file_io_done,
+ 	.vdev_op_state_change = NULL,
+diff --git a/module/os/freebsd/zfs/vdev_geom.c b/module/os/freebsd/zfs/vdev_geom.c
+index 2ef4811a8..a2222ae5b 100644
+--- a/module/os/freebsd/zfs/vdev_geom.c
++++ b/module/os/freebsd/zfs/vdev_geom.c
+@@ -1306,6 +1306,7 @@ vdev_ops_t vdev_disk_ops = {
+ 	.vdev_op_asize = vdev_default_asize,
+ 	.vdev_op_min_asize = vdev_default_min_asize,
+ 	.vdev_op_min_alloc = NULL,
++	.vdev_op_worst_alloc = NULL,
+ 	.vdev_op_io_start = vdev_geom_io_start,
+ 	.vdev_op_io_done = vdev_geom_io_done,
+ 	.vdev_op_state_change = NULL,
+diff --git a/module/os/linux/zfs/vdev_disk.c b/module/os/linux/zfs/vdev_disk.c
+index a432a7364..f871377ad 100644
+--- a/module/os/linux/zfs/vdev_disk.c
++++ b/module/os/linux/zfs/vdev_disk.c
+@@ -882,6 +882,7 @@ vdev_ops_t vdev_disk_ops = {
+ 	.vdev_op_asize = vdev_default_asize,
+ 	.vdev_op_min_asize = vdev_default_min_asize,
+ 	.vdev_op_min_alloc = NULL,
++	.vdev_op_worst_alloc = NULL,
+ 	.vdev_op_io_start = vdev_disk_io_start,
+ 	.vdev_op_io_done = vdev_disk_io_done,
+ 	.vdev_op_state_change = NULL,
+diff --git a/module/os/linux/zfs/vdev_file.c b/module/os/linux/zfs/vdev_file.c
+index bf8a13ae6..1906f7fb6 100644
+--- a/module/os/linux/zfs/vdev_file.c
++++ b/module/os/linux/zfs/vdev_file.c
+@@ -312,6 +312,7 @@ vdev_ops_t vdev_file_ops = {
+ 	.vdev_op_asize = vdev_default_asize,
+ 	.vdev_op_min_asize = vdev_default_min_asize,
+ 	.vdev_op_min_alloc = NULL,
++	.vdev_op_worst_alloc = NULL,
+ 	.vdev_op_io_start = vdev_file_io_start,
+ 	.vdev_op_io_done = vdev_file_io_done,
+ 	.vdev_op_state_change = NULL,
+@@ -357,6 +358,7 @@ vdev_ops_t vdev_disk_ops = {
+ 	.vdev_op_asize = vdev_default_asize,
+ 	.vdev_op_min_asize = vdev_default_min_asize,
+ 	.vdev_op_min_alloc = NULL,
++	.vdev_op_worst_alloc = NULL,
+ 	.vdev_op_io_start = vdev_file_io_start,
+ 	.vdev_op_io_done = vdev_file_io_done,
+ 	.vdev_op_state_change = NULL,
+diff --git a/module/zfs/spa_misc.c b/module/zfs/spa_misc.c
+index d971b8a31..6bc7e5dd2 100644
+--- a/module/zfs/spa_misc.c
++++ b/module/zfs/spa_misc.c
+@@ -1765,7 +1765,8 @@ spa_get_worst_case_asize(spa_t *spa, uint64_t lsize)
+ {
+ 	if (lsize == 0)
+ 		return (0);	/* No inflation needed */
+-	return (MAX(lsize, 1 << spa->spa_max_ashift) * spa_asize_inflation);
++	return (MAX(lsize, 1 << spa->spa_max_ashift)
++	    * MIN(spa->spa_worst_alloc, spa_asize_inflation));
+ }
+ 
+ /*
+diff --git a/module/zfs/vdev.c b/module/zfs/vdev.c
+index d659ec5bf..fe8be9bd2 100644
+--- a/module/zfs/vdev.c
++++ b/module/zfs/vdev.c
+@@ -365,6 +365,20 @@ vdev_get_min_alloc(vdev_t *vd)
+ 	return (min_alloc);
+ }
+ 
++/*
++ * Get the worst case allocation size for the top-level vdev.
++ */
++uint64_t
++vdev_get_worst_alloc(vdev_t *vd)
++{
++	uint64_t worst_alloc = 1;
++
++	if (vd->vdev_ops->vdev_op_worst_alloc != NULL)
++		worst_alloc = vd->vdev_ops->vdev_op_worst_alloc(vd);
++
++	return (worst_alloc);
++}
++
+ /*
+  * Get the parity level for a top-level vdev.
+  */
+@@ -1390,6 +1404,10 @@ vdev_metaslab_group_create(vdev_t *vd)
+ 			uint64_t min_alloc = vdev_get_min_alloc(vd);
+ 			if (min_alloc < spa->spa_min_alloc)
+ 				spa->spa_min_alloc = min_alloc;
++
++			uint64_t worst_alloc = vdev_get_worst_alloc(vd);
++			if (worst_alloc > spa->spa_worst_alloc)
++				spa->spa_worst_alloc = worst_alloc;
+ 		}
+ 	}
+ }
+@@ -2128,6 +2146,10 @@ vdev_open(vdev_t *vd)
+ 		uint64_t min_alloc = vdev_get_min_alloc(vd);
+ 		if (min_alloc < spa->spa_min_alloc)
+ 			spa->spa_min_alloc = min_alloc;
++
++		uint64_t worst_alloc = vdev_get_worst_alloc(vd);
++		if (worst_alloc > spa->spa_worst_alloc)
++			spa->spa_worst_alloc = worst_alloc;
+ 	}
+ 
+ 	/*
+diff --git a/module/zfs/vdev_draid.c b/module/zfs/vdev_draid.c
+index b8f82d52e..d05213cc2 100644
+--- a/module/zfs/vdev_draid.c
++++ b/module/zfs/vdev_draid.c
+@@ -1150,6 +1150,16 @@ vdev_draid_min_alloc(vdev_t *vd)
+ 	return (vdc->vdc_ndata << vd->vdev_ashift);
+ }
+ 
++static uint64_t
++vdev_draid_worst_alloc(vdev_t *vd)
++{
++	vdev_draid_config_t *vdc = vd->vdev_tsd;
++
++	ASSERT3P(vd->vdev_ops, ==, &vdev_draid_ops);
++
++	return (vdc->vdc_groupwidth);
++}
++
+ /*
+  * Returns true if the txg range does not exist on any leaf vdev.
+  *
+@@ -2271,6 +2281,7 @@ vdev_ops_t vdev_draid_ops = {
+ 	.vdev_op_asize = vdev_draid_asize,
+ 	.vdev_op_min_asize = vdev_draid_min_asize,
+ 	.vdev_op_min_alloc = vdev_draid_min_alloc,
++	.vdev_op_worst_alloc = vdev_draid_worst_alloc,
+ 	.vdev_op_io_start = vdev_draid_io_start,
+ 	.vdev_op_io_done = vdev_draid_io_done,
+ 	.vdev_op_state_change = vdev_draid_state_change,
+@@ -2766,6 +2777,7 @@ vdev_ops_t vdev_draid_spare_ops = {
+ 	.vdev_op_asize = vdev_default_asize,
+ 	.vdev_op_min_asize = vdev_default_min_asize,
+ 	.vdev_op_min_alloc = NULL,
++	.vdev_op_worst_alloc = NULL,
+ 	.vdev_op_io_start = vdev_draid_spare_io_start,
+ 	.vdev_op_io_done = vdev_draid_spare_io_done,
+ 	.vdev_op_state_change = NULL,
+diff --git a/module/zfs/vdev_indirect.c b/module/zfs/vdev_indirect.c
+index 3237dc402..e2ec29ed9 100644
+--- a/module/zfs/vdev_indirect.c
++++ b/module/zfs/vdev_indirect.c
+@@ -1861,6 +1861,7 @@ vdev_ops_t vdev_indirect_ops = {
+ 	.vdev_op_asize = vdev_default_asize,
+ 	.vdev_op_min_asize = vdev_default_min_asize,
+ 	.vdev_op_min_alloc = NULL,
++	.vdev_op_worst_alloc = NULL,
+ 	.vdev_op_io_start = vdev_indirect_io_start,
+ 	.vdev_op_io_done = vdev_indirect_io_done,
+ 	.vdev_op_state_change = NULL,
+diff --git a/module/zfs/vdev_mirror.c b/module/zfs/vdev_mirror.c
+index 5eb331046..9806419cd 100644
+--- a/module/zfs/vdev_mirror.c
++++ b/module/zfs/vdev_mirror.c
+@@ -894,6 +894,7 @@ vdev_ops_t vdev_mirror_ops = {
+ 	.vdev_op_asize = vdev_default_asize,
+ 	.vdev_op_min_asize = vdev_default_min_asize,
+ 	.vdev_op_min_alloc = NULL,
++	.vdev_op_worst_alloc = NULL,
+ 	.vdev_op_io_start = vdev_mirror_io_start,
+ 	.vdev_op_io_done = vdev_mirror_io_done,
+ 	.vdev_op_state_change = vdev_mirror_state_change,
+@@ -919,6 +920,7 @@ vdev_ops_t vdev_replacing_ops = {
+ 	.vdev_op_asize = vdev_default_asize,
+ 	.vdev_op_min_asize = vdev_default_min_asize,
+ 	.vdev_op_min_alloc = NULL,
++	.vdev_op_worst_alloc = NULL,
+ 	.vdev_op_io_start = vdev_mirror_io_start,
+ 	.vdev_op_io_done = vdev_mirror_io_done,
+ 	.vdev_op_state_change = vdev_mirror_state_change,
+@@ -944,6 +946,7 @@ vdev_ops_t vdev_spare_ops = {
+ 	.vdev_op_asize = vdev_default_asize,
+ 	.vdev_op_min_asize = vdev_default_min_asize,
+ 	.vdev_op_min_alloc = NULL,
++	.vdev_op_worst_alloc = NULL,
+ 	.vdev_op_io_start = vdev_mirror_io_start,
+ 	.vdev_op_io_done = vdev_mirror_io_done,
+ 	.vdev_op_state_change = vdev_mirror_state_change,
+diff --git a/module/zfs/vdev_missing.c b/module/zfs/vdev_missing.c
+index e9145fd01..c16d67503 100644
+--- a/module/zfs/vdev_missing.c
++++ b/module/zfs/vdev_missing.c
+@@ -88,6 +88,7 @@ vdev_ops_t vdev_missing_ops = {
+ 	.vdev_op_asize = vdev_default_asize,
+ 	.vdev_op_min_asize = vdev_default_min_asize,
+ 	.vdev_op_min_alloc = NULL,
++	.vdev_op_worst_alloc = NULL,
+ 	.vdev_op_io_start = vdev_missing_io_start,
+ 	.vdev_op_io_done = vdev_missing_io_done,
+ 	.vdev_op_state_change = NULL,
+@@ -113,6 +114,7 @@ vdev_ops_t vdev_hole_ops = {
+ 	.vdev_op_asize = vdev_default_asize,
+ 	.vdev_op_min_asize = vdev_default_min_asize,
+ 	.vdev_op_min_alloc = NULL,
++	.vdev_op_worst_alloc = NULL,
+ 	.vdev_op_io_start = vdev_missing_io_start,
+ 	.vdev_op_io_done = vdev_missing_io_done,
+ 	.vdev_op_state_change = NULL,
+diff --git a/module/zfs/vdev_raidz.c b/module/zfs/vdev_raidz.c
+index 1feebf708..fce11139a 100644
+--- a/module/zfs/vdev_raidz.c
++++ b/module/zfs/vdev_raidz.c
+@@ -1477,6 +1477,20 @@ vdev_raidz_min_asize(vdev_t *vd)
+ 	    vd->vdev_children);
+ }
+ 
++/*
++ * When using RAIDz the worst case allocation size is determined by the level
++ * of parity in the redundancy group.
++ */
++static uint64_t
++vdev_raidz_worst_alloc(vdev_t *vd)
++{
++	vdev_raidz_t *vdrz = vd->vdev_tsd;
++
++	ASSERT3P(vd->vdev_ops, ==, &vdev_raidz_ops);
++
++	return (vdrz->vd_nparity + 1);
++}
++
+ void
+ vdev_raidz_child_done(zio_t *zio)
+ {
+@@ -2532,6 +2546,7 @@ vdev_ops_t vdev_raidz_ops = {
+ 	.vdev_op_asize = vdev_raidz_asize,
+ 	.vdev_op_min_asize = vdev_raidz_min_asize,
+ 	.vdev_op_min_alloc = NULL,
++	.vdev_op_worst_alloc = vdev_raidz_worst_alloc,
+ 	.vdev_op_io_start = vdev_raidz_io_start,
+ 	.vdev_op_io_done = vdev_raidz_io_done,
+ 	.vdev_op_state_change = vdev_raidz_state_change,
+diff --git a/module/zfs/vdev_root.c b/module/zfs/vdev_root.c
+index 45ddc2f71..abb9edc85 100644
+--- a/module/zfs/vdev_root.c
++++ b/module/zfs/vdev_root.c
+@@ -149,6 +149,7 @@ vdev_ops_t vdev_root_ops = {
+ 	.vdev_op_asize = vdev_default_asize,
+ 	.vdev_op_min_asize = vdev_default_min_asize,
+ 	.vdev_op_min_alloc = NULL,
++	.vdev_op_worst_alloc = NULL,
+ 	.vdev_op_io_start = NULL,	/* not applicable to the root */
+ 	.vdev_op_io_done = NULL,	/* not applicable to the root */
+ 	.vdev_op_state_change = vdev_root_state_change,
+-- 
+2.25.1
+

--- a/pkg/kernel/patches-zfs-2.1.2/0007-spa_get_worst_case_asize-calculate-RAID-Z-inflation-.patch
+++ b/pkg/kernel/patches-zfs-2.1.2/0007-spa_get_worst_case_asize-calculate-RAID-Z-inflation-.patch
@@ -1,0 +1,105 @@
+From f9ba0da534acf6d0b1cb7a2f4ca0c78af231c235 Mon Sep 17 00:00:00 2001
+From: Allan Jude <allan@klarasystems.com>
+Date: Tue, 16 Nov 2021 23:29:06 +0000
+Subject: [PATCH 7/7] spa_get_worst_case_asize: calculate RAID-Z inflation
+ correctly
+
+Rather than just multiplying the logical size by the minimum
+RAID-Z allocation size, we round the lsize up to the next
+multiple of the worst-case minimum allocation size.
+
+Then multiply that by the number of copies.
+
+This replaces spa_asize_inflation which always assumed the worst case
+
+Sponsored-by: Zededa Inc.
+Sponsored-by: Klara Inc.
+Signed-off-by: Allan Jude <allan@klarasystems.com>
+---
+ include/sys/spa.h       |  3 ++-
+ module/zfs/dmu_objset.c |  2 +-
+ module/zfs/dmu_tx.c     |  3 ++-
+ module/zfs/spa_misc.c   | 16 +++++++++++++---
+ 4 files changed, 18 insertions(+), 6 deletions(-)
+
+diff --git a/include/sys/spa.h b/include/sys/spa.h
+index 532926e12..7132a271a 100644
+--- a/include/sys/spa.h
++++ b/include/sys/spa.h
+@@ -1043,7 +1043,8 @@ extern uint64_t spa_version(spa_t *spa);
+ extern pool_state_t spa_state(spa_t *spa);
+ extern spa_load_state_t spa_load_state(spa_t *spa);
+ extern uint64_t spa_freeze_txg(spa_t *spa);
+-extern uint64_t spa_get_worst_case_asize(spa_t *spa, uint64_t lsize);
++extern uint64_t spa_get_worst_case_asize(spa_t *spa, objset_t *os,
++    uint64_t lsize);
+ extern uint64_t spa_get_dspace(spa_t *spa);
+ extern uint64_t spa_get_checkpoint_space(spa_t *spa);
+ extern uint64_t spa_get_slop_space(spa_t *spa);
+diff --git a/module/zfs/dmu_objset.c b/module/zfs/dmu_objset.c
+index af107fb8a..bd7f7c151 100644
+--- a/module/zfs/dmu_objset.c
++++ b/module/zfs/dmu_objset.c
+@@ -2993,7 +2993,7 @@ void
+ dmu_objset_willuse_space(objset_t *os, int64_t space, dmu_tx_t *tx)
+ {
+ 	dsl_dataset_t *ds = os->os_dsl_dataset;
+-	int64_t aspace = spa_get_worst_case_asize(os->os_spa, space);
++	int64_t aspace = spa_get_worst_case_asize(os->os_spa, os, space);
+ 
+ 	if (ds != NULL) {
+ 		dsl_dir_willuse_space(ds->ds_dir, aspace, tx);
+diff --git a/module/zfs/dmu_tx.c b/module/zfs/dmu_tx.c
+index 10e26bbff..6b369d558 100644
+--- a/module/zfs/dmu_tx.c
++++ b/module/zfs/dmu_tx.c
+@@ -957,7 +957,8 @@ dmu_tx_try_assign(dmu_tx_t *tx, uint64_t txg_how)
+ 	}
+ 
+ 	/* needed allocation: worst-case estimate of write space */
+-	uint64_t asize = spa_get_worst_case_asize(tx->tx_pool->dp_spa, towrite);
++	uint64_t asize = spa_get_worst_case_asize(tx->tx_pool->dp_spa,
++	    tx->tx_objset, towrite);
+ 	/* calculate memory footprint estimate */
+ 	uint64_t memory = towrite + tohold;
+ 
+diff --git a/module/zfs/spa_misc.c b/module/zfs/spa_misc.c
+index 6bc7e5dd2..9da813822 100644
+--- a/module/zfs/spa_misc.c
++++ b/module/zfs/spa_misc.c
+@@ -35,6 +35,7 @@
+ #include <sys/zio_checksum.h>
+ #include <sys/zio_compress.h>
+ #include <sys/dmu.h>
++#include <sys/dmu_objset.h>
+ #include <sys/dmu_tx.h>
+ #include <sys/zap.h>
+ #include <sys/zil.h>
+@@ -1761,12 +1762,21 @@ spa_freeze_txg(spa_t *spa)
+  * block anyway.
+  */
+ uint64_t
+-spa_get_worst_case_asize(spa_t *spa, uint64_t lsize)
++spa_get_worst_case_asize(spa_t *spa, objset_t *os, uint64_t lsize)
+ {
++	ASSERT3U(spa->spa_worst_alloc, >, 0);
+ 	if (lsize == 0)
+ 		return (0);	/* No inflation needed */
+-	return (MAX(lsize, 1 << spa->spa_max_ashift)
+-	    * MIN(spa->spa_worst_alloc, spa_asize_inflation));
++
++	uint64_t inflation = roundup(lsize, (1 << spa->spa_max_ashift) *
++	    spa->spa_worst_alloc);
++
++	if (os != NULL && os->os_copies > 0)
++		inflation *= os->os_copies;
++	else
++		inflation *= SPA_DVAS_PER_BP;
++
++	return (inflation);
+ }
+ 
+ /*
+-- 
+2.25.1
+

--- a/pkg/new-kernel/patches-zfs-2.1.2/0001-Introduce-write-throttle-smoothing.patch
+++ b/pkg/new-kernel/patches-zfs-2.1.2/0001-Introduce-write-throttle-smoothing.patch
@@ -1,0 +1,215 @@
+From 93a0762328099431ecaddabb419625aaa63ebb40 Mon Sep 17 00:00:00 2001
+From: Mariusz Zaborski <mariusz.zaborski@klarasystems.com>
+Date: Tue, 7 Dec 2021 11:49:01 +0100
+Subject: [PATCH 1/7] Introduce write throttle smoothing
+
+To avoid stalls and uneven performance during heavy write workloads,
+continue to apply write throttling even when the amount of dirty data
+has temporarily dipped below zfs_delay_min_dirty_percent for up to
+zfs_write_smoothing seconds.
+
+Signed-off-by: Allan Jude <allan@klarasystems.com>
+Signed-off-by: Mariusz Zaborski <mariusz.zaborski@klarasystems.com>
+(cherry picked from commit ad3ee4a5e15c813277c5cb9b69e4a17f009118b8)
+---
+ include/sys/dsl_pool.h |  3 +++
+ man/man4/zfs.4         | 17 ++++++++++++++++-
+ module/zfs/dmu_tx.c    | 35 +++++++++++++++++++++++++----------
+ module/zfs/dsl_pool.c  | 12 +++++++++++-
+ 4 files changed, 55 insertions(+), 12 deletions(-)
+
+diff --git a/include/sys/dsl_pool.h b/include/sys/dsl_pool.h
+index 8249bb8fc..9dd9c35f3 100644
+--- a/include/sys/dsl_pool.h
++++ b/include/sys/dsl_pool.h
+@@ -63,6 +63,8 @@ extern int zfs_dirty_data_max_percent;
+ extern int zfs_dirty_data_max_max_percent;
+ extern int zfs_delay_min_dirty_percent;
+ extern unsigned long zfs_delay_scale;
++extern unsigned long zfs_smoothing_scale;
++extern unsigned long zfs_smoothing_write;
+ 
+ /* These macros are for indexing into the zfs_all_blkstats_t. */
+ #define	DMU_OT_DEFERRED	DMU_OT_NONE
+@@ -114,6 +116,7 @@ typedef struct dsl_pool {
+ 	kcondvar_t dp_spaceavail_cv;
+ 	uint64_t dp_dirty_pertxg[TXG_SIZE];
+ 	uint64_t dp_dirty_total;
++	hrtime_t dp_last_smooth;
+ 	uint64_t dp_long_free_dirty_pertxg[TXG_SIZE];
+ 	uint64_t dp_mos_used_delta;
+ 	uint64_t dp_mos_compressed_delta;
+diff --git a/man/man4/zfs.4 b/man/man4/zfs.4
+index 20b24d898..23ce4a6cf 100644
+--- a/man/man4/zfs.4
++++ b/man/man4/zfs.4
+@@ -15,7 +15,7 @@
+ .\" own identifying information:
+ .\" Portions Copyright [yyyy] [name of copyright owner]
+ .\"
+-.Dd June 1, 2021
++.Dd January 8, 2021
+ .Dt ZFS 4
+ .Os
+ .
+@@ -928,6 +928,21 @@ This will smoothly handle between ten times and a tenth of this number.
+ .Pp
+ .Sy zfs_delay_scale * zfs_dirty_data_max Em must be smaller than Sy 2^64 .
+ .
++.It Sy zfs_smoothing_write Ns = Ns Sy 0 Ns s Pq ulong
++This controls for how many seconds smoothing should be applied.
++The smoothing mechanism is used to add additional transaction delays
++after the amount of dirty data drops below
++.Sy zfs_delay_min_dirty_percent .
++This mechanism may be used to avoid stalls and uneven performance during
++heavy write workloads
++.
++.It Sy zfs_smoothing_scale Ns = Ns Sy 100000 Pq int
++Similar to
++.Sy zfs_delay_scale ,
++but for write smoothing.
++This variable controls the scale of smoothing curve.
++Larger values cause longer delays for a given amount of dirty data.
++.
+ .It Sy zfs_disable_ivset_guid_check Ns = Ns Sy 0 Ns | Ns 1 Pq int
+ Disables requirement for IVset GUIDs to be present and match when doing a raw
+ receive of encrypted datasets.
+diff --git a/module/zfs/dmu_tx.c b/module/zfs/dmu_tx.c
+index 0beb983f9..10e26bbff 100644
+--- a/module/zfs/dmu_tx.c
++++ b/module/zfs/dmu_tx.c
+@@ -777,14 +777,16 @@ int zfs_delay_resolution_ns = 100 * 1000; /* 100 microseconds */
+  * of zfs_delay_scale to increase the steepness of the curve.
+  */
+ static void
+-dmu_tx_delay(dmu_tx_t *tx, uint64_t dirty)
++dmu_tx_delay(dmu_tx_t *tx, uint64_t dirty, hrtime_t last_smooth)
+ {
+ 	dsl_pool_t *dp = tx->tx_pool;
+ 	uint64_t delay_min_bytes =
+ 	    zfs_dirty_data_max * zfs_delay_min_dirty_percent / 100;
+-	hrtime_t wakeup, min_tx_time, now;
++	hrtime_t wakeup, min_tx_time, now, smoothing_time, delay_time;
+ 
+-	if (dirty <= delay_min_bytes)
++	now = gethrtime();
++
++	if (dirty <= delay_min_bytes && last_smooth <= now)
+ 		return;
+ 
+ 	/*
+@@ -795,11 +797,20 @@ dmu_tx_delay(dmu_tx_t *tx, uint64_t dirty)
+ 	 */
+ 	ASSERT3U(dirty, <, zfs_dirty_data_max);
+ 
+-	now = gethrtime();
+-	min_tx_time = zfs_delay_scale *
+-	    (dirty - delay_min_bytes) / (zfs_dirty_data_max - dirty);
+-	min_tx_time = MIN(min_tx_time, zfs_delay_max_ns);
+-	if (now > tx->tx_start + min_tx_time)
++	smoothing_time = 0;
++	delay_time = 0;
++
++	if (dirty > delay_min_bytes) {
++		delay_time = zfs_delay_scale *
++		    (dirty - delay_min_bytes) / (zfs_dirty_data_max - dirty);
++	}
++	if (last_smooth > now) {
++		smoothing_time = zfs_smoothing_scale * dirty /
++		    (zfs_dirty_data_max - dirty);
++	}
++
++	min_tx_time = MIN(MAX(smoothing_time, delay_time), zfs_delay_max_ns);
++	if (zfs_smoothing_write == 0 && now > tx->tx_start + min_tx_time)
+ 		return;
+ 
+ 	DTRACE_PROBE3(delay__mintime, dmu_tx_t *, tx, uint64_t, dirty,
+@@ -809,6 +820,9 @@ dmu_tx_delay(dmu_tx_t *tx, uint64_t dirty)
+ 	wakeup = MAX(tx->tx_start + min_tx_time,
+ 	    dp->dp_last_wakeup + min_tx_time);
+ 	dp->dp_last_wakeup = wakeup;
++	if (dirty > delay_min_bytes) {
++		dp->dp_last_smooth = now + zfs_smoothing_write * NANOSEC;
++	}
+ 	mutex_exit(&dp->dp_lock);
+ 
+ 	zfs_sleep_until(wakeup);
+@@ -1064,7 +1078,7 @@ dmu_tx_wait(dmu_tx_t *tx)
+ {
+ 	spa_t *spa = tx->tx_pool->dp_spa;
+ 	dsl_pool_t *dp = tx->tx_pool;
+-	hrtime_t before;
++	hrtime_t before, last_smooth;
+ 
+ 	ASSERT(tx->tx_txg == 0);
+ 	ASSERT(!dsl_pool_config_held(tx->tx_pool));
+@@ -1084,10 +1098,11 @@ dmu_tx_wait(dmu_tx_t *tx)
+ 			DMU_TX_STAT_BUMP(dmu_tx_dirty_over_max);
+ 		while (dp->dp_dirty_total >= zfs_dirty_data_max)
+ 			cv_wait(&dp->dp_spaceavail_cv, &dp->dp_lock);
++		last_smooth = dp->dp_last_smooth;
+ 		dirty = dp->dp_dirty_total;
+ 		mutex_exit(&dp->dp_lock);
+ 
+-		dmu_tx_delay(tx, dirty);
++		dmu_tx_delay(tx, dirty, last_smooth);
+ 
+ 		tx->tx_wait_dirty = B_FALSE;
+ 
+diff --git a/module/zfs/dsl_pool.c b/module/zfs/dsl_pool.c
+index e66c136a9..6d7a1e6a8 100644
+--- a/module/zfs/dsl_pool.c
++++ b/module/zfs/dsl_pool.c
+@@ -103,6 +103,7 @@ unsigned long zfs_dirty_data_max = 0;
+ unsigned long zfs_dirty_data_max_max = 0;
+ int zfs_dirty_data_max_percent = 10;
+ int zfs_dirty_data_max_max_percent = 25;
++unsigned long zfs_smoothing_write = 0;
+ 
+ /*
+  * If there's at least this much dirty data (as a percentage of
+@@ -132,6 +133,7 @@ int zfs_delay_min_dirty_percent = 60;
+  * multiply in dmu_tx_delay().
+  */
+ unsigned long zfs_delay_scale = 1000 * 1000 * 1000 / 2000;
++unsigned long zfs_smoothing_scale = 100000;
+ 
+ /*
+  * This determines the number of threads used by the dp_sync_taskq.
+@@ -904,10 +906,12 @@ dsl_pool_need_dirty_delay(dsl_pool_t *dp)
+ 
+ 	mutex_enter(&dp->dp_lock);
+ 	dirty = dp->dp_dirty_total;
++	hrtime_t last_delay = dp->dp_last_smooth;
+ 	mutex_exit(&dp->dp_lock);
+ 	if (dirty > dirty_min_bytes)
+ 		txg_kick(dp);
+-	return (dirty > delay_min_bytes);
++
++	return (dirty > delay_min_bytes || last_delay > gethrtime());
+ }
+ 
+ void
+@@ -1392,6 +1396,9 @@ ZFS_MODULE_PARAM(zfs, zfs_, delay_min_dirty_percent, INT, ZMOD_RW,
+ ZFS_MODULE_PARAM(zfs, zfs_, dirty_data_max, ULONG, ZMOD_RW,
+ 	"Determines the dirty space limit");
+ 
++ZFS_MODULE_PARAM(zfs, zfs_, smoothing_write, ULONG, ZMOD_RW,
++	"How long should we smooth write after last delay (sec)");
++
+ /* zfs_dirty_data_max_max only applied at module load in arc_init(). */
+ ZFS_MODULE_PARAM(zfs, zfs_, dirty_data_max_max, ULONG, ZMOD_RD,
+ 	"zfs_dirty_data_max upper bound in bytes");
+@@ -1402,6 +1409,9 @@ ZFS_MODULE_PARAM(zfs, zfs_, dirty_data_sync_percent, INT, ZMOD_RW,
+ ZFS_MODULE_PARAM(zfs, zfs_, delay_scale, ULONG, ZMOD_RW,
+ 	"How quickly delay approaches infinity");
+ 
++ZFS_MODULE_PARAM(zfs, zfs_, smoothing_scale, ULONG, ZMOD_RW,
++	"Delay smoothing scale");
++
+ ZFS_MODULE_PARAM(zfs, zfs_, sync_taskq_batch_pct, INT, ZMOD_RW,
+ 	"Max percent of CPUs that are used to sync dirty data");
+ 
+-- 
+2.25.1
+

--- a/pkg/new-kernel/patches-zfs-2.1.2/0002-Fix-TRIM-tests.patch
+++ b/pkg/new-kernel/patches-zfs-2.1.2/0002-Fix-TRIM-tests.patch
@@ -1,0 +1,79 @@
+From aa51482978389622abadf5c77cfe5fef0a6c5110 Mon Sep 17 00:00:00 2001
+From: Allan Jude <allan@klarasystems.com>
+Date: Tue, 21 Dec 2021 16:08:51 -0500
+Subject: [PATCH 2/7] Fix TRIM tests
+
+Do a sync before checking how much space was used
+Make sure fill_mb is at least VDEV_MAX_MB or the test will fail
+
+Signed-off-by: Allan Jude <allan@klarasystems.com>
+Sponsored-by: Zededa Inc.
+---
+ .../tests/functional/trim/autotrim_config.ksh          |  8 ++++++++
+ tests/zfs-tests/tests/functional/trim/trim_config.ksh  | 10 +++++++++-
+ 2 files changed, 17 insertions(+), 1 deletion(-)
+
+diff --git a/tests/zfs-tests/tests/functional/trim/autotrim_config.ksh b/tests/zfs-tests/tests/functional/trim/autotrim_config.ksh
+index 924b56935..5de97bd10 100755
+--- a/tests/zfs-tests/tests/functional/trim/autotrim_config.ksh
++++ b/tests/zfs-tests/tests/functional/trim/autotrim_config.ksh
+@@ -92,13 +92,21 @@ for type in "" "mirror" "raidz2" "draid"; do
+ 
+ 	typeset availspace=$(get_prop available $TESTPOOL)
+ 	typeset fill_mb=$(( floor(availspace * 0.90 / 1024 / 1024) ))
++	# We can't fill less than VDEV_MAX_MB and expect the vdev to be full
++	if [[ $fill_mb -lt $VDEV_MAX_MB ]]; then
++		fill_mb=$VDEV_MAX_MB
++	fi
+ 
+ 	# Fill the pool, verify the vdevs are no longer sparse.
+ 	file_write -o create -f /$TESTPOOL/file -b 1048576 -c $fill_mb -d R
++	sync_pool $TESTPOOL
++	sync
+ 	verify_vdevs "-ge" "$VDEV_MAX_MB" $VDEVS
+ 
+ 	# Remove the file, wait for trim, verify the vdevs are now sparse.
+ 	log_must rm /$TESTPOOL/file
++	sync_pool $TESTPOOL
++	sync
+ 	wait_trim_io $TESTPOOL "ind" 64
+ 	verify_vdevs "-le" "$VDEV_MIN_MB" $VDEVS
+ 
+diff --git a/tests/zfs-tests/tests/functional/trim/trim_config.ksh b/tests/zfs-tests/tests/functional/trim/trim_config.ksh
+index 9a6e19e1c..958e03e48 100755
+--- a/tests/zfs-tests/tests/functional/trim/trim_config.ksh
++++ b/tests/zfs-tests/tests/functional/trim/trim_config.ksh
+@@ -82,7 +82,7 @@ for type in "" "mirror" "raidz2" "draid"; do
+ 		VDEVS="$TRIM_VDEV1 $TRIM_VDEV2 $TRIM_VDEV3 $TRIM_VDEV4"
+ 
+ 		# The per-vdev utilization is lower due to the capacity
+-		# resilverd for the distributed spare.
++		# reserved for the distributed spare.
+ 		VDEV_MAX_MB=$(( floor(4 * MINVDEVSIZE * 0.50 / 1024 / 1024) ))
+ 	fi
+ 
+@@ -91,13 +91,21 @@ for type in "" "mirror" "raidz2" "draid"; do
+ 
+ 	typeset availspace=$(get_prop available $TESTPOOL)
+ 	typeset fill_mb=$(( floor(availspace * 0.90 / 1024 / 1024) ))
++	# We can't fill less than VDEV_MAX_MB and expect the vdev to be full
++	if [[ $fill_mb -lt $VDEV_MAX_MB ]]; then
++		fill_mb=$VDEV_MAX_MB
++	fi
+ 
+ 	# Fill the pool, verify the vdevs are no longer sparse.
+ 	file_write -o create -f /$TESTPOOL/file -b 1048576 -c $fill_mb -d R
++	sync_pool $TESTPOOL
++	sync
+ 	verify_vdevs "-ge" "$VDEV_MAX_MB" $VDEVS
+ 
+ 	# Remove the file, issue trim, verify the vdevs are now sparse.
+ 	log_must rm /$TESTPOOL/file
++	sync_pool $TESTPOOL
++	sync
+ 	log_must timeout 120 zpool trim -w $TESTPOOL
+ 	verify_vdevs "-le" "$VDEV_MIN_MB" $VDEVS
+ 
+-- 
+2.25.1
+

--- a/pkg/new-kernel/patches-zfs-2.1.2/0003-test-refquota-refquota_003_pos-sync-before-measuring.patch
+++ b/pkg/new-kernel/patches-zfs-2.1.2/0003-test-refquota-refquota_003_pos-sync-before-measuring.patch
@@ -1,0 +1,27 @@
+From 899f38ee41f214216a6f5a43e5dff04fea1d9786 Mon Sep 17 00:00:00 2001
+From: Allan Jude <allan@klarasystems.com>
+Date: Tue, 21 Dec 2021 16:13:00 -0500
+Subject: [PATCH 3/7] test refquota/refquota_003_pos: sync before measuring
+ space
+
+Signed-off-by: Allan Jude <allan@klarasystems.com>
+Sponsored-by: Zededa Inc.
+---
+ tests/zfs-tests/tests/functional/refquota/refquota_003_pos.ksh | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/tests/zfs-tests/tests/functional/refquota/refquota_003_pos.ksh b/tests/zfs-tests/tests/functional/refquota/refquota_003_pos.ksh
+index e4def1a0a..60c063ae1 100755
+--- a/tests/zfs-tests/tests/functional/refquota/refquota_003_pos.ksh
++++ b/tests/zfs-tests/tests/functional/refquota/refquota_003_pos.ksh
+@@ -61,6 +61,7 @@ log_must zfs create $fs/subfs
+ 
+ mntpnt=$(get_prop mountpoint $fs/subfs)
+ log_must mkfile 20M $mntpnt/$TESTFILE
++sync_pool $TESTPOOL
+ 
+ typeset -i used quota refquota
+ used=$(get_prop used $fs)
+-- 
+2.25.1
+

--- a/pkg/new-kernel/patches-zfs-2.1.2/0004-fault-auto_spare-tests-zpool-sync-before-zinject.patch
+++ b/pkg/new-kernel/patches-zfs-2.1.2/0004-fault-auto_spare-tests-zpool-sync-before-zinject.patch
@@ -1,0 +1,42 @@
+From d4af65336a52c6d72fdd157cf20b5e2d46d1f216 Mon Sep 17 00:00:00 2001
+From: Allan Jude <allan@klarasystems.com>
+Date: Tue, 21 Dec 2021 16:32:34 -0500
+Subject: [PATCH 4/7] fault/auto_spare tests: zpool sync before zinject
+
+Ensure the data has been flushed to the disk, else we read it back
+from the anonymous ARC and never encounter the zinject'd faults
+
+Signed-off-by: Allan Jude <allan@klarasystems.com>
+Sponsored-by: Zededa Inc.
+---
+ tests/zfs-tests/tests/functional/fault/auto_spare_001_pos.ksh | 1 +
+ tests/zfs-tests/tests/functional/fault/auto_spare_002_pos.ksh | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/tests/zfs-tests/tests/functional/fault/auto_spare_001_pos.ksh b/tests/zfs-tests/tests/functional/fault/auto_spare_001_pos.ksh
+index a93267185..d13ace31f 100755
+--- a/tests/zfs-tests/tests/functional/fault/auto_spare_001_pos.ksh
++++ b/tests/zfs-tests/tests/functional/fault/auto_spare_001_pos.ksh
+@@ -82,6 +82,7 @@ for type in "mirror" "raidz" "raidz2" "draid:1s"; do
+ 
+ 	# 3. Write a file to the pool to be read back
+ 	log_must dd if=/dev/urandom of=$TESTFILE bs=1M count=64
++	sync_pool $TESTPOOL
+ 
+ 	# 4. Inject IO ERRORS on read with a zinject error handler
+ 	log_must zinject -d $FAULT -e io -T read $TESTPOOL
+diff --git a/tests/zfs-tests/tests/functional/fault/auto_spare_002_pos.ksh b/tests/zfs-tests/tests/functional/fault/auto_spare_002_pos.ksh
+index e9517bad7..8555f730c 100755
+--- a/tests/zfs-tests/tests/functional/fault/auto_spare_002_pos.ksh
++++ b/tests/zfs-tests/tests/functional/fault/auto_spare_002_pos.ksh
+@@ -70,6 +70,7 @@ for type in "mirror" "raidz" "raidz2"; do
+ 
+ 	# 3. Write a file to the pool to be read back
+ 	log_must dd if=/dev/urandom of=$TESTFILE bs=1M count=64
++	sync_pool $TESTPOOL
+ 
+ 	# 4. Inject CHECKSUM ERRORS on read with a zinject error handler
+ 	log_must zinject -d $FAULT_FILE -e corrupt -f 50 -T read $TESTPOOL
+-- 
+2.25.1
+

--- a/pkg/new-kernel/patches-zfs-2.1.2/0005-Reduce-the-default-spa_asize_inflation-by-a-factor-o.patch
+++ b/pkg/new-kernel/patches-zfs-2.1.2/0005-Reduce-the-default-spa_asize_inflation-by-a-factor-o.patch
@@ -1,0 +1,38 @@
+From 507058638c521c9ea748fc43344560107d953441 Mon Sep 17 00:00:00 2001
+From: Allan Jude <allan@klarasystems.com>
+Date: Tue, 16 Nov 2021 23:11:00 +0000
+Subject: [PATCH 5/7] Reduce the default spa_asize_inflation by a factor of 2
+
+The formula included * 2 for possible dedup ditto blocks, a feature
+that was was removed in: 050d720c43b6285fc0c30e1e97591f6b796dbd68
+
+Sponsored-by: Zededa Inc.
+Sponsored-by: Klara Inc.
+Signed-off-by: Allan Jude <allan@klarasystems.com>
+---
+ module/zfs/spa_misc.c | 8 +++-----
+ 1 file changed, 3 insertions(+), 5 deletions(-)
+
+diff --git a/module/zfs/spa_misc.c b/module/zfs/spa_misc.c
+index 00515db02..d971b8a31 100644
+--- a/module/zfs/spa_misc.c
++++ b/module/zfs/spa_misc.c
+@@ -338,12 +338,10 @@ char *zfs_deadman_failmode = "wait";
+  * The worst case is single-sector max-parity RAID-Z blocks, in which
+  * case the space requirement is exactly (VDEV_RAIDZ_MAXPARITY + 1)
+  * times the size; so just assume that.  Add to this the fact that
+- * we can have up to 3 DVAs per bp, and one more factor of 2 because
+- * the block may be dittoed with up to 3 DVAs by ddt_sync().  All together,
+- * the worst case is:
+- *     (VDEV_RAIDZ_MAXPARITY + 1) * SPA_DVAS_PER_BP * 2 == 24
++ * we can have up to 3 DVAs per bp.  All together, the worst case is:
++ *     (VDEV_RAIDZ_MAXPARITY + 1) * SPA_DVAS_PER_BP == 12
+  */
+-int spa_asize_inflation = 24;
++int spa_asize_inflation = 12;
+ 
+ /*
+  * Normally, we don't allow the last 3.2% (1/(2^spa_slop_shift)) of space in
+-- 
+2.25.1
+

--- a/pkg/new-kernel/patches-zfs-2.1.2/0006-Calculate-the-worst-case-allocation-inflation.patch
+++ b/pkg/new-kernel/patches-zfs-2.1.2/0006-Calculate-the-worst-case-allocation-inflation.patch
@@ -1,0 +1,346 @@
+From 765b92c12bfbfe813c06ba23f942d64f2893156f Mon Sep 17 00:00:00 2001
+From: Allan Jude <allan@klarasystems.com>
+Date: Thu, 14 Oct 2021 15:50:49 +0000
+Subject: [PATCH 6/7] Calculate the worst case allocation inflation
+
+Instead of using a static formula of:
+  (VDEV_RAIDZ_MAXPARITY + 1) * SPA_DVAS_PER_BP == 12
+
+When adding/opening a vdev, set spa->spa_worst_alloc to the worst case
+for the worst vdev in the pool.
+
+This will lower the excessive inflation for pools that are simple
+spripes or mirror sets.
+
+Is it possible that for dRAID the static formula is not enough?
+
+Sponsored-by: Zededa Inc.
+Sponsored-by: Klara Inc.
+Signed-off-by: Allan Jude <allan@klarasystems.com>
+---
+ include/sys/spa_impl.h            |  1 +
+ include/sys/vdev_impl.h           |  3 +++
+ module/os/freebsd/zfs/vdev_file.c |  2 ++
+ module/os/freebsd/zfs/vdev_geom.c |  1 +
+ module/os/linux/zfs/vdev_disk.c   |  1 +
+ module/os/linux/zfs/vdev_file.c   |  2 ++
+ module/zfs/spa_misc.c             |  3 ++-
+ module/zfs/vdev.c                 | 22 ++++++++++++++++++++++
+ module/zfs/vdev_draid.c           | 12 ++++++++++++
+ module/zfs/vdev_indirect.c        |  1 +
+ module/zfs/vdev_mirror.c          |  3 +++
+ module/zfs/vdev_missing.c         |  2 ++
+ module/zfs/vdev_raidz.c           | 15 +++++++++++++++
+ module/zfs/vdev_root.c            |  1 +
+ 14 files changed, 68 insertions(+), 1 deletion(-)
+
+diff --git a/include/sys/spa_impl.h b/include/sys/spa_impl.h
+index cb2c49e58..ce8f4f755 100644
+--- a/include/sys/spa_impl.h
++++ b/include/sys/spa_impl.h
+@@ -249,6 +249,7 @@ struct spa {
+ 	uint64_t	spa_min_ashift;		/* of vdevs in normal class */
+ 	uint64_t	spa_max_ashift;		/* of vdevs in normal class */
+ 	uint64_t	spa_min_alloc;		/* of vdevs in normal class */
++	uint64_t	spa_worst_alloc;	/* of vdevs in normal class */
+ 	uint64_t	spa_config_guid;	/* config pool guid */
+ 	uint64_t	spa_load_guid;		/* spa_load initialized guid */
+ 	uint64_t	spa_last_synced_guid;	/* last synced guid */
+diff --git a/include/sys/vdev_impl.h b/include/sys/vdev_impl.h
+index 3cfde40a7..d51e60846 100644
+--- a/include/sys/vdev_impl.h
++++ b/include/sys/vdev_impl.h
+@@ -76,6 +76,7 @@ typedef void	vdev_close_func_t(vdev_t *vd);
+ typedef uint64_t vdev_asize_func_t(vdev_t *vd, uint64_t psize);
+ typedef uint64_t vdev_min_asize_func_t(vdev_t *vd);
+ typedef uint64_t vdev_min_alloc_func_t(vdev_t *vd);
++typedef uint64_t vdev_worst_alloc_func_t(vdev_t *vd);
+ typedef void	vdev_io_start_func_t(zio_t *zio);
+ typedef void	vdev_io_done_func_t(zio_t *zio);
+ typedef void	vdev_state_change_func_t(vdev_t *vd, int, int);
+@@ -110,6 +111,7 @@ typedef const struct vdev_ops {
+ 	vdev_asize_func_t		*vdev_op_asize;
+ 	vdev_min_asize_func_t		*vdev_op_min_asize;
+ 	vdev_min_alloc_func_t		*vdev_op_min_alloc;
++	vdev_worst_alloc_func_t		*vdev_op_worst_alloc;
+ 	vdev_io_start_func_t		*vdev_op_io_start;
+ 	vdev_io_done_func_t		*vdev_op_io_done;
+ 	vdev_state_change_func_t	*vdev_op_state_change;
+@@ -618,6 +620,7 @@ extern uint64_t vdev_default_min_asize(vdev_t *vd);
+ extern uint64_t vdev_get_min_asize(vdev_t *vd);
+ extern void vdev_set_min_asize(vdev_t *vd);
+ extern uint64_t vdev_get_min_alloc(vdev_t *vd);
++extern uint64_t vdev_get_worst_alloc(vdev_t *vd);
+ extern uint64_t vdev_get_nparity(vdev_t *vd);
+ extern uint64_t vdev_get_ndisks(vdev_t *vd);
+ 
+diff --git a/module/os/freebsd/zfs/vdev_file.c b/module/os/freebsd/zfs/vdev_file.c
+index fc04a7476..9b7f29004 100644
+--- a/module/os/freebsd/zfs/vdev_file.c
++++ b/module/os/freebsd/zfs/vdev_file.c
+@@ -300,6 +300,7 @@ vdev_ops_t vdev_file_ops = {
+ 	.vdev_op_asize = vdev_default_asize,
+ 	.vdev_op_min_asize = vdev_default_min_asize,
+ 	.vdev_op_min_alloc = NULL,
++	.vdev_op_worst_alloc = NULL,
+ 	.vdev_op_io_start = vdev_file_io_start,
+ 	.vdev_op_io_done = vdev_file_io_done,
+ 	.vdev_op_state_change = NULL,
+@@ -330,6 +331,7 @@ vdev_ops_t vdev_disk_ops = {
+ 	.vdev_op_asize = vdev_default_asize,
+ 	.vdev_op_min_asize = vdev_default_min_asize,
+ 	.vdev_op_min_alloc = NULL,
++	.vdev_op_worst_alloc = NULL,
+ 	.vdev_op_io_start = vdev_file_io_start,
+ 	.vdev_op_io_done = vdev_file_io_done,
+ 	.vdev_op_state_change = NULL,
+diff --git a/module/os/freebsd/zfs/vdev_geom.c b/module/os/freebsd/zfs/vdev_geom.c
+index 2ef4811a8..a2222ae5b 100644
+--- a/module/os/freebsd/zfs/vdev_geom.c
++++ b/module/os/freebsd/zfs/vdev_geom.c
+@@ -1306,6 +1306,7 @@ vdev_ops_t vdev_disk_ops = {
+ 	.vdev_op_asize = vdev_default_asize,
+ 	.vdev_op_min_asize = vdev_default_min_asize,
+ 	.vdev_op_min_alloc = NULL,
++	.vdev_op_worst_alloc = NULL,
+ 	.vdev_op_io_start = vdev_geom_io_start,
+ 	.vdev_op_io_done = vdev_geom_io_done,
+ 	.vdev_op_state_change = NULL,
+diff --git a/module/os/linux/zfs/vdev_disk.c b/module/os/linux/zfs/vdev_disk.c
+index a432a7364..f871377ad 100644
+--- a/module/os/linux/zfs/vdev_disk.c
++++ b/module/os/linux/zfs/vdev_disk.c
+@@ -882,6 +882,7 @@ vdev_ops_t vdev_disk_ops = {
+ 	.vdev_op_asize = vdev_default_asize,
+ 	.vdev_op_min_asize = vdev_default_min_asize,
+ 	.vdev_op_min_alloc = NULL,
++	.vdev_op_worst_alloc = NULL,
+ 	.vdev_op_io_start = vdev_disk_io_start,
+ 	.vdev_op_io_done = vdev_disk_io_done,
+ 	.vdev_op_state_change = NULL,
+diff --git a/module/os/linux/zfs/vdev_file.c b/module/os/linux/zfs/vdev_file.c
+index bf8a13ae6..1906f7fb6 100644
+--- a/module/os/linux/zfs/vdev_file.c
++++ b/module/os/linux/zfs/vdev_file.c
+@@ -312,6 +312,7 @@ vdev_ops_t vdev_file_ops = {
+ 	.vdev_op_asize = vdev_default_asize,
+ 	.vdev_op_min_asize = vdev_default_min_asize,
+ 	.vdev_op_min_alloc = NULL,
++	.vdev_op_worst_alloc = NULL,
+ 	.vdev_op_io_start = vdev_file_io_start,
+ 	.vdev_op_io_done = vdev_file_io_done,
+ 	.vdev_op_state_change = NULL,
+@@ -357,6 +358,7 @@ vdev_ops_t vdev_disk_ops = {
+ 	.vdev_op_asize = vdev_default_asize,
+ 	.vdev_op_min_asize = vdev_default_min_asize,
+ 	.vdev_op_min_alloc = NULL,
++	.vdev_op_worst_alloc = NULL,
+ 	.vdev_op_io_start = vdev_file_io_start,
+ 	.vdev_op_io_done = vdev_file_io_done,
+ 	.vdev_op_state_change = NULL,
+diff --git a/module/zfs/spa_misc.c b/module/zfs/spa_misc.c
+index d971b8a31..6bc7e5dd2 100644
+--- a/module/zfs/spa_misc.c
++++ b/module/zfs/spa_misc.c
+@@ -1765,7 +1765,8 @@ spa_get_worst_case_asize(spa_t *spa, uint64_t lsize)
+ {
+ 	if (lsize == 0)
+ 		return (0);	/* No inflation needed */
+-	return (MAX(lsize, 1 << spa->spa_max_ashift) * spa_asize_inflation);
++	return (MAX(lsize, 1 << spa->spa_max_ashift)
++	    * MIN(spa->spa_worst_alloc, spa_asize_inflation));
+ }
+ 
+ /*
+diff --git a/module/zfs/vdev.c b/module/zfs/vdev.c
+index d659ec5bf..fe8be9bd2 100644
+--- a/module/zfs/vdev.c
++++ b/module/zfs/vdev.c
+@@ -365,6 +365,20 @@ vdev_get_min_alloc(vdev_t *vd)
+ 	return (min_alloc);
+ }
+ 
++/*
++ * Get the worst case allocation size for the top-level vdev.
++ */
++uint64_t
++vdev_get_worst_alloc(vdev_t *vd)
++{
++	uint64_t worst_alloc = 1;
++
++	if (vd->vdev_ops->vdev_op_worst_alloc != NULL)
++		worst_alloc = vd->vdev_ops->vdev_op_worst_alloc(vd);
++
++	return (worst_alloc);
++}
++
+ /*
+  * Get the parity level for a top-level vdev.
+  */
+@@ -1390,6 +1404,10 @@ vdev_metaslab_group_create(vdev_t *vd)
+ 			uint64_t min_alloc = vdev_get_min_alloc(vd);
+ 			if (min_alloc < spa->spa_min_alloc)
+ 				spa->spa_min_alloc = min_alloc;
++
++			uint64_t worst_alloc = vdev_get_worst_alloc(vd);
++			if (worst_alloc > spa->spa_worst_alloc)
++				spa->spa_worst_alloc = worst_alloc;
+ 		}
+ 	}
+ }
+@@ -2128,6 +2146,10 @@ vdev_open(vdev_t *vd)
+ 		uint64_t min_alloc = vdev_get_min_alloc(vd);
+ 		if (min_alloc < spa->spa_min_alloc)
+ 			spa->spa_min_alloc = min_alloc;
++
++		uint64_t worst_alloc = vdev_get_worst_alloc(vd);
++		if (worst_alloc > spa->spa_worst_alloc)
++			spa->spa_worst_alloc = worst_alloc;
+ 	}
+ 
+ 	/*
+diff --git a/module/zfs/vdev_draid.c b/module/zfs/vdev_draid.c
+index b8f82d52e..d05213cc2 100644
+--- a/module/zfs/vdev_draid.c
++++ b/module/zfs/vdev_draid.c
+@@ -1150,6 +1150,16 @@ vdev_draid_min_alloc(vdev_t *vd)
+ 	return (vdc->vdc_ndata << vd->vdev_ashift);
+ }
+ 
++static uint64_t
++vdev_draid_worst_alloc(vdev_t *vd)
++{
++	vdev_draid_config_t *vdc = vd->vdev_tsd;
++
++	ASSERT3P(vd->vdev_ops, ==, &vdev_draid_ops);
++
++	return (vdc->vdc_groupwidth);
++}
++
+ /*
+  * Returns true if the txg range does not exist on any leaf vdev.
+  *
+@@ -2271,6 +2281,7 @@ vdev_ops_t vdev_draid_ops = {
+ 	.vdev_op_asize = vdev_draid_asize,
+ 	.vdev_op_min_asize = vdev_draid_min_asize,
+ 	.vdev_op_min_alloc = vdev_draid_min_alloc,
++	.vdev_op_worst_alloc = vdev_draid_worst_alloc,
+ 	.vdev_op_io_start = vdev_draid_io_start,
+ 	.vdev_op_io_done = vdev_draid_io_done,
+ 	.vdev_op_state_change = vdev_draid_state_change,
+@@ -2766,6 +2777,7 @@ vdev_ops_t vdev_draid_spare_ops = {
+ 	.vdev_op_asize = vdev_default_asize,
+ 	.vdev_op_min_asize = vdev_default_min_asize,
+ 	.vdev_op_min_alloc = NULL,
++	.vdev_op_worst_alloc = NULL,
+ 	.vdev_op_io_start = vdev_draid_spare_io_start,
+ 	.vdev_op_io_done = vdev_draid_spare_io_done,
+ 	.vdev_op_state_change = NULL,
+diff --git a/module/zfs/vdev_indirect.c b/module/zfs/vdev_indirect.c
+index 3237dc402..e2ec29ed9 100644
+--- a/module/zfs/vdev_indirect.c
++++ b/module/zfs/vdev_indirect.c
+@@ -1861,6 +1861,7 @@ vdev_ops_t vdev_indirect_ops = {
+ 	.vdev_op_asize = vdev_default_asize,
+ 	.vdev_op_min_asize = vdev_default_min_asize,
+ 	.vdev_op_min_alloc = NULL,
++	.vdev_op_worst_alloc = NULL,
+ 	.vdev_op_io_start = vdev_indirect_io_start,
+ 	.vdev_op_io_done = vdev_indirect_io_done,
+ 	.vdev_op_state_change = NULL,
+diff --git a/module/zfs/vdev_mirror.c b/module/zfs/vdev_mirror.c
+index 5eb331046..9806419cd 100644
+--- a/module/zfs/vdev_mirror.c
++++ b/module/zfs/vdev_mirror.c
+@@ -894,6 +894,7 @@ vdev_ops_t vdev_mirror_ops = {
+ 	.vdev_op_asize = vdev_default_asize,
+ 	.vdev_op_min_asize = vdev_default_min_asize,
+ 	.vdev_op_min_alloc = NULL,
++	.vdev_op_worst_alloc = NULL,
+ 	.vdev_op_io_start = vdev_mirror_io_start,
+ 	.vdev_op_io_done = vdev_mirror_io_done,
+ 	.vdev_op_state_change = vdev_mirror_state_change,
+@@ -919,6 +920,7 @@ vdev_ops_t vdev_replacing_ops = {
+ 	.vdev_op_asize = vdev_default_asize,
+ 	.vdev_op_min_asize = vdev_default_min_asize,
+ 	.vdev_op_min_alloc = NULL,
++	.vdev_op_worst_alloc = NULL,
+ 	.vdev_op_io_start = vdev_mirror_io_start,
+ 	.vdev_op_io_done = vdev_mirror_io_done,
+ 	.vdev_op_state_change = vdev_mirror_state_change,
+@@ -944,6 +946,7 @@ vdev_ops_t vdev_spare_ops = {
+ 	.vdev_op_asize = vdev_default_asize,
+ 	.vdev_op_min_asize = vdev_default_min_asize,
+ 	.vdev_op_min_alloc = NULL,
++	.vdev_op_worst_alloc = NULL,
+ 	.vdev_op_io_start = vdev_mirror_io_start,
+ 	.vdev_op_io_done = vdev_mirror_io_done,
+ 	.vdev_op_state_change = vdev_mirror_state_change,
+diff --git a/module/zfs/vdev_missing.c b/module/zfs/vdev_missing.c
+index e9145fd01..c16d67503 100644
+--- a/module/zfs/vdev_missing.c
++++ b/module/zfs/vdev_missing.c
+@@ -88,6 +88,7 @@ vdev_ops_t vdev_missing_ops = {
+ 	.vdev_op_asize = vdev_default_asize,
+ 	.vdev_op_min_asize = vdev_default_min_asize,
+ 	.vdev_op_min_alloc = NULL,
++	.vdev_op_worst_alloc = NULL,
+ 	.vdev_op_io_start = vdev_missing_io_start,
+ 	.vdev_op_io_done = vdev_missing_io_done,
+ 	.vdev_op_state_change = NULL,
+@@ -113,6 +114,7 @@ vdev_ops_t vdev_hole_ops = {
+ 	.vdev_op_asize = vdev_default_asize,
+ 	.vdev_op_min_asize = vdev_default_min_asize,
+ 	.vdev_op_min_alloc = NULL,
++	.vdev_op_worst_alloc = NULL,
+ 	.vdev_op_io_start = vdev_missing_io_start,
+ 	.vdev_op_io_done = vdev_missing_io_done,
+ 	.vdev_op_state_change = NULL,
+diff --git a/module/zfs/vdev_raidz.c b/module/zfs/vdev_raidz.c
+index 1feebf708..fce11139a 100644
+--- a/module/zfs/vdev_raidz.c
++++ b/module/zfs/vdev_raidz.c
+@@ -1477,6 +1477,20 @@ vdev_raidz_min_asize(vdev_t *vd)
+ 	    vd->vdev_children);
+ }
+ 
++/*
++ * When using RAIDz the worst case allocation size is determined by the level
++ * of parity in the redundancy group.
++ */
++static uint64_t
++vdev_raidz_worst_alloc(vdev_t *vd)
++{
++	vdev_raidz_t *vdrz = vd->vdev_tsd;
++
++	ASSERT3P(vd->vdev_ops, ==, &vdev_raidz_ops);
++
++	return (vdrz->vd_nparity + 1);
++}
++
+ void
+ vdev_raidz_child_done(zio_t *zio)
+ {
+@@ -2532,6 +2546,7 @@ vdev_ops_t vdev_raidz_ops = {
+ 	.vdev_op_asize = vdev_raidz_asize,
+ 	.vdev_op_min_asize = vdev_raidz_min_asize,
+ 	.vdev_op_min_alloc = NULL,
++	.vdev_op_worst_alloc = vdev_raidz_worst_alloc,
+ 	.vdev_op_io_start = vdev_raidz_io_start,
+ 	.vdev_op_io_done = vdev_raidz_io_done,
+ 	.vdev_op_state_change = vdev_raidz_state_change,
+diff --git a/module/zfs/vdev_root.c b/module/zfs/vdev_root.c
+index 45ddc2f71..abb9edc85 100644
+--- a/module/zfs/vdev_root.c
++++ b/module/zfs/vdev_root.c
+@@ -149,6 +149,7 @@ vdev_ops_t vdev_root_ops = {
+ 	.vdev_op_asize = vdev_default_asize,
+ 	.vdev_op_min_asize = vdev_default_min_asize,
+ 	.vdev_op_min_alloc = NULL,
++	.vdev_op_worst_alloc = NULL,
+ 	.vdev_op_io_start = NULL,	/* not applicable to the root */
+ 	.vdev_op_io_done = NULL,	/* not applicable to the root */
+ 	.vdev_op_state_change = vdev_root_state_change,
+-- 
+2.25.1
+

--- a/pkg/new-kernel/patches-zfs-2.1.2/0007-spa_get_worst_case_asize-calculate-RAID-Z-inflation-.patch
+++ b/pkg/new-kernel/patches-zfs-2.1.2/0007-spa_get_worst_case_asize-calculate-RAID-Z-inflation-.patch
@@ -1,0 +1,105 @@
+From f9ba0da534acf6d0b1cb7a2f4ca0c78af231c235 Mon Sep 17 00:00:00 2001
+From: Allan Jude <allan@klarasystems.com>
+Date: Tue, 16 Nov 2021 23:29:06 +0000
+Subject: [PATCH 7/7] spa_get_worst_case_asize: calculate RAID-Z inflation
+ correctly
+
+Rather than just multiplying the logical size by the minimum
+RAID-Z allocation size, we round the lsize up to the next
+multiple of the worst-case minimum allocation size.
+
+Then multiply that by the number of copies.
+
+This replaces spa_asize_inflation which always assumed the worst case
+
+Sponsored-by: Zededa Inc.
+Sponsored-by: Klara Inc.
+Signed-off-by: Allan Jude <allan@klarasystems.com>
+---
+ include/sys/spa.h       |  3 ++-
+ module/zfs/dmu_objset.c |  2 +-
+ module/zfs/dmu_tx.c     |  3 ++-
+ module/zfs/spa_misc.c   | 16 +++++++++++++---
+ 4 files changed, 18 insertions(+), 6 deletions(-)
+
+diff --git a/include/sys/spa.h b/include/sys/spa.h
+index 532926e12..7132a271a 100644
+--- a/include/sys/spa.h
++++ b/include/sys/spa.h
+@@ -1043,7 +1043,8 @@ extern uint64_t spa_version(spa_t *spa);
+ extern pool_state_t spa_state(spa_t *spa);
+ extern spa_load_state_t spa_load_state(spa_t *spa);
+ extern uint64_t spa_freeze_txg(spa_t *spa);
+-extern uint64_t spa_get_worst_case_asize(spa_t *spa, uint64_t lsize);
++extern uint64_t spa_get_worst_case_asize(spa_t *spa, objset_t *os,
++    uint64_t lsize);
+ extern uint64_t spa_get_dspace(spa_t *spa);
+ extern uint64_t spa_get_checkpoint_space(spa_t *spa);
+ extern uint64_t spa_get_slop_space(spa_t *spa);
+diff --git a/module/zfs/dmu_objset.c b/module/zfs/dmu_objset.c
+index af107fb8a..bd7f7c151 100644
+--- a/module/zfs/dmu_objset.c
++++ b/module/zfs/dmu_objset.c
+@@ -2993,7 +2993,7 @@ void
+ dmu_objset_willuse_space(objset_t *os, int64_t space, dmu_tx_t *tx)
+ {
+ 	dsl_dataset_t *ds = os->os_dsl_dataset;
+-	int64_t aspace = spa_get_worst_case_asize(os->os_spa, space);
++	int64_t aspace = spa_get_worst_case_asize(os->os_spa, os, space);
+ 
+ 	if (ds != NULL) {
+ 		dsl_dir_willuse_space(ds->ds_dir, aspace, tx);
+diff --git a/module/zfs/dmu_tx.c b/module/zfs/dmu_tx.c
+index 10e26bbff..6b369d558 100644
+--- a/module/zfs/dmu_tx.c
++++ b/module/zfs/dmu_tx.c
+@@ -957,7 +957,8 @@ dmu_tx_try_assign(dmu_tx_t *tx, uint64_t txg_how)
+ 	}
+ 
+ 	/* needed allocation: worst-case estimate of write space */
+-	uint64_t asize = spa_get_worst_case_asize(tx->tx_pool->dp_spa, towrite);
++	uint64_t asize = spa_get_worst_case_asize(tx->tx_pool->dp_spa,
++	    tx->tx_objset, towrite);
+ 	/* calculate memory footprint estimate */
+ 	uint64_t memory = towrite + tohold;
+ 
+diff --git a/module/zfs/spa_misc.c b/module/zfs/spa_misc.c
+index 6bc7e5dd2..9da813822 100644
+--- a/module/zfs/spa_misc.c
++++ b/module/zfs/spa_misc.c
+@@ -35,6 +35,7 @@
+ #include <sys/zio_checksum.h>
+ #include <sys/zio_compress.h>
+ #include <sys/dmu.h>
++#include <sys/dmu_objset.h>
+ #include <sys/dmu_tx.h>
+ #include <sys/zap.h>
+ #include <sys/zil.h>
+@@ -1761,12 +1762,21 @@ spa_freeze_txg(spa_t *spa)
+  * block anyway.
+  */
+ uint64_t
+-spa_get_worst_case_asize(spa_t *spa, uint64_t lsize)
++spa_get_worst_case_asize(spa_t *spa, objset_t *os, uint64_t lsize)
+ {
++	ASSERT3U(spa->spa_worst_alloc, >, 0);
+ 	if (lsize == 0)
+ 		return (0);	/* No inflation needed */
+-	return (MAX(lsize, 1 << spa->spa_max_ashift)
+-	    * MIN(spa->spa_worst_alloc, spa_asize_inflation));
++
++	uint64_t inflation = roundup(lsize, (1 << spa->spa_max_ashift) *
++	    spa->spa_worst_alloc);
++
++	if (os != NULL && os->os_copies > 0)
++		inflation *= os->os_copies;
++	else
++		inflation *= SPA_DVAS_PER_BP;
++
++	return (inflation);
+ }
+ 
+ /*
+-- 
+2.25.1
+

--- a/pkg/storage-init/storage-init.sh
+++ b/pkg/storage-init/storage-init.sh
@@ -75,7 +75,10 @@ zfs_vdev_sync_write_max_active=35 \
 zfs_vdev_async_read_min_active=1 \
 zfs_vdev_async_read_max_active=10 \
 zfs_vdev_async_write_min_active=1 \
-zfs_vdev_async_write_max_active=10
+zfs_vdev_async_write_max_active=10 \
+\
+zfs_smoothing_scale=50000 \
+zfs_smoothing_write=5
 "
 
     # Disabling SC2086 because word splitting here is intended -


### PR DESCRIPTION
For the reference, these patches can be found in my [zfs fork](https://github.com/zededa-yuri/zfs/tree/2.1.2-smoothing-v3)

    Some of these patches are already in the upstream ZFS repo, others are
    in the process of getting there. We will remove at least some of these
    patches with the next release of ZFS.

    Patches significantly reduce the write amplification, therefore less
    data needs to be written, and fewer uneccessary syncs issued.

    Another feature introduced in the patches is write bandwidth smoothing
    algorithm which prevents huge latency spikes under the heavy load on
    the storage.

# Testing done

```
$ make HV=zfs-kvm pkg/kernel pkg/pillar pkg/storage-init live run

linuxkit-525400123456:~# cat /sys/module/zfs/parameters/zfs_smoothing_scale
50000
linuxkit-525400123456:~# cat /sys/module/zfs/parameters/zfs_smoothing_write
5
```