### PR TITLE
Rework purge to remove old volumes before creating new one

### DIFF
--- a/pkg/pillar/cmd/volumemgr/sizemgmt.go
+++ b/pkg/pillar/cmd/volumemgr/sizemgmt.go
@@ -42,8 +42,9 @@ func getRemainingDiskSpace(ctxPtr *volumemgrContext) (uint64, error) {
 		sizeToUseInCalculation := uint64(iterVolumeStatus.CurrentSize)
 		if cfg == nil {
 			// we have no config with this volume, so it will be purged
-			log.Noticef("getRemainingDiskSpace: Volume %s not found in VolumeConfigs, use CurrentSize",
+			log.Noticef("getRemainingDiskSpace: Volume %s not found in VolumeConfigs, ignore",
 				iterVolumeStatus.Key())
+			continue
 		} else if cfg.ReadOnly {
 			// it is ReadOnly and will not grow
 			log.Noticef("getRemainingDiskSpace: Volume %s is ReadOnly, use CurrentSize",

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -1525,6 +1525,7 @@ func parseVolumeRefList(volumeRefConfigList []types.VolumeRefConfig,
 		volume.GenerationCounter = volumeRef.GenerationCount
 		volume.RefCount = 1
 		volume.MountDir = volumeRef.GetMountDir()
+		volume.VerifyOnly = true
 		volumeRefConfigList[idx] = *volume
 		idx++
 	}

--- a/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
+++ b/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
@@ -16,13 +16,17 @@ import (
 // MaybeAddVolumeRefConfig publishes volume ref config with refcount
 // to the volumemgr
 func MaybeAddVolumeRefConfig(ctx *zedmanagerContext, appInstID uuid.UUID,
-	volumeID uuid.UUID, generationCounter int64, mountDir string) {
+	volumeID uuid.UUID, generationCounter int64, mountDir string, verifyOnly bool) {
 
 	key := fmt.Sprintf("%s#%d", volumeID.String(), generationCounter)
 	log.Functionf("MaybeAddVolumeRefConfig for %s", key)
 	m := lookupVolumeRefConfig(ctx, key)
 	if m != nil {
 		m.RefCount++
+		// only update from VerifyOnly to non-VerifyOnly
+		if m.VerifyOnly {
+			m.VerifyOnly = verifyOnly
+		}
 		log.Functionf("VolumeRefConfig exists for %s to refcount %d",
 			key, m.RefCount)
 		publishVolumeRefConfig(ctx, m)
@@ -33,6 +37,7 @@ func MaybeAddVolumeRefConfig(ctx *zedmanagerContext, appInstID uuid.UUID,
 			GenerationCounter: generationCounter,
 			RefCount:          1,
 			MountDir:          mountDir,
+			VerifyOnly:        verifyOnly,
 		}
 		publishVolumeRefConfig(ctx, &vrc)
 	}

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -569,7 +569,7 @@ func handleCreate(ctxArg interface{}, key string,
 			log.Warnf("handleCreate(%v) for %s found different purge counter %d vs. %d",
 				config.UUIDandVersion, config.DisplayName, c,
 				config.PurgeCmd.Counter)
-			status.PurgeInprogress = types.RecreateVolumes
+			status.PurgeInprogress = types.DownloadAndVerify
 			status.State = types.PURGING
 			// We persist the PurgeCmd Counter when
 			// PurgeInprogress is done
@@ -594,6 +594,7 @@ func handleCreate(ctxArg interface{}, key string,
 		vrs.MountDir = vrc.MountDir
 		vrs.PendingAdd = true
 		vrs.State = types.INITIAL
+		vrs.VerifyOnly = true
 	}
 
 	allErrors := ""
@@ -703,7 +704,7 @@ func handleModify(ctxArg interface{}, key string,
 			log.Functionf("Removing error %s", status.Error)
 			status.ClearErrorWithSource()
 		}
-		status.PurgeInprogress = types.RecreateVolumes
+		status.PurgeInprogress = types.DownloadAndVerify
 		status.State = types.PURGING
 		// We persist the PurgeCmd Counter when PurgeInprogress is done
 	} else if needPurge {

--- a/pkg/pillar/types/volumetypes.go
+++ b/pkg/pillar/types/volumetypes.go
@@ -238,6 +238,7 @@ type VolumeRefConfig struct {
 	GenerationCounter int64
 	RefCount          uint
 	MountDir          string
+	VerifyOnly        bool
 }
 
 // Key : VolumeRefConfig unique key
@@ -313,6 +314,7 @@ type VolumeRefStatus struct {
 	MountDir           string
 	PendingAdd         bool // Flag to identify whether volume ref config published or not
 	WWN                string
+	VerifyOnly         bool
 
 	ErrorAndTimeWithSource
 }

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -252,9 +252,10 @@ type Inprogress uint8
 
 // NotInprogress and other values for Inprogress
 const (
-	NotInprogress   Inprogress = iota
-	RecreateVolumes            // Download and verify new images if need be
+	NotInprogress     Inprogress = iota
+	DownloadAndVerify            // Download and verify new images if need be
 	BringDown
+	RecreateVolumes
 	BringUp
 )
 


### PR DESCRIPTION
Currently as part of make before break this means that zedmanager asks
volummgr to create the new volume, and when that is done it halts the
application and restarts it.

To save on diskspace (not have 2X of the volumes) it makes more sense:
to have zedmanager asks volumemgr to ensure that all the content has
been downloaded and verified;
zedmanager asks domainmgr to halt the task;
zedmanager asks volumemgr to delete the old volume and create the new
volume;
zedmanager asks domainmgr to start the task with the new volume

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>