### PR TITLE
Remove use of openssl

### DIFF
--- a/pkg/debug/Dockerfile
+++ b/pkg/debug/Dockerfile
@@ -12,7 +12,7 @@ ENV BUILD_PKGS abuild curl tar make linux-headers patch g++ git gcc ncurses-dev 
 # forget to check on all supported architectures: e.g. arm64
 # binaries are typically larger and amd64 ones).
 # RUN apk add --no-cache gdb valgrind
-ENV PKGS openssh-client openssh-server tini util-linux ca-certificates pciutils usbutils vim tcpdump perf strace iproute2-minimal
+ENV PKGS openssl openssh-client openssh-server tini util-linux ca-certificates pciutils usbutils vim tcpdump perf strace iproute2-minimal
 RUN eve-alpine-deploy.sh
 
 ENV LSHW_VERSION 02.19.2

--- a/pkg/guacd/Dockerfile
+++ b/pkg/guacd/Dockerfile
@@ -1,6 +1,6 @@
 FROM lfedge/eve-alpine:6.7.0 as build
 ENV BUILD_PKGS cairo-dev jpeg-dev libpng-dev gcc make libc-dev openssl-dev libvncserver-dev file patch
-ENV PKGS alpine-baselayout musl-utils libtasn1-progs p11-kit cairo jpeg libpng openssl libvncserver
+ENV PKGS alpine-baselayout musl-utils libtasn1-progs p11-kit cairo jpeg libpng libvncserver
 RUN eve-alpine-deploy.sh
 
 ENV GUACD_VERSION=1.0.0

--- a/pkg/pillar/Dockerfile
+++ b/pkg/pillar/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 FROM lfedge/eve-alpine:6.7.0 as build
 ENV BUILD_PKGS git gcc linux-headers libc-dev make linux-pam-dev m4 findutils go util-linux make patch wget
-ENV PKGS alpine-baselayout musl-utils libtasn1-progs pciutils yajl xz bash openssl iptables ip6tables iproute2 dhcpcd coreutils dmidecode libbz2 libuuid ipset curl radvd ethtool util-linux e2fsprogs libcrypto1.1 xorriso qemu-img jq e2fsprogs-extra keyutils ca-certificates ip6tables-openrc iptables-openrc ipset-openrc hdparm
+ENV PKGS alpine-baselayout musl-utils libtasn1-progs pciutils yajl xz bash iptables ip6tables iproute2 dhcpcd coreutils dmidecode libbz2 libuuid ipset curl radvd ethtool util-linux e2fsprogs libcrypto1.1 xorriso qemu-img jq e2fsprogs-extra keyutils ca-certificates ip6tables-openrc iptables-openrc ipset-openrc hdparm
 RUN eve-alpine-deploy.sh
 
 # FIXME bump eve-alpine to alpine 3.14

--- a/pkg/pillar/cmd/upgradeconverter/moveconfigitem.go
+++ b/pkg/pillar/cmd/upgradeconverter/moveconfigitem.go
@@ -5,6 +5,8 @@ package upgradeconverter
 
 import (
 	"os"
+
+	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 )
 
 func moveConfigItemValueMap(ctxPtr *ucContext) error {
@@ -42,7 +44,7 @@ func moveConfigItemValueMap(ctxPtr *ucContext) error {
 	}
 
 	log.Functionf("Copy from %s to %s", oldFile, newFile)
-	err := CopyFile(oldFile, newFile)
+	err := fileutils.CopyFile(oldFile, newFile)
 	if err != nil {
 		log.Error(err)
 		return err

--- a/pkg/pillar/cmd/upgradeconverter/persistlayout.go
+++ b/pkg/pillar/cmd/upgradeconverter/persistlayout.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/lf-edge/eve/pkg/pillar/containerd"
+	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 
 	uuid "github.com/satori/go.uuid"
 )
@@ -131,7 +132,7 @@ func maybeMove(oldPath string, oldModTime time.Time, newPath string, noFlag bool
 			return
 		}
 		if fi.IsDir() {
-			if err := CopyDir(oldPath, newPath); err != nil {
+			if err := fileutils.CopyDir(oldPath, newPath); err != nil {
 				log.Errorf("cp old to new failed: %s", err)
 			} else {
 				err := os.RemoveAll(oldPath)

--- a/pkg/pillar/cmd/upgradeconverter/renameverifiedfiles.go
+++ b/pkg/pillar/cmd/upgradeconverter/renameverifiedfiles.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 )
 
 const (
@@ -106,7 +107,7 @@ func copyRenameDelete(srcFile, dstFile string) {
 			return
 		}
 	}
-	if err := CopyFile(srcFile, dstTmpFile); err != nil {
+	if err := fileutils.CopyFile(srcFile, dstTmpFile); err != nil {
 		log.Errorf("Copy failed: %s", err)
 	} else if err := os.Rename(dstTmpFile, dstFile); err != nil {
 		log.Errorf("Rename to %s failed: %s", dstFile, err)

--- a/pkg/pillar/types/locationconsts.go
+++ b/pkg/pillar/types/locationconsts.go
@@ -46,7 +46,8 @@ const (
 	RootCertFileName = IdentityDirname + "/root-certificate.pem"
 	// V2TLSCertShaFilename - find TLS root cert for API V2 based on this sha
 	V2TLSCertShaFilename = CertificateDirname + "/v2tlsbaseroot-certificates.sha256"
-
+	// V2TLSBaseFile is where the initial file
+	V2TLSBaseFile = IdentityDirname + "/v2tlsbaseroot-certificates.pem"
 	// APIV1FileName - user can statically allow for API v1
 	APIV1FileName = IdentityDirname + "/Force-API-V1"
 

--- a/pkg/pillar/utils/file/copy.go
+++ b/pkg/pillar/utils/file/copy.go
@@ -21,7 +21,7 @@
  * SOFTWARE.
  */
 
-package upgradeconverter
+package utils
 
 import (
 	"fmt"

--- a/pkg/pillar/zedbox/zedbox.go
+++ b/pkg/pillar/zedbox/zedbox.go
@@ -48,6 +48,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/pubsub/reverse"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub/socketdriver"
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/lf-edge/eve/pkg/pillar/zedcloud"
 	"github.com/sirupsen/logrus"
 )
 
@@ -132,6 +133,10 @@ func main() {
 		sep := entrypoint{f: runZedbox, inline: inlineAlways}
 		logger, log = agentlog.Init(basename)
 		inline := true
+		err := zedcloud.InitializeCertDir(log)
+		if err != nil {
+			log.Fatal(err)
+		}
 		retval := runService(basename, sep, inline)
 		// Not likely to ever return, but for uniformity ...
 		os.Exit(retval)


### PR DESCRIPTION
We already rely on the golang crypto package for 99% of the code. This replaces the remaining use of sha256 with golang.

Note that we add openssl package to the debug container in case there are debug cases to check/dump the certificates.