### PR TITLE
Add debug.enable.vga support

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -25,6 +25,7 @@
 | network.fallback.any.eth | "enabled" or "disabled" | enabled | if no connectivity try any Ethernet, WiFi, or LTE |
 | network.download.max.cost | 0-255 | 0 | [max port cost for download](DEVICE-CONNECTIVITY.md) to avoid e.g., LTE ports |
 | debug.enable.usb | boolean | false | allow USB e.g. keyboards on device |
+| debug.enable.vga | boolean | false | allow VGA console on device |
 | debug.enable.ssh | authorized ssh key | empty string(ssh disabled) | allow ssh to EVE |
 | debug.default.loglevel | string | info | min level saved in files on device |
 | debug.default.remote.loglevel | string | warning | min level sent to controller |

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -2151,14 +2151,15 @@ func parseConfigItems(config *zconfig.EdgeDevConfig, ctx *getconfigContext) {
 	//  value or retain the previous value.
 	gcPtr := &ctx.zedagentCtx.globalConfig
 	newGlobalConfig := types.DefaultConfigItemValueMap()
-	// Note: UsbAccess is special in that it has two defaults.
+	// Note: UsbAccess and VgaAccess are special in that they has two defaults.
 	// When the device first boots the default is "true" as specified
 	// in the DefaultConfigItemValueMap. But when connecting to the
 	// controller, if the controller does not include the item, it
 	// should default to "false".
 	// That way bringup of new hardware models can be done using an
-	// attached keyboard.
+	// attached keyboard and monitor.
 	newGlobalConfig.SetGlobalValueBool(types.UsbAccess, false)
+	newGlobalConfig.SetGlobalValueBool(types.VgaAccess, false)
 	newGlobalStatus := types.NewGlobalStatus()
 
 	for _, item := range items {

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -173,6 +173,8 @@ const (
 	// Bool Items
 	// UsbAccess global setting key
 	UsbAccess GlobalSettingKey = "debug.enable.usb"
+	// VgaAccess global setting to enable host VGA console if it is not assigned to an application
+	VgaAccess GlobalSettingKey = "debug.enable.vga"
 	// AllowAppVnc global setting key
 	AllowAppVnc GlobalSettingKey = "app.allow.vnc"
 	// EveMemoryLimitInBytes global setting key
@@ -755,6 +757,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 
 	// Add Bool Items
 	configItemSpecMap.AddBoolItem(UsbAccess, true) // Controller likely default to false
+	configItemSpecMap.AddBoolItem(VgaAccess, true) // Controller likely default to false
 	configItemSpecMap.AddBoolItem(AllowAppVnc, false)
 	configItemSpecMap.AddBoolItem(IgnoreMemoryCheckForApps, false)
 	configItemSpecMap.AddBoolItem(IgnoreDiskCheckForApps, false)

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -174,6 +174,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		DownloadMaxPortCost,
 		// Bool Items
 		UsbAccess,
+		VgaAccess,
 		AllowAppVnc,
 		EveMemoryLimitInBytes,
 		IgnoreMemoryCheckForApps,

--- a/pkg/pillar/types/ifnametopci.go
+++ b/pkg/pillar/types/ifnametopci.go
@@ -252,3 +252,15 @@ func IfRename(log *base.LogObject, ifname string, newIfname string) error {
 	}
 	return nil
 }
+
+// PCIIsBootVga return 'true' if VGA device is a console device
+func PCIIsBootVga(log *base.LogObject, long string) (bool, error) {
+	log.Functionf("PCIIsBootVga %s", long)
+
+	bootVgaFile := pciPath + "/" + long + "/boot_vga"
+	if isBoot, err := ioutil.ReadFile(bootVgaFile); err != nil {
+		return false, err
+	} else {
+		return strings.TrimSpace(strings.TrimSuffix(string(isBoot), "\n")) == "1", err
+	}
+}


### PR DESCRIPTION
Sometimes it is required to debug EVE issues when HW is accessible directly e.g. in the field but access to the cloud is problematic e.g. due to bad connectivity.
    
Another case is EVE onboarding problems when SSH is not yet available.
    
VGA console may help in both cases. We only return VGA devices that were marked as boot devices. Console output won't be visible on others anyway. It also allows us to debug issues using VGA console while other GPUs are still  assigned to aplications
