### PR TITLE
[zfs] Accounting for memory under zfs_arc_mem when creating applications

### DIFF
--- a/docs/ZFS.md
+++ b/docs/ZFS.md
@@ -3,8 +3,8 @@
 ZFS provides a rich set of functionality but at a cost of extra
 resource usage. Currently ARC (Adaptive Replacement Cache) size is
 limited to `min(256 MiB + 0.3% of total zpool size, 20% of system RAM)` but at least 384
-MiB. Keep in mind that this memory will be taken out form the
-applications.
+MiB. This RAM is included in the memory EVE reserves for its own operational needs.
+Thus would this memory not be available for allocation for applications.
 
 If system does not have enough memory to satisfy the limit mentioned
 above, severe performance degradation can occur on random access

--- a/pkg/pillar/cmd/zedmanager/memorysizemgmt.go
+++ b/pkg/pillar/cmd/zedmanager/memorysizemgmt.go
@@ -5,9 +5,12 @@ package zedmanager
 
 import (
 	"fmt"
+	"io/ioutil"
+	"strconv"
 	"strings"
 
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/lf-edge/eve/pkg/pillar/vault"
 )
 
 // getRemainingMemory returns how many bytes remain for app instance usage
@@ -40,6 +43,18 @@ func getRemainingMemory(ctxPtr *zedmanagerContext) (uint64, uint64, uint64, erro
 		}
 	}
 	memoryReservedForEve := ctxPtr.globalConfig.GlobalValueInt(types.EveMemoryLimitInBytes)
+	if vault.ReadPersistType() == types.PersistZFS {
+		byteCountStr, err := ioutil.ReadFile("/sys/module/zfs/parameters/zfs_arc_max")
+		if err != nil {
+			return 0, 0, 0, fmt.Errorf("failed to get data from zfs_arc_max. error: %v", err)
+		}
+		zfsArcMaxLimit, err := strconv.Atoi(string(byteCountStr))
+		if err != nil {
+			return 0, 0, 0, fmt.Errorf("failed to convert zfs_arc_max in to int: value: %s err: %v", byteCountStr, err)
+		} else {
+			memoryReservedForEve += uint32(zfsArcMaxLimit)
+		}
+	}
 	usedMemorySize += uint64(memoryReservedForEve)
 	deviceMemorySize, err := sysTotalMemory(ctxPtr)
 	if err != nil {


### PR DESCRIPTION
This fix allows you to take into account the memory required
for the operation of zfs_arc_mem (Adaptive Replacement Cache)
when calculating free memory when creating applications.