### PR TITLE
Rework zedUpload to support another endpoint

### DIFF
--- a/libs/zedUpload/datastore_azure.go
+++ b/libs/zedUpload/datastore_azure.go
@@ -116,7 +116,7 @@ func (ep *AzureTransportMethod) WithLogging(onoff bool) error {
 // File upload to Azure Blob Datastore
 func (ep *AzureTransportMethod) processAzureUpload(req *DronaRequest) (string, error) {
 	file := req.name
-	loc, err := azure.UploadAzureBlob(ep.acName, ep.acKey, ep.container, file, req.objloc, ep.hClient)
+	loc, err := azure.UploadAzureBlob(ep.aurl, ep.acName, ep.acKey, ep.container, file, req.objloc, ep.hClient)
 	if err != nil {
 		return loc, err
 	}
@@ -146,7 +146,7 @@ func (ep *AzureTransportMethod) processAzureDownload(req *DronaRequest) error {
 			}
 		}(req, prgChan)
 	}
-	doneParts, err := azure.DownloadAzureBlob(ep.acName, ep.acKey, ep.container, file, req.objloc, req.sizelimit, ep.hClient, req.doneParts, prgChan)
+	doneParts, err := azure.DownloadAzureBlob(ep.aurl, ep.acName, ep.acKey, ep.container, file, req.objloc, req.sizelimit, ep.hClient, req.doneParts, prgChan)
 	req.doneParts = doneParts
 	if err != nil {
 		return err
@@ -156,7 +156,7 @@ func (ep *AzureTransportMethod) processAzureDownload(req *DronaRequest) error {
 
 // File delete from Azure Blob Datastore
 func (ep *AzureTransportMethod) processAzureBlobDelete(req *DronaRequest) error {
-	err := azure.DeleteAzureBlob(ep.acName, ep.acKey, ep.container, req.name, ep.hClient)
+	err := azure.DeleteAzureBlob(ep.aurl, ep.acName, ep.acKey, ep.container, req.name, ep.hClient)
 	//log.Printf("Azure Blob delete status: %v", status)
 	return err
 }
@@ -165,7 +165,7 @@ func (ep *AzureTransportMethod) processAzureBlobDelete(req *DronaRequest) error 
 func (ep *AzureTransportMethod) processAzureBlobList(req *DronaRequest) ([]string, error, int) {
 	var csize int
 	var img []string
-	img, err := azure.ListAzureBlob(ep.acName, ep.acKey, ep.container, ep.hClient)
+	img, err := azure.ListAzureBlob(ep.aurl, ep.acName, ep.acKey, ep.container, ep.hClient)
 	if err != nil {
 		return img, err, csize
 	}
@@ -173,7 +173,7 @@ func (ep *AzureTransportMethod) processAzureBlobList(req *DronaRequest) ([]strin
 }
 
 func (ep *AzureTransportMethod) processAzureBlobMetaData(req *DronaRequest) (int64, string, error) {
-	size, md5, err := azure.GetAzureBlobMetaData(ep.acName, ep.acKey, ep.container, req.name, ep.hClient)
+	size, md5, err := azure.GetAzureBlobMetaData(ep.aurl, ep.acName, ep.acKey, ep.container, req.name, ep.hClient)
 	if err != nil {
 		return 0, "", err
 	}
@@ -185,11 +185,11 @@ func (ep *AzureTransportMethod) getContext() *DronaCtx {
 }
 
 func (ep *AzureTransportMethod) processAzureUploadByChunks(req *DronaRequest) error {
-	return azure.UploadPartByChunk(ep.acName, ep.acKey, ep.container, req.localName, req.UploadID, ep.hClient, bytes.NewReader(req.Adata))
+	return azure.UploadPartByChunk(ep.aurl, ep.acName, ep.acKey, ep.container, req.localName, req.UploadID, ep.hClient, bytes.NewReader(req.Adata))
 }
 
 func (ep *AzureTransportMethod) processAzureDownloadByChunks(req *DronaRequest) error {
-	readCloser, size, err := azure.DownloadAzureBlobByChunks(ep.acName, ep.acKey, ep.container, req.name, req.objloc, ep.hClient)
+	readCloser, size, err := azure.DownloadAzureBlobByChunks(ep.aurl, ep.acName, ep.acKey, ep.container, req.name, req.objloc, ep.hClient)
 	if err != nil {
 		return err
 	}
@@ -204,11 +204,11 @@ func (ep *AzureTransportMethod) processAzureDownloadByChunks(req *DronaRequest) 
 }
 
 func (ep *AzureTransportMethod) processGenerateBlobSasURI(req *DronaRequest) (string, error) {
-	return azure.GenerateBlobSasURI(ep.acName, ep.acKey, ep.container, req.localName, ep.hClient, req.Duration)
+	return azure.GenerateBlobSasURI(ep.aurl, ep.acName, ep.acKey, ep.container, req.localName, ep.hClient, req.Duration)
 }
 
 func (ep *AzureTransportMethod) processPutBlockListIntoBlob(req *DronaRequest) error {
-	return azure.UploadBlockListToBlob(ep.acName, ep.acKey, ep.container, req.localName, ep.hClient, req.Blocks)
+	return azure.UploadBlockListToBlob(ep.aurl, ep.acName, ep.acKey, ep.container, req.localName, ep.hClient, req.Blocks)
 }
 
 func (ep *AzureTransportMethod) NewRequest(opType SyncOpType, objname, objloc string, sizelimit int64, ackback bool, reply chan *DronaRequest) *DronaRequest {

--- a/pkg/pillar/cmd/downloader/download.go
+++ b/pkg/pillar/cmd/downloader/download.go
@@ -71,7 +71,7 @@ func download(ctx *downloaderContext, trType zedUpload.SyncTransportType,
 	case zedUpload.SyncHttpTr, zedUpload.SyncSftpTr:
 		dEndPoint, err = ctx.dCtx.NewSyncerDest(trType, downloadURL, dpath, auth)
 	case zedUpload.SyncAzureTr:
-		dEndPoint, err = ctx.dCtx.NewSyncerDest(trType, "", dpath, auth)
+		dEndPoint, err = ctx.dCtx.NewSyncerDest(trType, downloadURL, dpath, auth)
 	case zedUpload.SyncAwsTr:
 		dEndPoint, err = ctx.dCtx.NewSyncerDest(trType, region, dpath, auth)
 	case zedUpload.SyncOCIRegistryTr:

--- a/pkg/pillar/cmd/downloader/syncop.go
+++ b/pkg/pillar/cmd/downloader/syncop.go
@@ -113,7 +113,17 @@ func handleSyncOp(ctx *downloaderContext, key string,
 			Password: dsCtx.Password,
 		}
 		trType = zedUpload.SyncAzureTr
-		serverURL = dsCtx.DownloadURL
+		serverURL = strings.TrimSpace(dst.Fqdn)
+		// if fqdn is defined, ensure that we have scheme defined
+		// if not, assume it is https
+		if serverURL != "" {
+			u, err := url.Parse(serverURL)
+			if err != nil {
+				errStr = fmt.Sprintf("invalid fqdn(%s): %s", serverURL, err)
+			} else if u.Scheme == "" {
+				serverURL = fmt.Sprintf("https://%s", serverURL)
+			}
+		}
 		// pass in the config.Name instead of 'filename' which
 		// does not contain the prefix of the relative path with '/'s
 		remoteName = config.Name

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_azure.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_azure.go
@@ -116,7 +116,7 @@ func (ep *AzureTransportMethod) WithLogging(onoff bool) error {
 // File upload to Azure Blob Datastore
 func (ep *AzureTransportMethod) processAzureUpload(req *DronaRequest) (string, error) {
 	file := req.name
-	loc, err := azure.UploadAzureBlob(ep.acName, ep.acKey, ep.container, file, req.objloc, ep.hClient)
+	loc, err := azure.UploadAzureBlob(ep.aurl, ep.acName, ep.acKey, ep.container, file, req.objloc, ep.hClient)
 	if err != nil {
 		return loc, err
 	}
@@ -146,7 +146,7 @@ func (ep *AzureTransportMethod) processAzureDownload(req *DronaRequest) error {
 			}
 		}(req, prgChan)
 	}
-	doneParts, err := azure.DownloadAzureBlob(ep.acName, ep.acKey, ep.container, file, req.objloc, req.sizelimit, ep.hClient, req.doneParts, prgChan)
+	doneParts, err := azure.DownloadAzureBlob(ep.aurl, ep.acName, ep.acKey, ep.container, file, req.objloc, req.sizelimit, ep.hClient, req.doneParts, prgChan)
 	req.doneParts = doneParts
 	if err != nil {
 		return err
@@ -156,7 +156,7 @@ func (ep *AzureTransportMethod) processAzureDownload(req *DronaRequest) error {
 
 // File delete from Azure Blob Datastore
 func (ep *AzureTransportMethod) processAzureBlobDelete(req *DronaRequest) error {
-	err := azure.DeleteAzureBlob(ep.acName, ep.acKey, ep.container, req.name, ep.hClient)
+	err := azure.DeleteAzureBlob(ep.aurl, ep.acName, ep.acKey, ep.container, req.name, ep.hClient)
 	//log.Printf("Azure Blob delete status: %v", status)
 	return err
 }
@@ -165,7 +165,7 @@ func (ep *AzureTransportMethod) processAzureBlobDelete(req *DronaRequest) error 
 func (ep *AzureTransportMethod) processAzureBlobList(req *DronaRequest) ([]string, error, int) {
 	var csize int
 	var img []string
-	img, err := azure.ListAzureBlob(ep.acName, ep.acKey, ep.container, ep.hClient)
+	img, err := azure.ListAzureBlob(ep.aurl, ep.acName, ep.acKey, ep.container, ep.hClient)
 	if err != nil {
 		return img, err, csize
 	}
@@ -173,7 +173,7 @@ func (ep *AzureTransportMethod) processAzureBlobList(req *DronaRequest) ([]strin
 }
 
 func (ep *AzureTransportMethod) processAzureBlobMetaData(req *DronaRequest) (int64, string, error) {
-	size, md5, err := azure.GetAzureBlobMetaData(ep.acName, ep.acKey, ep.container, req.name, ep.hClient)
+	size, md5, err := azure.GetAzureBlobMetaData(ep.aurl, ep.acName, ep.acKey, ep.container, req.name, ep.hClient)
 	if err != nil {
 		return 0, "", err
 	}
@@ -185,11 +185,11 @@ func (ep *AzureTransportMethod) getContext() *DronaCtx {
 }
 
 func (ep *AzureTransportMethod) processAzureUploadByChunks(req *DronaRequest) error {
-	return azure.UploadPartByChunk(ep.acName, ep.acKey, ep.container, req.localName, req.UploadID, ep.hClient, bytes.NewReader(req.Adata))
+	return azure.UploadPartByChunk(ep.aurl, ep.acName, ep.acKey, ep.container, req.localName, req.UploadID, ep.hClient, bytes.NewReader(req.Adata))
 }
 
 func (ep *AzureTransportMethod) processAzureDownloadByChunks(req *DronaRequest) error {
-	readCloser, size, err := azure.DownloadAzureBlobByChunks(ep.acName, ep.acKey, ep.container, req.name, req.objloc, ep.hClient)
+	readCloser, size, err := azure.DownloadAzureBlobByChunks(ep.aurl, ep.acName, ep.acKey, ep.container, req.name, req.objloc, ep.hClient)
 	if err != nil {
 		return err
 	}
@@ -204,11 +204,11 @@ func (ep *AzureTransportMethod) processAzureDownloadByChunks(req *DronaRequest) 
 }
 
 func (ep *AzureTransportMethod) processGenerateBlobSasURI(req *DronaRequest) (string, error) {
-	return azure.GenerateBlobSasURI(ep.acName, ep.acKey, ep.container, req.localName, ep.hClient, req.Duration)
+	return azure.GenerateBlobSasURI(ep.aurl, ep.acName, ep.acKey, ep.container, req.localName, ep.hClient, req.Duration)
 }
 
 func (ep *AzureTransportMethod) processPutBlockListIntoBlob(req *DronaRequest) error {
-	return azure.UploadBlockListToBlob(ep.acName, ep.acKey, ep.container, req.localName, ep.hClient, req.Blocks)
+	return azure.UploadBlockListToBlob(ep.aurl, ep.acName, ep.acKey, ep.container, req.localName, ep.hClient, req.Blocks)
 }
 
 func (ep *AzureTransportMethod) NewRequest(opType SyncOpType, objname, objloc string, sizelimit int64, ackback bool, reply chan *DronaRequest) *DronaRequest {


### PR DESCRIPTION
Currently, we hardcode `blob.core.windows.net`, seems we should support other endpoints. They should be defined inside datastore's `Fqdn` [field](https://github.com/lf-edge/eve/blob/6941dbe720015a39826f9a308b10f8451684f0bf/api/go/config/storage.pb.go#L439) in notation that is accessible from azure portal (i.e. `tryazureeve.blob.core.windows.net` or `https://tryazureeve.blob.core.windows.net` or ``https://tryazureeve.blob.core.windows.net/``).
In case of empty Fqdn received we will use the old logic.