### PR TITLE
Use context with timeout in sending to the cloud functions

### DIFF
--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -511,7 +511,9 @@ func myPost(zedcloudCtx *zedcloud.ZedCloudContext, tlsConfig *tls.Config,
 	requrl string, retryCount int, reqlen int64, b *bytes.Buffer) (bool, *http.Response, types.SenderResult, []byte) {
 
 	zedcloudCtx.TlsConfig = tlsConfig
-	resp, contents, senderStatus, err := zedcloud.SendOnAllIntf(zedcloudCtx,
+	ctxWork, cancel := zedcloud.GetContextForAllIntfFunctions(zedcloudCtx)
+	defer cancel()
+	resp, contents, senderStatus, err := zedcloud.SendOnAllIntf(ctxWork, zedcloudCtx,
 		requrl, reqlen, b, retryCount, bailOnHTTPErr)
 	if err != nil {
 		switch senderStatus {

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -1034,7 +1034,7 @@ func myGet(ctx *diagContext, reqURL string, ifname string,
 			ifname, proxyURL.String(), reqURL)
 	}
 	const allowProxy = true
-	resp, contents, senderStatus, err := zedcloud.SendOnIntf(zedcloudCtx,
+	resp, contents, senderStatus, err := zedcloud.SendOnIntf(context.Background(), zedcloudCtx,
 		reqURL, ifname, 0, nil, allowProxy, ctx.usingOnboardCert)
 	if err != nil {
 		switch senderStatus {
@@ -1098,7 +1098,7 @@ func myPost(ctx *diagContext, reqURL string, ifname string,
 			ifname, proxyURL.String(), reqURL)
 	}
 	const allowProxy = true
-	resp, contents, senderStatus, err := zedcloud.SendOnIntf(zedcloudCtx,
+	resp, contents, senderStatus, err := zedcloud.SendOnIntf(context.Background(), zedcloudCtx,
 		reqURL, ifname, reqlen, b, allowProxy, ctx.usingOnboardCert)
 	if err != nil {
 		switch senderStatus {

--- a/pkg/pillar/cmd/loguploader/loguploader.go
+++ b/pkg/pillar/cmd/loguploader/loguploader.go
@@ -768,11 +768,13 @@ func sendToCloud(ctx *loguploaderContext, data []byte, iter int, fName string, f
 	}
 	startTime := time.Now()
 
+	ctxWork, cancel := zedcloud.GetContextForAllIntfFunctions(ctx.zedcloudCtx)
+	defer cancel()
 	// if resp statusOK, then sent success
 	// otherwise have to retry the same file later:
 	//  - if resp is nil, or it's 'StatusServiceUnavailable', mark as serviceUnavailabe
 	//  - if resp is 4xx, the file maybe moved to 'failtosend' directory later
-	resp, contents, _, err := zedcloud.SendOnAllIntf(ctx.zedcloudCtx, logsURL, size, buf, iter, true)
+	resp, contents, _, err := zedcloud.SendOnAllIntf(ctxWork, ctx.zedcloudCtx, logsURL, size, buf, iter, true)
 	if resp != nil {
 		if resp.StatusCode == http.StatusOK {
 			latency := time.Since(startTime).Nanoseconds() / int64(time.Millisecond)

--- a/pkg/pillar/cmd/zedagent/attesttask.go
+++ b/pkg/pillar/cmd/zedagent/attesttask.go
@@ -77,7 +77,9 @@ func trySendToController(attestReq *attest.ZAttestReq, iteration int) (*http.Res
 	size := int64(proto.Size(attestReq))
 	attestURL := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API,
 		devUUID, "attest")
-	return zedcloud.SendOnAllIntf(zedcloudCtx, attestURL,
+	ctxWork, cancel := zedcloud.GetContextForAllIntfFunctions(zedcloudCtx)
+	defer cancel()
+	return zedcloud.SendOnAllIntf(ctxWork, zedcloudCtx, attestURL,
 		size, buf, iteration, true)
 }
 

--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -204,7 +204,10 @@ func getCertsFromController(ctx *zedagentContext) bool {
 		return false
 	}
 
-	resp, contents, rtf, err := zedcloud.SendOnAllIntf(zedcloudCtx,
+	ctxWork, cancel := zedcloud.GetContextForAllIntfFunctions(zedcloudCtx)
+	defer cancel()
+
+	resp, contents, rtf, err := zedcloud.SendOnAllIntf(ctxWork, zedcloudCtx,
 		certURL, 0, nil, 0, false)
 	if err != nil {
 		switch rtf {

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -284,7 +284,9 @@ func getLatestConfig(url string, iteration int,
 	}
 	buf := bytes.NewBuffer(b)
 	size := int64(proto.Size(cr))
-	resp, contents, senderStatus, err := zedcloud.SendOnAllIntf(zedcloudCtx, url, size, buf, iteration, bailOnHTTPErr)
+	ctxWork, cancel := zedcloud.GetContextForAllIntfFunctions(zedcloudCtx)
+	defer cancel()
+	resp, contents, senderStatus, err := zedcloud.SendOnAllIntf(ctxWork, zedcloudCtx, url, size, buf, iteration, bailOnHTTPErr)
 	if err != nil {
 		newCount := types.LedBlinkConnectingToController
 		switch senderStatus {

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -1418,7 +1418,9 @@ func SendProtobuf(url string, buf *bytes.Buffer, size int64,
 	iteration int) error {
 
 	const bailOnHTTPErr = true // For 4xx and 5xx HTTP errors we don't try other interfaces
-	resp, _, _, err := zedcloud.SendOnAllIntf(zedcloudCtx, url,
+	ctxWork, cancel := zedcloud.GetContextForAllIntfFunctions(zedcloudCtx)
+	defer cancel()
+	resp, _, _, err := zedcloud.SendOnAllIntf(ctxWork, zedcloudCtx, url,
 		size, buf, iteration, bailOnHTTPErr)
 	if resp != nil {
 		switch resp.StatusCode {
@@ -1453,7 +1455,9 @@ func SendMetricsProtobuf(ctx *getconfigContext, ReportMetrics *metrics.ZMetricMs
 	size := int64(proto.Size(ReportMetrics))
 	metricsUrl := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, devUUID, "metrics")
 	const bailOnHTTPErr = false
-	_, _, rtf, err := zedcloud.SendOnAllIntf(zedcloudCtx, metricsUrl,
+	ctxWork, cancel := zedcloud.GetContextForAllIntfFunctions(zedcloudCtx)
+	defer cancel()
+	_, _, rtf, err := zedcloud.SendOnAllIntf(ctxWork, zedcloudCtx, metricsUrl,
 		size, buf, iteration, bailOnHTTPErr)
 	if err != nil {
 		// Hopefully next timeout will be more successful

--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -626,7 +626,9 @@ func publishFlowMessage(flowMsg *flowlog.FlowMessage, iteration int) error {
 
 	flowlogURL := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, devUUID, "flowlog")
 	const bailOnHTTPErr = false
-	_, _, rtf, err := zedcloud.SendOnAllIntf(zedcloudCtx, flowlogURL,
+	ctxWork, cancel := zedcloud.GetContextForAllIntfFunctions(zedcloudCtx)
+	defer cancel()
+	_, _, rtf, err := zedcloud.SendOnAllIntf(ctxWork, zedcloudCtx, flowlogURL,
 		size, buf, iteration, bailOnHTTPErr)
 	if err != nil {
 		err = fmt.Errorf("publishFlowMessage: SendOnAllIntf failed with %d: %s",

--- a/pkg/pillar/cmd/zedrouter/probe.go
+++ b/pkg/pillar/cmd/zedrouter/probe.go
@@ -6,6 +6,7 @@
 package zedrouter
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"io/ioutil"
@@ -397,7 +398,7 @@ func launchHostProbe(ctx *zedrouterContext) {
 						startTime := time.Now()
 						const allowProxy = true
 						const useOnboard = false
-						resp, _, _, err := zedcloud.SendOnIntf(&zcloudCtx, remoteURL, info.IfName, 0, nil, allowProxy, useOnboard)
+						resp, _, _, err := zedcloud.SendOnIntf(context.Background(), &zcloudCtx, remoteURL, info.IfName, 0, nil, allowProxy, useOnboard)
 						if err != nil {
 							log.Tracef("launchHostProbe: send on intf %s, err %v\n", info.IfName, err)
 						}

--- a/pkg/pillar/devicenetwork/wpad.go
+++ b/pkg/pillar/devicenetwork/wpad.go
@@ -4,6 +4,7 @@
 package devicenetwork
 
 import (
+	"context"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -104,7 +105,7 @@ func getPacFile(ctx *DeviceNetworkContext, status *types.DeviceNetworkStatus, ur
 	// Avoid using a proxy to fetch the wpad.dat; 15 second timeout
 	const allowProxy = false
 	const useOnboard = false
-	resp, contents, _, err := zedcloud.SendOnIntf(&zedcloudCtx, url, ifname, 0, nil,
+	resp, contents, _, err := zedcloud.SendOnIntf(context.Background(), &zedcloudCtx, url, ifname, 0, nil,
 		allowProxy, useOnboard)
 	if err != nil {
 		return "", err

--- a/pkg/pillar/zedcloud/deferred.go
+++ b/pkg/pillar/zedcloud/deferred.go
@@ -101,6 +101,8 @@ func (ctx *DeferredContext) handleDeferred(log *base.LogObject, event time.Time,
 
 	exit := false
 	sent := 0
+	ctxWork, cancel := GetContextForAllIntfFunctions(ctx.zedcloudCtx)
+	defer cancel()
 	for _, f := range ctx.priorityCheckFunctions {
 		for _, item := range ctx.deferredItems {
 			key := item.key
@@ -119,7 +121,7 @@ func (ctx *DeferredContext) handleDeferred(log *base.LogObject, event time.Time,
 			}
 
 			//SenderStatusNone indicates no problems
-			resp, _, result, err := SendOnAllIntf(ctx.zedcloudCtx, item.url,
+			resp, _, result, err := SendOnAllIntf(ctxWork, ctx.zedcloudCtx, item.url,
 				item.size, item.buf, ctx.iteration, item.bailOnHTTPErr)
 			if item.bailOnHTTPErr && resp != nil &&
 				resp.StatusCode >= 400 && resp.StatusCode < 600 {


### PR DESCRIPTION
We can possibly consume long time when we try to send an information to the cloud with long delays/lot of interfaces.
To not hit watchdog I add context with timeout.