### PR TITLE
Run potentialUUIDUpdate on 400 and on attest problems

### DIFF
--- a/pkg/pillar/zedcloud/deferred.go
+++ b/pkg/pillar/zedcloud/deferred.go
@@ -238,6 +238,31 @@ func (ctx *DeferredContext) setDeferred(zedcloudCtx *ZedCloudContext,
 	}
 }
 
+// RemoveDeferred removes key from deferred items if exists
+func RemoveDeferred(zedcloudCtx *ZedCloudContext, key string) {
+	zedcloudCtx.deferredCtx.removeDeferred(zedcloudCtx, key)
+}
+
+func (ctx *DeferredContext) removeDeferred(zedcloudCtx *ZedCloudContext, key string) {
+	ctx.lock.Lock()
+	defer ctx.lock.Unlock()
+
+	log := zedcloudCtx.log
+	log.Functionf("RemoveDeferred(%s) items %d",
+		key, len(ctx.deferredItems))
+
+	for ind, itemList := range ctx.deferredItems {
+		if itemList.key == key {
+			log.Tracef("Deleting key %s", key)
+			ctx.deferredItems = append(ctx.deferredItems[:ind], ctx.deferredItems[ind+1:]...)
+			break
+		}
+	}
+	if len(ctx.deferredItems) == 0 {
+		stopTimer(log, ctx)
+	}
+}
+
 // Try every minute backoff to every 15 minutes
 func startTimer(log *base.LogObject, ctx *DeferredContext) {
 

--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -117,7 +117,7 @@ func SendOnAllIntf(ctx *ZedCloudContext, url string, reqlen int64, b *bytes.Buff
 			switch resp.StatusCode {
 			case http.StatusServiceUnavailable:
 				senderStatus = types.SenderStatusUpgrade
-			case http.StatusNotFound:
+			case http.StatusNotFound, http.StatusBadRequest:
 				senderStatus = types.SenderStatusNotFound
 			}
 		}


### PR DESCRIPTION
As described in the APIv2 documentation, we should assume that the
device does not exist in the controller if the controller returns 400.
Also seems we do not run potentialUUIDUpdate before successful
attestation, but we should.
Also we must remove old attest message on change and push new.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>