### PR TITLE
Use logicalreferenced as actualSize of zvol

### DIFF
--- a/pkg/pillar/zfs/zfs.go
+++ b/pkg/pillar/zfs/zfs.go
@@ -152,11 +152,11 @@ func GetZFSVolumeInfo(log *base.LogObject, device string) (*types.ImgInfo, error
 		return nil, fmt.Errorf("GetDatasetByDevice returns empty for device: %s",
 			device)
 	}
-	referenced, err := GetDatasetOption(log, dataset, "referenced")
+	logicalreferenced, err := GetDatasetOption(log, dataset, "logicalreferenced")
 	if err != nil {
 		return nil, fmt.Errorf("GetZFSVolumeInfo GetDatasetOption failed: %s", err)
 	}
-	imgInfo.ActualSize, err = strconv.ParseUint(referenced, 10, 64)
+	imgInfo.ActualSize, err = strconv.ParseUint(logicalreferenced, 10, 64)
 	if err != nil {
 		return nil, fmt.Errorf("GetZFSVolumeInfo: failed to parse referenced: %s", err)
 	}


### PR DESCRIPTION
Seems reasonable to show size of zvol before compression to not confuse
user with free space that is not visible from inside of VM

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>