### PR TITLE
Implement appinfo extension for purge/restart command requests

### DIFF
--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -108,6 +109,8 @@ type getconfigContext struct {
 	triggerRadioPOST chan Notify
 
 	localAppInfoPOSTTicker flextimer.FlexTickerHandle
+	localAppCommands       types.LocalAppCommands
+	localAppCommandsLock   sync.Mutex
 
 	callProcessLocalProfileServerChange bool //did we already call processLocalProfileServerChange
 
@@ -377,7 +380,7 @@ func getLatestConfig(url string, iteration int,
 		publishZedAgentStatus(getconfigCtx)
 
 		log.Tracef("Configuration from zedcloud is unchanged")
-		// Update modification time since checked by readSavedProtoMessage
+		// Update modification time since checked by readSavedConfig
 		touchReceivedProtoMessage()
 		return false
 	}
@@ -413,77 +416,77 @@ func getLatestConfig(url string, iteration int,
 
 	if !changed {
 		log.Tracef("Configuration from zedcloud is unchanged")
-		// Update modification time since checked by readSavedProtoMessage
+		// Update modification time since checked by readSavedConfig
 		touchReceivedProtoMessage()
 		return false
 	}
-	writeReceivedProtoMessage(contents)
+	saveReceivedProtoMessage(contents)
 
 	return inhaleDeviceConfig(config, getconfigCtx, false)
 }
 
-func writeReceivedProtoMessage(contents []byte) {
-	writeProtoMessage("lastconfig", contents)
+func saveReceivedProtoMessage(contents []byte) {
+	saveConfig("lastconfig", contents)
 }
 
 // Update timestamp - no content changes
 func touchReceivedProtoMessage() {
-	touchProtoMessage("lastconfig")
+	touchSavedConfig("lastconfig")
 }
 
 // XXX for debug we track these
-func writeSentMetricsProtoMessage(contents []byte) {
-	writeProtoMessage("lastmetrics", contents)
+func saveSentMetricsProtoMessage(contents []byte) {
+	saveConfig("lastmetrics", contents)
 }
 
 // XXX for debug we track these
-func writeSentDeviceInfoProtoMessage(contents []byte) {
-	writeProtoMessage("lastdeviceinfo", contents)
+func saveSentDeviceInfoProtoMessage(contents []byte) {
+	saveConfig("lastdeviceinfo", contents)
 }
 
 // XXX for debug we track these
-func writeSentAppInfoProtoMessage(contents []byte) {
-	writeProtoMessage("lastappinfo", contents)
+func saveSentAppInfoProtoMessage(contents []byte) {
+	saveConfig("lastappinfo", contents)
 }
 
-func writeProtoMessage(filename string, contents []byte) {
+func saveConfig(filename string, contents []byte) {
 	filename = checkpointDirname + "/" + filename
 	err := fileutils.WriteRename(filename, contents)
 	if err != nil {
 		// Can occur if no space in filesystem
-		log.Errorf("writeProtoMessage failed: %s", err)
+		log.Errorf("saveConfig failed: %s", err)
 		return
 	}
 }
 
-// remove saved proto file if exists
-func cleanSavedProtoMessage(filename string) {
+// Remove saved config file if it exists.
+func cleanSavedConfig(filename string) {
 	filename = checkpointDirname + "/" + filename
 	if err := os.Remove(filename); err != nil {
-		log.Functionf("cleanSavedProtoMessage failed: %s", err)
+		log.Functionf("cleanSavedConfig failed: %s", err)
 	}
 }
 
 // Update modification time
-func touchProtoMessage(filename string) {
+func touchSavedConfig(filename string) {
 	filename = checkpointDirname + "/" + filename
 	_, err := os.Stat(filename)
 	if err != nil {
-		log.Warnf("touchProtoMessage stat failed: %s", err)
+		log.Warnf("touchSavedConfig stat failed: %s", err)
 	}
 	currentTime := time.Now()
 	err = os.Chtimes(filename, currentTime, currentTime)
 	if err != nil {
 		// Can occur if no space in filesystem?
-		log.Errorf("touchProtoMessage failed: %s", err)
+		log.Errorf("touchSavedConfig failed: %s", err)
 	}
 }
 
 // If the file exists then read the config, and return is modify time
-// Ignore if if older than StaleConfigTime seconds
+// Ignore if older than StaleConfigTime seconds
 func readSavedProtoMessageConfig(staleConfigTime uint32,
 	filename string, force bool) (*zconfig.EdgeDevConfig, time.Time, error) {
-	contents, ts, err := readSavedProtoMessage(staleConfigTime, filename, force)
+	contents, ts, err := readSavedConfig(staleConfigTime, filename, force)
 	if err != nil {
 		log.Errorln("readSavedProtoMessageConfig", err)
 		return nil, ts, err
@@ -499,9 +502,9 @@ func readSavedProtoMessageConfig(staleConfigTime uint32,
 	return config, ts, nil
 }
 
-// If the file exists then read the proto message from it, and return its modify time
-// Ignore if if older than staleTime seconds
-func readSavedProtoMessage(staleTime uint32,
+// If the file exists then read the config content from it, and return its modify time.
+// Ignore if older than staleTime seconds.
+func readSavedConfig(staleTime uint32,
 	filename string, force bool) ([]byte, time.Time, error) {
 	info, err := os.Stat(filename)
 	if err != nil {
@@ -514,14 +517,14 @@ func readSavedProtoMessage(staleTime uint32,
 	age := time.Since(info.ModTime())
 	staleLimit := time.Second * time.Duration(staleTime)
 	if !force && age > staleLimit {
-		errStr := fmt.Sprintf("savedProto too old: age %v limit %d\n",
+		errStr := fmt.Sprintf("saved config too old: age %v limit %d\n",
 			age, staleLimit)
 		log.Errorln(errStr)
 		return nil, info.ModTime(), nil
 	}
 	contents, err := ioutil.ReadFile(filename)
 	if err != nil {
-		log.Errorln("readSavedProtoMessage", err)
+		log.Errorln("readSavedConfig", err)
 		return nil, info.ModTime(), err
 	}
 	return contents, info.ModTime(), nil
@@ -638,6 +641,7 @@ func publishZedAgentStatus(getconfigCtx *getconfigContext) {
 		ForceFallbackCounter: ctx.forceFallbackCounter,
 		CurrentProfile:       getconfigCtx.currentProfile,
 		RadioSilence:         getconfigCtx.radioSilence,
+		LocalAppCommands:     getconfigCtx.localAppCommands,
 	}
 	pub := getconfigCtx.pubZedAgentStatus
 	pub.Publish(agentName, status)

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -1465,7 +1465,7 @@ func SendMetricsProtobuf(ctx *getconfigContext, ReportMetrics *metrics.ZMetricMs
 		return
 	} else {
 		maybeUpdateMetricsTimer(ctx, true)
-		writeSentMetricsProtoMessage(data)
+		saveSentMetricsProtoMessage(data)
 	}
 }
 

--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -635,7 +635,7 @@ func publishFlowMessage(flowMsg *flowlog.FlowMessage, iteration int) error {
 			rtf, err)
 		return err
 	}
-	writeSentFlowProtoMessage(data)
+	saveSentFlowProtoMessage(data)
 	return nil
 }
 
@@ -644,8 +644,8 @@ func timeNanoToProto(timenum int64) *timestamp.Timestamp {
 	return timeProto
 }
 
-func writeSentFlowProtoMessage(contents []byte) {
-	writeProtoMessage("lastflowlog", contents)
+func saveSentFlowProtoMessage(contents []byte) {
+	saveConfig("lastflowlog", contents)
 }
 
 func handleAppContainerMetricsCreate(ctxArg interface{}, key string,

--- a/pkg/pillar/cmd/zedagent/localinfo.go
+++ b/pkg/pillar/cmd/zedagent/localinfo.go
@@ -4,10 +4,10 @@
 package zedagent
 
 import (
-	"bytes"
-	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -15,17 +15,18 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/flextimer"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/zedcloud"
+	uuid "github.com/satori/go.uuid"
 )
 
 const (
 	localAppInfoURLPath               = "/api/v1/appinfo"
 	localAppInfoPOSTInterval          = time.Minute
 	localAppInfoPOSTThrottledInterval = time.Hour
+	savedAppCommandsFile              = "appcommands"
 )
 
 var (
-	lastLocalAppInfoSentHash []byte
-	throttledLocalAppInfo    bool
+	throttledLocalAppInfo bool
 )
 
 //updateLocalAppInfoTicker sets ticker options to the initial value
@@ -45,6 +46,12 @@ func initializeLocalAppInfo(ctx *getconfigContext) {
 	max := 1.1 * float64(localAppInfoPOSTInterval)
 	min := 0.8 * max
 	ctx.localAppInfoPOSTTicker = flextimer.NewRangeTicker(time.Duration(min), time.Duration(max))
+	if loadSavedAppCommands(ctx) {
+		publishZedAgentStatus(ctx)
+	} else {
+		// Write the initial empty content.
+		persistAppCommands(ctx.localAppCommands)
+	}
 }
 
 func triggerLocalAppInfoPOST(ctx *getconfigContext) {
@@ -56,7 +63,8 @@ func triggerLocalAppInfoPOST(ctx *getconfigContext) {
 	ctx.localAppInfoPOSTTicker.TickNow()
 }
 
-// Run a periodic POST request to send information message about apps to local server.
+// Run a periodic POST request to send information message about apps to local server
+// and optionally receive app commands to run in the response.
 func localAppInfoPOSTTask(ctx *getconfigContext) {
 
 	log.Functionf("localAppInfoPOSTTask: waiting for localAppInfoPOSTTicker")
@@ -77,9 +85,8 @@ func localAppInfoPOSTTask(ctx *getconfigContext) {
 		select {
 		case <-ctx.localAppInfoPOSTTicker.C:
 			start := time.Now()
-
-			sendLocalAppInfo(ctx)
-
+			appCmds := postLocalAppInfo(ctx)
+			processReceivedAppCommands(ctx, appCmds)
 			ctx.zedagentCtx.ps.CheckMaxTimeTopic(wdName, "localAppInfoPOSTTask", start,
 				warningTime, errorTime)
 		case <-stillRunning.C:
@@ -88,66 +95,174 @@ func localAppInfoPOSTTask(ctx *getconfigContext) {
 	}
 }
 
-func sendLocalAppInfo(ctx *getconfigContext) {
+// Post the current state of locally running application instances to the local server
+// and optionally receive a set of app commands to run in the response.
+func postLocalAppInfo(ctx *getconfigContext) *profile.LocalAppCmdList {
 	localProfileServer := ctx.localProfileServer
 	if localProfileServer == "" {
-		return
+		return nil
 	}
 	localServerURL, err := makeLocalServerBaseURL(localProfileServer)
 	if err != nil {
 		log.Errorf("sendLocalAppInfo: makeLocalServerBaseURL: %v", err)
-		return
+		return nil
 	}
 	if !ctx.localServerMap.upToDate {
 		err := updateLocalServerMap(ctx, localServerURL)
 		if err != nil {
 			log.Errorf("sendLocalAppInfo: updateLocalServerMap: %v", err)
-			return
+			return nil
 		}
 	}
 	srvMap := ctx.localServerMap.servers
 	if len(srvMap) == 0 {
 		log.Functionf("sendLocalAppInfo: cannot find any configured apps for localServerURL: %s",
 			localServerURL)
-		return
+		return nil
 	}
 
 	localInfo := prepareLocalInfo(ctx)
-
-	h := sha256.New()
-	computeConfigElementSha(h, localInfo)
-	newHash := h.Sum(nil)
-
-	if bytes.Equal(lastLocalAppInfoSentHash, newHash) {
-		log.Functionln("sendLocalAppInfo: no update")
-		return
-	}
-
 	var errList []string
 	for bridgeName, servers := range srvMap {
 		for _, srv := range servers {
 			fullURL := srv.localServerAddr + localAppInfoURLPath
+			appCmds := &profile.LocalAppCmdList{}
 			resp, err := zedcloud.SendLocalProto(
-				zedcloudCtx, fullURL, bridgeName, srv.bridgeIP, localInfo, nil)
+				zedcloudCtx, fullURL, bridgeName, srv.bridgeIP, localInfo, appCmds)
 			if err != nil {
 				errList = append(errList, fmt.Sprintf("SendLocalProto: %v", err))
 				continue
 			}
-			if resp.StatusCode == http.StatusNotFound {
-				//throttle sending to be about once per hour
+			switch resp.StatusCode {
+			case http.StatusNotFound:
+				// Throttle sending to be about once per hour.
 				updateLocalAppInfoTicker(ctx, true)
-			}
-			if resp.StatusCode != http.StatusOK {
+				return nil
+			case http.StatusOK:
+				if len(appCmds.AppCommands) != 0 {
+					if appCmds.GetServerToken() != ctx.profileServerToken {
+						errList = append(errList,
+							fmt.Sprintf("invalid token submitted by local server (%s)", appCmds.GetServerToken()))
+						continue
+					}
+					updateLocalAppInfoTicker(ctx, false)
+					return appCmds
+				}
+				// No content in the response.
+				fallthrough
+			case http.StatusNoContent:
+				log.Functionf("Local server %s does not require additional app commands to execute",
+					localServerURL)
+				updateLocalAppInfoTicker(ctx, false)
+				return nil
+			default:
 				errList = append(errList, fmt.Sprintf("SendLocal: wrong response status code: %d",
 					resp.StatusCode))
 				continue
 			}
-			updateLocalAppInfoTicker(ctx, false)
-			lastLocalAppInfoSentHash = newHash
-			return
 		}
 	}
 	log.Errorf("sendLocalAppInfo: all attempts failed: %s", strings.Join(errList, ";"))
+	return nil
+}
+
+func processReceivedAppCommands(ctx *getconfigContext, cmdList *profile.LocalAppCmdList) {
+	ctx.localAppCommandsLock.Lock()
+	defer ctx.localAppCommandsLock.Unlock()
+	if cmdList == nil {
+		// Nothing requested by local server, just refresh the persisted config.
+		touchAppCommands()
+		return
+	}
+	var cmdChanges bool
+	for _, appCmdReq := range cmdList.AppCommands {
+		var err error
+		appUUID := nilUUID
+		if appCmdReq.Id != "" {
+			appUUID, err = uuid.FromString(appCmdReq.Id)
+			if err != nil {
+				log.Warnf("Failed to parse UUID from app command request: %v", err)
+				continue
+			}
+		}
+		displayName := appCmdReq.Displayname
+		if appUUID == nilUUID && displayName == "" {
+			log.Warnf("App command request is missing both UUID and display name: %+v",
+				appCmdReq)
+			continue
+		}
+		// Try to find the application instance.
+		ais := findAppInstance(ctx, appUUID, displayName)
+		if ais == nil {
+			log.Warnf("Failed to find app instance with UUID=%s, displayName=%s",
+				appUUID, displayName)
+			continue
+		}
+		appUUID = ais.UUIDandVersion.UUID
+		command := types.AppCommand(appCmdReq.Command)
+		appCmd := ctx.localAppCommands.LookupByAppUUID(appUUID)
+		if appCmd != nil {
+			// Entry for this app already exists.
+			if appCmd.Command == command &&
+				appCmd.LocalServerTimestamp == appCmdReq.Timestamp {
+				// already accepted
+				continue
+			}
+			appCmd.Command = command
+			appCmd.LocalServerTimestamp = appCmdReq.Timestamp
+			appCmd.DeviceTimestamp = time.Now()
+			appCmd.Completed = false
+			cmdChanges = true
+			continue
+		}
+		// Add new entry.
+		ctx.localAppCommands.Cmds = append(ctx.localAppCommands.Cmds,
+			types.LocalAppCommand{
+				AppUUID:              appUUID,
+				Command:              command,
+				LocalServerTimestamp: appCmdReq.Timestamp,
+				DeviceTimestamp:      time.Now(),
+				Completed:            false,
+			})
+		cmdChanges = true
+	}
+	if cmdChanges {
+		publishZedAgentStatus(ctx)
+		persistAppCommands(ctx.localAppCommands)
+	} else {
+		// No actual configuration change to apply, just refresh the persisted config.
+		touchAppCommands()
+	}
+}
+
+func processAppCommandStatus(ctx *getconfigContext, appStatus types.AppInstanceStatus) {
+	ctx.localAppCommandsLock.Lock()
+	defer ctx.localAppCommandsLock.Unlock()
+	appCmdStatus := appStatus.LocalCommand
+	if appCmdStatus.Command == types.AppCommandUnspecified {
+		return
+	}
+	if !appCmdStatus.Completed {
+		// Command has not yet completed, nothing to update.
+		return
+	}
+	appCmd := ctx.localAppCommands.LookupByAppUUID(appStatus.UUIDandVersion.UUID)
+	if appCmd == nil {
+		log.Warnf("Missing entry for app command: %+v", appStatus.LocalCommand)
+		return
+	}
+	var updated bool
+	if appCmd.LastCompletedTimestamp != appCmdStatus.LocalServerTimestamp {
+		appCmd.LastCompletedTimestamp = appCmdStatus.LocalServerTimestamp
+		updated = true
+	}
+	if !appCmd.Completed && appCmd.SameCommand(appCmdStatus) {
+		appCmd.Completed = true
+		updated = true
+	}
+	if updated {
+		persistAppCommands(ctx.localAppCommands)
+	}
 }
 
 func prepareLocalInfo(ctx *getconfigContext) *profile.LocalAppInfoList {
@@ -160,9 +275,80 @@ func prepareLocalInfo(ctx *getconfigContext) *profile.LocalAppInfoList {
 		zinfoAppInst.Name = ais.DisplayName
 		zinfoAppInst.Err = encodeErrorInfo(ais.ErrorAndTimeWithSource.ErrorDescription)
 		zinfoAppInst.State = ais.State.ZSwState()
+		ctx.localAppCommandsLock.Lock()
+		for _, appCmd := range ctx.localAppCommands.Cmds {
+			if appCmd.AppUUID == ais.UUIDandVersion.UUID {
+				zinfoAppInst.LastCmdTimestamp = appCmd.LastCompletedTimestamp
+				break
+			}
+		}
+		ctx.localAppCommandsLock.Unlock()
 		msg.AppsInfo = append(msg.AppsInfo, zinfoAppInst)
 		return true
 	}
 	ctx.subAppInstanceStatus.Iterate(addAppInstanceFunc)
 	return &msg
+}
+
+func findAppInstance(
+	ctx *getconfigContext, appUUID uuid.UUID, displayName string) (appInst *types.AppInstanceStatus) {
+	matchApp := func(_ string, value interface{}) bool {
+		ais := value.(types.AppInstanceStatus)
+		if (appUUID == nilUUID || appUUID == ais.UUIDandVersion.UUID) &&
+			(displayName == "" || displayName == ais.DisplayName) {
+			appInst = &ais
+			// stop iteration
+			return false
+		}
+		return true
+	}
+	ctx.subAppInstanceStatus.Iterate(matchApp)
+	return appInst
+}
+
+func readSavedAppCommands(ctx *getconfigContext) (types.LocalAppCommands, error) {
+	appCommands := types.LocalAppCommands{}
+	contents, ts, err := readSavedConfig(
+		ctx.zedagentCtx.globalConfig.GlobalValueInt(types.StaleConfigTime),
+		filepath.Join(checkpointDirname, savedAppCommandsFile), false)
+	if err != nil {
+		return appCommands, err
+	}
+	if contents != nil {
+		err := json.Unmarshal(contents, &appCommands)
+		if err != nil {
+			return appCommands, err
+		}
+		log.Noticef("Using saved app commands dated %s",
+			ts.Format(time.RFC3339Nano))
+		return appCommands, nil
+	}
+	return appCommands, nil
+}
+
+// loadSavedAppCommands reads saved application commands and sets it.
+func loadSavedAppCommands(ctx *getconfigContext) bool {
+	appCommands, err := readSavedAppCommands(ctx)
+	if err != nil {
+		log.Errorf("readSavedAppCommands failed: %v", err)
+		return false
+	}
+	log.Noticef("Starting with app commands: %+v", appCommands)
+	ctx.localAppCommands = appCommands
+	return true
+}
+
+func persistAppCommands(cmds types.LocalAppCommands) {
+	contents, err := json.Marshal(cmds)
+	if err != nil {
+		log.Fatalf("persistAppCommands: Marshalling failed: %v", err)
+	}
+	saveConfig(savedAppCommandsFile, contents)
+	return
+}
+
+// touchAppCommands is used to update the modification time of the persisted
+// application commands.
+func touchAppCommands() {
+	touchSavedConfig(savedAppCommandsFile)
 }

--- a/pkg/pillar/cmd/zedagent/radiosilence.go
+++ b/pkg/pillar/cmd/zedagent/radiosilence.go
@@ -27,7 +27,7 @@ func initializeRadioConfig(ctx *getconfigContext) {
 	ctx.triggerRadioPOST = make(chan Notify, 1)
 	if !loadSavedRadioConfig(ctx) {
 		// invalid or missing configuration - overwrite with the default
-		writeRadioConfig(&profile.RadioConfig{RadioSilence: false})
+		saveRadioConfig(&profile.RadioConfig{RadioSilence: false})
 	}
 	ctx.radioSilence.ChangeRequestedAt = time.Now()
 	ctx.radioSilence.ChangeInProgress = true
@@ -212,7 +212,7 @@ func getRadioConfig(ctx *getconfigContext, radioStatus *profile.RadioStatus) *pr
 				// no actual configuration change to apply, just refresh the persisted config
 				touchRadioConfig()
 			} else {
-				writeRadioConfig(radioConfig)
+				saveRadioConfig(radioConfig)
 			}
 			return radioConfig
 		}
@@ -223,7 +223,7 @@ func getRadioConfig(ctx *getconfigContext, radioStatus *profile.RadioStatus) *pr
 
 // read saved radio config in case of a reboot
 func readSavedRadioConfig(ctx *getconfigContext) (*profile.RadioConfig, error) {
-	radioConfigBytes, ts, err := readSavedProtoMessage(
+	radioConfigBytes, ts, err := readSavedConfig(
 		ctx.zedagentCtx.globalConfig.GlobalValueInt(types.StaleConfigTime),
 		filepath.Join(checkpointDirname, savedRadioConfigFile), false)
 	if err != nil {
@@ -258,17 +258,17 @@ func loadSavedRadioConfig(ctx *getconfigContext) bool {
 	return true
 }
 
-// writeRadioConfig saves received RadioConfig into the persisted partition.
-func writeRadioConfig(radioConfig *profile.RadioConfig) {
+// saveRadioConfig saves received RadioConfig into the persisted partition.
+func saveRadioConfig(radioConfig *profile.RadioConfig) {
 	contents, err := proto.Marshal(radioConfig)
 	if err != nil {
-		log.Fatalf("writeRadioConfig: Marshalling failed: %v", err)
+		log.Fatalf("saveRadioConfig: Marshalling failed: %v", err)
 	}
-	writeProtoMessage(savedRadioConfigFile, contents)
+	saveConfig(savedRadioConfigFile, contents)
 	return
 }
 
 // touchRadioConfig is used to update the modification time of the persisted radio config.
 func touchRadioConfig() {
-	touchProtoMessage(savedRadioConfigFile)
+	touchSavedConfig(savedRadioConfigFile)
 }

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -1681,6 +1681,7 @@ func handleAppInstanceStatusCreate(ctxArg interface{}, key string,
 	PublishAppInfoToZedCloud(ctx, uuidStr, &status, ctx.assignableAdapters,
 		ctx.iteration)
 	triggerPublishDevInfo(ctx)
+	processAppCommandStatus(ctx.getconfigCtx, status)
 	triggerLocalAppInfoPOST(ctx.getconfigCtx)
 	ctx.iteration++
 	log.Functionf("handleAppInstanceStatusCreate(%s) DONE", key)
@@ -1698,6 +1699,7 @@ func handleAppInstanceStatusModify(ctxArg interface{}, key string,
 	uuidStr := status.Key()
 	PublishAppInfoToZedCloud(ctx, uuidStr, &status, ctx.assignableAdapters,
 		ctx.iteration)
+	processAppCommandStatus(ctx.getconfigCtx, status)
 	triggerLocalAppInfoPOST(ctx.getconfigCtx)
 	ctx.iteration++
 	log.Functionf("handleAppInstanceStatusModify(%s) DONE", key)
@@ -2141,10 +2143,10 @@ func getDeferredSentHandlerFunction(ctx *zedagentContext) *zedcloud.SentHandlerF
 				return
 			}
 			if el, ok := itemType.(info.ZInfoTypes); ok && el == info.ZInfoTypes_ZiDevice {
-				writeSentDeviceInfoProtoMessage(data.Bytes())
+				saveSentDeviceInfoProtoMessage(data.Bytes())
 			}
 			if el, ok := itemType.(info.ZInfoTypes); ok && el == info.ZInfoTypes_ZiApp {
-				writeSentAppInfoProtoMessage(data.Bytes())
+				saveSentAppInfoProtoMessage(data.Bytes())
 			}
 			if el, ok := itemType.(attest.ZAttestReqType); ok && el == attest.ZAttestReqType_ATTEST_REQ_CERT {
 				log.Noticef("sendAttestReqProtobuf: Sent EdgeNodeCerts")

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -678,6 +678,7 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 				status.Key())
 			status.RestartInprogress = types.NotInprogress
 			status.State = types.RUNNING
+			updateLocalCommand(ctx, status)
 			changed = true
 		} else {
 			log.Functionf("RestartInprogress(%s) waiting for Activated",
@@ -690,6 +691,7 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 				status.Key())
 			status.PurgeInprogress = types.NotInprogress
 			status.State = types.RUNNING
+			updateLocalCommand(ctx, status)
 			changed = true
 		} else {
 			log.Functionf("PurgeInprogress(%s) waiting for Activated",

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -154,7 +154,9 @@ type AppInstanceStatus struct {
 	BootTime            time.Time
 	IoAdapterList       []IoAdapter // Report what was actually used
 	RestartInprogress   Inprogress
+	RestartStartedAt    time.Time
 	PurgeInprogress     Inprogress
+	PurgeStartedAt      time.Time
 
 	// Mininum state across all steps and all StorageStatus.
 	// Error* set implies error.
@@ -163,6 +165,9 @@ type AppInstanceStatus struct {
 	MissingMemory  bool // Waiting for memory
 
 	EffectiveActivate bool //set here effective activate after profile check and apply
+
+	// Status of the application command (purge, restart) requested via the local profile server.
+	LocalCommand LocalAppCommand
 
 	// All error strings across all steps and all StorageStatus
 	// ErrorAndTimeWithSource provides SetError, SetErrrorWithSource, etc


### PR DESCRIPTION
This commit implements the extension to the `/api/v1/appinfo` local profile
endpoint, which allows the server to submit purge/restart commands
for locally running application instances.

This functionality is already documented in `api/PROFILE.md` under
`AppInfo`.

Test is prepared here: https://github.com/lf-edge/eden/pull/744

Signed-off-by: Milan Lenco <milan@zededa.com>