### PR TITLE
Fix dynamic IPs allocation for several interfaces in the same network

### DIFF
--- a/pkg/pillar/base/logobjecttypes.go
+++ b/pkg/pillar/base/logobjecttypes.go
@@ -154,8 +154,8 @@ const (
 	MemoryNotificationType = "memory_notification"
 	// DiskNotificationType
 	DiskNotificationType = "disk_notification"
-	// UUIDPairToNumLogType:
-	UUIDPairToNumLogType LogObjectType = "uuid_pair_to_num"
+	// UUIDPairToNumAndIfIdxLogType:
+	UUIDPairToNumAndIfIdxLogType LogObjectType = "uuid_pair_and_if_idx_to_num"
 	// EncryptedVaultKeyFromDeviceLogType:
 	EncryptedVaultKeyFromDeviceLogType LogObjectType = "encrypted_vault_key_from_device"
 	// EncryptedVaultKeyFromControllerLogType:

--- a/pkg/pillar/cmd/upgradeconverter/UUIDPairToNumConvert.go
+++ b/pkg/pillar/cmd/upgradeconverter/UUIDPairToNumConvert.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2022 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package upgradeconverter
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	uuid "github.com/satori/go.uuid"
+)
+
+// UUIDPairToNum used for appNum on network instance
+type UUIDPairToNum struct {
+	BaseID      uuid.UUID
+	AppID       uuid.UUID
+	Number      int
+	NumType     string
+	CreateTime  time.Time
+	LastUseTime time.Time
+	InUse       bool
+}
+
+// Key is the key in pubsub
+func (info UUIDPairToNum) Key() string {
+	return fmt.Sprintf("%s-%s", info.BaseID.String(), info.AppID.String())
+}
+
+func convertUUIDPairToNum(ctxPtr *ucContext) error {
+
+	pubUUIDPairToNum, err := ctxPtr.ps.NewPublication(pubsub.PublicationOptions{
+		AgentName:  "zedrouter",
+		Persistent: true,
+		TopicType:  UUIDPairToNum{},
+	})
+
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+	defer pubUUIDPairToNum.Close()
+
+	pubUUIDPairAndIfIdxToNum, err := ctxPtr.ps.NewPublication(pubsub.PublicationOptions{
+		AgentName:  "zedrouter",
+		Persistent: true,
+		TopicType:  types.UUIDPairAndIfIdxToNum{},
+	})
+
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+	defer pubUUIDPairAndIfIdxToNum.Close()
+
+	items := pubUUIDPairToNum.GetAll()
+	if len(items) == 0 {
+		log.Trace("UUIDPairToNum not found")
+		return nil
+	}
+
+	log.Tracef("UUIDPairToNum found %d", len(items))
+
+	// if we have UUIDPairToNum assume that we should remove old items and recreate them
+	olditems := pubUUIDPairAndIfIdxToNum.GetAll()
+	for key := range olditems {
+		err = pubUUIDPairAndIfIdxToNum.Unpublish(key)
+		if err != nil {
+			log.Error(err)
+		}
+	}
+
+	for _, item := range items {
+		uptn := item.(UUIDPairToNum)
+		upitn := types.UUIDPairAndIfIdxToNum{
+			BaseID:      uptn.BaseID,
+			AppID:       uptn.AppID,
+			Number:      uptn.Number,
+			NumType:     uptn.NumType,
+			CreateTime:  uptn.CreateTime,
+			LastUseTime: uptn.LastUseTime,
+			InUse:       uptn.InUse,
+			IfIdx:       0,
+		}
+		// publish new allocator
+		err = pubUUIDPairAndIfIdxToNum.Publish(upitn.Key(), upitn)
+		if err != nil {
+			log.Error(err)
+			continue
+		}
+		// unpublish old allocator
+		err = pubUUIDPairToNum.Unpublish(uptn.Key())
+		if err != nil {
+			log.Error(err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/pillar/cmd/upgradeconverter/upgradeconverter.go
+++ b/pkg/pillar/cmd/upgradeconverter/upgradeconverter.go
@@ -42,6 +42,10 @@ var preVaultconversionHandlers = []ConversionHandler{
 		description: "Apply defaults for new items in ConfigItemValueMap",
 		handlerFunc: applyDefaultConfigItem,
 	},
+	{
+		description: "Move UUIDPairToNumKey to UUIDPairAndIfIdxToNumKey",
+		handlerFunc: convertUUIDPairToNum,
+	},
 }
 
 //postVaultconversionHandlers run after vault is setup

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -1992,6 +1992,20 @@ func parseUnderlayNetworkConfig(appInstance *types.AppInstanceConfig,
 			return appInstance.UnderlayNetworkList[i].IntfOrder <
 				appInstance.UnderlayNetworkList[j].IntfOrder
 		})
+
+	// calculate IfIdx field for interfaces connected to the same network
+	nextIfIndexForNetwork := make(map[uuid.UUID]uint32)
+	for i := range appInstance.UnderlayNetworkList {
+		ulCfg := &appInstance.UnderlayNetworkList[i]
+		if ind, ok := nextIfIndexForNetwork[ulCfg.Network]; ok {
+			ulCfg.IfIdx = ind
+			nextIfIndexForNetwork[ulCfg.Network] = ind + 1
+			continue
+		}
+		nextIfIndexForNetwork[ulCfg.Network] = 1
+		ulCfg.IfIdx = 0
+	}
+
 	// XXX remove? Debug?
 	if len(appInstance.UnderlayNetworkList) > 1 {
 		log.Functionf("XXX post sort %+v", appInstance.UnderlayNetworkList)

--- a/pkg/pillar/cmd/zedrouter/ipaddronunet.go
+++ b/pkg/pillar/cmd/zedrouter/ipaddronunet.go
@@ -21,7 +21,7 @@ func appNumsOnUNetAllocate(ctx *zedrouterContext,
 		appID := config.UUIDandVersion.UUID
 		networkID := ulConfig.Network
 		appNum, err := appNumOnUNetAllocate(ctx, networkID, appID,
-			isStatic, false)
+			isStatic, ulConfig.IfIdx, false)
 		if err != nil {
 			errStr := fmt.Sprintf("App Num get fail :%s", err)
 			log.Errorf("appNumsOnUNetAllocate(%s, %s): fail: %s",
@@ -44,9 +44,6 @@ func appNumsOnUNetFree(ctx *zedrouterContext,
 		ulStatus := &status.UnderlayNetworkList[ulNum]
 		networkID := ulStatus.Network
 		// release the app number
-		_, err := appNumOnUNetGet(ctx, networkID, appID)
-		if err == nil {
-			appNumOnUNetFree(ctx, networkID, appID)
-		}
+		appNumOnUNetClean(ctx, networkID, appID)
 	}
 }

--- a/pkg/pillar/types/types.go
+++ b/pkg/pillar/types/types.go
@@ -275,10 +275,11 @@ type UEvent struct {
 	Env    map[string]string
 }
 
-// UUIDPairToNum used for appNum on network instance
-type UUIDPairToNum struct {
+// UUIDPairAndIfIdxToNum used for appNum on network instance
+type UUIDPairAndIfIdxToNum struct {
 	BaseID      uuid.UUID
 	AppID       uuid.UUID
+	IfIdx       uint32
 	Number      int
 	NumType     string
 	CreateTime  time.Time
@@ -287,49 +288,49 @@ type UUIDPairToNum struct {
 }
 
 // Key is the key in pubsub
-func (info UUIDPairToNum) Key() string {
-	return UUIDPairToNumKey(info.BaseID, info.AppID)
+func (info UUIDPairAndIfIdxToNum) Key() string {
+	return UUIDPairAndIfIdxToNumKey(info.BaseID, info.AppID, info.IfIdx)
 }
 
-// UUIDPairToNumKey is the index key
-func UUIDPairToNumKey(baseID, appID uuid.UUID) string {
-	return baseID.String() + "-" + appID.String()
+// UUIDPairAndIfIdxToNumKey is the index key
+func UUIDPairAndIfIdxToNumKey(baseID, appID uuid.UUID, ifIdx uint32) string {
+	return fmt.Sprintf("%s-%s-%d", baseID.String(), appID.String(), ifIdx)
 }
 
 // LogCreate :
-func (info UUIDPairToNum) LogCreate(logBase *base.LogObject) {
-	logObject := base.NewLogObject(logBase, base.UUIDPairToNumLogType, "",
+func (info UUIDPairAndIfIdxToNum) LogCreate(logBase *base.LogObject) {
+	logObject := base.NewLogObject(logBase, base.UUIDPairToNumAndIfIdxLogType, "",
 		info.BaseID, info.LogKey())
 	if logObject == nil {
 		return
 	}
-	logObject.Noticef("UUIDPairToNum info create")
+	logObject.Noticef("UUIDPairAndIfIdxToNum info create")
 }
 
 // LogModify :
-func (info UUIDPairToNum) LogModify(logBase *base.LogObject, old interface{}) {
-	logObject := base.EnsureLogObject(logBase, base.UUIDPairToNumLogType, "",
+func (info UUIDPairAndIfIdxToNum) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.UUIDPairToNumAndIfIdxLogType, "",
 		info.BaseID, info.LogKey())
 
-	oldInfo, ok := old.(UUIDPairToNum)
+	oldInfo, ok := old.(UUIDPairAndIfIdxToNum)
 	if !ok {
-		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of UUIDPairToNum type")
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of UUIDPairAndIfIdxToNum type")
 	}
 	// XXX remove?
 	logObject.CloneAndAddField("diff", cmp.Diff(oldInfo, info)).
-		Noticef("UUIDPairToNum info modify")
+		Noticef("UUIDPairAndIfIdxToNum info modify")
 }
 
 // LogDelete :
-func (info UUIDPairToNum) LogDelete(logBase *base.LogObject) {
-	logObject := base.EnsureLogObject(logBase, base.UUIDPairToNumLogType, "",
+func (info UUIDPairAndIfIdxToNum) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.UUIDPairToNumAndIfIdxLogType, "",
 		info.BaseID, info.LogKey())
-	logObject.Noticef("UUIDPairToNum info delete")
+	logObject.Noticef("UUIDPairAndIfIdxToNum info delete")
 
 	base.DeleteLogObject(logBase, info.LogKey())
 }
 
 // LogKey :
-func (info UUIDPairToNum) LogKey() string {
-	return string(base.UUIDPairToNumLogType) + "-" + info.Key()
+func (info UUIDPairAndIfIdxToNum) LogKey() string {
+	return string(base.UUIDPairToNumAndIfIdxLogType) + "-" + info.Key()
 }

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -1968,6 +1968,7 @@ type UnderlayNetworkConfig struct {
 	Network      uuid.UUID // Points to a NetworkInstance.
 	ACLs         []ACE
 	AccessVlanID uint32
+	IfIdx        uint32 // If we have multiple interfaces on that network, we will increase the index
 }
 
 type UnderlayNetworkStatus struct {

--- a/pkg/pillar/uuidpairtonum/uuidpairtonum.go
+++ b/pkg/pillar/uuidpairtonum/uuidpairtonum.go
@@ -14,32 +14,58 @@ import (
 	"github.com/satori/go.uuid"
 )
 
-// NumGet : return the number for a given UUID pair
+// NumGet : return the number for a given UUID pair and interface index
 func NumGet(log *base.LogObject, pub pubsub.Publication,
-	baseID uuid.UUID, appID uuid.UUID, numType string) (int, error) {
-	key := types.UUIDPairToNumKey(baseID, appID)
+	baseID uuid.UUID, appID uuid.UUID, numType string, ifIdx uint32) (int, error) {
+	key := types.UUIDPairAndIfIdxToNumKey(baseID, appID, ifIdx)
 	log.Functionf("NumGet(%s, %s)", key, numType)
 	i, err := pub.Get(key)
 	if err != nil {
 		return -1, err
 	}
-	u := i.(types.UUIDPairToNum)
+	u := i.(types.UUIDPairAndIfIdxToNum)
 	return u.Number, nil
 }
 
-// NumAllocate : stores the number for a given UUID pair
+// NumGetAll : return slice of the numbers for a given UUID pair
+func NumGetAll(log *base.LogObject, pub pubsub.Publication,
+	baseID uuid.UUID, appID uuid.UUID, numType string) ([]types.UUIDPairAndIfIdxToNum, error) {
+	log.Functionf("NumGetAll(%s, %s)", baseID, appID)
+	pairs := pub.GetAll()
+	var val []types.UUIDPairAndIfIdxToNum
+	if pairs == nil {
+		return val, nil
+	}
+	for _, el := range pairs {
+		uuidPairToNum := el.(types.UUIDPairAndIfIdxToNum)
+		if uuidPairToNum.AppID != appID {
+			continue
+		}
+		if uuidPairToNum.BaseID != baseID {
+			continue
+		}
+		if uuidPairToNum.NumType != numType {
+			continue
+		}
+		val = append(val, uuidPairToNum)
+	}
+	return val, nil
+}
+
+// NumAllocate : stores the number for a given UUID pair and interface index
 func NumAllocate(log *base.LogObject, pub pubsub.Publication,
 	baseID uuid.UUID, appID uuid.UUID, appNum int, mustCreate bool,
-	numType string) {
-	log.Functionf("NumAllocate(%s, %s, %d, %v)", baseID.String(),
-		appID.String(), appNum, mustCreate)
+	numType string, ifIdx uint32) {
+	log.Functionf("NumAllocate(%s, %s, %d, %d, %v)", baseID.String(),
+		appID.String(), ifIdx, appNum, mustCreate)
 	now := time.Now()
-	key := types.UUIDPairToNumKey(baseID, appID)
+	key := types.UUIDPairAndIfIdxToNumKey(baseID, appID, ifIdx)
 	i, err := pub.Get(key)
 	if err != nil {
-		u := types.UUIDPairToNum{
+		u := types.UUIDPairAndIfIdxToNum{
 			BaseID:      baseID,
 			AppID:       appID,
+			IfIdx:       ifIdx,
 			CreateTime:  now,
 			LastUseTime: now,
 			InUse:       true,
@@ -51,7 +77,7 @@ func NumAllocate(log *base.LogObject, pub pubsub.Publication,
 		pub.Publish(u.Key(), u)
 		return
 	}
-	u := i.(types.UUIDPairToNum)
+	u := i.(types.UUIDPairAndIfIdxToNum)
 	if u.NumType != numType {
 		log.Fatalf("NumAllocate(%s) wrong numType %s vs. %s",
 			key, u.NumType, numType)
@@ -84,13 +110,13 @@ func NumAllocate(log *base.LogObject, pub pubsub.Publication,
 
 // NumFree : Clears InUse flag
 func NumFree(log *base.LogObject, pub pubsub.Publication,
-	baseID uuid.UUID, appID uuid.UUID) {
-	key := types.UUIDPairToNumKey(baseID, appID)
+	baseID uuid.UUID, appID uuid.UUID, ifIdx uint32) {
+	key := types.UUIDPairAndIfIdxToNumKey(baseID, appID, ifIdx)
 	i, err := pub.Get(key)
 	if err != nil {
 		log.Fatalf("NumFree(%s) does not exist", key)
 	}
-	u := i.(types.UUIDPairToNum)
+	u := i.(types.UUIDPairAndIfIdxToNum)
 	u.InUse = false
 	u.LastUseTime = time.Now()
 	log.Functionf("NumFree(%s) publishing updated %v",
@@ -102,10 +128,10 @@ func NumFree(log *base.LogObject, pub pubsub.Publication,
 	}
 }
 
-// NumDelete : Removes the integer map for a given UUID pair
+// NumDelete : Removes the integer map for a given UUID pair and interface index
 func NumDelete(log *base.LogObject, pub pubsub.Publication,
-	baseID uuid.UUID, appID uuid.UUID) {
-	key := types.UUIDPairToNumKey(baseID, appID)
+	baseID uuid.UUID, appID uuid.UUID, ifIdx uint32) {
+	key := types.UUIDPairAndIfIdxToNumKey(baseID, appID, ifIdx)
 	_, err := pub.Get(key)
 	if err != nil {
 		log.Fatalf("NumDelete(%s) does not exist", key)
@@ -121,10 +147,10 @@ func NumGetOldestUnused(log *base.LogObject, pub pubsub.Publication,
 	baseID uuid.UUID, numType string) (uuid.UUID, int, error) {
 	log.Functionf("NumGetOldestUnused(%s)", numType)
 	// Will have a LastUseTime of zero
-	oldest := new(types.UUIDPairToNum)
+	oldest := new(types.UUIDPairAndIfIdxToNum)
 	items := pub.GetAll()
 	for _, st := range items {
-		item := st.(types.UUIDPairToNum)
+		item := st.(types.UUIDPairAndIfIdxToNum)
 		if item.NumType != numType || item.InUse || item.BaseID != baseID {
 			continue
 		}


### PR DESCRIPTION
If we allocate several interfaces on the same network instance all of
them receive the same IP. It comes because we save and check only
networkInstance - app pairs, so, we can allocate only one IP.
I move UUIDPairToNum to UUIDPairAndIfIdxToNumKey and allows to allocate
different appNum (and IPs) for different interfaces on the same
networkInstance.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>