### PR TITLE
Rework zfs_arc_max get logic

### DIFF
--- a/pkg/pillar/types/locationconsts.go
+++ b/pkg/pillar/types/locationconsts.go
@@ -84,6 +84,8 @@ const (
 	EveMemoryUsageFile = "/hostfs/sys/fs/cgroup/memory/eve/memory.usage_in_bytes"
 	// EveKmemUsageFile - current kernel usage
 	EveKmemUsageFile = "/hostfs/sys/fs/cgroup/memory/eve/memory.kmem.usage_in_bytes"
+	// ZFSArcMaxSizeFile - file with zfs_arc_max size in bytes
+	ZFSArcMaxSizeFile = "/hostfs/sys/module/zfs/parameters/zfs_arc_max"
 
 	// ContainerdContentDir - path to containerd`s content store
 	ContainerdContentDir = PersistDir + "/containerd/io.containerd.content.v1.content"

--- a/pkg/pillar/types/memory.go
+++ b/pkg/pillar/types/memory.go
@@ -27,6 +27,12 @@ func GetEveKmemUsageInBytes() (uint64, error) {
 	return readUint64File(EveKmemUsageFile)
 }
 
+// GetZFSArcMaxSizeInBytes returns memory limit
+// reserved for zfs arc
+func GetZFSArcMaxSizeInBytes() (uint64, error) {
+	return readUint64File(ZFSArcMaxSizeFile)
+}
+
 func readUint64File(filename string) (uint64, error) {
 	dataBytes, err := ioutil.ReadFile(filename)
 	if err != nil {


### PR DESCRIPTION
I can see `description:"getRemainingMemory failed: failed to convert zfs_arc_max in to int: value: 402653184\n err: strconv.Atoi: parsing \"402653184\\n\": invalid syntax\n" timestamp:{seconds:1644190170 nanos:916080189} severity:SEVERITY_NOTICE retry_condition:"Will retry when information about memory will be available in zedmanager"` with PR #2483 merged. Seems we must remove newline character. I can see the same logic in memory.go, so here I reuse existing logic of loading bytes from file.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>