### PR TITLE
Use TLS with S3

### DIFF
--- a/libs/zedUpload/awsutil/s3api.go
+++ b/libs/zedUpload/awsutil/s3api.go
@@ -62,11 +62,11 @@ func NewAwsCtx(id, secret, region string, hctx *http.Client) *S3ctx {
 	cfg.WithRegion(region)
 
 	if hctx != nil {
+		// This picks up the TLS settings including any extra proxy
+		// certificates.
 		cfg.WithHTTPClient(hctx)
 	}
 
-	// FIXME: We need figoure out how to do this with SSL verification
-	cfg.WithDisableSSL(true)
 	// s3.New is deprecated.. Ignoring the lint error as this is not new code.
 	ctx.ss3 = s3.New(session.New(), cfg) // nolint
 	ctx.up = s3manager.NewUploaderWithClient(ctx.ss3, func(u *s3manager.Uploader) {

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/awsutil/s3api.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/awsutil/s3api.go
@@ -62,11 +62,11 @@ func NewAwsCtx(id, secret, region string, hctx *http.Client) *S3ctx {
 	cfg.WithRegion(region)
 
 	if hctx != nil {
+		// This picks up the TLS settings including any extra proxy
+		// certificates.
 		cfg.WithHTTPClient(hctx)
 	}
 
-	// FIXME: We need figoure out how to do this with SSL verification
-	cfg.WithDisableSSL(true)
 	// s3.New is deprecated.. Ignoring the lint error as this is not new code.
 	ctx.ss3 = s3.New(session.New(), cfg) // nolint
 	ctx.up = s3manager.NewUploaderWithClient(ctx.ss3, func(u *s3manager.Uploader) {


### PR DESCRIPTION
Some old code had this disabled, thus we relied on the image SHA256 for verification. However, this means that firewalls need to open up outbound port 80 when port 443 should be sufficient.

Verified that the S3 downloads work correctly even when a TLS MiTM proxy is in use thus the proxy certificate is passed in to the S3 download code.