### PR TITLE
Allow /30 subnets for local network instance

### DIFF
--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -1883,7 +1883,7 @@ func parseIpspec(ipspec *zconfig.Ipspec,
 	}
 
 	addrCount := types.GetIPAddrCountOnSubnet(config.Subnet)
-	if addrCount <= types.MinSubnetSize {
+	if addrCount < types.MinSubnetSize {
 		return fmt.Errorf("network(%s), Subnet too small(%d)",
 			config.Key(), addrCount)
 	}

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -3204,12 +3204,13 @@ func GetIPBroadcast(subnet net.IPNet) net.IP {
 	return net.IP{}
 }
 
-// AppNumber :
 // PS. Any change to BitMapMax, must be
 // reflected in the BitMap Size(32 bytes)
+// At the MinSubnetSize there is room for one app instance (.0 being reserved,
+// .3 broadcast, .1 is the bridgeIPAddr, and .2 is usable).
 const (
 	BitMapMax       = 255 // with 0 base, its 256
-	MinSubnetSize   = 8   // minimum Subnet Size
+	MinSubnetSize   = 4   // minimum Subnet Size
 	LargeSubnetSize = 16  // for determining default Dhcp Range
 )
 


### PR DESCRIPTION
The current MinSubnetSize of > 8 is too restrictive. We these changes we can handle /30 subnet, which means that there is one IP address available for an app instance (and one for the bridge IP address which is the default router as seen by the app instance).