### PR TITLE
Rework ECO to show information to log and VNC

### DIFF
--- a/pkg/xen-tools/initrd/init-initrd
+++ b/pkg/xen-tools/initrd/init-initrd
@@ -125,8 +125,14 @@ if [ -f /mnt/ug ]; then
 fi
 echo "Executing with uid gid: $ug"
 
-#shellcheck disable=SC2086
-eval /chroot2 /mnt/rootfs "${WORKDIR:-/}" $ug $cmd <> /dev/console 2>&1
+if grep -q "console=tty0" /proc/cmdline; then
+  #shellcheck disable=SC2086
+  #we have tty0 console primary, so will add output to hvc0 for logging
+  eval /chroot2 /mnt/rootfs "${WORKDIR:-/}" $ug $cmd 2>&1 | tee -i /dev/hvc0
+else
+  #shellcheck disable=SC2086
+  eval /chroot2 /mnt/rootfs "${WORKDIR:-/}" $ug $cmd <> /dev/console 2>&1
+fi
 
 # once the command exits -- the only thing left is shut everything down
 /sbin/poweroff


### PR DESCRIPTION
Now we cannot see information from app in logs if VNC enabled, with this change we will output an information to both places.