### PR TITLE
Allow eve_pause_before_install and eve_pause_after_install in installer

### DIFF
--- a/pkg/mkimage-raw-efi/install
+++ b/pkg/mkimage-raw-efi/install
@@ -25,8 +25,14 @@ BAIL_FINAL_CMD=${BAIL_FINAL_CMD:-"exit 1"}
 [ -n "$DEBUG" ] && set -x
 
 pause() {
+   echo "stop rungetty.sh to not re-run login"
+   killall -STOP rungetty.sh
+   echo "killing login"
+   killall login
    echo "Pausing before $1. Entering shell. Type 'exit' to proceed to $1"
-   sh
+   sh </dev/console >/dev/console 2>&1
+   echo "resume rungetty.sh"
+   killall -CONT rungetty.sh
 }
 
 bail() {


### PR DESCRIPTION
We have `eve_pause_before_install` and `eve_pause_after_install` options but they are broken now. We are fighting with login process from linuxkit/getty for console access. Seems reasonable to stop rungetty when we need console from installer.

Also seems reasonable to have possibility to start interactive app in installer.