### PR TITLE
Use custom overlay snapshotter to ensure encryption

### DIFF
--- a/pkg/dom0-ztools/rootfs/etc/containerd/config.toml
+++ b/pkg/dom0-ztools/rootfs/etc/containerd/config.toml
@@ -21,6 +21,9 @@ disabled_plugins = ["cri", "btrfs", "aufs"]
   [proxy_plugins."eve.zfs.snapshotter"]
     type = "snapshot"
     address = "/run/eve.zfs.snapshotter.sock"
+  [proxy_plugins."eve.overlay.snapshotter"]
+    type = "snapshot"
+    address = "/run/eve.overlay.snapshotter.sock"
 
 # [plugins]
 #  [plugins.content]

--- a/pkg/pillar/cmd/vaultmgr/vaultmgrzfs.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgrzfs.go
@@ -4,17 +4,9 @@
 package vaultmgr
 
 import (
-	"net"
-	"os"
-	"path/filepath"
 	"regexp"
 
-	snapshotsapi "github.com/containerd/containerd/api/services/snapshots/v1"
-	"github.com/containerd/containerd/contrib/snapshotservice"
-	zfsSnapshooter "github.com/containerd/zfs"
-	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/vault"
-	"google.golang.org/grpc"
 )
 
 const (
@@ -22,7 +14,6 @@ const (
 	defaultCfgSecretDataset = vault.DefaultZpool + "/config"
 	zfsKeyFile              = zfsKeyDir + "/protector.key"
 	zfsKeyDir               = "/run/TmpVaultDir2"
-	zfsSnapshotterSock      = "/run/" + types.ZFSSnapshotter + ".sock"
 )
 
 func getCreateParams(vaultPath string, encrypted bool) []string {
@@ -133,33 +124,4 @@ func setupZfsVault(vaultPath string) error {
 	}
 	//try creating the dataset
 	return createZfsVault(vaultPath)
-}
-
-// eveZFSSnapshotterInit initializes containerd snapshotter eve.zfs.snapshotter
-// we cannot use default one because of no mount of persist/vault dataset on boot if encrypted
-// we use proxy plugin and start it here after defaultVault is mounted
-func eveZFSSnapshotterInit() error {
-	dirToSaveMetadata := filepath.Join(defaultVault, types.ZFSSnapshotter)
-	err := os.MkdirAll(dirToSaveMetadata, os.ModeDir)
-	if err != nil {
-		return err
-	}
-	//it makes lookup internally for mount point of provided path
-	sn, err := zfsSnapshooter.NewSnapshotter(dirToSaveMetadata)
-	if err != nil {
-		return err
-	}
-	service := snapshotservice.FromSnapshotter(sn)
-	rpc := grpc.NewServer()
-	snapshotsapi.RegisterSnapshotsServer(rpc, service)
-	l, err := net.Listen("unix", zfsSnapshotterSock)
-	if err != nil {
-		return err
-	}
-	go func() {
-		if err := rpc.Serve(l); err != nil {
-			log.Fatalf("eveZFSSnapshotterInit Serve error: %v\n", err)
-		}
-	}()
-	return nil
 }

--- a/pkg/pillar/containerd/snapshotter.go
+++ b/pkg/pillar/containerd/snapshotter.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2022 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package containerd
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+
+	snapshotsapi "github.com/containerd/containerd/api/services/snapshots/v1"
+	"github.com/containerd/containerd/contrib/snapshotservice"
+	"github.com/containerd/containerd/snapshots"
+	overlaySnapshooter "github.com/containerd/containerd/snapshots/overlay"
+	zfsSnapshooter "github.com/containerd/zfs"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+)
+
+// EveSnapshotterInit initializes custom containerd snapshotter
+// we use proxy plugin and start it here after defaultVault is mounted
+func EveSnapshotterInit(snapshotter types.EveSnapshotter) error {
+	dirToSaveMetadata := filepath.Join(types.PersistDir, "vault", snapshotter.String())
+	err := os.MkdirAll(dirToSaveMetadata, os.ModeDir)
+	if err != nil {
+		return err
+	}
+	var sn snapshots.Snapshotter
+	switch snapshotter {
+	case types.ZFSSnapshotter:
+		//it makes lookup internally for mount point of provided path
+		sn, err = zfsSnapshooter.NewSnapshotter(dirToSaveMetadata)
+		if err != nil {
+			return err
+		}
+	case types.OverlaySnapshotter:
+		sn, err = overlaySnapshooter.NewSnapshotter(dirToSaveMetadata)
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("no custom snapshotter for %s", snapshotter.String())
+	}
+	service := snapshotservice.FromSnapshotter(sn)
+	rpc := grpc.NewServer()
+	snapshotsapi.RegisterSnapshotsServer(rpc, service)
+
+	// socket must be in sync with containerd config.toml
+	l, err := net.Listen("unix", fmt.Sprintf("/run/%s.sock", snapshotter))
+	if err != nil {
+		return err
+	}
+	go func() {
+		if err := rpc.Serve(l); err != nil {
+			logrus.Fatalf("EveSnapshotterInit %s Serve error: %v\n", snapshotter, err)
+		}
+	}()
+	return nil
+}

--- a/pkg/pillar/types/containerdtypes.go
+++ b/pkg/pillar/types/containerdtypes.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2022 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+// EveSnapshotter is containerd snapshotter
+type EveSnapshotter string
+
+//String representation
+func (s EveSnapshotter) String() string {
+	return string(s)
+}
+
+const (
+	//ZFSSnapshotter is containerd snapshotter for zfs
+	ZFSSnapshotter EveSnapshotter = "eve.zfs.snapshotter"
+	//OverlaySnapshotter is containerd snapshotter for overlay
+	OverlaySnapshotter EveSnapshotter = "eve.overlay.snapshotter"
+	//OldSnapshotter is containerd snapshotter we cannot migrate from
+	//if we have any snapshots there we will use it for new ones
+	OldSnapshotter EveSnapshotter = "overlayfs"
+)

--- a/pkg/pillar/types/zfs.go
+++ b/pkg/pillar/types/zfs.go
@@ -11,9 +11,6 @@ import (
 const (
 	// ZVolDevicePrefix controlled by mdev
 	ZVolDevicePrefix = "/dev/zvol"
-
-	//ZFSSnapshotter is containerd snapshotter for zfs
-	ZFSSnapshotter = "eve.zfs.snapshotter"
 )
 
 // ZVolName returns name of zvol for volume

--- a/pkg/pillar/vendor/github.com/containerd/containerd/snapshots/overlay/overlay.go
+++ b/pkg/pillar/vendor/github.com/containerd/containerd/snapshots/overlay/overlay.go
@@ -1,0 +1,526 @@
+// +build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package overlay
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/snapshots"
+	"github.com/containerd/containerd/snapshots/overlay/overlayutils"
+	"github.com/containerd/containerd/snapshots/storage"
+	"github.com/containerd/continuity/fs"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// SnapshotterConfig is used to configure the overlay snapshotter instance
+type SnapshotterConfig struct {
+	asyncRemove bool
+}
+
+// Opt is an option to configure the overlay snapshotter
+type Opt func(config *SnapshotterConfig) error
+
+// AsynchronousRemove defers removal of filesystem content until
+// the Cleanup method is called. Removals will make the snapshot
+// referred to by the key unavailable and make the key immediately
+// available for re-use.
+func AsynchronousRemove(config *SnapshotterConfig) error {
+	config.asyncRemove = true
+	return nil
+}
+
+type snapshotter struct {
+	root        string
+	ms          *storage.MetaStore
+	asyncRemove bool
+	indexOff    bool
+	userxattr   bool // whether to enable "userxattr" mount option
+}
+
+// NewSnapshotter returns a Snapshotter which uses overlayfs. The overlayfs
+// diffs are stored under the provided root. A metadata file is stored under
+// the root.
+func NewSnapshotter(root string, opts ...Opt) (snapshots.Snapshotter, error) {
+	var config SnapshotterConfig
+	for _, opt := range opts {
+		if err := opt(&config); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := os.MkdirAll(root, 0700); err != nil {
+		return nil, err
+	}
+	supportsDType, err := fs.SupportsDType(root)
+	if err != nil {
+		return nil, err
+	}
+	if !supportsDType {
+		return nil, fmt.Errorf("%s does not support d_type. If the backing filesystem is xfs, please reformat with ftype=1 to enable d_type support", root)
+	}
+	ms, err := storage.NewMetaStore(filepath.Join(root, "metadata.db"))
+	if err != nil {
+		return nil, err
+	}
+
+	if err := os.Mkdir(filepath.Join(root, "snapshots"), 0700); err != nil && !os.IsExist(err) {
+		return nil, err
+	}
+
+	// figure out whether "index=off" option is recognized by the kernel
+	var indexOff bool
+	if _, err = os.Stat("/sys/module/overlay/parameters/index"); err == nil {
+		indexOff = true
+	}
+
+	// figure out whether "userxattr" option is recognized by the kernel && needed
+	userxattr, err := overlayutils.NeedsUserXAttr(root)
+	if err != nil {
+		logrus.WithError(err).Warnf("cannot detect whether \"userxattr\" option needs to be used, assuming to be %v", userxattr)
+	}
+
+	return &snapshotter{
+		root:        root,
+		ms:          ms,
+		asyncRemove: config.asyncRemove,
+		indexOff:    indexOff,
+		userxattr:   userxattr,
+	}, nil
+}
+
+// Stat returns the info for an active or committed snapshot by name or
+// key.
+//
+// Should be used for parent resolution, existence checks and to discern
+// the kind of snapshot.
+func (o *snapshotter) Stat(ctx context.Context, key string) (snapshots.Info, error) {
+	ctx, t, err := o.ms.TransactionContext(ctx, false)
+	if err != nil {
+		return snapshots.Info{}, err
+	}
+	defer t.Rollback()
+	_, info, _, err := storage.GetInfo(ctx, key)
+	if err != nil {
+		return snapshots.Info{}, err
+	}
+
+	return info, nil
+}
+
+func (o *snapshotter) Update(ctx context.Context, info snapshots.Info, fieldpaths ...string) (snapshots.Info, error) {
+	ctx, t, err := o.ms.TransactionContext(ctx, true)
+	if err != nil {
+		return snapshots.Info{}, err
+	}
+
+	info, err = storage.UpdateInfo(ctx, info, fieldpaths...)
+	if err != nil {
+		t.Rollback()
+		return snapshots.Info{}, err
+	}
+
+	if err := t.Commit(); err != nil {
+		return snapshots.Info{}, err
+	}
+
+	return info, nil
+}
+
+// Usage returns the resources taken by the snapshot identified by key.
+//
+// For active snapshots, this will scan the usage of the overlay "diff" (aka
+// "upper") directory and may take some time.
+//
+// For committed snapshots, the value is returned from the metadata database.
+func (o *snapshotter) Usage(ctx context.Context, key string) (snapshots.Usage, error) {
+	ctx, t, err := o.ms.TransactionContext(ctx, false)
+	if err != nil {
+		return snapshots.Usage{}, err
+	}
+	id, info, usage, err := storage.GetInfo(ctx, key)
+	t.Rollback() // transaction no longer needed at this point.
+
+	if err != nil {
+		return snapshots.Usage{}, err
+	}
+
+	if info.Kind == snapshots.KindActive {
+		upperPath := o.upperPath(id)
+		du, err := fs.DiskUsage(ctx, upperPath)
+		if err != nil {
+			// TODO(stevvooe): Consider not reporting an error in this case.
+			return snapshots.Usage{}, err
+		}
+
+		usage = snapshots.Usage(du)
+	}
+
+	return usage, nil
+}
+
+func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
+	return o.createSnapshot(ctx, snapshots.KindActive, key, parent, opts)
+}
+
+func (o *snapshotter) View(ctx context.Context, key, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
+	return o.createSnapshot(ctx, snapshots.KindView, key, parent, opts)
+}
+
+// Mounts returns the mounts for the transaction identified by key. Can be
+// called on an read-write or readonly transaction.
+//
+// This can be used to recover mounts after calling View or Prepare.
+func (o *snapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, error) {
+	ctx, t, err := o.ms.TransactionContext(ctx, false)
+	if err != nil {
+		return nil, err
+	}
+	s, err := storage.GetSnapshot(ctx, key)
+	t.Rollback()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get active mount")
+	}
+	return o.mounts(s), nil
+}
+
+func (o *snapshotter) Commit(ctx context.Context, name, key string, opts ...snapshots.Opt) error {
+	ctx, t, err := o.ms.TransactionContext(ctx, true)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if err != nil {
+			if rerr := t.Rollback(); rerr != nil {
+				log.G(ctx).WithError(rerr).Warn("failed to rollback transaction")
+			}
+		}
+	}()
+
+	// grab the existing id
+	id, _, _, err := storage.GetInfo(ctx, key)
+	if err != nil {
+		return err
+	}
+
+	usage, err := fs.DiskUsage(ctx, o.upperPath(id))
+	if err != nil {
+		return err
+	}
+
+	if _, err = storage.CommitActive(ctx, key, name, snapshots.Usage(usage), opts...); err != nil {
+		return errors.Wrap(err, "failed to commit snapshot")
+	}
+	return t.Commit()
+}
+
+// Remove abandons the snapshot identified by key. The snapshot will
+// immediately become unavailable and unrecoverable. Disk space will
+// be freed up on the next call to `Cleanup`.
+func (o *snapshotter) Remove(ctx context.Context, key string) (err error) {
+	ctx, t, err := o.ms.TransactionContext(ctx, true)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			if rerr := t.Rollback(); rerr != nil {
+				log.G(ctx).WithError(rerr).Warn("failed to rollback transaction")
+			}
+		}
+	}()
+
+	_, _, err = storage.Remove(ctx, key)
+	if err != nil {
+		return errors.Wrap(err, "failed to remove")
+	}
+
+	if !o.asyncRemove {
+		var removals []string
+		removals, err = o.getCleanupDirectories(ctx, t)
+		if err != nil {
+			return errors.Wrap(err, "unable to get directories for removal")
+		}
+
+		// Remove directories after the transaction is closed, failures must not
+		// return error since the transaction is committed with the removal
+		// key no longer available.
+		defer func() {
+			if err == nil {
+				for _, dir := range removals {
+					if err := os.RemoveAll(dir); err != nil {
+						log.G(ctx).WithError(err).WithField("path", dir).Warn("failed to remove directory")
+					}
+				}
+			}
+		}()
+
+	}
+
+	return t.Commit()
+}
+
+// Walk the snapshots.
+func (o *snapshotter) Walk(ctx context.Context, fn snapshots.WalkFunc, fs ...string) error {
+	ctx, t, err := o.ms.TransactionContext(ctx, false)
+	if err != nil {
+		return err
+	}
+	defer t.Rollback()
+	return storage.WalkInfo(ctx, fn, fs...)
+}
+
+// Cleanup cleans up disk resources from removed or abandoned snapshots
+func (o *snapshotter) Cleanup(ctx context.Context) error {
+	cleanup, err := o.cleanupDirectories(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, dir := range cleanup {
+		if err := os.RemoveAll(dir); err != nil {
+			log.G(ctx).WithError(err).WithField("path", dir).Warn("failed to remove directory")
+		}
+	}
+
+	return nil
+}
+
+func (o *snapshotter) cleanupDirectories(ctx context.Context) ([]string, error) {
+	// Get a write transaction to ensure no other write transaction can be entered
+	// while the cleanup is scanning.
+	ctx, t, err := o.ms.TransactionContext(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+
+	defer t.Rollback()
+	return o.getCleanupDirectories(ctx, t)
+}
+
+func (o *snapshotter) getCleanupDirectories(ctx context.Context, t storage.Transactor) ([]string, error) {
+	ids, err := storage.IDMap(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	snapshotDir := filepath.Join(o.root, "snapshots")
+	fd, err := os.Open(snapshotDir)
+	if err != nil {
+		return nil, err
+	}
+	defer fd.Close()
+
+	dirs, err := fd.Readdirnames(0)
+	if err != nil {
+		return nil, err
+	}
+
+	cleanup := []string{}
+	for _, d := range dirs {
+		if _, ok := ids[d]; ok {
+			continue
+		}
+
+		cleanup = append(cleanup, filepath.Join(snapshotDir, d))
+	}
+
+	return cleanup, nil
+}
+
+func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, key, parent string, opts []snapshots.Opt) (_ []mount.Mount, err error) {
+	ctx, t, err := o.ms.TransactionContext(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+
+	var td, path string
+	defer func() {
+		if err != nil {
+			if td != "" {
+				if err1 := os.RemoveAll(td); err1 != nil {
+					log.G(ctx).WithError(err1).Warn("failed to cleanup temp snapshot directory")
+				}
+			}
+			if path != "" {
+				if err1 := os.RemoveAll(path); err1 != nil {
+					log.G(ctx).WithError(err1).WithField("path", path).Error("failed to reclaim snapshot directory, directory may need removal")
+					err = errors.Wrapf(err, "failed to remove path: %v", err1)
+				}
+			}
+		}
+	}()
+
+	snapshotDir := filepath.Join(o.root, "snapshots")
+	td, err = o.prepareDirectory(ctx, snapshotDir, kind)
+	if err != nil {
+		if rerr := t.Rollback(); rerr != nil {
+			log.G(ctx).WithError(rerr).Warn("failed to rollback transaction")
+		}
+		return nil, errors.Wrap(err, "failed to create prepare snapshot dir")
+	}
+	rollback := true
+	defer func() {
+		if rollback {
+			if rerr := t.Rollback(); rerr != nil {
+				log.G(ctx).WithError(rerr).Warn("failed to rollback transaction")
+			}
+		}
+	}()
+
+	s, err := storage.CreateSnapshot(ctx, kind, key, parent, opts...)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create snapshot")
+	}
+
+	if len(s.ParentIDs) > 0 {
+		st, err := os.Stat(o.upperPath(s.ParentIDs[0]))
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to stat parent")
+		}
+
+		stat := st.Sys().(*syscall.Stat_t)
+
+		if err := os.Lchown(filepath.Join(td, "fs"), int(stat.Uid), int(stat.Gid)); err != nil {
+			if rerr := t.Rollback(); rerr != nil {
+				log.G(ctx).WithError(rerr).Warn("failed to rollback transaction")
+			}
+			return nil, errors.Wrap(err, "failed to chown")
+		}
+	}
+
+	path = filepath.Join(snapshotDir, s.ID)
+	if err = os.Rename(td, path); err != nil {
+		return nil, errors.Wrap(err, "failed to rename")
+	}
+	td = ""
+
+	rollback = false
+	if err = t.Commit(); err != nil {
+		return nil, errors.Wrap(err, "commit failed")
+	}
+
+	return o.mounts(s), nil
+}
+
+func (o *snapshotter) prepareDirectory(ctx context.Context, snapshotDir string, kind snapshots.Kind) (string, error) {
+	td, err := ioutil.TempDir(snapshotDir, "new-")
+	if err != nil {
+		return "", errors.Wrap(err, "failed to create temp dir")
+	}
+
+	if err := os.Mkdir(filepath.Join(td, "fs"), 0755); err != nil {
+		return td, err
+	}
+
+	if kind == snapshots.KindActive {
+		if err := os.Mkdir(filepath.Join(td, "work"), 0711); err != nil {
+			return td, err
+		}
+	}
+
+	return td, nil
+}
+
+func (o *snapshotter) mounts(s storage.Snapshot) []mount.Mount {
+	if len(s.ParentIDs) == 0 {
+		// if we only have one layer/no parents then just return a bind mount as overlay
+		// will not work
+		roFlag := "rw"
+		if s.Kind == snapshots.KindView {
+			roFlag = "ro"
+		}
+
+		return []mount.Mount{
+			{
+				Source: o.upperPath(s.ID),
+				Type:   "bind",
+				Options: []string{
+					roFlag,
+					"rbind",
+				},
+			},
+		}
+	}
+	var options []string
+
+	// set index=off when mount overlayfs
+	if o.indexOff {
+		options = append(options, "index=off")
+	}
+
+	if o.userxattr {
+		options = append(options, "userxattr")
+	}
+
+	if s.Kind == snapshots.KindActive {
+		options = append(options,
+			fmt.Sprintf("workdir=%s", o.workPath(s.ID)),
+			fmt.Sprintf("upperdir=%s", o.upperPath(s.ID)),
+		)
+	} else if len(s.ParentIDs) == 1 {
+		return []mount.Mount{
+			{
+				Source: o.upperPath(s.ParentIDs[0]),
+				Type:   "bind",
+				Options: []string{
+					"ro",
+					"rbind",
+				},
+			},
+		}
+	}
+
+	parentPaths := make([]string, len(s.ParentIDs))
+	for i := range s.ParentIDs {
+		parentPaths[i] = o.upperPath(s.ParentIDs[i])
+	}
+
+	options = append(options, fmt.Sprintf("lowerdir=%s", strings.Join(parentPaths, ":")))
+	return []mount.Mount{
+		{
+			Type:    "overlay",
+			Source:  "overlay",
+			Options: options,
+		},
+	}
+
+}
+
+func (o *snapshotter) upperPath(id string) string {
+	return filepath.Join(o.root, "snapshots", id, "fs")
+}
+
+func (o *snapshotter) workPath(id string) string {
+	return filepath.Join(o.root, "snapshots", id, "work")
+}
+
+// Close closes the snapshotter
+func (o *snapshotter) Close() error {
+	return o.ms.Close()
+}

--- a/pkg/pillar/vendor/github.com/containerd/containerd/snapshots/overlay/overlayutils/check.go
+++ b/pkg/pillar/vendor/github.com/containerd/containerd/snapshots/overlay/overlayutils/check.go
@@ -1,0 +1,170 @@
+// +build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package overlayutils
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/pkg/userns"
+	"github.com/containerd/continuity/fs"
+	"github.com/pkg/errors"
+)
+
+// SupportsMultipleLowerDir checks if the system supports multiple lowerdirs,
+// which is required for the overlay snapshotter. On 4.x kernels, multiple lowerdirs
+// are always available (so this check isn't needed), and backported to RHEL and
+// CentOS 3.x kernels (3.10.0-693.el7.x86_64 and up). This function is to detect
+// support on those kernels, without doing a kernel version compare.
+//
+// Ported from moby overlay2.
+func SupportsMultipleLowerDir(d string) error {
+	td, err := ioutil.TempDir(d, "multiple-lowerdir-check")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := os.RemoveAll(td); err != nil {
+			log.L.WithError(err).Warnf("Failed to remove check directory %v", td)
+		}
+	}()
+
+	for _, dir := range []string{"lower1", "lower2", "upper", "work", "merged"} {
+		if err := os.Mkdir(filepath.Join(td, dir), 0755); err != nil {
+			return err
+		}
+	}
+
+	opts := fmt.Sprintf("lowerdir=%s:%s,upperdir=%s,workdir=%s", filepath.Join(td, "lower2"), filepath.Join(td, "lower1"), filepath.Join(td, "upper"), filepath.Join(td, "work"))
+	m := mount.Mount{
+		Type:    "overlay",
+		Source:  "overlay",
+		Options: []string{opts},
+	}
+	dest := filepath.Join(td, "merged")
+	if err := m.Mount(dest); err != nil {
+		return errors.Wrap(err, "failed to mount overlay")
+	}
+	if err := mount.UnmountAll(dest, 0); err != nil {
+		log.L.WithError(err).Warnf("Failed to unmount check directory %v", dest)
+	}
+	return nil
+}
+
+// Supported returns nil when the overlayfs is functional on the system with the root directory.
+// Supported is not called during plugin initialization, but exposed for downstream projects which uses
+// this snapshotter as a library.
+func Supported(root string) error {
+	if err := os.MkdirAll(root, 0700); err != nil {
+		return err
+	}
+	supportsDType, err := fs.SupportsDType(root)
+	if err != nil {
+		return err
+	}
+	if !supportsDType {
+		return fmt.Errorf("%s does not support d_type. If the backing filesystem is xfs, please reformat with ftype=1 to enable d_type support", root)
+	}
+	return SupportsMultipleLowerDir(root)
+}
+
+// NeedsUserXAttr returns whether overlayfs should be mounted with the "userxattr" mount option.
+//
+// The "userxattr" option is needed for mounting overlayfs inside a user namespace with kernel >= 5.11.
+//
+// The "userxattr" option is NOT needed for the initial user namespace (aka "the host").
+//
+// Also, Ubuntu (since circa 2015) and Debian (since 10) with kernel < 5.11 can mount
+// the overlayfs in a user namespace without the "userxattr" option.
+//
+// The corresponding kernel commit: https://github.com/torvalds/linux/commit/2d2f2d7322ff43e0fe92bf8cccdc0b09449bf2e1
+// > ovl: user xattr
+// >
+// > Optionally allow using "user.overlay." namespace instead of "trusted.overlay."
+// > ...
+// > Disable redirect_dir and metacopy options, because these would allow privilege escalation through direct manipulation of the
+// > "user.overlay.redirect" or "user.overlay.metacopy" xattrs.
+// > ...
+//
+// The "userxattr" support is not exposed in "/sys/module/overlay/parameters".
+func NeedsUserXAttr(d string) (bool, error) {
+	if !userns.RunningInUserNS() {
+		// we are the real root (i.e., the root in the initial user NS),
+		// so we do never need "userxattr" opt.
+		return false, nil
+	}
+
+	// TODO: add fast path for kernel >= 5.11 .
+	//
+	// Keep in mind that distro vendors might be going to backport the patch to older kernels.
+	// So we can't completely remove the check.
+
+	tdRoot := filepath.Join(d, "userxattr-check")
+	if err := os.RemoveAll(tdRoot); err != nil {
+		log.L.WithError(err).Warnf("Failed to remove check directory %v", tdRoot)
+	}
+
+	if err := os.MkdirAll(tdRoot, 0700); err != nil {
+		return false, err
+	}
+
+	defer func() {
+		if err := os.RemoveAll(tdRoot); err != nil {
+			log.L.WithError(err).Warnf("Failed to remove check directory %v", tdRoot)
+		}
+	}()
+
+	td, err := ioutil.TempDir(tdRoot, "")
+	if err != nil {
+		return false, err
+	}
+
+	for _, dir := range []string{"lower1", "lower2", "upper", "work", "merged"} {
+		if err := os.Mkdir(filepath.Join(td, dir), 0755); err != nil {
+			return false, err
+		}
+	}
+
+	opts := []string{
+		fmt.Sprintf("lowerdir=%s:%s,upperdir=%s,workdir=%s", filepath.Join(td, "lower2"), filepath.Join(td, "lower1"), filepath.Join(td, "upper"), filepath.Join(td, "work")),
+		"userxattr",
+	}
+
+	m := mount.Mount{
+		Type:    "overlay",
+		Source:  "overlay",
+		Options: opts,
+	}
+
+	dest := filepath.Join(td, "merged")
+	if err := m.Mount(dest); err != nil {
+		// Probably the host is running Ubuntu/Debian kernel (< 5.11) with the userns patch but without the userxattr patch.
+		// Return false without error.
+		log.L.WithError(err).Debugf("cannot mount overlay with \"userxattr\", probably the kernel does not support userxattr")
+		return false, nil
+	}
+	if err := mount.UnmountAll(dest, 0); err != nil {
+		log.L.WithError(err).Warnf("Failed to unmount check directory %v", dest)
+	}
+	return true, nil
+}

--- a/pkg/pillar/vendor/modules.txt
+++ b/pkg/pillar/vendor/modules.txt
@@ -171,6 +171,8 @@ github.com/containerd/containerd/runtime/v2/runc/options
 github.com/containerd/containerd/services
 github.com/containerd/containerd/services/introspection
 github.com/containerd/containerd/snapshots
+github.com/containerd/containerd/snapshots/overlay
+github.com/containerd/containerd/snapshots/overlay/overlayutils
 github.com/containerd/containerd/snapshots/proxy
 github.com/containerd/containerd/snapshots/storage
 github.com/containerd/containerd/sys


### PR DESCRIPTION
We use `/persist/containerd/io.containerd.snapshotter.v1.overlayfs` for overlay snapshots and this not encrypted. I move them to `/persist/vault/eve.overlay.snapshotter` to use encryption.
Unfortunately it is not possible to make upgrade converter for old snapshots, we should modify containerd's meta.db, but it is locked from our init process. So, I use fallback mechanism (for mount and remove, not for creating of new snapshots) to try both snapshotters if new one failed. 