### PR TITLE
Set hostname for containerd app

### DIFF
--- a/pkg/pillar/containerd/oci.go
+++ b/pkg/pillar/containerd/oci.go
@@ -298,6 +298,7 @@ func (s *ociSpec) UpdateFromDomain(dom *types.DomainConfig) {
 
 		s.Linux.CgroupsPath = fmt.Sprintf("/%s/%s", ctrdServicesNamespace, dom.GetTaskName())
 	}
+	s.Hostname = dom.UUIDandVersion.UUID.String()
 	s.Annotations[EVEOCIVNCPasswordLabel] = dom.VncPasswd
 }
 


### PR DESCRIPTION
We should explicitly set hostname of ociSpec to use it from
non-accelerated applications

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>