### PR TITLE
Set to not bail on http error for attest [6.6 branch]

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -363,7 +363,7 @@ func sendAttestReqProtobuf(attestReq *attest.ZAttestReq, iteration int) {
 			log.Errorf("sendAttestReqProtobuf failed: %s", err)
 		}
 		zedcloud.SetDeferred(zedcloudCtx, deferKey, buf, size, attestURL,
-			true)
+			bailOnHTTPErr)
 	}
 }
 


### PR DESCRIPTION
We should re-try to send attest request in case of errors.

In master we have another approach with fix https://github.com/lf-edge/eve/pull/2283