### PR TITLE
Implementation of disks modify

### DIFF
--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -88,6 +88,7 @@ type getconfigContext struct {
 	pubContentTreeConfig     pubsub.Publication
 	subVolumeStatus          pubsub.Subscription
 	pubVolumeConfig          pubsub.Publication
+	pubDisksConfig           pubsub.Publication
 	NodeAgentStatus          *types.NodeAgentStatus
 	rebootFlag               bool
 	lastReceivedConfig       time.Time

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -108,6 +108,8 @@ func parseConfig(config *zconfig.EdgeDevConfig, getconfigCtx *getconfigContext,
 
 		parseEvConfig(getconfigCtx, config)
 
+		parseDisksConfig(getconfigCtx, config)
+
 		getconfigCtx.lastProcessedConfig = time.Now()
 	}
 	return false

--- a/pkg/pillar/cmd/zedagent/parsedisk.go
+++ b/pkg/pillar/cmd/zedagent/parsedisk.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2022 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package zedagent
+
+import (
+	"bytes"
+	"crypto/sha256"
+
+	zconfig "github.com/lf-edge/eve/api/go/config"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+var disksHash []byte
+
+// disks parsing routine
+func parseDisksConfig(ctx *getconfigContext,
+	config *zconfig.EdgeDevConfig) {
+
+	log.Tracef("Started parsing disks config")
+	cfgDisks := config.GetDisks()
+	if cfgDisks == nil {
+		return
+	}
+	cfgDisksList := cfgDisks.GetDisks()
+	h := sha256.New()
+	computeConfigElementSha(h, cfgDisks)
+	newHash := h.Sum(nil)
+	if bytes.Equal(newHash, disksHash) {
+		return
+	}
+	log.Functionf("parseDisksConfig: Applying updated config "+
+		"Last Sha: % x, "+
+		"New  Sha: % x, "+
+		"Num of cfgDisksList: %d",
+		disksHash, newHash, len(cfgDisksList))
+
+	disksHash = newHash
+
+	edgeNodeDisks := parseEdgeNodeDisks(cfgDisks)
+
+	publishDisksConfig(ctx, edgeNodeDisks)
+
+	log.Traceln("parsing disks config done")
+}
+
+func parseEdgeNodeDisks(config *zconfig.DisksConfig) types.EdgeNodeDisks {
+	disks := types.EdgeNodeDisks{}
+	disks.ArrayType = types.EdgeNodeDiskArrayType(config.ArrayType)
+	for _, el := range config.Disks {
+		diskConfig := new(types.EdgeNodeDiskConfig)
+		if el.Disk != nil {
+			diskConfig.Disk = types.EdgeNodeDiskDescription{Name: el.Disk.Name, LogicalName: el.Disk.LogicalName, Serial: el.Disk.Serial}
+		}
+		if el.OldDisk != nil {
+			diskConfig.OldDisk = &types.EdgeNodeDiskDescription{Name: el.OldDisk.Name, LogicalName: el.OldDisk.LogicalName, Serial: el.OldDisk.Serial}
+		}
+		diskConfig.Config = types.EdgeNodeDiskConfigType(el.DiskConfig)
+		disks.Disks = append(disks.Disks, *diskConfig)
+	}
+	for _, el := range config.Children {
+		disks.Children = append(disks.Children, parseEdgeNodeDisks(el))
+	}
+	return disks
+}
+
+func publishDisksConfig(ctx *getconfigContext,
+	config types.EdgeNodeDisks) {
+
+	key := config.Key()
+	log.Tracef("publishDisksConfig(%s)\n", key)
+	pub := ctx.pubDisksConfig
+	pub.Publish(key, config)
+	log.Tracef("publishDisksConfig(%s) done\n", key)
+}

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -537,6 +537,18 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	pubVolumeConfig.ClearRestarted()
 	getconfigCtx.pubVolumeConfig = pubVolumeConfig
 
+	// for disk config Publisher
+	pubDisksConfig, err := ps.NewPublication(
+		pubsub.PublicationOptions{
+			AgentName: agentName,
+			TopicType: types.EdgeNodeDisks{},
+		})
+	if err != nil {
+		log.Fatal(err)
+	}
+	pubDisksConfig.ClearRestarted()
+	getconfigCtx.pubDisksConfig = pubDisksConfig
+
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     agentName,

--- a/pkg/pillar/cmd/zfsmanager/handlediskconfig.go
+++ b/pkg/pillar/cmd/zfsmanager/handlediskconfig.go
@@ -1,0 +1,227 @@
+// Copyright (c) 2022 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package zfsmanager
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	libzfs "github.com/bicomsystems/go-libzfs"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/lf-edge/eve/pkg/pillar/utils/disks"
+	"github.com/lf-edge/eve/pkg/pillar/vault"
+	"github.com/lf-edge/eve/pkg/pillar/zfs"
+)
+
+func getVdevNameAndStatus(devTree libzfs.VDevTree, name string) (string, libzfs.VDevStat) {
+	if devTree.Type != libzfs.VDevTypeDisk {
+		for _, d := range devTree.Devices {
+			retDev, retStat := getVdevNameAndStatus(d, name)
+			if retDev != "" {
+				return retDev, retStat
+			}
+		}
+	} else {
+		// we can receive partition number
+		devName, err := disks.GetDiskNameByPartName(devTree.Name)
+		if err != nil {
+			log.Errorf("failed to get disk name by part name %s: %s", devTree.Name, err)
+		}
+		if strings.Contains(devName, name) {
+			return devName, devTree.Stat
+		}
+	}
+	return "", libzfs.VDevStat{}
+}
+
+func handleDisksConfigCreate(ctxArg interface{}, _ string, _ interface{}) {
+	handleDisksConfigImpl(ctxArg.(*zfsContext))
+}
+
+func handleDisksConfigModify(ctxArg interface{}, _ string, _ interface{}, _ interface{}) {
+	handleDisksConfigImpl(ctxArg.(*zfsContext))
+}
+
+func handleDisksConfigImpl(ctx *zfsContext) {
+	log.Functionf("handleDisksConfigImpl")
+	select {
+	case ctx.disksProcessingTrigger <- struct{}{}:
+	default:
+		log.Functionf("handleDiskConfigRestart: disksProcessingTrigger already triggered")
+	}
+	log.Functionf("handleDisksConfigImpl Done")
+}
+
+func processDisksTask(ctx *zfsContext) {
+
+	disksProcessingTicker := time.NewTicker(disksProcessingInterval)
+
+	wdName := agentName + "diskstask"
+	stillRunning := time.NewTicker(stillRunningInterval)
+	ctx.ps.StillRunning(wdName, warningTime, errorTime)
+
+	for {
+		select {
+		case <-disksProcessingTicker.C:
+			// we run processing periodically to ensure that our expectation and states/layout are in sync
+			// potentially some commands may return errors in case of not-ended operations
+			// we should cover hot-plugged devices
+			if err := processDisks(ctx); err != nil {
+				log.Errorf("processDisks error: %s", err)
+			}
+		case <-ctx.disksProcessingTrigger:
+			if err := processDisks(ctx); err != nil {
+				log.Errorf("processDisks error: %s", err)
+			}
+		case <-stillRunning.C:
+		}
+		ctx.ps.StillRunning(wdName, warningTime, errorTime)
+	}
+}
+
+func processDisks(ctx *zfsContext) error {
+	if vault.ReadPersistType() != types.PersistZFS {
+		return nil
+	}
+	disksConfigInterface, err := ctx.subDisksConfig.Get("global")
+	if err != nil {
+		log.Functionf("cannot get disks config: %s", err)
+		return nil
+	}
+	disksConfig := disksConfigInterface.(types.EdgeNodeDisks)
+	persistPool, err := libzfs.PoolOpen(vault.DefaultZpool)
+	if err != nil {
+		return fmt.Errorf("cannot open pool: %s", err)
+	}
+	defer persistPool.Close()
+	disksStateProcessing(disksConfig, persistPool)
+	disksLayoutProcessing(disksConfig, persistPool)
+	return nil
+}
+
+//disksStateProcessing iterate over disks and adjust its state accordingly to the config
+//we expect that zfs will handle conflicts between order of calls
+func disksStateProcessing(disks types.EdgeNodeDisks, pool libzfs.Pool) {
+	vdevTree, err := pool.VDevTree()
+	if err != nil {
+		log.Errorf("cannot get vdev tree: %s", err)
+		return
+	}
+	for _, diskCfg := range disks.Disks {
+		diskName := filepath.Base(diskCfg.Disk.Name)
+		if diskCfg.OldDisk != nil {
+			oldDiskName := filepath.Base(diskCfg.OldDisk.Name)
+			oldDevName, oldDevStat := getVdevNameAndStatus(vdevTree, oldDiskName)
+			if oldDevName != "" && diskCfg.Disk.Name != "" {
+				// if we found device oldDevName, replace it
+				log.Functionf("replacing %s with %s, old stat %s", oldDevName, diskCfg.Disk.Name, oldDevStat.State.String())
+				if stdout, err := zfs.ReplaceVDev(log, vault.DefaultZpool, oldDevName, diskCfg.Disk.Name); err != nil {
+					log.Errorf("cannot replace %s with %s: %s %s", oldDevName, diskCfg.Disk.Name, stdout, err)
+					continue
+				}
+			}
+		}
+		devName, devStat := getVdevNameAndStatus(vdevTree, diskName)
+		// found in pool
+		if devName != "" {
+			log.Functionf("zpool config disk %s, op %d, stat %s", devName, diskCfg.Config, devStat.State.String())
+			switch diskCfg.Config {
+			case types.EdgeNodeDiskConfigTypeZfsOnline:
+				switch zfs.GetZfsDeviceStatusFromStr(devStat.State.String()) {
+				case types.StorageStatusOffline:
+					if err := pool.Online(true, devName); err != nil {
+						log.Errorf("cannot bring %s online: %s", devName, err)
+					}
+				case types.StorageStatusOnline:
+					continue
+				default:
+					log.Errorf("unexpected state of disk %s (%s) to make online", devName, devStat.State.String())
+					continue
+				}
+			case types.EdgeNodeDiskConfigTypeZfsOffline:
+				switch zfs.GetZfsDeviceStatusFromStr(devStat.State.String()) {
+				case types.StorageStatusOnline:
+					if err := pool.Offline(true, devName); err != nil {
+						log.Errorf("cannot bring %s offline: %s", devName, err)
+					}
+				case types.StorageStatusOffline:
+					continue
+				default:
+					log.Errorf("unexpected state of disk %s (%s) to make offline", devName, devStat.State.String())
+					continue
+				}
+			case types.EdgeNodeDiskConfigTypeUnused:
+				if stdout, err := zfs.RemoveVDev(log, vault.DefaultZpool, devName); err != nil {
+					log.Errorf("cannot remove %s: %s %s", devName, stdout, err)
+				}
+			}
+		}
+	}
+	for _, el := range disks.Children {
+		// process children states
+		// we process only states of devices as part of vdevs, so we assume that we can handle them in any order
+		disksStateProcessing(el, pool)
+	}
+}
+
+//disksLayoutProcessing iterate over disks and adjust pool layout accordingly to the config
+func disksLayoutProcessing(disks types.EdgeNodeDisks, pool libzfs.Pool) {
+	vdevTree, err := pool.VDevTree()
+	if err != nil {
+		log.Errorf("cannot get vdev tree: %s", err)
+		return
+	}
+	switch disks.ArrayType {
+	case types.EdgeNodeDiskArrayTypeRAID0:
+		disksLayoutRaid0Process(vdevTree, disks.Children)
+	default:
+		// TBD: other array types
+		log.Warnf("Not implemented layout processing for array type: %d", disks.ArrayType)
+	}
+}
+
+//disksLayoutRaid0Process ensure layout for batch of top-level vdevs in pool
+//we support raid0 of unspecified (single disk) and raid1 (mirror of disks) layout here
+func disksLayoutRaid0Process(vdevTree libzfs.VDevTree, disks []types.EdgeNodeDisks) {
+	for _, el := range disks {
+		switch el.ArrayType {
+		case types.EdgeNodeDiskArrayTypeUnspecified, types.EdgeNodeDiskArrayTypeRAID1:
+			diskName := ""
+			// check if we have one of defined devices as part of vdev
+			for _, dsk := range el.Disks {
+				if currentDiskName, _ := getVdevNameAndStatus(vdevTree, dsk.Disk.Name); currentDiskName != "" {
+					diskName = dsk.Disk.Name
+					break
+				}
+			}
+			// if no disk found add first as a new vdev
+			if diskName == "" {
+				if len(el.Disks) > 0 {
+					// we add first device here as a new vdev to attach needed disks to it later
+					if stdout, err := zfs.AddVDev(log, vault.DefaultZpool, el.Disks[0].Disk.Name); err != nil {
+						log.Errorf("cannot add %s: %s %s", diskName, stdout, err)
+					} else {
+						diskName = el.Disks[0].Disk.Name
+					}
+				}
+			}
+			// if disk is here attach another disks
+			if diskName != "" {
+				for _, dsk := range el.Disks {
+					// check if already in pool or added as part of current iteration (we do not refresh the tree)
+					if currentDiskName, _ := getVdevNameAndStatus(vdevTree, dsk.Disk.Name); currentDiskName != "" || diskName == dsk.Disk.Name {
+						continue
+					}
+					if stdout, err := zfs.AttachVDev(log, vault.DefaultZpool, diskName, dsk.Disk.Name); err != nil {
+						log.Errorf("cannot attach %s to %s: %s %s", dsk.Disk.Name, diskName, stdout, err)
+					}
+				}
+			}
+		default:
+			log.Warnf("No supported child processing for array type: %d", el.ArrayType)
+		}
+	}
+}

--- a/pkg/pillar/types/disktypes.go
+++ b/pkg/pillar/types/disktypes.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2022 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+//EdgeNodeDiskDescription stores information to identify disk
+type EdgeNodeDiskDescription struct {
+	Name        string
+	LogicalName string
+	Serial      string
+}
+
+//EdgeNodeDisks stores expected layout of disks
+type EdgeNodeDisks struct {
+	Disks     []EdgeNodeDiskConfig
+	ArrayType EdgeNodeDiskArrayType
+	Children  []EdgeNodeDisks
+}
+
+//Key for pubsub
+func (EdgeNodeDisks) Key() string {
+	return "global"
+}
+
+//EdgeNodeDiskConfigType should be in sync with api
+type EdgeNodeDiskConfigType int32
+
+// enum should be in sync with api
+const (
+	EdgeNodeDiskConfigTypeUnspecified EdgeNodeDiskConfigType = iota // no configured, do nothing
+	EdgeNodeDiskConfigTypeEveOs                                     // the disk EVE is installed on
+	EdgeNodeDiskConfigTypePersist                                   // the disk is separate persist partition or disk, not zfs
+	EdgeNodeDiskConfigTypeZfsOnline                                 // included in zfs and online
+	EdgeNodeDiskConfigTypeZfsOffline                                // included in zfs and offline
+	EdgeNodeDiskConfigTypeAppDirect                                 // for direct assignment
+	EdgeNodeDiskConfigTypeUnused                                    // removed from zfs/app-direct
+)
+
+//EdgeNodeDiskArrayType should be in sync with api
+type EdgeNodeDiskArrayType int32
+
+// enum should be in sync with api
+const (
+	EdgeNodeDiskArrayTypeUnspecified EdgeNodeDiskArrayType = 0 // no configured
+	EdgeNodeDiskArrayTypeRAID0       EdgeNodeDiskArrayType = 1 // stripe
+	EdgeNodeDiskArrayTypeRAID1       EdgeNodeDiskArrayType = 2 // mirror
+	EdgeNodeDiskArrayTypeRAID5       EdgeNodeDiskArrayType = 3 // raidz1
+	EdgeNodeDiskArrayTypeRAID6       EdgeNodeDiskArrayType = 4 // raidz2
+)
+
+//EdgeNodeDiskConfig disk configuration
+type EdgeNodeDiskConfig struct {
+	Disk    EdgeNodeDiskDescription
+	OldDisk *EdgeNodeDiskDescription
+	Config  EdgeNodeDiskConfigType
+}

--- a/pkg/pillar/zfs/zfs.go
+++ b/pkg/pillar/zfs/zfs.go
@@ -227,6 +227,46 @@ func alignUpToBlockSize(size uint64) uint64 {
 	return (size + volBlockSize - 1) & ^(volBlockSize - 1)
 }
 
+//RemoveVDev removes vdev from the pool
+func RemoveVDev(log *base.LogObject, pool, vdev string) (string, error) {
+	args := append(zpoolPath, "remove", pool, vdev)
+	stdoutStderr, err := base.Exec(log, vault.ZfsPath, args...).CombinedOutput()
+	if err != nil {
+		return string(stdoutStderr), err
+	}
+	return strings.TrimSpace(string(stdoutStderr)), nil
+}
+
+//AttachVDev attach newVdev to existing vdev
+func AttachVDev(log *base.LogObject, pool, vdev, newVdev string) (string, error) {
+	args := append(zpoolPath, "attach", pool, vdev, newVdev)
+	stdoutStderr, err := base.Exec(log, vault.ZfsPath, args...).CombinedOutput()
+	if err != nil {
+		return string(stdoutStderr), err
+	}
+	return strings.TrimSpace(string(stdoutStderr)), nil
+}
+
+//AddVDev add newVdev to pool
+func AddVDev(log *base.LogObject, pool, vdev string) (string, error) {
+	args := append(zpoolPath, "add", "-f", pool, vdev)
+	stdoutStderr, err := base.Exec(log, vault.ZfsPath, args...).CombinedOutput()
+	if err != nil {
+		return string(stdoutStderr), err
+	}
+	return strings.TrimSpace(string(stdoutStderr)), nil
+}
+
+//ReplaceVDev replaces vdev from the pool
+func ReplaceVDev(log *base.LogObject, pool, oldVdev, newVdev string) (string, error) {
+	args := append(zpoolPath, "replace", pool, oldVdev, newVdev)
+	stdoutStderr, err := base.Exec(log, vault.ZfsPath, args...).CombinedOutput()
+	if err != nil {
+		return string(stdoutStderr), err
+	}
+	return strings.TrimSpace(string(stdoutStderr)), nil
+}
+
 // GetZfsVersion return zfs kernel module version
 func GetZfsVersion() (string, error) {
 	dataBytes, err := ioutil.ReadFile("/hostfs/sys/module/zfs/version")


### PR DESCRIPTION
Implementation for changes from #2531 

We expect structure like

```
Disks: &config.DisksConfig{
	ArrayType: config.DisksArrayType_DISKS_ARRAY_TYPE_RAID0,
	Children: []*config.DisksConfig{
			{
				Disks: []*config.DiskConfig{
					{
						Disk: &evecommon.DiskDescription{Name: "/dev/sdb"}, DiskConfig: config.DiskConfigType_DISK_CONFIG_TYPE_ZFS_ONLINE,
					},
					{
						Disk: &evecommon.DiskDescription{Name: "/dev/sdc"}, DiskConfig: config.DiskConfigType_DISK_CONFIG_TYPE_ZFS_ONLINE,
					},
				},
				ArrayType: config.DisksArrayType_DISKS_ARRAY_TYPE_RAID1,
			},
			{
				Disks: []*config.DiskConfig{
					{
						Disk: &evecommon.DiskDescription{Name: "/dev/sdd"}, DiskConfig: config.DiskConfigType_DISK_CONFIG_TYPE_ZFS_ONLINE,
					},
					{
						Disk: &evecommon.DiskDescription{Name: "/dev/sde"}, DiskConfig: config.DiskConfigType_DISK_CONFIG_TYPE_ZFS_ONLINE,
					},
				},
				ArrayType: config.DisksArrayType_DISKS_ARRAY_TYPE_RAID1,
			},
		},
}
```

to be provided as a configuration