### PR TITLE
Additional patches from CoreOS for grub

### DIFF
--- a/pkg/grub/patches-aarch64-2.06/0007-set-cmddevice.patch
+++ b/pkg/grub/patches-aarch64-2.06/0007-set-cmddevice.patch
@@ -1,0 +1,26 @@
+From 35c2f5ba467711b308124ebb61ea6aef4eb77707 Mon Sep 17 00:00:00 2001
+From: Petr Fedchenkov <giggsoff@gmail.com>
+Date: Thu, 3 Mar 2022 13:00:27 +0100
+Subject: [PATCH 1/2] set cmddevice
+
+---
+ grub-core/kern/main.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/grub-core/kern/main.c b/grub-core/kern/main.c
+index 73967e2f5..f4ffecc2a 100644
+--- a/grub-core/kern/main.c
++++ b/grub-core/kern/main.c
+@@ -132,6 +132,9 @@ grub_set_prefix_and_root (void)
+     {
+       char *cmdpath;
+ 
++      grub_env_set ("cmddevice", fwdevice);
++      grub_env_export ("cmddevice");
++
+       cmdpath = grub_xasprintf ("(%s)%s", fwdevice, fwpath ? : "");
+       if (cmdpath)
+ 	{
+-- 
+2.32.0
+

--- a/pkg/grub/patches-aarch64-2.06/0008-search.patch
+++ b/pkg/grub/patches-aarch64-2.06/0008-search.patch
@@ -1,0 +1,130 @@
+From 7e7a53bd7911df2f4e83f0be369e52fd4a47ac8e Mon Sep 17 00:00:00 2001
+From: Petr Fedchenkov <giggsoff@gmail.com>
+Date: Thu, 3 Mar 2022 13:59:20 +0100
+Subject: [PATCH 2/2] search changes
+
+---
+ grub-core/commands/search.c | 75 ++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 74 insertions(+), 1 deletion(-)
+
+diff --git a/grub-core/commands/search.c b/grub-core/commands/search.c
+index ed090b3af..fd411ce3e 100644
+--- a/grub-core/commands/search.c
++++ b/grub-core/commands/search.c
+@@ -30,6 +30,10 @@
+ #include <grub/i18n.h>
+ #include <grub/disk.h>
+ #include <grub/partition.h>
++#if defined(DO_SEARCH_PART_UUID) || defined(DO_SEARCH_PART_LABEL) || \
++    defined(DO_SEARCH_DISK_UUID)
++#include <grub/gpt_partition.h>
++#endif
+ 
+ GRUB_MOD_LICENSE ("GPLv3+");
+ 
+@@ -66,7 +70,7 @@ iterate_device (const char *name, void *data)
+       name[0] == 'f' && name[1] == 'd' && name[2] >= '0' && name[2] <= '9')
+     return 1;
+ 
+-#ifdef DO_SEARCH_FS_UUID
++#if defined(DO_SEARCH_FS_UUID) || defined(DO_SEARCH_DISK_UUID)
+ #define compare_fn grub_strcasecmp
+ #else
+ #define compare_fn grub_strcmp
+@@ -90,6 +94,63 @@ iterate_device (const char *name, void *data)
+ 	}
+       grub_free (buf);
+     }
++#elif defined(DO_SEARCH_PART_UUID)
++    {
++      grub_device_t dev;
++      char *quid;
++
++      dev = grub_device_open (name);
++      if (dev)
++	{
++	  if (grub_gpt_part_uuid (dev, &quid) == GRUB_ERR_NONE)
++	    {
++	      if (grub_strcasecmp (quid, ctx->key) == 0)
++		    found = 1;
++
++	      grub_free (quid);
++	    }
++
++	  grub_device_close (dev);
++	}
++    }
++#elif defined(DO_SEARCH_PART_LABEL)
++    {
++      grub_device_t dev;
++      char *quid;
++
++      dev = grub_device_open (name);
++      if (dev)
++	{
++	  if (grub_gpt_part_label (dev, &quid) == GRUB_ERR_NONE)
++	    {
++	      if (grub_strcmp (quid, ctx->key) == 0)
++		    found = 1;
++
++	      grub_free (quid);
++	    }
++
++	  grub_device_close (dev);
++	}
++    }
++#elif defined(DO_SEARCH_DISK_UUID)
++    {
++      grub_device_t dev;
++      char *quid;
++
++      dev = grub_device_open (name);
++      if (dev)
++	{
++	  if (grub_gpt_disk_uuid (dev, &quid) == GRUB_ERR_NONE)
++	    {
++	      if (grub_strcmp (quid, ctx->key) == 0)
++		found = 1;
++
++	      grub_free (quid);
++	    }
++
++	  grub_device_close (dev);
++	}
++    }
+ #else
+     {
+       /* SEARCH_FS_UUID or SEARCH_LABEL */
+@@ -313,8 +374,14 @@ static grub_command_t cmd;
+ 
+ #ifdef DO_SEARCH_FILE
+ GRUB_MOD_INIT(search_fs_file)
++#elif defined(DO_SEARCH_PART_UUID)
++GRUB_MOD_INIT(search_part_uuid)
++#elif defined(DO_SEARCH_PART_LABEL)
++GRUB_MOD_INIT(search_part_label)
+ #elif defined (DO_SEARCH_FS_UUID)
+ GRUB_MOD_INIT(search_fs_uuid)
++#elif defined (DO_SEARCH_DISK_UUID)
++GRUB_MOD_INIT(search_disk_uuid)
+ #else
+ GRUB_MOD_INIT(search_label)
+ #endif
+@@ -327,8 +394,14 @@ GRUB_MOD_INIT(search_label)
+ 
+ #ifdef DO_SEARCH_FILE
+ GRUB_MOD_FINI(search_fs_file)
++#elif defined(DO_SEARCH_PART_UUID)
++GRUB_MOD_FINI(search_part_uuid)
++#elif defined(DO_SEARCH_PART_LABEL)
++GRUB_MOD_FINI(search_part_label)
+ #elif defined (DO_SEARCH_FS_UUID)
+ GRUB_MOD_FINI(search_fs_uuid)
++#elif defined (DO_SEARCH_DISK_UUID)
++GRUB_MOD_FINI(search_disk_uuid)
+ #else
+ GRUB_MOD_FINI(search_label)
+ #endif
+-- 
+2.32.0
+


### PR DESCRIPTION
Seems we miss several patches from CoreOS when move to 2.06 and right now we cannot boot installer from usb on arm64 because of empty `cmddevice` and non-implemented `search.part_label`.
I have no ideas, do we support it on riscv64, so I put patches into directory for arm64.