### PR TITLE
Use only TPM key to encrypt the vault

### DIFF
--- a/pkg/pillar/cmd/vaultmgr/vaultmgrzfs.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgrzfs.go
@@ -76,6 +76,11 @@ func unlockZfsVault(vaultPath string) error {
 
 //e.g. zfs create -o encryption=aes-256-gcm -o keylocation=file://tmp/raw.key -o keyformat=raw perist/vault
 func createZfsVault(vaultPath string) error {
+
+	//create vault config file before creating the vault
+	if err := createVaultConfigFile(); err != nil {
+		return err
+	}
 	//prepare key in the staging file
 	//we never create deprecated vault on ZFS
 	//cloudKeyOnlyMode=false, useSealedKey=true


### PR DESCRIPTION
Starting this commit a new  install of EVE-OS will create vaultconfig.json file on systems with TPM support. That file will be used to determine whether to use only the TPM key or merge the TPM and controller key. All existing installs will not get this config file and hence will always merge the keys for upgrade compatibility. This applies to both ext4 and zfs filesystems.

Testing done
============
1) New installs on both ext4 and zfs created vaultconfig.json with content {"TpmKeyOnly":true} and only 32byte TPM key is used to encrypt the vault.
2) Upgrades from earlier versions did not create the vaultconfig file and hence merged key is used.



Signed-off-by: Pramodh Pallapothu <pramodh@zededa.com>