### PR TITLE
Use TPM key only for vault protection

### DIFF
--- a/pkg/pillar/types/vaultmgrtypes.go
+++ b/pkg/pillar/types/vaultmgrtypes.go
@@ -20,6 +20,16 @@ type VaultStatus struct {
 	ErrorAndTime
 }
 
+// VaultConfig represents vault key to be used
+type VaultConfig struct {
+	TpmKeyOnly bool
+}
+
+// Key :
+func (config VaultConfig) Key() string {
+	return "global"
+}
+
 //Key returns the key used for indexing into a list of vaults
 func (status VaultStatus) Key() string {
 	return status.Name


### PR DESCRIPTION
Starting this commit a new install of EVE-OS will create vault config file on systems with TPM support. That file will be used to determine whether to use only the TPM key or merge the TPM and controller key.  This applies to both ext4 and zfs filesystems.

On systems with TPM enabled
1) All existing installs as part of upgrade will create vault config with {"TpmKeyOnly":false}
2) New installs will create create vault config with {"TpmKeyOnly":true}

On non-TPM systems, its a no-op

Testing
========
1) New installs on both ext4 and zfs created global.json with content {"TpmKeyOnly":true} and only 32byte TPM key is used to encrypt the vault.
2) Upgrades from earlier versions did not create the vaultconfig file and hence merged key is used.
3) Restart/reboot of devices always read vaultconfig file and use keys according to the config set.



Signed-off-by: Pramodh Pallapothu <pramodh@zededa.com>