### PR TITLE
Remove temp directories as part of Test_ConvertUUIDPairToNum

### DIFF
--- a/pkg/pillar/cmd/upgradeconverter/upgradeconverter_test.go
+++ b/pkg/pillar/cmd/upgradeconverter/upgradeconverter_test.go
@@ -516,4 +516,5 @@ func Test_ConvertUUIDPairToNum(t *testing.T) {
 			t.Fatalf("CreateTime mismatch: %s vs %s", val.CreateTime, uptn.CreateTime)
 		}
 	}
+	ucContextCleanupDirs(ctxPtr)
 }


### PR DESCRIPTION
We should delete directories created by Test_ConvertUUIDPairToNum

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>