### PR TITLE
Set max_sectors explicitly to run Windows VM with vhost-scsi-pci

### DIFF
--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -271,6 +271,7 @@ const qemuDiskTemplate = `
 {{- else}}
 [device "vhost-disk{{.DiskID}}"]
   driver = "vhost-scsi-pci"
+  max_sectors = "16384"
   wwpn = "{{.WWN}}"
   bus = "pci.{{.PCIId}}"
   addr = "0x0"

--- a/pkg/pillar/hypervisor/kvm_test.go
+++ b/pkg/pillar/hypervisor/kvm_test.go
@@ -1150,6 +1150,7 @@ func TestCreateDomConfig(t *testing.T) {
 
 [device "vhost-disk4"]
   driver = "vhost-scsi-pci"
+  max_sectors = "16384"
   wwpn = "naa.000000000000000a"
   bus = "pci.7"
   addr = "0x0"
@@ -1447,6 +1448,7 @@ func TestCreateDomConfig(t *testing.T) {
 
 [device "vhost-disk4"]
   driver = "vhost-scsi-pci"
+  max_sectors = "16384"
   wwpn = "naa.000000000000000a"
   bus = "pci.7"
   addr = "0x0"
@@ -1755,6 +1757,7 @@ func TestCreateDomConfig(t *testing.T) {
 
 [device "vhost-disk4"]
   driver = "vhost-scsi-pci"
+  max_sectors = "16384"
   wwpn = "naa.000000000000000a"
   bus = "pci.7"
   addr = "0x0"
@@ -2040,6 +2043,7 @@ func TestCreateDomConfig(t *testing.T) {
 
 [device "vhost-disk4"]
   driver = "vhost-scsi-pci"
+  max_sectors = "16384"
   wwpn = "naa.000000000000000a"
   bus = "pci.7"
   addr = "0x0"


### PR DESCRIPTION
I can see `[  259.573575] vhost_scsi_calc_sgls: requested sgl_count: 2649 exceeds pre-allocated max_sgls: 2048` in kernel messages and Windows VM do not boot with zfs/vhost-scsi-pci.

As discussed in https://edk2.groups.io/g/discuss/topic/windows_2019_vm_fails_to_boot/74465994: `I/O size exceeds the max SCSI I/O limitation(8M) of vhost-scsi in KVM` and we should adjust options to run Windows VM with vhost-scsi-pci.