### PR TITLE
Have installer default to fixed disk/partition UUIDs

### DIFF
--- a/pkg/mkimage-raw-efi/install
+++ b/pkg/mkimage-raw-efi/install
@@ -16,6 +16,7 @@
 #   eve_pause_before_install
 #   eve_pause_after_install
 #   eve_reboot_after_install
+#   eve_install_random_disk_uuids
 #   eve_install_skip_config
 #   eve_install_skip_persist
 #   eve_install_skip_rootfs
@@ -254,6 +255,11 @@ done
 # we may be asked to pause before install procedure
 grep -q eve_pause_before_install /proc/cmdline && pause "formatting the /dev/$INSTALL_DEV"
 
+# Do we want random or fixed disk and partition UUIDs?
+RANDOM_DISK_UUIDS=
+grep -q eve_install_random_disk_uuids /proc/cmdline && RANDOM_DISK_UUIDS="-r"
+logmsg "INFO: RANDOM_DISK_UUIDS $RANDOM_DISK_UUIDS"
+
 # User may have requested to skip the zfs requirements checks.
 SKIP_ZFS_CHECKS=false
 grep -q eve_install_skip_zfs_checks /proc/cmdline && SKIP_ZFS_CHECKS=true
@@ -317,6 +323,10 @@ if [ "$INSTALL_DEV" != "$INSTALL_PERSIST" ]; then
      sgdisk -Z --clear "$PDEV" 2>/dev/null || :
      sgdisk --new 1:2048:0 --typecode=1:5f24425a-2dfa-11e8-a270-7b663faccc2c --change-name=1:P3 "$PDEV"
      sgdisk -v "$PDEV"
+     if [ -z "$RANDOM_DISK_UUIDS" ]; then
+        PERSIST_UUID=ad6871ee-31f9-4cf3-9e09-6f7a25c30059
+        sgdisk --partition-guid="1:$PERSIST_UUID" "$PDEV"
+     fi
      # force make-raw to skip persist
      MAKE_RAW_PARTS="efi imga imgb conf"
    fi
@@ -329,7 +339,8 @@ else
 fi
 
 # do the install (unless we're only here to collect the black box)
-grep -q eve_blackbox /proc/cmdline || /make-raw "/dev/$INSTALL_DEV" $MAKE_RAW_PARTS || bail "Installation failed. Entering shell..."
+# shellcheck disable=SC2086
+grep -q eve_blackbox /proc/cmdline || /make-raw $RANDOM_DISK_UUIDS "/dev/$INSTALL_DEV" $MAKE_RAW_PARTS || bail "Installation failed. Entering shell..."
 
 if [ "$MULTIPLE_DISKS" = true ] && [ "$INSTALL_ZFS" = true ]; then
   if [ "$DISK_WITH_P3" != "" ]; then

--- a/pkg/mkimage-raw-efi/make-raw
+++ b/pkg/mkimage-raw-efi/make-raw
@@ -22,10 +22,11 @@
 #   * /persist partition
 #
 # The script CLI UX is really not user friendly for now, since it is expected
-# to be called mostly from other scripts (and also linuxkit VMs). So no, there's
-# no printing of help for this one and all the arguments are required! Here they are:
-#   <img> [part1...] 
+# to be called mostly from other scripts (and also linuxkit VMs).
+# The syntax is:
+#   [-r] <img> [part1...]
 # 
+# -r          use random_disk_uuids (old behavior)
 # <img>       file name of the raw disk image (we expect it to be pre-created and 
 #             sized correctly OR be an actual physical device)
 # [part1...]  list of partitions to be created: efi imga imgb conf persist
@@ -42,6 +43,16 @@
 set -e
 [ -n "$DEBUG" ] && set -x
 
+RANDOM_DISK_UUIDS=
+while getopts r o
+do      case "$o" in
+        r)      RANDOM_DISK_UUIDS="-r";;
+        [?])    echo "Usage: $0 [-r] <img> [parts...]"
+                exit 1;;
+        esac
+done
+shift $((OPTIND-1))
+
 IMGFILE=$1
 shift
 PARTS=${*:-"efi imga imgb conf persist"}
@@ -49,6 +60,14 @@ PARTS=${*:-"efi imga imgb conf persist"}
 # This is the only partition type that PARTITION_TYPE_USR_X86_64
 # grub-core/commands/gptprio.c code will pay attention to
 PARTITION_TYPE_USR_X86_64=5dfbf5f4-2848-4bac-aa5e-0d9a20b745a6
+
+# The static UUIDs for the disk and the partitions
+DISK_UUID=ad6871ee-31f9-4cf3-9e09-6f7a25c30050
+EFI_UUID=ad6871ee-31f9-4cf3-9e09-6f7a25c30051
+IMGA_UUID=ad6871ee-31f9-4cf3-9e09-6f7a25c30052
+IMGB_UUID=ad6871ee-31f9-4cf3-9e09-6f7a25c30053
+CONF_UUID=ad6871ee-31f9-4cf3-9e09-6f7a25c30054
+PERSIST_UUID=ad6871ee-31f9-4cf3-9e09-6f7a25c30059
 
 # EFI partition size in bytes 
 EFI_PART_SIZE=$((36 * 1024 * 1024))
@@ -133,10 +152,14 @@ do_system_vfat_part() {
 }
 
 do_efi() {
+  local NUM_PART=$(( PART_OFFSET + 1 ))
   mkefifs
   sed -e 's#@PATH_TO_GRUB@#'"$(cd /efifs; echo EFI/BOOT/BOOT*EFI)"'#' < /grub.cfg.in > /efifs/EFI/BOOT/grub.cfg
   cp -r "$BOOT_DIR"/* /efifs/ 2>/dev/null || :
   do_system_vfat_part "$1" "$EFI_PART_SIZE"
+  if [ -z "$RANDOM_DISK_UUIDS" ]; then
+      sgdisk --partition-guid="$NUM_PART:$EFI_UUID" "$IMGFILE"
+  fi
 }
 
 do_installer() {
@@ -155,14 +178,15 @@ do_installer() {
 do_rootfs() {
     eval SEC_START=\$$1
     local SEC_END=`grow_part $SEC_START $ROOTFS_PART_SIZE`
+    local NUM_PART
     LABEL=$2
     IMG=$3
 
-    case $2 in
-      IMGA) NUM_PART=$(( $PART_OFFSET + 2 ))
+    case $LABEL in
+      IMGA) NUM_PART=$(( PART_OFFSET + 2 ))
             EXTRA_ATTR="--attributes=$NUM_PART:set:56 --attributes=$NUM_PART:set:49"
             ;;
-      IMGB) NUM_PART=$(( $PART_OFFSET + 3 ))
+      IMGB) NUM_PART=$(( PART_OFFSET + 3 ))
             ;;
     esac
 
@@ -170,6 +194,15 @@ do_rootfs() {
     sgdisk --new "$NUM_PART:$SEC_START:$SEC_END" \
            --typecode="$NUM_PART:$PARTITION_TYPE_USR_X86_64" \
            --change-name="$NUM_PART:$LABEL" $EXTRA_ATTR "$IMGFILE"
+
+    if [ -z "$RANDOM_DISK_UUIDS" ]; then
+        case $LABEL in
+            IMGA) sgdisk --partition-guid="$NUM_PART:$IMGA_UUID" "$IMGFILE"
+                  ;;
+            IMGB) sgdisk --partition-guid="$NUM_PART:$IMGB_UUID" "$IMGFILE"
+            ;;
+        esac
+    fi
 
     # Copy rootfs to image A
     dd if=$IMG of=$IMGFILE bs=1M conv=notrunc seek="$(( SEC_START * 512 ))" oflag=seek_bytes
@@ -189,12 +222,12 @@ do_imgb() {
 do_vfat() {
     eval local SEC_START=\$$1
     local SEC_END=`grow_part $SEC_START $CONF_PART_SIZE`
-    local NUM_PART=$(( $PART_OFFSET + 4 ))
+    local NUM_PART=$(( PART_OFFSET + 4 ))
     local PART_TYPE=$2
 
     sgdisk --new $NUM_PART:$SEC_START:$SEC_END \
            --typecode=$NUM_PART:$PART_TYPE \
-	   --change-name=$NUM_PART:'CONFIG' $IMGFILE
+           --change-name="$NUM_PART:CONFIG" "$IMGFILE"
 
     dd if=$CONF_FILE of=$IMGFILE bs=1M conv=notrunc seek="$(( SEC_START * 512 ))" oflag=seek_bytes
 
@@ -203,6 +236,10 @@ do_vfat() {
 
 do_conf() {
     do_vfat $1 13307e62-cd9c-4920-8f9b-91b45828b798
+    if [ -z "$RANDOM_DISK_UUIDS" ]; then
+        local NUM_PART=$(( PART_OFFSET + 4 ))
+        sgdisk --partition-guid="$NUM_PART:$CONF_UUID" "$IMGFILE"
+    fi
 }
 
 do_conf_win() {
@@ -232,7 +269,7 @@ do_persist() {
     eval SEC_START=\$$1
     # Persistent Purgeable Partition.  It is set at partition
     # number 9 to reserve the first 8 partitions to system types.
-    local NUM_PART=$(( $PART_OFFSET + 9 ))
+    local NUM_PART=$(( PART_OFFSET + 9 ))
     # P3 takes all space available
     local SEC_END=0
 
@@ -240,6 +277,9 @@ do_persist() {
            --typecode=$NUM_PART:5f24425a-2dfa-11e8-a270-7b663faccc2c \
            --change-name=$NUM_PART:'P3' $IMGFILE
 
+    if [ -z "$RANDOM_DISK_UUIDS" ]; then
+        sgdisk --partition-guid="$NUM_PART:$PERSIST_UUID" "$IMGFILE"
+    fi
     dd if="$PERSIST_FILE" of="$IMGFILE" bs=1M conv=notrunc seek="$(( SEC_START * 512 ))" oflag=seek_bytes
     
     eval $1=0
@@ -363,6 +403,10 @@ case "$(sgdisk -p $IMGFILE 2>/dev/null | sed -ne '/^Number/,$s/^.* //p' | tr '\0
       sgdisk -Z --clear $IMGFILE 2>/dev/null || :
       ;;
 esac
+
+if [ -z "$RANDOM_DISK_UUIDS" ]; then
+  sgdisk --disk-guid=$DISK_UUID "$IMGFILE"
+fi
 
 for p in $PARTS ; do
   eval do_$p CUR_SEC


### PR DESCRIPTION
This is needed to make PCR5 in the TPM measured boot be the same for
otherwise identical hardware and firmware/software. The new
eve_install_random_disk_uuids can be set to get the old behavior.


With these changes the installer with produce disk and partition UUIDs with a fixed but random prefix of
AD6871EE-31F9-4CF3-9E09-6F7A25C3005* where the last digit varies.

For example:
linuxkit-525400123456:~# cgpt show -v /dev/sda
       start        size    part  contents
           0           1          PMBR (Boot GUID: 3CAC10CD-7500-C3F4-0000-000000000000)
           1           1          Pri GPT header
                                  Sig: [EFI PART]
                                  Rev: 0x00010000
                                  Size: 92
                                  Header CRC: 0x7b073ff9 
                                  My LBA: 1
                                  Alternate LBA: 16777215
                                  First LBA: 34
                                  Last LBA: 16777182
                                  Disk UUID: AD6871EE-31F9-4CF3-9E09-6F7A25C30050
                                  Entries LBA: 2
                                  Number of entries: 128
                                  Size of entry: 128
                                  Entries CRC: 0x766521ac 
           2          32          Pri GPT table
        2048       73728       1  Label: "EFI System"
                                  Type: EFI System Partition
                                  UUID: AD6871EE-31F9-4CF3-9E09-6F7A25C30051
                                  Attr: legacy_boot=1 
       75776      614400       2  Label: "IMGA"
                                  Type: 5DFBF5F4-2848-4BAC-AA5E-0D9A20B745A6
                                  UUID: AD6871EE-31F9-4CF3-9E09-6F7A25C30052
      690176      614400       3  Label: "IMGB"
                                  Type: 5DFBF5F4-2848-4BAC-AA5E-0D9A20B745A6
                                  UUID: AD6871EE-31F9-4CF3-9E09-6F7A25C30053
     1304576        2048       4  Label: "CONFIG"
                                  Type: 13307E62-CD9C-4920-8F9B-91B45828B798
                                  UUID: AD6871EE-31F9-4CF3-9E09-6F7A25C30054
     1306624    15470559       9  Label: "P3"
                                  Type: 5F24425A-2DFA-11E8-A270-7B663FACCC2C
                                  UUID: AD6871EE-31F9-4CF3-9E09-6F7A25C30059
    16777183          32          Sec GPT table
    16777215           1          Sec GPT header

Note that different size disks are likely to produce different PCR5 values because the end sectors will be different.
