### PR TITLE
Extract raw filename from mime

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -2352,7 +2352,7 @@ func createCloudInitISO(ctx *domainContext,
 	// as normal and fill in a user-data file below.
 	if config.MetaDataType == types.MetaDataDriveMultipart ||
 		ctx.processCloudInitMultiPart {
-		didMultipart, err = handleMimeMultipart(dir, ciStr)
+		didMultipart, err = handleMimeMultipart(dir, ciStr, true)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/pillar/cmd/domainmgr/domainmgr_test.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr_test.go
@@ -415,7 +415,7 @@ func TestHandleMimeMultipart(t *testing.T) {
 		if err != nil {
 			continue
 		}
-		ok, err := handleMimeMultipart(mydir, test.ciStr)
+		ok, err := handleMimeMultipart(mydir, test.ciStr, true)
 		assert.Equal(t, test.expectMultipart, ok)
 		if test.expectFail {
 			assert.NotNil(t, err)


### PR DESCRIPTION
This is necessary to handle new version of the mime package and allow creating the CDROM directory layout for cloud-init.