### PR TITLE
Show string status for zpool in case of not online

### DIFF
--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -425,6 +425,9 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 				rStorageInfo.CompressionRatio = *proto.Float64(compressratio)
 				rStorageInfo.CountZvols = *proto.Uint32(countZvolume)
 				rStorageInfo.StorageState = storageState
+				if storageState != info.StorageStatus_STORAGE_STATUS_ONLINE {
+					rStorageInfo.CollectorErrors = zfs.GetZfsStatusStr(log, zpoolName)
+				}
 				ReportDeviceInfo.StorageInfo = append(ReportDeviceInfo.StorageInfo, rStorageInfo)
 				log.Tracef("report metrics sending info for ZFS zpool %s", zpoolName)
 			}


### PR DESCRIPTION
Show string status for zpool in case of not online (i.e. `One or more devices has been taken offline by the administrator. Sufficient replicas exist for the pool to continue functioning in a degraded state.`).
Library we use has no support for showing this, so I parse output of zpool status here.