### PR TITLE
Pass grub config file for iso installer

### DIFF
--- a/pkg/eve/installer/grub.cfg
+++ b/pkg/eve/installer/grub.cfg
@@ -53,5 +53,9 @@ if [ -n "$install_part" -a -f "($install_part)/rootfs.img" -a -f "($install_part
    set_global eve_flavor kvm
 
    loopback loop0 "$rootfs_root"
+   if [ -f "($install_part)/config.img" ]; then
+       loopback loop1 "($install_part)/config.img"
+       set_global config_grub_cfg "(loop1)/grub.cfg"
+   fi
    configfile (loop0)/EFI/BOOT/grub.cfg
 fi


### PR DESCRIPTION
Seems we still need to have possibility to pass options from grub.cfg comes with config.img file in case of iso installer.

Solution to sort disks (https://github.com/lf-edge/eve/pull/2309) discussed https://github.com/lf-edge/eve/pull/2303#issuecomment-934955500 is not enough and we still need to define explicitly the disk to install EVE onto with `eve_install_disk` option.