### PR TITLE
vhost: default num_queues to number of vcpus

### DIFF
--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -275,6 +275,7 @@ const qemuDiskTemplate = `
   wwpn = "{{.WWN}}"
   bus = "pci.{{.PCIId}}"
   addr = "0x0"
+  num_queues = "{{.NumQueues}}"
 {{- end}}
 {{end}}`
 
@@ -515,11 +516,11 @@ func (ctx kvmContext) CreateDomConfig(domainName string, config types.DomainConf
 
 	// render disk device model settings
 	diskContext := struct {
-		Machine               string
-		PCIId, DiskID, SATAId int
-		AioType               string
+		Machine                          string
+		PCIId, DiskID, SATAId, NumQueues int
+		AioType                          string
 		types.DiskStatus
-	}{Machine: ctx.devicemodel, PCIId: 4, DiskID: 0, SATAId: 0, AioType: "io_uring"}
+	}{Machine: ctx.devicemodel, PCIId: 4, DiskID: 0, SATAId: 0, AioType: "io_uring", NumQueues: config.VCpus}
 
 	t, _ = template.New("qemuDisk").
 		Funcs(template.FuncMap{"Fmt": func(f zconfig.Format) string { return strings.ToLower(f.String()) }}).

--- a/pkg/pillar/hypervisor/kvm_test.go
+++ b/pkg/pillar/hypervisor/kvm_test.go
@@ -1154,6 +1154,7 @@ func TestCreateDomConfig(t *testing.T) {
   wwpn = "naa.000000000000000a"
   bus = "pci.7"
   addr = "0x0"
+  num_queues = "2"
 
 [device "pci.8"]
   driver = "pcie-root-port"
@@ -1452,6 +1453,7 @@ func TestCreateDomConfig(t *testing.T) {
   wwpn = "naa.000000000000000a"
   bus = "pci.7"
   addr = "0x0"
+  num_queues = "2"
 
 [device "pci.8"]
   driver = "pcie-root-port"
@@ -1761,6 +1763,7 @@ func TestCreateDomConfig(t *testing.T) {
   wwpn = "naa.000000000000000a"
   bus = "pci.7"
   addr = "0x0"
+  num_queues = "2"
 
 [device "pci.8"]
   driver = "pcie-root-port"
@@ -2047,6 +2050,7 @@ func TestCreateDomConfig(t *testing.T) {
   wwpn = "naa.000000000000000a"
   bus = "pci.7"
   addr = "0x0"
+  num_queues = "2"
 
 [device "pci.8"]
   driver = "pcie-root-port"


### PR DESCRIPTION
To enable multiple io queues for vhost-scsi based storage.

# Testing done

Install Eve on c2.medium.x86 machine, with options:
```
eve_install_disk=sda eve_persist_disk=sdb,sdc,sdd eve_install_skip_zfs_checks
```
Onboard node, and launch a  VM with 4 vCPUs, then:

```
ssh user@instance_ip 
$ ls /sys/block/sda/mq/
0  1  2  3
```

# Updates
v1 -> v2: dummy push to restart the tests
v2 -> v3: update unit tests to match num_queues