### PR TITLE
Set storage name and state for ext4 systems

### DIFF
--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -432,10 +432,14 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 	} else {
 		xStorageInfo := new(info.StorageInfo)
 		xStorageInfo.StorageType = info.StorageTypeInfo_STORAGE_TYPE_INFO_EXT4
+		xStorageInfo.PoolName = *proto.String(types.PersistDir)
 		mi, err := mount.Lookup(types.PersistDir)
 		if err != nil {
 			log.Errorf("cannot find device with %s mount", types.PersistDir)
+			xStorageInfo.StorageState = info.StorageStatus_STORAGE_STATUS_OFFLINE
 		} else {
+			// If ext4 is mounted its state is considered online
+			xStorageInfo.StorageState = info.StorageStatus_STORAGE_STATUS_ONLINE
 			serialNumber, err := hardware.GetSerialNumberForDisk(mi.Source)
 			if err != nil {
 				serialNumber = "unknown"


### PR DESCRIPTION
Sets the storage name to /persist for ext4 and sets the state to ONLINE if /persist is mounted else sets to OFFLINE.

Signed-off-by: Pramodh Pallapothu <pramodh@zededa.com>