### PR TITLE
runc 1.0.1 and containerd 1.6.1

### DIFF
--- a/images/rootfs-mini.yml.in.patch
+++ b/images/rootfs-mini.yml.in.patch
@@ -6,9 +6,9 @@
 +  image: NEW_KERNEL_TAG
    cmdline: "rootdelay=3"
  init:
--  - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
--  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
--  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
+-  - linuxkit/init:8f1e6a0747acbbb4d7e24dc98f97faa8d1c6cec7
+-  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
+-  - linuxkit/containerd:de1b18eed76a266baa3092e5c154c84f595e56da
 -  - linuxkit/getty:v0.5
 -  - linuxkit/memlogd:v0.5
    - DOM0ZTOOLS_TAG

--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -2,9 +2,9 @@ kernel:
   image: KERNEL_TAG
   cmdline: "rootdelay=3"
 init:
-  - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
-  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
-  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
+  - linuxkit/init:8f1e6a0747acbbb4d7e24dc98f97faa8d1c6cec7
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
+  - linuxkit/containerd:de1b18eed76a266baa3092e5c154c84f595e56da
   - linuxkit/getty:v0.5
   - linuxkit/memlogd:v0.5
   - DOM0ZTOOLS_TAG


### PR DESCRIPTION
Includes the fix for https://nvd.nist.gov/vuln/detail/CVE-2022-23648 

Note that highlighting in GitHub diff is a bit off because of the lines that start with `-` in the `.patch` file.