### PR TITLE
remove deprecated notary trust

### DIFF
--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -65,6 +65,3 @@ services:
 files:
    - path: /etc/eve-release
      contents: 'EVE_VERSION'
-trust:
-  org:
-    - linuxkit


### PR DESCRIPTION
linuxkit stopped supporting notary v1 trust a while back, notary v1 is mostly deprecated anyways. Newer images for linuxkit in any case are not notary-signed, as it is deprecated.

This removes the usage of trust from the rootfs.yml file.

Without it, we will be unable to use the non-notary-v1-signed containers for the base image.