### PR TITLE
Support to install EVE and ZFS on same disk

### DIFF
--- a/pkg/mkimage-raw-efi/install
+++ b/pkg/mkimage-raw-efi/install
@@ -276,12 +276,19 @@ INSTALL_ZFS=false
 grep -q eve_install_zfs_with_raid_level /proc/cmdline && INSTALL_ZFS=true
 RAID_LEVEL="none"
 
+
 if [ "$INSTALL_ZFS" = true ]; then
    # User explicitly asked to install ZFS so skip the zfs minimum requirement checks.
    # We will do checks only when user just provides multiple disks for persist and did not expliclty ask to install zfs
    SKIP_ZFS_CHECKS=true
    RAID_LEVEL=$(</proc/cmdline tr ' ' '\012' | sed -ne '/^eve_install_zfs_with_raid_level=/s#^.*=##p')
    logmsg "ZFS raid level: $RAID_LEVEL"
+   #If installing eve and zfs on same drive set DISK_WITH_P3
+   if [ "$INSTALL_DEV" = "$INSTALL_PERSIST" ]; then
+      DISK_WITH_P3=$INSTALL_PERSIST
+      POOL_CREATION_COMMAND_SUFFIX="$POOL_CREATION_COMMAND_SUFFIX $P3_ON_BOOT_PLACEHOLDER"
+      logmsg "Installing EVE and ZFS on same drive $DISK_WITH_P3"
+   fi
 fi
 
 if [ "$INSTALL_DEV" != "$INSTALL_PERSIST" ]; then


### PR DESCRIPTION
Installed with grub parameters eve_install_zfs_with_raid_level=none eve_install_disk=nvme0n1

Installer log:
2022-03-23 20:59:28 : EVE-OS installation started
2022-03-23 20:59:28 : Nuked partition tables on nvme0n1
2022-03-23 20:59:28 : Nuked partition tables on nvme1n1
2022-03-23 20:59:33 : Installing EVE-OS on device nvme0n1
2022-03-23 20:59:33 : Installing persist on disk(s) nvme0n1
2022-03-23 20:59:33 : EVE install server : zedcloud.alpha.zededa.net
2022-03-23 20:59:33 : INFO: RANDOM_DISK_UUIDS 
2022-03-23 20:59:33 : SKIP_ZFS_CHECKS = false
2022-03-23 20:59:33 : ZFS raid level: none
2022-03-23 20:59:33 : Installing EVE and ZFS on same drive nvme0n1
2022-03-23 20:59:33 : Installing ZFS filesystem, MULTIPLE_DISKS = false
2022-03-23 20:59:51 : Creating ZFS pool with raid level: none
2022-03-23 20:59:51 : Pool creation command:  /dev/nvme0n1p9
2022-03-23 20:59:51 : DISK_WITH_P3 : nvme0n1 P3_ID : nvme0n1p9
2022-03-23 21:01:09 : Preparing ZFS pool and mounts
2022-03-23 21:01:10 : mount_part PART = CONFIG DISK = nvme0n1 TARGET = /config
2022-03-23 21:01:10 : SOFT_SERIAL = f65f802b-84e4-4f54-81ac-6665d35cfc0c
2022-03-23 21:01:10 : mount_part PART = INVENTORY DISK = sdc TARGET = /run/INVENTORY
2022-03-23 21:01:13 : No TPM; Generating soft device certificate
2022-03-23 21:01:18 : Setting ZFS mountpoint to /persist
2022-03-23 21:01:18 : EVE-OS installation completed, device will now reboot/poweroff

On the device:

zpool status
  pool: persist
 state: ONLINE
config:

	NAME         STATE     READ WRITE CKSUM
	persist      ONLINE       0     0     0
	  nvme0n1p9  ONLINE       0     0     0


Signed-off-by: Pramodh Pallapothu <pramodh@zededa.com>