### PR TITLE
Split zfs pool info to zfsmanager

### DIFF
--- a/pkg/pillar/cmd/zfsmanager/zfsstoragestatus.go
+++ b/pkg/pillar/cmd/zfsmanager/zfsstoragestatus.go
@@ -1,0 +1,184 @@
+// Copyright (c) 2022 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package zfsmanager
+
+import (
+	"strconv"
+	"time"
+
+	libzfs "github.com/bicomsystems/go-libzfs"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/lf-edge/eve/pkg/pillar/vault"
+	"github.com/lf-edge/eve/pkg/pillar/zfs"
+)
+
+const (
+	storageStatusPublishInterval = 30 * time.Second // interval between publishing zfs pool status
+)
+
+func storageStatusPublisher(ctxPtr *zfsContext) {
+	if vault.ReadPersistType() != types.PersistZFS {
+		return
+	}
+	collectAndPublishStorageStatus(ctxPtr)
+
+	t := time.NewTicker(storageStatusPublishInterval)
+	for {
+		select {
+		case <-t.C:
+			collectAndPublishStorageStatus(ctxPtr)
+		}
+	}
+}
+
+func collectAndPublishStorageStatus(ctxPtr *zfsContext) {
+	log.Functionf("collectAndPublishStorageStatus start")
+	zfsVersion, err := zfs.GetZfsVersion()
+	if err != nil {
+		log.Errorf("error: %v", err)
+	}
+
+	zpoolList, err := libzfs.PoolOpenAll()
+	if err != nil {
+		log.Errorf("get zpool list failed %v", err)
+	} else {
+		for _, zpool := range zpoolList {
+			status := new(types.ZFSPoolStatus)
+			defer zpool.Close()
+			currentRaid := types.StorageRaidTypeNoRAID
+			zpoolPropName, err := zpool.GetProperty(libzfs.PoolPropName)
+			if err != nil {
+				log.Errorf("error with get properties PoolPropName %v", err)
+				continue
+			}
+
+			zpoolPropHealth, err := zpool.GetProperty(libzfs.PoolPropHealth)
+			if err != nil {
+				log.Errorf("error with get properties PoolPropHealth %v", err)
+				continue
+			}
+
+			zpoolPropSize, err := zpool.GetProperty(libzfs.PoolPropSize)
+			if err != nil {
+				log.Errorf("error with get properties PoolPropSize %v", err)
+				continue
+			}
+
+			zpoolName := zpoolPropName.Value
+			storageState := zfs.GetZfsDeviceStatusFromStr(zpoolPropHealth.Value)
+			zpoolSizeInByte, err := strconv.ParseUint(zpoolPropSize.Value, 10, 64)
+			if err != nil {
+				log.Errorf("error with ParseUint for get zpool size in byte: %v", err)
+			}
+
+			countZvolume, err := zfs.GetZfsCountVolume(zpoolName)
+			if err != nil {
+				log.Errorf("get count volume failed %v", err)
+			}
+
+			compressratio, _ := zfs.GetZfsCompressratio(zpoolName)
+			if err != nil {
+				log.Errorf("error with ParseFloat for get compression ratio: %v", err)
+			}
+
+			vdevs, err := zpool.VDevTree()
+			if err != nil {
+				log.Errorf("error with get about RAID info from devTree: %v", err)
+			} else {
+				// it returns top-level raid type
+				currentRaid = zfs.GetZpoolRaidType(vdevs)
+				// handle the case when we have only one top-level vdev
+				if currentRaid != types.StorageRaidTypeRAID0 {
+					for _, vdev := range vdevs.Devices {
+						// If this is a RAID or mirror, look at the disks it consists of
+						if vdev.Type == libzfs.VDevTypeMirror || vdev.Type == libzfs.VDevTypeRaidz {
+							for _, disk := range vdev.Devices {
+								rDiskStatus, err := zfs.GetZfsDiskAndStatus(disk)
+								// vdev.Devices might includes snapshots or caches,
+								// and those will result in errors which need to ignore.
+								if err == nil {
+									status.Disks = append(status.Disks, rDiskStatus)
+								}
+							}
+							break // in that case we have only one RAID
+						}
+						// If there is no RAID or mirror, add a disk if it is a disk
+						rDiskStatus, err := zfs.GetZfsDiskAndStatus(vdev)
+						// vdev.Devices might includes snapshots or caches,
+						// and those will result in errors which need to ignore.
+						if err == nil {
+							status.Disks = append(status.Disks, rDiskStatus)
+						}
+					}
+				} else {
+					// multiple top-level vdevs should be handled separately
+					currentRaid = types.StorageRaidTypeUnspecified
+					// if unspecified, use provided
+					// if noraid, keep it
+					// if lower than current, update
+					updateCurrentRaid := func(raidType types.StorageRaidType) {
+						if currentRaid == types.StorageRaidTypeUnspecified {
+							currentRaid = raidType
+							return
+						}
+						if currentRaid == types.StorageRaidTypeNoRAID {
+							return
+						}
+						if raidType < currentRaid {
+							currentRaid = raidType
+							return
+						}
+					}
+					for _, vdev := range vdevs.Devices {
+						child := new(types.StorageChildren)
+						// If this is a RAID or mirror, look at the disks it consists of
+						if vdev.Type == libzfs.VDevTypeMirror || vdev.Type == libzfs.VDevTypeRaidz {
+							child.CurrentRaid = zfs.GetRaidTypeFromStr(vdev.Name)
+							updateCurrentRaid(child.CurrentRaid)
+							for _, disk := range vdev.Devices {
+								rDiskStatus, err := zfs.GetZfsDiskAndStatus(disk)
+								// vdev.Devices might includes snapshots or caches,
+								// and those will result in errors which need to ignore.
+								if err == nil {
+									child.Disks = append(child.Disks, rDiskStatus)
+								}
+							}
+							status.Children = append(status.Children, child)
+							continue
+						}
+						// If there is no RAID or mirror, add a disk if it is a disk
+						rDiskStatus, err := zfs.GetZfsDiskAndStatus(vdev)
+						// vdev.Devices might includes snapshots or caches,
+						// and those will result in errors which need to ignore.
+						if err == nil {
+							child.CurrentRaid = types.StorageRaidTypeNoRAID
+							updateCurrentRaid(child.CurrentRaid)
+							child.Disks = append(child.Disks, rDiskStatus)
+							status.Children = append(status.Children, child)
+						}
+					}
+					// unspecified or raid0 gives no redundancy, so noraid here
+					if currentRaid == types.StorageRaidTypeUnspecified ||
+						currentRaid == types.StorageRaidTypeRAID0 {
+						currentRaid = types.StorageRaidTypeNoRAID
+					}
+				}
+			}
+			status.PoolName = zpoolName
+			status.ZpoolSize = zpoolSizeInByte
+			status.ZfsVersion = zfsVersion
+			status.CurrentRaid = currentRaid
+			status.CompressionRatio = compressratio
+			status.CountZvols = countZvolume
+			status.StorageState = storageState
+			if storageState != types.StorageStatusOnline {
+				status.CollectorErrors = zfs.GetZfsStatusStr(log, zpoolName)
+			}
+			if err := ctxPtr.storageStatusPub.Publish(status.Key(), *status); err != nil {
+				log.Errorf("error in publishing of storageStatus: %s", err)
+			}
+		}
+	}
+	log.Functionf("collectAndPublishStorageStatus Done")
+}

--- a/pkg/pillar/types/zfs.go
+++ b/pkg/pillar/types/zfs.go
@@ -42,3 +42,71 @@ type ZVolStatus struct {
 func (status ZVolStatus) Key() string {
 	return status.Device
 }
+
+// StorageRaidType indicates storage raid type
+type StorageRaidType int32
+
+// StorageRaidType enum should be in sync with info api
+const (
+	StorageRaidTypeUnspecified StorageRaidType = 0
+	StorageRaidTypeRAID0       StorageRaidType = 1 // RAID-0
+	StorageRaidTypeRAID1       StorageRaidType = 2 // Mirror
+	StorageRaidTypeRAID5       StorageRaidType = 3 // raidz1 (RAID-5)
+	StorageRaidTypeRAID6       StorageRaidType = 4 // raidz2 (RAID-6)
+	StorageRaidTypeRAID7       StorageRaidType = 5 // raidz3 (RAID-7)
+	StorageRaidTypeNoRAID      StorageRaidType = 6 // without RAID
+)
+
+// StorageStatus indicates current status of storage
+type StorageStatus int32
+
+// StorageStatus enum should be in sync with info api
+const (
+	StorageStatusUnspecified StorageStatus = 0
+	StorageStatusOnline      StorageStatus = 1 // The device or virtual device is in normal working order.
+	StorageStatusDegraded    StorageStatus = 2 // The virtual device has experienced a failure but can still function.
+	StorageStatusFaulted     StorageStatus = 3 // The device or virtual device is completely inaccessible.
+	StorageStatusOffline     StorageStatus = 4 // The device has been explicitly taken offline by the administrator.
+	StorageStatusUnavail     StorageStatus = 5 // The device or virtual device cannot be opened. In some cases, pools with UNAVAIL devices appear in DEGRADED mode.
+	StorageStatusRemoved     StorageStatus = 6 // The device was physically removed while the system was running.
+	StorageStatusSuspended   StorageStatus = 7 // A pool that is waiting for device connectivity to be restored.
+)
+
+// ZFSPoolStatus stores collected information about zpool
+type ZFSPoolStatus struct {
+	PoolName         string
+	ZfsVersion       string
+	CurrentRaid      StorageRaidType
+	CompressionRatio float64
+	ZpoolSize        uint64
+	CountZvols       uint32
+	StorageState     StorageStatus
+	Disks            []*StorageDiskState
+	CollectorErrors  string
+	Children         []*StorageChildren
+}
+
+//Key for pubsub
+func (s ZFSPoolStatus) Key() string {
+	return s.PoolName
+}
+
+// DiskDescription stores disk information
+type DiskDescription struct {
+	Name        string // bus-related name, for example: /dev/sdc
+	LogicalName string // logical name, for example: disk3
+	Serial      string // serial number of disk
+}
+
+//StorageDiskState represent state of disk
+type StorageDiskState struct {
+	DiskName *DiskDescription
+	Status   StorageStatus
+}
+
+// StorageChildren stores children of zfs pool
+type StorageChildren struct {
+	CurrentRaid StorageRaidType
+	Disks       []*StorageDiskState
+	Children    []*StorageChildren
+}

--- a/pkg/pillar/zfs/zfs.go
+++ b/pkg/pillar/zfs/zfs.go
@@ -15,8 +15,6 @@ import (
 
 	libzfs "github.com/bicomsystems/go-libzfs"
 	"github.com/golang/protobuf/proto"
-	"github.com/lf-edge/eve/api/go/evecommon"
-	"github.com/lf-edge/eve/api/go/info"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/hardware"
 	"github.com/lf-edge/eve/pkg/pillar/types"
@@ -292,25 +290,25 @@ func GetZfsCountVolume(datasetName string) (uint32, error) {
 }
 
 // GetRaidTypeFromStr takes a RAID name as input and returns current RAID type
-func GetRaidTypeFromStr(raidName string) info.StorageRaidType {
+func GetRaidTypeFromStr(raidName string) types.StorageRaidType {
 	if len(raidName) == 0 {
-		return info.StorageRaidType_STORAGE_RAID_TYPE_NORAID
+		return types.StorageRaidTypeNoRAID
 	} else if strings.Contains(raidName, "raidz1") {
-		return info.StorageRaidType_STORAGE_RAID_TYPE_RAID5
+		return types.StorageRaidTypeRAID5
 	} else if strings.Contains(raidName, "raidz2") {
-		return info.StorageRaidType_STORAGE_RAID_TYPE_RAID6
+		return types.StorageRaidTypeRAID6
 	} else if strings.Contains(raidName, "raidz3") {
-		return info.StorageRaidType_STORAGE_RAID_TYPE_RAID7
+		return types.StorageRaidTypeRAID7
 	} else if strings.Contains(raidName, "mirror") {
-		return info.StorageRaidType_STORAGE_RAID_TYPE_RAID1
+		return types.StorageRaidTypeRAID1
 	}
 
-	return info.StorageRaidType_STORAGE_RAID_TYPE_NORAID
+	return types.StorageRaidTypeNoRAID
 }
 
 // GetZpoolRaidType takes a libzfs.VDevTree as input and returns current RAID type.
 // return RAID0 in case of mixed topology as we can mix nested topology into the stripe
-func GetZpoolRaidType(vdevs libzfs.VDevTree) info.StorageRaidType {
+func GetZpoolRaidType(vdevs libzfs.VDevTree) types.StorageRaidType {
 	vdevsCount := 0
 	for _, vdev := range vdevs.Devices {
 		if vdev.Type == libzfs.VDevTypeMirror || vdev.Type == libzfs.VDevTypeRaidz || vdev.Type == libzfs.VDevTypeDisk {
@@ -318,7 +316,7 @@ func GetZpoolRaidType(vdevs libzfs.VDevTree) info.StorageRaidType {
 		}
 	}
 	if vdevsCount > 1 {
-		return info.StorageRaidType_STORAGE_RAID_TYPE_RAID0
+		return types.StorageRaidTypeRAID0
 	}
 	for _, vdev := range vdevs.Devices {
 		if vdev.Type == libzfs.VDevTypeMirror || vdev.Type == libzfs.VDevTypeRaidz {
@@ -326,35 +324,35 @@ func GetZpoolRaidType(vdevs libzfs.VDevTree) info.StorageRaidType {
 		}
 		break
 	}
-	return info.StorageRaidType_STORAGE_RAID_TYPE_NORAID
+	return types.StorageRaidTypeNoRAID
 }
 
 // GetZfsDeviceStatusFromStr takes a string with status as input and returns status
-func GetZfsDeviceStatusFromStr(statusStr string) info.StorageStatus {
+func GetZfsDeviceStatusFromStr(statusStr string) types.StorageStatus {
 	if len(statusStr) == 0 {
-		return info.StorageStatus_STORAGE_STATUS_UNSPECIFIED
+		return types.StorageStatusUnspecified
 	} else if strings.TrimSpace(statusStr) == "ONLINE" {
-		return info.StorageStatus_STORAGE_STATUS_ONLINE
+		return types.StorageStatusOnline
 	} else if strings.TrimSpace(statusStr) == "DEGRADED" {
-		return info.StorageStatus_STORAGE_STATUS_DEGRADED
+		return types.StorageStatusDegraded
 	} else if strings.TrimSpace(statusStr) == "FAULTED" {
-		return info.StorageStatus_STORAGE_STATUS_FAULTED
+		return types.StorageStatusFaulted
 	} else if strings.TrimSpace(statusStr) == "OFFLINE" {
-		return info.StorageStatus_STORAGE_STATUS_OFFLINE
+		return types.StorageStatusOffline
 	} else if strings.TrimSpace(statusStr) == "UNAVAIL" {
-		return info.StorageStatus_STORAGE_STATUS_UNAVAIL
+		return types.StorageStatusUnavail
 	} else if strings.TrimSpace(statusStr) == "REMOVED" {
-		return info.StorageStatus_STORAGE_STATUS_REMOVED
+		return types.StorageStatusRemoved
 	} else if strings.TrimSpace(statusStr) == "SUSPENDED" {
-		return info.StorageStatus_STORAGE_STATUS_SUSPENDED
+		return types.StorageStatusSuspended
 	}
 
-	return info.StorageStatus_STORAGE_STATUS_UNSPECIFIED
+	return types.StorageStatusUnspecified
 }
 
 // GetZfsDiskAndStatus takes a libzfs.VDevTree as input and returns
 // *info.StorageDiskState.
-func GetZfsDiskAndStatus(disk libzfs.VDevTree) (*info.StorageDiskState, error) {
+func GetZfsDiskAndStatus(disk libzfs.VDevTree) (*types.StorageDiskState, error) {
 	if disk.Type != libzfs.VDevTypeDisk {
 		return nil, fmt.Errorf("%s is not a disk", disk.Name)
 	}
@@ -379,8 +377,8 @@ func GetZfsDiskAndStatus(disk libzfs.VDevTree) (*info.StorageDiskState, error) {
 		serialNumber = "unknown"
 	}
 
-	rDiskStatus := new(info.StorageDiskState)
-	rDiskStatus.DiskName = new(evecommon.DiskDescription)
+	rDiskStatus := new(types.StorageDiskState)
+	rDiskStatus.DiskName = new(types.DiskDescription)
 	rDiskStatus.DiskName.Name = *proto.String(diskZfsName)
 	rDiskStatus.DiskName.Serial = *proto.String(serialNumber)
 	rDiskStatus.Status = GetZfsDeviceStatusFromStr(disk.Stat.State.String())


### PR DESCRIPTION
We should not depend on info publishing interval for sending zfs pool
status info. So we should split data structures filling and call info
publishing on change.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>