### PR TITLE
Fill skipped error with logutils.NoSuitableAddrStr prefix

### DIFF
--- a/pkg/pillar/cmd/downloader/resolveconfig.go
+++ b/pkg/pillar/cmd/downloader/resolveconfig.go
@@ -288,6 +288,10 @@ func resolveTagsToHash(ctx *downloaderContext, rc types.ResolveConfig,
 		return
 
 	}
+	// we skip this error earlier but we must fill errStr
+	if errStr == "" {
+		errStr = logutils.NoSuitableAddrStr
+	}
 	if !cancelled {
 		log.Errorf("All source IP addresses failed. All errors:%s",
 			errStr)

--- a/pkg/pillar/cmd/downloader/syncop.go
+++ b/pkg/pillar/cmd/downloader/syncop.go
@@ -285,6 +285,10 @@ func handleSyncOp(ctx *downloaderContext, key string,
 		return
 
 	}
+	// we skip this error earlier but we must fill errStr
+	if errStr == "" {
+		errStr = logutils.NoSuitableAddrStr
+	}
 	if !cancelled {
 		log.Errorf("All source IP addresses failed. All errors:%s",
 			errStr)


### PR DESCRIPTION
To avoid fatal errors while setting empty Error in ErrorDescription we
should fill errStr properly

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>