### PR TITLE
Fix ntpd.pid watchdog after server change

### DIFF
--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -587,7 +587,13 @@ while true; do
     if [ -n "$ns" ] && [ "$ns" != "$NTPSERVER" ] && [ -f /run/ntpd.pid ]; then
         echo "$(date -Ins -u) NTP server changed from $NTPSERVER to $ns"
         NTPSERVER="$ns"
-        kill "$(cat /run/ntpd.pid)"
+        ntpd_pid="$(cat /run/ntpd.pid)"
+        kill "$ntpd_pid"
+        # Wait for it to go away before restarting
+        while kill -0 "$ntpd_pid"; do
+            echo "$(date -Ins -u) NTP server $ntpd_pid still running"
+            sleep 3
+        done
         echo "$(date -Ins -u) ntpd -g -p $NTPSERVER"
         /usr/sbin/ntpd -g -p "$NTPSERVER"
         ret_code=$?


### PR DESCRIPTION
We sometimes see a watchdog due to ntpd.pid not running in the case when
EVE-OS picks up a NTP server from DHCP thus we see a log line of the
form:
NTP server changed from poll.ntp.org to $ns

The attempt to track this down has been to record the exit value from
starting ntpd after it was killed, but that returns zero even when ntpd
was not actually started. So adding a wait for the killed process to go
away.
