### PR TITLE
Reduce memory usage for DownloadedParts Hash

### DIFF
--- a/libs/zedUpload/types/downloadedparts.go
+++ b/libs/zedUpload/types/downloadedparts.go
@@ -23,12 +23,10 @@ type DownloadedParts struct {
 
 // Hash returns hash of DownloadedParts struct
 func (dp *DownloadedParts) Hash() string {
-	data, err := json.Marshal(dp)
-	if err != nil {
-		return ""
-	}
 	hash := sha256.New()
-	if _, err = hash.Write(data); err != nil {
+	encoder := json.NewEncoder(hash)
+	err := encoder.Encode(dp)
+	if err != nil {
 		return ""
 	}
 	return hex.EncodeToString(hash.Sum(nil))

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/types/downloadedparts.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/types/downloadedparts.go
@@ -23,12 +23,10 @@ type DownloadedParts struct {
 
 // Hash returns hash of DownloadedParts struct
 func (dp *DownloadedParts) Hash() string {
-	data, err := json.Marshal(dp)
-	if err != nil {
-		return ""
-	}
 	hash := sha256.New()
-	if _, err = hash.Write(data); err != nil {
+	encoder := json.NewEncoder(hash)
+	err := encoder.Encode(dp)
+	if err != nil {
 		return ""
 	}
 	return hex.EncodeToString(hash.Sum(nil))


### PR DESCRIPTION
We can use json encoder to stream checksum calculation instead of using all data in place to reduce memory usage.