### PR TITLE
Show user containerd stdout/stderr in pillar logs

### DIFF
--- a/pkg/pillar/containerd/containerd.go
+++ b/pkg/pillar/containerd/containerd.go
@@ -873,6 +873,8 @@ func StartUserContainerdInstance() error {
 	name := "/usr/bin/containerd"
 	args := []string{"--config", "/etc/containerd/user.toml"}
 	cmd := exec.Command(name, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("user containerd cannot start: %v", err)
 	}


### PR DESCRIPTION
Seems reasonable to show logs from user containerd as part of pillar logs. 