### PR TITLE
Do not skip DNS State check in client

### DIFF
--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -819,8 +819,8 @@ func handleDNSImpl(ctxArg interface{}, key string,
 		return
 	}
 	log.Functionf("handleDNSImpl for %s", key)
-	// Ignore test status and timestamps
-	if ctx.deviceNetworkStatus.MostlyEqual(status) {
+	// Ignore timestamps
+	if ctx.deviceNetworkStatus.State == status.State && ctx.deviceNetworkStatus.MostlyEqual(status) {
 		log.Functionf("handleDNSImpl no change")
 		return
 	}


### PR DESCRIPTION
It seems we do not update networkState in client if only DNS State
changed. It may block onboarding process.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>