### PR TITLE
Fix locally triggered purge

### DIFF
--- a/api/proto/profile/local_profile.proto
+++ b/api/proto/profile/local_profile.proto
@@ -128,6 +128,7 @@ message AppCommand {
       // Application instance, which is either running or transitioning to a running state,
       // will be stopped and the mutated run time state of the app is deleted.
       // A subsequent action to start the app will start it with a pristine runtime state.
+      // This command will purge ALL volumes used by the application.
       COMMAND_PURGE = 2;
    }
    // Command to run.

--- a/pkg/pillar/cmd/volumemgr/create.go
+++ b/pkg/pillar/cmd/volumemgr/create.go
@@ -176,7 +176,7 @@ func createContainerVolume(ctx *volumemgrContext, status types.VolumeStatus,
 	ctStatus := lookupContentTreeStatusAny(ctx, status.ContentID.String())
 	if ctStatus == nil {
 		err := fmt.Errorf("createContainerVolume: Unable to find contentTreeStatus %s for Volume %s",
-			status.ContentID.String(), status.VolumeID)
+			status.ContentID.String(), status.Key())
 		log.Errorf(err.Error())
 		return created, filelocation, err
 	}
@@ -184,7 +184,7 @@ func createContainerVolume(ctx *volumemgrContext, status types.VolumeStatus,
 	rootBlobStatus := lookupBlobStatus(ctx, ctStatus.Blobs[0])
 	if rootBlobStatus == nil {
 		err := fmt.Errorf("createContainerVolume: Unable to find root BlobStatus %s for Volume %s",
-			ctStatus.Blobs[0], status.VolumeID)
+			ctStatus.Blobs[0], status.Key())
 		log.Errorf(err.Error())
 		return created, filelocation, err
 	}

--- a/pkg/pillar/cmd/volumemgr/handlevolume.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume.go
@@ -108,6 +108,7 @@ func handleDeferredVolumeCreate(ctx *volumemgrContext, key string, config *types
 		MaxVolSize:              config.MaxVolSize,
 		ReadOnly:                config.ReadOnly,
 		GenerationCounter:       config.GenerationCounter,
+		LocalGenerationCounter:  config.LocalGenerationCounter,
 		Encrypted:               config.Encrypted,
 		DisplayName:             config.DisplayName,
 		RefCount:                config.RefCount,

--- a/pkg/pillar/cmd/volumemgr/handlevolumeref.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolumeref.go
@@ -23,18 +23,19 @@ func handleVolumeRefCreate(ctxArg interface{}, key string,
 		updateVolumeStatusRefCount(ctx, vs)
 		publishVolumeStatus(ctx, vs)
 		status = &types.VolumeRefStatus{
-			VolumeID:           config.VolumeID,
-			GenerationCounter:  config.GenerationCounter,
-			RefCount:           config.RefCount,
-			MountDir:           config.MountDir,
-			State:              vs.State,
-			ActiveFileLocation: vs.FileLocation,
-			ContentFormat:      vs.ContentFormat,
-			ReadOnly:           vs.ReadOnly,
-			DisplayName:        vs.DisplayName,
-			MaxVolSize:         vs.MaxVolSize,
-			WWN:                vs.WWN,
-			VerifyOnly:         config.VerifyOnly,
+			VolumeID:               config.VolumeID,
+			GenerationCounter:      config.GenerationCounter,
+			LocalGenerationCounter: config.LocalGenerationCounter,
+			RefCount:               config.RefCount,
+			MountDir:               config.MountDir,
+			State:                  vs.State,
+			ActiveFileLocation:     vs.FileLocation,
+			ContentFormat:          vs.ContentFormat,
+			ReadOnly:               vs.ReadOnly,
+			DisplayName:            vs.DisplayName,
+			MaxVolSize:             vs.MaxVolSize,
+			WWN:                    vs.WWN,
+			VerifyOnly:             config.VerifyOnly,
 		}
 		if vs.HasError() {
 			description := vs.ErrorDescription
@@ -46,12 +47,13 @@ func handleVolumeRefCreate(ctxArg interface{}, key string,
 		needUpdateVol = true
 	} else {
 		status = &types.VolumeRefStatus{
-			VolumeID:          config.VolumeID,
-			GenerationCounter: config.GenerationCounter,
-			RefCount:          config.RefCount,
-			MountDir:          config.MountDir,
-			State:             types.INITIAL, // Waiting for VolumeConfig from zedagent
-			VerifyOnly:        config.VerifyOnly,
+			VolumeID:               config.VolumeID,
+			GenerationCounter:      config.GenerationCounter,
+			LocalGenerationCounter: config.LocalGenerationCounter,
+			RefCount:               config.RefCount,
+			MountDir:               config.MountDir,
+			State:                  types.INITIAL, // Waiting for VolumeConfig from zedagent
+			VerifyOnly:             config.VerifyOnly,
 		}
 	}
 	publishVolumeRefStatus(ctx, status)
@@ -186,18 +188,19 @@ func updateVolumeRefStatus(ctx *volumemgrContext, vs *types.VolumeStatus) {
 				return
 			}
 			status = &types.VolumeRefStatus{
-				VolumeID:           config.VolumeID,
-				GenerationCounter:  config.GenerationCounter,
-				RefCount:           config.RefCount,
-				MountDir:           config.MountDir,
-				State:              vs.State,
-				ActiveFileLocation: vs.FileLocation,
-				ContentFormat:      vs.ContentFormat,
-				ReadOnly:           vs.ReadOnly,
-				DisplayName:        vs.DisplayName,
-				MaxVolSize:         vs.MaxVolSize,
-				WWN:                vs.WWN,
-				VerifyOnly:         config.VerifyOnly,
+				VolumeID:               config.VolumeID,
+				GenerationCounter:      config.GenerationCounter,
+				LocalGenerationCounter: config.LocalGenerationCounter,
+				RefCount:               config.RefCount,
+				MountDir:               config.MountDir,
+				State:                  vs.State,
+				ActiveFileLocation:     vs.FileLocation,
+				ContentFormat:          vs.ContentFormat,
+				ReadOnly:               vs.ReadOnly,
+				DisplayName:            vs.DisplayName,
+				MaxVolSize:             vs.MaxVolSize,
+				WWN:                    vs.WWN,
+				VerifyOnly:             config.VerifyOnly,
 			}
 			if vs.HasError() {
 				description := vs.ErrorDescription

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -631,14 +631,14 @@ func doUpdateVol(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool)
 				status.Key(), vr.FileLocation, vr.VolumeCreated)
 			if vr.VolumeCreated && status.SubState == types.VolumeSubStatePrepareDone {
 				log.Functionf("From vr set VolumeCreated to %s for %s",
-					vr.FileLocation, status.VolumeID)
+					vr.FileLocation, status.Key())
 				status.SubState = types.VolumeSubStateCreated
 				status.CreateTime = vr.CreateTime
 				changed = true
 			}
 			if status.FileLocation != vr.FileLocation && vr.Error == nil {
 				log.Functionf("doUpdateContentTree: From vr set FileLocation to %s for %s",
-					vr.FileLocation, status.VolumeID)
+					vr.FileLocation, status.Key())
 				status.FileLocation = vr.FileLocation
 				changed = true
 			}

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -111,8 +111,10 @@ type getconfigContext struct {
 	triggerRadioPOST chan Notify
 
 	localAppInfoPOSTTicker flextimer.FlexTickerHandle
-	localAppCommands       types.LocalAppCommands
-	localAppCommandsLock   sync.Mutex
+
+	// localCommands : list of commands requested from a local server.
+	// This information is persisted under /persist/checkpoint/localcommands
+	localCommands *types.LocalCommands
 
 	callProcessLocalProfileServerChange bool //did we already call processLocalProfileServerChange
 
@@ -658,7 +660,6 @@ func publishZedAgentStatus(getconfigCtx *getconfigContext) {
 		ForceFallbackCounter: ctx.forceFallbackCounter,
 		CurrentProfile:       getconfigCtx.currentProfile,
 		RadioSilence:         getconfigCtx.radioSilence,
-		LocalAppCommands:     getconfigCtx.localAppCommands,
 	}
 	pub := getconfigCtx.pubZedAgentStatus
 	pub.Publish(agentName, status)

--- a/pkg/pillar/cmd/zedagent/localinfo.go
+++ b/pkg/pillar/cmd/zedagent/localinfo.go
@@ -22,7 +22,7 @@ const (
 	localAppInfoURLPath               = "/api/v1/appinfo"
 	localAppInfoPOSTInterval          = time.Minute
 	localAppInfoPOSTThrottledInterval = time.Hour
-	savedAppCommandsFile              = "appcommands"
+	savedLocalCommandsFile            = "localcommands"
 )
 
 var (
@@ -46,11 +46,13 @@ func initializeLocalAppInfo(ctx *getconfigContext) {
 	max := 1.1 * float64(localAppInfoPOSTInterval)
 	min := 0.8 * max
 	ctx.localAppInfoPOSTTicker = flextimer.NewRangeTicker(time.Duration(min), time.Duration(max))
-	if loadSavedAppCommands(ctx) {
-		publishZedAgentStatus(ctx)
-	} else {
+}
+
+func initializeLocalCommands(ctx *getconfigContext) {
+	if !loadSavedLocalCommands(ctx) {
 		// Write the initial empty content.
-		persistAppCommands(ctx.localAppCommands)
+		ctx.localCommands = &types.LocalCommands{}
+		persistLocalCommands(ctx.localCommands)
 	}
 }
 
@@ -167,14 +169,18 @@ func postLocalAppInfo(ctx *getconfigContext) *profile.LocalAppCmdList {
 }
 
 func processReceivedAppCommands(ctx *getconfigContext, cmdList *profile.LocalAppCmdList) {
-	ctx.localAppCommandsLock.Lock()
-	defer ctx.localAppCommandsLock.Unlock()
+	ctx.localCommands.Lock()
+	defer ctx.localCommands.Unlock()
 	if cmdList == nil {
 		// Nothing requested by local server, just refresh the persisted config.
-		touchAppCommands()
+		if !ctx.localCommands.Empty() {
+			touchLocalCommands()
+		}
 		return
 	}
-	var cmdChanges bool
+
+	var cmdChanges, volChanges bool
+	processedApps := make(map[string]struct{})
 	for _, appCmdReq := range cmdList.AppCommands {
 		var err error
 		appUUID := nilUUID
@@ -192,81 +198,216 @@ func processReceivedAppCommands(ctx *getconfigContext, cmdList *profile.LocalApp
 			continue
 		}
 		// Try to find the application instance.
-		ais := findAppInstance(ctx, appUUID, displayName)
-		if ais == nil {
+		appInst := findAppInstance(ctx, appUUID, displayName)
+		if appInst == nil {
 			log.Warnf("Failed to find app instance with UUID=%s, displayName=%s",
 				appUUID, displayName)
 			continue
 		}
-		appUUID = ais.UUIDandVersion.UUID
-		command := types.AppCommand(appCmdReq.Command)
-		appCmd := ctx.localAppCommands.LookupByAppUUID(appUUID)
-		if appCmd != nil {
-			// Entry for this app already exists.
-			if appCmd.Command == command &&
-				appCmd.LocalServerTimestamp == appCmdReq.Timestamp {
-				// already accepted
-				continue
-			}
-			appCmd.Command = command
-			appCmd.LocalServerTimestamp = appCmdReq.Timestamp
-			appCmd.DeviceTimestamp = time.Now()
-			appCmd.Completed = false
-			cmdChanges = true
+		appUUID = appInst.UUIDandVersion.UUID
+		if _, duplicate := processedApps[appUUID.String()]; duplicate {
+			log.Warnf("Multiple commands requested for app instance with UUID=%s",
+				appUUID)
 			continue
 		}
-		// Add new entry.
-		ctx.localAppCommands.Cmds = append(ctx.localAppCommands.Cmds,
-			types.LocalAppCommand{
-				AppUUID:              appUUID,
-				Command:              command,
-				LocalServerTimestamp: appCmdReq.Timestamp,
-				DeviceTimestamp:      time.Now(),
-				Completed:            false,
-			})
+		processedApps[appUUID.String()] = struct{}{}
+
+		// Accept (or skip already accepted) application command.
+		command := types.AppCommand(appCmdReq.Command)
+		appCmd, hasLocalCmd := ctx.localCommands.AppCommands[appUUID.String()]
+		if !hasLocalCmd {
+			appCmd = &types.LocalAppCommand{}
+			if ctx.localCommands.AppCommands == nil {
+				ctx.localCommands.AppCommands = make(map[string]*types.LocalAppCommand)
+			}
+			ctx.localCommands.AppCommands[appUUID.String()] = appCmd
+		}
+		if appCmd.Command == command &&
+			appCmd.LocalServerTimestamp == appCmdReq.Timestamp {
+			// already accepted
+			continue
+		}
+		appCmd.Command = command
+		appCmd.LocalServerTimestamp = appCmdReq.Timestamp
+		appCmd.DeviceTimestamp = time.Now()
+		appCmd.Completed = false
 		cmdChanges = true
+
+		// Update and re-publish configuration to trigger the operation.
+		timestamp := appCmd.DeviceTimestamp.String()
+		changedVolumes := triggerLocalCommand(ctx, command, appInst, timestamp)
+		if changedVolumes {
+			volChanges = true
+		}
 	}
+
+	// Persist accepted application commands and counters.
 	if cmdChanges {
-		publishZedAgentStatus(ctx)
-		persistAppCommands(ctx.localAppCommands)
+		persistLocalCommands(ctx.localCommands)
 	} else {
 		// No actual configuration change to apply, just refresh the persisted config.
-		touchAppCommands()
+		touchLocalCommands()
+	}
+
+	// Signal changes in the configuration of volumes.
+	if volChanges {
+		signalVolumeConfigRestarted(ctx)
 	}
 }
 
-func processAppCommandStatus(ctx *getconfigContext, appStatus types.AppInstanceStatus) {
-	ctx.localAppCommandsLock.Lock()
-	defer ctx.localAppCommandsLock.Unlock()
-	appCmdStatus := appStatus.LocalCommand
-	if appCmdStatus.Command == types.AppCommandUnspecified {
+// Trigger application command (restart, purge, ...) requested via Local profile server.
+// TODO: move this logic to zedmanager
+func triggerLocalCommand(ctx *getconfigContext, cmd types.AppCommand,
+	app *types.AppInstanceConfig, timestamp string) (changedVolumes bool) {
+	// Get current local counters of the application.
+	appUUID := app.UUIDandVersion.UUID
+	appCounters, hasCounters := ctx.localCommands.AppCounters[appUUID.String()]
+	if !hasCounters {
+		appCounters = &types.LocalAppCounters{}
+		if ctx.localCommands.AppCounters == nil {
+			ctx.localCommands.AppCounters = make(map[string]*types.LocalAppCounters)
+		}
+		ctx.localCommands.AppCounters[appUUID.String()] = appCounters
+	}
+
+	// Update configuration to trigger the operation.
+	switch cmd {
+	case types.AppCommandRestart:
+		// To trigger application restart we take the previously published
+		// app instance config, increase the local-restart command counter by 1
+		// and re-publish the updated configuration.
+		appCounters.RestartCmd.Counter++
+		appCounters.RestartCmd.ApplyTime = timestamp
+		app.LocalRestartCmd = appCounters.RestartCmd
+		checkAndPublishAppInstanceConfig(ctx, *app)
+
+	case types.AppCommandPurge:
+		// To trigger application purge we take the previously published
+		// app instance config, increase the local-purge command counter by 1,
+		// next we add increment of 1 to local-generation counters of ALL volumes
+		// used by the application (inside both volume config and volume-reference
+		// config), and re-publish the updated configuration of the application
+		// and all the volumes.
+		appCounters.PurgeCmd.Counter++
+		appCounters.PurgeCmd.ApplyTime = timestamp
+		app.LocalPurgeCmd = appCounters.PurgeCmd
+		// Trigger purge of all volumes used by the application.
+		// XXX Currently the assumption is that every volume instance is used
+		//     by at most one application.
+		if ctx.localCommands.VolumeGenCounters == nil {
+			ctx.localCommands.VolumeGenCounters = make(map[string]int64)
+		}
+		for i := range app.VolumeRefConfigList {
+			vr := &app.VolumeRefConfigList[i]
+			uuid := vr.VolumeID.String()
+			remoteGenCounter := vr.GenerationCounter
+			localGenCounter := ctx.localCommands.VolumeGenCounters[uuid]
+			// Un-publish volume with the current counters.
+			volKey := volumeKey(uuid, remoteGenCounter, localGenCounter)
+			volObj, _ := ctx.pubVolumeConfig.Get(volKey)
+			if volObj == nil {
+				log.Warnf("Failed to find volume %s referenced by app instance "+
+					"with UUID=%s - not purging this volume", volKey, appUUID)
+				continue
+			}
+			volume := volObj.(types.VolumeConfig)
+			unpublishVolumeConfig(ctx, volKey)
+			// Publish volume with an increased local generation counter.
+			localGenCounter++
+			ctx.localCommands.VolumeGenCounters[uuid] = localGenCounter
+			vr.LocalGenerationCounter = localGenCounter
+			volume.LocalGenerationCounter = localGenCounter
+			publishVolumeConfig(ctx, volume)
+			changedVolumes = true
+		}
+		checkAndPublishAppInstanceConfig(ctx, *app)
+	}
+	return changedVolumes
+}
+
+func processAppCommandStatus(
+	ctx *getconfigContext, appStatus types.AppInstanceStatus) {
+	ctx.localCommands.Lock()
+	defer ctx.localCommands.Unlock()
+	uuid := appStatus.UUIDandVersion.UUID.String()
+	appCmd, hasLocalCmd := ctx.localCommands.AppCommands[uuid]
+	if !hasLocalCmd {
+		// This app received no local command requests.
 		return
 	}
-	if !appCmdStatus.Completed {
-		// Command has not yet completed, nothing to update.
+	if appCmd.Completed {
+		// Nothing to update.
 		return
 	}
-	appCmd := ctx.localAppCommands.LookupByAppUUID(appStatus.UUIDandVersion.UUID)
-	if appCmd == nil {
-		log.Warnf("Missing entry for app command: %+v", appStatus.LocalCommand)
+	if appStatus.PurgeInprogress != types.NotInprogress ||
+		appStatus.RestartInprogress != types.NotInprogress {
+		// A command is still ongoing.
 		return
 	}
 	var updated bool
-	if appCmd.LastCompletedTimestamp != appCmdStatus.LocalServerTimestamp {
-		appCmd.LastCompletedTimestamp = appCmdStatus.LocalServerTimestamp
-		updated = true
-	}
-	if !appCmd.Completed && appCmd.SameCommand(appCmdStatus) {
-		appCmd.Completed = true
-		updated = true
+	switch appCmd.Command {
+	case types.AppCommandRestart:
+		if appStatus.RestartStartedAt.After(appCmd.DeviceTimestamp) {
+			appCmd.Completed = true
+			appCmd.LastCompletedTimestamp = appCmd.LocalServerTimestamp
+			updated = true
+			log.Noticef("Local restart completed: %+v", appCmd)
+		}
+	case types.AppCommandPurge:
+		if appStatus.PurgeStartedAt.After(appCmd.DeviceTimestamp) {
+			appCmd.Completed = true
+			appCmd.LastCompletedTimestamp = appCmd.LocalServerTimestamp
+			updated = true
+			log.Noticef("Local purge completed: %+v", appCmd)
+		}
 	}
 	if updated {
-		persistAppCommands(ctx.localAppCommands)
+		persistLocalCommands(ctx.localCommands)
 	}
+}
+
+// Add config submitted for the application via local profile server.
+// ctx.localCommands should be locked!
+func addLocalAppConfig(ctx *getconfigContext, appInstance *types.AppInstanceConfig) {
+	uuid := appInstance.UUIDandVersion.UUID.String()
+	appCounters, hasCounters := ctx.localCommands.AppCounters[uuid]
+	if hasCounters {
+		appInstance.LocalRestartCmd = appCounters.RestartCmd
+		appInstance.LocalPurgeCmd = appCounters.PurgeCmd
+	}
+	for i := range appInstance.VolumeRefConfigList {
+		vr := &appInstance.VolumeRefConfigList[i]
+		uuid = vr.VolumeID.String()
+		vr.LocalGenerationCounter = ctx.localCommands.VolumeGenCounters[uuid]
+	}
+}
+
+// Delete all local config for this application.
+// ctx.localCommands should be locked!
+func delLocalAppConfig(ctx *getconfigContext, appUUID string) {
+	delete(ctx.localCommands.AppCommands, appUUID)
+	delete(ctx.localCommands.AppCounters, appUUID)
+	persistLocalCommands(ctx.localCommands)
+}
+
+// Add config submitted for the volume via local profile server.
+// ctx.localCommands should be locked!
+func addLocalVolumeConfig(ctx *getconfigContext, volumeConfig *types.VolumeConfig) {
+	uuid := volumeConfig.VolumeID.String()
+	volumeConfig.LocalGenerationCounter = ctx.localCommands.VolumeGenCounters[uuid]
+}
+
+// Delete all local config for this volume.
+// ctx.localCommands should be locked!
+func delLocalVolumeConfig(ctx *getconfigContext, volumeUUID string) {
+	delete(ctx.localCommands.VolumeGenCounters, volumeUUID)
+	persistLocalCommands(ctx.localCommands)
 }
 
 func prepareLocalInfo(ctx *getconfigContext) *profile.LocalAppInfoList {
 	msg := profile.LocalAppInfoList{}
+	ctx.localCommands.Lock()
+	defer ctx.localCommands.Unlock()
 	addAppInstanceFunc := func(key string, value interface{}) bool {
 		ais := value.(types.AppInstanceStatus)
 		zinfoAppInst := new(profile.LocalAppInfo)
@@ -275,14 +416,9 @@ func prepareLocalInfo(ctx *getconfigContext) *profile.LocalAppInfoList {
 		zinfoAppInst.Name = ais.DisplayName
 		zinfoAppInst.Err = encodeErrorInfo(ais.ErrorAndTimeWithSource.ErrorDescription)
 		zinfoAppInst.State = ais.State.ZSwState()
-		ctx.localAppCommandsLock.Lock()
-		for _, appCmd := range ctx.localAppCommands.Cmds {
-			if appCmd.AppUUID == ais.UUIDandVersion.UUID {
-				zinfoAppInst.LastCmdTimestamp = appCmd.LastCompletedTimestamp
-				break
-			}
+		if appCmd, hasEntry := ctx.localCommands.AppCommands[zinfoAppInst.Id]; hasEntry {
+			zinfoAppInst.LastCmdTimestamp = appCmd.LastCompletedTimestamp
 		}
-		ctx.localAppCommandsLock.Unlock()
 		msg.AppsInfo = append(msg.AppsInfo, zinfoAppInst)
 		return true
 	}
@@ -291,9 +427,9 @@ func prepareLocalInfo(ctx *getconfigContext) *profile.LocalAppInfoList {
 }
 
 func findAppInstance(
-	ctx *getconfigContext, appUUID uuid.UUID, displayName string) (appInst *types.AppInstanceStatus) {
+	ctx *getconfigContext, appUUID uuid.UUID, displayName string) (appInst *types.AppInstanceConfig) {
 	matchApp := func(_ string, value interface{}) bool {
-		ais := value.(types.AppInstanceStatus)
+		ais := value.(types.AppInstanceConfig)
 		if (appUUID == nilUUID || appUUID == ais.UUIDandVersion.UUID) &&
 			(displayName == "" || displayName == ais.DisplayName) {
 			appInst = &ais
@@ -302,53 +438,55 @@ func findAppInstance(
 		}
 		return true
 	}
-	ctx.subAppInstanceStatus.Iterate(matchApp)
+	ctx.pubAppInstanceConfig.Iterate(matchApp)
 	return appInst
 }
 
-func readSavedAppCommands(ctx *getconfigContext) (types.LocalAppCommands, error) {
-	appCommands := types.LocalAppCommands{}
+func readSavedLocalCommands(ctx *getconfigContext) (*types.LocalCommands, error) {
+	commands := &types.LocalCommands{}
 	contents, ts, err := readSavedConfig(
 		ctx.zedagentCtx.globalConfig.GlobalValueInt(types.StaleConfigTime),
-		filepath.Join(checkpointDirname, savedAppCommandsFile), false)
+		filepath.Join(checkpointDirname, savedLocalCommandsFile), false)
 	if err != nil {
-		return appCommands, err
+		return commands, err
 	}
 	if contents != nil {
-		err := json.Unmarshal(contents, &appCommands)
+		err := json.Unmarshal(contents, &commands)
 		if err != nil {
-			return appCommands, err
+			return commands, err
 		}
-		log.Noticef("Using saved app commands dated %s",
+		log.Noticef("Using saved local commands dated %s",
 			ts.Format(time.RFC3339Nano))
-		return appCommands, nil
+		return commands, nil
 	}
-	return appCommands, nil
+	return commands, nil
 }
 
-// loadSavedAppCommands reads saved application commands and sets it.
-func loadSavedAppCommands(ctx *getconfigContext) bool {
-	appCommands, err := readSavedAppCommands(ctx)
+// loadSavedLocalCommands reads saved locally-issued commands and sets them.
+func loadSavedLocalCommands(ctx *getconfigContext) bool {
+	commands, err := readSavedLocalCommands(ctx)
 	if err != nil {
-		log.Errorf("readSavedAppCommands failed: %v", err)
+		log.Errorf("loadSavedLocalCommands failed: %v", err)
 		return false
 	}
-	log.Noticef("Starting with app commands: %+v", appCommands)
-	ctx.localAppCommands = appCommands
+	for _, appCmd := range commands.AppCommands {
+		log.Noticef("Loaded persisted local app command: %+v", appCmd)
+	}
+	ctx.localCommands = commands
 	return true
 }
 
-func persistAppCommands(cmds types.LocalAppCommands) {
-	contents, err := json.Marshal(cmds)
+func persistLocalCommands(localCommands *types.LocalCommands) {
+	contents, err := json.Marshal(localCommands)
 	if err != nil {
-		log.Fatalf("persistAppCommands: Marshalling failed: %v", err)
+		log.Fatalf("persistLocalCommands: Marshalling failed: %v", err)
 	}
-	saveConfig(savedAppCommandsFile, contents)
+	saveConfig(savedLocalCommandsFile, contents)
 	return
 }
 
-// touchAppCommands is used to update the modification time of the persisted
-// application commands.
-func touchAppCommands() {
-	touchSavedConfig(savedAppCommandsFile)
+// touchLocalCommands is used to update the modification time of the persisted
+// local commands.
+func touchLocalCommands() {
+	touchSavedConfig(savedLocalCommandsFile)
 }

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -1334,6 +1334,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// initialize localInfo
 	initializeLocalAppInfo(&getconfigCtx)
 	go localAppInfoPOSTTask(&getconfigCtx)
+	initializeLocalCommands(&getconfigCtx)
 
 	// start the config fetch tasks, when zboot status is ready
 	log.Functionf("Creating %s at %s", "configTimerTask", agentlog.GetMyStack())

--- a/pkg/pillar/cmd/zedmanager/handledomainmgr.go
+++ b/pkg/pillar/cmd/zedmanager/handledomainmgr.go
@@ -53,8 +53,9 @@ func MaybeAddDomainConfig(ctx *zedmanagerContext,
 	for _, vrc := range aiConfig.VolumeRefConfigList {
 		vrs := getVolumeRefStatusFromAIStatus(&aiStatus, vrc)
 		if vrs == nil {
-			log.Errorf("Missing VolumeRefStatus for (VolumeID: %s, GenerationCounter: %d)",
-				vrc.VolumeID, vrc.GenerationCounter)
+			log.Errorf("Missing VolumeRefStatus for "+
+				"(VolumeID: %s, GenerationCounter: %d, LocalGenerationCounter: %d)",
+				vrc.VolumeID, vrc.GenerationCounter, vrc.LocalGenerationCounter)
 			continue
 		}
 		location := vrs.ActiveFileLocation

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -60,6 +60,8 @@ type AppInstanceConfig struct {
 	IoAdapterList       []IoAdapter
 	RestartCmd          AppInstanceOpsCmd
 	PurgeCmd            AppInstanceOpsCmd
+	LocalRestartCmd     AppInstanceOpsCmd
+	LocalPurgeCmd       AppInstanceOpsCmd
 	// XXX: to be deprecated, use CipherBlockStatus instead
 	CloudInitUserData *string `json:"pubsub-large-CloudInitUserData"`
 	RemoteConsole     bool
@@ -165,9 +167,6 @@ type AppInstanceStatus struct {
 	MissingMemory  bool // Waiting for memory
 
 	EffectiveActivate bool //set here effective activate after profile check and apply
-
-	// Status of the application command (purge, restart) requested via the local profile server.
-	LocalCommand LocalAppCommand
 
 	// All error strings across all steps and all StorageStatus
 	// ErrorAndTimeWithSource provides SetError, SetErrrorWithSource, etc

--- a/pkg/pillar/types/zfs.go
+++ b/pkg/pillar/types/zfs.go
@@ -22,7 +22,8 @@ func (status VolumeStatus) ZVolName() string {
 	if status.Encrypted {
 		pool = VolumeEncryptedZFSDataset
 	}
-	return fmt.Sprintf("%s/%s.%d", pool, status.VolumeID.String(), status.GenerationCounter)
+	return fmt.Sprintf("%s/%s.%d", pool, status.VolumeID.String(),
+		status.GenerationCounter+status.LocalGenerationCounter)
 }
 
 // ZVolNameToKey returns key for volumestatus for provided zVolName


### PR DESCRIPTION
This PR fixes the feature allowing to trigger app purge/restart via 
local profile server, originally delivered by https://github.com/lf-edge/eve/pull/2492
As it turned out, to purge an application _with all its volumes_,
it is required to either change UUIDs of those volumes (effectively
configure new volume instances) or to increase their generation counters.
However, locally triggered application commands (via local profile server)
cannot change configuration in a way that would break consistency with
the controller, therefore change of UUIDs is not an option.
Instead, this PR introduces a _local generation counter_ for volume,
which is added to the remote generation counter (from the controller)
to form a volume key changing by remotely as well as locally issued purge.
In a similar way the PR adds separate purge and restart counters
for locally triggered operations to the application config.
Note that currently most of the logic for local operations is handled
by zedagent. Later, this could be refactored and moved to zedmanager
to keep only config parsing and info/metrics publishing inside zedagent.

Test: https://github.com/lf-edge/eden/pull/744

Signed-off-by: Milan Lenco <milan@zededa.com>