### PR TITLE
Update update_eve_image test versions

### DIFF
--- a/tests/eden/update_eve_image/testdata/update_eve_image_http.txt
+++ b/tests/eden/update_eve_image/testdata/update_eve_image_http.txt
@@ -1,5 +1,5 @@
 # Default EVE version to update
-{{$eve_ver := "7.4.0"}}
+{{$eve_ver := "7.10.0"}}
 
 # Obtain EVE version from environment variable EVE_VERSION
 {{$env := EdenGetEnv "EVE_VERSION"}}

--- a/tests/eden/update_eve_image/testdata/update_eve_image_oci.txt
+++ b/tests/eden/update_eve_image/testdata/update_eve_image_oci.txt
@@ -1,5 +1,5 @@
 # Default EVE version to update
-{{$eve_ver := "7.5.0"}}
+{{$eve_ver := "7.11.0"}}
 
 # Obtain EVE version from environment variable EVE_VERSION
 {{$env := EdenGetEnv "EVE_VERSION"}}


### PR DESCRIPTION
After https://github.com/lf-edge/eve/pull/2546 merged we should use new version of EVE inside test to be compatible with TPM-enabled EdenGCP.