### PR TITLE
Fix verification of persisted DPCs

### DIFF
--- a/pkg/pillar/dpcmanager/verify.go
+++ b/pkg/pillar/dpcmanager/verify.go
@@ -27,7 +27,8 @@ func (m *DpcManager) restartVerify(ctx context.Context, reason string) {
 		m.Log.Noticef("DPC verify: DPC list verification in progress")
 		return
 	}
-	if !m.radioSilence.ChangeInProgress && m.radioSilence.Imposed {
+	if m.currentDPC() != nil &&
+		!m.radioSilence.ChangeInProgress && m.radioSilence.Imposed {
 		m.Log.Noticef("DPC verify: Radio-silence is imposed, skipping DPC verification")
 		return
 	}
@@ -77,10 +78,14 @@ func (m *DpcManager) runVerify(ctx context.Context, reason string) {
 		return
 	}
 
-	// Stop DPC test timer.
+	// Stop DPC test timer (if running).
 	// It shall be resumed when we find working network configuration.
-	m.dpcTestTimer.Stop()
-	m.dpcTestBetterTimer.Stop()
+	if m.dpcTestTimer.C != nil {
+		m.dpcTestTimer.Stop()
+	}
+	if m.dpcTestBetterTimer.C != nil {
+		m.dpcTestBetterTimer.Stop()
+	}
 
 	endloop := false
 	var res types.DPCState


### PR DESCRIPTION
With persisted DPCs from previous run but with last-resort DPC disabled,
there is only dpcTestTimer that will trigger DPC verification.
And since this timer is set (by default) to 5 minutes, there is quite
a delay until device applies working DPC after a reboot.
This commit makes sure that persisted DPCs are tested as soon as
possible after a reboot. DPC manager only waits for the global
configuration before it starts verification.
Also, if device is rebooted during a radio-silence mode, the very
first DPC verification should proceed even if in general the
verification is disabled during radio silence.

Signed-off-by: Milan Lenco <milan@zededa.com>