### PR TITLE
Fix multiple DNS servers configured for network instance

### DIFF
--- a/pkg/pillar/cmd/zedrouter/dnsmasq.go
+++ b/pkg/pillar/cmd/zedrouter/dnsmasq.go
@@ -231,10 +231,14 @@ func createDnsmasqConfiglet(
 		}
 	}
 	advertizeDns := false
-	for _, ns := range netstatus.DnsServers {
+	if len(netstatus.DnsServers) > 0 {
 		advertizeDns = true
+		var addrList []string
+		for _, srvIP := range netstatus.DnsServers {
+			addrList = append(addrList, srvIP.String())
+		}
 		file.WriteString(fmt.Sprintf("dhcp-option=option:dns-server,%s\n",
-			ns.String()))
+			strings.Join(addrList, ",")))
 	}
 	if netstatus.NtpServer != nil {
 		file.WriteString(fmt.Sprintf("dhcp-option=option:ntp-server,%s\n",


### PR DESCRIPTION
Multiple DNS servers (to advertize) should be configured for dnsmasq
as a one-line "dns-server" DHCP option, with comma-separated DNS server
IP addresses. Puting DNS servers each on a separate line is not correct,
dnsmasq will only advertize the last entry.

Signed-off-by: Milan Lenco <milan@zededa.com>