### PR TITLE
Fix setting hostname to uuid on boot

### DIFF
--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -531,17 +531,6 @@ $BINDIR/tpmmgr runAsService &
 wait_for_touch tpmmgr
 touch "$WATCHDOG_FILE/tpmmgr.touch"
 
-# XXX to handle a downgrade we need a /config/uuid file to boot old EVE
-if [ ! -f $CONFIGDIR/uuid ]; then
-    echo "$(date -Ins -u) cp -p $PERSISTDIR/status/uuid $CONFIGDIR/uuid"
-    cp -p $PERSISTDIR/status/uuid $CONFIGDIR/uuid
-elif ! diff $PERSISTDIR/status/uuid $CONFIGDIR/uuid >/dev/null; then
-    echo "$(date -Ins -u) rm -f $CONFIGDIR/uuid"
-    rm -f $CONFIGDIR/uuid
-    echo "$(date -Ins -u) cp -p $PERSISTDIR/status/uuid $CONFIGDIR/uuid"
-    cp -p $PERSISTDIR/status/uuid $CONFIGDIR/uuid
-fi
-
 if ! pgrep loguploader >/dev/null; then
     echo "$(date -Ins -u) Starting loguploader"
     $BINDIR/loguploader &


### PR DESCRIPTION
This includes removing some old unneeded code and relying on the 5
second timer when we have a UUID.

Also remove the /config/uuid compatibility for downgrade to older than 5.21