### PR TITLE
Fix acl test to handle multiple IPs from dig

### DIFF
--- a/tests/eden/eclient/testdata/acl.txt
+++ b/tests/eden/eclient/testdata/acl.txt
@@ -116,10 +116,11 @@ done
 -- dns_lookup.sh --
 
 # Performs DNS lookup for a given hostname and adds host_ip=<ip> into the .env file
+# If query returns several IPs they will be joined into one line with comma separator
 # Uses dig command which is already included by most modern Linux systems and also macOS.
 # Usage: dns_lookup.sh <hostname>
 
-IP=$(dig +short $1)
+IP=$(dig +short $1 | paste -sd "," -)
 echo host_ip=$IP>>.env
 
 -- curl.sh --


### PR DESCRIPTION
Dig command may return several IPs to properly handle them during
creation of network we should join lines from output into one with comma
 separator.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>