### PR TITLE
DPC verify: more sensitive handling of DNS errors

### DIFF
--- a/pkg/pillar/conntester/conntester.go
+++ b/pkg/pillar/conntester/conntester.go
@@ -29,3 +29,28 @@ func (e *RemoteTemporaryFailure) Error() string {
 	return fmt.Sprintf("Remote temporary failure (endpoint: %s): %v",
 		e.Endpoint, e.WrappedErr)
 }
+
+// Unwrap : return wrapped error.
+func (e *RemoteTemporaryFailure) Unwrap() error {
+	return e.WrappedErr
+}
+
+// PortsNotReady can be returned by TestConnectivity to indicate that one or more
+// ports do not have working connectivity due to a potentially transient error
+// (e.g. missing DNS config, no suitable IP addresses, etc.).
+// For the caller this is a signal to possibly wait and repeat the test later.
+type PortsNotReady struct {
+	WrappedErr error
+	// Ports which are not ready.
+	Ports []string
+}
+
+// Error message.
+func (e *PortsNotReady) Error() string {
+	return fmt.Sprintf("Ports %v are not ready: %v", e.Ports, e.WrappedErr)
+}
+
+// Unwrap : return wrapped error.
+func (e *PortsNotReady) Unwrap() error {
+	return e.WrappedErr
+}

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -6,7 +6,6 @@ package types
 import (
 	"bytes"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -21,6 +20,28 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 )
+
+// IPAddrNotAvail is returned when there is no (suitable) IP address
+// assigned to a given interface.
+type IPAddrNotAvail struct {
+	IfName string
+}
+
+// Error message.
+func (e *IPAddrNotAvail) Error() string {
+	return fmt.Sprintf("interface %s: no suitable IP address available", e.IfName)
+}
+
+// DNSNotAvail is returned when there is no DNS server configured
+// for a given interface.
+type DNSNotAvail struct {
+	IfName string
+}
+
+// Error message.
+func (e *DNSNotAvail) Error() string {
+	return fmt.Sprintf("interface %s: no DNS server available", e.IfName)
+}
 
 // Indexed by UUID
 type AppNetworkConfig struct {
@@ -1833,7 +1854,7 @@ func getLocalAddrIf(globalStatus DeviceNetworkStatus, ifname string,
 	if len(addrs) != 0 {
 		return addrs, nil
 	} else {
-		return []net.IP{}, errors.New("No good IP address")
+		return []net.IP{}, &IPAddrNotAvail{IfName: ifname}
 	}
 }
 


### PR DESCRIPTION
We often get errors like:
```
All attempts to connect to https://zedcloud.hummingbird.zededa.net/api/v2/edgedevice/ping
using intf eth0 failed: [Get "https://zedcloud.hummingbird.zededa.net/api/v2/edgedevice/ping":
dial tcp: lookup zedcloud.hummingbird.zededa.net on 127.0.0.1:53: DNS server 127.0.0.1 is from
a different network, skipping]
```
This is likely because the Golang's resolver reloads `resolv.conf`
at most once per 5 seconds, thus it may miss the latest update.
In this case DPC manager should wait instead of falling back to the
previous DPC. But to detect this, `Send*` functions inside zedcloud had to
be improved to return error value that allows to unwrap errors from all
the send attempts.

Signed-off-by: Milan Lenco <milan@zededa.com>