### PR TITLE
Handle loosing /persist/status/nim/DevicePortConfigList/global.json due to power failure with ext4 journalling issues

### DIFF
--- a/pkg/pillar/dpcmanager/dpcmanager_test.go
+++ b/pkg/pillar/dpcmanager/dpcmanager_test.go
@@ -132,7 +132,7 @@ func initTest(test *testing.T) *GomegaWithT {
 		ZedcloudMetrics:          zedcloud.NewAgentMetrics(),
 	}
 	ctx := reconciler.MockRun(context.Background())
-	if err := dpcManager.Run(ctx); err != nil {
+	if _, err := dpcManager.Run(ctx); err != nil {
 		log.Fatal(err)
 	}
 	return t

--- a/pkg/storage-init/storage-init.sh
+++ b/pkg/storage-init/storage-init.sh
@@ -190,7 +190,7 @@ if [ -n "$IMGA" ] && [ -z "$P3" ] && [ -z "$IMGB" ]; then
        sgdisk --partition-guid="$P3_ID:$PERSIST_UUID" "$DEV"
    fi
 
-   # focrce kernel to re-scan partition table
+   # force kernel to re-scan partition table
    partprobe "$DEV"
    partx -a --nr "$IMGB_ID:$P3_ID" "$DEV"
 
@@ -247,6 +247,9 @@ if P3=$(findfs PARTLABEL=P3) && [ -n "$P3" ]; then
                    if [ "$INIT_FS" = 1 ]; then
                       mkfs -t ext4 -v -F -F -O encrypt "$P3"
                    fi
+                   # Reduce risk of losing file content on power failure.
+                   # Enable encryption.
+                   tune2fs -o journal_data "$P3" && \
                    tune2fs -O encrypt "$P3" && \
                    mount -t ext4 -o dirsync,noatime "$P3" $PERSISTDIR
                    ;;


### PR DESCRIPTION
1. Reduce risk of loosing file data on power failures

We've seen one case where
/persist/status/nim/DevicePortConfigList/global.json was lost when the
device lost power shortly after that file had been renamed into place
with a message about orphaned inode on boot. Per the ext4 documentation
using journal_data should solve that issue.

2. If we loose DevicePortConfigList in /persist do fallback

This file should never be missing and if it is something went wrong and
we enable the lastresort for this boot. Once we connect to the
controller we ensure that we remove any lastresort which was added for
this emergency.
