### PR TITLE
Fix attestation restart on 403 config response

### DIFF
--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -28,6 +28,7 @@ const (
 	SenderStatusCertUnknownAuthority                   // device may miss proxy certificate for MiTM
 	SenderStatusCertUnknownAuthorityProxy              // device configed proxy, may miss proxy certificate for MiTM
 	SenderStatusNotFound                               // 404 indicating device might have been deleted in controller
+	SenderStatusForbidden                              // 403 indicating integrity token might invalidated
 )
 
 const (

--- a/pkg/pillar/types/vaultmgrtypes.go
+++ b/pkg/pillar/types/vaultmgrtypes.go
@@ -82,7 +82,7 @@ func (status VaultStatus) LogKey() string {
 //EncryptedVaultKeyFromDevice is published by vaultmgr towards Controller (through zedagent)
 type EncryptedVaultKeyFromDevice struct {
 	Name              string
-	EncryptedVaultKey []byte
+	EncryptedVaultKey []byte // empty if no TPM enabled
 }
 
 //Key returns name of the vault corresponding to this object

--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -142,6 +142,8 @@ func SendOnAllIntf(ctxWork context.Context, ctx *ZedCloudContext, url string, re
 				senderStatus = types.SenderStatusUpgrade
 			case http.StatusNotFound, http.StatusBadRequest:
 				senderStatus = types.SenderStatusNotFound
+			case http.StatusForbidden:
+				senderStatus = types.SenderStatusForbidden
 			}
 		}
 


### PR DESCRIPTION
We should restart attestation on 403 code as config response and this
code assumed as an error, so we should move handling to the proper place
 inside error from SendOnAllIntf handling.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>