### PR TITLE
Fix accidental loop for poweroff command

### DIFF
--- a/pkg/gpt-tools/files/zboot
+++ b/pkg/gpt-tools/files/zboot
@@ -132,7 +132,7 @@ reset() {
 
     # Warning, this does not really play nice with init
     # do not sync, don't go through init
-    reboot -n -f
+    /sbin/reboot -n -f
 }
 
 #
@@ -141,7 +141,7 @@ reset() {
 poweroff() {
     # Warning, this does not really play nice with init
     # do not sync, don't go through init
-    poweroff -f
+    /sbin/poweroff -f
 }
 
 if [ $# -eq 0 ]; then


### PR DESCRIPTION
This was introduced in PR #2609 and discovered as part of the review for
PR #2610
