### PR TITLE
Clean up dhcpmanager Init vs Run API

### DIFF
--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -107,7 +107,7 @@ type nim struct {
 	assignableAdapters types.AssignableAdapters
 	enabledLastResort  bool
 	lastResort         *types.DevicePortConfig
-	dpclPresent        bool // DPC List present on boot
+	dpclPresentAtBoot  bool // DPC List present on boot
 }
 
 // Run - Main function - invoked from zedbox.go
@@ -192,7 +192,11 @@ func (n *nim) run(ctx context.Context) (err error) {
 	n.Log.Noticef("Starting %s", agentName)
 
 	// Start DPC Manager.
-	if n.dpclPresent, err = n.dpcManager.Run(ctx); err != nil {
+	if err = n.dpcManager.Init(ctx); err != nil {
+		return err
+	}
+	n.dpclPresentAtBoot = n.dpcManager.GetDpclPresentAtBoot(ctx)
+	if err = n.dpcManager.Run(ctx); err != nil {
 		return err
 	}
 
@@ -654,7 +658,7 @@ func (n *nim) applyGlobalConfig(gcp *types.ConfigItemValueMap) {
 	fallbackAnyEth := gcp.GlobalValueTriState(types.NetworkFallbackAnyEth)
 	enableLastResort := fallbackAnyEth == types.TS_ENABLED
 	// If we had no DevicePortConfigList on boot then always enable last resort
-	enableLastResort = enableLastResort || !n.dpclPresent
+	enableLastResort = enableLastResort || !n.dpclPresentAtBoot
 	if n.enabledLastResort != enableLastResort {
 		if enableLastResort {
 			n.updateLastResortDPC("lastresort enabled by global config")

--- a/pkg/pillar/dpcmanager/dpc.go
+++ b/pkg/pillar/dpcmanager/dpc.go
@@ -216,16 +216,15 @@ func (m *DpcManager) lookupDPC(dpc types.DevicePortConfig) (*types.DevicePortCon
 // Removes useless ones (which might be re-added by the controller/zedagent
 // later but at least they are not in the way during boot).
 // Returns whether or not the DPCList was present
-func (m *DpcManager) ingestDPCList() (dpclPresent bool) {
+func (m *DpcManager) ingestDPCList() (dpclPresentAtBoot bool) {
 	m.Log.Functionf("IngestDPCList")
 	item, err := m.PubDevicePortConfigList.Get("global")
 	var storedDpcl types.DevicePortConfigList
 	if err != nil {
 		m.Log.Errorf("No global key for DevicePortConfigList")
-		dpclPresent = false
+		dpclPresentAtBoot = false
 	} else {
 		storedDpcl = item.(types.DevicePortConfigList)
-		dpclPresent = true
 	}
 	m.Log.Functionf("Initial DPCL %v", storedDpcl)
 	var dpcl types.DevicePortConfigList
@@ -259,6 +258,8 @@ func (m *DpcManager) ingestDPCList() (dpclPresent bool) {
 			continue
 		}
 		dpcl.PortConfigList = append(dpcl.PortConfigList, portConfig)
+		// We have at least one port
+		dpclPresentAtBoot = true
 	}
 	m.dpcList = dpcl
 	m.Log.Functionf("Sanitized DPCL %v", dpcl)
@@ -266,7 +267,7 @@ func (m *DpcManager) ingestDPCList() (dpclPresent bool) {
 	m.dpcList.CurrentIndex = -1 // No known working one
 	m.Log.Functionf("Published DPCL %v", m.dpcList)
 	m.Log.Functionf("IngestDPCList len %d", len(m.dpcList.PortConfigList))
-	return dpclPresent
+	return dpclPresentAtBoot
 }
 
 func (m *DpcManager) compressAndPublishDPCL() {

--- a/pkg/pillar/dpcmanager/dpcmanager_test.go
+++ b/pkg/pillar/dpcmanager/dpcmanager_test.go
@@ -132,7 +132,10 @@ func initTest(test *testing.T) *GomegaWithT {
 		ZedcloudMetrics:          zedcloud.NewAgentMetrics(),
 	}
 	ctx := reconciler.MockRun(context.Background())
-	if _, err := dpcManager.Run(ctx); err != nil {
+	if err := dpcManager.Init(ctx); err != nil {
+		log.Fatal(err)
+	}
+	if err := dpcManager.Run(ctx); err != nil {
 		log.Fatal(err)
 	}
 	return t


### PR DESCRIPTION
@milan-zededa I see the original code sets 	m.dpcList.CurrentIndex = -1
before ingesting the list. Shouldn't it be set afterwards to avoid starting with index 0?