### PR TITLE
Patch 7.9 FIX - Do not restart a crashed VM within the handleModify function.

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1874,7 +1874,8 @@ func handleModify(ctx *domainContext, key string,
 	publishDomainStatus(ctx, status)
 
 	changed := false
-	if config.Activate && !status.Activated && status.State != types.BROKEN {
+	// if a VM has an error status, it should be restarted in the maybeRetryBoot function, not here
+	if config.Activate && !status.Activated && status.State != types.BROKEN && !status.HasError() {
 		log.Functionf("handleModify(%v) activating for %s",
 			config.UUIDandVersion, config.DisplayName)
 

--- a/tests/eden/eclient/testdata/acl.txt
+++ b/tests/eden/eclient/testdata/acl.txt
@@ -116,10 +116,11 @@ done
 -- dns_lookup.sh --
 
 # Performs DNS lookup for a given hostname and adds host_ip=<ip> into the .env file
+# If query returns several IPs they will be joined into one line with comma separator
 # Uses dig command which is already included by most modern Linux systems and also macOS.
 # Usage: dns_lookup.sh <hostname>
 
-IP=$(dig +short $1)
+IP=$(dig +short $1 | paste -sd "," -)
 echo host_ip=$IP>>.env
 
 -- curl.sh --


### PR DESCRIPTION
Do not restart a crashed VM within the `handleModify` function.  PR https://github.com/lf-edge/eve/pull/2617 
It is enough, bearing in mind all the facts described above, to add a check for
`status.HasError()` in the condition in the `handleModify` function to
eliminate the restart of crashed VM earlier than in `config.timer.reboot`
seconds.