### PR TITLE
Sanitize DPC: add IsL3Port missing in older DPCs

### DIFF
--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -683,13 +683,13 @@ func (n *nim) handleDPCModify(_ interface{}, key string, configArg, _ interface{
 
 func (n *nim) handleDPCImpl(key string, configArg interface{}) {
 	dpc := configArg.(types.DevicePortConfig)
-	dpc.DoSanitize(n.Log, true, true, key, true)
+	dpc.DoSanitize(n.Log, true, true, key, true, true)
 	n.dpcManager.AddDPC(dpc)
 }
 
 func (n *nim) handleDPCDelete(_ interface{}, key string, configArg interface{}) {
 	dpc := configArg.(types.DevicePortConfig)
-	dpc.DoSanitize(n.Log, false, true, key, true)
+	dpc.DoSanitize(n.Log, false, true, key, true, true)
 	n.dpcManager.DelDPC(dpc)
 }
 
@@ -775,7 +775,7 @@ func (n *nim) ingestDevicePortConfigFile(oldDirname string, newDirname string, n
 			filename, err)
 		return
 	}
-	dpc.DoSanitize(n.Log, true, false, "", true)
+	dpc.DoSanitize(n.Log, true, false, "", true, true)
 	dpc.OriginFile = filename
 
 	// Save New config to file.

--- a/pkg/pillar/dpcmanager/dpc.go
+++ b/pkg/pillar/dpcmanager/dpc.go
@@ -230,6 +230,8 @@ func (m *DpcManager) ingestDPCList() (dpclPresent bool) {
 	m.Log.Functionf("Initial DPCL %v", storedDpcl)
 	var dpcl types.DevicePortConfigList
 	for _, portConfig := range storedDpcl.PortConfigList {
+		// Sanitize port labels and IsL3Port flag.
+		portConfig.DoSanitize(m.Log, false, false, "", true, true)
 		// Clear the errors from before reboot and start fresh.
 		for i := 0; i < len(portConfig.Ports); i++ {
 			portPtr := &portConfig.Ports[i]

--- a/pkg/pillar/dpcmanager/dpc.go
+++ b/pkg/pillar/dpcmanager/dpc.go
@@ -6,6 +6,7 @@ package dpcmanager
 import (
 	"context"
 	"crypto/x509"
+	"fmt"
 	"os"
 
 	"github.com/lf-edge/eve/pkg/pillar/types"
@@ -50,7 +51,7 @@ func (m *DpcManager) addDPC(ctx context.Context, dpc types.DevicePortConfig) {
 
 	// Restart verification.
 	m.dpcVerify.inProgress = false
-	m.restartVerify(ctx, "new DPC")
+	m.restartVerify(ctx, fmt.Sprintf("new DPC (%s/%v)", dpc.Key, dpc.TimePriority))
 }
 
 func (m *DpcManager) delDPC(ctx context.Context, dpc types.DevicePortConfig) {
@@ -59,7 +60,7 @@ func (m *DpcManager) delDPC(ctx context.Context, dpc types.DevicePortConfig) {
 		m.Log.Functionf("delDPC: System current. No change detected.\n")
 		return
 	}
-	m.restartVerify(ctx, "removed DPC")
+	m.restartVerify(ctx, fmt.Sprintf("removed DPC (%s/%v)", dpc.Key, dpc.TimePriority))
 }
 
 // Returns true if the current config has actually changed.

--- a/pkg/pillar/dpcmanager/dpcmanager_test.go
+++ b/pkg/pillar/dpcmanager/dpcmanager_test.go
@@ -35,6 +35,7 @@ import (
 )
 
 var (
+	logObj          *base.LogObject
 	networkMonitor  *netmonitor.MockNetworkMonitor
 	wwanWatcher     *MockWwanWatcher
 	geoService      *MockGeoService
@@ -55,7 +56,7 @@ func initTest(test *testing.T) *GomegaWithT {
 	t.SetDefaultConsistentlyDuration(5 * time.Second) // > NetworkTestInterval
 	t.SetDefaultConsistentlyPollingInterval(250 * time.Millisecond)
 	logger := logrus.StandardLogger()
-	logObj := base.NewSourceLogObject(logger, "test", 1234)
+	logObj = base.NewSourceLogObject(logger, "test", 1234)
 	ps := pubsub.New(&pubsub.EmptyDriver{}, logger, logObj)
 	var err error
 	pubDummyDPC, err = ps.NewPublication(
@@ -1815,4 +1816,44 @@ func TestTransientDNSError(test *testing.T) {
 	t.Expect(dnsEth0).ToNot(BeNil())
 	t.Expect(dnsEth0.HasError()).To(BeFalse())
 	t.Expect(dnsEth0.LastError).To(BeEmpty())
+}
+
+// Test DPC from before 7.3.0 which does not have IsL3Port flag.
+func TestOldDPC(test *testing.T) {
+	t := initTest(test)
+
+	// Prepare simulated network stack.
+	eth0 := mockEth0()
+	networkMonitor.AddOrUpdateInterface(eth0)
+
+	// Single interface configured for mgmt.
+	aa := makeAA(selectedIntfs{eth0: true})
+	dpcManager.UpdateAA(aa)
+
+	// Apply global config.
+	dpcManager.UpdateGCP(globalConfig())
+
+	// Apply "zedagent" DPC persisted by an older version of EVE,
+	// which is missing IsL3Port flag.
+	timePrio1 := time.Time{}
+	dpc := makeDPC("zedagent", timePrio1, selectedIntfs{eth0: true})
+	dpc.Ports[0].IsL3Port = false
+
+	// This is run by nim for any input DPC to make sure that it is compliant
+	// with the latest EVE version.
+	dpc.DoSanitize(logObj, true, false, "", true, true)
+
+	dpcManager.AddDPC(dpc)
+
+	// Verification should succeed even with the old DPC.
+	t.Eventually(testingInProgressCb()).Should(BeTrue())
+	t.Eventually(testingInProgressCb()).Should(BeFalse())
+	t.Eventually(dpcIdxCb()).Should(Equal(0))
+	t.Eventually(dnsKeyCb()).Should(Equal("zedagent"))
+	t.Eventually(dpcStateCb(0)).Should(Equal(types.DPCStateSuccess))
+
+	// DPC manager should have applied L3 config for eth0 even if it was
+	// not marked as L3 port in the old DPC.
+	eth0Dhcpcd := dg.Reference(generic.Dhcpcd{AdapterIfName: "eth0"})
+	t.Expect(itemIsCreated(eth0Dhcpcd)).To(BeTrue())
 }


### PR DESCRIPTION
`IsL3Port` flag was introduced to `NetworkPortConfig` in 7.3.0
It is used to differentiate between L3 ports (with IP/DNS config)
and intermediate L2-only ports (bond slaves, VLAN parents, etc.).
Before 7.3.0, EVE didn't support L2-only adapters and all uplink ports
were L3 endpoints.
However, even with VLANs and bonds there has to be at least one L3
port (L2 adapters are only intermediates with L3 endpoint(s) at the top).
This is ensured and validated by `parseSystemAdapterConfig` from zedagent.
This means that to support upgrade from older EVE versions,
we can simply check if there is at least one L3 port, and if not, it means
that we are dealing with an older persisted/override DPC, where all
ports should be marked as L3.

As a separate commit, this PR includes some small improvements in logging
for DPC verification/reconciliation.