### PR TITLE
Use timeout to kill hung ssh process in log test

### DIFF
--- a/tests/eden/lim/testdata/log_test.txt
+++ b/tests/eden/lim/testdata/log_test.txt
@@ -19,4 +19,4 @@ test:
 
 -- ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-until $EDEN eve ssh sleep 10; do sleep 10; done
+until timeout 10 $EDEN eve ssh exit; do sleep 10; done


### PR DESCRIPTION
We should run ssh command several times until success to properly create
 log message for log test. We can use timeout command to kill hung
 process.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>