### PR TITLE
Enable TPM in uefi

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -82,6 +82,7 @@ You must have the following installed in order to build EVE:
 * [Go](https://golang.org) (optional) Required only if you want to build packages locally. By default, all builds happen in a docker environment.
 * [qemu](https://www.qemu.org) (optional) Required only if you wish to run the generated image. On macOS, easiest to install via [homebrew](https://brew.sh) via `brew install qemu`.
 * [git](https://git-scm.com) which you must have to clone this repository.
+* [swtpm](https://github.com/stefanberger/swtpm) (optional) Required only if you wish to run EVE-OS in qemu with TPM device. On macOS, easiest to install via [homebrew](https://brew.sh) via `brew install swtpm`. On Ubuntu with enabled apparmor please disable apparmor for swtpm after install to use it from local directory: `sudo ln -s /etc/apparmor.d/usr.bin.swtpm /etc/apparmor.d/disable/ && sudo apparmor_parser -R /etc/apparmor.d/disable/usr.bin.swtpm`.
 
 ### Installed As Needed
 

--- a/pkg/uefi/build.sh
+++ b/pkg/uefi/build.sh
@@ -13,7 +13,7 @@ case $(uname -m) in
              cp /opensbi/build/platform/generic/firmware/fw_payload.bin OVMF_VARS.fd
              cp /opensbi/build/platform/generic/firmware/fw_jump.bin OVMF.fd
              ;;
-    aarch64) build -b RELEASE -t GCC5 -a AARCH64 -p ArmVirtPkg/ArmVirtQemu.dsc
+    aarch64) build -b RELEASE -t GCC5 -a AARCH64 -p ArmVirtPkg/ArmVirtQemu.dsc -D TPM2_ENABLE=TRUE -D TPM2_CONFIG_ENABLE=TRUE
              cp Build/ArmVirtQemu-AARCH64/RELEASE_GCC5/FV/QEMU_EFI.fd OVMF.fd
              cp Build/ArmVirtQemu-AARCH64/RELEASE_GCC5/FV/QEMU_VARS.fd OVMF_VARS.fd
              # now let's build PVH UEFI kernel
@@ -21,7 +21,7 @@ case $(uname -m) in
              build -b RELEASE -t GCC5 -a AARCH64  -p ArmVirtPkg/ArmVirtXen.dsc
              cp Build/ArmVirtXen-AARCH64/RELEASE_*/FV/XEN_EFI.fd OVMF_PVH.fd
              ;;
-     x86_64) build -b RELEASE -t GCC5 -a X64 -p OvmfPkg/OvmfPkgX64.dsc
+     x86_64) build -b RELEASE -t GCC5 -a X64 -p OvmfPkg/OvmfPkgX64.dsc -D TPM_ENABLE=TRUE -D TPM_CONFIG_ENABLE=TRUE
              cp Build/OvmfX64/RELEASE_*/FV/OVMF*.fd .
              build -b RELEASE -t GCC5 -a X64 -p OvmfPkg/OvmfXen.dsc
              BaseTools/Source/C/bin/EfiRom -f 0x1F96 -i 0x0778 -e Build/OvmfX64/RELEASE_*/X64/IgdAssignmentDxe.efi

--- a/pkg/xen-tools/Dockerfile
+++ b/pkg/xen-tools/Dockerfile
@@ -1,5 +1,5 @@
 # hadolint ignore=DL3006
-FROM lfedge/eve-uefi:6be7d8ce5c058a39cb0b120f84e2e508e126c24a as uefi-build
+FROM lfedge/eve-uefi:2dbd55c5aaa69de821e510ca416ce88ffe60555f as uefi-build
 
 FROM lfedge/eve-alpine:6.7.0 as runx-build
 ENV BUILD_PKGS mkinitfs gcc musl-dev e2fsprogs


### PR DESCRIPTION
To use TPM devices with qemu (when we use uefi provided by eve-uefi package) we should enable support inside uefi. Right now I can see zero values inside PCRs when I try to use eve-uefi.

Also this PR enables TPM option in Makefile to use swtpm as TPM device for Qemu.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>