### PR TITLE
Revert ext4 journal_data in f0af447046dbbd5bdf81978549a0467bf148f688

### DIFF
--- a/pkg/storage-init/storage-init.sh
+++ b/pkg/storage-init/storage-init.sh
@@ -247,9 +247,7 @@ if P3=$(findfs PARTLABEL=P3) && [ -n "$P3" ]; then
                    if [ "$INIT_FS" = 1 ]; then
                       mkfs -t ext4 -v -F -F -O encrypt "$P3"
                    fi
-                   # Reduce risk of losing file content on power failure.
-                   # Enable encryption.
-                   tune2fs -o journal_data "$P3" && \
+		   # Enable encryption
                    tune2fs -O encrypt "$P3" && \
                    mount -t ext4 -o dirsync,noatime "$P3" $PERSISTDIR
                    ;;


### PR DESCRIPTION
The performance implications of using journal_data can be severe for the application volumes etc.

The added robustness checks and fallbacks for DevicePortConfigList/global.json are sufficient to avoid the issue unless there are proxy config we need to recover, which we will address separately using multiple files for DevicePortConfigList.