### PR TITLE
introduce new mechanism of composing rootfs templates

### DIFF
--- a/images/acrn.patch
+++ b/images/acrn.patch
@@ -1,0 +1,18 @@
+--- images/rootfs.yml.in.sed
++++ images/rootfs.yml.in.sed
+@@ -1,5 +1,5 @@
+ kernel:
+-  image: KERNEL_TAG
++  image: ACRN_KERNEL_TAG
+   cmdline: "rootdelay=3"
+ init:
+   - linuxkit/init:v0.5
+@@ -9,7 +9,7 @@
+   - linuxkit/memlogd:v0.5
+   - GRUB_TAG
+   - FW_TAG
+-  - XEN_TAG
++  - ACRN_TAG
+   - GPTTOOLS_TAG
+   - DOM0ZTOOLS_TAG
+ onboot:

--- a/images/adam.patch
+++ b/images/adam.patch
@@ -1,0 +1,15 @@
+--- images/rootfs.yml.in.sed
++++ images/rootfs.yml.in.sed
+@@ -30,6 +30,12 @@
+      image: NEWLOGD_TAG
+      cgroupsPath: /eve/services/eve-newlog
+      oomScoreAdj: -999
++   - name: adam
++     image: lfedge/adam:latest
++     binds:
++        - /var/persist:/persist
++        - /var/config:/config
++     command: ["/bin/eve-embedded.sh"]
+    - name: debug
+      image: DEBUG_TAG
+      cgroupsPath: /eve/services/debug

--- a/images/mini.patch
+++ b/images/mini.patch
@@ -1,0 +1,71 @@
+--- images/rootfs.yml.in.sed
++++ images/rootfs.yml.in.sed
+@@ -1,67 +1,18 @@
+ kernel:
+-  image: KERNEL_TAG
++  image: NEW_KERNEL_TAG
+   cmdline: "rootdelay=3"
+ init:
+-  - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
+-  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+-  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
+-  - linuxkit/getty:v0.5
+-  - linuxkit/memlogd:v0.5
+   - DOM0ZTOOLS_TAG
+   - GRUB_TAG
+-  - FW_TAG
+-  - XEN_TAG
+   - GPTTOOLS_TAG
+ onboot:
+-   - name: rngd
+-     image: RNGD_TAG
+-     command: ["/sbin/rngd", "-1"]
+-   - name: sysctl
+-     image: linuxkit/sysctl:v0.5
+-     binds:
+-        - /etc/sysctl.d:/etc/sysctl.d
+-   - name: modprobe
+-     image: linuxkit/modprobe:v0.5
+-     command: ["/bin/sh", "-c", "modprobe -a nct6775 w83627hf_wdt hpwdt wlcore_sdio wl18xx br_netfilter dwc3 rk808 rk808-regulator smsc75xx cp210x nicvf tpm_tis_spi rtc_rx8010 gpio_pca953x leds_siemens_ipc127 upboard-fpga pinctrl-upboard leds-upboard xhci_tegra 2>/dev/null || :"]
+    - name: storage-init
+      image: STORAGE_INIT_TAG
+ services:
+-   - name: newlogd
+-     image: NEWLOGD_TAG
+-     cgroupsPath: /eve/services/eve-newlog
+-     oomScoreAdj: -999
+    - name: debug
+      image: DEBUG_TAG
+      cgroupsPath: /eve/services/debug
+      oomScoreAdj: -999
+-   - name: wwan
+-     image: WWAN_TAG
+-     cgroupsPath: /eve/services/wwan
+-     oomScoreAdj: -999
+-   - name: wlan
+-     image: WLAN_TAG
+-     cgroupsPath: /eve/services/wlan
+-     oomScoreAdj: -999
+-   - name: guacd
+-     image: GUACD_TAG
+-     cgroupsPath: /eve/services/guacd
+-     oomScoreAdj: -999
+-   - name: pillar
+-     image: PILLAR_TAG
+-     cgroupsPath: /eve/services/pillar
+-     oomScoreAdj: -999
+-   - name: vtpm
+-     image: VTPM_TAG
+-     cgroupsPath: /eve/services/vtpm
+-     oomScoreAdj: -999
+-   - name: watchdog
+-     image: WATCHDOG_TAG
+-     cgroupsPath: /eve/services/watchdog
+-     oomScoreAdj: -1000
+-   - name: xen-tools
+-     image: XENTOOLS_TAG
+-     cgroupsPath: /eve/services/xen-tools
+-     oomScoreAdj: -999
+ files:
+    - path: /etc/eve-release
+      contents: 'EVE_VERSION'

--- a/images/tools.patch
+++ b/images/tools.patch
@@ -1,0 +1,12 @@
+--- images/rootfs.yml.in.sed
++++ images/rootfs.yml.in.sed
+@@ -66,6 +66,9 @@
+      image: XENTOOLS_TAG
+      cgroupsPath: /eve/services/xen-tools
+      oomScoreAdj: -999
++   - name: kvm-tools
++     image: KVMTOOLS_TAG
++     cgroupsPath: /eve/services/kvmtool
+ files:
+    - path: /etc/eve-release
+      contents: 'EVE_VERSION'

--- a/tools/compose-image-yml.sh
+++ b/tools/compose-image-yml.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+main() {
+    local base_templ_path="$1"
+    local out_templ_path="$2"
+    local eve_version="$3"
+
+    local out_dir
+    local tock_str
+
+    out_dir="$(dirname "${out_templ_path}")"
+    tock_str="$(basename "${out_templ_path}")"
+    tock_str=${tock_str%.yml.in.new}
+    IFS="-" read -r -a tockens <<< "${tock_str}"
+
+    echo "out_templ_path is ${out_templ_path}"
+
+    cp "${base_templ_path}" "${base_templ_path}".sed
+    for i in "${tockens[@]}"; do
+        local patch_name="${out_dir}"/"$i".patch
+        echo "checking ${patch_name}"
+        if [ -e "${patch_name}" ]; then
+            patch -p0 -i "${patch_name}"
+        fi
+    done
+
+    sed "s/EVE_VERSION/${eve_version}/g" <  "${base_templ_path}".sed > "${out_templ_path}"
+}
+
+main "$@"


### PR DESCRIPTION
This is preparation for introducing the development builds. The main goal of the patch is to be able to combine different build flavors together, by sequentially applying patches to the rootfs Configuration.

At the moment the final rootfs configuration is built by applying patches on the base configuration. To instruct the build to mutate rootfs, the user needs to pass the `HV` variable to the `make`. For example 

```
   make HV=acrn #to build the acrn-based Eve
   make HV=zfs-kvm #to build kvm-based with zfs as default file system
```

Currently, the build system would look under the `images` folder for the corresponding patch. For example `images/rootfs-acrn.yml.in.patch`. This means for each build flavor we want to support we need a separate `*.patch` file.

This becomes a problem once we need to mix flavors. Particularly, with upcoming “development” build flavor, which is orthogonal to the hypervisor type and can be applied to kvm, xen and acrn. If we keep this approach, to add a `dev` build we would have to introduce 3 patches under the `images` directory. This approach clearly does not scale.

In this patch the `HV` string is tokenized, using minus (‘-’) as a separator. And each token represents a separate patch under the `images` directory. For example for the `HV=acrn-dev`, 2 patches would be applied to the base configuration:
   - ‘images/acrn.patch’
   - ‘images/dev.patch’ (will be introduced later)

For now, since this new mechanism is not used, we have the luxury of a transition period. This patch still keeps the old approach and the both mechanisms co-exist: in addition to rootfs-*.yml.in also the rootfs-*.yml.in.new file is generated and the context is compared. Bail if they do not match.

If any broken build configurations are overlooked during testing, keeping both mechanisms will let us catch any broken builds before they cause any damage.
