### PR TITLE
Set primarycache=metadata property

### DIFF
--- a/pkg/mkimage-raw-efi/install
+++ b/pkg/mkimage-raw-efi/install
@@ -186,6 +186,7 @@ prepare_mounts_and_zfs_pool() {
   eval "$POOL_CREATION_COMMAND"
   chroot /root zfs create -o refreservation="$(chroot /root zfs get -o value -Hp available persist | awk '{ print ($1/1024/1024)/5 }')"m persist/reserved
   chroot /root zfs set mountpoint="/run/P3" persist
+  chroot /root zfs set primarycache=metadata persist
 }
 
 adjust_zfs_mounts_and_umount() {

--- a/pkg/storage-init/storage-init.sh
+++ b/pkg/storage-init/storage-init.sh
@@ -257,6 +257,7 @@ if P3=$(findfs PARTLABEL=P3) && [ -n "$P3" ]; then
                       chroot /hostfs zpool create -f -m none -o feature@encryption=enabled -O overlay=on persist "$P3" && \
                       chroot /hostfs zfs create -o refreservation="$(chroot /hostfs zfs get -o value -Hp available persist | awk '{ print ($1/1024/1024)/5 }')"m persist/reserved && \
                       chroot /hostfs zfs set mountpoint="$PERSISTDIR" persist                                          && \
+                      chroot /hostfs zfs set primarycache=metadata persist                                             && \
                       chroot /hostfs zfs create -p -o mountpoint="$PERSISTDIR/containerd/io.containerd.snapshotter.v1.zfs" persist/snapshots
                    fi
                    chroot /hostfs zpool import -f persist


### PR DESCRIPTION
Setting primarycache to metadata is a recommended value from the third party vendor after the performance analysis and also validated in internal testing.

Before this fix it was set to default value "all"


Signed-off-by: Pramodh Pallapothu <pramodh@zededa.com>