### PR TITLE
zfs storage init fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -482,7 +482,6 @@ $(CONFIG_IMG): $(CONF_FILES) | $(INSTALLER)
 	$(QUIET): $@: Succeeded
 
 $(PERSIST_IMG): | $(INSTALLER)
-	$(if $(findstring zfs,$(HV)),echo 'eve<3zfs' > $@)
 	# 1M of zeroes should be enough to trigger filesystem wipe on first boot
 	dd if=/dev/zero bs=1048576 count=1 >> $@
 	$(QUIET): $@: Succeeded

--- a/pkg/storage-init/storage-init.sh
+++ b/pkg/storage-init/storage-init.sh
@@ -293,7 +293,12 @@ for BLK_DEVICE in $BLK_DEVICES; do
 done
 
 #Recording SMART details to a file
-SMART_JSON=$(smartctl -a "$(grep -m 1 /persist < /proc/mounts | cut -d ' ' -f 1)" --json)
+if [ -L /dev/root ] ; then
+  DEV_TO_CHECK_SMART=/dev/root
+else
+  DEV_TO_CHECK_SMART=$(grep -m 1 /persist < /proc/mounts | cut -d ' ' -f 1)
+fi
+SMART_JSON=$(smartctl -a "$DEV_TO_CHECK_SMART" --json)
 if [ -f "$SMART_DETAILS_PREVIOUS_FILE" ];
 then
   mv $SMART_DETAILS_FILE $SMART_DETAILS_PREVIOUS_FILE

--- a/pkg/storage-init/storage-init.sh
+++ b/pkg/storage-init/storage-init.sh
@@ -217,15 +217,6 @@ if P3=$(findfs PARTLABEL=P3) && [ -n "$P3" ]; then
     P3_FS_TYPE=$(blkid "$P3"| tr ' ' '\012' | awk -F= '/^TYPE/{print $2;}' | sed 's/"//g')
     echo "$(date -Ins -u) Using $P3 (formatted with $P3_FS_TYPE), for $PERSISTDIR"
 
-    # XXX FIXME: the following hack MUST go away when/if we decide to officially support ZFS
-    # for now we are using first block in the device to flip into zfs on demand
-    if [ "$(dd if="$P3" bs=8 count=1 2>/dev/null)" = "eve<3zfs" ]; then
-       # zero out the request (regardless of whether we can convert to zfs)
-       dd if=/dev/zero of="$P3" bs=8 count=1 conv=noerror,sync,notrunc
-
-       P3_FS_TYPE=zfs
-    fi
-
     if [ "$P3_FS_TYPE" = zfs_member ]; then
         if ! chroot /hostfs zpool import -f persist; then
             echo "$(date -Ins -u) Cannot import persist pool on P3 partition $P3 of type $P3_FS_TYPE, recreating it as $P3_FS_TYPE_DEFAULT"


### PR DESCRIPTION
Several changes in storage-init:

1. Removal of zfs hack, we do not need it with replacement by another options
2. Removal of double-import of zfs pool problem
3. Use root device for smart properties check instead of mounted as /persist which is not valid for zfs deployments