### PR TITLE
vHost target wait for enable file and use only for kvm hypervisor

### DIFF
--- a/pkg/pillar/cmd/volumemgr/create.go
+++ b/pkg/pillar/cmd/volumemgr/create.go
@@ -239,15 +239,17 @@ func destroyVdiskVolume(ctx *volumemgrContext, status types.VolumeStatus) (bool,
 		return created, "", errors.New(errStr)
 	}
 	if info.Mode()&os.ModeDevice != 0 {
-		if err := tgt.VHostDeleteIBlock(status.WWN); err != nil {
-			errStr := fmt.Sprintf("Error deleting vhost for %s, error=%v",
-				status.Key(), err)
-			log.Error(errStr)
-		}
-		if err := tgt.TargetDeleteIBlock(status.Key()); err != nil {
-			errStr := fmt.Sprintf("Error deleting target for %s, error=%v",
-				status.Key(), err)
-			log.Error(errStr)
+		if ctx.useVHost {
+			if err := tgt.VHostDeleteIBlock(status.WWN); err != nil {
+				errStr := fmt.Sprintf("Error deleting vhost for %s, error=%v",
+					status.Key(), err)
+				log.Error(errStr)
+			}
+			if err := tgt.TargetDeleteIBlock(status.Key()); err != nil {
+				errStr := fmt.Sprintf("Error deleting target for %s, error=%v",
+					status.Key(), err)
+				log.Error(errStr)
+			}
 		}
 		//Assume this is zfs device
 		zVolName := status.ZVolName()

--- a/pkg/pillar/cmd/volumemgr/handlevolume.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume.go
@@ -139,7 +139,7 @@ func handleDeferredVolumeCreate(ctx *volumemgrContext, key string, config *types
 			}
 			created = true
 			status.FileLocation = zVolDevice
-			if !tgt.CheckTargetIBlock(status.Key()) {
+			if ctx.useVHost && !tgt.CheckTargetIBlock(status.Key()) {
 				log.Functionf("generating target and vhost for %s", status.Key())
 				wwn, err := createTargetVhost(zVolDevice, status)
 				if err != nil {

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -595,7 +595,7 @@ func doUpdateVol(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool)
 		}
 	}
 	if status.State == types.CREATING_VOLUME && status.SubState == types.VolumeSubStatePreparing {
-		if ctx.persistType == types.PersistZFS && !status.IsContainer() {
+		if ctx.useVHost && ctx.persistType == types.PersistZFS && !status.IsContainer() {
 			zVolStatus := lookupZVolStatusByDataset(ctx, status.ZVolName())
 			if zVolStatus != nil {
 				wwn, err := createTargetVhost(zVolStatus.Device, status)

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/cas"
 	"github.com/lf-edge/eve/pkg/pillar/flextimer"
+	"github.com/lf-edge/eve/pkg/pillar/hypervisor"
 	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
@@ -93,6 +94,7 @@ type volumemgrContext struct {
 	volumeConfigCreateDeferredMap map[string]*types.VolumeConfig
 
 	persistType types.PersistType
+	useVHost    bool //indicates that we want to use vhost
 }
 
 var debug = false
@@ -177,6 +179,15 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		log.Fatal(err)
 	}
 	log.Functionf("user containerd ready")
+
+	_, enabledHVs := hypervisor.GetAvailableHypervisors()
+	for _, el := range enabledHVs {
+		if el == hypervisor.KVMHypervisorName {
+			ctx.useVHost = true
+			break
+		}
+	}
+	log.Functionf("will use vhost: %t", ctx.useVHost)
 
 	if ctx.persistType == types.PersistZFS {
 		// create datasets for volumes

--- a/pkg/pillar/hypervisor/acrn.go
+++ b/pkg/pillar/hypervisor/acrn.go
@@ -3,6 +3,9 @@
 
 package hypervisor
 
+//ACRNHypervisorName is a name of acrn hypervisor
+const ACRNHypervisorName = "acrn"
+
 type acrnContext struct {
 	nullContext
 }
@@ -13,5 +16,5 @@ func newAcrn() Hypervisor {
 
 // Name returns the name of this hypervisor implementation
 func (ctx acrnContext) Name() string {
-	return "acrn"
+	return ACRNHypervisorName
 }

--- a/pkg/pillar/hypervisor/containerd.go
+++ b/pkg/pillar/hypervisor/containerd.go
@@ -17,6 +17,9 @@ import (
 
 const (
 	vifsDir string = "/run/tasks/vifs"
+
+	//ContainerdHypervisorName is a name of containerd hypervisor
+	ContainerdHypervisorName = "containerd"
 )
 
 type ctrdContext struct {
@@ -55,7 +58,7 @@ func (ctx ctrdContext) GetCapabilities() (*types.Capabilities, error) {
 }
 
 func (ctx ctrdContext) Name() string {
-	return "containerd"
+	return ContainerdHypervisorName
 }
 
 func (ctx ctrdContext) Task(status *types.DomainStatus) types.Task {

--- a/pkg/pillar/hypervisor/hypervisor.go
+++ b/pkg/pillar/hypervisor/hypervisor.go
@@ -33,15 +33,17 @@ type hypervisorDesc struct {
 }
 
 var knownHypervisors = map[string]hypervisorDesc{
-	"xen":        {constructor: newXen, dom0handle: "/proc/xen"},
-	"kvm":        {constructor: newKvm, dom0handle: "/dev/kvm"},
-	"acrn":       {constructor: newAcrn, dom0handle: "/dev/acrn"},
-	"containerd": {constructor: newContainerd, dom0handle: "/run/containerd/containerd.sock"},
-	"null":       {constructor: newNull, dom0handle: "/"},
+	XenHypervisorName:        {constructor: newXen, dom0handle: "/proc/xen"},
+	KVMHypervisorName:        {constructor: newKvm, dom0handle: "/dev/kvm"},
+	ACRNHypervisorName:       {constructor: newAcrn, dom0handle: "/dev/acrn"},
+	ContainerdHypervisorName: {constructor: newContainerd, dom0handle: "/run/containerd/containerd.sock"},
+	NullHypervisorName:       {constructor: newNull, dom0handle: "/"},
 }
 
-// this is a priority order to pick a default hypervisor if multiple are availabel (more to less likely)
-var hypervisorPriority = []string{"xen", "kvm", "acrn", "containerd", "null"}
+// this is a priority order to pick a default hypervisor if multiple are available (more to less likely)
+var hypervisorPriority = []string{
+	XenHypervisorName, KVMHypervisorName, ACRNHypervisorName, ContainerdHypervisorName, NullHypervisorName,
+}
 
 // GetHypervisor returns a particular hypervisor implementation
 func GetHypervisor(hint string) (Hypervisor, error) {

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -19,6 +19,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+//KVMHypervisorName is a name of kvm hypervisor
+const KVMHypervisorName = "kvm"
+
 //TBD: Have a better way to calculate this number.
 //For now it is based on some trial-and-error experiments
 const minQemuOverHead = int64(600 * 1024 * 1024)
@@ -436,7 +439,7 @@ func (ctx kvmContext) checkIOVirtualisation() (bool, error) {
 }
 
 func (ctx kvmContext) Name() string {
-	return "kvm"
+	return KVMHypervisorName
 }
 
 func (ctx kvmContext) Task(status *types.DomainStatus) types.Task {

--- a/pkg/pillar/hypervisor/null.go
+++ b/pkg/pillar/hypervisor/null.go
@@ -12,6 +12,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+//NullHypervisorName is a name of null hypervisor
+const NullHypervisorName = "null"
+
 type domState struct {
 	id     int
 	config string
@@ -45,7 +48,7 @@ func newNull() Hypervisor {
 }
 
 func (ctx nullContext) Name() string {
-	return "null"
+	return NullHypervisorName
 }
 
 func (ctx nullContext) Task(status *types.DomainStatus) types.Task {

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -19,6 +19,9 @@ import (
 
 const (
 	dom0Name = "Domain-0"
+
+	//XenHypervisorName is a name of xen hypervisor
+	XenHypervisorName = "xen"
 )
 
 type typeAndPCI struct {
@@ -117,7 +120,7 @@ func newXen() Hypervisor {
 }
 
 func (ctx xenContext) Name() string {
-	return "xen"
+	return XenHypervisorName
 }
 
 func (ctx xenContext) Task(status *types.DomainStatus) types.Task {

--- a/pkg/pillar/tgt/tgt.go
+++ b/pkg/pillar/tgt/tgt.go
@@ -76,6 +76,9 @@ func TargetCreateIBlock(dev, tgtName, serial string) error {
 	if err := ioutil.WriteFile(filepath.Join(targetRoot, "wwn", "vpd_unit_serial"), []byte(serial), 0660); err != nil {
 		return fmt.Errorf("error set vpd_unit_serial: %v", err)
 	}
+	if err := waitForFile(filepath.Join(targetRoot, "enable")); err != nil {
+		return fmt.Errorf("error waitForFile: %v", err)
+	}
 	if err := ioutil.WriteFile(filepath.Join(targetRoot, "enable"), []byte("1"), 0660); err != nil {
 		return fmt.Errorf("error set enable: %v", err)
 	}


### PR DESCRIPTION
I can see "error set enable: /hostfs/sys/kernel/config/target/../enable no such file or directory", seems we
should wait a little for this file.
In general we expect vHost target only for kvm hypervisor so I put check for the hypervisor before we run logic for targets.