### PR TITLE
Store vault key in TPM sealed and legacy

### DIFF
--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -673,6 +673,7 @@ func publishZedAgentStatus(getconfigCtx *getconfigContext) {
 		ForceFallbackCounter: ctx.forceFallbackCounter,
 		CurrentProfile:       getconfigCtx.currentProfile,
 		RadioSilence:         getconfigCtx.radioSilence,
+		AttestationStatus:    ctx.attestationStatus,
 	}
 	pub := getconfigCtx.pubZedAgentStatus
 	pub.Publish(agentName, status)

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -184,6 +184,8 @@ type zedagentContext struct {
 
 	// Interlock with controller to ensure we get the encrypted secrets
 	publishedEdgeNodeCerts bool
+
+	attestationStatus types.AttestationStatus
 }
 
 var debug = false

--- a/pkg/pillar/types/zedagenttypes.go
+++ b/pkg/pillar/types/zedagenttypes.go
@@ -514,6 +514,40 @@ func (do DeviceOperation) String() string {
 	}
 }
 
+//AttestationStatus contains current status of attestation
+type AttestationStatus uint8
+
+const (
+	//AttestationStatusNone placeholder
+	AttestationStatusNone AttestationStatus = iota
+	//AttestationStatusQuoteMismatch indicates that we cannot pass attestation with template issue
+	AttestationStatusQuoteMismatch
+	//AttestationStatusEmptyKeys empty keys received from controller
+	AttestationStatusEmptyKeys
+	//AttestationStatusKeysReceived keys received from controller
+	AttestationStatusKeysReceived
+	//AttestationStatusCompleted completed
+	AttestationStatusCompleted
+)
+
+// String returns the verbose equivalent of AttestationStatus code
+func (a AttestationStatus) String() string {
+	switch a {
+	case AttestationStatusNone:
+		return "none"
+	case AttestationStatusQuoteMismatch:
+		return "quote mismatch"
+	case AttestationStatusEmptyKeys:
+		return "no keys"
+	case AttestationStatusKeysReceived:
+		return "keys received"
+	case AttestationStatusCompleted:
+		return "completed"
+	default:
+		return fmt.Sprintf("Unknown AttestationStatus %d", a)
+	}
+}
+
 // ZedAgentStatus :
 type ZedAgentStatus struct {
 	Name                 string
@@ -527,6 +561,7 @@ type ZedAgentStatus struct {
 	ForceFallbackCounter int          // Try image fallback when counter changes
 	CurrentProfile       string       // Current profile
 	RadioSilence         RadioSilence // Currently requested state of radio devices
+	AttestationStatus    AttestationStatus
 }
 
 // Key :


### PR DESCRIPTION
We can hit problems with storing of storage key because of no
connectivity to the controller or attestation template mismatch. In that
 case after reboot we will try to unseal key from TPM but if PCR values
 changed across reboots we will hit an error while unlock.

In this PR I store vault key in legacy mode (without sealing) alongside
with sealed one and use legacy key as a fallback. To properly handle
attestation process we should remove legacy key. I remove it on event
 of keys received from the controller (on next attestation process,
 for example after reboot), so we will wait for successful
 storing and responding of keys from the controller to not hit the
 problem with loosing of keys.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>