### PR TITLE
Add TPM module support for rpi4

### DIFF
--- a/pkg/kernel/patches-5.10.x/0013-add-slb9670-TPM-module-support-for-rpi4.patch
+++ b/pkg/kernel/patches-5.10.x/0013-add-slb9670-TPM-module-support-for-rpi4.patch
@@ -1,0 +1,66 @@
+From ce476c00f41802bbe1818ae3ac601689aecd1865 Mon Sep 17 00:00:00 2001
+From: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>
+Date: Sun, 29 May 2022 19:09:38 +0300
+Subject: [PATCH] add slb9670 TPM module support for rpi4
+
+Signed-off-by: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>
+---
+ arch/arm/boot/dts/bcm2711-rpi-4-b.dts         |  1 +
+ .../arm/boot/dts/bcm2835-spi-tpm-slb9670.dtsi | 33 +++++++++++++++++++
+ 2 files changed, 34 insertions(+)
+ create mode 100644 arch/arm/boot/dts/bcm2835-spi-tpm-slb9670.dtsi
+
+diff --git a/arch/arm/boot/dts/bcm2711-rpi-4-b.dts b/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
+index fcd561c021ea..ff4a896deb16 100644
+--- a/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
++++ b/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
+@@ -3,6 +3,7 @@
+ #include "bcm2711.dtsi"
+ #include "bcm2835-rpi.dtsi"
+ #include "bcm283x-rpi-usb-peripheral.dtsi"
++#include "bcm2835-spi-tpm-slb9670.dtsi"
+ 
+ #include <dt-bindings/reset/raspberrypi,firmware-reset.h>
+ 
+diff --git a/arch/arm/boot/dts/bcm2835-spi-tpm-slb9670.dtsi b/arch/arm/boot/dts/bcm2835-spi-tpm-slb9670.dtsi
+new file mode 100644
+index 000000000000..8b522d8702bb
+--- /dev/null
++++ b/arch/arm/boot/dts/bcm2835-spi-tpm-slb9670.dtsi
+@@ -0,0 +1,33 @@
++// SPDX-License-Identifier: GPL-2.0
++
++&gpio {
++	spi0_pins: spi0_pins {
++		brcm,pins = <9 10 11>;
++		brcm,function = <4>;
++	};
++
++	spi0_cs_pins: spi0_cs_pins {
++		brcm,pins = <8 7>;
++		brcm,function = <1>;
++	};
++};
++
++&spi {
++	/* needed to avoid dtc warning */
++	#address-cells = <1>;
++	#size-cells = <0>;
++
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi0_pins &spi0_cs_pins>;
++	cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
++	status = "okay";
++
++	slb9670: slb9670@1 {
++		compatible = "infineon,slb9670";
++		reg = <1>;	/* CE1 */
++		#address-cells = <1>;
++		#size-cells = <0>;
++		spi-max-frequency = <32000000>;
++		status = "okay";
++	};
++};
+-- 
+2.25.1
+

--- a/pkg/new-kernel/patches-5.12.x/0012-add-slb9670-TPM-module-support-for-rpi4.patch
+++ b/pkg/new-kernel/patches-5.12.x/0012-add-slb9670-TPM-module-support-for-rpi4.patch
@@ -1,0 +1,66 @@
+From ce476c00f41802bbe1818ae3ac601689aecd1865 Mon Sep 17 00:00:00 2001
+From: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>
+Date: Sun, 29 May 2022 19:09:38 +0300
+Subject: [PATCH] add slb9670 TPM module support for rpi4
+
+Signed-off-by: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>
+---
+ arch/arm/boot/dts/bcm2711-rpi-4-b.dts         |  1 +
+ .../arm/boot/dts/bcm2835-spi-tpm-slb9670.dtsi | 33 +++++++++++++++++++
+ 2 files changed, 34 insertions(+)
+ create mode 100644 arch/arm/boot/dts/bcm2835-spi-tpm-slb9670.dtsi
+
+diff --git a/arch/arm/boot/dts/bcm2711-rpi-4-b.dts b/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
+index fcd561c021ea..ff4a896deb16 100644
+--- a/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
++++ b/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
+@@ -3,6 +3,7 @@
+ #include "bcm2711.dtsi"
+ #include "bcm2835-rpi.dtsi"
+ #include "bcm283x-rpi-usb-peripheral.dtsi"
++#include "bcm2835-spi-tpm-slb9670.dtsi"
+ 
+ #include <dt-bindings/reset/raspberrypi,firmware-reset.h>
+ 
+diff --git a/arch/arm/boot/dts/bcm2835-spi-tpm-slb9670.dtsi b/arch/arm/boot/dts/bcm2835-spi-tpm-slb9670.dtsi
+new file mode 100644
+index 000000000000..8b522d8702bb
+--- /dev/null
++++ b/arch/arm/boot/dts/bcm2835-spi-tpm-slb9670.dtsi
+@@ -0,0 +1,33 @@
++// SPDX-License-Identifier: GPL-2.0
++
++&gpio {
++	spi0_pins: spi0_pins {
++		brcm,pins = <9 10 11>;
++		brcm,function = <4>;
++	};
++
++	spi0_cs_pins: spi0_cs_pins {
++		brcm,pins = <8 7>;
++		brcm,function = <1>;
++	};
++};
++
++&spi {
++	/* needed to avoid dtc warning */
++	#address-cells = <1>;
++	#size-cells = <0>;
++
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi0_pins &spi0_cs_pins>;
++	cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
++	status = "okay";
++
++	slb9670: slb9670@1 {
++		compatible = "infineon,slb9670";
++		reg = <1>;	/* CE1 */
++		#address-cells = <1>;
++		#size-cells = <0>;
++		spi-max-frequency = <32000000>;
++		status = "okay";
++	};
++};
+-- 
+2.25.1
+


### PR DESCRIPTION
Add TPM module support for rpi4.

https://www.infineon.com/dgdl/Infineon-OPTIGA_SLx_9670_TPM_2.0_Pi_4-ApplicationNotes-v07_19-EN.pdf?fileId=5546d4626c1f3dc3016c3d19f43972eb