### PR TITLE
Fix unexpected starting of xen with local branch

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -309,9 +309,9 @@ function set_xen_boot {
 
 function set_eve_flavor {
    # if eve_flavor is not set explicitly we assume it is
-   # embedded in the name of the image
+   # embedded in the end of the name of the image
    if [ "$eve_flavor" != xen -a "$eve_flavor" != kvm ] ; then
-      if regexp -- '-xen(-|$)' $rootfs_title ; then
+      if regexp -- '-xen(-amd64$|-arm64$|-riscv64$|$)' $rootfs_title ; then
          eve_flavor=xen
       else
          eve_flavor=kvm


### PR DESCRIPTION
We check for "-xen-" inside of version and run xen hypervisor which is
not expected. We must be more selective when starting xen version and
only run with "xen" in the end.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>