### PR TITLE
Stop service containers based on environment

### DIFF
--- a/pkg/pillar/hypervisor/containerd.go
+++ b/pkg/pillar/hypervisor/containerd.go
@@ -42,6 +42,16 @@ func newContainerd() Hypervisor {
 		logrus.Fatalf("couldn't initialize containerd (this should not happen): %v. Exiting.", err)
 		return nil // it really never returns on account of above
 	} else {
+		ctrdSystemCtx, done := ret.ctrdClient.CtrNewSystemServicesCtx()
+		defer done()
+		// we do not need running shim of xen-tools for containerd hypervisor
+		if err = ret.ctrdClient.CtrDeleteContainer(ctrdSystemCtx, "xen-tools"); err != nil {
+			logrus.Errorf("cannot delete xen-tools: %s", err)
+		}
+		// we cannot provide VNC with containerd hypervisor, so no need for guacd container
+		if err = ret.ctrdClient.CtrDeleteContainer(ctrdSystemCtx, "guacd"); err != nil {
+			logrus.Errorf("cannot delete xen-tools: %s", err)
+		}
 		return ret
 	}
 }

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -378,6 +378,12 @@ func newKvm() Hypervisor {
 		logrus.Fatalf("couldn't initialize containerd (this should not happen): %v. Exiting.", err)
 		return nil // it really never returns on account of above
 	}
+	// we do not need running shim of xen-tools for kvm hypervisor
+	ctrdSystemCtx, done := ctrdCtx.ctrdClient.CtrNewSystemServicesCtx()
+	defer done()
+	if err = ctrdCtx.ctrdClient.CtrDeleteContainer(ctrdSystemCtx, "xen-tools"); err != nil {
+		logrus.Errorf("cannot delete xen-tools: %s", err)
+	}
 	// later on we may want to pass device model machine type in DomainConfig directly;
 	// for now -- lets just pick a static device model based on the host architecture
 	// "-cpu host",

--- a/pkg/xen-tools/init.sh
+++ b/pkg/xen-tools/init.sh
@@ -30,12 +30,7 @@ if [ -d /proc/xen/ ]; then
    while true ; do sleep 60 ; done
 
 elif [ -e /dev/kvm ]; then
-   echo "KVM hypervisor support detected"
-
-   # set things up for R/O FS qemu task execution
-   ln -s . /run/run || :
-
-   while true ; do sleep 60 ; done
+   echo "KVM hypervisor support detected, no need for xen-tools"
 
 else
    echo "No hypervisor support detected, feel free to run bare-metal containers"


### PR DESCRIPTION
We do not need xen-tools to be running for kvm and containerd
hypervisors, guacd for containerd hypervisor and vtpm when we have no
tpm device. We can stop and remove them to reduce memory usage

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>