### PR TITLE
Zed upload changes

### DIFF
--- a/libs/zedUpload/awsutil/s3api.go
+++ b/libs/zedUpload/awsutil/s3api.go
@@ -73,10 +73,12 @@ func NewAwsCtx(id, secret, region string, hctx *http.Client) *S3ctx {
 		u.PartSize = S3PartSize
 		u.LeavePartsOnError = S3PartLeaveError
 		u.Concurrency = S3Concurrency
+		u.BufferProvider = s3manager.NewBufferedReadSeekerWriteToPool(32 * 1024)
 	})
 	ctx.dn = s3manager.NewDownloaderWithClient(ctx.ss3, func(d *s3manager.Downloader) {
 		d.PartSize = S3PartSize
 		d.Concurrency = S3Concurrency
+		d.BufferProvider = s3manager.NewPooledBufferedWriterReadFromProvider(32 * 1024)
 	})
 
 	return &ctx

--- a/libs/zedUpload/azureutil/azure.go
+++ b/libs/zedUpload/azureutil/azure.go
@@ -112,7 +112,12 @@ func newPipeline(accountName, accountKey string, httpClient *http.Client) (pipel
 	if err != nil {
 		return nil, fmt.Errorf("Invalid credentials with error: " + err.Error())
 	}
-	p := azblob.NewPipeline(credential, azblob.PipelineOptions{HTTPSender: sender})
+	p := azblob.NewPipeline(credential, azblob.PipelineOptions{
+		HTTPSender: sender,
+		RequestLog: azblob.RequestLogOptions{
+			LogWarningIfTryOverThreshold: -1,
+			SyslogDisabled:               true,
+		}})
 	return p, nil
 }
 

--- a/libs/zedUpload/datastore_aws.go
+++ b/libs/zedUpload/datastore_aws.go
@@ -134,6 +134,7 @@ func (ep *AwsTransportMethod) processS3Upload(req *DronaRequest) (error, int) {
 	if req.ackback {
 		go func(req *DronaRequest, prgNotif zedAWS.NotifChan) {
 			ticker := time.NewTicker(StatsUpdateTicker)
+			defer ticker.Stop()
 			var stats zedAWS.UpdateStats
 			var ok bool
 			for {
@@ -195,6 +196,7 @@ func (ep *AwsTransportMethod) processS3Download(req *DronaRequest) (error, int) 
 				select {
 				case stats, ok = <-prgNotif:
 					if !ok {
+						ticker.Stop()
 						return
 					}
 				case <-ticker.C:
@@ -281,6 +283,7 @@ func (ep *AwsTransportMethod) processS3List(req *DronaRequest) ([]string, error,
 	if req.ackback {
 		go func(req *DronaRequest, prgNotif zedAWS.NotifChan) {
 			ticker := time.NewTicker(StatsUpdateTicker)
+			defer ticker.Stop()
 			var stats zedAWS.UpdateStats
 			var ok bool
 			for {

--- a/libs/zedUpload/datastore_azure.go
+++ b/libs/zedUpload/datastore_azure.go
@@ -131,6 +131,7 @@ func (ep *AzureTransportMethod) processAzureDownload(req *DronaRequest) error {
 	if req.ackback {
 		go func(req *DronaRequest, prgNotif azure.NotifChan) {
 			ticker := time.NewTicker(StatsUpdateTicker)
+			defer ticker.Stop()
 			var stats azure.UpdateStats
 			var ok bool
 			for {

--- a/libs/zedUpload/datastore_gs.go
+++ b/libs/zedUpload/datastore_gs.go
@@ -128,6 +128,7 @@ func (ep *GsTransportMethod) processGSUpload(req *DronaRequest) (int, error) {
 	if req.ackback {
 		go func(req *DronaRequest, prgNotif zedGS.NotifChan) {
 			ticker := time.NewTicker(StatsUpdateTicker)
+			defer ticker.Stop()
 			var stats zedGS.UpdateStats
 			var ok bool
 			for {
@@ -175,6 +176,7 @@ func (ep *GsTransportMethod) processGSDownload(req *DronaRequest) (int, error) {
 	if req.ackback {
 		go func(req *DronaRequest, prgNotif zedGS.NotifChan) {
 			ticker := time.NewTicker(StatsUpdateTicker)
+			defer ticker.Stop()
 			var stats zedGS.UpdateStats
 			var ok bool
 			for {
@@ -229,6 +231,7 @@ func (ep *GsTransportMethod) processGSList(req *DronaRequest) ([]string, int, er
 	if req.ackback {
 		go func(req *DronaRequest, prgNotif zedGS.NotifChan) {
 			ticker := time.NewTicker(StatsUpdateTicker)
+			defer ticker.Stop()
 			var stats zedGS.UpdateStats
 			var ok bool
 			for {

--- a/libs/zedUpload/datastore_http.go
+++ b/libs/zedUpload/datastore_http.go
@@ -118,6 +118,7 @@ func (ep *HttpTransportMethod) processHttpUpload(req *DronaRequest) (error, int)
 	if req.ackback {
 		go func(req *DronaRequest, prgNotif zedHttp.NotifChan) {
 			ticker := time.NewTicker(StatsUpdateTicker)
+			defer ticker.Stop()
 			var stats zedHttp.UpdateStats
 			var ok bool
 			for {
@@ -147,6 +148,7 @@ func (ep *HttpTransportMethod) processHttpDownload(req *DronaRequest) (error, in
 	if req.ackback {
 		go func(req *DronaRequest, prgNotif zedHttp.NotifChan) {
 			ticker := time.NewTicker(StatsUpdateTicker)
+			defer ticker.Stop()
 			var stats zedHttp.UpdateStats
 			var ok bool
 			for {
@@ -181,6 +183,7 @@ func (ep *HttpTransportMethod) processHttpList(req *DronaRequest) ([]string, err
 	if req.ackback {
 		go func(req *DronaRequest, prgNotif zedHttp.NotifChan) {
 			ticker := time.NewTicker(StatsUpdateTicker)
+			defer ticker.Stop()
 			var stats zedHttp.UpdateStats
 			var ok bool
 			for {
@@ -210,6 +213,7 @@ func (ep *HttpTransportMethod) processHttpObjectMetaData(req *DronaRequest) (err
 	if req.ackback {
 		go func(req *DronaRequest, prgNotif zedHttp.NotifChan) {
 			ticker := time.NewTicker(StatsUpdateTicker)
+			defer ticker.Stop()
 			var stats zedHttp.UpdateStats
 			var ok bool
 			for {

--- a/libs/zedUpload/datastore_oci.go
+++ b/libs/zedUpload/datastore_oci.go
@@ -150,6 +150,7 @@ func (ep *OCITransportMethod) processDownload(req *DronaRequest) (int64, string,
 	if req.ackback {
 		go func(req *DronaRequest, prgNotif ociutil.NotifChan) {
 			ticker := time.NewTicker(StatsUpdateTicker)
+			defer ticker.Stop()
 			var stats ociutil.UpdateStats
 			var ok bool
 			for {
@@ -183,6 +184,7 @@ func (ep *OCITransportMethod) processList(req *DronaRequest) ([]string, error) {
 	if req.ackback {
 		go func(req *DronaRequest, prgNotif ociutil.NotifChan) {
 			ticker := time.NewTicker(StatsUpdateTicker)
+			defer ticker.Stop()
 			var stats ociutil.UpdateStats
 			var ok bool
 			for {
@@ -216,6 +218,7 @@ func (ep *OCITransportMethod) processObjectMetaData(req *DronaRequest) (string, 
 	if req.ackback {
 		go func(req *DronaRequest, prgNotif ociutil.NotifChan) {
 			ticker := time.NewTicker(StatsUpdateTicker)
+			defer ticker.Stop()
 			var stats ociutil.UpdateStats
 			var ok bool
 			for {

--- a/libs/zedUpload/datastore_sftp.go
+++ b/libs/zedUpload/datastore_sftp.go
@@ -128,6 +128,7 @@ func (ep *SftpTransportMethod) processSftpUpload(req *DronaRequest) (error, int)
 	if req.ackback {
 		go func(req *DronaRequest, prgNotif sftp.NotifChan) {
 			ticker := time.NewTicker(StatsUpdateTicker)
+			defer ticker.Stop()
 			var stats sftp.UpdateStats
 			var ok bool
 			for {
@@ -162,6 +163,7 @@ func (ep *SftpTransportMethod) processSftpDownload(req *DronaRequest) (error, in
 	if req.ackback {
 		go func(req *DronaRequest, prgNotif sftp.NotifChan) {
 			ticker := time.NewTicker(StatsUpdateTicker)
+			defer ticker.Stop()
 			var stats sftp.UpdateStats
 			var ok bool
 			for {
@@ -202,6 +204,7 @@ func (ep *SftpTransportMethod) processSftpList(req *DronaRequest) ([]string, err
 	if req.ackback {
 		go func(req *DronaRequest, prgNotif sftp.NotifChan) {
 			ticker := time.NewTicker(StatsUpdateTicker)
+			defer ticker.Stop()
 			var stats sftp.UpdateStats
 			var ok bool
 			for {

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/awsutil/s3api.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/awsutil/s3api.go
@@ -73,10 +73,12 @@ func NewAwsCtx(id, secret, region string, hctx *http.Client) *S3ctx {
 		u.PartSize = S3PartSize
 		u.LeavePartsOnError = S3PartLeaveError
 		u.Concurrency = S3Concurrency
+		u.BufferProvider = s3manager.NewBufferedReadSeekerWriteToPool(32 * 1024)
 	})
 	ctx.dn = s3manager.NewDownloaderWithClient(ctx.ss3, func(d *s3manager.Downloader) {
 		d.PartSize = S3PartSize
 		d.Concurrency = S3Concurrency
+		d.BufferProvider = s3manager.NewPooledBufferedWriterReadFromProvider(32 * 1024)
 	})
 
 	return &ctx

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/azureutil/azure.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/azureutil/azure.go
@@ -26,7 +26,7 @@ const (
 	SingleMB       int64 = 1024 * 1024
 	blobURLPattern       = "https://%s.blob.core.windows.net"
 	maxRetries           = 20
-	parallelism          = 128
+	parallelism          = 16
 )
 
 // UpdateStats contains the information for the progress of an update
@@ -112,7 +112,12 @@ func newPipeline(accountName, accountKey string, httpClient *http.Client) (pipel
 	if err != nil {
 		return nil, fmt.Errorf("Invalid credentials with error: " + err.Error())
 	}
-	p := azblob.NewPipeline(credential, azblob.PipelineOptions{HTTPSender: sender})
+	p := azblob.NewPipeline(credential, azblob.PipelineOptions{
+		HTTPSender: sender,
+		RequestLog: azblob.RequestLogOptions{
+			LogWarningIfTryOverThreshold: -1,
+			SyslogDisabled:               true,
+		}})
 	return p, nil
 }
 
@@ -263,6 +268,14 @@ func DownloadAzureBlob(accountURL, accountName, accountKey, containerName, remot
 	}
 	progressLock := &sync.Mutex{}
 
+	// use pool of buffers to re-use them if needed without re-allocation
+	var bufPool = sync.Pool{
+		New: func() interface{} {
+			buf := make([]byte, 32*1024)
+			return &buf
+		},
+	}
+
 	err = azblob.DoBatchTransfer(ctx, azblob.BatchTransferOptions{
 		OperationName: "DownloadAzureBlob",
 		TransferSize:  objSize,
@@ -311,9 +324,17 @@ func DownloadAzureBlob(accountURL, accountName, accountKey, containerName, remot
 					progressReceiver(progress)
 					progressLock.Unlock()
 				})
-			_, err = io.Copy(newSectionWriter(file, chunkStart+offset, count-offset, part), body)
-			body.Close()
-			return err
+			// we get buffer from the pool to not allocate
+			// new buffer per every chunk inside io.copyBuffer
+			// and to not rely on garbage collecting of them
+			bp := *bufPool.Get().(*[]byte)
+			_, err = io.CopyBuffer(newSectionWriter(file, chunkStart+offset, count-offset, part), body, bp)
+			bufPool.Put(&bp)
+			if err != nil {
+				_ = body.Close()
+				return err
+			}
+			return body.Close()
 		},
 	})
 	if err != nil {

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_aws.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_aws.go
@@ -134,6 +134,7 @@ func (ep *AwsTransportMethod) processS3Upload(req *DronaRequest) (error, int) {
 	if req.ackback {
 		go func(req *DronaRequest, prgNotif zedAWS.NotifChan) {
 			ticker := time.NewTicker(StatsUpdateTicker)
+			defer ticker.Stop()
 			var stats zedAWS.UpdateStats
 			var ok bool
 			for {
@@ -195,6 +196,7 @@ func (ep *AwsTransportMethod) processS3Download(req *DronaRequest) (error, int) 
 				select {
 				case stats, ok = <-prgNotif:
 					if !ok {
+						ticker.Stop()
 						return
 					}
 				case <-ticker.C:
@@ -281,6 +283,7 @@ func (ep *AwsTransportMethod) processS3List(req *DronaRequest) ([]string, error,
 	if req.ackback {
 		go func(req *DronaRequest, prgNotif zedAWS.NotifChan) {
 			ticker := time.NewTicker(StatsUpdateTicker)
+			defer ticker.Stop()
 			var stats zedAWS.UpdateStats
 			var ok bool
 			for {

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_azure.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_azure.go
@@ -131,6 +131,7 @@ func (ep *AzureTransportMethod) processAzureDownload(req *DronaRequest) error {
 	if req.ackback {
 		go func(req *DronaRequest, prgNotif azure.NotifChan) {
 			ticker := time.NewTicker(StatsUpdateTicker)
+			defer ticker.Stop()
 			var stats azure.UpdateStats
 			var ok bool
 			for {

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_gs.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_gs.go
@@ -128,6 +128,7 @@ func (ep *GsTransportMethod) processGSUpload(req *DronaRequest) (int, error) {
 	if req.ackback {
 		go func(req *DronaRequest, prgNotif zedGS.NotifChan) {
 			ticker := time.NewTicker(StatsUpdateTicker)
+			defer ticker.Stop()
 			var stats zedGS.UpdateStats
 			var ok bool
 			for {
@@ -175,6 +176,7 @@ func (ep *GsTransportMethod) processGSDownload(req *DronaRequest) (int, error) {
 	if req.ackback {
 		go func(req *DronaRequest, prgNotif zedGS.NotifChan) {
 			ticker := time.NewTicker(StatsUpdateTicker)
+			defer ticker.Stop()
 			var stats zedGS.UpdateStats
 			var ok bool
 			for {
@@ -229,6 +231,7 @@ func (ep *GsTransportMethod) processGSList(req *DronaRequest) ([]string, int, er
 	if req.ackback {
 		go func(req *DronaRequest, prgNotif zedGS.NotifChan) {
 			ticker := time.NewTicker(StatsUpdateTicker)
+			defer ticker.Stop()
 			var stats zedGS.UpdateStats
 			var ok bool
 			for {

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_http.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_http.go
@@ -118,6 +118,7 @@ func (ep *HttpTransportMethod) processHttpUpload(req *DronaRequest) (error, int)
 	if req.ackback {
 		go func(req *DronaRequest, prgNotif zedHttp.NotifChan) {
 			ticker := time.NewTicker(StatsUpdateTicker)
+			defer ticker.Stop()
 			var stats zedHttp.UpdateStats
 			var ok bool
 			for {
@@ -147,6 +148,7 @@ func (ep *HttpTransportMethod) processHttpDownload(req *DronaRequest) (error, in
 	if req.ackback {
 		go func(req *DronaRequest, prgNotif zedHttp.NotifChan) {
 			ticker := time.NewTicker(StatsUpdateTicker)
+			defer ticker.Stop()
 			var stats zedHttp.UpdateStats
 			var ok bool
 			for {
@@ -181,6 +183,7 @@ func (ep *HttpTransportMethod) processHttpList(req *DronaRequest) ([]string, err
 	if req.ackback {
 		go func(req *DronaRequest, prgNotif zedHttp.NotifChan) {
 			ticker := time.NewTicker(StatsUpdateTicker)
+			defer ticker.Stop()
 			var stats zedHttp.UpdateStats
 			var ok bool
 			for {
@@ -210,6 +213,7 @@ func (ep *HttpTransportMethod) processHttpObjectMetaData(req *DronaRequest) (err
 	if req.ackback {
 		go func(req *DronaRequest, prgNotif zedHttp.NotifChan) {
 			ticker := time.NewTicker(StatsUpdateTicker)
+			defer ticker.Stop()
 			var stats zedHttp.UpdateStats
 			var ok bool
 			for {

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_oci.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_oci.go
@@ -150,6 +150,7 @@ func (ep *OCITransportMethod) processDownload(req *DronaRequest) (int64, string,
 	if req.ackback {
 		go func(req *DronaRequest, prgNotif ociutil.NotifChan) {
 			ticker := time.NewTicker(StatsUpdateTicker)
+			defer ticker.Stop()
 			var stats ociutil.UpdateStats
 			var ok bool
 			for {
@@ -183,6 +184,7 @@ func (ep *OCITransportMethod) processList(req *DronaRequest) ([]string, error) {
 	if req.ackback {
 		go func(req *DronaRequest, prgNotif ociutil.NotifChan) {
 			ticker := time.NewTicker(StatsUpdateTicker)
+			defer ticker.Stop()
 			var stats ociutil.UpdateStats
 			var ok bool
 			for {
@@ -216,6 +218,7 @@ func (ep *OCITransportMethod) processObjectMetaData(req *DronaRequest) (string, 
 	if req.ackback {
 		go func(req *DronaRequest, prgNotif ociutil.NotifChan) {
 			ticker := time.NewTicker(StatsUpdateTicker)
+			defer ticker.Stop()
 			var stats ociutil.UpdateStats
 			var ok bool
 			for {

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_sftp.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore_sftp.go
@@ -128,6 +128,7 @@ func (ep *SftpTransportMethod) processSftpUpload(req *DronaRequest) (error, int)
 	if req.ackback {
 		go func(req *DronaRequest, prgNotif sftp.NotifChan) {
 			ticker := time.NewTicker(StatsUpdateTicker)
+			defer ticker.Stop()
 			var stats sftp.UpdateStats
 			var ok bool
 			for {
@@ -162,6 +163,7 @@ func (ep *SftpTransportMethod) processSftpDownload(req *DronaRequest) (error, in
 	if req.ackback {
 		go func(req *DronaRequest, prgNotif sftp.NotifChan) {
 			ticker := time.NewTicker(StatsUpdateTicker)
+			defer ticker.Stop()
 			var stats sftp.UpdateStats
 			var ok bool
 			for {
@@ -202,6 +204,7 @@ func (ep *SftpTransportMethod) processSftpList(req *DronaRequest) ([]string, err
 	if req.ackback {
 		go func(req *DronaRequest, prgNotif sftp.NotifChan) {
 			ticker := time.NewTicker(StatsUpdateTicker)
+			defer ticker.Stop()
 			var stats sftp.UpdateStats
 			var ok bool
 			for {


### PR DESCRIPTION
Changes for zedUpload to reduce memory allocations and usage:

1. Use pool of buffers to reduce memory allocations and GC work
2. Disable syslog usage for azure. We want to see only final error and do not expect any logs.
3. Stop tickers to release resources properly in zedUpload