### PR TITLE
GH Aciton - Apache Yetus, varnamelen checks is off for pillars

### DIFF
--- a/pkg/pillar/.golangci.yml
+++ b/pkg/pillar/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - stylecheck        # covered by revive
     - typecheck         # See golangci/golangci-lint#419
     - varcheck          # unreliable
+    - varnamelen        # Too opinionated about var length
     - funlen            # function length checks
     - godot             # Don't mandate periods at end of comments
     - nlreturn          # Too opioniated about whitespace


### PR DESCRIPTION
We turned off these checks because of messages:

"variable name 'i' is too short for the scope of its usage (varnamelen) " for loop indexers 

Signed-off-by: Ruslan Dautov <ruslan@zededa.com>