### PR TITLE
Ensure that volume creation operation ends

### DIFF
--- a/pkg/pillar/base/logobjecttypes.go
+++ b/pkg/pillar/base/logobjecttypes.go
@@ -92,6 +92,8 @@ const (
 	VolumeRefConfigLogType LogObjectType = "volume_ref_config"
 	// VolumeRefStatusLogType:
 	VolumeRefStatusLogType LogObjectType = "volume_ref_status"
+	// VolumeCreatePendingLogType:
+	VolumeCreatePendingLogType LogObjectType = "volume_create_pending"
 	// ServiceInitType:
 	ServiceInitLogType LogObjectType = "service_init"
 	// AppAndImageToHashLogType:

--- a/pkg/pillar/diskmetrics/diskmetrics.go
+++ b/pkg/pillar/diskmetrics/diskmetrics.go
@@ -75,7 +75,8 @@ func ConvertImg(ctx context.Context, log *base.LogObject, diskfile, outputFile, 
 	if _, err := os.Stat(diskfile); err != nil {
 		return err
 	}
-	args := []string{"convert", "-O", outputFormat, diskfile, outputFile}
+	// writeback cache instead of default unsafe, out of order enabled, skip file creation
+	args := []string{"convert", "-t", "writeback", "-W", "-n", "-O", outputFormat, diskfile, outputFile}
 	output, err := base.Exec(log, "/usr/bin/qemu-img", args...).WithContext(ctx).CombinedOutput()
 	if err != nil {
 		errStr := fmt.Sprintf("qemu-img failed: %s, %s\n",

--- a/pkg/pillar/types/zfs.go
+++ b/pkg/pillar/types/zfs.go
@@ -26,6 +26,16 @@ func (status VolumeStatus) ZVolName() string {
 		status.GenerationCounter+status.LocalGenerationCounter)
 }
 
+// ZVolName returns name of zvol for volume
+func (status VolumeCreatePending) ZVolName() string {
+	pool := VolumeClearZFSDataset
+	if status.Encrypted {
+		pool = VolumeEncryptedZFSDataset
+	}
+	return fmt.Sprintf("%s/%s.%d", pool, status.VolumeID.String(),
+		status.GenerationCounter+status.LocalGenerationCounter)
+}
+
 // ZVolNameToKey returns key for volumestatus for provided zVolName
 func ZVolNameToKey(zVolName string) string {
 	split := strings.Split(zVolName, "/")


### PR DESCRIPTION
In case of unexpected reboot or error during volume creation operation
we may have broken file with partial data. We should ensure that volume
creation operation ends. This PR introduces persistent
VolumeCreatePending type that will survive reboot and will indicate that
 volume was not created properly, hence we should re-create it.