### PR TITLE
Fix golangci-lint settings

### DIFF
--- a/pkg/pillar/.golangci.yml
+++ b/pkg/pillar/.golangci.yml
@@ -32,3 +32,9 @@ linters:
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
+
+# yetus expects stable output from linter
+# that is we should return all errors
+# not only the first hit
+output:
+  uniq-by-line: false


### PR DESCRIPTION
Yetus expects stable output from linter that is we should return all
errors not only the first hit

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>