### PR TITLE
Update to runc v1.1.0 and containerd v1.6.1

### DIFF
--- a/images/rootfs-acrn.yml.in.patch
+++ b/images/rootfs-acrn.yml.in.patch
@@ -6,7 +6,7 @@
 +  image: ACRN_KERNEL_TAG
    cmdline: "rootdelay=3"
  init:
-   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
+   - linuxkit/init:8f1e6a0747acbbb4d7e24dc98f97faa8d1c6cec7
 @@ -10,7 +10,7 @@
    - DOM0ZTOOLS_TAG
    - GRUB_TAG

--- a/images/rootfs-mini.yml.in.patch
+++ b/images/rootfs-mini.yml.in.patch
@@ -6,9 +6,9 @@
 +  image: NEW_KERNEL_TAG
    cmdline: "rootdelay=3"
  init:
--  - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
--  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
--  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
+-  - linuxkit/init:8f1e6a0747acbbb4d7e24dc98f97faa8d1c6cec7
+-  - linuxkit/runc:f01b88c7033180d50ae43562d72707c6881904e4
+-  - linuxkit/containerd:de1b18eed76a266baa3092e5c154c84f595e56da
 -  - linuxkit/getty:v0.5
 -  - linuxkit/memlogd:v0.5
    - DOM0ZTOOLS_TAG

--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -2,9 +2,9 @@ kernel:
   image: KERNEL_TAG
   cmdline: "rootdelay=3"
 init:
-  - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
-  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
-  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
+  - linuxkit/init:8f1e6a0747acbbb4d7e24dc98f97faa8d1c6cec7
+  - linuxkit/runc:f01b88c7033180d50ae43562d72707c6881904e4
+  - linuxkit/containerd:de1b18eed76a266baa3092e5c154c84f595e56da
   - linuxkit/getty:v0.5
   - linuxkit/memlogd:v0.5
   - DOM0ZTOOLS_TAG

--- a/pkg/debug/build.yml
+++ b/pkg/debug/build.yml
@@ -27,3 +27,6 @@ config:
     - /var/log:/var/log
   capabilities:
     - all
+  devices:
+    - path: all
+      type: a

--- a/pkg/dom0-ztools/rootfs/etc/containerd/config.toml
+++ b/pkg/dom0-ztools/rootfs/etc/containerd/config.toml
@@ -5,7 +5,9 @@ disabled_plugins = [
     "io.containerd.grpc.v1.cri",
     "io.containerd.snapshotter.v1.btrfs",
     "io.containerd.snapshotter.v1.aufs",
-    "io.containerd.internal.v1.opt"
+    "io.containerd.internal.v1.opt",
+    "io.containerd.internal.v1.tracing",
+    "io.containerd.tracing.processor.v1.otlp"
 ]
 
 [grpc]

--- a/pkg/edgeview/build.yml
+++ b/pkg/edgeview/build.yml
@@ -15,3 +15,6 @@ config:
     - all
   net: host
   pid: host
+  devices:
+    - path: all
+      type: a

--- a/pkg/guacd/build.yml
+++ b/pkg/guacd/build.yml
@@ -10,3 +10,6 @@ config:
   net: host
   capabilities:
     - all
+  devices:
+    - path: all
+      type: a

--- a/pkg/kvm-tools/build.yml
+++ b/pkg/kvm-tools/build.yml
@@ -15,3 +15,6 @@ config:
     - all
   pid: host
   userns: host
+  devices:
+    - path: all
+      type: a

--- a/pkg/mkimage-raw-efi/config.json
+++ b/pkg/mkimage-raw-efi/config.json
@@ -316,7 +316,15 @@
         }
     ],
     "linux": {
-        "resources": {},
+        "resources": {
+            "devices": [
+                {
+                    "allow": true,
+                    "type": "a",
+                    "access": "rwm"
+                }
+            ]
+        },
         "namespaces": [
             {
                 "type": "mount"

--- a/pkg/newlog/build.yml
+++ b/pkg/newlog/build.yml
@@ -11,3 +11,6 @@ config:
     - all
   net: host
   pid: host
+  devices:
+    - path: all
+      type: a

--- a/pkg/pillar/build-dev.yml
+++ b/pkg/pillar/build-dev.yml
@@ -20,6 +20,9 @@ config:
     - all
   pid: host
   rootfsPropagation: shared
+  devices:
+    - path: all
+      type: a
   security_opt:
     - seccomp:unconfined
   ports:

--- a/pkg/pillar/build.yml
+++ b/pkg/pillar/build.yml
@@ -20,3 +20,6 @@ config:
     - all
   pid: host
   rootfsPropagation: shared
+  devices:
+    - path: all
+      type: a

--- a/pkg/pillar/containerd/oci.go
+++ b/pkg/pillar/containerd/oci.go
@@ -83,9 +83,13 @@ func (client *Client) NewOciSpec(name string) (OCISpec, error) {
 	// default OCI specs have all devices being denied by default,
 	// we flip it back to all allow for now, but later on we may
 	// need to get more fine-grained
-	if s.Linux != nil && s.Linux.Resources != nil && s.Linux.Resources.Devices != nil {
-		s.Linux.Resources.Devices = nil
+	if s.Linux == nil {
+		s.Linux = &specs.Linux{}
 	}
+	if s.Linux.Resources == nil {
+		s.Linux.Resources = &specs.LinuxResources{}
+	}
+	s.Linux.Resources.Devices = []specs.LinuxDeviceCgroup{{Type: "a", Allow: true, Access: "rwm"}}
 	s.Root.Path = "/"
 	return s, nil
 }

--- a/pkg/pillar/rootfs/etc/containerd/user.toml
+++ b/pkg/pillar/rootfs/etc/containerd/user.toml
@@ -13,7 +13,9 @@ disabled_plugins = [
     "io.containerd.service.v1.containers-service",
     "io.containerd.grpc.v1.containers",
     "io.containerd.monitor.v1.cgroups",
-    "io.containerd.snapshotter.v1.native"
+    "io.containerd.snapshotter.v1.native",
+    "io.containerd.internal.v1.tracing",
+    "io.containerd.tracing.processor.v1.otlp"
 ]
 
 [grpc]

--- a/pkg/storage-init/build.yml
+++ b/pkg/storage-init/build.yml
@@ -18,3 +18,6 @@ config:
   rootfsPropagation: shared
   capabilities:
     - all
+  devices:
+    - path: all
+      type: a

--- a/pkg/vtpm/build.yml
+++ b/pkg/vtpm/build.yml
@@ -9,3 +9,6 @@ config:
   net: host
   capabilities:
     - all
+  devices:
+    - path: all
+      type: a

--- a/pkg/watchdog/build.yml
+++ b/pkg/watchdog/build.yml
@@ -9,3 +9,6 @@ config:
   pid: host
   capabilities:
     - all
+  devices:
+    - path: all
+      type: a

--- a/pkg/wlan/build.yml
+++ b/pkg/wlan/build.yml
@@ -11,3 +11,6 @@ config:
   net: host
   capabilities:
     - all
+  devices:
+    - path: all
+      type: a

--- a/pkg/wwan/build.yml
+++ b/pkg/wwan/build.yml
@@ -9,3 +9,6 @@ config:
   net: host
   capabilities:
     - all
+  devices:
+    - path: all
+      type: a

--- a/pkg/xen-tools/build.yml
+++ b/pkg/xen-tools/build.yml
@@ -14,3 +14,6 @@ config:
     - all
   pid: host
   userns: host
+  devices:
+    - path: all
+      type: a


### PR DESCRIPTION
In order to support new versions of containerd and runc we should to define
devices options to allow access explicitly in build.yml files.

As described inside https://github.com/lf-edge/eve/pull/2565#issuecomment-1085696587