### PR TITLE
Prefer MBIM protocol for SierraWireless EM7565

### DIFF
--- a/pkg/wwan/Dockerfile
+++ b/pkg/wwan/Dockerfile
@@ -11,6 +11,7 @@ RUN git clone https://github.com/json-c/json-c.git
 RUN git clone https://gitlab.freedesktop.org/mobile-broadband/libqmi
 RUN git clone https://gitlab.freedesktop.org/mobile-broadband/libmbim
 RUN git clone https://github.com/inotify-tools/inotify-tools
+RUN git clone https://github.com/npat-efault/picocom.git
 
 WORKDIR /json-c
 RUN git checkout ed54353d && ./autogen.sh && ./configure && make install
@@ -30,6 +31,10 @@ RUN git checkout 1.26.2 && ./autogen.sh --without-udev && ./configure --prefix=/
 WORKDIR /inotify-tools
 RUN git checkout 3.20.11.0 && ./autogen.sh && ./configure --prefix=/usr && make && make install
 
+WORKDIR /picocom
+# Need this patch to build with musl: https://github.com/npat-efault/picocom/commit/1acf1ddabaf3576b4023c4f6f09c5a3e4b086fb8
+RUN git checkout 1acf1ddabaf3576b && make && strip picocom && cp picocom /usr/bin/
+
 RUN strip /usr/bin/*cli /usr/libexec/*proxy /usr/lib/libmbim*.so.* /usr/lib/libqmi*.so.* /usr/lib/libinotifytools*.so.*
 
 # second stage (new-ish Docker feature) for smaller image
@@ -38,7 +43,7 @@ FROM scratch
 ENTRYPOINT []
 WORKDIR /
 COPY --from=build /out/ /
-COPY --from=build /usr/bin/qmicli /usr/bin/mbimcli /usr/bin/inotify* /bin/
+COPY --from=build /usr/bin/qmicli /usr/bin/mbimcli /usr/bin/inotify* /usr/bin/picocom /bin/
 COPY --from=build /usr/lib/libmbim*.so.[0-9] /usr/lib/libqmi*.so.[0-9] /usr/lib/
 COPY --from=build /usr/lib/libinotifytools*.so.[0-9] /usr/lib/
 COPY --from=build /usr/libexec/*proxy /usr/libexec/


### PR DESCRIPTION
With cellular modem SierraWireless EM7565 we are experiencing quite
often a firmware bug causing the transmit queue to get stuck. In dmesg
we see:
```
  NETDEV WATCHDOG: wwan0 (qmi_wwan): transmit queue 0 timed out
```
Followed by a stacktrace which shows that `netif_tx_lock` hangs.
This can be only fixed by restarting the modem (not just the connection),
but it does not guarantee that it will not happen again and so we may end
up restarting the modem quite frequently, disrupting the ongoing traffic.
This bug is easily reproducible with the QMI control protocol.
With MBIM, we have not been able to reproduce this issue even after many
attempts. Therefore we prefer to use MBIM with this modem until we find
a better solution (that would not require running modem-specific AT
commands).
However, unless we switch from the opensource `qmi_wwan`+`libqmi` to
SierraWireless' own SDK, they will not provide us any support. :(

Signed-off-by: Milan Lenco <milan@zededa.com>