### PR TITLE
Disable atime for zfs

### DIFF
--- a/pkg/mkimage-raw-efi/install
+++ b/pkg/mkimage-raw-efi/install
@@ -182,7 +182,7 @@ prepare_mounts_and_zfs_pool() {
   [ -e /root/proc ] || mkdir /root/proc && mount -t proc proc /root/proc
   [ -e /root/dev ] || mkdir /root/dev && mount -t devtmpfs -o size=10m,nr_inodes=248418,mode=755,nosuid,noexec,relatime devtmpfs /root/dev
   [ -e /root/run ] || mkdir /root/run && mount --rbind /run /root/run
-  POOL_CREATION_COMMAND="chroot /root zpool create -f -m none -o feature@encryption=enabled -O overlay=on persist $1"
+  POOL_CREATION_COMMAND="chroot /root zpool create -f -m none -o feature@encryption=enabled -O atime=off -O overlay=on persist $1"
   eval "$POOL_CREATION_COMMAND"
   chroot /root zfs create -o refreservation="$(chroot /root zfs get -o value -Hp available persist | awk '{ print ($1/1024/1024)/5 }')"m persist/reserved
   chroot /root zfs set mountpoint="/run/P3" persist

--- a/pkg/storage-init/storage-init.sh
+++ b/pkg/storage-init/storage-init.sh
@@ -253,7 +253,7 @@ if P3=$(findfs PARTLABEL=P3) && [ -n "$P3" ]; then
              zfs) if [ "$INIT_FS" = 1 ]; then
                       # note that we immediately create a zfs dataset for containerd, since otherwise the init sequence will fail
                       #   https://bugs.launchpad.net/ubuntu/+source/zfs-linux/+bug/1718761
-                      chroot /hostfs zpool create -f -m none -o feature@encryption=enabled -O overlay=on persist "$P3" && \
+                      chroot /hostfs zpool create -f -m none -o feature@encryption=enabled -O atime=off -O overlay=on persist "$P3" && \
                       chroot /hostfs zfs create -o refreservation="$(chroot /hostfs zfs get -o value -Hp available persist | awk '{ print ($1/1024/1024)/5 }')"m persist/reserved && \
                       chroot /hostfs zfs set mountpoint="$PERSISTDIR" persist                                          && \
                       chroot /hostfs zfs set primarycache=metadata persist                                             && \


### PR DESCRIPTION
We do not want to use atime, so we should disable it for zfs to reduce
writes the same way we do it for ext4

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>