### PR TITLE
refactor common code out of zedUpload, add explanational comment

### DIFF
--- a/libs/zedUpload/types/stats.go
+++ b/libs/zedUpload/types/stats.go
@@ -1,0 +1,23 @@
+package types
+
+// UpdateStats standard structure for statistics that get sent on a notification channel
+// during a data transfer operation
+type UpdateStats struct {
+	Size      int64
+	Asize     int64
+	DoneParts DownloadedParts
+	Error     error
+}
+
+// StatsNotifChan channel to send UpdateStats
+type StatsNotifChan chan UpdateStats
+
+// SendStats send stats of type UpdateStats on prgChan, but after first checking that the prgChan is not nil
+func SendStats(prgChan StatsNotifChan, stats UpdateStats) {
+	if prgChan != nil {
+		select {
+		case prgChan <- stats:
+		default: //ignore we cannot write
+		}
+	}
+}

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/types/stats.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/types/stats.go
@@ -1,0 +1,23 @@
+package types
+
+// UpdateStats standard structure for statistics that get sent on a notification channel
+// during a data transfer operation
+type UpdateStats struct {
+	Size      int64
+	Asize     int64
+	DoneParts DownloadedParts
+	Error     error
+}
+
+// StatsNotifChan channel to send UpdateStats
+type StatsNotifChan chan UpdateStats
+
+// SendStats send stats of type UpdateStats on prgChan, but after first checking that the prgChan is not nil
+func SendStats(prgChan StatsNotifChan, stats UpdateStats) {
+	if prgChan != nil {
+		select {
+		case prgChan <- stats:
+		default: //ignore we cannot write
+		}
+	}
+}


### PR DESCRIPTION
This is something I wanted to do after #2643 

1. It adds a lot more detail to the explanation as to why we use `sync.Pool`
2. It refactors out a lot of repetitive code into a few utility types and functions
3. It separates between actual update stats - sizes, errors, parts that are done - and responses, which are implementation-specific.

I assume yetus will fail, let's let it and then fix.