### PR TITLE
Mount persist in installer, store and send logs

### DIFF
--- a/pkg/mkimage-raw-efi/config.json
+++ b/pkg/mkimage-raw-efi/config.json
@@ -272,14 +272,6 @@
             ]
         },
         {
-            "destination": "/persist",
-            "type": "tmpfs",
-            "source": "tmpfs",
-            "options": [
-                "rw"
-            ]
-        },
-        {
             "destination": "/dev",
             "type": "bind",
             "source": "/dev",

--- a/pkg/mkimage-raw-efi/install
+++ b/pkg/mkimage-raw-efi/install
@@ -170,7 +170,7 @@ collect_black_box() {
    tar -C /proc -cjf "$1/procfs.tar.bz2" cpuinfo meminfo
    tar -C /sys -cjf "$1/sysfs.tar.bz2" .
    tar -C /config -cjf "$1/config.tar.bz2" .
-   tar -C /run/P3 -cjf "$1/persist.tar.bz2" status newlog log config checkpoint certs agentdebug
+   tar -C /persist -cjf "$1/persist.tar.bz2" status newlog log config checkpoint certs agentdebug
    pillar_run tpmmgr saveTpmInfo "$1"/tpminfo.txt
 }
 
@@ -181,22 +181,22 @@ prepare_mounts_and_zfs_pool() {
   [ -e /root/sys ] || mkdir /root/sys && mount -t sysfs sysfs /root/sys
   [ -e /root/proc ] || mkdir /root/proc && mount -t proc proc /root/proc
   [ -e /root/dev ] || mkdir /root/dev && mount -t devtmpfs -o size=10m,nr_inodes=248418,mode=755,nosuid,noexec,relatime devtmpfs /root/dev
-  [ -e /root/run ] || mkdir /root/run && mount --rbind /run /root/run
   POOL_CREATION_COMMAND="chroot /root zpool create -f -m none -o feature@encryption=enabled -O atime=off -O overlay=on persist $1"
   eval "$POOL_CREATION_COMMAND"
   chroot /root zfs create -o refreservation="$(chroot /root zfs get -o value -Hp available persist | awk '{ print ($1/1024/1024)/5 }')"m persist/reserved
-  chroot /root zfs set mountpoint="/run/P3" persist
+  chroot /root zfs set mountpoint="/persist" persist
   chroot /root zfs set primarycache=metadata persist
+  chroot /root zfs create -o mountpoint="/persist/containerd/io.containerd.snapshotter.v1.zfs" persist/snapshots
+  # we need this mount to propagate persist from /root/persist after call to zfs command in changed root
+  [ -e /persist ] || mkdir /persist && mount --rbind --make-rslave /root/persist /persist
 }
 
-adjust_zfs_mounts_and_umount() {
-  logmsg "Setting ZFS mountpoint to /persist"
-  chroot /root zfs set mountpoint="/persist" persist
-  chroot /root zfs create -p -o mountpoint="/persist/containerd/io.containerd.snapshotter.v1.zfs" persist/snapshots
+zfs_umount() {
+  umount -R /persist ||:
+  chroot /root zfs unmount persist ||:
   umount /root/sys ||:
   umount /root/proc ||:
   umount /root/dev ||:
-  umount /root/run ||:
 }
 
 logmsg "EVE-OS installation started"
@@ -440,8 +440,15 @@ if [ "$INSTALL_ZFS" = true ]; then
       done
   fi
 else
+  P3="$(find_part P3 "$INSTALL_DEV")"
+  [ -z "$P3" ] && bail "Installation failed. Cannot found P3. Entering shell..."
+  # attempt to zero the first 5Mb of the P3 (to get rid of any residual prior data)
+  dd if=/dev/zero of="/dev/$P3" bs=512 count=10240 2>/dev/null
+  # Use -F option twice, to avoid any user confirmation in mkfs
+  mkfs -t ext4 -v -F -F -O encrypt "/dev/$P3"
+  mkdir -p /persist
   # now the disk is ready - mount partitions
-  mount_part P3 "$INSTALL_DEV" /run/P3 2>/dev/null
+  mount_part P3 "$INSTALL_DEV" /persist 2>/dev/null
 fi
 
 
@@ -457,18 +464,23 @@ REPORT=
 # collect information about the node
 if mount_part INVENTORY "$(root_dev)" /run/INVENTORY -t vfat -o iocharset=iso8859-1; then
    REPORT="/run/INVENTORY/$(cat /config/soft_serial 2>/dev/null)"
-   mkdir -p "$REPORT"
-
-   # first lets look at hardware model
-   dmidecode > "$REPORT/hardwaremodel.txt"
-
-   # try to generate model json file
-   ctr_run /opt/debug spec.sh > "$REPORT/controller-model.json"
-   ctr_run /opt/debug spec.sh -v > "$REPORT/controller-model-verbose.json"
-
-   # Save to help figure out if RTC is not in UTC
-   (hwclock -v -u; date -Is -u ) > "$REPORT/clock"
+   logmsg "EVE-OS installation will store report to USB inside /INVENTORY/$(cat /config/soft_serial 2>/dev/null)"
+else
+   REPORT="/persist/installer"
+   logmsg "EVE-OS installation will store report to $REPORT"
 fi
+
+mkdir -p "$REPORT"
+
+# first lets look at hardware model
+dmidecode > "$REPORT/hardwaremodel.txt"
+
+# try to generate model json file
+ctr_run /opt/debug spec.sh > "$REPORT/controller-model.json"
+ctr_run /opt/debug spec.sh -v > "$REPORT/controller-model-verbose.json"
+
+# Save to help figure out if RTC is not in UTC
+(hwclock -v -u; date -Is -u ) > "$REPORT/clock"
 
 # The creation of the 4 key pairs on the TPM below can take significant
 # time. Make sure a hardware watchdog will not fire.
@@ -522,22 +534,34 @@ fi
 # we also maybe asked to pause after
 grep -q eve_pause_after_install /proc/cmdline && pause "shutting the node down"
 
-if [ "$INSTALL_ZFS" = true ]; then
-   adjust_zfs_mounts_and_umount
-fi
-
 if [ -n "$REPORT" ]; then
    # Copy the LOGFILE under REPORT"
    logmsg "EVE-OS installation completed, device will now reboot/poweroff"
    cat $LOGFILE > "$REPORT/installer.log"
 fi
 
+# if we store report to USB copy installer.log to persist explicitly
+if [ ! -d "/persist/installer" ]; then
+  mkdir "/persist/installer"
+  cat $LOGFILE > "/persist/installer/installer.log"
+fi
+
+#store file to indicate first boot after installer
+touch /persist/installer/first-boot
+
+# lets hope this is enough to flush the caches
+sync; sleep 5; sync
+
+if [ "$INSTALL_ZFS" = true ]; then
+   zfs_umount
+else
+   umount /persist 2>/dev/null
+fi
+
 # lets hope this is enough to flush the caches
 sync; sleep 5; sync
 umount /config 2>/dev/null
-for p in INVENTORY P3; do
-   umount "/run/$p" 2>/dev/null
-done
+umount /run/INVENTORY 2>/dev/null
 
 # we need a copy of these in tmpfs so that a block device with rootfs can be yanked
 cp /sbin/poweroff /sbin/reboot /bin/sleep /run

--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -16,6 +16,7 @@
 package nodeagent
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"fmt"
@@ -47,6 +48,8 @@ const (
 	configDir                   = "/config"
 	tmpDirname                  = "/run/global"
 	firstbootFile               = tmpDirname + "/first-boot"
+	installLog                  = types.PersistInstallerDir + "/installer.log"
+	installLogSendReq           = types.PersistInstallerDir + "/send-require" //indicates that we should send logs
 	restartCounterFile          = types.PersistStatusDir + "/restartcounter"
 	// Time limits for event loop handlers
 	errorTime   = 3 * time.Minute
@@ -216,6 +219,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	parseSMARTData()
 	// get the last reboot reason
 	handleLastRebootReason(ctxPtr)
+	// send Installation log and remove first-boot from installation
+	handleInstallationLog(ctxPtr)
 
 	// Fault injection; if /persist/fault-injection/readfile exists we read it
 	// which will use memory
@@ -611,6 +616,39 @@ func handleLastRebootReason(ctx *nodeagentContext) {
 	// Read and increment restartCounter
 	ctx.restartCounter = incrementRestartCounter()
 	ctx.lastLock.Unlock()
+}
+
+// handleInstallationLog checks if we should send installer logs
+// send log from installation to the controller
+// and remove file after small timeout to not send them after reboot
+func handleInstallationLog(ctx *nodeagentContext) {
+	if fileExists(installLogSendReq) {
+		f, err := os.Open(installLog)
+		if err != nil {
+			log.Errorf("cannot open installation log: %s", err)
+			return
+		}
+		scanner := bufio.NewScanner(f)
+		buf := make([]byte, 0, maxReadSize)
+		scanner.Buffer(buf, maxReadSize)
+		// installerLog is logger with modified source and zeroed pid
+		installerLog := base.NewSourceLogObject(ctx.agentBaseContext.Logger, "installer", 0)
+		for scanner.Scan() {
+			installerLog.Noticeln(scanner.Text())
+		}
+		if scanner.Err() != nil {
+			log.Errorf("cannot read installation log: %s", scanner.Err())
+		}
+		_ = f.Close()
+		// schedule remove of installLogSendReq file after small timeout
+		// to not re-send log after reboot
+		time.AfterFunc(warningTime, func() {
+			err := os.Remove(installLogSendReq)
+			if err != nil {
+				log.Errorf("cannot remove installation log sending request file: %s", err)
+			}
+		})
+	}
 }
 
 // If the file doesn't exist we pick zero.

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -121,6 +121,14 @@ fi
 
 DIRS="$CONFIGDIR $CONFIGDIR/DevicePortConfig $PERSIST_CERTS $PERSIST_AGENT_DEBUG /persist/status/zedclient/OnboardingStatus"
 
+# If /persist/installer/first-boot exists treat this as a first boot
+# we rename file to not assume that it is the first boot if we reboot occasionally
+if [ -f "$PERSISTDIR/installer/first-boot" ]; then
+    mv "$PERSISTDIR/installer/first-boot" "$PERSISTDIR/installer/send-require"
+    touch $FIRSTBOOTFILE # For nodeagent
+    FIRSTBOOT=1
+fi
+
 # If /persist didn't exist or was removed treat this as a first boot
 if [ ! -d $PERSIST_CERTS ]; then
     touch $FIRSTBOOTFILE # For nodeagent

--- a/pkg/pillar/types/locationconsts.go
+++ b/pkg/pillar/types/locationconsts.go
@@ -27,6 +27,8 @@ const (
 	VolumeClearDirName = ClearDirName + "/volumes"
 	// PersistDebugDir - Location for service specific debug/traces
 	PersistDebugDir = PersistDir + "/agentdebug"
+	// PersistInstallerDir - location for installer output
+	PersistInstallerDir = PersistDir + "/installer"
 
 	// IdentityDirname - Config dir
 	IdentityDirname = "/config"


### PR DESCRIPTION
Add support to store data in persist during installation. THis PR adds
logs to /persist/installer/installer.log and send them during first boot
 as logs to the controller.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>