### PR TITLE
Introduce developmen build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,6 +237,7 @@ LINUXKIT_VERSION=80c4edd5c54dc05fbeae932440372990fce39bd6
 LINUXKIT_SOURCE=https://github.com/linuxkit/linuxkit.git
 LINUXKIT_OPTS=--disable-content-trust $(if $(strip $(EVE_HASH)),--hash) $(EVE_HASH) $(if $(strip $(EVE_REL)),--release) $(EVE_REL) $(FORCE_BUILD)
 LINUXKIT_PKG_TARGET=build
+LINUXKIT_PATCHES_DIR=tools/linuxkit/patches
 RESCAN_DEPS=FORCE
 FORCE_BUILD=--force
 
@@ -609,6 +610,9 @@ $(LINUXKIT): | $(GOBUILDER)
 	git clone $(LINUXKIT_SOURCE) /tmp/linuxkit && \
 	cd /tmp/linuxkit && \
 	git checkout $(LINUXKIT_VERSION) && \
+	if [ -e /eve/$(LINUXKIT_PATCHES_DIR) ]; then \
+	    patch -p1 < /eve/$(LINUXKIT_PATCHES_DIR)/*.patch; \
+	fi && \
 	cd /tmp/linuxkit/src/cmd/linuxkit && \
 	GO111MODULE=on CGO_ENABLED=0 go build -o /go/bin/linuxkit -mod=vendor . && \
 	cd && \

--- a/Makefile
+++ b/Makefile
@@ -657,10 +657,7 @@ eve-%: pkg/%/Dockerfile build-tools $(RESCAN_DEPS)
 	$(QUIET): "$@: Succeeded (intermediate for pkg/%)"
 
 images/rootfs-%.yml.in: images/rootfs.yml.in FORCE
-	@if [ -e $@.patch ]; then patch -p0 -o $@.sed < $@.patch ;else cp $< $@.sed ;fi
-	$(QUIET)sed -e 's#EVE_VERSION#$(ROOTFS_VERSION)-$*-$(ZARCH)#' < $@.sed > $@ || rm $@ $@.sed
-	@rm $@.sed
-	$(QUIET): $@: Succeeded
+	$(QUITE)tools/compose-image-yml.sh $< $@ "$(ROOTFS_VERSION)-$*-$(ZARCH)"
 
 $(ROOTFS_FULL_NAME)-adam-kvm-$(ZARCH).$(ROOTFS_FORMAT): $(ROOTFS_FULL_NAME)-kvm-adam-$(ZARCH).$(ROOTFS_FORMAT)
 $(ROOTFS_FULL_NAME)-kvm-adam-$(ZARCH).$(ROOTFS_FORMAT): fullname-rootfs $(SSH_KEY)

--- a/build-tools/src/scripts/Dockerfile
+++ b/build-tools/src/scripts/Dockerfile
@@ -9,7 +9,7 @@ ARG GID
 # this must be an ARG so it doesn't carry through post-build phase
 ARG all_proxy
 # hadolint ignore=DL3018
-RUN apk add --no-cache openssh-client git gcc linux-headers libc-dev util-linux libpcap-dev bash vim make protobuf protobuf-dev sudo tar curl graphviz ttf-freefont
+RUN apk add --no-cache openssh-client git gcc linux-headers libc-dev util-linux libpcap-dev bash vim make protobuf protobuf-dev sudo tar curl graphviz ttf-freefont patch
 # we need updated libraries, here we use the same version as for eve/alpine
 # hadolint ignore=DL3018
 RUN apk --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/v3.13/main add -U --upgrade zfs-dev zfs-libs

--- a/pkg/pillar/Dockerfile
+++ b/pkg/pillar/Dockerfile
@@ -1,6 +1,9 @@
 # Copyright (c) 2018 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 FROM lfedge/eve-alpine:3a7658b4168bcf40dfbcb15fbae8979d81efb6f1 as build
+
+ARG DEV=n
+
 ENV BUILD_PKGS git gcc linux-headers libc-dev make linux-pam-dev m4 findutils go util-linux make patch wget zfs-dev
 ENV PKGS alpine-baselayout musl-utils libtasn1-progs pciutils yajl xz bash iptables ip6tables iproute2 dhcpcd coreutils dmidecode libbz2 libuuid ipset curl radvd ethtool util-linux e2fsprogs libcrypto1.1 xorriso qemu-img jq e2fsprogs-extra keyutils ca-certificates ip6tables-openrc iptables-openrc ipset-openrc hdparm zfs
 RUN eve-alpine-deploy.sh
@@ -45,9 +48,15 @@ RUN [ -z "$GOARCH" ] || export CC=$(echo /*-cross/bin/*-gcc) ;\
     echo "Running go vet" && go vet ./... && \
     echo "Running go fmt" && ERR=$(gofmt -e -l -s $(find . -name \*.go | grep -v /vendor/)) && \
        if [ -n "$ERR" ] ; then echo "go fmt Failed - ERR: "$ERR ; exit 1 ; fi && \
-    make DISTDIR=/out/opt/zededa/bin build
+    make DEV=$DEV DISTDIR=/out/opt/zededa/bin build
 
 WORKDIR /
+
+RUN if [ ${DEV} = "y" ]; then \
+    CGO_ENABLED=0 go get -ldflags "-s -w -extldflags '-static'" github.com/go-delve/delve/cmd/dlv@v1.8.3 && \
+    cp /root/go/bin/dlv /out/opt; \
+fi
+
 COPY patches/* /sys-patches/
 # hadolint ignore=SC1097
 RUN set -e && for patch in /sys-patches/*.patch; do \

--- a/pkg/pillar/Makefile
+++ b/pkg/pillar/Makefile
@@ -32,10 +32,14 @@ $(DISTDIR):
 
 build: $(APPS) $(APPS1)
 
+
+LDFLAGS=-s -w -X=main.Version=$(BUILD_VERSION)
+LDFLAGS:=-ldflags "$(LDFLAGS)"
+
 $(APPS): $(DISTDIR)/$(APPS)
 $(DISTDIR)/$(APPS): $(DISTDIR)
 	@echo "Building $@"
-	GO111MODULE=on GOOS=linux go build -mod=vendor -ldflags "-s -w -X=main.Version=$(BUILD_VERSION)" -o $@ ./$(@F)
+	GO111MODULE=on GOOS=linux go build -mod=vendor $(LDFLAGS) -o $@ ./$(@F)
 
 $(APPS1): $(DISTDIR)
 	@echo $@

--- a/pkg/pillar/Makefile
+++ b/pkg/pillar/Makefile
@@ -33,13 +33,21 @@ $(DISTDIR):
 build: $(APPS) $(APPS1)
 
 
-LDFLAGS=-s -w -X=main.Version=$(BUILD_VERSION)
+LDFLAGS=-X=main.Version=$(BUILD_VERSION)
+ifneq ($(DEV),y)
+	LDFLAGS+=-s -w
+endif
 LDFLAGS:=-ldflags "$(LDFLAGS)"
+
+GCFLAGS=
+ifeq ($(DEV),y)
+	GCFLAGS:=-gcflags=all="-N -l"
+endif
 
 $(APPS): $(DISTDIR)/$(APPS)
 $(DISTDIR)/$(APPS): $(DISTDIR)
 	@echo "Building $@"
-	GO111MODULE=on GOOS=linux go build -mod=vendor $(LDFLAGS) -o $@ ./$(@F)
+	GO111MODULE=on GOOS=linux go build -mod=vendor $(GCFLAGS) $(LDFLAGS) -o $@ ./$(@F)
 
 $(APPS1): $(DISTDIR)
 	@echo $@

--- a/pkg/pillar/build-dev.yml
+++ b/pkg/pillar/build-dev.yml
@@ -1,0 +1,30 @@
+# linuxkit build template
+#
+# Copyright (c) 2018-2022 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+org: lfedge
+image: eve-pillar-dev
+network: yes
+config:
+  binds:
+    - /lib/modules:/lib/modules
+    - /dev:/dev
+    - /etc/resolv.conf:/etc/resolv.conf
+    - /run:/run
+    - /config:/config
+    - /:/hostfs
+    - /persist:/persist:rshared,rbind
+    - /usr/bin/containerd:/usr/bin/containerd
+    - /usr/bin/containerd-shim:/usr/bin/containerd-shim
+    - /usr/bin/containerd-shim-runc-v2:/usr/bin/containerd-shim-runc-v2
+  net: host
+  capabilities:
+    - all
+  pid: host
+  rootfsPropagation: shared
+  security_opt:
+    - seccomp:unconfined
+  ports:
+    - 2345:2345
+buildArgs:
+  - DEV=y

--- a/tools/compose-image-yml.sh
+++ b/tools/compose-image-yml.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+yq() {
+  docker run --rm -i -v "${PWD}":/workdir mikefarah/yq "$@"
+}
+
 process-image-template() {
     local out_templ_path="$1"
     local eve_version="$2"
@@ -16,7 +20,7 @@ process-image-template() {
     for bit in "${bits[@]}"; do
         case "${bit}" in
             dev)
-                # TODO: process DEV flag
+                yq eval -i '(.services[] | select(.name == "pillar").image) |= "PILLAR_DEV_TAG"' "${out_templ_path}"
                 ;;
         esac
     done

--- a/tools/compose-image-yml.sh
+++ b/tools/compose-image-yml.sh
@@ -1,5 +1,27 @@
 #!/bin/bash
 
+process-image-template() {
+    local out_templ_path="$1"
+    local eve_version="$2"
+
+    local flags
+    local -a bits
+
+    # Drop everything before the git hashcode (including the hash)
+    flags="$(sed -r 's/.*[0-9a-fA-F]{8}(.*)/\1/p' <<< "${eve_version}")"
+    # Drop dirty flag
+    flags="$(sed -r 's/-dirty[0-9.\-]{18}//g' <<< "${flags}")"
+    IFS='-' read -r -a bits <<< "${flags}"
+
+    for bit in "${bits[@]}"; do
+        case "${bit}" in
+            dev)
+                # TODO: process DEV flag
+                ;;
+        esac
+    done
+}
+
 main() {
     local base_templ_path="$1"
     local out_templ_path="$2"
@@ -12,6 +34,8 @@ main() {
     fi
 
     sed "s/EVE_VERSION/${eve_version}/g" < "${out_templ_path}".sed > "${out_templ_path}"
+
+    process-image-template "${out_templ_path}" "${eve_version}"
 }
 
 main "$@"

--- a/tools/compose-image-yml.sh
+++ b/tools/compose-image-yml.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+main() {
+    local base_templ_path="$1"
+    local out_templ_path="$2"
+    local eve_version="$3"
+
+    if [ -e "${out_templ_path}".patch ]; then
+        patch -p0 -o "${out_templ_path}".sed < "${out_templ_path}".patch
+    else
+        cp "${base_templ_path}" "${out_templ_path}".sed
+    fi
+
+    sed "s/EVE_VERSION/${eve_version}/g" < "${out_templ_path}".sed > "${out_templ_path}"
+}
+
+main "$@"

--- a/tools/linuxkit/patches/0001-Declare-build-args-in-build.yml.patch
+++ b/tools/linuxkit/patches/0001-Declare-build-args-in-build.yml.patch
@@ -1,0 +1,132 @@
+From fed2c444497a9eb8dddee02f180a67a95b912280 Mon Sep 17 00:00:00 2001
+From: Yuri Volchkov <yuri@zededa.com>
+Date: Thu, 9 Jun 2022 15:09:04 +0000
+Subject: [PATCH] Declare build-args in build.yml
+
+This allows multiple build flavors for a single codebase, without
+sacrificing reproducible builds. The build-args are set in build.yml,
+which is typically under the source control (if it is not, then no
+reproducible builds are possible anyways). Meaning that mutating
+build-args would result in setting "dirty" flag.
+
+Intended use of this commit is to switch between build flavors by
+specifying a different yaml file (presumably also under the version
+control)  by  `-build-yml` option.
+
+Because it is impossible to build a final image from packages in
+cache, the test for this feature relies on the `RUN echo $build-arg`
+output during the `pkg build` process.
+
+Cherry-picked from
+1a013f442446eb48062550ba7c0b3f8707e85aaa
+
+Signed-off-by: Yuri Volchkov <yuri@zededa.com>
+---
+ src/cmd/linuxkit/pkglib/build.go               |  6 ++++++
+ src/cmd/linuxkit/pkglib/pkglib.go              |  3 +++
+ test/cases/000_build/030_build_args/Dockerfile |  7 +++++++
+ test/cases/000_build/030_build_args/build.yml  |  7 +++++++
+ test/cases/000_build/030_build_args/test.sh    | 18 ++++++++++++++++++
+ 5 files changed, 41 insertions(+)
+ create mode 100644 test/cases/000_build/030_build_args/Dockerfile
+ create mode 100644 test/cases/000_build/030_build_args/build.yml
+ create mode 100755 test/cases/000_build/030_build_args/test.sh
+
+diff --git a/src/cmd/linuxkit/pkglib/build.go b/src/cmd/linuxkit/pkglib/build.go
+index 0d822aa5f..6b9fcfb9d 100644
+--- a/src/cmd/linuxkit/pkglib/build.go
++++ b/src/cmd/linuxkit/pkglib/build.go
+@@ -169,6 +169,12 @@ func (p Pkg) Build(bos ...BuildOpt) error {
+ 			args = append(args, "--label=org.mobyproject.config="+string(b))
+ 		}
+ 
++		if p.buildArgs != nil {
++			for _, buildArg := range *p.buildArgs {
++				args = append(args, "--build-arg", buildArg)
++			}
++		}
++
+ 		args = append(args, "--label=org.mobyproject.linuxkit.version="+version.Version)
+ 		args = append(args, "--label=org.mobyproject.linuxkit.revision="+version.GitCommit)
+ 
+diff --git a/src/cmd/linuxkit/pkglib/pkglib.go b/src/cmd/linuxkit/pkglib/pkglib.go
+index c5c1108a5..a3440d18d 100644
+--- a/src/cmd/linuxkit/pkglib/pkglib.go
++++ b/src/cmd/linuxkit/pkglib/pkglib.go
+@@ -25,6 +25,7 @@ type pkgInfo struct {
+ 	DisableContentTrust bool              `yaml:"disable-content-trust"`
+ 	DisableCache        bool              `yaml:"disable-cache"`
+ 	Config              *moby.ImageConfig `yaml:"config"`
++	BuildArgs    *[]string         `yaml:"buildArgs,omitempty"`
+ 	Depends             struct {
+ 		DockerImages struct {
+ 			TargetDir string   `yaml:"target-dir"`
+@@ -53,6 +54,7 @@ type Pkg struct {
+ 	trust         bool
+ 	cache         bool
+ 	config        *moby.ImageConfig
++	buildArgs     *[]string
+ 	dockerDepends dockerDepends
+ 
+ 	// Internal state
+@@ -251,6 +253,7 @@ func NewFromCLI(fs *flag.FlagSet, args ...string) (Pkg, error) {
+ 		trust:         !pi.DisableContentTrust,
+ 		cache:         !pi.DisableCache,
+ 		config:        pi.Config,
++		buildArgs:     pi.BuildArgs,
+ 		dockerDepends: dockerDepends,
+ 		dirty:         dirty,
+ 		path:          pkgPath,
+diff --git a/test/cases/000_build/030_build_args/Dockerfile b/test/cases/000_build/030_build_args/Dockerfile
+new file mode 100644
+index 000000000..edc852693
+--- /dev/null
++++ b/test/cases/000_build/030_build_args/Dockerfile
+@@ -0,0 +1,7 @@
++FROM alpine:3.13
++
++ARG TEST_RESULT=FAILED
++
++RUN echo "printf \"Build-arg test $TEST_RESULT\\n\"" >> check.sh
++
++ENTRYPOINT ["/bin/sh", "/check.sh"]
+diff --git a/test/cases/000_build/030_build_args/build.yml b/test/cases/000_build/030_build_args/build.yml
+new file mode 100644
+index 000000000..f278801ef
+--- /dev/null
++++ b/test/cases/000_build/030_build_args/build.yml
+@@ -0,0 +1,7 @@
++image: build-args-test
++network: true
++arches:
++    - amd64
++    - arm64
++buildArgs:
++    - TEST_RESULT=PASSED
+diff --git a/test/cases/000_build/030_build_args/test.sh b/test/cases/000_build/030_build_args/test.sh
+new file mode 100755
+index 000000000..1d7bc1b38
+--- /dev/null
++++ b/test/cases/000_build/030_build_args/test.sh
+@@ -0,0 +1,18 @@
++#!/bin/sh
++# SUMMARY: Check that the build-args are correctly passed to Dockerfiles
++# LABELS:
++# REPEAT:
++
++set -ex
++
++# Source libraries. Uncomment if needed/defined
++#. "${RT_LIB}"
++. "${RT_PROJECT_ROOT}/_lib/lib.sh"
++
++# Test code goes here
++echo Linuxkig is "$(which linuxkit)"
++RESULT="$(2>&1 linuxkit pkg build --force . | grep PASSED)"
++echo RESULT="${RESULT}"
++echo "${RESULT}" | grep  "Build-arg test PASSED"
++
++exit 0
+-- 
+2.25.1
+

--- a/tools/parse-pkgs.sh
+++ b/tools/parse-pkgs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -u
+#!/bin/bash
 # Poor man's[1] yml generator
 #
 #
@@ -12,7 +12,25 @@ get_git_tag() {
 }
 
 linuxkit_tag() {
-    echo "$(linuxkit pkg show-tag ${EVE_HASH:+--hash $EVE_HASH} "$EVE/$1")$ARCH"
+    local pkg="$1"
+    _linuxkit_tag 0 "${pkg}"
+}
+
+linuxkit_dev_tag() {
+    local pkg="$1"
+    _linuxkit_tag 1 "${pkg}"
+}
+
+_linuxkit_tag() {
+    local is_dev_build="$1"
+    local pkg="$2"
+    local -a build_yml_cmd
+
+    if [[ "${is_dev_build}" == 1 ]]; then
+      build_yml_cmd=(-build-yml build-dev.yml)
+    fi
+
+    echo "$(linuxkit pkg show-tag "${build_yml_cmd[@]}" ${EVE_HASH:+--hash $EVE_HASH} "${EVE}/${pkg}")${ARCH}"
 }
 
 immutable_tag() {
@@ -76,6 +94,7 @@ DNSMASQ_TAG=${DNSMASQ_TAG}
 STRONGSWAN_TAG=${STRONGSWAN_TAG}
 TESTMSVCS_TAG=${TESTMSVCS_TAG}
 PILLAR_TAG=${PILLAR_TAG}
+PILLAR_DEV_TAG=${PILLAR_DEV_TAG}
 STORAGE_INIT_TAG=${STORAGE_INIT_TAG}
 WWAN_TAG=${WWAN_TAG}
 WLAN_TAG=${WLAN_TAG}
@@ -129,6 +148,7 @@ WWAN_TAG=$(linuxkit_tag pkg/wwan)
 WLAN_TAG=$(linuxkit_tag pkg/wlan)
 GUACD_TAG=$(linuxkit_tag pkg/guacd)
 PILLAR_TAG=$(linuxkit_tag pkg/pillar)
+PILLAR_DEV_TAG=$(linuxkit_dev_tag pkg/pillar)
 STORAGE_INIT_TAG=$(linuxkit_tag pkg/storage-init)
 GPTTOOLS_TAG=$(linuxkit_tag pkg/gpt-tools)
 WATCHDOG_TAG=$(linuxkit_tag pkg/watchdog)


### PR DESCRIPTION
This obsoletes #2626.

With this series, one can build Eve image with some extra debug capabilities. For now this includes pillar with debug symbols, and `delve` included in the pillar container.

To get yourself a development build:
```
make DEV=y pkg/pillar live run
```

Bellow is an example of the feature in action:

```
ssh -L 2348:localhost:2345 -p 2222 root@localhost
# -L 2348:localhost:2345 - forward host's port 2348 to Eve's port 2345
# -p 2222 - use port 2222, as qemu forward it to Guest's (in this case EveOS) port 22 (ssh)

eve enter pillar
/opt/dlv --headless --listen :2345 attach "$(pgrep zedbox)"
```

In a different termianl
```
❯ dlv connect :2348
Type 'help' for list of commands.
(dlv) b github.com/lf-edge/eve/pkg/pillar/base.(*LogObject).Functionf
Breakpoint 1 set at 0xf50db8 for github.com/lf-edge/eve/pkg/pillar/base.(*LogObject).Functionf() /pillar/base/log.\go:74
(dlv) c
> github.com/lf-edge/eve/pkg/pillar/base.(*LogObject).Functionf() /pillar/base/log.go:74 (hits goroutine(56):1 tot\al:1) (PC: 0xf50db8)
(dlv) bt
0  0x0000000000f50db8 in github.com/lf-edge/eve/pkg/pillar/base.(*LogObject).Functionf
   at /pillar/base/log.go:74
1  0x0000000001c82067 in github.com/lf-edge/eve/pkg/pillar/utils.WaitForOnboarded
   at /pillar/utils/waitfor.go:111
2  0x000000000254f047 in github.com/lf-edge/eve/pkg/pillar/cmd/domainmgr.Run
   at /pillar/cmd/domainmgr/domainmgr.go:456
3  0x0000000002bc5225 in main.startAgentAndDone
   at /pillar/zedbox/zedbox.go:246
4  0x0000000000ceef01 in runtime.goexit
   at /usr/lib/go/src/runtime/asm_amd64.s:1371
(dlv)
```