### PR TITLE
Sync eden tests and add tpm and zfs workflows

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -10,11 +10,13 @@ on:
 
 jobs:
   integration:
-    runs-on: ubuntu-20.04
+    name: Integration test (tpm=${{ matrix.tpm }};${{ matrix.fs }})
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        hv: ["kvm", "zfs-kvm"]
+        tpm: ["true", "false"]
+        fs: ["zfs", "ext4"]
     if: ${{ github.event.review.state == 'approved' || github.ref == 'refs/heads/master' }}
     steps:
       - name: Check
@@ -25,10 +27,13 @@ jobs:
                 echo "$addr overlaps with test"; exit 1
               fi
           done
+          sudo df -h
+          sudo swapoff -a
+          sudo free
       - name: setup
         run: |
-          sudo add-apt-repository ppa:canonical-server/server-backports
-          sudo apt install -y qemu-utils qemu-system-x86 jq
+          sudo add-apt-repository ppa:stefanberger/swtpm-jammy
+          sudo apt install -y qemu-utils qemu-system-x86 jq swtpm
       - name: get eve
         uses: actions/checkout@v2
         with:
@@ -38,7 +43,7 @@ jobs:
           if [ -f ${{ github.workspace }}/eve/tests/eden/eden-version ]; then
             EDEN_VERSION=$(cat ${{ github.workspace }}/eve/tests/eden/eden-version)
           else
-            EDEN_VERSION=lfedge/eden:0.4.0
+            EDEN_VERSION=lfedge/eden:0.5.0
           fi
           docker run -v $PWD:/out $EDEN_VERSION cp -a /eden/. /out/
           sudo chown -R $(whoami) .
@@ -48,12 +53,12 @@ jobs:
           TAG: pr${{ github.event.pull_request.number }}
           CACHE: evebuild/danger
         run: |
-          if docker pull "$CACHE:$TAG-${{ matrix.hv }}"; then
-             docker tag  "$CACHE:$TAG-${{ matrix.hv }}" "lfedge/eve:$TAG-${{ matrix.hv }}"
-             docker tag  "$CACHE:$TAG-${{ matrix.hv }}" "lfedge/eve:$TAG-${{ matrix.hv }}-amd64"
+          if docker pull "$CACHE:$TAG-kvm"; then
+             docker tag  "$CACHE:$TAG-kvm" "lfedge/eve:$TAG-kvm"
+             docker tag  "$CACHE:$TAG-kvm" "lfedge/eve:$TAG-kvm-amd64"
           else
              make -C eve V=1 pkgs
-             make -C eve V=1 ROOTFS_VERSION="$TAG" HV=${{ matrix.hv }} eve
+             make -C eve V=1 ROOTFS_VERSION="$TAG" eve
              IMAGES="$(docker images -f reference="lfedge/eve-*" -q)"
              IMAGES="$IMAGES $(docker images -f reference="eve-build-*" -q)"
              IMAGES="$IMAGES $(docker images -f reference="golang" -q)"
@@ -70,13 +75,22 @@ jobs:
       - name: run
         run: |
           ./eden config set default --key eve.tag --value="$TAG"
-          ./eden config set default --key eve.hv --value="${{ matrix.hv }}"
           ./eden config set default --key=eve.accel --value=false
+          ./eden config set default --key=eve.tpm --value=${{ matrix.tpm }}
           ./eden config set default --key=eve.cpu --value=2
           ./eden config set default --key=eden.tests --value=${{ github.workspace }}/eve/tests/eden
           EDITOR=cat ./eden config edit default
-          echo > ${{ github.workspace }}/eve/tests/eden/workflow/testdata/eden_stop.txt
-          ./eden test ${{ github.workspace }}/eve/tests/eden/workflow -v debug
+      - name: setup-ext4
+        if: matrix.fs == 'ext4'
+        run: ./eden setup -v debug
+      - name: setup-zfs
+        if: matrix.fs == 'zfs'
+        run: |
+          ./eden config set default --key=eve.disks --value=4
+          ./eden config set default --key=eve.disk --value=4096
+          ./eden setup -v debug --grub-options='set_global dom0_extra_args "$dom0_extra_args eve_install_zfs_with_raid_level "'
+      - name: run
+        run: EDEN_TEST_STOP=n ./eden test ${{ github.workspace }}/eve/tests/eden/workflow -v debug
       - name: Collect logs
         if: ${{ always() }}
         run: |
@@ -109,7 +123,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
-          name: eden-report-${{ matrix.hv }}
+          name: eden-report-tpm-${{ matrix.tpm }}-${{ matrix.fs }}
           path: |
             ${{ github.workspace }}/trace.log
             ${{ github.workspace }}/info.log

--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -9,12 +9,14 @@ on:  # yamllint disable-line rule:truthy
 # yamllint disable rule:line-length
 jobs:
   integration:
-    runs-on: ubuntu-20.04
+    name: Integration test (${{ matrix.backend }};${{ matrix.hv }};${{ matrix.fs }})
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         backend: ["gcp", "rol"]
         hv: ["kvm", "xen"]
+        fs: ["zfs", "ext4"]
     steps:
       - name: Check
         run: |
@@ -27,6 +29,9 @@ jobs:
                 echo "$addr overlaps with vpn"; exit 1
               fi
           done
+          sudo df -h
+          sudo swapoff -a
+          sudo free
       - name: Check RoL secrets
         if: matrix.backend == 'rol'
         run: |
@@ -59,8 +64,8 @@ jobs:
       - name: GCP Clean
         if: matrix.backend == 'gcp'
         run: |
-          gcloud compute instances delete eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} -q --zone=us-west1-a || echo "Does not exist"
-          gcloud compute images delete eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} -q || echo "Does not exist"
+          gcloud compute instances delete eve-edengcp-actions-${{ matrix.hv }}-${{ matrix.fs }}-${{github.run_number}} -q --zone=us-west1-a || echo "Does not exist"
+          gcloud compute images delete eve-edengcp-actions-${{ matrix.hv }}-${{ matrix.fs }}-${{github.run_number}} -q || echo "Does not exist"
       - name: Connect VPN
         id: connect_vpn
         timeout-minutes: 1
@@ -81,45 +86,60 @@ jobs:
       # Conditions for backwards compatibility on old branches
       - name: Prepare eden
         run: |
-          if [ "${{ matrix.backend }}" == "rol" ]; then
-             EDEN_VERSION=lfedge/eden:0.4.0
-          elif [ -f ${{ github.workspace }}/eve/tests/eden/eden-version ]; then
-             EDEN_VERSION=$(cat ${{ github.workspace }}/eve/tests/eden/eden-version)
+          if [ "${{ matrix.backend }}" == "rol" ] || ! [ -f ${{ github.workspace }}/eve/tests/eden/eden-version ]; then
+             EDEN_VERSION=lfedge/eden:0.5.0
           else
-             EDEN_VERSION=lfedge/eden:0.4.0
+             EDEN_VERSION=$(cat ${{ github.workspace }}/eve/tests/eden/eden-version)
           fi
           docker run -v $PWD:/out $EDEN_VERSION cp -a /eden/. /out/
           sudo chown -R $(whoami) .
       - name: Eden setup
         run: |
-          devmodel="--devmodel GCP"; [ "${{ matrix.backend }}" == "rol" ] && devmodel="--devmodel general --arch=arm64"
-          setup_flags="-v debug $([ "${{ matrix.backend }}" == "gcp" ] || echo "--netboot=true")"
-          eval ./eden config add default $devmodel
+          if [ "${{ matrix.backend }}" == "rol" ]; then
+            devmodel='general'
+            arch='arm64'
+            netboot='true'
+            tpm='false'
+          else
+            devmodel='GCP'
+            arch='amd64'
+            netboot='false'
+            tpm='true'
+          fi
+          ./eden config add default --devmodel="${devmodel}" --arch="${arch}"
           ./eden config set default --key eve.tag --value="snapshot"
           ./eden config set default --key eve.hv --value ${{ matrix.hv }}
-          ./eden config set default --key eve.tpm --value true
+          ./eden config set default --key eve.tpm --value "${tpm}"
           ./eden config set default --key adam.eve-ip --value ${{ steps.connect_vpn.outputs.tunnel_ip }}
           ./eden config set default --key registry.ip --value ${{ steps.connect_vpn.outputs.tunnel_ip }}
           ./eden config set default --key=eden.tests --value=${{ github.workspace }}/eve/tests/eden
-          eval ./eden setup "$setup_flags"
+          if [ "${{ matrix.fs }}" == "zfs" ]; then
+            if [ "${{ matrix.backend }}" == "gcp" ]; then
+              ./eden config set default --key=eve.disks --value=4
+            fi
+            grub_options='set_global dom0_extra_args "$dom0_extra_args eve_install_zfs_with_raid_level "'
+          else
+            grub_options=''
+          fi
+          ./eden setup -v debug --grub-options="${grub_options}" --netboot="${netboot}"
           ./eden start
       - name: GCP Create VM
         if: matrix.backend == 'gcp'
         run: |
           export ipv4=`curl https://api.ipify.org/?format=json | jq ".ip" -r`
-          ./eden utils gcp firewall --source-range $ipv4/32 --name eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} -k "${{ steps.gcpauth.outputs.credentials_file_path }}"
-          ./eden utils gcp image --image-name eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} -k "${{ steps.gcpauth.outputs.credentials_file_path }}" upload
-          ./eden utils gcp vm --image-name eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} --vm-name eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} -k "${{ steps.gcpauth.outputs.credentials_file_path }}" run
+          ./eden utils gcp firewall --source-range $ipv4/32 --name eve-edengcp-actions-${{ matrix.hv }}-${{ matrix.fs }}-${{github.run_number}} -k "${{ steps.gcpauth.outputs.credentials_file_path }}"
+          ./eden utils gcp image --image-name eve-edengcp-actions-${{ matrix.hv }}-${{ matrix.fs }}-${{github.run_number}} -k "${{ steps.gcpauth.outputs.credentials_file_path }}" upload
+          ./eden utils gcp vm --image-name eve-edengcp-actions-${{ matrix.hv }}-${{ matrix.fs }}-${{github.run_number}} --vm-name eve-edengcp-actions-${{ matrix.hv }}-${{ matrix.fs }}-${{github.run_number}} -k "${{ steps.gcpauth.outputs.credentials_file_path }}" run
           sleep 100
-          BWD=$(./eden utils gcp vm get-ip --vm-name eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} -k "${{ steps.gcpauth.outputs.credentials_file_path }}") || { echo "no IP, probably VM does not exist"; exit 1; }
+          BWD=$(./eden utils gcp vm get-ip --vm-name eve-edengcp-actions-${{ matrix.hv }}-${{ matrix.fs }}-${{github.run_number}} -k "${{ steps.gcpauth.outputs.credentials_file_path }}") || { echo "no IP, probably VM does not exist"; exit 1; }
           echo "the IP is $BWD"
-          ./eden utils gcp firewall -k "${{ steps.gcpauth.outputs.credentials_file_path }}" --source-range $BWD --name edengcp-actions-${{ matrix.hv }}-${{github.run_number}} || { echo "cannot set firewall"; exit 1; }
+          ./eden utils gcp firewall -k "${{ steps.gcpauth.outputs.credentials_file_path }}" --source-range $BWD --name edengcp-actions-${{ matrix.hv }}-${{ matrix.fs }}-${{github.run_number}} || { echo "cannot set firewall"; exit 1; }
       - name: RoL rent RPi4
         id: rol
         if: matrix.backend == 'rol'
         timeout-minutes: 60
         run: |
-          rent_id=$(./eden rol rent create -p "$ROL_PROJECT" -m raspberry --model pi_4_model_b_8gb -n GHAction-${{ github.run_number }}-snapshot-${{ matrix.hv }})
+          rent_id=$(./eden rol rent create -p "$ROL_PROJECT" -m raspberry --model pi_4_model_b_8gb -n GHAction-${{ github.run_number }}-snapshot-${{ matrix.hv }}-${{ matrix.fs }})
           echo ::set-output name=id::$(echo $rent_id)
           until [[ "$(./eden rol rent get -p "$ROL_PROJECT" -i $rent_id | jq -r .machineState)" == "Ready" ]]; do sleep 10; echo "Waiting for EVE to load"; done
         env:
@@ -131,9 +151,8 @@ jobs:
           ./eden eve onboard
       - name: Test
         run: |
-          echo > tests/workflow/testdata/eden_stop.txt
           if [ "${{ matrix.backend }}" == "gcp" ]; then export EDEN_TEST=gcp; fi
-          ./eden test ${{ github.workspace }}/eve/tests/eden/workflow -v debug
+          EDEN_TEST_STOP=n ./eden test ${{ github.workspace }}/eve/tests/eden/workflow -v debug
       - name: Collect logs
         if: ${{ always() }}
         run: |
@@ -142,7 +161,7 @@ jobs:
           ./eden metric > metric.log || echo "no metric"
           ./eden netstat > netstat.log || echo "no netstat"
           docker logs eden_adam > adam.log 2>&1 || echo "no adam log"
-          ./eden utils gcp vm log --vm-name eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} -k "${{ steps.gcpauth.outputs.credentials_file_path }}" > console.log || echo "no device log"
+          ./eden utils gcp vm log --vm-name eve-edengcp-actions-${{ matrix.hv }}-${{ matrix.fs }}-${{github.run_number}} -k "${{ steps.gcpauth.outputs.credentials_file_path }}" > console.log || echo "no device log"
       - name: Log counting
         if: ${{ always() }}
         run: |
@@ -165,10 +184,10 @@ jobs:
       - name: GCP Clean
         if: ${{ always() }}
         run: |
-          gcloud compute firewall-rules delete eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} || echo "Does not exist"
-          gcloud compute firewall-rules delete edengcp-actions-${{ matrix.hv }}-${{github.run_number}} || echo "Does not exist"
-          gcloud compute instances delete eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} -q --zone=us-west1-a || echo "Does not exist"
-          gcloud compute images delete eve-edengcp-actions-${{ matrix.hv }}-${{github.run_number}} -q || echo "Does not exist"
+          gcloud compute firewall-rules delete eve-edengcp-actions-${{ matrix.hv }}-${{ matrix.fs }}-${{github.run_number}} || echo "Does not exist"
+          gcloud compute firewall-rules delete edengcp-actions-${{ matrix.hv }}-${{ matrix.fs }}-${{github.run_number}} || echo "Does not exist"
+          gcloud compute instances delete eve-edengcp-actions-${{ matrix.hv }}-${{ matrix.fs }}-${{github.run_number}} -q --zone=us-west1-a || echo "Does not exist"
+          gcloud compute images delete eve-edengcp-actions-${{ matrix.hv }}-${{ matrix.fs }}-${{github.run_number}} -q || echo "Does not exist"
       - name: RoL Clean
         if: ${{ always() }}
         run: |
@@ -182,7 +201,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
-          name: eden-report-${{ matrix.backend }}-${{ matrix.hv }}
+          name: eden-report-${{ matrix.backend }}-${{ matrix.hv }}-${{ matrix.fs }}
           path: |
             ${{ github.workspace }}/trace.log
             ${{ github.workspace }}/info.log

--- a/Makefile
+++ b/Makefile
@@ -296,10 +296,6 @@ test: $(GOBUILDER) | $(DIST)
 	$(QUIET)$(DOCKER_GO) "gotestsum --jsonfile $(DOCKER_DIST)/results.json --junitfile $(DOCKER_DIST)/results.xml" $(GOTREE) $(GOMODULE)
 	$(QUIET): $@: Succeeded
 
-itest: $(GOBUILDER) run-proxy | $(DIST)
-	@echo Running integration tests
-	@cd tests/integration ; CGO_ENABLED=0 GOOS= go test -v -run "$(ITESTS)" .
-
 clean:
 	rm -rf $(DIST) images/*.yml
 

--- a/tests/eden/eclient/testdata/app_dhcp.txt
+++ b/tests/eden/eclient/testdata/app_dhcp.txt
@@ -1,0 +1,169 @@
+# Test verifies if EVE is able to learn IP addresses allocated by DHCP
+# to applications connected via switch network instances. These IP address
+# allocations are then published inside the network info messages.
+# Note that the learning is based on packet sniffing of DHCP messages going
+# through the bridge of the switch network.
+
+[!exec:bash] stop
+[!exec:sleep] stop
+[!exec:ssh] stop
+[!exec:chmod] stop
+
+# The application providing DHCP services requires netadmin capabilities.
+# For security reasons, EVE does not allow to grant these capabilities to native
+# containers, therefore it is required to deploy apps as VMs-in-Containers for
+# this test to pass.
+exec -t 2m bash check_vm_support.sh
+source .env
+[!env:with_hw_virt] skip 'Missing HW-assisted virtualization capability'
+
+{{define "port"}}2223{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{template "port"}} root@{{end}}
+
+exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
+
+# Starting of reboot detector with a 1 reboot limit
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
+
+message 'Resetting of EVE'
+eden eve reset
+exec sleep 30
+
+message 'Creating networks'
+eden network create 10.11.12.0/24 -n nat
+eden network create --type switch --uplink none -n switch
+test eden.network.test -test.v -timewait 10m ACTIVATED nat switch
+
+message 'Starting applications'
+eden pod deploy -v debug -n dhcp-server --memory=512MB --networks=switch --mount=src={{EdenConfig "eden.tests"}}/eclient/testdata/dhcp-server,dst=/app docker://lfedge/eden-docker-test:83cfe07
+eden pod deploy -v debug -n eclient --memory=512MB --networks=nat --networks=switch -p {{template "port"}}:22 docker://lfedge/eden-eclient:8d29db6
+test eden.app.test -test.v -timewait 20m RUNNING dhcp-server eclient
+
+message 'Checking accessibility'
+exec -t 5m bash wait_ssh.sh
+
+message 'Waiting for IP allocation'
+exec -t 5m bash wait_for_app_ip.sh eclient
+grep 'eclient_ip=10.11.13.\d+' .env
+source .env
+
+message 'Waiting for EVE to publish IP assignment'
+exec -t 2m bash wait_for_ip_assignment.sh $eclient_mac $eclient_ip
+! stderr .
+
+# We had a bug that DHCPACK returned for DHCPINFORM would result
+# in EVE replacing the recorded IP address with unspecified IP 0.0.0.0.
+# This is because RFC2131 states (in section 4.3.5) that yiaddr inside
+# DHCPACK should be empty in this case and EVE uses this field to learn
+# IP assignments.
+exec -t 2m bash send_dhcpinform.sh $eclient_mac $eclient_ip
+exec sleep 60
+exec -t 2m bash wait_for_ip_assignment.sh $eclient_mac $eclient_ip
+! stderr .
+
+message 'Resource cleaning'
+eden pod delete eclient
+eden pod delete dhcp-server
+test eden.app.test -test.v -timewait 10m - eclient dhcp-server
+
+eden network delete switch
+eden network delete nat
+test eden.network.test -test.v -timewait 10m - switch nat
+stdout 'no network with switch found'
+stdout 'no network with nat found'
+eden network ls
+! stdout '^switch\s'
+! stdout '^nat\s'
+
+-- check_vm_support.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+
+:>.env
+while true;
+do
+    virt=$($EDEN info --out InfoContent.dinfo.Capabilities.HWAssistedVirtualization | tail -n 1)
+    if [ -z "$virt" ]; then
+        sleep 3
+        continue
+    fi
+    [ "$virt" == "true" ] && echo "with_hw_virt=true" >>.env
+    break
+done
+
+-- wait_ssh.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+for i in `seq 20`
+do
+  sleep 20
+  # Test SSH-access to container
+  echo {{template "ssh"}}$HOST grep -q Ubuntu /etc/issue
+  {{template "ssh"}}$HOST grep -q Ubuntu /etc/issue && break
+done
+
+-- wait_for_app_ip.sh --
+#!/bin/sh
+
+APP=$1
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+function get_ip {
+    ifconfig=$({{template "ssh"}}$HOST ifconfig 2>/dev/null) || return 1
+    if [ -z "$ifconfig" ]; then
+        return 1
+    fi
+    interfaces=$(echo "$ifconfig" | grep "^\w" | grep -v LOOPBACK | cut -d: -f1)
+    eth1=$(echo "$interfaces" | awk 'NR==2')
+    IP=$(echo "$ifconfig" | grep "^${eth1}: " -A 1 | awk '/inet / {print $2}')
+    MAC=$(echo "$ifconfig" | grep "^${eth1}: " -A 2 | awk '/ether / {print $2}')
+    if [ ! -z "$IP" ]; then
+        echo "IP address of $APP is: $IP"
+        echo "${APP}_ip=$IP" >.env
+        echo "MAC address of $APP is: $MAC"
+        echo "${APP}_mac=$MAC" >>.env
+        return 0
+    fi
+    return 1
+}
+
+until get_ip; do sleep 3; done
+
+-- wait_for_ip_assignment.sh --
+#!/bin/sh
+
+EXP_MAC=$1
+EXP_IP=$2
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+
+function get_ip_assignments {
+    assignments=$($EDEN info InfoContent.niinfo.displayname:switch --tail 1 --out InfoContent.niinfo.ipAssignments)
+    echo "Current IP assignments: $assignments"
+    if echo "$assignments" | grep -q "macAddress:\"$EXP_MAC\" \+ipAddress:\"$EXP_IP\""; then
+        return 0
+    fi
+    return 1
+}
+
+until get_ip_assignments; do sleep 3; done
+
+-- send_dhcpinform.sh --
+#!/bin/sh
+
+CLIENT_MAC=$1
+CLIENT_IP=$2
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+{{template "ssh"}}$HOST dhcping -c $CLIENT_IP -h $CLIENT_MAC -s 10.11.13.1 -i -v
+
+-- eden-config.yml --
+{{/* Test's config. file */}}
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}

--- a/tests/eden/eclient/testdata/app_local_info.txt
+++ b/tests/eden/eclient/testdata/app_local_info.txt
@@ -1,0 +1,262 @@
+# Test app local info
+
+{{define "mngr_port"}}8027{{end}}
+{{define "app_port"}}8028{{end}}
+{{define "token"}}server_token_123{{end}}
+{{define "app_info_status_file"}}/mnt/app-info-status.json{{end}}
+{{define "app_cmd_file"}}/mnt/app-command.json{{end}}
+{{define "network"}}n1{{end}}
+{{define "ssh"}}ssh -q -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@{{end}}
+
+[!exec:bash] stop
+[!exec:sleep] stop
+[!exec:ssh] stop
+[!exec:chmod] stop
+[!exec:jq] stop
+
+exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
+
+# Starting of reboot detector with a 1 reboot limit
+! test eden.reboot.test -test.v -timewait 100m -reboot=0 -count=1 &
+
+message 'Resetting of EVE'
+eden eve reset
+exec sleep 30
+
+# Create n1 network
+eden -t 1m network create 10.11.12.0/24 -n {{template "network"}}
+test eden.network.test -test.v -timewait 10m ACTIVATED {{template "network"}}
+
+# Deploy local-manager
+eden pod deploy -n local-manager --memory=512MB docker://lfedge/eden-eclient:afaa332 -p {{template "mngr_port"}}:22 --networks={{template "network"}}
+test eden.app.test -test.v -timewait 10m RUNNING local-manager
+
+# Wait for ssh access
+exec -t 5m bash wait-ssh.sh {{template "mngr_port"}}
+
+# Start local manager application
+exec -t 1m bash local-manager-start.sh
+
+# Obtain local-manager IP address
+exec -t 2m bash get-app-ip.sh local-manager
+source .env
+
+# Configure local server
+eden controller edge-node update --device profile_server_token={{template "token"}}
+eden controller edge-node update --device local_profile_server=$app_ip:8888
+
+# STEP 1: Wait for appinfo status
+exec sleep 30
+exec -t 1m bash get-appinfo-status.sh
+stdout 'local-manager'
+! stdout 'app1'
+! stderr .
+
+# STEP 2: Deploy the second app
+eden pod deploy -n app1 --memory=512MB docker://lfedge/eden-eclient:9455582 -p {{template "app_port"}}:22 --networks={{template "network"}}
+test eden.app.test -test.v -timewait 10m RUNNING app1
+
+# Wait for ssh access
+exec -t 5m bash wait-ssh.sh {{template "app_port"}}
+
+# STEP 3: Wait for new appinfo status
+exec sleep 30
+exec -t 1m bash get-appinfo-status.sh
+stdout 'local-manager'
+stdout 'app1'
+! stderr .
+
+# STEP 4: Request for the app1 to be purged
+exec -t 1m bash create-file-in-app1.sh /root/purge_test
+exec -t 1m bash get-appinfo-status.sh app1
+! stdout 'lastCmdTimestamp'
+! stderr .
+exec -t 1m bash put-appinfo-cmd.sh app1 123 COMMAND_PURGE &
+exec -t 5m bash wait-for-app-state.sh app1 PURGING
+! stderr .
+exec -t 5m bash wait-for-app-state.sh app1 RUNNING
+! stderr .
+exec -t 5m bash wait-for-volume.sh app1
+stdout DELIVERED
+! stderr .
+# Internally, EVE increases generationCount to trigger the purge,
+# but this is fully hidden from the controller.
+eden info --tail 1 InfoContent.vinfo.displayName:app1 --out InfoContent.vinfo.generationCount
+stdout 0
+exec -t 1m bash get-appinfo-status.sh app1
+stdout '"lastCmdTimestamp": "123"'
+! stderr .
+exec -t 5m bash wait-ssh.sh {{template "app_port"}}
+! exec -t 1m bash file-exists-in-app1.sh /root/purge_test
+
+# STEP 5: Test that purge via controller also works.
+# Note that eve sums local and remote purge counters.
+exec -t 1m bash create-file-in-app1.sh /root/purge_test
+eden pod purge app1
+exec -t 5m bash wait-for-app-state.sh app1 PURGING
+! stderr .
+exec -t 5m bash wait-for-app-state.sh app1 RUNNING
+! stderr .
+exec -t 5m bash wait-for-volume.sh app1
+stdout DELIVERED
+! stderr .
+eden info --tail 1 InfoContent.vinfo.displayName:app1 --out InfoContent.vinfo.generationCount
+stdout 0
+exec -t 1m bash get-appinfo-status.sh app1
+stdout '"lastCmdTimestamp": "123"'
+! stderr .
+exec -t 5m bash wait-ssh.sh {{template "app_port"}}
+! exec -t 1m bash file-exists-in-app1.sh /root/purge_test
+
+# STEP 6: Request for the app1 to be restarted
+exec -t 1m bash create-file-in-app1.sh /run/restart_test
+exec -t 1m bash create-file-in-app1.sh /root/purge_test
+exec -t 1m bash put-appinfo-cmd.sh app1 456 COMMAND_RESTART &
+exec -t 5m bash wait-for-app-state.sh app1 RESTARTING
+! stderr .
+exec -t 5m bash wait-for-app-state.sh app1 RUNNING
+! stderr .
+exec -t 1m bash get-appinfo-status.sh app1
+stdout '"lastCmdTimestamp": "456"'
+! stderr .
+exec -t 5m bash wait-ssh.sh {{template "app_port"}}
+! exec -t 1m bash file-exists-in-app1.sh /run/restart_test
+exec -t 1m bash file-exists-in-app1.sh /root/purge_test
+
+# STEP 7: Test that restart via controller also works.
+# Note that eve sums local and remote restart counters.
+exec -t 1m bash create-file-in-app1.sh /run/restart_test
+exec -t 1m bash create-file-in-app1.sh /root/purge_test
+eden pod restart app1
+exec -t 5m bash wait-for-app-state.sh app1 RESTARTING
+! stderr .
+exec -t 5m bash wait-for-app-state.sh app1 RUNNING
+! stderr .
+exec -t 1m bash get-appinfo-status.sh app1
+stdout '"lastCmdTimestamp": "456"'
+! stderr .
+exec -t 5m bash wait-ssh.sh {{template "app_port"}}
+! exec -t 1m bash file-exists-in-app1.sh /run/restart_test
+exec -t 1m bash file-exists-in-app1.sh /root/purge_test
+
+# STEP 8: Remove the second app
+eden pod delete app1
+test eden.app.test -test.v -timewait 15m - app1
+
+# STEP 9: Wait for new appinfo status
+exec sleep 30
+exec -t 1m bash get-appinfo-status.sh
+stdout 'local-manager'
+! stdout 'app1'
+! stderr .
+
+# STEP 10: Undeploy local-manager
+eden pod delete local-manager
+test eden.app.test -test.v -timewait 15m - local-manager
+eden network delete {{template "network"}}
+test eden.network.test -test.v -timewait 10m - {{template "network"}}
+
+-- wait-ssh.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+for p in $*
+do
+  for i in `seq 20`
+  do
+    sleep 20
+    # Test SSH-access to container
+    echo {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue
+    {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue && break
+  done
+done
+
+-- local-manager-start.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+ARGS="--token={{template "token"}}"
+{{template "ssh"}}$HOST -p {{template "mngr_port"}} "/root/local_manager $ARGS &>/dev/null &"
+
+-- get-app-ip.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+IP=$($EDEN pod ps | grep $1 | awk '{print $4}' | cut -d ":" -f 1)
+echo app_ip=$IP>>.env
+
+-- get-appinfo-status.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+APP="$1"
+CMDS="
+until test -f {{template "app_info_status_file"}}; do sleep 5; done
+sleep 2
+cat {{template "app_info_status_file"}}
+"
+
+OUTPUT="$({{template "ssh"}}$HOST -p {{template "mngr_port"}} "$CMDS")"
+if [ -n "$APP" ]; then
+    echo "$OUTPUT" | jq --arg APP "$APP" '.appsInfo[] | select(.name==$APP)'
+else
+    echo "$OUTPUT"
+fi
+
+-- put-appinfo-cmd.sh --
+DN="$1"
+TIMESTAMP="${2:-0}"
+CMD="${3:-COMMAND_UNSPECIFIED}"
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+CONFIG="{\"displayname\": \"$DN\", \"timestamp\": $TIMESTAMP, \"command\": \"$CMD\"}"
+echo "$CONFIG" | {{template "ssh"}}$HOST -p {{template "mngr_port"}} 'cat > {{template "app_cmd_file"}}'
+
+-- wait-for-app-state.sh --
+APP="${1}"
+EXPSTATE="${2}"
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+while true; do
+    APPINFO="$({{template "ssh"}}$HOST -p {{template "mngr_port"}} "cat {{template "app_info_status_file"}}")"
+    APPINFO="$(echo "$APPINFO" | jq --arg APP "$APP" '.appsInfo[] | select(.name==$APP)')"
+    echo "$APPINFO" | grep "$EXPSTATE" && break
+    sleep 1
+done
+
+-- create-file-in-app1.sh --
+FILEPATH="${1}"
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+{{template "ssh"}}$HOST -p {{template "app_port"}} "touch \"$FILEPATH\""
+
+-- file-exists-in-app1.sh --
+FILEPATH="${1}"
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+{{template "ssh"}}$HOST -p {{template "app_port"}} "test -f \"$FILEPATH\""
+
+-- wait-for-volume.sh --
+APP="${1}"
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+
+for i in `seq 30`
+do
+    echo Step $i volume ls
+    $EDEN volume ls | grep "${APP}" | grep DELIVERED && break
+    sleep 10
+done
+
+$EDEN volume ls | grep "${APP}"
+
+-- eden-config.yml --
+{{/* Test's config file */}}
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}

--- a/tests/eden/eclient/testdata/dev_local_info.txt
+++ b/tests/eden/eclient/testdata/dev_local_info.txt
@@ -1,0 +1,268 @@
+# Test dev local info
+
+{{define "mngr_port"}}8027{{end}}
+{{define "app_port"}}8028{{end}}
+{{define "token"}}server_token_123{{end}}
+{{define "app_info_status_file"}}/mnt/app-info-status.json{{end}}
+{{define "dev_info_status_file"}}/mnt/dev-info-status.json{{end}}
+{{define "dev_cmd_file"}}/mnt/dev-command.json{{end}}
+{{define "network"}}n1{{end}}
+{{define "ssh"}}ssh -q -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@{{end}}
+
+[!exec:bash] stop
+[!exec:sleep] stop
+[!exec:ssh] stop
+[!exec:chmod] stop
+[!exec:jq] stop
+
+exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
+
+# Starting of reboot detector with a 3 reboot limit since we reboot twice
+! test eden.reboot.test -test.v -timewait 100m -reboot=0 -count=3 &
+
+message 'Resetting of EVE'
+eden eve reset
+exec sleep 30
+
+# Create n1 network
+eden -t 1m network create 10.11.12.0/24 -n {{template "network"}}
+test eden.network.test -test.v -timewait 10m ACTIVATED {{template "network"}}
+
+# Deploy local-manager
+eden pod deploy -n local-manager --memory=512MB docker://lfedge/eden-eclient:99d7f62 -p {{template "mngr_port"}}:22 --networks={{template "network"}}
+test eden.app.test -test.v -timewait 10m RUNNING local-manager
+
+# Wait for ssh access
+exec -t 5m bash wait-ssh.sh {{template "mngr_port"}}
+
+# Start local manager application
+exec -t 1m bash local-manager-start.sh
+
+# Obtain local-manager IP address
+exec -t 2m bash get-app-ip.sh local-manager
+source .env
+
+# Configure local server
+eden controller edge-node update --device profile_server_token={{template "token"}}
+eden controller edge-node update --device local_profile_server=$app_ip:8888
+
+# STEP 1: Wait for devinfo status
+exec sleep 30
+exec -t 10m bash get-devinfo-status.sh
+! stderr .
+
+# STEP 2: Deploy the second app
+eden pod deploy -n app1 --memory=512MB docker://lfedge/eden-eclient:9455582 -p {{template "app_port"}}:22 --networks={{template "network"}}
+test eden.app.test -test.v -timewait 10m RUNNING app1
+
+# Wait for ssh access
+exec -t 5m bash wait-ssh.sh {{template "app_port"}}
+
+# STEP 3: Wait for devinfo status reporting ONLINE
+exec -t 10m bash wait-for-dev-state.sh ONLINE
+! stderr .
+
+# STEP 4: Request for shutdown. Check that app1 stops before local_manager
+exec -t 10m bash wait-for-app-state.sh app1 HALTED &app1halted&
+exec -t 1m bash put-devinfo-cmd.sh COMMAND_SHUTDOWN &
+exec -t 5m bash wait-for-dev-state.sh SHUTTING_DOWN
+! stderr .
+# Could it already have HALTED? Match HALTING or HALTED
+exec -t 5m bash wait-for-app-state.sh app1 HALT
+! stderr .
+exec -t 1m bash get-appinfo-status.sh local-manager
+stdout 'RUNNING'
+! stderr .
+wait app1halted
+
+# Did local-manager halt? Can't check by asking local-manager
+exec -t 1m bash eden-pod-ps.sh local-manager
+! stdout 'RUNNING'
+! stderr .
+
+# STEP 5: test reboot via controller bringing them back up
+# send reboot command without wait
+eden controller edge-node reboot
+
+# STEP 5.1: Wait for ssh access
+test eden.app.test -test.v -timewait 20m RUNNING app1
+exec -t 10m bash wait-ssh.sh {{template "app_port"}}
+
+# STEP 5.2: Start local manager application
+exec -t 1m bash local-manager-start.sh
+
+# STEP 5.3: Wait for devinfo status reporting ONLINE
+exec sleep 30
+exec -t 10m bash wait-for-dev-state.sh ONLINE
+! stderr .
+
+# STEP 5.4: Check apps are back
+exec -t 20m bash wait-for-app-state.sh local-manager RUNNING
+! stderr .
+exec -t 20m bash wait-for-app-state.sh app1 RUNNING
+! stderr .
+
+# We can run the rest of the test only with qemu right now to properly
+# handle start of EVE after poweroff.
+{{$devmodel := EdenConfig "eve.devmodel"}}
+{{if not (eq $devmodel "ZedVirtual-4G")}}
+eden pod delete app1
+eden pod delete local-manager
+test eden.app.test -test.v -timewait 5m - app1 local-manager
+eden network delete {{template "network"}}
+test eden.network.test -test.v -timewait 5m - {{template "network"}}
+eden eve reset
+exec sleep 10
+skip 'The rest of the test is supported only on QEMU'
+{{end}}
+
+# STEP 6: Request for poweroff. Check that app1 stops before local_manager
+exec -t 1m bash put-devinfo-cmd.sh COMMAND_SHUTDOWN_POWEROFF &
+exec -t 5m bash wait-for-dev-state.sh POWERING_OFF
+! stderr .
+# Could it already have HALTED? Match HALTING or HALTED
+exec -t 5m bash wait-for-app-state.sh app1 HALT
+! stderr .
+exec -t 1m bash get-appinfo-status.sh local-manager
+stdout 'RUNNING'
+! stderr .
+exec -t 5m bash wait-for-app-state.sh app1 HALTED
+! stderr .
+
+# Did local-manager halt? Can't check by asking local-manager
+exec -t 1m bash eden-pod-ps.sh local-manager
+! stdout 'RUNNING'
+! stderr .
+
+# STEP 7: Check qemu process is gone aka powered off
+exec sleep 120
+eden eve status
+stdout 'process not running'
+
+# STEP 8: Restart EVE; check apps come up
+message 'Restart EVE'
+eden eve start
+exec sleep 30
+
+# STEP 8.1: Wait for ssh access
+test eden.app.test -test.v -timewait 20m RUNNING app1
+exec -t 10m bash wait-ssh.sh {{template "app_port"}}
+
+# STEP 9: Remove the second app
+eden pod delete app1
+test eden.app.test -test.v -timewait 15m - app1
+
+# STEP 10: Undeploy local-manager
+eden pod delete local-manager
+test eden.app.test -test.v -timewait 15m - local-manager
+eden network delete {{template "network"}}
+test eden.network.test -test.v -timewait 10m - {{template "network"}}
+eden eve reset
+exec sleep 10
+
+-- wait-ssh.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+for p in $*
+do
+  for i in `seq 20`
+  do
+    sleep 30
+    # Test SSH-access to container
+    echo {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue
+    {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue && break
+  done
+done
+
+-- local-manager-start.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+ARGS="--token={{template "token"}}"
+{{template "ssh"}}$HOST -p {{template "mngr_port"}} "/root/local_manager $ARGS &>/dev/null &"
+
+-- get-app-ip.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+IP=$($EDEN pod ps | grep $1 | awk '{print $4}' | cut -d ":" -f 1)
+echo app_ip=$IP>>.env
+
+-- eden-pod-ps.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+line=$($EDEN pod ps | grep $1)
+echo line
+
+-- get-appinfo-status.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+APP="$1"
+CMDS="
+until test -f {{template "app_info_status_file"}}; do sleep 5; done
+sleep 2
+cat {{template "app_info_status_file"}}
+"
+
+OUTPUT="$({{template "ssh"}}$HOST -p {{template "mngr_port"}} "$CMDS")"
+if [ -n "$APP" ]; then
+    echo "$OUTPUT" | jq --arg APP "$APP" '.appsInfo[] | select(.name==$APP)'
+else
+    echo "$OUTPUT"
+fi
+
+-- wait-for-app-state.sh --
+APP="${1}"
+EXPSTATE="${2}"
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+while true; do
+    APPINFO="$({{template "ssh"}}$HOST -p {{template "mngr_port"}} "cat {{template "app_info_status_file"}}")"
+    APPINFO="$(echo "$APPINFO" | jq --arg APP "$APP" '.appsInfo[] | select(.name==$APP)')"
+    echo "$APPINFO" | grep "$EXPSTATE" && break
+    sleep 1
+done
+
+-- get-devinfo-status.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+CMDS="
+until test -f {{template "dev_info_status_file"}}; do sleep 5; done
+sleep 2
+cat {{template "dev_info_status_file"}}
+"
+
+OUTPUT="$({{template "ssh"}}$HOST -p {{template "mngr_port"}} "$CMDS")"
+echo "$OUTPUT"
+
+OUTPUT="$({{template "ssh"}}$HOST -p {{template "mngr_port"}} "$CMDS")"
+echo "$OUTPUT"
+
+-- put-devinfo-cmd.sh --
+CMD="${1:-COMMAND_UNSPECIFIED}"
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+CONFIG="{\"command\": \"$CMD\"}"
+echo "$CONFIG"
+echo "$CONFIG" | {{template "ssh"}}$HOST -p {{template "mngr_port"}} 'cat > {{template "dev_cmd_file"}}'
+
+-- wait-for-dev-state.sh --
+EXPSTATE="${1}"
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+while true; do
+    DEVINFO="$({{template "ssh"}}$HOST -p {{template "mngr_port"}} "cat {{template "dev_info_status_file"}}")"
+    echo "$DEVINFO" | grep "$EXPSTATE" && break
+    sleep 1
+done
+
+-- eden-config.yml --
+{{/* Test's config file */}}
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}

--- a/tests/eden/eclient/testdata/dhcp-server/entrypoint.sh
+++ b/tests/eden/eclient/testdata/dhcp-server/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -x
+
+interfaces=$(ifconfig | grep "^\w" | grep -v LOOPBACK | cut -d: -f1)
+eth0=$(echo "$interfaces" | awk 'NR==1')
+
+ip addr add 10.11.13.1/24 dev "${eth0}"
+
+cat <<EOF > /etc/dnsmasq.conf
+bind-interfaces
+except-interface=lo
+dhcp-leasefile=/run/dnsmasq.leases
+interface=${eth0}
+dhcp-range=10.11.13.2,10.11.13.254,60m
+EOF
+
+cat <<EOF > /etc/supervisord.conf
+[supervisord]
+nodaemon=true
+
+[program:dnsmasq]
+command=dnsmasq -d -b -C /etc/dnsmasq.conf
+EOF
+
+exec /usr/bin/supervisord -c /etc/supervisord.conf

--- a/tests/eden/eclient/testdata/disk.txt
+++ b/tests/eden/eclient/testdata/disk.txt
@@ -20,7 +20,8 @@ test eden.app.test -test.v -timewait 20m RUNNING eclient-disk
 #stdout 'Executing "/usr/sbin/sshd" "-D"'
 
 exec -t 20m bash ssh.sh
-stdout 'vd.*disk'
+# we can receive sd* for zfs-enabled test
+stdout '[sv]d.*disk'
 
 eden pod delete eclient-disk
 

--- a/tests/eden/eclient/testdata/profile.txt
+++ b/tests/eden/eclient/testdata/profile.txt
@@ -115,6 +115,7 @@ exec sleep 20
 eden controller edge-node update --device global_profile=""
 eden controller edge-node update --device local_profile_server=""
 
+exec sleep 30
 # We have empty local_manager and empty default_profile, so apps should come back to RUNNING state now
 test eden.app.test -test.v -timewait 5m RUNNING app-profile-1 app-profile-2 app-profile-1-2 local-manager
 

--- a/tests/eden/eclient/testdata/publish_location.txt
+++ b/tests/eden/eclient/testdata/publish_location.txt
@@ -1,0 +1,221 @@
+# Test publishing of device location information.
+# Note that this test does not cover extraction of the location information.
+# This would be done by the wwan microservice using a GNSS receiver integrated with
+# an LTE modem. Here we instead inject a fake location information and make it look
+# like it was extracted by the wwan microservice. Then we test if this location data
+# are properly published to applications, local profile server and to the controller.
+
+{{define "mngr_port"}}8027{{end}}
+{{define "app_port"}}8028{{end}}
+{{define "token"}}server_token_123{{end}}
+{{define "location_file"}}/mnt/location.json{{end}}
+{{define "network"}}n1{{end}}
+{{define "ssh"}}ssh -q -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@{{end}}
+
+[!exec:bash] stop
+[!exec:sleep] stop
+[!exec:ssh] stop
+[!exec:chmod] stop
+[!exec:jq] stop
+
+exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
+
+# Starting of reboot detector with a 1 reboot limit
+! test eden.reboot.test -test.v -timewait 100m -reboot=0 -count=1 &
+
+message 'Resetting of EVE'
+eden eve reset
+exec sleep 30
+
+# Create n1 network
+eden -t 1m network create 10.11.12.0/24 -n {{template "network"}}
+test eden.network.test -test.v -timewait 10m ACTIVATED {{template "network"}}
+
+# Deploy local-manager
+eden pod deploy -n local-manager --memory=512MB docker://lfedge/eden-eclient:a8b6f1a -p {{template "mngr_port"}}:22 --networks={{template "network"}}
+test eden.app.test -test.v -timewait 10m RUNNING local-manager
+
+# Wait for ssh access
+exec -t 5m bash wait-ssh.sh {{template "mngr_port"}}
+
+# Start local manager application
+exec -t 1m bash local-manager-start.sh
+
+# Obtain local-manager IP address
+exec -t 2m bash get-app-ip.sh local-manager
+source .env
+
+# Configure local server
+eden controller edge-node update --device profile_server_token={{template "token"}}
+eden controller edge-node update --device local_profile_server=$app_ip:8888
+
+# Deploy (ordinary) application
+eden pod deploy -n app --memory=512MB docker://lfedge/eden-eclient:a8b6f1a -p {{template "app_port"}}:22 --networks={{template "network"}}
+test eden.app.test -test.v -timewait 10m RUNNING app
+
+# Wait for ssh access
+exec -t 5m bash wait-ssh.sh {{template "app_port"}}
+
+# Inject fake location information
+exec -t 1m bash inject-fake-location.sh 57.928721 -5.197889 120.542 1650531954000
+
+# Local profile server should obtain the location information
+exec -t 1m bash wait-for-location-lps.sh '"2022-04-21T09:05:54Z"'
+stdout '"logicallabel":.*"wwan0"'
+stdout '"latitude":.*57.928721'
+stdout '"longitude":.*-5.197889'
+stdout '"altitude":.*120.542'
+stdout '"horizontalUncertainty":.*16'
+stdout '"verticalUncertainty":.*25.1'
+stdout '"horizontalReliability":.*"LOC_RELIABILITY_MEDIUM"'
+stdout '"verticalReliability":.*"LOC_RELIABILITY_LOW"'
+
+# App should be able to obtain the location information
+exec -t 1m bash wait-for-location-app.sh 1650531954000
+stdout '"logical-label":.*"wwan0"'
+stdout '"latitude":.*57.928721'
+stdout '"longitude":.*-5.197889'
+stdout '"altitude":.*120.542'
+stdout '"horizontal-uncertainty":.*16'
+stdout '"vertical-uncertainty":.*25.1'
+stdout '"horizontal-reliability":.*"medium"'
+stdout '"vertical-reliability":.*"low"'
+
+# Controller should be able to obtain the location information
+# Note: expected timestamp is in seconds in this case
+exec -t 6m bash wait-for-location-controller.sh 1650531954
+stdout 'logicallabel:.*wwan0'
+stdout 'latitude:.*57.928721'
+stdout 'longitude:.*-5.197889'
+stdout 'altitude:.*120.542'
+stdout 'horizontal_reliability:.*LOC_RELIABILITY_MEDIUM'
+stdout 'vertical_reliability:.*LOC_RELIABILITY_LOW'
+stdout 'horizontal_uncertainty:.*16'
+stdout 'vertical_uncertainty:.*25.1'
+
+# Check location update.
+exec sleep 30
+exec -t 1m bash inject-fake-location.sh 65.0931802 28.9032144 52.142 1650531987000
+exec -t 1m bash wait-for-location-lps.sh '"2022-04-21T09:06:27Z"'
+stdout '"logicallabel":.*"wwan0"'
+stdout '"latitude":.*65.0931802'
+stdout '"longitude":.*28.9032144'
+stdout '"altitude":.*52.142'
+exec -t 1m bash wait-for-location-app.sh 1650531987000
+stdout '"logical-label":.*"wwan0"'
+stdout '"latitude":.*65.0931802'
+stdout '"longitude":.*28.9032144'
+stdout '"altitude":.*52.142'
+exec -t 6m bash wait-for-location-controller.sh 1650531987
+stdout 'logicallabel:.*wwan0'
+stdout 'latitude:.*65.0931802'
+stdout 'longitude:.*28.9032144'
+stdout 'altitude:.*52.142'
+
+# Undeploy applications
+eden pod delete local-manager
+eden pod delete app
+test eden.app.test -test.v -timewait 15m - local-manager
+test eden.app.test -test.v -timewait 15m - app
+eden network delete {{template "network"}}
+test eden.network.test -test.v -timewait 10m - {{template "network"}}
+
+message 'Resetting of EVE'
+eden eve reset
+exec sleep 30
+
+-- wait-ssh.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+for p in $*
+do
+  for i in `seq 20`
+  do
+    sleep 20
+    # Test SSH-access to container
+    echo {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue
+    {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue && break
+  done
+done
+
+-- local-manager-start.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+ARGS="--token={{template "token"}}"
+{{template "ssh"}}$HOST -p {{template "mngr_port"}} "/root/local_manager $ARGS &>/dev/null &"
+
+-- get-app-ip.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+IP=$($EDEN pod ps | grep $1 | awk '{print $4}' | cut -d ":" -f 1)
+echo app_ip=$IP>>.env
+
+-- inject-fake-location.sh --
+LAT="$1"
+LONG="$2"
+ALT="$3"
+TIME="$4"
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+CONFIG="{
+  \"logical-label\": \"wwan0\",
+  \"latitude\": $LAT,
+  \"longitude\": $LONG,
+  \"altitude\": $ALT,
+  \"utc-timestamp\": $TIME,
+  \"horizontal-uncertainty\": 16.00,
+  \"vertical-uncertainty\": 25.10,
+  \"horizontal-reliability\": \"medium\",
+  \"vertical-reliability\": \"low\"}"
+echo "$CONFIG" | $EDEN eve ssh 'cat > /run/wwan/location.json'
+
+-- wait-for-location-lps.sh --
+EXPTIME="$1"
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+# Wait until Local Profile server receives it.
+while true; do
+  LOCATION="$({{template "ssh"}}$HOST -p {{template "mngr_port"}} "cat {{template "location_file"}}")"
+  TIMESTAMP="$(echo "$LOCATION" | jq '."utcTimestamp"')"
+  if [ "$TIMESTAMP" = "$EXPTIME" ]; then
+    echo "$LOCATION"
+    break
+  fi
+  sleep 1
+done
+
+-- wait-for-location-app.sh --
+EXPTIME="$1"
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+# Wait until app is able to receive it.
+while true; do
+  LOCATION="$({{template "ssh"}}$HOST -p {{template "app_port"}} "curl -s 169.254.169.254/eve/v1/location.json")"
+  TIMESTAMP="$(echo "$LOCATION" | jq '."utc-timestamp"')"
+  if [ "$TIMESTAMP" = "$EXPTIME" ]; then
+    echo "$LOCATION" | jq
+    break
+  fi
+  sleep 1
+done
+
+-- wait-for-location-controller.sh --
+EXPTIME="$1"
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+while true;
+do
+    LOCATION=$($EDEN info InfoContent.locinfo.UtcTimestamp.Seconds:$EXPTIME --tail 1 --out InfoContent)
+    if [ -n "$LOCATION" ]; then
+        echo "$LOCATION"
+        break
+    fi
+    sleep 3
+done
+

--- a/tests/eden/eclient/testdata/shutdown_test.txt
+++ b/tests/eden/eclient/testdata/shutdown_test.txt
@@ -1,0 +1,84 @@
+# Test for shutdown of all app instances of EVE
+
+{{$port := "2223"}}
+{{$network_name := "n1"}}
+{{$app_name := "eclient"}}
+
+[!exec:bash] stop
+[!exec:sleep] stop
+[!exec:ssh] stop
+[!exec:chmod] stop
+
+exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
+
+# Create n1 network
+eden -t 1m network create 10.11.12.0/24 -n {{$network_name}}
+
+# Wait for run
+test eden.network.test -test.v -timewait 10m ACTIVATED {{$network_name}}
+
+eden pod deploy -n {{$app_name}} --memory=512MB docker://lfedge/eden-eclient:d9eb23f -p {{$port}}:22 --networks={{$network_name}}
+
+test eden.app.test -test.v -timewait 20m RUNNING {{$app_name}}
+
+# exec -t 5m bash ssh.sh
+# stdout 'Ubuntu'
+
+# check for the ZDEVICE_STATE_PREPARING_POWEROFF state
+test eden.lim.test -test.v -timewait 5m -test.run TestInfo -out InfoContent.dinfo.state 'InfoContent.dinfo.state:ZDEVICE_STATE_PREPARING_POWEROFF' &
+
+# send shutdown command
+eden controller edge-node shutdown
+
+# wait for detectors
+wait
+
+# wait for HALTED state which indicates that we are shutting down
+test eden.app.test -test.v -timewait 5m HALTED {{$app_name}} &
+
+# check for the ZDEVICE_STATE_PREPARED_POWEROFF state
+test eden.lim.test -test.v -timewait 5m -test.run TestInfo -out InfoContent.dinfo.state 'InfoContent.dinfo.state:ZDEVICE_STATE_PREPARED_POWEROFF' &
+
+# wait for detectors
+wait
+
+# now reboot node to bring app back up
+test eden.reboot.test -test.v -timewait=15m -reboot=1 -count=1 &
+
+# check info messages sent correct data in background
+test eden.app.test -test.v -timewait 15m -check-new RUNNING {{$app_name}} &
+test eden.network.test -test.v -timewait 15m -check-new ACTIVATED {{$network_name}} &
+
+# wait for detectors
+wait
+
+# check ssh access to app after reboot
+# exec -t 5m bash ssh.sh
+# stdout 'Ubuntu'
+
+eden pod delete {{$app_name}}
+test eden.app.test -test.v -timewait 10m - {{$app_name}}
+
+eden network delete {{$network_name}}
+test eden.network.test -test.v -timewait 10m - {{$network_name}}
+
+-- eden-config.yml --
+{{/* Test's config. file */}}
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+
+-- ssh.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+for i in `seq 20`
+do
+sleep 20
+# Test SSH-access to container
+echo $i\) ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{$port}} root@$HOST grep Ubuntu /etc/issue
+ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{$port}} root@$HOST grep Ubuntu /etc/issue && break
+done

--- a/tests/eden/eden-version
+++ b/tests/eden/eden-version
@@ -1,1 +1,1 @@
-lfedge/eden:0.4.0
+lfedge/eden:0.5.0

--- a/tests/eden/escript/README.md
+++ b/tests/eden/escript/README.md
@@ -151,6 +151,8 @@ are:
 - [link] for whether the OS has hard link support
 - [symlink] for whether the OS has symbolic link support
 - [exec:prog] for whether prog is available for execution (found by exec.LookPath)
+- [env:variable] if the environment variable has a non-empty string value assigned
+- [stdout:pattern] and [stderr:pattern] if stdout/stderr match provided pattern
 ```
 
 A condition can be negated: [!short] means to run the rest of the line when
@@ -224,6 +226,10 @@ The predefined commands are:
     test. At the end of the test, any remaining background processes are
     terminated using os.Interrupt (if supported) or os.Kill.
 
+    If the last token is '&word&` (where "word" is alphanumeric), the
+    command runs in the background but has a name, and can be waited
+    for specifically by passing the word to 'wait'.
+
     Standard input can be provided using the stdin command; this will be
     cleared after exec has been called.
 
@@ -288,7 +294,7 @@ The predefined commands are:
     Run the given 'eden' test executable program with the arguments.
     Behaves the same way as an 'exec'.
 
-* wait
+* wait [command]
 
     Wait for all 'exec', 'eden' and 'test' commands started in
     the background (with the '&' token) to exit, and display success
@@ -296,6 +302,8 @@ The predefined commands are:
     After a call to wait, the 'stderr' and 'stdout' commands will apply to the
     concatenation of the corresponding streams of the background commands,
     in the order in which those commands were started.
+
+    If an argument is specified, it waits for just that command.
 
 When TestEdenScripts runs a script and the script fails, by default TestEdenScripts
 shows the execution of the most recent phase of the script (since the last # comment)
@@ -355,14 +363,14 @@ directory behind when it exits, for manual debugging of failing tests:
     $ ./eden test tests/escript/ -r TestEdenScripts/bug -v debug -a '-testwork'
     DEBU[0000] DIR: tests/escript/
     DEBU[0000] Will use config from /home/user/.eden/contexts/default.yml
-    DEBU[0000] Try to add config from /data/work/user/EVE/github/itmo-eve/eden/tests/escript/eden-config.yml
-    DEBU[0000] Merged config with /data/work/user/EVE/github/itmo-eve/eden/tests/escript/eden-config.yml
+    DEBU[0000] Try to add config from /data/work/user/EVE/github/lf-edge/eden/tests/escript/eden-config.yml
+    DEBU[0000] Merged config with /data/work/user/EVE/github/lf-edge/eden/tests/escript/eden-config.yml
     DEBU[0000] testApp: eden.escript.test
     DEBU[0000] Will use config from /home/user/.eden/contexts/default.yml
-    DEBU[0000] Try to add config from /data/work/user/EVE/github/itmo-eve/eden/tests/escript/eden-config.yml
-    DEBU[0000] Merged config with /data/work/user/EVE/github/itmo-eve/eden/tests/escript/eden-config.yml
-    DEBU[0000] testProg: /home/user/work/EVE/github/itmo-eve/eden/dist/bin/eden.escript.test
-    DEBU[0000] Test: /home/user/work/EVE/github/itmo-eve/eden/dist/bin/eden.escript.test -test.run TestEdenScripts/bug -test.v -testwork
+    DEBU[0000] Try to add config from /data/work/user/EVE/github/lf-edge/eden/tests/escript/eden-config.yml
+    DEBU[0000] Merged config with /data/work/user/EVE/github/lf-edge/eden/tests/escript/eden-config.yml
+    DEBU[0000] testProg: /home/user/work/EVE/github/lf-edge/eden/dist/bin/eden.escript.test
+    DEBU[0000] Test: /home/user/work/EVE/github/lf-edge/eden/dist/bin/eden.escript.test -test.run TestEdenScripts/bug -test.v -testwork
     === RUN   TestEdenScripts
     INFO[0000] testData directory: testdata
     === RUN   TestEdenScripts/bug

--- a/tests/eden/hardware_reboot/testdata/hardware_eth_reboot.txt
+++ b/tests/eden/hardware_reboot/testdata/hardware_eth_reboot.txt
@@ -154,5 +154,21 @@ echo {{template "ssh"}}$HOST "$CMDS"
         "freeUplink": true
       }
     }
+  ],
+  "networks": [
+    {
+      "id": "6605d17b-3273-4108-8e6e-4965441ebe01",
+      "type": 4,
+      "ip": {
+        "dhcp": 4
+      }
+    }
+  ],
+  "systemAdapterList": [
+    {
+      "name": "eth0",
+      "uplink": true,
+      "networkUUID": "6605d17b-3273-4108-8e6e-4965441ebe01"
+    }
   ]
 }

--- a/tests/eden/lim/testdata/info_test.txt
+++ b/tests/eden/lim/testdata/info_test.txt
@@ -1,5 +1,4 @@
-{{$test1 := "test eden.lim.test -test.v -timewait 10m -test.run TestInfo"}}
-{{$test2 := "test eden.lim.test -test.v -timewait 1m -test.run TestInfo"}}
+{{$test := "test eden.lim.test -test.v -timewait 5m -test.run TestInfo"}}
 
 #eden config add default
 #eden setup
@@ -7,14 +6,18 @@
 #eden eve onboard
 
 eden eve epoch &
-
 # Trying to find eth0 or eth1 in dinfo.network.devName.
-{{$test1}} -out InfoContent.dinfo.network.devName 'InfoContent.dinfo.network.devName:.*eth[01].*'
+{{$test}} -out InfoContent.dinfo.network.devName 'InfoContent.dinfo.network.devName:.*eth[01].*'
 stdout 'eth[01]'
 
-# Checking dinfo.network.devName for interfaces other than eth0 or eth1.
-! {{$test2}} -out InfoContent.dinfo.network.devName 'InfoContent.dinfo.network.devName:.*eth[^01].*'
-! stdout 'eth[^01]'
+{{$tpm := EdenConfig "eve.tpm"}}
+{{if (eq $tpm "true")}}
+eden eve epoch &
+{{$test}} -out InfoContent.dinfo.HSMStatus 'InfoContent.dinfo.HSMStatus:ENABLED'
+stdout 'ENABLED'
+{{end}}
+
+wait
 
 # Test's config. file
 -- eden-config.yml --

--- a/tests/eden/network/testdata/switch_net_vlans.txt
+++ b/tests/eden/network/testdata/switch_net_vlans.txt
@@ -36,21 +36,21 @@ test eden.network.test -test.v -timewait 10m ACTIVATED nat
 test eden.network.test -test.v -timewait 10m ACTIVATED switch
 
 # Deploy DHCP server
-eden pod deploy -n dhcp-server --memory=512MB --networks=nat --networks=switch -p 8027:80 --mount=src={{EdenConfig "eden.tests"}}/network/testdata/vlans/dhcp-server,dst=/app {{$image}}
+eden pod deploy -n dhcp-server --memory=448MB --networks=nat --networks=switch -p 8027:80 --mount=src={{EdenConfig "eden.tests"}}/network/testdata/vlans/dhcp-server,dst=/app {{$image}}
 test eden.app.test -test.v -timewait 10m RUNNING dhcp-server
 exec -t 2m bash wait_and_get_ifconfig.sh dhcp-server 8027
 stdout '10.2.100.1  netmask 255.255.255.0'
 stdout '10.2.200.1  netmask 255.255.255.0'
 
 # Deploy app1 and connect it to VLAN 100
-eden pod deploy -n app1 --memory=512MB --networks=nat --networks=switch -p 8028:80 --vlan=switch:100 --metadata='url={{$test_data}}' {{$image}}
+eden pod deploy -n app1 --memory=448MB --networks=nat --networks=switch -p 8028:80 --vlan=switch:100 --metadata='url={{$test_data}}' {{$image}}
 test eden.app.test -test.v -timewait 10m RUNNING app1
 exec -t 5m bash wait_and_get_ip.sh app1 8028
 grep 'app1_ip=10.2.100.\d+' .env
 source .env
 
 # Deploy app2 and connect it to VLAN 100
-eden pod deploy -n app2 --memory=512MB --networks=nat --networks=switch -p 8029:80 --vlan=switch:100 --metadata="url=http://${app1_ip}/user-data.html" {{$image}}
+eden pod deploy -n app2 --memory=448MB --networks=nat --networks=switch -p 8029:80 --vlan=switch:100 --metadata="url=http://${app1_ip}/user-data.html" {{$image}}
 test eden.app.test -test.v -timewait 10m RUNNING app2
 exec -t 5m bash wait_and_get_ip.sh app2 8029
 grep 'app2_ip=10.2.100.\d+' .env
@@ -61,7 +61,7 @@ exec -t 5m bash wait_and_get_recv_data.sh app2 8029
 stdout '{{$test_data}}'
 
 # Deploy app3 and connect it to VLAN 200
-eden pod deploy -n app3 --memory=512MB --networks=nat --networks=switch -p 8030:80 --vlan=switch:200 --metadata="url=http://${app1_ip}/user-data.html" {{$image}}
+eden pod deploy -n app3 --memory=448MB --networks=nat --networks=switch -p 8030:80 --vlan=switch:200 --metadata="url=http://${app1_ip}/user-data.html" {{$image}}
 test eden.app.test -test.v -timewait 10m RUNNING app3
 exec -t 5m bash wait_and_get_ip.sh app3 8030
 grep 'app3_ip=10.2.200.\d+' .env
@@ -72,7 +72,7 @@ exec -t 5m bash wait_and_get_recv_data.sh app3 8030
 ! stdout '{{$test_data}}'
 
 # Deploy app4 outside of VLANs
-eden pod deploy -n app4 --memory=512MB --networks=nat --networks=switch -p 8031:80 --metadata="url=http://${app1_ip}/user-data.html" {{$image}}
+eden pod deploy -n app4 --memory=448MB --networks=nat --networks=switch -p 8031:80 --metadata="url=http://${app1_ip}/user-data.html" {{$image}}
 test eden.app.test -test.v -timewait 10m RUNNING app4
 exec -t 5m bash wait_and_get_ip.sh app4 8031
 grep 'app4_ip=10.2.0.\d+' .env

--- a/tests/eden/network/testdata/vlans_and_bonds.txt
+++ b/tests/eden/network/testdata/vlans_and_bonds.txt
@@ -1,0 +1,404 @@
+[!exec:bash] stop
+[!exec:grep] stop
+[!exec:cut] stop
+[!exec:curl] stop
+[!exec:sleep] stop
+
+{{$srvimage := "docker://lfedge/eden-docker-test:83cfe07"}}
+{{$appimage := "docker://lfedge/eden-eclient:d9eb23f"}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@{{end}}
+
+# In this test we first create two ethernet loops (pairs of eth interfaces interconnected
+# using virtual crossover cables). On both ends of these cables we put bonds to aggregate
+# them together as one link (with RR policy). On one end we then configure two VLAN sub-interfaces
+# to be used as EVE uplinks (VLAN 100 & 200), while the other end is attached to a switch network
+# with applications separated by these VLANs and with a DHCP server connected by a trunk port,
+# providing IP allocation separately for each VLAN.
+# If bonds and VLAN sub-interfaces work correctly, then applications as well as uplink ports should
+# receive IP addresses from the DHCP server and it should be possible to ping between applications
+# and EVE through these VLANs.
+#
+# Network topology:
+#
+#  bond1.100 (EVE uplink) --+           +-- eth2 -- (eth loop) -- eth3 --+                        +-- (trunk port) -- DHCP server
+#                           |           |                                |                        |                   (with VLAN sub-interfaces inside)
+#                           +-- bond1 --+                                +-- bond2 -- switch NI --+-- (VLAN 100) -- app1
+#                           |           |                                |                        |
+#  bond1.200 (EVE uplink) --+           +-- eth4 -- (eth loop) -- eth5 --+                        +-- (VLAN 200) -- app2
+#
+#
+
+
+# The application providing DHCP services for VLANs requires netadmin capabilities, otherwise
+# it is not permitted to create VLAN sub-interfaces. For security reasons, EVE does not allow
+# to grant these capabilities to native containers, therefore it is required to deploy apps
+# as VMs-in-Containers for this test to pass.
+exec -t 2m bash check_vm_support.sh
+source .env
+[!env:with_hw_virt] skip 'Missing HW-assisted virtualization capability'
+
+# This test is based on ethernet loops, which are only supported on the QEMU dev model.
+{{$devmodel := EdenConfig "eve.devmodel"}}
+{{if not (eq $devmodel "ZedVirtual-4G")}}
+skip 'Test is supported only on QEMU'
+{{end}}
+
+# Apply custom devmodel with ethernet loops, bonds (LAGs) and VLANs.
+eden config set $EDEN_CONFIG --key eve.devmodelfile --value $WORK/devmodel.json
+
+# Re-generate device config
+message 'Resetting of EVE'
+eden eve reset
+
+# Make sure that if test fails mid-through, devmodelfile will be left unset.
+eden config set $EDEN_CONFIG --key eve.devmodelfile
+
+# Restart EVE with two ethernet loops.
+eden -t 2m eve stop
+! stderr .
+exec sleep 1m
+eden -t 2m eve start --with-eth-loops 2
+! stderr .
+
+# Deploy DHCP server inside a switch network
+eden network create 10.1.0.0/24 -n ni-nat
+test eden.network.test -test.v -timewait 10m ACTIVATED ni-nat
+eden network create --type switch --uplink bond-switch -n ni-switch
+test eden.network.test -test.v -timewait 10m ACTIVATED ni-switch
+eden pod deploy -n dhcp-server --memory=512MB --networks=ni-nat --networks=ni-switch -p 8027:80 --mount=src={{EdenConfig "eden.tests"}}/network/testdata/vlans/dhcp-server,dst=/app {{$srvimage}}
+test eden.app.test -test.v -timewait 10m RUNNING dhcp-server
+exec -t 2m bash wait_and_get_ifconfig.sh dhcp-server 8027
+stdout '10.2.100.1  netmask 255.255.255.0'
+stdout '10.2.200.1  netmask 255.255.255.0'
+
+# Deploy applications inside the switch network, separated by VLANs
+eden pod deploy -n app1 --memory=512MB -p 2223:22 --networks=ni-nat --networks=ni-switch --vlan=ni-switch:100 {{$appimage}}
+eden pod deploy -n app2 --memory=512MB -p 2224:22 --networks=ni-nat --networks=ni-switch --vlan=ni-switch:200 {{$appimage}}
+test eden.app.test -test.v -timewait 10m RUNNING app1 app2
+exec -t 10m bash wait_ssh.sh 2223
+exec -t 10m bash wait_ssh.sh 2224
+
+# Create local networks attached to VLAN uplinks.
+# While these networks are not used in the test, it makes sense to verify that they can be created.
+eden network create 10.11.12.0/24 --uplink vlan100 -n ni-vlan100
+test eden.network.test -test.v -timewait 10m ACTIVATED ni-vlan100
+eden network create 10.11.13.0/24 --uplink vlan200 -n ni-vlan200
+test eden.network.test -test.v -timewait 10m ACTIVATED ni-vlan200
+
+exec -t 5m bash wait_for_uplink_ip.sh bond1.100 vlan100_uplink
+grep 'vlan100_uplink_ip=10.2.100.\d+' .env
+source .env
+exec -t 5m bash wait_for_uplink_ip.sh bond1.200 vlan200_uplink
+grep 'vlan200_uplink_ip=10.2.200.\d+' .env
+source .env
+
+exec -t 5m bash wait_for_app_ip.sh app1 2223
+grep 'app1_ip=10.2.100.\d+' .env
+source .env
+exec -t 5m bash wait_for_app_ip.sh app2 2224
+grep 'app2_ip=10.2.200.\d+' .env
+source .env
+
+exec -t 2m bash ping_from_app_to_uplink.sh 2223 ${vlan100_uplink_ip}
+exec -t 2m bash ping_from_app_to_uplink.sh 2224 ${vlan200_uplink_ip}
+
+# Cleanup - undeploy applications
+eden pod delete dhcp-server
+eden pod delete app1
+eden pod delete app2
+test eden.app.test -test.v -timewait 10m - dhcp-server app1 app2
+eden pod ps
+! stdout 'dhcp-server'
+! stdout 'app'
+
+# Cleanup - remove networks
+eden network delete ni-nat
+eden network delete ni-switch
+eden network delete ni-vlan100
+eden network delete ni-vlan200
+test eden.network.test -test.v -timewait 10m - ni-nat ni-switch ni-vlan100 ni-vlan200
+eden network ls
+! stdout 'ni-'
+
+# Restore original devmodel (devmodelfile is already unset in the config)
+message 'Resetting of EVE'
+eden eve reset
+
+# Restart EVE into the original state
+eden -t 2m eve stop
+! stderr .
+exec sleep 1m
+eden -t 2m eve start
+! stderr .
+
+-- check_vm_support.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+
+:>.env
+while true;
+do
+    virt=$($EDEN info --out InfoContent.dinfo.Capabilities.HWAssistedVirtualization | tail -n 1)
+    if [ -z "$virt" ]; then
+        sleep 3
+        continue
+    fi
+    [ "$virt" == "true" ] && echo "with_hw_virt=true" >>.env
+    break
+done
+
+-- wait_and_get_ifconfig.sh --
+APP=$1
+PORT=$2
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+address=http://${HOST}:${PORT}/ifconfig.html
+until curl -m 10 $address | grep -q LOOPBACK; do sleep 3; done
+curl -m 10 $address
+
+-- wait_ssh.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+for p in $*
+do
+  for i in `seq 20`
+  do
+    sleep 20
+    # Test SSH-access to container
+    echo {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue
+    {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue && break
+  done
+done
+
+-- wait_for_uplink_ip.sh --
+UPLINK=$1
+UPLINK_ENV=$2
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+
+function get_ip {
+    IP=$($EDEN eve ssh ifconfig 2>/dev/null | grep "^${UPLINK} " -A 1 | awk '/inet / {print $2}' | cut -d":" -f2)
+    if [ ! -z "$IP" ]; then
+        echo "IP address of $UPLINK is: $IP"
+        echo "${UPLINK_ENV}_ip=$IP" >.env
+        return 0
+    fi
+    return 1
+}
+
+until get_ip; do sleep 3; done
+
+-- wait_for_app_ip.sh --
+APP=$1
+PORT=$2
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+function get_ip {
+    ifconfig=$({{template "ssh"}}$HOST -p $PORT ifconfig 2>/dev/null) || return 1
+    if [ -z "$ifconfig" ]; then
+        return 1
+    fi
+    interfaces=$(echo "$ifconfig" | grep "^\w" | grep -v LOOPBACK | cut -d: -f1)
+    eth1=$(echo "$interfaces" | awk 'NR==2')
+    IP=$(echo "$ifconfig" | grep "^${eth1}: " -A 1 | awk '/inet / {print $2}' | cut -d"/" -f1)
+    if [ ! -z "$IP" ]; then
+        echo "IP address of $APP is: $IP"
+        echo "${APP}_ip=$IP" >.env
+        return 0
+    fi
+    return 1
+}
+
+until get_ip; do sleep 3; done
+
+-- ping_from_app_to_uplink.sh --
+APP_PORT=$1
+UPLINK_IP=$2
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+{{template "ssh"}}$HOST -p $APP_PORT ping -c 5 $UPLINK_IP
+
+-- eden-config.yml --
+{{/* Test's config file */}}
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+
+-- devmodel.json --
+{
+  "ioMemberList": [
+    {
+      "ztype": 1,
+      "phylabel": "eth0",
+      "phyaddrs": {
+        "Ifname": "eth0"
+      },
+      "logicallabel": "eth0",
+      "assigngrp": "eth0",
+      "usage": 1,
+      "usagePolicy": {
+        "freeUplink": true
+      }
+    },
+    {
+      "ztype": 1,
+      "phylabel": "eth1",
+      "phyaddrs": {
+        "Ifname": "eth1"
+      },
+      "logicallabel": "eth1",
+      "assigngrp": "eth1",
+      "usage": 2,
+      "usagePolicy": {
+        "freeUplink": true
+      }
+    },
+    {
+      "ztype": 1,
+      "phylabel": "eth2",
+      "phyaddrs": {
+        "Ifname": "eth2"
+      },
+      "logicallabel": "loop1-local",
+      "assigngrp": "eth2",
+      "usage": 2,
+      "usagePolicy": {
+        "freeUplink": true
+      }
+    },
+    {
+      "ztype": 1,
+      "phylabel": "eth3",
+      "phyaddrs": {
+        "Ifname": "eth3"
+      },
+      "logicallabel": "loop1-switch",
+      "assigngrp": "eth3",
+      "usage": 2,
+      "usagePolicy": {
+        "freeUplink": true
+      }
+    },
+    {
+      "ztype": 1,
+      "phylabel": "eth4",
+      "phyaddrs": {
+        "Ifname": "eth4"
+      },
+      "logicallabel": "loop2-local",
+      "assigngrp": "eth4",
+      "usage": 2,
+      "usagePolicy": {
+        "freeUplink": true
+      }
+    },
+    {
+      "ztype": 1,
+      "phylabel": "eth5",
+      "phyaddrs": {
+        "Ifname": "eth5"
+      },
+      "logicallabel": "loop2-switch",
+      "assigngrp": "eth5",
+      "usage": 2,
+      "usagePolicy": {
+        "freeUplink": true
+      }
+    }
+  ],
+  "bondAdapters": [
+    {
+      "logicallabel": "bond-local",
+      "interface_name": "bond1",
+      "lower_layer_names": ["loop1-local", "loop2-local"],
+      "bond_mode": 1
+    },
+    {
+      "logicallabel": "bond-switch",
+      "interface_name": "bond2",
+      "lower_layer_names": ["loop1-switch", "loop2-switch"],
+      "bond_mode": 1
+    }
+  ],
+  "vlanAdapters": [
+    {
+      "logicallabel": "vlan100",
+      "interface_name": "bond1.100",
+      "lower_layer_name": "bond-local",
+      "vlan_id": 100
+    },
+    {
+      "logicallabel": "vlan200",
+      "interface_name": "bond1.200",
+      "lower_layer_name": "bond-local",
+      "vlan_id": 200
+    }
+  ],
+  "networks": [
+    {
+      "id": "6605d17b-3273-4108-8e6e-4965441ebe01",
+      "type": 4,
+      "ip": {
+        "dhcp": 4
+      }
+    },
+    {
+      "id": "6605d17b-3273-4108-8e6e-4965441ebe02",
+      "type": 4,
+      "ip": {
+        "dhcp": 4
+      }
+    },
+    {
+      "id": "6605d17b-3273-4108-8e6e-4965441ebe03",
+      "type": 4,
+      "ip": {
+        "dhcp": 4
+      }
+    },
+    {
+      "id": "6605d17b-3273-4108-8e6e-4965441ebe04",
+      "type": 4,
+      "ip": {
+        "dhcp": 4
+      }
+    },
+    {
+      "id": "6605d17b-3273-4108-8e6e-4965441ebe05",
+      "type": 4,
+      "ip": {
+        "dhcp": 2
+      }
+    }
+  ],
+  "systemAdapterList": [
+    {
+      "name": "eth0",
+      "uplink": true,
+      "networkUUID": "6605d17b-3273-4108-8e6e-4965441ebe01"
+    },
+    {
+      "name": "eth1",
+      "uplink": true,
+      "networkUUID": "6605d17b-3273-4108-8e6e-4965441ebe02"
+    },
+    {
+      "name": "vlan100",
+      "networkUUID": "6605d17b-3273-4108-8e6e-4965441ebe03"
+    },
+    {
+      "name": "vlan200",
+      "networkUUID": "6605d17b-3273-4108-8e6e-4965441ebe04"
+    },
+    {
+      "name": "bond-switch",
+      "networkUUID": "6605d17b-3273-4108-8e6e-4965441ebe05"
+    }
+  ]
+}

--- a/tests/eden/volume/testdata/local_datastore.txt
+++ b/tests/eden/volume/testdata/local_datastore.txt
@@ -1,10 +1,12 @@
 # Test for deploying app from local datastore https://wiki.lfedge.org/display/EVE/Local+DataStore+with+ZeroConfig
 
 {{$port := "2223"}}
-{{$eve_arch := EdenConfig "eve.arch"}}
-{{$image_dir := "releases/groovy/release-20210108"}}
-{{$image_path := printf "%s/ubuntu-20.10-server-cloudimg-%s.img" $image_dir $eve_arch}}
-{{$image_url := printf "https://cloud-images.ubuntu.com/%s" $image_path}}
+{{$arch := EdenConfig "eve.arch"}}
+{{if (eq $arch "amd64")}}{{$arch = "x86_64"}}{{end}}
+{{if (eq $arch "arm64")}}{{$arch = "aarch64"}}{{end}}
+{{$image_dir := "0.5.2"}}
+{{$image_path := printf "%s/cirros-0.5.2-%s-disk.img" $image_dir $arch}}
+{{$image_url := printf "http://download.cirros-cloud.net/%s" $image_path}}
 {{$datastore := "http://ubuntu-http-server.local"}}
 
 [!exec:bash] stop

--- a/tests/eden/workflow/eden.workflow.tests.txt
+++ b/tests/eden/workflow/eden.workflow.tests.txt
@@ -42,6 +42,8 @@ eden+ports.sh 2223:2223 2224:2224 5912:5902 5911:5901 8027:8027 8028:8028 8029:8
 eden.escript.test -test.run TestEdenScripts/eden_start
 /bin/echo Eden onboard (03/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/eden_onboard
+/bin/echo Eden template check (03.1/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/template_check
 {{end}}
 
 {{if (ne $setup "y")}}
@@ -57,10 +59,8 @@ eden.escript.test -test.run TestEdenScripts/eve_restart
 eden.escript.test -testdata ../lim/testdata/ -test.run TestEdenScripts/log_test
 /bin/echo Eden SSH test (06/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/ssh
-{{ if or (eq $workflow "large") (eq $workflow "gcp") }}
 /bin/echo Eden Info test (07/{{$tests}})
 eden.escript.test -testdata ../lim/testdata/ -test.run TestEdenScripts/info_test
-{{end}}
 /bin/echo Eden Metric test (08/{{$tests}})
 eden.escript.test -testdata ../lim/testdata/ -test.run TestEdenScripts/metric_test
 
@@ -79,10 +79,15 @@ eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/sourc
 /bin/echo Escript fail scenario test (15/{{$tests}})
 eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/fail_scenario
 
+/bin/echo Eden ZFS state and layout check (zfs.1/{{$tests}})
+eden.escript.test -testdata ../zfs/testdata/ -test.run TestEdenScripts/state_and_layout_check
+
 /bin/echo Eden basic network test (16/{{$tests}})
 eden.escript.test -testdata ../network/testdata/ -test.run TestEdenScripts/network_test
 /bin/echo Eden basic VLAN test (16.1/{{$tests}})
-eden.escript.test -testdata ../network/testdata/ -test.run TestEdenScripts/vlans
+eden.escript.test -testdata ../network/testdata/ -test.run TestEdenScripts/switch_net_vlans
+/bin/echo Eden basic VLAN test (16.2/{{$tests}})
+eden.escript.test -testdata ../network/testdata/ -test.run TestEdenScripts/vlans_and_bonds
 /bin/echo Eden basic volumes test (17.1/{{$tests}})
 eden.escript.test -testdata ../volume/testdata/ -test.run TestEdenScripts/volumes_test
 /bin/echo Eden sftp volumes test (17.2/{{$tests}})
@@ -116,6 +121,14 @@ eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/port_
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/port_forward
 /bin/echo Eden test radio silence (21.4/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/radio_silence
+/bin/echo Eden test app info (21.5/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/app_local_info
+/bin/echo Eden test app info (21.6/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/app_dhcp
+/bin/echo Eden test dev info (21.7/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/dev_local_info
+/bin/echo Eden location publish test (21.8/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/publish_location
 
 {{if (eq $usb_pt "y")}}
 /bin/echo Hardware reboot - USB (22/{{$tests}})
@@ -167,6 +180,9 @@ eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/eclie
 
 /bin/echo Eden Reboot test (34/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/reboot_test
+
+/bin/echo Eden Shutdown test (34.1/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/shutdown_test
 
 {{ if ne $workflow "small" }}
 /bin/echo Eden base OS update http (35/{{$tests}})

--- a/tests/eden/workflow/testdata/eden_onboard.txt
+++ b/tests/eden/workflow/testdata/eden_onboard.txt
@@ -1,8 +1,22 @@
-# eden start
+# eden onboard
+
+[!exec:bash] stop
+[!exec:jq] stop
+
+{{$tpm := EdenConfig "eve.tpm"}}
+{{if (eq $tpm "true")}}
+# enable templates check if we run with TPM enabled
+exec -t 1m bash set_template_check_enforce.sh true
+{{end}}
 
 # Onboarding.
 eden eve onboard
 stdout 'onboarded'
+
+-- set_template_check_enforce.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+
+$EDEN controller get-options|jq ".enforceTemplateAttestation = $1"|$EDEN controller set-options
 
 -- eden-config.yml --
 test:

--- a/tests/eden/workflow/testdata/template_check.txt
+++ b/tests/eden/workflow/testdata/template_check.txt
@@ -1,0 +1,76 @@
+# check for templates apply inside controller
+
+# note: the test may be run only once per workflow run
+#       it expects non-attested device
+#       we set force template attestation
+#       inside eden_onboard for tpm-enabled
+
+{{$tpm := EdenConfig "eve.tpm"}}
+{{if not (eq $tpm "true")}}
+skip 'The test is only for TPM-enabled deployment'
+{{end}}
+
+[!exec:bash] stop
+[!exec:jq] stop
+[!exec:sleep] stop
+
+exec sleep 30
+
+# we expect non-attested state, skip if not
+exec -t 1m bash check_non_attest_state.sh
+source .env
+[!env:check_pass] skip 'Only for the boot with non-attested device'
+
+# wait for template received from device
+exec -t 5m bash wait_template.sh
+
+# set template received from device to controller
+exec -t 1m bash approve_template.sh
+
+exec -t 5m bash wait_attest_state.sh true
+stdout 'true'
+
+# disable template attestation to not affect the rest of the tests
+exec -t 1m bash set_template_check_enforce.sh false
+
+-- check_non_attest_state.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+
+$EDEN controller edge-node get-options
+
+if $EDEN controller edge-node get-options |jq ".attested" | grep -q "false"; then
+    echo "check_pass=true" >>.env
+else
+    echo "" >>.env
+    $EDEN controller get-options|jq ".enforceTemplateAttestation = false"|$EDEN controller set-options
+fi
+
+-- wait_attest_state.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+
+until $EDEN controller edge-node get-options |jq ".attested" | grep -q "$1"; do sleep 10; done
+$EDEN controller edge-node get-options |jq ".attested"
+
+-- set_template_check_enforce.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+
+$EDEN controller get-options|jq ".enforceTemplateAttestation = $1"|$EDEN controller set-options
+$EDEN controller get-options|jq ".enforceTemplateAttestation"
+
+-- approve_template.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+
+$EDEN controller get-options|jq ".PCRTemplates = $($EDEN controller edge-node get-options|jq [.receivedPCRTemplate])"|$EDEN controller set-options
+$EDEN controller get-options|jq ".PCRTemplates"
+
+-- wait_template.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+
+while true; do
+    template=$($EDEN controller edge-node get-options |jq ".receivedPCRTemplate")
+    if [ "$template" != "null" ]; then
+      break
+    fi
+    sleep 10
+done
+$EDEN controller edge-node get-options |jq ".receivedPCRTemplate"

--- a/tests/eden/zfs/testdata/state_and_layout_check.txt
+++ b/tests/eden/zfs/testdata/state_and_layout_check.txt
@@ -1,0 +1,81 @@
+# check for state for zfs-enabled EVE
+
+# Starting of reboot detector with a 1 reboots limit
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
+
+# Use eden.lim.test for access Infos with timewait 5m
+{{$info_test := "test eden.lim.test -test.v -timewait 5m -test.run TestInfo"}}
+
+# skip test if no STORAGE_TYPE_INFO_ZFS
+eden info --out InfoContent.dinfo.StorageInfo.StorageType 'InfoContent.dinfo.StorageInfo.StorageType:\w+' --tail 1
+[!stdout:STORAGE_TYPE_INFO_ZFS] skip 'No zfs type storage'
+
+# check for storage state
+eden info --out InfoContent.dinfo.StorageInfo.StorageState 'InfoContent.dinfo.StorageInfo.StorageState:\w+' --tail 1
+stdout 'STORAGE_STATUS_ONLINE'
+
+# show StorageInfo structure
+eden info --out InfoContent.dinfo.StorageInfo 'InfoContent.dinfo.StorageInfo:\w+' --tail 1
+[stdout:sda9] env part=true
+
+eden info --out InfoContent.dinfo.StorageInfo 'InfoContent.dinfo.StorageInfo:\w+' --tail 1
+[stdout:sde] skip 'Cannot replace twice'
+
+eden info --out InfoContent.hwinfo 'InfoContent.hwinfo:\w+' --tail 1
+[!stdout:'(/dev/sd.*){2,}'] skip 'No additional disks'
+
+# move to raid1
+[env:part] eden disks set --layout-type=raid1 --part-disks=0
+[!env:part] eden disks set --layout-type=raid1
+
+# Trying to find sdb in storage info
+eden eve epoch &
+{{$info_test}} -out InfoContent.dinfo.StorageInfo 'InfoContent.dinfo.StorageInfo:sdb'
+stdout '/dev/sdb'
+
+
+eden info --out InfoContent.hwinfo 'InfoContent.hwinfo:\w+' --tail 1
+[!stdout:'(/dev/sd.*){4,}'] skip 'No additional disks'
+
+# move to raid10 layout
+[env:part] eden disks set --layout-type=raid10 --part-disks=0
+[!env:part] eden disks set --layout-type=raid10
+
+# Trying to find sdc and sdd in storage info
+eden eve epoch &
+{{$info_test}} -out InfoContent.dinfo.StorageInfo 'InfoContent.dinfo.StorageInfo:sdc' 'InfoContent.dinfo.StorageInfo:sdd'
+stdout '/dev/sdc'
+stdout '/dev/sdd'
+
+# set first disk offline
+[env:part] eden disks set --layout-type=raid10 --part-disks=0 --offline-disks=0
+[!env:part] eden disks set --layout-type=raid10 --offline-disks=0
+
+# Trying to find sda offline and degraded pool
+eden eve epoch &
+{{$info_test}} -out InfoContent.dinfo.StorageInfo 'InfoContent.dinfo.StorageInfo:STORAGE_STATUS_OFFLINE' 'InfoContent.dinfo.StorageInfo:STORAGE_STATUS_DEGRADED'
+stdout 'STORAGE_STATUS_DEGRADED'
+
+# remove offline disks from config
+[env:part] eden disks set --layout-type=raid10 --part-disks=0
+[!env:part] eden disks set --layout-type=raid10
+
+# Trying to not find degraded pool
+eden eve epoch &
+{{$info_test}} -out InfoContent.dinfo.StorageInfo 'InfoContent.dinfo.StorageInfo[].StorageState:STORAGE_STATUS_ONLINE'
+! stdout 'STORAGE_STATUS_DEGRADED'
+
+eden info --out InfoContent.hwinfo 'InfoContent.hwinfo:\w+' --tail 1
+[!stdout:'(/dev/sd.*){5,}'] skip 'No additional disks'
+
+# replace sda9 with sde
+[env:part] eden disks set --layout-type=raid10 --part-disks=0 --replace-disks=0
+[!env:part] eden disks set --layout-type=raid10 --replace-disks=0
+
+# Trying to find sde and not degraded pool
+eden eve epoch &
+{{$info_test}} -out InfoContent.dinfo.StorageInfo 'InfoContent.dinfo.StorageInfo:sde' 'InfoContent.dinfo.StorageInfo[].StorageState:STORAGE_STATUS_ONLINE'
+! stdout '/dev/sda'
+
+eden eve reset
+exec sleep 10


### PR DESCRIPTION
New Eden tests:

1. local app info
2. dev local ifo
3. publish location
4. shutdown test
5. app dhcp test
6. adam update to handle templates and test
7. zfs state and layout test
8. reduce local_datastore test time

Workflow updates:

1. Enable TPM in PR tests and remove separate building for ZFS
2. Enable ZFS in main branch tests
3. Update ubuntu and disable swap

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>