### PR TITLE
More sensible ticker range for location publishing to cloud

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlelocation.go
+++ b/pkg/pillar/cmd/zedagent/handlelocation.go
@@ -34,8 +34,8 @@ func locationTimerTask(ctx *zedagentContext, handleChannel chan interface{}) {
 	// Ticker for periodic publishing to the controller.
 	cloudInterval := ctx.globalConfig.GlobalValueInt(types.LocationCloudInterval)
 	interval := time.Duration(cloudInterval) * time.Second
-	max := float64(interval)
-	min := max * 0.3
+	max := float64(interval) * 1.5
+	min := float64(interval) * 0.5
 	cloudTicker := flextimer.NewRangeTicker(time.Duration(min), time.Duration(max))
 
 	// Ticker for periodic publishing to the Local profile server.
@@ -96,8 +96,8 @@ func updateLocationCloudTimer(ctx *getconfigContext, cloudInterval uint32) {
 	}
 	interval := time.Duration(cloudInterval) * time.Second
 	log.Functionf("updateLocationCloudTimer: cloudInterval change to %v", interval)
-	max := float64(interval)
-	min := max * 0.3
+	max := float64(interval) * 1.5
+	min := float64(interval) * 0.5
 	flextimer.UpdateRangeTicker(ctx.locationCloudTickerHandle,
 		time.Duration(min), time.Duration(max))
 	// Force an immediate timeout since timer could have decreased.


### PR DESCRIPTION
Currently, we use ticker with range `(0.3 * interval, interval)`.
However, since the interval for location publishing to cloud is typically
quite long to avoid flooding controller with location data (by default
1 hour), it gives us a bit too wide range for publishing (`18 min - 60 min`
by default). Instead, this PR proposes to use `(0.9 * interval, 1.1 * interval)`.
For the default value, it results in the range between `54 min and 66 min`.
Note that the minimum value allowed for this interval is 5 minutes.
In the minimum case the range would be therefore `4.5 min to 5.5 min`.

Signed-off-by: Milan Lenco <milan@zededa.com>