### PR TITLE
Properly report NTP server used for network with static config

### DIFF
--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -1625,8 +1625,19 @@ func GetNTPServers(globalStatus DeviceNetworkStatus, ifname string) []net.IP {
 		if ifname != "" && ifname != us.IfName {
 			continue
 		}
-		for _, server := range us.NtpServers {
-			servers = append(servers, server)
+		servers = append(servers, us.NtpServers...)
+		// Add statically configured NTP server as well, but avoid duplicates.
+		if us.NtpServer != nil {
+			var found bool
+			for _, server := range servers {
+				if server.Equal(us.NtpServer) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				servers = append(servers, us.NtpServer)
+			}
 		}
 	}
 	return servers


### PR DESCRIPTION
For networks with static IP configurations, there is a different
field inside DNS used to store the address of the assigned NTP server.
`GetNTPServers` should therefore differentiate between statically
configured and DHCP-based networks, and report the assigned NTP
server(s) accordingly.

Signed-off-by: Milan Lenco <milan@zededa.com>