### PR TITLE
use sparce write while rolling out image to zvol

### DIFF
--- a/pkg/pillar/cmd/volumemgr/create.go
+++ b/pkg/pillar/cmd/volumemgr/create.go
@@ -102,7 +102,7 @@ func createVdiskVolume(ctx *volumemgrContext, status types.VolumeStatus,
 				log.Error(errStr)
 				return created, "", errors.New(errStr)
 			}
-			if err := diskmetrics.ConvertImg(createContext, log, pathToFile, zVolDevice, "raw"); err != nil {
+			if err := diskmetrics.RolloutImgToBlock(createContext, log, pathToFile, zVolDevice, "raw"); err != nil {
 				errStr := fmt.Sprintf("Error converting %s to zfs zvol %s: %v",
 					pathToFile, zVolDevice, err)
 				log.Error(errStr)

--- a/pkg/pillar/diskmetrics/diskmetrics.go
+++ b/pkg/pillar/diskmetrics/diskmetrics.go
@@ -70,14 +70,15 @@ func CreateImg(ctx context.Context, log *base.LogObject, diskfile string, format
 	return nil
 }
 
-//ConvertImg do conversion of diskfile to outputFile with defined format
-func ConvertImg(ctx context.Context, log *base.LogObject, diskfile, outputFile, outputFormat string) error {
+//RolloutImgToBlock do conversion of diskfile to outputFile with defined format
+func RolloutImgToBlock(ctx context.Context, log *base.LogObject, diskfile, outputFile, outputFormat string) error {
 	if _, err := os.Stat(diskfile); err != nil {
 		return err
 	}
 	// writeback cache instead of default unsafe, out of order enabled, skip file creation
-	args := []string{"convert", "-t", "writeback", "-W", "-n", "-O", outputFormat, diskfile, outputFile}
-	output, err := base.Exec(log, "/usr/bin/qemu-img", args...).WithContext(ctx).CombinedOutput()
+	// Timeout 2 hours
+	args := []string{"convert", "--target-is-zero", "-t", "writeback", "-W", "-n", "-O", outputFormat, diskfile, outputFile}
+	output, err := base.Exec(log, "/usr/bin/qemu-img", args...).WithContext(ctx).CombinedOutputWithCustomTimeout(432000)
 	if err != nil {
 		errStr := fmt.Sprintf("qemu-img failed: %s, %s\n",
 			err, output)


### PR DESCRIPTION
It takes forever to write huge amount of data to the disk. The limit
for qemu-img operation was 16 minutes, which was not even close to be
enough for flashing 2TiB of data.

Assuming that zvol is created with all zerroes, we can instruct
qemu-img to skip writing zeroes. This drastically speeds up the
process of rolling out the image, as qcow2 almost never contains data
to fill target volume entirely.

Also in case we indeed have to flash a lot of data to the disk, this
patch increases timeout up to 2 hours.

Signed-off-by: Yuri Volchkov <yuri@volch.org>