### PR TITLE
Patch for 8.3 

### DIFF
--- a/pkg/pillar/dpcmanager/dpc.go
+++ b/pkg/pillar/dpcmanager/dpc.go
@@ -223,11 +223,10 @@ func (m *DpcManager) ingestDPCList() (dpclPresentAtBoot bool) {
 	var storedDpcl types.DevicePortConfigList
 	if err != nil {
 		m.Log.Errorf("No global key for DevicePortConfigList")
-		dpclPresentAtBoot = false
 	} else {
 		storedDpcl = item.(types.DevicePortConfigList)
 	}
-	m.Log.Functionf("Initial DPCL %v", storedDpcl)
+	m.Log.Noticef("Initial DPCL %v", storedDpcl)
 	var dpcl types.DevicePortConfigList
 	for _, portConfig := range storedDpcl.PortConfigList {
 		// Sanitize port labels and IsL3Port flag.

--- a/pkg/pillar/pubsub/socketdriver/driver.go
+++ b/pkg/pillar/pubsub/socketdriver/driver.go
@@ -146,6 +146,7 @@ func (s *SocketDriver) Publisher(global bool, name, topic string, persistent boo
 	}
 	doneChan := make(chan struct{})
 	return &Publisher{
+		persistent:     persistent,
 		sockName:       sockName,
 		listener:       listener,
 		dirName:        dirName,

--- a/pkg/pillar/pubsub/socketdriver/recovery_test.go
+++ b/pkg/pillar/pubsub/socketdriver/recovery_test.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2022 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package socketdriver_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub/socketdriver"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockPubSub struct{}
+
+func (mockPubSub) IsRestarted() bool {
+	return false
+}
+
+func (mockPubSub) RestartCounter() int {
+	return 0
+}
+
+func (mockPubSub) DetermineDiffs(pubsub.LocalCollection) []string {
+	return nil
+}
+
+func TestRecovery(t *testing.T) {
+	// Run in a unique directory.
+	rootPath, err := ioutil.TempDir("", "recovery_test")
+	if err != nil {
+		t.Fatalf("TempDir failed: %s", err)
+	}
+	defer os.RemoveAll(rootPath)
+	logger := logrus.StandardLogger()
+	log := base.NewSourceLogObject(logger, "test", 1234)
+
+	newPublisher := func() pubsub.DriverPublisher {
+		driver := socketdriver.SocketDriver{
+			Logger:  logger,
+			Log:     log,
+			RootDir: rootPath,
+		}
+		publisher, err := driver.Publisher(true, "test", "item", true, &pubsub.Updaters{},
+			mockPubSub{}, mockPubSub{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return publisher
+	}
+	publisher := newPublisher()
+	err = publisher.Publish("global", []byte(`{"field":"abcdef"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	filePath := filepath.Join(rootPath, "persist", "config", "test", "global.json")
+	_, err = os.Stat(filePath)
+	if err != nil {
+		t.Fatalf("published item was not persisted: %v", err)
+	}
+	// Nothing has been backed up yet, this was the first publication.
+	backupPath := filePath + ".bak"
+	_, err = os.Stat(backupPath)
+	if !os.IsNotExist(err) {
+		t.Fatal("unexpected backup file")
+	}
+
+	// Second publication, the first value should be copied to a backup file.
+	err = publisher.Publish("global", []byte(`{"field":"123456"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	file, err := os.Stat(backupPath)
+	if err != nil {
+		t.Fatalf("missing backup file: %v", err)
+	}
+
+	// Simulate reboot without the persisted file getting lost.
+	publisher = newPublisher()
+	items, _, err := publisher.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Len(t, items, 1)
+	assert.Contains(t, items, "global")
+	assert.Equal(t, items["global"], []byte(`{"field":"123456"}`))
+
+	// Simulate reboot and the persisted file getting lost.
+	err = os.Remove(filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	publisher = newPublisher()
+	// Load should recover the first publication.
+	items, _, err = publisher.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Len(t, items, 1)
+	assert.Contains(t, items, "global")
+	assert.Equal(t, items["global"], []byte(`{"field":"abcdef"}`))
+
+	// Simulate reboot and the persisted file getting emptied.
+	err = ioutil.WriteFile(filePath, nil, file.Mode())
+	if err != nil {
+		t.Fatal(err)
+	}
+	publisher = newPublisher()
+	// Load should recover the first publication.
+	items, _, err = publisher.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Len(t, items, 1)
+	assert.Contains(t, items, "global")
+	assert.Equal(t, items["global"], []byte(`{"field":"abcdef"}`))
+
+	// Un-publish - backup file should be also removed.
+	err = publisher.Unpublish("global")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = os.Stat(backupPath)
+	if !os.IsNotExist(err) {
+		t.Fatal("unexpected backup file")
+	}
+}


### PR DESCRIPTION
pubsub: populate from backup if the original json file is corrupted/missing

This is a follow up to [1].
This PR enhances pubsub such that it is now able to recover lost json files
with persisted items from backups. This is done by the Load()
method of the publisher's driver. The procedure of recovery is to first read
and then write the content of the *.bak file into the location of the original
file. This is done from inside of NewPublication() constructor, meaning that
all recovered items are then automatically also (re)published through sockets
(alongside all other loaded items).

[1] https://github.com/lf-edge/eve/pull/2630

Signed-off-by: Milan Lenco <milan@zededa.com>
(cherry picked from commit 71a6ed0790a8f786859c76172bed521c774f57ec)