### PR TITLE
Appinstance activate cleanup

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1105,7 +1105,6 @@ func handleCreate(ctx *domainContext, key string, config *types.DomainConfig) {
 		DisplayName:        config.DisplayName,
 		DomainName:         config.GetTaskName(),
 		AppNum:             config.AppNum,
-		VifList:            config.VifList,
 		VirtualizationMode: config.VirtualizationModeOrDefault(),
 		EnableVnc:          config.EnableVnc,
 		VncDisplay:         config.VncDisplay,
@@ -1116,7 +1115,7 @@ func handleCreate(ctx *domainContext, key string, config *types.DomainConfig) {
 	}
 	// Note that the -emu interface doesn't exist until after boot of the domU, but we
 	// initialize the VifList here with the VifUsed.
-	status.VifList = checkIfEmu(status.VifList)
+	status.VifList = fillVifUsed(config.VifList)
 
 	publishDomainStatus(ctx, &status)
 	log.Functionf("handleCreate(%v) set domainName %s for %s",
@@ -1928,7 +1927,7 @@ func handleModify(ctx *domainContext, key string,
 				config.UUIDandVersion, status.DomainName,
 				config.DisplayName)
 		}
-		status.VifList = checkIfEmu(config.VifList)
+		status.VifList = fillVifUsed(config.VifList)
 		publishDomainStatus(ctx, status)
 
 		// Update disks based on any change to volumes
@@ -2016,6 +2015,15 @@ func updateStatusFromConfig(status *types.DomainStatus, config types.DomainConfi
 	status.VncDisplay = config.VncDisplay
 	status.VncPasswd = config.VncPasswd
 	status.DisableLogs = config.DisableLogs
+}
+
+// fillVifUsed iterates over vifs from received config and fill VifUsed
+func fillVifUsed(vifList []types.VifConfig) []types.VifInfo {
+	var retList []types.VifInfo
+	for _, net := range vifList {
+		retList = append(retList, types.VifInfo{VifConfig: net})
+	}
+	return checkIfEmu(retList)
 }
 
 // If we have a -emu named interface we assume it is being used

--- a/pkg/pillar/cmd/zedmanager/handledomainmgr.go
+++ b/pkg/pillar/cmd/zedmanager/handledomainmgr.go
@@ -35,11 +35,11 @@ func MaybeAddDomainConfig(ctx *zedmanagerContext,
 	if ns != nil {
 		AppNum = ns.AppNum
 	}
-
+	effectiveActivate := effectiveActivateCurrentProfile(aiConfig, ctx.currentProfile)
 	dc := types.DomainConfig{
 		UUIDandVersion:    aiConfig.UUIDandVersion,
 		DisplayName:       aiConfig.DisplayName,
-		Activate:          aiStatus.EffectiveActivate,
+		Activate:          effectiveActivate,
 		AppNum:            AppNum,
 		VmConfig:          aiConfig.FixedResources,
 		IoAdapterList:     aiConfig.IoAdapterList,

--- a/pkg/pillar/cmd/zedmanager/handledomainmgr.go
+++ b/pkg/pillar/cmd/zedmanager/handledomainmgr.go
@@ -112,10 +112,10 @@ func MaybeAddDomainConfig(ctx *zedmanagerContext,
 	if ns != nil {
 		ulNum := len(ns.UnderlayNetworkList)
 
-		dc.VifList = make([]types.VifInfo, ulNum)
+		dc.VifList = make([]types.VifConfig, ulNum)
 		// Put UL before OL
 		for i, ul := range ns.UnderlayNetworkList {
-			dc.VifList[i] = ul.VifInfo
+			dc.VifList[i] = ul.VifInfo.VifConfig
 		}
 	}
 	log.Functionf("MaybeAddDomainConfig done for %s", key)

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -142,7 +142,9 @@ func doUpdate(ctx *zedmanagerContext,
 		return changed
 	}
 
-	if !status.EffectiveActivate {
+	effectiveActivate := effectiveActivateCurrentProfile(config, ctx.currentProfile)
+
+	if !effectiveActivate {
 		if status.Activated || status.ActivateInprogress {
 			c := doInactivateHalt(ctx, config, status)
 			changed = changed || c

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -148,7 +148,9 @@ func doUpdate(ctx *zedmanagerContext,
 		if status.Activated || status.ActivateInprogress {
 			c := doInactivateHalt(ctx, config, status)
 			changed = changed || c
-		} else {
+		}
+		// Activated and ActivateInprogress flags may be changed during doInactivateHalt call
+		if !status.Activated && !status.ActivateInprogress {
 			// Since we are not activating we set the state to
 			// HALTED to indicate it is not running since it
 			// might have been halted before the device was rebooted

--- a/pkg/pillar/containerd/oci.go
+++ b/pkg/pillar/containerd/oci.go
@@ -56,7 +56,7 @@ type OCISpec interface {
 	CreateContainer(bool) error
 	AddLoader(string) error
 	AdjustMemLimit(types.DomainConfig, int64)
-	UpdateVifList([]types.VifInfo)
+	UpdateVifList([]types.VifConfig)
 	UpdateFromDomain(*types.DomainConfig)
 	UpdateFromVolume(string) error
 	UpdateMounts([]types.DiskStatus) error
@@ -252,7 +252,7 @@ func (s *ociSpec) AdjustMemLimit(dom types.DomainConfig, addMemory int64) {
 }
 
 // UpdateVifList creates VIF management hooks in OCI spec
-func (s *ociSpec) UpdateVifList(vifs []types.VifInfo) {
+func (s *ociSpec) UpdateVifList(vifs []types.VifConfig) {
 	// use pre-start and post-stop hooks for networking
 	if s.Hooks == nil {
 		s.Hooks = &specs.Hooks{}

--- a/pkg/pillar/containerd/oci_test.go
+++ b/pkg/pillar/containerd/oci_test.go
@@ -383,9 +383,9 @@ func TestOciSpec(t *testing.T) {
 
 	conf := &types.DomainConfig{
 		VmConfig: types.VmConfig{Memory: 1234, VCpus: 4},
-		VifList: []types.VifInfo{
-			{Vif: "vif0", Bridge: "br0", Mac: "52:54:00:12:34:56", VifUsed: "vif0-ctr"},
-			{Vif: "vif1", Bridge: "br0", Mac: "52:54:00:12:34:57", VifUsed: "vif1-ctr"},
+		VifList: []types.VifConfig{
+			{Vif: "vif0", Bridge: "br0", Mac: "52:54:00:12:34:56"},
+			{Vif: "vif1", Bridge: "br0", Mac: "52:54:00:12:34:57"},
 		},
 	}
 	spec.UpdateFromDomain(conf)

--- a/pkg/pillar/hypervisor/containerd.go
+++ b/pkg/pillar/hypervisor/containerd.go
@@ -75,7 +75,7 @@ func (ctx ctrdContext) setupSpec(status *types.DomainStatus, config *types.Domai
 	}
 	spec.UpdateFromDomain(config)
 	spec.UpdateMounts(status.DiskStatusList)
-	spec.UpdateVifList(status.VifList)
+	spec.UpdateVifList(config.VifList)
 	spec.UpdateEnvVar(status.EnvVariables)
 
 	return spec, nil

--- a/pkg/pillar/hypervisor/kvm_test.go
+++ b/pkg/pillar/hypervisor/kvm_test.go
@@ -58,7 +58,7 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
 			VncPasswd:  "rosebud",
 		},
 		GPUConfig: "legacy",
-		VifList: []types.VifInfo{
+		VifList: []types.VifConfig{
 			{Bridge: "bn0", Mac: "6a:00:03:61:a6:90", Vif: "nbu1x1"},
 			{Bridge: "bn0", Mac: "6a:00:03:61:a6:91", Vif: "nbu1x2"},
 		},
@@ -874,7 +874,7 @@ func TestCreateDomConfig(t *testing.T) {
 			VncPasswd:  "rosebud",
 		},
 		GPUConfig: "legacy",
-		VifList: []types.VifInfo{
+		VifList: []types.VifConfig{
 			{Bridge: "bn0", Mac: "6a:00:03:61:a6:90", Vif: "nbu1x1"},
 			{Bridge: "bn0", Mac: "6a:00:03:61:a6:91", Vif: "nbu1x2"},
 		},
@@ -2150,7 +2150,7 @@ func TestCreateDom(t *testing.T) {
 			VirtualizationMode: types.HVM,
 		},
 		GPUConfig: "legacy",
-		VifList: []types.VifInfo{
+		VifList: []types.VifConfig{
 			{Bridge: "bn0", Mac: "6a:00:03:61:a6:90", Vif: "nbu1x1"},
 			{Bridge: "bn0", Mac: "6a:00:03:61:a6:91", Vif: "nbu1x2"},
 		},

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -32,7 +32,7 @@ type DomainConfig struct {
 	VmConfig
 	GPUConfig      string
 	DiskConfigList []DiskConfig
-	VifList        []VifInfo
+	VifList        []VifConfig
 	IoAdapterList  []IoAdapter
 
 	// XXX: to be deprecated, use CipherBlockStatus instead
@@ -358,13 +358,19 @@ type VlanInfo struct {
 	SwitchUplink string
 }
 
-type VifInfo struct {
-	Bridge  string
-	Vif     string
-	VifUsed string // Has -emu in name in Status if appropriate
-	Mac     string
+// VifConfig configure vif
+type VifConfig struct {
+	Bridge string
+	Vif    string
+	Mac    string
 
 	Vlan VlanInfo
+}
+
+// VifInfo store info about vif
+type VifInfo struct {
+	VifConfig
+	VifUsed string // Has -emu in name in Status if appropriate
 }
 
 // DomainManager will pass these to the xen xl config file

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -169,8 +169,6 @@ type AppInstanceStatus struct {
 	MissingNetwork bool // If some Network UUID not found
 	MissingMemory  bool // Waiting for memory
 
-	EffectiveActivate bool //set here effective activate after profile check and apply
-
 	// All error strings across all steps and all StorageStatus
 	// ErrorAndTimeWithSource provides SetError, SetErrrorWithSource, etc
 	ErrorAndTimeWithSource


### PR DESCRIPTION
Several fixes to avoid hungs with activate state and reduce false-positive
modifications for DomainConfig.

We calculate EffectiveActivate flag for AppInstanceStatus in several
places inside zedmanager and set state of DomainConfig based on
AppInstanceStatus which is suboptimal. We should use AppInstanceConfig
and calculate effective activate based on it.

I can see calls of DomainConfig.LogModify with only VifUsed changed, but
we do not expect this field inside the configuration, so we should
split config and info

We may potentially stay in INSTALLED state if we get INSTALLED state
from DomainStatus. We should check for Activated state after
doInactivateHalt in all cases.