### PR TITLE
Use concurrency to cancel old builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
       - "master"
       - "[0-9]+.[0-9]+"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
We run PR build workflow on every update of branch in PR, but we are not
 interested in old results. Let use concurrency feature to cancel old
 builds and not reserve runners.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>