### PR TITLE
Fix app_dhcp for ROL workflow and cleanup

### DIFF
--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -188,6 +188,7 @@ jobs:
           gcloud compute firewall-rules delete edengcp-actions-${{ matrix.hv }}-${{ matrix.fs }}-${{github.run_number}} || echo "Does not exist"
           gcloud compute instances delete eve-edengcp-actions-${{ matrix.hv }}-${{ matrix.fs }}-${{github.run_number}} -q --zone=us-west1-a || echo "Does not exist"
           gcloud compute images delete eve-edengcp-actions-${{ matrix.hv }}-${{ matrix.fs }}-${{github.run_number}} -q || echo "Does not exist"
+          gsutil -o "Credentials:gs_service_key_file=${{ steps.gcpauth.outputs.credentials_file_path }}" rm gs://eve-live/eve-edengcp-actions-${{ matrix.hv }}-${{ matrix.fs }}-${{github.run_number}}.img.tar.gz || echo "Does not exists"
       - name: RoL Clean
         if: ${{ always() }}
         run: |

--- a/tests/eden/eclient/testdata/app_dhcp.txt
+++ b/tests/eden/eclient/testdata/app_dhcp.txt
@@ -36,7 +36,7 @@ test eden.network.test -test.v -timewait 10m ACTIVATED nat switch
 
 message 'Starting applications'
 eden pod deploy -v debug -n dhcp-server --memory=512MB --networks=switch --mount=src={{EdenConfig "eden.tests"}}/eclient/testdata/dhcp-server,dst=/app docker://lfedge/eden-docker-test:83cfe07
-eden pod deploy -v debug -n eclient --memory=512MB --networks=nat --networks=switch -p {{template "port"}}:22 docker://lfedge/eden-eclient:8d29db6
+eden pod deploy -v debug -n eclient --memory=512MB --networks=nat --networks=switch -p {{template "port"}}:22 docker://lfedge/eden-eclient:77dc00b
 test eden.app.test -test.v -timewait 20m RUNNING dhcp-server eclient
 
 message 'Checking accessibility'


### PR DESCRIPTION
We are failing on app_dhcp test in ROL workflow because of problems with dhcping solved https://github.com/lf-edge/eden/pull/786. Let update eclient image with fix.
Also this PR add cleanup of uploaded images into GCP workflow