### PR TITLE
Add CAP_NET_ADMIN capability to sysctl

### DIFF
--- a/images/rootfs-adam-kvm.yml.in.patch
+++ b/images/rootfs-adam-kvm.yml.in.patch
@@ -1,6 +1,6 @@
 --- images/rootfs.yml.in
 +++ images/rootfs-adam-kvm.yml.in
-@@ -30,6 +30,12 @@
+@@ -33,6 +33,12 @@
       image: NEWLOGD_TAG
       cgroupsPath: /eve/services/eve-newlog
       oomScoreAdj: -999

--- a/images/rootfs-mini.yml.in.patch
+++ b/images/rootfs-mini.yml.in.patch
@@ -1,6 +1,6 @@
 --- images/rootfs.yml.in	2022-06-24 08:41:44.000000000 +0300
 +++ images/rootfs-mini.yml.in	2022-06-24 08:45:15.000000000 +0300
-@@ -1,71 +1,18 @@
+@@ -1,74 +1,18 @@
  kernel:
 -  image: KERNEL_TAG
 +  image: NEW_KERNEL_TAG
@@ -24,6 +24,9 @@
 -     image: linuxkit/sysctl:v0.5
 -     binds:
 -        - /etc/sysctl.d:/etc/sysctl.d
+-     capabilities:
+-        - CAP_SYS_ADMIN
+-        - CAP_NET_ADMIN
 -   - name: modprobe
 -     image: linuxkit/modprobe:v0.5
 -     command: ["/bin/sh", "-c", "modprobe -a nct6775 w83627hf_wdt hpwdt wlcore_sdio wl18xx br_netfilter dwc3 rk808 rk808-regulator smsc75xx cp210x nicvf tpm_tis_spi rtc_rx8010 gpio_pca953x leds_siemens_ipc127 upboard-fpga pinctrl-upboard leds-upboard xhci_tegra 2>/dev/null || :"]

--- a/images/rootfs-tools-kvm.yml.in.patch
+++ b/images/rootfs-tools-kvm.yml.in.patch
@@ -1,6 +1,6 @@
 --- images/rootfs.yml.in
 +++ images/rootfs-tools-kvm.yml.in
-@@ -66,6 +66,9 @@
+@@ -69,6 +69,9 @@
       image: XENTOOLS_TAG
       cgroupsPath: /eve/services/xen-tools
       oomScoreAdj: -999

--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -20,6 +20,9 @@ onboot:
      image: linuxkit/sysctl:v0.5
      binds:
         - /etc/sysctl.d:/etc/sysctl.d
+     capabilities:
+        - CAP_SYS_ADMIN
+        - CAP_NET_ADMIN
    - name: modprobe
      image: linuxkit/modprobe:v0.5
      command: ["/bin/sh", "-c", "modprobe -a nct6775 w83627hf_wdt hpwdt wlcore_sdio wl18xx br_netfilter dwc3 rk808 rk808-regulator smsc75xx cp210x nicvf tpm_tis_spi rtc_rx8010 gpio_pca953x leds_siemens_ipc127 upboard-fpga pinctrl-upboard leds-upboard xhci_tegra 2>/dev/null || :"]


### PR DESCRIPTION
With linux kernel 5.15+ change of /proc/sys/net/ipv4/ip_forward require
CAP_NET_ADMIN (https://github.com/torvalds/linux/commit/8292d7f6) which
is not present in linuxkit/sysctl (we use custom config with enabled
 forwarding).

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>