### PR TITLE
No disk led blinking on VMware

### DIFF
--- a/pkg/pillar/cmd/ledmanager/ledmanager.go
+++ b/pkg/pillar/cmd/ledmanager/ledmanager.go
@@ -186,6 +186,11 @@ var mToF = []modelToFuncs{
 		// No disk light blinking on Google
 	},
 	{
+		model:  "VMware.*",
+		regexp: true,
+		// No disk light blinking on VMware
+	},
+	{
 		model:       "raspberrypi.rpi.raspberrypi,4-model-b.brcm,bcm2711",
 		initFunc:    InitLedCmd,
 		displayFunc: ExecuteLedCmd,


### PR DESCRIPTION
We have no leds in virtual machine, so we should not stress disk

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>