### PR TITLE
Make it easier to build DEBUG target for UEFI

### DIFF
--- a/pkg/uefi/build.sh
+++ b/pkg/uefi/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+TARGET=RELEASE
+
 make -C BaseTools
 
 # shellcheck disable=SC1091
@@ -13,20 +15,20 @@ case $(uname -m) in
              cp /opensbi/build/platform/generic/firmware/fw_payload.bin OVMF_VARS.fd
              cp /opensbi/build/platform/generic/firmware/fw_jump.bin OVMF.fd
              ;;
-    aarch64) build -b RELEASE -t GCC5 -a AARCH64 -p ArmVirtPkg/ArmVirtQemu.dsc -D TPM2_ENABLE=TRUE -D TPM2_CONFIG_ENABLE=TRUE
-             cp Build/ArmVirtQemu-AARCH64/RELEASE_GCC5/FV/QEMU_EFI.fd OVMF.fd
-             cp Build/ArmVirtQemu-AARCH64/RELEASE_GCC5/FV/QEMU_VARS.fd OVMF_VARS.fd
+    aarch64) build -b ${TARGET} -t GCC5 -a AARCH64 -p ArmVirtPkg/ArmVirtQemu.dsc -D TPM2_ENABLE=TRUE -D TPM2_CONFIG_ENABLE=TRUE
+             cp Build/ArmVirtQemu-AARCH64/${TARGET}_GCC5/FV/QEMU_EFI.fd OVMF.fd
+             cp Build/ArmVirtQemu-AARCH64/${TARGET}_GCC5/FV/QEMU_VARS.fd OVMF_VARS.fd
              # now let's build PVH UEFI kernel
              make -C BaseTools/Source/C
-             build -b RELEASE -t GCC5 -a AARCH64  -p ArmVirtPkg/ArmVirtXen.dsc
-             cp Build/ArmVirtXen-AARCH64/RELEASE_*/FV/XEN_EFI.fd OVMF_PVH.fd
+             build -b ${TARGET} -t GCC5 -a AARCH64  -p ArmVirtPkg/ArmVirtXen.dsc
+             cp Build/ArmVirtXen-AARCH64/${TARGET}_*/FV/XEN_EFI.fd OVMF_PVH.fd
              ;;
-     x86_64) build -b RELEASE -t GCC5 -a X64 -p OvmfPkg/OvmfPkgX64.dsc -D TPM_ENABLE=TRUE -D TPM_CONFIG_ENABLE=TRUE
-             cp Build/OvmfX64/RELEASE_*/FV/OVMF*.fd .
-             build -b RELEASE -t GCC5 -a X64 -p OvmfPkg/OvmfXen.dsc
-             BaseTools/Source/C/bin/EfiRom -f 0x1F96 -i 0x0778 -e Build/OvmfX64/RELEASE_*/X64/IgdAssignmentDxe.efi
-             cp Build/OvmfX64/RELEASE_*/X64/IgdAssignmentDxe.rom IgdAssignmentDxe.rom
-             cp Build/OvmfXen/RELEASE_*/FV/OVMF.fd OVMF_PVH.fd
+     x86_64) build -b ${TARGET} -t GCC5 -a X64 -p OvmfPkg/OvmfPkgX64.dsc -D TPM_ENABLE=TRUE -D TPM_CONFIG_ENABLE=TRUE
+             cp Build/OvmfX64/${TARGET}_*/FV/OVMF*.fd .
+             build -b ${TARGET} -t GCC5 -a X64 -p OvmfPkg/OvmfXen.dsc
+             BaseTools/Source/C/bin/EfiRom -f 0x1F96 -i 0x0778 -e Build/OvmfX64/${TARGET}_*/X64/IgdAssignmentDxe.efi
+             cp Build/OvmfX64/${TARGET}_*/X64/IgdAssignmentDxe.rom IgdAssignmentDxe.rom
+             cp Build/OvmfXen/${TARGET}_*/FV/OVMF.fd OVMF_PVH.fd
              ;;
           *) echo "Unsupported architecture $(uname). Bailing."
              exit 1


### PR DESCRIPTION
Following  parameters are used with quemu to get UEFI logs
"-debugcon file:debug.log -global isa-debugcon.iobase=0x402"