### PR TITLE
Handle persist usage properly for zfs

### DIFF
--- a/pkg/pillar/types/diskmetrics.go
+++ b/pkg/pillar/types/diskmetrics.go
@@ -191,3 +191,10 @@ type ImgInfo struct {
 	ActualSize  uint64 `json:"actual-size"`
 	DirtyFlag   bool   `json:"dirty-flag"`
 }
+
+//UsageStat stores usage information about directory
+type UsageStat struct {
+	Total uint64
+	Used  uint64
+	Free  uint64
+}

--- a/pkg/pillar/types/locationconsts.go
+++ b/pkg/pillar/types/locationconsts.go
@@ -94,6 +94,10 @@ const (
 )
 
 var (
+	// PersistDataset - parent dataset
+	PersistDataset = strings.TrimLeft(PersistDir, "/")
+	// PersistReservedDataset - reserved dataset
+	PersistReservedDataset = PersistDataset + "/reserved"
 	//VolumeClearZFSDataset - dataset to create volumes without encryption
 	VolumeClearZFSDataset = strings.TrimLeft(VolumeClearDirName, "/")
 	//VolumeEncryptedZFSDataset - dataset to create volumes with encryption


### PR DESCRIPTION
We cannot use disk.Usage for persist in case of zfs since the mounted
/persist does not indicate usage of zvols and snapshots. So let use
information from zfs.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>