### PR TITLE
Seal disk decryption key to PCR 13

### DIFF
--- a/pkg/pillar/evetpm/tpm.go
+++ b/pkg/pillar/evetpm/tpm.go
@@ -93,7 +93,7 @@ var (
 	pcrBank256Status = PCRBank256StatusUnknown
 
 	//DiskKeySealingPCRs represents PCRs that we use for sealing
-	DiskKeySealingPCRs = tpm2.PCRSelection{Hash: tpm2.AlgSHA1, PCRs: []int{0, 1, 2, 3, 4, 6, 7, 8, 9}}
+	DiskKeySealingPCRs = tpm2.PCRSelection{Hash: tpm2.AlgSHA1, PCRs: []int{0, 1, 2, 3, 4, 6, 7, 8, 9, 13}}
 )
 
 //SealedKeyType holds different types of sealed key


### PR DESCRIPTION
PCR 13 is used by GRUB to measure rootfs and config partitions

It is safe to mere this even though we do not have GRUB PR yet. all PCRs have their default values 