### PR TITLE
Wipe data from the end of P3

### DIFF
--- a/pkg/mkimage-raw-efi/install
+++ b/pkg/mkimage-raw-efi/install
@@ -442,8 +442,9 @@ if [ "$INSTALL_ZFS" = true ]; then
 else
   P3="$(find_part P3 "$INSTALL_DEV")"
   [ -z "$P3" ] && bail "Installation failed. Cannot found P3. Entering shell..."
-  # attempt to zero the first 5Mb of the P3 (to get rid of any residual prior data)
+  # attempt to zero the first and last 5Mb of the P3 (to get rid of any residual prior data)
   dd if=/dev/zero of="/dev/$P3" bs=512 count=10240 2>/dev/null
+  dd if=/dev/zero of="/dev/$P3" bs=512 seek=$(( $(blockdev --getsz "/dev/$P3") - 10240 )) count=10240 2>/dev/null
   # Use -F option twice, to avoid any user confirmation in mkfs
   mkfs -t ext4 -v -F -F -O encrypt "/dev/$P3"
   mkdir -p /persist

--- a/pkg/storage-init/storage-init.sh
+++ b/pkg/storage-init/storage-init.sh
@@ -201,9 +201,10 @@ if [ -n "$IMGA" ] && [ -z "$P3" ] && [ -z "$IMGB" ]; then
    partprobe "$DEV"
    partx -a --nr "$IMGB_ID:$P3_ID" "$DEV"
 
-   # attempt to zero the first 5Mb of the P3 (to get rid of any residual prior data)
+   # attempt to zero the first and last 5Mb of the P3 (to get rid of any residual prior data)
    if P3=$(findfs PARTLABEL=P3) && [ -n "$P3" ]; then
       dd if=/dev/zero of="$P3" bs=512 count=10240 2>/dev/null
+      dd if=/dev/zero of="$P3" bs=512 seek=$(( $(blockdev --getsz "$P3") - 10240 )) count=10240 2>/dev/null
    fi
 fi
 


### PR DESCRIPTION
To remove residual zfs data we should wipe P3 from the end as well.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>