### PR TITLE
Fix usage calculation for zfs

### DIFF
--- a/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
+++ b/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
@@ -203,7 +203,7 @@ func createOrUpdateDiskMetrics(ctx *volumemgrContext) {
 	log.Tracef("createOrUpdateDiskMetrics: persistUsage %d, elapse sec %v", persistUsage, time.Since(startPubTime).Seconds())
 
 	for _, path := range types.ReportDirPaths {
-		usage, err := diskmetrics.SizeFromDir(log, path)
+		usage, err := dirUsage(ctx, path)
 		log.Tracef("createOrUpdateDiskMetrics: ReportDirPath %s usage %d err %v", path, usage, err)
 		if err != nil {
 			// Do not report
@@ -225,7 +225,7 @@ func createOrUpdateDiskMetrics(ctx *volumemgrContext) {
 	log.Tracef("createOrUpdateDiskMetrics: DirPaths in persist, elapse sec %v", time.Since(startPubTime).Seconds())
 
 	for _, path := range types.AppPersistPaths {
-		usage, err := diskmetrics.SizeFromDir(log, path)
+		usage, err := dirUsage(ctx, path)
 		log.Tracef("createOrUpdateDiskMetrics: AppPersistPath %s usage %d err %v", path, usage, err)
 		if err != nil {
 			// Do not report

--- a/pkg/pillar/cmd/volumemgr/handlevolumeref.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolumeref.go
@@ -62,6 +62,10 @@ func handleVolumeRefCreate(ctxArg interface{}, key string,
 		if changed {
 			publishVolumeStatus(ctx, vs)
 			updateVolumeRefStatus(ctx, vs)
+			if err := createOrUpdateAppDiskMetrics(ctx, vs); err != nil {
+				log.Errorf("handleVolumeRefCreate(%s): exception while publishing diskmetric. %s",
+					status.Key(), err.Error())
+			}
 		}
 	}
 	log.Functionf("handleVolumeRefCreate(%s) Done", key)
@@ -91,6 +95,10 @@ func handleVolumeRefModify(ctxArg interface{}, key string,
 		}
 		updateVolumeStatusRefCount(ctx, vs)
 		publishVolumeStatus(ctx, vs)
+		if err := createOrUpdateAppDiskMetrics(ctx, vs); err != nil {
+			log.Errorf("handleVolumeRefModify(%s): exception while publishing diskmetric. %s",
+				status.Key(), err.Error())
+		}
 	}
 	log.Functionf("handleVolumeRefModify(%s) Done", key)
 }
@@ -107,6 +115,7 @@ func handleVolumeRefDelete(ctxArg interface{}, key string,
 		updateVolumeStatusRefCount(ctx, vs)
 		publishVolumeStatus(ctx, vs)
 		maybeDeleteVolume(ctx, vs)
+		maybeSpaceAvailable(ctx)
 	}
 	log.Functionf("handleVolumeRefDelete(%s) Done", key)
 }


### PR DESCRIPTION
We should use information from zfs to calculate usage of
/persist/vault/volumes as we use zvol devices not placed in that
directory

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>