### PR TITLE
Fix diag output when proxy is configured

### DIFF
--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -696,10 +696,14 @@ func printOutput(ctx *diagContext) {
 				ifname)
 			continue
 		}
-		// DNS lookup, ping and getUuid calls
-		if !tryLookupIP(ctx, ifname) {
-			continue
+		// DNS lookup - skip if an explicit (i.e. not transparent) proxy is configured.
+		// In that case it is the proxy which is responsible for domain name resolution.
+		if !devicenetwork.IsExplicitProxyConfigured(port.ProxyConfig) {
+			if !tryLookupIP(ctx, ifname) {
+				continue
+			}
 		}
+		// ping and getUuid calls
 		if !tryPing(ctx, ifname, "") {
 			fmt.Fprintf(outfile, "ERROR: %s: ping failed to %s; trying google\n",
 				ifname, ctx.serverNameAndPort)

--- a/pkg/pillar/devicenetwork/devicenetwork.go
+++ b/pkg/pillar/devicenetwork/devicenetwork.go
@@ -25,6 +25,17 @@ func IsProxyConfigEmpty(proxyConfig types.ProxyConfig) bool {
 	return false
 }
 
+// IsExplicitProxyConfigured returns true if EVE is explicitly configured
+// to route traffic via a proxy for a given uplink interface.
+func IsExplicitProxyConfigured(proxyConfig types.ProxyConfig) bool {
+	if len(proxyConfig.Proxies) > 0 ||
+		proxyConfig.Pacfile != "" ||
+		proxyConfig.NetworkProxyEnable {
+		return true
+	}
+	return false
+}
+
 // GetIPAddrs return all IP addresses for an ifindex, and updates the cached info.
 // Also returns the up flag (based on admin status), and hardware address.
 // Leaves mask uninitialized


### PR DESCRIPTION
With explicit proxy configured, the resolution of the controller's
domain name is done by the proxy, not EVE. Actually, in some scenarious
it is possible that local DNS server(s) configured for uplink interfaces
are (intentionally) not able to translate external endpoints.
In such cases, it is expected for the DNS check performed by diag to
fail. Therefore, it makes sense to skip this check if explicit proxy
is being used.

Signed-off-by: Milan Lenco <milan@zededa.com>