### PR TITLE
Mount modules into container-in-vm

### DIFF
--- a/pkg/pillar/containerd/oci.go
+++ b/pkg/pillar/containerd/oci.go
@@ -169,7 +169,17 @@ func (s *ociSpec) AddLoader(volume string) error {
 			Type:        "bind",
 			Source:      volumeRoot,
 			Destination: "/mnt",
-			Options:     []string{"rbind", "rw"}})
+			Options:     []string{"rbind", "rw", "rslave"}})
+
+		if err := os.MkdirAll(filepath.Join(volumeRoot, "modules"), 0600); err != nil {
+			return err
+		}
+
+		spec.Mounts = append(spec.Mounts, specs.Mount{
+			Type:        "bind",
+			Source:      "/lib/modules",
+			Destination: "/mnt/modules",
+			Options:     []string{"rbind", "ro", "rslave"}})
 	}
 	for _, mount := range s.Mounts {
 		// for now we're filtering anything that is not a bind-mount

--- a/pkg/pillar/containerd/oci_test.go
+++ b/pkg/pillar/containerd/oci_test.go
@@ -832,8 +832,9 @@ func TestAddLoader(t *testing.T) {
 	g.Expect(spec2.AddLoader(tmpdir)).ToNot(HaveOccurred())
 	g.Expect(spec2.Root).To(Equal(&specs.Root{Path: filepath.Join(tmpdir, "rootfs"), Readonly: true}))
 	g.Expect(spec2.Linux.CgroupsPath).To(Equal("/foo/bar/baz"))
-	g.Expect(spec2.Mounts[10]).To(Equal(specs.Mount{Destination: "/mnt/rootfs/test", Type: "bind", Source: "/test", Options: []string{"ro"}}))
-	g.Expect(spec2.Mounts[9]).To(Equal(specs.Mount{Destination: "/mnt", Type: "bind", Source: path.Join(tmpdir, ".."), Options: []string{"rbind", "rw"}}))
+	g.Expect(spec2.Mounts[11]).To(Equal(specs.Mount{Destination: "/mnt/rootfs/test", Type: "bind", Source: "/test", Options: []string{"ro"}}))
+	g.Expect(spec2.Mounts[10]).To(Equal(specs.Mount{Destination: "/mnt/modules", Type: "bind", Source: "/lib/modules", Options: []string{"rbind", "ro", "rslave"}}))
+	g.Expect(spec2.Mounts[9]).To(Equal(specs.Mount{Destination: "/mnt", Type: "bind", Source: path.Join(tmpdir, ".."), Options: []string{"rbind", "rw", "rslave"}}))
 	g.Expect(spec2.Mounts[0]).To(Equal(specs.Mount{Destination: "/dev", Type: "bind", Source: "/dev", Options: []string{"rw", "rbind", "rshared"}}))
 }
 

--- a/pkg/xen-tools/initrd/init-initrd
+++ b/pkg/xen-tools/initrd/init-initrd
@@ -106,6 +106,15 @@ then
     done
 fi
 
+# mount modules shared by EVE-OS in /mnt/modules to /lib/modules
+# if /lib/modules inside container is not empty we will silently ignore the content
+# we use overlayfs to allow replacing of modules from user's entrypoint scripts
+# but changes will not persist reboot
+mkdir -p /mnt/rootfs/lib/modules
+mkdir -p /mnt/rootfs/tmp/modules.upper
+mkdir -p /mnt/rootfs/tmp/modules.work
+mount -t overlay -o rw,relatime,lowerdir=/mnt/modules,upperdir=/mnt/rootfs/tmp/modules.upper,workdir=/mnt/rootfs/tmp/modules.work overlay /mnt/rootfs/lib/modules
+
 # Mounting requested volumes
 echo "Executing /mount_disk.sh"
 /mount_disk.sh


### PR DESCRIPTION
We ship modules with EVE-OS, but they are not available inside
container-in-VM. This PR allows user to modprobe shipped modules.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>