### PR TITLE
Check zvols existence in zfsmanager

### DIFF
--- a/pkg/dom0-ztools/rootfs/bin/mdev-zvol.sh
+++ b/pkg/dom0-ztools/rootfs/bin/mdev-zvol.sh
@@ -7,15 +7,26 @@ if [ "$ACTION" = "add" ]; then
     echo "failed to run /lib/udev/zvol_id /dev/$MDEV code: $retVal output: $datasetName"
     exit $retVal
   fi
+  if [ -f "/run/mdev/zvol/$MDEV" ]; then
+    oldDatasetName=$(cat "/run/mdev/zvol/$MDEV")
+    if [ "$oldDatasetName" != "$datasetName" ]; then
+      # clean old link if not match
+      rm "/dev/zvol/$oldDatasetName"
+    fi
+  fi
   #temp directory to map $MDEV->datasetName
   mkdir -p "/run/mdev/zvol"
   echo "$datasetName" >"/run/mdev/zvol/$MDEV"
   mkdir -p "$(dirname "/dev/zvol/$datasetName")"
-  ln -s "/dev/$MDEV" "/dev/zvol/$datasetName"
+  ln -sf "/dev/$MDEV" "/dev/zvol/$datasetName"
 fi
 
 if [ "$ACTION" = "remove" ]; then
-  datasetName=$(cat "/run/mdev/zvol/$MDEV")
-  rm "/run/mdev/zvol/$MDEV"
-  rm "/dev/zvol/$datasetName"
+  if [ -f "/run/mdev/zvol/$MDEV" ]; then
+    datasetName=$(cat "/run/mdev/zvol/$MDEV")
+    rm "/run/mdev/zvol/$MDEV"
+    rm "/dev/zvol/$datasetName"
+  else
+    echo "failed to remove /dev/$MDEV: no temp file"
+  fi
 fi

--- a/pkg/pillar/types/zfs.go
+++ b/pkg/pillar/types/zfs.go
@@ -49,9 +49,9 @@ type ZVolStatus struct {
 	Device  string
 }
 
-// Key is volume UUID which will be unique
+// Key is Dataset with '/' replaced by '_'
 func (status ZVolStatus) Key() string {
-	return status.Device
+	return strings.ReplaceAll(status.Dataset, "/", "_")
 }
 
 // StorageRaidType indicates storage raid type


### PR DESCRIPTION
I can see "Error converting ... to zfs zvol ...: qemu-img failed: exit
status 1, qemu-img: Could not open '...': Could not open '...': No such
file or directory". We rely onto fsnotify and mdev to properly create
symlinks to zvols, but seems we should check existence explicitly and
publish only if we have zvol.
Mdev log indicates that we do add-remove-add sequence, seems we should
enforce sequence handling for mdev.
Also we should not use persist publisher as devices may changed on
reboot and should align Key to not have '/' which leads to problems with
 publishing.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>