### PR TITLE
Encode pubsub key if '/' found

### DIFF
--- a/docs/IPC.md
+++ b/docs/IPC.md
@@ -256,7 +256,7 @@ The specific implementations of the `DriverPublisher` interface and `DriverSubsc
 ##### `socketdriver.Publisher` Updates
 
 When `socketdriver.Publisher` receives updates from its calling `pubsub.Publication`, it saves the data in a file, whose name is determined
-as `<dirName>/<key>.json`.
+as `<dirName>/<key>.json`. If key contains slashes we encode key using hex and store into `<dirName>/<encoded_key>.json.enc` to not create nested directories.
 
 For example, if the `<dirName>` from above was `/persist/tester/configmgr/inputs/`, and the `Publish()` used the key `important`, then
 the filename is `/persist/tester/configmgr/inputs/important.json`.
@@ -269,7 +269,7 @@ _Where_ those files are, i.e. which directory, is determined by whether or not t
 
 ##### `socketdriver.Publisher` Actions
 
-As described above, `socketdriver.Publisher` _always_ writes to a file, whose name is `<dirName>/<key>.json`, whether the `<dirName>` is determined by the
+As described above, `socketdriver.Publisher` _always_ writes to a file, whose name is `<dirName>/<key>.json` or to `<dirName>/<encoded_key>.json.enc` if key contains slashes, whether the `<dirName>` is determined by the
 algorithm above. `persistent` determines where that directory will be placed.
 
 When `socketdriver.Publisher` receives a [`Publish()` call](https://github.com/lf-edge/eve/blob/6160d0e96c72a1954db2a8bdfd99c2fec1972341/pkg/pillar/pubsub/socketdriver/publish.go#L45-L54), it determines the file name

--- a/pkg/pillar/pubsub/const.go
+++ b/pkg/pillar/pubsub/const.go
@@ -1,0 +1,13 @@
+// Copyright (c) 2022 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package pubsub
+
+const (
+	// JSONSuffix expected after key file name
+	JSONSuffix = ".json"
+	// EncodedJSONSuffix indicate that key is encoded
+	EncodedJSONSuffix = JSONSuffix + ".enc"
+	// BackupSuffix expected in the end of file to indicate that it is backup
+	BackupSuffix = ".bak"
+)

--- a/pkg/pillar/pubsub/socketdriver/key_with_slash_test.go
+++ b/pkg/pillar/pubsub/socketdriver/key_with_slash_test.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2022 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package socketdriver_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub/socketdriver"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+type Item struct {
+	Content string
+}
+
+// nolint: paralleltest
+func TestKeyWithSlash(t *testing.T) {
+	key := "/dev/zd0"
+	// Run in a unique directory.
+	rootPath, err := ioutil.TempDir("", "key_with_slash_test")
+	if err != nil {
+		t.Fatalf("TempDir failed: %s", err)
+	}
+	defer os.RemoveAll(rootPath)
+	logger := logrus.StandardLogger()
+	log := base.NewSourceLogObject(logger, "test", 1234)
+
+	driver := socketdriver.SocketDriver{
+		Logger:  logger,
+		Log:     log,
+		RootDir: rootPath,
+	}
+	ctx := Item{}
+	ps := pubsub.New(&driver, logger, log)
+	pub, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName:  "test",
+		TopicType:  Item{},
+		Persistent: true,
+	})
+	if err != nil {
+		t.Fatalf("unable to create publisher: %v", err)
+	}
+	sub, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:   "test",
+		MyAgentName: "test",
+		TopicImpl:   Item{},
+		Persistent:  true,
+		Ctx:         &ctx,
+	})
+	if err != nil {
+		t.Fatalf("unable to create subscriber: %v", err)
+	}
+	err = sub.Activate()
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		for change := range sub.MsgChan() {
+			sub.ProcessChange(change)
+		}
+	}()
+
+	// Second publication, the first value should be copied to a backup file.
+	err = pub.Publish(key, Item{Content: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	encodedKey, encoded := pubsub.MaybeEncodeKey(key)
+	assert.True(t, encoded)
+
+	filePath := filepath.Join(rootPath, "persist", "status", "test", "Item", encodedKey+pubsub.EncodedJSONSuffix)
+	_, err = os.Stat(filePath)
+	if err != nil {
+		t.Fatalf("published item was not persisted: %v", err)
+	}
+
+	items := sub.GetAll()
+	assert.Len(t, items, 1)
+	assert.Contains(t, items, key)
+	assert.Equal(t, Item{Content: "test"}, items[key])
+
+	items = sub.GetAll()
+	assert.Len(t, items, 1)
+	assert.Contains(t, items, key)
+	assert.Equal(t, Item{Content: "test"}, items[key])
+
+	err = pub.Unpublish(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = os.Stat(filePath)
+	if !os.IsNotExist(err) {
+		t.Fatal("unexpected orig file")
+	}
+
+	items = sub.GetAll()
+	assert.Len(t, items, 0)
+}

--- a/pkg/pillar/pubsub/socketdriver/recovery_test.go
+++ b/pkg/pillar/pubsub/socketdriver/recovery_test.go
@@ -59,13 +59,13 @@ func TestRecovery(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	filePath := filepath.Join(rootPath, "persist", "config", "test", "global.json")
+	filePath := filepath.Join(rootPath, "persist", "config", "test", "global"+pubsub.JSONSuffix)
 	_, err = os.Stat(filePath)
 	if err != nil {
 		t.Fatalf("published item was not persisted: %v", err)
 	}
 	// Nothing has been backed up yet, this was the first publication.
-	backupPath := filePath + ".bak"
+	backupPath := filePath + pubsub.BackupSuffix
 	_, err = os.Stat(backupPath)
 	if !os.IsNotExist(err) {
 		t.Fatal("unexpected backup file")

--- a/pkg/pillar/pubsub/util.go
+++ b/pkg/pillar/pubsub/util.go
@@ -4,6 +4,7 @@
 package pubsub
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -96,4 +97,23 @@ func ConnReadCheck(conn net.Conn) error {
 			err)
 	}
 	return sysErr
+}
+
+// MaybeEncodeKey checks and encode key if needed
+func MaybeEncodeKey(key string) (string, bool) {
+	var encoded bool
+	if strings.Contains(key, "/") {
+		key = hex.EncodeToString([]byte(key))
+		encoded = true
+	}
+	return key, encoded
+}
+
+// DecodeKey decode key
+func DecodeKey(key string) (string, error) {
+	b, err := hex.DecodeString(key)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
 }


### PR DESCRIPTION
With '/' in key we hit errors on publishing because we construct file
path based on key. This commit encodes key if '/' found and store in
file with '.enc' suffix.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>