### PR TITLE
Fix object provided as argument of DeleteLogObject

### DIFF
--- a/pkg/pillar/base/logobjecttypes.go
+++ b/pkg/pillar/base/logobjecttypes.go
@@ -359,7 +359,8 @@ func EnsureLogObject(logBase *LogObject, objType LogObjectType, objName string, 
 	return logObject
 }
 
-// DeleteLogObject :
+// DeleteLogObject : Delete log object from internal map
+// logBase must be the same object as for calls to EnsureLogObject and NewLogObject
 func DeleteLogObject(logBase *LogObject, key string) {
 	if logBase == nil {
 		logrus.Fatalf("No logBase for %s", key)
@@ -367,7 +368,8 @@ func DeleteLogObject(logBase *LogObject, key string) {
 	mapKey := logBase.mapKey(key)
 	_, ok := logObjectMap.Load(mapKey)
 	if !ok {
-		logrus.Errorf("DeleteLogObject: LogObject with mapKey %s not found in internal map", mapKey)
+		// use logBase as logger to show agent in source instead of zedbox
+		logBase.Errorf("DeleteLogObject: LogObject with mapKey %s not found in internal map", mapKey)
 		return
 	}
 	logObjectMap.Delete(mapKey)

--- a/pkg/pillar/types/contenttreetypes.go
+++ b/pkg/pillar/types/contenttreetypes.go
@@ -90,7 +90,7 @@ func (config ContentTreeConfig) LogDelete(logBase *base.LogObject) {
 		AddField("max-download-size-int64", config.MaxDownloadSize).
 		Noticef("Content tree config delete")
 
-	base.DeleteLogObject(logObject, config.LogKey())
+	base.DeleteLogObject(logBase, config.LogKey())
 }
 
 // LogKey :

--- a/pkg/pillar/types/verifiertypes.go
+++ b/pkg/pillar/types/verifiertypes.go
@@ -173,7 +173,7 @@ func (status VerifyImageStatus) LogDelete(logBase *base.LogObject) {
 		AddField("filelocation", status.FileLocation).
 		Noticef("VerifyImage status delete")
 
-	base.DeleteLogObject(logObject, status.LogKey())
+	base.DeleteLogObject(logBase, status.LogKey())
 }
 
 // LogKey :


### PR DESCRIPTION
I can see errors "DeleteLogObject: LogObject with mapKey
verifyimage_status-... not found in internal map". Seems we must pass
the same logBase object as we provide when call EnsureLogObject and
NewLogObject. Otherwise, we will not delete objects from logObjectMap.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>