### PR TITLE
Unit-tests fixes

### DIFF
--- a/pkg/pillar/cmd/upgradeconverter/upgradeconverter_test.go
+++ b/pkg/pillar/cmd/upgradeconverter/upgradeconverter_test.go
@@ -106,15 +106,15 @@ func ucContextForTest() *ucContext {
 	//log.SetLevel(log.TraceLevel)
 	var err error
 	ctxPtr := &ucContext{}
-	ctxPtr.persistDir, err = ioutil.TempDir(".", "PersistDir")
+	ctxPtr.persistDir, err = ioutil.TempDir("", "PersistDir")
 	if err != nil {
 		log.Fatalf("Failed to create persistDir. err: %s", err)
 	}
-	ctxPtr.persistConfigDir, err = ioutil.TempDir(".", "PersistConfigDir")
+	ctxPtr.persistConfigDir, err = ioutil.TempDir("", "PersistConfigDir")
 	if err != nil {
 		log.Fatalf("Failed to create persistConfigDir. err: %s", err)
 	}
-	ctxPtr.persistStatusDir, err = ioutil.TempDir(".", "PersistStatusDir")
+	ctxPtr.persistStatusDir, err = ioutil.TempDir("", "PersistStatusDir")
 	if err != nil {
 		log.Fatalf("Failed to create persistStatusDir. err: %s", err)
 	}

--- a/pkg/pillar/cmd/zedagent/parseconfig_test.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig_test.go
@@ -93,7 +93,7 @@ func TestParsePhysicalNetworkAdapters(t *testing.T) {
 				Assigngrp:    "eth-grp-1",
 				Phyaddrs: map[string]string{
 					"ifname":  "eth0",
-					"pcilong": "0000:04:00.0",
+					"pcilong": "0000:f4:00.0",
 				},
 				Usage: zcommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
 			},
@@ -154,7 +154,7 @@ func TestDPCWithError(t *testing.T) {
 				Assigngrp:    "eth-grp-1",
 				Phyaddrs: map[string]string{
 					"ifname":  "eth0",
-					"pcilong": "0000:04:00.0",
+					"pcilong": "0000:f4:00.0",
 				},
 				Usage: zcommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
 			},
@@ -242,7 +242,7 @@ func TestParseVlans(t *testing.T) {
 				Assigngrp:    "eth-grp-1",
 				Phyaddrs: map[string]string{
 					"ifname":  "eth0",
-					"pcilong": "0000:04:00.0",
+					"pcilong": "0000:f4:00.0",
 				},
 				Usage: zcommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
 			},
@@ -421,7 +421,7 @@ func TestParseBonds(t *testing.T) {
 				Assigngrp:    "eth-grp-1",
 				Phyaddrs: map[string]string{
 					"ifname":  "eth0",
-					"pcilong": "0000:04:00.0",
+					"pcilong": "0000:f4:00.0",
 				},
 				Usage: zcommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
 			},
@@ -553,7 +553,7 @@ func TestParseVlansOverBonds(t *testing.T) {
 				Assigngrp:    "eth-grp-1",
 				Phyaddrs: map[string]string{
 					"ifname":  "eth0",
-					"pcilong": "0000:04:00.0",
+					"pcilong": "0000:f4:00.0",
 				},
 				Usage: zcommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
 			},
@@ -740,7 +740,7 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 				Assigngrp:    "eth-grp-1",
 				Phyaddrs: map[string]string{
 					"ifname":  "eth0",
-					"pcilong": "0000:04:00.0",
+					"pcilong": "0000:f4:00.0",
 				},
 				Usage: zcommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
 			},

--- a/pkg/pillar/dpcmanager/dpcmanager_test.go
+++ b/pkg/pillar/dpcmanager/dpcmanager_test.go
@@ -466,7 +466,7 @@ func mockWwan0Status() types.WwanStatus {
 				PhysAddrs: types.WwanPhysAddrs{
 					Interface: "wwan0",
 					USB:       "1:3.3",
-					PCI:       "0000:04:00.0",
+					PCI:       "0000:f4:00.0",
 				},
 				Module: types.WwanCellModule{
 					IMEI:            "353533101772021",
@@ -501,7 +501,7 @@ func mockWwan0Metrics() types.WwanMetrics {
 				PhysAddrs: types.WwanPhysAddrs{
 					Interface: "wwan0",
 					USB:       "1:3.3",
-					PCI:       "0000:04:00.0",
+					PCI:       "0000:f4:00.0",
 				},
 				PacketStats: types.WwanPacketStats{
 					RxBytes:   12345,
@@ -1155,7 +1155,7 @@ func TestWireless(test *testing.T) {
 	t.Expect(wwanDNS.Cellular.SimCards[0].IMSI).To(Equal("310180933695713"))
 	t.Expect(wwanDNS.Cellular.PhysAddrs.Interface).To(Equal("wwan0"))
 	t.Expect(wwanDNS.Cellular.PhysAddrs.USB).To(Equal("1:3.3"))
-	t.Expect(wwanDNS.Cellular.PhysAddrs.PCI).To(Equal("0000:04:00.0"))
+	t.Expect(wwanDNS.Cellular.PhysAddrs.PCI).To(Equal("0000:f4:00.0"))
 
 	// Check published wwan status
 	t.Eventually(func() bool {
@@ -1175,7 +1175,7 @@ func TestWireless(test *testing.T) {
 	metrics := obj.(types.WwanMetrics)
 	t.Expect(metrics.Networks).To(HaveLen(1))
 	t.Expect(metrics.Networks[0].LogicalLabel).To(Equal("mock-wwan0"))
-	t.Expect(metrics.Networks[0].PhysAddrs.PCI).To(Equal("0000:04:00.0"))
+	t.Expect(metrics.Networks[0].PhysAddrs.PCI).To(Equal("0000:f4:00.0"))
 	t.Expect(metrics.Networks[0].PhysAddrs.USB).To(Equal("1:3.3"))
 	t.Expect(metrics.Networks[0].PhysAddrs.Interface).To(Equal("wwan0"))
 	t.Expect(metrics.Networks[0].PacketStats.RxBytes).To(BeEquivalentTo(12345))

--- a/pkg/pillar/hypervisor/kvm_test.go
+++ b/pkg/pillar/hypervisor/kvm_test.go
@@ -908,7 +908,7 @@ func TestCreateDomConfig(t *testing.T) {
 				AssignmentGroup: "eth0-1",
 				Phylabel:        "eth0",
 				Ifname:          "eth0",
-				PciLong:         "0000:03:00.0",
+				PciLong:         "0000:f3:00.0",
 				UsedByUUID:      config.UUIDandVersion.UUID,
 			},
 			{
@@ -1210,7 +1210,7 @@ func TestCreateDomConfig(t *testing.T) {
 
 [device]
   driver = "vfio-pci"
-  host = "03:00.0"
+  host = "f3:00.0"
   bus = "pci.10"
   addr = "0x0"
 [chardev "charserial-usr0"]
@@ -1509,7 +1509,7 @@ func TestCreateDomConfig(t *testing.T) {
 
 [device]
   driver = "vfio-pci"
-  host = "03:00.0"
+  host = "f3:00.0"
   bus = "pci.10"
   addr = "0x0"
 [chardev "charserial-usr0"]
@@ -1536,12 +1536,13 @@ func TestCreateDomConfig(t *testing.T) {
 			Type: types.IoNetEth,
 			Name: "eth1",
 		})
+		// we use device that expected to not exists on the real hardware
 		aa.IoBundleList = append(aa.IoBundleList, types.IoBundle{
 			Type:            types.IoNetEth,
 			AssignmentGroup: "eth1-1",
 			Phylabel:        "eth1",
 			Ifname:          "eth1",
-			PciLong:         "0000:04:00.0",
+			PciLong:         "0000:f4:00.0",
 			UsedByUUID:      config.UUIDandVersion.UUID,
 		})
 		if err := kvmIntel.CreateDomConfig("test", config, disks, &aa, conf); err != nil {
@@ -1819,7 +1820,7 @@ func TestCreateDomConfig(t *testing.T) {
 
 [device]
   driver = "vfio-pci"
-  host = "03:00.0"
+  host = "f3:00.0"
   bus = "pci.10"
   addr = "0x0"
 [device "pci.11"]
@@ -1832,7 +1833,7 @@ func TestCreateDomConfig(t *testing.T) {
 
 [device]
   driver = "vfio-pci"
-  host = "04:00.0"
+  host = "f4:00.0"
   bus = "pci.11"
   addr = "0x0"
 [chardev "charserial-usr0"]
@@ -2106,7 +2107,7 @@ func TestCreateDomConfig(t *testing.T) {
 
 [device]
   driver = "vfio-pci"
-  host = "03:00.0"
+  host = "f3:00.0"
   bus = "pci.10"
   addr = "0x0"
 [chardev "charserial-usr0"]

--- a/pkg/pillar/types/assignableadapters_test.go
+++ b/pkg/pillar/types/assignableadapters_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var aa AssignableAdapters = AssignableAdapters{
+var aa = AssignableAdapters{
 	Initialized: true,
 	IoBundleList: []IoBundle{
 		{
@@ -150,7 +150,7 @@ func TestIoBundleFromPhyAdapter(t *testing.T) {
 		Assigngrp:    "eth-grp-1",
 		Phyaddr: PhysicalAddress{
 			Ifname:  "eth0",
-			PciLong: "0000:04:00.0",
+			PciLong: "0000:f4:00.0",
 			Irq:     "5",
 			Ioports: "3f8-3ff",
 			Serial:  "/dev/ttyS0",
@@ -175,7 +175,7 @@ func TestIoBundleFromPhyAdapter(t *testing.T) {
 	assert.Equal(t, phyAdapter.Usage, ibPtr.Usage)
 }
 
-var aa2 AssignableAdapters = AssignableAdapters{
+var aa2 = AssignableAdapters{
 	Initialized: true,
 	IoBundleList: []IoBundle{
 		{
@@ -183,70 +183,70 @@ var aa2 AssignableAdapters = AssignableAdapters{
 			AssignmentGroup: "eth0-1",
 			Phylabel:        "eth0",
 			Ifname:          "eth0",
-			PciLong:         "0000:02:00.0",
+			PciLong:         "0000:f2:00.0",
 		},
 		{
 			Type:            IoNetEth,
 			AssignmentGroup: "eth0-1",
 			Phylabel:        "eth1",
 			Ifname:          "eth1",
-			PciLong:         "0000:02:00.0",
+			PciLong:         "0000:f2:00.0",
 		},
 		{
 			Type:            IoNetEth,
 			AssignmentGroup: "eth2",
 			Phylabel:        "eth2",
 			Ifname:          "eth2",
-			PciLong:         "0000:02:00.0",
+			PciLong:         "0000:f2:00.0",
 		},
 		{
 			Type:            IoNetEth,
 			AssignmentGroup: "eth3",
 			Phylabel:        "eth3",
 			Ifname:          "eth3",
-			PciLong:         "0000:02:00.1",
+			PciLong:         "0000:f2:00.1",
 		},
 		{
 			Type:            IoNetEth,
 			AssignmentGroup: "eth4-7",
 			Phylabel:        "eth4",
 			Ifname:          "eth4",
-			PciLong:         "0000:04:00.0",
+			PciLong:         "0000:f4:00.0",
 		},
 		{
 			Type:            IoNetEth,
 			AssignmentGroup: "eth4-7",
 			Phylabel:        "eth5",
 			Ifname:          "eth5",
-			PciLong:         "0000:04:00.1",
+			PciLong:         "0000:f4:00.1",
 		},
 		{
 			Type:            IoNetEth,
 			AssignmentGroup: "eth4-7",
 			Phylabel:        "eth6",
 			Ifname:          "eth6",
-			PciLong:         "0000:04:00.2",
+			PciLong:         "0000:f4:00.2",
 		},
 		{
 			Type:            IoNetEth,
 			AssignmentGroup: "eth4-7",
 			Phylabel:        "eth7",
 			Ifname:          "eth7",
-			PciLong:         "0000:04:00.3",
+			PciLong:         "0000:f4:00.3",
 		},
 		{
 			Type:            IoNetEth,
 			AssignmentGroup: "eth8",
 			Phylabel:        "eth8",
 			Ifname:          "eth8",
-			PciLong:         "0000:08:00.0",
+			PciLong:         "0000:f8:00.0",
 		},
 		{
 			Type:            IoNetEth,
 			AssignmentGroup: "eth9",
 			Phylabel:        "eth9",
 			Ifname:          "eth9",
-			PciLong:         "0000:08:00.1",
+			PciLong:         "0000:f8:00.1",
 		},
 		{
 			Type:            IoUSB,
@@ -254,7 +254,7 @@ var aa2 AssignableAdapters = AssignableAdapters{
 			Logicallabel:    "USB0",
 			AssignmentGroup: "USB-A",
 			Ifname:          "",
-			PciLong:         "0000:00:15.0",
+			PciLong:         "0000:f0:15.0",
 		},
 		{
 			Type:            IoUSB,
@@ -262,7 +262,7 @@ var aa2 AssignableAdapters = AssignableAdapters{
 			Logicallabel:    "USB1",
 			AssignmentGroup: "USB-A",
 			Ifname:          "",
-			PciLong:         "0000:00:15.0",
+			PciLong:         "0000:f0:15.0",
 		},
 		{
 			Type:            IoUSB,
@@ -270,7 +270,7 @@ var aa2 AssignableAdapters = AssignableAdapters{
 			Logicallabel:    "USB2",
 			AssignmentGroup: "USB-A",
 			Ifname:          "",
-			PciLong:         "0000:00:15.0",
+			PciLong:         "0000:f0:15.0",
 		},
 		{
 			Type:            IoUSB,
@@ -278,7 +278,7 @@ var aa2 AssignableAdapters = AssignableAdapters{
 			Logicallabel:    "USB3",
 			AssignmentGroup: "USB-A",
 			Ifname:          "",
-			PciLong:         "0000:00:15.0",
+			PciLong:         "0000:f0:15.0",
 		},
 		{
 			Type:            IoUSB,
@@ -286,7 +286,7 @@ var aa2 AssignableAdapters = AssignableAdapters{
 			Logicallabel:    "USB4",
 			AssignmentGroup: "USB-A",
 			Ifname:          "",
-			PciLong:         "0000:00:15.0",
+			PciLong:         "0000:f0:15.0",
 		},
 		{
 			Type:            IoUSB,
@@ -294,7 +294,7 @@ var aa2 AssignableAdapters = AssignableAdapters{
 			Logicallabel:    "USB5",
 			AssignmentGroup: "USB-A",
 			Ifname:          "",
-			PciLong:         "0000:00:15.0",
+			PciLong:         "0000:f0:15.0",
 		},
 		{
 			Type:            IoUSB,
@@ -302,7 +302,7 @@ var aa2 AssignableAdapters = AssignableAdapters{
 			Logicallabel:    "USB6",
 			AssignmentGroup: "USB-C",
 			Ifname:          "",
-			PciLong:         "0000:05:00.0",
+			PciLong:         "0000:f5:00.0",
 		},
 		{
 			Type:            IoCom,
@@ -346,23 +346,23 @@ var aa2 AssignableAdapters = AssignableAdapters{
 			Logicallabel:    "Audio",
 			AssignmentGroup: "",
 			Ifname:          "None",
-			PciLong:         "0000:05:01.f",
+			PciLong:         "0000:f5:01.f",
 		},
 	},
 }
 
 // Same indices as above
 var aa2Errors = []string{
-	"CheckBadAssignmentGroup: eth3 same PCI controller as eth0; pci long 0000:02:00.1 vs 0000:02:00.0",
-	"CheckBadAssignmentGroup: eth3 same PCI controller as eth1; pci long 0000:02:00.1 vs 0000:02:00.0",
-	"CheckBadAssignmentGroup: eth3 same PCI controller as eth2; pci long 0000:02:00.1 vs 0000:02:00.0",
-	"CheckBadAssignmentGroup: eth2 same PCI controller as eth3; pci long 0000:02:00.0 vs 0000:02:00.1",
+	"CheckBadAssignmentGroup: eth3 same PCI controller as eth0; pci long 0000:f2:00.1 vs 0000:f2:00.0",
+	"CheckBadAssignmentGroup: eth3 same PCI controller as eth1; pci long 0000:f2:00.1 vs 0000:f2:00.0",
+	"CheckBadAssignmentGroup: eth3 same PCI controller as eth2; pci long 0000:f2:00.1 vs 0000:f2:00.0",
+	"CheckBadAssignmentGroup: eth2 same PCI controller as eth3; pci long 0000:f2:00.0 vs 0000:f2:00.1",
 	"",
 	"",
 	"",
 	"",
-	"CheckBadAssignmentGroup: eth9 same PCI controller as eth8; pci long 0000:08:00.1 vs 0000:08:00.0",
-	"CheckBadAssignmentGroup: eth8 same PCI controller as eth9; pci long 0000:08:00.0 vs 0000:08:00.1",
+	"CheckBadAssignmentGroup: eth9 same PCI controller as eth8; pci long 0000:f8:00.1 vs 0000:f8:00.0",
+	"CheckBadAssignmentGroup: eth8 same PCI controller as eth9; pci long 0000:f8:00.0 vs 0000:f8:00.1",
 	"",
 	"",
 	"",

--- a/pkg/pillar/types/ifnametopci_test.go
+++ b/pkg/pillar/types/ifnametopci_test.go
@@ -10,9 +10,13 @@ func TestPciLongExists(t *testing.T) {
 		long string
 		val  bool
 	}{
-		"Long value: 0000:03:00.0": {
-			long: "0000:03:00.0",
+		"Long value: 0000:ff:ff.f": {
+			long: "0000:ff:ff.f",
 			val:  false,
+		},
+		"Long value: 0000:00:00.0": {
+			long: "0000:00:00.0",
+			val:  true,
 		},
 	}
 	for testname, test := range testMatrix {


### PR DESCRIPTION
Several fixes for unit tests:

1. Seems we have problem with workerpool test as GC may run or not run in
the background in time of check for workers count. Let's spread the test
work in time and add sleep according to GC intervals.
2. We should not use current directory for pubsub in test as it will be
mounted and we potentially (for example on MacOS) will not have
possibility to use sockets there
3. We use pci addresses in tests and potentially can intersect with HW
which is not expected, i.e. I can see errors in
TestCreateDomConfig/amd64-fml and TestPciLongExists when I have 03:00.0
on device. Let's try to avoid it using bus number from the end of
possible values.