### PR TITLE
Force unmount container rootfs

### DIFF
--- a/pkg/pillar/cas/cas.go
+++ b/pkg/pillar/cas/cas.go
@@ -106,7 +106,9 @@ type CAS interface {
 	PrepareContainerRootDir(rootPath, reference, rootBlobSha string) error
 
 	// UnmountContainerRootDir unmounts container's rootPath.
-	UnmountContainerRootDir(rootPath string) error
+	// with force flag will use MNT_FORCE
+	// if not mounted will not return error
+	UnmountContainerRootDir(rootPath string, force bool) error
 
 	// RemoveContainerRootDir removes contents of a container's rootPath, existing snapshot and reference.
 	RemoveContainerRootDir(rootPath string) error


### PR DESCRIPTION
I can see errors with "device or resource busy" when we try to re-start
container-based app instance occasionally. Let's wait for success in
unmount of rootfs more and try to force unmount the second time.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>