### PR TITLE
Update containerd runtime to v2

### DIFF
--- a/pkg/dom0-ztools/rootfs/etc/containerd/config.toml
+++ b/pkg/dom0-ztools/rootfs/etc/containerd/config.toml
@@ -1,6 +1,12 @@
+version = 2
 state = "/run/containerd"
 root = "/persist/containerd-system-root"
-disabled_plugins = ["cri", "btrfs", "aufs"]
+disabled_plugins = [
+    "io.containerd.grpc.v1.cri",
+    "io.containerd.snapshotter.v1.btrfs",
+    "io.containerd.snapshotter.v1.aufs",
+    "io.containerd.internal.v1.opt"
+]
 
 [grpc]
   address = "/run/containerd/containerd.sock"

--- a/pkg/pillar/build-dev.yml
+++ b/pkg/pillar/build-dev.yml
@@ -15,8 +15,6 @@ config:
     - /:/hostfs
     - /persist:/persist:rshared,rbind
     - /usr/bin/containerd:/usr/bin/containerd
-    - /usr/bin/containerd-shim:/usr/bin/containerd-shim
-    - /usr/bin/containerd-shim-runc-v2:/usr/bin/containerd-shim-runc-v2
   net: host
   capabilities:
     - all

--- a/pkg/pillar/build.yml
+++ b/pkg/pillar/build.yml
@@ -15,8 +15,6 @@ config:
     - /:/hostfs
     - /persist:/persist:rshared,rbind
     - /usr/bin/containerd:/usr/bin/containerd
-    - /usr/bin/containerd-shim:/usr/bin/containerd-shim
-    - /usr/bin/containerd-shim-runc-v2:/usr/bin/containerd-shim-runc-v2
   net: host
   capabilities:
     - all

--- a/pkg/pillar/containerd/containerd.go
+++ b/pkg/pillar/containerd/containerd.go
@@ -51,7 +51,7 @@ const (
 	// ctrdServicesNamespace containerd namespace for running user containers
 	ctrdServicesNamespace = "eve-user-apps"
 	//containerdRunTime - default runtime of containerd
-	containerdRunTime = "io.containerd.runtime.v1.linux"
+	containerdRunTime = "io.containerd.runc.v2"
 	// container config file name
 	imageConfigFilename = "image-config.json"
 	// full OCI runtime spec

--- a/pkg/pillar/rootfs/etc/containerd/user.toml
+++ b/pkg/pillar/rootfs/etc/containerd/user.toml
@@ -1,6 +1,20 @@
+version = 2
 state = "/run/containerd-user"
 root = "/persist/vault/containerd"
-disabled_plugins = ["cri", "btrfs", "aufs"]
+disabled_plugins = [
+    "io.containerd.grpc.v1.cri",
+    "io.containerd.snapshotter.v1.btrfs",
+    "io.containerd.snapshotter.v1.aufs",
+    "io.containerd.runtime.v1.linux",
+    "io.containerd.runtime.v2.task",
+    "io.containerd.service.v1.tasks-service",
+    "io.containerd.internal.v1.restart",
+    "io.containerd.grpc.v1.tasks",
+    "io.containerd.service.v1.containers-service",
+    "io.containerd.grpc.v1.containers",
+    "io.containerd.monitor.v1.cgroups",
+    "io.containerd.snapshotter.v1.native"
+]
 
 [grpc]
   address = "/run/containerd-user/containerd.sock"


### PR DESCRIPTION
Containerd runtime v1 is deprecated and we use v2 runtime for linuxkit
services. Let's move to runtime v2 in pillar and replace v1 shim with
empty file to reduce space usage. Also version 1 of config.toml is
deprecated, we should move to version 2.

When run app instance on EVE-OS:
Before:
```
WARN[2022-07-20T16:07:20.654542386Z] runtime v1 is deprecated since containerd v1.4, consider using runtime v2
INFO[2022-07-20T16:07:20.671019410Z] shim containerd-shim started                  address=/containerd-shim/878eca779708a61fdd37aa98307e86c10c8efc9a8845e0587ff9c10d627e3179.sock debug=false pid=3151
```
After:
```
time="2022-07-20T16:12:07.500883005Z" level=info msg="starting signal loop" namespace=eve-user-apps path=/run/containerd/io.containerd.runtime.v2.task/eve-user-apps/774d8a63-6c63-4d7b-9a49-f90b1b3041bc.1.1 pid=3611
```