### PR TITLE
Reduce workflows run time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [arm64-dirty, ubuntu-20.04]
-        hv: [xen, kvm]
     steps:
       - name: Starting Report
         run: |
@@ -37,10 +36,11 @@ jobs:
         env:
           PR_ID: ${{ github.event.pull_request.number  }}
         run: |
-          make V=1 pkgs
+          make V=1 PRUNE=1 pkgs
           COMMIT_ID=$(git describe --abbrev=8 --always)
           echo "VERSION=0.0.0-pr$PR_ID-$COMMIT_ID" >> $GITHUB_ENV
           echo "TAG=evebuild/danger:pr$PR_ID" >> $GITHUB_ENV
+          echo "ARCH=$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')" >> "$GITHUB_ENV"
       - name: Post package report
         run: |
           echo Disk usage
@@ -49,11 +49,9 @@ jobs:
           free -m
           docker system df
           docker system df -v
-      - name: Build EVE
-        env:
-          HV: ${{ matrix.hv }}
+      - name: Build EVE KVM
         run: |
-          make V=1 ROOTFS_VERSION="$VERSION" HV=$HV eve
+          make V=1 ROOTFS_VERSION="$VERSION" HV=kvm eve
       - name: Post eve build report
         run: |
           echo Disk usage
@@ -63,22 +61,49 @@ jobs:
           docker system df
           docker system df -v
       - name: Export docker container
-        env:
-          HV: ${{ matrix.hv }}
         run: |
-          ARCH=$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')
-          echo "ARCH=$ARCH" >> "$GITHUB_ENV"
-          docker tag "lfedge/eve:$VERSION-$HV" "$TAG-$HV-$ARCH"
-          IMGS="$IMGS $TAG-$HV-$ARCH"
-          docker save $IMGS > eve-$HV-$ARCH.tar
-      - name: Upload EVE
+          docker tag "lfedge/eve:$VERSION-kvm" "$TAG-kvm-${{ env.ARCH }}"
+          docker save "$TAG-kvm-${{ env.ARCH }}" > "eve-kvm-${{ env.ARCH }}.tar"
+      - name: Upload EVE KVM
         uses: actions/upload-artifact@v2
         with:
-          name: eve-${{ matrix.hv }}-${{ env.ARCH }}
-          path: eve-${{ matrix.hv }}-${{ env.ARCH }}.tar
+          name: eve-kvm-${{ env.ARCH }}
+          path: eve-kvm-${{ env.ARCH }}.tar
+      - name: Clean EVE KVM
+        run: |
+          make clean
+          docker rmi "$TAG-kvm-${{ env.ARCH }}" "lfedge/eve:$VERSION-kvm" "lfedge/eve:$VERSION-kvm-${{ env.ARCH }}" ||:
+      - name: Post clean eve KVM report
+        run: |
+          echo Disk usage
+          df -h
+          echo Memory
+          free -m
+          docker system df
+          docker system df -v
+      - name: Build EVE XEN
+        run: |
+          make V=1 ROOTFS_VERSION="$VERSION" HV=xen eve
+      - name: Post eve build report
+        run: |
+          echo Disk usage
+          df -h
+          echo Memory
+          free -m
+          docker system df
+          docker system df -v
+      - name: Export docker container
+        run: |
+          docker tag "lfedge/eve:$VERSION-xen" "$TAG-xen-${{ env.ARCH }}"
+          docker save "$TAG-xen-${{ env.ARCH }}" > "eve-xen-${{ env.ARCH }}.tar"
+      - name: Upload EVE XEN
+        uses: actions/upload-artifact@v2
+        with:
+          name: eve-xen-${{ env.ARCH }}
+          path: eve-xen-${{ env.ARCH }}.tar
       - name: Clean
         if: ${{ always() }}
         run: |
           make clean
-          docker system prune -f -a
+          docker system prune -f -a --volumes
           rm -rf ~/.linuxkit

--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -61,7 +61,7 @@ jobs:
              docker tag  "$CACHE:$TAG-kvm" "lfedge/eve:$TAG-kvm"
              docker tag  "$CACHE:$TAG-kvm" "lfedge/eve:$TAG-kvm-amd64"
           else
-             make -C eve V=1 pkgs
+             make -C eve V=1 PRUNE=1 pkgs
              make -C eve V=1 ROOTFS_VERSION="$TAG" eve
              IMAGES="$(docker images -f reference="lfedge/eve-*" -q)"
              IMAGES="$IMAGES $(docker images -f reference="eve-build-*" -q)"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,7 +66,7 @@ jobs:
           # sadly, our build sometimes times out on network access
           # and running out of disk space: re-trying for 3 times
           for i in 1 2 3; do
-             if make -e V=1 LINUXKIT_PKG_TARGET=push pkgs; then
+             if make -e V=1 LINUXKIT_PKG_TARGET=push PRUNE=1 pkgs; then
                 break
              else
                 # the most likely reason for 'make pkgs' to fail is

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ SSH_KEY=$(CONF_DIR)/ssh.key
 ACCEL=
 # Use TPM device (any non-empty value will trigger using it), i.e. 'make TPM=y run'
 TPM=
+# Prune dangling images after build of package to reduce disk usage (any non-empty value will trigger using it)
+# Be aware that with this flag we will clean all dangling images in system, not only EVE-OS related
+PRUNE=
 # Location of the EVE configuration folder to be used in builds
 CONF_DIR=conf
 # Source of the cloud-init enabled qcow2 Linux VM for all architectures
@@ -690,6 +693,7 @@ get_pkg_build_dev_yml = $(if $(wildcard pkg/$1/build-dev.yml),build-dev.yml,buil
 eve-%: pkg/%/Dockerfile build-tools $(RESCAN_DEPS)
 	$(QUIET): "$@: Begin: LINUXKIT_PKG_TARGET=$(LINUXKIT_PKG_TARGET)"
 	$(QUIET)$(LINUXKIT) $(DASH_V) pkg $(LINUXKIT_PKG_TARGET) $(LINUXKIT_OPTS) -build-yml $(call get_pkg_build_yml,$*) pkg/$*
+	$(QUIET)if [ -n "$(PRUNE)" ]; then docker image prune -f; fi
 	$(QUIET): "$@: Succeeded (intermediate for pkg/%)"
 
 images/rootfs-%.yml.in: images/rootfs.yml.in FORCE

--- a/pkg/alpine/Dockerfile
+++ b/pkg/alpine/Dockerfile
@@ -27,7 +27,7 @@ RUN for p in */*; do build-cache.sh "$p" "/mirror/$(dirname "$p")" $(cat "$p") ;
 # set the default repository to use
 RUN cp /mirror/${ALPINE_VERSION}/rootfs/etc/apk/repositories /etc/apk && apk update
 
-FROM ${EVE_BUILDER_IMAGE}
+FROM ${EVE_BUILDER_IMAGE} as compactor
 
 COPY --from=cache /etc/apk/repositories* /etc/apk/
 COPY --from=cache /etc/apk/keys /etc/apk/keys/
@@ -35,3 +35,9 @@ COPY --from=cache /mirror /mirror/
 COPY eve-alpine-deploy.sh go-compile.sh /bin/
 
 RUN apk update && apk upgrade -a
+
+# we merge layers in previous step
+# so we should avoid large possible diff
+FROM scratch
+COPY --from=compactor / /
+CMD ["/bin/sh"]


### PR DESCRIPTION
Usage of distinct workers to build separate HV is sub-optimal as they
are different only in rootfs and we spend time building the same set
of packages. So let's re-use worker.
Also we are possibly limited in space and should try to remove dangling
images if they are not needed.
We build eve-alpine using layers of previous eve-alpine. In that case we
end with sum of layers as they are different. We should use separate
step to merge all layers into one.