### PR TITLE
Wait more for newlog and vlans

### DIFF
--- a/pkg/newlog/Dockerfile
+++ b/pkg/newlog/Dockerfile
@@ -1,6 +1,6 @@
 FROM lfedge/eve-alpine:6.7.0 as build
 ENV BUILD_PKGS git go
-ENV PKGS busybox
+ENV PKGS coreutils
 RUN eve-alpine-deploy.sh
 
 # FIXME bump eve-alpine to alpine 3.14

--- a/pkg/newlog/newlogd-init.sh
+++ b/pkg/newlog/newlogd-init.sh
@@ -1,29 +1,44 @@
 #!/bin/sh
 
+echo "$(date --iso-8601=ns --utc) starting newlogd"
 /usr/bin/newlogd &
-mkdir -p /run/watchdog/pid
-touch /run/watchdog/pid/newlogd.pid
+NEWLOGD_PID=$!
+echo "$(date --iso-8601=ns --utc) newlogd is starting..., pid $NEWLOGD_PID"
 
-NEWLOGD_PID=$(cat /run/newlogd.pid)
-LOOP_COUNT=0
-while [ -z "$NEWLOGD_PID" ] && [ "$LOOP_COUNT" -le 30 ];
+NEWLOGD_TOUCH_FILE="/run/newlogd.touch"
+SECONDS_PASSED=0
+while [ ! -f "$NEWLOGD_TOUCH_FILE" ] && [ "$SECONDS_PASSED" -le 60 ];
 do
-    sleep 1
-    LOOP_COUNT=$((LOOP_COUNT + 1))
-    NEWLOGD_PID=$(cat /run/newlogd.pid)
+    echo "$(date --iso-8601=ns --utc) waiting for $NEWLOGD_TOUCH_FILE"
+    sleep 3
+    SECONDS_PASSED=$((SECONDS_PASSED + 3))
 done
+
+if [ ! -f "$NEWLOGD_TOUCH_FILE" ]; then
+    echo "$(date --iso-8601=ns --utc) gave up waiting for $NEWLOGD_TOUCH_FILE"
+else
+    echo "$(date --iso-8601=ns --utc) waited $SECONDS_PASSED seconds for $NEWLOGD_TOUCH_FILE"
+fi
+
+# subject for watchdog
+mkdir -p /run/watchdog/pid /run/watchdog/file
+touch /run/watchdog/pid/newlogd.pid /run/watchdog/file/newlogd.touch
 
 NEWLOGD_RESTART_COUNT=0
 
-echo "newlogd init.sh starting..., newlogd pid $NEWLOGD_PID"
 while true;
 do
     sleep 10
     PID=$(pgrep /usr/bin/newlogd)
-    if [ "$NEWLOGD_RESTART_COUNT" -eq "0" ] && { [ "$PID" != "$NEWLOGD_PID" ] || [ -z "$NEWLOGD_PID" ]; }; then
+    if [ "$NEWLOGD_RESTART_COUNT" -eq "0" ] && [ "$PID" != "$NEWLOGD_PID" ]; then
+        if [ -n "$PID" ]; then
+          # kill old process
+          echo "$(date --iso-8601=ns --utc) kill old newlogd with pid $PID"
+          kill -9 "$PID"
+        fi
         ## restart it once to pickup the stack trace of newlogd
         /usr/bin/newlogd -r &
         NEWLOGD_RESTART_COUNT=$((NEWLOGD_RESTART_COUNT + 1))
-        echo "newlogd init.sh restarted"
+        echo "$(date --iso-8601=ns --utc) newlogd restarted"
     fi
 done

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1402,7 +1402,8 @@ func doActivateTail(ctx *domainContext, status *types.DomainStatus,
 	status.Activated = true
 	err = setupVlans(status.VifList)
 	if err != nil {
-		log.Errorf("setupVlans failed: %v", err)
+		log.Errorf("doActivateTail(%v) setupVlans failed for %s: %v",
+			status.UUIDandVersion, status.DisplayName, err)
 	}
 	log.Functionf("doActivateTail(%v) done for %s",
 		status.UUIDandVersion, status.DisplayName)
@@ -1433,8 +1434,8 @@ func enableVlanFiltering(bridgeName string) error {
 
 // TODO Move this to zedrouter.
 func setupVlans(vifList []types.VifInfo) error {
-	deadline := time.Now().Add(20 * time.Second)
-	const delay = 500 * time.Millisecond
+	deadline := time.Now().Add(time.Minute)
+	const delay = time.Second
 	for _, vif := range vifList {
 		if vif.Vlan.End == 0 {
 			// VLAN not configured for this interface


### PR DESCRIPTION
Tests for RPi (ROL) indicate that our timeouts for newlog and vlans do not cover real workloads (for slowest case with RPi running xen and zfs).