### PR TITLE
Docs and errors about keys with slashes

### DIFF
--- a/docs/IPC.md
+++ b/docs/IPC.md
@@ -256,7 +256,7 @@ The specific implementations of the `DriverPublisher` interface and `DriverSubsc
 ##### `socketdriver.Publisher` Updates
 
 When `socketdriver.Publisher` receives updates from its calling `pubsub.Publication`, it saves the data in a file, whose name is determined
-as `<dirName>/<key>.json`.
+as `<dirName>/<key>.json`. Key must not contain slashes and should fit max filesize limit (not exceed 255 symbols).
 
 For example, if the `<dirName>` from above was `/persist/tester/configmgr/inputs/`, and the `Publish()` used the key `important`, then
 the filename is `/persist/tester/configmgr/inputs/important.json`.

--- a/pkg/pillar/pubsub/socketdriver/publish.go
+++ b/pkg/pillar/pubsub/socketdriver/publish.go
@@ -42,10 +42,19 @@ type Publisher struct {
 	rootDir        string
 }
 
+const maxFileName = 255
+
 // Publish publish a key-value pair
 func (s *Publisher) Publish(key string, item []byte) error {
 	if len(item) == 0 {
 		return fmt.Errorf("empty content published for %s/%s", s.name, key)
+	}
+	if strings.Contains(key, "/") {
+		return fmt.Errorf("key(%s) must not contain slashes", key)
+	}
+	if len(key+".json") > maxFileName {
+		return fmt.Errorf("key(%s) exceed maximum filename limit of %d bytes: %d",
+			key, maxFileName, len(key+".json"))
 	}
 	fileName := s.dirName + "/" + key + ".json"
 	s.log.Tracef("Publish writing %s\n", fileName)


### PR DESCRIPTION
We must not use key with slashes or with length more than allowed for
file name. Let's make errors more readable and add note in docs.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>