### PR TITLE
dom0-ztools: Add version command

### DIFF
--- a/pkg/dom0-ztools/rootfs/bin/eve
+++ b/pkg/dom0-ztools/rootfs/bin/eve
@@ -19,6 +19,7 @@ Welcome to EVE!
             persist attach <disk>
             firewall drop
             verbose on|off
+            version
 __EOT__
   exit 1
 }
@@ -117,6 +118,10 @@ __EOT__
               *) help
                  ;;
           esac
+          ;;
+ version)
+          v=$(cat /run/eve-release)
+          echo "$v"
           ;;
  persist) case "$2" in
                list) list_partitions


### PR DESCRIPTION
Users might not be aware about /run/eve-release file in order to check
EVE's running version. This commit adds a "version" option to eve command
line, so users can use "eve version" to easily retrieve the version from
/run/eve-release.

Signed-off-by: Renê de Souza Pinto <rene@renesp.com.br>