### PR TITLE
pkg/fw: Add wifi firmware package for Raspberry pi

### DIFF
--- a/pkg/fw/Dockerfile
+++ b/pkg/fw/Dockerfile
@@ -12,6 +12,7 @@ RUN apk add --no-cache \
     linux-firmware-nvidia \
     linux-firmware-rtl_nic \
     linux-firmware-brcm \
+    linux-firmware-cypress \
     linux-firmware-ti-connectivity
 
 FROM busybox as compactor
@@ -43,6 +44,7 @@ COPY --from=build /lib/firmware/iwlwifi-QuZ-a0-hr-b0* /lib/firmware/
 COPY --from=build /lib/firmware/rtl_nic/* /lib/firmware/rtl_nic/
 # Firmware for Raspberry Pi4 and Broadcom wifi
 COPY --from=build /lib/firmware/brcm /lib/firmware/brcm
+COPY --from=build /lib/firmware/cypress /lib/firmware/cypress
 # ath10k firmware
 COPY --from=build /lib/firmware/ath10k /lib/firmware/ath10k
 # firmware for HiKey


### PR DESCRIPTION
Commit 86404c6c8d548e6d3d0ecc9361c744a6ee975aa9 moved firmware blobs to
packages. However, WiFi firmware files used by Raspberry pi are present on
the sub package linux-firmware-cypress, which was not included in
Dockerfile. This commit adds the missing package.

Signed-off-by: Renê de Souza Pinto <rene@renesp.com.br>