### PR TITLE
Use lock for PoolOpenAll

### DIFF
--- a/pkg/pillar/cmd/zfsmanager/zfsmanager.go
+++ b/pkg/pillar/cmd/zfsmanager/zfsmanager.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -51,6 +52,7 @@ type zfsContext struct {
 	subDisksConfig         pubsub.Subscription
 	disksProcessingTrigger chan interface{}
 	zVolDeviceEvents       *base.LockedStringMap // stores device->zVolDeviceEvent mapping to check and publish
+	zfsIterLock            sync.Mutex
 }
 
 // Run - an zfs run

--- a/pkg/pillar/cmd/zfsmanager/zfsstoragemetrics.go
+++ b/pkg/pillar/cmd/zfsmanager/zfsstoragemetrics.go
@@ -32,6 +32,9 @@ func storageMetricsPublisher(ctxPtr *zfsContext) {
 }
 
 func collectAndPublishStorageMetrics(ctxPtr *zfsContext) {
+	log.Functionf("collectAndPublishStorageMetrics start")
+	ctxPtr.zfsIterLock.Lock()
+	defer ctxPtr.zfsIterLock.Unlock()
 	zpoolList, err := libzfs.PoolOpenAll()
 	if err != nil {
 		log.Errorf("get zpool list for collect metrics failed %v", err)
@@ -50,4 +53,5 @@ func collectAndPublishStorageMetrics(ctxPtr *zfsContext) {
 			}
 		}
 	}
+	log.Functionf("collectAndPublishStorageMetrics Done")
 }

--- a/pkg/pillar/cmd/zfsmanager/zfsstoragestatus.go
+++ b/pkg/pillar/cmd/zfsmanager/zfsstoragestatus.go
@@ -34,6 +34,8 @@ func storageStatusPublisher(ctxPtr *zfsContext) {
 
 func collectAndPublishStorageStatus(ctxPtr *zfsContext) {
 	log.Functionf("collectAndPublishStorageStatus start")
+	ctxPtr.zfsIterLock.Lock()
+	defer ctxPtr.zfsIterLock.Unlock()
 	zfsVersion, err := zfs.GetZfsVersion()
 	if err != nil {
 		log.Errorf("error: %v", err)


### PR DESCRIPTION
I can see panic from libzfs

uu_avl_find(hdl->libzfs_ns_avl, cn, NULL, &where) == NULL
ASSERT at libzfs_config.c:205:namespace_reload()SIGABRT: abort

Seems namespace_reload function is expected to not run concurrently on
the same handler pointer, we should use lock for iteration functions
(PoolOpenAll and DatasetOpenAll).

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>