### PR TITLE
Run only one EdenGCP at a time

### DIFF
--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -6,6 +6,10 @@ on:  # yamllint disable-line rule:truthy
       - Publish
     types:
       - completed
+
+concurrency:
+  group: ${{ github.workflow }}
+
 # yamllint disable rule:line-length
 jobs:
   integration:


### PR DESCRIPTION
We are limited in ROL devices, so should limit concurrent runs of
EdenGCP workflows. Using concurrency group we will run one workflow at a
 time. According to guthub's docs "When a concurrent job or workflow is
 queued, if another job or workflow using the same concurrency group in
 the repository is in progress, the queued job or workflow will be
 pending. Any previously pending job or workflow in the concurrency
 group will be canceled.". But we use snapshot version of EVE-OS, so it
 is expected behaviour.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>