### PR TITLE
wwan: configure MTU requested by the network

### DIFF
--- a/pkg/wwan/usr/bin/wwan-init.sh
+++ b/pkg/wwan/usr/bin/wwan-init.sh
@@ -220,6 +220,9 @@ bringup_iface() {
     return 1
   fi
   ifconfig "$IFACE" "$IP" netmask "$SUBNET" pointopoint "$GW"
+  if [ -n "$MTU" ]; then
+    ip link set mtu "$MTU" dev "$IFACE"
+  fi
   # NOTE we may want to disable /proc/sys/net/ipv4/conf/default/rp_filter instead
   #      Verify it by cat /proc/net/netstat | awk '{print $80}'
   ip route add default via "$GW" dev "$IFACE" metric 65000

--- a/pkg/wwan/usr/bin/wwan-mbim.sh
+++ b/pkg/wwan/usr/bin/wwan-mbim.sh
@@ -130,6 +130,7 @@ mbim_get_ip_settings() {
   GW="$(echo "$SETTINGS" | jq -r .ipv4.gateway)"
   DNS1="$(echo "$SETTINGS" | jq -r .ipv4.dns0)"
   DNS2="$(echo "$SETTINGS" | jq -r .ipv4.dns1)"
+  MTU="$(echo "$SETTINGS" | jq -r .mtu)"
 }
 
 mbim_start_network() {

--- a/pkg/wwan/usr/bin/wwan-qmi.sh
+++ b/pkg/wwan/usr/bin/wwan-qmi.sh
@@ -221,6 +221,7 @@ qmi_get_ip_settings() {
   GW=$(parse_modem_attr "$SETTINGS" "IPv4 gateway address")
   DNS1=$(parse_modem_attr "$SETTINGS" "IPv4 primary DNS")
   DNS2=$(parse_modem_attr "$SETTINGS" "IPv4 secondary DNS")
+  MTU=$(parse_modem_attr "$SETTINGS" "MTU")
 }
 
 qmi_start_network() {


### PR DESCRIPTION
Currently we leave the default `MTU=1500` configured on the wwan
interface. However, we should respect the MTU settings required by the
network to which the modem has connected.

Signed-off-by: Milan Lenco <milan@zededa.com>