### PR TITLE
Build NuGet package with EVE-OS API

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -55,6 +55,10 @@ jobs:
           rm -rf assets && mkdir assets && cd assets
           docker run "$EVE" rootfs > rootfs.img
           docker run "$EVE" installer_net | tar -xvf -
+          if [ "${{ env.ARCH }}" = amd64 ]; then
+            # it is new feature, old releases may not support this
+            docker run "$EVE" nupkg > LFEdge.EVE.API.nupkg && echo "NUPKG=true" >> "$GITHUB_ENV" || echo "not supported"
+          fi
       - name: Create direct iPXE config
         run: |
           URL="${{ github.event.repository.html_url }}/releases/download/${{ env.TAG }}/${{ env.ARCH }}."
@@ -205,4 +209,15 @@ jobs:
           upload_url: ${{ steps.create-release.outputs.result }}
           asset_path: assets/ipxe.efi.ip.cfg
           asset_name: ${{ env.ARCH }}.ipxe.efi.ip.cfg
+          asset_content_type: application/octet-stream
+      - name: Upload nupkg for the release
+        id: upload-nupkg-asset
+        if: ${{ env.NUPKG == 'true' }}
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.result }}
+          asset_path: assets/LFEdge.EVE.API.nupkg
+          asset_name: LFEdge.EVE.API.${{ env.TAG }}.nupkg
           asset_content_type: application/octet-stream

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,7 @@ KERNEL_IMG=$(INSTALLER)/kernel
 IPXE_IMG=$(INSTALLER)/ipxe.efi
 EFI_PART=$(INSTALLER)/EFI
 BOOT_PART=$(INSTALLER)/boot
+NUPKG_IMG=$(INSTALLER)/LFEdge.EVE.API.nupkg
 
 DEVICETREE_DTB_amd64=
 DEVICETREE_DTB_arm64=$(DIST)/dtb/eve.dtb
@@ -524,6 +525,11 @@ $(ROOTFS_IMG): images/rootfs-$(HV).yml | $(INSTALLER)
 	        echo "ERROR: size of $@ is greater than 250MB (bigger than allocated partition)" && exit 1 || :
 	$(QUIET): $@: Succeeded
 
+$(NUPKG_IMG): | $(INSTALLER)
+	$(QUIET): $@: Begin
+	./tools/makenupkg.sh $(ROOTFS_VERSION) $@
+	$(QUIET): $@: Succeeded
+
 $(LIVE).raw: $(BOOT_PART) $(EFI_PART) $(ROOTFS_IMG) $(CONFIG_IMG) $(PERSIST_IMG) | $(INSTALLER)
 	./tools/makeflash.sh -C 350 $| $@ $(PART_SPEC)
 	$(QUIET): $@: Succeeded
@@ -568,7 +574,7 @@ pkg/%: eve-% FORCE
 $(RUNME) $(BUILD_YML):
 	cp pkg/eve/$(@F) $@
 
-EVE_ARTIFACTS=$(BIOS_IMG) $(EFI_PART) $(CONFIG_IMG) $(PERSIST_IMG) $(INITRD_IMG) $(INSTALLER_IMG) $(ROOTFS_IMG) fullname-rootfs $(BOOT_PART)
+EVE_ARTIFACTS=$(BIOS_IMG) $(EFI_PART) $(CONFIG_IMG) $(PERSIST_IMG) $(INITRD_IMG) $(INSTALLER_IMG) $(ROOTFS_IMG) fullname-rootfs $(BOOT_PART) $(NUPKG_IMG)
 eve: $(INSTALLER) $(EVE_ARTIFACTS) current $(RUNME) $(BUILD_YML) | $(BUILD_DIR)
 	$(QUIET): "$@: Begin: EVE_REL=$(EVE_REL), HV=$(HV), LINUXKIT_PKG_TARGET=$(LINUXKIT_PKG_TARGET)"
 	cp images/*.yml $|

--- a/api/LFEdge.EVE.API.csproj
+++ b/api/LFEdge.EVE.API.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <PackageId>LFEdge.EVE.API</PackageId>
+    <Company>Zededa</Company>
+    <Authors>Zededa</Authors>
+    <Copyright>2022, Zededa, Inc</Copyright>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
+    <Description>EVE-OS API definitions</Description>
+    <RepositoryUrl>https://github.com/lf-edge/eve.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageProjectUrl>https://www.lfedge.org/projects/eve</PackageProjectUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Google.Protobuf" Version="3.19.4" />
+    <PackageReference Include="Grpc.Tools" Version="2.47.0">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Protobuf Include="proto\**\*.proto" ProtoRoot="proto"/>
+  </ItemGroup>
+</Project>

--- a/api/README.md
+++ b/api/README.md
@@ -11,7 +11,7 @@ This directory defines only the API itself. It is in two parts:
 * message definitions as [protobufs](https://developers.google.com/protocol-buffers/) in subdirectories to this directory
 
 To use the protobufs, you need to compile them into the target language of your choice, such as Go, Python or Node.
-The actual compiled language-specific libraries are in the [go/](go/) and [python/](python/) folders of this repository, and are compiled via the command `make proto` in the root of this repository.
+The actual compiled language-specific libraries are in the [go/](./go) and [python/](./python) folders of this repository, and are compiled via the command `make proto` in the root of this repository.
 
 In addition to the language-specific libraries, `make proto` generates visualizations of the protobuf structure,
 beginning with the root of an edge device config. These are

--- a/pkg/eve/runme.sh
+++ b/pkg/eve/runme.sh
@@ -48,7 +48,7 @@ dump() {
 
 do_help() {
 cat <<__EOT__
-Usage: docker run [-v <option>] lfedge/eve [-f <fmt>] version|rootfs|live|installer_raw|installer_iso|installer_net
+Usage: docker run [-v <option>] lfedge/eve [-f <fmt>] version|rootfs|live|installer_raw|installer_iso|installer_net|nupkg
 
 The artifact will be produced on stdout, so don't forget to redirect
 it to a file or use the /out option below.
@@ -92,6 +92,13 @@ docker run --rm lfedge/eve -f qcow2 installer_iso > eve-iso.img
 
 The two raw formats "live" and "installer_raw" support an optional
 last argument specifying the size of the image in Mb.
+
+Option nupkg allows you to extract nuget package of EVE-OS API. Only arm64 and amd64 supported now.
+Be aware that nupkg file name should have LFEdge.EVE.API.\$eve_version.nupkg notation to use from local source.
+
+Example:
+eve_version=\$(docker run lfedge/eve version)
+docker run --rm lfedge/eve nupkg > LFEdge.EVE.API.\$eve_version.nupkg
 __EOT__
   exit 0
 }
@@ -162,6 +169,17 @@ __EOT__
     tar -C / -rhvf /output.net boot.scr.uimg overlays u-boot.bin bcm2711-rpi-4-b.dtb config.txt fixup4.dat start4.elf
   fi
   dump /output.net installer.net
+}
+
+do_nupkg() {
+  case $(uname -m) in
+  x86_64) ;;
+  aarch64) ;;
+  *)
+    echo "Unsupported architecture $(uname -m)." && exit 1
+    ;;
+  esac
+  dump /bits/LFEdge.EVE.API.nupkg LFEdge.EVE.API.nupkg
 }
 
 # Lets' parse global options first

--- a/tools/makenupkg.sh
+++ b/tools/makenupkg.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+EVE="$(cd "$(dirname "$0")" && pwd)/../"
+SOURCE="$(cd "$EVE/api" && pwd)"
+EVE_OS_VERSION="$1"
+OUT_FILE=$(basename "$2")
+OUT_FULL_PATH="$(cd "$(dirname "$2")" && pwd)/$OUT_FILE"
+
+if [ ! -d "$SOURCE" ] || [ $# -lt 2 ]; then
+  echo "Usage: $0 <version> <output nupkg file>"
+  exit 1
+fi
+
+case $(uname -m) in
+x86_64) ;;
+aarch64) ;;
+*)
+  echo "Unsupported architecture $(uname -m). Nothing to do" && exit 0
+  ;;
+esac
+
+: >"$OUT_FULL_PATH"
+
+cat <<__EOT__ | docker run --rm -v "$SOURCE:/api" -v "$OUT_FULL_PATH:/$OUT_FILE" -i mcr.microsoft.com/dotnet/sdk:6.0 sh
+   TEMP_DIR="\$(mktemp -d)"
+   cp -r /api/* "/\$TEMP_DIR"
+   cd "/\$TEMP_DIR"
+   # replace relative paths inside of README.md
+   sed -i 's@(\.@(https://github.com/lf-edge/eve/blob/master/api@g' README.md
+   dotnet build LFEdge.EVE.API.csproj -c Release /property:Version="$EVE_OS_VERSION" -o "/\$TEMP_DIR"
+   cp "/\$TEMP_DIR/LFEdge.EVE.API.$EVE_OS_VERSION.nupkg" /"$OUT_FILE"
+__EOT__


### PR DESCRIPTION
To use EVE API inside C# projects it would be useful to build and share
NuGet package to import it into the project directly.

We can extract nupkg with commands:

eve_version=$(docker run lfedge/eve version)
docker run --rm lfedge/eve nupkg > LFEdge.EVE.API.$eve_version.nupkg

And will upload nupkg in assets of release.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>