### PR TITLE
Log sending of EscrowData

### DIFF
--- a/pkg/pillar/cmd/vaultmgr/vaultmgr.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgr.go
@@ -1107,7 +1107,7 @@ func publishVaultKey(ctx *vaultMgrContext, vaultName string) error {
 	//otherwise we leave it empty
 	if etpm.IsTpmEnabled() {
 		if !ctx.defaultVaultUnlocked {
-			log.Errorf("Vault is not yet unlocked, waiting for Controller key")
+			log.Errorf("Vault is not yet unlocked")
 			return nil
 		}
 		keyBytes, err := retrieveTpmKey(true)

--- a/pkg/pillar/cmd/zedagent/attesttask.go
+++ b/pkg/pillar/cmd/zedagent/attesttask.go
@@ -70,6 +70,7 @@ const (
 
 //One shot send, if fails, return an error to the state machine to retry later
 func trySendToController(attestReq *attest.ZAttestReq, iteration int) (*http.Response, []byte, types.SenderResult, error) {
+	log.Noticef("trySendToController type %d", attestReq.ReqType)
 	data, err := proto.Marshal(attestReq)
 	if err != nil {
 		log.Fatal("SendInfoProtobufStr proto marshaling error: ", err)
@@ -444,7 +445,7 @@ func (server *VerifierImpl) SendAttestEscrow(ctx *zattest.Context) error {
 
 	//Increment Iteration for interface rotation
 	attestCtx.Iteration++
-	log.Tracef("Sending Escrow data")
+	log.Noticef("[ATTEST] Sending Escrow data len %d", len(key.Key))
 
 	_, contents, senderStatus, err := trySendToController(attestReq, attestCtx.Iteration)
 	if err != nil || senderStatus != types.SenderStatusNone {
@@ -746,6 +747,8 @@ func handleEncryptedKeyFromDeviceImpl(ctxArg interface{}, key string,
 	if !ok {
 		log.Fatalf("[ATTEST] Unexpected pub type %T", vaultKeyArg)
 	}
+	log.Noticef("handleEncryptedKeyFromDeviceImpl len %d",
+		len(vaultKey.EncryptedVaultKey))
 
 	if ctx.attestCtx == nil {
 		log.Fatalf("[ATTEST] Uninitialized access to attestCtx")


### PR DESCRIPTION
We've seen one case where the controller didn't have EscrowData and the device could not unseal the storage key due to the PCRs being different. This PR improves on the loggin should this case happen again.