### PR TITLE
[TEST] Revert "Use xz compression for squashfs"

### DIFF
--- a/pkg/uefi/Dockerfile
+++ b/pkg/uefi/Dockerfile
@@ -26,7 +26,8 @@ WORKDIR /ws
 RUN git submodule update --init
 COPY build.sh /ws/
 COPY patch /ws/patch
-RUN for p in /ws/patch/*.patch ; do patch -p1 < "$p" || exit 1 ; done
+RUN for p in /ws/patch/*.patch ; do patch -p1 < "$p"; echo "$p"; done
+RUN sed -i 's/DEFINE DEBUG_PRINT_ERROR_LEVEL = 0x8000004F/DEFINE DEBUG_PRINT_ERROR_LEVEL = 0x00000001/g' ArmVirtPkg/ArmVirt.dsc.inc
 RUN ln -s python3 /usr/bin/python
 RUN ./build.sh
 

--- a/pkg/uefi/build.sh
+++ b/pkg/uefi/build.sh
@@ -13,13 +13,13 @@ case $(uname -m) in
              cp /opensbi/build/platform/generic/firmware/fw_payload.bin OVMF_VARS.fd
              cp /opensbi/build/platform/generic/firmware/fw_jump.bin OVMF.fd
              ;;
-    aarch64) build -b RELEASE -t GCC5 -a AARCH64 -p ArmVirtPkg/ArmVirtQemu.dsc -D TPM2_ENABLE=TRUE -D TPM2_CONFIG_ENABLE=TRUE
-             cp Build/ArmVirtQemu-AARCH64/RELEASE_GCC5/FV/QEMU_EFI.fd OVMF.fd
-             cp Build/ArmVirtQemu-AARCH64/RELEASE_GCC5/FV/QEMU_VARS.fd OVMF_VARS.fd
+    aarch64) build -b DEBUG -t GCC5 -a AARCH64 -p ArmVirtPkg/ArmVirtQemu.dsc -D TPM2_ENABLE=TRUE -D TPM2_CONFIG_ENABLE=TRUE -D DEBUG_ON_SERIAL_PORT
+             cp Build/ArmVirtQemu-AARCH64/DEBUG_GCC5/FV/QEMU_EFI.fd OVMF.fd
+             cp Build/ArmVirtQemu-AARCH64/DEBUG_GCC5/FV/QEMU_VARS.fd OVMF_VARS.fd
              # now let's build PVH UEFI kernel
              make -C BaseTools/Source/C
-             build -b RELEASE -t GCC5 -a AARCH64  -p ArmVirtPkg/ArmVirtXen.dsc
-             cp Build/ArmVirtXen-AARCH64/RELEASE_*/FV/XEN_EFI.fd OVMF_PVH.fd
+             build -b DEBUG -t GCC5 -a AARCH64  -p ArmVirtPkg/ArmVirtXen.dsc
+             cp Build/ArmVirtXen-AARCH64/DEBUG_*/FV/XEN_EFI.fd OVMF_PVH.fd
              ;;
      x86_64) build -b RELEASE -t GCC5 -a X64 -p OvmfPkg/OvmfPkgX64.dsc -D TPM_ENABLE=TRUE -D TPM_CONFIG_ENABLE=TRUE
              cp Build/OvmfX64/RELEASE_*/FV/OVMF*.fd .


### PR DESCRIPTION
After we switched the squashfs compression type to xz, all workflow edenGCP processes were constantly failing on rpi4. This is likely due to rpi4 not having the required performance to work properly, this PR is needed to get EVE-OS images without XZ compression for further testing.

Signed-off-by: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>