### PR TITLE
Remove chroot for zpool and zfs commands

### DIFF
--- a/pkg/pillar/cmd/vaultmgr/vaultmgr.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgr.go
@@ -712,7 +712,7 @@ func setupDefaultVault(ctx *vaultMgrContext) error {
 			//No TPM or TPM lacks required features
 			if persistFsType == types.PersistZFS {
 				args := getCreateParams(defaultSecretDataset, false)
-				if stdOut, stdErr, err := execCmd(vault.ZfsPath, args...); err != nil {
+				if stdOut, stdErr, err := execCmd(types.ZFSBinary, args...); err != nil {
 					return fmt.Errorf("error creating zfs vault %s, error=%v, %s, %s",
 						defaultVault, err, stdOut, stdErr)
 				}

--- a/pkg/pillar/cmd/vaultmgr/vaultmgrzfs.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgrzfs.go
@@ -16,28 +16,27 @@ const (
 	defaultCfgSecretDataset = vault.DefaultZpool + "/config"
 	zfsKeyFile              = zfsKeyDir + "/protector.key"
 	zfsKeyDir               = "/run/TmpVaultDir2"
-	zfsSnapshotterSock      = "/run/" + types.ZFSSnapshotter + ".sock"
 )
 
 func getCreateParams(vaultPath string, encrypted bool) []string {
 	if encrypted {
-		return []string{"/hostfs", "zfs", "create", "-o", "encryption=aes-256-gcm", "-o", "keylocation=file://" + zfsKeyFile, "-o", "keyformat=raw", vaultPath}
+		return []string{"create", "-o", "encryption=aes-256-gcm", "-o", "keylocation=file://" + zfsKeyFile, "-o", "keyformat=raw", vaultPath}
 	}
-	return []string{"/hostfs", "zfs", "create", vaultPath}
+	return []string{"create", vaultPath}
 }
 
 func getLoadKeyParams(vaultPath string) []string {
-	args := []string{"/hostfs", "zfs", "load-key", vaultPath}
+	args := []string{"load-key", vaultPath}
 	return args
 }
 
 func getMountParams(vaultPath string) []string {
-	args := []string{"/hostfs", "zfs", "mount", vaultPath}
+	args := []string{"mount", vaultPath}
 	return args
 }
 
 func getKeyStatusParams(vaultPath string) []string {
-	args := []string{"/hostfs", "zfs", "get", "keystatus", vaultPath}
+	args := []string{"get", "keystatus", vaultPath}
 	return args
 }
 
@@ -54,14 +53,14 @@ func unlockZfsVault(vaultPath string) error {
 
 	//zfs load-key
 	args := getLoadKeyParams(vaultPath)
-	if stdOut, stdErr, err := execCmd(vault.ZfsPath, args...); err != nil {
+	if stdOut, stdErr, err := execCmd(types.ZFSBinary, args...); err != nil {
 		log.Errorf("Error loading key for vault: %v, %s, %s",
 			err, stdOut, stdErr)
 		return err
 	}
 	//zfs mount
 	args = getMountParams(vaultPath)
-	if stdOut, stdErr, err := execCmd(vault.ZfsPath, args...); err != nil {
+	if stdOut, stdErr, err := execCmd(types.ZFSBinary, args...); err != nil {
 		log.Errorf("Error unlocking vault: %v, %s, %s", err, stdOut, stdErr)
 		return err
 	}
@@ -78,7 +77,7 @@ func createZfsVault(vaultPath string) error {
 	}
 	defer unstageKey(zfsKeyDir, zfsKeyFile)
 	args := getCreateParams(vaultPath, true)
-	if stdOut, stdErr, err := execCmd(vault.ZfsPath, args...); err != nil {
+	if stdOut, stdErr, err := execCmd(types.ZFSBinary, args...); err != nil {
 		log.Errorf("Error creating zfs vault %s, error=%v, %s, %s",
 			vaultPath, err, stdOut, stdErr)
 		return err
@@ -90,7 +89,7 @@ func createZfsVault(vaultPath string) error {
 //e.g. zfs get keystatus persist/vault
 func checkKeyStatus(vaultPath string) error {
 	args := getKeyStatusParams(vaultPath)
-	if stdOut, stdErr, err := execCmd(vault.ZfsPath, args...); err != nil {
+	if stdOut, stdErr, err := execCmd(types.ZFSBinary, args...); err != nil {
 		log.Tracef("keystatus query for %s results in error=%v, %s, %s",
 			vaultPath, err, stdOut, stdErr)
 		return err

--- a/pkg/pillar/types/zfs.go
+++ b/pkg/pillar/types/zfs.go
@@ -15,6 +15,12 @@ const (
 
 	//ZFSSnapshotter is containerd snapshotter for zfs
 	ZFSSnapshotter = "zfs"
+
+	// ZFSBinary is the zfs binary
+	ZFSBinary = "zfs"
+
+	// ZPoolBinary is the zpool binary
+	ZPoolBinary = "zpool"
 )
 
 // ZVolName returns name of zvol for volume

--- a/pkg/pillar/vault/vault.go
+++ b/pkg/pillar/vault/vault.go
@@ -23,9 +23,6 @@ const (
 	// FscryptPath is the fscrypt binary
 	FscryptPath = "/opt/zededa/bin/fscrypt"
 
-	// ZfsPath is the zfs binary(?)
-	ZfsPath = "/usr/sbin/chroot"
-
 	// MountPoint is the root of all vaults
 	MountPoint = types.PersistDir
 

--- a/pkg/pillar/vault/vaultzfs.go
+++ b/pkg/pillar/vault/vaultzfs.go
@@ -5,17 +5,18 @@ package vault
 
 import (
 	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/types"
 )
 
 func getOperStatusParams(vaultPath string) []string {
-	args := []string{"/hostfs", "zfs", "get", "mounted,encryption,keystatus", vaultPath}
+	args := []string{"get", "mounted,encryption,keystatus", vaultPath}
 	return args
 }
 
 // CheckOperStatus returns ZFS status
 func CheckOperStatus(log *base.LogObject, vaultPath string) (string, error) {
 	args := getOperStatusParams(vaultPath)
-	if stdOut, stdErr, err := execCmd(ZfsPath, args...); err != nil {
+	if stdOut, stdErr, err := execCmd(types.ZFSBinary, args...); err != nil {
 		log.Errorf("oper status query for %s results in error=%v, %s, %s",
 			vaultPath, err, stdOut, stdErr)
 		return stdErr, err


### PR DESCRIPTION
We have zpool and zfs binaries in pillar, because they are required by
snapshotter of the user containerd, so no need to chroot into hostfs.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>