### PR TITLE
readme: update RPi4 part of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,12 +210,10 @@ Raspberry Pi 4 is a tiny, but capable enough ARM board that allows EVE to run wi
 Since a full Raspberry Pi 4 support is only available in upstream Linux kernels starting from 5.6.0, you'll have to use that bleeding edge kernel for your build. Another peculiar aspect of this board is that it doesn't use a standard [bootloader (e.g. u-boot or UEFI)](https://www.raspberrypi.org/documentation/configuration/boot_folder.md) so we need to trick it into using our own u-boot as UEFI environment. Thankfully, our Makefile logic tries to automate as much of it as possible. Thus, putting it all together, here are the steps to run EVE on Raspberry Pi 4:
 
 1. Make sure you have a clean build directory (since this is a non-standard build) `rm -rf dist/arm64`
-2. Build a live image `make ZARCH=arm64 HV=rpi live-raw` (or `make ZARCH=arm64 HV=rpi-kvm live-raw` if you want KVM by default)
+2. Build a live image `make ZARCH=arm64 HV=kvm live-raw` (or `make ZARCH=arm64 HV=xen live-raw` if you want XEN by default)
 3. Flash the `dist/arm64/live.raw` live EVE image onto your SD card by [following these instructions](#how-to-write-eve-image-and-installer-onto-an-sd-card-or-an-installer-medium)
 
-Once your Raspberry Pi 4 is happily running an EVE image you can start using EVE controller for further updates (so that you don't ever have to take an SD card out of your board). Build your rootfs by running `make ZARCH=arm64 rootfs-rpi` (or `make ZARCH=arm64 rootfs-kvm-rpi` if you want KVM by default) and give resulting `dist/arm64/installer/rootfs.img` to the controller.
-
-One final note about Raspberry Pi 4 GPU support is that since we are running EVE in 64bit (aarch64) mode we are still waiting for the proper [VC4 DRM BCM2711 drivers](https://lore.kernel.org/dri-devel/cover.6c896ace9a5a7840e9cec008b553cbb004ca1f91.1582533919.git-series.maxime@cerno.tech/T/#m0275b55e1518be1fb2154d3c95e13c1b7de1f347) to be upstreamed. Currently it is expected that Kernel 5.7 may actually ship the fully functional driver.
+Once your Raspberry Pi 4 is happily running an EVE image you can start using EVE controller for further updates (so that you don't ever have to take an SD card out of your board). Build your rootfs by running `make ZARCH=arm64 HV=xen rootfs` (or `make ZARCH=arm64 HV=kvm rootfs` if you want KVM by default) and give resulting `dist/arm64/installer/rootfs.img` to the controller.
 
 ## How to use on an HiKey ARM board
 
@@ -315,7 +313,7 @@ In Jetson nano, from January 22, 2021, it became possible to save the u-boot to 
 
 1. Follow steps in [instruction](https://github.com/lf-edge/eve/blob/master/boards/nvidia/jetson/) for flash jetson boot flow partitions to qspi.
 2. Make sure you have a clean build directory (since this is a non-standard build) `rm -rf dist/arm64`
-3. Build a live image `make ZARCH=arm64 HV=kvm live-raw`
+3. Build a live image `make ZARCH=arm64 HV=kvm live-raw` (Only KVM is supported)
 4. Flash the `dist/arm64/live.raw` live EVE image onto your SD card by [following these instructions](#how-to-write-eve-image-and-installer-onto-an-sd-card-or-an-installer-medium)
 
 ## How to use on an AMD board


### PR DESCRIPTION
We no longer have separate commands for building an image only for rpi4.
And we not planned add GPU driver (DRM) for rpi4 in EVE-OS. We use simplefb driver.

Signed-off-by: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>