### PR TITLE
compose-image: do not use inplace edit in yq container

### DIFF
--- a/tools/compose-image-yml.sh
+++ b/tools/compose-image-yml.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 yq() {
   docker run --rm -i -v "${PWD}":/workdir mikefarah/yq "$@"
 }
@@ -18,11 +20,16 @@ process-image-template() {
     IFS='-' read -r -a bits <<< "${flags}"
 
     for bit in "${bits[@]}"; do
+        template_data=""
         case "${bit}" in
             dev)
-                yq eval -i '(.services[] | select(.name == "pillar").image) |= "PILLAR_DEV_TAG"' "${out_templ_path}"
+                template_data="$(yq eval '(.services[] | select(.name == "pillar").image) |= "PILLAR_DEV_TAG"' "${out_templ_path}")"
                 ;;
         esac
+
+        if [ "${template_data}" != "" ]; then
+            echo "${template_data}" > "${out_templ_path}"
+        fi
     done
 }
 


### PR DESCRIPTION
compose-image: do not use inplace edit in yq container
The yq container assumes that user id is 1000. Which is true for most
of the systems, but not for all of them. The obvious example is a
shared machine, where only the first user will have uid 1000.

As the result the development build (DEV=y) will work only for uid
1000, and for other users yq will silently fail to update the rootfs
yaml configuration.

Instead inplace editing, lets use the stdout redirection. Yq container
still have permissions to read. And the actual write will happen on
the host in case of redirection.

Also add `set -e` to fail build earlier if something is wrong with the
script.

