### PR TITLE
Populate EVE meta data with edge node enterprise, project and device info

### DIFF
--- a/docs/ECO-METADATA.md
+++ b/docs/ECO-METADATA.md
@@ -21,6 +21,13 @@ The returned json contains
 - caller-ip: a string with the IP address and TCP port of the requesting app instance
 - external-ipv4: a string with the external IPv4 address
 - hostname: a string with the UUID hostname assigned to the app instance
+- app-instance-uuid: a string with the app instance UUID
+- device-uuid: a string with the device UUID
+- device-name: a string with the device name
+- project-uuid: a string with the UUID of the project the device is associated with
+- project-name: a string with the name of the project the device is associated with
+- enterprise-id: a string with the id of the enterprise the device is associated with
+- enterprise-name: a string with the name of the enterprise the device is associated with
 
 Note that there is no need to specify the application instance identity since the meta-data server in EVE determines that from the virtual network adapter the application instance is using to communicate with EVE.
 
@@ -28,7 +35,7 @@ Note that there is no need to specify the application instance identity since th
 
 curl <http://169.254.169.254/eve/v1/network.json>
 
-{"caller-ip":"10.1.0.2:39380","external-ipv4":"192.168.1.10","hostname":"afa43e51-56b7-4021-a5fa-4272b0381913", "app-instance-uuid":"afa43e51-56b7-4021-a5fa-4272b0381913","device-uuid":"6c6cb828-b0be-4166-9daf-ab353430dbc1","device-name":"test-system","project-name":"test-project","project-uuid":"4d12659e-6c9f-44bc-8e98-d525347afae6","enterprise-name":"testing","enterprise-uuid":"AAFlABBtJ0mP_lhJjIyVzjzgMXiR"}
+{"caller-ip":"10.1.0.2:39380","external-ipv4":"192.168.1.10","hostname":"afa43e51-56b7-4021-a5fa-4272b0381913", "app-instance-uuid":"afa43e51-56b7-4021-a5fa-4272b0381913","device-uuid":"6c6cb828-b0be-4166-9daf-ab353430dbc1","device-name":"test-system","project-name":"test-project","project-uuid":"4d12659e-6c9f-44bc-8e98-d525347afae6","enterprise-name":"testing","enterprise-id":"AAFlABBtJ0mP_lhJjIyVzjzgMXiR"}
 
 ## Application instances with multiple network interface adapters
 

--- a/docs/ECO-METADATA.md
+++ b/docs/ECO-METADATA.md
@@ -28,7 +28,7 @@ Note that there is no need to specify the application instance identity since th
 
 curl <http://169.254.169.254/eve/v1/network.json>
 
-{"caller-ip":"10.1.0.2:39380","external-ipv4":"192.168.1.10","hostname":"afa43e51-56b7-4021-a5fa-4272b0381913"}
+{"caller-ip":"10.1.0.2:39380","external-ipv4":"192.168.1.10","hostname":"afa43e51-56b7-4021-a5fa-4272b0381913", "app-instance-uuid":"afa43e51-56b7-4021-a5fa-4272b0381913","device-uuid":"6c6cb828-b0be-4166-9daf-ab353430dbc1","device-name":"test-system","project-name":"test-project","project-uuid":"4d12659e-6c9f-44bc-8e98-d525347afae6","enterprise-name":"testing","enterprise-uuid":"AAFlABBtJ0mP_lhJjIyVzjzgMXiR"}
 
 ## Application instances with multiple network interface adapters
 

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -94,6 +94,7 @@ type getconfigContext struct {
 	subVolumeStatus           pubsub.Subscription
 	pubVolumeConfig           pubsub.Publication
 	pubDisksConfig            pubsub.Publication
+	pubEdgeNodeInfo           pubsub.Publication
 	NodeAgentStatus           *types.NodeAgentStatus
 	configProcessingSkipFlag  bool
 	lastReceivedConfig        time.Time

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -127,6 +127,8 @@ func parseConfig(config *zconfig.EdgeDevConfig, getconfigCtx *getconfigContext,
 
 		parseDisksConfig(getconfigCtx, config)
 
+		parseEdgeNodeInfo(getconfigCtx, config)
+
 		getconfigCtx.lastProcessedConfig = time.Now()
 	}
 	return false

--- a/pkg/pillar/cmd/zedagent/parseedgenodeinfo.go
+++ b/pkg/pillar/cmd/zedagent/parseedgenodeinfo.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2022 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package zedagent
+
+import (
+	zconfig "github.com/lf-edge/eve/api/go/config"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// Get the node information
+func parseEdgeNodeInfo(ctx *getconfigContext,
+	config *zconfig.EdgeDevConfig) {
+
+	log.Tracef("Started parsing edge node information")
+
+	enInfo := types.EdgeNodeInfo{}
+	enInfo = types.EdgeNodeInfo{
+		DeviceName:     config.GetDeviceName(),
+		DeviceID:       config.GetId().Uuid,
+		ProjectName:    config.GetProjectName(),
+		ProjectID:      config.GetProjectId(),
+		EnterpriseName: config.GetEnterpriseName(),
+		EnterpriseID:   config.GetEnterpriseId(),
+	}
+
+	publishEdgeNodeInfo(ctx, &enInfo)
+}
+
+func publishEdgeNodeInfo(ctx *getconfigContext, info *types.EdgeNodeInfo) {
+	pub := ctx.pubEdgeNodeInfo
+	pub.Publish("global", *info)
+	log.Traceln("Done publishing node information")
+}

--- a/pkg/pillar/cmd/zedagent/parseedgenodeinfo.go
+++ b/pkg/pillar/cmd/zedagent/parseedgenodeinfo.go
@@ -6,6 +6,7 @@ package zedagent
 import (
 	zconfig "github.com/lf-edge/eve/api/go/config"
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	uuid "github.com/satori/go.uuid"
 )
 
 // Get the node information
@@ -14,12 +15,14 @@ func parseEdgeNodeInfo(ctx *getconfigContext,
 
 	log.Tracef("Started parsing edge node information")
 
+	deviceID, _ := uuid.FromString(config.GetId().Uuid)
+	projectID, _ := uuid.FromString(config.GetProjectId())
 	enInfo := types.EdgeNodeInfo{}
 	enInfo = types.EdgeNodeInfo{
 		DeviceName:     config.GetDeviceName(),
-		DeviceID:       config.GetId().Uuid,
+		DeviceID:       deviceID,
 		ProjectName:    config.GetProjectName(),
-		ProjectID:      config.GetProjectId(),
+		ProjectID:      projectID,
 		EnterpriseName: config.GetEnterpriseName(),
 		EnterpriseID:   config.GetEnterpriseId(),
 	}

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -567,6 +567,19 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	pubDisksConfig.ClearRestarted()
 	getconfigCtx.pubDisksConfig = pubDisksConfig
 
+	// for Edge Node Info Publisher
+	pubEdgeNodeInfo, err := ps.NewPublication(
+		pubsub.PublicationOptions{
+			AgentName:  agentName,
+			TopicType:  types.EdgeNodeInfo{},
+			Persistent: true,
+		})
+	if err != nil {
+		log.Fatal(err)
+	}
+	pubEdgeNodeInfo.ClearRestarted()
+	getconfigCtx.pubEdgeNodeInfo = pubEdgeNodeInfo
+
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     agentName,

--- a/pkg/pillar/cmd/zedrouter/server.go
+++ b/pkg/pillar/cmd/zedrouter/server.go
@@ -443,12 +443,26 @@ func (hdl networkHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if anStatus != nil {
 		hostname = anStatus.UUIDandVersion.UUID.String()
 	}
+
+	enInfoObj, err := hdl.ctx.subEdgeNodeInfo.Get("global")
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusNoContent), http.StatusNoContent)
+		return
+	}
+	enInfo := enInfoObj.(types.EdgeNodeInfo)
 	w.Header().Add("Content-Type", "application/json")
 	w.WriteHeader(code)
 	resp, _ := json.Marshal(map[string]string{
-		"caller-ip":     r.RemoteAddr,
-		"external-ipv4": ipStr,
-		"hostname":      hostname,
+		"caller-ip":         r.RemoteAddr,
+		"external-ipv4":     ipStr,
+		"hostname":          hostname, // Do not delete this line for backward compatibility
+		"app-instance-uuid": hostname,
+		"device-uuid":       enInfo.DeviceID,
+		"device-name":       enInfo.DeviceName,
+		"project-name":      enInfo.ProjectName,
+		"project-uuid":      enInfo.ProjectID,
+		"enterprise-name":   enInfo.EnterpriseName,
+		"enterprise-uuid":   enInfo.EnterpriseID,
 		// TBD: add public-ipv4 when controller tells us
 	})
 	w.Write(resp)

--- a/pkg/pillar/cmd/zedrouter/server.go
+++ b/pkg/pillar/cmd/zedrouter/server.go
@@ -446,13 +446,15 @@ func (hdl networkHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	enInfoObj, err := hdl.ctx.subEdgeNodeInfo.Get("global")
 	if err != nil {
-		http.Error(w, http.StatusText(http.StatusNoContent), http.StatusNoContent)
+		errorLine := fmt.Sprintf("cannot fetch edge node information: %s", err)
+		log.Error(errorLine)
+		http.Error(w, errorLine, http.StatusInternalServerError)
 		return
 	}
 	enInfo := enInfoObj.(types.EdgeNodeInfo)
 	w.Header().Add("Content-Type", "application/json")
 	w.WriteHeader(code)
-	resp, _ := json.Marshal(map[string]string{
+	resp, _ := json.Marshal(map[string]interface{}{
 		"caller-ip":         r.RemoteAddr,
 		"external-ipv4":     ipStr,
 		"hostname":          hostname, // Do not delete this line for backward compatibility
@@ -462,7 +464,7 @@ func (hdl networkHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		"project-name":      enInfo.ProjectName,
 		"project-uuid":      enInfo.ProjectID,
 		"enterprise-name":   enInfo.EnterpriseName,
-		"enterprise-uuid":   enInfo.EnterpriseID,
+		"enterprise-id":     enInfo.EnterpriseID,
 		// TBD: add public-ipv4 when controller tells us
 	})
 	w.Write(resp)

--- a/pkg/pillar/types/edgenodetypes.go
+++ b/pkg/pillar/types/edgenodetypes.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2022 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+// EdgeNodeInfo - edge node info from controller
+type EdgeNodeInfo struct {
+	DeviceName     string
+	DeviceID       string
+	ProjectName    string
+	ProjectID      string
+	EnterpriseName string
+	EnterpriseID   string
+}

--- a/pkg/pillar/types/edgenodetypes.go
+++ b/pkg/pillar/types/edgenodetypes.go
@@ -3,12 +3,16 @@
 
 package types
 
+import (
+	uuid "github.com/satori/go.uuid"
+)
+
 // EdgeNodeInfo - edge node info from controller
 type EdgeNodeInfo struct {
 	DeviceName     string
-	DeviceID       string
+	DeviceID       uuid.UUID
 	ProjectName    string
-	ProjectID      string
+	ProjectID      uuid.UUID
 	EnterpriseName string
 	EnterpriseID   string
 }


### PR DESCRIPTION
Returns enterprise, project and device information in http://169.254.169.254/eve/v1/network.json

pocuser@ubuntu-tiny:~$ curl -q http://169.254.169.254/eve/v1/network.json | jq
{
  "app-instance-uuid": "3f516657-c794-4d01-a11c-757438e2540b",
  "caller-ip": "10.1.0.128:49366",
  "device-name": "",
  "device-uuid": "6c6cb828-b0be-4166-9daf-ab353430dbc1",
  "enterprise-name": "",
  "enterprise-uuid": "",
  "external-ipv4": "10.129.17.197",
  "hostname": "3f516657-c794-4d01-a11c-757438e2540b",
  "project-name": "",
  "project-uuid": ""
}


Signed-off-by: Pramodh Pallapothu <pramodh@zededa.com>