### PR TITLE
Update rpi patches in new-kernel package

### DIFF
--- a/pkg/kernel/patches-5.10.x/0006-add-raspberry-pi-uno-device-tree.patch
+++ b/pkg/kernel/patches-5.10.x/0006-add-raspberry-pi-uno-device-tree.patch
@@ -1,7 +1,7 @@
 From 62e0b1695fa5ee079d6115c1c9c0af31a61da656 Mon Sep 17 00:00:00 2001
 From: Roman Shaposhnik <rvs@apache.org>
 Date: Sun, 1 Nov 2020 01:41:51 -0500
-Subject: [PATCH 06/10] Add stdout path overlay
+Subject: [PATCH 06/10] add raspberry pi uno device tree
 
 ---
  arch/arm/boot/dts/Makefile                    |   1 +

--- a/pkg/new-kernel/patches-5.15.x/0004-add-raspberry-pi-uno-device-tree.patch
+++ b/pkg/new-kernel/patches-5.15.x/0004-add-raspberry-pi-uno-device-tree.patch
@@ -1,7 +1,7 @@
 From d435e56397ff2620c275f964e57426eadb0d7d6f Mon Sep 17 00:00:00 2001
 From: Roman Shaposhnik <rvs@apache.org>
 Date: Sun, 1 Nov 2020 01:41:51 -0500
-Subject: [PATCH 4/9] Add stdout path overlay
+Subject: [PATCH 4/9] add raspberry pi uno device tree
 
 ---
  arch/arm/boot/dts/Makefile                    |   1 +

--- a/pkg/new-kernel/patches-5.15.x/0010-add-slb9670-TPM-module-support-for-rpi4.patch
+++ b/pkg/new-kernel/patches-5.15.x/0010-add-slb9670-TPM-module-support-for-rpi4.patch
@@ -11,17 +11,17 @@ Signed-off-by: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>
  create mode 100644 arch/arm/boot/dts/bcm2835-spi-tpm-slb9670.dtsi
 
 diff --git a/arch/arm/boot/dts/bcm2711-rpi-4-b.dts b/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
-index fcd561c021ea..ff4a896deb16 100644
+index 72ce80fbf266..34d876efee51 100644
 --- a/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
 +++ b/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
 @@ -3,6 +3,7 @@
  #include "bcm2711.dtsi"
- #include "bcm2835-rpi.dtsi"
+ #include "bcm2711-rpi.dtsi"
  #include "bcm283x-rpi-usb-peripheral.dtsi"
 +#include "bcm2835-spi-tpm-slb9670.dtsi"
  
- #include <dt-bindings/reset/raspberrypi,firmware-reset.h>
- 
+ / {
+ 	compatible = "raspberrypi,4-model-b", "brcm,bcm2711";
 diff --git a/arch/arm/boot/dts/bcm2835-spi-tpm-slb9670.dtsi b/arch/arm/boot/dts/bcm2835-spi-tpm-slb9670.dtsi
 new file mode 100644
 index 000000000000..8b522d8702bb

--- a/pkg/new-kernel/patches-5.15.x/0011-arm-dts-rpi4-swap-uart-as-in-raspberry-linux.patch
+++ b/pkg/new-kernel/patches-5.15.x/0011-arm-dts-rpi4-swap-uart-as-in-raspberry-linux.patch
@@ -1,0 +1,32 @@
+From 92f128d2f3586a735937a4b27022f5ac700e802d Mon Sep 17 00:00:00 2001
+From: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>
+Date: Sat, 6 Aug 2022 18:17:07 +0300
+Subject: [PATCH 11/11] arm: dts: rpi4: swap uart as in raspberry/linux
+
+Signed-off-by: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>
+---
+ arch/arm/boot/dts/bcm2711-rpi-4-b.dts | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm/boot/dts/bcm2711-rpi-4-b.dts b/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
+index 34d876efee51..7fa410cd7f07 100644
+--- a/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
++++ b/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
+@@ -11,7 +11,13 @@ / {
+ 
+ 	chosen {
+ 		/* 8250 auxiliary UART instead of pl011 */
+-		stdout-path = "serial1:115200n8";
++		stdout-path = "serial0:115200n8";
++	};
++
++
++	aliases {
++		serial0 = &uart1;
++		serial1 = &uart0;
+ 	};
+ 
+ 	leds {
+-- 
+2.25.1
+


### PR DESCRIPTION
Added lost patch for rpi: uart swap like in raspberry/linux.
Renamed patch with device tree for rpi uno.
Fixed patch with tpm module for rpi4 so that git am can be used.