### PR TITLE
Recreate vault in case of no controller key

### DIFF
--- a/pkg/mkimage-raw-efi/install
+++ b/pkg/mkimage-raw-efi/install
@@ -555,6 +555,11 @@ fi
 #store file to indicate first boot after installer
 touch /persist/installer/first-boot
 
+# store file to indicate that EVE will clean vault
+# in case of no key received from controller
+mkdir -p /persist/status
+touch /persist/status/allow-vault-clean
+
 # lets hope this is enough to flush the caches
 sync; sleep 5; sync
 

--- a/pkg/pillar/cmd/vaultmgr/vaultmgrzfs.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgrzfs.go
@@ -86,6 +86,17 @@ func createZfsVault(vaultPath string) error {
 	return nil
 }
 
+// remove vault from zfs
+func removeDefaultVaultOnZfs() error {
+	args := []string{"destroy", "-fr", defaultSecretDataset}
+	if stdOut, stdErr, err := execCmd(types.ZFSBinary, args...); err != nil {
+		log.Errorf("error remove zfs vault %s, error=%v, %s, %s",
+			defaultSecretDataset, err, stdOut, stdErr)
+		return err
+	}
+	return nil
+}
+
 //e.g. zfs get keystatus persist/vault
 func checkKeyStatus(vaultPath string) error {
 	args := getKeyStatusParams(vaultPath)

--- a/pkg/pillar/cmd/volumemgr/handlecontent.go
+++ b/pkg/pillar/cmd/volumemgr/handlecontent.go
@@ -12,6 +12,7 @@ import (
 	zconfig "github.com/lf-edge/eve/api/go/config"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils"
+	"github.com/lf-edge/eve/pkg/pillar/vault"
 )
 
 func handleContentTreeCreate(ctxArg interface{}, key string,
@@ -20,6 +21,12 @@ func handleContentTreeCreate(ctxArg interface{}, key string,
 	log.Functionf("handleContentTreeCreate(%s)", key)
 	config := configArg.(types.ContentTreeConfig)
 	ctx := ctxArg.(*volumemgrContext)
+	// we received content tree configuration
+	// clean of vault is not safe from now
+	// note that we wait for vault before start this handler
+	if err := vault.DisallowVaultCleanup(); err != nil {
+		log.Errorf("cannot disallow vault cleanup: %s", err)
+	}
 	status := createContentTreeStatus(ctx, config)
 	updateContentTree(ctx, status)
 	log.Functionf("handleContentTreeCreate(%s) Done", key)

--- a/pkg/pillar/cmd/volumemgr/handlevolume.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/tgt"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils"
+	"github.com/lf-edge/eve/pkg/pillar/vault"
 	"github.com/lf-edge/eve/pkg/pillar/zfs"
 )
 
@@ -21,6 +22,12 @@ func handleVolumeCreate(ctxArg interface{}, key string,
 	log.Functionf("handleVolumeCreate(%s)", key)
 	config := configArg.(types.VolumeConfig)
 	ctx := ctxArg.(*volumemgrContext)
+	// we received volume configuration
+	// clean of vault is not safe from now
+	// note that we wait for vault before start this handler
+	if err := vault.DisallowVaultCleanup(); err != nil {
+		log.Errorf("cannot disallow vault cleanup: %s", err)
+	}
 	//defer creation to restart handler
 	ctx.volumeConfigCreateDeferredMap[key] = &config
 	log.Functionf("handleVolumeCreate(%s) Done", key)

--- a/pkg/storage-init/storage-init.sh
+++ b/pkg/storage-init/storage-init.sh
@@ -284,6 +284,13 @@ if P3=$(findfs PARTLABEL=P3) && [ -n "$P3" ]; then
 
     # this is safe, since if the mount fails the following will fail too
     zfs_module_unload
+
+    if [ "$INIT_FS" = 1 ]; then
+      # store file to indicate that EVE will clean vault
+      # in case of no key received from controller
+      mkdir -p /persist/status
+      touch /persist/status/allow-vault-clean
+    fi
 else
     #in case of no P3 we may have EVE persist on another disks
     zfs_module_load


### PR DESCRIPTION
In case of no storage key stored on the controller side and no
information about previously sent storage keys, we are forced to
re-create vault. We will send empty key to vaultmgr to indicate
that no key received. If we receive empty key in vaultmgr and
was not able to decrypt vault with sealed key, we remove old vault and
setup the new one.

During installation, we create /persist/status/allow-vault-clean file
and remove it in case of success of publishing storage keys or if vault
unlocked and we about to create content tree or volume. In case of
non-unlocked vault, no storage keys received from controller and
existence of the file we will re-create the vault.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>