### PR TITLE
Make function doActivate, hande{Modify,Create} less overloaded

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -825,9 +825,9 @@ func runHandler(ctx *domainContext, key string, c <-chan Notify) {
 				config := c.(types.DomainConfig)
 				status := lookupDomainStatus(ctx, key)
 				if status == nil {
-					handleCreate(ctx, key, &config)
+					doCreateDomain(ctx, key, &config)
 				} else {
-					handleModify(ctx, key, &config, status)
+					doModifyDomain(ctx, key, &config, status)
 				}
 			} else {
 				// Closed
@@ -1095,7 +1095,7 @@ func lookupDomainConfig(ctx *domainContext, key string) *types.DomainConfig {
 	return &config
 }
 
-func handleCreate(ctx *domainContext, key string, config *types.DomainConfig) {
+func doCreateDomain(ctx *domainContext, key string, config *types.DomainConfig) {
 
 	log.Functionf("handleCreate(%v) for %s",
 		config.UUIDandVersion, config.DisplayName)
@@ -1919,7 +1919,7 @@ func addNoDuplicate(list []string, add string) []string {
 // then we need to reboot. Thus version can change but can't handle disk or
 // vif changes.
 // XXX should we reboot if there are such changes? Or reject with error?
-func handleModify(ctx *domainContext, key string,
+func doModifyDomain(ctx *domainContext, key string,
 	config *types.DomainConfig, status *types.DomainStatus) {
 
 	log.Functionf("handleModify(%v) activate %t for %s state %s",

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -163,7 +163,7 @@ func doUpdate(ctx *zedmanagerContext,
 		return changed
 	}
 	log.Functionf("Have config.Activate for %s", uuidStr)
-	c = doActivate(ctx, uuidStr, config, status)
+	c = doUpdateActivate(ctx, uuidStr, config, status)
 	changed = changed || c
 	log.Functionf("doUpdate done for %s", uuidStr)
 	return changed
@@ -417,12 +417,12 @@ func doPrepare(ctx *zedmanagerContext,
 	return changed, true
 }
 
-// doActivate - Returns if the status has changed. Doesn't publish any changes.
+// doUpdateActivate - Returns if the status has changed. Doesn't publish any changes.
 // It is caller's responsibility to publish.
-func doActivate(ctx *zedmanagerContext, uuidStr string,
+func doUpdateActivate(ctx *zedmanagerContext, uuidStr string,
 	config types.AppInstanceConfig, status *types.AppInstanceStatus) bool {
 
-	log.Functionf("doActivate for %s", uuidStr)
+	log.Functionf("doUpdateActivate for %s", uuidStr)
 	changed := false
 
 	// Are we doing a restart and it came down?
@@ -464,7 +464,7 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 		if err != nil {
 			errStr := fmt.Sprintf("getRemainingMemory failed: %s\n",
 				err)
-			log.Errorf("doActivate(%s) failed: %s",
+			log.Errorf("doUpdateActivate(%s) failed: %s",
 				status.Key(), errStr)
 			description := types.ErrorDescription{
 				Error:               errStr,
@@ -504,7 +504,7 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 				}
 				retryCondition = "Retry will be triggered when one or more apps will shutdown"
 			}
-			log.Errorf("doActivate(%s) failed: %s",
+			log.Errorf("doUpdateActivate(%s) failed: %s",
 				status.Key(), errStr)
 			description := types.ErrorDescription{
 				Error:               errStr,
@@ -579,10 +579,10 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 				status.State = types.START_DELAYED
 				return true
 			}
-			// if the VM is already in the START_DELAYED state - just return from the doActivate now
+			// if the VM is already in the START_DELAYED state - just return from the doUpdateActivate now
 			return changed
 		}
-		// if the VM already active or in restarting/purging state - continue with the doActivate logic
+		// if the VM already active or in restarting/purging state - continue with the doUpdateActivate logic
 	}
 
 	// Make sure we have a DomainConfig
@@ -719,7 +719,7 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 				status.Key())
 		}
 	}
-	log.Functionf("doActivate done for %s", uuidStr)
+	log.Functionf("doUpdateActivate done for %s", uuidStr)
 	return changed
 }
 

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -977,7 +977,7 @@ func handleAppNetworkCreate(ctxArg interface{}, key string, configArg interface{
 	}
 
 	if config.Activate {
-		doActivate(ctx, config, &status) // We check any error below
+		doNetActivate(ctx, config, &status) // We check any error below
 	}
 	status.PendingAdd = false
 	publishAppNetworkStatus(ctx, &status)
@@ -1048,10 +1048,10 @@ func handleAppInstConfigDelete(ctxArg interface{}, key string, configArg interfa
 	log.Functionf("handleAppNetworkConfigDelete(%s) done\n", key)
 }
 
-func doActivate(ctx *zedrouterContext, config types.AppNetworkConfig,
+func doNetActivate(ctx *zedrouterContext, config types.AppNetworkConfig,
 	status *types.AppNetworkStatus) error {
 
-	log.Functionf("doActivate %s-%s", config.DisplayName, config.UUIDandVersion)
+	log.Functionf("doNetActivate %s-%s", config.DisplayName, config.UUIDandVersion)
 
 	// Check that Network exists for all underlays.
 	// We look for AwaitNetworkInstance when a NetworkInstance is added
@@ -1059,7 +1059,7 @@ func doActivate(ctx *zedrouterContext, config types.AppNetworkConfig,
 	if !allNetworksExist {
 		// Not reported as error since should be transient, but has unique state
 		status.AwaitNetworkInstance = true
-		log.Functionf("doActivate(%v) for %s: missing networks\n",
+		log.Functionf("doNetActivate(%v) for %s: missing networks\n",
 			config.UUIDandVersion, config.DisplayName)
 		publishAppNetworkStatus(ctx, status)
 		return nil
@@ -1071,7 +1071,7 @@ func doActivate(ctx *zedrouterContext, config types.AppNetworkConfig,
 
 	appNetworkDoCopyNetworksToStatus(ctx, config, status)
 	if err := validateAppNetworkConfig(ctx, config, status); err != nil {
-		log.Errorf("doActivate(%v) AppNetwork Config check failed for %s: %v",
+		log.Errorf("doNetActivate(%v) AppNetwork Config check failed for %s: %v",
 			config.UUIDandVersion, config.DisplayName, err)
 		// addError has already been done
 		publishAppNetworkStatus(ctx, status)
@@ -1090,7 +1090,7 @@ func doActivate(ctx *zedrouterContext, config types.AppNetworkConfig,
 		return err
 	}
 	if status.AwaitNetworkInstance {
-		log.Functionf("doActivate %s-%s clearing error %s",
+		log.Functionf("doNetActivate %s-%s clearing error %s",
 			config.DisplayName, config.UUIDandVersion, status.Error)
 		status.AwaitNetworkInstance = false
 		// XXX better to use ErrorWithSource and check for NetworkInstanceStatus?
@@ -1402,7 +1402,7 @@ func checkAndRecreateAppNetwork(ctx *zedrouterContext, niStatus types.NetworkIns
 
 		log.Functionf("checkAndRecreateAppNetwork(%s) try remove error %s for %s",
 			niStatus.Key(), status.Error, status.DisplayName)
-		doActivate(ctx, *config, &status) // If error we will try again
+		doNetActivate(ctx, *config, &status) // If error we will try again
 		log.Functionf("checkAndRecreateAppNetwork(%s) done for %s\n",
 			niStatus.Key(), config.DisplayName)
 	}
@@ -1572,7 +1572,7 @@ func handleAppNetworkModify(ctxArg interface{}, key string,
 	} else if config.Activate && !status.Activated {
 		checkAppNetworkModifyUNetAppNum(ctx, config, status)
 		appNetworkDoCopyNetworksToStatus(ctx, config, status)
-		doActivate(ctx, config, status) // We check any error below
+		doNetActivate(ctx, config, status) // We check any error below
 	} else if !status.Activated {
 		checkAppNetworkModifyUNetAppNum(ctx, config, status)
 		// Just copy in config


### PR DESCRIPTION
This PR is pure function renaming (and changing log messages to reflect that rename)

These was confusing me for a long time. These are not parts of any interfaces, nor any overloading in OOP sense. They do not have any good reason to not to have a bit more unique names.