### PR TITLE
wwan: patches for register and connect procedures

### DIFF
--- a/pkg/wwan/usr/bin/wwan-mbim.sh
+++ b/pkg/wwan/usr/bin/wwan-mbim.sh
@@ -166,6 +166,13 @@ mbim_wait_for_wds() {
 }
 
 mbim_wait_for_register() {
+  # Make sure we are registering with the right APN.
+  # Some LTE networks require explicit (and correct) APN for the registration/attach
+  # procedure (for the initial EPS bearer activation).
+  # Note that qmicli is able to apply this change even in the mbim mode.
+  # On the other hand, mbimcli does not yet provide command to manipulate with profiles.
+  qmi --wds-modify-profile="3gpp,1,apn=${APN},pdp-type=ip"
+
   echo "[$CDC_DEV] Waiting for the device to register on the network"
   local CMD="mbim --query-registration-state | grep -qE 'Register state:.*(home|roaming|partner)' && echo registered"
 

--- a/pkg/wwan/usr/bin/wwan-qmi.sh
+++ b/pkg/wwan/usr/bin/wwan-qmi.sh
@@ -269,6 +269,11 @@ qmi_get_registration_status() {
 }
 
 qmi_wait_for_register() {
+  # Make sure we are registering with the right APN.
+  # Some LTE networks require explicit (and correct) APN for the registration/attach
+  # procedure (for the initial EPS bearer activation).
+  qmi --wds-modify-profile="3gpp,1,apn=${APN},pdp-type=ip"
+
   echo "[$CDC_DEV] Waiting for the device to register on the network"
   local CMD="qmi_get_registration_status"
 

--- a/pkg/wwan/usr/bin/wwan-qmi.sh
+++ b/pkg/wwan/usr/bin/wwan-qmi.sh
@@ -231,7 +231,7 @@ qmi_start_network() {
   ip link set "$IFACE" up
 
   qmi --wds-reset
-  if ! OUTPUT="$(qmi --wds-start-network="apn=${APN}" --client-no-release-cid)"; then
+  if ! OUTPUT="$(qmi --wds-start-network="ip-type=4,apn=${APN}" --client-no-release-cid)"; then
     return 1
   fi
 


### PR DESCRIPTION
This PR contains two patches for LTE connectivity:

**wwan: Explicitly request IPv4 connection**

Without explicitly asking for IPv4 (which we only support for wwan),
for some LTE networks the connect request may fail with:

```
error: couldn't start network: QMI protocol error (14): 'CallFailed'
call end reason (1): generic-unspecified
verbose call end reason (6,50): [3gpp] ipv4-only-allowed
```

This error is returned by network to indicate that only PDN type IPv4
is allowed for the requested PDN connectivity (which is want we want
but we need to be explicit about it).

-----------------

**wwan: make sure we are registering to network with the right APN**

Some LTE networks require explicit (and correct) APN for the registration/attach
procedure (for the initial EPS bearer activation).