### PR TITLE
Fix PCIe BAR allocation on HPE m750

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -187,6 +187,11 @@ function set_x86_64_baremetal {
       if [ "$smb_product" = "ProLiant DL360 Gen10" ]; then
          set_global hv_platform_tweaks "$hv_platform_tweaks cmos-rtc-probe=1"
       fi
+      # On m750 BAR registers are not correctly reassigned by Linux
+      # if there are devices with 64bit BARs. Using UEFI assignments
+      if regexp -- "m750" "$smb_product"; then
+         set_global dom0_platform_tweaks "$dom0_platform_tweaks pci=realloc=off"
+      fi
    fi
 }
 


### PR DESCRIPTION
By default Linux reassign BAR addresses if there are devices with 64 bit addresses
However on m750 it fails to assign BAR registers in some HW configurations
e.g. P1000 NVIDIA GPU is installed into slot 1. We just force using UEFI assignments
in this case.

We set it only for m750 to be on a safe side

Signed-off-by: Mikhail Malyshev <mikem@zededa.com>