### PR TITLE
Checkpoint EdgeDevConfig with AuthContainer

### DIFF
--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -1026,6 +1026,7 @@ func myGet(ctx *diagContext, reqURL string, ifname string,
 			ifname, proxyURL.String(), reqURL)
 	}
 	const allowProxy = true
+	// No verification of AuthContainer for this GET
 	resp, contents, senderStatus, err := zedcloud.SendOnIntf(context.Background(), zedcloudCtx,
 		reqURL, ifname, 0, nil, allowProxy, ctx.usingOnboardCert)
 	if err != nil {
@@ -1116,10 +1117,8 @@ func myPost(ctx *diagContext, reqURL string, ifname string,
 	switch resp.StatusCode {
 	case http.StatusOK:
 		fmt.Fprintf(outfile, "INFO: %s: %s StatusOK\n", ifname, reqURL)
-		return true, resp, senderStatus, contents
 	case http.StatusNotModified:
 		fmt.Fprintf(outfile, "INFO: %s: %s StatusNotModified\n", ifname, reqURL)
-		return true, resp, senderStatus, contents
 	default:
 		fmt.Fprintf(outfile, "ERROR: %s: %s statuscode %d %s\n",
 			ifname, reqURL, resp.StatusCode,
@@ -1128,6 +1127,16 @@ func myPost(ctx *diagContext, reqURL string, ifname string,
 			ifname, string(contents))
 		return false, nil, senderStatus, nil
 	}
+	if len(contents) > 0 {
+		contents, senderStatus, err = zedcloud.RemoveAndVerifyAuthContainer(zedcloudCtx,
+			reqURL, contents, false, senderStatus)
+		if err != nil {
+			fmt.Fprintf(outfile, "ERROR: %s: %s RemoveAndVerifyAuthContainer  %s\n",
+				ifname, reqURL, err)
+			return false, nil, senderStatus, nil
+		}
+	}
+	return true, resp, senderStatus, contents
 }
 
 func handleGlobalConfigCreate(ctxArg interface{}, key string,

--- a/pkg/pillar/cmd/loguploader/loguploader.go
+++ b/pkg/pillar/cmd/loguploader/loguploader.go
@@ -790,6 +790,16 @@ func sendToCloud(ctx *loguploaderContext, data []byte, iter int, fName string, f
 			totalLatency := int64(ctx.metrics.Latency.AvgUploadMsec) *
 				int64(ctx.metrics.AppMetrics.NumGZipFilesSent+ctx.metrics.DevMetrics.NumGZipFilesSent)
 			filetime := time.Unix(int64(fTime/1000), 0) // convert msec to unix sec
+			if len(contents) != 0 {
+				contents, _, err = zedcloud.RemoveAndVerifyAuthContainer(ctx.zedcloudCtx,
+					logsURL, contents, false, types.SenderStatusNone)
+				if err != nil {
+					log.Errorf("RemoveAndVerifyAuthContainer failed: %s", err)
+					// Ignore response payload
+					contents = []byte{}
+				}
+			}
+
 			if isApp {
 				ctx.metrics.AppMetrics.RecentUploadTimestamp = filetime
 				ctx.metrics.AppMetrics.NumGZipFilesSent++

--- a/pkg/pillar/cmd/nodeagent/handletimers.go
+++ b/pkg/pillar/cmd/nodeagent/handletimers.go
@@ -254,11 +254,12 @@ func handleDeviceCmd(ctxPtr *nodeagentContext, status types.ZedAgentStatus, op t
 		return
 	}
 	log.Functionf("handleDeviceCmd reason %s bootReason %s",
-		status.RebootReason, status.BootReason.String())
-	scheduleNodeOperation(ctxPtr, status.RebootReason, status.BootReason, op)
+		status.RequestedRebootReason, status.RequestedBootReason)
+	scheduleNodeOperation(ctxPtr, status.RequestedRebootReason,
+		status.RequestedBootReason, op)
 }
 
-func scheduleNodeOperation(ctxPtr *nodeagentContext, reasonStr string, bootReason types.BootReason, op types.DeviceOperation) {
+func scheduleNodeOperation(ctxPtr *nodeagentContext, requestedReasonStr string, requestedBootReason types.BootReason, op types.DeviceOperation) {
 	switch op {
 	case types.DeviceOperationReboot:
 		if ctxPtr.deviceReboot {
@@ -282,16 +283,16 @@ func scheduleNodeOperation(ctxPtr *nodeagentContext, reasonStr string, bootReaso
 		log.Errorf("scheduleNodeOperation unknown operation: %v", op)
 		return
 	}
-	log.Functionf("scheduleNodeOperation(): current RebootReason: %s BootReason %s",
-		reasonStr, bootReason.String())
+	log.Functionf("scheduleNodeOperation(): current ReBootReason: %s BootReason %s",
+		requestedReasonStr, requestedBootReason.String())
 
 	// publish, for zedagent to pick up the event
-	// TBD:XXX, all other agents can subscribe to nodeagent or,
-	// status to gracefully shutdown their states, for example
+	// TBD:XXX make other agents subscribe NodeAgentStatus to
+	// gracefully shutdown their states, for example
 	// downloader can teardown the existing connections
 	// and clean up its temporary states etc.
-	ctxPtr.currentRebootReason = reasonStr
-	ctxPtr.currentBootReason = bootReason
+	ctxPtr.requestedRebootReason = requestedReasonStr
+	ctxPtr.requestedBootReason = requestedBootReason
 	publishNodeAgentStatus(ctxPtr)
 
 	// in any case, execute the reboot procedure
@@ -351,8 +352,8 @@ func handleNodeOperation(ctxPtr *nodeagentContext, op types.DeviceOperation) {
 
 	if op != types.DeviceOperationShutdown {
 		// set the reboot reason
-		agentlog.RebootReason(ctxPtr.currentRebootReason,
-			ctxPtr.currentBootReason, agentName, os.Getpid(), true)
+		agentlog.RebootReason(ctxPtr.requestedRebootReason,
+			ctxPtr.requestedBootReason, agentName, os.Getpid(), true)
 	}
 	// Wait for All Domains Halted
 	waitForAllDomainsHalted(ctxPtr)

--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -101,8 +101,8 @@ type nodeagentContext struct {
 	deviceShutdown              bool
 	devicePoweroff              bool
 	allDomainsHalted            bool   // Progression of reboot, shutdown, etc
-	currentRebootReason         string // Reason we are rebooting
-	currentBootReason           types.BootReason
+	requestedRebootReason       string // Reason we will be rebooting
+	requestedBootReason         types.BootReason
 	lastLock                    sync.Mutex       // Ensure publish gets consistent data
 	rebootReason                string           // From last reboot
 	bootReason                  types.BootReason // From last reboot

--- a/pkg/pillar/cmd/upgradeconverter/parseconfig.go
+++ b/pkg/pillar/cmd/upgradeconverter/parseconfig.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 
 	"github.com/golang/protobuf/proto"
+	zauth "github.com/lf-edge/eve/api/go/auth"
 	zconfig "github.com/lf-edge/eve/api/go/config"
 	uuid "github.com/satori/go.uuid"
 )
@@ -69,9 +70,23 @@ func readSavedProtoMessage(filename string) (*zconfig.EdgeDevConfig, error) {
 	var configResponse = &zconfig.ConfigResponse{}
 	err = proto.Unmarshal(contents, configResponse)
 	if err != nil {
-		log.Errorf("readSavedProtoMessage Unmarshalling failed: %v",
-			err)
-		return nil, err
+		// Try with AuthContainer
+		sm := &zauth.AuthContainer{}
+		err1 := proto.Unmarshal(contents, sm)
+		if err1 != nil {
+			log.Errorf("readSavedProtoMessage Unmarshalling ConfigResponse failed: %v",
+				err)
+			log.Errorf("readSavedProtoMessage Unmarshalling AuthContainer failed: %v",
+				err1)
+			return nil, err1
+		}
+		contents = sm.ProtectedPayload.GetPayload()
+		err = proto.Unmarshal(contents, configResponse)
+		if err != nil {
+			log.Errorf("readSavedProtoMessage Unmarshalling ConfigResponse inside AuthContainer failed: %v",
+				err)
+			return nil, err
+		}
 	}
 	config := configResponse.GetConfig()
 	return config, nil

--- a/pkg/pillar/cmd/zedagent/attesttask.go
+++ b/pkg/pillar/cmd/zedagent/attesttask.go
@@ -311,6 +311,7 @@ func (server *VerifierImpl) SendAttestQuote(ctx *zattest.Context) error {
 	//Increment Iteration for interface rotation
 	attestCtx.Iteration++
 	log.Tracef("Sending Quote request")
+	recordAttestationTry(attestCtx.zedagentCtx)
 
 	_, contents, senderStatus, err := trySendToController(attestReq, attestCtx.Iteration)
 	if err != nil || senderStatus != types.SenderStatusNone {

--- a/pkg/pillar/cmd/zedagent/attesttask.go
+++ b/pkg/pillar/cmd/zedagent/attesttask.go
@@ -81,8 +81,14 @@ func trySendToController(attestReq *attest.ZAttestReq, iteration int) (*http.Res
 		devUUID, "attest")
 	ctxWork, cancel := zedcloud.GetContextForAllIntfFunctions(zedcloudCtx)
 	defer cancel()
-	return zedcloud.SendOnAllIntf(ctxWork, zedcloudCtx, attestURL,
-		size, buf, iteration, true)
+	resp, contents, senderStatus, err := zedcloud.SendOnAllIntf(ctxWork,
+		zedcloudCtx, attestURL, size, buf, iteration, true)
+	if err != nil || len(contents) == 0 {
+		return resp, contents, senderStatus, err
+	}
+	contents, senderStatus, err = zedcloud.RemoveAndVerifyAuthContainer(zedcloudCtx,
+		attestURL, contents, false, senderStatus)
+	return resp, contents, senderStatus, err
 }
 
 //setAttestErrorAndTriggerInfo sets errorDescription on zattest.Context,

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -697,17 +697,17 @@ func potentialUUIDUpdate(_ *getconfigContext) {
 func publishZedAgentStatus(getconfigCtx *getconfigContext) {
 	ctx := getconfigCtx.zedagentCtx
 	status := types.ZedAgentStatus{
-		Name:                 agentName,
-		ConfigGetStatus:      getconfigCtx.configGetStatus,
-		RebootCmd:            ctx.rebootCmd,
-		ShutdownCmd:          ctx.shutdownCmd,
-		PoweroffCmd:          ctx.poweroffCmd,
-		RebootReason:         ctx.currentRebootReason,
-		BootReason:           ctx.currentBootReason,
-		MaintenanceMode:      ctx.maintenanceMode,
-		ForceFallbackCounter: ctx.forceFallbackCounter,
-		CurrentProfile:       getconfigCtx.currentProfile,
-		RadioSilence:         getconfigCtx.radioSilence,
+		Name:                  agentName,
+		ConfigGetStatus:       getconfigCtx.configGetStatus,
+		RebootCmd:             ctx.rebootCmd,
+		ShutdownCmd:           ctx.shutdownCmd,
+		PoweroffCmd:           ctx.poweroffCmd,
+		RequestedRebootReason: ctx.requestedRebootReason,
+		RequestedBootReason:   ctx.requestedBootReason,
+		MaintenanceMode:       ctx.maintenanceMode,
+		ForceFallbackCounter:  ctx.forceFallbackCounter,
+		CurrentProfile:        getconfigCtx.currentProfile,
+		RadioSilence:          getconfigCtx.radioSilence,
 	}
 	pub := getconfigCtx.pubZedAgentStatus
 	pub.Publish(agentName, status)

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -412,6 +412,17 @@ func getLatestConfig(url string, iteration int,
 		return false
 	}
 
+	contents, senderStatus, err = zedcloud.RemoveAndVerifyAuthContainer(zedcloudCtx,
+		url, contents, false, senderStatus)
+	if err != nil {
+		log.Errorf("RemoveAndVerifyAuthContainer failed: %s", err)
+		// Inform ledmanager about problem
+		utils.UpdateLedManagerConfig(log, types.LedBlinkInvalidAuthContainer)
+		getconfigCtx.ledBlinkCount = types.LedBlinkInvalidAuthContainer
+		publishZedAgentStatus(getconfigCtx)
+		return false
+	}
+
 	changed, config, err := readConfigResponseProtoMessage(resp, contents)
 	if err != nil {
 		log.Errorln("readConfigResponseProtoMessage: ", err)

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -285,10 +285,11 @@ func getLatestConfig(url string, iteration int,
 	getconfigCtx *getconfigContext) bool {
 
 	log.Tracef("getLatestConfig(%s, %d)", url, iteration)
-	// If we haven't yet published our certificates we defer to ensure
-	// that the controller has our certs and can add encrypted secrets to
-	// our config.
-	if !getconfigCtx.zedagentCtx.publishedEdgeNodeCerts {
+	// On first boot, if we haven't yet published our certificates we defer
+	// to ensure that the controller has our certs and can add encrypted
+	// secrets to our config.
+	if getconfigCtx.zedagentCtx.bootReason == types.BootReasonFirst &&
+		!getconfigCtx.zedagentCtx.publishedEdgeNodeCerts {
 		log.Noticef("Defer fetching config until our EdgeNodeCerts have been published")
 		return false
 	}
@@ -345,7 +346,8 @@ func getLatestConfig(url string, iteration int,
 		if senderStatus == types.SenderStatusNotFound {
 			potentialUUIDUpdate(getconfigCtx)
 		}
-		if senderStatus == types.SenderStatusForbidden {
+		if senderStatus == types.SenderStatusForbidden &&
+			ctx.attestationTryCount > 0 {
 			log.Errorf("Config request is forbidden, triggering attestation again")
 			_ = restartAttestation(ctx)
 			if getconfigCtx.updateInprogress {

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -365,6 +365,7 @@ func getLatestConfig(url string, iteration int,
 					ctx.bootReason)
 			} else {
 				config, ts, err := readSavedProtoMessageConfig(
+					zedcloudCtx, url,
 					ctx.globalConfig.GlobalValueInt(types.StaleConfigTime),
 					checkpointDirname+"/lastconfig", false)
 				if err != nil {
@@ -412,7 +413,8 @@ func getLatestConfig(url string, iteration int,
 		return false
 	}
 
-	contents, senderStatus, err = zedcloud.RemoveAndVerifyAuthContainer(zedcloudCtx,
+	var configContents []byte
+	configContents, senderStatus, err = zedcloud.RemoveAndVerifyAuthContainer(zedcloudCtx,
 		url, contents, false, senderStatus)
 	if err != nil {
 		log.Errorf("RemoveAndVerifyAuthContainer failed: %s", err)
@@ -423,7 +425,7 @@ func getLatestConfig(url string, iteration int,
 		return false
 	}
 
-	changed, config, err := readConfigResponseProtoMessage(resp, contents)
+	changed, config, err := readConfigResponseProtoMessage(resp, configContents)
 	if err != nil {
 		log.Errorln("readConfigResponseProtoMessage: ", err)
 		// Inform ledmanager about cloud connectivity
@@ -526,15 +528,21 @@ func existsSavedConfig(filename string) bool {
 
 // If the file exists then read the config, and return is modify time
 // Ignore if older than StaleConfigTime seconds
-func readSavedProtoMessageConfig(staleConfigTime uint32,
-	filename string, force bool) (*zconfig.EdgeDevConfig, time.Time, error) {
+func readSavedProtoMessageConfig(zedcloudCtx *zedcloud.ZedCloudContext, URL string,
+	staleConfigTime uint32, filename string, force bool) (*zconfig.EdgeDevConfig, time.Time, error) {
 	contents, ts, err := readSavedConfig(staleConfigTime, filename, force)
 	if err != nil {
 		log.Errorln("readSavedProtoMessageConfig", err)
 		return nil, ts, err
 	}
+	configContents, _, err := zedcloud.RemoveAndVerifyAuthContainer(zedcloudCtx,
+		URL, contents, false, types.SenderStatusNone)
+	if err != nil {
+		log.Errorf("RemoveAndVerifyAuthContainer failed: %s", err)
+		return nil, ts, err
+	}
 	var configResponse = &zconfig.ConfigResponse{}
-	err = proto.Unmarshal(contents, configResponse)
+	err = proto.Unmarshal(configContents, configResponse)
 	if err != nil {
 		log.Errorf("readSavedProtoMessageConfig Unmarshalling failed: %v",
 			err)

--- a/pkg/pillar/cmd/zedagent/localinfo.go
+++ b/pkg/pillar/cmd/zedagent/localinfo.go
@@ -731,8 +731,8 @@ func processReceivedDevCommands(getconfigCtx *getconfigContext, cmd *profile.Loc
 		}
 		ctx.poweroffCmd = true
 		infoStr := fmt.Sprintf("NORMAL: local profile server power off")
-		ctx.currentRebootReason = infoStr
-		ctx.currentBootReason = types.BootReasonPoweroffCmd
+		ctx.requestedRebootReason = infoStr
+		ctx.requestedBootReason = types.BootReasonPoweroffCmd
 	}
 
 	// shutdown the application instances

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -2660,8 +2660,8 @@ func handleDeviceOperationCmd(ctxPtr *zedagentContext, infoStr string, op types.
 			return
 		}
 		ctxPtr.rebootCmd = true
-		ctxPtr.currentRebootReason = infoStr
-		ctxPtr.currentBootReason = types.BootReasonRebootCmd
+		ctxPtr.requestedRebootReason = infoStr
+		ctxPtr.requestedBootReason = types.BootReasonRebootCmd
 	case types.DeviceOperationShutdown:
 		if ctxPtr.shutdownCmd || ctxPtr.deviceShutdown {
 			return
@@ -2672,8 +2672,8 @@ func handleDeviceOperationCmd(ctxPtr *zedagentContext, infoStr string, op types.
 			return
 		}
 		ctxPtr.poweroffCmd = true
-		ctxPtr.currentRebootReason = infoStr
-		ctxPtr.currentBootReason = types.BootReasonPoweroffCmd
+		ctxPtr.requestedRebootReason = infoStr
+		ctxPtr.requestedBootReason = types.BootReasonPoweroffCmd
 	default:
 		log.Errorf("handleDeviceOperationCmd wrong operation: %v", op)
 		return

--- a/pkg/pillar/cmd/zedagent/validate.go
+++ b/pkg/pillar/cmd/zedagent/validate.go
@@ -12,7 +12,8 @@ import (
 
 func readValidateConfig(staleConfigTime uint32,
 	validateFile string) (bool, *zconfig.EdgeDevConfig) {
-	config, _, err := readSavedProtoMessageConfig(staleConfigTime, validateFile, true)
+	config, _, err := readSavedProtoMessageConfig(zedcloudCtx, "https://",
+		staleConfigTime, validateFile, true)
 	if err != nil {
 		fmt.Printf("getconfig: %v\n", err)
 		return false, nil

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -185,6 +185,8 @@ type zedagentContext struct {
 
 	// Interlock with controller to ensure we get the encrypted secrets
 	publishedEdgeNodeCerts bool
+
+	attestationTryCount int
 }
 
 var debug = false
@@ -1774,6 +1776,12 @@ func triggerPublishAllInfo(ctxPtr *zedagentContext) {
 			}
 		}
 	}()
+}
+
+// This is called when we try sending an ATTEST_REQ_QUOTE
+func recordAttestationTry(ctxPtr *zedagentContext) {
+	ctxPtr.attestationTryCount++
+	log.Noticef("recordAttestationTry count %d", ctxPtr.attestationTryCount)
 }
 
 func handleZbootRestarted(ctxArg interface{}, restartCounter int) {

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -146,8 +146,8 @@ type zedagentContext struct {
 	poweroffCmdDeferred       bool
 	devicePoweroff            bool // From nodeagent
 	allDomainsHalted          bool
-	currentRebootReason       string           // Set by zedagent
-	currentBootReason         types.BootReason // Set by zedagent
+	requestedRebootReason     string           // Set by zedagent
+	requestedBootReason       types.BootReason // Set by zedagent
 	rebootReason              string           // Previous reboot from nodeagent
 	bootReason                types.BootReason // Previous reboot from nodeagent
 	rebootStack               string           // Previous reboot from nodeagent

--- a/pkg/pillar/cmd/zedrouter/probe.go
+++ b/pkg/pillar/cmd/zedrouter/probe.go
@@ -398,6 +398,7 @@ func launchHostProbe(ctx *zedrouterContext) {
 						startTime := time.Now()
 						const allowProxy = true
 						const useOnboard = false
+						// No verification of AuthContainer in this reachability probe
 						resp, _, _, err := zedcloud.SendOnIntf(context.Background(), &zcloudCtx, remoteURL, info.IfName, 0, nil, allowProxy, useOnboard)
 						if err != nil {
 							log.Tracef("launchHostProbe: send on intf %s, err %v\n", info.IfName, err)

--- a/pkg/pillar/dpcreconciler/linuxitems/wlan.go
+++ b/pkg/pillar/dpcreconciler/linuxitems/wlan.go
@@ -138,12 +138,7 @@ func (c *WlanConfigurator) installWifiConfig(config []WifiConfig) error {
 	}
 	if len(config) == 0 {
 		// generate dummy wpa_supplicant.conf
-		tmpfile.WriteString("# Fill in the networks and their passwords\nnetwork={\n")
-		tmpfile.WriteString("       ssid=\"XXX\"\n")
-		tmpfile.WriteString("       scan_ssid=1\n")
-		tmpfile.WriteString("       key_mgmt=WPA-PSK\n")
-		tmpfile.WriteString("       psk=\"YYYYYYYY\"\n")
-		tmpfile.WriteString("}\n")
+		tmpfile.WriteString("# No WiFi config received\n")
 	} else {
 		tmpfile.WriteString("# Automatically generated\n")
 		for _, wifi := range config {

--- a/pkg/pillar/types/ledmanagertypes.go
+++ b/pkg/pillar/types/ledmanagertypes.go
@@ -32,6 +32,8 @@ const (
 	LedBlinkRespWithoutOSCP
 	// LedBlinkInvalidControllerCert - LED indication or device failing to validate or fetch the controller certificate.
 	LedBlinkInvalidControllerCert
+	// LedBlinkInvalidAuthContainer - LED indication of message not being signed by controller.
+	LedBlinkInvalidAuthContainer
 )
 
 // String returns human-readable description of the state indicated by the particular LED blinking count.
@@ -57,6 +59,8 @@ func (c LedBlinkCount) String() string {
 		return "Response without OSCP or bad OSCP - ignored"
 	case LedBlinkInvalidControllerCert:
 		return "Failed to fetch or verify EV Controller certificate"
+	case LedBlinkInvalidAuthContainer:
+		return "Response has invalid controller signature"
 	default:
 		return fmt.Sprintf("Unsupported LED counter (%d)", c)
 	}

--- a/pkg/pillar/types/zedagenttypes.go
+++ b/pkg/pillar/types/zedagenttypes.go
@@ -517,17 +517,17 @@ func (do DeviceOperation) String() string {
 
 // ZedAgentStatus :
 type ZedAgentStatus struct {
-	Name                 string
-	ConfigGetStatus      ConfigGetStatus
-	RebootCmd            bool
-	ShutdownCmd          bool
-	PoweroffCmd          bool
-	RebootReason         string       // Current reason to reboot
-	BootReason           BootReason   // Current reason to reboot
-	MaintenanceMode      bool         // Don't run apps etc
-	ForceFallbackCounter int          // Try image fallback when counter changes
-	CurrentProfile       string       // Current profile
-	RadioSilence         RadioSilence // Currently requested state of radio devices
+	Name                  string
+	ConfigGetStatus       ConfigGetStatus
+	RebootCmd             bool
+	ShutdownCmd           bool
+	PoweroffCmd           bool
+	RequestedRebootReason string       // Why we will reboot
+	RequestedBootReason   BootReason   // Why we will reboot
+	MaintenanceMode       bool         // Don't run apps etc
+	ForceFallbackCounter  int          // Try image fallback when counter changes
+	CurrentProfile        string       // Current profile
+	RadioSilence          RadioSilence // Currently requested state of radio devices
 }
 
 // Key :


### PR DESCRIPTION
First commit: Refactors the verification of AuthContainer to prepare for the second commit 
Second commit: Checkpointing to /persist/checkpoint/lastconfig includes the authcontainer and it is verified when when reading the checkpoint.

PR also contains somewhat unrelated changes:
3. The introduction of a check for having pushed edge node certs to the controller means that the device will not use /persist/checkpoint/config until it can reach the controller. Fixed to only apply defer on first boot.
4. The development of commit 3 tripped on poor naming of current*Reason so renaming those to be more clear.
5. Removed the sample dummy wpa_supplicant code since the existence of what looks like hard-coded passwords caused confusion.