### PR TITLE
Fix incorrect error handling when processing deferred sends.

### DIFF
--- a/pkg/pillar/cmd/zedagent/hardwareinfo.go
+++ b/pkg/pillar/cmd/zedagent/hardwareinfo.go
@@ -48,7 +48,7 @@ func PublishHardwareInfoToZedCloud(ctx *zedagentContext) {
 	hwType := new(info.ZInfoTypes)
 	*hwType = info.ZInfoTypes_ZiHardware
 	ReportHwInfo.Ztype = *hwType
-	ReportHwInfo.DevId = *proto.String(hwInfoKey)
+	ReportHwInfo.DevId = *proto.String(devUUID.String())
 	ReportHwInfo.AtTimeStamp = ptypes.TimestampNow()
 	log.Functionf("PublishHardwareInfoToZedCloud uuid %s", hwInfoKey)
 

--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -139,12 +139,22 @@ func objectInfoTask(ctxPtr *zedagentContext, triggerInfo <-chan infoForObjectKey
 						ctxPtr.iteration)
 					ctxPtr.iteration++
 				}
+			case info.ZInfoTypes_ZiHardware:
+				PublishHardwareInfoToZedCloud(ctxPtr)
+				ctxPtr.iteration++
 			case info.ZInfoTypes_ZiEdgeview:
 				// publish Edgeview info
 				sub := ctxPtr.subEdgeviewStatus
 				if c, err = sub.Get(infoForKeyMessage.objectKey); err == nil {
 					evStatus := c.(types.EdgeviewStatus)
 					PublishEdgeviewToZedCloud(ctxPtr, &evStatus)
+				}
+			case info.ZInfoTypes_ZiLocation:
+				locInfo := getLocationInfo(ctxPtr)
+				if locInfo != nil {
+					// Note that we use a zero iteration
+					// counter here.
+					publishLocationToController(locInfo, 0)
 				}
 			}
 			if err != nil {

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -39,6 +39,7 @@ import (
 	"github.com/lf-edge/eve/api/go/info"
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/flextimer"
 	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
@@ -1729,6 +1730,12 @@ func triggerPublishDevInfo(ctxPtr *zedagentContext) {
 	triggerLocalDevInfoPOST(ctxPtr.getconfigCtx)
 }
 
+func triggerPublishLocationToController(ctxPtr *zedagentContext) {
+
+	log.Function("Triggered publishLocationToController")
+	flextimer.TickNow(ctxPtr.getconfigCtx.locationCloudTickerHandle)
+}
+
 func triggerPublishAllInfo(ctxPtr *zedagentContext) {
 
 	log.Function("Triggered PublishAllInfo")
@@ -1737,7 +1744,6 @@ func triggerPublishAllInfo(ctxPtr *zedagentContext) {
 	go func() {
 		// we need only the last one device info to publish
 		triggerPublishDevInfo(ctxPtr)
-		triggerPublishHwInfo(ctxPtr)
 		// trigger publish applications infos
 		for _, c := range ctxPtr.getconfigCtx.subAppInstanceStatus.GetAll() {
 			ctxPtr.TriggerObjectInfo <- infoForObjectKey{
@@ -1781,6 +1787,7 @@ func triggerPublishAllInfo(ctxPtr *zedagentContext) {
 				c.(types.AppInstMetaData).Key(),
 			}
 		}
+		triggerPublishHwInfo(ctxPtr)
 		// trigger publish edgeview infos
 		for _, c := range ctxPtr.subEdgeviewStatus.GetAll() {
 			ctxPtr.TriggerObjectInfo <- infoForObjectKey{
@@ -1788,6 +1795,7 @@ func triggerPublishAllInfo(ctxPtr *zedagentContext) {
 				c.(types.EdgeviewStatus).Key(),
 			}
 		}
+		triggerPublishLocationToController(ctxPtr)
 	}()
 }
 

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -2335,7 +2335,15 @@ func handleNodeAgentStatusDelete(ctxArg interface{}, key string,
 func getDeferredSentHandlerFunction(ctx *zedagentContext) *zedcloud.SentHandlerFunction {
 	var function zedcloud.SentHandlerFunction
 	function = func(itemType interface{}, data *bytes.Buffer, result types.SenderResult) {
-		if result == types.SenderStatusNone {
+		if result == types.SenderStatusDebug {
+			// Debug stuff
+			if el, ok := itemType.(info.ZInfoTypes); ok {
+				log.Noticef("deferred queue has INFO: %d", el)
+			}
+			if el, ok := itemType.(attest.ZAttestReqType); ok {
+				log.Noticef("deferred queue has ATTEST: %d", el)
+			}
+		} else if result == types.SenderStatusNone {
 			if data == nil {
 				return
 			}

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -29,6 +29,7 @@ const (
 	SenderStatusCertUnknownAuthorityProxy              // device configed proxy, may miss proxy certificate for MiTM
 	SenderStatusNotFound                               // 404 indicating device might have been deleted in controller
 	SenderStatusForbidden                              // 403 indicating integrity token might invalidated
+	SenderStatusFailed                                 // Other failure
 )
 
 const (

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -30,6 +30,7 @@ const (
 	SenderStatusNotFound                               // 404 indicating device might have been deleted in controller
 	SenderStatusForbidden                              // 403 indicating integrity token might invalidated
 	SenderStatusFailed                                 // Other failure
+	SenderStatusDebug                                  // Not a failure
 )
 
 const (

--- a/pkg/pillar/zedcloud/deferred.go
+++ b/pkg/pillar/zedcloud/deferred.go
@@ -196,8 +196,19 @@ func (ctx *DeferredContext) handleDeferred(log *base.LogObject, event time.Time,
 	if len(ctx.deferredItems) == 0 {
 		stopTimer(log, ctx)
 	}
-	log.Functionf("handleDeferred() done items %d", len(ctx.deferredItems))
-	return len(ctx.deferredItems) == 0
+	if len(ctx.deferredItems) == 0 {
+		log.Functionf("handleDeferred() done")
+		return true
+	}
+	log.Noticef("handleDeferred() done items %d", len(ctx.deferredItems))
+	// Log the content of the queue
+	if ctx.sentHandler != nil {
+		for _, item := range ctx.deferredItems {
+			f := *ctx.sentHandler
+			f(item.itemType, item.buf, types.SenderStatusDebug)
+		}
+	}
+	return false
 }
 
 // Replace any item for the specified key. If timer not running start it

--- a/pkg/pillar/zedcloud/deferred.go
+++ b/pkg/pillar/zedcloud/deferred.go
@@ -137,7 +137,7 @@ func (ctx *DeferredContext) handleDeferred(log *base.LogObject, event time.Time,
 				// Make sure we pass a non-zero result
 				// to the sentHandler.
 				if result == types.SenderStatusNone {
-					result = types.SenderStatusRefused
+					result = types.SenderStatusFailed
 				}
 			} else if result != types.SenderStatusNone {
 				log.Functionf("handleDeferred: for %s received unexpected status %d",

--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -715,6 +715,8 @@ func SendOnIntf(workContext context.Context, ctx *ZedCloudContext, destURL strin
 			// zedrouter probing sends 'http' to zedcloud server, expect to get status of 404, not an error
 			if resp.StatusCode != http.StatusNotFound || ctx.AgentName != "zedrouter" {
 				log.Errorln(errStr)
+				log.Errorf("Got payload for status %s: %s",
+					http.StatusText(resp.StatusCode), contents)
 			}
 			log.Tracef("received response %v\n", resp)
 			// Get caller to schedule a retry based on StatusCode

--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -718,7 +718,6 @@ func SendOnIntf(workContext context.Context, ctx *ZedCloudContext, destURL strin
 				log.Errorf("Got payload for status %s: %s",
 					http.StatusText(resp.StatusCode), contents)
 			}
-			log.Tracef("received response %v\n", resp)
 			// Get caller to schedule a retry based on StatusCode
 			return resp, nil, types.SenderStatusNone, errors.New(errStr)
 		}


### PR DESCRIPTION
This was a bit of a chase which found several minor issues, fixed in separate commits:

1. Fix incorrect error handling when processing deferred sends.
Need to check both error and SenderStatus to determine it was ok.
Without this we declare that the EdgeNodeCerts have been sent when
the send failed.

2. ZInfoTypes_ZiHardware sent with wrong DevId
This resulted in 403 errors from the controller since the uuid in the
URL and the payload did not match.

3. Missing objects in objectInfoTask
The new Hardware and Location info messages needs to be sent when
triggered to send all objects to the controller.

4. Log content when http error status
This makes it easier to track down future issues like number 2 above

5. Add debug of the deferred queue

