### PR TITLE
Fixed commit version downloads

### DIFF
--- a/pkg/fw/Dockerfile
+++ b/pkg/fw/Dockerfile
@@ -45,7 +45,7 @@ RUN curl -fsSL ${RPI_BT_FIRMWARE_URL}/${RPI_BT_FIRMWARE_VERSION}/broadcom/BCM434
     curl -fsSL ${RPI_BT_FIRMWARE_URL}/${RPI_BT_FIRMWARE_VERSION}/broadcom/BCM43430B0.hcd -O &&\
     curl -fsSL ${RPI_BT_FIRMWARE_URL}/${RPI_BT_FIRMWARE_VERSION}/broadcom/BCM4345C5.hcd -O
 
-FROM busybox as compactor
+FROM busybox@sha256:ef320ff10026a50cf5f0213d35537ce0041ac1d96e9b7800bafd8bc9eff6c693 as compactor
 ENTRYPOINT []
 WORKDIR /
 COPY --from=build /lib/firmware/regulatory* /lib/firmware/

--- a/pkg/fw/Dockerfile
+++ b/pkg/fw/Dockerfile
@@ -45,7 +45,7 @@ RUN curl -fsSL ${RPI_BT_FIRMWARE_URL}/${RPI_BT_FIRMWARE_VERSION}/broadcom/BCM434
     curl -fsSL ${RPI_BT_FIRMWARE_URL}/${RPI_BT_FIRMWARE_VERSION}/broadcom/BCM43430B0.hcd -O &&\
     curl -fsSL ${RPI_BT_FIRMWARE_URL}/${RPI_BT_FIRMWARE_VERSION}/broadcom/BCM4345C5.hcd -O
 
-FROM busybox@sha256:ef320ff10026a50cf5f0213d35537ce0041ac1d96e9b7800bafd8bc9eff6c693 as compactor
+FROM ${EVE_BUILDER_IMAGE} as compactor
 ENTRYPOINT []
 WORKDIR /
 COPY --from=build /lib/firmware/regulatory* /lib/firmware/

--- a/pkg/strongswan/Dockerfile
+++ b/pkg/strongswan/Dockerfile
@@ -6,7 +6,9 @@ FROM lfedge/eve-alpine:6.7.0 as build
 ENV BUILD_PKGS gcc make patch libc-dev linux-headers tar build-base ca-certificates iptables iproute2 openssl openssl-dev
 RUN eve-alpine-deploy.sh
 
-ENV STRONGSWAN_RELEASE https://download.strongswan.org/strongswan.tar.bz2
+ENV STRONGSWAN_VERSION 5.6.3
+ENV STRONGSWAN_FILE strongswan-${STRONGSWAN_VERSION}.tar.bz2
+ENV STRONGSWAN_RELEASE https://download.strongswan.org/${STRONGSWAN_FILE}
 ENV CONFIGURE_OPTS_x86_64 --enable-aesni
 ENV CONFIGURE_OPTS --prefix=/usr \
             --sysconfdir=/etc \
@@ -52,7 +54,7 @@ RUN rm -rf /out && mkdir /out
 COPY curl-7.61.1.tar.bz2 /tmp/curl-7.61.1.tar.bz2
 RUN tar -C /tmp -xjvf /tmp/curl-7.61.1.tar.bz2 ; cd /tmp/curl-7.61.1 ; ./configure --prefix=/usr ; make  -j "$(getconf _NPROCESSORS_ONLN)" install
 
-COPY strongswan.tar.bz2 /tmp/strongswan/strongswan.tar.bz2 
+COPY ${STRONGSWAN_FILE} /tmp/strongswan/strongswan.tar.bz2
 RUN  tar --strip-components=1 -C /tmp/strongswan -xjf /tmp/strongswan/strongswan.tar.bz2
 RUN  eval ./configure $CONFIGURE_OPTS \$CONFIGURE_OPTS_`uname -m`
 RUN    make  -j "$(getconf _NPROCESSORS_ONLN)"

--- a/pkg/uefi/Dockerfile
+++ b/pkg/uefi/Dockerfile
@@ -17,8 +17,11 @@ ENV BUILD_PKGS_amd64 iasl
 ENV BUILD_PKGS_arm64 iasl
 RUN eve-alpine-deploy.sh
 
-RUN git clone --depth 1 -b edk2-stable202005 https://github.com/tianocore/edk2.git /ws
-RUN git clone --depth 1 https://github.com/riscv/opensbi.git /opensbi
+ENV EDK_COMMIT ca407c7246bf405da6d9b1b9d93e5e7f17b4b1f9
+ENV SBI_COMMIT cbaa9b0333517b3c25bea8d1c71ac8005ff1f727
+
+RUN git clone -b edk2-stable202005 https://github.com/tianocore/edk2.git /ws && git -C /ws checkout ${EDK_COMMIT}
+RUN git clone https://github.com/riscv/opensbi.git /opensbi && git -C /opensbi checkout ${SBI_COMMIT}
 WORKDIR /ws
 RUN git submodule update --init
 COPY build.sh /ws/


### PR DESCRIPTION
In 3 places in building various `pkg/*`, in the Dockerfile, we downloaded from the Internet or used the `busybox` image with just the latest. This meant that reproducing it was not reliable, as `latest` for an OCI image or a download link could change.

3 commits in this PR each addresses it for 3 different `pkg/*/Dockerfile`:

* `pkg/strongswan`: explicitly specify a version rather than just downloading link to latest. Note that I checked which version we currently are using via the md5 hash and used the same one. This PR **does not** change the version used, only explicitly references it
* `pkg/fw`: use an explicit `FROM busybox@sha256:<hash>` instead of just `FROM busybox`
* `pkg/uefi`: check out the specific commits of edk2 and opensbi instead of just cloning and using whatever the most recent commit is