### PR TITLE
Fix reporting of used data by a zvol

### DIFF
--- a/pkg/pillar/zfs/zfs.go
+++ b/pkg/pillar/zfs/zfs.go
@@ -191,11 +191,11 @@ func GetZFSVolumeInfo(log *base.LogObject, device string) (*types.ImgInfo, error
 		return nil, fmt.Errorf("GetDatasetByDevice returns empty for device: %s",
 			device)
 	}
-	logicalreferenced, err := GetDatasetOption(log, dataset, "logicalreferenced")
+	usedbydataset, err := GetDatasetOption(log, dataset, "usedbydataset")
 	if err != nil {
 		return nil, fmt.Errorf("GetZFSVolumeInfo GetDatasetOption failed: %s", err)
 	}
-	imgInfo.ActualSize, err = strconv.ParseUint(logicalreferenced, 10, 64)
+	imgInfo.ActualSize, err = strconv.ParseUint(usedbydataset, 10, 64)
 	if err != nil {
 		return nil, fmt.Errorf("GetZFSVolumeInfo: failed to parse referenced: %s", err)
 	}


### PR DESCRIPTION
This commit fixes a bug where zfs property logicalreferenced was used to get the space used by a zvol.
That is incorrect because that property does not give the accurate amount of data stored on the volume. It excludes compression and includes metadata which is not user data.

usedbydataset is the correct property for this purpose.

Signed-off-by: Pramodh Pallapothu <pramodh@zededa.com>