### PR TITLE
Update functions in the ZFS package that use base.Exec() to get information

### DIFF
--- a/pkg/pillar/cmd/volumemgr/dirs.go
+++ b/pkg/pillar/cmd/volumemgr/dirs.go
@@ -41,7 +41,7 @@ func initializeDatasets() {
 		types.VolumeEncryptedZFSDataset,
 	}
 	for _, datasetName := range volumeDatasets {
-		if _, err := zfs.GetDatasetOptions(log, datasetName); err != nil {
+		if !zfs.DatasetExist(log, datasetName) {
 			if output, err := zfs.CreateDataset(log, datasetName); err != nil {
 				log.Fatalf("CreateDataset failed: %s %s ", output, err)
 			}

--- a/pkg/pillar/cmd/volumemgr/handlevolume.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume.go
@@ -126,7 +126,7 @@ func handleDeferredVolumeCreate(ctx *volumemgrContext, key string, config *types
 
 	if persistFsType == types.PersistZFS && !status.IsContainer() {
 		zvolName := status.ZVolName()
-		if _, err := zfs.GetDatasetOptions(log, zvolName); err == nil {
+		if zfs.DatasetExist(log, zvolName) {
 			zVolDevice := zfs.GetZVolDeviceByDataset(zvolName)
 			if zVolDevice == "" {
 				errStr := fmt.Sprintf("cannot find device for zvol %s of %s", zvolName, status.Key())

--- a/pkg/pillar/cmd/volumemgr/initialvolumestatus.go
+++ b/pkg/pillar/cmd/volumemgr/initialvolumestatus.go
@@ -82,9 +82,9 @@ func gcDatasets(ctx *volumemgrContext, dataset string) {
 		return
 	}
 	log.Tracef("gcDatasets(%s)", dataset)
-	locations, err := zfs.GetVolumesInDataset(log, dataset)
+	locations, err := zfs.GetVolumesFromDataset(dataset)
 	if err != nil {
-		log.Errorf("gcDatasets: GetVolumesInDataset '%s' failed: %v",
+		log.Errorf("gcDatasets: GetVolumesFromDataset '%s' failed: %v",
 			dataset, err)
 		return
 	}
@@ -162,7 +162,7 @@ func gcPendingCreateVolume(ctx *volumemgrContext) {
 				zVolName := vcp.ZVolName()
 				// check if dataset exists
 				// assume that we should remove it as not created completely
-				if _, err := zfs.GetDatasetOptions(log, zVolName); err == nil {
+				if zfs.DatasetExist(log, zVolName) {
 					if stdoutStderr, err := zfs.DestroyDataset(log, zVolName); err != nil {
 						log.Errorf("gcPendingCreateVolume: error destroying zfs zvol at %s, error=%s, output=%s",
 							zVolName, err, stdoutStderr)

--- a/pkg/pillar/utils/volumeutils.go
+++ b/pkg/pillar/utils/volumeutils.go
@@ -29,7 +29,7 @@ func GetVolumeSize(log *base.LogObject, name string) (uint64, uint64, string, bo
 	}
 	if info.Mode()&os.ModeDevice != 0 {
 		//Assume this is zfs device
-		imgInfo, err := zfs.GetZFSVolumeInfo(log, name)
+		imgInfo, err := zfs.GetZFSVolumeInfo(name)
 		if err != nil {
 			errStr := fmt.Sprintf("GetVolumeSize/GetZFSInfo failed for %s: %v",
 				name, err)


### PR DESCRIPTION
This commit changes the functions in the ZFS package where we used base.Exec() to get information. 
After this commit, data will be collected through the go-libzfs.

Signed-off-by: Vitaliy Kuznetsov <ahil52_25@mail.ru>