### PR TITLE
Make sure to check StatusCreated

### DIFF
--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -1117,6 +1117,8 @@ func myPost(ctx *diagContext, reqURL string, ifname string,
 	switch resp.StatusCode {
 	case http.StatusOK:
 		fmt.Fprintf(outfile, "INFO: %s: %s StatusOK\n", ifname, reqURL)
+	case http.StatusCreated:
+		fmt.Fprintf(outfile, "INFO: %s: %s StatusCreated\n", ifname, reqURL)
 	case http.StatusNotModified:
 		fmt.Fprintf(outfile, "INFO: %s: %s StatusNotModified\n", ifname, reqURL)
 	default:

--- a/pkg/pillar/cmd/loguploader/loguploader.go
+++ b/pkg/pillar/cmd/loguploader/loguploader.go
@@ -779,7 +779,8 @@ func sendToCloud(ctx *loguploaderContext, data []byte, iter int, fName string, f
 	//  - if resp is 4xx, the file maybe moved to 'failtosend' directory later
 	resp, contents, _, err := zedcloud.SendOnAllIntf(ctxWork, ctx.zedcloudCtx, logsURL, size, buf, iter, true)
 	if resp != nil {
-		if resp.StatusCode == http.StatusOK {
+		if resp.StatusCode == http.StatusOK ||
+			resp.StatusCode == http.StatusCreated {
 			latency := time.Since(startTime).Nanoseconds() / int64(time.Millisecond)
 			if ctx.metrics.Latency.MinUploadMsec == 0 || ctx.metrics.Latency.MinUploadMsec > uint32(latency) {
 				ctx.metrics.Latency.MinUploadMsec = uint32(latency)

--- a/pkg/pillar/cmd/zedagent/handlelocation.go
+++ b/pkg/pillar/cmd/zedagent/handlelocation.go
@@ -206,7 +206,7 @@ func publishLocationToLocalServer(ctx *getconfigContext, locInfo *info.ZInfoLoca
 			case http.StatusNotFound:
 				ctx.lpsThrottledLocation = true
 				return
-			case http.StatusOK, http.StatusNoContent:
+			case http.StatusOK, http.StatusCreated, http.StatusNoContent:
 				ctx.lpsThrottledLocation = false
 				return
 			default:

--- a/pkg/pillar/cmd/zedagent/localinfo.go
+++ b/pkg/pillar/cmd/zedagent/localinfo.go
@@ -152,7 +152,7 @@ func postLocalAppInfo(ctx *getconfigContext) *profile.LocalAppCmdList {
 				// Throttle sending to be about once per hour.
 				updateLocalAppInfoTicker(ctx, true)
 				return nil
-			case http.StatusOK:
+			case http.StatusOK, http.StatusCreated:
 				if len(appCmds.AppCommands) != 0 {
 					if appCmds.GetServerToken() != ctx.profileServerToken {
 						errList = append(errList,
@@ -644,7 +644,7 @@ func postLocalDevInfo(ctx *getconfigContext) *profile.LocalDevCmd {
 				// Throttle sending to be about once per hour.
 				updateLocalDevInfoTicker(ctx, true)
 				return nil
-			case http.StatusOK:
+			case http.StatusOK, http.StatusCreated:
 				if devCmd.GetServerToken() != ctx.profileServerToken {
 					errList = append(errList,
 						fmt.Sprintf("invalid token submitted by local server (%s)",

--- a/pkg/pillar/cmd/zedagent/radiosilence.go
+++ b/pkg/pillar/cmd/zedagent/radiosilence.go
@@ -196,7 +196,7 @@ func getRadioConfig(ctx *getconfigContext, radioStatus *profile.RadioStatus) *pr
 				errList = append(errList, fmt.Sprintf("SendLocalProto: %v", err))
 				continue
 			}
-			if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+			if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusCreated {
 				errList = append(errList, fmt.Sprintf("SendLocal: wrong response status code: %d",
 					resp.StatusCode))
 				continue

--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -317,7 +317,7 @@ func VerifyAllIntf(ctx *ZedCloudContext,
 			continue
 		}
 		switch resp.StatusCode {
-		case http.StatusOK, http.StatusCreated:
+		case http.StatusOK, http.StatusCreated, http.StatusNotModified, http.StatusNoContent:
 			log.Tracef("VerifyAllIntf: Zedcloud reachable via interface %s", intf)
 			intfStatusMap.RecordSuccess(intf)
 			intfSuccessCount++
@@ -705,7 +705,7 @@ func SendOnIntf(workContext context.Context, ctx *ZedCloudContext, destURL strin
 		}
 
 		switch resp.StatusCode {
-		case http.StatusOK, http.StatusCreated, http.StatusNotModified:
+		case http.StatusOK, http.StatusCreated, http.StatusNotModified, http.StatusNoContent:
 			log.Tracef("SendOnIntf to %s, response %s\n", reqUrl, resp.Status)
 			return resp, contents, senderStatus, nil
 		default:

--- a/pkg/pillar/zedcloud/wstunnelclient.go
+++ b/pkg/pillar/zedcloud/wstunnelclient.go
@@ -137,14 +137,16 @@ func (t *WSTunnelClient) TestConnection(devNetStatus *types.DeviceNetworkStatus,
 	}
 	log.Tracef("Read ping response status code: %v for ping url: %s", resp.StatusCode, pingURL)
 
-	if resp.StatusCode == http.StatusOK {
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusCreated, http.StatusNotModified:
 		url := URLPathString(t.Tunnel, zedcloudCtx.V2API, devUUID, "connection/tunnel")
 		t.DestURL = url
 		t.Dialer = dialer
 		log.Functionf("Connection test succeeded for url: %s on local address: %v, proxy: %v", url, localAddr, proxyURL)
 		return nil
+	default:
+		return err
 	}
-	return err
 }
 
 // startSession connects to configured backend on a


### PR DESCRIPTION
The issue fixed in bf8b4d0b10dcb37d6366769edba358152c88a349 was not detected by the Eden tests because the loguploader code had different code for StatusOK and StatusCreated.
Here we fix that plus other places where we do not allow all different statuses which indicate success. 