### PR TITLE
Patch 8.9.1

### DIFF
--- a/pkg/pillar/cmd/loguploader/loguploader.go
+++ b/pkg/pillar/cmd/loguploader/loguploader.go
@@ -790,16 +790,8 @@ func sendToCloud(ctx *loguploaderContext, data []byte, iter int, fName string, f
 			totalLatency := int64(ctx.metrics.Latency.AvgUploadMsec) *
 				int64(ctx.metrics.AppMetrics.NumGZipFilesSent+ctx.metrics.DevMetrics.NumGZipFilesSent)
 			filetime := time.Unix(int64(fTime/1000), 0) // convert msec to unix sec
-			if len(contents) != 0 {
-				contents, _, err = zedcloud.RemoveAndVerifyAuthContainer(ctx.zedcloudCtx,
-					logsURL, contents, false, types.SenderStatusNone)
-				if err != nil {
-					log.Errorf("RemoveAndVerifyAuthContainer failed: %s", err)
-					// Ignore response payload
-					contents = []byte{}
-				}
-			}
-
+			// Note that contents does not have an AuthContainer
+			// FIXME: documentation or code needs to change
 			if isApp {
 				ctx.metrics.AppMetrics.RecentUploadTimestamp = filetime
 				ctx.metrics.AppMetrics.NumGZipFilesSent++


### PR DESCRIPTION
In
https://github.com/lf-edge/eve/pull/2764/commits/3690c47152303db391c65bc5b273e0791d4bb4e4
there is a subtle bug related to reusing the err variable in
loguploader.go. Reading the diff it seems like loguploader will just log
an error and that is it, but since err is set before the added
VerifyAuthentication call and checked long after, this is also treated
as complete failure to send, resulting in no logs being sent to the
controller.

Signed-off-by: eriknordmark <erik@zededa.com>
(cherry picked from commit bf8b4d0b10dcb37d6366769edba358152c88a349)