### PR TITLE
Refactor zedagent's Run function

### DIFF
--- a/pkg/pillar/cmd/zedagent/attesttask.go
+++ b/pkg/pillar/cmd/zedagent/attesttask.go
@@ -612,7 +612,7 @@ func cleanupEventLog(quoteMsg *attest.ZAttestQuote) {
 }
 
 // initialize attest pubsub trigger handlers and channels
-func attestModuleInitialize(ctx *zedagentContext, ps *pubsub.PubSub) error {
+func attestModuleInitialize(ctx *zedagentContext) error {
 	zattest.RegisterExternalIntf(&TpmAgentImpl{}, &VerifierImpl{}, &WatchdogImpl{})
 
 	if ctx.attestCtx == nil {
@@ -625,7 +625,7 @@ func attestModuleInitialize(ctx *zedagentContext, ps *pubsub.PubSub) error {
 		return err
 	}
 	ctx.attestCtx.attestFsmCtx = c
-	pubAttestNonce, err := ps.NewPublication(
+	pubAttestNonce, err := ctx.ps.NewPublication(
 		pubsub.PublicationOptions{
 			AgentName: agentName,
 			TopicType: types.AttestNonce{},
@@ -634,7 +634,7 @@ func attestModuleInitialize(ctx *zedagentContext, ps *pubsub.PubSub) error {
 		log.Fatal(err)
 	}
 	ctx.attestCtx.pubAttestNonce = pubAttestNonce
-	pubEncryptedKeyFromController, err := ps.NewPublication(
+	pubEncryptedKeyFromController, err := ctx.ps.NewPublication(
 		pubsub.PublicationOptions{
 			AgentName: agentName,
 			TopicType: types.EncryptedVaultKeyFromController{},

--- a/pkg/pillar/cmd/zedagent/handlebaseos.go
+++ b/pkg/pillar/cmd/zedagent/handlebaseos.go
@@ -10,6 +10,68 @@ import (
 	"strings"
 )
 
+// base os status event handlers
+// Report BaseOsStatus to zedcloud
+func handleBaseOsStatusCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleBaseOsStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleBaseOsStatusModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleBaseOsStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleBaseOsStatusImpl(ctxArg interface{}, key string,
+	statusArg interface{}) {
+
+	ctx := ctxArg.(*zedagentContext)
+	triggerPublishDevInfo(ctx)
+	log.Functionf("handleBaseOsStatusImpl(%s) done", key)
+}
+
+func handleBaseOsStatusDelete(ctxArg interface{}, key string,
+	statusArg interface{}) {
+
+	log.Functionf("handleBaseOsStatusDelete(%s)", key)
+	ctx := ctxArg.(*zedagentContext)
+	triggerPublishDevInfo(ctx)
+	log.Functionf("handleBaseOsStatusDelete(%s) done", key)
+}
+
+func handleZbootStatusCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleZbootStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleZbootStatusModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleZbootStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleZbootStatusImpl(ctxArg interface{}, key string,
+	statusArg interface{}) {
+
+	ctx := ctxArg.(*zedagentContext)
+	if !isZbootValidPartitionLabel(key) {
+		log.Errorf("handleZbootStatusImpl: invalid key %s", key)
+		return
+	}
+	log.Functionf("handleZbootStatusImpl: for %s", key)
+	// nothing to do
+	triggerPublishDevInfo(ctx)
+}
+
+func handleZbootStatusDelete(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	if !isZbootValidPartitionLabel(key) {
+		log.Errorf("handleZbootStatusDelete: invalid key %s", key)
+		return
+	}
+	log.Functionf("handleZbootStatusDelete: for %s", key)
+	// Nothing to do
+}
+
 // utility routines to access baseos partition status
 func isZbootValidPartitionLabel(name string) bool {
 	partitionNames := []string{"IMGA", "IMGB"}

--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -18,7 +18,6 @@ import (
 	zconfig "github.com/lf-edge/eve/api/go/config"
 	"github.com/lf-edge/eve/api/go/evecommon"
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
-	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/zedcloud"
 	"google.golang.org/protobuf/proto"
@@ -383,7 +382,7 @@ func sendAttestReqProtobuf(attestReq *attest.ZAttestReq, iteration int) {
 }
 
 // initialize cipher pubsub trigger handlers and channels
-func cipherModuleInitialize(ctx *zedagentContext, ps *pubsub.PubSub) {
+func cipherModuleInitialize(ctx *zedagentContext) {
 
 	// create the trigger channels
 	ctx.cipherCtx.triggerEdgeNodeCerts = make(chan struct{}, 1)

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -150,7 +150,7 @@ var nilUUID uuid.UUID
 // current epoch received from controller
 var controllerEpoch int64
 
-func handleConfigInit(networkSendTimeout uint32, agentMetrics *zedcloud.AgentMetrics) *zedcloud.ZedCloudContext {
+func initZedcloudContext(networkSendTimeout uint32, agentMetrics *zedcloud.AgentMetrics) *zedcloud.ZedCloudContext {
 
 	// get the server name
 	bytes, err := ioutil.ReadFile(types.ServerFileName)

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -204,7 +204,9 @@ func maybeUpdateMetricsTimer(ctx *getconfigContext, forceUpdate bool) {
 			updateMetricsTimer(ctx, latestMetricsInterval)
 		} else {
 			// Force an immediate timeout to publish metrics.
-			flextimer.TickNow(ctx.metricsTickerHandle)
+			if ctx.metricsTickerHandle != nil {
+				flextimer.TickNow(ctx.metricsTickerHandle)
+			}
 		}
 	}
 }

--- a/pkg/pillar/cmd/zedagent/radiosilence.go
+++ b/pkg/pillar/cmd/zedagent/radiosilence.go
@@ -112,7 +112,8 @@ func radioPOSTTask(ctx *getconfigContext) {
 }
 
 func getRadioStatus(ctx *getconfigContext) *profile.RadioStatus {
-	obj, err := ctx.zedagentCtx.subDeviceNetworkStatus.Get("global")
+	dnsCtx := ctx.zedagentCtx.dnsCtx
+	obj, err := dnsCtx.subDeviceNetworkStatus.Get("global")
 	if err != nil {
 		log.Error(err)
 		return nil

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -1847,6 +1847,10 @@ func triggerPublishDevInfo(ctxPtr *zedagentContext) {
 }
 
 func triggerPublishLocationToController(ctxPtr *zedagentContext) {
+	if ctxPtr.getconfigCtx.locationCloudTickerHandle == nil {
+		// Location reporting task is not yet running.
+		return
+	}
 	log.Function("Triggered publishLocationToController")
 	flextimer.TickNow(ctxPtr.getconfigCtx.locationCloudTickerHandle)
 }

--- a/pkg/pillar/pubsub/subscribe.go
+++ b/pkg/pillar/pubsub/subscribe.go
@@ -28,6 +28,7 @@ type SubscriptionImpl struct {
 	Persistent          bool
 
 	// Private fields
+	activated    bool
 	agentName    string
 	agentScope   string
 	topic        string
@@ -50,6 +51,10 @@ func (sub *SubscriptionImpl) MsgChan() <-chan Change {
 
 // Activate starts the subscription
 func (sub *SubscriptionImpl) Activate() error {
+	if sub.activated {
+		return errors.New("already activated")
+	}
+	sub.activated = true
 	if sub.Persistent {
 		sub.populate()
 	}
@@ -58,6 +63,9 @@ func (sub *SubscriptionImpl) Activate() error {
 
 // Close stops the subscription and removes the content
 func (sub *SubscriptionImpl) Close() error {
+	if !sub.activated {
+		return errors.New("not activated")
+	}
 	sub.driver.Stop()
 	items := sub.GetAll()
 	for key := range items {
@@ -67,6 +75,7 @@ func (sub *SubscriptionImpl) Close() error {
 	}
 	handleRestart(sub, 0)
 	handleSynchronized(sub, false)
+	sub.activated = false
 	return nil
 }
 

--- a/pkg/pillar/pubsub/subscribe.go
+++ b/pkg/pillar/pubsub/subscribe.go
@@ -28,7 +28,6 @@ type SubscriptionImpl struct {
 	Persistent          bool
 
 	// Private fields
-	activated    bool
 	agentName    string
 	agentScope   string
 	topic        string
@@ -51,10 +50,6 @@ func (sub *SubscriptionImpl) MsgChan() <-chan Change {
 
 // Activate starts the subscription
 func (sub *SubscriptionImpl) Activate() error {
-	if sub.activated {
-		return errors.New("already activated")
-	}
-	sub.activated = true
 	if sub.Persistent {
 		sub.populate()
 	}
@@ -63,9 +58,6 @@ func (sub *SubscriptionImpl) Activate() error {
 
 // Close stops the subscription and removes the content
 func (sub *SubscriptionImpl) Close() error {
-	if !sub.activated {
-		return errors.New("not activated")
-	}
 	sub.driver.Stop()
 	items := sub.GetAll()
 	for key := range items {
@@ -75,7 +67,6 @@ func (sub *SubscriptionImpl) Close() error {
 	}
 	handleRestart(sub, 0)
 	handleSynchronized(sub, false)
-	sub.activated = false
 	return nil
 }
 


### PR DESCRIPTION
The function has become very long (1500 lines), very hard to orientate.
As part of bootstrap config implementation, I started by splitting the Run function into multiple smaller ones for better readability (just code cleanup, no behaviour changes).
Opening this as a standalone PR so that bootstrap config (which will be opened once this is merged) can be reviewed without these non-functional changes increasing the diff.

Signed-off-by: Milan Lenco <milan@zededa.com>