### PR TITLE
Handle containerd upgrade taking a long time

### DIFF
--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -740,16 +740,20 @@ func handleVaultStatusImpl(ctxArg interface{}, key string,
 	if vault.Name != types.DefaultVaultName {
 		return
 	}
-	if vault.ConversionComplete && vault.Status != info.DataSecAtRestStatus_DATASEC_AT_REST_ERROR {
-		ctx.vaultOperational = types.TS_ENABLED
-		// Do we need to clear maintenance?
-		if ctx.maintMode &&
-			ctx.maintModeReason == types.MaintenanceModeReasonVaultLockedUp {
-			log.Noticef("Clearing %s",
-				types.MaintenanceModeReasonVaultLockedUp)
-			ctx.maintMode = false
-			ctx.maintModeReason = types.MaintenanceModeReasonNone
-			publishNodeAgentStatus(ctx)
+	if vault.Status != info.DataSecAtRestStatus_DATASEC_AT_REST_ERROR {
+		if vault.ConversionComplete {
+			ctx.vaultOperational = types.TS_ENABLED
+			// Do we need to clear maintenance?
+			if ctx.maintMode &&
+				ctx.maintModeReason == types.MaintenanceModeReasonVaultLockedUp {
+				log.Noticef("Clearing %s",
+					types.MaintenanceModeReasonVaultLockedUp)
+				ctx.maintMode = false
+				ctx.maintModeReason = types.MaintenanceModeReasonNone
+				publishNodeAgentStatus(ctx)
+			}
+		} else {
+			ctx.vaultOperational = types.TS_NONE
 		}
 	} else {
 		ctx.vaultOperational = types.TS_DISABLED

--- a/pkg/pillar/cmd/upgradeconverter/containerd.go
+++ b/pkg/pillar/cmd/upgradeconverter/containerd.go
@@ -8,6 +8,8 @@ import (
 )
 
 func moveToUserContainerd(ctxPtr *ucContext) error {
-	log.Functionf("moveToUserContainerd()")
-	return utils.MoveDir(ctxPtr.persistDir+"/containerd", ctxPtr.persistDir+"/vault/containerd")
+	log.Noticef("moveToUserContainerd()")
+	err := utils.MoveDir(log, ctxPtr.persistDir+"/containerd", ctxPtr.persistDir+"/vault/containerd")
+	log.Noticef("moveToUserContainerd() DONE")
+	return err
 }

--- a/pkg/pillar/cmd/upgradeconverter/renameverifiedfiles.go
+++ b/pkg/pillar/cmd/upgradeconverter/renameverifiedfiles.go
@@ -32,7 +32,7 @@ func renameVerifiedFiles(ctxPtr *ucContext) error {
 		ctxPtr.noFlag)
 	renameFiles(srcDirRoot+"/"+types.BaseOsObj+"/verified", dstDir,
 		ctxPtr.noFlag)
-	log.Functionf("renameVerifiedFiles() DONE")
+	log.Noticef("renameVerifiedFiles() DONE")
 	return nil
 }
 

--- a/pkg/pillar/cmd/vaultmgr/vaultmgr.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgr.go
@@ -1092,9 +1092,12 @@ func handleVaultKeyFromControllerImpl(ctxArg interface{}, key string,
 			log.Errorf("Failed to publish Vault Key, %v", err)
 		}
 
-		//Now that vault is unlocked, run any upgrade converter handler if needed
-		//The main select loop which is waiting on ucChan event, will publish
-		//latest status of vault(s) once RunPostVaultHandlers is complete.
+		// Publish current status of vault
+		publishVaultStatus(ctx)
+
+		// Now that vault is unlocked, run any upgrade converter handler if needed
+		// The main select loop which is waiting on ucChan event, will publish
+		// latest status of vault(s) once RunPostVaultHandlers is complete.
 		log.Notice("Starting upgradeconverter(post-vault)")
 		go uc.RunPostVaultHandlers(agentName, ctx.ps, logger, log,
 			debugOverride, ctx.ucChan)

--- a/pkg/pillar/utils/file/move.go
+++ b/pkg/pillar/utils/file/move.go
@@ -9,11 +9,13 @@ import (
 	"os"
 	"path/filepath"
 	"syscall"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
 )
 
 // MoveDir recursively move a directory tree, attempting to preserve permissions.
 // if file exists in dst (sub)directory it will be replaced
-func MoveDir(src string, dst string) error {
+func MoveDir(log *base.LogObject, src string, dst string) error {
 	src = filepath.Clean(src)
 	dst = filepath.Clean(dst)
 
@@ -43,12 +45,16 @@ func MoveDir(src string, dst string) error {
 		return fmt.Errorf("error read dst directory: %v", err)
 	}
 
+	if log != nil {
+		log.Noticef("MoveDir %d entries from %s to %s",
+			len(entries), src, dst)
+	}
 	for _, entry := range entries {
 		srcPath := filepath.Join(src, entry.Name())
 		dstPath := filepath.Join(dst, entry.Name())
 
 		if entry.IsDir() {
-			err = MoveDir(srcPath, dstPath)
+			err = MoveDir(log, srcPath, dstPath)
 			if err != nil {
 				return err
 			}
@@ -93,5 +99,14 @@ func MoveDir(src string, dst string) error {
 			}
 		}
 	}
-	return os.RemoveAll(src)
+	if log != nil {
+		log.Noticef("MoveDir deleting %d entries from %s",
+			len(entries), src)
+	}
+	err = os.RemoveAll(src)
+	if log != nil {
+		log.Noticef("MoveDir DONE %d entries from %s to %s",
+			len(entries), src, dst)
+	}
+	return err
 }


### PR DESCRIPTION
The logic in upgradeconverter can take a long time; one observed case
did not finish in 7 minutes with 10,000 files and 1.5Gbyte to copy from
/persist/containerd to /persist/vault/containerd. That resulted in the
vault not being unlocked in time for the EVE-OS update to succeed. Here
we tell the vault is unlocked before we run the upgrade converter. Other
microservices which will use the vault continue to check for it having
completed.

Plus a separate commit to add logging to be able to see the upgradeconverter progress when moving the files.