### PR TITLE
Update linuxkit to have a fix for riscv64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,7 @@ DOCKER_GO = _() { $(SET_X); mkdir -p $(CURDIR)/.go/src/$${3:-dummy} ; mkdir -p $
 
 PARSE_PKGS=$(if $(strip $(EVE_HASH)),EVE_HASH=)$(EVE_HASH) DOCKER_ARCH_TAG=$(DOCKER_ARCH_TAG) ./tools/parse-pkgs.sh
 LINUXKIT=$(BUILDTOOLS_BIN)/linuxkit
-LINUXKIT_VERSION=5f37332f4a0bd018af4bf6ebe8c5193a55d9e115
+LINUXKIT_VERSION=7c4e89b652dd4cfaed766fb3098658862668aacb
 LINUXKIT_SOURCE=https://github.com/linuxkit/linuxkit.git
 LINUXKIT_OPTS=$(if $(strip $(EVE_HASH)),--hash) $(EVE_HASH) $(if $(strip $(EVE_REL)),--release) $(EVE_REL) $(FORCE_BUILD)
 LINUXKIT_PKG_TARGET=build

--- a/Makefile
+++ b/Makefile
@@ -660,8 +660,14 @@ shell: $(GOBUILDER)
 # Utility targets in support of our Dockerized build infrastrucutre
 #
 
+# file to store current linuxkit version
+# if version mismatch will delete linuxkit to rebuild
+$(LINUXKIT).$(LINUXKIT_VERSION):
+	@rm -rf $(LINUXKIT)
+	@touch $(LINUXKIT).$(LINUXKIT_VERSION)
 # build linuxkit for the host OS, not the container OS
 $(LINUXKIT): GOOS=$(shell uname -s | tr '[A-Z]' '[a-z]')
+$(LINUXKIT): $(LINUXKIT).$(LINUXKIT_VERSION)
 $(LINUXKIT): | $(GOBUILDER)
 	$(QUIET)$(DOCKER_GO) \
 	"unset GOFLAGS; rm -rf /tmp/linuxkit && \


### PR DESCRIPTION
We noticed that publish workflow stuck on building of packages for riscv64. This has been resolved in https://github.com/linuxkit/linuxkit/pull/3820. Also PR includes check to rebuild linuxkit on version update.