### PR TITLE
Fix building on MacOS with new linuxkit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,7 @@ DOCKER_GO = _() { $(SET_X); mkdir -p $(CURDIR)/.go/src/$${3:-dummy} ; mkdir -p $
 
 PARSE_PKGS=$(if $(strip $(EVE_HASH)),EVE_HASH=)$(EVE_HASH) DOCKER_ARCH_TAG=$(DOCKER_ARCH_TAG) ./tools/parse-pkgs.sh
 LINUXKIT=$(BUILDTOOLS_BIN)/linuxkit
-LINUXKIT_VERSION=7c4e89b652dd4cfaed766fb3098658862668aacb
+LINUXKIT_VERSION=86cc42bf79fde5bba63519313da337144841b647
 LINUXKIT_SOURCE=https://github.com/linuxkit/linuxkit.git
 LINUXKIT_OPTS=$(if $(strip $(EVE_HASH)),--hash) $(EVE_HASH) $(if $(strip $(EVE_REL)),--release) $(EVE_REL)
 LINUXKIT_PKG_TARGET=build


### PR DESCRIPTION
We cannot build linuxkit now on MacOS as we use build inside docker and do not use CGO. Let's update linuxkit to have a patch to allow build for
 MacOS without CGO (https://github.com/linuxkit/linuxkit/pull/3822).

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>