### PR TITLE
pkg/fw: Fix firmware version for Intel AX210 WiFi

### DIFF
--- a/pkg/fw/Dockerfile
+++ b/pkg/fw/Dockerfile
@@ -56,8 +56,7 @@ COPY --from=build /lib/firmware/iwlwifi-8265* /lib/firmware/
 COPY --from=build /lib/firmware/iwlwifi-7260* /lib/firmware/
 COPY --from=build /lib/firmware/iwlwifi-9260* /lib/firmware/
 # AX210 160MHZ
-COPY --from=build /lib/firmware/iwlwifi-ty-a0-gf-a0-62.ucode /lib/firmware/
-COPY --from=build /lib/firmware/iwlwifi-ty-a0-gf-a0.pnvm /lib/firmware/
+COPY --from=build /lib/firmware/iwlwifi-ty-a0-gf-a0-59.ucode /lib/firmware/
 # NVidia Jetson
 COPY --from=build /lib/firmware/nvidia/tegra210 /lib/firmware/nvidia/tegra210
 # Dell Edge Gateway 300x firmware


### PR DESCRIPTION
Currently the firmware package (pkg/fw) is providing the following firmware for Intel AX210 WiFi chip:

iwlwifi-ty-a0-gf-a0-62.ucode

However, this version is not supported by the device driver of kernel 5.10.x, as pointed out by kernel messages:

iwlwifi 0000:65:00.0: Direct firmware load for iwlwifi-ty-a0-gf-a0-39.ucode failed with error -2
iwlwifi 0000:65:00.0: no suitable firmware found!
iwlwifi 0000:65:00.0: minimum version required: iwlwifi-ty-a0-gf-a0-39 iwlwifi 0000:65:00.0: maximum version supported: iwlwifi-ty-a0-gf-a0-59

This commit downgrades the firmware to version iwlwifi-ty-a0-gf-a0-59 and removes the file iwlwifi-ty-a0-gf-a0.pnvm, which is not compatible with this version. For more information, see the following bug report:

https://bugzilla.kernel.org/show_bug.cgi?id=212371

This commit was successfully tested on a x86 machine with a TP-Link AX3000 WiFi PCIe card.

Signed-off-by: Renê de Souza Pinto <rene@renesp.com.br>