### PR TITLE
[Require controller changes] Use ContentTree for BaseOS

### DIFF
--- a/pkg/pillar/cmd/baseosmgr/handlevolumemgr.go
+++ b/pkg/pillar/cmd/baseosmgr/handlevolumemgr.go
@@ -9,44 +9,6 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/types"
 )
 
-// MaybeAddContentTreeConfig makes sure we have a ContentTreeConfig
-func MaybeAddContentTreeConfig(ctx *baseOsMgrContext, ctc *types.ContentTreeConfig) bool {
-	log.Functionf("MaybeAddContentTreeConfig for %s", ctc.Key())
-	m := lookupContentTreeConfig(ctx, ctc.Key())
-	if m != nil {
-		log.Functionf("Content tree config exists for %s", ctc.Key())
-		return false
-	}
-	publishContentTreeConfig(ctx, ctc)
-	log.Functionf("MaybeAddContentTreeConfig for %s Done", ctc.Key())
-	return true
-}
-
-// MaybeRemoveContentTreeConfig deletes the ContentTreeConfig
-func MaybeRemoveContentTreeConfig(ctx *baseOsMgrContext, key string) bool {
-	log.Functionf("MaybeRemoveContentTreeConfig for %s", key)
-	m := lookupContentTreeConfig(ctx, key)
-	if m == nil {
-		log.Functionf("MaybeRemoveContentTreeConfig: config doesn't exist for %s", key)
-		return false
-	}
-	unpublishContentTreeConfig(ctx, key)
-	log.Functionf("MaybeRemoveContentTreeConfig for %s Done", key)
-	return true
-}
-
-func lookupContentTreeConfig(ctx *baseOsMgrContext, key string) *types.ContentTreeConfig {
-
-	pub := ctx.pubContentTreeConfig
-	c, _ := pub.Get(key)
-	if c == nil {
-		log.Functionf("lookupContentTreeConfig(%s) not found", key)
-		return nil
-	}
-	config := c.(types.ContentTreeConfig)
-	return &config
-}
-
 func lookupContentTreeStatus(ctx *baseOsMgrContext, key string) *types.ContentTreeStatus {
 
 	sub := ctx.subContentTreeStatus
@@ -59,26 +21,6 @@ func lookupContentTreeStatus(ctx *baseOsMgrContext, key string) *types.ContentTr
 	return &status
 }
 
-func publishContentTreeConfig(ctx *baseOsMgrContext, config *types.ContentTreeConfig) {
-
-	key := config.Key()
-	log.Functionf("publishContentTreeConfig(%s)", key)
-	pub := ctx.pubContentTreeConfig
-	pub.Publish(key, *config)
-}
-
-func unpublishContentTreeConfig(ctx *baseOsMgrContext, key string) {
-
-	log.Functionf("unpublishContentTreeConfig(%s)", key)
-	pub := ctx.pubContentTreeConfig
-	c, _ := pub.Get(key)
-	if c == nil {
-		log.Errorf("unpublishContentTreeConfig(%s) not found", key)
-		return
-	}
-	pub.Unpublish(key)
-}
-
 func handleContentTreeStatusCreate(ctxArg interface{}, key string,
 	statusArg interface{}) {
 	handleContentTreeStatusImpl(ctxArg, key, statusArg)
@@ -89,6 +31,11 @@ func handleContentTreeStatusModify(ctxArg interface{}, key string,
 	handleContentTreeStatusImpl(ctxArg, key, statusArg)
 }
 
+func handleContentTreeStatusDelete(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleContentTreeStatusImpl(ctxArg, key, statusArg)
+}
+
 func handleContentTreeStatusImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
@@ -96,16 +43,9 @@ func handleContentTreeStatusImpl(ctxArg interface{}, key string,
 	ctx := ctxArg.(*baseOsMgrContext)
 	log.Functionf("handleContentTreeStatusImpl: key:%s, name:%s",
 		key, status.DisplayName)
-	baseOsHandleStatusUpdateUUID(ctx, status.Key())
+	baseOSStatuses := lookupBaseOsStatusesByContentID(ctx, status.ContentID.String())
+	for _, el := range baseOSStatuses {
+		baseOsHandleStatusUpdateUUID(ctx, el.Key())
+	}
 	log.Functionf("handleContentTreeStatusImpl done for %s", key)
-}
-
-func handleContentTreeStatusDelete(ctxArg interface{}, key string,
-	statusArg interface{}) {
-
-	log.Functionf("handleContentTreeStatusDelete for %s", key)
-	ctx := ctxArg.(*baseOsMgrContext)
-	status := statusArg.(types.ContentTreeStatus)
-	baseOsHandleStatusUpdateUUID(ctx, status.Key())
-	log.Functionf("handleContentTreeStatusDelete done for %s", key)
 }

--- a/pkg/pillar/cmd/baseosmgr/worker.go
+++ b/pkg/pillar/cmd/baseosmgr/worker.go
@@ -17,17 +17,17 @@ const (
 
 // installWorkDescription install work we feed into the worker go routine
 type installWorkDescription struct {
-	contentID string
-	ref       string
-	target    string
+	key    string
+	ref    string
+	target string
 }
 
 // AddWorkInstall create a Work job to install the provided image to the target path
 func AddWorkInstall(ctx *baseOsMgrContext, key, ref, target string) {
 	d := installWorkDescription{
-		contentID: key,
-		ref:       ref,
-		target:    target,
+		key:    key,
+		ref:    ref,
+		target: target,
 	}
 	// Don't fail on errors to make idempotent (Submit returns an error if
 	// the work was already submitted)
@@ -72,6 +72,6 @@ func installWorker(ctxPtr interface{}, w worker.Work) worker.WorkResult {
 func processInstallWorkResult(ctxPtr interface{}, res worker.WorkResult) error {
 	ctx := ctxPtr.(*baseOsMgrContext)
 	d := res.Description.(installWorkDescription)
-	baseOsHandleStatusUpdateUUID(ctx, d.contentID)
+	baseOsHandleStatusUpdateUUID(ctx, d.key)
 	return nil
 }

--- a/pkg/pillar/cmd/volumemgr/handlevolume_test.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume_test.go
@@ -43,9 +43,8 @@ func initStatusCtx(t *testing.T) volumemgrContext {
 	ps := pubsub.New(&pubsub.EmptyDriver{}, logger, log)
 
 	pubVolumeStatus, err := ps.NewPublication(pubsub.PublicationOptions{
-		AgentName:  agentName,
-		AgentScope: types.AppImgObj,
-		TopicType:  types.VolumeStatus{},
+		AgentName: agentName,
+		TopicType: types.VolumeStatus{},
 	})
 	assert.Nil(t, err)
 	ctx.pubVolumeStatus = pubVolumeStatus

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -47,10 +47,9 @@ var volumeFormat = make(map[string]zconfig.Format)
 
 type volumemgrContext struct {
 	agentbase.AgentBase
-	ps                         *pubsub.PubSub
-	subBaseOsContentTreeConfig pubsub.Subscription
-	subGlobalConfig            pubsub.Subscription
-	subZedAgentStatus          pubsub.Subscription
+	ps                *pubsub.PubSub
+	subGlobalConfig   pubsub.Subscription
+	subZedAgentStatus pubsub.Subscription
 
 	pubDownloaderConfig  pubsub.Publication
 	subDownloaderStatus  pubsub.Subscription
@@ -278,9 +277,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	ctx.pubContentTreeStatus = pubContentTreeStatus
 
 	pubVolumeStatus, err := ps.NewPublication(pubsub.PublicationOptions{
-		AgentName:  agentName,
-		AgentScope: types.AppImgObj,
-		TopicType:  types.VolumeStatus{},
+		AgentName: agentName,
+		TopicType: types.VolumeStatus{},
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -288,9 +286,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	ctx.pubVolumeStatus = pubVolumeStatus
 
 	pubVolumeRefStatus, err := ps.NewPublication(pubsub.PublicationOptions{
-		AgentName:  agentName,
-		AgentScope: types.AppImgObj,
-		TopicType:  types.VolumeRefStatus{},
+		AgentName: agentName,
+		TopicType: types.VolumeRefStatus{},
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -460,7 +457,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		WarningTime:   warningTime,
 		ErrorTime:     errorTime,
 		AgentName:     "zedmanager",
-		AgentScope:    types.AppImgObj,
 		MyAgentName:   agentName,
 		TopicImpl:     types.VolumeRefConfig{},
 		Ctx:           &ctx,
@@ -470,23 +466,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	}
 	ctx.subVolumeRefConfig = subVolumeRefConfig
 	subVolumeRefConfig.Activate()
-
-	subBaseOsContentTreeConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		CreateHandler: handleContentTreeCreate,
-		ModifyHandler: handleContentTreeModify,
-		DeleteHandler: handleContentTreeDelete,
-		WarningTime:   warningTime,
-		ErrorTime:     errorTime,
-		AgentName:     "baseosmgr",
-		MyAgentName:   agentName,
-		TopicImpl:     types.ContentTreeConfig{},
-		Ctx:           &ctx,
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
-	ctx.subBaseOsContentTreeConfig = subBaseOsContentTreeConfig
-	subBaseOsContentTreeConfig.Activate()
 
 	subDatastoreConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		CreateHandler: handleDatastoreConfigCreate,
@@ -616,9 +595,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 
 		case change := <-ctx.subVolumeRefConfig.MsgChan():
 			ctx.subVolumeRefConfig.ProcessChange(change)
-
-		case change := <-ctx.subBaseOsContentTreeConfig.MsgChan():
-			ctx.subBaseOsContentTreeConfig.ProcessChange(change)
 
 		case change := <-ctx.subDatastoreConfig.MsgChan():
 			ctx.subDatastoreConfig.ProcessChange(change)

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -84,7 +84,6 @@ type getconfigContext struct {
 	pubAppNetworkConfig       pubsub.Publication
 	subAppNetworkStatus       pubsub.Subscription
 	pubBaseOsConfig           pubsub.Publication
-	pubBaseOs                 pubsub.Publication
 	pubDatastoreConfig        pubsub.Publication
 	pubNetworkInstanceConfig  pubsub.Publication
 	pubControllerCert         pubsub.Publication

--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -293,9 +293,12 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 			swInfo.Status = bos.State.ZSwState()
 			swInfo.ShortVersion = bos.BaseOsVersion
 			swInfo.LongVersion = "" // XXX
-			if len(bos.ContentTreeStatusList) > 0 {
-				// Assume one - pick first ContentTreeStatus
-				swInfo.DownloadProgress = uint32(bos.ContentTreeStatusList[0].Progress)
+			ctInterface, _ := ctx.getconfigCtx.subContentTreeStatus.Get(bos.ContentTreeUUID)
+			if ctInterface != nil {
+				ct, ok := ctInterface.(types.ContentTreeStatus)
+				if ok {
+					swInfo.DownloadProgress = uint32(ct.Progress)
+				}
 			}
 			if !bos.ErrorTime.IsZero() {
 				log.Tracef("reportMetrics sending error time %v error %v for %s",
@@ -347,9 +350,13 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 		swInfo.Status = bos.State.ZSwState()
 		swInfo.ShortVersion = bos.BaseOsVersion
 		swInfo.LongVersion = "" // XXX
-		if len(bos.ContentTreeStatusList) > 0 {
-			// Assume one - pick first ContentTreeStatus
-			swInfo.DownloadProgress = uint32(bos.ContentTreeStatusList[0].Progress)
+		ctInterface, _ := ctx.getconfigCtx.subContentTreeStatus.Get(bos.ContentTreeUUID)
+		if ctInterface != nil {
+			ct, ok := ctInterface.(types.ContentTreeStatus)
+			if ok {
+				// Assume one - pick first ContentTreeStatus
+				swInfo.DownloadProgress = uint32(ct.Progress)
+			}
 		}
 		if !bos.ErrorTime.IsZero() {
 			log.Tracef("reportMetrics sending error time %v error %v for %s",

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -1037,15 +1037,6 @@ func initPublications(zedagentCtx *zedagentContext) {
 	}
 	getconfigCtx.pubBaseOsConfig.ClearRestarted()
 
-	getconfigCtx.pubBaseOs, err = ps.NewPublication(pubsub.PublicationOptions{
-		AgentName: agentName,
-		TopicType: types.BaseOs{},
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
-	getconfigCtx.pubBaseOs.ClearRestarted()
-
 	getconfigCtx.pubDatastoreConfig, err = ps.NewPublication(pubsub.PublicationOptions{
 		AgentName: agentName,
 		TopicType: types.DatastoreConfig{},
@@ -1257,7 +1248,6 @@ func initPostOnboardSubs(zedagentCtx *zedagentContext) {
 	getconfigCtx.subVolumeStatus, err = ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "volumemgr",
 		MyAgentName:   agentName,
-		AgentScope:    types.AppImgObj,
 		TopicImpl:     types.VolumeStatus{},
 		Activate:      true,
 		Ctx:           zedagentCtx,

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -123,9 +123,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	pubAppInstanceSummary.ClearRestarted()
 
 	pubVolumeRefConfig, err := ps.NewPublication(pubsub.PublicationOptions{
-		AgentName:  agentName,
-		AgentScope: types.AppImgObj,
-		TopicType:  types.VolumeRefConfig{},
+		AgentName: agentName,
+		TopicType: types.VolumeRefConfig{},
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -207,7 +206,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	subVolumeRefStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "volumemgr",
 		MyAgentName:   agentName,
-		AgentScope:    types.AppImgObj,
 		TopicImpl:     types.VolumeRefStatus{},
 		Activate:      false,
 		Ctx:           &ctx,

--- a/pkg/pillar/cmd/zfsmanager/zfsmanager.go
+++ b/pkg/pillar/cmd/zfsmanager/zfsmanager.go
@@ -141,7 +141,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	subVolumeStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:   "volumemgr",
 		MyAgentName: agentName,
-		AgentScope:  types.AppImgObj,
 		TopicImpl:   types.VolumeStatus{},
 		Activate:    false,
 		Ctx:         &ctxPtr,

--- a/pkg/pillar/types/zedagenttypes.go
+++ b/pkg/pillar/types/zedagenttypes.go
@@ -14,28 +14,24 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
-// This is what we assume will come from the ZedControl for base OS.
-// Note that we can have different versions  configured for the
-// same UUID, hence the key is the UUIDandVersion  We assume the
-// elements in ContentTreeConfig should be installed, but activation
+// BaseOsConfig is what we assume will come from the ZedControl for base OS.
+// We assume ContentTreeUUID should be installed, but activation
 // is driven by the Activate attribute.
-
 type BaseOsConfig struct {
-	UUIDandVersion        UUIDandVersion
-	BaseOsVersion         string // From GetShortVersion
-	ContentTreeConfigList []ContentTreeConfig
-	RetryCount            int32
-	Activate              bool
+	BaseOsVersion      string
+	ContentTreeUUID    string
+	RetryUpdateCounter uint32
+	Activate           bool
 }
 
 func (config BaseOsConfig) Key() string {
-	return config.UUIDandVersion.UUID.String()
+	return config.ContentTreeUUID
 }
 
 // LogCreate :
 func (config BaseOsConfig) LogCreate(logBase *base.LogObject) {
 	logObject := base.NewLogObject(logBase, base.BaseOsConfigLogType, config.BaseOsVersion,
-		config.UUIDandVersion.UUID, config.LogKey())
+		nilUUID, config.LogKey())
 	if logObject == nil {
 		return
 	}
@@ -46,7 +42,7 @@ func (config BaseOsConfig) LogCreate(logBase *base.LogObject) {
 // LogModify :
 func (config BaseOsConfig) LogModify(logBase *base.LogObject, old interface{}) {
 	logObject := base.EnsureLogObject(logBase, base.BaseOsConfigLogType, config.BaseOsVersion,
-		config.UUIDandVersion.UUID, config.LogKey())
+		nilUUID, config.LogKey())
 
 	oldConfig, ok := old.(BaseOsConfig)
 	if !ok {
@@ -68,7 +64,7 @@ func (config BaseOsConfig) LogModify(logBase *base.LogObject, old interface{}) {
 // LogDelete :
 func (config BaseOsConfig) LogDelete(logBase *base.LogObject) {
 	logObject := base.EnsureLogObject(logBase, base.BaseOsConfigLogType, config.BaseOsVersion,
-		config.UUIDandVersion.UUID, config.LogKey())
+		nilUUID, config.LogKey())
 	logObject.CloneAndAddField("activate", config.Activate).
 		Noticef("BaseOs config delete")
 
@@ -80,16 +76,15 @@ func (config BaseOsConfig) LogKey() string {
 	return string(base.BaseOsConfigLogType) + "-" + config.BaseOsVersion
 }
 
-// Indexed by UUIDandVersion as above
+// BaseOsStatus indexed by ContentTreeUUID as above
 type BaseOsStatus struct {
-	UUIDandVersion        UUIDandVersion
-	BaseOsVersion         string
-	Activated             bool
-	TooEarly              bool // Failed since previous was inprogress/test
-	ContentTreeStatusList []ContentTreeStatus
-	PartitionLabel        string
-	PartitionDevice       string // From zboot
-	PartitionState        string // From zboot
+	BaseOsVersion   string
+	Activated       bool
+	TooEarly        bool // Failed since previous was inprogress/test
+	ContentTreeUUID string
+	PartitionLabel  string
+	PartitionDevice string // From zboot
+	PartitionState  string // From zboot
 	// Minimum state across all steps/StorageStatus.
 	// Error* set implies error.
 	State SwState
@@ -99,13 +94,13 @@ type BaseOsStatus struct {
 }
 
 func (status BaseOsStatus) Key() string {
-	return status.UUIDandVersion.UUID.String()
+	return status.ContentTreeUUID
 }
 
 // LogCreate :
 func (status BaseOsStatus) LogCreate(logBase *base.LogObject) {
 	logObject := base.NewLogObject(logBase, base.BaseOsStatusLogType, status.BaseOsVersion,
-		status.UUIDandVersion.UUID, status.LogKey())
+		nilUUID, status.LogKey())
 	if logObject == nil {
 		return
 	}
@@ -116,7 +111,7 @@ func (status BaseOsStatus) LogCreate(logBase *base.LogObject) {
 // LogModify :
 func (status BaseOsStatus) LogModify(logBase *base.LogObject, old interface{}) {
 	logObject := base.EnsureLogObject(logBase, base.BaseOsStatusLogType, status.BaseOsVersion,
-		status.UUIDandVersion.UUID, status.LogKey())
+		nilUUID, status.LogKey())
 
 	oldStatus, ok := old.(BaseOsStatus)
 	if !ok {
@@ -145,7 +140,7 @@ func (status BaseOsStatus) LogModify(logBase *base.LogObject, old interface{}) {
 // LogDelete :
 func (status BaseOsStatus) LogDelete(logBase *base.LogObject) {
 	logObject := base.EnsureLogObject(logBase, base.BaseOsStatusLogType, status.BaseOsVersion,
-		status.UUIDandVersion.UUID, status.LogKey())
+		nilUUID, status.LogKey())
 	logObject.CloneAndAddField("state", status.State.String()).
 		Noticef("BaseOs status delete")
 
@@ -583,12 +578,6 @@ type DeviceOpsCmd struct {
 // BaseOSMgrStatus : for sending from baseosmgr
 type BaseOSMgrStatus struct {
 	CurrentRetryUpdateCounter uint32 // CurrentRetryUpdateCounter from baseosmgr
-}
-
-// BaseOs : copy of zconfig.BaseOS
-type BaseOs struct {
-	ContentTreeUUID          string
-	ConfigRetryUpdateCounter uint32
 }
 
 // RadioSilence : used in ZedAgentStatus to record the *requested* state of radio devices.


### PR DESCRIPTION
We made transition to ContentTrees/Volumes about two years ago but still use Image/Drive in BaseOSConfig. This PR adjusts BaseOSConfig to use ContentTreeUuid from BaseOS as well as a current behavior. This way we can simplify the logic of baseosmgr.