### PR TITLE
add reproducibility and source tracing documentation

### DIFF
--- a/docs/EVE-IMAGE-REPRODUCIBILITY.md
+++ b/docs/EVE-IMAGE-REPRODUCIBILITY.md
@@ -1,0 +1,291 @@
+# EVE Reproducibility
+
+A key element of EVE is its consistency. Among other things, that means that it must be possible to rebuild EVE images, and the packages that are composed to form EVE, and get functionally identical bits.
+
+We write "functionally identical" rather than "precisely identical" or just "identical", because the compilation and composition process can change
+elements like timestamps or randomly generated data, leading to minor differences. Ideally, two builds of EVE from the same source would be
+precisely identical; that is a future goal. However, functionally identical images are a requirement for EVE.
+
+This document describes the reproducibility structures and process of EVE. It answers the "source-to-binary" question:
+
+    given that I have a specific version of this source code repository, how does the process ensure that I will get an
+    image that is functionally identical every time I run it, or else fail?
+
+This means that EVE's build process should always lead to one of only two outcomes:
+
+* Successfully build a functionally identical image; OR
+* Fail to build.
+
+It never should succeed in producing an image if it cannot produce one that is functionally identical. For example, if
+a part of the process depends on downloading a specific version of a dependency, then it must either get that precise version,
+or fail. It should not fall back to getting another version.
+
+It answers the question at multiple levels, each a layer deeper than the previous:
+
+1. EVE OS Images: how is the distributed, bootable EVE OS image created, and how does the build process render it reproducible.
+1. Package Images: how are the OCI container images that are used in the EVE OS image created, and how does the build process render them reproducible.
+1. OS Packages: how are the OS packages used inside the OCI container images consumed, and how does the build process render them reproducible.
+
+It does **not** answer the question, "given an image, how do I trace the precise source that created it?" The answer
+to that question, binary-to-source, is available in [EVE-IMAGE-SOURCES.md](./EVE-IMAGE-SOURCES.md).
+
+The description of the build process in [BUILD.md](./BUILD.md) is helpful in understanding how the build works in detail.
+
+## EVE OS Images
+
+EVE OS images are composed using [linuxkit](https://github.com/linuxkit/linuxkit). Linuxkit uses OCI container image contents to compose the
+bootable operating system.
+
+The yaml-format configuration files for composing the operating system are in [../images], primarily [rootfs.yml.in](../images/rootfs.yml.in).
+The detailed description of the yaml format can be found in [the linuxkit docs](https://github.com/linuxkit/linuxkit/blob/master/docs/yaml.md).
+
+Each container image used as an input is provided with a precise and unchanging tag.
+
+There are two image formats in the yaml file: fixed and templated.
+
+### Fixed Images
+
+Fixed tags are those that look like normal container images with tags or hashes. For example:
+
+* `linuxkit/init:8f1e6a0747acbbb4d7e24dc98f97faa8d1c6cec7`
+* `linuxkit/getty:v0.5`
+
+While tags on OCI registries, like [Docker Hub](https://hub.docker.com), are mutable, EVE only uses tags that are never mutated. This is true for both tags on `lfedge/eve-*` images, and those that come from upstream or other sources, like `linuxkit/*`.
+
+The semver tags, like `v0.5`, are never changed, nor are the hash-based tags.
+
+The hash-tags are, in all cases, the hash of the git-commited source tree of the package. Using the above example, the source to the `linuxkit/init` image
+is in this directory [https://github.com/linuxkit/linuxkit/tree/master/pkg/init](https://github.com/linuxkit/linuxkit/tree/master/pkg/init). When building the
+container image, it is tagged with the git hashed content of the directory tree. Thus, the result of that hash at the time the image was built
+was `8f1e6a0747acbbb4d7e24dc98f97faa8d1c6cec7`.
+
+It is possible to lock them down further, and make mutating tags impossible to slip through, by adding image index hashes to the yaml file, e.g.:
+
+* `linuxkit/init:8f1e6a0747acbbb4d7e24dc98f97faa8d1c6cec7@sha256:5c503aa479ae89ff7e3ea5e9d6c427e58ec78b7216ba1ad3cb2e4da2720913f0`
+* `linuxkit/getty:v0.5@sha256:6eba389196328d02ad01aea691a60931a42b6c81978a33f87e770df902869b9c`
+
+### Templated Images
+
+The other image names are templated. These are all captialized, and end in `_TAG`. For example:
+
+* `RNGD_TAG`
+* `PILLAR_TAG`
+
+These are not consumable by linuxkit; instead, the `Makefile` target that builds an EVE image, `make eve`, calls lower-level targets that parse
+this templated yaml file [rootfs.yml.in](../images/rootfs.yml.in), replacing all templates that end in `_TAG` with the appropriate image tags.
+
+These tags are calculated from the relevant directory. For example, `RNGD_TAG` is calculated based on the image that would be generated
+from the directory [pkg/rngd](../pkg/rngd/), and `PILLAR_TAG` based on the directory [pkg/pillar](../pkg/pillar/).
+
+The actual image name and tag are calculated identically to the process for the fixed tags, i.e. the git hash of the directory tree.
+The calculation is provided by running `linuxkit pkg show-tag dir/`. For example:
+
+```sh
+$ linuxkit pkg show-tag pkg/pillar
+lfedge/eve-pillar:b20146debd08bbfffb23f53fc9f5c3c4af377f67
+```
+
+With the template complete, every OCI container image used to compose an EVE operating system is in the generated `rootfs.yml`, each of which
+contains a hash of the state of the source at generation time.
+
+## Package Images
+
+The packages used as part of the EVE OS composition process are standard OCI container images.
+
+As described above in [EVE OS Images][EVE OS Images], all of the packages used to compose a bootable EVE image
+are configured in [rootfs.yml.in](../images/rootfs.yml.in). Those container images are from one of two sources:
+
+* `docker.io/linuxkit/*` whose sources are [https://github.com/linuxkit/linuxkit/tree/master/pkg/](https://github.com/linuxkit/linuxkit/tree/master/pkg/)
+* `docker.io/lfedge/eve-*` whose sources are in this repository under [../pkg](../pkg)
+
+Every source directory is git committed. As described above, when the source is compiled into an OCI container image, it always is named as follows:
+
+* the name of the image, e.g. `lfedge/eve-pillar`, is in the directory's `build.yaml` which, itself, is in git
+* the tag of the image, e.g. `b20146debd08bbfffb23f53fc9f5c3c4af377f67`, is calculated based on the git hash of the directory tree
+
+Further, if the directory is git "dirty", i.e. has any uncommitted files that are not in `.gitignore`, or has changed but uncommitted files,
+then the image tag is appended with the word `dirty` and the hash of the contents of the directory, e.g.
+`b20146debd08bbfffb23f53fc9f5c3c4af377f67-dirty-abcdefg112334`.
+
+The sources to all components used in the image, based on the `Dockerfile`, must come from one of several places.
+
+|Source|Method|Reproducibility|
+|---|---|---|
+|Another container image|Using `FROM` in the Dockerfile|Must use a properly immutably tagged image or one that includes the content hash|
+|Internet|`curl`, `wget` or other download|Must download a specific version and, wherever possible, check the content hash, md5 or sha|
+|Go packages|`go mod` or `go get`|Go inherently records the specific hash of the package version used in `go.sum`, which itself is git committed|
+|OS packages|`apk add`|See next section|
+
+It is possible for human error in any of the above to slip through. EVE uses peer review and maintainer approval to reduce the probabilities of
+any non-reproducible source slipping in.
+
+Further, the EVE project is exploring additional gates. These include:
+
+* Contributors certifying on each Pull Request that they have not used non-reproducible sources.
+* Regular automated audits of all `pkg/` sources.
+* CI scans of `pkg/` sources.
+
+## Linux Packages
+
+The primary source for many software packages in Linux is the OS packaging system. All of the OCI images used in EVE are based on
+[Alpine](https://hub.docker.com/_/alpine), which uses the [apk package manager](https://wiki.alpinelinux.org/wiki/Alpine_Package_Keeper).
+
+For example, to install bash:
+
+```sh
+apk add bash
+```
+
+Alpine packages creates unique challenges for reproducibility. Specifically:
+
+1. The version of the package changes when changing the alpine version. `apk add bash` can give entirely different bits when running on `alpine:3.15` vs `alpine:3.16`.
+1. The version of the package can change even _without_ changing the alpine version. `apk add bash` can give a different version running today on `alpine:3.16` vs yesterday or tomorrow on the same base `alpine:3.16`.
+
+It is possible to mitigate, but not completely solve, the above issue by adding a specific version:
+
+```sh
+apk add bash=5.1.16-r2
+```
+
+The above does not completely solve it, as sometimes alpine packages change their bits _even for the same version_. Thus, running
+`apk add bash=5.1.16-r2` on the same base `alpine:3.16` can give different bits on different days. Alpine packages are changed "under the covers"
+when bugs are found or updates are provided.
+
+In addition, often the public Alpine apk repositories only contain the most recent versions of packages. Thus, if the source
+installed bash version `5.1.16-r2`, but the most recent update is `5.1.16-r3`, then the one used, `5.1.16-r2`, may not be available.
+
+In order to resolve this issue, both the external/upstream `linuxkit/*` packages and the `lfedge/eve-*` packages in this repository follow the same principles.
+
+1. Create an alpine "cache" image: `linuxkit/alpine` and `lfedge/eve-alpine`. These are used as the base `FROM` for downstream images.
+1. All packages included in the composed EVE image **must** use `FROM lfedge/eve-alpine` or, in the case of linuxkit packages, `FROM linuxkit/alpine`, in their `Dockerfile`. `FROM alpine` is strictly forbidden.
+1. The cache images source from upstream alpine, download all necessary apk packages needed by downstream, `lfedge/eve-alpine` for EVE packages and `linuxkit/alpine` for linuxkit packages, and cache them.
+1. When downstream images need to install packages, they run `apk add package` which sources it solely from the cache in the cache image.
+
+The cache images - `lfedge/eve-alpine` and `linuxkit/alpine` - act as pinning cache, with precise versions and bits of each package.
+
+Only when the cache is regenerated, i.e. when `lfedge/eve-alpine` or `linuxkit/alpine` is rebuilt, can these change.
+
+Further, the caches maintain hashes of the local cache contents, to ensure that any changes are known and captured.
+
+To make this more concrete, we will walk through a specific example, `lfedge/eve-dom0-ztools`, which is based in [../pkg/dom0-ztools](../pkg/dom0-ztools/).
+
+The key parts of the Dockerfile are as follows:
+
+```dockerfile
+FROM lfedge/eve-alpine:145f062a40639b6c65efa36bed1c5614b873be52 as zfs
+ENV BUILD_PKGS git patch ca-certificates util-linux build-base gettext-dev libtirpc-dev automake autoconf \
+    libtool linux-headers attr-dev e2fsprogs-dev glib-dev openssl-dev util-linux-dev coreutils
+ENV PKGS ca-certificates util-linux libintl libuuid libtirpc libblkid libcrypto1.1 zlib
+RUN eve-alpine-deploy.sh
+...
+FROM scratch
+COPY --from=zfs /out/ /
+ADD rootfs/ /
+```
+
+Note the key elements:
+
+* The final image is based on `scratch`
+* The `FROM` image for installing necessary packages is **not** `alpine:3.16`, but rather the eve alpine cache image `lfedge/eve-alpine:145f062a40639b6c65efa36bed1c5614b873be52`
+* The packages needed to be installed are set in the `PKGS` environment variable: `ca-certificates util-linux libintl libuuid libtirpc libblkid libcrypto1.1 zlib`
+* The build packages needed to be installed are set in the `BUILD_PKGS` environment variable: `git patch ca-certificates util-linux build-base gettext-dev libtirpc-dev automake autoconf libtool linux-headers attr-dev e2fsprogs-dev glib-dev openssl-dev util-linux-dev coreutils`
+
+The usage of the `PKGS` and `BUILD_PKGS` environment variables and the script `eve-alpine-deploy.sh` is a simplified way to install packages.
+It is similar to calling:
+`apk add ca-certificates util-linux libintl libuuid libtirpc libblkid libcrypto1.1 zlib`, but
+do so from the cache.
+
+* Those packages listed in `BUILD_PKGS` are installed and available during the build of the `Dockerfile`.
+* Those packages listed in `PKGS` are installed and available during the build of the `Dockerfile`, but are also available in `/out/`. This enables copying them over to the final image.
+
+## How the Alpine cache image is built
+
+The two alpine cache images, linuxkit and EVE, use similar but slightly different caching techniques.
+Both use the official apk local cache feature described [here](https://wiki.alpinelinux.org/wiki/Alpine_Package_Keeper#Local_Cache).
+
+Both follow the same primary process in the Dockerfile:
+
+1. Install the tools necessary for working with apk
+1. Create a local mirror directory and set it up according to the above documentation
+1. Go through the list of packages required for all platforms, as well as platform specific, and install it to local cache
+1. Change the apk configuration so that any downstream container image that uses it and runs `apk add` will get it from cache, rather than the Internet
+
+### EVE alpine cache image
+
+The EVE alpine cache image is `lfedge/eve-alpine`, source at [../pkg/alpine](../pkg/alpine/)
+
+The list of packages to install is in [../pkg/alpine/mirrors](../pkg/alpine/mirrors/). There is a subdirectory for each version of alpine package
+repository we want, for example [../pkg/alpine/mirrors/3.16](../pkg/alpine/mirrors/3.16). Underneath those is a file for each repository type.
+Every package listed in those files will be installed to the cache.
+
+* `main` - list of packages to cache from the `main` package repository for all architectures
+* `community` - list of packages to cache from the `community` package repository for all architectures
+
+Optionally, there can be files with architecture extensions, which will be installed only on those architectures. For example:
+
+* `main.aarch64` - list packages from `main` to be installed only on `aarch64`.
+
+### Linuxkit alpine cache image
+
+The alpine cache image is `linuxkit/alpine`, source at
+[https://github.com/linuxkit/linuxkit/tree/master/tools/alpine](https://github.com/linuxkit/linuxkit/tree/master/tools/alpine).
+
+The list of packages to install is in the root directory of the package as [packages](https://github.com/linuxkit/linuxkit/tree/master/tools/alpine/packages).
+
+The linuxkit cache does not distinguish between repositories, e.g. `main` vs `community`. It also does not have support for installing from other versions of
+alpine, for example, if running on alpine 3.15 and needing a package only available in alpine 3.16.
+
+Optionally, there can be files with architecture extensions, which will be installed only on those architectures. For example:
+
+* `packages.aarch64` - list packages be installed only on `aarch64`.
+
+The linuxkit cache alpine image provides several additional checks to ensure reproducibility.
+
+Upon running a build, the build process updates `versions.<arch>` with:
+
+* the actual version of each package installed to cache
+* the hash of the cached content
+
+Specifically, at the end of the `Dockerfile` build, the following command is run:
+
+```sh
+echo Dockerfile /lib/apk/db/installed $(find /mirror -name '*.apk' -type f) $(find /go/bin -type f) | xargs cat | sha1sum | sed 's/ .*//' | sed 's/$/-'"${TARGETARCH}"'/' > /etc/alpine-hash-arch
+```
+
+This creates, inside the image, a file `/etc/alpine-hash-arch` with a single line. The contents of that line are `<hash>-<arch>` where:
+
+* `<hash>` is the sha1 hash of the entire contents of:
+  * the apk package database
+  * all of the apk cached files
+  * all of the golang binaries
+* `<arch>` is the architecture of the image
+
+For example, as of this writing, the contents of `/etc/alpine-hash-arch` on x86_64, a.k.a. amd64, are:
+
+```
+linuxkit/alpine:c9b0f6a435b663b98952d67f4c6f105c310d0a21-amd64
+```
+
+and the file [versions.x86_64](https://github.com/linuxkit/linuxkit/tree/master/tools/alpine/versions.x86_64) begins with:
+
+```
+# linuxkit/alpine:c9b0f6a435b663b98952d67f4c6f105c310d0a21-amd64
+# automatically generated list of installed packages
+abuild-3.8.0_rc4-r0
+alpine-baselayout-3.2.0-r16
+alpine-keys-2.4-r0
+apk-tools-2.12.7-r0
+argon2-libs-20190702-r1
+argp-standalone-1.3-r4
+```
+
+## Summary
+
+1. EVE itself can be reproduced reliably because it is built based on effectively immutably tagged OCI container images, based primarily on git tree hashes.
+1. Each package can be reproduced reliably because it sources only:
+   * specific versioned software from the Internet
+   * go modules with hashes
+   * hash-based other container images
+   * apk packages solely from the EVE or linuxkit alpine cache image
+1. The EVE or linuxkit alpine cache can be used as an immutable cache, and changes only when specifically selected to do so
+1. The images are functionally reproducible, rather than precisely reproducible, because of potential variants in file timestamps and random data used

--- a/docs/EVE-IMAGE-SOURCES.md
+++ b/docs/EVE-IMAGE-SOURCES.md
@@ -1,0 +1,741 @@
+# Source Tracing
+
+As an open source project, it is important for all of the sources for EVE to be open and available. While for some having this repository
+may suffice, EVE sets higher standards. Specifically, EVE desires that it be possible to trace from a given EVE image back to the
+sources of all software used in that binary compilation of EVE.
+
+This is done for several purposes:
+
+* Debugging, where knowledge of the precise source used is critical.
+* Auditing, where users auditing a particular distribution require confidence that they are reviewing precisely the correct source.
+* License compliance, where several licenses, notably the GPL family, require either distribution of source or links to source when distributing binary artifacts.
+
+This document will describe how to trace from a given compiled distribution of EVE all the way back to all sources.
+
+The stages are:
+
+1. Binary to source commit
+1. Binary to builder configuration
+1. Container images to container sources
+1. Container sources to contents:
+   * Local content
+   * Go modules
+   * External sources
+   * Alpine packages
+
+## Binary to source commit
+
+EVE is distributed in several formats.
+
+* Docker Images at [Docker Hub](https://hub.docker.com/r/lfedge/eve/). These are tagged with the version or commit of the image, as well as the architecture and hypervisor.
+* Release artifacts [on github](https://github.com/lf-edge/eve/releases). For example, [version 8.10.0](https://github.com/lf-edge/eve/releases/tag/8.10.0).
+
+If you are using a particular artifact, use the version provided to get your release version.
+
+* For Docker images with a [semver](https://semver.org/) tag, use the tag. For example, for `lfedge/eve:8.10.0-kvm`, use `8.10.0`.
+* For Docker images with a hash commit, use the commit. For example, for `lfedge/eve:0.0.0-master-5729285b-kvm-arm64`, use `5729285b`.
+* For release artifacts, use the version on the download page. FOr example, if you downloaded from https://github.com/lf-edge/eve/releases/download/8.10.0/amd64.rootfs.img, use `8.10.0`.
+
+If you have an image for which you do not have the hash or semver version, you should be able to retrieve the version from the image itself.
+
+* For Docker images, run the `version` command.. For example:
+```
+$ docker run --rm lfedge/eve:0.0.0-master-0c6de671-kvm version
+0.0.0-master-0c6de671-kvm-arm64
+```
+* For release artifacts, mount or expand the `rootfs.img`, which is in squashfs format, and retrieve `/etc/eve-release`. For example:
+```
+$ cat /tmp/unmounted/etc/eve-release
+8.10.0-kvm-amd64
+```
+
+With the specific release tag or commit in hand, go to this source repository https://github.com/lf-edge/eve, either on the Web or cloned locally.
+Then check out the specific commit or tag. For example:
+
+```sh
+$ git checkout 8.10.0
+$ # OR
+$ git checkout 0c6de671
+```
+
+At this point, you have the specific version of source code used to build the EVE binary distribution you are using.
+
+## Binary to Builder Configuration
+
+The specific configuration used to build this distribution of EVE is distributed inside the EVE OS image.
+The actual configuration is available in binary `rootfs.img`, specifically in `/etc/linuxkit-eve-config.yaml`. 
+
+For example, you can run:
+
+```
+$ docker run --rm --entrypoint=cat lfedge/eve:0.0.0-master-0c6de671-kvm /etc/linuxkit-config-version.yaml
+```
+
+Or use `docker create`, followed by `docker cp` and `docker rm`.
+
+A sample configuration is:
+
+```yml
+kernel:
+  image: lfedge/eve-kernel:27897827d2e6fab1e2eb4f6ce0ea3a6d44a27cc1-amd64
+  cmdline: "rootdelay=3"
+init:
+  - linuxkit/init:8f1e6a0747acbbb4d7e24dc98f97faa8d1c6cec7
+  - linuxkit/runc:f01b88c7033180d50ae43562d72707c6881904e4
+  - linuxkit/containerd:de1b18eed76a266baa3092e5c154c84f595e56da
+  - linuxkit/getty:v0.5
+  - linuxkit/memlogd:v0.5
+  - lfedge/eve-dom0-ztools:417d4ff6a57d2317c9e65166274b0ea6f6da16e2-amd64
+  - lfedge/eve-grub:080a301fbd8f1f1ef99013f81cc3c5aa2effface-amd64
+  - lfedge/eve-fw:972657ee489ceb3efe7db7eb5907f9d3aeeaa1fd-amd64
+  - lfedge/eve-xen:9bf0be924fc91c74b993d7cf3ed5f4523fb09cee-amd64
+  - lfedge/eve-gpt-tools:ab2e9f924e22709b4e08ebedd6d3c6a2882d071e-amd64
+onboot:
+   - name: rngd
+     image: lfedge/eve-rngd:ee02bc3f3273db42d7d05da21f02e1563072ad10-amd64
+     command: ["/sbin/rngd", "-1"]
+   - name: sysctl
+     image: linuxkit/sysctl:v0.5
+     binds:
+        - /etc/sysctl.d:/etc/sysctl.d
+     capabilities:
+        - CAP_SYS_ADMIN
+        - CAP_NET_ADMIN
+   - name: modprobe
+     image: linuxkit/modprobe:v0.5
+     command: ["/bin/sh", "-c", "modprobe -a nct6775 w83627hf_wdt hpwdt wlcore_sdio wl18xx br_netfilter dwc3 rk808 rk808-regulator smsc75xx cp210x nicvf tpm_tis_spi rtc_rx8010 gpio_pca953x leds_siemens_ipc127 upboard-fpga pinctrl-upboard leds-upboard xhci_tegra 2>/dev/null || :"]
+   - name: storage-init
+     image: lfedge/eve-storage-init:82b0220db7a5cb1e56e127593b5d763ec0beb78d-amd64
+services:
+   - name: newlogd
+     image: lfedge/eve-newlog:571319e0e6c6c8a21afd081409fafb3193fc7d3b-amd64
+     cgroupsPath: /eve/services/newlogd
+     oomScoreAdj: -999
+   - name: edgeview
+     image: lfedge/eve-edgeview:1f6fa3372dc20bcbabe357ee06550c2aae938063-amd64
+     cgroupsPath: /eve/services/eve-edgeview
+     oomScoreAdj: -800
+   - name: debug
+     image: lfedge/eve-debug:db1af614916c9bfb1d6144ae7e5b88acdbf58579-amd64
+     cgroupsPath: /eve/services/debug
+     oomScoreAdj: -999
+   - name: wwan
+     image: lfedge/eve-wwan:d714ad6c7facffa1c2a6ae13b9e76d55b10cd1a4-amd64
+     cgroupsPath: /eve/services/wwan
+     oomScoreAdj: -999
+   - name: wlan
+     image: lfedge/eve-wlan:f60f85ed52a9731dc8714b058d2dec71dab97cfd-amd64
+     cgroupsPath: /eve/services/wlan
+     oomScoreAdj: -999
+   - name: guacd
+     image: lfedge/eve-guacd:98688a5b3c8972665225de789160c2bbdbdb4fd4-amd64
+     cgroupsPath: /eve/services/guacd
+     oomScoreAdj: -999
+   - name: pillar
+     image: lfedge/eve-pillar:17837a9fcd05c765e9a1f6707b2e48f0f1dd215b-amd64
+     cgroupsPath: /eve/services/pillar
+     oomScoreAdj: -999
+   - name: vtpm
+     image: lfedge/eve-vtpm:0d4173a868a9c23974e6e1b37e6369df5d4e272e-amd64
+     cgroupsPath: /eve/services/vtpm
+     oomScoreAdj: -999
+   - name: watchdog
+     image: lfedge/eve-watchdog:d4bf7ed4e3fa170061b8e6af6bd09ef7546c9c60-amd64
+     cgroupsPath: /eve/services/watchdog
+     oomScoreAdj: -1000
+   - name: xen-tools
+     image: lfedge/eve-xen-tools:1335e0e2d14d82ce3030f8d235f916474ae33bf4-amd64
+     cgroupsPath: /eve/services/xen-tools
+     oomScoreAdj: -999
+files:
+   - path: /etc/eve-release
+     contents: '0.0.0-master-12a6fb8d-kvm-amd64'     
+   - path: /etc/linuxkit-eve-config.yml
+     metadata: yaml
+```
+
+
+
+The above shows each container image used in creating this EVE bootable OS image. For example, the version of pillar used is
+`lfedge/eve-pillar:17837a9fcd05c765e9a1f6707b2e48f0f1dd215b-amd64`.
+
+The source for the builder configuration is rendered at build time from a series of templates.
+The base templates are in [images/](../images/). Specifically, the primary configuration file is the template
+[rootfs.yml.in](../images/rootfs.yml.in), which is rendered using templating, and potentially patched using
+other files in the same directory.
+
+As described above, when building an EVE image, the build process takes the final rendered configuration
+actually used and save it in the EVE image at `/etc/linuxkit-eve-config.yml`.
+
+## Container Images to Sources
+
+With the specific name and tag of each OCI image in hand, you can trace the source for each such package.
+
+The OCI container image can be pulled from Docker Hub using `docker pull`, for example:
+
+```sh
+docker pull lfedge/eve-pillar:17837a9fcd05c765e9a1f6707b2e48f0f1dd215b-amd64
+```
+
+and it can be inspected using any image inspection tool, including `docker image inspect`:
+
+```sh
+docker image inspect lfedge/eve-pillar:17837a9fcd05c765e9a1f6707b2e48f0f1dd215b-amd64
+```
+
+The results of the inspection will yield information about the container image, including tags that tell which git commit
+was used when building this image. In the above example:
+
+```json
+      "Labels": {
+        "org.mobyproject.config": "{\"capabilities\":[\"all\"],\"binds\":[\"/lib/modules:/lib/modules\",\"/dev:/dev\",\"/etc/resolv.conf:/etc/resolv.conf\",\"/r
+un:/run\",\"/config:/config\",\"/:/hostfs\",\"/persist:/persist:rshared,rbind\",\"/usr/bin/containerd:/usr/bin/containerd\"],\"devices\":[{\"path\":\"all\",\"ty
+pe\":\"a\",\"major\":0,\"minor\":0}],\"net\":\"host\",\"pid\":\"host\",\"rootfsPropagation\":\"shared\"}",
+        "org.mobyproject.linuxkit.revision": "unknown",
+        "org.mobyproject.linuxkit.version": "unknown",
+        "org.opencontainers.image.revision": "12a6fb8d29a6b47f998cd077dfb92213f0e6a55f",
+        "org.opencontainers.image.source": "https://github.com/linuxkit/linuxkit"
+      },
+```
+
+The git commit for the above source is given in the label `"org.opencontainers.image.revision": "12a6fb8d29a6b47f998cd077dfb92213f0e6a55f"`, i.e.
+you can get the same commit via `git checkout 12a6fb8d29a6b47f998cd077dfb92213f0e6a55f`.
+
+The above _should_ be the same as the git commit you checked out in the stage [Binary to source commit][Binary to source commit].
+Nonetheless, even if it is not, the git commit given by the label is the git commit that was used to build
+this particular container image.
+
+Further, you can validate that the current contents of `pkg/pillar` give the correct output, by running:
+
+```sh
+$ linuxkit pkg show-tag pkg/pillar
+lfedge/eve-pillar:17837a9fcd05c765e9a1f6707b2e48f0f1dd215b
+```
+
+The above `17837a9fcd05c765e9a1f6707b2e48f0f1dd215b` is the same git tree hash used in the container image tag,
+`lfedge/eve-pillar:17837a9fcd05c765e9a1f6707b2e48f0f1dd215b-amd64`.
+
+## Container sources to Content
+
+With the specific source directory and commit in hand for each container image, we turn to the various sources that are used.
+
+There are several types of content that are loaded used to create the container image.
+
+### Local content
+
+Local content includes anything in the same directory, which therefore is used in the
+[docker build context](https://docs.docker.com/engine/reference/commandline/build/) when creating the container image.
+
+Everything used in the source directory is committed to git. This includes sources, the `Dockerfile` itself, and the `build.yaml`
+file used to control the image build via `linuxkit pkg build`.
+
+Further, our build command, `linuxkit pkg build`, validates that the git repository is "clean", i.e. that there are no uncommitted changes
+or files not saved in git. If there are, it treats the repository as "dirty", and appends both `dirty` and a hash of all of the file
+contents in the directory to the tag. Thus `lfedge/eve-pillar:17837a9fcd05c765e9a1f6707b2e48f0f1dd215b-amd64` means that there were no
+uncommitted changes or files in the source directory. If there were, it would have indicated on the tag as
+`lfedge/eve-pillar:17837a9fcd05c765e9a1f6707b2e48f0f1dd215b-dirty-<hash_of_file_contents>-amd64`.
+
+Note that if the contents are "dirty", there is no guaranteed way to get to the original source. While the tag, and `linuxkit pkg show-tag`,
+will include the git commit, the word `dirty`, and the hash of all of the file contents, there is no way to get to that specific set of
+contents when it is dirty. The hash of the contents only tells you if it was the same, but does not provide a way to get there.
+
+### Go modules
+
+Most of the code unique to EVE is written in [go](http://golang.org). For all go package dependencies, all sources
+use the [go module system](https://go.dev/ref/mod). It is beyond the scope of this document to describe the complete details of go's module
+system and reproducibility. For more details, see the reference. This section provides a brief overview.
+
+The list of each module used is available in `go.mod`, including the [semantic version (semver)](https://semver.org) if the module
+uses semver, a hash otherwise. For example, [pkg/pillar/go.mod](../pkg/pillar/go.mod) contains partially:
+
+```go
+require (
+	cloud.google.com/go/storage v1.21.0 // indirect
+	github.com/Focinfi/go-dns-resolver v1.0.0
+	github.com/anatol/smart.go v0.0.0-20220615232124-371056cd18c3
+```
+
+Some of the above include only semver, and some include the precise git commit and date.
+
+To get the source of each of those:
+
+1. Retrieve the URL to the source
+1. Retrieve the semver tag or commit
+1. Check out the tag or commit
+
+We will look at examples from the above `go.mod`.
+
+#### semver
+
+The first required module is:
+
+```go
+	cloud.google.com/go/storage v1.21.0 // indirect
+```
+
+The source is at `cloud.google.com/go/storage`. You can get the exact code used by cloning the repository and checking out the
+tag `v1.21.0` or referencing it online.
+
+Of course, git tags are mutable and can change. To avoid issues, the go module system includes a cryptographic hash
+of the contents either of the module itself or the module's own `go.mod` file in `go.sum`. The relevant section
+from [pkg/pillar/go.sum](../pkg/pillar/go.sum) is:
+
+```go
+cloud.google.com/go/storage v1.21.0 h1:HwnT2u2D309SFDHQII6m18HlrCi3jAXhUMTLOWXYH14=
+cloud.google.com/go/storage v1.21.0/go.mod h1:XmRlxkgPjlBONznT2dDUU/5XlpU2OjMnKuqnZI01LAA=
+```
+
+The cryptographic hash of the zip file for the contents is `HwnT2u2D309SFDHQII6m18HlrCi3jAXhUMTLOWXYH14=`, while the
+hash of the `go.mod` file is `XmRlxkgPjlBONznT2dDUU/5XlpU2OjMnKuqnZI01LAA=`. The above is base64-encoded sha256 sum, as indicated
+by `h1`. For further details, see the [go modules reference](https://go.dev/ref/mod).
+
+#### commit
+
+The third module is:
+
+```go
+	github.com/anatol/smart.go v0.0.0-20220615232124-371056cd18c3
+```
+
+The source is at `github.com/anatol/smart.go`. You can get the exact code used by cloning the repository and checkout out the commit
+`371056cd18c3` or referencing it online. Note that it also includes the date and time of the commit.
+
+As for semver, go modules preserves the cryptographic hash of the contents of the module, even when a commit is used.
+
+The relevant section from [pkg/pillar/go.sum](../pkg/pillar/go.sum) is:
+
+```go
+github.com/anatol/smart.go v0.0.0-20220615232124-371056cd18c3 h1:0nVT/S4r4gSyJNb/74vZaTjW7izLUZ/CRtcuH+G2DcE=
+github.com/anatol/smart.go v0.0.0-20220615232124-371056cd18c3/go.mod h1:F486dIGdTbYMmAj8dtlVbjQasL8WS7lhnijBk4wJmKQ=
+```
+
+The cryptographic hash of the zip file for the contents is `0nVT/S4r4gSyJNb/74vZaTjW7izLUZ/CRtcuH+G2DcE=`, while the
+hash of the `go.mod` file is `F486dIGdTbYMmAj8dtlVbjQasL8WS7lhnijBk4wJmKQ=`. The above is base64-encoded sha256 sum, as indicated
+by `h1`. For further details, see the [go modules reference](https://go.dev/ref/mod).
+
+### External sources
+
+Some of the container image sources may require external software from the Internet. For example, [pkg/fw](../pkg/fw) needs to
+download various firmware packages.
+
+Container image sources in [pkg/](../pkg/) are not discouraged from downloading such software. However, they are required to
+use specific versions, preferably immutable, and, wherever possible, commit based. When possible, they also are encouraged to store
+the hash of contents locally to validate that it has not changed.
+
+The precise commit gives the ability to retrieve the precise source used.
+
+Continuing the [pkg/fw](../pkg/fw) example, part of the [pkg/fw/Dockerfile](../pkg/fw/Dockerfile) contains:
+
+```dockerfile
+ENV RPI_FIRMWARE_VERSION 2c8f665254899a52260788dd902083bb57a99738
+ENV RPI_FIRMWARE_URL https://github.com/RPi-Distro/firmware-nonfree/archive
+RUN mkdir /rpi-firmware &&\
+    curl -fsSL ${RPI_FIRMWARE_URL}/${RPI_FIRMWARE_VERSION}.tar.gz | tar -xz --strip-components=1 -C /rpi-firmware &&\
+    cp -a /rpi-firmware/debian/config/brcm80211/brcm/brcmfmac43436* /lib/firmware/brcm
+```
+
+By inspecting the Dockerfile, we can see the source of the Raspberry Pi firmware used and the precise commit.
+
+### Alpine packages
+
+The source for standard packages, such as `go` or `gcc` for compilation or `openssl` or `bash` for useful utilities, is the operating
+system package manager. In the case of all or almost all of the container images, the base image, shown as `FROM` in the Dockerfile,
+that is [Alpine Linux](https://www.alpinelinux.org).
+
+Alpine Linux uses the [apk package manager](https://wiki.alpinelinux.org/wiki/Package_management). Unfortunately, apk changes
+package versions for the default install via `apk add <packagename>`, and even when pinned to a specific version, it can change the
+underlying bits for a particular version. This can make it challenging to track precisely which version of a apckage was used and,
+therefore, which software.
+
+For example, [pkg/pillar](../pkgs/pillar) requires the following Alpine packages to be installed via apk:
+`alpine-baselayout musl-utils bash glib squashfs-tools util-linux e2fsprogs e2fsprogs-extra keyutils dosfstools coreutils sgdisk smartmontools`.
+
+Given that `apk add alpine-baselayout` or `apk add glib` can be any version, EVE provides a methdology for tracking the precise package and, by
+extension, source used when installing those packages.
+
+All container images used in the EVE OS image do **not** source from [the standard Alpine container image](https://hub.docker.com/_/alpine).
+Instead, EVE itself creates an Alpine package cache called [lfedge/eve-alpine](https://hub.docker.com/r/lfedge/eve-alpine), whose source is
+at [pkg/alpine](../pkg/alpine). All container images included in EVE OS **must** use that cache as the base.
+
+The Alpine cache image often is referred to as the Alpine "base" image.
+
+Further, the cache container image includes a utility called `eve-alpine-deploy.sh`, which simplifies installation of apk packages based
+on environment variables.
+
+For example, [pkg/pillar/Dockerfile](../pkg/pillar/Dockerfile) starts with:
+
+```dockerfile
+FROM lfedge/eve-alpine:145f062a40639b6c65efa36bed1c5614b873be52 as build
+ENV PKGS alpine-baselayout musl-utils bash glib squashfs-tools util-linux e2fsprogs e2fsprogs-extra keyutils dosfstools coreutils sgdisk smartmontools
+RUN eve-alpine-deploy.sh
+```
+
+The above means:
+
+1. Use the cache, or base, image `lfedge/eve-alpine:145f062a40639b6c65efa36bed1c5614b873be52`
+1. Use `eve-alpine-deploy.sh` to install all of the packages listed in `PKGS` from the cache image: `alpine-baselayout musl-utils bash glib squashfs-tools util-linux e2fsprogs e2fsprogs-extra keyutils dosfstools coreutils sgdisk smartmontools`
+
+The images in the cache are stored in `.apk` format.
+
+Using the above, we can trace the apk packages and sources for a particular container image, assuming we already have the source
+repository and git commit, from the previous steps. The steps below will be followed by an example.
+
+1. Locate the `Dockerfile` in the source for the container image.
+1. From the `Dockerfile`, find the `lfedge/eve-alpine` cache image used.
+1. From the container image itself, retrieve the Alpine apk installed database at `/lib/apk/db/installed`
+1. From the `installed` file, retrieve the specific URL to the source and version or commit used to build the package.
+
+We will walk through a practical example, continuing to use our `lfedge/eve-pillar` image from above.
+
+From the `Dockerfile`, we retrieved the cache image of `lfedge/eve-alpine:145f062a40639b6c65efa36bed1c5614b873be52`.
+
+We now need to retrieve the list of all packages and versions installed. If it **not** sufficient to just look at the list
+in the `Dockerfile`, as one package may have upstream dependencies that get installed automatically. Instead, we need to look at the actual
+image itself, and specifically Alpine's installed list at `/lib/apk/db/installed`.
+
+You can use any tool you like to copy files from a container image. We use a simple `docker create` then
+`docker cp` then `docker rm`.
+
+
+```sh
+$ docker create lfedge/eve-pillar:17837a9fcd05c765e9a1f6707b2e48f0f1dd215b-amd64
+364cdf9537a77bff25379c557da7d63f4993ecd4baf9b567e745bfe855e937e7
+$ docker cp 364cdf9537a77bff25379c557da7d63f4993ecd4baf9b567e745bfe855e937e7:/lib/apk/db/installed /tmp/installed
+$ docker rm 364cdf9537a77bff25379c557da7d63f4993ecd4baf9b567e745bfe855e937e7
+364cdf9537a77bff25379c557da7d63f4993ecd4baf9b567e745bfe855e937e7
+```
+
+The `installed` file's structure is described at [the official page](https://wiki.alpinelinux.org/wiki/Apk_spec#Index_Format_V2).
+
+The key parts are that each package is given in a paragraph, with blank lines separating packages. For example:
+
+```
+C:Q1aCu0LmUDoAFSOX49uHvkYC1WasQ=
+P:musl
+V:1.2.3-r0
+A:x86_64
+S:383304
+I:622592
+T:the musl c library (libc) implementation
+U:https://musl.libc.org/
+L:MIT
+o:musl
+m:Timo Teräs <timo.teras@iki.fi>
+t:1649396308
+c:ee13d43a53938d8a04ba787b9423f3270a3c14a7
+p:so:libc.musl-x86_64.so.1=1
+F:lib
+R:ld-musl-x86_64.so.1
+a:0:0:755
+Z:Q1ZZqflKEvStJz4SXV0SDMi3wOtM0=
+R:libc.musl-x86_64.so.1
+a:0:0:777
+Z:Q17yJ3JFNypA4mxhJJr0ou6CzsJVI=
+
+C:Q1iZ+C2JJdBlm2KKtAOkSkM7zZegY=
+P:busybox
+V:1.35.0-r17
+A:x86_64
+S:507831
+I:962560
+T:Size optimized toolbox of many common UNIX utilities
+U:https://busybox.net/
+L:GPL-2.0-only
+o:busybox
+m:Sören Tempel <soeren+alpine@soeren-tempel.net>
+t:1659366884
+c:2bf6ec48e526113f87216683cd341a78af5f0b3f
+D:so:libc.musl-x86_64.so.1
+p:/bin/sh cmd:busybox=1.35.0-r17 cmd:sh=1.35.0-r17
+r:busybox-initscripts
+F:bin
+R:busybox
+a:0:0:755
+Z:Q1WUwBY0eOGgzgVxTZxJBZPyQUicI=
+R:sh
+a:0:0:777
+Z:Q1pcfTfDNEbNKQc2s1tia7da05M8Q=
+F:etc
+R:securetty
+Z:Q1mB95Hq2NUTZ599RDiSsj9w5FrOU=
+R:udhcpd.conf
+Z:Q1EgLFjj67ou3eMqp4m3r2ZjnQ7QU=
+F:etc/logrotate.d
+R:acpid
+Z:Q1TylyCINVmnS+A/Tead4vZhE7Bks=
+F:etc/network
+F:etc/network/if-down.d
+F:etc/network/if-post-down.d
+F:etc/network/if-post-up.d
+F:etc/network/if-pre-down.d
+F:etc/network/if-pre-up.d
+F:etc/network/if-up.d
+R:dad
+a:0:0:775
+Z:Q1ORf+lPRKuYgdkBBcKoevR1t60Q4=
+F:sbin
+F:tmp
+M:0:0:1777
+F:usr
+F:usr/sbin
+F:usr/share
+F:usr/share/udhcpc
+R:default.script
+a:0:0:755
+Z:Q1t9vir/ZrX3nbSIYT9BDLWZenkVQ=
+F:var
+F:var/cache
+F:var/cache/misc
+F:var/lib
+F:var/lib/udhcpd
+
+...
+
+C:Q1JdllpChcMaHc7DnVs+DRWAnD2zE=
+P:ip6tables
+V:1.8.8-r1
+A:x86_64
+S:41963
+I:348160
+T:Linux kernel firewall, NAT and packet mangling tools
+U:https://www.netfilter.org/projects/iptables/index.html
+L:GPL-2.0-or-later
+o:iptables
+m:Natanael Copa <ncopa@alpinelinux.org>
+t:1652905555
+c:e7e60a9e6ff8cc55b004dac6392b75e4993518da
+D:iptables=1.8.8-r1 so:libc.musl-x86_64.so.1 so:libxtables.so.12
+r:ebtables
+F:sbin
+R:ip6tables
+a:0:0:777
+Z:Q12mo8ikesb2KnfgWolLj1gsf4cwc=
+R:ip6tables-apply
+a:0:0:777
+Z:Q1D7sdEIH4PzvxaB7e3X8EmxgVsu4=
+R:ip6tables-legacy
+a:0:0:777
+Z:Q12mo8ikesb2KnfgWolLj1gsf4cwc=
+R:ip6tables-legacy-restore
+a:0:0:777
+Z:Q12mo8ikesb2KnfgWolLj1gsf4cwc=
+R:ip6tables-legacy-save
+a:0:0:777
+Z:Q12mo8ikesb2KnfgWolLj1gsf4cwc=
+R:ip6tables-nft
+a:0:0:777
+Z:Q1WPPdXUGL+Fma+jYAArGGbVCwOqk=
+R:ip6tables-nft-restore
+a:0:0:777
+Z:Q1WPPdXUGL+Fma+jYAArGGbVCwOqk=
+R:ip6tables-nft-save
+a:0:0:777
+Z:Q1WPPdXUGL+Fma+jYAArGGbVCwOqk=
+R:ip6tables-restore
+a:0:0:777
+Z:Q12mo8ikesb2KnfgWolLj1gsf4cwc=
+R:ip6tables-restore-translate
+a:0:0:777
+Z:Q1WPPdXUGL+Fma+jYAArGGbVCwOqk=
+R:ip6tables-save
+a:0:0:777
+Z:Q12mo8ikesb2KnfgWolLj1gsf4cwc=
+R:ip6tables-translate
+a:0:0:777
+Z:Q1WPPdXUGL+Fma+jYAArGGbVCwOqk=
+F:usr
+F:usr/lib
+F:usr/lib/xtables
+R:libip6t_DNPT.so
+a:0:0:755
+Z:Q1WraOfsi+kgSlIN7aQ+Rq35GP1S4=
+R:libip6t_HL.so
+a:0:0:755
+Z:Q1lZ7H8yyq0Vu0wFW80bpvoP2gnug=
+R:libip6t_LOG.so
+a:0:0:755
+Z:Q1jPvkFPJ9Wlmu6G44oaB4odBdqf0=
+R:libip6t_MASQUERADE.so
+a:0:0:755
+Z:Q11PFah9jKg2t3CrG2+YK9NshCE6o=
+R:libip6t_NETMAP.so
+a:0:0:755
+Z:Q13g7xSrZBAfa3Nr78FdkHF+pFctM=
+R:libip6t_REJECT.so
+a:0:0:755
+Z:Q1vM7gC27Uv7lEoDXI+EIDqvqXpss=
+R:libip6t_SNAT.so
+a:0:0:755
+Z:Q1j/XbdyaCkMPOJbyGZqprs7HXdas=
+R:libip6t_SNPT.so
+a:0:0:755
+Z:Q1WB5IwC5Q9mr5okiSdLgw4ezo7u4=
+R:libip6t_ah.so
+a:0:0:755
+Z:Q1hFgkHm/vd4Fjc+LQ8Uoe6bPIt7o=
+R:libip6t_dst.so
+a:0:0:755
+Z:Q1drVG6nuYR9TJZWhaUHtKHyg6tkc=
+R:libip6t_eui64.so
+a:0:0:755
+Z:Q1vleF/Hbue2DhlyoKJ4wJtDHgJjo=
+R:libip6t_frag.so
+a:0:0:755
+Z:Q1ejt6B8/0AwnyX9N0LBh8q//f+kU=
+R:libip6t_hbh.so
+a:0:0:755
+Z:Q16IsIQy+q7V5qdxt710Mqds6M0e8=
+R:libip6t_hl.so
+a:0:0:755
+Z:Q1udmHKTC6alJKFzVBdbSJz23ATZY=
+R:libip6t_icmp6.so
+a:0:0:755
+Z:Q1QGhlbChLsiMHYHrji3SLp62wRQQ=
+R:libip6t_ipv6header.so
+a:0:0:755
+Z:Q1XI/vQ7njuNFN8aNA0LKTSgCaxXg=
+R:libip6t_mh.so
+a:0:0:755
+Z:Q1hESH+jdme+AnTNPQ4c5HIXS8qCY=
+R:libip6t_rt.so
+a:0:0:755
+Z:Q1vLoeZs41MWkOdJX9ceGnmN7MYyA=
+R:libip6t_srh.so
+a:0:0:755
+Z:Q1ry15xfrU3eLcYzqoMj32ZTRTaY8=
+F:var
+F:var/lib
+F:var/lib/ip6tables
+```
+
+The package listing provides information about every file installed: the name of the package, the origin of the package if it is
+an alias, the source commit used to build the package, and every file installed with its permissions.
+
+Using the `ip6tables` install above as an example, it contains a lot of information. the most important parts for our purposes are:
+
+* The name: `P:ip6tables`
+* The origin, i.e. the original package: `o:iptables`
+* The version: `V:1.8.8-r1`
+* The commit: `c:e7e60a9e6ff8cc55b004dac6392b75e4993518da`
+
+If `o` for origin exists, then that is the name of the package as stored in the Alpine package source; the package name `P` is just an alias.
+
+The commit `c` is not the commit of the original source, but the commit in the Alpine packages git repository that built the package.
+To get the full source, we go to the Alpine Linux git URL that includes the package name and hash:
+
+```sh
+https://git.alpinelinux.org/aports/tree/main/${PACKAGENAME}/APKBUILD?id=${COMMIT}
+```
+
+For our example, that is:
+
+```sh
+https://git.alpinelinux.org/aports/tree/main/ip6tables/APKBUILD?id=e7e60a9e6ff8cc55b004dac6392b75e4993518da
+```
+
+The file there shows:
+
+```sh
+# Maintainer: Natanael Copa <ncopa@alpinelinux.org>
+pkgname=iptables
+pkgver=1.8.8
+pkgrel=1
+pkgdesc="Linux kernel firewall, NAT and packet mangling tools"
+url="https://www.netfilter.org/projects/iptables/index.html"
+arch="all"
+license="GPL-2.0-or-later"
+depends_dev="linux-headers"
+makedepends="$depends_dev libnftnl-dev bison flex autoconf automake"
+subpackages="ip6tables $pkgname-doc $pkgname-dev $pkgname-openrc ip6tables-openrc:ip6tables_openrc"
+provides="ebtables" # for backards compat
+replaces="ebtables"
+source="https://www.netfilter.org/projects/iptables/files/iptables-$pkgver.tar.bz2
+	use-sh-iptables-apply.patch
+	iptables.initd
+	iptables.confd
+	ip6tables.confd
+	ebtables.initd
+	ebtables.confd
+
+	fix-xtables.patch
+	fix-u_int16_t.patch
+	"
+
+build() {
+	export CFLAGS="$CFLAGS -D_GNU_SOURCE"
+	./configure \
+		--build="$CBUILD" \
+		--host="$CHOST" \
+		--prefix=/usr \
+		--mandir=/usr/share/man \
+		--sbindir=/sbin \
+		--sysconfdir=/etc \
+		--without-kernel \
+		--enable-devel \
+		--enable-libipq \
+		--enable-shared
+
+	# do not use rpath
+	sed -i 's|^hardcode_libdir_flag_spec=.*|hardcode_libdir_flag_spec=""|g' libtool
+	sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
+
+	make
+}
+
+package() {
+	make -j1 install DESTDIR="$pkgdir"
+
+	mkdir -p "$pkgdir"/usr/include/libiptc \
+		"$pkgdir"/usr/lib \
+		"$pkgdir"/var/lib/iptables \
+		"$pkgdir"/etc/iptables
+
+	install -m644 include/iptables.h include/ip6tables.h \
+		"$pkgdir"/usr/include/
+	install include/libiptc/*.h "$pkgdir"/usr/include/libiptc/
+
+	install -D -m755 "$srcdir"/iptables.initd "$pkgdir"/etc/init.d/iptables
+	install -D -m644 "$srcdir"/iptables.confd "$pkgdir"/etc/conf.d/iptables
+	install -D -m755 "$srcdir"/ebtables.initd "$pkgdir"/etc/init.d/ebtables
+	install -D -m644 "$srcdir"/ebtables.confd "$pkgdir"/etc/conf.d/ebtables
+}
+
+ip6tables() {
+	mkdir -p "$subpkgdir"
+	cd "$subpkgdir"
+
+	mkdir -p sbin \
+		var/lib/ip6tables \
+		usr/lib/xtables
+
+	mv "$pkgdir"/sbin/ip6* sbin/
+	mv "$pkgdir"/usr/lib/xtables/libip6* usr/lib/xtables/
+}
+
+ip6tables_openrc() {
+	default_openrc
+
+	install -D -m755 "$srcdir"/iptables.initd "$subpkgdir"/etc/init.d/ip6tables
+	install -D -m644 "$srcdir"/ip6tables.confd "$subpkgdir"/etc/conf.d/ip6tables
+}
+
+sha512sums="
+f21df23279a77531a23f3fcb1b8f0f8ec0c726bda236dd0e33af74b06753baff6ce3f26fb9fcceb6fada560656ba901e68fc6452eb840ac1b206bc4654950f59  iptables-1.8.8.tar.bz2
+ac78898c2acbe66ed8d32a06f41ff08cde7c22c3df6dfec6bc89a912d2cef2bde730de19d25a5407886d567cb0972a0b7bde7e6b18a34c4511495b4dad3b90ad  use-sh-iptables-apply.patch
+a37c17a5382c756fcfb183af73af2283f0d09932c5a767241cbab5d784738f6f587f287a0cdf13b4fa74724ecd3a2063a9689ccee84c1bda02e730f63480f74d  iptables.initd
+cb7fecd5cab2c78bd3f215a41f39ec11c37eb360efbe83982378a0e647e0aa9dc0b7ec915a5b5081aa2f7747464787e69404aa15ba15a063c32cb8fb7dd13d1e  iptables.confd
+0897a7a22f8b700f7f1f5c355ad6cbf39740e44d6c962af99e479978d8a2d556ca7fe4e31f238829046b4a871ce0b5fd52e2544f1361d15dd1ea3e33992646c4  ip6tables.confd
+8809d6fc69fbaa7d83ca4675d9e605f73e74ea8907495d39abdfbdca5c74bafb4fe0e413c88a4bd9470688a243581fa239527af06be15c9c94190664d9557fca  ebtables.initd
+1623109d7b564b817904e35b6c6964ce84fe123a8ae1b656944648a39cfef719431cfad313b48eb36ae53a0d1a6b388a5caec1a990448d02f77e5d12b1f7ee9d  ebtables.confd
+ce8c4ff001be49b77bb82efc3cb8b9f3c8f8684abcb07d079c6a00fab5c7a22e0d7f66f8ccdf3aab63d8fdb2b01b249679a89561e2f723111c8ce4075681b134  fix-xtables.patch
+015ca550cf27802446d74521b7618095a342663d4fd73700975f3186428ecdc9eec27016f4d40862d3837cbbe0bb43509c1022b19ef8692ab28cc24e18831d57  fix-u_int16_t.patch
+"
+```
+
+Describing how apk builds work and how to read the entire `APKBUILD` file is beyond the scope of this document. The important points
+for our purposes are:
+
+* The URL to the source code: `source="https://www.netfilter.org/projects/iptables/files/iptables-$pkgver.tar.bz2"`
+* Any referenced versions or commits used in that URL: `pkgver=1.8.8`
+
+The above is a reference to the original root source code for the binaries distributed.


### PR DESCRIPTION
We have had several requests describing how EVE is reproducible. How can we reliably reproduce the same bits over and over again. This is good practice, but also important for debugging, auditing and security concerns. I call this "downward" - given the source, how can I get to (functionally) the same bits over and over again. This is especially relevant in light of OCI registry (like Docker Hub and quay.io) mutable tags, and Alpine apk package changes.

The `REPRODUCIBILITY.md` document here addresses that question.

Additionally, we have had requests describing how to trace all of the sources in EVE. Given an EVE OS image, how can we reliably trace the precise software used to create it? This is good practice, but also important for debugging, auditing and security concerns. It also may become important when managing various open source licenses. I call this "upward" - given the binary, how can I get to the sources.

The `SOURCES.md` document here addresses that question.