### PR TITLE
Add uuid  to eve command

### DIFF
--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -288,3 +288,10 @@ It will extract the contents of the `/persist` partition to `./tmp/persist.tgz` 
 * `type`: either `live` or `installer`. Defaults to `live`.
 * `arch`: any supported architecture, currently `arm64` or `amd64`. Defaults to `amd64`.
 
+## Device uuid
+
+The uuid of the device running eve-os can be obtained by running following command
+
+```bash
+eve uuid
+```

--- a/pkg/dom0-ztools/rootfs/bin/eve
+++ b/pkg/dom0-ztools/rootfs/bin/eve
@@ -20,6 +20,7 @@ Welcome to EVE!
             firewall drop
             verbose on|off
             version
+            uuid
 __EOT__
   exit 1
 }
@@ -122,6 +123,10 @@ __EOT__
  version)
           v=$(cat /run/eve-release)
           echo "$v"
+          ;;
+ uuid)
+          uuid=$(cat /persist/status/uuid)
+          echo "$uuid"
           ;;
  persist) case "$2" in
                list) list_partitions


### PR DESCRIPTION
Users should be able to get uuid of the device easily than searching for it.

Tested on my device
eve uuid
6c6cb828-b0be-4166-9daf-ab353430dbc1

Signed-off-by: Pramodh Pallapothu <pramodh@zededa.com>