### PR TITLE
Remove references to libpac/duktape from the LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -200,9 +200,6 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 
-This product bundles libpac/duktape, which is available under the MIT
-license.  For details, see the zedpac/README.md
-
 This product bundles portions of the go net package, which is available
 under the BSD-style license. For details, see the netclone/README
 


### PR DESCRIPTION
libpac/duktape has been removed in the commit d046f0b15a447af430d57863f1a13d1b570cf09a and is not bundled anymore.