### PR TITLE
[WIP] try with NetworkFallbackAnyEth disabled

### DIFF
--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -778,7 +778,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddBoolItem(ProcessCloudInitMultiPart, false)
 
 	// Add TriState Items
-	configItemSpecMap.AddTriStateItem(NetworkFallbackAnyEth, TS_ENABLED)
+	configItemSpecMap.AddTriStateItem(NetworkFallbackAnyEth, TS_DISABLED)
 	configItemSpecMap.AddTriStateItem(MaintenanceMode, TS_NONE)
 
 	// Add String Items

--- a/pkg/pillar/types/globalconfigold.go
+++ b/pkg/pillar/types/globalconfigold.go
@@ -99,7 +99,7 @@ var globalConfigDefaults = OldGlobalConfig{
 	NetworkTestDuration:       30,
 	NetworkTestInterval:       300, // 5 minutes
 	NetworkTestBetterInterval: 0,   // Disabled
-	NetworkFallbackAnyEth:     TS_ENABLED,
+	NetworkFallbackAnyEth:     TS_DISABLED,
 	NetworkTestTimeout:        15,
 
 	NetworkSendTimeout: 120,


### PR DESCRIPTION
Test to see if this gets past the failures when running tests on equnix metal, where we get fallback to lastresort for some reason.