### PR TITLE
Split dhcpcd from veth and move to mount namespace

### DIFF
--- a/pkg/pillar/Dockerfile
+++ b/pkg/pillar/Dockerfile
@@ -100,6 +100,7 @@ ADD conf/root-certificate.pem conf/server conf/server.production /opt/zededa/exa
 ADD scripts/device-steps.sh \
     scripts/handlezedserverconfig.sh \
     scripts/veth.sh \
+    scripts/dhcpcd.sh \
   /opt/zededa/bin/
 ADD conf/lisp.config.base /var/tmp/zededa/lisp.config.base
 

--- a/pkg/pillar/containerd/oci_test.go
+++ b/pkg/pillar/containerd/oci_test.go
@@ -409,10 +409,12 @@ func TestOciSpec(t *testing.T) {
 	assert.Equal(t, []string{"/bin/sh", "-c", "/runme.sh"}, s.Process.Args)
 	assert.Equal(t, []string{"VIF_NAME=vif0", "VIF_BRIDGE=br0", "VIF_MAC=52:54:00:12:34:56"}, s.Hooks.Prestart[0].Env)
 	assert.Equal(t, []string{"VIF_NAME=vif1", "VIF_BRIDGE=br0", "VIF_MAC=52:54:00:12:34:57"}, s.Hooks.Prestart[1].Env)
-	assert.Equal(t, []string{"VIF_NAME=vif0", "VIF_BRIDGE=br0", "VIF_MAC=52:54:00:12:34:56"}, s.Hooks.Poststop[0].Env)
+	assert.Equal(t, []string{"VIF_NAME=vif0", "VIF_BRIDGE=br0", "VIF_MAC=52:54:00:12:34:56"}, s.Hooks.Poststop[1].Env)
 	assert.Equal(t, "/bin/eve", s.Hooks.Poststop[1].Path)
-	assert.Equal(t, []string{"eve", "exec", "pillar", "/opt/zededa/bin/veth.sh", "up", "test", "vif0", "br0", "52:54:00:12:34:56"}, s.Hooks.Prestart[0].Args)
-	assert.Equal(t, []string{"eve", "exec", "pillar", "/opt/zededa/bin/veth.sh", "down", "vif1"}, s.Hooks.Poststop[1].Args)
+	assert.Equal(t, []string{"eve", "exec", "pillar", "/opt/zededa/bin/veth.sh", "up", "vif0", "br0", "52:54:00:12:34:56"}, s.Hooks.Prestart[0].Args)
+	assert.Equal(t, []string{"eve", "exec", "pillar", "/opt/zededa/bin/dhcpcd.sh", "up", "test"}, s.Hooks.Prestart[2].Args)
+	assert.Equal(t, []string{"eve", "exec", "pillar", "/opt/zededa/bin/dhcpcd.sh", "down", "test"}, s.Hooks.Poststop[0].Args)
+	assert.Equal(t, []string{"eve", "exec", "pillar", "/opt/zededa/bin/veth.sh", "down", "vif1"}, s.Hooks.Poststop[2].Args)
 	assert.Equal(t, 60, *s.Hooks.Poststop[1].Timeout)
 }
 

--- a/pkg/pillar/hypervisor/containerd.go
+++ b/pkg/pillar/hypervisor/containerd.go
@@ -91,7 +91,8 @@ func (ctx ctrdContext) Setup(status types.DomainStatus, config types.DomainConfi
 		return logError("setting up OCI spec for domain %s failed %v", status.DomainName, err)
 	}
 
-	vifsTaskResolv := filepath.Join(vifsDir, status.DomainName, "etc", "resolv.conf")
+	// we use patched version of dhcpcd with /etc/resolv.conf.new
+	vifsTaskResolv := filepath.Join(vifsDir, status.DomainName, "etc", "resolv.conf.new")
 	err = os.MkdirAll(filepath.Dir(vifsTaskResolv), 0755)
 	if err != nil {
 		return logError("Failed to create directory for vifs task %s with err: %s",
@@ -99,7 +100,7 @@ func (ctx ctrdContext) Setup(status types.DomainStatus, config types.DomainConfi
 	}
 	f, err := os.OpenFile(vifsTaskResolv, os.O_WRONLY|os.O_CREATE|os.O_SYNC, 0755)
 	if err != nil {
-		return logError("Failed creating empty resolv.conf file %s with err: %s", vifsTaskResolv, err)
+		return logError("Failed creating empty resolv.conf.new file %s with err: %s", vifsTaskResolv, err)
 	}
 	defer f.Close()
 

--- a/pkg/pillar/scripts/dhcpcd.sh
+++ b/pkg/pillar/scripts/dhcpcd.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+set -e
+
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+export PATH
+
+TASK="$2"
+VIF_TASK=/run/tasks/vifs/"$TASK"
+
+case $1 in
+down)
+  unshare --mount --root="$VIF_TASK" dhcpcd --exit || :
+  umount "$VIF_TASK"/etc/dhcpcd.conf || :
+  umount "$VIF_TASK"/lib || :
+  umount "$VIF_TASK"/usr/lib || :
+  umount "$VIF_TASK"/bin || :
+  umount "$VIF_TASK"/usr/bin || :
+  umount "$VIF_TASK"/sbin || :
+  rm -rf "$VIF_TASK"
+  ;;
+up)
+  VIF_NS=$(jq '.pid')
+  mkdir -p "$VIF_TASK"
+
+  # mount files and directories required to run dhcpcd
+
+  mkdir -p "$VIF_TASK"/etc
+  touch "$VIF_TASK"/etc/dhcpcd.conf
+  mount --bind /etc/dhcpcd.conf "$VIF_TASK"/etc/dhcpcd.conf
+
+  mkdir -p "$VIF_TASK"/lib
+  mount --bind /lib "$VIF_TASK"/lib
+
+  mkdir -p "$VIF_TASK"/usr/lib
+  mount --bind /usr/lib "$VIF_TASK"/usr/lib
+
+  mkdir -p "$VIF_TASK"/bin
+  mount --bind /bin "$VIF_TASK"/bin
+
+  mkdir -p "$VIF_TASK"/sbin
+  mount --bind /sbin "$VIF_TASK"/sbin
+
+  mkdir -p "$VIF_TASK"/usr/bin
+  mount --bind /usr/bin "$VIF_TASK"/usr/bin
+
+  nsenter --target "$VIF_NS" --net unshare --uts --mount --root="$VIF_TASK" dhcpcd
+  ;;
+*)
+  echo "ERROR: correct use is $0 up TASK or $0 down TASK"
+  exit 2
+  ;;
+esac


### PR DESCRIPTION
We run dhcpcd in veth.sh and use complex mount to make it work. Let's reduce complexity by running dhcpcd inside mount namespace in separate dhcpcd.sh hook instead of host namespace.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>