### PR TITLE
Bootstrap config

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,9 @@ $ poweroff -f # leave qemu
 As described in [BUILD.md](./docs/BUILD.md) and [REGISTRATION.md](./docs/REGISTRATION.md), a booting EVE looks in its config partition to determine:
 
 * the URL to a Controller
-* hostnames to add to the `/etc/hosts` file
+* [OPTIONAL] hostnames to add to the `/etc/hosts` file
 * certificates to trust
+* [OPTIONAL] initial device configuration (aka bootstrap) used only until device is onboarded
 
 When run in an emulator using `make run`, you can override the built-in `/config` partition by passing it the path of a directory to mount as that partition:
 

--- a/docs/COMMS.md
+++ b/docs/COMMS.md
@@ -104,6 +104,7 @@ functions provided by the `zedcloud` package.
 * Requesting the configuration from the Controller via functions in `zedcloud`.
 * Receiving the latest correct configuration in response to its request.
 * Saving the latest correct configuration locally.
+* Loading the initial (aka bootstrap) device configuration if present (see [CONFIG.md](./CONFIG.md))
 * Informing any services of changes to their relevant configurations via [pubsub](../pkg/pillar/pubsub), which allows those services to restart or make changes in response to the updated configuration.
 
 #### loguploader

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -45,7 +45,7 @@ Thereafter, the live image is available on the storage device so there's no need
 
 In general, once deployed, EVE-OS assumes a hands-free environment that does not rely on a human
 operator. No one is required to configure initial settings "at the console". Any
-ncessary configuration can be included as part of the EVE-OS image.
+necessary configuration can be included as part of the EVE-OS image.
 To find out more regarding how EVE-OS can be configured, check out the
 [configuration](CONFIG.md) documentation. The remainder of this document will
 assume that either the config partition of the EVE-OS image has the required configuration information,

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,6 +1,6 @@
 # EVE Frequently Asked Questions
 
-## 1. How to ssh into a running instance of EVE
+## 1. How to ssh into a running instance of EVE?
 
 If you are running EVE in production there is *no* way to do that. For developer
 or debug builds of EVE you can set a debug.enable.ssh property to your ssh public
@@ -9,24 +9,8 @@ key. E.g:
 zcli edge-node update myqemu --config="debug.enable.ssh:`cat .ssh/id_rsa.pub`"
 ```
 
-## 2. Legacy method for out-of-band configuration delivery
+## 2. How to apply (initial) device configuration needed to establish controller connectivity?
 
-It is possible to provide an initial DevicePortConfig during the build. Read up on [legacy EVE configuration management](CONFIG.md) for more details on how it is structured.
+The preferred method is to build a single-use EVE installer with the initial, aka bootstrap, configuration baked in. To learn more about this, please refer to [CONFIG.md](./CONFIG.md), section "Bootstrap configuration".
 
-The DevicePortConfig can be statically put into EVE's configuration partition under */config/DevicePortConfig/global.json*
-to specify proxies and static IPs for the ports. This could be required
-to have your Edge Node connect to the controller. DevicePortConfig file can also be
-put onto a USB stick that you will plug into your Edge Node in which case it will
-be copied from the USB stick during boot and used.  See [tools/makeusbconf.sh](../tools/makeusbconf.sh)
-for details. The format of the DevicePortConfig/global.json is specified with
-examples in [legacy EVE configuration management](CONFIG.md)
-
-To add it during the build, in EVE's conf directory create a subdirectory called DevicePortConfig. Then add the valid json file named as global.json in that directory.
-Finally:
-
-```bash
-make config
-make installer
-```
-
-or just copy them into the partition called EVE on the writable installation medium.
+A legacy method, which may be the only option available with older EVE versions, is to prepare "override" json file with `DevicePortConfig` and put it into the installer or deliver it to the device using a USB stick. To learn more about this, please refer to [CONFIG.md](./CONFIG.md), section "Legacy mechanism for off-line configuration management".

--- a/docs/LED-INDICATION.md
+++ b/docs/LED-INDICATION.md
@@ -23,6 +23,8 @@ that deserve user attention.
 | 12  | Controller replied without TLS connection state. |
 | 13  | Controller replied without OCSP response. |
 | 14  | Failed to fetch or verify Controller certificate. |
+| 15  | Received message from the controller with invalid or missing signature. |
+| 16  | Bootstrap configuration (see [CONFIG.md](./CONFIG.md)) is not valid. |
 
 Application status is also displayed using LEDs on device model SIEMENS AG.SIMATIC IPC127E
 Uses LED3 (the one labeled as L3 MAINT) for application state.

--- a/docs/README.md
+++ b/docs/README.md
@@ -174,28 +174,22 @@ sequence, the second part ensures that EVE never ends up in a situation where
 the new configuration object made it impossible to receive further configuration
 objects due to erroneous configuration provided for network interfaces.
 
-There are currently two mechanisms for delivering out-of-band configuration
+There are currently two approaches for delivering out-of-band configuration
 object to EVE:
 
 1. Installing it during the [normal EVE installation process](#installing-eve-on-edge-nodes)
 2. Providing it to a running version of EVE on a specially formatted removable
    media (USB stick, CDROM, external hard drive, etc.)
 
-Both methods start with obtaining a set of files (see the note below on how we
-are working towards making it a single file) and either putting them into the
-EVE configuration partition on the installation media (see [EVE Installation](#installing-eve-on-edge-nodes)
-for details) or using [tools/makeusbconf.sh](../tools/makeusbconf.sh) script to format
-removable media.
+For the installation-time config delivery, recent EVE versions are able to consume
+exactly the same protobuf-encoded binary blob (`EdgeDevConfig`) that is used by the Controller
+to post the device configuration. This initial device configuration is called bootstrap config
+and more detailed information on this topic can be found in [CONFIG.md](./CONFIG.md).
 
-It must be noted that currently we are still not quite there with out-of-band
-mechanism for delivery of EVE's configuration object. While ideal EVE
-implementation would simply be able to consume exactly the same protobuf encoded
-binary blob that it receives from the Controller, currently we still have to
-rely on an ad-hoc collection of configuration files that serve the same purpose.
-We expect these configuration files to go away relatively quickly, but for now
-EVE is still stuck with at least *DevicePortConfig/global.json* and it is documented in [legacy configuration](CONFIG.md).
-See [the following FAQ entry](FAQ.md) for how to manage both of these
-legacy files.
+For run-time out-of-band configuration delivery and with older EVE versions we rely on an ad-hoc
+collection of configuration files, modeled by internal Go structures, edited manually
+by users and installed from specially formatted USB sticks.
+Just like bootstrap config, this is documented in more detail in [CONFIG.md](./CONFIG.md)
 
 ### Runtime Configuration Properties
 

--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -687,7 +687,7 @@ func fetchCertChain(zedcloudCtx *zedcloud.ZedCloudContext, tlsConfig *tls.Config
 
 	zedcloudCtx.TlsConfig = tlsConfig
 	// verify the certificate chain
-	certBytes, err := zedcloud.VerifySigningCertChain(zedcloudCtx, contents)
+	certBytes, err := zedcloud.VerifyProtoSigningCertChain(log, contents)
 	if err != nil {
 		errStr := fmt.Sprintf("controller certificate signature verify fail, %v", err)
 		log.Errorln("fetchCertChain: " + errStr)
@@ -695,7 +695,7 @@ func fetchCertChain(zedcloudCtx *zedcloud.ZedCloudContext, tlsConfig *tls.Config
 	}
 
 	// write the signing cert to file
-	if err := zedcloud.UpdateServerCert(zedcloudCtx, certBytes); err != nil {
+	if err := zedcloud.SaveServerSigningCert(zedcloudCtx, certBytes); err != nil {
 		errStr := fmt.Sprintf("%v", err)
 		log.Errorln("fetchCertChain: " + errStr)
 		return false

--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -247,14 +247,14 @@ func getCertsFromController(ctx *zedagentContext) bool {
 	}
 
 	// validate the certificate message payload
-	certBytes, ret := zedcloud.VerifySigningCertChain(zedcloudCtx, contents)
+	certBytes, ret := zedcloud.VerifyProtoSigningCertChain(log, contents)
 	if ret != nil {
 		log.Errorf("getCertsFromController: verify err %v", ret)
 		return false
 	}
 
 	// write the signing cert to file
-	if err := zedcloud.UpdateServerCert(zedcloudCtx, certBytes); err != nil {
+	if err := zedcloud.SaveServerSigningCert(zedcloudCtx, certBytes); err != nil {
 		errStr := fmt.Sprintf("%v", err)
 		log.Errorf("getCertsFromController: " + errStr)
 		return false

--- a/pkg/pillar/cmd/zedagent/parseconfig_test.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig_test.go
@@ -110,9 +110,9 @@ func TestParsePhysicalNetworkAdapters(t *testing.T) {
 		},
 	}
 
-	parseDeviceIoListConfig(config, getconfigCtx)
-	parseNetworkXObjectConfig(config, getconfigCtx)
-	parseSystemAdapterConfig(config, getconfigCtx, true)
+	parseDeviceIoListConfig(getconfigCtx, config)
+	parseNetworkXObjectConfig(getconfigCtx, config)
+	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 
 	portConfig, err := getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -171,9 +171,9 @@ func TestDPCWithError(t *testing.T) {
 		},
 	}
 
-	parseDeviceIoListConfig(config, getconfigCtx)
-	parseNetworkXObjectConfig(config, getconfigCtx)
-	parseSystemAdapterConfig(config, getconfigCtx, true)
+	parseDeviceIoListConfig(getconfigCtx, config)
+	parseNetworkXObjectConfig(getconfigCtx, config)
+	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 
 	portConfig, err := getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -297,10 +297,10 @@ func TestParseVlans(t *testing.T) {
 		},
 	}
 
-	parseDeviceIoListConfig(config, getconfigCtx)
-	parseVlans(config, getconfigCtx)
-	parseNetworkXObjectConfig(config, getconfigCtx)
-	parseSystemAdapterConfig(config, getconfigCtx, true)
+	parseDeviceIoListConfig(getconfigCtx, config)
+	parseVlans(getconfigCtx, config)
+	parseNetworkXObjectConfig(getconfigCtx, config)
+	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 
 	portConfig, err := getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -359,7 +359,7 @@ func TestParseVlans(t *testing.T) {
 		Cost:           30,
 		Addr:           "192.168.1.150",
 	})
-	parseSystemAdapterConfig(config, getconfigCtx, true)
+	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -463,10 +463,10 @@ func TestParseBonds(t *testing.T) {
 		},
 	}
 
-	parseDeviceIoListConfig(config, getconfigCtx)
-	parseBonds(config, getconfigCtx)
-	parseNetworkXObjectConfig(config, getconfigCtx)
-	parseSystemAdapterConfig(config, getconfigCtx, true)
+	parseDeviceIoListConfig(getconfigCtx, config)
+	parseBonds(getconfigCtx, config)
+	parseNetworkXObjectConfig(getconfigCtx, config)
+	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 
 	portConfig, err := getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -616,11 +616,11 @@ func TestParseVlansOverBonds(t *testing.T) {
 		},
 	}
 
-	parseDeviceIoListConfig(config, getconfigCtx)
-	parseBonds(config, getconfigCtx)
-	parseVlans(config, getconfigCtx)
-	parseNetworkXObjectConfig(config, getconfigCtx)
-	parseSystemAdapterConfig(config, getconfigCtx, true)
+	parseDeviceIoListConfig(getconfigCtx, config)
+	parseBonds(getconfigCtx, config)
+	parseVlans(getconfigCtx, config)
+	parseNetworkXObjectConfig(getconfigCtx, config)
+	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 
 	portConfig, err := getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -759,8 +759,8 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 	}
 
 	// IO and networks do not change between scenarios
-	parseDeviceIoListConfig(baseConfig, getconfigCtx)
-	parseNetworkXObjectConfig(baseConfig, getconfigCtx)
+	parseDeviceIoListConfig(getconfigCtx, baseConfig)
+	parseNetworkXObjectConfig(getconfigCtx, baseConfig)
 
 	// Scenario 1: System adapters referencing the same underlying port
 	config := &zconfig.EdgeDevConfig{
@@ -781,7 +781,7 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 			},
 		},
 	}
-	parseSystemAdapterConfig(config, getconfigCtx, true)
+	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err := getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
 	dpc := portConfig.(types.DevicePortConfig)
@@ -794,7 +794,7 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 
 	// fix:
 	config.SystemAdapterList[1].LowerLayerName = "warehouse"
-	parseSystemAdapterConfig(config, getconfigCtx, true)
+	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
 	dpc = portConfig.(types.DevicePortConfig)
@@ -820,8 +820,8 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 			},
 		},
 	}
-	parseBonds(config, getconfigCtx)
-	parseSystemAdapterConfig(config, getconfigCtx, true)
+	parseBonds(getconfigCtx, config)
+	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
 	dpc = portConfig.(types.DevicePortConfig)
@@ -832,8 +832,8 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 	// fix:
 	config.Bonds[0].Logicallabel = "bond-shopfloor"
 	config.SystemAdapterList[0].LowerLayerName = "bond-shopfloor"
-	parseBonds(config, getconfigCtx)
-	parseSystemAdapterConfig(config, getconfigCtx, true)
+	parseBonds(getconfigCtx, config)
+	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
 	dpc = portConfig.(types.DevicePortConfig)
@@ -851,8 +851,8 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 			},
 		},
 	}
-	parseBonds(config, getconfigCtx)
-	parseSystemAdapterConfig(config, getconfigCtx, true)
+	parseBonds(getconfigCtx, config)
+	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
 	dpc = portConfig.(types.DevicePortConfig)
@@ -869,8 +869,8 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 			BondMode:        zconfig.BondMode_BOND_MODE_ACTIVE_BACKUP,
 		},
 	}
-	parseBonds(config, getconfigCtx)
-	parseSystemAdapterConfig(config, getconfigCtx, true)
+	parseBonds(getconfigCtx, config)
+	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
 	dpc = portConfig.(types.DevicePortConfig)
@@ -902,8 +902,8 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 			},
 		},
 	}
-	parseBonds(config, getconfigCtx)
-	parseSystemAdapterConfig(config, getconfigCtx, true)
+	parseBonds(getconfigCtx, config)
+	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
 	dpc = portConfig.(types.DevicePortConfig)
@@ -916,8 +916,8 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 
 	// fix:
 	config.Bonds[0].LowerLayerNames = []string{"shopfloor"}
-	parseBonds(config, getconfigCtx)
-	parseSystemAdapterConfig(config, getconfigCtx, true)
+	parseBonds(getconfigCtx, config)
+	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
 	dpc = portConfig.(types.DevicePortConfig)
@@ -955,9 +955,9 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 			},
 		},
 	}
-	parseBonds(config, getconfigCtx)
-	parseVlans(config, getconfigCtx)
-	parseSystemAdapterConfig(config, getconfigCtx, true)
+	parseBonds(getconfigCtx, config)
+	parseVlans(getconfigCtx, config)
+	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
 	dpc = portConfig.(types.DevicePortConfig)
@@ -970,9 +970,9 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 
 	// fix:
 	config.Vlans[1].VlanId = 200
-	parseBonds(config, getconfigCtx)
-	parseVlans(config, getconfigCtx)
-	parseSystemAdapterConfig(config, getconfigCtx, true)
+	parseBonds(getconfigCtx, config)
+	parseVlans(getconfigCtx, config)
+	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
 	dpc = portConfig.(types.DevicePortConfig)
@@ -1012,9 +1012,9 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 			},
 		},
 	}
-	parseBonds(config, getconfigCtx)
-	parseVlans(config, getconfigCtx)
-	parseSystemAdapterConfig(config, getconfigCtx, true)
+	parseBonds(getconfigCtx, config)
+	parseVlans(getconfigCtx, config)
+	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
 	dpc = portConfig.(types.DevicePortConfig)
@@ -1027,9 +1027,9 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 
 	// fix:
 	config.Bonds[0].LowerLayerNames = []string{"shopfloor"} // remove warehouse from the LAG
-	parseBonds(config, getconfigCtx)
-	parseVlans(config, getconfigCtx)
-	parseSystemAdapterConfig(config, getconfigCtx, true)
+	parseBonds(getconfigCtx, config)
+	parseVlans(getconfigCtx, config)
+	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
 	dpc = portConfig.(types.DevicePortConfig)
@@ -1067,8 +1067,8 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 			},
 		},
 	}
-	parseBonds(config, getconfigCtx)
-	parseSystemAdapterConfig(config, getconfigCtx, true)
+	parseBonds(getconfigCtx, config)
+	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
 	dpc = portConfig.(types.DevicePortConfig)
@@ -1082,8 +1082,8 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 	// fix
 	config.Bonds[0].LowerLayerNames = []string{"shopfloor"}
 	config.Bonds[1].LowerLayerNames = []string{"warehouse"}
-	parseBonds(config, getconfigCtx)
-	parseSystemAdapterConfig(config, getconfigCtx, true)
+	parseBonds(getconfigCtx, config)
+	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
 	dpc = portConfig.(types.DevicePortConfig)
@@ -1109,9 +1109,9 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 			},
 		},
 	}
-	parseBonds(config, getconfigCtx)
-	parseVlans(config, getconfigCtx)
-	parseSystemAdapterConfig(config, getconfigCtx, true)
+	parseBonds(getconfigCtx, config)
+	parseVlans(getconfigCtx, config)
+	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
 	dpc = portConfig.(types.DevicePortConfig)
@@ -1122,9 +1122,9 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 
 	// fix:
 	config.Vlans[0].VlanId = 1000
-	parseBonds(config, getconfigCtx)
-	parseVlans(config, getconfigCtx)
-	parseSystemAdapterConfig(config, getconfigCtx, true)
+	parseBonds(getconfigCtx, config)
+	parseVlans(getconfigCtx, config)
+	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
 	dpc = portConfig.(types.DevicePortConfig)

--- a/pkg/pillar/docs/nim.md
+++ b/pkg/pillar/docs/nim.md
@@ -3,8 +3,8 @@
 ## Overview
 
 NIM manages (physical) network interfaces (Ethernet, WiFi, LTE) of a device based
-on configuration coming from various sources (controller, override, last-resort,
-persisted config).
+on configuration coming from various sources (controller, bootstrap-config.pb,
+override/usb.json, last-resort, persisted config).
 Its main goal is to preserve connectivity between the device and the controller.
 NIM verifies new configuration changes before fully committing to them.
 Moreover, it maintains one or more old but working configurations with a lower-priority,
@@ -19,10 +19,10 @@ to move to the most recent, aka the highest-priority configuration.
   * an instance of the `DevicePortConfig` struct (abbreviated to DPC)
   * contains configuration for every physical interface, except those which are
     disabled or directly assigned to applications
-  * DPC is received from different sources, such as zedagent (config from controller),
-    the `/config` partition with override DPC copied from USB stick
-    by `device-steps.sh` and even from NIM itself, which builds and publishes
-    the *last-resort* config if enabled
+  * DPC is received from different sources, such as zedagent (bootstrap config
+    or config from the controller), the `/config` partition with `override.json`,
+    specially formatted USB stick with `usb.json` and even from NIM itself,
+    which builds and publishes the *last-resort* config if enabled
 * global configuration properties
   * an instance of `ConfigItemValueMap` struct received from zedagent
   * used to determine if last-resort should be enabled, also to obtain time

--- a/pkg/pillar/types/ledmanagertypes.go
+++ b/pkg/pillar/types/ledmanagertypes.go
@@ -34,6 +34,8 @@ const (
 	LedBlinkInvalidControllerCert
 	// LedBlinkInvalidAuthContainer - LED indication of message not being signed by controller.
 	LedBlinkInvalidAuthContainer
+	// LedBlinkInvalidBootstrapConfig - LED indication of bootstrap configuration (bootstrap-config.pb) not being valid.
+	LedBlinkInvalidBootstrapConfig
 )
 
 // String returns human-readable description of the state indicated by the particular LED blinking count.
@@ -61,6 +63,8 @@ func (c LedBlinkCount) String() string {
 		return "Failed to fetch or verify EV Controller certificate"
 	case LedBlinkInvalidAuthContainer:
 		return "Response has invalid controller signature"
+	case LedBlinkInvalidBootstrapConfig:
+		return "Invalid Bootstrap configuration"
 	default:
 		return fmt.Sprintf("Unsupported LED counter (%d)", c)
 	}

--- a/pkg/pillar/types/locationconsts.go
+++ b/pkg/pillar/types/locationconsts.go
@@ -52,6 +52,10 @@ const (
 	V2TLSBaseFile = IdentityDirname + "/v2tlsbaseroot-certificates.pem"
 	// APIV1FileName - user can statically allow for API v1
 	APIV1FileName = IdentityDirname + "/Force-API-V1"
+	// BootstrapConfFileName - file to store initial device configuration for bootstrapping
+	BootstrapConfFileName = IdentityDirname + "/bootstrap-config.pb"
+	// BootstrapShaFileName - file to store SHA hash of an already ingested bootstrap config
+	BootstrapShaFileName = IngestedDirname + "/bootstrap-config.sha"
 
 	// ServerSigningCertFileName - filename for server signing leaf certificate
 	ServerSigningCertFileName = CertificateDirname + "/server-signing-cert.pem"


### PR DESCRIPTION
A new method for out-of-band delivery of the initial device configuration, which is sometimes needed to establish a working network connectivity between the device and the controller. Most of the design description and discussions is inside Zededa-internal documents, however the second commit of this PR contains documentation describing this feature at least within the scope of EVE OS.

Note that I had to make small adjustments in config processing by zedagent, domainmgr and nim, so that they would not be stuck waiting for device UUID but process the initial bootstrap config (just like a regular config from controller). In other words, EVE must have been enhanced to support config processing before onboarding.