### PR TITLE
simplify publish workflow with explicit matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,12 +11,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  packages:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [arm64-dirty, ubuntu-20.04]
+        include:
+        - os: arm64-dirty
+          arch: arm64
+        - os: ubuntu-20.04
+          arch: amd64
     steps:
       - name: Starting Report
         run: |
@@ -32,15 +36,18 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: ensure zstd for cache  # this should be removed once the arm64 VM includes zstd
+        if: ${{ matrix.os == 'arm64-dirty' || matrix.os == 'arm64-secure' }}
+        run: |
+          sudo apt install -y zstd
+      - name: update linuxkit cache if available
+        uses: actions/cache@v3
+        with:
+          path: ~/.linuxkit/cache
+          key: linuxkit-${{ matrix.arch }}-${{ github.sha }}
       - name: Build packages
-        env:
-          PR_ID: ${{ github.event.pull_request.number  }}
         run: |
           make V=1 PRUNE=1 pkgs
-          COMMIT_ID=$(git describe --abbrev=8 --always)
-          echo "VERSION=0.0.0-pr$PR_ID-$COMMIT_ID" >> $GITHUB_ENV
-          echo "TAG=evebuild/danger:pr$PR_ID" >> $GITHUB_ENV
-          echo "ARCH=$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')" >> "$GITHUB_ENV"
       - name: Post package report
         run: |
           echo Disk usage
@@ -49,9 +56,49 @@ jobs:
           free -m
           docker system df
           docker system df -v
-      - name: Build EVE KVM
+
+  eve:
+    needs: packages  # all packages for all platforms must be built first
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [arm64, amd64]
+        hv: [xen, kvm]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: update linuxkit cache for runner arch so we can get desired images
+        uses: actions/cache@v3
+        with:
+          path: ~/.linuxkit/cache
+          key: linuxkit-amd64-${{ github.sha }}
+      - name: load images we need from linuxkit cache into docker
         run: |
-          make V=1 ROOTFS_VERSION="$VERSION" HV=kvm eve  # note that this already loads it into docker
+          make cache-export-docker-load-all
+      - name: clear linuxkit cache so we can load for target arch
+        if: ${{ matrix.arch != 'amd64' }}  # because our runner arch is amd64; if that changes, this will have to change
+        run: |
+          rm -rf ~/.linuxkit
+      - name: update linuxkit cache for our arch
+        if: ${{ matrix.arch != 'amd64' }}  # because our runner arch is amd64; if that changes, this will have to change
+        uses: actions/cache@v3
+        with:
+          path: ~/.linuxkit/cache
+          key: linuxkit-${{ matrix.arch }}-${{ github.sha }}
+      - name: set environment
+        env:
+          PR_ID: ${{ github.event.pull_request.number  }}
+        run: |
+          COMMIT_ID=$(git describe --abbrev=8 --always)
+          echo "VERSION=0.0.0-pr$PR_ID-$COMMIT_ID" >> $GITHUB_ENV
+          echo "TAG=evebuild/danger:pr$PR_ID" >> $GITHUB_ENV
+          echo "ARCH=${{ matrix.arch }}" >> "$GITHUB_ENV"
+
+      - name: Build EVE ${{ matrix.hv }}-${{ matrix.arch }}
+        run: |
+          make V=1 ROOTFS_VERSION="$VERSION" HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} eve  # note that this already loads it into docker
       - name: Post eve build report
         run: |
           echo Disk usage
@@ -62,18 +109,17 @@ jobs:
           docker system df -v
       - name: Export docker container
         run: |
-          docker tag "lfedge/eve:$VERSION-kvm" "$TAG-kvm-${{ env.ARCH }}"
-          docker save "$TAG-kvm-${{ env.ARCH }}" > "eve-kvm-${{ env.ARCH }}.tar"
-      - name: Upload EVE KVM
+          make cache-export ZARCH=${{ matrix.arch }} IMAGE=lfedge/eve:$VERSION-${{ matrix.hv }} OUTFILE=eve-${{ matrix.hv }}-${{ matrix.arch }}.tar IMAGE_NAME=$TAG-${{ matrix.hv }}-${{ matrix.arch }}
+      - name: Upload EVE ${{ matrix.hv }}-${{ matrix.arch }}
         uses: actions/upload-artifact@v2
         with:
-          name: eve-kvm-${{ env.ARCH }}
-          path: eve-kvm-${{ env.ARCH }}.tar
-      - name: Clean EVE KVM
+          name: eve-${{ matrix.hv }}-${{ matrix.arch }}
+          path: eve-${{ matrix.hv }}-${{ matrix.arch }}.tar
+      - name: Clean EVE ${{ matrix.hv }}-${{ matrix.arch }}
         run: |
           make clean
-          docker rmi "$TAG-kvm-${{ env.ARCH }}" "lfedge/eve:$VERSION-kvm" "lfedge/eve:$VERSION-kvm-${{ env.ARCH }}" ||:
-      - name: Post clean eve KVM report
+          docker rmi "$TAG-${{ matrix.hv }}-${{ matrix.arch }}" "lfedge/eve:$VERSION-${{ matrix.hv }}" "lfedge/eve:$VERSION-${{ matrix.hv }}-${{ matrix.arch }}" ||:
+      - name: Post clean eve ${{ matrix.hv }}-${{ matrix.arch }} report
         run: |
           echo Disk usage
           df -h
@@ -81,26 +127,6 @@ jobs:
           free -m
           docker system df
           docker system df -v
-      - name: Build EVE XEN
-        run: |
-          make V=1 ROOTFS_VERSION="$VERSION" HV=xen eve
-      - name: Post eve build report
-        run: |
-          echo Disk usage
-          df -h
-          echo Memory
-          free -m
-          docker system df
-          docker system df -v
-      - name: Export docker container
-        run: |
-          docker tag "lfedge/eve:$VERSION-xen" "$TAG-xen-${{ env.ARCH }}"
-          docker save "$TAG-xen-${{ env.ARCH }}" > "eve-xen-${{ env.ARCH }}.tar"
-      - name: Upload EVE XEN
-        uses: actions/upload-artifact@v2
-        with:
-          name: eve-xen-${{ env.ARCH }}
-          path: eve-xen-${{ env.ARCH }}.tar
       - name: Clean
         if: ${{ always() }}
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,13 +9,19 @@ on:
       - "[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
-  build:
+  packages:
     if: github.event.repository.full_name == 'lf-edge/eve'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [arm64-secure, ubuntu-20.04, ubuntu-latest]
+        include:
+          - os: arm64-secure
+            arch: arm64
+          - os: ubuntu-20.04
+            arch: amd64
+          - os: ubuntu-latest
+            arch: riscv64
     steps:
       - name: Starting Report
         run: |
@@ -33,8 +39,8 @@ jobs:
         env:
           REF: ${{ github.ref }}
         run: |
-          # we are using ubuntu-latest as our riscv64 cross build machine
-          if [ "${{ matrix.os }}" = ubuntu-latest ]; then
+          # some special installs when building for riscv64
+          if [ "${{ matrix.arch }}" = riscv64 ]; then
              APT_INSTALL="sudo apt install -y binfmt-support qemu-user-static"
              # the following weird statement is here to speed up the happy path
              # if the default server is responding -- we can skip apt update
@@ -42,7 +48,7 @@ jobs:
              # constraining environment for riscv64 builds
              echo "ZARCH=riscv64" >> "$GITHUB_ENV"
           fi
-          echo "ARCH=$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')" >> "$GITHUB_ENV"
+          echo "ARCH=${{ matrix.arch }}" >> "$GITHUB_ENV"
           echo "TAG=$(echo "$REF" | sed -e 's#^.*/##' -e 's#master#snapshot#' -e 's#main#snapshot#')" >> "$GITHUB_ENV"
       - name: Login to DockerHUB
         run: |
@@ -81,14 +87,37 @@ jobs:
           free -m
           docker system df
           docker system df -v
-      - name: Build EVE for KVM
+      - name: Clean
+        run: |
+          make clean
+          docker system prune -f -a
+          rm -rf ~/.linuxkit
+
+  # eve composition can run as a separate job, even on a separate runner, because the packages job
+  # published everything. Which means all images are already on the OCI registry.
+  eve:
+    if: github.event.repository.full_name == 'lf-edge/eve'
+    needs: packages
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [arm64, amd64]
+        hv: [kvm, xen]
+        include:
+          - arch: riscv64
+            hv: mini
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Build EVE for ${{ matrix.arch }}-${{ matrix.hv }}
         # build #1 without push (do not push either unless both can build)
-        if: ${{ matrix.os != 'ubuntu-latest' }}
         run: |
-          rm -rf dist dist.xen
-          make -e V=1 HV=kvm eve
-          mv -f dist dist.xen
-      - name: Post eve KVM report
+          rm -rf dist dist.${{ matrix.hv }}
+          make -e V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} eve
+          mv -f dist dist.${{ matrix.hv }}
+      - name: Post eve ${{ matrix.arch }}-${{ matrix.hv }} report
         run: |
           echo Disk usage
           df -h
@@ -96,12 +125,11 @@ jobs:
           free -m
           docker system df
           docker system df -v
-      - name: Build and push EVE for Xen
+      - name: Build and push EVE for ${{ matrix.arch }}-${{ matrix.hv }}
         # since build #1 works, build and push #2
-        if: ${{ matrix.os != 'ubuntu-latest' }}
         run: |
-          make -e V=1 HV=xen LINUXKIT_PKG_TARGET=push eve
-      - name: Post eve Xen report
+          make -e V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} LINUXKIT_PKG_TARGET=push eve
+      - name: Post eve ${{ matrix.arch }}-${{ matrix.hv }} report
         run: |
           echo Disk usage
           df -h
@@ -109,21 +137,7 @@ jobs:
           free -m
           docker system df
           docker system df -v
-      - name: Build and push EVE for KVM
-        # redo build #1 with push
-        if: ${{ matrix.os != 'ubuntu-latest' }}
-        run: |
-          rm -rf dist
-          mv -f dist.xen dist
-          make -e V=1 HV=kvm LINUXKIT_PKG_TARGET=push eve
-      - name: Build EVE for riscv64
-        # special HV for riscv64
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: |
-          rm -rf dist dist.xen
-          make -e V=1 HV=mini LINUXKIT_PKG_TARGET=push eve
       - name: Pre clean report
-        if: ${{ always() }}
         run: |
           echo Disk usage
           df -h
@@ -132,7 +146,6 @@ jobs:
           docker system df
           docker system df -v
       - name: Clean
-        if: ${{ always() }}
         run: |
           make clean
           docker system prune -f -a
@@ -141,7 +154,7 @@ jobs:
   manifest:
     if: github.event.repository.full_name == 'lf-edge/eve'
     runs-on: ubuntu-latest
-    needs: build
+    needs: packages
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Simplifies the `publish.yml` workflow by explicitly using the matrix for arch, and removing a lot of the redundant `if` conditions.

I would like to do the same to `build.yml`, but it is harder there. Because those _build_ packages but do not _publish_ them , the packages are only available on the linuxkit cache on the specific runner. We would have to get the cached packages off of the runner and onto another runner before we could start doing `make eve`. The easiest thing to do is what we do now: run `make eve` as part of the same job on the same runner.

If we could use `lkt pkg build` with its docker context support for remote runners, then it already would centralize it all to a single cache. But we do not do that here; it would require setting up docker contexts on machines that are not necessarily remotely accessible from the "main" runner.

This is a step forward for now.