### PR TITLE
Update Eden tests

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -47,7 +47,7 @@ jobs:
           if [ -f ${{ github.workspace }}/eve/tests/eden/eden-version ]; then
             EDEN_VERSION=$(cat ${{ github.workspace }}/eve/tests/eden/eden-version)
           else
-            EDEN_VERSION=lfedge/eden:0.7.0
+            EDEN_VERSION=lfedge/eden:0.7.2
           fi
           docker run -v $PWD:/out $EDEN_VERSION cp -a /eden/. /out/
           sudo chown -R $(whoami) .

--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -95,7 +95,7 @@ jobs:
       # Use the latest version of EDEN with subset of tests from EVE-OS repo
       - name: Prepare eden
         run: |
-          EDEN_VERSION=lfedge/eden:0.7.0
+          EDEN_VERSION=lfedge/eden:0.7.2
           docker run -v $PWD:/out $EDEN_VERSION cp -a /eden/. /out/
           sudo chown -R $(whoami) .
       - name: Eden setup

--- a/tests/eden/docker/testdata/10dockers_test.txt
+++ b/tests/eden/docker/testdata/10dockers_test.txt
@@ -42,7 +42,7 @@ stdout 't8.+library/nginx:latest.+RUNNING'
 stdout 't9.+library/nginx:latest.+RUNNING'
 stdout 't10.+library/nginx:latest.+RUNNING'
 
-# Ngnix detecting
+# nginx detecting
 exec -t 1m curl localhost:8027
 stdout 'Welcome to nginx'
 exec -t 1m curl localhost:8028

--- a/tests/eden/docker/testdata/2dockers_test.txt
+++ b/tests/eden/docker/testdata/2dockers_test.txt
@@ -21,7 +21,7 @@ cp stdout pod_ps
 grep '^t1\s*' pod_ps
 grep '^t2\s*' pod_ps
 
-# Ngnix detecting
+# nginx detecting
 exec -t 1m bash get.sh t1
 stdout 'Welcome to nginx'
 exec -t 1m bash get.sh t2

--- a/tests/eden/eclient/testdata/maridb.txt
+++ b/tests/eden/eclient/testdata/maridb.txt
@@ -18,7 +18,7 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 eden pod deploy -n eclient --memory=512MB {{template "eclient_image"}} -p {{template "port"}}:22
 
-eden pod deploy -n {{$server}} --memory=512MB docker://mariadb:10.5.6-focal --metadata='MYSQL_ROOT_PASSWORD=adam&eve'
+eden pod deploy -n {{$server}} --cpus=2 --memory=1024MB docker://mariadb:10.8.3 --volume-size=2GB --metadata='MYSQL_ROOT_PASSWORD=adam&eve\nMYSQL_DATABASE=sbtest'
 
 test eden.app.test -test.v -timewait 20m RUNNING eclient {{$server}}
 
@@ -29,9 +29,15 @@ cp stdout pod_ps
 exec bash server_ip.sh {{$server}}
 
 exec sleep 10
-exec -t 20m bash wait_db.sh
+exec -t 10m bash wait_db.sh
 exec -t 1m bash run_client.sh
 cmp out mariadb.out
+
+exec -t 10m bash sysbench-read.sh
+stdout 'statistics'
+
+exec -t 10m bash sysbench-read-write.sh
+stdout 'statistics'
 
 eden pod delete eclient
 eden pod delete {{$server}}
@@ -51,7 +57,7 @@ done
 
 -- server_ip.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-echo export ESERVER_IP=$(grep "^$1\s" pod_ps | cut -f 4) > env
+echo export ESERVER_IP=$(grep "^$1\s" pod_ps | awk '{print $4}') > env
 echo export HOST=$($EDEN eve ip) >> env
 
 -- wait_db.sh --
@@ -73,6 +79,38 @@ echo {{template "ssh"}}$HOST "mysql --user=root --password='adam&eve' --host=$ES
 sleep 10
 echo {{template "ssh"}}$HOST 'cat /tmp/mariadb.out'
 {{template "ssh"}}$HOST 'cat /tmp/mariadb.out' > out
+
+-- sysbench-read.sh --
+. ./env
+
+BENCH_OPTS="/usr/share/sysbench/oltp_read_only.lua --threads=2 --tables=5 --table-size=100000"
+DRIVER_OPTS="--mysql-host=$ESERVER_IP --mysql-user=root --mysql-password='adam&eve' --mysql-port=3306"
+OPTS="$BENCH_OPTS $DRIVER_OPTS"
+
+echo {{template "ssh"}}$HOST "sysbench $OPTS prepare"
+{{template "ssh"}}$HOST "sysbench $OPTS prepare"
+
+echo {{template "ssh"}}$HOST "sysbench $OPTS --range_selects=off --db-ps-mode=disable run"
+{{template "ssh"}}$HOST "sysbench $OPTS --range_selects=off --db-ps-mode=disable run"
+
+echo {{template "ssh"}}$HOST "sysbench $OPTS --range_selects=off --db-ps-mode=disable cleanup"
+{{template "ssh"}}$HOST "sysbench $OPTS --range_selects=off --db-ps-mode=disable cleanup"
+
+-- sysbench-read-write.sh --
+. ./env
+
+BENCH_OPTS="/usr/share/sysbench/oltp_read_write.lua --threads=2 --tables=5 --table-size=100000"
+DRIVER_OPTS="--mysql-host=$ESERVER_IP --mysql-user=root --mysql-password='adam&eve' --mysql-port=3306"
+OPTS="$BENCH_OPTS $DRIVER_OPTS"
+
+echo {{template "ssh"}}$HOST "sysbench $OPTS prepare"
+{{template "ssh"}}$HOST "sysbench $OPTS prepare"
+
+echo {{template "ssh"}}$HOST "sysbench $OPTS --delete_inserts=10 --index_updates=10 --non_index_updates=10 --db-ps-mode=disable run"
+{{template "ssh"}}$HOST "sysbench $OPTS --delete_inserts=10 --index_updates=10 --non_index_updates=10 --db-ps-mode=disable run"
+
+echo {{template "ssh"}}$HOST "sysbench $OPTS --delete_inserts=10 --index_updates=10 --non_index_updates=10 --db-ps-mode=disable cleanup"
+{{template "ssh"}}$HOST "sysbench $OPTS --delete_inserts=10 --index_updates=10 --non_index_updates=10 --db-ps-mode=disable cleanup"
 
 -- mariadb.in --
 CREATE DATABASE bookstore;

--- a/tests/eden/eclient/testdata/networking_light.txt
+++ b/tests/eden/eclient/testdata/networking_light.txt
@@ -1,4 +1,4 @@
-# Test for internal TCP clien/server interconnection
+# Test for internal TCP client/server interconnection
 
 {{$test_msg := "This is a test"}}
 {{define "port"}}2223{{end}}
@@ -15,11 +15,19 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 # Starting of reboot detector with a 1 reboot limit
 ! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
-eden pod deploy -n eclient --memory=512MB {{template "eclient_image"}} -p {{template "port"}}:22
-#eden -t 20m pod logs eclient
-#stdout 'Executing "/usr/sbin/sshd" "-D"'
+message 'Resetting of EVE'
+eden eve reset
+exec sleep 30
 
-eden pod deploy -v warning -n eserver --memory=512MB {{template "eclient_image"}}
+message 'Creating networks'
+eden network create 10.11.12.0/24 -n n1
+eden network create 10.11.13.0/24 -n n2
+
+test eden.network.test -test.v -timewait 10m ACTIVATED n1 n2
+
+eden pod deploy -n eclient --memory=512MB {{template "eclient_image"}} --networks=n1 --networks=n2 -p {{template "port"}}:22
+
+eden pod deploy -v warning -n eserver --memory=512MB --networks=n1 --networks=n2 {{template "eclient_image"}}
 
 test eden.app.test -test.v -timewait 20m RUNNING eclient eserver
 
@@ -28,8 +36,21 @@ exec -t 20m bash wait_ssh.sh
 
 eden pod ps
 cp stdout pod_ps
-exec bash eserver_ip.sh
 
+# the first try with the first eserver ip
+exec bash eserver_ip.sh 1
+exec sleep 10
+exec -t 1m bash setup_srv.sh
+exec sleep 10
+exec -t 1m bash run_srv.sh &
+exec sleep 10
+exec -t 1m bash run_client.sh
+exec sleep 10
+exec -t 1m bash get_result.sh
+stdout '{{$test_msg}}'
+
+# the second try with the second eserver ip
+exec bash eserver_ip.sh 2
 exec sleep 10
 exec -t 1m bash setup_srv.sh
 exec sleep 10
@@ -45,6 +66,11 @@ eden pod delete eserver
 
 test eden.app.test -test.v -timewait 10m - eclient eserver
 
+eden network delete n1
+eden network delete n2
+
+test eden.network.test -test.v -timewait 10m - n1 n2
+
 -- wait_ssh.sh --
 
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
@@ -58,8 +84,9 @@ do
 done
 
 -- eserver_ip.sh --
+IP_NUM="$1"
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-echo export ESERVER_IP=$(grep '^eserver\s' pod_ps | cut -f 4) > env
+echo export ESERVER_IP=$(grep '^eserver\s' pod_ps | cut -f 4|tr -d ' '|cut -d";" -f"$IP_NUM") > env
 echo export HOST=$($EDEN eve ip) >> env
 
 -- setup_srv.sh --
@@ -83,8 +110,8 @@ echo {{template "ssh"}}$HOST "echo {{$test_msg}} | nc -N $ESERVER_IP 1234"
 -- get_result.sh --
 . ./env
 
-echo {{template "ssh"}}$HOST 'cat /tmp/out'
-{{template "ssh"}}$HOST 'cat /tmp/out'
+echo {{template "ssh"}}$HOST 'cat /tmp/out&&rm /tmp/out'
+{{template "ssh"}}$HOST 'cat /tmp/out&&rm /tmp/out'
 
 -- eden-config.yml --
 {{/* Test's config. file */}}

--- a/tests/eden/eclient/testdata/ngnix.txt
+++ b/tests/eden/eclient/testdata/ngnix.txt
@@ -1,6 +1,6 @@
 # Simple test of standard `nginx` image
 
-{{$server := "ngnix"}}
+{{$server := "nginx"}}
 {{$test_msg := "Welcome to nginx!"}}
 {{define "port"}}2223{{end}}
 {{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{template "port"}} root@{{end}}

--- a/tests/eden/eclient/testdata/nw_switch.txt
+++ b/tests/eden/eclient/testdata/nw_switch.txt
@@ -1,4 +1,4 @@
-# Test for apllications network connectivity switching
+# Test for applications network connectivity switching
 
 {{$test_msg := "This is a test"}}
 {{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@{{end}}
@@ -79,7 +79,7 @@ stdout '0% packet loss'
 stdout '100% packet loss'
 exec -t 5m bash wait_ssh.sh 2223 2224
 
-message 'Resource cleanng'
+message 'Resource cleanup'
 eden pod delete ping1
 eden pod delete ping2
 eden pod delete pong

--- a/tests/eden/eden-version
+++ b/tests/eden/eden-version
@@ -1,1 +1,1 @@
-lfedge/eden:0.7.0
+lfedge/eden:0.7.2

--- a/tests/eden/phoronix/testdata/deploy_app.txt
+++ b/tests/eden/phoronix/testdata/deploy_app.txt
@@ -1,1 +1,1 @@
-eden pod deploy {{EdenGetEnv "external_port"}} --metadata='BENCHMARK={{EdenGetEnv "benchmark"}}' --name='{{EdenGetEnv "name"}}' --memory=2GB --cpus=2 docker://lfedge/eden-phoronix-test:83cfe07
+eden pod deploy {{EdenGetEnv "external_port"}} --metadata='BENCHMARK={{EdenGetEnv "benchmark"}}' --name='{{EdenGetEnv "name"}}' --memory=2GB --cpus=2 --volume-size=3GB docker://lfedge/eden-phoronix-test:83cfe07

--- a/tests/eden/update_eve_image/testdata/update_eve_image_oci.txt
+++ b/tests/eden/update_eve_image/testdata/update_eve_image_oci.txt
@@ -20,8 +20,15 @@
 # Use eden.lim.test for access Infos with timewait 30m
 {{$test := "test eden.lim.test -test.v -timewait 30m -test.run TestInfo"}}
 
+{{$devmodel := EdenConfig "eve.devmodel"}}
+
+{{if (eq $devmodel "ZedVirtual-4G")}}
+# Decrease update testing time, but give a time to boot in testing state
+eden controller edge-node update --config timer.test.baseimage.update=120
+{{else}}
 # Decrease update testing time
 eden controller edge-node update --config timer.test.baseimage.update=30
+{{end}}
 
 # Send command to update eveimage from OCI image
 message 'EVE update request'
@@ -30,12 +37,38 @@ eden -t 10m controller edge-node eveimage-update oci://docker.io/lfedge/eve:{{$e
 # Check stderr, it must be empty
 ! stderr .
 
-# Run monitoring of Info messages to obtain info with PartitionState inprogress or active and previously defined ShortVersion
+{{if (eq $devmodel "ZedVirtual-4G")}}
+# Run monitoring of Info messages to obtain info with PartitionState inprogress and previously defined ShortVersion
+message 'Waiting for EVE update...'
+{{$test}} -out InfoContent.dinfo.SwList[0].ShortVersion 'InfoContent.dinfo.SwList[0].PartitionState:inprogress InfoContent.dinfo.SwList[0].ShortVersion:{{ $short_version }}'
+
+# Check stdout of previous command. Expected to get previously defined ShortVersion
+stdout '{{ $short_version }}'
+
+# simulate reboot during testing
+# to jump back to the previous EVE-OS image
+eden -t 2m eve stop
+exec sleep 10
+eden -t 2m eve start
+
+message 'Waiting for EVE update...'
+# waiting for defined ShortVersion in the second SwList and first one to be active
+{{$test}} -out InfoContent.dinfo.SwList[0].ShortVersion 'InfoContent.dinfo.SwList[0].PartitionState:active InfoContent.dinfo.SwList[1].ShortVersion:{{ $short_version }}'
+
+# send retry to initiate update again
+eden -t 2m controller edge-node eveimage-update-retry
+
+{{end}}
+
+# Run monitoring of Info messages to obtain info with PartitionState active and previously defined ShortVersion
 message 'Waiting for EVE update...'
 {{$test}} -out InfoContent.dinfo.SwList[0].ShortVersion 'InfoContent.dinfo.SwList[0].PartitionState:active InfoContent.dinfo.SwList[0].ShortVersion:{{ $short_version }}'
 
 # Check stdout of previous command. Expected to get previously defined ShortVersion
 stdout '{{ $short_version }}'
+
+# Decrease update testing time
+eden controller edge-node update --config timer.test.baseimage.update=30
 
 # Reset EVE version
 test eden.escript.test -test.run TestEdenScripts/revert_eve_image_update -test.v -testdata {{EdenConfig "eden.tests"}}/update_eve_image/testdata/

--- a/tests/eden/volume/testdata/volumes_test.txt
+++ b/tests/eden/volume/testdata/volumes_test.txt
@@ -57,7 +57,7 @@ wait errorwait
 # delete old volume and check if app goes into running state
 eden -t 1m volume delete blank-vol-2
 test eden.vol.test -test.v -timewait 5m - blank-vol-2
-test eden.app.test -test.v -timewait 5m RUNNING eclient-mount
+test eden.app.test -test.v -timewait 15m RUNNING eclient-mount
 
 exec sleep 10
 


### PR DESCRIPTION
1. Support BaseOS api logic
2. Implementation and test for retry of BaseOS image update
3. Fix stale error for volumes
4. Add sysbench to mariadb test
5. Expand networking_light to test multiple networks