### PR TITLE
add zstd to self-hosted runner cloud-init

### DIFF
--- a/build-tools/src/scripts/cloud-init.in
+++ b/build-tools/src/scripts/cloud-init.in
@@ -8,6 +8,7 @@ packages:
   - curl
   - ca-certificates
   - gnupg
+  - zstd
 
 groups:
   - docker


### PR DESCRIPTION
We need zstd in our self-hosted runners for GitHub actions/cache to work correctly across runners. Thanks to @giggsoff for pointing out the right location for this.