### PR TITLE
Prevent NVME devices used by EVE to be passed through to VMs

### DIFF
--- a/pkg/pillar/types/assignableadapters_test.go
+++ b/pkg/pillar/types/assignableadapters_test.go
@@ -5,6 +5,7 @@ package types
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	zcommon "github.com/lf-edge/eve/api/go/evecommon"
@@ -458,6 +459,41 @@ func TestExpandControllers(t *testing.T) {
 				}
 			}
 			assert.True(t, found, fmt.Sprintf("Expected %s in postList", m))
+		}
+	}
+}
+
+func TestNVMEIsUsed(t *testing.T) {
+	t.Parallel()
+	log := base.NewSourceLogObject(logrus.StandardLogger(), "test", 1234)
+	var err error
+
+	zfsManagerDir, err = os.MkdirTemp("./", "zfsmanager")
+	if err != nil {
+		t.Fatalf("unable to make %s directory: %v", zfsManagerDir, err)
+	}
+	defer os.RemoveAll(zfsManagerDir)
+
+	// Init phase
+	testMatrix := map[string]struct {
+		pciIDs          []string
+		devNames        []string // e.g., nvme0
+		mountEntries    []string // e.g., /dev/nvme0p1 /mnt/nvme0p1 ext4 rw 0 0
+		expectedAnswers []bool
+	}{
+		"Test empty": {},
+		"falseDev": {
+			pciIDs:          []string{"0000:00:00.0"},
+			devNames:        []string{"nvme0"},
+			mountEntries:    []string{""},
+			expectedAnswers: []bool{false},
+		},
+	}
+
+	for testname, test := range testMatrix {
+		t.Logf("Running test case %s", testname)
+		for i, pciID := range test.pciIDs {
+			assert.Equal(t, test.expectedAnswers[i], NVMEIsUsed(log, nil, pciID))
 		}
 	}
 }


### PR DESCRIPTION
1) Add a function that checks if a device is used by EVE 
2) Set keepInHost to true for such devices

Signed-off-by: Ioannis Sfakianakis <ioannis@zededa.com>