### PR TITLE
Add  the  cpumask options to QEMU.

### DIFF
--- a/pkg/xen-tools/patches-4.15.0/13-qemu-Add-cpu-pin-and-cpumask-options.patch
+++ b/pkg/xen-tools/patches-4.15.0/13-qemu-Add-cpu-pin-and-cpumask-options.patch
@@ -1,0 +1,151 @@
+From ccfea3c5e131b3ee623aa5e4e16e13bf8d0291d2 Mon Sep 17 00:00:00 2001
+From: Nikolay Martyanov <ohmspectator@gmail.com>
+Date: Wed, 28 Sep 2022 15:47:11 +0200
+Subject: [PATCH 13/15] qemu: Add 'cpu-pin' and 'cpumask' options.
+
+Add the 'cpumask' option to set the CPU mask for the threads created by QEMU.
+The mask affects all the threads belonging to a VM: both VCPU threads and
+non-VCPU threads. If the option is not provided, it's considered to be '-1',
+which corresponds to all the available CPUs.
+The CPU mask in represented in the form "d[[,-]d]*". E.g. "0-2" or "0-2,5,6".
+CPUs start with 0. For example, the mask "0,3" would mean that only
+physical CPUs 0 and 3 are available for the VM.
+
+Add the 'cpu-pin' option to pin any VCPU thread to a specific CPU. If the
+option is set, any VCPU thread will be assigned to a CPU provided with the
+'cpumask'. If it's not provided, the VPCU threads can migrate from a CPU to a
+CPU within the set of CPUs provided by the 'cpumask' option.
+
+Signed-off-by: Nikolay Martyanov <ohmspectator@gmail.com>
+---
+ tools/qemu-xen/hw/core/machine.c   | 38 ++++++++++++++++++++++++++++++
+ tools/qemu-xen/include/hw/boards.h |  2 ++
+ tools/qemu-xen/qemu-options.hx     | 18 ++++++++++++++
+ tools/qemu-xen/softmmu/vl.c        |  4 ++++
+ 4 files changed, 62 insertions(+)
+
+diff --git a/tools/qemu-xen/hw/core/machine.c b/tools/qemu-xen/hw/core/machine.c
+index 8d1a90c..2f9993e 100644
+--- a/tools/qemu-xen/hw/core/machine.c
++++ b/tools/qemu-xen/hw/core/machine.c
+@@ -372,6 +372,35 @@ static void machine_set_graphics(Object *obj, bool value, Error **errp)
+     ms->enable_graphics = value;
+ }
+ 
++static bool machine_get_cpu_pin(Object *obj, Error **errp)
++{
++    MachineState *ms = MACHINE(obj);
++
++    return ms->cpu_pin;
++}
++
++static void machine_set_cpu_pin(Object *obj, bool value, Error **errp)
++{
++    MachineState *ms = MACHINE(obj);
++
++    ms->cpu_pin = value;
++}
++
++static char *machine_get_cpumask(Object *obj, Error **errp)
++{
++    MachineState *ms = MACHINE(obj);
++
++    return g_strdup(ms->cpumask_str);
++}
++
++static void machine_set_cpumask(Object *obj, const char *value, Error **errp)
++{
++    MachineState *ms = MACHINE(obj);
++
++    g_free(ms->cpumask_str);
++    ms->cpumask_str = g_strdup(value);
++}
++
+ static char *machine_get_firmware(Object *obj, Error **errp)
+ {
+     MachineState *ms = MACHINE(obj);
+@@ -841,6 +870,15 @@ static void machine_class_init(ObjectClass *oc, void *data)
+     object_class_property_set_description(oc, "usb",
+         "Set on/off to enable/disable usb");
+ 
++    object_class_property_add_bool(oc, "cpu-pin",
++        machine_get_cpu_pin, machine_set_cpu_pin);
++    object_class_property_set_description(oc, "cpu-pin",
++        "Set on/off to enable/disable CPU pinning");
++
++    object_class_property_add_str(oc, "cpumask",
++        machine_get_cpumask, machine_set_cpumask);
++    object_class_property_set_description(oc, "cpumask", "CPU Mask");
++
+     object_class_property_add_bool(oc, "graphics",
+         machine_get_graphics, machine_set_graphics);
+     object_class_property_set_description(oc, "graphics",
+diff --git a/tools/qemu-xen/include/hw/boards.h b/tools/qemu-xen/include/hw/boards.h
+index 426ce5f..b06f13e 100644
+--- a/tools/qemu-xen/include/hw/boards.h
++++ b/tools/qemu-xen/include/hw/boards.h
+@@ -294,6 +294,8 @@ struct MachineState {
+     char *kernel_filename;
+     char *kernel_cmdline;
+     char *initrd_filename;
++    bool cpu_pin;
++    char *cpumask_str;
+     const char *cpu_type;
+     AccelState *accelerator;
+     CPUArchIdList *possible_cpus;
+diff --git a/tools/qemu-xen/qemu-options.hx b/tools/qemu-xen/qemu-options.hx
+index 708583b..a33ee1e 100644
+--- a/tools/qemu-xen/qemu-options.hx
++++ b/tools/qemu-xen/qemu-options.hx
+@@ -509,6 +509,24 @@ SRST
+     Preallocate memory when using -mem-path.
+ ERST
+ 
++DEF("cpu-pin", 0, QEMU_OPTION_cpu_pin,
++    "-cpu-pin   pin any VPCU thread to a physical CPU\n",
++    QEMU_ARCH_ALL)
++SRST
++``-cpu-pin``
++    Pin any VCPU thread to a physical CPU.
++ERST
++
++DEF("cpumask", HAS_ARG, QEMU_OPTION_cpumask,
++    "-cpumask=value   define the set of CPUs used by the VM\n",
++    QEMU_ARCH_ALL)
++SRST
++``-cpumask=value``
++    CPU mask in form "d[[,-]d]*". E.g. "0-2" or "0-2,5,6". CPUs start with 0.
++    For example, the mask "0,3" would mean that only physical CPUs 0 and 3 are
++    available for the VM.
++ERST
++
+ DEF("k", HAS_ARG, QEMU_OPTION_k,
+     "-k language     use keyboard layout (for example 'fr' for French)\n",
+     QEMU_ARCH_ALL)
+diff --git a/tools/qemu-xen/softmmu/vl.c b/tools/qemu-xen/softmmu/vl.c
+index 4eb9d1f..c7c8abc 100644
+--- a/tools/qemu-xen/softmmu/vl.c
++++ b/tools/qemu-xen/softmmu/vl.c
+@@ -2868,6 +2868,7 @@ void qemu_init(int argc, char **argv, char **envp)
+     BlockdevOptionsQueue bdo_queue = QSIMPLEQ_HEAD_INITIALIZER(bdo_queue);
+     QemuPluginList plugin_list = QTAILQ_HEAD_INITIALIZER(plugin_list);
+     int mem_prealloc = 0; /* force preallocation of physical target memory */
++    bool cpu_pin = false;
+ 
+     os_set_line_buffering();
+ 
+@@ -3638,6 +3639,9 @@ void qemu_init(int argc, char **argv, char **envp)
+             case QEMU_OPTION_nodefaults:
+                 has_defaults = 0;
+                 break;
++	    case QEMU_OPTION_cpu_pin:
++		cpu_pin = true;
++		break;
+             case QEMU_OPTION_xen_domid:
+                 if (!(xen_available())) {
+                     error_report("Option not supported for this target");
+
+base-commit: 9c55fdd5e54c5ea4bf238cee787f13a03eac1c86
+-- 
+2.35.1
+

--- a/pkg/xen-tools/patches-4.15.0/14-qemu-Init-CPU-mask-per-VCPU.patch
+++ b/pkg/xen-tools/patches-4.15.0/14-qemu-Init-CPU-mask-per-VCPU.patch
@@ -1,0 +1,189 @@
+From ee13ecbab30e8a0d42e9c870e9a234ebcd0f45c9 Mon Sep 17 00:00:00 2001
+From: Nikolay Martyanov <ohmspectator@gmail.com>
+Date: Wed, 28 Sep 2022 15:52:24 +0200
+Subject: [PATCH 14/15] qemu: Init CPU mask per VCPU.
+
+Signed-off-by: Nikolay Martyanov <ohmspectator@gmail.com>
+---
+ tools/qemu-xen/include/hw/boards.h   |  1 +
+ tools/qemu-xen/include/hw/core/cpu.h |  2 +
+ tools/qemu-xen/softmmu/cpus.c        | 31 +++++++++++
+ tools/qemu-xen/softmmu/vl.c          | 81 ++++++++++++++++++++++++++++
+ 4 files changed, 115 insertions(+)
+
+diff --git a/tools/qemu-xen/include/hw/boards.h b/tools/qemu-xen/include/hw/boards.h
+index b06f13e..a4b4f11 100644
+--- a/tools/qemu-xen/include/hw/boards.h
++++ b/tools/qemu-xen/include/hw/boards.h
+@@ -296,6 +296,7 @@ struct MachineState {
+     char *initrd_filename;
+     bool cpu_pin;
+     char *cpumask_str;
++    uint64_t cpumask;
+     const char *cpu_type;
+     AccelState *accelerator;
+     CPUArchIdList *possible_cpus;
+diff --git a/tools/qemu-xen/include/hw/core/cpu.h b/tools/qemu-xen/include/hw/core/cpu.h
+index 8f14573..628b31a 100644
+--- a/tools/qemu-xen/include/hw/core/cpu.h
++++ b/tools/qemu-xen/include/hw/core/cpu.h
+@@ -374,6 +374,8 @@ struct CPUState {
+     bool created;
+     bool stop;
+     bool stopped;
++    bool pinned;
++    uint64_t cpumask;
+     bool unplug;
+     bool crash_occurred;
+     bool exit_request;
+diff --git a/tools/qemu-xen/softmmu/cpus.c b/tools/qemu-xen/softmmu/cpus.c
+index a802e89..da56052 100644
+--- a/tools/qemu-xen/softmmu/cpus.c
++++ b/tools/qemu-xen/softmmu/cpus.c
+@@ -2011,6 +2011,23 @@ static void qemu_dummy_start_vcpu(CPUState *cpu)
+                        QEMU_THREAD_JOINABLE);
+ }
+ 
++static inline void cpumask_clear_bit(uint64_t *mask, uint8_t bit)
++{
++    *mask &= ~(1ul << bit);
++}
++
++static inline long cpumask_get_min_bit(uint64_t mask)
++{
++  return __builtin_ffsll(mask) - 1;
++}
++
++static long pick_pcpu(uint64_t *cpumask)
++{
++    long ret = cpumask_get_min_bit(*cpumask);
++    cpumask_clear_bit(cpumask, ret);
++    return ret;
++}
++
+ void qemu_init_vcpu(CPUState *cpu)
+ {
+     MachineState *ms = MACHINE(qdev_get_machine());
+@@ -2019,6 +2036,20 @@ void qemu_init_vcpu(CPUState *cpu)
+     cpu->nr_threads =  ms->smp.threads;
+     cpu->stopped = true;
+     cpu->random_seed = qemu_guest_random_seed_thread_part1();
++    cpu->pinned = ms->cpu_pin;
++    static uint64_t vm_cpumask;
++    uint64_t vcpu_cpumask;
++    if (!vm_cpumask)
++        vm_cpumask = ms->cpumask;
++    if (!cpu->pinned) {
++        /* If the CPUs are not pinned, assign the whole CPU mask to the VCPU */
++        vcpu_cpumask = vm_cpumask;
++    } else {
++        /* If the CPUs are pinned, pick only one CPU for this VCPU */
++        vcpu_cpumask = 1ull << pick_pcpu(&vm_cpumask);
++    }
++
++    cpu->cpumask = vcpu_cpumask;
+ 
+     if (!cpu->as) {
+         /* If the target cpu hasn't set up any address spaces itself,
+diff --git a/tools/qemu-xen/softmmu/vl.c b/tools/qemu-xen/softmmu/vl.c
+index c7c8abc..34c5a75 100644
+--- a/tools/qemu-xen/softmmu/vl.c
++++ b/tools/qemu-xen/softmmu/vl.c
+@@ -2829,6 +2829,73 @@ static void create_default_memdev(MachineState *ms, const char *path)
+                             &error_fatal);
+ }
+ 
++static inline unsigned get_max_cpu_in_mask(unsigned int cpumask)
++{
++    return (sizeof(cpumask) * BITS_PER_BYTE) - __builtin_clz(cpumask) - 1;
++}
++
++static inline void cpumask_set_bit(uint64_t *mask, uint8_t bit)
++{
++    *mask |= 1ull << bit ;
++}
++
++/* Parse d[[,-]d]* mask (0-2 or 0-2,5,6). CPUs start with 0.
++ * Return 0 in case of error, bitmask if ok
++ */
++static uint64_t cpumask_parse(const char* cpumask_str)
++{
++    uint64_t cpumask = 0;
++    const char *cur = cpumask_str;
++    bool range = false;
++
++    assert(cpumask_str != NULL);
++
++    if (strcmp(cpumask_str, "") == 0)
++        return 0;
++
++    if (cpumask_str[0] == '-') {
++        warn_report("The CPU mask cannot start with -\n");
++        return 0;
++    }
++
++    uint8_t last_set;
++    while (*cur) {
++        unsigned long num;
++        char *end;
++        if (*cur == '-') {
++            cur++;
++            range = true;
++            continue;
++        }
++        if (*cur == ',') {
++            cur++;
++            continue;
++        }
++        num = strtoul(cur, &end, 10);
++        if (num > UCHAR_MAX) {
++            warn_report ("Too big CPU number is provided! Numbers more than %d "
++                         "are not supported at the moment!\n", UCHAR_MAX);
++            return 0;
++        }
++        if (end != cur) {
++            if (num == 0 || num > sizeof(cpumask) * BITS_PER_BYTE)
++                return 0;
++            if (range) {
++                range = false;
++                for (int i = last_set + 1; i < num; i++)
++                    cpumask_set_bit(&cpumask, i);
++            }
++            cpumask_set_bit(&cpumask, num);
++            last_set = num;
++            cur = end;
++            continue;
++        }
++        warn_report("The CPU mask option is broken!\n");
++        return 0;
++    }
++    return cpumask;
++}
++
+ void qemu_init(int argc, char **argv, char **envp)
+ {
+     int i;
+@@ -4306,6 +4373,20 @@ void qemu_init(int argc, char **argv, char **envp)
+ 
+     current_machine->boot_order = boot_order;
+ 
++    current_machine->cpumask = 0;
++    if (current_machine->cpumask_str) {
++        current_machine->cpumask = cpumask_parse(current_machine->cpumask_str);
++        if (!current_machine->cpumask) {
++            warn_report ("The CPU mask option is broken, use all available CPUs\n");
++            current_machine->cpumask = ~0ull;
++        }
++    }
++    if (current_machine->cpu_pin) {
++        if (!current_machine->cpumask_str) {
++            current_machine->cpumask = ~0ull;
++        }
++    }
++
+     /* parse features once if machine provides default cpu_type */
+     current_machine->cpu_type = machine_class->default_cpu_type;
+     if (cpu_option) {
+-- 
+2.35.1
+

--- a/pkg/xen-tools/patches-4.15.0/15-qemu-Set-the-affinity-of-QEMU-threads-according-to-t.patch
+++ b/pkg/xen-tools/patches-4.15.0/15-qemu-Set-the-affinity-of-QEMU-threads-according-to-t.patch
@@ -1,0 +1,100 @@
+From b043f147ba3cdd24791955d1c4c9bf6ed0e223ff Mon Sep 17 00:00:00 2001
+From: Nikolay Martyanov <ohmspectator@gmail.com>
+Date: Wed, 28 Sep 2022 16:01:48 +0200
+Subject: [PATCH 15/15] qemu: Set the affinity of QEMU threads according to the
+ CPU mask options.
+
+Signed-off-by: Nikolay Martyanov <ohmspectator@gmail.com>
+---
+ tools/qemu-xen/include/qemu/thread.h    |  2 ++
+ tools/qemu-xen/softmmu/cpus.c           |  6 +++++
+ tools/qemu-xen/util/qemu-thread-posix.c | 36 +++++++++++++++++++++++++
+ 3 files changed, 44 insertions(+)
+
+diff --git a/tools/qemu-xen/include/qemu/thread.h b/tools/qemu-xen/include/qemu/thread.h
+index 4baf4d1..3d1a76e 100644
+--- a/tools/qemu-xen/include/qemu/thread.h
++++ b/tools/qemu-xen/include/qemu/thread.h
+@@ -174,6 +174,8 @@ void qemu_event_destroy(QemuEvent *ev);
+ void qemu_thread_create(QemuThread *thread, const char *name,
+                         void *(*start_routine)(void *),
+                         void *arg, int mode);
++/* TODO implemented for POSIX only by now */
++void qemu_thread_set_affinity(QemuThread *thread, unsigned int cpumask);
+ void *qemu_thread_join(QemuThread *thread);
+ void qemu_thread_get_self(QemuThread *thread);
+ bool qemu_thread_is_self(QemuThread *thread);
+diff --git a/tools/qemu-xen/softmmu/cpus.c b/tools/qemu-xen/softmmu/cpus.c
+index da56052..000df00 100644
+--- a/tools/qemu-xen/softmmu/cpus.c
++++ b/tools/qemu-xen/softmmu/cpus.c
+@@ -2073,6 +2073,12 @@ void qemu_init_vcpu(CPUState *cpu)
+         qemu_dummy_start_vcpu(cpu);
+     }
+ 
++    if(cpu_can_run(cpu))
++        warn_report("Change a CPU affinity after the CPU may have been running for a while\n");
++
++    if (cpu->cpumask)
++        qemu_thread_set_affinity(cpu->thread, cpu->cpumask);
++
+     while (!cpu->created) {
+         qemu_cond_wait(&qemu_cpu_cond, &qemu_global_mutex);
+     }
+diff --git a/tools/qemu-xen/util/qemu-thread-posix.c b/tools/qemu-xen/util/qemu-thread-posix.c
+index b4c2359..f19ca60 100644
+--- a/tools/qemu-xen/util/qemu-thread-posix.c
++++ b/tools/qemu-xen/util/qemu-thread-posix.c
+@@ -17,6 +17,8 @@
+ #include "qemu-thread-common.h"
+ #include "qemu/tsan.h"
+ 
++#include "hw/core/cpu.h"
++
+ static bool name_threads;
+ 
+ void qemu_thread_naming(bool enable)
+@@ -523,6 +525,40 @@ static void *qemu_thread_start(void *args)
+     return r;
+ }
+ 
++static inline unsigned get_max_cpu_in_mask(unsigned int cpumask)
++{
++    return (sizeof (cpumask) * BITS_PER_BYTE) - __builtin_clz (cpumask) - 1;
++}
++
++void qemu_thread_set_affinity(QemuThread *thread, unsigned int cpumask)
++{
++    int err;
++    size_t cpu_set_size;
++    cpu_set_t cpu_set;
++    unsigned int max_pcpu;
++    unsigned int cpumask_tmp = cpumask;
++
++    CPU_ZERO(&cpu_set);
++
++    /* set the CPU_SET according to mask */
++    int cur_pcpu = 0;
++    while(cpumask_tmp) {
++        if (cpumask_tmp & 1)
++            CPU_SET (cur_pcpu, &cpu_set);
++        cpumask_tmp >>= 1;
++        cur_pcpu += 1;
++    }
++
++    /* Count the size of the necessary CPU_SET k*/
++    max_pcpu = get_max_cpu_in_mask(cpumask);
++    cpu_set_size = max_pcpu / BITS_PER_BYTE + 1;
++
++    err = pthread_setaffinity_np(thread->thread, cpu_set_size, &cpu_set);
++
++    if (err)
++        error_exit (err, __func__);
++}
++
+ void qemu_thread_create(QemuThread *thread, const char *name,
+                        void *(*start_routine)(void*),
+                        void *arg, int mode)
+-- 
+2.35.1
+


### PR DESCRIPTION
We must add the corresponding features to the QEMU code to implement the CPU pinning feature.

Add the 'cpumask' option to set the CPU mask to the threads created with QEMU. The mask affects all the threads belonging to a VM: both VCPU threads and non-VCPU threads. If the option is not provided, it's considered to be '-1', which corresponds to all the available CPUs.

Add the 'cpu-pin' option to pin any VCPU thread to a specific CPU. If the option is set, any VCPU thread will be assigned to a CPU provided with the 'cpumask'. If it's not provided, the VPCU threads can migrate from a CPU to a CPU within the set of CPUs provided by the 'cpumask' option.