### PR TITLE
Delete stale container on cleanup

### DIFF
--- a/pkg/pillar/hypervisor/containerd.go
+++ b/pkg/pillar/hypervisor/containerd.go
@@ -167,9 +167,15 @@ func (ctx ctrdContext) Delete(domainName string) error {
 	return nil
 }
 
-//Cleanup is noop for containerd hypervisor
-func (ctx ctrdContext) Cleanup(_ string) error {
-	return nil
+// Cleanup deletes stale containers if exists
+func (ctx ctrdContext) Cleanup(domainName string) error {
+	ctrdCtx, done := ctx.ctrdClient.CtrNewUserServicesCtx()
+	defer done()
+	container, _ := ctx.ctrdClient.CtrLoadContainer(ctrdCtx, domainName)
+	if container == nil {
+		return nil
+	}
+	return ctx.Delete(domainName)
 }
 
 func (ctx ctrdContext) Annotations(domainName string) (map[string]string, error) {

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -813,7 +813,7 @@ func (ctx kvmContext) Info(domainName string) (int, types.SwState, error) {
 }
 
 func (ctx kvmContext) Cleanup(domainName string) error {
-	if err := ctx.ctrdContext.Delete(domainName); err != nil {
+	if err := ctx.ctrdContext.Cleanup(domainName); err != nil {
 		return fmt.Errorf("couldn't cleanup task %s: %v", domainName, err)
 	}
 	if err := waitForQmp(domainName, false); err != nil {

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -516,7 +516,7 @@ func (ctx xenContext) Delete(domainName string) (result error) {
 
 //Cleanup removes containerd-shim
 func (ctx xenContext) Cleanup(domainName string) error {
-	if err := ctx.ctrdContext.Delete(domainName); err != nil {
+	if err := ctx.ctrdContext.Cleanup(domainName); err != nil {
 		return fmt.Errorf("couldn't cleanup task %s: %v", domainName, err)
 	}
 	return nil


### PR DESCRIPTION
Seems because of internal delay between task stop command issue and real
 stop we may not delete container itself after successful stopped task
 in doInactivate.
 Let's expand Cleanup function for containerd hypervisor with container
 delete if still exists.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>