### PR TITLE
Fix login in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -111,6 +111,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Login to DockerHUB
+        run: |
+          echo "${{ secrets.RELEASE_DOCKERHUB_TOKEN }}" |\
+             docker login -u "${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}" --password-stdin
       - name: Build EVE for ${{ matrix.arch }}-${{ matrix.hv }}
         # build #1 without push (do not push either unless both can build)
         run: |


### PR DESCRIPTION
We should login to DockerHUB before push.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>