### PR TITLE
Wait for baseOSConfig to handle RetryUpdateCounter

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlebaseos.go
+++ b/pkg/pillar/cmd/zedagent/handlebaseos.go
@@ -132,3 +132,12 @@ func getZbootOtherPartition(ctx *zedagentContext) string {
 	log.Errorf("getZbootOtherPartition() not found")
 	return partName
 }
+
+func signalBaseOSConfigConfigRestarted(ctx *getconfigContext) {
+	log.Trace("signalBaseOSConfigConfigRestarted")
+	pub := ctx.pubBaseOsConfig
+	if err := pub.SignalRestarted(); err != nil {
+		log.Errorf("failed to SignalRestarted: %s", err)
+	}
+	log.Trace("signalBaseOSConfigConfigRestarted done")
+}

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -333,6 +333,8 @@ func parseBaseOsConfig(getconfigCtx *getconfigContext,
 			baseOs)
 		publishBaseOsConfig(getconfigCtx, baseOs)
 	}
+	// notify baseosmgr that we published all configs
+	signalBaseOSConfigConfigRestarted(getconfigCtx)
 }
 
 var networkConfigPrevConfigHash []byte


### PR DESCRIPTION
BaseOs and BaseOsConfig come from zedagent in parallel. We hit the problem with no update retry because of internal checks for BaseOsConfig existence during handling of ConfigRetryUpdateCounter. Let's use BaseOsConfig restart handler to notify baseosmgr that all scheduled BaseOsConfig published and we are ready to handle BaseOs.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>