### PR TITLE
Add knob to manually adjust vmm overhead

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -39,6 +39,7 @@
 | force.fallback.counter | integer | 0 | forces fallback to other image if counter is changed |
 | newlog.allow.fastupload | boolean | false | allow faster upload gzip logfiles to controller |
 | memory.apps.ignore.check | boolean | false | Ignore memory usage check for Apps|
+| memory.vmm.limit.MiB | integer | 0 | Manually override how much overhead is allocated for each running VMM |
 | newlog.gzipfiles.ondisk.maxmegabytes | integer in Mbytes | 2048 | the quota for keepig newlog gzip files on device |
 | process.cloud-init.multipart | boolean | false | help VMs which do not handle mime multi-part themselves |
 | edgeview.authen.jwt | edgeview session jwt token | empty string(edgeview disabled) | format as standard JWT for websocket session for temporary testing, this configitem will be removed once controllers are setup to send EdgeViewConfig in configuration |

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1258,7 +1258,8 @@ func doActivate(ctx *domainContext, config types.DomainConfig,
 	}
 	defer file.Close()
 
-	if err := hyper.Task(status).Setup(*status, config, ctx.assignableAdapters, nil, file); err != nil {
+	globalConfig := agentlog.GetGlobalConfig(log, ctx.subGlobalConfig)
+	if err := hyper.Task(status).Setup(*status, config, ctx.assignableAdapters, globalConfig, file); err != nil {
 		log.Errorf("Failed to create DomainStatus from %v: %s",
 			config, err)
 		status.SetErrorNow(err.Error())

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -948,7 +948,7 @@ func maybeRetryBoot(ctx *domainContext, status *types.DomainStatus) {
 	}
 	defer file.Close()
 
-	if err := hyper.Task(status).Setup(*status, *config, ctx.assignableAdapters, file); err != nil {
+	if err := hyper.Task(status).Setup(*status, *config, ctx.assignableAdapters, nil, file); err != nil {
 		//it is retry, so omit error
 		log.Errorf("Failed to create DomainStatus from %v: %s",
 			config, err)
@@ -1258,7 +1258,7 @@ func doActivate(ctx *domainContext, config types.DomainConfig,
 	}
 	defer file.Close()
 
-	if err := hyper.Task(status).Setup(*status, config, ctx.assignableAdapters, file); err != nil {
+	if err := hyper.Task(status).Setup(*status, config, ctx.assignableAdapters, nil, file); err != nil {
 		log.Errorf("Failed to create DomainStatus from %v: %s",
 			config, err)
 		status.SetErrorNow(err.Error())

--- a/pkg/pillar/hypervisor/containerd.go
+++ b/pkg/pillar/hypervisor/containerd.go
@@ -81,7 +81,8 @@ func (ctx ctrdContext) setupSpec(status *types.DomainStatus, config *types.Domai
 	return spec, nil
 }
 
-func (ctx ctrdContext) Setup(status types.DomainStatus, config types.DomainConfig, aa *types.AssignableAdapters, file *os.File) error {
+func (ctx ctrdContext) Setup(status types.DomainStatus, config types.DomainConfig,
+	aa *types.AssignableAdapters, globalConfig *types.ConfigItemValueMap, file *os.File) error {
 	if status.OCIConfigDir == "" {
 		return logError("failed to run domain %s: not based on an OCI image", status.DomainName)
 	}

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -450,7 +450,8 @@ func (ctx kvmContext) Task(status *types.DomainStatus) types.Task {
 	}
 }
 
-func (ctx kvmContext) Setup(status types.DomainStatus, config types.DomainConfig, aa *types.AssignableAdapters, file *os.File) error {
+func (ctx kvmContext) Setup(status types.DomainStatus, config types.DomainConfig,
+	aa *types.AssignableAdapters, globalConfig *types.ConfigItemValueMap, file *os.File) error {
 
 	diskStatusList := status.DiskStatusList
 	domainName := status.DomainName

--- a/pkg/pillar/hypervisor/null.go
+++ b/pkg/pillar/hypervisor/null.go
@@ -55,7 +55,8 @@ func (ctx nullContext) Task(status *types.DomainStatus) types.Task {
 	return ctx
 }
 
-func (ctx nullContext) Setup(types.DomainStatus, types.DomainConfig, *types.AssignableAdapters, *os.File) error {
+func (ctx nullContext) Setup(types.DomainStatus, types.DomainConfig,
+	*types.AssignableAdapters, *types.ConfigItemValueMap, *os.File) error {
 	return nil
 }
 

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -131,7 +131,8 @@ func (ctx xenContext) Task(status *types.DomainStatus) types.Task {
 	}
 }
 
-func (ctx xenContext) Setup(status types.DomainStatus, config types.DomainConfig, aa *types.AssignableAdapters, file *os.File) error {
+func (ctx xenContext) Setup(status types.DomainStatus, config types.DomainConfig,
+	aa *types.AssignableAdapters, globalConfig *types.ConfigItemValueMap, file *os.File) error {
 	// first lets build the domain config
 	if err := ctx.CreateDomConfig(status.DomainName, config, status.DiskStatusList, aa, file); err != nil {
 		return logError("failed to build domain config: %v", err)

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -230,7 +230,8 @@ const (
 
 // Task represents any runnable entity on EVE
 type Task interface {
-	Setup(DomainStatus, DomainConfig, *AssignableAdapters, *os.File) error
+	Setup(DomainStatus, DomainConfig, *AssignableAdapters,
+		*ConfigItemValueMap, *os.File) error
 	Create(string, string, *DomainConfig) (int, error)
 	Start(string) error
 	Stop(string, bool) error

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -186,6 +186,8 @@ const (
 	AllowAppVnc GlobalSettingKey = "app.allow.vnc"
 	// EveMemoryLimitInBytes global setting key
 	EveMemoryLimitInBytes GlobalSettingKey = "memory.eve.limit.bytes"
+	// How much memory overhead is allowed for VMM needs
+	VmmMemoryLimitInMiB GlobalSettingKey = "memory.vmm.limit.MiB"
 	// IgnoreMemoryCheckForApps global setting key
 	IgnoreMemoryCheckForApps GlobalSettingKey = "memory.apps.ignore.check"
 	// IgnoreDiskCheckForApps global setting key
@@ -763,6 +765,8 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddIntItem(ForceFallbackCounter, 0, 0, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(EveMemoryLimitInBytes, uint32(eveMemoryLimitInBytes),
 		uint32(eveMemoryLimitInBytes), 0xFFFFFFFF)
+	// Limit manual vmm overhead override to 1 PiB
+	configItemSpecMap.AddIntItem(VmmMemoryLimitInMiB, 0, 0, uint32(1024*1024*1024))
 	// LogRemainToSendMBytes - Default is 2 Gbytes, minimum is 10 Mbytes
 	configItemSpecMap.AddIntItem(LogRemainToSendMBytes, 2048, 10, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(DownloadMaxPortCost, 0, 0, 255)

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -179,6 +179,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		VgaAccess,
 		AllowAppVnc,
 		EveMemoryLimitInBytes,
+		VmmMemoryLimitInMiB,
 		IgnoreMemoryCheckForApps,
 		IgnoreDiskCheckForApps,
 		AllowLogFastupload,


### PR DESCRIPTION
# Summary
 We have experienced rare corner cases, when QEMU consumes significantly more than we estimated. This PR allows to manually adjust the limits for these corner cases.

# Testing done
Apply patch to trace in the logs how much overhead has been allocated, and build Eve
```bash
git fetch https://github.com/yvolchkov/eve.git overrideVmmOverhead-debug
git cherry-pick aa49beaeed01f2700f9bb0da494be26806fe5cd2
make pkg/pillar eve
```

Prepare a script to spin up `eden` and onboard newly build `eve`

``` bash
cd ~/src/eden
tee restart.sh << `EOF`
#!/bin/bash

set -e

function main() {
    local eve_src_path="$(readlink -f ~/src/eve)"
    local eve_version="$(make DEV=n --no-print-directory --directory "${eve_src_path}" version)"

    echo "using eve version ${eve_version}"

    make clean
    make eden
    ./eden config add
    ./eden setup --eve-tag "${eve_version}"
    ./eden start
    ./eden eve onboard
}

main "${@}"
EOF
```

Create an ssh alias for the node managed by eden. Add the following to `~/.ssh/config`
```
host eden-eve
     hostname localhost
     StrictHostKeyChecking no
     IdentityFile ~/src/eden/dist/default-certs/id_rsa
     ConnectTimeout 1
     port 2222
     user root
```

Onboard, deploy instance without overrides, check how much memory has been allocated
``` bash
./restart.sh
./eden pod deploy file://"${PWD}"/alpine.qcow2  --name=overhead-test
# Allow some time for the app to start
ssh eden-eve "logread " | tee  logs_local.json |  cut -d ';' -f 2-  | jq -R '. as $line | (fromjson? | .time + ": " + .msg + " " + .diff) // $line' | grep "Qemu overhead for domain"

"2022-10-05T11:33:47.797785213Z: Qemu overhead for domain c3554dbe-a547-4d7b-ba2d-894885684c37.1.1 is 629145600 bytes "
```

Override overhead and redeploy the app
``` bash
./eden controller edge-node update --config memory.vmm.limit.MiB="778"
./eden pod delete overhead-test
./eden pod deploy file://"${PWD}"/alpine.qcow2  --name=overhead-test
ssh eden-eve "logread " | tee  logs_local.json |  cut -d ';' -f 2-  | jq -R '. as $line | (fromjson? | .time + ": " + .msg + " " + .diff) // $line' | grep "Qemu overhead for domain"

"2022-10-05T11:33:47.797785213Z: Qemu overhead for domain c3554dbe-a547-4d7b-ba2d-894885684c37.1.1 is 629145600 bytes "
"2022-10-05T11:37:59.585219193Z: Qemu overhead for domain e861192a-cf27-421f-926e-de0d3859b02e.1.1 is 815792128 bytes
```

Convert bytes to MiB and verify
``` bash
echo "815792128 / 1024 / 1024" | bc
778
```

Repeat the experiment but instead of redeploying, simply reboot the app

``` bash
./restart.sh
./eden pod deploy file://"${PWD}"/alpine.qcow2  --name=overhead-test
# Allow some time for the app to start
ssh eden-eve "logread " | tee  logs_local.json |  cut -d ';' -f 2-  | jq -R '. as $line | (fromjson? | .time + ": " + .msg + " " + .diff) // $line' | grep "Qemu overhead for domain"

"2022-10-05T11:45:17.826541082Z: Qemu overhead for domain d9039e2a-1f7a-407d-b4d0-486490289c4f.1.1 is 629145600 bytes "
```

```bash
./eden pod restart overhead-test
ssh eden-eve "logread " | tee  logs_local.json |  cut -d ';' -f 2-  | jq -R '. as $line | (fromjson? | .time + ": " + .msg + " " + .diff) // $line' | grep "Qemu overhead for domain"

"2022-10-05T11:45:17.826541082Z: Qemu overhead for domain d9039e2a-1f7a-407d-b4d0-486490289c4f.1.1 is 629145600 bytes "
"2022-10-05T11:47:36.408674527Z: Qemu overhead for domain d9039e2a-1f7a-407d-b4d0-486490289c4f.1.1 is 815792128 byte
```