### PR TITLE
Function refactoring where ZFS is used

### DIFF
--- a/pkg/pillar/cmd/vaultmgr/vaultmgrzfs.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgrzfs.go
@@ -4,11 +4,10 @@
 package vaultmgr
 
 import (
-	"regexp"
-
 	etpm "github.com/lf-edge/eve/pkg/pillar/evetpm"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/vault"
+	"github.com/lf-edge/eve/pkg/pillar/zfs"
 )
 
 const (
@@ -18,119 +17,83 @@ const (
 	zfsKeyDir               = "/run/TmpVaultDir2"
 )
 
-func getCreateParams(vaultPath string, encrypted bool) []string {
-	if encrypted {
-		return []string{"create", "-o", "encryption=aes-256-gcm", "-o", "keylocation=file://" + zfsKeyFile, "-o", "keyformat=raw", vaultPath}
-	}
-	return []string{"create", vaultPath}
-}
-
-func getLoadKeyParams(vaultPath string) []string {
-	args := []string{"load-key", vaultPath}
-	return args
-}
-
-func getMountParams(vaultPath string) []string {
-	args := []string{"mount", vaultPath}
-	return args
-}
-
-func getKeyStatusParams(vaultPath string) []string {
-	args := []string{"get", "keystatus", vaultPath}
-	return args
-}
-
-//e.g. zfs load-key persist/vault followed by
-//zfs mount persist/vault
+// e.g. zfs load-key persist/vault followed by
+// zfs mount persist/vault
 func unlockZfsVault(vaultPath string) error {
-	//prepare key in the staging file
-	//we never unlock a deprecated vault in ZFS (we never created those)
-	//cloudKeyOnlyMode=false, useSealedKey=true
+	// prepare key in the staging file
+	// we never unlock a deprecated vault in ZFS (we never created those)
+	// cloudKeyOnlyMode=false, useSealedKey=true
 	if err := stageKey(false, true, zfsKeyDir, zfsKeyFile); err != nil {
 		return err
 	}
 	defer unstageKey(zfsKeyDir, zfsKeyFile)
 
-	//zfs load-key
-	args := getLoadKeyParams(vaultPath)
+	// zfs load-key
+	args := []string{"load-key", vaultPath}
 	if stdOut, stdErr, err := execCmd(types.ZFSBinary, args...); err != nil {
 		log.Errorf("Error loading key for vault: %v, %s, %s",
 			err, stdOut, stdErr)
 		return err
 	}
-	//zfs mount
-	args = getMountParams(vaultPath)
-	if stdOut, stdErr, err := execCmd(types.ZFSBinary, args...); err != nil {
-		log.Errorf("Error unlocking vault: %v, %s, %s", err, stdOut, stdErr)
+
+	// zfs mount
+	if err := zfs.MountDataset(vaultPath); err != nil {
+		log.Errorf("Error unlocking vault: %v", err)
 		return err
 	}
+
 	return nil
 }
 
-//e.g. zfs create -o encryption=aes-256-gcm -o keylocation=file://tmp/raw.key -o keyformat=raw persist/vault
+// e.g. zfs create -o encryption=aes-256-gcm -o keylocation=file://tmp/raw.key -o keyformat=raw persist/vault
 func createZfsVault(vaultPath string) error {
-	//prepare key in the staging file
-	//we never create deprecated vault on ZFS
-	//cloudKeyOnlyMode=false, useSealedKey=true
+	// prepare key in the staging file
+	// we never create deprecated vault on ZFS
+	// cloudKeyOnlyMode=false, useSealedKey=true
 	if err := stageKey(false, true, zfsKeyDir, zfsKeyFile); err != nil {
 		return err
 	}
 	defer unstageKey(zfsKeyDir, zfsKeyFile)
-	args := getCreateParams(vaultPath, true)
-	if stdOut, stdErr, err := execCmd(types.ZFSBinary, args...); err != nil {
-		log.Errorf("Error creating zfs vault %s, error=%v, %s, %s",
-			vaultPath, err, stdOut, stdErr)
+
+	if err := zfs.CreateVaultDataset(vaultPath, zfsKeyFile); err != nil {
+		log.Errorf("Error creating zfs vault %s, error=%v", vaultPath, err)
 		return err
 	}
+
 	log.Functionf("Created new vault %s", vaultPath)
 	return nil
 }
 
 // remove vault from zfs
+// e.g. zfs destroy -fr persist/vault
 func removeDefaultVaultOnZfs() error {
-	args := []string{"destroy", "-fr", defaultSecretDataset}
-	if stdOut, stdErr, err := execCmd(types.ZFSBinary, args...); err != nil {
-		log.Errorf("error remove zfs vault %s, error=%v, %s, %s",
-			defaultSecretDataset, err, stdOut, stdErr)
+	if err := zfs.UnmountDataset(defaultSecretDataset); err != nil {
+		log.Errorf("Error unmounting vault %s, error=%v", defaultSecretDataset, err)
 		return err
 	}
+
+	if err := zfs.DestroyDataset(defaultSecretDataset); err != nil {
+		log.Errorf("Error destroying vault %s, error=%v", defaultSecretDataset, err)
+		return err
+	}
+
 	return nil
 }
 
-//e.g. zfs get keystatus persist/vault
+// e.g. zfs get keystatus persist/vault
 func checkKeyStatus(vaultPath string) error {
-	args := getKeyStatusParams(vaultPath)
-	if stdOut, stdErr, err := execCmd(types.ZFSBinary, args...); err != nil {
-		log.Tracef("keystatus query for %s results in error=%v, %s, %s",
-			vaultPath, err, stdOut, stdErr)
+	if _, err := zfs.GetDatasetKeyStatus(vaultPath); err != nil {
+		log.Tracef("keystatus query for %s results in error=%v",
+			vaultPath, err)
 		return err
 	}
+
 	return nil
-}
-
-func processOperStatus(status string) string {
-	//Expect mounted:yes keystatus:available encryption:aes-256-gcm
-	matchConditions := []struct {
-		regexStr string //match this
-		errStr   string //if no match, this is the error to show
-	}{
-		{"keystatus\\s+available\\s", "Key is not loaded"},
-		{"mounted\\s+yes\\s", "Dataset is not mounted"},
-		{"encryption\\s+aes-256-gcm\\s", "Encryption is not enabled"},
-	}
-
-	for _, match := range matchConditions {
-		pattern := regexp.MustCompile(match.regexStr)
-		if !pattern.MatchString(status) {
-			return match.errStr
-		}
-	}
-	return ""
 }
 
 func setupZfsVault(vaultPath string) error {
-	//zfs get keystatus returns success as long as vaultPath is a dataset,
-	//(even if not mounted yet), so use it to check dataset presence
+	// zfs get keystatus returns success as long as vaultPath is a dataset,
+	// (even if not mounted yet), so use it to check dataset presence
 	if err := checkKeyStatus(vaultPath); err == nil {
 		//present, call unlock
 		return unlockZfsVault(vaultPath)
@@ -147,6 +110,6 @@ func setupZfsVault(vaultPath string) error {
 			log.Errorf("WipteOutStaleSealKeyIfAny failed: %s", err)
 		}
 	}
-	//try creating the dataset
+	// try creating the dataset
 	return createZfsVault(vaultPath)
 }

--- a/pkg/pillar/cmd/volumemgr/create.go
+++ b/pkg/pillar/cmd/volumemgr/create.go
@@ -282,9 +282,9 @@ func destroyVdiskVolume(ctx *volumemgrContext, status types.VolumeStatus) (bool,
 		}
 		//Assume this is zfs device
 		zVolName := status.ZVolName()
-		if stdoutStderr, err := zfs.DestroyDataset(log, zVolName); err != nil {
-			errStr := fmt.Sprintf("Error destroying zfs zvol at %s, error=%v, output=%s",
-				zVolName, err, stdoutStderr)
+		if err := zfs.DestroyDataset(zVolName); err != nil {
+			errStr := fmt.Sprintf("Error destroying zfs zvol at %s, error=%v",
+				zVolName, err)
 			log.Error(errStr)
 			return created, "", errors.New(errStr)
 		}

--- a/pkg/pillar/cmd/volumemgr/dirs.go
+++ b/pkg/pillar/cmd/volumemgr/dirs.go
@@ -42,13 +42,13 @@ func initializeDatasets() {
 	}
 	for _, datasetName := range volumeDatasets {
 		if !zfs.DatasetExist(log, datasetName) {
-			if output, err := zfs.CreateDataset(log, datasetName); err != nil {
-				log.Fatalf("CreateDataset failed: %s %s ", output, err)
+			if err := zfs.CreateDatasets(log, datasetName); err != nil {
+				log.Fatalf("CreateDataset failed: %s", err)
 			}
 		} else {
-			if output, err := zfs.MountDataset(log, datasetName); err != nil {
+			if err := zfs.MountDataset(datasetName); err != nil {
 				// it may be mounted
-				log.Functionf("MountDataset failed: %s %s ", output, err)
+				log.Functionf("MountDataset failed: %s", err)
 			}
 		}
 	}

--- a/pkg/pillar/cmd/volumemgr/initialvolumestatus.go
+++ b/pkg/pillar/cmd/volumemgr/initialvolumestatus.go
@@ -108,10 +108,9 @@ func gcDatasets(ctx *volumemgrContext, dataset string) {
 				log.Warnf("gcDatasets: Error deleting target for %s, error=%v",
 					key, err)
 			}
-			output, err := zfs.DestroyDataset(log, location)
-			if err != nil {
-				log.Errorf("gcDatasets: DestroyDataset '%s' failed: %v output:%s",
-					location, err, output)
+			if err := zfs.DestroyDataset(location); err != nil {
+				log.Errorf("gcDatasets: DestroyDataset '%s' failed: %v",
+					location, err)
 			}
 		}
 	}
@@ -163,9 +162,9 @@ func gcPendingCreateVolume(ctx *volumemgrContext) {
 				// check if dataset exists
 				// assume that we should remove it as not created completely
 				if zfs.DatasetExist(log, zVolName) {
-					if stdoutStderr, err := zfs.DestroyDataset(log, zVolName); err != nil {
-						log.Errorf("gcPendingCreateVolume: error destroying zfs zvol at %s, error=%s, output=%s",
-							zVolName, err, stdoutStderr)
+					if err := zfs.DestroyDataset(zVolName); err != nil {
+						log.Errorf("gcPendingCreateVolume: error destroying zfs zvol at %s, error=%s",
+							zVolName, err)
 						continue
 					}
 				}

--- a/pkg/pillar/cmd/volumemgr/prepare.go
+++ b/pkg/pillar/cmd/volumemgr/prepare.go
@@ -75,9 +75,9 @@ func prepareZVol(ctx *volumemgrContext, status types.VolumeStatus) error {
 		}
 	}
 	zVolName := status.ZVolName()
-	if stdoutStderr, err := zfs.CreateVolumeDataset(log, zVolName, size, "zstd"); err != nil {
-		errStr := fmt.Sprintf("Error creating zfs zvol at %s, error=%v, output=%s",
-			zVolName, err, stdoutStderr)
+	if err := zfs.CreateVolumeDataset(log, zVolName, size, "zstd"); err != nil {
+		errStr := fmt.Sprintf("Error creating zfs zvol at %s, error=%v",
+			zVolName, err)
 		log.Error(errStr)
 		return errors.New(errStr)
 	}

--- a/pkg/pillar/cmd/zfsmanager/zfsstoragestatus.go
+++ b/pkg/pillar/cmd/zfsmanager/zfsstoragestatus.go
@@ -184,9 +184,6 @@ func collectAndPublishStorageStatus(ctxPtr *zfsContext) {
 			status.CompressionRatio = compressratio
 			status.CountZvols = countZvolume
 			status.StorageState = storageState
-			if storageState != types.StorageStatusOnline {
-				status.CollectorErrors = zfs.GetZfsStatusStr(log, zpoolName)
-			}
 			if err := ctxPtr.storageStatusPub.Publish(status.Key(), *status); err != nil {
 				log.Errorf("error in publishing of storageStatus: %s", err)
 			}

--- a/pkg/pillar/types/zfs.go
+++ b/pkg/pillar/types/zfs.go
@@ -15,7 +15,7 @@ const (
 	// ZVolDevicePrefix controlled by mdev
 	ZVolDevicePrefix = "/dev/zvol"
 
-	//ZFSSnapshotter is containerd snapshotter for zfs
+	// ZFSSnapshotter is containerd snapshotter for zfs
 	ZFSSnapshotter = "zfs"
 
 	// ZFSBinary is the zfs binary
@@ -291,7 +291,7 @@ type ZFSPoolMetrics struct {
 	ZVols           []*StorageZVolMetrics     // Metrics for zvols from /proc/diskstats
 }
 
-//Key for pubsub ZFSPoolMetrics
+// Key for pubsub ZFSPoolMetrics
 func (s ZFSPoolMetrics) Key() string {
 	return s.PoolName
 }

--- a/pkg/pillar/vault/vault.go
+++ b/pkg/pillar/vault/vault.go
@@ -17,6 +17,7 @@ import (
 	etpm "github.com/lf-edge/eve/pkg/pillar/evetpm"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	utils "github.com/lf-edge/eve/pkg/pillar/utils/file"
+	"github.com/lf-edge/eve/pkg/pillar/zfs"
 )
 
 const (
@@ -45,17 +46,17 @@ var (
 	StatusParams = []string{"status", MountPoint}
 )
 
-//getFscryptOperInfo returns operational status of fscrypt encryption
+// getFscryptOperInfo returns operational status of fscrypt encryption
 func getFscryptOperInfo(log *base.LogObject) (info.DataSecAtRestStatus, string) {
 	_, err := os.Stat(FscryptConfFile)
 	if err == nil {
 		if _, _, err := execCmd(FscryptPath, StatusParams...); err != nil {
-			//fscrypt is setup, but not being used
+			// fscrypt is setup, but not being used
 			log.Trace("Setting status to Error")
 			return info.DataSecAtRestStatus_DATASEC_AT_REST_ERROR,
 				"Fscrypt Encryption is not setup"
 		} else {
-			//fscrypt is setup, and being used on /persist
+			// fscrypt is setup, and being used on /persist
 			log.Trace("Setting status to Enabled")
 			return info.DataSecAtRestStatus_DATASEC_AT_REST_ENABLED,
 				"Fscrypt is enabled and active"
@@ -67,24 +68,22 @@ func getFscryptOperInfo(log *base.LogObject) (info.DataSecAtRestStatus, string) 
 	}
 }
 
-//getZfsOperInfo returns operational status of ZFS encryption
+// getZfsOperInfo returns operational status of ZFS encryption
 func getZfsOperInfo(log *base.LogObject) (info.DataSecAtRestStatus, string) {
-	//Check if default zpool (i.e. "persist" dataset) is setup
-	_, err := CheckOperStatus(log, DefaultZpool)
-	if err != nil {
-		log.Errorf("default zpool status returns error %v", err)
+	// Check if default zpool (i.e. "persist" dataset) is setup
+	if !zfs.DatasetExist(log, DefaultZpool) {
+		log.Errorf("default ZFS zpool is not setup")
 		return info.DataSecAtRestStatus_DATASEC_AT_REST_ERROR,
 			"Default ZFS zpool is not setup"
 	}
 	return info.DataSecAtRestStatus_DATASEC_AT_REST_ENABLED,
 		"ZFS Encryption is enabled for vaults"
-
 }
 
-//GetOperInfo gets the current operational state of encryption tool
+// GetOperInfo gets the current operational state of encryption tool
 func GetOperInfo(log *base.LogObject) (info.DataSecAtRestStatus, string) {
 	if !etpm.IsTpmEnabled() {
-		//No encryption on platforms without a (working) TPM
+		// No encryption on platforms without a (working) TPM
 		log.Trace("Setting status to disabled, TPM is not in use")
 		return info.DataSecAtRestStatus_DATASEC_AT_REST_DISABLED,
 			"TPM is either absent or not in use"
@@ -115,7 +114,7 @@ func execCmd(command string, args ...string) (string, string, error) {
 	return stdoutStr, stderrStr, err
 }
 
-//ReadPersistType returns the persist filesystem
+// ReadPersistType returns the persist filesystem
 func ReadPersistType() types.PersistType {
 	persistFsType := ""
 	pBytes, err := ioutil.ReadFile(evePersistTypeFile)

--- a/pkg/pillar/vault/vaultzfs.go
+++ b/pkg/pillar/vault/vaultzfs.go
@@ -1,26 +1,63 @@
-// Copyright (c) 2020 Zededa, Inc.
+// Copyright (c) 2020-2022 Zededa, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 package vault
 
 import (
+	"fmt"
+
+	libzfs "github.com/bicomsystems/go-libzfs"
 	"github.com/lf-edge/eve/pkg/pillar/base"
-	"github.com/lf-edge/eve/pkg/pillar/types"
 )
 
-func getOperStatusParams(vaultPath string) []string {
-	args := []string{"get", "mounted,encryption,keystatus", vaultPath}
-	return args
-}
-
-// CheckOperStatus returns ZFS status
-func CheckOperStatus(log *base.LogObject, vaultPath string) (string, error) {
-	args := getOperStatusParams(vaultPath)
-	if stdOut, stdErr, err := execCmd(types.ZFSBinary, args...); err != nil {
-		log.Errorf("oper status query for %s results in error=%v, %s, %s",
-			vaultPath, err, stdOut, stdErr)
-		return stdErr, err
-	} else {
-		return stdOut, nil
+// CheckOperStatus returns nil if for vaultPath properties
+// for in ZFS have the following values:
+// mounted:yes keystatus:available encryption:aes-256-gcm;
+// else return err
+func CheckOperStatus(log *base.LogObject, vaultPath string) error {
+	dataset, err := libzfs.DatasetOpen(vaultPath)
+	if err != nil {
+		return err
 	}
+	defer dataset.Close()
+
+	mounted, err := dataset.GetProperty(libzfs.DatasetPropMounted)
+	if err != nil {
+		return fmt.Errorf("DatasetExist(%s): Get property PropMounted failed. %s",
+			vaultPath, err.Error())
+	}
+
+	encryption, err := dataset.GetProperty(libzfs.DatasetPropEncryption)
+	if err != nil {
+		return fmt.Errorf("DatasetExist(%s): Get property Encryption failed. %s",
+			vaultPath, err.Error())
+
+	}
+
+	// This property is not available for a dataset if no options associated
+	// with the key were specified during it's creation.
+	keyStatus, err := dataset.GetProperty(libzfs.DatasetPropKeyStatus)
+	if err != nil {
+		return fmt.Errorf("DatasetExist(%s): Get property KeyStatus failed. %s",
+			vaultPath, err.Error())
+
+	}
+
+	//Expect mounted:yes keystatus:available encryption:aes-256-gcm
+	if mounted.Value != "yes" {
+		return fmt.Errorf("DatasetExist(%s): Dataset is not mounted. value: %s",
+			vaultPath, mounted.Value)
+	}
+
+	if keyStatus.Value != "available" {
+		return fmt.Errorf("DatasetExist(%s): Key is not loaded. value: %s",
+			vaultPath, keyStatus.Value)
+	}
+
+	if encryption.Value != "aes-256-gcm" {
+		return fmt.Errorf("DatasetExist(%s): Encryption is not enabled. value: %s",
+			vaultPath, encryption.Value)
+	}
+
+	return nil
 }


### PR DESCRIPTION
This PR brings together changes that change the way you interact with ZFS, removing call zfs commands via the console in favor of working with the go-libzfs package, where it can be possible.

Also, the extra functionality for collecting the state of the zpool in the zfs package and other minor changes were removed here.