### PR TITLE
include rootfs.yml in lfedge/eve image, and add command to print it out

### DIFF
--- a/docs/EVE-IMAGE-SOURCES.md
+++ b/docs/EVE-IMAGE-SOURCES.md
@@ -63,15 +63,16 @@ At this point, you have the specific version of source code used to build the EV
 ## Binary to Builder Configuration
 
 The specific configuration used to build this distribution of EVE is distributed inside the EVE OS image.
-The actual configuration is available in binary `rootfs.img`, specifically in `/etc/linuxkit-eve-config.yaml`. 
+The actual configuration is available in binary `rootfs.img`, specifically in `/etc/linuxkit-eve-config.yaml`,
+and thus is available on every running eve-os device.
 
-For example, you can run:
+It also is in the `lfedge/eve` container image, so you can run:
 
 ```
-$ docker run --rm --entrypoint=cat lfedge/eve:0.0.0-master-0c6de671-kvm /etc/linuxkit-config-version.yaml
+$ docker run --rm lfedge/eve:<version> build_config
+# e.g.
+$ docker run --rm lfedge/eve:8.11.0 build_config
 ```
-
-Or use `docker create`, followed by `docker cp` and `docker rm`.
 
 A sample configuration is:
 

--- a/pkg/eve/runme.sh
+++ b/pkg/eve/runme.sh
@@ -111,6 +111,10 @@ do_version() {
   echo /bits/*.squash | sed -e 's#/bits/rootfs-##' -e 's#.squash##' >&3
 }
 
+do_build_config() {
+  unsquashfs -cat /bits/rootfs.img /etc/linuxkit-eve-config.yml >&3
+}
+
 do_live() {
   PART_SPEC="efi conf imga"
   # each live image is expected to have a soft serial number that


### PR DESCRIPTION
@eriknordmark pointed out that we include the build config yaml in the `rootfs.img` but not in the `lfedge/eve` OCI container image. That makes it harder to get at, but also makes our docs in `EVE-IMAGE-SOURCES.md` incorrect.

This fixes that:

* include it in the `lfedge/eve` image
* add a command `docker run lfedge/eve build_config` to spit it out
* update the documentation to describe it correctly