### PR TITLE
qemu: In the set_affinity function, use a round up macro.

### DIFF
--- a/pkg/xen-tools/patches-4.15.0/14-qemu-Init-CPU-mask-per-VCPU.patch
+++ b/pkg/xen-tools/patches-4.15.0/14-qemu-Init-CPU-mask-per-VCPU.patch
@@ -1,4 +1,4 @@
-From ee13ecbab30e8a0d42e9c870e9a234ebcd0f45c9 Mon Sep 17 00:00:00 2001
+From 15ca400172894c128cb4ff2916fe8c882205b587 Mon Sep 17 00:00:00 2001
 From: Nikolay Martyanov <ohmspectator@gmail.com>
 Date: Wed, 28 Sep 2022 15:52:24 +0200
 Subject: [PATCH 14/15] qemu: Init CPU mask per VCPU.
@@ -8,8 +8,8 @@ Signed-off-by: Nikolay Martyanov <ohmspectator@gmail.com>
  tools/qemu-xen/include/hw/boards.h   |  1 +
  tools/qemu-xen/include/hw/core/cpu.h |  2 +
  tools/qemu-xen/softmmu/cpus.c        | 31 +++++++++++
- tools/qemu-xen/softmmu/vl.c          | 81 ++++++++++++++++++++++++++++
- 4 files changed, 115 insertions(+)
+ tools/qemu-xen/softmmu/vl.c          | 80 ++++++++++++++++++++++++++++
+ 4 files changed, 114 insertions(+)
 
 diff --git a/tools/qemu-xen/include/hw/boards.h b/tools/qemu-xen/include/hw/boards.h
 index b06f13e..a4b4f11 100644
@@ -86,7 +86,7 @@ index a802e89..da56052 100644
      if (!cpu->as) {
          /* If the target cpu hasn't set up any address spaces itself,
 diff --git a/tools/qemu-xen/softmmu/vl.c b/tools/qemu-xen/softmmu/vl.c
-index c7c8abc..34c5a75 100644
+index c7c8abc..0222c6c 100644
 --- a/tools/qemu-xen/softmmu/vl.c
 +++ b/tools/qemu-xen/softmmu/vl.c
 @@ -2829,6 +2829,73 @@ static void create_default_memdev(MachineState *ms, const char *path)
@@ -163,7 +163,7 @@ index c7c8abc..34c5a75 100644
  void qemu_init(int argc, char **argv, char **envp)
  {
      int i;
-@@ -4306,6 +4373,20 @@ void qemu_init(int argc, char **argv, char **envp)
+@@ -4306,6 +4373,19 @@ void qemu_init(int argc, char **argv, char **envp)
  
      current_machine->boot_order = boot_order;
  
@@ -171,7 +171,6 @@ index c7c8abc..34c5a75 100644
 +    if (current_machine->cpumask_str) {
 +        current_machine->cpumask = cpumask_parse(current_machine->cpumask_str);
 +        if (!current_machine->cpumask) {
-+            warn_report ("The CPU mask option is broken, use all available CPUs\n");
 +            current_machine->cpumask = ~0ull;
 +        }
 +    }

--- a/pkg/xen-tools/patches-4.15.0/15-qemu-Set-the-affinity-of-QEMU-threads-according-to-t.patch
+++ b/pkg/xen-tools/patches-4.15.0/15-qemu-Set-the-affinity-of-QEMU-threads-according-to-t.patch
@@ -1,4 +1,4 @@
-From b043f147ba3cdd24791955d1c4c9bf6ed0e223ff Mon Sep 17 00:00:00 2001
+From 086bd5f84c5a41ba76586eec1570997c0775b78c Mon Sep 17 00:00:00 2001
 From: Nikolay Martyanov <ohmspectator@gmail.com>
 Date: Wed, 28 Sep 2022 16:01:48 +0200
 Subject: [PATCH 15/15] qemu: Set the affinity of QEMU threads according to the
@@ -42,7 +42,7 @@ index da56052..000df00 100644
          qemu_cond_wait(&qemu_cpu_cond, &qemu_global_mutex);
      }
 diff --git a/tools/qemu-xen/util/qemu-thread-posix.c b/tools/qemu-xen/util/qemu-thread-posix.c
-index b4c2359..f19ca60 100644
+index b4c2359..44975eb 100644
 --- a/tools/qemu-xen/util/qemu-thread-posix.c
 +++ b/tools/qemu-xen/util/qemu-thread-posix.c
 @@ -17,6 +17,8 @@
@@ -82,9 +82,9 @@ index b4c2359..f19ca60 100644
 +        cur_pcpu += 1;
 +    }
 +
-+    /* Count the size of the necessary CPU_SET k*/
++    /* Count the size of the necessary CPU_SET */
 +    max_pcpu = get_max_cpu_in_mask(cpumask);
-+    cpu_set_size = max_pcpu / BITS_PER_BYTE + 1;
++    cpu_set_size = DIV_ROUND_UP(max_pcpu, BITS_PER_BYTE);
 +
 +    err = pthread_setaffinity_np(thread->thread, cpu_set_size, &cpu_set);
 +

--- a/pkg/xen-tools/patches-4.15.0/15-qemu-Set-the-affinity-of-QEMU-threads-according-to-t.patch
+++ b/pkg/xen-tools/patches-4.15.0/15-qemu-Set-the-affinity-of-QEMU-threads-according-to-t.patch
@@ -1,4 +1,4 @@
-From 086bd5f84c5a41ba76586eec1570997c0775b78c Mon Sep 17 00:00:00 2001
+From e6e6e65185832d17f2d5f298ae16e78a3c6422fd Mon Sep 17 00:00:00 2001
 From: Nikolay Martyanov <ohmspectator@gmail.com>
 Date: Wed, 28 Sep 2022 16:01:48 +0200
 Subject: [PATCH 15/15] qemu: Set the affinity of QEMU threads according to the


### PR DESCRIPTION
Use the DIV_ROUND_UP macro when calculating CPU set size. The original implementation gives the resulting CPU set size greater by 1 in cases where the maximum CPU is a multiple of BYTE_SIZE.

Signed-off-by: Nikolay Martyanov <ohmspectator@gmail.com>