### PR TITLE
if eve CI job fails to get cache hit, request rerun of all jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,10 +70,16 @@ jobs:
         with:
           fetch-depth: 0
       - name: update linuxkit cache for runner arch so we can get desired images
+        id: cache_for_docker
         uses: actions/cache@v3
         with:
           path: ~/.linuxkit/cache
           key: linuxkit-amd64-${{ github.sha }}
+      - name: Fail if cache miss
+        uses: actions/github-script@v6
+        if: steps.cache_for_docker.outputs.cache-hit != 'true'
+        with:
+          script: core.setFailed('Cache hit failed for loading packages. Please rerun all jobs, including "packages", not just "eve".')
       - name: load images we need from linuxkit cache into docker
         run: |
           make cache-export-docker-load-all
@@ -82,11 +88,17 @@ jobs:
         run: |
           rm -rf ~/.linuxkit
       - name: update linuxkit cache for our arch
+        id: cache_for_packages
         if: ${{ matrix.arch != 'amd64' }}  # because our runner arch is amd64; if that changes, this will have to change
         uses: actions/cache@v3
         with:
           path: ~/.linuxkit/cache
           key: linuxkit-${{ matrix.arch }}-${{ github.sha }}
+      - name: Fail if cache miss
+        uses: actions/github-script@v6
+        if: ${{ matrix.arch != 'amd64' && steps.cache_for_packages.outputs.cache-hit != 'true' }}  # because our runner arch is amd64; if that changes, this will have to change
+        with:
+          script: core.setFailed('Cache hit failed for loading packages. Please rerun all jobs, including "packages", not just "eve".')
       - name: set environment
         env:
           PR_ID: ${{ github.event.pull_request.number  }}


### PR DESCRIPTION
Our CI `build.yaml` has 2 jobs:

1. `packages`
2. `eve`

`packages` builds once on each architecture, while `eve` builds once for each target (matrix of architecture and hypervisor). The output of `packages` is cached using GitHub Actions cache, and then loaded into `eve`.

GHA caches have a maximum size with FIFO. As more caches get used, the oldest one is removed. That means that if we wait long enough from running `packages` until we run `eve`, the cached packages are timed out, `eve` gets a cache miss, and the job fails.

Normally this does not happen, since `eve` jobs get run immediately after `packages`. But since we can rerun just one job a day or two later, we can get a silent cache miss. This will cause later steps to fail for reasons that are unclear. It looks like a linuxkit cache or docker problem, but it really is a GitHub Actions cache problem.

This PR adds an explicit check on the `eve` job GHA cache restore. If we get a cache miss, it immediately fails with an error message to rerun them all.

Note that we could use artifacts instead of cache to make these more persistent, but that goes against the grain, and will end up publishing them where we do not want to. cache is the right thing to use; we just need to capture cache misses.