### PR TITLE
Wait for certificates in tpm and vault mgrs

### DIFF
--- a/pkg/pillar/cmd/tpmmgr/tpmmgr.go
+++ b/pkg/pillar/cmd/tpmmgr/tpmmgr.go
@@ -31,6 +31,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 )
@@ -580,7 +581,7 @@ func testEcdhAES() error {
 	}
 
 	isTpm := true
-	if !etpm.IsTpmEnabled() || etpm.FileExists(etpm.EcdhKeyFile) {
+	if !etpm.IsTpmEnabled() || fileutils.FileExists(etpm.EcdhKeyFile) {
 		isTpm = false
 	}
 
@@ -619,7 +620,7 @@ func testEncryptDecrypt() error {
 
 func createQuoteCert() error {
 	// certificate is already created
-	if etpm.FileExists(quoteCertFile) {
+	if fileutils.FileExists(quoteCertFile) {
 		return nil
 	}
 	// try TPM
@@ -636,7 +637,7 @@ func createQuoteCert() error {
 }
 
 func createEkCert() error {
-	if etpm.FileExists(EkCertFile) {
+	if fileutils.FileExists(EkCertFile) {
 		// certificate is already created
 		return nil
 	}
@@ -648,7 +649,7 @@ func createEkCert() error {
 
 func createEkCertOnTpm() error {
 	//Check if we already have the certificate
-	if !etpm.FileExists(EkCertFile) {
+	if !fileutils.FileExists(EkCertFile) {
 		//Cert is not present, generate new one
 		rw, err := tpm2.OpenTPM(etpm.TpmDevicePath)
 		if err != nil {
@@ -743,7 +744,7 @@ func createDeviceCertTemplate() *x509.Certificate {
 // the certificate is self-signed using the device private key
 func createDeviceCertOnTpm(pubkey crypto.PublicKey) error {
 	//Check if we already have the certificate
-	if etpm.FileExists(types.DeviceCertName) {
+	if fileutils.FileExists(types.DeviceCertName) {
 		return nil
 	}
 
@@ -902,7 +903,7 @@ func createEkTemplate(deviceCert x509.Certificate) x509.Certificate {
 
 func createQuoteCertOnTpm() error {
 	//Check if we already have the certificate
-	if !etpm.FileExists(quoteCertFile) {
+	if !fileutils.FileExists(quoteCertFile) {
 		//Cert is not present, generate new one
 		rw, err := tpm2.OpenTPM(etpm.TpmDevicePath)
 		if err != nil {
@@ -1078,7 +1079,7 @@ func getQuoteCert(certPath string) ([]byte, error) {
 
 func createEcdhCert() error {
 	// certificate is already created
-	if etpm.FileExists(ecdhCertFile) {
+	if fileutils.FileExists(ecdhCertFile) {
 		return nil
 	}
 	// try TPM
@@ -1096,7 +1097,7 @@ func createEcdhCert() error {
 
 func createEcdhCertOnTpm() error {
 	//Check if we already have the certificate
-	if !etpm.FileExists(ecdhCertFile) {
+	if !fileutils.FileExists(ecdhCertFile) {
 		//Cert is not present, generate new one
 		rw, err := tpm2.OpenTPM(etpm.TpmDevicePath)
 		if err != nil {
@@ -1287,7 +1288,7 @@ func getCertHash(cert []byte, hashAlgo types.CertHashType) ([]byte, error) {
 
 func publishEdgeNodeCertToController(ctx *tpmMgrContext, certFile string, certType types.CertType, isTpm bool, metaDataItems []types.CertMetaData) {
 	log.Functionf("publishEdgeNodeCertToController started")
-	if !etpm.FileExists(certFile) {
+	if !fileutils.FileExists(certFile) {
 		log.Errorf("publishEdgeNodeCertToController failed: no cert file of type: %v", certType)
 		return
 	}
@@ -1465,11 +1466,11 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	// publish ECDH cert
 	publishEdgeNodeCertToController(&ctx, ecdhCertFile, types.CertTypeEcdhXchange,
-		etpm.IsTpmEnabled() && !etpm.FileExists(etpm.EcdhKeyFile), nil)
+		etpm.IsTpmEnabled() && !fileutils.FileExists(etpm.EcdhKeyFile), nil)
 
 	// publish attestation quote cert
 	publishEdgeNodeCertToController(&ctx, quoteCertFile, types.CertTypeRestrictSigning,
-		etpm.IsTpmEnabled() && !etpm.FileExists(quoteKeyFile), nil)
+		etpm.IsTpmEnabled() && !fileutils.FileExists(quoteKeyFile), nil)
 
 	ekCertMetaData, err := getEkCertMetaData()
 	if err == nil {
@@ -1491,7 +1492,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	}
 	log.Functionf("processed GlobalConfig")
 
-	if etpm.IsTpmEnabled() && !etpm.FileExists(etpm.TpmCredentialsFileName) {
+	if etpm.IsTpmEnabled() && !fileutils.FileExists(etpm.TpmCredentialsFileName) {
 		err := readCredentials()
 		if err != nil {
 			// this indicates that we are in a very bad state

--- a/pkg/pillar/cmd/vaultmgr/vaultmgr.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgr.go
@@ -45,6 +45,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/lf-edge/eve/pkg/pillar/utils"
 	"github.com/lf-edge/eve/pkg/pillar/vault"
 	"github.com/lf-edge/eve/pkg/pillar/zfs"
 	"github.com/sirupsen/logrus"
@@ -933,6 +934,9 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 		ps.StillRunning(agentName, warningTime, errorTime)
 	}
 	log.Functionf("processed GlobalConfig")
+
+	utils.WaitForFile(ps, log, agentName, warningTime, errorTime, types.CertsGeneratedFileName)
+	log.Functionf("done waiting for certificates")
 
 	// initialize publishing handles
 	initializeSelfPublishHandles(ps, &ctx)

--- a/pkg/pillar/evetpm/tpm.go
+++ b/pkg/pillar/evetpm/tpm.go
@@ -23,6 +23,7 @@ import (
 	"github.com/lf-edge/eve/api/go/info"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	utils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 )
 
 const (
@@ -212,16 +213,10 @@ func TpmSign(digest []byte) (*big.Int, *big.Int, error) {
 	return sig.ECC.R, sig.ECC.S, nil
 }
 
-//FileExists returns true if a file with name filename is found
-func FileExists(filename string) bool {
-	_, err := os.Stat(filename)
-	return err == nil
-}
-
 //IsTpmEnabled checks if TPM is being used by software for creating device cert
 // Note that this must not be called before the device certificate has been generated
 func IsTpmEnabled() bool {
-	return FileExists(types.DeviceCertName) && !FileExists(types.DeviceKeyName)
+	return utils.FileExists(types.DeviceCertName) && !utils.FileExists(types.DeviceKeyName)
 }
 
 //GetRandom returns a random []byte of requested length

--- a/pkg/pillar/types/locationconsts.go
+++ b/pkg/pillar/types/locationconsts.go
@@ -3,7 +3,9 @@
 
 package types
 
-import "strings"
+import (
+	"strings"
+)
 
 const (
 	// TmpDirname - used for files fed into pubsub as global subscriptions
@@ -59,6 +61,9 @@ const (
 
 	// ServerSigningCertFileName - filename for server signing leaf certificate
 	ServerSigningCertFileName = CertificateDirname + "/server-signing-cert.pem"
+
+	// CertsGeneratedFileName indicates that we are done with certificates generation
+	CertsGeneratedFileName = CertificateDirname + "/generated"
 
 	// ShareCertDirname - directory to place private proxy server certificates
 	ShareCertDirname = "/usr/local/share/ca-certificates"

--- a/pkg/pillar/utils/file/file.go
+++ b/pkg/pillar/utils/file/file.go
@@ -198,3 +198,9 @@ func ReadSavedCounter(log *base.LogObject, fileName string) (uint32, bool) {
 	}
 	return 0, false
 }
+
+// FileExists returns true if a file with name filename is found
+func FileExists(filename string) bool {
+	_, err := os.Stat(filename)
+	return err == nil
+}


### PR DESCRIPTION
Inside device-steps we rely on the order of services startup after
certificates generation. Let's move the dependency into the code. Inside
the PR I touch CertsGenerated file after certificates generation and
wait for the file before start main loop of tpm and vault mgrs.