### PR TITLE
Fix DeviceInfo output

### DIFF
--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -216,9 +216,9 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 	if err != nil {
 		log.Errorf("get info from uname failed %s", err)
 	} else {
-		ReportDeviceInfo.MachineArch = *proto.String(string(uname.Machine[:]))
-		ReportDeviceInfo.CpuArch = *proto.String(string(uname.Machine[:]))
-		ReportDeviceInfo.Platform = *proto.String(string(uname.Machine[:]))
+		ReportDeviceInfo.MachineArch = *proto.String(unix.ByteSliceToString(uname.Machine[:]))
+		ReportDeviceInfo.CpuArch = *proto.String(unix.ByteSliceToString(uname.Machine[:]))
+		ReportDeviceInfo.Platform = *proto.String(unix.ByteSliceToString(uname.Machine[:]))
 	}
 
 	sub := ctx.getconfigCtx.subHostMemory


### PR DESCRIPTION
Inside device info message I can see unexpected termination symbols `x86_64\x00\x00\x00...`. Let's use `unix.ByteSliceToString` function to remove them.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>