### PR TITLE
Measure CONFIG into PCR 14

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -134,7 +134,7 @@ function set_config_overrides {
      search.part_label CONFIG config_part "$self_drive"
      if [ -n "$config_part" ]; then
         set_to_existing_file config_grub_cfg "($config_part)/grub.cfg"
-        measurefs $config_part --pcr 13
+        measurefs $config_part --pcr 14
         if [ "$grub_virt" != qemu ]; then
            set_to_existing_file devicetree "($config_part)/eve.dtb"
         fi


### PR DESCRIPTION
While CONFIG is R/W there is not way to test rootfs measurment

Signed-off-by: Mikhail Malyshev <mikem@zededa.com>