### PR TITLE
Disable DNS rebinding protection

### DIFF
--- a/pkg/pillar/cmd/zedrouter/dnsmasq.go
+++ b/pkg/pillar/cmd/zedrouter/dnsmasq.go
@@ -39,8 +39,6 @@ quiet-dhcp6
 no-hosts
 no-ping
 bogus-priv
-stop-dns-rebind
-rebind-localhost-ok
 neg-ttl=10
 dhcp-ttl=600
 `


### PR DESCRIPTION
dnsmasq deployed by EVE as a DNS server for a local network instance has DNS rebinding protection enabled. However, this protection as implemented by dnsmasq is not particularly sophisticated - it simply rejects any A/AAAA answer from an upstream DNS servers with an IP address falling into a private IP range.

A better solution would be if dnsmasq detected that a particular DNS record has a short TTL and the resolved IP address changed from a public to a private one.

The protection from dnsmasq rejecting any DNS records with private IPs actually breaks domain name resolution for apps in certain cases. Namely, if the upstream DNS server is actually a customer private one, resolving some domain names into private IPs of endpoints inside the customer network. Applications will not succeed in resolving these domain names because DNS rebind protection will block responses coming from the customer DNS server.

It is therefore better to disable this protection and leave it to the applications to protect themselves against DNS attacks if deemed necessary.

Signed-off-by: Milan Lenco <milan@zededa.com>