### PR TITLE
qemu: Fix CPU set size calculation.

### DIFF
--- a/pkg/xen-tools/patches-4.15.0/14-qemu-Init-CPU-mask-per-VCPU.patch
+++ b/pkg/xen-tools/patches-4.15.0/14-qemu-Init-CPU-mask-per-VCPU.patch
@@ -1,4 +1,4 @@
-From 15ca400172894c128cb4ff2916fe8c882205b587 Mon Sep 17 00:00:00 2001
+From bea4aaef5c4dd309799055da9c5d7036579b89e9 Mon Sep 17 00:00:00 2001
 From: Nikolay Martyanov <ohmspectator@gmail.com>
 Date: Wed, 28 Sep 2022 15:52:24 +0200
 Subject: [PATCH 14/15] qemu: Init CPU mask per VCPU.
@@ -7,9 +7,9 @@ Signed-off-by: Nikolay Martyanov <ohmspectator@gmail.com>
 ---
  tools/qemu-xen/include/hw/boards.h   |  1 +
  tools/qemu-xen/include/hw/core/cpu.h |  2 +
- tools/qemu-xen/softmmu/cpus.c        | 31 +++++++++++
- tools/qemu-xen/softmmu/vl.c          | 80 ++++++++++++++++++++++++++++
- 4 files changed, 114 insertions(+)
+ tools/qemu-xen/softmmu/cpus.c        | 31 ++++++++++++
+ tools/qemu-xen/softmmu/vl.c          | 75 ++++++++++++++++++++++++++++
+ 4 files changed, 109 insertions(+)
 
 diff --git a/tools/qemu-xen/include/hw/boards.h b/tools/qemu-xen/include/hw/boards.h
 index b06f13e..a4b4f11 100644
@@ -86,18 +86,13 @@ index a802e89..da56052 100644
      if (!cpu->as) {
          /* If the target cpu hasn't set up any address spaces itself,
 diff --git a/tools/qemu-xen/softmmu/vl.c b/tools/qemu-xen/softmmu/vl.c
-index c7c8abc..0222c6c 100644
+index c7c8abc..f514f59 100644
 --- a/tools/qemu-xen/softmmu/vl.c
 +++ b/tools/qemu-xen/softmmu/vl.c
-@@ -2829,6 +2829,73 @@ static void create_default_memdev(MachineState *ms, const char *path)
+@@ -2829,6 +2829,68 @@ static void create_default_memdev(MachineState *ms, const char *path)
                              &error_fatal);
  }
  
-+static inline unsigned get_max_cpu_in_mask(unsigned int cpumask)
-+{
-+    return (sizeof(cpumask) * BITS_PER_BYTE) - __builtin_clz(cpumask) - 1;
-+}
-+
 +static inline void cpumask_set_bit(uint64_t *mask, uint8_t bit)
 +{
 +    *mask |= 1ull << bit ;
@@ -163,7 +158,7 @@ index c7c8abc..0222c6c 100644
  void qemu_init(int argc, char **argv, char **envp)
  {
      int i;
-@@ -4306,6 +4373,19 @@ void qemu_init(int argc, char **argv, char **envp)
+@@ -4306,6 +4368,19 @@ void qemu_init(int argc, char **argv, char **envp)
  
      current_machine->boot_order = boot_order;
  

--- a/pkg/xen-tools/patches-4.15.0/15-qemu-Set-the-affinity-of-QEMU-threads-according-to-t.patch
+++ b/pkg/xen-tools/patches-4.15.0/15-qemu-Set-the-affinity-of-QEMU-threads-according-to-t.patch
@@ -1,15 +1,15 @@
-From f241d0b1bda7e3b9ceffc5d958aafa54a335c517 Mon Sep 17 00:00:00 2001
+From f6861fa011836c9101977e2b0ad1aadaf8d45a57 Mon Sep 17 00:00:00 2001
 From: Nikolay Martyanov <ohmspectator@gmail.com>
 Date: Wed, 28 Sep 2022 16:01:48 +0200
-Subject: [PATCH] qemu: Set the affinity of QEMU threads according to the CPU
- mask options.
+Subject: [PATCH 15/15] qemu: Set the affinity of QEMU threads according to the
+ CPU mask options.
 
 Signed-off-by: Nikolay Martyanov <ohmspectator@gmail.com>
 ---
  tools/qemu-xen/include/qemu/thread.h    |  2 ++
- tools/qemu-xen/softmmu/cpus.c           |  6 +++++
- tools/qemu-xen/util/qemu-thread-posix.c | 36 +++++++++++++++++++++++++
- 3 files changed, 44 insertions(+)
+ tools/qemu-xen/softmmu/cpus.c           |  6 ++++
+ tools/qemu-xen/util/qemu-thread-posix.c | 37 +++++++++++++++++++++++++
+ 3 files changed, 45 insertions(+)
 
 diff --git a/tools/qemu-xen/include/qemu/thread.h b/tools/qemu-xen/include/qemu/thread.h
 index 4baf4d1..3d1a76e 100644
@@ -42,7 +42,7 @@ index da56052..000df00 100644
          qemu_cond_wait(&qemu_cpu_cond, &qemu_global_mutex);
      }
 diff --git a/tools/qemu-xen/util/qemu-thread-posix.c b/tools/qemu-xen/util/qemu-thread-posix.c
-index b4c2359..f716855 100644
+index b4c2359..c404ff4 100644
 --- a/tools/qemu-xen/util/qemu-thread-posix.c
 +++ b/tools/qemu-xen/util/qemu-thread-posix.c
 @@ -17,6 +17,8 @@
@@ -54,12 +54,13 @@ index b4c2359..f716855 100644
  static bool name_threads;
  
  void qemu_thread_naming(bool enable)
-@@ -523,6 +525,40 @@ static void *qemu_thread_start(void *args)
+@@ -523,6 +525,41 @@ static void *qemu_thread_start(void *args)
      return r;
  }
  
 +static inline unsigned get_max_cpu_in_mask(unsigned int cpumask)
 +{
++    assert(cpumask != 0);
 +    return (sizeof (cpumask) * BITS_PER_BYTE) - __builtin_clz (cpumask) - 1;
 +}
 +
@@ -95,8 +96,6 @@ index b4c2359..f716855 100644
  void qemu_thread_create(QemuThread *thread, const char *name,
                         void *(*start_routine)(void*),
                         void *arg, int mode)
-
-base-commit: 15ca400172894c128cb4ff2916fe8c882205b587
 -- 
 2.35.1
 

--- a/pkg/xen-tools/patches-4.15.0/15-qemu-Set-the-affinity-of-QEMU-threads-according-to-t.patch
+++ b/pkg/xen-tools/patches-4.15.0/15-qemu-Set-the-affinity-of-QEMU-threads-according-to-t.patch
@@ -1,8 +1,8 @@
-From e6e6e65185832d17f2d5f298ae16e78a3c6422fd Mon Sep 17 00:00:00 2001
+From f241d0b1bda7e3b9ceffc5d958aafa54a335c517 Mon Sep 17 00:00:00 2001
 From: Nikolay Martyanov <ohmspectator@gmail.com>
 Date: Wed, 28 Sep 2022 16:01:48 +0200
-Subject: [PATCH 15/15] qemu: Set the affinity of QEMU threads according to the
- CPU mask options.
+Subject: [PATCH] qemu: Set the affinity of QEMU threads according to the CPU
+ mask options.
 
 Signed-off-by: Nikolay Martyanov <ohmspectator@gmail.com>
 ---
@@ -42,7 +42,7 @@ index da56052..000df00 100644
          qemu_cond_wait(&qemu_cpu_cond, &qemu_global_mutex);
      }
 diff --git a/tools/qemu-xen/util/qemu-thread-posix.c b/tools/qemu-xen/util/qemu-thread-posix.c
-index b4c2359..44975eb 100644
+index b4c2359..f716855 100644
 --- a/tools/qemu-xen/util/qemu-thread-posix.c
 +++ b/tools/qemu-xen/util/qemu-thread-posix.c
 @@ -17,6 +17,8 @@
@@ -84,7 +84,7 @@ index b4c2359..44975eb 100644
 +
 +    /* Count the size of the necessary CPU_SET */
 +    max_pcpu = get_max_cpu_in_mask(cpumask);
-+    cpu_set_size = DIV_ROUND_UP(max_pcpu, BITS_PER_BYTE);
++    cpu_set_size = DIV_ROUND_UP(max_pcpu + 1, BITS_PER_BYTE);
 +
 +    err = pthread_setaffinity_np(thread->thread, cpu_set_size, &cpu_set);
 +
@@ -95,6 +95,8 @@ index b4c2359..44975eb 100644
  void qemu_thread_create(QemuThread *thread, const char *name,
                         void *(*start_routine)(void*),
                         void *arg, int mode)
+
+base-commit: 15ca400172894c128cb4ff2916fe8c882205b587
 -- 
 2.35.1
 


### PR DESCRIPTION
Bits in a bit mask are indexed starting with 1, the CPUs are indexed starting with 0. Take it into acoount when counting the CPU set size.

Signed-off-by: Nikolay Martyanov <ohmspectator@gmail.com>