### PR TITLE
With bootstrap config disable lastresort by default

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -24,7 +24,7 @@
 | timer.port.testinterval | timer in seconds | 300 | retest the current port config |
 | timer.port.timeout | timer in seconds | 15 | time for each http/send |
 | timer.port.testbetterinterval | timer in seconds | 600 | test a higher prio port config |
-| network.fallback.any.eth | "enabled" or "disabled" | enabled | if no connectivity try any Ethernet, WiFi, or LTE |
+| network.fallback.any.eth | "enabled" or "disabled" | enabled (disabled if device was installed with [bootstrap config](CONFIG.md) included) | if no connectivity try any Ethernet, WiFi, or LTE |
 | network.download.max.cost | 0-255 | 0 | [max port cost for download](DEVICE-CONNECTIVITY.md) to avoid e.g., LTE ports |
 | debug.enable.usb | boolean | false | allow USB e.g. keyboards on device |
 | debug.enable.vga | boolean | false | allow VGA console on device |

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -2315,6 +2315,22 @@ func parseConfigItems(ctx *getconfigContext, config *zconfig.EdgeDevConfig,
 		newGlobalConfig.SetGlobalValueBool(types.UsbAccess, false)
 		newGlobalConfig.SetGlobalValueBool(types.VgaAccess, false)
 	}
+	// Default value of NetworkFallbackAnyEth (aka lastresort network config)
+	// depends on how the device was installed. If a single-use EVE installer
+	// was used, the lastresort is by default disabled because the intended network
+	// configuration is available right from the first boot, even before onboarding.
+	// Still, it is possible to (explicitly) enable lastresort inside the bootstrap
+	// config even if it is not recommended (falling back to lastresort and marking
+	// all ethernet interfaces for management can create all sorts of problems).
+	// Without bootstrap config, device will by default enable lastresort at least until
+	// it onboards and obtains the intended config from the controller. This can be avoided
+	// by disabling lastresort and providing an alternative network configuration using
+	// (deprecated) override json files (global.json and override.json or usb.json).
+	_, err := os.Stat(types.BootstrapConfFileName)
+	bootstrapExists := err == nil
+	if bootstrapExists {
+		newGlobalConfig.SetGlobalValueTriState(types.NetworkFallbackAnyEth, types.TS_DISABLED)
+	}
 	newGlobalStatus := types.NewGlobalStatus()
 
 	for _, item := range items {


### PR DESCRIPTION
When device is installed using a single-use EVE installer, the intended network configuration is available from the very first boot, even before device onboarding. It therefore does not make much sense to still keep using last-resort network config as a fallback.

In fact, lastresort is often causing issues, especially when network outage is outside of the EVE control (external network goes down). Changing network configuration from the intended state to lastresort not only cannot help in such cases, but it can also have negative side effects, such as:
 - prolonged outage: device will stay with lastresort if all DPCs are failing and it will only retest the intended config once per 10 minutes
 - confusing logs and events - customer might get a wrong impression that outage was caused by EVE when it unwantedly changed applied config (customer will blame EVE instead of troubleshooting outside networks)
 - break NIC pass-through - EVE will mark all ethernets for management which will prevent them from being assigned to apps (this can be triggered by a race between domainmgr deploying app and NIM falling back to lastresort at around the same time)

Instead of changing the default value of lastresort all across the board, the proposal is to at least change it for the case of device being installed using a single-use EVE installer (which is a new feature so this is not changing behavior for older workflows).

Signed-off-by: Milan Lenco <milan@zededa.com>