### PR TITLE
pillar/domainmng: remove versionning from the cloud-init meta-data file

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -2423,9 +2423,8 @@ func createCloudInitISO(ctx *domainContext,
 		if err != nil {
 			log.Fatalf("createCloudInitISO failed %s", err)
 		}
-		metafile.WriteString(fmt.Sprintf("instance-id: %s/%s\n",
-			config.UUIDandVersion.UUID.String(),
-			config.UUIDandVersion.Version))
+		metafile.WriteString(fmt.Sprintf("instance-id: %s\n",
+			config.UUIDandVersion.UUID.String()))
 		metafile.WriteString(fmt.Sprintf("local-hostname: %s\n",
 			config.UUIDandVersion.UUID.String()))
 		metafile.Close()


### PR DESCRIPTION
There is a nasty behavior observed on the VM with a cloud-init configuration: the field config.UUIDandVersion.Version is incremented by one each time an application (VM) restarts from the zedcontrol, which causes cloud-init to be triggered in the guest and repeat the whole init procedure.

This patch fixes the problem by removing the "version" part from the instance-id field in the meta-data file in order to keep 
cloud-init executed only once.

PS. this patch is a good candidate for a stable branch, thus "stable" or whatevert mark is needed here.
