### PR TITLE
maybeRetryConfig function to handle config retry

### DIFF
--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -267,6 +267,7 @@ type DomainStatus struct {
 	TriedCount         int
 	// ErrorAndTime provides SetErrorNow() and ClearError()
 	ErrorAndTime
+	ConfigFailed   bool
 	BootFailed     bool
 	AdaptersFailed bool
 	OCIConfigDir   string            // folder holding an OCI Image config for this domain (empty string means no config)


### PR DESCRIPTION
In case of configuration issues we do not retry domain boot. We may hit such problem in case of races between publishing of cipher contexts and cloud-init data inside app instance config.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>