### PR TITLE
Manually set ServerName in TLS config breaks proxy listening on HTTPS

### DIFF
--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -225,7 +225,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		log.Fatal(err)
 	}
 	serverNameAndPort = strings.TrimSpace(string(server))
-	serverName := strings.Split(serverNameAndPort, ":")[0]
 
 	var onboardCert tls.Certificate
 	var deviceCertPem []byte
@@ -239,7 +238,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 			log.Fatal(err)
 		}
 		onboardTLSConfig, err = zedcloud.GetTlsConfig(zedcloudCtx.DeviceNetworkStatus,
-			serverName, &onboardCert, &zedcloudCtx)
+			&onboardCert, &zedcloudCtx)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -256,7 +255,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		log.Fatal(err)
 	}
 	devtlsConfig, err = zedcloud.GetTlsConfig(zedcloudCtx.DeviceNetworkStatus,
-		serverName, &deviceCert, &zedcloudCtx)
+		&deviceCert, &zedcloudCtx)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -365,21 +364,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 					server, nserver)
 				server = nserver
 				serverNameAndPort = strings.TrimSpace(string(server))
-				serverName = strings.Split(serverNameAndPort, ":")[0]
-				if onboardTLSConfig != nil {
-					onboardTLSConfig, err = zedcloud.GetTlsConfig(zedcloudCtx.DeviceNetworkStatus,
-						serverName, &onboardCert, &zedcloudCtx)
-					if err != nil {
-						log.Fatal(err)
-					}
-				}
-				if devtlsConfig != nil {
-					devtlsConfig, err = zedcloud.GetTlsConfig(zedcloudCtx.DeviceNetworkStatus,
-						serverName, &deviceCert, &zedcloudCtx)
-					if err != nil {
-						log.Fatal(err)
-					}
-				}
 				// Force a refresh
 				ok := fetchCertChain(&zedcloudCtx, devtlsConfig, retryCount, true)
 				if !ok && !zedcloudCtx.NoLedManager {

--- a/pkg/pillar/cmd/loguploader/loguploader.go
+++ b/pkg/pillar/cmd/loguploader/loguploader.go
@@ -400,7 +400,6 @@ func sendCtxInit(ctx *loguploaderContext) {
 	}
 	// Preserve port
 	ctx.serverNameAndPort = strings.TrimSpace(string(bytes))
-	serverName := strings.Split(ctx.serverNameAndPort, ":")[0]
 
 	//set newlog url
 	zedcloudCtx := zedcloud.NewContext(log, zedcloud.ContextOptions{
@@ -418,7 +417,7 @@ func sendCtxInit(ctx *loguploaderContext) {
 		zedcloudCtx.DevSoftSerial)
 
 	// XXX need to redo this since the root certificates can change when DeviceNetworkStatus changes
-	err = zedcloud.UpdateTLSConfig(&zedcloudCtx, serverName, nil)
+	err = zedcloud.UpdateTLSConfig(&zedcloudCtx, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -307,7 +307,6 @@ func initZedcloudContext(networkSendTimeout uint32, agentMetrics *zedcloud.Agent
 		log.Fatal(err)
 	}
 	serverNameAndPort = strings.TrimSpace(string(bytes))
-	serverName = strings.Split(serverNameAndPort, ":")[0]
 
 	zedcloudCtx := zedcloud.NewContext(log, zedcloud.ContextOptions{
 		DevNetworkStatus: deviceNetworkStatus,
@@ -322,7 +321,7 @@ func initZedcloudContext(networkSendTimeout uint32, agentMetrics *zedcloud.Agent
 		zedcloudCtx.DevSoftSerial, zedcloud.UseV2API())
 
 	// XXX need to redo this since the root certificates can change
-	err = zedcloud.UpdateTLSConfig(&zedcloudCtx, serverName, nil)
+	err = zedcloud.UpdateTLSConfig(&zedcloudCtx, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/pillar/conntester/zedcloud.go
+++ b/pkg/pillar/conntester/zedcloud.go
@@ -52,7 +52,6 @@ func (t *ZedcloudConnectivityTester) TestConnectivity(
 		t.Log.Fatal(err)
 	}
 	serverNameAndPort := strings.TrimSpace(string(server))
-	serverName := strings.Split(serverNameAndPort, ":")[0]
 
 	zedcloudCtx := zedcloud.NewContext(t.Log, zedcloud.ContextOptions{
 		DevNetworkStatus: &dns,
@@ -65,7 +64,7 @@ func (t *ZedcloudConnectivityTester) TestConnectivity(
 	t.Log.Functionf("TestConnectivity: Use V2 API %v\n", zedcloud.UseV2API())
 	testURL := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, nilUUID, "ping")
 
-	tlsConfig, err := zedcloud.GetTlsConfig(zedcloudCtx.DeviceNetworkStatus, serverName,
+	tlsConfig, err := zedcloud.GetTlsConfig(zedcloudCtx.DeviceNetworkStatus,
 		nil, &zedcloudCtx)
 	if err != nil {
 		t.Log.Functionf("TestConnectivity: " +
@@ -79,7 +78,7 @@ func (t *ZedcloudConnectivityTester) TestConnectivity(
 		}
 		clientCert := &onboardingCert
 		tlsConfig, err = zedcloud.GetTlsConfig(zedcloudCtx.DeviceNetworkStatus,
-			serverName, clientCert, &zedcloudCtx)
+			clientCert, &zedcloudCtx)
 		if err != nil {
 			err = fmt.Errorf("failed to load TLS config for talking to Zedcloud: %v", err)
 			t.Log.Functionf("TestConnectivity: %v", err)

--- a/pkg/pillar/zedcloud/wstunnelclient.go
+++ b/pkg/pillar/zedcloud/wstunnelclient.go
@@ -105,13 +105,11 @@ func (t *WSTunnelClient) TestConnection(devNetStatus *types.DeviceNetworkStatus,
 	log.Tracef("Testing connection to %s on local address: %v, proxy: %v", t.Tunnel, localAddr, proxyURL)
 	log.Functionf("Testing connection to %s on local address: %v, proxy: %v", t.Tunnel, localAddr, proxyURL)
 
-	serverName := strings.Split(t.TunnelServerNameAndPort, ":")[0]
-
 	zedcloudCtx := ZedCloudContext{
 		V2API: UseV2API(),
 	}
 	// zedcloudCtx V2API UseV2API()
-	tlsConfig, err := GetTlsConfig(devNetStatus, serverName, nil, &zedcloudCtx)
+	tlsConfig, err := GetTlsConfig(devNetStatus, nil, &zedcloudCtx)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
We manually set [ServerName](https://cs.opensource.google/go/go/+/refs/tags/go1.19.2:src/crypto/tls/common.go;l=625-629) inside tls.Config, which is then used by tls package to verify the hostname on the returned certificates and as the SNI value of the ClientHello TLS message.

However, it is better let the higher-level packages like net/http (see [here](https://github.com/golang/go/blob/release-branch.go1.16/src/net/http/transport.go#L1511-L1513)) and gorilla/websocket (see [here](https://github.com/gorilla/websocket/blob/v1.5.0/client.go#L340-L342)) to set it automatically from the destination URL. Setting this manually actually breaks certificate verification when (non-transparent) network proxy listening on HTTPS (not HTTP) is being used between the device and the destination.
In that case, the first TLS handshake is being done with the proxy and it is expected that proxy presents its own certificate, with CN set to its hostname.

With ServerName set to destination hostname already for this first TLS handshake, proxy cert verification would fail with:
`proxyconnect tcp: x509: certificate is valid for <proxy-hostname>, not <destination-hostname>`

Higher-level packages first set ServerName to the proxy hostname, then for the subsequent TLS handshake they use the destination hostname. I checked that if either the proxy presents cert with a wrong CN or the destination server sends cert with unexpected CN (or proxy acting as MITM generates cert with bad CN), the request fails in every case, returning a cert verification error as expected even if we do not manually set ServerName.

Additionally, when diag runs tests towards google.com, it disables server verification in the TLS config and this stays disabled even for future diag tests against the controller URL, which is not desired. This commit fixes this issue as well.

Signed-off-by: Milan Lenco <milan@zededa.com>