### PR TITLE
wwan: make sure the APN is set in the correct profile

### DIFF
--- a/pkg/wwan/usr/bin/wwan-mbim.sh
+++ b/pkg/wwan/usr/bin/wwan-mbim.sh
@@ -171,7 +171,9 @@ mbim_wait_for_register() {
   # procedure (for the initial EPS bearer activation).
   # Note that qmicli is able to apply this change even in the mbim mode.
   # On the other hand, mbimcli does not yet provide command to manipulate with profiles.
-  qmi --wds-modify-profile="3gpp,1,apn=${APN},pdp-type=ip"
+  local PROFILE="$(qmi --wds-get-default-profile-num=3gpp)"
+  local PROFILE_NUM="$(parse_modem_attr "$PROFILE" "Default profile number")"
+  qmi --wds-modify-profile="3gpp,${PROFILE_NUM},apn=${APN}"
 
   echo "[$CDC_DEV] Waiting for the device to register on the network"
   local CMD="mbim --query-registration-state | grep -qE 'Register state:.*(home|roaming|partner)' && echo registered"

--- a/pkg/wwan/usr/bin/wwan-qmi.sh
+++ b/pkg/wwan/usr/bin/wwan-qmi.sh
@@ -272,7 +272,9 @@ qmi_wait_for_register() {
   # Make sure we are registering with the right APN.
   # Some LTE networks require explicit (and correct) APN for the registration/attach
   # procedure (for the initial EPS bearer activation).
-  qmi --wds-modify-profile="3gpp,1,apn=${APN},pdp-type=ip"
+  local PROFILE="$(qmi --wds-get-default-profile-num=3gpp)"
+  local PROFILE_NUM="$(parse_modem_attr "$PROFILE" "Default profile number")"
+  qmi --wds-modify-profile="3gpp,${PROFILE_NUM},apn=${APN}"
 
   echo "[$CDC_DEV] Waiting for the device to register on the network"
   local CMD="qmi_get_registration_status"


### PR DESCRIPTION
Previously, wwan microservice would always set APN for the first PDP profile (index 1), but some LTE service providers use different profile number for the data service. For example, in case of Verizon the profile no. 1 should not be modified and is supposed to be always the same (APN=vzwims), while data service is supposed to be defined inside the profile number 3.

wwan microservice should therefore obtain the index of the data service profile and set the APN there. With qmicli, the data profile is referenced to as "default" profile.

Additionally, it is better to keep PDP type (IP, IPV6, IPV4V6) unchanged rather than to assume what the right value should be, which could cause problems with the registration of the device into the network.

Signed-off-by: Milan Lenco <milan@zededa.com>