### PR TITLE
NIM: make reconciliation of Linux routes more robust

### DIFF
--- a/libs/depgraph/depgraph.go
+++ b/libs/depgraph/depgraph.go
@@ -162,7 +162,10 @@ func (g *graph) DiffItems(graph2 GraphR) (diff []ItemRef) {
 	for i < end1 && j < end2 {
 		n1 := g.root.sortedNodes[i]
 		n2 := g2.root.sortedNodes[j]
-		pathCmp := n1.path.Compare(n2.path)
+		// Compare relative paths (w.r.t. g and g2), not absolute paths.
+		n1Path := n1.path.TrimPrefix(g.pathFromRoot)
+		n2Path := n2.path.TrimPrefix(g2.pathFromRoot)
+		pathCmp := n1Path.Compare(n2Path)
 		idCmp := n1.itemRef().Compare(n2.itemRef())
 		if pathCmp == -1 || (pathCmp == 0 && idCmp == -1) {
 			diffMap[n1.itemRef()] = struct{}{}

--- a/pkg/pillar/dpcreconciler/linuxitems/route.go
+++ b/pkg/pillar/dpcreconciler/linuxitems/route.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
-
 	"github.com/lf-edge/eve/libs/depgraph"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/dpcreconciler/genericitems"
@@ -58,7 +56,7 @@ func (r Route) Type() string {
 // Equal is a comparison method for two equally-named route instances.
 func (r Route) Equal(other depgraph.Item) bool {
 	r2 := other.(Route)
-	return reflect.DeepEqual(r.Route, r2.Route)
+	return r.Route.Equal(r2.Route)
 }
 
 // External returns false.

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/depgraph/depgraph.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/depgraph/depgraph.go
@@ -162,7 +162,10 @@ func (g *graph) DiffItems(graph2 GraphR) (diff []ItemRef) {
 	for i < end1 && j < end2 {
 		n1 := g.root.sortedNodes[i]
 		n2 := g2.root.sortedNodes[j]
-		pathCmp := n1.path.Compare(n2.path)
+		// Compare relative paths (w.r.t. g and g2), not absolute paths.
+		n1Path := n1.path.TrimPrefix(g.pathFromRoot)
+		n2Path := n2.path.TrimPrefix(g2.pathFromRoot)
+		pathCmp := n1Path.Compare(n2Path)
 		idCmp := n1.itemRef().Compare(n2.itemRef())
 		if pathCmp == -1 || (pathCmp == 0 && idCmp == -1) {
 			diffMap[n1.itemRef()] = struct{}{}


### PR DESCRIPTION
A Linux network route can be automatically removed by Linux network stack when interface dissapears or IP address is unconfigured. This means that DPC reconciler can work with outdated view of the current state because changes happen outside of its control.

I have seen this especially with wwan0 interface, where this is mostly caused by the fact that LTE connectivity is managed by wwan microservice, meaning IP settings change outside of the pillar control in this case. The solution is to simply re-read the current state of installed routes using netlink calls everytime DPC reconciler runs reconciliation (either full or for the L3 subgraph of the config state).

Additionally, to compare route intended vs. actual config, `reflect.DeepEqual` was (lazily) used, which as it turns out does not work well with netlink route attributes - there are pointers which can make two `netlink.Route` instances look different even if they point to the same Linux route. It turns out that netlink actually provides `Equal` method that handles comparison properly.

Lastly, there is a small fix for depgraph included - `DiffItems` (used to compare the intended and the current states) would return in some cases false positives, i.e. an item could have been wrongly marked as out-of-sync.
In the end it didn't have any actual negative effect because Reconciler calls `Item.Equal` method before running Create/Modify/Delete, so it would detect NOOP. However, just the fact that it may trigger reconciliation unnecessarily, wasting cycles and producing confusing logs, makes it worth fixing.

Signed-off-by: Milan Lenco <milan@zededa.com>