### PR TITLE
pillar: update Focinfi/go-dns-resolver to include newly added LICENSE

### DIFF
--- a/docs/EVE-IMAGE-SOURCES.md
+++ b/docs/EVE-IMAGE-SOURCES.md
@@ -253,7 +253,7 @@ uses semver, a hash otherwise. For example, [pkg/pillar/go.mod](../pkg/pillar/go
 ```go
 require (
     cloud.google.com/go/storage v1.21.0 // indirect
-    github.com/Focinfi/go-dns-resolver v1.0.0
+    github.com/Focinfi/go-dns-resolver v1.0.1
     github.com/anatol/smart.go v0.0.0-20220615232124-371056cd18c3
 ```
 

--- a/pkg/pillar/go.mod
+++ b/pkg/pillar/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	cloud.google.com/go/storage v1.21.0 // indirect
-	github.com/Focinfi/go-dns-resolver v1.0.0
+	github.com/Focinfi/go-dns-resolver v1.0.1
 	github.com/anatol/smart.go v0.0.0-20220615232124-371056cd18c3
 	github.com/bicomsystems/go-libzfs v0.4.0
 	github.com/containerd/cgroups v1.0.3

--- a/pkg/pillar/go.sum
+++ b/pkg/pillar/go.sum
@@ -156,8 +156,8 @@ github.com/Code-Hex/vz v0.0.4/go.mod h1:UeHKXSv3hP7BzU6IaVE/a7VHSHUHpqbS3oVko4O5
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/Djarvur/go-err113 v0.0.0-20200410182137-af658d038157/go.mod h1:4UJr5HIiMZrwgkSPdsjy2uOQExX/WEILpIrO9UPGuXs=
 github.com/Djarvur/go-err113 v0.1.0/go.mod h1:4UJr5HIiMZrwgkSPdsjy2uOQExX/WEILpIrO9UPGuXs=
-github.com/Focinfi/go-dns-resolver v1.0.0 h1:jirsf1vQX9p3BBPZFKFbYEB359/cCu8ihL0OlmYSAzk=
-github.com/Focinfi/go-dns-resolver v1.0.0/go.mod h1:DDoAgG4IEfaLksj8/CrTwT1Y/T1tJ2Hg4jznkTL8W0g=
+github.com/Focinfi/go-dns-resolver v1.0.1 h1:fSNrahh/8Ge06z6HtTEbagPy/WGdV2O1VOEm9+S9vds=
+github.com/Focinfi/go-dns-resolver v1.0.1/go.mod h1:DDoAgG4IEfaLksj8/CrTwT1Y/T1tJ2Hg4jznkTL8W0g=
 github.com/GoogleCloudPlatform/cloudsql-proxy v0.0.0-20191009163259-e802c2cb94ae/go.mod h1:mjwGPas4yKduTyubHvD1Atl9r1rUq8DfVy+gkVvZ+oo=
 github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20190822182118-27a4ced34534/go.mod h1:iroGtC8B3tQiqtds1l+mgk/BBOrxbqjH+eUfFQYRc14=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=

--- a/pkg/pillar/vendor/github.com/Focinfi/go-dns-resolver/LICENSE
+++ b/pkg/pillar/vendor/github.com/Focinfi/go-dns-resolver/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+As this is fork of the official Go code the same license applies.
+Extensions of the original work are copyright (c) 2011 Miek Gieben

--- a/pkg/pillar/vendor/github.com/Focinfi/go-dns-resolver/README.md
+++ b/pkg/pillar/vendor/github.com/Focinfi/go-dns-resolver/README.md
@@ -33,7 +33,7 @@ func main() {
   dns.Config.RetryTimes = uint(4)
 
   // Simple usage
-  if results, err := dns.Exchange("google.com", "119.29.29.29", typeA); err == nil {
+  if results, err := dns.Exchange("google.com", "119.29.29.29", dns.TypeA); err == nil {
     for _, r := range results {
       log.Println(r.Record, r.Type, r.Ttl, r.Priority, r.Content)
     }

--- a/pkg/pillar/vendor/modules.txt
+++ b/pkg/pillar/vendor/modules.txt
@@ -20,7 +20,7 @@ github.com/Azure/azure-storage-blob-go/azblob
 # github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1
 github.com/Azure/go-ansiterm
 github.com/Azure/go-ansiterm/winterm
-# github.com/Focinfi/go-dns-resolver v1.0.0
+# github.com/Focinfi/go-dns-resolver v1.0.1
 ## explicit
 github.com/Focinfi/go-dns-resolver
 # github.com/Microsoft/go-winio v0.5.2


### PR DESCRIPTION
There are also indirect references to the previous version of `Focinfi/go-dns-resolver` from newlog and edgeview, but first we need to merge this and then update dependency on `github.com/lf-edge/eve/pkg/pillar` for those packages.

Signed-off-by: Milan Lenco <milan@zededa.com>