### PR TITLE
Build riscv64 EVE-OS per PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ jobs:
           arch: arm64
         - os: ubuntu-20.04
           arch: amd64
+        - os: ubuntu-20.04
+          arch: riscv64
     steps:
       - name: Starting Report
         run: |
@@ -40,6 +42,13 @@ jobs:
         if: ${{ matrix.os == 'arm64-dirty' || matrix.os == 'arm64-secure' }}
         run: |
           sudo apt install -y zstd
+      - name: ensure packages for cross-arch build
+        if: ${{ matrix.arch == 'riscv64' }}
+        run: |
+          APT_INSTALL="sudo apt install -y binfmt-support qemu-user-static"
+          # the following weird statement is here to speed up the happy path
+          # if the default server is responding -- we can skip apt update
+          $APT_INSTALL || { sudo apt update && $APT_INSTALL ; }
       - name: update linuxkit cache if available
         uses: actions/cache@v3
         with:
@@ -47,7 +56,7 @@ jobs:
           key: linuxkit-${{ matrix.arch }}-${{ github.sha }}
       - name: Build packages
         run: |
-          make V=1 PRUNE=1 pkgs
+          make V=1 PRUNE=1 ZARCH=${{ matrix.arch }} pkgs
       - name: Post package report
         run: |
           echo Disk usage
@@ -65,6 +74,9 @@ jobs:
       matrix:
         arch: [arm64, amd64]
         hv: [xen, kvm]
+        include:
+          - arch: riscv64
+            hv: mini
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -30,7 +30,8 @@ jobs:
           find . -name '*.tar' -exec docker load --input {} \;
           docker image push --all-tags evebuild/danger
 
-          IMGS=$(docker images --format "{{.Repository}}:{{.Tag}}" evebuild/danger | sed -r 's/.{6}$//' | sort -u)
+          # no manifest for riscv64 for now
+          IMGS=$(docker images --format "{{.Repository}}:{{.Tag}}" evebuild/danger | grep -v 'riscv64$' | sed -r 's/.{6}$//' | sort -u)
           for i in ${IMGS}; do
             docker manifest create "$i" --amend "$i-arm64" --amend "$i-amd64"
             docker manifest push "$i"


### PR DESCRIPTION
Let's expand build workflow to have riscv64 build and publish riscv64 
evebuild/danger image.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>