### PR TITLE
Periodically perform at least local checks for all uplink interfaces

### DIFF
--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -1054,7 +1054,7 @@ func myGet(ctx *diagContext, reqURL string, ifname string,
 	const allowProxy = true
 	// No verification of AuthContainer for this GET
 	resp, contents, senderStatus, err := zedcloud.SendOnIntf(context.Background(), zedcloudCtx,
-		reqURL, ifname, 0, nil, allowProxy, ctx.usingOnboardCert)
+		reqURL, ifname, 0, nil, allowProxy, ctx.usingOnboardCert, false)
 	if err != nil {
 		switch senderStatus {
 		case types.SenderStatusUpgrade:
@@ -1118,7 +1118,7 @@ func myPost(ctx *diagContext, reqURL string, ifname string,
 	}
 	const allowProxy = true
 	resp, contents, senderStatus, err := zedcloud.SendOnIntf(context.Background(), zedcloudCtx,
-		reqURL, ifname, reqlen, b, allowProxy, ctx.usingOnboardCert)
+		reqURL, ifname, reqlen, b, allowProxy, ctx.usingOnboardCert, false)
 	if err != nil {
 		switch senderStatus {
 		case types.SenderStatusUpgrade:

--- a/pkg/pillar/cmd/zedrouter/probe.go
+++ b/pkg/pillar/cmd/zedrouter/probe.go
@@ -399,7 +399,9 @@ func launchHostProbe(ctx *zedrouterContext) {
 						const allowProxy = true
 						const useOnboard = false
 						// No verification of AuthContainer in this reachability probe
-						resp, _, _, err := zedcloud.SendOnIntf(context.Background(), &zcloudCtx, remoteURL, info.IfName, 0, nil, allowProxy, useOnboard)
+						resp, _, _, err := zedcloud.SendOnIntf(
+							context.Background(), &zcloudCtx, remoteURL, info.IfName,
+							0, nil, allowProxy, useOnboard, false)
 						if err != nil {
 							log.Tracef("launchHostProbe: send on intf %s, err %v\n", info.IfName, err)
 						}

--- a/pkg/pillar/devicenetwork/wpad.go
+++ b/pkg/pillar/devicenetwork/wpad.go
@@ -102,8 +102,9 @@ func getPacFile(log *base.LogObject, url string,
 	// Avoid using a proxy to fetch the wpad.dat; 15 second timeout
 	const allowProxy = false
 	const useOnboard = false
-	resp, contents, _, err := zedcloud.SendOnIntf(context.Background(), &zedcloudCtx, url, ifname, 0, nil,
-		allowProxy, useOnboard)
+	resp, contents, _, err := zedcloud.SendOnIntf(
+		context.Background(), &zedcloudCtx, url, ifname, 0, nil,
+		allowProxy, useOnboard, false)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/pillar/dpcmanager/dns.go
+++ b/pkg/pillar/dpcmanager/dns.go
@@ -43,7 +43,7 @@ func (m *DpcManager) updateDNS() {
 	m.deviceNetStatus.Testing = m.dpcVerify.inProgress
 	m.deviceNetStatus.CurrentIndex = m.dpcList.CurrentIndex
 	m.deviceNetStatus.RadioSilence = m.radioSilence
-	oldPorts := m.deviceNetStatus.Ports
+	oldDNS := m.deviceNetStatus
 	m.deviceNetStatus.Ports = make([]types.NetworkPortStatus, len(dpc.Ports))
 	for ix, port := range dpc.Ports {
 		m.deviceNetStatus.Ports[ix].IfName = port.IfName
@@ -161,7 +161,7 @@ func (m *DpcManager) updateDNS() {
 		for addrIdx := range port.AddrInfoList {
 			// Need pointer since we are going to modify
 			ai := &port.AddrInfoList[addrIdx]
-			oai := lookupPortStatusAddr(oldPorts, port.IfName, ai.Addr)
+			oai := oldDNS.GetPortAddrInfo(port.IfName, ai.Addr)
 			if oai == nil {
 				continue
 			}
@@ -266,22 +266,6 @@ func (m *DpcManager) getDNSInfo(port *types.NetworkPortStatus) error {
 	// XXX just pick first since have one DomainName slot
 	if len(dnsInfo.Domains) > 0 {
 		port.DomainName = dnsInfo.Domains[0]
-	}
-	return nil
-}
-
-func lookupPortStatusAddr(ports []types.NetworkPortStatus,
-	ifname string, addr net.IP) *types.AddrInfo {
-
-	for _, port := range ports {
-		if port.IfName != ifname {
-			continue
-		}
-		for _, ai := range port.AddrInfoList {
-			if ai.Addr.Equal(addr) {
-				return &ai
-			}
-		}
 	}
 	return nil
 }

--- a/pkg/pillar/types/zedroutertypes_test.go
+++ b/pkg/pillar/types/zedroutertypes_test.go
@@ -433,11 +433,13 @@ func TestGetPortCostList(t *testing.T) {
 	}
 }
 
+// TestGetMgmtPortsSortedCost covers both GetMgmtPortsSortedCost and GetAllPortsSortedCost.
 func TestGetMgmtPortsSortedCost(t *testing.T) {
 	testMatrix := map[string]struct {
 		deviceNetworkStatus DeviceNetworkStatus
 		rotate              int
-		expectedValue       []string
+		expectedMgmtValue   []string
+		expectedAllValue    []string
 	}{
 		"Test single": {
 			deviceNetworkStatus: DeviceNetworkStatus{
@@ -448,7 +450,8 @@ func TestGetMgmtPortsSortedCost(t *testing.T) {
 						Cost:   0},
 				},
 			},
-			expectedValue: []string{"port1"},
+			expectedMgmtValue: []string{"port1"},
+			expectedAllValue:  []string{"port1"},
 		},
 		"Test single rotate": {
 			deviceNetworkStatus: DeviceNetworkStatus{
@@ -459,12 +462,14 @@ func TestGetMgmtPortsSortedCost(t *testing.T) {
 						Cost:   0},
 				},
 			},
-			rotate:        14,
-			expectedValue: []string{"port1"},
+			rotate:            14,
+			expectedMgmtValue: []string{"port1"},
+			expectedAllValue:  []string{"port1"},
 		},
 		"Test empty": {
 			deviceNetworkStatus: DeviceNetworkStatus{},
-			expectedValue:       []string{},
+			expectedMgmtValue:   []string{},
+			expectedAllValue:    []string{},
 		},
 		"Test no management": {
 			deviceNetworkStatus: DeviceNetworkStatus{
@@ -475,8 +480,9 @@ func TestGetMgmtPortsSortedCost(t *testing.T) {
 						Cost:   0},
 				},
 			},
-			rotate:        14,
-			expectedValue: []string{},
+			rotate:            14,
+			expectedMgmtValue: []string{},
+			expectedAllValue:  []string{"port1"},
 		},
 		"Test duplicates": {
 			deviceNetworkStatus: DeviceNetworkStatus{
@@ -496,7 +502,8 @@ func TestGetMgmtPortsSortedCost(t *testing.T) {
 						Cost:   1},
 				},
 			},
-			expectedValue: []string{"port2", "port4", "port1", "port3"},
+			expectedMgmtValue: []string{"port2", "port4", "port1", "port3"},
+			expectedAllValue:  []string{"port2", "port4", "port1", "port3"},
 		},
 		"Test duplicates rotate": {
 			deviceNetworkStatus: DeviceNetworkStatus{
@@ -516,8 +523,9 @@ func TestGetMgmtPortsSortedCost(t *testing.T) {
 						Cost:   1},
 				},
 			},
-			rotate:        1,
-			expectedValue: []string{"port4", "port2", "port3", "port1"},
+			rotate:            1,
+			expectedMgmtValue: []string{"port4", "port2", "port3", "port1"},
+			expectedAllValue:  []string{"port4", "port2", "port3", "port1"},
 		},
 		"Test duplicates some management": {
 			deviceNetworkStatus: DeviceNetworkStatus{
@@ -537,7 +545,8 @@ func TestGetMgmtPortsSortedCost(t *testing.T) {
 						Cost:   1},
 				},
 			},
-			expectedValue: []string{"port4", "port3"},
+			expectedMgmtValue: []string{"port4", "port3"},
+			expectedAllValue:  []string{"port2", "port4", "port1", "port3"},
 		},
 		"Test reverse": {
 			deviceNetworkStatus: DeviceNetworkStatus{
@@ -554,7 +563,8 @@ func TestGetMgmtPortsSortedCost(t *testing.T) {
 						Cost:   0},
 				},
 			},
-			expectedValue: []string{"port3", "port2", "port1"},
+			expectedMgmtValue: []string{"port3", "port2", "port1"},
+			expectedAllValue:  []string{"port3", "port2", "port1"},
 		},
 		"Test reverse some management": {
 			deviceNetworkStatus: DeviceNetworkStatus{
@@ -571,13 +581,16 @@ func TestGetMgmtPortsSortedCost(t *testing.T) {
 						Cost:   0},
 				},
 			},
-			expectedValue: []string{"port3", "port1"},
+			expectedMgmtValue: []string{"port3", "port1"},
+			expectedAllValue:  []string{"port3", "port2", "port1"},
 		},
 	}
 	for testname, test := range testMatrix {
 		t.Logf("Running test case %s", testname)
 		value := GetMgmtPortsSortedCost(test.deviceNetworkStatus, test.rotate)
-		assert.Equal(t, test.expectedValue, value)
+		assert.Equal(t, test.expectedMgmtValue, value)
+		value = GetAllPortsSortedCost(test.deviceNetworkStatus, test.rotate)
+		assert.Equal(t, test.expectedAllValue, value)
 	}
 }
 


### PR DESCRIPTION
When device has multiple interfaces, the connectivity testing, as
currently implemented, stops as soon as it finds one working uplink
interface. However, this means that some interfaces may not get retested
for a long time, potentially having some old (and now obsolete) error
still reported.

This is often the case when device has eth0 + wwan0 for management.
After a device boot, it may take a while for eth0 to get an IP address
from DHCP and during that time wwan0 will be tested (because eth0 is not
yet providing controller connectivity). But wwan0 can also spend some
time registering and connecting into a cellular network (likely more
than eth0 needs to get an IP address), producing intermittent testing
failures as a result.

For ethernet interface the failure is removed from the port status as
soon as it gets an IP address. It has zero cost so it will be retested
periodically. However, once eth0 starts working, wwan0 is no longer
being tested and may end up having a (potentially obsolete) error
reported indefinitely (or as long as eth0 is working).

Another possible scenario when this can be a problem, is when a EVE
user is troubleshooting LTE connectivity while using eth0 for management
at the same time. The user might not realize that wwan0 is not being
retested at that time, hence any changes made by the user (like
adding/replacing antennas or moving device to another location) will not
have any impact on the reported port status.

We can think of more such scenarious where this is an issue, for example
with multiple ethernet interfaces. Lower priority ones (even if
effectively free) might not be tested for a long time and have a false
negative or false positive information reported.

Simply put, the user is not getting a real-time feedback about fixed
(or broken) connectivity for lower-priority uplink interfaces and may get
confused by an obsolete reported status.

The challenge is that we want to limit the amount of traffic sent or
received via non-free interfaces. The idea of this commit is to change
the connectivity testing algorithm such that all interfaces are at
least verified using local-only checks - i.e. tests that do not involve
sending or receiving any traffic. For example:
 * Does interface (i.e. link) exist in the kernel?
 * Does interface have a routable IP address?
 * Is there any DNS server associated with the interface?
 * If there is a proxy config, is it valid?

Additionally, for wwan we already run (quite low cost) connectivity
probing and we could use the status determined using that here as well.
As part of this commit, the reported probing error was enhanced to
include all detected issues (not responding proxy and/or DNS server, etc.)


Signed-off-by: Milan Lenco <milan@zededa.com>