### PR TITLE
Fix volume info resources publishing

### DIFF
--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -1552,13 +1552,14 @@ func initPostOnboardSubs(zedagentCtx *zedagentContext) {
 	}
 
 	zedagentCtx.subAppDiskMetric, err = ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName:   "volumemgr",
-		MyAgentName: agentName,
-		TopicImpl:   types.AppDiskMetric{},
-		Activate:    true,
-		Ctx:         zedagentCtx,
-		WarningTime: warningTime,
-		ErrorTime:   errorTime,
+		AgentName:     "volumemgr",
+		MyAgentName:   agentName,
+		TopicImpl:     types.AppDiskMetric{},
+		Activate:      true,
+		Ctx:           zedagentCtx,
+		CreateHandler: handleAppDiskMetricCreate,
+		WarningTime:   warningTime,
+		ErrorTime:     errorTime,
 	})
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
We use information from AppDiskMetric subscription to fill resources field in VolumeInfo. But the data come in async, we should explicitly publish VolumeInfo in case of AppDiskMetric created after VolumeState.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>