### PR TITLE
Adding TPM support to U-boot for RPi4

### DIFF
--- a/pkg/u-boot/patches/patches-v2022.10/0003-add-TPM-support-to-the-config-for-rpi4.patch
+++ b/pkg/u-boot/patches/patches-v2022.10/0003-add-TPM-support-to-the-config-for-rpi4.patch
@@ -1,0 +1,28 @@
+From 5a6603ad90b622207f1421f4a46aa3c96d61f6b8 Mon Sep 17 00:00:00 2001
+From: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>
+Date: Sun, 30 Oct 2022 18:20:19 -0100
+Subject: [PATCH] add TPM support to the config for rpi4
+
+Signed-off-by: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>
+---
+ configs/rpi_4_defconfig | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/configs/rpi_4_defconfig b/configs/rpi_4_defconfig
+index 1163750558..50adbe9fa2 100644
+--- a/configs/rpi_4_defconfig
++++ b/configs/rpi_4_defconfig
+@@ -65,3 +65,10 @@ CONFIG_VIDEO_BCM2835=y
+ CONFIG_CONSOLE_SCROLL_LINES=10
+ CONFIG_PHYS_TO_BUS=y
+ CONFIG_OF_LIBFDT_OVERLAY=y
++CONFIG_SPI=y
++CONFIG_DM_SPI=y
++CONFIG_SOFT_SPI=y
++CONFIG_TPM=y
++CONFIG_TPM_V2=y
++CONFIG_TPM2_TIS_SPI=y
++CONFIG_CMD_TPM=y
+-- 
+2.25.1
+

--- a/pkg/u-boot/rpi/config.txt
+++ b/pkg/u-boot/rpi/config.txt
@@ -24,6 +24,13 @@ enable_uart=1
 # this overlay overwrites the SMBIOS information.
 #dtoverlay=raspberrypi-uno-220
 
+# This overlay adds support for the slb9670 tpm module to uboot
+# Some boards can have different ce(address), we can set ce by param,
+# for most popular TPM modules that based on slb9670 we use default ce param value (0x01),
+# but for advantech uno-220 we need to set ce to 0x00
+# https://github.com/Advantech-IIoT/UNO-220-POE-/tree/master/srcs/dtbo/tpm#notes
+dtoverlay=bcm2711-spi-tpm-slb9670,ce=0x01
+
 # Disable warning overlays as they don't work well together with linux's graphical output
 avoid_warnings=1
 

--- a/pkg/u-boot/rpi/overlays/bcm2711-spi-tpm-slb9670.dts
+++ b/pkg/u-boot/rpi/overlays/bcm2711-spi-tpm-slb9670.dts
@@ -1,0 +1,54 @@
+/*
+ * Device Tree overlay for the Infineon SLB9670 Trusted Platform Module add-on
+ * boards, which can be used as a secure key storage and hwrng.
+ * available as "Iridium SLB9670" by Infineon and "LetsTrust TPM" by pi3g.
+ */
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2711";
+	fragment@0 {
+		target = <&spi>;
+		__overlay__ {
+			compatible = "brcm,bcm2835-spi", "spi-gpio";
+			pinctrl-names = "default";
+			pinctrl-0 = <&spi0_pins &spi0_cs_pins>;
+			gpio-sck = <&gpio 11 0>;
+			gpio-mosi = <&gpio 10 0>;
+			gpio-miso = <&gpio 9 0>;
+			cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
+			spi-delay-us = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			slb9670: slb9670@1 {
+				compatible = "infineon,slb9670", "tis,tpm2-spi", "tcg,tpm_tis-spi";
+				reg = <1>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				spi-max-frequency = <32000000>;
+				status = "okay";
+			};
+		};
+	};
+	__overrides__ {
+		ce = <&slb9670>,"reg:0";
+	};
+
+	fragment@1 {
+		target = <&gpio>;
+		__overlay__ {
+			spi0_pins: spi0_pins {
+				brcm,pins = <9 10 11>;
+				brcm,function = <4>;
+			};
+
+			spi0_cs_pins: spi0_cs_pins {
+				brcm,pins = <8 7>;
+				brcm,function = <1>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
Add TPM slb9670 module support to U-boot for RPi4 via overlay.