### PR TITLE
Fix PAC file retrieval

### DIFF
--- a/pkg/pillar/conntester/zedcloud.go
+++ b/pkg/pillar/conntester/zedcloud.go
@@ -91,9 +91,9 @@ func (t *ZedcloudConnectivityTester) TestConnectivity(
 	}
 	zedcloudCtx.TlsConfig = tlsConfig
 	for ix := range dns.Ports {
-		err = devicenetwork.CheckAndGetNetworkProxy(t.Log, &dns.Ports[ix], t.Metrics)
+		ifName := dns.Ports[ix].IfName
+		err = devicenetwork.CheckAndGetNetworkProxy(t.Log, &dns, ifName, t.Metrics)
 		if err != nil {
-			ifName := dns.Ports[ix].IfName
 			err = fmt.Errorf("failed to get network proxy for interface %s: %v",
 				ifName, err)
 			t.Log.Errorf("TestConnectivity: %v", err)

--- a/pkg/pillar/dpcmanager/dns.go
+++ b/pkg/pillar/dpcmanager/dns.go
@@ -133,7 +133,7 @@ func (m *DpcManager) updateDNS() {
 		// We always redo this since we don't know what has changed
 		// from the previous DeviceNetworkStatus.
 		err = devicenetwork.CheckAndGetNetworkProxy(
-			m.Log, &m.deviceNetStatus.Ports[ix], m.ZedcloudMetrics)
+			m.Log, &m.deviceNetStatus, port.IfName, m.ZedcloudMetrics)
 		if err != nil {
 			err = fmt.Errorf("updateDNS: CheckAndGetNetworkProxy failed for %s: %v",
 				port.IfName, err)

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -1414,9 +1414,9 @@ func EqualSubnet(subnet1, subnet2 net.IPNet) bool {
 // GetPortByIfName - Get Port Status for port with given Ifname
 func (status *DeviceNetworkStatus) GetPortByIfName(
 	ifname string) *NetworkPortStatus {
-	for _, portStatus := range status.Ports {
-		if portStatus.IfName == ifname {
-			return &portStatus
+	for i := range status.Ports {
+		if status.Ports[i].IfName == ifname {
+			return &status.Ports[i]
 		}
 	}
 	return nil
@@ -1425,9 +1425,9 @@ func (status *DeviceNetworkStatus) GetPortByIfName(
 // GetPortByLogicallabel - Get Port Status for port with given label
 func (status *DeviceNetworkStatus) GetPortByLogicallabel(
 	label string) *NetworkPortStatus {
-	for _, portStatus := range status.Ports {
-		if portStatus.Logicallabel == label {
-			return &portStatus
+	for i := range status.Ports {
+		if status.Ports[i].Logicallabel == label {
+			return &status.Ports[i]
 		}
 	}
 	return nil


### PR DESCRIPTION
`getPacFile` calls `SendOnIntf` which requires zedcloud context with `DeviceNetworkStatus` included, otherwise it panics.

Additionally, `NetworkPortStatus` getters for `DeviceNetworkStatus` would return pointer to a copy, not to the original, which is also fixed by this commit.

Btw. PR to allow to test proxy auto-discovery with eden: https://github.com/lf-edge/eden/pull/818

Signed-off-by: Milan Lenco <milan@zededa.com>