### PR TITLE
[WIP] Add Podman support for building a bootable image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ endif
 
 DOCKER_GO = _() { $(SET_X); mkdir -p $(CURDIR)/.go/src/$${3:-dummy} ; mkdir -p $(CURDIR)/.go/bin ; \
     docker_go_line="docker run $$DOCKER_GO_ARGS -i --rm -u $(USER) -w /go/src/$${3:-dummy} \
-    -v $(CURDIR)/.go:/go -v $$2:/go/src/$${3:-dummy} -v $${4:-$(CURDIR)/.go/bin}:/go/bin -v $(CURDIR)/:/eve -v $${HOME}:/home/$(USER) \
+    -v $(CURDIR)/.go:/go -v $$2:/go/src/$${3:-dummy} -v $${4:-$(CURDIR)/.go/bin}:/go/bin:Z -v $(CURDIR)/:/eve -v $${HOME}:/home/$(USER) \
     -e GOOS -e GOARCH -e CGO_ENABLED -e BUILD=local $(GOBUILDER) bash --noprofile --norc -c" ; \
     verbose=$(V) ;\
     verbose=$${verbose:-0} ;\

--- a/build-tools/src/scripts/Dockerfile
+++ b/build-tools/src/scripts/Dockerfile
@@ -28,3 +28,4 @@ RUN mv /go/bin/* /usr/bin
 ENV HOME /home/${USER}
 ENV GOFLAGS=-mod=vendor
 ENV GO111MODULE=on
+ENV GOCACHE=/tmp

--- a/build-tools/src/scripts/Dockerfile
+++ b/build-tools/src/scripts/Dockerfile
@@ -1,5 +1,5 @@
 ARG GOVER=1.18.5
-FROM golang:${GOVER}-alpine
+FROM docker.io/golang:${GOVER}-alpine
 ARG USER
 ARG GROUP
 ARG UID


### PR DESCRIPTION

Podman has some differences compared to the vanilla Docker. Even though Podman is advertised as Docker compatible there are some differences especially, when being run in SELinux environments. Problems are mostly caused by file permissions of mounted volumes. Podman also requires a TTY when short container names are used. TTY requirement causes an error being run via make. This PR attempts to fix  those problems.

At current state of this PR `$ make build tools` succeeds. The next step `$ make live` fails with multiple permission errors. These are most likely caused by Podman not being able to mount the `/dev` directory.

```
dev/null: Can't create 'dev/null': Operation not permitted
dev/random: Can't create 'dev/random': Operation not permitted
dev/urandom: Can't create 'dev/urandom': Operation not permitted
dev/zero: Can't create 'dev/zero': Operation not permitted
```

Note that you will also need atleast 4.3.0 version of Podman to run `$ make live`. On Fedora you can install it with:

```
$ sudo dnf update --refresh --enablerepo=updates-testing podman
```

If something seems really off it is just my lack of deeper understanding  of EVE at this point. Each commit message has an explanation why the change was done.
