### PR TITLE
Actions based on Node.js 12 deprecated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Clear repository
         run: |
           sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: ensure zstd for cache  # this should be removed once the arm64 VM includes zstd
@@ -78,7 +78,7 @@ jobs:
           - arch: riscv64
             hv: mini
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: update linuxkit cache for runner arch so we can get desired images
@@ -135,7 +135,7 @@ jobs:
         run: |
           make cache-export ZARCH=${{ matrix.arch }} IMAGE=lfedge/eve:$VERSION-${{ matrix.hv }} OUTFILE=eve-${{ matrix.hv }}-${{ matrix.arch }}.tar IMAGE_NAME=$TAG-${{ matrix.hv }}-${{ matrix.arch }}
       - name: Upload EVE ${{ matrix.hv }}-${{ matrix.arch }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: eve-${{ matrix.hv }}-${{ matrix.arch }}
           path: eve-${{ matrix.hv }}-${{ matrix.arch }}.tar

--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -39,7 +39,7 @@ jobs:
           sudo add-apt-repository ppa:stefanberger/swtpm-jammy
           sudo apt install -y qemu-utils qemu-system-x86 jq swtpm
       - name: get eve
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: 'eve'
       - name: prepare eden
@@ -140,7 +140,7 @@ jobs:
           echo "::endgroup::"
       - name: Store raw test results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: eden-report-tpm-${{ matrix.tpm }}-${{ matrix.fs }}
           path: |

--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -82,13 +82,13 @@ jobs:
           sudo apt install -y qemu binfmt-support qemu-user-static qemu-system-x86 qemu-system-aarch64 qemu-utils openvpn curl jq
       - name: GCP Set up Google Cloud SDK
         if: matrix.backend == 'gcp'
-        uses: google-github-actions/setup-gcloud@v0.5.0
+        uses: google-github-actions/setup-gcloud@v0.6.3
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
       - id: 'gcpauth'
         if: matrix.backend == 'gcp'
         name: GCP Auth to Google Cloud SDK
-        uses: google-github-actions/auth@v0.4.1
+        uses: google-github-actions/auth@v0.8.3
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           credentials_json: ${{ secrets.GCP_SA_KEY }}
@@ -278,7 +278,7 @@ jobs:
           ROL_PROJECT: ${{ secrets.ROL_PROJECT }}
       - name: Store raw test results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: eden-report-${{ matrix.backend }}-${{ matrix.hv }}-${{ matrix.fs }}
           path: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
           df -h
           echo Memory
           free -m
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -108,7 +108,7 @@ jobs:
           - arch: riscv64
             hv: mini
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Login to DockerHUB
@@ -160,7 +160,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: packages
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Login to DockerHUB

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -24,7 +24,7 @@ jobs:
           test-results: dist/amd64/results.json
       - name: Store raw test results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: 'test-report'
           path: ${{ github.workspace }}/dist

--- a/.github/workflows/yetus.yml
+++ b/.github/workflows/yetus.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: src
           fetch-depth: 0
@@ -36,7 +36,7 @@ jobs:
 
       - name: Store Yetus artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: 'yetus-scan'
           path: ${{ github.workspace }}/out


### PR DESCRIPTION
Most GitHub actions got the following notification:

"Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16:"

Signed-off-by: Ruslan Dautov <ruslan@zededa.com>