### PR TITLE
Workaround for github tags override

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-
+      - name: Force fetch annotated tags (workaround)
+        # Workaround for https://github.com/actions/checkout/issues/290
+        run: |
+          git fetch --force --tags
       - name: Determine architecture prefix and ref
         env:
           REF: ${{ github.ref }}
@@ -56,15 +59,6 @@ jobs:
              docker login -u "${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}" --password-stdin
       - name: Build packages
         run: |
-          # GH Actions convert our annotated tags into plain ones,
-          # so we need to convert it back (but only if it exists).
-          if [ -n "$(git tag)" ]; then
-             git config --global user.name "Edge Virtualization Engine"
-             git config --global user.email "eve@lfedge.org"
-             for t in $(git tag); do
-                git tag -a -m"Release $t" -f "$t" "$t"
-             done
-          fi
           # sadly, our build sometimes times out on network access
           # and running out of disk space: re-trying for 3 times
           for i in 1 2 3; do
@@ -111,6 +105,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Force fetch annotated tags (workaround)
+        # Workaround for https://github.com/actions/checkout/issues/290
+        run: |
+          git fetch --force --tags
       - name: Login to DockerHUB
         run: |
           echo "${{ secrets.RELEASE_DOCKERHUB_TOKEN }}" |\
@@ -163,6 +161,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Force fetch annotated tags (workaround)
+        # Workaround for https://github.com/actions/checkout/issues/290
+        run: |
+          git fetch --force --tags
       - name: Login to DockerHUB
         run: |
           echo "${{ secrets.RELEASE_DOCKERHUB_TOKEN }}" |\


### PR DESCRIPTION
I can see in publish workflow that we try to build `0.0.0-HEAD-eb72104a`
 version instead of expected 9.0.0. It seems it come from removal of
 annotated tags by github/checkout action.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>