### PR TITLE
Clear cache directory in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Clear repository
         run: |
           sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
+          rm -fr ~/.linuxkit
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0


### PR DESCRIPTION
We do not clean cache in our self-hosted runners: I can see [Warning](https://github.com/lf-edge/eve/actions/runs/3387572937/jobs/5628487487#step:17:3): Failed to save: Cache size of ~10630 MB (11146442317 B) is over the 10GB limit, not saving cache. With the [cleanup](https://github.com/lf-edge/eve/actions/runs/3388212659/jobs/5629920893#step:17:3) I see: Cache Size: ~1144 MB (1199220655 B)