### PR TITLE
Make lastresort DPC disabled by default

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -24,7 +24,7 @@
 | timer.port.testinterval | timer in seconds | 300 | retest the current port config |
 | timer.port.timeout | timer in seconds | 15 | time for each http/send |
 | timer.port.testbetterinterval | timer in seconds | 600 | test a higher prio port config |
-| network.fallback.any.eth | "enabled" or "disabled" | enabled (disabled if device was installed with [bootstrap config](CONFIG.md) included) | if no connectivity try any Ethernet, WiFi, or LTE |
+| network.fallback.any.eth | "enabled" or "disabled" | disabled (enabled forcefully during onboarding if no network config) | if no connectivity try any Ethernet, WiFi, or LTE with DHCP client |
 | network.download.max.cost | 0-255 | 0 | [max port cost for download](DEVICE-CONNECTIVITY.md) to avoid e.g., LTE ports |
 | debug.enable.usb | boolean | false | allow USB e.g. keyboards on device |
 | debug.enable.vga | boolean | false | allow VGA console on device |

--- a/pkg/pillar/.golangci.yml
+++ b/pkg/pillar/.golangci.yml
@@ -29,6 +29,7 @@ linters:
     - maligned          # Too opinionated on existing structs
     - nestif            # Too opinionated on existing code
     - exhaustruct       # Too opinionated on existing code
+    - nosnakecase       # Uppercase with underscores is in some cases used for enum values
 
 issues:
   max-issues-per-linter: 0

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -30,6 +30,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/hardware"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 	"github.com/lf-edge/eve/pkg/pillar/zedcloud"
 	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
@@ -186,15 +187,15 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 
 	log.Functionf("diag Run: Use V2 API %v", zedcloudCtx.V2API)
 
-	if fileExists(types.DeviceCertName) {
+	if fileutils.FileExists(log, types.DeviceCertName) {
 		// Load device cert
 		cert, err := zedcloud.GetClientCert()
 		if err != nil {
 			log.Fatal(err)
 		}
 		ctx.cert = &cert
-	} else if fileExists(types.OnboardCertName) &&
-		fileExists(types.OnboardKeyName) {
+	} else if fileutils.FileExists(log, types.OnboardCertName) &&
+		fileutils.FileExists(log, types.OnboardKeyName) {
 		cert, err := tls.LoadX509KeyPair(types.OnboardCertName,
 			types.OnboardKeyName)
 		if err != nil {
@@ -327,7 +328,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		if !ctx.forever && ctx.gotDNS && ctx.gotBC && ctx.gotDPCList {
 			break
 		}
-		if ctx.usingOnboardCert && fileExists(types.DeviceCertName) {
+		if ctx.usingOnboardCert && fileutils.FileExists(log, types.DeviceCertName) {
 			fmt.Fprintf(outfile, "WARNING: Switching from onboard to device cert\n")
 			// Load device cert
 			cert, err := zedcloud.GetClientCert()
@@ -350,11 +351,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		}
 	}
 	return 0
-}
-
-func fileExists(filename string) bool {
-	_, err := os.Stat(filename)
-	return err == nil
 }
 
 func handleLedBlinkCreate(ctxArg interface{}, key string,

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -9,7 +9,6 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -818,9 +817,7 @@ func (n *nim) ingestDevicePortConfig() {
 		dpcFiles = append(dpcFiles, dpcFile)
 	}
 	// Skip these legacy DPC json files if there is bootstrap config.
-	_, err = os.Stat(types.BootstrapConfFileName)
-	bootstrapExists := err == nil
-	if bootstrapExists && len(dpcFiles) > 0 {
+	if fileutils.FileExists(n.Log, types.BootstrapConfFileName) && len(dpcFiles) > 0 {
 		n.Log.Noticef("Not ingesting DPC jsons (%v) from config partition: "+
 			"bootstrap config is present", strings.Join(dpcFiles, ", "))
 		return

--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -538,7 +538,7 @@ func handleLastRebootReason(ctx *nodeagentContext) {
 		rebootTime = time.Now()
 		dateStr := rebootTime.Format(time.RFC3339Nano)
 		var reason string
-		if fileExists(firstbootFile) {
+		if fileutils.FileExists(log, firstbootFile) {
 			reason = fmt.Sprintf("NORMAL: First boot of device - at %s",
 				dateStr)
 			if bootReason == types.BootReasonNone {
@@ -570,7 +570,7 @@ func handleLastRebootReason(ctx *nodeagentContext) {
 		rebootStack = ""
 	}
 	// remove the first boot file, if it is present
-	if fileExists(firstbootFile) {
+	if fileutils.FileExists(log, firstbootFile) {
 		os.Remove(firstbootFile)
 	}
 
@@ -602,7 +602,7 @@ func handleLastRebootReason(ctx *nodeagentContext) {
 // send log from installation to the controller
 // and remove file after small timeout to not send them after reboot
 func handleInstallationLog(ctx *nodeagentContext) {
-	if fileExists(installLogSendReq) {
+	if fileutils.FileExists(log, installLogSendReq) {
 		f, err := os.Open(installLog)
 		if err != nil {
 			log.Errorf("cannot open installation log: %s", err)
@@ -657,11 +657,6 @@ func incrementRestartCounter() uint32 {
 		log.Errorf("incrementRestartCounter write: %s", err)
 	}
 	return restartCounter
-}
-
-func fileExists(filename string) bool {
-	_, err := os.Stat(filename)
-	return err == nil
 }
 
 // publish nodeagent status

--- a/pkg/pillar/cmd/tpmmgr/tpmmgr.go
+++ b/pkg/pillar/cmd/tpmmgr/tpmmgr.go
@@ -33,6 +33,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils"
+	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 )
@@ -588,7 +589,7 @@ func testEcdhAES() error {
 	}
 
 	isTpm := true
-	if !etpm.IsTpmEnabled() || etpm.FileExists(etpm.EcdhKeyFile) {
+	if !etpm.IsTpmEnabled() || fileutils.FileExists(log, etpm.EcdhKeyFile) {
 		isTpm = false
 	}
 
@@ -627,7 +628,7 @@ func testEncryptDecrypt() error {
 
 func createQuoteCert() error {
 	// certificate is already created
-	if etpm.FileExists(quoteCertFile) {
+	if fileutils.FileExists(log, quoteCertFile) {
 		return nil
 	}
 	// try TPM
@@ -644,7 +645,7 @@ func createQuoteCert() error {
 }
 
 func createEkCert() error {
-	if etpm.FileExists(EkCertFile) {
+	if fileutils.FileExists(log, EkCertFile) {
 		// certificate is already created
 		return nil
 	}
@@ -656,7 +657,7 @@ func createEkCert() error {
 
 func createEkCertOnTpm() error {
 	//Check if we already have the certificate
-	if !etpm.FileExists(EkCertFile) {
+	if !fileutils.FileExists(log, EkCertFile) {
 		//Cert is not present, generate new one
 		rw, err := tpm2.OpenTPM(etpm.TpmDevicePath)
 		if err != nil {
@@ -751,7 +752,7 @@ func createDeviceCertTemplate() *x509.Certificate {
 // the certificate is self-signed using the device private key
 func createDeviceCertOnTpm(pubkey crypto.PublicKey) error {
 	//Check if we already have the certificate
-	if etpm.FileExists(types.DeviceCertName) {
+	if fileutils.FileExists(log, types.DeviceCertName) {
 		return nil
 	}
 
@@ -910,7 +911,7 @@ func createEkTemplate(deviceCert x509.Certificate) x509.Certificate {
 
 func createQuoteCertOnTpm() error {
 	//Check if we already have the certificate
-	if !etpm.FileExists(quoteCertFile) {
+	if !fileutils.FileExists(log, quoteCertFile) {
 		//Cert is not present, generate new one
 		rw, err := tpm2.OpenTPM(etpm.TpmDevicePath)
 		if err != nil {
@@ -1086,7 +1087,7 @@ func getQuoteCert(certPath string) ([]byte, error) {
 
 func createEcdhCert() error {
 	// certificate is already created
-	if etpm.FileExists(ecdhCertFile) {
+	if fileutils.FileExists(log, ecdhCertFile) {
 		return nil
 	}
 	// try TPM
@@ -1104,7 +1105,7 @@ func createEcdhCert() error {
 
 func createEcdhCertOnTpm() error {
 	//Check if we already have the certificate
-	if !etpm.FileExists(ecdhCertFile) {
+	if !fileutils.FileExists(log, ecdhCertFile) {
 		//Cert is not present, generate new one
 		rw, err := tpm2.OpenTPM(etpm.TpmDevicePath)
 		if err != nil {
@@ -1295,7 +1296,7 @@ func getCertHash(cert []byte, hashAlgo types.CertHashType) ([]byte, error) {
 
 func publishEdgeNodeCertToController(ctx *tpmMgrContext, certFile string, certType types.CertType, isTpm bool, metaDataItems []types.CertMetaData) {
 	log.Functionf("publishEdgeNodeCertToController started")
-	if !etpm.FileExists(certFile) {
+	if !fileutils.FileExists(log, certFile) {
 		log.Errorf("publishEdgeNodeCertToController failed: no cert file of type: %v", certType)
 		return
 	}
@@ -1471,11 +1472,11 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 
 	// publish ECDH cert
 	publishEdgeNodeCertToController(&ctx, ecdhCertFile, types.CertTypeEcdhXchange,
-		etpm.IsTpmEnabled() && !etpm.FileExists(etpm.EcdhKeyFile), nil)
+		etpm.IsTpmEnabled() && !fileutils.FileExists(log, etpm.EcdhKeyFile), nil)
 
 	// publish attestation quote cert
 	publishEdgeNodeCertToController(&ctx, quoteCertFile, types.CertTypeRestrictSigning,
-		etpm.IsTpmEnabled() && !etpm.FileExists(quoteKeyFile), nil)
+		etpm.IsTpmEnabled() && !fileutils.FileExists(log, quoteKeyFile), nil)
 
 	ekCertMetaData, err := getEkCertMetaData()
 	if err == nil {
@@ -1497,7 +1498,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	}
 	log.Functionf("processed GlobalConfig")
 
-	if etpm.IsTpmEnabled() && !etpm.FileExists(etpm.TpmCredentialsFileName) {
+	if etpm.IsTpmEnabled() && !fileutils.FileExists(log, etpm.TpmCredentialsFileName) {
 		err := readCredentials()
 		if err != nil {
 			// this indicates that we are in a very bad state

--- a/pkg/pillar/cmd/upgradeconverter/applydefaultconfigitem.go
+++ b/pkg/pillar/cmd/upgradeconverter/applydefaultconfigitem.go
@@ -27,8 +27,8 @@ const (
 func applyDefaultConfigItem(ctxPtr *ucContext) error {
 	createConfigItemMapDir(ctxPtr.newConfigItemValueMapDir())
 	newConfigItemFile := ctxPtr.newConfigItemValueMapFile()
-	newExists := fileExists(newConfigItemFile)
-	bootstrapExists := fileExists(types.BootstrapConfFileName)
+	newExists := fileutils.FileExists(log, newConfigItemFile)
+	bootstrapExists := fileutils.FileExists(log, types.BootstrapConfFileName)
 
 	newConfigPtr := types.DefaultConfigItemValueMap()
 	if newExists {
@@ -83,10 +83,10 @@ func importFromConfigPartition(ctxPtr *ucContext) error {
 	var configSha, authorizedKeysSha []byte
 
 	persistStatusFile := ctxPtr.newConfigItemValueMapFile()
-	globalConfigExists := fileExists(importGlobalConfigFile)
-	persistedConfigExists := fileExists(persistStatusFile)
-	bootstrapExists := fileExists(types.BootstrapConfFileName)
-	authKeysExists := fileExists(baseAuthorizedKeysFile)
+	globalConfigExists := fileutils.FileExists(log, importGlobalConfigFile)
+	persistedConfigExists := fileutils.FileExists(log, persistStatusFile)
+	bootstrapExists := fileutils.FileExists(log, types.BootstrapConfFileName)
+	authKeysExists := fileutils.FileExists(log, baseAuthorizedKeysFile)
 
 	doImport := globalConfigExists
 
@@ -208,7 +208,7 @@ func parseFile(filename string) (*types.ConfigItemValueMap, error) {
 }
 
 func readAuthorizedKeys(filename string) (string, bool) {
-	if !fileExists(filename) {
+	if !fileutils.FileExists(log, filename) {
 		return "", false
 	}
 

--- a/pkg/pillar/cmd/upgradeconverter/convertglobalconfig.go
+++ b/pkg/pillar/cmd/upgradeconverter/convertglobalconfig.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 )
 
 func createConfigItemMapDir(configItemMapDir string) {
@@ -55,12 +56,12 @@ func delOldGlobalConfigDir(ctxPtr *ucContext) error {
 
 func convertGlobalConfig(ctxPtr *ucContext) error {
 	oldGlobalConfigFile := ctxPtr.globalConfigFile()
-	oldExists := fileExists(oldGlobalConfigFile)
+	oldExists := fileutils.FileExists(log, oldGlobalConfigFile)
 	if oldExists {
 		createConfigItemMapDir(ctxPtr.oldConfigItemValueMapDir())
 	}
 	newGlobalConfigFile := ctxPtr.oldConfigItemValueMapFile()
-	newExists := fileExists(newGlobalConfigFile)
+	newExists := fileutils.FileExists(log, newGlobalConfigFile)
 
 	var newConfigPtr *types.ConfigItemValueMap
 

--- a/pkg/pillar/cmd/upgradeconverter/moveconfigitem.go
+++ b/pkg/pillar/cmd/upgradeconverter/moveconfigitem.go
@@ -13,8 +13,8 @@ func moveConfigItemValueMap(ctxPtr *ucContext) error {
 	createConfigItemMapDir(ctxPtr.newConfigItemValueMapDir())
 	newFile := ctxPtr.newConfigItemValueMapFile()
 	oldFile := ctxPtr.oldConfigItemValueMapFile()
-	newExists := fileExists(newFile)
-	oldExists := fileExists(oldFile)
+	newExists := fileutils.FileExists(log, newFile)
+	oldExists := fileutils.FileExists(log, oldFile)
 
 	if oldExists {
 		if newExists {

--- a/pkg/pillar/cmd/upgradeconverter/persistlayout.go
+++ b/pkg/pillar/cmd/upgradeconverter/persistlayout.go
@@ -22,7 +22,7 @@ import (
 func convertPersistVolumes(ctxPtr *ucContext) error {
 	log.Functionf("convertPersistVolumes()")
 	checkpointFile := ctxPtr.configCheckpointFile()
-	if !fileExists(checkpointFile) {
+	if !fileutils.FileExists(log, checkpointFile) {
 		// This error always happens on first boot of a device.
 		// In that case there is nothing to convert.
 		errStr := fmt.Sprintf("No checkpoint file in %s", checkpointFile)
@@ -44,9 +44,9 @@ func convertPersistVolumes(ctxPtr *ucContext) error {
 	oldVMVolumesDir := ctxPtr.imgDir()
 	oldOCIVolumesDir := ctxPtr.preparedDir()
 	newVolumesDir := ctxPtr.volumesDir()
-	newExists := dirExists(newVolumesDir)
-	oldVMExists := dirExists(oldVMVolumesDir)
-	oldOCIExists := dirExists(oldOCIVolumesDir)
+	newExists := fileutils.DirExists(log, newVolumesDir)
+	oldVMExists := fileutils.DirExists(log, oldVMVolumesDir)
+	oldOCIExists := fileutils.DirExists(log, oldOCIVolumesDir)
 	if !newExists {
 		log.Functionf("Creating new %s", newVolumesDir)
 		if err := os.MkdirAll(newVolumesDir, 0700); err != nil {

--- a/pkg/pillar/cmd/upgradeconverter/upgradeconverter_test.go
+++ b/pkg/pillar/cmd/upgradeconverter/upgradeconverter_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub/socketdriver"
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -60,7 +61,7 @@ func newConfigItemValueMap() types.ConfigItemValueMap {
 func createJSONFile(config interface{}, file string) {
 
 	parentDir := filepath.Dir(file)
-	if !fileExists(parentDir) {
+	if !fileutils.DirExists(log, parentDir) {
 		err := os.MkdirAll(parentDir, 0700)
 		if err != nil {
 			log.Fatalf("Failed to create Dir: %s", parentDir)
@@ -97,7 +98,7 @@ func configItemValueMapFromFile(file string) *types.ConfigItemValueMap {
 }
 
 func checkNoDir(t *testing.T, dir string) {
-	if fileExists(dir) {
+	if fileutils.DirExists(log, dir) {
 		t.Fatalf("***Dir %s Still Present. Expected it to be deleted.", dir)
 	}
 }

--- a/pkg/pillar/cmd/upgradeconverter/upgradeconverterutils.go
+++ b/pkg/pillar/cmd/upgradeconverter/upgradeconverterutils.go
@@ -8,31 +8,6 @@ import (
 	"time"
 )
 
-func fileExists(filename string) bool {
-	_, err := os.Stat(filename)
-	if err == nil {
-		return true
-	}
-	if os.IsNotExist(err) {
-		return false
-	}
-	log.Errorf("***File %s May or May Not exist. Err: %s", filename, err)
-	return false
-}
-
-func dirExists(dirname string) bool {
-	fi, err := os.Stat(dirname)
-	if err == nil {
-		return fi.IsDir()
-	}
-	if os.IsNotExist(err) {
-		return false
-	}
-	log.Errorf("***Directory %s may or may not exist. Err: %s",
-		dirname, err)
-	return false
-}
-
 func fileTimeStamp(filename string) (time.Time, error) {
 	file, err := os.Stat(filename)
 	if err != nil {

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -193,14 +193,9 @@ const (
 // vlans, bonds, etc.).
 func maybeLoadBootstrapConfig(getconfigCtx *getconfigContext) {
 	//  Check if bootstrap config has been already loaded.
-	if _, err := os.Stat(types.BootstrapConfFileName); err != nil {
-		if os.IsNotExist(err) {
-			// No bootstrap config to read
-			return
-		}
-		// Potentially there is a problem reading bootstrap config,
-		// but continue and try anyway.
-		log.Errorf("Failed to stat bootstrap config: %v", err)
+	if !fileutils.FileExists(log, types.BootstrapConfFileName) {
+		// No bootstrap config to read
+		return
 	}
 	changed, configSha, err := fileutils.CompareSha(
 		types.BootstrapConfFileName, types.BootstrapShaFileName)

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -2317,22 +2317,6 @@ func parseConfigItems(ctx *getconfigContext, config *zconfig.EdgeDevConfig,
 		newGlobalConfig.SetGlobalValueBool(types.UsbAccess, false)
 		newGlobalConfig.SetGlobalValueBool(types.VgaAccess, false)
 	}
-	// Default value of NetworkFallbackAnyEth (aka lastresort network config)
-	// depends on how the device was installed. If a single-use EVE installer
-	// was used, the lastresort is by default disabled because the intended network
-	// configuration is available right from the first boot, even before onboarding.
-	// Still, it is possible to (explicitly) enable lastresort inside the bootstrap
-	// config even if it is not recommended (falling back to lastresort and marking
-	// all ethernet interfaces for management can create all sorts of problems).
-	// Without bootstrap config, device will by default enable lastresort at least until
-	// it onboards and obtains the intended config from the controller. This can be avoided
-	// by disabling lastresort and providing an alternative network configuration using
-	// (deprecated) override json files (global.json and override.json or usb.json).
-	_, err := os.Stat(types.BootstrapConfFileName)
-	bootstrapExists := err == nil
-	if bootstrapExists {
-		newGlobalConfig.SetGlobalValueTriState(types.NetworkFallbackAnyEth, types.TS_DISABLED)
-	}
 	newGlobalStatus := types.NewGlobalStatus()
 
 	for _, item := range items {

--- a/pkg/pillar/dpcmanager/dpc.go
+++ b/pkg/pillar/dpcmanager/dpc.go
@@ -265,8 +265,10 @@ func (m *DpcManager) ingestDPCList() (dpclPresentAtBoot bool) {
 	}
 	m.dpcList = dpcl
 	m.Log.Functionf("Sanitized DPCL %v", dpcl)
-	m.compressAndPublishDPCL()
 	m.dpcList.CurrentIndex = -1 // No known working one
+	// Publish without compressing - this early in the init sequence we do not know
+	// if lastresort is enabled. The list will be compressed later during DPC verification.
+	m.publishDPCL()
 	m.Log.Functionf("Published DPCL %v", m.dpcList)
 	m.Log.Functionf("IngestDPCList len %d", len(m.dpcList.PortConfigList))
 	return dpclPresentAtBoot
@@ -311,7 +313,7 @@ func (m *DpcManager) compressDPCL() {
 				m.Log.Tracef("compressDPCL: Retaining last resort. i = %d, dpc: %+v",
 					i, dpc)
 				newConfig = append(newConfig, dpc)
-				// last resort also found.. discard all remaining entries
+				continue
 			}
 			m.Log.Noticef("compressDPCL: Ignoring - i = %d, dpc: %+v", i, dpc)
 			// Update any ShaFile with Shavalue

--- a/pkg/pillar/dpcmanager/dpc.go
+++ b/pkg/pillar/dpcmanager/dpc.go
@@ -320,7 +320,6 @@ func (m *DpcManager) compressDPCL() {
 				if err != nil {
 					m.Log.Errorf("SaveShaInFile %s failed: %s", dpc.ShaFile, err)
 				} else {
-
 					m.Log.Noticef("Updated %s for %d", dpc.ShaFile, i)
 				}
 			}

--- a/pkg/pillar/dpcmanager/dpcmanager_test.go
+++ b/pkg/pillar/dpcmanager/dpcmanager_test.go
@@ -310,6 +310,12 @@ func globalConfig() types.ConfigItemValueMap {
 	return *gcp
 }
 
+func globalConfigWithLastresort() types.ConfigItemValueMap {
+	gcp := globalConfig()
+	gcp.SetGlobalValueTriState(types.NetworkFallbackAnyEth, types.TS_ENABLED)
+	return gcp
+}
+
 func mockEth0() netmonitor.MockInterface {
 	eth0 := netmonitor.MockInterface{
 		Attrs: netmonitor.IfAttrs{
@@ -762,7 +768,7 @@ func TestDPCFallback(test *testing.T) {
 	networkMonitor.AddOrUpdateInterface(eth0)
 
 	// Apply global config first.
-	dpcManager.UpdateGCP(globalConfig())
+	dpcManager.UpdateGCP(globalConfigWithLastresort())
 
 	// Apply "lastresort" DPC with single ethernet port.
 	aa := makeAA(selectedIntfs{eth0: true})
@@ -898,7 +904,7 @@ func TestDPCWithMultipleEths(test *testing.T) {
 		errors.New("failed to connect over eth1"))
 
 	// Apply global config first.
-	dpcManager.UpdateGCP(globalConfig())
+	dpcManager.UpdateGCP(globalConfigWithLastresort())
 
 	// Apply last-resort DPC with two ethernet ports.
 	aa := makeAA(selectedIntfs{eth0: true, eth1: true})
@@ -977,7 +983,7 @@ func TestDNS(test *testing.T) {
 		errors.New("failed to connect over eth1"))
 
 	// Apply global config first.
-	dpcManager.UpdateGCP(globalConfig())
+	dpcManager.UpdateGCP(globalConfigWithLastresort())
 
 	// Apply last-resort DPC with two ethernet ports.
 	aa := makeAA(selectedIntfs{eth0: true, eth1: true})
@@ -1407,7 +1413,7 @@ func TestDeleteDPC(test *testing.T) {
 	dpcManager.UpdateAA(aa)
 
 	// Apply global config.
-	dpcManager.UpdateGCP(globalConfig())
+	dpcManager.UpdateGCP(globalConfigWithLastresort())
 
 	// Apply "lastresort" DPC.
 	timePrio1 := time.Time{}

--- a/pkg/pillar/evetpm/tpm.go
+++ b/pkg/pillar/evetpm/tpm.go
@@ -23,6 +23,7 @@ import (
 	"github.com/lf-edge/eve/api/go/info"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 )
 
 const (
@@ -212,16 +213,11 @@ func TpmSign(digest []byte) (*big.Int, *big.Int, error) {
 	return sig.ECC.R, sig.ECC.S, nil
 }
 
-//FileExists returns true if a file with name filename is found
-func FileExists(filename string) bool {
-	_, err := os.Stat(filename)
-	return err == nil
-}
-
 //IsTpmEnabled checks if TPM is being used by software for creating device cert
 // Note that this must not be called before the device certificate has been generated
 func IsTpmEnabled() bool {
-	return FileExists(types.DeviceCertName) && !FileExists(types.DeviceKeyName)
+	return fileutils.FileExists(nil, types.DeviceCertName) &&
+		!fileutils.FileExists(nil, types.DeviceKeyName)
 }
 
 //GetRandom returns a random []byte of requested length

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -782,7 +782,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddBoolItem(ProcessCloudInitMultiPart, false)
 
 	// Add TriState Items
-	configItemSpecMap.AddTriStateItem(NetworkFallbackAnyEth, TS_ENABLED)
+	configItemSpecMap.AddTriStateItem(NetworkFallbackAnyEth, TS_DISABLED)
 	configItemSpecMap.AddTriStateItem(MaintenanceMode, TS_NONE)
 
 	// Add String Items

--- a/pkg/pillar/utils/file/file.go
+++ b/pkg/pillar/utils/file/file.go
@@ -20,6 +20,37 @@ import (
 
 const maxCounterReadSize = 16384 // Max size of counter file
 
+// FileExists checks file existence.
+func FileExists(log *base.LogObject, filename string) bool {
+	_, err := os.Stat(filename)
+	if err == nil {
+		return true
+	}
+	if os.IsNotExist(err) {
+		return false
+	}
+	if log != nil {
+		log.Errorf("File %s may or may not exist. Err: %s", filename, err)
+	}
+	return false
+}
+
+// DirExists checks directory existence.
+func DirExists(log *base.LogObject, dirname string) bool {
+	fi, err := os.Stat(dirname)
+	if err == nil {
+		return fi.IsDir()
+	}
+	if os.IsNotExist(err) {
+		return false
+	}
+	if log != nil {
+		log.Errorf("Directory %s may or may not exist. Err: %s",
+			dirname, err)
+	}
+	return false
+}
+
 // DirSync flushes changes made to a directory.
 func DirSync(dirName string) error {
 	f, err := os.OpenFile(dirName, os.O_RDONLY, 0755)


### PR DESCRIPTION
"Last resort DPC" (pubsub key `lastresort`) is a device network config automatically generated by EVE, where all ethernet interfaces are marked for management and tried with DHCP client to obtain IP settings. The name suggests that this is something that EVE will try to use to establish controller connectivity if the user-submitted network config is not providing functional connectivity. Oftentimes, this is used as the only network config available for the device onboarding.

However, we have seen many customer issues where this lastresort actually caused more harm than good, especially when network outage is outside of the EVE control (external network goes down). Changing network configuration from the intended state to lastresort not only cannot help in such cases, but it can also have additional negative side effects, such as:

* prolonged outage: device will stay with lastresort if all available network configs are failing and it will only retest the latest intended config once per 10 minutes
* confusing logs and events - customer might get a wrong impression that outage was caused by EVE when it unwantedly changed applied config (customer will blame EVE instead of troubleshooting outside networks)
* break NIC pass-through - EVE will mark all ethernets for management which will prevent them from being assigned to apps (this can be triggered by a race between domainmgr deploying app and NIM falling back to lastresort at around the same time)

For the device onboarding it is possible to provide the initial network configuration either using the legacy override json file or by installing EVE using a single-use EVE installer with a bootstrap configuration baked in.

Given the above, the proposal is to make Last resort DPC _DISABLED_ by default.

However, there are still cases when using Last resort is actually quite convenient. With ethernet connectivity available, DHCP enabled and no obstacles in the way (like network proxies), it is rather convenient to be able to just install EVE (using the generic installer), plug the cables, power on the device and expect it to onboard without further work needed. This is often the case in lab/testing scenarios, but it is also relatively common in the production.

For these cases, we propose that NIM will forcefully, but only temporarily, use Last resort if there is _NO_ network configuration available whatsoever (incl. bootstrap, override, persisted DPCs). In such case, device could be just stuck with no connectivity indefinitely or until user plugs in a USB stick with network config. To keep things convenient and avoid making bootstrap/override a necessity in Ethernet+DHCP scenarios, NIM will use Last resort to connect to the controller. However, once it will get a proper device config (from controller or a USB stick), it will stop using Last resort forcefully (must be enabled explicitly in config to keep using it).

This commit also contains a small cleanup of `fileExists()` functions, which existed across the pillar packages in many incarnations. There should be only one implementation, residing inside the `pillar/utils` package.

Signed-off-by: Milan Lenco <milan@zededa.com>