### PR TITLE
Reduce GH cache usage by explicitly pull/build/skip packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,7 @@ jobs:
         run: |
           sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
           rm -fr ~/.linuxkit
+          docker system prune --all --force --volumes
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0


### PR DESCRIPTION
In order to reduce GH cache usage we can pull packages explicitly if
needed using novel `--pull` flag implemented by linuxkit. With unset of
--pull flag in we can skip pulling published images and not fill the
cache by them. This commit also adjusts the logic of cache export as we
need to skip not-pulled images there.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>