### PR TITLE
pkg/pillar: Run the CPU Pinning logic only in the KVM case.

### DIFF
--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -187,12 +187,15 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	log.Functionf("user containerd ready")
 
 	_, enabledHVs := hypervisor.GetAvailableHypervisors()
-	for _, el := range enabledHVs {
-		if el == hypervisor.KVMHypervisorName {
-			ctx.useVHost = true
-			break
-		}
+	hyper, err := hypervisor.GetHypervisor(enabledHVs[0])
+	if err != nil {
+		log.Fatal(err)
 	}
+	caps, err := hyper.GetCapabilities()
+	if err != nil {
+		log.Fatal(err)
+	}
+	ctx.useVHost = caps.UseVHost
 	log.Functionf("will use vhost: %t", ctx.useVHost)
 
 	if ctx.persistType == types.PersistZFS {

--- a/pkg/pillar/containerd/oci.go
+++ b/pkg/pillar/containerd/oci.go
@@ -318,7 +318,9 @@ func (s *ociSpec) UpdateFromDomain(dom *types.DomainConfig, status *types.Domain
 		s.Linux.Resources.Memory.Limit = &m
 		s.Linux.Resources.CPU.Period = &p
 		s.Linux.Resources.CPU.Quota = &q
-		s.Linux.Resources.CPU.Cpus = status.VmConfig.CPUs
+		if status.VmConfig.CPUs != "" {
+			s.Linux.Resources.CPU.Cpus = status.VmConfig.CPUs
+		}
 
 		s.Linux.CgroupsPath = fmt.Sprintf("/%s/%s", ctrdServicesNamespace, dom.GetTaskName())
 	}

--- a/pkg/pillar/hypervisor/containerd.go
+++ b/pkg/pillar/hypervisor/containerd.go
@@ -54,6 +54,8 @@ func (ctx ctrdContext) GetCapabilities() (*types.Capabilities, error) {
 	return &types.Capabilities{
 		HWAssistedVirtualization: false,
 		IOVirtualization:         false,
+		CPUPinning:               false,
+		UseVHost:                 false,
 	}, nil
 }
 

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -426,6 +426,8 @@ func (ctx kvmContext) GetCapabilities() (*types.Capabilities, error) {
 	ctx.capabilities = &types.Capabilities{
 		HWAssistedVirtualization: true,
 		IOVirtualization:         vtd,
+		CPUPinning:               true,
+		UseVHost:                 true,
 	}
 	return ctx.capabilities, nil
 }

--- a/pkg/pillar/hypervisor/null.go
+++ b/pkg/pillar/hypervisor/null.go
@@ -33,6 +33,8 @@ func (ctx nullContext) GetCapabilities() (*types.Capabilities, error) {
 	return &types.Capabilities{
 		HWAssistedVirtualization: false,
 		IOVirtualization:         false,
+		CPUPinning:               false,
+		UseVHost:                 false,
 	}, nil
 }
 

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -73,6 +73,8 @@ func (ctx xenContext) GetCapabilities() (*types.Capabilities, error) {
 	ctx.capabilities = &types.Capabilities{
 		HWAssistedVirtualization: vtx,
 		IOVirtualization:         vtd,
+		CPUPinning:               false,
+		UseVHost:                 false,
 	}
 	return ctx.capabilities, nil
 }

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -526,4 +526,6 @@ func (hm HostMemory) LogKey() string {
 type Capabilities struct {
 	HWAssistedVirtualization bool // VMX/SVM for amd64 or Arm virtualization extensions for arm64
 	IOVirtualization         bool // I/O Virtualization support
+	CPUPinning               bool // CPU Pinning support
+	UseVHost                 bool // vHost support
 }


### PR DESCRIPTION
The cgroups/cpuset setting makes sense only in the case of the KVM hypervisor, as it affects the VCPU threads. Do not run it for the other hypervisors.