### PR TITLE
split part of pillar to onboot

### DIFF
--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -37,6 +37,10 @@ onboot:
     image: KDUMP_TAG
   - name: measure-config
     image: MEASURE_CONFIG_TAG
+  # onboot part of pillar to prepare services to start
+  - name: pillar-onboot
+    image: PILLAR_TAG
+    command: ["/opt/zededa/bin/onboot.sh"]
 services:
   - name: newlogd
     image: NEWLOGD_TAG

--- a/pkg/pillar/Dockerfile
+++ b/pkg/pillar/Dockerfile
@@ -97,6 +97,7 @@ COPY --from=strongswan / /final
 # the default /config (since that is expected to be an empty mount point)
 ADD conf/root-certificate.pem conf/server conf/server.production /final/opt/zededa/examples/config/
 ADD scripts/device-steps.sh \
+    scripts/onboot.sh \
     scripts/handlezedserverconfig.sh \
     scripts/veth.sh \
     scripts/dhcpcd.sh \

--- a/pkg/pillar/agentlog/agentlog.go
+++ b/pkg/pillar/agentlog/agentlog.go
@@ -575,13 +575,12 @@ func spoofStdFDs(log *base.LogObject, agentName string) *os.File {
 		log.Fatalf("spoofStdFDs: Failed opening stdout file %s with err: %s", stdOutFile, err)
 	}
 
-	fd2, err := syscall.Dup(int(os.Stdout.Fd()))
+	fd2, err := syscall.Dup(syscall.Stdout)
 	if err != nil {
 		log.Fatalf("spoofStdFDs: Error duplicating Stdout: %s", err)
 	}
-	originalStdout, err := os.OpenFile(fmt.Sprintf("/dev/fd/%d", fd2),
-		os.O_WRONLY|os.O_CREATE|os.O_SYNC, 0755)
-	if err != nil {
+	originalStdout := os.NewFile(uintptr(fd2), "originalStdout")
+	if originalStdout == nil {
 		log.Fatalf("spoofStdFDs: Error opening duplicate stdout with fd: %v", fd2)
 	}
 	// replace stdout

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -8,27 +8,27 @@ WATCHDOG_FILE=/run/watchdog/file
 CONFIGDIR=/config
 CONFIGDIR_PERSIST=/tmp/config_persist
 PERSISTDIR=/persist
-PERSIST_CERTS=$PERSISTDIR/certs
 DEVICE_CERT_NAME="/config/device.cert.pem"
 DEVICE_KEY_NAME="/config/device.key.pem"
 TPM_CREDENTIAL="/config/tpm_credential"
 BOOTSTRAP_CONFIG="${CONFIGDIR}/bootstrap-config.pb"
-PERSIST_AGENT_DEBUG=$PERSISTDIR/agentdebug
 BINDIR=/opt/zededa/bin
-TMPDIR=/persist/tmp
+TMPDIR=$PERSISTDIR/tmp
 ZTMPDIR=/run/global
 DPCDIR=$ZTMPDIR/DevicePortConfig
 FIRSTBOOTFILE=$ZTMPDIR/first-boot
 FIRSTBOOT=
 AGENTS="diag zedagent ledmanager nim nodeagent domainmgr loguploader tpmmgr vaultmgr zedmanager zedrouter downloader verifier baseosmgr wstunnelclient volumemgr watcher zfsmanager"
 TPM_DEVICE_PATH="/dev/tpmrm0"
-SECURITYFSPATH=/sys/kernel/security
 PATH=$BINDIR:$PATH
 TPMINFOTEMPFILE=/var/tmp/tpminfo.txt
-DISKSPACE_RECOVERY_LIMIT=70
 
 echo "$(date -Ins -u) Starting device-steps.sh"
 echo "$(date -Ins -u) EVE version: $(cat /run/eve-release)"
+
+if [ -f "$FIRSTBOOTFILE" ]; then
+  FIRSTBOOT=1
+fi
 
 # For checking whether we have a Keyboard etc at startup
 in=$(cat /sys/class/input/input*/name)
@@ -105,158 +105,12 @@ get_ntp_server() {
     echo "$one"
 }
 
-mkdir -p $ZTMPDIR
-if [ -d $TMPDIR ]; then
-    echo "$(date -Ins -u) Old TMPDIR files:"
-    ls -lt $TMPDIR
-    rm -rf $TMPDIR
-fi
-mkdir -p $TMPDIR
-export TMPDIR
-
-if ! mount -t securityfs securityfs "$SECURITYFSPATH"; then
-    echo "$(date -Ins -u) mounting securityfs failed"
-fi
-
-DIRS="$PERSIST_CERTS $PERSIST_AGENT_DEBUG /persist/status/zedclient/OnboardingStatus"
-
-# If /persist/installer/first-boot exists treat this as a first boot
-# we rename file to not assume that it is the first boot if we reboot occasionally
-if [ -f "$PERSISTDIR/installer/first-boot" ]; then
-    mv "$PERSISTDIR/installer/first-boot" "$PERSISTDIR/installer/send-require"
-    touch $FIRSTBOOTFILE # For nodeagent
-    FIRSTBOOT=1
-fi
-
-# If /persist didn't exist or was removed treat this as a first boot
-if [ ! -d $PERSIST_CERTS ]; then
-    touch $FIRSTBOOTFILE # For nodeagent
-    FIRSTBOOT=1
-fi
-
-for d in $DIRS; do
-    d1=$(dirname "$d")
-    if [ ! -d "$d1" ]; then
-        echo "$(date -Ins -u) Create $d1"
-        mkdir -p "$d1"
-        chmod 700 "$d1"
-    fi
-    if [ ! -d "$d" ]; then
-        echo "$(date -Ins -u) Create $d"
-        mkdir -p "$d"
-        chmod 700 "$d"
-    fi
-done
-
-# Save any existing checkpoint directory for debugging
-rm -rf $PERSIST_AGENT_DEBUG/checkpoint
-if [ -d /persist/checkpoint ]; then
-    echo "$(date -Ins -u) Saving copy of /persist/checkpoint in /persist/agentdebug"
-    cp -rp /persist/checkpoint $PERSIST_AGENT_DEBUG/
-fi
-
-# Save any existing /persist/status directory for debugging
-rm -rf $PERSIST_AGENT_DEBUG/status
-if [ -d /persist/status ]; then
-    echo "$(date -Ins -u) Saving copy of /persist/status in /persist/agentdebug"
-    cp -rp /persist/status $PERSIST_AGENT_DEBUG/
-fi
-
-echo "$(date -Ins -u) Configuration from factory/install:"
-(cd $CONFIGDIR || return; ls -l)
-echo
-
-CONFIGDEV=$(zboot partdev CONFIG)
-
 # If zedbox is already running we don't have to start it.
 if ! pgrep zedbox >/dev/null; then
     echo "$(date -Ins -u) Starting zedbox"
     $BINDIR/zedbox &
     wait_for_touch zedbox
 fi
-
-mkdir -p "$WATCHDOG_PID" "$WATCHDOG_FILE"
-touch "$WATCHDOG_PID/zedbox.pid" "$WATCHDOG_FILE/zedbox.touch"
-
-if [ -c $TPM_DEVICE_PATH ] && ! [ -f $DEVICE_KEY_NAME ]; then
-    # It is a device with TPM, enable disk encryption
-    if ! $BINDIR/vaultmgr setupDeprecatedVaults; then
-        echo "$(date -Ins -u) device-steps: vaultmgr setupDeprecatedVaults failed"
-    fi
-fi
-
-if [ -f $PERSISTDIR/reboot-reason ]; then
-    echo "Reboot reason: $(cat $PERSISTDIR/reboot-reason)" > /dev/console
-elif [ -n "$FIRSTBOOT" ]; then
-    echo "Reboot reason: NORMAL: First boot of device - at $(date -Ins -u)" > /dev/console
-else
-    echo "Reboot reason: UNKNOWN: reboot reason - power failure or crash - at $(date -Ins -u)" > /dev/console
-fi
-
-if [ ! -d $PERSISTDIR/log ]; then
-    echo "$(date -Ins -u) Creating $PERSISTDIR/log"
-    mkdir $PERSISTDIR/log
-fi
-
-if [ ! -d $PERSISTDIR/status ]; then
-    echo "$(date -Ins -u) Creating $PERSISTDIR/status"
-    mkdir $PERSISTDIR/status
-fi
-
-if [ -f $CONFIGDIR/restartcounter ]; then
-    echo "$(date -Ins -u) move $CONFIGDIR/restartcounter $PERSISTDIR/status"
-    mv $CONFIGDIR/restartcounter $PERSISTDIR/status
-fi
-if [ -f $CONFIGDIR/rebootConfig ]; then
-    echo "$(date -Ins -u) move $CONFIGDIR/rebootConfig $PERSISTDIR/status"
-    mv $CONFIGDIR/rebootConfig $PERSISTDIR/status
-fi
-if [ -f $CONFIGDIR/hardwaremodel ]; then
-    echo "$(date -Ins -u) move $CONFIGDIR/hardwaremodel $PERSISTDIR/status"
-    mv $CONFIGDIR/hardwaremodel $PERSISTDIR/status
-fi
-
-# Checking for low diskspace at bootup. If used percentage of
-# /persist directory is more than 70% then we will remove the
-# following sub directories:
-# /persist/log/*
-# /persist/newlog/appUpload/*
-# /persist/newlog/devUpload/*
-# /persist/newlog/keepSentQueue/*
-# /persist/newlog/failedUpload/*
-diskspace_used=$(df /persist |awk '/\/dev\//{printf("%d",$5);}')
-echo "Used percentage of /persist: $diskspace_used"
-if [ "$diskspace_used" -ge "$DISKSPACE_RECOVERY_LIMIT" ]
-then
-    echo "Used percentage of /persist is $diskspace_used more than the limit $DISKSPACE_RECOVERY_LIMIT"
-    for DIR in log newlog/keepSentQueue newlog/failedUpload newlog/appUpload newlog/devUpload
-    do
-        dir_del=$PERSISTDIR/$DIR
-        rm -rf "${dir_del:?}/"*
-        diskspace_used=$(df /persist |awk '/\/dev\//{printf("%d",$5);}')
-        echo "Used percentage of /persist is $diskspace_used after clearing $dir_del"
-        if [ "$diskspace_used" -le "$DISKSPACE_RECOVERY_LIMIT" ]
-        then
-            break
-        fi
-    done
-    diskspace_used=$(df /persist |awk '/\/dev\//{printf("%d",$5);}')
-    echo "Used percentage of /persist after recovery: $diskspace_used"
-fi
-
-# Run upgradeconverter
-mkdir -p /persist/ingested/
-echo "$(date -Ins -u) device-steps: Starting upgradeconverter (pre-vault)"
-$BINDIR/upgradeconverter pre-vault
-echo "$(date -Ins -u) device-steps: upgradeconverter (pre-vault) Completed"
-
-# BlinkCounter 1 means we have started; might not yet have IP addresses
-# client/selfRegister and zedagent update this when the found at least
-# one free uplink with IP address(s)
-mkdir -p "$ZTMPDIR/LedBlinkCounter"
-echo '{"BlinkCounter": 1}' > "$ZTMPDIR/LedBlinkCounter/ledconfig.json"
-
-mkdir -p $DPCDIR
 
 # Look for a USB stick with a usb.json file
 # XXX note that gpt on the USB stick needs to be labeled with DevicePortConfig
@@ -435,6 +289,7 @@ else
 fi
 if [ ! -s "$DEVICE_CERT_NAME" ]; then
     echo "$(date -Ins -u) Generating a device key pair and self-signed cert (using TPM if available)"
+    CONFIGDEV=$(zboot partdev CONFIG)
     mount -o remount,rw $CONFIGDIR
     mkdir -p $CONFIGDIR_PERSIST
     mount -t vfat -o flush,dirsync,noatime,rw "$CONFIGDEV" $CONFIGDIR_PERSIST

--- a/pkg/pillar/scripts/onboot.sh
+++ b/pkg/pillar/scripts/onboot.sh
@@ -1,0 +1,173 @@
+#!/bin/sh
+#
+# Copyright (c) 2022 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+WATCHDOG_PID=/run/watchdog/pid
+WATCHDOG_FILE=/run/watchdog/file
+CONFIGDIR=/config
+PERSISTDIR=/persist
+PERSIST_CERTS="$PERSISTDIR/certs"
+DEVICE_KEY_NAME="$CONFIGDIR/device.key.pem"
+PERSIST_AGENT_DEBUG=$PERSISTDIR/agentdebug
+BINDIR=/opt/zededa/bin
+TMPDIR="${PERSISTDIR}/tmp"
+ZTMPDIR=/run/global
+DPCDIR="$ZTMPDIR/DevicePortConfig"
+FIRSTBOOTFILE="$ZTMPDIR/first-boot"
+FIRSTBOOT=
+TPM_DEVICE_PATH="/dev/tpmrm0"
+SECURITYFSPATH=/sys/kernel/security
+PATH=$BINDIR:$PATH
+DISKSPACE_RECOVERY_LIMIT=70
+
+echo "$(date -Ins -u) Starting onboot.sh"
+
+# Copy pre-defined fscrypt.conf
+cp fscrypt.conf /etc/fscrypt.conf
+
+mkdir -p $ZTMPDIR
+if [ -d $TMPDIR ]; then
+    echo "$(date -Ins -u) Old TMPDIR files:"
+    ls -lt $TMPDIR
+    rm -rf $TMPDIR
+fi
+mkdir -p $TMPDIR
+export TMPDIR
+
+if ! mount -t securityfs securityfs "$SECURITYFSPATH"; then
+    echo "$(date -Ins -u) mounting securityfs failed"
+fi
+
+DIRS="$PERSIST_CERTS $PERSIST_AGENT_DEBUG /persist/status/zedclient/OnboardingStatus"
+
+# If /persist/installer/first-boot exists treat this as a first boot
+# we rename file to not assume that it is the first boot if we reboot occasionally
+if [ -f "$PERSISTDIR/installer/first-boot" ]; then
+    mv "$PERSISTDIR/installer/first-boot" "$PERSISTDIR/installer/send-require"
+    touch $FIRSTBOOTFILE # For nodeagent
+    FIRSTBOOT=1
+fi
+
+# If /persist didn't exist or was removed treat this as a first boot
+if [ ! -d $PERSIST_CERTS ]; then
+    touch $FIRSTBOOTFILE # For nodeagent
+    FIRSTBOOT=1
+fi
+
+for d in $DIRS; do
+    d1=$(dirname "$d")
+    if [ ! -d "$d1" ]; then
+        echo "$(date -Ins -u) Create $d1"
+        mkdir -p "$d1"
+        chmod 700 "$d1"
+    fi
+    if [ ! -d "$d" ]; then
+        echo "$(date -Ins -u) Create $d"
+        mkdir -p "$d"
+        chmod 700 "$d"
+    fi
+done
+
+# Save any existing checkpoint directory for debugging
+rm -rf $PERSIST_AGENT_DEBUG/checkpoint
+if [ -d /persist/checkpoint ]; then
+    echo "$(date -Ins -u) Saving copy of /persist/checkpoint in /persist/agentdebug"
+    cp -rp /persist/checkpoint $PERSIST_AGENT_DEBUG/
+fi
+
+# Save any existing /persist/status directory for debugging
+rm -rf $PERSIST_AGENT_DEBUG/status
+if [ -d /persist/status ]; then
+    echo "$(date -Ins -u) Saving copy of /persist/status in /persist/agentdebug"
+    cp -rp /persist/status $PERSIST_AGENT_DEBUG/
+fi
+
+echo "$(date -Ins -u) Configuration from factory/install:"
+(cd $CONFIGDIR || return; ls -l)
+echo
+
+mkdir -p "$WATCHDOG_PID" "$WATCHDOG_FILE"
+touch "$WATCHDOG_PID/zedbox.pid" "$WATCHDOG_FILE/zedbox.touch"
+
+if [ -c $TPM_DEVICE_PATH ] && ! [ -f $DEVICE_KEY_NAME ]; then
+    # It is a device with TPM, enable disk encryption
+    if ! $BINDIR/vaultmgr setupDeprecatedVaults; then
+        echo "$(date -Ins -u) onboot.sh: vaultmgr setupDeprecatedVaults failed"
+    fi
+fi
+
+if [ -f $PERSISTDIR/reboot-reason ]; then
+    echo "Reboot reason: $(cat $PERSISTDIR/reboot-reason)" | tee /dev/console
+elif [ -n "$FIRSTBOOT" ]; then
+    echo "Reboot reason: NORMAL: First boot of device - at $(date -Ins -u)" | tee /dev/console
+else
+    echo "Reboot reason: UNKNOWN: reboot reason - power failure or crash - at $(date -Ins -u)" | tee /dev/console
+fi
+
+if [ ! -d $PERSISTDIR/log ]; then
+    echo "$(date -Ins -u) Creating $PERSISTDIR/log"
+    mkdir $PERSISTDIR/log
+fi
+
+if [ ! -d $PERSISTDIR/status ]; then
+    echo "$(date -Ins -u) Creating $PERSISTDIR/status"
+    mkdir $PERSISTDIR/status
+fi
+
+if [ -f $CONFIGDIR/restartcounter ]; then
+    echo "$(date -Ins -u) move $CONFIGDIR/restartcounter $PERSISTDIR/status"
+    mv $CONFIGDIR/restartcounter $PERSISTDIR/status
+fi
+if [ -f $CONFIGDIR/rebootConfig ]; then
+    echo "$(date -Ins -u) move $CONFIGDIR/rebootConfig $PERSISTDIR/status"
+    mv $CONFIGDIR/rebootConfig $PERSISTDIR/status
+fi
+if [ -f $CONFIGDIR/hardwaremodel ]; then
+    echo "$(date -Ins -u) move $CONFIGDIR/hardwaremodel $PERSISTDIR/status"
+    mv $CONFIGDIR/hardwaremodel $PERSISTDIR/status
+fi
+
+# Checking for low diskspace at bootup. If used percentage of
+# /persist directory is more than 70% then we will remove the
+# following sub directories:
+# /persist/log/*
+# /persist/newlog/appUpload/*
+# /persist/newlog/devUpload/*
+# /persist/newlog/keepSentQueue/*
+# /persist/newlog/failedUpload/*
+diskspace_used=$(df /persist |awk '/\/dev\//{printf("%d",$5);}')
+echo "Used percentage of /persist: $diskspace_used"
+if [ "$diskspace_used" -ge "$DISKSPACE_RECOVERY_LIMIT" ]
+then
+    echo "Used percentage of /persist is $diskspace_used more than the limit $DISKSPACE_RECOVERY_LIMIT"
+    for DIR in log newlog/keepSentQueue newlog/failedUpload newlog/appUpload newlog/devUpload
+    do
+        dir_del=$PERSISTDIR/$DIR
+        rm -rf "${dir_del:?}/"*
+        diskspace_used=$(df /persist |awk '/\/dev\//{printf("%d",$5);}')
+        echo "Used percentage of /persist is $diskspace_used after clearing $dir_del"
+        if [ "$diskspace_used" -le "$DISKSPACE_RECOVERY_LIMIT" ]
+        then
+            break
+        fi
+    done
+    diskspace_used=$(df /persist |awk '/\/dev\//{printf("%d",$5);}')
+    echo "Used percentage of /persist after recovery: $diskspace_used"
+fi
+
+# Run upgradeconverter
+mkdir -p /persist/ingested/
+echo "$(date -Ins -u) onboot.sh: Starting upgradeconverter (pre-vault)"
+$BINDIR/upgradeconverter pre-vault
+echo "$(date -Ins -u) onboot.sh: upgradeconverter (pre-vault) Completed"
+
+# BlinkCounter 1 means we have started; might not yet have IP addresses
+# client/selfRegister and zedagent update this when the found at least
+# one free uplink with IP address(s)
+mkdir -p "$ZTMPDIR/LedBlinkCounter"
+echo '{"BlinkCounter": 1}' > "$ZTMPDIR/LedBlinkCounter/ledconfig.json"
+
+mkdir -p $DPCDIR
+
+echo "$(date -Ins -u) onboot.sh done"


### PR DESCRIPTION
In order to simplify the logic in device-steps and prepare environment before starting of services we can move part of pillar logic before actual start of pillar services into onboot section.

As proposed https://github.com/lf-edge/eve/pull/2839#issuecomment-1301478796

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>