### PR TITLE
check dispatcher url and add meaningful policy error messages

### DIFF
--- a/pkg/edgeview/src/basics.go
+++ b/pkg/edgeview/src/basics.go
@@ -236,15 +236,18 @@ func getAddrFromJWT(token string, isServer bool, instID int) (string, string, er
 		}
 	}
 
-	if strings.Contains(jdata.Dep, "/") {
-		urls := strings.SplitN(jdata.Dep, "/", 2)
+	// remove the https:// prefix if exists
+	jdataDep := strings.TrimPrefix(jdata.Dep, "https://")
+	jdataDep = strings.TrimPrefix(jdataDep, "http://")
+	if strings.Contains(jdataDep, "/") {
+		urls := strings.SplitN(jdataDep, "/", 2)
 		if len(urls) != 2 {
 			return addrport, path, fmt.Errorf("JWT url invalid")
 		}
 		addrport = urls[0]
 		path = "/" + urls[1]
 	} else {
-		addrport = jdata.Dep
+		addrport = jdataDep
 	}
 
 	evStatus.ExpireOn = jdata.Exp

--- a/pkg/edgeview/src/edge-view.go
+++ b/pkg/edgeview/src/edge-view.go
@@ -364,9 +364,9 @@ func main() {
 						continue
 					} else {
 						// check the query commands against defined policy
-						ok := checkCmdPolicy(recvCmds, &evStatus)
+						ok, errmsg := checkCmdPolicy(recvCmds, &evStatus)
 						if !ok {
-							_ = addEnvelopeAndWriteWss([]byte("cmd policy check failed"), true)
+							_ = addEnvelopeAndWriteWss([]byte("cmd policy check failed: "+errmsg), true)
 							sendCloseToWss()
 							continue
 						}

--- a/pkg/edgeview/src/proxy.go
+++ b/pkg/edgeview/src/proxy.go
@@ -121,15 +121,16 @@ func copyHeader(dst, src http.Header) {
 
 func checkAppPolicyAllow(host string) error {
 	var allowed bool
+	var errmsg string
 	isAllowed, ok := remoteMap.Load(host)
 	if ok {
 		allowed = *isAllowed.(*bool)
 	} else {
-		allowed = checkAndLogProxySession(host)
+		allowed, errmsg = checkAndLogProxySession(host)
 		remoteMap.Store(host, &allowed)
 	}
 	if !allowed {
-		err := fmt.Errorf("host %s access not allowed by policy", host)
+		err := fmt.Errorf("host %s access not allowed by policy: %s", host, errmsg)
 		return err
 	}
 	return nil


### PR DESCRIPTION
Signed-off-by: Naiming Shen <naiming@zededa.com>
- handle user putting 'https://' in front of the dispatcher url string
- add some meaningful error string for easier detecting the reason of TCP access failure