### PR TITLE
Fix and sync setup-gcloud/auth versions

### DIFF
--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -80,19 +80,19 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y qemu binfmt-support qemu-user-static qemu-system-x86 qemu-system-aarch64 qemu-utils openvpn curl jq
-      - name: GCP Set up Google Cloud SDK
-        if: matrix.backend == 'gcp'
-        uses: google-github-actions/setup-gcloud@v0.6.3
-        with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
       - id: 'gcpauth'
         if: matrix.backend == 'gcp'
         name: GCP Auth to Google Cloud SDK
-        uses: google-github-actions/auth@v0.8.3
+        uses: google-github-actions/auth@v1
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           credentials_json: ${{ secrets.GCP_SA_KEY }}
           create_credentials_file: true
+      - name: GCP Set up Google Cloud SDK
+        if: matrix.backend == 'gcp'
+        uses: google-github-actions/setup-gcloud@v1
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
       - name: GCP Clean
         if: matrix.backend == 'gcp'
         run: |


### PR DESCRIPTION
Seems current version is not available: Unable to resolve action `google-github-actions/setup-gcloud@v0.6.3`, unable to find version `v0 .6.3`. Also the commit sync version of google-github-actions/auth and adjust the order according to official samples.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>