### PR TITLE
Embed CipherContext into CipherBlockStatus

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -353,23 +353,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	domainCtx.decryptCipherContext.SubEdgeNodeCert = subEdgeNodeCert
 	subEdgeNodeCert.Activate()
 
-	// Look for cipher context which will be used for decryption
-	subCipherContext, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName:   "zedagent",
-		MyAgentName: agentName,
-		TopicImpl:   types.CipherContext{},
-		Activate:    false,
-		Ctx:         &domainCtx,
-		WarningTime: warningTime,
-		ErrorTime:   errorTime,
-		Persistent:  true,
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
-	domainCtx.decryptCipherContext.SubCipherContext = subCipherContext
-	subCipherContext.Activate()
-
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(
 		pubsub.SubscriptionOptions{
@@ -602,9 +585,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 
 		case change := <-subEdgeNodeCert.MsgChan():
 			subEdgeNodeCert.ProcessChange(change)
-
-		case change := <-subCipherContext.MsgChan():
-			subCipherContext.ProcessChange(change)
 
 		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)

--- a/pkg/pillar/cmd/downloader/context.go
+++ b/pkg/pillar/cmd/downloader/context.go
@@ -79,23 +79,6 @@ func (ctx *downloaderContext) registerHandlers(ps *pubsub.PubSub) error {
 	ctx.decryptCipherContext.SubEdgeNodeCert = subEdgeNodeCert
 	subEdgeNodeCert.Activate()
 
-	// Look for cipher context which will be used for decryption
-	subCipherContext, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName:   "zedagent",
-		MyAgentName: agentName,
-		TopicImpl:   types.CipherContext{},
-		Activate:    false,
-		Ctx:         ctx,
-		WarningTime: warningTime,
-		ErrorTime:   errorTime,
-		Persistent:  true,
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
-	ctx.decryptCipherContext.SubCipherContext = subCipherContext
-	subCipherContext.Activate()
-
 	// Look for global config such as log levels
 	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "zedagent",

--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -164,10 +164,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 			ctx.decryptCipherContext.SubEdgeNodeCert.ProcessChange(change)
 			log.Noticef("Processed EdgeNodeCert")
 
-		case change := <-ctx.decryptCipherContext.SubCipherContext.MsgChan():
-			ctx.decryptCipherContext.SubCipherContext.ProcessChange(change)
-			log.Noticef("Processed CipherContext")
-
 		case change := <-ctx.subGlobalConfig.MsgChan():
 			ctx.subGlobalConfig.ProcessChange(change)
 

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -82,7 +82,6 @@ type nim struct {
 	// Subscriptions
 	subGlobalConfig       pubsub.Subscription
 	subControllerCert     pubsub.Subscription
-	subCipherContext      pubsub.Subscription
 	subEdgeNodeCert       pubsub.Subscription
 	subDevicePortConfigA  pubsub.Subscription
 	subDevicePortConfigO  pubsub.Subscription
@@ -183,7 +182,6 @@ func (n *nim) init() (err error) {
 		AgentName:            agentName,
 		NetworkMonitor:       linuxNetMonitor,
 		SubControllerCert:    n.subControllerCert,
-		SubCipherContext:     n.subCipherContext,
 		SubEdgeNodeCert:      n.subEdgeNodeCert,
 		PubCipherBlockStatus: n.pubCipherBlockStatus,
 		CipherMetrics:        n.cipherMetrics,
@@ -243,9 +241,6 @@ func (n *nim) run(ctx context.Context) (err error) {
 		return err
 	}
 	if err = n.subEdgeNodeCert.Activate(); err != nil {
-		return err
-	}
-	if err = n.subCipherContext.Activate(); err != nil {
 		return err
 	}
 	if err = n.subDevicePortConfigS.Activate(); err != nil {
@@ -340,9 +335,6 @@ func (n *nim) run(ctx context.Context) (err error) {
 
 		case change := <-n.subEdgeNodeCert.MsgChan():
 			n.subEdgeNodeCert.ProcessChange(change)
-
-		case change := <-n.subCipherContext.MsgChan():
-			n.subCipherContext.ProcessChange(change)
 
 		case change := <-n.subGlobalConfig.MsgChan():
 			n.subGlobalConfig.ProcessChange(change)
@@ -570,20 +562,6 @@ func (n *nim) initSubscriptions() (err error) {
 		Persistent:  true,
 		WarningTime: warningTime,
 		ErrorTime:   errorTime,
-	})
-	if err != nil {
-		return err
-	}
-
-	// Look for cipher context which will be used for decryption
-	n.subCipherContext, err = n.PubSub.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName:   "zedagent",
-		MyAgentName: agentName,
-		TopicImpl:   types.CipherContext{},
-		Activate:    false,
-		WarningTime: warningTime,
-		ErrorTime:   errorTime,
-		Persistent:  true,
 	})
 	if err != nil {
 		return err

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -88,7 +88,6 @@ type getconfigContext struct {
 	pubDatastoreConfig        pubsub.Publication
 	pubNetworkInstanceConfig  pubsub.Publication
 	pubControllerCert         pubsub.Publication
-	pubCipherContext          pubsub.Publication
 	subContentTreeStatus      pubsub.Subscription
 	pubContentTreeConfig      pubsub.Publication
 	subVolumeStatus           pubsub.Subscription
@@ -141,6 +140,8 @@ type getconfigContext struct {
 	currentMetricInterval uint32
 
 	configEdgeview *types.EdgeviewConfig // edge-view config save
+
+	cipherContexts map[string]types.CipherContext
 }
 
 // current devUUID from OnboardingStatus

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -685,8 +685,7 @@ func parseAppInstanceConfig(getconfigCtx *getconfigContext,
 			appInstance.CloudInitUserData = &userData
 		}
 		appInstance.RemoteConsole = cfgApp.GetRemoteConsole()
-		appInstance.CipherBlockStatus = parseCipherBlock(getconfigCtx, appInstance.Key(),
-			cfgApp.GetCipherData())
+		appInstance.CipherBlockStatus = parseCipherBlock(getconfigCtx, appInstance.Key(), cfgApp.GetCipherData())
 		appInstance.ProfileList = cfgApp.ProfileList
 
 		// Add config submitted via local profile server.
@@ -1618,8 +1617,7 @@ func publishDatastoreConfig(ctx *getconfigContext,
 
 		datastore.DsCertPEM = ds.GetDsCertPEM()
 
-		datastore.CipherBlockStatus = parseCipherBlock(ctx, datastore.Key(),
-			ds.GetCipherData())
+		datastore.CipherBlockStatus = parseCipherBlock(ctx, datastore.Key(), ds.GetCipherData())
 		ctx.pubDatastoreConfig.Publish(datastore.Key(), *datastore)
 	}
 }
@@ -1898,8 +1896,7 @@ func parseNetworkWirelessConfig(ctx *getconfigContext, key string, netEnt *zconf
 			wifi.Password = wificfg.GetPassword()
 			wifi.Priority = wificfg.GetPriority()
 			key = fmt.Sprintf("%s-%s", key, wifi.SSID)
-			wifi.CipherBlockStatus = parseCipherBlock(ctx, key,
-				wificfg.GetCipherData())
+			wifi.CipherBlockStatus = parseCipherBlock(ctx, key, wificfg.GetCipherData())
 
 			wconfig.Wifi = append(wconfig.Wifi, wifi)
 		}

--- a/pkg/pillar/cmd/zedagent/parseconfig_test.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig_test.go
@@ -41,6 +41,7 @@ func initGetConfigCtx(g *GomegaWithT) *getconfigContext {
 		zedagentCtx: &zedagentContext{
 			physicalIoAdapterMap: make(map[string]types.PhysicalIOAdapter),
 		},
+		cipherContexts: make(map[string]types.CipherContext),
 	}
 	// cleanup between tests
 	deviceIoListPrevConfigHash = nil

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -488,6 +488,7 @@ func (zedagentCtx *zedagentContext) init() {
 		currentMetricInterval: zedagentCtx.globalConfig.GlobalValueInt(types.MetricInterval),
 		// edge-view configure
 		configEdgeview: &types.EdgeviewConfig{},
+		cipherContexts: make(map[string]types.CipherContext),
 	}
 
 	cipherCtx := &cipherContext{}
@@ -1064,18 +1065,6 @@ func initPublications(zedagentCtx *zedagentContext) {
 		log.Fatal(err)
 	}
 	getconfigCtx.pubControllerCert.ClearRestarted()
-
-	// for CipherContextStatus Publisher
-	getconfigCtx.pubCipherContext, err = ps.NewPublication(
-		pubsub.PublicationOptions{
-			AgentName:  agentName,
-			Persistent: true,
-			TopicType:  types.CipherContext{},
-		})
-	if err != nil {
-		log.Fatal(err)
-	}
-	getconfigCtx.pubCipherContext.ClearRestarted()
 
 	// for ContentTree config Publisher
 	getconfigCtx.pubContentTreeConfig, err = ps.NewPublication(

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -380,23 +380,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	zedrouterCtx.decryptCipherContext.SubControllerCert = subControllerCert
 	subControllerCert.Activate()
 
-	// Look for cipher context which will be used for decryption
-	subCipherContext, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName:   "zedagent",
-		MyAgentName: agentName,
-		TopicImpl:   types.CipherContext{},
-		Activate:    false,
-		Ctx:         &zedrouterCtx,
-		WarningTime: warningTime,
-		ErrorTime:   errorTime,
-		Persistent:  true,
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
-	zedrouterCtx.decryptCipherContext.SubCipherContext = subCipherContext
-	subCipherContext.Activate()
-
 	// Look for edge node certs which will be used for decryption
 	subEdgeNodeCert, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:   "tpmmgr",
@@ -679,9 +662,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 
 		case change := <-subEdgeNodeCert.MsgChan():
 			subEdgeNodeCert.ProcessChange(change)
-
-		case change := <-subCipherContext.MsgChan():
-			subCipherContext.ProcessChange(change)
 
 		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)

--- a/pkg/pillar/dpcreconciler/linux.go
+++ b/pkg/pillar/dpcreconciler/linux.go
@@ -149,7 +149,6 @@ type LinuxDpcReconciler struct {
 	AgentName            string
 	NetworkMonitor       netmonitor.NetworkMonitor // mandatory
 	SubControllerCert    pubsub.Subscription
-	SubCipherContext     pubsub.Subscription
 	SubEdgeNodeCert      pubsub.Subscription
 	PubCipherBlockStatus pubsub.Publication
 	CipherMetrics        *cipher.AgentMetrics
@@ -1164,8 +1163,7 @@ func (r *LinuxDpcReconciler) getIntendedWlanConfig(
 }
 
 func (r *LinuxDpcReconciler) getWifiCredentials(wifi types.WifiConfig) (types.EncryptionBlock, error) {
-	decryptAvailable := r.SubControllerCert != nil &&
-		r.SubCipherContext != nil && r.SubEdgeNodeCert != nil
+	decryptAvailable := r.SubControllerCert != nil && r.SubEdgeNodeCert != nil
 	if !wifi.CipherBlockStatus.IsCipher || !decryptAvailable {
 		if !wifi.CipherBlockStatus.IsCipher {
 			r.Log.Functionf("%s, wifi config cipherblock is not present\n", wifi.SSID)
@@ -1191,7 +1189,6 @@ func (r *LinuxDpcReconciler) getWifiCredentials(wifi types.WifiConfig) (types.En
 			AgentName:         r.AgentName,
 			AgentMetrics:      r.CipherMetrics,
 			SubControllerCert: r.SubControllerCert,
-			SubCipherContext:  r.SubCipherContext,
 			SubEdgeNodeCert:   r.SubEdgeNodeCert,
 		},
 		wifi.CipherBlockStatus)

--- a/pkg/pillar/types/cipherinfotypes.go
+++ b/pkg/pillar/types/cipherinfotypes.go
@@ -87,6 +87,7 @@ type CipherBlockStatus struct {
 	CipherData      []byte `json:"pubsub-large-CipherData"`
 	ClearTextHash   []byte
 	IsCipher        bool
+	CipherContext   *CipherContext
 	// ErrorAndTime provides SetErrorNow() and ClearError()
 	ErrorAndTime
 }


### PR DESCRIPTION
In order to reduce potential races between filling CipherContext for CipherBlock and publish/unpublish of CipherContext we can embed CipherContext into CipherBlockStatus. This PR removes publications/subscriptions for CipherContext.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>