### PR TITLE
Do not force pkg build by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,7 +267,8 @@ LINUXKIT_OPTS=$(if $(strip $(EVE_HASH)),--hash) $(EVE_HASH) $(if $(strip $(EVE_R
 LINUXKIT_PKG_TARGET=build
 LINUXKIT_PATCHES_DIR=tools/linuxkit/patches
 RESCAN_DEPS=FORCE
-FORCE_BUILD=--force
+# set FORCE_BUILD to --force to enforce rebuild
+FORCE_BUILD=
 
 # we use the following block to assign correct tag to the Docker registry artifact
 ifeq ($(LINUXKIT_PKG_TARGET),push)
@@ -584,7 +585,6 @@ $(LIVE).parallels: $(LIVE).raw
 
 # top-level linuxkit packages targets, note the one enforcing ordering between packages
 pkgs: RESCAN_DEPS=
-pkgs: FORCE_BUILD=
 pkgs: build-tools $(PKGS)
 	@echo Done building packages
 


### PR DESCRIPTION
Let's make FORCE_BUILD flag optional and rely on hash provided by linuxkit on changes (https://github.com/linuxkit/linuxkit/pull/3875).
With no flag provided linuxkit will check that image published, if not, will build it.
This way we can avoid building of dependencies as well.

Few measurements on my PC (`time make pkg/pillar`) with changes from PR vs without:

- after `docker rm -f --volumes linuxkit-builder&&rm -rf ~/.linuxkit`: 0m6,400s vs 9m15,422s
- with change in go code (just one comment): 3m17,143s vs 2m10,048s
- with another change in go code (to use cached layers of Dockerfile): 1m46,950s vs 2m10,048s
- no changes in go code: 0m6,300s vs 0m44,811s

Also PR includes [update](https://github.com/linuxkit/linuxkit/pull/3874) of linuxkit version to speedup restart of buildkit container.