### PR TITLE
Avoid Unmount EBUSY failures

### DIFF
--- a/pkg/pillar/zboot/zboot.go
+++ b/pkg/pillar/zboot/zboot.go
@@ -521,12 +521,17 @@ func getVersion(log *base.LogObject, part string, verFilename string) (string, e
 		log.Noticef("Mounted %s on %s", devname, target)
 		defer func() {
 			log.Noticef("Unmount(%s)", target)
-			err := syscall.Unmount(target, 0)
-			if err != nil {
-				errStr := fmt.Sprintf("Unmount of %s failed: %s", target, err)
-				logrus.Error(errStr)
-			} else {
-				log.Noticef("Unmounted %s", target)
+			for i := 0; i < 10; i++ {
+				err := zbootUnmount(target, i > 0)
+				if err != nil {
+					errStr := fmt.Sprintf("Unmount of %s %d failed: %s",
+						target, i, err)
+					logrus.Error(errStr)
+					time.Sleep(time.Second)
+				} else {
+					log.Noticef("Unmounted %s", target)
+					break
+				}
 			}
 		}()
 		filename := fmt.Sprintf("%s/%s",

--- a/pkg/pillar/zboot/zboot_linux.go
+++ b/pkg/pillar/zboot/zboot_linux.go
@@ -20,3 +20,8 @@ func zbootMount(devname string, target string, fstype string,
 	}
 	return syscall.Mount(devname, target, fstype, flagsLinux, data)
 }
+
+func zbootUnmount(target string, retry bool) (err error) {
+	// Maybe we need to feed some MNT_ flags in here. TBD.
+	return syscall.Unmount(target, 0)
+}

--- a/pkg/pillar/zboot/zboot_macos.go
+++ b/pkg/pillar/zboot/zboot_macos.go
@@ -13,3 +13,8 @@ func zbootMount(devname string, target string, fstype string,
 	// Dummy function to allow compilation on OSX
 	return nil
 }
+
+func zbootUnmount(target string, retry bool) (err error) {
+	// Dummy function to allow compilation on OSX
+	return nil
+}


### PR DESCRIPTION
In ztests runs we see EBUSY unmount failires which cause the mount to stick around, which results in errors if an EVE image update is tried, because it doesn't read the version string which was dd'ed into place but a cached string from before the dd. Such errors started appearing in zome ztests runs about two weeks ago for some unknown reason.

We see errors of the form func:github.com/lf-edge/eve/pkg/pillar/zboot.getVersion.func2 image:IMGB msg:Unmount of /run/baseosmgr/tmpmnt1587217456 failed: device or resource busy

Looking at other code like containerd doing unmount, they seem to have an infinite retry loop. Here we sleep for a second and only retry ten times to avoid waiting forever. If that is insufficient we will adjust.
