### PR TITLE
Control for getty start process

### DIFF
--- a/docs/BOOTING.md
+++ b/docs/BOOTING.md
@@ -78,8 +78,12 @@ conditional or looping statements).
 Second stage GRUB is expected to do all the [heavy lifting](../pkg/grub/rootfs.cfg) of actually booting
 an EVE instance and because it resides in IMGA or IMGB partitions it can easily be upgraded and patched.
 Behavior of this stage of boot process is controlled by a read-only grub.cfg under {IMGA,IMGB}/EFI/BOOT/
-but it can further be tweaked by the grub.cfg overrides on the CONFIG partition. Note that an override
-grub.cfg is expected to be a [complete override](../pkg/grub/rootfs.cfg#L143) and anyone constructing
+but it can further be tweaked by the grub.cfg overrides on the CONFIG partition. The content of
+CONFIG partition mounted using tmpfs mount. In order to mount partition itself you can use
+`eve config mount <mountpoint>` command. To unmount config partition you can use `eve config unmount`.
+Modification of files in CONFIG partition may affect booting process
+and invalidate TPM measurements. Note that an override grub.cfg is expected
+to be a [complete override](../pkg/grub/rootfs.cfg#L143) and anyone constructing
 its content is expected to be familiar with the overall flow of read-only grub.cfg.
 
 Options to use in grub.cfg on the CONFIG partition are defined below. Most options may be defined in the format

--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -29,6 +29,7 @@
 | debug.enable.usb | boolean | false | allow USB e.g. keyboards on device |
 | debug.enable.vga | boolean | false | allow VGA console on device |
 | debug.enable.ssh | authorized ssh key | empty string(ssh disabled) | allow ssh to EVE |
+| debug.enable.console | boolean | false | allow console access to EVE (reboot required to disable) |
 | debug.default.loglevel | string | info | min level saved in files on device |
 | debug.default.remote.loglevel | string | warning | min level sent to controller |
 | storage.dom0.disk.minusage.percent | integer percent | 20 | min. percent of persist partition reserved for dom0 |

--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -5,6 +5,7 @@ init:
   - linuxkit/init:8f1e6a0747acbbb4d7e24dc98f97faa8d1c6cec7
   - linuxkit/runc:f01b88c7033180d50ae43562d72707c6881904e4
   - linuxkit/containerd:de1b18eed76a266baa3092e5c154c84f595e56da
+  # pillar's logic rely on existence of getty and /etc/init.d/001-getty inside
   - linuxkit/getty:v0.5
   - linuxkit/memlogd:v0.5
   - DOM0ZTOOLS_TAG

--- a/pkg/dom0-ztools/rootfs/bin/eve
+++ b/pkg/dom0-ztools/rootfs/bin/eve
@@ -17,6 +17,8 @@ Welcome to EVE!
             destroy <service>
             persist list
             persist attach <disk>
+            config mount <mountpoint>
+            config unmount
             firewall drop
             verbose on|off
             version
@@ -49,6 +51,35 @@ create_new_p3_part() {
   /usr/bin/sgdisk --new "$num_p3_part":"$sec_start":"$sec_end" \
                   --typecode="$num_p3_part":7dcc9ef1-b744-454a-b6ee-c15af7e3eea9 \
                   --change-name="$num_p3_part":'P3' "$1"
+}
+
+mount_partlabel() {
+  PARTLABEL="$1"
+  if [ -z "$2" ]; then
+    echo "ERROR: no mountpoint provided" && help
+  fi
+  MOUNTPOINT="$2"
+  if ! mkdir -p "$MOUNTPOINT"; then
+     echo "ERROR: failed to ensure $MOUNTPOINT" && exit 1
+  fi
+  MOUNT_DEV=$(/sbin/findfs PARTLABEL="$PARTLABEL")
+  if [ -z "$MOUNT_DEV" ]; then
+    echo "ERROR: no device with PARTLABEL=$PARTLABEL found" && exit 1
+  fi
+  if ! mount -t vfat -o rw,iocharset=iso8859-1 "$MOUNT_DEV" "$MOUNTPOINT"; then
+     echo "ERROR: mount $MOUNT_DEV on $MOUNTPOINT failed" && exit 1
+  fi
+}
+
+unmount_partlabel() {
+  PARTLABEL="$1"
+  MOUNT_DEV=$(/sbin/findfs PARTLABEL="$PARTLABEL")
+  if [ -z "$MOUNT_DEV" ]; then
+    echo "ERROR: no device with PARTLABEL=$PARTLABEL found" && exit 1
+  fi
+  if ! umount "$MOUNT_DEV"; then
+     echo "ERROR: umount $MOUNT_DEV failed" && exit 1
+  fi
 }
 
 case "$1" in
@@ -160,6 +191,15 @@ __EOT__
                      list_partitions
                      ;;
                   *) help
+                     ;;
+          esac
+          ;;
+ config) case "$2" in
+               mount) mount_partlabel "CONFIG" "$3"
+                     ;;
+               unmount) unmount_partlabel "CONFIG"
+                     ;;
+               *) help
                      ;;
           esac
           ;;

--- a/pkg/dom0-ztools/rootfs/etc/init.d/001-getty
+++ b/pkg/dom0-ztools/rootfs/etc/init.d/001-getty
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# we override content of https://github.com/linuxkit/linuxkit/blob/master/pkg/getty/etc/init.d/001-getty
+# with conditional behavior
+# if we see getty in kernel command line
+# we will start getty
+
+if cat /proc/cmdline | grep -q getty; then
+  export INITGETTY=true
+  export INSECURE=true
+  /usr/bin/rungetty.sh
+else
+  echo "no getty"
+fi

--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -48,6 +48,7 @@
 #  dom0_console         settings for having a viable Dom0 console output
 #  dom0_rootfs          pointer to a root filesystem we expect Dom0 to use
 #  dom0_platform_tweaks any kind of platform specific (hardware/etc.) Dom0 settings
+#  dom0_flavor_tweaks   any kind of flavor specific (kvm/xen) Dom0 settings
 #  dom0_cmdline         additional static Dom0 settings (see linuxkit_cmdline below)
 #  dom0_extra_args      additional dynamic Dom0 settings
 #
@@ -148,12 +149,6 @@ function set_rootfs_title {
    cat -s rootfs_title /etc/eve-release
 }
 
-function set_crashkernel {
-   if [ "$eve_flavor" != xen ]; then
-      set_global crashkernel "crashkernel=2G-64G:128M,64G-1T:256M,1T-:512M"
-   fi
-}
-
 function set_generic {
    set_global hv_dom0_mem_settings "dom0_mem=800M,max:800M"
    set_global hv_dom0_cpu_settings "dom0_max_vcpus=1 dom0_vcpus_pin"
@@ -171,7 +166,6 @@ function set_generic {
 }
 
 function set_x86_64 {
-   set_crashkernel
    set_global load_hv_cmd multiboot2
    set_global load_dom0_cmd module2
    set_global load_initrd_cmd module2
@@ -308,7 +302,10 @@ function set_kvm_boot {
    set_global load_hv_cmd echo
    set_global load_dom0_cmd linux
    set_global load_initrd_cmd initrd
-   set_global dom0_extra_args "$dom0_extra_args pcie_acs_override=downstream,multifunction"
+   set_global dom0_flavor_tweaks "pcie_acs_override=downstream,multifunction"
+   if [ "$arch" = "x86_64" ]; then
+      set_global dom0_flavor_tweaks "$dom0_flavor_tweaks crashkernel=2G-64G:128M,64G-1T:256M,1T-:512M"
+   fi
    # this may strike readers as circular, but it really isn't
    # the reason we have to also set eve_flavor to kvm here is
    # that it used to be that set_kvm_boot was a sanctioned way
@@ -319,6 +316,7 @@ function set_kvm_boot {
 }
 
 function set_xen_boot {
+   set_global dom0_flavor_tweaks " "
    # see the set_global eve_flavor kvm comment in set_kvm_boot
    set_global eve_flavor xen
 }
@@ -361,7 +359,7 @@ set_${eve_flavor}_boot
 
 menuentry "Boot ${rootfs_title}${rootfs_title_suffix}" {
      $load_hv_cmd $hv $hv_console $hv_platform_tweaks $hv_dom0_mem_settings $hv_dom0_cpu_settings $hv_extra_args
-     $load_dom0_cmd $dom0 $dom0_console $dom0_rootfs $hv_dom0_mem_settings $hv_dom0_cpu_settings $hv_eve_mem_settings $hv_eve_cpu_settings $hv_ctrd_mem_settings $hv_ctrd_cpu_settings $hv_watchdog_timer $dom0_platform_tweaks $dom0_cmdline $dom0_extra_args $crashkernel
+     $load_dom0_cmd $dom0 $dom0_console $dom0_rootfs $hv_dom0_mem_settings $hv_dom0_cpu_settings $hv_eve_mem_settings $hv_eve_cpu_settings $hv_ctrd_mem_settings $hv_ctrd_cpu_settings $hv_watchdog_timer $dom0_platform_tweaks $dom0_flavor_tweaks $dom0_cmdline $dom0_extra_args
      do_if_args $load_devicetree_cmd $devicetree
      do_if_args $load_initrd_cmd $initrd
 }
@@ -402,7 +400,7 @@ submenu 'Set Boot Options' {
 
    menuentry 'show boot options' {
       set_global zboot1 "$load_hv_cmd $hv $hv_console $hv_platform_tweaks $hv_dom0_mem_settings $hv_dom0_cpu_settings $hv_extra_args"
-      set_global zboot2 "$load_dom0_cmd $dom0 $dom0_console $dom0_rootfs $hv_dom0_mem_settings $hv_dom0_cpu_settings $hv_eve_mem_settings $hv_eve_cpu_settings $hv_ctrd_mem_settings $hv_ctrd_cpu_settings $hv_watchdog_timer $dom0_platform_tweaks $dom0_cmdline $dom0_extra_args"
+      set_global zboot2 "$load_dom0_cmd $dom0 $dom0_console $dom0_rootfs $hv_dom0_mem_settings $hv_dom0_cpu_settings $hv_eve_mem_settings $hv_eve_cpu_settings $hv_ctrd_mem_settings $hv_ctrd_cpu_settings $hv_watchdog_timer $dom0_platform_tweaks $dom0_flavor_tweaks $dom0_cmdline $dom0_extra_args"
       set_global zboot3 "do_if_args $load_devicetree_cmd $devicetree"
       set_global zboot4 "do_if_args $load_initrd_cmd $initrd"
    }

--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -333,6 +333,10 @@ function set_eve_flavor {
    fi
 }
 
+function set_getty {
+      set_global dom0_extra_args "$dom0_extra_args getty"
+}
+
 set arch=${grub_cpu}
 if [ "$arch" = "i386" ]; then
    # grub CPU i386 means we are running in legacy BIOS mode
@@ -396,6 +400,10 @@ submenu 'Set Boot Options' {
 
    menuentry 'skip hypervisor booting' {
       set_kvm_boot
+   }
+
+   menuentry 'enable getty' {
+      set_getty
    }
 
    menuentry 'unset dom0_extra_args' {

--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -398,6 +398,10 @@ submenu 'Set Boot Options' {
       set_kvm_boot
    }
 
+   menuentry 'unset dom0_extra_args' {
+      set_global dom0_extra_args " "
+   }
+
    menuentry 'show boot options' {
       set_global zboot1 "$load_hv_cmd $hv $hv_console $hv_platform_tweaks $hv_dom0_mem_settings $hv_dom0_cpu_settings $hv_extra_args"
       set_global zboot2 "$load_dom0_cmd $dom0 $dom0_console $dom0_rootfs $hv_dom0_mem_settings $hv_dom0_cpu_settings $hv_eve_mem_settings $hv_eve_cpu_settings $hv_ctrd_mem_settings $hv_ctrd_cpu_settings $hv_watchdog_timer $dom0_platform_tweaks $dom0_flavor_tweaks $dom0_cmdline $dom0_extra_args"

--- a/pkg/pillar/cmd/domainmgr/handlegetty.go
+++ b/pkg/pillar/cmd/domainmgr/handlegetty.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2022 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package domainmgr
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+)
+
+// cmdlineGettyFlag should be aligned with grub.cfg in grub and 001-getty in dom0-ztools
+const cmdlineGettyFlag = "getty"
+
+var gettyStarted bool
+
+func hasInitGettyStarted(log *base.LogObject) bool {
+	data, err := os.ReadFile("/proc/cmdline")
+	if err != nil {
+		log.Errorf("cannot read /proc/cmdline: %v", err)
+		return false
+	}
+	bootArgs := strings.Fields(string(data))
+	for _, arg := range bootArgs {
+		if arg == cmdlineGettyFlag {
+			return true
+		}
+	}
+	return false
+}
+
+func startGetty(log *base.LogObject) {
+	if gettyStarted {
+		log.Noticeln("getty already started")
+		return
+	}
+	if hasInitGettyStarted(log) {
+		log.Noticeln("getty started in init")
+		return
+	}
+	args := []string{"/hostfs", "/bin/sh", "-c", "INSECURE=true /usr/bin/rungetty.sh"}
+	cmd := exec.Command("chroot", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		log.Fatalf("failed to start getty: %v", err)
+	}
+	log.Noticeln("getty started")
+	gettyStarted = true
+	go func() {
+		err := cmd.Wait()
+		log.Fatalf("getty stopped: %v", err)
+	}()
+}

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -2302,7 +2302,7 @@ func parseConfigItems(ctx *getconfigContext, config *zconfig.EdgeDevConfig,
 	//  value or retain the previous value.
 	gcPtr := &ctx.zedagentCtx.globalConfig
 	newGlobalConfig := types.DefaultConfigItemValueMap()
-	// Note: UsbAccess and VgaAccess are special in that they has two defaults.
+	// Note: UsbAccess, VgaAccess and ConsoleAccess are special in that they has two defaults.
 	// When the device first boots the default is "true" as specified
 	// in the DefaultConfigItemValueMap. But when connecting to the
 	// controller, if the controller does not include the item, it
@@ -2312,10 +2312,12 @@ func parseConfigItems(ctx *getconfigContext, config *zconfig.EdgeDevConfig,
 	if source == fromBootstrap {
 		newGlobalConfig.SetGlobalValueBool(types.UsbAccess, true)
 		newGlobalConfig.SetGlobalValueBool(types.VgaAccess, true)
+		newGlobalConfig.SetGlobalValueBool(types.ConsoleAccess, true)
 	} else {
 		// from controller (live or saved)
 		newGlobalConfig.SetGlobalValueBool(types.UsbAccess, false)
 		newGlobalConfig.SetGlobalValueBool(types.VgaAccess, false)
+		newGlobalConfig.SetGlobalValueBool(types.ConsoleAccess, false)
 	}
 	newGlobalStatus := types.NewGlobalStatus()
 

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -206,6 +206,8 @@ const (
 	// String Items
 	// SSHAuthorizedKeys global setting key
 	SSHAuthorizedKeys GlobalSettingKey = "debug.enable.ssh"
+	// ConsoleAccess global setting key
+	ConsoleAccess GlobalSettingKey = "debug.enable.console"
 	// DefaultLogLevel global setting key
 	DefaultLogLevel GlobalSettingKey = "debug.default.loglevel"
 	// DefaultRemoteLogLevel global setting key
@@ -783,6 +785,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddBoolItem(AllowLogFastupload, false)
 	configItemSpecMap.AddBoolItem(DisableDHCPAllOnesNetMask, false)
 	configItemSpecMap.AddBoolItem(ProcessCloudInitMultiPart, false)
+	configItemSpecMap.AddBoolItem(ConsoleAccess, true) // Controller likely default to false
 
 	// Add TriState Items
 	configItemSpecMap.AddTriStateItem(NetworkFallbackAnyEth, TS_DISABLED)

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -177,6 +177,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		// Bool Items
 		UsbAccess,
 		VgaAccess,
+		ConsoleAccess,
 		AllowAppVnc,
 		EveMemoryLimitInBytes,
 		VmmMemoryLimitInMiB,


### PR DESCRIPTION
In order to not start getty process by default (from init container) we can use novel explicit getty option
in kernel command line. Which may be set using grub.cfg on the CONFIG partition as described [here](https://github.com/lf-edge/eve/blob/dfa564681838f7cd289d8f1ef00ada47e5a44ad0/docs/BOOTING.md#booting-under-uefi-firmware), i.e. by defining there `set_global dom0_extra_args "$dom0_extra_args getty "` or with just
`set_getty`.

This PR also contains `eve config mount <mountpoint>` command to support modifications of CONFIG partition content.

And several grub menu options to enable getty and clean dom0_extra_args without touching grub.cfg for one boot.

Also I implemented `debug.enable.console` option to control getty start from pillar. For now I only implemented enabling of getty,
to disable edge-node must be rebooted.