### PR TITLE
pkg/pillar: Fix the maxvcpus option in the xen VMs config files.

### DIFF
--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -266,7 +266,7 @@ func (ctx xenContext) CreateDomConfig(domainName string, config types.DomainConf
 	if maxCpus == 0 {
 		maxCpus = vCpus
 	}
-	file.WriteString(fmt.Sprintf("maxcpus = %d\n", maxCpus))
+	file.WriteString(fmt.Sprintf("maxvcpus = %d\n", maxCpus))
 	if config.CPUs != "" {
 		file.WriteString(fmt.Sprintf("cpus = \"%s\"\n", config.CPUs))
 	}


### PR DESCRIPTION
The xl.cfg files that are used to configure the Xen guests have the `maxvcpus` option. The option is used to allow the guest to bring up more VCPUs than it has online on its start (specified by the `vcpus` option).

There was a typo in the option string generated by pillar. Fix it.

Signed-off-by: Nikolay Martyanov <ohmspectator@gmail.com>