### PR TITLE
Improve error message for portmap on switch

### DIFF
--- a/pkg/pillar/cmd/zedrouter/acl.go
+++ b/pkg/pillar/cmd/zedrouter/acl.go
@@ -948,6 +948,12 @@ func aceToRules(ctx *zedrouterContext, aclArgs types.AppNetworkACLArgs,
 			inArgs = append(inArgs, add...)
 		}
 		if action.PortMap {
+			if aclArgs.NIType == types.NetworkInstanceTypeSwitch {
+				errStr := fmt.Sprintf("PortMap not supported on switch network instance: %+v",
+					ace)
+				log.Errorln(errStr)
+				return nil, nil, errors.New(errStr)
+			}
 			actionCount += 1
 			// Generate NAT and ACCEPT rules based on protocol,
 			// lport, and TargetPort


### PR DESCRIPTION
The Portmap ACL does not make sense on a switch network instance since there is no NAT in that case. Here we generate a specific error instead of tripping on the "PortMap without appIP" error.

Makes issue  #2934 easier to detect