### PR TITLE
Fix-patch 9.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,10 +59,12 @@ jobs:
              docker login -u "${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}" --password-stdin
       - name: Build packages
         run: |
+          SUCCESS=
           # sadly, our build sometimes times out on network access
           # and running out of disk space: re-trying for 3 times
           for i in 1 2 3; do
              if make -e V=1 LINUXKIT_PKG_TARGET=push PRUNE=1 pkgs; then
+                SUCCESS=true
                 break
              else
                 # the most likely reason for 'make pkgs' to fail is
@@ -73,6 +75,7 @@ jobs:
                 docker system prune -f || :
              fi
           done
+          if [ -z "$SUCCESS" ]; then echo "::error::failed to build and push packages" && exit 1; fi
       - name: Post package report
         run: |
           echo Disk usage

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -116,22 +116,7 @@ jobs:
         run: |
           echo "${{ secrets.RELEASE_DOCKERHUB_TOKEN }}" |\
              docker login -u "${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}" --password-stdin
-      - name: Build EVE for ${{ matrix.arch }}-${{ matrix.hv }}
-        # build #1 without push (do not push either unless both can build)
-        run: |
-          rm -rf dist dist.${{ matrix.hv }}
-          make -e V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} eve
-          mv -f dist dist.${{ matrix.hv }}
-      - name: Post eve ${{ matrix.arch }}-${{ matrix.hv }} report
-        run: |
-          echo Disk usage
-          df -h
-          echo Memory
-          free -m
-          docker system df
-          docker system df -v
       - name: Build and push EVE for ${{ matrix.arch }}-${{ matrix.hv }}
-        # since build #1 works, build and push #2
         run: |
           make -e V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} LINUXKIT_PKG_TARGET=push eve
       - name: Post eve ${{ matrix.arch }}-${{ matrix.hv }} report

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,12 @@
 *.swp
+.idea/
+.vscode/
 obj
 dist/
 build-tools/bin/
 images/*.yml
+images/rootfs-*.yml.in
+images/*.yml.in.sed
 .go/
 tags
 tmp/

--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,7 @@ DOCKER_GO = _() { $(SET_X); mkdir -p $(CURDIR)/.go/src/$${3:-dummy} ; mkdir -p $
 
 PARSE_PKGS=$(if $(strip $(EVE_HASH)),EVE_HASH=)$(EVE_HASH) DOCKER_ARCH_TAG=$(DOCKER_ARCH_TAG) ./tools/parse-pkgs.sh
 LINUXKIT=$(BUILDTOOLS_BIN)/linuxkit
-LINUXKIT_VERSION=4f23407838366e362d2615f6c781d99de6d32ddc
+LINUXKIT_VERSION=bbd62314edf03b8e947536511c1286df65b1e0ff
 LINUXKIT_SOURCE=https://github.com/linuxkit/linuxkit.git
 LINUXKIT_OPTS=$(if $(strip $(EVE_HASH)),--hash) $(EVE_HASH) $(if $(strip $(EVE_REL)),--release) $(EVE_REL)
 LINUXKIT_PKG_TARGET=build
@@ -756,8 +756,6 @@ eve-%: pkg/%/Dockerfile build-tools $(RESCAN_DEPS)
 	$(eval LINUXKIT_BUILD_PLATFORMS_LIST := $(call uniq,linux/$(ZARCH) $(if $(filter $(PKGS_HOSTARCH),$*),linux/$(HOSTARCH),)))
 	$(eval LINUXKIT_BUILD_PLATFORMS := --platforms $(subst $(space),$(comma),$(strip $(LINUXKIT_BUILD_PLATFORMS_LIST))))
 	$(eval LINUXKIT_FLAGS := $(if $(filter manifest,$(LINUXKIT_PKG_TARGET)),,$(FORCE_BUILD) $(LINUXKIT_DOCKER_LOAD) $(LINUXKIT_BUILD_PLATFORMS)))
-	$(QUIET)# ensures that we either pull it down or build it when we want to push
-	$(if $(filter push,$(LINUXKIT_PKG_TARGET)),$(QUIET)$(LINUXKIT) pkg build --pull $(LINUXKIT_BUILD_PLATFORMS) -build-yml $(call get_pkg_build_yml,$*) pkg/$*,)
 	$(QUIET)$(LINUXKIT) $(DASH_V) pkg $(LINUXKIT_PKG_TARGET) $(LINUXKIT_OPTS) $(LINUXKIT_FLAGS) -build-yml $(call get_pkg_build_yml,$*) pkg/$*
 	$(QUIET)if [ -n "$(PRUNE)" ]; then \
   		$(LINUXKIT) pkg builder prune; \


### PR DESCRIPTION
by @giggsoff "We cannot use linuxkit pkg push after pkg build --pull if we define different docker flags in commands (and right now we have [problems](https://github.com/lf-edge/eve/actions/runs/3465353503/jobs/5787980476#step:7:1652) in publish workflow).
Let's remove pkg build --pull step and wait for changes from https://github.com/linuxkit/linuxkit/pull/3876" 

Also PR includes explicit exit from publish workflow in case of error in our retry logic.