### PR TITLE
Fix tpm on uno220 (rpi4 based device)

### DIFF
--- a/pkg/kernel/patches-5.10.x/0006-add-raspberry-pi-uno-device-tree.patch
+++ b/pkg/kernel/patches-5.10.x/0006-add-raspberry-pi-uno-device-tree.patch
@@ -6,8 +6,8 @@ Subject: [PATCH 06/10] add raspberry pi uno device tree
 ---
  arch/arm/boot/dts/Makefile                    |   1 +
  arch/arm64/boot/dts/broadcom/Makefile         |   1 +
- .../boot/dts/broadcom/raspberrypi-uno-220.dts | 216 ++++++++++++++++++
- 3 files changed, 218 insertions(+)
+ .../boot/dts/broadcom/raspberrypi-uno-220.dts | 184 ++++++++++++++++++
+ 3 files changed, 186 insertions(+)
  create mode 100644 arch/arm64/boot/dts/broadcom/raspberrypi-uno-220.dts
 
 diff --git a/arch/arm/boot/dts/Makefile b/arch/arm/boot/dts/Makefile
@@ -38,42 +38,20 @@ new file mode 100644
 index 000000000000..c3d25f522be8
 --- /dev/null
 +++ b/arch/arm64/boot/dts/broadcom/raspberrypi-uno-220.dts
-@@ -0,0 +1,216 @@
+@@ -0,0 +1,184 @@
 +#include "arm/bcm2711-rpi-4-b.dts"
 +#include <dt-bindings/leds/common.h>
 +
 +&spi {
-+	pinctrl-names = "default";
-+	#address-cells = < 0x01 >;
-+	#size-cells = < 0x00 >;
-+	pinctrl-0 = <&spi0_pins &spi0_cs_pins>;
-+	cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
 +	status = "okay";
 +
-+	/* spidev0: spidev@0{
-+		compatible = "spidev";
-+		reg = <0>;
-+		#address-cells = <1>;
-+		#size-cells = <0>;
-+		spi-max-frequency = <125000000>;
-+	}; */
-+
-+	slb96701: slb9670@0{
++	slb9670: slb9670@0 {
 +		compatible = "infineon,slb9670";
-+		reg = < 0x00 >;
-+		#address-cells = < 0x01 >;
-+		#size-cells = < 0x00 >;
-+		spi-max-frequency = < 0x1e84800 >;
-+		status = "okay";
-+	};
-+
-+	spidev1: spidev@1{
-+		compatible = "spidev";
-+		reg = <1>;	/* CE1 */
++		reg = <0>;	/* CE0 */
 +		#address-cells = <1>;
 +		#size-cells = <0>;
-+		spi-max-frequency = <125000000>;
-+                status = "disabled";
++		spi-max-frequency = <32000000>;
++		status = "okay";
 +	};
 +};
 +
@@ -85,16 +63,6 @@ index 000000000000..c3d25f522be8
 +		brcm,pins = < 12 >;
 +		brcm,pull = < 2 >;
 +		brcm,function = < 0 >;
-+	};
-+
-+	spi0_pins: spi0_pins {
-+		brcm,pins = <9 10 11>;
-+		brcm,function = <BCM2835_FSEL_ALT0>;
-+	};
-+
-+	spi0_cs_pins: spi0_cs_pins {
-+		brcm,pins = <8 7>;
-+		brcm,function = <BCM2835_FSEL_GPIO_OUT>;
 +	};
 +
 +	spi3_pins: spi3_pins {

--- a/pkg/kernel/patches-5.10.x/0013-add-slb9670-TPM-module-support-for-rpi4.patch
+++ b/pkg/kernel/patches-5.10.x/0013-add-slb9670-TPM-module-support-for-rpi4.patch
@@ -1,34 +1,22 @@
-From ce476c00f41802bbe1818ae3ac601689aecd1865 Mon Sep 17 00:00:00 2001
+From 8d81fb34bd24b9f6181edd590c861ed0c313d260 Mon Sep 17 00:00:00 2001
 From: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>
 Date: Sun, 29 May 2022 19:09:38 +0300
 Subject: [PATCH] add slb9670 TPM module support for rpi4
 
 Signed-off-by: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>
 ---
- arch/arm/boot/dts/bcm2711-rpi-4-b.dts         |  1 +
- .../arm/boot/dts/bcm2835-spi-tpm-slb9670.dtsi | 33 +++++++++++++++++++
- 2 files changed, 34 insertions(+)
- create mode 100644 arch/arm/boot/dts/bcm2835-spi-tpm-slb9670.dtsi
+ arch/arm/boot/dts/bcm2711-rpi-4-b.dts          | 18 ++++++++++++++++++
+ .../boot/dts/broadcom/bcm2711-rpi-4-b.dts      | 13 +++++++++++++
+ 2 files changed, 31 insertions(+)
 
 diff --git a/arch/arm/boot/dts/bcm2711-rpi-4-b.dts b/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
-index fcd561c021ea..ff4a896deb16 100644
+index fcd561c021ea..67b9ac899b31 100644
 --- a/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
 +++ b/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
-@@ -3,6 +3,7 @@
- #include "bcm2711.dtsi"
- #include "bcm2835-rpi.dtsi"
- #include "bcm283x-rpi-usb-peripheral.dtsi"
-+#include "bcm2835-spi-tpm-slb9670.dtsi"
- 
- #include <dt-bindings/reset/raspberrypi,firmware-reset.h>
- 
-diff --git a/arch/arm/boot/dts/bcm2835-spi-tpm-slb9670.dtsi b/arch/arm/boot/dts/bcm2835-spi-tpm-slb9670.dtsi
-new file mode 100644
-index 000000000000..8b522d8702bb
---- /dev/null
-+++ b/arch/arm/boot/dts/bcm2835-spi-tpm-slb9670.dtsi
-@@ -0,0 +1,33 @@
-+// SPDX-License-Identifier: GPL-2.0
+@@ -304,3 +304,21 @@ &vc4 {
+ &vec {
+ 	status = "disabled";
+ };
 +
 +&gpio {
 +	spi0_pins: spi0_pins {
@@ -43,13 +31,19 @@ index 000000000000..8b522d8702bb
 +};
 +
 +&spi {
-+	/* needed to avoid dtc warning */
-+	#address-cells = <1>;
-+	#size-cells = <0>;
-+
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&spi0_pins &spi0_cs_pins>;
 +	cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
++};
+diff --git a/arch/arm64/boot/dts/broadcom/bcm2711-rpi-4-b.dts b/arch/arm64/boot/dts/broadcom/bcm2711-rpi-4-b.dts
+index d24c53682e44..6abea2e0d024 100644
+--- a/arch/arm64/boot/dts/broadcom/bcm2711-rpi-4-b.dts
++++ b/arch/arm64/boot/dts/broadcom/bcm2711-rpi-4-b.dts
+@@ -1,2 +1,15 @@
+ // SPDX-License-Identifier: GPL-2.0
+ #include "arm/bcm2711-rpi-4-b.dts"
++
++&spi {
 +	status = "okay";
 +
 +	slb9670: slb9670@1 {

--- a/pkg/new-kernel/patches-5.15.x/0004-add-raspberry-pi-uno-device-tree.patch
+++ b/pkg/new-kernel/patches-5.15.x/0004-add-raspberry-pi-uno-device-tree.patch
@@ -6,8 +6,8 @@ Subject: [PATCH 4/9] add raspberry pi uno device tree
 ---
  arch/arm/boot/dts/Makefile                    |   1 +
  arch/arm64/boot/dts/broadcom/Makefile         |   1 +
- .../boot/dts/broadcom/raspberrypi-uno-220.dts | 216 ++++++++++++++++++
- 3 files changed, 218 insertions(+)
+ .../boot/dts/broadcom/raspberrypi-uno-220.dts | 184 ++++++++++++++++++
+ 3 files changed, 186 insertions(+)
  create mode 100644 arch/arm64/boot/dts/broadcom/raspberrypi-uno-220.dts
 
 diff --git a/arch/arm/boot/dts/Makefile b/arch/arm/boot/dts/Makefile
@@ -38,42 +38,20 @@ new file mode 100644
 index 000000000000..c3d25f522be8
 --- /dev/null
 +++ b/arch/arm64/boot/dts/broadcom/raspberrypi-uno-220.dts
-@@ -0,0 +1,216 @@
+@@ -0,0 +1,184 @@
 +#include "arm/bcm2711-rpi-4-b.dts"
 +#include <dt-bindings/leds/common.h>
 +
 +&spi {
-+	pinctrl-names = "default";
-+	#address-cells = < 0x01 >;
-+	#size-cells = < 0x00 >;
-+	pinctrl-0 = <&spi0_pins &spi0_cs_pins>;
-+	cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
 +	status = "okay";
 +
-+	/* spidev0: spidev@0{
-+		compatible = "spidev";
-+		reg = <0>;
-+		#address-cells = <1>;
-+		#size-cells = <0>;
-+		spi-max-frequency = <125000000>;
-+	}; */
-+
-+	slb96701: slb9670@0{
++	slb9670: slb9670@0 {
 +		compatible = "infineon,slb9670";
-+		reg = < 0x00 >;
-+		#address-cells = < 0x01 >;
-+		#size-cells = < 0x00 >;
-+		spi-max-frequency = < 0x1e84800 >;
-+		status = "okay";
-+	};
-+
-+	spidev1: spidev@1{
-+		compatible = "spidev";
-+		reg = <1>;	/* CE1 */
++		reg = <0>;	/* CE0 */
 +		#address-cells = <1>;
 +		#size-cells = <0>;
-+		spi-max-frequency = <125000000>;
-+                status = "disabled";
++		spi-max-frequency = <32000000>;
++		status = "okay";
 +	};
 +};
 +
@@ -85,16 +63,6 @@ index 000000000000..c3d25f522be8
 +		brcm,pins = < 12 >;
 +		brcm,pull = < 2 >;
 +		brcm,function = < 0 >;
-+	};
-+
-+	spi0_pins: spi0_pins {
-+		brcm,pins = <9 10 11>;
-+		brcm,function = <BCM2835_FSEL_ALT0>;
-+	};
-+
-+	spi0_cs_pins: spi0_cs_pins {
-+		brcm,pins = <8 7>;
-+		brcm,function = <BCM2835_FSEL_GPIO_OUT>;
 +	};
 +
 +	spi3_pins: spi3_pins {

--- a/pkg/new-kernel/patches-5.15.x/0010-add-slb9670-TPM-module-support-for-rpi4.patch
+++ b/pkg/new-kernel/patches-5.15.x/0010-add-slb9670-TPM-module-support-for-rpi4.patch
@@ -1,34 +1,22 @@
-From ce476c00f41802bbe1818ae3ac601689aecd1865 Mon Sep 17 00:00:00 2001
+From 8d81fb34bd24b9f6181edd590c861ed0c313d260 Mon Sep 17 00:00:00 2001
 From: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>
 Date: Sun, 29 May 2022 19:09:38 +0300
 Subject: [PATCH] add slb9670 TPM module support for rpi4
 
 Signed-off-by: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>
 ---
- arch/arm/boot/dts/bcm2711-rpi-4-b.dts         |  1 +
- .../arm/boot/dts/bcm2835-spi-tpm-slb9670.dtsi | 33 +++++++++++++++++++
- 2 files changed, 34 insertions(+)
- create mode 100644 arch/arm/boot/dts/bcm2835-spi-tpm-slb9670.dtsi
+ arch/arm/boot/dts/bcm2711-rpi-4-b.dts          | 18 ++++++++++++++++++
+ .../boot/dts/broadcom/bcm2711-rpi-4-b.dts      | 13 +++++++++++++
+ 2 files changed, 31 insertions(+)
 
 diff --git a/arch/arm/boot/dts/bcm2711-rpi-4-b.dts b/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
-index 72ce80fbf266..34d876efee51 100644
+index fcd561c021ea..67b9ac899b31 100644
 --- a/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
 +++ b/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
-@@ -3,6 +3,7 @@
- #include "bcm2711.dtsi"
- #include "bcm2711-rpi.dtsi"
- #include "bcm283x-rpi-usb-peripheral.dtsi"
-+#include "bcm2835-spi-tpm-slb9670.dtsi"
- 
- / {
- 	compatible = "raspberrypi,4-model-b", "brcm,bcm2711";
-diff --git a/arch/arm/boot/dts/bcm2835-spi-tpm-slb9670.dtsi b/arch/arm/boot/dts/bcm2835-spi-tpm-slb9670.dtsi
-new file mode 100644
-index 000000000000..8b522d8702bb
---- /dev/null
-+++ b/arch/arm/boot/dts/bcm2835-spi-tpm-slb9670.dtsi
-@@ -0,0 +1,33 @@
-+// SPDX-License-Identifier: GPL-2.0
+@@ -304,3 +304,21 @@ &vc4 {
+ &vec {
+ 	status = "disabled";
+ };
 +
 +&gpio {
 +	spi0_pins: spi0_pins {
@@ -43,13 +31,19 @@ index 000000000000..8b522d8702bb
 +};
 +
 +&spi {
-+	/* needed to avoid dtc warning */
-+	#address-cells = <1>;
-+	#size-cells = <0>;
-+
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&spi0_pins &spi0_cs_pins>;
 +	cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
++};
+diff --git a/arch/arm64/boot/dts/broadcom/bcm2711-rpi-4-b.dts b/arch/arm64/boot/dts/broadcom/bcm2711-rpi-4-b.dts
+index d24c53682e44..6abea2e0d024 100644
+--- a/arch/arm64/boot/dts/broadcom/bcm2711-rpi-4-b.dts
++++ b/arch/arm64/boot/dts/broadcom/bcm2711-rpi-4-b.dts
+@@ -1,2 +1,15 @@
+ // SPDX-License-Identifier: GPL-2.0
+ #include "arm/bcm2711-rpi-4-b.dts"
++
++&spi {
 +	status = "okay";
 +
 +	slb9670: slb9670@1 {


### PR DESCRIPTION
Problem: For rpi4 the default address for tpm module is 0x01 but for uno220 it is 0x0. Due to the fact that dt uno220 is based on dt rpi4, there are 2 nodes with tpm in uno220  dt at the same time. This situation led to the impossibility of initializing the TPM module on the uno 220.

I separate nodes for spi and slb9670 tpm module, for adding ability to configure slb9670 tpm node for other boards that bases on rpi4.

I adapted the patch with the addition of a device tree for uno220, taking into account our changes.

In addition, I removed unused `spidev` nodes from uno220 device tree. This was copied from the device tree for rpi4 form raspberry/linux repo.

I am using **PR builds as a build machine**, once the docker image is built I will test and remove "Not tested" from
PR name.

Signed-off-by: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>