### PR TITLE
Fix building rpi4 overlays

### DIFF
--- a/pkg/u-boot/Dockerfile
+++ b/pkg/u-boot/Dockerfile
@@ -1,5 +1,5 @@
 FROM lfedge/eve-alpine:145f062a40639b6c65efa36bed1c5614b873be52 as build-base
-ENV BUILD_PKGS bash binutils-dev build-base bc bison flex openssl-dev python3 swig
+ENV BUILD_PKGS bash binutils-dev build-base bc bison flex openssl-dev python3 swig dtc
 ENV BUILD_PKGS_amd64 python3-dev py-pip
 RUN eve-alpine-deploy.sh
 
@@ -38,7 +38,7 @@ ADD ${RASPBERRY_FIRMWARE_BLOBS}/boot/fixup4.dat /tmp/rpi/fixup4.dat
 ADD ${RASPBERRY_FIRMWARE_BLOBS}/boot/start4.elf /tmp/rpi/start4.elf
 # hadolint ignore=SC3060
 RUN  for i in /tmp/rpi/overlays/*.dts ; do                                         \
-          scripts/dtc/dtc -@ -I dts -O dtb -o "${i/.dts/.dtbo}" "$i" && rm "$i"     ;\
+          dtc -@ -I dts -O dtb -o "${i/.dts/.dtbo}" "$i" && rm "$i"     ;\
        done                                                                         ;\
        cp -r /tmp/rpi/* /boot
 


### PR DESCRIPTION
[Previously](https://github.com/lf-edge/eve/pull/2913), we built u-boot before building overlays and had a compiled version of dtc to build overlays, now we build u-boot at the end. We can just use dtc from the package.

Signed-off-by: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>