### PR TITLE
kdump: collect dmesg along with a kdump

### DIFF
--- a/pkg/kdump/kdump.sh
+++ b/pkg/kdump/kdump.sh
@@ -25,7 +25,7 @@ if test -f /proc/vmcore; then
     while read -r line; do echo "$line" > /dev/kmsg; done < /tmp/backtrace
     echo ">>>>>>>>>> Crashed kernel dmesg END <<<<<<<<<<" > /dev/kmsg
 
-    TS=$(date +%Y-%m-%d-%H-%M-%S)
+    TS=$(date -Is)
 
     # Collect a minimal kernel dump for security reasons
     KDUMP_PATH="$DIR/kdump-$TS.dump"

--- a/pkg/kdump/kdump.sh
+++ b/pkg/kdump/kdump.sh
@@ -25,10 +25,17 @@ if test -f /proc/vmcore; then
     while read -r line; do echo "$line" > /dev/kmsg; done < /tmp/backtrace
     echo ">>>>>>>>>> Crashed kernel dmesg END <<<<<<<<<<" > /dev/kmsg
 
+    TS=$(date +%Y-%m-%d-%H-%M-%S)
+
     # Collect a minimal kernel dump for security reasons
-    KDUMP_PATH="$DIR/kcrash-$(date +%Y-%m-%d-%H-%M-%S).dump"
+    KDUMP_PATH="$DIR/kdump-$TS.dump"
     makedumpfile -d 31 /proc/vmcore "$KDUMP_PATH" > /dev/null 2>&1
     echo "kdump collected: $KDUMP_PATH" > /dev/kmsg
+
+    # Collect dmesg
+    DMESG_PATH="$DIR/dmesg-$TS.log"
+    cp /tmp/dmesg "$DMESG_PATH"
+    echo "dmesg collected: $DMESG_PATH" > /dev/kmsg
 
     # Prepare reboot-reason, reboot-stack and boot-reason
     echo "kernel panic, kdump collected: $KDUMP_PATH" > /persist/reboot-reason


### PR DESCRIPTION
Colect plain-text dmesg log along with a kernel dump in order to simplify kernel debugging: sometimes it can be enough to take a look into a dmesg once in order to understand a root cause rather than to download kernel debug symbols, use the crash tool and dive deeper into the analysis.

And yes, I renamed the 'kcrash-*' to 'kdump-*' in order to have both files aligned, thus the log looks perfect now:
```
   >>>>>>>>>>>> Crashed kernel dmesg END <<<<<<<<<<
   kdump collected: /persist/kcrashes/kdump-2022-11-30-13-58-40.dump
   dmesg collected: /persist/kcrashes/dmesg-2022-11-30-13-58-40.log
```

Promise not to change filenames anymore!