### PR TITLE
Do not allow switch NI with multiple ports

### DIFF
--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -1239,6 +1239,13 @@ func doNetworkInstanceActivate(ctx *zedrouterContext,
 	if status.Type == types.NetworkInstanceTypeSwitch {
 		// switched NI is not probed and does not have a CurrentUplinkIntf
 		status.IfNameList = getIfNameListForLLOrIfname(ctx, status.Logicallabel)
+		if len(status.IfNameList) > 1 {
+			err := fmt.Errorf("Name %s maps to more than one (%d) interfaces",
+				status.Logicallabel, len(status.IfNameList))
+			log.Errorf("NetworkInstance(%s-%s): %s",
+				status.DisplayName, status.UUID, err)
+			return err
+		}
 	} else {
 		status.IfNameList = getIfNameListForLLOrIfname(ctx, status.CurrentUplinkIntf)
 	}


### PR DESCRIPTION
It is confusing to allow specifying "uplink" or "freeuplink" for the port for a switch network instance since it will pick an arbitrary port and there is no check whether the port is up and usable (the probe logic assumes we have a local IP address to do the probes hence is not and can not be used on a switch network instance).

While we could block using the labels "uplink" and "freeuplink" that might cause unneeded errors/failures for configurations where there is only one uplink aka management port. So instead we check how many ports are returned when we get the list and reject if > 1.