### PR TITLE
Fix installer config.json to point onto pillar's code

### DIFF
--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -37,6 +37,9 @@ onboot:
     image: KDUMP_TAG
   - name: measure-config
     image: MEASURE_CONFIG_TAG
+  # If you change the order of pillar-onboot don't forget to
+  # change /containers/onboot/006-pillar-onboot/lower in pkg/mkimage-raw-efi accordingly:
+  # 006-pillar-onboot must follow the order number of pillar-onboot
   # onboot part of pillar to prepare services to start
   - name: pillar-onboot
     image: PILLAR_TAG

--- a/pkg/mkimage-raw-efi/config.json
+++ b/pkg/mkimage-raw-efi/config.json
@@ -220,7 +220,7 @@
         {
             "destination": "/opt/pillar",
             "type": "bind",
-            "source": "/containers/services/pillar/lower",
+            "source": "/containers/onboot/006-pillar-onboot/lower",
             "options": [
                 "rw",
                 "rbind",


### PR DESCRIPTION
We must adjust installer mount to work with moved pillar.

Installer logic is broken now since the actual pillar's data was moved to onboot section after changes in #2917.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>