### PR TITLE
Reflect dmesg file generation in the doc and kdump.sh script

### DIFF
--- a/docs/KERNEL-DUMPS.md
+++ b/docs/KERNEL-DUMPS.md
@@ -33,7 +33,8 @@ After successfully loading the dump-capture kernel as previously described in th
 EVE-OS has a `kdump` container that checks for `/proc/vmcore` and generates a minimal crash dump by calling the makedumpfile tool. The `kdump` container is part of the linuxkit onboot process and is run strictly after the storage is initialized. The minimal kernel dump collection includes the following steps:
 
 * Minimal kernel dump will be generated in the `/persist/kcrashes` folder.
-* Only 5 fresh kernel dumps is stored in the folder, old dumps are deleted.
+* Dmesg (kernel ring buffer) of the crashed kernel will be saved in the `/persist/kcrashes` folder.
+* Only 5 fresh kernel dumps and dmesgs are stored in the folder, old files are deleted.
 * Kernel panic message from the crashed system buffer is redirected to the EVE-OS /persist/reboot-stack file and to the tty console in order to show it on the connected monitor for debug purposes.
 * Reboot reason string "kernel panic, kdump collected: $KDUMP_PATH" is redirected to the EVE-OS /persist/reboot-reason file.
 * After the crash dump is created, the kernel will be rebooted according to the `/proc/sys/kernel/panic` timeout configuration value.

--- a/pkg/kdump/kdump.sh
+++ b/pkg/kdump/kdump.sh
@@ -6,7 +6,12 @@ if test -f /proc/vmcore; then
     #
     # We are in dump capture kernel, nice.
     #
-    MAX=5
+
+    # Maximum number of kernel dumps and dmesgs we keep in the folder.
+    # After each kernel crash 2 files are generated: dump and dmesg,
+    # so the divide MAX on number of files to get total number of
+    # kernel crashes which we keep persist.
+    MAX=10
     DIR=/persist/kcrashes
 
     # Create a folder


### PR DESCRIPTION
Commit 7e6274c2edb8 ("kdump: collect dmesg along with a kdump") introduced generation of the dmesg file of a crashed kernel, so by this PR doc is updated and the maximum number for persist crashes is doubled in order to keep all files for exact 5 kernel crashes.
