### PR TITLE
use linuxkit with complete apk db on base

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,7 @@ DOCKER_GO = _() { $(SET_X); mkdir -p $(CURDIR)/.go/src/$${3:-dummy} ; mkdir -p $
 
 PARSE_PKGS=$(if $(strip $(EVE_HASH)),EVE_HASH=)$(EVE_HASH) DOCKER_ARCH_TAG=$(DOCKER_ARCH_TAG) ./tools/parse-pkgs.sh
 LINUXKIT=$(BUILDTOOLS_BIN)/linuxkit
-LINUXKIT_VERSION=bbd62314edf03b8e947536511c1286df65b1e0ff
+LINUXKIT_VERSION=d1452385cca6574e0f0bfa8c120e39bef89f2852
 LINUXKIT_SOURCE=https://github.com/linuxkit/linuxkit.git
 LINUXKIT_OPTS=$(if $(strip $(EVE_HASH)),--hash) $(EVE_HASH) $(if $(strip $(EVE_REL)),--release) $(EVE_REL)
 LINUXKIT_PKG_TARGET=build


### PR DESCRIPTION
No functionality change, but the `/lib/apk/db/installed` in the base OS image as generated by linuxkit is now fully complete. This is a step towards generating integrated SBoMs.

As discussed with @eriknordmark 