### PR TITLE
separate steps for generating rootfs

### DIFF
--- a/tools/makerootfs.sh
+++ b/tools/makerootfs.sh
@@ -1,30 +1,122 @@
 #!/bin/bash
 # Usage:
 #
-#     ./makerootfs.sh <image.yml> <output rootfs image> <fs> <arch>
+#     ./makerootfs.sh mode [-y <image.yml>] [-i <output rootfs image>] [-t <tar file>] [-f <filesystem format>] [-a <arch>]
 # <fs> defaults to squash
 # <arch> defaults to the current machine architecture
 
 set -e
 set -o pipefail
 
+# mode 3 - generate image from yml
+do_image() {
+  # shellcheck disable=SC2166
+  if [ -z "$ymlfile" -o -z "$imgfile" -o -n "$tarfile" ]; then
+    echo "must supply ymlfile and imgfile and not tarfile" >&2
+    help
+  fi
+  # did we specify an architecture?
+  ARCHARG=""
+  if [ -n "$arch" ]; then
+    ARCHARG="-arch ${arch}"
+  fi
+  : > "$IMAGE"
+  # shellcheck disable=SC2086
+  linuxkit build -docker ${ARCHARG} -o - "$ymlfile" | docker run -i --rm -v /dev:/dev --privileged -v "$IMAGE:/rootfs.img" "${MKROOTFS_TAG}"
+}
+
+# mode 1 - generate tarfile from yml and save
+do_tar() {
+  # shellcheck disable=SC2166
+  if [ -z "$ymlfile" -o -z "$tarfile" -o -n "$imgfile" ]; then
+    echo "must supply ymlfile and tarfile and not imgfile" >&2
+    help
+  fi
+  # did we specify an architecture?
+  ARCHARG=""
+  if [ -n "$arch" ]; then
+    ARCHARG="-arch ${arch}"
+  fi
+  # shellcheck disable=SC2086
+  linuxkit build -docker ${ARCHARG} -o "${tarfile}" "$ymlfile"
+}
+
+# mode 2 - generate image from tarfile
+do_imagefromtar() {
+  # shellcheck disable=SC2166
+  if [ -z "$tarfile" -o -z "$imgfile" -o -n "$ymlfile" ]; then
+    echo "must supply tarfile and imgfile and not ymlfile" >&2
+    help
+  fi
+  : > "$IMAGE"
+  # shellcheck disable=SC2002
+  cat "${tarfile}" | docker run -i --rm -v /dev:/dev --privileged -v "$IMAGE:/rootfs.img" "${MKROOTFS_TAG}"
+}
+
+bail() {
+  echo "$@" >&2
+  help
+}
+
+
+# no mode we recognize
+help() {
+  echo "Usage: $0 <mode> [-y <image.yml>] [-i <output rootfs image>] [-t <tarfile>] [-f {ext4|squash}] [-a <arch>]" >&2
+  echo "must be one of the following modes:" >&2
+  echo "  generate final image from yml:" >&2
+  echo "    $0 image [-y <image.yml>] [-i <output rootfs image>] [-f {ext4|squash}] [-a <arch>]" >&2
+  echo "  generate tar from yml:" >&2
+  echo "    $0 tar [-y <image.yml>] [-t <output tarfile>] [-a <arch>]" >&2
+  echo "  generate final image from tar:" >&2
+  echo "    $0 imagefromtar [-i <output rootfs image>] [-f {ext4|squash}] [-t <input tarfile>]" >&2
+  exit 1
+}
+
+# there are 3 modes we can run in:
+# 1. generate tarfile from yml and save
+# 2. generate image from tarfile
+# 3. generate image from yml
+mode="$1"
+shift
+
+unset tarfile imgfile arch format ymlfile
+while getopts "t:i:a:f:y:h" o
+do
+  case $o in
+    t)
+      tarfile=$OPTARG
+      ;;
+    i)
+      imgfile=$OPTARG
+      ;;
+    a)
+      arch=$OPTARG
+      ;;
+    f)
+      format=$OPTARG
+      ;;
+    y)
+      ymlfile=$OPTARG
+      ;;
+    h)
+      help
+      ;;
+    *)
+      ;;
+  esac
+done
+
+[ -z "$format" ] && format="squash"
+
 EVE="$(cd "$(dirname "$0")" && pwd)/../"
 PATH="$EVE/build-tools/bin:$PATH"
-MKROOTFS_TAG="$(linuxkit pkg show-tag "$EVE/pkg/mkrootfs-${3:-squash}")"
-YMLFILE="$1"
-IMAGE="$(cd "$(dirname "$2")" && pwd)/$(basename "$2")"
+MKROOTFS_TAG="$(linuxkit pkg show-tag "$EVE/pkg/mkrootfs-${format}")"
+IMAGE="$(cd "$(dirname "$imgfile")" && pwd)/$(basename "$imgfile")"
 
-if [ ! -f "$YMLFILE" ] || [ $# -lt 2 ]; then
-    echo "Usage: $0 <image.yml> <output rootfs image> [{ext4|squash}]"
-    exit 1
-fi
+action="do_${mode}"
+#shellcheck disable=SC2039
+command -V "$action" > /dev/null 2>&1 || bail "Error: unsupported command '$mode'."
 
-# did we specify an architecture?
-ARCH="$4"
-ARCHARG=""
-if [ -n "$ARCH" ]; then
-  ARCHARG="-arch ${ARCH}"
-fi
+# Do. Or do not. There is no try.
+"$action" "$@"
 
-: > "$IMAGE"
-linuxkit build -docker ${ARCHARG} -o - "$YMLFILE" | docker run -i --rm -v /dev:/dev --privileged -v "$IMAGE:/rootfs.img" "${MKROOTFS_TAG}"


### PR DESCRIPTION
This does not change anything in the output, only in the interim steps.

### Current

Currently, we generate the `rootfs.img` by calling `makerootfs.sh`, which calls (simplified):

```
linuxkit build -o - $YML | docker run mkrootfs-squash
```

In other words, we build the OS root filesystem (left hand side of above) and pipe the tar stream to the container that creates squashfs (or ext4).

This works, but has two shortcomings:

1. If we need to regenerate, we have to do the whole thing, both expensive parts.
2. We cannot use the interim output tar for anything useful (like, perhaps, scanning for an SBoM or security)

### Proposed

This PR breaks the above down into 2 steps:

1. Generate the `rootfs.tar` file
2. Use the tar file to generate the rootfs image (squashfs or ext4)

The `rootfs.tar` is in the `dist/<arch>/<release>/` directory, but _not_ in the `installer/` subdir, as we do not need the tar file artifact in the final eve image.

A next step PR will add scanners, initial for an SBoM which will be included in `installer/` and thus in the resulting image, but possibly also in other places (release artifacts), and future security scanners.

### How

Change:

* `tools/makerootfs.sh` to have 3 different operating modes, as well as use `getopt` to parse the CLI flags
* `Makefile` to add a `rootfstar` target and several target changes
* `docs/BUILD.md` to describe the new usage