### PR TITLE
Update of eden tests and EdenGCP workflow

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -47,7 +47,7 @@ jobs:
           if [ -f ${{ github.workspace }}/eve/tests/eden/eden-version ]; then
             EDEN_VERSION=$(cat ${{ github.workspace }}/eve/tests/eden/eden-version)
           else
-            EDEN_VERSION=lfedge/eden:0.7.2
+            EDEN_VERSION=lfedge/eden:0.8.0
           fi
           docker run -v $PWD:/out $EDEN_VERSION cp -a /eden/. /out/
           sudo chown -R $(whoami) .

--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -124,23 +124,18 @@ jobs:
             if [ -z "${{ github.event.inputs.pr_number }}" ]; then echo "::error::pr_number is empty" && exit 1; fi
           fi
       # We run this workflow for tags, release and default branches,
-      # so we should pull required version of EVE.
-      - name: Prepare EVE (workflow)
-        if: github.event_name == 'workflow_run'
-        env:
-          REF: ${{ github.event.workflow_run.head_branch }}
-        run: |
-          BRANCH="$(echo "$REF" | sed -e 's#^.*/##')"
-          git clone ${{ github.event.repository.html_url }} eve
-          git --git-dir ./eve/.git reset --hard "$BRANCH"
-          echo "EVE_TAG=$(make -C eve --no-print-directory version)" >> "$GITHUB_ENV"
-          echo "EVE_REGISTRY=lfedge/eve" >> "$GITHUB_ENV"
-      - name: Checkout EVE (manual run)
-        if: github.event_name == 'workflow_dispatch'
+      # so we should pull required version of EVE
+      # actions/checkout supports information from workflow_run
+      - name: Checkout EVE
         uses: actions/checkout@v3
         with:
-          ref: master
+          fetch-depth: 0
           path: eve
+      - name: Prepare EVE (workflow)
+        if: github.event_name == 'workflow_run'
+        run: |
+          echo "EVE_TAG=$(make -C eve --no-print-directory version)" >> "$GITHUB_ENV"
+          echo "EVE_REGISTRY=lfedge/eve" >> "$GITHUB_ENV"
       - name: Prepare EVE (manual run)
         if: github.event_name == 'workflow_dispatch'
         run: |
@@ -156,10 +151,14 @@ jobs:
               echo "EVE_REGISTRY=${{ github.event.inputs.eve_docker_reg }}" >> "$GITHUB_ENV"
             fi
           fi
-      # Use the latest version of EDEN with subset of tests from EVE-OS repo
+      # Use stored or the latest version of EDEN with subset of tests from EVE-OS repo
       - name: Prepare eden
         run: |
-          EDEN_VERSION=lfedge/eden:0.7.2
+          if [ -f ${{ github.workspace }}/eve/tests/eden/eden-version ]; then
+            EDEN_VERSION=$(cat ${{ github.workspace }}/eve/tests/eden/eden-version)
+          else
+            EDEN_VERSION=lfedge/eden:0.7.2
+          fi
           docker run -v $PWD:/out $EDEN_VERSION cp -a /eden/. /out/
           sudo chown -R $(whoami) .
       - name: Eden setup

--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -157,7 +157,7 @@ jobs:
           if [ -f ${{ github.workspace }}/eve/tests/eden/eden-version ]; then
             EDEN_VERSION=$(cat ${{ github.workspace }}/eve/tests/eden/eden-version)
           else
-            EDEN_VERSION=lfedge/eden:0.7.2
+            EDEN_VERSION=lfedge/eden:0.8.0
           fi
           docker run -v $PWD:/out $EDEN_VERSION cp -a /eden/. /out/
           sudo chown -R $(whoami) .

--- a/tests/eden/app/testdata/2dockers_test.txt
+++ b/tests/eden/app/testdata/2dockers_test.txt
@@ -58,7 +58,9 @@ test:
         onboard-cert: {{EdenConfigPath "eve.cert"}}
         serial: "{{EdenConfig "eve.serial"}}"
         model: {{EdenConfig "eve.devmodel"}}
+
 -- get.sh --
-address=`grep "^$1"'\s*' pod_ps | cut -f 5`
-until curl $address; do sleep 5; done
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+PORT=`grep "^$1"'\s*' pod_ps | awk '{print $5}' | cut -d ":" -f 2`
+until $EDEN sdn fwd eth0 $PORT -- curl FWD_IP:FWD_PORT; do sleep 5; done
 

--- a/tests/eden/docker/testdata/2dockers_test.txt
+++ b/tests/eden/docker/testdata/2dockers_test.txt
@@ -48,4 +48,6 @@ test:
         model: {{EdenConfig "eve.devmodel"}}
 
 -- get.sh --
-curl `grep "^$1"'\s*' pod_ps | cut -f 5`
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+PORT=`grep "^$1"'\s*' pod_ps | awk '{print $5}' | cut -d ":" -f 2`
+$EDEN sdn fwd eth0 $PORT -- curl FWD_IP:FWD_PORT

--- a/tests/eden/eclient/testdata/acl.txt
+++ b/tests/eden/eclient/testdata/acl.txt
@@ -1,6 +1,6 @@
 # Test particular host access
 
-{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@FWD_IP -p FWD_PORT{{end}}
 
 # source for very long domains: https://longest.domains/
 {{$long_domain := "theofficialabsolutelongestdomainnameregisteredontheworldwideweb.international"}}
@@ -92,7 +92,7 @@ stdout 'ieee.org'
 # Cleanup - undeploy applications
 eden pod delete curl-acl1
 eden pod delete curl-acl2
-test eden.app.test -test.v -timewait 10m - curl-acl1 curl-acl2
+test eden.app.test -test.v -timewait 20m - curl-acl1 curl-acl2
 
 # Cleanup - remove network
 eden network delete {{$network_name}}
@@ -103,15 +103,14 @@ eden network ls
 -- wait_ssh.sh --
 
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 for p in $*
 do
   for i in `seq 20`
   do
     sleep 20
     # Test SSH-access to container
-    echo {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue
-    {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue && break
+    echo $EDEN sdn fwd eth0 $p -- {{template "ssh"}} grep -q Ubuntu /etc/issue
+    $EDEN sdn fwd eth0 $p -- {{template "ssh"}} grep -q Ubuntu /etc/issue && break
   done
 done
 
@@ -128,15 +127,13 @@ echo host_ip=$IP>>.env
 -- curl.sh --
 
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
-echo {{template "ssh"}}$HOST -p $1 curl -v --max-time 30 "$2"
-{{template "ssh"}}$HOST -p $1 curl -v --max-time 30 "$2"
+echo $EDEN sdn fwd eth0 $1 -- {{template "ssh"}} curl -v --max-time 30 "$2"
+$EDEN sdn fwd eth0 $1 -- {{template "ssh"}} curl -v --max-time 30 "$2"
 
 -- ping_between_apps.sh --
 
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
 app1=$1
 app2=$2
@@ -145,10 +142,10 @@ app2_ssh_port=$($EDEN pod ps | grep $app2 | awk '{print $5}' | cut -d ":" -f 2)
 app1_ip=$($EDEN pod ps | grep $app1 | awk '{print $4}' | cut -d ":" -f 1)
 app2_ip=$($EDEN pod ps | grep $app2 | awk '{print $4}' | cut -d ":" -f 1)
 
-echo {{template "ssh"}}$HOST -p $app1_ssh_port ping -c 5 $app2_ip
-{{template "ssh"}}$HOST -p $app1_ssh_port ping -c 5 $app2_ip      && exit
-echo {{template "ssh"}}$HOST -p $app2_ssh_port ping -c 5 $app1_ip
-{{template "ssh"}}$HOST -p $app2_ssh_port ping -c 5 $app1_ip      && exit
+echo $EDEN sdn fwd eth0 $app1_ssh_port -- {{template "ssh"}} ping -c 5 $app2_ip
+$EDEN sdn fwd eth0 $app1_ssh_port -- {{template "ssh"}} ping -c 5 $app2_ip      && exit
+echo $EDEN sdn fwd eth0 $app2_ssh_port -- {{template "ssh"}} ping -c 5 $app1_ip
+$EDEN sdn fwd eth0 $app2_ssh_port -- {{template "ssh"}} ping -c 5 $app1_ip      && exit
 
 # ping routed by EVE was blocked, but check if on the L2 layer it is blocked as well
 # (i.e. when only forwarded by EVE)...
@@ -160,16 +157,16 @@ function configure_link_route {
     iface=\$(ifconfig | awk -v filter=\"inet $from_ip\" '\$0 ~ filter {print \$1}' RS=\"\n\n\" FS=\":\") &&
     ip route add $to_ip dev \$iface
     "
-    echo {{template "ssh"}}$HOST -p $from_ssh_port "$CMDS"
-    {{template "ssh"}}$HOST -p $from_ssh_port "$CMDS"
+    echo $EDEN sdn fwd eth0 $from_ssh_port -- {{template "ssh"}} "$CMDS"
+    $EDEN sdn fwd eth0 $from_ssh_port -- {{template "ssh"}} "$CMDS"
 }
 configure_link_route $app1_ssh_port $app1_ip $app2_ip
 configure_link_route $app2_ssh_port $app2_ip $app1_ip
 
-echo {{template "ssh"}}$HOST -p $app1_ssh_port ping -c 5 $app2_ip
-{{template "ssh"}}$HOST -p $app1_ssh_port ping -c 5 $app2_ip      && exit
-echo {{template "ssh"}}$HOST -p $app2_ssh_port ping -c 5 $app1_ip
-{{template "ssh"}}$HOST -p $app2_ssh_port ping -c 5 $app1_ip      && exit
+echo $EDEN sdn fwd eth0 $app1_ssh_port -- {{template "ssh"}} ping -c 5 $app2_ip
+$EDEN sdn fwd eth0 $app1_ssh_port -- {{template "ssh"}} ping -c 5 $app2_ip      && exit
+echo $EDEN sdn fwd eth0 $app2_ssh_port -- {{template "ssh"}} ping -c 5 $app1_ip
+$EDEN sdn fwd eth0 $app2_ssh_port -- {{template "ssh"}} ping -c 5 $app1_ip      && exit
 
 -- wait_netstat.sh --
 #!/bin/sh

--- a/tests/eden/eclient/testdata/air-gapped-switch.txt
+++ b/tests/eden/eclient/testdata/air-gapped-switch.txt
@@ -6,7 +6,7 @@
 {{define "port2"}}2224{{end}}
 {{define "mac2"}}00:01:02:03:04:02{{end}}
 {{define "ip2"}}11.12.13.12{{end}}
-{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@FWD_IP -p FWD_PORT{{end}}
 {{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
 
 [!exec:bash] stop
@@ -70,45 +70,40 @@ eden network ls
 
 -- wait_ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 for p in $*
 do
   for i in `seq 20`
   do
     # Test SSH-access to container
-    echo {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue
-    {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue && break
+    echo $EDEN sdn fwd eth0 $p -- {{template "ssh"}} grep -q Ubuntu /etc/issue
+    $EDEN sdn fwd eth0 $p -- {{template "ssh"}} grep -q Ubuntu /etc/issue && break
     sleep 10
   done
 done
 
 -- prepare1.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
-echo {{template "ssh"}}$HOST -p {{template "port1"}} ip a add {{template "ip1"}}/24 dev eth1
-{{template "ssh"}}$HOST -p {{template "port1"}} ip a add {{template "ip1"}}/24 dev eth1
+echo $EDEN sdn fwd eth0 {{template "port1"}} -- {{template "ssh"}} ip a add {{template "ip1"}}/24 dev eth1
+$EDEN sdn fwd eth0 {{template "port1"}} -- {{template "ssh"}} ip a add {{template "ip1"}}/24 dev eth1
 
-echo {{template "ssh"}}$HOST -p {{template "port1"}} ip a
-{{template "ssh"}}$HOST -p {{template "port1"}} ip a
+echo $EDEN sdn fwd eth0 {{template "port1"}} -- {{template "ssh"}} ip a
+$EDEN sdn fwd eth0 {{template "port1"}} -- {{template "ssh"}} ip a
 
 -- prepare2.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
-echo {{template "ssh"}}$HOST -p {{template "port2"}} ip a add {{template "ip2"}}/24 dev eth1
-{{template "ssh"}}$HOST -p {{template "port2"}} ip a add {{template "ip2"}}/24 dev eth1
+echo $EDEN sdn fwd eth0 {{template "port2"}} -- {{template "ssh"}} ip a add {{template "ip2"}}/24 dev eth1
+$EDEN sdn fwd eth0 {{template "port2"}} -- {{template "ssh"}} ip a add {{template "ip2"}}/24 dev eth1
 
-echo {{template "ssh"}}$HOST -p {{template "port2"}} ip a
-{{template "ssh"}}$HOST -p {{template "port2"}} ip a
-
+echo $EDEN sdn fwd eth0 {{template "port2"}} -- {{template "ssh"}} ip a
+$EDEN sdn fwd eth0 {{template "port2"}} -- {{template "ssh"}} ip a
 
 -- ping.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
-echo {{template "ssh"}}$HOST -p {{template "port1"}} ping -I eth1 -c 10 {{template "ip2"}}
-{{template "ssh"}}$HOST -p {{template "port1"}} ping -I eth1 -c 10 {{template "ip2"}}
+echo $EDEN sdn fwd eth0 {{template "port1"}} -- {{template "ssh"}} ping -I eth1 -c 10 {{template "ip2"}}
+$EDEN sdn fwd eth0 {{template "port1"}} -- {{template "ssh"}} ping -I eth1 -c 10 {{template "ip2"}}
 
 -- eden-config.yml --
 {{/* Test's config. file */}}

--- a/tests/eden/eclient/testdata/app_dhcp.txt
+++ b/tests/eden/eclient/testdata/app_dhcp.txt
@@ -18,7 +18,7 @@ source .env
 [!env:with_hw_virt] skip 'Missing HW-assisted virtualization capability'
 
 {{define "port"}}2223{{end}}
-{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{template "port"}} root@{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@FWD_IP -p FWD_PORT{{end}}
 {{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
 
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
@@ -93,14 +93,13 @@ done
 
 -- wait_ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
 for i in `seq 20`
 do
   sleep 20
   # Test SSH-access to container
-  echo {{template "ssh"}}$HOST grep -q Ubuntu /etc/issue
-  {{template "ssh"}}$HOST grep -q Ubuntu /etc/issue && break
+  echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} grep -q Ubuntu /etc/issue
+  $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} grep -q Ubuntu /etc/issue && break
 done
 
 -- wait_for_app_ip.sh --
@@ -108,17 +107,16 @@ done
 
 APP=$1
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
 function get_ip {
-    ifconfig=$({{template "ssh"}}$HOST ifconfig 2>/dev/null) || return 1
+    ifconfig=$($EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} ifconfig 2>/dev/null) || return 1
     if [ -z "$ifconfig" ]; then
         return 1
     fi
-    interfaces=$(echo "$ifconfig" | grep "^\w" | grep -v LOOPBACK | cut -d: -f1)
+    interfaces=$(echo "$ifconfig" | grep "^\w" | grep -iv LOOPBACK | cut -d' ' -f1 | cut -d':' -f1)
     eth1=$(echo "$interfaces" | awk 'NR==2')
-    IP=$(echo "$ifconfig" | grep "^${eth1}: " -A 1 | awk '/inet / {print $2}')
-    MAC=$(echo "$ifconfig" | grep "^${eth1}: " -A 2 | awk '/ether / {print $2}')
+    IP=$(echo "$ifconfig" | grep "^${eth1}" -A 1 | grep 'inet ' | sed 's/addr://' | awk '/inet / {print $2}')
+    MAC=$(echo "$ifconfig" | grep "^${eth1}" -A 3 | sed 's/^.*HWaddr/ether/' | awk '/ether / {print $2}' | awk -F' ' '{print tolower($NF)}')
     if [ ! -z "$IP" ]; then
         echo "IP address of $APP is: $IP"
         echo "${APP}_ip=$IP" >.env
@@ -155,9 +153,8 @@ until get_ip_assignments; do sleep 3; done
 CLIENT_MAC=$1
 CLIENT_IP=$2
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
-{{template "ssh"}}$HOST dhcping -c $CLIENT_IP -h $CLIENT_MAC -s 10.11.13.1 -i -v
+$EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} dhcping -c $CLIENT_IP -h $CLIENT_MAC -s 10.11.13.1 -i -v
 
 -- eden-config.yml --
 {{/* Test's config. file */}}

--- a/tests/eden/eclient/testdata/app_local_info.txt
+++ b/tests/eden/eclient/testdata/app_local_info.txt
@@ -6,7 +6,7 @@
 {{define "app_info_status_file"}}/mnt/app-info-status.json{{end}}
 {{define "app_cmd_file"}}/mnt/app-command.json{{end}}
 {{define "network"}}n1{{end}}
-{{define "ssh"}}ssh -q -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@{{end}}
+{{define "ssh"}}ssh -q -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@FWD_IP -p FWD_PORT{{end}}
 {{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
 
 [!exec:bash] stop
@@ -151,23 +151,21 @@ test eden.network.test -test.v -timewait 10m - {{template "network"}}
 
 -- wait-ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 for p in $*
 do
   for i in `seq 20`
   do
     sleep 20
     # Test SSH-access to container
-    echo {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue
-    {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue && break
+    echo $EDEN sdn fwd eth0 $p -- {{template "ssh"}} grep -q Ubuntu /etc/issue
+    $EDEN sdn fwd eth0 $p -- {{template "ssh"}} grep -q Ubuntu /etc/issue && break
   done
 done
 
 -- local-manager-start.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 ARGS="--token={{template "token"}}"
-{{template "ssh"}}$HOST -p {{template "mngr_port"}} "/root/local_manager $ARGS &>/proc/1/fd/1 &"
+$EDEN sdn fwd eth0 {{template "mngr_port"}} -- {{template "ssh"}} "/root/local_manager $ARGS &>/proc/1/fd/1 &"
 
 -- get-app-ip.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
@@ -176,7 +174,6 @@ echo app_ip=$IP>>.env
 
 -- get-appinfo-status.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 APP="$1"
 CMDS="
 until test -f {{template "app_info_status_file"}}; do sleep 5; done
@@ -184,7 +181,7 @@ sleep 2
 cat {{template "app_info_status_file"}}
 "
 
-OUTPUT="$({{template "ssh"}}$HOST -p {{template "mngr_port"}} "$CMDS")"
+OUTPUT="$($EDEN sdn fwd eth0 {{template "mngr_port"}} -- {{template "ssh"}} "$CMDS")"
 if [ -n "$APP" ]; then
     echo "$OUTPUT" | jq --arg APP "$APP" '.appsInfo[] | select(.name==$APP)'
 else
@@ -197,12 +194,11 @@ TIMESTAMP="${2:-0}"
 CMD="${3:-COMMAND_UNSPECIFIED}"
 
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 CONFIG="{\"displayname\": \"$DN\", \"timestamp\": $TIMESTAMP, \"command\": \"$CMD\"}"
 
 while true; do
-    echo "$CONFIG" | {{template "ssh"}}$HOST -p {{template "mngr_port"}} 'cat > {{template "app_cmd_file"}}'
-    APP_CMD_FILE_CONTENT="$({{template "ssh"}}$HOST -p {{template "mngr_port"}} "cat {{template "app_cmd_file"}}")"
+    echo "$CONFIG" | $EDEN sdn fwd eth0 {{template "mngr_port"}} -- {{template "ssh"}} 'cat > {{template "app_cmd_file"}}'
+    APP_CMD_FILE_CONTENT="$($EDEN sdn fwd eth0 {{template "mngr_port"}} -- {{template "ssh"}} "cat {{template "app_cmd_file"}}")"
     echo "$APP_CMD_FILE_CONTENT" | grep "$CMD" && break
     sleep 1
 done
@@ -212,10 +208,9 @@ APP="${1}"
 EXPSTATE="${2}"
 
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
 while true; do
-    APPINFO="$({{template "ssh"}}$HOST -p {{template "mngr_port"}} "cat {{template "app_info_status_file"}}")"
+    APPINFO="$($EDEN sdn fwd eth0 {{template "mngr_port"}} -- {{template "ssh"}} "cat {{template "app_info_status_file"}}")"
     APPINFO="$(echo "$APPINFO" | jq --arg APP "$APP" '.appsInfo[] | select(.name==$APP)')"
     echo "$APPINFO" | grep "$EXPSTATE" && break
     sleep 1
@@ -225,17 +220,15 @@ done
 FILEPATH="${1}"
 
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
-{{template "ssh"}}$HOST -p {{template "app_port"}} "touch \"$FILEPATH\""
+$EDEN sdn fwd eth0 {{template "app_port"}} -- {{template "ssh"}} "touch \"$FILEPATH\""
 
 -- file-exists-in-app1.sh --
 FILEPATH="${1}"
 
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
-{{template "ssh"}}$HOST -p {{template "app_port"}} "test -f \"$FILEPATH\""
+$EDEN sdn fwd eth0 {{template "app_port"}} -- {{template "ssh"}} "test -f \"$FILEPATH\""
 
 -- wait-for-volume.sh --
 APP="${1}"

--- a/tests/eden/eclient/testdata/app_nonat.txt
+++ b/tests/eden/eclient/testdata/app_nonat.txt
@@ -1,7 +1,7 @@
 # Test app_nonat is verifying that we can use a switch network instance on a management port.
 
 {{define "port"}}2223{{end}}
-{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{template "port"}} root@{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@FWD_IP -p FWD_PORT{{end}}
 {{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
 
 [!exec:bash] stop
@@ -67,24 +67,22 @@ eden network ls
 
 -- wait_ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
 for i in `seq 20`
 do
   sleep 20
   # Test SSH-access to container
-  echo {{template "ssh"}}$HOST grep -q Ubuntu /etc/issue
-  {{template "ssh"}}$HOST grep -q Ubuntu /etc/issue && break
+  echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} grep -q Ubuntu /etc/issue
+  $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} grep -q Ubuntu /etc/issue && break
 done
 
 -- ping.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
-echo {{template "ssh"}}$HOST sysctl net.ipv4.conf.eth1.rp_filter=2
-{{template "ssh"}}$HOST sysctl net.ipv4.conf.eth1.rp_filter=2
-echo {{template "ssh"}}$HOST ping -I eth1 -c 50 www.google.com
-{{template "ssh"}}$HOST ping -I eth1 -c 50 www.google.com
+echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} sysctl net.ipv4.conf.eth1.rp_filter=2
+$EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} sysctl net.ipv4.conf.eth1.rp_filter=2
+echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} ping -I eth1 -c 10 www.google.com
+$EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} ping -I eth1 -c 10 www.google.com
 
 -- eden-config.yml --
 {{/* Test's config. file */}}

--- a/tests/eden/eclient/testdata/com-pt_test.txt
+++ b/tests/eden/eclient/testdata/com-pt_test.txt
@@ -3,7 +3,7 @@
 # We can not test that the serial port is functional; merely that it exists.
 
 {{define "port"}}2223{{end}}
-{{define "ssh"}} ssh -oServerAliveInterval=10 -oConnectTimeout=10 -oStrictHostKeyChecking=no -oPasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{template "port"}} root@$HOST {{end}}
+{{define "ssh"}} ssh -oServerAliveInterval=10 -oConnectTimeout=10 -oStrictHostKeyChecking=no -oPasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@FWD_IP -p FWD_PORT{{end}}
 {{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
 
 [!exec:bash] stop
@@ -62,19 +62,17 @@ test eden.app.test -test.v -timewait 10m - eclient
 
 -- ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
 for i in `seq 20`
 do
-sleep 20
-# Test SSH-access to container
-echo $i\) {{template "ssh"}} grep Ubuntu /etc/issue
-{{template "ssh"}} grep Ubuntu /etc/issue && break
+  sleep 20
+  # Test SSH-access to container
+  echo $i\) $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} grep Ubuntu /etc/issue
+  $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} grep Ubuntu /etc/issue && break
 done
 
 -- set_serial.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 CNF=eve.cfg
 
 $EDEN controller edge-node get-config --file $CNF
@@ -87,29 +85,26 @@ $EDEN controller edge-node set-config --file $CNF.new
 
 -- get_serial.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
 for i in `seq 20`
 do
-sleep 20
-# Test SSH-access to container
-echo $i\) {{template "ssh"}} setserial -g $1
-{{template "ssh"}} setserial -g $1 && break
+  sleep 20
+  # Test SSH-access to container
+  echo $i\) $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} setserial -g $1
+  $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} setserial -g $1 && break
 done
 
 -- get_reboot_time.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
-echo {{template "ssh"}} uptime -s
-{{template "ssh"}} uptime -s
+echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} uptime -s
+$EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} uptime -s
 
 -- reboot.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
-echo {{template "ssh"}} reboot
-{{template "ssh"}} reboot
+echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} reboot
+$EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} reboot
 
 -- eden-config.yml --
 {{/* Test's config. file */}}

--- a/tests/eden/eclient/testdata/dev_local_info.txt
+++ b/tests/eden/eclient/testdata/dev_local_info.txt
@@ -7,7 +7,7 @@
 {{define "dev_info_status_file"}}/mnt/dev-info-status.json{{end}}
 {{define "dev_cmd_file"}}/mnt/dev-command.json{{end}}
 {{define "network"}}n1{{end}}
-{{define "ssh"}}ssh -q -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@{{end}}
+{{define "ssh"}}ssh -q -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@FWD_IP -p FWD_PORT{{end}}
 {{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
 
 [!exec:bash] stop
@@ -63,13 +63,12 @@ exec -t 5m bash wait-ssh.sh {{template "app_port"}}
 exec -t 10m bash wait-for-dev-state.sh ONLINE
 
 # STEP 4: Request for shutdown. Check that app1 stops before local_manager
-exec -t 10m bash wait-for-app-state.sh app1 HALTED &app1halted&
+exec -t 15m bash wait-for-app-state.sh app1 HALTED &app1halted&
 exec -t 1m bash put-devinfo-cmd.sh COMMAND_SHUTDOWN &
-exec -t 5m bash wait-for-dev-state.sh SHUTTING_DOWN
+exec -t 5m bash wait-for-dev-state.sh SHUTTING_DOWN &
 # Could it already have HALTED? Match HALTING or HALTED
 exec -t 5m bash wait-for-app-state.sh app1 HALT
-exec -t 1m bash get-appinfo-status.sh local-manager
-stdout 'RUNNING'
+exec -t 2m bash wait-for-app-state.sh local-manager RUNNING &
 wait app1halted
 
 # Did local-manager halt? Can't check by asking local-manager
@@ -112,11 +111,10 @@ skip 'The rest of the test is supported only on QEMU'
 
 # STEP 6: Request for poweroff. Check that app1 stops before local_manager
 exec -t 1m bash put-devinfo-cmd.sh COMMAND_SHUTDOWN_POWEROFF &
-exec -t 5m bash wait-for-dev-state.sh POWERING_OFF
+exec -t 5m bash wait-for-dev-state.sh POWERING_OFF &
 # Could it already have HALTED? Match HALTING or HALTED
 exec -t 5m bash wait-for-app-state.sh app1 HALT
-exec -t 1m bash get-appinfo-status.sh local-manager
-stdout 'RUNNING'
+exec -t 2m bash wait-for-app-state.sh local-manager RUNNING &
 exec -t 5m bash wait-for-app-state.sh app1 HALTED
 
 # Did local-manager halt? Can't check by asking local-manager
@@ -127,10 +125,13 @@ exec -t 1m bash eden-pod-ps.sh local-manager
 # STEP 7: Check qemu process is gone aka powered off
 exec sleep 120
 eden eve status
-stdout 'process not running'
+stdout 'EVE.*process not running'
 
 # STEP 8: Restart EVE; check apps come up
 message 'Restart EVE'
+# EVE VM is stopped but SDN VM (if used) is still running - stop it.
+eden eve stop
+exec sleep 10
 eden eve start
 exec sleep 30
 
@@ -152,24 +153,22 @@ exec sleep 10
 
 -- wait-ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 for p in $*
 do
   for i in `seq 20`
   do
     sleep 30
     # Test SSH-access to container
-    echo {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue
-    {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue && break
+    echo $EDEN sdn fwd eth0 $p -- {{template "ssh"}} grep -q Ubuntu /etc/issue
+    $EDEN sdn fwd eth0 $p -- {{template "ssh"}} grep -q Ubuntu /etc/issue && break
   done
 done
 
 -- local-manager-start.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 ARGS="--token={{template "token"}}"
 while true; do
-    {{template "ssh"}}$HOST -p {{template "mngr_port"}} "/root/local_manager $ARGS &>/proc/1/fd/1 &" && break
+    $EDEN sdn fwd eth0 {{template "mngr_port"}} -- {{template "ssh"}} "/root/local_manager $ARGS &>/proc/1/fd/1 &" && break
     sleep 5
 done
 
@@ -183,32 +182,14 @@ EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "ede
 line=$($EDEN pod ps | grep $1)
 echo line
 
--- get-appinfo-status.sh --
-EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
-APP="$1"
-CMDS="
-until test -f {{template "app_info_status_file"}}; do sleep 5; done
-sleep 2
-cat {{template "app_info_status_file"}}
-"
-
-OUTPUT="$({{template "ssh"}}$HOST -p {{template "mngr_port"}} "$CMDS")"
-if [ -n "$APP" ]; then
-    echo "$OUTPUT" | jq --arg APP "$APP" '.appsInfo[] | select(.name==$APP)'
-else
-    echo "$OUTPUT"
-fi
-
 -- wait-for-app-state.sh --
 APP="${1}"
 EXPSTATE="${2}"
 
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
 while true; do
-    APPINFO="$({{template "ssh"}}$HOST -p {{template "mngr_port"}} "cat {{template "app_info_status_file"}}")"
+    APPINFO="$($EDEN sdn fwd eth0 {{template "mngr_port"}} -- {{template "ssh"}} "cat {{template "app_info_status_file"}}")"
     APPINFO="$(echo "$APPINFO" | jq --arg APP "$APP" '.appsInfo[] | select(.name==$APP)')"
     echo "$APPINFO" | grep "$EXPSTATE" && break
     sleep 1
@@ -216,30 +197,28 @@ done
 
 -- get-devinfo-status.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 CMDS="
 until test -f {{template "dev_info_status_file"}}; do sleep 5; done
 sleep 2
 cat {{template "dev_info_status_file"}}
 "
 
-OUTPUT="$({{template "ssh"}}$HOST -p {{template "mngr_port"}} "$CMDS")"
+OUTPUT="$($EDEN sdn fwd eth0 {{template "mngr_port"}} -- {{template "ssh"}} "$CMDS")"
 echo "$OUTPUT"
 
-OUTPUT="$({{template "ssh"}}$HOST -p {{template "mngr_port"}} "$CMDS")"
+OUTPUT="$($EDEN sdn fwd eth0 {{template "mngr_port"}} -- {{template "ssh"}} "$CMDS")"
 echo "$OUTPUT"
 
 -- put-devinfo-cmd.sh --
 CMD="${1:-COMMAND_UNSPECIFIED}"
 
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 CONFIG="{\"command\": \"$CMD\"}"
 echo "$CONFIG"
 
 while true; do
-    echo "$CONFIG" | {{template "ssh"}}$HOST -p {{template "mngr_port"}} 'cat > {{template "dev_cmd_file"}}'
-    DEV_CMD_FILE_CONTENT="$({{template "ssh"}}$HOST -p {{template "mngr_port"}} "cat {{template "dev_cmd_file"}}")"
+    echo "$CONFIG" | $EDEN sdn fwd eth0 {{template "mngr_port"}} -- {{template "ssh"}} 'cat > {{template "dev_cmd_file"}}'
+    DEV_CMD_FILE_CONTENT="$($EDEN sdn fwd eth0 {{template "mngr_port"}} -- {{template "ssh"}} "cat {{template "dev_cmd_file"}}")"
     echo "$DEV_CMD_FILE_CONTENT" | grep "$CMD" && break
     sleep 1
 done
@@ -248,10 +227,9 @@ done
 EXPSTATE="${1}"
 
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
 while true; do
-    DEVINFO="$({{template "ssh"}}$HOST -p {{template "mngr_port"}} "cat {{template "dev_info_status_file"}}")"
+    DEVINFO="$($EDEN sdn fwd eth0 {{template "mngr_port"}} -- {{template "ssh"}} "cat {{template "dev_info_status_file"}}")"
     echo "$DEVINFO" | grep "$EXPSTATE" && break
     sleep 1
 done

--- a/tests/eden/eclient/testdata/disk.txt
+++ b/tests/eden/eclient/testdata/disk.txt
@@ -2,6 +2,7 @@
 
 {{$port := "2223"}}
 {{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
+{{define "ssh"}} ssh -oServerAliveInterval=10 -oConnectTimeout=10 -oStrictHostKeyChecking=no -oPasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@FWD_IP -p FWD_PORT{{end}}
 
 [!exec:bash] stop
 [!exec:sleep] stop
@@ -20,7 +21,7 @@ test eden.app.test -test.v -timewait 20m RUNNING eclient-disk
 #eden -t 20m pod logs eclient-disk
 #stdout 'Executing "/usr/sbin/sshd" "-D"'
 
-exec -t 20m bash ssh.sh
+exec -t 20m bash lsblk.sh
 # we can receive sd* for zfs-enabled test
 stdout '[sv]d.*disk'
 
@@ -38,13 +39,11 @@ test:
         serial: "{{EdenConfig "eve.serial"}}"
         model: {{EdenConfig "eve.devmodel"}}
 
--- ssh.sh --
+-- lsblk.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 for i in `seq 20`
 do
-sleep 20
-# Test SSH-access to container
-echo $i\) ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{$port}} root@$HOST grep Ubuntu /etc/issue
-ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{$port}} root@$HOST lsblk && break
+  sleep 20
+  echo $i\) $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} lsblk
+  $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} lsblk && break
 done

--- a/tests/eden/eclient/testdata/eclient.txt
+++ b/tests/eden/eclient/testdata/eclient.txt
@@ -2,6 +2,7 @@
 
 {{$port := "2223"}}
 {{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
+{{define "ssh"}} ssh -oServerAliveInterval=10 -oConnectTimeout=10 -oStrictHostKeyChecking=no -oPasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@FWD_IP -p FWD_PORT{{end}}
 
 [!exec:bash] stop
 [!exec:sleep] stop
@@ -39,11 +40,10 @@ test:
 
 -- ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 for i in `seq 20`
 do
-sleep 20
-# Test SSH-access to container
-echo $i\) ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{$port}} root@$HOST grep Ubuntu /etc/issue
-ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{$port}} root@$HOST grep Ubuntu /etc/issue && break
+  sleep 20
+  # Test SSH-access to container
+  echo $i\) $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} grep Ubuntu /etc/issue
+  $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} grep Ubuntu /etc/issue && break
 done

--- a/tests/eden/eclient/testdata/eclients.txt
+++ b/tests/eden/eclient/testdata/eclients.txt
@@ -3,6 +3,7 @@
 {{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
 {{$port := "2222"}}
 {{$test_opts := "-test.v -timewait 20m"}}
+{{define "ssh"}} ssh -oServerAliveInterval=10 -oConnectTimeout=10 -oStrictHostKeyChecking=no -oPasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@FWD_IP -p FWD_PORT{{end}}
 # Number of apps
 {{$apps := EdenGetEnv "EDEN_TEST_APPS"}}
 # Time of app waiting (default -- 30 min)
@@ -47,7 +48,6 @@ test:
 
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}" --config $EDEN_CONFIG"
 TAPP={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/eden.app.test
-HOST=$($EDEN eve ip)
 
 APPS="{{$apps}}"
 # Default image -- {{template "eclient_image"}}
@@ -80,8 +80,8 @@ do
 
 check() {
   # Test SSH-access to container
-  echo $1\) ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/../tests/eclient/image/cert/id_rsa -p $(({{$port}}+$1)) root@$HOST grep Ubuntu /etc/issue
-  ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/../tests/eclient/image/cert/id_rsa -p $(({{$port}}+$1)) root@$HOST grep Ubuntu /etc/issue
+  echo $1\) $EDEN sdn fwd eth0 -p $(({{$port}}+$1)) -- {{template "ssh"}} grep Ubuntu /etc/issue
+  $EDEN sdn fwd eth0 -p $(({{$port}}+$1)) -- {{template "ssh"}} grep Ubuntu /etc/issue
 }
 
 end () {
@@ -107,7 +107,6 @@ done
 
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}" --config $EDEN_CONFIG"
 TAPP={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/eden.app.test
-HOST=$($EDEN eve ip)
 
 APPS="{{$apps}}"
 # Default image -- {{template "eclient_image"}}

--- a/tests/eden/eclient/testdata/host-only.txt
+++ b/tests/eden/eclient/testdata/host-only.txt
@@ -1,7 +1,7 @@
 # Test host-only ACL application isolation
 
 {{$test_msg := "This is a test"}}
-{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@FWD_IP -p FWD_PORT{{end}}
 {{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
 
 [!exec:bash] stop
@@ -41,15 +41,14 @@ test eden.app.test -test.v -timewait 10m - ping-nw ping-fw pong
 -- wait_ssh.sh --
 
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 for p in $*
 do
   for i in `seq 20`
   do
     sleep 20
     # Test SSH-access to container
-    echo {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue
-    {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue && break
+    echo $EDEN sdn fwd eth0 $p -- {{template "ssh"}} grep -q Ubuntu /etc/issue
+    $EDEN sdn fwd eth0 $p -- {{template "ssh"}} grep -q Ubuntu /etc/issue && break
   done
 done
 
@@ -61,10 +60,9 @@ cat env
 . ./env
 
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
-echo {{template "ssh"}}$HOST -p $1 ping -c 5 "$PONG_IP"
-{{template "ssh"}}$HOST -p $1 ping -c 5 "$PONG_IP"
+echo $EDEN sdn fwd eth0 $1 -- {{template "ssh"}} ping -c 5 "$PONG_IP"
+$EDEN sdn fwd eth0 $1 -- {{template "ssh"}} ping -c 5 "$PONG_IP"
 
 -- eden-config.yml --
 {{/* Test's config. file */}}

--- a/tests/eden/eclient/testdata/maridb.txt
+++ b/tests/eden/eclient/testdata/maridb.txt
@@ -3,7 +3,7 @@
 {{$server := "mariadb"}}
 {{$test_msg := "MariaDB [(none)]> "}}
 {{define "port"}}2223{{end}}
-{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{template "port"}} root@{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@FWD_IP -p FWD_PORT{{end}}
 {{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
 
 [!exec:bash] stop
@@ -46,71 +46,73 @@ test eden.app.test -test.v -timewait 10m - eclient {{$server}}
 
 -- wait_ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 for i in `seq 20`
 do
   sleep 20
   # Test SSH-access to container
-  echo {{template "ssh"}}$HOST grep -q Ubuntu /etc/issue
-  {{template "ssh"}}$HOST grep -q Ubuntu /etc/issue && break
+  echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} grep -q Ubuntu /etc/issue
+  $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} grep -q Ubuntu /etc/issue && break
 done
 
 -- server_ip.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 echo export ESERVER_IP=$(grep "^$1\s" pod_ps | awk '{print $4}') > env
-echo export HOST=$($EDEN eve ip) >> env
 
 -- wait_db.sh --
 . ./env
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 
-until {{template "ssh"}}$HOST "echo 'SHOW DATABASES;' | mysql --user=root --password='adam&eve' --host=$ESERVER_IP"
+until $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} "echo 'SHOW DATABASES;' | mysql --user=root --password='adam&eve' --host=$ESERVER_IP"
 do
    sleep 10
 done
 
 -- run_client.sh --
 . ./env
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 
-echo {{template "ssh"}}$HOST 'cat > /tmp/mariadb.sql' < mariadb.in
-{{template "ssh"}}$HOST 'cat > /tmp/mariadb.sql' < mariadb.in
+echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} 'cat > /tmp/mariadb.sql' < mariadb.in
+$EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} 'cat > /tmp/mariadb.sql' < mariadb.in
 sleep 10
-echo {{template "ssh"}}$HOST "mysql --user=root --password='adam&eve' --host=$ESERVER_IP < /tmp/mariadb.sql > /tmp/mariadb.out"
-{{template "ssh"}}$HOST "mysql --user=root --password='adam&eve' --host=$ESERVER_IP < /tmp/mariadb.sql > /tmp/mariadb.out"
+echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} "mysql --user=root --password='adam&eve' --host=$ESERVER_IP < /tmp/mariadb.sql > /tmp/mariadb.out"
+$EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} "mysql --user=root --password='adam&eve' --host=$ESERVER_IP < /tmp/mariadb.sql > /tmp/mariadb.out"
 sleep 10
-echo {{template "ssh"}}$HOST 'cat /tmp/mariadb.out'
-{{template "ssh"}}$HOST 'cat /tmp/mariadb.out' > out
+echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} 'cat /tmp/mariadb.out'
+$EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} 'cat /tmp/mariadb.out' > out
 
 -- sysbench-read.sh --
 . ./env
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 
 BENCH_OPTS="/usr/share/sysbench/oltp_read_only.lua --threads=2 --tables=5 --table-size=100000"
 DRIVER_OPTS="--mysql-host=$ESERVER_IP --mysql-user=root --mysql-password='adam&eve' --mysql-port=3306"
 OPTS="$BENCH_OPTS $DRIVER_OPTS"
 
-echo {{template "ssh"}}$HOST "sysbench $OPTS prepare"
-{{template "ssh"}}$HOST "sysbench $OPTS prepare"
+echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} "sysbench $OPTS prepare"
+$EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} "sysbench $OPTS prepare"
 
-echo {{template "ssh"}}$HOST "sysbench $OPTS --range_selects=off --db-ps-mode=disable run"
-{{template "ssh"}}$HOST "sysbench $OPTS --range_selects=off --db-ps-mode=disable run"
+echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} "sysbench $OPTS --range_selects=off --db-ps-mode=disable run"
+$EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} "sysbench $OPTS --range_selects=off --db-ps-mode=disable run"
 
-echo {{template "ssh"}}$HOST "sysbench $OPTS --range_selects=off --db-ps-mode=disable cleanup"
-{{template "ssh"}}$HOST "sysbench $OPTS --range_selects=off --db-ps-mode=disable cleanup"
+echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} "sysbench $OPTS --range_selects=off --db-ps-mode=disable cleanup"
+$EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} "sysbench $OPTS --range_selects=off --db-ps-mode=disable cleanup"
 
 -- sysbench-read-write.sh --
 . ./env
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 
 BENCH_OPTS="/usr/share/sysbench/oltp_read_write.lua --threads=2 --tables=5 --table-size=100000"
 DRIVER_OPTS="--mysql-host=$ESERVER_IP --mysql-user=root --mysql-password='adam&eve' --mysql-port=3306"
 OPTS="$BENCH_OPTS $DRIVER_OPTS"
 
-echo {{template "ssh"}}$HOST "sysbench $OPTS prepare"
-{{template "ssh"}}$HOST "sysbench $OPTS prepare"
+echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} "sysbench $OPTS prepare"
+$EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} "sysbench $OPTS prepare"
 
-echo {{template "ssh"}}$HOST "sysbench $OPTS --delete_inserts=10 --index_updates=10 --non_index_updates=10 --db-ps-mode=disable run"
-{{template "ssh"}}$HOST "sysbench $OPTS --delete_inserts=10 --index_updates=10 --non_index_updates=10 --db-ps-mode=disable run"
+echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} "sysbench $OPTS --delete_inserts=10 --index_updates=10 --non_index_updates=10 --db-ps-mode=disable run"
+$EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} "sysbench $OPTS --delete_inserts=10 --index_updates=10 --non_index_updates=10 --db-ps-mode=disable run"
 
-echo {{template "ssh"}}$HOST "sysbench $OPTS --delete_inserts=10 --index_updates=10 --non_index_updates=10 --db-ps-mode=disable cleanup"
-{{template "ssh"}}$HOST "sysbench $OPTS --delete_inserts=10 --index_updates=10 --non_index_updates=10 --db-ps-mode=disable cleanup"
+echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} "sysbench $OPTS --delete_inserts=10 --index_updates=10 --non_index_updates=10 --db-ps-mode=disable cleanup"
+$EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} "sysbench $OPTS --delete_inserts=10 --index_updates=10 --non_index_updates=10 --db-ps-mode=disable cleanup"
 
 -- mariadb.in --
 CREATE DATABASE bookstore;

--- a/tests/eden/eclient/testdata/metadata.txt
+++ b/tests/eden/eclient/testdata/metadata.txt
@@ -2,6 +2,7 @@
 
 {{$port := "2223"}}
 {{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@FWD_IP -p FWD_PORT{{end}}
 
 [!exec:bash] stop
 [!exec:sleep] stop
@@ -40,11 +41,10 @@ test:
 
 -- ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 for i in `seq 20`
 do
-sleep 20
-# Test SSH-access to container
-echo $i\) ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{$port}} root@$HOST curl --header \"Content-Type: application/json\" --request POST -d \'{\"hello\":\"world\"}\' 169.254.169.254/eve/v1/kubeconfig
-ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{$port}} root@$HOST curl --header \"Content-Type: application/json\" --request POST -d \'{\"hello\":\"world\"}\' 169.254.169.254/eve/v1/kubeconfig && break
+  sleep 20
+  # Test SSH-access to container
+  echo $i\) $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} curl --header \"Content-Type: application/json\" --request POST -d \'{\"hello\":\"world\"}\' 169.254.169.254/eve/v1/kubeconfig
+  $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} curl --header \"Content-Type: application/json\" --request POST -d \'{\"hello\":\"world\"}\' 169.254.169.254/eve/v1/kubeconfig && break
 done

--- a/tests/eden/eclient/testdata/mount.txt
+++ b/tests/eden/eclient/testdata/mount.txt
@@ -2,6 +2,7 @@
 
 {{$port := "2223"}}
 {{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@FWD_IP -p FWD_PORT{{end}}
 
 [!exec:bash] stop
 [!exec:sleep] stop
@@ -68,11 +69,11 @@ test:
 
 -- ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
+
 for i in `seq 20`
 do
 sleep 20
 # Test SSH-access to container
-echo $i\) ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{$port}} root@$HOST ls $*
-ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{$port}} root@$HOST ls $* && break
+echo $i\) $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} ls $*
+$EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} ls $* && break
 done

--- a/tests/eden/eclient/testdata/networking_light.txt
+++ b/tests/eden/eclient/testdata/networking_light.txt
@@ -2,7 +2,7 @@
 
 {{$test_msg := "This is a test"}}
 {{define "port"}}2223{{end}}
-{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{template "port"}} root@{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@FWD_IP -p FWD_PORT{{end}}
 {{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
 
 [!exec:bash] stop
@@ -72,46 +72,47 @@ eden network delete n2
 test eden.network.test -test.v -timewait 10m - n1 n2
 
 -- wait_ssh.sh --
-
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 for i in `seq 20`
 do
   sleep 20
   # Test SSH-access to container
-  echo {{template "ssh"}}$HOST grep -q Ubuntu /etc/issue
-  {{template "ssh"}}$HOST grep -q Ubuntu /etc/issue && break
+  echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} grep -q Ubuntu /etc/issue
+  $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} grep -q Ubuntu /etc/issue && break
 done
 
 -- eserver_ip.sh --
 IP_NUM="$1"
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 echo export ESERVER_IP=$(grep '^eserver\s' pod_ps | cut -f 4|tr -d ' '|cut -d";" -f"$IP_NUM") > env
-echo export HOST=$($EDEN eve ip) >> env
 
 -- setup_srv.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 . ./env
 
-echo {{template "ssh"}}$HOST "echo ssh -o StrictHostKeyChecking=no root@$ESERVER_IP nc -l 1234 > /tmp/server"
-{{template "ssh"}}$HOST "echo ssh -o StrictHostKeyChecking=no root@$ESERVER_IP nc -l 1234 > /tmp/server"
+echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} "echo ssh -o StrictHostKeyChecking=no root@$ESERVER_IP nc -l 1234 > /tmp/server"
+$EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} "echo ssh -o StrictHostKeyChecking=no root@$ESERVER_IP nc -l 1234 > /tmp/server"
 
 -- run_srv.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 . ./env
 
-echo {{template "ssh"}}$HOST 'sh /tmp/server > /tmp/out'
-{{template "ssh"}}$HOST 'sh /tmp/server > /tmp/out'
+echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} 'sh /tmp/server > /tmp/out'
+$EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} 'sh /tmp/server > /tmp/out'
 
 -- run_client.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 . ./env
 
-echo {{template "ssh"}}$HOST "echo {{$test_msg}} | nc -N $ESERVER_IP 1234"
-{{template "ssh"}}$HOST "echo {{$test_msg}} | nc -N $ESERVER_IP 1234"
+echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} "echo {{$test_msg}} | nc -N $ESERVER_IP 1234"
+$EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} "echo {{$test_msg}} | nc -N $ESERVER_IP 1234"
 
 -- get_result.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 . ./env
 
-echo {{template "ssh"}}$HOST 'cat /tmp/out&&rm /tmp/out'
-{{template "ssh"}}$HOST 'cat /tmp/out&&rm /tmp/out'
+echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} 'cat /tmp/out && rm /tmp/out'
+$EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} 'cat /tmp/out && rm /tmp/out'
 
 -- eden-config.yml --
 {{/* Test's config. file */}}

--- a/tests/eden/eclient/testdata/ngnix.txt
+++ b/tests/eden/eclient/testdata/ngnix.txt
@@ -3,7 +3,7 @@
 {{$server := "nginx"}}
 {{$test_msg := "Welcome to nginx!"}}
 {{define "port"}}2223{{end}}
-{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{template "port"}} root@{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@FWD_IP -p FWD_PORT{{end}}
 {{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
 
 [!exec:bash] stop
@@ -39,26 +39,25 @@ test eden.app.test -test.v -timewait 10m - eclient {{$server}}
 
 -- wait_ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
 for i in `seq 20`
 do
   sleep 20
   # Test SSH-access to container
-  echo {{template "ssh"}}$HOST grep -q Ubuntu /etc/issue
-  {{template "ssh"}}$HOST grep -q Ubuntu /etc/issue && break
+  echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} grep -q Ubuntu /etc/issue
+  $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} grep -q Ubuntu /etc/issue && break
 done
 
 -- server_ip.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 echo export ESERVER_IP=$(grep "^$1\s" pod_ps | cut -f 4) > env
-echo export HOST=$($EDEN eve ip) >> env
 
 -- run_client.sh --
 . ./env
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 
-echo {{template "ssh"}}$HOST "curl $ESERVER_IP"
-until {{template "ssh"}}$HOST "curl $ESERVER_IP" | grep Welcome; do sleep 3; done
+echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} "curl $ESERVER_IP"
+until $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} "curl $ESERVER_IP" | grep Welcome; do sleep 3; done
 
 -- eden-config.yml --
 {{/* Test's config. file */}}

--- a/tests/eden/eclient/testdata/nodered.txt
+++ b/tests/eden/eclient/testdata/nodered.txt
@@ -24,10 +24,9 @@ test eden.app.test -test.v -timewait 10m - nodered
 
 -- wait_curl.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
-PORT={{template "port"}}
-echo "curl $HOST:$PORT"
-until curl "$HOST:$PORT" | grep {{template "test_msg"}}; do sleep 5; done
+
+echo $EDEN sdn fwd eth0 {{template "port"}} -- curl FWD_IP:FWD_PORT
+until $EDEN sdn fwd eth0 {{template "port"}} -- curl FWD_IP:FWD_PORT | grep {{template "test_msg"}}; do sleep 5; done
 
 -- eden-config.yml --
 test:

--- a/tests/eden/eclient/testdata/nw_switch.txt
+++ b/tests/eden/eclient/testdata/nw_switch.txt
@@ -1,7 +1,7 @@
 # Test for applications network connectivity switching
 
 {{$test_msg := "This is a test"}}
-{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@FWD_IP -p FWD_PORT{{end}}
 {{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
 
 [!exec:bash] stop
@@ -100,7 +100,6 @@ eden network ls
 
 -- wait_ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
 for p in $*
 do
@@ -108,8 +107,8 @@ do
   do
     sleep 20
     # Test SSH-access to container
-    echo {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue
-    {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue && break
+    echo $EDEN sdn fwd eth0 $p -- {{template "ssh"}} grep -q Ubuntu /etc/issue
+    $EDEN sdn fwd eth0 $p -- {{template "ssh"}} grep -q Ubuntu /etc/issue && break
   done
 done
 
@@ -119,12 +118,11 @@ cat env
 
 -- ping.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
 . ./env
 
-echo {{template "ssh"}}$HOST -p $1 ping -c 5 "$PONG_IP"
-{{template "ssh"}}$HOST -p $1 ping -c 5 "$PONG_IP"
+echo $EDEN sdn fwd eth0 $1 -- {{template "ssh"}} ping -c 5 "$PONG_IP"
+$EDEN sdn fwd eth0 $1 -- {{template "ssh"}} ping -c 5 "$PONG_IP"
 
 -- eden-config.yml --
 {{/* Test's config. file */}}

--- a/tests/eden/eclient/testdata/port_forward.txt
+++ b/tests/eden/eclient/testdata/port_forward.txt
@@ -2,7 +2,7 @@
 
 {{$test_msg := "Port forward tests"}}
 {{$devmodel := EdenConfig "eve.devmodel"}}
-{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@FWD_IP -p FWD_PORT{{end}}
 {{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
 
 [!exec:bash] stop
@@ -37,14 +37,15 @@ message 'SCENARIO 1: Waiting for apps to enter RUNNING state'
 test eden.app.test -test.v -timewait 20m RUNNING app1 app2
 
 message 'SCENARIO 1: Checking accessibility'
-exec -t 5m bash wait_ssh.sh 2223 2224
+exec -t 5m bash wait_ssh.sh eth0 2223
+exec -t 5m bash wait_ssh.sh eth0 2224
 
 eden eve status
 cp stdout eve_status
 
 message 'SCENARIO 1: Testing port map connectivity between apps'
 exec sleep 20
-exec -t 1m bash test_connectivity.sh 2223 2224
+exec -t 1m bash test_connectivity.sh eth0 2223 eth0 2224
 stdout 'Ubuntu'
 
 {{if or (eq $devmodel "ZedVirtual-4G") (eq $devmodel "VBox") }}
@@ -52,12 +53,14 @@ message 'SCENARIO 1: Simulating network outage'
 eden eve link down
 # keep link down long enough for EVE to notice and un-configure port maps
 exec sleep 60
-! exec -t 1m bash check_ssh.sh 2223 2224
+! exec -t 1m bash check_ssh.sh eth0 2223
+! exec -t 1m bash check_ssh.sh eth1 2224
 eden eve link up
 # give EVE some time to recover (largely depends on the DHCP server)
 exec sleep 20
-exec -t 5m bash wait_ssh.sh 2223 2224
-exec -t 1m bash test_connectivity.sh 2223 2224
+exec -t 5m bash wait_ssh.sh eth0 2223
+exec -t 5m bash wait_ssh.sh eth0 2224
+exec -t 1m bash test_connectivity.sh eth0 2223 eth0 2224
 stdout 'Ubuntu'
 {{end}}
 
@@ -100,26 +103,29 @@ message 'SCENARIO 2: Waiting for apps to enter RUNNING state'
 test eden.app.test -test.v -timewait 20m RUNNING app1 app2
 
 message 'SCENARIO 2: Checking accessibility'
-exec -t 5m bash wait_ssh.sh 2223 2234
+exec -t 5m bash wait_ssh.sh eth0 2223
+exec -t 5m bash wait_ssh.sh eth1 2234
 
 eden eve status
 cp stdout eve_status
 
 message 'SCENARIO 2: Testing port map connectivity between apps'
 exec sleep 20
-exec -t 1m bash test_connectivity.sh 2234 2223
+exec -t 1m bash test_connectivity.sh eth0 2223 eth1 2234
 stdout 'Ubuntu'
 
 message 'SCENARIO 2: Simulating network outage'
 eden eve link down
 # keep link down long enough for EVE to notice and un-configure port maps
 exec sleep 60
-! exec -t 1m bash check_ssh.sh 2223 2234
+! exec -t 1m bash check_ssh.sh eth0 2223
+! exec -t 1m bash check_ssh.sh eth1 2234
 eden eve link up
 # give EVE some time to recover (largely depends on the DHCP server)
 exec sleep 20
-exec -t 5m bash wait_ssh.sh 2223 2234
-exec -t 1m bash test_connectivity.sh 2234 2223
+exec -t 5m bash wait_ssh.sh eth0 2223
+exec -t 5m bash wait_ssh.sh eth1 2234
+exec -t 1m bash test_connectivity.sh eth0 2223 eth1 2234
 stdout 'Ubuntu'
 
 message 'SCENARIO 2: Resource cleaning'
@@ -144,37 +150,37 @@ eden network ls
 
 -- wait_ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
+IFNAME=$1
+PORT=$2
 
-for p in $*
+for i in `seq 20`
 do
-  for i in `seq 20`
-  do
-    sleep 20
-    # Test SSH-access to container
-    echo timeout 10s {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue
-    timeout 10s {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue && break
-  done
+  sleep 20
+  # Test SSH-access to container
+  echo $EDEN sdn fwd $IFNAME $PORT -- timeout 30s {{template "ssh"}} grep -q Ubuntu /etc/issue
+  $EDEN sdn fwd $IFNAME $PORT -- timeout 30s {{template "ssh"}} grep -q Ubuntu /etc/issue && break
 done
 
 -- check_ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
+IFNAME=$1
+PORT=$2
 
-for p in $*
-do
-  echo {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue
-  {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue || exit
-done
+echo $EDEN sdn fwd $IFNAME $PORT -- {{template "ssh"}} grep -q Ubuntu /etc/issue
+$EDEN sdn fwd $IFNAME $PORT -- {{template "ssh"}} grep -q Ubuntu /etc/issue || exit
 
 -- test_connectivity.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
-EVE_IP=$({{template "ssh"}}$HOST -p $2 sh /root/get_eve_ip.sh)
+IFNAME1=$1
+PORT1=$2
+IFNAME2=$3
+PORT2=$4
+
+EVE_IP=$($EDEN sdn fwd $IFNAME2 $PORT2 -- {{template "ssh"}} sh /root/get_eve_ip.sh)
 echo "$EVE_IP"
 
-echo {{template "ssh"}}$HOST -p $1 sh /root/portmap_test.sh $EVE_IP $2
-{{template "ssh"}}$HOST -p $1 sh /root/portmap_test.sh $EVE_IP $2
+echo $EDEN sdn fwd $IFNAME1 $PORT1 -- {{template "ssh"}} sh /root/portmap_test.sh $EVE_IP $PORT2
+$EDEN sdn fwd $IFNAME1 $PORT1 -- {{template "ssh"}} sh /root/portmap_test.sh $EVE_IP $PORT2
 
 -- eden-config.yml --
 {{/* Test's config. file */}}

--- a/tests/eden/eclient/testdata/port_switch.txt
+++ b/tests/eden/eclient/testdata/port_switch.txt
@@ -47,15 +47,16 @@ eden eve reset
 exec sleep 10
 
 -- server_ip.sh --
-echo export ENGINX=$(grep "^$1\s" pod_ps | cut -f 5) > env
+echo export ENGINX_PORT=$(grep "^$1\s" pod_ps | awk '{print $5}' | cut -d ":" -f 2) > env
 
 -- run_client.sh --
 . ./env
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 
 for i in `seq 10`
 do
-    echo curl $ENGINX
-    curl $ENGINX | grep "Welcome to nginx!" && break
+    echo $EDEN sdn fwd eth0 $ENGINX_PORT -- curl FWD_IP:FWD_PORT
+    $EDEN sdn fwd eth0 $ENGINX_PORT -- curl FWD_IP:FWD_PORT | grep "Welcome to nginx!" && break
     sleep 20
 done
 

--- a/tests/eden/eclient/testdata/profile.txt
+++ b/tests/eden/eclient/testdata/profile.txt
@@ -2,7 +2,7 @@
 
 {{define "profile_server_token"}}server_token_123{{end}}
 {{define "profile_server_file"}}/mnt/profile{{end}}
-{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@FWD_IP -p FWD_PORT{{end}}
 {{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
 
 [!exec:bash] stop
@@ -132,27 +132,25 @@ test eden.app.test -test.v -timewait 15m - app-profile-1 app-profile-2 app-profi
 -- wait_ssh.sh --
 
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
+
 for p in $*
 do
   for i in `seq 20`
   do
     sleep 20
     # Test SSH-access to container
-    echo {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue
-    {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue && break
+    echo $EDEN sdn fwd eth0 $p -- {{template "ssh"}} grep -q Ubuntu /etc/issue
+    $EDEN sdn fwd eth0 $p -- {{template "ssh"}} grep -q Ubuntu /etc/issue && break
   done
 done
 
 -- local-manager-start.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
-{{template "ssh"}}$HOST -p $1 '/root/local_manager --token={{template "profile_server_token"}} --profile={{template "profile_server_file"}} &>/proc/1/fd/1 &'
+$EDEN sdn fwd eth0 $1 -- {{template "ssh"}} '/root/local_manager --token={{template "profile_server_token"}} --profile={{template "profile_server_file"}} &>/proc/1/fd/1 &'
 
 -- local-manager-profile.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
-{{template "ssh"}}$HOST -p $1 "echo $2>{{template "profile_server_file"}}"
+$EDEN sdn fwd eth0 $1 -- {{template "ssh"}} "echo $2>{{template "profile_server_file"}}"
 
 -- eden-config.yml --
 {{/* Test's config file */}}

--- a/tests/eden/eclient/testdata/publish_location.txt
+++ b/tests/eden/eclient/testdata/publish_location.txt
@@ -10,7 +10,7 @@
 {{define "token"}}server_token_123{{end}}
 {{define "location_file"}}/mnt/location.json{{end}}
 {{define "network"}}n1{{end}}
-{{define "ssh"}}ssh -q -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@{{end}}
+{{define "ssh"}}ssh -q -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@FWD_IP -p FWD_PORT{{end}}
 {{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
 
 [!exec:bash] stop
@@ -127,23 +127,21 @@ exec sleep 30
 
 -- wait-ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 for p in $*
 do
   for i in `seq 20`
   do
     sleep 20
     # Test SSH-access to container
-    echo {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue
-    {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue && break
+    echo $EDEN sdn fwd eth0 $p -- {{template "ssh"}} grep -q Ubuntu /etc/issue
+    $EDEN sdn fwd eth0 $p -- {{template "ssh"}} grep -q Ubuntu /etc/issue && break
   done
 done
 
 -- local-manager-start.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 ARGS="--token={{template "token"}}"
-{{template "ssh"}}$HOST -p {{template "mngr_port"}} "/root/local_manager $ARGS &>/proc/1/fd/1 &"
+$EDEN sdn fwd eth0 {{template "mngr_port"}} -- {{template "ssh"}} "/root/local_manager $ARGS &>/proc/1/fd/1 &"
 
 -- get-app-ip.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
@@ -157,7 +155,6 @@ ALT="$3"
 TIME="$4"
 
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 CONFIG="{
   \"logical-label\": \"wwan0\",
   \"latitude\": $LAT,
@@ -174,11 +171,10 @@ echo "$CONFIG" | $EDEN eve ssh 'cat > /run/wwan/location.json'
 EXPTIME="$1"
 
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
 # Wait until Local Profile server receives it.
 while true; do
-  LOCATION="$({{template "ssh"}}$HOST -p {{template "mngr_port"}} "cat {{template "location_file"}}")"
+  LOCATION="$($EDEN sdn fwd eth0 {{template "mngr_port"}} -- {{template "ssh"}} "cat {{template "location_file"}}")"
   TIMESTAMP="$(echo "$LOCATION" | jq '."utcTimestamp"')"
   if [ "$TIMESTAMP" = "$EXPTIME" ]; then
     echo "$LOCATION"
@@ -191,11 +187,10 @@ done
 EXPTIME="$1"
 
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
 # Wait until app is able to receive it.
 while true; do
-  LOCATION="$({{template "ssh"}}$HOST -p {{template "app_port"}} "curl -s 169.254.169.254/eve/v1/location.json")"
+  LOCATION="$($EDEN sdn fwd eth0 {{template "app_port"}} -- {{template "ssh"}} "curl -s 169.254.169.254/eve/v1/location.json")"
   TIMESTAMP="$(echo "$LOCATION" | jq '."utc-timestamp"')"
   if [ "$TIMESTAMP" = "$EXPTIME" ]; then
     echo "$LOCATION" | jq
@@ -208,7 +203,6 @@ done
 EXPTIME="$1"
 
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
 while true;
 do

--- a/tests/eden/eclient/testdata/radio_silence.txt
+++ b/tests/eden/eclient/testdata/radio_silence.txt
@@ -11,7 +11,7 @@
 {{define "radio_silence_counter_file"}}/mnt/radio-silence-counter{{end}}
 {{define "radio_status_file"}}/mnt/radio-status.json{{end}}
 {{define "network"}}n1{{end}}
-{{define "ssh"}}ssh -q -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@{{end}}
+{{define "ssh"}}ssh -q -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@FWD_IP -p FWD_PORT{{end}}
 {{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
 
 [!exec:bash] stop
@@ -73,26 +73,24 @@ test eden.network.test -test.v -timewait 10m - {{template "network"}}
 
 -- wait-ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 for p in $*
 do
   for i in `seq 20`
   do
     sleep 20
     # Test SSH-access to container
-    echo {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue
-    {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue && break
+    echo $EDEN sdn fwd eth0 $p -- {{template "ssh"}} grep -q Ubuntu /etc/issue
+    $EDEN sdn fwd eth0 $p -- {{template "ssh"}} grep -q Ubuntu /etc/issue && break
   done
 done
 
 -- local-manager-start.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 ARGS="--token={{template "token"}}"
 ARGS="$ARGS --radio-silence={{template "radio_silence_config_file"}}"
 ARGS="$ARGS --radio-silence-counter={{template "radio_silence_counter_file"}}"
 ARGS="$ARGS --radio-status={{template "radio_status_file"}}"
-{{template "ssh"}}$HOST -p {{template "port"}} "/root/local_manager $ARGS &>/proc/1/fd/1 &"
+$EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} "/root/local_manager $ARGS &>/proc/1/fd/1 &"
 
 -- get-app-ip.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
@@ -101,7 +99,6 @@ echo app_ip=$IP>>.env
 
 -- toggle-radio-silence.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 CMDS="
 prev_counter=\$(cat {{template "radio_silence_counter_file"}})
 prev_counter=\${prev_counter:-0}
@@ -114,11 +111,10 @@ while true; do
     sleep 5
 done
 "
-{{template "ssh"}}$HOST -p {{template "port"}} "$CMDS"
+$EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} "$CMDS"
 
 -- wait-radio-status.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 CMDS="
 until test -f {{template "radio_status_file"}}; do sleep 5; done
 echo \"{{template "radio_status_file"}} file found\"
@@ -138,7 +134,7 @@ while true; do
 done
 "
 
-{{template "ssh"}}$HOST -p {{template "port"}} "$CMDS"
+$EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} "$CMDS"
 
 -- eden-config.yml --
 {{/* Test's config file */}}

--- a/tests/eden/eclient/testdata/reboot_test.txt
+++ b/tests/eden/eclient/testdata/reboot_test.txt
@@ -5,6 +5,7 @@
 {{$network_name := "n1"}}
 {{$app_name := "eclient"}}
 {{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@FWD_IP -p FWD_PORT{{end}}
 
 [!exec:bash] stop
 [!exec:sleep] stop
@@ -76,11 +77,10 @@ test:
 
 -- ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 for i in `seq 20`
 do
-sleep 20
-# Test SSH-access to container
-echo $i\) ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{$port}} root@$HOST grep Ubuntu /etc/issue
-ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{$port}} root@$HOST grep Ubuntu /etc/issue && break
+  sleep 20
+  # Test SSH-access to container
+  echo $i\) $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} grep Ubuntu /etc/issue
+  $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} grep Ubuntu /etc/issue && break
 done

--- a/tests/eden/eclient/testdata/shutdown_test.txt
+++ b/tests/eden/eclient/testdata/shutdown_test.txt
@@ -5,6 +5,7 @@
 {{$network_name := "n1"}}
 {{$app_name := "eclient"}}
 {{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@FWD_IP -p FWD_PORT{{end}}
 
 [!exec:bash] stop
 [!exec:sleep] stop
@@ -94,11 +95,10 @@ test:
 
 -- ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 for i in `seq 20`
 do
-sleep 20
-# Test SSH-access to container
-echo $i\) ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{$port}} root@$HOST grep Ubuntu /etc/issue
-ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{$port}} root@$HOST grep Ubuntu /etc/issue && break
+  sleep 20
+  # Test SSH-access to container
+  echo $i\) $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} grep Ubuntu /etc/issue
+  $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} grep Ubuntu /etc/issue && break
 done

--- a/tests/eden/eclient/testdata/usb-pt_test.txt
+++ b/tests/eden/eclient/testdata/usb-pt_test.txt
@@ -2,6 +2,7 @@
 
 {{$usb_dev := "2-2"}}
 {{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@FWD_IP -p FWD_PORT{{end}}
 
 [!exec:bash] stop
 [!exec:sleep] stop
@@ -48,18 +49,17 @@ test:
 -- ssh.sh --
 port=$1
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 for i in `seq 20`
 do
  sleep 20
  # Test SSH-access to container
- echo $i\) ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p $port root@$HOST grep Ubuntu /etc/issue
- ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p $port root@$HOST grep Ubuntu /etc/issue && break
+ echo $i\) $EDEN sdn fwd eth0 $port -- {{template "ssh"}} grep Ubuntu /etc/issue
+ $EDEN sdn fwd eth0 $port -- {{template "ssh"}} grep Ubuntu /etc/issue && break
 done
 
 -- get-usb.sh --
 port=$1
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
- echo ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p $port root@$HOST cat /sys/bus/usb/devices/{{$usb_dev}}/product
- ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p $port root@$HOST cat /sys/bus/usb/devices/{{$usb_dev}}/product > {{$usb_dev}}.usb.product
+
+echo $EDEN sdn fwd eth0 $port -- {{template "ssh"}} cat /sys/bus/usb/devices/{{$usb_dev}}/product
+$EDEN sdn fwd eth0 $port -- {{template "ssh"}} cat /sys/bus/usb/devices/{{$usb_dev}}/product > {{$usb_dev}}.usb.product

--- a/tests/eden/eden-version
+++ b/tests/eden/eden-version
@@ -1,1 +1,1 @@
-lfedge/eden:0.7.2
+lfedge/eden:0.8.0

--- a/tests/eden/flir/testdata/test_flir.txt
+++ b/tests/eden/flir/testdata/test_flir.txt
@@ -43,14 +43,18 @@ test:
 
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 
-address=http://$($EDEN eve ip):8028
+function fwd_curl {
+  $EDEN sdn fwd eth0 8028 -- curl "$@"
+}
 
-until curl -s $address/fledge/ping | grep green; do sleep 10; done
+address=http://FWD_IP:FWD_PORT
 
-curl -s $address/fledge/ping -o result1
+until fwd_curl -s $address/fledge/ping | grep green; do sleep 10; done
 
-curl -d '{"name":"flircamera","type":"south","plugin":"FlirAX8","enabled":true,"config":{"address":{"value":"{{EdenGetEnv "CAMERA_IP"}}"},"port":{"value":"{{EdenGetEnv "CAMERA_PORT"}}"}}}' -X POST $address/fledge/service
+fwd_curl -s $address/fledge/ping -o result1
 
-until curl -s $address/fledge/ping |grep "dataRead\": [^0]"; do sleep 10; done
+fwd_curl -d '{"name":"flircamera","type":"south","plugin":"FlirAX8","enabled":true,"config":{"address":{"value":"{{EdenGetEnv "CAMERA_IP"}}"},"port":{"value":"{{EdenGetEnv "CAMERA_PORT"}}"}}}' -X POST $address/fledge/service
 
-until curl -s $address/fledge/asset/AX8/summary?seconds=60 -o result2; do sleep 10; done
+until fwd_curl -s $address/fledge/ping |grep "dataRead\": [^0]"; do sleep 10; done
+
+until fwd_curl -s $address/fledge/asset/AX8/summary?seconds=60 -o result2; do sleep 10; done

--- a/tests/eden/hardware_reboot/testdata/hardware_2usb_reboot.txt
+++ b/tests/eden/hardware_reboot/testdata/hardware_2usb_reboot.txt
@@ -2,7 +2,7 @@
 # Works only on KVM
 
 {{define "port"}}2223{{end}}
-{{define "ssh"}} ssh -oServerAliveInterval=10 -oConnectTimeout=10 -oStrictHostKeyChecking=no -oPasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{template "port"}} root@$HOST {{end}}
+{{define "ssh"}} ssh -oServerAliveInterval=10 -oConnectTimeout=10 -oStrictHostKeyChecking=no -oPasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@FWD_IP -p FWD_PORT{{end}}
 {{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
 
 [!exec:bash] stop
@@ -16,15 +16,15 @@ eden pod deploy -n eclient --memory=512MB {{template "eclient_image"}} -p {{temp
 
 test eden.app.test -test.v -timewait 20m RUNNING eclient
 
-exec -t 20m bash ssh.sh {{template "port"}}
+exec -t 20m bash ssh.sh
 stdout 'Ubuntu'
 
 # Check usb_1
-exec -t 20m bash get-lshw.sh {{template "port"}}
+exec -t 20m bash get-lshw.sh
 stdout '1024B QEMU HARDDISK'
 
 # Check usb_2
-exec -t 20m bash get-lshw.sh {{template "port"}}
+exec -t 20m bash get-lshw.sh
 stdout '10MB QEMU HARDDISK'
 
 exec -t 5m bash get_reboot_time.sh
@@ -38,11 +38,11 @@ exec -t 20m bash ssh.sh
 stdout 'Ubuntu'
 
 # Check usb_1
-exec -t 20m bash get-lshw.sh {{template "port"}}
+exec -t 20m bash get-lshw.sh
 stdout '1024B QEMU HARDDISK'
 
 # Check usb_2
-exec -t 20m bash get-lshw.sh {{template "port"}}
+exec -t 20m bash get-lshw.sh
 stdout '10MB QEMU HARDDISK'
 
 exec -t 5m bash get_reboot_time.sh
@@ -64,36 +64,30 @@ test:
         model: {{EdenConfig "eve.devmodel"}}
 
 -- ssh.sh --
-port=$1
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
 for i in `seq 20`
 do
-sleep 20
-# Test SSH-access to container
-echo $i\) {{template "ssh"}} grep Ubuntu /etc/issue
-{{template "ssh"}} grep Ubuntu /etc/issue && break
+  sleep 20
+  # Test SSH-access to container
+  echo $i\) $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} grep Ubuntu /etc/issue
+  $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} grep Ubuntu /etc/issue && break
 done
-
 
 -- get_reboot_time.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
-echo {{template "ssh"}} uptime -s
-{{template "ssh"}} uptime -s
+echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} uptime -s
+$EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} uptime -s
 
 -- get-lshw.sh --
-port=$1
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
- echo {{template "ssh"}} lshw -businfo
- {{template "ssh"}} lshw -businfo
+
+echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} lshw -businfo
+$EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} lshw -businfo
 
 -- reboot.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
-echo {{template "ssh"}} reboot
-{{template "ssh"}} reboot
+echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} reboot
+$EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} reboot

--- a/tests/eden/hardware_reboot/testdata/hardware_audio_reboot.txt
+++ b/tests/eden/hardware_reboot/testdata/hardware_audio_reboot.txt
@@ -1,7 +1,7 @@
 # Simple test of Audio device after reboot of guest
 
 {{define "port"}}2223{{end}}
-{{define "ssh"}} ssh -oServerAliveInterval=10 -oConnectTimeout=10 -oStrictHostKeyChecking=no -oPasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{template "port"}} ubuntu@$HOST {{end}}
+{{define "ssh"}} ssh -oServerAliveInterval=10 -oConnectTimeout=10 -oStrictHostKeyChecking=no -oPasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa ubuntu@FWD_IP -p FWD_PORT{{end}}
 
 [!exec:bash] stop
 [!exec:sleep] stop
@@ -10,10 +10,10 @@
 # Starting of eve reboot detector with a 1 reboot limit
 ! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
-exec -t 20m bash deploy.sh {{template "port"}}
+exec -t 20m bash deploy.sh
 test eden.app.test -test.v -timewait 30m RUNNING eclient
 
-exec -t 20m bash ssh.sh {{template "port"}}
+exec -t 20m bash ssh.sh
 stdout 'Ubuntu'
 
 # Audio device passthrough setup
@@ -71,30 +71,26 @@ test:
         model: {{EdenConfig "eve.devmodel"}}
 
 -- deploy.sh --
-port=$1
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 
 IMG="https://cloud-images.ubuntu.com/releases/focal/release-20210510/ubuntu-20.04-server-cloudimg-amd64.img"
 PUB_KEY="$( cat {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa.pub )"
-$EDEN pod deploy -n eclient --memory=1GB  ${IMG} -p $port:22 --metadata="#cloud-config\nssh_authorized_keys:\n - $PUB_KEY mykey@host"
+$EDEN pod deploy -n eclient --memory=1GB  ${IMG} -p {{template "port"}}:22 --metadata="#cloud-config\nssh_authorized_keys:\n - $PUB_KEY mykey@host"
 
 
 -- ssh.sh --
-port=$1
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
 for i in `seq 20`
 do
-sleep 20
-# Test SSH-access to VM
-echo $i\) {{template "ssh"}} grep Ubuntu /etc/issue
-{{template "ssh"}} grep Ubuntu /etc/issue && break
+  sleep 20
+  # Test SSH-access to VM
+  echo $i\) $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} grep Ubuntu /etc/issue
+  $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} grep Ubuntu /etc/issue && break
 done
 
 -- set_audio.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 CNF=eve.cfg
 
 $EDEN controller edge-node get-config --file $CNF
@@ -106,29 +102,25 @@ $EDEN controller edge-node set-config --file $CNF.new
 
 -- get_reboot_time.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
-echo {{template "ssh"}} uptime -s
-{{template "ssh"}} uptime -s
+echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} uptime -s
+$EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} uptime -s
 
 -- get_soundcard.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
-echo {{template "ssh"}} aplay -L
-{{template "ssh"}} aplay -L
+echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} aplay -L
+$EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} aplay -L
 
 -- reboot.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
-echo {{template "ssh"}} 'sudo shutdown -r +1 &>/dev/null &'
-{{template "ssh"}} 'sudo shutdown -r +1 &>/dev/null &'
+echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} 'sudo shutdown -r +1 &>/dev/null &'
+$EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} 'sudo shutdown -r +1 &>/dev/null &'
 
 -- install_drivers.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
-echo {{template "ssh"}} 'sudo apt update && sudo apt-get install -y linux-modules-extra-`uname -r` alsa-utils'
-{{template "ssh"}} 'sudo apt update && sudo apt-get install -y linux-modules-extra-`uname -r` alsa-utils'
+echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} 'sudo apt update && sudo apt-get install -y linux-modules-extra-`uname -r` alsa-utils'
+$EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} 'sudo apt update && sudo apt-get install -y linux-modules-extra-`uname -r` alsa-utils'
 

--- a/tests/eden/hardware_reboot/testdata/hardware_eth_reboot.txt
+++ b/tests/eden/hardware_reboot/testdata/hardware_eth_reboot.txt
@@ -4,7 +4,7 @@
 {{define "port"}}2223{{end}}
 {{define "virtio_iface"}}enp3s0{{end}}
 {{define "passthrough_iface"}}enp4s0{{end}}
-{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{template "port"}} ubuntu@{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa ubuntu@FWD_IP -p FWD_PORT{{end}}
 
 [!exec:bash] stop
 [!exec:sleep] stop
@@ -73,8 +73,8 @@ eden -t 2m eve start
 
 -- deploy.sh --
 
-NETWORK=$1
-PORT=$2
+NETWORK={{template "network"}}
+PORT={{template "port"}}
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 
 IMG="https://cloud-images.ubuntu.com/releases/focal/release-20210510/ubuntu-20.04-server-cloudimg-amd64.img"
@@ -84,26 +84,23 @@ $EDEN pod deploy -n app --networks=${NETWORK} --acl=${NETWORK}:github.com -p ${P
 -- ssh.sh --
 
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 for i in `seq 20`
 do
  sleep 20
  # Test SSH-access to VM
- echo $i\) {{template "ssh"}}$HOST grep Ubuntu /etc/issue
- {{template "ssh"}}$HOST grep Ubuntu /etc/issue && break
+ echo $i\) $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} grep Ubuntu /etc/issue
+ $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} grep Ubuntu /etc/issue && break
 done
 
 -- reboot.sh --
 
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
-echo {{template "ssh"}}$HOST 'sudo shutdown -r +1 &>/dev/null &'
-{{template "ssh"}}$HOST 'sudo shutdown -r +1 &>/dev/null &'
+echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} 'sudo shutdown -r +1 &>/dev/null &'
+$EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} 'sudo shutdown -r +1 &>/dev/null &'
 
 -- check_passthrough.sh --
 
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
 CMDS="
 uptime -s;
@@ -121,8 +118,8 @@ ping -c 5 -I {{template "passthrough_iface"}} github.com || exit;
 ping -c 5 -I {{template "passthrough_iface"}} google.com || exit;
 touch /tmp/passthrough-checked
 "
-echo {{template "ssh"}}$HOST "$CMDS"
-{{template "ssh"}}$HOST "$CMDS"
+echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} "$CMDS"
+$EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} "$CMDS"
 
 -- devmodel.json --
 

--- a/tests/eden/hardware_reboot/testdata/hardware_usb_reboot.txt
+++ b/tests/eden/hardware_reboot/testdata/hardware_usb_reboot.txt
@@ -1,40 +1,42 @@
 # Simple test of USB passthrough functionality after reboot of guest
 
 {{$port := "2223"}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa ubuntu@FWD_IP -p FWD_PORT{{end}}
 
 [!exec:bash] stop
 [!exec:sleep] stop
 [!exec:ssh] stop
 
+
 eden pod deploy -n n11 --memory=1GB https://cloud-images.ubuntu.com/releases/groovy/release-20210108/ubuntu-20.10-server-cloudimg-amd64.img --metadata='#cloud-config\nssh_authorized_keys:\n - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDOLVxfqzHzozOOBzbgLEAU66vTztBvIyKe9NH3ILb1f2gjlAKaPCinkDNH8m2bbbsccPfNWCuAKxNPN4ZWnXkYP0BnQKVnJxtES519PgyZLk6NlTzC4lsSJxWbkLOwV/3gjqBA7u+MQ+erJLFZQRUwtDq8LY2P0pQIsEiYFJi/SUjifADnBHhb3MXTWrxbRdiga8UH5Ksbz1HTBSGx0jwiaylsgN8qKs6N7TNMIYtGO1YZE9aMEFNHIW3zC5D5bzTBBa44FHtURXhLg6lVHXaPvBAUU5Q6QH9iyVxVNRQqO5EHO1Th0h0+lgWkRDFuVSu3gl/QR1MbRvRa10i/44jSnhQtuBZGS7Av7/Ef0ESymBp+4m2wBFFJQ6PpIZ2uu9iEVGFv2EbL0/gabOgjWauLlaCSG1PKG3p64C4qNvvXbMzfvsX1+yVLPw+Q59R5y3Q66wFpCrsd2OO5Cfp3WpGH51j8C7j6UWQAhXXDv+rdsu4VoJWCk8ulnZ1PRnLFHh3tw9VkESTXVxIo8BjxsbFiUWcMoXm6Nr3QnBGISRlDDutJ0ycxgZFjpLVpHCZLpM+NsVBiLIZ8Y3AHGaxW5vtD/oJAg2fc9APf0mwTMEEjeC0QCOgl5AijWxdaJFk3sXUqPp63oFKnIv7g//bSQ20Vuqor2JV8JaGDBExsMzZO4Q== mykey@host' -p {{$port}}:22 --adapters USB2:2
 
 test eden.app.test -test.v -timewait 20m RUNNING n11
 
-exec -t 20m bash ssh.sh {{$port}}
+exec -t 20m bash ssh.sh
 stdout 'Ubuntu'
 
-exec -t 20m bash get-lshw.sh {{$port}}
+exec -t 20m bash get-lshw.sh
 stdout 'QEMU USB HARDDRIVE'
 
-exec -t 20m bash get-lshw.sh {{$port}}
+exec -t 20m bash get-lshw.sh
 cp stdout before_reboot
 
 # get last reboot time
-exec -t 20m bash get-last-reboot-time.sh {{$port}}
+exec -t 20m bash get-last-reboot-time.sh
 cp stdout timestamp1
 
 # reboot from guest
-exec -t 20m bash reboot.sh {{$port}}
+exec -t 20m bash reboot.sh
 exec sleep 5m
 
-exec -t 20m bash ssh.sh {{$port}}
+exec -t 20m bash ssh.sh
 stdout 'Ubuntu'
 
-exec -t 20m bash get-lshw.sh {{$port}}
+exec -t 20m bash get-lshw.sh
 cp stdout after_reboot
 
 # get last reboot time
-exec -t 20m bash get-last-reboot-time.sh {{$port}}
+exec -t 20m bash get-last-reboot-time.sh
 cp stdout timestamp2
 
 # comparison of lshw output
@@ -59,34 +61,29 @@ test:
         model: {{EdenConfig "eve.devmodel"}}
 
 -- ssh.sh --
-port=$1
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 for i in `seq 20`
 do
  sleep 20
  # Test SSH-access to container
- echo $i\) ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p $port ubuntu@$HOST grep Ubuntu /etc/issue
- ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p $port ubuntu@$HOST grep Ubuntu /etc/issue && break
+ echo $i\) $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} grep Ubuntu /etc/issue
+ $EDEN sdn fwd eth0 {{$port}} -- grep Ubuntu /etc/issue && break
 done
 
 -- get-lshw.sh --
-port=$1
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
- echo ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p $port ubuntu@$HOST lsusb
- ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p $port ubuntu@$HOST lsusb
+
+echo $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} lsusb
+$EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} lsusb
 
 -- get-last-reboot-time.sh --
-port=$1
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
- echo ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p $port ubuntu@$HOST last -n 1 --time-format iso reboot | head -1 | awk '{print $5}'
- ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p $port ubuntu@$HOST last -n 1 --time-format iso reboot | head -1 | awk '{print $5}'
+
+echo $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} last -n 1 --time-format iso reboot | head -1 | awk '{print $5}'
+$EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} last -n 1 --time-format iso reboot | head -1 | awk '{print $5}'
 
 -- reboot.sh --
-port=$1
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
- echo ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p $port ubuntu@$HOST 'sudo shutdown -r +1 &>/dev/null &'
- ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p $port ubuntu@$HOST 'sudo shutdown -r +1 &>/dev/null &'
+
+echo $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} 'sudo shutdown -r +1 &>/dev/null &'
+$EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} 'sudo shutdown -r +1 &>/dev/null &'

--- a/tests/eden/lim/testdata/metric_test.txt
+++ b/tests/eden/lim/testdata/metric_test.txt
@@ -10,10 +10,6 @@
 {{$test1}} -out MetricContent.dm.network.iName 'MetricContent.dm.network.iName:.*eth[01].*'
 stdout 'eth[01]'
 
-# Checking dm.network.iName for interfaces other than eth0 or eth1.
-! {{$test2}} -out MetricContent.dm.network.iName 'MetricContent.dm.network.iName:.*eth[^01].*'
-! stdout 'eth[^01]'
-
 # Test's config. file
 -- eden-config.yml --
 test:

--- a/tests/eden/network/testdata/switch_net_vlans.txt
+++ b/tests/eden/network/testdata/switch_net_vlans.txt
@@ -20,6 +20,7 @@
 # The application providing DHCP services for multiple VLANs requires netadmin capabilities, otherwise
 # it is not permitted to create VLAN sub-interfaces. For security reasons, EVE does not allow to grant these
 # capabilities to native containers, therefore it is required to deploy apps as VMs-in-Containers for this test to pass.
+# TODO: rewrite test to use DHCP provided by SDN
 exec -t 2m bash check_vm_support.sh
 source .env
 [!env:with_hw_virt] skip 'Missing HW-assisted virtualization capability'
@@ -144,11 +145,10 @@ done
 APP=$1
 PORT=$2
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
-address=http://${HOST}:${PORT}/ifconfig.html
-until curl -m 10 $address | grep -q LOOPBACK; do sleep 3; done
-curl -m 10 $address
+address=http://FWD_IP:FWD_PORT/ifconfig.html
+until $EDEN sdn fwd eth0 $PORT -- curl -m 10 $address | grep -q LOOPBACK; do sleep 3; done
+$EDEN sdn fwd eth0 $PORT -- curl -m 10 $address
 
 -- wait_and_get_ip.sh --
 #!/bin/sh
@@ -156,11 +156,10 @@ curl -m 10 $address
 APP=$1
 PORT=$2
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
 function get_ip {
-    address=http://${HOST}:${PORT}/ifconfig.html
-    ifconfig=$(curl -m 10 $address) || return 1
+    address=http://FWD_IP:FWD_PORT/ifconfig.html
+    ifconfig=$($EDEN sdn fwd eth0 $PORT -- curl -m 10 $address) || return 1
     if [ -z "$ifconfig" ]; then
         return 1
     fi
@@ -183,20 +182,19 @@ until get_ip; do sleep 3; done
 APP=$1
 PORT=$2
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
 
-address=http://${HOST}:${PORT}/received-data.html
+address=http://FWD_IP:FWD_PORT/received-data.html
 
 # wait at most 1 minute for received-data.html to be available
 for i in `seq 12`
 do
     sleep 5
-    recv_data=$(curl -m 10 $address)
+    recv_data=$($EDEN sdn fwd eth0 $PORT -- curl -m 10 $address)
     if [ ! -z "$recv_data" ]; then
         break
     fi
 done
-curl -m 10 $address
+$EDEN sdn fwd eth0 $PORT -- curl -m 10 $address
 
 -- eden-config.yml --
 {{/* Test's config file */}}

--- a/tests/eden/network/testdata/test_networking.txt
+++ b/tests/eden/network/testdata/test_networking.txt
@@ -120,8 +120,8 @@ EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "ede
 
 echo "waiting for the second app response"
 
-address=http://$($EDEN pod ps|grep app2|grep -o -E '([0-9]{1,3}[\.]){3}[0-9]{1,3}:8027')/received-data.html
-until curl $address | grep {{$test_data}}; do sleep 3; done
+address=http://FWD_IP:FWD_PORT/received-data.html
+until $EDEN sdn fwd eth0 8027 -- curl $address | grep {{$test_data}}; do sleep 3; done
 
 -- app3.sh --
 #!/bin/sh
@@ -142,14 +142,13 @@ EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "ede
 
 echo "waiting for the third app response"
 
-address=http://$($EDEN pod ps|grep app3|grep -o -E '([0-9]{1,3}[\.]){3}[0-9]{1,3}:8028')/received-data.html
-until curl $address; do sleep 3; done
+address=http://FWD_IP:FWD_PORT/received-data.html
+until $EDEN sdn fwd eth0 8028 -- curl $address; do sleep 3; done
 
 echo "sleep for 10 seconds"
 sleep 10
 
-address=http://$($EDEN pod ps|grep app3|grep -o -E '([0-9]{1,3}[\.]){3}[0-9]{1,3}:8028')/received-data.html
-until curl $address; do sleep 3; done
+until $EDEN sdn fwd eth0 8028 -- curl $address; do sleep 3; done
 
 -- eden-config.yml --
 {{/* Test's config file */}}

--- a/tests/eden/network/testdata/vlans_and_bonds.txt
+++ b/tests/eden/network/testdata/vlans_and_bonds.txt
@@ -4,6 +4,8 @@
 [!exec:curl] stop
 [!exec:sleep] stop
 
+skip 'TODO: completely rewrite this test for Eden-SDN'
+
 {{$srvimage := "docker://lfedge/eden-docker-test:83cfe07"}}
 {{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@{{end}}
 {{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
@@ -202,9 +204,9 @@ function get_ip {
     if [ -z "$ifconfig" ]; then
         return 1
     fi
-    interfaces=$(echo "$ifconfig" | grep "^\w" | grep -v LOOPBACK | cut -d: -f1)
+    interfaces=$(echo "$ifconfig" | grep "^\w" | grep -iv LOOPBACK | cut -d' ' -f1 | cut -d':' -f 1)
     eth1=$(echo "$interfaces" | awk 'NR==2')
-    IP=$(echo "$ifconfig" | grep "^${eth1}: " -A 1 | awk '/inet / {print $2}' | cut -d"/" -f1)
+    IP=$(echo "$ifconfig" | grep "^${eth1}" -A 1 | grep 'inet ' | sed 's/addr://' | awk '/inet / {print $2}')
     if [ ! -z "$IP" ]; then
         echo "IP address of $APP is: $IP"
         echo "${APP}_ip=$IP" >.env

--- a/tests/eden/phoronix/testdata/test_phoronix.txt
+++ b/tests/eden/phoronix/testdata/test_phoronix.txt
@@ -51,5 +51,4 @@ sleep 60
 
 echo "waiting for the test results"
 
-address=http://$($EDEN pod ps|grep app1|grep -o -E '([0-9]{1,3}[\.]){3}[0-9]{1,3}:8027')
-until curl -s $address -o result; do sleep 30; done
+until $EDEN sdn fwd eth0 8027 -- curl -s FWD_IP:FWD_PORT -o result; do sleep 30; done

--- a/tests/eden/registry/testdata/registry_test.txt
+++ b/tests/eden/registry/testdata/registry_test.txt
@@ -62,7 +62,9 @@ test:
         onboard-cert: {{EdenConfigPath "eve.cert"}}
         serial: "{{EdenConfig "eve.serial"}}"
         model: {{EdenConfig "eve.devmodel"}}
+
 -- get.sh --
-address=`grep "^$1"'\s*' pod_ps | cut -f 5`
-until curl $address; do sleep 5; done
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+PORT=`grep "^$1"'\s*' pod_ps | awk '{print $5}' | cut -d ":" -f 2`
+until $EDEN sdn fwd eth0 $PORT -- curl FWD_IP:FWD_PORT; do sleep 5; done
 

--- a/tests/eden/volume/testdata/local_datastore.txt
+++ b/tests/eden/volume/testdata/local_datastore.txt
@@ -9,6 +9,7 @@
 {{$image_url := printf "http://download.cirros-cloud.net/%s" $image_path}}
 {{$datastore := "http://ubuntu-http-server.local"}}
 {{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
+{{define "ssh"}}ssh -q -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@FWD_IP -p FWD_PORT{{end}}
 
 [!exec:bash] stop
 [!exec:sleep] stop
@@ -26,6 +27,8 @@ test eden.app.test -test.v -timewait 20m RUNNING eclient
 
 exec -t 5m bash ssh.sh
 stdout 'Ubuntu'
+
+exec sleep 10
 
 exec -t 10m bash download-image.sh
 
@@ -53,17 +56,17 @@ test:
 
 -- ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
+
 for i in `seq 20`
 do
-sleep 20
-# Test SSH-access to container
-echo $i\) ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{$port}} root@$HOST grep Ubuntu /etc/issue
-ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{$port}} root@$HOST grep Ubuntu /etc/issue && break
+  sleep 20
+  # Test SSH-access to container
+  echo $i\) $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} grep Ubuntu /etc/issue
+  $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} grep Ubuntu /etc/issue && break
 done
 
 -- download-image.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-HOST=$($EDEN eve ip)
-ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{$port}} root@$HOST mkdir -p /var/www/html/{{$image_dir}}
-ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{$port}} root@$HOST curl -k -L {{$image_url}} -o /var/www/html/{{$image_path}}
+
+$EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} mkdir -p /var/www/html/{{$image_dir}}
+$EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} curl -k -L {{$image_url}} -o /var/www/html/{{$image_path}}

--- a/tests/eden/workflow/testdata/deploy_docker_eden.txt
+++ b/tests/eden/workflow/testdata/deploy_docker_eden.txt
@@ -30,9 +30,7 @@ EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "ede
 
 $EDEN pod ps | grep nginx || exit
 
-URL=`$EDEN pod ps | grep nginx | awk '{print $4}'`
-
-test -n "$URL" && until curl $URL | grep 'Welcome to nginx'; do sleep 3; done
+until $EDEN sdn fwd eth0 8028 -- curl FWD_IP:FWD_PORT | grep 'Welcome to nginx'; do sleep 3; done
 
 -- del_dckr.sh --
 #!/bin/bash

--- a/tests/eden/workflow/testdata/eden_start.txt
+++ b/tests/eden/workflow/testdata/eden_start.txt
@@ -1,4 +1,4 @@
-eden -t 2m start
+eden -t 5m start
 eden status
 stdout 'Adam.* status:.* running'
 stdout 'Redis.* status:.* running'

--- a/tests/eden/workflow/testdata/ssh.txt
+++ b/tests/eden/workflow/testdata/ssh.txt
@@ -8,10 +8,6 @@
 #eden start
 #eden eve onboard
 
-# Get redirected SSH port
-eden config get --key eve.hostfwd
-cp stdout eve.hostfwd
-
 # SSH login to EVE and getting issue
 exec -t 2m bash ssh.sh
 cp stdout issue
@@ -31,11 +27,4 @@ test:
 
 -- ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-PORT=`cat eve.hostfwd | sed 's/.*[^0-9]\([0-9]*\)":"22[^0-9].*/\1/'`
-[ -n "$PORT" ] && [ "$PORT" -eq "$PORT" ] 2>/dev/null
-if [ $? -ne 0 ]; then
-   PORT=22
-fi
-CERT=`echo {{EdenConfig "eden.root"}}/{{EdenConfig "eden.ssh-key"}} | sed 's/\.pub$//'`
-HOST=$($EDEN eve ip)
-until ssh -o ConnectTimeout=5 -oStrictHostKeyChecking=no -i $CERT -p $PORT root@$HOST cat /hostfs/etc/issue; do sleep 10; done
+until $EDEN eve ssh cat /hostfs/etc/issue; do sleep 10; done


### PR DESCRIPTION
Update of Eden tests (additional information available [here](https://github.com/lf-edge/eden/releases/tag/0.8.0)):
1. Rework tests to be ready for Eden SDN
2. Use firmware blobs from EVE-OS image
3. Update BaseOS updates logic to use BaseOsVersion

PR also contains adjustment of EdenGCP logic: we should use actions/checkout to have correct revision of EVE-OS repo