### PR TITLE
Write the whole dmesg of the crashed kernel to the /persist/reboot-stack

### DIFF
--- a/docs/KERNEL-DUMPS.md
+++ b/docs/KERNEL-DUMPS.md
@@ -35,8 +35,10 @@ EVE-OS has a `kdump` container that checks for `/proc/vmcore` and generates a mi
 * Minimal kernel dump will be generated in the `/persist/kcrashes` folder.
 * Dmesg (kernel ring buffer) of the crashed kernel will be saved in the `/persist/kcrashes` folder.
 * Only 5 fresh kernel dumps and dmesgs are stored in the folder, old files are deleted.
-* Kernel panic message from the crashed system buffer is redirected to the EVE-OS /persist/reboot-stack file and to the tty console in order to show it on the connected monitor for debug purposes.
-* Reboot reason string "kernel panic, kdump collected: $KDUMP_PATH" is redirected to the EVE-OS /persist/reboot-reason file.
+* The whole dmesg from the crashed system buffer is written to the EVE-OS `/persist/reboot-stack` file.
+* Only kernel panic message from the crashed system buffer is redirected to the tty console in order to show it on the connected monitor for debug purposes.
+* Boot reason string "BootReasonKernel" is written to the EVE-OS `/persist/boot-reason` file.
+* Reboot reason string "kernel panic, kdump collected: $KDUMP_PATH" is written to the EVE-OS `/persist/reboot-reason` file.
 * After the crash dump is created, the kernel will be rebooted according to the `/proc/sys/kernel/panic` timeout configuration value.
 
 As was mentioned earlier `makedumpfile` generates minimal kernel dump which excludes zeroed, cache, private, free and user-space memory pages. This is done not only to minimize the resulting dump file, but also for security reasons: customer data does not leak.

--- a/pkg/kdump/kdump.sh
+++ b/pkg/kdump/kdump.sh
@@ -44,7 +44,7 @@ if test -f /proc/vmcore; then
 
     # Prepare reboot-reason, reboot-stack and boot-reason
     echo "kernel panic, kdump collected: $KDUMP_PATH" > /persist/reboot-reason
-    cat /tmp/backtrace > /persist/reboot-stack
+    cat /tmp/dmesg > /persist/reboot-stack
     echo "BootReasonKernel" > /persist/boot-reason
 
     # Simulate the default reboot after panic kernel behaviour

--- a/pkg/newlog/cmd/newlogd.go
+++ b/pkg/newlog/cmd/newlogd.go
@@ -51,7 +51,7 @@ const (
 	uploadDevDir = types.NewlogUploadDevDir
 	uploadAppDir = types.NewlogUploadAppDir
 	keepSentDir  = types.NewlogKeepSentQueueDir
-	failSendDIr  = types.NewlogDir + "/failedUpload"
+	failSendDir  = types.NewlogDir + "/failedUpload"
 	panicFileDir = types.NewlogDir + "/panicStacks"
 	symlinkFile  = collectDir + "/current.device.log"
 	tmpSymlink   = collectDir + "/tmp-sym.dev.log"
@@ -987,7 +987,7 @@ func checkKeepQuota() {
 	if err != nil {
 		log.Errorf("checkKeepQuota: DevDir %v", err)
 	}
-	key3, size3, err := checkDirGZFiles(sfiles, failSendDIr)
+	key3, size3, err := checkDirGZFiles(sfiles, failSendDir)
 	if err != nil && !os.IsNotExist(err) {
 		log.Errorf("checkKeepQuota: FailToSendDir %v", err)
 	}

--- a/pkg/newlog/cmd/newlogd.go
+++ b/pkg/newlog/cmd/newlogd.go
@@ -1598,7 +1598,7 @@ func getPersistSpace() uint64 {
 func getSyslogMsg(loggerChan chan inputEntry) {
 
 	sysfmt := regexp.MustCompile("<([0-9]+)>(.{15}|.{25}) (.*?): (.*)")
-	conn, err := listenUnix()
+	conn, err := listenDevLog()
 	if err != nil {
 		log.Error(err)
 		return
@@ -1626,8 +1626,9 @@ func getSyslogMsg(loggerChan chan inputEntry) {
 	}
 }
 
-//func listenUnix() (net.PacketConn, error) {
-func listenUnix() (*net.UnixConn, error) {
+// listenDevLog() - substitute /dev/log with our AF_UNIX socket and open it
+//                  for listening
+func listenDevLog() (*net.UnixConn, error) {
 	UnixPath := "/dev/log"
 	os.Remove(UnixPath)
 	a, err := net.ResolveUnixAddr("unixgram", UnixPath)

--- a/pkg/pillar/agentlog/agentlog.go
+++ b/pkg/pillar/agentlog/agentlog.go
@@ -27,7 +27,8 @@ const (
 	stackFile      = "reboot-stack"
 	rebootImage    = "reboot-image"
 	bootReasonFile = "boot-reason"
-	maxReadSize    = 16384 // From files in /persist
+	readSize16k    = 16 << 10  // From files in /persist
+	readSize512k   = 512 << 10 // Kernel dmesg
 )
 
 var savedRebootReason = "unknown"
@@ -335,7 +336,7 @@ func RebootReason(reason string, bootReason types.BootReason, agentName string,
 	if bootReason != types.BootReasonNone {
 		filename = "/persist/" + bootReasonFile
 		brString := bootReason.String()
-		b, _ := fileutils.ReadWithMaxSize(nil, filename, maxReadSize)
+		b, _ := fileutils.ReadWithMaxSize(nil, filename, readSize16k)
 		if len(b) != 0 {
 			// Note: can not use log here since we are called from a log hook!
 			fmt.Printf("not replacing BootReason %s with %s\n",
@@ -375,27 +376,30 @@ func RebootStack(log *base.LogObject, stacks string, agentName string, agentPid 
 }
 
 // GetRebootReason returns the RebootReason string together with
-// its timestamp plus the reboot stack
-// We limit the size we read to 16k for both of those.
+// its timestamp plus the reboot stack. We limit the size we read
+// to 16k for the RebootReason and to 512k for the stack, because
+// in case of a kernel crash, the stack file contains the whole
+// dmesg, which kernel buffer is limited to some reasonable value
+// below 512k.
 func GetRebootReason(log *base.LogObject) (string, time.Time, string) {
 	reasonFilename := fmt.Sprintf("%s/%s", types.PersistDir, reasonFile)
 	stackFilename := fmt.Sprintf("%s/%s", types.PersistDir, stackFile)
-	reason, ts, _ := fileutils.StatAndRead(log, reasonFilename, maxReadSize)
-	stack, _, _ := fileutils.StatAndRead(log, stackFilename, maxReadSize)
+	reason, ts, _ := fileutils.StatAndRead(log, reasonFilename, readSize16k)
+	stack, _, _ := fileutils.StatAndRead(log, stackFilename, readSize512k)
 	return reason, ts, stack
 }
 
 // GetBootReason returns the BootReason enum, which is stored as a string in /persist, together with its timestamp
 func GetBootReason(log *base.LogObject) (types.BootReason, time.Time) {
 	reasonFilename := fmt.Sprintf("%s/%s", types.PersistDir, bootReasonFile)
-	reason, ts, _ := fileutils.StatAndRead(log, reasonFilename, maxReadSize)
+	reason, ts, _ := fileutils.StatAndRead(log, reasonFilename, readSize16k)
 	return types.BootReasonFromString(reason), ts
 }
 
 // GetRebootImage : Image from which the reboot happened
 func GetRebootImage(log *base.LogObject) string {
 	rebootFilename := fmt.Sprintf("%s/%s", types.PersistDir, rebootImage)
-	image, _, _ := fileutils.StatAndRead(log, rebootFilename, maxReadSize)
+	image, _, _ := fileutils.StatAndRead(log, rebootFilename, readSize16k)
 	return image
 }
 

--- a/pkg/pillar/types/zedagenttypes.go
+++ b/pkg/pillar/types/zedagenttypes.go
@@ -264,7 +264,7 @@ const (
 	BootReasonOOM                // OOM causing process to be killed
 	BootReasonWatchdogHung       // Software watchdog due stuck agent
 	BootReasonWatchdogPid        // Software watchdog due to e.g., golang panic
-	BootReasonKernel             // TBD how we detect this
+	BootReasonKernel             // Set by dump-capture kernel, see docs/KERNEL-DUMPS.md and pkg/kdump/kdump.sh for details
 	BootReasonPowerFail          // Known power failure e.g., from disk controller S.M.A.R.T counter increase
 	BootReasonUnknown            // Could be power failure, kernel panic, or hardware watchdog
 	BootReasonVaultFailure       // Vault was not ready within the expected time

--- a/pkg/pillar/utils/file/file.go
+++ b/pkg/pillar/utils/file/file.go
@@ -188,7 +188,7 @@ func ReadWithMaxSize(log *base.LogObject, filename string, maxReadSize int) ([]b
 	}
 	defer f.Close()
 	r := bufio.NewReader(f)
-	content := make([]byte, maxReadSize)
+	content := make([]byte, maxReadSize+1)
 	n, err := r.Read(content)
 	if err != nil {
 		err = fmt.Errorf("ReadWithMaxSize %s failed: %v", filename, err)
@@ -197,13 +197,14 @@ func ReadWithMaxSize(log *base.LogObject, filename string, maxReadSize int) ([]b
 		}
 		return nil, err
 	}
-	if n == maxReadSize {
+	if n > maxReadSize {
 		err = fmt.Errorf("ReadWithMaxSize %s truncated after %d bytes",
 			filename, maxReadSize)
+		n = maxReadSize
 	} else {
 		err = nil
 	}
-	return content[0:n], err
+	return content[:n], err
 }
 
 // ReadSavedCounter returns counter value from provided file


### PR DESCRIPTION
The intention of this PR is to write the whole dmesg of the crashed kernel to the `/persist/reboot-stack` and not only the backtrace. Why? Because full dmesg is the only way to understand the real state of the crashed node and then investigate the log from the cloud (kibana, elastic, whatever) without physical node access. 

The dmesg of the crashed kernel is written to the `/persist/reboot-stack` and then `nodeagent` redirects the content of the file to the EVE-OS log line by line marking each line with the 'dmesg' prefix for easy grep (kibana, elastic, json, etc).

Internally max read size is increased from 16k to 128k in order to fit the kernel log buffer, which is configured to 128k now.

The other minor thing done in this PR is to truncate the backtrace from head (keeping the tail) before publishing the backtrace on the cloud, because in case of the kernel dmesg we have the backtrace in question at the end of the buffer.

Also I cleaned up the code here and there: a few renamings, a few document tweaks, more explicit comments, correct read limit check (max read size), etc, etc.