### PR TITLE
Use INITGETTY option to start rungetty in background

### DIFF
--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:f01b88c7033180d50ae43562d72707c6881904e4
   - linuxkit/containerd:de1b18eed76a266baa3092e5c154c84f595e56da
   # pillar's logic rely on existence of getty and /etc/init.d/001-getty inside
-  - linuxkit/getty:v0.5
+  - linuxkit/getty:c9d5afa9a61ac907904090643e946874ff6bf07c
   - linuxkit/memlogd:v0.5
   - DOM0ZTOOLS_TAG
   - GRUB_TAG

--- a/pkg/dom0-ztools/rootfs/etc/profile.d/path.sh
+++ b/pkg/dom0-ztools/rootfs/etc/profile.d/path.sh
@@ -1,0 +1,3 @@
+# make PATH variable stable
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+export PATH

--- a/pkg/pillar/cmd/domainmgr/handlegetty.go
+++ b/pkg/pillar/cmd/domainmgr/handlegetty.go
@@ -40,17 +40,14 @@ func startGetty(log *base.LogObject) {
 		log.Noticeln("getty started in init")
 		return
 	}
-	args := []string{"/hostfs", "/bin/sh", "-c", "INSECURE=true /usr/bin/rungetty.sh"}
+	// INITGETTY option will run the script in background
+	args := []string{"/hostfs", "/bin/sh", "-c", "INITGETTY=true INSECURE=true /usr/bin/rungetty.sh"}
 	cmd := exec.Command("chroot", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	if err := cmd.Start(); err != nil {
+	if err := cmd.Run(); err != nil {
 		log.Fatalf("failed to start getty: %v", err)
 	}
 	log.Noticeln("getty started")
 	gettyStarted = true
-	go func() {
-		err := cmd.Wait()
-		log.Fatalf("getty stopped: %v", err)
-	}()
 }


### PR DESCRIPTION
rungetty may exit in case of no need to run getty (for example if no console defined). We should avoid fatal error and use the same logic as we use in init with INITGETTY=true.

getty package should be updated to have fix for exit code of rungetty in
 case of INITGETTY=true.

Also commit contains explicit set of PATH variable as after update of getty package I can see PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/local /sbin:/usr/local/bin which is not expected.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>