### PR TITLE
Update lkt and use tagged syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,7 +263,7 @@ DOCKER_GO = _() { $(SET_X); mkdir -p $(CURDIR)/.go/src/$${3:-dummy} ; mkdir -p $
 
 PARSE_PKGS=$(if $(strip $(EVE_HASH)),EVE_HASH=)$(EVE_HASH) DOCKER_ARCH_TAG=$(DOCKER_ARCH_TAG) ./tools/parse-pkgs.sh
 LINUXKIT=$(BUILDTOOLS_BIN)/linuxkit
-LINUXKIT_VERSION=d1452385cca6574e0f0bfa8c120e39bef89f2852
+LINUXKIT_VERSION=8b04a8c92affacb13584c164161d7253d4b7ba4b
 LINUXKIT_SOURCE=https://github.com/linuxkit/linuxkit.git
 LINUXKIT_OPTS=$(if $(strip $(EVE_HASH)),--hash) $(EVE_HASH) $(if $(strip $(EVE_REL)),--release) $(EVE_REL)
 LINUXKIT_PKG_TARGET=build

--- a/pkg/acrn/Dockerfile
+++ b/pkg/acrn/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile-upstream:master-labs
+# syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
 FROM lfedge/eve-alpine:145f062a40639b6c65efa36bed1c5614b873be52 AS kernel-build
 
 ENV BUILD_PKGS \

--- a/pkg/fscrypt/Dockerfile
+++ b/pkg/fscrypt/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile-upstream:master-labs
+# syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/grub/Dockerfile
+++ b/pkg/grub/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile-upstream:master-labs
+# syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
 
 FROM lfedge/eve-alpine:145f062a40639b6c65efa36bed1c5614b873be52 as grub-build-base
 ENV BUILD_PKGS automake \

--- a/pkg/pillar/Dockerfile
+++ b/pkg/pillar/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2018 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-fscrypt:d5e104001ebf23fdaddd4305fe1ddc00dab42cf1 as fscrypt
+FROM lfedge/eve-fscrypt:0b7cc0d9d620e47fc54e21d56cb8a5cd224f9c9b as fscrypt
 
 FROM lfedge/eve-dom0-ztools:417d4ff6a57d2317c9e65166274b0ea6f6da16e2 as zfs
 RUN mkdir /out

--- a/pkg/uefi/Dockerfile
+++ b/pkg/uefi/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile-upstream:master-labs
+# syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
 # Instructions for this package are taken from:
 #   https://wiki.ubuntu.com/UEFI/EDK2
 #   https://wiki.linaro.org/LEG/UEFIforQEMU

--- a/pkg/wwan/Dockerfile
+++ b/pkg/wwan/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile-upstream:master-labs
+# syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
 FROM lfedge/eve-alpine:145f062a40639b6c65efa36bed1c5614b873be52 as build
 ENV BUILD_PKGS automake autoconf gettext gettext-dev git pkgconfig \
                libtool libc-dev linux-headers gcc make glib-dev \

--- a/pkg/xen-tools/Dockerfile
+++ b/pkg/xen-tools/Dockerfile
@@ -1,6 +1,6 @@
-# syntax=docker/dockerfile-upstream:master-labs
+# syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
 
-FROM lfedge/eve-uefi:b66d94780b1986e13d4db082adb5630a95911089 as uefi-build
+FROM lfedge/eve-uefi:d821658883d6748d8bbf0d6640c62288e3ce8c6f as uefi-build
 
 FROM lfedge/eve-alpine:145f062a40639b6c65efa36bed1c5614b873be52 as runx-build
 ENV BUILD_PKGS mkinitfs gcc musl-dev e2fsprogs


### PR DESCRIPTION
We [hit](https://github.com/lf-edge/eve/pull/2905#issuecomment-1352454605) the problem with changes in branch of buildkit, so it would be better to use rc, but at least tagged version

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>