### PR TITLE
Use working-directory to run git reset and make version

### DIFF
--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -133,22 +133,25 @@ jobs:
           path: eve
           ref: '${{ github.event.workflow_run.head_branch }}'
       - name: Force fetch annotated tags (workaround)
+        working-directory: ./eve
         # Workaround for https://github.com/actions/checkout/issues/290
         run: |
-          git --git-dir ./eve/.git fetch --force --tags
+          git fetch --force --tags
       # we want to test the same commit as we publish during workflow_run
       - name: Prepare EVE (workflow)
         if: github.event_name == 'workflow_run'
+        working-directory: ./eve
         run: |
-          git --git-dir ./eve/.git reset --hard '${{ github.event.workflow_run.head_sha }}'
-          git --git-dir ./eve/.git clean -f -x -d
-          echo "EVE_TAG=$(make -C eve --no-print-directory version)" >> "$GITHUB_ENV"
+          git reset --hard '${{ github.event.workflow_run.head_sha }}'
+          git clean -f -x -d
+          echo "EVE_TAG=$(make version)" >> "$GITHUB_ENV"
           echo "EVE_REGISTRY=lfedge/eve" >> "$GITHUB_ENV"
       - name: Prepare EVE (manual run)
         if: github.event_name == 'workflow_dispatch'
+        working-directory: ./eve
         run: |
           if [ "${{ github.event.inputs.test_type }}" == "PR" ]; then
-            cd eve && git fetch origin pull/${{ github.event.inputs.pr_number }}/head && git checkout FETCH_HEAD
+            git fetch origin pull/${{ github.event.inputs.pr_number }}/head && git checkout FETCH_HEAD
             echo "EVE_TAG=pr${{ github.event.inputs.pr_number }}" >> "$GITHUB_ENV"
             echo "EVE_REGISTRY=evebuild/danger" >> "$GITHUB_ENV"
           else


### PR DESCRIPTION
Seems git reset have different behaviour when run using --git-dir:
```
$ git --git-dir ./eve/.git reset --hard 'd2c4b7a339674c65de5baa2ba4632c1c54fab0e3'
HEAD is now at d2c4b7a33 readme: added the missing 'current' path part
$ make -C eve --no-print-directory version
0.0.0-master-d2c4b7a3-dirty-2022-12-15.14.37
$ cd eve&&git status
On branch master
Your branch is behind 'origin/master' by 1 commit, and can be fast-forwarded.
  (use "git pull" to update your local branch)

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   .github/workflows/eden_gcp.yml

no changes added to commit (use "git add" and/or "git commit -a")
```

So we should avoid such call.

Sorry for the third commit about the same problem.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>