### PR TITLE
[8.12 stable] volumemgr/updatestatus: fix crash by checking status.Blobs is not empty

### DIFF
--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -229,6 +229,11 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 				currentSize, totalSize, status.Progress)
 		}
 
+		if len(status.Blobs) == 0 {
+			log.Errorf("doUpdateContentTree(%s) name %s: blobs array is empty",
+				status.Key(), status.DisplayName)
+			return changed, false
+		}
 		rootBlob := lookupOrCreateBlobStatus(ctx, status.Blobs[0])
 		if rootBlob == nil {
 			log.Errorf("doUpdateContentTree(%s) name %s: could not find BlobStatus(%s)",

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -115,6 +115,16 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 			if len(status.Blobs) == 0 {
 				AddBlobsToContentTreeStatus(ctx, status, rootBlob.Sha256)
 			}
+		} else {
+			// Not an OCI registry, thus must have a valid sha256
+			if status.ContentSha256 == "" {
+				err := fmt.Sprintf("doUpdateContentTree(%s) name %s: no content sha256 defined",
+					status.Key(), status.DisplayName)
+				log.Errorf(err)
+				status.SetErrorDescription(types.ErrorDescription{Error: err})
+				changed = true
+				return changed, false
+			}
 		}
 
 		// at this point, we at least are downloading


### PR DESCRIPTION
[Backport of the #2966 PR for the 8.12-stable branch]

There is a crash with the following backtrace:

```
  github.com/lf-edge/eve/pkg/pillar/cmd/volumemgr.doUpdateContentTree(0xc000cf52c0, 0xc001a8d360, 0x42)
  pillar/cmd/volumemgr/updatestatus.go:233 +0x54b6
  github.com/lf-edge/eve/pkg/pillar/cmd/volumemgr.updateStatusByDatastore(0xc000cf52c0, 0xb42d8eee7664805, 0x23f4997dd60c22a7, 0xc001a4c190, 0xb, 0xc0018c30b0, 0x2c, 0x0, 0x0, 0x0, ...)
  /pillar/cmd/volumemgr/updatestatus.go:778 +0x3d2
  github.com/lf-edge/eve/pkg/pillar/cmd/volumemgr.handleDatastoreConfigImpl(0x23890e0, 0xc000cf52c0, 0xc0015b3ce0, 0x24, 0x26f6cc0, 0xc001a5e6e0
  /pillar/cmd/volumemgr/handledatastore.go:26 +0x198
  github.com/lf-edge/eve/pkg/pillar/cmd/volumemgr.handleDatastoreConfigCreate(0x23890e0, 0xc000cf52c0, 0xc0015b3ce0, 0x24, 0x26f6cc0, 0xc001a5e6e0)
  /pillar/cmd/volumemgr/handledatastore.go:12 +0x5d
  github.com/lf-edge/eve/pkg/pillar/pubsub.handleModify(0x26ac320, 0xc00078c100, 0xc0015b3ce0, 0x24, 0xc0012d42c0, 0x2a7, 0x2a9)
  /pillar/pubsub/subscribe.go:268 +0x7fd
  github.com/lf-edge/eve/pkg/pillar/pubsub.(*SubscriptionImpl).ProcessChange(0xc00078c100, 0x3, 0xc0015b3ce0, 0x24, 0xc0012d42c0, 0x2a7, 0x2a9)
  /pillar/pubsub/subscribe.go:132 +0x586
```

Patch introduces a simple check before array access and if array is empty - return an error.

@giggsoff pointed out that the following config (originally used by the customer) does not have a proper SHA256 for the image:

```
        {
            "uuid": "35ce9d94-f8c8-4a76-92ad-d43d764110a2",
            "dsId": "054866e7-eed8-420b-a722-0cd67d99f423",
            "URL": "container-disk-1G.qcow2",
            "iformat": "QCOW2",
            "sha256": "",
            "maxSizeBytes": "0",
            "siginfo": {
                "intercertsurl": "",
                "signercerturl": "",
                "signature": ""
            },
            "displayName": "container-disk-1G",
            "generationCount": "0"
        },
```

which causes the crash (reproduced by @giggsoff). Not clear how it is possible to create such a config without SHA256 on zedcloud, but this is another question. 


