### PR TITLE
Stable branch and lts release

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -20,6 +20,7 @@ on:  # yamllint disable-line rule:truthy
       - completed
     branches-ignore:
       - "[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+-stable"
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "master"
       - "[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+-stable"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}

--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -5,6 +5,7 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - "master"
       - "[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+-stable"
     paths-ignore:
       - 'docs/**'
   pull_request_review:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,8 +5,10 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - "master"
       - "[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+-stable"
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+-lts"
 
 jobs:
   packages:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -5,6 +5,7 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - "master"
       - "[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+-stable"
 
 jobs:
   test:

--- a/.github/workflows/yetus.yml
+++ b/.github/workflows/yetus.yml
@@ -12,6 +12,7 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - "master"
       - "[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+-stable"
 
 jobs:
   yetus:

--- a/Makefile
+++ b/Makefile
@@ -673,29 +673,37 @@ proto-api-%: $(GOBUILDER)
 	@$(DOCKER_GO) "protoc -I./proto --$(*)_out=$(PROTOC_OUT_OPTS)./$* \
 		proto/*/*.proto" $(CURDIR)/api api
 
-patch:
-	@if ! echo $(REPO_BRANCH) | grep -Eq '^[0-9]+\.[0-9]+$$'; then echo "ERROR: must be on a release branch X.Y"; exit 1; fi
-	@if ! echo $(EVE_TREE_TAG) | grep -Eq '^$(REPO_BRANCH).[0-9]+-'; then echo "ERROR: can't find previous release's tag X.Y.Z"; exit 1; fi
-	@TAG=$(REPO_BRANCH).$$((`echo $(EVE_TREE_TAG) | sed -e 's#-.*$$##' | cut -f3 -d.` + 1))  &&\
-	 git tag -a -m"Release $$TAG" $$TAG                                                      &&\
-	 echo "Done tagging $$TAG patch release. Check the branch with git log and then run"     &&\
-	 echo "  git push origin $(REPO_BRANCH) $$TAG"
+check-patch-%:
+	@if ! echo $* | grep -Eq '^[0-9]+\.[0-9]+$$'; then echo "ERROR: must be on a release branch X.Y"; exit 1; fi
+	@if ! echo $(EVE_TREE_TAG) | grep -Eq '^$*.[0-9]+-'; then echo "ERROR: can't find previous release's tag X.Y.Z"; exit 1; fi
+
+patch-%: check-patch-%
+	@$(eval PATCH_TAG:=$*.$(shell echo $$((`echo $(EVE_TREE_TAG) | sed -e 's#-.*$$##' | cut -f3 -d.` + 1))))
+
+patch-%-stable: patch-%
+	@$(eval PATCH_TAG:=$(PATCH_TAG)-lts)
+
+patch: patch-$(REPO_BRANCH)
+	@git tag -a -m"Release $(PATCH_TAG)" $(PATCH_TAG)
+	@echo "Done tagging $(PATCH_TAG) patch release. Check the branch with git log and then run"
+	@echo "  git push origin $(REPO_BRANCH) $(PATCH_TAG)"
 
 release:
 	@bail() { echo "ERROR: $$@" ; exit 1 ; } ;\
 	 X=`echo $(VERSION) | cut -s -d. -f1` ; Y=`echo $(VERSION) | cut -s -d. -f2` ; Z=`echo $(VERSION) | cut -s -d. -f3` ;\
+	 if echo $$Z | grep -Eq '[0-9]+-lts'; then BRANCH=$$X.$$Y-stable; else BRANCH=$$X.$$Y; fi ;\
 	 [ -z "$$X" -o -z "$$Y" -o -z "$$Z" ] && bail "VERSION missing (or incorrect). Re-run as: make VERSION=x.y.z $@" ;\
 	 (git fetch && [ `git diff origin/master..master | wc -l` -eq 0 ]) || bail "origin/master is different from master" ;\
-	 if git checkout $$X.$$Y 2>/dev/null ; then \
-	    echo "WARNING: branch $$X.$$Y already exists: you may want to run make patch instead" ;\
+	 if git checkout $$BRANCH 2>/dev/null ; then \
+	    echo "WARNING: branch $$BRANCH already exists: you may want to run make patch instead" ;\
 	    git merge origin/master ;\
 	 else \
-	    git checkout master -b $$X.$$Y && echo zedcloud.zededa.net > conf/server &&\
+	    git checkout master -b $$BRANCH && echo zedcloud.zededa.net > conf/server &&\
 	    git commit -m"Setting default server to prod" conf/server ;\
-	 fi || bail "Can't create $$X.$$Y branch" ;\
+	 fi || bail "Can't create $$BRANCH branch" ;\
 	 git tag -a -m"Release $$X.$$Y.$$Z" $$X.$$Y.$$Z &&\
 	 echo "Done tagging $$X.$$Y.$$Z release. Check the branch with git log and then run" &&\
-	 echo "  git push origin $$X.$$Y $$X.$$Y.$$Z"
+	 echo "  git push origin $$BRANCH $$X.$$Y.$$Z"
 
 shell: $(GOBUILDER)
 	$(QUIET)DOCKER_GO_ARGS=-t ; $(DOCKER_GO) bash $(GOTREE) $(GOMODULE)


### PR DESCRIPTION
We should adjust Makefile and workflow to support 'stable' suffix for branch name
and 'lts' suffix for tag name.

To create stable branch one can use 'make VERSION=X.Y.Z-lts release'
On stable branch 'make patch' will create new tag with lts suffix