### PR TITLE
Enable console for non-released versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -699,7 +699,8 @@ release:
 	    git merge origin/master ;\
 	 else \
 	    git checkout master -b $$BRANCH && echo zedcloud.zededa.net > conf/server &&\
-	    git commit -m"Setting default server to prod" conf/server ;\
+	    sed 's/set_getty/# set_getty/g' -i conf/grub.cfg &&\
+	    git commit -m"Setting default server to prod and disable console" conf/server conf/grub.cfg ;\
 	 fi || bail "Can't create $$BRANCH branch" ;\
 	 git tag -a -m"Release $$X.$$Y.$$Z" $$X.$$Y.$$Z &&\
 	 echo "Done tagging $$X.$$Y.$$Z release. Check the branch with git log and then run" &&\

--- a/conf/grub.cfg
+++ b/conf/grub.cfg
@@ -3,3 +3,6 @@
 #   set_global eve_flavor kvm
 # to force booting in Xen mode, uncomment:
 #   set_global eve_flavor xen
+
+# enable getty console
+set_getty


### PR DESCRIPTION
In order to simplify development we can enable console by default on non-released branches

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>