### PR TITLE
generate eve sbom in build process

### DIFF
--- a/pkg/eve/runme.sh
+++ b/pkg/eve/runme.sh
@@ -168,6 +168,10 @@ __EOT__
   dump /output.net installer.net
 }
 
+do_sbom() {
+  cat /bits/*.spdx.json >&3
+}
+
 # Lets' parse global options first
 while true; do
    case "$1" in


### PR DESCRIPTION
* adds a target `make sbom`, which takes the generated `rootfs.tar`, expands it to a temporary directory (excluding special devices, which would cause it to fail), runs `syft` on it, saves the output into the `installer/` directory, and removes the tmpdir
* adds `sbom` to the dependencies of `make eve`, so that the sbom is generated with every build and included in the `lfedge/eve` docker image
* adds a command `sbom`, so that you can run `docker run lfedge/eve sbom` and get an sbom in spdx json format

