### PR TITLE
Cross compilers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -300,7 +300,7 @@ endif
 # since they are not getting published in Docker HUB
 PKGS_$(ZARCH)=$(shell ls -d pkg/* | grep -Ev "eve|test-microsvcs|alpine")
 PKGS_riscv64=pkg/ipxe pkg/mkconf pkg/mkimage-iso-efi pkg/grub     \
-             pkg/mkimage-raw-efi pkg/uefi pkg/u-boot pkg/grub pkg/new-kernel \
+             pkg/mkimage-raw-efi pkg/uefi pkg/u-boot pkg/cross-compilers pkg/new-kernel \
 	     pkg/debug pkg/dom0-ztools pkg/gpt-tools pkg/storage-init pkg/mkrootfs-squash \
 		 pkg/bsp-imx
 # alpine-base and alpine must be the first packages to build
@@ -314,8 +314,8 @@ PKGS=pkg/alpine $(PKGS_$(ZARCH))
 # if you need a pkg to be loaded into docker, in addition to the lkt cache, add it here
 PKGS_DOCKER_LOAD=mkconf mkimage-iso-efi mkimage-raw-efi mkrootfs-ext4 mkrootfs-squash
 # these packages should exists for HOSTARCH as well as for ZARCH
-# alpine-base and alpine are dependencies for others
-PKGS_HOSTARCH=alpine-base alpine $(PKGS_DOCKER_LOAD)
+# alpine-base, alpine and cross-compilers are dependencies for others
+PKGS_HOSTARCH=alpine-base alpine cross-compilers $(PKGS_DOCKER_LOAD)
 # Top-level targets
 
 all: help

--- a/pkg/alpine/Dockerfile
+++ b/pkg/alpine/Dockerfile
@@ -44,8 +44,20 @@ COPY eve-alpine-deploy.sh go-compile.sh /bin/
 
 RUN apk update && apk upgrade -a
 
+# define arch-specific envs
+FROM scratch as final-amd64
+ENV BUILD_ARCH=x86_64
+ENV TARGET_ARCH=x86_64
+FROM scratch as final-arm64
+ENV BUILD_ARCH=aarch64
+ENV TARGET_ARCH=aarch64
+FROM scratch as final-riscv64
+ENV BUILD_ARCH=riscv64
+ENV TARGET_ARCH=riscv64
+
 # we merge layers in previous step
 # so we should avoid large possible diff
-FROM scratch
+# hadolint ignore=DL3006
+FROM final-${TARGETARCH}
 COPY --from=compactor / /
 CMD ["/bin/sh"]

--- a/pkg/alpine/mirrors/3.16/main
+++ b/pkg/alpine/mirrors/3.16/main
@@ -62,6 +62,7 @@ iproute2-minimal
 ipset
 ipset-openrc
 iptables
+isl-dev
 jpeg
 jpeg-dev
 jq
@@ -177,6 +178,7 @@ yajl-dev
 zfs
 zfs-dev
 zfs-udev
+zip
 zlib
 zlib-dev
 zlib-static

--- a/pkg/alpine/mirrors/3.16/main.aarch64
+++ b/pkg/alpine/mirrors/3.16/main.aarch64
@@ -1,1 +1,2 @@
 binutils-gold
+gcc-gnat

--- a/pkg/alpine/mirrors/3.16/main.x86_64
+++ b/pkg/alpine/mirrors/3.16/main.x86_64
@@ -1,1 +1,2 @@
 binutils-gold
+gcc-gnat

--- a/pkg/cross-compilers/Dockerfile
+++ b/pkg/cross-compilers/Dockerfile
@@ -1,0 +1,58 @@
+FROM lfedge/eve-alpine:b8b32c8353e50d7131d9ddc912581d14923806b0 as build-base
+ENV BUILD_PKGS abuild curl tar make linux-headers patch g++ git gcc ncurses-dev autoconf file sudo
+RUN eve-alpine-deploy.sh
+
+ENV ALPINE_VERSION 3.16.2
+ENV APORTS /home/builder/aports
+
+# setting up building account and output directory
+RUN adduser -G abuild -D builder && \
+    echo 'builder ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
+    install -d -m 0755 -o builder -g abuild /packages
+
+USER builder
+
+RUN git config --global user.email 'builder@projecteve.dev' && git config --global user.name 'Project EVE' && \
+    abuild-keygen -a -n -i && \
+    mkdir /home/builder/packages
+
+ADD --chown=builder:abuild https://gitlab.alpinelinux.org/alpine/aports/-/archive/"v${ALPINE_VERSION}"/aports-"v${ALPINE_VERSION}".tar.gz "${APORTS}"/aports.tar.gz
+
+COPY --chown=builder:abuild patches/aports /home/builder/patches
+
+WORKDIR $APORTS
+
+RUN tar -xzvf aports.tar.gz --strip-components=1 && rm -rf aports.tar.gz
+
+# Versions must be aligned with content of APKBUILD
+ENV BINUTILS_VERSION 2.38
+ENV MUSL_VERSION 1.2.3
+ENV GCC_VERSION 11.2.1_git20220219
+ADD --chown=builder:abuild https://ftp.gnu.org/gnu/binutils/binutils-${BINUTILS_VERSION}.tar.xz /var/cache/distfiles/binutils-${BINUTILS_VERSION}.tar.xz
+ADD --chown=builder:abuild https://git.musl-libc.org/cgit/musl/snapshot/v${MUSL_VERSION}.tar.gz /var/cache/distfiles/musl-v${MUSL_VERSION}.tar.gz
+ADD --chown=builder:abuild https://dev.alpinelinux.org/~nenolod/gcc-${GCC_VERSION}.tar.xz /var/cache/distfiles/gcc-${GCC_VERSION}.tar.xz
+
+ENV allTargets="riscv64 aarch64 x86_64"
+
+# hadolint ignore=SC2068
+RUN for patch in /home/builder/patches/*patch ; do patch -p1 < "$patch" ; done && \
+    for target in ${allTargets}; do \
+        [ "${target}" = "${BUILD_ARCH}" ] || sh -x ./scripts/bootstrap.sh "${target}"; \
+    done && \
+    rm -rf /home/builder/packages/main/"${BUILD_ARCH}"/gcc-pass2* && \
+    cp -r /home/builder/packages/main/"${BUILD_ARCH}" /packages/
+
+
+FROM build-base as build-amd64
+FROM build-base as build-arm64
+# we do not support cross-compilers for riscv64 host
+# as gcc-gnat is not available on riscv64
+# we cannot build cross-compilers without additional patches
+FROM lfedge/eve-alpine:b8b32c8353e50d7131d9ddc912581d14923806b0 as build-riscv64
+
+# hadolint ignore=DL3006
+FROM build-${TARGETARCH} as build
+RUN mkdir -p /packages
+
+FROM scratch
+COPY --from=build /packages /packages

--- a/pkg/cross-compilers/build.yml
+++ b/pkg/cross-compilers/build.yml
@@ -1,0 +1,2 @@
+image: eve-cross-compilers
+org: lfedge

--- a/pkg/cross-compilers/patches/aports/0001-only-cross-compile-prepare.patch
+++ b/pkg/cross-compilers/patches/aports/0001-only-cross-compile-prepare.patch
@@ -1,0 +1,27 @@
+From 8340b586f7dad1b3aab299c9d1b2a31c2fa37274 Mon Sep 17 00:00:00 2001
+From: Petr Fedchenkov <giggsoff@gmail.com>
+Date: Fri, 9 Dec 2022 14:06:55 +0300
+Subject: [PATCH] only cross-compile prepare
+
+Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>
+---
+ scripts/bootstrap.sh | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/scripts/bootstrap.sh b/scripts/bootstrap.sh
+index 8af1db858a..f4662a30a6 100755
+--- a/scripts/bootstrap.sh
++++ b/scripts/bootstrap.sh
+@@ -99,6 +99,9 @@ CTARGET=$TARGET_ARCH BOOTSTRAP=nobase APKBUILD=$(apkbuildname gcc) abuild -r
+ # Cross build-base
+ CTARGET=$TARGET_ARCH BOOTSTRAP=nobase APKBUILD=$(apkbuildname build-base) abuild -r
+ 
++# only prepare cross compiler
++exit 0
++
+ msg "Cross building base system"
+ 
+ # Implicit dependencies for early targets
+-- 
+2.37.2
+

--- a/pkg/cross-compilers/patches/aports/0002-adjust-sysroot.patch
+++ b/pkg/cross-compilers/patches/aports/0002-adjust-sysroot.patch
@@ -1,0 +1,26 @@
+From b0e5cb97c00dbfd799c705596a1e29c047924ce1 Mon Sep 17 00:00:00 2001
+From: Petr Fedchenkov <giggsoff@gmail.com>
+Date: Fri, 9 Dec 2022 17:44:25 +0300
+Subject: [PATCH] adjust sysroot
+
+Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>
+---
+ main/gcc/APKBUILD | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/main/gcc/APKBUILD b/main/gcc/APKBUILD
+index f0ec4ee18c..0425c56aa2 100644
+--- a/main/gcc/APKBUILD
++++ b/main/gcc/APKBUILD
+@@ -307,7 +307,7 @@ build() {
+ 	esac
+ 
+ 	[ "$CBUILD" != "$CHOST"   ] && _cross_configure="--disable-bootstrap"
+-	[ "$CHOST"  != "$CTARGET" ] && _cross_configure="--disable-bootstrap --with-sysroot=$CBUILDROOT"
++	[ "$CHOST"  != "$CTARGET" ] && _cross_configure="--disable-bootstrap --with-build-sysroot=$CBUILDROOT --with-sysroot=/usr/$CTARGET"
+ 
+ 	case "$BOOTSTRAP" in
+ 	nolibc)	_bootstrap_configure="--with-newlib --disable-shared --enable-threads=no" ;;
+-- 
+2.37.2
+

--- a/pkg/kernel/Dockerfile
+++ b/pkg/kernel/Dockerfile
@@ -1,33 +1,82 @@
 # This file must be kept as much in sync with pkg/new-kernel/Dockerfile as posisble
-FROM lfedge/eve-alpine:145f062a40639b6c65efa36bed1c5614b873be52 AS kernel-build-base
+# use the same set of packages for simplicity
+ARG BUILD_PKGS_BASE="argp-standalone automake bash bc binutils-dev bison build-base \
+                     diffutils flex git gmp-dev gnupg installkernel kmod elfutils-dev    \
+                     linux-headers libunwind-dev mpc1-dev mpfr-dev ncurses-dev findutils \
+                     openssl-dev patch rsync sed squashfs-tools tar xz xz-dev zlib-dev openssl \
+                     attr-dev autoconf file coreutils libtirpc-dev libtool util-linux-dev"
 
-ENV BUILD_PKGS \
-    argp-standalone automake bash bc binutils-dev bison build-base \
-    diffutils flex git gmp-dev gnupg installkernel kmod elfutils-dev    \
-    linux-headers libunwind-dev mpc1-dev mpfr-dev ncurses-dev findutils \
-    openssl-dev patch rsync sed squashfs-tools tar xz xz-dev zlib-dev openssl \
-    attr-dev autoconf file coreutils libtirpc-dev libtool util-linux-dev
+# we use the same image in several places
+ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:b8b32c8353e50d7131d9ddc912581d14923806b0
+
+# hadolint ignore=DL3006
+FROM ${EVE_ALPINE_IMAGE} as kernel-build-base-native
+ARG BUILD_PKGS_BASE
+RUN BUILD_PKGS="${BUILD_PKGS_BASE}" eve-alpine-deploy.sh
+
+# use build platform as a base image for cross-compilation
+# hadolint ignore=DL3006,DL3029
+FROM --platform=${BUILDPLATFORM} ${EVE_ALPINE_IMAGE} as kernel-build-base-cross
+ARG BUILD_PKGS_BASE
+RUN BUILD_PKGS="${BUILD_PKGS_BASE}" eve-alpine-deploy.sh
+
+# hadolint ignore=DL3029
+FROM --platform=${BUILDPLATFORM} lfedge/eve-cross-compilers:2a1d062fce410865e7024a83de327a68e52db26c AS cross-compilers
+
+# will use several packages from target arch and copy them to sysroot
+# hadolint ignore=DL3006
+FROM ${EVE_ALPINE_IMAGE} AS cross-compile-libs
+ENV PKGS musl-dev libgcc
 RUN eve-alpine-deploy.sh
 
+# adjust TARGET_ARCH for cross-compiler
+FROM kernel-build-base-cross AS kernel-cross-target-amd64
+ENV TARGET_ARCH=x86_64
+FROM kernel-build-base-cross AS kernel-cross-target-arm64
+ENV TARGET_ARCH=aarch64
+
+# install cross-compile packages and libs for target
+# hadolint ignore=DL3006
+FROM kernel-cross-target-${TARGETARCH} AS kernel-cross-build-target
+ENV CROSS_COMPILE_ENV="${TARGET_ARCH}"-alpine-linux-musl-
+COPY --from=cross-compilers /packages /packages
+# hadolint ignore=DL3018
+RUN apk add --no-cache --allow-untrusted -X /packages build-base-"${TARGET_ARCH}"
+COPY --from=cross-compile-libs /out/ /usr/"${TARGET_ARCH}"-alpine-linux-musl/
+
+# support cross compile from amd64 and arm64 for now
+FROM kernel-cross-build-target AS kernel-target-arm64-build-amd64
+FROM kernel-cross-build-target AS kernel-target-amd64-build-arm64
+
+# use kernel-build-base-native image as a base for the rest of target and build archs
+FROM kernel-build-base-native AS kernel-target-amd64-build-amd64
+FROM kernel-build-base-native AS kernel-target-arm64-build-arm64
+
 # set versions for arm64
-FROM kernel-build-base AS kernel-build-arm64
+# hadolint ignore=DL3006
+FROM kernel-target-${TARGETARCH}-build-${BUILDARCH} AS kernel-target-arm64
 ARG KERNEL_VERSION_arm64=5.10.121
 # this has to be specified separately because of dockerfile limitations
 ARG KERNEL_MAJOR=5
 ENV KERNEL_VERSION=${KERNEL_VERSION_arm64}
 ENV KERNEL_MAJOR=${KERNEL_MAJOR}
+ENV KERNEL_ARCH=arm64
+ENV KERNEL_DEFCONFIG=defconfig
 
 # set versions for amd64
-FROM kernel-build-base AS kernel-build-amd64
+# hadolint ignore=DL3006
+FROM kernel-target-${TARGETARCH}-build-${BUILDARCH} AS kernel-target-amd64
 ARG KERNEL_VERSION_amd64=5.10.121
 # this has to be specified separately because of dockerfile limitations
 ARG KERNEL_MAJOR=5
 ENV KERNEL_VERSION=${KERNEL_VERSION_amd64}
 ENV KERNEL_MAJOR=${KERNEL_MAJOR}
+ENV KERNEL_ARCH=x86
+ENV KERNEL_DEFCONFIG=x86_64_defconfig
 
 # build for all arches
 # hadolint ignore=DL3006
-FROM kernel-build-${TARGETARCH} AS kernel-build
+FROM kernel-target-${TARGETARCH} AS kernel-build
 
 # We copy the entire directory. This copies some unneeded files, but
 # allows us to check for the existence /patches-${KERNEL_SERIES} to
@@ -59,33 +108,28 @@ RUN gpg2 -q --import keys.asc && \
 
 # Apply local patches
 WORKDIR /linux
-RUN set -e ; KERNEL_SERIES=${KERNEL_VERSION%.*}.x; \
+RUN set -e ; KERNEL_SERIES="${KERNEL_VERSION%.*}".x; \
     [ ! -d /patches-"${KERNEL_SERIES}" ] || for patch in /patches-"${KERNEL_SERIES}"/*.patch; do \
         echo "Applying $patch"; \
         patch -p1 < "$patch"; \
     done
 
 # Copy default kconfig and prepare kbuild
-RUN case $(uname -m) in \
-    x86_64) \
-        KERNEL_DEF_CONF=/linux/arch/x86/configs/x86_64_defconfig; \
-        ;; \
-    aarch64) \
-        KERNEL_DEF_CONF=/linux/arch/arm64/configs/defconfig; \
-        ;; \
-    esac  && \
-    KERNEL_SERIES=${KERNEL_VERSION%.*}.x; \
-    cp /kernel_config-${KERNEL_SERIES}-$(uname -m) ${KERNEL_DEF_CONF}; \
+# hadolint ignore=SC2086
+RUN KERNEL_DEF_CONF="/linux/arch/${KERNEL_ARCH}/configs/${KERNEL_DEFCONFIG}"; \
+    KERNEL_SERIES="${KERNEL_VERSION%.*}".x; \
+    cp /kernel_config-"${KERNEL_SERIES}"-"${TARGET_ARCH}" "${KERNEL_DEF_CONF}"; \
     if [ -n "${EXTRA}" ]; then \
-        sed -i "s/CONFIG_LOCALVERSION=\"-linuxkit\"/CONFIG_LOCALVERSION=\"-linuxkit${EXTRA}\"/" ${KERNEL_DEF_CONF}; \
+        sed -i "s/CONFIG_LOCALVERSION=\"-linuxkit\"/CONFIG_LOCALVERSION=\"-linuxkit${EXTRA}\"/" "${KERNEL_DEF_CONF}"; \
         if [ "${EXTRA}" = "-dbg" ]; then \
-            sed -i 's/CONFIG_PANIC_ON_OOPS=y/# CONFIG_PANIC_ON_OOPS is not set/' ${KERNEL_DEF_CONF}; \
+            sed -i 's/CONFIG_PANIC_ON_OOPS=y/# CONFIG_PANIC_ON_OOPS is not set/' "${KERNEL_DEF_CONF}"; \
         fi && \
-        cat /kernel_config${EXTRA} >> ${KERNEL_DEF_CONF}; \
+        cat /kernel_config${EXTRA} >> "${KERNEL_DEF_CONF}"; \
     fi && \
-    cp ${KERNEL_DEF_CONF} .config && \
-    cp ${KERNEL_DEF_CONF} .config.new && \
-    make prepare
+    sed -i "s/CONFIG_CC_VERSION_TEXT=\"gcc/CONFIG_CC_VERSION_TEXT=\"${CROSS_COMPILE_ENV}gcc/" "${KERNEL_DEF_CONF}" && \
+    cp "${KERNEL_DEF_CONF}" .config && \
+    cp "${KERNEL_DEF_CONF}" .config.new && \
+    make CROSS_COMPILE="${CROSS_COMPILE_ENV}" ARCH="${KERNEL_ARCH}" prepare
 
 # Prepare built-in ZFS
 #  * ZFS on Linux
@@ -110,23 +154,24 @@ RUN set -e; \
         done \
     fi
 RUN ./autogen.sh && \
-    ./configure \
+    CROSS_COMPILE="${CROSS_COMPILE_ENV}" ARCH="${KERNEL_ARCH}" ./configure \
         --with-linux=/linux \
         --with-linux-obj=/linux \
         --with-config=kernel  \
-        --enable-linux-builtin && \
+        --enable-linux-builtin \
+        --host="${TARGET_ARCH}"-linux-musl --build="${BUILD_ARCH}"-linux-musl && \
     ./scripts/make_gitrev.sh && \
     ./copy-builtin /linux
 
 # Verify kconfig after ZFS is prepared as built-in
 WORKDIR /linux
-RUN make defconfig && \
-    make oldconfig && \
+RUN make CROSS_COMPILE="${CROSS_COMPILE_ENV}" ARCH="${KERNEL_ARCH}" "${KERNEL_DEFCONFIG}" && \
+    make CROSS_COMPILE="${CROSS_COMPILE_ENV}" ARCH="${KERNEL_ARCH}" oldconfig && \
     diff -cw .config .config.new
 
 # Make kernel
-RUN make -j "$(getconf _NPROCESSORS_ONLN)" KCFLAGS="-fno-pie" && \
-    case $(uname -m) in \
+RUN make -j "$(getconf _NPROCESSORS_ONLN)" CROSS_COMPILE="${CROSS_COMPILE_ENV}" ARCH="${KERNEL_ARCH}" KCFLAGS="-fno-pie" && \
+    case ${TARGET_ARCH} in \
     x86_64) \
         cp arch/x86_64/boot/bzImage /out/kernel; \
         ;; \
@@ -142,14 +187,14 @@ RUN make -j "$(getconf _NPROCESSORS_ONLN)" KCFLAGS="-fno-pie" && \
     tar -cf /out/kernel-debug.tar -C /tmp $DIR
 
 # Modules
-RUN make -j "$(getconf _NPROCESSORS_ONLN)" INSTALL_MOD_PATH=/tmp/kernel-modules modules_install
+RUN make -j "$(getconf _NPROCESSORS_ONLN)" CROSS_COMPILE="${CROSS_COMPILE_ENV}" ARCH="${KERNEL_ARCH}" INSTALL_MOD_PATH=/tmp/kernel-modules modules_install
 
 # Out-of-tree, creepy modules
 #  * Maxlinear USB (option #2 https://github.com/lipnitsk/xr/archive/master.zip)
 WORKDIR /linux
 ADD https://www.maxlinear.com/document?id=21651 /tmp/xr.zip
 RUN unzip -d /tmp /tmp/xr.zip ;\
-    make -j "$(getconf _NPROCESSORS_ONLN)" \
+    make -j "$(getconf _NPROCESSORS_ONLN)" CROSS_COMPILE="${CROSS_COMPILE_ENV}" ARCH="${KERNEL_ARCH}" \
          -C /linux INSTALL_MOD_PATH=/tmp/kernel-modules \
          M=/tmp/xr_usb_serial_common_lnx-3.6-and-newer-pak \
          modules modules_install
@@ -160,15 +205,15 @@ RUN tar -zxvf /tmp/rtl8821CU.tgz  --strip-components=1 && \
     rm /tmp/rtl8821CU.tgz
 
 WORKDIR /linux
-RUN make -j "$(getconf _NPROCESSORS_ONLN)" \
+RUN make -j "$(getconf _NPROCESSORS_ONLN)" CROSS_COMPILE="${CROSS_COMPILE_ENV}" ARCH="${KERNEL_ARCH}" \
     -C /tmp/rtl8821CU KSRC=/linux modules && \
     install -D -p -m 644 /tmp/rtl8821CU/8821cu.ko $(echo /tmp/kernel-modules/lib/modules/*)/kernel/drivers/net/wireless/realtek/rtl8821cu/8821cu.ko
 
 # Strip at least some of the modules to conserve space
-RUN if [ "$(uname -m)" = aarch64 ];then strip --strip-debug `find /tmp/kernel-modules/lib/modules -name \*.ko` ;fi
+RUN if [ "${TARGET_ARCH}" = aarch64 ];then "${CROSS_COMPILE_ENV}strip" --strip-debug `find /tmp/kernel-modules/lib/modules -name \*.ko` ;fi
 
 # Device Tree Blobs
-RUN if [ "$(uname -m)" = aarch64 ];then make INSTALL_DTBS_PATH=/tmp/kernel-modules/boot/dtb dtbs_install ;fi
+RUN if [ "${TARGET_ARCH}" = aarch64 ];then make INSTALL_DTBS_PATH=/tmp/kernel-modules/boot/dtb CROSS_COMPILE="${CROSS_COMPILE_ENV}" ARCH="${KERNEL_ARCH}" dtbs_install ;fi
 
 # Package all the modules up
 RUN ( DVER=$(basename $(find /tmp/kernel-modules/lib/modules/ -mindepth 1 -maxdepth 1)) && \
@@ -179,7 +224,7 @@ RUN ( DVER=$(basename $(find /tmp/kernel-modules/lib/modules/ -mindepth 1 -maxde
 
 # Headers (userspace API)
 RUN mkdir -p /tmp/kernel-headers/usr && \
-    make INSTALL_HDR_PATH=/tmp/kernel-headers/usr headers_install && \
+    make INSTALL_HDR_PATH=/tmp/kernel-headers/usr CROSS_COMPILE="${CROSS_COMPILE_ENV}" ARCH="${KERNEL_ARCH}" headers_install && \
     ( cd /tmp/kernel-headers && tar cf /out/kernel-headers.tar usr )
 
 # Headers (kernel development)

--- a/pkg/new-kernel/Dockerfile
+++ b/pkg/new-kernel/Dockerfile
@@ -1,41 +1,98 @@
 # This file must be kept as much in sync with pkg/kernel/Dockerfile as possible
-FROM lfedge/eve-alpine:145f062a40639b6c65efa36bed1c5614b873be52 as kernel-build-base
+# use the same set of packages for simplicity
+ARG BUILD_PKGS_BASE="argp-standalone automake bash bc binutils-dev bison build-base \
+                     diffutils flex git gmp-dev gnupg installkernel kmod elfutils-dev    \
+                     linux-headers libunwind-dev mpc1-dev mpfr-dev ncurses-dev findutils \
+                     openssl-dev patch rsync sed squashfs-tools tar xz xz-dev zlib-dev openssl \
+                     attr-dev autoconf file coreutils libtirpc-dev libtool util-linux-dev"
 
-ENV BUILD_PKGS \
-    argp-standalone automake bash bc binutils-dev bison build-base \
-    diffutils flex git gmp-dev gnupg installkernel kmod elfutils-dev    \
-    linux-headers libunwind-dev mpc1-dev mpfr-dev ncurses-dev findutils \
-    openssl-dev patch rsync sed squashfs-tools tar xz xz-dev zlib-dev openssl \
-    attr-dev autoconf file coreutils libtirpc-dev libtool util-linux-dev
+# we use the same image in several places
+ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:b8b32c8353e50d7131d9ddc912581d14923806b0
+
+# hadolint ignore=DL3006
+FROM ${EVE_ALPINE_IMAGE} as kernel-build-base-native
+ARG BUILD_PKGS_BASE
+RUN BUILD_PKGS="${BUILD_PKGS_BASE}" eve-alpine-deploy.sh
+
+# use build platform as a base image for cross-compilation
+# hadolint ignore=DL3006,DL3029
+FROM --platform=${BUILDPLATFORM} ${EVE_ALPINE_IMAGE} as kernel-build-base-cross
+ARG BUILD_PKGS_BASE
+RUN BUILD_PKGS="${BUILD_PKGS_BASE}" eve-alpine-deploy.sh
+
+# hadolint ignore=DL3029
+FROM --platform=${BUILDPLATFORM} lfedge/eve-cross-compilers:2a1d062fce410865e7024a83de327a68e52db26c AS cross-compilers
+
+# will use several packages from target arch and copy them to sysroot
+# hadolint ignore=DL3006
+FROM ${EVE_ALPINE_IMAGE} AS cross-compile-libs
+ENV PKGS musl-dev libgcc
 RUN eve-alpine-deploy.sh
 
+# adjust TARGET_ARCH for cross-compiler
+FROM kernel-build-base-cross AS kernel-cross-target-arm64
+ENV TARGET_ARCH=aarch64
+FROM kernel-build-base-cross AS kernel-cross-target-riscv64
+ENV TARGET_ARCH=riscv64
+
+# install cross-compile packages and libs for target
+# hadolint ignore=DL3006
+FROM kernel-cross-target-${TARGETARCH} AS kernel-cross-build-target
+ENV CROSS_COMPILE_ENV="${TARGET_ARCH}"-alpine-linux-musl-
+COPY --from=cross-compilers /packages /packages
+# hadolint ignore=DL3018
+RUN apk add --no-cache --allow-untrusted -X /packages build-base-"${TARGET_ARCH}"
+COPY --from=cross-compile-libs /out/ /usr/"${TARGET_ARCH}"-alpine-linux-musl/
+
+# support cross compile from amd64 and arm64 for now
+FROM kernel-cross-build-target AS kernel-target-arm64-build-amd64
+FROM kernel-cross-build-target AS kernel-target-riscv64-build-amd64
+FROM kernel-cross-build-target AS kernel-target-amd64-build-arm64
+FROM kernel-cross-build-target AS kernel-target-riscv64-build-arm64
+
+# use kernel-build-base-native image as a base for the rest of target and build archs
+FROM kernel-build-base-native AS kernel-target-amd64-build-amd64
+FROM kernel-build-base-native AS kernel-target-amd64-build-riscv64
+FROM kernel-build-base-native AS kernel-target-arm64-build-arm64
+FROM kernel-build-base-native AS kernel-target-arm64-build-riscv64
+FROM kernel-build-base-native AS kernel-target-riscv64-build-riscv64
+
 # set versions for arm64
-FROM kernel-build-base AS kernel-build-arm64
+# hadolint ignore=DL3006
+FROM kernel-target-${TARGETARCH}-build-${BUILDARCH} AS kernel-target-arm64
 ARG KERNEL_VERSION_arm64=5.15.46
 # this has to be specified separately because of dockerfile limitations
 ARG KERNEL_MAJOR=5
 ENV KERNEL_VERSION=${KERNEL_VERSION_arm64}
 ENV KERNEL_MAJOR=${KERNEL_MAJOR}
+ENV KERNEL_ARCH=arm64
+ENV KERNEL_DEFCONFIG=defconfig
 
 # set versions for amd64
-FROM kernel-build-base AS kernel-build-amd64
+# hadolint ignore=DL3006
+FROM kernel-target-${TARGETARCH}-build-${BUILDARCH} AS kernel-target-amd64
 ARG KERNEL_VERSION_amd64=5.15.46
 # this has to be specified separately because of dockerfile limitations
 ARG KERNEL_MAJOR=5
 ENV KERNEL_VERSION=${KERNEL_VERSION_amd64}
 ENV KERNEL_MAJOR=${KERNEL_MAJOR}
+ENV KERNEL_ARCH=x86
+ENV KERNEL_DEFCONFIG=x86_64_defconfig
 
 # set versions for riscv64
-FROM kernel-build-base AS kernel-build-riscv64
+# hadolint ignore=DL3006
+FROM kernel-target-${TARGETARCH}-build-${BUILDARCH} AS kernel-target-riscv64
 ARG KERNEL_VERSION_riscv64=5.15.46
 # this has to be specified separately because of dockerfile limitations
 ARG KERNEL_MAJOR=5
 ENV KERNEL_VERSION=${KERNEL_VERSION_riscv64}
 ENV KERNEL_MAJOR=${KERNEL_MAJOR}
+ENV KERNEL_ARCH=riscv
+ENV KERNEL_DEFCONFIG=defconfig
 
 # build for all arches
 # hadolint ignore=DL3006
-FROM kernel-build-${TARGETARCH} AS kernel-build
+FROM kernel-target-${TARGETARCH} AS kernel-build
 
 # We copy the entire directory. This copies some unneeded files, but
 # allows us to check for the existence /patches-${KERNEL_SERIES} to
@@ -69,36 +126,28 @@ RUN gpg2 -q --import keys.asc && \
 
 # Apply local patches
 WORKDIR /linux
-RUN set -e ; KERNEL_SERIES=${KERNEL_VERSION%.*}.x; \
+RUN set -e ; KERNEL_SERIES="${KERNEL_VERSION%.*}".x; \
     [ ! -d /patches-"${KERNEL_SERIES}" ] || for patch in /patches-"${KERNEL_SERIES}"/*.patch; do \
         echo "Applying $patch"; \
         patch -p1 < "$patch"; \
     done
 
 # Copy default kconfig and prepare kbuild
-RUN case $(uname -m) in \
-    x86_64) \
-        KERNEL_DEF_CONF=/linux/arch/x86/configs/x86_64_defconfig; \
-        ;; \
-    aarch64) \
-        KERNEL_DEF_CONF=/linux/arch/arm64/configs/defconfig; \
-        ;; \
-    riscv64) \
-        KERNEL_DEF_CONF=/linux/arch/riscv/configs/defconfig; \
-        ;; \
-    esac  && \
-    KERNEL_SERIES=${KERNEL_VERSION%.*}.x; \
-    cp /kernel_config-${KERNEL_SERIES}-$(uname -m) ${KERNEL_DEF_CONF}; \
+# hadolint ignore=SC2086
+RUN KERNEL_DEF_CONF="/linux/arch/${KERNEL_ARCH}/configs/${KERNEL_DEFCONFIG}"; \
+    KERNEL_SERIES="${KERNEL_VERSION%.*}".x; \
+    cp /kernel_config-"${KERNEL_SERIES}"-"${TARGET_ARCH}" "${KERNEL_DEF_CONF}"; \
     if [ -n "${EXTRA}" ]; then \
-        sed -i "s/CONFIG_LOCALVERSION=\"-linuxkit\"/CONFIG_LOCALVERSION=\"-linuxkit${EXTRA}\"/" ${KERNEL_DEF_CONF}; \
+        sed -i "s/CONFIG_LOCALVERSION=\"-linuxkit\"/CONFIG_LOCALVERSION=\"-linuxkit${EXTRA}\"/" "${KERNEL_DEF_CONF}"; \
         if [ "${EXTRA}" = "-dbg" ]; then \
-            sed -i 's/CONFIG_PANIC_ON_OOPS=y/# CONFIG_PANIC_ON_OOPS is not set/' ${KERNEL_DEF_CONF}; \
+            sed -i 's/CONFIG_PANIC_ON_OOPS=y/# CONFIG_PANIC_ON_OOPS is not set/' "${KERNEL_DEF_CONF}"; \
         fi && \
-        cat /kernel_config${EXTRA} >> ${KERNEL_DEF_CONF}; \
+        cat /kernel_config"${EXTRA}" >> "${KERNEL_DEF_CONF}"; \
     fi && \
-    cp ${KERNEL_DEF_CONF} .config && \
-    cp ${KERNEL_DEF_CONF} .config.new && \
-    make prepare
+    sed -i "s/CONFIG_CC_VERSION_TEXT=\"gcc/CONFIG_CC_VERSION_TEXT=\"${CROSS_COMPILE_ENV}gcc/" "${KERNEL_DEF_CONF}" && \
+    cp "${KERNEL_DEF_CONF}" .config && \
+    cp "${KERNEL_DEF_CONF}" .config.new && \
+    make CROSS_COMPILE="${CROSS_COMPILE_ENV}" ARCH="${KERNEL_ARCH}" prepare
 
 # Prepare built-in ZFS
 #  * ZFS on Linux
@@ -123,23 +172,24 @@ RUN set -e; \
         done \
     fi
 RUN ./autogen.sh && \
-    ./configure \
+    CROSS_COMPILE="${CROSS_COMPILE_ENV}" ARCH="${KERNEL_ARCH}" ./configure \
         --with-linux=/linux \
         --with-linux-obj=/linux \
         --with-config=kernel  \
-        --enable-linux-builtin && \
+        --enable-linux-builtin  \
+        --host="${TARGET_ARCH}"-linux-musl --build="${BUILD_ARCH}"-linux-musl && \
     ./scripts/make_gitrev.sh && \
     ./copy-builtin /linux
 
 # Verify kconfig after ZFS is prepared as built-in
 WORKDIR /linux
-RUN make defconfig && \
-    make oldconfig && \
+RUN make CROSS_COMPILE="${CROSS_COMPILE_ENV}" ARCH="${KERNEL_ARCH}" "${KERNEL_DEFCONFIG}" && \
+    make CROSS_COMPILE="${CROSS_COMPILE_ENV}" ARCH="${KERNEL_ARCH}" oldconfig && \
     diff -cw .config .config.new
 
 # Make kernel
-RUN make -j "$(getconf _NPROCESSORS_ONLN)" KCFLAGS="-fno-pie" && \
-    case $(uname -m) in \
+RUN make -j "$(getconf _NPROCESSORS_ONLN)" CROSS_COMPILE="${CROSS_COMPILE_ENV}" ARCH="${KERNEL_ARCH}" KCFLAGS="-fno-pie" && \
+    case ${TARGET_ARCH} in \
     x86_64) \
         cp arch/x86_64/boot/bzImage /out/kernel; \
         ;; \
@@ -158,7 +208,7 @@ RUN make -j "$(getconf _NPROCESSORS_ONLN)" KCFLAGS="-fno-pie" && \
     tar -cf /out/kernel-debug.tar -C /tmp $DIR
 
 # Modules
-RUN make -j "$(getconf _NPROCESSORS_ONLN)" INSTALL_MOD_PATH=/tmp/kernel-modules modules_install
+RUN make -j "$(getconf _NPROCESSORS_ONLN)" CROSS_COMPILE="${CROSS_COMPILE_ENV}" ARCH="${KERNEL_ARCH}" INSTALL_MOD_PATH=/tmp/kernel-modules modules_install
 
 # Out-of-tree, creepy modules
 WORKDIR /tmp/rtl8821CU
@@ -167,18 +217,18 @@ RUN tar -zxvf /tmp/rtl8821CU.tgz --strip-components=1 && \
     rm /tmp/rtl8821CU.tgz
 
 WORKDIR /linux
-RUN if [ "$(uname -m)" != riscv64 ]; then \
-        make -j "$(getconf _NPROCESSORS_ONLN)" -C /tmp/rtl8821CU KSRC=/linux modules && \
+RUN if [ "${TARGET_ARCH}" != riscv64 ]; then \
+        make -j "$(getconf _NPROCESSORS_ONLN)" -C /tmp/rtl8821CU KSRC=/linux CROSS_COMPILE="${CROSS_COMPILE_ENV}" ARCH="${KERNEL_ARCH}" modules && \
         install -D -p -m 644 /tmp/rtl8821CU/8821cu.ko $(echo /tmp/kernel-modules/lib/modules/*)/kernel/drivers/net/wireless/realtek/rtl8821cu/8821cu.ko ;\
     fi
 
 WORKDIR /linux
 
 # Strip at least some of the modules to conserve space
-RUN [ "$(uname -m)" = x86_64 ] || strip --strip-debug `find /tmp/kernel-modules/lib/modules -name \*.ko`
+RUN [ "${TARGET_ARCH}" = x86_64 ] || "${CROSS_COMPILE_ENV}strip" --strip-debug `find /tmp/kernel-modules/lib/modules -name \*.ko`
 
 # Device Tree Blobs
-RUN [ "$(uname -m)" = x86_64 ] || make INSTALL_DTBS_PATH=/tmp/kernel-modules/boot/dtb dtbs_install
+RUN [ "${TARGET_ARCH}" = x86_64 ] || make INSTALL_DTBS_PATH=/tmp/kernel-modules/boot/dtb CROSS_COMPILE="${CROSS_COMPILE_ENV}" ARCH="${KERNEL_ARCH}" dtbs_install
 
 # Package all the modules up
 RUN ( DVER=$(basename $(find /tmp/kernel-modules/lib/modules/ -mindepth 1 -maxdepth 1)) && \
@@ -189,7 +239,7 @@ RUN ( DVER=$(basename $(find /tmp/kernel-modules/lib/modules/ -mindepth 1 -maxde
 
 # Headers (userspace API)
 RUN mkdir -p /tmp/kernel-headers/usr && \
-    make INSTALL_HDR_PATH=/tmp/kernel-headers/usr headers_install && \
+    make INSTALL_HDR_PATH=/tmp/kernel-headers/usr CROSS_COMPILE="${CROSS_COMPILE_ENV}" ARCH="${KERNEL_ARCH}" headers_install && \
     ( cd /tmp/kernel-headers && tar cf /out/kernel-headers.tar usr )
 
 # Headers (kernel development)

--- a/pkg/pillar/Dockerfile
+++ b/pkg/pillar/Dockerfile
@@ -1,6 +1,12 @@
 # Copyright (c) 2018 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-fscrypt:0b7cc0d9d620e47fc54e21d56cb8a5cd224f9c9b as fscrypt
+
+# use the same set of packages for simplicity
+ARG BUILD_PKGS_BASE="git gcc linux-headers libc-dev make linux-pam-dev m4 findutils go util-linux make patch \
+                     libintl libuuid libtirpc libblkid libcrypto1.1 zlib tar"
+
+# we use the same image in several places
+ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:b8b32c8353e50d7131d9ddc912581d14923806b0
 
 FROM lfedge/eve-dom0-ztools:417d4ff6a57d2317c9e65166274b0ea6f6da16e2 as zfs
 RUN mkdir /out
@@ -13,38 +19,67 @@ RUN while read -r x; do \
         fi \
     done < /etc/zfs-files
 
-FROM lfedge/eve-alpine:145f062a40639b6c65efa36bed1c5614b873be52 as build
+# hadolint ignore=DL3006
+FROM ${EVE_ALPINE_IMAGE} as build-native
+ARG BUILD_PKGS_BASE
+RUN BUILD_PKGS="${BUILD_PKGS_BASE}" eve-alpine-deploy.sh
 
-ARG DEV=n
+# hadolint ignore=DL3006,DL3029
+FROM --platform=${BUILDPLATFORM} ${EVE_ALPINE_IMAGE} as build-cross
+ARG BUILD_PKGS_BASE
+RUN BUILD_PKGS="${BUILD_PKGS_BASE}" eve-alpine-deploy.sh
 
-ENV BUILD_PKGS git gcc linux-headers libc-dev make linux-pam-dev m4 findutils go util-linux make patch \
-    libintl libuuid libtirpc libblkid libcrypto1.1 zlib tar
-ENV PKGS alpine-baselayout musl-utils libtasn1-progs pciutils yajl xz bash iptables ip6tables iproute2 dhcpcd \
-    coreutils dmidecode libbz2 libuuid ipset curl radvd ethtool util-linux e2fsprogs libcrypto1.1 xorriso \
-    qemu-img jq e2fsprogs-extra keyutils ca-certificates ip6tables-openrc iptables-openrc ipset-openrc hdparm \
-    libintl libtirpc libblkid zlib
+# hadolint ignore=DL3029
+FROM --platform=${BUILDPLATFORM} lfedge/eve-cross-compilers:2a1d062fce410865e7024a83de327a68e52db26c AS cross-compilers
+
+# will use several packages from target arch and copy them to sysroot
+# hadolint ignore=DL3006
+FROM ${EVE_ALPINE_IMAGE} AS cross-compile-libs
+ENV PKGS musl-dev libgcc libintl libuuid libtirpc libblkid
 RUN eve-alpine-deploy.sh
+# we need zfs files during build
+COPY --from=zfs / /
 
-COPY --from=fscrypt /opt/zededa/bin /out/opt/zededa/bin
+# adjust TARGET_ARCH for cross-compiler
+FROM build-cross AS build-cross-target-arm64
+ENV TARGET_ARCH=aarch64
+FROM build-cross AS build-cross-target-amd64
+ENV TARGET_ARCH=x86_64
+
+# hadolint ignore=DL3006
+FROM build-cross-target-${TARGETARCH} AS build-cross-target
+ENV CROSS_COMPILE_ENV="${TARGET_ARCH}"-alpine-linux-musl-
+COPY --from=cross-compilers /packages /packages
+# hadolint ignore=DL3018
+RUN apk add --no-cache --allow-untrusted -X /packages build-base-"${TARGET_ARCH}"
+COPY --from=cross-compile-libs /out/ /usr/"${TARGET_ARCH}"-alpine-linux-musl/
+
+# cross-compilers
+FROM build-cross-target AS target-arm64-build-amd64
+FROM build-cross-target AS target-amd64-build-arm64
+# native
+FROM build-native AS target-amd64-build-amd64
+FROM build-native AS target-arm64-build-arm64
+
+# hadolint ignore=DL3006
+FROM target-${TARGETARCH}-build-${BUILDARCH} AS build
+ARG DEV=n
+ARG TARGETARCH
 
 # we need zfs files during build
 COPY --from=zfs /out /
-
-# These three are supporting rudimentary cross-build capabilities.
-# The only one supported so far is cross compiling for aarch64 on x86
-ENV GOFLAGS=-mod=vendor
-ENV GO111MODULE=on
-ENV CGO_ENABLED=1
-ARG GOARCH=
-ARG CROSS_GCC=https://musl.cc/aarch64-linux-musl-cross.tgz
-# hadolint ignore=DL3020
-ADD ${CROSS_GCC} /cross.tgz
-RUN [ -z "$GOARCH" ] || tar -C / -xzvf /cross.tgz && rm -f /cross.tgz
 
 ADD ./  /pillar/
 
 # go vet/format and go install
 WORKDIR /pillar
+
+ENV GOFLAGS=-mod=vendor
+ENV GO111MODULE=on
+ENV CGO_ENABLED=1
+ENV GOOS=linux
+ENV GOARCH=${TARGETARCH}
+ENV CC=${CROSS_COMPILE_ENV}gcc
 
 COPY pillar-patches/* /patches/
 RUN set -e && for patch in ../patches/*.patch; do \
@@ -53,11 +88,10 @@ RUN set -e && for patch in ../patches/*.patch; do \
     done
 
 # hadolint ignore=DL4006
-RUN [ -z "$GOARCH" ] || export CC=$(echo /*-cross/bin/*-gcc) ;\
-    echo "Running go vet" && go vet ./... && \
+RUN echo "Running go vet" && go vet ./... && \
     echo "Running go fmt" && ERR=$(gofmt -e -l -s $(find . -name \*.go | grep -v /vendor/)) && \
        if [ -n "$ERR" ] ; then echo "go fmt Failed - ERR: "$ERR ; exit 1 ; fi && \
-    make DEV=$DEV DISTDIR=/out/opt/zededa/bin build
+    make DEV=$DEV DISTDIR=/final/opt/zededa/bin build
 
 WORKDIR /
 
@@ -68,8 +102,27 @@ ADD ${DELVE_SOURCE} /delve.tar.gz
 RUN if [ ${DEV} = "y" ]; then \
     tar --absolute-names -xz < /delve.tar.gz && \
     cd "/delve-${DELVE_VERSION}" &&  \
-    GOFLAGS= CGO_ENABLED=0 GOBIN=/out/opt go install -ldflags "-s -w -extldflags '-static'" github.com/go-delve/delve/cmd/dlv ; \
+    GOFLAGS= CGO_ENABLED=0 go build -ldflags "-s -w -extldflags '-static'" github.com/go-delve/delve/cmd/dlv && \
+    cp dlv /final/opt/ ; \
 fi
+
+FROM lfedge/eve-fscrypt:0b7cc0d9d620e47fc54e21d56cb8a5cd224f9c9b as fscrypt
+FROM lfedge/eve-dnsmasq:3af908d86a95a627c729e09b1b125bf8de7fadcb as dnsmasq
+FROM lfedge/eve-strongswan:3f426e1c9fe2bbeb324a61c33b861c37459f616a as strongswan
+FROM lfedge/eve-gpt-tools:ab2e9f924e22709b4e08ebedd6d3c6a2882d071e as gpttools
+
+# collector collects everything together and then does any processing like stripping binaries.
+# We use this interim "collector" so that we can do processing.
+# hadolint ignore=DL3006
+FROM ${EVE_ALPINE_IMAGE} as collector
+ENV BUILD_PKGS patch
+ENV PKGS alpine-baselayout musl-utils libtasn1-progs pciutils yajl xz bash iptables ip6tables iproute2 dhcpcd \
+    coreutils dmidecode libbz2 libuuid ipset curl radvd ethtool util-linux e2fsprogs libcrypto1.1 xorriso \
+    qemu-img jq e2fsprogs-extra keyutils ca-certificates ip6tables-openrc iptables-openrc ipset-openrc hdparm \
+    libintl libtirpc libblkid zlib
+RUN eve-alpine-deploy.sh
+
+SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
 WORKDIR /
 
@@ -80,43 +133,33 @@ RUN set -e && for patch in /sys-patches/*.patch; do \
         patch -p0 --no-backup-if-mismatch -r /tmp/deleteme.rej < "$patch"; \
     done
 
-# we need zfs files on running system
 COPY --from=zfs /out /out
-
-FROM lfedge/eve-dnsmasq:3af908d86a95a627c729e09b1b125bf8de7fadcb as dnsmasq
-FROM lfedge/eve-strongswan:3f426e1c9fe2bbeb324a61c33b861c37459f616a as strongswan
-FROM lfedge/eve-gpt-tools:ab2e9f924e22709b4e08ebedd6d3c6a2882d071e as gpttools
-
-# collector collects everything together and then does any processing like stripping binaries.
-# We use this interim "collector" so that we can do processing.
-FROM lfedge/eve-alpine:145f062a40639b6c65efa36bed1c5614b873be52 as collector
-
-SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
-
-# we put everything into /final
-COPY --from=build /out/ /final
-COPY --from=gpttools / /final
-COPY --from=dnsmasq /usr/sbin/dnsmasq /final/opt/zededa/bin/dnsmasq
-COPY --from=strongswan / /final
+COPY --from=fscrypt /opt/zededa/bin /out/opt/zededa/bin
+COPY --from=gpttools / /out
+COPY --from=dnsmasq /usr/sbin/dnsmasq /out/opt/zededa/bin/dnsmasq
+COPY --from=strongswan / /out
+# we use final directory and move the line to the bottom
+# to avoid conflicts and speedup re-builds
+COPY --from=build /final /out
 
 # We have to make sure configs survive in some location, but they don't pollute
 # the default /config (since that is expected to be an empty mount point)
-ADD conf/root-certificate.pem conf/server conf/server.production /final/opt/zededa/examples/config/
+ADD conf/root-certificate.pem conf/server conf/server.production /out/opt/zededa/examples/config/
 ADD scripts/device-steps.sh \
     scripts/onboot.sh \
     scripts/handlezedserverconfig.sh \
     scripts/veth.sh \
     scripts/dhcpcd.sh \
-  /final/opt/zededa/bin/
-ADD conf/lisp.config.base /final/var/tmp/zededa/lisp.config.base
+  /out/opt/zededa/bin/
+ADD conf/lisp.config.base /out/var/tmp/zededa/lisp.config.base
 
 # And now a few local tweaks
-COPY rootfs/ /final
+COPY rootfs/ /out
 
 # We will start experimenting with stripping go binaries on ARM only for now
 RUN if [ "$(uname -m)" = "aarch64" ] ; then                                             \
        apk add --no-cache findutils binutils file                                      ;\
-       find /final -type f -executable -exec file {} \; | grep 'not stripped' | cut -f1 -d: |\
+       find /out -type f -executable -exec file {} \; | grep 'not stripped' | cut -f1 -d: |\
        xargs strip                                                                     ;\
        apk del findutils binutils file                                                 ;\
     fi
@@ -125,7 +168,7 @@ FROM scratch
 
 SHELL ["/bin/sh", "-c"]
 
-COPY --from=collector /final /
+COPY --from=collector /out /
 
 # FIXME: replace with tini+monit ASAP
 WORKDIR /


### PR DESCRIPTION
Let's enable cross compilation for kernel and new-kernel (from amd64 host for now). It reduce kernel compilation time arm64 target on my PC (amd64) from more than 2 hours down to 15 minutes.

The PR contains new packages where we build apks for cross-compilers using slightly modified aports with the same versions we use for native compilers. The build process of new package is quite time consuming, but we can just remove it from our build system as well as we do it for alpine-base until we will move to another version of Alpine.

Inside kernel and new-kernel we install cross-compilers and extract libraries to sysroot from native eve-alpine.
Only one change required in kernel config to use cross-compilers (CONFIG_CC_VERSION_TEXT from just gcc in the beginning to arch-specific).