### PR TITLE
Introduce list of datastores IDs for fallback download

### DIFF
--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -209,13 +209,23 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	}
 }
 
+// lookupDatastore() - does lookup for datastore ID and returns true if found
+func lookupDatastore(dsidArg uuid.UUID, status types.DownloaderStatus) bool {
+	for _, dsid := range status.DatastoreIDList {
+		if dsid == dsidArg {
+			return true
+		}
+	}
+	return false
+}
+
 // handle the datastore modification
 func checkAndUpdateDownloadableObjects(ctx *downloaderContext, dsID uuid.UUID) {
 	pub := ctx.pubDownloaderStatus
 	items := pub.GetAll()
 	for _, st := range items {
 		status := st.(types.DownloaderStatus)
-		if status.DatastoreID == dsID {
+		if lookupDatastore(dsID, status) {
 			config := lookupDownloaderConfig(ctx, status.Key())
 			if config != nil {
 				log.Noticef("checkAndUpdateDownloadableObjects updating %s due to datastore %s",
@@ -483,10 +493,8 @@ func doDownload(ctx *downloaderContext, config types.DownloaderConfig, status *t
 		return
 	}
 
-	//TODO: will be used the real list of IDS in the following patches
-	dsids := []uuid.UUID{config.DatastoreID}
-
-	dslist, err := prepareDatastoresList(ctx, config, dsids)
+	// Prepare list of datastore contexts and configs
+	dslist, err := prepareDatastoresList(ctx, config, config.DatastoreIDList)
 	if err != nil {
 		errStr := fmt.Sprintf("Retry download in %v: %s failed: %s",
 			retryTime, config.Name, err)

--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -434,10 +434,6 @@ func doDelete(ctx *downloaderContext, key string, filename string,
 
 	deletePath(filename)
 	deletePath(filename + progressFileSuffix)
-
-	status.State = types.INITIAL
-
-	publishDownloaderStatus(ctx, status)
 }
 
 // perform download of the object, by reserving storage
@@ -481,6 +477,7 @@ func handleDelete(ctx *downloaderContext, key string,
 	doDelete(ctx, key, status.Target, status)
 
 	status.PendingDelete = false
+	status.State = types.INITIAL
 	publishDownloaderStatus(ctx, status)
 
 	// Write out what we modified to DownloaderStatus aka delete

--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -417,22 +417,23 @@ func handleModify(ctx *downloaderContext, key string,
 	log.Functionf("handleModify done for %s", config.Name)
 }
 
+func deletePath(path string) {
+	if _, err := os.Stat(path); err == nil {
+		log.Functionf("Deleting %s", path)
+		if err := os.RemoveAll(path); err != nil {
+			log.Errorf("Failed to remove %s: err %s",
+				path, err)
+		}
+	}
+}
+
 func doDelete(ctx *downloaderContext, key string, filename string,
 	status *types.DownloaderStatus) {
 
 	log.Functionf("doDelete(%s) for %s", status.ImageSha256, status.Name)
 
-	if _, err := os.Stat(filename); err == nil {
-		log.Functionf("Deleting %s", filename)
-		if err := os.RemoveAll(filename); err != nil {
-			log.Errorf("Failed to remove %s: err %s",
-				filename, err)
-		}
-		if err := os.RemoveAll(filename + progressFileSuffix); err != nil {
-			log.Errorf("Failed to remove %s: err %s",
-				filename, err)
-		}
-	}
+	deletePath(filename)
+	deletePath(filename + progressFileSuffix)
 
 	status.State = types.INITIAL
 

--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -359,20 +359,22 @@ func handleCreate(ctx *downloaderContext, config types.DownloaderConfig,
 	if status == nil {
 		// Start by marking with PendingAdd
 		status0 := types.DownloaderStatus{
-			DatastoreID: config.DatastoreID,
-			Name:        config.Name,
-			ImageSha256: config.ImageSha256,
-			State:       types.DOWNLOADING,
-			RefCount:    config.RefCount,
-			Size:        config.Size,
-			LastUse:     time.Now(),
-			PendingAdd:  true,
+			DatastoreID:     config.DatastoreID,
+			DatastoreIDList: config.DatastoreIDList,
+			Name:            config.Name,
+			ImageSha256:     config.ImageSha256,
+			State:           types.DOWNLOADING,
+			RefCount:        config.RefCount,
+			Size:            config.Size,
+			LastUse:         time.Now(),
+			PendingAdd:      true,
 		}
 		status = &status0
 	} else {
 		// when refcount moves from 0 to a non-zero number,
 		// should trigger a fresh download of the object
 		status.DatastoreID = config.DatastoreID
+		status.DatastoreIDList = config.DatastoreIDList
 		status.ImageSha256 = config.ImageSha256
 		status.State = types.DOWNLOADING
 		status.RefCount = config.RefCount

--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -369,7 +369,6 @@ func handleCreate(ctx *downloaderContext, config types.DownloaderConfig,
 	if status == nil {
 		// Start by marking with PendingAdd
 		status0 := types.DownloaderStatus{
-			DatastoreID:     config.DatastoreID,
 			DatastoreIDList: config.DatastoreIDList,
 			Name:            config.Name,
 			ImageSha256:     config.ImageSha256,
@@ -383,7 +382,6 @@ func handleCreate(ctx *downloaderContext, config types.DownloaderConfig,
 	} else {
 		// when refcount moves from 0 to a non-zero number,
 		// should trigger a fresh download of the object
-		status.DatastoreID = config.DatastoreID
 		status.DatastoreIDList = config.DatastoreIDList
 		status.ImageSha256 = config.ImageSha256
 		status.State = types.DOWNLOADING

--- a/pkg/pillar/cmd/downloader/syncop.go
+++ b/pkg/pillar/cmd/downloader/syncop.go
@@ -25,7 +25,8 @@ import (
 // Drona APIs for object Download
 func handleSyncOp(ctx *downloaderContext, key string,
 	config types.DownloaderConfig, status *types.DownloaderStatus,
-	dst *types.DatastoreConfig, receiveChan chan<- CancelChannel) {
+	dst *types.DatastoreConfig, dsCtx *types.DatastoreContext,
+	receiveChan chan<- CancelChannel) (bool, string) {
 	var (
 		err                     error
 		errStr                  string
@@ -52,26 +53,8 @@ func handleSyncOp(ctx *downloaderContext, key string,
 	locDirname = path.Dir(locFilename)
 	cleanOnError := true
 
-	// construct the datastore context
-	dsCtx, err := constructDatastoreContext(ctx, config.Name, config.NameIsURL, *dst)
-	if err != nil {
-		errStr := fmt.Sprintf("Will retry in %v: %s failed: %s",
-			retryTime, config.Name, err)
-		handleSyncOpResponse(ctx, config, status, locFilename, key,
-			errStr, cancelled, cleanOnError)
-		return
-	}
-
 	// by default the metricsURL _is_ the DownloadURL, but can override in switch
 	metricsURL := dsCtx.DownloadURL
-
-	// update status to DOWNLOADING
-	status.State = types.DOWNLOADING
-	// save the name of the Target filename to our status. In theory, this can be
-	// derived, but it is good for the status to say where it *is*, as opposed to
-	// config, which says where it *should be*
-	status.Target = locFilename
-	publishDownloaderStatus(ctx, status)
 
 	// make sure the directory exists - just a safety check
 	if _, err := os.Stat(locDirname); err != nil {
@@ -195,9 +178,8 @@ func handleSyncOp(ctx *downloaderContext, key string,
 	// and return, but we will get to it later
 	if errStr != "" {
 		log.Errorf("Error preparing to download. All errors:%s", errStr)
-		handleSyncOpResponse(ctx, config, status, locFilename,
+		return handleSyncOpResponse(ctx, config, status, locFilename,
 			key, errStr, cancelled, cleanOnError)
-		return
 	}
 
 	// if the server URL ends with '.local', it is considered to be local data store
@@ -211,9 +193,8 @@ func handleSyncOp(ctx *downloaderContext, key string,
 			err := fmt.Errorf("No IP management port addresses with cost <= %d",
 				downloadMaxPortCost)
 			log.Error(err.Error())
-			handleSyncOpResponse(ctx, config, status, locFilename,
+			return handleSyncOpResponse(ctx, config, status, locFilename,
 				key, err.Error(), cancelled, cleanOnError)
-			return
 		}
 	}
 	// Note that network tracing of image downloads over SFTP is not supported.
@@ -322,10 +303,8 @@ func handleSyncOp(ctx *downloaderContext, key string,
 		if withNetTracing {
 			publishNetdump(ctx, true, tracedReqs)
 		}
-		handleSyncOpResponse(ctx, config, status,
+		return handleSyncOpResponse(ctx, config, status,
 			locFilename, key, "", cancelled, cleanOnError)
-		return
-
 	}
 	// we skip this error earlier but we must fill errStr
 	if errStr == "" {
@@ -338,7 +317,7 @@ func handleSyncOp(ctx *downloaderContext, key string,
 	if withNetTracing {
 		publishNetdump(ctx, false, tracedReqs)
 	}
-	handleSyncOpResponse(ctx, config, status, locFilename,
+	return handleSyncOpResponse(ctx, config, status, locFilename,
 		key, errStr, cancelled, cleanOnError)
 }
 
@@ -354,7 +333,7 @@ func getServerURL(dsCtx *types.DatastoreContext) (string, error) {
 
 func handleSyncOpResponse(ctx *downloaderContext, config types.DownloaderConfig,
 	status *types.DownloaderStatus, locFilename,
-	key, errStr string, cancelled, cleanOnError bool) {
+	key, errStr string, cancelled, cleanOnError bool) (bool, string) {
 
 	// have finished the download operation
 	// based on the result, perform some storage
@@ -365,11 +344,7 @@ func handleSyncOpResponse(ctx *downloaderContext, config types.DownloaderConfig,
 			// Delete downloaded files
 			doDelete(ctx, key, locFilename, status)
 		}
-		status.HandleDownloadFail(errStr, retryTime, cancelled)
-		publishDownloaderStatus(ctx, status)
-		log.Errorf("handleSyncOpResponse(%s): failed with %s",
-			status.Name, errStr)
-		return
+		return cancelled, errStr
 	}
 
 	// make sure the file exists
@@ -378,11 +353,7 @@ func handleSyncOpResponse(ctx *downloaderContext, config types.DownloaderConfig,
 		// Nothing was downloaded? Delete progress files if any
 		doDelete(ctx, key, locFilename, status)
 		errStr := fmt.Sprintf("%v", err)
-		status.HandleDownloadFail(errStr, retryTime, cancelled)
-		publishDownloaderStatus(ctx, status)
-		log.Errorf("handleSyncOpResponse(%s): failed with %s",
-			status.Name, errStr)
-		return
+		return cancelled, errStr
 	}
 
 	err = os.RemoveAll(locFilename + progressFileSuffix)
@@ -393,15 +364,9 @@ func handleSyncOpResponse(ctx *downloaderContext, config types.DownloaderConfig,
 
 	log.Functionf("handleSyncOpResponse(%s): successful <%s>",
 		config.Name, locFilename)
-	// We do not clear any status.RetryCount, Error, etc. The caller
-	// should look at State == DOWNLOADED to determine it is done.
 
-	status.ClearError()
-	status.ModTime = time.Now()
-	status.State = types.DOWNLOADED
-	status.Progress = 100 // Just in case
-	status.ClearPendingStatus()
-	publishDownloaderStatus(ctx, status)
+	// Report success
+	return false, ""
 }
 
 // cloud storage interface functions/APIs

--- a/pkg/pillar/cmd/downloader/syncop.go
+++ b/pkg/pillar/cmd/downloader/syncop.go
@@ -362,7 +362,7 @@ func handleSyncOpResponse(ctx *downloaderContext, config types.DownloaderConfig,
 
 	if errStr != "" {
 		if cleanOnError {
-			// Delete file, and update the storage
+			// Delete downloaded files
 			doDelete(ctx, key, locFilename, status)
 		}
 		status.HandleDownloadFail(errStr, retryTime, cancelled)
@@ -375,7 +375,7 @@ func handleSyncOpResponse(ctx *downloaderContext, config types.DownloaderConfig,
 	// make sure the file exists
 	_, err := os.Stat(locFilename)
 	if err != nil {
-		// error, so delete the file
+		// Nothing was downloaded? Delete progress files if any
 		doDelete(ctx, key, locFilename, status)
 		errStr := fmt.Sprintf("%v", err)
 		status.HandleDownloadFail(errStr, retryTime, cancelled)

--- a/pkg/pillar/cmd/volumemgr/blob.go
+++ b/pkg/pillar/cmd/volumemgr/blob.go
@@ -274,7 +274,6 @@ func getBlobChildren(ctx *volumemgrContext, blob *types.BlobStatus) []*types.Blo
 		if existingChild == nil {
 			return []*types.BlobStatus{
 				{
-					DatastoreID:            blob.DatastoreID,
 					DatastoreIDList:        blob.DatastoreIDList,
 					RelativeURL:            replaceSha(blob.RelativeURL, manifest.Digest),
 					Sha256:                 strings.ToLower(manifest.Digest.Hex),
@@ -286,7 +285,6 @@ func getBlobChildren(ctx *volumemgrContext, blob *types.BlobStatus) []*types.Blo
 		} else if existingChild.State == types.LOADED {
 			// Need to update DatastoreIDList and RelativeURL if the blob is already loaded into CAS,
 			// because if any child blob is not downloaded already, then we would need the below data.
-			existingChild.DatastoreID = blob.DatastoreID
 			existingChild.DatastoreIDList = blob.DatastoreIDList
 			existingChild.RelativeURL = replaceSha(blob.RelativeURL, manifest.Digest)
 		}
@@ -314,7 +312,6 @@ func getBlobChildren(ctx *volumemgrContext, blob *types.BlobStatus) []*types.Blo
 				} else {
 					log.Functionf("getBlobChildren(%s): creating a new BlobStatus for child %s", blob.Sha256, childHash)
 					blobChildren = append(blobChildren, &types.BlobStatus{
-						DatastoreID:            blob.DatastoreID,
 						DatastoreIDList:        blob.DatastoreIDList,
 						RelativeURL:            replaceSha(blob.RelativeURL, child.Digest),
 						Sha256:                 childHash,

--- a/pkg/pillar/cmd/volumemgr/blob.go
+++ b/pkg/pillar/cmd/volumemgr/blob.go
@@ -275,6 +275,7 @@ func getBlobChildren(ctx *volumemgrContext, blob *types.BlobStatus) []*types.Blo
 			return []*types.BlobStatus{
 				{
 					DatastoreID:            blob.DatastoreID,
+					DatastoreIDList:        blob.DatastoreIDList,
 					RelativeURL:            replaceSha(blob.RelativeURL, manifest.Digest),
 					Sha256:                 strings.ToLower(manifest.Digest.Hex),
 					Size:                   uint64(manifest.Size),
@@ -283,9 +284,10 @@ func getBlobChildren(ctx *volumemgrContext, blob *types.BlobStatus) []*types.Blo
 				},
 			}
 		} else if existingChild.State == types.LOADED {
-			// Need to update DatastoreID and RelativeURL if the blob is already loaded into CAS,
+			// Need to update DatastoreIDList and RelativeURL if the blob is already loaded into CAS,
 			// because if any child blob is not downloaded already, then we would need the below data.
 			existingChild.DatastoreID = blob.DatastoreID
+			existingChild.DatastoreIDList = blob.DatastoreIDList
 			existingChild.RelativeURL = replaceSha(blob.RelativeURL, manifest.Digest)
 		}
 		log.Functionf("getBlobChildren(%s): manifest %s already exists.", blob.Sha256, childHash)
@@ -313,6 +315,7 @@ func getBlobChildren(ctx *volumemgrContext, blob *types.BlobStatus) []*types.Blo
 					log.Functionf("getBlobChildren(%s): creating a new BlobStatus for child %s", blob.Sha256, childHash)
 					blobChildren = append(blobChildren, &types.BlobStatus{
 						DatastoreID:            blob.DatastoreID,
+						DatastoreIDList:        blob.DatastoreIDList,
 						RelativeURL:            replaceSha(blob.RelativeURL, child.Digest),
 						Sha256:                 childHash,
 						Size:                   uint64(child.Size),

--- a/pkg/pillar/cmd/volumemgr/handlecontent.go
+++ b/pkg/pillar/cmd/volumemgr/handlecontent.go
@@ -172,7 +172,6 @@ func createContentTreeStatus(ctx *volumemgrContext, config types.ContentTreeConf
 	if status == nil {
 		status = &types.ContentTreeStatus{
 			ContentID:         config.ContentID,
-			DatastoreID:       config.DatastoreID,
 			DatastoreIDList:   config.DatastoreIDList,
 			RelativeURL:       config.RelativeURL,
 			Format:            config.Format,
@@ -202,7 +201,6 @@ func createContentTreeStatus(ctx *volumemgrContext, config types.ContentTreeConf
 					mediaType = ""
 				}
 				rootBlob := &types.BlobStatus{
-					DatastoreID:            config.DatastoreID,
 					DatastoreIDList:        config.DatastoreIDList,
 					RelativeURL:            config.RelativeURL,
 					Sha256:                 strings.ToLower(config.ContentSha256),

--- a/pkg/pillar/cmd/volumemgr/handlecontent.go
+++ b/pkg/pillar/cmd/volumemgr/handlecontent.go
@@ -153,6 +153,7 @@ func createContentTreeStatus(ctx *volumemgrContext, config types.ContentTreeConf
 			ContentID:         config.ContentID,
 			DatastoreID:       config.DatastoreID,
 			DatastoreType:     datastoreType,
+			DatastoreIDList:   config.DatastoreIDList,
 			RelativeURL:       config.RelativeURL,
 			Format:            config.Format,
 			ContentSha256:     config.ContentSha256,
@@ -181,6 +182,7 @@ func createContentTreeStatus(ctx *volumemgrContext, config types.ContentTreeConf
 				}
 				rootBlob := &types.BlobStatus{
 					DatastoreID:            config.DatastoreID,
+					DatastoreIDList:        config.DatastoreIDList,
 					RelativeURL:            config.RelativeURL,
 					Sha256:                 strings.ToLower(config.ContentSha256),
 					Size:                   config.MaxDownloadSize,

--- a/pkg/pillar/cmd/volumemgr/handlecontent.go
+++ b/pkg/pillar/cmd/volumemgr/handlecontent.go
@@ -134,25 +134,45 @@ func lookupContentTreeConfig(ctx *volumemgrContext, key string) *types.ContentTr
 	return &config
 }
 
+// populateDatastoreFields() - populate all datastore related fields traversing
+//                             all datastore IDs list. Type of the found datastore
+//                             is stored into the types list. Mark the whole
+//                             status as resolved if all the datastores were
+//                             successfully found.
+func populateDatastoreFields(ctx *volumemgrContext, config types.ContentTreeConfig,
+	status *types.ContentTreeStatus) {
+
+	nr := len(config.DatastoreIDList)
+	status.DatastoreTypesList = make([]string, nr)
+
+	nrResolved := 0
+	for i, dsid := range config.DatastoreIDList {
+		dsConfig, err := utils.LookupDatastoreConfig(ctx.subDatastoreConfig, dsid)
+		if dsConfig == nil {
+			// Still not found, repeat on the datastore update
+			log.Errorf("populateDatastoreFields(%s): datastoreConfig for %s not found %v", config.Key(), dsid, err)
+			continue
+		}
+		status.DatastoreTypesList[i] = dsConfig.DsType
+		nrResolved++
+
+		// OCI registry is special, so mark the whole status if there is any
+		if dsConfig.DsType == zconfig.DsType_DsContainerRegistry.String() {
+			status.IsOCIRegistry = true
+		}
+	}
+
+	status.AllDatastoresResolved = (nrResolved == nr)
+}
+
 func createContentTreeStatus(ctx *volumemgrContext, config types.ContentTreeConfig) *types.ContentTreeStatus {
 
 	log.Functionf("createContentTreeStatus for %v", config.ContentID)
 	status := ctx.LookupContentTreeStatus(config.Key())
 	if status == nil {
-		// need to save the datastore type
-		var datastoreType string
-		datastoreConfig, err := utils.LookupDatastoreConfig(ctx.subDatastoreConfig, config.DatastoreID)
-		if datastoreConfig == nil {
-			log.Errorf("createContentTreeStatus(%s): datastoreConfig for %s not found %v", config.Key(), config.DatastoreID, err)
-		} else {
-			log.Tracef("Found datastore(%s) for %s", config.DatastoreID.String(), config.Key())
-			datastoreType = datastoreConfig.DsType
-		}
-
 		status = &types.ContentTreeStatus{
 			ContentID:         config.ContentID,
 			DatastoreID:       config.DatastoreID,
-			DatastoreType:     datastoreType,
 			DatastoreIDList:   config.DatastoreIDList,
 			RelativeURL:       config.RelativeURL,
 			Format:            config.Format,
@@ -164,6 +184,7 @@ func createContentTreeStatus(ctx *volumemgrContext, config types.ContentTreeConf
 			Blobs:             []string{},
 			// LastRefCountChangeTime: time.Now(),
 		}
+		populateDatastoreFields(ctx, config, status)
 
 		// we only publish the BlobStatus if we have the hash for it; this
 		// might come later

--- a/pkg/pillar/cmd/volumemgr/handledownloader.go
+++ b/pkg/pillar/cmd/volumemgr/handledownloader.go
@@ -46,7 +46,9 @@ func AddOrRefcountDownloaderConfig(ctx *volumemgrContext, blob types.BlobStatus)
 	// where should the final downloaded file be?
 	// Pick a name based on existing info about object to persist it across reboots
 	idHash := sha256.New()
-	idHash.Write(blob.DatastoreID.Bytes())
+	for _, uuid := range blob.DatastoreIDList {
+		idHash.Write(uuid.Bytes())
+	}
 	idHash.Write([]byte(blob.RelativeURL))
 	idHash.Write([]byte(strconv.FormatUint(blob.Size, 10)))
 	pendingFile := hex.EncodeToString(idHash.Sum(nil)) + "." + blob.Sha256

--- a/pkg/pillar/cmd/volumemgr/handledownloader.go
+++ b/pkg/pillar/cmd/volumemgr/handledownloader.go
@@ -56,12 +56,13 @@ func AddOrRefcountDownloaderConfig(ctx *volumemgrContext, blob types.BlobStatus)
 	// try to reserve storage, must be released on error
 	size := blob.Size
 	n := types.DownloaderConfig{
-		DatastoreID: blob.DatastoreID,
-		Name:        blob.RelativeURL,
-		ImageSha256: blob.Sha256,
-		Size:        size,
-		Target:      locFilename,
-		RefCount:    refCount,
+		DatastoreID:     blob.DatastoreID,
+		DatastoreIDList: blob.DatastoreIDList,
+		Name:            blob.RelativeURL,
+		ImageSha256:     blob.Sha256,
+		Size:            size,
+		Target:          locFilename,
+		RefCount:        refCount,
 	}
 	log.Functionf("AddOrRefcountDownloaderConfig: DownloaderConfig: %+v", n)
 	publishDownloaderConfig(ctx, &n)

--- a/pkg/pillar/cmd/volumemgr/handledownloader.go
+++ b/pkg/pillar/cmd/volumemgr/handledownloader.go
@@ -58,7 +58,6 @@ func AddOrRefcountDownloaderConfig(ctx *volumemgrContext, blob types.BlobStatus)
 	// try to reserve storage, must be released on error
 	size := blob.Size
 	n := types.DownloaderConfig{
-		DatastoreID:     blob.DatastoreID,
 		DatastoreIDList: blob.DatastoreIDList,
 		Name:            blob.RelativeURL,
 		ImageSha256:     blob.Sha256,

--- a/pkg/pillar/cmd/volumemgr/handleresolve.go
+++ b/pkg/pillar/cmd/volumemgr/handleresolve.go
@@ -13,7 +13,7 @@ func MaybeAddResolveConfig(ctx *volumemgrContext, cs types.ContentTreeStatus) {
 
 	log.Functionf("MaybeAddResolveConfig for %s", cs.ContentID)
 	resolveConfig := types.ResolveConfig{
-		DatastoreID: cs.DatastoreID,
+		DatastoreID: cs.DatastoreIDList[0],
 		Name:        cs.RelativeURL,
 		Counter:     uint32(cs.GenerationCounter),
 	}
@@ -103,7 +103,7 @@ func handleResolveStatusImpl(ctxArg interface{}, key string,
 		status := cs.(types.ContentTreeStatus)
 		if !status.HasResolverRef ||
 			status.RelativeURL != rs.Name ||
-			status.DatastoreID != rs.DatastoreID {
+			status.DatastoreIDList[0] != rs.DatastoreID {
 			continue
 		}
 		log.Functionf("Updating SHA for content tree: %v",

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -94,6 +94,7 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 			if rootBlob == nil {
 				rootBlob = &types.BlobStatus{
 					DatastoreID:            status.DatastoreID,
+					DatastoreIDList:        status.DatastoreIDList,
 					RelativeURL:            status.RelativeURL,
 					Sha256:                 status.ContentSha256,
 					Size:                   status.MaxDownloadSize,
@@ -105,9 +106,10 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 					status.ContentSha256, status.ContentID)
 				publishBlobStatus(ctx, rootBlob)
 			} else if rootBlob.State == types.LOADED {
-				//Need to update DatastoreID and RelativeURL if the blob is already loaded into CAS,
+				//Need to update DatastoreIDList and RelativeURL if the blob is already loaded into CAS,
 				// because if any child blob is not downloaded, then we would need the below data.
 				rootBlob.DatastoreID = status.DatastoreID
+				rootBlob.DatastoreIDList = status.DatastoreIDList
 				rootBlob.RelativeURL = status.RelativeURL
 				log.Functionf("doUpdateContentTree: publishing loaded root BlobStatus (%s) for content tree (%s)",
 					status.ContentSha256, status.ContentID)

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -102,7 +102,6 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 			rootBlob := lookupOrCreateBlobStatus(ctx, status.ContentSha256)
 			if rootBlob == nil {
 				rootBlob = &types.BlobStatus{
-					DatastoreID:            status.DatastoreID,
 					DatastoreIDList:        status.DatastoreIDList,
 					RelativeURL:            status.RelativeURL,
 					Sha256:                 status.ContentSha256,
@@ -117,7 +116,6 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 			} else if rootBlob.State == types.LOADED {
 				//Need to update DatastoreIDList and RelativeURL if the blob is already loaded into CAS,
 				// because if any child blob is not downloaded, then we would need the below data.
-				rootBlob.DatastoreID = status.DatastoreID
 				rootBlob.DatastoreIDList = status.DatastoreIDList
 				rootBlob.RelativeURL = status.RelativeURL
 				log.Functionf("doUpdateContentTree: publishing loaded root BlobStatus (%s) for content tree (%s)",

--- a/pkg/pillar/cmd/zedagent/handlecontent.go
+++ b/pkg/pillar/cmd/zedagent/handlecontent.go
@@ -88,7 +88,6 @@ func parseContentInfoConfig(ctx *getconfigContext,
 	for _, cfgContentTree := range cfgContentTreeList {
 		contentConfig := new(types.ContentTreeConfig)
 		contentConfig.ContentID, _ = uuid.FromString(cfgContentTree.GetUuid())
-		contentConfig.DatastoreID, _ = uuid.FromString(cfgContentTree.GetDsId())
 		contentConfig.DatastoreIDList, _ = getDatastoreIDList(cfgContentTree)
 		contentConfig.RelativeURL = cfgContentTree.GetURL()
 		contentConfig.Format = cfgContentTree.GetIformat()

--- a/pkg/pillar/cmd/zedagent/handlecontent.go
+++ b/pkg/pillar/cmd/zedagent/handlecontent.go
@@ -17,6 +17,35 @@ import (
 
 var contentInfoHash []byte
 
+// stringsToUuids() - converts list of strings to a list of uuids,
+//                    returns a list with a nil uuid and a last error if
+//                    conversion fails
+func stringsToUuids(strings []string) ([]uuid.UUID, error) {
+	list := make([]uuid.UUID, len(strings))
+	for i, str := range strings {
+		var err error
+		list[i], err = uuid.FromString(str)
+		if err != nil {
+			log.Errorf("stringsToUuids(): error parsing UUID '%s' index %d, %v\n",
+				str, i, err)
+			return []uuid.UUID{nilUUID}, err
+		}
+	}
+
+	return list, nil
+}
+
+// getDatastoreIDList() - returns list of datastores UUIDs
+func getDatastoreIDList(contentTree *zconfig.ContentTree) ([]uuid.UUID, error) {
+	idsStrList := contentTree.GetDsIdsList()
+	if len(idsStrList) == 0 {
+		// Compatibility with the old controller, which does not support
+		// list of datastores
+		idsStrList = []string{contentTree.GetDsId()}
+	}
+	return stringsToUuids(idsStrList)
+}
+
 // content info parsing routine
 func parseContentInfoConfig(ctx *getconfigContext,
 	config *zconfig.EdgeDevConfig) {
@@ -60,6 +89,7 @@ func parseContentInfoConfig(ctx *getconfigContext,
 		contentConfig := new(types.ContentTreeConfig)
 		contentConfig.ContentID, _ = uuid.FromString(cfgContentTree.GetUuid())
 		contentConfig.DatastoreID, _ = uuid.FromString(cfgContentTree.GetDsId())
+		contentConfig.DatastoreIDList, _ = getDatastoreIDList(cfgContentTree)
 		contentConfig.RelativeURL = cfgContentTree.GetURL()
 		contentConfig.Format = cfgContentTree.GetIformat()
 		contentConfig.ContentSha256 = strings.ToLower(cfgContentTree.GetSha256())

--- a/pkg/pillar/types/blob.go
+++ b/pkg/pillar/types/blob.go
@@ -16,6 +16,8 @@ import (
 type BlobStatus struct {
 	// DatastoreID ID of the datastore where the blob can be retrieved
 	DatastoreID uuid.UUID
+	// DatastoreIDList list of datastores where the blob can be retrieved
+	DatastoreIDList []uuid.UUID
 	// RelativeURL URL relative to the root of the datastore
 	RelativeURL string
 	// Sha256 the sha of the blob

--- a/pkg/pillar/types/blob.go
+++ b/pkg/pillar/types/blob.go
@@ -4,6 +4,7 @@
 package types
 
 import (
+	"strings"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -82,8 +83,11 @@ func (status BlobStatus) LogCreate(logBase *base.LogObject) {
 	if logObject == nil {
 		return
 	}
+
+	uuids := strings.Join(UuidsToStrings(status.DatastoreIDList), ",")
+
 	logObject.CloneAndAddField("state", status.State.String()).
-		AddField("datastoreid-uuid", status.DatastoreID).
+		AddField("datastoreid-uuids", uuids).
 		AddField("size-int64", status.Size).
 		AddField("blobtype-string", status.MediaType).
 		AddField("refcount-int64", status.RefCount).

--- a/pkg/pillar/types/blob.go
+++ b/pkg/pillar/types/blob.go
@@ -15,8 +15,6 @@ import (
 
 // BlobStatus status of a downloaded blob
 type BlobStatus struct {
-	// DatastoreID ID of the datastore where the blob can be retrieved
-	DatastoreID uuid.UUID
 	// DatastoreIDList list of datastores where the blob can be retrieved
 	DatastoreIDList []uuid.UUID
 	// RelativeURL URL relative to the root of the datastore

--- a/pkg/pillar/types/contenttreetypes.go
+++ b/pkg/pillar/types/contenttreetypes.go
@@ -5,6 +5,7 @@ package types
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -40,7 +41,8 @@ func (config ContentTreeConfig) LogCreate(logBase *base.LogObject) {
 	if logObject == nil {
 		return
 	}
-	logObject.CloneAndAddField("datastore-id", config.DatastoreID).
+	uuids := strings.Join(UuidsToStrings(config.DatastoreIDList), ",")
+	logObject.CloneAndAddField("datastore-ids", uuids).
 		AddField("relative-URL", config.RelativeURL).
 		AddField("format", config.Format).
 		AddField("content-sha256", config.ContentSha256).
@@ -57,18 +59,21 @@ func (config ContentTreeConfig) LogModify(logBase *base.LogObject, old interface
 	if !ok {
 		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of ContentTreeConfig type")
 	}
-	if oldConfig.DatastoreID != config.DatastoreID ||
+	uuids := strings.Join(UuidsToStrings(config.DatastoreIDList), ",")
+	oldUuids := strings.Join(UuidsToStrings(oldConfig.DatastoreIDList), ",")
+
+	if uuids != oldUuids ||
 		oldConfig.RelativeURL != config.RelativeURL ||
 		oldConfig.Format != config.Format ||
 		oldConfig.ContentSha256 != config.ContentSha256 ||
 		oldConfig.MaxDownloadSize != config.MaxDownloadSize {
 
-		logObject.CloneAndAddField("datastore-id", config.DatastoreID).
+		logObject.CloneAndAddField("datastore-ids", uuids).
 			AddField("relative-URL", config.RelativeURL).
 			AddField("format", config.Format).
 			AddField("content-sha256", config.ContentSha256).
 			AddField("max-download-size-int64", config.MaxDownloadSize).
-			AddField("old-datastore-id", oldConfig.DatastoreID).
+			AddField("old-datastore-ids", oldUuids).
 			AddField("old-relative-URL", oldConfig.RelativeURL).
 			AddField("old-format", oldConfig.Format).
 			AddField("old-content-sha256", oldConfig.ContentSha256).
@@ -85,7 +90,8 @@ func (config ContentTreeConfig) LogModify(logBase *base.LogObject, old interface
 func (config ContentTreeConfig) LogDelete(logBase *base.LogObject) {
 	logObject := base.EnsureLogObject(logBase, base.ContentTreeConfigLogType, config.DisplayName,
 		config.ContentID, config.LogKey())
-	logObject.CloneAndAddField("datastore-id", config.DatastoreID).
+	uuids := strings.Join(UuidsToStrings(config.DatastoreIDList), ",")
+	logObject.CloneAndAddField("datastore-ids", uuids).
 		AddField("relative-URL", config.RelativeURL).
 		AddField("format", config.Format).
 		AddField("content-sha256", config.ContentSha256).
@@ -138,7 +144,8 @@ func (status ContentTreeStatus) Key() string {
 
 // ResolveKey will return the key of resolver config/status
 func (status ContentTreeStatus) ResolveKey() string {
-	return fmt.Sprintf("%s+%s+%v", status.DatastoreID.String(),
+	uuids := strings.Join(UuidsToStrings(status.DatastoreIDList), ",")
+	return fmt.Sprintf("%s+%s+%v", uuids,
 		status.RelativeURL, status.GenerationCounter)
 }
 

--- a/pkg/pillar/types/contenttreetypes.go
+++ b/pkg/pillar/types/contenttreetypes.go
@@ -18,6 +18,7 @@ import (
 type ContentTreeConfig struct {
 	ContentID         uuid.UUID
 	DatastoreID       uuid.UUID
+	DatastoreIDList   []uuid.UUID
 	RelativeURL       string
 	Format            zconfig.Format // this is the format of the content tree itself, not necessarily of the datastore
 	ContentSha256     string
@@ -103,6 +104,7 @@ func (config ContentTreeConfig) LogKey() string {
 type ContentTreeStatus struct {
 	ContentID         uuid.UUID
 	DatastoreID       uuid.UUID
+	DatastoreIDList   []uuid.UUID
 	DatastoreType     string
 	RelativeURL       string
 	Format            zconfig.Format
@@ -160,9 +162,11 @@ func (status ContentTreeStatus) ReferenceID() string {
 }
 
 // UpdateFromContentTreeConfig sets up ContentTreeStatus based on ContentTreeConfig struct
+// Be aware: don't expect all fields are updated from the config
 func (status *ContentTreeStatus) UpdateFromContentTreeConfig(config ContentTreeConfig) {
 	status.ContentID = config.ContentID
 	status.DatastoreID = config.DatastoreID
+	status.DatastoreIDList = config.DatastoreIDList
 	status.RelativeURL = config.RelativeURL
 	status.Format = config.Format
 	status.ContentSha256 = config.ContentSha256

--- a/pkg/pillar/types/contenttreetypes.go
+++ b/pkg/pillar/types/contenttreetypes.go
@@ -18,7 +18,6 @@ import (
 // which might need to be downloaded and verified
 type ContentTreeConfig struct {
 	ContentID         uuid.UUID
-	DatastoreID       uuid.UUID
 	DatastoreIDList   []uuid.UUID
 	RelativeURL       string
 	Format            zconfig.Format // this is the format of the content tree itself, not necessarily of the datastore
@@ -109,7 +108,6 @@ func (config ContentTreeConfig) LogKey() string {
 // ContentTreeStatus is response from volumemgr about status of content tree
 type ContentTreeStatus struct {
 	ContentID             uuid.UUID
-	DatastoreID           uuid.UUID
 	DatastoreIDList       []uuid.UUID
 	DatastoreTypesList    []string
 	AllDatastoresResolved bool
@@ -166,7 +164,6 @@ func (status ContentTreeStatus) ReferenceID() string {
 // Be aware: don't expect all fields are updated from the config
 func (status *ContentTreeStatus) UpdateFromContentTreeConfig(config ContentTreeConfig) {
 	status.ContentID = config.ContentID
-	status.DatastoreID = config.DatastoreID
 	status.DatastoreIDList = config.DatastoreIDList
 	status.RelativeURL = config.RelativeURL
 	status.Format = config.Format

--- a/pkg/pillar/types/contenttreetypes.go
+++ b/pkg/pillar/types/contenttreetypes.go
@@ -102,18 +102,20 @@ func (config ContentTreeConfig) LogKey() string {
 
 // ContentTreeStatus is response from volumemgr about status of content tree
 type ContentTreeStatus struct {
-	ContentID         uuid.UUID
-	DatastoreID       uuid.UUID
-	DatastoreIDList   []uuid.UUID
-	DatastoreType     string
-	RelativeURL       string
-	Format            zconfig.Format
-	ContentSha256     string
-	MaxDownloadSize   uint64
-	GenerationCounter int64
-	DisplayName       string
-	HasResolverRef    bool
-	State             SwState
+	ContentID             uuid.UUID
+	DatastoreID           uuid.UUID
+	DatastoreIDList       []uuid.UUID
+	DatastoreTypesList    []string
+	AllDatastoresResolved bool
+	IsOCIRegistry         bool
+	RelativeURL           string
+	Format                zconfig.Format
+	ContentSha256         string
+	MaxDownloadSize       uint64
+	GenerationCounter     int64
+	DisplayName           string
+	HasResolverRef        bool
+	State                 SwState
 	// XXX RefCount not needed?
 	// RefCount                uint
 	// LastRefCountChangeTime  time.Time
@@ -143,14 +145,6 @@ func (status ContentTreeStatus) ResolveKey() string {
 // IsContainer will return true if content tree is of container type
 func (status ContentTreeStatus) IsContainer() bool {
 	if status.Format == zconfig.Format_CONTAINER {
-		return true
-	}
-	return false
-}
-
-// IsOCIRegistry will return true if datastore is an OCI registry
-func (status ContentTreeStatus) IsOCIRegistry() bool {
-	if status.DatastoreType == zconfig.DsType_DsContainerRegistry.String() {
 		return true
 	}
 	return false

--- a/pkg/pillar/types/downloadertypes.go
+++ b/pkg/pillar/types/downloadertypes.go
@@ -5,6 +5,7 @@ package types
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -36,8 +37,9 @@ func (config DownloaderConfig) LogCreate(logBase *base.LogObject) {
 	if logObject == nil {
 		return
 	}
+	uuids := strings.Join(UuidsToStrings(config.DatastoreIDList), ",")
 	logObject.CloneAndAddField("target", config.Target).
-		AddField("datastore-id", config.DatastoreID).
+		AddField("datastore-ids", uuids).
 		AddField("refcount-int64", config.RefCount).
 		AddField("size-int64", config.Size).
 		Noticef("Download config create")
@@ -52,17 +54,20 @@ func (config DownloaderConfig) LogModify(logBase *base.LogObject, old interface{
 	if !ok {
 		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of DownloaderConfig type")
 	}
+	uuids := strings.Join(UuidsToStrings(config.DatastoreIDList), ",")
+	oldUuids := strings.Join(UuidsToStrings(oldConfig.DatastoreIDList), ",")
+
 	if oldConfig.Target != config.Target ||
-		oldConfig.DatastoreID != config.DatastoreID ||
+		oldUuids != uuids ||
 		oldConfig.RefCount != config.RefCount ||
 		oldConfig.Size != config.Size {
 
 		logObject.CloneAndAddField("target", config.Target).
-			AddField("datastore-id", config.DatastoreID).
+			AddField("datastore-ids", uuids).
 			AddField("refcount-int64", config.RefCount).
 			AddField("size-int64", config.Size).
 			AddField("old-target", oldConfig.Target).
-			AddField("old-datastore-id", oldConfig.DatastoreID).
+			AddField("old-datastore-ids", oldUuids).
 			AddField("old-refcount-int64", oldConfig.RefCount).
 			AddField("old-size-int64", oldConfig.Size).
 			Noticef("Download config modify")
@@ -77,8 +82,9 @@ func (config DownloaderConfig) LogModify(logBase *base.LogObject, old interface{
 func (config DownloaderConfig) LogDelete(logBase *base.LogObject) {
 	logObject := base.EnsureLogObject(logBase, base.DownloaderConfigLogType, config.Name,
 		nilUUID, config.LogKey())
+	uuids := strings.Join(UuidsToStrings(config.DatastoreIDList), ",")
 	logObject.CloneAndAddField("target", config.Target).
-		AddField("datastore-id", config.DatastoreID).
+		AddField("datastore-ids", uuids).
 		AddField("refcount-int64", config.RefCount).
 		AddField("size-int64", config.Size).
 		Noticef("Download config delete")

--- a/pkg/pillar/types/downloadertypes.go
+++ b/pkg/pillar/types/downloadertypes.go
@@ -14,14 +14,15 @@ import (
 
 // The key/index to this is the ImageSha256 which is allocated by the controller or resolver.
 type DownloaderConfig struct {
-	ImageSha256 string
-	DatastoreID uuid.UUID
-	Name        string
-	Target      string // file path where to download the file
-	NameIsURL   bool   // If not we form URL based on datastore info
-	Size        uint64 // In bytes
-	FinalObjDir string // final Object Store
-	RefCount    uint
+	ImageSha256     string
+	DatastoreID     uuid.UUID
+	DatastoreIDList []uuid.UUID
+	Name            string
+	Target          string // file path where to download the file
+	NameIsURL       bool   // If not we form URL based on datastore info
+	Size            uint64 // In bytes
+	FinalObjDir     string // final Object Store
+	RefCount        uint
 }
 
 func (config DownloaderConfig) Key() string {
@@ -92,25 +93,26 @@ func (config DownloaderConfig) LogKey() string {
 
 // The key/index to this is the ImageSha256 which comes from DownloaderConfig.
 type DownloaderStatus struct {
-	ImageSha256   string
-	DatastoreID   uuid.UUID
-	Target        string // file path where we download the file
-	Name          string
-	PendingAdd    bool
-	PendingModify bool
-	PendingDelete bool
-	RefCount      uint      // Zero means not downloaded
-	LastUse       time.Time // When RefCount dropped to zero
-	Expired       bool      // Handshake to client
-	NameIsURL     bool      // If not we form URL based on datastore info
-	State         SwState   // DOWNLOADED etc
-	ReservedSpace uint64    // Contribution to global ReservedSpace
-	Size          uint64    // Once DOWNLOADED; in bytes
-	TotalSize     int64     // expected size as reported by the downloader, if any
-	CurrentSize   int64     // current total downloaded size as reported by the downloader
-	Progress      uint      // In percent i.e., 0-100, given by CurrentSize/ExpectedSize
-	ModTime       time.Time
-	ContentType   string // content-type header, if provided
+	ImageSha256     string
+	DatastoreID     uuid.UUID
+	DatastoreIDList []uuid.UUID
+	Target          string // file path where we download the file
+	Name            string
+	PendingAdd      bool
+	PendingModify   bool
+	PendingDelete   bool
+	RefCount        uint      // Zero means not downloaded
+	LastUse         time.Time // When RefCount dropped to zero
+	Expired         bool      // Handshake to client
+	NameIsURL       bool      // If not we form URL based on datastore info
+	State           SwState   // DOWNLOADED etc
+	ReservedSpace   uint64    // Contribution to global ReservedSpace
+	Size            uint64    // Once DOWNLOADED; in bytes
+	TotalSize       int64     // expected size as reported by the downloader, if any
+	CurrentSize     int64     // current total downloaded size as reported by the downloader
+	Progress        uint      // In percent i.e., 0-100, given by CurrentSize/ExpectedSize
+	ModTime         time.Time
+	ContentType     string // content-type header, if provided
 	// ErrorAndTime provides SetErrorNow() and ClearError()
 	ErrorAndTime
 	RetryCount int

--- a/pkg/pillar/types/downloadertypes.go
+++ b/pkg/pillar/types/downloadertypes.go
@@ -16,7 +16,6 @@ import (
 // The key/index to this is the ImageSha256 which is allocated by the controller or resolver.
 type DownloaderConfig struct {
 	ImageSha256     string
-	DatastoreID     uuid.UUID
 	DatastoreIDList []uuid.UUID
 	Name            string
 	Target          string // file path where to download the file
@@ -100,7 +99,6 @@ func (config DownloaderConfig) LogKey() string {
 // The key/index to this is the ImageSha256 which comes from DownloaderConfig.
 type DownloaderStatus struct {
 	ImageSha256     string
-	DatastoreID     uuid.UUID
 	DatastoreIDList []uuid.UUID
 	Target          string // file path where we download the file
 	Name            string

--- a/pkg/pillar/types/types.go
+++ b/pkg/pillar/types/types.go
@@ -454,3 +454,13 @@ func (info AppInterfaceToNum) LogDelete(logBase *base.LogObject) {
 func (info AppInterfaceToNum) LogKey() string {
 	return string(base.AppInterfaceToNumLogType) + "-" + info.Key()
 }
+
+// UuidsToStrings converts list of uuids to a list of strings
+func UuidsToStrings(uuids []uuid.UUID) []string {
+	list := make([]string, len(uuids))
+	for i, uuid := range uuids {
+		list[i] = uuid.String()
+	}
+
+	return list
+}


### PR DESCRIPTION
This is an attempt to introduce a new field for the ContentTree message: ds_ids_list. This field will be used by the controller to list datastores, which can be used for fallback download if download from the main datastore has been failed. 

A new field 'DatastoreIDList' is added to the following run-time structures:
    
       ContentTreeConfig
       ContentTreeStatus
       DownloaderConfig
       DownloaderStatus
       BlobStatus

so that eventually list of fallback datastores reaches the 'downloader', which tries to download from each datastore if an attempt to download from the main one has been failed. 

It is worth to mention, that OCI registries in fallback datastores are not supported. The whole logic with async sha resolving gets complicated and for now it is left untouched.
