### PR TITLE
edgeview support tar of a directory

### DIFF
--- a/pkg/edgeview/build.yml
+++ b/pkg/edgeview/build.yml
@@ -7,6 +7,7 @@ config:
     - /run:/run:ro
     - /run/edgeview:/run/edgeview
     - /persist:/persist:ro
+    - /persist/tmp:/persist/tmp
     - /config:/config:ro
     - /etc/resolv.conf:/etc/resolv.conf:ro
     - /proc:/host/proc:ro

--- a/pkg/edgeview/src/basics.go
+++ b/pkg/edgeview/src/basics.go
@@ -129,6 +129,7 @@ func initOpts() {
 		"ps",
 		"cipher",
 		"usb",
+		"tar",
 		"techsupport",
 		"top",
 		"volume",
@@ -694,6 +695,9 @@ func printHelp(opt string) {
 			helpOn("cipher", "display cipher information on datastore, device and controller certificates, etc.")
 		case "usb":
 			helpOn("usb", "display the lsusb information on device")
+		case "tar":
+			helpOn("tar/<path to directory>", "to generate a tarfile of the directory")
+			helpExample("tar//persist/agentdebug", "download the tarfile persist.agentdebug.<time>.tar of that directory", true)
 		case "techsupport":
 			helpOn("techsupport", "show tech-support, run various edgeview commands with output downloaded in a compressed file")
 		case "volume":


### PR DESCRIPTION
Signed-off-by: Naiming Shen <naiming@zededa.com>
- support tar a directory on EVE device through EdgeView
  it generates a tar file on the user's laptop
- remove unused '-ws' option
- use copy type enum to handle different types of copy files
- add blocked directory and file suffix list, for cp, cat and tar operations
- add /persist/tmp to volume 'rw' for temp tar location