### PR TITLE
Add storage.zfs.reserved.percent to adjust reservation

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -33,6 +33,7 @@
 | debug.default.loglevel | string | info | min level saved in files on device |
 | debug.default.remote.loglevel | string | warning | min level sent to controller |
 | storage.dom0.disk.minusage.percent | integer percent | 20 | min. percent of persist partition reserved for dom0 |
+| storage.zfs.reserved.percent | integer percent | 20 | min. percent of persist partition reserved for zfs performance |
 | storage.apps.ignore.disk.check | boolean | false | Ignore disk usage check for Apps. Allows apps to create images bigger than available disk|
 | timer.appcontainer.stats.interval | integer in seconds | 300 | collect application container stats |
 | timer.vault.ready.cutoff | integer in seconds | 300 | reboot after inaccessible vault |

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -163,6 +163,8 @@ const (
 	// Dom0DiskUsageMaxBytes - Max disk usage for Dom0. Dom0 can use
 	//  Dom0MinDiskUsagePercent up to a max of  Dom0DiskUsageMaxBytes
 	Dom0DiskUsageMaxBytes GlobalSettingKey = "storage.dom0.disk.maxusagebytes"
+	// StorageZfsReserved is the percentage reserved in a ZFS pool
+	StorageZfsReserved GlobalSettingKey = "storage.zfs.reserved.percent"
 	// AppContainerStatsInterval - App Container Stats Collection
 	AppContainerStatsInterval GlobalSettingKey = "timer.appcontainer.stats.interval"
 	// VaultReadyCutOffTime global setting key
@@ -767,7 +769,9 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	// Dom0DiskUsageMaxBytes - Default is 2GB, min is 100MB
 	configItemSpecMap.AddIntItem(Dom0DiskUsageMaxBytes, 2*1024*1024*1024,
 		100*1024*1024, 0xFFFFFFFF)
+	configItemSpecMap.AddIntItem(StorageZfsReserved, 20, 1, 99)
 	configItemSpecMap.AddIntItem(ForceFallbackCounter, 0, 0, 0xFFFFFFFF)
+
 	configItemSpecMap.AddIntItem(EveMemoryLimitInBytes, uint32(eveMemoryLimitInBytes),
 		uint32(eveMemoryLimitInBytes), 0xFFFFFFFF)
 	// Limit manual vmm overhead override to 1 PiB

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -171,6 +171,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		AppContainerStatsInterval,
 		VaultReadyCutOffTime,
 		Dom0DiskUsageMaxBytes,
+		StorageZfsReserved,
 		ForceFallbackCounter,
 		LogRemainToSendMBytes,
 		DownloadMaxPortCost,


### PR DESCRIPTION
By default 20% of the ZFS pool is reserved for optimal ZFS performance. Here we add a ConfigItem to be able to set that percentage (between 1 and 99%).
