### PR TITLE
wwan: give CLI commands that got stuck a chance to exit cleanly

### DIFF
--- a/pkg/wwan/usr/bin/wwan-mbim.sh
+++ b/pkg/wwan/usr/bin/wwan-mbim.sh
@@ -4,7 +4,7 @@
 # shellcheck disable=SC2034
 
 mbim() {
-  timeout -s KILL "$LTESTAT_TIMEOUT" mbimcli -p -d "/dev/$CDC_DEV" "$@"
+  timeout -s INT -k 5 "$LTESTAT_TIMEOUT" mbimcli -p -d "/dev/$CDC_DEV" "$@"
 }
 
 mbim_get_packet_stats() {

--- a/pkg/wwan/usr/bin/wwan-qmi.sh
+++ b/pkg/wwan/usr/bin/wwan-qmi.sh
@@ -4,7 +4,7 @@
 # shellcheck disable=SC2034
 
 qmi() {
-  timeout -s KILL "$LTESTAT_TIMEOUT" qmicli -p -d "/dev/$CDC_DEV" "$@"
+  timeout -s INT -k 5 "$LTESTAT_TIMEOUT" qmicli -p -d "/dev/$CDC_DEV" "$@"
 }
 
 qmi_get_packet_stats() {


### PR DESCRIPTION
Behind the scenes, every QMI CLI command starts by allocating Client ID (CID), then uses it for the duration of the request and releases it just before returning.

However, we wrap qmicli calls with "timeout" to make sure that if a command gets (seemingly) stuck (which happens quite often), it will not hang indefinitely. But if a command timeouts and gets killed abruptly with SIGKILL, it does not get the opportunity to release the allocated client ID and CID will leak.

The number of available client IDs is quite limited - some services, like NAS, may provide only 10. After we allocate (and leak) all of them, we are no longer able to use the service (getting 'ClientIdsExhausted' error) and a modem reboot is required to fix the issue.

Even when command is seemingly stuck, it will still actually react to SIGINT and exit with all resources freed (I'm yet to experience a case where SIGKILL was necessary). This commit therefore changes args for the "timeout" command to send the SIGINT signal instead. If the underlying command remains hanging still, SIGKILL will be sent 5 seconds later, avoiding an indefinite hang at the cost of one CID leaked.

I'm applying the same patch for mbimcli as well, which also nicely reacts to SIGINT and frees resources before exiting.

Originally, I intended to solve the issue in a more robust way by manually allocating and releasing CIDs from the EVE/wwan microservice (https://github.com/lf-edge/eve/pull/2992), but the QMI commands provided for CID management turned out to be not as reliable as advertised. This PR, on the other hand, is much simpler but probably good enough to avoid CID exhaustion.

Signed-off-by: Milan Lenco <milan@zededa.com>