### PR TITLE
Use TPMEvent function instead of TPMExtend in measure-config 

### DIFF
--- a/pkg/pillar/evetpm/tpm.go
+++ b/pkg/pillar/evetpm/tpm.go
@@ -94,7 +94,7 @@ var (
 	pcrBank256Status = PCRBank256StatusUnknown
 
 	//DiskKeySealingPCRs represents PCRs that we use for sealing
-	DiskKeySealingPCRs = tpm2.PCRSelection{Hash: tpm2.AlgSHA1, PCRs: []int{0, 1, 2, 3, 4, 6, 7, 8, 9, 13}}
+	DiskKeySealingPCRs = tpm2.PCRSelection{Hash: tpm2.AlgSHA256, PCRs: []int{0, 1, 2, 3, 4, 6, 7, 8, 9, 13, 14}}
 )
 
 // SealedKeyType holds different types of sealed key


### PR DESCRIPTION
TPMExtend extends only a PCR in a specified bank (e.g. SHA256). We need to extend PCRs in all available banks