### PR TITLE
Do not double copy bsp-imx

### DIFF
--- a/pkg/eve/Dockerfile.in
+++ b/pkg/eve/Dockerfile.in
@@ -3,8 +3,6 @@ ENV PKGS qemu-img tar u-boot-tools coreutils dosfstools
 RUN eve-alpine-deploy.sh
 
 # hadolint ignore=DL3006
-FROM BSP_IMX_TAG as bsp-imx
-# hadolint ignore=DL3006
 FROM MKISO_TAG as iso
 # hadolint ignore=DL3006
 FROM IPXE_TAG as ipxe
@@ -19,7 +17,6 @@ COPY --from=iso / /
 COPY --from=raw / /
 COPY --from=ipxe / /
 COPY --from=tools /out/ /
-COPY --from=bsp-imx / /
 COPY installer /bits
 COPY runme.sh /
 RUN mkdir /in /out


### PR DESCRIPTION
We copy `bsp-imx` twice, from installer directory populated in Makefile into `/bits/bsp-imx` and directly from Dockerfile into `/bsp-imx`. We do not use the second copy (only the first one [here](https://github.com/lf-edge/eve/blob/fae04b0396c26b3378832900dcfbd82528e850e1/pkg/eve/runme.sh#L194-L196)) and hit [problems](https://github.com/lf-edge/eve/actions/runs/4013250503/jobs/6894195675#step:15:181) with `installer_net` target as it try to make symlinks.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>