### PR TITLE
wwan: Be more lenient about the SIM card ready status.

### DIFF
--- a/pkg/wwan/usr/bin/wwan-qmi.sh
+++ b/pkg/wwan/usr/bin/wwan-qmi.sh
@@ -241,7 +241,7 @@ qmi_start_network() {
 
 qmi_get_sim_status() {
   # FIXME: limited to a single SIM card
-  parse_modem_attr "$(qmi --uim-get-card-status)" "Application state" | head -n 1
+  parse_modem_attr "$(qmi --uim-get-card-status | grep ready)" "Application state" | head -n 1
 }
 
 qmi_wait_for_sim() {


### PR DESCRIPTION
Currently, `parse_modem_attr` looks at only the first instance of "Application state", however, there can be multiple application states for a single slot. If the first one, doesn't show ready, but subsequent ones show ready, the sim card is still ready. Also `parse_modem_attr` already calls head -n1, so remove the redundant call at the call site.

With this change, my LTE modem successfully connects to Verizon's network and I can use it reliably. Without this change, I get "Timed out waiting for SIM card"

Ex of the situation:
```
e81b83d2-bc7b-41da-9a77-b2e8368703db:/# qmicli -p -d /dev/cdc-wdm0 --uim-get-card-status
[/dev/cdc-wdm0] Successfully got card status
Provisioning applications:
	Primary GW:   slot '1', application '3'
	Primary 1X:   session doesn't exist
	Secondary GW: session doesn't exist
	Secondary 1X: session doesn't exist
Slot [1]:
	Card state: 'present'
	UPIN state: 'not-initialized'
		UPIN retries: '0'
		UPUK retries: '0'
	Application [1]:
		Application type:  'csim (4)'
		Application state: 'detected'
		Application ID:
			A0:00:00:03:43:10:02:F3:10:FF:FF:89:02:00:00:FF
		Personalization state: 'unknown'
		UPIN replaces PIN1: 'no'
		PIN1 state: 'not-initialized'
			PIN1 retries: '0'
			PUK1 retries: '0'
		PIN2 state: 'not-initialized'
			PIN2 retries: '0'
			PUK2 retries: '0'
	Application [2]:
		Application type:  'isim (5)'
		Application state: 'detected'
		Application ID:
			A0:00:00:00:87:10:04:F3:10:FF:FF:89:08:00:00:FF
		Personalization state: 'unknown'
		UPIN replaces PIN1: 'no'
		PIN1 state: 'not-initialized'
			PIN1 retries: '0'
			PUK1 retries: '0'
		PIN2 state: 'not-initialized'
			PIN2 retries: '0'
			PUK2 retries: '0'
	Application [3]:
		Application type:  'usim (2)'
		Application state: 'ready'
		Application ID:
			A0:00:00:00:87:10:02:F3:10:FF:FF:89:08:00:00:FF
		Personalization state: 'ready'
		UPIN replaces PIN1: 'no'
		PIN1 state: 'disabled'
			PIN1 retries: '3'
			PUK1 retries: '10'
		PIN2 state: 'enabled-not-verified'
			PIN2 retries: '3'
			PUK2 retries: '10'
	Application [4]:
		Application type:  'unknown (0)'
		Application state: 'detected'
		Application ID:
			A0:00:00:00:63:50:4B:43:53:2D:31:35
		Personalization state: 'unknown'
		UPIN replaces PIN1: 'no'
		PIN1 state: 'not-initialized'
			PIN1 retries: '0'
			PUK1 retries: '0'
		PIN2 state: 'not-initialized'
			PIN2 retries: '0'
			PUK2 retries: '0'
Slot [2]:
	Card state: 'absent'
	UPIN state: 'not-initialized'
		UPIN retries: '0'
		UPUK retries: '0'
```