### PR TITLE
explicitly restore cache and fail on miss for actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,15 +86,11 @@ jobs:
           fetch-depth: 0
       - name: update linuxkit cache for runner arch so we can get desired images
         id: cache_for_docker
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
           path: ~/.linuxkit/cache
           key: linuxkit-amd64-${{ github.sha }}
-      - name: Fail if cache miss
-        uses: actions/github-script@v6
-        if: steps.cache_for_docker.outputs.cache-hit != 'true'
-        with:
-          script: core.setFailed('Cache hit failed for loading packages. Please rerun all jobs, including "packages", not just "eve".')
+          fail-on-cache-miss: true
       - name: load images we need from linuxkit cache into docker
         run: |
           make cache-export-docker-load-all
@@ -105,15 +101,11 @@ jobs:
       - name: update linuxkit cache for our arch
         id: cache_for_packages
         if: ${{ matrix.arch != 'amd64' }}  # because our runner arch is amd64; if that changes, this will have to change
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
           path: ~/.linuxkit/cache
           key: linuxkit-${{ matrix.arch }}-${{ github.sha }}
-      - name: Fail if cache miss
-        uses: actions/github-script@v6
-        if: ${{ matrix.arch != 'amd64' && steps.cache_for_packages.outputs.cache-hit != 'true' }}  # because our runner arch is amd64; if that changes, this will have to change
-        with:
-          script: core.setFailed('Cache hit failed for loading packages. Please rerun all jobs, including "packages", not just "eve".')
+          fail-on-cache-miss: true
       - name: set environment
         env:
           PR_ID: ${{ github.event.pull_request.number  }}


### PR DESCRIPTION
This affects only GitHub actions, and only during the build phase.

We use the GitHub `actions/cache` to save packages in the linuxkit cache when building, and then restore them at later stage. We depend on that cache hit to restore the packages, and constructed a convoluted next step to force a failure of the job if we get a cache miss.

As of GitHub `actions/cache` v3.2.4 (just released), there is an option to fail on cache miss. 

This PR does two things:

1. Replace our extra step of "check for cache miss in previous step and force job failure if missed" with the single option to `actions/cache`
2. Replace `actions/cache@v3` with `actions/cache/restore@v3`, which ensures we only restore from the cache, do not try to save it again afterwards. The cache only should be affected by the first build job.