### PR TITLE
Fix the order of dhcpcd arguments for static DNS config

### DIFF
--- a/pkg/pillar/dpcreconciler/genericitems/dhcpcd.go
+++ b/pkg/pillar/dpcreconciler/genericitems/dhcpcd.go
@@ -298,6 +298,10 @@ func (c *DhcpcdConfigurator) dhcpcdArgs(config types.DhcpConfig) (op string, arg
 		for _, dns := range config.DnsServers {
 			dnsServers = append(dnsServers, dns.String())
 		}
+		if config.DomainName != "" {
+			args = append(args, "--static",
+				fmt.Sprintf("domain_name=%s", config.DomainName))
+		}
 		if len(dnsServers) > 0 {
 			// dhcpcd uses a very odd space-separation for multiple DNS servers.
 			// For manual invocation one must be very careful to not forget
@@ -308,10 +312,6 @@ func (c *DhcpcdConfigurator) dhcpcdArgs(config types.DhcpConfig) (op string, arg
 			args = append(args, "--static",
 				fmt.Sprintf("domain_name_servers=%s",
 					strings.Join(dnsServers, " ")))
-		}
-		if config.DomainName != "" {
-			args = append(args, "--static",
-				fmt.Sprintf("domain_name=%s", config.DomainName))
 		}
 		if config.NtpServer != nil && !config.NtpServer.IsUnspecified() {
 			args = append(args, "--static",


### PR DESCRIPTION
For some strange reason the order of dhcpcd arguments `domain_name_servers` and `domain_name` matters. In fact, domain name should be configured first, otherwise the list of DNS servers is not applied (or maybe gets reset?). I couldn't find the root cause for this odd behaviour in the dhcpcd source code or any explanation in the documentation. I decided to at least report the issue: https://github.com/NetworkConfiguration/dhcpcd/issues/184

Signed-off-by: Milan Lenco <milan@zededa.com>