### PR TITLE
Collect runtime stats from pillar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -805,9 +805,12 @@ endif
 
 
 # If DEV=y and file pkg/my_package/build-dev.yml returns the path to that file.
+# If RSTATS=y and file pkg/my_package/build-rstats.yml returns the path to that file.
 # Ortherwise returns pkg/my_package/build.yml.
-get_pkg_build_yml = $(if $(filter y,$(DEV)),$(call get_pkg_build_dev_yml,$1),build.yml)
+get_pkg_build_yml = $(if $(filter y,$(RSTATS)), $(call get_pkg_build_rstats_yml,$1), $(call get_pkg_build_def_yml,$1))
+get_pkg_build_def_yml = $(if $(filter y,$(DEV)),$(call get_pkg_build_dev_yml,$1),build.yml)
 get_pkg_build_dev_yml = $(if $(wildcard pkg/$1/build-dev.yml),build-dev.yml,build.yml)
+get_pkg_build_rstats_yml = $(if $(wildcard pkg/$1/build-rstats.yml),build-rstats.yml,build.yml)
 
 eve-%: pkg/%/Dockerfile build-tools $(RESCAN_DEPS)
 	$(QUIET): "$@: Begin: LINUXKIT_PKG_TARGET=$(LINUXKIT_PKG_TARGET)"

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -489,6 +489,23 @@ All of these packages are published regularly to the dockerhub registry, so it i
 
 **Note:** The net effect of this is that if you try to build `rootfs.img` or `installer.img` and reference a package that is _not_ published on the docker hub or available as a local image, it will _not_ try to build it locally for you; this functionality is not available in linuxkit. Instead, it will simply fail. You _must_ build the package and at least have it available in your local cache for the `rootfs.img` or `installer.img` build to succeed.
 
+#### Building packages with runtime stats
+
+Packages (currently Pillar) support collecting runtime memory and cpu statistics offered by Golang runtime. Collected statistics collected are sent over UDP to a [statsd](https://github.com/statsd/statsd) daemon running outside of EVE. To enable this, change the `RSTATS_ENDPOINT` (statsd endpoint) and `RSTATS_TAG` (the custom string used for tagging collected stats) inside `pkg/pillar/build-rstats.yml` to a proper value, then build:
+
+```shell
+make pkg/pillar RSTATS=y
+```
+
+To see the result, before running the image run statsd and graphite, for example:
+
+```shell
+docker pull graphiteapp/graphite-statsd
+docker run -p 8080:80 -p 8125:8125/udp --rm --name statsd graphiteapp/graphite-statsd
+```
+
+While the EVE is running, navigate to `http://IP:8080/dashboard` and find the result under `stats.gauges`.
+
 ## Summary of Build Process
 
 This section provides an overview of the processes used to create the

--- a/pkg/pillar/Dockerfile
+++ b/pkg/pillar/Dockerfile
@@ -66,6 +66,11 @@ FROM target-${TARGETARCH}-build-${BUILDARCH} AS build
 ARG DEV=n
 ARG TARGETARCH
 
+# building with runtime stats
+ARG RSTATS=n
+ARG RSTATS_ENDPOINT=
+ARG RSTATS_TAG=
+
 # we need zfs files during build
 COPY --from=zfs /out /
 
@@ -91,7 +96,7 @@ RUN set -e && for patch in ../patches/*.patch; do \
 RUN --mount=type=cache,target=/root/.cache/go-build echo "Running go vet" && go vet ./... && \
     echo "Running go fmt" && ERR="$(find . -name \*.go | grep -v /vendor/ | xargs gofmt -d -e -l -s)" && \
        if [ -n "$ERR" ] ; then printf 'go fmt Failed - ERR: %s' "$ERR" ; exit 1 ; fi && \
-       make DEV="$DEV" DISTDIR=/final/opt/zededa/bin build
+       make DEV="$DEV" RSTATS=$RSTATS RSTATS_ENDPOINT=$RSTATS_ENDPOINT RSTATS_TAG=$RSTATS_TAG DISTDIR=/final/opt/zededa/bin build
 
 WORKDIR /
 

--- a/pkg/pillar/Makefile
+++ b/pkg/pillar/Makefile
@@ -32,10 +32,18 @@ $(DISTDIR):
 
 build: $(APPS) $(APPS1)
 
+TAGS=
+ifeq ($(RSTATS),y)
+	TAGS:=-tags rstats
+endif
 
 LDFLAGS=-X=main.Version=$(BUILD_VERSION)
 ifneq ($(DEV),y)
 	LDFLAGS+=-s -w
+endif
+ifeq ($(RSTATS),y)
+	LDFLAGS+=-X=github.com/lf-edge/eve/pkg/pillar/rstats.Endpoint=$(RSTATS_ENDPOINT)
+	LDFLAGS+=-X=github.com/lf-edge/eve/pkg/pillar/rstats.Tag=$(RSTATS_TAG)
 endif
 LDFLAGS:=-ldflags "$(LDFLAGS)"
 
@@ -47,7 +55,7 @@ endif
 $(APPS): $(DISTDIR)/$(APPS)
 $(DISTDIR)/$(APPS): $(DISTDIR)
 	@echo "Building $@"
-	GO111MODULE=on GOOS=linux go build -mod=vendor $(GCFLAGS) $(LDFLAGS) -o $@ ./$(@F)
+	GO111MODULE=on GOOS=linux go build -mod=vendor $(TAGS) $(GCFLAGS) $(LDFLAGS) -o $@ ./$(@F)
 
 $(APPS1): $(DISTDIR)
 	@echo $@

--- a/pkg/pillar/build-rstats.yml
+++ b/pkg/pillar/build-rstats.yml
@@ -1,0 +1,27 @@
+# linuxkit build template
+#
+# Copyright (c) 2018 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+org: lfedge
+image: eve-pillar
+config:
+  binds:
+    - /lib/modules:/lib/modules
+    - /dev:/dev
+    - /etc/resolv.conf:/etc/resolv.conf
+    - /run:/run
+    - /config:/config
+    - /:/hostfs
+    - /persist:/persist:rshared,rbind
+    - /usr/bin/containerd:/usr/bin/containerd
+  capabilities:
+    - all
+  pid: host
+  rootfsPropagation: shared
+  devices:
+    - path: all
+      type: a
+buildArgs:
+  - RSTATS=y
+  - RSTATS_TAG=pillar
+  - RSTATS_ENDPOINT=localhost:8125

--- a/pkg/pillar/go.mod
+++ b/pkg/pillar/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/prometheus/procfs v0.7.3
 	github.com/satori/go.uuid v1.2.1-0.20180404165556-75cca531ea76
 	github.com/shirou/gopsutil v3.21.11+incompatible
+	github.com/shjala/gostats v0.0.0-20230215094906-69a32327600f
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1
 	github.com/tatsushid/go-fastping v0.0.0-20160109021039-d7bb493dee3e

--- a/pkg/pillar/go.sum
+++ b/pkg/pillar/go.sum
@@ -1493,6 +1493,10 @@ github.com/shirou/gopsutil v0.0.0-20190901111213-e4ec7b275ada/go.mod h1:WWnYX4lz
 github.com/shirou/gopsutil v3.21.11+incompatible h1:+1+c1VGhc88SSonWP6foOcLhvnKlUeu/erjjvaPEYiI=
 github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
+github.com/shjala/gostats v0.0.0-20230208150848-bc4811238713 h1:b7M6nocrTUmfLY+Q81aPQaohVyE6ZzGzL0qDK34liYA=
+github.com/shjala/gostats v0.0.0-20230208150848-bc4811238713/go.mod h1:q+gDX7TvIEKrYhu+O5JscT71IIlSi8cxMl5hfxp538I=
+github.com/shjala/gostats v0.0.0-20230215094906-69a32327600f h1:LO/+1189h3P6S3ZPoDhaUpBPvnaYGbic+6M7+bNxu0A=
+github.com/shjala/gostats v0.0.0-20230215094906-69a32327600f/go.mod h1:q+gDX7TvIEKrYhu+O5JscT71IIlSi8cxMl5hfxp538I=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=

--- a/pkg/pillar/rstats/rstats_n.go
+++ b/pkg/pillar/rstats/rstats_n.go
@@ -1,0 +1,10 @@
+//go:build !rstats
+// +build !rstats
+
+package rstats
+
+// Endpoint is statsd endpoint address, gets replaced at build time.
+var Endpoint = "<ip>:<port>"
+
+// Tag is bucket tag, gets replaced at build time.
+var Tag = "<tag>"

--- a/pkg/pillar/rstats/rstats_y.go
+++ b/pkg/pillar/rstats/rstats_y.go
@@ -1,0 +1,25 @@
+//go:build rstats
+// +build rstats
+
+package rstats
+
+import (
+	"fmt"
+
+	"github.com/shjala/gostats"
+)
+
+// Endpoint is statsd endpoint address, gets replaced at build time.
+var Endpoint = "<ip>:<port>"
+
+// Tag is bucket tag, gets replaced at build time.
+var Tag = "<tag>"
+
+func init() {
+	// collect stats every 5 seconds
+	err := gostats.Collect(Endpoint, Tag, 5, true, true, true)
+	if err != nil {
+		fmt.Printf("Failed to start collecting runtime stats : %v\n", err)
+		return
+	}
+}

--- a/pkg/pillar/vendor/github.com/shjala/gostats/LICENSE
+++ b/pkg/pillar/vendor/github.com/shjala/gostats/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Brian Hatfield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pkg/pillar/vendor/github.com/shjala/gostats/README.md
+++ b/pkg/pillar/vendor/github.com/shjala/gostats/README.md
@@ -1,0 +1,43 @@
+## Intro
+`gostats` is a simple, self contained package that collects runtime statistics from `runtime.MemStats` and sends them over UDP to [statsd](https://github.com/statsd/statsd) as a set of gauges.
+
+### Usage
+
+You need graphite and statsd running in your preferred way, for example using Docker:
+
+```
+docker pull graphiteapp/graphite-statsd
+docker run -p 8080:80 -p 8125:8125/udp --rm --name statsd graphiteapp/graphite-statsd
+```
+
+Then simply, collect the data:
+
+```
+package main
+
+import (
+	"fmt"
+	"github.com/shjala/gostats"
+)
+
+func main() {
+  // Endpoint is statsd endpoint address
+  var Endpoint = "localhost:2125"
+
+  // Tag is bucket tag
+  var Tag = "your_tag"
+
+  // collect stats every 5 seconds
+  err := gostats.Collect(Endpoint, Tag, 5, true, true, true)
+  if err != nil {
+    fmt.Printf("Failed to start collecting runtime stats : %v\n", err)
+    return
+  }
+
+  // Rest of the code
+}
+```
+
+
+
+

--- a/pkg/pillar/vendor/github.com/shjala/gostats/gostats.go
+++ b/pkg/pillar/vendor/github.com/shjala/gostats/gostats.go
@@ -1,0 +1,165 @@
+package gostats
+
+import (
+	"fmt"
+	"net"
+	"runtime"
+	"time"
+)
+
+// Statsd host:port pair
+var Endpoint = "localhost:8125"
+
+// collector
+var c *collector = nil
+
+// Collector implements the periodic grabbing of informational data from the
+// runtime package and outputting it to statsd.
+type collector struct {
+	// PauseDur represents the interval between each set of stats output.
+	// Defaults to 5 seconds.
+	pauseDur time.Duration
+
+	// EnableCPU determines whether CPU statistics will be output. Defaults to true.
+	enableCPU bool
+
+	// EnableMem determines whether memory statistics will be output. Defaults to true.
+	enableMem bool
+
+	// EnableGC determines whether garbage collection statistics will be output. EnableMem
+	// must also be set to true for this to take affect. Defaults to true.
+	enableGC bool
+
+	// Bucket prefix
+	prefix string
+
+	// Connection handler
+	conn net.Conn
+}
+
+// New creates a new Collector that will periodically output statistics to send.
+func newCollector(prefix string, conn net.Conn) *collector {
+	return &collector{
+		pauseDur:  5 * time.Second,
+		enableCPU: true,
+		enableMem: true,
+		enableGC:  true,
+		prefix:    prefix,
+		conn:      conn,
+	}
+}
+
+// Run gathers statistics from package runtime and outputs them statsd,
+// this will never return.
+func (c *collector) run() {
+	c.outputStats()
+
+	// Gauges are a 'snapshot' rather than a histogram. Pausing for some interval
+	// aims to get a 'recent' snapshot out before statsd flushes metrics.
+	tick := time.NewTicker(c.pauseDur)
+	defer tick.Stop()
+	for {
+		select {
+		case <-tick.C:
+			c.outputStats()
+		}
+	}
+}
+
+type cpuStats struct {
+	NumGoroutine uint64
+	NumCgoCall   uint64
+}
+
+func (c *collector) outputStats() {
+	if c.enableCPU {
+		cStats := cpuStats{
+			NumGoroutine: uint64(runtime.NumGoroutine()),
+			NumCgoCall:   uint64(runtime.NumCgoCall()),
+		}
+		c.outputCPUStats(&cStats)
+	}
+	if c.enableMem {
+		m := &runtime.MemStats{}
+		runtime.ReadMemStats(m)
+		c.outputMemStats(m)
+		if c.enableGC {
+			c.outputGCStats(m)
+		}
+	}
+}
+
+func (c *collector) outputCPUStats(s *cpuStats) {
+	c.send("cpu.NumGoroutine", s.NumGoroutine)
+	c.send("cpu.NumCgoCall", s.NumCgoCall)
+}
+
+func (c *collector) outputMemStats(m *runtime.MemStats) {
+	// sys
+	c.send("mem.sys.Sys", m.Sys)
+	c.send("mem.sys.Lookups", m.Lookups)
+	c.send("mem.sys.OtherSys", m.OtherSys)
+
+	// common
+	c.send("mem.com.Total_VM_Bytes_Reserved", m.Sys)
+	c.send("mem.com.Live_Heap_Bytes_Allocated", m.Alloc)
+	c.send("mem.com.Cumulative_Heap_Bytes_Allocated", m.TotalAlloc)
+	c.send("mem.com.Total_Stack_Allocation", m.StackSys)
+	c.send("mem.com.Other_Bytes_Allocation", m.OtherSys)
+
+	// Heap
+	c.send("mem.heap.Alloc", m.Alloc)
+	c.send("mem.heap.TotalAlloc", m.TotalAlloc)
+	c.send("mem.heap.Mallocs", m.Mallocs)
+	c.send("mem.heap.Frees", m.Frees)
+	c.send("mem.heap.HeapAlloc", m.HeapAlloc)
+	c.send("mem.heap.HeapSys", m.HeapSys)
+	c.send("mem.heap.HeapIdle", m.HeapIdle)
+	c.send("mem.heap.HeapInuse", m.HeapInuse)
+	c.send("mem.heap.HeapReleased", m.HeapReleased)
+	c.send("mem.heap.HeapObjects", m.HeapObjects)
+
+	// Stack
+	c.send("mem.stack.StackSys", m.StackSys)
+	c.send("mem.stack.StackInuse", m.StackInuse)
+	c.send("mem.stack.MSpanInuse", m.MSpanInuse)
+	c.send("mem.stack.MSpanSys", m.MSpanSys)
+	c.send("mem.stack.MCacheInuse", m.MCacheInuse)
+	c.send("mem.stack.MCacheSys", m.MCacheSys)
+
+}
+
+func (c *collector) outputGCStats(m *runtime.MemStats) {
+	c.send("mem.gc.GCSys", m.GCSys)
+	c.send("mem.gc.NextGC", m.NextGC)
+	c.send("mem.gc.LastGC", m.LastGC)
+	c.send("mem.gc.PauseTotalNs", m.PauseTotalNs)
+	c.send("mem.gc.Pause", m.PauseNs[(m.NumGC+255)%256])
+	c.send("mem.gc.NumGC", uint64(m.NumGC))
+}
+
+func (c *collector) send(bucket string, value uint64) {
+	buf := []byte(fmt.Sprintf("%v.%v:%v|g", c.prefix, bucket, value))
+	n, err := c.conn.Write(buf)
+	if err != nil {
+		fmt.Printf("error sending data:  %s", err)
+	} else if n != len(buf) {
+		fmt.Printf("error short send: %d < %d", n, len(buf))
+	}
+}
+
+func Collect(endpoint string, prefix string, pauseDuration int, cpu bool, mem bool, gc bool) error {
+	conn, err := net.DialTimeout("udp", endpoint, 2*time.Second)
+	if err != nil {
+		return err
+	}
+
+	c = newCollector(prefix, conn)
+	c.pauseDur = time.Duration(pauseDuration) * time.Second
+	c.enableCPU = cpu
+	c.enableMem = mem
+	c.enableGC = gc
+
+	go c.run()
+	return nil
+}

--- a/pkg/pillar/vendor/modules.txt
+++ b/pkg/pillar/vendor/modules.txt
@@ -626,6 +626,9 @@ github.com/shirou/gopsutil/internal/common
 github.com/shirou/gopsutil/mem
 github.com/shirou/gopsutil/net
 github.com/shirou/gopsutil/process
+# github.com/shjala/gostats v0.0.0-20230215094906-69a32327600f
+## explicit; go 1.19
+github.com/shjala/gostats
 # github.com/sirupsen/logrus v1.9.0
 ## explicit; go 1.13
 github.com/sirupsen/logrus

--- a/pkg/pillar/zedbox/zedbox.go
+++ b/pkg/pillar/zedbox/zedbox.go
@@ -47,6 +47,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub/reverse"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub/socketdriver"
+	_ "github.com/lf-edge/eve/pkg/pillar/rstats"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/zedcloud"
 	"github.com/sirupsen/logrus"


### PR DESCRIPTION
## What
The patch enable pillar to collect runtime stats which are provided by Golang through `runtime.MemStats` and then send it over UDP in a format that [statsd](https://github.com/statsd/statsd) daemon understands. Statsd format is simple and text based, for example in our case we use gauge to collect data, so network packets consist of data similar to `gaugor:<number>|g` .

## Why
I order to break the Zebox service into individual processes and retain low memory footprint, we needed to understand where bulk of the memory usage is coming from, is it mapping of the binaries or Golang runtime? some simple tests (booting the system in various scenarios) shows runtime uses 5 to 10 MB of memory.

## Testing
In your host (or a place reachable from eve-os), spin up a container that contains statsd (for collection) and graphite (for visualisation):
```
docker pull graphiteapp/graphite-statsd
docker run -p 8080:80 -p 8125:8125/udp --rm --name statsd graphiteapp/graphite-statsd
```
Change the RSTATS_ENDPOINT (statsd endpoint) inside `pkg/pillar/build-rstats.yml` to a proper value, then simply build pillar:
```
make pkg/pillar RSTATS=y
```

Navigate to graphite GUI (`http://localhost:8080/dashboard` or appropriate ip) in your browser. Pillar stats are located in `stats.gauges.pillar`. Yo can also copy-paste the following config to create a simple dashboard, first click on "Edit Dashboard" :

![image](https://user-images.githubusercontent.com/121871672/217207561-8d20bcca-9228-4317-9c0c-25c91b23a4b3.png)

Paste the following config : 
```
[
  {
    "target": [
      "stats.gauges.pillar.mem.com.Total_VM_Bytes_Reserved",
      "stats.gauges.pillar.mem.com.Live_Heap_Bytes_Allocated",
      "stats.gauges.pillar.mem.com.Cumulative_Heap_Bytes_Allocated",
      "stats.gauges.pillar.mem.com.Other_Bytes_Allocation",
      "stats.gauges.pillar.mem.com.Total_Stack_Allocation"
    ],
    "title": "Memory Allocation",
    "vtitle": "Bytes"
  }
]
```

And should see result similar to this :

![image](https://user-images.githubusercontent.com/121871672/217207849-2f9894c0-b1c6-4f9b-82c6-90ad87de3a0f.png)


Signed-off-by: Shahriyar Jalayeri shahriyar@zededa.com