### PR TITLE
Avoid spurious download 'cancelled by user'

### DIFF
--- a/libs/zedUpload/datastore.go
+++ b/libs/zedUpload/datastore.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/lf-edge/eve/libs/nettrace"
 	"github.com/lf-edge/eve/libs/zedUpload/types"
+	"github.com/sirupsen/logrus"
 )
 
 // Sync Operation type
@@ -87,10 +88,16 @@ type DronaCtx struct {
 func (ctx *DronaCtx) ListenAndServe() {
 	for {
 		select {
-		case req := <-ctx.reqChan:
-			_ = ctx.handleRequest(req)
-
+		case req, ok := <-ctx.reqChan:
+			if ok {
+				logrus.Infof("ListenAndServe got request")
+				_ = ctx.handleRequest(req)
+			} else {
+				logrus.Infof("ListenAndServe reqChan closed")
+				return
+			}
 		case <-ctx.quitChan:
+			logrus.Infof("ListenAndServe quitChan")
 			_ = ctx.handleQuit()
 			return
 		}

--- a/pkg/pillar/cmd/downloader/download.go
+++ b/pkg/pillar/cmd/downloader/download.go
@@ -206,14 +206,20 @@ func download(ctx *downloaderContext, trType zedUpload.SyncTransportType,
 	go func() {
 		select {
 		case <-doneChan:
+			log.Functionf("doneChan")
 			// remove cancel channel
 			receiveChan <- nil
-		case <-cancelChan:
-			cancel = true
-			errStr := fmt.Sprintf("cancelled by user: <%s>, <%s>, <%s>",
-				dpath, region, filename)
-			log.Error(errStr)
-			_ = req.Cancel()
+		case _, ok := <-cancelChan:
+			if ok {
+				cancel = true
+				errStr := fmt.Sprintf("cancelled by user: <%s>, <%s>, <%s>",
+					dpath, region, filename)
+				log.Error(errStr)
+				_ = req.Cancel()
+			} else {
+				log.Warnf("cancelChan closed")
+				return
+			}
 		}
 	}()
 
@@ -339,14 +345,20 @@ func objectMetadata(ctx *downloaderContext, trType zedUpload.SyncTransportType,
 	go func() {
 		select {
 		case <-doneChan:
+			log.Functionf("doneChan")
 			// remove cancel channel
 			receiveChan <- nil
-		case <-cancelChan:
-			cancel = true
-			errStr := fmt.Sprintf("cancelled by user: <%s>, <%s>, <%s>",
-				dpath, region, filename)
-			log.Error(errStr)
-			_ = req.Cancel()
+		case _, ok := <-cancelChan:
+			if ok {
+				cancel = true
+				errStr := fmt.Sprintf("cancelled by user: <%s>, <%s>, <%s>",
+					dpath, region, filename)
+				log.Error(errStr)
+				_ = req.Cancel()
+			} else {
+				log.Warnf("cancelChan closed")
+				return
+			}
 		}
 	}()
 

--- a/pkg/pillar/cmd/downloader/handlers.go
+++ b/pkg/pillar/cmd/downloader/handlers.go
@@ -100,13 +100,15 @@ func (d *downloadHandler) create(ctxArg interface{},
 	go func() {
 		for ch := range receiveChan {
 			if h.currentCancelChan != nil && ch != nil {
-				log.Noticef("downloadHandler(%s) received updated cancelChan %v",
-					key, ch)
+				log.Noticef("downloadHandler(%s) received updated cancelChan %v old %v",
+					key, ch, h.currentCancelChan)
 			}
-			if h.currentCancelChan != nil {
-				close(h.currentCancelChan)
+			if ch != h.currentCancelChan {
+				if h.currentCancelChan != nil {
+					close(h.currentCancelChan)
+				}
+				h.currentCancelChan = ch
 			}
-			h.currentCancelChan = ch
 		}
 		if h.currentCancelChan != nil {
 			log.Noticef("downloadHandler(%s) receiveChan func done", key)

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/lf-edge/eve/libs/nettrace"
 	"github.com/lf-edge/eve/libs/zedUpload/types"
+	"github.com/sirupsen/logrus"
 )
 
 // Sync Operation type
@@ -87,10 +88,16 @@ type DronaCtx struct {
 func (ctx *DronaCtx) ListenAndServe() {
 	for {
 		select {
-		case req := <-ctx.reqChan:
-			_ = ctx.handleRequest(req)
-
+		case req, ok := <-ctx.reqChan:
+			if ok {
+				logrus.Infof("ListenAndServe got request")
+				_ = ctx.handleRequest(req)
+			} else {
+				logrus.Infof("ListenAndServe reqChan closed")
+				return
+			}
 		case <-ctx.quitChan:
+			logrus.Infof("ListenAndServe quitChan")
 			_ = ctx.handleQuit()
 			return
 		}


### PR DESCRIPTION
We've seen one case of this failure and reviewing the code it is clear that it needs to be more robust against different order on the done and cancel channels; when the work is done the cancel channel will be closed. In addition, should the cancel channel be closed it should not loop reading from it. Also adding logging so we can catch if this happens and can explain the spurious error.

This is based on an earlier observation by @giggsoff when it comes to handling closed channels and ending up with a loop reading from the channel.
