### PR TITLE
LOC: request device configuration and publish metrics/info 

### DIFF
--- a/pkg/pillar/cmd/zedagent/handleappInstMetadata.go
+++ b/pkg/pillar/cmd/zedagent/handleappInstMetadata.go
@@ -20,7 +20,7 @@ func handleAppInstMetaDataModify(ctxArg interface{}, key string,
 func handleAppInstMetaDataDelete(ctxArg interface{}, key string, statusArg interface{}) {
 	appInstMetaData := statusArg.(types.AppInstMetaData)
 	ctx := ctxArg.(*zedagentContext)
-	PublishAppInstMetaDataToZedCloud(ctx, &appInstMetaData, true)
+	PublishAppInstMetaDataToZedCloud(ctx, &appInstMetaData, true, AllDest)
 	ctx.iteration++
 }
 
@@ -28,6 +28,6 @@ func handleAppInstMetaDataImpl(ctxArg interface{}, key string, statusArg interfa
 
 	appInstMetaData := statusArg.(types.AppInstMetaData)
 	ctx := ctxArg.(*zedagentContext)
-	PublishAppInstMetaDataToZedCloud(ctx, &appInstMetaData, false)
+	PublishAppInstMetaDataToZedCloud(ctx, &appInstMetaData, false, AllDest)
 	ctx.iteration++
 }

--- a/pkg/pillar/cmd/zedagent/handleblob.go
+++ b/pkg/pillar/cmd/zedagent/handleblob.go
@@ -28,7 +28,7 @@ func handleBlobStatusImpl(ctxArg interface{}, key string,
 	status := statusArg.(types.BlobStatus)
 	ctx := ctxArg.(*zedagentContext)
 	uuidStr := status.Key()
-	PublishBlobInfoToZedCloud(ctx, uuidStr, &status, ctx.iteration)
+	PublishBlobInfoToZedCloud(ctx, uuidStr, &status, ctx.iteration, AllDest)
 	ctx.iteration++
 }
 
@@ -36,6 +36,6 @@ func handleBlobDelete(ctxArg interface{}, key string, statusArg interface{}) {
 	status := statusArg.(types.BlobStatus)
 	ctx := ctxArg.(*zedagentContext)
 	uuidStr := status.Key()
-	PublishBlobInfoToZedCloud(ctx, uuidStr, nil, ctx.iteration)
+	PublishBlobInfoToZedCloud(ctx, uuidStr, nil, ctx.iteration, AllDest)
 	ctx.iteration++
 }

--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -428,9 +428,9 @@ func sendAttestReqProtobuf(attestReq *attest.ZAttestReq, iteration int) {
 	//We queue the message and then get the highest priority message to send.
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
-	zedcloud.SetDeferred(zedcloudCtx, deferKey, buf, size, attestURL,
+	zedcloudCtx.DeferredEventCtx.SetDeferred(deferKey, buf, size, attestURL,
 		false, false, attestReq.ReqType)
-	zedcloud.HandleDeferred(zedcloudCtx, time.Now(), 0, true)
+	zedcloudCtx.DeferredEventCtx.HandleDeferred(time.Now(), 0, true)
 }
 
 // initialize cipher pubsub trigger handlers and channels

--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -429,7 +429,7 @@ func sendAttestReqProtobuf(attestReq *attest.ZAttestReq, iteration int) {
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
 	zedcloudCtx.DeferredEventCtx.SetDeferred(deferKey, buf, size, attestURL,
-		false, false, attestReq.ReqType)
+		false, false, false, attestReq.ReqType)
 	zedcloudCtx.DeferredEventCtx.HandleDeferred(time.Now(), 0, true)
 }
 

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -907,7 +907,7 @@ func inhaleDeviceConfig(getconfigCtx *getconfigContext, config *zconfig.EdgeDevC
 		if controllerEpoch != newControllerEpoch {
 			log.Noticef("Controller epoch changed from %d to %d", controllerEpoch, newControllerEpoch)
 			controllerEpoch = newControllerEpoch
-			triggerPublishAllInfo(getconfigCtx.zedagentCtx)
+			triggerPublishAllInfo(getconfigCtx.zedagentCtx, AllDest)
 		}
 	}
 

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -138,8 +138,6 @@ type getconfigContext struct {
 	// This information is persisted under /persist/checkpoint/localcommands
 	localCommands *types.LocalCommands
 
-	callProcessLocalProfileServerChange bool //did we already call processLocalProfileServerChange
-
 	configRetryUpdateCounter uint32 // received from config
 
 	// Frequency in seconds at which metrics is published to the controller.

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -116,6 +116,7 @@ type getconfigContext struct {
 	localProfileTrigger       chan Notify
 	localServerMap            *localServerMap
 	lastDevCmdTimestamp       uint64 // From lastDevCmdTimestampFile
+	locConfig                 *types.LOCConfig
 
 	// parsed L2 adapters
 	vlans []L2Adapter

--- a/pkg/pillar/cmd/zedagent/handlecontent.go
+++ b/pkg/pillar/cmd/zedagent/handlecontent.go
@@ -141,7 +141,7 @@ func handleContentTreeStatusImpl(ctxArg interface{}, key string,
 	status := statusArg.(types.ContentTreeStatus)
 	ctx := ctxArg.(*zedagentContext)
 	uuidStr := status.Key()
-	PublishContentInfoToZedCloud(ctx, uuidStr, &status, ctx.iteration)
+	PublishContentInfoToZedCloud(ctx, uuidStr, &status, ctx.iteration, AllDest)
 	ctx.iteration++
 }
 
@@ -150,6 +150,6 @@ func handleContentTreeStatusDelete(ctxArg interface{}, key string,
 
 	ctx := ctxArg.(*zedagentContext)
 	uuidStr := key
-	PublishContentInfoToZedCloud(ctx, uuidStr, nil, ctx.iteration)
+	PublishContentInfoToZedCloud(ctx, uuidStr, nil, ctx.iteration, AllDest)
 	ctx.iteration++
 }

--- a/pkg/pillar/cmd/zedagent/handlelocation.go
+++ b/pkg/pillar/cmd/zedagent/handlelocation.go
@@ -28,7 +28,8 @@ const (
 )
 
 // Run a periodic post of the location information.
-func locationTimerTask(ctx *zedagentContext, handleChannel chan interface{}) {
+func locationTimerTask(ctx *zedagentContext, handleChannel chan interface{},
+	triggerLocationInfo chan destinationBitset) {
 	var cloudIteration int
 
 	// Ticker for periodic publishing to the controller.
@@ -59,28 +60,11 @@ func locationTimerTask(ctx *zedagentContext, handleChannel chan interface{}) {
 	for {
 		select {
 		case <-cloudTicker.C:
-			locInfo := getLocationInfo(ctx)
-			if locInfo == nil {
-				// Not available.
-				break
-			}
-			start := time.Now()
-			cloudIteration++
-			publishLocationToController(locInfo, cloudIteration)
-			ctx.ps.CheckMaxTimeTopic(wdName, "publishLocationToController", start,
-				warningTime, errorTime)
-
+			publishLocation(ctx, &cloudIteration, wdName, ControllerDest)
+		case dest := <-triggerLocationInfo:
+			publishLocation(ctx, &cloudIteration, wdName, dest)
 		case <-appTicker.C:
-			locInfo := getLocationInfo(ctx)
-			if locInfo == nil {
-				// Not available.
-				break
-			}
-			start := time.Now()
-			publishLocationToLocalServer(ctx.getconfigCtx, locInfo)
-			ctx.ps.CheckMaxTimeTopic(wdName, "publishLocationToLocalServer", start,
-				warningTime, errorTime)
-
+			publishLocation(ctx, &cloudIteration, wdName, LPSDest)
 		case <-stillRunning.C:
 		}
 		ctx.ps.StillRunning(wdName, warningTime, errorTime)
@@ -121,8 +105,31 @@ func updateLocationAppTimer(ctx *getconfigContext, appInterval uint32) {
 	flextimer.TickNow(ctx.locationAppTickerHandle)
 }
 
-func publishLocationToController(locInfo *info.ZInfoLocation, iteration int) {
-	log.Functionf("publishLocationToController: iteration %d", iteration)
+func publishLocation(ctx *zedagentContext, iter *int, wdName string,
+	dest destinationBitset) {
+	locInfo := getLocationInfo(ctx)
+	if locInfo == nil {
+		// Not available.
+		return
+	}
+	if dest&(ControllerDest|LOCDest) != 0 {
+		*iter++
+		start := time.Now()
+		publishLocationToDest(locInfo, *iter, dest)
+		ctx.ps.CheckMaxTimeTopic(wdName, "publishLocationToDest", start,
+			warningTime, errorTime)
+	}
+	if dest&LPSDest != 0 {
+		start := time.Now()
+		publishLocationToLocalServer(ctx.getconfigCtx, locInfo)
+		ctx.ps.CheckMaxTimeTopic(wdName, "publishLocationToLocalServer", start,
+			warningTime, errorTime)
+	}
+}
+
+func publishLocationToDest(locInfo *info.ZInfoLocation, iteration int,
+	dest destinationBitset) {
+	log.Functionf("publishLocationToDest: iteration %d", iteration)
 	infoMsg := &info.ZInfoMsg{
 		Ztype: info.ZInfoTypes_ZiLocation,
 		DevId: devUUID.String(),
@@ -132,10 +139,10 @@ func publishLocationToController(locInfo *info.ZInfoLocation, iteration int) {
 		AtTimeStamp: ptypes.TimestampNow(),
 	}
 
-	log.Functionf("publishLocationToController: sending %v", infoMsg)
+	log.Functionf("publishLocationToDest: sending %v", infoMsg)
 	data, err := proto.Marshal(infoMsg)
 	if err != nil {
-		log.Fatal("publishLocationToController: proto marshaling error: ", err)
+		log.Fatal("publishLocationToDest: proto marshaling error: ", err)
 	}
 	infoURL := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API,
 		devUUID, "info")
@@ -154,7 +161,7 @@ func publishLocationToController(locInfo *info.ZInfoLocation, iteration int) {
 		size, buf, iteration, bailOnHTTPErr, withNetTrace)
 	if err != nil {
 		// Hopefully next timeout will be more successful
-		log.Errorf("publishLocationToController: failed (status %d): %v", rv.Status, err)
+		log.Errorf("publishLocationToDest: failed (status %d): %v", rv.Status, err)
 		return
 	}
 }

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -1214,7 +1214,7 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 	//We queue the message and then get the highest priority message to send.
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
-	queueInfoToDest(ctx, dest, uuid, buf, size, true, false,
+	queueInfoToDest(ctx, dest, uuid, buf, size, true, false, false,
 		info.ZInfoTypes_ZiApp)
 }
 
@@ -1282,7 +1282,7 @@ func PublishContentInfoToZedCloud(ctx *zedagentContext, uuid string,
 	//We queue the message and then get the highest priority message to send.
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
-	queueInfoToDest(ctx, dest, uuid, buf, size, true, false,
+	queueInfoToDest(ctx, dest, uuid, buf, size, true, false, false,
 		info.ZInfoTypes_ZiContentTree)
 }
 
@@ -1359,7 +1359,7 @@ func PublishVolumeToZedCloud(ctx *zedagentContext, uuid string,
 	//We queue the message and then get the highest priority message to send.
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
-	queueInfoToDest(ctx, dest, uuid, buf, size, true, false,
+	queueInfoToDest(ctx, dest, uuid, buf, size, true, false, false,
 		info.ZInfoTypes_ZiVolume)
 }
 
@@ -1417,7 +1417,7 @@ func PublishBlobInfoToZedCloud(ctx *zedagentContext, blobSha string,
 	//We queue the message and then get the highest priority message to send.
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
-	queueInfoToDest(ctx, dest, blobSha, buf, size, true, false,
+	queueInfoToDest(ctx, dest, blobSha, buf, size, true, false, false,
 		info.ZInfoTypes_ZiBlobList)
 }
 
@@ -1466,7 +1466,7 @@ func PublishEdgeviewToZedCloud(ctx *zedagentContext,
 	//We queue the message and then get the highest priority message to send.
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
-	queueInfoToDest(ctx, dest, "global", buf, size, true, false,
+	queueInfoToDest(ctx, dest, "global", buf, size, true, false, false,
 		info.ZInfoTypes_ZiEdgeview)
 	ctx.iteration++
 }

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -102,7 +102,8 @@ func handleAppDiskMetricCreate(ctxArg interface{}, key string, _ interface{}) {
 			continue
 		}
 		uuidStr := volumeStatus.VolumeID.String()
-		PublishVolumeToZedCloud(ctx, uuidStr, &volumeStatus, ctx.iteration)
+		PublishVolumeToZedCloud(ctx, uuidStr, &volumeStatus,
+			ctx.iteration, AllDest)
 	}
 	log.Functionf("handleAppDiskMetricCreate: %s", key)
 }
@@ -1082,7 +1083,7 @@ func encodeNetworkPortConfig(ctx *zedagentContext,
 // containing only the UUID to inform zedcloud about the delete.
 func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 	aiStatus *types.AppInstanceStatus,
-	aa *types.AssignableAdapters, iteration int) {
+	aa *types.AssignableAdapters, iteration int, dest destinationBitset) {
 	log.Functionf("PublishAppInfoToZedCloud uuid %s", uuid)
 	var ReportInfo = &info.ZInfoMsg{}
 
@@ -1223,7 +1224,7 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 // When content tree Status is nil it means a delete and we send a message
 // containing only the UUID to inform zedcloud about the delete.
 func PublishContentInfoToZedCloud(ctx *zedagentContext, uuid string,
-	ctStatus *types.ContentTreeStatus, iteration int) {
+	ctStatus *types.ContentTreeStatus, iteration int, dest destinationBitset) {
 
 	log.Functionf("PublishContentInfoToZedCloud uuid %s", uuid)
 	var ReportInfo = &info.ZInfoMsg{}
@@ -1293,7 +1294,7 @@ func PublishContentInfoToZedCloud(ctx *zedagentContext, uuid string,
 // When volume status is nil it means a delete and we send a message
 // containing only the UUID to inform zedcloud about the delete.
 func PublishVolumeToZedCloud(ctx *zedagentContext, uuid string,
-	volStatus *types.VolumeStatus, iteration int) {
+	volStatus *types.VolumeStatus, iteration int, dest destinationBitset) {
 
 	log.Functionf("PublishVolumeToZedCloud uuid %s", uuid)
 	var ReportInfo = &info.ZInfoMsg{}
@@ -1371,7 +1372,8 @@ func PublishVolumeToZedCloud(ctx *zedagentContext, uuid string,
 // PublishBlobInfoToZedCloud is called per change, hence needs to try over all management ports
 // When blob Status is nil it means a delete and we send a message
 // containing only the UUID to inform zedcloud about the delete.
-func PublishBlobInfoToZedCloud(ctx *zedagentContext, blobSha string, blobStatus *types.BlobStatus, iteration int) {
+func PublishBlobInfoToZedCloud(ctx *zedagentContext, blobSha string,
+	blobStatus *types.BlobStatus, iteration int, dest destinationBitset) {
 	log.Functionf("PublishBlobInfoToZedCloud blobSha %v", blobSha)
 	var ReportInfo = &info.ZInfoMsg{}
 
@@ -1428,7 +1430,8 @@ func PublishBlobInfoToZedCloud(ctx *zedagentContext, blobSha string, blobStatus 
 }
 
 // PublishEdgeviewToZedCloud - publish Edgeview info to controller
-func PublishEdgeviewToZedCloud(ctx *zedagentContext, evStatus *types.EdgeviewStatus) {
+func PublishEdgeviewToZedCloud(ctx *zedagentContext,
+	evStatus *types.EdgeviewStatus, dest destinationBitset) {
 
 	log.Functionf("PublishEdgeviewToZedCloud")
 	var ReportInfo = &info.ZInfoMsg{}

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -1215,7 +1215,7 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
 	zedcloudCtx.DeferredEventCtx.SetDeferred(uuid, buf, size, statusUrl,
-		true, false, info.ZInfoTypes_ZiApp)
+		true, false, false, info.ZInfoTypes_ZiApp)
 	zedcloudCtx.DeferredEventCtx.HandleDeferred(time.Now(), 0, true)
 }
 
@@ -1285,7 +1285,7 @@ func PublishContentInfoToZedCloud(ctx *zedagentContext, uuid string,
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
 	zedcloudCtx.DeferredEventCtx.SetDeferred(uuid, buf, size, statusURL,
-		true, false, info.ZInfoTypes_ZiContentTree)
+		true, false, false, info.ZInfoTypes_ZiContentTree)
 	zedcloudCtx.DeferredEventCtx.HandleDeferred(time.Now(), 0, true)
 }
 
@@ -1364,7 +1364,7 @@ func PublishVolumeToZedCloud(ctx *zedagentContext, uuid string,
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
 	zedcloudCtx.DeferredEventCtx.SetDeferred(uuid, buf, size, statusURL,
-		true, false, info.ZInfoTypes_ZiVolume)
+		true, false, false, info.ZInfoTypes_ZiVolume)
 	zedcloudCtx.DeferredEventCtx.HandleDeferred(time.Now(), 0, true)
 }
 
@@ -1423,7 +1423,7 @@ func PublishBlobInfoToZedCloud(ctx *zedagentContext, blobSha string, blobStatus 
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
 	zedcloudCtx.DeferredEventCtx.SetDeferred(blobSha, buf, size, statusURL,
-		true, false, info.ZInfoTypes_ZiBlobList)
+		true, false, false, info.ZInfoTypes_ZiBlobList)
 	zedcloudCtx.DeferredEventCtx.HandleDeferred(time.Now(), 0, true)
 }
 
@@ -1473,7 +1473,7 @@ func PublishEdgeviewToZedCloud(ctx *zedagentContext, evStatus *types.EdgeviewSta
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
 	zedcloudCtx.DeferredEventCtx.SetDeferred("global", buf, size, statusURL,
-		true, false, info.ZInfoTypes_ZiEdgeview)
+		true, false, false, info.ZInfoTypes_ZiEdgeview)
 	zedcloudCtx.DeferredEventCtx.HandleDeferred(time.Now(), 0, true)
 	ctx.iteration++
 }

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -165,10 +165,10 @@ func encodeTestResults(tr types.TestResults) *info.ErrorInfo {
 	return errInfo
 }
 
-// Run a periodic post of the metrics
-func metricsTimerTask(ctx *zedagentContext, handleChannel chan interface{}) {
+// Run a periodic post of the metrics and info to an LOC if we have one
+func metricsAndInfoTimerTask(ctx *zedagentContext, handleChannel chan interface{}) {
 	iteration := 0
-	log.Functionln("starting report metrics timer task")
+	log.Functionln("starting report metrics/info timer task")
 	publishMetrics(ctx, iteration)
 
 	interval := time.Duration(ctx.globalConfig.GlobalValueInt(types.MetricInterval)) * time.Second
@@ -193,6 +193,12 @@ func metricsTimerTask(ctx *zedagentContext, handleChannel chan interface{}) {
 			publishMetrics(ctx, iteration)
 			ctx.ps.CheckMaxTimeTopic(wdName, "publishMetrics", start,
 				warningTime, errorTime)
+
+			locConfig := ctx.getconfigCtx.locConfig
+			if locConfig != nil {
+				// Publish all info by timer only for LOC
+				triggerPublishAllInfo(ctx, LOCDest)
+			}
 
 		case <-stillRunning.C:
 		}

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -1204,7 +1204,6 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 	if err != nil {
 		log.Fatal("PublishAppInfoToZedCloud proto marshaling error: ", err)
 	}
-	statusUrl := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, devUUID, "info")
 
 	buf := bytes.NewBuffer(data)
 	if buf == nil {
@@ -1215,9 +1214,8 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 	//We queue the message and then get the highest priority message to send.
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
-	zedcloudCtx.DeferredEventCtx.SetDeferred(uuid, buf, size, statusUrl,
-		true, false, false, info.ZInfoTypes_ZiApp)
-	zedcloudCtx.DeferredEventCtx.HandleDeferred(time.Now(), 0, true)
+	queueInfoToDest(ctx, dest, uuid, buf, size, true, false,
+		info.ZInfoTypes_ZiApp)
 }
 
 // PublishContentInfoToZedCloud is called per change, hence needs to try over all management ports
@@ -1274,7 +1272,6 @@ func PublishContentInfoToZedCloud(ctx *zedagentContext, uuid string,
 	if err != nil {
 		log.Fatal("PublishContentInfoToZedCloud proto marshaling error: ", err)
 	}
-	statusURL := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, devUUID, "info")
 
 	buf := bytes.NewBuffer(data)
 	if buf == nil {
@@ -1285,9 +1282,8 @@ func PublishContentInfoToZedCloud(ctx *zedagentContext, uuid string,
 	//We queue the message and then get the highest priority message to send.
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
-	zedcloudCtx.DeferredEventCtx.SetDeferred(uuid, buf, size, statusURL,
-		true, false, false, info.ZInfoTypes_ZiContentTree)
-	zedcloudCtx.DeferredEventCtx.HandleDeferred(time.Now(), 0, true)
+	queueInfoToDest(ctx, dest, uuid, buf, size, true, false,
+		info.ZInfoTypes_ZiContentTree)
 }
 
 // PublishVolumeToZedCloud is called per change, hence needs to try over all management ports
@@ -1353,7 +1349,6 @@ func PublishVolumeToZedCloud(ctx *zedagentContext, uuid string,
 	if err != nil {
 		log.Fatal("PublishVolumeToZedCloud proto marshaling error: ", err)
 	}
-	statusURL := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, devUUID, "info")
 
 	buf := bytes.NewBuffer(data)
 	if buf == nil {
@@ -1364,9 +1359,8 @@ func PublishVolumeToZedCloud(ctx *zedagentContext, uuid string,
 	//We queue the message and then get the highest priority message to send.
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
-	zedcloudCtx.DeferredEventCtx.SetDeferred(uuid, buf, size, statusURL,
-		true, false, false, info.ZInfoTypes_ZiVolume)
-	zedcloudCtx.DeferredEventCtx.HandleDeferred(time.Now(), 0, true)
+	queueInfoToDest(ctx, dest, uuid, buf, size, true, false,
+		info.ZInfoTypes_ZiVolume)
 }
 
 // PublishBlobInfoToZedCloud is called per change, hence needs to try over all management ports
@@ -1413,7 +1407,6 @@ func PublishBlobInfoToZedCloud(ctx *zedagentContext, blobSha string,
 	if err != nil {
 		log.Fatal("PublishBlobInfoToZedCloud proto marshaling error: ", err)
 	}
-	statusURL := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, devUUID, "info")
 
 	buf := bytes.NewBuffer(data)
 	if buf == nil {
@@ -1424,9 +1417,8 @@ func PublishBlobInfoToZedCloud(ctx *zedagentContext, blobSha string,
 	//We queue the message and then get the highest priority message to send.
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
-	zedcloudCtx.DeferredEventCtx.SetDeferred(blobSha, buf, size, statusURL,
-		true, false, false, info.ZInfoTypes_ZiBlobList)
-	zedcloudCtx.DeferredEventCtx.HandleDeferred(time.Now(), 0, true)
+	queueInfoToDest(ctx, dest, blobSha, buf, size, true, false,
+		info.ZInfoTypes_ZiBlobList)
 }
 
 // PublishEdgeviewToZedCloud - publish Edgeview info to controller
@@ -1464,7 +1456,6 @@ func PublishEdgeviewToZedCloud(ctx *zedagentContext,
 	if err != nil {
 		log.Fatal("PublishEdgeviewToZedCloud proto marshaling error: ", err)
 	}
-	statusURL := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, devUUID, "info")
 
 	buf := bytes.NewBuffer(data)
 	if buf == nil {
@@ -1475,9 +1466,8 @@ func PublishEdgeviewToZedCloud(ctx *zedagentContext,
 	//We queue the message and then get the highest priority message to send.
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
-	zedcloudCtx.DeferredEventCtx.SetDeferred("global", buf, size, statusURL,
-		true, false, false, info.ZInfoTypes_ZiEdgeview)
-	zedcloudCtx.DeferredEventCtx.HandleDeferred(time.Now(), 0, true)
+	queueInfoToDest(ctx, dest, "global", buf, size, true, false,
+		info.ZInfoTypes_ZiEdgeview)
 	ctx.iteration++
 }
 

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -1214,9 +1214,9 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 	//We queue the message and then get the highest priority message to send.
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
-	zedcloud.SetDeferred(zedcloudCtx, uuid, buf, size, statusUrl,
+	zedcloudCtx.DeferredEventCtx.SetDeferred(uuid, buf, size, statusUrl,
 		true, false, info.ZInfoTypes_ZiApp)
-	zedcloud.HandleDeferred(zedcloudCtx, time.Now(), 0, true)
+	zedcloudCtx.DeferredEventCtx.HandleDeferred(time.Now(), 0, true)
 }
 
 // PublishContentInfoToZedCloud is called per change, hence needs to try over all management ports
@@ -1284,9 +1284,9 @@ func PublishContentInfoToZedCloud(ctx *zedagentContext, uuid string,
 	//We queue the message and then get the highest priority message to send.
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
-	zedcloud.SetDeferred(zedcloudCtx, uuid, buf, size, statusURL,
+	zedcloudCtx.DeferredEventCtx.SetDeferred(uuid, buf, size, statusURL,
 		true, false, info.ZInfoTypes_ZiContentTree)
-	zedcloud.HandleDeferred(zedcloudCtx, time.Now(), 0, true)
+	zedcloudCtx.DeferredEventCtx.HandleDeferred(time.Now(), 0, true)
 }
 
 // PublishVolumeToZedCloud is called per change, hence needs to try over all management ports
@@ -1363,9 +1363,9 @@ func PublishVolumeToZedCloud(ctx *zedagentContext, uuid string,
 	//We queue the message and then get the highest priority message to send.
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
-	zedcloud.SetDeferred(zedcloudCtx, uuid, buf, size, statusURL,
+	zedcloudCtx.DeferredEventCtx.SetDeferred(uuid, buf, size, statusURL,
 		true, false, info.ZInfoTypes_ZiVolume)
-	zedcloud.HandleDeferred(zedcloudCtx, time.Now(), 0, true)
+	zedcloudCtx.DeferredEventCtx.HandleDeferred(time.Now(), 0, true)
 }
 
 // PublishBlobInfoToZedCloud is called per change, hence needs to try over all management ports
@@ -1422,9 +1422,9 @@ func PublishBlobInfoToZedCloud(ctx *zedagentContext, blobSha string, blobStatus 
 	//We queue the message and then get the highest priority message to send.
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
-	zedcloud.SetDeferred(zedcloudCtx, blobSha, buf, size, statusURL,
+	zedcloudCtx.DeferredEventCtx.SetDeferred(blobSha, buf, size, statusURL,
 		true, false, info.ZInfoTypes_ZiBlobList)
-	zedcloud.HandleDeferred(zedcloudCtx, time.Now(), 0, true)
+	zedcloudCtx.DeferredEventCtx.HandleDeferred(time.Now(), 0, true)
 }
 
 // PublishEdgeviewToZedCloud - publish Edgeview info to controller
@@ -1472,9 +1472,9 @@ func PublishEdgeviewToZedCloud(ctx *zedagentContext, evStatus *types.EdgeviewSta
 	//We queue the message and then get the highest priority message to send.
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
-	zedcloud.SetDeferred(zedcloudCtx, "global", buf, size, statusURL,
+	zedcloudCtx.DeferredEventCtx.SetDeferred("global", buf, size, statusURL,
 		true, false, info.ZInfoTypes_ZiEdgeview)
-	zedcloud.HandleDeferred(zedcloudCtx, time.Now(), 0, true)
+	zedcloudCtx.DeferredEventCtx.HandleDeferred(time.Now(), 0, true)
 	ctx.iteration++
 }
 

--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -180,9 +180,9 @@ func prepareAndPublishNetworkInstanceInfoMsg(ctx *zedagentContext,
 	//We queue the message and then get the highest priority message to send.
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
-	zedcloud.SetDeferred(zedcloudCtx, uuid, buf, size, statusURL,
+	zedcloudCtx.DeferredEventCtx.SetDeferred(uuid, buf, size, statusURL,
 		true, false, zinfo.ZInfoTypes_ZiNetworkInstance)
-	zedcloud.HandleDeferred(zedcloudCtx, time.Now(), 0, true)
+	zedcloudCtx.DeferredEventCtx.HandleDeferred(time.Now(), 0, true)
 }
 
 func fillVpnInfo(info *zinfo.ZInfoNetworkInstance, vpnStatus *types.VpnStatus) {

--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -170,7 +170,7 @@ func prepareAndPublishNetworkInstanceInfoMsg(ctx *zedagentContext,
 	if err != nil {
 		log.Fatal("Publish NetworkInstance proto marshaling error: ", err)
 	}
-	statusURL := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, devUUID, "info")
+
 	buf := bytes.NewBuffer(data)
 	if buf == nil {
 		log.Fatal("malloc error")
@@ -180,9 +180,8 @@ func prepareAndPublishNetworkInstanceInfoMsg(ctx *zedagentContext,
 	//We queue the message and then get the highest priority message to send.
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
-	zedcloudCtx.DeferredEventCtx.SetDeferred(uuid, buf, size, statusURL,
-		true, false, false, zinfo.ZInfoTypes_ZiNetworkInstance)
-	zedcloudCtx.DeferredEventCtx.HandleDeferred(time.Now(), 0, true)
+	queueInfoToDest(ctx, dest, uuid, buf, size, true, false,
+		zinfo.ZInfoTypes_ZiNetworkInstance)
 }
 
 func fillVpnInfo(info *zinfo.ZInfoNetworkInstance, vpnStatus *types.VpnStatus) {

--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -180,7 +180,7 @@ func prepareAndPublishNetworkInstanceInfoMsg(ctx *zedagentContext,
 	//We queue the message and then get the highest priority message to send.
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
-	queueInfoToDest(ctx, dest, uuid, buf, size, true, false,
+	queueInfoToDest(ctx, dest, uuid, buf, size, true, false, false,
 		zinfo.ZInfoTypes_ZiNetworkInstance)
 }
 

--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -44,7 +44,7 @@ func handleNetworkInstanceImpl(ctxArg interface{}, key string,
 		log.Errorf("Received NetworkInstance error %s",
 			status.Error)
 	}
-	prepareAndPublishNetworkInstanceInfoMsg(ctx, status, false)
+	prepareAndPublishNetworkInstanceInfoMsg(ctx, status, false, AllDest)
 	log.Functionf("handleNetworkInstanceImpl(%s) done", key)
 }
 
@@ -54,7 +54,7 @@ func handleNetworkInstanceDelete(ctxArg interface{}, key string,
 	log.Functionf("handleNetworkInstanceDelete(%s)", key)
 	status := statusArg.(types.NetworkInstanceStatus)
 	ctx := ctxArg.(*zedagentContext)
-	prepareAndPublishNetworkInstanceInfoMsg(ctx, status, true)
+	prepareAndPublishNetworkInstanceInfoMsg(ctx, status, true, AllDest)
 	log.Functionf("handleNetworkInstanceDelete(%s) done", key)
 }
 
@@ -66,7 +66,7 @@ func handleNetworkInstanceDelete(ctxArg interface{}, key string,
 // (indicating deletion) would make is explicit
 // and easy for the cloud process.
 func prepareAndPublishNetworkInstanceInfoMsg(ctx *zedagentContext,
-	status types.NetworkInstanceStatus, deleted bool) {
+	status types.NetworkInstanceStatus, deleted bool, dest destinationBitset) {
 
 	infoMsg := &zinfo.ZInfoMsg{}
 	infoType := new(zinfo.ZInfoTypes)

--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -181,7 +181,7 @@ func prepareAndPublishNetworkInstanceInfoMsg(ctx *zedagentContext,
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
 	zedcloudCtx.DeferredEventCtx.SetDeferred(uuid, buf, size, statusURL,
-		true, false, zinfo.ZInfoTypes_ZiNetworkInstance)
+		true, false, false, zinfo.ZInfoTypes_ZiNetworkInstance)
 	zedcloudCtx.DeferredEventCtx.HandleDeferred(time.Now(), 0, true)
 }
 

--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -441,7 +441,7 @@ func handleAppFlowMonitorImpl(ctxArg interface{}, key string,
 
 	// publish protobuf-encoded flowlog to zedcloud
 	select {
-	case ctx.FlowlogQueue <- pflows:
+	case ctx.flowlogQueue <- pflows:
 	default:
 		log.Errorf("Flowlog queue is full, dropping flowlog entry: %+v", pflows.Scope)
 		ctx.flowLogMetrics.Lock()

--- a/pkg/pillar/cmd/zedagent/handlevolume.go
+++ b/pkg/pillar/cmd/zedagent/handlevolume.go
@@ -180,7 +180,7 @@ func handleVolumeStatusImpl(ctxArg interface{}, key string,
 	status := statusArg.(types.VolumeStatus)
 	ctx := ctxArg.(*zedagentContext)
 	uuidStr := status.VolumeID.String()
-	PublishVolumeToZedCloud(ctx, uuidStr, &status, ctx.iteration)
+	PublishVolumeToZedCloud(ctx, uuidStr, &status, ctx.iteration, AllDest)
 	ctx.iteration++
 }
 
@@ -190,6 +190,6 @@ func handleVolumeStatusDelete(ctxArg interface{},
 	status := statusArg.(types.VolumeStatus)
 	ctx := ctxArg.(*zedagentContext)
 	uuidStr := status.VolumeID.String()
-	PublishVolumeToZedCloud(ctx, uuidStr, nil, ctx.iteration)
+	PublishVolumeToZedCloud(ctx, uuidStr, nil, ctx.iteration, AllDest)
 	ctx.iteration++
 }

--- a/pkg/pillar/cmd/zedagent/hardwareinfo.go
+++ b/pkg/pillar/cmd/zedagent/hardwareinfo.go
@@ -106,9 +106,9 @@ func PublishHardwareInfoToZedCloud(ctx *zedagentContext) {
 	}
 	size := int64(proto.Size(ReportHwInfo))
 
-	zedcloud.SetDeferred(zedcloudCtx, hwInfoKey, buf, size,
+	zedcloudCtx.DeferredEventCtx.SetDeferred(hwInfoKey, buf, size,
 		statusURL, bailOnHTTPErr, false, info.ZInfoTypes_ZiHardware)
-	zedcloud.HandleDeferred(zedcloudCtx, time.Now(), 0, true)
+	zedcloudCtx.DeferredEventCtx.HandleDeferred(time.Now(), 0, true)
 }
 
 func getSmartAttr(id int, diskData []*types.DAttrTable) *info.SmartAttr {

--- a/pkg/pillar/cmd/zedagent/hardwareinfo.go
+++ b/pkg/pillar/cmd/zedagent/hardwareinfo.go
@@ -106,8 +106,8 @@ func PublishHardwareInfoToZedCloud(ctx *zedagentContext) {
 	}
 	size := int64(proto.Size(ReportHwInfo))
 
-	zedcloudCtx.DeferredEventCtx.SetDeferred(hwInfoKey, buf, size,
-		statusURL, bailOnHTTPErr, false, info.ZInfoTypes_ZiHardware)
+	zedcloudCtx.DeferredEventCtx.SetDeferred(hwInfoKey, buf, size, statusURL,
+		bailOnHTTPErr, false, false, info.ZInfoTypes_ZiHardware)
 	zedcloudCtx.DeferredEventCtx.HandleDeferred(time.Now(), 0, true)
 }
 

--- a/pkg/pillar/cmd/zedagent/hardwareinfo.go
+++ b/pkg/pillar/cmd/zedagent/hardwareinfo.go
@@ -16,7 +16,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func hardwareInfoTask(ctxPtr *zedagentContext, triggerHwInfo <-chan struct{}) {
+func hardwareInfoTask(ctxPtr *zedagentContext, triggerHwInfo <-chan destinationBitset) {
 	wdName := agentName + "hwinfo"
 
 	stillRunning := time.NewTicker(30 * time.Second)
@@ -25,11 +25,11 @@ func hardwareInfoTask(ctxPtr *zedagentContext, triggerHwInfo <-chan struct{}) {
 
 	for {
 		select {
-		case <-triggerHwInfo:
+		case dest := <-triggerHwInfo:
 			start := time.Now()
 			log.Function("HardwareInfoTask got message")
 
-			PublishHardwareInfoToZedCloud(ctxPtr)
+			PublishHardwareInfoToZedCloud(ctxPtr, dest)
 			ctxPtr.iteration++
 			log.Function("HardwareInfoTask done with message")
 			ctxPtr.ps.CheckMaxTimeTopic(wdName, "PublishHardwareInfo", start,
@@ -41,7 +41,7 @@ func hardwareInfoTask(ctxPtr *zedagentContext, triggerHwInfo <-chan struct{}) {
 }
 
 // PublishHardwareInfoToZedCloud send ZInfoHardware message
-func PublishHardwareInfoToZedCloud(ctx *zedagentContext) {
+func PublishHardwareInfoToZedCloud(ctx *zedagentContext, dest destinationBitset) {
 	var ReportHwInfo = &info.ZInfoMsg{}
 	hwInfoKey := devUUID.String() + "hwinfo"
 	bailOnHTTPErr := true

--- a/pkg/pillar/cmd/zedagent/hardwareinfo.go
+++ b/pkg/pillar/cmd/zedagent/hardwareinfo.go
@@ -103,7 +103,7 @@ func PublishHardwareInfoToZedCloud(ctx *zedagentContext, dest destinationBitset)
 	}
 	size := int64(proto.Size(ReportHwInfo))
 
-	queueInfoToDest(ctx, dest, hwInfoKey, buf, size, bailOnHTTPErr, false,
+	queueInfoToDest(ctx, dest, hwInfoKey, buf, size, bailOnHTTPErr, false, false,
 		info.ZInfoTypes_ZiHardware)
 }
 

--- a/pkg/pillar/cmd/zedagent/hardwareinfo.go
+++ b/pkg/pillar/cmd/zedagent/hardwareinfo.go
@@ -12,7 +12,6 @@ import (
 	"github.com/lf-edge/eve/api/go/info"
 	"github.com/lf-edge/eve/pkg/pillar/hardware"
 	"github.com/lf-edge/eve/pkg/pillar/types"
-	"github.com/lf-edge/eve/pkg/pillar/zedcloud"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -98,17 +97,14 @@ func PublishHardwareInfoToZedCloud(ctx *zedagentContext, dest destinationBitset)
 		log.Fatal("PublishHardwareInfoToZedCloud proto marshaling error: ", err)
 	}
 
-	statusURL := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API, devUUID, "info")
-
 	buf := bytes.NewBuffer(data)
 	if buf == nil {
 		log.Fatal("PublishHardwareInfoToZedCloud malloc error")
 	}
 	size := int64(proto.Size(ReportHwInfo))
 
-	zedcloudCtx.DeferredEventCtx.SetDeferred(hwInfoKey, buf, size, statusURL,
-		bailOnHTTPErr, false, false, info.ZInfoTypes_ZiHardware)
-	zedcloudCtx.DeferredEventCtx.HandleDeferred(time.Now(), 0, true)
+	queueInfoToDest(ctx, dest, hwInfoKey, buf, size, bailOnHTTPErr, false,
+		info.ZInfoTypes_ZiHardware)
 }
 
 func getSmartAttr(id int, diskData []*types.DAttrTable) *info.SmartAttr {

--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -655,9 +655,9 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
 	withNetTracing := traceNextInfoReq(ctx)
-	zedcloud.SetDeferred(zedcloudCtx, deviceUUID, buf, size,
+	zedcloudCtx.DeferredEventCtx.SetDeferred(deviceUUID, buf, size,
 		statusUrl, true, withNetTracing, info.ZInfoTypes_ZiDevice)
-	zedcloud.HandleDeferred(zedcloudCtx, time.Now(), 0, true)
+	zedcloudCtx.DeferredEventCtx.HandleDeferred(time.Now(), 0, true)
 }
 
 // PublishAppInstMetaDataToZedCloud is called when an appInst reports its Metadata to EVE.
@@ -708,9 +708,9 @@ func PublishAppInstMetaDataToZedCloud(ctx *zedagentContext, appInstMetadata *typ
 	//We queue the message and then get the highest priority message to send.
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
-	zedcloud.SetDeferred(zedcloudCtx, deferKey, buf, size, statusURL, true,
+	zedcloudCtx.DeferredEventCtx.SetDeferred(deferKey, buf, size, statusURL, true,
 		false, info.ZInfoTypes_ZiAppInstMetaData)
-	zedcloud.HandleDeferred(zedcloudCtx, time.Now(), 0, true)
+	zedcloudCtx.DeferredEventCtx.HandleDeferred(time.Now(), 0, true)
 }
 
 // Convert the implementation details to the user-friendly userStatus and subStatus*

--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -656,7 +656,7 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 	//but if there is a queue we'll retry sending the highest priority message.
 	withNetTracing := traceNextInfoReq(ctx)
 	zedcloudCtx.DeferredEventCtx.SetDeferred(deviceUUID, buf, size,
-		statusUrl, true, withNetTracing, info.ZInfoTypes_ZiDevice)
+		statusUrl, true, withNetTracing, false, info.ZInfoTypes_ZiDevice)
 	zedcloudCtx.DeferredEventCtx.HandleDeferred(time.Now(), 0, true)
 }
 
@@ -709,7 +709,7 @@ func PublishAppInstMetaDataToZedCloud(ctx *zedagentContext, appInstMetadata *typ
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
 	zedcloudCtx.DeferredEventCtx.SetDeferred(deferKey, buf, size, statusURL, true,
-		false, info.ZInfoTypes_ZiAppInstMetaData)
+		false, false, info.ZInfoTypes_ZiAppInstMetaData)
 	zedcloudCtx.DeferredEventCtx.HandleDeferred(time.Now(), 0, true)
 }
 

--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -165,7 +165,7 @@ func objectInfoTask(ctxPtr *zedagentContext, triggerInfo <-chan infoForObjectKey
 				if locInfo != nil {
 					// Note that we use a zero iteration
 					// counter here.
-					publishLocationToDest(locInfo, 0, infoDest)
+					publishLocationToDest(ctxPtr, locInfo, 0, infoDest)
 				}
 			}
 			if err != nil {

--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -658,7 +658,7 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext, dest destinationBitset) {
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
 	withNetTracing := traceNextInfoReq(ctx)
-	queueInfoToDest(ctx, dest, deviceUUID, buf, size, true, withNetTracing,
+	queueInfoToDest(ctx, dest, deviceUUID, buf, size, true, withNetTracing, false,
 		info.ZInfoTypes_ZiDevice)
 }
 
@@ -710,7 +710,7 @@ func PublishAppInstMetaDataToZedCloud(ctx *zedagentContext,
 	//We queue the message and then get the highest priority message to send.
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
-	queueInfoToDest(ctx, dest, deferKey, buf, size, true, false,
+	queueInfoToDest(ctx, dest, deferKey, buf, size, true, false, false,
 		info.ZInfoTypes_ZiAppInstMetaData)
 }
 

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -469,8 +469,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 
 	// start the metrics reporting task
 	handleChannel := make(chan interface{})
-	log.Functionf("Creating %s at %s", "metricsTimerTask", agentlog.GetMyStack())
-	go metricsTimerTask(zedagentCtx, handleChannel)
+	log.Functionf("Creating %s at %s", "metricsAndInfoTimerTask", agentlog.GetMyStack())
+	go metricsAndInfoTimerTask(zedagentCtx, handleChannel)
 	metricsTickerHandle := <-handleChannel
 	getconfigCtx.metricsTickerHandle = metricsTickerHandle
 

--- a/pkg/pillar/types/zedagenttypes.go
+++ b/pkg/pillar/types/zedagenttypes.go
@@ -696,3 +696,9 @@ const (
 	// DevCommandShutdownPoweroff : shut down all app instances + poweroff
 	DevCommandShutdownPoweroff
 )
+
+// LOCConfig : configuration of the Local Operator Console
+type LOCConfig struct {
+	// LOC URL
+	LocURL string
+}

--- a/pkg/pillar/zedcloud/deferred.go
+++ b/pkg/pillar/zedcloud/deferred.go
@@ -283,6 +283,11 @@ func (ctx *DeferredContext) RemoveDeferred(key string) {
 	}
 }
 
+// KickTimer kicks the timer for immediate execution
+func (ctx *DeferredContext) KickTimer() {
+	ctx.Ticker.TickNow()
+}
+
 // Try every minute backoff to every 15 minutes
 func startTimer(log *base.LogObject, ctx *DeferredContext) {
 

--- a/pkg/pillar/zedcloud/deferred.go
+++ b/pkg/pillar/zedcloud/deferred.go
@@ -17,15 +17,14 @@ import (
 )
 
 // Example usage:
-// deferredChan := zedcloud.InitDeferred(zedcloudCtx)
+// ctx := zedcloud.CreateDeferredCtx(zedcloudCtx, ...)
 // select {
-//      case change := <- deferredChan:
-//		zedcloud.HandleDeferred(zedcloudCtx, change)
+//      case change := <- ctx.Ticker.C:
+//          ctx.HandleDeferred(...)
 // Before or after sending success call:
-//	zedcloud.RemoveDeferred(key)
+//     ctx.RemoveDeferred(key)
 // After failure call
-// 	zedcloud.SetDeferred(key, buf, size, url, zedcloudCtx)
-// or AddDeferred to build a queue for each key
+//     ctx.SetDeferred(key, buf, size, ...)
 
 type deferredItem struct {
 	itemType       interface{}
@@ -44,7 +43,7 @@ const longTime2 = time.Hour * 48
 // DeferredContext is part of ZedcloudContext
 type DeferredContext struct {
 	deferredItems          []*deferredItem
-	ticker                 flextimer.FlexTickerHandle
+	Ticker                 flextimer.FlexTickerHandle
 	priorityCheckFunctions []TypePriorityCheckFunction
 	lock                   *sync.Mutex
 	sentHandler            *SentHandlerFunction
@@ -61,40 +60,41 @@ type SentHandlerFunction func(
 	itemType interface{}, data *bytes.Buffer, result types.SenderStatus,
 	traces []netdump.TracedNetRequest)
 
-// GetDeferredChan creates and returns a channel to the caller
+// CreateDeferredCtx creates and returns a deferred context
 // We always keep a flextimer running so that we can return
 // the associated channel. We adjust the times when we start and stop
 // the timer.
 // sentHandler is callback which will be run on successful sent
 // priorityCheckFunctions may be added to send item with matched itemType firstly
 // default function at the end of priorityCheckFunctions added to serve non-priority items
-func GetDeferredChan(zedcloudCtx *ZedCloudContext, sentHandler *SentHandlerFunction, priorityCheckFunctions ...TypePriorityCheckFunction) <-chan time.Time {
-	//append with return first
-	priorityCheckFunctions = append(priorityCheckFunctions, func(obj interface{}) bool {
-		return true
-	})
-	zedcloudCtx.deferredCtx = DeferredContext{
+func CreateDeferredCtx(zedcloudCtx *ZedCloudContext, sentHandler *SentHandlerFunction,
+	priorityCheckFunctions ...TypePriorityCheckFunction) *DeferredContext {
+	// Default "accept all" priority
+	priorityCheckFunctions = append(priorityCheckFunctions,
+		func(obj interface{}) bool {
+			return true
+		})
+
+	deferredCtx := DeferredContext{
 		lock:                   &sync.Mutex{},
-		ticker:                 flextimer.NewRangeTicker(longTime1, longTime2),
+		Ticker:                 flextimer.NewRangeTicker(longTime1, longTime2),
 		sentHandler:            sentHandler,
 		priorityCheckFunctions: priorityCheckFunctions,
 		zedcloudCtx:            zedcloudCtx,
 	}
-	return zedcloudCtx.deferredCtx.ticker.C
+
+	return &deferredCtx
 }
 
 // HandleDeferred try to send all deferred items (or only one if sendOne set). Give up if any one fails
 // Stop timer if map becomes empty
 // Returns true when there are no more deferred items
-func HandleDeferred(zedcloudCtx *ZedCloudContext, event time.Time, spacing time.Duration, sendOne bool) bool {
-
-	return zedcloudCtx.deferredCtx.handleDeferred(zedcloudCtx.log, event, spacing, sendOne)
-}
-
-func (ctx *DeferredContext) handleDeferred(log *base.LogObject, event time.Time,
+func (ctx *DeferredContext) HandleDeferred(event time.Time,
 	spacing time.Duration, sendOne bool) bool {
 	ctx.lock.Lock()
 	defer ctx.lock.Unlock()
+
+	log := ctx.zedcloudCtx.log
 
 	if len(ctx.deferredItems) == 0 {
 		return true
@@ -214,26 +214,18 @@ func (ctx *DeferredContext) handleDeferred(log *base.LogObject, event time.Time,
 	return false
 }
 
-// Replace any item for the specified key. If timer not running start it
-// SetDeferred uses the key for identifying the channel. Please note that
-// for deviceUUID key is used for attestUrl, which is not the same for
-// other Urls, where in other caes, the key is very specific for the object
-//
-//	and object type
-func SetDeferred(zedcloudCtx *ZedCloudContext, key string, buf *bytes.Buffer,
-	size int64, url string, bailOnHTTPErr, withNetTracing bool, itemType interface{}) {
-
-	zedcloudCtx.deferredCtx.setDeferred(zedcloudCtx, key, buf, size, url, bailOnHTTPErr,
-		withNetTracing, itemType)
-}
-
-func (ctx *DeferredContext) setDeferred(zedcloudCtx *ZedCloudContext,
+// SetDeferred sets or replaces any item for the specified key and
+// starts the timer. Key is used for identifying the channel. Please
+// note that for deviceUUID key is used for attestUrl, which is not the
+// same for other Urls, where in other case, the key is very specific
+// for the object
+func (ctx *DeferredContext) SetDeferred(
 	key string, buf *bytes.Buffer, size int64, url string, bailOnHTTPErr,
 	withNetTracing bool, itemType interface{}) {
 	ctx.lock.Lock()
 	defer ctx.lock.Unlock()
 
-	log := zedcloudCtx.log
+	log := ctx.zedcloudCtx.log
 	log.Functionf("SetDeferred(%s) size %d items %d",
 		key, size, len(ctx.deferredItems))
 	if len(ctx.deferredItems) == 0 {
@@ -267,15 +259,11 @@ func (ctx *DeferredContext) setDeferred(zedcloudCtx *ZedCloudContext,
 }
 
 // RemoveDeferred removes key from deferred items if exists
-func RemoveDeferred(zedcloudCtx *ZedCloudContext, key string) {
-	zedcloudCtx.deferredCtx.removeDeferred(zedcloudCtx, key)
-}
-
-func (ctx *DeferredContext) removeDeferred(zedcloudCtx *ZedCloudContext, key string) {
+func (ctx *DeferredContext) RemoveDeferred(key string) {
 	ctx.lock.Lock()
 	defer ctx.lock.Unlock()
 
-	log := zedcloudCtx.log
+	log := ctx.zedcloudCtx.log
 	log.Functionf("RemoveDeferred(%s) items %d",
 		key, len(ctx.deferredItems))
 
@@ -297,11 +285,11 @@ func startTimer(log *base.LogObject, ctx *DeferredContext) {
 	log.Functionf("startTimer()")
 	min := 1 * time.Minute
 	max := 15 * time.Minute
-	ctx.ticker.UpdateExpTicker(min, max, 0.3)
+	ctx.Ticker.UpdateExpTicker(min, max, 0.3)
 }
 
 func stopTimer(log *base.LogObject, ctx *DeferredContext) {
 
 	log.Functionf("stopTimer()")
-	ctx.ticker.UpdateRangeTicker(longTime1, longTime2)
+	ctx.Ticker.UpdateRangeTicker(longTime1, longTime2)
 }

--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -68,7 +68,7 @@ type ZedCloudContext struct {
 	serverSigningCertHash []byte
 	onBoardCertBytes      []byte
 	log                   *base.LogObject
-	deferredCtx           DeferredContext
+	DeferredEventCtx      *DeferredContext
 }
 
 // ContextOptions - options to be passed at NewContext

--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -69,6 +69,7 @@ type ZedCloudContext struct {
 	onBoardCertBytes      []byte
 	log                   *base.LogObject
 	DeferredEventCtx      *DeferredContext
+	DeferredPeriodicCtx   *DeferredContext
 }
 
 // ContextOptions - options to be passed at NewContext


### PR DESCRIPTION
This work introduces two LOC related things if LOC configuration exists (LOC URL is set by a controller):

1. Device configuration can be fetched from another source, aka LOC, if main controller is unreachable or returns an error.

3. /info and /metrics are published to the LOC URL along with publishing to a controller. The main difference is that /info is made recurring for the LOC case, because LOC is supposed to be stateless so all /info structures are published without any sending error handling.

Most of the commits are API changes to support different destinations for publishing requests: controller, loc, local server.






