### PR TITLE
pillar: improve Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ PATH:=$(BUILDTOOLS_BIN):$(PATH)
 
 export CGO_ENABLED GOOS GOARCH PATH
 
+ifeq ($(BUILDKIT_PROGRESS),)
+export BUILDKIT_PROGRESS := plain
+endif
+
 # A set of tweakable knobs for our build needs (tweak at your risk!)
 # Which version to assign to snapshot builds (0.0.0 if built locally, 0.0.0-snapshot if on CI/CD)
 EVE_SNAPSHOT_VERSION=0.0.0

--- a/pkg/pillar/Dockerfile
+++ b/pkg/pillar/Dockerfile
@@ -88,10 +88,10 @@ RUN set -e && for patch in ../patches/*.patch; do \
     done
 
 # hadolint ignore=DL4006
-RUN echo "Running go vet" && go vet ./... && \
-    echo "Running go fmt" && ERR=$(gofmt -e -l -s $(find . -name \*.go | grep -v /vendor/)) && \
-       if [ -n "$ERR" ] ; then echo "go fmt Failed - ERR: "$ERR ; exit 1 ; fi && \
-    make DEV=$DEV DISTDIR=/final/opt/zededa/bin build
+RUN --mount=type=cache,target=/root/.cache/go-build echo "Running go vet" && go vet ./... && \
+    echo "Running go fmt" && ERR="$(find . -name \*.go | grep -v /vendor/ | xargs gofmt -d -e -l -s)" && \
+       if [ -n "$ERR" ] ; then printf 'go fmt Failed - ERR: %s' "$ERR" ; exit 1 ; fi && \
+       make DEV="$DEV" DISTDIR=/final/opt/zededa/bin build
 
 WORKDIR /
 
@@ -99,7 +99,7 @@ ENV DELVE_VERSION 1.20.1
 ENV DELVE_SOURCE=https://github.com/go-delve/delve/archive/refs/tags/v${DELVE_VERSION}.tar.gz
 # hadolint ignore=DL3020
 ADD ${DELVE_SOURCE} /delve.tar.gz
-RUN if [ ${DEV} = "y" ]; then \
+RUN --mount=type=cache,target=/root/.cache/go-build if [ ${DEV} = "y" ]; then \
     tar --absolute-names -xz < /delve.tar.gz && \
     cd "/delve-${DELVE_VERSION}" &&  \
     GOFLAGS= CGO_ENABLED=0 go build -ldflags "-s -w -extldflags '-static'" github.com/go-delve/delve/cmd/dlv && \


### PR DESCRIPTION
make gofmt more verbose
re-use go cache

"-d" for "gofmt" will show the diff to the correct formatting;
example output (with a deliberately introduced formatting error):
```#24 [build 6/9] RUN --mount=type=cache,target=/root/.cache/go-build echo "Running go vet" && go vet ./... &&     echo "Running go fmt" && ERR=$(gofmt -d -e -l -s $(find . -name *.go | grep -v /vendor/)) &&        if [ -n "$ERR" ] ; then echo -e "go fmt Failed - ERR: $ERR" ; exit 1 ; fi &&     make DEV=n DISTDIR=/final/opt/zededa/bin build
#24 0.177 Running go vet
#24 4.700 Running go fmt
#24 5.740 go fmt Failed - ERR: ./cmd/zedrouter/dnsmasq.go
#24 5.740 diff -u ./cmd/zedrouter/dnsmasq.go.orig ./cmd/zedrouter/dnsmasq.go
#24 5.740 --- ./cmd/zedrouter/dnsmasq.go.orig
#24 5.740 +++ ./cmd/zedrouter/dnsmasq.go
#24 5.740 @@ -751,7 +751,7 @@
#24 5.740  				tokens)
#24 5.740  			continue
#24 5.740  		}
#24 5.740 -		i, err := strconv.ParseInt(tokens[0], 10,64)
#24 5.740 +		i, err := strconv.ParseInt(tokens[0], 10, 64)
#24 5.740  		if err != nil {
#24 5.740  			log.Errorf("Bad unix time %s: %s", tokens[0], err)
#24 5.740  			i = 0
#24 ERROR: process "/bin/sh -c echo \"Running go vet\" && go vet ./... &&     echo \"Running go fmt\" && ERR=$(gofmt -d -e -l -s $(find . -name \\*.go | grep -v /vendor/)) &&        if [ -n \"$ERR\" ] ; then echo -e \"go fmt Failed - ERR: $ERR\" ; exit 1 ; fi &&     make DEV=$DEV DISTDIR=/final/opt/zededa/bin build" did not complete successfully: exit code: 1
Error building "lfedge/eve-pillar:0b599445469e44e3fb2ec682989fbe12fe1e886e-dirty-329a283": error building for arch amd64: failed to solve: process "/bin/sh -c echo \"Running go vet\" && go vet ./... &&     echo \"Running go fmt\" && ERR=$(gofmt -d -e -l -s $(find . -name \\*.go | grep -v /vendor/)) &&        if [ -n \"$ERR\" ] ; then echo -e \"go fmt Failed - ERR: $ERR\" ; exit 1 ; fi &&     make DEV=$DEV DISTDIR=/final/opt/zededa/bin build" did not complete successfully: exit code: 1
make: *** [eve-pillar] Error 1
```

Small benchmark:
```$ git reset --hard; cat bench.sh; echo; bash bench.sh
HEAD is now at b0a968281 pillar: improve Dockerfile


git checkout master
docker images -aq | xargs docker rmi -f > /dev/null 2>&1
.//build-tools/bin/linuxkit cache clean

make pkg/pillar > /dev/null 2>&1
echo >> pkg/pillar/cmd/zedrouter/zedrouter.go
echo BEFORE:
time make pkg/pillar > /dev/null 2>&1


git checkout improve_pillar_dockerfile
docker images -aq | xargs docker rmi -f > /dev/null 2>&1
.//build-tools/bin/linuxkit cache clean

make pkg/pillar > /dev/null 2>&1
echo >> pkg/pillar/cmd/zedrouter/zedrouter.go
echo AFTER:
time make pkg/pillar > /dev/null 2>&1

Switched to branch 'master'
Your branch is up to date with 'origin/master'.
Cache emptied: { /Users/zededa/.linuxkit/cache LINUXKIT_CACHE}
BEFORE:

real	2m44.107s
user	0m5.334s
sys	0m5.081s
M	pkg/pillar/cmd/zedrouter/zedrouter.go
Switched to branch 'improve_pillar_dockerfile'
Cache emptied: { /Users/zededa/.linuxkit/cache LINUXKIT_CACHE}
AFTER:

real	0m38.664s
user	0m5.376s
sys	0m5.079s
```

Signed-off-by: Christoph Ostarek <christoph@zededa.com>