### PR TITLE
Allow multiple LED names and fix LED name list for RPi

### DIFF
--- a/pkg/pillar/cmd/ledmanager/ledmanager.go
+++ b/pkg/pillar/cmd/ledmanager/ledmanager.go
@@ -208,13 +208,13 @@ var mToF = []modelToFuncs{
 		model:       "raspberrypi.rpi.raspberrypi,4-model-b.brcm,bcm2711",
 		initFunc:    InitLedCmd,
 		displayFunc: ExecuteLedCmd,
-		arg:         "led0",
+		arg:         "ACT,led0",
 	},
 	{
 		model:       "RaspberryPi.RPi4",
 		initFunc:    InitLedCmd,
 		displayFunc: ExecuteLedCmd,
-		arg:         "led0",
+		arg:         "ACT,led0",
 	},
 	{
 		model:       "raspberrypi.uno-220.raspberrypi,4-model-b.brcm,bcm2711",


### PR DESCRIPTION
Labels of some LEDs might diverge depending on device tree file version. This PR changes InitFunc() to support as argument not only a single LED name but also a list (comma-separated) of possible names.

Adds ACT label as a possible name for Raspberry PI's LEDs. This LED is the former led0 which was renamed in u-boot v2022. Keep led0 for backwards compatibility.

This PR is a re-working of PR https://github.com/lf-edge/eve/pull/2253