### PR TITLE
[wip] onboot.sh: block loading of kernel modules

### DIFF
--- a/pkg/pillar/scripts/onboot.sh
+++ b/pkg/pillar/scripts/onboot.sh
@@ -170,4 +170,7 @@ echo '{"BlinkCounter": 1}' > "$ZTMPDIR/LedBlinkCounter/ledconfig.json"
 
 mkdir -p $DPCDIR
 
+# Block loading kernel module at arbitrary time
+echo 1 > /proc/sys/kernel/modules_disabled
+
 echo "$(date -Ins -u) onboot.sh done"


### PR DESCRIPTION
This change blocks the loading of kernel modules at an arbitrary time during system's life. Since we are loading the needed modules during boot in the modprobe container and also do not support hot-plugging new hardware, it should be fine.

This change affects delete_module(2), finit_module(2), init_module(2) and as a result `modprobe`. The kernel's [request_module](https://elixir.bootlin.com/linux/v5.15.96/source/kernel/kmod.c#L124) will also fail because it ends up calling `modprobe` in user-mode.