### PR TITLE
Add badge from OpenSSF Best Practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # EVE is Edge Virtualization Engine
 
+[![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/4746/badge)](https://bestpractices.coreinfrastructure.org/projects/4746)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/lf-edge/eve/badge)](https://api.securityscorecards.dev/projects/github.com/lf-edge/eve)
 [![Publish](https://github.com/lf-edge/eve/actions/workflows/publish.yml/badge.svg?branch=master)](https://github.com/lf-edge/eve/actions/workflows/publish.yml)
 [![Goreport](https://goreportcard.com/badge/github.com/lf-edge/eve)](https://goreportcard.com/report/github.com/lf-edge/eve)
 [![Godoc](https://godoc.org/github.com/lf-edge/eve/pkg/pillar?status.svg)](https://godoc.org/github.com/lf-edge/eve/pkg/pillar)


### PR DESCRIPTION
We are now passing OpenSSF Best Practices.
PR also adds a badge for OpenSSF Scorecard but I haven't looked at the data behind that one and whether we can easily improve it.