### PR TITLE
Bump go version in docker part 3

### DIFF
--- a/pkg/alpine/Dockerfile
+++ b/pkg/alpine/Dockerfile
@@ -1,6 +1,6 @@
 # image was bootstraped using FROM lfedge/eve-alpine-base:f11c7a5dcffe1ab7b466bea7e26010a27da62b3b AS cache
 # to update please see https://github.com/lf-edge/eve/blob/master/docs/BUILD.md#how-to-update-eve-alpine-package
-FROM lfedge/eve-alpine:145f062a40639b6c65efa36bed1c5614b873be52 AS cache
+FROM lfedge/eve-alpine:9fb9b9cbf7d90066a70e4704d04a6fe248ff52bb AS cache
 
 ARG ALPINE_VERSION=3.16
 # this is only needed once, when this package
@@ -13,9 +13,6 @@ COPY Dockerfile abuild.conf /etc/
 COPY mirrors /tmp/mirrors/
 COPY build-cache.sh /bin/
 
-RUN mkdir -vp "/mirror/edge/$(apk --print-arch)"
-# download newest go=1.20.1 from alpine/edge repository
-RUN wget -q "http://dl-cdn.alpinelinux.org/alpine/edge/community/$(apk --print-arch)/go-1.20.1-r0.apk" -O "/mirror/edge/$(apk --print-arch)/go-1.20.1-r0.apk"
 # install abuild for signing (which requires gcc as well)
 RUN apk add --no-cache abuild gcc sudo
 

--- a/pkg/new-kernel/Dockerfile
+++ b/pkg/new-kernel/Dockerfile
@@ -29,20 +29,20 @@ FROM ${EVE_ALPINE_IMAGE} AS cross-compile-libs
 ENV PKGS musl-dev libgcc
 RUN eve-alpine-deploy.sh
 
-# adjust TARGET_ARCH for cross-compiler
+# adjust EVE_TARGET_ARCH for cross-compiler
 FROM kernel-build-base-cross AS kernel-cross-target-arm64
-ENV TARGET_ARCH=aarch64
+ENV EVE_TARGET_ARCH=aarch64
 FROM kernel-build-base-cross AS kernel-cross-target-riscv64
-ENV TARGET_ARCH=riscv64
+ENV EVE_TARGET_ARCH=riscv64
 
 # install cross-compile packages and libs for target
 # hadolint ignore=DL3006
 FROM kernel-cross-target-${TARGETARCH} AS kernel-cross-build-target
-ENV CROSS_COMPILE_ENV="${TARGET_ARCH}"-alpine-linux-musl-
+ENV CROSS_COMPILE_ENV="${EVE_TARGET_ARCH}"-alpine-linux-musl-
 COPY --from=cross-compilers /packages /packages
 # hadolint ignore=DL3018
-RUN apk add --no-cache --allow-untrusted -X /packages build-base-"${TARGET_ARCH}"
-COPY --from=cross-compile-libs /out/ /usr/"${TARGET_ARCH}"-alpine-linux-musl/
+RUN apk add --no-cache --allow-untrusted -X /packages build-base-"${EVE_TARGET_ARCH}"
+COPY --from=cross-compile-libs /out/ /usr/"${EVE_TARGET_ARCH}"-alpine-linux-musl/
 
 # support cross compile from amd64 and arm64 for now
 FROM kernel-cross-build-target AS kernel-target-arm64-build-amd64
@@ -136,7 +136,7 @@ RUN set -e ; KERNEL_SERIES="${KERNEL_VERSION%.*}".x; \
 # hadolint ignore=SC2086
 RUN KERNEL_DEF_CONF="/linux/arch/${KERNEL_ARCH}/configs/${KERNEL_DEFCONFIG}"; \
     KERNEL_SERIES="${KERNEL_VERSION%.*}".x; \
-    cp /kernel_config-"${KERNEL_SERIES}"-"${TARGET_ARCH}" "${KERNEL_DEF_CONF}"; \
+    cp /kernel_config-"${KERNEL_SERIES}"-"${EVE_TARGET_ARCH}" "${KERNEL_DEF_CONF}"; \
     if [ -n "${EXTRA}" ]; then \
         sed -i "s/CONFIG_LOCALVERSION=\"-linuxkit\"/CONFIG_LOCALVERSION=\"-linuxkit${EXTRA}\"/" "${KERNEL_DEF_CONF}"; \
         if [ "${EXTRA}" = "-dbg" ]; then \
@@ -177,7 +177,7 @@ RUN ./autogen.sh && \
         --with-linux-obj=/linux \
         --with-config=kernel  \
         --enable-linux-builtin  \
-        --host="${TARGET_ARCH}"-linux-musl --build="${BUILD_ARCH}"-linux-musl && \
+        --host="${EVE_TARGET_ARCH}"-linux-musl --build="${EVE_BUILD_ARCH}"-linux-musl && \
     ./scripts/make_gitrev.sh && \
     ./copy-builtin /linux
 
@@ -189,7 +189,7 @@ RUN make CROSS_COMPILE="${CROSS_COMPILE_ENV}" ARCH="${KERNEL_ARCH}" "${KERNEL_DE
 
 # Make kernel
 RUN make -j "$(getconf _NPROCESSORS_ONLN)" CROSS_COMPILE="${CROSS_COMPILE_ENV}" ARCH="${KERNEL_ARCH}" KCFLAGS="-fno-pie" && \
-    case ${TARGET_ARCH} in \
+    case ${EVE_TARGET_ARCH} in \
     x86_64) \
         cp arch/x86_64/boot/bzImage /out/kernel; \
         ;; \
@@ -217,7 +217,7 @@ RUN tar -zxvf /tmp/rtl8821CU.tgz --strip-components=1 && \
     rm /tmp/rtl8821CU.tgz
 
 WORKDIR /linux
-RUN if [ "${TARGET_ARCH}" != riscv64 ]; then \
+RUN if [ "${EVE_TARGET_ARCH}" != riscv64 ]; then \
         make -j "$(getconf _NPROCESSORS_ONLN)" -C /tmp/rtl8821CU KSRC=/linux CROSS_COMPILE="${CROSS_COMPILE_ENV}" ARCH="${KERNEL_ARCH}" modules && \
         install -D -p -m 644 /tmp/rtl8821CU/8821cu.ko $(echo /tmp/kernel-modules/lib/modules/*)/kernel/drivers/net/wireless/realtek/rtl8821cu/8821cu.ko ;\
     fi
@@ -225,10 +225,10 @@ RUN if [ "${TARGET_ARCH}" != riscv64 ]; then \
 WORKDIR /linux
 
 # Strip at least some of the modules to conserve space
-RUN [ "${TARGET_ARCH}" = x86_64 ] || "${CROSS_COMPILE_ENV}strip" --strip-debug `find /tmp/kernel-modules/lib/modules -name \*.ko`
+RUN [ "${EVE_TARGET_ARCH}" = x86_64 ] || "${CROSS_COMPILE_ENV}strip" --strip-debug `find /tmp/kernel-modules/lib/modules -name \*.ko`
 
 # Device Tree Blobs
-RUN [ "${TARGET_ARCH}" = x86_64 ] || make INSTALL_DTBS_PATH=/tmp/kernel-modules/boot/dtb CROSS_COMPILE="${CROSS_COMPILE_ENV}" ARCH="${KERNEL_ARCH}" dtbs_install
+RUN [ "${EVE_TARGET_ARCH}" = x86_64 ] || make INSTALL_DTBS_PATH=/tmp/kernel-modules/boot/dtb CROSS_COMPILE="${CROSS_COMPILE_ENV}" ARCH="${KERNEL_ARCH}" dtbs_install
 
 # Package all the modules up
 # hadolint ignore=SC2086

--- a/pkg/new-kernel/Dockerfile
+++ b/pkg/new-kernel/Dockerfile
@@ -7,7 +7,7 @@ ARG BUILD_PKGS_BASE="argp-standalone automake bash bc binutils-dev bison build-b
                      attr-dev autoconf file coreutils libtirpc-dev libtool util-linux-dev"
 
 # we use the same image in several places
-ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:b8b32c8353e50d7131d9ddc912581d14923806b0
+ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:9fb9b9cbf7d90066a70e4704d04a6fe248ff52bb
 
 # hadolint ignore=DL3006
 FROM ${EVE_ALPINE_IMAGE} as kernel-build-base-native


### PR DESCRIPTION
This is part 3; for part 1 (and links to the other parts), see: https://github.com/lf-edge/eve/pull/3070

1. Bumping the eve-alpine image for pkg/new-kernel which has go version 1.20.1
2. Follow-up renaming TARGET_ARCH/BUILD_ARCH into EVE_TARGE_ARCH and EVE_BUILD_ARCH for pkg/new-kernel