### PR TITLE
fix measure-config package

### DIFF
--- a/pkg/measure-config/go.mod
+++ b/pkg/measure-config/go.mod
@@ -1,4 +1,4 @@
-module github.com/measure-config
+module github.com/lf-edge/eve/pkg/measure-config
 
 go 1.20
 


### PR DESCRIPTION
The measure-config package was shown as at `github.com/measure-config`, when it should be its proper path at `github.com/lf-edge/eve/pkg/measure-config`.