### PR TITLE
eve-alpine: remove stage 0 step for go 1.20.1

### DIFF
--- a/pkg/alpine/Dockerfile
+++ b/pkg/alpine/Dockerfile
@@ -1,6 +1,6 @@
 # image was bootstraped using FROM lfedge/eve-alpine-base:f11c7a5dcffe1ab7b466bea7e26010a27da62b3b AS cache
 # to update please see https://github.com/lf-edge/eve/blob/master/docs/BUILD.md#how-to-update-eve-alpine-package
-FROM lfedge/eve-alpine:145f062a40639b6c65efa36bed1c5614b873be52 AS cache
+FROM lfedge/eve-alpine:9fb9b9cbf7d90066a70e4704d04a6fe248ff52bb AS cache
 
 ARG ALPINE_VERSION=3.16
 # this is only needed once, when this package
@@ -13,9 +13,6 @@ COPY Dockerfile abuild.conf /etc/
 COPY mirrors /tmp/mirrors/
 COPY build-cache.sh /bin/
 
-RUN mkdir -vp "/mirror/edge/$(apk --print-arch)"
-# download newest go=1.20.1 from alpine/edge repository
-RUN wget -q "http://dl-cdn.alpinelinux.org/alpine/edge/community/$(apk --print-arch)/go-1.20.1-r0.apk" -O "/mirror/edge/$(apk --print-arch)/go-1.20.1-r0.apk"
 # install abuild for signing (which requires gcc as well)
 RUN apk add --no-cache abuild gcc sudo
 


### PR DESCRIPTION
In order to update to go 1.20.1 lines to the dockerfile were added to download go from edge/community from alpine.
Unfortunately the package for aarch64 has been removed, but fortunately it is still in our /mirror directory. So the solution is to base this image on the eve-alpine image that has an up-to-date /mirror directory and remove downloading go version 1.20.1 and rely only on /mirror

To check that the go 1.20.1 apk is indeed in our mirror, one can execute:
`skopeo copy --multi-arch all docker://docker.io/lfedge/eve-alpine:9fb9b9cbf7d90066a70e4704d04a6fe248ff52bb oci-archive:image.tar; tar xvf image.tar; tar tvf blobs/sha256//1e13bbbb82c4c2994dce25902557517e2d5429ec9693b383c61c5c4f08c975c4 | grep go-1.20.1`