### PR TITLE
Switch to miekg/dns 

### DIFF
--- a/pkg/pillar/devicenetwork/dns.go
+++ b/pkg/pillar/devicenetwork/dns.go
@@ -5,13 +5,32 @@ package devicenetwork
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/miekg/dns"
 )
 
 // ResolveConfDirs : directories where resolv.conf for an interface could be found.
 var ResolveConfDirs = []string{"/run/dhcpcd/resolv.conf", "/run/wwan/resolv.conf"}
+
+const (
+	// DNSMaxParallelRequests is the maximum amount of parallel DNS requests
+	DNSMaxParallelRequests     = 5
+	maxTTLSec              int = 3600
+	dnsTimeout                 = 30 * time.Second
+)
+
+// DNSResponse represents a response from a DNS server (A Record)
+type DNSResponse struct {
+	IP  net.IP
+	TTL uint32
+}
 
 // IfnameToResolvConf : Look for a file created by dhcpcd
 func IfnameToResolvConf(ifname string) string {
@@ -38,4 +57,122 @@ func ResolvConfToIfname(resolvConf string) string {
 		}
 	}
 	return ""
+}
+
+// ResolveWithSrcIP resolves a domain with a given dns server and source Ip
+func ResolveWithSrcIP(domain string, dnsServerIP net.IP, srcIP net.IP) ([]DNSResponse, error) {
+	var response []DNSResponse
+	sourceUDPAddr := net.UDPAddr{IP: srcIP}
+	dialer := net.Dialer{LocalAddr: &sourceUDPAddr}
+	dnsClient := dns.Client{Dialer: &dialer}
+	msg := dns.Msg{}
+	if domain[len(domain)-1] != '.' {
+		domain = domain + "."
+	}
+	msg.SetQuestion(domain, dns.TypeA)
+	dnsClient.Timeout = time.Duration(dnsTimeout)
+	reply, _, err := dnsClient.Exchange(&msg, net.JoinHostPort(dnsServerIP.String(), "53"))
+	if err != nil {
+		return response, fmt.Errorf("dns exchange failed: %v", err)
+	}
+	for _, answer := range reply.Answer {
+		if aRecord, ok := answer.(*dns.A); ok {
+			response = append(response, DNSResponse{
+				IP:  aRecord.A,
+				TTL: aRecord.Header().Ttl,
+			})
+		}
+	}
+
+	return response, nil
+}
+
+// ResolveWithPortsLambda resolves a domain by using source IPs and dns servers from DeviceNetworkStatus
+// As a resolver func ResolveWithSrcIP can be used
+func ResolveWithPortsLambda(domain string,
+	dns types.DeviceNetworkStatus,
+	resolve func(string, net.IP, net.IP) ([]DNSResponse, error)) ([]DNSResponse, []error) {
+
+	quit := make(chan struct{})
+	work := make(chan struct{}, DNSMaxParallelRequests)
+	resolvedIPsChan := make(chan []DNSResponse)
+	countDNSRequests := 0
+	var errs []error
+	var errsMutex sync.Mutex
+	var wg sync.WaitGroup
+
+	for _, port := range dns.Ports {
+		if port.Cost > 0 {
+			continue
+		}
+
+		var srcIPs []net.IP
+		for _, addrInfo := range port.AddrInfoList {
+			srcIPs = append(srcIPs, addrInfo.Addr)
+		}
+
+		for _, dnsIP := range port.DNSServers {
+			for _, srcIP := range srcIPs {
+				wg.Add(1)
+				dnsIPCopy := make(net.IP, len(dnsIP))
+				copy(dnsIPCopy, dnsIP)
+				srcIPCopy := make(net.IP, len(srcIP))
+				copy(srcIPCopy, srcIP)
+				countDNSRequests++
+				go func(dnsIP, srcIP net.IP) {
+					select {
+					case work <- struct{}{}:
+						// if writable, means less than dnsMaxParallelRequests goroutines are currently running
+					}
+					select {
+					case <-quit:
+						// will return in case the quit chan has been closed,
+						// meaning another dns server already resolved the IP
+						return
+					default:
+						// do not wait for receiving a quit
+					}
+					response, err := resolve(domain, dnsIP, srcIP)
+					if err != nil {
+						errsMutex.Lock()
+						defer errsMutex.Unlock()
+						errs = append(errs, err)
+					}
+					if response != nil {
+						resolvedIPsChan <- response
+					}
+					<-work
+					wg.Done()
+				}(dnsIPCopy, srcIPCopy)
+			}
+		}
+	}
+
+	wgChan := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(wgChan)
+	}()
+
+	select {
+	case <-wgChan:
+		var responses []DNSResponse
+		if countDNSRequests == 0 {
+			// fallback in case no resolver is configured
+			ips, err := net.LookupIP(domain)
+			if err != nil {
+				return nil, append(errs, fmt.Errorf("fallback resolver failed: %+v", err))
+			}
+			for _, ip := range ips {
+				responses = append(responses, DNSResponse{
+					IP:  ip,
+					TTL: uint32(maxTTLSec),
+				})
+			}
+		}
+		return responses, nil
+	case ip := <-resolvedIPsChan:
+		close(quit)
+		return ip, errs
+	}
 }

--- a/pkg/pillar/devicenetwork/dns_test.go
+++ b/pkg/pillar/devicenetwork/dns_test.go
@@ -1,0 +1,201 @@
+// Copyright (c) 2023 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package devicenetwork_test
+
+import (
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/devicenetwork"
+	"github.com/lf-edge/eve/pkg/pillar/netmonitor"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+func createNetmonitorMockInterface() []netmonitor.MockInterface {
+	mockInterface := []netmonitor.MockInterface{
+		{
+			Attrs: netmonitor.IfAttrs{
+				IfIndex: 0,
+				IfName:  "if0",
+			},
+			IPAddrs: []*net.IPNet{
+				{
+					IP:   []byte{192, 168, 0, 1},
+					Mask: []byte{255, 255, 255, 0},
+				},
+				{
+					IP:   []byte{192, 168, 0, 2},
+					Mask: []byte{255, 255, 255, 0},
+				},
+			},
+			HwAddr: []byte{},
+			DNS: netmonitor.DNSInfo{
+				ResolvConfPath: "/etc/resolv.conf",
+				Domains:        []string{},
+				DNSServers: []net.IP{
+					{208, 67, 220, 220},
+					{208, 67, 222, 222},
+					{141, 1, 1, 1},
+					{1, 1, 1, 1},
+					{9, 9, 9, 9},
+				},
+			},
+		},
+		{
+			Attrs: netmonitor.IfAttrs{
+				IfIndex: 1,
+				IfName:  "if1",
+			},
+			IPAddrs: []*net.IPNet{
+				{
+					IP:   []byte{192, 168, 1, 1},
+					Mask: []byte{255, 255, 255, 0},
+				},
+				{
+					IP:   []byte{192, 168, 1, 2},
+					Mask: []byte{255, 255, 255, 0},
+				},
+			},
+			HwAddr: []byte{},
+			DNS: netmonitor.DNSInfo{
+				ResolvConfPath: "/etc/resolv.conf",
+				Domains:        []string{},
+				DNSServers: []net.IP{
+					{1, 0, 0, 1},
+					{8, 8, 8, 8},
+				},
+			},
+		},
+		{
+			Attrs: netmonitor.IfAttrs{
+				IfIndex: 2,
+				IfName:  "ExpensiveIf",
+			},
+			IPAddrs: []*net.IPNet{{
+				IP:   []byte{6, 6, 6, 6},
+				Mask: []byte{255, 255, 255, 0},
+			}},
+			HwAddr: []byte{},
+			DNS: netmonitor.DNSInfo{
+				ResolvConfPath: "/etc/resolv.conf",
+				Domains:        []string{},
+				DNSServers: []net.IP{
+					{0, 6, 6, 6},
+					{0, 7, 7, 7},
+				},
+			},
+		},
+	}
+	return mockInterface
+}
+
+func createDeviceNetworkStatus() types.DeviceNetworkStatus {
+	mockInterface := createNetmonitorMockInterface()
+	deviceNetworkStatusPorts := make([]types.NetworkPortStatus, len(mockInterface))
+	for i := range deviceNetworkStatusPorts {
+		deviceNetworkStatusPorts[i].IfName = mockInterface[i].Attrs.IfName
+		deviceNetworkStatusPorts[i].DNSServers = mockInterface[i].DNS.DNSServers
+		addrInfos := make([]types.AddrInfo, len(mockInterface[i].IPAddrs))
+		for j := range mockInterface[i].IPAddrs {
+			addrInfos[j] = types.AddrInfo{
+				Addr: mockInterface[i].IPAddrs[j].IP,
+			}
+		}
+
+		deviceNetworkStatusPorts[i].AddrInfoList = addrInfos
+	}
+
+	deviceNetworkStatus := types.DeviceNetworkStatus{
+		CurrentIndex: 0,
+		Ports:        deviceNetworkStatusPorts,
+	}
+	return deviceNetworkStatus
+}
+
+func TestDnsResolve(t *testing.T) {
+	t.Parallel()
+
+	testHost := "255.255.255.255.nip.io"
+	expectedIP := net.IP{255, 255, 255, 255}
+	if testing.Short() {
+		t.Skipf(
+			"Skipping as connecting to the internet would take too much time and short tests are enabled",
+		)
+	}
+
+	res, errs := devicenetwork.ResolveWithSrcIP(testHost, net.IP{1, 1, 1, 1}, net.IP{0, 0, 0, 0})
+	if errs != nil {
+		panic(errs)
+	}
+	if res == nil {
+		t.Skipf(
+			"could not resolve, skipping as probably the tests don't have internet connection of %s is down",
+			testHost,
+		)
+	}
+	if !res[0].IP.Equal(expectedIP) {
+		t.Fatalf(
+			"resolving returned wrong IP address %+v, but should have been %+v",
+			res,
+			expectedIP,
+		)
+	}
+}
+
+func TestDnsResolveTimeout(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skipf("Skipping as timing out would take too much time and short tests are enabled")
+	}
+	exampleCom := net.IP{93, 184, 216, 34} // example.com, they drop packets on 53/udp
+	res, _ := devicenetwork.ResolveWithSrcIP("www.google.com", exampleCom, net.IP{0, 0, 0, 0})
+	if res != nil {
+		t.Fatalf("resolving with dns server %+v should fail, but succeeded: %+v", exampleCom, res)
+	}
+}
+
+func TestResolveWithPortsLambda(t *testing.T) {
+	t.Parallel()
+
+	expectedIP := net.IP{1, 2, 3, 4}
+
+	var first atomic.Bool
+	first.Store(true)
+	var countCalls atomic.Int32
+	resolverFunc := func(domain string, dnsServer net.IP, srcIP net.IP) ([]devicenetwork.DNSResponse, error) {
+		countCalls.Add(1)
+		if !first.Swap(false) {
+			time.Sleep(1 * time.Second)
+			return []devicenetwork.DNSResponse{}, nil
+		}
+		return []devicenetwork.DNSResponse{
+			{
+				IP:  expectedIP,
+				TTL: 3600,
+			},
+		}, nil
+	}
+
+	deviceNetworkStatus := createDeviceNetworkStatus()
+	res, err := devicenetwork.ResolveWithPortsLambda(
+		"example.com",
+		deviceNetworkStatus,
+		resolverFunc,
+	)
+	if err != nil {
+		panic(err)
+	}
+	if !res[0].IP.Equal(expectedIP) {
+		t.Errorf("wrong result, expected IP 1.2.3.4, but got: %+v", res)
+	}
+	if countCalls.Load() > devicenetwork.DNSMaxParallelRequests+1 {
+		// checking for +1 as the first call immediately returns
+		t.Errorf(
+			"more calls to resolverFunc than dnsMaxParallelRequests+1, but first call should already succeed",
+		)
+	}
+}


### PR DESCRIPTION
1. prepare by splitting controllerDNSCache into pieces to make it more readable
2. switch from go-dns-resolver to miekg/dns
 
    this allows us to set the source interface when doing
    DNS requests
    
    go-dns-resolver itself is using miekg/dns under the hood,
    so now nim is using it directly instead