### PR TITLE
downloader: Add the image URL into the error message.

### DIFF
--- a/pkg/pillar/cmd/downloader/oci.go
+++ b/pkg/pillar/cmd/downloader/oci.go
@@ -15,11 +15,12 @@ func ociRepositorySplit(image string) (string, string, error) {
 	var registry, path string
 	imageURL, err := url.Parse(image)
 	if err != nil {
-		return registry, path, fmt.Errorf("invalid image URL: %v", err)
+		return registry, path, fmt.Errorf("invalid image URL: %s, %v", image, err)
 	}
 
 	if imageURL.Scheme != "docker" && imageURL.Scheme != "oci" {
-		return registry, path, fmt.Errorf("unknown OCI registry scheme %s", imageURL.Scheme)
+		return registry, path, fmt.Errorf("unknown OCI registry scheme %s, original URL: %s", imageURL.Scheme,
+			image)
 	}
 
 	// remove any leading slash on the path, as that can mess things up

--- a/pkg/pillar/cmd/downloader/resolveconfig.go
+++ b/pkg/pillar/cmd/downloader/resolveconfig.go
@@ -231,7 +231,7 @@ func resolveTagsToHash(ctx *downloaderContext, rc types.ResolveConfig,
 		// get the name of the repository and the URL for the registry
 		serverURL, remoteName, err = ociRepositorySplit(dsCtx.DownloadURL)
 		if err != nil {
-			errStr = fmt.Sprintf("invalid OCI registry URL: %s", serverURL)
+			errStr = fmt.Sprintf("invalid OCI registry URL: %s", err.Error())
 		}
 
 	default:

--- a/pkg/pillar/cmd/downloader/syncop.go
+++ b/pkg/pillar/cmd/downloader/syncop.go
@@ -81,7 +81,7 @@ func handleSyncOp(ctx *downloaderContext, key string,
 		// get the name of the repository and the URL for the registry
 		serverURL, remoteName, err = ociRepositorySplit(dsCtx.DownloadURL)
 		if err != nil {
-			errStr = fmt.Sprintf("invalid OCI registry URL: %s", serverURL)
+			errStr = fmt.Sprintf("invalid OCI registry URL: %s", err.Error())
 		}
 	case zconfig.DsType_DsS3.String():
 		auth = &zedUpload.AuthInput{


### PR DESCRIPTION
In the case the URL of the image cannot be parsed for any reason, put it to the error message, so the user can see what can be the issue.