### PR TITLE
Fix newlogd crash due to VM's console output

### DIFF
--- a/pkg/newlog/cmd/newlogd.go
+++ b/pkg/newlog/cmd/newlogd.go
@@ -595,7 +595,7 @@ func getMemlogMsg(logChan chan inputEntry, panicFileChan chan []byte) {
 		if !isApp && logInfo.Source == "" {
 			logInfo.Source = sourceName
 		}
-		if logInfo.Time == "" && strings.HasSuffix(msgTime, "Z") {
+		if logInfo.Time == "" {
 			logInfo.Time = msgTime
 		}
 		if logInfo.Pid != 0 {
@@ -762,7 +762,7 @@ func writelogFile(logChan <-chan inputEntry, moveChan chan fileChanInfo) {
 			if appuuid != "" {
 				appM = getAppStatsMap(appuuid)
 			}
-			timeS := getPtypeTimestamp(entry.timestamp)
+			timeS, _ := getPtypeTimestamp(entry.timestamp)
 			mapLog := logs.LogEntry{
 				Severity:  entry.severity,
 				Source:    entry.source,
@@ -1575,13 +1575,13 @@ func getDevTop10Inputs() {
 	devSourceBytes = base.NewLockedStringMap()
 }
 
-func getPtypeTimestamp(timeStr string) *timestamp.Timestamp {
+func getPtypeTimestamp(timeStr string) (*timestamp.Timestamp, error) {
 	t, err := time.Parse(time.RFC3339, timeStr)
 	if err != nil {
-		log.Fatal(err)
+		t = time.Unix(0, 0)
 	}
 	tt := &timestamp.Timestamp{Seconds: t.Unix(), Nanos: int32(t.Nanosecond())}
-	return tt
+	return tt, err
 }
 
 // get total MBytes in '/persist' partition on device

--- a/pkg/newlog/cmd/newlogd.go
+++ b/pkg/newlog/cmd/newlogd.go
@@ -764,10 +764,6 @@ func writelogFile(logChan <-chan inputEntry, moveChan chan fileChanInfo) {
 
 		case entry := <-logChan:
 			appuuid := checkAppEntry(&entry)
-			var appM statsLogFile
-			if appuuid != "" {
-				appM = getAppStatsMap(appuuid)
-			}
 			timeS, _ := getPtypeTimestamp(entry.timestamp)
 			mapLog := logs.LogEntry{
 				Severity:  entry.severity,
@@ -782,13 +778,11 @@ func writelogFile(logChan <-chan inputEntry, moveChan chan fileChanInfo) {
 			mapJentry, _ := json.Marshal(&mapLog)
 			logline := string(mapJentry) + "\n"
 			if appuuid != "" {
+				appM := getAppStatsMap(appuuid)
 				len := writelogEntry(&appM, logline)
-
 				logmetrics.AppMetrics.NumBytesWrite += uint64(len)
-				appStatsMap[appuuid] = appM
 
 				trigMoveToGzip(fileinfo, &appM, appuuid, moveChan, false)
-
 			} else {
 				len := writelogEntry(&devStats, logline)
 				updateDevInputlogStats(entry.source, uint64(len))


### PR DESCRIPTION
This PR fixes the issue: https://github.com/lf-edge/eve/issues/3090 (see issue for context and discussion)

pkg: newlog: Do not crash on a bad timestamp
    
    Formatted log messages (coming from memlogd, for instance) are suppose to
    have a timestamp in the RFC 3339 standard. In this format, dates can be
    represented through different ways. For example, the strings below
    represent the same date:
    
    2020-12-31T21:07:14-05:00
    2021-01-01T02:07:14Z
    
    The Z character in the second one means UTC time. In getMemlogMsg(), if
    ParseLogInfo() was not able to get the timestamp, the one used in the
    original message will be used. However, it assumes only the second format
    (with suffix Z). This commit removes this assumption and let the timestamp
    to be parsed in getPtypeTimeStamp(). If it fails, it considers Unix default
    (initial) time as the timestamp.
    

    
pkg: newlog: Do not parse application's console as JSON log messages
    
    The output console from an application VM can be logged, i.e., have
    contents sent from memlogd to newlogd container. In this case, it should
    not be parsed as a JSON log message.
    
    This commit removes the calling of ParseLogInfo() for any log message
    coming from an application and treat it as a normal log message. Also, it
    searches for "guest_vm" only in the field source of the log message.
    Otherwise, any JSON log message containing the string "guest_vm" would be
    considered as an application's log message.

 pkg: newlog: make a small improvement
    
    This commit makes a small improvement in newlogd.go:
    
    - Agregate two ifs into one: getAppStatsMap() must be called only if
      appuuid is not null
    - Remove redundant attribution: getAppStatsMap() already attributes the
      found item to the map ("appStatsMap[appuuid] = appM") inside the
      function
