### PR TITLE
Makefile: Increase the size of the live image.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ HV=$(HV_DEFAULT)
 # Enable development build (disabled by default)
 DEV=n
 # How large to we want the disk to be in Mb
-MEDIA_SIZE=8192
+MEDIA_SIZE=32768
 # Image type for final disk images
 IMG_FORMAT=qcow2
 # Filesystem type for rootfs image


### PR DESCRIPTION
The MEDIA_SIZE variable is used to define the size of the disk to be used on the EVE live start (`make run`). 8Gb is too small disk for most of the VMs that run Ubuntu, so we can increase the default size to make it usable.