### PR TITLE
debug/scripts: introduce a set of scripts for collecting info

### DIFF
--- a/pkg/debug/scripts/collect-info.sh
+++ b/pkg/debug/scripts/collect-info.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+#
+# This script is used to collect all info from the machine which
+# helps to debug and resolve EVE issues.
+#
+
+DATE=$(date -Is)
+INFO_DIR="eve-info-$DATE"
+TARBALL_FILE="/persist/$INFO_DIR.tar.gz"
+
+# Create temporary dir
+TMP_DIR=$(mktemp -d)
+DIR="$TMP_DIR/$INFO_DIR"
+mkdir -p "$DIR"
+mkdir -p "$DIR/network"
+
+# Install GNU version of the 'ps' and other tools
+apk add procps dmidecode >/dev/null 2>&1
+
+collect_network_info()
+{
+    # Install missing tools
+    apk add iptables dhcpcd >/dev/null 2>&1
+
+    ifconfig       > "$DIR/network/ifconfig"
+    ip -s link     > "$DIR/network/ip-s-link"
+    arp -n         > "$DIR/network/arp-n"
+    netstat -tuapn > "$DIR/network/netstat-tuapn"
+
+    ip route show table all \
+                   > "$DIR/network/ip-route-show-table-all"
+    iptables -L -v -n --line-numbers -t raw \
+                   > "$DIR/network/iptables-raw"
+    iptables -L -v -n --line-numbers -t filter \
+                   > "$DIR/network/iptables-filter"
+    iptables -L -v -n --line-numbers -t mangle \
+                   > "$DIR/network/iptables-mangle"
+    iptables -L -v -n --line-numbers -t nat \
+                   > "$DIR/network/iptables-nat"
+
+    for iface in /sys/class/net/*; do
+        iface="${iface##*/}"
+        echo "------ $iface -------"
+        dhcpcd -U -4 "$iface"
+    done > "$DIR/network/dhcpcd-all-ifaces" 2>&1
+}
+
+# Have to chroot, lsusb does not work from this container
+chroot /hostfs lsusb -vvv    > "$DIR/lsusb-vvv"
+chroot /hostfs lsusb -vvv -t > "$DIR/lsusb-vvv-t"
+
+dmesg         > "$DIR/dmesg"
+ps -ef        > "$DIR/ps-ef"
+lspci -vvv    > "$DIR/lspci-vvv"
+lspci -vvv -t > "$DIR/lspci-vvv-t"
+lsblk -a      > "$DIR/lsblk-a"
+lshw          > "$DIR/lshw"
+lsof          > "$DIR/lsof"
+lsmod         > "$DIR/lsmod"
+logread       > "$DIR/logread"
+dmidecode     > "$DIR/dmidecode"
+
+cat /proc/vmallocinfo > "$DIR/vmallocinfo"
+cat /proc/slabinfo    > "$DIR/slabinfo"
+cat /proc/zoneinfo    > "$DIR/zoneinfo"
+cat /proc/mounts      > "$DIR/mounts"
+cat /proc/vmstat      > "$DIR/vmstat"
+cat /proc/cpuinfo     > "$DIR/cpuinfo"
+
+qemu-affinities.sh    > "$DIR/qemu-affinities"
+iommu-groups.sh       > "$DIR/iommu-groups"
+
+cp -r /persist/status  "$DIR/persist-status"
+cp -r /persist/log     "$DIR/persist-log"
+cp -r /persist/newlog  "$DIR/persist-newlog"
+cp -r /persist/netdump "$DIR/persist-netdump" >/dev/null 2>&1
+cp -r /run             "$DIR/run"
+
+# Network part
+collect_network_info
+
+# Make a tarball
+tar -C "$TMP_DIR" -czf "$TARBALL_FILE" "$INFO_DIR" 2>&1 | grep -v 'socket ignored'
+rm -rf "$TMP_DIR"
+sync
+
+echo "EVE info is collected '$TARBALL_FILE'"

--- a/pkg/debug/scripts/iommu-groups.sh
+++ b/pkg/debug/scripts/iommu-groups.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#
+# Output the PCI devices grouped by the IOMMU
+#
+
+for d in /sys/kernel/iommu_groups/*/devices/*; do
+    if [ ! -e "$d" ]; then
+        continue
+    fi
+    n="${d#*/iommu_groups/*}"
+    n="${n%%/*}"
+    printf 'IOMMU Group %s \n--------------\n' "$n"
+    lspci -vmms "${d##*/}" | grep -E "^Slot|^Class|^Vendor|^Device"
+    printf 'IDs:    '
+    lspci -ns "${d##*/}" | awk {print\ \$3}
+    lspci -vmms "${d##*/}" | grep -E "^Rev"
+    printf '\n'
+done

--- a/pkg/debug/scripts/qemu-affinities.sh
+++ b/pkg/debug/scripts/qemu-affinities.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+#
+# Output affinities for each QEMU thread
+#
+
+# We need GNU version of the 'ps' tool
+apk=$(apk add procps 2>&1)
+if [ $? -ne 0 ]; then
+    echo "$apk"
+    exit 1
+fi
+
+for pid in $(pgrep qemu-system); do
+    echo "======= QEMU $pid threads: ======="
+    for spid in $(ps -T -o spid= -p "$pid" ); do
+        taskset -pc "$spid"
+    done
+    echo
+done


### PR DESCRIPTION
Commit introduces a set of scripts, which helps to retrieve useful debug information.

iommu-groups.sh
--------------------------
The script outputs PCI devices grouped by the IOMMU group
    
qemu-affinities.sh
--------------------------
The script outputs affinities of QEMU threads
    
collect-info.sh
--------------------------
This script will be a part of 'debug' container and the main purpose of it is to collect all useful information about the EVE node running in one tar.gz file for further debugging. Ideally script is executed by the one, who maintains the edge node and experiences any problems which can be analysed by the EVE team. 

Script doesn't collect any secrets, but rather logs and system information.

The script should be executed from the debug container, so:

```
# eve enter debug (not needed if there is an SSH access)
# collect-info.sh
```

cc: @milan-zededa 
cc: @mikem-zed 
cc: @christoph-zededa 
cc: @shjala 

Folks, please take a look in the script, what else do we need to be collected?