### PR TITLE
zedrouter: Fix metadata server for switch network instances

### DIFF
--- a/pkg/pillar/cmd/downloader/mdns.go
+++ b/pkg/pillar/cmd/downloader/mdns.go
@@ -119,7 +119,7 @@ func findLocalDsSrc(niItems map[string]interface{}, hostip net.IP) (ifname strin
 	for _, item := range niItems {
 		status := item.(types.NetworkInstanceStatus)
 		if status.IsIpAssigned(hostip) {
-			return status.BridgeName, net.ParseIP(status.BridgeIPAddr)
+			return status.BridgeName, status.BridgeIPAddr
 		}
 	}
 	return "", nil

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -988,8 +988,7 @@ func updateLocalServerMap(getconfigCtx *getconfigContext, localServerURL string)
 	for _, entry := range appNetworkStatuses {
 		appNetworkStatus := entry.(types.AppNetworkStatus)
 		for _, ulStatus := range appNetworkStatus.UnderlayNetworkList {
-			bridgeIP := net.ParseIP(ulStatus.BridgeIPAddr)
-			if bridgeIP == nil {
+			if len(ulStatus.BridgeIPAddr) == 0 {
 				continue
 			}
 			if localServerIP != nil {
@@ -997,7 +996,7 @@ func updateLocalServerMap(getconfigCtx *getconfigContext, localServerURL string)
 				if ulStatus.AllocatedIPv4Addr == localServerIP.String() {
 					srvAddr := localServerAddr{
 						localServerAddr: localServerURL,
-						bridgeIP:        bridgeIP,
+						bridgeIP:        ulStatus.BridgeIPAddr,
 						appUUID:         appNetworkStatus.UUIDandVersion.UUID,
 					}
 					srvMap.servers[ulStatus.Bridge] = append(srvMap.servers[ulStatus.Bridge], srvAddr)
@@ -1019,7 +1018,7 @@ func updateLocalServerMap(getconfigCtx *getconfigContext, localServerURL string)
 							localServerURLReplaced, ulStatus.Bridge)
 						srvAddr := localServerAddr{
 							localServerAddr: localServerURLReplaced,
-							bridgeIP:        bridgeIP,
+							bridgeIP:        ulStatus.BridgeIPAddr,
 							appUUID:         appNetworkStatus.UUIDandVersion.UUID,
 						}
 						srvMap.servers[ulStatus.Bridge] = append(srvMap.servers[ulStatus.Bridge], srvAddr)

--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -99,7 +99,9 @@ func prepareAndPublishNetworkInstanceInfoMsg(ctx *zedagentContext,
 
 		info.BridgeNum = uint32(status.BridgeNum)
 		info.BridgeName = status.BridgeName
-		info.BridgeIPAddr = status.BridgeIPAddr
+		if len(status.BridgeIPAddr) > 0 {
+			info.BridgeIPAddr = status.BridgeIPAddr.String()
+		}
 
 		for mac, addrs := range status.IPAssignments {
 			assignment := new(zinfo.ZmetIPAssignmentEntry)

--- a/pkg/pillar/cmd/zedrouter/dnsmasq_test.go
+++ b/pkg/pillar/cmd/zedrouter/dnsmasq_test.go
@@ -33,7 +33,7 @@ func init() {
 type dnsmasqConfigletParams struct {
 	ctx          *zedrouterContext
 	bridgeName   string
-	bridgeIPAddr string
+	bridgeIPAddr net.IP
 	netstatus    *types.NetworkInstanceStatus
 	hostsDir     string
 	ipsetHosts   []string
@@ -46,7 +46,7 @@ func exampleDnsmasqConfigletParams() dnsmasqConfigletParams {
 	var dcp dnsmasqConfigletParams
 
 	dcp.bridgeName = "br0"
-	dcp.bridgeIPAddr = "10.0.0.1"
+	dcp.bridgeIPAddr = net.IP{10, 0, 0, 1}
 
 	var netstatus types.NetworkInstanceStatus
 	netstatus.DhcpRange.Start = net.IP{10, 0, 0, 2}
@@ -67,7 +67,9 @@ func exampleDnsmasqConfigletParams() dnsmasqConfigletParams {
 func runCreateDnsmasqConfiglet(dcp dnsmasqConfigletParams) string {
 	var buf bytes.Buffer
 
-	createDnsmasqConfigletToWriter(&buf, dcp.ctx, dcp.bridgeName, dcp.bridgeIPAddr, dcp.netstatus, dcp.hostsDir, dcp.ipsetHosts, dcp.uplink, dcp.dnsServers, dcp.ntpServers)
+	createDnsmasqConfigletToWriter(&buf, dcp.ctx, dcp.bridgeName, dcp.bridgeIPAddr,
+		dcp.netstatus, dcp.hostsDir, dcp.ipsetHosts, dcp.uplink, dcp.dnsServers,
+		dcp.ntpServers)
 
 	return buf.String()
 }

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -1296,7 +1296,7 @@ func appNetworkDoActivateUnderlayNetwork(
 	newIpsets, staleIpsets, restartDnsmasq := diffIpsets(ipsets,
 		netInstStatus.BridgeIPSets)
 
-	if restartDnsmasq && ulStatus.BridgeIPAddr != "" {
+	if restartDnsmasq && !isEmptyIP(ulStatus.BridgeIPAddr) {
 		stopDnsmasq(bridgeName, true, false)
 		dnsServers := types.GetDNSServers(*ctx.deviceNetworkStatus,
 			netInstStatus.SelectedUplinkIntf)
@@ -1772,7 +1772,7 @@ func doAppNetworkModifyUNetAcls(
 	newIpsets, staleIpsets, restartDnsmasq := diffIpsets(ipsets,
 		netstatus.BridgeIPSets)
 
-	if restartDnsmasq && ulStatus.BridgeIPAddr != "" {
+	if restartDnsmasq && !isEmptyIP(ulStatus.BridgeIPAddr) {
 		hostsDirpath := runDirname + "/hosts." + bridgeName
 		stopDnsmasq(bridgeName, true, false)
 		dnsServers := types.GetDNSServers(*ctx.deviceNetworkStatus,
@@ -2018,7 +2018,7 @@ func appNetworkDoInactivateUnderlayNetwork(
 	newIpsets, staleIpsets, restartDnsmasq := diffIpsets(ipsets,
 		netstatus.BridgeIPSets)
 
-	if restartDnsmasq && ulStatus.BridgeIPAddr != "" {
+	if restartDnsmasq && !isEmptyIP(ulStatus.BridgeIPAddr) {
 		stopDnsmasq(bridgeName, true, false)
 		dnsServers := types.GetDNSServers(*ctx.deviceNetworkStatus,
 			netstatus.SelectedUplinkIntf)

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -2055,7 +2055,7 @@ type UnderlayNetworkStatus struct {
 	ACLs int // drop ACLs field from UnderlayNetworkConfig
 	VifInfo
 	BridgeMac         net.HardwareAddr
-	BridgeIPAddr      string   // The address for DNS/DHCP service in zedrouter
+	BridgeIPAddr      net.IP   // The address for DNS/DHCP service in zedrouter
 	AllocatedIPv4Addr string   // Assigned to domU
 	AllocatedIPv6List []string // IPv6 addresses assigned to domU
 	IPv4Assigned      bool     // Set to true once DHCP has assigned it to domU
@@ -2201,7 +2201,7 @@ type AssignedAddrs struct {
 type NetworkInstanceInfo struct {
 	BridgeNum     int
 	BridgeName    string // bn<N>
-	BridgeIPAddr  string
+	BridgeIPAddr  net.IP
 	BridgeMac     string
 	BridgeIfindex int
 
@@ -2233,7 +2233,7 @@ type NetworkInstanceInfo struct {
 	NumTrunkPorts uint32
 
 	// IP address on which the meta-data server listens
-	MetaDataServerIP string
+	MetaDataServerIP net.IP
 }
 
 func (instanceInfo *NetworkInstanceInfo) IsVifInBridge(
@@ -2674,7 +2674,7 @@ type AppNetworkACLArgs struct {
 	IPVer      int
 	BridgeName string
 	VifName    string
-	BridgeIP   string
+	BridgeIP   net.IP
 	AppIP      string
 	UpLinks    []string // List of ifnames
 	NIType     NetworkInstanceType


### PR DESCRIPTION
`createServer4` expects bridge IP address without prefix length, but this wasn't the case with switch network instances. This (rather old) bug was introduced because we used `string` instead of `net.IP` for the data type and therefore it wasn't clear what is the expected value. In order to avoid the confusion, I have also changed the type to `net.IP`. An additional bonus is that we avoid some `net.ParseIP` calls repeatedly made across zedrouter.