### PR TITLE
Have SenderStatusCertMiss trigger fetching certs in attest case

### DIFF
--- a/pkg/pillar/attest/attest_test.go
+++ b/pkg/pillar/attest/attest_test.go
@@ -106,7 +106,7 @@ func initTest() *Context {
 		event:        EventInitialize,
 		state:        StateNone,
 		restartTimer: time.NewTimer(1 * time.Second),
-		eventTrigger: make(chan Event),
+		eventTrigger: make(chan Event, 1),
 		retryTime:    1,
 	}
 	ctx.restartTimer.Stop()

--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -444,8 +444,10 @@ func sendAttestReqProtobuf(attestReq *attest.ZAttestReq, iteration int) {
 	//We queue the message and then get the highest priority message to send.
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
+	// Since attest messages can fail if there is a certificate mismatch
+	// we set ignoreErr to allow other messages to be sent as well.
 	zedcloudCtx.DeferredEventCtx.SetDeferred(deferKey, buf, size, attestURL,
-		false, false, false, attestReq.ReqType)
+		false, false, true, attestReq.ReqType)
 	zedcloudCtx.DeferredEventCtx.HandleDeferred(time.Now(), 0, true)
 }
 

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -508,11 +508,11 @@ func requestConfigByURL(getconfigCtx *getconfigContext, url string,
 		case types.SenderStatusCertInvalid:
 			log.Warnf("getLatestConfig : Controller certificate invalid time")
 		case types.SenderStatusCertMiss:
-			log.Functionf("getLatestConfig : Controller certificate miss")
+			log.Warnf("getLatestConfig : Controller certificate miss")
 		case types.SenderStatusNotFound:
-			log.Functionf("getLatestConfig : Device deleted in controller?")
+			log.Noticef("getLatestConfig : Device deleted in controller?")
 		case types.SenderStatusForbidden:
-			log.Functionf("getLatestConfig : Device integrity token mismatch")
+			log.Warnf("getLatestConfig : Device integrity token mismatch")
 		default:
 			log.Errorf("getLatestConfig  failed: %s", err)
 		}

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -754,8 +754,10 @@ func handleDeferredPeriodicTask(zedagentCtx *zedagentContext) {
 		select {
 		case change := <-zedcloudCtx.DeferredPeriodicCtx.Ticker.C:
 			start := time.Now()
-			zedcloudCtx.DeferredPeriodicCtx.HandleDeferred(
-				change, 100*time.Millisecond, false)
+			if !zedcloudCtx.DeferredPeriodicCtx.HandleDeferred(
+				change, 100*time.Millisecond, false) {
+				log.Noticef("handleDeferredPeriodicTask: some deferred items remain to be sent")
+			}
 			zedagentCtx.ps.CheckMaxTimeTopic(agentName, "deferredPeriodicCtx",
 				start, warningTime, errorTime)
 		case <-stillRunning.C:


### PR DESCRIPTION
In some cases the /config API endpoint might be accessed less frequently than the /attest API endpoint so it makes sense to check for SenderStatusCertMiss and SenderStatusCertInvalid.