### PR TITLE
pillar/zedagent: prevent possible crash if 'locConfig' is set to nil

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -1569,11 +1569,13 @@ func sendMetricsProtobuf(ctx *getconfigContext,
 		devUUID, "metrics")
 	sendMetricsProtobufByURL(ctx, url, ReportMetrics, iteration)
 
+	locConfig := ctx.locConfig
+
 	// Repeat metrics for LOC as well
-	if ctx.locConfig != nil {
+	if locConfig != nil {
 		// Don't block current execution context
 		go func() {
-			url := zedcloud.URLPathString(ctx.locConfig.LocURL, zedcloudCtx.V2API,
+			url := zedcloud.URLPathString(locConfig.LocURL, zedcloudCtx.V2API,
 				devUUID, "metrics")
 			sendMetricsProtobufByURL(ctx, url, ReportMetrics, iteration)
 		}()


### PR DESCRIPTION
There is a possible race between checking the locConfig variable and passing it to the function which does not expect nil.

This patch fixes possible crash if config re-fetched, locConfig is set to nil but goroutine was scheduled for execution.

To prevent a crash use cached value.