### PR TITLE
Set max ashift to 4K

### DIFF
--- a/pkg/dom0-ztools/rootfs/etc/init.d/000-mod-params
+++ b/pkg/dom0-ztools/rootfs/etc/init.d/000-mod-params
@@ -14,6 +14,7 @@ set_module_parameter() {
 zfs_set_default_parameters() {
     set_module_parameter zfs zfs_compressed_arc_enabled 0
     set_module_parameter zfs zfs_vdev_min_auto_ashift 12
+    set_module_parameter zfs zfs_vdev_max_auto_ashift 12
     set_module_parameter zfs zvol_request_sync 0
     set_module_parameter zfs zfs_vdev_aggregation_limit_non_rotating $((1024*1024))
     set_module_parameter zfs zfs_vdev_async_write_active_min_dirty_percent 10


### PR DESCRIPTION
Set max auto ashift to 4K. This will ensure ashift is always set to 4K irrespective of the block size supported by the physical device.

Testing done
============
Compiled.

Tested that parameter is set.

Before fix
========
(ns: pillar) 5e2b3989-174a-450f-ad73-47b021784f28:/sys/module/zfs/parameters# cat zfs_vdev_min_auto_ashift
12
(ns: pillar) 5e2b3989-174a-450f-ad73-47b021784f28:/sys/module/zfs/parameters# cat zfs_vdev_max_auto_ashift
16

After Fix
=======
5e2b3989-174a-450f-ad73-47b021784f28:/sys/module/zfs/parameters# cat zfs_vdev_min_auto_ashift
12
5e2b3989-174a-450f-ad73-47b021784f28:/sys/module/zfs/parameters# cat zfs_vdev_max_auto_ashift
12
