### PR TITLE
[OPTEE-OS 5/5] bsp-imx: Add support to OPTEE for i.MX8MP

### DIFF
--- a/pkg/bsp-imx/Dockerfile
+++ b/pkg/bsp-imx/Dockerfile
@@ -4,7 +4,10 @@
 ARG BUILD_PKGS_BASE="bash binutils-dev build-base bc bison flex openssl-dev util-linux-dev swig gnutls-dev perl python3 python3-dev py3-setuptools py3-pycryptodome py3-elftools"
 
 # we use the same image in several places
-ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:9fb9b9cbf7d90066a70e4704d04a6fe248ff52bb
+ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:269db59bde11b9acd9a5485c98a7c1383a159613
+
+# OPTEE-OS images
+FROM lfedge/eve-optee-os:150dfb58cd0fc2b781aa8e700d479e369c8cc5e9 AS optee-os
 
 # hadolint ignore=DL3006
 FROM ${EVE_ALPINE_IMAGE} as build-native
@@ -17,7 +20,7 @@ ARG BUILD_PKGS_BASE
 RUN BUILD_PKGS="${BUILD_PKGS_BASE}" eve-alpine-deploy.sh
 
 # hadolint ignore=DL3029
-FROM --platform=${BUILDPLATFORM} lfedge/eve-cross-compilers:2a1d062fce410865e7024a83de327a68e52db26c AS cross-compilers
+FROM --platform=${BUILDPLATFORM} lfedge/eve-cross-compilers:250abc77c8c39664905b66a2673102ec5cd3b056 AS cross-compilers
 
 # will use several packages from target arch and copy them to sysroot
 # hadolint ignore=DL3006
@@ -49,7 +52,7 @@ FROM build-cross-target AS target-riscv64-build-arm64
 # native
 FROM build-native AS target-amd64-build-amd64
 FROM build-native AS target-arm64-build-arm64
-FROM build-native AS target-riscv6-build-riscv64
+FROM build-native AS target-riscv64-build-riscv64
 
 # hadolint ignore=DL3006
 FROM target-${TARGETARCH}-build-${BUILDARCH} AS build
@@ -63,6 +66,7 @@ ENV ATF_TARGETS "imx8mq_evk imx8mp_pollux imx8mp_epc_r3720"
 
 RUN mkdir /uboot-firmwares
 
+COPY --from=optee-os /opteeos_images /opteeos_images
 COPY patches /tmp/patches
 
 # ATF
@@ -71,6 +75,7 @@ WORKDIR /imx-atf
 # imx8mq_evk: last commit from imx_5.4.70_2.3.0 branch
 ENV ATF_COMMIT_imx8mq_evk 15e8ff164a8becfddb76cba2c68eeeae684cb398
 ENV ATF_imx8mq_evk "imx8mq"
+ENV ATF_SPD_imx8mq_evk "none"
 ENV ATF_SRC_imx8mq_evk "imx8mq_evk"
 ENV ATF_UART_imx8mq_evk "0x30860000"
 
@@ -78,12 +83,14 @@ ENV ATF_UART_imx8mq_evk "0x30860000"
 # Revision used by phytec's yocto bsp: lf-5.10.72-2.2.0
 ENV ATF_COMMIT_imx8mp_pollux 5782363f92a2fdf926784449270433cf3ddf44bd
 ENV ATF_imx8mp_pollux "imx8mp"
+ENV ATF_SPD_imx8mp_pollux "opteed"
 ENV ATF_SRC_imx8mp_pollux "pollux"
 ENV ATF_UART_imx8mp_pollux "0x30860000"
 
 # Advantech EPC-R3720
 ENV ATF_COMMIT_imx8mp_epc_r3720 5782363f92a2fdf926784449270433cf3ddf44bd
 ENV ATF_imx8mp_epc_r3720 "imx8mp"
+ENV ATF_SPD_imx8mp_epc_r3720 "opteed"
 ENV ATF_SRC_imx8mp_epc_r3720 "epc-r3720"
 ENV ATF_UART_imx8mp_epc_r3720 "0x30880000"
 
@@ -95,6 +102,7 @@ ADD https://github.com/nxp-imx/imx-atf.git#${ATF_COMMIT_imx8mp_epc_r3720} ${ATF_
 RUN for t in ${ATF_TARGETS}; do \
         [ "$EVE_TARGET_ARCH" != "aarch64" ] && break ;\
         target=$(eval echo \$ATF_${t}) ;\
+        spd=$(eval echo \$ATF_SPD_${t}) ;\
         repo=$(eval echo \$ATF_SRC_${t}) ;\
         uartbase=$(eval echo \$ATF_UART_${t}) ;\
         patchdir=$(eval echo /tmp/patches/atf-${t}) ;\
@@ -105,8 +113,12 @@ RUN for t in ${ATF_TARGETS}; do \
             CROSS_COMPILE="${CROSS_COMPILE_ENV}" \
             IMX_BOOT_UART_BASE="${uartbase}" \
             PLAT=${target} \
+            SPD=${spd} \
             bl31 ;\
-         mv build/${target}/release/bl31.bin /uboot-firmwares/${t}-bl31.bin) ;\
+         [ "$spd" = "none" ] && \
+            mv build/${target}/release/bl31.bin /uboot-firmwares/${t}-bl31.bin || \
+            (mv build/${target}/release/bl31.bin /uboot-firmwares/${t}-bl31-tee.bin && \
+             cp /opteeos_images/${t}/optee.bin /uboot-firmwares/${t}-tee.bin)) ;\
     done
 
 # IMX firmware
@@ -164,8 +176,11 @@ ENV FLASH_OFFSET_imx8mp_epc_r3720 "32"
 RUN for target in ${UBOOT_TARGETS}; do \
         [ "$EVE_TARGET_ARCH" != "aarch64" ] && break ;\
         make CROSS_COMPILE="${CROSS_COMPILE_ENV}" clean && \
-            rm -rf bl31.bin && \
-        cp "${target}"-bl31.bin bl31.bin && \
+            rm -rf bl31*.bin tee.bin && \
+        ([ -f "${target}"-bl31-tee.bin ] && \
+         (cp "${target}"-bl31-tee.bin bl31-tee.bin && \
+          cp "${target}"-tee.bin tee.bin) \
+         || cp "${target}"-bl31.bin bl31.bin) && \
         make CROSS_COMPILE="${CROSS_COMPILE_ENV}" \
             "$(eval echo \$UBOOT_CONFIG_${target})"_defconfig && \
         make CROSS_COMPILE="${CROSS_COMPILE_ENV}" \

--- a/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0019-arm-mach-imx-Add-OPTEE-options-to-Kconfig.patch
+++ b/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0019-arm-mach-imx-Add-OPTEE-options-to-Kconfig.patch
@@ -1,0 +1,43 @@
+From 8761b446824300bb8e5a1f5ae0a0db680ef9f294 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ren=C3=AA=20de=20Souza=20Pinto?= <rene@renesp.com.br>
+Date: Thu, 23 Mar 2023 14:42:45 +0100
+Subject: [PATCH 19/20] arm: mach: imx: Add OPTEE options to Kconfig
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Add options to Kconfig regarding OPTEE image file that can be included in
+u-boot image using BINMAN. The following options are added:
+
+- CONFIG_OPTEE_FIRMWARE_SET
+- CONFIG_OPTEE_FIRMWARE
+
+Signed-off-by: Renê de Souza Pinto <rene@renesp.com.br>
+---
+ arch/arm/mach-imx/Kconfig | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/arch/arm/mach-imx/Kconfig b/arch/arm/mach-imx/Kconfig
+index 9976ab78d0f..12ff5034f4c 100644
+--- a/arch/arm/mach-imx/Kconfig
++++ b/arch/arm/mach-imx/Kconfig
+@@ -14,6 +14,16 @@ config IMX_OPTEE
+ 	help
+ 	 Enable support for OP-TEE
+ 
++config OPTEE_FIRMWARE_SET
++	bool "Include OPTEE firmware image"
++	default y
++	select BINMAN
++
++config OPTEE_FIRMWARE
++	string "Image file name"
++	depends on OPTEE_FIRMWARE_SET
++	default "tee.bin"
++
+ config ROM_UNIFIED_SECTIONS
+ 	bool
+ 
+-- 
+2.39.2
+

--- a/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0020-configs-Enable-OPTEE-image-loading.patch
+++ b/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0020-configs-Enable-OPTEE-image-loading.patch
@@ -1,0 +1,42 @@
+From bb56bdcf90b736524a44e37b7758fb752cbc2441 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ren=C3=AA=20de=20Souza=20Pinto?= <rene@renesp.com.br>
+Date: Thu, 23 Mar 2023 14:55:35 +0100
+Subject: [PATCH 20/20] configs: Enable OPTEE image loading
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Enable OPTEE image loading for the following i.MX8MP platforms:
+
+- phycore-POLLUX board
+- Advantech EPC-R3720
+
+Signed-off-by: Renê de Souza Pinto <rene@renesp.com.br>
+---
+ configs/imx8mp_rsb3720a1_6G_defconfig | 2 ++
+ configs/phycore-imx8mp_defconfig      | 2 ++
+ 2 files changed, 4 insertions(+)
+
+diff --git a/configs/imx8mp_rsb3720a1_6G_defconfig b/configs/imx8mp_rsb3720a1_6G_defconfig
+index b7329a30043..33bc53bdd55 100644
+--- a/configs/imx8mp_rsb3720a1_6G_defconfig
++++ b/configs/imx8mp_rsb3720a1_6G_defconfig
+@@ -144,3 +144,5 @@ CONFIG_EFI_SET_TIME=y
+ CONFIG_EFI_SECURE_BOOT=y
+ CONFIG_SYSINFO=y
+ CONFIG_SYSINFO_SMBIOS=y
++CONFIG_OPTEE_FIRMWARE_SET=y
++CONFIG_OPTEE_FIRMWARE="tee.bin"
+diff --git a/configs/phycore-imx8mp_defconfig b/configs/phycore-imx8mp_defconfig
+index dccffbac970..68048bf5ed9 100644
+--- a/configs/phycore-imx8mp_defconfig
++++ b/configs/phycore-imx8mp_defconfig
+@@ -113,3 +113,5 @@ CONFIG_DM_THERMAL=y
+ CONFIG_IMX_WATCHDOG=y
+ CONFIG_SYSINFO=y
+ CONFIG_SYSINFO_SMBIOS=y
++CONFIG_OPTEE_FIRMWARE_SET=y
++CONFIG_OPTEE_FIRMWARE="tee.bin"
+-- 
+2.39.2
+

--- a/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0021-arm-dts-Remove-binman-node-from-imx8mp-rsb3720-a1-u-.patch
+++ b/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0021-arm-dts-Remove-binman-node-from-imx8mp-rsb3720-a1-u-.patch
@@ -1,0 +1,53 @@
+From 904b0025dc2a950e6ddd0a7c224828c892dd50b9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ren=C3=AA=20de=20Souza=20Pinto?= <rene@renesp.com.br>
+Date: Fri, 24 Mar 2023 14:05:59 +0100
+Subject: [PATCH] arm: dts: Remove binman node from
+ imx8mp-rsb3720-a1-u-boot.dtsi
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The binman node with the expected ATF and OPTEE images is already defined
+at arch/arm/dts/imx8mp-u-boot.dtsi.
+
+Signed-off-by: Renê de Souza Pinto <rene@renesp.com.br>
+---
+ arch/arm/dts/imx8mp-rsb3720-a1-u-boot.dtsi | 25 ----------------------
+ 1 file changed, 25 deletions(-)
+
+diff --git a/arch/arm/dts/imx8mp-rsb3720-a1-u-boot.dtsi b/arch/arm/dts/imx8mp-rsb3720-a1-u-boot.dtsi
+index 3c2517a79ab..69ea625053a 100644
+--- a/arch/arm/dts/imx8mp-rsb3720-a1-u-boot.dtsi
++++ b/arch/arm/dts/imx8mp-rsb3720-a1-u-boot.dtsi
+@@ -189,28 +189,3 @@
+ 	/delete-property/ assigned-clock-rates;
+ };
+ 
+-&binman {
+-	itb {
+-		fit {
+-			images {
+-				fip {
+-					description = "Trusted Firmware FIP";
+-					type = "firmware";
+-					arch = "arm64";
+-					compression = "none";
+-					load = <0x40310000>;
+-
+-					fip_blob: blob-ext{
+-						filename = "fip.bin";
+-					};
+-				};
+-			};
+-
+-			configurations {
+-				conf {
+-					loadables = "atf", "fip";
+-				};
+-			};
+-		};
+-	};
+-};
+-- 
+2.39.2
+


### PR DESCRIPTION
Enable the support for OPTEE-OS on the following i.MX8MP platforms:
    
- Phytec phyBOARD-Pollux
- Advantech EPC-R3720

:warning: This is the last PR of the series and should be merged only after the following PRs:

- https://github.com/lf-edge/eve/pull/3126
- https://github.com/lf-edge/eve/pull/3127
- https://github.com/lf-edge/eve/pull/3128
- https://github.com/lf-edge/eve/pull/3129

Reviewers: In this PR, please, focus only on commit https://github.com/lf-edge/eve/pull/3130/commits/902485448fd6b30f85fe99ed24c64f2dc1528b15

PS: Since this PR has all the dependencies above, it's expected to not build (so some of the checkings will fail).