### PR TITLE
client: Try to fetch the UUID each boot.

### DIFF
--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -385,7 +385,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 			// Unlikely to have a network outage during that
 			// upgrade *and* require an override.
 			if clientCtx.networkState != types.DPCStateSuccess &&
-				clientCtx.operations["getUuid"] && oldUUID != nilUUID {
+				clientCtx.operations["getUuid"] && gotUUID && oldUUID != nilUUID {
 
 				log.Noticef("Already have a UUID %s; declaring success",
 					oldUUID.String())


### PR DESCRIPTION
previously, we would declare success if the old uuid existed, but there is a possibility that a device has been deleted and re-onboarded, so attempt to actually fetch the UUID and re-register.

This allows you to recover an accidently deleted device by rebooting instead of requiring a re-image.

Helps with #3109