### PR TITLE
single download for alpine sources

### DIFF
--- a/tools/get-alpine-pkg-source.sh
+++ b/tools/get-alpine-pkg-source.sh
@@ -11,18 +11,23 @@
 #    get-alpine-pkg-source.sh -s /tmp/sources -u urls 9.7.0-kvm-amd64
 # 2. Specify one or more tags using -t <tag> e.g.,
 #    get-alpine-pkg-source.sh -t lfedge/eve-pillar:17837a9fcd05c765e9a1f6707b2e48f0f1dd215b-amd64
-# 3. Speify a directory where EVE has been extracted using -e <evedir> e.g,
+# 3. Specify a directory where EVE has been extracted using -e <evedir> e.g,
 #    get-alpine-pkg-source.sh -s /tmp/sources -u urls -e .
 #
 # With -u <urlfile> it dumps the source URL + licenses into the file
 # With -s <srcdir> it dumps all the source in that directory
+# With -g <gitdir> use the directory as a pre-cloned repo for git.alpinelinux.org instead of cloning it
+
+set -e
+
 verbose=
 tags=
 evedir=
 urlfile=
+gitdir=
 outdir=/tmp/$$
 quiet=
-while getopts e:vt:u:s:q o
+while getopts e:vt:u:s:g:q o
 do      case "$o" in
         v)      verbose=1;;
         q)      quiet=1;;
@@ -30,11 +35,15 @@ do      case "$o" in
         t)      tags="$tags $OPTARG";;
         s)      outdir=$OPTARG;;
         u)      urlfile=$OPTARG;;
-        [?])    >&2 echo "Usage: $0 [-v] [-s <outdir>] [-u <urlfile>] [-t <tag>]+ [-e <evedir>] [<version>]"
+        g)      gitdir=$OPTARG;;
+        [?])    >&2 echo "Usage: $0 [-v] [-s <outdir>] [-u <urlfile>] [-t <tag>]+ [-e <evedir>] [-g <gitdir>] [<version>]"
                 exit 1;;
         esac
 done
 shift $((OPTIND-1))
+
+# ensure absolute path for outdir
+outdir=$(readlink -f "${outdir}")
 
 if [ $# == 0 ] && [ -z "$tags" ] && [ -z "$evedir" ]; then
     >&2 echo "Usage: $0 [-v] [-s <outdir>] [-u <urlfile>] [-t <tag>]+ [-e <evedir>] [<version>]"
@@ -50,20 +59,17 @@ if [ -d "$outdir" ]; then
     exit 1
 fi
 
+if [ -n "$gitdir" ] && [ ! -d "$gitdir" ]; then
+    >&2 echo "gitdir $gitdir does not exist"
+    exit 1
+fi
+
+
 startdir=$(pwd)
 mkdir -p "$outdir"
 cd "$outdir" || exit 2
 
 [ -n "$verbose" ] && echo "outdir: $outdir"
-
-if [ $# == 1 ]; then
-    VERSION=$1
-    [ -n "$verbose" ] && echo "retrieving build_config for $VERSION"
-    docker run "lfedge/eve:${VERSION}" build_config >build_config.out
-    tags1=$(grep image: build_config.out | awk '{print $2}')
-    tags2=$(awk '/^init:/ {pr=1} /^onboot:/ {pr=0} /^-/ {if (pr) {print $2}}' <build_config.out)
-    tags="$tags2 $tags1"
-fi
 
 # Collect all package origin and commit pairs in this file
 OCPAIRS=/tmp/ocpairs.$$
@@ -77,51 +83,35 @@ get_ocpairs() {
         /^o:/ { origin=$2 }
         /^L:/ { license=$2 }
         /^V:/ { version=$2 }
-        /^c:/ { commit=$2; if (commit == "") { commit = "unknown" }; print origin, version, commit, license; origin="XXX"; license="";version="" }' < "$1" | sort -u > "$2"
+        /^c:/ { commit=$2 }
+        /^\s*$/ {
+            if (origin != "") {
+                if (commit ~ /^\s*$/) { commit="unknown" };
+                print origin, version, commit, license;
+                origin=""; license=""; version=""; commit="unknown";
+            }
+        }' | sort -u
 }
 
-if [ -n "$evedir" ]; then
-    find "$evedir" -wholename '*lib/apk/db/installed' | while read -r installed ; do
-        [ -n "$verbose" ] && echo "packages from ${TAG} in ${installed}"
-        ocpairs=$(mktemp "${OCPAIRS}.XXXXXX")
-        get_ocpairs "${installed}" "${ocpairs}"
-        if grep -sq XXX "${ocpairs}"; then
-            >&2 echo "Missing package origin in ${installed}"
-            exit 2
-        fi
-    done
-else
-    for TAG in ${tags}; do
-        [ -n "$verbose" ] && echo "processing $TAG"
-        installed=$(mktemp "/tmp/installed.$$.XXXXXX")
-        ocpairs=$(mktemp "${OCPAIRS}.XXXXXX")
-        c=$(docker create "${TAG}" 2>/dev/null)
-        if [ -z "$c" ]; then
-            # Try bogus command
-            c=$(docker create "${TAG}" xxx 2>/dev/null)
-        fi
-        docker cp "$c":/lib/apk/db/installed "${installed}"
-        docker rm "$c" >/dev/null
-
-        # XXX check: Need COPY lib/apk/db /lib/apk/db in Dockerfile for linuxkit/getty etc
-        if [ ! -s "${installed}" ]; then
-            echo "No /lib/apk/db/installed for ${TAG}"
-            continue
-        fi
-
-        [ -n "$verbose" ] && echo "packages from ${TAG} in ${installed}"
-
-        get_ocpairs "${installed}" "${ocpairs}"
-        if grep -sq XXX "${ocpairs}"; then
-            >&2 echo "Missing package origin in ${installed}"
-            exit 2
-        fi
-        # shellcheck disable=SC2002
-        [ -n "$verbose" ] && echo "processing $TAG: $(cat "${ocpairs}" | wc -l) packages"
-    done
+if [ $# == 1 ]; then
+    VERSION=$1
+    tags="lfedge/eve:${VERSION}"
 fi
 
-cat ${OCPAIRS}.* | sort -u >${OCPAIRS}
+
+if [ -n "$evedir" ]; then
+    find "$evedir" -wholename '*lib/apk/db/installed' -exec cat {} \; | get_ocpairs > ${OCPAIRS}
+else
+    # for multiple tags, it is easier to handle them one by one and then merge, so we don't miss any CR/LF breaks
+    tmppairs=${OCPAIRS}.tmp
+    for TAG in ${tags}; do
+        [ -n "$verbose" ] && echo "retrieving installed databases for $TAG"
+        docker run --rm --entrypoint=sh "${TAG}" -c "unsquashfs -d /newroot /bits/rootfs.img >/dev/null && find /newroot -wholename '*lib/apk/db/installed' -exec cat {} \;" | get_ocpairs >> "${tmppairs}"
+        echo >> ${tmppairs}
+    done
+    cat ${tmppairs} | sort -u > ${OCPAIRS}
+fi
+
 
 # shellcheck disable=SC2002
 [ -z "$quiet" ] && echo "found $(cat ${OCPAIRS} |wc -l) packages times licenses"
@@ -131,12 +121,22 @@ awk '{print $1, $2, $3}' ${OCPAIRS}.with_licenses | sort -u >${OCPAIRS}
 # shellcheck disable=SC2002
 [ -z "$quiet" ] && echo "found $(cat ${OCPAIRS} |wc -l) packages"
 
-missing=0
+badfilescount=0
+badfileslist=""
+
+TMP_DIR=$(mktemp -d)
+if [ -n "$gitdir" ]; then
+    cp -r "$gitdir/." "${TMP_DIR}"
+else
+    pkgurl="https://git.alpinelinux.org/aports.git"
+    git clone "${pkgurl}" "${TMP_DIR}" >/dev/null
+fi
 
 # shellcheck disable=SC2002
-cat ${OCPAIRS} | while read -r line ; do
+while read -r line ; do
     # shellcheck disable=SC2086
     set -- $line
+    [ $# -lt 3 ] && continue
     origin=$1   
     version=$2
     commit=$3
@@ -151,36 +151,35 @@ cat ${OCPAIRS} | while read -r line ; do
     commitstr="?id=${commit}"
 
     # Include commit in directory to handle different versions
-    dstdir="${origin}.${version}.${commit}"
+    pkgpath="${origin}.${version}.${commit}"
+    dstdir="${outdir}/${pkgpath}"
     [ -n "$verbose" ] && echo "origin: ${origin} commit: ${commit} dstdir: ${dstdir}"
-    mkdir "${dstdir}"
     # Need to handle main, community and testing repos
+    foundRepo=""
     for repo in main community testing; do
-            pkgurl="https://git.alpinelinux.org/aports/plain/${repo}/${origin}/APKBUILD${commitstr}"
-            if ! curl -sSLo "${dstdir}"/APKBUILD "$pkgurl"; then
-                echo "Failed to download $pkgurl"
-                pkgurl=""
+            echo "Trying ${origin} in ${repo} at commit ${commit}"
+            git -C "${TMP_DIR}" checkout "${commit}" >/dev/null
+            sourceDir="${TMP_DIR}/${repo}/${origin}"
+            if [ ! -d "${sourceDir}" ]; then
+                echo "${origin} not in ${repo} at commit ${commit}"
                 continue
             fi
-            if [ ! -f "${dstdir}"/APKBUILD ]; then
-                echo "Failed to fetch ${pkgurl}"
-                pkgurl=""
+            if [ ! -f "${sourceDir}"/APKBUILD ]; then
+                echo "${origin} in ${repo} missing APKBUILD"
                 continue
             fi
-            # We do not get a 404 on failure but an html document
-            if grep -qsi '^<!DOCTYPE html' "${dstdir}"/APKBUILD; then
-                [ -n "$verbose" ] && echo "Fetched html from ${pkgurl}"
-                pkgurl=""
-                continue
-            fi
+            cp -r "${sourceDir}/." "${dstdir}/"
+            foundRepo="${repo}"
+
             break
     done
-    if [ -z "${pkgurl}" ]; then
-        >&2 echo "Failed to fetch ${origin} ${commit}"
+    if [ -z "${foundRepo}" ]; then
+        >&2 echo "Failed to find ${origin} at ${commit}"
         exit 2
     fi
-    [ -n "$verbose" ] && echo "Fetched ${origin} ${commit} from ${pkgurl}"
+    [ -n "$verbose" ] && echo "Retrieved ${origin} ${commit}"
     if [ -n "$urlfile" ]; then
+        pkgurl="https://git.alpinelinux.org/aports/plain/${foundRepo}/${origin}/APKBUILD${commitstr}"
         echo "$origin $pkgurl $license" >>"${urlfile}"
     fi
     # XXX is this dangerous? subshell?
@@ -188,7 +187,7 @@ cat ${OCPAIRS} | while read -r line ; do
     source=
     sha512sums=
     # shellcheck disable=SC1090,SC1091
-    source "${dstdir}"/APKBUILD
+    source "${dstdir}/APKBUILD"
     # shellcheck disable=SC2154
     [ -n "$verbose" ] && echo "source: ${source}"
     # shellcheck disable=SC2154
@@ -196,79 +195,73 @@ cat ${OCPAIRS} | while read -r line ; do
         echo "${sha512sums}" > "${dstdir}/sha512sums.APKBUILD"
     fi
     for s in ${source}; do
-        if echo "$s" | grep -sq "https://"; then
-            [ -n "$verbose" ] && echo "found $s basename $(basename "$s")"
-            filename="$(basename "$s")"
-            url="$s"
-            # Do we need to split on "::"?
-            if echo "$s" | grep -sq "::"; then
-                # shellcheck disable=SC2001
-                filename="$(echo "$s" | sed 's/^\(.*\)::\(.*$\)/\1/')"
-                # shellcheck disable=SC2001
-                url="$(echo "$s" | sed 's/^\(.*\)::\(.*$\)/\2/')"
-            fi
-        elif echo "$s" | grep -sq "http://"; then
-            [ -n "$verbose" ] && echo "found $s basename $(basename "$s")"
-            filename="$(basename "$s")"
-            url="$s"
-            # Do we need to split on "::"?
-            if echo "$s" | grep -sq "::"; then
-                # shellcheck disable=SC2001
-                filename="$(echo "$s" | sed 's/^\(.*\)::\(.*$\)/\1/')"
-                # shellcheck disable=SC2001
-                url="$(echo "$s" | sed 's/^\(.*\)::\(.*$\)/\2/')"
-            fi
-        elif echo "$s" | grep -sq "ftp://"; then
-            [ -n "$verbose" ] && echo "found $s basename $(basename "$s")"
-            filename="$(basename "$s")"
-            url="$s"
-            # Do we need to split on "::"?
-            if echo "$s" | grep -sq "::"; then
-                # shellcheck disable=SC2001
-                filename="$(echo "$s" | sed 's/^\(.*\)::\(.*$\)/\1/')"
-                # shellcheck disable=SC2001
-                url="$(echo "$s" | sed 's/^\(.*\)::\(.*$\)/\2/')"
-            fi
-        else
-            [ -n "$verbose" ] && echo "not http*: $s"
-            filename="$s"
-            url="https://git.alpinelinux.org/aports/plain/${repo}/${origin}/${s}${commitstr}"
+        url="$s"
+        filename=$(basename "${url}")
+        # Do we need to split on "::"?
+        if echo "$s" | grep -sq "::"; then
+            # shellcheck disable=SC2001
+            filename="$(echo "$s" | sed 's/^\(.*\)::\(.*$\)/\1/')"
+            # shellcheck disable=SC2001
+            url="$(echo "$s" | sed 's/^\(.*\)::\(.*$\)/\2/')"
         fi
-        [ -n "$verbose" ] && echo "filename: $filename url: $url"
-        if ! curl -sSLo "${dstdir}/${filename}" "${url}"; then
-            >&2 echo "Failed to download $url"
-            rm -f "${dstdir}/${filename}"
-            missing=$((missing + 1))
-            continue
-        fi
+        case $url in
+            https://*|http://*|ftp://*)
+                [ -n "$verbose" ] && echo "found $s basename ${filename}"
+                if ! curl -sSLo "${dstdir}/${filename}" "${url}"; then
+                    >&2 echo "Failed to download $url"
+                    rm -f "${dstdir}/${filename}"
+                    badfileslist="${badfileslist} missing:${pkgpath}:${filename}"
+                    badfilescount=$((badfilescount + 1))
+                    continue
+                fi
+                ;;
+            *)
+                [ -n "$verbose" ] && echo "not http*: $s"
+                if [ ! -f "${dstdir}/${filename}" ]; then
+                    >&2 echo "Missing file ${filename} $url"
+                    badfileslist="${badfileslist} missing:${pkgpath}:${filename}"
+                    badfilescount=$((badfilescount + 1))
+                    continue
+                fi
+                ;;
+        esac
         if [ -n "${sha512sums}" ]; then
             sum=$(openssl sha512 "${dstdir}/${filename}" | awk '{print $2}')
             rsum=$(grep ' '"$filename"\$ "${dstdir}/sha512sums.APKBUILD" | awk '{print $1}')
             if [ "${sum}" != "${rsum}" ]; then
+                errmsg="mismatched-sh512"
                 echo "Mismatched sh512 for $url into ${dstdir}/${filename}"
-                if grep -qsi '^<!DOCTYPE html' "${dstdir}/${filename}"; then
+                if grep -qsi '404 Not Found' "${dstdir}/${filename}"; then
+                    errmsg="404-not-found"
+                    >&2 echo "404 Not Found for ${url}"
+                    rm -f "${dstdir}/${filename}"
+                elif grep -qsi '^<!DOCTYPE html' "${dstdir}/${filename}"; then
                     >&2 echo "Bad DOCTYPE for $url into ${dstdir}/${filename}"
+                    errmsg="bad-content"
                     rm -f "${dstdir}/${filename}"
                 elif grep -qsi 'Too many requests' "${dstdir}/${filename}"; then
+                    errmsg="too-many-requests"
                     >&2 echo "Too many requests for ${url}"
-                    rm -f "${dstdir}/${filename}"
-                elif grep -qsi '404 Not Found' "${dstdir}/${filename}"; then
-                    >&2 echo "404 Not Found for ${url}"
                     rm -f "${dstdir}/${filename}"
                 else
                     [ -n "$verbose" ] && echo "Bad content: $(cat "${dstdir}/${filename}")"
                 fi
                 # "Bad content" and "Too many requests" isn't really missing ...
-                missing=$((missing + 1))
+                badfileslist="${badfileslist} ${errmsg}:${pkgpath}:${filename}"
+                badfilescount=$((badfilescount + 1))
             else
                 echo "$sum $filename" >> "${dstdir}/sha512sums.received"
             fi
         fi
     done
-    if [ "$missing" != 0 ]; then
-        echo "Missing/bad $missing files"
+    if [ "$badfilescount" != 0 ]; then
+        echo "Missing/bad $badfilescount files"
     fi
-done
+done < "${OCPAIRS}"
+
+# clean up our temporary cloned directory
+rm -rf "$TMP_DIR"
+sync
 
 if [ -n "$urlfile" ]; then
     # shellcheck disable=SC2002
@@ -277,3 +270,12 @@ fi
 cd "$startdir" || exit
 # shellcheck disable=SC2002
 [ -z "$quiet" ] && echo "Collected $(du -sm "$outdir" | cut -f 1) Mbytes for $(cat "${OCPAIRS}" | wc -l) packages of source in $outdir"
+
+# any errors?
+if [ -n "$badfileslist" ]; then
+    echo "Missing/bad $badfilescount files"
+    for b in $badfileslist; do
+        echo "  $b"
+    done
+    exit 1
+fi


### PR DESCRIPTION
This update does a few things.

* rather than `curl` getting for the commit for each package, it clones the repo just once, to a tempdir, and then checks out different commits for each package (main change).
* provides an option to use `-g <gitdir>` in case you already have it checked out, in which case it just copies to the tmpdir instead of cloning it; this is faster and useful for testing or including in other workflows.
* `set -e` for the script, so any errors fail immediately
* simplify some of the `if`/`then`/`else` statements

