### PR TITLE
Makefile: run tests with race condition detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -392,7 +392,7 @@ currentversion:
 
 test: $(LINUXKIT) test-images-patches | $(DIST)
 	@echo Running tests on $(GOMODULE)
-	$(QUIET)$(DOCKER_GO) "gotestsum --jsonfile $(DOCKER_DIST)/results.json --junitfile $(DOCKER_DIST)/results.xml --raw-command -- go test -coverprofile=coverage.txt -covermode=atomic -json ./..." $(GOTREE) $(GOMODULE)
+	$(QUIET)$(DOCKER_GO) "gotestsum --jsonfile $(DOCKER_DIST)/results.json --junitfile $(DOCKER_DIST)/results.xml --raw-command -- go test -coverprofile=coverage.txt -covermode=atomic -race -json ./..." $(GOTREE) $(GOMODULE)
 	$(QUIET)$(DOCKER_GO) "cd \"$(GOTREE)\"; find ./ -type d \! -path ./vendor/\* -exec go test -fuzz=^Fuzz -run=^Fuzz -fuzztime=30s "{}" \;" $(GOTREE) $(GOMODULE)
 	$(QUIET): $@: Succeeded
 

--- a/Makefile
+++ b/Makefile
@@ -392,7 +392,7 @@ currentversion:
 
 test: $(LINUXKIT) test-images-patches | $(DIST)
 	@echo Running tests on $(GOMODULE)
-	$(QUIET)$(DOCKER_GO) "gotestsum --jsonfile $(DOCKER_DIST)/results.json --junitfile $(DOCKER_DIST)/results.xml --raw-command -- go test -coverprofile=coverage.txt -covermode=atomic -race -json ./..." $(GOTREE) $(GOMODULE)
+	$(QUIET)$(DOCKER_GO) "gotestsum --jsonfile $(DOCKER_DIST)/results.json --junitfile $(DOCKER_DIST)/results.xml --raw-command -- $(GOTREE)/../../tools/go-test.sh" $(GOTREE) $(GOMODULE)
 	$(QUIET)$(DOCKER_GO) "cd \"$(GOTREE)\"; find ./ -type d \! -path ./vendor/\* -exec go test -fuzz=^Fuzz -run=^Fuzz -fuzztime=30s "{}" \;" $(GOTREE) $(GOMODULE)
 	$(QUIET): $@: Succeeded
 

--- a/tools/go-test.sh
+++ b/tools/go-test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+BROKEN_TESTS="TestDPCWithReleasedAndRenamedInterface TestUnsubscribe/IPC_with_persistent TestRestarted TestUnsubscribe/IPC TestCheckMaxSize"
+SKIP_BROKEN_TESTS_PARAM=""
+for t in $BROKEN_TESTS
+do
+    SKIP_BROKEN_TESTS_PARAM="$SKIP_BROKEN_TESTS_PARAM|^$t\$"
+done
+SKIP_BROKEN_TESTS_PARAM=${SKIP_BROKEN_TESTS_PARAM:1}
+
+BROKEN_TESTS_PARAM=""
+for t in $BROKEN_TESTS
+do
+    BROKEN_TESTS_PARAM="$BROKEN_TESTS_PARAM|$t"
+done
+BROKEN_TESTS_PARAM=${BROKEN_TESTS_PARAM:1}
+
+trap 'rm -f coverage_part.txt' EXIT
+
+echo 'mode: atomic' > coverage.txt
+go test -coverprofile=coverage_part.txt -covermode=atomic -skip "$SKIP_BROKEN_TESTS_PARAM" -race -json ./...
+if [ -f coverage_part.txt ]; then
+    tail -n +2 >> coverage.txt < coverage_part.txt
+fi
+
+go test -coverprofile=coverage_part.txt -covermode=atomic -run "$BROKEN_TESTS_PARAM" -json ./...
+if [ -f coverage_part.txt ]; then
+    tail -n +2 >> coverage.txt < coverage_part.txt
+fi


### PR DESCRIPTION
this change runs go tests with '-race' in order
to find race conditions between go routines