### PR TITLE
debug/collect-info.sh: collect kcrashes and pillar backtraces

### DIFF
--- a/pkg/debug/scripts/collect-info.sh
+++ b/pkg/debug/scripts/collect-info.sh
@@ -5,7 +5,7 @@
 #
 
 # Script version, don't forget to bump up once something is changed
-VERSION=2
+VERSION=3
 
 DATE=$(date -Is)
 INFO_DIR="eve-info-v$VERSION-$DATE"
@@ -38,19 +38,25 @@ while getopts "vh" o; do
 done
 
 # Create temporary dir
+echo "- basic setup"
 TMP_DIR=$(mktemp -d)
 DIR="$TMP_DIR/$INFO_DIR"
 mkdir -p "$DIR"
 mkdir -p "$DIR/network"
 
 # Install GNU version of the 'ps', 'tar' and other tools
+echo "- install GNU tools"
 apk add procps tar dmidecode >/dev/null 2>&1
 
 collect_network_info()
 {
+    echo "- network info"
+
     # Install missing tools
+    echo "   - install networking GNU tools"
     apk add iptables dhcpcd >/dev/null 2>&1
 
+    echo "   - ifconfig, ip, arp, netstat, iptables"
     ifconfig       > "$DIR/network/ifconfig"
     ip -s link     > "$DIR/network/ip-s-link"
     arp -n         > "$DIR/network/arp-n"
@@ -67,14 +73,49 @@ collect_network_info()
     iptables -L -v -n --line-numbers -t nat \
                    > "$DIR/network/iptables-nat"
 
+    echo "   - dhcpcd for all ifaces"
     for iface in /sys/class/net/*; do
         iface="${iface##*/}"
         echo "------ $iface -------"
         dhcpcd -U -4 "$iface"
     done > "$DIR/network/dhcpcd-all-ifaces" 2>&1
+
+    echo "- done network info"
 }
 
+collect_pillar_backtraces()
+{
+    echo "- pillar backtraces"
+    logread -f > "$DIR/pillar-backtraces" &
+    pid=$!
+
+    echo "  - pkill -USR1 /opt/zededa/bin/zedbox"
+    eve exec pillar pkill -USR1 /opt/zededa/bin/zedbox
+
+    iters=15
+    echo "  - wait for pillar backtraces"
+    until grep -q "sigusr" "$DIR/pillar-backtraces"; do
+        sleep 1s
+        if [ $iters -eq 0 ]; then
+            echo "      ERR: timeout! exit wait"
+            break
+        fi
+        iters=$((iters - 1))
+    done
+
+    # To be sure all backtraces are written
+    sleep 1s
+
+    kill $pid
+
+    echo "- done pillar backtraces"
+}
+
+# Copy itself
+cp "${0}" "$DIR"
+
 # Have to chroot, lsusb does not work from this container
+echo "- lsusb, dmesg, ps, lspci, lsblk, lshw, lsof, lsmod, logread, dmidecode"
 chroot /hostfs lsusb -vvv    > "$DIR/lsusb-vvv"
 chroot /hostfs lsusb -vvv -t > "$DIR/lsusb-vvv-t"
 
@@ -89,6 +130,7 @@ lsmod         > "$DIR/lsmod"
 logread       > "$DIR/logread"
 dmidecode     > "$DIR/dmidecode"
 
+echo "- vmallocinfo, slabinfo, zoneinfo, mounts, vmstat, cpuinfo"
 cat /proc/vmallocinfo > "$DIR/vmallocinfo"
 cat /proc/slabinfo    > "$DIR/slabinfo"
 cat /proc/zoneinfo    > "$DIR/zoneinfo"
@@ -96,24 +138,34 @@ cat /proc/mounts      > "$DIR/mounts"
 cat /proc/vmstat      > "$DIR/vmstat"
 cat /proc/cpuinfo     > "$DIR/cpuinfo"
 
+echo "- qemu affinities"
 qemu-affinities.sh    > "$DIR/qemu-affinities"
+
+echo "- iommu groups"
 iommu-groups.sh       > "$DIR/iommu-groups"
 
-ln -s /persist/status  "$DIR/persist-status"
-ln -s /persist/log     "$DIR/persist-log"
-ln -s /persist/newlog  "$DIR/persist-newlog"
-ln -s /persist/netdump "$DIR/persist-netdump"
-ln -s /run             "$DIR/root-run"
+ln -s /persist/status   "$DIR/persist-status"
+ln -s /persist/log      "$DIR/persist-log"
+ln -s /persist/newlog   "$DIR/persist-newlog"
+ln -s /persist/netdump  "$DIR/persist-netdump"
+ln -s /persist/kcrashes "$DIR/persist-kcrashes"
+ln -s /run              "$DIR/root-run"
 
 # Network part
 collect_network_info
+
+# Pillar part
+collect_pillar_backtraces
 
 # Make a tarball
 # --exlude='root-run/run'              /run/run/run/.. exclude symbolic link loop
 # --ignore-failed-read --warning=none  ignore all errors, even if read fails
 # --dereference                        follow symlinks
+echo "- tar/gzip"
 tar -C "$TMP_DIR" --exclude='root-run/run' --ignore-failed-read --warning=none --dereference -czf "$TARBALL_FILE" "$INFO_DIR"
 rm -rf "$TMP_DIR"
 sync
 
+echo "- done"
+echo
 echo "EVE info is collected '$TARBALL_FILE'"


### PR DESCRIPTION
This patch adds:

 1. collection of /persist/kcrashes
 2. collection of pillar backtraces into a pillar-backtraces file by sending the SIGUSR1 to the zedbox process
 3. makes script output more pretty

Bump up version to 3.

cc: @milan-zededa 