### PR TITLE
Backport #3113 to 8.5

### DIFF
--- a/pkg/pillar/attest/attest.go
+++ b/pkg/pillar/attest/attest.go
@@ -184,7 +184,7 @@ func New(ps *pubsub.PubSub, log *base.LogObject, retryTime, watchdogTickerTime t
 		log:                log,
 		event:              EventInitialize,
 		state:              StateNone,
-		eventTrigger:       make(chan Event),
+		eventTrigger:       make(chan Event, 1),
 		retryTime:          retryTime,
 		watchdogTickerTime: watchdogTickerTime,
 		OpaqueCtx:          opaque,
@@ -248,9 +248,15 @@ func Kickstart(ctx *Context) {
 	ctx.eventTrigger <- EventInitialize
 }
 
-//RestartAttestation adds EventRestart event to the fsm
+// RestartAttestation adds EventRestart event to the fsm
+// To avoid hanging forever we use a conditional send here.
 func RestartAttestation(ctx *Context) {
-	ctx.eventTrigger <- EventRestart
+	select {
+	case ctx.eventTrigger <- EventRestart:
+		// Do nothing more
+	default:
+		ctx.log.Warnf("RestartAttestation(): already triggered, still not processed")
+	}
 }
 
 //InternalQuoteRecvd adds EventInternalQuoteRecvd to the fsm

--- a/pkg/pillar/attest/attest_test.go
+++ b/pkg/pillar/attest/attest_test.go
@@ -106,7 +106,7 @@ func initTest() *Context {
 		event:        EventInitialize,
 		state:        StateNone,
 		restartTimer: time.NewTimer(1 * time.Second),
-		eventTrigger: make(chan Event),
+		eventTrigger: make(chan Event, 1),
 		retryTime:    1,
 	}
 	ctx.restartTimer.Stop()

--- a/pkg/pillar/cmd/zedagent/attesttask.go
+++ b/pkg/pillar/cmd/zedagent/attesttask.go
@@ -69,7 +69,8 @@ const (
 )
 
 //One shot send, if fails, return an error to the state machine to retry later
-func trySendToController(attestReq *attest.ZAttestReq, iteration int) (*http.Response, []byte, types.SenderResult, error) {
+func trySendToController(attestReq *attest.ZAttestReq, attestCtx *attestContext) (*http.Response, []byte, types.SenderResult, error) {
+	log.Noticef("trySendToController type %d", attestReq.ReqType)
 	data, err := proto.Marshal(attestReq)
 	if err != nil {
 		log.Fatal("SendInfoProtobufStr proto marshaling error: ", err)
@@ -82,12 +83,19 @@ func trySendToController(attestReq *attest.ZAttestReq, iteration int) (*http.Res
 	ctxWork, cancel := zedcloud.GetContextForAllIntfFunctions(zedcloudCtx)
 	defer cancel()
 	resp, contents, senderStatus, err := zedcloud.SendOnAllIntf(ctxWork,
-		zedcloudCtx, attestURL, size, buf, iteration, true)
+		zedcloudCtx, attestURL, size, buf, attestCtx.Iteration, true)
 	if err != nil || len(contents) == 0 {
-		return resp, contents, senderStatus, err
+		// Error case handled below
+	} else {
+		contents, senderStatus, err = zedcloud.RemoveAndVerifyAuthContainer(zedcloudCtx,
+			attestURL, contents, false, senderStatus)
 	}
-	contents, senderStatus, err = zedcloud.RemoveAndVerifyAuthContainer(zedcloudCtx,
-		attestURL, contents, false, senderStatus)
+	switch senderStatus {
+	case types.SenderStatusCertMiss, types.SenderStatusCertInvalid:
+		// trigger to acquire new controller certs from cloud
+		log.Noticef("%s trigger", senderStatus.String())
+		triggerControllerCertEvent(attestCtx.zedagentCtx)
+	}
 	return resp, contents, senderStatus, err
 }
 
@@ -131,7 +139,7 @@ func (server *VerifierImpl) SendNonceRequest(ctx *zattest.Context) error {
 	attestCtx.Iteration++
 	log.Tracef("Sending Nonce request %v", attestReq)
 
-	_, contents, senderStatus, err := trySendToController(attestReq, attestCtx.Iteration)
+	_, contents, senderStatus, err := trySendToController(attestReq, attestCtx)
 	if err != nil || senderStatus != types.SenderStatusNone {
 		errorDescription := types.ErrorDescription{
 			Error: fmt.Sprintf("[ATTEST] Error %v, senderStatus %v",
@@ -313,7 +321,7 @@ func (server *VerifierImpl) SendAttestQuote(ctx *zattest.Context) error {
 	log.Tracef("Sending Quote request")
 	recordAttestationTry(attestCtx.zedagentCtx)
 
-	_, contents, senderStatus, err := trySendToController(attestReq, attestCtx.Iteration)
+	_, contents, senderStatus, err := trySendToController(attestReq, attestCtx)
 	if err != nil || senderStatus != types.SenderStatusNone {
 		errorDescription := types.ErrorDescription{
 			Error: fmt.Sprintf("[ATTEST] Error %v, senderStatus %v",
@@ -453,7 +461,7 @@ func (server *VerifierImpl) SendAttestEscrow(ctx *zattest.Context) error {
 	attestCtx.Iteration++
 	log.Tracef("Sending Escrow data")
 
-	_, contents, senderStatus, err := trySendToController(attestReq, attestCtx.Iteration)
+	_, contents, senderStatus, err := trySendToController(attestReq, attestCtx)
 	if err != nil || senderStatus != types.SenderStatusNone {
 		errorDescription := types.ErrorDescription{
 			Error: fmt.Sprintf("[ATTEST] Error %v, senderStatus %v", err, senderStatus),

--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -444,8 +444,10 @@ func sendAttestReqProtobuf(attestReq *attest.ZAttestReq, iteration int) {
 	//We queue the message and then get the highest priority message to send.
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
+	// Since attest messages can fail if there is a certificate mismatch
+	// we set ignoreErr to allow other messages to be sent as well.
 	zedcloud.SetDeferred(zedcloudCtx, deferKey, buf, size, attestURL,
-		false, false, attestReq.ReqType)
+		false, true, attestReq.ReqType)
 	zedcloud.HandleDeferred(zedcloudCtx, time.Now(), 0, true)
 }
 

--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -261,8 +261,12 @@ func getCertsFromController(ctx *zedagentContext, desc string) (success bool) {
 			log.Noticef("getCertsFromController: Controller returned ECONNREFUSED")
 		case types.SenderStatusCertInvalid:
 			log.Warnf("getCertsFromController: Controller certificate invalid time")
+			log.Noticef("%s trigger", senderStatus.String())
+			triggerControllerCertEvent(ctx)
 		case types.SenderStatusCertMiss:
 			log.Noticef("getCertsFromController: Controller certificate miss")
+			log.Noticef("%s trigger", senderStatus.String())
+			triggerControllerCertEvent(ctx)
 		default:
 			log.Errorf("getCertsFromController failed: %s", err)
 		}
@@ -275,6 +279,12 @@ func getCertsFromController(ctx *zedagentContext, desc string) (success bool) {
 	default:
 		log.Errorf("getCertsFromController: failed, statuscode %d %s",
 			resp.StatusCode, http.StatusText(resp.StatusCode))
+		switch senderStatus {
+		case types.SenderStatusCertMiss, types.SenderStatusCertInvalid:
+			// trigger to acquire new controller certs from cloud
+			log.Noticef("%s trigger", senderStatus.String())
+			triggerControllerCertEvent(ctx)
+		}
 		return false
 	}
 
@@ -295,6 +305,12 @@ func getCertsFromController(ctx *zedagentContext, desc string) (success bool) {
 	certBytes, ret := zedcloud.VerifySigningCertChain(zedcloudCtx, contents)
 	if ret != nil {
 		log.Errorf("getCertsFromController: verify err %v", ret)
+		switch senderStatus {
+		case types.SenderStatusCertMiss, types.SenderStatusCertInvalid:
+			// trigger to acquire new controller certs from cloud
+			log.Noticef("%s trigger", senderStatus.String())
+			triggerControllerCertEvent(ctx)
+		}
 		return false
 	}
 

--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -445,7 +445,7 @@ func sendAttestReqProtobuf(attestReq *attest.ZAttestReq, iteration int) {
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
 	zedcloud.SetDeferred(zedcloudCtx, deferKey, buf, size, attestURL,
-		false, attestReq.ReqType)
+		false, false, attestReq.ReqType)
 	zedcloud.HandleDeferred(zedcloudCtx, time.Now(), 0, true)
 }
 

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -337,11 +337,11 @@ func getLatestConfig(url string, iteration int,
 		case types.SenderStatusCertInvalid:
 			log.Warnf("getLatestConfig : Controller certificate invalid time")
 		case types.SenderStatusCertMiss:
-			log.Functionf("getLatestConfig : Controller certificate miss")
+			log.Warnf("getLatestConfig : Controller certificate miss")
 		case types.SenderStatusNotFound:
-			log.Functionf("getLatestConfig : Device deleted in controller?")
+			log.Noticef("getLatestConfig : Device deleted in controller?")
 		case types.SenderStatusForbidden:
-			log.Functionf("getLatestConfig : Device integrity token mismatch")
+			log.Warnf("getLatestConfig : Device integrity token mismatch")
 		default:
 			log.Errorf("getLatestConfig  failed: %s", err)
 		}

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -1175,7 +1175,7 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
 	zedcloud.SetDeferred(zedcloudCtx, uuid, buf, size, statusUrl,
-		true, info.ZInfoTypes_ZiApp)
+		true, false, info.ZInfoTypes_ZiApp)
 	zedcloud.HandleDeferred(zedcloudCtx, time.Now(), 0, true)
 }
 
@@ -1245,7 +1245,7 @@ func PublishContentInfoToZedCloud(ctx *zedagentContext, uuid string,
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
 	zedcloud.SetDeferred(zedcloudCtx, uuid, buf, size, statusURL,
-		true, info.ZInfoTypes_ZiContentTree)
+		true, false, info.ZInfoTypes_ZiContentTree)
 	zedcloud.HandleDeferred(zedcloudCtx, time.Now(), 0, true)
 }
 
@@ -1323,7 +1323,7 @@ func PublishVolumeToZedCloud(ctx *zedagentContext, uuid string,
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
 	zedcloud.SetDeferred(zedcloudCtx, uuid, buf, size, statusURL,
-		true, info.ZInfoTypes_ZiVolume)
+		true, false, info.ZInfoTypes_ZiVolume)
 	zedcloud.HandleDeferred(zedcloudCtx, time.Now(), 0, true)
 }
 
@@ -1382,7 +1382,7 @@ func PublishBlobInfoToZedCloud(ctx *zedagentContext, blobSha string, blobStatus 
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
 	zedcloud.SetDeferred(zedcloudCtx, blobSha, buf, size, statusURL,
-		true, info.ZInfoTypes_ZiBlobList)
+		true, false, info.ZInfoTypes_ZiBlobList)
 	zedcloud.HandleDeferred(zedcloudCtx, time.Now(), 0, true)
 }
 
@@ -1432,7 +1432,7 @@ func PublishEdgeviewToZedCloud(ctx *zedagentContext, evStatus *types.EdgeviewSta
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
 	zedcloud.SetDeferred(zedcloudCtx, "global", buf, size, statusURL,
-		true, info.ZInfoTypes_ZiEdgeview)
+		true, false, info.ZInfoTypes_ZiEdgeview)
 	zedcloud.HandleDeferred(zedcloudCtx, time.Now(), 0, true)
 }
 

--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -181,7 +181,7 @@ func prepareAndPublishNetworkInstanceInfoMsg(ctx *zedagentContext,
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
 	zedcloud.SetDeferred(zedcloudCtx, uuid, buf, size, statusURL,
-		true, zinfo.ZInfoTypes_ZiNetworkInstance)
+		true, false, zinfo.ZInfoTypes_ZiNetworkInstance)
 	zedcloud.HandleDeferred(zedcloudCtx, time.Now(), 0, true)
 }
 

--- a/pkg/pillar/cmd/zedagent/hardwareinfo.go
+++ b/pkg/pillar/cmd/zedagent/hardwareinfo.go
@@ -107,7 +107,7 @@ func PublishHardwareInfoToZedCloud(ctx *zedagentContext) {
 	size := int64(proto.Size(ReportHwInfo))
 
 	zedcloud.SetDeferred(zedcloudCtx, hwInfoKey, buf, size,
-		statusURL, bailOnHTTPErr, info.ZInfoTypes_ZiHardware)
+		statusURL, bailOnHTTPErr, false, info.ZInfoTypes_ZiHardware)
 	zedcloud.HandleDeferred(zedcloudCtx, time.Now(), 0, true)
 }
 

--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -644,7 +644,7 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
 	zedcloud.SetDeferred(zedcloudCtx, deviceUUID, buf, size,
-		statusUrl, true, info.ZInfoTypes_ZiDevice)
+		statusUrl, true, false, info.ZInfoTypes_ZiDevice)
 	zedcloud.HandleDeferred(zedcloudCtx, time.Now(), 0, true)
 }
 
@@ -695,7 +695,8 @@ func PublishAppInstMetaDataToZedCloud(ctx *zedagentContext, appInstID string, ap
 	//We queue the message and then get the highest priority message to send.
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
-	zedcloud.SetDeferred(zedcloudCtx, deferKey, buf, size, statusURL, true, info.ZInfoTypes_ZiAppInstMetaData)
+	zedcloud.SetDeferred(zedcloudCtx, deferKey, buf, size, statusURL, true,
+		false, info.ZInfoTypes_ZiAppInstMetaData)
 	zedcloud.HandleDeferred(zedcloudCtx, time.Now(), 0, true)
 }
 


### PR DESCRIPTION
Not clear exactly when this can happen since many different factors are involved but the key is to have /attest API invocations trigger fetching the controller certificates, and for controller visibibilty, not have failing attestation messages block the sending of e.g., device info messages.