### PR TITLE
Backport #3113 to 8.12

### DIFF
--- a/pkg/pillar/attest/attest.go
+++ b/pkg/pillar/attest/attest.go
@@ -184,7 +184,7 @@ func New(ps *pubsub.PubSub, log *base.LogObject, retryTime, watchdogTickerTime t
 		log:                log,
 		event:              EventInitialize,
 		state:              StateNone,
-		eventTrigger:       make(chan Event),
+		eventTrigger:       make(chan Event, 1),
 		retryTime:          retryTime,
 		watchdogTickerTime: watchdogTickerTime,
 		OpaqueCtx:          opaque,
@@ -248,9 +248,15 @@ func Kickstart(ctx *Context) {
 	ctx.eventTrigger <- EventInitialize
 }
 
-//RestartAttestation adds EventRestart event to the fsm
+// RestartAttestation adds EventRestart event to the fsm
+// To avoid hanging forever we use a conditional send here.
 func RestartAttestation(ctx *Context) {
-	ctx.eventTrigger <- EventRestart
+	select {
+	case ctx.eventTrigger <- EventRestart:
+		// Do nothing more
+	default:
+		ctx.log.Warnf("RestartAttestation(): already triggered, still not processed")
+	}
 }
 
 //InternalQuoteRecvd adds EventInternalQuoteRecvd to the fsm

--- a/pkg/pillar/attest/attest_test.go
+++ b/pkg/pillar/attest/attest_test.go
@@ -106,7 +106,7 @@ func initTest() *Context {
 		event:        EventInitialize,
 		state:        StateNone,
 		restartTimer: time.NewTimer(1 * time.Second),
-		eventTrigger: make(chan Event),
+		eventTrigger: make(chan Event, 1),
 		retryTime:    1,
 	}
 	ctx.restartTimer.Stop()

--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -444,7 +444,7 @@ func sendAttestReqProtobuf(attestReq *attest.ZAttestReq, iteration int) {
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
 	zedcloud.SetDeferred(zedcloudCtx, deferKey, buf, size, attestURL,
-		false, false, attestReq.ReqType)
+		false, true, attestReq.ReqType)
 	zedcloud.HandleDeferred(zedcloudCtx, time.Now(), 0, true)
 }
 

--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -444,7 +444,7 @@ func sendAttestReqProtobuf(attestReq *attest.ZAttestReq, iteration int) {
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
 	zedcloud.SetDeferred(zedcloudCtx, deferKey, buf, size, attestURL,
-		false, attestReq.ReqType)
+		false, false, attestReq.ReqType)
 	zedcloud.HandleDeferred(zedcloudCtx, time.Now(), 0, true)
 }
 

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -487,11 +487,11 @@ func getLatestConfig(getconfigCtx *getconfigContext, url string,
 		case types.SenderStatusCertInvalid:
 			log.Warnf("getLatestConfig : Controller certificate invalid time")
 		case types.SenderStatusCertMiss:
-			log.Functionf("getLatestConfig : Controller certificate miss")
+			log.Warnf("getLatestConfig : Controller certificate miss")
 		case types.SenderStatusNotFound:
-			log.Functionf("getLatestConfig : Device deleted in controller?")
+			log.Noticef("getLatestConfig : Device deleted in controller?")
 		case types.SenderStatusForbidden:
-			log.Functionf("getLatestConfig : Device integrity token mismatch")
+			log.Warnf("getLatestConfig : Device integrity token mismatch")
 		default:
 			log.Errorf("getLatestConfig  failed: %s", err)
 		}

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -1187,7 +1187,7 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
 	zedcloud.SetDeferred(zedcloudCtx, uuid, buf, size, statusUrl,
-		true, info.ZInfoTypes_ZiApp)
+		true, false, info.ZInfoTypes_ZiApp)
 	zedcloud.HandleDeferred(zedcloudCtx, time.Now(), 0, true)
 }
 
@@ -1257,7 +1257,7 @@ func PublishContentInfoToZedCloud(ctx *zedagentContext, uuid string,
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
 	zedcloud.SetDeferred(zedcloudCtx, uuid, buf, size, statusURL,
-		true, info.ZInfoTypes_ZiContentTree)
+		true, false, info.ZInfoTypes_ZiContentTree)
 	zedcloud.HandleDeferred(zedcloudCtx, time.Now(), 0, true)
 }
 
@@ -1335,7 +1335,7 @@ func PublishVolumeToZedCloud(ctx *zedagentContext, uuid string,
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
 	zedcloud.SetDeferred(zedcloudCtx, uuid, buf, size, statusURL,
-		true, info.ZInfoTypes_ZiVolume)
+		true, false, info.ZInfoTypes_ZiVolume)
 	zedcloud.HandleDeferred(zedcloudCtx, time.Now(), 0, true)
 }
 
@@ -1394,7 +1394,7 @@ func PublishBlobInfoToZedCloud(ctx *zedagentContext, blobSha string, blobStatus 
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
 	zedcloud.SetDeferred(zedcloudCtx, blobSha, buf, size, statusURL,
-		true, info.ZInfoTypes_ZiBlobList)
+		true, false, info.ZInfoTypes_ZiBlobList)
 	zedcloud.HandleDeferred(zedcloudCtx, time.Now(), 0, true)
 }
 
@@ -1444,7 +1444,7 @@ func PublishEdgeviewToZedCloud(ctx *zedagentContext, evStatus *types.EdgeviewSta
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
 	zedcloud.SetDeferred(zedcloudCtx, "global", buf, size, statusURL,
-		true, info.ZInfoTypes_ZiEdgeview)
+		true, false, info.ZInfoTypes_ZiEdgeview)
 	zedcloud.HandleDeferred(zedcloudCtx, time.Now(), 0, true)
 	ctx.iteration++
 }

--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -181,7 +181,7 @@ func prepareAndPublishNetworkInstanceInfoMsg(ctx *zedagentContext,
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
 	zedcloud.SetDeferred(zedcloudCtx, uuid, buf, size, statusURL,
-		true, zinfo.ZInfoTypes_ZiNetworkInstance)
+		true, false, zinfo.ZInfoTypes_ZiNetworkInstance)
 	zedcloud.HandleDeferred(zedcloudCtx, time.Now(), 0, true)
 }
 

--- a/pkg/pillar/cmd/zedagent/hardwareinfo.go
+++ b/pkg/pillar/cmd/zedagent/hardwareinfo.go
@@ -107,7 +107,7 @@ func PublishHardwareInfoToZedCloud(ctx *zedagentContext) {
 	size := int64(proto.Size(ReportHwInfo))
 
 	zedcloud.SetDeferred(zedcloudCtx, hwInfoKey, buf, size,
-		statusURL, bailOnHTTPErr, info.ZInfoTypes_ZiHardware)
+		statusURL, bailOnHTTPErr, false, info.ZInfoTypes_ZiHardware)
 	zedcloud.HandleDeferred(zedcloudCtx, time.Now(), 0, true)
 }
 

--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -656,7 +656,7 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext) {
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
 	zedcloud.SetDeferred(zedcloudCtx, deviceUUID, buf, size,
-		statusUrl, true, info.ZInfoTypes_ZiDevice)
+		statusUrl, true, false, info.ZInfoTypes_ZiDevice)
 	zedcloud.HandleDeferred(zedcloudCtx, time.Now(), 0, true)
 }
 
@@ -707,7 +707,8 @@ func PublishAppInstMetaDataToZedCloud(ctx *zedagentContext, appInstID string, ap
 	//We queue the message and then get the highest priority message to send.
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
-	zedcloud.SetDeferred(zedcloudCtx, deferKey, buf, size, statusURL, true, info.ZInfoTypes_ZiAppInstMetaData)
+	zedcloud.SetDeferred(zedcloudCtx, deferKey, buf, size, statusURL, true,
+		false, info.ZInfoTypes_ZiAppInstMetaData)
 	zedcloud.HandleDeferred(zedcloudCtx, time.Now(), 0, true)
 }
 

--- a/pkg/pillar/zedcloud/deferred.go
+++ b/pkg/pillar/zedcloud/deferred.go
@@ -33,6 +33,7 @@ type deferredItem struct {
 	size          int64
 	url           string
 	bailOnHTTPErr bool // Return 4xx and 5xx without trying other interfaces
+	ignoreErr     bool
 }
 
 const maxTimeToHandleDeferred = time.Minute
@@ -133,7 +134,7 @@ func (ctx *DeferredContext) handleDeferred(log *base.LogObject, event time.Time,
 			} else if err != nil {
 				log.Functionf("handleDeferred: for %s status %d failed %s",
 					key, result, err)
-				exit = true
+				exit = !item.ignoreErr
 				// Make sure we pass a non-zero result
 				// to the sentHandler.
 				if result == types.SenderStatusNone {
@@ -142,7 +143,7 @@ func (ctx *DeferredContext) handleDeferred(log *base.LogObject, event time.Time,
 			} else if result != types.SenderStatusNone {
 				log.Functionf("handleDeferred: for %s received unexpected status %d",
 					key, result)
-				exit = true
+				exit = !item.ignoreErr
 			}
 			if ctx.sentHandler != nil {
 				f := *ctx.sentHandler
@@ -211,19 +212,21 @@ func (ctx *DeferredContext) handleDeferred(log *base.LogObject, event time.Time,
 	return false
 }
 
-// Replace any item for the specified key. If timer not running start it
-// SetDeferred uses the key for identifying the channel. Please note that
-// for deviceUUID key is used for attestUrl, which is not the same for
-// other Urls, where in other caes, the key is very specific for the object
-//  and object type
+// SetDeferred sets or replaces any item for the specified key and
+// starts the timer. Key is used for identifying the channel. Please
+// note that for deviceUUID key is used for attestUrl, which is not the
+// same for other Urls, where in other case, the key is very specific
+// for the object. If @ignoreErr is true the queue processing is not
+// stopped on any error and will continue, although all errors will be
+// passed to @sentHandler callback (see the CreateDeferredCtx()).
 func SetDeferred(zedcloudCtx *ZedCloudContext, key string, buf *bytes.Buffer,
-	size int64, url string, bailOnHTTPErr bool, itemType interface{}) {
+	size int64, url string, bailOnHTTPErr bool, ignoreErr bool, itemType interface{}) {
 
-	zedcloudCtx.deferredCtx.setDeferred(zedcloudCtx, key, buf, size, url, bailOnHTTPErr, itemType)
+	zedcloudCtx.deferredCtx.setDeferred(zedcloudCtx, key, buf, size, url, bailOnHTTPErr, ignoreErr, itemType)
 }
 
 func (ctx *DeferredContext) setDeferred(zedcloudCtx *ZedCloudContext,
-	key string, buf *bytes.Buffer, size int64, url string, bailOnHTTPErr bool, itemType interface{}) {
+	key string, buf *bytes.Buffer, size int64, url string, bailOnHTTPErr bool, ignoreErr bool, itemType interface{}) {
 	ctx.lock.Lock()
 	defer ctx.lock.Unlock()
 
@@ -240,6 +243,7 @@ func (ctx *DeferredContext) setDeferred(zedcloudCtx *ZedCloudContext,
 		size:          size,
 		url:           url,
 		bailOnHTTPErr: bailOnHTTPErr,
+		ignoreErr:     ignoreErr,
 	}
 	found := false
 	ind := 0


### PR DESCRIPTION
Not clear exactly when this can happen since many different factors are involved but the key is to have /attest API invocations trigger fetching the controller certificates, and for controller visibibilty, not have failing attestation messages block the sending of e.g., device info messages.