### PR TITLE
Catch panic caused by race condition when handling a buggy stream

### DIFF
--- a/libs/zedUpload/datastore.go
+++ b/libs/zedUpload/datastore.go
@@ -149,6 +149,12 @@ func (ctx *DronaCtx) postChunk(req *DronaRequest, chunkDetail ChunkData) {
 //	make sure the reply is always sent back
 func (ctx *DronaCtx) postResponse(req *DronaRequest, status error) {
 	// status is already set up by action, we just have to set processed flag
+	defer func() {
+		err := recover()
+		if err != nil {
+			req.logger.Error(err)
+		}
+	}()
 	req.setProcessed()
 	req.result <- req
 }


### PR DESCRIPTION
If the data passed has a faulty chunk or the stream is closed from the other side then there is a race condition that can 
mean that zedUpload/datastore.go:postResponse can panic from trying to write to a closed response stream. Things
 seem to get cleaned up, but this can still cause applications using this library to crash. 

The offending stack trace looks like this:
```text
panic: send on closed channel

goroutine 93 [running]:
github.com/zededa/zedcloud/vendor/github.com/lf-edge/eve/libs/zedUpload.(*DronaCtx).postResponse(...)
	/go/src/github.com/zededa/zedcloud/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore.go:215
github.com/zededa/zedcloud/vendor/github.com/lf-edge/eve/libs/zedUpload.(*DronaCtx).handleRequest.func1()
	/go/src/github.com/zededa/zedcloud/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore.go:183 +0x7b
created by github.com/zededa/zedcloud/vendor/github.com/lf-edge/eve/libs/zedUpload.(*DronaCtx).handleRequest
	/go/src/github.com/zededa/zedcloud/vendor/github.com/lf-edge/eve/libs/zedUpload/datastore.go:179 +0xf1```