### PR TITLE
update syft to version with full golang and kernel support

### DIFF
--- a/.syft.yaml
+++ b/.syft.yaml
@@ -1,0 +1,65 @@
+# the output format(s) of the SBOM report (options: table, text, json, spdx, ...)
+# same as -o, --output, and SYFT_OUTPUT env var
+# to specify multiple output files in differing formats, use a list:
+# output:
+#   - "json=<syft-json-output-file>"
+#   - "spdx-json=<spdx-json-output-file>"
+output: "spdx-json"
+
+# enable/disable checking for application updates on startup
+# same as SYFT_CHECK_FOR_APP_UPDATE env var
+check-for-app-update: false
+
+# set the list of package catalogers to use when generating the SBOM
+# default = empty (cataloger set determined automatically by the source type [image or file/directory])
+# catalogers:
+#   - ruby-gemfile
+#   - ruby-gemspec
+#   - python-index
+#   - python-package
+#   - javascript-lock
+#   - javascript-package
+#   - php-composer-installed
+#   - php-composer-lock
+#   - alpmdb
+#   - dpkgdb
+#   - rpmdb
+#   - java
+#   - apkdb
+#   - go-module-binary
+#   - go-mod-file
+#   - dartlang-lock
+#   - rust
+#   - dotnet-deps
+# rust-audit-binary scans Rust binaries built with https://github.com/Shnatsel/rust-audit
+#   - rust-audit-binary
+catalogers:
+
+golang:
+   # search for go package licences in the GOPATH of the system running Syft, note that this is outside the
+   # container filesystem and potentially outside the root of a local directory scan
+   # SYFT_GOLANG_SEARCH_LOCAL_MOD_CACHE_LICENSES env var
+   search-local-mod-cache-licenses: true
+
+   # specify an explicit go mod cache directory, if unset this defaults to $GOPATH/pkg/mod or $HOME/go/pkg/mod
+   # SYFT_GOLANG_LOCAL_MOD_CACHE_DIR env var
+   local-mod-cache-dir: ""
+
+   # search for go package licences by retrieving the package from a network proxy
+   # SYFT_GOLANG_SEARCH_REMOTE_LICENSES env var
+   search-remote-licenses: true
+
+   # remote proxy to use when retrieving go packages from the network,
+   # if unset this defaults to $GOPROXY followed by https://proxy.golang.org
+   # SYFT_GOLANG_PROXY env var
+   proxy: ""
+
+   # specifies packages which should not be fetched by proxy
+   # if unset this defaults to $GONOPROXY
+   # SYFT_GOLANG_NOPROXY env var
+   no-proxy: ""
+
+linux-kernel:
+   # whether to catalog linux kernel modules found within lib/modules/** directories
+   # SYFT_LINUX_KERNEL_CATALOG_MODULES env var
+   catalog-modules: true

--- a/Makefile
+++ b/Makefile
@@ -290,7 +290,7 @@ GOSOURCES_VERSION=bc8b291f04566f35172f3d30f66e02e339f0342c
 GOSOURCES_SOURCE=github.com/deitch/go-sources-and-licenses
 
 
-SYFT_VERSION:=v0.63.0
+SYFT_VERSION:=v0.78.0
 SYFT_IMAGE:=docker.io/anchore/syft:$(SYFT_VERSION)
 
 # we use the following block to assign correct tag to the Docker registry artifact
@@ -608,7 +608,7 @@ $(SBOM): $(ROOTFS_TAR) | $(INSTALLER)
 	# this all can go away, and we can read the rootfs.tar
 	# see https://github.com/anchore/syft/issues/1400
 	tar xf $< -C $(TMP_ROOTDIR) --exclude "dev/*"
-	docker run -v $(TMP_ROOTDIR):/rootdir:ro $(SYFT_IMAGE) -o spdx-json /rootdir > $@
+	docker run -v $(TMP_ROOTDIR):/rootdir:ro -v $(PWD)/.syft.yaml:/syft.yaml:ro $(SYFT_IMAGE) -c /syft.yaml /rootdir > $@
 	rm -rf $(TMP_ROOTDIR)
 	$(QUIET): $@: Succeeded
 


### PR DESCRIPTION
This version has all of the fixes we have wanted for a long time: ability to retrieve golang licenses, ability to scan for kernel files, fixes for alpine package purls and licenses, etc.

The PR also includes a syft configuration file, which is mounted read-only into the image to configure it.