### PR TITLE
use CURDIR instead of PWD for call to mount config into syft

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -608,7 +608,7 @@ $(SBOM): $(ROOTFS_TAR) | $(INSTALLER)
 	# this all can go away, and we can read the rootfs.tar
 	# see https://github.com/anchore/syft/issues/1400
 	tar xf $< -C $(TMP_ROOTDIR) --exclude "dev/*"
-	docker run -v $(TMP_ROOTDIR):/rootdir:ro -v $(PWD)/.syft.yaml:/syft.yaml:ro $(SYFT_IMAGE) -c /syft.yaml /rootdir > $@
+	docker run -v $(TMP_ROOTDIR):/rootdir:ro -v $(CURDIR)/.syft.yaml:/syft.yaml:ro $(SYFT_IMAGE) -c /syft.yaml /rootdir > $@
 	rm -rf $(TMP_ROOTDIR)
 	$(QUIET): $@: Succeeded
 


### PR DESCRIPTION
It was mounting via `-v $(PWD)/.syft.yaml:/syft.yaml:ro`, which didn't work as it was the wrong directory, causing builds to fail. As @eriknordmark pointed out, we tend to use `$(CURDIR)` for that purpose elsewhere in the Makefile, and it works.