### PR TITLE
Add ibt-0041-0041 firmware for AX210 BT

### DIFF
--- a/pkg/fw/Dockerfile
+++ b/pkg/fw/Dockerfile
@@ -60,6 +60,7 @@ COPY --from=build /lib/firmware/iwlwifi-7260* /lib/firmware/
 COPY --from=build /lib/firmware/iwlwifi-9260* /lib/firmware/
 # AX210 160MHZ
 COPY --from=build /lib/firmware/iwlwifi-ty-a0-gf-a0-59.ucode /lib/firmware/
+COPY --from=build /lib/firmware/intel/ibt-0041-0041* /lib/firmware/intel/
 # NVidia Jetson
 COPY --from=build /lib/firmware/nvidia/tegra210 /lib/firmware/nvidia/tegra210
 # Dell Edge Gateway 300x firmware


### PR DESCRIPTION
To avoid an infinite loop failing to load firmware for AX210 bluetooth
for new EM321 model. Note that bluetooth is not likely to work with this
since we need a newer kernel with newer drivers for that.

Note that we avoid adding all of linux-firmware-intel and not even all ibt-* firmware to keep the image size under control.