### PR TITLE
Make SBOM optional to override; can put in different target or set to blank to skip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ EFI_PART=$(INSTALLER)/EFI
 BOOT_PART=$(INSTALLER)/boot
 BSP_IMX_PART=$(INSTALLER)/bsp-imx
 
-SBOM=$(ROOTFS).spdx.json
+SBOM?=$(ROOTFS).spdx.json
 COLLECTED_SOURCES=$(BUILD_DIR)/collected_sources.tar.gz
 DEVICETREE_DTB_amd64=
 DEVICETREE_DTB_arm64=$(DIST)/dtb/eve.dtb


### PR DESCRIPTION
`make eve` builds the eve container image with everything we need. Everything includes the sbom. This is great when building an image to distribute, but unnecessary when doing development, where fast cycle times matter.

This change lets someone write

```sh
make eve SBOM=
```

That overrides it to blank, and thus should have no sbom generated.

cc @milan-zededa 