### PR TITLE
simplify collection of sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -291,7 +291,7 @@ FORCE_BUILD=
 
 # for the go build sources
 GOSOURCES=$(BUILDTOOLS_BIN)/go-sources-and-licenses
-GOSOURCES_VERSION=bc8b291f04566f35172f3d30f66e02e339f0342c
+GOSOURCES_VERSION=91c965e0392ece0362bb9ac017ed052b679fc6f9
 GOSOURCES_SOURCE=github.com/deitch/go-sources-and-licenses
 
 
@@ -640,23 +640,7 @@ $(GOSOURCES):
 
 $(COLLECTED_SOURCES): $(ROOTFS_TAR) $(GOSOURCES)| $(INSTALLER)
 	$(QUIET): $@: Begin
-	$(eval TMP_ROOTDIR := $(shell mktemp -d))
-	# this is a bit of a hack, but we need to extract the rootfs tar to a directory, and it fails if
-	# we try to extract character devices, block devices or pipes, so we just exclude the dir.
-	# when syft supports reading straight from a tar archive with duplicate entries,
-	# this all can go away, and we can read the rootfs.tar
-	# see https://github.com/anchore/syft/issues/1400
-	tar xf $< -C $(TMP_ROOTDIR) --exclude "dev/*"
-	$(eval TMP_COLLECTED_SOURCES := $(shell mktemp -d))
-	bash tools/get-alpine-pkg-source.sh -s $(TMP_COLLECTED_SOURCES)/alpine -e $(TMP_ROOTDIR)
-	bash tools/get-kernel-source.sh -s $(TMP_COLLECTED_SOURCES)/kernel/
-	for i in $$(find . -name 'go.sum'); \
-		do								 		   \
-			$(GOSOURCES) sources -d $$(dirname $$i) --recursive --out $(TMP_COLLECTED_SOURCES)/go; \
-		done;
-	bash tools/generate-sources-manifests.sh $(TMP_COLLECTED_SOURCES)
-	tar -cf $(COLLECTED_SOURCES) -C $(TMP_COLLECTED_SOURCES) .
-	rm -rf $(TMP_ROOTDIR) $(TMP_COLLECTED_SOURCES)
+	bash tools/collect-sources.sh $< $(CURDIR) $@
 	$(QUIET): $@: Succeeded
 
 $(LIVE).raw: $(BOOT_PART) $(EFI_PART) $(ROOTFS_IMG) $(CONFIG_IMG) $(PERSIST_IMG) $(BSP_IMX_PART) | $(INSTALLER)

--- a/tools/collect-sources.sh
+++ b/tools/collect-sources.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+#
+# Copyright (c) 2023 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# collect-sources.sh
+# collect sources for alpine, go and kernel packages used in eve
+# arg1=tarfile with rootfs.tar
+# arg2=path to eve root
+# arg3=path to tar.gz file for output. If blank, will send to stdout
+
+set -e
+
+rootfs="$1"
+eve="$2"
+outfile="$3"
+
+[ -z "$outfile" ] && outfile=-
+
+tmproot=$(mktemp -d)
+tmpout=$(mktemp -d)
+manifest=${tmpout}/collected_sources_manifest.csv
+
+# this is a bit of a hack, but we need to extract the rootfs tar to a directory, and it fails if
+# we try to extract character devices, block devices or pipes, so we just exclude the dir.
+tar -xf "$rootfs" -C "$tmproot" --exclude "dev/*"
+
+{
+"${eve}/tools/get-alpine-pkg-source.sh" -s "${tmpout}" -e "${tmproot}" -p alpine
+"${eve}/tools/get-kernel-source.sh" -s "${tmpout}" -p kernel
+"${eve}/build-tools/bin/go-sources-and-licenses" sources -d "${eve}/pkg" --find --recursive --out "${tmpout}" --prefix golang --template 'golang,{{.Module}}@{{.Version}},{{.Version}},{{.Path}}'
+} > "${manifest}"
+
+tar -zcf "${outfile}" -C "${tmpout}" .
+rm -rf "${tmproot}" "${tmpout}"


### PR DESCRIPTION
* Updated the go program that retrieves the go sources to make it better able to loop, which eliminates complexity
* Moved some of the complex logic for source collection from a make target to a script in `tools/`
* Added output from each source to the desired format, to simplify manifest collection

The above is the basis for reconciliation between sbom and sources, which will come next.