### PR TITLE
[8.12 stable] Move HTTP send operations away from the main event loop

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -10,6 +10,7 @@
 | timer.location.cloud.interval | integer in seconds | 1 hour | how frequently device reports geographic location information to controller |
 | timer.location.app.interval | integer in seconds | 20 | how frequently device reports geographic location information to applications (to local profile server and to other apps via meta-data server) |
 | timer.send.timeout | timer in seconds | 120 | time for each http/send |
+| timer.dial.timeout | timer in seconds | 10 | maximum time allowed to establish connection |
 | timer.reboot.no.network | integer in seconds | 7 days | reboot after no cloud connectivity |
 | timer.update.fallback.no.network | integer in seconds | 300 | fallback after no cloud connectivity |
 | timer.test.baseimage.update | integer in seconds | 600 | commit to update |

--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -194,7 +194,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	subDeviceNetworkStatus.Activate()
 	zedcloudCtx := zedcloud.NewContext(log, zedcloud.ContextOptions{
 		DevNetworkStatus: clientCtx.deviceNetworkStatus,
-		Timeout:          clientCtx.globalConfig.GlobalValueInt(types.NetworkSendTimeout),
+		SendTimeout:      clientCtx.globalConfig.GlobalValueInt(types.NetworkSendTimeout),
+		DialTimeout:      clientCtx.globalConfig.GlobalValueInt(types.NetworkDialTimeout),
 		AgentMetrics:     clientCtx.zedcloudMetrics,
 		Serial:           hardware.GetProductSerial(log),
 		SoftSerial:       hardware.GetSoftSerial(log),

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -165,7 +165,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	zedcloudCtx := zedcloud.NewContext(log, zedcloud.ContextOptions{
 		DevNetworkStatus: ctx.DeviceNetworkStatus,
-		Timeout:          ctx.globalConfig.GlobalValueInt(types.NetworkSendTimeout),
+		SendTimeout:      ctx.globalConfig.GlobalValueInt(types.NetworkSendTimeout),
+		DialTimeout:      ctx.globalConfig.GlobalValueInt(types.NetworkDialTimeout),
 		AgentMetrics:     ctx.zedcloudMetrics,
 		Serial:           hardware.GetProductSerial(log),
 		SoftSerial:       hardware.GetSoftSerial(log),

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -481,12 +481,9 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// Before starting to process DomainConfig, domainmgr should (in this order):
 	//   1. wait for NIM to publish DNS to learn which ports are used for management
 	//   2. wait for PhysicalIOAdapters (from zedagent) to be processed
-	//   3. wait for NIM to finalize testing of selected DPC
-	// Note: 2. and 3. can also execute in the reverse order.
 	for !domainCtx.assignableAdapters.Initialized ||
-		len(domainCtx.deviceNetworkStatus.Ports) == 0 ||
-		domainCtx.deviceNetworkStatus.Testing {
-		log.Noticef("Waiting for AssignableAdapters and/or verified DPC")
+		len(domainCtx.deviceNetworkStatus.Ports) == 0 {
+		log.Noticef("Waiting for AssignableAdapters, DPC with management ports ")
 		select {
 		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)

--- a/pkg/pillar/cmd/loguploader/loguploader.go
+++ b/pkg/pillar/cmd/loguploader/loguploader.go
@@ -417,7 +417,8 @@ func sendCtxInit(ctx *loguploaderContext) {
 	//set newlog url
 	zedcloudCtx := zedcloud.NewContext(log, zedcloud.ContextOptions{
 		DevNetworkStatus: deviceNetworkStatus,
-		Timeout:          ctx.globalConfig.GlobalValueInt(types.NetworkSendTimeout),
+		SendTimeout:      ctx.globalConfig.GlobalValueInt(types.NetworkSendTimeout),
+		DialTimeout:      ctx.globalConfig.GlobalValueInt(types.NetworkDialTimeout),
 		AgentMetrics:     ctx.zedcloudMetrics,
 		Serial:           hardware.GetProductSerial(log),
 		SoftSerial:       hardware.GetSoftSerial(log),

--- a/pkg/pillar/cmd/zedagent/handleappInstMetadata.go
+++ b/pkg/pillar/cmd/zedagent/handleappInstMetadata.go
@@ -5,7 +5,10 @@
 
 package zedagent
 
-import "github.com/lf-edge/eve/pkg/pillar/types"
+import (
+	"github.com/lf-edge/eve/api/go/info"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
 
 func handleAppInstMetaDataCreate(ctxArg interface{}, key string,
 	statusArg interface{}) {
@@ -20,16 +23,11 @@ func handleAppInstMetaDataModify(ctxArg interface{}, key string,
 func handleAppInstMetaDataDelete(ctxArg interface{}, key string, statusArg interface{}) {
 	appInstMetaData := statusArg.(types.AppInstMetaData)
 	ctx := ctxArg.(*zedagentContext)
-	uuidStr := appInstMetaData.Key()
-	PublishAppInstMetaDataToZedCloud(ctx, uuidStr, nil, appInstMetaData.Type, ctx.iteration)
-	ctx.iteration++
+	triggerPublishDeletedObjectInfo(
+		ctx, info.ZInfoTypes_ZiAppInstMetaData, key, appInstMetaData)
 }
 
 func handleAppInstMetaDataImpl(ctxArg interface{}, key string, statusArg interface{}) {
-
-	appInstMetaData := statusArg.(types.AppInstMetaData)
 	ctx := ctxArg.(*zedagentContext)
-	uuidStr := appInstMetaData.Key()
-	PublishAppInstMetaDataToZedCloud(ctx, uuidStr, &appInstMetaData, appInstMetaData.Type, ctx.iteration)
-	ctx.iteration++
+	triggerPublishObjectInfo(ctx, info.ZInfoTypes_ZiAppInstMetaData, key)
 }

--- a/pkg/pillar/cmd/zedagent/handleblob.go
+++ b/pkg/pillar/cmd/zedagent/handleblob.go
@@ -1,6 +1,9 @@
 package zedagent
 
-import "github.com/lf-edge/eve/pkg/pillar/types"
+import (
+	"github.com/lf-edge/eve/api/go/info"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
 
 func blobStatusGetAll(ctx *zedagentContext) map[string]*types.BlobStatus {
 	sub := ctx.subBlobStatus
@@ -24,18 +27,12 @@ func handleBlobStatusModify(ctxArg interface{}, key string,
 
 func handleBlobStatusImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
-
-	status := statusArg.(types.BlobStatus)
 	ctx := ctxArg.(*zedagentContext)
-	uuidStr := status.Key()
-	PublishBlobInfoToZedCloud(ctx, uuidStr, &status, ctx.iteration)
-	ctx.iteration++
+	triggerPublishObjectInfo(ctx, info.ZInfoTypes_ZiBlobList, key)
 }
 
 func handleBlobDelete(ctxArg interface{}, key string, statusArg interface{}) {
 	status := statusArg.(types.BlobStatus)
 	ctx := ctxArg.(*zedagentContext)
-	uuidStr := status.Key()
-	PublishBlobInfoToZedCloud(ctx, uuidStr, nil, ctx.iteration)
-	ctx.iteration++
+	triggerPublishDeletedObjectInfo(ctx, info.ZInfoTypes_ZiBlobList, key, status)
 }

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -300,7 +300,8 @@ func indicateInvalidBootstrapConfig(getconfigCtx *getconfigContext) {
 	getconfigCtx.ledBlinkCount = types.LedBlinkInvalidBootstrapConfig
 }
 
-func initZedcloudContext(networkSendTimeout uint32, agentMetrics *zedcloud.AgentMetrics) *zedcloud.ZedCloudContext {
+func initZedcloudContext(networkSendTimeout, networkDialTimeout uint32,
+	agentMetrics *zedcloud.AgentMetrics) *zedcloud.ZedCloudContext {
 
 	// get the server name
 	bytes, err := ioutil.ReadFile(types.ServerFileName)
@@ -312,7 +313,8 @@ func initZedcloudContext(networkSendTimeout uint32, agentMetrics *zedcloud.Agent
 
 	zedcloudCtx := zedcloud.NewContext(log, zedcloud.ContextOptions{
 		DevNetworkStatus: deviceNetworkStatus,
-		Timeout:          networkSendTimeout,
+		SendTimeout:      networkSendTimeout,
+		DialTimeout:      networkDialTimeout,
 		AgentMetrics:     agentMetrics,
 		Serial:           hardware.GetProductSerial(log),
 		SoftSerial:       hardware.GetSoftSerial(log),

--- a/pkg/pillar/cmd/zedagent/handlecontent.go
+++ b/pkg/pillar/cmd/zedagent/handlecontent.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	zconfig "github.com/lf-edge/eve/api/go/config"
+	"github.com/lf-edge/eve/api/go/info"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/satori/go.uuid"
 )
@@ -106,19 +107,13 @@ func handleContentTreeStatusModify(ctxArg interface{}, key string,
 
 func handleContentTreeStatusImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
-
-	status := statusArg.(types.ContentTreeStatus)
 	ctx := ctxArg.(*zedagentContext)
-	uuidStr := status.Key()
-	PublishContentInfoToZedCloud(ctx, uuidStr, &status, ctx.iteration)
-	ctx.iteration++
+	triggerPublishObjectInfo(ctx, info.ZInfoTypes_ZiContentTree, key)
 }
 
 func handleContentTreeStatusDelete(ctxArg interface{}, key string,
 	statusArg interface{}) {
-
+	status := statusArg.(types.ContentTreeStatus)
 	ctx := ctxArg.(*zedagentContext)
-	uuidStr := key
-	PublishContentInfoToZedCloud(ctx, uuidStr, nil, ctx.iteration)
-	ctx.iteration++
+	triggerPublishDeletedObjectInfo(ctx, info.ZInfoTypes_ZiContentTree, key, status)
 }

--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -44,7 +44,7 @@ func handleNetworkInstanceImpl(ctxArg interface{}, key string,
 		log.Errorf("Received NetworkInstance error %s",
 			status.Error)
 	}
-	prepareAndPublishNetworkInstanceInfoMsg(ctx, status, false)
+	triggerPublishObjectInfo(ctx, zinfo.ZInfoTypes_ZiNetworkInstance, key)
 	log.Functionf("handleNetworkInstanceImpl(%s) done", key)
 }
 
@@ -52,9 +52,8 @@ func handleNetworkInstanceDelete(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
 	log.Functionf("handleNetworkInstanceDelete(%s)", key)
-	status := statusArg.(types.NetworkInstanceStatus)
 	ctx := ctxArg.(*zedagentContext)
-	prepareAndPublishNetworkInstanceInfoMsg(ctx, status, true)
+	triggerPublishDeletedObjectInfo(ctx, zinfo.ZInfoTypes_ZiNetworkInstance, key, statusArg)
 	log.Functionf("handleNetworkInstanceDelete(%s) done", key)
 }
 

--- a/pkg/pillar/cmd/zedagent/handlevolume.go
+++ b/pkg/pillar/cmd/zedagent/handlevolume.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 
 	zconfig "github.com/lf-edge/eve/api/go/config"
+	"github.com/lf-edge/eve/api/go/info"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/satori/go.uuid"
 )
@@ -166,20 +167,13 @@ func handleVolumeStatusModify(ctxArg interface{}, key string,
 
 func handleVolumeStatusImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
-
-	status := statusArg.(types.VolumeStatus)
 	ctx := ctxArg.(*zedagentContext)
-	uuidStr := status.VolumeID.String()
-	PublishVolumeToZedCloud(ctx, uuidStr, &status, ctx.iteration)
-	ctx.iteration++
+	triggerPublishObjectInfo(ctx, info.ZInfoTypes_ZiVolume, key)
 }
 
 func handleVolumeStatusDelete(ctxArg interface{},
 	key string, statusArg interface{}) {
-
 	status := statusArg.(types.VolumeStatus)
 	ctx := ctxArg.(*zedagentContext)
-	uuidStr := status.VolumeID.String()
-	PublishVolumeToZedCloud(ctx, uuidStr, nil, ctx.iteration)
-	ctx.iteration++
+	triggerPublishDeletedObjectInfo(ctx, info.ZInfoTypes_ZiVolume, key, status)
 }

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -112,6 +112,7 @@ type zedagentContext struct {
 	TriggerDeviceInfo         chan<- struct{}
 	TriggerHwInfo             chan<- struct{}
 	TriggerObjectInfo         chan<- infoForObjectKey
+	triggerHandleDeferred     chan<- time.Time
 	zbootRestarted            bool // published by baseosmgr
 	subOnboardStatus          pubsub.Subscription
 	subBaseOsStatus           pubsub.Subscription
@@ -215,8 +216,10 @@ var zedcloudCtx *zedcloud.ZedCloudContext
 
 // object to trigger sending of info with infoType for objectKey
 type infoForObjectKey struct {
-	infoType  info.ZInfoTypes
-	objectKey string
+	infoType    info.ZInfoTypes
+	objectKey   string
+	deleted     bool
+	deletedInfo interface{}
 }
 
 func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) int {
@@ -277,13 +280,16 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	zedagentCtx.fatalFlag = *fatalPtr
 
 	flowlogQueue := make(chan *flowlog.FlowMessage, flowlogQueueCap)
+	// Channels with buffer of size 1 are used with non-blocking send.
 	triggerDeviceInfo := make(chan struct{}, 1)
 	triggerHwInfo := make(chan struct{}, 1)
-	triggerObjectInfo := make(chan infoForObjectKey, 1)
+	triggerObjectInfo := make(chan infoForObjectKey, 256)
+	triggerHandleDeferred := make(chan time.Time, 1)
 	zedagentCtx.FlowlogQueue = flowlogQueue
 	zedagentCtx.TriggerDeviceInfo = triggerDeviceInfo
 	zedagentCtx.TriggerHwInfo = triggerHwInfo
 	zedagentCtx.TriggerObjectInfo = triggerObjectInfo
+	zedagentCtx.triggerHandleDeferred = triggerHandleDeferred
 
 	// Initialize all zedagent publications.
 	initPublications(zedagentCtx)
@@ -346,6 +352,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 	// We know our own UUID; prepare for communication with controller
 	zedcloudCtx = initZedcloudContext(
 		zedagentCtx.globalConfig.GlobalValueInt(types.NetworkSendTimeout),
+		zedagentCtx.globalConfig.GlobalValueInt(types.NetworkDialTimeout),
 		zedagentCtx.zedcloudMetrics)
 	// Timer for deferred sends of info messages
 	zedagentCtx.deferredChan = zedcloud.GetDeferredChan(zedcloudCtx,
@@ -361,6 +368,9 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject) in
 
 	//initialize remote attestation context
 	attestModuleInitialize(zedagentCtx)
+
+	// Handle deferred requests from periodic queue
+	go handleDeferredPeriodicTask(zedagentCtx, triggerHandleDeferred)
 
 	// Pick up debug aka log level before we start real work
 	waitUntilGCReady(zedagentCtx, stillRunning)
@@ -610,11 +620,7 @@ func waitUntilDNSReady(zedagentCtx *zedagentContext, stillRunning *time.Ticker) 
 		case change := <-dnsCtx.subDeviceNetworkStatus.MsgChan():
 			dnsCtx.subDeviceNetworkStatus.ProcessChange(change)
 			if dnsCtx.triggerHandleDeferred {
-				start := time.Now()
-				zedcloud.HandleDeferred(zedcloudCtx, start, 100*time.Millisecond, false)
-				zedagentCtx.ps.CheckMaxTimeTopic(agentName, "deferredChan", start,
-					warningTime, errorTime)
-				dnsCtx.triggerHandleDeferred = false
+				triggerHandleDeferred(zedagentCtx)
 			}
 
 		case change := <-zedagentCtx.subAssignableAdapters.MsgChan():
@@ -645,12 +651,6 @@ func waitUntilDNSReady(zedagentCtx *zedagentContext, stillRunning *time.Ticker) 
 		case change := <-zedagentCtx.subLocationInfo.MsgChan():
 			zedagentCtx.subLocationInfo.ProcessChange(change)
 
-		case change := <-zedagentCtx.deferredChan:
-			start := time.Now()
-			zedcloud.HandleDeferred(zedcloudCtx, change, 100*time.Millisecond, false)
-			zedagentCtx.ps.CheckMaxTimeTopic(agentName, "deferredChan", start,
-				warningTime, errorTime)
-
 		case <-stillRunning.C:
 			// Fault injection
 			if zedagentCtx.fatalFlag {
@@ -662,6 +662,37 @@ func waitUntilDNSReady(zedagentCtx *zedagentContext, stillRunning *time.Ticker) 
 		} else {
 			zedagentCtx.ps.StillRunning(agentName, warningTime, errorTime)
 		}
+	}
+}
+
+func handleDeferredPeriodicTask(zedagentCtx *zedagentContext,
+	triggerHandleDeferred <-chan time.Time) {
+	wdName := agentName + "devinfo"
+
+	// Run a periodic timer so we always update StillRunning
+	stillRunning := time.NewTicker(25 * time.Second)
+	zedagentCtx.ps.StillRunning(wdName, warningTime, errorTime)
+	zedagentCtx.ps.RegisterFileWatchdog(wdName)
+
+	runHandleDeferred := func(change time.Time) {
+		start := time.Now()
+		if !zedcloud.HandleDeferred(zedcloudCtx,
+			change, 100*time.Millisecond, false) {
+			log.Noticef("handleDeferredPeriodicTask: some deferred items remain to be sent")
+		}
+		zedagentCtx.ps.CheckMaxTimeTopic(agentName, "deferredPeriodicCtx",
+			start, warningTime, errorTime)
+	}
+
+	for {
+		select {
+		case change := <-triggerHandleDeferred:
+			runHandleDeferred(change)
+		case change := <-zedagentCtx.deferredChan:
+			runHandleDeferred(change)
+		case <-stillRunning.C:
+		}
+		zedagentCtx.ps.StillRunning(wdName, warningTime, errorTime)
 	}
 }
 
@@ -726,10 +757,7 @@ func mainEventLoop(zedagentCtx *zedagentContext, stillRunning *time.Ticker) {
 				dnsCtx.triggerDeviceInfo = false
 			}
 			if dnsCtx.triggerHandleDeferred {
-				start := time.Now()
-				zedcloud.HandleDeferred(zedcloudCtx, start, 100*time.Millisecond, false)
-				zedagentCtx.ps.CheckMaxTimeTopic(agentName, "deferredChan", start, warningTime, errorTime)
-				dnsCtx.triggerHandleDeferred = false
+				triggerHandleDeferred(zedagentCtx)
 			}
 			if dnsCtx.triggerRadioPOST {
 				triggerRadioPOST(getconfigCtx)
@@ -818,12 +846,6 @@ func mainEventLoop(zedagentCtx *zedagentContext, stillRunning *time.Ticker) {
 			} else {
 				downloaderMetrics = m.(types.MetricsMap)
 			}
-
-		case change := <-zedagentCtx.deferredChan:
-			start := time.Now()
-			zedcloud.HandleDeferred(zedcloudCtx, change, 100*time.Millisecond, false)
-			zedagentCtx.ps.CheckMaxTimeTopic(agentName, "deferredChan", start,
-				warningTime, errorTime)
 
 		case change := <-zedagentCtx.subCipherMetricsDL.MsgChan():
 			zedagentCtx.subCipherMetricsDL.ProcessChange(change)
@@ -1810,6 +1832,17 @@ func triggerPublishDevInfo(ctxPtr *zedagentContext) {
 	triggerLocalDevInfoPOST(ctxPtr.getconfigCtx)
 }
 
+func triggerHandleDeferred(ctxPtr *zedagentContext) {
+
+	select {
+	case ctxPtr.triggerHandleDeferred <- time.Now():
+		// Do nothing more
+	default:
+		// Probably already triggered but not yet received by the Go routine.
+		log.Warnf("Failed to trigger HandleDeferred")
+	}
+}
+
 func triggerPublishLocationToController(ctxPtr *zedagentContext) {
 	if ctxPtr.getconfigCtx.locationCloudTickerHandle == nil {
 		// Location reporting task is not yet running.
@@ -1817,6 +1850,24 @@ func triggerPublishLocationToController(ctxPtr *zedagentContext) {
 	}
 	log.Function("Triggered publishLocationToController")
 	flextimer.TickNow(ctxPtr.getconfigCtx.locationCloudTickerHandle)
+}
+
+func triggerPublishObjectInfo(ctxPtr *zedagentContext, infoType info.ZInfoTypes,
+	objectKey string) {
+	ctxPtr.TriggerObjectInfo <- infoForObjectKey{
+		infoType:  infoType,
+		objectKey: objectKey,
+	}
+}
+
+func triggerPublishDeletedObjectInfo(ctxPtr *zedagentContext, infoType info.ZInfoTypes,
+	objectKey string, deletedInfo interface{}) {
+	ctxPtr.TriggerObjectInfo <- infoForObjectKey{
+		infoType:    infoType,
+		objectKey:   objectKey,
+		deleted:     true,
+		deletedInfo: deletedInfo,
+	}
 }
 
 func triggerPublishAllInfo(ctxPtr *zedagentContext) {
@@ -1830,52 +1881,52 @@ func triggerPublishAllInfo(ctxPtr *zedagentContext) {
 		// trigger publish applications infos
 		for _, c := range ctxPtr.getconfigCtx.subAppInstanceStatus.GetAll() {
 			ctxPtr.TriggerObjectInfo <- infoForObjectKey{
-				info.ZInfoTypes_ZiApp,
-				c.(types.AppInstanceStatus).Key(),
+				infoType:  info.ZInfoTypes_ZiApp,
+				objectKey: c.(types.AppInstanceStatus).Key(),
 			}
 		}
 		// trigger publish network instance infos
 		for _, c := range ctxPtr.subNetworkInstanceStatus.GetAll() {
 			niStatus := c.(types.NetworkInstanceStatus)
 			ctxPtr.TriggerObjectInfo <- infoForObjectKey{
-				info.ZInfoTypes_ZiNetworkInstance,
-				(&niStatus).Key(),
+				infoType:  info.ZInfoTypes_ZiNetworkInstance,
+				objectKey: (&niStatus).Key(),
 			}
 		}
 		// trigger publish volume infos
 		for _, c := range ctxPtr.getconfigCtx.subVolumeStatus.GetAll() {
 			ctxPtr.TriggerObjectInfo <- infoForObjectKey{
-				info.ZInfoTypes_ZiVolume,
-				c.(types.VolumeStatus).Key(),
+				infoType:  info.ZInfoTypes_ZiVolume,
+				objectKey: c.(types.VolumeStatus).Key(),
 			}
 		}
 		// trigger publish content tree infos
 		for _, c := range ctxPtr.getconfigCtx.subContentTreeStatus.GetAll() {
 			ctxPtr.TriggerObjectInfo <- infoForObjectKey{
-				info.ZInfoTypes_ZiContentTree,
-				c.(types.ContentTreeStatus).Key(),
+				infoType:  info.ZInfoTypes_ZiContentTree,
+				objectKey: c.(types.ContentTreeStatus).Key(),
 			}
 		}
 		// trigger publish blob infos
 		for _, c := range ctxPtr.subBlobStatus.GetAll() {
 			ctxPtr.TriggerObjectInfo <- infoForObjectKey{
-				info.ZInfoTypes_ZiBlobList,
-				c.(types.BlobStatus).Key(),
+				infoType:  info.ZInfoTypes_ZiBlobList,
+				objectKey: c.(types.BlobStatus).Key(),
 			}
 		}
 		// trigger publish appInst metadata infos
 		for _, c := range ctxPtr.subAppInstMetaData.GetAll() {
 			ctxPtr.TriggerObjectInfo <- infoForObjectKey{
-				info.ZInfoTypes_ZiAppInstMetaData,
-				c.(types.AppInstMetaData).Key(),
+				infoType:  info.ZInfoTypes_ZiAppInstMetaData,
+				objectKey: c.(types.AppInstMetaData).Key(),
 			}
 		}
 		triggerPublishHwInfo(ctxPtr)
 		// trigger publish edgeview infos
 		for _, c := range ctxPtr.subEdgeviewStatus.GetAll() {
 			ctxPtr.TriggerObjectInfo <- infoForObjectKey{
-				info.ZInfoTypes_ZiEdgeview,
-				c.(types.EdgeviewStatus).Key(),
+				infoType:  info.ZInfoTypes_ZiEdgeview,
+				objectKey: c.(types.EdgeviewStatus).Key(),
 			}
 		}
 		triggerPublishLocationToController(ctxPtr)
@@ -1903,9 +1954,7 @@ func handleAppInstanceStatusCreate(ctxArg interface{}, key string,
 	status := statusArg.(types.AppInstanceStatus)
 	log.Functionf("handleAppInstanceStatusCreate(%s)", key)
 	ctx := ctxArg.(*zedagentContext)
-	uuidStr := status.Key()
-	PublishAppInfoToZedCloud(ctx, uuidStr, &status, ctx.assignableAdapters,
-		ctx.iteration)
+	triggerPublishObjectInfo(ctx, info.ZInfoTypes_ZiApp, key)
 	triggerPublishDevInfo(ctx)
 	processAppCommandStatus(ctx.getconfigCtx, status)
 	triggerLocalAppInfoPOST(ctx.getconfigCtx)
@@ -1922,9 +1971,7 @@ func handleAppInstanceStatusModify(ctxArg interface{}, key string,
 	status := statusArg.(types.AppInstanceStatus)
 	log.Functionf("handleAppInstanceStatusModify(%s)", key)
 	ctx := ctxArg.(*zedagentContext)
-	uuidStr := status.Key()
-	PublishAppInfoToZedCloud(ctx, uuidStr, &status, ctx.assignableAdapters,
-		ctx.iteration)
+	triggerPublishObjectInfo(ctx, info.ZInfoTypes_ZiApp, key)
 	processAppCommandStatus(ctx.getconfigCtx, status)
 	triggerLocalAppInfoPOST(ctx.getconfigCtx)
 	ctx.iteration++
@@ -1935,10 +1982,8 @@ func handleAppInstanceStatusDelete(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
 	ctx := ctxArg.(*zedagentContext)
-	uuidStr := key
 	log.Functionf("handleAppInstanceStatusDelete(%s)", key)
-	PublishAppInfoToZedCloud(ctx, uuidStr, nil, ctx.assignableAdapters,
-		ctx.iteration)
+	triggerPublishDeletedObjectInfo(ctx, info.ZInfoTypes_ZiApp, key, statusArg)
 	triggerPublishDevInfo(ctx)
 	triggerLocalAppInfoPOST(ctx.getconfigCtx)
 	ctx.iteration++
@@ -2445,7 +2490,6 @@ func handleEdgeviewStatusModify(ctxArg interface{}, key string,
 }
 
 func handleEdgeviewStatusImpl(ctxArg interface{}, key string, statusArg interface{}) {
-	status := statusArg.(types.EdgeviewStatus)
 	ctx := ctxArg.(*zedagentContext)
-	PublishEdgeviewToZedCloud(ctx, &status)
+	triggerPublishObjectInfo(ctx, info.ZInfoTypes_ZiEdgeview, key)
 }

--- a/pkg/pillar/cmd/zedrouter/probe.go
+++ b/pkg/pillar/cmd/zedrouter/probe.go
@@ -303,7 +303,7 @@ func launchHostProbe(ctx *zedrouterContext) {
 	ditems := dpub.GetAll()
 
 	zcloudCtx := zedcloud.NewContext(log, zedcloud.ContextOptions{
-		Timeout:      maxRemoteProbeWait,
+		SendTimeout:  maxRemoteProbeWait,
 		TLSConfig:    &tls.Config{InsecureSkipVerify: true},
 		AgentMetrics: ctx.zedcloudMetrics,
 		AgentName:    agentName,

--- a/pkg/pillar/conntester/zedcloud.go
+++ b/pkg/pillar/conntester/zedcloud.go
@@ -56,7 +56,7 @@ func (t *ZedcloudConnectivityTester) TestConnectivity(
 
 	zedcloudCtx := zedcloud.NewContext(t.Log, zedcloud.ContextOptions{
 		DevNetworkStatus: &dns,
-		Timeout:          uint32(t.TestTimeout.Seconds()),
+		SendTimeout:      uint32(t.TestTimeout.Seconds()),
 		AgentMetrics:     t.Metrics,
 		Serial:           hardware.GetProductSerial(t.Log),
 		SoftSerial:       hardware.GetSoftSerial(t.Log),

--- a/pkg/pillar/devicenetwork/wpad.go
+++ b/pkg/pillar/devicenetwork/wpad.go
@@ -95,7 +95,7 @@ func getPacFile(log *base.LogObject, url string,
 	ifname string, metrics *zedcloud.AgentMetrics) (string, error) {
 
 	zedcloudCtx := zedcloud.NewContext(log, zedcloud.ContextOptions{
-		Timeout:      15,
+		SendTimeout:  15,
 		AgentName:    "wpad",
 		AgentMetrics: metrics,
 	})

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -191,6 +191,8 @@ const (
 	NetworkTestTimeout GlobalSettingKey = "timer.port.timeout"
 	// NetworkSendTimeout global setting key
 	NetworkSendTimeout GlobalSettingKey = "timer.send.timeout"
+	// NetworkDialTimeout global setting key
+	NetworkDialTimeout GlobalSettingKey = "timer.dial.timeout"
 	// LocationCloudInterval global setting key
 	LocationCloudInterval GlobalSettingKey = "timer.location.cloud.interval"
 	// LocationAppInterval global setting key
@@ -793,6 +795,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddIntItem(NetworkTestBetterInterval, 600, 0, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(NetworkTestTimeout, 15, 0, 3600)
 	configItemSpecMap.AddIntItem(NetworkSendTimeout, 120, 0, 3600)
+	configItemSpecMap.AddIntItem(NetworkDialTimeout, 10, 0, 3600)
 	configItemSpecMap.AddIntItem(LocationCloudInterval, HourInSec, 5*MinuteInSec, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(LocationAppInterval, 20, 5, HourInSec)
 	configItemSpecMap.AddIntItem(Dom0MinDiskUsagePercent, 20, 20, 80)

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -168,6 +168,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		NetworkTestBetterInterval,
 		NetworkTestTimeout,
 		NetworkSendTimeout,
+		NetworkDialTimeout,
 		Dom0MinDiskUsagePercent,
 		AppContainerStatsInterval,
 		VaultReadyCutOffTime,


### PR DESCRIPTION
Zedagent main event loop is responsible for handling pubsub updates along with sending messages to the controller. HTTP send is synchronous call and can stall the whole main event loop for up to 6 minutes (overall send timeout). This badly affects the system responsiveness which can be observed in air gaped environment (no connectivity to the controller), when the queue is stuck waiting for send to be completed and no other pubsub updates are handled. 

Three things are done in this PR:
1. Introduced ```connect()``` ("dial" in terms of Go) timeout, which is less than actual ```send()``` timeout (helps to fail faster).
2. All direct HTTP ```send()``` calls are moved away from the main event loop and executed in dedicated goroutines.
3. (second commit) Also make sure that VMs (such as Local Profile Server or Local Operator Console) are not delayed by NIM testing DPC. In offline mode connectivity probes will take longer (until dial timeout elapsed).

This is a backport of original patches from @milan-zededa to the 8.12 stable branch.

CC: @milan-zededa 