### PR TITLE
Move HTTP send operations away from the zedagent main event loop

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -10,6 +10,7 @@
 | timer.location.cloud.interval | integer in seconds | 1 hour | how frequently device reports geographic location information to controller |
 | timer.location.app.interval | integer in seconds | 20 | how frequently device reports geographic location information to applications (to local profile server and to other apps via meta-data server) |
 | timer.send.timeout | timer in seconds | 120 | time for each http/send |
+| timer.dial.timeout | timer in seconds | 10 | maximum time allowed to establish connection |
 | timer.reboot.no.network | integer in seconds | 7 days | reboot after no cloud connectivity |
 | timer.update.fallback.no.network | integer in seconds | 300 | fallback after no cloud connectivity |
 | timer.test.baseimage.update | integer in seconds | 600 | commit to update |

--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -197,7 +197,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	subDeviceNetworkStatus.Activate()
 	zedcloudCtx := zedcloud.NewContext(log, zedcloud.ContextOptions{
 		DevNetworkStatus: clientCtx.deviceNetworkStatus,
-		Timeout:          clientCtx.globalConfig.GlobalValueInt(types.NetworkSendTimeout),
+		SendTimeout:      clientCtx.globalConfig.GlobalValueInt(types.NetworkSendTimeout),
+		DialTimeout:      clientCtx.globalConfig.GlobalValueInt(types.NetworkDialTimeout),
 		AgentMetrics:     clientCtx.zedcloudMetrics,
 		Serial:           hardware.GetProductSerial(log),
 		SoftSerial:       hardware.GetSoftSerial(log),

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -172,7 +172,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 
 	zedcloudCtx := zedcloud.NewContext(log, zedcloud.ContextOptions{
 		DevNetworkStatus: ctx.DeviceNetworkStatus,
-		Timeout:          ctx.globalConfig.GlobalValueInt(types.NetworkSendTimeout),
+		SendTimeout:      ctx.globalConfig.GlobalValueInt(types.NetworkSendTimeout),
+		DialTimeout:      ctx.globalConfig.GlobalValueInt(types.NetworkDialTimeout),
 		AgentMetrics:     ctx.zedcloudMetrics,
 		Serial:           hardware.GetProductSerial(log),
 		SoftSerial:       hardware.GetSoftSerial(log),

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -486,15 +486,13 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	// Before starting to process DomainConfig, domainmgr should (in this order):
 	//   1. wait for NIM to publish DNS to learn which ports are used for management
 	//   2. wait for PhysicalIOAdapters (from zedagent) to be processed
-	//   3. wait for NIM to finalize testing of selected DPC
-	//   4. wait for capabilities information from hypervisor
-	// Note: 2. and 3. can also execute in the reverse order.
-	// Note: 4 may come in any order
+	//   3. wait for capabilities information from hypervisor
+	// Note: 3 may come in any order
 	for !domainCtx.assignableAdapters.Initialized ||
 		len(domainCtx.deviceNetworkStatus.Ports) == 0 ||
-		domainCtx.deviceNetworkStatus.Testing ||
 		!capabilitiesSent {
-		log.Noticef("Waiting for AssignableAdapters and/or verified DPC")
+		log.Noticef("Waiting for AssignableAdapters, DPC with management ports " +
+			"and hypervisor capabilities")
 		select {
 		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)

--- a/pkg/pillar/cmd/loguploader/loguploader.go
+++ b/pkg/pillar/cmd/loguploader/loguploader.go
@@ -403,7 +403,8 @@ func sendCtxInit(ctx *loguploaderContext) {
 	//set newlog url
 	zedcloudCtx := zedcloud.NewContext(log, zedcloud.ContextOptions{
 		DevNetworkStatus: deviceNetworkStatus,
-		Timeout:          ctx.globalConfig.GlobalValueInt(types.NetworkSendTimeout),
+		SendTimeout:      ctx.globalConfig.GlobalValueInt(types.NetworkSendTimeout),
+		DialTimeout:      ctx.globalConfig.GlobalValueInt(types.NetworkDialTimeout),
 		AgentMetrics:     ctx.zedcloudMetrics,
 		Serial:           hardware.GetProductSerial(log),
 		SoftSerial:       hardware.GetSoftSerial(log),

--- a/pkg/pillar/cmd/zedagent/handleappInstMetadata.go
+++ b/pkg/pillar/cmd/zedagent/handleappInstMetadata.go
@@ -5,7 +5,10 @@
 
 package zedagent
 
-import "github.com/lf-edge/eve/pkg/pillar/types"
+import (
+	"github.com/lf-edge/eve/api/go/info"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
 
 func handleAppInstMetaDataCreate(ctxArg interface{}, key string,
 	statusArg interface{}) {
@@ -20,14 +23,11 @@ func handleAppInstMetaDataModify(ctxArg interface{}, key string,
 func handleAppInstMetaDataDelete(ctxArg interface{}, key string, statusArg interface{}) {
 	appInstMetaData := statusArg.(types.AppInstMetaData)
 	ctx := ctxArg.(*zedagentContext)
-	PublishAppInstMetaDataToZedCloud(ctx, &appInstMetaData, true, AllDest)
-	ctx.iteration++
+	triggerPublishDeletedObjectInfo(
+		ctx, info.ZInfoTypes_ZiAppInstMetaData, key, appInstMetaData)
 }
 
 func handleAppInstMetaDataImpl(ctxArg interface{}, key string, statusArg interface{}) {
-
-	appInstMetaData := statusArg.(types.AppInstMetaData)
 	ctx := ctxArg.(*zedagentContext)
-	PublishAppInstMetaDataToZedCloud(ctx, &appInstMetaData, false, AllDest)
-	ctx.iteration++
+	triggerPublishObjectInfo(ctx, info.ZInfoTypes_ZiAppInstMetaData, key)
 }

--- a/pkg/pillar/cmd/zedagent/handleappInstMetadata.go
+++ b/pkg/pillar/cmd/zedagent/handleappInstMetadata.go
@@ -23,7 +23,7 @@ func handleAppInstMetaDataModify(ctxArg interface{}, key string,
 func handleAppInstMetaDataDelete(ctxArg interface{}, key string, statusArg interface{}) {
 	appInstMetaData := statusArg.(types.AppInstMetaData)
 	ctx := ctxArg.(*zedagentContext)
-	triggerPublishDeletedObjectInfo(
+	triggerUnpublishObjectInfo(
 		ctx, info.ZInfoTypes_ZiAppInstMetaData, key, appInstMetaData)
 }
 

--- a/pkg/pillar/cmd/zedagent/handleblob.go
+++ b/pkg/pillar/cmd/zedagent/handleblob.go
@@ -1,6 +1,9 @@
 package zedagent
 
-import "github.com/lf-edge/eve/pkg/pillar/types"
+import (
+	"github.com/lf-edge/eve/api/go/info"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
 
 func blobStatusGetAll(ctx *zedagentContext) map[string]*types.BlobStatus {
 	sub := ctx.subBlobStatus
@@ -24,18 +27,12 @@ func handleBlobStatusModify(ctxArg interface{}, key string,
 
 func handleBlobStatusImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
-
-	status := statusArg.(types.BlobStatus)
 	ctx := ctxArg.(*zedagentContext)
-	uuidStr := status.Key()
-	PublishBlobInfoToZedCloud(ctx, uuidStr, &status, ctx.iteration, AllDest)
-	ctx.iteration++
+	triggerPublishObjectInfo(ctx, info.ZInfoTypes_ZiBlobList, key)
 }
 
 func handleBlobDelete(ctxArg interface{}, key string, statusArg interface{}) {
 	status := statusArg.(types.BlobStatus)
 	ctx := ctxArg.(*zedagentContext)
-	uuidStr := status.Key()
-	PublishBlobInfoToZedCloud(ctx, uuidStr, nil, ctx.iteration, AllDest)
-	ctx.iteration++
+	triggerPublishDeletedObjectInfo(ctx, info.ZInfoTypes_ZiBlobList, key, status)
 }

--- a/pkg/pillar/cmd/zedagent/handleblob.go
+++ b/pkg/pillar/cmd/zedagent/handleblob.go
@@ -34,5 +34,5 @@ func handleBlobStatusImpl(ctxArg interface{}, key string,
 func handleBlobDelete(ctxArg interface{}, key string, statusArg interface{}) {
 	status := statusArg.(types.BlobStatus)
 	ctx := ctxArg.(*zedagentContext)
-	triggerPublishDeletedObjectInfo(ctx, info.ZInfoTypes_ZiBlobList, key, status)
+	triggerUnpublishObjectInfo(ctx, info.ZInfoTypes_ZiBlobList, key, status)
 }

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -303,7 +303,8 @@ func indicateInvalidBootstrapConfig(getconfigCtx *getconfigContext) {
 	getconfigCtx.ledBlinkCount = types.LedBlinkInvalidBootstrapConfig
 }
 
-func initZedcloudContext(networkSendTimeout uint32, agentMetrics *zedcloud.AgentMetrics) *zedcloud.ZedCloudContext {
+func initZedcloudContext(networkSendTimeout, networkDialTimeout uint32,
+	agentMetrics *zedcloud.AgentMetrics) *zedcloud.ZedCloudContext {
 
 	// get the server name
 	bytes, err := os.ReadFile(types.ServerFileName)
@@ -314,7 +315,8 @@ func initZedcloudContext(networkSendTimeout uint32, agentMetrics *zedcloud.Agent
 
 	zedcloudCtx := zedcloud.NewContext(log, zedcloud.ContextOptions{
 		DevNetworkStatus: deviceNetworkStatus,
-		Timeout:          networkSendTimeout,
+		SendTimeout:      networkSendTimeout,
+		DialTimeout:      networkDialTimeout,
 		AgentMetrics:     agentMetrics,
 		Serial:           hardware.GetProductSerial(log),
 		SoftSerial:       hardware.GetSoftSerial(log),

--- a/pkg/pillar/cmd/zedagent/handlecontent.go
+++ b/pkg/pillar/cmd/zedagent/handlecontent.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	zconfig "github.com/lf-edge/eve/api/go/config"
+	"github.com/lf-edge/eve/api/go/info"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	uuid "github.com/satori/go.uuid"
 )
@@ -137,19 +138,13 @@ func handleContentTreeStatusModify(ctxArg interface{}, key string,
 
 func handleContentTreeStatusImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
-
-	status := statusArg.(types.ContentTreeStatus)
 	ctx := ctxArg.(*zedagentContext)
-	uuidStr := status.Key()
-	PublishContentInfoToZedCloud(ctx, uuidStr, &status, ctx.iteration, AllDest)
-	ctx.iteration++
+	triggerPublishObjectInfo(ctx, info.ZInfoTypes_ZiContentTree, key)
 }
 
 func handleContentTreeStatusDelete(ctxArg interface{}, key string,
 	statusArg interface{}) {
-
+	status := statusArg.(types.ContentTreeStatus)
 	ctx := ctxArg.(*zedagentContext)
-	uuidStr := key
-	PublishContentInfoToZedCloud(ctx, uuidStr, nil, ctx.iteration, AllDest)
-	ctx.iteration++
+	triggerPublishDeletedObjectInfo(ctx, info.ZInfoTypes_ZiContentTree, key, status)
 }

--- a/pkg/pillar/cmd/zedagent/handlecontent.go
+++ b/pkg/pillar/cmd/zedagent/handlecontent.go
@@ -146,5 +146,5 @@ func handleContentTreeStatusDelete(ctxArg interface{}, key string,
 	statusArg interface{}) {
 	status := statusArg.(types.ContentTreeStatus)
 	ctx := ctxArg.(*zedagentContext)
-	triggerPublishDeletedObjectInfo(ctx, info.ZInfoTypes_ZiContentTree, key, status)
+	triggerUnpublishObjectInfo(ctx, info.ZInfoTypes_ZiContentTree, key, status)
 }

--- a/pkg/pillar/cmd/zedagent/handlelocation.go
+++ b/pkg/pillar/cmd/zedagent/handlelocation.go
@@ -28,7 +28,7 @@ const (
 )
 
 // Run a periodic post of the location information.
-func locationTimerTask(ctx *zedagentContext, handleChannel chan interface{},
+func locationInfoTask(ctx *zedagentContext, handleChannel chan interface{},
 	triggerLocationInfo chan destinationBitset) {
 	var cloudIteration int
 

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -101,9 +101,7 @@ func handleAppDiskMetricCreate(ctxArg interface{}, key string, _ interface{}) {
 		if key != types.PathToKey(volumeStatus.FileLocation) {
 			continue
 		}
-		uuidStr := volumeStatus.VolumeID.String()
-		PublishVolumeToZedCloud(ctx, uuidStr, &volumeStatus,
-			ctx.iteration, AllDest)
+		triggerPublishObjectInfo(ctx, info.ZInfoTypes_ZiVolume, key)
 	}
 	log.Functionf("handleAppDiskMetricCreate: %s", key)
 }

--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -52,7 +52,7 @@ func handleNetworkInstanceDelete(ctxArg interface{}, key string,
 
 	log.Functionf("handleNetworkInstanceDelete(%s)", key)
 	ctx := ctxArg.(*zedagentContext)
-	triggerPublishDeletedObjectInfo(ctx, zinfo.ZInfoTypes_ZiNetworkInstance, key, statusArg)
+	triggerUnpublishObjectInfo(ctx, zinfo.ZInfoTypes_ZiNetworkInstance, key, statusArg)
 	log.Functionf("handleNetworkInstanceDelete(%s) done", key)
 }
 

--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -43,7 +43,7 @@ func handleNetworkInstanceImpl(ctxArg interface{}, key string,
 		log.Errorf("Received NetworkInstance error %s",
 			status.Error)
 	}
-	prepareAndPublishNetworkInstanceInfoMsg(ctx, status, false, AllDest)
+	triggerPublishObjectInfo(ctx, zinfo.ZInfoTypes_ZiNetworkInstance, key)
 	log.Functionf("handleNetworkInstanceImpl(%s) done", key)
 }
 
@@ -51,9 +51,8 @@ func handleNetworkInstanceDelete(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
 	log.Functionf("handleNetworkInstanceDelete(%s)", key)
-	status := statusArg.(types.NetworkInstanceStatus)
 	ctx := ctxArg.(*zedagentContext)
-	prepareAndPublishNetworkInstanceInfoMsg(ctx, status, true, AllDest)
+	triggerPublishDeletedObjectInfo(ctx, zinfo.ZInfoTypes_ZiNetworkInstance, key, statusArg)
 	log.Functionf("handleNetworkInstanceDelete(%s) done", key)
 }
 

--- a/pkg/pillar/cmd/zedagent/handlevolume.go
+++ b/pkg/pillar/cmd/zedagent/handlevolume.go
@@ -185,5 +185,5 @@ func handleVolumeStatusDelete(ctxArg interface{},
 	key string, statusArg interface{}) {
 	status := statusArg.(types.VolumeStatus)
 	ctx := ctxArg.(*zedagentContext)
-	triggerPublishDeletedObjectInfo(ctx, info.ZInfoTypes_ZiVolume, key, status)
+	triggerUnpublishObjectInfo(ctx, info.ZInfoTypes_ZiVolume, key, status)
 }

--- a/pkg/pillar/cmd/zedagent/handlevolume.go
+++ b/pkg/pillar/cmd/zedagent/handlevolume.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 
 	zconfig "github.com/lf-edge/eve/api/go/config"
+	"github.com/lf-edge/eve/api/go/info"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	uuid "github.com/satori/go.uuid"
 )
@@ -176,20 +177,13 @@ func handleVolumeStatusModify(ctxArg interface{}, key string,
 
 func handleVolumeStatusImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
-
-	status := statusArg.(types.VolumeStatus)
 	ctx := ctxArg.(*zedagentContext)
-	uuidStr := status.VolumeID.String()
-	PublishVolumeToZedCloud(ctx, uuidStr, &status, ctx.iteration, AllDest)
-	ctx.iteration++
+	triggerPublishObjectInfo(ctx, info.ZInfoTypes_ZiVolume, key)
 }
 
 func handleVolumeStatusDelete(ctxArg interface{},
 	key string, statusArg interface{}) {
-
 	status := statusArg.(types.VolumeStatus)
 	ctx := ctxArg.(*zedagentContext)
-	uuidStr := status.VolumeID.String()
-	PublishVolumeToZedCloud(ctx, uuidStr, nil, ctx.iteration, AllDest)
-	ctx.iteration++
+	triggerPublishDeletedObjectInfo(ctx, info.ZInfoTypes_ZiVolume, key, status)
 }

--- a/pkg/pillar/conntester/zedcloud.go
+++ b/pkg/pillar/conntester/zedcloud.go
@@ -57,7 +57,7 @@ func (t *ZedcloudConnectivityTester) TestConnectivity(dns types.DeviceNetworkSta
 
 	zedcloudCtx := zedcloud.NewContext(t.Log, zedcloud.ContextOptions{
 		DevNetworkStatus: &dns,
-		Timeout:          uint32(t.TestTimeout.Seconds()),
+		SendTimeout:      uint32(t.TestTimeout.Seconds()),
 		AgentMetrics:     t.Metrics,
 		Serial:           hardware.GetProductSerial(t.Log),
 		SoftSerial:       hardware.GetSoftSerial(t.Log),
@@ -204,7 +204,7 @@ func (t *ZedcloudConnectivityTester) tryGoogleWithTracing(
 	const withNetTracing = true
 	zedcloudCtx := zedcloud.NewContext(t.Log, zedcloud.ContextOptions{
 		DevNetworkStatus: &dns,
-		Timeout:          uint32(t.TestTimeout.Seconds()),
+		SendTimeout:      uint32(t.TestTimeout.Seconds()),
 		AgentName:        t.AgentName,
 		NetTraceOpts:     t.netTraceOpts(dns),
 	})

--- a/pkg/pillar/devicenetwork/wpad.go
+++ b/pkg/pillar/devicenetwork/wpad.go
@@ -100,7 +100,7 @@ func getPacFile(log *base.LogObject, url string, dns *types.DeviceNetworkStatus,
 	ifname string, metrics *zedcloud.AgentMetrics) (string, error) {
 
 	zedcloudCtx := zedcloud.NewContext(log, zedcloud.ContextOptions{
-		Timeout:          15,
+		SendTimeout:      15,
 		AgentName:        "wpad",
 		AgentMetrics:     metrics,
 		DevNetworkStatus: dns,

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -192,6 +192,8 @@ const (
 	NetworkTestTimeout GlobalSettingKey = "timer.port.timeout"
 	// NetworkSendTimeout global setting key
 	NetworkSendTimeout GlobalSettingKey = "timer.send.timeout"
+	// NetworkDialTimeout global setting key
+	NetworkDialTimeout GlobalSettingKey = "timer.dial.timeout"
 	// LocationCloudInterval global setting key
 	LocationCloudInterval GlobalSettingKey = "timer.location.cloud.interval"
 	// LocationAppInterval global setting key
@@ -820,6 +822,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddIntItem(NetworkTestBetterInterval, 600, 0, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(NetworkTestTimeout, 15, 0, 3600)
 	configItemSpecMap.AddIntItem(NetworkSendTimeout, 120, 0, 3600)
+	configItemSpecMap.AddIntItem(NetworkDialTimeout, 10, 0, 3600)
 	configItemSpecMap.AddIntItem(LocationCloudInterval, HourInSec, 5*MinuteInSec, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(LocationAppInterval, 20, 5, HourInSec)
 	configItemSpecMap.AddIntItem(Dom0MinDiskUsagePercent, 20, 20, 80)

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -168,6 +168,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		NetworkTestBetterInterval,
 		NetworkTestTimeout,
 		NetworkSendTimeout,
+		NetworkDialTimeout,
 		Dom0MinDiskUsagePercent,
 		AppContainerStatsInterval,
 		VaultReadyCutOffTime,


### PR DESCRIPTION
Zedagent main event loop is responsible for handling pubsub updates along with sending messages to the controller. HTTP send is synchronous call and can stall the whole main event loop for up to 6 minutes (overall send timeout).
This badly affects the system responsiveness which can be observed in air-gaped environment (no connectivity to the controller), when the queue is stuck waiting for send to be completed and no other pubsub updates are handled.

Three things are done in this PR:

1. Introduced connect() ("dial" in terms of Go) timeout, which is much less than the send() timeout (helps to fail faster).
2. All direct HTTP send() calls are moved away from the main event loop and executed in dedicated goroutines.
3. (second commit) Also make sure that VMs (such as Local Profile Server or Local Operator Console) are not delayed by NIM testing DPC. In offline mode connectivity probes will take longer (until dial timeout elapsed).