### PR TITLE
[9.4 stable] Move HTTP send operations away from the main event loop

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -10,6 +10,7 @@
 | timer.location.cloud.interval | integer in seconds | 1 hour | how frequently device reports geographic location information to controller |
 | timer.location.app.interval | integer in seconds | 20 | how frequently device reports geographic location information to applications (to local profile server and to other apps via meta-data server) |
 | timer.send.timeout | timer in seconds | 120 | time for each http/send |
+| timer.dial.timeout | timer in seconds | 10 | maximum time allowed to establish connection |
 | timer.reboot.no.network | integer in seconds | 7 days | reboot after no cloud connectivity |
 | timer.update.fallback.no.network | integer in seconds | 300 | fallback after no cloud connectivity |
 | timer.test.baseimage.update | integer in seconds | 600 | commit to update |

--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -197,7 +197,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	subDeviceNetworkStatus.Activate()
 	zedcloudCtx := zedcloud.NewContext(log, zedcloud.ContextOptions{
 		DevNetworkStatus: clientCtx.deviceNetworkStatus,
-		Timeout:          clientCtx.globalConfig.GlobalValueInt(types.NetworkSendTimeout),
+		SendTimeout:      clientCtx.globalConfig.GlobalValueInt(types.NetworkSendTimeout),
+		DialTimeout:      clientCtx.globalConfig.GlobalValueInt(types.NetworkDialTimeout),
 		AgentMetrics:     clientCtx.zedcloudMetrics,
 		Serial:           hardware.GetProductSerial(log),
 		SoftSerial:       hardware.GetSoftSerial(log),

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -172,7 +172,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 
 	zedcloudCtx := zedcloud.NewContext(log, zedcloud.ContextOptions{
 		DevNetworkStatus: ctx.DeviceNetworkStatus,
-		Timeout:          ctx.globalConfig.GlobalValueInt(types.NetworkSendTimeout),
+		SendTimeout:      ctx.globalConfig.GlobalValueInt(types.NetworkSendTimeout),
+		DialTimeout:      ctx.globalConfig.GlobalValueInt(types.NetworkDialTimeout),
 		AgentMetrics:     ctx.zedcloudMetrics,
 		Serial:           hardware.GetProductSerial(log),
 		SoftSerial:       hardware.GetSoftSerial(log),

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -487,15 +487,13 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	// Before starting to process DomainConfig, domainmgr should (in this order):
 	//   1. wait for NIM to publish DNS to learn which ports are used for management
 	//   2. wait for PhysicalIOAdapters (from zedagent) to be processed
-	//   3. wait for NIM to finalize testing of selected DPC
-	//   4. wait for capabilities information from hypervisor
-	// Note: 2. and 3. can also execute in the reverse order.
+	//   3. wait for capabilities information from hypervisor
 	// Note: 4 may come in any order
 	for !domainCtx.assignableAdapters.Initialized ||
 		len(domainCtx.deviceNetworkStatus.Ports) == 0 ||
-		domainCtx.deviceNetworkStatus.Testing ||
 		!capabilitiesSent {
-		log.Noticef("Waiting for AssignableAdapters and/or verified DPC")
+		log.Noticef("Waiting for AssignableAdapters, DPC with management ports " +
+			"and hypervisor capabilities")
 		select {
 		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)

--- a/pkg/pillar/cmd/loguploader/loguploader.go
+++ b/pkg/pillar/cmd/loguploader/loguploader.go
@@ -404,7 +404,8 @@ func sendCtxInit(ctx *loguploaderContext) {
 	//set newlog url
 	zedcloudCtx := zedcloud.NewContext(log, zedcloud.ContextOptions{
 		DevNetworkStatus: deviceNetworkStatus,
-		Timeout:          ctx.globalConfig.GlobalValueInt(types.NetworkSendTimeout),
+		SendTimeout:      ctx.globalConfig.GlobalValueInt(types.NetworkSendTimeout),
+		DialTimeout:      ctx.globalConfig.GlobalValueInt(types.NetworkDialTimeout),
 		AgentMetrics:     ctx.zedcloudMetrics,
 		Serial:           hardware.GetProductSerial(log),
 		SoftSerial:       hardware.GetSoftSerial(log),

--- a/pkg/pillar/cmd/zedagent/handleappInstMetadata.go
+++ b/pkg/pillar/cmd/zedagent/handleappInstMetadata.go
@@ -5,7 +5,10 @@
 
 package zedagent
 
-import "github.com/lf-edge/eve/pkg/pillar/types"
+import (
+	"github.com/lf-edge/eve/api/go/info"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
 
 func handleAppInstMetaDataCreate(ctxArg interface{}, key string,
 	statusArg interface{}) {
@@ -20,14 +23,11 @@ func handleAppInstMetaDataModify(ctxArg interface{}, key string,
 func handleAppInstMetaDataDelete(ctxArg interface{}, key string, statusArg interface{}) {
 	appInstMetaData := statusArg.(types.AppInstMetaData)
 	ctx := ctxArg.(*zedagentContext)
-	PublishAppInstMetaDataToZedCloud(ctx, &appInstMetaData, true)
-	ctx.iteration++
+	triggerPublishDeletedObjectInfo(
+		ctx, info.ZInfoTypes_ZiAppInstMetaData, key, appInstMetaData)
 }
 
 func handleAppInstMetaDataImpl(ctxArg interface{}, key string, statusArg interface{}) {
-
-	appInstMetaData := statusArg.(types.AppInstMetaData)
 	ctx := ctxArg.(*zedagentContext)
-	PublishAppInstMetaDataToZedCloud(ctx, &appInstMetaData, false)
-	ctx.iteration++
+	triggerPublishObjectInfo(ctx, info.ZInfoTypes_ZiAppInstMetaData, key)
 }

--- a/pkg/pillar/cmd/zedagent/handleblob.go
+++ b/pkg/pillar/cmd/zedagent/handleblob.go
@@ -1,6 +1,9 @@
 package zedagent
 
-import "github.com/lf-edge/eve/pkg/pillar/types"
+import (
+	"github.com/lf-edge/eve/api/go/info"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
 
 func blobStatusGetAll(ctx *zedagentContext) map[string]*types.BlobStatus {
 	sub := ctx.subBlobStatus
@@ -24,18 +27,12 @@ func handleBlobStatusModify(ctxArg interface{}, key string,
 
 func handleBlobStatusImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
-
-	status := statusArg.(types.BlobStatus)
 	ctx := ctxArg.(*zedagentContext)
-	uuidStr := status.Key()
-	PublishBlobInfoToZedCloud(ctx, uuidStr, &status, ctx.iteration)
-	ctx.iteration++
+	triggerPublishObjectInfo(ctx, info.ZInfoTypes_ZiBlobList, key)
 }
 
 func handleBlobDelete(ctxArg interface{}, key string, statusArg interface{}) {
 	status := statusArg.(types.BlobStatus)
 	ctx := ctxArg.(*zedagentContext)
-	uuidStr := status.Key()
-	PublishBlobInfoToZedCloud(ctx, uuidStr, nil, ctx.iteration)
-	ctx.iteration++
+	triggerPublishDeletedObjectInfo(ctx, info.ZInfoTypes_ZiBlobList, key, status)
 }

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -297,7 +297,8 @@ func indicateInvalidBootstrapConfig(getconfigCtx *getconfigContext) {
 	getconfigCtx.ledBlinkCount = types.LedBlinkInvalidBootstrapConfig
 }
 
-func initZedcloudContext(networkSendTimeout uint32, agentMetrics *zedcloud.AgentMetrics) *zedcloud.ZedCloudContext {
+func initZedcloudContext(networkSendTimeout, networkDialTimeout uint32,
+	agentMetrics *zedcloud.AgentMetrics) *zedcloud.ZedCloudContext {
 
 	// get the server name
 	bytes, err := ioutil.ReadFile(types.ServerFileName)
@@ -308,7 +309,8 @@ func initZedcloudContext(networkSendTimeout uint32, agentMetrics *zedcloud.Agent
 
 	zedcloudCtx := zedcloud.NewContext(log, zedcloud.ContextOptions{
 		DevNetworkStatus: deviceNetworkStatus,
-		Timeout:          networkSendTimeout,
+		SendTimeout:      networkSendTimeout,
+		DialTimeout:      networkDialTimeout,
 		AgentMetrics:     agentMetrics,
 		Serial:           hardware.GetProductSerial(log),
 		SoftSerial:       hardware.GetSoftSerial(log),

--- a/pkg/pillar/cmd/zedagent/handlecontent.go
+++ b/pkg/pillar/cmd/zedagent/handlecontent.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	zconfig "github.com/lf-edge/eve/api/go/config"
+	"github.com/lf-edge/eve/api/go/info"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	uuid "github.com/satori/go.uuid"
 )
@@ -107,19 +108,13 @@ func handleContentTreeStatusModify(ctxArg interface{}, key string,
 
 func handleContentTreeStatusImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
-
-	status := statusArg.(types.ContentTreeStatus)
 	ctx := ctxArg.(*zedagentContext)
-	uuidStr := status.Key()
-	PublishContentInfoToZedCloud(ctx, uuidStr, &status, ctx.iteration)
-	ctx.iteration++
+	triggerPublishObjectInfo(ctx, info.ZInfoTypes_ZiContentTree, key)
 }
 
 func handleContentTreeStatusDelete(ctxArg interface{}, key string,
 	statusArg interface{}) {
-
+	status := statusArg.(types.ContentTreeStatus)
 	ctx := ctxArg.(*zedagentContext)
-	uuidStr := key
-	PublishContentInfoToZedCloud(ctx, uuidStr, nil, ctx.iteration)
-	ctx.iteration++
+	triggerPublishDeletedObjectInfo(ctx, info.ZInfoTypes_ZiContentTree, key, status)
 }

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -101,8 +101,7 @@ func handleAppDiskMetricCreate(ctxArg interface{}, key string, _ interface{}) {
 		if key != types.PathToKey(volumeStatus.FileLocation) {
 			continue
 		}
-		uuidStr := volumeStatus.VolumeID.String()
-		PublishVolumeToZedCloud(ctx, uuidStr, &volumeStatus, ctx.iteration)
+		triggerPublishObjectInfo(ctx, info.ZInfoTypes_ZiVolume, key)
 	}
 	log.Functionf("handleAppDiskMetricCreate: %s", key)
 }

--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -44,7 +44,7 @@ func handleNetworkInstanceImpl(ctxArg interface{}, key string,
 		log.Errorf("Received NetworkInstance error %s",
 			status.Error)
 	}
-	prepareAndPublishNetworkInstanceInfoMsg(ctx, status, false)
+	triggerPublishObjectInfo(ctx, zinfo.ZInfoTypes_ZiNetworkInstance, key)
 	log.Functionf("handleNetworkInstanceImpl(%s) done", key)
 }
 
@@ -52,9 +52,8 @@ func handleNetworkInstanceDelete(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
 	log.Functionf("handleNetworkInstanceDelete(%s)", key)
-	status := statusArg.(types.NetworkInstanceStatus)
 	ctx := ctxArg.(*zedagentContext)
-	prepareAndPublishNetworkInstanceInfoMsg(ctx, status, true)
+	triggerPublishDeletedObjectInfo(ctx, zinfo.ZInfoTypes_ZiNetworkInstance, key, statusArg)
 	log.Functionf("handleNetworkInstanceDelete(%s) done", key)
 }
 

--- a/pkg/pillar/cmd/zedagent/handlevolume.go
+++ b/pkg/pillar/cmd/zedagent/handlevolume.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 
 	zconfig "github.com/lf-edge/eve/api/go/config"
+	"github.com/lf-edge/eve/api/go/info"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	uuid "github.com/satori/go.uuid"
 )
@@ -176,20 +177,13 @@ func handleVolumeStatusModify(ctxArg interface{}, key string,
 
 func handleVolumeStatusImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
-
-	status := statusArg.(types.VolumeStatus)
 	ctx := ctxArg.(*zedagentContext)
-	uuidStr := status.VolumeID.String()
-	PublishVolumeToZedCloud(ctx, uuidStr, &status, ctx.iteration)
-	ctx.iteration++
+	triggerPublishObjectInfo(ctx, info.ZInfoTypes_ZiVolume, key)
 }
 
 func handleVolumeStatusDelete(ctxArg interface{},
 	key string, statusArg interface{}) {
-
 	status := statusArg.(types.VolumeStatus)
 	ctx := ctxArg.(*zedagentContext)
-	uuidStr := status.VolumeID.String()
-	PublishVolumeToZedCloud(ctx, uuidStr, nil, ctx.iteration)
-	ctx.iteration++
+	triggerPublishDeletedObjectInfo(ctx, info.ZInfoTypes_ZiVolume, key, status)
 }

--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -74,7 +74,10 @@ func objectInfoTask(ctxPtr *zedagentContext, triggerInfo <-chan infoForObjectKey
 	for {
 		select {
 		case infoForKeyMessage := <-triggerInfo:
+			objKey := infoForKeyMessage.objectKey
 			infoType := infoForKeyMessage.infoType
+			deleted := infoForKeyMessage.deleted
+			deletedInfo := infoForKeyMessage.deletedInfo
 			log.Functionf("objectInfoTask got message for %s", infoType.String())
 			start := time.Now()
 			var err error
@@ -87,17 +90,25 @@ func objectInfoTask(ctxPtr *zedagentContext, triggerInfo <-chan infoForObjectKey
 			case info.ZInfoTypes_ZiApp:
 				// publish application info
 				sub := ctxPtr.getconfigCtx.subAppInstanceStatus
-				if c, err = sub.Get(infoForKeyMessage.objectKey); err == nil {
+				if deleted {
+					PublishAppInfoToZedCloud(ctxPtr, objKey, nil,
+						ctxPtr.assignableAdapters, ctxPtr.iteration)
+					ctxPtr.iteration++
+				} else if c, err = sub.Get(objKey); err == nil {
 					appStatus := c.(types.AppInstanceStatus)
-					uuidStr := appStatus.Key()
-					PublishAppInfoToZedCloud(ctxPtr, uuidStr, &appStatus, ctxPtr.assignableAdapters,
-						ctxPtr.iteration)
+					PublishAppInfoToZedCloud(ctxPtr, objKey, &appStatus,
+						ctxPtr.assignableAdapters, ctxPtr.iteration)
 					ctxPtr.iteration++
 				}
 			case info.ZInfoTypes_ZiNetworkInstance:
 				// publish network instance info
 				sub := ctxPtr.subNetworkInstanceStatus
-				if c, err = sub.Get(infoForKeyMessage.objectKey); err == nil {
+				if deleted {
+					niStatus := deletedInfo.(types.NetworkInstanceStatus)
+					prepareAndPublishNetworkInstanceInfoMsg(ctxPtr, niStatus,
+						true)
+					ctxPtr.iteration++
+				} else if c, err = sub.Get(objKey); err == nil {
 					niStatus := c.(types.NetworkInstanceStatus)
 					prepareAndPublishNetworkInstanceInfoMsg(ctxPtr, niStatus, false)
 					ctxPtr.iteration++
@@ -105,7 +116,13 @@ func objectInfoTask(ctxPtr *zedagentContext, triggerInfo <-chan infoForObjectKey
 			case info.ZInfoTypes_ZiVolume:
 				// publish volume info
 				sub := ctxPtr.getconfigCtx.subVolumeStatus
-				if c, err = sub.Get(infoForKeyMessage.objectKey); err == nil {
+				if deleted {
+					volumeStatus := deletedInfo.(types.VolumeStatus)
+					uuidStr := volumeStatus.VolumeID.String()
+					PublishVolumeToZedCloud(ctxPtr, uuidStr, nil,
+						ctxPtr.iteration)
+					ctxPtr.iteration++
+				} else if c, err = sub.Get(objKey); err == nil {
 					volumeStatus := c.(types.VolumeStatus)
 					uuidStr := volumeStatus.VolumeID.String()
 					PublishVolumeToZedCloud(ctxPtr, uuidStr, &volumeStatus, ctxPtr.iteration)
@@ -114,25 +131,37 @@ func objectInfoTask(ctxPtr *zedagentContext, triggerInfo <-chan infoForObjectKey
 			case info.ZInfoTypes_ZiContentTree:
 				// publish content tree info
 				sub := ctxPtr.getconfigCtx.subContentTreeStatus
-				if c, err = sub.Get(infoForKeyMessage.objectKey); err == nil {
+				if deleted {
+					PublishContentInfoToZedCloud(ctxPtr, objKey, nil,
+						ctxPtr.iteration)
+					ctxPtr.iteration++
+				} else if c, err = sub.Get(objKey); err == nil {
 					ctStatus := c.(types.ContentTreeStatus)
-					uuidStr := ctStatus.Key()
-					PublishContentInfoToZedCloud(ctxPtr, uuidStr, &ctStatus, ctxPtr.iteration)
+					PublishContentInfoToZedCloud(ctxPtr, objKey, &ctStatus,
+						ctxPtr.iteration)
 					ctxPtr.iteration++
 				}
 			case info.ZInfoTypes_ZiBlobList:
 				// publish blob info
 				sub := ctxPtr.subBlobStatus
-				if c, err = sub.Get(infoForKeyMessage.objectKey); err == nil {
+				if deleted {
+					PublishBlobInfoToZedCloud(ctxPtr, objKey, nil,
+						ctxPtr.iteration)
+					ctxPtr.iteration++
+				} else if c, err = sub.Get(objKey); err == nil {
 					blobStatus := c.(types.BlobStatus)
-					uuidStr := blobStatus.Key()
-					PublishBlobInfoToZedCloud(ctxPtr, uuidStr, &blobStatus, ctxPtr.iteration)
+					PublishBlobInfoToZedCloud(ctxPtr, objKey, &blobStatus,
+						ctxPtr.iteration)
 					ctxPtr.iteration++
 				}
 			case info.ZInfoTypes_ZiAppInstMetaData:
 				// publish appInst metadata info
 				sub := ctxPtr.subAppInstMetaData
-				if c, err = sub.Get(infoForKeyMessage.objectKey); err == nil {
+				if deleted {
+					appInstMetaData := deletedInfo.(types.AppInstMetaData)
+					PublishAppInstMetaDataToZedCloud(ctxPtr, &appInstMetaData, true)
+					ctxPtr.iteration++
+				} else if c, err = sub.Get(objKey); err == nil {
 					appInstMetaData := c.(types.AppInstMetaData)
 					PublishAppInstMetaDataToZedCloud(ctxPtr, &appInstMetaData, false)
 					ctxPtr.iteration++
@@ -143,9 +172,13 @@ func objectInfoTask(ctxPtr *zedagentContext, triggerInfo <-chan infoForObjectKey
 			case info.ZInfoTypes_ZiEdgeview:
 				// publish Edgeview info
 				sub := ctxPtr.subEdgeviewStatus
-				if c, err = sub.Get(infoForKeyMessage.objectKey); err == nil {
+				if deleted {
+					PublishEdgeviewToZedCloud(ctxPtr, nil)
+					ctxPtr.iteration++
+				} else if c, err = sub.Get(objKey); err == nil {
 					evStatus := c.(types.EdgeviewStatus)
 					PublishEdgeviewToZedCloud(ctxPtr, &evStatus)
+					ctxPtr.iteration++
 				}
 			case info.ZInfoTypes_ZiLocation:
 				locInfo := getLocationInfo(ctxPtr)

--- a/pkg/pillar/cmd/zedrouter/probe.go
+++ b/pkg/pillar/cmd/zedrouter/probe.go
@@ -303,7 +303,7 @@ func launchHostProbe(ctx *zedrouterContext) {
 	ditems := dpub.GetAll()
 
 	zcloudCtx := zedcloud.NewContext(log, zedcloud.ContextOptions{
-		Timeout:      maxRemoteProbeWait,
+		SendTimeout:  maxRemoteProbeWait,
 		TLSConfig:    &tls.Config{InsecureSkipVerify: true},
 		AgentMetrics: ctx.zedcloudMetrics,
 		AgentName:    agentName,

--- a/pkg/pillar/conntester/zedcloud.go
+++ b/pkg/pillar/conntester/zedcloud.go
@@ -55,7 +55,7 @@ func (t *ZedcloudConnectivityTester) TestConnectivity(
 
 	zedcloudCtx := zedcloud.NewContext(t.Log, zedcloud.ContextOptions{
 		DevNetworkStatus: &dns,
-		Timeout:          uint32(t.TestTimeout.Seconds()),
+		SendTimeout:      uint32(t.TestTimeout.Seconds()),
 		AgentMetrics:     t.Metrics,
 		Serial:           hardware.GetProductSerial(t.Log),
 		SoftSerial:       hardware.GetSoftSerial(t.Log),

--- a/pkg/pillar/devicenetwork/wpad.go
+++ b/pkg/pillar/devicenetwork/wpad.go
@@ -100,7 +100,7 @@ func getPacFile(log *base.LogObject, url string, dns *types.DeviceNetworkStatus,
 	ifname string, metrics *zedcloud.AgentMetrics) (string, error) {
 
 	zedcloudCtx := zedcloud.NewContext(log, zedcloud.ContextOptions{
-		Timeout:          15,
+		SendTimeout:      15,
 		AgentName:        "wpad",
 		AgentMetrics:     metrics,
 		DevNetworkStatus: dns,

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -192,6 +192,8 @@ const (
 	NetworkTestTimeout GlobalSettingKey = "timer.port.timeout"
 	// NetworkSendTimeout global setting key
 	NetworkSendTimeout GlobalSettingKey = "timer.send.timeout"
+	// NetworkDialTimeout global setting key
+	NetworkDialTimeout GlobalSettingKey = "timer.dial.timeout"
 	// LocationCloudInterval global setting key
 	LocationCloudInterval GlobalSettingKey = "timer.location.cloud.interval"
 	// LocationAppInterval global setting key
@@ -800,6 +802,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddIntItem(NetworkTestBetterInterval, 600, 0, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(NetworkTestTimeout, 15, 0, 3600)
 	configItemSpecMap.AddIntItem(NetworkSendTimeout, 120, 0, 3600)
+	configItemSpecMap.AddIntItem(NetworkDialTimeout, 10, 0, 3600)
 	configItemSpecMap.AddIntItem(LocationCloudInterval, HourInSec, 5*MinuteInSec, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(LocationAppInterval, 20, 5, HourInSec)
 	configItemSpecMap.AddIntItem(Dom0MinDiskUsagePercent, 20, 20, 80)

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -168,6 +168,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		NetworkTestBetterInterval,
 		NetworkTestTimeout,
 		NetworkSendTimeout,
+		NetworkDialTimeout,
 		Dom0MinDiskUsagePercent,
 		AppContainerStatsInterval,
 		VaultReadyCutOffTime,


### PR DESCRIPTION
Zedagent main event loop is responsible for handling pubsub updates along with sending messages to the controller. HTTP send is synchronous call and can stall the whole main event loop for up to 6 minutes (overall send timeout).
This badly affects the system responsiveness which can be observed in air-gaped environment (no connectivity to the controller), when the queue is stuck waiting for send to be completed and no other pubsub updates are handled.

Three things are done in this PR:

1. Introduced connect() ("dial" in terms of Go) timeout, which is much less than the send() timeout (helps to fail faster).
2. All direct HTTP send() calls are moved away from the main event loop and executed in dedicated goroutines.
3. (second commit) Also make sure that VMs (such as Local Profile Server or Local Operator Console) are not delayed by NIM testing DPC. In offline mode connectivity probes will take longer (until dial timeout elapsed).

This is a backport of original patches from @milan-zededa to the 9.4 branch.

CC: @milan-zededa