### PR TITLE
Do not try to resolve with link-local src IP

### DIFF
--- a/pkg/pillar/devicenetwork/dns.go
+++ b/pkg/pillar/devicenetwork/dns.go
@@ -108,7 +108,9 @@ func ResolveWithPortsLambda(domain string,
 
 		var srcIPs []net.IP
 		for _, addrInfo := range port.AddrInfoList {
-			srcIPs = append(srcIPs, addrInfo.Addr)
+			if addrInfo.Addr.IsGlobalUnicast() {
+				srcIPs = append(srcIPs, addrInfo.Addr)
+			}
 		}
 
 		for _, dnsIP := range port.DNSServers {


### PR DESCRIPTION
`ResolveWithPortsLambda` would try every IP address assigned to a given port as a source address for a resolution query. However, if port has a link-local IP address assigned, we get lot's of warnings in the log such as this one:
```
[2023-04-28 10:14:42 | 85s]  <warning>   nim:nim.(*nim).resolveWithPorts   resolveWithPortsLambda failed: [dns exchange failed: dial udp: address [fe80::3306:6654:670:beeb]:0: no suitable address found dns exchange failed: dial udp: address [fe80::5d2d:ab19:3624:4ef7]:0: no suitable address found]
```
This can be avoided if `ResolveWithPortsLambda` skips non-global non-unicast IPs.

CC @christoph-zededa 