### PR TITLE
fix assets release

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -42,6 +42,13 @@ jobs:
           $APT_INSTALL || { sudo apt update && $APT_INSTALL ; }
           echo "ARCH=${{ matrix.arch }}" >> "$GITHUB_ENV"
           echo "TAG=$(echo "$REF" | sed -e 's#^.*/##' -e 's#master#snapshot#' -e 's#main#snapshot#')" >> "$GITHUB_ENV"
+      - name: checkout repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: ensure clean assets dir
+        run : |
+          rm -rf assets && mkdir -p assets
       - name: Pull the EVE release from DockerHUB or build it
         run: |
           HV=kvm
@@ -49,15 +56,12 @@ jobs:
              EVE=lfedge/eve:${{ env.TAG }}-${HV}-${{ env.ARCH }}
              docker pull "$EVE"
           else
-             git clone ${{ github.event.repository.html_url }} .
-             git reset --hard ${{ github.event.workflow_run.head_branch }}
              make pkgs
              make HV=${HV} ZARCH=${{ env.ARCH }} eve
              EVE=lfedge/eve:$(make version)-${HV}-${{ env.ARCH }}
           fi
-          rm -rf assets && mkdir assets && cd assets
-          docker run "$EVE" rootfs > rootfs.img
-          docker run "$EVE" installer_net | tar -xvf -
+          docker run "$EVE" rootfs > assets/rootfs.img
+          docker run "$EVE" installer_net | tar -C assets -xvf -
       - name: Create direct iPXE config
         run: |
           URL="${{ github.event.repository.html_url }}/releases/download/${{ env.TAG }}/${{ env.ARCH }}."
@@ -75,13 +79,9 @@ jobs:
              mv assets/kernel assets/kernel.gz
              gzip -d assets/kernel.gz
           fi
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - name: Build SBOM and collected sources
         run: |
           make sbom collected_sources
-          mkdir -p assets
           mv $(make sbom_info collected_sources_info) assets/
       - name: Create a GitHub release and clean up artifacts
         id: create-release

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ tags
 tmp/
 mkdocs.yml
 yetus-output/
+assets/


### PR DESCRIPTION
The assets release workflow was breaking, see https://github.com/lf-edge/eve/actions/runs/4840159952

The cause was that the `checkout` action was happening _after_ some of the assets were created. `checkout` can wipe out the contents of the current directory.

This does several things:

1. Moves checkout to the first step
2. Removes the `rm -rf assets && mkdir -p assets`  to its own step, so it is very clear when and where it is happening
3. Adds `assets/` to `.gitignore`, so we do not have any issues with an apparently dirty git repo after checkout and then creating things in assets.
4. Uses the existing checkout in the step `Pull the EVE release from DockerHUB or build it`  rather than trying to check out again
5. Ensures that the one step that did a `cd assets` (`Pull the EVE release from DockerHUB or build it`) works out of root and explicitly paths things to `assets/`

