### PR TITLE
avoid conflict with existing sbom and sources assets

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -225,7 +225,7 @@ jobs:
         with:
           upload_url: ${{ steps.create-release.outputs.result }}
           asset_path: assets/rootfs.spdx.json
-          asset_name: rootfs.spdx.json
+          asset_name: ${{ env.ARCH }}.rootfs.spdx.json
           asset_content_type: application/json
       - name: Upload COLLECTED_SOURCES
         id: upload-collected-sources-asset
@@ -235,5 +235,5 @@ jobs:
         with:
           upload_url: ${{ steps.create-release.outputs.result }}
           asset_path: assets/collected_sources.tar.gz
-          asset_name: collected_sources.tar.gz
+          asset_name: ${{ env.ARCH }}.collected_sources.tar.gz
           asset_content_type: application/octet-stream


### PR DESCRIPTION
We were generating the sbom and sources with each arch in the Actions matrix, but then uploading with a unified filename. This causes a conflict with the existing file, showing errors like [this](https://github.com/lf-edge/eve/actions/runs/4846824473/jobs/8640258833#step:18:12)

This changes it to include the architecture in the asset name, so it will not conflict.