### PR TITLE
Partial Revert "docker: bump to newest pkg/alpine docker image"

### DIFF
--- a/pkg/alpine/Dockerfile
+++ b/pkg/alpine/Dockerfile
@@ -50,14 +50,14 @@ RUN apk update && apk upgrade -a
 
 # define arch-specific envs
 FROM scratch as final-amd64
-ENV BUILD_ARCH=x86_64
-ENV TARGET_ARCH=x86_64
+ENV EVE_BUILD_ARCH=x86_64
+ENV EVE_TARGET_ARCH=x86_64
 FROM scratch as final-arm64
-ENV BUILD_ARCH=aarch64
-ENV TARGET_ARCH=aarch64
+ENV EVE_BUILD_ARCH=aarch64
+ENV EVE_TARGET_ARCH=aarch64
 FROM scratch as final-riscv64
-ENV BUILD_ARCH=riscv64
-ENV TARGET_ARCH=riscv64
+ENV EVE_BUILD_ARCH=riscv64
+ENV EVE_TARGET_ARCH=riscv64
 
 # we merge layers in previous step
 # so we should avoid large possible diff


### PR DESCRIPTION
This partially reverts commit 13b4e6fb07c52256a1ac10eed3158e1e7765da70.

Seems this went wrong during resolving merge conflicts on my side.