### PR TITLE
containerd: remove unused 'qemuOverHead' variable

### DIFF
--- a/pkg/pillar/containerd/containerd.go
+++ b/pkg/pillar/containerd/containerd.go
@@ -66,10 +66,6 @@ const (
 	// EVEOCIVNCPasswordLabel is OCI runtime spec label that tracks VNC password in OCI Image config
 	EVEOCIVNCPasswordLabel = "org.lfedge.eve.vnc_password"
 
-	//TBD: Have a better way to calculate this number.
-	//For now it is based on some trial-and-error experiments
-	qemuOverHead = int64(500 * 1024 * 1024)
-
 	// default signal to kill tasks
 	defaultSignal = "SIGTERM"
 )


### PR DESCRIPTION
Clean up forgotten leftovers. No more that that. Nothing to look at.