### PR TITLE
Update to latest version of collect go sources, add parsing of go binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -293,7 +293,7 @@ FORCE_BUILD=
 
 # for the go build sources
 GOSOURCES=$(BUILDTOOLS_BIN)/go-sources-and-licenses
-GOSOURCES_VERSION=91c965e0392ece0362bb9ac017ed052b679fc6f9
+GOSOURCES_VERSION=c73009667f4871c084c1f2164063321c81d053a2
 GOSOURCES_SOURCE=github.com/deitch/go-sources-and-licenses
 
 

--- a/tools/collect-sources.sh
+++ b/tools/collect-sources.sh
@@ -29,7 +29,8 @@ tar -xf "$rootfs" -C "$tmproot" --exclude "dev/*"
 {
 "${eve}/tools/get-alpine-pkg-source.sh" -s "${tmpout}" -e "${tmproot}" -p alpine
 "${eve}/tools/get-kernel-source.sh" -s "${tmpout}" -p kernel
-"${eve}/build-tools/bin/go-sources-and-licenses" sources -d "${eve}/pkg" --find --recursive --out "${tmpout}" --prefix golang --template 'golang,{{.Module}}@{{.Version}},{{.Version}},{{.Path}}'
+"${eve}/build-tools/bin/go-sources-and-licenses" sources -s "${eve}/pkg" --find --recursive --out "${tmpout}" --prefix golang --template 'golang,{{.Module}}@{{.Version}},{{.Version}},{{.Path}}'
+"${eve}/build-tools/bin/go-sources-and-licenses" sources -b "${tmproot}" --find --recursive --out "${tmpout}" --prefix golang --template 'golang,{{.Module}}@{{.Version}},{{.Version}},{{.Path}}'
 } > "${manifest}"
 
 tar -zcf "${outfile}" -C "${tmpout}" .


### PR DESCRIPTION
When this is done, we will have only 8 go packages not in the sources, of which 7 are just local references