### PR TITLE
Fix for statically configured NTP server

### DIFF
--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -77,9 +77,16 @@ get_ntp_servers() {
         if [ "$portInfo" = "null" ] || [ -z "$portInfo" ]; then
             break
         fi
-        list=$(echo "$portInfo" | jq .NtpServers)
-        ns=$(echo "$list" | awk -F\" '{ if (NF > 2) { print $2}}')
+        # Add statically configured NTP server.
+        ns="$(echo "$portInfo" | jq -r .NtpServer)"
         res="$res $ns"
+        if [ -z "$ns" ]; then
+            # If NTP server is not statically configured, add the first NTP server
+            # advertised by DHCP server.
+            list=$(echo "$portInfo" | jq .NtpServers)
+            ns=$(echo "$list" | awk -F\" '{ if (NF > 2) { print $2}}')
+            res="$res $ns"
+        fi
         i=$((i + 1))
     done
     out=


### PR DESCRIPTION
Statically configured NTP server is stored in DeviceNetworkStatus under a [different field](https://github.com/lf-edge/eve/blob/master/pkg/pillar/types/zedroutertypes.go#L1165) than [NTP servers advertised by a DHCP server](https://github.com/lf-edge/eve/blob/master/pkg/pillar/types/zedroutertypes.go#L1168). This fix ensures that with static-only NTP server config, `device-steps.sh` will not miss the NTP server and will properly update `ntpd`. With both statically and dynamically configured NTP servers, the static config should take precedence.

Fixes bug reported here: https://github.com/lf-edge/eve/issues/3140