### PR TITLE
Support installation of EVE in the eMMC of i.MX8MP devices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -675,16 +675,12 @@ compare_sbom_collected_sources: $(COLLECTED_SOURCES) $(SBOM) | $(COMPARESOURCES)
 
 
 $(LIVE).raw: $(BOOT_PART) $(EFI_PART) $(ROOTFS_IMG) $(CONFIG_IMG) $(PERSIST_IMG) $(BSP_IMX_PART) | $(INSTALLER)
-	@[ "$(PLATFORM)" != "${PLATFORM/imx/}" ] && \
-		cp $(INSTALLER)/bsp-imx/NXP-EULA-LICENSE.txt $(INSTALLER)/NXP-EULA-LICENSE.txt && \
-		cp $(INSTALLER)/bsp-imx/NXP-EULA-LICENSE.txt $(BUILD_DIR)/NXP-EULA-LICENSE.txt && \
-		cp $(INSTALLER)/bsp-imx/"$(PLATFORM)"-flash.bin $(INSTALLER)/imx8-flash.bin && \
-		cp $(INSTALLER)/bsp-imx/"$(PLATFORM)"-flash.conf $(INSTALLER)/imx8-flash.conf && \
-		cp $(INSTALLER)/bsp-imx/*.dtb $(INSTALLER)/boot  || :
+	./tools/prepare-platform.sh "$(PLATFORM)" "$(BUILD_DIR)" "$(INSTALLER)" || :
 	./tools/makeflash.sh -C 350 $| $@ $(PART_SPEC)
 	$(QUIET): $@: Succeeded
 
-$(INSTALLER).raw: $(BOOT_PART) $(EFI_PART) $(ROOTFS_IMG) $(INITRD_IMG) $(INSTALLER_IMG) $(CONFIG_IMG) $(PERSIST_IMG) | $(INSTALLER)
+$(INSTALLER).raw: $(BOOT_PART) $(EFI_PART) $(ROOTFS_IMG) $(INITRD_IMG) $(INSTALLER_IMG) $(CONFIG_IMG) $(PERSIST_IMG) $(BSP_IMX_PART) | $(INSTALLER)
+	./tools/prepare-platform.sh "$(PLATFORM)" "$(BUILD_DIR)" "$(INSTALLER)" || :
 	./tools/makeflash.sh -C 350 $| $@ "conf_win installer inventory_win"
 	$(QUIET): $@: Succeeded
 

--- a/README.md
+++ b/README.md
@@ -394,20 +394,43 @@ In Jetson nano, from January 22, 2021, it became possible to save the u-boot to 
 
 ## How to use on an i.MX 8M Plus Phytec phyBOARD-Pollux board
 
+### Running from SD Card (phyBOARD-Pollux)
+
 1. Set bootmode switch (S3) to boot device from an SD card (positions 1,2,3,4 set to ON,OFF,OFF,OFF).
 2. Build a live image `make ZARCH=arm64 HV=kvm PLATFORM=imx8mp_pollux live-raw` (Only KVM is supported)
 3. Flash the `dist/arm64/current/live.raw` live EVE image onto your SD card by [following these instructions](#how-to-write-eve-image-and-installer-onto-an-sd-card-or-an-installer-medium)
 
+### Installing on eMMC (phyBOARD-Pollux)
+
+1. Build an installation raw image `make ZARCH=arm64 HV=kvm PLATFORM=imx8mp_pollux installer-raw` (Only KVM is supported)
+2. Flash the `dist/arm64/current/installer.raw` install EVE image onto your SD card by [following these instructions](#how-to-write-eve-image-and-installer-onto-an-sd-card-or-an-installer-medium)
+3. Set bootmode switch (S3) to boot device from an SD card (positions 1,2,3,4 set to ON,OFF,OFF,OFF).
+4. Boot the device from SD Card. Installation process should initialize automatically, the device will be powered off when the process is done
+5. Remove the SD Card from the device
+6. Set bootmode switch (S3) to boot device from eMMC (positions 1,2,3,4 set to OFF,OFF,OFF,OFF).
+7. Power on the device, EVE should start from eMMC
+
 ## How to use on an EPC-R3720 (Advantech, based on i.MX 8M Plus)
 
 This device, from [Advantech](https://www.advantech.com/en-eu/products/880a61e5-3fed-41f3-bf53-8be2410c0f19/epc-r3720/mod_fde326be-b36e-4044-ba9a-28c4c49a25c6), it's an Edge AI Box Computer
-based on the NXP i.MX 8M Plus SoC. Three different models are available. EVE was tested and it supports the model EPC-R3720IQ-ALA220. The installation should be performed through the following steps:
+based on the NXP i.MX 8M Plus SoC. Three different models are available. EVE was tested and it supports the model EPC-R3720IQ-ALA220. The installation should be performed through the following steps
+according to the main boot device: SD Card or eMMC.
+
+### Running from SD Card (EPC-R3720)
 
 1. Set [Boot Select switch (SW1)](http://ess-wiki.advantech.com.tw/view/File:RSB-3720_connector_location_2021-10-21_143853.jpg) to boot device from an SD card (positions 1,2,3,4 set to ON,ON,OFF,OFF).
 2. Build a live image `make ZARCH=arm64 HV=kvm PLATFORM=imx8mp_epc_r3720 live-raw` (Only KVM is supported)
 3. Flash the `dist/arm64/current/live.raw` live EVE image onto your SD card by [following these instructions](#how-to-write-eve-image-and-installer-onto-an-sd-card-or-an-installer-medium)
 
-Note: installation to eMMC is currently not supported. EVE should run from SD Card.
+### Installing on eMMC (EPC-R3720)
+
+1. Build an installation raw image `make ZARCH=arm64 HV=kvm PLATFORM=imx8mp_epc_r3720 installer-raw` (Only KVM is supported)
+2. Flash the `dist/arm64/current/installer.raw` install EVE image onto your SD card by [following these instructions](#how-to-write-eve-image-and-installer-onto-an-sd-card-or-an-installer-medium)
+3. Set [Boot Select switch (SW1)](http://ess-wiki.advantech.com.tw/view/File:RSB-3720_connector_location_2021-10-21_143853.jpg) to boot device from an SD card (positions 1,2,3,4 set to ON,ON,OFF,OFF).
+4. Boot the device from SD Card. Installation process should initialize automatically, the device will be powered off when the process is done
+5. Remove the SD Card from the device
+6. Set [Boot Select switch (SW1)](http://ess-wiki.advantech.com.tw/view/File:RSB-3720_connector_location_2021-10-21_143853.jpg) to boot device from eMMC (positions 1,2,3,4 set to OFF,ON,OFF,OFF).
+7. Power on the device, EVE should start from eMMC
 
 ## How to use on an AMD board
 

--- a/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0022-arm-imx8m-Set-mmcdev-variable-at-the-initialization.patch
+++ b/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0022-arm-imx8m-Set-mmcdev-variable-at-the-initialization.patch
@@ -1,0 +1,52 @@
+From 08cea66d64dba53850842ed92744685002d4295a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ren=C3=AA=20de=20Souza=20Pinto?= <rene@renesp.com.br>
+Date: Tue, 2 May 2023 16:42:19 +0200
+Subject: [PATCH] arm: imx8m: Set mmcdev variable at the initialization
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Adds the following changes to Advantech's RSB3720 platform:
+
+- Check the boot device and set mmcdev variable accordingly: 1, in case
+  device booted from SD Card, or 2, in case device booted from eMMC
+
+Code taken from: board/phytec/phycore_imx8mp/phycore-imx8mp.c
+
+Signed-off-by: Renê de Souza Pinto <rene@renesp.com.br>
+---
+ board/advantech/imx8mp_rsb3720a1/imx8mp_rsb3720a1.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/board/advantech/imx8mp_rsb3720a1/imx8mp_rsb3720a1.c b/board/advantech/imx8mp_rsb3720a1/imx8mp_rsb3720a1.c
+index 16566092bd8..b0b890edfe7 100644
+--- a/board/advantech/imx8mp_rsb3720a1/imx8mp_rsb3720a1.c
++++ b/board/advantech/imx8mp_rsb3720a1/imx8mp_rsb3720a1.c
+@@ -18,6 +18,7 @@
+ #include <asm/arch/sys_proto.h>
+ #include <asm/mach-imx/gpio.h>
+ #include <asm/mach-imx/mxc_i2c.h>
++#include <asm/mach-imx/boot_mode.h>
+ #include <asm/arch/clock.h>
+ #include <asm/mach-imx/dma.h>
+ #include <linux/delay.h>
+@@ -192,6 +193,16 @@ int board_late_init(void)
+ 	if (IS_ENABLED(CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG)) {
+ 		env_set("board_name", "RSB3720A1");
+ 		env_set("board_rev", "iMX8MP");
++		switch (get_boot_device()) {
++		case SD2_BOOT:
++			env_set_ulong("mmcdev", 1);
++			break;
++		case MMC3_BOOT:
++			env_set_ulong("mmcdev", 2);
++			break;
++		default:
++			break;
++		}
+ 	}
+ 
+ 	return 0;
+-- 
+2.39.2
+

--- a/pkg/mkimage-raw-efi/make-raw
+++ b/pkg/mkimage-raw-efi/make-raw
@@ -173,6 +173,9 @@ do_installer() {
   mkdir -p /efifs/boot && cp -r "$BOOT_DIR"/* /efifs/boot/ 2>/dev/null
   cp "$INSTALLER_GRUB_CFG" /efifs/EFI/BOOT/grub.cfg
   cp "$PERSIST_FILE" "$INITRD_IMG" "$ROOTFS_IMG" "$INSTALLER_IMG" /UsbInvocationScript.txt /efifs
+  if [ -f "$IMX8_BLOB" ] && [ -f "$IMX8_CONF" ]; then
+     cp "$IMX8_BLOB" "$IMX8_CONF" /efifs
+  fi
   touch /efifs/boot/.boot_repository
   od -An -x -N 16 /dev/random | tr -d ' ' > /efifs/boot/.uuid
   do_system_vfat_part "$1" "$INSTALLER_SYS_PART_SIZE"

--- a/tools/prepare-platform.sh
+++ b/tools/prepare-platform.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+#
+# Copyright (c) 2023 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Usage:
+#
+#      ./prepare-platform.sh <platform_identifier> <build_dir> <output_dir>
+#
+if [ $# != 3 ]; then
+    exit 0
+else
+    PLATFORM="$1"
+    BUILD_DIR="$2"
+    OUTPUT_DIR="$3"
+fi
+
+get_platform() {
+    IDSTR="$1"
+    IMX="$(echo "$IDSTR" | grep "^imx.*_.*")"
+    if [ -n "$IMX" ]; then
+        echo "imx"
+    else
+        echo "unknown"
+    fi
+}
+
+copy_a() {
+    # shellcheck disable=SC2086,SC2048
+    cp -v $* || exit 1
+}
+
+PLAT=$(get_platform "$PLATFORM")
+case "$PLAT" in
+    imx)
+        copy_a "${OUTPUT_DIR}"/bsp-imx/NXP-EULA-LICENSE.txt "${OUTPUT_DIR}"/NXP-EULA-LICENSE.txt
+        copy_a "${OUTPUT_DIR}"/bsp-imx/NXP-EULA-LICENSE.txt "${BUILD_DIR}"/NXP-EULA-LICENSE.txt
+        copy_a "${OUTPUT_DIR}"/bsp-imx/"${PLATFORM}"-flash.bin "${OUTPUT_DIR}"/imx8-flash.bin
+        copy_a "${OUTPUT_DIR}"/bsp-imx/"${PLATFORM}"-flash.conf "${OUTPUT_DIR}"/imx8-flash.conf
+        copy_a "${OUTPUT_DIR}"/bsp-imx/*.dtb "${OUTPUT_DIR}"/boot
+    ;;
+
+    *)
+        exit 1
+    ;;
+esac
+


### PR DESCRIPTION
This PR adds support to install EVE in the eMMC of i.MX8MP devices. Installation process should be performed as usual through the installation raw image.

A new tool script (prepare-platform.sh) is introduced in order to check PLATFORM variable and take specific actions regarding the target platform. This scripts helps to generalize platform code and reduces Makefile complexity.