### PR TITLE
Check for filesystem existence only, not its type

### DIFF
--- a/pkg/xen-tools/initrd/mount_disk.sh
+++ b/pkg/xen-tools/initrd/mount_disk.sh
@@ -13,9 +13,10 @@ find /sys/block/ -maxdepth 1 -regex '.*[sv]d.*' -exec basename '{}' ';'| sort | 
       exit 0
   fi
 
-  #Checking and creating a file system inside the partition
-  fileSystem="ext2"
-  existingFileSystem="$(eval "$(blkid "/dev/$disk" | awk ' { print $3 } ')"; echo "$TYPE")"
+  #Checking and creating a ext4 file system inside the partition
+  fileSystem="ext4"
+  # We only care if filesystem exists, not what type it is. So just check for TYPE existence.
+  existingFileSystem="$(blkid "/dev/$disk" | grep TYPE= )"
   if [ "$existingFileSystem" = "" ]; then
     echo "Creating $fileSystem file system on /dev/$disk"
     mke2fs -t $fileSystem "/dev/$disk" && \


### PR DESCRIPTION
If no filesystem exists create ext4 fs instead of ext2

Testing done
===========

1) Assigned a raw block device to container and verified that ext4 is created on that and mounted at the requested mount point.

2) Assigned a raw block device which already has a ext4 filesystem and verified that contents on it are intact, ie filesystem is not recreated.