### PR TITLE
parse-pkgs fail on error

### DIFF
--- a/tools/parse-pkgs.sh
+++ b/tools/parse-pkgs.sh
@@ -4,6 +4,10 @@
 #
 # [1] A poor man is a man on a deadline.
 #
+
+# if this has problems, it should fail right away
+set -e
+
 EVE="$(cd "$(dirname "$0")" && pwd)/../"
 PATH="$EVE/build-tools/bin:$PATH"
 


### PR DESCRIPTION
Otherwise, it keeps going, and the build thinks it has a valid build.yml, which it doesn't, and we get strange build errors which take a while to track down. If parse-pkgs fails, it should fail right away.