### PR TITLE
kernel-yml was too high in Makefile dep tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -713,7 +713,7 @@ $(RUNME) $(BUILD_YML):
 	cp pkg/eve/$(@F) $@
 
 EVE_ARTIFACTS=$(BIOS_IMG) $(EFI_PART) $(CONFIG_IMG) $(PERSIST_IMG) $(INITRD_IMG) $(INSTALLER_IMG) $(ROOTFS_IMG) $(SBOM) $(BSP_IMX_PART) fullname-rootfs $(BOOT_PART)
-eve: kernel-yml $(INSTALLER) $(EVE_ARTIFACTS) current $(RUNME) $(BUILD_YML) | $(BUILD_DIR)
+eve: $(INSTALLER) $(EVE_ARTIFACTS) current $(RUNME) $(BUILD_YML) | $(BUILD_DIR)
 	$(QUIET): "$@: Begin: EVE_REL=$(EVE_REL), HV=$(HV), LINUXKIT_PKG_TARGET=$(LINUXKIT_PKG_TARGET)"
 	cp images/*.yml $|
 	$(PARSE_PKGS) pkg/eve/Dockerfile.in > $|/Dockerfile
@@ -869,7 +869,7 @@ endif
 	qemu-img resize $@ ${MEDIA_SIZE}M
 	$(QUIET): $@: Succeeded
 
-%.yml: %.yml.in build-tools $(RESCAN_DEPS)
+%.yml: %.yml.in build-tools kernel-yml $(RESCAN_DEPS)
 	$(QUIET)$(PARSE_PKGS) $< > $@
 	$(QUIET): $@: Succeeded
 


### PR DESCRIPTION
We had this line:

```makefile
eve: kernel-yml $(INSTALLER) $(EVE_ARTIFACTS) current $(RUNME) $(BUILD_YML) | $(BUILD_DIR)
```

That makes `eve` dependent on `kernel-yml`. But `eve` does _not_ depend on the kernel ymls. It depends only on `ROOTFS_IMG` (in `EVE_ARTIFACTS`), which in turn depends on `ROOTFS_TAR`, which depends on `images/rootfs-kvm.yml`, which itself depends on `kernel-yml` to `parse-pkgs.sh` and build the `rootfs-kvm.yml`, which is needed for the tar.

Having it too high in the tree means anything else that tries to depend upon `ROOTFS_IMG` or `ROOTFS_TAR` can fail, because it doesn't know it needs `kernel-yml`.

This places it in the correct location.