### PR TITLE
compare sbom fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -668,8 +668,8 @@ $(COMPARESOURCES):
 
 compare_sbom_collected_sources: $(COLLECTED_SOURCES) $(SBOM) | $(COMPARESOURCES)
 	$(QUIET): $@: Begin
-	$(COMPARESOURCES) $(COLLECTED_SOURCES):collected_sources_manifest.csv $(SBOM)
-	@echo Done building packages
+	$(COMPARESOURCES) $(COLLECTED_SOURCES):./collected_sources_manifest.csv $(SBOM)
+	@echo Done comparing the sbom and collected sources manifest file
 	$(QUIET): $@: Succeeded
 
 


### PR DESCRIPTION
- the compare sbom and collected sources utility fails reading the csv file when we don't refer the internal path of the file. 
For eg. 

`/somepath/collected_sources.tar.gz:./collected_sources_manifest.csv`

`./` is required for the compare utility to read from the archive which acts as an internal path