### PR TITLE
compare: read data before file closes

### DIFF
--- a/tools/compare-sbom-sources/main.go
+++ b/tools/compare-sbom-sources/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
 	"encoding/csv"
 	"encoding/json"
@@ -181,11 +182,11 @@ func compareMaps(csvPackages, jsonPackages map[string]*singlePackage) (csvNotInJ
 func getFileReader(filename string) (io.Reader, error) {
 	parts := strings.Split(filename, ":")
 	if len(parts) == 1 {
-		file, err := os.Open(filename)
+		b, err := os.ReadFile(filename)
 		if err != nil {
-			return nil, fmt.Errorf("error opening file: %v", err)
+			return nil, fmt.Errorf("error reading file: %v", err)
 		}
-		return file, nil
+		return bytes.NewReader(b), nil
 	}
 
 	archiveFile := parts[0]
@@ -214,7 +215,11 @@ func getFileReader(filename string) (io.Reader, error) {
 				return nil, fmt.Errorf("error reading .tar.gz file: %v", err)
 			}
 			if hdr.Name == targetFile {
-				return tr, nil
+				var buf bytes.Buffer
+				if _, err := io.Copy(&buf, tr); err != nil {
+					return nil, fmt.Errorf("error copying file contents: %v", err)
+				}
+				return bytes.NewReader(buf.Bytes()), nil
 			}
 		}
 	} else if strings.HasSuffix(archiveFile, ".tar") {
@@ -234,7 +239,11 @@ func getFileReader(filename string) (io.Reader, error) {
 				return nil, fmt.Errorf("error reading .tar file: %v", err)
 			}
 			if hdr.Name == targetFile {
-				return tr, nil
+				var buf bytes.Buffer
+				if _, err := io.Copy(&buf, tr); err != nil {
+					return nil, fmt.Errorf("error copying file contents: %v", err)
+				}
+				return bytes.NewReader(buf.Bytes()), nil
 			}
 		}
 	}


### PR DESCRIPTION
`compare-sources-sbom` was returning a handle to the file inside the tar reader, but returning from a function with a `defer.Close()` set. That caused the tar or tgz file to close before or while reading, leading to the error:

```
2023/05/09 00:02:14 Error parsing CSV file: error reading CSV file: read /home/runner/work/eve/eve/dist/amd64/0.0.0-master-32ca7d4e/collected_sources.tar.gz: file already closed
```

We didn't catch it before because it was intermittent. The whole CSV manifest to be read is ~56KB. That meant that the caller could actually read the file before the closing function (and underlying OS) might have read it. Hence, sometimes it worked, and we got (un)lucky when testing it earlier that it worked.

This fixes it by reading the whole small manifest into memory before returning.

cc @yash-zededa @eriknordmark 