### PR TITLE
u-boot: Fix RPi4 boot on newer SoC revisions

### DIFF
--- a/pkg/u-boot/patches/patches-v2022.10/0004-rpi-Copy-properties-from-firmware-dtb-to-the-loaded-.patch
+++ b/pkg/u-boot/patches/patches-v2022.10/0004-rpi-Copy-properties-from-firmware-dtb-to-the-loaded-.patch
@@ -1,0 +1,94 @@
+From daccc4e118c4249796ab377c2e4112a70596e909 Mon Sep 17 00:00:00 2001
+From: Antoine Mazeas <antoine@karthanis.net>
+Date: Fri, 19 Aug 2022 10:56:45 +0200
+Subject: [PATCH] rpi: Copy properties from firmware dtb to the loaded dtb
+
+The RPI firmware adjusts several property values in the dtb it passes
+to u-boot depending on the board/SoC revision. Inherit some of these
+when u-boot loads a dtb itself. Specificaly copy:
+
+* /model: The firmware provides a more specific string
+* /memreserve: The firmware defines a reserved range, better keep it
+* emmc2bus and pcie0 dma-ranges: The C0T revision of the bcm2711 Soc (as
+  present on rpi 400 and some rpi 4B boards) has different values for
+  these then the B0T revision. So these need to be adjusted to boot on
+  these boards
+* blconfig: The firmware defines the memory area where the blconfig
+  stored. Copy those over so it can be enabled.
+* /chosen/kaslr-seed: The firmware generates a kaslr seed, take advantage
+  of that.
+
+Signed-off-by: Sjoerd Simons <sjoerd@collabora.com>
+Signed-off-by: Antoine Mazeas <antoine@karthanis.net>
+Reviewed-by: Simon Glass <sjg@chromium.org>
+Signed-off-by: Peter Robinson <pbrobinson@gmail.com>
+---
+ board/raspberrypi/rpi/rpi.c | 48 +++++++++++++++++++++++++++++++++++++
+ 1 file changed, 48 insertions(+)
+
+diff --git a/board/raspberrypi/rpi/rpi.c b/board/raspberrypi/rpi/rpi.c
+index 17b8108cc8..28b6f52506 100644
+--- a/board/raspberrypi/rpi/rpi.c
++++ b/board/raspberrypi/rpi/rpi.c
+@@ -504,10 +504,58 @@ void *board_fdt_blob_setup(int *err)
+ 	return (void *)fw_dtb_pointer;
+ }
+ 
++int copy_property(void *dst, void *src, char *path, char *property)
++{
++	int dst_offset, src_offset;
++	const fdt32_t *prop;
++	int len;
++
++	src_offset = fdt_path_offset(src, path);
++	dst_offset = fdt_path_offset(dst, path);
++
++	if (src_offset < 0 || dst_offset < 0)
++		return -1;
++
++	prop = fdt_getprop(src, src_offset, property, &len);
++	if (!prop)
++		return -1;
++
++	return fdt_setprop(dst, dst_offset, property, prop, len);
++}
++
++/* Copy tweaks from the firmware dtb to the loaded dtb */
++void  update_fdt_from_fw(void *fdt, void *fw_fdt)
++{
++	/* Using dtb from firmware directly; leave it alone */
++	if (fdt == fw_fdt)
++		return;
++
++	/* The firmware provides a more precie model; so copy that */
++	copy_property(fdt, fw_fdt, "/", "model");
++
++	/* memory reserve as suggested by the firmware */
++	copy_property(fdt, fw_fdt, "/", "memreserve");
++
++	/* Adjust dma-ranges for the SD card and PCI bus as they can depend on
++	 * the SoC revision
++	 */
++	copy_property(fdt, fw_fdt, "emmc2bus", "dma-ranges");
++	copy_property(fdt, fw_fdt, "pcie0", "dma-ranges");
++
++	/* Bootloader configuration template exposes as nvmem */
++	if (copy_property(fdt, fw_fdt, "blconfig", "reg") == 0)
++		copy_property(fdt, fw_fdt, "blconfig", "status");
++
++	/* kernel address randomisation seed as provided by the firmware */
++	copy_property(fdt, fw_fdt, "/chosen", "kaslr-seed");
++}
++
+ int ft_board_setup(void *blob, struct bd_info *bd)
+ {
+ 	int node;
+ 
++	update_fdt_from_fw(blob, (void *)fw_dtb_pointer);
++
+ 	node = fdt_node_offset_by_compatible(blob, -1, "simple-framebuffer");
+ 	if (node < 0)
+ 		fdt_simplefb_add_node(blob);
+-- 
+2.39.2
+


### PR DESCRIPTION
Port u-boot patch from upstream that loads dtb values passed on newer revisions of bcm2711 SoC. EVE won't boot on these boards, so this patch fixes this issue.

Background:

- https://github.com/NixOS/nixpkgs/pull/139865
- https://github.com/NixOS/nixpkgs/pull/140552/commits/b0f99ad5270605d9f0da072048c2723ab62f9780

This issue was initially observed with RPi4 from revisions C03114 and C03115, but recently @naiming-zededa also observed with newer RPi4 of revision d03114. Applying this PR, the issue is solved. Thanks @naiming-zededa for testing.