### PR TITLE
ARP Snooping for Switch NI to learn Interface IP

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -51,6 +51,7 @@
 | netdump.topic.postonboard.interval | integer in seconds | 1 day | how frequently (in seconds) can be netdumps of the same topic published after device has been onboarded |
 | netdump.topic.maxcount | integer | 10 | maximum number of netdumps that can be published for each topic. The oldest netdump is unpublished should a new netdump exceed the limit.
 | netdump.downloader.with.pcap | boolean | false | include packet captures inside netdumps for download requests. However, even if enabled, TCP segments carrying non-empty payload (i.e. content which is being downloaded) are excluded and the overall PCAP size is limited to 64MB. |
+| network.switch.enable.arpsnoop | boolean | true | enable ARP Snooping on switch Network Instance, may need a device reboot to take effect |
 
 In addition, there can be per-agent settings.
 The Per-agent settings begin with "agent.*agentname*.*setting*"

--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -390,7 +390,7 @@ func handleNetworkInstanceCreate(
 
 	br, vifs, err := getArgsForStateCollecting(ctx, config.UUID)
 	if err == nil {
-		err = ctx.niStateCollector.StartCollectingForNI(config, br, vifs)
+		err = ctx.niStateCollector.StartCollectingForNI(config, br, vifs, ctx.enableArpSnooping)
 	}
 	if err != nil {
 		log.Error(err)

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -124,6 +124,8 @@ type zedrouterContext struct {
 	publishTicker        *flextimer.FlexTickerHandle
 	// cli options
 	versionPtr *bool
+	// disable switch NI arp snooping
+	enableArpSnooping bool
 }
 
 // AddAgentSpecificCLIFlags adds CLI options
@@ -2179,6 +2181,7 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 
 			ctx.metricInterval = metricInterval
 		}
+		ctx.enableArpSnooping = gcp.GlobalValueBool(types.EnableARPSnoop)
 	}
 	log.Functionf("handleGlobalConfigImpl done for %s\n", key)
 }

--- a/pkg/pillar/nistate/linux.go
+++ b/pkg/pillar/nistate/linux.go
@@ -74,7 +74,7 @@ func NewLinuxCollector(log *base.LogObject) *LinuxCollector {
 // StartCollectingForNI : start collecting state data for the given network instance.
 // It is called by zedrouter whenever a new network instance is configured.
 func (lc *LinuxCollector) StartCollectingForNI(
-	niConfig types.NetworkInstanceConfig, br NIBridge, vifs []AppVIF) error {
+	niConfig types.NetworkInstanceConfig, br NIBridge, vifs []AppVIF, enableARPSnoop bool) error {
 	lc.mu.Lock()
 	defer lc.mu.Unlock()
 	if _, duplicate := lc.nis[niConfig.UUID]; duplicate {
@@ -91,7 +91,7 @@ func (lc *LinuxCollector) StartCollectingForNI(
 		ni.vifs = append(ni.vifs, VIFAddrs{VIF: vif})
 	}
 	lc.nis[niConfig.UUID] = ni
-	go lc.sniffDNSandDHCP(pcapCtx, br, niConfig.Type)
+	go lc.sniffDNSandDHCP(pcapCtx, br, niConfig.Type, enableARPSnoop)
 	lc.log.Noticef("%s: Started collecting state data for NI %v "+
 		"(br: %+v, vifs: %+v)", LogAndErrPrefix, niConfig.UUID, br, vifs)
 	return nil

--- a/pkg/pillar/nistate/linux_flow.go
+++ b/pkg/pillar/nistate/linux_flow.go
@@ -8,11 +8,13 @@ package nistate
 import (
 	"bytes"
 	"context"
-	log "github.com/sirupsen/logrus"
 	"net"
 	"strconv"
 	"syscall"
 	"time"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/bpf"
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
@@ -20,7 +22,6 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/packetcap/go-pcap"
 	"github.com/vishvananda/netlink"
-	"golang.org/x/net/bpf"
 )
 
 const (
@@ -273,7 +274,7 @@ func (lc *LinuxCollector) convertConntrackToFlow(
 // so that all state collecting and processing happens from the main event loop
 // (to simplify and avoid race conditions...).
 func (lc *LinuxCollector) sniffDNSandDHCP(ctx context.Context,
-	br NIBridge, niType types.NetworkInstanceType) {
+	br NIBridge, niType types.NetworkInstanceType, enableArpSnoop bool) {
 	var (
 		err         error
 		snapshotLen int32 = 1280             // draft-madi-dnsop-udp4dns-00
@@ -312,44 +313,89 @@ func (lc *LinuxCollector) sniffDNSandDHCP(ctx context.Context,
 		switched = true
 		filter = "(ip6 and icmp6 and ip6[40] == 135) or (udp and (port 53 or port 67 or port 546 or port 547))"
 		// Raw instructions below are the compiled instructions of the filter above.
-		// tcpdump -dd "(ip6 and icmp6 and ip6[40] == 135) or (udp and (port 53 or port 67 or port 546 or port 547))"
-		rawInstructions = []bpf.RawInstruction{
-			{Op: 0x28, Jt: 0, Jf: 0, K: 0x0000000c},
-			{Op: 0x15, Jt: 0, Jf: 16, K: 0x000086dd},
-			{Op: 0x30, Jt: 0, Jf: 0, K: 0x00000014},
-			{Op: 0x15, Jt: 3, Jf: 0, K: 0x0000003a},
-			{Op: 0x15, Jt: 0, Jf: 4, K: 0x0000002c},
-			{Op: 0x30, Jt: 0, Jf: 0, K: 0x00000036},
-			{Op: 0x15, Jt: 0, Jf: 28, K: 0x0000003a},
-			{Op: 0x30, Jt: 0, Jf: 0, K: 0x00000036},
-			{Op: 0x15, Jt: 25, Jf: 0, K: 0x00000087},
-			{Op: 0x30, Jt: 0, Jf: 0, K: 0x00000014},
-			{Op: 0x15, Jt: 0, Jf: 24, K: 0x00000011},
-			{Op: 0x28, Jt: 0, Jf: 0, K: 0x00000036},
-			{Op: 0x15, Jt: 21, Jf: 0, K: 0x00000035},
-			{Op: 0x15, Jt: 20, Jf: 0, K: 0x00000043},
-			{Op: 0x15, Jt: 19, Jf: 0, K: 0x00000222},
-			{Op: 0x15, Jt: 18, Jf: 0, K: 0x00000223},
-			{Op: 0x28, Jt: 0, Jf: 0, K: 0x00000038},
-			{Op: 0x15, Jt: 16, Jf: 13, K: 0x00000035},
-			{Op: 0x15, Jt: 0, Jf: 16, K: 0x00000800},
-			{Op: 0x30, Jt: 0, Jf: 0, K: 0x00000017},
-			{Op: 0x15, Jt: 0, Jf: 14, K: 0x00000011},
-			{Op: 0x28, Jt: 0, Jf: 0, K: 0x00000014},
-			{Op: 0x45, Jt: 12, Jf: 0, K: 0x00001fff},
-			{Op: 0xb1, Jt: 0, Jf: 0, K: 0x0000000e},
-			{Op: 0x48, Jt: 0, Jf: 0, K: 0x0000000e},
-			{Op: 0x15, Jt: 8, Jf: 0, K: 0x00000035},
-			{Op: 0x15, Jt: 7, Jf: 0, K: 0x00000043},
-			{Op: 0x15, Jt: 6, Jf: 0, K: 0x00000222},
-			{Op: 0x15, Jt: 5, Jf: 0, K: 0x00000223},
-			{Op: 0x48, Jt: 0, Jf: 0, K: 0x00000010},
-			{Op: 0x15, Jt: 3, Jf: 0, K: 0x00000035},
-			{Op: 0x15, Jt: 2, Jf: 0, K: 0x00000043},
-			{Op: 0x15, Jt: 1, Jf: 0, K: 0x00000222},
-			{Op: 0x15, Jt: 0, Jf: 1, K: 0x00000223},
-			{Op: 0x6, Jt: 0, Jf: 0, K: 0x00040000},
-			{Op: 0x6, Jt: 0, Jf: 0, K: 0x00000000},
+		// tcpdump -dd "(ip6 and icmp6 and ip6[40] == 135) or (udp and (port 53 or port 67 or port 546 or port 547)) or arp"
+		if !enableArpSnoop {
+			// If the user disables the ARP Snooping, the filter will omit the "or arp" above.
+			// This configitem change may need a reboot of the device to take effect.
+			rawInstructions = []bpf.RawInstruction{
+				{Op: 0x28, Jt: 0, Jf: 0, K: 0x0000000c},
+				{Op: 0x15, Jt: 0, Jf: 16, K: 0x000086dd},
+				{Op: 0x30, Jt: 0, Jf: 0, K: 0x00000014},
+				{Op: 0x15, Jt: 3, Jf: 0, K: 0x0000003a},
+				{Op: 0x15, Jt: 0, Jf: 4, K: 0x0000002c},
+				{Op: 0x30, Jt: 0, Jf: 0, K: 0x00000036},
+				{Op: 0x15, Jt: 0, Jf: 28, K: 0x0000003a},
+				{Op: 0x30, Jt: 0, Jf: 0, K: 0x00000036},
+				{Op: 0x15, Jt: 25, Jf: 0, K: 0x00000087},
+				{Op: 0x30, Jt: 0, Jf: 0, K: 0x00000014},
+				{Op: 0x15, Jt: 0, Jf: 24, K: 0x00000011},
+				{Op: 0x28, Jt: 0, Jf: 0, K: 0x00000036},
+				{Op: 0x15, Jt: 21, Jf: 0, K: 0x00000035},
+				{Op: 0x15, Jt: 20, Jf: 0, K: 0x00000043},
+				{Op: 0x15, Jt: 19, Jf: 0, K: 0x00000222},
+				{Op: 0x15, Jt: 18, Jf: 0, K: 0x00000223},
+				{Op: 0x28, Jt: 0, Jf: 0, K: 0x00000038},
+				{Op: 0x15, Jt: 16, Jf: 13, K: 0x00000035},
+				{Op: 0x15, Jt: 0, Jf: 16, K: 0x00000800},
+				{Op: 0x30, Jt: 0, Jf: 0, K: 0x00000017},
+				{Op: 0x15, Jt: 0, Jf: 14, K: 0x00000011},
+				{Op: 0x28, Jt: 0, Jf: 0, K: 0x00000014},
+				{Op: 0x45, Jt: 12, Jf: 0, K: 0x00001fff},
+				{Op: 0xb1, Jt: 0, Jf: 0, K: 0x0000000e},
+				{Op: 0x48, Jt: 0, Jf: 0, K: 0x0000000e},
+				{Op: 0x15, Jt: 8, Jf: 0, K: 0x00000035},
+				{Op: 0x15, Jt: 7, Jf: 0, K: 0x00000043},
+				{Op: 0x15, Jt: 6, Jf: 0, K: 0x00000222},
+				{Op: 0x15, Jt: 5, Jf: 0, K: 0x00000223},
+				{Op: 0x48, Jt: 0, Jf: 0, K: 0x00000010},
+				{Op: 0x15, Jt: 3, Jf: 0, K: 0x00000035},
+				{Op: 0x15, Jt: 2, Jf: 0, K: 0x00000043},
+				{Op: 0x15, Jt: 1, Jf: 0, K: 0x00000222},
+				{Op: 0x15, Jt: 0, Jf: 1, K: 0x00000223},
+				{Op: 0x6, Jt: 0, Jf: 0, K: 0x00040000},
+				{Op: 0x6, Jt: 0, Jf: 0, K: 0x00000000},
+			}
+		} else {
+			filter = filter + " or arp"
+			rawInstructions = []bpf.RawInstruction{
+				{Op: 0x28, Jt: 0, Jf: 0, K: 0x0000000c},
+				{Op: 0x15, Jt: 0, Jf: 16, K: 0x000086dd},
+				{Op: 0x30, Jt: 0, Jf: 0, K: 0x00000014},
+				{Op: 0x15, Jt: 3, Jf: 0, K: 0x0000003a},
+				{Op: 0x15, Jt: 0, Jf: 4, K: 0x0000002c},
+				{Op: 0x30, Jt: 0, Jf: 0, K: 0x00000036},
+				{Op: 0x15, Jt: 0, Jf: 29, K: 0x0000003a},
+				{Op: 0x30, Jt: 0, Jf: 0, K: 0x00000036},
+				{Op: 0x15, Jt: 26, Jf: 0, K: 0x00000087},
+				{Op: 0x30, Jt: 0, Jf: 0, K: 0x00000014},
+				{Op: 0x15, Jt: 0, Jf: 25, K: 0x00000011},
+				{Op: 0x28, Jt: 0, Jf: 0, K: 0x00000036},
+				{Op: 0x15, Jt: 22, Jf: 0, K: 0x00000035},
+				{Op: 0x15, Jt: 21, Jf: 0, K: 0x00000043},
+				{Op: 0x15, Jt: 20, Jf: 0, K: 0x00000222},
+				{Op: 0x15, Jt: 19, Jf: 0, K: 0x00000223},
+				{Op: 0x28, Jt: 0, Jf: 0, K: 0x00000038},
+				{Op: 0x15, Jt: 17, Jf: 13, K: 0x00000035},
+				{Op: 0x15, Jt: 0, Jf: 15, K: 0x00000800},
+				{Op: 0x30, Jt: 0, Jf: 0, K: 0x00000017},
+				{Op: 0x15, Jt: 0, Jf: 15, K: 0x00000011},
+				{Op: 0x28, Jt: 0, Jf: 0, K: 0x00000014},
+				{Op: 0x45, Jt: 13, Jf: 0, K: 0x00001fff},
+				{Op: 0xb1, Jt: 0, Jf: 0, K: 0x0000000e},
+				{Op: 0x48, Jt: 0, Jf: 0, K: 0x0000000e},
+				{Op: 0x15, Jt: 9, Jf: 0, K: 0x00000035},
+				{Op: 0x15, Jt: 8, Jf: 0, K: 0x00000043},
+				{Op: 0x15, Jt: 7, Jf: 0, K: 0x00000222},
+				{Op: 0x15, Jt: 6, Jf: 0, K: 0x00000223},
+				{Op: 0x48, Jt: 0, Jf: 0, K: 0x00000010},
+				{Op: 0x15, Jt: 4, Jf: 0, K: 0x00000035},
+				{Op: 0x15, Jt: 3, Jf: 0, K: 0x00000043},
+				{Op: 0x15, Jt: 2, Jf: 0, K: 0x00000222},
+				{Op: 0x15, Jt: 1, Jf: 2, K: 0x00000223},
+				{Op: 0x15, Jt: 0, Jf: 1, K: 0x00000806},
+				{Op: 0x6, Jt: 0, Jf: 0, K: 0x00040000},
+				{Op: 0x6, Jt: 0, Jf: 0, K: 0x00000000},
+			}
 		}
 	}
 	lc.log.Noticef("%s: Installing pcap on %s (bridge-num %d), "+
@@ -417,21 +463,77 @@ func (lc *LinuxCollector) processCapturedPacket(
 	}
 	packet := capPacket.packet
 	dnslayer := packet.Layer(layers.LayerTypeDNS)
-	if niInfo.config.Type == types.NetworkInstanceTypeSwitch && dnslayer == nil {
-		addrUpdates, isDhcp := lc.processDHCPPacket(niInfo, packet)
-		if isDhcp {
+	if packet.NetworkLayer() != nil {
+		if niInfo.config.Type == types.NetworkInstanceTypeSwitch && dnslayer == nil {
+			addrUpdates, isDhcp := lc.processDHCPPacket(niInfo, packet)
+			if isDhcp {
+				return addrUpdates
+			}
+			return lc.processDADProbe(niInfo, packet)
+		}
+		if dnslayer != nil {
+			lc.processDNSPacketInfo(niInfo, packet)
+		}
+	} else if niInfo.config.Type == types.NetworkInstanceTypeSwitch && packet.LinkLayer() != nil {
+		addrUpdates := lc.processARPPacket(niInfo, packet)
+		if len(addrUpdates) > 0 {
 			return addrUpdates
 		}
-		return lc.processDADProbe(niInfo, packet)
-	}
-	if dnslayer != nil {
-		lc.processDNSPacketInfo(niInfo, packet)
 	}
 	return nil
 }
 
 // Used as a constant.
 var broadcastMAC = []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+
+func (lc *LinuxCollector) processARPPacket(
+	niInfo *niInfo, packet gopacket.Packet) (addrUpdates []VIFAddrsUpdate) {
+
+	arpLayer := packet.Layer(layers.LayerTypeARP)
+	if arpLayer == nil {
+		return nil
+	}
+
+	arp, _ := arpLayer.(*layers.ARP)
+	if arp == nil {
+		return nil
+	}
+
+	var vif *VIFAddrs
+	var weAreSource bool
+	var gotAddress []byte
+	if arp.Operation == layers.ARPReply || arp.Operation == layers.ARPRequest {
+		vif = niInfo.vifs.LookupByGuestMAC(arp.DstHwAddress)
+		if vif == nil {
+			vif = niInfo.vifs.LookupByGuestMAC(arp.SourceHwAddress)
+			if vif != nil {
+				weAreSource = true
+			}
+		}
+		if vif == nil || !vif.VIF.Activated {
+			return nil
+		}
+	} else {
+		return nil
+	}
+
+	prevAddrs := *vif
+	if weAreSource {
+		gotAddress = arp.SourceProtAddress
+	} else {
+		gotAddress = arp.DstProtAddress
+	}
+	if vif.IPv4Addr.Equal(gotAddress) {
+		return nil
+	}
+	vif.IPv4Addr = gotAddress
+	newAddrs := *vif
+	addrUpdates = append(addrUpdates, VIFAddrsUpdate{
+		Prev: prevAddrs,
+		New:  newAddrs,
+	})
+	return addrUpdates
+}
 
 // Process captured DHCP packets for switched network instances.
 // Returns true if the packet being inspected is DHCP and intended for application(s)

--- a/pkg/pillar/nistate/statecollector.go
+++ b/pkg/pillar/nistate/statecollector.go
@@ -30,7 +30,7 @@ type Collector interface {
 	// StartCollectingForNI : start collecting state data for the given network instance.
 	// It is called by zedrouter whenever a new network instance is configured.
 	StartCollectingForNI(
-		niConfig types.NetworkInstanceConfig, br NIBridge, vifs []AppVIF) error
+		niConfig types.NetworkInstanceConfig, br NIBridge, vifs []AppVIF, enableArpSnoop bool) error
 
 	// UpdateCollectingForNI : update state data collecting process to reflect a change
 	// in the network or app instance config.

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -235,6 +235,8 @@ const (
 	IgnoreDiskCheckForApps GlobalSettingKey = "storage.apps.ignore.disk.check"
 	// AllowLogFastupload global setting key
 	AllowLogFastupload GlobalSettingKey = "newlog.allow.fastupload"
+	// EnableARPSnoopOnNI global setting key
+	EnableARPSnoop GlobalSettingKey = "network.switch.enable.arpsnoop"
 
 	// TriState Items
 	// NetworkFallbackAnyEth global setting key
@@ -849,6 +851,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddBoolItem(DisableDHCPAllOnesNetMask, false)
 	configItemSpecMap.AddBoolItem(ProcessCloudInitMultiPart, false)
 	configItemSpecMap.AddBoolItem(ConsoleAccess, true) // Controller likely default to false
+	configItemSpecMap.AddBoolItem(EnableARPSnoop, true)
 
 	// Add TriState Items
 	configItemSpecMap.AddTriStateItem(NetworkFallbackAnyEth, TS_DISABLED)

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -186,6 +186,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		IgnoreMemoryCheckForApps,
 		IgnoreDiskCheckForApps,
 		AllowLogFastupload,
+		EnableARPSnoop,
 		// TriState Items
 		NetworkFallbackAnyEth,
 		MaintenanceMode,


### PR DESCRIPTION
This patch fixes an issue of EdgeView treats EVE App on switch-NI with static Intf IP
configuration inside the App as 'External' IP address which can be disallowed by EdgeView policy.
The patch extends the EVE switch-NI snooping operation currently of DNS and DHCP,
to now including the ARP request and reply. This gives us the capability of learning the
App IP addresses on switch-NI in all the conditions. In rare cases, if a user does
not want this ARP snooping, it can be disabled by a configitem knob, but it may require
a device reboot if the App is already running.