### PR TITLE
Process HTTP send operations from the dedicated task in deferred queue

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -10,6 +10,7 @@
 | timer.location.cloud.interval | integer in seconds | 1 hour | how frequently device reports geographic location information to controller |
 | timer.location.app.interval | integer in seconds | 20 | how frequently device reports geographic location information to applications (to local profile server and to other apps via meta-data server) |
 | timer.send.timeout | timer in seconds | 120 | time for each http/send |
+| timer.dial.timeout | timer in seconds | 10 | maximum time allowed to establish connection |
 | timer.reboot.no.network | integer in seconds | 7 days | reboot after no cloud connectivity |
 | timer.update.fallback.no.network | integer in seconds | 300 | fallback after no cloud connectivity |
 | timer.test.baseimage.update | integer in seconds | 600 | commit to update |

--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -197,7 +197,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	subDeviceNetworkStatus.Activate()
 	zedcloudCtx := zedcloud.NewContext(log, zedcloud.ContextOptions{
 		DevNetworkStatus: clientCtx.deviceNetworkStatus,
-		Timeout:          clientCtx.globalConfig.GlobalValueInt(types.NetworkSendTimeout),
+		SendTimeout:      clientCtx.globalConfig.GlobalValueInt(types.NetworkSendTimeout),
+		DialTimeout:      clientCtx.globalConfig.GlobalValueInt(types.NetworkDialTimeout),
 		AgentMetrics:     clientCtx.zedcloudMetrics,
 		Serial:           hardware.GetProductSerial(log),
 		SoftSerial:       hardware.GetSoftSerial(log),

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -172,7 +172,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 
 	zedcloudCtx := zedcloud.NewContext(log, zedcloud.ContextOptions{
 		DevNetworkStatus: ctx.DeviceNetworkStatus,
-		Timeout:          ctx.globalConfig.GlobalValueInt(types.NetworkSendTimeout),
+		SendTimeout:      ctx.globalConfig.GlobalValueInt(types.NetworkSendTimeout),
+		DialTimeout:      ctx.globalConfig.GlobalValueInt(types.NetworkDialTimeout),
 		AgentMetrics:     ctx.zedcloudMetrics,
 		Serial:           hardware.GetProductSerial(log),
 		SoftSerial:       hardware.GetSoftSerial(log),

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -486,15 +486,13 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	// Before starting to process DomainConfig, domainmgr should (in this order):
 	//   1. wait for NIM to publish DNS to learn which ports are used for management
 	//   2. wait for PhysicalIOAdapters (from zedagent) to be processed
-	//   3. wait for NIM to finalize testing of selected DPC
-	//   4. wait for capabilities information from hypervisor
-	// Note: 2. and 3. can also execute in the reverse order.
-	// Note: 4 may come in any order
+	//   3. wait for capabilities information from hypervisor
+	// Note: 3 may come in any order
 	for !domainCtx.assignableAdapters.Initialized ||
 		len(domainCtx.deviceNetworkStatus.Ports) == 0 ||
-		domainCtx.deviceNetworkStatus.Testing ||
 		!capabilitiesSent {
-		log.Noticef("Waiting for AssignableAdapters and/or verified DPC")
+		log.Noticef("Waiting for AssignableAdapters, DPC with management ports " +
+			"and hypervisor capabilities")
 		select {
 		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)

--- a/pkg/pillar/cmd/loguploader/loguploader.go
+++ b/pkg/pillar/cmd/loguploader/loguploader.go
@@ -403,7 +403,8 @@ func sendCtxInit(ctx *loguploaderContext) {
 	//set newlog url
 	zedcloudCtx := zedcloud.NewContext(log, zedcloud.ContextOptions{
 		DevNetworkStatus: deviceNetworkStatus,
-		Timeout:          ctx.globalConfig.GlobalValueInt(types.NetworkSendTimeout),
+		SendTimeout:      ctx.globalConfig.GlobalValueInt(types.NetworkSendTimeout),
+		DialTimeout:      ctx.globalConfig.GlobalValueInt(types.NetworkDialTimeout),
 		AgentMetrics:     ctx.zedcloudMetrics,
 		Serial:           hardware.GetProductSerial(log),
 		SoftSerial:       hardware.GetSoftSerial(log),

--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -448,7 +448,6 @@ func sendAttestReqProtobuf(attestReq *attest.ZAttestReq, iteration int) {
 	// we set ignoreErr to allow other messages to be sent as well.
 	zedcloudCtx.DeferredEventCtx.SetDeferred(deferKey, buf, size, attestURL,
 		false, false, true, attestReq.ReqType)
-	zedcloudCtx.DeferredEventCtx.HandleDeferred(time.Now(), 0, true)
 }
 
 // initialize cipher pubsub trigger handlers and channels

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -303,7 +303,8 @@ func indicateInvalidBootstrapConfig(getconfigCtx *getconfigContext) {
 	getconfigCtx.ledBlinkCount = types.LedBlinkInvalidBootstrapConfig
 }
 
-func initZedcloudContext(networkSendTimeout uint32, agentMetrics *zedcloud.AgentMetrics) *zedcloud.ZedCloudContext {
+func initZedcloudContext(networkSendTimeout, networkDialTimeout uint32,
+	agentMetrics *zedcloud.AgentMetrics) *zedcloud.ZedCloudContext {
 
 	// get the server name
 	bytes, err := os.ReadFile(types.ServerFileName)
@@ -314,7 +315,8 @@ func initZedcloudContext(networkSendTimeout uint32, agentMetrics *zedcloud.Agent
 
 	zedcloudCtx := zedcloud.NewContext(log, zedcloud.ContextOptions{
 		DevNetworkStatus: deviceNetworkStatus,
-		Timeout:          networkSendTimeout,
+		SendTimeout:      networkSendTimeout,
+		DialTimeout:      networkDialTimeout,
 		AgentMetrics:     agentMetrics,
 		Serial:           hardware.GetProductSerial(log),
 		SoftSerial:       hardware.GetSoftSerial(log),

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -744,7 +744,7 @@ func waitUntilDNSReady(zedagentCtx *zedagentContext, stillRunning *time.Ticker) 
 }
 
 func handleDeferredPeriodicTask(zedagentCtx *zedagentContext) {
-	wdName := agentName + "devinfo"
+	wdName := agentName + "deferred"
 
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(25 * time.Second)

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -400,6 +400,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	// We know our own UUID; prepare for communication with controller
 	zedcloudCtx = initZedcloudContext(
 		zedagentCtx.globalConfig.GlobalValueInt(types.NetworkSendTimeout),
+		zedagentCtx.globalConfig.GlobalValueInt(types.NetworkDialTimeout),
 		zedagentCtx.zedcloudMetrics)
 
 	if parse != "" {

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -423,8 +423,13 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 
 	// Timer for deferred sends of info messages
 	zedcloudCtx.DeferredEventCtx = zedcloud.CreateDeferredCtx(zedcloudCtx,
-		getDeferredSentHandlerFunction(zedagentCtx), getDeferredPriorityFunctions()...)
-	zedcloudCtx.DeferredPeriodicCtx = zedcloud.CreateDeferredCtx(zedcloudCtx, nil)
+		zedagentCtx.ps, agentName, "DeferredEvent",
+		warningTime, errorTime,
+		getDeferredSentHandlerFunction(zedagentCtx),
+		getDeferredPriorityFunctions()...)
+	zedcloudCtx.DeferredPeriodicCtx = zedcloud.CreateDeferredCtx(zedcloudCtx,
+		zedagentCtx.ps, agentName, "DeferredPeriodic",
+		warningTime, errorTime, nil)
 	// XXX defer this until we have some config from cloud or saved copy
 	getconfigCtx.pubAppInstanceConfig.SignalRestarted()
 

--- a/pkg/pillar/conntester/zedcloud.go
+++ b/pkg/pillar/conntester/zedcloud.go
@@ -57,7 +57,7 @@ func (t *ZedcloudConnectivityTester) TestConnectivity(dns types.DeviceNetworkSta
 
 	zedcloudCtx := zedcloud.NewContext(t.Log, zedcloud.ContextOptions{
 		DevNetworkStatus: &dns,
-		Timeout:          uint32(t.TestTimeout.Seconds()),
+		SendTimeout:      uint32(t.TestTimeout.Seconds()),
 		AgentMetrics:     t.Metrics,
 		Serial:           hardware.GetProductSerial(t.Log),
 		SoftSerial:       hardware.GetSoftSerial(t.Log),
@@ -204,7 +204,7 @@ func (t *ZedcloudConnectivityTester) tryGoogleWithTracing(
 	const withNetTracing = true
 	zedcloudCtx := zedcloud.NewContext(t.Log, zedcloud.ContextOptions{
 		DevNetworkStatus: &dns,
-		Timeout:          uint32(t.TestTimeout.Seconds()),
+		SendTimeout:      uint32(t.TestTimeout.Seconds()),
 		AgentName:        t.AgentName,
 		NetTraceOpts:     t.netTraceOpts(dns),
 	})

--- a/pkg/pillar/devicenetwork/wpad.go
+++ b/pkg/pillar/devicenetwork/wpad.go
@@ -100,7 +100,7 @@ func getPacFile(log *base.LogObject, url string, dns *types.DeviceNetworkStatus,
 	ifname string, metrics *zedcloud.AgentMetrics) (string, error) {
 
 	zedcloudCtx := zedcloud.NewContext(log, zedcloud.ContextOptions{
-		Timeout:          15,
+		SendTimeout:      15,
 		AgentName:        "wpad",
 		AgentMetrics:     metrics,
 		DevNetworkStatus: dns,

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -192,6 +192,8 @@ const (
 	NetworkTestTimeout GlobalSettingKey = "timer.port.timeout"
 	// NetworkSendTimeout global setting key
 	NetworkSendTimeout GlobalSettingKey = "timer.send.timeout"
+	// NetworkDialTimeout global setting key
+	NetworkDialTimeout GlobalSettingKey = "timer.dial.timeout"
 	// LocationCloudInterval global setting key
 	LocationCloudInterval GlobalSettingKey = "timer.location.cloud.interval"
 	// LocationAppInterval global setting key
@@ -820,6 +822,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddIntItem(NetworkTestBetterInterval, 600, 0, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(NetworkTestTimeout, 15, 0, 3600)
 	configItemSpecMap.AddIntItem(NetworkSendTimeout, 120, 0, 3600)
+	configItemSpecMap.AddIntItem(NetworkDialTimeout, 10, 0, 3600)
 	configItemSpecMap.AddIntItem(LocationCloudInterval, HourInSec, 5*MinuteInSec, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(LocationAppInterval, 20, 5, HourInSec)
 	configItemSpecMap.AddIntItem(Dom0MinDiskUsagePercent, 20, 20, 80)

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -168,6 +168,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		NetworkTestBetterInterval,
 		NetworkTestTimeout,
 		NetworkSendTimeout,
+		NetworkDialTimeout,
 		Dom0MinDiskUsagePercent,
 		AppContainerStatsInterval,
 		VaultReadyCutOffTime,

--- a/pkg/pillar/zedcloud/deferred.go
+++ b/pkg/pillar/zedcloud/deferred.go
@@ -48,6 +48,8 @@ type deferredItem struct {
 	ignoreErr      bool
 }
 
+// We create a timer with really a huge duration to avoid any problems
+// with timer recreation, so we keep timer always alive.
 const longTime1 = time.Hour * 24
 const longTime2 = time.Hour * 48
 

--- a/pkg/pillar/zedcloud/deferred.go
+++ b/pkg/pillar/zedcloud/deferred.go
@@ -302,6 +302,9 @@ func (ctx *DeferredContext) SetDeferred(
 		log.Tracef("Adding key %s", key)
 		ctx.deferredItems = append(ctx.deferredItems, &item)
 	}
+
+	// Run to a completion from the processing task
+	ctx.KickTimer()
 }
 
 // RemoveDeferred removes key from deferred items if exists

--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -69,8 +69,15 @@ type ZedCloudContext struct {
 	serverSigningCertHash []byte
 	onBoardCertBytes      []byte
 	log                   *base.LogObject
-	DeferredEventCtx      *DeferredContext
-	DeferredPeriodicCtx   *DeferredContext
+	// All HTTP requests which can't be dropped and send should be
+	// repeated in case of a transmission error are added to this
+	// queue.
+	DeferredEventCtx *DeferredContext
+	// All periodic HTTP requests are added to this queue, sending
+	// errors of which can be ignored. This means even the request has
+	// failed, it will be removed from the queue, so there is no need
+	// to `kick` this queue once connectivity has restored.
+	DeferredPeriodicCtx *DeferredContext
 }
 
 // ContextOptions - options to be passed at NewContext


### PR DESCRIPTION
Zedagent main event loop is responsible for handling pubsub updates along with sending messages to the controller. HTTP send is synchronous call and can stall the whole main event loop for up to 6 minutes (overall send timeout).
This badly affects the system responsiveness which can be observed in air-gaped environment (no connectivity to the controller), when the queue is stuck waiting for send to be completed and no other pubsub updates are handled.

Three things are done in this PR:

* Introduced connect() ("dial" in terms of Go) timeout, which is much less than the send() timeout (helps to fail faster).
* All direct HTTP send() calls are moved away from the main event loop and executed in dedicated deferred goroutines.
* Also make sure that VMs (such as Local Profile Server or Local Operator Console) are not delayed by NIM testing DPC. In offline mode connectivity probes will take longer (until dial timeout elapsed).

This PR borrows a few commits from the original #3169 PR from @milan-zededa: in general the idea is the same (don't call HTTP send directly), implementation is different.

CC: @milan-zededa 

PS. Milan, please fill free to ping me if you do not agree on the missing signed-off of some of my patches. This heavily based on what you did, but implementation is a bit different, but I'm absolutely fine to put you as a co-author. 