### PR TITLE
Stabilizing eden integration tests

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -2410,6 +2410,18 @@ func handleDNSImpl(ctxArg interface{}, key string,
 		log.Functionf("handleDNSImpl: ignoring %s", key)
 		return
 	}
+	if status.DPCKey == "" {
+		// Do not activate PhysicalIOAdapterList subscription until NIM receives
+		// a DPC and publishes corresponding DNS.
+		// NIM can publish DNS even before it receives first DPC. In such case
+		// DPCKey is empty.
+		// The goal is to avoid assigning network ports to PCIBack if they are going to be
+		// used for management purposes. This way we avoid doing unintended port assignment
+		// to PCIBack that would be shortly followed by a release, therefore mitigating
+		// the risk of race conditions between domainmgr and NIM.
+		log.Warnf("handleDNSImpl: DNS with empty DPCKey")
+		return
+	}
 	// Ignore test status and timestamps
 	// Compare Testing to save its updated value which is used by us
 	if ctx.deviceNetworkStatus.MostlyEqual(status) &&

--- a/pkg/pillar/containerd/containerd.go
+++ b/pkg/pillar/containerd/containerd.go
@@ -110,7 +110,9 @@ func NewContainerdClient(user bool) (*Client, error) {
 		socket = ctrdUserSocket
 	}
 
-	ctrdClient, err = containerd.New(socket, containerd.WithDefaultRuntime(containerdRunTime))
+	ctrdClient, err = containerd.New(socket,
+		containerd.WithDefaultRuntime(containerdRunTime),
+		containerd.WithTimeout(30*time.Second))
 	if err != nil {
 		logrus.Errorf("NewContainerdClient: could not create containerd client. %v", err.Error())
 		return nil, fmt.Errorf("initContainerdClient: could not create containerd client. %v", err.Error())

--- a/tests/eden/eclient/testdata/dev_local_info.txt
+++ b/tests/eden/eclient/testdata/dev_local_info.txt
@@ -31,7 +31,7 @@ test eden.network.test -test.v -timewait 10m ACTIVATED {{template "network"}}
 
 # Deploy local-manager
 eden pod deploy -n local-manager --memory=512MB {{template "eclient_image"}} -p {{template "mngr_port"}}:22 --networks={{template "network"}}
-test eden.app.test -test.v -timewait 10m RUNNING local-manager
+test eden.app.test -test.v -timewait 15m RUNNING local-manager
 
 # Wait for ssh access
 exec -t 5m bash wait-ssh.sh {{template "mngr_port"}}
@@ -54,7 +54,7 @@ exec -t 10m bash get-devinfo-status.sh
 
 # STEP 2: Deploy the second app
 eden pod deploy -n app1 --memory=512MB {{template "eclient_image"}} -p {{template "app_port"}}:22 --networks={{template "network"}}
-test eden.app.test -test.v -timewait 10m RUNNING app1
+test eden.app.test -test.v -timewait 15m RUNNING app1
 
 # Wait for ssh access
 exec -t 5m bash wait-ssh.sh {{template "app_port"}}
@@ -123,9 +123,7 @@ exec -t 1m bash eden-pod-ps.sh local-manager
 ! stderr .
 
 # STEP 7: Check qemu process is gone aka powered off
-exec sleep 120
-eden eve status
-stdout 'EVE.*process not running'
+exec -t 5m bash wait-for-eve-to-stop.sh
 
 # STEP 8: Restart EVE; check apps come up
 message 'Restart EVE'
@@ -232,6 +230,16 @@ while true; do
     DEVINFO="$($EDEN sdn fwd eth0 {{template "mngr_port"}} -- {{template "ssh"}} "cat {{template "dev_info_status_file"}}")"
     echo "$DEVINFO" | grep "$EXPSTATE" && break
     sleep 1
+done
+
+-- wait-for-eve-to-stop.sh --
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+
+while true; do
+    STATUS="$($EDEN eve status)"
+    echo "$STATUS" | grep "EVE.*process not running" && break
+    sleep 3
 done
 
 -- eden-config.yml --

--- a/tests/eden/eclient/testdata/networking_light.txt
+++ b/tests/eden/eclient/testdata/networking_light.txt
@@ -43,7 +43,6 @@ exec sleep 10
 exec -t 1m bash setup_srv.sh
 exec sleep 10
 exec -t 1m bash run_srv.sh &
-exec sleep 10
 exec -t 1m bash run_client.sh
 exec sleep 10
 exec -t 1m bash get_result.sh
@@ -55,7 +54,6 @@ exec sleep 10
 exec -t 1m bash setup_srv.sh
 exec sleep 10
 exec -t 1m bash run_srv.sh &
-exec sleep 10
 exec -t 1m bash run_client.sh
 exec sleep 10
 exec -t 1m bash get_result.sh
@@ -103,6 +101,18 @@ $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} 'sh /tmp/server > /
 -- run_client.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 . ./env
+
+function check_server_port {
+    # get to server app via client app
+    listeners=$($EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} ssh -o StrictHostKeyChecking=no root@$ESERVER_IP netstat -tlpn)
+    echo "Current listeners: $listeners"
+    if echo "$listeners" | grep -q ":1234"; then
+        return 0
+    fi
+    return 1
+}
+
+until check_server_port; do sleep 3; done
 
 echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} "echo {{$test_msg}} | nc -N $ESERVER_IP 1234"
 $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} "echo {{$test_msg}} | nc -N $ESERVER_IP 1234"

--- a/tests/eden/eclient/testdata/nw_switch.txt
+++ b/tests/eden/eclient/testdata/nw_switch.txt
@@ -34,7 +34,8 @@ eden pod deploy -v debug -n pong {{template "eclient_image"}} --networks=n1 --me
 message 'Waiting of running'
 test eden.app.test -test.v -timewait 20m RUNNING ping1 ping2 pong
 
-message 'Getting of "pong" IP'
+message 'Getting "pong" IP'
+exec sleep 5
 eden pod ps
 cp stdout pod_ps
 exec bash pong_ip.sh
@@ -52,6 +53,9 @@ stdout '100% packet loss'
 message 'Switching to 2nd network'
 eden pod modify pong --networks n2
 test eden.app.test -test.v -timewait 15m RUNNING pong
+
+message 'Getting new "pong" IP'
+exec sleep 5
 eden pod ps
 cp stdout pod_ps
 exec bash pong_ip.sh
@@ -67,6 +71,9 @@ stdout '0% packet loss'
 message 'Switching back to 1st network'
 eden pod modify pong --networks n1
 test eden.app.test -test.v -timewait 15m RUNNING pong
+
+message 'Getting new "pong" IP'
+exec sleep 5
 eden pod ps
 cp stdout pod_ps
 exec bash pong_ip.sh

--- a/tests/eden/eclient/testdata/profile.txt
+++ b/tests/eden/eclient/testdata/profile.txt
@@ -40,7 +40,7 @@ eden controller edge-node update --device global_profile=profile-1
 
 # We set default_profile to profile-1, so app-profile-2 should be in HALTED state
 test eden.app.test -test.v -timewait 15m HALTED app-profile-2
-test eden.app.test -test.v -timewait 5m RUNNING app-profile-1 app-profile-1-2 local-manager
+test eden.app.test -test.v -timewait 15m RUNNING app-profile-1 app-profile-1-2 local-manager
 
 exec sleep 20
 
@@ -49,7 +49,7 @@ eden controller edge-node update --device global_profile=profile-2
 
 # We set default_profile to profile-2, so app-profile-1 should be in HALTED state
 test eden.app.test -test.v -timewait 15m HALTED app-profile-1
-test eden.app.test -test.v -timewait 5m RUNNING app-profile-2 app-profile-1-2 local-manager
+test eden.app.test -test.v -timewait 15m RUNNING app-profile-2 app-profile-1-2 local-manager
 
 # STEP 3: global_profile=profile-3
 
@@ -57,7 +57,7 @@ eden controller edge-node update --device global_profile=profile-3
 
 # We set default_profile to profile-3, so all apps against local-manager should be in HALTED state
 test eden.app.test -test.v -timewait 15m HALTED app-profile-1 app-profile-2 app-profile-1-2
-test eden.app.test -test.v -timewait 5m RUNNING local-manager
+test eden.app.test -test.v -timewait 15m RUNNING local-manager
 
 exec sleep 20
 
@@ -66,7 +66,7 @@ eden pod stop local-manager
 test eden.app.test -test.v -timewait 15m HALTED local-manager
 
 eden pod start local-manager
-test eden.app.test -test.v -timewait 5m RUNNING local-manager
+test eden.app.test -test.v -timewait 15m RUNNING local-manager
 
 # Wait for ssh access
 exec -t 5m bash wait_ssh.sh 2223
@@ -85,7 +85,7 @@ exec -t 1m bash local-manager-profile.sh 2223 profile-1
 
 # We set local_manager and use profile-1 in it, so app-profile-2 should be in HALTED state
 test eden.app.test -test.v -timewait 15m HALTED app-profile-2
-test eden.app.test -test.v -timewait 5m RUNNING app-profile-1 app-profile-1-2 local-manager
+test eden.app.test -test.v -timewait 15m RUNNING app-profile-1 app-profile-1-2 local-manager
 
 exec sleep 20
 
@@ -96,7 +96,7 @@ exec -t 1m bash local-manager-profile.sh 2223 profile-2
 
 # We set local_manager and use profile-2 in it, so app-profile-1 should be in HALTED state
 test eden.app.test -test.v -timewait 15m HALTED app-profile-1
-test eden.app.test -test.v -timewait 5m RUNNING app-profile-2 app-profile-1-2 local-manager
+test eden.app.test -test.v -timewait 15m RUNNING app-profile-2 app-profile-1-2 local-manager
 
 exec sleep 20
 
@@ -107,7 +107,7 @@ exec -t 1m bash local-manager-profile.sh 2223 profile-3
 
 # We set local_manager and use profile-3 in it, so all apps against local-manager should be in HALTED state
 test eden.app.test -test.v -timewait 15m HALTED app-profile-1 app-profile-2 app-profile-1-2
-test eden.app.test -test.v -timewait 5m RUNNING local-manager
+test eden.app.test -test.v -timewait 15m RUNNING local-manager
 
 exec sleep 20
 
@@ -118,7 +118,7 @@ eden controller edge-node update --device local_profile_server=""
 
 exec sleep 30
 # We have empty local_manager and empty default_profile, so apps should come back to RUNNING state now
-test eden.app.test -test.v -timewait 5m RUNNING app-profile-1 app-profile-2 app-profile-1-2 local-manager
+test eden.app.test -test.v -timewait 15m RUNNING app-profile-1 app-profile-2 app-profile-1-2 local-manager
 
 exec sleep 20
 

--- a/tests/eden/eden-version
+++ b/tests/eden/eden-version
@@ -1,1 +1,1 @@
-lfedge/eden:0.8.0
+lfedge/eden:f8748ae

--- a/tests/eden/volume/testdata/volumes_test.txt
+++ b/tests/eden/volume/testdata/volumes_test.txt
@@ -18,7 +18,7 @@ eden -t 1m volume create -n v-vhdx file://{{EdenConfig "eden.root"}}/empty.vhdx 
 stdout 'create volume v-vhdx with file://{{EdenConfig "eden.root"}}/empty.vhdx request sent'
 
 # Wait for ready
-test eden.vol.test -test.v -timewait 10m DELIVERED v-qcow2 v-docker v-qcow v-vmdk v-vhdx
+test eden.vol.test -test.v -timewait 15m DELIVERED v-qcow2 v-docker v-qcow v-vmdk v-vhdx
 
 # measure reported total space of persist
 exec -t 5m bash wait-and-get-half-total.sh
@@ -26,7 +26,7 @@ source .env
 
 # allocate volume with size of half total space
 eden -t 1m volume create -n blank-vol-1 blank --disk-size=$half_total
-test eden.vol.test -test.v -timewait 1m CREATED_VOLUME blank-vol-1
+test eden.vol.test -test.v -timewait 3m CREATED_VOLUME blank-vol-1
 
 # allocate background info check for volumeErr contains Remaining word
 test eden.lim.test -test.v -timewait 3m -test.run TestInfo -out InfoContent.vinfo 'InfoContent.vinfo.volumeErr:Remaining' 'InfoContent.vinfo.displayName:blank-vol-2' &errorwait&


### PR DESCRIPTION
This PR contains 3 commits that are addressing at least some issues that we are frequently seeing in the eden integration testing.

**Make domainmgr skip DNS with empty DPCKey**

Do not activate `PhysicalIOAdapterList` subscription until NIM receives
a DPC and publishes corresponding DNS.
NIM can publish DNS even before it receives first DPC. In such case
`DPCKey` is empty.
The goal is to avoid assigning network ports to PCIBack if they are going to be
used for management purposes. This way we avoid doing unintended port assignment
to PCIBack that would be shortly followed by a release, therefore mitigating
the risk of race conditions between domainmgr and NIM.

**Increase timeout for containerd client connection**

This is mostly to address error frequently seen when run eden tests on
(slow) github runners:
```
Rebooting EVE. Reason: Reboot from agent zedbox[1468] in partition IMGA at EVE version pr3184-kvm-amd64 at 2023-05-02T23:53:59.207011689Z: fatal: agent zedbox[1468]: couldn't initialize containerd (this should not happen): initContainerdClient: could not create containerd client. failed to dial "/run/containerd/containerd.sock": context deadline exceeded: failed to receive server preface within timeout. Exiting.
```
I have not seen this when running tests locally or when running EVE
on bare-metal devices.
Note that default timeout for containerd client to connect is 10
seconds. Increasing this to 30 seconds should not have any negative
unintended consequences.

**Update eden tests**

Bring in patches done in the eden repository to address some
unstable eden tests.