### PR TITLE
Install and use gsed instead of sed on MacOS systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,18 +113,18 @@ Make sure that Docker is up and running on your system. On MacOS just start a do
 docker version
 ```
 
-#### Get system dependencies (git, make, qemu, jq)
+#### Get system dependencies (git, make, qemu, jq, gnu-sed)
 
 ##### On OSX (using [Brew](https://brew.sh/))
 
 ```sh
-$ brew install git make jq qemu
+$ brew install git make jq qemu gnu-sed
 ```
 
 > **_NOTE:_** (M1 Macs) `qemu` may also require `python3 nettle ninja` to install properly, that is:
 >
 > ```sh
-> $ brew install git make jq python3 nettle ninja qemu
+> $ brew install git make jq python3 nettle ninja qemu gnu-sed
 > ```
 
 ##### On Ubuntu Linux

--- a/tools/kernel-build-yml.sh
+++ b/tools/kernel-build-yml.sh
@@ -3,6 +3,16 @@
 # Copyright (c) 2021 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 #
+
+SED=sed
+OS=`uname`
+
+if [ "$OS" = "Darwin" ]; then
+	#If already installed, that is fine, error message goes to /dev/null
+	brew install gnu-sed > /dev/null 2>&1
+	SED=gsed
+fi
+
 KBUILD_BUILD_HOST="eve"
 for k in "pkg/kernel" "pkg/new-kernel"; do
     KBUILD_BUILD_USER="eve"
@@ -11,7 +21,7 @@ for k in "pkg/kernel" "pkg/new-kernel"; do
     if [ $(git diff --quiet HEAD -- :"$k") ] || [ $(git ls-files --other --directory --exclude-standard :"$k" | grep .) ]; then
         KBUILD_BUILD_TIMESTAMP=$(LC_ALL=C date)
         SOURCE_DATE_EPOCH=$(date +%s)
-        KBUILD_BUILD_USER=$(whoami | sed 's/\\/\\\\/')
+        KBUILD_BUILD_USER=$(whoami | $SED 's/\\/\\\\/')
         KBUILD_BUILD_HOST=$(uname -n)
         KCONFIG_NOTIMESTAMP="false"
     else
@@ -20,9 +30,9 @@ for k in "pkg/kernel" "pkg/new-kernel"; do
         KBUILD_BUILD_TIMESTAMP=$(git log -1 --format=%cd "$k" | cut -f1 -d"+")
     fi
     cp "$k/build.yml.in" "$k/build.yml"
-    sed -i "/KBUILD_BUILD_TIMESTAMP/c\  - KBUILD_BUILD_TIMESTAMP=$KBUILD_BUILD_TIMESTAMP" "$k/build.yml"
-    sed -i "/KBUILD_BUILD_USER/c\  - KBUILD_BUILD_USER=$KBUILD_BUILD_USER" "$k/build.yml"
-    sed -i "/KBUILD_BUILD_HOST/c\  - KBUILD_BUILD_HOST=$KBUILD_BUILD_HOST" "$k/build.yml"
-    sed -i "/KCONFIG_NOTIMESTAMP/c\  - KCONFIG_NOTIMESTAMP=$KCONFIG_NOTIMESTAMP" "$k/build.yml"
-    sed -i "/SOURCE_DATE_EPOCH/c\  - SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH" "$k/build.yml"
+    $SED -i "/KBUILD_BUILD_TIMESTAMP/c\  - KBUILD_BUILD_TIMESTAMP=$KBUILD_BUILD_TIMESTAMP" "$k/build.yml"
+    $SED -i "/KBUILD_BUILD_USER/c\  - KBUILD_BUILD_USER=$KBUILD_BUILD_USER" "$k/build.yml"
+    $SED -i "/KBUILD_BUILD_HOST/c\  - KBUILD_BUILD_HOST=$KBUILD_BUILD_HOST" "$k/build.yml"
+    $SED -i "/KCONFIG_NOTIMESTAMP/c\  - KCONFIG_NOTIMESTAMP=$KCONFIG_NOTIMESTAMP" "$k/build.yml"
+    $SED -i "/SOURCE_DATE_EPOCH/c\  - SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH" "$k/build.yml"
 done

--- a/tools/kernel-build-yml.sh
+++ b/tools/kernel-build-yml.sh
@@ -8,8 +8,7 @@ SED=sed
 OS=`uname`
 
 if [ "$OS" = "Darwin" ]; then
-	#If already installed, that is fine, error message goes to /dev/null
-	brew install gnu-sed > /dev/null 2>&1
+	#gsed is a requirement on MacOS, please see eve/README.md
 	SED=gsed
 fi
 


### PR DESCRIPTION
Verified that "make pkgs" compilation works and was able to build eve on MacOS.