### PR TITLE
removed the version for compare sources utility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -663,13 +663,13 @@ $(COLLECTED_SOURCES): $(ROOTFS_TAR) $(GOSOURCES)| $(INSTALLER) $(SOURCES_DIR)
 	bash tools/collect-sources.sh $< $(CURDIR) $@
 	$(QUIET): $@: Succeeded
 
-$(COMPARESOURCES):
+$(COMPARE_SOURCE):
 	$(QUIET): $@: Begin
 	$(shell GOBIN=$(BUILDTOOLS_BIN) GO111MODULE=on CGO_ENABLED=0 go install $(COMPARE_SOURCE))
 	@echo Done building packages
 	$(QUIET): $@: Succeeded
 
-compare_sbom_collected_sources: $(COLLECTED_SOURCES) $(SBOM) | $(COMPARESOURCES)
+compare_sbom_collected_sources: $(COLLECTED_SOURCES) $(SBOM) | $(COMPARE_SOURCE)
 	$(QUIET): $@: Begin
 	$(COMPARESOURCES) $(COLLECTED_SOURCES):./collected_sources_manifest.csv $(SBOM)
 	@echo Done comparing the sbom and collected sources manifest file

--- a/Makefile
+++ b/Makefile
@@ -299,9 +299,7 @@ GOSOURCES_SOURCE=github.com/deitch/go-sources-and-licenses
 
 
 # for the compare sbom and collecte sources
-COMPARESOURCES=$(BUILDTOOLS_BIN)/compare-sbom-sources
-COMPARESOURCES_VERSION=fcf3c1558b1627ad06852b95851fbf097562b78f
-COMPARE_SOURCE=github.com/lf-edge/eve/tools/compare-sbom-sources
+COMPARE_SOURCE=./tools/compare-sbom-sources
 
 SYFT_VERSION:=v0.78.0
 SYFT_IMAGE:=docker.io/anchore/syft:$(SYFT_VERSION)
@@ -667,7 +665,7 @@ $(COLLECTED_SOURCES): $(ROOTFS_TAR) $(GOSOURCES)| $(INSTALLER) $(SOURCES_DIR)
 
 $(COMPARESOURCES):
 	$(QUIET): $@: Begin
-	$(shell GOBIN=$(BUILDTOOLS_BIN) GO111MODULE=on CGO_ENABLED=0 go install $(COMPARE_SOURCE)@$(COMPARESOURCES_VERSION))
+	$(shell GOBIN=$(BUILDTOOLS_BIN) GO111MODULE=on CGO_ENABLED=0 go install $(COMPARE_SOURCE))
 	@echo Done building packages
 	$(QUIET): $@: Succeeded
 

--- a/Makefile
+++ b/Makefile
@@ -299,6 +299,7 @@ GOSOURCES_SOURCE=github.com/deitch/go-sources-and-licenses
 
 
 # for the compare sbom and collecte sources
+COMPARESOURCES=$(BUILDTOOLS_BIN)/compare-sbom-sources
 COMPARE_SOURCE=./tools/compare-sbom-sources
 
 SYFT_VERSION:=v0.78.0
@@ -663,13 +664,13 @@ $(COLLECTED_SOURCES): $(ROOTFS_TAR) $(GOSOURCES)| $(INSTALLER) $(SOURCES_DIR)
 	bash tools/collect-sources.sh $< $(CURDIR) $@
 	$(QUIET): $@: Succeeded
 
-$(COMPARE_SOURCE):
+$(COMPARESOURCES):
 	$(QUIET): $@: Begin
 	$(shell GOBIN=$(BUILDTOOLS_BIN) GO111MODULE=on CGO_ENABLED=0 go install $(COMPARE_SOURCE))
 	@echo Done building packages
 	$(QUIET): $@: Succeeded
 
-compare_sbom_collected_sources: $(COLLECTED_SOURCES) $(SBOM) | $(COMPARE_SOURCE)
+compare_sbom_collected_sources: $(COLLECTED_SOURCES) $(SBOM) | $(COMPARESOURCES)
 	$(QUIET): $@: Begin
 	$(COMPARESOURCES) $(COLLECTED_SOURCES):./collected_sources_manifest.csv $(SBOM)
 	@echo Done comparing the sbom and collected sources manifest file


### PR DESCRIPTION
Makefile was referring to the specific commit of the COMPARE SOURCES utility. Since the source code for compare utility is in the eve repo. We are referring the folder to install the utility in the makefile.