### PR TITLE
SBOM sources arch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -123,8 +123,7 @@ jobs:
           make -e V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} LINUXKIT_PKG_TARGET=push eve
       - name: Build and push collected_sources to eve-source repo
         run: |
-          make sbom collected_sources compare_sbom_collected_sources
-          make -e V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} LINUXKIT_PKG_TARGET=push publish_sources
+          make -e V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} LINUXKIT_PKG_TARGET=push sbom collected_sources compare_sbom_collected_sources publish_sources
       - name: Post eve ${{ matrix.arch }}-${{ matrix.hv }} report
         run: |
           echo Disk usage

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -122,6 +122,7 @@ jobs:
         run: |
           make -e V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} LINUXKIT_PKG_TARGET=push eve
       - name: Build and push collected_sources to eve-source repo
+        if: matrix.arch != 'riscv64'
         run: |
           make -e V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} LINUXKIT_PKG_TARGET=push sbom collected_sources compare_sbom_collected_sources publish_sources
       - name: Post eve ${{ matrix.arch }}-${{ matrix.hv }} report


### PR DESCRIPTION
We have found sources collection for riscv64 to be sketchy, as it depends on edge things that don't always exist. This can lead to failures in the ability to collect sources, so let's disable source collection for experimental riscv64.

Also, when collecting sbom and sources, let's be sure we collect for the right arch, or we build the wrong thing.