### PR TITLE
Check for filesystem existence only, not its type

### DIFF
--- a/pkg/xen-tools/initrd/mount_disk.sh
+++ b/pkg/xen-tools/initrd/mount_disk.sh
@@ -13,9 +13,10 @@ find /sys/block/ -maxdepth 1 -regex '.*[sv]d.*' -exec basename '{}' ';'| sort | 
       exit 0
   fi
 
-  #Checking and creating a file system inside the partition
-  fileSystem="ext2"
-  existingFileSystem="$(eval "$(blkid "/dev/$disk" | awk ' { print $3 } ')"; echo "$TYPE")"
+  #Checking and creating a ext4 file system inside the partition
+  fileSystem="ext4"
+  # We only care if filesystem exists, not what type it is. So just check for TYPE existence.
+  existingFileSystem="$(blkid "/dev/$disk" | grep TYPE= )"
   if [ "$existingFileSystem" = "" ]; then
     echo "Creating $fileSystem file system on /dev/$disk"
     mke2fs -t $fileSystem "/dev/$disk" && \


### PR DESCRIPTION
If no filesystem exists create ext4 fs instead of ext2

Signed-off-by: Pramodh Pallapothu <pramodh@zededa.com>
(cherry picked from commit b3e44754a966df8d13f4a7f6f0b5b7e7ee64d445)