### PR TITLE
Allow menu and override for dom0_flavor_tweaks

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -386,12 +386,12 @@ set_${arch}_${grub_virt}
 set_config_overrides
 set_to_existing_file efi_grub_cfg "/EFI/BOOT/grub-hv.cfg"
 
+# setup bootflow per EVE's flavor
+set_${eve_flavor}_boot
+
 # process the overrides
 do_if_args source $efi_grub_cfg
 do_if_args source $config_grub_cfg
-
-# setup bootflow per EVE's flavor
-set_${eve_flavor}_boot
 
 menuentry "Boot ${rootfs_title}${rootfs_title_suffix}" {
      $load_hv_cmd $hv $hv_console $hv_platform_tweaks $hv_dom0_mem_settings $hv_dom0_cpu_settings $hv_extra_args


### PR DESCRIPTION
This makes it so that /config/grub.cfg can be used to e.g., 'set_global dom0_flavor_tweaks " "', and the menu item 'unset dom0_extra_args' will work

One use for this is to try booting without the acs override which we set by default with kvm.

BUT I don't know if this reorder will upset something else. I can't think of such cases.

I tested this (using qemu) with a conf/grub.cfg containing:
```
set_global hv_dom0_mem_settings "dom0_mem=2G,max:2G"
set_global hv_eve_mem_settings "eve_mem=1200M,max:1200M"
set_global hv_ctrd_mem_settings "ctrd_mem=700M,max:700M"
# Set automatically based on smb_product:
# But clocksource settings not present!
set_global dom0_platform_tweaks "pci=realloc=off"
set_global dom0_extra_args "$dom0_extra_args video=efifb:off"

```
Then compared /proc/cmdline with current EVE master and with this PR and I get the identical result.
Thus this fix does not get in the way of the used override example.