### PR TITLE
to pull the image from eve-sources for sbom

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -79,10 +79,13 @@ jobs:
              mv assets/kernel assets/kernel.gz
              gzip -d assets/kernel.gz
           fi
-      - name: Build SBOM and collected sources
+      - name: Pull eve-sources and publish collected_sources.tar.gz to assets
         run: |
-          make sbom collected_sources compare_sbom_collected_sources
-          mv $(make sbom_info collected_sources_info) assets/
+          EVE_SOURCES=lfedge/eve-sources:${{ env.TAG }}-${HV}-${{ env.ARCH }}
+          docker pull "$EVE_SOURCES"
+          docker create --name eve_sources "$EVE_SOURCES" bash
+          docker export --output assets/collected_sources.tar.gz eve_sources
+          docker rm eve_sources
       - name: Create a GitHub release and clean up artifacts
         id: create-release
         uses: actions/github-script@v3


### PR DESCRIPTION
This MR will pull the image based on the tag from eve-sources dockerhub repo. 

```
 EVE_SOURCES=lfedge/eve-sources:${{ env.TAG }}-${HV}-${{ env.ARCH }}
```
It will create a new container from the specified image, without starting it. We then use the export command to get the filesystem and store it into assets as tar.gz file. 
