### PR TITLE
Add compile time /etc/eve-hv-type file 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -925,7 +925,7 @@ eve-%: pkg/%/Dockerfile build-tools $(RESCAN_DEPS)
 	$(QUIET): "$@: Succeeded (intermediate for pkg/%)"
 
 images/rootfs-%.yml.in: images/rootfs.yml.in FORCE
-	$(QUITE)tools/compose-image-yml.sh $< $@ "$(ROOTFS_VERSION)-$*-$(ZARCH)"
+	$(QUITE)tools/compose-image-yml.sh $< $@ "$(ROOTFS_VERSION)-$*-$(ZARCH)" $(HV)
 
 images-patches := $(wildcard images/*.yq)
 test-images-patches: $(images-patches:%.yq=%)

--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -93,3 +93,5 @@ files:
     contents: 'EVE_VERSION'
   - path: etc/linuxkit-eve-config.yml
     metadata: yaml
+  - path: /etc/eve-hv-type
+    contents: 'EVE_HV'

--- a/pkg/dom0-ztools/rootfs/bin/eve
+++ b/pkg/dom0-ztools/rootfs/bin/eve
@@ -23,7 +23,7 @@ Welcome to EVE!
             verbose on|off
             version
             uuid
-            virttype
+            hv
 __EOT__
   exit 1
 }
@@ -160,8 +160,8 @@ __EOT__
           uuid=$(cat /persist/status/uuid)
           echo "$uuid"
           ;;
- virttype)
-          type=$(cat /run/eve-virt-type)
+ hv)
+          type=$(cat /run/eve-hv-type)
           echo "$type"
           ;;
  persist) case "$2" in

--- a/pkg/dom0-ztools/rootfs/bin/eve
+++ b/pkg/dom0-ztools/rootfs/bin/eve
@@ -23,6 +23,7 @@ Welcome to EVE!
             verbose on|off
             version
             uuid
+            virttype
 __EOT__
   exit 1
 }
@@ -158,6 +159,10 @@ __EOT__
  uuid)
           uuid=$(cat /persist/status/uuid)
           echo "$uuid"
+          ;;
+ virttype)
+          type=$(cat /run/eve-virt-type)
+          echo "$type"
           ;;
  persist) case "$2" in
                list) list_partitions

--- a/pkg/dom0-ztools/rootfs/etc/init.d/009-id
+++ b/pkg/dom0-ztools/rootfs/etc/init.d/009-id
@@ -5,16 +5,4 @@
 ID=$(zboot curpart 2>/dev/null)
 echo "${ID:-RAM}" > /run/eve.id
 cp -p /etc/eve-release /run/eve-release
-v=$(cat /run/eve-release)
-echo $v | grep kubevirt
-if [ $? -eq 0 ]; then
-   echo "kubevirt" > /run/eve-virt-type
-else
-   echo $v | grep kvm
-   if [ $? -eq 0 ]; then
-      echo "kvm" > /run/eve-virt-type
-   else
-      echo "xen" > /run/eve-virt-type
-   fi
-   #ignore acrn for now
-fi
+cp -p /etc/eve-hv-type /run/eve-hv-type

--- a/pkg/dom0-ztools/rootfs/etc/init.d/009-id
+++ b/pkg/dom0-ztools/rootfs/etc/init.d/009-id
@@ -12,9 +12,9 @@ if [ $? -eq 0 ]; then
 else
    echo $v | grep kvm
    if [ $? -eq 0 ]; then
-   	echo "kvm" > /run/eve-virt-type
+      echo "kvm" > /run/eve-virt-type
    else
-	echo "xen" > /run/eve-virt-type
+      echo "xen" > /run/eve-virt-type
    fi
    #ignore acrn for now
 fi

--- a/pkg/dom0-ztools/rootfs/etc/init.d/009-id
+++ b/pkg/dom0-ztools/rootfs/etc/init.d/009-id
@@ -5,3 +5,16 @@
 ID=$(zboot curpart 2>/dev/null)
 echo "${ID:-RAM}" > /run/eve.id
 cp -p /etc/eve-release /run/eve-release
+v=$(cat /run/eve-release)
+echo $v | grep kubevirt
+if [ $? -eq 0 ]; then
+   echo "kubevirt" > /run/eve-virt-type
+else
+   echo $v | grep kvm
+   if [ $? -eq 0 ]; then
+   	echo "kvm" > /run/eve-virt-type
+   else
+	echo "xen" > /run/eve-virt-type
+   fi
+   #ignore acrn for now
+fi

--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -343,15 +343,7 @@ function set_xen_boot {
 }
 
 function set_eve_flavor {
-   # if eve_flavor is not set explicitly we assume it is
-   # embedded in the end of the name of the image
-   if [ "$eve_flavor" != xen -a "$eve_flavor" != kvm ] ; then
-      if regexp -- '-xen(-amd64$|-arm64$|-riscv64$|$)' $rootfs_title ; then
-         eve_flavor=xen
-      else
-         eve_flavor=kvm
-      fi
-   fi
+   cat -s eve_flavor /etc/eve-hv-type
 }
 
 function set_getty {

--- a/pkg/storage-init/storage-init.sh
+++ b/pkg/storage-init/storage-init.sh
@@ -100,11 +100,6 @@ fi
 
 INIT_FS=0
 P3_FS_TYPE_DEFAULT=ext4
-# check if we have zfs-kvm or zfs-xen or zfs-acrn in eve version
-# if so use zfs as default
-if grep -E 'zfs-(kvm|xen|acrn)' /hostfs/etc/eve-release; then
-   P3_FS_TYPE_DEFAULT=zfs
-fi
 # check if we have eve_install_zfs_with_raid_level in kernel command line
 # if so use zfs as default
 if grep -q 'eve_install_zfs_with_raid_level' /proc/cmdline; then

--- a/tools/compose-image-yml.sh
+++ b/tools/compose-image-yml.sh
@@ -34,10 +34,15 @@ patch_version() {
     yq --arg version "$1" '(.files[] | select(.contents == "EVE_VERSION")).contents |= $version' "$2"
 }
 
+patch_hv() {
+    # shellcheck disable=SC2016
+    yq --arg hv "$1" '(.files[] | select(.contents == "EVE_HV")).contents |= $hv' "$2"
+}
 main() {
     local base_templ_path="$1"
     local out_templ_path="$2"
     local eve_version="$3"
+    local eve_hv="$4"
 
     cp "${base_templ_path}" "${out_templ_path}"
     if [ -e "${out_templ_path}".yq ]; then
@@ -45,6 +50,8 @@ main() {
     fi
 
     patch_version "${eve_version}" "${out_templ_path}"
+
+    patch_hv "${eve_hv}" "${out_templ_path}"
 
     process-image-template "${out_templ_path}" "${eve_version}"
 }


### PR DESCRIPTION
1) Set eve virttype in /run/eve-virt-type based on /run/eve-release
 2) Add "eve virttype" option to return the virtualization type

This PR is a split from PR https://github.com/lf-edge/eve/pull/3210/

Testing done with kubevirt image
=========================

0e55274f-a647-4756-9e7f-bb6bbdcad366:~# cat /run/eve-virt-type 
kubevirt

0e55274f-a647-4756-9e7f-bb6bbdcad366:~# eve
Welcome to EVE!
  commands: enter [service] [command (assumed sh)]
            enter-user-app <service>
            exec [service] command
            list
            status
            start <service>
            pause <service>
            resume <service>
            destroy <service>
            persist list
            persist attach <disk>
            config mount <mountpoint>
            config unmount
            firewall drop
            verbose on|off
            version
            uuid
            virttype
0e55274f-a647-4756-9e7f-bb6bbdcad366:~# eve virttype
kubevirt


