### PR TITLE
Enhance install script to support clustered-storage

### DIFF
--- a/docs/BOOTING.md
+++ b/docs/BOOTING.md
@@ -131,8 +131,8 @@ in grub.cfg with graphical GRUB menu to get the device to boot again.
     10. `eve_install_skip_persist` - do not install persist partition onto device. May be selected from graphical GRUB menu.
     11. `eve_install_skip_rootfs` - do not install rootfs partition onto device. May be selected from graphical GRUB menu.
     12. `eve_install_skip_zfs_checks` - install zfs by skipping minimum requirement checks.
-    13. `eve_install_zfs_with_raid_level` - Sets raid level for zfs storage. Valid values are none,raid1,raid5,raid6. Default value is none.
-       This option also applied for the first boot of a live image to prepare zfs persist pool instead of ext4.
+    13. `eve_install_zfs_with_raid_level` - Sets raid level for zfs storage. Valid values are none,raid1,raid5,raid6. Default value is none. This option also applied for the first boot of a live image to prepare zfs persist pool instead of ext4.
+    14. `eve_install_clustered_storage_sizeGB` - Per node storage sizeGB in a clustered config (This is highly experimental and not supported config)
 3. General kernel parameters may be adjusted with `set_global dom0_extra_args "$dom0_extra_args OPTION1=VAL1 OPTION2 "`.
    They will be added to kernel cmdline.
 

--- a/docs/BOOTING.md
+++ b/docs/BOOTING.md
@@ -132,7 +132,7 @@ in grub.cfg with graphical GRUB menu to get the device to boot again.
     11. `eve_install_skip_rootfs` - do not install rootfs partition onto device. May be selected from graphical GRUB menu.
     12. `eve_install_skip_zfs_checks` - install zfs by skipping minimum requirement checks.
     13. `eve_install_zfs_with_raid_level` - Sets raid level for zfs storage. Valid values are none,raid1,raid5,raid6. Default value is none. This option also applied for the first boot of a live image to prepare zfs persist pool instead of ext4.
-    14. `eve_install_clustered_storage_sizeGB` - Per node storage sizeGB in a clustered config (This is highly experimental and not supported config)
+    14. `eve_install_kubevirt_reserve_for_eve_sizeGB` - Amount of space in GB to reserve for eve services in kubevirt based images (This is highly experimental and not supported config, also its an optional parameter and defaults to 20GB if not set)
 3. General kernel parameters may be adjusted with `set_global dom0_extra_args "$dom0_extra_args OPTION1=VAL1 OPTION2 "`.
    They will be added to kernel cmdline.
 

--- a/pkg/mkimage-raw-efi/install
+++ b/pkg/mkimage-raw-efi/install
@@ -22,7 +22,7 @@
 #   eve_install_skip_rootfs
 #   eve_install_skip_zfs_checks
 #   eve_install_zfs_with_raid_level
-#   eve_install_clustered_storage_sizeGB
+#   eve_install_kubevirt_reserve_for_eve_sizeGB
 #
 BAIL_FINAL_CMD=${BAIL_FINAL_CMD:-"exit 1"}
 [ -n "$DEBUG" ] && set -x
@@ -140,7 +140,7 @@ collect_black_box() {
    pillar_run tpmmgr saveTpmInfo "$1"/tpminfo.txt
 }
 
-# prepare_mounts_and_zfs_pool POOL_CREATION_COMMAND_SUFFIX_SUFFIX CLUSTERED_STORAGE_SIZE
+# prepare_mounts_and_zfs_pool POOL_CREATION_COMMAND_SUFFIX_SUFFIX INSTALL_CLUSTERED_STORAGE RESERVE_EVE_STORAGE_SIZEGB
 prepare_mounts_and_zfs_pool() {
   logmsg "Preparing ZFS pool and mounts"
   [ -e /root/sys ] || mkdir /root/sys && mount -t sysfs sysfs /root/sys
@@ -155,26 +155,32 @@ prepare_mounts_and_zfs_pool() {
   # we need this mount to propagate persist from /root/persist after call to zfs command in changed root
   [ -e /persist ] || mkdir /persist && mount --rbind --make-rslave /root/persist /persist
 
-  # If clustered storage, then create volume of that size and format it with ext4
-  # When k3s cluster components start they will mount this volume
-  # If zfs-udev module is available at this point we will use path to the volume
-  # else we will format the raw device /dev/zd0 which is guaranteed to exist since its the first
-  # zfs volume being created on this device.
-  SIZEGB=$2
-  if [ $SIZEGB -gt 0 ]; then
-     SIZEGB=$SIZEGB"G"
-     logmsg "Creating clustered-storage volume of size $SIZEGB"
-     /sbin/modprobe  zfs-udev
-     chroot /root zfs create -V $SIZEGB -o volblocksize=16k persist/clustered-storage
-     if [ -b /dev/zvol/persist/clustered-storage ]; then
-        logmsg "Formatting clustered-storage to ext4"
-        /sbin/mkfs -t ext4 /dev/zvol/persist/clustered-storage
-     elif [ -b /dev/zd0 ]; then
-        logmsg "Formatting /dev/zd0 to ext4"
-        /sbin/mkfs -t ext4 /dev/zd0
-     else
-        logmsg "FATAL: clustered-storage volume creation failed."
-     fi
+  # If clustered storage, then create volume of (available space - RESERVE_EVE_STORAGE_SIZEGB) and format it with ext4
+  if [ "$2" = true ]; then
+	  logmsg "Creating clustered-storage"
+	  # When k3s cluster components start they will mount this volume
+	  # If zfs-udev module is available at this point we will use path to the volume
+	  # else we will format the raw device /dev/zd0 which is guaranteed to exist since its the first
+	  # zfs volume being created on this device.
+          availableGB="$(chroot /root zfs get -o value -Hp available persist | awk '{ print int($1/1024/1024/1024) }')"
+          reservedGB=$3
+          logmsg "AvailableGB : $availableGB  ReservedGB : $reservedGB"
+	  SIZEGB=$(($availableGB - $reservedGB))
+	  if [ $SIZEGB -gt 0 ]; then
+	     SIZEGB=$SIZEGB"G"
+	     logmsg "Creating clustered-storage volume of size $SIZEGB"
+	     /sbin/modprobe  zfs-udev
+	     chroot /root zfs create -V $SIZEGB -o volblocksize=16k persist/clustered-storage
+	     if [ -b /dev/zvol/persist/clustered-storage ]; then
+		logmsg "Formatting clustered-storage to ext4"
+		/sbin/mkfs -t ext4 /dev/zvol/persist/clustered-storage
+	     elif [ -b /dev/zd0 ]; then
+		logmsg "Formatting /dev/zd0 to ext4"
+		/sbin/mkfs -t ext4 /dev/zd0
+	     else
+		logmsg "FATAL: clustered-storage volume creation failed."
+	     fi
+	  fi
   fi
 }
 
@@ -201,6 +207,7 @@ if grep -q eve_nuke_disks /proc/cmdline; then
   sync; sleep 5; sync
   echo " done!"
 fi
+
 
 # The static UUIDs for the disk and the partitions
 # Also in make-raw and storage-init.sh
@@ -307,10 +314,24 @@ PDEV_LIST=""
 MULTIPLE_DISKS=false
 INSTALL_ZFS=false
 INSTALL_CLUSTERED_STORAGE=false
-CLUSTERED_STORAGE_SIZEGB=0
 grep -q eve_install_zfs_with_raid_level /proc/cmdline && INSTALL_ZFS=true
-grep -q eve_install_clustered_storage_sizeGB /proc/cmdline && INSTALL_CLUSTERED_STORAGE=true && INSTALL_ZFS=true
 RAID_LEVEL="none"
+
+eve_flavor=$(cat /root/etc/eve-hv-type)
+
+if [ "$eve_flavor" = "kubevirt" ]; then
+   INSTALL_CLUSTERED_STORAGE=true
+   INSTALL_ZFS=true
+   RESERVE_EVE_STORAGE_SIZEGB=$(</proc/cmdline tr ' ' '\012' | sed -ne '/^eve_install_kubevirt_reserve_for_eve_sizeGB=/s#^.*=##p')
+
+   #If not set, default it to 20GB
+   # NOTE reserving 20GB for eve services is an experimental change and could be modified in future after analysing data.
+   if [ -z "$RESERVE_EVE_STORAGE_SIZEGB" ]; then
+      RESERVE_EVE_STORAGE_SIZEGB=20
+   fi
+
+   logmsg "Kubevirt image installing ZFS and EVE reserved storage sizeGB $RESERVE_EVE_STORAGE_SIZEGB"
+fi
 
 
 if [ "$INSTALL_ZFS" = true ]; then
@@ -325,11 +346,6 @@ if [ "$INSTALL_ZFS" = true ]; then
       POOL_CREATION_COMMAND_SUFFIX="$POOL_CREATION_COMMAND_SUFFIX $P3_ON_BOOT_PLACEHOLDER"
       logmsg "Installing EVE and ZFS on same drive $DISK_WITH_P3"
    fi
-fi
-
-# In clustered storage config we default install ZFS with raid0 (none)
-if [ "$INSTALL_CLUSTERED_STORAGE" = true ]; then
-   CLUSTERED_STORAGE_SIZEGB=$(</proc/cmdline tr ' ' '\012' | sed -ne '/^eve_install_clustered_storage_sizeGB=/s#^.*=##p')
 fi
 
 if [ "$INSTALL_DEV" != "$INSTALL_PERSIST" ]; then
@@ -423,8 +439,8 @@ if [ "$INSTALL_ZFS" = true ]; then
   fi
 
   logmsg "Creating ZFS pool with raid level: $RAID_LEVEL"
-  logmsg "Pool creation command: $POOL_CREATION_COMMAND_SUFFIX"
-  prepare_mounts_and_zfs_pool "$POOL_CREATION_COMMAND_SUFFIX" "$CLUSTERED_STORAGE_SIZEGB"
+  logmsg "Pool creation command: $POOL_CREATION_COMMAND_SUFFIX $INSTALL_CLUSTERED_STORAGE $RESERVE_EVE_STORAGE_SIZEGB"
+  prepare_mounts_and_zfs_pool "$POOL_CREATION_COMMAND_SUFFIX" "$INSTALL_CLUSTERED_STORAGE" "$RESERVE_EVE_STORAGE_SIZEGB"
   if [ -z "$RANDOM_DISK_UUIDS" ]; then
       # Walk disks and set fixed UUIDs
       # We assume that as part of adding to the zpool there is partition 1 and 9

--- a/pkg/mkimage-raw-efi/install
+++ b/pkg/mkimage-raw-efi/install
@@ -168,19 +168,19 @@ prepare_mounts_and_zfs_pool() {
           SIZEGB=$((availableGB - reservedGB))
           if [ $SIZEGB -gt 0 ]; then
              SIZEGB=$SIZEGB"G"
-	     logmsg "Creating clustered-storage volume of size $SIZEGB"
-	     /sbin/modprobe  zfs-udev
-	     chroot /root zfs create -V $SIZEGB -o volblocksize=16k persist/clustered-storage
-	     if [ -b /dev/zvol/persist/clustered-storage ]; then
-		logmsg "Formatting clustered-storage to ext4"
-		/sbin/mkfs -t ext4 /dev/zvol/persist/clustered-storage
-	     elif [ -b /dev/zd0 ]; then
-		logmsg "Formatting /dev/zd0 to ext4"
-		/sbin/mkfs -t ext4 /dev/zd0
-	     else
-		logmsg "FATAL: clustered-storage volume creation failed."
-	     fi
-	  fi
+             logmsg "Creating clustered-storage volume of size $SIZEGB"
+             /sbin/modprobe  zfs-udev
+             chroot /root zfs create -V $SIZEGB -o volblocksize=16k persist/clustered-storage
+             if [ -b /dev/zvol/persist/clustered-storage ]; then
+                logmsg "Formatting clustered-storage to ext4"
+                /sbin/mkfs -t ext4 /dev/zvol/persist/clustered-storage
+             elif [ -b /dev/zd0 ]; then
+                logmsg "Formatting /dev/zd0 to ext4"
+                /sbin/mkfs -t ext4 /dev/zd0
+             else
+                logmsg "FATAL: clustered-storage volume creation failed."
+             fi
+          fi
   fi
 }
 

--- a/pkg/mkimage-raw-efi/install
+++ b/pkg/mkimage-raw-efi/install
@@ -157,17 +157,17 @@ prepare_mounts_and_zfs_pool() {
 
   # If clustered storage, then create volume of (available space - RESERVE_EVE_STORAGE_SIZEGB) and format it with ext4
   if [ "$2" = true ]; then
-	  logmsg "Creating clustered-storage"
-	  # When k3s cluster components start they will mount this volume
-	  # If zfs-udev module is available at this point we will use path to the volume
-	  # else we will format the raw device /dev/zd0 which is guaranteed to exist since its the first
-	  # zfs volume being created on this device.
+          logmsg "Creating clustered-storage"
+          # When k3s cluster components start they will mount this volume
+          # If zfs-udev module is available at this point we will use path to the volume
+          # else we will format the raw device /dev/zd0 which is guaranteed to exist since its the first
+          # zfs volume being created on this device.
           availableGB="$(chroot /root zfs get -o value -Hp available persist | awk '{ print int($1/1024/1024/1024) }')"
           reservedGB=$3
           logmsg "AvailableGB : $availableGB  ReservedGB : $reservedGB"
-	  SIZEGB=$(($availableGB - $reservedGB))
-	  if [ $SIZEGB -gt 0 ]; then
-	     SIZEGB=$SIZEGB"G"
+          SIZEGB=$((availableGB - reservedGB))
+          if [ $SIZEGB -gt 0 ]; then
+             SIZEGB=$SIZEGB"G"
 	     logmsg "Creating clustered-storage volume of size $SIZEGB"
 	     /sbin/modprobe  zfs-udev
 	     chroot /root zfs create -V $SIZEGB -o volblocksize=16k persist/clustered-storage

--- a/pkg/mkimage-raw-efi/install
+++ b/pkg/mkimage-raw-efi/install
@@ -22,6 +22,7 @@
 #   eve_install_skip_rootfs
 #   eve_install_skip_zfs_checks
 #   eve_install_zfs_with_raid_level
+#   eve_install_clustered_storage_sizeGB
 #
 BAIL_FINAL_CMD=${BAIL_FINAL_CMD:-"exit 1"}
 [ -n "$DEBUG" ] && set -x
@@ -139,7 +140,7 @@ collect_black_box() {
    pillar_run tpmmgr saveTpmInfo "$1"/tpminfo.txt
 }
 
-# prepare_mounts_and_zfs_pool POOL_CREATION_COMMAND_SUFFIX_SUFFIX
+# prepare_mounts_and_zfs_pool POOL_CREATION_COMMAND_SUFFIX_SUFFIX CLUSTERED_STORAGE_SIZE
 prepare_mounts_and_zfs_pool() {
   logmsg "Preparing ZFS pool and mounts"
   [ -e /root/sys ] || mkdir /root/sys && mount -t sysfs sysfs /root/sys
@@ -153,6 +154,28 @@ prepare_mounts_and_zfs_pool() {
   chroot /root zfs create -o mountpoint="/persist/containerd/io.containerd.snapshotter.v1.zfs" persist/snapshots
   # we need this mount to propagate persist from /root/persist after call to zfs command in changed root
   [ -e /persist ] || mkdir /persist && mount --rbind --make-rslave /root/persist /persist
+
+  # If clustered storage, then create volume of that size and format it with ext4
+  # When k3s cluster components start they will mount this volume
+  # If zfs-udev module is available at this point we will use path to the volume
+  # else we will format the raw device /dev/zd0 which is guaranteed to exist since its the first
+  # zfs volume being created on this device.
+  SIZEGB=$2
+  if [ $SIZEGB -gt 0 ]; then
+     SIZEGB=$SIZEGB"G"
+     logmsg "Creating clustered-storage volume of size $SIZEGB"
+     /sbin/modprobe  zfs-udev
+     chroot /root zfs create -V $SIZEGB -o volblocksize=16k persist/clustered-storage
+     if [ -b /dev/zvol/persist/clustered-storage ]; then
+        logmsg "Formatting clustered-storage to ext4"
+        /sbin/mkfs -t ext4 /dev/zvol/persist/clustered-storage
+     elif [ -b /dev/zd0 ]; then
+        logmsg "Formatting /dev/zd0 to ext4"
+        /sbin/mkfs -t ext4 /dev/zd0
+     else
+        logmsg "FATAL: clustered-storage volume creation failed."
+     fi
+  fi
 }
 
 zfs_umount() {
@@ -283,7 +306,10 @@ DISKS_TO_MERGE_COUNT=0
 PDEV_LIST=""
 MULTIPLE_DISKS=false
 INSTALL_ZFS=false
+INSTALL_CLUSTERED_STORAGE=false
+CLUSTERED_STORAGE_SIZEGB=0
 grep -q eve_install_zfs_with_raid_level /proc/cmdline && INSTALL_ZFS=true
+grep -q eve_install_clustered_storage_sizeGB /proc/cmdline && INSTALL_CLUSTERED_STORAGE=true && INSTALL_ZFS=true
 RAID_LEVEL="none"
 
 
@@ -299,6 +325,11 @@ if [ "$INSTALL_ZFS" = true ]; then
       POOL_CREATION_COMMAND_SUFFIX="$POOL_CREATION_COMMAND_SUFFIX $P3_ON_BOOT_PLACEHOLDER"
       logmsg "Installing EVE and ZFS on same drive $DISK_WITH_P3"
    fi
+fi
+
+# In clustered storage config we default install ZFS with raid0 (none)
+if [ "$INSTALL_CLUSTERED_STORAGE" = true ]; then
+   CLUSTERED_STORAGE_SIZEGB=$(</proc/cmdline tr ' ' '\012' | sed -ne '/^eve_install_clustered_storage_sizeGB=/s#^.*=##p')
 fi
 
 if [ "$INSTALL_DEV" != "$INSTALL_PERSIST" ]; then
@@ -393,7 +424,7 @@ if [ "$INSTALL_ZFS" = true ]; then
 
   logmsg "Creating ZFS pool with raid level: $RAID_LEVEL"
   logmsg "Pool creation command: $POOL_CREATION_COMMAND_SUFFIX"
-  prepare_mounts_and_zfs_pool "$POOL_CREATION_COMMAND_SUFFIX"
+  prepare_mounts_and_zfs_pool "$POOL_CREATION_COMMAND_SUFFIX" "$CLUSTERED_STORAGE_SIZEGB"
   if [ -z "$RANDOM_DISK_UUIDS" ]; then
       # Walk disks and set fixed UUIDs
       # We assume that as part of adding to the zpool there is partition 1 and 9


### PR DESCRIPTION
1. Added new parameter eve_install_clustered_storage_sizeGB  
2. Creates a ZVOL of size eve_install_clustered_storage_sizeGB  and mounts ext4 on that volume.
3. That volume is where all k3s components persist the data. See pkg/k3s/cluster-init.sh


Tested
=======
Installation and verified all k3s  components start.