### PR TITLE
removed the ignore branches from the assets.yml

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -18,7 +18,7 @@ on:
       - Publish
     types:
       - completed
-    branches-ignore:
+    branches:
       - "[0-9]+.[0-9]+"
       - "[0-9]+.[0-9]+-stable"
 


### PR DESCRIPTION
assets.yml was not build in the recent patch release due to [ignore_branches](branches-ignore:) filter. Removed the filter so that the assets can be published to github.

This filter was added in https://github.com/lf-edge/eve/pull/2743/