### PR TITLE
bump go-sources to calculate go version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,7 +302,7 @@ DOCKERFILE_ADD_SCANNER_SOURCE=./tools/dockerfile-add-scanner
 
 # for the go build sources
 GOSOURCES=$(BUILDTOOLS_BIN)/go-sources-and-licenses
-GOSOURCES_VERSION=c73009667f4871c084c1f2164063321c81d053a2
+GOSOURCES_VERSION=35a4cc0e0a12f91ef11278eb0ce22f02fe9c96f6
 GOSOURCES_SOURCE=github.com/deitch/go-sources-and-licenses
 
 


### PR DESCRIPTION
When we get the sources from _modules_, it is able to get the version/pseufo-version. For pointing at source trees, however, we had no version.

This updates go-sources-and-versions to replicate how go does it, and calculate the actual version (or pseudo-version, if most recent commit is not a version), including it in the name of the file and the manifest.