### PR TITLE
Makefile: Remove -C flag from go command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -678,13 +678,13 @@ $(COLLECTED_SOURCES): $(ROOTFS_TAR) $(GOSOURCES)| $(INSTALLER) $(SOURCES_DIR)
 
 $(COMPARESOURCES):
 	$(QUIET): $@: Begin
-	GOOS=$(LOCAL_GOOS) CGO_ENABLED=0 go build -o $(COMPARESOURCES) -C $(COMPARE_SOURCE)
+	cd $(COMPARE_SOURCE) && GOOS=$(LOCAL_GOOS) CGO_ENABLED=0 go build -o $(COMPARESOURCES)
 	@echo Done building packages
 	$(QUIET): $@: Succeeded
 
 $(DOCKERFILE_ADD_SCANNER):
 	$(QUIET): $@: Begin
-	GOOS=$(LOCAL_GOOS) CGO_ENABLED=0 go build -o $@ -C $(DOCKERFILE_ADD_SCANNER_SOURCE)
+	cd $(DOCKERFILE_ADD_SCANNER_SOURCE) && GOOS=$(LOCAL_GOOS) CGO_ENABLED=0 go build -o $@
 	@echo Done building dockerfile-add-scanner
 	$(QUIET): $@: Succeeded
 


### PR DESCRIPTION
go 1.20 introduced flag -C, which changes to the directory pointed in the argument before performing the command. Commit
3a5201fec76813907146872352e44c2c8074ac3e started to use -C, breaking the build on systems with go versions lower than 1.20. Many distros (checked Ubuntu and Debian) still don't have package for Go 1.20, requiring manual installation, which can be annoying for users. This PR provides a workaround for this issue. In the future, when distros bump go version to 1.20, this commit can be reverted.