### PR TITLE
pkg/new-kernel: fix build

### DIFF
--- a/pkg/new-kernel/build.yml.in
+++ b/pkg/new-kernel/build.yml.in
@@ -1,4 +1,4 @@
-image: eve-kernel
+image: eve-new-kernel
 org: lfedge
 buildArgs:
   - KBUILD_BUILD_TIMESTAMP=


### PR DESCRIPTION
Accidentally the image was renamed from 'eve-new-kernel' to the 'eve-kernel' by the commit:

bcf0618590e3 ("kernel/new-kernel : make build reproducible")

Fix the typo.

СС: @shjala 