### PR TITLE
make eve version from file rather than templating

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,7 @@ LIVE=$(BUILD_DIR)/live
 LIVE_IMG=$(BUILD_DIR)/live.$(IMG_FORMAT)
 TARGET_IMG=$(BUILD_DIR)/target.img
 INSTALLER=$(BUILD_DIR)/installer
+VERSION_FILE=$(INSTALLER)/eve_version
 VERIFICATION=$(BUILD_DIR)/verification
 BUILD_DIR=$(DIST)/$(ROOTFS_VERSION)
 CURRENT_DIR=$(DIST)/current
@@ -582,7 +583,7 @@ $(INSTALLER):
 	@mkdir -p $@
 	@cp -r pkg/eve/installer/* $@
 	# sample output 0.0.0-HEAD-a437e8e4-xen-amd64
-	@echo $(FULL_VERSION) > $(INSTALLER)/eve_version
+	@echo $(FULL_VERSION) > $(VERSION_FILE)
 
 $(VERIFICATION):
 	@mkdir -p $@
@@ -631,7 +632,7 @@ $(ROOTFS)-%.img: $(ROOTFS_IMG)
 
 $(ROOTFS_TAR): images/rootfs-$(HV).yml | $(INSTALLER)
 	$(QUIET): $@: Begin
-	./tools/makerootfs.sh tar -y $< -t $@ -a $(ZARCH)
+	./tools/makerootfs.sh tar -y $< -t $@ -d $(INSTALLER) -a $(ZARCH)
 	$(QUIET): $@: Succeeded
 
 $(ROOTFS_IMG): $(ROOTFS_TAR) | $(INSTALLER)

--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -90,7 +90,7 @@ services:
     oomScoreAdj: -999
 files:
   - path: /etc/eve-release
-    contents: 'EVE_VERSION'
+    source: eve_version
   - path: etc/linuxkit-eve-config.yml
     metadata: yaml
   - path: /etc/eve-hv-type

--- a/tools/compose-image-yml.sh
+++ b/tools/compose-image-yml.sh
@@ -29,11 +29,6 @@ process-image-template() {
     done
 }
 
-patch_version() {
-    # shellcheck disable=SC2016
-    yq --arg version "$1" '(.files[] | select(.contents == "EVE_VERSION")).contents |= $version' "$2"
-}
-
 patch_hv() {
     # shellcheck disable=SC2016
     yq --arg hv "$1" '(.files[] | select(.contents == "EVE_HV")).contents |= $hv' "$2"
@@ -48,8 +43,6 @@ main() {
     if [ -e "${out_templ_path}".yq ]; then
         yq -f "${out_templ_path}".yq "${out_templ_path}" || exit 1
     fi
-
-    patch_version "${eve_version}" "${out_templ_path}"
 
     patch_hv "${eve_hv}" "${out_templ_path}"
 


### PR DESCRIPTION
as discussed with @eriknordmark in #3251 , this uses a similar approach, removing templating for the `EVE_VERSION` from `rootfs.yml.in` and just reusing a file in `installer/` that already exists.

It requires some changes to `makerootfs.sh` so that it knows what directory to run.