### PR TITLE
pillar: ledmanager: Enable max brightness on LEDs

### DIFF
--- a/pkg/pillar/cmd/ledmanager/ledmanager.go
+++ b/pkg/pillar/cmd/ledmanager/ledmanager.go
@@ -761,7 +761,7 @@ func doLedAction(ledName string, turnon bool) {
 	var brightnessFilename string
 	var b []byte
 	if turnon == true {
-		b = []byte("1")
+		b = maxLEDBrightness(ledName)
 	} else {
 		b = []byte("0")
 	}
@@ -786,12 +786,12 @@ func doLedBlink(ledName string) {
 		return
 	}
 	var brightnessFilename string
-	b := []byte("1")
 	if strings.HasPrefix(ledName, "/") {
 		brightnessFilename = ledName
 	} else {
 		brightnessFilename = fmt.Sprintf("/sys/class/leds/%s/brightness", ledName)
 	}
+	b := maxLEDBrightness(ledName)
 	err := os.WriteFile(brightnessFilename, b, 0644)
 	if err != nil {
 		if printOnce {
@@ -845,6 +845,21 @@ func appendLogfile(deviceNetworkStatus *types.DeviceNetworkStatus,
 	if _, err := file.WriteString(msg); err != nil {
 		log.Errorf("WriteString %s failed: %v", filename, err)
 		return
+	}
+}
+
+func maxLEDBrightness(ledName string) []byte {
+	log.Functionf("maxLEDBrightness(%s)", ledName)
+	if !strings.HasPrefix(ledName, "/") {
+		bmaxFilename := fmt.Sprintf("/sys/class/leds/%s/max_brightness", ledName)
+		brightness, err := os.ReadFile(bmaxFilename)
+		if err == nil {
+			return brightness
+		} else {
+			return []byte("1")
+		}
+	} else {
+		return []byte("1")
 	}
 }
 


### PR DESCRIPTION
Some devices allow different levels of brightness for LEDs. The maximum value allowed is provided by max_brightness file under /sys/class/leds/. Currently, EVE doesn't consider this file and uses only 1 as brightness value, making LEDs glow very weak on platforms that supports many levels of brightness. This commit implements the reading of max_brightness file and sets the maximum value (when available).