### PR TITLE
pillar: ledmanager: Add user LED for phyBOARD-Pollux

### DIFF
--- a/pkg/pillar/cmd/ledmanager/ledmanager.go
+++ b/pkg/pillar/cmd/ledmanager/ledmanager.go
@@ -248,6 +248,13 @@ var mToF = []modelToFuncs{
 		arg:         "user",
 	},
 	{
+		model:       "phytec,imx8mp-phyboard-pollux-rdk.*",
+		regexp:      true,
+		initFunc:    InitLedCmd,
+		displayFunc: ExecuteLedCmd,
+		arg:         "user-led3", // Blue LED
+	},
+	{
 		// Last in table as a default
 		model:       "",
 		initFunc:    InitForceDiskCmd,


### PR DESCRIPTION
Add support for user LED (blue) for phyBOARD-Pollux board.