### PR TITLE
Temporarily increase cgroup limits for hv kubevirt

### DIFF
--- a/pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup
+++ b/pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup
@@ -5,8 +5,20 @@ if test -f /proc/vmcore; then
     exit 0;
 fi
 
-default_cgroup_memory_limit=838860800 #800M
+hv=`cat /run/eve-hv-type`
 default_cgroup_cpus_limit=1
+
+#Increase memory limits temporarily for kubevirt type only.
+case $hv in
+   kubevirt)
+            default_cgroup_memory_limit=8388608000 #8G
+            EVESERVICES="sshd edgeview wwan wlan lisp guacd pillar vtpm watchdog xen-tools newlogd kube "
+            ;;
+          *)
+            default_cgroup_memory_limit=838860800 #800M
+            EVESERVICES="sshd edgeview wwan wlan lisp guacd pillar vtpm watchdog xen-tools newlogd "
+            ;;
+esac
 
 dom0_cgroup_memory_soft_limit=$(</proc/cmdline grep -o '\bdom0_mem=[^, ]*' | cut -d = -f 2)
 dom0_cgroup_memory_limit=$(</proc/cmdline grep -o "\bdom0_mem=[^,]*,max:[^ ]*" | cut -d : -f 2)
@@ -66,7 +78,6 @@ if [ -z "${ctrd_cgroup_cpus_limit}" ] || [ "${ctrd_cgroup_cpus_limit}" = "0" ]; 
 fi
 
 CGROUPS="cpuset cpu cpuacct blkio memory devices freezer net_cls perf_event net_prio hugetlb pids systemd "
-EVESRVICES="sshd edgeview wwan wlan lisp guacd pillar vtpm watchdog xen-tools newlogd "
 
 #Creating eve cgroup which will be parent/dom0 cgroup
 for cg in $CGROUPS; do
@@ -74,7 +85,7 @@ for cg in $CGROUPS; do
 done
 
 #Creating cgroup for individual eve services
-for srv in $EVESRVICES; do
+for srv in $EVESERVICES; do
     for cg in $CGROUPS; do
         mkdir -p /sys/fs/cgroup/"${cg}"/eve/services/"${srv}"
     done
@@ -109,7 +120,7 @@ if [ -n "${existingCPULimit}" ] && [ "$existingCPULimit" -ge "$eve_cgroup_cpus_l
     /bin/echo "0-$((eve_cgroup_cpus_limit-1))" > /sys/fs/cgroup/cpuset/eve/services/cpuset.cpus
 fi
 
-for srv in $EVESRVICES; do
+for srv in $EVESERVICES; do
     /bin/echo $eve_cgroup_memory_limit > /sys/fs/cgroup/memory/eve/services/"${srv}"/memory.limit_in_bytes
     /bin/echo $eve_cgroup_memory_soft_limit > /sys/fs/cgroup/memory/eve/services/"${srv}"/memory.soft_limit_in_bytes
     if [ -n "${existingCPULimit}" ] && [ "$existingCPULimit" -ge "$eve_cgroup_cpus_limit" ]; then

--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -60,7 +60,7 @@
 # what kind of control external context will have over this config file).
 #
 # Input variables (can NOT be longer than 20 characters)
-#  eve_flavor           can set to be either xen or kvm to indicated required boot sequence
+#  eve_flavor           can set to be either xen, kvm or kubevirt to indicated required boot sequence
 #  rootfs_root          name of a rootfilesystem recognizable by Dom0, if not set in the
 #                       outer context, the default value will be dynamically discovered
 #                       by running a partprobe command with an EVE rootfs UUID.
@@ -150,11 +150,18 @@ function set_rootfs_title {
 }
 
 function set_generic {
-   set_global hv_dom0_mem_settings "dom0_mem=800M,max:800M"
    set_global hv_dom0_cpu_settings "dom0_max_vcpus=1 dom0_vcpus_pin"
-   set_global hv_eve_mem_settings "eve_mem=650M,max:650M"
    set_global hv_eve_cpu_settings "eve_max_vcpus=1"
-   set_global hv_ctrd_mem_settings "ctrd_mem=400M,max:400M"
+   #temporarily increase memory settings for kubevirt
+   if [ "$eve_flavor" = "kubevirt" ]; then
+      set_global hv_dom0_mem_settings "dom0_mem=8000M,max:8000M"
+      set_global hv_eve_mem_settings "eve_mem=6500M,max:6500M"
+      set_global hv_ctrd_mem_settings "ctrd_mem=4000M,max:4000M"
+   else
+      set_global hv_dom0_mem_settings "dom0_mem=800M,max:800M"
+      set_global hv_eve_mem_settings "eve_mem=650M,max:650M"
+      set_global hv_ctrd_mem_settings "ctrd_mem=400M,max:400M"
+   fi
    set_global hv_ctrd_cpu_settings "ctrd_max_vcpus=1"
    set_global hv_platform_tweaks "smt=false"
    set_global hv_watchdog_timer "change=500"
@@ -340,6 +347,18 @@ function set_xen_boot {
    set_global dom0_flavor_tweaks " "
    # see the set_global eve_flavor kvm comment in set_kvm_boot
    set_global eve_flavor xen
+}
+
+function set_kubevirt_boot {
+   set_global load_hv_cmd echo
+   set_global load_dom0_cmd linux
+   set_global load_initrd_cmd initrd
+   set_global dom0_flavor_tweaks "pcie_acs_override=downstream,multifunction"
+   if [ "$arch" = "x86_64" ]; then
+      set_global dom0_flavor_tweaks "$dom0_flavor_tweaks crashkernel=2G-64G:128M,64G-1T:256M,1T-:512M"
+   fi
+   # see the set_global eve_flavor kvm comment in set_kvm_boot
+   set_global eve_flavor kubevirt
 }
 
 function set_eve_flavor {


### PR DESCRIPTION
Increased cgroup memory limits by 10 times.
Will be re-configured to proper limits in future commits after resizing the system.

Tested:
=======
All k3s components starts well in kubevirt image.
No-op in kvm image.


Also this PR is clone of closed PR https://github.com/lf-edge/eve/pull/3232