### PR TITLE
[WIP] Snapshot: enabling rollback post-restart

### DIFF
--- a/pkg/pillar/cmd/volumemgr/handlevolume.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume.go
@@ -104,7 +104,8 @@ func handleDeferredVolumeCreate(ctx *volumemgrContext, key string, config *types
 	log.Tracef("handleDeferredVolumeCreate(%s)", key)
 	status := ctx.LookupVolumeStatus(config.Key())
 	if status != nil {
-		log.Fatalf("status exists at handleVolumeCreate for %s", config.Key())
+		log.Warnf("status exists at handleVolumeCreate for %s", config.Key())
+		return
 	}
 	status = &types.VolumeStatus{
 		VolumeID:                config.VolumeID,

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -103,6 +103,22 @@ type volumemgrContext struct {
 	versionPtr *bool
 }
 
+func (ctxPtr *volumemgrContext) lookupOrCreateVolumeStatusByUUID(volumeID string, snapshotID string) *types.VolumeStatus {
+	// try to find in pubVolumeStatus
+	status := ctxPtr.lookupVolumeStatusByUUID(volumeID)
+	if status != nil {
+		return status
+	}
+	// try to deserialize
+	status, err := deserializeVolumeStatus(volumeID, snapshotID)
+	if err != nil {
+		log.Errorf("Failed to find volume status for %s: %s", volumeID, err)
+		return nil
+	}
+	publishVolumeStatus(ctxPtr, status)
+	return status
+}
+
 func (ctxPtr *volumemgrContext) lookupVolumeStatusByUUID(id string) *types.VolumeStatus {
 	sub := ctxPtr.pubVolumeStatus
 	items := sub.GetAll()

--- a/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
+++ b/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
@@ -460,6 +460,17 @@ func restoreConfigFromSnapshot(ctx *zedmanagerContext, appInstanceStatus *types.
 	if snappedAppInstanceConfig == nil {
 		return nil, fmt.Errorf("failed to read AppInstanceConfig from file for %s", snapshotID)
 	}
+	config, err := addFixupsIntoSnappedConfig(ctx, appInstanceStatus, snappedAppInstanceConfig)
+	if err != nil {
+		return config, err
+	}
+	return snappedAppInstanceConfig, nil
+}
+
+// addFixupsIntoSnappedConfig adds the fixups into the snapped app instance config.
+// The fixups are the information that should be taken from the current app instance config, not from the snapshot.
+// The fixups should correspond to the fixups done on the cloud side, in a function like: applyAppInstanceFromSnapshot
+func addFixupsIntoSnappedConfig(ctx *zedmanagerContext, appInstanceStatus *types.AppInstanceStatus, snappedAppInstanceConfig *types.AppInstanceConfig) (*types.AppInstanceConfig, error) {
 	// Get the app instance config from the app instance status
 	currentAppInstanceConfig := lookupAppInstanceConfig(ctx, appInstanceStatus.Key())
 	if currentAppInstanceConfig == nil {

--- a/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
+++ b/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -470,7 +471,7 @@ func serializeSnapshotInstanceStatus(status *types.AppInstanceStatus, moved *typ
 		log.Errorf("serializeSnapshotInstanceStatus: Failed to marshal SnapshotInstanceStatus: %s", err)
 		return fmt.Errorf("failed to marshal SnapshotInstanceStatus: %s", err)
 	}
-	err = os.WriteFile(metadataFile, data, 0644)
+	err = fileutils.WriteRename(metadataFile, data)
 	if err != nil {
 		log.Errorf("serializeSnapshotInstanceStatus: Failed to write SnapshotInstanceStatus to file: %s", err)
 		return fmt.Errorf("failed to write SnapshotInstanceStatus to file: %s", err)

--- a/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
+++ b/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
@@ -401,7 +401,7 @@ func restoreConfigFromSnapshot(ctx *zedmanagerContext, appInstanceStatus *types.
 		return nil, fmt.Errorf("SnapshotInstanceStatus not found for %s", snapshotID)
 	}
 	// Get the app instance config from the snapshot
-	snappedAppInstanceConfig := deserializeConfigFromSnapshot(snapshotStatus)
+	snappedAppInstanceConfig := deserializeConfigFromSnapshot(snapshotStatus.Snapshot.SnapshotID)
 	if snappedAppInstanceConfig == nil {
 		return nil, fmt.Errorf("failed to read AppInstanceConfig from file for %s", snapshotID)
 	}
@@ -422,9 +422,9 @@ func restoreConfigFromSnapshot(ctx *zedmanagerContext, appInstanceStatus *types.
 }
 
 // deserializeConfigFromSnapshot deserializes the config from a file
-func deserializeConfigFromSnapshot(status *types.SnapshotInstanceStatus) *types.AppInstanceConfig {
+func deserializeConfigFromSnapshot(snapshotID string) *types.AppInstanceConfig {
 	log.Noticef("deserializeConfigFromSnapshot")
-	dirname := getSnapshotDir(status.Snapshot.SnapshotID)
+	dirname := getSnapshotDir(snapshotID)
 	filename := path.Join(dirname, types.SnapshotConfigFilename)
 	var appInstanceConfig types.AppInstanceConfig
 	configFile, err := os.Open(filename)

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -282,7 +282,7 @@ func restorePresnapStatus(ctx *zedmanagerContext, status *types.AppInstanceStatu
 			return errors.New("error deserializing volumeRefStatus")
 		}
 		restoredVolumeRefStatusList = append(restoredVolumeRefStatusList, *volumeRefStatus)
-		volumeRefConfig := lookupVolumeRefConfig(ctx, volumeRefStatus.Key())
+		volumeRefConfig := lookupOrCreateVolumeRefConfig(ctx, volumeRefStatus.VolumeID.String(), volumesSnapshotConfig.SnapshotID)
 		if volumeRefConfig == nil {
 			log.Errorf("restorePresnapStatus: No volumeRefConfig found for volume %s", volumeID.String())
 			return errors.New("no volumeRefConfig found")

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -64,6 +64,10 @@ func removeAIStatus(ctx *zedmanagerContext, status *types.AppInstanceStatus) {
 	if !uninstall && domainStatus != nil && !domainStatus.Activated {
 		// We should do it before the doRemove is called, so that all the volumes are still available.
 		if status.SnapStatus.SnapshotOnUpgrade && len(status.SnapStatus.PreparedVolumesSnapshotConfigs) > 0 {
+			// Check whether there are snapshots to be deleted first (not to exceed the maximum number of snapshots).
+			if len(status.SnapStatus.SnapshotsToBeDeleted) > 0 {
+				triggerSnapshotDeletion(status.SnapStatus.SnapshotsToBeDeleted, ctx, status)
+			}
 			triggerSnapshots(ctx, status)
 		}
 	}

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -254,6 +254,23 @@ func triggerRollback(ctx *zedmanagerContext, status *types.AppInstanceStatus) (*
 		log.Errorf("triggerRollback: No snapshot config found for %s", status.SnapStatus.ActiveSnapshot)
 		return nil, errors.New("no snapshot config found")
 	}
+	err := restorePresnapStatus(ctx, status, volumesSnapshotConfig)
+	if err != nil {
+		return nil, err
+	}
+	var snappedAppInstanceConfig *types.AppInstanceConfig
+	snappedAppInstanceConfig, err = restoreConfigFromSnapshot(ctx, status)
+	if err != nil {
+		log.Errorf("triggerRollback: Error restoring config from snapshot %s: %s", status.SnapStatus.ActiveSnapshot, err)
+		return nil, errors.New("error restoring config from snapshot")
+	}
+	// Switch the action to rollback
+	volumesSnapshotConfig.Action = types.VolumesSnapshotRollback
+	publishVolumesSnapshotConfig(ctx, volumesSnapshotConfig)
+	return snappedAppInstanceConfig, nil
+}
+
+func restorePresnapStatus(ctx *zedmanagerContext, status *types.AppInstanceStatus, volumesSnapshotConfig *types.VolumesSnapshotConfig) error {
 	// Restore volumeRefStatuses from the snapshot config. Do it before doActivate is called, so that the volumeRefStatuses are available
 	// when the maybeAddDomainConfig inside doActivate is called (the list is used there to update the domain config).
 	restoredVolumeRefStatusList := make([]types.VolumeRefStatus, 0)
@@ -261,14 +278,14 @@ func triggerRollback(ctx *zedmanagerContext, status *types.AppInstanceStatus) (*
 	for _, volumeID := range volumesSnapshotConfig.VolumeIDs {
 		volumeRefStatus, err := deserializeVolumeRefStatusFromSnapshot(volumeID.String(), status.SnapStatus.ActiveSnapshot)
 		if err != nil {
-			log.Errorf("triggerRollback: Error deserializing volumeRefStatus for volume %s from snapshot %s: %s", volumeID.String(), status.SnapStatus.ActiveSnapshot, err)
-			return nil, errors.New("error deserializing volumeRefStatus")
+			log.Errorf("restorePresnapStatus: Error deserializing volumeRefStatus for volume %s from snapshot %s: %s", volumeID.String(), status.SnapStatus.ActiveSnapshot, err)
+			return errors.New("error deserializing volumeRefStatus")
 		}
 		restoredVolumeRefStatusList = append(restoredVolumeRefStatusList, *volumeRefStatus)
 		volumeRefConfig := lookupVolumeRefConfig(ctx, volumeRefStatus.Key())
 		if volumeRefConfig == nil {
-			log.Errorf("triggerRollback: No volumeRefConfig found for volume %s", volumeID.String())
-			return nil, errors.New("no volumeRefConfig found")
+			log.Errorf("restorePresnapStatus: No volumeRefConfig found for volume %s", volumeID.String())
+			return errors.New("no volumeRefConfig found")
 		}
 		fixedVolumesRefConfig = append(fixedVolumesRefConfig, *volumeRefConfig)
 	}
@@ -286,15 +303,7 @@ func triggerRollback(ctx *zedmanagerContext, status *types.AppInstanceStatus) (*
 			unpublishVolumeRefConfig(ctx, volumeRefConfig.Key())
 		}
 	}
-	snappedAppInstanceConfig, err := restoreConfigFromSnapshot(ctx, status)
-	if err != nil {
-		log.Errorf("triggerRollback: Error restoring config from snapshot %s: %s", status.SnapStatus.ActiveSnapshot, err)
-		return nil, errors.New("error restoring config from snapshot")
-	}
-	// Switch the action to rollback
-	volumesSnapshotConfig.Action = types.VolumesSnapshotRollback
-	publishVolumesSnapshotConfig(ctx, volumesSnapshotConfig)
-	return snappedAppInstanceConfig, nil
+	return nil
 }
 
 func triggerSnapshotDeletion(snapshotsToBeDeleted []types.SnapshotDesc, ctx *zedmanagerContext, status *types.AppInstanceStatus) {

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -266,6 +266,10 @@ func triggerRollback(ctx *zedmanagerContext, status *types.AppInstanceStatus) (*
 		}
 		restoredVolumeRefStatusList = append(restoredVolumeRefStatusList, *volumeRefStatus)
 		volumeRefConfig := lookupVolumeRefConfig(ctx, volumeRefStatus.Key())
+		if volumeRefConfig == nil {
+			log.Errorf("triggerRollback: No volumeRefConfig found for volume %s", volumeID.String())
+			return nil, errors.New("no volumeRefConfig found")
+		}
 		fixedVolumesRefConfig = append(fixedVolumesRefConfig, *volumeRefConfig)
 	}
 	status.VolumeRefStatusList = restoredVolumeRefStatusList

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sort"
 	"time"
@@ -874,7 +873,7 @@ func serializeVolumeRefStatusToSnapshot(status *types.VolumeRefStatus, snapshotI
 		return err
 	}
 	// Create the file for storing the volume ref status
-	err = ioutil.WriteFile(filename, statusAsBytes, 0644)
+	err = os.WriteFile(filename, statusAsBytes, 0644)
 	if err != nil {
 		log.Errorf("Failed to write the volume ref status for %s, error: %s", status.VolumeID, err)
 		return err
@@ -931,7 +930,7 @@ func serializeConfigToSnapshot(config types.AppInstanceConfig, snapshotID string
 		return err
 	}
 	configFile := fmt.Sprintf("%s/%s", snapshotDir, types.SnapshotConfigFilename)
-	err = ioutil.WriteFile(configFile, configAsBytes, 0644)
+	err = os.WriteFile(configFile, configAsBytes, 0644)
 	if err != nil {
 		log.Errorf("Failed to write the old config for %s, error: %s", config.DisplayName, err)
 		return err

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -25,6 +25,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils"
+	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 	"github.com/sirupsen/logrus"
 )
 
@@ -940,7 +941,7 @@ func serializeVolumeRefStatusToSnapshot(status *types.VolumeRefStatus, snapshotI
 		return err
 	}
 	// Create the file for storing the volume ref status
-	err = os.WriteFile(filename, statusAsBytes, 0644)
+	err = fileutils.WriteRename(filename, statusAsBytes)
 	if err != nil {
 		log.Errorf("Failed to write the volume ref status for %s, error: %s", status.VolumeID, err)
 		return err
@@ -1001,7 +1002,7 @@ func serializeConfigToSnapshot(config types.AppInstanceConfig, snapshotID string
 		return err
 	}
 	configFile := fmt.Sprintf("%s/%s", snapshotDir, types.SnapshotConfigFilename)
-	err = os.WriteFile(configFile, configAsBytes, 0644)
+	err = fileutils.WriteRename(configFile, configAsBytes)
 	if err != nil {
 		log.Errorf("Failed to write the old config for %s, error: %s", config.DisplayName, err)
 		return err

--- a/pkg/pillar/types/locationconsts.go
+++ b/pkg/pillar/types/locationconsts.go
@@ -33,10 +33,18 @@ const (
 	IngestedDirname = PersistDir + "/ingested"
 	// SnapshotsDirname - location for snapshots
 	SnapshotsDirname = PersistDir + "/snapshots"
+	// VolumeRefStatusDirName - directory used to store volume references
+	VolumeRefStatusDirName = "volumeRefStatuses"
+	// VolumeRefConfigDirName - directory used to store volume references
+	VolumeRefConfigDirName = "volumeRefConfigs"
+	// VolumeStatusDirName - directory used to store volume status
+	VolumeStatusDirName = "volumeStatuses"
 	// SnapshotConfigFilename - file to store snapshot configuration
-	SnapshotConfigFilename = "config.json"
-	// SnapshotMetadataFilename - file to store SnapshotInstanceStatus
-	SnapshotMetadataFilename = "metadata.json"
+	SnapshotConfigFilename = "appInstanceConfig.json"
+	// SnapshotInstanceStatusFilename - file to store SnapshotInstanceStatus
+	SnapshotInstanceStatusFilename = "snapshotInstanceStatus.json"
+	// SnapshotVolumesConfigFilename - file to store SnapshotVolumesConfig
+	SnapshotVolumesConfigFilename = "snapshotVolumesConfig.json"
 
 	// IdentityDirname - Config dir
 	IdentityDirname = "/config"

--- a/pkg/pillar/types/locationconsts.go
+++ b/pkg/pillar/types/locationconsts.go
@@ -35,6 +35,8 @@ const (
 	SnapshotsDirname = PersistDir + "/snapshots"
 	// SnapshotConfigFilename - file to store snapshot configuration
 	SnapshotConfigFilename = "config.json"
+	// SnapshotMetadataFilename - file to store SnapshotInstanceStatus
+	SnapshotMetadataFilename = "metadata.json"
 
 	// IdentityDirname - Config dir
 	IdentityDirname = "/config"


### PR DESCRIPTION
In this pull request, a series of enhancements are made to the pillar/zedmanager module, primarily aiming at improving the system's robustness during rollback procedures, especially after system restarts.

A notable enhancement in this pull request is in the area of data resilience. Several volume-related pubsub topics have been made persistent, which contributes to their survival through system reboots. These pubsubs, which include VolumeStatus{}, VolumesSnapshotConfig{}, and VolumeRefConfig{}, retain their messages during a system shutdown. Upon system startup, these messages are recovered.

In addition to enhancing data resilience, I have also improved the handling of snapshot metadata. I have introduced functions to serialize and deserialize snapshot metadata, which is crucial for enabling rollback functionality after a system restart. This functionality works by converting SnapshotInstanceStatus into a JSON file stored in the snapshot directory, allowing persistent storage of snapshot metadata. This stored metadata can then be recovered after a restart and transformed back into a SnapshotInstanceStatus instance. Additionally, a function to restore available snapshots during the application creation process after a system restart has been introduced.

To align the codebase with modern Go idioms, I have replaced the deprecated ioutil.WriteFile function calls with os.WriteFile in various functions. This change aligns the codebase with Go's latest practices and eliminates the need to import the ioutil package.

Additionally, an update has been made to the deserializeConfigFromSnapshot function. It has been adjusted to directly accept the SnapshotID string as an argument rather than the whole SnapshotInstanceStatus object. This change increases the function's flexibility, allowing it to be used in situations where the full Status object may not be available, but the SnapshotID is known.

A minor enhancement has also been introduced to improve the error handling process during the rollback trigger. If a VolumeRefConfig is not found, the system will now log an error message indicating the missing VolumeRefConfig for the respective volume and return an error.