### PR TITLE
pkg: bsp-imx: Enable TPM U-Boot support on phyBOARD-Pollux

### DIFF
--- a/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0023-clk-imx8mp-handle-ECSPI-clocks.patch
+++ b/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0023-clk-imx8mp-handle-ECSPI-clocks.patch
@@ -1,0 +1,67 @@
+From ae43f7bbb9651f23540b6060db14e472eba0ac75 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ren=C3=AA=20de=20Souza=20Pinto?= <rene@renesp.com.br>
+Date: Wed, 31 May 2023 12:01:25 +0200
+Subject: [PATCH 23/24] clk: imx8mp: handle ECSPI clocks
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Handle ECSPI clocks (1, 2 and 3) for imx8mp.
+
+Changes were based on the code from the following repository:
+
+Repository: git://git.phytec.de/linux-imx
+Revision: 452fa7e700fe953808d1c7a781fec6829f554333
+
+Signed-off-by: Renê de Souza Pinto <rene@renesp.com.br>
+---
+ drivers/clk/imx/clk-imx8mp.c | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
+
+diff --git a/drivers/clk/imx/clk-imx8mp.c b/drivers/clk/imx/clk-imx8mp.c
+index 435d5dc46b6..7869572b3ce 100644
+--- a/drivers/clk/imx/clk-imx8mp.c
++++ b/drivers/clk/imx/clk-imx8mp.c
+@@ -172,6 +172,18 @@ static const char *imx8mp_gic_sels[] = {"clock-osc-24m", "sys_pll2_200m", "sys_p
+ 					"sys_pll2_100m", "sys_pll1_800m",
+ 					"sys_pll2_500m", "clk_ext4", "audio_pll2_out" };
+ 
++static const char * const imx8mp_ecspi1_sels[] = {"clock-osc-24m", "sys_pll2_200m", "sys_pll1_40m",
++					"sys_pll1_160m", "sys_pll1_800m", "sys_pll3_out",
++					"sys_pll2_250m", "audio_pll2_out", };
++
++static const char * const imx8mp_ecspi2_sels[] = {"clock-osc-24m", "sys_pll2_200m", "sys_pll1_40m",
++					"sys_pll1_160m", "sys_pll1_800m", "sys_pll3_out",
++					"sys_pll2_250m", "audio_pll2_out", };
++
++static const char * const imx8mp_ecspi3_sels[] = {"clock-osc-24m", "sys_pll2_200m", "sys_pll1_40m",
++					"sys_pll1_160m", "sys_pll1_800m", "sys_pll3_out",
++					"sys_pll2_250m", "audio_pll2_out", };
++
+ static const char *imx8mp_wdog_sels[] = {"clock-osc-24m", "sys_pll1_133m", "sys_pll1_160m",
+ 					 "vpu_pll_out", "sys_pll2_125m", "sys_pll3_out",
+ 					 "sys_pll1_80m", "sys_pll2_166m" };
+@@ -387,6 +399,10 @@ static int imx8mp_clk_probe(struct udevice *dev)
+ 	clk_dm(IMX8MP_CLK_USB_PHY_REF, imx8m_clk_composite("usb_phy_ref", imx8mp_usb_phy_ref_sels, base + 0xb180));
+ 	clk_dm(IMX8MP_CLK_GIC, imx8m_clk_composite_critical("gic", imx8mp_gic_sels, base + 0xb200));
+ 
++	clk_dm(IMX8MP_CLK_ECSPI1, imx8m_clk_composite("ecspi1", imx8mp_ecspi1_sels, base + 0xb280));
++	clk_dm(IMX8MP_CLK_ECSPI2, imx8m_clk_composite("ecspi2", imx8mp_ecspi2_sels, base + 0xb300));
++	clk_dm(IMX8MP_CLK_ECSPI3, imx8m_clk_composite("ecspi3", imx8mp_ecspi3_sels, base + 0xc180));
++
+ 	clk_dm(IMX8MP_CLK_WDOG, imx8m_clk_composite("wdog", imx8mp_wdog_sels, base + 0xb900));
+ 	clk_dm(IMX8MP_CLK_USDHC3, imx8m_clk_composite("usdhc3", imx8mp_usdhc3_sels, base + 0xbc80));
+ 
+@@ -395,6 +411,9 @@ static int imx8mp_clk_probe(struct udevice *dev)
+ 
+ 	clk_dm(IMX8MP_CLK_DRAM1_ROOT, imx_clk_gate4_flags("dram1_root_clk", "dram_core_clk", base + 0x4050, 0, CLK_IS_CRITICAL));
+ 
++	clk_dm(IMX8MP_CLK_ECSPI1_ROOT, imx_clk_gate4("ecspi1_root_clk", "ecspi1", base + 0x4070, 0));
++	clk_dm(IMX8MP_CLK_ECSPI2_ROOT, imx_clk_gate4("ecspi2_root_clk", "ecspi2", base + 0x4080, 0));
++	clk_dm(IMX8MP_CLK_ECSPI3_ROOT, imx_clk_gate4("ecspi3_root_clk", "ecspi3", base + 0x4090, 0));
+ 	clk_dm(IMX8MP_CLK_ENET1_ROOT, imx_clk_gate4("enet1_root_clk", "enet_axi", base + 0x40a0, 0));
+ 	clk_dm(IMX8MP_CLK_GPIO1_ROOT, imx_clk_gate4("gpio1_root_clk", "ipg_root", base + 0x40b0, 0));
+ 	clk_dm(IMX8MP_CLK_GPIO2_ROOT, imx_clk_gate4("gpio2_root_clk", "ipg_root", base + 0x40c0, 0));
+-- 
+2.39.2
+

--- a/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0024-arm-imx8mp-Enable-hardware-TPM-on-phyBOARD-Pollux.patch
+++ b/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0024-arm-imx8mp-Enable-hardware-TPM-on-phyBOARD-Pollux.patch
@@ -1,0 +1,97 @@
+From 3ab8196db7b4b1d1dfd34352ab675900488448c0 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ren=C3=AA=20de=20Souza=20Pinto?= <rene@renesp.com.br>
+Date: Wed, 31 May 2023 13:09:19 +0200
+Subject: [PATCH 24/24] arm: imx8mp: Enable hardware TPM on phyBOARD-Pollux
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+- Add nodes related to ECSPI1 and TPM
+- Enale SPI and TPM drivers on default config (phycore-imx8mp)
+
+DTS code was based on DTS files from the following repository:
+
+Repository: git://git.phytec.de/linux-imx
+Revision: 452fa7e700fe953808d1c7a781fec6829f554333
+
+Signed-off-by: Renê de Souza Pinto <rene@renesp.com.br>
+---
+ arch/arm/dts/imx8mp-phyboard-pollux-rdk.dts | 43 +++++++++++++++++++++
+ configs/phycore-imx8mp_defconfig            |  5 +++
+ 2 files changed, 48 insertions(+)
+
+diff --git a/arch/arm/dts/imx8mp-phyboard-pollux-rdk.dts b/arch/arm/dts/imx8mp-phyboard-pollux-rdk.dts
+index 5f66e1a5fe0..83d2c676940 100644
+--- a/arch/arm/dts/imx8mp-phyboard-pollux-rdk.dts
++++ b/arch/arm/dts/imx8mp-phyboard-pollux-rdk.dts
+@@ -35,6 +35,7 @@
+ 
+ 	chosen {
+ 		stdout-path = &uart1;
++		spi1 = &ecspi1;
+ 	};
+ 
+ 	reg_usdhc2_vmmc: regulator-usdhc2 {
+@@ -220,4 +221,46 @@
+ 			MX8MP_IOMUXC_GPIO1_IO04__USDHC2_VSELECT	0xc1
+ 		>;
+ 	};
++
++	pinctrl_ecspi1: ecspi1grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_ECSPI1_MISO__ECSPI1_MISO	0x80
++			MX8MP_IOMUXC_ECSPI1_MOSI__ECSPI1_MOSI	0x80
++			MX8MP_IOMUXC_ECSPI1_SCLK__ECSPI1_SCLK	0x80
++		>;
++	};
++
++	pinctrl_ecspi1_cs: ecspi1csgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_ECSPI1_SS0__GPIO5_IO09	0x00
++		>;
++	};
++
++	pinctrl_tpm: tpmgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI1_RXC__GPIO4_IO01	0x140
++		>;
++	};
++};
++
++/* TPM */
++&ecspi1 {
++	#address-cells = <1>;
++	#size-cells = <0>;
++	cs-gpios = <&gpio5 9 GPIO_ACTIVE_LOW>;
++	fsl,spi-num-chipselects = <1>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_ecspi1 &pinctrl_ecspi1_cs>;
++	status = "okay";
++
++	tpm: tpm_tis@0 {
++		compatible = "tcg,tpm_tis-spi";
++		interrupts = <1 IRQ_TYPE_LEVEL_LOW>;
++		interrupt-parent = <&gpio4>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_tpm>;
++		reg = <0>;
++		spi-max-frequency = <38000000>;
++		status = "okay";
++	};
+ };
+diff --git a/configs/phycore-imx8mp_defconfig b/configs/phycore-imx8mp_defconfig
+index 68048bf5ed9..7b1c95ed520 100644
+--- a/configs/phycore-imx8mp_defconfig
++++ b/configs/phycore-imx8mp_defconfig
+@@ -115,3 +115,8 @@ CONFIG_SYSINFO=y
+ CONFIG_SYSINFO_SMBIOS=y
+ CONFIG_OPTEE_FIRMWARE_SET=y
+ CONFIG_OPTEE_FIRMWARE="tee.bin"
++CONFIG_SPI=y
++CONFIG_DM_SPI=y
++CONFIG_MXC_SPI=y
++CONFIG_TPM=y
++CONFIG_TPM2_TIS_SPI=y
+-- 
+2.39.2
+


### PR DESCRIPTION
Enable support for the TPM from phyBOARD-Pollux board on U-Boot, so Grub can perform boot measurements and save it to TPM's PCR registers.