### PR TITLE
Add coreutils package as prereq for MAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,18 +113,18 @@ Make sure that Docker is up and running on your system. On MacOS just start a do
 docker version
 ```
 
-#### Get system dependencies (git, make, qemu, jq, gnu-sed)
+#### Get system dependencies (git, make, qemu, jq, gnu-sed, coreutils)
 
 ##### On OSX (using [Brew](https://brew.sh/))
 
 ```sh
-$ brew install git make jq qemu gnu-sed
+$ brew install git make jq qemu gnu-sed coreutils
 ```
 
 > **_NOTE:_** (M1 Macs) `qemu` may also require `python3 nettle ninja` to install properly, that is:
 >
 > ```sh
-> $ brew install git make jq python3 nettle ninja qemu gnu-sed
+> $ brew install git make jq python3 nettle ninja qemu gnu-sed coreutils
 > ```
 
 ##### On Ubuntu Linux


### PR DESCRIPTION

commit e8ecbc76665a44a6c9bf780e8ec3552f989d6d8f added requirement for realpath binary.
On MAC coreutils package brings in realpath binary. So make coreutils as prerequisite.
