### PR TITLE
Preserve VIF IP status when only unrelated app config changes

### DIFF
--- a/pkg/pillar/cmd/zedrouter/appnetwork.go
+++ b/pkg/pillar/cmd/zedrouter/appnetwork.go
@@ -195,11 +195,17 @@ func (z *zedrouter) doCopyAppNetworkConfigToStatus(
 	status *types.AppNetworkStatus) {
 
 	ulcount := len(config.UnderlayNetworkList)
-	status.UnderlayNetworkList = make([]types.UnderlayNetworkStatus,
-		ulcount)
-	for i := range config.UnderlayNetworkList {
-		status.UnderlayNetworkList[i].UnderlayNetworkConfig =
-			config.UnderlayNetworkList[i]
+	prevNetStatus := status.UnderlayNetworkList
+	status.UnderlayNetworkList = make([]types.UnderlayNetworkStatus, ulcount)
+	for i, netConfig := range config.UnderlayNetworkList {
+		// Preserve previous VIF status unless it was moved to another network.
+		// Note that adding or removing VIF is not currently supported
+		// (such change would be rejected by config validation methods,
+		// see zedrouter/validation.go).
+		if i < len(prevNetStatus) && prevNetStatus[i].Network == netConfig.Network {
+			status.UnderlayNetworkList[i] = prevNetStatus[i]
+		}
+		status.UnderlayNetworkList[i].UnderlayNetworkConfig = netConfig
 	}
 }
 

--- a/pkg/pillar/devicenetwork/pbr.go
+++ b/pkg/pillar/devicenetwork/pbr.go
@@ -13,11 +13,8 @@ const (
 
 	// NIBaseRTIndex : base index for per-NI (network instance) routing tables used
 	// for uplink connectivity (between applications and remote endpoints).
-	// Routing table ID is a sum of the base with the interface index of the corresponding
-	// bridge interface.
-	// TODO: Once NIReconciler is integrated with zedrouter, routing table ID will be generated
-	// differently: as a sum of the base with the "bridge number" allocated (and persisted)
-	// for every network instance.
+	// Routing table ID is a sum of the base with the "bridge number" allocated
+	// (and persisted) for every network instance.
 	NIBaseRTIndex = 800
 
 	// PbrLocalDestPrio : IP rule priority for packets destined to locally owned addresses

--- a/pkg/pillar/nistate/linux.go
+++ b/pkg/pillar/nistate/linux.go
@@ -118,7 +118,7 @@ func (lc *LinuxCollector) UpdateCollectingForNI(
 	for _, vif := range vifs {
 		vifWithAddrs := VIFAddrs{VIF: vif}
 		prevVIF := prevVIFs.LookupByGuestMAC(vif.GuestIfMAC)
-		if prevVIF != nil && prevVIF.VIF.App == vif.App {
+		if prevVIF != nil && prevVIF.VIF.App == vif.App && prevVIF.VIF.NI == vif.NI {
 			vifWithAddrs.IPv4Addr = prevVIF.IPv4Addr
 			vifWithAddrs.IPv6Addrs = prevVIF.IPv6Addrs
 		}


### PR DESCRIPTION
When app config changes and the change is not relevant to VIF IP assignments (e.g. added ACL), zedrouter should preserve the existing IP status instead of clearing it up.
Commit also fixes one comment which had obsolete "TODO" inside.