### PR TITLE
debug : collect apparmor logs

### DIFF
--- a/pkg/debug/scripts/collect-info.sh
+++ b/pkg/debug/scripts/collect-info.sh
@@ -144,6 +144,9 @@ qemu-affinities.sh    > "$DIR/qemu-affinities"
 echo "- iommu groups"
 iommu-groups.sh       > "$DIR/iommu-groups"
 
+echo "- AppArmor logs"
+dmesg | grep -e "apparmor" > "$DIR/apparmor-log"
+
 echo "- TPM event log"
 find /sys/kernel/security -name "tpm*" | while read -r TPM; do
     if [ -f "$TPM/binary_bios_measurements" ]; then


### PR DESCRIPTION
Apparmor logs can be a source of information for debugging confined (sandboxed) applications that are not behaving properly, probably due to a permission failure. Collecting apparmor logs as part of our debug package can help triaging issues of this kind.