### PR TITLE
include go mod version in measure-config

### DIFF
--- a/pkg/measure-config/Dockerfile
+++ b/pkg/measure-config/Dockerfile
@@ -7,6 +7,7 @@ COPY src/  /measure-config/.
 COPY go.mod /measure-config/.
 COPY go.sum /measure-config/.
 COPY vendor /measure-config/vendor
+COPY gopkgversion /gopkgversion
 
 WORKDIR /measure-config
 
@@ -17,7 +18,7 @@ RUN echo "Running go vet" && go vet ./... && echo "Running go fmt" && \
     ERR=$(gofmt -e -l -s $(find . -name \*.go | grep -v /vendor/)) && \
     if [ -n "$ERR" ] ; then echo "go fmt Failed - ERR: $ERR"; exit 1 ; fi
 
-RUN GO111MODULE=on CGO_ENABLED=0 go build -ldflags "-s -w" -mod=vendor -o /out/usr/bin/measure-config .
+RUN GO111MODULE=on CGO_ENABLED=0 go build -ldflags "-s -w -X=main.Version=$(cat /gopkgversion)" -mod=vendor -o /out/usr/bin/measure-config .
 
 FROM scratch
 COPY --from=build /out/ /


### PR DESCRIPTION
This is a continuation of #3251 ; just as we added the version to the binaries built by edge-view and pillar, we add it to measure-config as well.