### PR TITLE
split packets into chunks when exceeding pipe buffer size

### DIFF
--- a/pkg/edgeview/Makefile
+++ b/pkg/edgeview/Makefile
@@ -9,5 +9,5 @@ eve-edgeview:
 # build the websocket server/dispatcher, should compile on a machine in the
 # same architecture as the server runs the websocket dispather
 #
-wss-server:
-	go build dispatcher/wss-server.go
+#wss-server:
+#	go build dispatcher/wss-server.go

--- a/pkg/edgeview/src/basics.go
+++ b/pkg/edgeview/src/basics.go
@@ -419,11 +419,23 @@ func runCmd(prog string, args []string, isPrint bool) (string, error) {
 	} else {
 		retStr = string(retBytes)
 		if isPrint {
-			fmt.Println(retStr)
-			closePipe(true)
+			maySplitAndPrint([]byte(retStr))
 		}
 	}
 	return retStr, err
+}
+
+func maySplitAndPrint(pBytes []byte) {
+	if len(pBytes) > pipeBufHalfSize {
+		chunks := splitBySize(pBytes, pipeBufHalfSize)
+		for _, chunk := range chunks {
+			fmt.Println(string(chunk))
+			closePipe(true)
+		}
+	} else {
+		fmt.Println(string(pBytes))
+		closePipe(true)
+	}
 }
 
 func runCmdInFunction(prog string, args []string) ([]byte, error) {

--- a/pkg/edgeview/src/system.go
+++ b/pkg/edgeview/src/system.go
@@ -971,10 +971,7 @@ func readAFile(path string, extraline int) {
 			buf = append(buf, l...)
 		}
 	}
-	for _, buff := range splitBySize(buf, 8192) {
-		fmt.Printf("%s", string(buff))
-		closePipe(true)
-	}
+	maySplitAndPrint(buf)
 	fmt.Printf("\n")
 }
 


### PR DESCRIPTION
- noticed an issue when the ACL entries too large, some of the Edgeview commends 
  may hang due to the pipe buffer was full. This patch is to split it into the separate
  chunks if the size is too large.