### PR TITLE
zedrouter/appcontainer: fix connectivity to the VM docker

### DIFF
--- a/pkg/pillar/cmd/zedrouter/appcontainer.go
+++ b/pkg/pillar/cmd/zedrouter/appcontainer.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -309,7 +310,10 @@ func (z *zedrouter) getAppContainers(status types.AppNetworkStatus) (
 	*client.Client, []apitypes.Container, error) {
 	containerEndpoint := "tcp://" + status.GetStatsIPAddr.String() +
 		":" + strconv.Itoa(dockerAPIPort)
-	cli, err := client.NewClient(containerEndpoint, dockerAPIVersion, nil, nil)
+	cli, err := client.NewClientWithOpts(
+		client.WithHost(containerEndpoint),
+		client.WithVersion(dockerAPIVersion),
+		client.WithHTTPClient(&http.Client{}))
 	if err != nil {
 		z.log.Errorf("getAppContainers: client create failed, error %v", err)
 		return nil, nil, err


### PR DESCRIPTION
From some version of the docker/client library the .NewClient() call was deprecated, which caused the following error:

  "getAppContainers: Container list error Cannot connect to the Docker daemon at tcp://$IP:2375. Is the docker daemon running?"

because by default the connectivity was established through the unix docker.sock socket.

This patch fixes the problem by passing the HTTP client to the constructor of the docker client.

The main motivation of this fix is the "Unknown" state of "Modules" visible on the UI of the controller, because statistics was never collected from the docker.

cc: @naiming-zededa 