### PR TITLE
handle realpath in makerootfs.sh sanely

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,18 +113,18 @@ Make sure that Docker is up and running on your system. On MacOS just start a do
 docker version
 ```
 
-#### Get system dependencies (git, make, qemu, jq, gnu-sed, coreutils)
+#### Get system dependencies (git, make, qemu, jq, gnu-sed)
 
 ##### On OSX (using [Brew](https://brew.sh/))
 
 ```sh
-$ brew install git make jq qemu gnu-sed coreutils
+$ brew install git make jq qemu gnu-sed
 ```
 
 > **_NOTE:_** (M1 Macs) `qemu` may also require `python3 nettle ninja` to install properly, that is:
 >
 > ```sh
-> $ brew install git make jq python3 nettle ninja qemu gnu-sed coreutils
+> $ brew install git make jq python3 nettle ninja qemu gnu-sed
 > ```
 
 ##### On Ubuntu Linux


### PR DESCRIPTION
We use `realpath` in `makerootfs.sh` to find the absolute path to various elements. Unfortunately, that has two shortcomings:

1. `realpath` is not available on all systems, mainly some Mac
2. even where `realpath` is available, we run it against a filename that may not yet exist. Some systems will resolve it, but others will error out.

This updates `makerootfs.sh` to handle those cases sanely. Instead of `realpath` the target _file_, we `realpath` the parent _directory_.

If `realpath` does not exist, we fall back to `cd $parent && pwd -P`, which gives the same result.
