### PR TITLE
[9.4 stable] zedrouter/appcontainer: fix connectivity to the VM docker

### DIFF
--- a/pkg/pillar/cmd/zedrouter/appcontainer.go
+++ b/pkg/pillar/cmd/zedrouter/appcontainer.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"io"
 	"net"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -324,7 +325,10 @@ func getAppContainerLogs(ctx *zedrouterContext, status types.AppNetworkStatus, l
 
 func getAppContainers(status types.AppNetworkStatus) (*client.Client, []apitypes.Container, error) {
 	containerEndpoint := "tcp://" + status.GetStatsIPAddr.String() + ":" + strconv.Itoa(DOCKERAPIPORT)
-	cli, err := client.NewClient(containerEndpoint, DOCKERAPIVERSION, nil, nil)
+	cli, err := client.NewClientWithOpts(
+		client.WithHost(containerEndpoint),
+		client.WithVersion(DOCKERAPIVERSION),
+		client.WithHTTPClient(&http.Client{}))
 	if err != nil {
 		log.Errorf("getAppContainers: client create failed, error %v", err)
 		return nil, nil, err


### PR DESCRIPTION
From some version of the docker/client library the .NewClient() call was deprecated, which caused the following error:

  "getAppContainers: Container list error Cannot connect to the Docker daemon at tcp://$IP:2375. Is the docker daemon running?"

because by default the connectivity was established through the unix docker.sock socket.

This patch fixes the problem by passing the HTTP client to the constructor of the docker client.

The main motiviation of this fix is the "Unknown" state of "Modules" visible on the UI of the controller, because statistics was never collected from the docker.