### PR TITLE
Add apparmor profile for vtpm service

### DIFF
--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -43,12 +43,12 @@ onboot:
   - name: pillar-onboot
     image: PILLAR_TAG
     command: ["/opt/zededa/bin/onboot.sh"]
+  - name: apparmor
+    image: APPARMOR_TAG
   # measure-config must be executed after any other container that changes 
   # /config. Let's keep it the latest
   - name: measure-config
     image: MEASURE_CONFIG_TAG
-  - name: apparmor
-    image: APPARMOR_TAG
 services:
   - name: newlogd
     image: NEWLOGD_TAG

--- a/pkg/apparmor/Dockerfile
+++ b/pkg/apparmor/Dockerfile
@@ -16,12 +16,12 @@ WORKDIR /apparmor/parser
 RUN ../common/list_af_names.sh > base_af_names.h && \
     make
 
-
 #Pull a selected set of artifacts into the final stage.
 FROM scratch
 COPY --from=build /out/ /
 COPY --from=build /apparmor/parser/apparmor_parser /usr/bin/
 COPY /etc/ /etc
+COPY /profiles/* /etc/apparmor.d
 COPY aa-init.sh /
 
 WORKDIR /

--- a/pkg/apparmor/etc/apparmor.d/abstractions/base
+++ b/pkg/apparmor/etc/apparmor.d/abstractions/base
@@ -62,24 +62,24 @@
   @{etc_ro}/ld.so.conf                r,
   @{etc_ro}/ld.so.conf.d/{,*.conf}    r,
   @{etc_ro}/ld.so.preload             r,
-  /{usr/,}lib{,32,64}/ld{,32,64}-*.so   mr,
-  /{usr/,}lib/@{multiarch}/ld{,32,64}-*.so    mr,
-  /{usr/,}lib/tls/i686/{cmov,nosegneg}/ld-*.so     mr,
-  /{usr/,}lib/i386-linux-gnu/tls/i686/{cmov,nosegneg}/ld-*.so     mr,
+  /{usr/,usr/local/}lib{,32,64}/ld{,32,64}-*.so   mr,
+  /{usr/,usr/local/}lib/@{multiarch}/ld{,32,64}-*.so    mr,
+  /{usr/,usr/local/}lib/tls/i686/{cmov,nosegneg}/ld-*.so     mr,
+  /{usr/,usr/local/}lib/i386-linux-gnu/tls/i686/{cmov,nosegneg}/ld-*.so     mr,
   /opt/*-linux-uclibc/lib/ld-uClibc*so* mr,
 
   # we might as well allow everything to use common libraries
-  /{usr/,}lib{,32,64}/**                r,
-  /{usr/,}lib{,32,64}/**.so*       mr,
-  /{usr/,}lib/@{multiarch}/**            r,
-  /{usr/,}lib/@{multiarch}/**.so*   mr,
-  /{usr/,}lib/tls/i686/{cmov,nosegneg}/*.so*    mr,
-  /{usr/,}lib/i386-linux-gnu/tls/i686/{cmov,nosegneg}/*.so*    mr,
+  /{usr/,usr/local/}lib{,32,64}/**                r,
+  /{usr/,usr/local/}lib{,32,64}/**.so*       mr,
+  /{usr/,usr/local/}lib/@{multiarch}/**            r,
+  /{usr/,usr/local/}lib/@{multiarch}/**.so*   mr,
+  /{usr/,usr/local/}lib/tls/i686/{cmov,nosegneg}/*.so*    mr,
+  /{usr/,usr/local/}lib/i386-linux-gnu/tls/i686/{cmov,nosegneg}/*.so*    mr,
 
   # FIPS-140-2 versions of some crypto libraries need to access their
   # associated integrity verification file, or they will abort.
-  /{usr/,}lib{,32,64}/.lib*.so*.hmac      r,
-  /{usr/,}lib/@{multiarch}/.lib*.so*.hmac r,
+  /{usr/,usr/local/}lib{,32,64}/.lib*.so*.hmac      r,
+  /{usr/,usr/local/}lib/@{multiarch}/.lib*.so*.hmac r,
 
   # /dev/null is pretty harmless and frequently used
   /dev/null                      rw,

--- a/pkg/apparmor/profiles/usr.bin.tpm2
+++ b/pkg/apparmor/profiles/usr.bin.tpm2
@@ -1,0 +1,17 @@
+# Copyright (c) 2023 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+#include <tunables/global>
+
+@{exec_path} = /usr/bin/tpm2
+profile tpm2 @{exec_path} {
+    #include <abstractions/base>
+
+    # alow necessary access for operations
+    /usr/bin/tpm2           rm,
+    /jail/{,*,**}           rw,
+
+    # alow access to tpm device
+    /dev/tpm0               rw,
+    /dev/tpmrm0             rw,
+}

--- a/pkg/apparmor/profiles/usr.bin.tpm2
+++ b/pkg/apparmor/profiles/usr.bin.tpm2
@@ -7,11 +7,11 @@
 profile tpm2 @{exec_path} {
     #include <abstractions/base>
 
-    # alow necessary access for operations
+    # allow necessary access for operations
     /usr/bin/tpm2           rm,
     /jail/{,*,**}           rw,
 
-    # alow access to tpm device
+    # allow access to tpm device
     /dev/tpm0               rw,
     /dev/tpmrm0             rw,
 }

--- a/pkg/apparmor/profiles/usr.bin.vtpm
+++ b/pkg/apparmor/profiles/usr.bin.vtpm
@@ -7,7 +7,7 @@
 profile vtpm @{exec_path} {
     #include <abstractions/base>
 
-    # alow necessary access for operations
+    # allow necessary access for operations
     /jail/{,*,**}    rw,
     /usr/bin/tpm2   rPx,
     network inet stream,

--- a/pkg/apparmor/profiles/usr.bin.vtpm
+++ b/pkg/apparmor/profiles/usr.bin.vtpm
@@ -1,0 +1,14 @@
+# Copyright (c) 2023 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+#include <tunables/global>
+
+@{exec_path} = /usr/bin/vtpm_server
+profile vtpm @{exec_path} {
+    #include <abstractions/base>
+
+    # alow necessary access for operations
+    /jail/{,*,**}    rw,
+    /usr/bin/tpm2   rPx,
+    network inet stream,
+}

--- a/pkg/vtpm/build.yml
+++ b/pkg/vtpm/build.yml
@@ -5,8 +5,6 @@ config:
     - /dev:/dev
     - /run:/run
     - /config:/config
-  capabilities:
-    - all
   devices:
     - path: all
       type: a


### PR DESCRIPTION
This commit amongst other minor changes, mainly adds apparmor profile for vtpm service and consequently tpm2-tools used by vtpm service.

Confined (sandboxed) vtpm service passed tests from [azure-on-eve](https://github.com/shjala/eve-tools/tree/master/azure-on-eve/tests) and [eve-tools](https://github.com/shjala/eve-tools/tree/master/eve-tools/examples).