### PR TITLE
Bump rootfs part size to 512MB

### DIFF
--- a/pkg/mkimage-raw-efi/make-raw
+++ b/pkg/mkimage-raw-efi/make-raw
@@ -73,7 +73,7 @@ PERSIST_UUID=ad6871ee-31f9-4cf3-9e09-6f7a25c30059
 # EFI partition size in bytes
 EFI_PART_SIZE=$((36 * 1024 * 1024))
 # rootfs partition size in bytes
-ROOTFS_PART_SIZE=$(( 300 * 1024 * 1024 ))
+ROOTFS_PART_SIZE=$(( 512 * 1024 * 1024 ))
 # conf partition size in bytes
 CONF_PART_SIZE=$((1024 * 1024))
 # installer inventory partition size in bytes


### PR DESCRIPTION
There are flavors of eve like kubevirt, SUSE etc where the rootfs size could be more than current 300MB limit. Bumping it to 512MB.

All new installs of EVE will get 512MB part size.


Testing:
=======

Installed and verified that eve_install_disk has 512MB partitions

nvme0n1     259:0    0 465.8G  0 disk 
├─nvme0n1p1 259:1    0    36M  0 part 
├─nvme0n1p2 259:2    0   512M  0 part /usr/bin/runc
│                                     /usr/bin/logread
│                                     /usr/bin/ctr
│                                     /hostroot/etc
│                                     /hostfs/containers/services/debug/rootfs/etc/profile.d
│                                     /hostfs/containers/services/debug/rootfs/etc/profile
│                                     /hostfs/containers/services/debug/rootfs/etc/motd
│                                     /hostfs/containers/services/debug/rootfs/containers/services/debug/rootfs/bin/eve
│                                     /hostfs/containers/services/debug/rootfs/containers
│                                     /hostfs/containers/services/debug/rootfs/bin/eve
│                                     /hostfs
│                                     /etc/profile.d
│                                     /etc/profile
│                                     /etc/motd
│                                     /containers/services/debug/rootfs/bin/eve
│                                     /containers
│                                     /bin/eve
├─nvme0n1p3 259:3    0   512M  0 part 
└─nvme0n1p4 259:4    0     1M  0 part 
