### PR TITLE
vtpm : remove net from build yaml

### DIFF
--- a/pkg/vtpm/build.yml
+++ b/pkg/vtpm/build.yml
@@ -5,7 +5,6 @@ config:
     - /dev:/dev
     - /run:/run
     - /config:/config
-  net: host
   capabilities:
     - all
   devices:


### PR DESCRIPTION
This build uses ADD instruction, so seems there is no need for net access, build succeeds without net access.