### PR TITLE
updated go sources which can read ldflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -311,7 +311,7 @@ DOCKERFILE_ADD_SCANNER_SOURCE=./tools/dockerfile-add-scanner
 
 # for the go build sources
 GOSOURCES=$(BUILDTOOLS_BIN)/go-sources-and-licenses
-GOSOURCES_VERSION=35a4cc0e0a12f91ef11278eb0ce22f02fe9c96f6
+GOSOURCES_VERSION=668fbc58b7b48e0202e106c45c2caaf9f5be189f
 GOSOURCES_SOURCE=github.com/deitch/go-sources-and-licenses
 
 


### PR DESCRIPTION
A problem with go binaries is that when built with `go build`, they do not include their main module information, e.g.:

```
/tmp/fscrypt: go1.18.6
	path	github.com/google/fscrypt/cmd/fscrypt
	mod	github.com/google/fscrypt	(devel)
	dep	github.com/golang/protobuf	v1.2.0	h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
	dep	github.com/pkg/errors	v0.8.0	h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
	dep	github.com/urfave/cli	v1.20.0	h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
	dep	golang.org/x/crypto	v0.0.0-20180820150726-614d502a4dac	h1:7d7lG9fHOLdL6jZPtnV4LpI41SbohIJ1Atq7U991dMg=
	dep	golang.org/x/sys	v0.0.0-20180828065106-d99a578cf41b	h1:cmOZLU2i7CLArKNViO+ZCQ47wqYFyKEIpbGWp+b6Uoc=
	build	-compiler=gc
	build	-ldflags="-s -w -X \"main.version=v0.2.4\" -X \"main.buildTime=Fri Dec 16 11:03:45 UTC 2022\" -extldflags \"\""
	build	CGO_ENABLED=1
	build	CGO_CFLAGS="-O2 -Wall"
	build	CGO_CPPFLAGS=
	build	CGO_CXXFLAGS=
	build	CGO_LDFLAGS=
	build	GOARCH=amd64
	build	GOOS=linux
	build	GOAMD64=v1
	build	vcs=git
	build	vcs.revision=b41569d397d3e66099cde07d8eef36b2f42dd0ec
	build	vcs.time=2019-07-28T02:24:19Z
	build	vcs.modified=true
```

See the `mod` line at the beginning above.

This is a core golang issue which we will not solve here. However, we have started in previous PRs to ensure that the ldflags include `-X main.Version=<version>`, which some utilities know how to read and interpret.

Those utilities include syft, and now, the utility that collects the go sources.

This PR updates our version of that utility to be able to read the `main.Version`.