### PR TITLE
pkg: grub: Replace echo command by true command

### DIFF
--- a/pkg/grub/Dockerfile
+++ b/pkg/grub/Dockerfile
@@ -24,7 +24,7 @@ RUN eve-alpine-deploy.sh
 # list of grub modules that are portable between x86_64 and aarch64
 ENV GRUB_MODULES_PORT="part_gpt fat ext2 iso9660 squash4 gzio linux acpi normal cpio crypto disk boot crc64 \
 search_disk_uuid search_part_label search_label xzio xfs video gfxterm serial gptprio chain probe reboot regexp smbios \
-part_msdos cat echo test configfile loopback"
+part_msdos cat echo test configfile loopback true"
 
 FROM grub-build-base AS grub-build-amd64
 ENV GRUB_MODULES="multiboot multiboot2 efi_uga efi_gop linuxefi gpt verify gcry_sha256 measurefs"

--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -327,7 +327,7 @@ function set_riscv64_qemu {
 }
 
 function set_kvm_boot {
-   set_global load_hv_cmd echo
+   set_global load_hv_cmd true
    set_global load_dom0_cmd linux
    set_global load_initrd_cmd initrd
    set_global dom0_flavor_tweaks "pcie_acs_override=downstream,multifunction"
@@ -350,7 +350,7 @@ function set_xen_boot {
 }
 
 function set_kubevirt_boot {
-   set_global load_hv_cmd echo
+   set_global load_hv_cmd true
    set_global load_dom0_cmd linux
    set_global load_initrd_cmd initrd
    set_global dom0_flavor_tweaks "pcie_acs_override=downstream,multifunction"


### PR DESCRIPTION
The load_hv_cmd variable present in EVE's GRUB config points to the command used to load a hypervisor. However, in case of "kvm" and "kubervirt" this command is not needed and it's just translated to an echo command. However, this approach will make messages like the following to appear during a KVM based boot:

`/boot/xen.gz console=com1 smt=false clocksource=pit dom0_mem=800M,max:800M dom0_max_vcpus=1 dom0_vcpus_pin`

This can lead to misunderstandings and confusion since a Xen's boot command line it's being printed on a KVM's system.

This commit replaces echo by true command. The true command can receive any number of arguments and will always return true without any printing, so no Xen's boot command line will be printed in "kvm" or "kubevirt" cases.