### PR TITLE
include gopkgversion in rngd as well

### DIFF
--- a/pkg/rngd/Dockerfile
+++ b/pkg/rngd/Dockerfile
@@ -6,9 +6,10 @@ ENV GOPATH=/go PATH=$PATH:/go/bin
 
 # see https://github.com/golang/go/issues/23672
 ENV CGO_CFLAGS_ALLOW=(-mrdrnd|-mrdseed)
+ARG GOPKGVERSION
 
 COPY cmd/rngd/ /go/src/rngd/
-RUN GO111MODULE=auto REQUIRE_CGO=1 go-compile.sh /go/src/rngd
+RUN GO111MODULE=auto REQUIRE_CGO=1 ldflags="-X main.Version=${GOPKGVERSION}" go-compile.sh /go/src/rngd
 
 FROM scratch
 ENTRYPOINT []


### PR DESCRIPTION
The same way we include it in measure-config and edgeview and pillar etc., include it in rngd (I missed it on the previous PR).