### PR TITLE
set ARG for newlog GOPKGVERSION

### DIFF
--- a/pkg/newlog/Dockerfile
+++ b/pkg/newlog/Dockerfile
@@ -5,6 +5,7 @@ RUN eve-alpine-deploy.sh
 
 COPY ./  /newlog/.
 WORKDIR /newlog
+ARG GOPKGVERSION
 
 RUN GO111MODULE=on CGO_ENABLED=0 go build -ldflags "-s -w -X=main.Version=${GOPKGVERSION}" -mod=vendor -o /out/usr/bin/newlogd ./cmd
 


### PR DESCRIPTION
We passed `GOPKGVERSION` to the `go build`, but never actually set it as an `ARG` like we do in others, so it never inherited it; this fixes it.