### PR TITLE
bump linuxkit to version that includes index auth scope fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,7 @@ DOCKER_GO = _() { $(SET_X); mkdir -p $(CURDIR)/.go/src/$${3:-dummy} ; mkdir -p $
 
 PARSE_PKGS=$(if $(strip $(EVE_HASH)),EVE_HASH=)$(EVE_HASH) DOCKER_ARCH_TAG=$(DOCKER_ARCH_TAG) ./tools/parse-pkgs.sh
 LINUXKIT=$(BUILDTOOLS_BIN)/linuxkit
-LINUXKIT_VERSION=655c7fb80712e6fd62b84ca2f03607501408dba7
+LINUXKIT_VERSION=7164b2c04d40eb276cee6e16c7fa617fe6840a17
 LINUXKIT_SOURCE=https://github.com/linuxkit/linuxkit.git
 LINUXKIT_OPTS=$(if $(strip $(EVE_HASH)),--hash) $(EVE_HASH) $(if $(strip $(EVE_REL)),--release) $(EVE_REL)
 LINUXKIT_PKG_TARGET=build


### PR DESCRIPTION
The last few weeks, I have seen issues with latest linuxkit where it tries to update the index and fails.

Either way, I fixed this in linuxkit with the commit referenced herein.

I didn't pull it into eve immediately, as I was not sure it would be an issue. @yash-zededa found this to be an issue with eve, so pulling in the fix.