### PR TITLE
Snapshot: Survive evolving of a rolled back VM, and minor refactorings.

### DIFF
--- a/pkg/pillar/cmd/volumemgr/handlevolume.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume.go
@@ -104,7 +104,8 @@ func handleDeferredVolumeCreate(ctx *volumemgrContext, key string, config *types
 	log.Tracef("handleDeferredVolumeCreate(%s)", key)
 	status := ctx.LookupVolumeStatus(config.Key())
 	if status != nil {
-		log.Fatalf("status exists at handleVolumeCreate for %s", config.Key())
+		log.Warnf("status exists at handleVolumeCreate for %s", config.Key())
+		return
 	}
 	status = &types.VolumeStatus{
 		VolumeID:                config.VolumeID,

--- a/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
+++ b/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
@@ -405,6 +405,18 @@ func restoreConfigFromSnapshot(ctx *zedmanagerContext, appInstanceStatus *types.
 	if snappedAppInstanceConfig == nil {
 		return nil, fmt.Errorf("failed to read AppInstanceConfig from file for %s", snapshotID)
 	}
+	config, err := addFixupsIntoSnappedConfig(ctx, appInstanceStatus, snappedAppInstanceConfig)
+	if err != nil {
+		return config, err
+	}
+	return snappedAppInstanceConfig, nil
+}
+
+// addFixupsIntoSnappedConfig adds the fixups into the snapped app instance config.
+// The fixups are the information that should be taken from the current app instance config, not from the snapshot.
+// The fixups should correspond to the fixups done on the controller side. A function name, where it's done maybe
+// something like: applyAppInstanceFromSnapshot.
+func addFixupsIntoSnappedConfig(ctx *zedmanagerContext, appInstanceStatus *types.AppInstanceStatus, snappedAppInstanceConfig *types.AppInstanceConfig) (*types.AppInstanceConfig, error) {
 	// Get the app instance config from the app instance status
 	currentAppInstanceConfig := lookupAppInstanceConfig(ctx, appInstanceStatus.Key())
 	if currentAppInstanceConfig == nil {

--- a/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
+++ b/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
@@ -401,7 +401,7 @@ func restoreConfigFromSnapshot(ctx *zedmanagerContext, appInstanceStatus *types.
 		return nil, fmt.Errorf("SnapshotInstanceStatus not found for %s", snapshotID)
 	}
 	// Get the app instance config from the snapshot
-	snappedAppInstanceConfig := deserializeConfigFromSnapshot(snapshotStatus)
+	snappedAppInstanceConfig := deserializeConfigFromSnapshot(snapshotStatus.Snapshot.SnapshotID)
 	if snappedAppInstanceConfig == nil {
 		return nil, fmt.Errorf("failed to read AppInstanceConfig from file for %s", snapshotID)
 	}
@@ -434,9 +434,9 @@ func addFixupsIntoSnappedConfig(ctx *zedmanagerContext, appInstanceStatus *types
 }
 
 // deserializeConfigFromSnapshot deserializes the config from a file
-func deserializeConfigFromSnapshot(status *types.SnapshotInstanceStatus) *types.AppInstanceConfig {
+func deserializeConfigFromSnapshot(snapshotID string) *types.AppInstanceConfig {
 	log.Noticef("deserializeConfigFromSnapshot")
-	dirname := getSnapshotDir(status.Snapshot.SnapshotID)
+	dirname := getSnapshotDir(snapshotID)
 	filename := path.Join(dirname, types.SnapshotConfigFilename)
 	var appInstanceConfig types.AppInstanceConfig
 	configFile, err := os.Open(filename)

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -64,6 +64,10 @@ func removeAIStatus(ctx *zedmanagerContext, status *types.AppInstanceStatus) {
 	if !uninstall && domainStatus != nil && !domainStatus.Activated {
 		// We should do it before the doRemove is called, so that all the volumes are still available.
 		if status.SnapStatus.SnapshotOnUpgrade && len(status.SnapStatus.PreparedVolumesSnapshotConfigs) > 0 {
+			// Check whether there are snapshots to be deleted first (not to exceed the maximum number of snapshots).
+			if len(status.SnapStatus.SnapshotsToBeDeleted) > 0 {
+				triggerSnapshotDeletion(status.SnapStatus.SnapshotsToBeDeleted, ctx, status)
+			}
 			triggerSnapshots(ctx, status)
 		}
 	}

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sort"
 	"time"
@@ -874,7 +873,7 @@ func serializeVolumeRefStatusToSnapshot(status *types.VolumeRefStatus, snapshotI
 		return err
 	}
 	// Create the file for storing the volume ref status
-	err = ioutil.WriteFile(filename, statusAsBytes, 0644)
+	err = os.WriteFile(filename, statusAsBytes, 0644)
 	if err != nil {
 		log.Errorf("Failed to write the volume ref status for %s, error: %s", status.VolumeID, err)
 		return err
@@ -931,7 +930,7 @@ func serializeConfigToSnapshot(config types.AppInstanceConfig, snapshotID string
 		return err
 	}
 	configFile := fmt.Sprintf("%s/%s", snapshotDir, types.SnapshotConfigFilename)
-	err = ioutil.WriteFile(configFile, configAsBytes, 0644)
+	err = os.WriteFile(configFile, configAsBytes, 0644)
 	if err != nil {
 		log.Errorf("Failed to write the old config for %s, error: %s", config.DisplayName, err)
 		return err


### PR DESCRIPTION
This PR includes a series of changes to improve the robustness and modularity of the snapshot rollback process in the pillar service. It addresses issues with pre-existing Volume Status and introduces a more flexible way of restoring snapshot data structures. It also ensures alignment with Go's newer file-writing idioms and deals with excess snapshots during an application restart.

Details of the changes are as follows:

Preventing fatal errors for pre-existing Volume Status
An enhancement to the snapshot rollback process has been made. In scenarios where the controller dispatches a new config with a rolled-back volume, the pre-existence of a volume status no longer triggers a fatal error. Instead, it triggers a warning, resulting in an early return from the function.

Passing SnapshotID directly to deserializeConfigFromSnapshot
The function deserializeConfigFromSnapshot has been modified to directly accept a SnapshotID string as an argument instead of the whole SnapshotInstanceStatus object. This allows the function to be used in scenarios where the full Status object is unavailable, but the SnapshotID is known.

Replacing ioutil.WriteFile with os.WriteFile
The deprecated ioutil.WriteFile function calls have been replaced with os.WriteFile in two functions (serializeVolumeRefStatusToSnapshot and serializeConfigToSnapshot). This aligns the code with Go's newer file writing idioms and removes the unnecessary import of the ioutil package.

Handling excess snapshots during application restart
The system now checks for snapshots marked for deletion before creating a new one and triggers their deletion. This keeps the snapshot list from exceeding the set limit and ensures accurate snapshot data is reported to the cloud.

Enhancing modularity of snapshot data structure restoration
Changes have been made to facilitate more modular handling of snapshots and to prepare for future additions of restore functions. This includes introducing a new function, adding addFixupsIntoSnappedConfig, and refactoring the triggerRollback function.