### PR TITLE
Handle missing default machine type in qemu-system-aarch64 on Apple M2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,9 +213,13 @@ ACCEL=1
 else
 ACCEL=
 endif
+ifeq ($(UNAME_S)_$(ZARCH),Darwin_arm64)
+QEMU_DEFAULT_MACHINE=virt,
+endif
 QEMU_ACCEL_Y_Darwin_amd64=-machine q35,accel=hvf,usb=off -cpu kvm64,kvmclock=off
 QEMU_ACCEL_Y_Linux_amd64=-machine q35,accel=kvm,usb=off,dump-guest-core=off -cpu host,invtsc=on,kvmclock=off -machine kernel-irqchip=split -device intel-iommu,intremap=on,caching-mode=on,aw-bits=48
 # -machine virt,gic_version=3
+QEMU_ACCEL_Y_Darwin_arm64=-machine $(QEMU_DEFAULT_MACHINE)accel=hvf,usb=off -cpu host
 QEMU_ACCEL_Y_Linux_arm64=-machine virt,accel=kvm,usb=off,dump-guest-core=off -cpu host
 QEMU_ACCEL__$(UNAME_S)_arm64=-machine virt,virtualization=true -cpu cortex-a57
 QEMU_ACCEL__$(UNAME_S)_amd64=-machine q35 -cpu SandyBridge
@@ -440,7 +444,7 @@ $(DEVICETREE_DTB): $(BIOS_IMG) | $(DIST)
 	mkdir $(dir $@) 2>/dev/null || :
 	# start swtpm to generate dtb
 	$(MAKE) $(SWTPM)
-	$(QEMU_SYSTEM) $(QEMU_OPTS) -machine dumpdtb=$@
+	$(QEMU_SYSTEM) $(QEMU_OPTS) -machine $(QEMU_DEFAULT_MACHINE)dumpdtb=$@
 	$(QUIET): $@: Succeeded
 
 $(EFI_PART): PKG=grub


### PR DESCRIPTION
Currently build of master on MacOS Apple M2 errors out in two calls to qemu-system-aarch64.  This change resolves these errors and allows running "make run-live".

`qemu-system-aarch64: No machine specified, and there is no default`