### PR TITLE
fix in memlogd to exit cleanly; containerd binaries with proper go version info

### DIFF
--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -2,12 +2,12 @@ kernel:
   image: KERNEL_TAG
   cmdline: "rootdelay=3"
 init:
-  - linuxkit/init:6542ad0457ac153861870bfe2d036b6647cdc69f
+  - linuxkit/init:144c9cee8aed9e30a16940f2bf1d3813883aceda
   - linuxkit/runc:d971bd4ffcfc92fec49d1b46757a2a1bb98d1a65
-  - linuxkit/containerd:682d2a1f63b31cc76f1fb8ae59f6e54b0932e182
+  - linuxkit/containerd:d445de33c7f08470187b068d247b1c0dea240f0a
   # pillar's logic rely on existence of getty and /etc/init.d/001-getty inside
   - linuxkit/getty:06f34bce0facea79161566d67345c3ea49965437
-  - linuxkit/memlogd:cf7ea20e6b68aacaa888aa178f267dcad602ed05
+  - linuxkit/memlogd:9a1bb29abca6d739f4b22c3e637faf1898e14184
   - DOM0ZTOOLS_TAG
   - GRUB_TAG
   - FW_TAG


### PR DESCRIPTION
Updates several upstream linuxkit packages:

* `memlogd` - with the fix to prevent `logread` from exiting with a `panic` when EOF, instead of an `exit 0`
* `init` and `containerd` - build with proper go module version info

These should not change functionality, although containerd minor version is bumped, so worth a proper eden test run.

It eliminates more of the `(devel)` versions in the sbom and missing info in the source. When this is done, the list of packages missing from source is:

```
Packages in SPDX file but not in CSV file:
golang:github.com/lf-edge/eve/pkg/measure-config@v0.0.0-20230612095446-3208e0b2991b
golang:github.com/lf-edge/eve/pkg/rngd@v0.0.0-20230618123711-10f164f563fb
golang:github.com/opencontainers/runc@(devel)
```

The `runc` is an open issue because of the build using `-trimpath`, which we cannot get around easily. It will have to remain an open issue for now. The other two are due to the proxy not having it.

The proxy itself and `pkg.go.dev` look like they have not been updated for `rngd` since Dec 16, 2021, [v7.4.0-master-private+incompatible](https://pkg.go.dev/github.com/lf-edge/eve@v7.4.0-master-private+incompatible/pkg/rngd), even as other sub modules (pillar, api/go, etc.) have. It is worth figuring out why.
In the meantime, `measure-config` is more up to date. 

Either way, these are good fixes.