### PR TITLE
hypervisor/kvm: Fix serial device access for ARM

### DIFF
--- a/pkg/pillar/hypervisor/kvm_test.go
+++ b/pkg/pillar/hypervisor/kvm_test.go
@@ -845,11 +845,11 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
   addr = "0x0"
 
 [chardev "charserial-usr0"]
-  backend = "tty"
+  backend = "serial"
   path = "/dev/ttyS0"
 
 [device "serial-usr0"]
-  driver = "isa-serial"
+  driver = "pci-serial"
   chardev = "charserial-usr0"
 ` {
 			t.Errorf("got an unexpected resulting config %s", string(result))
@@ -2111,11 +2111,11 @@ func TestCreateDomConfig(t *testing.T) {
   bus = "pci.10"
   addr = "0x0"
 [chardev "charserial-usr0"]
-  backend = "tty"
+  backend = "serial"
   path = "/dev/ttyS0"
 
 [device "serial-usr0"]
-  driver = "isa-serial"
+  driver = "pci-serial"
   chardev = "charserial-usr0"
 
 [device]


### PR DESCRIPTION
The QEMU's virt machine model (ARM64) doesn't support isa-serial emulation, so guests cannot access serial devices of the host. This commit fixes this issue changing emulation to pci-serial only for the virt machine model.

Error message from the logs:

```
2023-06-23T10:02:45Z,guest_vm_err-a9fcef42-11d9-4ce9-9a7b-5ead87abd6ad.1.1;qemu-system-aarch64:/run/domainmgr/xen/xen1.cfg:145: 'isa-serial' is not a valid device model name
```