### PR TITLE
Snapshot: Rollback after restart.

### DIFF
--- a/pkg/pillar/cmd/volumemgr/handlesnapshot.go
+++ b/pkg/pillar/cmd/volumemgr/handlesnapshot.go
@@ -11,7 +11,6 @@ import (
 	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 	"github.com/lf-edge/eve/pkg/pillar/volumehandlers"
 	"os"
-	"reflect"
 )
 
 func createSnapshot(ctx *volumemgrContext, config *types.VolumesSnapshotConfig) *types.VolumesSnapshotStatus {
@@ -98,12 +97,12 @@ func deserializeVolumesSnapshotStatus(snapshotID string) (*types.VolumesSnapshot
 	// Get the filename for the snapshot status
 	volumesSnapshotStatusFilename := types.GetVolumesSnapshotStatusFile(snapshotID)
 
-	deserializedStruct, err := utils.DeserializeToStruct(volumesSnapshotStatusFilename, reflect.TypeOf(types.VolumesSnapshotStatus{}), types.VolumesSnapshotStatusCriticalFields)
+	volumesSnapshotStatus := new(types.VolumesSnapshotStatus)
+	err := utils.DeserializeToStruct(volumesSnapshotStatusFilename, volumesSnapshotStatus)
 	if err != nil {
 		log.Errorf("deserializeVolumesSnapshotStatus: failed to deserialize snapshot status for %s, %s", snapshotID, err.Error())
 		return nil, fmt.Errorf("failed to deserialize snapshot status for %s, %s", snapshotID, err.Error())
 	}
-	volumesSnapshotStatus := deserializedStruct.(*types.VolumesSnapshotStatus)
 
 	return volumesSnapshotStatus, nil
 

--- a/pkg/pillar/cmd/volumemgr/handlesnapshot.go
+++ b/pkg/pillar/cmd/volumemgr/handlesnapshot.go
@@ -4,206 +4,286 @@
 package volumemgr
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"os"
+	"reflect"
+
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/lf-edge/eve/pkg/pillar/utils"
+	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 	"github.com/lf-edge/eve/pkg/pillar/volumehandlers"
-	"time"
 )
 
-func handleVolumesSnapshotCreate(ctxArg interface{}, key string, configArg interface{}) {
-	ctx := ctxArg.(*volumemgrContext)
-	config := configArg.(types.VolumesSnapshotConfig)
-	log.Noticef("handleVolumesSnapshotCreate(%s) handles %s", key, config.Action)
-	// Check if snapshot snapshotStatus already exists, or it's a new snapshot request
-	snapshotStatus := lookupVolumesSnapshotStatus(ctx, config.SnapshotID)
-	if snapshotStatus != nil {
-		log.Errorf("Snapshot %s already exists", config.SnapshotID)
-		return
+func createSnapshot(ctx *volumemgrContext, config *types.VolumesSnapshotConfig) *types.VolumesSnapshotStatus {
+	// Check if snapshot volumesSnapshotStatus already exists, or it's a new snapshot request
+	volumesSnapshotStatus := lookupVolumesSnapshotStatus(ctx, config.SnapshotID)
+	if volumesSnapshotStatus != nil {
+		warnMsg := fmt.Sprintf("Snapshot %s already exists", config.SnapshotID)
+		log.Warn(warnMsg)
+		errDesc := types.ErrorDescription{}
+		errDesc.Error = warnMsg
+		errDesc.ErrorSeverity = types.ErrorSeverityWarning
+		volumesSnapshotStatus.SetErrorWithSourceAndDescription(errDesc, types.VolumesSnapshotStatus{})
+		return volumesSnapshotStatus
 	}
-	// Create a new snapshotStatus
-	snapshotStatus = &types.VolumesSnapshotStatus{
+	// Create a new volumesSnapshotStatus
+	volumesSnapshotStatus = &types.VolumesSnapshotStatus{
 		SnapshotID:         config.SnapshotID,
 		VolumeSnapshotMeta: make(map[string]interface{}, len(config.VolumeIDs)),
 		AppUUID:            config.AppUUID,
-		// Save the config UUID and version, so it can be reported later to the controller during the rollback
-	}
-	if config.Action != types.VolumesSnapshotCreate {
-		errDesc := types.ErrorDescription{}
-		errDesc.Error = fmt.Sprintf("handleVolumesSnapshotCreate: unexpected action %s", config.Action)
-		log.Error(errDesc.Error)
-		snapshotStatus.SetErrorWithSourceAndDescription(errDesc, types.VolumesSnapshotStatus{})
-		publishVolumesSnapshotStatus(ctx, snapshotStatus)
-		return
 	}
 	// Find the corresponding volume status
 	for _, volumeID := range config.VolumeIDs {
 		volumeStatus := ctx.lookupVolumeStatusByUUID(volumeID.String())
 		if volumeStatus == nil {
 			errDesc := types.ErrorDescription{}
-			errDesc.Error = fmt.Sprintf("handleVolumesSnapshotCreate: volume %s not found", volumeID.String())
+			errDesc.Error = fmt.Sprintf("createSnapshot: volume %s not found", volumeID.String())
 			log.Errorf(errDesc.Error)
-			snapshotStatus.SetErrorWithSourceAndDescription(errDesc, types.VolumesSnapshotStatus{})
-			publishVolumesSnapshotStatus(ctx, snapshotStatus)
-			return
+			volumesSnapshotStatus.SetErrorWithSourceAndDescription(errDesc, types.VolumesSnapshotStatus{})
+			return volumesSnapshotStatus
 		}
-		log.Noticef("handleVolumesSnapshotCreate: volume %s file found %s", volumeID.String(), volumeStatus.FileLocation)
-		snapshotMeta, timeCreated, err := createVolumeSnapshot(ctx, volumeStatus)
+		volumeHandler := volumehandlers.GetVolumeHandler(log, ctx, volumeStatus)
+		snapshotMeta, timeCreated, err := volumeHandler.CreateSnapshot()
 		if err != nil {
 			errDesc := types.ErrorDescription{}
-			errDesc.Error = fmt.Sprintf("handleVolumesSnapshotCreate: failed to create snapshot for %s, %s", volumeID.String(), err.Error())
+			errDesc.Error = fmt.Sprintf("createSnapshot: failed to create snapshot for %s, %s", volumeID.String(), err.Error())
 			log.Errorf(errDesc.Error)
-			snapshotStatus.SetErrorWithSourceAndDescription(errDesc, types.VolumesSnapshotStatus{})
-			publishVolumesSnapshotStatus(ctx, snapshotStatus)
-			return
+			volumesSnapshotStatus.SetErrorWithSourceAndDescription(errDesc, types.VolumesSnapshotStatus{})
+			return volumesSnapshotStatus
 		}
 		// Save the snapshot metadata (for example, snapshot file location), so later it can be used for rollback
-		snapshotStatus.VolumeSnapshotMeta[volumeID.String()] = snapshotMeta
+		volumesSnapshotStatus.VolumeSnapshotMeta[volumeID.String()] = snapshotMeta
 		// Save the time when the snapshot was created
-		snapshotStatus.TimeCreated = timeCreated
+		volumesSnapshotStatus.TimeCreated = timeCreated
 	}
-	log.Noticef("handleVolumesSnapshotCreate: successfully created snapshot %s", config.SnapshotID)
-	publishVolumesSnapshotStatus(ctx, snapshotStatus)
-}
-
-func createVolumeSnapshot(ctx *volumemgrContext, volumeStatus *types.VolumeStatus) (interface{}, time.Time, error) {
-	volumeHandlers := volumehandlers.GetVolumeHandler(log, ctx, volumeStatus)
-	log.Noticef("createVolumeSnapshot: create snapshot for %s", volumeStatus.VolumeID.String())
-	snapshotMeta, timeCreated, err := volumeHandlers.CreateSnapshot()
+	err := serializeVolumesSnapshotStatus(config.SnapshotID, volumesSnapshotStatus)
 	if err != nil {
-		log.Errorf("createVolumeSnapshot: failed to create snapshot for %s, %s", volumeStatus.VolumeID.String(), err.Error())
-		return "", timeCreated, err
+		errDesc := types.ErrorDescription{}
+		errDesc.Error = fmt.Sprintf("handleVolumesSnapshotConfigCreate: failed to serialize snapshot status for %s, %s", config.SnapshotID, err.Error())
+		log.Errorf(errDesc.Error)
+		volumesSnapshotStatus.SetErrorWithSourceAndDescription(errDesc, types.VolumesSnapshotStatus{})
 	}
-	log.Noticef("createVolumeSnapshot: successfully created snapshot for %s", volumeStatus.VolumeID.String())
-	return snapshotMeta, timeCreated, nil
+	return volumesSnapshotStatus
 }
 
-func handleVolumesSnapshotModify(ctxArg interface{}, key string, configArg, _ interface{}) {
-	ctx := ctxArg.(*volumemgrContext)
-	config := configArg.(types.VolumesSnapshotConfig)
-	log.Functionf("handleVolumesSnapshotModify(%s) handles %s", key, config.Action)
+func serializeVolumesSnapshotStatus(snapshotID string, status *types.VolumesSnapshotStatus) error {
+	// check if the snapshot directory exists
+	snapshotDir := types.GetSnapshotDir(snapshotID)
+	if _, err := os.Stat(snapshotDir); os.IsNotExist(err) {
+		// Create the directory
+		err = os.MkdirAll(snapshotDir, 0755)
+		if err != nil {
+			log.Errorf("serializeVolumesSnapshotStatus: failed to create snapshot directory %s, %s", snapshotDir, err.Error())
+			return err
+		}
+	}
+	// marshal to JSON
+	statusAsBytes, err := json.Marshal(status)
+	if err != nil {
+		log.Errorf("serializeVolumesSnapshotStatus: failed to marshal snapshot status for %s, %s", snapshotID, err.Error())
+		return err
+	}
+	// Get the filename for the snapshot status
+	volumesSnapshotStatusFile := types.GetVolumesSnapshotStatusFile(snapshotID)
+	// Write the status to the file
+	err = fileutils.WriteRename(volumesSnapshotStatusFile, statusAsBytes)
+	if err != nil {
+		log.Errorf("serializeVolumesSnapshotStatus: failed to write snapshot status for %s, %s", snapshotID, err.Error())
+		return err
+	}
+	return nil
+}
+
+func deserializeVolumesSnapshotStatus(snapshotID string) (*types.VolumesSnapshotStatus, error) {
+	// Get the filename for the snapshot status
+	volumesSnapshotStatusFilename := types.GetVolumesSnapshotStatusFile(snapshotID)
+
+	// check if the volumesSnapshotStatusFile exists
+	if _, err := os.Stat(volumesSnapshotStatusFilename); os.IsNotExist(err) {
+		log.Errorf("deserializeVolumesSnapshotStatus: snapshot status file %s does not exist", volumesSnapshotStatusFilename)
+		return nil, err
+	}
+
+	// open the file
+	volumesSnapshotStatusFile, err := os.Open(volumesSnapshotStatusFilename)
+	if err != nil {
+		log.Errorf("deserializeVolumesSnapshotStatus: failed to open snapshot status file %s, %s", volumesSnapshotStatusFilename, err.Error())
+		return nil, err
+	}
+	defer volumesSnapshotStatusFile.Close()
+
+	// read the raw data
+	data, err := io.ReadAll(volumesSnapshotStatusFile)
+	if err != nil {
+		log.Errorf("deserializeVolumesSnapshotStatus: failed to read snapshot status for %s, %s", snapshotID, err.Error())
+		return nil, err
+	}
+
+	// read to an opaque map to check the fields
+	var dataMap map[string]interface{}
+	err = json.Unmarshal(data, &dataMap)
+	if err != nil {
+		log.Errorf("deserializeVolumesSnapshotStatus: failed to unmarshal snapshot status for %s, %s", snapshotID, err.Error())
+		return nil, err
+	}
+
+	// Automatically extract the field names from the struct using reflection.
+	var volumeSnapshotStatus types.VolumesSnapshotStatus
+	expectedFields := make(map[string]bool)
+	v := reflect.ValueOf(volumeSnapshotStatus)
+	typeOfVolumesSnapshotStatus := v.Type()
+	utils.ExtractFields(typeOfVolumesSnapshotStatus, &expectedFields)
+
+	// Check if there are any unexpected fields
+	for k := range dataMap {
+		if _, ok := expectedFields[k]; !ok {
+			// This is an unexpected field, make warning and ignore
+			log.Warnf("deserializeVolumesSnapshotStatus: unexpected field %s in stored volumes snapshot status for %s", k, snapshotID)
+		}
+	}
+
+	// Check if there are any missing fields
+	for k := range expectedFields {
+		if _, ok := dataMap[k]; !ok {
+			// This is a missing field, check if it is critical
+			if types.VolumesSnapshotStatusCriticalFields[k] {
+				// This is a missing critical field, return error
+				errMsg := fmt.Sprintf("deserializeVolumesSnapshotStatus: critical field %s missing in stored volumes snapshot status for %s", k, snapshotID)
+				log.Errorf(errMsg)
+				return nil, fmt.Errorf(errMsg)
+			}
+			// This is a missing non-critical field, make warning and ignore
+			log.Warnf("deserializeVolumesSnapshotStatus: missing field %s in stored volumes snapshot status for %s", k, snapshotID)
+		}
+	}
+
+	// All the checks passed, so it is safe to unmarshal the data into the struct
+
+	// Unmarshal from JSON
+	status := types.VolumesSnapshotStatus{}
+	err = json.Unmarshal(data, &status)
+	if err != nil {
+		log.Errorf("deserializeVolumesSnapshotStatus: failed to unmarshal snapshot status for %s, %s", snapshotID, err.Error())
+		return nil, err
+	}
+	log.Noticef("deserializeVolumesSnapshotStatus: successfully deserialized snapshot status for %s", snapshotID)
+	return &status, nil
+}
+
+func rollbackSnapshot(ctx *volumemgrContext, config *types.VolumesSnapshotConfig) *types.VolumesSnapshotStatus {
 	// Check if snapshot status already exists, or it's a new snapshot request
 	volumesSnapshotStatus := lookupVolumesSnapshotStatus(ctx, config.SnapshotID)
 	if volumesSnapshotStatus == nil {
 		// Create a new volumesSnapshotStatus to report an error
 		volumesSnapshotStatus = &types.VolumesSnapshotStatus{SnapshotID: config.SnapshotID}
 		errDesc := types.ErrorDescription{}
-		errDesc.Error = fmt.Sprintf("handleVolumesSnapshotModify: snapshot %s not found", key)
+		errDesc.Error = fmt.Sprintf("rollbackSnapshot: snapshot %s not found", config.SnapshotID)
 		log.Error(errDesc.Error)
 		volumesSnapshotStatus.SetErrorWithSourceAndDescription(errDesc, types.VolumesSnapshotStatus{})
-		publishVolumesSnapshotStatus(ctx, volumesSnapshotStatus)
-		return
-	}
-	if config.Action != types.VolumesSnapshotRollback {
-		errDesc := types.ErrorDescription{}
-		errDesc.Error = fmt.Sprintf("handleVolumesSnapshotModify: unexpected action %s", config.Action)
-		log.Error(errDesc.Error)
-		volumesSnapshotStatus.SetErrorWithSourceAndDescription(errDesc, types.VolumesSnapshotStatus{})
-		publishVolumesSnapshotStatus(ctx, volumesSnapshotStatus)
-		return
+		return volumesSnapshotStatus
 	}
 	for volumeID, snapMeta := range volumesSnapshotStatus.VolumeSnapshotMeta {
 		volumeStatus := ctx.lookupVolumeStatusByUUID(volumeID)
 		if volumeStatus == nil {
 			errDesc := types.ErrorDescription{}
-			errDesc.Error = fmt.Sprintf("handleVolumesSnapshotModify: volume %s not found", volumeID)
+			errDesc.Error = fmt.Sprintf("handleVolumesSnapshotConfigModify: volume %s not found", volumeID)
 			log.Error(errDesc.Error)
 			volumesSnapshotStatus.SetErrorWithSourceAndDescription(errDesc, types.VolumesSnapshotStatus{})
-			publishVolumesSnapshotStatus(ctx, volumesSnapshotStatus)
-			return
+			return volumesSnapshotStatus
 		}
 		volumeHandlers := volumehandlers.GetVolumeHandler(log, ctx, volumeStatus)
-		log.Noticef("handleVolumesSnapshotModify: rollback to snapshot %s for volume %s", config.SnapshotID, volumeID)
-		err := rollbackToSnapshot(volumeHandlers, snapMeta)
+		log.Noticef("handleVolumesSnapshotConfigModify: rollback to snapshot %s for volume %s", config.SnapshotID, volumeID)
+		err := volumeHandlers.RollbackToSnapshot(snapMeta)
 		if err != nil {
 			errDesc := types.ErrorDescription{}
 			errDesc.Error = fmt.Sprintf("Failed to rollback to snapshot %s for volume %s, %s", config.SnapshotID, volumeID, err.Error())
 			log.Error(errDesc.Error)
 			volumesSnapshotStatus.SetErrorWithSourceAndDescription(errDesc, types.VolumesSnapshotStatus{})
-			publishVolumesSnapshotStatus(ctx, volumesSnapshotStatus)
-			return
+			return volumesSnapshotStatus
 		}
-		log.Noticef("handleVolumesSnapshotModify: successfully rolled back to snapshot %s for volume %s", config.SnapshotID, volumeID)
+		log.Noticef("handleVolumesSnapshotConfigModify: successfully rolled back to snapshot %s for volume %s", config.SnapshotID, volumeID)
 	}
-	// Increment the refCount to indicate that the snapshot is being used and trigger the modify handler
-	volumesSnapshotStatus.RefCount++
-	log.Noticef("handleVolumesSnapshotModify: successfully rolled back to snapshot %s", config.SnapshotID)
-	publishVolumesSnapshotStatus(ctx, volumesSnapshotStatus)
+	return volumesSnapshotStatus
 }
 
-func handleVolumesSnapshotDelete(ctxArg interface{}, keyArg string, configArg interface{}) {
-	ctx := ctxArg.(*volumemgrContext)
-	config := configArg.(types.VolumesSnapshotConfig)
-	log.Noticef("handleVolumesSnapshotDelete(%s)", keyArg)
+func deleteSnapshot(ctx *volumemgrContext, config *types.VolumesSnapshotConfig) *types.VolumesSnapshotStatus {
 	volumesSnapshotStatus := lookupVolumesSnapshotStatus(ctx, config.SnapshotID)
 	if volumesSnapshotStatus == nil {
 		// Create a new volumesSnapshotStatus to report an error
 		volumesSnapshotStatus = &types.VolumesSnapshotStatus{SnapshotID: config.SnapshotID}
 		errDesc := types.ErrorDescription{}
-		errDesc.Error = fmt.Sprintf("handleVolumesSnapshotDelete: snapshot %s not found", keyArg)
+		errDesc.Error = fmt.Sprintf("deleteSnapshot: snapshot %s not found", config.SnapshotID)
 		log.Error(errDesc.Error)
 		volumesSnapshotStatus.SetErrorWithSourceAndDescription(errDesc, types.VolumesSnapshotStatus{})
-		publishVolumesSnapshotStatus(ctx, volumesSnapshotStatus)
-		return
+		return volumesSnapshotStatus
 	}
 	for volumeUUID, snapMeta := range volumesSnapshotStatus.VolumeSnapshotMeta {
 		volumeStatus := ctx.lookupVolumeStatusByUUID(volumeUUID)
 		if volumeStatus == nil {
 			errDesc := types.ErrorDescription{}
-			errDesc.Error = fmt.Sprintf("handleVolumesSnapshotDelete: volume %s not found", volumeUUID)
+			errDesc.Error = fmt.Sprintf("deleteSnapshot: volume %s not found", volumeUUID)
 			log.Error(errDesc.Error)
 			volumesSnapshotStatus.SetErrorWithSourceAndDescription(errDesc, types.VolumesSnapshotStatus{})
-			publishVolumesSnapshotStatus(ctx, volumesSnapshotStatus)
-			return
+			return volumesSnapshotStatus
 		}
 		volumeHandlers := volumehandlers.GetVolumeHandler(log, ctx, volumeStatus)
-		log.Noticef("handleVolumesSnapshotDelete: delete snapshot %s for volume %s", config.SnapshotID, volumeUUID)
-		err := deleteSnapshot(volumeHandlers, snapMeta)
+		log.Noticef("deleteSnapshot: delete snapshot %s for volume %s", config.SnapshotID, volumeUUID)
+		err := volumeHandlers.DeleteSnapshot(snapMeta)
 		if err != nil {
 			errDesc := types.ErrorDescription{}
-			errDesc.Error = fmt.Sprintf("Failed to delete snapshot %s for volume %s, %s", config.SnapshotID, volumeUUID, err.Error())
+			errDesc.Error = fmt.Sprintf("deleteSnapshot: failed to delete snapshot %s for volume %s, %s", config.SnapshotID, volumeUUID, err.Error())
 			log.Error(errDesc.Error)
 			volumesSnapshotStatus.SetErrorWithSourceAndDescription(errDesc, types.VolumesSnapshotStatus{})
-			publishVolumesSnapshotStatus(ctx, volumesSnapshotStatus)
-			return
+			return volumesSnapshotStatus
 		}
-		log.Noticef("handleVolumesSnapshotDelete: successfully deleted snapshot %s for volume %s", config.SnapshotID, volumeUUID)
-		// Decrement the refcount for the volume, so it can be deleted if needed
-		currentVolumeRefConfig := lookupVolumeRefConfig(ctx, volumeStatus.Key())
-		newVolumeRefConfig := types.VolumeRefConfig{
-			VolumeID:               currentVolumeRefConfig.VolumeID,
-			GenerationCounter:      currentVolumeRefConfig.GenerationCounter,
-			LocalGenerationCounter: currentVolumeRefConfig.LocalGenerationCounter,
-			RefCount:               currentVolumeRefConfig.RefCount - 1,
-			MountDir:               currentVolumeRefConfig.MountDir,
-			VerifyOnly:             currentVolumeRefConfig.VerifyOnly,
-		}
-		log.Noticef("handleVolumesSnapshotDelete: decrementing refcount for volume %s to %d", volumeUUID, newVolumeRefConfig.RefCount)
-		handleVolumeRefModify(ctx, volumeStatus.Key(), newVolumeRefConfig, *currentVolumeRefConfig)
+		log.Noticef("deleteSnapshot: successfully deleted snapshot %s for volume %s", config.SnapshotID, volumeUUID)
 	}
-	unpublishVolumesSnapshotStatus(ctx, volumesSnapshotStatus)
-	log.Noticef("handleVolumesSnapshotDelete(%s) done", keyArg)
+	return volumesSnapshotStatus
 }
 
-func rollbackToSnapshot(volumeHandlers volumehandlers.VolumeHandler, meta interface{}) error {
-	log.Noticef("rollbackToSnapshot: rollback to snapshot")
-	err := volumeHandlers.RollbackToSnapshot(meta)
-	if err != nil {
-		log.Errorf("rollbackToSnapshot: failed to rollback to snapshot")
-		return err
+func handleVolumesSnapshotConfigImpl(ctx *volumemgrContext, config types.VolumesSnapshotConfig) {
+	log.Noticef("handleVolumesSnapshotConfigImpl(%s) handles %s", config.SnapshotID, config.Action)
+	var volumesSnapshotStatus *types.VolumesSnapshotStatus
+	switch config.Action {
+	case types.VolumesSnapshotCreate:
+		volumesSnapshotStatus = createSnapshot(ctx, &config)
+		volumesSnapshotStatus.ResultOfAction = types.VolumesSnapshotCreate
+		publishVolumesSnapshotStatus(ctx, volumesSnapshotStatus)
+	case types.VolumesSnapshotRollback:
+		volumesSnapshotStatus = rollbackSnapshot(ctx, &config)
+		volumesSnapshotStatus.ResultOfAction = types.VolumesSnapshotRollback
+		publishVolumesSnapshotStatus(ctx, volumesSnapshotStatus)
+	case types.VolumesSnapshotDelete:
+		volumesSnapshotStatus = deleteSnapshot(ctx, &config)
+		volumesSnapshotStatus.ResultOfAction = types.VolumesSnapshotDelete
+		unpublishVolumesSnapshotStatus(ctx, volumesSnapshotStatus)
 	}
-	log.Noticef("rollbackToSnapshot: successfully rolled back to snapshot")
-	return nil
+	log.Noticef("handleVolumesSnapshotConfigImpl(%s) done", config.SnapshotID)
 }
 
-func deleteSnapshot(volumeHandlers volumehandlers.VolumeHandler, meta interface{}) error {
-	log.Noticef("deleteSnapshot: delete snapshot")
-	err := volumeHandlers.DeleteSnapshot(meta)
-	if err != nil {
-		log.Errorf("deleteSnapshot: failed to delete snapshot")
-		return err
-	}
-	log.Noticef("deleteSnapshot: successfully deleted snapshot")
-	return nil
+func handleVolumesSnapshotConfigCreate(ctxArg interface{}, key string, configArg interface{}) {
+	ctx := ctxArg.(*volumemgrContext)
+	config := configArg.(types.VolumesSnapshotConfig)
+	log.Noticef("handleVolumesSnapshotConfigCreate(%s) handles %s", key, config.Action)
+	handleVolumesSnapshotConfigImpl(ctx, config)
+}
+
+func handleVolumesSnapshotConfigModify(ctxArg interface{}, key string, configArg, _ interface{}) {
+	ctx := ctxArg.(*volumemgrContext)
+	config := configArg.(types.VolumesSnapshotConfig)
+	log.Noticef("handleVolumesSnapshotConfigModify(%s) handles %s", key, config.Action)
+	handleVolumesSnapshotConfigImpl(ctx, config)
+}
+
+func handleVolumesSnapshotConfigDelete(ctxArg interface{}, keyArg string, configArg interface{}) {
+	ctx := ctxArg.(*volumemgrContext)
+	config := configArg.(types.VolumesSnapshotConfig)
+	log.Noticef("handleVolumesSnapshotConfigDelete(%s) handles %s", keyArg, config.Action)
+	// Change the action to delete, as this handler is called when the config is deleted only
+	config.Action = types.VolumesSnapshotDelete
+	handleVolumesSnapshotConfigImpl(ctx, config)
 }
 
 func publishVolumesSnapshotStatus(ctx *volumemgrContext, status *types.VolumesSnapshotStatus) {
@@ -221,11 +301,17 @@ func unpublishVolumesSnapshotStatus(ctx *volumemgrContext, status *types.Volumes
 }
 
 func lookupVolumesSnapshotStatus(ctx *volumemgrContext, key string) *types.VolumesSnapshotStatus {
+	// First check if the status is already published
 	sub := ctx.pubVolumesSnapStatus
 	st, _ := sub.Get(key)
-	if st == nil {
+	if st != nil {
+		status := st.(types.VolumesSnapshotStatus)
+		return &status
+	}
+	// Does not exist in a published state, check if it exists in the store
+	status, err := deserializeVolumesSnapshotStatus(key)
+	if err != nil {
 		return nil
 	}
-	status := st.(types.VolumesSnapshotStatus)
-	return &status
+	return status
 }

--- a/pkg/pillar/cmd/volumemgr/handlevolume.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume.go
@@ -104,8 +104,7 @@ func handleDeferredVolumeCreate(ctx *volumemgrContext, key string, config *types
 	log.Tracef("handleDeferredVolumeCreate(%s)", key)
 	status := ctx.LookupVolumeStatus(config.Key())
 	if status != nil {
-		log.Warnf("status exists at handleVolumeCreate for %s", config.Key())
-		return
+		log.Fatalf("status exists at handleVolumeCreate for %s", config.Key())
 	}
 	status = &types.VolumeStatus{
 		VolumeID:                config.VolumeID,

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -517,9 +517,9 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	subZVolStatus.Activate()
 
 	subVolumesSnapshotConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		CreateHandler: handleVolumesSnapshotCreate,
-		ModifyHandler: handleVolumesSnapshotModify,
-		DeleteHandler: handleVolumesSnapshotDelete,
+		CreateHandler: handleVolumesSnapshotConfigCreate,
+		ModifyHandler: handleVolumesSnapshotConfigModify,
+		DeleteHandler: handleVolumesSnapshotConfigDelete,
 		WarningTime:   warningTime,
 		ErrorTime:     errorTime,
 		AgentName:     "zedmanager",
@@ -534,9 +534,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 
 	pubVolumesSnapshotStatus, err := ps.NewPublication(
 		pubsub.PublicationOptions{
-			AgentName:  agentName,
-			TopicType:  types.VolumesSnapshotStatus{},
-			Persistent: true,
+			AgentName: agentName,
+			TopicType: types.VolumesSnapshotStatus{},
 		},
 	)
 	if err != nil {

--- a/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
+++ b/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"reflect"
 	"time"
 
 	"github.com/lf-edge/eve/pkg/pillar/base"
@@ -445,12 +444,12 @@ func deserializeSnapshotInstanceStatus(snapshotID string) (*types.SnapshotInstan
 	// get the filename
 	snapshotInstanceStatusFilename := types.GetSnapshotInstanceStatusFile(snapshotID)
 
-	retStruct, err := utils.DeserializeToStruct(snapshotInstanceStatusFilename, reflect.TypeOf(types.SnapshotInstanceStatus{}), types.SnapshotInstanceStatusCriticalFields)
+	snapshotInstanceStatus := new(types.SnapshotInstanceStatus)
+	err := utils.DeserializeToStruct(snapshotInstanceStatusFilename, snapshotInstanceStatus)
 	if err != nil {
 		log.Errorf("deserializeSnapshotInstanceStatus: Failed to deserialize SnapshotInstanceStatus: %s", err)
 		return nil, fmt.Errorf("failed to deserialize SnapshotInstanceStatus: %s", err)
 	}
-	snapshotInstanceStatus := retStruct.(*types.SnapshotInstanceStatus)
 	return snapshotInstanceStatus, nil
 }
 

--- a/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
+++ b/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
@@ -525,7 +525,7 @@ func restoreConfigFromSnapshot(ctx *zedmanagerContext, appInstanceStatus *types.
 // something like: applyAppInstanceFromSnapshot.
 func addFixupsIntoSnappedConfig(ctx *zedmanagerContext, appInstanceStatus *types.AppInstanceStatus, snappedAppInstanceConfig *types.AppInstanceConfig) (*types.AppInstanceConfig, error) {
 	// Get the app instance config from the app instance status
-	currentAppInstanceConfig := lookupAppInstanceConfig(ctx, appInstanceStatus.Key())
+	currentAppInstanceConfig := lookupAppInstanceConfig(ctx, appInstanceStatus.Key(), true)
 	if currentAppInstanceConfig == nil {
 		return nil, fmt.Errorf("AppInstanceConfig not found for %s", appInstanceStatus.Key())
 	}

--- a/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
+++ b/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
@@ -242,40 +242,60 @@ func getVolumeRefConfigFromAIConfig(config *types.AppInstanceConfig,
 
 /* Handlers for VolumesSnapshotStatus */
 
-func handleVolumesSnapshotStatusCreate(ctx interface{}, key string, status interface{}) {
-	log.Noticef("handleVolumesSnapshotStatusCreate")
-	volumesSnapshotStatus := status.(types.VolumesSnapshotStatus)
-	zedmanagerCtx := ctx.(*zedmanagerContext)
-	appInstanceStatus := lookupAppInstanceStatus(zedmanagerCtx, volumesSnapshotStatus.AppUUID.String())
+func handleVolumesSnapshotStatusImpl(ctx *zedmanagerContext, volumesSnapshotStatus types.VolumesSnapshotStatus) {
+	log.Noticef("handleVolumesSnapshotStatusImpl")
+	switch volumesSnapshotStatus.ResultOfAction {
+	case types.VolumesSnapshotCreate:
+		reactToSnapshotCreate(ctx, volumesSnapshotStatus)
+	case types.VolumesSnapshotRollback:
+		reactToSnapshotRollback(ctx, volumesSnapshotStatus)
+	case types.VolumesSnapshotDelete:
+		reactToSnapshotDelete(ctx, volumesSnapshotStatus)
+	}
+	log.Noticef("handleVolumesSnapshotStatusImpl done")
+}
+
+func reactToSnapshotDelete(ctx *zedmanagerContext, volumesSnapshotStatus types.VolumesSnapshotStatus) {
+	log.Noticef("reactToSnapshotDelete: %s", volumesSnapshotStatus.SnapshotID)
+	appInstanceStatus := lookupAppInstanceStatus(ctx, volumesSnapshotStatus.AppUUID.String())
 	if appInstanceStatus == nil {
-		log.Errorf("handleVolumesSnapshotStatusCreate: AppInstanceStatus not found for %s", volumesSnapshotStatus.AppUUID.String())
+		log.Errorf("reactToSnapshotDelete: AppInstanceStatus not found for %s", volumesSnapshotStatus.AppUUID.String())
 		return
 	}
 	if volumesSnapshotStatus.HasError() {
 		appInstanceStatus.Error = volumesSnapshotStatus.Error
 		appInstanceStatus.ErrorTime = volumesSnapshotStatus.ErrorTime
 		setSnapshotStatusError(appInstanceStatus, volumesSnapshotStatus.SnapshotID, volumesSnapshotStatus.ErrorDescription)
-		publishAppInstanceStatus(zedmanagerCtx, appInstanceStatus)
+		publishAppInstanceStatus(ctx, appInstanceStatus)
 		return
 	}
-	log.Noticef("Snapshot %s created", volumesSnapshotStatus.SnapshotID)
-	err := moveSnapshotToAvailable(appInstanceStatus, volumesSnapshotStatus)
-	if err != nil {
-		errDesc := types.ErrorDescription{}
-		errDesc.Error = err.Error()
-		log.Errorf("handleVolumesSnapshotStatusCreate: %s", errDesc.Error)
-		setSnapshotStatusError(appInstanceStatus, volumesSnapshotStatus.SnapshotID, errDesc)
-		appInstanceStatus.SetErrorWithSourceAndDescription(errDesc, types.SnapshotInstanceStatus{})
+	deleteSnapshotFromStatus(appInstanceStatus, volumesSnapshotStatus.SnapshotID)
+	// Delete the serialized config, if it exists
+	if err := DeleteSnapshotFiles(volumesSnapshotStatus.SnapshotID); err != nil {
+		return
 	}
-	publishAppInstanceStatus(zedmanagerCtx, appInstanceStatus)
+	log.Noticef("Deleting snapshot from the App status")
+	publishAppInstanceStatus(ctx, appInstanceStatus)
 }
 
-func handleVolumesSnapshotStatusModify(ctx interface{}, key string, status interface{}, status2 interface{}) {
-	log.Noticef("handleVolumesSnapshotStatusModify")
-	// Reaction to a snapshot rollback
-	volumesSnapshotStatus := status.(types.VolumesSnapshotStatus)
-	zedmanagerCtx := ctx.(*zedmanagerContext)
-	appInstanceStatus := lookupAppInstanceStatus(zedmanagerCtx, volumesSnapshotStatus.AppUUID.String())
+// DeleteSnapshotFiles deletes the snapshot directory
+func DeleteSnapshotFiles(snapshotID string) error {
+	configDir := types.GetSnapshotDir(snapshotID)
+	// delete the directory if it exists
+	if _, err := os.Stat(configDir); err == nil {
+		log.Noticef("Deleting snapshot directory %s", configDir)
+		err = os.RemoveAll(configDir)
+		if err != nil {
+			log.Errorf("Failed to delete snapshot directory %s: %s", configDir, err)
+			return err
+		}
+	}
+	return nil
+}
+
+func reactToSnapshotRollback(ctx *zedmanagerContext, volumesSnapshotStatus types.VolumesSnapshotStatus) {
+	log.Noticef("reactToSnapshotRollback: %s", volumesSnapshotStatus.SnapshotID)
+	appInstanceStatus := lookupAppInstanceStatus(ctx, volumesSnapshotStatus.AppUUID.String())
 	if appInstanceStatus == nil {
 		log.Errorf("handleVolumesSnapshotStatusModify: AppInstanceStatus not found for %s", volumesSnapshotStatus.AppUUID.String())
 		return
@@ -284,44 +304,70 @@ func handleVolumesSnapshotStatusModify(ctx interface{}, key string, status inter
 		log.Errorf("Snapshot handling %s failed: %s", volumesSnapshotStatus.SnapshotID, volumesSnapshotStatus.Error)
 		appInstanceStatus.SetErrorWithSourceAndDescription(volumesSnapshotStatus.ErrorDescription, volumesSnapshotStatus.ErrorSourceType)
 		setSnapshotStatusError(appInstanceStatus, volumesSnapshotStatus.SnapshotID, volumesSnapshotStatus.ErrorDescription)
-		publishAppInstanceStatus(zedmanagerCtx, appInstanceStatus)
+		publishAppInstanceStatus(ctx, appInstanceStatus)
 		return
 	}
 	appInstanceStatus.SnapStatus.RollbackInProgress = false
-	publishAppInstanceStatus(zedmanagerCtx, appInstanceStatus)
+	// unpublish local app instance config, as the rollback is complete, we do not need to replace the config
+	config := lookupAppInstanceConfig(ctx, appInstanceStatus.Key(), false)
+	if config == nil {
+		log.Fatalf("reactToSnapshotRollback: AppInstanceConfig not found for %s", appInstanceStatus.Key())
+	}
+	unpublishLocalAppInstanceConfig(ctx, appInstanceStatus.Key())
+	publishAppInstanceStatus(ctx, appInstanceStatus)
+	doUpdate(ctx, *config, appInstanceStatus)
+}
+
+func reactToSnapshotCreate(ctx *zedmanagerContext, volumesSnapshotStatus types.VolumesSnapshotStatus) {
+	log.Noticef("reactToSnapshotCreate")
+	appInstanceStatus := lookupAppInstanceStatus(ctx, volumesSnapshotStatus.AppUUID.String())
+	if appInstanceStatus == nil {
+		log.Errorf("reactToSnapshotCreate: AppInstanceStatus not found for %s", volumesSnapshotStatus.AppUUID.String())
+		return
+	}
+
+	if volumesSnapshotStatus.HasError() && volumesSnapshotStatus.ErrorSeverity != types.ErrorSeverityWarning {
+		appInstanceStatus.Error = volumesSnapshotStatus.Error
+		appInstanceStatus.ErrorTime = volumesSnapshotStatus.ErrorTime
+		setSnapshotStatusError(appInstanceStatus, volumesSnapshotStatus.SnapshotID, volumesSnapshotStatus.ErrorDescription)
+		publishAppInstanceStatus(ctx, appInstanceStatus)
+		return
+	}
+	log.Noticef("Snapshot %s created", volumesSnapshotStatus.SnapshotID)
+	err := moveSnapshotToAvailable(appInstanceStatus, volumesSnapshotStatus)
+	if err != nil {
+		errDesc := types.ErrorDescription{}
+		errDesc.Error = err.Error()
+		log.Errorf("reactToSnapshotCreate: %s", errDesc.Error)
+		setSnapshotStatusError(appInstanceStatus, volumesSnapshotStatus.SnapshotID, errDesc)
+		appInstanceStatus.SetErrorWithSourceAndDescription(errDesc, types.SnapshotInstanceStatus{})
+	}
+	publishAppInstanceStatus(ctx, appInstanceStatus)
+}
+
+func handleVolumesSnapshotStatusCreate(ctx interface{}, key string, status interface{}) {
+	log.Noticef("handleVolumesSnapshotStatusCreate")
+	volumesSnapshotStatus := status.(types.VolumesSnapshotStatus)
+	zedmanagerCtx := ctx.(*zedmanagerContext)
+	handleVolumesSnapshotStatusImpl(zedmanagerCtx, volumesSnapshotStatus)
+	log.Noticef("handleVolumesSnapshotStatusCreate done")
+}
+
+func handleVolumesSnapshotStatusModify(ctx interface{}, key string, status interface{}, status2 interface{}) {
+	log.Noticef("handleVolumesSnapshotStatusModify")
+	volumesSnapshotStatus := status.(types.VolumesSnapshotStatus)
+	zedmanagerCtx := ctx.(*zedmanagerContext)
+	handleVolumesSnapshotStatusImpl(zedmanagerCtx, volumesSnapshotStatus)
+	log.Noticef("handleVolumesSnapshotStatusModify done")
 }
 
 func handleVolumesSnapshotStatusDelete(ctx interface{}, key string, status interface{}) {
 	log.Noticef("handleVolumesSnapshotStatusDelete")
 	volumesSnapshotStatus := status.(types.VolumesSnapshotStatus)
 	zedmanagerCtx := ctx.(*zedmanagerContext)
-	appInstanceStatus := lookupAppInstanceStatus(zedmanagerCtx, volumesSnapshotStatus.AppUUID.String())
-	if appInstanceStatus == nil {
-		log.Errorf("handleVolumesSnapshotStatusDelete: AppInstanceStatus not found for %s", volumesSnapshotStatus.AppUUID.String())
-		return
-	}
-	if volumesSnapshotStatus.HasError() {
-		appInstanceStatus.Error = volumesSnapshotStatus.Error
-		appInstanceStatus.ErrorTime = volumesSnapshotStatus.ErrorTime
-		setSnapshotStatusError(appInstanceStatus, volumesSnapshotStatus.SnapshotID, volumesSnapshotStatus.ErrorDescription)
-		publishAppInstanceStatus(zedmanagerCtx, appInstanceStatus)
-		return
-	}
-	deleteSnapshotFromStatus(appInstanceStatus, volumesSnapshotStatus.SnapshotID)
-	// Delete the serialized config, if it exists
-	configDir := getSnapshotDir(volumesSnapshotStatus.SnapshotID)
-	// delete the directory if it exists
-	if _, err := os.Stat(configDir); err == nil {
-		log.Noticef("Deleting snapshot directory %s", configDir)
-		err = os.RemoveAll(configDir)
-		if err != nil {
-			log.Errorf("handleVolumesSnapshotStatusDelete: Failed to delete snapshot directory %s: %s", configDir, err)
-			return
-		}
-	}
-
-	log.Noticef("Deleting snapshot from the App status")
-	publishAppInstanceStatus(zedmanagerCtx, appInstanceStatus)
+	volumesSnapshotStatus.ResultOfAction = types.VolumesSnapshotDelete
+	handleVolumesSnapshotStatusImpl(zedmanagerCtx, volumesSnapshotStatus)
+	log.Noticef("handleVolumesSnapshotStatusDelete done")
 }
 
 /* Helper functions for the VolumesSnapshotStatus handlers */

--- a/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
+++ b/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
@@ -542,8 +542,7 @@ func fixupAppInstanceConfig(ctx *zedmanagerContext, appInstanceStatus *types.App
 // deserializeAppInstanceConfigFromSnapshot deserializes the config from a file
 func deserializeAppInstanceConfigFromSnapshot(snapshotID string) *types.AppInstanceConfig {
 	log.Noticef("deserializeAppInstanceConfigFromSnapshot")
-	dirname := getSnapshotDir(snapshotID)
-	filename := path.Join(dirname, types.SnapshotConfigFilename)
+	filename := types.GetSnapshotAppInstanceConfigFile(snapshotID)
 	var appInstanceConfig types.AppInstanceConfig
 	configFile, err := os.Open(filename)
 	if err != nil {

--- a/pkg/pillar/cmd/zedmanager/memorysizemgmt.go
+++ b/pkg/pillar/cmd/zedmanager/memorysizemgmt.go
@@ -32,7 +32,7 @@ func getRemainingMemory(ctxPtr *zedmanagerContext) (uint64, uint64, uint64, erro
 		if status.Activated || status.ActivateInprogress {
 			usedMemorySize += mem
 			accountedApps = append(accountedApps, status.Key())
-			config := lookupAppInstanceConfig(ctxPtr, status.Key())
+			config := lookupAppInstanceConfig(ctxPtr, status.Key(), true)
 			if config == nil || !config.Activate {
 				haltingMemorySize += mem
 			}

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -278,6 +278,7 @@ func triggerSnapshotDeletion(snapshotsToBeDeleted []types.SnapshotDesc, ctx *zed
 		if volumesSnapshotConfig != nil {
 			// The snapshot has already been triggered, so we need to delete the config and notify volumemanager
 			log.Noticef("It has already been triggered, so deleting the config and notifying volumemanager")
+			volumesSnapshotConfig.Action = types.VolumesSnapshotDelete
 			unpublishVolumesSnapshotConfig(ctx, volumesSnapshotConfig)
 		}
 	}

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -1056,6 +1056,14 @@ func doUninstall(ctx *zedmanagerContext, appInstID uuid.UUID,
 	changed := false
 	del := false
 
+	// Clean the snapshot files related to this app instance
+	for _, snap := range status.SnapStatus.AvailableSnapshots {
+		log.Noticef("doUninstall: DeleteSnapshotFiles(%s)", snap.Snapshot.SnapshotID)
+		if err := DeleteSnapshotFiles(snap.Snapshot.SnapshotID); err != nil {
+			log.Warnf("doUninstall: DeleteSnapshotFiles(%s) failed: %s", snap.Snapshot.SnapshotID, err)
+		}
+	}
+
 	for i := range status.VolumeRefStatusList {
 		vrs := &status.VolumeRefStatusList[i]
 		MaybeRemoveVolumeRefConfig(ctx, appInstID,

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -24,7 +24,7 @@ func updateAIStatusUUID(ctx *zedmanagerContext, uuidStr string) {
 			uuidStr)
 		return
 	}
-	config := lookupAppInstanceConfig(ctx, uuidStr)
+	config := lookupAppInstanceConfig(ctx, uuidStr, true)
 	if config == nil || (status.PurgeInprogress == types.BringDown) {
 		removeAIStatus(ctx, status)
 		return
@@ -99,7 +99,7 @@ func removeAIStatus(ctx *zedmanagerContext, status *types.AppInstanceStatus) {
 		status.Key())
 	status.PurgeInprogress = types.RecreateVolumes
 	publishAppInstanceStatus(ctx, status)
-	config := lookupAppInstanceConfig(ctx, uuidStr)
+	config := lookupAppInstanceConfig(ctx, uuidStr, true)
 	if config != nil {
 		changed := purgeCmdDone(ctx, *config, status)
 		if changed {

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -929,13 +929,13 @@ func removePreparedVolumesSnapshotConfig(status *types.AppInstanceStatus, id str
 	}
 }
 
-// saveConfigForSnapshots saves the config for the snapshots for which the config has been prepared
-func saveConfigForSnapshots(ctx *zedmanagerContext, status *types.AppInstanceStatus, config types.AppInstanceConfig) error {
+// saveAppInstanceConfigForSnapshot saves the config for the snapshots for which the config has been prepared
+func saveAppInstanceConfigForSnapshot(status *types.AppInstanceStatus, config types.AppInstanceConfig) error {
 	for i, snapshot := range status.SnapStatus.PreparedVolumesSnapshotConfigs {
 		// Set the old config version to the snapshot status
 		status.SnapStatus.RequestedSnapshots[i].ConfigVersion = config.UUIDandVersion
 		// Serialize the old config and store it in a file
-		err := serializeConfigToSnapshot(config, snapshot.SnapshotID)
+		err := serializeAppInstanceConfigToSnapshot(config, snapshot.SnapshotID)
 		if err != nil {
 			log.Errorf("Failed to serialize the old config for %s, error: %s", config.DisplayName, err)
 			return err
@@ -944,8 +944,8 @@ func saveConfigForSnapshots(ctx *zedmanagerContext, status *types.AppInstanceSta
 	return nil
 }
 
-// serializeConfigToSnapshot serializes the config to a file
-func serializeConfigToSnapshot(config types.AppInstanceConfig, snapshotID string) error {
+// serializeAppInstanceConfigToSnapshot serializes the config to a file
+func serializeAppInstanceConfigToSnapshot(config types.AppInstanceConfig, snapshotID string) error {
 	// Store the old config in a file, so that we can use it to roll back to the previous version
 	// if the upgrade fails
 	configAsBytes, err := json.Marshal(config)
@@ -1124,7 +1124,7 @@ func handleModify(ctxArg interface{}, key string,
 		// it's triggered. We cannot trigger the snapshot creation here immediately, as the VM
 		// should be stopped first. But we still need to save the list of volumes that are known only at this point.
 		status.SnapStatus.PreparedVolumesSnapshotConfigs = prepareVolumesSnapshotConfigs(ctx, oldConfig, status)
-		err := saveConfigForSnapshots(ctx, status, oldConfig)
+		err := saveAppInstanceConfigForSnapshot(status, oldConfig)
 		if err != nil {
 			log.Errorf("handleModify(%v) for %s: error saving old config for snapshots: %v",
 				config.UUIDandVersion, config.DisplayName, err)

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -25,6 +25,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils"
+	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 	"github.com/sirupsen/logrus"
 )
 
@@ -960,7 +961,7 @@ func serializeAppInstanceConfigToSnapshot(config types.AppInstanceConfig, snapsh
 		return err
 	}
 	configFile := types.GetSnapshotAppInstanceConfigFile(snapshotID)
-	err = os.WriteFile(configFile, configAsBytes, 0644)
+	err = fileutils.WriteRename(configFile, configAsBytes)
 	if err != nil {
 		log.Errorf("Failed to write the old config for %s, error: %s", config.DisplayName, err)
 		return err

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -682,6 +682,9 @@ func lookupAppInstanceStatus(ctx *zedmanagerContext, key string) *types.AppInsta
 	return &status
 }
 
+// lookupAppInstanceConfig returns the AppInstanceConfig for the given key. If checkLocal is true, then the local
+// AppInstanceConfig subscription is checked first, not the regular one. The local subscription is used for
+// AppInstanceConfig that comes from snapshot during a rollback.
 func lookupAppInstanceConfig(ctx *zedmanagerContext, key string, checkLocal bool) *types.AppInstanceConfig {
 	if checkLocal {
 		sub := ctx.subLocalAppInstanceConfig
@@ -907,9 +910,6 @@ func prepareVolumesSnapshotConfigs(ctx *zedmanagerContext, config types.AppInsta
 			for _, volumeRefConfig := range config.VolumeRefConfigList {
 				log.Noticef("Adding volume %s to volumesSnapshotConfig", volumeRefConfig.VolumeID)
 				volumesSnapshotConfig.VolumeIDs = append(volumesSnapshotConfig.VolumeIDs, volumeRefConfig.VolumeID)
-				// Increment the reference count for the volume, so it's not deleted when it's temporary not used by any application
-				volumeRefConfig.RefCount++
-				publishVolumeRefConfig(ctx, &volumeRefConfig)
 			}
 			volumesSnapshotConfigList = append(volumesSnapshotConfigList, volumesSnapshotConfig)
 		}

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -25,6 +25,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils"
+	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 	"github.com/sirupsen/logrus"
 )
 
@@ -409,6 +410,43 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		case <-stillRunning.C:
 		}
 		ps.StillRunning(agentName, warningTime, errorTime)
+	}
+}
+
+func restoreAvailableSnapshots(aiStatus *types.AppInstanceStatus) {
+	// List all the directories that are present in snapshots directory
+	// and restore the snapshot status for each of them
+	snapDir := types.SnapshotsDirname
+	dirEntries, err := os.ReadDir(snapDir)
+	if err != nil {
+		log.Warnf("No %s directory, nothing to restore", snapDir)
+		return
+	}
+	for _, dirEntry := range dirEntries {
+		if !dirEntry.IsDir() {
+			continue
+		}
+		snapshotID := dirEntry.Name()
+		// Figure out the ID of the app that this snapshot belongs to
+		aiConfig := deserializeAppInstanceConfigFromSnapshot(snapshotID)
+		if aiConfig == nil {
+			log.Warnf("cannot deserialize config for snapshot %s", snapshotID)
+			continue
+		}
+		if aiConfig.UUIDandVersion.UUID != aiStatus.UUIDandVersion.UUID {
+			// This snapshot is not for this app
+			continue
+		}
+		// Get the metadata for this snapshot
+		var availableSnapshot *types.SnapshotInstanceStatus
+		availableSnapshot, err = deserializeSnapshotInstanceStatus(snapshotID)
+		if err != nil {
+			log.Errorf("restoreAvailableSnapshots: %s", err)
+			continue
+		}
+		log.Noticef("restoreAvailableSnapshots: %s", availableSnapshot.Snapshot.SnapshotID)
+		// add to the list of the available snapshots
+		aiStatus.SnapStatus.AvailableSnapshots = append(aiStatus.SnapStatus.AvailableSnapshots, *availableSnapshot)
 	}
 }
 
@@ -960,6 +998,8 @@ func handleCreate(ctxArg interface{}, key string,
 
 	// Calculate the moment when the application should start, taking into account the configured delay
 	status.StartTime = ctx.delayBaseTime.Add(config.Delay)
+
+	restoreAvailableSnapshots(&status)
 
 	updateSnapshotsInAIStatus(&status, config)
 

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -953,25 +953,20 @@ func serializeAppInstanceConfigToSnapshot(config types.AppInstanceConfig, snapsh
 		log.Errorf("Failed to marshal the old config for %s, error: %s", config.DisplayName, err)
 		return err
 	}
-	snapshotDir := getSnapshotDir(snapshotID)
+	snapshotDir := types.GetSnapshotDir(snapshotID)
 	// Create the directory for storing the old config
 	err = os.MkdirAll(snapshotDir, 0755)
 	if err != nil {
 		log.Errorf("Failed to create the config dir for %s, error: %s", config.DisplayName, err)
 		return err
 	}
-	configFile := fmt.Sprintf("%s/%s", snapshotDir, types.SnapshotConfigFilename)
+	configFile := types.GetSnapshotAppInstanceConfigFile(snapshotID)
 	err = os.WriteFile(configFile, configAsBytes, 0644)
 	if err != nil {
 		log.Errorf("Failed to write the old config for %s, error: %s", config.DisplayName, err)
 		return err
 	}
 	return nil
-}
-
-func getSnapshotDir(snapshotID string) string {
-	snapshotDir := fmt.Sprintf("%s/%s", types.SnapshotsDirname, snapshotID)
-	return snapshotDir
 }
 
 func handleCreate(ctxArg interface{}, key string,

--- a/pkg/pillar/types/locationconsts.go
+++ b/pkg/pillar/types/locationconsts.go
@@ -33,8 +33,12 @@ const (
 	IngestedDirname = PersistDir + "/ingested"
 	// SnapshotsDirname - location for snapshots
 	SnapshotsDirname = PersistDir + "/snapshots"
-	// SnapshotConfigFilename - file to store snapshot configuration
-	SnapshotConfigFilename = "config.json"
+	// SnapshotAppInstanceConfigFilename - file to store snapshot-related app instance config
+	SnapshotAppInstanceConfigFilename = "appInstanceConfig.json"
+	// SnapshotVolumesSnapshotStatusFilename - file to store volume snapshot status
+	SnapshotVolumesSnapshotStatusFilename = "volumesSnapshotStatus.json"
+	// SnapshotInstanceStatusFilename - file to store SnapshotInstanceStatus
+	SnapshotInstanceStatusFilename = "snapshotInstanceStatus.json"
 
 	// IdentityDirname - Config dir
 	IdentityDirname = "/config"

--- a/pkg/pillar/types/volumetypes.go
+++ b/pkg/pillar/types/volumetypes.go
@@ -276,7 +276,6 @@ type VolumesSnapshotConfig struct {
 	VolumeIDs []uuid.UUID
 	// AppUUID used as a backlink to the app
 	AppUUID uuid.UUID
-	// ConfigID is the ID of the config that created the snapshot
 }
 
 // Key returns unique key for the snapshot

--- a/pkg/pillar/types/volumetypes.go
+++ b/pkg/pillar/types/volumetypes.go
@@ -286,26 +286,19 @@ func (config VolumesSnapshotConfig) Key() string {
 // VolumesSnapshotStatus is used to send snapshot status from volumemgr to zedmanager
 type VolumesSnapshotStatus struct {
 	// SnapshotID is the ID of the snapshot, critical field
-	SnapshotID string
+	SnapshotID string `mandatory:"true"`
 	// Metadata is a map of volumeID to metadata, depending on the volume type. Critical field.
-	VolumeSnapshotMeta map[string]interface{}
+	VolumeSnapshotMeta map[string]interface{} `mandatory:"true"`
 	// TimeCreated is the time the snapshot was created, reported by FS-specific code
 	TimeCreated time.Time
 	// AppUUID used as a backlink to the app, critical field
-	AppUUID uuid.UUID
+	AppUUID uuid.UUID `mandatory:"true"`
 	// RefCount is the number of times the snapshot is used. Necessary to trigger the handleModify handler
 	RefCount int
 	// ResultOfAction is the type of action that was performed on the snapshot that resulted in this status
 	ResultOfAction VolumesSnapshotAction
 	// ErrorAndTimeWithSource provides SetErrorNow() and ClearError()
 	ErrorAndTimeWithSource
-}
-
-// VolumesSnapshotStatusCriticalFields are the fields that must present in a serialized snapshot status
-var VolumesSnapshotStatusCriticalFields = map[string]bool{
-	"SnapshotID":         true,
-	"VolumeSnapshotMeta": true,
-	"AppUUID":            true,
 }
 
 // Key returns unique key for the snapshot

--- a/pkg/pillar/types/volumetypes.go
+++ b/pkg/pillar/types/volumetypes.go
@@ -285,18 +285,27 @@ func (config VolumesSnapshotConfig) Key() string {
 
 // VolumesSnapshotStatus is used to send snapshot status from volumemgr to zedmanager
 type VolumesSnapshotStatus struct {
-	// SnapshotID is the ID of the snapshot
+	// SnapshotID is the ID of the snapshot, critical field
 	SnapshotID string
-	// Metadata is a map of volumeID to metadata, depending on the volume type
+	// Metadata is a map of volumeID to metadata, depending on the volume type. Critical field.
 	VolumeSnapshotMeta map[string]interface{}
 	// TimeCreated is the time the snapshot was created, reported by FS-specific code
 	TimeCreated time.Time
-	// AppUUID used as a backlink to the app
+	// AppUUID used as a backlink to the app, critical field
 	AppUUID uuid.UUID
 	// RefCount is the number of times the snapshot is used. Necessary to trigger the handleModify handler
 	RefCount int
+	// ResultOfAction is the type of action that was performed on the snapshot that resulted in this status
+	ResultOfAction VolumesSnapshotAction
 	// ErrorAndTimeWithSource provides SetErrorNow() and ClearError()
 	ErrorAndTimeWithSource
+}
+
+// VolumesSnapshotStatusCriticalFields are the fields that must present in a serialized snapshot status
+var VolumesSnapshotStatusCriticalFields = map[string]bool{
+	"SnapshotID":         true,
+	"VolumeSnapshotMeta": true,
+	"AppUUID":            true,
 }
 
 // Key returns unique key for the snapshot

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -100,6 +100,13 @@ type SnapshotInstanceStatus struct {
 	Error ErrorDescription
 }
 
+// SnapshotInstanceStatusCriticalFields list of mandatory fields in SnapshotInstanceStatus to be restored from persistent storage
+var SnapshotInstanceStatusCriticalFields = map[string]bool{
+	"Snapshot":      true,
+	"AppInstanceID": true,
+	"ConfigVersion": true,
+}
+
 // SnapshotConfig configuration of the snapshot handling for the app instance
 type SnapshotConfig struct {
 	ActiveSnapshot string            // UUID of the active snapshot used by the app instance

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -83,7 +83,7 @@ type SnapshotDesc struct {
 // SnapshotInstanceStatus status of a snapshot instance. Used as a zedmanager-level representation of a snapshot
 type SnapshotInstanceStatus struct {
 	// Snapshot contains the snapshot description
-	Snapshot SnapshotDesc
+	Snapshot SnapshotDesc `mandatory:"true"`
 	// Reported indicates if the snapshot has been reported to the controller
 	Reported bool
 	// TimeTriggered is the time when the snapshot was triggered. At the moment, it is used to check if the snapshot has
@@ -93,19 +93,12 @@ type SnapshotInstanceStatus struct {
 	// TimeCreated is the time when the snapshot was created. It's reported by FS-specific snapshot creation code.
 	TimeCreated time.Time
 	// AppInstanceID is the UUID of the app instance the snapshot belongs to
-	AppInstanceID uuid.UUID
+	AppInstanceID uuid.UUID `mandatory:"true"`
 	// ConfigVersion is the version of the app instance config at the moment of the snapshot creation
 	// It is reported to the controller, so it can use the proper config to roll back the app instance
-	ConfigVersion UUIDandVersion
+	ConfigVersion UUIDandVersion `mandatory:"true"`
 	// Error indicates if snapshot deletion or a rollback to the snapshot failed
 	Error ErrorDescription
-}
-
-// SnapshotInstanceStatusCriticalFields list of mandatory fields in SnapshotInstanceStatus to be restored from persistent storage
-var SnapshotInstanceStatusCriticalFields = map[string]bool{
-	"Snapshot":      true,
-	"AppInstanceID": true,
-	"ConfigVersion": true,
 }
 
 // SnapshotConfig configuration of the snapshot handling for the app instance

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -251,14 +251,14 @@ type SnapshottingStatus struct {
 	PreparedVolumesSnapshotConfigs []VolumesSnapshotConfig
 	// SnapshotOnUpgrade indicates whether a snapshot should be taken during the app instance update.
 	SnapshotOnUpgrade bool
-	// HasRollbackRequest indicates whether a rollback is in progress for the app instance.
+	// HasRollbackRequest indicates whether there are any rollback requests for the app instance.
+	// Set to true when a rollback is requested by controller, set to false when the rollback is triggered.
 	HasRollbackRequest bool
 	// ActiveSnapshot contains the id of the snapshot to be used for the rollback.
 	ActiveSnapshot string
 	// RollbackInProgress indicates whether a rollback is in progress for the app instance.
+	// Set to true when a rollback is triggered, set to false when the rollback is completed.
 	RollbackInProgress bool
-	// ConfigBeforeRollback contains the version of the configuration of the app instance before the rollback
-	ConfigBeforeRollback UUIDandVersion
 }
 
 // Indexed by UUIDandVersion as above

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -6,6 +6,7 @@ package types
 import (
 	"fmt"
 	"net"
+	"path/filepath"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -480,4 +481,24 @@ func (aih AppAndImageToHash) LogDelete(logBase *base.LogObject) {
 // LogKey :
 func (aih AppAndImageToHash) LogKey() string {
 	return string(base.AppAndImageToHashLogType) + "-" + aih.Key()
+}
+
+// GetSnapshotDir returns the snapshot directory for the given snapshot ID
+func GetSnapshotDir(snapshotID string) string {
+	return filepath.Join(SnapshotsDirname, snapshotID)
+}
+
+// GetVolumesSnapshotStatusFile returns the volumes snapshot status file for the given snapshot ID and volume ID
+func GetVolumesSnapshotStatusFile(snapshotID string) string {
+	return filepath.Join(GetSnapshotDir(snapshotID), SnapshotVolumesSnapshotStatusFilename)
+}
+
+// GetSnapshotInstanceStatusFile returns the instance status file for the given snapshot ID
+func GetSnapshotInstanceStatusFile(snapshotID string) string {
+	return filepath.Join(GetSnapshotDir(snapshotID), SnapshotInstanceStatusFilename)
+}
+
+// GetSnapshotAppInstanceConfigFile returns the app instance config file for the given snapshot ID
+func GetSnapshotAppInstanceConfigFile(snapshotID string) string {
+	return filepath.Join(GetSnapshotDir(snapshotID), SnapshotAppInstanceConfigFilename)
 }

--- a/pkg/pillar/utils/deserialize.go
+++ b/pkg/pillar/utils/deserialize.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2017-2023 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	log "github.com/sirupsen/logrus"
+	"io"
+	"os"
+	"reflect"
+)
+
+func readFile(filename string) ([]byte, error) {
+	// Check if the file exists
+	if _, err := os.Stat(filename); os.IsNotExist(err) {
+		log.Errorf("File %s does not exist", filename)
+		return nil, err
+	}
+
+	// Open the file
+	file, err := os.Open(filename)
+	if err != nil {
+		log.Errorf("Failed to open file %s, %s", filename, err.Error())
+		return nil, err
+	}
+	defer file.Close()
+
+	// Read the data
+	data, err := io.ReadAll(file)
+	if err != nil {
+		log.Errorf("Failed to read data from file %s, %s", filename, err.Error())
+		return nil, err
+	}
+
+	return data, nil
+}
+
+func validateFields(dataMap map[string]interface{}, expectedFields map[string]bool, criticalFields map[string]bool, filename string) error {
+	for k := range dataMap {
+		if _, ok := expectedFields[k]; !ok {
+			log.Warnf("Unexpected field %s in stored data in %s", k, filename)
+		}
+	}
+
+	for k := range expectedFields {
+		if _, ok := dataMap[k]; !ok {
+			if criticalFields[k] {
+				errMsg := fmt.Sprintf("Critical field %s missing in stored data in %s", k, filename)
+				log.Errorf(errMsg)
+				return fmt.Errorf(errMsg)
+			}
+			log.Warnf("Missing field %s in stored data in %s", k, filename)
+		}
+	}
+
+	return nil
+}
+
+// ExtractFields extracts all fields from the given type and its anonymous fields
+// and adds them to the given map. This can be used for a careful deserialization.
+func extractFields(t reflect.Type, fieldMap *map[string]bool) {
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+
+		if field.Anonymous {
+			// If this is an anonymous field, recursively extract its fields as well.
+			extractFields(field.Type, fieldMap)
+		} else {
+			// This is a normal field, so just add its name to the map.
+			(*fieldMap)[field.Name] = true
+		}
+	}
+}
+
+// DeserializeToStruct deserializes the given file into the given struct type.
+// It also validates that all mandatory fields in the struct are present in the file. It prints warnings
+// for all unexpected fields in the file and for all missing fields in the file that are not mandatory.
+func DeserializeToStruct(filename string, structType reflect.Type, criticalFields map[string]bool) (interface{}, error) {
+	data, err := readFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	var dataMap map[string]interface{}
+	err = json.Unmarshal(data, &dataMap)
+	if err != nil {
+		log.Errorf("Failed to unmarshal data, %s", err.Error())
+		return nil, err
+	}
+
+	expectedFields := make(map[string]bool)
+	extractFields(structType, &expectedFields)
+
+	err = validateFields(dataMap, expectedFields, criticalFields, filename)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unmarshal from JSON
+	retStruct := reflect.New(structType).Interface()
+	err = json.Unmarshal(data, &retStruct)
+	if err != nil {
+		log.Errorf("Failed to unmarshal data, %s", err.Error())
+		return nil, err
+	}
+
+	return retStruct, nil
+}

--- a/pkg/pillar/utils/deserialize_test.go
+++ b/pkg/pillar/utils/deserialize_test.go
@@ -1,0 +1,262 @@
+package utils
+
+import (
+	"encoding/json"
+	"os"
+	"reflect"
+	"testing"
+)
+
+type TestStruct struct {
+	Field1 string `mandatory:"true"`
+	Field2 int
+}
+
+func TestDeserializeToStruct(t *testing.T) {
+	testSimpleStruct(t)
+	testErrorConditions(t)
+	testMandatoryFieldLogic(t)
+	testExtraFieldInFile(t)
+	testMissingNonMandatoryFieldInFile(t)
+	testStructWithAnonymousField(t)
+	testNestedStructs(t)
+	testArrayOfStructs(t)
+	testAnonymousStructs(t)
+}
+
+func testSimpleStruct(t *testing.T) {
+	t.Log("Testing simple struct...")
+	tmpfile, testObject := createTempFileWithObject(t, TestStruct{
+		Field1: "test",
+		Field2: 123,
+	})
+	defer os.Remove(tmpfile.Name()) // clean up
+
+	var result TestStruct
+	err := DeserializeToStruct(tmpfile.Name(), &result)
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	if result != testObject {
+		t.Errorf("expected %v, got %v", testObject, result)
+	} else {
+		t.Log("Success: simple struct")
+	}
+}
+
+func testErrorConditions(t *testing.T) {
+	t.Log("Testing error conditions...")
+	var result TestStruct
+	err := DeserializeToStruct("nonexistentfile", &result)
+	if err == nil {
+		t.Errorf("expected error, got nil")
+	} else {
+		t.Log("Success: nonexistent file")
+	}
+	err = DeserializeToStruct("", result) // not a pointer
+	if err == nil {
+		t.Errorf("expected error, got nil")
+	} else {
+		t.Log("Success: non-pointer argument")
+	}
+	err = DeserializeToStruct("", &[]TestStruct{}) // not a struct
+	if err == nil {
+		t.Errorf("expected error, got nil")
+	} else {
+		t.Log("Success: non-struct argument")
+	}
+}
+
+func testMandatoryFieldLogic(t *testing.T) {
+	t.Log("Testing mandatory field logic...")
+	tmpfile, _ := createTempFileWithObject(t, struct {
+		Field2 int
+	}{
+		Field2: 123,
+	})
+	defer os.Remove(tmpfile.Name()) // clean up
+
+	var result TestStruct
+	err := DeserializeToStruct(tmpfile.Name(), &result)
+	if err == nil {
+		t.Errorf("expected error due to missing mandatory field, got nil")
+	} else {
+		t.Log("Success: missing mandatory field")
+	}
+}
+
+func testExtraFieldInFile(t *testing.T) {
+	t.Log("Testing extra field in file...")
+	tmpfile, _ := createTempFileWithObject(t, struct {
+		Field1 string `mandatory:"true"`
+		Field2 int
+		Field3 string
+	}{
+		Field1: "test",
+		Field2: 123,
+		Field3: "extra",
+	})
+	defer os.Remove(tmpfile.Name()) // clean up
+
+	var result TestStruct
+	err := DeserializeToStruct(tmpfile.Name(), &result)
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	} else {
+		t.Log("Success: extra field in file")
+	}
+}
+
+func testMissingNonMandatoryFieldInFile(t *testing.T) {
+	t.Log("Testing missing non-mandatory field in file...")
+	tmpfile, _ := createTempFileWithObject(t, struct {
+		Field1 string `mandatory:"true"`
+	}{
+		Field1: "test",
+	})
+	defer os.Remove(tmpfile.Name()) // clean up
+
+	var result TestStruct
+	err := DeserializeToStruct(tmpfile.Name(), &result)
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	} else {
+		t.Log("Success: missing non-mandatory field in file")
+	}
+}
+
+func testStructWithAnonymousField(t *testing.T) {
+	t.Log("Testing struct with anonymous field...")
+	type TestStructWithAnonymous struct {
+		TestStruct
+		Field3 string
+	}
+	tmpfile, _ := createTempFileWithObject(t, TestStructWithAnonymous{
+		TestStruct: TestStruct{
+			Field1: "test",
+			Field2: 123,
+		},
+		Field3: "extra",
+	})
+	defer os.Remove(tmpfile.Name()) // clean up
+
+	var result TestStructWithAnonymous
+	err := DeserializeToStruct(tmpfile.Name(), &result)
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	} else {
+		t.Log("Success: struct with anonymous field")
+	}
+}
+
+func testNestedStructs(t *testing.T) {
+	t.Log("Testing nested structs...")
+	type NestedStruct struct {
+		Field1 string `mandatory:"true"`
+		Field2 int
+	}
+	type TestStructWithNested struct {
+		Field1 string `mandatory:"true"`
+		Field2 NestedStruct
+	}
+	tmpfile, testObject := createTempFileWithObject(t, TestStructWithNested{
+		Field1: "test",
+		Field2: NestedStruct{
+			Field1: "nested",
+			Field2: 456,
+		},
+	})
+	defer os.Remove(tmpfile.Name()) // clean up
+
+	var result TestStructWithNested
+	err := DeserializeToStruct(tmpfile.Name(), &result)
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	} else {
+		t.Log("Success: nested structs")
+	}
+	if result != testObject {
+		t.Errorf("expected %v, got %v", testObject, result)
+	}
+}
+
+func testArrayOfStructs(t *testing.T) {
+	t.Log("Testing array of structs...")
+	type ArrayElementStruct struct {
+		Field1 string `mandatory:"true"`
+		Field2 int
+	}
+	type TestStructWithArray struct {
+		Field1 string `mandatory:"true"`
+		Field2 []ArrayElementStruct
+	}
+	tmpfile, testObject := createTempFileWithObject(t, TestStructWithArray{
+		Field1: "test",
+		Field2: []ArrayElementStruct{
+			{
+				Field1: "element1",
+				Field2: 456,
+			},
+			{
+				Field1: "element2",
+				Field2: 789,
+			},
+		},
+	})
+	defer os.Remove(tmpfile.Name()) // clean up
+
+	var result TestStructWithArray
+	err := DeserializeToStruct(tmpfile.Name(), &result)
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	} else {
+		t.Log("Success: array of structs")
+	}
+	if !reflect.DeepEqual(result, testObject) {
+		t.Errorf("expected %v, got %v", testObject, result)
+	}
+}
+
+func testAnonymousStructs(t *testing.T) {
+	t.Log("Testing anonymous structs...")
+	tmpfile, testObject := createTempFileWithObject(t, struct {
+		Field1 string `mandatory:"true"`
+		Field2 int
+	}{
+		Field1: "test",
+		Field2: 123,
+	})
+	defer os.Remove(tmpfile.Name()) // clean up
+
+	var result struct {
+		Field1 string `mandatory:"true"`
+		Field2 int
+	}
+	err := DeserializeToStruct(tmpfile.Name(), &result)
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	} else {
+		t.Log("Success: anonymous structs")
+	}
+	if result != testObject {
+		t.Errorf("expected %v, got %v", testObject, result)
+	}
+}
+
+func createTempFileWithObject(t *testing.T, object interface{}) (tmpfile *os.File, testObject interface{}) {
+	tmpfile, err := os.CreateTemp("", "example")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(object)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tmpfile.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return tmpfile, object
+}

--- a/pkg/pillar/utils/generics/generics.go
+++ b/pkg/pillar/utils/generics/generics.go
@@ -3,6 +3,8 @@
 
 package generics
 
+import "reflect"
+
 // EqualLists returns true if the two slices representing lists (i.e. order dependent)
 // are equal in size and items they contain.
 // This function can be used if slice items are comparable
@@ -160,4 +162,20 @@ func ContainsItemFn[Type any](list []Type, item Type, equal func(a, b Type) bool
 		}
 	}
 	return false
+}
+
+// ExtractFields extracts all fields from the given type and its anonymous fields
+// and adds them to the given map. This can be used for a careful deserialization.
+func ExtractFields(t reflect.Type, fieldMap *map[string]bool) {
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+
+		if field.Anonymous {
+			// If this is an anonymous field, recursively extract its fields as well.
+			ExtractFields(field.Type, fieldMap)
+		} else {
+			// This is a normal field, so just add its name to the map.
+			(*fieldMap)[field.Name] = true
+		}
+	}
 }

--- a/pkg/pillar/utils/generics/generics.go
+++ b/pkg/pillar/utils/generics/generics.go
@@ -3,8 +3,6 @@
 
 package generics
 
-import "reflect"
-
 // EqualLists returns true if the two slices representing lists (i.e. order dependent)
 // are equal in size and items they contain.
 // This function can be used if slice items are comparable
@@ -162,20 +160,4 @@ func ContainsItemFn[Type any](list []Type, item Type, equal func(a, b Type) bool
 		}
 	}
 	return false
-}
-
-// ExtractFields extracts all fields from the given type and its anonymous fields
-// and adds them to the given map. This can be used for a careful deserialization.
-func ExtractFields(t reflect.Type, fieldMap *map[string]bool) {
-	for i := 0; i < t.NumField(); i++ {
-		field := t.Field(i)
-
-		if field.Anonymous {
-			// If this is an anonymous field, recursively extract its fields as well.
-			ExtractFields(field.Type, fieldMap)
-		} else {
-			// This is a normal field, so just add its name to the map.
-			(*fieldMap)[field.Name] = true
-		}
-	}
 }


### PR DESCRIPTION
This pull request introduces significant changes to handling volume snapshots in the system with the primary goal of enabling rollback functionality after a system reboot without requiring persistent subscriptions. Additionally, serialization and deserialization have been implemented in a way that allows the serialized data to survive EVE upgrades, even if the data format undergoes changes.

The key changes in this PR include:

Reworked snapshot configuration handlers in volumemgr.go to improve their functionality and code organization. The new handlers (handleVolumesSnapshotConfigCreate, handleVolumesSnapshotConfigModify, and handleVolumesSnapshotConfigDelete) now call a common implementation function (handleVolumesSnapshotConfigImpl).

Significant rework of functions in handlesnapshot.go such as handleVolumesSnapshotCreate, handleVolumesSnapshotModify, and handleVolumesSnapshotDelete. These functions now call handleVolumesSnapshotConfigImpl with the appropriate action set in the snapshot config. The new functions (createSnapshot, rollbackSnapshot, and deleteSnapshot) have been introduced to handle the respective actions.

Updates to existing functions (publishVolumesSnapshotStatus, unpublishVolumesSnapshotStatus, and lookupVolumesSnapshotStatus) to improve their functionality and handle snapshot status more effectively. A new function (deserializeVolumesSnapshotStatus) has been introduced to read the snapshot status from a file, allowing rollback after system reboot.

Improvements in the rollback process within the Zedmanager's updatestatus module. Instead of restoring VolumeRefStatuses and AppInstanceConfig from a snapshot, the function now creates or updates a VolumesSnapshotConfig to indicate a rollback action. This change simplifies the rollback process and makes it more resilient to system reboots.

Various code refactoring, cleanup, and optimization changes throughout the codebase to improve clarity, readability, and maintainability.