### PR TITLE
assets.yml: use actual release tag

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -32,6 +32,15 @@ jobs:
       matrix:
         arch: [amd64, arm64]
     steps:
+      - name: checkout repo
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0
+      - name: Force fetch annotated tags (workaround)
+        # Workaround for https://github.com/actions/checkout/issues/290
+        run: |
+          git fetch --force --tags
       - name: Determine architecture prefix and ref
         env:
           REF: ${{ github.event.workflow_run.head_branch }}
@@ -43,11 +52,7 @@ jobs:
           # if the default server is responding -- we can skip apt update
           $APT_INSTALL || { sudo apt update && $APT_INSTALL ; }
           echo "ARCH=${{ matrix.arch }}" >> "$GITHUB_ENV"
-          echo "TAG=$(echo "$REF" | sed -e 's#^.*/##' -e 's#master#snapshot#' -e 's#main#snapshot#')" >> "$GITHUB_ENV"
-      - name: checkout repo
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+          echo "TAG=$(git describe --always --tags | grep -E '[0-9]*\.[0-9]*\.[0-9]*' || echo snapshot) >> "$GITHUB_ENV"
       - name: ensure clean assets dir
         run : |
           rm -rf assets && mkdir -p assets


### PR DESCRIPTION
This changes the TAG variable from being the branch to the actual tag e.g., 10.1 vs. 10.1.0, which is needed so we can pull the correct container from docker hub.

Note that I do not understand how the assets worked in 10.0.0 since that one worked. Hasn't worked in 10.1.0 and 10.2.0. Also I have no idea how one can sanity test this. Ideas?