### PR TITLE
domainmgr needs to wait on Xen boot

### DIFF
--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -632,12 +632,12 @@ func (ctx xenContext) GetHostCPUMem() (types.HostMemory, error) {
 	xlInfo, stderr, err := ctx.ctrdClient.CtrSystemExec(ctrdSystemCtx, "xen-tools",
 		[]string{"xl", "info"})
 	if err != nil {
-		return hm, fmt.Errorf("xl info failed stdout: %s stderr: %s, err: %v falling back on Dom0 stats",
+		return hm, fmt.Errorf("xl info failed stdout: %s stderr: %s, err: %v",
 			xlInfo, stderr, err)
 	}
 	// Seems like we can get empty output, or partial output, from xl info
 	if xlInfo == "" {
-		return hm, fmt.Errorf("xl info empty stderr: %s falling back on Dom0 stats",
+		return hm, fmt.Errorf("xl info empty stdout, stderr: %s",
 			stderr)
 	}
 	splitXlInfo := strings.Split(xlInfo, "\n")


### PR DESCRIPTION
On Xen we use xl info on boot, which might return empty output early after boot. So we wait to avoid a fatal "xl info empty stderr: falling back on Dom0 stats". Also, there is no falling back so correcting the error messages.