### PR TITLE
Netdump enhancements

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -52,6 +52,7 @@
 | netdump.topic.postonboard.interval | integer in seconds | 1 day | how frequently (in seconds) can be netdumps of the same topic published after device has been onboarded |
 | netdump.topic.maxcount | integer | 10 | maximum number of netdumps that can be published for each topic. The oldest netdump is unpublished should a new netdump exceed the limit.
 | netdump.downloader.with.pcap | boolean | false | include packet captures inside netdumps for download requests. However, even if enabled, TCP segments carrying non-empty payload (i.e. content which is being downloaded) are excluded and the overall PCAP size is limited to 64MB. |
+| netdump.downloader.http.with.fieldvalue | boolean | false | include HTTP header field values in captured network traces for download requests (beware: may contain secrets, such as datastore credentials). |
 | network.switch.enable.arpsnoop | boolean | true | enable ARP Snooping on switch Network Instance, may need a device reboot to take effect |
 
 In addition, there can be per-agent settings.

--- a/pkg/pillar/cmd/downloader/context.go
+++ b/pkg/pillar/cmd/downloader/context.go
@@ -36,6 +36,7 @@ type downloaderContext struct {
 	downloadMaxPortCost      uint8
 	netDumper                *netdump.NetDumper // nil if netdump is disabled
 	netdumpWithPCAP          bool
+	netdumpWithHdrFieldVal   bool
 	// cli options
 	versionPtr *bool
 }

--- a/pkg/pillar/cmd/downloader/globalconfig.go
+++ b/pkg/pillar/cmd/downloader/globalconfig.go
@@ -77,5 +77,7 @@ func reinitNetdumper(ctx *downloaderContext) {
 		netDumper = nil
 	}
 	ctx.netdumpWithPCAP = gcp.GlobalValueBool(types.NetDumpDownloaderPCAP)
+	ctx.netdumpWithHdrFieldVal = gcp.GlobalValueBool(
+		types.NetDumpDownloaderHTTPWithFieldValue)
 	ctx.netDumper = netDumper
 }

--- a/pkg/pillar/cmd/downloader/syncop.go
+++ b/pkg/pillar/cmd/downloader/syncop.go
@@ -201,6 +201,13 @@ func handleSyncOp(ctx *downloaderContext, key string,
 	withNetTracing := ctx.netDumper != nil && !dsLocal && trType != zedUpload.SyncSftpTr
 	var traceOpts []nettrace.TraceOpt
 	if withNetTracing {
+		// Include HTTP header field values only if explicitly enabled.
+		// By default, we record only the length of values.
+		// May contain secrets (e.g. datastore credentials).
+		headerFieldsOpt := nettrace.HdrFieldsOptValueLenOnly
+		if ctx.netdumpWithHdrFieldVal {
+			headerFieldsOpt = nettrace.HdrFieldsOptWithValues
+		}
 		// Avoid socket trace for download. Otherwise, it would increase
 		// the size of the resulting netdump considerably.
 		traceOpts = []nettrace.TraceOpt{
@@ -210,9 +217,7 @@ func handleSyncOp(ctx *downloaderContext, key string,
 			&nettrace.WithConntrack{},
 			&nettrace.WithDNSQueryTrace{},
 			&nettrace.WithHTTPReqTrace{
-				// Do not disclose sensitive data stored inside headers,
-				// record only their length.
-				HeaderFields: nettrace.HdrFieldsOptValueLenOnly,
+				HeaderFields: headerFieldsOpt,
 			},
 		}
 		if ctx.netdumpWithPCAP {

--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -1147,11 +1147,7 @@ func isUpdating(ctx *zedagentContext) bool {
 // Function decides if the next call to SendOnAllIntf for /info request should be traced
 // and netdump published at the end (see libs/nettrace and pkg/pillar/netdump).
 func traceNextInfoReq(ctx *zedagentContext) bool {
-	if !isNettraceEnabled(ctx) {
-		return false
-	}
-	return ctx.lastInfoNetdumpPub.IsZero() ||
-		time.Since(ctx.lastInfoNetdumpPub) >= ctx.netdumpInterval
+	return traceNextReq(ctx, ctx.lastInfoNetdumpPub)
 }
 
 // Publish netdump containing traces of executed /info requests.

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -219,6 +219,7 @@ type zedagentContext struct {
 	netdumpInterval      time.Duration
 	lastConfigNetdumpPub time.Time // last call to publishConfigNetdump
 	lastInfoNetdumpPub   time.Time // last call to publishInfoNetdump
+	startTime            time.Time
 }
 
 // AddAgentSpecificCLIFlags adds CLI options
@@ -315,6 +316,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	zedagentCtx.ps = ps
 	zedagentCtx.hangFlag = *zedagentCtx.hangPtr
 	zedagentCtx.fatalFlag = *zedagentCtx.fatalPtr
+	zedagentCtx.startTime = time.Now()
 
 	flowlogQueue := make(chan *flowlog.FlowMessage, flowlogQueueCap)
 	triggerDeviceInfo := make(chan destinationBitset, 1)

--- a/pkg/pillar/dpcmanager/dpcmanager.go
+++ b/pkg/pillar/dpcmanager/dpcmanager.go
@@ -129,6 +129,7 @@ type DpcManager struct {
 	netDumper       *netdump.NetDumper // nil if netdump is disabled
 	netdumpInterval time.Duration
 	lastNetdumpPub  time.Time // last call to publishNetdump
+	startTime       time.Time
 }
 
 // Watchdog : methods used by DpcManager to interact with Watchdog.
@@ -238,6 +239,7 @@ func (m *DpcManager) Init(ctx context.Context) error {
 
 // Run DpcManager as a separate task with its own loop and a watchdog file.
 func (m *DpcManager) Run(ctx context.Context) (err error) {
+	m.startTime = time.Now()
 	m.networkEvents = m.NetworkMonitor.WatchEvents(ctx, "dpc-reconciler")
 	m.wwanEvents, err = m.WwanWatcher.Watch(ctx)
 	if err != nil {

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -283,6 +283,10 @@ const (
 	// download requests. However, even if enabled, TCP segments carrying non-empty payload
 	// (i.e. content which is being downloaded) are excluded.
 	NetDumpDownloaderPCAP GlobalSettingKey = "netdump.downloader.with.pcap"
+	// NetDumpDownloaderHTTPWithFieldValue : Enable to include HTTP header field values in captured
+	// network traces for download requests.
+	// Beware: may contain secrets, such as datastore credentials.
+	NetDumpDownloaderHTTPWithFieldValue GlobalSettingKey = "netdump.downloader.http.with.fieldvalue"
 )
 
 // AgentSettingKey - keys for per-agent settings
@@ -878,6 +882,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddIntItem(NetDumpTopicPostOnboardInterval, 24*HourInSec, 60, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(NetDumpTopicMaxCount, 10, 1, 0xFFFFFFFF)
 	configItemSpecMap.AddBoolItem(NetDumpDownloaderPCAP, false)
+	configItemSpecMap.AddBoolItem(NetDumpDownloaderHTTPWithFieldValue, false)
 	return configItemSpecMap
 }
 

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -203,6 +203,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		NetDumpTopicPreOnboardInterval,
 		NetDumpTopicPostOnboardInterval,
 		NetDumpDownloaderPCAP,
+		NetDumpDownloaderHTTPWithFieldValue,
 	}
 	if len(specMap.GlobalSettings) != len(gsKeys) {
 		t.Errorf("GlobalSettings has more (%d) than expected keys (%d)",


### PR DESCRIPTION
Two small commits with netdump enhancements that could be useful for troubleshooting of customer issues.

 **netdump: Add option to capture HTTP field values for download requests**
This can be useful to troubleshoot download failures caused by MITM
changing the HTTP header fields (proxy, CDN, etc.).
The option is disabled by default becase HTTP header field values may contain
sensitive information, such as datastore credentials.

**Ensure we get at least one netdump in each topic for tested EVE upgrade**
If upgrade fails, the recorded netdumps will remain persisted and
available for retrieval from the older EVE version.