### PR TITLE
mkinitfs update to Alpine 3.8

### DIFF
--- a/pkg/alpine/Dockerfile
+++ b/pkg/alpine/Dockerfile
@@ -36,6 +36,7 @@ RUN for repo in main community testing; do \
 
 # set the default repository to use
 RUN cp /mirror/${ALPINE_VERSION}/rootfs/etc/apk/repositories /etc/apk
+RUN cat /mirror/3.18/rootfs/etc/apk/repositories >> /etc/apk/repositories
 RUN cat /mirror/edge/rootfs/etc/apk/repositories >> /etc/apk/repositories
 RUN apk update
 

--- a/pkg/alpine/mirrors/3.16/main
+++ b/pkg/alpine/mirrors/3.16/main
@@ -125,7 +125,6 @@ lz4-libs
 lzo-dev
 m4
 make
-mkinitfs
 mpc1-dev
 mpfr-dev
 mtools

--- a/pkg/alpine/mirrors/3.18/main
+++ b/pkg/alpine/mirrors/3.18/main
@@ -1,0 +1,1 @@
+mkinitfs


### PR DESCRIPTION
Some Supermicro servers have a lot of PCIe devices and during EVE startup the kernel uevent buffer in nlplug-findfs overflows and the installation/eve startup fails. These patches address this problem by bumping up version of mkinitfs package to 3.18 that has updated nlplug-findfs that has 4Mb allocated instead of 512kb for the uevent buffer. There is also uevent_buf_size kernel command line parameter that can be set in grub.cfg if even bigger buffer is required

**NOTE:** This is the first PR to get an updated hash for eve-alpine package

NOTE: these changes are not yet tested on real HW because it is currently in use