### PR TITLE
Add activation interlock for baseOS configuration changes

### DIFF
--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -191,7 +191,7 @@ const (
 	invalidConfig                           // config is not valid (cannot be parsed, UUID mismatch, bad signature, etc.)
 	skipConfigReboot                        // reboot or shutdown flag is set
 	skipConfigUpdate                        // update flag is set
-	defferConfig                            // not ready to process config yet
+	deferConfig                             // not ready to process config yet
 )
 
 func (r configProcessingRetval) isSkip() bool {
@@ -212,8 +212,8 @@ func (r configProcessingRetval) String() string {
 		return "skipConfigReboot"
 	case skipConfigUpdate:
 		return "skipConfigUpdate"
-	case defferConfig:
-		return "defferConfig"
+	case deferConfig:
+		return "deferConfig"
 	}
 	return "<invalid>"
 }
@@ -507,7 +507,7 @@ func requestConfigByURL(getconfigCtx *getconfigContext, url string,
 	if getconfigCtx.zedagentCtx.bootReason == types.BootReasonFirst &&
 		!getconfigCtx.zedagentCtx.publishedEdgeNodeCerts {
 		log.Noticef("Defer fetching config until our EdgeNodeCerts have been published")
-		return defferConfig, nil
+		return deferConfig, nil
 	}
 	ctx := getconfigCtx.zedagentCtx
 	const bailOnHTTPErr = false // For 4xx and 5xx HTTP errors we try other interfaces
@@ -1140,7 +1140,7 @@ func publishConfigNetdump(ctx *zedagentContext,
 	switch configRV {
 	case configOK:
 		topic = netDumpConfigOKTopic
-	case defferConfig:
+	case deferConfig:
 		// There was no actual /config request so there is nothing interesting to publish.
 		return
 	default:

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -198,6 +198,26 @@ func (r configProcessingRetval) isSkip() bool {
 	return r == skipConfigReboot || r == skipConfigUpdate
 }
 
+func (r configProcessingRetval) String() string {
+	switch r {
+	case configOK:
+		return "configOK"
+	case configReqFailed:
+		return "configReqFailed"
+	case obsoleteConfig:
+		return "obsoleteConfig"
+	case invalidConfig:
+		return "invalidConfig"
+	case skipConfigReboot:
+		return "skipConfigReboot"
+	case skipConfigUpdate:
+		return "skipConfigUpdate"
+	case defferConfig:
+		return "defferConfig"
+	}
+	return "<invalid>"
+}
+
 // Load bootstrap config provided that:
 //   - it exists
 //   - has not been loaded before (incl. previous device boots)
@@ -422,8 +442,8 @@ func configTimerTask(getconfigCtx *getconfigContext, handleChannel chan interfac
 				warningTime, errorTime)
 
 		case <-stillRunning.C:
-			if getconfigCtx.configProcessingRV.isSkip() {
-				log.Noticef("config processing skip flag set")
+			if getconfigCtx.configProcessingRV != configOK {
+				log.Noticef("config processing flag is not OK: %s", getconfigCtx.configProcessingRV)
 			}
 		}
 		ctx.ps.StillRunning(wdName, warningTime, errorTime)

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -177,18 +177,21 @@ type zedagentContext struct {
 	//  This is the value of counter that triggered reboot. This is sent in
 	//  device info msg. Can be used to verify device is caught up on all
 	// outstanding reboot commands from cloud.
-	rebootConfigCounter     uint32
-	shutdownConfigCounter   uint32
-	subDevicePortConfigList pubsub.Subscription
-	DevicePortConfigList    *types.DevicePortConfigList
-	remainingTestTime       time.Duration
-	physicalIoAdapterMap    map[string]types.PhysicalIOAdapter
-	globalConfig            types.ConfigItemValueMap
-	globalConfigPublished   bool // was last globalConfig successfully published
-	specMap                 types.ConfigItemSpecMap
-	globalStatus            types.GlobalStatus
-	flowLogMetrics          types.FlowlogMetrics
-	appContainerStatsTime   time.Time // last time the App Container stats uploaded
+	rebootConfigCounter   uint32
+	shutdownConfigCounter uint32
+	// Part of the fields above (the reboot ones) are initialized only once the NodeAgent status is received
+	// This flag is used to make sure we initialize them before continuing with the rest of the agent's initialization
+	initializedFromNodeAgentStatus bool
+	subDevicePortConfigList        pubsub.Subscription
+	DevicePortConfigList           *types.DevicePortConfigList
+	remainingTestTime              time.Duration
+	physicalIoAdapterMap           map[string]types.PhysicalIOAdapter
+	globalConfig                   types.ConfigItemValueMap
+	globalConfigPublished          bool // was last globalConfig successfully published
+	specMap                        types.ConfigItemSpecMap
+	globalStatus                   types.GlobalStatus
+	flowLogMetrics                 types.FlowlogMetrics
+	appContainerStatsTime          time.Time // last time the App Container stats uploaded
 	// The MaintenanceMode can come from GlobalConfig and from the config
 	// API. Those are merged into maintenanceMode
 	// TBD will be also decide locally to go into maintenanceMode based
@@ -430,6 +433,11 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	// With device UUID, zedagent is ready to initialize and activate all subscriptions.
 	initPostOnboardSubs(zedagentCtx)
 
+	// Wait until we initialize the context from node agent status.
+	// At least we need to be sure the bootReason field is set properly, as it's used during fetching local config,
+	// when it's necessary (necessary or not is determined exactly by the bootReason).
+	waitUntilInitializedFromNodeAgentStatus(zedagentCtx, stillRunning)
+
 	//initialize cipher processing block
 	cipherModuleInitialize(zedagentCtx)
 
@@ -517,6 +525,19 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	// Enter main zedagent event loop.
 	mainEventLoop(zedagentCtx, stillRunning) // never exits
 	return 0
+}
+
+func waitUntilInitializedFromNodeAgentStatus(ctx *zedagentContext, running *time.Ticker) {
+	log.Functionf("waitUntilInitializedFromNodeAgentStatus()")
+	for !ctx.initializedFromNodeAgentStatus {
+		select {
+		case change := <-ctx.getconfigCtx.subNodeAgentStatus.MsgChan():
+			ctx.getconfigCtx.subNodeAgentStatus.ProcessChange(change)
+		case <-running.C:
+		}
+		ctx.ps.StillRunning(agentName, warningTime, errorTime)
+	}
+	log.Functionf("waitUntilInitializedFromNodeAgentStatus() done")
 }
 
 func (zedagentCtx *zedagentContext) init() {
@@ -2326,6 +2347,8 @@ func handleNodeAgentStatusImpl(ctxArg interface{}, key string,
 	ctx.bootReason = status.BootReason
 	ctx.restartCounter = status.RestartCounter
 	ctx.allDomainsHalted = status.AllDomainsHalted
+	// Mark that we have received the NodeAgentStatus and initialized the context properly
+	ctx.initializedFromNodeAgentStatus = true
 	// if config reboot command was initiated and
 	// was deferred, and the device is not in inprogress
 	// state, initiate the reboot process


### PR DESCRIPTION
This pull request is a Work In Progress (WIP) to discuss a proposed approach for handling baseOS configuration changes. This solution adds an activation interlock to prevent app instance configuration changes from being processed if a baseOS configuration change has been detected.

The proposed changes include:

* Modifying the parseBaseOS function to return a flag indicating whether a new baseOS needs to be activated.
* Checking the returned flag in the parseConfig function to determine whether the rest of the configuration parsing should be skipped.
* This configuration parsing skip applies only when the source is from the controller and not during the first parseConfig call after the device boot.

Please note that this solution may not handle cases where a purge operation starts and then a baseOS update or reboot is initiated shortly after. However, it should handle cases where the device receives both a purge command and a baseOS update at the same time.

I would appreciate any feedback or suggestions on the proposed changes. Please note that this PR is not ready for merging as the changes are still under review and testing.