### PR TITLE
Reconciler: improvements for processing of async operations

### DIFF
--- a/libs/reconciler/README.md
+++ b/libs/reconciler/README.md
@@ -369,9 +369,9 @@ type MyAgent struct {
      registry       reconciler.ConfiguratorRegistry
 
      // To manage asynchronous operations.
-     resumeReconciliation <-chan struct{}     // nil if no async ops
-     cancelAsyncOps       context.CancelFunc  // nil if no async ops
-     waitForAsyncOps      func()              // NOOP if no async ops
+     resumeReconciliation <-chan struct{}        // nil if no async ops
+     cancelAsyncOps       reconciler.CancelFunc  // nil if no async ops
+     waitForAsyncOps      func()                 // NOOP if no async ops
 }
 
 func (a *MyAgent) main() {
@@ -395,7 +395,7 @@ func (a *MyAgent) main() {
                case <- event2:
                     // If you need to cancel all asynchronous operations, run:
                     if a.cancelAsyncOps != nil {
-                         a.cancelAsyncOps()
+                         a.cancelAsyncOps(nil)
                          a.waitForAsyncOps()
                          fmt.Println("Asynchronous operations were canceled!")
                     }

--- a/libs/reconciler/async.go
+++ b/libs/reconciler/async.go
@@ -61,12 +61,14 @@ func (c *asyncManager) reconcileEnds() (anyAsyncOps bool, resumeChan <-chan stri
 	return false, nil
 }
 
-func (c *asyncManager) cancelOps() {
+func (c *asyncManager) cancelOps(cancelForItem func(ref dg.ItemRef) bool) {
 	c.Lock()
 	defer c.Unlock()
 	for _, asyncOp := range c.asyncOps {
-		cancel := asyncOp.params.cancel
-		if cancel != nil {
+		if cancelForItem != nil && !cancelForItem(asyncOp.params.itemRef) {
+			continue
+		}
+		if cancel := asyncOp.params.cancel; cancel != nil {
 			cancel()
 			asyncOp.status.cancelTime = time.Now()
 		}

--- a/libs/reconciler/reconciler_test.go
+++ b/libs/reconciler/reconciler_test.go
@@ -2228,6 +2228,326 @@ func TestAsyncOperations(test *testing.T) {
 	t.Expect(stateData.State).To(Equal(rec.ItemStateCreated))
 }
 
+// Items: A, B, C, D
+// Dependencies: A->B->C
+// Scenario: Asynchronous operations with failures.
+func TestAsyncFailures(test *testing.T) {
+	t := NewGomegaWithT(test)
+
+	itemA := mockItem{
+		name:     "A",
+		itemType: "type1",
+		deps: []dg.Dependency{
+			{
+				RequiredItem: dg.ItemRef{
+					ItemType: "type1",
+					ItemName: "B",
+				},
+			},
+		},
+	}
+	itemB := mockItem{
+		name:     "B",
+		itemType: "type1",
+		deps: []dg.Dependency{
+			{
+				RequiredItem: dg.ItemRef{
+					ItemType: "type2",
+					ItemName: "C",
+				},
+			},
+		},
+	}
+	itemC := mockItem{
+		name:     "C",
+		itemType: "type2",
+	}
+
+	itemD := mockItem{
+		name:     "D",
+		itemType: "type2",
+	}
+
+	reg := &rec.DefaultRegistry{}
+	t.Expect(addConfigurator(reg, "type1")).To(Succeed())
+	t.Expect(addConfigurator(reg, "type2")).To(Succeed())
+
+	// 1. itemB and itemD will fail to be created asynchronously
+	itemB.failToCreate = true
+	itemB.asyncCreate = true
+	itemD.failToCreate = true
+	itemD.asyncCreate = true
+	itemA.failToCreate = true // prepare for scenario 4.
+	itemA.asyncCreate = true
+	intent := dg.New(dg.InitArgs{
+		Name:        "TestGraph",
+		Description: "Graph for testing",
+		Items: []dg.Item{
+			itemA, itemB, itemC, itemD,
+		},
+	})
+
+	r := rec.New(reg)
+	status = r.Reconcile(context.Background(), nil, intent)
+	t.Expect(status.Err).To(BeNil())
+	t.Expect(status.AsyncOpsInProgress).To(BeTrue())
+	t.Expect(status.ReadyToResume).ToNot(BeNil())
+	t.Expect(itemA).ToNot(BeCreated())
+	t.Expect(itemB).To(BeingCreated().After(itemC).IsCreated())
+	t.Expect(itemC).To(BeCreated())
+	t.Expect(itemD).To(BeingCreated())
+	t.Expect(status.OperationLog).To(HaveLen(3))
+	t.Expect(status.NewCurrentState).ToNot(BeNil())
+	current := status.NewCurrentState
+
+	_, _, _, exists := current.Item(dg.Reference(itemA))
+	t.Expect(exists).To(BeFalse())
+
+	item, state, path, exists := current.Item(dg.Reference(itemB))
+	t.Expect(exists).To(BeTrue())
+	t.Expect(path.Len()).To(BeZero())
+	t.Expect(item).To(BeMockItem(itemB))
+	stateData := state.(*rec.ItemStateData)
+	t.Expect(stateData).ToNot(BeNil())
+	t.Expect(stateData.LastOperation).To(Equal(rec.OperationUnknown))
+	t.Expect(stateData.LastError).To(BeNil())
+	t.Expect(stateData.State).To(Equal(rec.ItemStateCreating))
+
+	item, state, path, exists = current.Item(dg.Reference(itemC))
+	t.Expect(exists).To(BeTrue())
+	t.Expect(path.Len()).To(BeZero())
+	t.Expect(item).To(BeMockItem(itemC))
+	stateData = state.(*rec.ItemStateData)
+	t.Expect(stateData).ToNot(BeNil())
+	t.Expect(stateData.LastOperation).To(Equal(rec.OperationCreate))
+	t.Expect(stateData.LastError).To(BeNil())
+	t.Expect(stateData.State).To(Equal(rec.ItemStateCreated))
+
+	item, state, path, exists = current.Item(dg.Reference(itemD))
+	t.Expect(exists).To(BeTrue())
+	t.Expect(path.Len()).To(BeZero())
+	t.Expect(item).To(BeMockItem(itemD))
+	stateData = state.(*rec.ItemStateData)
+	t.Expect(stateData).ToNot(BeNil())
+	t.Expect(stateData.LastOperation).To(Equal(rec.OperationUnknown))
+	t.Expect(stateData.LastError).To(BeNil())
+	t.Expect(stateData.State).To(Equal(rec.ItemStateCreating))
+
+	waitForAsyncOps(t, 2)
+
+	// 2. Resume reconciliation now that Create() for itemB and itemD finalized (with errors)
+	r = rec.New(reg)
+	status = r.Reconcile(context.Background(), current, intent)
+	t.Expect(status.Err).ToNot(BeNil())
+	t.Expect(status.AsyncOpsInProgress).To(BeFalse())
+	t.Expect(itemA).ToNot(BeCreated())
+	t.Expect(itemB).To(BeCreated().WithError("failed to create"))
+	t.Expect(itemD).To(BeCreated().WithError("failed to create"))
+	t.Expect(status.OperationLog).To(HaveLen(2))
+	t.Expect(status.NewCurrentState).To(BeIdenticalTo(current))
+
+	_, _, _, exists = current.Item(dg.Reference(itemA))
+	t.Expect(exists).To(BeFalse())
+
+	item, state, path, exists = current.Item(dg.Reference(itemB))
+	t.Expect(exists).To(BeTrue())
+	t.Expect(path.Len()).To(BeZero())
+	t.Expect(item).To(BeMockItem(itemB))
+	stateData = state.(*rec.ItemStateData)
+	t.Expect(stateData).ToNot(BeNil())
+	t.Expect(stateData.LastOperation).To(Equal(rec.OperationCreate))
+	t.Expect(stateData.LastError).To(MatchError("failed to create"))
+	t.Expect(stateData.State).To(Equal(rec.ItemStateFailure))
+
+	item, state, path, exists = current.Item(dg.Reference(itemD))
+	t.Expect(exists).To(BeTrue())
+	t.Expect(path.Len()).To(BeZero())
+	t.Expect(item).To(BeMockItem(itemD))
+	stateData = state.(*rec.ItemStateData)
+	t.Expect(stateData).ToNot(BeNil())
+	t.Expect(stateData.LastOperation).To(Equal(rec.OperationCreate))
+	t.Expect(stateData.LastError).To(MatchError("failed to create"))
+	t.Expect(stateData.State).To(Equal(rec.ItemStateFailure))
+
+	// 2. Next attempt to create itemB is successful and create for A starts
+	itemB.failToCreate = false
+	itemB.failToDelete = true // prepare for scenario 7.
+	itemB.asyncDelete = true
+	itemB.modifiableAttrs.boolAttr = true
+	intent.PutItem(itemB, nil)
+
+	r = rec.New(reg)
+	status = r.Reconcile(context.Background(), current, intent)
+	t.Expect(status.Err).To(BeNil())
+	t.Expect(status.AsyncOpsInProgress).To(BeTrue())
+	t.Expect(status.NewCurrentState).To(BeIdenticalTo(current))
+	t.Expect(status.ReadyToResume).ToNot(BeNil())
+	t.Expect(itemB).To(BeingCreated())
+	t.Expect(status.OperationLog).To(HaveLen(1))
+
+	item, state, path, exists = current.Item(dg.Reference(itemB))
+	t.Expect(exists).To(BeTrue())
+	t.Expect(path.Len()).To(BeZero())
+	t.Expect(item).To(BeMockItem(itemB))
+	stateData = state.(*rec.ItemStateData)
+	t.Expect(stateData).ToNot(BeNil())
+	t.Expect(stateData.LastOperation).To(Equal(rec.OperationCreate))
+	t.Expect(stateData.LastError).To(MatchError("failed to create"))
+	t.Expect(stateData.State).To(Equal(rec.ItemStateCreating))
+
+	waitForAsyncOps(t, 1)
+
+	// 3. Resume reconciliation now that Create() for itemB finalized
+	r = rec.New(reg)
+	status = r.Reconcile(context.Background(), current, intent)
+	t.Expect(status.Err).To(BeNil())
+	t.Expect(status.AsyncOpsInProgress).To(BeTrue())
+	t.Expect(status.NewCurrentState).To(BeIdenticalTo(current))
+	t.Expect(status.ReadyToResume).ToNot(BeNil())
+	t.Expect(itemA).To(BeingCreated().After(itemB))
+	t.Expect(itemB).To(BeCreated())
+	t.Expect(status.OperationLog).To(HaveLen(2))
+
+	item, state, path, exists = current.Item(dg.Reference(itemA))
+	t.Expect(exists).To(BeTrue())
+	t.Expect(path.Len()).To(BeZero())
+	t.Expect(item).To(BeMockItem(itemA))
+	stateData = state.(*rec.ItemStateData)
+	t.Expect(stateData).ToNot(BeNil())
+	t.Expect(stateData.LastOperation).To(Equal(rec.OperationUnknown))
+	t.Expect(stateData.LastError).To(BeNil())
+	t.Expect(stateData.State).To(Equal(rec.ItemStateCreating))
+
+	item, state, path, exists = current.Item(dg.Reference(itemB))
+	t.Expect(exists).To(BeTrue())
+	t.Expect(path.Len()).To(BeZero())
+	t.Expect(item).To(BeMockItem(itemB))
+	stateData = state.(*rec.ItemStateData)
+	t.Expect(stateData).ToNot(BeNil())
+	t.Expect(stateData.LastOperation).To(Equal(rec.OperationCreate))
+	t.Expect(stateData.LastError).To(BeNil())
+	t.Expect(stateData.State).To(Equal(rec.ItemStateCreated))
+
+	waitForAsyncOps(t, 1)
+
+	// 4. Resume reconciliation now that Create() for itemA finalized (with error)
+	r = rec.New(reg)
+	status = r.Reconcile(context.Background(), current, intent)
+	t.Expect(status.Err).ToNot(BeNil())
+	t.Expect(status.AsyncOpsInProgress).To(BeFalse())
+	t.Expect(itemA).To(BeCreated().WithError("failed to create"))
+	t.Expect(status.OperationLog).To(HaveLen(1))
+	t.Expect(status.NewCurrentState).To(BeIdenticalTo(current))
+
+	item, state, path, exists = current.Item(dg.Reference(itemA))
+	t.Expect(exists).To(BeTrue())
+	t.Expect(path.Len()).To(BeZero())
+	t.Expect(item).To(BeMockItem(itemA))
+	stateData = state.(*rec.ItemStateData)
+	t.Expect(stateData).ToNot(BeNil())
+	t.Expect(stateData.LastOperation).To(Equal(rec.OperationCreate))
+	t.Expect(stateData.LastError).To(MatchError("failed to create"))
+	t.Expect(stateData.State).To(Equal(rec.ItemStateFailure))
+
+	// 5. Simulate failure to modify C asynchronously
+	itemC.failToCreate = true
+	itemC.modifiableAttrs.strAttr = "modified"
+	itemC.asyncCreate = true
+	intent.PutItem(itemC, nil)
+
+	r = rec.New(reg)
+	status = r.Reconcile(context.Background(), current, intent)
+	t.Expect(status.Err).To(BeNil())
+	t.Expect(status.AsyncOpsInProgress).To(BeTrue())
+	t.Expect(status.ReadyToResume).ToNot(BeNil())
+	t.Expect(status.NewCurrentState).To(BeIdenticalTo(current))
+	t.Expect(itemC).To(BeingModified())
+	t.Expect(status.OperationLog).To(HaveLen(1))
+
+	item, state, path, exists = current.Item(dg.Reference(itemC))
+	t.Expect(exists).To(BeTrue())
+	t.Expect(path.Len()).To(BeZero())
+	itemC.modifiableAttrs.strAttr = "" // not applied
+	t.Expect(item).To(BeMockItem(itemC))
+	stateData = state.(*rec.ItemStateData)
+	t.Expect(stateData).ToNot(BeNil())
+	t.Expect(stateData.LastOperation).To(Equal(rec.OperationCreate))
+	t.Expect(stateData.LastError).To(BeNil())
+	t.Expect(stateData.State).To(Equal(rec.ItemStateModifying))
+
+	waitForAsyncOps(t, 1)
+
+	// 6. Resume reconciliation now that Modify() for itemC finalized (with error)
+	r = rec.New(reg)
+	status = r.Reconcile(context.Background(), current, intent)
+	t.Expect(status.Err).ToNot(BeNil())
+	t.Expect(status.AsyncOpsInProgress).To(BeFalse())
+	t.Expect(status.NewCurrentState).To(BeIdenticalTo(current))
+	t.Expect(status.ReadyToResume).To(BeNil())
+	t.Expect(itemC).To(BeModified().WithError("failed to modify"))
+	t.Expect(status.OperationLog).To(HaveLen(1))
+
+	item, state, path, exists = current.Item(dg.Reference(itemC))
+	t.Expect(exists).To(BeTrue())
+	t.Expect(path.Len()).To(BeZero())
+	itemC.modifiableAttrs.strAttr = "" // not applied
+	t.Expect(item).To(BeMockItem(itemC))
+	stateData = state.(*rec.ItemStateData)
+	t.Expect(stateData).ToNot(BeNil())
+	t.Expect(stateData.LastOperation).To(Equal(rec.OperationModify))
+	t.Expect(stateData.LastError).To(MatchError("failed to modify"))
+	t.Expect(stateData.State).To(Equal(rec.ItemStateFailure))
+
+	// 7. Simulate failure to re-create itemB (asynchronous delete fails)
+	prevItemB := itemB
+	itemB.staticAttrs.strAttr = "modified"
+	intent.PutItem(itemB, nil)
+	intent.PutItem(itemC, nil) // give up on trying to modify C
+
+	r = rec.New(reg)
+	status = r.Reconcile(context.Background(), current, intent)
+	t.Expect(status.Err).To(BeNil())
+	t.Expect(status.AsyncOpsInProgress).To(BeTrue())
+	t.Expect(status.ReadyToResume).ToNot(BeNil())
+	t.Expect(status.NewCurrentState).To(BeIdenticalTo(current))
+	t.Expect(itemA).ToNot(BeDeleted()) // create failed
+	t.Expect(itemB).To(BeingDeleted())
+	t.Expect(status.OperationLog).To(HaveLen(1))
+
+	item, state, path, exists = current.Item(dg.Reference(itemB))
+	t.Expect(exists).To(BeTrue())
+	t.Expect(path.Len()).To(BeZero())
+	t.Expect(item).To(BeMockItem(prevItemB))
+	stateData = state.(*rec.ItemStateData)
+	t.Expect(stateData).ToNot(BeNil())
+	t.Expect(stateData.LastOperation).To(Equal(rec.OperationCreate))
+	t.Expect(stateData.LastError).To(BeNil())
+	t.Expect(stateData.State).To(Equal(rec.ItemStateDeleting))
+
+	waitForAsyncOps(t, 1)
+
+	// 8. Resume reconciliation now that async op has finalized
+	r = rec.New(reg)
+	status = r.Reconcile(context.Background(), current, intent)
+	t.Expect(status.Err).ToNot(BeNil())
+	t.Expect(status.AsyncOpsInProgress).To(BeFalse())
+	t.Expect(status.NewCurrentState).To(BeIdenticalTo(current))
+	t.Expect(status.ReadyToResume).To(BeNil())
+	t.Expect(itemB).To(BeDeleted().WithError("failed to delete"))
+	t.Expect(status.OperationLog).To(HaveLen(1))
+
+	item, state, path, exists = current.Item(dg.Reference(itemB))
+	t.Expect(exists).To(BeTrue())
+	t.Expect(path.Len()).To(BeZero())
+	itemB.staticAttrs.strAttr = "" // not applied
+	t.Expect(item).To(BeMockItem(itemB))
+	stateData = state.(*rec.ItemStateData)
+	t.Expect(stateData).ToNot(BeNil())
+	t.Expect(stateData.LastOperation).To(Equal(rec.OperationDelete))
+	t.Expect(stateData.LastError).To(MatchError("failed to delete"))
+	t.Expect(stateData.State).To(Equal(rec.ItemStateFailure))
+}
+
 // Items: A
 // No dependencies
 func TestCancelAsyncOperation(test *testing.T) {


### PR DESCRIPTION
3 commits in this PR related to reconciliation of async operations:

- added unit test to cover handling of failures of async operations
- added option to reconciler API to select which async operations to cancel (previously was possible to only cancel *all* running async ops without exceptions)
- avoid race conditions by not processing async ops that finalize *during* reconciliation - they are instead left to be processed
in the next reconciliation run (some race conditions were found during zedrouter testing and this way they can be easily avoided)

This updates `libs/reconciler` package. Changes made here will be propagated to pillar in the next PR together with some zedrouter patches.