### PR TITLE
Decrease time needed to boot pillar microservices

### DIFF
--- a/pkg/pillar/cmd/loguploader/loguploader.go
+++ b/pkg/pillar/cmd/loguploader/loguploader.go
@@ -102,6 +102,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(stillRunningInerval)
+	ps.StillRunning(agentName, warningTime, errorTime)
 
 	// Wait until we have been onboarded aka know our own UUID
 	subOnboardStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{

--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -123,7 +123,7 @@ type nodeagentContext struct {
 	domainHaltWaitIncrement uint32
 }
 
-func newNodeagentContext(_ *pubsub.PubSub, _ *logrus.Logger, _ *base.LogObject) *nodeagentContext {
+func newNodeagentContext(ps *pubsub.PubSub, _ *logrus.Logger, _ *base.LogObject) *nodeagentContext {
 	nodeagentCtx := nodeagentContext{}
 	nodeagentCtx.minRebootDelay = minRebootDelay
 	nodeagentCtx.maxDomainHaltTime = maxDomainHaltTime
@@ -134,6 +134,7 @@ func newNodeagentContext(_ *pubsub.PubSub, _ *logrus.Logger, _ *base.LogObject) 
 	// start the watchdog process timer tick
 	duration := time.Duration(watchdogInterval) * time.Second
 	nodeagentCtx.stillRunning = time.NewTicker(duration)
+	ps.StillRunning(agentName, warningTime, errorTime)
 
 	// set the ticker timer
 	duration = time.Duration(timeTickInterval) * time.Second

--- a/pkg/pillar/cmd/zfsmanager/zfsmanager.go
+++ b/pkg/pillar/cmd/zfsmanager/zfsmanager.go
@@ -77,6 +77,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(stillRunningInterval)
+	ps.StillRunning(agentName, warningTime, errorTime)
 
 	// Wait until we have been onboarded aka know our own UUID, but we don't use the UUID
 	err := utils.WaitForOnboarded(ps, log, agentName, warningTime, errorTime)

--- a/pkg/pillar/zedbox/zedbox.go
+++ b/pkg/pillar/zedbox/zedbox.go
@@ -180,6 +180,7 @@ func runZedbox(ps *pubsub.PubSub, logger *logrus.Logger, log *base.LogObject, ar
 		agentbase.WithArguments(arguments))
 
 	stillRunning := time.NewTicker(15 * time.Second)
+	ps.StillRunning(agentName, warningTime, errorTime)
 
 	subChan := reverse.NewSubscriber(log, agentName,
 		types.ServiceInitStatus{})


### PR DESCRIPTION
`device-steps.sh` [waits for zedbox to create touch file](https://github.com/lf-edge/eve/blob/master/pkg/pillar/scripts/device-steps.sh#L119).
However, the first iteration of zedbox updating touch file starts only after 15 seconds of pointless sleep.