### PR TITLE
tpm : more verbose error reporting when policy check fails

### DIFF
--- a/pkg/pillar/cmd/vaultmgr/vaultmgr.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgr.go
@@ -456,7 +456,7 @@ func handleVaultKeyFromControllerImpl(ctxArg interface{}, key string,
 		}
 		log.Warnln("default vault removed")
 		if err := handler.SetupDefaultVault(); err != nil {
-			log.Errorf("setupDefaultVault failed, err: %v", err)
+			log.Errorf("SetupDefaultVault failed, err: %v", err)
 			getAndPublishAllVaultStatuses(ctx)
 			return
 		}
@@ -494,12 +494,12 @@ func publishVaultKey(ctx *vaultMgrContext, vaultName string) error {
 		}
 		keyBytes, err := etpm.FetchSealedVaultKey(log)
 		if err != nil {
-			return fmt.Errorf("Failed to retrieve key from TPM %v", err)
+			return fmt.Errorf("Failed to retrieve key from TPM %w", err)
 		}
 
 		encryptedKey, err := etpm.EncryptDecryptUsingTpm(keyBytes, true)
 		if err != nil {
-			return fmt.Errorf("Failed to encrypt vault key %v", err)
+			return fmt.Errorf("Failed to encrypt vault key %w", err)
 		}
 
 		hash := sha256.New()
@@ -512,7 +512,7 @@ func publishVaultKey(ctx *vaultMgrContext, vaultName string) error {
 		}
 		encryptedVaultKey, err = proto.Marshal(keyData)
 		if err != nil {
-			return fmt.Errorf("Failed to Marshal keyData %v", err)
+			return fmt.Errorf("Failed to Marshal keyData %w", err)
 		}
 	}
 

--- a/pkg/pillar/evetpm/tpm.go
+++ b/pkg/pillar/evetpm/tpm.go
@@ -196,7 +196,7 @@ func TpmSign(digest []byte) (*big.Int, *big.Int, error) {
 
 	tpmOwnerPasswd, err := ReadOwnerCrdl()
 	if err != nil {
-		return nil, nil, fmt.Errorf("fetching TPM credentials failed: %v", err)
+		return nil, nil, fmt.Errorf("fetching TPM credentials failed: %w", err)
 	}
 
 	//XXX This "32" should really come from Hash algo used.
@@ -211,7 +211,7 @@ func TpmSign(digest []byte) (*big.Int, *big.Int, error) {
 	sig, err := tpm2.Sign(rw, TpmDeviceKeyHdl,
 		tpmOwnerPasswd, digest, nil, scheme)
 	if err != nil {
-		return nil, nil, fmt.Errorf("signing data using TPM failed: %v", err)
+		return nil, nil, fmt.Errorf("signing data using TPM failed: %w", err)
 	}
 	return sig.ECC.R, sig.ECC.S, nil
 }
@@ -344,6 +344,7 @@ func FetchTpmHwInfo() (string, error) {
 	//Take care of non-TPM platforms
 	if _, err := os.Stat(TpmDevicePath); err != nil {
 		tpmHwInfo = "Not Available"
+		//nolint:nilerr
 		return tpmHwInfo, nil
 	}
 
@@ -399,11 +400,11 @@ func FetchVaultKey(log *base.LogObject) ([]byte, error) {
 		//
 		key, err = GetRandom(vaultKeyLength)
 		if err != nil {
-			return nil, fmt.Errorf("GetRandom failed: %v", err)
+			return nil, fmt.Errorf("GetRandom failed: %w", err)
 		}
 		err = writeDiskKey(key)
 		if err != nil {
-			return nil, fmt.Errorf("writing legacy Key to TPM failed: %v", err)
+			return nil, fmt.Errorf("writing legacy Key to TPM failed: %w", err)
 		}
 	} else {
 		log.Noticef("successfully read the legacy disk key from TPM")
@@ -498,11 +499,11 @@ func FetchSealedVaultKey(log *base.LogObject) ([]byte, error) {
 		//
 		key, err := GetRandom(vaultKeyLength)
 		if err != nil {
-			return nil, fmt.Errorf("GetRandom failed: %v", err)
+			return nil, fmt.Errorf("GetRandom failed: %w", err)
 		}
 		err = SealDiskKey(key, DiskKeySealingPCRs)
 		if err != nil {
-			return nil, fmt.Errorf("sealing the fresh disk key failed: %v", err)
+			return nil, fmt.Errorf("sealing the fresh disk key failed: %w", err)
 		}
 
 		log.Noticef("successfully sealed the fresh disk key into TPM")
@@ -522,14 +523,14 @@ func FetchSealedVaultKey(log *base.LogObject) ([]byte, error) {
 		//Upgrade path will be to first upgrade to a) first release and then b)
 		key, err := readDiskKey()
 		if err != nil {
-			return nil, fmt.Errorf("retrieving the legacy disk key from TPM failed: %v", err)
+			return nil, fmt.Errorf("retrieving the legacy disk key from TPM failed: %w", err)
 		}
 
 		log.Noticef("try to convert the legacy key into a sealed key")
 
 		err = SealDiskKey(key, DiskKeySealingPCRs)
 		if err != nil {
-			return nil, fmt.Errorf("sealing the legacy disk key into TPM failed: %v", err)
+			return nil, fmt.Errorf("sealing the legacy disk key into TPM failed: %w", err)
 		}
 	}
 	//sealedKeyPresent && !legacyKeyPresent : unseal
@@ -584,7 +585,7 @@ func SealDiskKey(key []byte, pcrSel tpm2.PCRSelection) error {
 
 	priv, public, err := tpm2.Seal(rw, TpmSRKHdl, EmptyPassword, EmptyPassword, policy, key)
 	if err != nil {
-		return fmt.Errorf("sealing the disk key into TPM failed: %v", err)
+		return fmt.Errorf("sealing the disk key into TPM failed: %w", err)
 	}
 
 	// Define space in NV storage and clean up afterwards or subsequent runs will fail.
@@ -626,7 +627,7 @@ func SealDiskKey(key []byte, pcrSel tpm2.PCRSelection) error {
 
 	// save a snapshot of PCR values
 	if err := saveDiskKeySealingPCRs(TpmSavedDiskSealingPcrs); err != nil {
-		return fmt.Errorf("saving snapshot of sealing PCRs failed: %v", err)
+		return fmt.Errorf("saving snapshot of sealing PCRs failed: %w", err)
 	}
 
 	return nil
@@ -672,7 +673,7 @@ func UnsealDiskKey(pcrSel tpm2.PCRSelection) ([]byte, error) {
 
 	sealedObjHandle, _, err := tpm2.Load(rw, TpmSRKHdl, "", pub, priv)
 	if err != nil {
-		return nil, fmt.Errorf("loading the disk key into TPM failed: %v", err)
+		return nil, fmt.Errorf("loading the disk key into TPM failed: %w", err)
 	}
 	defer tpm2.FlushContext(rw, sealedObjHandle)
 
@@ -686,12 +687,12 @@ func UnsealDiskKey(pcrSel tpm2.PCRSelection) ([]byte, error) {
 	if err != nil {
 		// We get here mostly because of RCPolicyFail error, so try to get more
 		// information about the failure by finding the mismatching PCR index.
-		mismatch, newErr := findMismatchingPCRs(TpmSavedDiskSealingPcrs)
-		if newErr != nil {
-			return nil, fmt.Errorf("UnsealWithSession failed: %v, getting more info failed: %v", err, newErr)
+		mismatch, extraErr := findMismatchingPCRs(TpmSavedDiskSealingPcrs)
+		if extraErr != nil {
+			return nil, fmt.Errorf("UnsealWithSession failed: %w, getting more info failed: %v", err, extraErr)
 		}
 
-		return nil, fmt.Errorf("UnsealWithSession failed: %v, possibly mismatching PCR indexes %v", err, mismatch)
+		return nil, fmt.Errorf("UnsealWithSession failed: %w, possibly mismatching PCR indexes %v", err, mismatch)
 	}
 	return key, nil
 }
@@ -722,7 +723,7 @@ func PolicyPCRSession(rw io.ReadWriteCloser, pcrSel tpm2.PCRSelection) (tpmutil.
 
 	policy, err := tpm2.PolicyGetDigest(rw, session)
 	if err != nil {
-		return session, nil, fmt.Errorf("PolicyGetDigest failed: %v", err)
+		return session, nil, fmt.Errorf("PolicyGetDigest failed: %w", err)
 	}
 	return session, policy, nil
 }
@@ -813,19 +814,14 @@ func saveDiskKeySealingPCRs(pcrsFile string) error {
 		return err
 	}
 
-	frw, err := os.Create(pcrsFile)
-	if err != nil {
-		return err
-	}
-	defer frw.Close()
-
-	e := gob.NewEncoder(frw)
+	buff := new(bytes.Buffer)
+	e := gob.NewEncoder(buff)
 	err = e.Encode(readPCRs)
 	if err != nil {
 		return err
 	}
 
-	return nil
+	return fileutils.WriteRename(pcrsFile, buff.Bytes())
 }
 
 func findMismatchingPCRs(savedPCRsFile string) ([]int, error) {

--- a/pkg/pillar/vault/handler_ext4.go
+++ b/pkg/pillar/vault/handler_ext4.go
@@ -117,7 +117,7 @@ func (h *Ext4Handler) SetupDefaultVault() error {
 		return fmt.Errorf("error in setting up vault %s:%v", defaultVault, err)
 	}
 	// Log the type of key used for unlocking default vault
-	h.log.Noticef("default vault unlocked using key type %s",
+	h.log.Noticef("default vault unlocked using key type: %s",
 		etpm.CompareLegacyandSealedKey().String())
 	return nil
 }


### PR DESCRIPTION
When EVE fails to unseal the vault due to policy check failure, it reports a generic error. This changes makes the error more verbose by finding the mismatching PCR(s) and report it.

Before this changes we would get : 
`UnsealWithSession failed: session 1, error code 0x1d : a policy check failed`

Now for example if indexes 1, 7 and 8 are not matching the original value, it reports : 
`UnsealWithSession failed: session 1, error code 0x1d : a policy check failed, possibly mismatching PCR indexes [1 7 8]`

-----

second commit, makes the errors more informative and easier to follow in the logs.