### PR TITLE
Makefile: Workaround to fix QEMU's MSR errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,10 @@ ifeq ($(UNAME_S)_$(ZARCH),Darwin_arm64)
 QEMU_DEFAULT_MACHINE=virt,
 endif
 QEMU_ACCEL_Y_Darwin_amd64=-machine q35,accel=hvf,usb=off -cpu kvm64,kvmclock=off
-QEMU_ACCEL_Y_Linux_amd64=-machine q35,accel=kvm,usb=off,dump-guest-core=off -cpu host,invtsc=on,kvmclock=off -machine kernel-irqchip=split -device intel-iommu,intremap=on,caching-mode=on,aw-bits=48
+# NOTE: -vmx-true-ctls and -vmx-secondary-ctls is used as a workaround to
+# mitigate QEMU crashes due to MSR access errors like the following:
+# "error: failed to set MSR 0x48b to 0x137bff00000000"
+QEMU_ACCEL_Y_Linux_amd64=-machine q35,accel=kvm,usb=off,dump-guest-core=off -cpu host,-vmx-true-ctls,-vmx-secondary-ctls,invtsc=on,kvmclock=off -machine kernel-irqchip=split -device intel-iommu,intremap=on,caching-mode=on,aw-bits=48
 # -machine virt,gic_version=3
 QEMU_ACCEL_Y_Darwin_arm64=-machine $(QEMU_DEFAULT_MACHINE)accel=hvf,usb=off -cpu host
 QEMU_ACCEL_Y_Linux_arm64=-machine virt,accel=kvm,usb=off,dump-guest-core=off -cpu host


### PR DESCRIPTION
A QEMU crash has being experienced for some combinations of newer kernels and QEMU versions on the host when running EVE from QEMU (with make run-live). QEMU crashes when trying to access VMX_PROCBASED_CTLS2 MSR register and VMs/Containers are not initialized:

error: failed to set MSR 0x48b to 0x137bff00000000

This commit provides a workaround while the proper fix is not provided.