### PR TITLE
[9.4 stable] Make domainmgr skip DNS with empty DPCKey

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -2409,6 +2409,18 @@ func handleDNSImpl(ctxArg interface{}, key string,
 		log.Functionf("handleDNSImpl: ignoring %s", key)
 		return
 	}
+	if status.DPCKey == "" {
+		// Do not activate PhysicalIOAdapterList subscription until NIM receives
+		// a DPC and publishes corresponding DNS.
+		// NIM can publish DNS even before it receives first DPC. In such case
+		// DPCKey is empty.
+		// The goal is to avoid assigning network ports to PCIBack if they are going to be
+		// used for management purposes. This way we avoid doing unintended port assignment
+		// to PCIBack that would be shortly followed by a release, therefore mitigating
+		// the risk of race conditions between domainmgr and NIM.
+		log.Warnf("handleDNSImpl: DNS with empty DPCKey")
+		return
+	}
 	// Ignore test status and timestamps
 	// Compare Testing to save its updated value which is used by us
 	if ctx.deviceNetworkStatus.MostlyEqual(status) &&


### PR DESCRIPTION
Do not activate PhysicalIOAdapterList subscription until NIM receives a DPC and publishes corresponding DNS.
NIM can publish DNS even before it receives first DPC. In such case DPCKey is empty.
The goal is to avoid assigning network ports to PCIBack if they are going to be used for management purposes. This way we avoid doing unintended port assignment to PCIBack that would be shortly followed by a release, therefore mitigating the risk of race conditions between domainmgr and NIM.

_This patch is already in master, but we have observed this race-condition in the production causing some issues and therefore it should be backported to 9.4 LTS._