### PR TITLE
Further refactoring zedrouter to make it much more robust

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -90,10 +90,12 @@ func prepareAndPublishNetworkInstanceInfoMsg(ctx *zedagentContext,
 			errInfo.Timestamp = errTime
 			info.NetworkErr = append(info.NetworkErr, errInfo)
 			info.State = zinfo.ZNetworkInstanceState_ZNETINST_STATE_ERROR
+		} else if status.ChangeInProgress != types.ChangeInProgressTypeNone {
+			info.State = zinfo.ZNetworkInstanceState_ZNETINST_STATE_INIT
 		} else if status.Activated {
 			info.State = zinfo.ZNetworkInstanceState_ZNETINST_STATE_ONLINE
 		} else {
-			info.State = zinfo.ZNetworkInstanceState_ZNETINST_STATE_INIT
+			info.State = zinfo.ZNetworkInstanceState_ZNETINST_STATE_UNSPECIFIED
 		}
 		info.Activated = status.Activated
 

--- a/pkg/pillar/cmd/zedrouter/appnetwork.go
+++ b/pkg/pillar/cmd/zedrouter/appnetwork.go
@@ -140,6 +140,8 @@ func (z *zedrouter) doActivateAppNetwork(config types.AppNetworkConfig,
 
 	// Update AppNetwork and NetworkInstance status.
 	status.Activated = true
+	status.PendingAdd = false
+	status.PendingModify = false
 	z.publishAppNetworkStatus(status)
 	z.updateNIStatusAfterAppNetworkActivate(status)
 
@@ -305,6 +307,7 @@ func (z *zedrouter) doUpdateActivatedAppNetwork(oldConfig, newConfig types.AppNe
 	// Update app network status as well as status of connected network instances.
 	z.processAppConnReconcileStatus(appConnRecStatus, status)
 	z.reloadStatusOfAssignedIPs(status)
+	status.PendingModify = false
 	z.publishAppNetworkStatus(status)
 	z.updateNIStatusAfterAppNetworkActivate(status)
 }
@@ -332,6 +335,8 @@ func (z *zedrouter) doInactivateAppNetwork(config types.AppNetworkConfig,
 
 	// Update AppNetwork and NetworkInstance status.
 	status.Activated = false
+	status.PendingModify = false
+	status.PendingDelete = false
 	z.updateNIStatusAfterAppNetworkInactivate(status)
 	z.removeAssignedIPsFromAppNetStatus(status)
 	z.publishAppNetworkStatus(status)

--- a/pkg/pillar/cmd/zedrouter/pubsubhandlers.go
+++ b/pkg/pillar/cmd/zedrouter/pubsubhandlers.go
@@ -176,7 +176,7 @@ func (z *zedrouter) handleNetworkInstanceCreate(ctxArg interface{}, key string,
 		return
 	}
 
-	if err := z.doNetworkInstanceSanityCheck(&status); err != nil {
+	if err := z.doNetworkInstanceSanityCheck(&config); err != nil {
 		z.log.Error(err)
 		status.SetErrorNow(err.Error())
 		status.ChangeInProgress = types.ChangeInProgressTypeNone
@@ -295,7 +295,7 @@ func (z *zedrouter) handleNetworkInstanceModify(ctxArg interface{}, key string,
 
 	prevPortLL := status.PortLogicalLabel
 	status.NetworkInstanceConfig = config
-	if err := z.doNetworkInstanceSanityCheck(status); err != nil {
+	if err := z.doNetworkInstanceSanityCheck(&config); err != nil {
 		z.log.Error(err)
 		status.SetErrorNow(err.Error())
 		status.WaitingForUplink = false

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -798,7 +798,7 @@ func (z *zedrouter) processNIReconcileStatus(recStatus nireconciler.NIReconcileS
 		niStatus.BridgeName = recStatus.BrIfName
 		changed = true
 	}
-	if !recStatus.AsyncInProgress {
+	if !recStatus.InProgress {
 		if niStatus.ChangeInProgress != types.ChangeInProgressTypeNone {
 			niStatus.ChangeInProgress = types.ChangeInProgressTypeNone
 			changed = true
@@ -835,10 +835,10 @@ func (z *zedrouter) processAppConnReconcileStatus(
 		}
 		return false
 	}
-	var asyncInProgress bool
+	var inProgress bool
 	var failedItems []string
 	for _, vif := range recStatus.VIFs {
-		asyncInProgress = asyncInProgress || vif.AsyncInProgress
+		inProgress = inProgress || vif.InProgress
 		for itemRef, itemErr := range vif.FailedItems {
 			failedItems = append(failedItems, fmt.Sprintf("%v (%v)", itemRef, itemErr))
 		}
@@ -853,13 +853,9 @@ func (z *zedrouter) processAppConnReconcileStatus(
 			}
 		}
 	}
-	if !asyncInProgress {
-		if appNetStatus.Pending() {
-			changed = true
-		}
-		appNetStatus.PendingAdd = false
-		appNetStatus.PendingModify = false
-		appNetStatus.PendingDelete = false
+	if appNetStatus.ConfigInSync != !inProgress {
+		changed = true
+		appNetStatus.ConfigInSync = !inProgress
 	}
 	if len(failedItems) > 0 {
 		err := fmt.Errorf("failed items: %s", strings.Join(failedItems, ";"))

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -416,7 +416,7 @@ func (z *zedrouter) run(ctx context.Context) (err error) {
 				}
 				if appNetConfig == nil && recUpdate.AppConnStatus.Deleted &&
 					appNetStatus != nil && !appNetStatus.HasError() &&
-					!appNetStatus.Pending() {
+					!appNetStatus.Pending() && appNetStatus.ConfigInSync {
 					z.unpublishAppNetworkStatus(appNetStatus)
 				}
 			}

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -1069,6 +1069,11 @@ func (z *zedrouter) publishNetworkInstanceMetricsAll(nms *types.NetworkMetrics) 
 	}
 	for _, ni := range niList {
 		status := ni.(types.NetworkInstanceStatus)
+		config := z.lookupNetworkInstanceConfig(status.Key())
+		if config == nil || !config.Activate {
+			// NI was deleted or is inactive - skip metrics publishing.
+			continue
+		}
 		netMetrics := z.createNetworkInstanceMetrics(&status, nms)
 		err := z.pubNetworkInstanceMetrics.Publish(netMetrics.Key(), *netMetrics)
 		if err != nil {

--- a/pkg/pillar/dpcreconciler/linux.go
+++ b/pkg/pillar/dpcreconciler/linux.go
@@ -436,7 +436,6 @@ func (r *LinuxDpcReconciler) Reconcile(ctx context.Context, args Args) Reconcile
 	}
 
 	// Log every executed operation.
-	// XXX Do we want to have this always logged or only with DEBUG enabled?
 	for _, log := range rs.OperationLog {
 		var withErr string
 		if log.Err != nil {
@@ -525,7 +524,7 @@ func (r *LinuxDpcReconciler) Reconcile(ctx context.Context, args Args) Reconcile
 		Error:           rs.Err,
 		AsyncInProgress: rs.AsyncOpsInProgress,
 		ResumeReconcile: r.resumeReconcile,
-		CancelAsyncOps:  rs.CancelAsyncOps,
+		CancelAsyncOps:  func() { rs.CancelAsyncOps(nil) },
 		WaitForAsyncOps: rs.WaitForAsyncOps,
 		FailingItems:    failingItems,
 		RS: RadioSilenceStatus{

--- a/pkg/pillar/go.mod
+++ b/pkg/pillar/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/jaypipes/ghw v0.8.0
 	github.com/lf-edge/edge-containers v0.0.0-20221025050409-93c34bebadd2
 	github.com/lf-edge/eve/api/go v0.0.0-20230602070228-0c11e32c7718
-	github.com/lf-edge/eve/libs v0.0.0-20230621123421-9968f5332761
+	github.com/lf-edge/eve/libs v0.0.0-20230705061838-6ed29226fccf
 	github.com/linuxkit/linuxkit/src/cmd/linuxkit v0.0.0-20220913135124-e532e7310810
 	github.com/miekg/dns v1.1.41
 	github.com/moby/sys/mountinfo v0.6.0

--- a/pkg/pillar/go.sum
+++ b/pkg/pillar/go.sum
@@ -1127,8 +1127,8 @@ github.com/lf-edge/edge-containers v0.0.0-20221025050409-93c34bebadd2 h1:ckxNk8M
 github.com/lf-edge/edge-containers v0.0.0-20221025050409-93c34bebadd2/go.mod h1:eA41YxPbZRVvewIYRzmqDB1PeLQXxCy9WQEc3AVCsPI=
 github.com/lf-edge/eve/api/go v0.0.0-20230602070228-0c11e32c7718 h1:gtmjnX95WEKWCg6g+9kB9iTDuTTrUG/PEf17TMpLs1Q=
 github.com/lf-edge/eve/api/go v0.0.0-20230602070228-0c11e32c7718/go.mod h1:pNFho84HAA/Vlb1DpLFlatJgQBJ43wH28elAs7wXdtA=
-github.com/lf-edge/eve/libs v0.0.0-20230621123421-9968f5332761 h1:XCPiRrhNPGM5JNYF8Vwxs/VRtDifR+JxqllRGTQ1Dvw=
-github.com/lf-edge/eve/libs v0.0.0-20230621123421-9968f5332761/go.mod h1:/Q+4ZoyyKPPzvVs6u50ac802LbHwu8xtCYJBvlVXTLE=
+github.com/lf-edge/eve/libs v0.0.0-20230705061838-6ed29226fccf h1:aFyd3eRfZKy/DVYF42eysfDnUAHQT+EV8Gy1Dszr+/0=
+github.com/lf-edge/eve/libs v0.0.0-20230705061838-6ed29226fccf/go.mod h1:/Q+4ZoyyKPPzvVs6u50ac802LbHwu8xtCYJBvlVXTLE=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=

--- a/pkg/pillar/nireconciler/genericitems/dnsmasq_test.go
+++ b/pkg/pillar/nireconciler/genericitems/dnsmasq_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/nireconciler/genericitems"
+	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 )
 
@@ -31,7 +32,7 @@ func init() {
 
 func exampleDnsmasqParams() genericitems.Dnsmasq {
 	var dnsmasq genericitems.Dnsmasq
-	dnsmasq.InstanceName = "br0"
+	dnsmasq.ForNI, _ = uuid.FromString("d882ce20-fac2-448b-82e6-d411619d488f")
 	dnsmasq.ListenIf.IfName = "br0"
 	_, subnet, _ := net.ParseCIDR("10.0.0.0/24")
 	dnsmasq.DHCPServer = genericitems.DHCPServer{

--- a/pkg/pillar/nireconciler/genericitems/httpsrv.go
+++ b/pkg/pillar/nireconciler/genericitems/httpsrv.go
@@ -237,6 +237,8 @@ func (c *HTTPServerConfigurator) runServer(ctx context.Context, srvName string,
 		case <-ctx.Done():
 			c.Log.Noticef("%s: stopped trying to Listen, context is done", logPrefix)
 			// Return error from net.Listen to Reconciler.
+			err = fmt.Errorf("net.Listen failed with error (%v) "+
+				"and repeated attempts were canceled", err)
 			listenDoneFn(err)
 			return
 		case <-time.After(2 * time.Second):

--- a/pkg/pillar/nireconciler/genericitems/ipreserve.go
+++ b/pkg/pillar/nireconciler/genericitems/ipreserve.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2023 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package genericitems
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+
+	dg "github.com/lf-edge/eve/libs/depgraph"
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/utils"
+)
+
+// IPReserve : an item representing allocation and use of an IP address (for bridge).
+// The purpose of this item is to ensure that the same IP address will not be
+// used by multiple bridges at the same time (incl. inside intermediate reconciliation
+// states).
+// This works by having the bridge depending on the reservation and by requesting
+// re-creation of IPReserve when it changes, thus triggering re-create of bridges
+// and all higher-layers items that depend on it.
+type IPReserve struct {
+	// AddrWithMask : IP address including mask of the subnet to which it belongs.
+	AddrWithMask *net.IPNet
+	// NetIf : network interface to which the IP address is assigned.
+	NetIf NetworkIf
+}
+
+// Name returns the IP address in the string format.
+func (ip IPReserve) Name() string {
+	return ip.AddrWithMask.IP.String()
+}
+
+// Label returns the IP address including the mask in the string format.
+func (ip IPReserve) Label() string {
+	return ip.AddrWithMask.String()
+}
+
+// Type of the item.
+func (ip IPReserve) Type() string {
+	return IPReserveTypename
+}
+
+// Equal compares two IP reservations.
+func (ip IPReserve) Equal(other dg.Item) bool {
+	ip2, isIPReserve := other.(IPReserve)
+	if !isIPReserve {
+		return false
+	}
+	return ip.NetIf == ip2.NetIf &&
+		utils.EqualIPNets(ip.AddrWithMask, ip2.AddrWithMask)
+}
+
+// External returns false - not used for IPs assigned by NIM.
+func (ip IPReserve) External() bool {
+	return false
+}
+
+// String describes IP reservation.
+func (ip IPReserve) String() string {
+	return fmt.Sprintf("IPReserve: {ifName: %s, address: %s}",
+		ip.NetIf.IfName, ip.AddrWithMask.String())
+}
+
+// Dependencies returns empty slice.
+func (ip IPReserve) Dependencies() (deps []dg.Dependency) {
+	return nil
+}
+
+// IPReserveConfigurator implements Configurator interface (libs/reconciler)
+// for IPReserve.
+type IPReserveConfigurator struct {
+	Log *base.LogObject
+}
+
+// Create is NOOP - IPReserve is not an actual config item, it is used only for
+// dependency purposes (to avoid duplicate use of the same IP address).
+func (c *IPReserveConfigurator) Create(ctx context.Context, item dg.Item) error {
+	return nil
+}
+
+// Modify is not implemented.
+func (c *IPReserveConfigurator) Modify(ctx context.Context, oldItem, newItem dg.Item) (err error) {
+	return errors.New("not implemented")
+}
+
+// Delete is NOOP.
+func (c *IPReserveConfigurator) Delete(ctx context.Context, item dg.Item) error {
+	return nil
+}
+
+// NeedsRecreate returns true - change in IPReserve.NetIf usage intentionally triggers
+// recreate which cascades to the bridge and other dependent higher-layer items.
+func (c *IPReserveConfigurator) NeedsRecreate(oldItem, newItem dg.Item) (recreate bool) {
+	return true
+}

--- a/pkg/pillar/nireconciler/genericitems/registry.go
+++ b/pkg/pillar/nireconciler/genericitems/registry.go
@@ -17,6 +17,7 @@ func RegisterItems(log *base.LogObject, logger *logrus.Logger,
 		t string
 	}
 	configurators := []configurator{
+		{c: &IPReserveConfigurator{Log: log}, t: IPReserveTypename},
 		{c: &DnsmasqConfigurator{Log: log, Logger: logger}, t: DnsmasqTypename},
 		{c: &HTTPServerConfigurator{Log: log, Logger: logger}, t: HTTPServerTypename},
 		{c: &RadvdConfigurator{Log: log}, t: RadvdTypename},

--- a/pkg/pillar/nireconciler/genericitems/typenames.go
+++ b/pkg/pillar/nireconciler/genericitems/typenames.go
@@ -13,6 +13,8 @@ const (
 	// UnsupportedRouteTypename : typename which can be used for kinds of routes
 	// not supported/expected by a particular implementation of NIReconciler.
 	UnsupportedRouteTypename = "Unsupported-Route"
+	// IPReserveTypename : typename for reserved IP address (for use with a bridge)
+	IPReserveTypename = "IPReserve"
 	// VIFTypename : typename for VIF.
 	VIFTypename = "VIF"
 	// UplinkTypename : typename for uplink interface.

--- a/pkg/pillar/nireconciler/genericitems/uplink.go
+++ b/pkg/pillar/nireconciler/genericitems/uplink.go
@@ -70,3 +70,10 @@ func (u Uplink) String() string {
 func (u Uplink) Dependencies() (deps []dg.Dependency) {
 	return nil
 }
+
+// GetAssignedIPs returns IP addresses assigned to the uplink interface.
+// The function is needed for the definition of dependencies for
+// dnsmasq and HTTP server.
+func (u Uplink) GetAssignedIPs() []*net.IPNet {
+	return u.IPAddresses
+}

--- a/pkg/pillar/nireconciler/linux_config.go
+++ b/pkg/pillar/nireconciler/linux_config.go
@@ -736,8 +736,8 @@ func (r *LinuxNIReconciler) getIntendedMetadataSrvCfg(niID uuid.UUID) (items []d
 		})
 	}
 	items = append(items, generic.HTTPServer{
-		ServerName: fmt.Sprintf("Metadata-NI-%v", niID),
-		ListenIP:   bridgeIP.IP,
+		ForNI:    niID,
+		ListenIP: bridgeIP.IP,
 		ListenIf: generic.NetworkIf{
 			IfName:  ni.brIfName,
 			ItemRef: dg.Reference(linux.Bridge{IfName: ni.brIfName}),
@@ -909,9 +909,7 @@ func (r *LinuxNIReconciler) getIntendedDnsmasqCfg(niID uuid.UUID) (items []dg.It
 		})
 	}
 	items = append(items, generic.Dnsmasq{
-		// Use bridge interface name as the dnsmasq instance name.
-		// There is at most one dnsmasq instance running per every NI bridge.
-		InstanceName: ni.brIfName,
+		ForNI: niID,
 		ListenIf: generic.NetworkIf{
 			IfName:  ni.brIfName,
 			ItemRef: dg.Reference(linux.Bridge{IfName: ni.brIfName}),
@@ -930,9 +928,7 @@ func (r *LinuxNIReconciler) getIntendedRadvdCfg(niID uuid.UUID) (items []dg.Item
 	// XXX do we need same logic as for IPv4 dnsmasq to not advertise as default router?
 	// Might we need lower radvd preference if isolated local network?
 	items = append(items, generic.Radvd{
-		// Use bridge interface name as the radvd instance name.
-		// There is at most one radvd instance running per every NI bridge.
-		InstanceName: ni.brIfName,
+		ForNI: niID,
 		ListenIf: generic.NetworkIf{
 			IfName:  ni.brIfName,
 			ItemRef: dg.Reference(linux.Bridge{IfName: ni.brIfName}),

--- a/pkg/pillar/nireconciler/linux_reconciler.go
+++ b/pkg/pillar/nireconciler/linux_reconciler.go
@@ -21,6 +21,7 @@ import (
 	generic "github.com/lf-edge/eve/pkg/pillar/nireconciler/genericitems"
 	linux "github.com/lf-edge/eve/pkg/pillar/nireconciler/linuxitems"
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/lf-edge/eve/pkg/pillar/utils"
 	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
@@ -35,11 +36,6 @@ const (
 	// File where the intended state graph is exported (as DOT) after each reconcile.
 	// Can be used for troubleshooting purposes.
 	intendedStateFile = "/run/zedrouter-intended-state.dot"
-)
-
-const (
-	vifIfNamePrefix    = "nbu"
-	bridgeIfNamePrefix = "bn"
 )
 
 var emptyUUID = uuid.UUID{} // used as a constant
@@ -69,8 +65,9 @@ type LinuxNIReconciler struct {
 
 	// To manage asynchronous operations.
 	watcherControl   chan watcherCtrl
-	pendingReconcile map[string]pendingReconcile // key : subgraph name
-	resumeAsync      <-chan string               // nil if no async ops
+	pendingReconcile pendingReconcile
+	resumeAsync      <-chan string // nil if no async ops
+	cancelAsync      reconciler.CancelFunc
 
 	// Publishing of reconciler updates.
 	// When reconcileMu and publishMu are both needed to acquire,
@@ -86,10 +83,18 @@ type LinuxNIReconciler struct {
 }
 
 type pendingReconcile struct {
-	// Either forGlobalSG is true or forNI is non-empty.
-	forGlobalSG bool
-	forNI       uuid.UUID
-	reasons     []string
+	// True if we need to resume reconciliation because async op(s) finalized.
+	asyncFinalized bool
+	// Non-nil if the intended state of the global config is outdated
+	// and needs to be rebuilt before triggering reconciliation.
+	rebuildGlobalCfg *pendingCfgRebuild
+	// A map of network instances whose intended state is outdated
+	// and needs to be rebuilt before triggering reconciliation.
+	rebuildNICfg map[uuid.UUID]pendingCfgRebuild
+}
+
+type pendingCfgRebuild struct {
+	reasons []string
 }
 
 type watcherCtrl uint8
@@ -173,7 +178,7 @@ func (r *LinuxNIReconciler) init() (startWatcher func()) {
 	r.intendedState = r.initialDepGraph()
 	r.nis = make(map[uuid.UUID]*niInfo)
 	r.apps = make(map[uuid.UUID]*appInfo)
-	r.pendingReconcile = make(map[string]pendingReconcile)
+	r.pendingReconcile.rebuildNICfg = make(map[uuid.UUID]pendingCfgRebuild)
 	r.wakeupPublisher = make(chan bool, 1)
 	go r.runPublisher()
 	r.watcherControl = make(chan watcherCtrl, 10)
@@ -237,20 +242,8 @@ func (r *LinuxNIReconciler) runWatcher(netEvents <-chan netmonitor.Event) {
 	defer r.reconcileMu.Unlock()
 	for {
 		select {
-		case subgraph := <-r.resumeAsync:
-			reconcileReason := "async op finalized"
-			if subgraph == GlobalSG {
-				r.addPendingReconcile(true, emptyUUID, reconcileReason)
-			} else {
-				niID := SGNameToNI(subgraph)
-				if niID == emptyUUID {
-					r.log.Errorf(
-						"%s: received resumeAsync signal for unrecognized subgraph: %s",
-						LogAndErrPrefix, subgraph)
-					continue
-				}
-				r.addPendingReconcile(false, niID, reconcileReason)
-			}
+		case <-r.resumeAsync:
+			r.pendingReconcile.asyncFinalized = true
 			updateMsg := ReconcilerUpdate{UpdateType: AsyncOpDone}
 			r.publishReconcilerUpdates(updateMsg)
 
@@ -272,7 +265,7 @@ func (r *LinuxNIReconciler) runWatcher(netEvents <-chan netmonitor.Event) {
 						}
 						if ifName == ni.brIfName || ifName == ni.bridge.Uplink.IfName {
 							r.updateCurrentNIRoutes(ni.config.UUID)
-							r.addPendingReconcile(false, ni.config.UUID, "route change")
+							r.scheduleNICfgRebuild(ni.config.UUID, "route change")
 							needReconcile = true
 						}
 					}
@@ -292,7 +285,7 @@ func (r *LinuxNIReconciler) runWatcher(netEvents <-chan netmonitor.Event) {
 						if uplinkChanged {
 							for _, ni := range r.getNIsUsingUplink(ifName) {
 								r.updateCurrentNIRoutes(ni.config.UUID)
-								r.addPendingReconcile(false, ni.config.UUID,
+								r.scheduleNICfgRebuild(ni.config.UUID,
 									"uplink state change")
 								needReconcile = true
 							}
@@ -309,7 +302,7 @@ func (r *LinuxNIReconciler) runWatcher(netEvents <-chan netmonitor.Event) {
 						if _, _, _, found = subG.Item(brRef); found {
 							brChanged := r.updateCurrentNIBridge(niID)
 							if brChanged {
-								r.addPendingReconcile(false, niID, "bridge state change")
+								r.scheduleNICfgRebuild(niID, "bridge state change")
 								needReconcile = true
 							}
 							break
@@ -317,7 +310,7 @@ func (r *LinuxNIReconciler) runWatcher(netEvents <-chan netmonitor.Event) {
 						if _, _, _, found = subG.Item(vifRef); found {
 							vifChanged := r.updateCurrentVIFs(niID)
 							if vifChanged {
-								r.addPendingReconcile(false, niID, "VIF state change")
+								r.scheduleNICfgRebuild(niID, "VIF state change")
 								needReconcile = true
 							}
 							break
@@ -344,7 +337,7 @@ func (r *LinuxNIReconciler) runWatcher(netEvents <-chan netmonitor.Event) {
 						// Also, DHCP ACLs need to be updated.
 						brChanged := r.updateCurrentNIBridge(brForNI.config.UUID)
 						if brChanged {
-							r.addPendingReconcile(false, brForNI.config.UUID,
+							r.scheduleNICfgRebuild(brForNI.config.UUID,
 								"bridge IP change")
 							needReconcile = true
 						}
@@ -358,7 +351,7 @@ func (r *LinuxNIReconciler) runWatcher(netEvents <-chan netmonitor.Event) {
 					if uplinkChanged {
 						for _, ni := range uplinkForNIs {
 							r.updateCurrentNIRoutes(ni.config.UUID)
-							r.addPendingReconcile(false, ni.config.UUID,
+							r.scheduleNICfgRebuild(ni.config.UUID,
 								"uplink IP change")
 							needReconcile = true
 						}
@@ -397,53 +390,86 @@ func (r *LinuxNIReconciler) pauseWatcher() (cont func()) {
 // reconcile the current state of network instances and application connectivity with
 // the intended state.
 func (r *LinuxNIReconciler) reconcile(ctx context.Context) (updates []ReconcilerUpdate) {
-	if len(r.pendingReconcile) == 0 {
-		// Nothing to reconcile.
-		return nil
-	}
-	statusUpdateMap := make(map[uuid.UUID]ReconcilerUpdate)
-	// Reconcile with clear network monitor cache to avoid working with stale data.
+	// Stage 1: Rebuild intended state if needed
+	var reconcileReasons []string
+	// Rebuild intended state and reconcile with clear network monitor cache to avoid
+	// working with stale data.
 	r.netMonitor.ClearCache()
-	for sgName, pReconcile := range r.pendingReconcile {
-		// Prepare intended+current subgraphs for reconciliation.
-		var intSG dg.Graph
-		if pReconcile.forGlobalSG {
-			intSG = r.getIntendedGlobalState()
-			if r.currentState.SubGraph(GlobalSG) == nil {
-				// Very first reconciliation.
-				r.updateCurrentGlobalState(false)
-			}
+	if r.pendingReconcile.rebuildGlobalCfg != nil {
+		reasons := r.pendingReconcile.rebuildGlobalCfg.reasons
+		r.log.Noticef("%s: Rebuilding intended global config, reasons: %s",
+			LogAndErrPrefix, strings.Join(reasons, ", "))
+		reconcileReasons = append(reconcileReasons,
+			"rebuilt intended state for global config")
+		r.intendedState.PutSubGraph(r.getIntendedGlobalState())
+	}
+	for niID, pReconcile := range r.pendingReconcile.rebuildNICfg {
+		reasons := pReconcile.reasons
+		r.log.Noticef("%s: Rebuilding intended config for NI %s, reasons: %s",
+			LogAndErrPrefix, niID, strings.Join(reasons, ", "))
+		reconcileReasons = append(reconcileReasons,
+			fmt.Sprintf("rebuilt intended state for NI %s", niID))
+		sgName := NIToSGName(niID)
+		niInfo := r.nis[niID]
+		deleted := niInfo == nil || niInfo.deleted
+		if deleted {
+			r.intendedState.DelSubGraph(sgName)
 		} else {
-			niInfo := r.nis[pReconcile.forNI]
-			intSG = r.getIntendedNICfg(pReconcile.forNI)
-			if r.currentState.SubGraph(sgName) == nil {
-				if niInfo == nil || niInfo.deleted {
-					// Nothing to do for removed NI.
-					continue
-				}
-				// New network instance. Get the current state of external items.
-				r.updateCurrentNIState(pReconcile.forNI)
-			}
+			r.intendedState.PutSubGraph(r.getIntendedGlobalState())
 		}
-		r.intendedState.PutSubGraph(intSG)
-		currSG := r.currentState.SubGraph(sgName) // non-nil at this point
+	}
 
-		// Run state reconciliation.
-		r.log.Noticef("%s: Running state reconciliation for subgraph %s, reasons: %s",
-			LogAndErrPrefix, sgName, strings.Join(pReconcile.reasons, ", "))
-		reconcileStartTime := time.Now()
-		stateReconciler := reconciler.New(r.registry)
-		rs := stateReconciler.Reconcile(ctx, r.currentState.EditSubGraph(currSG), intSG)
-		r.resumeAsync = rs.ReadyToResume
+	// Stage 2: Run reconciliation between the intended and the current state
+	if r.pendingReconcile.asyncFinalized {
+		reconcileReasons = append(reconcileReasons, "async op finalized")
+	}
+	if len(reconcileReasons) == 0 {
+		return
+	}
+	reconcileStartTime := time.Now()
+	stateReconciler := reconciler.New(r.registry)
+	rs := stateReconciler.Reconcile(ctx, r.currentState, r.intendedState)
+	r.resumeAsync = rs.ReadyToResume
+	r.cancelAsync = rs.CancelAsyncOps
+	r.logReconciliation(rs, reconcileStartTime)
+	// Clear pending reconciliation.
+	r.pendingReconcile.rebuildGlobalCfg = nil
+	r.pendingReconcile.asyncFinalized = false
+	r.pendingReconcile.rebuildNICfg = make(map[uuid.UUID]pendingCfgRebuild)
 
-		// Detect and collect status updates.
-		if pReconcile.forNI != emptyUUID {
-			niStatus := r.updateNIStatus(pReconcile.forNI, currSG, statusUpdateMap)
-			// Clear UDP flows if any NAT ACL rule has changed.
+	// Stage 3: Collect NI and VIF status updates
+	for niID := range r.nis {
+		niStatus, changed := r.updateNIStatus(niID)
+		if changed {
+			updates = append(updates, ReconcilerUpdate{
+				UpdateType: NIReconcileStatusChanged,
+				NIStatus:   &niStatus,
+			})
+		}
+	}
+	for appID := range r.apps {
+		appConnStatus, changed := r.updateAppConnStatus(appID)
+		if changed {
+			updates = append(updates, ReconcilerUpdate{
+				UpdateType:    AppConnReconcileStatusChanged,
+				AppConnStatus: &appConnStatus,
+			})
+		}
+	}
+
+	// Stage 4: Clear UDP flows if any NAT ACL rule has changed.
+	for appID, app := range r.apps {
+		for i, vif := range app.vifs {
 			var natV4RuleChanged, natV6RuleChanged bool
+			acls := app.config.UnderlayNetworkList[i].ACLs
 			for _, log := range rs.OperationLog {
 				rule, isRule := log.Item.(iptables.Rule)
-				if isRule && rule.Table == "nat" {
+				if !isRule || rule.Table != "nat" {
+					continue
+				}
+				preRChain := vifChain("PREROUTING", vif)
+				postRChain := vifChain("POSTROUTING", vif)
+				if rule.ChainName == preRChain || rule.ChainName == postRChain {
 					if rule.ForIPv6 {
 						natV6RuleChanged = true
 					} else {
@@ -451,79 +477,67 @@ func (r *LinuxNIReconciler) reconcile(ctx context.Context) (updates []Reconciler
 					}
 				}
 			}
-			if natV4RuleChanged || natV6RuleChanged {
-				for _, app := range r.apps {
-					for i, vif := range app.vifs {
-						if vif.NI != pReconcile.forNI {
-							continue
-						}
-						acls := app.config.UnderlayNetworkList[i].ACLs
-						if natV4RuleChanged {
-							r.clearUDPFlows(acls, false)
-						}
-						if natV6RuleChanged {
-							r.clearUDPFlows(acls, true)
-						}
-					}
-				}
+			if natV4RuleChanged {
+				r.log.Noticef("%s: Clearing IPv4 UDP flows for app VIF %s/%s",
+					LogAndErrPrefix, appID, vif.NetAdapterName)
+				r.clearUDPFlows(acls, false)
 			}
-			// Remove NI subgraph if the network instance has been fully un-configured.
-			niInfo := r.nis[pReconcile.forNI]
-			if niInfo == nil || niInfo.deleted {
-				r.intendedState.DelSubGraph(sgName)
-				if !niStatus.AsyncInProgress {
-					r.currentState.DelSubGraph(sgName)
-				}
+			if natV6RuleChanged {
+				r.log.Noticef("%s: Clearing IPv6 UDP flows for app VIF %s/%s",
+					LogAndErrPrefix, appID, vif.NetAdapterName)
+				r.clearUDPFlows(acls, true)
 			}
 		}
+	}
+	return updates
+}
 
-		// Log every executed operation.
-		// XXX Do we want to have this always logged or only with DEBUG enabled?
-		for _, log := range rs.OperationLog {
-			var withErr string
-			if log.Err != nil {
-				withErr = fmt.Sprintf(" with error: %v", log.Err)
-			}
-			var action string
-			if log.InProgress {
-				action = "Started async execution of"
+func (r *LinuxNIReconciler) logReconciliation(rs reconciler.Status,
+	reconcileStartTime time.Time) {
+	// Log every executed operation.
+	for _, log := range rs.OperationLog {
+		var withErr string
+		if log.Err != nil {
+			withErr = fmt.Sprintf(" with error: %v", log.Err)
+		}
+		var action string
+		if log.InProgress {
+			action = "Started async execution of"
+		} else {
+			if log.StartTime.Before(reconcileStartTime) {
+				action = "Finalized async execution of"
 			} else {
-				if log.StartTime.Before(reconcileStartTime) {
-					action = "Finalized async execution of"
-				} else {
-					// synchronous operation
-					action = "Executed"
-				}
+				// synchronous operation
+				action = "Executed"
 			}
-			r.log.Noticef("%s: %s %v for %v%s, content: %s",
-				LogAndErrPrefix, action, log.Operation, dg.Reference(log.Item),
-				withErr, log.Item.String())
 		}
+		r.log.Noticef("%s: %s %v for %v%s, content: %s",
+			LogAndErrPrefix, action, log.Operation, dg.Reference(log.Item),
+			withErr, log.Item.String())
+	}
 
-		// Log transitions from no-error to error and vice-versa.
-		var failed, fixed []string
-		var failingItems reconciler.OperationLog
-		for _, log := range rs.OperationLog {
-			if log.PrevErr == nil && log.Err != nil {
-				failed = append(failed,
-					fmt.Sprintf("%v (err: %v)", dg.Reference(log.Item), log.Err))
-			}
-			if log.PrevErr != nil && log.Err == nil {
-				fixed = append(fixed, dg.Reference(log.Item).String())
-			}
-			if log.Err != nil {
-				failingItems = append(failingItems, log)
-			}
+	// Log transitions from no-error to error and vice-versa.
+	var failed, fixed []string
+	var failingItems reconciler.OperationLog
+	for _, log := range rs.OperationLog {
+		if log.PrevErr == nil && log.Err != nil {
+			failed = append(failed,
+				fmt.Sprintf("%v (err: %v)", dg.Reference(log.Item), log.Err))
 		}
-		if len(failed) > 0 {
-			r.log.Errorf("%s: Newly failed config items: %s",
-				LogAndErrPrefix, strings.Join(failed, ", "))
+		if log.PrevErr != nil && log.Err == nil {
+			fixed = append(fixed, dg.Reference(log.Item).String())
 		}
-		if len(fixed) > 0 {
-			r.log.Noticef("%s: Fixed config items: %s",
-				LogAndErrPrefix, strings.Join(fixed, ", "))
+		if log.Err != nil {
+			failingItems = append(failingItems, log)
 		}
-		delete(r.pendingReconcile, sgName)
+	}
+	if len(failed) > 0 {
+		r.log.Errorf("%s: Newly failed config items: %s",
+			LogAndErrPrefix, strings.Join(failed, ", "))
+	}
+	if len(fixed) > 0 {
+		r.log.Noticef("%s: Fixed config items: %s",
+			LogAndErrPrefix, strings.Join(fixed, ", "))
 	}
 
 	// Output the current state into a file for troubleshooting purposes.
@@ -557,95 +571,87 @@ func (r *LinuxNIReconciler) reconcile(ctx context.Context) (updates []Reconciler
 			}
 		}
 	}
-
-	// Return status updates for changed NIs and app connections.
-	for _, statusUpdate := range statusUpdateMap {
-		updates = append(updates, statusUpdate)
-	}
-	return updates
 }
 
-// Called after NI reconciliation to update status of the given network instance
-// and VIFs that connect to it.
-// Function adds detected status changes to statusUpdateMap.
-func (r *LinuxNIReconciler) updateNIStatus(niID uuid.UUID, currNISG dg.GraphR,
-	statusUpdateMap map[uuid.UUID]ReconcilerUpdate) (niStatus NIReconcileStatus) {
-	asyncInProgress, failedItems := r.getSubgraphState(currNISG)
+// Called after reconciliation to update status of the given network instance.
+func (r *LinuxNIReconciler) updateNIStatus(
+	niID uuid.UUID) (niStatus NIReconcileStatus, changed bool) {
 	var brIfName string
-	niInfo := r.nis[niID]
-	if niInfo != nil {
-		brIfName = niInfo.brIfName
-	}
-	brIfIndex, _, _ := r.netMonitor.GetInterfaceIndex(brIfName)
+	var brIfIndex int
+	niInfo := r.nis[niID] // guaranteed not to be nil
+	brIfName = niInfo.brIfName
+	brIfIndex, _, _ = r.netMonitor.GetInterfaceIndex(brIfName)
+	deleted := niInfo == nil || niInfo.deleted
+	sgName := NIToSGName(niID)
+	currSG := r.currentState.SubGraph(sgName)
+	intSG := r.intendedState.SubGraph(sgName)
+	inProgress, failedItems := r.getSubgraphState(intSG, currSG, false)
 	niStatus = NIReconcileStatus{
-		NI:              niID,
-		Deleted:         niInfo == nil || niInfo.deleted,
-		BrIfName:        brIfName,
-		BrIfIndex:       brIfIndex,
-		AsyncInProgress: asyncInProgress,
-		FailedItems:     failedItems,
+		NI:          niID,
+		Deleted:     deleted,
+		BrIfName:    brIfName,
+		BrIfIndex:   brIfIndex,
+		InProgress:  inProgress,
+		FailedItems: failedItems,
 	}
-	if niInfo == nil || !niInfo.status.Equal(niStatus) {
-		statusUpdateMap[niID] = ReconcilerUpdate{
-			UpdateType: NIReconcileStatusChanged,
-			NIStatus:   &niStatus,
-		}
-		if niInfo != nil {
-			niInfo.status = niStatus
-		}
+	if !niInfo.status.Equal(niStatus) {
+		changed = true
+		niInfo.status = niStatus
 	}
+	if deleted && !inProgress {
+		changed = true
+		delete(r.nis, niID)
+		if currSG != nil {
+			r.currentState.DelSubGraph(sgName)
+		}
+		r.log.Noticef("%s: Deleted niInfo for NI %s", LogAndErrPrefix, niID)
+	}
+	return
+}
 
-	// Update AppVIFReconcileStatus for all VIFs connected to this NI.
-	for appID, app := range r.apps {
-		var updated bool
-		for _, vif := range app.vifs {
-			if vif.NI != niID {
-				continue
-			}
-			vifStatus := AppVIFReconcileStatus{
-				NetAdapterName: vif.NetAdapterName,
-				VIFNum:         vif.VIFNum,
-				HostIfName:     vif.hostIfName,
-			}
-			appConnSG := currNISG.SubGraph(AppConnSGName(vif.App, vif.NetAdapterName))
-			if appConnSG != nil && !app.deleted {
-				vifStatus.AsyncInProgress, vifStatus.FailedItems =
-					r.getSubgraphState(appConnSG)
-				// Is VIF ready for use?
-				vifRef := dg.Reference(generic.VIF{IfName: vif.hostIfName})
-				item, state, _, found := appConnSG.Item(vifRef)
-				vifStatus.Ready = found && state.IsCreated() &&
-					!state.InTransition() && state.WithError() == nil
-				if vifStatus.Ready {
-					// Check that VIF is bridged.
-					vifItem, isVifItem := item.(generic.VIF)
-					vifStatus.Ready = isVifItem && vifItem.MasterIfName == niInfo.brIfName
-				}
-			}
-			if app.vifStatus == nil {
-				app.vifStatus = make(map[string]AppVIFReconcileStatus)
-			}
-			if !app.vifStatus[vif.NetAdapterName].Equal(vifStatus) {
-				app.vifStatus[vif.NetAdapterName] = vifStatus
-				updated = true
-			}
-		}
-		if updated {
-			appStatus := &AppConnReconcileStatus{
-				App:     appID,
-				Deleted: app.deleted,
-			}
-			for _, vif := range app.vifStatus {
-				appStatus.VIFs = append(appStatus.VIFs, vif)
-			}
-			appStatus.SortVIFs()
-			statusUpdateMap[appID] = ReconcilerUpdate{
-				UpdateType:    AppConnReconcileStatusChanged,
-				AppConnStatus: appStatus,
-			}
-		}
+// Called after reconciliation to update connectivity status of the given app.
+func (r *LinuxNIReconciler) updateAppConnStatus(
+	appID uuid.UUID) (appConnStatus AppConnReconcileStatus, changed bool) {
+	appInfo := r.apps[appID] // guaranteed not to be nil
+	appConnStatus = AppConnReconcileStatus{
+		App:     appID,
+		Deleted: appInfo.deleted,
 	}
-	return niStatus
+	var anyInProgress bool
+	for _, vif := range appInfo.vifs {
+		var currSG, intSG dg.GraphR
+		if niSG := r.currentState.SubGraph(NIToSGName(vif.NI)); niSG != nil {
+			currSG = niSG.SubGraph(AppConnSGName(vif.App, vif.NetAdapterName))
+		}
+		if niSG := r.intendedState.SubGraph(NIToSGName(vif.NI)); niSG != nil {
+			intSG = niSG.SubGraph(AppConnSGName(vif.App, vif.NetAdapterName))
+		}
+		inProgress, failedItems := r.getSubgraphState(intSG, currSG, true)
+		anyInProgress = anyInProgress || inProgress
+		vifStatus := AppVIFReconcileStatus{
+			NetAdapterName: vif.NetAdapterName,
+			VIFNum:         vif.VIFNum,
+			HostIfName:     vif.hostIfName,
+			InProgress:     inProgress,
+			FailedItems:    failedItems,
+		}
+		if appInfo.vifStatus == nil {
+			appInfo.vifStatus = make(map[string]AppVIFReconcileStatus)
+		}
+		if !appInfo.vifStatus[vif.NetAdapterName].Equal(vifStatus) {
+			appInfo.vifStatus[vif.NetAdapterName] = vifStatus
+			changed = true
+		}
+		appConnStatus.VIFs = append(appConnStatus.VIFs, vifStatus)
+	}
+	// Sort VIF status for deterministic order and easier unit-testing.
+	appConnStatus.SortVIFs()
+	if !anyInProgress && appInfo.deleted {
+		changed = true
+		delete(r.apps, appID)
+		r.log.Noticef("%s: Deleted appInfo for app %s", LogAndErrPrefix, appID)
+	}
+	return
 }
 
 // This function looks for any UDP port map rules among the ACLs and if so clears
@@ -705,28 +711,22 @@ func (r *LinuxNIReconciler) clearUDPFlows(ACLs []types.ACE, ipv6 bool) {
 	}
 }
 
-func (r *LinuxNIReconciler) addPendingReconcile(
-	forGlobalSG bool, forNI uuid.UUID, reason string) {
-	var sgName string
-	if forGlobalSG {
-		sgName = GlobalSG
-	} else {
-		sgName = NIToSGName(forNI)
+func (r *LinuxNIReconciler) scheduleGlobalCfgRebuild(reason string) {
+	if r.pendingReconcile.rebuildGlobalCfg == nil {
+		r.pendingReconcile.rebuildGlobalCfg = &pendingCfgRebuild{}
 	}
-	pReconcile := r.pendingReconcile[sgName]
-	pReconcile.forGlobalSG = forGlobalSG
-	pReconcile.forNI = forNI
-	var duplicateReason bool
-	for _, prevReason := range pReconcile.reasons {
-		if prevReason == reason {
-			duplicateReason = true
-			break
-		}
+	rebuild := r.pendingReconcile.rebuildGlobalCfg
+	if !utils.ContainsItem(rebuild.reasons, reason) {
+		rebuild.reasons = append(rebuild.reasons, reason)
 	}
-	if !duplicateReason {
-		pReconcile.reasons = append(pReconcile.reasons, reason)
+}
+
+func (r *LinuxNIReconciler) scheduleNICfgRebuild(niID uuid.UUID, reason string) {
+	rebuild := r.pendingReconcile.rebuildNICfg[niID]
+	if !utils.ContainsItem(rebuild.reasons, reason) {
+		rebuild.reasons = append(rebuild.reasons, reason)
 	}
-	r.pendingReconcile[sgName] = pReconcile
+	r.pendingReconcile.rebuildNICfg[niID] = rebuild
 }
 
 // RunInitialReconcile is called once by zedrouter at startup before any NI
@@ -735,8 +735,10 @@ func (r *LinuxNIReconciler) addPendingReconcile(
 func (r *LinuxNIReconciler) RunInitialReconcile(ctx context.Context) {
 	contWatcher := r.pauseWatcher()
 	defer contWatcher()
-	// Just reconcile the global configuration (primarily for BlackHole config).
-	r.addPendingReconcile(true, emptyUUID, "initial reconciliation")
+	// Initial state after a boot.
+	r.updateCurrentGlobalState(false)
+	// Build and reconcile the global configuration (primarily for BlackHole config).
+	r.scheduleGlobalCfgRebuild("initial reconciliation")
 	updates := r.reconcile(ctx)
 	r.publishReconcilerUpdates(updates...)
 }
@@ -766,7 +768,7 @@ func (r *LinuxNIReconciler) ApplyUpdatedGCP(ctx context.Context,
 			// Not running DHCP server for switch NI inside EVE.
 			continue
 		}
-		r.addPendingReconcile(false, niID,
+		r.scheduleNICfgRebuild(niID,
 			fmt.Sprintf("global config property %s changed to %t",
 				types.DisableDHCPAllOnesNetMask, r.disableAllOnesNetmask))
 	}
@@ -784,20 +786,9 @@ func (r *LinuxNIReconciler) AddNI(ctx context.Context,
 	if _, duplicate := r.nis[niID]; duplicate {
 		return niStatus, fmt.Errorf("%s: NI %v is already added", LogAndErrPrefix, niID)
 	}
-	var brIfName string
-	switch niConfig.Type {
-	case types.NetworkInstanceTypeSwitch:
-		if br.Uplink.IfName != "" {
-			brIfName = br.Uplink.IfName
-			break
-		}
-		// Air-gapped, create bridge just like for local NI.
-		fallthrough
-	case types.NetworkInstanceTypeLocal:
-		brIfName = fmt.Sprintf("%s%d", bridgeIfNamePrefix, br.BrNum)
-	default:
-		return niStatus, fmt.Errorf("%s: Unsupported type %v for NI %v",
-			LogAndErrPrefix, niConfig.Type, niID)
+	brIfName, err := r.generateBridgeIfName(niConfig, br)
+	if err != nil {
+		return niStatus, err
 	}
 	r.nis[niID] = &niInfo{
 		config:   niConfig,
@@ -805,10 +796,13 @@ func (r *LinuxNIReconciler) AddNI(ctx context.Context,
 		brIfName: brIfName,
 	}
 	reconcileReason := fmt.Sprintf("adding new NI (%v)", niID)
-	// Reconcile also GlobalSG to update the set of intended/current uplinks.
+	// Rebuild and reconcile also global config to update the set of intended/current
+	// uplinks.
 	r.updateCurrentGlobalState(true) // uplinks only
-	r.addPendingReconcile(true, emptyUUID, reconcileReason)
-	r.addPendingReconcile(false, niID, reconcileReason)
+	// Get the current state of external items used by NI.
+	r.updateCurrentNIState(niID)
+	r.scheduleGlobalCfgRebuild(reconcileReason)
+	r.scheduleNICfgRebuild(niID, reconcileReason)
 	updates := r.reconcile(ctx)
 	r.publishReconcilerUpdates(updates...)
 	niStatus = r.nis[niID].status
@@ -829,11 +823,21 @@ func (r *LinuxNIReconciler) UpdateNI(ctx context.Context,
 	}
 	r.nis[niID].config = niConfig
 	r.nis[niID].bridge = br
+	// Re-generate bridge interface name to support change in the select uplink port
+	// for switch network instances.
+	brIfName, err := r.generateBridgeIfName(niConfig, br)
+	if err != nil {
+		return niStatus, err
+	}
+	r.nis[niID].brIfName = brIfName
 	reconcileReason := fmt.Sprintf("updating NI (%v)", niID)
-	// Reconcile also GlobalSG to update the set of intended/current uplinks.
+	// Get the current state of external items to be used by NI.
+	r.updateCurrentNIState(niID)
+	// Rebuild and reconcile also global config to update the set of intended/current
+	// uplinks.
 	r.updateCurrentGlobalState(true) // uplinks only
-	r.addPendingReconcile(true, emptyUUID, reconcileReason)
-	r.addPendingReconcile(false, niID, reconcileReason)
+	r.scheduleGlobalCfgRebuild(reconcileReason)
+	r.scheduleNICfgRebuild(niID, reconcileReason)
 	updates := r.reconcile(ctx)
 	r.publishReconcilerUpdates(updates...)
 	niStatus = r.nis[niID].status
@@ -850,16 +854,32 @@ func (r *LinuxNIReconciler) DelNI(ctx context.Context,
 		return niStatus, fmt.Errorf("%s: Cannot delete NI %v: does not exist",
 			LogAndErrPrefix, niID)
 	}
+	// Deleted from the map when removal is completed successfully (incl. async ops).
 	r.nis[niID].deleted = true
+	niStatus = r.nis[niID].status
 	reconcileReason := fmt.Sprintf("deleting NI (%v)", niID)
-	// Reconcile also GlobalSG to update the set of intended/current uplinks.
+	// Rebuild and reconcile also global config to update the set of intended/current
+	// uplinks.
 	r.updateCurrentGlobalState(true) // uplinks only
-	r.addPendingReconcile(true, emptyUUID, reconcileReason)
-	r.addPendingReconcile(false, niID, reconcileReason)
+	r.scheduleGlobalCfgRebuild(reconcileReason)
+	r.scheduleNICfgRebuild(niID, reconcileReason)
+	// Cancel any in-progress configuration changes previously
+	// submitted for this NI.
+	sg := r.currentState.SubGraph(NIToSGName(niID))
+	if sg != nil && r.cancelAsync != nil {
+		r.cancelAsync(func(ref dg.ItemRef) bool {
+			_, _, _, isForThisNI := sg.Item(ref)
+			return isForThisNI
+		})
+	}
 	updates := r.reconcile(ctx)
 	r.publishReconcilerUpdates(updates...)
-	niStatus = r.nis[niID].status
-	delete(r.nis, niID)
+	// r.nis[niID] could be deleted by this point
+	for _, update := range updates {
+		if update.UpdateType == NIReconcileStatusChanged && update.NIStatus.NI == niID {
+			niStatus = *update.NIStatus
+		}
+	}
 	return niStatus, nil
 }
 
@@ -886,22 +906,23 @@ func (r *LinuxNIReconciler) ConnectApp(ctx context.Context,
 	for _, vif := range vifs {
 		appInfo.vifs = append(appInfo.vifs, vifInfo{
 			AppVIF:     vif,
-			hostIfName: fmt.Sprintf("%s%dx%d", vifIfNamePrefix, vif.VIFNum, appNum),
+			hostIfName: r.generateVifHostIfName(vif.VIFNum, appNum),
 		})
 	}
 	r.apps[appID] = appInfo
 	reconcileReason := fmt.Sprintf("connecting new app (%v)", appID)
-	// Reconcile also GlobalSG to update the set of intended IPSets.
-	r.addPendingReconcile(true, emptyUUID, reconcileReason)
-	// Reconcile every NI that this app is trying to connect into.
+	// Rebuild and reconcile also global config to update the set of intended IPSets.
+	r.scheduleGlobalCfgRebuild(reconcileReason)
+	// Rebuild and reconcile config of every NI that this app is trying to connect into.
 	for _, vif := range vifs {
-		r.addPendingReconcile(false, vif.NI, reconcileReason)
+		r.scheduleNICfgRebuild(vif.NI, reconcileReason)
 	}
 	updates := r.reconcile(ctx)
 	r.publishReconcilerUpdates(updates...)
 	for _, vifStatus := range r.apps[appID].vifStatus {
 		appStatus.VIFs = append(appStatus.VIFs, vifStatus)
 	}
+	// Sort VIF status for deterministic order and easier unit-testing.
 	appStatus.SortVIFs()
 	return appStatus, nil
 }
@@ -925,28 +946,28 @@ func (r *LinuxNIReconciler) ReconnectApp(ctx context.Context,
 	appInfo.vifStatus = nil
 	for _, vif := range vifs {
 		appInfo.vifs = append(appInfo.vifs, vifInfo{
-			AppVIF: vif,
-			hostIfName: fmt.Sprintf("%s%dx%d", vifIfNamePrefix, vif.VIFNum,
-				appInfo.appNum),
+			AppVIF:     vif,
+			hostIfName: r.generateVifHostIfName(vif.VIFNum, appInfo.appNum),
 		})
 	}
 	r.apps[appID] = appInfo
 	reconcileReason := fmt.Sprintf("reconnecting app (%v)", appID)
-	// Reconcile also GlobalSG to update the set of intended IPSets.
-	r.addPendingReconcile(true, emptyUUID, reconcileReason)
+	// Rebuild and reconcile also global config to update the set of intended IPSets.
+	r.scheduleGlobalCfgRebuild(reconcileReason)
 	// Reconcile every NI that this app is either disconnecting from or trying
 	// to (re)connect into.
 	for _, vif := range prevVifs {
-		r.addPendingReconcile(false, vif.NI, reconcileReason)
+		r.scheduleNICfgRebuild(vif.NI, reconcileReason)
 	}
 	for _, vif := range vifs {
-		r.addPendingReconcile(false, vif.NI, reconcileReason)
+		r.scheduleNICfgRebuild(vif.NI, reconcileReason)
 	}
 	updates := r.reconcile(ctx)
 	r.publishReconcilerUpdates(updates...)
 	for _, vifStatus := range r.apps[appID].vifStatus {
 		appStatus.VIFs = append(appStatus.VIFs, vifStatus)
 	}
+	// Sort VIF status for deterministic order and easier unit-testing.
 	appStatus.SortVIFs()
 	return appStatus, nil
 }
@@ -961,21 +982,24 @@ func (r *LinuxNIReconciler) DisconnectApp(ctx context.Context,
 		return appStatus, fmt.Errorf("%s: Cannot disconnect App %v: does not exist",
 			LogAndErrPrefix, appID)
 	}
+	// Deleted from the map when removal is completed successfully (incl. async ops).
 	r.apps[appID].deleted = true
 	reconcileReason := fmt.Sprintf("disconnecting app (%v)", appID)
-	// Reconcile also GlobalSG to update the set of intended IPSets.
-	r.addPendingReconcile(true, emptyUUID, reconcileReason)
+	// Rebuild and reconcile also global config to update the set of intended IPSets.
+	r.scheduleGlobalCfgRebuild(reconcileReason)
 	// Reconcile every NI that this app is trying to disconnect from.
 	for _, vif := range r.apps[appID].vifs {
-		r.addPendingReconcile(false, vif.NI, reconcileReason)
+		r.scheduleNICfgRebuild(vif.NI, reconcileReason)
 	}
 	updates := r.reconcile(ctx)
 	r.publishReconcilerUpdates(updates...)
-	for _, vifStatus := range r.apps[appID].vifStatus {
-		appStatus.VIFs = append(appStatus.VIFs, vifStatus)
+	// r.apps[appID] could be deleted by this point
+	for _, update := range updates {
+		if update.UpdateType == AppConnReconcileStatusChanged &&
+			update.AppConnStatus.App == appID {
+			appStatus = *update.AppConnStatus
+		}
 	}
-	appStatus.SortVIFs()
-	delete(r.apps, appID)
 	return appStatus, nil
 }
 
@@ -1023,13 +1047,51 @@ func (r *LinuxNIReconciler) getNIWithBridge(ifName string) *niInfo {
 	return nil
 }
 
-func (r *LinuxNIReconciler) getSubgraphState(sg dg.GraphR) (
-	asyncInProgress bool, failedItems map[dg.ItemRef]error) {
-	iter := sg.Items(true)
+// Function returns inProgress as true if any intended item is missing or is still being
+// asynchronously updated or if there is an unintended item not yet deleted.
+// Additionally, returns a map of items for which the last operation failed.
+func (r *LinuxNIReconciler) getSubgraphState(intSG, currSG dg.GraphR, forApp bool) (
+	inProgress bool, failedItems map[dg.ItemRef]error) {
+	if currSG == nil {
+		if intSG == nil {
+			return false, nil
+		}
+		emptyIntSG := intSG.Items(true).Next() == false
+		return !emptyIntSG, nil
+	}
+	itemIsForApp := func(item dg.Item) bool {
+		// XXX Better would be to check if item is inside AppConn-* subgraph
+		// but depgraph API does not allow to do that.
+		if item.Type() == generic.VIFTypename {
+			return true
+		}
+		if item.Type() == linux.VLANPortTypename {
+			if item.(linux.VLANPort).BridgePort.VIFIfName != "" {
+				return true
+			}
+		}
+		return false
+	}
+	ignoreExtraItem := func(item dg.Item) bool {
+		// Ignore if extra item is external.
+		if item.External() {
+			return true
+		}
+		// Also ignore extra routes added by kernel.
+		route, isRoute := item.(linux.Route)
+		if isRoute && route.Dst != nil && route.Dst.IP.IsLinkLocalUnicast() {
+			return true
+		}
+		return false
+	}
+	iter := currSG.Items(true)
 	for iter.Next() {
 		item, state := iter.Item()
+		if !forApp && itemIsForApp(item) {
+			continue
+		}
 		if state.InTransition() {
-			asyncInProgress = true
+			inProgress = true
 		}
 		if itemErr := state.WithError(); itemErr != nil {
 			if failedItems == nil {
@@ -1038,5 +1100,35 @@ func (r *LinuxNIReconciler) getSubgraphState(sg dg.GraphR) (
 			failedItems[dg.Reference(item)] = itemErr
 		}
 	}
-	return asyncInProgress, failedItems
+	if intSG == nil {
+		iter := currSG.Items(true)
+		for iter.Next() {
+			item, _ := iter.Item()
+			if !forApp && itemIsForApp(item) {
+				continue
+			}
+			if ignoreExtraItem(item) {
+				continue
+			}
+			inProgress = true
+		}
+		return inProgress, failedItems
+	}
+	diff := currSG.DiffItems(intSG)
+	for _, itemRef := range diff {
+		intItem, _, _, shouldExist := intSG.Item(itemRef)
+		currItem, _, _, exists := currSG.Item(itemRef)
+		item := intItem
+		if item == nil {
+			item = currItem
+		}
+		if !forApp && item != nil && itemIsForApp(item) {
+			continue
+		}
+		if exists && !shouldExist && ignoreExtraItem(item) {
+			continue
+		}
+		inProgress = true
+	}
+	return inProgress, failedItems
 }

--- a/pkg/pillar/nireconciler/linux_test.go
+++ b/pkg/pillar/nireconciler/linux_test.go
@@ -946,7 +946,7 @@ func TestSingleLocalNI(test *testing.T) {
 	t.Expect(err).ToNot(HaveOccurred())
 	t.Expect(niStatus.NI).To(Equal(ni1UUID.UUID))
 	t.Expect(niStatus.Deleted).To(BeFalse())
-	t.Expect(niStatus.AsyncInProgress).To(BeFalse())
+	t.Expect(niStatus.InProgress).To(BeFalse())
 	t.Expect(niStatus.BrIfName).To(Equal("bn1"))
 	t.Expect(niStatus.FailedItems).To(BeEmpty())
 
@@ -1033,9 +1033,8 @@ func TestSingleLocalNI(test *testing.T) {
 	t.Expect(appStatus.Deleted).To(BeFalse())
 	t.Expect(appStatus.VIFs).To(HaveLen(1))
 	t.Expect(appStatus.VIFs[0].NetAdapterName).To(Equal("adapter1"))
-	t.Expect(appStatus.VIFs[0].AsyncInProgress).To(BeFalse())
+	t.Expect(appStatus.VIFs[0].InProgress).To(BeTrue())
 	t.Expect(appStatus.VIFs[0].HostIfName).To(Equal("nbu1x1"))
-	t.Expect(appStatus.VIFs[0].Ready).To(BeFalse())
 	t.Expect(appStatus.VIFs[0].FailedItems).To(BeEmpty())
 
 	t.Eventually(updatesCh).Should(Receive(&recUpdate))
@@ -1063,7 +1062,7 @@ func TestSingleLocalNI(test *testing.T) {
 
 	t.Eventually(updatesCh).Should(Receive(&recUpdate))
 	t.Expect(recUpdate.UpdateType).To(Equal(nirec.AppConnReconcileStatusChanged))
-	t.Expect(recUpdate.AppConnStatus.VIFs[0].Ready).To(BeTrue())
+	t.Expect(recUpdate.AppConnStatus.VIFs[0].InProgress).To(BeFalse())
 	t.Expect(recUpdate.AppConnStatus.VIFs[0].FailedItems).To(BeEmpty())
 
 	graphs := []dg.GraphR{niReconciler.GetIntendedState(), niReconciler.GetCurrentState()}
@@ -1129,9 +1128,8 @@ func TestSingleLocalNI(test *testing.T) {
 	t.Expect(appStatus.Deleted).To(BeTrue())
 	t.Expect(appStatus.VIFs).To(HaveLen(1))
 	t.Expect(appStatus.VIFs[0].NetAdapterName).To(Equal("adapter1"))
-	t.Expect(appStatus.VIFs[0].AsyncInProgress).To(BeFalse())
+	t.Expect(appStatus.VIFs[0].InProgress).To(BeFalse())
 	t.Expect(appStatus.VIFs[0].HostIfName).To(Equal("nbu1x1"))
-	t.Expect(appStatus.VIFs[0].Ready).To(BeFalse())
 	t.Expect(appStatus.VIFs[0].FailedItems).To(BeEmpty())
 
 	t.Eventually(updatesCh).Should(Receive(&recUpdate))
@@ -1156,7 +1154,7 @@ func TestSingleLocalNI(test *testing.T) {
 	t.Expect(err).ToNot(HaveOccurred())
 	t.Expect(niStatus.NI).To(Equal(ni1UUID.UUID))
 	t.Expect(niStatus.Deleted).To(BeTrue())
-	t.Expect(niStatus.AsyncInProgress).To(BeFalse())
+	t.Expect(niStatus.InProgress).To(BeFalse())
 	t.Expect(niStatus.BrIfName).To(Equal("bn1"))
 	t.Expect(niStatus.FailedItems).To(BeEmpty())
 	networkMonitor.DelInterface(ni1BridgeIf.Attrs.IfName)
@@ -1178,6 +1176,7 @@ func TestIPv4LocalAndSwitchNIs(test *testing.T) {
 	eth1IPs := eth1.IPAddrs
 	eth1.IPAddrs = nil
 	networkMonitor.AddOrUpdateInterface(eth0)
+	networkMonitor.AddOrUpdateInterface(keth1)
 	networkMonitor.AddOrUpdateInterface(eth1)
 	networkMonitor.UpdateRoutes(eth0Routes)
 	ctx := reconciler.MockRun(context.Background())
@@ -1189,7 +1188,7 @@ func TestIPv4LocalAndSwitchNIs(test *testing.T) {
 	t.Expect(err).ToNot(HaveOccurred())
 	t.Expect(niStatus.NI).To(Equal(ni1UUID.UUID))
 	t.Expect(niStatus.Deleted).To(BeFalse())
-	t.Expect(niStatus.AsyncInProgress).To(BeFalse())
+	t.Expect(niStatus.InProgress).To(BeFalse())
 	t.Expect(niStatus.BrIfName).To(Equal("bn1"))
 	t.Expect(niStatus.FailedItems).To(BeEmpty())
 
@@ -1225,7 +1224,7 @@ func TestIPv4LocalAndSwitchNIs(test *testing.T) {
 	t.Expect(err).ToNot(HaveOccurred())
 	t.Expect(niStatus.NI).To(Equal(ni2UUID.UUID))
 	t.Expect(niStatus.Deleted).To(BeFalse())
-	t.Expect(niStatus.AsyncInProgress).To(BeFalse())
+	t.Expect(niStatus.InProgress).To(BeFalse())
 	t.Expect(niStatus.BrIfName).To(Equal("eth1"))
 	t.Expect(niStatus.FailedItems).To(BeEmpty())
 
@@ -1264,19 +1263,16 @@ func TestIPv4LocalAndSwitchNIs(test *testing.T) {
 	t.Expect(appStatus.Deleted).To(BeFalse())
 	t.Expect(appStatus.VIFs).To(HaveLen(3))
 	t.Expect(appStatus.VIFs[0].NetAdapterName).To(Equal("adapter1"))
-	t.Expect(appStatus.VIFs[0].AsyncInProgress).To(BeFalse())
+	t.Expect(appStatus.VIFs[0].InProgress).To(BeTrue())
 	t.Expect(appStatus.VIFs[0].HostIfName).To(Equal("nbu1x2"))
-	t.Expect(appStatus.VIFs[0].Ready).To(BeFalse())
 	t.Expect(appStatus.VIFs[0].FailedItems).To(BeEmpty())
 	t.Expect(appStatus.VIFs[1].NetAdapterName).To(Equal("adapter2"))
-	t.Expect(appStatus.VIFs[1].AsyncInProgress).To(BeFalse())
+	t.Expect(appStatus.VIFs[1].InProgress).To(BeTrue())
 	t.Expect(appStatus.VIFs[1].HostIfName).To(Equal("nbu2x2"))
-	t.Expect(appStatus.VIFs[1].Ready).To(BeFalse())
 	t.Expect(appStatus.VIFs[1].FailedItems).To(BeEmpty())
 	t.Expect(appStatus.VIFs[2].NetAdapterName).To(Equal("adapter3"))
-	t.Expect(appStatus.VIFs[2].AsyncInProgress).To(BeFalse())
+	t.Expect(appStatus.VIFs[2].InProgress).To(BeTrue())
 	t.Expect(appStatus.VIFs[2].HostIfName).To(Equal("nbu3x2"))
-	t.Expect(appStatus.VIFs[2].Ready).To(BeFalse())
 	t.Expect(appStatus.VIFs[2].FailedItems).To(BeEmpty())
 
 	t.Eventually(updatesCh).Should(Receive(&recUpdate))
@@ -1300,9 +1296,9 @@ func TestIPv4LocalAndSwitchNIs(test *testing.T) {
 	t.Expect(recUpdate.UpdateType).To(Equal(nirec.AppConnReconcileStatusChanged))
 	for i := 0; i < 3; i++ {
 		if i < 2 {
-			t.Expect(recUpdate.AppConnStatus.VIFs[i].Ready).To(BeTrue())
+			t.Expect(recUpdate.AppConnStatus.VIFs[i].InProgress).To(BeFalse())
 		} else {
-			t.Expect(recUpdate.AppConnStatus.VIFs[i].Ready).To(BeFalse())
+			t.Expect(recUpdate.AppConnStatus.VIFs[i].InProgress).To(BeTrue())
 		}
 		t.Expect(recUpdate.AppConnStatus.VIFs[i].FailedItems).To(BeEmpty())
 	}
@@ -1348,7 +1344,7 @@ func TestIPv4LocalAndSwitchNIs(test *testing.T) {
 
 	t.Eventually(updatesCh).Should(Receive(&recUpdate))
 	t.Expect(recUpdate.UpdateType).To(Equal(nirec.AppConnReconcileStatusChanged))
-	t.Expect(recUpdate.AppConnStatus.VIFs[2].Ready).To(BeTrue())
+	t.Expect(recUpdate.AppConnStatus.VIFs[2].InProgress).To(BeFalse())
 
 	t.Expect(itemIsCreated(dg.Reference(
 		linuxitems.VLANPort{
@@ -1371,7 +1367,7 @@ func TestIPv4LocalAndSwitchNIs(test *testing.T) {
 	t.Expect(appStatus.Deleted).To(BeFalse())
 	t.Expect(appStatus.VIFs).To(HaveLen(3))
 	for i := 0; i < 3; i++ {
-		t.Expect(appStatus.VIFs[i].Ready).To(BeTrue())
+		t.Expect(appStatus.VIFs[i].InProgress).To(BeFalse())
 		t.Expect(appStatus.VIFs[i].FailedItems).To(BeEmpty())
 	}
 
@@ -1389,7 +1385,7 @@ func TestIPv4LocalAndSwitchNIs(test *testing.T) {
 	t.Expect(appStatus.Deleted).To(BeTrue())
 	t.Expect(appStatus.VIFs).To(HaveLen(3))
 	for i := 0; i < 3; i++ {
-		t.Expect(appStatus.VIFs[i].Ready).To(BeFalse())
+		t.Expect(appStatus.VIFs[i].InProgress).To(BeFalse())
 	}
 
 	// Delete network instances
@@ -1476,7 +1472,7 @@ func TestUplinkFailover(test *testing.T) {
 	niReconciler.ResumeReconcile(ctx)
 	t.Eventually(updatesCh).Should(Receive(&recUpdate))
 	t.Expect(recUpdate.UpdateType).To(Equal(nirec.AppConnReconcileStatusChanged))
-	t.Expect(recUpdate.AppConnStatus.VIFs[0].Ready).To(BeTrue())
+	t.Expect(recUpdate.AppConnStatus.VIFs[0].InProgress).To(BeFalse())
 
 	eth0PortMapRuleIn := iptables.Rule{
 		RuleLabel: "User-configured PORTMAP ACL rule 4 for uplink IP 192.168.10.5 from inside",
@@ -1551,7 +1547,7 @@ func TestUplinkFailover(test *testing.T) {
 	niStatus, err := niReconciler.UpdateNI(ctx, ni1Config, ni1Bridge)
 	t.Expect(niStatus.NI).To(Equal(ni1UUID.UUID))
 	t.Expect(niStatus.Deleted).To(BeFalse())
-	t.Expect(niStatus.AsyncInProgress).To(BeFalse())
+	t.Expect(niStatus.InProgress).To(BeFalse())
 	t.Expect(niStatus.BrIfName).To(Equal("bn1"))
 	t.Expect(niStatus.FailedItems).To(BeEmpty())
 
@@ -1573,7 +1569,7 @@ func TestUplinkFailover(test *testing.T) {
 	niStatus, err = niReconciler.UpdateNI(ctx, ni1Config, ni1Bridge)
 	t.Expect(niStatus.NI).To(Equal(ni1UUID.UUID))
 	t.Expect(niStatus.Deleted).To(BeFalse())
-	t.Expect(niStatus.AsyncInProgress).To(BeFalse())
+	t.Expect(niStatus.InProgress).To(BeFalse())
 	t.Expect(niStatus.BrIfName).To(Equal("bn1"))
 	t.Expect(niStatus.FailedItems).To(BeEmpty())
 
@@ -1601,6 +1597,7 @@ func TestUplinkFailover(test *testing.T) {
 
 func TestIPv6LocalAndSwitchNIs(test *testing.T) {
 	t := initTest(test)
+	networkMonitor.AddOrUpdateInterface(keth2)
 	networkMonitor.AddOrUpdateInterface(eth2)
 	networkMonitor.UpdateRoutes(eth2Routes)
 	ctx := reconciler.MockRun(context.Background())
@@ -1612,7 +1609,7 @@ func TestIPv6LocalAndSwitchNIs(test *testing.T) {
 	t.Expect(err).ToNot(HaveOccurred())
 	t.Expect(niStatus.NI).To(Equal(ni3UUID.UUID))
 	t.Expect(niStatus.Deleted).To(BeFalse())
-	t.Expect(niStatus.AsyncInProgress).To(BeFalse())
+	t.Expect(niStatus.InProgress).To(BeFalse())
 	t.Expect(niStatus.BrIfName).To(Equal("bn3"))
 	t.Expect(niStatus.FailedItems).To(BeEmpty())
 
@@ -1628,7 +1625,7 @@ func TestIPv6LocalAndSwitchNIs(test *testing.T) {
 	t.Expect(err).ToNot(HaveOccurred())
 	t.Expect(niStatus.NI).To(Equal(ni4UUID.UUID))
 	t.Expect(niStatus.Deleted).To(BeFalse())
-	t.Expect(niStatus.AsyncInProgress).To(BeFalse())
+	t.Expect(niStatus.InProgress).To(BeFalse())
 	t.Expect(niStatus.BrIfName).To(Equal("eth2"))
 	t.Expect(niStatus.FailedItems).To(BeEmpty())
 
@@ -1655,14 +1652,12 @@ func TestIPv6LocalAndSwitchNIs(test *testing.T) {
 	t.Expect(appStatus.Deleted).To(BeFalse())
 	t.Expect(appStatus.VIFs).To(HaveLen(2))
 	t.Expect(appStatus.VIFs[0].NetAdapterName).To(Equal("adapter1"))
-	t.Expect(appStatus.VIFs[0].AsyncInProgress).To(BeFalse())
+	t.Expect(appStatus.VIFs[0].InProgress).To(BeTrue())
 	t.Expect(appStatus.VIFs[0].HostIfName).To(Equal("nbu1x3"))
-	t.Expect(appStatus.VIFs[0].Ready).To(BeFalse())
 	t.Expect(appStatus.VIFs[0].FailedItems).To(BeEmpty())
 	t.Expect(appStatus.VIFs[1].NetAdapterName).To(Equal("adapter2"))
-	t.Expect(appStatus.VIFs[1].AsyncInProgress).To(BeFalse())
+	t.Expect(appStatus.VIFs[1].InProgress).To(BeTrue())
 	t.Expect(appStatus.VIFs[1].HostIfName).To(Equal("nbu2x3"))
-	t.Expect(appStatus.VIFs[1].Ready).To(BeFalse())
 	t.Expect(appStatus.VIFs[1].FailedItems).To(BeEmpty())
 
 	t.Eventually(updatesCh).Should(Receive(&recUpdate))
@@ -1679,8 +1674,8 @@ func TestIPv6LocalAndSwitchNIs(test *testing.T) {
 	niReconciler.ResumeReconcile(ctx)
 	t.Eventually(updatesCh).Should(Receive(&recUpdate))
 	t.Expect(recUpdate.UpdateType).To(Equal(nirec.AppConnReconcileStatusChanged))
-	t.Expect(recUpdate.AppConnStatus.VIFs[0].Ready).To(BeTrue())
-	t.Expect(recUpdate.AppConnStatus.VIFs[1].Ready).To(BeTrue())
+	t.Expect(recUpdate.AppConnStatus.VIFs[0].InProgress).To(BeFalse())
+	t.Expect(recUpdate.AppConnStatus.VIFs[1].InProgress).To(BeFalse())
 
 	vif2VLAN := linuxitems.VLANPort{
 		BridgeIfName: "eth2",
@@ -1817,7 +1812,7 @@ func TestAirGappedLocalAndSwitchNIs(test *testing.T) {
 	t.Expect(err).ToNot(HaveOccurred())
 	t.Expect(niStatus.NI).To(Equal(ni1UUID.UUID))
 	t.Expect(niStatus.Deleted).To(BeFalse())
-	t.Expect(niStatus.AsyncInProgress).To(BeFalse())
+	t.Expect(niStatus.InProgress).To(BeFalse())
 	t.Expect(niStatus.BrIfName).To(Equal("bn1"))
 	t.Expect(niStatus.FailedItems).To(BeEmpty())
 
@@ -1861,7 +1856,7 @@ func TestAirGappedLocalAndSwitchNIs(test *testing.T) {
 	t.Expect(err).ToNot(HaveOccurred())
 	t.Expect(niStatus.NI).To(Equal(ni2UUID.UUID))
 	t.Expect(niStatus.Deleted).To(BeFalse())
-	t.Expect(niStatus.AsyncInProgress).To(BeFalse())
+	t.Expect(niStatus.InProgress).To(BeFalse())
 	t.Expect(niStatus.BrIfName).To(Equal("bn2"))
 	t.Expect(niStatus.FailedItems).To(BeEmpty())
 
@@ -1896,19 +1891,16 @@ func TestAirGappedLocalAndSwitchNIs(test *testing.T) {
 	t.Expect(appStatus.Deleted).To(BeFalse())
 	t.Expect(appStatus.VIFs).To(HaveLen(3))
 	t.Expect(appStatus.VIFs[0].NetAdapterName).To(Equal("adapter1"))
-	t.Expect(appStatus.VIFs[0].AsyncInProgress).To(BeFalse())
+	t.Expect(appStatus.VIFs[0].InProgress).To(BeTrue())
 	t.Expect(appStatus.VIFs[0].HostIfName).To(Equal("nbu1x2"))
-	t.Expect(appStatus.VIFs[0].Ready).To(BeFalse())
 	t.Expect(appStatus.VIFs[0].FailedItems).To(BeEmpty())
 	t.Expect(appStatus.VIFs[1].NetAdapterName).To(Equal("adapter2"))
-	t.Expect(appStatus.VIFs[1].AsyncInProgress).To(BeFalse())
+	t.Expect(appStatus.VIFs[1].InProgress).To(BeTrue())
 	t.Expect(appStatus.VIFs[1].HostIfName).To(Equal("nbu2x2"))
-	t.Expect(appStatus.VIFs[1].Ready).To(BeFalse())
 	t.Expect(appStatus.VIFs[1].FailedItems).To(BeEmpty())
 	t.Expect(appStatus.VIFs[2].NetAdapterName).To(Equal("adapter3"))
-	t.Expect(appStatus.VIFs[2].AsyncInProgress).To(BeFalse())
+	t.Expect(appStatus.VIFs[2].InProgress).To(BeTrue())
 	t.Expect(appStatus.VIFs[2].HostIfName).To(Equal("nbu3x2"))
-	t.Expect(appStatus.VIFs[2].Ready).To(BeFalse())
 	t.Expect(appStatus.VIFs[2].FailedItems).To(BeEmpty())
 
 	t.Eventually(updatesCh).Should(Receive(&recUpdate))
@@ -1932,7 +1924,7 @@ func TestAirGappedLocalAndSwitchNIs(test *testing.T) {
 	t.Eventually(updatesCh).Should(Receive(&recUpdate))
 	t.Expect(recUpdate.UpdateType).To(Equal(nirec.AppConnReconcileStatusChanged))
 	for i := 0; i < 3; i++ {
-		t.Expect(recUpdate.AppConnStatus.VIFs[i].Ready).To(BeTrue())
+		t.Expect(recUpdate.AppConnStatus.VIFs[i].InProgress).To(BeFalse())
 		t.Expect(recUpdate.AppConnStatus.VIFs[i].FailedItems).To(BeEmpty())
 	}
 
@@ -1975,7 +1967,7 @@ func TestAirGappedLocalAndSwitchNIs(test *testing.T) {
 	t.Expect(appStatus.Deleted).To(BeFalse())
 	t.Expect(appStatus.VIFs).To(HaveLen(3))
 	for i := 0; i < 3; i++ {
-		t.Expect(appStatus.VIFs[i].Ready).To(BeTrue())
+		t.Expect(appStatus.VIFs[i].InProgress).To(BeFalse())
 		t.Expect(appStatus.VIFs[i].FailedItems).To(BeEmpty())
 	}
 
@@ -1991,7 +1983,7 @@ func TestAirGappedLocalAndSwitchNIs(test *testing.T) {
 	t.Expect(appStatus.Deleted).To(BeTrue())
 	t.Expect(appStatus.VIFs).To(HaveLen(3))
 	for i := 0; i < 3; i++ {
-		t.Expect(appStatus.VIFs[i].Ready).To(BeFalse())
+		t.Expect(appStatus.VIFs[i].InProgress).To(BeFalse())
 	}
 
 	// Delete network instances

--- a/pkg/pillar/nireconciler/linuxitems/bridge.go
+++ b/pkg/pillar/nireconciler/linuxitems/bridge.go
@@ -74,6 +74,13 @@ func (b Bridge) Dependencies() (deps []dg.Dependency) {
 	return nil
 }
 
+// GetAssignedIPs returns IP addresses assigned to the bridge interface.
+// The function is needed for the definition of dependencies for
+// dnsmasq and HTTP server.
+func (b Bridge) GetAssignedIPs() []*net.IPNet {
+	return b.IPAddresses
+}
+
 // BridgeConfigurator implements Configurator interface (libs/reconciler) for Linux bridge.
 type BridgeConfigurator struct {
 	Log *base.LogObject

--- a/pkg/pillar/nireconciler/nireconciler.go
+++ b/pkg/pillar/nireconciler/nireconciler.go
@@ -186,8 +186,9 @@ type NIReconcileStatus struct {
 	// BrIfIndex : integer used as a handle for the bridge interface
 	// inside the network stack.
 	BrIfIndex int
-	// AsyncInProgress is true if any async operations are in progress.
-	AsyncInProgress bool
+	// InProgress is true if any config operations are still in progress
+	// (i.e. network instance is not yet fully created).
+	InProgress bool
 	// FailedItems : The set of configuration items currently in a failed state.
 	FailedItems map[dg.ItemRef]error
 }
@@ -204,7 +205,7 @@ func (s NIReconcileStatus) Equal(s2 NIReconcileStatus) bool {
 	}
 	return s.NI == s2.NI && s.Deleted == s2.Deleted &&
 		s.BrIfName == s2.BrIfName &&
-		s.AsyncInProgress == s2.AsyncInProgress
+		s.InProgress == s2.InProgress
 }
 
 // AppConnReconcileStatus : status of the config reconciliation related to application
@@ -246,14 +247,12 @@ type AppVIFReconcileStatus struct {
 	VIFNum int
 	// HostIfName : name of the interface inside the network stack on the host-side.
 	HostIfName string
-	// Ready is true if the VIF interface is ready for use or if some configuration
-	// operations are still in progress or pending.
-	// VIF is typically created in cooperation with zedmanager + domainmgr, meaning
-	// that NIReconciler may spend some time waiting for an action to be completed
+	// True if any config operations are still in progress
+	// (i.e. VIF is not yet fully created and ready).
+	// Note that VIF is typically created in cooperation with zedmanager + domainmgr,
+	// meaning that NIReconciler may spend some time waiting for an action to be completed
 	// by other microservices.
-	Ready bool
-	// True if any async operations are in progress.
-	AsyncInProgress bool
+	InProgress bool
 	// FailedItems : The set of configuration items currently in a failed state.
 	FailedItems map[dg.ItemRef]error
 }
@@ -269,6 +268,5 @@ func (s AppVIFReconcileStatus) Equal(s2 AppVIFReconcileStatus) bool {
 		}
 	}
 	return s.NetAdapterName == s2.NetAdapterName && s.VIFNum == s2.VIFNum &&
-		s.HostIfName == s2.HostIfName && s.Ready == s2.Ready &&
-		s.AsyncInProgress == s2.AsyncInProgress
+		s.HostIfName == s2.HostIfName && s.InProgress == s2.InProgress
 }

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -2610,6 +2610,7 @@ type NetworkInstanceStatus struct {
 	Activate uint64
 
 	ChangeInProgress ChangeInProgressType
+	NIConflict       bool // True if config conflicts with another NI
 
 	// Activated is true if the network instance has been created in the network stack.
 	Activated bool

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -157,6 +157,7 @@ type AppNetworkStatus struct {
 	PendingAdd     bool
 	PendingModify  bool
 	PendingDelete  bool
+	ConfigInSync   bool
 	DisplayName    string
 	// Copy from the AppNetworkConfig; used to delete when config is gone.
 	GetStatsIPAddr       net.IP

--- a/pkg/pillar/utils/generics.go
+++ b/pkg/pillar/utils/generics.go
@@ -138,3 +138,26 @@ func FilterDuplicatesFn[Type any](list []Type, equal func(a, b Type) bool) (filt
 	}
 	return
 }
+
+// ContainsItem returns true if the slice contains the given item.
+// This function can be used if slice items are comparable
+// (operator "==" can be used).
+func ContainsItem[Type comparable](list []Type, item Type) bool {
+	for i := range list {
+		if list[i] == item {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsItemFn returns true if the slice contains the given item.
+// Two slice items are compared using the provided "equal" callback.
+func ContainsItemFn[Type any](list []Type, item Type, equal func(a, b Type) bool) bool {
+	for i := range list {
+		if equal(list[i], item) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/reconciler/README.md
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/reconciler/README.md
@@ -369,9 +369,9 @@ type MyAgent struct {
      registry       reconciler.ConfiguratorRegistry
 
      // To manage asynchronous operations.
-     resumeReconciliation <-chan struct{}     // nil if no async ops
-     cancelAsyncOps       context.CancelFunc  // nil if no async ops
-     waitForAsyncOps      func()              // NOOP if no async ops
+     resumeReconciliation <-chan struct{}        // nil if no async ops
+     cancelAsyncOps       reconciler.CancelFunc  // nil if no async ops
+     waitForAsyncOps      func()                 // NOOP if no async ops
 }
 
 func (a *MyAgent) main() {
@@ -395,7 +395,7 @@ func (a *MyAgent) main() {
                case <- event2:
                     // If you need to cancel all asynchronous operations, run:
                     if a.cancelAsyncOps != nil {
-                         a.cancelAsyncOps()
+                         a.cancelAsyncOps(nil)
                          a.waitForAsyncOps()
                          fmt.Println("Asynchronous operations were canceled!")
                     }

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/reconciler/async.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/reconciler/async.go
@@ -61,12 +61,14 @@ func (c *asyncManager) reconcileEnds() (anyAsyncOps bool, resumeChan <-chan stri
 	return false, nil
 }
 
-func (c *asyncManager) cancelOps() {
+func (c *asyncManager) cancelOps(cancelForItem func(ref dg.ItemRef) bool) {
 	c.Lock()
 	defer c.Unlock()
 	for _, asyncOp := range c.asyncOps {
-		cancel := asyncOp.params.cancel
-		if cancel != nil {
+		if cancelForItem != nil && !cancelForItem(asyncOp.params.itemRef) {
+			continue
+		}
+		if cancel := asyncOp.params.cancel; cancel != nil {
 			cancel()
 			asyncOp.status.cancelTime = time.Now()
 		}

--- a/pkg/pillar/vendor/modules.txt
+++ b/pkg/pillar/vendor/modules.txt
@@ -481,7 +481,7 @@ github.com/lf-edge/eve/api/go/logs
 github.com/lf-edge/eve/api/go/metrics
 github.com/lf-edge/eve/api/go/profile
 github.com/lf-edge/eve/api/go/register
-# github.com/lf-edge/eve/libs v0.0.0-20230621123421-9968f5332761
+# github.com/lf-edge/eve/libs v0.0.0-20230705061838-6ed29226fccf
 ## explicit; go 1.20
 github.com/lf-edge/eve/libs/depgraph
 github.com/lf-edge/eve/libs/nettrace


### PR DESCRIPTION
Testing of refactored zedrouter showed that while it can handle incremental changes (one change at a time, e.g.: add network instance; connect new app; etc.), there are some cracks when it comes to applying new device config containing multiple changes at once (e.g. the set of currently deployed network instances is replaced with a completely different set). However unlikely it is to encounter such complex sudden device config changes in practice, it would be nice if zedrouter was robust enough to handle anything.

An eden test was prepared to stress zedrouter under complex config changes: https://github.com/lf-edge/eden/pull/870
This test would fail even before already merged zedrouter refactoring. Zedrouter was never robust enough to handle any config change (even if both the previous and the new config are valid). This PR changes that and makes the test pass.

This PR continues (and hopefully ends!) with zedrouter refactoring and adds some commits. The three main topics are:
- bring the latest reconciler improvements related to async operations (https://github.com/lf-edge/eve/pull/3311) to pillar
- several changes made to `LinuxNIReconciler` for more robustness
- better reporting of the network instance status

More detailed info can be found in descriptions of individual commits.