### PR TITLE
Define all constants we use in our Makefile and build scripts in one place

### DIFF
--- a/pkg/eve/runme.sh
+++ b/pkg/eve/runme.sh
@@ -143,13 +143,13 @@ do_live() {
      IMAGE_UUID=$(uuidgen | tee /tmp/soft_serial)
      mcopy -o -i /bits/config.img /tmp/soft_serial ::/soft_serial
   fi
-  create_efi_raw "${1:-350}" "$PART_SPEC"
+  create_efi_raw "${1:-592}" "$PART_SPEC"
   dump "$OUTPUT_IMG" live.raw
   echo "$IMAGE_UUID" >&2
 }
 
 do_installer_raw() {
-  create_efi_raw "${1:-350}" "conf_win installer inventory_win"
+  create_efi_raw "${1:-592}" "conf_win installer inventory_win"
   dump "$OUTPUT_IMG" installer.raw
 }
 


### PR DESCRIPTION
- docker run lfedge/eve -f raw installer_raw/live_raw produce images with 0 size.
- Increased the size of the produced images in functions do_installer_raw() and do_live() in file pkg/eve/runme.sh to fix this issue