### PR TITLE
Fix pushing verification with github actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -123,7 +123,7 @@ jobs:
           make -e V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} LINUXKIT_PKG_TARGET=push eve
       - name: Build and push VERIFICATION for ${{ matrix.arch }}-${{ matrix.hv }}
         run: |
-          make -e V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} LINUXKIT_PKG_TARGET=push eve-verification
+          make -e V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} LINUXKIT_PKG_TARGET=push verification
       - name: Build and push collected_sources to eve-source repo
         if: matrix.arch != 'riscv64'
         run: |

--- a/Makefile
+++ b/Makefile
@@ -760,7 +760,7 @@ $(LIVE).parallels: $(LIVE).raw
 $(VERIFICATION).raw: $(BOOT_PART) $(EFI_PART) $(ROOTFS_IMG) $(INITRD_IMG) $(VERIFICATION_IMG) $(CONFIG_IMG) $(PERSIST_IMG) $(BSP_IMX_PART) | $(VERIFICATION)
 	@cp -r $(INSTALLER)/* $(VERIFICATION)
 	./tools/prepare-platform.sh "$(PLATFORM)" "$(BUILD_DIR)" "$(VERIFICATION)" || :
-	./tools/makeverification.sh -C 650 $| $@ "conf_win verification inventory_win"
+	./tools/makeverification.sh -C 850 $| $@ "conf_win verification inventory_win"
 	$(QUIET): $@: Succeeded
 
 $(VERIFICATION).net: $(EFI_PART) $(ROOTFS_IMG) $(INITRD_IMG) $(VERIFICATION_IMG) $(CONFIG_IMG) $(PERSIST_IMG) $(KERNEL_IMG) | $(VERIFICATION)

--- a/pkg/mkverification-raw-efi/make-raw
+++ b/pkg/mkverification-raw-efi/make-raw
@@ -63,13 +63,13 @@ PERSIST_UUID=ad6871ee-31f9-4cf3-9e09-6f7a25c30059
 # EFI partition size in bytes
 EFI_PART_SIZE=$((36 * 1024 * 1024))
 # rootfs partition size in bytes
-ROOTFS_PART_SIZE=$(( 600 * 1024 * 1024 ))
+ROOTFS_PART_SIZE=$(( 800 * 1024 * 1024 ))
 # conf partition size in bytes
 CONF_PART_SIZE=$((1024 * 1024))
 # installer inventory partition size in bytes
 WIN_INVENTORY_PART_SIZE=$((40240 * 1024))
 # installer system partition size in bytes
-VERIFICATION_SYS_PART_SIZE=$(( 600 * 1024 * 1024 ))
+VERIFICATION_SYS_PART_SIZE=$(( 800 * 1024 * 1024 ))
 # imx8 boot blob size in bytes
 IMX8_BLOB_SIZE=$(( 8 * 1024 * 1024 ))
 # sector where the first partition starts on a blank disk

--- a/pkg/verification/runme.sh
+++ b/pkg/verification/runme.sh
@@ -146,13 +146,13 @@ do_verification_live() {
      IMAGE_UUID=$(uuidgen | tee /tmp/soft_serial)
      mcopy -o -i /bits/config.img /tmp/soft_serial ::/soft_serial
   fi
-  create_efi_raw "${1:-650}" "$PART_SPEC"
+  create_efi_raw "${1:-850}" "$PART_SPEC"
   dump "$OUTPUT_IMG" live.raw
   echo "$IMAGE_UUID" >&2
 }
 
 do_verification_raw() {
-  create_efi_raw "${1:-650}" "conf_win verification inventory_win"
+  create_efi_raw "${1:-850}" "conf_win verification inventory_win"
   dump "$OUTPUT_IMG" verification.raw
 }
 


### PR DESCRIPTION
- Changed `make eve-verification` to `make verification` in publish.yml
- Adjusted the size of verification image according to recent changes in rootfs.img