### PR TITLE
Some EdgeView copy function missed protection when writing to websocket

### DIFF
--- a/pkg/edgeview/src/crypto.go
+++ b/pkg/edgeview/src/crypto.go
@@ -51,7 +51,13 @@ func addEnvelopeAndWriteWss(msg []byte, isText bool) error {
 	} else {
 		msgType = websocket.BinaryMessage
 	}
+	// for websocket write, the requirement is that: Applications are responsible for
+	// ensuring that no more than one goroutine calls the write methods.
+	// we do grab the mutex before write in this function, and another place is
+	// in function sendKeepalive() which the packet is only sent to dispatcher.
+	wssWrMutex.Lock()
 	err := websocketConn.WriteMessage(msgType, jdata)
+	wssWrMutex.Unlock()
 	return err
 }
 

--- a/pkg/edgeview/src/tcp.go
+++ b/pkg/edgeview/src/tcp.go
@@ -228,9 +228,7 @@ func clientTCPtunnel(here net.Conn, idx, chNum int, rport int) {
 			log.Noticef("ch(%d)-%d, websocketConn nil. exit", idx, chNum)
 			return
 		}
-		wssWrMutex.Lock()
 		err = addEnvelopeAndWriteWss(jdata, false)
-		wssWrMutex.Unlock()
 		if err != nil {
 			close(done)
 			log.Errorf("ch(%d)-%d, client write wss error %v", idx, chNum, err)
@@ -345,9 +343,7 @@ func setAndStartProxyTCP(opt string) {
 				continue
 			}
 			log.Tracef("setAndStartProxyTCP: timer expired, close and notify client")
-			wssWrMutex.Lock()
 			_ = addEnvelopeAndWriteWss([]byte("\n"), true) // try send a text msg to other side
-			wssWrMutex.Unlock()
 			if !isClosed(tcpServerDone) {
 				close(tcpServerDone)
 			} else if !isClosed(proxyServerDone) {
@@ -506,9 +502,7 @@ func tcpTransfer(url string, wssMsg tcpData, idx int) {
 			close(done)
 			return
 		}
-		wssWrMutex.Lock()
 		err = addEnvelopeAndWriteWss(jdata, false)
-		wssWrMutex.Unlock()
 		if err != nil {
 			log.Errorf("ch(%d)-%d, server wrote error %v", idx, chNum, err)
 			break
@@ -648,16 +642,12 @@ func tcpRecvTimeCheckExpire() bool {
 
 func tcpClientSendDone() {
 	if !isTCPClient {
-		wssWrMutex.Lock()
 		sendCloseToWss()
-		wssWrMutex.Unlock()
 		return
 	}
-	wssWrMutex.Lock()
 	// send to server first, then to dispatcher to close
 	_ = addEnvelopeAndWriteWss([]byte(tcpDONEMessage), true)
 	sendCloseToWss()
-	wssWrMutex.Unlock()
 }
 
 func getProxyOpt(opt string) (bool, string) {


### PR DESCRIPTION
- consolidate the mutex locks inside addEnvelopeAndWriteWss(), except for some keepalives
   which only goes to dispatcher
- during the tar operation of a directory, sometimes a file underneath can be removed such as
   in /persist/newlog, log a notice of the error if it happens and continue.