### PR TITLE
Use input variables in `run-make` action

### DIFF
--- a/.github/actions/run-make/action.yml
+++ b/.github/actions/run-make/action.yml
@@ -22,8 +22,8 @@ runs:
       shell: bash
     - name: Login to DockerHUB
       run: |
-        echo "${{ inputs.RELEASE_DOCKERHUB_TOKEN }}" |\
-           docker login -u "${{ inputs.RELEASE_DOCKERHUB_ACCOUNT }}" --password-stdin
+        echo "${{ inputs.dockerhub-token }}" |\
+           docker login -u "${{ inputs.dockerhub-account }}" --password-stdin
       shell: bash
     - name: Build and push `make -e ${{ inputs.command }}`
       run: |


### PR DESCRIPTION
Fixing typo in naming variables in run-make action.

When passing secrets as input arguments GitHub will still not print them. Tested [here](https://github.com/uncleDecart/gha-playground/actions/runs/5517908781/jobs/10061169531)

Second round, hopefully without any merge conflicts 