### PR TITLE
Separate radio silence config from status

### DIFF
--- a/pkg/pillar/dpcmanager/dns.go
+++ b/pkg/pillar/dpcmanager/dns.go
@@ -42,7 +42,7 @@ func (m *DpcManager) updateDNS() {
 	m.deviceNetStatus.State = dpc.State
 	m.deviceNetStatus.Testing = m.dpcVerify.inProgress
 	m.deviceNetStatus.CurrentIndex = m.dpcList.CurrentIndex
-	m.deviceNetStatus.RadioSilence = m.radioSilence
+	m.deviceNetStatus.RadioSilence = m.rsStatus
 	oldDNS := m.deviceNetStatus
 	m.deviceNetStatus.Ports = make([]types.NetworkPortStatus, len(dpc.Ports))
 	for ix, port := range dpc.Ports {

--- a/pkg/pillar/dpcmanager/dpcmanager.go
+++ b/pkg/pillar/dpcmanager/dpcmanager.go
@@ -93,7 +93,8 @@ type DpcManager struct {
 	adapters         types.AssignableAdapters
 	globalCfg        types.ConfigItemValueMap
 	hasGlobalCfg     bool
-	radioSilence     types.RadioSilence
+	rsConfig         types.RadioSilence
+	rsStatus         types.RadioSilence
 	enableLastResort bool
 	devUUID          uuid.UUID
 	// Boot-time configuration
@@ -426,7 +427,7 @@ func (m *DpcManager) reconcilerArgs() dpcreconciler.Args {
 	args := dpcreconciler.Args{
 		GCP: m.globalCfg,
 		AA:  m.adapters,
-		RS:  m.radioSilence,
+		RS:  m.rsConfig,
 	}
 	if m.currentDPC() != nil {
 		args.DPC = *m.currentDPC()

--- a/pkg/pillar/dpcmanager/verify.go
+++ b/pkg/pillar/dpcmanager/verify.go
@@ -28,7 +28,7 @@ func (m *DpcManager) restartVerify(ctx context.Context, reason string) {
 		return
 	}
 	if m.currentDPC() != nil &&
-		!m.radioSilence.ChangeInProgress && m.radioSilence.Imposed {
+		!m.rsStatus.ChangeInProgress && m.rsStatus.Imposed {
 		m.Log.Noticef("DPC verify: Radio-silence is imposed, skipping DPC verification")
 		return
 	}


### PR DESCRIPTION
Config stores the intended state of the radio silence mode, while status stores the actual state.

Previously, if the operation to enable radio silence failed, `RadioSilence.Imposed` would be set to false and because the same field was used for both status and the intended config, RS flag passed to wwan microservice would be inadvertently reverted back to false. As a consequence, after the initial unsuccessful attempt to enable RS, the wwan microservice would cease making any further retry attempts.