### PR TITLE
Revert "Bump mkinitfs version to Alpine 3.18"

### DIFF
--- a/pkg/alpine/Dockerfile
+++ b/pkg/alpine/Dockerfile
@@ -36,7 +36,6 @@ RUN for repo in main community testing; do \
 
 # set the default repository to use
 RUN cp /mirror/${ALPINE_VERSION}/rootfs/etc/apk/repositories /etc/apk
-RUN cat /mirror/3.18/rootfs/etc/apk/repositories >> /etc/apk/repositories
 RUN cat /mirror/edge/rootfs/etc/apk/repositories >> /etc/apk/repositories
 RUN apk update
 

--- a/pkg/alpine/mirrors/3.16/main
+++ b/pkg/alpine/mirrors/3.16/main
@@ -125,6 +125,7 @@ lz4-libs
 lzo-dev
 m4
 make
+mkinitfs
 mpc1-dev
 mpfr-dev
 mtools

--- a/pkg/alpine/mirrors/3.18/main
+++ b/pkg/alpine/mirrors/3.18/main
@@ -1,1 +1,0 @@
-mkinitfs


### PR DESCRIPTION
This reverts commit 0ee5605cdc0cd4df89aed6d9b90ac74f7d256f75.

These changes broke the pkg/xen-tools package because the mkinitfs is fetched as build dependency along with musl-dev package. However, when installing both packages with mkinitfs from 3.18 there will be a mixing of different libraries and busybox will be replaced with newer version, broking the whole system.