### PR TITLE
GH workflows: restrict publish runs

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -22,7 +22,6 @@ on:  # yamllint disable-line rule:truthy
       - "master"
       - "[0-9]+.[0-9]+"
       - "[0-9]+.[0-9]+-stable"
-      - "[0-9]+.[0-9]+-lts"
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,9 @@
 name: Publish
 on:  # yamllint disable-line rule:truthy
   push:
+    # Assuming it is an or so that all pushes on master get published but on
+    # other branches we only build when the below tags are set.
+    branches: ["master"]
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
       - "[0-9]+.[0-9]+.[0-9]+-lts"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,10 +2,6 @@
 name: Publish
 on:  # yamllint disable-line rule:truthy
   push:
-    branches:
-      - "master"
-      - "[0-9]+.[0-9]+"
-      - "[0-9]+.[0-9]+-stable"
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
       - "[0-9]+.[0-9]+.[0-9]+-lts"


### PR DESCRIPTION
When we create a new branch X.Y and push the X.Y.0 tag we kick off publish on both the branch creation, and the tag. Not only is this a waste of resources but it causes the assets workflow to fail when X.Y has completed since it does not create lfedge/eve:x.y.0 in docker hub. See e.g., https://github.com/lf-edge/eve/actions/runs/5530119491/jobs/10093429995#step:6:19

This attempt is to only run on the tags.

Plus a tiny cleanup commit.