### PR TITLE
GH workflows: Add publishing sbom in workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -115,6 +115,12 @@ jobs:
           command: "V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} LINUXKIT_PKG_TARGET=push eve"
           dockerhub-token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
           dockerhub-account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
+      - uses: ./.github/actions/run-make
+        if: matrix.arch != 'riscv64'
+        with:
+          command: "V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} LINUXKIT_PKG_TARGET=push sbom collected_sources compare_sbom_collected_sources publish_sources"
+          dockerhub-token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+          dockerhub-account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
 
   verification:
     if: github.event.repository.full_name == 'lf-edge/eve'


### PR DESCRIPTION
Thix fix previously removed publishing of sbom from `publish.yml` workflow. Now it is separate from `make eve` which should reduce disk space used