### PR TITLE
attest : fix race-condition in tests

### DIFF
--- a/pkg/pillar/attest/attest_test.go
+++ b/pkg/pillar/attest/attest_test.go
@@ -120,7 +120,7 @@ func TestGoodPath(t *testing.T) {
 
 	go func() {
 		ctx.eventTrigger <- EventInitialize
-		for ctx.state != StateInternalQuoteWait {
+		for getStateAtomic(ctx) != StateInternalQuoteWait {
 			time.Sleep(1 * time.Second)
 		}
 		ctx.eventTrigger <- EventInternalQuoteRecvd
@@ -149,7 +149,7 @@ func TestNonceMismatch(t *testing.T) {
 
 	go func() {
 		ctx.eventTrigger <- EventInitialize
-		for ctx.state != StateInternalQuoteWait {
+		for getStateAtomic(ctx) != StateInternalQuoteWait {
 			time.Sleep(1 * time.Second)
 		}
 		ctx.eventTrigger <- EventInternalQuoteRecvd
@@ -176,7 +176,7 @@ func TestQuoteMismatch(t *testing.T) {
 
 	go func() {
 		ctx.eventTrigger <- EventInitialize
-		for ctx.state != StateInternalQuoteWait {
+		for getStateAtomic(ctx) != StateInternalQuoteWait {
 			time.Sleep(1 * time.Second)
 		}
 		ctx.eventTrigger <- EventInternalQuoteRecvd
@@ -203,7 +203,7 @@ func TestNoCertInController(t *testing.T) {
 
 	go func() {
 		ctx.eventTrigger <- EventInitialize
-		for ctx.state != StateInternalQuoteWait {
+		for getStateAtomic(ctx) != StateInternalQuoteWait {
 			time.Sleep(1 * time.Second)
 		}
 		ctx.eventTrigger <- EventInternalQuoteRecvd
@@ -230,7 +230,7 @@ func TestControllerNotAvbleInNonceWait(t *testing.T) {
 
 	go func() {
 		ctx.eventTrigger <- EventInitialize
-		for ctx.state != StateInternalQuoteWait {
+		for getStateAtomic(ctx) != StateInternalQuoteWait {
 			time.Sleep(1 * time.Second)
 		}
 		ctx.eventTrigger <- EventInternalQuoteRecvd
@@ -255,7 +255,7 @@ func TestControllerNotAvbleInAttestWait(t *testing.T) {
 	ctx := initTest()
 
 	go func() {
-		ctx.state = StateInternalQuoteWait
+		setStateAtomic(ctx, StateInternalQuoteWait)
 		simulateControllerReqFailure = true
 		ctx.eventTrigger <- EventInternalQuoteRecvd
 	}()
@@ -279,7 +279,7 @@ func TestControllerNotAvbleInAttestEscrowWait(t *testing.T) {
 	ctx := initTest()
 
 	go func() {
-		ctx.state = StateAttestWait
+		setStateAtomic(ctx, StateAttestWait)
 		simulateControllerReqFailure = true
 		ctx.eventTrigger <- EventAttestSuccessful
 	}()
@@ -304,7 +304,7 @@ func TestNoEscrowDataAttestEscrowWait(t *testing.T) {
 	stopTrigger := make(chan int)
 
 	go func() {
-		ctx.state = StateAttestWait
+		setStateAtomic(ctx, StateAttestWait)
 		simulateNoEscrowData = true
 		ctx.eventTrigger <- EventAttestSuccessful
 		time.Sleep(time.Second)
@@ -330,7 +330,7 @@ func TestItokenMismatchAttestEscrowWait(t *testing.T) {
 	ctx := initTest()
 
 	go func() {
-		ctx.state = StateAttestWait
+		setStateAtomic(ctx, StateAttestWait)
 		simulateITokenMismatch = true
 		ctx.eventTrigger <- EventAttestSuccessful
 	}()
@@ -355,7 +355,7 @@ func TestNoVerifierInNonceWait(t *testing.T) {
 	stopTrigger := make(chan int)
 
 	go func() {
-		ctx.state = StateNone
+		setStateAtomic(ctx, StateNone)
 		simulateNoVerifier = true
 		ctx.eventTrigger <- EventInitialize
 		time.Sleep(1 * time.Second)
@@ -381,7 +381,7 @@ func TestInternalEscrowRcvdAtAnyOther(t *testing.T) {
 	ctx := initTest()
 
 	testInternalEscrowRcvdAt := func(state State) {
-		ctx.state = state
+		setStateAtomic(ctx, state)
 		stopTrigger := make(chan int)
 		go func() {
 			ctx.eventTrigger <- EventInternalEscrowRecvd
@@ -409,7 +409,7 @@ func TestRestartAtEachState(t *testing.T) {
 	ctx := initTest()
 
 	testRestartEvent := func(state State) {
-		ctx.state = state
+		setStateAtomic(ctx, state)
 		stopTrigger := make(chan int)
 		go func() {
 			ctx.eventTrigger <- EventRestart


### PR DESCRIPTION
Relates to : #3134

The attestation uses a state-machine to process the request, the state-machine safely runs on a single go routine, but to test it we need to externally set the state machine status to different values to simulate a request, this requires to spawn a seperate go routine, this leads to read/writes to some internal values that causes data race-conditions.

this changes introduces atomic read/write helpers to fix the issue.

```
shah@dev:~/eve/pkg/pillar/attest$ go test -race -v
=== RUN   TestGoodPath
------TestGoodPath-------
--- PASS: TestGoodPath (11.02s)
=== RUN   TestNonceMismatch
-------TestNonceMismatch---
Simulating Nonce mismatch
ERRO[0012] Error Nonce Mismatch while sending quote      pid=1234 source=test
--- PASS: TestNonceMismatch (2.01s)
=== RUN   TestQuoteMismatch
-------TestQuoteMismatch------
Simulating Quote mismatch
ERRO[0014] Error Quote Mismatch while sending quote      pid=1234 source=test
--- PASS: TestQuoteMismatch (2.01s)
=== RUN   TestNoCertInController
-------TestNoCertInController------
Simulating No quote cert in Controller
ERRO[0016] Error No Cert Found while sending quote       pid=1234 source=test
--- PASS: TestNoCertInController (2.01s)
=== RUN   TestControllerNotAvbleInNonceWait
-----TestControllerNotAvbleInNonceWait--
Simulating Controller being down
ERRO[0017] Error Controller Request Failed while sending nonce request  pid=1234 source=test
--- PASS: TestControllerNotAvbleInNonceWait (1.00s)
=== RUN   TestControllerNotAvbleInAttestWait
--------TestControllerNotAvbleInAttestWait----
Simulating Controller being down
ERRO[0018] Error Controller Request Failed while sending quote  pid=1234 source=test
--- PASS: TestControllerNotAvbleInAttestWait (1.00s)
=== RUN   TestControllerNotAvbleInAttestEscrowWait
--------TestControllerNotAvbleInAttestEscrowWait----
Simulating Controller being down
ERRO[0019] Error Controller Request Failed while sending attest escrow keys  pid=1234 source=test
--- PASS: TestControllerNotAvbleInAttestEscrowWait (1.00s)
=== RUN   TestNoEscrowDataAttestEscrowWait
--------TestNoEscrowDataAttestEscrowWait----
Simulating no escrow data
ERRO[0020] Error No Escrow Data available while sending attest escrow keys  pid=1234 source=test
--- PASS: TestNoEscrowDataAttestEscrowWait (1.00s)
=== RUN   TestItokenMismatchAttestEscrowWait
--------TestItokenMismatchAttestEscrowWait----
Simulating Integrity Token mismatch
ERRO[0021] Error Mismatch in integrity-token while sending attest escrow keys  pid=1234 source=test
--- PASS: TestItokenMismatchAttestEscrowWait (1.00s)
=== RUN   TestNoVerifierInNonceWait
--------TestNoVerifierInNonceWait----
Simulating no verifier support in Controller
ERRO[0022] Error No verifier support in Controller while sending nonce request  pid=1234 source=test
--- PASS: TestNoVerifierInNonceWait (1.00s)
=== RUN   TestInternalEscrowRcvdAtAnyOther
--------TestInternalEscrowRcvdAtAnyOther----
INFO[0023] Calling wildcard handler(Event EventInternalEscrowRecvd in State StateNone)  pid=1234 source=test
INFO[0024] Calling wildcard handler(Event EventInternalEscrowRecvd in State StateNonceWait)  pid=1234 source=test
INFO[0025] Calling wildcard handler(Event EventInternalEscrowRecvd in State StateInternalQuoteWait)  pid=1234 source=test
INFO[0027] Calling wildcard handler(Event EventInternalEscrowRecvd in State StateAttestWait)  pid=1234 source=test
INFO[0028] Calling wildcard handler(Event EventInternalEscrowRecvd in State StateAttestEscrowWait)  pid=1234 source=test
INFO[0029] Calling wildcard handler(Event EventInternalEscrowRecvd in State StateRestartWait)  pid=1234 source=test
INFO[0030] Calling wildcard handler(Event EventInternalEscrowRecvd in State StateComplete)  pid=1234 source=test
--- PASS: TestInternalEscrowRcvdAtAnyOther (8.01s)
=== RUN   TestRestartAtEachState
--------TestRestartAtEachState----
--- PASS: TestRestartAtEachState (8.03s)
PASS
ok  	github.com/lf-edge/eve/pkg/pillar/attest	39.142s
```

---
🤡🤡🤡🤡🤡
From what I understood, the problem is only in the test because attest dispatcher runs on a single go routine and the ctx.state is not exported and only set internally in attest. We can get rid of the atomic helpers and just change this : 

```
	go func() {
		ctx.eventTrigger <- EventInitialize
		for getStateAtomic(ctx) != StateInternalQuoteWait {
			time.Sleep(1 * time.Second)
		}
		ctx.eventTrigger <- EventInternalQuoteRecvd
		time.Sleep(10 * time.Second)
		stopTrigger <- 1
	}()
```

to something like this and achieve the same result, but it will be flaky 0.001% of the time: 
```
	go func() {
		ctx.eventTrigger <- EventInitialize
		time.Sleep(10 * time.Second)
		ctx.eventTrigger <- EventInternalQuoteRecvd
		time.Sleep(10 * time.Second)
		stopTrigger <- 1
	}()
```

