### PR TITLE
Update go-pcap dependency in pillar

### DIFF
--- a/pkg/pillar/go.mod
+++ b/pkg/pillar/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/jaypipes/ghw v0.8.0
 	github.com/lf-edge/edge-containers v0.0.0-20221025050409-93c34bebadd2
 	github.com/lf-edge/eve/api/go v0.0.0-20230602070228-0c11e32c7718
-	github.com/lf-edge/eve/libs v0.0.0-20230712053757-b4a564c38a6d
+	github.com/lf-edge/eve/libs v0.0.0-20230717153241-cc5629af4657
 	github.com/linuxkit/linuxkit/src/cmd/linuxkit v0.0.0-20220913135124-e532e7310810
 	github.com/miekg/dns v1.1.41
 	github.com/moby/sys/mountinfo v0.6.0
@@ -33,7 +33,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
-	github.com/packetcap/go-pcap v0.0.0-20230711190632-81137528cfbc
+	github.com/packetcap/go-pcap v0.0.0-20230717110547-c34843f9206d
 	github.com/prometheus/procfs v0.7.3
 	github.com/satori/go.uuid v1.2.1-0.20180404165556-75cca531ea76
 	github.com/shirou/gopsutil v3.21.11+incompatible

--- a/pkg/pillar/go.sum
+++ b/pkg/pillar/go.sum
@@ -1117,8 +1117,8 @@ github.com/lf-edge/edge-containers v0.0.0-20221025050409-93c34bebadd2 h1:ckxNk8M
 github.com/lf-edge/edge-containers v0.0.0-20221025050409-93c34bebadd2/go.mod h1:eA41YxPbZRVvewIYRzmqDB1PeLQXxCy9WQEc3AVCsPI=
 github.com/lf-edge/eve/api/go v0.0.0-20230602070228-0c11e32c7718 h1:gtmjnX95WEKWCg6g+9kB9iTDuTTrUG/PEf17TMpLs1Q=
 github.com/lf-edge/eve/api/go v0.0.0-20230602070228-0c11e32c7718/go.mod h1:pNFho84HAA/Vlb1DpLFlatJgQBJ43wH28elAs7wXdtA=
-github.com/lf-edge/eve/libs v0.0.0-20230712053757-b4a564c38a6d h1:2GC5dYLbOuRJ1hoous1TzsvkBwSGyuVFtmhQVmMDsbI=
-github.com/lf-edge/eve/libs v0.0.0-20230712053757-b4a564c38a6d/go.mod h1:9xoaLCcMlTZQBviUUxU4qBpB+nAbnPk2K156GLvyDsI=
+github.com/lf-edge/eve/libs v0.0.0-20230717153241-cc5629af4657 h1:2DERGuT2XEkCJIvtfnD0+XAaovV73KtMD3bzfV8AVdI=
+github.com/lf-edge/eve/libs v0.0.0-20230717153241-cc5629af4657/go.mod h1:OLbkEWaPL1SKTywCA3wg2xBwwF+wB78IB5ASHbJ52IQ=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -1342,8 +1342,8 @@ github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYr
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
 github.com/openzipkin/zipkin-go v0.1.3/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
-github.com/packetcap/go-pcap v0.0.0-20230711190632-81137528cfbc h1:5dlCC9oUswDMJwR9jBuq3JPSatOY0/hzcGc0oaVS5nw=
-github.com/packetcap/go-pcap v0.0.0-20230711190632-81137528cfbc/go.mod h1:IwL7NJSMD5mvRco6A6uxPca1Zv0OJp0tY5Gf++9LBYQ=
+github.com/packetcap/go-pcap v0.0.0-20230717110547-c34843f9206d h1:3VdKDbNiQZ5CzDF1PNMwsM03BZUR0AEoRzt9sMyB8kQ=
+github.com/packetcap/go-pcap v0.0.0-20230717110547-c34843f9206d/go.mod h1:IwL7NJSMD5mvRco6A6uxPca1Zv0OJp0tY5Gf++9LBYQ=
 github.com/packethost/packngo v0.1.1-0.20171201154433-f1be085ecd6f/go.mod h1:otzZQXgoO96RTzDB/Hycg0qZcXZsWJGJRSXbmEIJ+4M=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/pkg/pillar/vendor/modules.txt
+++ b/pkg/pillar/vendor/modules.txt
@@ -481,7 +481,7 @@ github.com/lf-edge/eve/api/go/logs
 github.com/lf-edge/eve/api/go/metrics
 github.com/lf-edge/eve/api/go/profile
 github.com/lf-edge/eve/api/go/register
-# github.com/lf-edge/eve/libs v0.0.0-20230712053757-b4a564c38a6d
+# github.com/lf-edge/eve/libs v0.0.0-20230717153241-cc5629af4657
 ## explicit; go 1.20
 github.com/lf-edge/eve/libs/depgraph
 github.com/lf-edge/eve/libs/nettrace
@@ -574,7 +574,7 @@ github.com/opencontainers/selinux/go-selinux
 github.com/opencontainers/selinux/go-selinux/label
 github.com/opencontainers/selinux/pkg/pwalk
 github.com/opencontainers/selinux/pkg/pwalkdir
-# github.com/packetcap/go-pcap v0.0.0-20230711190632-81137528cfbc
+# github.com/packetcap/go-pcap v0.0.0-20230717110547-c34843f9206d
 ## explicit; go 1.13
 github.com/packetcap/go-pcap
 github.com/packetcap/go-pcap/filter


### PR DESCRIPTION
The update contains a patch that avoids closure of a packet capture to hang, see: https://github.com/packetcap/go-pcap/pull/43