### PR TITLE
Build mkinitfs version 3.8.1 from source

### DIFF
--- a/pkg/mkimage-raw-efi/Dockerfile
+++ b/pkg/mkimage-raw-efi/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
 # This mkimage-raw-efi produces the raw EFI partition for EVE,
 # including the files in efi-files in the image.  This includes:
 #
@@ -6,9 +7,19 @@
 #
 FROM lfedge/eve-alpine:9fb9b9cbf7d90066a70e4704d04a6fe248ff52bb AS build
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
-ENV BUILD_PKGS mkinitfs grep patch
-ENV PKGS mtools dosfstools libarchive-tools sgdisk e2fsprogs util-linux squashfs-tools coreutils tar dmidecode
+ENV BUILD_PKGS grep patch git make gcc linux-headers musl-dev autoconf automake pkgconfig kmod-dev util-linux-dev cryptsetup-dev lddtree libgcc
+ENV PKGS mtools dosfstools libarchive-tools sgdisk e2fsprogs util-linux squashfs-tools coreutils tar dmidecode \
+    kmod-libs cryptsetup-libs libblkid
 RUN eve-alpine-deploy.sh
+
+# get mkinitfs source from git and build it locally
+# it depends on mod-libs cryptsetup-libs libblkid at runtime and lddtree to run mkinitfs itself
+# we could build APK file ourselves but 'apk add' would failed because networking is disabled for almost all linuxkit images
+WORKDIR /tmp/mkinitfs
+ADD https://github.com/alpinelinux/mkinitfs.git#3.8.1 /tmp/mkinitfs
+RUN make -j "$(getconf _NPROCESSORS_ONLN)"
+WORKDIR /
+RUN make -C /tmp/mkinitfs install
 
 WORKDIR /out
 RUN echo "mtools_skip_check=1" >> etc/mtools.conf
@@ -32,6 +43,16 @@ RUN mv rootfs /out
 WORKDIR /
 COPY initramfs-init.patch /tmp/
 RUN patch -p1 < /tmp/initramfs-init.patch
+
+# from https://git.alpinelinux.org/aports/tree/main/mkinitfs/mkinitfs.post-install?id=7b64ec6e904040bd75ea21529b4fce61c908a553
+# we need to simulate mkinitfs.post-install from the original APK file
+# --- Quote ---
+# safety. if nlplug-findfs is missing in the initramfs image we may end up
+# with an unbootable system.
+RUN if ! grep -q -w /sbin/nlplug-findfs  /etc/mkinitfs/features.d/base.files; then \
+        echo "/sbin/nlplug-findfs" >> /etc/mkinitfs/features.d/base.files; \
+    fi
+
 RUN echo /bin/grep >> /etc/mkinitfs/features.d/base.files
 RUN mkinitfs -n -o /out/initrd.img
 

--- a/pkg/mkimage-raw-efi/initramfs-init.patch
+++ b/pkg/mkimage-raw-efi/initramfs-init.patch
@@ -2,115 +2,114 @@
 +++ b/usr/share/mkinitfs/initramfs-init
 @@ -1,7 +1,7 @@
  #!/bin/sh
-
+ 
  # this is the init script version
--VERSION=3.6.2-r0
-+VERSION=3.6.2-EVE
+-VERSION=3.8.1
++VERSION=3.8.1-EVE
  SINGLEMODE=no
- sysroot=/sysroot
+ sysroot="$ROOT"/sysroot
  splashfile=/.splash.ctrl
-@@ -347,7 +347,7 @@
+@@ -375,7 +375,7 @@ myopts="alpine_dev autodetect autoraid chart cryptroot cryptdm cryptheader crypt
  	cryptdiscards cryptkey debug_init dma init init_args keep_apk_new modules ovl_dev
  	pkgs quiet root_size root usbdelay ip alpine_repo apkovl alpine_start splash
  	blacklist overlaytmpfs overlaytmpfsflags rootfstype rootflags nbd resume s390x_net
--	dasd ssh_key BOOTIF zfcp"
-+	dasd ssh_key BOOTIF zfcp find_boot"
-
+-	dasd ssh_key BOOTIF zfcp uevent_buf_size"
++	dasd ssh_key BOOTIF zfcp uevent_buf_size find_boot"
+ 
  for opt; do
  	case "$opt" in
-@@ -496,6 +496,40 @@
+@@ -533,13 +533,64 @@ fi
  # zpool reports /dev/zfs missing if it can't read /etc/mtab
- ln -s /proc/mounts /etc/mtab
-
+ ln -s /proc/mounts "$ROOT"/etc/mtab
+ 
 +# let's see if we were told to identify a boot partition
 +if [ -n "$KOPT_find_boot" ]; then
-+        # locate boot media and mount it
-+        # NOTE that we may require up to 3 tries with
-+        # 30 seconds pauses between them to accomodate
-+        # really slow controllers (such as bad USB sticks)
-+        for i in 0 1 2; do
-+                ebegin "Attempt $i to find and mount boot media"
-+                MEDIA_ID=$(grep -l "$KOPT_find_boot" /media/*/boot/.uuid 2>/dev/null)
-+                if [ -n "$MEDIA_ID" ]; then
-+                        mkdir -p /media/boot
-+                        mount --bind "/media/$(echo "$MEDIA_ID" | cut -f3 -d/)" /media/boot
-+                        break
-+                fi
-+                sleep $(( i * 30 ))
-+                nlplug-findfs $cryptopts -p /sbin/mdev ${KOPT_debug_init:+-d} \
-+                   ${KOPT_usbdelay:+-t $(( $KOPT_usbdelay * 1000 ))} \
-+                   -n -b $repofile -a /tmp/apkovls
-+                eend $?
-+        done
++		# locate boot media and mount it
++		# NOTE that we may require up to 3 tries with
++		# 30 seconds pauses between them to accomodate
++		# really slow controllers (such as bad USB sticks)
++		for i in 0 1 2; do
++				ebegin "Attempt $i to find and mount boot media"
++				MEDIA_ID=$(grep -l "$KOPT_find_boot" /media/*/boot/.uuid 2>/dev/null)
++				if [ -n "$MEDIA_ID" ]; then
++						mkdir -p /media/boot
++						$MOCK mount --bind "/media/$(echo "$MEDIA_ID" | cut -f3 -d/)" /media/boot
++						break
++				fi
++				sleep $(( i * 30 ))
++				$MOCK nlplug-findfs $cryptopts -p /sbin/mdev ${KOPT_debug_init:+-d} \
++					${KOPT_usbdelay:+-t $(( $KOPT_usbdelay * 1000 ))} \
++					${KOPT_uevent_buf_size:+-U $KOPT_uevent_buf_size} \
++					-n -b $repofile -a /tmp/apkovls
++				eend $?
++		done
 +
-+        # if we didn't find anything, but were asked to -- treat it
-+        # as an error condition (it maybe transient, but it needs to
-+        # be corrected
-+        if [ -z "$MEDIA_ID" ]; then
-+                echo "Failed to identify boot media. Try to re-run nlplug-findfs manually to see what's wrong:"
-+                echo "  nlplug-findfs -p /sbin/mdev -d -t 30000 -n  -n -b $repofile -a /tmp/apkovls"
-+                echo "once you find boot device, run:"
-+                echo "  mount --bind /media/XXX /media/boot"
-+                echo "and then exit the shell."
-+                sh
-+        fi
++		# if we didn't find anything, but were asked to -- treat it
++		# as an error condition (it maybe transient, but it needs to
++		# be corrected
++		if [ -z "$MEDIA_ID" ]; then
++				echo "Failed to identify boot media. Try to re-run nlplug-findfs manually to see what's wrong:"
++				echo "  nlplug-findfs -p /sbin/mdev -d -t 30000 -n  -n -b $repofile -a /tmp/apkovls"
++				echo "once you find boot device, run:"
++				echo "  mount --bind /media/XXX /media/boot"
++				echo "and then exit the shell."
++				sh
++		fi
 +fi
 +
  # check if root=... was set
  if [ -n "$KOPT_root" ]; then
- 	if [ "$SINGLEMODE" = "yes" ]; then
-@@ -504,9 +538,24 @@
- 	fi
- 
+ 	# run nlplug-findfs before SINGLEMODE so we load keyboard drivers
  	ebegin "Mounting root"
--	nlplug-findfs $cryptopts -p /sbin/mdev ${KOPT_debug_init:+-d} \
+-	$MOCK nlplug-findfs $cryptopts -p /sbin/mdev ${KOPT_debug_init:+-d} \
+-		${KOPT_uevent_buf_size:+-U $KOPT_uevent_buf_size} \
 -		$KOPT_root
-+        if [ -f "$KOPT_root" ]; then
-+                LOOP_IMG=$(realpath "$KOPT_root")
-+                # workingaround linux kernel's desire to lump the entire
-+                # set of initrd images into /initrd.image
-+                if [ "$LOOP_IMG" = /initrd.image ]; then
-+                        OFFSET=$(LANG=C grep -obUaP hsqs /initrd.image|cut -f1 -d:|head -1)
-+                        if [ -n "$OFFSET" ]; then
-+                                LOSETUP_EXTRA_OPTS="-o$OFFSET"
-+                        fi
-+                fi
-
-+                KOPT_root=$(losetup -f)
-+                losetup $LOSETUP_EXTRA_OPTS -r -f "$LOOP_IMG"
-+        else
-+                nlplug-findfs $cryptopts -p /sbin/mdev ${KOPT_debug_init:+-d} \
-+                        $KOPT_root
-+        fi
++	if [ -f "$KOPT_root" ]; then
++			LOOP_IMG=$(realpath "$KOPT_root")
++			# workingaround linux kernel's desire to lump the entire
++			# set of initrd images into /initrd.image
++			if [ "$LOOP_IMG" = /initrd.image ]; then
++					OFFSET=$(LANG=C grep -obUaP hsqs /initrd.image|cut -f1 -d:|head -1)
++					if [ -n "$OFFSET" ]; then
++							LOSETUP_EXTRA_OPTS="-o$OFFSET"
++					fi
++			fi
 +
- 	if echo "$KOPT_modules $rootfstype" | grep -qw btrfs; then
- 		/sbin/btrfs device scan >/dev/null || \
- 			echo "Failed to scan devices for btrfs filesystem."
-@@ -540,13 +555,15 @@
- 		mount ${KOPT_rootfstype:+-t $KOPT_rootfstype} -o $rootflags \
++			KOPT_root=$(losetup -f)
++			losetup $LOSETUP_EXTRA_OPTS -r -f "$LOOP_IMG"
++	else
++			$MOCK nlplug-findfs $cryptopts -p /sbin/mdev ${KOPT_debug_init:+-d} \
++				${KOPT_uevent_buf_size:+-U $KOPT_uevent_buf_size} \
++				$KOPT_root
++	fi
++
+ 
+ 	if [ "$SINGLEMODE" = "yes" ]; then
+ 		echo "Entering single mode. Type 'exit' to continue booting."
+@@ -573,13 +624,15 @@ if [ -n "$KOPT_root" ]; then
+ 		$MOCK mount ${KOPT_rootfstype:+-t $KOPT_rootfstype} -o $rootflags \
  			$KOPT_root /media/root-ro
  		# Mount writable overlay tmpfs
 -		overlaytmpfsflags="mode=0755,${KOPT_overlaytmpfsflags:+$KOPT_overlaytmpfsflags,}rw"
--		mount -t tmpfs -o $overlaytmpfsflags root-tmpfs /media/root-rw
+-		$MOCK mount -t tmpfs -o $overlaytmpfsflags root-tmpfs /media/root-rw
 +		# overlaytmpfsflags="mode=0755,${KOPT_overlaytmpfsflags:+$KOPT_overlaytmpfsflags,}rw"
-+		# mount -t tmpfs -o $overlaytmpfsflags root-tmpfs /media/root-rw
++		# $MOCK mount -t tmpfs -o $overlaytmpfsflags root-tmpfs /media/root-rw
  		# Create additional mountpoints and do the overlay mount
  		mkdir -p /media/root-rw/work /media/root-rw/root
- 		mount -t overlay -o \
+ 		$MOCK mount -t overlay -o \
  			lowerdir=/media/root-ro,upperdir=/media/root-rw/root,workdir=/media/root-rw/work \
  			overlayfs $sysroot
 +		# this protects /media/root-rw from being destroyed by switch_root
-+		mount -t proc proc /media/root-rw
++		$MOCK mount -t proc proc /media/root-rw			
  	else
  		if [ "$rootfstype" = "zfs" ]; then
  			prepare_zfs_root
-@@ -557,7 +574,8 @@
+@@ -590,7 +643,7 @@ if [ -n "$KOPT_root" ]; then
  	fi
-
+ 
  	eend $?
--	cat /proc/mounts | while read DEV DIR TYPE OPTS ; do
-+
+-	cat "$ROOT"/proc/mounts 2>/dev/null | while read DEV DIR TYPE OPTS ; do
 +	grep -vE '^(proc|sysfs|devtmpfs|devpts|shm) ' /proc/mounts | while read DEV DIR TYPE OPTS ; do
  		if [ "$DIR" != "/" -a "$DIR" != "$sysroot" -a -d "$DIR" ]; then
  			mkdir -p $sysroot/$DIR
- 			mount -o move $DIR $sysroot/$DIR
+ 			$MOCK mount -o move $DIR $sysroot/$DIR


### PR DESCRIPTION
Alpine 3.16 has nlplug-findfs tool in mkinitfs package that has very small buffer for uevents and cannot detect file system on some devices with many PCIe devices

Here we build the package from Alpine 3.18 from source

In theory we could create an alpine APK builder container and build APK file. But installing APK files is not really possible because networking is disabled for almost all Linuxkit images we build so it won't be able to download dependencies and they must be specified in 