### PR TITLE
Support routing where gateway depends on link route

### DIFF
--- a/pkg/pillar/nireconciler/linux_currentstate.go
+++ b/pkg/pillar/nireconciler/linux_currentstate.go
@@ -269,8 +269,9 @@ func (r *LinuxNIReconciler) updateCurrentNIRoutes(niID uuid.UUID) (changed bool)
 		}
 		for _, rt := range routes {
 			route := linux.Route{
-				Route:    rt.Data.(netlink.Route),
-				OutputIf: rtOutIf,
+				Route:          rt.Data.(netlink.Route),
+				OutputIf:       rtOutIf,
+				GwViaLinkRoute: gwViaLinkRoute(rt, routes),
 			}
 			prevRoute := prevRoutes[dg.Reference(route)]
 			if prevRoute == nil || !prevRoute.Equal(route) {


### PR DESCRIPTION
Especially in public clouds it is common to assign `/32` IPs to VM instances and publish a link route for the gateway via DHCP. This is used to reduce ARP traffic, enhance security, isolation, scalability of IP address allocations, etc.

In physical networks, this is rather unlikely configuration. Still, since we test EVE on GCP, we must support routing where gateway depends on a link route. For the routes added to per-NI routing tables it means that we need to better describe route dependency, because the gateway could be either inside the subnet of the IP assigned to the output interface or it could be routed by a link-scoped route (and this link route must be configured first). Both cases must be supported.