### PR TITLE
[PREEMPT_RT] pkg/kernel: disable CONFIG_PREEMPT_DEBUG

### DIFF
--- a/pkg/kernel/kernel-config/kernel_config-5.10.x-preempt-rt-x86_64.patch
+++ b/pkg/kernel/kernel-config/kernel_config-5.10.x-preempt-rt-x86_64.patch
@@ -165,7 +165,7 @@
  # end of Scheduler Debugging
  
  # CONFIG_DEBUG_TIMEKEEPING is not set
-+CONFIG_DEBUG_PREEMPT=y
++# CONFIG_DEBUG_PREEMPT is not set
  
  #
  # Lock Debugging (spinlocks, mutexes, etc...)


### PR DESCRIPTION
Running a VM on PREEMPT_RT kernel on real hardware shows no issues with RT kernel, so that PREEMPT tracing can be disabled.

CC: @rene 