### PR TITLE
CODEOWNERS: fix formatting

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,137 +2,71 @@
 # the repo. Unless a later match takes precedence, these will
 # be requested for review when someone opens a pull request.
 
-*                                  @eriknordmark
-
-/pkg/edgeview/                     @naiming-zededa
-/pkg/newlog/                       @naiming-zededa
-
-
-/api/                              @deitch
-/build-tools/                      @deitch
-/libs/zedUpload/                   @deitch
-/pkg/newlog/                       @deitch
-/pkg/pillar/cas/                   @deitch
-/pkg/pillar/cmd/baseosmgr/         @deitch
-/pkg/pillar/cmd/downloader/        @deitch
-/pkg/pillar/cmd/volumemgr/         @deitch
-/pkg/pillar/containerd/            @deitch
-/pkg/rngd/                         @deitch
-/tools/                            @deitch
-
-
-/libs/zedUpload/                   @christoph-zededa
-/pkg/alpine/                       @christoph-zededa
-/pkg/dom0-ztools/                  @christoph-zededa
-/pkg/edgeview/                     @christoph-zededa
-/pkg/pillar/cmd/zedrouter/         @christoph-zededa
-/pkg/pillar/zedcloud/              @christoph-zededa
-
-
-/pkg/mkimage-raw-efi/              @jsfakian
-/pkg/mkverification-raw-efi/       @jsfakian
-/pkg/pillar/cmd/domainmgr/         @jsfakian
-/pkg/verification/                 @jsfakian
-/tools/                            @jsfakian
-
-
-/pkg/grub/                         @mikem-zed
-/pkg/kernel/                       @mikem-zed
-/pkg/measure-config/               @mikem-zed
-/pkg/new-kernel/                   @mikem-zed
-/pkg/pillar/cmd/ledmanager/        @mikem-zed
-/pkg/pillar/cmd/tpmmgr/            @mikem-zed
-/pkg/pillar/evetpm/                @mikem-zed
-/pkg/pillar/hypervisor/            @mikem-zed
-/pkg/uefi/                         @mikem-zed
-/pkg/xen-tools/                    @mikem-zed
-/pkg/xen/                          @mikem-zed
-
-
-/libs/depgraph/                    @milan-zededa
-/libs/nettrace/                    @milan-zededa
-/libs/reconciler/                  @milan-zededa
-/pkg/pillar/cmd/domainmgr/         @milan-zededa
-/pkg/pillar/cmd/downloader/        @milan-zededa
-/pkg/pillar/cmd/nim/               @milan-zededa
-/pkg/pillar/cmd/zedagent/          @milan-zededa
-/pkg/pillar/cmd/zedrouter/         @milan-zededa
-/pkg/pillar/devicenetwork/         @milan-zededa
-/pkg/pillar/dpcmanager/            @milan-zededa
-/pkg/pillar/dpcreconciler/         @milan-zededa
-/pkg/pillar/iptables/              @milan-zededa
-/pkg/pillar/netdump/               @milan-zededa
-/pkg/pillar/netmonitor/            @milan-zededa
-/pkg/pillar/nireconciler/          @milan-zededa
-/pkg/pillar/nistate/               @milan-zededa
-/pkg/pillar/uplinkprober/          @milan-zededa
-/pkg/pillar/utils/                 @milan-zededa
-/pkg/wwan/                         @milan-zededa
-/tests/eden/                       @milan-zededa
-
-
-/pkg/pillar/cmd/domainmgr/         @OhmSpectator
-/pkg/pillar/cmd/volumemgr/         @OhmSpectator
-/pkg/pillar/cmd/zedagent/          @OhmSpectator
-/pkg/pillar/cmd/zedmanager/        @OhmSpectator
-/pkg/pillar/cpuallocator/          @OhmSpectator
-/pkg/pillar/hypervisor/            @OhmSpectator
-/pkg/pillar/volumehandlers/        @OhmSpectator
-/pkg/xen-tools/                    @OhmSpectator
-/pkg/xen/                          @OhmSpectator
-
-
-/pkg/pillar/cmd/domainmgr/         @uncleDecart
-/pkg/pillar/cmd/zedagent/          @uncleDecart
-/pkg/pillar/sriov/                 @uncleDecart
-/tests/eden/                       @uncleDecart
-
-
-/pkg/kube/                         @zedi-pramodh
-/pkg/mkimage-raw-efi/              @zedi-pramodh
-/pkg/pillar/zfs/                   @zedi-pramodh
-
-
-/pkg/bsp-imx/                      @rene
-/pkg/cross-compilers/              @rene
-/pkg/debug/lshw/                   @rene
-/pkg/fw/                           @rene
-/pkg/grub/                         @rene
-/pkg/kernel/                       @rene
-/pkg/new-kernel/                   @rene
-/pkg/optee-os/                     @rene
-/pkg/pillar/cmd/ledmanager/        @rene
-/pkg/pillar/hypervisor/            @rene
-/pkg/u-boot/                       @rene
-/pkg/xen-tools/                    @rene
-/pkg/xen/                          @rene
-
-
-/libs/zedUpload/                   @rouming
-/pkg/debug/                        @rouming
-/pkg/dom0-ztools/                  @rouming
-/pkg/kdump/                        @rouming
-/pkg/kernel/                       @rouming
-/pkg/kexec/                        @rouming
-/pkg/new-kernel/                   @rouming
-/pkg/pillar/cmd/downloader/        @rouming
-/pkg/pillar/cmd/volumemgr/         @rouming
-/pkg/pillar/cmd/zedagent/          @rouming
-/pkg/pillar/cmd/zedmanager/        @rouming
-/pkg/pillar/cmd/zedrouter/         @rouming
-/pkg/pillar/containerd/            @rouming
-/pkg/pillar/hypervisor/            @rouming
-/pkg/pillar/zedcloud/              @rouming
-/pkg/storage-init/                 @rouming
-
-
-/pkg/apparmor/                     @shjala
-/pkg/dom0-tools/                   @shjala
-/pkg/kernel/                       @shjala
-/pkg/new-kernel/                   @shjala
-/pkg/pillar/cmd/tpmmgr/            @shjala
-/pkg/pillar/evetpm/                @shjala
-/pkg/pillar/hypervisor/            @shjala
-/pkg/vtpm/                         @shjala
-/pkg/xen-tools/                    @shjala
-/pkg/xen/                          @shjala
+*                             @eriknordmark
+/api/                         @deitch
+/build-tools/                 @deitch
+/libs/depgraph/               @milan-zededa
+/libs/nettrace/               @milan-zededa
+/libs/reconciler/             @milan-zededa
+/libs/zedUpload/              @christoph-zededa @deitch @rouming
+/pkg/alpine/                  @christoph-zededa
+/pkg/apparmor/                @shjala
+/pkg/bsp-imx/                 @rene
+/pkg/cross-compilers/         @rene
+/pkg/debug/                   @rouming
+/pkg/debug/lshw/              @rene
+/pkg/dom0-tools/              @shjala
+/pkg/dom0-ztools/             @christoph-zededa @rouming
+/pkg/edgeview/                @christoph-zededa @naiming-zededa
+/pkg/fw/                      @rene
+/pkg/grub/                    @mikem-zed @rene
+/pkg/kdump/                   @rouming
+/pkg/kernel/                  @mikem-zed @rene @rouming @shjala
+/pkg/kexec/                   @rouming
+/pkg/kube/                    @zedi-pramodh
+/pkg/measure-config/          @mikem-zed
+/pkg/mkimage-raw-efi/         @jsfakian @zedi-pramodh
+/pkg/mkverification-raw-efi/  @jsfakian
+/pkg/new-kernel/              @mikem-zed @rene @rouming @shjala
+/pkg/newlog/                  @deitch @naiming-zededa
+/pkg/optee-os/                @rene
+/pkg/pillar/cas/              @deitch
+/pkg/pillar/cmd/baseosmgr/    @deitch
+/pkg/pillar/cmd/domainmgr/    @OhmSpectator @jsfakian @milan-zededa @uncleDecart
+/pkg/pillar/cmd/downloader/   @deitch @milan-zededa @rouming
+/pkg/pillar/cmd/ledmanager/   @mikem-zed @rene
+/pkg/pillar/cmd/nim/          @milan-zededa
+/pkg/pillar/cmd/tpmmgr/       @mikem-zed @shjala
+/pkg/pillar/cmd/volumemgr/    @OhmSpectator @deitch @rouming
+/pkg/pillar/cmd/zedagent/     @OhmSpectator @milan-zededa @rouming @uncleDecart
+/pkg/pillar/cmd/zedmanager/   @OhmSpectator @rouming
+/pkg/pillar/cmd/zedrouter/    @christoph-zededa @milan-zededa @rouming
+/pkg/pillar/containerd/       @deitch @rouming
+/pkg/pillar/cpuallocator/     @OhmSpectator
+/pkg/pillar/devicenetwork/    @milan-zededa
+/pkg/pillar/dpcmanager/       @milan-zededa
+/pkg/pillar/dpcreconciler/    @milan-zededa
+/pkg/pillar/evetpm/           @mikem-zed @shjala
+/pkg/pillar/hypervisor/       @OhmSpectator @mikem-zed @rene @rouming @shjala
+/pkg/pillar/iptables/         @milan-zededa
+/pkg/pillar/netdump/          @milan-zededa
+/pkg/pillar/netmonitor/       @milan-zededa
+/pkg/pillar/nireconciler/     @milan-zededa
+/pkg/pillar/nistate/          @milan-zededa
+/pkg/pillar/sriov/            @uncleDecart
+/pkg/pillar/uplinkprober/     @milan-zededa
+/pkg/pillar/utils/            @milan-zededa
+/pkg/pillar/volumehandlers/   @OhmSpectator
+/pkg/pillar/zedcloud/         @christoph-zededa @rouming
+/pkg/pillar/zfs/              @zedi-pramodh
+/pkg/rngd/                    @deitch
+/pkg/storage-init/            @rouming
+/pkg/u-boot/                  @rene
+/pkg/uefi/                    @mikem-zed
+/pkg/verification/            @jsfakian
+/pkg/vtpm/                    @shjala
+/pkg/wwan/                    @milan-zededa
+/pkg/xen-tools/               @OhmSpectator @mikem-zed @rene @shjala
+/pkg/xen/                     @OhmSpectator @mikem-zed @rene @shjala
+/tests/eden/                  @milan-zededa @uncleDecart
+/tools/                       @deitch @jsfakian


### PR DESCRIPTION
Apparently the CODEOWNERS format does not accept the multi-lines, so if there are multiple reviewers for the same pattern, those should be specified on the same line. Here is what doc says:

"If you want to match two or more code owners with the same pattern,
 all the code owners must be on the same line. If the code owners are
 not on the same line, the pattern matches only the last mentioned
 code owner."

But who reads docs ...

There is no any difference in reviewers list, only format change.