### PR TITLE
To call the tests on PR from lf-edge/eden

### DIFF
--- a/.github/workflows/eden_test.yml
+++ b/.github/workflows/eden_test.yml
@@ -1,0 +1,21 @@
+---
+name: Test from lf-edge/eden
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "master"
+      - "[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+-stable"
+    paths-ignore:
+      - 'docs/**'
+  pull_request_review:
+    types: [submitted]
+    paths-ignore:
+      - 'docs/**'
+
+jobs:
+  call_test_wf_from_eden:
+    uses: lf-edge/eden/.github/workflows/test.yml@master
+    with:
+      eve_tag: "evebuild/danger:pr${{ github.event.pull_request.number  }}"


### PR DESCRIPTION
For the purpose of running the eden tests, this PR will call the lf-edge/eden process and pass the eve build tag. 

Note:- TIDY version of https://github.com/lf-edge/eve/pull/3370 