### PR TITLE
Process an empty IP correctly

### DIFF
--- a/pkg/pillar/cmd/zedrouter/dnsmasq.go
+++ b/pkg/pillar/cmd/zedrouter/dnsmasq.go
@@ -573,7 +573,7 @@ func checkAndPublishDhcpLeases(ctx *zedrouterContext) {
 }
 
 func isEmptyIP(ip net.IP) bool {
-	return ip.Equal(net.IP{})
+	return ip == nil || ip.Equal(net.IP{})
 }
 
 func ipListEqual(one []net.IP, two []string) bool {

--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -1083,7 +1083,7 @@ func handleMetaDataServerChange(ctx *zedrouterContext, dnstatus *types.DeviceNet
 		if addr.String() == status.MetaDataServerIP {
 			continue
 		}
-		if (err != nil || (addr.String() == "" && status.MetaDataServerIP != "")) &&
+		if (err != nil || (isEmptyIP(addr) && status.MetaDataServerIP != "")) &&
 			status.Server4Running == true {
 			// Bridge had a valid IP and it is gone now
 			deleteServer4(ctx, status.MetaDataServerIP, status.BridgeName)
@@ -1102,7 +1102,7 @@ func handleMetaDataServerChange(ctx *zedrouterContext, dnstatus *types.DeviceNet
 				status.MetaDataServerIP, status.BridgeName)
 			status.Server4Running = false
 		}
-		if addr.String() != "" {
+		if !isEmptyIP(addr) {
 			// Start new meta-data server
 			status.MetaDataServerIP = addr.String()
 			err := createServer4(ctx, status.MetaDataServerIP, status.BridgeName)


### PR DESCRIPTION
An empty IP can be an empty string or nil.
So process it correctly.