### PR TITLE
[workflows] fix syntax in codeql

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,11 +1,11 @@
----
 # For most projects, this workflow file will not need changing; you simply need
 # to commit it to your repository.
 #
 # You may wish to alter this file to override the set of languages analyzed,
 # or to provide custom queries or build logic.
-name: "CodeQL"
 
+---
+name: "CodeQL"
 on:  # yamllint disable-line rule:truthy
   push:
     branches:


### PR DESCRIPTION
Apparently the syntax was botched as part of fixing yamllint complaints., resulting in workflow failures of the form:
every step must define a `uses` or `run` key

This puts the '---' in the same place as for the other workflow files.
