### PR TITLE
An empty IP can be represented using an empty slice or nil, so check …

### DIFF
--- a/pkg/pillar/cmd/zedrouter/dnsmasq.go
+++ b/pkg/pillar/cmd/zedrouter/dnsmasq.go
@@ -573,7 +573,7 @@ func checkAndPublishDhcpLeases(ctx *zedrouterContext) {
 }
 
 func isEmptyIP(ip net.IP) bool {
-	return ip.Equal(net.IP{})
+	return ip == nil || ip.Equal(net.IP{})
 }
 
 func ipListEqual(one []net.IP, two []string) bool {

--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -1074,7 +1074,7 @@ func handleMetaDataServerChange(ctx *zedrouterContext, dnstatus *types.DeviceNet
 		if addr.String() == status.MetaDataServerIP {
 			continue
 		}
-		if (err != nil || (addr.String() == "" && status.MetaDataServerIP != "")) &&
+		if (err != nil || (isEmptyIP(addr) && status.MetaDataServerIP != "")) &&
 			status.Server4Running == true {
 			// Bridge had a valid IP and it is gone now
 			deleteServer4(ctx, status.MetaDataServerIP, status.BridgeName)
@@ -1093,7 +1093,7 @@ func handleMetaDataServerChange(ctx *zedrouterContext, dnstatus *types.DeviceNet
 				status.MetaDataServerIP, status.BridgeName)
 			status.Server4Running = false
 		}
-		if addr.String() != "" {
+		if !isEmptyIP(addr) {
 			// Start new meta-data server
 			status.MetaDataServerIP = addr.String()
 			err := createServer4(ctx, status.MetaDataServerIP, status.BridgeName)


### PR DESCRIPTION
…for both.

This code is inspired from commit 3720584 where isEmptyIP is fixed to handle both nil and "" IP

An incorrectly performed IP-emptiness check may lead to zedrouter trying to stop metadata server which has not been yet started, resulting in panic triggered from log.Fatal.

Signed-off-by: Pramodh Pallapothu <pramodh@zededa.com>
(cherry picked from commit bae0ecdd32301786b7db0f3d8bb1f4de37ad1ff8)