### PR TITLE
pillar/containerd: introduce specific NotFound err

### DIFF
--- a/pkg/pillar/containerd/containerd.go
+++ b/pkg/pillar/containerd/containerd.go
@@ -258,7 +258,6 @@ func (client *Client) CtrGetImage(ctx context.Context, reference string) (contai
 	}
 	image, err := client.ctrdClient.GetImage(ctx, reference)
 	if err != nil {
-		logrus.Errorf("CtrGetImage: could not get image %s from containerd: %+s", reference, err.Error())
 		return nil, err
 	}
 	return image, nil


### PR DESCRIPTION
In some cases it is expected that the image hash is not found when getting called by IngestBlobsAndCreateImage.

In order to not confuse the reader of logs, this code now reflects the status quo and does not output an error message anymore.