### PR TITLE
pkg: debug: Add /usr/bin/service to debug container

### DIFF
--- a/pkg/debug/build.yml
+++ b/pkg/debug/build.yml
@@ -20,6 +20,7 @@ config:
     - /etc/profile.d:/etc/profile.d
     - /run:/root/.ssh
     - /bin/eve:/bin/eve
+    - /usr/bin/service:/usr/bin/service
     - /usr/bin/logread:/usr/bin/logread
     - /usr/bin/ctr:/usr/bin/ctr
     - /usr/bin/runc:/usr/bin/runc


### PR DESCRIPTION
This PR adds the /usr/bin/service binary to debug container in order to allow the "eve start <container>" command to be executed. Since other commands, like the "eve destroy <container>" works, there is not reason to no allow the start option.

This will fix errors like the following:

```
ce9eb1a5-8e58-4e87-9932-2bd8561b95c7:~# eve destroy vtpm
WARN[0000] task vtpm exit with non-zero exit code 137   
ce9eb1a5-8e58-4e87-9932-2bd8561b95c7:~# eve start vtpm
/bin/eve: line 106: /usr/bin/service: not found
ce9eb1a5-8e58-4e87-9932-2bd8561b95c7:~# 
```
