### PR TITLE
Docker image lfedge/eve-verification missing necessary files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -806,6 +806,7 @@ verification: $(VERIFICATION) $(VERIFICATION_ARTIFACTS) current | $(BUILD_DIR)
 	$(QUIET)if [ -n "$(EVE_REL)" ] && [ $(HV) = $(HV_DEFAULT) ]; then \
 	   $(LINUXKIT) $(DASH_V) pkg $(LINUXKIT_PKG_TARGET) --platforms linux/$(ZARCH) --hash-path $(CURDIR) --hash $(EVE_REL)-$(HV) --docker --release $(EVE_REL) $(FORCE_BUILD) $| ;\
 	fi
+	cp -r $|/installer/* $|/verification
 	$(QUIET): $@: Succeeded
 
 .PHONY: image-set outfile-set cache-export cache-export-docker-load cache-export-docker-load-all


### PR DESCRIPTION
- When pushing containts into ledge/eve-verification image, we are missing files and folders necessary (e.g., rootfs.img, EFI/, config.img, etc.) to create the verification.img. We add a command on the makefile rule "make verification" to copy files from dist/<ZARCH>/current/installer to dist/<ZARCH>/current/verification.