### PR TITLE
[10.4] debug : add GNU tar to the container

### DIFF
--- a/pkg/debug/Dockerfile
+++ b/pkg/debug/Dockerfile
@@ -10,7 +10,7 @@ ENV BUILD_PKGS abuild curl tar make linux-headers patch g++ git gcc ncurses-dev 
 # forget to check on all supported architectures: e.g. arm64
 # binaries are typically larger and amd64 ones).
 # RUN apk add --no-cache gdb valgrind
-ENV PKGS openssl openssh-client openssh-server tini util-linux ca-certificates pciutils usbutils vim tcpdump perf strace iproute2-minimal curl
+ENV PKGS openssl openssh-client openssh-server tini util-linux ca-certificates pciutils usbutils vim tcpdump perf strace iproute2-minimal curl tar
 RUN eve-alpine-deploy.sh
 
 ENV LSHW_VERSION 02.19.2


### PR DESCRIPTION
Add GNU tar to the container, otherwise running collect-info.sh script while the device is offline fails to gzip the collected logs, because the BusyBox tar lacks some features compared to GNU version.