### PR TITLE
Disable eden_test workflows from running on each PR and master push

### DIFF
--- a/.github/workflows/eden_test.yml
+++ b/.github/workflows/eden_test.yml
@@ -2,17 +2,6 @@
 name: Test Eden WF from lf-edge/eden
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - "master"
-      - "[0-9]+.[0-9]+"
-      - "[0-9]+.[0-9]+-stable"
-    paths-ignore:
-      - 'docs/**'
-  pull_request_review:
-    types: [submitted]
-    paths-ignore:
-      - 'docs/**'
 
 jobs:
   test_suite:


### PR DESCRIPTION
New workflows do not timeout since they have better granularity, however this way they bloat queue of works and slow down pipeline.

This commit temprorary disables them from automatically running so that queue won't bloat