### PR TITLE
pkg: kernel: Fix kernel crash on RPi4 when using TPM

### DIFF
--- a/pkg/kernel/patches-5.10.x/0056-tpm-fix-potential-NULL-pointer-access-in-tpm_del_cha.patch
+++ b/pkg/kernel/patches-5.10.x/0056-tpm-fix-potential-NULL-pointer-access-in-tpm_del_cha.patch
@@ -1,0 +1,64 @@
+From 1c282406ba9c9de36fa5a25bdd9bfaee73f8e7e7 Mon Sep 17 00:00:00 2001
+From: Lino Sanfilippo <LinoSanfilippo@gmx.de>
+Date: Mon, 20 Dec 2021 16:06:35 +0100
+Subject: [PATCH] tpm: fix potential NULL pointer access in tpm_del_char_device
+
+Some SPI controller drivers unregister the controller in the shutdown
+handler (e.g. BCM2835). If such a controller is used with a TPM 2 slave
+chip->ops may be accessed when it is already NULL:
+
+At system shutdown the pre-shutdown handler tpm_class_shutdown() shuts down
+TPM 2 and sets chip->ops to NULL. Then at SPI controller unregistration
+tpm_tis_spi_remove() is called and eventually calls tpm_del_char_device()
+which tries to shut down TPM 2 again. Thereby it accesses chip->ops again:
+(tpm_del_char_device calls tpm_chip_start which calls tpm_clk_enable which
+calls chip->ops->clk_enable).
+
+Avoid the NULL pointer access by testing if chip->ops is valid and skipping
+the TPM 2 shutdown procedure in case it is NULL.
+
+Cc: stable@vger.kernel.org
+Signed-off-by: Lino Sanfilippo <LinoSanfilippo@gmx.de>
+Fixes: 39d0099f9439 ("powerpc/pseries: Add shutdown() to vio_driver and vio_bus")
+Reviewed-by: Stefan Berger <stefanb@linux.ibm.com>
+Tested-by: Stefan Berger <stefanb@linux.ibm.com>
+Reviewed-by: Jarkko Sakkinen <jarkko@kernel.org>
+Signed-off-by: Jarkko Sakkinen <jarkko@kernel.org>
+---
+ drivers/char/tpm/tpm-chip.c | 18 +++++++++++++-----
+ 1 file changed, 13 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/char/tpm/tpm-chip.c b/drivers/char/tpm/tpm-chip.c
+index ed600473ad7e..65d800ecc996 100644
+--- a/drivers/char/tpm/tpm-chip.c
++++ b/drivers/char/tpm/tpm-chip.c
+@@ -444,13 +444,21 @@ static void tpm_del_char_device(struct tpm_chip *chip)
+ 
+ 	/* Make the driver uncallable. */
+ 	down_write(&chip->ops_sem);
+-	if (chip->flags & TPM_CHIP_FLAG_TPM2) {
+-		if (!tpm_chip_start(chip)) {
+-			tpm2_shutdown(chip, TPM2_SU_CLEAR);
+-			tpm_chip_stop(chip);
++
++	/*
++	 * Check if chip->ops is still valid: In case that the controller
++	 * drivers shutdown handler unregisters the controller in its
++	 * shutdown handler we are called twice and chip->ops to NULL.
++	 */
++	if (chip->ops) {
++		if (chip->flags & TPM_CHIP_FLAG_TPM2) {
++			if (!tpm_chip_start(chip)) {
++				tpm2_shutdown(chip, TPM2_SU_CLEAR);
++				tpm_chip_stop(chip);
++			}
+ 		}
++		chip->ops = NULL;
+ 	}
+-	chip->ops = NULL;
+ 	up_write(&chip->ops_sem);
+ }
+ 
+-- 
+2.40.1
+


### PR DESCRIPTION
When using a Infineon SLB9670 TPM attached to the board, kernel crashes during reboot/shutdown. Some discussions about this issue can be found at the links below:

https://bugzilla.redhat.com/show_bug.cgi?id=2014462 https://marc.info/?l=linux-integrity&m=163129718414118&w=2

Port the patch that adds some checks to TPM driver and fixes this issue.