### PR TITLE
pkg: kernel: Fix USB HID kernel configuration on ARM64

### DIFF
--- a/pkg/kernel/kernel-config/kernel_config-5.10.x-aarch64
+++ b/pkg/kernel/kernel-config/kernel_config-5.10.x-aarch64
@@ -4969,9 +4969,16 @@ CONFIG_HID_PLANTRONICS=m
 #
 # USB HID support
 #
-CONFIG_USB_HID=y
+CONFIG_USB_HID=m
 CONFIG_HID_PID=y
 # CONFIG_USB_HIDDEV is not set
+
+#
+# USB HID Boot Protocol drivers
+#
+CONFIG_USB_KBD=m
+CONFIG_USB_MOUSE=m
+# end of USB HID Boot Protocol drivers
 # end of USB HID support
 
 #


### PR DESCRIPTION
USB keyboard, mouse and HID drivers are built in on ARM64 kernel configuration, but they must be built as modules, so EVE can control (load/unload) them through pillar.