### PR TITLE
diag: print more information about attestation, apps, downloads

### DIFF
--- a/pkg/pillar/attest/attest.go
+++ b/pkg/pillar/attest/attest.go
@@ -17,9 +17,6 @@ import (
 // Event represents an event in the attest state machine
 type Event int
 
-// AttestState represents a state in the attest state machine
-type AttestState int32
-
 // Events
 const (
 	EventInitialize Event = iota + 0
@@ -35,19 +32,6 @@ const (
 	EventAttestEscrowFailed
 	EventAttestSuccessful
 	EventRestart
-)
-
-// States
-const (
-	StateNone               AttestState = iota + 0 //State when (Re)Starting attestation
-	StateNonceWait                                 //Waiting for response from Controller for Nonce request
-	StateInternalQuoteWait                         //Waiting for internal PCR quote to be published
-	StateInternalEscrowWait                        //Waiting for internal Escrow data to be published
-	StateAttestWait                                //Waiting for response from Controller for PCR quote
-	StateAttestEscrowWait                          //Waiting for response from Controller for Escrow data
-	StateRestartWait                               //Waiting for restart timer to expire, to start all over again
-	StateComplete                                  //Everything w.r.t attestation is complete
-	StateAny                                       //Not a real state per se. helps defining wildcard transitions(below)
 )
 
 // String returns human readable equivalent of an Event
@@ -81,32 +65,6 @@ func (event Event) String() string {
 		return "EventRestart"
 	default:
 		return "Unknown Event"
-	}
-}
-
-// String returns human readable string of an AttestState
-func (state AttestState) String() string {
-	switch state {
-	case StateNone:
-		return "StateNone"
-	case StateNonceWait:
-		return "StateNonceWait"
-	case StateInternalQuoteWait:
-		return "StateInternalQuoteWait"
-	case StateInternalEscrowWait:
-		return "StateInternalEscrowWait"
-	case StateAttestWait:
-		return "StateAttestWait"
-	case StateAttestEscrowWait:
-		return "StateAttestEscrowWait"
-	case StateRestartWait:
-		return "StateRestartWait"
-	case StateComplete:
-		return "StateComplete"
-	case StateAny:
-		return "StateAny"
-	default:
-		return "Unknown State"
 	}
 }
 
@@ -161,7 +119,7 @@ type Context struct {
 	PubSub                *pubsub.PubSub
 	log                   *base.LogObject
 	event                 Event
-	state                 AttestState
+	state                 types.AttestState
 	restartTimer          *time.Timer
 	eventTrigger          chan Event
 	retryTime             time.Duration //in seconds
@@ -175,7 +133,7 @@ type Context struct {
 // Transition represents an event triggered from a state
 type Transition struct {
 	event Event
-	state AttestState
+	state types.AttestState
 }
 
 // New returns a new instance of the state machine
@@ -184,7 +142,7 @@ func New(ps *pubsub.PubSub, log *base.LogObject, retryTime, watchdogTickerTime t
 		PubSub:             ps,
 		log:                log,
 		event:              EventInitialize,
-		state:              StateNone,
+		state:              types.StateNone,
 		eventTrigger:       make(chan Event, 1),
 		retryTime:          retryTime,
 		watchdogTickerTime: watchdogTickerTime,
@@ -198,7 +156,7 @@ func (ctx *Context) Initialize() error {
 }
 
 // GetState returns current state
-func (ctx *Context) GetState() AttestState {
+func (ctx *Context) GetState() types.AttestState {
 	return getStateAtomic(ctx)
 }
 
@@ -207,33 +165,33 @@ type EventHandler func(*Context) error
 
 // the state machine
 var transitions = map[Transition]EventHandler{
-	{EventInitialize, StateNone}:                        handleInitializeAtNone,                        //goes to NonceWait
-	{EventRestart, StateNone}:                           handleRestartAtNone,                           //goes to NonceWait
-	{EventRetryTimerExpiry, StateRestartWait}:           handleRetryTimerExpiryAtRestartWait,           //goes to NonceWait
-	{EventRestart, StateRestartWait}:                    handleRestart,                                 //goes to RestartWait
-	{EventNonceRecvd, StateNonceWait}:                   handleNonceRecvdAtNonceWait,                   //goes to InternalQuoteWait
-	{EventRetryTimerExpiry, StateNonceWait}:             handleRetryTimerExpiryAtNonceWait,             //goes to InternalQuoteWait
-	{EventRestart, StateNonceWait}:                      handleRestart,                                 //goes to RestartWait
-	{EventInternalQuoteRecvd, StateInternalQuoteWait}:   handleInternalQuoteRecvdAtInternalQuoteWait,   //goes to AttestWait
-	{EventRetryTimerExpiry, StateInternalQuoteWait}:     handleRetryTimerExpiryAtInternalQuoteWait,     //retries in InternalQuoteWait
-	{EventRestart, StateInternalQuoteWait}:              handleRestart,                                 //goes to RestartWait
-	{EventRestart, StateInternalEscrowWait}:             handleRestart,                                 //goes to RestartWait
-	{EventInternalEscrowRecvd, StateInternalEscrowWait}: handleInternalEscrowRecvdAtInternalEscrowWait, //goes to AttestEscrowWait
-	{EventNonceMismatch, StateAttestWait}:               handleNonceMismatchAtAttestWait,               //goes to RestartWait
-	{EventQuoteMismatch, StateAttestWait}:               handleQuoteMismatchAtAttestWait,               //goes to RestartWait
-	{EventNoQuoteCertRecvd, StateAttestWait}:            handleNoQuoteCertRcvdAtAttestWait,             //goes to RestartWait
-	{EventAttestSuccessful, StateAttestWait}:            handleAttestSuccessfulAtAttestWait,            //goes to AttestEscrowWait | RestartWait
-	{EventRetryTimerExpiry, StateAttestWait}:            handleRetryTimerExpiryAtAttestWait,            //retries in AttestWait
-	{EventRestart, StateAttestWait}:                     handleRestart,                                 //goes to RestartWait
-	{EventAttestEscrowFailed, StateAttestEscrowWait}:    handleAttestEscrowFailedAtAttestEscrowWait,    //goes to RestartWait (XXX: optimise)
-	{EventNoEscrow, StateAttestEscrowWait}:              handleNoEscrowAtAttestEscrowWait,              //goes to InternalEscrowWait
-	{EventAttestEscrowRecorded, StateAttestEscrowWait}:  handleAttestEscrowRecordedAtAttestEscrowWait,  //goes to Complete | RestartWait
-	{EventRetryTimerExpiry, StateAttestEscrowWait}:      handleRetryTimerExpiryWhileAttestEscrowWait,   //goes to Complete | RestartWait
-	{EventRestart, StateAttestEscrowWait}:               handleRestart,                                 //goes to RestartWait
-	{EventRestart, StateComplete}:                       handleRestartAtStateComplete,                  //goes to RestartWait
+	{EventInitialize, types.StateNone}:                        handleInitializeAtNone,                        //goes to NonceWait
+	{EventRestart, types.StateNone}:                           handleRestartAtNone,                           //goes to NonceWait
+	{EventRetryTimerExpiry, types.StateRestartWait}:           handleRetryTimerExpiryAtRestartWait,           //goes to NonceWait
+	{EventRestart, types.StateRestartWait}:                    handleRestart,                                 //goes to RestartWait
+	{EventNonceRecvd, types.StateNonceWait}:                   handleNonceRecvdAtNonceWait,                   //goes to InternalQuoteWait
+	{EventRetryTimerExpiry, types.StateNonceWait}:             handleRetryTimerExpiryAtNonceWait,             //goes to InternalQuoteWait
+	{EventRestart, types.StateNonceWait}:                      handleRestart,                                 //goes to RestartWait
+	{EventInternalQuoteRecvd, types.StateInternalQuoteWait}:   handleInternalQuoteRecvdAtInternalQuoteWait,   //goes to AttestWait
+	{EventRetryTimerExpiry, types.StateInternalQuoteWait}:     handleRetryTimerExpiryAtInternalQuoteWait,     //retries in InternalQuoteWait
+	{EventRestart, types.StateInternalQuoteWait}:              handleRestart,                                 //goes to RestartWait
+	{EventRestart, types.StateInternalEscrowWait}:             handleRestart,                                 //goes to RestartWait
+	{EventInternalEscrowRecvd, types.StateInternalEscrowWait}: handleInternalEscrowRecvdAtInternalEscrowWait, //goes to AttestEscrowWait
+	{EventNonceMismatch, types.StateAttestWait}:               handleNonceMismatchAtAttestWait,               //goes to RestartWait
+	{EventQuoteMismatch, types.StateAttestWait}:               handleQuoteMismatchAtAttestWait,               //goes to RestartWait
+	{EventNoQuoteCertRecvd, types.StateAttestWait}:            handleNoQuoteCertRcvdAtAttestWait,             //goes to RestartWait
+	{EventAttestSuccessful, types.StateAttestWait}:            handleAttestSuccessfulAtAttestWait,            //goes to AttestEscrowWait | RestartWait
+	{EventRetryTimerExpiry, types.StateAttestWait}:            handleRetryTimerExpiryAtAttestWait,            //retries in AttestWait
+	{EventRestart, types.StateAttestWait}:                     handleRestart,                                 //goes to RestartWait
+	{EventAttestEscrowFailed, types.StateAttestEscrowWait}:    handleAttestEscrowFailedAtAttestEscrowWait,    //goes to RestartWait (XXX: optimise)
+	{EventNoEscrow, types.StateAttestEscrowWait}:              handleNoEscrowAtAttestEscrowWait,              //goes to InternalEscrowWait
+	{EventAttestEscrowRecorded, types.StateAttestEscrowWait}:  handleAttestEscrowRecordedAtAttestEscrowWait,  //goes to Complete | RestartWait
+	{EventRetryTimerExpiry, types.StateAttestEscrowWait}:      handleRetryTimerExpiryWhileAttestEscrowWait,   //goes to Complete | RestartWait
+	{EventRestart, types.StateAttestEscrowWait}:               handleRestart,                                 //goes to RestartWait
+	{EventRestart, types.StateComplete}:                       handleRestartAtStateComplete,                  //goes to RestartWait
 
 	////////////// wildcard event handlers below this///////////////////
-	{EventInternalEscrowRecvd, StateAny}: handleInternalEscrowRecvdAtAnyOther, //stays in the same state
+	{EventInternalEscrowRecvd, types.StateAny}: handleInternalEscrowRecvdAtAnyOther, //stays in the same state
 }
 
 // some helpers
@@ -244,12 +202,12 @@ func triggerSelfEvent(ctx *Context, event Event) error {
 	return nil
 }
 
-func setStateAtomic(ctx *Context, state AttestState) {
+func setStateAtomic(ctx *Context, state types.AttestState) {
 	atomic.StoreInt32((*int32)(&ctx.state), int32(state))
 }
 
-func getStateAtomic(ctx *Context) AttestState {
-	return AttestState(atomic.LoadInt32((*int32)(&ctx.state)))
+func getStateAtomic(ctx *Context) types.AttestState {
+	return types.AttestState(atomic.LoadInt32((*int32)(&ctx.state)))
 }
 
 // Kickstart starts the state machine with EventInitialize
@@ -293,7 +251,7 @@ func startNewRetryTimer(ctx *Context) error {
 // The event handlers
 func handleInitializeAtNone(ctx *Context) error {
 	ctx.log.Trace("handleInitializeAtNone")
-	setStateAtomic(ctx, StateNonceWait)
+	setStateAtomic(ctx, types.StateNonceWait)
 	err := verifier.SendNonceRequest(ctx)
 	if err == nil {
 		triggerSelfEvent(ctx, EventNonceRecvd)
@@ -322,7 +280,7 @@ func handleRestartAtNone(ctx *Context) error {
 
 func handleNonceRecvdAtNonceWait(ctx *Context) error {
 	ctx.log.Trace("handleNonceRecvdAtNonceWait")
-	setStateAtomic(ctx, StateInternalQuoteWait)
+	setStateAtomic(ctx, types.StateInternalQuoteWait)
 	err := tpmAgent.SendInternalQuoteRequest(ctx)
 	if err == nil {
 		return nil
@@ -338,7 +296,7 @@ func handleNonceRecvdAtNonceWait(ctx *Context) error {
 
 func handleInternalQuoteRecvdAtInternalQuoteWait(ctx *Context) error {
 	ctx.log.Trace("handleInternalQuoteRecvdAtInternalQuoteWait")
-	setStateAtomic(ctx, StateAttestWait)
+	setStateAtomic(ctx, types.StateAttestWait)
 	err := verifier.SendAttestQuote(ctx)
 	if err == nil {
 		triggerSelfEvent(ctx, EventAttestSuccessful)
@@ -368,7 +326,7 @@ func handleInternalQuoteRecvdAtInternalQuoteWait(ctx *Context) error {
 
 func handleAttestSuccessfulAtAttestWait(ctx *Context) error {
 	ctx.log.Trace("handleAttestSuccessfulAtAttestWait")
-	setStateAtomic(ctx, StateAttestEscrowWait)
+	setStateAtomic(ctx, types.StateAttestEscrowWait)
 	err := verifier.SendAttestEscrow(ctx)
 	if err == nil {
 		triggerSelfEvent(ctx, EventAttestEscrowRecorded)
@@ -396,9 +354,9 @@ func handleAttestSuccessfulAtAttestWait(ctx *Context) error {
 
 func handleAttestEscrowRecordedAtAttestEscrowWait(ctx *Context) error {
 	ctx.log.Trace("handleAttestEscrowRecordedAtAttestEscrowWait")
-	setStateAtomic(ctx, StateComplete)
+	setStateAtomic(ctx, types.StateComplete)
 	if ctx.restartRequestPending {
-		setStateAtomic(ctx, StateRestartWait)
+		setStateAtomic(ctx, types.StateRestartWait)
 		startNewRetryTimer(ctx)
 	}
 	return nil
@@ -406,7 +364,7 @@ func handleAttestEscrowRecordedAtAttestEscrowWait(ctx *Context) error {
 
 func handleRestartAtStateComplete(ctx *Context) error {
 	ctx.log.Trace("handleRestartAtStateComplete")
-	setStateAtomic(ctx, StateRestartWait)
+	setStateAtomic(ctx, types.StateRestartWait)
 	return startNewRetryTimer(ctx)
 }
 
@@ -418,7 +376,7 @@ func handleRestart(ctx *Context) error {
 
 func handleNonceMismatchAtAttestWait(ctx *Context) error {
 	ctx.log.Trace("handleNonceMismatchAtAttestWait")
-	setStateAtomic(ctx, StateRestartWait)
+	setStateAtomic(ctx, types.StateRestartWait)
 	return startNewRetryTimer(ctx)
 }
 
@@ -434,7 +392,7 @@ func handleNoQuoteCertRcvdAtAttestWait(ctx *Context) error {
 
 func handleAttestEscrowFailedAtAttestEscrowWait(ctx *Context) error {
 	ctx.log.Trace("handleAttestEscrowFailedAtAttestEscrowWait")
-	setStateAtomic(ctx, StateRestartWait)
+	setStateAtomic(ctx, types.StateRestartWait)
 	return startNewRetryTimer(ctx)
 }
 
@@ -445,12 +403,12 @@ func handleInternalEscrowRecvdAtInternalEscrowWait(ctx *Context) error {
 }
 
 // handleInternalEscrowRecvdAtAnyOther handles EventInternalEscrowRecvd
-// at any other state, other than StateInternalQuoteWait.
-// for StateInternalQuoteWait, we have handleInternalEscrowRecvdAtInternalEscrowWait
+// at any other state, other than types.StateInternalQuoteWait.
+// for types.StateInternalQuoteWait, we have handleInternalEscrowRecvdAtInternalEscrowWait
 func handleInternalEscrowRecvdAtAnyOther(ctx *Context) error {
 	ctx.log.Trace("handleInternalEscrowRecvdAtAnyOther")
 	switch ctx.state {
-	case StateInternalEscrowWait:
+	case types.StateInternalEscrowWait:
 		//We should not have reached here since there is an explicit
 		//handler. Log an error about this, and call the actual
 		//handler. don't fatal
@@ -467,20 +425,20 @@ func handleInternalEscrowRecvdAtAnyOther(ctx *Context) error {
 func handleNoEscrowAtAttestEscrowWait(ctx *Context) error {
 	ctx.log.Trace("handleNoEscrowAtAttestEscrowWait")
 	//Wait till we get escrow data published
-	setStateAtomic(ctx, StateInternalEscrowWait)
+	setStateAtomic(ctx, types.StateInternalEscrowWait)
 	return nil
 }
 
 func handleRetryTimerExpiryAtRestartWait(ctx *Context) error {
 	ctx.log.Trace("handleRetryTimerExpiryAtRestartWait")
-	setStateAtomic(ctx, StateNone)
+	setStateAtomic(ctx, types.StateNone)
 	ctx.restartRequestPending = false
 	return triggerSelfEvent(ctx, EventInitialize)
 }
 
 func handleRetryTimerExpiryAtNonceWait(ctx *Context) error {
 	ctx.log.Trace("handleRetryTimerExpiryAtNonceWait")
-	setStateAtomic(ctx, StateNone)
+	setStateAtomic(ctx, types.StateNone)
 	return triggerSelfEvent(ctx, EventInitialize)
 }
 
@@ -501,13 +459,13 @@ func handleRetryTimerExpiryAtInternalQuoteWait(ctx *Context) error {
 	return handleNonceRecvdAtNonceWait(ctx)
 }
 
-func despatchEvent(event Event, state AttestState, ctx *Context) error {
+func despatchEvent(event Event, state types.AttestState, ctx *Context) error {
 	elem, ok := transitions[Transition{event: event, state: state}]
 	if ok {
 		return elem(ctx)
 	}
 	//Specific handler is not found, look for a wildcard handler
-	elem, ok = transitions[Transition{event: event, state: StateAny}]
+	elem, ok = transitions[Transition{event: event, state: types.StateAny}]
 	if ok {
 		ctx.log.Noticef("Calling wildcard handler(Event %s in State %s)",
 			event.String(), state.String())

--- a/pkg/pillar/attest/attest.go
+++ b/pkg/pillar/attest/attest.go
@@ -165,33 +165,33 @@ type EventHandler func(*Context) error
 
 // the state machine
 var transitions = map[Transition]EventHandler{
-	{EventInitialize, types.StateNone}:                        handleInitializeAtNone,                        //goes to NonceWait
-	{EventRestart, types.StateNone}:                           handleRestartAtNone,                           //goes to NonceWait
-	{EventRetryTimerExpiry, types.StateRestartWait}:           handleRetryTimerExpiryAtRestartWait,           //goes to NonceWait
-	{EventRestart, types.StateRestartWait}:                    handleRestart,                                 //goes to RestartWait
-	{EventNonceRecvd, types.StateNonceWait}:                   handleNonceRecvdAtNonceWait,                   //goes to InternalQuoteWait
-	{EventRetryTimerExpiry, types.StateNonceWait}:             handleRetryTimerExpiryAtNonceWait,             //goes to InternalQuoteWait
-	{EventRestart, types.StateNonceWait}:                      handleRestart,                                 //goes to RestartWait
-	{EventInternalQuoteRecvd, types.StateInternalQuoteWait}:   handleInternalQuoteRecvdAtInternalQuoteWait,   //goes to AttestWait
-	{EventRetryTimerExpiry, types.StateInternalQuoteWait}:     handleRetryTimerExpiryAtInternalQuoteWait,     //retries in InternalQuoteWait
-	{EventRestart, types.StateInternalQuoteWait}:              handleRestart,                                 //goes to RestartWait
-	{EventRestart, types.StateInternalEscrowWait}:             handleRestart,                                 //goes to RestartWait
-	{EventInternalEscrowRecvd, types.StateInternalEscrowWait}: handleInternalEscrowRecvdAtInternalEscrowWait, //goes to AttestEscrowWait
-	{EventNonceMismatch, types.StateAttestWait}:               handleNonceMismatchAtAttestWait,               //goes to RestartWait
-	{EventQuoteMismatch, types.StateAttestWait}:               handleQuoteMismatchAtAttestWait,               //goes to RestartWait
-	{EventNoQuoteCertRecvd, types.StateAttestWait}:            handleNoQuoteCertRcvdAtAttestWait,             //goes to RestartWait
-	{EventAttestSuccessful, types.StateAttestWait}:            handleAttestSuccessfulAtAttestWait,            //goes to AttestEscrowWait | RestartWait
-	{EventRetryTimerExpiry, types.StateAttestWait}:            handleRetryTimerExpiryAtAttestWait,            //retries in AttestWait
-	{EventRestart, types.StateAttestWait}:                     handleRestart,                                 //goes to RestartWait
-	{EventAttestEscrowFailed, types.StateAttestEscrowWait}:    handleAttestEscrowFailedAtAttestEscrowWait,    //goes to RestartWait (XXX: optimise)
-	{EventNoEscrow, types.StateAttestEscrowWait}:              handleNoEscrowAtAttestEscrowWait,              //goes to InternalEscrowWait
-	{EventAttestEscrowRecorded, types.StateAttestEscrowWait}:  handleAttestEscrowRecordedAtAttestEscrowWait,  //goes to Complete | RestartWait
-	{EventRetryTimerExpiry, types.StateAttestEscrowWait}:      handleRetryTimerExpiryWhileAttestEscrowWait,   //goes to Complete | RestartWait
-	{EventRestart, types.StateAttestEscrowWait}:               handleRestart,                                 //goes to RestartWait
-	{EventRestart, types.StateComplete}:                       handleRestartAtStateComplete,                  //goes to RestartWait
+	{EventInitialize, types.StateNone}:                        handleInitializeAtNone,                        // goes to NonceWait
+	{EventRestart, types.StateNone}:                           handleRestartAtNone,                           // goes to NonceWait
+	{EventRetryTimerExpiry, types.StateRestartWait}:           handleRetryTimerExpiryAtRestartWait,           // goes to NonceWait
+	{EventRestart, types.StateRestartWait}:                    handleRestart,                                 // goes to RestartWait
+	{EventNonceRecvd, types.StateNonceWait}:                   handleNonceRecvdAtNonceWait,                   // goes to InternalQuoteWait
+	{EventRetryTimerExpiry, types.StateNonceWait}:             handleRetryTimerExpiryAtNonceWait,             // goes to InternalQuoteWait
+	{EventRestart, types.StateNonceWait}:                      handleRestart,                                 // goes to RestartWait
+	{EventInternalQuoteRecvd, types.StateInternalQuoteWait}:   handleInternalQuoteRecvdAtInternalQuoteWait,   // goes to AttestWait
+	{EventRetryTimerExpiry, types.StateInternalQuoteWait}:     handleRetryTimerExpiryAtInternalQuoteWait,     // retries in InternalQuoteWait
+	{EventRestart, types.StateInternalQuoteWait}:              handleRestart,                                 // goes to RestartWait
+	{EventRestart, types.StateInternalEscrowWait}:             handleRestart,                                 // goes to RestartWait
+	{EventInternalEscrowRecvd, types.StateInternalEscrowWait}: handleInternalEscrowRecvdAtInternalEscrowWait, // goes to AttestEscrowWait
+	{EventNonceMismatch, types.StateAttestWait}:               handleNonceMismatchAtAttestWait,               // goes to RestartWait
+	{EventQuoteMismatch, types.StateAttestWait}:               handleQuoteMismatchAtAttestWait,               // goes to RestartWait
+	{EventNoQuoteCertRecvd, types.StateAttestWait}:            handleNoQuoteCertRcvdAtAttestWait,             // goes to RestartWait
+	{EventAttestSuccessful, types.StateAttestWait}:            handleAttestSuccessfulAtAttestWait,            // goes to AttestEscrowWait | RestartWait
+	{EventRetryTimerExpiry, types.StateAttestWait}:            handleRetryTimerExpiryAtAttestWait,            // retries in AttestWait
+	{EventRestart, types.StateAttestWait}:                     handleRestart,                                 // goes to RestartWait
+	{EventAttestEscrowFailed, types.StateAttestEscrowWait}:    handleAttestEscrowFailedAtAttestEscrowWait,    // goes to RestartWait (XXX: optimise)
+	{EventNoEscrow, types.StateAttestEscrowWait}:              handleNoEscrowAtAttestEscrowWait,              // goes to InternalEscrowWait
+	{EventAttestEscrowRecorded, types.StateAttestEscrowWait}:  handleAttestEscrowRecordedAtAttestEscrowWait,  // goes to Complete | RestartWait
+	{EventRetryTimerExpiry, types.StateAttestEscrowWait}:      handleRetryTimerExpiryWhileAttestEscrowWait,   // goes to Complete | RestartWait
+	{EventRestart, types.StateAttestEscrowWait}:               handleRestart,                                 // goes to RestartWait
+	{EventRestart, types.StateComplete}:                       handleRestartAtStateComplete,                  // goes to RestartWait
 
 	////////////// wildcard event handlers below this///////////////////
-	{EventInternalEscrowRecvd, types.StateAny}: handleInternalEscrowRecvdAtAnyOther, //stays in the same state
+	{EventInternalEscrowRecvd, types.StateAny}: handleInternalEscrowRecvdAtAnyOther, // stays in the same state
 }
 
 // some helpers

--- a/pkg/pillar/attest/attest_test.go
+++ b/pkg/pillar/attest/attest_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/sirupsen/logrus"
 )
 
@@ -104,7 +105,7 @@ func initTest() *Context {
 		PubSub:       ps,
 		log:          log,
 		event:        EventInitialize,
-		state:        StateNone,
+		state:        types.StateNone,
 		restartTimer: time.NewTimer(1 * time.Second),
 		eventTrigger: make(chan Event, 1),
 		retryTime:    1,
@@ -120,7 +121,7 @@ func TestGoodPath(t *testing.T) {
 
 	go func() {
 		ctx.eventTrigger <- EventInitialize
-		for getStateAtomic(ctx) != StateInternalQuoteWait {
+		for getStateAtomic(ctx) != types.StateInternalQuoteWait {
 			time.Sleep(1 * time.Second)
 		}
 		ctx.eventTrigger <- EventInternalQuoteRecvd
@@ -134,8 +135,8 @@ func TestGoodPath(t *testing.T) {
 				t.Errorf("%v", err)
 			}
 		case <-stopTrigger:
-			if ctx.state != StateComplete {
-				t.Errorf("Expected %s, Got %s", StateComplete.String(), ctx.state.String())
+			if ctx.state != types.StateComplete {
+				t.Errorf("Expected %s, Got %s", types.StateComplete.String(), ctx.state.String())
 			}
 			return
 		}
@@ -149,7 +150,7 @@ func TestNonceMismatch(t *testing.T) {
 
 	go func() {
 		ctx.eventTrigger <- EventInitialize
-		for getStateAtomic(ctx) != StateInternalQuoteWait {
+		for getStateAtomic(ctx) != types.StateInternalQuoteWait {
 			time.Sleep(1 * time.Second)
 		}
 		ctx.eventTrigger <- EventInternalQuoteRecvd
@@ -161,8 +162,8 @@ func TestNonceMismatch(t *testing.T) {
 				t.Errorf("%v", err)
 			}
 		case <-ctx.restartTimer.C:
-			if ctx.state != StateRestartWait {
-				t.Errorf("Expected %s, Got %s", StateRestartWait.String(), ctx.state.String())
+			if ctx.state != types.StateRestartWait {
+				t.Errorf("Expected %s, Got %s", types.StateRestartWait.String(), ctx.state.String())
 			}
 			return
 		}
@@ -176,7 +177,7 @@ func TestQuoteMismatch(t *testing.T) {
 
 	go func() {
 		ctx.eventTrigger <- EventInitialize
-		for getStateAtomic(ctx) != StateInternalQuoteWait {
+		for getStateAtomic(ctx) != types.StateInternalQuoteWait {
 			time.Sleep(1 * time.Second)
 		}
 		ctx.eventTrigger <- EventInternalQuoteRecvd
@@ -188,8 +189,8 @@ func TestQuoteMismatch(t *testing.T) {
 				t.Errorf("%v", err)
 			}
 		case <-ctx.restartTimer.C:
-			if ctx.state != StateRestartWait {
-				t.Errorf("Expected %s, Got %s", StateRestartWait.String(), ctx.state.String())
+			if ctx.state != types.StateRestartWait {
+				t.Errorf("Expected %s, Got %s", types.StateRestartWait.String(), ctx.state.String())
 			}
 			return
 		}
@@ -203,7 +204,7 @@ func TestNoCertInController(t *testing.T) {
 
 	go func() {
 		ctx.eventTrigger <- EventInitialize
-		for getStateAtomic(ctx) != StateInternalQuoteWait {
+		for getStateAtomic(ctx) != types.StateInternalQuoteWait {
 			time.Sleep(1 * time.Second)
 		}
 		ctx.eventTrigger <- EventInternalQuoteRecvd
@@ -215,8 +216,8 @@ func TestNoCertInController(t *testing.T) {
 				t.Errorf("%v", err)
 			}
 		case <-ctx.restartTimer.C:
-			if ctx.state != StateRestartWait {
-				t.Errorf("Expected %s, Got %s", StateRestartWait.String(), ctx.state.String())
+			if ctx.state != types.StateRestartWait {
+				t.Errorf("Expected %s, Got %s", types.StateRestartWait.String(), ctx.state.String())
 			}
 			return
 		}
@@ -230,7 +231,7 @@ func TestControllerNotAvbleInNonceWait(t *testing.T) {
 
 	go func() {
 		ctx.eventTrigger <- EventInitialize
-		for getStateAtomic(ctx) != StateInternalQuoteWait {
+		for getStateAtomic(ctx) != types.StateInternalQuoteWait {
 			time.Sleep(1 * time.Second)
 		}
 		ctx.eventTrigger <- EventInternalQuoteRecvd
@@ -242,8 +243,8 @@ func TestControllerNotAvbleInNonceWait(t *testing.T) {
 				t.Errorf("%v", err)
 			}
 		case <-ctx.restartTimer.C:
-			if ctx.state != StateNonceWait {
-				t.Errorf("Expected %s, Got %s", StateNonceWait.String(), ctx.state.String())
+			if ctx.state != types.StateNonceWait {
+				t.Errorf("Expected %s, Got %s", types.StateNonceWait.String(), ctx.state.String())
 			}
 			return
 		}
@@ -255,7 +256,7 @@ func TestControllerNotAvbleInAttestWait(t *testing.T) {
 	ctx := initTest()
 
 	go func() {
-		setStateAtomic(ctx, StateInternalQuoteWait)
+		setStateAtomic(ctx, types.StateInternalQuoteWait)
 		simulateControllerReqFailure = true
 		ctx.eventTrigger <- EventInternalQuoteRecvd
 	}()
@@ -266,8 +267,8 @@ func TestControllerNotAvbleInAttestWait(t *testing.T) {
 				t.Errorf("%v", err)
 			}
 		case <-ctx.restartTimer.C:
-			if ctx.state != StateAttestWait {
-				t.Errorf("Expected %s, Got %s", StateAttestWait.String(), ctx.state.String())
+			if ctx.state != types.StateAttestWait {
+				t.Errorf("Expected %s, Got %s", types.StateAttestWait.String(), ctx.state.String())
 			}
 			return
 		}
@@ -279,7 +280,7 @@ func TestControllerNotAvbleInAttestEscrowWait(t *testing.T) {
 	ctx := initTest()
 
 	go func() {
-		setStateAtomic(ctx, StateAttestWait)
+		setStateAtomic(ctx, types.StateAttestWait)
 		simulateControllerReqFailure = true
 		ctx.eventTrigger <- EventAttestSuccessful
 	}()
@@ -290,8 +291,8 @@ func TestControllerNotAvbleInAttestEscrowWait(t *testing.T) {
 				t.Errorf("%v", err)
 			}
 		case <-ctx.restartTimer.C:
-			if ctx.state != StateAttestEscrowWait {
-				t.Errorf("Expected %s, Got %s", StateAttestEscrowWait.String(), ctx.state.String())
+			if ctx.state != types.StateAttestEscrowWait {
+				t.Errorf("Expected %s, Got %s", types.StateAttestEscrowWait.String(), ctx.state.String())
 			}
 			return
 		}
@@ -304,7 +305,7 @@ func TestNoEscrowDataAttestEscrowWait(t *testing.T) {
 	stopTrigger := make(chan int)
 
 	go func() {
-		setStateAtomic(ctx, StateAttestWait)
+		setStateAtomic(ctx, types.StateAttestWait)
 		simulateNoEscrowData = true
 		ctx.eventTrigger <- EventAttestSuccessful
 		time.Sleep(time.Second)
@@ -317,8 +318,8 @@ func TestNoEscrowDataAttestEscrowWait(t *testing.T) {
 				t.Errorf("%v", err)
 			}
 		case <-stopTrigger:
-			if ctx.state != StateInternalEscrowWait {
-				t.Errorf("Expected %s, Got %s", StateInternalEscrowWait.String(), ctx.state.String())
+			if ctx.state != types.StateInternalEscrowWait {
+				t.Errorf("Expected %s, Got %s", types.StateInternalEscrowWait.String(), ctx.state.String())
 			}
 			return
 		}
@@ -330,7 +331,7 @@ func TestItokenMismatchAttestEscrowWait(t *testing.T) {
 	ctx := initTest()
 
 	go func() {
-		setStateAtomic(ctx, StateAttestWait)
+		setStateAtomic(ctx, types.StateAttestWait)
 		simulateITokenMismatch = true
 		ctx.eventTrigger <- EventAttestSuccessful
 	}()
@@ -341,8 +342,8 @@ func TestItokenMismatchAttestEscrowWait(t *testing.T) {
 				t.Errorf("%v", err)
 			}
 		case <-ctx.restartTimer.C:
-			if ctx.state != StateRestartWait {
-				t.Errorf("Expected %s, Got %s", StateRestartWait.String(), ctx.state.String())
+			if ctx.state != types.StateRestartWait {
+				t.Errorf("Expected %s, Got %s", types.StateRestartWait.String(), ctx.state.String())
 			}
 			return
 		}
@@ -355,7 +356,7 @@ func TestNoVerifierInNonceWait(t *testing.T) {
 	stopTrigger := make(chan int)
 
 	go func() {
-		setStateAtomic(ctx, StateNone)
+		setStateAtomic(ctx, types.StateNone)
 		simulateNoVerifier = true
 		ctx.eventTrigger <- EventInitialize
 		time.Sleep(1 * time.Second)
@@ -368,8 +369,8 @@ func TestNoVerifierInNonceWait(t *testing.T) {
 				t.Errorf("%v", err)
 			}
 		case <-stopTrigger:
-			if ctx.state != StateNonceWait {
-				t.Errorf("Expected %s, Got %s", StateNonceWait.String(), ctx.state.String())
+			if ctx.state != types.StateNonceWait {
+				t.Errorf("Expected %s, Got %s", types.StateNonceWait.String(), ctx.state.String())
 			}
 			return
 		}
@@ -380,7 +381,7 @@ func TestInternalEscrowRcvdAtAnyOther(t *testing.T) {
 	fmt.Println("--------TestInternalEscrowRcvdAtAnyOther----")
 	ctx := initTest()
 
-	testInternalEscrowRcvdAt := func(state AttestState) {
+	testInternalEscrowRcvdAt := func(state types.AttestState) {
 		setStateAtomic(ctx, state)
 		stopTrigger := make(chan int)
 		go func() {
@@ -399,7 +400,7 @@ func TestInternalEscrowRcvdAtAnyOther(t *testing.T) {
 			}
 		}
 	}
-	for state := StateNone; state < StateAny; state++ {
+	for state := types.StateNone; state < types.StateAny; state++ {
 		testInternalEscrowRcvdAt(state)
 	}
 }
@@ -408,7 +409,7 @@ func TestRestartAtEachState(t *testing.T) {
 	fmt.Println("--------TestRestartAtEachState----")
 	ctx := initTest()
 
-	testRestartEvent := func(state AttestState) {
+	testRestartEvent := func(state types.AttestState) {
 		setStateAtomic(ctx, state)
 		stopTrigger := make(chan int)
 		go func() {
@@ -427,7 +428,7 @@ func TestRestartAtEachState(t *testing.T) {
 			}
 		}
 	}
-	for state := StateNone; state < StateAny; state++ {
+	for state := types.StateNone; state < types.StateAny; state++ {
 		testRestartEvent(state)
 	}
 }

--- a/pkg/pillar/attest/attest_test.go
+++ b/pkg/pillar/attest/attest_test.go
@@ -380,7 +380,7 @@ func TestInternalEscrowRcvdAtAnyOther(t *testing.T) {
 	fmt.Println("--------TestInternalEscrowRcvdAtAnyOther----")
 	ctx := initTest()
 
-	testInternalEscrowRcvdAt := func(state State) {
+	testInternalEscrowRcvdAt := func(state AttestState) {
 		setStateAtomic(ctx, state)
 		stopTrigger := make(chan int)
 		go func() {
@@ -408,7 +408,7 @@ func TestRestartAtEachState(t *testing.T) {
 	fmt.Println("--------TestRestartAtEachState----")
 	ctx := initTest()
 
-	testRestartEvent := func(state State) {
+	testRestartEvent := func(state AttestState) {
 		setStateAtomic(ctx, state)
 		stopTrigger := make(chan int)
 		go func() {

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -898,7 +898,7 @@ func printOutput(ctx *diagContext, caller string) {
 		priority := types.GetPortCost(*ctx.DeviceNetworkStatus,
 			ifname)
 		if isMgmt {
-			mgmtPorts += 1
+			mgmtPorts++
 		}
 
 		typeStr := "use: app-shared "
@@ -925,7 +925,7 @@ func printOutput(ctx *diagContext, caller string) {
 			if ai.Addr.IsLinkLocalUnicast() {
 				continue
 			}
-			ipCount += 1
+			ipCount++
 			noGeo := ipinfo.IPInfo{}
 			if dpcSuccess {
 				PrintIfSpace(ctx, "INFO: Port %s: %s%s%s%s\n",
@@ -947,7 +947,7 @@ func printOutput(ctx *diagContext, caller string) {
 		// all as connected
 		if dpcSuccess {
 			if isMgmt {
-				passPorts += 1
+				passPorts++
 			}
 			continue
 		}
@@ -1018,7 +1018,7 @@ func printOutput(ctx *diagContext, caller string) {
 			continue
 		}
 		if isMgmt {
-			passPorts += 1
+			passPorts++
 		}
 		PrintIfSpace(ctx, "PASS: port %s fully connected to EV controller %s\n",
 			ifname, ctx.serverName)
@@ -1234,7 +1234,7 @@ func tryPing(ctx *diagContext, ifname string, reqURL string) bool {
 		if done {
 			break
 		}
-		retryCount += 1
+		retryCount++
 		if maxRetries != 0 && retryCount > maxRetries {
 			PrintIfSpace(ctx, "ERROR: %s: Exceeded %d retries for ping\n",
 				ifname, maxRetries)
@@ -1289,7 +1289,7 @@ func tryPostUUID(ctx *diagContext, ifname string) bool {
 			zedcloud.ClearCloudCert(zedcloudCtx)
 			return false
 		}
-		retryCount += 1
+		retryCount++
 		if maxRetries != 0 && retryCount > maxRetries {
 			PrintIfSpace(ctx, "ERROR: %s: Exceeded %d retries for get config\n",
 				ifname, maxRetries)

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -154,10 +154,10 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 			log.Fatal(err)
 		}
 	}
+	log.Noticef("diag starting with max rows %d columns %d",
+		*ctx.rowPtr, *ctx.columnPtr)
 	PrintIfSpaceInit(&ctx, outfile, *ctx.stateFilenamePtr,
 		*ctx.rowPtr, *ctx.columnPtr, false)
-	PrintIfSpace(&ctx, "INFO: output limited to %drows and %d columns\n",
-		*ctx.rowPtr, *ctx.columnPtr)
 	ctx.DeviceNetworkStatus = &types.DeviceNetworkStatus{}
 	ctx.DevicePortConfigList = &types.DevicePortConfigList{}
 

--- a/pkg/pillar/cmd/diag/diag_test.go
+++ b/pkg/pillar/cmd/diag/diag_test.go
@@ -1,0 +1,198 @@
+// Copyright (c) 2023 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package diag
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	string9   = "012345678"
+	string10  = "0123456789"
+	string11  = "0123456789X"
+	string9n  = string9 + "\n"
+	string10n = string10 + "\n"
+	string11n = string11 + "\n"
+	string9a  = "abcdefghi\n"
+	string10a = "abcdefghij\n"
+	string11a = "abcdefghijk\n"
+	string9A  = "ABCDEFGHI\n"
+	string10A = "ABCDEFGHIJ\n"
+	string11A = "ABCDEFGHIJK\n"
+	leading9  = "\n" + string9a
+	trailing9 = string9A + "\n"
+	fmt1      = "%s\n"
+	fmt2      = "%s %s\n"
+	fmt3      = "%s %s %s\n"
+	longest   = "012345678901234567890123456789" // Wraps to 10x3
+	toolong   = longest + "x"
+)
+
+func TestPrintIfSpace(t *testing.T) {
+	log = base.NewSourceLogObject(logrus.StandardLogger(), "diag", 0)
+	outfile := os.Stdout
+	stateFilename := ""
+	ctx := diagContext{}
+	maxRows := 3
+	maxColumns := 10
+
+	type printArg struct {
+		format string
+		args   []interface{}
+	}
+	type printArgs struct {
+		sequence []printArg
+		expected bool // Checked on last call only
+	}
+	printTests := map[string]printArgs{
+		"threeFits": {
+			sequence: []printArg{
+				{format: string9n},
+				{format: string9a},
+				{format: string9A},
+			},
+			expected: true,
+		},
+		"threeFitsExact": {
+			sequence: []printArg{
+				{format: string10n},
+				{format: string10a},
+				{format: string10A},
+			},
+			expected: true,
+		},
+		"threeFitsExactPlus": {
+			sequence: []printArg{
+				{format: string10n},
+				{format: string10a},
+				{format: string11A},
+			},
+			expected: false,
+		},
+		"fourFail": {
+			sequence: []printArg{
+				{format: string9n},
+				{format: string9a},
+				{format: string9A},
+				{format: string9n},
+			},
+			expected: false,
+		},
+		"wrapThree": {
+			sequence: []printArg{
+				{format: string11n},
+				{format: string9a},
+				{format: string9A},
+			},
+			expected: false,
+		},
+		"leadingTwo": {
+			sequence: []printArg{
+				{format: leading9},
+				{format: string9n},
+			},
+			expected: true,
+		},
+		"leadingThree": {
+			sequence: []printArg{
+				{format: leading9},
+				{format: string9A},
+				{format: string9a},
+			},
+			expected: false,
+		},
+		"trailingTwo": {
+			sequence: []printArg{
+				{format: string9n},
+				{format: trailing9},
+			},
+			expected: true,
+		},
+		"trailingThree": {
+			sequence: []printArg{
+				{format: string9n},
+				{format: string9a},
+				{format: trailing9},
+			},
+			expected: false,
+		},
+		"fmtTwo": {
+			sequence: []printArg{
+				{
+					format: fmt2,
+					args:   []interface{}{string11, string11},
+				},
+			},
+			expected: true,
+		},
+		"fmtThree": {
+			sequence: []printArg{
+				{
+					format: fmt3,
+					args:   []interface{}{string9, string9, string10},
+				},
+			},
+			expected: true,
+		},
+		"fmtThreePlus": {
+			sequence: []printArg{
+				{
+					format: fmt3,
+					args:   []interface{}{string9, string10, string10},
+				},
+			},
+			expected: false,
+		},
+		"fmtwrap": {
+			sequence: []printArg{
+				{
+					format: fmt2,
+					args:   []interface{}{string10, string9a},
+				},
+			},
+			expected: true,
+		},
+		"longest": {
+			sequence: []printArg{
+				{format: longest},
+			},
+			expected: true,
+		},
+		"too long": {
+			sequence: []printArg{
+				{format: toolong},
+			},
+			expected: false,
+		},
+	}
+
+	for testname, test := range printTests {
+		t.Logf("Running test case %s", testname)
+		PrintIfSpaceInit(&ctx, outfile, stateFilename,
+			maxRows, maxColumns, true)
+		lastIndex := len(test.sequence) - 1
+		for i, pa := range test.sequence {
+			assertString := fmt.Sprintf("test %s sequence %d",
+				testname, i)
+			res, err := PrintIfSpace(&ctx, pa.format, pa.args...)
+			if i == lastIndex {
+				assert.Equal(t, test.expected, res, assertString)
+				if test.expected {
+					assert.Nil(t, err, assertString)
+				} else {
+					assert.NotNil(t, err, assertString)
+				}
+			} else {
+				assert.Equal(t, true, res, assertString)
+				assert.Nil(t, err, assertString)
+			}
+		}
+	}
+}

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -1003,6 +1003,12 @@ func publishZedAgentStatus(getconfigCtx *getconfigContext) {
 		ForceFallbackCounter:  ctx.forceFallbackCounter,
 		CurrentProfile:        getconfigCtx.currentProfile,
 		RadioSilence:          getconfigCtx.radioSilence,
+		DeviceState:           ctx.devState,
+		AttestState:           ctx.attestState,
+		AttestError:           ctx.attestError,
+		VaultStatus:           ctx.vaultStatus,
+		PCRStatus:             ctx.pcrStatus,
+		VaultErr:              ctx.vaultErr,
 	}
 	pub := getconfigCtx.pubZedAgentStatus
 	pub.Publish(agentName, status)

--- a/pkg/pillar/cmd/zedagent/localinfo.go
+++ b/pkg/pillar/cmd/zedagent/localinfo.go
@@ -672,7 +672,7 @@ func postLocalDevInfo(ctx *getconfigContext) *profile.LocalDevCmd {
 func prepareLocalDevInfo(ctx *zedagentContext) *profile.LocalDevInfo {
 	msg := profile.LocalDevInfo{}
 	msg.DeviceUuid = devUUID.String()
-	msg.State = getState(ctx)
+	msg.State = info.ZDeviceState(getDeviceState(ctx))
 	msg.MaintenanceModeReasons = append(msg.MaintenanceModeReasons,
 		info.MaintenanceModeReason(ctx.maintModeReason))
 	hinfo, err := host.Info()

--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -592,6 +592,23 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext, dest destinationBitset) {
 	ReportDataSecAtRestInfo.Status, ReportDataSecAtRestInfo.Info =
 		vault.GetOperationalInfo(log)
 	ReportDeviceInfo.DataSecAtRestInfo = ReportDataSecAtRestInfo
+	if len(ReportDataSecAtRestInfo.VaultList) > 0 {
+		// We look at the first one since current implementation only
+		// has the default vault
+		first := ReportDataSecAtRestInfo.VaultList[0]
+		var firstErr string
+		if first.VaultErr != nil {
+			firstErr = first.VaultErr.Description
+		}
+		if ctx.vaultStatus != first.Status ||
+			ctx.pcrStatus != first.PcrStatus ||
+			ctx.vaultErr != firstErr {
+			ctx.vaultStatus = first.Status
+			ctx.pcrStatus = first.PcrStatus
+			ctx.vaultErr = firstErr
+			publishZedAgentStatus(ctx.getconfigCtx)
+		}
+	}
 
 	// Add SecurityInfo
 	ReportDeviceInfo.SecInfo = getSecurityInfo(ctx)
@@ -611,7 +628,12 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext, dest destinationBitset) {
 
 	ReportDeviceInfo.Capabilities = getCapabilities(ctx)
 
-	ReportDeviceInfo.State = getState(ctx)
+	devState := getDeviceState(ctx)
+	if ctx.devState != devState {
+		ctx.devState = devState
+		publishZedAgentStatus(ctx.getconfigCtx)
+	}
+	ReportDeviceInfo.State = info.ZDeviceState(devState)
 
 	// TODO: Enhance capability reporting with a bitmap-like approach for increased granularity.
 	// We report the snapshot capability despite the fact that we support snapshots only
@@ -643,6 +665,15 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext, dest destinationBitset) {
 		}
 		if ctx.attestCtx.attestFsmCtx.HasError() {
 			ReportDeviceInfo.AttestationInfo.Error = encodeErrorInfo(ctx.attestCtx.attestFsmCtx.ErrorDescription)
+		}
+		if ctx.attestCtx.Started {
+			attestFsmCtx := ctx.attestCtx.attestFsmCtx
+			if ctx.attestState != attestFsmCtx.GetState() ||
+				ctx.attestError != attestFsmCtx.ErrorDescription.Error {
+				ctx.attestState = attestFsmCtx.GetState()
+				ctx.attestError = attestFsmCtx.ErrorDescription.Error
+				publishZedAgentStatus(ctx.getconfigCtx)
+			}
 		}
 	}
 
@@ -1237,30 +1268,30 @@ func getBaseosUpdateCounter(ctx *zedagentContext) uint32 {
 	return status.CurrentRetryUpdateCounter
 }
 
-func getState(ctx *zedagentContext) info.ZDeviceState {
+func getDeviceState(ctx *zedagentContext) types.DeviceState {
 	if ctx.maintenanceMode {
-		return info.ZDeviceState_ZDEVICE_STATE_MAINTENANCE_MODE
+		return types.DEVICE_STATE_MAINTENANCE_MODE
 	}
 	if isUpdating(ctx) {
-		return info.ZDeviceState_ZDEVICE_STATE_BASEOS_UPDATING
+		return types.DEVICE_STATE_BASEOS_UPDATING
 	}
 	if ctx.rebootCmd || ctx.deviceReboot {
-		return info.ZDeviceState_ZDEVICE_STATE_REBOOTING
+		return types.DEVICE_STATE_REBOOTING
 	}
 	if ctx.shutdownCmd || ctx.deviceShutdown {
 		if ctx.allDomainsHalted {
-			return info.ZDeviceState_ZDEVICE_STATE_PREPARED_POWEROFF
+			return types.DEVICE_STATE_PREPARED_POWEROFF
 		}
-		return info.ZDeviceState_ZDEVICE_STATE_PREPARING_POWEROFF
+		return types.DEVICE_STATE_PREPARING_POWEROFF
 	}
 	if ctx.poweroffCmd || ctx.devicePoweroff {
-		return info.ZDeviceState_ZDEVICE_STATE_POWERING_OFF
+		return types.DEVICE_STATE_POWERING_OFF
 	}
 	if ctx.getconfigCtx != nil && (ctx.getconfigCtx.configReceived ||
 		ctx.getconfigCtx.readSavedConfig) {
-		return info.ZDeviceState_ZDEVICE_STATE_ONLINE
+		return types.DEVICE_STATE_ONLINE
 	}
-	return info.ZDeviceState_ZDEVICE_STATE_BOOTING
+	return types.DEVICE_STATE_BOOTING
 }
 
 func lookupZbootStatus(ctx *zedagentContext, key string) *types.ZbootStatus {

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -203,6 +203,12 @@ type zedagentContext struct {
 	apiMaintenanceMode   bool
 	localMaintenanceMode bool                        //maintenance mode triggered by local failure
 	localMaintModeReason types.MaintenanceModeReason //local failure reason for maintenance mode
+	devState             types.DeviceState
+	attestState          types.AttestState
+	attestError          string
+	vaultStatus          info.DataSecAtRestStatus
+	pcrStatus            info.PCRStatus
+	vaultErr             string
 
 	// Track the counter from force.fallback.counter to detect changes
 	forceFallbackCounter int

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -33,6 +33,7 @@ func updateAIStatusUUID(ctx *zedmanagerContext, uuidStr string) {
 		log.Functionf("updateAIStatusUUID status change %d for %s",
 			status.State, uuidStr)
 		publishAppInstanceStatus(ctx, status)
+		publishAppInstanceSummary(ctx)
 	}
 }
 
@@ -103,6 +104,7 @@ func removeAIStatus(ctx *zedmanagerContext, status *types.AppInstanceStatus) {
 		changed = doUpdate(ctx, *config, status)
 		if changed {
 			publishAppInstanceStatus(ctx, status)
+			publishAppInstanceSummary(ctx)
 		}
 	} else {
 		log.Errorf("removeAIStatus(%s): PurgeInprogress no config!",

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -612,10 +612,10 @@ func publishAppInstanceSummary(ctxPtr *zedmanagerContext) {
 		}
 		// Only condition we did not count is EffectiveActive = true and Activated = false.
 		// That means customer either halted his app or did not activate it yet.
-		if effectiveActivate && status.Activated {
-			summary.TotalRunning++
-		} else if len(status.Error) > 0 {
+		if len(status.Error) > 0 {
 			summary.TotalError++
+		} else if effectiveActivate && status.Activated {
+			summary.TotalRunning++
 		} else if status.Activated {
 			summary.TotalStopping++
 		} else if effectiveActivate {

--- a/pkg/pillar/docs/vaultmgr.md
+++ b/pkg/pillar/docs/vaultmgr.md
@@ -10,7 +10,7 @@ A "Vault" refers to a directory, where files under that directory are stored in 
 
 ## Default Vaults
 
-By default, vaultmgr creates two vaults on the device: `persist/img` and `/persist/config`. They are created when a device is booting for the first time, after an USB installation.
+Currently vaultmgr creates one vaults on the device `persist/vault`. This is created when a device is booting for the first time, after the installation.
 
 ## Encryption Tool
 

--- a/pkg/pillar/dpcmanager/dns.go
+++ b/pkg/pillar/dpcmanager/dns.go
@@ -114,7 +114,7 @@ func (m *DpcManager) updateDNS() {
 				"updateDNS: failed to get attrs for interface %s with index %d: %v",
 				port.IfName, ifindex, err)
 		} else {
-			m.deviceNetStatus.Ports[ix].Up = ifAttrs.AdminUp
+			m.deviceNetStatus.Ports[ix].Up = ifAttrs.LowerUp
 			m.deviceNetStatus.Ports[ix].MTU = ifAttrs.MTU
 		}
 		ipAddrs, macAddr, err := m.NetworkMonitor.GetInterfaceAddrs(ifindex)

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -201,15 +201,15 @@ for AGENT in $AGENTS; do
       # NOTE: it is safe to do either kill -STOP or an outright
       # kill -9 on the following cat process if you want to stop
       # receiving those messages on the console.
-      rows=$(stty size | awk '{print $1}')
-      columns=$(stty size | awk '{print $2}')
-      [ -n "$rows" ] || rows=40
-      [ "$rows" = 0 ] || rows=40
-      [ -n "$columns" ] || columns=80
-      [ "$columns" = 0 ] || columns=80
+      size="$(stty -F /dev/console size)"
+      rows=$(echo "$size" | awk '{print $1}')
+      columns=$(echo "$size" | awk '{print $2}')
+      [ -z "$rows" ] || rows="-r $rows"
+      [ -z "$columns" ] || columns="-c $columns"
       mkfifo /run/diag.pipe
       (while true; do cat; done) < /run/diag.pipe >/dev/console 2>&1 &
-      $BINDIR/diag -f -o /run/diag.pipe -s /run/diag.out -r $rows -c $columns &
+      # shellcheck disable=SC2086
+      $BINDIR/diag -f -o /run/diag.pipe -s /run/diag.out $rows $columns &
     else
       $BINDIR/"$AGENT" &
     fi

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -173,7 +173,7 @@ access_usb() {
             fi
             NETDUMPDIR="/persist/netdump"
             [ -d "$NETDUMPDIR" ] || NETDUMPDIR=""
-            if tar cf /mnt/dump/diag1.tar /persist/status/ /var/run/ /persist/log /persist/newlog $NETDUMPDIR $TPMINFOTEMPFILE; then
+            if tar cf /mnt/dump/diag1.tar /persist/status/ /var/run/ /persist/log /persist/newlog "$NETDUMPDIR" $TPMINFOTEMPFILE; then
                 mv /mnt/dump/diag1.tar /mnt/dump/diag.tar
             else
                 rm -f /mnt/dump/diag1.tar
@@ -201,9 +201,15 @@ for AGENT in $AGENTS; do
       # NOTE: it is safe to do either kill -STOP or an outright
       # kill -9 on the following cat process if you want to stop
       # receiving those messages on the console.
+      rows=$(stty size | awk '{print $1}')
+      columns=$(stty size | awk '{print $2}')
+      [ -n "$rows" ] || rows=40
+      [ "$rows" = 0 ] || rows=40
+      [ -n "$columns" ] || columns=80
+      [ "$columns" = 0 ] || columns=80
       mkfifo /run/diag.pipe
       (while true; do cat; done) < /run/diag.pipe >/dev/console 2>&1 &
-      $BINDIR/diag -f -o /run/diag.pipe &
+      $BINDIR/diag -f -o /run/diag.pipe -s /run/diag.out -r $rows -c $columns &
     else
       $BINDIR/"$AGENT" &
     fi

--- a/pkg/pillar/types/attesttypes.go
+++ b/pkg/pillar/types/attesttypes.go
@@ -15,15 +15,15 @@ type AttestState int32
 
 // States
 const (
-	StateNone               AttestState = iota + 0 //State when (Re)Starting attestation
-	StateNonceWait                                 //Waiting for response from Controller for Nonce request
-	StateInternalQuoteWait                         //Waiting for internal PCR quote to be published
-	StateInternalEscrowWait                        //Waiting for internal Escrow data to be published
-	StateAttestWait                                //Waiting for response from Controller for PCR quote
-	StateAttestEscrowWait                          //Waiting for response from Controller for Escrow data
-	StateRestartWait                               //Waiting for restart timer to expire, to start all over again
-	StateComplete                                  //Everything w.r.t attestation is complete
-	StateAny                                       //Not a real state per se. helps defining wildcard transitions(below)
+	StateNone               AttestState = iota + 0 // State when (Re)Starting attestation
+	StateNonceWait                                 // Waiting for response from Controller for Nonce request
+	StateInternalQuoteWait                         // Waiting for internal PCR quote to be published
+	StateInternalEscrowWait                        // Waiting for internal Escrow data to be published
+	StateAttestWait                                // Waiting for response from Controller for PCR quote
+	StateAttestEscrowWait                          // Waiting for response from Controller for Escrow data
+	StateRestartWait                               // Waiting for restart timer to expire, to start all over again
+	StateComplete                                  // Everything w.r.t attestation is complete
+	StateAny                                       // Not a real state per se. helps defining wildcard transitions(below)
 )
 
 // String returns human readable string of an AttestState

--- a/pkg/pillar/types/attesttypes.go
+++ b/pkg/pillar/types/attesttypes.go
@@ -10,6 +10,48 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/base"
 )
 
+// AttestState represents a state in the attest state machine
+type AttestState int32
+
+// States
+const (
+	StateNone               AttestState = iota + 0 //State when (Re)Starting attestation
+	StateNonceWait                                 //Waiting for response from Controller for Nonce request
+	StateInternalQuoteWait                         //Waiting for internal PCR quote to be published
+	StateInternalEscrowWait                        //Waiting for internal Escrow data to be published
+	StateAttestWait                                //Waiting for response from Controller for PCR quote
+	StateAttestEscrowWait                          //Waiting for response from Controller for Escrow data
+	StateRestartWait                               //Waiting for restart timer to expire, to start all over again
+	StateComplete                                  //Everything w.r.t attestation is complete
+	StateAny                                       //Not a real state per se. helps defining wildcard transitions(below)
+)
+
+// String returns human readable string of an AttestState
+func (state AttestState) String() string {
+	switch state {
+	case StateNone:
+		return "StateNone"
+	case StateNonceWait:
+		return "StateNonceWait"
+	case StateInternalQuoteWait:
+		return "StateInternalQuoteWait"
+	case StateInternalEscrowWait:
+		return "StateInternalEscrowWait"
+	case StateAttestWait:
+		return "StateAttestWait"
+	case StateAttestEscrowWait:
+		return "StateAttestEscrowWait"
+	case StateRestartWait:
+		return "StateRestartWait"
+	case StateComplete:
+		return "StateComplete"
+	case StateAny:
+		return "StateAny"
+	default:
+		return "Unknown State"
+	}
+}
+
 // AttestNonce carries nonce published by requester
 type AttestNonce struct {
 	Nonce     []byte

--- a/pkg/pillar/types/zedagenttypes.go
+++ b/pkg/pillar/types/zedagenttypes.go
@@ -709,7 +709,6 @@ const (
 	AppCommandRestart
 	// AppCommandPurge : purge application with ALL of its volumes.
 	AppCommandPurge
-	// TODO : purge for a single or a subset of volumes.
 )
 
 // LocalAppCommand : An application command requested from a local server.

--- a/pkg/pillar/types/zedagenttypes.go
+++ b/pkg/pillar/types/zedagenttypes.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/lf-edge/eve-api/go/info"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	uuid "github.com/satori/go.uuid"
 )
@@ -524,6 +525,57 @@ type ZedAgentStatus struct {
 	ForceFallbackCounter  int          // Try image fallback when counter changes
 	CurrentProfile        string       // Current profile
 	RadioSilence          RadioSilence // Currently requested state of radio devices
+	DeviceState           DeviceState
+	AttestState           AttestState
+	AttestError           string
+	VaultStatus           info.DataSecAtRestStatus
+	PCRStatus             info.PCRStatus
+	VaultErr              string
+}
+
+// DeviceState represents overall state
+type DeviceState uint8
+
+// Integer values must match those in ZDeviceState in lf-edge/eve-api/proto/info/info.proto
+//
+//revive:disable:var-naming
+const (
+	DEVICE_STATE_UNSPECIFIED        DeviceState = iota
+	DEVICE_STATE_ONLINE                         = 1
+	DEVICE_STATE_REBOOTING                      = 2
+	DEVICE_STATE_MAINTENANCE_MODE               = 3
+	DEVICE_STATE_BASEOS_UPDATING                = 4
+	DEVICE_STATE_BOOTING                        = 5
+	DEVICE_STATE_PREPARING_POWEROFF             = 6
+	DEVICE_STATE_POWERING_OFF                   = 7
+	DEVICE_STATE_PREPARED_POWEROFF              = 8
+)
+
+//revive:enable:var-naming
+
+func (ds DeviceState) String() string {
+	switch ds {
+	case DEVICE_STATE_UNSPECIFIED:
+		return "unspecified"
+	case DEVICE_STATE_ONLINE:
+		return "online"
+	case DEVICE_STATE_REBOOTING:
+		return "rebooting"
+	case DEVICE_STATE_MAINTENANCE_MODE:
+		return "maintenance_mode"
+	case DEVICE_STATE_BASEOS_UPDATING:
+		return "baseos_updating"
+	case DEVICE_STATE_BOOTING:
+		return "booting"
+	case DEVICE_STATE_PREPARING_POWEROFF:
+		return "preparing_poweroff"
+	case DEVICE_STATE_POWERING_OFF:
+		return "powering_off"
+	case DEVICE_STATE_PREPARED_POWEROFF:
+		return "prepared_poweroff"
+	default:
+		return fmt.Sprintf("Unknown state %d", ds)
+	}
 }
 
 // Key :

--- a/pkg/pillar/vault/handler_zfs.go
+++ b/pkg/pillar/vault/handler_zfs.go
@@ -55,7 +55,6 @@ func (h *ZFSHandler) SetHandlerOptions(options HandlerOptions) {
 
 // GetVaultStatuses returns statuses of vault(s)
 func (h *ZFSHandler) GetVaultStatuses() []*types.VaultStatus {
-	// XXX: till Controller deprecates handling status of persist/config, keep sending
 	return []*types.VaultStatus{h.getVaultStatus(types.DefaultVaultName, types.SealedDataset)}
 }
 
@@ -186,6 +185,13 @@ func (h *ZFSHandler) setupVault(vaultPath string) error {
 func (h *ZFSHandler) getVaultStatus(vaultName, vaultPath string) *types.VaultStatus {
 	status := types.VaultStatus{}
 	status.Name = vaultName
+
+	if etpm.PCRBankSHA256Enabled() {
+		status.PCRStatus = info.PCRStatus_PCR_ENABLED
+	} else {
+		status.PCRStatus = info.PCRStatus_PCR_DISABLED
+	}
+
 	zfsEncryptStatus, zfsEncryptError := h.GetOperationalInfo()
 	if zfsEncryptStatus != info.DataSecAtRestStatus_DATASEC_AT_REST_ENABLED {
 		status.Status = zfsEncryptStatus


### PR DESCRIPTION
In some cases when the console output is visible it is useful to print more things than the current networking-related information from diag.
EVE-OS has information about the device state (booting, maintenance mode), attestation, vault, as well as an app summary with counters for number of app instances in error, starting, stopping, and running states.
Those are fixed size output (one line for device and one for apps).

In addition, after the networking output this prints information about each app instance and each running download (to show state/progress and any errors). But that output can be large if there are multiple of them (just like the network output can be large when there are lots of ports and/or proxy configuration). Limiting the output when DPC_SUCCESS to handle this.

The code in this PR counts how many lines are used and checks that against stty size to make sure it doesn't spill over a screen. Next output will indicate a count of how much was missed.

Also, added sending all output to /run/diag.out so that if ssh'd in you can do a tail -F of that file (it truncatees for each output "screen" worth of data.)

@zedi-pramodh Note that there are some related fixes in zedmanager to make sure the AppInstanceSummary captures crashes of app instances and updates the error counter.

@shjala I had to add some missing code in vaultmgr's zfs code to mirror the ext4 code to report PCR status.

@milan-zededa as part of testing this I saw that the Up flag was set based on AdminUp which isn't the intent. Running tests to see if the change to LowerUp will impact tests.

Example output is:

Device with a TPM chip and when DPC_SUCCESS (updated):
---------------------------------------

INFO: updated diag information at 2023-08-15T11:34:18.190841291Z due to Network
INFO: device: online attest: Complete vault: ENABLED pcr: ENABLED
INFO: applications: 0 starting, 2 running
INFO: Summary: Connected to EV Controller and onboarded
INFO: Using highest priority DevicePortConfig key zedagent
INFO: Have 1 total ports. 1 ports should be connected to EV controller
INFO: Port eth0: Mac: 52:54:00:12:34:56 link: up use: mgmt 192.168.1.10
INFO: Port eth0: Mac: 52:54:00:12:34:56 link: up use: mgmt fec0::52a1:bd8d:9240:3f8
INFO: App test-cont uuid d27832df-651d-4554-b022-57dcfd932f6b state RUNNING
INFO: App test-centos uuid 72a4a242-e7cd-4e9a-a3d6-a45a38cf688a state RUNNING

On device without a TPM the second line would look like this
--------------------

WARNING: device: online attest: Complete vault: DISABLED pcr: DISABLED

When some objects are downloading this is added towards the end
------------

INFO: dowload app-images/xenial.qcow2 sha b471ba590fa5e49622efcc82449c7ca1b3442fcd9f1ed91506cab34fa0af8609 progress 54% out of 1561853952 bytes
INFO: dowload alpine@sha256:25fad2a32ad1f6f510e528448ae1ec69a28ef81916a004d3629874104f8a7f70 sha 25fad2a32ad1f6f510e528448ae1ec69a28ef81916a004d3629874104f8a7f70 progress 100% out of 528 bytes
INFO: dowload alpine@sha256:31e352740f534f9ad170f75378a84fe453d6156e40700b882d737a8f4a6988a3 sha 31e352740f534f9ad170f75378a84fe453d6156e40700b882d737a8f4a6988a3 progress 100% out of 3397879 bytes

Shutting down:
--------------

[At the top]
WARNING: applications: 1 stopping, 0 starting, 0 running
[... and at the end ...]
INFO: App sc-supermicro-zc2-2023-08-07T00-36-167708 uuid 691d7c6f-e6b6-4b18-9e3d-f5d9b25ae1a5 state HALTING

Failed/crashed app:
-------------------

[At the top]
ERROR: applications: 1 with error, 0 starting, 2 running, 0 stopping
[... and at the end ...]
INFO: App sc-supermicro-zc2-2023-08-07T00-04-669117 uuid b9311a75-9074-4eb5-b3e9-3a95c55efc0f state RUNNING
INFO: App sc-supermicro-zc2-2023-08-07T00-13-043940 uuid 3e51a6c8-cc1e-494d-9982-7ca2d5a478bf state RUNNING
ERROR: App zc2-cont uuid 225a54b5-e452-435a-bc67-65f5c34c7ca1 state BROKEN error: one of the application's tasks has crashed - please restart application instance

Attestation issue:
------------------

[At the top]
ERROR: device: online attest: NonceWait error [ATTEST] Error All attempts to connect to zedcloud.alpha.zededa.net/api/v2/edgedevice/id/b08a23f1-3367-4618-a1f3-66cabb30316c/attest failed: send via eth1: signing data using TPM failed: handle 1, error code 0xb : the handle is not correct for the use; send via eth0: signing data using TPM failed: handle 1, error code 0xb : the handle is not correct for the use, senderStatus SenderStatusNone vault: ERROR error Vault key unavailable: pcr: ENABLED 
