### PR TITLE
support local cluster host mapping in edgeview

### DIFF
--- a/pkg/edgeview/src/edge-view-init.sh
+++ b/pkg/edgeview/src/edge-view-init.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
 if [ -z "$EDGEVIEW_CLIENT" ]; then
+  [ -f /config/hosts ] && cat /config/hosts >> /etc/hosts
+
   sleep 60 # allow system to settle, no need to come up too fast
   while true;
   do


### PR DESCRIPTION
- a simple change, to support for local cluster usage without private /etc/hosts changes
- pillar side is already doing this