### PR TITLE
workaround for firmware-imx download

### DIFF
--- a/pkg/bsp-imx/Dockerfile
+++ b/pkg/bsp-imx/Dockerfile
@@ -124,7 +124,7 @@ RUN for t in ${ATF_TARGETS}; do \
 # IMX firmware
 WORKDIR /tmp
 ENV FIRMWARE_VER=8.18
-ADD https://www.nxp.com/lgfiles/NMG/MAD/YOCTO/firmware-imx-${FIRMWARE_VER}.bin firmware-imx-${FIRMWARE_VER}.bin
+ADD https://cache.nxp.com/lgfiles/NMG/MAD/YOCTO/firmware-imx-${FIRMWARE_VER}.bin firmware-imx-${FIRMWARE_VER}.bin
 RUN chmod 777 firmware-imx-${FIRMWARE_VER}.bin && \
         echo "n" | ./firmware-imx-8.18.bin | head -n -1 > /bsp/NXP-EULA-LICENSE.txt || true && \
         ./firmware-imx-${FIRMWARE_VER}.bin --auto-accept && \


### PR DESCRIPTION
This fixes the build for now using that the "cache" URL doesn't go away.
The issue is that golang defaults to TLS1.3 and post go 1.19 there isn't even an environment variable to override this (meaning that the source code in buildkit would need to be tweaked to force TLS 1.2) since https://www.nxp.com/lgfiles/NMG/MAD/YOCTO/firmware-imx-8.18.bin is utterly broken in that TLS 1.3 results in a 404 error instead of negotiating down to TLS 1.2!
