### PR TITLE
Let constants in Go to be UPPER_CASE

### DIFF
--- a/.revive.toml
+++ b/.revive.toml
@@ -14,6 +14,7 @@ warningCode = 0
 [rule.if-return]
 [rule.increment-decrement]
 [rule.var-naming]
+  arguments = [[], [], [{upperCaseConst=true}]]
 [rule.var-declaration]
 #[rule.package-comments]
 [rule.range]


### PR DESCRIPTION
This option is not yet in Revive release but current revive works just fine if we have it in toml file. sooner or later we'll get updated revive in yetus