### PR TITLE
github workflows : run unit-tests on push

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,6 +1,11 @@
 ---
 name: Unit tests
 on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - "master"
+      - "[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+-stable"
   pull_request:
     branches:
       - "master"


### PR DESCRIPTION
When a PR is submitted, code-coverage bot looks up the parent commit code-coverage data to get a diff. To have this information available, run unit-tests not only on "pull_request" but "push" too.