### PR TITLE
Snapshot: Remove snapshots from available list immediately upon deletion request

### DIFF
--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -890,6 +890,10 @@ func updateSnapshotsInAIStatus(status *types.AppInstanceStatus, config types.App
 		status.SnapStatus.RequestedSnapshots = append(status.SnapStatus.RequestedSnapshots, newSnapshotStatus)
 	}
 	status.SnapStatus.SnapshotsToBeDeleted = snapshotsToBeDeleted
+	// Remove the snapshots marked for deletion from the list of available snapshots
+	for _, snapshot := range snapshotsToBeDeleted {
+		_ = removeSnapshotFromSlice(&status.SnapStatus.AvailableSnapshots, snapshot.SnapshotID)
+	}
 }
 
 // prepareVolumesSnapshotConfigs generates a 'volumesSnapshotConfig' for each pending snapshot request with a prepared configuration.


### PR DESCRIPTION
When a snapshot is marked for deletion, it is not immediately removed from the list of available snapshots reported to the controller. This can cause issues when a new snapshot is created simultaneously, as the controller may not handle this scenario correctly. To address this, we now remove the snapshot from the list of available snapshots as soon as we receive a command to delete it. The actual files associated with the snapshot are still removed later, during the next VM reboot.

This change ensures that the controller has an accurate view of the available snapshots and can handle snapshot creation and deletion more effectively.