### PR TITLE
handleconfig: deprecate 'timer.use.config.checkpoint' usage

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -14,7 +14,6 @@
 | timer.reboot.no.network | integer in seconds | 7 days | reboot after no cloud connectivity |
 | timer.update.fallback.no.network | integer in seconds | 300 | fallback after no cloud connectivity |
 | timer.test.baseimage.update | integer in seconds | 600 | commit to update |
-| timer.use.config.checkpoint | integer in seconds | 600 | use checkpointed config if no cloud connectivity |
 | timer.gc.vdisk | integer in seconds | 1 hour | garbage collect unused instance virtual disk |
 | timer.defer.content.delete | integer in seconds | zero | if set, keep content trees around for reuse after they have been deleted |
 | timer.download.retry | integer in seconds | 600 | retry a failed download |

--- a/pkg/pillar/cmd/zedagent/handleProfile.go
+++ b/pkg/pillar/cmd/zedagent/handleProfile.go
@@ -97,8 +97,7 @@ func parseLocalProfile(localProfileBytes []byte) (*profile.LocalProfile, error) 
 // read saved local profile in case of particular reboot reason
 func readSavedLocalProfile(getconfigCtx *getconfigContext) (*profile.LocalProfile, error) {
 	localProfileMessage, ts, err := readSavedConfig(
-		getconfigCtx.zedagentCtx.globalConfig.GlobalValueInt(types.StaleConfigTime),
-		filepath.Join(checkpointDirname, savedLocalProfileFile), false)
+		filepath.Join(checkpointDirname, savedLocalProfileFile))
 	if err != nil {
 		return nil, fmt.Errorf("readSavedLocalProfile: %v", err)
 	}

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -603,9 +603,7 @@ func requestConfigByURL(getconfigCtx *getconfigContext, url string,
 					ctx.bootReason)
 			} else {
 				config, ts, err := readSavedProtoMessageConfig(
-					zedcloudCtx, url,
-					ctx.globalConfig.GlobalValueInt(types.StaleConfigTime),
-					checkpointDirname+"/lastconfig", false)
+					zedcloudCtx, url, checkpointDirname+"/lastconfig")
 				if err != nil {
 					log.Errorf("getconfig: %v", err)
 					return invalidConfig, rv.TracedReqs
@@ -827,8 +825,8 @@ func existsSavedConfig(filename string) bool {
 // If the file exists then read the config, and return is modify time
 // Ignore if older than StaleConfigTime seconds
 func readSavedProtoMessageConfig(zedcloudCtx *zedcloud.ZedCloudContext, URL string,
-	staleConfigTime uint32, filename string, force bool) (*zconfig.EdgeDevConfig, time.Time, error) {
-	contents, ts, err := readSavedConfig(staleConfigTime, filename, force)
+	filename string) (*zconfig.EdgeDevConfig, time.Time, error) {
+	contents, ts, err := readSavedConfig(filename)
 	if err != nil {
 		log.Errorln("readSavedProtoMessageConfig", err)
 		return nil, ts, err
@@ -856,24 +854,10 @@ func readSavedProtoMessageConfig(zedcloudCtx *zedcloud.ZedCloudContext, URL stri
 }
 
 // If the file exists then read the config content from it, and return its modify time.
-// Ignore if older than staleTime seconds.
-func readSavedConfig(staleTime uint32,
-	filename string, force bool) ([]byte, time.Time, error) {
+func readSavedConfig(filename string) ([]byte, time.Time, error) {
 	info, err := os.Stat(filename)
 	if err != nil {
-		if os.IsNotExist(err) && !force {
-			return nil, time.Time{}, nil
-		} else {
-			return nil, time.Time{}, err
-		}
-	}
-	age := time.Since(info.ModTime())
-	staleLimit := time.Second * time.Duration(staleTime)
-	if !force && age > staleLimit {
-		errStr := fmt.Sprintf("saved config too old: age %v limit %d\n",
-			age, staleLimit)
-		log.Errorln(errStr)
-		return nil, info.ModTime(), nil
+		return nil, time.Time{}, err
 	}
 	contents, err := os.ReadFile(filename)
 	if err != nil {

--- a/pkg/pillar/cmd/zedagent/localinfo.go
+++ b/pkg/pillar/cmd/zedagent/localinfo.go
@@ -457,8 +457,7 @@ func findAppInstance(
 func readSavedLocalCommands(ctx *getconfigContext) (*types.LocalCommands, error) {
 	commands := &types.LocalCommands{}
 	contents, ts, err := readSavedConfig(
-		ctx.zedagentCtx.globalConfig.GlobalValueInt(types.StaleConfigTime),
-		filepath.Join(checkpointDirname, savedLocalCommandsFile), false)
+		filepath.Join(checkpointDirname, savedLocalCommandsFile))
 	if err != nil {
 		return commands, err
 	}

--- a/pkg/pillar/cmd/zedagent/radiosilence.go
+++ b/pkg/pillar/cmd/zedagent/radiosilence.go
@@ -228,8 +228,7 @@ func getRadioConfig(ctx *getconfigContext, radioStatus *profile.RadioStatus) *pr
 // read saved radio config in case of a reboot
 func readSavedRadioConfig(ctx *getconfigContext) (*profile.RadioConfig, error) {
 	radioConfigBytes, ts, err := readSavedConfig(
-		ctx.zedagentCtx.globalConfig.GlobalValueInt(types.StaleConfigTime),
-		filepath.Join(checkpointDirname, savedRadioConfigFile), false)
+		filepath.Join(checkpointDirname, savedRadioConfigFile))
 	if err != nil {
 		return nil, fmt.Errorf("readSavedRadioConfig: %v", err)
 	}

--- a/pkg/pillar/cmd/zedagent/validate.go
+++ b/pkg/pillar/cmd/zedagent/validate.go
@@ -10,10 +10,9 @@ import (
 	zconfig "github.com/lf-edge/eve-api/go/config"
 )
 
-func readValidateConfig(staleConfigTime uint32,
-	validateFile string) (bool, *zconfig.EdgeDevConfig) {
+func readValidateConfig(validateFile string) (bool, *zconfig.EdgeDevConfig) {
 	config, _, err := readSavedProtoMessageConfig(zedcloudCtx, "https://",
-		staleConfigTime, validateFile, true)
+		validateFile)
 	if err != nil {
 		fmt.Printf("getconfig: %v\n", err)
 		return false, nil

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -408,8 +408,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		zedagentCtx.zedcloudMetrics)
 
 	if parse != "" {
-		res, config := readValidateConfig(
-			types.DefaultConfigItemValueMap().GlobalValueInt(types.StaleConfigTime), parse)
+		res, config := readValidateConfig(parse)
 		if !res {
 			fmt.Printf("Failed to parse %s\n", parse)
 			return 1

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -166,9 +166,6 @@ const (
 	FallbackIfCloudGoneTime GlobalSettingKey = "timer.update.fallback.no.network"
 	// MintimeUpdateSuccess global setting key
 	MintimeUpdateSuccess GlobalSettingKey = "timer.test.baseimage.update"
-	// StaleConfigTime global setting key
-	// DEPRECATED! Saved config never expires!
-	StaleConfigTime GlobalSettingKey = "timer.use.config.checkpoint"
 	// VdiskGCTime global setting key
 	VdiskGCTime GlobalSettingKey = "timer.gc.vdisk"
 	// DeferContentDelete global setting key
@@ -816,8 +813,6 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddIntItem(ResetIfCloudGoneTime, 7*24*3600, 120, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(FallbackIfCloudGoneTime, 300, 60, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(MintimeUpdateSuccess, 600, 30, HourInSec)
-	// DEPRECATED
-	configItemSpecMap.AddIntItem(StaleConfigTime, 7*24*3600, 0, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(VdiskGCTime, 3600, 60, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(DeferContentDelete, 0, 0, 24*3600)
 	configItemSpecMap.AddIntItem(DownloadRetryTime, 600, 60, 0xFFFFFFFF)

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -167,6 +167,7 @@ const (
 	// MintimeUpdateSuccess global setting key
 	MintimeUpdateSuccess GlobalSettingKey = "timer.test.baseimage.update"
 	// StaleConfigTime global setting key
+	// DEPRECATED! Saved config never expires!
 	StaleConfigTime GlobalSettingKey = "timer.use.config.checkpoint"
 	// VdiskGCTime global setting key
 	VdiskGCTime GlobalSettingKey = "timer.gc.vdisk"
@@ -815,6 +816,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddIntItem(ResetIfCloudGoneTime, 7*24*3600, 120, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(FallbackIfCloudGoneTime, 300, 60, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(MintimeUpdateSuccess, 600, 30, HourInSec)
+	// DEPRECATED
 	configItemSpecMap.AddIntItem(StaleConfigTime, 7*24*3600, 0, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(VdiskGCTime, 3600, 60, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(DeferContentDelete, 0, 0, 24*3600)

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -155,7 +155,6 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		ResetIfCloudGoneTime,
 		FallbackIfCloudGoneTime,
 		MintimeUpdateSuccess,
-		StaleConfigTime,
 		VdiskGCTime,
 		DeferContentDelete,
 		DownloadRetryTime,

--- a/pkg/pillar/types/globalconfigold.go
+++ b/pkg/pillar/types/globalconfigold.go
@@ -107,7 +107,7 @@ var globalConfigDefaults = OldGlobalConfig{
 	UsbAccess:           true, // Controller likely to default to false
 	SshAccess:           true, // Controller likely to default to false
 	SshAuthorizedKeys:   "",
-	StaleConfigTime:     600,  // Use stale config for up to 10 minutes
+	StaleConfigTime:     600,  // DEPRECATED!
 	DownloadGCTime:      600,  // 10 minutes
 	VdiskGCTime:         3600, // 1 hour
 	DownloadRetryTime:   600,  // 10 minutes

--- a/pkg/pillar/types/globalconfigold.go
+++ b/pkg/pillar/types/globalconfigold.go
@@ -18,7 +18,6 @@ type OldGlobalConfig struct {
 	ResetIfCloudGoneTime    uint32 // reboot if no cloud connectivity
 	FallbackIfCloudGoneTime uint32 // ... and shorter during update
 	MintimeUpdateSuccess    uint32 // time before zedagent declares success
-	StaleConfigTime         uint32 // On reboot use saved config if not stale
 	DownloadGCTime          uint32 // Garbage collect if no use
 	VdiskGCTime             uint32 // Garbage collect RW disk if no use
 
@@ -107,7 +106,6 @@ var globalConfigDefaults = OldGlobalConfig{
 	UsbAccess:           true, // Controller likely to default to false
 	SshAccess:           true, // Controller likely to default to false
 	SshAuthorizedKeys:   "",
-	StaleConfigTime:     600,  // DEPRECATED!
 	DownloadGCTime:      600,  // 10 minutes
 	VdiskGCTime:         3600, // 1 hour
 	DownloadRetryTime:   600,  // 10 minutes
@@ -165,9 +163,6 @@ func ApplyDefaults(newgc OldGlobalConfig) OldGlobalConfig {
 	if newgc.NetworkSendTimeout == 0 {
 		newgc.NetworkSendTimeout = globalConfigDefaults.NetworkSendTimeout
 	}
-	if newgc.StaleConfigTime == 0 {
-		newgc.StaleConfigTime = globalConfigDefaults.StaleConfigTime
-	}
 	if newgc.DownloadGCTime == 0 {
 		newgc.DownloadGCTime = globalConfigDefaults.DownloadGCTime
 	}
@@ -211,7 +206,6 @@ var GlobalConfigMinimums = OldGlobalConfig{
 	NetworkTestInterval:       300, // 5 minutes
 	NetworkTestBetterInterval: 0,   // Disabled
 
-	StaleConfigTime:         0, // Don't use stale config
 	DownloadGCTime:          60,
 	VdiskGCTime:             60,
 	DownloadRetryTime:       60,
@@ -269,12 +263,6 @@ func EnforceGlobalConfigMinimums(newgc OldGlobalConfig) OldGlobalConfig {
 			newgc.NetworkTestBetterInterval, GlobalConfigMinimums.NetworkTestBetterInterval)
 		newgc.NetworkTestBetterInterval = GlobalConfigMinimums.NetworkTestBetterInterval
 	}
-
-	if newgc.StaleConfigTime < GlobalConfigMinimums.StaleConfigTime {
-		logrus.Warnf("Enforce minimum StaleConfigTime received %d; using %d",
-			newgc.StaleConfigTime, GlobalConfigMinimums.StaleConfigTime)
-		newgc.StaleConfigTime = GlobalConfigMinimums.StaleConfigTime
-	}
 	if newgc.DownloadGCTime < GlobalConfigMinimums.DownloadGCTime {
 		logrus.Warnf("Enforce minimum DownloadGCTime received %d; using %d",
 			newgc.DownloadGCTime, GlobalConfigMinimums.DownloadGCTime)
@@ -311,7 +299,6 @@ func (config OldGlobalConfig) MoveBetweenConfigs() *ConfigItemValueMap {
 	newConfig.SetGlobalValueInt(ResetIfCloudGoneTime, config.ResetIfCloudGoneTime)
 	newConfig.SetGlobalValueInt(FallbackIfCloudGoneTime, config.FallbackIfCloudGoneTime)
 	newConfig.SetGlobalValueInt(MintimeUpdateSuccess, config.MintimeUpdateSuccess)
-	newConfig.SetGlobalValueInt(StaleConfigTime, config.StaleConfigTime)
 	newConfig.SetGlobalValueInt(VdiskGCTime, config.VdiskGCTime)
 	newConfig.SetGlobalValueInt(DownloadRetryTime, config.DownloadRetryTime)
 	newConfig.SetGlobalValueInt(DomainBootRetryTime, config.DomainBootRetryTime)


### PR DESCRIPTION
The default behavior is to fetch saved config if its modification time does not exceed some stale config time (timer.use.config.checkpoint). This leads to the following problem observed by the customer:
    
1. EVE node and an app are up running.
2. Connection to the controller is lost for time > timer.use.config.checkpoint, so that last saved config modification time has not been updated.
3. Node is rebooted, connection to the controller is still missing.
4. Config is being fetched from a file, but modification time has not been updated for a while, thus config is rejected and applications do not show up.
    
Although the default setting for the timer is 7 days, it is not enough for the node which constantly has problems with the internet and which up-time is minimum, so it is not uncommon to have a last saved config with the modification time dated several weeks from now.
    
This is not safe and having outdated config (basically this is always the case, because there is always a time gap between actual config on controller and config on EVE) is better, than to have no config at all.
    
This patch deprecates the 'timer.use.config.checkpoint' and config is being always read from the file regardless of the modification time.
    
Kudos to Siddharth and Daniel for debugging this.
