### PR TITLE
Timeout calling dhcpcd

### DIFF
--- a/pkg/pillar/base/execwrapper.go
+++ b/pkg/pillar/base/execwrapper.go
@@ -17,84 +17,57 @@ import (
 )
 
 const (
-	// Will wait for 1000s max for a call instead of waiting forever
-	maxTimeOutLimit = 1000
-	timeOutLimit    = 100
+	/*
+	 * execution timeout is supposed to be less than the watchdog timeout,
+	 * as otherwise the watchdog might fire and reboot the system before
+	 * the timeout fires
+	 * exceptions are when an executable is started from a different goroutine
+	 * source of the error timeout and the watchdog timeout:
+	 * error timeout: $ grep -r errorTime pkg/pillar/cmd/ | grep time
+	 * watchdog timeout: $ grep hv_watchdog_timer pkg/grub/rootfs.cfg
+	 */
+	timeoutLimit   = 3 * time.Minute
+	defaultTimeout = 100 * time.Second
 )
 
 // Command holds the necessary data to execute command
 type Command struct {
-	command   *exec.Cmd
-	log       *LogObject
-	agentName string
-	timeout   time.Duration
-	buffer    *bytes.Buffer
-	ctx       context.Context
+	command    *exec.Cmd
+	log        *LogObject
+	agentName  string
+	timeout    time.Duration
+	buffer     *bytes.Buffer
+	ctx        context.Context
+	errorMonad error
 }
 
 // Output runs the command and returns its standard output.
 // Any returned error will usually be of type *ExitError.
-// Waits for the exec call to finish for `maxTimeOutLimit` after which timeout error is returned
+// Waits for the exec call to finish for `defaultTimeout` after which timeout error is returned
 func (c *Command) Output() ([]byte, error) {
 	var buf bytes.Buffer
 	c.command.Stdout = &buf
 	c.buffer = &buf
-	c.timeout = maxTimeOutLimit
+	c.timeout = defaultTimeout
 	return c.execCommand()
 }
 
 // CombinedOutput runs the command and returns its combined standard output and standard error.
-// Waits for the exec call to finish for `maxTimeOutLimit` after which timeout error is returned
+// Waits for the exec call to finish for `defaultTimeout` after which timeout error is returned
 func (c *Command) CombinedOutput() ([]byte, error) {
 	var buf bytes.Buffer
 	c.command.Stdout = &buf
 	c.command.Stderr = &buf
 	c.buffer = &buf
-	c.timeout = maxTimeOutLimit
-	return c.execCommand()
-}
-
-// OutputWithTimeout waits for the exec call to finish for `timeOutLimit`
-// after which timeout error is returned
-func (c *Command) OutputWithTimeout() ([]byte, error) {
-	var buf bytes.Buffer
-	c.command.Stdout = &buf
-	c.buffer = &buf
-	c.timeout = timeOutLimit
-	return c.execCommand()
-}
-
-// CombinedOutputWithTimeout waits for the exec call to finish for `timeOutLimit`
-// after which timeout error is returned
-func (c *Command) CombinedOutputWithTimeout() ([]byte, error) {
-	var buf bytes.Buffer
-	c.command.Stdout = &buf
-	c.command.Stderr = &buf
-	c.buffer = &buf
-	c.timeout = timeOutLimit
-	return c.execCommand()
-}
-
-// OutputWithCustomTimeout accepts a custom timeout limit to wait for the exec call.
-func (c *Command) OutputWithCustomTimeout(timeout uint) ([]byte, error) {
-	var buf bytes.Buffer
-	c.command.Stdout = &buf
-	c.buffer = &buf
-	c.timeout = time.Duration(timeout)
-	return c.execCommand()
-}
-
-// CombinedOutputWithCustomTimeout accepts a custom timeout limit to wait for the exec call.
-func (c *Command) CombinedOutputWithCustomTimeout(timeout uint) ([]byte, error) {
-	var buf bytes.Buffer
-	c.command.Stdout = &buf
-	c.command.Stderr = &buf
-	c.buffer = &buf
-	c.timeout = time.Duration(timeout)
+	c.timeout = defaultTimeout
 	return c.execCommand()
 }
 
 func (c *Command) execCommand() ([]byte, error) {
+	if c.errorMonad != nil {
+		return nil, c.errorMonad
+	}
+
 	if c.log != nil {
 		c.log.Tracef("execCommand(%v)", c.command.Args)
 	}
@@ -108,7 +81,7 @@ func (c *Command) execCommand() ([]byte, error) {
 	stillRunning := time.NewTicker(25 * time.Second)
 	defer stillRunning.Stop()
 
-	waitTimer := time.NewTimer(c.timeout * time.Second)
+	waitTimer := time.NewTimer(c.timeout)
 	defer waitTimer.Stop()
 
 	if c.ctx == nil {
@@ -132,6 +105,23 @@ func (c *Command) execCommand() ([]byte, error) {
 		}
 		updateAgentTouchFile(c.log, c.agentName)
 	}
+}
+
+// WithLimitedTimeout set custom timeout for command
+func (c *Command) WithLimitedTimeout(timeout time.Duration) *Command {
+	c.timeout = timeout
+	if c.timeout > timeoutLimit {
+		c.errorMonad = fmt.Errorf("custom timeout (%v) is longer than watchdog timeout (%v)", c.timeout, defaultTimeout)
+	}
+
+	return c
+}
+
+// WithUnlimitedTimeout set custom timeout for command not bound to any limits for when run in a separate goroutine
+func (c *Command) WithUnlimitedTimeout(timeout time.Duration) *Command {
+	c.timeout = timeout
+
+	return c
 }
 
 // WithContext set context for command

--- a/pkg/pillar/base/execwrapper_test.go
+++ b/pkg/pillar/base/execwrapper_test.go
@@ -1,0 +1,18 @@
+package base_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+)
+
+func TestTimeoutLongerThanLimit(t *testing.T) {
+	t.Parallel()
+
+	timeout := 600 * time.Second
+	_, err := base.Exec(nil, "/bin/true").WithLimitedTimeout(timeout).CombinedOutput()
+	if err == nil {
+		t.Fatalf("Execution should fail with timeout too long, but succeeded")
+	}
+}

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -2658,7 +2658,7 @@ func mkisofs(output string, dir string) error {
 		dir,
 	}
 	log.Functionf("Calling command %s %v\n", cmd, args)
-	stdoutStderr, err := base.Exec(log, cmd, args...).CombinedOutput()
+	stdoutStderr, err := base.Exec(log, cmd, args...).WithUnlimitedTimeout(15 * time.Minute).CombinedOutput()
 	if err != nil {
 		errStr := fmt.Sprintf("mkisofs failed: %s",
 			string(stdoutStderr))

--- a/pkg/pillar/diskmetrics/diskmetrics.go
+++ b/pkg/pillar/diskmetrics/diskmetrics.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/types"
@@ -93,7 +94,7 @@ func RolloutImgToBlock(ctx context.Context, log *base.LogObject, diskfile, outpu
 	// writeback cache instead of default unsafe, out of order enabled, skip file creation
 	// Timeout 2 hours
 	args := []string{"convert", "--target-is-zero", "-t", "writeback", "-W", "-n", "-O", outputFormat, diskfile, outputFile}
-	output, err := base.Exec(log, "/usr/bin/qemu-img", args...).WithContext(ctx).CombinedOutputWithCustomTimeout(432000)
+	output, err := base.Exec(log, "/usr/bin/qemu-img", args...).WithContext(ctx).WithUnlimitedTimeout(15 * time.Minute).CombinedOutput()
 	if err != nil {
 		errStr := fmt.Sprintf("qemu-img failed: %s, %s\n",
 			err, output)

--- a/pkg/pillar/diskmetrics/diskmetrics.go
+++ b/pkg/pillar/diskmetrics/diskmetrics.go
@@ -17,6 +17,11 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/types"
 )
 
+const qemuExecTimeout = 2 * time.Minute
+
+// qemuExecLongTimeout is a long timeout for command executions in separate worker thread that don't interfere with the watchdog
+const qemuExecLongTimeout = 1000 * time.Second
+
 func GetImgInfo(log *base.LogObject, diskfile string) (*types.ImgInfo, error) {
 	var imgInfo types.ImgInfo
 
@@ -24,7 +29,7 @@ func GetImgInfo(log *base.LogObject, diskfile string) (*types.ImgInfo, error) {
 		return nil, err
 	}
 	output, err := base.Exec(log, "/usr/bin/qemu-img", "info", "-U", "--output=json",
-		diskfile).CombinedOutput()
+		diskfile).WithUnlimitedTimeout(qemuExecLongTimeout).CombinedOutput()
 	if err != nil {
 		errStr := fmt.Sprintf("qemu-img failed: %s, %s\n",
 			err, output)
@@ -65,7 +70,7 @@ func ResizeImg(ctx context.Context, log *base.LogObject, diskfile string, newsiz
 		return err
 	}
 	output, err := base.Exec(log, "/usr/bin/qemu-img", "resize", diskfile,
-		strconv.FormatUint(newsize, 10)).WithContext(ctx).CombinedOutput()
+		strconv.FormatUint(newsize, 10)).WithContext(ctx).WithUnlimitedTimeout(qemuExecLongTimeout).CombinedOutput()
 	if err != nil {
 		errStr := fmt.Sprintf("qemu-img failed: %s, %s\n",
 			err, output)
@@ -77,7 +82,7 @@ func ResizeImg(ctx context.Context, log *base.LogObject, diskfile string, newsiz
 // CreateImg creates empty diskfile with defined format and size
 func CreateImg(ctx context.Context, log *base.LogObject, diskfile string, format string, size uint64) error {
 	output, err := base.Exec(log, "/usr/bin/qemu-img", "create", "-f", format, diskfile,
-		strconv.FormatUint(size, 10)).WithContext(ctx).CombinedOutput()
+		strconv.FormatUint(size, 10)).WithContext(ctx).WithUnlimitedTimeout(qemuExecLongTimeout).CombinedOutput()
 	if err != nil {
 		errStr := fmt.Sprintf("qemu-img failed: %s, %s\n",
 			err, output)
@@ -94,7 +99,7 @@ func RolloutImgToBlock(ctx context.Context, log *base.LogObject, diskfile, outpu
 	// writeback cache instead of default unsafe, out of order enabled, skip file creation
 	// Timeout 2 hours
 	args := []string{"convert", "--target-is-zero", "-t", "writeback", "-W", "-n", "-O", outputFormat, diskfile, outputFile}
-	output, err := base.Exec(log, "/usr/bin/qemu-img", args...).WithContext(ctx).WithUnlimitedTimeout(15 * time.Minute).CombinedOutput()
+	output, err := base.Exec(log, "/usr/bin/qemu-img", args...).WithContext(ctx).WithUnlimitedTimeout(qemuExecLongTimeout).CombinedOutput()
 	if err != nil {
 		errStr := fmt.Sprintf("qemu-img failed: %s, %s\n",
 			err, output)
@@ -113,7 +118,7 @@ func CreateSnapshot(ctx context.Context, log *base.LogObject, diskfile, snapshot
 	cmdBin := "/usr/bin/qemu-img"
 	cmdArgs := []string{"snapshot", "-c", snapshotName, diskfile}
 	log.Noticef("CreateSnapshot: %s %s", cmdBin, strings.Join(cmdArgs, " "))
-	output, err := base.Exec(log, cmdBin, cmdArgs...).WithContext(ctx).CombinedOutput()
+	output, err := base.Exec(log, cmdBin, cmdArgs...).WithContext(ctx).WithLimitedTimeout(qemuExecTimeout).CombinedOutput()
 	if err != nil {
 		errStr := fmt.Sprintf("qemu-img failed: %s, %s\n", err, output)
 		return errors.New(errStr)
@@ -131,7 +136,7 @@ func ApplySnapshot(ctx context.Context, log *base.LogObject, diskfile, snapshotN
 	cmdBin := "/usr/bin/qemu-img"
 	cmdArgs := []string{"snapshot", "-a", snapshotName, diskfile}
 	log.Noticef("ApplySnapshot: %s %s", cmdBin, strings.Join(cmdArgs, " "))
-	output, err := base.Exec(log, cmdBin, cmdArgs...).WithContext(ctx).CombinedOutput()
+	output, err := base.Exec(log, cmdBin, cmdArgs...).WithContext(ctx).WithLimitedTimeout(qemuExecTimeout).CombinedOutput()
 	if err != nil {
 		errStr := fmt.Sprintf("qemu-img failed: %s, %s\n", err, output)
 		return errors.New(errStr)
@@ -146,7 +151,7 @@ func DeleteSnapshot(ctx context.Context, log *base.LogObject, diskfile, snapshot
 	cmdBin := "/usr/bin/qemu-img"
 	cmdArgs := []string{"snapshot", "-d", snapshotName, diskfile}
 	log.Noticef("DeleteSnapshot: %s %s", cmdBin, strings.Join(cmdArgs, " "))
-	output, err := base.Exec(log, cmdBin, cmdArgs...).WithContext(ctx).CombinedOutput()
+	output, err := base.Exec(log, cmdBin, cmdArgs...).WithContext(ctx).WithLimitedTimeout(qemuExecTimeout).CombinedOutput()
 	if err != nil {
 		errStr := fmt.Sprintf("qemu-img failed: %s, %s\n", err, output)
 		return errors.New(errStr)

--- a/pkg/pillar/netmonitor/linux.go
+++ b/pkg/pillar/netmonitor/linux.go
@@ -258,7 +258,7 @@ func (m *LinuxNetworkMonitor) GetInterfaceDHCPInfo(ifIndex int) (info DHCPInfo, 
 	// XXX Getting error -1 unless we add argument -4.
 	// XXX Add IPv6 support.
 	m.Log.Functionf("Calling dhcpcd -U -4 %s\n", ifName)
-	stdoutStderr, err := base.Exec(m.Log, "dhcpcd", "-U", "-4", ifName).CombinedOutput()
+	stdoutStderr, err := base.Exec(m.Log, "dhcpcd", "-U", "-4", ifName).CombinedOutputWithTimeout()
 	if err != nil {
 		if strings.Contains(string(stdoutStderr), "dhcp_dump: No such file or directory") {
 			// DHCP is not configured for this interface. Return empty DHCPInfo.

--- a/pkg/pillar/netmonitor/linux.go
+++ b/pkg/pillar/netmonitor/linux.go
@@ -258,7 +258,7 @@ func (m *LinuxNetworkMonitor) GetInterfaceDHCPInfo(ifIndex int) (info DHCPInfo, 
 	// XXX Getting error -1 unless we add argument -4.
 	// XXX Add IPv6 support.
 	m.Log.Functionf("Calling dhcpcd -U -4 %s\n", ifName)
-	stdoutStderr, err := base.Exec(m.Log, "dhcpcd", "-U", "-4", ifName).CombinedOutputWithTimeout()
+	stdoutStderr, err := base.Exec(m.Log, "dhcpcd", "-U", "-4", ifName).CombinedOutput()
 	if err != nil {
 		if strings.Contains(string(stdoutStderr), "dhcp_dump: No such file or directory") {
 			// DHCP is not configured for this interface. Return empty DHCPInfo.


### PR DESCRIPTION
    netmonitor: timeout calling dhcpcd executable
    
    Add a timeout when calling dhcpcd in case it hangs; this
    prevents the whole DPCManager from hanging and ultimatevely
    making the watchdog fire and reboot the system.

reduce the timeout in general to 100 seconds as 1000 seconds is just too long and not even the watchdog is waiting that long
    