### PR TITLE
Fix verification-% rules in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -756,15 +756,19 @@ $(LIVE).parallels: $(LIVE).raw
 	qemu-img info -f parallels --output json $(LIVE).parallels/live.0.$(PARALLELS_UUID).hds | jq --raw-output '.["virtual-size"]' | xargs ./tools/parallels_disk.sh $(LIVE) $(PARALLELS_UUID)
 
 $(VERIFICATION).raw: $(BOOT_PART) $(EFI_PART) $(ROOTFS_IMG) $(INITRD_IMG) $(VERIFICATION_IMG) $(CONFIG_IMG) $(PERSIST_IMG) $(BSP_IMX_PART) | $(VERIFICATION)
-	@cp -r $(INSTALLER)/* $(VERIFICATION)
+	./tools/prepare-verification.sh pkg/verification $(INSTALLER) $(VERIFICATION)
 	./tools/prepare-platform.sh "$(PLATFORM)" "$(BUILD_DIR)" "$(VERIFICATION)" || :
 	./tools/makeflash.sh "mkverification-raw-efi" -C 850 $| $@ "conf_win verification inventory_win"
 	$(QUIET): $@: Succeeded
 
 $(VERIFICATION).net: $(EFI_PART) $(ROOTFS_IMG) $(INITRD_IMG) $(VERIFICATION_IMG) $(CONFIG_IMG) $(PERSIST_IMG) $(KERNEL_IMG) | $(VERIFICATION)
+	./tools/prepare-verification.sh pkg/verification $(INSTALLER) $(VERIFICATION)
+	./tools/prepare-platform.sh "$(PLATFORM)" "$(BUILD_DIR)" "$(VERIFICATION)" || :
 	./tools/makenet.sh $| verification.img $@
 
 $(VERIFICATION).iso: $(EFI_PART) $(ROOTFS_IMG) $(INITRD_IMG) $(VERIFICATION_IMG) $(CONFIG_IMG) $(PERSIST_IMG) | $(VERIFICATION)
+	./tools/prepare-verification.sh pkg/verification $(INSTALLER) $(VERIFICATION)
+	./tools/prepare-platform.sh "$(PLATFORM)" "$(BUILD_DIR)" "$(VERIFICATION)" || :
 	./tools/makeiso.sh $| $@ verification
 	$(QUIET): $@: Succeeded
 

--- a/tools/prepare-verification.sh
+++ b/tools/prepare-verification.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+#
+# Copyright (c) 2023 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Usage:
+#
+#      ./prepare-verification.sh <pkg/verification_dir> <installer_dir> <verification_dir>
+#
+if [ $# != 3 ]; then
+    exit 0
+else
+    PKGVERIFICATION_DIR="$1"
+    INSTALLER_DIR="$2"
+    VERIFICATION_DIR="$3"
+fi
+
+cp -r "${PKGVERIFICATION_DIR}/verification/*" "${INSTALLER_DIR}/"
+cp -r "${INSTALLER_DIR}/*" "${VERIFICATION_DIR}/"


### PR DESCRIPTION
- Added script that copies necessary files from dist/<arch>/current/installer to the verification directory
- Replaced `@cp -r $(INSTALLER)/* $(VERIFICATION)` with `./tools/prepare-verification.sh pkg/verification $(INSTALLER) $(VERIFICATION)`
- Added `./tools/prepare-verification.sh pkg/verification $(INSTALLER) $(VERIFICATION)` to verification.iso and verification.net rules