### PR TITLE
wwan: allow to disable periodic querying of visible providers

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -53,6 +53,7 @@
 | netdump.downloader.with.pcap | boolean | false | include packet captures inside netdumps for download requests. However, even if enabled, TCP segments carrying non-empty payload (i.e. content which is being downloaded) are excluded and the overall PCAP size is limited to 64MB. |
 | netdump.downloader.http.with.fieldvalue | boolean | false | include HTTP header field values in captured network traces for download requests (beware: may contain secrets, such as datastore credentials). |
 | network.switch.enable.arpsnoop | boolean | true | enable ARP Snooping on switch Network Instance, may need a device reboot to take effect |
+| wwan.query.visible.providers | bool | false | enable to periodically (once per hour) query the set of visible cellular service providers and publish them under WirelessStatus (for every modem) |
 
 In addition, there can be per-agent settings.
 The Per-agent settings begin with "agent.*agentname*.*setting*"

--- a/docs/WIRELESS.md
+++ b/docs/WIRELESS.md
@@ -342,10 +342,19 @@ ICCID if available). Information provided for each SIM card may include ICCID (a
 IMSI (a mobile subscriber identity) and a reference to the name of the modem to which it is inserted.
 SIM card state is also defined but currently not provided.
 
-Every device port associated with a cellular modem has `wireless_status` defined. It contains references
-to the names of the modem and the SIM card being used, information about visible network providers
-(with PLMN codes) and potentially also error messages if EVE failed to apply the last configuration for
-this port or if the connectivity testing is failing.
+Every device port associated with a cellular modem has `wireless_status` defined.
+It contains references to the names of the modem and the SIM card(s) being used, information
+about the currently used network provider (identified by PLMN code), and potentially,
+error messages if EVE failed to apply the last configuration for this port or if connectivity
+testing is failing.
+
+It is also possible to request information about all visible providers by enabling
+the [configuration property](CONFIG-PROPERTIES.md) `wwan.query.visible.providers`.
+By default, this feature is disabled because the operation to scan visible cellular providers
+is quite expensive and takes around 2 minutes to complete, during which the modem is practically
+unmanageable. Therefore, even if enabled, the period for re-scanning visible providers
+is quite long: 1 hour. For the user, it makes sense to enable scanning only temporarily,
+for example, when troubleshooting a modem that is failing to register on the network.
 
 EVE also collects metrics from cellular modems (i.e. stats recorded by modems themselves, not from the Linux
 network stack). These are published in `deviceMetric.cellular`.  Included are packet and byte RX/TX

--- a/pkg/pillar/dpcreconciler/linux.go
+++ b/pkg/pillar/dpcreconciler/linux.go
@@ -646,6 +646,11 @@ func (r *LinuxDpcReconciler) gcpChanged(newGCP types.ConfigItemValueMap) bool {
 	if prevWwanLogLevel != newWwanLogLevel {
 		return true
 	}
+	prevQueryProviders := r.prevArgs.GCP.GlobalValueBool(types.WwanQueryVisibleProviders)
+	newQueryProviders := newGCP.GlobalValueBool(types.WwanQueryVisibleProviders)
+	if prevQueryProviders != newQueryProviders {
+		return true
+	}
 	return false
 }
 
@@ -1374,9 +1379,10 @@ func (r *LinuxDpcReconciler) getIntendedWwanConfig(dpc types.DevicePortConfig,
 		r.Log.Warnf("getIntendedWwanConfig: failed to parse agent log level: %v", err)
 	}
 	config := types.WwanConfig{
-		RadioSilence: radioSilence,
-		Verbose:      verboseLogging,
-		Networks:     []types.WwanNetworkConfig{},
+		RadioSilence:          radioSilence,
+		Verbose:               verboseLogging,
+		QueryVisibleProviders: gcp.GlobalValueBool(types.WwanQueryVisibleProviders),
+		Networks:              []types.WwanNetworkConfig{},
 	}
 
 	// To begin, mark all cached passwords as unused.

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -237,6 +237,8 @@ const (
 	AllowLogFastupload GlobalSettingKey = "newlog.allow.fastupload"
 	// EnableARPSnoopOnNI global setting key
 	EnableARPSnoop GlobalSettingKey = "network.switch.enable.arpsnoop"
+	// WwanQueryVisibleProviders : periodically query visible cellular service providers
+	WwanQueryVisibleProviders GlobalSettingKey = "wwan.query.visible.providers"
 
 	// TriState Items
 	// NetworkFallbackAnyEth global setting key
@@ -856,6 +858,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddBoolItem(ProcessCloudInitMultiPart, false)
 	configItemSpecMap.AddBoolItem(ConsoleAccess, true) // Controller likely default to false
 	configItemSpecMap.AddBoolItem(EnableARPSnoop, true)
+	configItemSpecMap.AddBoolItem(WwanQueryVisibleProviders, false)
 
 	// Add TriState Items
 	configItemSpecMap.AddTriStateItem(NetworkFallbackAnyEth, TS_DISABLED)

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -187,6 +187,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		IgnoreDiskCheckForApps,
 		AllowLogFastupload,
 		EnableARPSnoop,
+		WwanQueryVisibleProviders,
 		// TriState Items
 		NetworkFallbackAnyEth,
 		MaintenanceMode,

--- a/pkg/pillar/types/wwan.go
+++ b/pkg/pillar/types/wwan.go
@@ -18,14 +18,24 @@ import (
 type WwanConfig struct {
 	RadioSilence bool `json:"radio-silence"`
 	// Enable verbose logging in the wwan microservice.
-	Verbose  bool                `json:"verbose"`
-	Networks []WwanNetworkConfig `json:"networks"`
+	Verbose bool `json:"verbose"`
+	// Enable to periodically obtain the set of visible network providers (for each modem)
+	// and publish them under WwanNetworkStatus.VisibleProviders.
+	// Use with caution because this operation may take quite some time (around 2 minutes)
+	// and makes modem unmanageable for the time being. Therefore, even if enabled,
+	// the period to query visible providers is quite long - 1 hour.
+	// Note that WwanNetworkStatus always provides info about the currently used
+	// network provider (CurrentProvider). Getting this info is not expensive so if you
+	// do not need info about other providers in the area, leave this disabled.
+	QueryVisibleProviders bool                `json:"query-visible-providers"`
+	Networks              []WwanNetworkConfig `json:"networks"`
 }
 
 // Equal compares two instances of WwanConfig for equality.
 func (wc WwanConfig) Equal(wc2 WwanConfig) bool {
 	if wc.RadioSilence != wc2.RadioSilence ||
-		wc.Verbose != wc2.Verbose {
+		wc.Verbose != wc2.Verbose ||
+		wc.QueryVisibleProviders != wc2.QueryVisibleProviders {
 		return false
 	}
 	return generics.EqualSetsFn(wc.Networks, wc2.Networks,
@@ -262,7 +272,7 @@ type WwanNetworkStatus struct {
 	CurrentProvider WwanProvider `json:"current-provider"`
 	// All networks that the modem is able to detect.
 	// This will include the currently used provider as well as other visible networks.
-	VisibleProviders []WwanProvider `json:"visible-providers"`
+	VisibleProviders []WwanProvider `json:"visible-providers,omitempty"`
 	// The list of Radio Access Technologies (RATs) currently used for registering/connecting
 	// to the network (typically just one).
 	CurrentRATs []WwanRAT `json:"current-rats"`


### PR DESCRIPTION
The operation to retrieve the set of visible cellular providers is quite expensive and takes around 2 minutes to complete, during which the modem is not manageable. After recent improvement in the wwan microservice we now separately publish info about the currently used provider, which is not so expensive to obtain. Therefore, there is little incentive left to query all visible providers now. For the user it makes sense to enable it only temporarily to for example troubleshoot modem failing to register in the network.
In this commit we make the operation to query visible providers configurable and disabled by default.