### PR TITLE
Do not pass zero console size to diag

### DIFF
--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -204,7 +204,9 @@ for AGENT in $AGENTS; do
       size="$(stty -F /dev/console size)"
       rows=$(echo "$size" | awk '{print $1}')
       columns=$(echo "$size" | awk '{print $2}')
+      [ "$rows" != 0 ] || rows=""
       [ -z "$rows" ] || rows="-r $rows"
+      [ "$columns" != 0 ] || columns=""
       [ -z "$columns" ] || columns="-c $columns"
       mkfifo /run/diag.pipe
       (while true; do cat; done) < /run/diag.pipe >/dev/console 2>&1 &


### PR DESCRIPTION
When EVE is run inside Qemu as part of eden testing, `stty -F /dev/console size` will return `0 0` when run so early. Interestingly, if run few seconds later, it starts to return correct values `24 80`.
I do not know what is the proper solution to get non-zero values early after boot and before starting diag, so let's at least make sure that zeroes are not passed to diag, otherwise it crashes together with the whole zedbox process and watchdog is triggered.