### PR TITLE
spec.sh: enumerate cellular modems with USB addr included

### DIFF
--- a/pkg/debug/Dockerfile
+++ b/pkg/debug/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
 # for debug container we need to build our own copy of musl
 # with -fno-omit-frame-pointer to make sure that perf(1)
 # has a fast path for stack unwinding. This also happens
@@ -49,6 +50,13 @@ WORKDIR /tmp/hexedit/hexedit-1.5
 ADD https://github.com/pixel/hexedit/archive/refs/tags/1.5.tar.gz ../1.5.tar.gz
 RUN tar -C .. -xzvf ../1.5.tar.gz
 RUN ./autogen.sh && ./configure && make DESTDIR=/out install
+
+# building picocom
+# Need this patch to build with musl: https://github.com/npat-efault/picocom/commit/1acf1ddabaf3576b4023c4f6f09c5a3e4b086fb8
+ENV PICOCOM_COMMIT=1acf1ddabaf3576b4023c4f6f09c5a3e4b086fb8
+ADD --keep-git-dir=true https://github.com/npat-efault/picocom.git#${PICOCOM_COMMIT} /tmp/picocom
+WORKDIR /tmp/picocom
+RUN make -j "$(getconf _NPROCESSORS_ONLN)" && strip picocom && cp picocom /out/usr/bin/
 
 # tweaking various bit
 WORKDIR /out

--- a/pkg/debug/spec.sh
+++ b/pkg/debug/spec.sh
@@ -89,7 +89,7 @@ pci_iommugroup_includes_unknown() {
 
         # Check if $pci is of unknown type
         ztype=$(pci_to_ztype "$pci")
-        if [ "$ztype" == 255 ]; then
+        if [ "$ztype" = 255 ]; then
             return 0
         fi
     done
@@ -140,6 +140,79 @@ add_pci_info() {
       "description": "${desc}",
       "iommu_group": ${iommu_group}
 __EOT__
+}
+
+get_modem_protocol() {
+    local sys_dev="$1"
+    local module
+    module="$(basename "$(readlink "${sys_dev}/device/driver/module")")" || return 1
+    case "$module" in
+        "cdc_mbim") echo "mbim"
+        ;;
+        "qmi_wwan") echo "qmi"
+        ;;
+        *) return 1
+        ;;
+    esac
+}
+
+get_modem_ifname() {
+    local sys_dev="$1"
+    ls "${sys_dev}/device/net"
+}
+
+get_modem_usbaddr() {
+    local sys_dev="$1"
+    local dev_path
+    dev_path="$(readlink -f "${sys_dev}/device")" || return 1
+    while [ -e "$dev_path/subsystem" ]; do
+        if [ "$(basename "$(readlink "$dev_path/subsystem")")" != "usb" ]; then
+            dev_path="$(dirname "$dev_path")"
+            continue
+        fi
+        basename "$dev_path" | cut -d ":" -f 1 | tr '-' ':'
+        return
+    done
+}
+
+get_modem_pciaddr() {
+    local sys_dev="$1"
+    local dev_path
+    dev_path="$(readlink -f "${sys_dev}/device")" || return 1
+    while [ -e "$dev_path/subsystem" ]; do
+        if [ "$(basename "$(readlink "$dev_path/subsystem")")" != "pci" ]; then
+            dev_path="$(dirname "$dev_path")"
+            continue
+        fi
+        basename "$dev_path"
+        return
+    done
+}
+
+# https://en.wikipedia.org/wiki/Hayes_command_set
+# Args: <command> <tty device>
+send_at_command() {
+    printf "%s\r\n" "$1" | picocom -qrx 2000 -b 9600 "$2"
+}
+
+get_modem_ttys() {
+    # Convert USB address to <bus>-<port> as used in the /sys filesystem.
+    local USB_ADDR
+    USB_ADDR="$(echo "$1" | tr ':' '-')"
+    find /sys/bus/usb/devices -maxdepth 1 -name "${USB_ADDR}*" |\
+        while read -r USB_INTF; do
+            find "$(realpath "$USB_INTF")" -maxdepth 1 -name "tty*" -exec basename {} \;
+        done
+}
+
+get_modem_atport() {
+    for TTY in $(get_modem_ttys "$1"); do
+        if send_at_command "AT" "/dev/$TTY" 2>/dev/null | grep -q "OK"; then
+            echo "/dev/$TTY"
+            return
+        fi
+    done
+    return 1
 }
 
 if [ -e /dev/xen ]; then
@@ -297,17 +370,66 @@ __EOT__
    fi
 done
 
-#enumerate NICs
+#enumerate cellular modems
+ID="0"
+for USBDEV in /sys/class/usbmisc/*; do
+    get_modem_protocol "$USBDEV" >/dev/null || continue
+    IFNAME="$(get_modem_ifname "$USBDEV")"
+    MODEMS="${MODEMS}${IFNAME}\n" # skip during NIC enumeration
+    USB_ADDR="$(get_modem_usbaddr "$USBDEV")"
+    PCI_ADDR="$(get_modem_pciaddr "$USBDEV")"
+    GROUP=$(get_assignmentgroup "${IFNAME}" "${PCI_ADDR}")
+    cat <<__EOT__
+    ${COMMA}
+    {
+      "ztype": 6,
+      "logicallabel": "modem${ID}",
+      "phylabel": "modem${ID}",
+      "assigngrp": "${GROUP}",
+      "phyaddrs": {
+        "PciLong": "${PCI_ADDR}",
+        "UsbAddr": "${USB_ADDR}"
+      },
+      "cost": 10,
+__EOT__
+    if [ -n "$verbose" ] && [ -x "$(command -v picocom)" ]; then
+        AT_PORT="$(get_modem_atport "$USB_ADDR")"
+        if [ -n "$AT_PORT" ]; then
+            # Close any previous communication at this AT port.
+            send_at_command "+++" "${AT_PORT}"
+            # Return modem identification.
+            # Use sed to remove lines containing only whitespace.
+            OUTPUT="$(send_at_command "ATI" "${AT_PORT}" | sed '/^\s*$/d')"
+            if echo "$OUTPUT" | grep -qv "ERROR"; then
+                # Remove control commands.
+                OUTPUT="$(echo "$OUTPUT" | sed '/^\s*ATI\s*$/d; /^\s*OK\s*$/d' | tr -d '\r')"
+                # Keep at most two lines and join them by semi-colon.
+                OUTPUT="$(echo "$OUTPUT" | head -n 2 | sed ':a;N;$!ba;s/\n/; /g')"
+                cat <<__EOT__
+      "description": "$OUTPUT",
+__EOT__
+            fi
+        fi
+    fi
+    cat <<__EOT__
+      "usagePolicy": {}
+__EOT__
+    COMMA="},"
+    ID=$(( ${ID:-0} + 1 ))
+done
+
+#enumerate NICs (except for cellular modems)
 for ETH in /sys/class/net/*; do
    LABEL=$(echo "$ETH" | sed -e 's#/sys/class/net/##' -e 's#^k##')
-   # Does $LABEL start with wlan or wwan? Change ztype and cost
    COST=0
    ZTYPE=1
-   if [ "${LABEL:0:4}" = "wlan" ]; then
+   if printf "%b" "$MODEMS" | grep -q "^$LABEL$"; then
+     # Cellular modems are enumerated separately (see above).
+     continue
+   fi
+   if [ -d "$ETH/wireless" ]; then
+       # WiFi
        ZTYPE=5
-   elif [ "${LABEL:0:4}" = "wwan" ]; then
-       ZTYPE=6
-       COST=10
    fi
    ETH=$(readlink "$ETH")
    if echo "$ETH" | grep -vq '/virtual/'; then
@@ -345,6 +467,7 @@ __EOT__
      COMMA="},"
   fi
 done
+
 #enumerate Audio
 ID=""
 for audio in $(lspci -D  | grep Audio | cut -f1 -d\ ); do
@@ -373,7 +496,7 @@ if [ -n "$verbose" ]; then
     ID=0
     for pci in $(lspci -Dn  | cut -f1 -d\ ); do
         ztype=$(pci_to_ztype "$pci")
-        [ "$ztype" == 255 ] || continue
+        [ "$ztype" = 255 ] || continue
         cat <<__EOT__
     ${COMMA}
     {


### PR DESCRIPTION
Now that EVE supports multiple cellular modems, it is preferred to use USB addresses to reference modems from the device model. This is because interface names are not deterministic and depend on the order of modem initialization, which may differ on each boot.
It is therefore desirable for `spec.sh` to enumerate cellular modems with the USB address included.

Moreover, `assigngrp` is now properly set to avoid USB controller used for a modem to be accidentally assigned to an application.

Lastly, to make it easier for users to identify multiple attached modems, `spec.sh` obtains description for each modem using Hayes command ATI.