### PR TITLE
github-actions: Exclude pkg/pillar/docs from Eden Workflow.

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -8,10 +8,12 @@ on:  # yamllint disable-line rule:truthy
       - "[0-9]+.[0-9]+-stable"
     paths-ignore:
       - 'docs/**'
+      - 'pkg/pillar/docs/**'
   pull_request_review:
     types: [submitted]
     paths-ignore:
       - 'docs/**'
+      - 'pkg/pillar/docs/**'
 
 jobs:
   integration:


### PR DESCRIPTION
Eden is used to check functional changes in EVE through integration testing. This commit updates the Eden GitHub Actions workflow to ignore changes in the pkg/pillar/docs directory, as documentation updates do not affect functional behavior.