### PR TITLE
LOC: support auxiliary device and application commands 

### DIFF
--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -607,7 +607,7 @@ func myPost(zedcloudCtx *zedcloud.ZedCloudContext, tlsConfig *tls.Config,
 	if len(rv.RespContents) == 0 {
 		return true, rv
 	}
-	err = zedcloud.RemoveAndVerifyAuthContainer(zedcloudCtx, nil, &rv, skipVerify)
+	err = zedcloud.RemoveAndVerifyAuthContainer(zedcloudCtx, &rv, skipVerify)
 	if err != nil {
 		if !zedcloudCtx.NoLedManager {
 			utils.UpdateLedManagerConfig(log,

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -1454,7 +1454,7 @@ func myPost(ctx *diagContext, reqURL string, ifname string,
 		return false, nil, rv.Status, nil
 	}
 	if len(rv.RespContents) > 0 {
-		err = zedcloud.RemoveAndVerifyAuthContainer(zedcloudCtx, nil, &rv, false)
+		err = zedcloud.RemoveAndVerifyAuthContainer(zedcloudCtx, &rv, false)
 		if err != nil {
 			ctx.ph.Print("ERROR: %s: %s RemoveAndVerifyAuthContainer  %s\n",
 				ifname, reqURL, err)

--- a/pkg/pillar/cmd/upgradeconverter/convertglobalconfig.go
+++ b/pkg/pillar/cmd/upgradeconverter/convertglobalconfig.go
@@ -130,10 +130,3 @@ func newConfigFromOld(globalConfigFile string) *types.ConfigItemValueMap {
 	}
 	return oldGlobalConfig.MoveBetweenConfigs()
 }
-
-func convert(ctxPtr *ucContext) error {
-	// Any any conversions we need here.
-	err := convertGlobalConfig(ctxPtr)
-	log.Tracef("upgradeconverter.convert done")
-	return err
-}

--- a/pkg/pillar/cmd/zedagent/attesttask.go
+++ b/pkg/pillar/cmd/zedagent/attesttask.go
@@ -92,7 +92,7 @@ func trySendToController(attestReq *attest.ZAttestReq, attestCtx *attestContext)
 	if err != nil || len(rv.RespContents) == 0 {
 		// Error case handled below
 	} else {
-		err = zedcloud.RemoveAndVerifyAuthContainer(zedcloudCtx, nil, &rv, false)
+		err = zedcloud.RemoveAndVerifyAuthContainer(zedcloudCtx, &rv, false)
 	}
 	switch rv.Status {
 	case types.SenderStatusCertMiss, types.SenderStatusCertInvalid:

--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -345,8 +345,8 @@ func getCertsFromController(ctx *zedagentContext, desc string) bool {
 		nilUUID, "certs")
 
 	rv := requestCertsByURL(ctx, url, desc)
-	if !rv && ctx.getconfigCtx.locConfig != nil {
-		locURL := ctx.getconfigCtx.locConfig.LocURL
+	if !rv && ctx.getconfigCtx.sideController.locConfig != nil {
+		locURL := ctx.getconfigCtx.sideController.locConfig.LocURL
 		url = zedcloud.URLPathString(locURL, zedcloudCtx.V2API,
 			nilUUID, "certs")
 

--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -288,7 +288,7 @@ func requestCertsByURL(ctx *zedagentContext, url string, desc string) bool {
 		return false
 	}
 	if len(rv.RespContents) > 0 {
-		err = zedcloud.RemoveAndVerifyAuthContainer(zedcloudCtx, nil, &rv, true)
+		err = zedcloud.RemoveAndVerifyAuthContainer(zedcloudCtx, &rv, true)
 		if err != nil {
 			log.Errorf("RemoveAndVerifyAuthContainer failed: %s", err)
 			return false

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -123,6 +123,7 @@ type getconfigContext struct {
 	// Combines both LPS (local profile server) and LOC (local operator console)
 	// configurations and structures
 	sideController struct {
+		sync.Mutex
 		localProfileServer  string
 		profileServerToken  string
 		currentProfile      string

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -570,7 +570,9 @@ func decryptAuthContainer(getconfigCtx *getconfigContext, sendRV *zedcloud.SendR
 	}
 
 	// Restore payload with decrypted bytes
-	sm.ProtectedPayload.Payload = clearBytes
+	sm.ProtectedPayload = &zauth.AuthBody{
+		Payload: clearBytes,
+	}
 	sm.CipherContext = nil
 	sm.CipherData = nil
 

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -760,18 +760,20 @@ func requestConfigByURL(getconfigCtx *getconfigContext, url string,
 			publishZedAgentStatus(getconfigCtx)
 			return invalidConfig, rv.TracedReqs
 		}
+		// Decrypts auth container envelope if it is encrypted
+		err = decryptAuthContainer(getconfigCtx, &rv)
+		if err != nil {
+			log.Errorf("decryptAuthContainer: %s", err)
+		}
 	}
 
 	// Copy of retval with auth container stream
 	var authWrappedRV zedcloud.SendRetval
 
-	// Decrypts auth container envelope if it is encrypted
-	err = decryptAuthContainer(getconfigCtx, &rv)
-	if err != nil {
-		log.Errorf("decryptAuthContainer: %s", err)
-	} else {
-		// Success path. Store auth container stream for further
-		// saving it into the file
+	if err == nil {
+		// Success path for both cases: generic config or compound decrypted
+		// config. Store auth container stream for further saving it into the
+		// file.
 		authWrappedRV = rv
 		err = zedcloud.RemoveAndVerifyAuthContainer(zedcloudCtx, &rv, false)
 		if err != nil {

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -191,7 +191,7 @@ func metricsAndInfoTimerTask(ctx *zedagentContext, handleChannel chan interface{
 			ctx.ps.CheckMaxTimeTopic(wdName, "publishMetrics", start,
 				warningTime, errorTime)
 
-			locConfig := ctx.getconfigCtx.locConfig
+			locConfig := ctx.getconfigCtx.sideController.locConfig
 			if locConfig != nil {
 				// Publish all info by timer only for LOC
 				triggerPublishAllInfo(ctx, LOCDest)
@@ -1543,7 +1543,7 @@ func sendMetricsProtobuf(ctx *getconfigContext,
 		devUUID, "metrics")
 	sendMetricsProtobufByURL(ctx, url, ReportMetrics, iteration)
 
-	locConfig := ctx.locConfig
+	locConfig := ctx.sideController.locConfig
 
 	// Repeat metrics for LOC as well
 	if locConfig != nil {

--- a/pkg/pillar/cmd/zedagent/localinfo.go
+++ b/pkg/pillar/cmd/zedagent/localinfo.go
@@ -183,8 +183,8 @@ func postLocalAppInfo(ctx *getconfigContext) *profile.LocalAppCmdList {
 }
 
 func processReceivedAppCommands(ctx *getconfigContext, cmdList *profile.LocalAppCmdList) {
-	ctx.sideController.localCommands.Lock()
-	defer ctx.sideController.localCommands.Unlock()
+	ctx.sideController.Lock()
+	defer ctx.sideController.Unlock()
 	if cmdList == nil {
 		// Nothing requested by local server, just refresh the persisted config.
 		if !ctx.sideController.localCommands.Empty() {
@@ -344,8 +344,8 @@ func triggerLocalCommand(ctx *getconfigContext, cmd types.AppCommand,
 
 func processAppCommandStatus(
 	ctx *getconfigContext, appStatus types.AppInstanceStatus) {
-	ctx.sideController.localCommands.Lock()
-	defer ctx.sideController.localCommands.Unlock()
+	ctx.sideController.Lock()
+	defer ctx.sideController.Unlock()
 	uuid := appStatus.UUIDandVersion.UUID.String()
 	appCmd, hasLocalCmd := ctx.sideController.localCommands.AppCommands[uuid]
 	if !hasLocalCmd {
@@ -384,7 +384,7 @@ func processAppCommandStatus(
 }
 
 // Add config submitted for the application via local profile server.
-// ctx.localCommands should be locked!
+// ctx.sideController should be locked!
 func addLocalAppConfig(ctx *getconfigContext, appInstance *types.AppInstanceConfig) {
 	uuid := appInstance.UUIDandVersion.UUID.String()
 	appCounters, hasCounters := ctx.sideController.localCommands.AppCounters[uuid]
@@ -401,7 +401,7 @@ func addLocalAppConfig(ctx *getconfigContext, appInstance *types.AppInstanceConf
 }
 
 // Delete all local config for this application.
-// ctx.localCommands should be locked!
+// ctx.sideController should be locked!
 func delLocalAppConfig(ctx *getconfigContext, appUUID string) {
 	delete(ctx.sideController.localCommands.AppCommands, appUUID)
 	delete(ctx.sideController.localCommands.AppCounters, appUUID)
@@ -409,7 +409,7 @@ func delLocalAppConfig(ctx *getconfigContext, appUUID string) {
 }
 
 // Add config submitted for the volume via local profile server.
-// ctx.localCommands should be locked!
+// ctx.sideController should be locked!
 func addLocalVolumeConfig(ctx *getconfigContext, volumeConfig *types.VolumeConfig) {
 	uuid := volumeConfig.VolumeID.String()
 	volumeConfig.LocalGenerationCounter =
@@ -425,8 +425,8 @@ func delLocalVolumeConfig(ctx *getconfigContext, volumeUUID string) {
 
 func prepareLocalAppInfo(ctx *getconfigContext) *profile.LocalAppInfoList {
 	msg := profile.LocalAppInfoList{}
-	ctx.sideController.localCommands.Lock()
-	defer ctx.sideController.localCommands.Unlock()
+	ctx.sideController.Lock()
+	defer ctx.sideController.Unlock()
 	addAppInstanceFunc := func(key string, value interface{}) bool {
 		ais := value.(types.AppInstanceStatus)
 		zinfoAppInst := new(profile.LocalAppInfo)

--- a/pkg/pillar/cmd/zedagent/localinfo.go
+++ b/pkg/pillar/cmd/zedagent/localinfo.go
@@ -698,10 +698,12 @@ func prepareLocalDevInfo(ctx *zedagentContext) *profile.LocalDevInfo {
 }
 
 func processReceivedDevCommands(getconfigCtx *getconfigContext, cmd *profile.LocalDevCmd) {
-	ctx := getconfigCtx.zedagentCtx
 	if cmd == nil {
 		return
 	}
+	ctx := getconfigCtx.zedagentCtx
+	getconfigCtx.sideController.Lock()
+	defer getconfigCtx.sideController.Unlock()
 
 	if cmd.Timestamp == getconfigCtx.sideController.lastDevCmdTimestamp {
 		log.Functionf("unchanged timestamp %v",

--- a/pkg/pillar/cmd/zedagent/localinfo.go
+++ b/pkg/pillar/cmd/zedagent/localinfo.go
@@ -49,20 +49,22 @@ func updateLocalAppInfoTicker(ctx *getconfigContext, throttle bool) {
 	max := 1.1 * interval
 	min := 0.8 * max
 	throttledLocalAppInfo = throttle
-	ctx.localAppInfoPOSTTicker.UpdateRangeTicker(time.Duration(min), time.Duration(max))
+	ctx.sideController.localAppInfoPOSTTicker.UpdateRangeTicker(
+		time.Duration(min), time.Duration(max))
 }
 
 func initializeLocalAppInfo(ctx *getconfigContext) {
 	max := 1.1 * float64(localAppInfoPOSTInterval)
 	min := 0.8 * max
-	ctx.localAppInfoPOSTTicker = flextimer.NewRangeTicker(time.Duration(min), time.Duration(max))
+	ctx.sideController.localAppInfoPOSTTicker =
+		flextimer.NewRangeTicker(time.Duration(min), time.Duration(max))
 }
 
 func initializeLocalCommands(ctx *getconfigContext) {
 	if !loadSavedLocalCommands(ctx) {
 		// Write the initial empty content.
-		ctx.localCommands = &types.LocalCommands{}
-		persistLocalCommands(ctx.localCommands)
+		ctx.sideController.localCommands = &types.LocalCommands{}
+		persistLocalCommands(ctx.sideController.localCommands)
 	}
 }
 
@@ -72,7 +74,7 @@ func triggerLocalAppInfoPOST(ctx *getconfigContext) {
 		log.Functionln("throttledLocalAppInfo flag set")
 		return
 	}
-	ctx.localAppInfoPOSTTicker.TickNow()
+	ctx.sideController.localAppInfoPOSTTicker.TickNow()
 }
 
 // Run a periodic POST request to send information message about apps to local server
@@ -81,7 +83,7 @@ func localAppInfoPOSTTask(ctx *getconfigContext) {
 
 	log.Functionf("localAppInfoPOSTTask: waiting for localAppInfoPOSTTicker")
 	// wait for the first trigger
-	<-ctx.localAppInfoPOSTTicker.C
+	<-ctx.sideController.localAppInfoPOSTTicker.C
 	log.Functionln("localAppInfoPOSTTask: waiting for localAppInfoPOSTTicker done")
 	// trigger again to pass into the loop
 	triggerLocalAppInfoPOST(ctx)
@@ -95,7 +97,7 @@ func localAppInfoPOSTTask(ctx *getconfigContext) {
 
 	for {
 		select {
-		case <-ctx.localAppInfoPOSTTicker.C:
+		case <-ctx.sideController.localAppInfoPOSTTicker.C:
 			start := time.Now()
 			appCmds := postLocalAppInfo(ctx)
 			processReceivedAppCommands(ctx, appCmds)
@@ -110,7 +112,7 @@ func localAppInfoPOSTTask(ctx *getconfigContext) {
 // Post the current state of locally running application instances to the local server
 // and optionally receive a set of app commands to run in the response.
 func postLocalAppInfo(ctx *getconfigContext) *profile.LocalAppCmdList {
-	localProfileServer := ctx.localProfileServer
+	localProfileServer := ctx.sideController.localProfileServer
 	if localProfileServer == "" {
 		return nil
 	}
@@ -119,7 +121,7 @@ func postLocalAppInfo(ctx *getconfigContext) *profile.LocalAppCmdList {
 		log.Errorf("sendLocalAppInfo: makeLocalServerBaseURL: %v", err)
 		return nil
 	}
-	if !ctx.localServerMap.upToDate {
+	if !ctx.sideController.localServerMap.upToDate {
 		err := updateLocalServerMap(ctx, localServerURL)
 		if err != nil {
 			log.Errorf("sendLocalAppInfo: updateLocalServerMap: %v", err)
@@ -128,7 +130,7 @@ func postLocalAppInfo(ctx *getconfigContext) *profile.LocalAppCmdList {
 		// Make sure HasLocalServer is set correctly for the AppInstanceConfig
 		updateHasLocalServer(ctx)
 	}
-	srvMap := ctx.localServerMap.servers
+	srvMap := ctx.sideController.localServerMap.servers
 	if len(srvMap) == 0 {
 		log.Functionf("sendLocalAppInfo: cannot find any configured apps for localServerURL: %s",
 			localServerURL)
@@ -154,7 +156,7 @@ func postLocalAppInfo(ctx *getconfigContext) *profile.LocalAppCmdList {
 				return nil
 			case http.StatusOK, http.StatusCreated:
 				if len(appCmds.AppCommands) != 0 {
-					if appCmds.GetServerToken() != ctx.profileServerToken {
+					if appCmds.GetServerToken() != ctx.sideController.profileServerToken {
 						errList = append(errList,
 							fmt.Sprintf("invalid token submitted by local server (%s)", appCmds.GetServerToken()))
 						continue
@@ -181,11 +183,11 @@ func postLocalAppInfo(ctx *getconfigContext) *profile.LocalAppCmdList {
 }
 
 func processReceivedAppCommands(ctx *getconfigContext, cmdList *profile.LocalAppCmdList) {
-	ctx.localCommands.Lock()
-	defer ctx.localCommands.Unlock()
+	ctx.sideController.localCommands.Lock()
+	defer ctx.sideController.localCommands.Unlock()
 	if cmdList == nil {
 		// Nothing requested by local server, just refresh the persisted config.
-		if !ctx.localCommands.Empty() {
+		if !ctx.sideController.localCommands.Empty() {
 			touchLocalCommands()
 		}
 		return
@@ -226,13 +228,14 @@ func processReceivedAppCommands(ctx *getconfigContext, cmdList *profile.LocalApp
 
 		// Accept (or skip already accepted) application command.
 		command := types.AppCommand(appCmdReq.Command)
-		appCmd, hasLocalCmd := ctx.localCommands.AppCommands[appUUID.String()]
+		appCmd, hasLocalCmd := ctx.sideController.localCommands.AppCommands[appUUID.String()]
 		if !hasLocalCmd {
 			appCmd = &types.LocalAppCommand{}
-			if ctx.localCommands.AppCommands == nil {
-				ctx.localCommands.AppCommands = make(map[string]*types.LocalAppCommand)
+			if ctx.sideController.localCommands.AppCommands == nil {
+				ctx.sideController.localCommands.AppCommands =
+					make(map[string]*types.LocalAppCommand)
 			}
-			ctx.localCommands.AppCommands[appUUID.String()] = appCmd
+			ctx.sideController.localCommands.AppCommands[appUUID.String()] = appCmd
 		}
 		if appCmd.Command == command &&
 			appCmd.LocalServerTimestamp == appCmdReq.Timestamp {
@@ -255,7 +258,7 @@ func processReceivedAppCommands(ctx *getconfigContext, cmdList *profile.LocalApp
 
 	// Persist accepted application commands and counters.
 	if cmdChanges {
-		persistLocalCommands(ctx.localCommands)
+		persistLocalCommands(ctx.sideController.localCommands)
 	} else {
 		// No actual configuration change to apply, just refresh the persisted config.
 		touchLocalCommands()
@@ -273,13 +276,14 @@ func triggerLocalCommand(ctx *getconfigContext, cmd types.AppCommand,
 	app *types.AppInstanceConfig, timestamp string) (changedVolumes bool) {
 	// Get current local counters of the application.
 	appUUID := app.UUIDandVersion.UUID
-	appCounters, hasCounters := ctx.localCommands.AppCounters[appUUID.String()]
+	appCounters, hasCounters := ctx.sideController.localCommands.AppCounters[appUUID.String()]
 	if !hasCounters {
 		appCounters = &types.LocalAppCounters{}
-		if ctx.localCommands.AppCounters == nil {
-			ctx.localCommands.AppCounters = make(map[string]*types.LocalAppCounters)
+		if ctx.sideController.localCommands.AppCounters == nil {
+			ctx.sideController.localCommands.AppCounters =
+				make(map[string]*types.LocalAppCounters)
 		}
-		ctx.localCommands.AppCounters[appUUID.String()] = appCounters
+		ctx.sideController.localCommands.AppCounters[appUUID.String()] = appCounters
 	}
 
 	// Update configuration to trigger the operation.
@@ -306,14 +310,15 @@ func triggerLocalCommand(ctx *getconfigContext, cmd types.AppCommand,
 		// Trigger purge of all volumes used by the application.
 		// XXX Currently the assumption is that every volume instance is used
 		//     by at most one application.
-		if ctx.localCommands.VolumeGenCounters == nil {
-			ctx.localCommands.VolumeGenCounters = make(map[string]int64)
+		if ctx.sideController.localCommands.VolumeGenCounters == nil {
+			ctx.sideController.localCommands.VolumeGenCounters =
+				make(map[string]int64)
 		}
 		for i := range app.VolumeRefConfigList {
 			vr := &app.VolumeRefConfigList[i]
 			uuid := vr.VolumeID.String()
 			remoteGenCounter := vr.GenerationCounter
-			localGenCounter := ctx.localCommands.VolumeGenCounters[uuid]
+			localGenCounter := ctx.sideController.localCommands.VolumeGenCounters[uuid]
 			// Un-publish volume with the current counters.
 			volKey := volumeKey(uuid, remoteGenCounter, localGenCounter)
 			volObj, _ := ctx.pubVolumeConfig.Get(volKey)
@@ -326,7 +331,7 @@ func triggerLocalCommand(ctx *getconfigContext, cmd types.AppCommand,
 			unpublishVolumeConfig(ctx, volKey)
 			// Publish volume with an increased local generation counter.
 			localGenCounter++
-			ctx.localCommands.VolumeGenCounters[uuid] = localGenCounter
+			ctx.sideController.localCommands.VolumeGenCounters[uuid] = localGenCounter
 			vr.LocalGenerationCounter = localGenCounter
 			volume.LocalGenerationCounter = localGenCounter
 			publishVolumeConfig(ctx, volume)
@@ -339,10 +344,10 @@ func triggerLocalCommand(ctx *getconfigContext, cmd types.AppCommand,
 
 func processAppCommandStatus(
 	ctx *getconfigContext, appStatus types.AppInstanceStatus) {
-	ctx.localCommands.Lock()
-	defer ctx.localCommands.Unlock()
+	ctx.sideController.localCommands.Lock()
+	defer ctx.sideController.localCommands.Unlock()
 	uuid := appStatus.UUIDandVersion.UUID.String()
-	appCmd, hasLocalCmd := ctx.localCommands.AppCommands[uuid]
+	appCmd, hasLocalCmd := ctx.sideController.localCommands.AppCommands[uuid]
 	if !hasLocalCmd {
 		// This app received no local command requests.
 		return
@@ -374,7 +379,7 @@ func processAppCommandStatus(
 		}
 	}
 	if updated {
-		persistLocalCommands(ctx.localCommands)
+		persistLocalCommands(ctx.sideController.localCommands)
 	}
 }
 
@@ -382,7 +387,7 @@ func processAppCommandStatus(
 // ctx.localCommands should be locked!
 func addLocalAppConfig(ctx *getconfigContext, appInstance *types.AppInstanceConfig) {
 	uuid := appInstance.UUIDandVersion.UUID.String()
-	appCounters, hasCounters := ctx.localCommands.AppCounters[uuid]
+	appCounters, hasCounters := ctx.sideController.localCommands.AppCounters[uuid]
 	if hasCounters {
 		appInstance.LocalRestartCmd = appCounters.RestartCmd
 		appInstance.LocalPurgeCmd = appCounters.PurgeCmd
@@ -390,36 +395,38 @@ func addLocalAppConfig(ctx *getconfigContext, appInstance *types.AppInstanceConf
 	for i := range appInstance.VolumeRefConfigList {
 		vr := &appInstance.VolumeRefConfigList[i]
 		uuid = vr.VolumeID.String()
-		vr.LocalGenerationCounter = ctx.localCommands.VolumeGenCounters[uuid]
+		vr.LocalGenerationCounter =
+			ctx.sideController.localCommands.VolumeGenCounters[uuid]
 	}
 }
 
 // Delete all local config for this application.
 // ctx.localCommands should be locked!
 func delLocalAppConfig(ctx *getconfigContext, appUUID string) {
-	delete(ctx.localCommands.AppCommands, appUUID)
-	delete(ctx.localCommands.AppCounters, appUUID)
-	persistLocalCommands(ctx.localCommands)
+	delete(ctx.sideController.localCommands.AppCommands, appUUID)
+	delete(ctx.sideController.localCommands.AppCounters, appUUID)
+	persistLocalCommands(ctx.sideController.localCommands)
 }
 
 // Add config submitted for the volume via local profile server.
 // ctx.localCommands should be locked!
 func addLocalVolumeConfig(ctx *getconfigContext, volumeConfig *types.VolumeConfig) {
 	uuid := volumeConfig.VolumeID.String()
-	volumeConfig.LocalGenerationCounter = ctx.localCommands.VolumeGenCounters[uuid]
+	volumeConfig.LocalGenerationCounter =
+		ctx.sideController.localCommands.VolumeGenCounters[uuid]
 }
 
 // Delete all local config for this volume.
 // ctx.localCommands should be locked!
 func delLocalVolumeConfig(ctx *getconfigContext, volumeUUID string) {
-	delete(ctx.localCommands.VolumeGenCounters, volumeUUID)
-	persistLocalCommands(ctx.localCommands)
+	delete(ctx.sideController.localCommands.VolumeGenCounters, volumeUUID)
+	persistLocalCommands(ctx.sideController.localCommands)
 }
 
 func prepareLocalAppInfo(ctx *getconfigContext) *profile.LocalAppInfoList {
 	msg := profile.LocalAppInfoList{}
-	ctx.localCommands.Lock()
-	defer ctx.localCommands.Unlock()
+	ctx.sideController.localCommands.Lock()
+	defer ctx.sideController.localCommands.Unlock()
 	addAppInstanceFunc := func(key string, value interface{}) bool {
 		ais := value.(types.AppInstanceStatus)
 		zinfoAppInst := new(profile.LocalAppInfo)
@@ -428,7 +435,8 @@ func prepareLocalAppInfo(ctx *getconfigContext) *profile.LocalAppInfoList {
 		zinfoAppInst.Name = ais.DisplayName
 		zinfoAppInst.Err = encodeErrorInfo(ais.ErrorAndTimeWithSource.ErrorDescription)
 		zinfoAppInst.State = ais.State.ZSwState()
-		if appCmd, hasEntry := ctx.localCommands.AppCommands[zinfoAppInst.Id]; hasEntry {
+		if appCmd, hasEntry :=
+			ctx.sideController.localCommands.AppCommands[zinfoAppInst.Id]; hasEntry {
 			zinfoAppInst.LastCmdTimestamp = appCmd.LastCompletedTimestamp
 		}
 		msg.AppsInfo = append(msg.AppsInfo, zinfoAppInst)
@@ -483,7 +491,7 @@ func loadSavedLocalCommands(ctx *getconfigContext) bool {
 	for _, appCmd := range commands.AppCommands {
 		log.Noticef("Loaded persisted local app command: %+v", appCmd)
 	}
-	ctx.localCommands = commands
+	ctx.sideController.localCommands = commands
 	return true
 }
 
@@ -512,42 +520,44 @@ func updateLocalDevInfoTicker(ctx *getconfigContext, throttle bool) {
 	max := 1.1 * interval
 	min := 0.8 * max
 	throttledLocalDevInfo = throttle
-	ctx.localDevInfoPOSTTicker.UpdateRangeTicker(time.Duration(min), time.Duration(max))
+	ctx.sideController.localDevInfoPOSTTicker.UpdateRangeTicker(
+		time.Duration(min), time.Duration(max))
 }
 
 func initializeLocalDevInfo(ctx *getconfigContext) {
 	max := 1.1 * float64(localDevInfoPOSTInterval)
 	min := 0.8 * max
-	ctx.localDevInfoPOSTTicker = flextimer.NewRangeTicker(time.Duration(min), time.Duration(max))
+	ctx.sideController.localDevInfoPOSTTicker =
+		flextimer.NewRangeTicker(time.Duration(min), time.Duration(max))
 }
 
 const maxReadSize = 1024 // Sufficient for a uin64
 
 func initializeLocalDevCmdTimestamp(ctx *getconfigContext) {
 	if _, err := os.Stat(lastDevCmdTimestampFile); err != nil && os.IsNotExist(err) {
-		ctx.lastDevCmdTimestamp = 0
+		ctx.sideController.lastDevCmdTimestamp = 0
 		return
 	}
 	b, err := fileutils.ReadWithMaxSize(log, lastDevCmdTimestampFile,
 		maxReadSize)
 	if err != nil {
 		log.Errorf("initializeLocalDevCmdTimestamp read: %s", err)
-		ctx.lastDevCmdTimestamp = 0
+		ctx.sideController.lastDevCmdTimestamp = 0
 		return
 	}
 	u, err := strconv.ParseUint(string(b), 10, 64)
 	if err != nil {
 		log.Errorf("initializeLocalDevCmdTimestamp: %s", err)
-		ctx.lastDevCmdTimestamp = 0
+		ctx.sideController.lastDevCmdTimestamp = 0
 	} else {
-		ctx.lastDevCmdTimestamp = u
+		ctx.sideController.lastDevCmdTimestamp = u
 		log.Noticef("initializeLocalDevCmdTimestamp: read %d",
-			ctx.lastDevCmdTimestamp)
+			ctx.sideController.lastDevCmdTimestamp)
 	}
 }
 
 func saveLocalDevCmdTimestamp(ctx *getconfigContext) {
-	b := []byte(fmt.Sprintf("%v", ctx.lastDevCmdTimestamp))
+	b := []byte(fmt.Sprintf("%v", ctx.sideController.lastDevCmdTimestamp))
 	err := fileutils.WriteRename(lastDevCmdTimestampFile, b)
 	if err != nil {
 		log.Errorf("saveLocalDevCmdTimestamp write: %s", err)
@@ -560,7 +570,7 @@ func triggerLocalDevInfoPOST(ctx *getconfigContext) {
 		log.Functionln("throttledLocalDevInfo flag set")
 		return
 	}
-	ctx.localDevInfoPOSTTicker.TickNow()
+	ctx.sideController.localDevInfoPOSTTicker.TickNow()
 }
 
 // Run a periodic POST request to send information message about devs to local server
@@ -569,7 +579,7 @@ func localDevInfoPOSTTask(ctx *getconfigContext) {
 
 	log.Functionf("localDevInfoPOSTTask: waiting for localDevInfoPOSTTicker")
 	// wait for the first trigger
-	<-ctx.localDevInfoPOSTTicker.C
+	<-ctx.sideController.localDevInfoPOSTTicker.C
 	log.Functionln("localDevInfoPOSTTask: waiting for localDevInfoPOSTTicker done")
 	// trigger again to pass into the loop
 	triggerLocalDevInfoPOST(ctx)
@@ -583,7 +593,7 @@ func localDevInfoPOSTTask(ctx *getconfigContext) {
 
 	for {
 		select {
-		case <-ctx.localDevInfoPOSTTicker.C:
+		case <-ctx.sideController.localDevInfoPOSTTicker.C:
 			start := time.Now()
 			devCmd := postLocalDevInfo(ctx)
 			if devCmd != nil {
@@ -600,7 +610,7 @@ func localDevInfoPOSTTask(ctx *getconfigContext) {
 // Post the current state of locally running devlication instances to the local server
 // and optionally receive a set of dev commands to run in the response.
 func postLocalDevInfo(ctx *getconfigContext) *profile.LocalDevCmd {
-	localProfileServer := ctx.localProfileServer
+	localProfileServer := ctx.sideController.localProfileServer
 	if localProfileServer == "" {
 		return nil
 	}
@@ -609,7 +619,7 @@ func postLocalDevInfo(ctx *getconfigContext) *profile.LocalDevCmd {
 		log.Errorf("sendLocalDevInfo: makeLocalServerBaseURL: %v", err)
 		return nil
 	}
-	if !ctx.localServerMap.upToDate {
+	if !ctx.sideController.localServerMap.upToDate {
 		err := updateLocalServerMap(ctx, localServerURL)
 		if err != nil {
 			log.Errorf("sendLocalDevInfo: updateLocalServerMap: %v", err)
@@ -618,7 +628,7 @@ func postLocalDevInfo(ctx *getconfigContext) *profile.LocalDevCmd {
 		// Make sure HasLocalServer is set correctly for the AppInstanceConfig
 		updateHasLocalServer(ctx)
 	}
-	srvMap := ctx.localServerMap.servers
+	srvMap := ctx.sideController.localServerMap.servers
 	if len(srvMap) == 0 {
 		log.Functionf("sendLocalDevInfo: cannot find any configured devs for localServerURL: %s",
 			localServerURL)
@@ -644,7 +654,7 @@ func postLocalDevInfo(ctx *getconfigContext) *profile.LocalDevCmd {
 				updateLocalDevInfoTicker(ctx, true)
 				return nil
 			case http.StatusOK, http.StatusCreated:
-				if devCmd.GetServerToken() != ctx.profileServerToken {
+				if devCmd.GetServerToken() != ctx.sideController.profileServerToken {
 					errList = append(errList,
 						fmt.Sprintf("invalid token submitted by local server (%s)",
 							devCmd.GetServerToken()))
@@ -683,7 +693,7 @@ func prepareLocalDevInfo(ctx *zedagentContext) *profile.LocalDevInfo {
 		msg.BootTime = bootTime
 	}
 	msg.LastBootReason = info.BootReason(ctx.bootReason)
-	msg.LastCmdTimestamp = ctx.getconfigCtx.lastDevCmdTimestamp
+	msg.LastCmdTimestamp = ctx.getconfigCtx.sideController.lastDevCmdTimestamp
 	return &msg
 }
 
@@ -693,9 +703,9 @@ func processReceivedDevCommands(getconfigCtx *getconfigContext, cmd *profile.Loc
 		return
 	}
 
-	if cmd.Timestamp == getconfigCtx.lastDevCmdTimestamp {
+	if cmd.Timestamp == getconfigCtx.sideController.lastDevCmdTimestamp {
 		log.Functionf("unchanged timestamp %v",
-			getconfigCtx.lastDevCmdTimestamp)
+			getconfigCtx.sideController.lastDevCmdTimestamp)
 		return
 	}
 	command := types.DevCommand(cmd.Command)
@@ -747,6 +757,6 @@ func processReceivedDevCommands(getconfigCtx *getconfigContext, cmd *profile.Loc
 	// power failure, then we will not poweroff. It seems impossible to do that
 	// without introducing a race condition where we might poweroff without
 	// a power cycle from a UPS to power on again.
-	getconfigCtx.lastDevCmdTimestamp = cmd.Timestamp
+	getconfigCtx.sideController.lastDevCmdTimestamp = cmd.Timestamp
 	saveLocalDevCmdTimestamp(getconfigCtx)
 }

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -47,9 +47,9 @@ func parseConfig(getconfigCtx *getconfigContext, config *zconfig.EdgeDevConfig,
 
 	// Do not accept new commands from Local profile server while new config
 	// from the controller is being applied.
-	if getconfigCtx.localCommands != nil {
-		getconfigCtx.localCommands.Lock()
-		defer getconfigCtx.localCommands.Unlock()
+	if getconfigCtx.sideController.localCommands != nil {
+		getconfigCtx.sideController.localCommands.Lock()
+		defer getconfigCtx.sideController.localCommands.Unlock()
 	}
 
 	// Make sure we do not accidentally revert to an older configuration.
@@ -2636,11 +2636,11 @@ func parseLocConfig(getconfigCtx *getconfigContext,
 	config *zconfig.EdgeDevConfig) {
 	locConfig := config.GetLocConfig()
 	if isLocConfigValid(locConfig) {
-		getconfigCtx.locConfig = &types.LOCConfig{
+		getconfigCtx.sideController.locConfig = &types.LOCConfig{
 			LocURL: locConfig.LocUrl,
 		}
 	} else {
-		getconfigCtx.locConfig = nil
+		getconfigCtx.sideController.locConfig = nil
 	}
 }
 

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -45,12 +45,10 @@ const (
 func parseConfig(getconfigCtx *getconfigContext, config *zconfig.EdgeDevConfig,
 	source configSource) configProcessingRetval {
 
-	// Do not accept new commands from Local profile server while new config
-	// from the controller is being applied.
-	if getconfigCtx.sideController.localCommands != nil {
-		getconfigCtx.sideController.localCommands.Lock()
-		defer getconfigCtx.sideController.localCommands.Unlock()
-	}
+	// Do not accept new commands from side controller while new config
+	// from the primary controller is being applied. Or vice versa.
+	getconfigCtx.sideController.Lock()
+	defer getconfigCtx.sideController.Unlock()
 
 	// Make sure we do not accidentally revert to an older configuration.
 	// This depends on the controller attaching config timestamp.

--- a/pkg/pillar/cmd/zedagent/radiosilence.go
+++ b/pkg/pillar/cmd/zedagent/radiosilence.go
@@ -158,7 +158,7 @@ func getRadioStatus(ctx *getconfigContext) *profile.RadioStatus {
 }
 
 func getRadioConfig(ctx *getconfigContext, radioStatus *profile.RadioStatus) *profile.RadioConfig {
-	localProfileServer := ctx.localProfileServer
+	localProfileServer := ctx.sideController.localProfileServer
 	if localProfileServer == "" {
 		// default configuration
 		return &profile.RadioConfig{
@@ -170,7 +170,7 @@ func getRadioConfig(ctx *getconfigContext, radioStatus *profile.RadioStatus) *pr
 		log.Errorf("getRadioConfig: makeLocalServerBaseURL: %v", err)
 		return nil
 	}
-	if !ctx.localServerMap.upToDate {
+	if !ctx.sideController.localServerMap.upToDate {
 		err := updateLocalServerMap(ctx, localServerURL)
 		if err != nil {
 			log.Errorf("getRadioConfig: updateLocalServerMap: %v", err)
@@ -179,7 +179,7 @@ func getRadioConfig(ctx *getconfigContext, radioStatus *profile.RadioStatus) *pr
 		// Make sure HasLocalServer is set correctly for the AppInstanceConfig
 		updateHasLocalServer(ctx)
 	}
-	srvMap := ctx.localServerMap.servers
+	srvMap := ctx.sideController.localServerMap.servers
 	if len(srvMap) == 0 {
 		log.Functionf("getRadioConfig: cannot find any configured apps for localServerURL: %s",
 			localServerURL)
@@ -207,7 +207,7 @@ func getRadioConfig(ctx *getconfigContext, radioStatus *profile.RadioStatus) *pr
 				touchRadioConfig()
 				return nil
 			}
-			if radioConfig.GetServerToken() != ctx.profileServerToken {
+			if radioConfig.GetServerToken() != ctx.sideController.profileServerToken {
 				errList = append(errList,
 					fmt.Sprintf("invalid token submitted by local server (%s)", radioConfig.GetServerToken()))
 				continue

--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -642,8 +642,9 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext, dest destinationBitset) {
 	ReportDeviceInfo.ApiCapability = info.APICapability_API_CAPABILITY_VOLUME_SNAPSHOTS
 
 	// Report if there is a local override of profile
-	if ctx.getconfigCtx.currentProfile != ctx.getconfigCtx.globalProfile {
-		ReportDeviceInfo.LocalProfile = ctx.getconfigCtx.currentProfile
+	if ctx.getconfigCtx.sideController.currentProfile !=
+		ctx.getconfigCtx.sideController.globalProfile {
+		ReportDeviceInfo.LocalProfile = ctx.getconfigCtx.sideController.currentProfile
 	}
 
 	ReportInfo.InfoContent = new(info.ZInfoMsg_Dinfo)

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -267,7 +267,7 @@ func queueInfoToDest(ctx *zedagentContext, dest destinationBitset,
 	key string, buf *bytes.Buffer, size int64, bailOnHTTPErr,
 	withNetTracing, forcePeriodic bool, itemType interface{}) {
 
-	locConfig := ctx.getconfigCtx.locConfig
+	locConfig := ctx.getconfigCtx.sideController.locConfig
 
 	if dest&ControllerDest != 0 {
 		url := zedcloud.URLPathString(serverNameAndPort, zedcloudCtx.V2API,
@@ -493,7 +493,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	getconfigCtx.locationAppTickerHandle = <-handleChannel
 
 	//trigger channel for localProfile state machine
-	getconfigCtx.localProfileTrigger = make(chan Notify, 1)
+	getconfigCtx.sideController.localProfileTrigger = make(chan Notify, 1)
 	//process saved local profile
 	processSavedProfile(getconfigCtx)
 
@@ -580,13 +580,13 @@ func (zedagentCtx *zedagentContext) init() {
 
 	// Initialize context used to get and parse device configuration.
 	getconfigCtx := &getconfigContext{
-		localServerMap: &localServerMap{},
 		// default value of currentMetricInterval
 		currentMetricInterval: zedagentCtx.globalConfig.GlobalValueInt(types.MetricInterval),
 		// edge-view configure
 		configEdgeview: &types.EdgeviewConfig{},
 		cipherContexts: make(map[string]types.CipherContext),
 	}
+	getconfigCtx.sideController.localServerMap = &localServerMap{}
 
 	cipherCtx := &cipherContext{}
 	attestCtx := &attestContext{}
@@ -737,7 +737,7 @@ func waitUntilDNSReady(zedagentCtx *zedagentContext, stillRunning *time.Ticker) 
 			zedagentCtx.subEncryptedKeyFromDevice.ProcessChange(change)
 
 		case change := <-getconfigCtx.subAppNetworkStatus.MsgChan():
-			getconfigCtx.localServerMap.upToDate = false
+			getconfigCtx.sideController.localServerMap.upToDate = false
 			getconfigCtx.subAppNetworkStatus.ProcessChange(change)
 
 		case change := <-zedagentCtx.subWwanStatus.MsgChan():
@@ -808,7 +808,7 @@ func mainEventLoop(zedagentCtx *zedagentContext, stillRunning *time.Ticker) {
 			getconfigCtx.subNodeAgentStatus.ProcessChange(change)
 
 		case change := <-getconfigCtx.subAppNetworkStatus.MsgChan():
-			getconfigCtx.localServerMap.upToDate = false
+			getconfigCtx.sideController.localServerMap.upToDate = false
 			getconfigCtx.subAppNetworkStatus.ProcessChange(change)
 
 		case change := <-dnsCtx.subDeviceNetworkStatus.MsgChan():

--- a/pkg/pillar/types/zedagenttypes.go
+++ b/pkg/pillar/types/zedagenttypes.go
@@ -6,7 +6,6 @@ package types
 import (
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -680,7 +679,6 @@ func (am RadioSilence) String() string {
 
 // LocalCommands : commands triggered locally via Local profile server.
 type LocalCommands struct {
-	sync.Mutex
 	// Locally issued app commands.
 	// For every app there is entry only for the last command (completed
 	// or still in progress). Previous commands are not remembered.

--- a/pkg/pillar/zedcloud/authen.go
+++ b/pkg/pillar/zedcloud/authen.go
@@ -110,15 +110,16 @@ func removeAndVerifyAuthContainer(ctx *ZedCloudContext,
 	return sm.ProtectedPayload.GetPayload(), senderSt, nil
 }
 
-// VerifyAuthContainer verifies the integrity of the payload inside AuthContainer.
-func VerifyAuthContainer(ctx *ZedCloudContext, sm *zauth.AuthContainer) (types.SenderStatus, error) {
+// VerifyAuthContainerHeader verifies correctness of algorithm fields in header
+func VerifyAuthContainerHeader(ctx *ZedCloudContext, sm *zauth.AuthContainer) (
+	types.SenderStatus, error) {
 	err := loadSavedServerSigningCert(ctx)
 	if err != nil {
 		return types.SenderStatusNone, err
 	}
 	if len(sm.GetSenderCertHash()) != hashSha256Len16 &&
 		len(sm.GetSenderCertHash()) != hashSha256Len32 {
-		err := fmt.Errorf("VerifyAuthContainer: unexpected senderCertHash length (%d)",
+		err := fmt.Errorf("VerifyAuthContainerHeader: unexpected senderCertHash length (%d)",
 			len(sm.GetSenderCertHash()))
 		ctx.log.Error(err)
 		return types.SenderStatusHashSizeError, err
@@ -127,30 +128,40 @@ func VerifyAuthContainer(ctx *ZedCloudContext, sm *zauth.AuthContainer) (types.S
 	switch sm.Algo {
 	case zcommon.HashAlgorithm_HASH_ALGORITHM_SHA256_32BYTES:
 		if bytes.Compare(sm.GetSenderCertHash(), ctx.serverSigningCertHash) != 0 {
-			ctx.log.Errorf("VerifyAuthContainer: local server cert hash (%d)"+
+			ctx.log.Errorf("VerifyAuthContainerHeader: local server cert hash (%d)"+
 				"does not match in authen (%d): %v, %v",
 				len(ctx.serverSigningCertHash), len(sm.GetSenderCertHash()),
 				ctx.serverSigningCertHash, sm.GetSenderCertHash())
-			err := fmt.Errorf("VerifyAuthContainer: local server cert hash " +
+			err := fmt.Errorf("VerifyAuthContainerHeader: local server cert hash " +
 				"does not match in authen (32 bytes)")
 			return types.SenderStatusCertMiss, err
 		}
 	case zcommon.HashAlgorithm_HASH_ALGORITHM_SHA256_16BYTES:
 		if bytes.Compare(sm.GetSenderCertHash(), ctx.serverSigningCertHash[:hashSha256Len16]) != 0 {
-			ctx.log.Errorf("VerifyAuthContainer: local server cert hash (%d)"+
+			ctx.log.Errorf("VerifyAuthContainerHeader: local server cert hash (%d)"+
 				"does not match in authen (%d): %v, %v",
 				len(ctx.serverSigningCertHash), len(sm.GetSenderCertHash()),
 				ctx.serverSigningCertHash, sm.GetSenderCertHash())
-			err := fmt.Errorf("VerifyAuthContainer: local server cert hash " +
+			err := fmt.Errorf("VerifyAuthContainerHeader: local server cert hash " +
 				"does not match in authen (16 bytes)")
 			return types.SenderStatusCertMiss, err
 		}
 	default:
-		err := fmt.Errorf("VerifyAuthContainer: hash algorithm is not supported")
+		err := fmt.Errorf("VerifyAuthContainerHeader: hash algorithm is not supported")
 		ctx.log.Error(err)
 		return types.SenderStatusAlgoFail, err
 	}
 
+	return types.SenderStatusNone, nil
+}
+
+// VerifyAuthContainer verifies the integrity of the payload inside AuthContainer.
+func VerifyAuthContainer(ctx *ZedCloudContext, sm *zauth.AuthContainer) (types.SenderStatus, error) {
+	status, err := VerifyAuthContainerHeader(ctx, sm)
+	if err != nil {
+		return status, err
+	}
+	// Verify payload integrity
 	data := sm.ProtectedPayload.GetPayload()
 	hash := ComputeSha(data)
 	err = verifyAuthSig(ctx, sm.GetSignatureHash(), ctx.serverSigningCert, hash)

--- a/pkg/pillar/zedcloud/authen.go
+++ b/pkg/pillar/zedcloud/authen.go
@@ -28,7 +28,6 @@ import (
 	zcert "github.com/lf-edge/eve-api/go/certs"
 	zcommon "github.com/lf-edge/eve-api/go/evecommon"
 	"github.com/lf-edge/eve/pkg/pillar/base"
-	"github.com/lf-edge/eve/pkg/pillar/cipher"
 	etpm "github.com/lf-edge/eve/pkg/pillar/evetpm"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
@@ -49,7 +48,7 @@ const (
 //
 // If skipVerify we remove the envelope but do not verify the signature.
 func RemoveAndVerifyAuthContainer(ctx *ZedCloudContext,
-	decryptCtx *cipher.DecryptCipherContext, sendRV *SendRetval, skipVerify bool) error {
+	sendRV *SendRetval, skipVerify bool) error {
 	var reqURL string
 	if strings.HasPrefix(sendRV.ReqURL, "http:") {
 		reqURL = sendRV.ReqURL
@@ -63,7 +62,7 @@ func RemoveAndVerifyAuthContainer(ctx *ZedCloudContext,
 	if !ctx.V2API {
 		return nil
 	}
-	contents, status, err := removeAndVerifyAuthContainer(ctx, decryptCtx,
+	contents, status, err := removeAndVerifyAuthContainer(ctx,
 		sendRV.RespContents, skipVerify)
 	if status != types.SenderStatusNone {
 		sendRV.Status = status
@@ -88,55 +87,9 @@ func RemoveAndVerifyAuthContainer(ctx *ZedCloudContext,
 	return nil
 }
 
-func decryptCipherBlock(decryptCtx *cipher.DecryptCipherContext,
-	sm *zauth.AuthContainer, cipherBlock *zcommon.CipherBlock) ([]byte, error) {
-	cipherContext := sm.GetCipherContext()
-	if decryptCtx == nil {
-		err := errors.New("removeAndVerifyAuthContainer: decrypt cipher context is undefined\n")
-		return nil, err
-	}
-	if cipherContext == nil {
-		err := errors.New("removeAndVerifyAuthContainer: cipher context is undefined\n")
-		return nil, err
-	}
-	if len(cipherBlock.CipherData) == 0 ||
-		len(cipherBlock.CipherContextId) == 0 {
-		err := errors.New("removeAndVerifyAuthContainer: cipher block data or context id are incorrect\n")
-		return nil, err
-	}
-	if cipherContext.ContextId != cipherBlock.CipherContextId {
-		err := errors.New("removeAndVerifyAuthContainer: cipher context ids do not match\n")
-		return nil, err
-	}
-	cipherCtx := &types.CipherContext{
-		ContextID:          cipherContext.GetContextId(),
-		HashScheme:         cipherContext.GetHashScheme(),
-		KeyExchangeScheme:  cipherContext.GetKeyExchangeScheme(),
-		EncryptionScheme:   cipherContext.GetEncryptionScheme(),
-		DeviceCertHash:     cipherContext.GetDeviceCertHash(),
-		ControllerCertHash: cipherContext.GetControllerCertHash(),
-	}
-	cipherBlockSt := types.CipherBlockStatus{
-		// No unique key is needed here, because this status is never published
-		CipherBlockID:   "cipher-block",
-		CipherContextID: cipherBlock.GetCipherContextId(),
-		InitialValue:    cipherBlock.GetInitialValue(),
-		CipherData:      cipherBlock.GetCipherData(),
-		ClearTextHash:   cipherBlock.GetClearTextSha256(),
-		CipherContext:   cipherCtx,
-		IsCipher:        true,
-	}
-	clearBytes, err := cipher.DecryptCipherBlock(decryptCtx, cipherBlockSt)
-	if err != nil {
-		return nil, err
-	}
-
-	return clearBytes, nil
-}
-
 // given an envelope protobuf received from controller, verify the authentication
 // If skipVerify we parse the envelope but do not verify the content.
-func removeAndVerifyAuthContainer(ctx *ZedCloudContext, decryptCtx *cipher.DecryptCipherContext,
+func removeAndVerifyAuthContainer(ctx *ZedCloudContext,
 	c []byte, skipVerify bool) ([]byte, types.SenderStatus, error) {
 	senderSt := types.SenderStatusNone
 	sm := &zauth.AuthContainer{}
@@ -145,17 +98,6 @@ func removeAndVerifyAuthContainer(ctx *ZedCloudContext, decryptCtx *cipher.Decry
 		ctx.log.Errorf(
 			"removeAndVerifyAuthContainer: can not unmarshal authen content, %v\n", err)
 		return nil, senderSt, err
-	}
-
-	// Firstly decrypt the payload if encrypted
-	if cipherBlock := sm.GetCipherData(); cipherBlock != nil {
-		clearBytes, err := decryptCipherBlock(decryptCtx, sm, cipherBlock)
-		if err != nil {
-			ctx.log.Errorf(
-				"removeAndVerifyAuthContainer: decryptCipherBlock failed: %v\n", err)
-			return nil, senderSt, err
-		}
-		sm.ProtectedPayload.Payload = clearBytes
 	}
 
 	if !skipVerify { // no verify for /certs itself

--- a/pkg/pillar/zedcloud/authen.go
+++ b/pkg/pillar/zedcloud/authen.go
@@ -172,23 +172,7 @@ func loadSavedServerSigningCert(ctx *ZedCloudContext) error {
 		ctx.log.Errorf("loadSavedServerSigningCert: can not read in server cert file, %v\n", err)
 		return err
 	}
-	block, _ := pem.Decode(certBytes)
-	if block == nil {
-		err := fmt.Errorf("loadSavedServerSigningCert: can not get client Cert")
-		return err
-	}
-
-	sCert, err := x509.ParseCertificate(block.Bytes)
-	if err != nil {
-		ctx.log.Errorf("loadSavedServerSigningCert: can not parse cert %v\n", err)
-		return err
-	}
-
-	// hash verify using PEM bytes from cloud
-	ctx.serverSigningCertHash = ComputeSha(certBytes)
-	ctx.serverSigningCert = sCert
-
-	return nil
+	return LoadServerSigningCert(ctx, certBytes)
 }
 
 // ClearCloudCert - zero out cached cloud certs in client zedcloudCtx


### PR DESCRIPTION
The PR implements support of auxiliary device and application commands which come as a member of the compound config, which is the extension to the original edge device config. This PR targets only LOC case, so no changes required on the cloud side.

The main idea is to send device or application commands from the LOC along with the encrypted edge device config. The corresponding API changes are here: https://github.com/lf-edge/eve-api/pull/27 . 

This approach reuses the LPS processing calls: `ProcessReceivedAppCommands` and `ProcessReceivedDevCommands` (@milan-zededa please take a look on that part thoroughly).

Also PR does a few config decryption cleanups.
