### PR TITLE
Add ccache to eve-alpine package cache

### DIFF
--- a/pkg/alpine/mirrors/3.16/main
+++ b/pkg/alpine/mirrors/3.16/main
@@ -20,6 +20,7 @@ ca-certificates
 ca-certificates-bundle
 cairo
 cairo-dev
+ccache
 cmake
 coreutils
 chrony


### PR DESCRIPTION
ccache will be necessary when we move to eve kernel to https://github.com/lf-edge/eve-kernel