### PR TITLE
Fixed bug in tools/prepare-verification.sh

### DIFF
--- a/tools/prepare-verification.sh
+++ b/tools/prepare-verification.sh
@@ -15,5 +15,5 @@ else
     VERIFICATION_DIR="$3"
 fi
 
-cp -r "${PKGVERIFICATION_DIR}/verification/*" "${INSTALLER_DIR}/"
-cp -r "${INSTALLER_DIR}/*" "${VERIFICATION_DIR}/"
+cp -r "${PKGVERIFICATION_DIR}/verification/"* "${INSTALLER_DIR}/"
+cp -r "${INSTALLER_DIR}/"* "${VERIFICATION_DIR}/"


### PR DESCRIPTION
- If we include * in double quotes, they are not treated as wildcard character