### PR TITLE
Workaround to allow verification image to boot on bare metal.

### DIFF
--- a/pkg/mkverification-raw-efi/Dockerfile
+++ b/pkg/mkverification-raw-efi/Dockerfile
@@ -34,7 +34,8 @@ RUN echo "mtools_skip_check=1" >> etc/mtools.conf; \
 ADD https://www.ddcutil.com/tarballs/ddcutil-1.2.2.tar.gz /out/ddcutil-1.2.2.tar.gz
 ADD http://sources.buildroot.net/edid-decode/edid-decode-188950472c19492547e298b27f9da0d72cf826df.tar.gz /out/edid-decode-188950472c19492547e298b27f9da0d72cf826df.tar.gz
 ADD https://github.com/linuxhw/build-stuff/releases/download/1.6/hw-probe-1.6-AI.tar.gz /out/hw-probe-1.6-AI.tar.gz
-ADD https://cloud-images.ubuntu.com/minimal/releases/jammy/release/ubuntu-22.04-minimal-cloudimg-amd64.img /out/ubuntu-22.04-minimal-cloudimg-amd64.img
+# Temporarily removed ubuntu VM image to make the verification image smaller.
+#ADD https://cloud-images.ubuntu.com/minimal/releases/jammy/release/ubuntu-22.04-minimal-cloudimg-amd64.img /out/ubuntu-22.04-minimal-cloudimg-amd64.img
 ADD https://github.com/tpm2-software/tpm2-tools/archive/5.2.tar.gz /out/5.2.tar.gz
 
 COPY make-raw verify grub.cfg.in UsbInvocationScript.txt ./
@@ -61,7 +62,9 @@ WORKDIR /out/tpm2-tools-5.2
 RUN ./bootstrap \
     && ./configure --prefix=/out/usr \
     && make -j"$(nproc)" \
-    && make install
+    && make install \
+    && rm -rf /out/edid-decode-188950472c19492547e298b27f9da0d72cf826df \
+    /out/ddcutil-1.2.2 /out/hw-probe-1.6-AI /out/tpm2-tools-5.2
 # Before changing something here please take a look into the
 # images/rootfs.yml.in onboot section: the verification should
 # precede the storage-init container.

--- a/pkg/mkverification-raw-efi/make-raw
+++ b/pkg/mkverification-raw-efi/make-raw
@@ -191,9 +191,10 @@ do_rootfs() {
     esac
 
     # Calculate partition size and add a partition
+    # shellcheck disable=SC2086
     sgdisk --new "$NUM_PART:$SEC_START:$SEC_END" \
            --typecode="$NUM_PART:$PARTITION_TYPE_USR_X86_64" \
-           --change-name="$NUM_PART:$LABEL" "$EXTRA_ATTR" "$IMGFILE"
+           --change-name="$NUM_PART:$LABEL" $EXTRA_ATTR "$IMGFILE"
 
     if [ -z "$RANDOM_DISK_UUIDS" ]; then
         case $LABEL in

--- a/pkg/mkverification-raw-efi/verify
+++ b/pkg/mkverification-raw-efi/verify
@@ -373,24 +373,31 @@ do
    fi
 done
 
-#Testing qemu and passthrough
-qemu_exec=/usr/bin/qemu-system-$(uname -m)
-machine=$($qemu_exec -machine help | awk '{if (NR==2) print $1}')
-$qemu_exec -m 1024 -smp 2 -display none -serial mon:stdio -global ICH9-LPC.noreboot=false \
-   -watchdog-action reset -rtc base=utc,clock=rt -machine "$machine" -cpu SandyBridge \
-   -drive file=/ubuntu-22.04-minimal-cloudimg-amd64.img,format=qcow2 &
+if false; # Temporarily commented out
+then
+   # Testing qemu and passthrough
+   qemu_exec=/usr/bin/qemu-system-$(uname -m)
+   machine=$($qemu_exec -machine help | awk '{if (NR==2) print $1}')
+   $qemu_exec -m 1024 -smp 2 -display none -serial mon:stdio -global ICH9-LPC.noreboot=false \
+      -watchdog-action reset -rtc base=utc,clock=rt -machine "$machine" -cpu SandyBridge \
+      -drive file=/ubuntu-22.04-minimal-cloudimg-amd64.img,format=qcow2 &
 
-# shellcheck disable=SC2181
-if [ "$?" -eq 0 ]; then
-   kill %1
-   echo "start VM success" > "$REPORT/guest-checks.log"
-   echo "Start of an edge application successful" >> "$REPORT/summary.log";
-else
-   echo "start VM failed" > "$REPORT/guest-checks.log"
-   echo "Start of an edge application failed" >> "$REPORT/summary.log";
+   # shellcheck disable=SC2181
+   if [ "$?" -eq 0 ]; then
+      kill %1
+      echo "start VM success" > "$REPORT/guest-checks.log"
+      echo "Start of an edge application successful" >> "$REPORT/summary.log";
+   else
+      echo "start VM failed" > "$REPORT/guest-checks.log"
+      echo "Start of an edge application failed" >> "$REPORT/summary.log";
+   fi
 fi
 
+echo "start VM test unavailable" > "$REPORT/guest-checks.log"
+
 tpm2_pcrread >> "$REPORT/summary.log"
+
+cp "/root/etc/eve-release" "$REPORT"
 
 cat "$REPORT/summary.log"
 
@@ -400,8 +407,24 @@ if [ -n "$REPORT" ]; then
    cat $LOGFILE > "$REPORT/verification.log"
 fi
 
+# if we store report to USB copy installer.log to persist explicitly
+if [ ! -d "/persist/installer" ]; then
+  mkdir "/persist/installer"
+  cat $LOGFILE > "/persist/installer/installer.log"
+fi
+
+#store file to indicate first boot after installer
+touch /persist/installer/first-boot
+
+# store file to indicate that EVE will clean vault
+# in case of no key received from controller
+mkdir -p /persist/status
+touch /persist/status/allow-vault-clean
+
 # lets hope this is enough to flush the caches
 sync; sleep 5; sync
+umount /config 2>/dev/null
+umount /run/INVENTORY 2>/dev/null
 
 # we need a copy of these in tmpfs so that a block device with rootfs can be yanked
 cp /sbin/poweroff /sbin/reboot /bin/sleep /run

--- a/tools/publish-verification-info.sh
+++ b/tools/publish-verification-info.sh
@@ -1,34 +1,61 @@
 #!/bin/bash
 
-verification_dir="$1"
-img="$1/verification.raw"
+img="$1"
 ip="$2"
 
-if [ "$verification_dir" == "" ] || [ "$ip" == "" ]; then
-  echo "Usage ./publish_verification_info.sh <verification_dir> <server_ip>"
+if [ "$img" == "" ] || [ "$ip" == "" ]; then
+  echo "Usage ./publish_verification_info.sh <USB_device_name|verification_img> <server_ip>"
+  echo "E.g., ./publish_verification_info.sh /dev/disk4 147.52.71.221"
+  echo "Or, ./publish_verification_info.sh dist/amd64/current/verification.img 147.52.71.221"
   exit
 fi
 
-size=$(fdisk -l "$img" | grep raw5 | awk '{print $2}')
-mkdir /tmp/verification_mnt
-sudo mount -o offset=$((size*512)) "$img" /tmp/verification_mnt
+checkOScmd="echo ${OSTYPE} | grep -q darwin" # Running on MacOS
+checkVerificationImg="eval file ${img} | grep -q DOS/MBR" # this is a file not a block device
+mountDir="/tmp/verification_mnt"
+if eval "${checkOScmd}"; then # MacOS
+  devicename="${img}"
+  if eval "${checkVerificationImg}"; then # file
+    tmp=$(/usr/bin/hdiutil attach -imagekey diskimage-class=CRawDiskImage -nomount "${img}")
+    devicename=$(echo "${tmp}" | grep "GUID_partition_scheme" | awk '{print $1}')
+  fi
+  /usr/sbin/diskutil mount "${devicename}"s5
+  mountDir="/Volumes/INVENTORY/"
+else # Linux
+  mkdir "${mountDir}"
+  if eval "${checkVerificationImg}"; then # file
+    size=$(fdisk -l "$img" | grep raw5 | awk '{print $2}')
+    sudo mount -o offset=$((size*512)) "$img" "${mountDir}"
+  else # block device
+    sudo mount "${img}"5 "${mountDir}"
+  fi
+fi
 
-dirname=$(cat /tmp/verification_mnt/*/hardwaremodel.txt | grep "Product Name:" | awk '{ for (i = 3; i <= NF; i++) printf "%s", $i; printf "\n" }' | tr ',' '-' | tr '(' '-' | tr ')' '-' | tr '+' '-')
-eve_version=$(cat "${verification_dir}/verification/eve_version")
+dirname=$(cat "${mountDir}/"*/summary.log | grep "Model:" | awk '{ for (i = 2; i < NF; i++) printf "%s-", $i; printf "%s", $i }' | tr -d ',()+\n\r')
+eve_version=$(cat "${mountDir}"/*"/eve-release")
 dirname="${dirname}###${eve_version}"
 
-mkdir "$dirname"
-cp -r /tmp/verification_mnt/*/* "$dirname/"
-tar xvf "${dirname}/hw.info.txz" -C "$dirname"
-rm "$dirname/hw.info.txz"
+echo "${dirname}"
+
+mkdir "${dirname}"
+cp -r "${mountDir}"/*/* "${dirname}/"
+tar xvf "${dirname}/hw.info.txz" -C "${dirname}"
+rm "${dirname}/hw.info.txz"
 
 fname="${dirname}.tar.gz"
-tar zcvf "${fname}" "$dirname"
-rm -rf "$dirname"
+tar zcvf "${fname}" "${dirname}"
+rm -rf "${dirname}"
 
 CSRF_TOKEN=$(curl -s -c cookies.txt "http://$ip:8999/upload" | xmllint --html --xpath 'string(//input[@name="csrfmiddlewaretoken"]/@value)' - 2>/dev/null)
 curl -X POST -b cookies.txt -F "csrfmiddlewaretoken=$CSRF_TOKEN" -F  "file=@${fname}" "http://$ip:8999/upload"
 
 rm cookies.txt "${fname}"
-sudo umount /tmp/verification_mnt
-rmdir /tmp/verification_mnt
+if eval "${checkOScmd}"; then # MacOS
+  /usr/sbin/diskutil umount "${devicename}"s5
+  if eval "${checkVerificationImg}"; then # file
+    /usr/bin/hdiutil detach "${devicename}"
+  fi
+else # Linux
+  sudo umount "${mountDir}"
+  rmdir "${mountDir}"
+fi


### PR DESCRIPTION
- The verification image is large, ~300MB. This causes an issue to initrd that tries to allocate physical pages in memory.
- This patch reduces the size of the verification image by more than 200MB by removing the image ubuntu-22.04-minimal-cloudimg-amd64.img, which we use to test if EVE spawns guests correctly. Therefore, this verification version does not have tests for guest VMs.