### PR TITLE
Use IFF_LOWERUP flag to determine link status if oper. state is unknown

### DIFF
--- a/pkg/pillar/netmonitor/linux.go
+++ b/pkg/pillar/netmonitor/linux.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/devicenetwork"
 	"github.com/lf-edge/eve/pkg/pillar/netclone"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -144,6 +145,18 @@ func (m *LinuxNetworkMonitor) getInterfaceAttrs(ifIndex int) (attrs IfAttrs, err
 }
 
 func (m *LinuxNetworkMonitor) ifAttrsFromLink(link netlink.Link) IfAttrs {
+	var lowerUP bool
+	switch link.Attrs().OperState {
+	case netlink.OperUnknown:
+		// It is common for cellular modems that the operating state is not reported,
+		// whereas lower-layer IFF_* flags are available and can be used to determine
+		// link status.
+		lowerUP = link.Attrs().RawFlags&unix.IFF_LOWER_UP != 0
+	case netlink.OperUp:
+		lowerUP = true
+	default:
+		lowerUP = false
+	}
 	return IfAttrs{
 		IfIndex:       link.Attrs().Index,
 		IfName:        link.Attrs().Name,
@@ -151,7 +164,7 @@ func (m *LinuxNetworkMonitor) ifAttrsFromLink(link netlink.Link) IfAttrs {
 		IsLoopback:    (link.Attrs().Flags & net.FlagLoopback) != 0,
 		WithBroadcast: (link.Attrs().Flags & net.FlagBroadcast) != 0,
 		AdminUp:       (link.Attrs().Flags & net.FlagUp) != 0,
-		LowerUp:       link.Attrs().OperState == netlink.OperUp,
+		LowerUp:       lowerUP,
 		Enslaved:      link.Attrs().MasterIndex != 0,
 		MasterIfIndex: link.Attrs().MasterIndex,
 		MTU:           uint16(link.Attrs().MTU),


### PR DESCRIPTION
`wwan*` interfaces of cellular modems do not seem to have operational state reported. Instead, we can use `IFF_LOWERUP` flag to determine if a modem is connected and interface has active link to transmit packets over.
Note that `ip link` uses the same IFF flag to determine if "LOWER_UP" should be printed for a given interface.

For other types of interfaces, I think it still makes sense to continue using operational state (if available) to evaluate link status, because it encompasses additional information related to higher levels of the network stack and can be even edited by userspace application controlling the interface (e.g. 802.1X implemented in userspace).

More info: https://docs.kernel.org/networking/operstates.html