### PR TITLE
Fix missed attestation

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -534,6 +534,13 @@ func triggerEdgeNodeCertEvent(ctxPtr *zedagentContext) {
 	}
 }
 
+func triggerEdgeNodeCertDelayedEvent(ctxPtr *zedagentContext, d time.Duration) {
+	go func() {
+		time.Sleep(d)
+		triggerEdgeNodeCertEvent(ctxPtr)
+	}()
+}
+
 func convertLocalToApiHashAlgo(algo types.CertHashType) evecommon.HashAlgorithm {
 	switch algo {
 	case types.CertHashTypeSha256First16:

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -2503,6 +2503,13 @@ func getDeferredSentHandlerFunction(ctx *zedagentContext) *zedcloud.SentHandlerF
 					log.Functionf("sendAttestReqProtobuf: Controller SenderStatusNotFound")
 					potentialUUIDUpdate(ctx.getconfigCtx)
 				}
+				if !ctx.publishedEdgeNodeCerts {
+					// Attestation request does not clog the send queue (issued
+					// with the `ignoreErr` set to true), but once fails has to
+					// be repeated in reasonable time to avoid tight fail-repeat
+					// loop.
+					triggerEdgeNodeCertDelayedEvent(ctx, 10*time.Second)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
92c4e9d68063 ("Stale signing cert should not block sending device info") introduced a problem of missing EVE certs on the controller side if very first attestation request fails: specified commit ignores a send error of the attestation request and does not repeat attestation.

The bug can be reproduced by applying iptables rules rejecting 443 port on early boot, so that first send requests fail and attestation never happens again.

The fix is simple: on a completion callback repeat attestation in case of failure in 10 seconds delay to avoid tight fail-repeat loops.