### PR TITLE
Failover to normal SendOnIntf if nettrace fails to create HTTP client

### DIFF
--- a/pkg/pillar/go.mod
+++ b/pkg/pillar/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/jaypipes/ghw v0.8.0
 	github.com/lf-edge/edge-containers v0.0.0-20221025050409-93c34bebadd2
 	github.com/lf-edge/eve-api/go v0.0.0-20230818142341-272fc065f4cb
-	github.com/lf-edge/eve-libs v0.0.0-20230724174211-8b4b7a344f7e
+	github.com/lf-edge/eve-libs v0.0.0-20230917102118-52bfdda7819c
 	github.com/linuxkit/linuxkit/src/cmd/linuxkit v0.0.0-20220913135124-e532e7310810
 	github.com/miekg/dns v1.1.41
 	github.com/moby/sys/mountinfo v0.6.0

--- a/pkg/pillar/go.sum
+++ b/pkg/pillar/go.sum
@@ -1117,8 +1117,8 @@ github.com/lf-edge/edge-containers v0.0.0-20221025050409-93c34bebadd2 h1:ckxNk8M
 github.com/lf-edge/edge-containers v0.0.0-20221025050409-93c34bebadd2/go.mod h1:eA41YxPbZRVvewIYRzmqDB1PeLQXxCy9WQEc3AVCsPI=
 github.com/lf-edge/eve-api/go v0.0.0-20230818142341-272fc065f4cb h1:fSDuzRqRU4Pt7XskLFCGYzbuxPW2S3TVyvu+KrozpoU=
 github.com/lf-edge/eve-api/go v0.0.0-20230818142341-272fc065f4cb/go.mod h1:6XqpOM8p1HsluNIGw2ihYPYsaAisQ5CuJpbIKHXQo5w=
-github.com/lf-edge/eve-libs v0.0.0-20230724174211-8b4b7a344f7e h1:zygnv38+Epha/+Rj11gaAhhdcXESib9Nu27859h2wdo=
-github.com/lf-edge/eve-libs v0.0.0-20230724174211-8b4b7a344f7e/go.mod h1:KzTF3OSzmy0ZFzY7+rKMAz3B5Vka+vodOci7aioNgJE=
+github.com/lf-edge/eve-libs v0.0.0-20230917102118-52bfdda7819c h1:0Alj0xMI3pTlP6za9GRiczQNCp7Gp/cuxvqUcTJefcw=
+github.com/lf-edge/eve-libs v0.0.0-20230917102118-52bfdda7819c/go.mod h1:KzTF3OSzmy0ZFzY7+rKMAz3B5Vka+vodOci7aioNgJE=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=

--- a/pkg/pillar/vendor/modules.txt
+++ b/pkg/pillar/vendor/modules.txt
@@ -481,7 +481,7 @@ github.com/lf-edge/eve-api/go/logs
 github.com/lf-edge/eve-api/go/metrics
 github.com/lf-edge/eve-api/go/profile
 github.com/lf-edge/eve-api/go/register
-# github.com/lf-edge/eve-libs v0.0.0-20230724174211-8b4b7a344f7e
+# github.com/lf-edge/eve-libs v0.0.0-20230917102118-52bfdda7819c
 ## explicit; go 1.20
 github.com/lf-edge/eve-libs/depgraph
 github.com/lf-edge/eve-libs/nettrace


### PR DESCRIPTION
In a rare case that nettrace fails to create HTTP client and establish network tracing for whatever reason, it is more reasonable to simply failover to running send operation without network tracing rather than failing the request completely. After all, nettrace is not essential and only helps with debugging of network issues.