### PR TITLE
zedrouter/ipam: drop interface number that produces IP outside DHCP range

### DIFF
--- a/pkg/pillar/cmd/zedrouter/ipam.go
+++ b/pkg/pillar/cmd/zedrouter/ipam.go
@@ -135,6 +135,18 @@ func (z *zedrouter) lookupOrAllocateIPv4ForVIF(niStatus *types.NetworkInstanceSt
 				niStatus.DhcpRange.Start, niStatus.DhcpRange.End)
 			z.log.Errorf("lookupOrAllocateIPv4(NI:%v, app:%v): %v",
 				networkID, appID, err)
+			// Release this interface number, it produces IP address outside the range
+			// anyway. Once another already deployed app is deleted and its IP allocations
+			// are freed, retryTimer will call handleAppNetworkCreate for this app
+			// again and it will reuse interface number(s) of the deleted app, which
+			// will then produce a valid IP address fitting the DHCP range.
+			// Otherwise, zedrouter would just try to use the same IP address outside
+			// the DHCP range and fail repeatedly, even after there is free IP available.
+			err2 := z.freeAppIntfNum(networkID, appID, ulStatus.IfIdx)
+			if err2 != nil {
+				// Should be unreachable.
+				z.log.Error(err2)
+			}
 			return nil, err
 		}
 	}


### PR DESCRIPTION
If number allocated for app interface (aka application underlay network) produces IP address outside of DHCP range (meaning that there is no free IP address left at the moment), then the number should be freed before trying to create the app again after another app was deleted. This way zedrouter will reuse interface number from the deleted app and therefore it will also reuse freed IP address (and the retry attempt to create the new app will succeed).
Otherwise, zedrouter would just try to use the same IP address outside the DHCP range and fail repeatedly, even if there is a free IP available after deletion of another app.

This should be then backported to 10.4