### PR TITLE
debug: collect-info.sh enhancements

### DIFF
--- a/pkg/debug/scripts/collect-info.sh
+++ b/pkg/debug/scripts/collect-info.sh
@@ -15,7 +15,7 @@ VERSION=7
 # still attempt to install those packages.
 PKG_DEPS="procps tar dmidecode iptables dhcpcd"
 
-DATE=$(date -Is)
+DATE=$(date "+%Y-%m-%d-%H-%M-%S")
 INFO_DIR="eve-info-v$VERSION-$DATE"
 TARBALL_FILE="/persist/$INFO_DIR.tar.gz"
 

--- a/pkg/debug/scripts/collect-info.sh
+++ b/pkg/debug/scripts/collect-info.sh
@@ -190,12 +190,13 @@ collect_pillar_backtraces()
 cp "${0}" "$DIR"
 
 # Have to chroot, lsusb does not work from this container
-echo "- lsusb, dmesg, ps, lspci, lsblk, lshw, lsof, lsmod, logread, dmidecode"
+echo "- lsusb, dmesg, ps, lspci, lsblk, lshw, lsof, lsmod, logread, dmidecode, ls -lRa /dev, free"
 chroot /hostfs lsusb -vvv    > "$DIR/lsusb-vvv"
 chroot /hostfs lsusb -vvv -t > "$DIR/lsusb-vvv-t"
 
 dmesg         > "$DIR/dmesg"
-ps -ef        > "$DIR/ps-ef"
+ps -xao uid,pid,ppid,vsz,rss,c,pcpu,pmem,stime,tname,stat,time,cmd \
+              > "$DIR/ps-xao"
 lspci -vvv    > "$DIR/lspci-vvv"
 lspci -vvv -t > "$DIR/lspci-vvv-t"
 lsblk -a      > "$DIR/lsblk-a"
@@ -204,14 +205,18 @@ lsof          > "$DIR/lsof"
 lsmod         > "$DIR/lsmod"
 logread       > "$DIR/logread"
 dmidecode     > "$DIR/dmidecode"
+ls -lRa /dev  > "$DIR/ls-lRa-dev"
+free          > "$DIR/free"
 
-echo "- vmallocinfo, slabinfo, zoneinfo, mounts, vmstat, cpuinfo"
+echo "- vmallocinfo, slabinfo, meminfo, zoneinfo, mounts, vmstat, cpuinfo, iomem"
 cat /proc/vmallocinfo > "$DIR/vmallocinfo"
 cat /proc/slabinfo    > "$DIR/slabinfo"
+cat /proc/meminfo     > "$DIR/meminfo"
 cat /proc/zoneinfo    > "$DIR/zoneinfo"
 cat /proc/mounts      > "$DIR/mounts"
 cat /proc/vmstat      > "$DIR/vmstat"
 cat /proc/cpuinfo     > "$DIR/cpuinfo"
+cat /proc/iomem       > "$DIR/iomem"
 
 echo "- qemu affinities"
 qemu-affinities.sh    > "$DIR/qemu-affinities"
@@ -236,12 +241,13 @@ find /sys/kernel/security -name "tpm*" | while read -r TPM; do
     fi
 done
 
-ln -s /persist/status   "$DIR/persist-status"
-ln -s /persist/log      "$DIR/persist-log"
-ln -s /persist/newlog   "$DIR/persist-newlog"
-ln -s /persist/netdump  "$DIR/persist-netdump"
-ln -s /persist/kcrashes "$DIR/persist-kcrashes"
-ln -s /run              "$DIR/root-run"
+ln -s /persist/status       "$DIR/persist-status"
+ln -s /persist/log          "$DIR/persist-log"
+ln -s /persist/newlog       "$DIR/persist-newlog"
+ln -s /persist/netdump      "$DIR/persist-netdump"
+ln -s /persist/kcrashes     "$DIR/persist-kcrashes"
+ln -s /run                  "$DIR/root-run"
+cp -r /sys/fs/cgroup/memory "$DIR/sys-fs-cgroup-memory" >/dev/null 2>&1
 
 # Network part
 collect_network_info


### PR DESCRIPTION
The PR does two things:

1. Change date format. Exclude colon symbol from the date format which is the name  of the result tarball, because tar utility complains with the following error on attempt to extract the folder:
    
       tar: Cannot connect to eve-info-v7-2023-09-22T14\: resolve failed
    
Now the resulting tarball name will be as follows:
    
       eve-info-v8-Tue-26-Sep-2023-10-03-18.tar.gz
    
which does not cause any nasty errors.

2. Add read-logs mode. We need a very simple command which can sort and read gzipped logs in one looooong sheet, which can be redirected to a JSON file and processed afterwards. Here it is: call collect-info.sh from the extracted tarball on your machine.

    ```collect-info.sh          : reads all (device and all applications logs) and outputs in JSON```

    ```collect-info.sh -d       : reads device logs and outputs in JSON```

    ```collect-info.sh -a UUID  : reads application logs and outputs in JSON```

3. Add a few additional command and files outputs: ls -la /dev/, free, vmstat, iomem, /sys/fs/cgroup/memory

