### PR TITLE
Use 'defer' to simplify handling of AppNetworkStatus pending flags

### DIFF
--- a/pkg/pillar/cmd/zedrouter/appnetwork.go
+++ b/pkg/pillar/cmd/zedrouter/appnetwork.go
@@ -141,8 +141,6 @@ func (z *zedrouter) doActivateAppNetwork(config types.AppNetworkConfig,
 
 	// Update AppNetwork and NetworkInstance status.
 	status.Activated = true
-	status.PendingAdd = false
-	status.PendingModify = false
 	z.publishAppNetworkStatus(status)
 	z.updateNIStatusAfterAppNetworkActivate(status)
 
@@ -308,7 +306,6 @@ func (z *zedrouter) doUpdateActivatedAppNetwork(oldConfig, newConfig types.AppNe
 	// Update app network status as well as status of connected network instances.
 	z.processAppConnReconcileStatus(appConnRecStatus, status)
 	z.reloadStatusOfAssignedIPs(status)
-	status.PendingModify = false
 	z.publishAppNetworkStatus(status)
 	z.updateNIStatusAfterAppNetworkActivate(status)
 }
@@ -336,8 +333,6 @@ func (z *zedrouter) doInactivateAppNetwork(config types.AppNetworkConfig,
 
 	// Update AppNetwork and NetworkInstance status.
 	status.Activated = false
-	status.PendingModify = false
-	status.PendingDelete = false
 	z.updateNIStatusAfterAppNetworkInactivate(status)
 	z.removeAssignedIPsFromAppNetStatus(status)
 	z.publishAppNetworkStatus(status)


### PR DESCRIPTION
Currently, we have to remember to set `PendingAdd`/`PendingModify` inside `AppNetworkStatus` to false just before the corresponding handler returns (to signal completed operation). However, there are few error branches where we forgot to clear the pending flag (e.g. when IP allocation for VIF fails). This causes zedmanager to just wait and not report the error published inside the `AppNetworkStatus`.
Instead of fixing this case-by-case, let's take advantage of `defer` to make sure that we will never forget to clear the pending flag, even if a new branch with return statement is added in the future.