### PR TITLE
Remove stdout redirect

### DIFF
--- a/pkg/pillar/agentlog/agentlog_test.go
+++ b/pkg/pillar/agentlog/agentlog_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub/socketdriver"
 	"github.com/lf-edge/eve/pkg/pillar/types"
-	"github.com/lf-edge/eve/pkg/pillar/utils/file"
-	"github.com/satori/go.uuid"
+	utils "github.com/lf-edge/eve/pkg/pillar/utils/file"
+	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
@@ -101,13 +101,13 @@ func TestPubsubLog(t *testing.T) {
 		t.Logf("Required directories not writeable; SKIP")
 		return
 	}
-	defaultLogger, defaultLog := agentlog.InitNoRedirect(defaultAgent)
+	defaultLogger, defaultLog := agentlog.Init(defaultAgent)
 	// how do we check this appears in log?
 	defaultLogger.Infof("defaultLogger")
 	defaultLog.Noticef("defaultLog")
 	logrus.Infof("logrus")
 
-	pubLogger, pubLog := agentlog.InitNoRedirect(publisherAgent)
+	pubLogger, pubLog := agentlog.Init(publisherAgent)
 	// pubLogger.SetLevel(logrus.TraceLevel)
 	pubPs := pubsub.New(
 		&socketdriver.SocketDriver{
@@ -124,7 +124,7 @@ func TestPubsubLog(t *testing.T) {
 		t.Fatalf("unable to publish: %v", err)
 	}
 
-	subLogger, subLog := agentlog.InitNoRedirect(subscriberAgent)
+	subLogger, subLog := agentlog.Init(subscriberAgent)
 	// subLogger.SetLevel(logrus.TraceLevel)
 	subPs := pubsub.New(
 		&socketdriver.SocketDriver{

--- a/pkg/pillar/cmd/volumemgr/blob_test.go
+++ b/pkg/pillar/cmd/volumemgr/blob_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub/socketdriver"
 	"github.com/lf-edge/eve/pkg/pillar/types"
-	"github.com/lf-edge/eve/pkg/pillar/utils/file"
+	utils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
@@ -22,7 +22,7 @@ func TestLookupBlobStatus(t *testing.T) {
 		t.Logf("Required directories not writeable; SKIP")
 		return
 	}
-	pubLogger, pubLog := agentlog.InitNoRedirect(agentName)
+	pubLogger, pubLog := agentlog.Init(agentName)
 	pubLogger.SetLevel(logrus.InfoLevel)
 	pubPs := pubsub.New(
 		&socketdriver.SocketDriver{


### PR DESCRIPTION
We used to redirect stdout for each individual service to a file in our persistant storage, but this way these messages are not written into the logs and it's easy to forget to check the file. By not redirecting the messages we make sure all prints are available in our logs.
I didn't find any issues while manually testing this change and I made sure that the output of `fmt.Print` now lands in our logs and is further visible in Kibana.

This PR also contains a small bug fix to the following problem:
The function dumpStacks takes a file path as parameter, but was given the agent name, thus resulting in saving the stack dumps in a local file.