### PR TITLE
debug: spec.sh: Express memory in MB instead of GB

### DIFF
--- a/pkg/debug/spec.sh
+++ b/pkg/debug/spec.sh
@@ -217,10 +217,10 @@ get_modem_atport() {
 
 if [ -e /dev/xen ]; then
    CPUS=$(eve exec xen-tools xl info | grep nr_cpus | cut -f2 -d:)
-   MEM=$(( $(eve exec xen-tools xl info | grep total_memory | cut -f2 -d:) / 1024 ))
+   MEM=$(( $(eve exec xen-tools xl info | grep total_memory | cut -f2 -d:) ))
 else
    CPUS=$(grep -c '^processor.*' < /proc/cpuinfo)
-   MEM=$(awk '/MemTotal:/ { print int($2 / 1048576); }' < /proc/meminfo)
+   MEM=$(awk '/MemTotal:/ { print int($2 / 1024); }' < /proc/meminfo)
 fi
 
 DISK=$(lsblk -b  | grep disk | awk '{ total += $4; } END { print int(total/(1024*1024*1024)); }')
@@ -233,7 +233,7 @@ cat <<__EOT__
   "productURL": "$(cat /persist/status/hardwaremodel || cat /config/hardwaremodel)",
   "productStatus": "production",
   "attr": {
-    "memory": "${MEM}G",
+    "memory": "${MEM}M",
     "storage": "${DISK}G",
     "Cpus": "${CPUS}",
     "watchdog": "${WDT}",


### PR DESCRIPTION
The spec.sh script gets the amount of available memory of the device from /proc/meminfo, which contains the total amount of installed memory minus the non-usable memory (reserved areas, etc) in KB. Then, awk is used to divide the value by 1024^2 and get the final value in GB. However, the integer division will round down the final value, so if the final value should be, for instance, 3.7GB, it will be converted to 3GB, missing around 700MB of usable RAM memory.

This commit changes the spec.sh to provide the total amount of available memory in MB instead of GB in order to increase the granularity and avoid missing substantial amounts of usable memory.