### PR TITLE
bsp-imx: Update U-Boot to support phyBOARD-Pollux 4GB model

### DIFF
--- a/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0001-Add-support-to-Phytec-s-phyBOARD-Pollux-board.patch
+++ b/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0001-Add-support-to-Phytec-s-phyBOARD-Pollux-board.patch
@@ -1,0 +1,10518 @@
+From 615fbd781890ae228b5eb0d936ab13bb8dde6c7f Mon Sep 17 00:00:00 2001
+From: Yannic Moog <y.moog@phytec.de>
+Date: Tue, 18 Jul 2023 15:27:36 +0200
+Subject: [PATCH 01/25] Add support to Phytec's phyBOARD-Pollux board
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This commit squashes a series of commits taken from:
+
+Repository: git://git.phytec.de/u-boot-imx
+Branch:     v2022.04_2.2.1-phy2
+
+The following original commits were ported:
+
+0313a0d9564 BSPIMX8M-1955 configs: phycore-imx8mp_defconfig: add redundand env
+d67b8f469dd board: phytec: phycore_imx8mp: Make RAM size configuration fix
+98ac472b972 board: phytec: phycore_imx8mm: Make RAM size configuration fix
+e7fd0ea7c90 BSPIMX8M-2946 board: phytec: phycore_imx8mm: spl: refactor spl_dram_init code
+b27a4e67c74 BSPIMX8M-2946 board: phytec: phycore_imx8mp: spl: refactor spl_dram_init code
+c19ed408eab arm: dts: imx8mm-phyboard-polis-rdk-u-boot: sync dt with tauri
+29e684759d6 configs: phycore-imx8m{m, p}_defconfig: add CMD_ERASEENV
+a9d713c61c2 configs: phytec imx8m* defconfig: enable DM_MMC
+7a2faf21efe BSPIMX8M-2927 board: phytec: Add initial support for phyGATE-Tauri-L
+8d448da1ccf include: configs: phycore_imx8mn: Add static ip for nfs
+09dce31b976 board: phycore_imx8mp: spl: Add 1GB RAM Timings
+c5f0c50b682 BSPIMX8M-2936 configs: phycore-imx8m{m, n, p}_defconfig: change SYS_LOAD_ADDR
+c1c1ba1cd12 BSPIMX8M-2894: board: phycore_imx8mp: spl: Add 1GB and 4GB RAM timings
+b95f95b91be board: phycore_imx8mn: spl: remove erroneous ddr_init call
+4517562b96d BSPIMX8M-2379 include: configs: phycore_imx8mp: Set PHYS_SDRAM macros to 4GB
+97734f61145 BSPIMX8M-2603: include: configs: phycore_imx8mm: Set PHYS_SDRAM macros to 4GB
+dda8af8ba7b BSPIMX8M-2429 board: phycore_imx8mp: spl.c: add 4GB 2GHz RAM timings
+861c34ac233 board: phycore_imx8mp: spl.c: fix 2GB 2GHz timing values
+5b36bce6b76 include: configs: phycore_imx8m{m, n, p}: Fix netmask value
+b93e4ce34d4 BSPIMX8M-2893 board: phycore_imx8mn: enable EEPROM SoM detection
+5f4ebadffdf board: phycore_imx8mm: spl: remove unused variable
+a80d7e78e7b BSPIMX8M-2893 board: phycore_imx8mm: spl: add 1 and 4GB RAM timings
+f165fa1d99d (tag: v2022.04_2.2.1-phy1) BSPIMX8M-2892 board: phytec: Add initial support for phyCORE-i.MX8MN
+7faebebe989 UPSTREAM: u-boot-initial-env: rework make target
+0f854a1e78d UPSTREAM: Makefile: Sort u-boot-initial-env output
+4e19e64bc44 arm: dts: Sync imx8mp-phyboard-pollux-rdk from linux-imx
+19fec492f71 include: configs: phycore_imx8mp: Add static ip for nfs
+35bc72bde09 configs: phycore-imx8mp: Enable automatic fsck during boot
+9bb29b8158a board: phycore-imx8mp: Add and align fec support
+d06e62ddf0a include: configs: phycore_imx8mm: Add static ip for nfs
+993e55ce354 configs: phycore-imx8mm: Enable automatic fsck during boot
+a5077872344 configs: phycore_imx8mm: Set static ip address
+2fc9de9acfb BACKPORT: imx: imx8m[m/p]_phycore: Enable DM_SERIAL
+126291f970e board: phytec: phycore_imx8mm: Add eeprom detection setup
+84a6ebe46d3 board: phytec: phycore-imx8mp: Calculate RAM size in U-Boot
+14bc3ae4103 board: phytec: phycore_imx8mm: Calculate RAM size in U-Boot
+2816f72c84c ddr: imx8m: workaround old spreadsheets not initializing ADDRMAP7
+a75dc61cfb6 arm: imx: mmdc_size: Ignore ADDRMAP8 for non-DDR4
+d666daae3f3 arm: mach-imx: mmdc_size: imx8m: Update check for imx8mn
+9a0f76b7a24 imx: mx8m: add imx8m_ddrc_sdram_size
+c09312be014 arm: dts: imx8mm-phyboard-polis-rdk: Sync u-boot dts with kernel dts
+1ad79cda7a7 FROMLIST: arm: dts: imx8mm-phyboard-polis-rdk: Sync dts files with kernel
+25a8b846592 arm: mach-imx: spl: Fail silently if no RCU node is found
+5f1c95ce44c FROMLIST: board: phytec: phycore_imx8mp: Add 4000MTS RAM timings based on PCB rev
+b729acb6d80 FROMLIST: board: phytec: common: phytec_som_detection: Add helper for PCB revision
+741136f61e5 FROMLIST: board: phytec: phycore_imx8mp: Update 2GB RAM Timings
+19cccb40e21 FROMLIST: board: phytec: phycore-imx8mp: Add EEPROM detection initialisation
+0187148006d FROMLIST: board: phytec: common: Add imx8m specific EEPROM detection support
+63dd9bbeac8 FROMLIST: board: phytec: Add common PHYTEC SoM detection
+718611057c9 BACKPORT: tpm: Add a proper Kconfig option for crc8 in SPL
+6d126cd92e2 BACKPORT: board: phytec: phycore_imx8mm: Update lpddr4_timing
+bf906283395 BACKPORT: configs: phycore-imx8mm_defconfig: Enable LTO
+aa3c01582c0 BACKPORT: doc: board: phytec: add phycore_imx8mp
+0e3e1d333e8 BACKPORT: doc: board: phytec: add phycore_imx8mm
+
+Signed-off-by: Renê de Souza Pinto <rene@renesp.com.br>
+---
+ Makefile                                      |    9 +-
+ arch/arm/dts/Makefile                         |    4 +-
+ ... => imx8mm-phyboard-polis-rdk-u-boot.dtsi} |   12 +
+ arch/arm/dts/imx8mm-phyboard-polis-rdk.dts    |  573 +++++++
+ arch/arm/dts/imx8mm-phycore-som.dtsi          |  462 +++++
+ arch/arm/dts/imx8mm-phygate-tauri-u-boot.dtsi |   83 +
+ arch/arm/dts/imx8mm-phygate-tauri.dts         |  465 +++++
+ .../arm/dts/imx8mn-phyboard-polis-u-boot.dtsi |   83 +
+ arch/arm/dts/imx8mn-phyboard-polis.dts        |  485 ++++++
+ arch/arm/dts/imx8mn-phycore-som.dtsi          |  437 +++++
+ arch/arm/dts/imx8mn-u-boot.dtsi               |  183 ++
+ arch/arm/dts/imx8mp-phyboard-pollux-rdk.dts   |  379 ++++-
+ arch/arm/dts/imx8mp-phycore-som.dtsi          |  218 ++-
+ arch/arm/dts/phycore-imx8mm.dts               |  287 ----
+ arch/arm/include/asm/arch-imx8m/ddr.h         |    1 +
+ arch/arm/include/asm/mach-imx/sys_proto.h     |   10 +
+ arch/arm/mach-imx/Makefile                    |    1 +
+ arch/arm/mach-imx/imx8m/Kconfig               |    8 +
+ arch/arm/mach-imx/mmdc_size.c                 |  196 +++
+ arch/arm/mach-imx/spl.c                       |    1 -
+ board/phytec/common/Kconfig                   |   13 +
+ board/phytec/common/Makefile                  |   11 +
+ board/phytec/common/imx8m_som_detection.c     |  169 ++
+ board/phytec/common/imx8m_som_detection.h     |   54 +
+ board/phytec/common/phytec_som_detection.c    |  203 +++
+ board/phytec/common/phytec_som_detection.h    |  109 ++
+ board/phytec/phycore_imx8mm/Kconfig           |   30 +
+ board/phytec/phycore_imx8mm/MAINTAINERS       |   20 +-
+ board/phytec/phycore_imx8mm/lpddr4_timing.c   | 1511 +++++++++--------
+ board/phytec/phycore_imx8mm/phycore-imx8mm.c  |   10 +
+ board/phytec/phycore_imx8mm/spl.c             |   68 +-
+ board/phytec/phycore_imx8mn/Kconfig           |   15 +
+ board/phytec/phycore_imx8mn/MAINTAINERS       |    9 +
+ board/phytec/phycore_imx8mn/Makefile          |   11 +
+ .../phytec/phycore_imx8mn/imximage-8mn-sd.cfg |    9 +
+ board/phytec/phycore_imx8mn/lpddr4_timing.c   | 1440 ++++++++++++++++
+ board/phytec/phycore_imx8mn/phycore-imx8mn.c  |   53 +
+ board/phytec/phycore_imx8mn/spl.c             |  143 ++
+ board/phytec/phycore_imx8mp/Kconfig           |   37 +
+ board/phytec/phycore_imx8mp/lpddr4_timing.c   |  408 +++--
+ board/phytec/phycore_imx8mp/phycore-imx8mp.c  |   10 +
+ board/phytec/phycore_imx8mp/spl.c             |   85 +-
+ configs/imx8mm-phygate-tauri_defconfig        |  124 ++
+ configs/phycore-imx8mm_defconfig              |   11 +-
+ configs/phycore-imx8mn_defconfig              |  146 ++
+ configs/phycore-imx8mp_defconfig              |    7 +-
+ doc/board/index.rst                           |    1 +
+ doc/board/phytec/index.rst                    |   10 +
+ doc/board/phytec/phycore-imx8mm.rst           |   60 +
+ doc/board/phytec/phycore-imx8mp.rst           |   60 +
+ drivers/ddr/imx/imx8m/ddr_init.c              |   17 +
+ drivers/ddr/imx/phy/helper.c                  |    6 +
+ include/configs/phycore_imx8mm.h              |   20 +-
+ include/configs/phycore_imx8mn.h              |  105 ++
+ include/configs/phycore_imx8mp.h              |   20 +-
+ lib/Kconfig                                   |   18 +
+ lib/Makefile                                  |    4 +-
+ tools/.gitignore                              |    1 +
+ tools/Makefile                                |    4 +
+ tools/printinitialenv.c                       |   44 +
+ 60 files changed, 7620 insertions(+), 1353 deletions(-)
+ rename arch/arm/dts/{phycore-imx8mm-u-boot.dtsi => imx8mm-phyboard-polis-rdk-u-boot.dtsi} (87%)
+ create mode 100644 arch/arm/dts/imx8mm-phyboard-polis-rdk.dts
+ create mode 100644 arch/arm/dts/imx8mm-phycore-som.dtsi
+ create mode 100644 arch/arm/dts/imx8mm-phygate-tauri-u-boot.dtsi
+ create mode 100644 arch/arm/dts/imx8mm-phygate-tauri.dts
+ create mode 100644 arch/arm/dts/imx8mn-phyboard-polis-u-boot.dtsi
+ create mode 100644 arch/arm/dts/imx8mn-phyboard-polis.dts
+ create mode 100644 arch/arm/dts/imx8mn-phycore-som.dtsi
+ create mode 100644 arch/arm/dts/imx8mn-u-boot.dtsi
+ delete mode 100644 arch/arm/dts/phycore-imx8mm.dts
+ create mode 100644 board/phytec/common/Kconfig
+ create mode 100644 board/phytec/common/Makefile
+ create mode 100644 board/phytec/common/imx8m_som_detection.c
+ create mode 100644 board/phytec/common/imx8m_som_detection.h
+ create mode 100644 board/phytec/common/phytec_som_detection.c
+ create mode 100644 board/phytec/common/phytec_som_detection.h
+ create mode 100644 board/phytec/phycore_imx8mn/Kconfig
+ create mode 100644 board/phytec/phycore_imx8mn/MAINTAINERS
+ create mode 100644 board/phytec/phycore_imx8mn/Makefile
+ create mode 100644 board/phytec/phycore_imx8mn/imximage-8mn-sd.cfg
+ create mode 100644 board/phytec/phycore_imx8mn/lpddr4_timing.c
+ create mode 100644 board/phytec/phycore_imx8mn/phycore-imx8mn.c
+ create mode 100644 board/phytec/phycore_imx8mn/spl.c
+ create mode 100644 configs/imx8mm-phygate-tauri_defconfig
+ create mode 100644 configs/phycore-imx8mn_defconfig
+ create mode 100644 doc/board/phytec/index.rst
+ create mode 100644 doc/board/phytec/phycore-imx8mm.rst
+ create mode 100644 doc/board/phytec/phycore-imx8mp.rst
+ create mode 100644 include/configs/phycore_imx8mn.h
+ create mode 100644 tools/printinitialenv.c
+
+diff --git a/Makefile b/Makefile
+index 33615b8706c..b623c1ec2a8 100644
+--- a/Makefile
++++ b/Makefile
+@@ -2445,10 +2445,13 @@ endif
+ 	$(Q)$(MAKE) -f $(srctree)/scripts/Makefile.modpost
+ 
+ quiet_cmd_genenv = GENENV  $@
+-cmd_genenv = $(OBJCOPY) --dump-section .rodata.default_environment=$@ env/common.o; \
+-	sed --in-place -e 's/\x00/\x0A/g' $@
++cmd_genenv = \
++	$(objtree)/tools/printinitialenv | \
++	sed -e '/^\s*$$/d' | \
++	sort --field-separator== -k1,1 --stable -o $@
+ 
+-u-boot-initial-env: u-boot.bin
++u-boot-initial-env: $(env_h) FORCE
++	$(Q)$(MAKE) $(build)=tools $(objtree)/tools/printinitialenv
+ 	$(call if_changed,genenv)
+ 
+ # Consistency checks
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+index 709fdaecd7d..887af7bb83f 100644
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -974,6 +974,8 @@ dtb-$(CONFIG_ARCH_IMX8M) += \
+ 	imx8mm-icore-mx8mm-edimm2.2.dtb \
+ 	imx8mm-kontron-n801x-s.dtb \
+ 	imx8mm-kontron-n801x-s-lvds.dtb \
++	imx8mm-phyboard-polis-rdk.dtb \
++	imx8mm-phygate-tauri.dtb \
+ 	imx8mm-venice.dtb \
+ 	imx8mm-venice-gw71xx-0x.dtb \
+ 	imx8mm-venice-gw72xx-0x.dtb \
+@@ -981,13 +983,13 @@ dtb-$(CONFIG_ARCH_IMX8M) += \
+ 	imx8mm-venice-gw7901.dtb \
+ 	imx8mm-venice-gw7902.dtb \
+ 	imx8mm-verdin.dtb \
+-	phycore-imx8mm.dtb \
+ 	imx8mn-ddr3l-evk.dtb \
+ 	imx8mn-ddr4-evk.dtb \
+ 	imx8mn-ddr4-ab2.dtb \
+ 	imx8mq-cm.dtb \
+ 	imx8mn-evk.dtb \
+ 	imx8mn-ab2.dtb \
++	imx8mn-phyboard-polis.dtb \
+ 	imx8mn-var-som-symphony.dtb \
+ 	imx8mn-venice.dtb \
+ 	imx8mn-venice-gw7902.dtb \
+diff --git a/arch/arm/dts/phycore-imx8mm-u-boot.dtsi b/arch/arm/dts/imx8mm-phyboard-polis-rdk-u-boot.dtsi
+similarity index 87%
+rename from arch/arm/dts/phycore-imx8mm-u-boot.dtsi
+rename to arch/arm/dts/imx8mm-phyboard-polis-rdk-u-boot.dtsi
+index 7c2dfb4a273..718750649f3 100644
+--- a/arch/arm/dts/phycore-imx8mm-u-boot.dtsi
++++ b/arch/arm/dts/imx8mm-phyboard-polis-rdk-u-boot.dtsi
+@@ -14,6 +14,14 @@
+ 	};
+ };
+ 
++&pinctrl_i2c1 {
++	u-boot,dm-spl;
++};
++
++&pinctrl_i2c1_gpio {
++	u-boot,dm-spl;
++};
++
+ &pinctrl_uart3 {
+ 	u-boot,dm-spl;
+ };
+@@ -54,6 +62,10 @@
+ 	u-boot,dm-spl;
+ };
+ 
++&i2c1 {
++	u-boot,dm-spl;
++};
++
+ &uart3 {
+ 	u-boot,dm-spl;
+ };
+diff --git a/arch/arm/dts/imx8mm-phyboard-polis-rdk.dts b/arch/arm/dts/imx8mm-phyboard-polis-rdk.dts
+new file mode 100644
+index 00000000000..fd3650a5a6f
+--- /dev/null
++++ b/arch/arm/dts/imx8mm-phyboard-polis-rdk.dts
+@@ -0,0 +1,573 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Copyright (C) 2022 PHYTEC Messtechnik GmbH
++ * Author: Teresa Remmet <t.remmet@phytec.de>
++ */
++
++/dts-v1/;
++
++#include <dt-bindings/interrupt-controller/irq.h>
++#include <dt-bindings/leds/common.h>
++#include "imx8mm-phycore-som.dtsi"
++
++/ {
++	model = "PHYTEC phyBOARD-Polis-i.MX8MM RDK";
++	compatible = "phytec,imx8mm-phyboard-polis-rdk",
++		     "phytec,imx8mm-phycore-som", "fsl,imx8mm";
++
++	chosen {
++		stdout-path = &uart3;
++	};
++
++	bt_osc_32k: bt-lp-clock {
++		compatible = "fixed-clock";
++		clock-frequency = <32768>;
++		clock-output-names = "bt_osc_32k";
++		#clock-cells = <0>;
++	};
++
++	can_osc_40m: can-clock {
++		compatible = "fixed-clock";
++		clock-frequency = <40000000>;
++		clock-output-names = "can_osc_40m";
++		#clock-cells = <0>;
++	};
++
++	fan {
++		compatible = "gpio-fan";
++		gpios = <&gpio4 8 GPIO_ACTIVE_HIGH>;
++		gpio-fan,speed-map = <0     0
++				      13000 1>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_fan>;
++		#cooling-cells = <2>;
++	};
++
++	leds {
++		compatible = "gpio-leds";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_leds>;
++
++		led-0 {
++			color = <LED_COLOR_ID_RED>;
++			function = LED_FUNCTION_DISK;
++			gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "mmc2";
++		};
++
++		led-1 {
++			color = <LED_COLOR_ID_BLUE>;
++			function = LED_FUNCTION_DISK;
++			gpios = <&gpio1 15 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "mmc1";
++		};
++
++		led-2 {
++			color = <LED_COLOR_ID_GREEN>;
++			function = LED_FUNCTION_CPU;
++			gpios = <&gpio1 14 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "heartbeat";
++		};
++	};
++
++	usdhc1_pwrseq: pwr-seq {
++		compatible = "mmc-pwrseq-simple";
++		post-power-on-delay-ms = <100>;
++		power-off-delay-us = <60>;
++		reset-gpios = <&gpio2 7 GPIO_ACTIVE_LOW>;
++	};
++
++	reg_can_en: regulator-can-en {
++		compatible = "regulator-fixed";
++		gpio = <&gpio1 9 GPIO_ACTIVE_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_can_en>;
++		regulator-max-microvolt = <3300000>;
++		regulator-min-microvolt = <3300000>;
++		regulator-name = "CAN_EN";
++		startup-delay-us = <20>;
++	};
++
++	reg_mipi_1p0: regulator-mipi-1p0 {
++		compatible = "regulator-fixed";
++		regulator-name = "mipi_1p0";
++		regulator-min-microvolt = <1000000>;
++		regulator-max-microvolt = <1000000>;
++	};
++
++	reg_usb_otg1_vbus: regulator-usb-otg1 {
++		compatible = "regulator-fixed";
++		gpio = <&gpio1 12 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_usbotg1pwrgrp>;
++		regulator-name = "usb_otg1_vbus";
++		regulator-max-microvolt = <5000000>;
++		regulator-min-microvolt = <5000000>;
++	};
++
++	reg_usdhc2_vmmc: regulator-usdhc2 {
++		compatible = "regulator-fixed";
++		gpio = <&gpio2 19 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++		off-on-delay-us = <20000>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_reg_usdhc2_vmmc>;
++		regulator-max-microvolt = <3300000>;
++		regulator-min-microvolt = <3300000>;
++		regulator-name = "VSD_3V3";
++	};
++
++	reg_vcc_3v3: regulator-vcc-3v3 {
++		compatible = "regulator-fixed";
++		regulator-max-microvolt = <3300000>;
++		regulator-min-microvolt = <3300000>;
++		regulator-name = "VCC_3V3";
++	};
++};
++
++&aips4 {
++	csi-upstream@32e20000 {
++		compatible = "fsl,imx8mm-csi", "fsl,imx7-csi";
++		reg = <0x32e20000 0x1000>;
++		interrupts = <GIC_SPI 16 IRQ_TYPE_LEVEL_HIGH>;
++		clocks = <&clk IMX8MM_CLK_CSI1_ROOT>;
++		clock-names = "mclk";
++		power-domains = <&mipi_pd>;
++		dma-coherent;
++		status = "okay";
++
++		port {
++			csi_up_ep: endpoint {
++				remote-endpoint = <&mipi_csi_out_ep>;
++			};
++		};
++	};
++
++	csi1_mipi_csi: mipi-csi-upstream@32e30000 {
++		compatible = "fsl,imx8mm-mipi-csi2";
++		reg = <0x32e30000 0x1000>;
++		interrupts = <GIC_SPI 17 IRQ_TYPE_LEVEL_HIGH>;
++		clock-frequency = <500000000>;
++		clocks = <&clk IMX8MM_CLK_DISP_APB_ROOT>,
++			 <&clk IMX8MM_CLK_CSI1_ROOT>,
++			 <&clk IMX8MM_CLK_CSI1_PHY_REF>,
++			 <&clk IMX8MM_CLK_DISP_AXI_ROOT>;
++		clock-names = "pclk", "wrap", "phy", "axi";
++		power-domains = <&mipi_pd>;
++		fsl,csis-hs-settle = <9>;
++		status = "disabled";
++
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		port@0 {
++			reg = <0>;
++		};
++
++		port@1 {
++			reg = <1>;
++
++			mipi_csi_out_ep: endpoint {
++				remote-endpoint = <&csi_up_ep>;
++			};
++		};
++	};
++};
++
++&csi1_bridge {
++	status = "disabled";
++};
++
++/* SPI - CAN MCP251XFD */
++&ecspi1 {
++	cs-gpios = <&gpio5 9 GPIO_ACTIVE_LOW>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_ecspi1>;
++	status = "okay";
++
++	can0: can@0 {
++		compatible = "microchip,mcp251xfd";
++		clocks = <&can_osc_40m>;
++		interrupt-parent = <&gpio1>;
++		interrupts = <8 IRQ_TYPE_LEVEL_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_can_int>;
++		reg = <0>;
++		spi-max-frequency = <20000000>;
++		xceiver-supply = <&reg_can_en>;
++	};
++};
++
++/* TPM */
++&ecspi2 {
++	cs-gpios = <&gpio5 13 GPIO_ACTIVE_LOW>;
++	num-cs = <1>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_ecspi2>;
++	#address-cells = <1>;
++	#size-cells = <0>;
++	status = "okay";
++
++	tpm: tpm-tis@0 {
++		compatible = "tcg,tpm_tis-spi";
++		interrupt-parent = <&gpio2>;
++		interrupts = <11 IRQ_TYPE_LEVEL_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_tpm>;
++		reg = <0>;
++		spi-max-frequency = <38000000>;
++	};
++};
++
++&gpio1 {
++	gpio-line-names = "", "LED_RED", "WDOG_INT", "X_RTC_INT",
++		"", "", "", "RESET_ETHPHY",
++		"CAN_nINT", "CAN_EN", "nENABLE_FLATLINK", "",
++		"USB_OTG_VBUS_EN", "", "LED_GREEN", "LED_BLUE";
++};
++
++&gpio2 {
++	gpio-line-names = "", "", "", "",
++		"", "", "BT_REG_ON", "WL_REG_ON",
++		"BT_DEV_WAKE", "BT_HOST_WAKE", "", "",
++		"X_SD2_CD_B", "", "", "",
++		"", "", "", "SD2_RESET_B";
++};
++
++&gpio4 {
++	gpio-line-names = "", "", "", "",
++		"", "", "", "",
++		"FAN", "miniPCIe_nPERST", "", "",
++		"COEX1", "COEX2";
++};
++
++&gpio5 {
++	gpio-line-names = "", "", "", "",
++		"", "", "", "",
++		"", "ECSPI1_SS0";
++};
++
++csi1_i2c: &i2c4 {
++	clock-frequency = <400000>;
++	pinctrl-names = "default", "gpio";
++	pinctrl-0 = <&pinctrl_i2c4>;
++	pinctrl-1 = <&pinctrl_i2c4_gpio>;
++	sda-gpios = <&gpio5 21 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
++	scl-gpios = <&gpio5 20 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
++};
++
++&mipi_csi_1 {
++	status = "disabled";
++};
++
++/* PCIe */
++&pcie0 {
++	assigned-clocks = <&clk IMX8MM_CLK_PCIE1_AUX>,
++			  <&clk IMX8MM_CLK_PCIE1_PHY>,
++			  <&clk IMX8MM_CLK_PCIE1_CTRL>;
++	assigned-clock-parents = <&clk IMX8MM_SYS_PLL2_50M>,
++				 <&clk IMX8MM_SYS_PLL2_100M>,
++				 <&clk IMX8MM_SYS_PLL2_250M>;
++	assigned-clock-rates = <10000000>, <100000000>, <250000000>;
++	clocks = <&clk IMX8MM_CLK_PCIE1_ROOT>,
++		 <&clk IMX8MM_CLK_PCIE1_AUX>,
++		 <&clk IMX8MM_CLK_PCIE1_PHY>,
++		 <&clk IMX8MM_CLK_DUMMY>;
++	clock-names = "pcie", "pcie_aux", "pcie_phy", "pcie_bus";
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_pcie>;
++	reset-gpio = <&gpio4 9 GPIO_ACTIVE_LOW>;
++	status = "okay";
++};
++
++/* RTC */
++&rv3028 {
++	interrupt-parent = <&gpio1>;
++	interrupts = <3 IRQ_TYPE_LEVEL_LOW>;
++	pinctrl-0 = <&pinctrl_rtc>;
++	pinctrl-names = "default";
++	trickle-resistor-ohms = <3000>;
++	wakeup-source;
++};
++
++&snvs_pwrkey {
++	status = "okay";
++};
++
++/* UART - RS232/RS485 */
++&uart1 {
++	assigned-clocks = <&clk IMX8MM_CLK_UART1>;
++	assigned-clock-parents = <&clk IMX8MM_SYS_PLL1_80M>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_uart1>;
++	uart-has-rtscts;
++	status = "okay";
++};
++
++/* UART - Sterling-LWB Bluetooth */
++&uart2 {
++	assigned-clocks = <&clk IMX8MM_CLK_UART2>;
++	assigned-clock-parents = <&clk IMX8MM_SYS_PLL1_80M>;
++	fsl,dte-mode;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_uart2_bt>;
++	uart-has-rtscts;
++	status = "okay";
++
++	bluetooth {
++		compatible = "brcm,bcm43438-bt";
++		clocks = <&bt_osc_32k>;
++		clock-names = "lpo";
++		device-wakeup-gpios = <&gpio2 8 GPIO_ACTIVE_HIGH>;
++		interrupt-names = "host-wakeup";
++		interrupt-parent = <&gpio2>;
++		interrupts = <9 IRQ_TYPE_EDGE_BOTH>;
++		max-speed = <2000000>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_bt>;
++		shutdown-gpios = <&gpio2 6 GPIO_ACTIVE_HIGH>;
++		vddio-supply = <&reg_vcc_3v3>;
++	};
++};
++
++/* UART - console */
++&uart3 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_uart3>;
++	status = "okay";
++};
++
++/* USB */
++&usbotg1 {
++	adp-disable;
++	dr_mode = "otg";
++	over-current-active-low;
++	samsung,picophy-pre-emp-curr-control = <3>;
++	samsung,picophy-dc-vol-level-adjust = <7>;
++	srp-disable;
++	vbus-supply = <&reg_usb_otg1_vbus>;
++	status = "okay";
++};
++
++&usbotg2 {
++	disable-over-current;
++	dr_mode = "host";
++	samsung,picophy-pre-emp-curr-control = <3>;
++	samsung,picophy-dc-vol-level-adjust = <7>;
++	status = "okay";
++};
++
++/* SDIO - Sterling-LWB Wifi */
++&usdhc1 {
++	assigned-clocks = <&clk IMX8MM_CLK_USDHC1>;
++	assigned-clock-rates = <200000000>;
++	bus-width = <4>;
++	mmc-pwrseq = <&usdhc1_pwrseq>;
++	non-removable;
++	no-1-8-v;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_usdhc1>, <&pinctrl_wlan>;
++	#address-cells = <1>;
++	#size-cells = <0>;
++	status = "okay";
++
++	brcmf: wifi@1 {
++		compatible = "brcm,bcm4329-fmac";
++		reg = <1>;
++	};
++};
++
++/* SD-Card */
++&usdhc2 {
++	assigned-clocks = <&clk IMX8MM_CLK_USDHC2>;
++	assigned-clock-rates = <200000000>;
++	bus-width = <4>;
++	cd-gpios = <&gpio2 12 GPIO_ACTIVE_LOW>;
++	disable-wp;
++	pinctrl-names = "default", "state_100mhz", "state_200mhz";
++	pinctrl-0 = <&pinctrl_usdhc2>, <&pinctrl_usdhc2_gpio>;
++	pinctrl-1 = <&pinctrl_usdhc2_100mhz>, <&pinctrl_usdhc2_gpio>;
++	pinctrl-2 = <&pinctrl_usdhc2_200mhz>, <&pinctrl_usdhc2_gpio>;
++	vmmc-supply = <&reg_usdhc2_vmmc>;
++	vqmmc-supply = <&reg_nvcc_sd2>;
++	status = "okay";
++};
++
++&iomuxc {
++	pinctrl_bt: btgrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SD1_DATA4_GPIO2_IO6	0x00
++			MX8MM_IOMUXC_SD1_DATA6_GPIO2_IO8	0x00
++			MX8MM_IOMUXC_SD1_DATA7_GPIO2_IO9	0x00
++		>;
++	};
++
++	pinctrl_can_en: can-engrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_GPIO1_IO09_GPIO1_IO9	0x00
++		>;
++	};
++
++	pinctrl_can_int: can-intgrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_GPIO1_IO08_GPIO1_IO8	0x00
++		>;
++	};
++
++	pinctrl_ecspi1: ecspi1grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_ECSPI1_MISO_ECSPI1_MISO	0x80
++			MX8MM_IOMUXC_ECSPI1_MOSI_ECSPI1_MOSI	0x80
++			MX8MM_IOMUXC_ECSPI1_SCLK_ECSPI1_SCLK	0x80
++			MX8MM_IOMUXC_ECSPI1_SS0_GPIO5_IO9	0x00
++		>;
++	};
++
++	pinctrl_ecspi2: ecspi2grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_ECSPI2_MISO_ECSPI2_MISO    0x80
++			MX8MM_IOMUXC_ECSPI2_MOSI_ECSPI2_MOSI    0x80
++			MX8MM_IOMUXC_ECSPI2_SCLK_ECSPI2_SCLK    0x80
++			MX8MM_IOMUXC_ECSPI2_SS0_GPIO5_IO13      0x00
++		>;
++	};
++
++	pinctrl_fan: fan0grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SAI1_RXD6_GPIO4_IO8	0x16
++		>;
++	};
++
++	pinctrl_i2c4: i2c4grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_I2C4_SCL_I2C4_SCL          0x400001c2
++			MX8MM_IOMUXC_I2C4_SDA_I2C4_SDA          0x400001c2
++		>;
++	};
++
++	pinctrl_i2c4_gpio: i2c4gpiogrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_I2C4_SCL_GPIO5_IO20        0x1e2
++			MX8MM_IOMUXC_I2C4_SDA_GPIO5_IO21        0x1e2
++		>;
++	};
++
++	pinctrl_leds: leds1grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_GPIO1_IO01_GPIO1_IO1	0x16
++			MX8MM_IOMUXC_GPIO1_IO14_GPIO1_IO14	0x16
++			MX8MM_IOMUXC_GPIO1_IO15_GPIO1_IO15	0x16
++		>;
++	};
++
++	pinctrl_pcie: pciegrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SAI1_RXD7_GPIO4_IO9	0x00
++			MX8MM_IOMUXC_SAI1_TXD0_GPIO4_IO12	0x12
++			MX8MM_IOMUXC_SAI1_TXD7_GPIO4_IO19	0x12
++		>;
++	};
++
++	pinctrl_reg_usdhc2_vmmc: regusdhc2vmmcgrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SD2_RESET_B_GPIO2_IO19	0x40
++		>;
++	};
++
++	pinctrl_tpm: tpmgrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SD1_STROBE_GPIO2_IO11      0x140
++		>;
++	};
++
++	pinctrl_uart1: uart1grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SAI2_RXC_UART1_DCE_RX	0x00
++			MX8MM_IOMUXC_SAI2_RXD0_UART1_DCE_RTS_B	0x00
++			MX8MM_IOMUXC_SAI2_RXFS_UART1_DCE_TX	0x00
++			MX8MM_IOMUXC_SAI2_TXFS_UART1_DCE_CTS_B	0x00
++		>;
++	};
++
++	pinctrl_uart2_bt: uart2btgrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SAI3_RXC_UART2_DTE_RTS_B	0x00
++			MX8MM_IOMUXC_SAI3_RXD_UART2_DTE_CTS_B	0x00
++			MX8MM_IOMUXC_SAI3_TXC_UART2_DTE_RX	0x00
++			MX8MM_IOMUXC_SAI3_TXFS_UART2_DTE_TX	0x00
++		>;
++	};
++
++	pinctrl_uart3: uart3grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_UART3_RXD_UART3_DCE_RX	0x140
++			MX8MM_IOMUXC_UART3_TXD_UART3_DCE_TX	0x140
++		>;
++	};
++
++	pinctrl_usbotg1pwrgrp: usbotg1pwrgrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_GPIO1_IO12_GPIO1_IO12	0x00
++		>;
++	};
++
++	pinctrl_usdhc1: usdhc1grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SD1_CLK_USDHC1_CLK		0x182
++			MX8MM_IOMUXC_SD1_CMD_USDHC1_CMD		0xc6
++			MX8MM_IOMUXC_SD1_DATA0_USDHC1_DATA0	0xc6
++			MX8MM_IOMUXC_SD1_DATA1_USDHC1_DATA1	0xc6
++			MX8MM_IOMUXC_SD1_DATA2_USDHC1_DATA2	0xc6
++			MX8MM_IOMUXC_SD1_DATA3_USDHC1_DATA3	0xc6
++		>;
++	};
++
++	pinctrl_usdhc2_gpio: usdhc2gpiogrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SD2_CD_B_GPIO2_IO12	0x40
++		>;
++	};
++
++	pinctrl_usdhc2: usdhc2grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_GPIO1_IO04_USDHC2_VSELECT	0x1d0
++			MX8MM_IOMUXC_SD2_CLK_USDHC2_CLK		0x192
++			MX8MM_IOMUXC_SD2_CMD_USDHC2_CMD		0x1d2
++			MX8MM_IOMUXC_SD2_DATA0_USDHC2_DATA0	0x1d2
++			MX8MM_IOMUXC_SD2_DATA1_USDHC2_DATA1	0x1d2
++			MX8MM_IOMUXC_SD2_DATA2_USDHC2_DATA2	0x1d2
++			MX8MM_IOMUXC_SD2_DATA3_USDHC2_DATA3	0x1d2
++		>;
++	};
++
++	pinctrl_usdhc2_100mhz: usdhc2-100mhzgrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_GPIO1_IO04_USDHC2_VSELECT	0x1d0
++			MX8MM_IOMUXC_SD2_CLK_USDHC2_CLK		0x194
++			MX8MM_IOMUXC_SD2_CMD_USDHC2_CMD		0x1d4
++			MX8MM_IOMUXC_SD2_DATA0_USDHC2_DATA0	0x1d4
++			MX8MM_IOMUXC_SD2_DATA1_USDHC2_DATA1	0x1d4
++			MX8MM_IOMUXC_SD2_DATA2_USDHC2_DATA2	0x1d4
++			MX8MM_IOMUXC_SD2_DATA3_USDHC2_DATA3	0x1d4
++		>;
++	};
++
++	pinctrl_usdhc2_200mhz: usdhc2-200mhzgrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_GPIO1_IO04_USDHC2_VSELECT	0x1d0
++			MX8MM_IOMUXC_SD2_CLK_USDHC2_CLK		0x196
++			MX8MM_IOMUXC_SD2_CMD_USDHC2_CMD		0x1d6
++			MX8MM_IOMUXC_SD2_DATA0_USDHC2_DATA0	0x1d6
++			MX8MM_IOMUXC_SD2_DATA1_USDHC2_DATA1	0x1d6
++			MX8MM_IOMUXC_SD2_DATA2_USDHC2_DATA2	0x1d6
++			MX8MM_IOMUXC_SD2_DATA3_USDHC2_DATA3	0x1d6
++		>;
++	};
++
++	pinctrl_wlan: wlangrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SD1_DATA5_GPIO2_IO7	0x00
++		>;
++	};
++};
+diff --git a/arch/arm/dts/imx8mm-phycore-som.dtsi b/arch/arm/dts/imx8mm-phycore-som.dtsi
+new file mode 100644
+index 00000000000..fa2fdd9e8c1
+--- /dev/null
++++ b/arch/arm/dts/imx8mm-phycore-som.dtsi
+@@ -0,0 +1,462 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Copyright (C) 2022 PHYTEC Messtechnik GmbH
++ * Author: Teresa Remmet <t.remmet@phytec.de>
++ */
++
++#include "imx8mm.dtsi"
++#include <dt-bindings/net/ti-dp83867.h>
++
++/ {
++	model = "PHYTEC phyCORE-i.MX8MM";
++	compatible = "phytec,imx8mm-phycore-som", "fsl,imx8mm";
++
++	aliases {
++		rtc0 = &rv3028;
++		rtc1 = &snvs_rtc;
++	};
++
++	memory@40000000 {
++		device_type = "memory";
++		reg = <0x0 0x40000000 0 0x80000000>;
++	};
++
++	reg_vdd_1p2: regulator-vdd-1p2 {
++		compatible = "regulator-fixed";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-max-microvolt = <1200000>;
++		regulator-min-microvolt = <1200000>;
++		regulator-name = "reg_vdd_1p2";
++	};
++
++	reg_vdd_3v3_s: regulator-vdd-3v3-s {
++		compatible = "regulator-fixed";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-max-microvolt = <3300000>;
++		regulator-min-microvolt = <3300000>;
++		regulator-name = "VDD_3V3_S";
++	};
++};
++
++&A53_0 {
++	cpu-supply = <&reg_vdd_arm>;
++};
++
++&A53_1 {
++	cpu-supply = <&reg_vdd_arm>;
++};
++
++&A53_2 {
++	cpu-supply = <&reg_vdd_arm>;
++};
++
++&A53_3 {
++	cpu-supply = <&reg_vdd_arm>;
++};
++
++/* Ethernet */
++&fec1 {
++	fsl,magic-packet;
++	phy-mode = "rgmii-id";
++	phy-handle = <&ethphy0>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_fec1>;
++	status = "okay";
++
++	mdio {
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		ethphy0: ethernet-phy@0 {
++			compatible = "ethernet-phy-ieee802.3-c22";
++			enet-phy-lane-no-swap;
++			ti,clk-output-sel = <DP83867_CLK_O_SEL_OFF>;
++			ti,fifo-depth = <DP83867_PHYCR_FIFO_DEPTH_4_B_NIB>;
++			ti,rx-internal-delay = <DP83867_RGMIIDCTL_2_00_NS>;
++			ti,tx-internal-delay = <DP83867_RGMIIDCTL_2_00_NS>;
++			reg = <0>;
++			reset-gpios = <&gpio1 7 GPIO_ACTIVE_HIGH>;
++			reset-assert-us = <1000>;
++			reset-deassert-us = <1000>;
++		};
++	};
++};
++
++/* SPI Flash */
++&flexspi {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_flexspi0>;
++	status = "okay";
++
++	som_flash: flash@0 {
++		#address-cells = <1>;
++		#size-cells = <1>;
++		compatible = "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <80000000>;
++		spi-rx-bus-width = <4>;
++		spi-tx-bus-width = <1>;
++	};
++};
++
++&gpio1 {
++	gpio-line-names = "", "", "WDOG_INT", "X_RTC_INT",
++		"", "", "", "RESET_ETHPHY",
++		"", "", "nENABLE_FLATLINK";
++};
++
++/* I2C1 */
++&i2c1 {
++	clock-frequency = <400000>;
++	pinctrl-names = "default","gpio";
++	pinctrl-0 = <&pinctrl_i2c1>;
++	pinctrl-1 = <&pinctrl_i2c1_gpio>;
++	scl-gpios = <&gpio5 14 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
++	sda-gpios = <&gpio5 15 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
++	status = "okay";
++
++	pmic@8 {
++		compatible = "nxp,pf8121a";
++		reg = <0x08>;
++
++		regulators {
++			reg_nvcc_sd1: ldo1 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-max-microvolt = <3300000>;
++				regulator-min-microvolt = <3300000>;
++				regulator-name = "NVCC_SD1 (LDO1)";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			reg_nvcc_sd2: ldo2 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-max-microvolt = <3300000>;
++				regulator-min-microvolt = <1800000>;
++				regulator-name = "NVCC_SD2 (LDO2)";
++				vselect-en;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			reg_vcc_enet: ldo3 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-max-microvolt = <3300000>;
++				regulator-min-microvolt = <1500000>;
++				regulator-name = "VCC_ENET (LDO3)";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			reg_vdda_1v8: ldo4 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-max-microvolt = <1800000>;
++				regulator-min-microvolt = <1500000>;
++				regulator-name = "VDDA_1V8 (LDO4)";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-min-microvolt = <1500000>;
++					regulator-suspend-max-microvolt = <1500000>;
++				};
++			};
++
++			reg_soc_vdda_phy: buck1 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-max-microvolt = <900000>;
++				regulator-min-microvolt = <400000>;
++				regulator-name = "VDD_SOC_VDDA_PHY_0P8 (BUCK1)";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-min-microvolt = <400000>;
++					regulator-suspend-max-microvolt = <400000>;
++				};
++			};
++
++			reg_vdd_gpu_dram: buck2 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-max-microvolt = <1000000>;
++				regulator-min-microvolt = <1000000>;
++				regulator-name = "VDD_GPU_DRAM (BUCK2)";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-max-microvolt = <1000000>;
++					regulator-suspend-min-microvolt = <1000000>;
++				};
++			};
++
++			reg_vdd_vpu: buck3 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-max-microvolt = <1000000>;
++				regulator-min-microvolt = <400000>;
++				regulator-name = "VDD_VPU (BUCK3)";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			reg_vdd_mipi: buck4 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-max-microvolt = <1050000>;
++				regulator-min-microvolt = <900000>;
++				regulator-name = "VDD_MIPI_0P9 (BUCK4)";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			reg_vdd_arm: buck5 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-max-microvolt = <1050000>;
++				regulator-min-microvolt = <400000>;
++				regulator-name = "VDD_ARM (BUCK5)";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			reg_vdd_1v8: buck6 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-max-microvolt = <1800000>;
++				regulator-min-microvolt = <1800000>;
++				regulator-name = "VDD_1V8 (BUCK6)";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-max-microvolt = <1800000>;
++					regulator-suspend-min-microvolt = <1800000>;
++				};
++			};
++
++			reg_nvcc_dram: buck7 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-max-microvolt = <1100000>;
++				regulator-min-microvolt = <1100000>;
++				regulator-name = "NVCC_DRAM_1P1V (BUCK7)";
++			};
++
++			reg_vsnvs: vsnvs {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-max-microvolt = <1800000>;
++				regulator-min-microvolt = <1800000>;
++				regulator-name = "NVCC_SNVS_1P8 (VSNVS)";
++			};
++		};
++	};
++
++	tc358775: bridge@f {
++		compatible = "toshiba,tc358775";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_tc358775>;
++		reg = <0x0f>;
++		reset-gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
++		stby-gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
++		vdd-supply = <&reg_vdd_1p2>;
++		vddio-supply = <&reg_vdd_1v8>;
++		status = "disabled";
++
++		/*
++		 * Setup is carrier board dependent please checkout
++		 * overlays/imx8mm-phyboard-polis-peb-av-010-tc358775.dtbo
++		 * as an example.
++		 */
++	};
++
++	sn65dsi83: bridge@2d {
++		compatible = "ti,sn65dsi83";
++		enable-gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_sn65dsi83>;
++		reg = <0x2d>;
++		status = "disabled";
++	};
++
++	/* EEPROM */
++	eeprom@51 {
++		compatible = "atmel,24c32";
++		pagesize = <32>;
++		reg = <0x51>;
++		vcc-supply = <&reg_vdd_3v3_s>;
++	};
++
++	/* RTC */
++	rv3028: rtc@52 {
++		compatible = "microcrystal,rv3028";
++		reg = <0x52>;
++	};
++
++	/* EEPROM ID page */
++	eepromid@59 {
++		compatible = "atmel,24c32";
++		pagesize = <32>;
++		reg = <0x59>;
++		size = <32>;
++	};
++};
++
++/* eMMC */
++&usdhc3 {
++	assigned-clocks = <&clk IMX8MM_CLK_USDHC3_ROOT>;
++	assigned-clock-rates = <400000000>;
++	bus-width = <8>;
++	keep-power-in-suspend;
++	pinctrl-names = "default", "state_100mhz", "state_200mhz";
++	pinctrl-0 = <&pinctrl_usdhc3>;
++	pinctrl-1 = <&pinctrl_usdhc3_100mhz>;
++	pinctrl-2 = <&pinctrl_usdhc3_200mhz>;
++	non-removable;
++	status = "okay";
++};
++
++/* Watchdog */
++&wdog1 {
++	fsl,ext-reset-output;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_wdog>;
++	status = "okay";
++};
++
++&iomuxc {
++	pinctrl_fec1: fec1grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_ENET_MDC_ENET1_MDC			0x0
++			MX8MM_IOMUXC_ENET_MDIO_ENET1_MDIO		0x0
++			MX8MM_IOMUXC_ENET_RD0_ENET1_RGMII_RD0		0x90
++			MX8MM_IOMUXC_ENET_RD1_ENET1_RGMII_RD1		0x90
++			MX8MM_IOMUXC_ENET_RD2_ENET1_RGMII_RD2		0x90
++			MX8MM_IOMUXC_ENET_RD3_ENET1_RGMII_RD3		0x90
++			MX8MM_IOMUXC_ENET_RXC_ENET1_RGMII_RXC		0x90
++			MX8MM_IOMUXC_ENET_RX_CTL_ENET1_RGMII_RX_CTL	0x90
++			MX8MM_IOMUXC_ENET_TD0_ENET1_RGMII_TD0		0x12
++			MX8MM_IOMUXC_ENET_TD1_ENET1_RGMII_TD1		0x12
++			MX8MM_IOMUXC_ENET_TD2_ENET1_RGMII_TD2		0x12
++			MX8MM_IOMUXC_ENET_TD3_ENET1_RGMII_TD3		0x12
++			MX8MM_IOMUXC_ENET_TXC_ENET1_RGMII_TXC		0x12
++			MX8MM_IOMUXC_ENET_TX_CTL_ENET1_RGMII_TX_CTL	0x12
++			MX8MM_IOMUXC_GPIO1_IO07_GPIO1_IO7		0x10
++		>;
++	};
++
++	pinctrl_flexspi0: flexspi0grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_NAND_ALE_QSPI_A_SCLK		0x1c2
++			MX8MM_IOMUXC_NAND_CE0_B_QSPI_A_SS0_B		0x82
++			MX8MM_IOMUXC_NAND_DATA00_QSPI_A_DATA0		0x82
++			MX8MM_IOMUXC_NAND_DATA01_QSPI_A_DATA1		0x82
++			MX8MM_IOMUXC_NAND_DATA02_QSPI_A_DATA2		0x82
++			MX8MM_IOMUXC_NAND_DATA03_QSPI_A_DATA3		0x82
++		>;
++	};
++
++	pinctrl_i2c1: i2c1grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_I2C1_SDA_I2C1_SDA			0x400001c0
++			MX8MM_IOMUXC_I2C1_SCL_I2C1_SCL			0x400001c0
++		>;
++	};
++
++	pinctrl_i2c1_gpio: i2c1gpiogrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_I2C1_SDA_GPIO5_IO15		0x1e0
++			MX8MM_IOMUXC_I2C1_SCL_GPIO5_IO14		0x1e0
++		>;
++	};
++
++	pinctrl_rtc: rtcgrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_GPIO1_IO03_GPIO1_IO3		0x1c0
++		>;
++	};
++
++	pinctrl_sn65dsi83: sn65dsi83grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_GPIO1_IO10_GPIO1_IO10		0x0
++		>;
++	};
++
++	pinctrl_tc358775: tc358775grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_GPIO1_IO10_GPIO1_IO10		0x0
++			MX8MM_IOMUXC_GPIO1_IO11_GPIO1_IO11		0x0
++		>;
++	};
++
++	pinctrl_usdhc3: usdhc3grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_NAND_CLE_USDHC3_DATA7		0x1d0
++			MX8MM_IOMUXC_NAND_CE1_B_USDHC3_STROBE		0x190
++			MX8MM_IOMUXC_NAND_CE2_B_USDHC3_DATA5		0x1d0
++			MX8MM_IOMUXC_NAND_CE3_B_USDHC3_DATA6		0x1d0
++			MX8MM_IOMUXC_NAND_DATA04_USDHC3_DATA0		0x1d0
++			MX8MM_IOMUXC_NAND_DATA05_USDHC3_DATA1		0x1d0
++			MX8MM_IOMUXC_NAND_DATA06_USDHC3_DATA2		0x1d0
++			MX8MM_IOMUXC_NAND_DATA07_USDHC3_DATA3		0x1d0
++			MX8MM_IOMUXC_NAND_RE_B_USDHC3_DATA4		0x1d0
++			MX8MM_IOMUXC_NAND_WE_B_USDHC3_CLK		0x190
++			MX8MM_IOMUXC_NAND_WP_B_USDHC3_CMD		0x1d0
++		>;
++	};
++
++	pinctrl_usdhc3_100mhz: usdhc3-100mhzgrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_NAND_CLE_USDHC3_DATA7		0x1d4
++			MX8MM_IOMUXC_NAND_CE1_B_USDHC3_STROBE		0x194
++			MX8MM_IOMUXC_NAND_CE2_B_USDHC3_DATA5		0x1d4
++			MX8MM_IOMUXC_NAND_CE3_B_USDHC3_DATA6		0x1d4
++			MX8MM_IOMUXC_NAND_DATA04_USDHC3_DATA0		0x1d4
++			MX8MM_IOMUXC_NAND_DATA05_USDHC3_DATA1		0x1d4
++			MX8MM_IOMUXC_NAND_DATA06_USDHC3_DATA2		0x1d4
++			MX8MM_IOMUXC_NAND_DATA07_USDHC3_DATA3		0x1d4
++			MX8MM_IOMUXC_NAND_RE_B_USDHC3_DATA4		0x1d4
++			MX8MM_IOMUXC_NAND_WE_B_USDHC3_CLK		0x194
++			MX8MM_IOMUXC_NAND_WP_B_USDHC3_CMD		0x1d4
++		>;
++	};
++
++	pinctrl_usdhc3_200mhz: usdhc3-200mhzgrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_NAND_CLE_USDHC3_DATA7		0x1d6
++			MX8MM_IOMUXC_NAND_CE1_B_USDHC3_STROBE		0x196
++			MX8MM_IOMUXC_NAND_CE2_B_USDHC3_DATA5		0x1d6
++			MX8MM_IOMUXC_NAND_CE3_B_USDHC3_DATA6		0x1d6
++			MX8MM_IOMUXC_NAND_DATA04_USDHC3_DATA0		0x1d6
++			MX8MM_IOMUXC_NAND_DATA05_USDHC3_DATA1		0x1d6
++			MX8MM_IOMUXC_NAND_DATA06_USDHC3_DATA2		0x1d6
++			MX8MM_IOMUXC_NAND_DATA07_USDHC3_DATA3		0x1d6
++			MX8MM_IOMUXC_NAND_RE_B_USDHC3_DATA4		0x1d6
++			MX8MM_IOMUXC_NAND_WE_B_USDHC3_CLK		0x196
++			MX8MM_IOMUXC_NAND_WP_B_USDHC3_CMD		0x1d6
++		>;
++	};
++
++	pinctrl_wdog: wdoggrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_GPIO1_IO02_WDOG1_WDOG_B		0x26
++		>;
++	};
++};
+diff --git a/arch/arm/dts/imx8mm-phygate-tauri-u-boot.dtsi b/arch/arm/dts/imx8mm-phygate-tauri-u-boot.dtsi
+new file mode 100644
+index 00000000000..b585b35cc4f
+--- /dev/null
++++ b/arch/arm/dts/imx8mm-phygate-tauri-u-boot.dtsi
+@@ -0,0 +1,83 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++/*
++ * Copyright (C) 2023 PHYTEC Messtechnik GmbH
++ * Author: Yannic Moog <y.moog@phytec.de>
++ */
++
++#include "imx8mm-u-boot.dtsi"
++
++/ {
++	wdt-reboot {
++		compatible = "wdt-reboot";
++		wdt = <&wdog1>;
++		u-boot,dm-spl;
++	};
++};
++
++&pinctrl_i2c1 {
++	u-boot,dm-spl;
++};
++
++&pinctrl_i2c1_gpio {
++	u-boot,dm-spl;
++};
++
++&pinctrl_uart3 {
++	u-boot,dm-spl;
++};
++
++&pinctrl_usdhc2_gpio {
++	u-boot,dm-spl;
++};
++
++&pinctrl_usdhc2 {
++	u-boot,dm-spl;
++};
++
++&pinctrl_usdhc3 {
++	u-boot,dm-spl;
++};
++
++&pinctrl_wdog {
++	u-boot,dm-spl;
++};
++
++&gpio1 {
++	u-boot,dm-spl;
++};
++
++&gpio2 {
++	u-boot,dm-spl;
++};
++
++&gpio3 {
++	u-boot,dm-spl;
++};
++
++&gpio4 {
++	u-boot,dm-spl;
++};
++
++&gpio5 {
++	u-boot,dm-spl;
++};
++
++&i2c1 {
++	u-boot,dm-spl;
++};
++
++&uart3 {
++	u-boot,dm-spl;
++};
++
++&usdhc2 {
++	u-boot,dm-spl;
++};
++
++&usdhc3 {
++	u-boot,dm-spl;
++};
++
++&wdog1 {
++	u-boot,dm-spl;
++};
+diff --git a/arch/arm/dts/imx8mm-phygate-tauri.dts b/arch/arm/dts/imx8mm-phygate-tauri.dts
+new file mode 100644
+index 00000000000..9553de30eca
+--- /dev/null
++++ b/arch/arm/dts/imx8mm-phygate-tauri.dts
+@@ -0,0 +1,465 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++* Copyright (C) 2021 PHYTEC Messtechnik GmbH
++* Author: Jens Lang <j.lang@phytec.de>
++*/
++
++/dts-v1/;
++#include "imx8mm-phycore-som.dtsi"
++#include <dt-bindings/leds/common.h>
++
++/ {
++	model = "PHYTEC phyGATE-Tauri-iMX8MM";
++
++	chosen {
++		stdout-path = &uart3;
++	};
++
++	clocks {
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		can_osc_40m: can-clock@0 {
++			compatible = "fixed-clock";
++			clock-frequency = <40000000>;
++			clock-output-names = "can_osc_40m";
++			reg = <0>;
++			#clock-cells = <0>;
++		};
++	};
++
++	gpio-keys {
++		compatible = "gpio-keys";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_gpiokeys>;
++
++		key {
++			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
++			label = "KEY-A";
++			linux,code = <30>;
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_leds>;
++
++		led1 {
++			color = <LED_COLOR_ID_RED>;
++			gpios = <&gpio5 5 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "off";
++		};
++
++		led2 {
++			color = <LED_COLOR_ID_YELLOW>;
++			gpios = <&gpio4 30 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "off";
++		};
++	};
++
++	usdhc1_pwrseq: pwr-seq {
++		compatible = "mmc-pwrseq-simple";
++		post-power-on-delay-ms = <100>;
++		power-off-delay-us = <60>;
++		reset-gpios = <&gpio2 7 GPIO_ACTIVE_LOW>;
++	};
++
++	reg_usb_hub_vbus: regulator-hub-otg1-vbus {
++		compatible = "regulator-fixed";
++		gpio = <&gpio1 14 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_usbhubpwr>;
++		regulator-name = "usb_hub_vbus";
++		regulator-max-microvolt = <5000000>;
++		regulator-min-microvolt = <5000000>;
++	};
++
++	reg_usb_otg1_vbus: regulator-usb-otg1-vbus {
++		compatible = "regulator-fixed";
++		gpio = <&gpio1 12 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_usbotg1pwr>;
++		regulator-name = "usb_otg1_vbus";
++		regulator-max-microvolt = <5000000>;
++		regulator-min-microvolt = <5000000>;
++	};
++
++	reg_usdhc2_vmmc: regulator-usdhc2 {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio2 19 GPIO_ACTIVE_HIGH>;
++		off-on-delay-us = <20000>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_reg_usdhc2_vmmc>;
++		regulator-max-microvolt = <3300000>;
++		regulator-min-microvolt = <3300000>;
++		regulator-name = "VSD_3V3";
++	};
++};
++
++/* CAN mcp251xfd */
++&ecspi1 {
++	cs-gpios = <&gpio5 9 GPIO_ACTIVE_LOW>,
++		   <&gpio5 13 GPIO_ACTIVE_LOW>,
++		   <&gpio5 2 GPIO_ACTIVE_LOW>;
++	num-cs = <3>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_ecspi1 &pinctrl_ecspi1_cs>;
++	#address-cells = <1>;
++	#size-cells = <0>;
++	status = "okay";
++
++	can0: can@0 {
++		compatible = "microchip,mcp251xfd";
++		clocks = <&can_osc_40m>;
++		interrupts = <8 IRQ_TYPE_LEVEL_LOW>;
++		interrupt-parent = <&gpio1>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_can_int>;
++		reg = <0>;
++		spi-max-frequency = <10000000>;
++	};
++
++	spidev: spi@2 {
++		compatible = "phytec,kitspi";
++		reg = <2>;
++		spi-max-frequency = <38000000>;
++	};
++
++	tpm: tpm-tis@1 {
++		compatible = "tcg,tpm_tis-spi";
++		interrupts = <11 IRQ_TYPE_LEVEL_LOW>;
++		interrupt-parent = <&gpio2>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_tpm>;
++		reg = <1>;
++		spi-max-frequency = <38000000>;
++	};
++};
++
++&i2c2 {
++	clock-frequency = <400000>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_i2c2>;
++	status = "okay";
++
++	temp_sense0: temp@49 {
++		compatible = "ti,tmp102";
++		interrupts = <31 IRQ_TYPE_LEVEL_LOW>;
++		interrupt-parent = <&gpio4>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_tempsense>;
++		reg = <0x49>;
++		#thermal-sensor-cells = <1>;
++	};
++};
++
++&i2c3 {
++	clock-frequency = <400000>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_i2c3>;
++	status = "okay";
++};
++
++&i2c4 {
++	clock-frequency = <400000>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_i2c4>;
++	status = "okay";
++};
++
++/* PCIe */
++&pcie0 {
++	assigned-clocks = <&clk IMX8MM_CLK_PCIE1_AUX>,
++			  <&clk IMX8MM_CLK_PCIE1_PHY>,
++			  <&clk IMX8MM_CLK_PCIE1_CTRL>;
++	assigned-clock-parents = <&clk IMX8MM_SYS_PLL2_50M>,
++				 <&clk IMX8MM_SYS_PLL2_100M>,
++				 <&clk IMX8MM_SYS_PLL2_250M>;
++	assigned-clock-rates = <10000000>, <100000000>, <250000000>;
++	clocks = <&clk IMX8MM_CLK_PCIE1_ROOT>,
++		<&clk IMX8MM_CLK_PCIE1_AUX>,
++		<&clk IMX8MM_CLK_PCIE1_PHY>,
++		<&clk IMX8MM_CLK_DUMMY>;
++	clock-names = "pcie", "pcie_aux", "pcie_phy", "pcie_bus";
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_pcie>;
++	reset-gpio = <&gpio3 22 GPIO_ACTIVE_LOW>;
++	status = "okay";
++};
++
++&pwm1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_pwm1>;
++	status = "okay";
++};
++
++&pwm3 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_pwm3>;
++	status = "okay";
++};
++
++&pwm4 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_pwm4>;
++	status = "okay";
++};
++
++/* RTC */
++&rv3028 {
++	enable-level-switching-mode;
++	interrupt-parent = <&gpio1>;
++	interrupts = <3 IRQ_TYPE_LEVEL_LOW>;
++	pinctrl-0 = <&pinctrl_rtc>;
++	pinctrl-names = "default";
++	trickle-resistor-ohms = <3000>;
++	wakeup-source;
++};
++
++&uart1 {
++	assigned-clocks = <&clk IMX8MM_CLK_UART1>;
++	assigned-clock-parents = <&clk IMX8MM_SYS_PLL1_80M>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_uart1>;
++	status = "okay";
++};
++
++/* UART console */
++&uart3 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_uart3>;
++	status = "okay";
++};
++
++&{/soc@0/bus@32c00000/display-subsystem} {
++	status = "disabled";
++};
++
++/* USB */
++&usbotg1 {
++	dr_mode = "host";
++	over-current-active-low;
++	picophy,pre-emp-curr-control = <3>;
++	picophy,dc-vol-level-adjust = <7>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_usbotg1>;
++	vbus-supply = <&reg_usb_otg1_vbus>;
++	status = "okay";
++};
++
++&usbotg2 {
++	disable-over-current;
++	dr_mode = "host";
++	picophy,dc-vol-level-adjust = <7>;
++	picophy,pre-emp-curr-control = <3>;
++	vbus-supply = <&reg_usb_hub_vbus>;
++	status = "okay";
++};
++
++/* SD-Card */
++&usdhc2 {
++	assigned-clocks = <&clk IMX8MM_CLK_USDHC2>;
++	assigned-clock-rates = <200000000>;
++	bus-width = <4>;
++	cd-gpios = <&gpio2 12 GPIO_ACTIVE_LOW>;
++	disable-wp;
++	pinctrl-0 = <&pinctrl_usdhc2>, <&pinctrl_usdhc2_gpio>;
++	pinctrl-1 = <&pinctrl_usdhc2_100mhz>, <&pinctrl_usdhc2_gpio>;
++	pinctrl-2 = <&pinctrl_usdhc2_200mhz>, <&pinctrl_usdhc2_gpio>;
++	pinctrl-names = "default", "state_100mhz", "state_200mhz";
++	vmmc-supply = <&reg_usdhc2_vmmc>;
++	vqmmc-supply = <&reg_nvcc_sd2>;
++	status = "okay";
++};
++
++&iomuxc {
++	pinctrl_can_int: can-intgrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_GPIO1_IO08_GPIO1_IO8	0x00
++		>;
++	};
++
++	pinctrl_ecspi1: ecspi1grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_ECSPI1_MISO_ECSPI1_MISO	0x82
++			MX8MM_IOMUXC_ECSPI1_MOSI_ECSPI1_MOSI	0x82
++			MX8MM_IOMUXC_ECSPI1_SCLK_ECSPI1_SCLK	0x82
++		>;
++	};
++
++	pinctrl_ecspi1_cs: ecspi1csgrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_ECSPI1_SS0_GPIO5_IO9	0x00
++			MX8MM_IOMUXC_ECSPI2_SS0_GPIO5_IO13	0x00
++			MX8MM_IOMUXC_SAI3_MCLK_GPIO5_IO2	0x00
++		>;
++	};
++
++	pinctrl_gpiokeys: keygrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_GPIO1_IO09_GPIO1_IO9	0x00
++		>;
++	};
++
++	pinctrl_i2c2: i2c2grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_I2C2_SCL_I2C2_SCL	0x400001c2
++			MX8MM_IOMUXC_I2C2_SDA_I2C2_SDA	0x400001c2
++		>;
++	};
++
++	pinctrl_i2c3: i2c3grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_I2C3_SCL_I2C3_SCL	0x400001c2
++			MX8MM_IOMUXC_I2C3_SDA_I2C3_SDA	0x400001c2
++		>;
++	};
++
++	pinctrl_i2c4: i2c4grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_I2C4_SCL_I2C4_SCL	0x400001c2
++			MX8MM_IOMUXC_I2C4_SDA_I2C4_SDA	0x400001c2
++		>;
++	};
++
++	pinctrl_leds: leds1grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SAI3_RXD_GPIO4_IO30	0x00
++			MX8MM_IOMUXC_SPDIF_EXT_CLK_GPIO5_IO5	0x00
++		>;
++	};
++
++	pinctrl_pcie: pciegrp {
++		fsl,pins = <
++			/* COEX2 */
++			MX8MM_IOMUXC_SAI5_RXD1_GPIO3_IO22	0x00
++			/* COEX1 */
++			MX8MM_IOMUXC_SAI1_TXD0_GPIO4_IO12	0x12
++		>;
++	};
++
++	pinctrl_pwm1: pwm1grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_GPIO1_IO01_PWM1_OUT	0x40
++		>;
++	};
++
++	pinctrl_pwm3: pwm3grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SPDIF_TX_PWM3_OUT		0x40
++		>;
++	};
++
++	pinctrl_pwm4: pwm4grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_GPIO1_IO15_PWM4_OUT	0x40
++		>;
++	};
++
++	pinctrl_reg_usdhc2_vmmc: regusdhc2vmmcgrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SD2_RESET_B_GPIO2_IO19     0x41
++		>;
++	};
++
++	pinctrl_tempsense: tempsensegrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SAI3_TXFS_GPIO4_IO31	0x00
++		>;
++	};
++
++	pinctrl_tpm: tpmgrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SD1_STROBE_GPIO2_IO11	0x140
++		>;
++	};
++
++	pinctrl_uart1: uart1grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_UART1_TXD_UART1_DCE_TX	0x00
++			MX8MM_IOMUXC_UART1_RXD_UART1_DCE_RX	0x00
++		>;
++	};
++
++	pinctrl_uart3: uart3grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_UART3_RXD_UART3_DCE_RX	0x140
++			MX8MM_IOMUXC_UART3_TXD_UART3_DCE_TX	0x140
++		>;
++	};
++
++	pinctrl_usbhubpwr: usbhubpwrgrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_GPIO1_IO14_GPIO1_IO14	0x00
++		>;
++	};
++
++	pinctrl_usbotg1pwr: usbotg1pwrgrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_GPIO1_IO12_GPIO1_IO12	0x00
++		>;
++	};
++
++	pinctrl_usbotg1: usbotg1grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_GPIO1_IO13_USB1_OTG_OC	0x80
++		>;
++	};
++
++	pinctrl_usdhc1: usdhc1grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SD1_CLK_USDHC1_CLK		0x182
++			MX8MM_IOMUXC_SD1_CMD_USDHC1_CMD		0xc6
++			MX8MM_IOMUXC_SD1_DATA0_USDHC1_DATA0	0xc6
++			MX8MM_IOMUXC_SD1_DATA1_USDHC1_DATA1	0xc6
++			MX8MM_IOMUXC_SD1_DATA2_USDHC1_DATA2	0xc6
++			MX8MM_IOMUXC_SD1_DATA3_USDHC1_DATA3	0xc6
++		>;
++	};
++
++	pinctrl_usdhc2_gpio: usdhc2gpiogrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SD2_CD_B_GPIO2_IO12	0x40
++		>;
++	};
++
++	pinctrl_usdhc2: usdhc2grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_GPIO1_IO04_USDHC2_VSELECT	0x1d0
++			MX8MM_IOMUXC_SD2_CLK_USDHC2_CLK		0x192
++			MX8MM_IOMUXC_SD2_CMD_USDHC2_CMD		0x1d2
++			MX8MM_IOMUXC_SD2_DATA0_USDHC2_DATA0	0x1d2
++			MX8MM_IOMUXC_SD2_DATA1_USDHC2_DATA1	0x1d2
++			MX8MM_IOMUXC_SD2_DATA2_USDHC2_DATA2	0x1d2
++			MX8MM_IOMUXC_SD2_DATA3_USDHC2_DATA3	0x1d2
++		>;
++	};
++
++	pinctrl_usdhc2_100mhz: usdhc2100mhzgrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_GPIO1_IO04_USDHC2_VSELECT	0x1d0
++			MX8MM_IOMUXC_SD2_CLK_USDHC2_CLK		0x194
++			MX8MM_IOMUXC_SD2_CMD_USDHC2_CMD		0x1d4
++			MX8MM_IOMUXC_SD2_DATA0_USDHC2_DATA0	0x1d4
++			MX8MM_IOMUXC_SD2_DATA1_USDHC2_DATA1	0x1d4
++			MX8MM_IOMUXC_SD2_DATA2_USDHC2_DATA2	0x1d4
++			MX8MM_IOMUXC_SD2_DATA3_USDHC2_DATA3	0x1d4
++		>;
++	};
++
++	pinctrl_usdhc2_200mhz: usdhc2200mhzgrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_GPIO1_IO04_USDHC2_VSELECT	0x1d0
++			MX8MM_IOMUXC_SD2_CLK_USDHC2_CLK		0x196
++			MX8MM_IOMUXC_SD2_CMD_USDHC2_CMD		0x1d6
++			MX8MM_IOMUXC_SD2_DATA0_USDHC2_DATA0	0x1d6
++			MX8MM_IOMUXC_SD2_DATA1_USDHC2_DATA1	0x1d6
++			MX8MM_IOMUXC_SD2_DATA2_USDHC2_DATA2	0x1d6
++			MX8MM_IOMUXC_SD2_DATA3_USDHC2_DATA3	0x1d6
++		>;
++	};
++};
+diff --git a/arch/arm/dts/imx8mn-phyboard-polis-u-boot.dtsi b/arch/arm/dts/imx8mn-phyboard-polis-u-boot.dtsi
+new file mode 100644
+index 00000000000..b1e183bc802
+--- /dev/null
++++ b/arch/arm/dts/imx8mn-phyboard-polis-u-boot.dtsi
+@@ -0,0 +1,83 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++/*
++ * Copyright (C) 2020 PHYTEC Messtechnik GmbH
++ * Author: Teresa Remmet <t.remmet@phytec.de>
++ */
++
++ #include "imx8mn-u-boot.dtsi"
++
++/ {
++	wdt-reboot {
++		compatible = "wdt-reboot";
++		wdt = <&wdog1>;
++		u-boot,dm-spl;
++	};
++};
++
++&pinctrl_i2c1 {
++	u-boot,dm-spl;
++};
++
++&pinctrl_i2c1_gpio {
++	u-boot,dm-spl;
++};
++
++&pinctrl_uart3 {
++	u-boot,dm-spl;
++};
++
++&pinctrl_usdhc2_gpio {
++	u-boot,dm-spl;
++};
++
++&pinctrl_usdhc2 {
++	u-boot,dm-spl;
++};
++
++&pinctrl_usdhc3 {
++	u-boot,dm-spl;
++};
++
++&pinctrl_wdog {
++	u-boot,dm-spl;
++};
++
++&gpio1 {
++	u-boot,dm-spl;
++};
++
++&gpio2 {
++	u-boot,dm-spl;
++};
++
++&gpio3 {
++	u-boot,dm-spl;
++};
++
++&gpio4 {
++	u-boot,dm-spl;
++};
++
++&gpio5 {
++	u-boot,dm-spl;
++};
++
++&i2c1 {
++	u-boot,dm-spl;
++};
++
++&uart3 {
++	u-boot,dm-spl;
++};
++
++&usdhc2 {
++	u-boot,dm-spl;
++};
++
++&usdhc3 {
++	u-boot,dm-spl;
++};
++
++&wdog1 {
++	u-boot,dm-spl;
++};
+diff --git a/arch/arm/dts/imx8mn-phyboard-polis.dts b/arch/arm/dts/imx8mn-phyboard-polis.dts
+new file mode 100644
+index 00000000000..b6418adae1e
+--- /dev/null
++++ b/arch/arm/dts/imx8mn-phyboard-polis.dts
+@@ -0,0 +1,485 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Copyright (C) 2020-2022 PHYTEC Messtechnik GmbH
++ * Author: Teresa Remmet <t.remmet@phytec.de>
++ */
++
++/dts-v1/;
++
++#include <dt-bindings/leds/common.h>
++#include "imx8mn-phycore-som.dtsi"
++
++/ {
++	model = "PHYTEC phyBOARD-Polis-i.MX8MN";
++	compatible = "phytec,imx8mn-phyboard-polis",
++		     "phytec,i.mx8mn-phycore-som","fsl,imx8mn";
++
++	chosen {
++		stdout-path = &uart3;
++	};
++
++	clocks {
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		can_osc_40m: can-clock@0 {
++			compatible = "fixed-clock";
++			clock-frequency = <40000000>;
++			clock-output-names = "can_osc_40m";
++			reg = <0>;
++			#clock-cells = <0>;
++		};
++	};
++
++	fan {
++		compatible = "gpio-fan";
++		gpios = <&gpio4 27 GPIO_ACTIVE_HIGH>;
++		gpio-fan,speed-map = <0     0
++				      13000 1>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_fan>;
++		#cooling-cells = <2>;
++	};
++
++	leds {
++		compatible = "gpio-leds";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_leds>;
++
++		led-0 {
++			color = <LED_COLOR_ID_RED>;
++			function = LED_FUNCTION_DISK;
++			gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "mmc2";
++		};
++
++		led-1 {
++			color = <LED_COLOR_ID_BLUE>;
++			function = LED_FUNCTION_DISK;
++			gpios = <&gpio1 15 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "mmc1";
++		};
++
++		led-2 {
++			color = <LED_COLOR_ID_GREEN>;
++			function = LED_FUNCTION_CPU;
++			gpios = <&gpio1 14 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "heartbeat";
++		};
++	};
++
++	usdhc1_pwrseq: pwr-seq {
++		compatible = "mmc-pwrseq-simple";
++		post-power-on-delay-ms = <100>;
++		power-off-delay-us = <60>;
++		reset-gpios = <&gpio2 7 GPIO_ACTIVE_LOW>;
++	};
++
++	reg_can_en: regulator-can-en {
++		compatible = "regulator-fixed";
++		gpio = <&gpio1 9 GPIO_ACTIVE_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_can_en>;
++		regulator-max-microvolt = <3300000>;
++		regulator-min-microvolt = <3300000>;
++		regulator-name = "reg_can_en";
++		startup-delay-us = <20>;
++	};
++
++	reg_usb_otg1_vbus: regulator-usb-otg1-vbus {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio1 12 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_usbotg1pwrgrp>;
++		regulator-max-microvolt = <5000000>;
++		regulator-min-microvolt = <5000000>;
++		regulator-name = "usb_otg1_vbus";
++	};
++
++	reg_usdhc2_vmmc: regulator-usdhc2 {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio2 19 GPIO_ACTIVE_HIGH>;
++		off-on-delay-us = <20000>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_reg_usdhc2_vmmc>;
++		regulator-max-microvolt = <3300000>;
++		regulator-min-microvolt = <3300000>;
++		regulator-name = "VSD_3V3";
++	};
++};
++
++&{/soc@0/bus@32c00000/display-subsystem} {
++	status = "disabled";
++};
++
++/* SPI - CAN MCP251XFD */
++&ecspi1 {
++	#address-cells = <1>;
++	#size-cells = <0>;
++	cs-gpios = <&gpio5 9 GPIO_ACTIVE_LOW>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_ecspi1 &pinctrl_ecspi1_cs>;
++	status = "okay";
++
++	can0: can@0 {
++		compatible = "microchip,mcp251xfd";
++		clocks = <&can_osc_40m>;
++		interrupts = <8 IRQ_TYPE_LEVEL_LOW>;
++		interrupt-parent = <&gpio1>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_can_int>;
++		reg = <0>;
++		spi-max-frequency = <20000000>;
++		xceiver-supply = <&reg_can_en>;
++	};
++};
++
++/* TPM */
++&ecspi2 {
++	cs-gpios = <&gpio5 13 GPIO_ACTIVE_LOW>;
++	num-cs = <1>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_ecspi2 &pinctrl_ecspi2_cs>;
++	#address-cells = <1>;
++	#size-cells =           <0>;
++	status = "okay";
++
++	tpm: tpm-tis@0 {
++		compatible = "tcg,tpm_tis-spi";
++		interrupts = <11 IRQ_TYPE_LEVEL_LOW>;
++		interrupt-parent = <&gpio2>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_tpm>;
++		reg = <0>;
++		spi-max-frequency = <38000000>;
++	};
++};
++
++&gpio1 {
++	gpio-line-names = "", "LED_RED", "WDOG_INT", "X_RTC_INT",
++		"", "", "", "RESET_ETHPHY",
++		"CAN_nINT", "CAN_EN", "nENABLE_FLATLINK", "",
++		"USB_OTG_VBUS_EN", "", "LED_GREEN", "LED_BLUE";
++};
++
++&gpio2 {
++	gpio-line-names = "", "", "", "",
++		"", "", "BT_REG_ON", "WL_REG_ON",
++		"BT_DEV_WAKE", "BT_HOST_WAKE", "", "",
++		"X_SD2_CD_B", "", "", "",
++		"", "", "", "SD2_RESET_B";
++};
++
++&gpio4 {
++	gpio-line-names = "", "", "", "",
++		"", "", "", "",
++		"FAN", "miniPCIe_nPERST", "", "",
++		"COEX1", "COEX2";
++};
++
++&gpio5 {
++	gpio-line-names = "", "", "", "",
++		"", "", "", "",
++		"", "ECSPI1_SS0";
++};
++
++&i2c3 {
++	clock-frequency = <400000>;
++	pinctrl-names = "default", "gpio";
++	pinctrl-0 = <&pinctrl_i2c3>;
++	pinctrl-1 = <&pinctrl_i2c3_gpio>;
++	scl-gpios = <&gpio5 18 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
++	sda-gpios = <&gpio5 19 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
++};
++
++&snvs_pwrkey {
++	status = "okay";
++};
++
++/* RTC */
++&rv3028 {
++	enable-level-switching-mode;
++	interrupt-parent = <&gpio1>;
++	interrupts = <3 IRQ_TYPE_LEVEL_LOW>;
++	pinctrl-0 = <&pinctrl_rtc>;
++	pinctrl-names = "default";
++	trickle-resistor-ohms = <3000>;
++	wakeup-source;
++};
++
++/* UART - RS232/RS485 */
++&uart1 {
++	assigned-clocks = <&clk IMX8MN_CLK_UART1>;
++	assigned-clock-parents = <&clk IMX8MN_SYS_PLL1_80M>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_uart1>;
++	uart-has-rtscts;
++	status = "okay";
++};
++
++/* UART - Sterling-LWB Bluetooth */
++&uart2 {
++	assigned-clocks = <&clk IMX8MN_CLK_UART2>;
++	assigned-clock-parents = <&clk IMX8MN_SYS_PLL1_80M>;
++	fsl,dte-mode;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_uart2_bt>;
++	uart-has-rtscts;
++	status = "okay";
++
++	bluetooth {
++		compatible = "brcm,bcm43438-bt";
++		device-wakeup-gpios = <&gpio2 8 GPIO_ACTIVE_HIGH>;
++		interrupts = <9 IRQ_TYPE_EDGE_BOTH>;
++		interrupt-names = "host-wakeup";
++		interrupt-parent = <&gpio2>;
++		max-speed = <2000000>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_bt>;
++		shutdown-gpios = <&gpio2 6 GPIO_ACTIVE_HIGH>;
++	};
++};
++
++/* UART - console */
++&uart3 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_uart3>;
++	status = "okay";
++};
++
++/* USB */
++&usbotg1 {
++	adp-disable;
++	dr_mode = "otg";
++	over-current-active-low;
++	samsung,picophy-pre-emp-curr-control = <3>;
++	samsung,picophy-dc-vol-level-adjust = <7>;
++	srp-disable;
++	vbus-supply = <&reg_usb_otg1_vbus>;
++	status = "okay";
++};
++
++/* SDIO - Sterling-LWB Wifi */
++&usdhc1 {
++	assigned-clocks = <&clk IMX8MN_CLK_USDHC1>;
++	assigned-clock-rates = <200000000>;
++	bus-width = <4>;
++	keep-power-in-suspend;
++	mmc-pwrseq = <&usdhc1_pwrseq>;
++	non-removable;
++	no-1-8-v;
++	pinctrl-names = "default", "state_100mhz", "state_200mhz";
++	pinctrl-0 = <&pinctrl_usdhc1>, <&pinctrl_wlan>;
++	#address-cells = <1>;
++	#size-cells = <0>;
++	status = "okay";
++
++	brcmf: wifi@1 {
++		compatible = "brcm,bcm4329-fmac";
++		reg = <1>;
++	};
++};
++
++/* SD-Card */
++&usdhc2 {
++	assigned-clocks = <&clk IMX8MN_CLK_USDHC2>;
++	assigned-clock-rates = <200000000>;
++	bus-width = <4>;
++	cd-gpios = <&gpio2 12 GPIO_ACTIVE_LOW>;
++	disable-wp;
++	pinctrl-names = "default", "state_100mhz", "state_200mhz";
++	pinctrl-0 = <&pinctrl_usdhc2>, <&pinctrl_usdhc2_gpio>;
++	pinctrl-1 = <&pinctrl_usdhc2_100mhz>, <&pinctrl_usdhc2_gpio>;
++	pinctrl-2 = <&pinctrl_usdhc2_200mhz>, <&pinctrl_usdhc2_gpio>;
++	vmmc-supply = <&reg_usdhc2_vmmc>;
++	vqmmc-supply = <&reg_nvcc_sd2>;
++	status = "okay";
++};
++
++&iomuxc {
++	pinctrl_bt: btgrp {
++		fsl,pins = <
++			MX8MN_IOMUXC_SD1_DATA4_GPIO2_IO6	0x00
++			MX8MN_IOMUXC_SD1_DATA6_GPIO2_IO8	0x00
++			MX8MN_IOMUXC_SD1_DATA7_GPIO2_IO9	0x00
++		>;
++	};
++
++	pinctrl_can_en: can-engrp {
++		fsl,pins = <
++			MX8MN_IOMUXC_GPIO1_IO09_GPIO1_IO9	0x00
++		>;
++	};
++
++	pinctrl_can_int: can-intgrp {
++		fsl,pins = <
++			MX8MN_IOMUXC_GPIO1_IO08_GPIO1_IO8	0x00
++		>;
++	};
++
++	pinctrl_ecspi1: ecspi1grp {
++		fsl,pins = <
++			MX8MN_IOMUXC_ECSPI1_MISO_ECSPI1_MISO	0x82
++			MX8MN_IOMUXC_ECSPI1_MOSI_ECSPI1_MOSI	0x82
++			MX8MN_IOMUXC_ECSPI1_SCLK_ECSPI1_SCLK	0x82
++		>;
++	};
++
++	pinctrl_ecspi1_cs: ecspi1csgrp {
++		fsl,pins = <
++			MX8MN_IOMUXC_ECSPI1_SS0_GPIO5_IO9	0x00
++		>;
++	};
++
++	pinctrl_ecspi2: ecspi2grp {
++		fsl,pins = <
++			MX8MN_IOMUXC_ECSPI2_MISO_ECSPI2_MISO    0x82
++			MX8MN_IOMUXC_ECSPI2_MOSI_ECSPI2_MOSI    0x82
++			MX8MN_IOMUXC_ECSPI2_SCLK_ECSPI2_SCLK    0x82
++		>;
++	};
++
++	pinctrl_ecspi2_cs: ecspi2csgrp {
++		fsl,pins = <
++			MX8MN_IOMUXC_ECSPI2_SS0_GPIO5_IO13      0x00
++		>;
++	};
++
++	pinctrl_fan: fan0grp {
++		fsl,pins = <
++			MX8MN_IOMUXC_SAI2_MCLK_GPIO4_IO27	0x16
++		>;
++	};
++
++	pinctrl_i2c3: i2c3grp {
++		fsl,pins = <
++			MX8MN_IOMUXC_I2C3_SDA_I2C3_SDA          0x400001c2
++			MX8MN_IOMUXC_I2C3_SCL_I2C3_SCL          0x400001c2
++		>;
++	};
++
++	pinctrl_i2c3_gpio: i2c3gpiogrp {
++		fsl,pins = <
++			MX8MN_IOMUXC_I2C3_SDA_GPIO5_IO19        0x1e2
++			MX8MN_IOMUXC_I2C3_SCL_GPIO5_IO18        0x1e2
++		>;
++	};
++
++	pinctrl_leds: leds1grp {
++		fsl,pins = <
++			MX8MN_IOMUXC_GPIO1_IO01_GPIO1_IO1	0x16
++			MX8MN_IOMUXC_GPIO1_IO14_GPIO1_IO14	0x16
++			MX8MN_IOMUXC_GPIO1_IO15_GPIO1_IO15	0x16
++		>;
++	};
++
++	pinctrl_reg_usdhc2_vmmc: regusdhc2vmmcgrp {
++		fsl,pins = <
++			MX8MN_IOMUXC_SD2_RESET_B_GPIO2_IO19     0x40
++		>;
++	};
++
++	pinctrl_tpm: tpmgrp {
++		fsl,pins = <
++			MX8MN_IOMUXC_SD1_STROBE_GPIO2_IO11      0x140
++		>;
++	};
++
++	pinctrl_uart1: uart1grp {
++		fsl,pins = <
++			MX8MN_IOMUXC_SAI2_RXC_UART1_DCE_RX	0x00
++			MX8MN_IOMUXC_SAI2_RXD0_UART1_DCE_RTS_B	0x00
++			MX8MN_IOMUXC_SAI2_RXFS_UART1_DCE_TX	0x00
++			MX8MN_IOMUXC_SAI2_TXFS_UART1_DCE_CTS_B	0x00
++		>;
++	};
++
++	pinctrl_uart2_bt: uart2btgrp {
++		fsl,pins = <
++			MX8MN_IOMUXC_SAI3_RXC_UART2_DTE_RTS_B	0x00
++			MX8MN_IOMUXC_SAI3_RXD_UART2_DTE_CTS_B	0x00
++			MX8MN_IOMUXC_SAI3_TXC_UART2_DTE_RX	0x00
++			MX8MN_IOMUXC_SAI3_TXFS_UART2_DTE_TX	0x00
++		>;
++	};
++
++	pinctrl_uart3: uart3grp {
++		fsl,pins = <
++			MX8MN_IOMUXC_UART3_RXD_UART3_DCE_RX	0x140
++			MX8MN_IOMUXC_UART3_TXD_UART3_DCE_TX	0x140
++		>;
++	};
++
++	pinctrl_usbotg1pwrgrp: usbotg1pwrgrp {
++		fsl,pins = <
++			MX8MN_IOMUXC_GPIO1_IO12_GPIO1_IO12      0x00
++		>;
++	};
++
++	pinctrl_usbotg1grp: usbotg1grp {
++		fsl,pins = <
++			MX8MN_IOMUXC_GPIO1_IO13_USB1_OTG_OC     0x80
++		>;
++	};
++
++	pinctrl_usdhc1: usdhc1grp {
++		fsl,pins = <
++			MX8MN_IOMUXC_SD1_CLK_USDHC1_CLK		0x182
++			MX8MN_IOMUXC_SD1_CMD_USDHC1_CMD		0xc6
++			MX8MN_IOMUXC_SD1_DATA0_USDHC1_DATA0	0xc6
++			MX8MN_IOMUXC_SD1_DATA1_USDHC1_DATA1	0xc6
++			MX8MN_IOMUXC_SD1_DATA2_USDHC1_DATA2	0xc6
++			MX8MN_IOMUXC_SD1_DATA3_USDHC1_DATA3	0xc6
++		>;
++	};
++
++	pinctrl_usdhc2_gpio: usdhc2gpiogrp {
++		fsl,pins = <
++			MX8MN_IOMUXC_SD2_CD_B_GPIO2_IO12	0x40
++		>;
++	};
++
++	pinctrl_usdhc2: usdhc2grp {
++		fsl,pins = <
++			MX8MN_IOMUXC_GPIO1_IO04_USDHC2_VSELECT	0x1d0
++			MX8MN_IOMUXC_SD2_CLK_USDHC2_CLK		0x192
++			MX8MN_IOMUXC_SD2_CMD_USDHC2_CMD		0x1d2
++			MX8MN_IOMUXC_SD2_DATA0_USDHC2_DATA0	0x1d2
++			MX8MN_IOMUXC_SD2_DATA1_USDHC2_DATA1	0x1d2
++			MX8MN_IOMUXC_SD2_DATA2_USDHC2_DATA2	0x1d2
++			MX8MN_IOMUXC_SD2_DATA3_USDHC2_DATA3	0x1d2
++		>;
++	};
++
++	pinctrl_usdhc2_100mhz: usdhc2-100mhzgrp {
++		fsl,pins = <
++			MX8MN_IOMUXC_GPIO1_IO04_USDHC2_VSELECT	0x1d0
++			MX8MN_IOMUXC_SD2_CLK_USDHC2_CLK		0x194
++			MX8MN_IOMUXC_SD2_CMD_USDHC2_CMD		0x1d4
++			MX8MN_IOMUXC_SD2_DATA0_USDHC2_DATA0	0x1d4
++			MX8MN_IOMUXC_SD2_DATA1_USDHC2_DATA1	0x1d4
++			MX8MN_IOMUXC_SD2_DATA2_USDHC2_DATA2	0x1d4
++			MX8MN_IOMUXC_SD2_DATA3_USDHC2_DATA3	0x1d4
++		>;
++	};
++
++	pinctrl_usdhc2_200mhz: usdhc2-200mhzgrp {
++		fsl,pins = <
++			MX8MN_IOMUXC_GPIO1_IO04_USDHC2_VSELECT	0x1d0
++			MX8MN_IOMUXC_SD2_CLK_USDHC2_CLK		0x196
++			MX8MN_IOMUXC_SD2_CMD_USDHC2_CMD		0x1d6
++			MX8MN_IOMUXC_SD2_DATA0_USDHC2_DATA0	0x1d6
++			MX8MN_IOMUXC_SD2_DATA1_USDHC2_DATA1	0x1d6
++			MX8MN_IOMUXC_SD2_DATA2_USDHC2_DATA2	0x1d6
++			MX8MN_IOMUXC_SD2_DATA3_USDHC2_DATA3	0x1d6
++		>;
++	};
++
++	pinctrl_wlan: wlangrp {
++		fsl,pins = <
++			MX8MN_IOMUXC_SD1_DATA5_GPIO2_IO7	0x00
++		>;
++	};
++};
+diff --git a/arch/arm/dts/imx8mn-phycore-som.dtsi b/arch/arm/dts/imx8mn-phycore-som.dtsi
+new file mode 100644
+index 00000000000..8316134491b
+--- /dev/null
++++ b/arch/arm/dts/imx8mn-phycore-som.dtsi
+@@ -0,0 +1,437 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Copyright (C) 2020 PHYTEC Messtechnik GmbH
++ * Author: Teresa Remmet <t.remmet@phytec.de>
++ */
++
++#include "imx8mn.dtsi"
++#include <dt-bindings/net/ti-dp83867.h>
++
++/ {
++	model = "PHYTEC phyCORE-i.MX8MN";
++	compatible = "phytec,imx8mn-phycore-som", "fsl,imx8mn";
++
++	aliases {
++		rtc0 = &rv3028;
++		rtc1 = &snvs_rtc;
++	};
++
++	memory@40000000 {
++		device_type = "memory";
++		reg = <0x0 0x40000000 0 0x40000000>;
++	};
++};
++
++&A53_0 {
++	cpu-supply = <&reg_vdd_arm>;
++};
++
++&A53_1 {
++	cpu-supply = <&reg_vdd_arm>;
++};
++
++&A53_2 {
++	cpu-supply = <&reg_vdd_arm>;
++};
++
++&A53_3 {
++	cpu-supply = <&reg_vdd_arm>;
++};
++
++/* Ethernet */
++&fec1 {
++	fsl,magic-packet;
++	phy-mode = "rgmii-id";
++	phy-handle = <&ethphy0>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_fec1>;
++	status = "okay";
++
++	mdio {
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		ethphy0: ethernet-phy@0 {
++			compatible = "ethernet-phy-ieee802.3-c22";
++			enet-phy-lane-no-swap;
++			ti,clk-output-sel = <DP83867_CLK_O_SEL_OFF>;
++			ti,fifo-depth = <DP83867_PHYCR_FIFO_DEPTH_4_B_NIB>;
++			ti,rx-internal-delay = <DP83867_RGMIIDCTL_2_00_NS>;
++			ti,tx-internal-delay = <DP83867_RGMIIDCTL_2_00_NS>;
++			reg = <0>;
++			reset-assert-us = <1000>;
++			reset-deassert-us = <1000>;
++			reset-gpios = <&gpio1 7 GPIO_ACTIVE_HIGH>;
++		};
++	};
++};
++
++/* SPI Flash */
++&flexspi {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_flexspi0>;
++	status = "okay";
++
++	flash0: norflash@0 {
++		compatible = "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <80000000>;
++		spi-rx-bus-width = <4>;
++		spi-tx-bus-width = <1>;
++		#address-cells = <1>;
++		#size-cells = <1>;
++	};
++};
++
++&gpio1 {
++	gpio-line-names = "", "", "WDOG_INT", "X_RTC_INT",
++		"", "", "", "RESET_ETHPHY",
++		"", "", "nENABLE_FLATLINK";
++};
++
++/* GPU */
++&gpu {
++	status = "okay";
++};
++
++/* I2C1 */
++&i2c1 {
++	clock-frequency = <400000>;
++	pinctrl-names = "default", "gpio";
++	pinctrl-0 = <&pinctrl_i2c1>;
++	pinctrl-1 = <&pinctrl_i2c1_gpio>;
++	scl-gpios = <&gpio5 14 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
++	sda-gpios = <&gpio5 15 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
++	status = "okay";
++
++	pmic@8 {
++		compatible = "nxp,pf8121a";
++		reg = <0x08>;
++
++		regulators {
++			reg_nvcc_sd1: ldo1 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-max-microvolt = <3300000>;
++				regulator-min-microvolt = <3300000>;
++				regulator-name = "NVCC_SD1";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++				};
++			};
++
++			reg_nvcc_sd2: ldo2 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-max-microvolt = <3300000>;
++				regulator-min-microvolt = <1800000>;
++				regulator-name = "NVCC_SD2";
++				vselect-en;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			reg_vcc_enet: ldo3 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-max-microvolt = <2500000>;
++				regulator-min-microvolt = <1500000>;
++				regulator-name = "VCC_ENET_2V5";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			reg_vdda_1v8: ldo4 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-max-microvolt = <1800000>;
++				regulator-min-microvolt = <1500000>;
++				regulator-name = "VDDA_1V8";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-max-microvolt = <1500000>;
++					regulator-suspend-min-microvolt = <1500000>;
++				};
++			};
++
++			reg_soc_vdda_phy: buck1 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-max-microvolt = <1000000>;
++				regulator-min-microvolt = <400000>;
++				regulator-name = "VDD_SOC_VDDA_PHY_0P8";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-max-microvolt = <400000>;
++					regulator-suspend-min-microvolt = <400000>;
++				};
++			};
++
++			reg_vdd_gpu_dram: buck2 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-max-microvolt = <1000000>;
++				regulator-min-microvolt = <1000000>;
++				regulator-name = "VDD_GPU_DRAM";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-max-microvolt = <1000000>;
++					regulator-suspend-min-microvolt = <1000000>;
++				};
++			};
++
++			reg_vdd_mipi: buck4 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-max-microvolt = <850000>;
++				regulator-min-microvolt = <850000>;
++				regulator-name = "VDD_MIPI_0P8";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			reg_vdd_arm: buck5 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-max-microvolt = <1050000>;
++				regulator-min-microvolt = <400000>;
++				regulator-name = "VDD_ARM";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			reg_vdd_1v8: buck6 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-max-microvolt = <1800000>;
++				regulator-min-microvolt = <1800000>;
++				regulator-name = "VDD_1V8";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-max-microvolt = <1800000>;
++					regulator-suspend-min-microvolt = <1800000>;
++				};
++			};
++
++			reg_nvcc_dram: buck7 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-max-microvolt = <1100000>;
++				regulator-min-microvolt = <1100000>;
++				regulator-name = "NVCC_DRAM_1P1V";
++			};
++
++			reg_vsnvs: vsnvs {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-max-microvolt = <1800000>;
++				regulator-min-microvolt = <1800000>;
++				regulator-name = "NVCC_SNVS_1P8";
++			};
++
++			reg_vdd_3v3_s: regulator-vdd-3v3-s {
++				compatible = "regulator-fixed";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-max-microvolt = <3300000>;
++				regulator-min-microvolt = <3300000>;
++				regulator-name = "VDD_3V3_S";
++			};
++		};
++	};
++
++	/* EEPROM */
++	eeprom@51 {
++		compatible = "atmel,24c32";
++		pagesize = <32>;
++		reg = <0x51>;
++		vcc-supply = <&reg_vdd_3v3_s>;
++	};
++
++	/* RTC */
++	rv3028: rtc@52 {
++		compatible = "microcrystal,rv3028";
++		reg = <0x52>;
++	};
++
++	sn65dsi83: bridge@2d {
++		compatible = "ti,sn65dsi83";
++		enable-gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_sn65dsi83>;
++		reg = <0x2d>;
++		status = "disabled";
++	};
++
++	/* EEPROM ID page */
++	eepromid@59 {
++		compatible = "atmel,24c32";
++		pagesize = <32>;
++		reg = <0x59>;
++		size = <32>;
++	};
++
++	i2c1_sn65dsi83: mipitolvds@2d {
++		compatible = "ti,sn65dsi83";
++		enable-gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_sn65dsi83>;
++		reg = <0x2d>;
++		status = "disabled";
++
++		sn65dsi83_ports: ports {
++		       /*
++			* Setup is carrier board dependent please checkout
++			* overlays/imx8mn-phyboard-polis-peb-av-010.dtbo
++			* as an example.
++			*/
++		};
++	};
++};
++
++/* eMMC */
++&usdhc3 {
++	assigned-clocks = <&clk IMX8MN_CLK_USDHC3_ROOT>;
++	assigned-clock-rates = <400000000>;
++	bus-width = <8>;
++	non-removable;
++	pinctrl-names = "default", "state_100mhz", "state_200mhz";
++	pinctrl-0 = <&pinctrl_usdhc3>;
++	pinctrl-1 = <&pinctrl_usdhc3_100mhz>;
++	pinctrl-2 = <&pinctrl_usdhc3_200mhz>;
++	status = "okay";
++};
++
++/* Watchdog */
++&wdog1 {
++	fsl,ext-reset-output;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_wdog>;
++	status = "okay";
++};
++
++&iomuxc {
++	pinctrl_fec1: fec1grp {
++		fsl,pins = <
++			MX8MN_IOMUXC_ENET_MDC_ENET1_MDC			0x2
++			MX8MN_IOMUXC_ENET_MDIO_ENET1_MDIO		0x2
++			MX8MN_IOMUXC_ENET_RD0_ENET1_RGMII_RD0		0x90
++			MX8MN_IOMUXC_ENET_RD1_ENET1_RGMII_RD1		0x90
++			MX8MN_IOMUXC_ENET_RD2_ENET1_RGMII_RD2		0x90
++			MX8MN_IOMUXC_ENET_RD3_ENET1_RGMII_RD3		0x90
++			MX8MN_IOMUXC_ENET_RXC_ENET1_RGMII_RXC		0x90
++			MX8MN_IOMUXC_ENET_RX_CTL_ENET1_RGMII_RX_CTL	0x90
++			MX8MN_IOMUXC_ENET_TD0_ENET1_RGMII_TD0		0x16
++			MX8MN_IOMUXC_ENET_TD1_ENET1_RGMII_TD1		0x16
++			MX8MN_IOMUXC_ENET_TD2_ENET1_RGMII_TD2		0x16
++			MX8MN_IOMUXC_ENET_TD3_ENET1_RGMII_TD3		0x16
++			MX8MN_IOMUXC_ENET_TXC_ENET1_RGMII_TXC		0x16
++			MX8MN_IOMUXC_ENET_TX_CTL_ENET1_RGMII_TX_CTL	0x16
++			MX8MN_IOMUXC_GPIO1_IO07_GPIO1_IO7		0x10
++		>;
++	};
++
++	pinctrl_flexspi0: flexspi0grp {
++		fsl,pins = <
++			MX8MN_IOMUXC_NAND_ALE_QSPI_A_SCLK		0x1c2
++			MX8MN_IOMUXC_NAND_CE0_B_QSPI_A_SS0_B		0x82
++			MX8MN_IOMUXC_NAND_DATA00_QSPI_A_DATA0		0x82
++			MX8MN_IOMUXC_NAND_DATA01_QSPI_A_DATA1		0x82
++			MX8MN_IOMUXC_NAND_DATA02_QSPI_A_DATA2		0x82
++			MX8MN_IOMUXC_NAND_DATA03_QSPI_A_DATA3		0x82
++		>;
++	};
++
++	pinctrl_i2c1: i2c1grp {
++		fsl,pins = <
++			MX8MN_IOMUXC_I2C1_SDA_I2C1_SDA			0x400001c0
++			MX8MN_IOMUXC_I2C1_SCL_I2C1_SCL			0x400001c0
++		>;
++	};
++
++	pinctrl_i2c1_gpio: i2c1gpiogrp {
++		fsl,pins = <
++			MX8MN_IOMUXC_I2C1_SDA_GPIO5_IO15		0x1c0
++			MX8MN_IOMUXC_I2C1_SCL_GPIO5_IO14		0x1c0
++		>;
++	};
++
++	pinctrl_rtc: rtcgrp {
++		fsl,pins = <
++			MX8MN_IOMUXC_GPIO1_IO03_GPIO1_IO3		0x1C0
++		>;
++	};
++
++	pinctrl_sn65dsi83: sn65dsi83grp {
++		fsl,pins = <
++			MX8MN_IOMUXC_GPIO1_IO10_GPIO1_IO10		0x0
++		>;
++	};
++
++	pinctrl_usdhc3: usdhc3grp {
++		fsl,pins = <
++			MX8MN_IOMUXC_NAND_CLE_USDHC3_DATA7		0x1d0
++			MX8MN_IOMUXC_NAND_CE1_B_USDHC3_STROBE		0x190
++			MX8MN_IOMUXC_NAND_CE2_B_USDHC3_DATA5		0x1d0
++			MX8MN_IOMUXC_NAND_CE3_B_USDHC3_DATA6		0x1d0
++			MX8MN_IOMUXC_NAND_DATA04_USDHC3_DATA0		0x1d0
++			MX8MN_IOMUXC_NAND_DATA05_USDHC3_DATA1		0x1d0
++			MX8MN_IOMUXC_NAND_DATA06_USDHC3_DATA2		0x1d0
++			MX8MN_IOMUXC_NAND_DATA07_USDHC3_DATA3		0x1d0
++			MX8MN_IOMUXC_NAND_RE_B_USDHC3_DATA4		0x1d0
++			MX8MN_IOMUXC_NAND_WE_B_USDHC3_CLK		0x190
++			MX8MN_IOMUXC_NAND_WP_B_USDHC3_CMD		0x1d0
++		>;
++	};
++
++	pinctrl_usdhc3_100mhz: usdhc3-100mhzgrp {
++		fsl,pins = <
++			MX8MN_IOMUXC_NAND_CLE_USDHC3_DATA7		0x1d4
++			MX8MN_IOMUXC_NAND_CE1_B_USDHC3_STROBE		0x194
++			MX8MN_IOMUXC_NAND_CE2_B_USDHC3_DATA5		0x1d4
++			MX8MN_IOMUXC_NAND_CE3_B_USDHC3_DATA6		0x1d4
++			MX8MN_IOMUXC_NAND_DATA04_USDHC3_DATA0		0x1d4
++			MX8MN_IOMUXC_NAND_DATA05_USDHC3_DATA1		0x1d4
++			MX8MN_IOMUXC_NAND_DATA06_USDHC3_DATA2		0x1d4
++			MX8MN_IOMUXC_NAND_DATA07_USDHC3_DATA3		0x1d4
++			MX8MN_IOMUXC_NAND_RE_B_USDHC3_DATA4		0x1d4
++			MX8MN_IOMUXC_NAND_WE_B_USDHC3_CLK		0x194
++			MX8MN_IOMUXC_NAND_WP_B_USDHC3_CMD		0x1d4
++		>;
++	};
++
++	pinctrl_usdhc3_200mhz: usdhc3-200mhzgrp {
++		fsl,pins = <
++			MX8MN_IOMUXC_NAND_CLE_USDHC3_DATA7		0x1d6
++			MX8MN_IOMUXC_NAND_CE1_B_USDHC3_STROBE		0x196
++			MX8MN_IOMUXC_NAND_CE2_B_USDHC3_DATA5		0x1d6
++			MX8MN_IOMUXC_NAND_CE3_B_USDHC3_DATA6		0x1d6
++			MX8MN_IOMUXC_NAND_DATA04_USDHC3_DATA0		0x1d6
++			MX8MN_IOMUXC_NAND_DATA05_USDHC3_DATA1		0x1d6
++			MX8MN_IOMUXC_NAND_DATA06_USDHC3_DATA2		0x1d6
++			MX8MN_IOMUXC_NAND_DATA07_USDHC3_DATA3		0x1d6
++			MX8MN_IOMUXC_NAND_RE_B_USDHC3_DATA4		0x1d6
++			MX8MN_IOMUXC_NAND_WE_B_USDHC3_CLK		0x196
++			MX8MN_IOMUXC_NAND_WP_B_USDHC3_CMD		0x1d6
++		>;
++	};
++
++	pinctrl_wdog: wdoggrp {
++		fsl,pins = <
++			MX8MN_IOMUXC_GPIO1_IO02_WDOG1_WDOG_B		0x26
++		>;
++	};
++};
+diff --git a/arch/arm/dts/imx8mn-u-boot.dtsi b/arch/arm/dts/imx8mn-u-boot.dtsi
+new file mode 100644
+index 00000000000..5ec52e4ac00
+--- /dev/null
++++ b/arch/arm/dts/imx8mn-u-boot.dtsi
+@@ -0,0 +1,183 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright (C) 2023 PHYTEC Messtechnik GmbH
++ * Author: Yannic Moog <y.moog@phytec.de>
++ */
++
++/ {
++	binman: binman {
++		multiple-images;
++	};
++};
++
++&{/soc@0} {
++	u-boot,dm-pre-reloc;
++	u-boot,dm-spl;
++};
++
++&aips1 {
++	u-boot,dm-pre-reloc;
++	u-boot,dm-spl;
++};
++
++&aips2 {
++	u-boot,dm-spl;
++};
++
++&aips3 {
++	u-boot,dm-spl;
++};
++
++&binman {
++	u-boot-spl-ddr {
++		align = <4>;
++		align-size = <4>;
++		filename = "u-boot-spl-ddr.bin";
++		pad-byte = <0xff>;
++
++		u-boot-spl {
++			align-end = <4>;
++			filename = "u-boot-spl.bin";
++		};
++
++		blob_1d_imem: blob-ext@1 {
++			filename = "lpddr4_pmu_train_1d_imem.bin";
++			size = <0x8000>;
++			type = "blob-ext";
++		};
++
++		blob_1d_dmem: blob-ext@2 {
++			filename = "lpddr4_pmu_train_1d_dmem.bin";
++			size = <0x4000>;
++			type = "blob-ext";
++		};
++
++		blob_2d_imem: blob-ext@3 {
++			filename = "lpddr4_pmu_train_2d_imem.bin";
++			size = <0x8000>;
++			type = "blob-ext";
++		};
++
++		blob_2d_dmem: blob-ext@4 {
++			filename = "lpddr4_pmu_train_2d_dmem.bin";
++			size = <0x4000>;
++			type = "blob-ext";
++		};
++	};
++
++	spl {
++		filename = "spl.bin";
++
++		mkimage {
++			args = "-n spl/u-boot-spl.cfgout -T imx8mimage -e 0x912000";
++
++			blob {
++				filename = "u-boot-spl-ddr.bin";
++			};
++		};
++	};
++
++	itb {
++		filename = "u-boot.itb";
++
++		fit {
++			description = "Configuration to load ATF before U-Boot";
++			fit,external-offset = <CONFIG_FIT_EXTERNAL_OFFSET>;
++			fit,fdt-list = "of-list";
++			#address-cells = <1>;
++
++			images {
++				uboot {
++					arch = "arm64";
++					compression = "none";
++					description = "U-Boot (64-bit)";
++					load = <CONFIG_SYS_TEXT_BASE>;
++					type = "standalone";
++
++					uboot-blob {
++						filename = "u-boot-nodtb.bin";
++						type = "blob-ext";
++					};
++				};
++
++				atf {
++					arch = "arm64";
++					compression = "none";
++					description = "ARM Trusted Firmware";
++					entry = <0x960000>;
++					load = <0x960000>;
++					type = "firmware";
++
++					atf-blob {
++						filename = "bl31.bin";
++						type = "blob-ext";
++					};
++				};
++
++				binman_fip: fip {
++					arch = "arm64";
++					compression = "none";
++					description = "Trusted Firmware FIP";
++					load = <0x40310000>;
++					type = "firmware";
++				};
++
++				@fdt-SEQ {
++					compression = "none";
++					description = "NAME";
++					type = "flat_dt";
++
++					uboot-fdt-blob {
++						filename = "u-boot.dtb";
++						type = "blob-ext";
++					};
++				};
++			};
++
++			configurations {
++				default = "@config-DEFAULT-SEQ";
++
++				binman_configuration: @config-SEQ {
++					description = "NAME";
++					fdt = "fdt-SEQ";
++					firmware = "uboot";
++					loadables = "atf";
++				};
++			};
++		};
++	};
++
++	imx-boot {
++		filename = "flash.bin";
++		pad-byte = <0x00>;
++
++		spl {
++			filename = "spl.bin";
++			offset = <0x0>;
++			type = "blob-ext";
++		};
++
++		binman_uboot: uboot {
++			filename = "u-boot.itb";
++			offset = <0x58000>;
++			type = "blob-ext";
++		};
++	};
++};
++
++&clk {
++	u-boot,dm-pre-reloc;
++	u-boot,dm-spl;
++	/delete-property/ assigned-clocks;
++	/delete-property/ assigned-clock-parents;
++	/delete-property/ assigned-clock-rates;
++};
++
++&iomuxc {
++	u-boot,dm-spl;
++};
++
++&osc_24m {
++	u-boot,dm-pre-reloc;
++	u-boot,dm-spl;
++};
+diff --git a/arch/arm/dts/imx8mp-phyboard-pollux-rdk.dts b/arch/arm/dts/imx8mp-phyboard-pollux-rdk.dts
+index 984a6b9ded8..3083530cd38 100644
+--- a/arch/arm/dts/imx8mp-phyboard-pollux-rdk.dts
++++ b/arch/arm/dts/imx8mp-phyboard-pollux-rdk.dts
+@@ -19,6 +19,56 @@
+ 		stdout-path = &uart1;
+ 	};
+ 
++	backlight1: backlight1 {
++		compatible = "pwm-backlight";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_lvds1>;
++		default-brightness-level = <6>;
++		pwms = <&pwm3 0 50000 0>;
++		power-supply = <&reg_lvds1_reg_en>;
++		enable-gpios = <&gpio2 20 GPIO_ACTIVE_LOW>;
++		brightness-levels= <0 4 8 16 32 64 128 255>;
++	};
++
++	fan {
++		compatible = "gpio-fan";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_fan>;
++		gpios = <&gpio5 4 GPIO_ACTIVE_HIGH>;
++		gpio-fan,speed-map = <0     0
++				      13000 1>;
++		#cooling-cells = <2>;
++	};
++
++	reg_can1_stby: regulator-can1-stby {
++		compatible = "regulator-fixed";
++		regulator-name = "can1-stby";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_flexcan1_reg>;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		gpio = <&gpio3 20 GPIO_ACTIVE_LOW>;
++	};
++
++	reg_can2_stby: regulator-can2-stby {
++		compatible = "regulator-fixed";
++		regulator-name = "can2-stby";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_flexcan2_reg>;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		gpio = <&gpio3 21 GPIO_ACTIVE_LOW>;
++	};
++
++	reg_lvds1_reg_en: regulator-lvds1 {
++		compatible = "regulator-fixed";
++		regulator-name = "lvds1_reg_en";
++		regulator-min-microvolt = <12000000>;
++		regulator-max-microvolt = <12000000>;
++		gpio = <&gpio1 9 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++	};
++
+ 	reg_usdhc2_vmmc: regulator-usdhc2 {
+ 		compatible = "regulator-fixed";
+ 		pinctrl-names = "default";
+@@ -31,13 +81,47 @@
+ 		startup-delay-us = <100>;
+ 		off-on-delay-us = <12000>;
+ 	};
++
++	reserved-memory {
++		#address-cells = <2>;
++		#size-cells = <2>;
++		ranges;
++
++		rpmsg_reserved: rpmsg@0x55800000 {
++			no-map;
++			reg = <0 0x55800000 0 0x800000>;
++		};
++	};
+ };
+ 
++/* TPM */
++&ecspi1 {
++	#address-cells = <1>;
++	#size-cells = <0>;
++	cs-gpios = <&gpio5 9 GPIO_ACTIVE_LOW>;
++	num-cs = <1>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_ecspi1 &pinctrl_ecspi1_cs>;
++	status = "okay";
++
++	tpm: tpm_tis@0 {
++		compatible = "tcg,tpm_tis-spi";
++		interrupts = <1 IRQ_TYPE_LEVEL_LOW>;
++		interrupt-parent = <&gpio4>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_tpm>;
++		reg = <0>;
++		spi-max-frequency = <38000000>;
++		status = "okay";
++	};
++};
++
++/* Ethernet */
+ &eqos {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&pinctrl_eqos>;
+ 	phy-mode = "rgmii-id";
+-	phy-handle = <&ethphy0>;
++	phy-handle = <&ethphy1>;
+ 	status = "okay";
+ 
+ 	mdio {
+@@ -45,7 +129,7 @@
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+ 
+-		ethphy0: ethernet-phy@1 {
++		ethphy1: ethernet-phy@1 {
+ 			compatible = "ethernet-phy-ieee802.3-c22";
+ 			reg = <0x1>;
+ 			ti,rx-internal-delay = <DP83867_RGMIIDCTL_1_50_NS>;
+@@ -57,7 +141,23 @@
+ 	};
+ };
+ 
+-&i2c2 {
++/* CAN FD1 */
++&flexcan1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_flexcan1>;
++	xceiver-supply = <&reg_can1_stby>;
++	status = "okay";
++};
++
++/* CAN FD2 */
++&flexcan2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_flexcan2>;
++	xceiver-supply = <&reg_can2_stby>;
++	status = "okay";
++};
++
++csi2_i2c: &i2c2 {
+ 	clock-frequency = <400000>;
+ 	pinctrl-names = "default", "gpio";
+ 	pinctrl-0 = <&pinctrl_i2c2>;
+@@ -66,6 +166,7 @@
+ 	scl-gpios = <&gpio5 16 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+ 	status = "okay";
+ 
++	/* EEPROM */
+ 	eeprom@51 {
+ 		compatible = "atmel,24c02";
+ 		reg = <0x51>;
+@@ -76,94 +177,308 @@
+ 		compatible = "nxp,pca9533";
+ 		reg = <0x62>;
+ 
+-		led1 {
++		led-1 {
+ 			type = <PCA9532_TYPE_LED>;
+ 		};
+ 
+-		led2 {
++		led-2 {
+ 			type = <PCA9532_TYPE_LED>;
+ 		};
+ 
+-		led3 {
++		led-3 {
+ 			type = <PCA9532_TYPE_LED>;
+ 		};
+ 	};
+ };
+ 
++csi1_i2c: &i2c3 {
++	clock-frequency = <400000>;
++	pinctrl-names = "default", "gpio";
++	pinctrl-0 = <&pinctrl_i2c3>;
++	pinctrl-1 = <&pinctrl_i2c3_gpio>;
++	sda-gpios = <&gpio5 18 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
++	scl-gpios = <&gpio5 19 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
++};
++
++/* Mini PCIe */
++&pcie{
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_pcie>;
++	clkreq-gpio = <&gpio1 11 GPIO_ACTIVE_LOW>;
++	disable-gpio = <&gpio1 14 GPIO_ACTIVE_LOW>;
++	reset-gpio = <&gpio1 8 GPIO_ACTIVE_LOW>;
++	ext_osc = <0>;
++	clocks = <&clk IMX8MP_CLK_HSIO_ROOT>,
++		 <&clk IMX8MP_CLK_PCIE_AUX>,
++		 <&clk IMX8MP_CLK_HSIO_AXI>,
++		 <&clk IMX8MP_CLK_PCIE_ROOT>;
++	clock-names = "pcie", "pcie_aux", "pcie_phy", "pcie_bus";
++	assigned-clocks = <&clk IMX8MP_CLK_HSIO_AXI>,
++			  <&clk IMX8MP_CLK_PCIE_AUX>;
++	assigned-clock-rates = <500000000>, <10000000>;
++	assigned-clock-parents = <&clk IMX8MP_SYS_PLL2_500M>,
++				 <&clk IMX8MP_SYS_PLL2_50M>;
++	reserved-region = <&rpmsg_reserved>;
++	status = "okay";
++};
++
++&pcie_phy{
++	ext_osc = <0>;
++	status = "okay";
++};
++
++/* PWM */
++&pwm3 {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_pwm3>;
++};
++
+ &snvs_pwrkey {
+ 	status = "okay";
+ };
+ 
+-/* debug console */
++/* RTC */
++&rv3028 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_rtc>;
++	interrupt-parent = <&gpio4>;
++	interrupts = <19 IRQ_TYPE_LEVEL_LOW>;
++	wakeup-source;
++	trickle-resistor-ohms = <3000>;
++};
++
++/* UART - console */
+ &uart1 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&pinctrl_uart1>;
+ 	status = "okay";
+ };
+ 
++/* UART - RS232/RS485 */
++&uart2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_uart2>;
++	assigned-clocks = <&clk IMX8MP_CLK_UART2>;
++	assigned-clock-parents = <&clk IMX8MP_SYS_PLL1_80M>;
++	uart-has-rtscts;
++	status = "okay";
++};
++
++/* USB */
++&usb3_phy0 {
++	status = "okay";
++};
++
++&usb3_0 {
++	status = "okay";
++};
++
++&usb_dwc3_0 {
++	dr_mode = "host";
++	status = "okay";
++};
++
++&usb3_phy1 {
++	status = "okay";
++};
++
++&usb3_1 {
++	status = "okay";
++};
++
++&usb_dwc3_1 {
++	dr_mode = "host";
++	status = "okay";
++};
++
+ /* SD-Card */
+ &usdhc2 {
++	assigned-clocks = <&clk IMX8MP_CLK_USDHC2>;
++	assigned-clock-rates = <200000000>;
++	disable-wp;
+ 	pinctrl-names = "default", "state_100mhz", "state_200mhz";
+ 	pinctrl-0 = <&pinctrl_usdhc2>, <&pinctrl_usdhc2_pins>;
+ 	pinctrl-1 = <&pinctrl_usdhc2_100mhz>, <&pinctrl_usdhc2_pins>;
+ 	pinctrl-2 = <&pinctrl_usdhc2_200mhz>, <&pinctrl_usdhc2_pins>;
+ 	cd-gpios = <&gpio2 12 GPIO_ACTIVE_LOW>;
+ 	vmmc-supply = <&reg_usdhc2_vmmc>;
++	vqmmc-supply = <&ldo5>;
+ 	bus-width = <4>;
+ 	status = "okay";
+ };
+ 
+ &iomuxc {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_hog>;
++
++	pinctrl_ecspi1: ecspi1grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_ECSPI1_MISO__ECSPI1_MISO	0x80
++			MX8MP_IOMUXC_ECSPI1_MOSI__ECSPI1_MOSI	0x80
++			MX8MP_IOMUXC_ECSPI1_SCLK__ECSPI1_SCLK	0x80
++		>;
++	};
++
++	pinctrl_ecspi1_cs: ecspi1csgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_ECSPI1_SS0__GPIO5_IO09	0x00
++		>;
++	};
++
+ 	pinctrl_eqos: eqosgrp {
+ 		fsl,pins = <
+-			MX8MP_IOMUXC_ENET_MDC__ENET_QOS_MDC			0x3
+-			MX8MP_IOMUXC_ENET_MDIO__ENET_QOS_MDIO			0x3
+-			MX8MP_IOMUXC_ENET_RD0__ENET_QOS_RGMII_RD0		0x91
+-			MX8MP_IOMUXC_ENET_RD1__ENET_QOS_RGMII_RD1		0x91
+-			MX8MP_IOMUXC_ENET_RD2__ENET_QOS_RGMII_RD2		0x91
+-			MX8MP_IOMUXC_ENET_RD3__ENET_QOS_RGMII_RD3		0x91
+-			MX8MP_IOMUXC_ENET_RXC__CCM_ENET_QOS_CLOCK_GENERATE_RX_CLK	0x91
+-			MX8MP_IOMUXC_ENET_RX_CTL__ENET_QOS_RGMII_RX_CTL		0x91
+-			MX8MP_IOMUXC_ENET_TD0__ENET_QOS_RGMII_TD0		0x1f
+-			MX8MP_IOMUXC_ENET_TD1__ENET_QOS_RGMII_TD1		0x1f
+-			MX8MP_IOMUXC_ENET_TD2__ENET_QOS_RGMII_TD2		0x1f
+-			MX8MP_IOMUXC_ENET_TD3__ENET_QOS_RGMII_TD3		0x1f
+-			MX8MP_IOMUXC_ENET_TX_CTL__ENET_QOS_RGMII_TX_CTL		0x1f
+-			MX8MP_IOMUXC_ENET_TXC__CCM_ENET_QOS_CLOCK_GENERATE_TX_CLK	0x1f
++			MX8MP_IOMUXC_ENET_MDC__ENET_QOS_MDC			0x2
++			MX8MP_IOMUXC_ENET_MDIO__ENET_QOS_MDIO			0x2
++			MX8MP_IOMUXC_ENET_RD0__ENET_QOS_RGMII_RD0		0x90
++			MX8MP_IOMUXC_ENET_RD1__ENET_QOS_RGMII_RD1		0x90
++			MX8MP_IOMUXC_ENET_RD2__ENET_QOS_RGMII_RD2		0x90
++			MX8MP_IOMUXC_ENET_RD3__ENET_QOS_RGMII_RD3		0x90
++			MX8MP_IOMUXC_ENET_RXC__CCM_ENET_QOS_CLOCK_GENERATE_RX_CLK	0x90
++			MX8MP_IOMUXC_ENET_RX_CTL__ENET_QOS_RGMII_RX_CTL		0x90
++			MX8MP_IOMUXC_ENET_TD0__ENET_QOS_RGMII_TD0		0x12
++			MX8MP_IOMUXC_ENET_TD1__ENET_QOS_RGMII_TD1		0x12
++			MX8MP_IOMUXC_ENET_TD2__ENET_QOS_RGMII_TD2		0x12
++			MX8MP_IOMUXC_ENET_TD3__ENET_QOS_RGMII_TD3		0x12
++			MX8MP_IOMUXC_ENET_TX_CTL__ENET_QOS_RGMII_TX_CTL		0x12
++			MX8MP_IOMUXC_ENET_TXC__CCM_ENET_QOS_CLOCK_GENERATE_TX_CLK	0x12
+ 			MX8MP_IOMUXC_SAI1_MCLK__GPIO4_IO20			0x10
+ 		>;
+ 	};
+ 
++	pinctrl_fan: fan0grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SPDIF_RX__GPIO5_IO04	0x16
++		>;
++	};
++
++	pinctrl_flexcan1: flexcan1grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI5_RXD2__CAN1_RX		0x154
++			MX8MP_IOMUXC_SAI5_RXD1__CAN1_TX		0x154
++		>;
++	};
++
++	pinctrl_flexcan2: flexcan2grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI5_MCLK__CAN2_RX		0x154
++			MX8MP_IOMUXC_SAI5_RXD3__CAN2_TX		0x154
++		>;
++	};
++
++	pinctrl_flexcan1_reg: flexcan1reggrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI5_RXC__GPIO3_IO20	0x154
++		>;
++	};
++
++	pinctrl_flexcan2_reg: flexcan2reggrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI5_RXD0__GPIO3_IO21	0x154
++		>;
++	};
++
++	pinctrl_hog: hoggrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_HDMI_DDC_SCL__HDMIMIX_HDMI_SCL	0x400001c3
++			MX8MP_IOMUXC_HDMI_DDC_SDA__HDMIMIX_HDMI_SDA	0x400001c3
++			MX8MP_IOMUXC_HDMI_HPD__HDMIMIX_HDMI_HPD		0x40000019
++			MX8MP_IOMUXC_HDMI_CEC__HDMIMIX_HDMI_CEC		0x40000019
++		>;
++	};
++
+ 	pinctrl_i2c2: i2c2grp {
+ 		fsl,pins = <
+-			MX8MP_IOMUXC_I2C2_SCL__I2C2_SCL		0x400001c3
+-			MX8MP_IOMUXC_I2C2_SDA__I2C2_SDA		0x400001c3
++			MX8MP_IOMUXC_I2C2_SCL__I2C2_SCL		0x400001c2
++			MX8MP_IOMUXC_I2C2_SDA__I2C2_SDA		0x400001c2
+ 		>;
+ 	};
+ 
+ 	pinctrl_i2c2_gpio: i2c2gpiogrp {
+ 		fsl,pins = <
+-			MX8MP_IOMUXC_I2C2_SCL__GPIO5_IO16	0x1e3
+-			MX8MP_IOMUXC_I2C2_SDA__GPIO5_IO17	0x1e3
++			MX8MP_IOMUXC_I2C2_SCL__GPIO5_IO16	0x1e2
++			MX8MP_IOMUXC_I2C2_SDA__GPIO5_IO17	0x1e2
++		>;
++	};
++
++	pinctrl_i2c3: i2c3grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_I2C3_SCL__I2C3_SCL		0x400001c3
++			MX8MP_IOMUXC_I2C3_SDA__I2C3_SDA		0x400001c3
++		>;
++	};
++
++	pinctrl_i2c3_gpio: i2c3gpiogrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_I2C3_SCL__GPIO5_IO18	0x1e3
++			MX8MP_IOMUXC_I2C3_SDA__GPIO5_IO19	0x1e3
++		>;
++	};
++
++	pinctrl_lvds1: lvds1grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SD2_WP__GPIO2_IO20		0x12
++			MX8MP_IOMUXC_GPIO1_IO09__GPIO1_IO09	0x12
++		>;
++	};
++
++	pinctrl_pcie: pciegrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_GPIO1_IO08__GPIO1_IO08	0x41
++			MX8MP_IOMUXC_GPIO1_IO11__GPIO1_IO11	0x61
++			MX8MP_IOMUXC_GPIO1_IO14__GPIO1_IO14	0x41
++		>;
++	};
++
++	pinctrl_pwm3: pwm3grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SPDIF_TX__PWM3_OUT		0x12
+ 		>;
+ 	};
+ 
+ 	pinctrl_reg_usdhc2_vmmc: regusdhc2vmmcgrp {
+ 		fsl,pins = <
+-			MX8MP_IOMUXC_SD2_RESET_B__GPIO2_IO19	0x41
++			MX8MP_IOMUXC_SD2_RESET_B__GPIO2_IO19	0x40
++		>;
++	};
++
++	pinctrl_rtc: rtcgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI1_TXD7__GPIO4_IO19	0x1C0
++		>;
++	};
++
++	pinctrl_tpm: tpmgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI1_RXC__GPIO4_IO01	0x140
+ 		>;
+ 	};
+ 
+ 	pinctrl_uart1: uart1grp {
+ 		fsl,pins = <
+-			MX8MP_IOMUXC_UART1_RXD__UART1_DCE_RX	0x49
+-			MX8MP_IOMUXC_UART1_TXD__UART1_DCE_TX	0x49
++			MX8MP_IOMUXC_UART1_RXD__UART1_DCE_RX	0x140
++			MX8MP_IOMUXC_UART1_TXD__UART1_DCE_TX	0x140
++		>;
++	};
++
++	pinctrl_usb1_vbus: usb1grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_GPIO1_IO12__GPIO1_IO12     0x19
++		>;
++	};
++
++	pinctrl_uart2: uart2grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_UART2_RXD__UART2_DCE_RX	0x49
++			MX8MP_IOMUXC_UART2_TXD__UART2_DCE_TX	0x49
++			MX8MP_IOMUXC_SAI3_RXC__UART2_DCE_CTS	0x140
++			MX8MP_IOMUXC_SAI3_RXD__UART2_DCE_RTS	0x140
+ 		>;
+ 	};
+ 
+ 	pinctrl_usdhc2_pins: usdhc2-gpiogrp {
+ 		fsl,pins = <
+-			MX8MP_IOMUXC_SD2_CD_B__GPIO2_IO12	0x1c4
++			MX8MP_IOMUXC_SD2_CD_B__GPIO2_IO12	0x41
+ 		>;
+ 	};
+ 
+@@ -175,7 +490,7 @@
+ 			MX8MP_IOMUXC_SD2_DATA1__USDHC2_DATA1	0x1d0
+ 			MX8MP_IOMUXC_SD2_DATA2__USDHC2_DATA2	0x1d0
+ 			MX8MP_IOMUXC_SD2_DATA3__USDHC2_DATA3	0x1d0
+-			MX8MP_IOMUXC_GPIO1_IO04__USDHC2_VSELECT	0xc1
++			MX8MP_IOMUXC_GPIO1_IO04__USDHC2_VSELECT	0xc0
+ 		>;
+ 	};
+ 
+@@ -187,7 +502,7 @@
+ 			MX8MP_IOMUXC_SD2_DATA1__USDHC2_DATA1	0x1d4
+ 			MX8MP_IOMUXC_SD2_DATA2__USDHC2_DATA2	0x1d4
+ 			MX8MP_IOMUXC_SD2_DATA3__USDHC2_DATA3	0x1d4
+-			MX8MP_IOMUXC_GPIO1_IO04__USDHC2_VSELECT	0xc1
++			MX8MP_IOMUXC_GPIO1_IO04__USDHC2_VSELECT	0xc0
+ 		>;
+ 	};
+ 
+@@ -199,7 +514,7 @@
+ 			MX8MP_IOMUXC_SD2_DATA1__USDHC2_DATA1	0x1d6
+ 			MX8MP_IOMUXC_SD2_DATA2__USDHC2_DATA2	0x1d6
+ 			MX8MP_IOMUXC_SD2_DATA3__USDHC2_DATA3	0x1d6
+-			MX8MP_IOMUXC_GPIO1_IO04__USDHC2_VSELECT	0xc1
++			MX8MP_IOMUXC_GPIO1_IO04__USDHC2_VSELECT	0xc0
+ 		>;
+ 	};
+ };
+diff --git a/arch/arm/dts/imx8mp-phycore-som.dtsi b/arch/arm/dts/imx8mp-phycore-som.dtsi
+index f3965ec5b31..4e0876cfcdd 100644
+--- a/arch/arm/dts/imx8mp-phycore-som.dtsi
++++ b/arch/arm/dts/imx8mp-phycore-som.dtsi
+@@ -38,164 +38,186 @@
+ 	cpu-supply = <&buck2>;
+ };
+ 
+-/* ethernet 1 */
++/* Ethernet */
+ &fec {
++	fsl,magic-packet;
++	phy-handle = <&ethphy0>;
++	phy-mode = "rgmii-id";
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&pinctrl_fec>;
+-	phy-mode = "rgmii-id";
+-	phy-handle = <&ethphy1>;
+-	fsl,magic-packet;
+ 	status = "okay";
+ 
+ 	mdio {
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+ 
+-		ethphy1: ethernet-phy@0 {
++		ethphy0: ethernet-phy@0 {
+ 			compatible = "ethernet-phy-ieee802.3-c22";
++			enet-phy-lane-no-swap;
+ 			reg = <0>;
+-			interrupt-parent = <&gpio1>;
+-			interrupts = <15 IRQ_TYPE_EDGE_FALLING>;
++			ti,clk-output-sel = <DP83867_CLK_O_SEL_OFF>;
++			ti,fifo-depth = <DP83867_PHYCR_FIFO_DEPTH_4_B_NIB>;
++			ti,min-output-impedance;
+ 			ti,rx-internal-delay = <DP83867_RGMIIDCTL_2_00_NS>;
+ 			ti,tx-internal-delay = <DP83867_RGMIIDCTL_2_00_NS>;
+-			ti,fifo-depth = <DP83867_PHYCR_FIFO_DEPTH_4_B_NIB>;
+-			ti,clk-output-sel = <DP83867_CLK_O_SEL_OFF>;
+-			enet-phy-lane-no-swap;
+ 		};
+ 	};
+ };
+ 
++/* SPI Flash */
++&flexspi {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_flexspi0>;
++	status = "okay";
++
++	som_flash: flash@0 {
++		#address-cells = <1>;
++		#size-cells = <1>;
++		compatible = "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <80000000>;
++		spi-rx-bus-width = <4>;
++		spi-tx-bus-width = <1>;
++	};
++};
++
++/* I2C1 */
+ &i2c1 {
+ 	clock-frequency = <400000>;
+ 	pinctrl-names = "default", "gpio";
+ 	pinctrl-0 = <&pinctrl_i2c1>;
+ 	pinctrl-1 = <&pinctrl_i2c1_gpio>;
+-	sda-gpios = <&gpio5 15 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+ 	scl-gpios = <&gpio5 14 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
++	sda-gpios = <&gpio5 15 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+ 	status = "okay";
+ 
+ 	pmic: pmic@25 {
+-		reg = <0x25>;
+ 		compatible = "nxp,pca9450c";
++		interrupts = <18 IRQ_TYPE_LEVEL_LOW>;
++		interrupt-parent = <&gpio4>;
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&pinctrl_pmic>;
+-		interrupt-parent = <&gpio4>;
+-		interrupts = <18 IRQ_TYPE_LEVEL_LOW>;
++		reg = <0x25>;
+ 
+ 		regulators {
+ 			buck1: BUCK1 {
+-				regulator-compatible = "BUCK1";
+-				regulator-min-microvolt = <600000>;
+-				regulator-max-microvolt = <2187500>;
+-				regulator-boot-on;
+ 				regulator-always-on;
++				regulator-boot-on;
++				regulator-max-microvolt = <1000000>;
++				regulator-min-microvolt = <805000>;
++				regulator-name = "VDD_SOC (BUCK1)";
+ 				regulator-ramp-delay = <3125>;
+ 			};
+ 
+ 			buck2: BUCK2 {
+-				regulator-compatible = "BUCK2";
+-				regulator-min-microvolt = <600000>;
+-				regulator-max-microvolt = <2187500>;
+-				regulator-boot-on;
++				nxp,dvs-run-voltage = <950000>;
++				nxp,dvs-standby-voltage = <850000>;
+ 				regulator-always-on;
++				regulator-boot-on;
++				regulator-max-microvolt = <1050000>;
++				regulator-min-microvolt = <805000>;
++				regulator-name = "VDD_ARM (BUCK2)";
+ 				regulator-ramp-delay = <3125>;
+ 			};
+ 
+ 			buck4: BUCK4 {
+-				regulator-compatible = "BUCK4";
+-				regulator-min-microvolt = <600000>;
+-				regulator-max-microvolt = <3400000>;
+-				regulator-boot-on;
+ 				regulator-always-on;
++				regulator-boot-on;
++				regulator-max-microvolt = <3300000>;
++				regulator-min-microvolt = <3300000>;
++				regulator-name = "VDD_3V3 (BUCK4)";
+ 			};
+ 
+ 			buck5: BUCK5 {
+-				regulator-compatible = "BUCK5";
+-				regulator-min-microvolt = <600000>;
+-				regulator-max-microvolt = <3400000>;
+-				regulator-boot-on;
+ 				regulator-always-on;
++				regulator-boot-on;
++				regulator-max-microvolt = <1800000>;
++				regulator-min-microvolt = <1800000>;
++				regulator-name = "VDD_1V8 (BUCK5)";
+ 			};
+ 
+ 			buck6: BUCK6 {
+-				regulator-compatible = "BUCK6";
+-				regulator-min-microvolt = <600000>;
+-				regulator-max-microvolt = <3400000>;
+-				regulator-boot-on;
+ 				regulator-always-on;
++				regulator-boot-on;
++				regulator-max-microvolt = <1155000>;
++				regulator-min-microvolt = <1045000>;
++				regulator-name = "NVCC_DRAM_1V1 (BUCK6)";
+ 			};
+ 
+ 			ldo1: LDO1 {
+-				regulator-compatible = "LDO1";
+-				regulator-min-microvolt = <1600000>;
+-				regulator-max-microvolt = <3300000>;
+-				regulator-boot-on;
+ 				regulator-always-on;
+-			};
+-
+-			ldo2: LDO2 {
+-				regulator-compatible = "LDO2";
+-				regulator-min-microvolt = <800000>;
+-				regulator-max-microvolt = <1150000>;
+ 				regulator-boot-on;
+-				regulator-always-on;
++				regulator-max-microvolt = <1950000>;
++				regulator-min-microvolt = <1710000>;
++				regulator-name = "NVCC_SNVS_1V8 (LDO1)";
+ 			};
+ 
+ 			ldo3: LDO3 {
+-				regulator-compatible = "LDO3";
+-				regulator-min-microvolt = <800000>;
+-				regulator-max-microvolt = <3300000>;
+-				regulator-boot-on;
+ 				regulator-always-on;
+-			};
+-
+-			ldo4: LDO4 {
+-				regulator-compatible = "LDO4";
+-				regulator-min-microvolt = <800000>;
+-				regulator-max-microvolt = <3300000>;
+ 				regulator-boot-on;
+-				regulator-always-on;
++				regulator-max-microvolt = <1800000>;
++				regulator-min-microvolt = <1800000>;
++				regulator-name = "VDDA_1V8 (LDO3)";
+ 			};
+ 
+ 			ldo5: LDO5 {
+-				regulator-compatible = "LDO5";
+-				regulator-min-microvolt = <1800000>;
++				regulator-always-on;
++				regulator-boot-on;
+ 				regulator-max-microvolt = <3300000>;
++				regulator-min-microvolt = <1800000>;
++				regulator-name = "NVCC_SD2 (LDO5)";
+ 			};
+ 		};
+ 	};
+ 
++	/* EEPROM */
+ 	eeprom@51 {
+ 		compatible = "atmel,24c32";
+-		reg = <0x51>;
+ 		pagesize = <32>;
++		reg = <0x51>;
+ 	};
+ 
++	/* RTC */
+ 	rv3028: rtc@52 {
+ 		compatible = "microcrystal,rv3028";
+ 		reg = <0x52>;
+-		trickle-resistor-ohms = <3000>;
++	};
++
++	/* EEPROM ID page */
++	eepromid@59 {
++		compatible = "atmel,24c32";
++		pagesize = <32>;
++		reg = <0x59>;
++		size = <32>;
+ 	};
+ };
+ 
+ /* eMMC */
+ &usdhc3 {
++	assigned-clocks = <&clk IMX8MP_CLK_USDHC3_ROOT>;
++	assigned-clock-rates = <400000000>;
++	bus-width = <8>;
++	non-removable;
+ 	pinctrl-names = "default", "state_100mhz", "state_200mhz";
+ 	pinctrl-0 = <&pinctrl_usdhc3>;
+ 	pinctrl-1 = <&pinctrl_usdhc3_100mhz>;
+ 	pinctrl-2 = <&pinctrl_usdhc3_200mhz>;
+-	bus-width = <8>;
+-	non-removable;
+ 	status = "okay";
+ };
+ 
++/* Watchdog */
+ &wdog1 {
++	fsl,ext-reset-output;
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&pinctrl_wdog>;
+-	fsl,ext-reset-output;
+ 	status = "okay";
+ };
+ 
++&{/reserved-memory/linux,cma} {
++	size = <0 0x28000000>;
++	alloc-ranges = <0 0x40000000 0 0x60000000>;
++};
++
+ &iomuxc {
+ 	pinctrl_fec: fecgrp {
+ 		fsl,pins = <
+@@ -206,21 +228,31 @@
+ 			MX8MP_IOMUXC_SAI1_RXD6__ENET1_RGMII_RD2		0x91
+ 			MX8MP_IOMUXC_SAI1_RXD7__ENET1_RGMII_RD3		0x91
+ 			MX8MP_IOMUXC_SAI1_TXC__ENET1_RGMII_RXC		0x91
++			MX8MP_IOMUXC_SAI1_TXD0__ENET1_RGMII_TD0		0x12
++			MX8MP_IOMUXC_SAI1_TXD1__ENET1_RGMII_TD1		0x12
++			MX8MP_IOMUXC_SAI1_TXD2__ENET1_RGMII_TD2		0x14
++			MX8MP_IOMUXC_SAI1_TXD3__ENET1_RGMII_TD3		0x14
++			MX8MP_IOMUXC_SAI1_TXD4__ENET1_RGMII_TX_CTL	0x14
++			MX8MP_IOMUXC_SAI1_TXD5__ENET1_RGMII_TXC		0x14
+ 			MX8MP_IOMUXC_SAI1_TXFS__ENET1_RGMII_RX_CTL	0x91
+-			MX8MP_IOMUXC_SAI1_TXD0__ENET1_RGMII_TD0		0x1f
+-			MX8MP_IOMUXC_SAI1_TXD1__ENET1_RGMII_TD1		0x1f
+-			MX8MP_IOMUXC_SAI1_TXD2__ENET1_RGMII_TD2		0x1f
+-			MX8MP_IOMUXC_SAI1_TXD3__ENET1_RGMII_TD3		0x1f
+-			MX8MP_IOMUXC_SAI1_TXD4__ENET1_RGMII_TX_CTL	0x1f
+-			MX8MP_IOMUXC_SAI1_TXD5__ENET1_RGMII_TXC		0x1f
+-			MX8MP_IOMUXC_GPIO1_IO15__GPIO1_IO15		0x11
++		>;
++	};
++
++	pinctrl_flexspi0: flexspi0grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_NAND_ALE__FLEXSPI_A_SCLK		0x1c2
++			MX8MP_IOMUXC_NAND_CE0_B__FLEXSPI_A_SS0_B	0x82
++			MX8MP_IOMUXC_NAND_DATA00__FLEXSPI_A_DATA00	0x82
++			MX8MP_IOMUXC_NAND_DATA01__FLEXSPI_A_DATA01	0x82
++			MX8MP_IOMUXC_NAND_DATA02__FLEXSPI_A_DATA02	0x82
++			MX8MP_IOMUXC_NAND_DATA03__FLEXSPI_A_DATA03	0x82
+ 		>;
+ 	};
+ 
+ 	pinctrl_i2c1: i2c1grp {
+ 		fsl,pins = <
+-			MX8MP_IOMUXC_I2C1_SCL__I2C1_SCL		0x400001c3
+ 			MX8MP_IOMUXC_I2C1_SDA__I2C1_SDA		0x400001c3
++			MX8MP_IOMUXC_I2C1_SCL__I2C1_SCL		0x400001c3
+ 		>;
+ 	};
+ 
+@@ -239,55 +271,55 @@
+ 
+ 	pinctrl_usdhc3: usdhc3grp {
+ 		fsl,pins = <
+-			MX8MP_IOMUXC_NAND_WE_B__USDHC3_CLK	0x190
+-			MX8MP_IOMUXC_NAND_WP_B__USDHC3_CMD	0x1d0
++			MX8MP_IOMUXC_NAND_CE1_B__USDHC3_STROBE	0x190
++			MX8MP_IOMUXC_NAND_CE2_B__USDHC3_DATA5	0x1d0
++			MX8MP_IOMUXC_NAND_CE3_B__USDHC3_DATA6	0x1d0
++			MX8MP_IOMUXC_NAND_CLE__USDHC3_DATA7	0x1d0
+ 			MX8MP_IOMUXC_NAND_DATA04__USDHC3_DATA0	0x1d0
+ 			MX8MP_IOMUXC_NAND_DATA05__USDHC3_DATA1	0x1d0
+ 			MX8MP_IOMUXC_NAND_DATA06__USDHC3_DATA2	0x1d0
+ 			MX8MP_IOMUXC_NAND_DATA07__USDHC3_DATA3	0x1d0
+ 			MX8MP_IOMUXC_NAND_RE_B__USDHC3_DATA4	0x1d0
+-			MX8MP_IOMUXC_NAND_CE2_B__USDHC3_DATA5	0x1d0
+-			MX8MP_IOMUXC_NAND_CE3_B__USDHC3_DATA6	0x1d0
+-			MX8MP_IOMUXC_NAND_CLE__USDHC3_DATA7	0x1d0
+-			MX8MP_IOMUXC_NAND_CE1_B__USDHC3_STROBE	0x190
++			MX8MP_IOMUXC_NAND_WE_B__USDHC3_CLK	0x190
++			MX8MP_IOMUXC_NAND_WP_B__USDHC3_CMD	0x1d0
+ 		>;
+ 	};
+ 
+ 	pinctrl_usdhc3_100mhz: usdhc3-100mhzgrp {
+ 		fsl,pins = <
+-			MX8MP_IOMUXC_NAND_WE_B__USDHC3_CLK	0x194
+-			MX8MP_IOMUXC_NAND_WP_B__USDHC3_CMD	0x1d4
++			MX8MP_IOMUXC_NAND_CE1_B__USDHC3_STROBE	0x194
++			MX8MP_IOMUXC_NAND_CE2_B__USDHC3_DATA5	0x1d4
++			MX8MP_IOMUXC_NAND_CE3_B__USDHC3_DATA6	0x1d4
++			MX8MP_IOMUXC_NAND_CLE__USDHC3_DATA7	0x1d4
+ 			MX8MP_IOMUXC_NAND_DATA04__USDHC3_DATA0	0x1d4
+ 			MX8MP_IOMUXC_NAND_DATA05__USDHC3_DATA1	0x1d4
+ 			MX8MP_IOMUXC_NAND_DATA06__USDHC3_DATA2	0x1d4
+ 			MX8MP_IOMUXC_NAND_DATA07__USDHC3_DATA3	0x1d4
+ 			MX8MP_IOMUXC_NAND_RE_B__USDHC3_DATA4	0x1d4
+-			MX8MP_IOMUXC_NAND_CE2_B__USDHC3_DATA5	0x1d4
+-			MX8MP_IOMUXC_NAND_CE3_B__USDHC3_DATA6	0x1d4
+-			MX8MP_IOMUXC_NAND_CLE__USDHC3_DATA7	0x1d4
+-			MX8MP_IOMUXC_NAND_CE1_B__USDHC3_STROBE	0x194
++			MX8MP_IOMUXC_NAND_WE_B__USDHC3_CLK	0x194
++			MX8MP_IOMUXC_NAND_WP_B__USDHC3_CMD	0x1d4
+ 		>;
+ 	};
+ 
+ 	pinctrl_usdhc3_200mhz: usdhc3-200mhzgrp {
+ 		fsl,pins = <
++			MX8MP_IOMUXC_NAND_CE1_B__USDHC3_STROBE	0x196
++			MX8MP_IOMUXC_NAND_CE2_B__USDHC3_DATA5	0x1d2
++			MX8MP_IOMUXC_NAND_CE3_B__USDHC3_DATA6	0x1d2
++			MX8MP_IOMUXC_NAND_CLE__USDHC3_DATA7	0x1d2
++			MX8MP_IOMUXC_NAND_DATA04__USDHC3_DATA0	0x1d2
++			MX8MP_IOMUXC_NAND_DATA05__USDHC3_DATA1	0x1d2
++			MX8MP_IOMUXC_NAND_DATA06__USDHC3_DATA2	0x1d2
++			MX8MP_IOMUXC_NAND_DATA07__USDHC3_DATA3	0x1d2
++			MX8MP_IOMUXC_NAND_RE_B__USDHC3_DATA4	0x1d2
+ 			MX8MP_IOMUXC_NAND_WE_B__USDHC3_CLK	0x196
+ 			MX8MP_IOMUXC_NAND_WP_B__USDHC3_CMD	0x1d6
+-			MX8MP_IOMUXC_NAND_DATA04__USDHC3_DATA0	0x1d6
+-			MX8MP_IOMUXC_NAND_DATA05__USDHC3_DATA1	0x1d6
+-			MX8MP_IOMUXC_NAND_DATA06__USDHC3_DATA2	0x1d6
+-			MX8MP_IOMUXC_NAND_DATA07__USDHC3_DATA3	0x1d6
+-			MX8MP_IOMUXC_NAND_RE_B__USDHC3_DATA4	0x1d6
+-			MX8MP_IOMUXC_NAND_CE2_B__USDHC3_DATA5	0x1d6
+-			MX8MP_IOMUXC_NAND_CE3_B__USDHC3_DATA6	0x1d6
+-			MX8MP_IOMUXC_NAND_CLE__USDHC3_DATA7	0x1d6
+-			MX8MP_IOMUXC_NAND_CE1_B__USDHC3_STROBE	0x196
+ 		>;
+ 	};
+ 
+ 	pinctrl_wdog: wdoggrp {
+ 		fsl,pins = <
+-			MX8MP_IOMUXC_GPIO1_IO02__WDOG1_WDOG_B	0xc6
++			MX8MP_IOMUXC_GPIO1_IO02__WDOG1_WDOG_B	0xe6
+ 		>;
+ 	};
+ };
+diff --git a/arch/arm/dts/phycore-imx8mm.dts b/arch/arm/dts/phycore-imx8mm.dts
+deleted file mode 100644
+index e57dfd368d6..00000000000
+--- a/arch/arm/dts/phycore-imx8mm.dts
++++ /dev/null
+@@ -1,287 +0,0 @@
+-// SPDX-License-Identifier: GPL-2.0-or-later
+-/*
+- * Copyright (C) 2019-2020 PHYTEC Messtechnik GmbH
+- * Author: Teresa Remmet <t.remmet@phytec.de>
+- */
+-
+-/dts-v1/;
+-
+-#include <dt-bindings/net/ti-dp83867.h>
+-#include "imx8mm.dtsi"
+-
+-/ {
+-	model = "PHYTEC phyCORE-i.MX8MM";
+-	compatible = "phytec,imx8mm-phycore-som", "fsl,imx8mm";
+-
+-	chosen {
+-		stdout-path = &uart3;
+-	};
+-
+-	reg_usdhc2_vmmc: regulator-usdhc2 {
+-		compatible = "regulator-fixed";
+-		regulator-name = "VSD_3V3";
+-		regulator-min-microvolt = <3300000>;
+-		regulator-max-microvolt = <3300000>;
+-		startup-delay-us = <100>;
+-		off-on-delay-us = <12000>;
+-	};
+-};
+-
+-/* ethernet */
+-&fec1 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&pinctrl_fec1>;
+-	phy-mode = "rgmii-id";
+-	phy-handle = <&ethphy0>;
+-	phy-reset-gpios = <&gpio1 7 GPIO_ACTIVE_HIGH>;
+-	phy-reset-duration = <1>;
+-	phy-reset-post-delay = <1>;
+-	status = "okay";
+-
+-	mdio {
+-		#address-cells = <1>;
+-		#size-cells = <0>;
+-
+-		ethphy0: ethernet-phy@0 {
+-			compatible = "ethernet-phy-ieee802.3-c22";
+-			reg = <0x0>;
+-			ti,rx-internal-delay = <DP83867_RGMIIDCTL_2_00_NS>;
+-			ti,tx-internal-delay = <DP83867_RGMIIDCTL_2_00_NS>;
+-			ti,fifo-depth = <DP83867_PHYCR_FIFO_DEPTH_4_B_NIB>;
+-			ti,clk-output-sel = <DP83867_CLK_O_SEL_OFF>;
+-			enet-phy-lane-no-swap;
+-		};
+-	};
+-};
+-
+-/* SPI nor flash */
+-&flexspi {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&pinctrl_flexspi0>;
+-	status = "okay";
+-
+-	flash0: norflash@0 {
+-		reg = <0>;
+-		#address-cells = <1>;
+-		#size-cells = <1>;
+-		compatible = "jedec,spi-nor";
+-		spi-max-frequency = <80000000>;
+-		spi-tx-bus-width = <4>;
+-		spi-rx-bus-width = <4>;
+-	};
+-};
+-
+-/* i2c eeprom */
+-&i2c1 {
+-	clock-frequency = <400000>;
+-	pinctrl-names = "default", "gpio";
+-	pinctrl-0 = <&pinctrl_i2c1>;
+-	pinctrl-1 = <&pinctrl_i2c1_gpio>;
+-	scl-gpios = <&gpio5 14 GPIO_ACTIVE_HIGH>;
+-	sda-gpios = <&gpio5 15 GPIO_ACTIVE_HIGH>;
+-	status = "okay";
+-
+-	/* M24C32-D */
+-	i2c_eeprom: eeprom@51 {
+-		compatible = "atmel,24c32";
+-		reg = <0x51>;
+-		u-boot,i2c-offset-len = <2>;
+-	};
+-
+-	/* M24C32-D Identification page */
+-	i2c_eeprom_id: eeprom@59 {
+-		compatible = "atmel,24c32";
+-		reg = <0x59>;
+-		u-boot,i2c-offset-len = <2>;
+-	};
+-};
+-
+-/* debug console */
+-&uart3 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&pinctrl_uart3>;
+-	status = "okay";
+-};
+-
+-/* sd-card */
+-&usdhc2 {
+-	pinctrl-names = "default", "state_100mhz", "state_200mhz";
+-	pinctrl-0 = <&pinctrl_usdhc2>, <&pinctrl_usdhc2_gpio>;
+-	pinctrl-1 = <&pinctrl_usdhc2_100mhz>, <&pinctrl_usdhc2_gpio>;
+-	pinctrl-2 = <&pinctrl_usdhc2_200mhz>, <&pinctrl_usdhc2_gpio>;
+-	cd-gpios = <&gpio2 12 GPIO_ACTIVE_LOW>;
+-	bus-width = <4>;
+-	vmmc-supply = <&reg_usdhc2_vmmc>;
+-	status = "okay";
+-};
+-
+-/* eMMC */
+-&usdhc3 {
+-	pinctrl-names = "default", "state_100mhz", "state_200mhz";
+-	pinctrl-0 = <&pinctrl_usdhc3>;
+-	pinctrl-1 = <&pinctrl_usdhc3_100mhz>;
+-	pinctrl-2 = <&pinctrl_usdhc3_200mhz>;
+-	bus-width = <8>;
+-	non-removable;
+-	status = "okay";
+-};
+-
+-/* watchdog */
+-&wdog1 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&pinctrl_wdog>;
+-	fsl,ext-reset-output;
+-	status = "okay";
+-};
+-
+-&iomuxc {
+-	pinctrl-names = "default";
+-
+-	pinctrl_fec1: fec1grp {
+-		fsl,pins = <
+-			MX8MM_IOMUXC_ENET_MDC_ENET1_MDC		0x3
+-			MX8MM_IOMUXC_ENET_MDIO_ENET1_MDIO	0x3
+-			MX8MM_IOMUXC_ENET_TD3_ENET1_RGMII_TD3	0x1f
+-			MX8MM_IOMUXC_ENET_TD2_ENET1_RGMII_TD2	0x1f
+-			MX8MM_IOMUXC_ENET_TD1_ENET1_RGMII_TD1	0x1f
+-			MX8MM_IOMUXC_ENET_TD0_ENET1_RGMII_TD0	0x1f
+-			MX8MM_IOMUXC_ENET_RD3_ENET1_RGMII_RD3	0x91
+-			MX8MM_IOMUXC_ENET_RD2_ENET1_RGMII_RD2	0x91
+-			MX8MM_IOMUXC_ENET_RD1_ENET1_RGMII_RD1	0x91
+-			MX8MM_IOMUXC_ENET_RD0_ENET1_RGMII_RD0	0x91
+-			MX8MM_IOMUXC_ENET_TXC_ENET1_RGMII_TXC	0x1f
+-			MX8MM_IOMUXC_ENET_RXC_ENET1_RGMII_RXC	0x91
+-			MX8MM_IOMUXC_ENET_RX_CTL_ENET1_RGMII_RX_CTL	0x91
+-			MX8MM_IOMUXC_ENET_TX_CTL_ENET1_RGMII_TX_CTL	0x1f
+-			MX8MM_IOMUXC_GPIO1_IO07_GPIO1_IO7	0x19
+-		>;
+-	};
+-
+-	pinctrl_flexspi0: flexspi0grp {
+-		fsl,pins = <
+-			MX8MM_IOMUXC_NAND_ALE_QSPI_A_SCLK		0x1c2
+-			MX8MM_IOMUXC_NAND_CE0_B_QSPI_A_SS0_B		0x82
+-			MX8MM_IOMUXC_NAND_DATA00_QSPI_A_DATA0		0x82
+-			MX8MM_IOMUXC_NAND_DATA01_QSPI_A_DATA1		0x82
+-			MX8MM_IOMUXC_NAND_DATA02_QSPI_A_DATA2		0x82
+-			MX8MM_IOMUXC_NAND_DATA03_QSPI_A_DATA3		0x82
+-		>;
+-	};
+-
+-	pinctrl_i2c1: i2c1grp {
+-		fsl,pins = <
+-			MX8MM_IOMUXC_I2C1_SCL_I2C1_SCL		0x400001c3
+-			MX8MM_IOMUXC_I2C1_SDA_I2C1_SDA		0x400001c3
+-		>;
+-	};
+-
+-	pinctrl_i2c1_gpio: i2c1grp-gpio {
+-		fsl,pins = <
+-			MX8MM_IOMUXC_I2C1_SCL_GPIO5_IO14	0x1c3
+-			MX8MM_IOMUXC_I2C1_SDA_GPIO5_IO15	0x1c3
+-		>;
+-	};
+-
+-	pinctrl_uart3: uart3grp {
+-		fsl,pins = <
+-			MX8MM_IOMUXC_UART3_RXD_UART3_DCE_RX	0x49
+-			MX8MM_IOMUXC_UART3_TXD_UART3_DCE_TX	0x49
+-		>;
+-	};
+-
+-	pinctrl_usdhc2_gpio: usdhc2grpgpio {
+-		fsl,pins = <
+-			MX8MM_IOMUXC_SD2_CD_B_GPIO2_IO12        0x41
+-		>;
+-	};
+-
+-	pinctrl_usdhc2: usdhc2grp {
+-		fsl,pins = <
+-			MX8MM_IOMUXC_SD2_CLK_USDHC2_CLK		0x190
+-			MX8MM_IOMUXC_SD2_CMD_USDHC2_CMD		0x1d0
+-			MX8MM_IOMUXC_SD2_DATA0_USDHC2_DATA0	0x1d0
+-			MX8MM_IOMUXC_SD2_DATA1_USDHC2_DATA1	0x1d0
+-			MX8MM_IOMUXC_SD2_DATA2_USDHC2_DATA2	0x1d0
+-			MX8MM_IOMUXC_SD2_DATA3_USDHC2_DATA3	0x1d0
+-			MX8MM_IOMUXC_GPIO1_IO04_USDHC2_VSELECT	0x1d0
+-		>;
+-	};
+-
+-	pinctrl_usdhc2_100mhz: usdhc2grp100mhz {
+-		fsl,pins = <
+-			MX8MM_IOMUXC_SD2_CLK_USDHC2_CLK		0x194
+-			MX8MM_IOMUXC_SD2_CMD_USDHC2_CMD		0x1d4
+-			MX8MM_IOMUXC_SD2_DATA0_USDHC2_DATA0	0x1d4
+-			MX8MM_IOMUXC_SD2_DATA1_USDHC2_DATA1	0x1d4
+-			MX8MM_IOMUXC_SD2_DATA2_USDHC2_DATA2	0x1d4
+-			MX8MM_IOMUXC_SD2_DATA3_USDHC2_DATA3	0x1d4
+-			MX8MM_IOMUXC_GPIO1_IO04_USDHC2_VSELECT	0x1d0
+-		>;
+-	};
+-
+-	pinctrl_usdhc2_200mhz: usdhc2grp200mhz {
+-		fsl,pins = <
+-			MX8MM_IOMUXC_SD2_CLK_USDHC2_CLK		0x196
+-			MX8MM_IOMUXC_SD2_CMD_USDHC2_CMD		0x1d6
+-			MX8MM_IOMUXC_SD2_DATA0_USDHC2_DATA0	0x1d6
+-			MX8MM_IOMUXC_SD2_DATA1_USDHC2_DATA1	0x1d6
+-			MX8MM_IOMUXC_SD2_DATA2_USDHC2_DATA2	0x1d6
+-			MX8MM_IOMUXC_SD2_DATA3_USDHC2_DATA3	0x1d6
+-			MX8MM_IOMUXC_GPIO1_IO04_USDHC2_VSELECT	0x1d0
+-		>;
+-	};
+-
+-	pinctrl_usdhc3: usdhc3grp {
+-		fsl,pins = <
+-			MX8MM_IOMUXC_NAND_WE_B_USDHC3_CLK		0x40000190
+-			MX8MM_IOMUXC_NAND_WP_B_USDHC3_CMD		0x1d0
+-			MX8MM_IOMUXC_NAND_DATA04_USDHC3_DATA0		0x1d0
+-			MX8MM_IOMUXC_NAND_DATA05_USDHC3_DATA1		0x1d0
+-			MX8MM_IOMUXC_NAND_DATA06_USDHC3_DATA2		0x1d0
+-			MX8MM_IOMUXC_NAND_DATA07_USDHC3_DATA3		0x1d0
+-			MX8MM_IOMUXC_NAND_RE_B_USDHC3_DATA4		0x1d0
+-			MX8MM_IOMUXC_NAND_CE2_B_USDHC3_DATA5		0x1d0
+-			MX8MM_IOMUXC_NAND_CE3_B_USDHC3_DATA6		0x1d0
+-			MX8MM_IOMUXC_NAND_CLE_USDHC3_DATA7		0x1d0
+-			MX8MM_IOMUXC_NAND_CE1_B_USDHC3_STROBE		0x190
+-		>;
+-	};
+-
+-	pinctrl_usdhc3_100mhz: usdhc3grp100mhz {
+-		fsl,pins = <
+-			MX8MM_IOMUXC_NAND_WE_B_USDHC3_CLK		0x40000194
+-			MX8MM_IOMUXC_NAND_WP_B_USDHC3_CMD		0x1d4
+-			MX8MM_IOMUXC_NAND_DATA04_USDHC3_DATA0		0x1d4
+-			MX8MM_IOMUXC_NAND_DATA05_USDHC3_DATA1		0x1d4
+-			MX8MM_IOMUXC_NAND_DATA06_USDHC3_DATA2		0x1d4
+-			MX8MM_IOMUXC_NAND_DATA07_USDHC3_DATA3		0x1d4
+-			MX8MM_IOMUXC_NAND_RE_B_USDHC3_DATA4		0x1d4
+-			MX8MM_IOMUXC_NAND_CE2_B_USDHC3_DATA5		0x1d4
+-			MX8MM_IOMUXC_NAND_CE3_B_USDHC3_DATA6		0x1d4
+-			MX8MM_IOMUXC_NAND_CLE_USDHC3_DATA7		0x1d4
+-			MX8MM_IOMUXC_NAND_CE1_B_USDHC3_STROBE		0x194
+-		>;
+-	};
+-
+-	pinctrl_usdhc3_200mhz: usdhc3grp200mhz {
+-		fsl,pins = <
+-			MX8MM_IOMUXC_NAND_WE_B_USDHC3_CLK		0x40000196
+-			MX8MM_IOMUXC_NAND_WP_B_USDHC3_CMD		0x1d6
+-			MX8MM_IOMUXC_NAND_DATA04_USDHC3_DATA0		0x1d6
+-			MX8MM_IOMUXC_NAND_DATA05_USDHC3_DATA1		0x1d6
+-			MX8MM_IOMUXC_NAND_DATA06_USDHC3_DATA2		0x1d6
+-			MX8MM_IOMUXC_NAND_DATA07_USDHC3_DATA3		0x1d6
+-			MX8MM_IOMUXC_NAND_RE_B_USDHC3_DATA4		0x1d6
+-			MX8MM_IOMUXC_NAND_CE2_B_USDHC3_DATA5		0x1d6
+-			MX8MM_IOMUXC_NAND_CE3_B_USDHC3_DATA6		0x1d6
+-			MX8MM_IOMUXC_NAND_CLE_USDHC3_DATA7		0x1d6
+-			MX8MM_IOMUXC_NAND_CE1_B_USDHC3_STROBE		0x196
+-		>;
+-	};
+-
+-	pinctrl_wdog: wdoggrp {
+-		fsl,pins = <
+-			MX8MM_IOMUXC_GPIO1_IO02_WDOG1_WDOG_B		0xc6
+-		>;
+-	};
+-};
+diff --git a/arch/arm/include/asm/arch-imx8m/ddr.h b/arch/arm/include/asm/arch-imx8m/ddr.h
+index 5e4fbecf052..7f82f158050 100644
+--- a/arch/arm/include/asm/arch-imx8m/ddr.h
++++ b/arch/arm/include/asm/arch-imx8m/ddr.h
+@@ -746,6 +746,7 @@ static inline void reg32setbit(unsigned long addr, u32 bit)
+ #define dwc_ddrphy_apb_rd(addr) \
+ 	reg32_read(IP2APB_DDRPHY_IPS_BASE_ADDR(0) + ddrphy_addr_remap(addr))
+ 
++extern bool imx8m_ddr_old_spreadsheet;
+ extern struct dram_cfg_param ddrphy_trained_csr[];
+ extern uint32_t ddrphy_trained_csr_num;
+ 
+diff --git a/arch/arm/include/asm/mach-imx/sys_proto.h b/arch/arm/include/asm/mach-imx/sys_proto.h
+index 04505d948c3..c684fa39087 100644
+--- a/arch/arm/include/asm/mach-imx/sys_proto.h
++++ b/arch/arm/include/asm/mach-imx/sys_proto.h
+@@ -100,6 +100,16 @@ struct bd_info;
+ 
+ /* gd->flags reserves high 16 bits for arch-specific flags */
+ #define GD_FLG_ARCH_IMX_USB_BOOT		0x80000000	 /* Only used for MX6/7, If set, the u-boot is booting from USB serial download */
++#ifdef CONFIG_IMX8M
++phys_size_t imx8m_ddrc_sdram_size(void);
++phys_size_t imx_ddrc_sdram_size(void *ddrc, const u32 addrmap[],
++				u8 col_max, const u8 col_b[],
++				unsigned int col_b_num,
++				u8 row_max, const u8 row_b[],
++				unsigned int row_b_num,
++				bool reduced_address_space,
++				bool is_imx8m);
++#endif
+ 
+ #ifdef CONFIG_MX6
+ #define IMX6_SRC_GPR10_BMODE			BIT(28)
+diff --git a/arch/arm/mach-imx/Makefile b/arch/arm/mach-imx/Makefile
+index 4ebf95d2b35..802741b6671 100644
+--- a/arch/arm/mach-imx/Makefile
++++ b/arch/arm/mach-imx/Makefile
+@@ -20,6 +20,7 @@ obj-$(CONFIG_DWC_ETH_QOS) += mac.o
+ obj-$(CONFIG_SYS_I2C_MXC) += i2c-mxv7.o
+ obj-$(CONFIG_IMX_HAB) += hab.o
+ obj-y += cpu.o
++obj-y += mmdc_size.o
+ endif
+ 
+ ifeq ($(SOC),$(filter $(SOC),mx5 mx6))
+diff --git a/arch/arm/mach-imx/imx8m/Kconfig b/arch/arm/mach-imx/imx8m/Kconfig
+index a225a9784f4..d7edf88a655 100644
+--- a/arch/arm/mach-imx/imx8m/Kconfig
++++ b/arch/arm/mach-imx/imx8m/Kconfig
+@@ -305,6 +305,13 @@ config TARGET_PHYCORE_IMX8MM
+ 	select SUPPORT_SPL
+ 	select IMX8M_LPDDR4
+ 
++config TARGET_PHYCORE_IMX8MN
++	bool "PHYTEC PHYCORE i.MX8MN"
++	select BINMAN
++	select IMX8MN
++	select SUPPORT_SPL
++	select IMX8M_LPDDR4
++
+ config TARGET_PHYCORE_IMX8MP
+ 	bool "PHYTEC PHYCORE i.MX8MP"
+ 	select BINMAN
+@@ -361,6 +368,7 @@ source "board/kontron/pitx_imx8m/Kconfig"
+ source "board/kontron/sl-mx8mm/Kconfig"
+ source "board/phytec/phycore_imx8mm/Kconfig"
+ source "board/phytec/phycore_imx8mp/Kconfig"
++source "board/phytec/phycore_imx8mn/Kconfig"
+ source "board/ronetix/imx8mq-cm/Kconfig"
+ source "board/technexion/pico-imx8mq/Kconfig"
+ source "board/variscite/imx8mn_var_som/Kconfig"
+diff --git a/arch/arm/mach-imx/mmdc_size.c b/arch/arm/mach-imx/mmdc_size.c
+index 41a5af6bd30..6e2cd2e818e 100644
+--- a/arch/arm/mach-imx/mmdc_size.c
++++ b/arch/arm/mach-imx/mmdc_size.c
+@@ -2,6 +2,8 @@
+ 
+ #include <common.h>
+ #include <asm/io.h>
++#include <linux/bitfield.h>
++#include <asm/arch/sys_proto.h>
+ 
+ #if defined(CONFIG_MX53)
+ #define MEMCTL_BASE	ESDCTL_BASE_ADDR
+@@ -13,6 +15,52 @@
+ static const unsigned char col_lookup[] = {9, 10, 11, 8, 12, 9, 9, 9};
+ static const unsigned char bank_lookup[] = {3, 2};
+ 
++#if defined(CONFIG_IMX8M)
++#define DDRC_ADDRMAP(n)                                (0x200 + 4 * (n))
++#define DDRC_ADDRMAP6_LPDDR4_6GB_12GB_24GB     GENMASK(30, 29)
++#define DDRC_ADDRMAP6_LPDDR3_6GB_12GB          BIT(31)
++#define DDRC_ADDRMAP0_CS_BIT0                  GENMASK(4, 0)
++
++#define DDRC_MSTR                              0x0000
++#define DDRC_MSTR_DDR4			       BIT(4)
++#define DDRC_MSTR_LPDDR4                       BIT(5)
++#define DDRC_MSTR_DATA_BUS_WIDTH               GENMASK(13, 12)
++#define DDRC_MSTR_ACTIVE_RANKS                 GENMASK(27, 24)
++#define DDRC_MSTR_DEVICE_CONFIG			GENMASK(31, 30)
++
++#define DDRC_ADDRMAP0_CS_BIT1                  GENMASK(12,  8)
++
++#define DDRC_ADDRMAP1_BANK_B2                  GENMASK(20, 16)
++
++#define DDRC_ADDRMAP2_COL_B5                   GENMASK(27, 24)
++#define DDRC_ADDRMAP2_COL_B4                   GENMASK(19, 16)
++
++#define DDRC_ADDRMAP3_COL_B9                   GENMASK(27, 24)
++#define DDRC_ADDRMAP3_COL_B8                   GENMASK(19, 16)
++#define DDRC_ADDRMAP3_COL_B7                   GENMASK(11,  8)
++#define DDRC_ADDRMAP3_COL_B6                   GENMASK(3,  0)
++#define DDRC_ADDRMAP4_COL_B10                  GENMASK(3, 0)
++#define DDRC_ADDRMAP4_COL_B11                  GENMASK(11, 8)
++
++#define DDRC_ADDRMAP5_ROW_B11                  GENMASK(27, 24)
++
++#define DDRC_ADDRMAP6_ROW_B15                  GENMASK(27, 24)
++#define DDRC_ADDRMAP6_ROW_B14                  GENMASK(19, 16)
++#define DDRC_ADDRMAP6_ROW_B13                  GENMASK(11,  8)
++#define DDRC_ADDRMAP6_ROW_B12                  GENMASK(3,  0)
++
++#define DDRC_ADDRMAP7_ROW_B17                  GENMASK(11,  8)
++#define DDRC_ADDRMAP7_ROW_B16                  GENMASK(3,  0)
++
++#define DDRC_ADDRMAP8_BG_B1			GENMASK(13,  8)
++#define DDRC_ADDRMAP8_BG_B0			GENMASK(4,  0)
++
++#define MEMCTL_BASE    0x3d400000
++
++#define DDRC_ADDRMAP_LENGTH	9
++
++#endif
++
+ /* these MMDC registers are common to the IMX53 and IMX6 */
+ struct esd_mmdc_regs {
+ 	u32 ctl;
+@@ -55,3 +103,151 @@ unsigned int imx_ddr_size(void)
+ 
+ 	return 1 << bits;
+ }
++
++static unsigned int imx_ddrc_count_bits(unsigned int bits, const u8 config[],
++					unsigned int config_num)
++{
++	unsigned int i;
++
++	for (i = 0; i < config_num; i++) {
++		if (config[i] == 0b1111)
++			bits--;
++	}
++
++	return bits;
++}
++
++resource_size_t imx_ddrc_sdram_size(void *ddrc, const u32 addrmap[DDRC_ADDRMAP_LENGTH],
++				    u8 col_max, const u8 col_b[],
++				    unsigned int col_b_num,
++				    u8 row_max, const u8 row_b[],
++				    unsigned int row_b_num,
++				    bool reduced_address_space, bool is_imx8)
++{
++	const u32 mstr = readl(ddrc + DDRC_MSTR);
++	unsigned int banks, ranks, columns, rows, active_ranks, width;
++	resource_size_t size;
++
++	banks = 2;
++	ranks = 0;
++
++	switch (FIELD_GET(DDRC_MSTR_ACTIVE_RANKS, mstr)) {
++	case 0b0001:
++		active_ranks = 1;
++		break;
++	case 0b0011:
++		active_ranks = 2;
++		break;
++	case 0b1111:
++		active_ranks = 4;
++		break;
++	default:
++		BUG();
++	}
++
++	/* Bus width in bytes, 0 means half byte or 4-bit mode */
++	if (is_imx8 && !(mstr & DDRC_MSTR_LPDDR4)) {
++		width = (1 << FIELD_GET(DDRC_MSTR_DEVICE_CONFIG, mstr)) >> 1;
++	} else {
++		if (is_imx8mn())
++			width = 2;
++		else
++			width = 4;
++	}
++
++	switch (FIELD_GET(DDRC_MSTR_DATA_BUS_WIDTH, mstr)) {
++	case 0b00:	/* Full DQ bus  */
++		break;
++	case 0b01:	/* Half DQ bus  */
++		width >>= 1;
++		break;
++	case 0b10:	/* Quarter DQ bus  */
++		width >>= 2;
++		break;
++	default:
++		BUG();
++	}
++
++	if (active_ranks == 4 &&
++	    (FIELD_GET(DDRC_ADDRMAP0_CS_BIT1, addrmap[0]) != 0b11111))
++			ranks++;
++	if (active_ranks > 1 &&
++	    (FIELD_GET(DDRC_ADDRMAP0_CS_BIT0, addrmap[0]) != 0b11111))
++			ranks++;
++
++	if (FIELD_GET(DDRC_ADDRMAP1_BANK_B2, addrmap[1]) != 0b11111)
++		banks++;
++
++	if (mstr & DDRC_MSTR_DDR4) {
++		/* FIXME: DDR register spreasheet claims this to be
++		 * 6-bit and 63 meaning bank group address bit 0 is 0,
++		 * but reference manual claims 5-bit without 'neutral' value
++		 * See MX8M_Mini_DDR4_RPA_v17, MX8M_Nano_DDR4_RPA_v8
++		 */
++		if (FIELD_GET(DDRC_ADDRMAP8_BG_B0, addrmap[8]) != 0b11111)
++			banks++;
++		if (FIELD_GET(DDRC_ADDRMAP8_BG_B1, addrmap[8]) != 0b111111)
++			banks++;
++	}
++
++	columns	= imx_ddrc_count_bits(col_max, col_b, col_b_num);
++	rows	= imx_ddrc_count_bits(row_max, row_b, row_b_num);
++
++	/*
++	 * Special case when bus width is 0 or x4 mode,
++	 * calculate the mem size and then divide the size by 2.
++	 */
++	if (width)
++		size = ((u64)(1 << banks) * width << (rows + columns));
++	else
++		size = ((u64)(1 << banks) << (rows + columns)) >> 1;
++	size <<= ranks;
++
++	return reduced_address_space ? size * 3 / 4 : size;
++}
++
++resource_size_t imx8m_ddrc_sdram_size(void)
++{
++	void __iomem *mem_base = (void __iomem *)MEMCTL_BASE;
++
++	const u32 addrmap[DDRC_ADDRMAP_LENGTH] = {
++		readl(mem_base + DDRC_ADDRMAP(0)),
++		readl(mem_base + DDRC_ADDRMAP(1)),
++		readl(mem_base + DDRC_ADDRMAP(2)),
++		readl(mem_base + DDRC_ADDRMAP(3)),
++		readl(mem_base + DDRC_ADDRMAP(4)),
++		readl(mem_base + DDRC_ADDRMAP(5)),
++		readl(mem_base + DDRC_ADDRMAP(6)),
++		readl(mem_base + DDRC_ADDRMAP(7)),
++		readl(mem_base + DDRC_ADDRMAP(8))
++	};
++
++	const u8 col_b[] = {
++		FIELD_GET(DDRC_ADDRMAP4_COL_B11, addrmap[4]),
++		FIELD_GET(DDRC_ADDRMAP4_COL_B10, addrmap[4]),
++		FIELD_GET(DDRC_ADDRMAP3_COL_B9,  addrmap[3]),
++		FIELD_GET(DDRC_ADDRMAP3_COL_B8,  addrmap[3]),
++		FIELD_GET(DDRC_ADDRMAP3_COL_B7,  addrmap[3]),
++		FIELD_GET(DDRC_ADDRMAP3_COL_B6,  addrmap[3]),
++		FIELD_GET(DDRC_ADDRMAP2_COL_B5,  addrmap[2]),
++		FIELD_GET(DDRC_ADDRMAP2_COL_B4,  addrmap[2]),
++	};
++
++	const u8 row_b[] = {
++		FIELD_GET(DDRC_ADDRMAP7_ROW_B17, addrmap[7]),
++		FIELD_GET(DDRC_ADDRMAP7_ROW_B16, addrmap[7]),
++		FIELD_GET(DDRC_ADDRMAP6_ROW_B15, addrmap[6]),
++		FIELD_GET(DDRC_ADDRMAP6_ROW_B14, addrmap[6]),
++		FIELD_GET(DDRC_ADDRMAP6_ROW_B13, addrmap[6]),
++		FIELD_GET(DDRC_ADDRMAP6_ROW_B12, addrmap[6]),
++		FIELD_GET(DDRC_ADDRMAP5_ROW_B11, addrmap[5]),
++	};
++
++	const bool reduced_address_space =
++		FIELD_GET(DDRC_ADDRMAP6_LPDDR4_6GB_12GB_24GB, addrmap[6]);
++
++	return imx_ddrc_sdram_size(mem_base, addrmap,
++					12, col_b, ARRAY_SIZE(col_b),
++					18, row_b, ARRAY_SIZE(row_b),
++					reduced_address_space, true);
++}
+diff --git a/arch/arm/mach-imx/spl.c b/arch/arm/mach-imx/spl.c
+index 919eb6180e0..de4097d3817 100644
+--- a/arch/arm/mach-imx/spl.c
++++ b/arch/arm/mach-imx/spl.c
+@@ -389,7 +389,6 @@ int board_handle_rdc_config(void *fdt_addr, const char *config_name, void *dst_a
+ 
+ 	node = fdt_node_offset_by_compatible(fdt_addr, -1, "imx8m,mcu_rdc");
+ 	if (node < 0) {
+-		printf("Failed to find node!, err: %d!\n", node);
+ 		ret = -1;
+ 		goto exit;
+ 	}
+diff --git a/board/phytec/common/Kconfig b/board/phytec/common/Kconfig
+new file mode 100644
+index 00000000000..3b1c5aa0d02
+--- /dev/null
++++ b/board/phytec/common/Kconfig
+@@ -0,0 +1,13 @@
++config PHYTEC_SOM_DETECTION
++	bool "Support SoM detection for PHYTEC platforms"
++	select SPL_CRC8 if SPL
++	help
++	   Support of I2C EEPROM based SoM detection.
++
++config PHYTEC_IMX8M_SOM_DETECTION
++	bool "Support SoM detection for i.MX8M PHYTEC platforms"
++	depends on ARCH_IMX8M && PHYTEC_SOM_DETECTION
++	default y
++	help
++	  Support of I2C EEPROM based SoM detection. Supported
++	  for PHYTEC i.MX8MM/i.MX8MP boards
+diff --git a/board/phytec/common/Makefile b/board/phytec/common/Makefile
+new file mode 100644
+index 00000000000..fe28964ce21
+--- /dev/null
++++ b/board/phytec/common/Makefile
+@@ -0,0 +1,11 @@
++# SPDX-License-Identifier: GPL-2.0+
++# Copyright (C) 2023 PHYTEC Messtechnik GmbH
++# Author: Teresa Remmet <t.remmet@phytec.de>
++
++ifdef CONFIG_SPL_BUILD
++# necessary to create built-in.o
++obj- := __dummy__.o
++endif
++
++obj-$(CONFIG_PHYTEC_SOM_DETECTION) += phytec_som_detection.o
++obj-$(CONFIG_PHYTEC_IMX8M_SOM_DETECTION) += imx8m_som_detection.o
+diff --git a/board/phytec/common/imx8m_som_detection.c b/board/phytec/common/imx8m_som_detection.c
+new file mode 100644
+index 00000000000..bbe64028319
+--- /dev/null
++++ b/board/phytec/common/imx8m_som_detection.c
+@@ -0,0 +1,169 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++/*
++ * Copyright (C) 2023 PHYTEC Messtechnik GmbH
++ * Author: Teresa Remmet <t.remmet@phytec.de>
++ */
++
++#include <common.h>
++#include <asm/arch/sys_proto.h>
++#include <dm/device.h>
++#include <dm/uclass.h>
++#include <i2c.h>
++#include <u-boot/crc.h>
++
++#include "imx8m_som_detection.h"
++
++extern struct phytec_eeprom_data eeprom_data;
++
++/* Check if the SoM is actually one of the following products:
++ * - i.MX8MM
++ * - i.MX8MN
++ * - i.MX8MP
++ * - i.MX8MQ
++ *
++ * Returns 0 in case it's a known SoM. Otherwise, returns -1.
++ */
++u8 __maybe_unused phytec_imx8m_detect(struct phytec_eeprom_data *data)
++{
++	char *opt;
++	u8 som;
++
++	/* We can not do the check for early API revsions */
++	if (data->api_rev < PHYTEC_API_REV2)
++		return -1;
++
++	if (!data)
++		data = &eeprom_data;
++
++	som = data->data.data_api2.som_no;
++	debug("%s: som id: %u\n", __func__, som);
++
++	opt = phytec_get_opt(data);
++	if (!opt)
++		return -1;
++
++	if (som == PHYTEC_IMX8MP_SOM && is_imx8mp())
++		return 0;
++
++	if (som == PHYTEC_IMX8MM_SOM) {
++		if ((PHYTEC_GET_OPTION(opt[0]) != 0) &&
++		    (PHYTEC_GET_OPTION(opt[1]) == 0) && is_imx8mm())
++			return 0;
++		else if ((PHYTEC_GET_OPTION(opt[0]) == 0) &&
++			 (PHYTEC_GET_OPTION(opt[1]) != 0) && is_imx8mn())
++			return 0;
++	}
++
++	if (som == PHYTEC_IMX8MQ_SOM && is_imx8mq())
++		return 0;
++
++	pr_err("%s: SoM ID does not match. Wrong EEPROM data?\n", __func__);
++	return -1;
++}
++
++/*
++ * All PHYTEC i.MX8M boards have RAM size definition at the
++ * same location.
++ */
++u8 __maybe_unused phytec_get_imx8m_ddr_size(struct phytec_eeprom_data *data)
++{
++	char *opt;
++	u8 ddr_id;
++
++	if (!data)
++		data = &eeprom_data;
++
++	opt = phytec_get_opt(data);
++	if (opt)
++		ddr_id = PHYTEC_GET_OPTION(opt[2]);
++	else
++		ddr_id = PHYTEC_EEPROM_INVAL;
++
++	debug("%s: ddr id: %u\n", __func__, ddr_id);
++	return ddr_id;
++}
++
++/*
++ * Filter SPI-NOR flash information. All i.MX8M boards have this at
++ * the same location.
++ * returns: 0x0 if no SPI is populated. Otherwise a board depended
++ * code for the size. PHYTEC_EEPROM_INVAL when the data is invalid.
++ */
++u8 __maybe_unused phytec_get_imx8m_spi(struct phytec_eeprom_data *data)
++{
++	char *opt;
++	u8 spi;
++
++	if (!data)
++		data = &eeprom_data;
++
++	if (data->api_rev < PHYTEC_API_REV2)
++		return PHYTEC_EEPROM_INVAL;
++
++	opt = phytec_get_opt(data);
++	if (opt)
++		spi = PHYTEC_GET_OPTION(opt[4]);
++	else
++		spi = PHYTEC_EEPROM_INVAL;
++
++	debug("%s: spi: %u\n", __func__, spi);
++	return spi;
++}
++
++/*
++ * Filter ethernet phy information. All i.MX8M boards have this at
++ * the same location.
++ * returns: 0x0 if no ethernet phy is populated. 0x1 if it is populated.
++ * PHYTEC_EEPROM_INVAL when the data is invalid.
++ */
++u8 __maybe_unused phytec_get_imx8m_eth(struct phytec_eeprom_data *data)
++{
++	char *opt;
++	u8 eth;
++
++	if (!data)
++		data = &eeprom_data;
++
++	if (data->api_rev < PHYTEC_API_REV2)
++		return PHYTEC_EEPROM_INVAL;
++
++	opt = phytec_get_opt(data);
++	if (opt) {
++		eth = PHYTEC_GET_OPTION(opt[5]);
++		eth &= 0x1;
++	} else {
++		eth = PHYTEC_EEPROM_INVAL;
++	}
++
++	debug("%s: eth: %u\n", __func__, eth);
++	return eth;
++}
++
++/*
++ * Filter RTC information for phyCORE-i.MX8MP.
++ * returns: 0 if no RTC is populated. 1 if it is populated.
++ * PHYTEC_EEPROM_INVAL when the data is invalid.
++ */
++u8 __maybe_unused phytec_get_imx8mp_rtc(struct phytec_eeprom_data *data)
++{
++	char *opt;
++	u8 rtc;
++
++	if (!data)
++		data = &eeprom_data;
++
++	if (data->api_rev < PHYTEC_API_REV2)
++		return PHYTEC_EEPROM_INVAL;
++
++	opt = phytec_get_opt(data);
++	if (opt) {
++		rtc = PHYTEC_GET_OPTION(opt[5]);
++		rtc &= 0x4;
++		rtc = !(rtc >> 2);
++	} else {
++		rtc = PHYTEC_EEPROM_INVAL;
++	}
++	debug("%s: rtc: %u\n", __func__, rtc);
++	return rtc;
++}
++
+diff --git a/board/phytec/common/imx8m_som_detection.h b/board/phytec/common/imx8m_som_detection.h
+new file mode 100644
+index 00000000000..88d3037bf36
+--- /dev/null
++++ b/board/phytec/common/imx8m_som_detection.h
+@@ -0,0 +1,54 @@
++/* SPDX-License-Identifier: GPL-2.0-or-later */
++/*
++ * Copyright (C) 2023 PHYTEC Messtechnik GmbH
++ * Author: Teresa Remmet <t.remmet@phytec.de>
++ */
++
++#ifndef _PHYTEC_IMX8M_SOM_DETECTION_H
++#define _PHYTEC_IMX8M_SOM_DETECTION_H
++
++#include "phytec_som_detection.h"
++
++#define PHYTEC_IMX8MQ_SOM       66
++#define PHYTEC_IMX8MM_SOM       69
++#define PHYTEC_IMX8MP_SOM       70
++
++#if IS_ENABLED(CONFIG_PHYTEC_IMX8M_SOM_DETECTION)
++
++u8 __maybe_unused phytec_imx8m_detect(struct phytec_eeprom_data *data);
++u8 __maybe_unused phytec_get_imx8m_ddr_size(struct phytec_eeprom_data *data);
++u8 __maybe_unused phytec_get_imx8mp_rtc(struct phytec_eeprom_data *data);
++u8 __maybe_unused phytec_get_imx8m_spi(struct phytec_eeprom_data *data);
++u8 __maybe_unused phytec_get_imx8m_eth(struct phytec_eeprom_data *data);
++
++#else
++
++inline u8 __maybe_unused phytec_imx8m_detect(struct phytec_eeprom_data *data)
++{
++	return -1;
++}
++
++inline u8 __maybe_unused
++phytec_get_imx8m_ddr_size(struct phytec_eeprom_data *data)
++{
++	return PHYTEC_EEPROM_INVAL;
++}
++
++inline u8 __maybe_unused phytec_get_imx8mp_rtc(struct phytec_eeprom_data *data)
++{
++	return PHYTEC_EEPROM_INVAL;
++}
++
++inline u8 __maybe_unused phytec_get_imx8m_spi(struct phytec_eeprom_data *data)
++{
++	return PHYTEC_EEPROM_INVAL;
++}
++
++inline u8 __maybe_unused phytec_get_imx8m_eth(struct phytec_eeprom_data *data)
++{
++	return PHYTEC_EEPROM_INVAL;
++}
++
++#endif /* IS_ENABLED(CONFIG_PHYTEC_IMX8M_SOM_DETECTION) */
++
++#endif /* _PHYTEC_IMX8M_SOM_DETECTION_H */
+diff --git a/board/phytec/common/phytec_som_detection.c b/board/phytec/common/phytec_som_detection.c
+new file mode 100644
+index 00000000000..55562731270
+--- /dev/null
++++ b/board/phytec/common/phytec_som_detection.c
+@@ -0,0 +1,203 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++/*
++ * Copyright (C) 2023 PHYTEC Messtechnik GmbH
++ * Author: Teresa Remmet <t.remmet@phytec.de>
++ */
++
++#include <common.h>
++#include <asm/mach-imx/mxc_i2c.h>
++#include <asm/arch/sys_proto.h>
++#include <dm/device.h>
++#include <dm/uclass.h>
++#include <i2c.h>
++#include <u-boot/crc.h>
++
++#include "phytec_som_detection.h"
++
++struct phytec_eeprom_data eeprom_data;
++
++int phytec_eeprom_data_setup_fallback(struct phytec_eeprom_data *data,
++				      int bus_num, int addr, int addr_fallback)
++{
++	int ret;
++
++	ret = phytec_eeprom_data_init(data, bus_num, addr);
++	if (ret) {
++		pr_err("%s: init failed. Trying fall back address 0x%x\n",
++		       __func__, addr_fallback);
++		ret = phytec_eeprom_data_init(data, bus_num, addr_fallback);
++	}
++
++	if (ret)
++		pr_err("%s: EEPROM data init failed\n", __func__);
++
++	return ret;
++}
++
++int phytec_eeprom_data_setup(struct phytec_eeprom_data *data,
++			     int bus_num, int addr)
++{
++	int ret;
++
++	ret = phytec_eeprom_data_init(data, bus_num, addr);
++	if (ret)
++		pr_err("%s: EEPROM data init failed\n", __func__);
++
++	return ret;
++}
++
++int phytec_eeprom_data_init(struct phytec_eeprom_data *data,
++			    int bus_num, int addr)
++{
++	int ret, i;
++	unsigned int crc;
++	int *ptr;
++
++	if (!data)
++		data = &eeprom_data;
++
++#if CONFIG_IS_ENABLED(DM_I2C)
++	struct udevice *dev;
++
++	ret = i2c_get_chip_for_busnum(bus_num, addr, 2, &dev);
++	if (ret) {
++		pr_err("%s: i2c EEPROM not found: %i.\n", __func__, ret);
++		return ret;
++	}
++
++	ret = dm_i2c_read(dev, 0, (uint8_t *)data,
++			  sizeof(struct phytec_eeprom_data));
++	if (ret) {
++		pr_err("%s: Unable to read EEPROM data\n", __func__);
++		return ret;
++	}
++#else
++	i2c_set_bus_num(bus_num);
++	ret = i2c_read(addr, 0, 2, (uint8_t *)data,
++		       sizeof(struct phytec_eeprom_data));
++#endif
++
++	if (data->api_rev == 0xff) {
++		pr_err("%s: EEPROM is not flashed. Prototype?\n", __func__);
++		return -EINVAL;
++	}
++
++	ptr = (int *)data;
++	for (i = 0; i < sizeof(struct phytec_eeprom_data); i += sizeof(ptr))
++		if (*ptr != 0x0)
++			break;
++
++	if (i == sizeof(struct phytec_eeprom_data)) {
++		pr_err("%s: EEPROM data is all zero. Erased?\n", __func__);
++		return -EINVAL;
++	}
++
++	/* We are done here for early revisions */
++	if (data->api_rev <= PHYTEC_API_REV1)
++		return 0;
++
++	crc = crc8(0, (const unsigned char *)data,
++		   sizeof(struct phytec_eeprom_data));
++	debug("%s: crc: %x\n", __func__, crc);
++
++	if (crc) {
++		pr_err("%s: CRC mismatch. EEPROM data is not usable\n",
++		       __func__);
++		return -EINVAL;
++	}
++
++	return 0;
++}
++
++void __maybe_unused phytec_print_som_info(struct phytec_eeprom_data *data)
++{
++	struct phytec_api2_data *api2;
++	char pcb_sub_rev;
++	unsigned int ksp_no, sub_som_type1, sub_som_type2;
++
++	if (!data)
++		data = &eeprom_data;
++
++	if (data->api_rev < PHYTEC_API_REV2)
++		return;
++
++	api2 = &data->data.data_api2;
++
++	/* Calculate PCB subrevision */
++	pcb_sub_rev = api2->pcb_sub_opt_rev & 0x0f;
++	pcb_sub_rev = pcb_sub_rev ? ((pcb_sub_rev - 1) + 'a') : ' ';
++
++	/* print standard product string */
++	if (api2->som_type <= 1) {
++		printf("SoM: %s-%03u-%s.%s PCB rev: %u%c\n",
++		       phytec_som_type_str[api2->som_type], api2->som_no,
++		       api2->opt, api2->bom_rev, api2->pcb_rev, pcb_sub_rev);
++		return;
++	}
++	/* print KSP/KSM string */
++	if (api2->som_type <= 3) {
++		ksp_no = (api2->ksp_no << 8) | api2->som_no;
++		printf("SoM: %s-%u ",
++		       phytec_som_type_str[api2->som_type], ksp_no);
++	/* print standard product based KSP/KSM strings */
++	} else {
++		switch (api2->som_type) {
++		case 4:
++			sub_som_type1 = 0;
++			sub_som_type2 = 3;
++			break;
++		case 5:
++			sub_som_type1 = 0;
++			sub_som_type2 = 2;
++			break;
++		case 6:
++			sub_som_type1 = 1;
++			sub_som_type2 = 3;
++			break;
++		case 7:
++			sub_som_type1 = 1;
++			sub_som_type2 = 2;
++			break;
++		default:
++			break;
++		};
++
++		printf("SoM: %s-%03u-%s-%03u ",
++		       phytec_som_type_str[sub_som_type1],
++		       api2->som_no, phytec_som_type_str[sub_som_type2],
++		       api2->ksp_no);
++	}
++
++	printf("Option: %s BOM rev: %s PCB rev: %u%c\n", api2->opt,
++	       api2->bom_rev, api2->pcb_rev, pcb_sub_rev);
++}
++
++char * __maybe_unused phytec_get_opt(struct phytec_eeprom_data *data)
++{
++	char *opt;
++
++	if (!data)
++		data = &eeprom_data;
++
++	if (data->api_rev < PHYTEC_API_REV2)
++		opt = data->data.data_api0.opt;
++	else
++		opt = data->data.data_api2.opt;
++
++	return opt;
++}
++
++u8 __maybe_unused phytec_get_rev(struct phytec_eeprom_data *data)
++{
++	struct phytec_api2_data *api2;
++
++	if (!data)
++		data = &eeprom_data;
++
++	if (data->api_rev < PHYTEC_API_REV2)
++		return PHYTEC_EEPROM_INVAL;
++
++	api2 = &data->data.data_api2;
++
++	return api2->pcb_rev;
++}
+diff --git a/board/phytec/common/phytec_som_detection.h b/board/phytec/common/phytec_som_detection.h
+new file mode 100644
+index 00000000000..c68e2302cc4
+--- /dev/null
++++ b/board/phytec/common/phytec_som_detection.h
+@@ -0,0 +1,109 @@
++/* SPDX-License-Identifier: GPL-2.0-or-later */
++/*
++ * Copyright (C) 2023 PHYTEC Messtechnik GmbH
++ * Author: Teresa Remmet <t.remmet@phytec.de>
++ */
++
++#ifndef _PHYTEC_SOM_DETECTION_H
++#define _PHYTEC_SOM_DETECTION_H
++
++#define PHYTEC_MAX_OPTIONS	17
++#define PHYTEC_EEPROM_INVAL	0xff
++
++#define PHYTEC_GET_OPTION(option) \
++	(((option) > '9') ? (option) - 'A' + 10 : (option) - '0')
++
++enum {
++	PHYTEC_API_REV0 = 0,
++	PHYTEC_API_REV1,
++	PHYTEC_API_REV2,
++};
++
++static const char * const phytec_som_type_str[] = {
++	"PCM",
++	"PCL",
++	"KSM",
++	"KSP",
++};
++
++struct phytec_api0_data {
++	u8 pcb_rev;		/* PCB revision of SoM */
++	u8 som_type;		/* SoM type */
++	u8 ksp_no;		/* KSP no */
++	char opt[16];		/* SoM options */
++	u8 mac[6];		/* MAC address (optional) */
++	u8 pad[5];		/* padding */
++	u8 cksum;		/* checksum */
++} __packed;
++
++struct phytec_api2_data {
++	u8 pcb_rev;		/* PCB revision of SoM */
++	u8 pcb_sub_opt_rev;	/* PCB subrevision and opt revision */
++	u8 som_type;		/* SoM type */
++	u8 som_no;		/* SoM number */
++	u8 ksp_no;		/* KSP information */
++	char opt[PHYTEC_MAX_OPTIONS]; /* SoM options */
++	char bom_rev[2];	/* BOM revision */
++	u8 mac[6];		/* MAC address (optional) */
++	u8 crc8;		/* checksum */
++} __packed;
++
++struct phytec_eeprom_data {
++	u8 api_rev;
++	union {
++		struct phytec_api0_data data_api0;
++		struct phytec_api2_data data_api2;
++	} data;
++} __packed;
++
++#if IS_ENABLED(CONFIG_PHYTEC_SOM_DETECTION)
++
++int phytec_eeprom_data_setup_fallback(struct phytec_eeprom_data *data,
++				      int bus_num, int addr,
++				      int addr_fallback);
++int phytec_eeprom_data_setup(struct phytec_eeprom_data *data,
++			     int bus_num, int addr);
++int phytec_eeprom_data_init(struct phytec_eeprom_data *data,
++			    int bus_num, int addr);
++void __maybe_unused phytec_print_som_info(struct phytec_eeprom_data *data);
++
++char * __maybe_unused phytec_get_opt(struct phytec_eeprom_data *data);
++u8 __maybe_unused phytec_get_rev(struct phytec_eeprom_data *data);
++
++#else
++
++inline int phytec_eeprom_data_setup(struct phytec_eeprom_data *data,
++				    int bus_num, int addr)
++{
++	return PHYTEC_EEPROM_INVAL;
++}
++
++inline int phytec_eeprom_data_setup_fallback(struct phytec_eeprom_data *data,
++					     int bus_num, int addr,
++					     int addr_fallback)
++{
++	return PHYTEC_EEPROM_INVAL;
++}
++
++inline int phytec_eeprom_data_init(struct phytec_eeprom_data *data,
++				   int bus_num, int addr)
++{
++	return PHYTEC_EEPROM_INVAL;
++}
++
++inline void __maybe_unused phytec_print_som_info(struct phytec_eeprom_data *data)
++{
++}
++
++inline char *__maybe_unused phytec_get_opt(struct phytec_eeprom_data *data)
++{
++	return NULL;
++}
++
++u8 __maybe_unused phytec_get_rev(struct phytec_eeprom_data *data)
++{
++	return PHYTEC_EEPROM_INVAL;
++}
++#endif /* IS_ENABLED(CONFIG_PHYTEC_SOM_DETECTION) */
++
++#endif /* _PHYTEC_SOM_DETECTION_H */
+diff --git a/board/phytec/phycore_imx8mm/Kconfig b/board/phytec/phycore_imx8mm/Kconfig
+index 25e4bf2f836..8c30efc14eb 100644
+--- a/board/phytec/phycore_imx8mm/Kconfig
++++ b/board/phytec/phycore_imx8mm/Kconfig
+@@ -12,4 +12,34 @@ config SYS_CONFIG_NAME
+ config IMX_CONFIG
+ 	default "board/phytec/phycore_imx8mm/imximage-8mm-sd.cfg"
+ 
++config PHYCORE_IMX8MM_RAM_SIZE_FIX
++	bool "Set phyCORE-i.MX8MM RAM size fix instead of detecting"
++	default false
++	help
++	  RAM size is automatic being detected with the help of
++	  the EEPROM introspection data. Set RAM size to a fix value
++	  instead.
++
++choice
++	prompt "phyCORE-i.MX8MM RAM size"
++	depends on PHYCORE_IMX8MM_RAM_SIZE_FIX
++	default PHYCORE_IMX8MM_RAM_SIZE_2GB
++
++config PHYCORE_IMX8MM_RAM_SIZE_1GB
++	bool "1GB RAM"
++	help
++	  Set RAM size fix to 1GB for phyCORE-i.MX8MM.
++
++config PHYCORE_IMX8MM_RAM_SIZE_2GB
++	bool "2GB RAM"
++	help
++	  Set RAM size fix to 2GB for phyCORE-i.MX8MM.
++
++config PHYCORE_IMX8MM_RAM_SIZE_4GB
++	bool "4GB RAM"
++	help
++	  Set RAM size fix to 4GB for phyCORE-i.MX8MM.
++endchoice
++
++source "board/phytec/common/Kconfig"
+ endif
+diff --git a/board/phytec/phycore_imx8mm/MAINTAINERS b/board/phytec/phycore_imx8mm/MAINTAINERS
+index 9edec7b7d28..3385854f4b6 100644
+--- a/board/phytec/phycore_imx8mm/MAINTAINERS
++++ b/board/phytec/phycore_imx8mm/MAINTAINERS
+@@ -1,9 +1,13 @@
+ phyCORE-i.MX8M Mini
+-M:      Teresa Remmet <t.remmet@phytec.de>
+-W:      https://www.phytec.eu/product-eu/system-on-modules/phycore-imx-8m-mini-nano/
+-S:      Maintained
+-F:      arch/arm/dts/phycore-imx8mm.dts
+-F:      arch/arm/dts/phycore-imx8mm-u-boot.dtsi
+-F:      board/phytec/phycore_imx8mm/
+-F:      configs/phycore-imx8mm_defconfig
+-F:      include/configs/phycore_imx8mm.h
++M:	Teresa Remmet <t.remmet@phytec.de>
++W:	https://www.phytec.eu/product-eu/system-on-modules/phycore-imx-8m-mini-nano/
++S:	Maintained
++F:	arch/arm/dts/imx8mm-phyboard-polis-rdk.dts
++F:	arch/arm/dts/imx8mm-phycore-som.dtsi
++F:	arch/arm/dts/imx8mm-phyboard-polis-rdk-u-boot.dtsi
++F:	arch/arm/dts/imx8mm-phygate-tauri.dts
++F:	arch/arm/dts/imx8mm-phygate-tauri-u-boot.dtsi
++F:	board/phytec/phycore_imx8mm/
++F:	configs/phycore-imx8mm_defconfig
++F:	configs/imx8mm-phygate-tauri_defconfig
++F:	include/configs/phycore_imx8mm.h
+diff --git a/board/phytec/phycore_imx8mm/lpddr4_timing.c b/board/phytec/phycore_imx8mm/lpddr4_timing.c
+index 811ac26415a..73e35c7c3b9 100644
+--- a/board/phytec/phycore_imx8mm/lpddr4_timing.c
++++ b/board/phytec/phycore_imx8mm/lpddr4_timing.c
+@@ -1,6 +1,7 @@
+ // SPDX-License-Identifier: GPL-2.0-or-later
+ /*
+- * Copyright (C) 2020 PHYTEC Messtechnik GmbH
++ * Copyright 2019 NXP
++ * Copyright (C) 2023 PHYTEC Messtechnik GmbH
+  *
+  * Generated code from MX8M_DDR_tool
+  */
+@@ -13,22 +14,22 @@ static struct dram_cfg_param ddr_ddrc_cfg[] = {
+ 	{0x3d400304, 0x1},
+ 	{0x3d400030, 0x1},
+ 	{0x3d400000, 0xa1080020},
+-	{0x3d400020, 0x223},
++	{0x3d400020, 0x222},
+ 	{0x3d400024, 0x3a980},
+-	{0x3d400064, 0x5b00d2},
++	{0x3d400064, 0x2d00d2},
+ 	{0x3d4000d0, 0xc00305ba},
+ 	{0x3d4000d4, 0x940000},
+ 	{0x3d4000dc, 0xd4002d},
+ 	{0x3d4000e0, 0x310000},
+ 	{0x3d4000e8, 0x66004d},
+ 	{0x3d4000ec, 0x16004d},
+-	{0x3d400100, 0x191e1920},
++	{0x3d400100, 0x191e0c20},
+ 	{0x3d400104, 0x60630},
+ 	{0x3d40010c, 0xb0b000},
+ 	{0x3d400110, 0xe04080e},
+ 	{0x3d400114, 0x2040c0c},
+ 	{0x3d400118, 0x1010007},
+-	{0x3d40011c, 0x401},
++	{0x3d40011c, 0x402},
+ 	{0x3d400130, 0x20600},
+ 	{0x3d400134, 0xc100002},
+ 	{0x3d400138, 0xd8},
+@@ -45,7 +46,7 @@ static struct dram_cfg_param ddr_ddrc_cfg[] = {
+ 	{0x3d4001b0, 0x11},
+ 	{0x3d4001c0, 0x1},
+ 	{0x3d4001c4, 0x1},
+-	{0x3d4000f4, 0xc99},
++	{0x3d4000f4, 0x699},
+ 	{0x3d400108, 0x70e1617},
+ 	{0x3d400200, 0x1f},
+ 	{0x3d40020c, 0x0},
+@@ -53,6 +54,7 @@ static struct dram_cfg_param ddr_ddrc_cfg[] = {
+ 	{0x3d400204, 0x80808},
+ 	{0x3d400214, 0x7070707},
+ 	{0x3d400218, 0x7070707},
++	{0x3d40021c, 0xf0f},
+ 	{0x3d400250, 0x29001701},
+ 	{0x3d400254, 0x2c},
+ 	{0x3d40025c, 0x4000030},
+@@ -64,22 +66,22 @@ static struct dram_cfg_param ddr_ddrc_cfg[] = {
+ 	{0x3d400498, 0x620096},
+ 	{0x3d40049c, 0x1100e07},
+ 	{0x3d4004a0, 0xc8012c},
+-	{0x3d402020, 0x21},
++	{0x3d402020, 0x20},
+ 	{0x3d402024, 0x7d00},
+ 	{0x3d402050, 0x20d040},
+-	{0x3d402064, 0xc001c},
++	{0x3d402064, 0x6001c},
+ 	{0x3d4020dc, 0x840000},
+ 	{0x3d4020e0, 0x310000},
+ 	{0x3d4020e8, 0x66004d},
+ 	{0x3d4020ec, 0x16004d},
+-	{0x3d402100, 0xa040305},
++	{0x3d402100, 0xa040105},
+ 	{0x3d402104, 0x30407},
+ 	{0x3d402108, 0x203060b},
+ 	{0x3d40210c, 0x505000},
+ 	{0x3d402110, 0x2040202},
+ 	{0x3d402114, 0x2030202},
+ 	{0x3d402118, 0x1010004},
+-	{0x3d40211c, 0x301},
++	{0x3d40211c, 0x302},
+ 	{0x3d402130, 0x20300},
+ 	{0x3d402134, 0xa100002},
+ 	{0x3d402138, 0x1d},
+@@ -88,8 +90,8 @@ static struct dram_cfg_param ddr_ddrc_cfg[] = {
+ 	{0x3d402190, 0x3818200},
+ 	{0x3d402194, 0x80303},
+ 	{0x3d4021b4, 0x100},
+-	{0x3d4020f4, 0xc99},
+-	{0x3d403020, 0x21},
++	{0x3d4020f4, 0x599},
++	{0x3d403020, 0x20},
+ 	{0x3d403024, 0x1f40},
+ 	{0x3d403050, 0x20d040},
+ 	{0x3d403064, 0x30007},
+@@ -104,7 +106,7 @@ static struct dram_cfg_param ddr_ddrc_cfg[] = {
+ 	{0x3d403110, 0x2040202},
+ 	{0x3d403114, 0x2030202},
+ 	{0x3d403118, 0x1010004},
+-	{0x3d40311c, 0x301},
++	{0x3d40311c, 0x302},
+ 	{0x3d403130, 0x20300},
+ 	{0x3d403134, 0xa100002},
+ 	{0x3d403138, 0x8},
+@@ -113,7 +115,7 @@ static struct dram_cfg_param ddr_ddrc_cfg[] = {
+ 	{0x3d403190, 0x3818200},
+ 	{0x3d403194, 0x80303},
+ 	{0x3d4031b4, 0x100},
+-	{0x3d4030f4, 0xc99},
++	{0x3d4030f4, 0x599},
+ 	{0x3d400028, 0x0},
+ };
+ 
+@@ -201,8 +203,8 @@ static struct dram_cfg_param ddr_ddrphy_cfg[] = {
+ 	{0x220024, 0x1ab},
+ 	{0x2003a, 0x0},
+ 	{0x20056, 0x3},
+-	{0x120056, 0xa},
+-	{0x220056, 0xa},
++	{0x120056, 0x3},
++	{0x220056, 0x3},
+ 	{0x1004d, 0xe00},
+ 	{0x1014d, 0xe00},
+ 	{0x1104d, 0xe00},
+@@ -323,727 +325,726 @@ static struct dram_cfg_param ddr_ddrphy_cfg[] = {
+ 
+ /* ddr phy trained csr */
+ static struct dram_cfg_param ddr_ddrphy_trained_csr[] = {
+-	{ 0x200b2, 0x0 },
+-	{ 0x1200b2, 0x0 },
+-	{ 0x2200b2, 0x0 },
+-	{ 0x200cb, 0x0 },
+-	{ 0x10043, 0x0 },
+-	{ 0x110043, 0x0 },
+-	{ 0x210043, 0x0 },
+-	{ 0x10143, 0x0 },
+-	{ 0x110143, 0x0 },
+-	{ 0x210143, 0x0 },
+-	{ 0x11043, 0x0 },
+-	{ 0x111043, 0x0 },
+-	{ 0x211043, 0x0 },
+-	{ 0x11143, 0x0 },
+-	{ 0x111143, 0x0 },
+-	{ 0x211143, 0x0 },
+-	{ 0x12043, 0x0 },
+-	{ 0x112043, 0x0 },
+-	{ 0x212043, 0x0 },
+-	{ 0x12143, 0x0 },
+-	{ 0x112143, 0x0 },
+-	{ 0x212143, 0x0 },
+-	{ 0x13043, 0x0 },
+-	{ 0x113043, 0x0 },
+-	{ 0x213043, 0x0 },
+-	{ 0x13143, 0x0 },
+-	{ 0x113143, 0x0 },
+-	{ 0x213143, 0x0 },
+-	{ 0x80, 0x0 },
+-	{ 0x100080, 0x0 },
+-	{ 0x200080, 0x0 },
+-	{ 0x1080, 0x0 },
+-	{ 0x101080, 0x0 },
+-	{ 0x201080, 0x0 },
+-	{ 0x2080, 0x0 },
+-	{ 0x102080, 0x0 },
+-	{ 0x202080, 0x0 },
+-	{ 0x3080, 0x0 },
+-	{ 0x103080, 0x0 },
+-	{ 0x203080, 0x0 },
+-	{ 0x4080, 0x0 },
+-	{ 0x104080, 0x0 },
+-	{ 0x204080, 0x0 },
+-	{ 0x5080, 0x0 },
+-	{ 0x105080, 0x0 },
+-	{ 0x205080, 0x0 },
+-	{ 0x6080, 0x0 },
+-	{ 0x106080, 0x0 },
+-	{ 0x206080, 0x0 },
+-	{ 0x7080, 0x0 },
+-	{ 0x107080, 0x0 },
+-	{ 0x207080, 0x0 },
+-	{ 0x8080, 0x0 },
+-	{ 0x108080, 0x0 },
+-	{ 0x208080, 0x0 },
+-	{ 0x9080, 0x0 },
+-	{ 0x109080, 0x0 },
+-	{ 0x209080, 0x0 },
+-	{ 0x10080, 0x0 },
+-	{ 0x110080, 0x0 },
+-	{ 0x210080, 0x0 },
+-	{ 0x10180, 0x0 },
+-	{ 0x110180, 0x0 },
+-	{ 0x210180, 0x0 },
+-	{ 0x11080, 0x0 },
+-	{ 0x111080, 0x0 },
+-	{ 0x211080, 0x0 },
+-	{ 0x11180, 0x0 },
+-	{ 0x111180, 0x0 },
+-	{ 0x211180, 0x0 },
+-	{ 0x12080, 0x0 },
+-	{ 0x112080, 0x0 },
+-	{ 0x212080, 0x0 },
+-	{ 0x12180, 0x0 },
+-	{ 0x112180, 0x0 },
+-	{ 0x212180, 0x0 },
+-	{ 0x13080, 0x0 },
+-	{ 0x113080, 0x0 },
+-	{ 0x213080, 0x0 },
+-	{ 0x13180, 0x0 },
+-	{ 0x113180, 0x0 },
+-	{ 0x213180, 0x0 },
+-	{ 0x10081, 0x0 },
+-	{ 0x110081, 0x0 },
+-	{ 0x210081, 0x0 },
+-	{ 0x10181, 0x0 },
+-	{ 0x110181, 0x0 },
+-	{ 0x210181, 0x0 },
+-	{ 0x11081, 0x0 },
+-	{ 0x111081, 0x0 },
+-	{ 0x211081, 0x0 },
+-	{ 0x11181, 0x0 },
+-	{ 0x111181, 0x0 },
+-	{ 0x211181, 0x0 },
+-	{ 0x12081, 0x0 },
+-	{ 0x112081, 0x0 },
+-	{ 0x212081, 0x0 },
+-	{ 0x12181, 0x0 },
+-	{ 0x112181, 0x0 },
+-	{ 0x212181, 0x0 },
+-	{ 0x13081, 0x0 },
+-	{ 0x113081, 0x0 },
+-	{ 0x213081, 0x0 },
+-	{ 0x13181, 0x0 },
+-	{ 0x113181, 0x0 },
+-	{ 0x213181, 0x0 },
+-	{ 0x100d0, 0x0 },
+-	{ 0x1100d0, 0x0 },
+-	{ 0x2100d0, 0x0 },
+-	{ 0x101d0, 0x0 },
+-	{ 0x1101d0, 0x0 },
+-	{ 0x2101d0, 0x0 },
+-	{ 0x110d0, 0x0 },
+-	{ 0x1110d0, 0x0 },
+-	{ 0x2110d0, 0x0 },
+-	{ 0x111d0, 0x0 },
+-	{ 0x1111d0, 0x0 },
+-	{ 0x2111d0, 0x0 },
+-	{ 0x120d0, 0x0 },
+-	{ 0x1120d0, 0x0 },
+-	{ 0x2120d0, 0x0 },
+-	{ 0x121d0, 0x0 },
+-	{ 0x1121d0, 0x0 },
+-	{ 0x2121d0, 0x0 },
+-	{ 0x130d0, 0x0 },
+-	{ 0x1130d0, 0x0 },
+-	{ 0x2130d0, 0x0 },
+-	{ 0x131d0, 0x0 },
+-	{ 0x1131d0, 0x0 },
+-	{ 0x2131d0, 0x0 },
+-	{ 0x100d1, 0x0 },
+-	{ 0x1100d1, 0x0 },
+-	{ 0x2100d1, 0x0 },
+-	{ 0x101d1, 0x0 },
+-	{ 0x1101d1, 0x0 },
+-	{ 0x2101d1, 0x0 },
+-	{ 0x110d1, 0x0 },
+-	{ 0x1110d1, 0x0 },
+-	{ 0x2110d1, 0x0 },
+-	{ 0x111d1, 0x0 },
+-	{ 0x1111d1, 0x0 },
+-	{ 0x2111d1, 0x0 },
+-	{ 0x120d1, 0x0 },
+-	{ 0x1120d1, 0x0 },
+-	{ 0x2120d1, 0x0 },
+-	{ 0x121d1, 0x0 },
+-	{ 0x1121d1, 0x0 },
+-	{ 0x2121d1, 0x0 },
+-	{ 0x130d1, 0x0 },
+-	{ 0x1130d1, 0x0 },
+-	{ 0x2130d1, 0x0 },
+-	{ 0x131d1, 0x0 },
+-	{ 0x1131d1, 0x0 },
+-	{ 0x2131d1, 0x0 },
+-	{ 0x10068, 0x0 },
+-	{ 0x10168, 0x0 },
+-	{ 0x10268, 0x0 },
+-	{ 0x10368, 0x0 },
+-	{ 0x10468, 0x0 },
+-	{ 0x10568, 0x0 },
+-	{ 0x10668, 0x0 },
+-	{ 0x10768, 0x0 },
+-	{ 0x10868, 0x0 },
+-	{ 0x11068, 0x0 },
+-	{ 0x11168, 0x0 },
+-	{ 0x11268, 0x0 },
+-	{ 0x11368, 0x0 },
+-	{ 0x11468, 0x0 },
+-	{ 0x11568, 0x0 },
+-	{ 0x11668, 0x0 },
+-	{ 0x11768, 0x0 },
+-	{ 0x11868, 0x0 },
+-	{ 0x12068, 0x0 },
+-	{ 0x12168, 0x0 },
+-	{ 0x12268, 0x0 },
+-	{ 0x12368, 0x0 },
+-	{ 0x12468, 0x0 },
+-	{ 0x12568, 0x0 },
+-	{ 0x12668, 0x0 },
+-	{ 0x12768, 0x0 },
+-	{ 0x12868, 0x0 },
+-	{ 0x13068, 0x0 },
+-	{ 0x13168, 0x0 },
+-	{ 0x13268, 0x0 },
+-	{ 0x13368, 0x0 },
+-	{ 0x13468, 0x0 },
+-	{ 0x13568, 0x0 },
+-	{ 0x13668, 0x0 },
+-	{ 0x13768, 0x0 },
+-	{ 0x13868, 0x0 },
+-	{ 0x10069, 0x0 },
+-	{ 0x10169, 0x0 },
+-	{ 0x10269, 0x0 },
+-	{ 0x10369, 0x0 },
+-	{ 0x10469, 0x0 },
+-	{ 0x10569, 0x0 },
+-	{ 0x10669, 0x0 },
+-	{ 0x10769, 0x0 },
+-	{ 0x10869, 0x0 },
+-	{ 0x11069, 0x0 },
+-	{ 0x11169, 0x0 },
+-	{ 0x11269, 0x0 },
+-	{ 0x11369, 0x0 },
+-	{ 0x11469, 0x0 },
+-	{ 0x11569, 0x0 },
+-	{ 0x11669, 0x0 },
+-	{ 0x11769, 0x0 },
+-	{ 0x11869, 0x0 },
+-	{ 0x12069, 0x0 },
+-	{ 0x12169, 0x0 },
+-	{ 0x12269, 0x0 },
+-	{ 0x12369, 0x0 },
+-	{ 0x12469, 0x0 },
+-	{ 0x12569, 0x0 },
+-	{ 0x12669, 0x0 },
+-	{ 0x12769, 0x0 },
+-	{ 0x12869, 0x0 },
+-	{ 0x13069, 0x0 },
+-	{ 0x13169, 0x0 },
+-	{ 0x13269, 0x0 },
+-	{ 0x13369, 0x0 },
+-	{ 0x13469, 0x0 },
+-	{ 0x13569, 0x0 },
+-	{ 0x13669, 0x0 },
+-	{ 0x13769, 0x0 },
+-	{ 0x13869, 0x0 },
+-	{ 0x1008c, 0x0 },
+-	{ 0x11008c, 0x0 },
+-	{ 0x21008c, 0x0 },
+-	{ 0x1018c, 0x0 },
+-	{ 0x11018c, 0x0 },
+-	{ 0x21018c, 0x0 },
+-	{ 0x1108c, 0x0 },
+-	{ 0x11108c, 0x0 },
+-	{ 0x21108c, 0x0 },
+-	{ 0x1118c, 0x0 },
+-	{ 0x11118c, 0x0 },
+-	{ 0x21118c, 0x0 },
+-	{ 0x1208c, 0x0 },
+-	{ 0x11208c, 0x0 },
+-	{ 0x21208c, 0x0 },
+-	{ 0x1218c, 0x0 },
+-	{ 0x11218c, 0x0 },
+-	{ 0x21218c, 0x0 },
+-	{ 0x1308c, 0x0 },
+-	{ 0x11308c, 0x0 },
+-	{ 0x21308c, 0x0 },
+-	{ 0x1318c, 0x0 },
+-	{ 0x11318c, 0x0 },
+-	{ 0x21318c, 0x0 },
+-	{ 0x1008d, 0x0 },
+-	{ 0x11008d, 0x0 },
+-	{ 0x21008d, 0x0 },
+-	{ 0x1018d, 0x0 },
+-	{ 0x11018d, 0x0 },
+-	{ 0x21018d, 0x0 },
+-	{ 0x1108d, 0x0 },
+-	{ 0x11108d, 0x0 },
+-	{ 0x21108d, 0x0 },
+-	{ 0x1118d, 0x0 },
+-	{ 0x11118d, 0x0 },
+-	{ 0x21118d, 0x0 },
+-	{ 0x1208d, 0x0 },
+-	{ 0x11208d, 0x0 },
+-	{ 0x21208d, 0x0 },
+-	{ 0x1218d, 0x0 },
+-	{ 0x11218d, 0x0 },
+-	{ 0x21218d, 0x0 },
+-	{ 0x1308d, 0x0 },
+-	{ 0x11308d, 0x0 },
+-	{ 0x21308d, 0x0 },
+-	{ 0x1318d, 0x0 },
+-	{ 0x11318d, 0x0 },
+-	{ 0x21318d, 0x0 },
+-	{ 0x100c0, 0x0 },
+-	{ 0x1100c0, 0x0 },
+-	{ 0x2100c0, 0x0 },
+-	{ 0x101c0, 0x0 },
+-	{ 0x1101c0, 0x0 },
+-	{ 0x2101c0, 0x0 },
+-	{ 0x102c0, 0x0 },
+-	{ 0x1102c0, 0x0 },
+-	{ 0x2102c0, 0x0 },
+-	{ 0x103c0, 0x0 },
+-	{ 0x1103c0, 0x0 },
+-	{ 0x2103c0, 0x0 },
+-	{ 0x104c0, 0x0 },
+-	{ 0x1104c0, 0x0 },
+-	{ 0x2104c0, 0x0 },
+-	{ 0x105c0, 0x0 },
+-	{ 0x1105c0, 0x0 },
+-	{ 0x2105c0, 0x0 },
+-	{ 0x106c0, 0x0 },
+-	{ 0x1106c0, 0x0 },
+-	{ 0x2106c0, 0x0 },
+-	{ 0x107c0, 0x0 },
+-	{ 0x1107c0, 0x0 },
+-	{ 0x2107c0, 0x0 },
+-	{ 0x108c0, 0x0 },
+-	{ 0x1108c0, 0x0 },
+-	{ 0x2108c0, 0x0 },
+-	{ 0x110c0, 0x0 },
+-	{ 0x1110c0, 0x0 },
+-	{ 0x2110c0, 0x0 },
+-	{ 0x111c0, 0x0 },
+-	{ 0x1111c0, 0x0 },
+-	{ 0x2111c0, 0x0 },
+-	{ 0x112c0, 0x0 },
+-	{ 0x1112c0, 0x0 },
+-	{ 0x2112c0, 0x0 },
+-	{ 0x113c0, 0x0 },
+-	{ 0x1113c0, 0x0 },
+-	{ 0x2113c0, 0x0 },
+-	{ 0x114c0, 0x0 },
+-	{ 0x1114c0, 0x0 },
+-	{ 0x2114c0, 0x0 },
+-	{ 0x115c0, 0x0 },
+-	{ 0x1115c0, 0x0 },
+-	{ 0x2115c0, 0x0 },
+-	{ 0x116c0, 0x0 },
+-	{ 0x1116c0, 0x0 },
+-	{ 0x2116c0, 0x0 },
+-	{ 0x117c0, 0x0 },
+-	{ 0x1117c0, 0x0 },
+-	{ 0x2117c0, 0x0 },
+-	{ 0x118c0, 0x0 },
+-	{ 0x1118c0, 0x0 },
+-	{ 0x2118c0, 0x0 },
+-	{ 0x120c0, 0x0 },
+-	{ 0x1120c0, 0x0 },
+-	{ 0x2120c0, 0x0 },
+-	{ 0x121c0, 0x0 },
+-	{ 0x1121c0, 0x0 },
+-	{ 0x2121c0, 0x0 },
+-	{ 0x122c0, 0x0 },
+-	{ 0x1122c0, 0x0 },
+-	{ 0x2122c0, 0x0 },
+-	{ 0x123c0, 0x0 },
+-	{ 0x1123c0, 0x0 },
+-	{ 0x2123c0, 0x0 },
+-	{ 0x124c0, 0x0 },
+-	{ 0x1124c0, 0x0 },
+-	{ 0x2124c0, 0x0 },
+-	{ 0x125c0, 0x0 },
+-	{ 0x1125c0, 0x0 },
+-	{ 0x2125c0, 0x0 },
+-	{ 0x126c0, 0x0 },
+-	{ 0x1126c0, 0x0 },
+-	{ 0x2126c0, 0x0 },
+-	{ 0x127c0, 0x0 },
+-	{ 0x1127c0, 0x0 },
+-	{ 0x2127c0, 0x0 },
+-	{ 0x128c0, 0x0 },
+-	{ 0x1128c0, 0x0 },
+-	{ 0x2128c0, 0x0 },
+-	{ 0x130c0, 0x0 },
+-	{ 0x1130c0, 0x0 },
+-	{ 0x2130c0, 0x0 },
+-	{ 0x131c0, 0x0 },
+-	{ 0x1131c0, 0x0 },
+-	{ 0x2131c0, 0x0 },
+-	{ 0x132c0, 0x0 },
+-	{ 0x1132c0, 0x0 },
+-	{ 0x2132c0, 0x0 },
+-	{ 0x133c0, 0x0 },
+-	{ 0x1133c0, 0x0 },
+-	{ 0x2133c0, 0x0 },
+-	{ 0x134c0, 0x0 },
+-	{ 0x1134c0, 0x0 },
+-	{ 0x2134c0, 0x0 },
+-	{ 0x135c0, 0x0 },
+-	{ 0x1135c0, 0x0 },
+-	{ 0x2135c0, 0x0 },
+-	{ 0x136c0, 0x0 },
+-	{ 0x1136c0, 0x0 },
+-	{ 0x2136c0, 0x0 },
+-	{ 0x137c0, 0x0 },
+-	{ 0x1137c0, 0x0 },
+-	{ 0x2137c0, 0x0 },
+-	{ 0x138c0, 0x0 },
+-	{ 0x1138c0, 0x0 },
+-	{ 0x2138c0, 0x0 },
+-	{ 0x100c1, 0x0 },
+-	{ 0x1100c1, 0x0 },
+-	{ 0x2100c1, 0x0 },
+-	{ 0x101c1, 0x0 },
+-	{ 0x1101c1, 0x0 },
+-	{ 0x2101c1, 0x0 },
+-	{ 0x102c1, 0x0 },
+-	{ 0x1102c1, 0x0 },
+-	{ 0x2102c1, 0x0 },
+-	{ 0x103c1, 0x0 },
+-	{ 0x1103c1, 0x0 },
+-	{ 0x2103c1, 0x0 },
+-	{ 0x104c1, 0x0 },
+-	{ 0x1104c1, 0x0 },
+-	{ 0x2104c1, 0x0 },
+-	{ 0x105c1, 0x0 },
+-	{ 0x1105c1, 0x0 },
+-	{ 0x2105c1, 0x0 },
+-	{ 0x106c1, 0x0 },
+-	{ 0x1106c1, 0x0 },
+-	{ 0x2106c1, 0x0 },
+-	{ 0x107c1, 0x0 },
+-	{ 0x1107c1, 0x0 },
+-	{ 0x2107c1, 0x0 },
+-	{ 0x108c1, 0x0 },
+-	{ 0x1108c1, 0x0 },
+-	{ 0x2108c1, 0x0 },
+-	{ 0x110c1, 0x0 },
+-	{ 0x1110c1, 0x0 },
+-	{ 0x2110c1, 0x0 },
+-	{ 0x111c1, 0x0 },
+-	{ 0x1111c1, 0x0 },
+-	{ 0x2111c1, 0x0 },
+-	{ 0x112c1, 0x0 },
+-	{ 0x1112c1, 0x0 },
+-	{ 0x2112c1, 0x0 },
+-	{ 0x113c1, 0x0 },
+-	{ 0x1113c1, 0x0 },
+-	{ 0x2113c1, 0x0 },
+-	{ 0x114c1, 0x0 },
+-	{ 0x1114c1, 0x0 },
+-	{ 0x2114c1, 0x0 },
+-	{ 0x115c1, 0x0 },
+-	{ 0x1115c1, 0x0 },
+-	{ 0x2115c1, 0x0 },
+-	{ 0x116c1, 0x0 },
+-	{ 0x1116c1, 0x0 },
+-	{ 0x2116c1, 0x0 },
+-	{ 0x117c1, 0x0 },
+-	{ 0x1117c1, 0x0 },
+-	{ 0x2117c1, 0x0 },
+-	{ 0x118c1, 0x0 },
+-	{ 0x1118c1, 0x0 },
+-	{ 0x2118c1, 0x0 },
+-	{ 0x120c1, 0x0 },
+-	{ 0x1120c1, 0x0 },
+-	{ 0x2120c1, 0x0 },
+-	{ 0x121c1, 0x0 },
+-	{ 0x1121c1, 0x0 },
+-	{ 0x2121c1, 0x0 },
+-	{ 0x122c1, 0x0 },
+-	{ 0x1122c1, 0x0 },
+-	{ 0x2122c1, 0x0 },
+-	{ 0x123c1, 0x0 },
+-	{ 0x1123c1, 0x0 },
+-	{ 0x2123c1, 0x0 },
+-	{ 0x124c1, 0x0 },
+-	{ 0x1124c1, 0x0 },
+-	{ 0x2124c1, 0x0 },
+-	{ 0x125c1, 0x0 },
+-	{ 0x1125c1, 0x0 },
+-	{ 0x2125c1, 0x0 },
+-	{ 0x126c1, 0x0 },
+-	{ 0x1126c1, 0x0 },
+-	{ 0x2126c1, 0x0 },
+-	{ 0x127c1, 0x0 },
+-	{ 0x1127c1, 0x0 },
+-	{ 0x2127c1, 0x0 },
+-	{ 0x128c1, 0x0 },
+-	{ 0x1128c1, 0x0 },
+-	{ 0x2128c1, 0x0 },
+-	{ 0x130c1, 0x0 },
+-	{ 0x1130c1, 0x0 },
+-	{ 0x2130c1, 0x0 },
+-	{ 0x131c1, 0x0 },
+-	{ 0x1131c1, 0x0 },
+-	{ 0x2131c1, 0x0 },
+-	{ 0x132c1, 0x0 },
+-	{ 0x1132c1, 0x0 },
+-	{ 0x2132c1, 0x0 },
+-	{ 0x133c1, 0x0 },
+-	{ 0x1133c1, 0x0 },
+-	{ 0x2133c1, 0x0 },
+-	{ 0x134c1, 0x0 },
+-	{ 0x1134c1, 0x0 },
+-	{ 0x2134c1, 0x0 },
+-	{ 0x135c1, 0x0 },
+-	{ 0x1135c1, 0x0 },
+-	{ 0x2135c1, 0x0 },
+-	{ 0x136c1, 0x0 },
+-	{ 0x1136c1, 0x0 },
+-	{ 0x2136c1, 0x0 },
+-	{ 0x137c1, 0x0 },
+-	{ 0x1137c1, 0x0 },
+-	{ 0x2137c1, 0x0 },
+-	{ 0x138c1, 0x0 },
+-	{ 0x1138c1, 0x0 },
+-	{ 0x2138c1, 0x0 },
+-	{ 0x10020, 0x0 },
+-	{ 0x110020, 0x0 },
+-	{ 0x210020, 0x0 },
+-	{ 0x11020, 0x0 },
+-	{ 0x111020, 0x0 },
+-	{ 0x211020, 0x0 },
+-	{ 0x12020, 0x0 },
+-	{ 0x112020, 0x0 },
+-	{ 0x212020, 0x0 },
+-	{ 0x13020, 0x0 },
+-	{ 0x113020, 0x0 },
+-	{ 0x213020, 0x0 },
+-	{ 0x20072, 0x0 },
+-	{ 0x20073, 0x0 },
+-	{ 0x20074, 0x0 },
+-	{ 0x100aa, 0x0 },
+-	{ 0x110aa, 0x0 },
+-	{ 0x120aa, 0x0 },
+-	{ 0x130aa, 0x0 },
+-	{ 0x20010, 0x0 },
+-	{ 0x120010, 0x0 },
+-	{ 0x220010, 0x0 },
+-	{ 0x20011, 0x0 },
+-	{ 0x120011, 0x0 },
+-	{ 0x220011, 0x0 },
+-	{ 0x100ae, 0x0 },
+-	{ 0x1100ae, 0x0 },
+-	{ 0x2100ae, 0x0 },
+-	{ 0x100af, 0x0 },
+-	{ 0x1100af, 0x0 },
+-	{ 0x2100af, 0x0 },
+-	{ 0x110ae, 0x0 },
+-	{ 0x1110ae, 0x0 },
+-	{ 0x2110ae, 0x0 },
+-	{ 0x110af, 0x0 },
+-	{ 0x1110af, 0x0 },
+-	{ 0x2110af, 0x0 },
+-	{ 0x120ae, 0x0 },
+-	{ 0x1120ae, 0x0 },
+-	{ 0x2120ae, 0x0 },
+-	{ 0x120af, 0x0 },
+-	{ 0x1120af, 0x0 },
+-	{ 0x2120af, 0x0 },
+-	{ 0x130ae, 0x0 },
+-	{ 0x1130ae, 0x0 },
+-	{ 0x2130ae, 0x0 },
+-	{ 0x130af, 0x0 },
+-	{ 0x1130af, 0x0 },
+-	{ 0x2130af, 0x0 },
+-	{ 0x20020, 0x0 },
+-	{ 0x120020, 0x0 },
+-	{ 0x220020, 0x0 },
+-	{ 0x100a0, 0x0 },
+-	{ 0x100a1, 0x0 },
+-	{ 0x100a2, 0x0 },
+-	{ 0x100a3, 0x0 },
+-	{ 0x100a4, 0x0 },
+-	{ 0x100a5, 0x0 },
+-	{ 0x100a6, 0x0 },
+-	{ 0x100a7, 0x0 },
+-	{ 0x110a0, 0x0 },
+-	{ 0x110a1, 0x0 },
+-	{ 0x110a2, 0x0 },
+-	{ 0x110a3, 0x0 },
+-	{ 0x110a4, 0x0 },
+-	{ 0x110a5, 0x0 },
+-	{ 0x110a6, 0x0 },
+-	{ 0x110a7, 0x0 },
+-	{ 0x120a0, 0x0 },
+-	{ 0x120a1, 0x0 },
+-	{ 0x120a2, 0x0 },
+-	{ 0x120a3, 0x0 },
+-	{ 0x120a4, 0x0 },
+-	{ 0x120a5, 0x0 },
+-	{ 0x120a6, 0x0 },
+-	{ 0x120a7, 0x0 },
+-	{ 0x130a0, 0x0 },
+-	{ 0x130a1, 0x0 },
+-	{ 0x130a2, 0x0 },
+-	{ 0x130a3, 0x0 },
+-	{ 0x130a4, 0x0 },
+-	{ 0x130a5, 0x0 },
+-	{ 0x130a6, 0x0 },
+-	{ 0x130a7, 0x0 },
+-	{ 0x2007c, 0x0 },
+-	{ 0x12007c, 0x0 },
+-	{ 0x22007c, 0x0 },
+-	{ 0x2007d, 0x0 },
+-	{ 0x12007d, 0x0 },
+-	{ 0x22007d, 0x0 },
+-	{ 0x400fd, 0x0 },
+-	{ 0x400c0, 0x0 },
+-	{ 0x90201, 0x0 },
+-	{ 0x190201, 0x0 },
+-	{ 0x290201, 0x0 },
+-	{ 0x90202, 0x0 },
+-	{ 0x190202, 0x0 },
+-	{ 0x290202, 0x0 },
+-	{ 0x90203, 0x0 },
+-	{ 0x190203, 0x0 },
+-	{ 0x290203, 0x0 },
+-	{ 0x90204, 0x0 },
+-	{ 0x190204, 0x0 },
+-	{ 0x290204, 0x0 },
+-	{ 0x90205, 0x0 },
+-	{ 0x190205, 0x0 },
+-	{ 0x290205, 0x0 },
+-	{ 0x90206, 0x0 },
+-	{ 0x190206, 0x0 },
+-	{ 0x290206, 0x0 },
+-	{ 0x90207, 0x0 },
+-	{ 0x190207, 0x0 },
+-	{ 0x290207, 0x0 },
+-	{ 0x90208, 0x0 },
+-	{ 0x190208, 0x0 },
+-	{ 0x290208, 0x0 },
+-	{ 0x10062, 0x0 },
+-	{ 0x10162, 0x0 },
+-	{ 0x10262, 0x0 },
+-	{ 0x10362, 0x0 },
+-	{ 0x10462, 0x0 },
+-	{ 0x10562, 0x0 },
+-	{ 0x10662, 0x0 },
+-	{ 0x10762, 0x0 },
+-	{ 0x10862, 0x0 },
+-	{ 0x11062, 0x0 },
+-	{ 0x11162, 0x0 },
+-	{ 0x11262, 0x0 },
+-	{ 0x11362, 0x0 },
+-	{ 0x11462, 0x0 },
+-	{ 0x11562, 0x0 },
+-	{ 0x11662, 0x0 },
+-	{ 0x11762, 0x0 },
+-	{ 0x11862, 0x0 },
+-	{ 0x12062, 0x0 },
+-	{ 0x12162, 0x0 },
+-	{ 0x12262, 0x0 },
+-	{ 0x12362, 0x0 },
+-	{ 0x12462, 0x0 },
+-	{ 0x12562, 0x0 },
+-	{ 0x12662, 0x0 },
+-	{ 0x12762, 0x0 },
+-	{ 0x12862, 0x0 },
+-	{ 0x13062, 0x0 },
+-	{ 0x13162, 0x0 },
+-	{ 0x13262, 0x0 },
+-	{ 0x13362, 0x0 },
+-	{ 0x13462, 0x0 },
+-	{ 0x13562, 0x0 },
+-	{ 0x13662, 0x0 },
+-	{ 0x13762, 0x0 },
+-	{ 0x13862, 0x0 },
+-	{ 0x20077, 0x0 },
+-	{ 0x10001, 0x0 },
+-	{ 0x11001, 0x0 },
+-	{ 0x12001, 0x0 },
+-	{ 0x13001, 0x0 },
+-	{ 0x10040, 0x0 },
+-	{ 0x10140, 0x0 },
+-	{ 0x10240, 0x0 },
+-	{ 0x10340, 0x0 },
+-	{ 0x10440, 0x0 },
+-	{ 0x10540, 0x0 },
+-	{ 0x10640, 0x0 },
+-	{ 0x10740, 0x0 },
+-	{ 0x10840, 0x0 },
+-	{ 0x10030, 0x0 },
+-	{ 0x10130, 0x0 },
+-	{ 0x10230, 0x0 },
+-	{ 0x10330, 0x0 },
+-	{ 0x10430, 0x0 },
+-	{ 0x10530, 0x0 },
+-	{ 0x10630, 0x0 },
+-	{ 0x10730, 0x0 },
+-	{ 0x10830, 0x0 },
+-	{ 0x11040, 0x0 },
+-	{ 0x11140, 0x0 },
+-	{ 0x11240, 0x0 },
+-	{ 0x11340, 0x0 },
+-	{ 0x11440, 0x0 },
+-	{ 0x11540, 0x0 },
+-	{ 0x11640, 0x0 },
+-	{ 0x11740, 0x0 },
+-	{ 0x11840, 0x0 },
+-	{ 0x11030, 0x0 },
+-	{ 0x11130, 0x0 },
+-	{ 0x11230, 0x0 },
+-	{ 0x11330, 0x0 },
+-	{ 0x11430, 0x0 },
+-	{ 0x11530, 0x0 },
+-	{ 0x11630, 0x0 },
+-	{ 0x11730, 0x0 },
+-	{ 0x11830, 0x0 },
+-	{ 0x12040, 0x0 },
+-	{ 0x12140, 0x0 },
+-	{ 0x12240, 0x0 },
+-	{ 0x12340, 0x0 },
+-	{ 0x12440, 0x0 },
+-	{ 0x12540, 0x0 },
+-	{ 0x12640, 0x0 },
+-	{ 0x12740, 0x0 },
+-	{ 0x12840, 0x0 },
+-	{ 0x12030, 0x0 },
+-	{ 0x12130, 0x0 },
+-	{ 0x12230, 0x0 },
+-	{ 0x12330, 0x0 },
+-	{ 0x12430, 0x0 },
+-	{ 0x12530, 0x0 },
+-	{ 0x12630, 0x0 },
+-	{ 0x12730, 0x0 },
+-	{ 0x12830, 0x0 },
+-	{ 0x13040, 0x0 },
+-	{ 0x13140, 0x0 },
+-	{ 0x13240, 0x0 },
+-	{ 0x13340, 0x0 },
+-	{ 0x13440, 0x0 },
+-	{ 0x13540, 0x0 },
+-	{ 0x13640, 0x0 },
+-	{ 0x13740, 0x0 },
+-	{ 0x13840, 0x0 },
+-	{ 0x13030, 0x0 },
+-	{ 0x13130, 0x0 },
+-	{ 0x13230, 0x0 },
+-	{ 0x13330, 0x0 },
+-	{ 0x13430, 0x0 },
+-	{ 0x13530, 0x0 },
+-	{ 0x13630, 0x0 },
+-	{ 0x13730, 0x0 },
+-	{ 0x13830, 0x0 },
++	{0x200b2, 0x0},
++	{0x1200b2, 0x0},
++	{0x2200b2, 0x0},
++	{0x200cb, 0x0},
++	{0x10043, 0x0},
++	{0x110043, 0x0},
++	{0x210043, 0x0},
++	{0x10143, 0x0},
++	{0x110143, 0x0},
++	{0x210143, 0x0},
++	{0x11043, 0x0},
++	{0x111043, 0x0},
++	{0x211043, 0x0},
++	{0x11143, 0x0},
++	{0x111143, 0x0},
++	{0x211143, 0x0},
++	{0x12043, 0x0},
++	{0x112043, 0x0},
++	{0x212043, 0x0},
++	{0x12143, 0x0},
++	{0x112143, 0x0},
++	{0x212143, 0x0},
++	{0x13043, 0x0},
++	{0x113043, 0x0},
++	{0x213043, 0x0},
++	{0x13143, 0x0},
++	{0x113143, 0x0},
++	{0x213143, 0x0},
++	{0x80, 0x0},
++	{0x100080, 0x0},
++	{0x200080, 0x0},
++	{0x1080, 0x0},
++	{0x101080, 0x0},
++	{0x201080, 0x0},
++	{0x2080, 0x0},
++	{0x102080, 0x0},
++	{0x202080, 0x0},
++	{0x3080, 0x0},
++	{0x103080, 0x0},
++	{0x203080, 0x0},
++	{0x4080, 0x0},
++	{0x104080, 0x0},
++	{0x204080, 0x0},
++	{0x5080, 0x0},
++	{0x105080, 0x0},
++	{0x205080, 0x0},
++	{0x6080, 0x0},
++	{0x106080, 0x0},
++	{0x206080, 0x0},
++	{0x7080, 0x0},
++	{0x107080, 0x0},
++	{0x207080, 0x0},
++	{0x8080, 0x0},
++	{0x108080, 0x0},
++	{0x208080, 0x0},
++	{0x9080, 0x0},
++	{0x109080, 0x0},
++	{0x209080, 0x0},
++	{0x10080, 0x0},
++	{0x110080, 0x0},
++	{0x210080, 0x0},
++	{0x10180, 0x0},
++	{0x110180, 0x0},
++	{0x210180, 0x0},
++	{0x11080, 0x0},
++	{0x111080, 0x0},
++	{0x211080, 0x0},
++	{0x11180, 0x0},
++	{0x111180, 0x0},
++	{0x211180, 0x0},
++	{0x12080, 0x0},
++	{0x112080, 0x0},
++	{0x212080, 0x0},
++	{0x12180, 0x0},
++	{0x112180, 0x0},
++	{0x212180, 0x0},
++	{0x13080, 0x0},
++	{0x113080, 0x0},
++	{0x213080, 0x0},
++	{0x13180, 0x0},
++	{0x113180, 0x0},
++	{0x213180, 0x0},
++	{0x10081, 0x0},
++	{0x110081, 0x0},
++	{0x210081, 0x0},
++	{0x10181, 0x0},
++	{0x110181, 0x0},
++	{0x210181, 0x0},
++	{0x11081, 0x0},
++	{0x111081, 0x0},
++	{0x211081, 0x0},
++	{0x11181, 0x0},
++	{0x111181, 0x0},
++	{0x211181, 0x0},
++	{0x12081, 0x0},
++	{0x112081, 0x0},
++	{0x212081, 0x0},
++	{0x12181, 0x0},
++	{0x112181, 0x0},
++	{0x212181, 0x0},
++	{0x13081, 0x0},
++	{0x113081, 0x0},
++	{0x213081, 0x0},
++	{0x13181, 0x0},
++	{0x113181, 0x0},
++	{0x213181, 0x0},
++	{0x100d0, 0x0},
++	{0x1100d0, 0x0},
++	{0x2100d0, 0x0},
++	{0x101d0, 0x0},
++	{0x1101d0, 0x0},
++	{0x2101d0, 0x0},
++	{0x110d0, 0x0},
++	{0x1110d0, 0x0},
++	{0x2110d0, 0x0},
++	{0x111d0, 0x0},
++	{0x1111d0, 0x0},
++	{0x2111d0, 0x0},
++	{0x120d0, 0x0},
++	{0x1120d0, 0x0},
++	{0x2120d0, 0x0},
++	{0x121d0, 0x0},
++	{0x1121d0, 0x0},
++	{0x2121d0, 0x0},
++	{0x130d0, 0x0},
++	{0x1130d0, 0x0},
++	{0x2130d0, 0x0},
++	{0x131d0, 0x0},
++	{0x1131d0, 0x0},
++	{0x2131d0, 0x0},
++	{0x100d1, 0x0},
++	{0x1100d1, 0x0},
++	{0x2100d1, 0x0},
++	{0x101d1, 0x0},
++	{0x1101d1, 0x0},
++	{0x2101d1, 0x0},
++	{0x110d1, 0x0},
++	{0x1110d1, 0x0},
++	{0x2110d1, 0x0},
++	{0x111d1, 0x0},
++	{0x1111d1, 0x0},
++	{0x2111d1, 0x0},
++	{0x120d1, 0x0},
++	{0x1120d1, 0x0},
++	{0x2120d1, 0x0},
++	{0x121d1, 0x0},
++	{0x1121d1, 0x0},
++	{0x2121d1, 0x0},
++	{0x130d1, 0x0},
++	{0x1130d1, 0x0},
++	{0x2130d1, 0x0},
++	{0x131d1, 0x0},
++	{0x1131d1, 0x0},
++	{0x2131d1, 0x0},
++	{0x10068, 0x0},
++	{0x10168, 0x0},
++	{0x10268, 0x0},
++	{0x10368, 0x0},
++	{0x10468, 0x0},
++	{0x10568, 0x0},
++	{0x10668, 0x0},
++	{0x10768, 0x0},
++	{0x10868, 0x0},
++	{0x11068, 0x0},
++	{0x11168, 0x0},
++	{0x11268, 0x0},
++	{0x11368, 0x0},
++	{0x11468, 0x0},
++	{0x11568, 0x0},
++	{0x11668, 0x0},
++	{0x11768, 0x0},
++	{0x11868, 0x0},
++	{0x12068, 0x0},
++	{0x12168, 0x0},
++	{0x12268, 0x0},
++	{0x12368, 0x0},
++	{0x12468, 0x0},
++	{0x12568, 0x0},
++	{0x12668, 0x0},
++	{0x12768, 0x0},
++	{0x12868, 0x0},
++	{0x13068, 0x0},
++	{0x13168, 0x0},
++	{0x13268, 0x0},
++	{0x13368, 0x0},
++	{0x13468, 0x0},
++	{0x13568, 0x0},
++	{0x13668, 0x0},
++	{0x13768, 0x0},
++	{0x13868, 0x0},
++	{0x10069, 0x0},
++	{0x10169, 0x0},
++	{0x10269, 0x0},
++	{0x10369, 0x0},
++	{0x10469, 0x0},
++	{0x10569, 0x0},
++	{0x10669, 0x0},
++	{0x10769, 0x0},
++	{0x10869, 0x0},
++	{0x11069, 0x0},
++	{0x11169, 0x0},
++	{0x11269, 0x0},
++	{0x11369, 0x0},
++	{0x11469, 0x0},
++	{0x11569, 0x0},
++	{0x11669, 0x0},
++	{0x11769, 0x0},
++	{0x11869, 0x0},
++	{0x12069, 0x0},
++	{0x12169, 0x0},
++	{0x12269, 0x0},
++	{0x12369, 0x0},
++	{0x12469, 0x0},
++	{0x12569, 0x0},
++	{0x12669, 0x0},
++	{0x12769, 0x0},
++	{0x12869, 0x0},
++	{0x13069, 0x0},
++	{0x13169, 0x0},
++	{0x13269, 0x0},
++	{0x13369, 0x0},
++	{0x13469, 0x0},
++	{0x13569, 0x0},
++	{0x13669, 0x0},
++	{0x13769, 0x0},
++	{0x13869, 0x0},
++	{0x1008c, 0x0},
++	{0x11008c, 0x0},
++	{0x21008c, 0x0},
++	{0x1018c, 0x0},
++	{0x11018c, 0x0},
++	{0x21018c, 0x0},
++	{0x1108c, 0x0},
++	{0x11108c, 0x0},
++	{0x21108c, 0x0},
++	{0x1118c, 0x0},
++	{0x11118c, 0x0},
++	{0x21118c, 0x0},
++	{0x1208c, 0x0},
++	{0x11208c, 0x0},
++	{0x21208c, 0x0},
++	{0x1218c, 0x0},
++	{0x11218c, 0x0},
++	{0x21218c, 0x0},
++	{0x1308c, 0x0},
++	{0x11308c, 0x0},
++	{0x21308c, 0x0},
++	{0x1318c, 0x0},
++	{0x11318c, 0x0},
++	{0x21318c, 0x0},
++	{0x1008d, 0x0},
++	{0x11008d, 0x0},
++	{0x21008d, 0x0},
++	{0x1018d, 0x0},
++	{0x11018d, 0x0},
++	{0x21018d, 0x0},
++	{0x1108d, 0x0},
++	{0x11108d, 0x0},
++	{0x21108d, 0x0},
++	{0x1118d, 0x0},
++	{0x11118d, 0x0},
++	{0x21118d, 0x0},
++	{0x1208d, 0x0},
++	{0x11208d, 0x0},
++	{0x21208d, 0x0},
++	{0x1218d, 0x0},
++	{0x11218d, 0x0},
++	{0x21218d, 0x0},
++	{0x1308d, 0x0},
++	{0x11308d, 0x0},
++	{0x21308d, 0x0},
++	{0x1318d, 0x0},
++	{0x11318d, 0x0},
++	{0x21318d, 0x0},
++	{0x100c0, 0x0},
++	{0x1100c0, 0x0},
++	{0x2100c0, 0x0},
++	{0x101c0, 0x0},
++	{0x1101c0, 0x0},
++	{0x2101c0, 0x0},
++	{0x102c0, 0x0},
++	{0x1102c0, 0x0},
++	{0x2102c0, 0x0},
++	{0x103c0, 0x0},
++	{0x1103c0, 0x0},
++	{0x2103c0, 0x0},
++	{0x104c0, 0x0},
++	{0x1104c0, 0x0},
++	{0x2104c0, 0x0},
++	{0x105c0, 0x0},
++	{0x1105c0, 0x0},
++	{0x2105c0, 0x0},
++	{0x106c0, 0x0},
++	{0x1106c0, 0x0},
++	{0x2106c0, 0x0},
++	{0x107c0, 0x0},
++	{0x1107c0, 0x0},
++	{0x2107c0, 0x0},
++	{0x108c0, 0x0},
++	{0x1108c0, 0x0},
++	{0x2108c0, 0x0},
++	{0x110c0, 0x0},
++	{0x1110c0, 0x0},
++	{0x2110c0, 0x0},
++	{0x111c0, 0x0},
++	{0x1111c0, 0x0},
++	{0x2111c0, 0x0},
++	{0x112c0, 0x0},
++	{0x1112c0, 0x0},
++	{0x2112c0, 0x0},
++	{0x113c0, 0x0},
++	{0x1113c0, 0x0},
++	{0x2113c0, 0x0},
++	{0x114c0, 0x0},
++	{0x1114c0, 0x0},
++	{0x2114c0, 0x0},
++	{0x115c0, 0x0},
++	{0x1115c0, 0x0},
++	{0x2115c0, 0x0},
++	{0x116c0, 0x0},
++	{0x1116c0, 0x0},
++	{0x2116c0, 0x0},
++	{0x117c0, 0x0},
++	{0x1117c0, 0x0},
++	{0x2117c0, 0x0},
++	{0x118c0, 0x0},
++	{0x1118c0, 0x0},
++	{0x2118c0, 0x0},
++	{0x120c0, 0x0},
++	{0x1120c0, 0x0},
++	{0x2120c0, 0x0},
++	{0x121c0, 0x0},
++	{0x1121c0, 0x0},
++	{0x2121c0, 0x0},
++	{0x122c0, 0x0},
++	{0x1122c0, 0x0},
++	{0x2122c0, 0x0},
++	{0x123c0, 0x0},
++	{0x1123c0, 0x0},
++	{0x2123c0, 0x0},
++	{0x124c0, 0x0},
++	{0x1124c0, 0x0},
++	{0x2124c0, 0x0},
++	{0x125c0, 0x0},
++	{0x1125c0, 0x0},
++	{0x2125c0, 0x0},
++	{0x126c0, 0x0},
++	{0x1126c0, 0x0},
++	{0x2126c0, 0x0},
++	{0x127c0, 0x0},
++	{0x1127c0, 0x0},
++	{0x2127c0, 0x0},
++	{0x128c0, 0x0},
++	{0x1128c0, 0x0},
++	{0x2128c0, 0x0},
++	{0x130c0, 0x0},
++	{0x1130c0, 0x0},
++	{0x2130c0, 0x0},
++	{0x131c0, 0x0},
++	{0x1131c0, 0x0},
++	{0x2131c0, 0x0},
++	{0x132c0, 0x0},
++	{0x1132c0, 0x0},
++	{0x2132c0, 0x0},
++	{0x133c0, 0x0},
++	{0x1133c0, 0x0},
++	{0x2133c0, 0x0},
++	{0x134c0, 0x0},
++	{0x1134c0, 0x0},
++	{0x2134c0, 0x0},
++	{0x135c0, 0x0},
++	{0x1135c0, 0x0},
++	{0x2135c0, 0x0},
++	{0x136c0, 0x0},
++	{0x1136c0, 0x0},
++	{0x2136c0, 0x0},
++	{0x137c0, 0x0},
++	{0x1137c0, 0x0},
++	{0x2137c0, 0x0},
++	{0x138c0, 0x0},
++	{0x1138c0, 0x0},
++	{0x2138c0, 0x0},
++	{0x100c1, 0x0},
++	{0x1100c1, 0x0},
++	{0x2100c1, 0x0},
++	{0x101c1, 0x0},
++	{0x1101c1, 0x0},
++	{0x2101c1, 0x0},
++	{0x102c1, 0x0},
++	{0x1102c1, 0x0},
++	{0x2102c1, 0x0},
++	{0x103c1, 0x0},
++	{0x1103c1, 0x0},
++	{0x2103c1, 0x0},
++	{0x104c1, 0x0},
++	{0x1104c1, 0x0},
++	{0x2104c1, 0x0},
++	{0x105c1, 0x0},
++	{0x1105c1, 0x0},
++	{0x2105c1, 0x0},
++	{0x106c1, 0x0},
++	{0x1106c1, 0x0},
++	{0x2106c1, 0x0},
++	{0x107c1, 0x0},
++	{0x1107c1, 0x0},
++	{0x2107c1, 0x0},
++	{0x108c1, 0x0},
++	{0x1108c1, 0x0},
++	{0x2108c1, 0x0},
++	{0x110c1, 0x0},
++	{0x1110c1, 0x0},
++	{0x2110c1, 0x0},
++	{0x111c1, 0x0},
++	{0x1111c1, 0x0},
++	{0x2111c1, 0x0},
++	{0x112c1, 0x0},
++	{0x1112c1, 0x0},
++	{0x2112c1, 0x0},
++	{0x113c1, 0x0},
++	{0x1113c1, 0x0},
++	{0x2113c1, 0x0},
++	{0x114c1, 0x0},
++	{0x1114c1, 0x0},
++	{0x2114c1, 0x0},
++	{0x115c1, 0x0},
++	{0x1115c1, 0x0},
++	{0x2115c1, 0x0},
++	{0x116c1, 0x0},
++	{0x1116c1, 0x0},
++	{0x2116c1, 0x0},
++	{0x117c1, 0x0},
++	{0x1117c1, 0x0},
++	{0x2117c1, 0x0},
++	{0x118c1, 0x0},
++	{0x1118c1, 0x0},
++	{0x2118c1, 0x0},
++	{0x120c1, 0x0},
++	{0x1120c1, 0x0},
++	{0x2120c1, 0x0},
++	{0x121c1, 0x0},
++	{0x1121c1, 0x0},
++	{0x2121c1, 0x0},
++	{0x122c1, 0x0},
++	{0x1122c1, 0x0},
++	{0x2122c1, 0x0},
++	{0x123c1, 0x0},
++	{0x1123c1, 0x0},
++	{0x2123c1, 0x0},
++	{0x124c1, 0x0},
++	{0x1124c1, 0x0},
++	{0x2124c1, 0x0},
++	{0x125c1, 0x0},
++	{0x1125c1, 0x0},
++	{0x2125c1, 0x0},
++	{0x126c1, 0x0},
++	{0x1126c1, 0x0},
++	{0x2126c1, 0x0},
++	{0x127c1, 0x0},
++	{0x1127c1, 0x0},
++	{0x2127c1, 0x0},
++	{0x128c1, 0x0},
++	{0x1128c1, 0x0},
++	{0x2128c1, 0x0},
++	{0x130c1, 0x0},
++	{0x1130c1, 0x0},
++	{0x2130c1, 0x0},
++	{0x131c1, 0x0},
++	{0x1131c1, 0x0},
++	{0x2131c1, 0x0},
++	{0x132c1, 0x0},
++	{0x1132c1, 0x0},
++	{0x2132c1, 0x0},
++	{0x133c1, 0x0},
++	{0x1133c1, 0x0},
++	{0x2133c1, 0x0},
++	{0x134c1, 0x0},
++	{0x1134c1, 0x0},
++	{0x2134c1, 0x0},
++	{0x135c1, 0x0},
++	{0x1135c1, 0x0},
++	{0x2135c1, 0x0},
++	{0x136c1, 0x0},
++	{0x1136c1, 0x0},
++	{0x2136c1, 0x0},
++	{0x137c1, 0x0},
++	{0x1137c1, 0x0},
++	{0x2137c1, 0x0},
++	{0x138c1, 0x0},
++	{0x1138c1, 0x0},
++	{0x2138c1, 0x0},
++	{0x10020, 0x0},
++	{0x110020, 0x0},
++	{0x210020, 0x0},
++	{0x11020, 0x0},
++	{0x111020, 0x0},
++	{0x211020, 0x0},
++	{0x12020, 0x0},
++	{0x112020, 0x0},
++	{0x212020, 0x0},
++	{0x13020, 0x0},
++	{0x113020, 0x0},
++	{0x213020, 0x0},
++	{0x20072, 0x0},
++	{0x20073, 0x0},
++	{0x20074, 0x0},
++	{0x100aa, 0x0},
++	{0x110aa, 0x0},
++	{0x120aa, 0x0},
++	{0x130aa, 0x0},
++	{0x20010, 0x0},
++	{0x120010, 0x0},
++	{0x220010, 0x0},
++	{0x20011, 0x0},
++	{0x120011, 0x0},
++	{0x220011, 0x0},
++	{0x100ae, 0x0},
++	{0x1100ae, 0x0},
++	{0x2100ae, 0x0},
++	{0x100af, 0x0},
++	{0x1100af, 0x0},
++	{0x2100af, 0x0},
++	{0x110ae, 0x0},
++	{0x1110ae, 0x0},
++	{0x2110ae, 0x0},
++	{0x110af, 0x0},
++	{0x1110af, 0x0},
++	{0x2110af, 0x0},
++	{0x120ae, 0x0},
++	{0x1120ae, 0x0},
++	{0x2120ae, 0x0},
++	{0x120af, 0x0},
++	{0x1120af, 0x0},
++	{0x2120af, 0x0},
++	{0x130ae, 0x0},
++	{0x1130ae, 0x0},
++	{0x2130ae, 0x0},
++	{0x130af, 0x0},
++	{0x1130af, 0x0},
++	{0x2130af, 0x0},
++	{0x20020, 0x0},
++	{0x120020, 0x0},
++	{0x220020, 0x0},
++	{0x100a0, 0x0},
++	{0x100a1, 0x0},
++	{0x100a2, 0x0},
++	{0x100a3, 0x0},
++	{0x100a4, 0x0},
++	{0x100a5, 0x0},
++	{0x100a6, 0x0},
++	{0x100a7, 0x0},
++	{0x110a0, 0x0},
++	{0x110a1, 0x0},
++	{0x110a2, 0x0},
++	{0x110a3, 0x0},
++	{0x110a4, 0x0},
++	{0x110a5, 0x0},
++	{0x110a6, 0x0},
++	{0x110a7, 0x0},
++	{0x120a0, 0x0},
++	{0x120a1, 0x0},
++	{0x120a2, 0x0},
++	{0x120a3, 0x0},
++	{0x120a4, 0x0},
++	{0x120a5, 0x0},
++	{0x120a6, 0x0},
++	{0x120a7, 0x0},
++	{0x130a0, 0x0},
++	{0x130a1, 0x0},
++	{0x130a2, 0x0},
++	{0x130a3, 0x0},
++	{0x130a4, 0x0},
++	{0x130a5, 0x0},
++	{0x130a6, 0x0},
++	{0x130a7, 0x0},
++	{0x2007c, 0x0},
++	{0x12007c, 0x0},
++	{0x22007c, 0x0},
++	{0x2007d, 0x0},
++	{0x12007d, 0x0},
++	{0x22007d, 0x0},
++	{0x400fd, 0x0},
++	{0x400c0, 0x0},
++	{0x90201, 0x0},
++	{0x190201, 0x0},
++	{0x290201, 0x0},
++	{0x90202, 0x0},
++	{0x190202, 0x0},
++	{0x290202, 0x0},
++	{0x90203, 0x0},
++	{0x190203, 0x0},
++	{0x290203, 0x0},
++	{0x90204, 0x0},
++	{0x190204, 0x0},
++	{0x290204, 0x0},
++	{0x90205, 0x0},
++	{0x190205, 0x0},
++	{0x290205, 0x0},
++	{0x90206, 0x0},
++	{0x190206, 0x0},
++	{0x290206, 0x0},
++	{0x90207, 0x0},
++	{0x190207, 0x0},
++	{0x290207, 0x0},
++	{0x90208, 0x0},
++	{0x190208, 0x0},
++	{0x290208, 0x0},
++	{0x10062, 0x0},
++	{0x10162, 0x0},
++	{0x10262, 0x0},
++	{0x10362, 0x0},
++	{0x10462, 0x0},
++	{0x10562, 0x0},
++	{0x10662, 0x0},
++	{0x10762, 0x0},
++	{0x10862, 0x0},
++	{0x11062, 0x0},
++	{0x11162, 0x0},
++	{0x11262, 0x0},
++	{0x11362, 0x0},
++	{0x11462, 0x0},
++	{0x11562, 0x0},
++	{0x11662, 0x0},
++	{0x11762, 0x0},
++	{0x11862, 0x0},
++	{0x12062, 0x0},
++	{0x12162, 0x0},
++	{0x12262, 0x0},
++	{0x12362, 0x0},
++	{0x12462, 0x0},
++	{0x12562, 0x0},
++	{0x12662, 0x0},
++	{0x12762, 0x0},
++	{0x12862, 0x0},
++	{0x13062, 0x0},
++	{0x13162, 0x0},
++	{0x13262, 0x0},
++	{0x13362, 0x0},
++	{0x13462, 0x0},
++	{0x13562, 0x0},
++	{0x13662, 0x0},
++	{0x13762, 0x0},
++	{0x13862, 0x0},
++	{0x20077, 0x0},
++	{0x10001, 0x0},
++	{0x11001, 0x0},
++	{0x12001, 0x0},
++	{0x13001, 0x0},
++	{0x10040, 0x0},
++	{0x10140, 0x0},
++	{0x10240, 0x0},
++	{0x10340, 0x0},
++	{0x10440, 0x0},
++	{0x10540, 0x0},
++	{0x10640, 0x0},
++	{0x10740, 0x0},
++	{0x10840, 0x0},
++	{0x10030, 0x0},
++	{0x10130, 0x0},
++	{0x10230, 0x0},
++	{0x10330, 0x0},
++	{0x10430, 0x0},
++	{0x10530, 0x0},
++	{0x10630, 0x0},
++	{0x10730, 0x0},
++	{0x10830, 0x0},
++	{0x11040, 0x0},
++	{0x11140, 0x0},
++	{0x11240, 0x0},
++	{0x11340, 0x0},
++	{0x11440, 0x0},
++	{0x11540, 0x0},
++	{0x11640, 0x0},
++	{0x11740, 0x0},
++	{0x11840, 0x0},
++	{0x11030, 0x0},
++	{0x11130, 0x0},
++	{0x11230, 0x0},
++	{0x11330, 0x0},
++	{0x11430, 0x0},
++	{0x11530, 0x0},
++	{0x11630, 0x0},
++	{0x11730, 0x0},
++	{0x11830, 0x0},
++	{0x12040, 0x0},
++	{0x12140, 0x0},
++	{0x12240, 0x0},
++	{0x12340, 0x0},
++	{0x12440, 0x0},
++	{0x12540, 0x0},
++	{0x12640, 0x0},
++	{0x12740, 0x0},
++	{0x12840, 0x0},
++	{0x12030, 0x0},
++	{0x12130, 0x0},
++	{0x12230, 0x0},
++	{0x12330, 0x0},
++	{0x12430, 0x0},
++	{0x12530, 0x0},
++	{0x12630, 0x0},
++	{0x12730, 0x0},
++	{0x12830, 0x0},
++	{0x13040, 0x0},
++	{0x13140, 0x0},
++	{0x13240, 0x0},
++	{0x13340, 0x0},
++	{0x13440, 0x0},
++	{0x13540, 0x0},
++	{0x13640, 0x0},
++	{0x13740, 0x0},
++	{0x13840, 0x0},
++	{0x13030, 0x0},
++	{0x13130, 0x0},
++	{0x13230, 0x0},
++	{0x13330, 0x0},
++	{0x13430, 0x0},
++	{0x13530, 0x0},
++	{0x13630, 0x0},
++	{0x13730, 0x0},
++	{0x13830, 0x0},
+ };
+-
+ /* P0 message block paremeter for training firmware */
+ struct dram_cfg_param ddr_fsp0_cfg[] = {
+ 	{0xd0000, 0x0},
+@@ -1054,7 +1055,6 @@ struct dram_cfg_param ddr_fsp0_cfg[] = {
+ 	{0x54008, 0x131f},
+ 	{0x54009, 0xc8},
+ 	{0x5400b, 0x2},
+-	{0x5400d, 0x100},
+ 	{0x54012, 0x110},
+ 	{0x54019, 0x2dd4},
+ 	{0x5401a, 0x31},
+@@ -1094,7 +1094,6 @@ static struct dram_cfg_param ddr_fsp1_cfg[] = {
+ 	{0x54008, 0x121f},
+ 	{0x54009, 0xc8},
+ 	{0x5400b, 0x2},
+-	{0x5400d, 0x100},
+ 	{0x54012, 0x110},
+ 	{0x54019, 0x84},
+ 	{0x5401a, 0x31},
+@@ -1134,7 +1133,6 @@ static struct dram_cfg_param ddr_fsp2_cfg[] = {
+ 	{0x54008, 0x121f},
+ 	{0x54009, 0xc8},
+ 	{0x5400b, 0x2},
+-	{0x5400d, 0x100},
+ 	{0x54012, 0x110},
+ 	{0x54019, 0x84},
+ 	{0x5401a, 0x31},
+@@ -1200,7 +1198,7 @@ static struct dram_cfg_param ddr_fsp0_2d_cfg[] = {
+ 	{0x5403b, 0x4d},
+ 	{0x5403c, 0x4d},
+ 	{0x5403d, 0x1600},
+-	{ 0xd0000, 0x1 },
++	{0xd0000, 0x1},
+ };
+ 
+ /* DRAM PHY init engine image */
+@@ -1693,15 +1691,15 @@ static struct dram_cfg_param ddr_phy_pie[] = {
+ 	{0x400d6, 0x20a},
+ 	{0x400d7, 0x20b},
+ 	{0x2003a, 0x2},
+-	{0x2000b, 0x5d},
++	{0x2000b, 0x34b},
+ 	{0x2000c, 0xbb},
+ 	{0x2000d, 0x753},
+ 	{0x2000e, 0x2c},
+-	{0x12000b, 0xc},
++	{0x12000b, 0x70},
+ 	{0x12000c, 0x19},
+ 	{0x12000d, 0xfa},
+ 	{0x12000e, 0x10},
+-	{0x22000b, 0x3},
++	{0x22000b, 0x1c},
+ 	{0x22000c, 0x6},
+ 	{0x22000d, 0x3e},
+ 	{0x22000e, 0x10},
+@@ -1842,5 +1840,30 @@ struct dram_timing_info dram_timing = {
+ 	.ddrphy_trained_csr_num = ARRAY_SIZE(ddr_ddrphy_trained_csr),
+ 	.ddrphy_pie = ddr_phy_pie,
+ 	.ddrphy_pie_num = ARRAY_SIZE(ddr_phy_pie),
+-	.fsp_table = { 3000, 400, 100, },
++	.fsp_table = { 3000, 400, 100,},
+ };
++
++void set_dram_timings_1gb(void)
++{
++	dram_timing.ddrc_cfg[5].val = 0x2d0087;
++	dram_timing.ddrc_cfg[21].val = 0x8d;
++	dram_timing.ddrc_cfg[42].val = 0xf070707;
++	dram_timing.ddrc_cfg[58].val = 0x60012;
++	dram_timing.ddrc_cfg[73].val = 0x13;
++	dram_timing.ddrc_cfg[83].val = 0x30005;
++	dram_timing.ddrc_cfg[98].val = 0x5;
++}
++
++void set_dram_timings_4gb(void)
++{
++	dram_timing.ddrc_cfg[2].val = 0xa3080020;
++	dram_timing.ddrc_cfg[37].val = 0x17;
++	dram_timing.fsp_msg[0].fsp_cfg[8].val = 0x310;
++	dram_timing.fsp_msg[0].fsp_cfg[20].val = 0x3;
++	dram_timing.fsp_msg[1].fsp_cfg[9].val = 0x310;
++	dram_timing.fsp_msg[1].fsp_cfg[21].val = 0x3;
++	dram_timing.fsp_msg[2].fsp_cfg[9].val = 0x310;
++	dram_timing.fsp_msg[2].fsp_cfg[21].val = 0x3;
++	dram_timing.fsp_msg[3].fsp_cfg[10].val = 0x310;
++	dram_timing.fsp_msg[3].fsp_cfg[22].val = 0x3;
++}
+diff --git a/board/phytec/phycore_imx8mm/phycore-imx8mm.c b/board/phytec/phycore_imx8mm/phycore-imx8mm.c
+index ef647291690..5e9b370685d 100644
+--- a/board/phytec/phycore_imx8mm/phycore-imx8mm.c
++++ b/board/phytec/phycore_imx8mm/phycore-imx8mm.c
+@@ -52,3 +52,13 @@ int board_late_init(void)
+ 
+ 	return 0;
+ }
++
++int board_phys_sdram_size(phys_size_t *size)
++{
++	if (!size)
++		return -EINVAL;
++
++	*size = imx8m_ddrc_sdram_size();
++
++	return 0;
++}
+diff --git a/board/phytec/phycore_imx8mm/spl.c b/board/phytec/phycore_imx8mm/spl.c
+index d54145ef995..b3a2d1c5cc5 100644
+--- a/board/phytec/phycore_imx8mm/spl.c
++++ b/board/phytec/phycore_imx8mm/spl.c
+@@ -12,13 +12,23 @@
+ #include <asm/global_data.h>
+ #include <asm/mach-imx/boot_mode.h>
+ #include <asm/mach-imx/iomux-v3.h>
++#include <dm/device.h>
++#include <dm/uclass.h>
+ #include <hang.h>
+ #include <init.h>
+ #include <log.h>
+ #include <spl.h>
+ 
++#include "../common/imx8m_som_detection.h"
++
+ DECLARE_GLOBAL_DATA_PTR;
+ 
++#define EEPROM_ADDR		0x51
++#define EEPROM_ADDR_FALLBACK	0x59
++
++void set_dram_timings_1gb(void);
++void set_dram_timings_4gb(void);
++
+ int spl_board_boot_device(enum boot_device boot_dev_spl)
+ {
+ 	switch (boot_dev_spl) {
+@@ -37,8 +47,54 @@ int spl_board_boot_device(enum boot_device boot_dev_spl)
+ 	}
+ }
+ 
++enum phytec_imx8mm_ddr_eeprom_code {
++	INVALID = PHYTEC_EEPROM_INVAL,
++	PHYTEC_IMX8MM_DDR_1GB = 1,
++	PHYTEC_IMX8MM_DDR_2GB = 3,
++	PHYTEC_IMX8MM_DDR_4GB = 5,
++};
++
+ static void spl_dram_init(void)
+ {
++	int ret;
++	enum phytec_imx8mm_ddr_eeprom_code size = INVALID;
++
++	ret = phytec_eeprom_data_setup_fallback(NULL, 0, EEPROM_ADDR,
++						EEPROM_ADDR_FALLBACK);
++	if (ret && !IS_ENABLED(CONFIG_PHYCORE_IMX8MM_RAM_SIZE_FIX))
++		goto out;
++
++	ret = phytec_imx8m_detect(NULL);
++	if (!ret)
++		phytec_print_som_info(NULL);
++
++	if (IS_ENABLED(CONFIG_PHYCORE_IMX8MM_RAM_SIZE_FIX)) {
++		if (IS_ENABLED(CONFIG_PHYCORE_IMX8MM_RAM_SIZE_1GB))
++			size = PHYTEC_IMX8MM_DDR_1GB;
++		else if (IS_ENABLED(CONFIG_PHYCORE_IMX8MM_RAM_SIZE_2GB))
++			size = PHYTEC_IMX8MM_DDR_2GB;
++		else if (IS_ENABLED(CONFIG_PHYCORE_IMX8MM_RAM_SIZE_4GB))
++			size = PHYTEC_IMX8MM_DDR_4GB;
++	} else {
++		size = phytec_get_imx8m_ddr_size(NULL);
++	}
++
++	switch (size) {
++	case PHYTEC_IMX8MM_DDR_1GB:
++		set_dram_timings_1gb();
++		break;
++	case PHYTEC_IMX8MM_DDR_2GB:
++		break;
++	case PHYTEC_IMX8MM_DDR_4GB:
++		set_dram_timings_4gb();
++		break;
++	default:
++		goto out;
++	}
++	ddr_init(&dram_timing);
++	return;
++out:
++	puts("Could not detect correct RAM size. Fall back to default.\n");
+ 	ddr_init(&dram_timing);
+ }
+ 
+@@ -57,14 +113,8 @@ int board_fit_config_name_match(const char *name)
+ 	return 0;
+ }
+ 
+-#define UART_PAD_CTRL	(PAD_CTL_DSE6 | PAD_CTL_FSEL1)
+ #define WDOG_PAD_CTRL	(PAD_CTL_DSE6 | PAD_CTL_ODE)
+ 
+-static iomux_v3_cfg_t const uart_pads[] = {
+-	IMX8MM_PAD_UART3_RXD_UART3_RX | MUX_PAD_CTRL(UART_PAD_CTRL),
+-	IMX8MM_PAD_UART3_TXD_UART3_TX | MUX_PAD_CTRL(UART_PAD_CTRL),
+-};
+-
+ static iomux_v3_cfg_t const wdog_pads[] = {
+ 	IMX8MM_PAD_GPIO1_IO02_WDOG1_WDOG_B  | MUX_PAD_CTRL(WDOG_PAD_CTRL),
+ };
+@@ -77,8 +127,6 @@ int board_early_init_f(void)
+ 
+ 	set_wdog_reset(wdog);
+ 
+-	imx_iomux_v3_setup_multiple_pads(uart_pads, ARRAY_SIZE(uart_pads));
+-
+ 	return 0;
+ }
+ 
+@@ -92,8 +140,6 @@ void board_init_f(ulong dummy)
+ 
+ 	board_early_init_f();
+ 
+-	preloader_console_init();
+-
+ 	/* Clear the BSS. */
+ 	memset(__bss_start, 0, __bss_end - __bss_start);
+ 
+@@ -103,6 +149,8 @@ void board_init_f(ulong dummy)
+ 		hang();
+ 	}
+ 
++	preloader_console_init();
++
+ 	enable_tzc380();
+ 
+ 	/* DDR initialization */
+diff --git a/board/phytec/phycore_imx8mn/Kconfig b/board/phytec/phycore_imx8mn/Kconfig
+new file mode 100644
+index 00000000000..50514ad2fb0
+--- /dev/null
++++ b/board/phytec/phycore_imx8mn/Kconfig
+@@ -0,0 +1,15 @@
++if TARGET_PHYCORE_IMX8MN
++config SYS_BOARD
++	default "phycore_imx8mn"
++
++config SYS_VENDOR
++	default "phytec"
++
++config SYS_CONFIG_NAME
++	default "phycore_imx8mn"
++
++config IMX_CONFIG
++	default "board/phytec/phycore_imx8mn/imximage-8mn-sd.cfg"
++
++source "board/phytec/common/Kconfig"
++endif
+diff --git a/board/phytec/phycore_imx8mn/MAINTAINERS b/board/phytec/phycore_imx8mn/MAINTAINERS
+new file mode 100644
+index 00000000000..0aa047f028f
+--- /dev/null
++++ b/board/phytec/phycore_imx8mn/MAINTAINERS
+@@ -0,0 +1,9 @@
++phyCORE-i.MX8M Nano
++M:      Teresa Remmet <t.remmet@phytec.de>
++W:      https://www.phytec.eu/product-eu/system-on-modules/phycore-imx-8m-mini-nano/
++S:      Maintained
++F:      arch/arm/dts/phycore-imx8mn.dts
++F:      arch/arm/dts/phycore-imx8mn-u-boot.dtsi
++F:      board/phytec/phycore_imx8mn/
++F:      configs/phycore-imx8mn_defconfig
++F:      include/configs/phycore_imx8mn.h
+diff --git a/board/phytec/phycore_imx8mn/Makefile b/board/phytec/phycore_imx8mn/Makefile
+new file mode 100644
+index 00000000000..7fed6892ca6
+--- /dev/null
++++ b/board/phytec/phycore_imx8mn/Makefile
+@@ -0,0 +1,11 @@
++# SPDX-License-Identifier: GPL-2.0-or-later
++#
++# Copyright (C) 2020 PHYTEC Messtechnik GmbH
++# Author: Teresa Remmet <t.remmet@phytec.de>
++
++obj-y += phycore-imx8mn.o
++
++ifdef CONFIG_SPL_BUILD
++obj-y += spl.o
++obj-$(CONFIG_IMX8M_LPDDR4) += lpddr4_timing.o
++endif
+diff --git a/board/phytec/phycore_imx8mn/imximage-8mn-sd.cfg b/board/phytec/phycore_imx8mn/imximage-8mn-sd.cfg
+new file mode 100644
+index 00000000000..0edda9c5e06
+--- /dev/null
++++ b/board/phytec/phycore_imx8mn/imximage-8mn-sd.cfg
+@@ -0,0 +1,9 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * Copyright 2021 NXP
++ */
++
++
++ROM_VERSION	v2
++BOOT_FROM	sd
++LOADER		u-boot-spl-ddr.bin	0x912000
+diff --git a/board/phytec/phycore_imx8mn/lpddr4_timing.c b/board/phytec/phycore_imx8mn/lpddr4_timing.c
+new file mode 100644
+index 00000000000..d4c4d9a07cc
+--- /dev/null
++++ b/board/phytec/phycore_imx8mn/lpddr4_timing.c
+@@ -0,0 +1,1440 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++/*
++ * Copyright (C) 2020 PHYTEC Messtechnik GmbH
++ *
++ * Generated code from MX8M_DDR_tool
++ */
++
++#include <linux/kernel.h>
++#include <asm/arch/ddr.h>
++
++static struct dram_cfg_param ddr_ddrc_cfg[] = {
++	/** Initialize DDRC registers **/
++	{0x3d400304, 0x1},
++	{0x3d400030, 0x1},
++	{0x3d400000, 0xa1080020},
++	{0x3d400020, 0x213},
++	{0x3d400024, 0x3e800},
++	{0x3d400064, 0x6100e0},
++	{0x3d4000d0, 0xc003061c},
++	{0x3d4000d4, 0x9e0000},
++	{0x3d4000dc, 0xd4002d},
++	{0x3d4000e0, 0x310000},
++	{0x3d4000e8, 0x66004d},
++	{0x3d4000ec, 0x16004d},
++	{0x3d400100, 0x1a201b22},
++	{0x3d400104, 0x60633},
++	{0x3d40010c, 0xc0c000},
++	{0x3d400110, 0xf04080f},
++	{0x3d400114, 0x2040c0c},
++	{0x3d400118, 0x1010007},
++	{0x3d40011c, 0x401},
++	{0x3d400130, 0x20600},
++	{0x3d400134, 0xc100002},
++	{0x3d400138, 0xe6},
++	{0x3d400144, 0xa00050},
++	{0x3d400180, 0x3200018},
++	{0x3d400184, 0x28061a8},
++	{0x3d400188, 0x0},
++	{0x3d400190, 0x497820a},
++	{0x3d400194, 0x80303},
++	{0x3d4001b4, 0x170a},
++	{0x3d4001a0, 0xe0400018},
++	{0x3d4001a4, 0xdf00e4},
++	{0x3d4001a8, 0x80000000},
++	{0x3d4001b0, 0x11},
++	{0x3d4001c0, 0x1},
++	{0x3d4001c4, 0x1},
++	{0x3d4000f4, 0xc99},
++	{0x3d400108, 0x70e1617},
++	{0x3d400200, 0x1f},
++	{0x3d40020c, 0x0},
++	{0x3d400210, 0x1f1f},
++	{0x3d400204, 0x80808},
++	{0x3d400214, 0x7070707},
++	{0x3d400218, 0x7070707},
++	{0x3d40021c, 0xf0f},
++	{0x3d400250, 0x29001701},
++	{0x3d400254, 0x2c},
++	{0x3d40025c, 0x4000030},
++	{0x3d400264, 0x900093e7},
++	{0x3d40026c, 0x2005574},
++	{0x3d400400, 0x111},
++	{0x3d400408, 0x72ff},
++	{0x3d400494, 0x2100e07},
++	{0x3d400498, 0x620096},
++	{0x3d40049c, 0x1100e07},
++	{0x3d4004a0, 0xc8012c},
++	{0x3d402020, 0x11},
++	{0x3d402024, 0x7d00},
++	{0x3d402050, 0x20d040},
++	{0x3d402064, 0xc001c},
++	{0x3d4020dc, 0x840000},
++	{0x3d4020e0, 0x310000},
++	{0x3d4020e8, 0x66004d},
++	{0x3d4020ec, 0x16004d},
++	{0x3d402100, 0xa040305},
++	{0x3d402104, 0x30407},
++	{0x3d402108, 0x203060b},
++	{0x3d40210c, 0x505000},
++	{0x3d402110, 0x2040202},
++	{0x3d402114, 0x2030202},
++	{0x3d402118, 0x1010004},
++	{0x3d40211c, 0x301},
++	{0x3d402130, 0x20300},
++	{0x3d402134, 0xa100002},
++	{0x3d402138, 0x1d},
++	{0x3d402144, 0x14000a},
++	{0x3d402180, 0x640004},
++	{0x3d402190, 0x3818200},
++	{0x3d402194, 0x80303},
++	{0x3d4021b4, 0x100},
++	{0x3d4020f4, 0xc99},
++	{0x3d403020, 0x11},
++	{0x3d403024, 0x1f40},
++	{0x3d403050, 0x20d040},
++	{0x3d403064, 0x30007},
++	{0x3d4030dc, 0x840000},
++	{0x3d4030e0, 0x310000},
++	{0x3d4030e8, 0x66004d},
++	{0x3d4030ec, 0x16004d},
++	{0x3d403100, 0xa010102},
++	{0x3d403104, 0x30404},
++	{0x3d403108, 0x203060b},
++	{0x3d40310c, 0x505000},
++	{0x3d403110, 0x2040202},
++	{0x3d403114, 0x2030202},
++	{0x3d403118, 0x1010004},
++	{0x3d40311c, 0x301},
++	{0x3d403130, 0x20300},
++	{0x3d403134, 0xa100002},
++	{0x3d403138, 0x8},
++	{0x3d403144, 0x50003},
++	{0x3d403180, 0x190004},
++	{0x3d403190, 0x3818200},
++	{0x3d403194, 0x80303},
++	{0x3d4031b4, 0x100},
++	{0x3d4030f4, 0xc99},
++	{0x3d400028, 0x0},
++};
++
++/* PHY Initialize Configuration */
++static struct dram_cfg_param ddr_ddrphy_cfg[] = {
++	{0x100a0, 0x0},
++	{0x100a1, 0x1},
++	{0x100a2, 0x2},
++	{0x100a3, 0x3},
++	{0x100a4, 0x4},
++	{0x100a5, 0x5},
++	{0x100a6, 0x6},
++	{0x100a7, 0x7},
++	{0x110a0, 0x0},
++	{0x110a1, 0x1},
++	{0x110a2, 0x3},
++	{0x110a3, 0x4},
++	{0x110a4, 0x5},
++	{0x110a5, 0x2},
++	{0x110a6, 0x7},
++	{0x110a7, 0x6},
++	{0x1005f, 0x1ff},
++	{0x1015f, 0x1ff},
++	{0x1105f, 0x1ff},
++	{0x1115f, 0x1ff},
++	{0x11005f, 0x1ff},
++	{0x11015f, 0x1ff},
++	{0x11105f, 0x1ff},
++	{0x11115f, 0x1ff},
++	{0x21005f, 0x1ff},
++	{0x21015f, 0x1ff},
++	{0x21105f, 0x1ff},
++	{0x21115f, 0x1ff},
++	{0x55, 0x1ff},
++	{0x1055, 0x1ff},
++	{0x2055, 0x1ff},
++	{0x3055, 0x1ff},
++	{0x4055, 0x1ff},
++	{0x5055, 0x1ff},
++	{0x6055, 0x1ff},
++	{0x7055, 0x1ff},
++	{0x8055, 0x1ff},
++	{0x9055, 0x1ff},
++	{0x200c5, 0x19},
++	{0x1200c5, 0x7},
++	{0x2200c5, 0x7},
++	{0x2002e, 0x2},
++	{0x12002e, 0x2},
++	{0x22002e, 0x2},
++	{0x90204, 0x0},
++	{0x190204, 0x0},
++	{0x290204, 0x0},
++	{0x20024, 0x1a3},
++	{0x2003a, 0x2},
++	{0x120024, 0x1a3},
++	{0x2003a, 0x2},
++	{0x220024, 0x1a3},
++	{0x2003a, 0x2},
++	{0x20056, 0x3},
++	{0x120056, 0x3},
++	{0x220056, 0x3},
++	{0x1004d, 0xe00},
++	{0x1014d, 0xe00},
++	{0x1104d, 0xe00},
++	{0x1114d, 0xe00},
++	{0x11004d, 0xe00},
++	{0x11014d, 0xe00},
++	{0x11104d, 0xe00},
++	{0x11114d, 0xe00},
++	{0x21004d, 0xe00},
++	{0x21014d, 0xe00},
++	{0x21104d, 0xe00},
++	{0x21114d, 0xe00},
++	{0x10049, 0xeba},
++	{0x10149, 0xeba},
++	{0x11049, 0xeba},
++	{0x11149, 0xeba},
++	{0x110049, 0xeba},
++	{0x110149, 0xeba},
++	{0x111049, 0xeba},
++	{0x111149, 0xeba},
++	{0x210049, 0xeba},
++	{0x210149, 0xeba},
++	{0x211049, 0xeba},
++	{0x211149, 0xeba},
++	{0x43, 0x63},
++	{0x1043, 0x63},
++	{0x2043, 0x63},
++	{0x3043, 0x63},
++	{0x4043, 0x63},
++	{0x5043, 0x63},
++	{0x6043, 0x63},
++	{0x7043, 0x63},
++	{0x8043, 0x63},
++	{0x9043, 0x63},
++	{0x20018, 0x1},
++	{0x20075, 0x4},
++	{0x20050, 0x0},
++	{0x20008, 0x320},
++	{0x120008, 0x64},
++	{0x220008, 0x19},
++	{0x20088, 0x9},
++	{0x200b2, 0xdc},
++	{0x10043, 0x5a1},
++	{0x10143, 0x5a1},
++	{0x11043, 0x5a1},
++	{0x11143, 0x5a1},
++	{0x1200b2, 0xdc},
++	{0x110043, 0x5a1},
++	{0x110143, 0x5a1},
++	{0x111043, 0x5a1},
++	{0x111143, 0x5a1},
++	{0x2200b2, 0xdc},
++	{0x210043, 0x5a1},
++	{0x210143, 0x5a1},
++	{0x211043, 0x5a1},
++	{0x211143, 0x5a1},
++	{0x200fa, 0x1},
++	{0x1200fa, 0x1},
++	{0x2200fa, 0x1},
++	{0x20019, 0x1},
++	{0x120019, 0x1},
++	{0x220019, 0x1},
++	{0x200f0, 0x660},
++	{0x200f1, 0x0},
++	{0x200f2, 0x4444},
++	{0x200f3, 0x8888},
++	{0x200f4, 0x5665},
++	{0x200f5, 0x0},
++	{0x200f6, 0x0},
++	{0x200f7, 0xf000},
++	{0x20025, 0x0},
++	{0x2002d, 0x0},
++	{0x12002d, 0x0},
++	{0x22002d, 0x0},
++	{0x2005b, 0x7529},
++	{0x2005c, 0x0},
++	{0x200c7, 0x21},
++	{0x200ca, 0x24},
++	{0x200cc, 0x1f7},
++	{0x1200c7, 0x21},
++	{0x1200ca, 0x24},
++	{0x1200cc, 0x1f7},
++	{0x2200c7, 0x21},
++	{0x2200ca, 0x24},
++	{0x2200cc, 0x1f7},
++	{0x2007d, 0x212},
++	{0x12007d, 0x212},
++	{0x22007d, 0x212},
++	{0x2007c, 0x61},
++	{0x12007c, 0x61},
++	{0x22007c, 0x61},
++	{0x1004a, 0x500},
++	{0x1104a, 0x500},
++	{0x2002c, 0x0},
++};
++
++/* ddr phy trained csr */
++static struct dram_cfg_param ddr_ddrphy_trained_csr[] = {
++	{0x0200b2, 0x0},
++	{0x1200b2, 0x0},
++	{0x2200b2, 0x0},
++	{0x0200cb, 0x0},
++	{0x010043, 0x0},
++	{0x110043, 0x0},
++	{0x210043, 0x0},
++	{0x010143, 0x0},
++	{0x110143, 0x0},
++	{0x210143, 0x0},
++	{0x011043, 0x0},
++	{0x111043, 0x0},
++	{0x211043, 0x0},
++	{0x011143, 0x0},
++	{0x111143, 0x0},
++	{0x211143, 0x0},
++	{0x000080, 0x0},
++	{0x100080, 0x0},
++	{0x200080, 0x0},
++	{0x001080, 0x0},
++	{0x101080, 0x0},
++	{0x201080, 0x0},
++	{0x002080, 0x0},
++	{0x102080, 0x0},
++	{0x202080, 0x0},
++	{0x003080, 0x0},
++	{0x103080, 0x0},
++	{0x203080, 0x0},
++	{0x004080, 0x0},
++	{0x104080, 0x0},
++	{0x204080, 0x0},
++	{0x005080, 0x0},
++	{0x105080, 0x0},
++	{0x205080, 0x0},
++	{0x006080, 0x0},
++	{0x106080, 0x0},
++	{0x206080, 0x0},
++	{0x007080, 0x0},
++	{0x107080, 0x0},
++	{0x207080, 0x0},
++	{0x008080, 0x0},
++	{0x108080, 0x0},
++	{0x208080, 0x0},
++	{0x009080, 0x0},
++	{0x109080, 0x0},
++	{0x209080, 0x0},
++	{0x010080, 0x0},
++	{0x110080, 0x0},
++	{0x210080, 0x0},
++	{0x010180, 0x0},
++	{0x110180, 0x0},
++	{0x210180, 0x0},
++	{0x011080, 0x0},
++	{0x111080, 0x0},
++	{0x211080, 0x0},
++	{0x011180, 0x0},
++	{0x111180, 0x0},
++	{0x211180, 0x0},
++	{0x010081, 0x0},
++	{0x110081, 0x0},
++	{0x210081, 0x0},
++	{0x010181, 0x0},
++	{0x110181, 0x0},
++	{0x210181, 0x0},
++	{0x011081, 0x0},
++	{0x111081, 0x0},
++	{0x211081, 0x0},
++	{0x011181, 0x0},
++	{0x111181, 0x0},
++	{0x211181, 0x0},
++	{0x0100d0, 0x0},
++	{0x1100d0, 0x0},
++	{0x2100d0, 0x0},
++	{0x0101d0, 0x0},
++	{0x1101d0, 0x0},
++	{0x2101d0, 0x0},
++	{0x0110d0, 0x0},
++	{0x1110d0, 0x0},
++	{0x2110d0, 0x0},
++	{0x0111d0, 0x0},
++	{0x1111d0, 0x0},
++	{0x2111d0, 0x0},
++	{0x0100d1, 0x0},
++	{0x1100d1, 0x0},
++	{0x2100d1, 0x0},
++	{0x0101d1, 0x0},
++	{0x1101d1, 0x0},
++	{0x2101d1, 0x0},
++	{0x0110d1, 0x0},
++	{0x1110d1, 0x0},
++	{0x2110d1, 0x0},
++	{0x0111d1, 0x0},
++	{0x1111d1, 0x0},
++	{0x2111d1, 0x0},
++	{0x010068, 0x0},
++	{0x010168, 0x0},
++	{0x010268, 0x0},
++	{0x010368, 0x0},
++	{0x010468, 0x0},
++	{0x010568, 0x0},
++	{0x010668, 0x0},
++	{0x010768, 0x0},
++	{0x010868, 0x0},
++	{0x011068, 0x0},
++	{0x011168, 0x0},
++	{0x011268, 0x0},
++	{0x011368, 0x0},
++	{0x011468, 0x0},
++	{0x011568, 0x0},
++	{0x011668, 0x0},
++	{0x011768, 0x0},
++	{0x011868, 0x0},
++	{0x010069, 0x0},
++	{0x010169, 0x0},
++	{0x010269, 0x0},
++	{0x010369, 0x0},
++	{0x010469, 0x0},
++	{0x010569, 0x0},
++	{0x010669, 0x0},
++	{0x010769, 0x0},
++	{0x010869, 0x0},
++	{0x011069, 0x0},
++	{0x011169, 0x0},
++	{0x011269, 0x0},
++	{0x011369, 0x0},
++	{0x011469, 0x0},
++	{0x011569, 0x0},
++	{0x011669, 0x0},
++	{0x011769, 0x0},
++	{0x011869, 0x0},
++	{0x01008c, 0x0},
++	{0x11008c, 0x0},
++	{0x21008c, 0x0},
++	{0x01018c, 0x0},
++	{0x11018c, 0x0},
++	{0x21018c, 0x0},
++	{0x01108c, 0x0},
++	{0x11108c, 0x0},
++	{0x21108c, 0x0},
++	{0x01118c, 0x0},
++	{0x11118c, 0x0},
++	{0x21118c, 0x0},
++	{0x01008d, 0x0},
++	{0x11008d, 0x0},
++	{0x21008d, 0x0},
++	{0x01018d, 0x0},
++	{0x11018d, 0x0},
++	{0x21018d, 0x0},
++	{0x01108d, 0x0},
++	{0x11108d, 0x0},
++	{0x21108d, 0x0},
++	{0x01118d, 0x0},
++	{0x11118d, 0x0},
++	{0x21118d, 0x0},
++	{0x0100c0, 0x0},
++	{0x1100c0, 0x0},
++	{0x2100c0, 0x0},
++	{0x0101c0, 0x0},
++	{0x1101c0, 0x0},
++	{0x2101c0, 0x0},
++	{0x0102c0, 0x0},
++	{0x1102c0, 0x0},
++	{0x2102c0, 0x0},
++	{0x0103c0, 0x0},
++	{0x1103c0, 0x0},
++	{0x2103c0, 0x0},
++	{0x0104c0, 0x0},
++	{0x1104c0, 0x0},
++	{0x2104c0, 0x0},
++	{0x0105c0, 0x0},
++	{0x1105c0, 0x0},
++	{0x2105c0, 0x0},
++	{0x0106c0, 0x0},
++	{0x1106c0, 0x0},
++	{0x2106c0, 0x0},
++	{0x0107c0, 0x0},
++	{0x1107c0, 0x0},
++	{0x2107c0, 0x0},
++	{0x0108c0, 0x0},
++	{0x1108c0, 0x0},
++	{0x2108c0, 0x0},
++	{0x0110c0, 0x0},
++	{0x1110c0, 0x0},
++	{0x2110c0, 0x0},
++	{0x0111c0, 0x0},
++	{0x1111c0, 0x0},
++	{0x2111c0, 0x0},
++	{0x0112c0, 0x0},
++	{0x1112c0, 0x0},
++	{0x2112c0, 0x0},
++	{0x0113c0, 0x0},
++	{0x1113c0, 0x0},
++	{0x2113c0, 0x0},
++	{0x0114c0, 0x0},
++	{0x1114c0, 0x0},
++	{0x2114c0, 0x0},
++	{0x0115c0, 0x0},
++	{0x1115c0, 0x0},
++	{0x2115c0, 0x0},
++	{0x0116c0, 0x0},
++	{0x1116c0, 0x0},
++	{0x2116c0, 0x0},
++	{0x0117c0, 0x0},
++	{0x1117c0, 0x0},
++	{0x2117c0, 0x0},
++	{0x0118c0, 0x0},
++	{0x1118c0, 0x0},
++	{0x2118c0, 0x0},
++	{0x0100c1, 0x0},
++	{0x1100c1, 0x0},
++	{0x2100c1, 0x0},
++	{0x0101c1, 0x0},
++	{0x1101c1, 0x0},
++	{0x2101c1, 0x0},
++	{0x0102c1, 0x0},
++	{0x1102c1, 0x0},
++	{0x2102c1, 0x0},
++	{0x0103c1, 0x0},
++	{0x1103c1, 0x0},
++	{0x2103c1, 0x0},
++	{0x0104c1, 0x0},
++	{0x1104c1, 0x0},
++	{0x2104c1, 0x0},
++	{0x0105c1, 0x0},
++	{0x1105c1, 0x0},
++	{0x2105c1, 0x0},
++	{0x0106c1, 0x0},
++	{0x1106c1, 0x0},
++	{0x2106c1, 0x0},
++	{0x0107c1, 0x0},
++	{0x1107c1, 0x0},
++	{0x2107c1, 0x0},
++	{0x0108c1, 0x0},
++	{0x1108c1, 0x0},
++	{0x2108c1, 0x0},
++	{0x0110c1, 0x0},
++	{0x1110c1, 0x0},
++	{0x2110c1, 0x0},
++	{0x0111c1, 0x0},
++	{0x1111c1, 0x0},
++	{0x2111c1, 0x0},
++	{0x0112c1, 0x0},
++	{0x1112c1, 0x0},
++	{0x2112c1, 0x0},
++	{0x0113c1, 0x0},
++	{0x1113c1, 0x0},
++	{0x2113c1, 0x0},
++	{0x0114c1, 0x0},
++	{0x1114c1, 0x0},
++	{0x2114c1, 0x0},
++	{0x0115c1, 0x0},
++	{0x1115c1, 0x0},
++	{0x2115c1, 0x0},
++	{0x0116c1, 0x0},
++	{0x1116c1, 0x0},
++	{0x2116c1, 0x0},
++	{0x0117c1, 0x0},
++	{0x1117c1, 0x0},
++	{0x2117c1, 0x0},
++	{0x0118c1, 0x0},
++	{0x1118c1, 0x0},
++	{0x2118c1, 0x0},
++	{0x010020, 0x0},
++	{0x110020, 0x0},
++	{0x210020, 0x0},
++	{0x011020, 0x0},
++	{0x111020, 0x0},
++	{0x211020, 0x0},
++	{0x020072, 0x0},
++	{0x020073, 0x0},
++	{0x020074, 0x0},
++	{0x0100aa, 0x0},
++	{0x0110aa, 0x0},
++	{0x020010, 0x0},
++	{0x120010, 0x0},
++	{0x220010, 0x0},
++	{0x020011, 0x0},
++	{0x120011, 0x0},
++	{0x220011, 0x0},
++	{0x0100ae, 0x0},
++	{0x1100ae, 0x0},
++	{0x2100ae, 0x0},
++	{0x0100af, 0x0},
++	{0x1100af, 0x0},
++	{0x2100af, 0x0},
++	{0x0110ae, 0x0},
++	{0x1110ae, 0x0},
++	{0x2110ae, 0x0},
++	{0x0110af, 0x0},
++	{0x1110af, 0x0},
++	{0x2110af, 0x0},
++	{0x020020, 0x0},
++	{0x120020, 0x0},
++	{0x220020, 0x0},
++	{0x0100a0, 0x0},
++	{0x0100a1, 0x0},
++	{0x0100a2, 0x0},
++	{0x0100a3, 0x0},
++	{0x0100a4, 0x0},
++	{0x0100a5, 0x0},
++	{0x0100a6, 0x0},
++	{0x0100a7, 0x0},
++	{0x0110a0, 0x0},
++	{0x0110a1, 0x0},
++	{0x0110a2, 0x0},
++	{0x0110a3, 0x0},
++	{0x0110a4, 0x0},
++	{0x0110a5, 0x0},
++	{0x0110a6, 0x0},
++	{0x0110a7, 0x0},
++	{0x02007c, 0x0},
++	{0x12007c, 0x0},
++	{0x22007c, 0x0},
++	{0x02007d, 0x0},
++	{0x12007d, 0x0},
++	{0x22007d, 0x0},
++	{0x0400fd, 0x0},
++	{0x0400c0, 0x0},
++	{0x090201, 0x0},
++	{0x190201, 0x0},
++	{0x290201, 0x0},
++	{0x090202, 0x0},
++	{0x190202, 0x0},
++	{0x290202, 0x0},
++	{0x090203, 0x0},
++	{0x190203, 0x0},
++	{0x290203, 0x0},
++	{0x090204, 0x0},
++	{0x190204, 0x0},
++	{0x290204, 0x0},
++	{0x090205, 0x0},
++	{0x190205, 0x0},
++	{0x290205, 0x0},
++	{0x090206, 0x0},
++	{0x190206, 0x0},
++	{0x290206, 0x0},
++	{0x090207, 0x0},
++	{0x190207, 0x0},
++	{0x290207, 0x0},
++	{0x090208, 0x0},
++	{0x190208, 0x0},
++	{0x290208, 0x0},
++	{0x010062, 0x0},
++	{0x010162, 0x0},
++	{0x010262, 0x0},
++	{0x010362, 0x0},
++	{0x010462, 0x0},
++	{0x010562, 0x0},
++	{0x010662, 0x0},
++	{0x010762, 0x0},
++	{0x010862, 0x0},
++	{0x011062, 0x0},
++	{0x011162, 0x0},
++	{0x011262, 0x0},
++	{0x011362, 0x0},
++	{0x011462, 0x0},
++	{0x011562, 0x0},
++	{0x011662, 0x0},
++	{0x011762, 0x0},
++	{0x011862, 0x0},
++	{0x020077, 0x0},
++	{0x010001, 0x0},
++	{0x011001, 0x0},
++	{0x010040, 0x0},
++	{0x010140, 0x0},
++	{0x010240, 0x0},
++	{0x010340, 0x0},
++	{0x010440, 0x0},
++	{0x010540, 0x0},
++	{0x010640, 0x0},
++	{0x010740, 0x0},
++	{0x010840, 0x0},
++	{0x010030, 0x0},
++	{0x010130, 0x0},
++	{0x010230, 0x0},
++	{0x010330, 0x0},
++	{0x010430, 0x0},
++	{0x010530, 0x0},
++	{0x010630, 0x0},
++	{0x010730, 0x0},
++	{0x010830, 0x0},
++	{0x011040, 0x0},
++	{0x011140, 0x0},
++	{0x011240, 0x0},
++	{0x011340, 0x0},
++	{0x011440, 0x0},
++	{0x011540, 0x0},
++	{0x011640, 0x0},
++	{0x011740, 0x0},
++	{0x011840, 0x0},
++	{0x011030, 0x0},
++	{0x011130, 0x0},
++	{0x011230, 0x0},
++	{0x011330, 0x0},
++	{0x011430, 0x0},
++	{0x011530, 0x0},
++	{0x011630, 0x0},
++	{0x011730, 0x0},
++	{0x011830, 0x0},
++};
++
++/* P0 message block paremeter for training firmware */
++static struct dram_cfg_param ddr_fsp0_cfg[] = {
++	{0xd0000, 0x0},
++	{0x54003, 0xc80},
++	{0x54004, 0x2},
++	{0x54005, 0x2228},
++	{0x54006, 0x11},
++	{0x54008, 0x131f},
++	{0x54009, 0xc8},
++	{0x5400b, 0x2},
++	{0x5400f, 0x100},
++	{0x54012, 0x110},
++	{0x54019, 0x2dd4},
++	{0x5401a, 0x31},
++	{0x5401b, 0x4d66},
++	{0x5401c, 0x4d00},
++	{0x5401e, 0x16},
++	{0x5401f, 0x2dd4},
++	{0x54020, 0x31},
++	{0x54021, 0x4d66},
++	{0x54022, 0x4d00},
++	{0x54024, 0x16},
++	{0x54032, 0xd400},
++	{0x54033, 0x312d},
++	{0x54034, 0x6600},
++	{0x54035, 0x4d},
++	{0x54036, 0x4d},
++	{0x54037, 0x1600},
++	{0x54038, 0xd400},
++	{0x54039, 0x312d},
++	{0x5403a, 0x6600},
++	{0x5403b, 0x4d},
++	{0x5403c, 0x4d},
++	{0x5403d, 0x1600},
++	{0xd0000, 0x1},
++};
++
++/* P1 message block paremeter for training firmware */
++static struct dram_cfg_param ddr_fsp1_cfg[] = {
++	{0xd0000, 0x0},
++	{0x54002, 0x101},
++	{0x54003, 0x190},
++	{0x54004, 0x2},
++	{0x54005, 0x2228},
++	{0x54006, 0x11},
++	{0x54008, 0x121f},
++	{0x54009, 0xc8},
++	{0x5400b, 0x2},
++	{0x5400f, 0x100},
++	{0x54012, 0x110},
++	{0x54019, 0x84},
++	{0x5401a, 0x31},
++	{0x5401b, 0x4d66},
++	{0x5401c, 0x4d00},
++	{0x5401e, 0x16},
++	{0x5401f, 0x84},
++	{0x54020, 0x31},
++	{0x54021, 0x4d66},
++	{0x54022, 0x4d00},
++	{0x54024, 0x16},
++	{0x54032, 0x8400},
++	{0x54033, 0x3100},
++	{0x54034, 0x6600},
++	{0x54035, 0x4d},
++	{0x54036, 0x4d},
++	{0x54037, 0x1600},
++	{0x54038, 0x8400},
++	{0x54039, 0x3100},
++	{0x5403a, 0x6600},
++	{0x5403b, 0x4d},
++	{0x5403c, 0x4d},
++	{0x5403d, 0x1600},
++	{0xd0000, 0x1},
++};
++
++/* P2 message block paremeter for training firmware */
++static struct dram_cfg_param ddr_fsp2_cfg[] = {
++	{0xd0000, 0x0},
++	{0x54002, 0x102},
++	{0x54003, 0x64},
++	{0x54004, 0x2},
++	{0x54005, 0x2228},
++	{0x54006, 0x11},
++	{0x54008, 0x121f},
++	{0x54009, 0xc8},
++	{0x5400b, 0x2},
++	{0x5400f, 0x100},
++	{0x54012, 0x110},
++	{0x54019, 0x84},
++	{0x5401a, 0x31},
++	{0x5401b, 0x4d66},
++	{0x5401c, 0x4d00},
++	{0x5401e, 0x16},
++	{0x5401f, 0x84},
++	{0x54020, 0x31},
++	{0x54021, 0x4d66},
++	{0x54022, 0x4d00},
++	{0x54024, 0x16},
++	{0x54032, 0x8400},
++	{0x54033, 0x3100},
++	{0x54034, 0x6600},
++	{0x54035, 0x4d},
++	{0x54036, 0x4d},
++	{0x54037, 0x1600},
++	{0x54038, 0x8400},
++	{0x54039, 0x3100},
++	{0x5403a, 0x6600},
++	{0x5403b, 0x4d},
++	{0x5403c, 0x4d},
++	{0x5403d, 0x1600},
++	{0xd0000, 0x1},
++};
++
++/* P0 2D message block paremeter for training firmware */
++static struct dram_cfg_param ddr_fsp0_2d_cfg[] = {
++	{0xd0000, 0x0},
++	{0x54003, 0xc80},
++	{0x54004, 0x2},
++	{0x54005, 0x2228},
++	{0x54006, 0x11},
++	{0x54008, 0x61},
++	{0x54009, 0xc8},
++	{0x5400b, 0x2},
++	{0x5400d, 0x100},
++	{0x5400f, 0x100},
++	{0x54010, 0x1f7f},
++	{0x54012, 0x110},
++	{0x54019, 0x2dd4},
++	{0x5401a, 0x31},
++	{0x5401b, 0x4d66},
++	{0x5401c, 0x4d00},
++	{0x5401e, 0x16},
++	{0x5401f, 0x2dd4},
++	{0x54020, 0x31},
++	{0x54021, 0x4d66},
++	{0x54022, 0x4d00},
++	{0x54024, 0x16},
++	{0x54032, 0xd400},
++	{0x54033, 0x312d},
++	{0x54034, 0x6600},
++	{0x54035, 0x4d},
++	{0x54036, 0x4d},
++	{0x54037, 0x1600},
++	{0x54038, 0xd400},
++	{0x54039, 0x312d},
++	{0x5403a, 0x6600},
++	{0x5403b, 0x4d},
++	{0x5403c, 0x4d},
++	{0x5403d, 0x1600},
++	{0xd0000, 0x1},
++};
++
++/* DRAM PHY init engine image */
++static struct dram_cfg_param ddr_phy_pie[] = {
++	{0xd0000, 0x0},
++	{0x90000, 0x10},
++	{0x90001, 0x400},
++	{0x90002, 0x10e},
++	{0x90003, 0x0},
++	{0x90004, 0x0},
++	{0x90005, 0x8},
++	{0x90029, 0xb},
++	{0x9002a, 0x480},
++	{0x9002b, 0x109},
++	{0x9002c, 0x8},
++	{0x9002d, 0x448},
++	{0x9002e, 0x139},
++	{0x9002f, 0x8},
++	{0x90030, 0x478},
++	{0x90031, 0x109},
++	{0x90032, 0x0},
++	{0x90033, 0xe8},
++	{0x90034, 0x109},
++	{0x90035, 0x2},
++	{0x90036, 0x10},
++	{0x90037, 0x139},
++	{0x90038, 0xb},
++	{0x90039, 0x7c0},
++	{0x9003a, 0x139},
++	{0x9003b, 0x44},
++	{0x9003c, 0x633},
++	{0x9003d, 0x159},
++	{0x9003e, 0x14f},
++	{0x9003f, 0x630},
++	{0x90040, 0x159},
++	{0x90041, 0x47},
++	{0x90042, 0x633},
++	{0x90043, 0x149},
++	{0x90044, 0x4f},
++	{0x90045, 0x633},
++	{0x90046, 0x179},
++	{0x90047, 0x8},
++	{0x90048, 0xe0},
++	{0x90049, 0x109},
++	{0x9004a, 0x0},
++	{0x9004b, 0x7c8},
++	{0x9004c, 0x109},
++	{0x9004d, 0x0},
++	{0x9004e, 0x1},
++	{0x9004f, 0x8},
++	{0x90050, 0x0},
++	{0x90051, 0x45a},
++	{0x90052, 0x9},
++	{0x90053, 0x0},
++	{0x90054, 0x448},
++	{0x90055, 0x109},
++	{0x90056, 0x40},
++	{0x90057, 0x633},
++	{0x90058, 0x179},
++	{0x90059, 0x1},
++	{0x9005a, 0x618},
++	{0x9005b, 0x109},
++	{0x9005c, 0x40c0},
++	{0x9005d, 0x633},
++	{0x9005e, 0x149},
++	{0x9005f, 0x8},
++	{0x90060, 0x4},
++	{0x90061, 0x48},
++	{0x90062, 0x4040},
++	{0x90063, 0x633},
++	{0x90064, 0x149},
++	{0x90065, 0x0},
++	{0x90066, 0x4},
++	{0x90067, 0x48},
++	{0x90068, 0x40},
++	{0x90069, 0x633},
++	{0x9006a, 0x149},
++	{0x9006b, 0x10},
++	{0x9006c, 0x4},
++	{0x9006d, 0x18},
++	{0x9006e, 0x0},
++	{0x9006f, 0x4},
++	{0x90070, 0x78},
++	{0x90071, 0x549},
++	{0x90072, 0x633},
++	{0x90073, 0x159},
++	{0x90074, 0xd49},
++	{0x90075, 0x633},
++	{0x90076, 0x159},
++	{0x90077, 0x94a},
++	{0x90078, 0x633},
++	{0x90079, 0x159},
++	{0x9007a, 0x441},
++	{0x9007b, 0x633},
++	{0x9007c, 0x149},
++	{0x9007d, 0x42},
++	{0x9007e, 0x633},
++	{0x9007f, 0x149},
++	{0x90080, 0x1},
++	{0x90081, 0x633},
++	{0x90082, 0x149},
++	{0x90083, 0x0},
++	{0x90084, 0xe0},
++	{0x90085, 0x109},
++	{0x90086, 0xa},
++	{0x90087, 0x10},
++	{0x90088, 0x109},
++	{0x90089, 0x9},
++	{0x9008a, 0x3c0},
++	{0x9008b, 0x149},
++	{0x9008c, 0x9},
++	{0x9008d, 0x3c0},
++	{0x9008e, 0x159},
++	{0x9008f, 0x18},
++	{0x90090, 0x10},
++	{0x90091, 0x109},
++	{0x90092, 0x0},
++	{0x90093, 0x3c0},
++	{0x90094, 0x109},
++	{0x90095, 0x18},
++	{0x90096, 0x4},
++	{0x90097, 0x48},
++	{0x90098, 0x18},
++	{0x90099, 0x4},
++	{0x9009a, 0x58},
++	{0x9009b, 0xb},
++	{0x9009c, 0x10},
++	{0x9009d, 0x109},
++	{0x9009e, 0x1},
++	{0x9009f, 0x10},
++	{0x900a0, 0x109},
++	{0x900a1, 0x5},
++	{0x900a2, 0x7c0},
++	{0x900a3, 0x109},
++	{0x40000, 0x811},
++	{0x40020, 0x880},
++	{0x40040, 0x0},
++	{0x40060, 0x0},
++	{0x40001, 0x4008},
++	{0x40021, 0x83},
++	{0x40041, 0x4f},
++	{0x40061, 0x0},
++	{0x40002, 0x4040},
++	{0x40022, 0x83},
++	{0x40042, 0x51},
++	{0x40062, 0x0},
++	{0x40003, 0x811},
++	{0x40023, 0x880},
++	{0x40043, 0x0},
++	{0x40063, 0x0},
++	{0x40004, 0x720},
++	{0x40024, 0xf},
++	{0x40044, 0x1740},
++	{0x40064, 0x0},
++	{0x40005, 0x16},
++	{0x40025, 0x83},
++	{0x40045, 0x4b},
++	{0x40065, 0x0},
++	{0x40006, 0x716},
++	{0x40026, 0xf},
++	{0x40046, 0x2001},
++	{0x40066, 0x0},
++	{0x40007, 0x716},
++	{0x40027, 0xf},
++	{0x40047, 0x2800},
++	{0x40067, 0x0},
++	{0x40008, 0x716},
++	{0x40028, 0xf},
++	{0x40048, 0xf00},
++	{0x40068, 0x0},
++	{0x40009, 0x720},
++	{0x40029, 0xf},
++	{0x40049, 0x1400},
++	{0x40069, 0x0},
++	{0x4000a, 0xe08},
++	{0x4002a, 0xc15},
++	{0x4004a, 0x0},
++	{0x4006a, 0x0},
++	{0x4000b, 0x625},
++	{0x4002b, 0x15},
++	{0x4004b, 0x0},
++	{0x4006b, 0x0},
++	{0x4000c, 0x4028},
++	{0x4002c, 0x80},
++	{0x4004c, 0x0},
++	{0x4006c, 0x0},
++	{0x4000d, 0xe08},
++	{0x4002d, 0xc1a},
++	{0x4004d, 0x0},
++	{0x4006d, 0x0},
++	{0x4000e, 0x625},
++	{0x4002e, 0x1a},
++	{0x4004e, 0x0},
++	{0x4006e, 0x0},
++	{0x4000f, 0x4040},
++	{0x4002f, 0x80},
++	{0x4004f, 0x0},
++	{0x4006f, 0x0},
++	{0x40010, 0x2604},
++	{0x40030, 0x15},
++	{0x40050, 0x0},
++	{0x40070, 0x0},
++	{0x40011, 0x708},
++	{0x40031, 0x5},
++	{0x40051, 0x0},
++	{0x40071, 0x2002},
++	{0x40012, 0x8},
++	{0x40032, 0x80},
++	{0x40052, 0x0},
++	{0x40072, 0x0},
++	{0x40013, 0x2604},
++	{0x40033, 0x1a},
++	{0x40053, 0x0},
++	{0x40073, 0x0},
++	{0x40014, 0x708},
++	{0x40034, 0xa},
++	{0x40054, 0x0},
++	{0x40074, 0x2002},
++	{0x40015, 0x4040},
++	{0x40035, 0x80},
++	{0x40055, 0x0},
++	{0x40075, 0x0},
++	{0x40016, 0x60a},
++	{0x40036, 0x15},
++	{0x40056, 0x1200},
++	{0x40076, 0x0},
++	{0x40017, 0x61a},
++	{0x40037, 0x15},
++	{0x40057, 0x1300},
++	{0x40077, 0x0},
++	{0x40018, 0x60a},
++	{0x40038, 0x1a},
++	{0x40058, 0x1200},
++	{0x40078, 0x0},
++	{0x40019, 0x642},
++	{0x40039, 0x1a},
++	{0x40059, 0x1300},
++	{0x40079, 0x0},
++	{0x4001a, 0x4808},
++	{0x4003a, 0x880},
++	{0x4005a, 0x0},
++	{0x4007a, 0x0},
++	{0x900a4, 0x0},
++	{0x900a5, 0x790},
++	{0x900a6, 0x11a},
++	{0x900a7, 0x8},
++	{0x900a8, 0x7aa},
++	{0x900a9, 0x2a},
++	{0x900aa, 0x10},
++	{0x900ab, 0x7b2},
++	{0x900ac, 0x2a},
++	{0x900ad, 0x0},
++	{0x900ae, 0x7c8},
++	{0x900af, 0x109},
++	{0x900b0, 0x10},
++	{0x900b1, 0x10},
++	{0x900b2, 0x109},
++	{0x900b3, 0x10},
++	{0x900b4, 0x2a8},
++	{0x900b5, 0x129},
++	{0x900b6, 0x8},
++	{0x900b7, 0x370},
++	{0x900b8, 0x129},
++	{0x900b9, 0xa},
++	{0x900ba, 0x3c8},
++	{0x900bb, 0x1a9},
++	{0x900bc, 0xc},
++	{0x900bd, 0x408},
++	{0x900be, 0x199},
++	{0x900bf, 0x14},
++	{0x900c0, 0x790},
++	{0x900c1, 0x11a},
++	{0x900c2, 0x8},
++	{0x900c3, 0x4},
++	{0x900c4, 0x18},
++	{0x900c5, 0xe},
++	{0x900c6, 0x408},
++	{0x900c7, 0x199},
++	{0x900c8, 0x8},
++	{0x900c9, 0x8568},
++	{0x900ca, 0x108},
++	{0x900cb, 0x18},
++	{0x900cc, 0x790},
++	{0x900cd, 0x16a},
++	{0x900ce, 0x8},
++	{0x900cf, 0x1d8},
++	{0x900d0, 0x169},
++	{0x900d1, 0x10},
++	{0x900d2, 0x8558},
++	{0x900d3, 0x168},
++	{0x900d4, 0x70},
++	{0x900d5, 0x788},
++	{0x900d6, 0x16a},
++	{0x900d7, 0x1ff8},
++	{0x900d8, 0x85a8},
++	{0x900d9, 0x1e8},
++	{0x900da, 0x50},
++	{0x900db, 0x798},
++	{0x900dc, 0x16a},
++	{0x900dd, 0x60},
++	{0x900de, 0x7a0},
++	{0x900df, 0x16a},
++	{0x900e0, 0x8},
++	{0x900e1, 0x8310},
++	{0x900e2, 0x168},
++	{0x900e3, 0x8},
++	{0x900e4, 0xa310},
++	{0x900e5, 0x168},
++	{0x900e6, 0xa},
++	{0x900e7, 0x408},
++	{0x900e8, 0x169},
++	{0x900e9, 0x6e},
++	{0x900ea, 0x0},
++	{0x900eb, 0x68},
++	{0x900ec, 0x0},
++	{0x900ed, 0x408},
++	{0x900ee, 0x169},
++	{0x900ef, 0x0},
++	{0x900f0, 0x8310},
++	{0x900f1, 0x168},
++	{0x900f2, 0x0},
++	{0x900f3, 0xa310},
++	{0x900f4, 0x168},
++	{0x900f5, 0x1ff8},
++	{0x900f6, 0x85a8},
++	{0x900f7, 0x1e8},
++	{0x900f8, 0x68},
++	{0x900f9, 0x798},
++	{0x900fa, 0x16a},
++	{0x900fb, 0x78},
++	{0x900fc, 0x7a0},
++	{0x900fd, 0x16a},
++	{0x900fe, 0x68},
++	{0x900ff, 0x790},
++	{0x90100, 0x16a},
++	{0x90101, 0x8},
++	{0x90102, 0x8b10},
++	{0x90103, 0x168},
++	{0x90104, 0x8},
++	{0x90105, 0xab10},
++	{0x90106, 0x168},
++	{0x90107, 0xa},
++	{0x90108, 0x408},
++	{0x90109, 0x169},
++	{0x9010a, 0x58},
++	{0x9010b, 0x0},
++	{0x9010c, 0x68},
++	{0x9010d, 0x0},
++	{0x9010e, 0x408},
++	{0x9010f, 0x169},
++	{0x90110, 0x0},
++	{0x90111, 0x8b10},
++	{0x90112, 0x168},
++	{0x90113, 0x0},
++	{0x90114, 0xab10},
++	{0x90115, 0x168},
++	{0x90116, 0x0},
++	{0x90117, 0x1d8},
++	{0x90118, 0x169},
++	{0x90119, 0x80},
++	{0x9011a, 0x790},
++	{0x9011b, 0x16a},
++	{0x9011c, 0x18},
++	{0x9011d, 0x7aa},
++	{0x9011e, 0x6a},
++	{0x9011f, 0xa},
++	{0x90120, 0x0},
++	{0x90121, 0x1e9},
++	{0x90122, 0x8},
++	{0x90123, 0x8080},
++	{0x90124, 0x108},
++	{0x90125, 0xf},
++	{0x90126, 0x408},
++	{0x90127, 0x169},
++	{0x90128, 0xc},
++	{0x90129, 0x0},
++	{0x9012a, 0x68},
++	{0x9012b, 0x9},
++	{0x9012c, 0x0},
++	{0x9012d, 0x1a9},
++	{0x9012e, 0x0},
++	{0x9012f, 0x408},
++	{0x90130, 0x169},
++	{0x90131, 0x0},
++	{0x90132, 0x8080},
++	{0x90133, 0x108},
++	{0x90134, 0x8},
++	{0x90135, 0x7aa},
++	{0x90136, 0x6a},
++	{0x90137, 0x0},
++	{0x90138, 0x8568},
++	{0x90139, 0x108},
++	{0x9013a, 0xb7},
++	{0x9013b, 0x790},
++	{0x9013c, 0x16a},
++	{0x9013d, 0x1f},
++	{0x9013e, 0x0},
++	{0x9013f, 0x68},
++	{0x90140, 0x8},
++	{0x90141, 0x8558},
++	{0x90142, 0x168},
++	{0x90143, 0xf},
++	{0x90144, 0x408},
++	{0x90145, 0x169},
++	{0x90146, 0xd},
++	{0x90147, 0x0},
++	{0x90148, 0x68},
++	{0x90149, 0x0},
++	{0x9014a, 0x408},
++	{0x9014b, 0x169},
++	{0x9014c, 0x0},
++	{0x9014d, 0x8558},
++	{0x9014e, 0x168},
++	{0x9014f, 0x8},
++	{0x90150, 0x3c8},
++	{0x90151, 0x1a9},
++	{0x90152, 0x3},
++	{0x90153, 0x370},
++	{0x90154, 0x129},
++	{0x90155, 0x20},
++	{0x90156, 0x2aa},
++	{0x90157, 0x9},
++	{0x90158, 0x0},
++	{0x90159, 0x400},
++	{0x9015a, 0x10e},
++	{0x9015b, 0x8},
++	{0x9015c, 0xe8},
++	{0x9015d, 0x109},
++	{0x9015e, 0x0},
++	{0x9015f, 0x8140},
++	{0x90160, 0x10c},
++	{0x90161, 0x10},
++	{0x90162, 0x8138},
++	{0x90163, 0x10c},
++	{0x90164, 0x8},
++	{0x90165, 0x7c8},
++	{0x90166, 0x101},
++	{0x90167, 0x8},
++	{0x90168, 0x448},
++	{0x90169, 0x109},
++	{0x9016a, 0xf},
++	{0x9016b, 0x7c0},
++	{0x9016c, 0x109},
++	{0x9016d, 0x0},
++	{0x9016e, 0xe8},
++	{0x9016f, 0x109},
++	{0x90170, 0x47},
++	{0x90171, 0x630},
++	{0x90172, 0x109},
++	{0x90173, 0x8},
++	{0x90174, 0x618},
++	{0x90175, 0x109},
++	{0x90176, 0x8},
++	{0x90177, 0xe0},
++	{0x90178, 0x109},
++	{0x90179, 0x0},
++	{0x9017a, 0x7c8},
++	{0x9017b, 0x109},
++	{0x9017c, 0x8},
++	{0x9017d, 0x8140},
++	{0x9017e, 0x10c},
++	{0x9017f, 0x0},
++	{0x90180, 0x1},
++	{0x90181, 0x8},
++	{0x90182, 0x8},
++	{0x90183, 0x4},
++	{0x90184, 0x8},
++	{0x90185, 0x8},
++	{0x90186, 0x7c8},
++	{0x90187, 0x101},
++	{0x90006, 0x0},
++	{0x90007, 0x0},
++	{0x90008, 0x8},
++	{0x90009, 0x0},
++	{0x9000a, 0x0},
++	{0x9000b, 0x0},
++	{0xd00e7, 0x400},
++	{0x90017, 0x0},
++	{0x9001f, 0x29},
++	{0x90026, 0x6a},
++	{0x400d0, 0x0},
++	{0x400d1, 0x101},
++	{0x400d2, 0x105},
++	{0x400d3, 0x107},
++	{0x400d4, 0x10f},
++	{0x400d5, 0x202},
++	{0x400d6, 0x20a},
++	{0x400d7, 0x20b},
++	{0x2003a, 0x2},
++	{0x2000b, 0x64},
++	{0x2000c, 0xc8},
++	{0x2000d, 0x7d0},
++	{0x2000e, 0x2c},
++	{0x12000b, 0xc},
++	{0x12000c, 0x19},
++	{0x12000d, 0xfa},
++	{0x12000e, 0x10},
++	{0x22000b, 0x3},
++	{0x22000c, 0x6},
++	{0x22000d, 0x3e},
++	{0x22000e, 0x10},
++	{0x9000c, 0x0},
++	{0x9000d, 0x173},
++	{0x9000e, 0x60},
++	{0x9000f, 0x6110},
++	{0x90010, 0x2152},
++	{0x90011, 0xdfbd},
++	{0x90012, 0x2060},
++	{0x90013, 0x6152},
++	{0x20010, 0x5a},
++	{0x20011, 0x3},
++	{0x120010, 0x5a},
++	{0x120011, 0x3},
++	{0x220010, 0x5a},
++	{0x220011, 0x3},
++	{0x40080, 0xe0},
++	{0x40081, 0x12},
++	{0x40082, 0xe0},
++	{0x40083, 0x12},
++	{0x40084, 0xe0},
++	{0x40085, 0x12},
++	{0x140080, 0xe0},
++	{0x140081, 0x12},
++	{0x140082, 0xe0},
++	{0x140083, 0x12},
++	{0x140084, 0xe0},
++	{0x140085, 0x12},
++	{0x240080, 0xe0},
++	{0x240081, 0x12},
++	{0x240082, 0xe0},
++	{0x240083, 0x12},
++	{0x240084, 0xe0},
++	{0x240085, 0x12},
++	{0x400fd, 0xf},
++	{0x10011, 0x1},
++	{0x10012, 0x1},
++	{0x10013, 0x180},
++	{0x10018, 0x1},
++	{0x10002, 0x6209},
++	{0x100b2, 0x1},
++	{0x101b4, 0x1},
++	{0x102b4, 0x1},
++	{0x103b4, 0x1},
++	{0x104b4, 0x1},
++	{0x105b4, 0x1},
++	{0x106b4, 0x1},
++	{0x107b4, 0x1},
++	{0x108b4, 0x1},
++	{0x11011, 0x1},
++	{0x11012, 0x1},
++	{0x11013, 0x180},
++	{0x11018, 0x1},
++	{0x11002, 0x6209},
++	{0x110b2, 0x1},
++	{0x111b4, 0x1},
++	{0x112b4, 0x1},
++	{0x113b4, 0x1},
++	{0x114b4, 0x1},
++	{0x115b4, 0x1},
++	{0x116b4, 0x1},
++	{0x117b4, 0x1},
++	{0x118b4, 0x1},
++	{0x20089, 0x1},
++	{0x20088, 0x19},
++	{0xc0080, 0x2},
++	{0xd0000, 0x1}
++};
++
++static struct dram_fsp_msg ddr_dram_fsp_msg[] = {
++	{
++		/* P0 3200mts 1D */
++		.drate = 3200,
++		.fw_type = FW_1D_IMAGE,
++		.fsp_cfg = ddr_fsp0_cfg,
++		.fsp_cfg_num = ARRAY_SIZE(ddr_fsp0_cfg),
++	},
++	{
++		/* P1 400mts 1D */
++		.drate = 400,
++		.fw_type = FW_1D_IMAGE,
++		.fsp_cfg = ddr_fsp1_cfg,
++		.fsp_cfg_num = ARRAY_SIZE(ddr_fsp1_cfg),
++	},
++	{
++		/* P2 100mts 1D */
++		.drate = 100,
++		.fw_type = FW_1D_IMAGE,
++		.fsp_cfg = ddr_fsp2_cfg,
++		.fsp_cfg_num = ARRAY_SIZE(ddr_fsp2_cfg),
++	},
++	{
++		/* P0 3200mts 2D */
++		.drate = 3200,
++		.fw_type = FW_2D_IMAGE,
++		.fsp_cfg = ddr_fsp0_2d_cfg,
++		.fsp_cfg_num = ARRAY_SIZE(ddr_fsp0_2d_cfg),
++	},
++};
++
++/* ddr timing config params */
++struct dram_timing_info dram_timing = {
++	.ddrc_cfg = ddr_ddrc_cfg,
++	.ddrc_cfg_num = ARRAY_SIZE(ddr_ddrc_cfg),
++	.ddrphy_cfg = ddr_ddrphy_cfg,
++	.ddrphy_cfg_num = ARRAY_SIZE(ddr_ddrphy_cfg),
++	.fsp_msg = ddr_dram_fsp_msg,
++	.fsp_msg_num = ARRAY_SIZE(ddr_dram_fsp_msg),
++	.ddrphy_trained_csr = ddr_ddrphy_trained_csr,
++	.ddrphy_trained_csr_num = ARRAY_SIZE(ddr_ddrphy_trained_csr),
++	.ddrphy_pie = ddr_phy_pie,
++	.ddrphy_pie_num = ARRAY_SIZE(ddr_phy_pie),
++	.fsp_table = {3200, 400, 100,},
++};
+diff --git a/board/phytec/phycore_imx8mn/phycore-imx8mn.c b/board/phytec/phycore_imx8mn/phycore-imx8mn.c
+new file mode 100644
+index 00000000000..94f265d75e1
+--- /dev/null
++++ b/board/phytec/phycore_imx8mn/phycore-imx8mn.c
+@@ -0,0 +1,53 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++/*
++ * Copyright (C) 2020 PHYTEC Messtechnik GmbH
++ * Author: Teresa Remmet <t.remmet@phytec.de>
++ */
++
++#include <common.h>
++#include <asm/arch/sys_proto.h>
++#include <asm/io.h>
++#include <asm/mach-imx/boot_mode.h>
++#include <env.h>
++#include <miiphy.h>
++
++DECLARE_GLOBAL_DATA_PTR;
++
++static int setup_fec(void)
++{
++	struct iomuxc_gpr_base_regs *gpr =
++		(struct iomuxc_gpr_base_regs *)IOMUXC_GPR_BASE_ADDR;
++
++	/* Use 125M anatop REF_CLK1 for ENET1, not from external */
++	clrsetbits_le32(&gpr->gpr[1], 0x2000, 0);
++
++	return 0;
++}
++
++int board_init(void)
++{
++	setup_fec();
++
++	return 0;
++}
++
++int board_mmc_get_env_dev(int devno)
++{
++	return devno;
++}
++
++int board_late_init(void)
++{
++	switch (get_boot_device()) {
++	case SD2_BOOT:
++		env_set_ulong("mmcdev", 1);
++		break;
++	case MMC3_BOOT:
++		env_set_ulong("mmcdev", 2);
++		break;
++	default:
++		break;
++	}
++
++	return 0;
++}
+diff --git a/board/phytec/phycore_imx8mn/spl.c b/board/phytec/phycore_imx8mn/spl.c
+new file mode 100644
+index 00000000000..23beb5251ce
+--- /dev/null
++++ b/board/phytec/phycore_imx8mn/spl.c
+@@ -0,0 +1,143 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++/*
++ * Copyright (C) 2019-2020 PHYTEC Messtechnik GmbH
++ * Author: Teresa Remmet <t.remmet@phytec.de>
++ */
++
++#include <common.h>
++#include <asm/arch/clock.h>
++#include <asm/arch/ddr.h>
++#include <asm/arch/imx8mn_pins.h>
++#include <asm/arch/sys_proto.h>
++#include <asm/global_data.h>
++#include <asm/mach-imx/boot_mode.h>
++#include <asm/mach-imx/iomux-v3.h>
++#include <dm/device.h>
++#include <dm/uclass.h>
++#include <hang.h>
++#include <init.h>
++#include <i2c_eeprom.h>
++#include <i2c.h>
++#include <log.h>
++#include <spl.h>
++
++#include "../common/imx8m_som_detection.h"
++
++DECLARE_GLOBAL_DATA_PTR;
++
++#define EEPROM_ADDR		0x51
++#define EEPROM_ADDR_FALLBACK	0x59
++
++#define PMIC_PF8121A_I2C_BUS		0x0
++#define PMIC_PF8121A_I2C_ADDR		0x8
++#define PMIC_PF8121A_SW3_MODE_ADDR	0x60
++#define PMIC_PF8121A_SW3_OFF		0x0
++
++int spl_board_boot_device(enum boot_device boot_dev_spl)
++{
++	return BOOT_DEVICE_BOOTROM;
++}
++
++void spl_dram_init(void)
++{
++	int ret = phytec_eeprom_data_setup_fallback(NULL, 0, EEPROM_ADDR,
++						    EEPROM_ADDR_FALLBACK);
++	if (ret)
++		goto out;
++
++	ret = phytec_imx8m_detect(NULL);
++	if (ret)
++		goto out;
++
++	phytec_print_som_info(NULL);
++	ddr_init(&dram_timing);
++	return;
++out:
++	puts("Could not detect correct RAM size. Fall back to default.");
++	ddr_init(&dram_timing);
++}
++
++void power_init_board(void)
++{
++	struct udevice *i2c_dev;
++	int ret = i2c_get_chip_for_busnum(PMIC_PF8121A_I2C_BUS,
++					  PMIC_PF8121A_I2C_ADDR, 1, &i2c_dev);
++	if (ret) {
++		printf("%s: Cannot find I2C chip: %i\n", __func__, ret);
++		return;
++	}
++	u8 const sw3 = PMIC_PF8121A_SW3_OFF;
++	ret = dm_i2c_write(i2c_dev, PMIC_PF8121A_SW3_MODE_ADDR, &sw3, 1);
++	if (ret)
++		printf("error writing pmic: %i\n", ret);
++}
++
++void spl_board_init(void)
++{
++	/* Serial download mode */
++	if (is_usb_boot()) {
++		puts("Back to ROM, SDP\n");
++		restore_boot_params();
++	}
++	puts("Normal Boot\n");
++}
++
++int board_fit_config_name_match(const char *name)
++{
++	return 0;
++}
++
++#define UART_PAD_CTRL	(PAD_CTL_DSE6 | PAD_CTL_FSEL1)
++#define WDOG_PAD_CTRL	(PAD_CTL_DSE6 | PAD_CTL_ODE)
++
++static iomux_v3_cfg_t const uart_pads[] = {
++	IMX8MN_PAD_UART3_RXD__UART3_DCE_RX | MUX_PAD_CTRL(UART_PAD_CTRL),
++	IMX8MN_PAD_UART3_TXD__UART3_DCE_TX | MUX_PAD_CTRL(UART_PAD_CTRL),
++};
++
++static iomux_v3_cfg_t const wdog_pads[] = {
++	IMX8MN_PAD_GPIO1_IO02__WDOG1_WDOG_B  | MUX_PAD_CTRL(WDOG_PAD_CTRL),
++};
++
++int board_early_init_f(void)
++{
++	struct wdog_regs *wdog = (struct wdog_regs *)WDOG1_BASE_ADDR;
++
++	imx_iomux_v3_setup_multiple_pads(wdog_pads, ARRAY_SIZE(wdog_pads));
++
++	set_wdog_reset(wdog);
++
++	imx_iomux_v3_setup_multiple_pads(uart_pads, ARRAY_SIZE(uart_pads));
++	init_uart_clk(2);
++
++	return 0;
++}
++
++void board_init_f(ulong dummy)
++{
++	/* Clear the BSS. */
++	memset(__bss_start, 0, __bss_end - __bss_start);
++
++	arch_cpu_init();
++
++	board_early_init_f();
++
++	timer_init();
++
++	preloader_console_init();
++
++	int ret = spl_early_init();
++	if (ret) {
++		debug("spl_early_init() failed: %d\n", ret);
++		hang();
++	}
++
++	enable_tzc380();
++
++	power_init_board();
++
++	/* DDR initialization */
++	spl_dram_init();
++
++	board_init_r(NULL, 0);
++}
+diff --git a/board/phytec/phycore_imx8mp/Kconfig b/board/phytec/phycore_imx8mp/Kconfig
+index c053a46fc9d..1555e602e17 100644
+--- a/board/phytec/phycore_imx8mp/Kconfig
++++ b/board/phytec/phycore_imx8mp/Kconfig
+@@ -12,4 +12,41 @@ config SYS_CONFIG_NAME
+ config IMX_CONFIG
+ 	default "board/phytec/phycore_imx8mp/imximage-8mp-sd.cfg"
+ 
++config PHYCORE_IMX8MP_RAM_SIZE_FIX
++	bool "Set phyCORE-i.MX8MP RAM size fix instead of detecting"
++	default false
++	help
++	  RAM size is automatic being detected with the help of
++	  the EEPROM introspection data. Set RAM size to a fix value
++	  instead.
++
++choice
++	prompt "phyCORE-i.MX8MP RAM size"
++	depends on PHYCORE_IMX8MP_RAM_SIZE_FIX
++	default PHYCORE_IMX8MP_RAM_SIZE_2GB
++
++config PHYCORE_IMX8MP_RAM_SIZE_1GB
++	bool "1GB RAM"
++	help
++	  Set RAM size fix to 1GB for phyCORE-i.MX8MP.
++
++config PHYCORE_IMX8MP_RAM_SIZE_2GB
++	bool "2GB RAM"
++	help
++	  Set RAM size fix to 2GB for phyCORE-i.MX8MP.
++
++config PHYCORE_IMX8MP_RAM_SIZE_4GB
++	bool "4GB RAM"
++	help
++	  Set RAM size fix to 4GB for phyCORE-i.MX8MP.
++endchoice
++
++config PHYCORE_IMX8MP_USE_2GHZ_RAM_TIMINGS
++	bool "Use 2GHz RAM timings"
++	depends on PHYCORE_IMX8MP_RAM_SIZE_FIX
++	default false
++	help
++	  Use 2GHz RAM timings instead of 1.5GHz Timings.
++
++source "board/phytec/common/Kconfig"
+ endif
+diff --git a/board/phytec/phycore_imx8mp/lpddr4_timing.c b/board/phytec/phycore_imx8mp/lpddr4_timing.c
+index e59dd74377c..d909cbd7b91 100644
+--- a/board/phytec/phycore_imx8mp/lpddr4_timing.c
++++ b/board/phytec/phycore_imx8mp/lpddr4_timing.c
+@@ -13,63 +13,68 @@ static struct dram_cfg_param ddr_ddrc_cfg[] = {
+ 	{ 0x3d400304, 0x1 },
+ 	{ 0x3d400030, 0x1 },
+ 	{ 0x3d400000, 0xa1080020 },
+-	{ 0x3d400020, 0x323 },
+-	{ 0x3d400024, 0x1e84800 },
+-	{ 0x3d400064, 0x7a0118 },
+-	{ 0x3d4000d0, 0xc00307a3 },
+-	{ 0x3d4000d4, 0xc50000 },
+-	{ 0x3d4000dc, 0xf4003f },
+-	{ 0x3d4000e0, 0x330000 },
++	{ 0x3d400020, 0x1223 },
++	{ 0x3d400024, 0x16e3600 },
++	{ 0x3d400064, 0x5b00d2 },
++	{ 0x3d400070, 0x7027f90 },
++	{ 0x3d400074, 0x790 },
++	{ 0x3d4000d0, 0xc00305ba },
++	{ 0x3d4000d4, 0x940000 },
++	{ 0x3d4000dc, 0xd4002d },
++	{ 0x3d4000e0, 0xf10000 },
+ 	{ 0x3d4000e8, 0x660048 },
+ 	{ 0x3d4000ec, 0x160048 },
+-	{ 0x3d400100, 0x2028222a },
+-	{ 0x3d400104, 0x807bf },
+-	{ 0x3d40010c, 0xe0e000 },
+-	{ 0x3d400110, 0x12040a12 },
+-	{ 0x3d400114, 0x2050f0f },
+-	{ 0x3d400118, 0x1010009 },
+-	{ 0x3d40011c, 0x501 },
+-	{ 0x3d400130, 0x20800 },
+-	{ 0x3d400134, 0xe100002 },
+-	{ 0x3d400138, 0x120 },
+-	{ 0x3d400144, 0xc80064 },
+-	{ 0x3d400180, 0x3e8001e },
+-	{ 0x3d400184, 0x3207a12 },
++	{ 0x3d400100, 0x191e1920 },
++	{ 0x3d400104, 0x60630 },
++	{ 0x3d40010c, 0xb0b000 },
++	{ 0x3d400110, 0xe04080e },
++	{ 0x3d400114, 0x2040c0c },
++	{ 0x3d400118, 0x1010007 },
++	{ 0x3d40011c, 0x401 },
++	{ 0x3d400130, 0x20600 },
++	{ 0x3d400134, 0xc100002 },
++	{ 0x3d400138, 0xd8 },
++	{ 0x3d400144, 0x96004b },
++	{ 0x3d400180, 0x2ee0017 },
++	{ 0x3d400184, 0x2605b8e },
+ 	{ 0x3d400188, 0x0 },
+-	{ 0x3d400190, 0x49f820e },
++	{ 0x3d400190, 0x49b820a },
+ 	{ 0x3d400194, 0x80303 },
+-	{ 0x3d4001b4, 0x1f0e },
++	{ 0x3d4001b4, 0x1b0a },
+ 	{ 0x3d4001a0, 0xe0400018 },
+ 	{ 0x3d4001a4, 0xdf00e4 },
+ 	{ 0x3d4001a8, 0x80000000 },
+ 	{ 0x3d4001b0, 0x11 },
+-	{ 0x3d4001c0, 0x1 },
++	{ 0x3d4001c0, 0x7 },
+ 	{ 0x3d4001c4, 0x1 },
+ 	{ 0x3d4000f4, 0xc99 },
+-	{ 0x3d400108, 0x9121c1c },
++	{ 0x3d400108, 0x7101817 },
+ 	{ 0x3d400200, 0x1f },
++	{ 0x3d400208, 0x0 },
+ 	{ 0x3d40020c, 0x0 },
+ 	{ 0x3d400210, 0x1f1f },
+ 	{ 0x3d400204, 0x80808 },
+ 	{ 0x3d400214, 0x7070707 },
+ 	{ 0x3d400218, 0x7070707 },
+-	{ 0x3d40021c, 0xf07 },
+-	{ 0x3d400250, 0x1f05 },
+-	{ 0x3d400254, 0x1f },
+-	{ 0x3d400264, 0x90003ff },
+-	{ 0x3d40026c, 0x20003ff },
++	{ 0x3d40021c, 0xf0f },
++	{ 0x3d400250, 0x1705 },
++	{ 0x3d400254, 0x2c },
++	{ 0x3d40025c, 0x4000030 },
++	{ 0x3d400264, 0x900093e7 },
++	{ 0x3d40026c, 0x2005574 },
+ 	{ 0x3d400400, 0x111 },
++	{ 0x3d400404, 0x72ff },
+ 	{ 0x3d400408, 0x72ff },
+-	{ 0x3d400494, 0x1000e00 },
+-	{ 0x3d400498, 0x3ff0000 },
+-	{ 0x3d40049c, 0x1000e00 },
+-	{ 0x3d4004a0, 0x3ff0000 },
+-	{ 0x3d402020, 0x21 },
++	{ 0x3d400494, 0x2100e07 },
++	{ 0x3d400498, 0x620096 },
++	{ 0x3d40049c, 0x1100e07 },
++	{ 0x3d4004a0, 0xc8012c },
++	{ 0x3d402020, 0x1021 },
+ 	{ 0x3d402024, 0x30d400 },
+-	{ 0x3d402050, 0x20d040 },
++	{ 0x3d402050, 0x20d000 },
+ 	{ 0x3d402064, 0xc001c },
+ 	{ 0x3d4020dc, 0x840000 },
+-	{ 0x3d4020e0, 0x330000 },
++	{ 0x3d4020e0, 0xf30000 },
+ 	{ 0x3d4020e8, 0x660048 },
+ 	{ 0x3d4020ec, 0x160048 },
+ 	{ 0x3d402100, 0xa040305 },
+@@ -89,12 +94,12 @@ static struct dram_cfg_param ddr_ddrc_cfg[] = {
+ 	{ 0x3d402194, 0x80303 },
+ 	{ 0x3d4021b4, 0x100 },
+ 	{ 0x3d4020f4, 0xc99 },
+-	{ 0x3d403020, 0x21 },
++	{ 0x3d403020, 0x1021 },
+ 	{ 0x3d403024, 0xc3500 },
+-	{ 0x3d403050, 0x20d040 },
++	{ 0x3d403050, 0x20d000 },
+ 	{ 0x3d403064, 0x30007 },
+ 	{ 0x3d4030dc, 0x840000 },
+-	{ 0x3d4030e0, 0x330000 },
++	{ 0x3d4030e0, 0xf30000 },
+ 	{ 0x3d4030e8, 0x660048 },
+ 	{ 0x3d4030ec, 0x160048 },
+ 	{ 0x3d403100, 0xa010102 },
+@@ -137,12 +142,12 @@ static struct dram_cfg_param ddr_ddrphy_cfg[] = {
+ 	{ 0x110a7, 0x6 },
+ 	{ 0x120a0, 0x0 },
+ 	{ 0x120a1, 0x1 },
+-	{ 0x120a2, 0x3 },
+-	{ 0x120a3, 0x2 },
+-	{ 0x120a4, 0x5 },
+-	{ 0x120a5, 0x4 },
+-	{ 0x120a6, 0x7 },
+-	{ 0x120a7, 0x6 },
++	{ 0x120a2, 0x2 },
++	{ 0x120a3, 0x3 },
++	{ 0x120a4, 0x4 },
++	{ 0x120a5, 0x5 },
++	{ 0x120a6, 0x6 },
++	{ 0x120a7, 0x7 },
+ 	{ 0x130a0, 0x0 },
+ 	{ 0x130a1, 0x1 },
+ 	{ 0x130a2, 0x2 },
+@@ -185,7 +190,7 @@ static struct dram_cfg_param ddr_ddrphy_cfg[] = {
+ 	{ 0x7055, 0x1ff },
+ 	{ 0x8055, 0x1ff },
+ 	{ 0x9055, 0x1ff },
+-	{ 0x200c5, 0x18 },
++	{ 0x200c5, 0x19 },
+ 	{ 0x1200c5, 0x7 },
+ 	{ 0x2200c5, 0x7 },
+ 	{ 0x2002e, 0x2 },
+@@ -194,11 +199,11 @@ static struct dram_cfg_param ddr_ddrphy_cfg[] = {
+ 	{ 0x90204, 0x0 },
+ 	{ 0x190204, 0x0 },
+ 	{ 0x290204, 0x0 },
+-	{ 0x20024, 0x1e3 },
++	{ 0x20024, 0x1a3 },
+ 	{ 0x2003a, 0x2 },
+-	{ 0x120024, 0x1e3 },
++	{ 0x120024, 0x1a3 },
+ 	{ 0x2003a, 0x2 },
+-	{ 0x220024, 0x1e3 },
++	{ 0x220024, 0x1a3 },
+ 	{ 0x2003a, 0x2 },
+ 	{ 0x20056, 0x3 },
+ 	{ 0x120056, 0x3 },
+@@ -264,7 +269,7 @@ static struct dram_cfg_param ddr_ddrphy_cfg[] = {
+ 	{ 0x20018, 0x3 },
+ 	{ 0x20075, 0x4 },
+ 	{ 0x20050, 0x0 },
+-	{ 0x20008, 0x3e8 },
++	{ 0x20008, 0x2ee },
+ 	{ 0x120008, 0x64 },
+ 	{ 0x220008, 0x19 },
+ 	{ 0x20088, 0x9 },
+@@ -310,19 +315,15 @@ static struct dram_cfg_param ddr_ddrphy_cfg[] = {
+ 	{ 0x200f6, 0x0 },
+ 	{ 0x200f7, 0xf000 },
+ 	{ 0x20025, 0x0 },
+-	{ 0x2002d, 0x0 },
+-	{ 0x12002d, 0x0 },
+-	{ 0x22002d, 0x0 },
++	{ 0x2002d, 0x1 },
++	{ 0x12002d, 0x1 },
++	{ 0x22002d, 0x1 },
+ 	{ 0x2007d, 0x212 },
+ 	{ 0x12007d, 0x212 },
+ 	{ 0x22007d, 0x212 },
+ 	{ 0x2007c, 0x61 },
+ 	{ 0x12007c, 0x61 },
+ 	{ 0x22007c, 0x61 },
+-	{ 0x1004a, 0x500 },
+-	{ 0x1104a, 0x500 },
+-	{ 0x1204a, 0x500 },
+-	{ 0x1304a, 0x500 },
+ 	{ 0x2002c, 0x0 },
+ };
+ 
+@@ -1052,7 +1053,7 @@ static struct dram_cfg_param ddr_ddrphy_trained_csr[] = {
+ /* P0 message block paremeter for training firmware */
+ static struct dram_cfg_param ddr_fsp0_cfg[] = {
+ 	{ 0xd0000, 0x0 },
+-	{ 0x54003, 0xfa0 },
++	{ 0x54003, 0xbb8 },
+ 	{ 0x54004, 0x2 },
+ 	{ 0x54005, 0x2228 },
+ 	{ 0x54006, 0x14 },
+@@ -1061,26 +1062,26 @@ static struct dram_cfg_param ddr_fsp0_cfg[] = {
+ 	{ 0x5400b, 0x2 },
+ 	{ 0x5400f, 0x100 },
+ 	{ 0x54012, 0x110 },
+-	{ 0x54019, 0x3ff4 },
+-	{ 0x5401a, 0x33 },
++	{ 0x54019, 0x2dd4 },
++	{ 0x5401a, 0xf1 },
+ 	{ 0x5401b, 0x4866 },
+ 	{ 0x5401c, 0x4800 },
+ 	{ 0x5401e, 0x16 },
+-	{ 0x5401f, 0x3ff4 },
+-	{ 0x54020, 0x33 },
++	{ 0x5401f, 0x2dd4 },
++	{ 0x54020, 0xf1 },
+ 	{ 0x54021, 0x4866 },
+ 	{ 0x54022, 0x4800 },
+ 	{ 0x54024, 0x16 },
+ 	{ 0x5402b, 0x1000 },
+ 	{ 0x5402c, 0x1 },
+-	{ 0x54032, 0xf400 },
+-	{ 0x54033, 0x333f },
++	{ 0x54032, 0xd400 },
++	{ 0x54033, 0xf12d },
+ 	{ 0x54034, 0x6600 },
+ 	{ 0x54035, 0x48 },
+ 	{ 0x54036, 0x48 },
+ 	{ 0x54037, 0x1600 },
+-	{ 0x54038, 0xf400 },
+-	{ 0x54039, 0x333f },
++	{ 0x54038, 0xd400 },
++	{ 0x54039, 0xf12d },
+ 	{ 0x5403a, 0x6600 },
+ 	{ 0x5403b, 0x48 },
+ 	{ 0x5403c, 0x48 },
+@@ -1102,25 +1103,25 @@ static struct dram_cfg_param ddr_fsp1_cfg[] = {
+ 	{ 0x5400f, 0x100 },
+ 	{ 0x54012, 0x110 },
+ 	{ 0x54019, 0x84 },
+-	{ 0x5401a, 0x33 },
++	{ 0x5401a, 0xf3 },
+ 	{ 0x5401b, 0x4866 },
+ 	{ 0x5401c, 0x4800 },
+ 	{ 0x5401e, 0x16 },
+ 	{ 0x5401f, 0x84 },
+-	{ 0x54020, 0x33 },
++	{ 0x54020, 0xf3 },
+ 	{ 0x54021, 0x4866 },
+ 	{ 0x54022, 0x4800 },
+ 	{ 0x54024, 0x16 },
+ 	{ 0x5402b, 0x1000 },
+ 	{ 0x5402c, 0x1 },
+ 	{ 0x54032, 0x8400 },
+-	{ 0x54033, 0x3300 },
++	{ 0x54033, 0xf300 },
+ 	{ 0x54034, 0x6600 },
+ 	{ 0x54035, 0x48 },
+ 	{ 0x54036, 0x48 },
+ 	{ 0x54037, 0x1600 },
+ 	{ 0x54038, 0x8400 },
+-	{ 0x54039, 0x3300 },
++	{ 0x54039, 0xf300 },
+ 	{ 0x5403a, 0x6600 },
+ 	{ 0x5403b, 0x48 },
+ 	{ 0x5403c, 0x48 },
+@@ -1142,25 +1143,25 @@ static struct dram_cfg_param ddr_fsp2_cfg[] = {
+ 	{ 0x5400f, 0x100 },
+ 	{ 0x54012, 0x110 },
+ 	{ 0x54019, 0x84 },
+-	{ 0x5401a, 0x33 },
++	{ 0x5401a, 0xf3 },
+ 	{ 0x5401b, 0x4866 },
+ 	{ 0x5401c, 0x4800 },
+ 	{ 0x5401e, 0x16 },
+ 	{ 0x5401f, 0x84 },
+-	{ 0x54020, 0x33 },
++	{ 0x54020, 0xf3 },
+ 	{ 0x54021, 0x4866 },
+ 	{ 0x54022, 0x4800 },
+ 	{ 0x54024, 0x16 },
+ 	{ 0x5402b, 0x1000 },
+ 	{ 0x5402c, 0x1 },
+ 	{ 0x54032, 0x8400 },
+-	{ 0x54033, 0x3300 },
++	{ 0x54033, 0xf300 },
+ 	{ 0x54034, 0x6600 },
+ 	{ 0x54035, 0x48 },
+ 	{ 0x54036, 0x48 },
+ 	{ 0x54037, 0x1600 },
+ 	{ 0x54038, 0x8400 },
+-	{ 0x54039, 0x3300 },
++	{ 0x54039, 0xf300 },
+ 	{ 0x5403a, 0x6600 },
+ 	{ 0x5403b, 0x48 },
+ 	{ 0x5403c, 0x48 },
+@@ -1171,37 +1172,36 @@ static struct dram_cfg_param ddr_fsp2_cfg[] = {
+ /* P0 2D message block paremeter for training firmware */
+ static struct dram_cfg_param ddr_fsp0_2d_cfg[] = {
+ 	{ 0xd0000, 0x0 },
+-	{ 0x54003, 0xfa0 },
++	{ 0x54003, 0xbb8 },
+ 	{ 0x54004, 0x2 },
+ 	{ 0x54005, 0x2228 },
+ 	{ 0x54006, 0x14 },
+ 	{ 0x54008, 0x61 },
+ 	{ 0x54009, 0xc8 },
+ 	{ 0x5400b, 0x2 },
+-	{ 0x5400d, 0x100 },
+ 	{ 0x5400f, 0x100 },
+ 	{ 0x54010, 0x1f7f },
+ 	{ 0x54012, 0x110 },
+-	{ 0x54019, 0x3ff4 },
+-	{ 0x5401a, 0x33 },
++	{ 0x54019, 0x2dd4 },
++	{ 0x5401a, 0xf1 },
+ 	{ 0x5401b, 0x4866 },
+ 	{ 0x5401c, 0x4800 },
+ 	{ 0x5401e, 0x16 },
+-	{ 0x5401f, 0x3ff4 },
+-	{ 0x54020, 0x33 },
++	{ 0x5401f, 0x2dd4 },
++	{ 0x54020, 0xf1 },
+ 	{ 0x54021, 0x4866 },
+ 	{ 0x54022, 0x4800 },
+ 	{ 0x54024, 0x16 },
+ 	{ 0x5402b, 0x1000 },
+ 	{ 0x5402c, 0x1 },
+-	{ 0x54032, 0xf400 },
+-	{ 0x54033, 0x333f },
++	{ 0x54032, 0xd400 },
++	{ 0x54033, 0xf12d },
+ 	{ 0x54034, 0x6600 },
+ 	{ 0x54035, 0x48 },
+ 	{ 0x54036, 0x48 },
+ 	{ 0x54037, 0x1600 },
+-	{ 0x54038, 0xf400 },
+-	{ 0x54039, 0x333f },
++	{ 0x54038, 0xd400 },
++	{ 0x54039, 0xf12d },
+ 	{ 0x5403a, 0x6600 },
+ 	{ 0x5403b, 0x48 },
+ 	{ 0x5403c, 0x48 },
+@@ -1629,67 +1629,58 @@ static struct dram_cfg_param ddr_phy_pie[] = {
+ 	{ 0x90155, 0x20 },
+ 	{ 0x90156, 0x2aa },
+ 	{ 0x90157, 0x9 },
+-	{ 0x90158, 0x0 },
+-	{ 0x90159, 0x400 },
+-	{ 0x9015a, 0x10e },
+-	{ 0x9015b, 0x8 },
+-	{ 0x9015c, 0xe8 },
+-	{ 0x9015d, 0x109 },
+-	{ 0x9015e, 0x0 },
+-	{ 0x9015f, 0x8140 },
+-	{ 0x90160, 0x10c },
+-	{ 0x90161, 0x10 },
+-	{ 0x90162, 0x8138 },
+-	{ 0x90163, 0x10c },
+-	{ 0x90164, 0x8 },
+-	{ 0x90165, 0x7c8 },
+-	{ 0x90166, 0x101 },
+-	{ 0x90167, 0x8 },
+-	{ 0x90168, 0x448 },
++	{ 0x90158, 0x8 },
++	{ 0x90159, 0xe8 },
++	{ 0x9015a, 0x109 },
++	{ 0x9015b, 0x0 },
++	{ 0x9015c, 0x8140 },
++	{ 0x9015d, 0x10c },
++	{ 0x9015e, 0x10 },
++	{ 0x9015f, 0x8138 },
++	{ 0x90160, 0x104 },
++	{ 0x90161, 0x8 },
++	{ 0x90162, 0x448 },
++	{ 0x90163, 0x109 },
++	{ 0x90164, 0xf },
++	{ 0x90165, 0x7c0 },
++	{ 0x90166, 0x109 },
++	{ 0x90167, 0x0 },
++	{ 0x90168, 0xe8 },
+ 	{ 0x90169, 0x109 },
+-	{ 0x9016a, 0xf },
+-	{ 0x9016b, 0x7c0 },
++	{ 0x9016a, 0x47 },
++	{ 0x9016b, 0x630 },
+ 	{ 0x9016c, 0x109 },
+-	{ 0x9016d, 0x0 },
+-	{ 0x9016e, 0xe8 },
++	{ 0x9016d, 0x8 },
++	{ 0x9016e, 0x618 },
+ 	{ 0x9016f, 0x109 },
+-	{ 0x90170, 0x47 },
+-	{ 0x90171, 0x630 },
++	{ 0x90170, 0x8 },
++	{ 0x90171, 0xe0 },
+ 	{ 0x90172, 0x109 },
+-	{ 0x90173, 0x8 },
+-	{ 0x90174, 0x618 },
++	{ 0x90173, 0x0 },
++	{ 0x90174, 0x7c8 },
+ 	{ 0x90175, 0x109 },
+ 	{ 0x90176, 0x8 },
+-	{ 0x90177, 0xe0 },
+-	{ 0x90178, 0x109 },
++	{ 0x90177, 0x8140 },
++	{ 0x90178, 0x10c },
+ 	{ 0x90179, 0x0 },
+-	{ 0x9017a, 0x7c8 },
++	{ 0x9017a, 0x478 },
+ 	{ 0x9017b, 0x109 },
+-	{ 0x9017c, 0x8 },
+-	{ 0x9017d, 0x8140 },
+-	{ 0x9017e, 0x10c },
+-	{ 0x9017f, 0x0 },
+-	{ 0x90180, 0x478 },
+-	{ 0x90181, 0x109 },
+-	{ 0x90182, 0x0 },
+-	{ 0x90183, 0x1 },
+-	{ 0x90184, 0x8 },
+-	{ 0x90185, 0x8 },
+-	{ 0x90186, 0x4 },
+-	{ 0x90187, 0x8 },
+-	{ 0x90188, 0x8 },
+-	{ 0x90189, 0x7c8 },
+-	{ 0x9018a, 0x101 },
+-	{ 0x90006, 0x0 },
+-	{ 0x90007, 0x0 },
+-	{ 0x90008, 0x8 },
++	{ 0x9017c, 0x0 },
++	{ 0x9017d, 0x1 },
++	{ 0x9017e, 0x8 },
++	{ 0x9017f, 0x8 },
++	{ 0x90180, 0x4 },
++	{ 0x90181, 0x0 },
++	{ 0x90006, 0x8 },
++	{ 0x90007, 0x7c8 },
++	{ 0x90008, 0x109 },
+ 	{ 0x90009, 0x0 },
+-	{ 0x9000a, 0x0 },
+-	{ 0x9000b, 0x0 },
++	{ 0x9000a, 0x400 },
++	{ 0x9000b, 0x106 },
+ 	{ 0xd00e7, 0x400 },
+ 	{ 0x90017, 0x0 },
+ 	{ 0x9001f, 0x29 },
+-	{ 0x90026, 0x6a },
++	{ 0x90026, 0x68 },
+ 	{ 0x400d0, 0x0 },
+ 	{ 0x400d1, 0x101 },
+ 	{ 0x400d2, 0x105 },
+@@ -1699,15 +1690,16 @@ static struct dram_cfg_param ddr_phy_pie[] = {
+ 	{ 0x400d6, 0x20a },
+ 	{ 0x400d7, 0x20b },
+ 	{ 0x2003a, 0x2 },
+-	{ 0x2000b, 0x7d },
+-	{ 0x2000c, 0xfa },
+-	{ 0x2000d, 0x9c4 },
++	{ 0x200be, 0x3 },
++	{ 0x2000b, 0x34b },
++	{ 0x2000c, 0xbb },
++	{ 0x2000d, 0x753 },
+ 	{ 0x2000e, 0x2c },
+-	{ 0x12000b, 0xc },
++	{ 0x12000b, 0x70 },
+ 	{ 0x12000c, 0x19 },
+ 	{ 0x12000d, 0xfa },
+ 	{ 0x12000e, 0x10 },
+-	{ 0x22000b, 0x3 },
++	{ 0x22000b, 0x1c },
+ 	{ 0x22000c, 0x6 },
+ 	{ 0x22000d, 0x3e },
+ 	{ 0x22000e, 0x10 },
+@@ -1804,8 +1796,8 @@ static struct dram_cfg_param ddr_phy_pie[] = {
+ 
+ static struct dram_fsp_msg ddr_dram_fsp_msg[] = {
+ 	{
+-		/* P0 4000mts 1D */
+-		.drate = 4000,
++		/* P0 3000mts 1D */
++		.drate = 3000,
+ 		.fw_type = FW_1D_IMAGE,
+ 		.fsp_cfg = ddr_fsp0_cfg,
+ 		.fsp_cfg_num = ARRAY_SIZE(ddr_fsp0_cfg),
+@@ -1825,8 +1817,8 @@ static struct dram_fsp_msg ddr_dram_fsp_msg[] = {
+ 		.fsp_cfg_num = ARRAY_SIZE(ddr_fsp2_cfg),
+ 	},
+ 	{
+-		/* P0 4000mts 2D */
+-		.drate = 4000,
++		/* P0 3000mts 2D */
++		.drate = 3000,
+ 		.fw_type = FW_2D_IMAGE,
+ 		.fsp_cfg = ddr_fsp0_2d_cfg,
+ 		.fsp_cfg_num = ARRAY_SIZE(ddr_fsp0_2d_cfg),
+@@ -1845,5 +1837,135 @@ struct dram_timing_info dram_timing = {
+ 	.ddrphy_trained_csr_num = ARRAY_SIZE(ddr_ddrphy_trained_csr),
+ 	.ddrphy_pie = ddr_phy_pie,
+ 	.ddrphy_pie_num = ARRAY_SIZE(ddr_phy_pie),
+-	.fsp_table = { 4000, 400, 100, },
++	.fsp_table = { 3000, 400, 100, },
+ };
++
++void set_dram_timings_2ghz_2gb(void)
++{
++	dram_timing.ddrc_cfg[3].val = 0x1323;
++	dram_timing.ddrc_cfg[4].val = 0x1e84800;
++	dram_timing.ddrc_cfg[5].val = 0x7a0118;
++	dram_timing.ddrc_cfg[8].val = 0xc00307a3;
++	dram_timing.ddrc_cfg[9].val = 0xc50000;
++	dram_timing.ddrc_cfg[10].val = 0xf4003f;
++	dram_timing.ddrc_cfg[11].val = 0xf30000;
++	dram_timing.ddrc_cfg[14].val = 0x2028222a;
++	dram_timing.ddrc_cfg[15].val = 0x8083f;
++	dram_timing.ddrc_cfg[16].val = 0xe0e000;
++	dram_timing.ddrc_cfg[17].val = 0x12040a12;
++	dram_timing.ddrc_cfg[18].val = 0x2050f0f;
++	dram_timing.ddrc_cfg[19].val = 0x1010009;
++	dram_timing.ddrc_cfg[20].val = 0x502;
++	dram_timing.ddrc_cfg[21].val = 0x20800;
++	dram_timing.ddrc_cfg[22].val = 0xe100002;
++	dram_timing.ddrc_cfg[23].val = 0x120;
++	dram_timing.ddrc_cfg[24].val = 0xc80064;
++	dram_timing.ddrc_cfg[25].val = 0x3e8001e;
++	dram_timing.ddrc_cfg[26].val = 0x3207a12;
++	dram_timing.ddrc_cfg[28].val = 0x4a3820e;
++	dram_timing.ddrc_cfg[30].val = 0x230e;
++	dram_timing.ddrc_cfg[37].val = 0x799;
++	dram_timing.ddrc_cfg[38].val = 0x9141d1c;
++	dram_timing.ddrc_cfg[74].val = 0x302;
++	dram_timing.ddrc_cfg[83].val = 0x599;
++	dram_timing.ddrc_cfg[99].val = 0x302;
++	dram_timing.ddrc_cfg[108].val = 0x599;
++	dram_timing.ddrphy_cfg[66].val = 0x18;
++	dram_timing.ddrphy_cfg[75].val = 0x1e3;
++	dram_timing.ddrphy_cfg[77].val = 0x1e3;
++	dram_timing.ddrphy_cfg[79].val = 0x1e3;
++	dram_timing.ddrphy_cfg[145].val = 0x3e8;
++	dram_timing.fsp_msg[0].drate = 4000;
++	dram_timing.fsp_msg[0].fsp_cfg[1].val = 0xfa0;
++	dram_timing.fsp_msg[0].fsp_cfg[10].val = 0x3ff4;
++	dram_timing.fsp_msg[0].fsp_cfg[11].val = 0xf3;
++	dram_timing.fsp_msg[0].fsp_cfg[15].val = 0x3ff4;
++	dram_timing.fsp_msg[0].fsp_cfg[16].val = 0xf3;
++	dram_timing.fsp_msg[0].fsp_cfg[22].val = 0xf400;
++	dram_timing.fsp_msg[0].fsp_cfg[23].val = 0xf33f;
++	dram_timing.fsp_msg[0].fsp_cfg[28].val = 0xf400;
++	dram_timing.fsp_msg[0].fsp_cfg[29].val = 0xf33f;
++	dram_timing.fsp_msg[3].drate = 4000;
++	dram_timing.fsp_msg[3].fsp_cfg[1].val = 0xfa0;
++	dram_timing.fsp_msg[3].fsp_cfg[11].val = 0x3ff4;
++	dram_timing.fsp_msg[3].fsp_cfg[12].val = 0xf3;
++	dram_timing.fsp_msg[3].fsp_cfg[16].val = 0x3ff4;
++	dram_timing.fsp_msg[3].fsp_cfg[17].val = 0xf3;
++	dram_timing.fsp_msg[3].fsp_cfg[23].val = 0xf400;
++	dram_timing.fsp_msg[3].fsp_cfg[24].val = 0xf33f;
++	dram_timing.fsp_msg[3].fsp_cfg[29].val = 0xf400;
++	dram_timing.fsp_msg[3].fsp_cfg[30].val = 0xf33f;
++	dram_timing.ddrphy_pie[480].val = 0x465;
++	dram_timing.ddrphy_pie[481].val = 0xfa;
++	dram_timing.ddrphy_pie[482].val = 0x9c4;
++	dram_timing.fsp_table[0] = 4000;
++}
++
++void set_dram_timings_2ghz_1gb(void)
++{
++	set_dram_timings_2ghz_2gb();
++	dram_timing.ddrc_cfg[5].val = 0x7a00b4;
++	dram_timing.ddrc_cfg[23].val = 0xbc;
++	dram_timing.ddrc_cfg[45].val = 0xf070707;
++	dram_timing.ddrc_cfg[62].val = 0xc0012;
++	dram_timing.ddrc_cfg[77].val = 0x13;
++	dram_timing.ddrc_cfg[87].val = 0x30005;
++	dram_timing.ddrc_cfg[102].val = 0x5;
++}
++
++void set_dram_timings_2ghz_4gb(void)
++{
++	set_dram_timings_2ghz_2gb();
++	dram_timing.ddrc_cfg[2].val = 0xa3080020;
++	dram_timing.ddrc_cfg[39].val = 0x17;
++	dram_timing.fsp_msg[0].fsp_cfg[9].val = 0x310;
++	dram_timing.fsp_msg[0].fsp_cfg[21].val = 0x3;
++	dram_timing.fsp_msg[1].fsp_cfg[10].val = 0x310;
++	dram_timing.fsp_msg[1].fsp_cfg[22].val = 0x3;
++	dram_timing.fsp_msg[2].fsp_cfg[10].val = 0x310;
++	dram_timing.fsp_msg[2].fsp_cfg[22].val = 0x3;
++	dram_timing.fsp_msg[3].fsp_cfg[10].val = 0x310;
++	dram_timing.fsp_msg[3].fsp_cfg[22].val = 0x3;
++}
++
++void set_dram_timings_1_5ghz_1gb(void)
++{
++	dram_timing.ddrc_cfg[3].val = 0x1233;
++	dram_timing.ddrc_cfg[5].val = 0x5b0087;
++	dram_timing.ddrc_cfg[6].val = 0x61027f10;
++	dram_timing.ddrc_cfg[7].val = 0x7b0;
++	dram_timing.ddrc_cfg[11].val = 0xf30000;
++	dram_timing.ddrc_cfg[23].val = 0x8d;
++	dram_timing.ddrc_cfg[45].val = 0xf070707;
++	dram_timing.ddrc_cfg[59].val = 0x1031;
++	dram_timing.ddrc_cfg[62].val = 0xc0012;
++	dram_timing.ddrc_cfg[77].val = 0x13;
++	dram_timing.ddrc_cfg[84].val = 0x1031;
++	dram_timing.ddrc_cfg[87].val = 0x30005;
++	dram_timing.ddrc_cfg[102].val = 0x5;
++	dram_timing.ddrphy_cfg[75].val = 0x1e3;
++	dram_timing.ddrphy_cfg[77].val = 0x1e3;
++	dram_timing.ddrphy_cfg[79].val = 0x1e3;
++	dram_timing.fsp_msg[0].fsp_cfg[11].val = 0xf3;
++	dram_timing.fsp_msg[0].fsp_cfg[16].val = 0xf3;
++	dram_timing.fsp_msg[0].fsp_cfg[23].val = 0xf32d;
++	dram_timing.fsp_msg[0].fsp_cfg[29].val = 0xf32d;
++	dram_timing.fsp_msg[3].fsp_cfg[12].val = 0xf3;
++	dram_timing.fsp_msg[3].fsp_cfg[17].val = 0xf3;
++	dram_timing.fsp_msg[3].fsp_cfg[24].val = 0xf32d;
++	dram_timing.fsp_msg[3].fsp_cfg[30].val = 0xf32d;
++}
++
++void set_dram_timings_1_5ghz_4gb(void)
++{
++	dram_timing.ddrc_cfg[2].val = 0xa3080020;
++	dram_timing.ddrc_cfg[39].val = 0x17;
++	dram_timing.fsp_msg[0].fsp_cfg[9].val = 0x310;
++	dram_timing.fsp_msg[0].fsp_cfg[21].val = 0x3;
++	dram_timing.fsp_msg[1].fsp_cfg[10].val = 0x310;
++	dram_timing.fsp_msg[1].fsp_cfg[22].val = 0x3;
++	dram_timing.fsp_msg[2].fsp_cfg[10].val = 0x310;
++	dram_timing.fsp_msg[2].fsp_cfg[22].val = 0x3;
++	dram_timing.fsp_msg[3].fsp_cfg[10].val = 0x310;
++	dram_timing.fsp_msg[3].fsp_cfg[22].val = 0x3;
++}
+diff --git a/board/phytec/phycore_imx8mp/phycore-imx8mp.c b/board/phytec/phycore_imx8mp/phycore-imx8mp.c
+index a8f08214376..1cdf716e969 100644
+--- a/board/phytec/phycore_imx8mp/phycore-imx8mp.c
++++ b/board/phytec/phycore_imx8mp/phycore-imx8mp.c
+@@ -52,3 +52,13 @@ int board_late_init(void)
+ 
+ 	return 0;
+ }
++
++int board_phys_sdram_size(phys_size_t *size)
++{
++	if (!size)
++		return -EINVAL;
++
++	*size = imx8m_ddrc_sdram_size();
++
++	return 0;
++}
+diff --git a/board/phytec/phycore_imx8mp/spl.c b/board/phytec/phycore_imx8mp/spl.c
+index 19c486e5517..20f02cbd0fb 100644
+--- a/board/phytec/phycore_imx8mp/spl.c
++++ b/board/phytec/phycore_imx8mp/spl.c
+@@ -21,15 +21,92 @@
+ #include <power/pca9450.h>
+ #include <spl.h>
+ 
++#include "../common/imx8m_som_detection.h"
++
+ DECLARE_GLOBAL_DATA_PTR;
+ 
++#define EEPROM_ADDR		0x51
++#define EEPROM_ADDR_FALLBACK	0x59
++
++void set_dram_timings_2ghz_2gb(void);
++void set_dram_timings_2ghz_1gb(void);
++void set_dram_timings_2ghz_4gb(void);
++void set_dram_timings_1_5ghz_1gb(void);
++void set_dram_timings_1_5ghz_4gb(void);
++
+ int spl_board_boot_device(enum boot_device boot_dev_spl)
+ {
+ 	return BOOT_DEVICE_BOOTROM;
+ }
+ 
++enum phytec_imx8mp_ddr_eeprom_code {
++	INVALID = PHYTEC_EEPROM_INVAL,
++	PHYTEC_IMX8MP_DDR_1GB = 2,
++	PHYTEC_IMX8MP_DDR_2GB = 3,
++	PHYTEC_IMX8MP_DDR_4GB = 5,
++	PHYTEC_IMX8MP_DDR_4GB_2GHZ = 8,
++};
++
+ void spl_dram_init(void)
+ {
++	int ret;
++	bool use_2ghz_timings = false;
++	enum phytec_imx8mp_ddr_eeprom_code size = INVALID;
++
++	ret = phytec_eeprom_data_setup_fallback(NULL, 0, EEPROM_ADDR,
++						EEPROM_ADDR_FALLBACK);
++	if (ret && !IS_ENABLED(CONFIG_PHYCORE_IMX8MP_RAM_SIZE_FIX))
++		goto out;
++
++	ret = phytec_imx8m_detect(NULL);
++	if (!ret)
++		phytec_print_som_info(NULL);
++
++	if (IS_ENABLED(CONFIG_PHYCORE_IMX8MP_RAM_SIZE_FIX)) {
++		if (IS_ENABLED(CONFIG_PHYCORE_IMX8MP_RAM_SIZE_1GB))
++			size = PHYTEC_IMX8MP_DDR_1GB;
++		else if (IS_ENABLED(CONFIG_PHYCORE_IMX8MP_RAM_SIZE_2GB))
++			size = PHYTEC_IMX8MP_DDR_2GB;
++		else if (IS_ENABLED(CONFIG_PHYCORE_IMX8MP_RAM_SIZE_4GB))
++			size = PHYTEC_IMX8MP_DDR_4GB;
++		if (IS_ENABLED(CONFIG_PHYCORE_IMX8MP_USE_2GHZ_RAM_TIMINGS)) {
++			if (size == PHYTEC_IMX8MP_DDR_4GB)
++				size = PHYTEC_IMX8MP_DDR_4GB_2GHZ;
++			else
++				use_2ghz_timings = true;
++		}
++	} else {
++		ret = phytec_get_rev(NULL);
++		if (ret >= 3 && ret != PHYTEC_EEPROM_INVAL)
++			use_2ghz_timings = true;
++
++		size = phytec_get_imx8m_ddr_size(NULL);
++	}
++
++	switch (size) {
++	case PHYTEC_IMX8MP_DDR_1GB:
++		if (use_2ghz_timings)
++			set_dram_timings_2ghz_1gb();
++		else
++			set_dram_timings_1_5ghz_1gb();
++		break;
++	case PHYTEC_IMX8MP_DDR_2GB:
++		if (use_2ghz_timings)
++			set_dram_timings_2ghz_2gb();
++		break;
++	case PHYTEC_IMX8MP_DDR_4GB:
++		set_dram_timings_1_5ghz_4gb();
++		break;
++	case PHYTEC_IMX8MP_DDR_4GB_2GHZ:
++		set_dram_timings_2ghz_4gb();
++		break;
++	default:
++		goto out;
++	}
++	ddr_init(&dram_timing);
++	return;
++out:
++	printf("Could not detect correct RAM size. Fallback to default.\n");
+ 	ddr_init(&dram_timing);
+ }
+ 
+@@ -89,14 +166,8 @@ int board_fit_config_name_match(const char *name)
+ 	return 0;
+ }
+ 
+-#define UART_PAD_CTRL   (PAD_CTL_DSE6 | PAD_CTL_FSEL1)
+ #define WDOG_PAD_CTRL   (PAD_CTL_DSE6 | PAD_CTL_ODE | PAD_CTL_PUE | PAD_CTL_PE)
+ 
+-static iomux_v3_cfg_t const uart_pads[] = {
+-	MX8MP_PAD_UART1_RXD__UART1_DCE_RX | MUX_PAD_CTRL(UART_PAD_CTRL),
+-	MX8MP_PAD_UART1_TXD__UART1_DCE_TX | MUX_PAD_CTRL(UART_PAD_CTRL),
+-};
+-
+ static iomux_v3_cfg_t const wdog_pads[] = {
+ 	MX8MP_PAD_GPIO1_IO02__WDOG1_WDOG_B  | MUX_PAD_CTRL(WDOG_PAD_CTRL),
+ };
+@@ -109,8 +180,6 @@ int board_early_init_f(void)
+ 
+ 	set_wdog_reset(wdog);
+ 
+-	imx_iomux_v3_setup_multiple_pads(uart_pads, ARRAY_SIZE(uart_pads));
+-
+ 	return 0;
+ }
+ 
+diff --git a/configs/imx8mm-phygate-tauri_defconfig b/configs/imx8mm-phygate-tauri_defconfig
+new file mode 100644
+index 00000000000..8190e60b61d
+--- /dev/null
++++ b/configs/imx8mm-phygate-tauri_defconfig
+@@ -0,0 +1,124 @@
++CONFIG_ARM=y
++CONFIG_ARCH_IMX8M=y
++CONFIG_SYS_TEXT_BASE=0x40200000
++CONFIG_SYS_MALLOC_LEN=0x2000000
++CONFIG_SYS_MALLOC_F_LEN=0x10000
++CONFIG_SPL_GPIO=y
++CONFIG_SPL_LIBCOMMON_SUPPORT=y
++CONFIG_SPL_LIBGENERIC_SUPPORT=y
++CONFIG_ENV_SIZE=0x10000
++CONFIG_ENV_OFFSET=0x3C0000
++CONFIG_DM_GPIO=y
++CONFIG_DEFAULT_DEVICE_TREE="imx8mm-phygate-tauri"
++CONFIG_SPL_TEXT_BASE=0x7E1000
++CONFIG_TARGET_PHYCORE_IMX8MM=y
++CONFIG_PHYTEC_SOM_DETECTION=y
++CONFIG_SPL_MMC=y
++CONFIG_SPL_SERIAL=y
++CONFIG_SPL_DRIVERS_MISC=y
++CONFIG_SPL=y
++CONFIG_ENV_OFFSET_REDUND=0x3E0000
++CONFIG_LTO=y
++CONFIG_SYS_LOAD_ADDR=0x58000000
++CONFIG_FIT=y
++CONFIG_FIT_EXTERNAL_OFFSET=0x3000
++CONFIG_SPL_LOAD_FIT=y
++# CONFIG_USE_SPL_FIT_GENERATOR is not set
++CONFIG_OF_SYSTEM_SETUP=y
++CONFIG_USE_BOOTCOMMAND=y
++CONFIG_BOOTCOMMAND="mmc dev ${mmcdev}; if mmc rescan; then if run loadimage; then run mmcboot; else run netboot; fi; fi;"
++CONFIG_DEFAULT_FDT_FILE="oftree"
++CONFIG_BOARD_LATE_INIT=y
++CONFIG_SPL_BOARD_INIT=y
++CONFIG_SPL_SEPARATE_BSS=y
++CONFIG_SYS_MMCSD_RAW_MODE_U_BOOT_USE_SECTOR=y
++CONFIG_SYS_MMCSD_RAW_MODE_U_BOOT_SECTOR=0x300
++CONFIG_SPL_I2C=y
++CONFIG_SPL_POWER=y
++CONFIG_SPL_SPI_FLASH_MTD=y
++CONFIG_SPL_WATCHDOG=y
++CONFIG_HUSH_PARSER=y
++CONFIG_SYS_PROMPT="u-boot=> "
++CONFIG_CMD_ERASEENV=y
++# CONFIG_CMD_EXPORTENV is not set
++# CONFIG_CMD_IMPORTENV is not set
++# CONFIG_CMD_CRC32 is not set
++CONFIG_CMD_EEPROM=y
++CONFIG_SYS_I2C_EEPROM_ADDR_LEN=2
++CONFIG_SYS_EEPROM_SIZE=4096
++CONFIG_SYS_EEPROM_PAGE_WRITE_BITS=5
++CONFIG_SYS_EEPROM_PAGE_WRITE_DELAY_MS=5
++CONFIG_CMD_CLK=y
++CONFIG_CMD_FUSE=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_I2C=y
++CONFIG_CMD_MMC=y
++CONFIG_CMD_SF_TEST=y
++CONFIG_CMD_DHCP=y
++CONFIG_CMD_MII=y
++CONFIG_CMD_PING=y
++CONFIG_CMD_CACHE=y
++CONFIG_CMD_REGULATOR=y
++CONFIG_CMD_EXT2=y
++CONFIG_CMD_EXT4=y
++CONFIG_CMD_EXT4_WRITE=y
++CONFIG_CMD_FAT=y
++CONFIG_OF_CONTROL=y
++CONFIG_SPL_OF_CONTROL=y
++CONFIG_ENV_OVERWRITE=y
++CONFIG_ENV_IS_IN_MMC=y
++CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_SYS_MMC_ENV_DEV=2
++CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
++CONFIG_SPL_DM=y
++CONFIG_SPL_CLK_IMX8MM=y
++CONFIG_CLK_IMX8MM=y
++CONFIG_MXC_GPIO=y
++CONFIG_DM_I2C=y
++CONFIG_DM_MMC=y
++CONFIG_MISC=y
++CONFIG_I2C_EEPROM=y
++CONFIG_SYS_I2C_EEPROM_ADDR=0x51
++CONFIG_SUPPORT_EMMC_BOOT=y
++CONFIG_MMC_IO_VOLTAGE=y
++CONFIG_MMC_UHS_SUPPORT=y
++CONFIG_MMC_HS400_ES_SUPPORT=y
++CONFIG_MMC_HS400_SUPPORT=y
++CONFIG_FSL_USDHC=y
++CONFIG_MTD=y
++CONFIG_DM_MTD=y
++CONFIG_DM_SPI_FLASH=y
++CONFIG_SF_DEFAULT_BUS=3
++CONFIG_SF_DEFAULT_SPEED=80000000
++CONFIG_SPI_FLASH_BAR=y
++CONFIG_SPI_FLASH_MACRONIX=y
++CONFIG_SPI_FLASH_SPANSION=y
++CONFIG_SPI_FLASH_STMICRO=y
++CONFIG_SPI_FLASH_SST=y
++CONFIG_SPI_FLASH_WINBOND=y
++# CONFIG_SPI_FLASH_USE_4K_SECTORS is not set
++CONFIG_SPI_FLASH_MTD=y
++CONFIG_PHYLIB=y
++CONFIG_PHY_TI_DP83867=y
++CONFIG_DM_ETH=y
++CONFIG_PHY_GIGE=y
++CONFIG_FEC_MXC=y
++CONFIG_MII=y
++CONFIG_PINCTRL=y
++CONFIG_SPL_PINCTRL=y
++CONFIG_PINCTRL_IMX8M=y
++CONFIG_DM_REGULATOR=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_DM_REGULATOR_GPIO=y
++CONFIG_DM_SERIAL=y
++CONFIG_MXC_UART=y
++CONFIG_SPI=y
++CONFIG_DM_SPI=y
++CONFIG_NXP_FSPI=y
++CONFIG_SYSRESET=y
++CONFIG_SPL_SYSRESET=y
++CONFIG_SYSRESET_PSCI=y
++CONFIG_SYSRESET_WATCHDOG=y
++CONFIG_DM_THERMAL=y
++CONFIG_IMX_WATCHDOG=y
+diff --git a/configs/phycore-imx8mm_defconfig b/configs/phycore-imx8mm_defconfig
+index c6b2719350d..b0ce6555997 100644
+--- a/configs/phycore-imx8mm_defconfig
++++ b/configs/phycore-imx8mm_defconfig
+@@ -9,15 +9,17 @@ CONFIG_SPL_LIBGENERIC_SUPPORT=y
+ CONFIG_ENV_SIZE=0x10000
+ CONFIG_ENV_OFFSET=0x3C0000
+ CONFIG_DM_GPIO=y
+-CONFIG_DEFAULT_DEVICE_TREE="phycore-imx8mm"
++CONFIG_DEFAULT_DEVICE_TREE="imx8mm-phyboard-polis-rdk"
+ CONFIG_SPL_TEXT_BASE=0x7E1000
+ CONFIG_TARGET_PHYCORE_IMX8MM=y
++CONFIG_PHYTEC_SOM_DETECTION=y
+ CONFIG_SPL_MMC=y
+ CONFIG_SPL_SERIAL=y
+ CONFIG_SPL_DRIVERS_MISC=y
+ CONFIG_SPL=y
+ CONFIG_ENV_OFFSET_REDUND=0x3E0000
+-CONFIG_SYS_LOAD_ADDR=0x40480000
++CONFIG_LTO=y
++CONFIG_SYS_LOAD_ADDR=0x58000000
+ CONFIG_FIT=y
+ CONFIG_FIT_EXTERNAL_OFFSET=0x3000
+ CONFIG_SPL_LOAD_FIT=y
+@@ -37,6 +39,7 @@ CONFIG_SPL_SPI_FLASH_MTD=y
+ CONFIG_SPL_WATCHDOG=y
+ CONFIG_HUSH_PARSER=y
+ CONFIG_SYS_PROMPT="u-boot=> "
++CONFIG_CMD_ERASEENV=y
+ # CONFIG_CMD_EXPORTENV is not set
+ # CONFIG_CMD_IMPORTENV is not set
+ # CONFIG_CMD_CRC32 is not set
+@@ -69,12 +72,11 @@ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
+ CONFIG_SYS_MMC_ENV_DEV=2
+ CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
+ CONFIG_SPL_DM=y
+-CONFIG_SPL_CLK_COMPOSITE_CCF=y
+-CONFIG_CLK_COMPOSITE_CCF=y
+ CONFIG_SPL_CLK_IMX8MM=y
+ CONFIG_CLK_IMX8MM=y
+ CONFIG_MXC_GPIO=y
+ CONFIG_DM_I2C=y
++CONFIG_DM_MMC=y
+ CONFIG_MISC=y
+ CONFIG_I2C_EEPROM=y
+ CONFIG_SYS_I2C_EEPROM_ADDR=0x51
+@@ -109,6 +111,7 @@ CONFIG_PINCTRL_IMX8M=y
+ CONFIG_DM_REGULATOR=y
+ CONFIG_DM_REGULATOR_FIXED=y
+ CONFIG_DM_REGULATOR_GPIO=y
++CONFIG_DM_SERIAL=y
+ CONFIG_MXC_UART=y
+ CONFIG_SPI=y
+ CONFIG_DM_SPI=y
+diff --git a/configs/phycore-imx8mn_defconfig b/configs/phycore-imx8mn_defconfig
+new file mode 100644
+index 00000000000..5b14d246e23
+--- /dev/null
++++ b/configs/phycore-imx8mn_defconfig
+@@ -0,0 +1,146 @@
++CONFIG_ARM=y
++CONFIG_ARCH_IMX8M=y
++CONFIG_SYS_TEXT_BASE=0x40200000
++CONFIG_SYS_MALLOC_LEN=0x2000000
++CONFIG_SYS_MALLOC_F_LEN=0x10000
++CONFIG_SPL_GPIO=y
++CONFIG_SPL_LIBCOMMON_SUPPORT=y
++CONFIG_SPL_LIBGENERIC_SUPPORT=y
++CONFIG_ENV_SIZE=0x10000
++CONFIG_ENV_OFFSET=0x3C0000
++CONFIG_SYS_I2C_MXC_I2C1=y
++CONFIG_SYS_I2C_MXC_I2C2=y
++CONFIG_SYS_I2C_MXC_I2C3=y
++CONFIG_SPL_DM_GPIO=y
++CONFIG_DM_GPIO=y
++CONFIG_DEFAULT_DEVICE_TREE="imx8mn-phyboard-polis"
++CONFIG_SPL_TEXT_BASE=0x912000
++CONFIG_TARGET_PHYCORE_IMX8MN=y
++CONFIG_PHYTEC_SOM_DETECTION=y
++CONFIG_SPL_MMC=y
++CONFIG_SPL_SERIAL=y
++CONFIG_SPL_DRIVERS_MISC=y
++CONFIG_SPL=y
++CONFIG_ENV_OFFSET_REDUND=0x3E0000
++CONFIG_IMX_BOOTAUX=y
++CONFIG_SPL_IMX_ROMAPI_LOADADDR=0x48000000
++# CONFIG_LTO is not set
++CONFIG_SYS_LOAD_ADDR=0x58000000
++CONFIG_FIT=y
++CONFIG_FIT_EXTERNAL_OFFSET=0x3000
++CONFIG_SPL_LOAD_FIT=y
++CONFIG_OF_SYSTEM_SETUP=y
++CONFIG_USE_BOOTCOMMAND=y
++CONFIG_BOOTCOMMAND="mmc dev ${mmcdev}; if mmc rescan; then if run loadimage; then run mmcboot; else run netboot; fi; fi;"
++CONFIG_DEFAULT_FDT_FILE="oftree"
++CONFIG_BOARD_LATE_INIT=y
++CONFIG_SPL_BOARD_INIT=y
++CONFIG_SPL_BOOTROM_SUPPORT=y
++CONFIG_SPL_SEPARATE_BSS=y
++CONFIG_SYS_MMCSD_RAW_MODE_U_BOOT_USE_SECTOR=y
++CONFIG_SYS_MMCSD_RAW_MODE_U_BOOT_SECTOR=0x300
++CONFIG_SPL_I2C=y
++CONFIG_SPL_POWER=y
++CONFIG_SPL_WATCHDOG=y
++CONFIG_HUSH_PARSER=y
++CONFIG_SYS_PROMPT="u-boot=> "
++CONFIG_CMD_ERASEENV=y
++CONFIG_CMD_EXTENSION=y
++# CONFIG_CMD_CRC32 is not set
++CONFIG_CMD_EEPROM=y
++CONFIG_SYS_I2C_EEPROM_ADDR=0x51
++CONFIG_SYS_I2C_EEPROM_ADDR_LEN=2
++CONFIG_SYS_I2C_EEPROM_ADDR_OVERFLOW=0x0
++CONFIG_SYS_EEPROM_SIZE=4096
++CONFIG_SYS_EEPROM_PAGE_WRITE_BITS=5
++CONFIG_SYS_EEPROM_PAGE_WRITE_DELAY_MS=5
++CONFIG_CMD_CLK=y
++CONFIG_CMD_FUSE=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_I2C=y
++CONFIG_CMD_MMC=y
++CONFIG_CMD_DHCP=y
++CONFIG_CMD_MII=y
++CONFIG_CMD_PING=y
++CONFIG_CMD_CACHE=y
++CONFIG_CMD_REGULATOR=y
++CONFIG_CMD_EXT2=y
++CONFIG_CMD_EXT4=y
++CONFIG_CMD_EXT4_WRITE=y
++CONFIG_CMD_FAT=y
++CONFIG_OF_CONTROL=y
++CONFIG_SPL_OF_CONTROL=y
++CONFIG_ENV_OVERWRITE=y
++CONFIG_ENV_IS_NOWHERE=y
++CONFIG_ENV_IS_IN_MMC=y
++CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_SYS_MMC_ENV_DEV=2
++CONFIG_SYS_MMC_IMG_LOAD_PART=1
++CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
++CONFIG_SPL_DM=y
++CONFIG_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_SPL_CLK_COMPOSITE_CCF=y
++CONFIG_NET_RANDOM_ETHADDR=y
++CONFIG_CLK_COMPOSITE_CCF=y
++CONFIG_CLK_IMX8MN=y
++CONFIG_SPL_CLK_IMX8MN=y
++CONFIG_MXC_GPIO=y
++CONFIG_DM_I2C=y
++CONFIG_SPL_DM_I2C=y
++CONFIG_SYS_I2C_MXC=y
++CONFIG_DM_MMC=y
++CONFIG_MISC=y
++CONFIG_I2C_EEPROM=y
++CONFIG_SUPPORT_EMMC_BOOT=y
++CONFIG_MMC_IO_VOLTAGE=y
++CONFIG_MMC_UHS_SUPPORT=y
++CONFIG_MMC_HS400_ES_SUPPORT=y
++CONFIG_MMC_HS400_SUPPORT=y
++CONFIG_FSL_USDHC=y
++CONFIG_MTD=y
++CONFIG_DM_MTD=y
++CONFIG_DM_SPI_FLASH=y
++CONFIG_SF_DEFAULT_MODE=0x0
++CONFIG_SF_DEFAULT_SPEED=80000000
++CONFIG_SPI_FLASH_BAR=y
++CONFIG_SPI_FLASH_MACRONIX=y
++CONFIG_SPI_FLASH_SPANSION=y
++CONFIG_SPI_FLASH_STMICRO=y
++CONFIG_SPI_FLASH_WINBOND=y
++# CONFIG_SPI_FLASH_USE_4K_SECTORS is not set
++CONFIG_SPI_FLASH_MTD=y
++CONFIG_PHYLIB=y
++CONFIG_PHY_TI_DP83867=y
++CONFIG_DM_ETH=y
++CONFIG_PHY_GIGE=y
++CONFIG_FEC_MXC=y
++CONFIG_MII=y
++CONFIG_PINCTRL=y
++CONFIG_SPL_PINCTRL=y
++CONFIG_PINCTRL_IMX8M=y
++CONFIG_SPL_DM_PMIC=y
++CONFIG_DM_REGULATOR=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_DM_REGULATOR_GPIO=y
++CONFIG_MXC_UART=y
++CONFIG_SPI=y
++CONFIG_DM_SPI=y
++CONFIG_NXP_FSPI=y
++CONFIG_SYSRESET=y
++CONFIG_SPL_SYSRESET=y
++CONFIG_SYSRESET_PSCI=y
++CONFIG_SYSRESET_WATCHDOG=y
++CONFIG_DM_THERMAL=y
++CONFIG_IMX_TMU=y
++CONFIG_USB=y
++CONFIG_DM_USB=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_GADGET=y
++CONFIG_USB_GADGET_MANUFACTURER="FSL"
++CONFIG_USB_GADGET_VENDOR_NUM=0x525
++CONFIG_USB_GADGET_PRODUCT_NUM=0xa4a5
++CONFIG_CI_UDC=y
++CONFIG_IMX_WATCHDOG=y
++CONFIG_OF_LIBFDT_OVERLAY=y
+diff --git a/configs/phycore-imx8mp_defconfig b/configs/phycore-imx8mp_defconfig
+index 2391aa49141..9623b84a783 100644
+--- a/configs/phycore-imx8mp_defconfig
++++ b/configs/phycore-imx8mp_defconfig
+@@ -13,12 +13,13 @@ CONFIG_DM_GPIO=y
+ CONFIG_DEFAULT_DEVICE_TREE="imx8mp-phyboard-pollux-rdk"
+ CONFIG_SPL_TEXT_BASE=0x920000
+ CONFIG_TARGET_PHYCORE_IMX8MP=y
++CONFIG_PHYTEC_SOM_DETECTION=y
+ CONFIG_SPL_MMC=y
+ CONFIG_SPL_SERIAL=y
+ CONFIG_SPL_DRIVERS_MISC=y
+ CONFIG_SPL=y
+ CONFIG_SPL_IMX_ROMAPI_LOADADDR=0x48000000
+-CONFIG_SYS_LOAD_ADDR=0x40480000
++CONFIG_SYS_LOAD_ADDR=0x58000000
+ CONFIG_FIT=y
+ CONFIG_FIT_EXTERNAL_OFFSET=0x3000
+ CONFIG_SPL_LOAD_FIT=y
+@@ -39,6 +40,7 @@ CONFIG_SPL_POWER=y
+ CONFIG_SPL_WATCHDOG=y
+ CONFIG_HUSH_PARSER=y
+ CONFIG_SYS_PROMPT="u-boot=> "
++CONFIG_CMD_ERASEENV=y
+ # CONFIG_CMD_EXPORTENV is not set
+ # CONFIG_CMD_IMPORTENV is not set
+ # CONFIG_CMD_CRC32 is not set
+@@ -65,6 +67,7 @@ CONFIG_OF_CONTROL=y
+ CONFIG_SPL_OF_CONTROL=y
+ CONFIG_ENV_OVERWRITE=y
+ CONFIG_ENV_IS_IN_MMC=y
++CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
+ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
+ CONFIG_SYS_MMC_ENV_DEV=2
+ CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
+@@ -76,6 +79,7 @@ CONFIG_MXC_GPIO=y
+ CONFIG_DM_I2C=y
+ # CONFIG_SPL_DM_I2C is not set
+ CONFIG_SPL_SYS_I2C_LEGACY=y
++CONFIG_DM_MMC=y
+ CONFIG_MISC=y
+ CONFIG_I2C_EEPROM=y
+ CONFIG_SYS_I2C_EEPROM_ADDR=0x51
+@@ -100,6 +104,7 @@ CONFIG_DM_REGULATOR=y
+ CONFIG_DM_REGULATOR_FIXED=y
+ CONFIG_DM_REGULATOR_GPIO=y
+ CONFIG_SPL_POWER_I2C=y
++CONFIG_DM_SERIAL=y
+ CONFIG_MXC_UART=y
+ CONFIG_SYSRESET=y
+ CONFIG_SPL_SYSRESET=y
+diff --git a/doc/board/index.rst b/doc/board/index.rst
+index f7bfc441f7c..6c33bf5f9bd 100644
+--- a/doc/board/index.rst
++++ b/doc/board/index.rst
+@@ -26,6 +26,7 @@ Board-specific doc
+    nokia/index
+    nxp/index
+    openpiton/index
++   phytec/index
+    qualcomm/index
+    rockchip/index
+    samsung/index
+diff --git a/doc/board/phytec/index.rst b/doc/board/phytec/index.rst
+new file mode 100644
+index 00000000000..a5b442045ed
+--- /dev/null
++++ b/doc/board/phytec/index.rst
+@@ -0,0 +1,10 @@
++.. SPDX-License-Identifier: GPL-2.0+
++
++PHYTEC
++======
++
++.. toctree::
++   :maxdepth: 2
++
++   phycore-imx8mm
++   phycore-imx8mp
+diff --git a/doc/board/phytec/phycore-imx8mm.rst b/doc/board/phytec/phycore-imx8mm.rst
+new file mode 100644
+index 00000000000..e9dc2259907
+--- /dev/null
++++ b/doc/board/phytec/phycore-imx8mm.rst
+@@ -0,0 +1,60 @@
++.. SPDX-License-Identifier: GPL-2.0+
++
++phyCORE-i.MX 8M Mini
++====================
++
++The phyCORE-i.MX 8M Mini with 2GB of main memory is supported.
++
++Quick Start
++-----------
++
++- Build the ARM Trusted firmware binary
++- Get ddr firmware
++- Build U-Boot
++- Boot
++
++Build the ARM Trusted firmware binary
++-------------------------------------
++
++.. code-block:: bash
++
++   $ git clone https://git.trustedfirmware.org/TF-A/trusted-firmware-a.git
++   $ cd trusted-firmware-a
++   $ export CROSS_COMPILE=aarch64-linux-gnu
++   $ export IMX_BOOT_UART_BASE=0x30880000
++   $ make PLAT=imx8mm bl31
++
++Get the ddr firmware
++--------------------
++
++.. code-block:: bash
++
++   $ wget https://www.nxp.com/lgfiles/NMG/MAD/YOCTO/firmware-imx-8.19.bin
++   $ chmod +x firmware-imx-8.19.bin
++   $ ./firmware-imx-8.19.bin
++
++Build U-Boot for SD card
++------------------------
++
++Copy binaries
++^^^^^^^^^^^^^
++
++.. code-block:: bash
++
++   $ cp <TF-A dir>/build/imx8mm/release/bl31.bin .
++   $ cp firmware-imx-8.19/firmware/ddr/synopsys/lpddr4*.bin .
++
++Build U-Boot
++^^^^^^^^^^^^
++
++.. code-block:: bash
++
++   $ make phycore-imx8mm_defconfig
++   $ make flash.bin
++
++Flash SD card
++^^^^^^^^^^^^^
++
++.. code-block:: bash
++
++   $ sudo dd if=flash.bin of=/dev/sd[x] bs=1024 seek=33 conv=sync
+diff --git a/doc/board/phytec/phycore-imx8mp.rst b/doc/board/phytec/phycore-imx8mp.rst
+new file mode 100644
+index 00000000000..fda751aeffb
+--- /dev/null
++++ b/doc/board/phytec/phycore-imx8mp.rst
+@@ -0,0 +1,60 @@
++.. SPDX-License-Identifier: GPL-2.0+
++
++phyCORE-i.MX 8M Plus
++====================
++
++The phyCORE-i.MX 8M Plus with 2GB of main memory is supported.
++
++Quick Start
++-----------
++
++- Build the ARM Trusted firmware binary
++- Get ddr firmware
++- Build U-Boot
++- Boot
++
++Build the ARM Trusted firmware binary
++-------------------------------------
++
++.. code-block:: bash
++
++   $ git clone https://git.trustedfirmware.org/TF-A/trusted-firmware-a.git
++   $ cd trusted-firmware-a
++   $ export CROSS_COMPILE=aarch64-linux-gnu
++   $ export IMX_BOOT_UART_BASE=0x30860000
++   $ make PLAT=imx8mp bl31
++
++Get the ddr firmware
++--------------------
++
++.. code-block:: bash
++
++   $ wget https://www.nxp.com/lgfiles/NMG/MAD/YOCTO/firmware-imx-8.19.bin
++   $ chmod +x firmware-imx-8.19.bin
++   $ ./firmware-imx-8.19.bin
++
++Build U-Boot for SD card
++------------------------
++
++Copy binaries
++^^^^^^^^^^^^^
++
++.. code-block:: bash
++
++   $ cp <TF-A dir>/build/imx8mp/release/bl31.bin .
++   $ cp firmware-imx-8.19/firmware/ddr/synopsys/lpddr4*.bin .
++
++Build U-Boot
++^^^^^^^^^^^^
++
++.. code-block:: bash
++
++   $ make phycore-imx8mp_defconfig
++   $ make flash.bin
++
++Flash SD card
++^^^^^^^^^^^^^
++
++.. code-block:: bash
++
++   $ sudo dd if=flash.bin of=/dev/sd[x] bs=1024 seek=32 conv=sync
+diff --git a/drivers/ddr/imx/imx8m/ddr_init.c b/drivers/ddr/imx/imx8m/ddr_init.c
+index d64edc57be0..16341c9891a 100644
+--- a/drivers/ddr/imx/imx8m/ddr_init.c
++++ b/drivers/ddr/imx/imx8m/ddr_init.c
+@@ -16,14 +16,31 @@ static unsigned int g_cdd_rw_max[4];
+ static unsigned int g_cdd_wr_max[4];
+ static unsigned int g_cdd_ww_max[4];
+ 
++bool imx8m_ddr_old_spreadsheet = true;
++
+ void ddr_cfg_umctl2(struct dram_cfg_param *ddrc_cfg, int num)
+ {
+ 	int i = 0;
+ 
+ 	for (i = 0; i < num; i++) {
++		if (ddrc_cfg->reg == DDRC_ADDRMAP7(0))
++			imx8m_ddr_old_spreadsheet = false;
+ 		reg32_write(ddrc_cfg->reg, ddrc_cfg->val);
+ 		ddrc_cfg++;
+ 	}
++
++	/*
++	 * Older NXP DDR configuration spreadsheets don't initialize ADDRMAP7,
++	 * which falsifies the memory size read back from the controller
++	 */
++	if (imx8m_ddr_old_spreadsheet) {
++		pr_warn("Working around old spreadsheet. Please regenerate\n");
++		/*
++		 * Alternatively, stick { DDRC_ADDRMAP7(0), 0xf0f } into
++		 * struct dram_timing_info::ddrc_cfg of your old timing file
++		 */
++		reg32_write(DDRC_ADDRMAP7(0), 0xf0f);
++	}
+ }
+ 
+ #ifdef CONFIG_IMX8M_DRAM_INLINE_ECC
+diff --git a/drivers/ddr/imx/phy/helper.c b/drivers/ddr/imx/phy/helper.c
+index 43b40a8029c..f10a29dd56f 100644
+--- a/drivers/ddr/imx/phy/helper.c
++++ b/drivers/ddr/imx/phy/helper.c
+@@ -155,6 +155,12 @@ void dram_config_save(struct dram_timing_info *timing_info,
+ 		cfg++;
+ 	}
+ 
++	if (imx8m_ddr_old_spreadsheet) {
++		cfg->reg = DDRC_ADDRMAP7(0);
++		cfg->val = 0xf0f;
++		cfg++;
++	}
++
+ 	/* save ddrphy config */
+ 	saved_timing->ddrphy_cfg = cfg;
+ 	for (i = 0; i < timing_info->ddrphy_cfg_num; i++) {
+diff --git a/include/configs/phycore_imx8mm.h b/include/configs/phycore_imx8mm.h
+index 7438d0a4647..235ecbfbd15 100644
+--- a/include/configs/phycore_imx8mm.h
++++ b/include/configs/phycore_imx8mm.h
+@@ -35,13 +35,16 @@
+ 	"console=ttymxc2,115200\0" \
+ 	"fdt_addr=0x48000000\0" \
+ 	"fdt_file=" CONFIG_DEFAULT_FDT_FILE "\0" \
+-	"ip_dyn=yes\0" \
++	"ipaddr=192.168.3.11\0" \
++	"serverip=192.168.3.10\0" \
++	"netmask=255.255.255.0\0" \
++	"ip_dyn=no\0" \
+ 	"mmcdev=" __stringify(CONFIG_SYS_MMC_ENV_DEV) "\0" \
+ 	"mmcpart=1\0" \
+ 	"mmcroot=2\0" \
+ 	"mmcautodetect=yes\0" \
+ 	"mmcargs=setenv bootargs console=${console} " \
+-		"root=/dev/mmcblk${mmcdev}p${mmcroot} rootwait rw\0" \
++		"root=/dev/mmcblk${mmcdev}p${mmcroot} fsck.repair=yes rootwait rw \0" \
+ 	"loadimage=fatload mmc ${mmcdev}:${mmcpart} ${loadaddr} ${image}\0" \
+ 	"loadfdt=fatload mmc ${mmcdev}:${mmcpart} ${fdt_addr} ${fdt_file}\0" \
+ 	"mmcboot=echo Booting from mmc ...; " \
+@@ -52,15 +55,17 @@
+ 			"echo WARN: Cannot load the DT; " \
+ 		"fi;\0 " \
+ 	"nfsroot=/nfs\0" \
+-	"netargs=setenv bootargs console=${console} root=/dev/nfs ip=dhcp " \
++	"netargs=setenv bootargs console=${console} root=/dev/nfs ip=${nfsip} " \
+ 		"nfsroot=${serverip}:${nfsroot},v3,tcp\0" \
+ 	"netboot=echo Booting from net ...; " \
+-		"run netargs; " \
+ 		"if test ${ip_dyn} = yes; then " \
++			"setenv nfsip dhcp; " \
+ 			"setenv get_cmd dhcp; " \
+ 		"else " \
++			"setenv nfsip ${ipaddr}:${serverip}::${netmask}::eth0:on; " \
+ 			"setenv get_cmd tftp; " \
+ 		"fi; " \
++		"run netargs; " \
+ 		"${get_cmd} ${loadaddr} ${image}; " \
+ 		"if ${get_cmd} ${fdt_addr} ${fdt_file}; then " \
+ 			"booti ${loadaddr} - ${fdt_addr}; " \
+@@ -82,10 +87,9 @@
+ #define CONFIG_SYS_SDRAM_BASE		0x40000000
+ 
+ #define PHYS_SDRAM			0x40000000
+-#define PHYS_SDRAM_SIZE                 SZ_2G /* 2GB DDR */
+-
+-/* UART */
+-#define CONFIG_MXC_UART_BASE		UART3_BASE_ADDR
++#define PHYS_SDRAM_SIZE			0xC0000000 /* 3GB */
++#define PHYS_SDRAM_2			0x100000000
++#define PHYS_SDRAM_2_SIZE		SZ_1G
+ 
+ /* Monitor Command Prompt */
+ #define CONFIG_SYS_CBSIZE		SZ_2K
+diff --git a/include/configs/phycore_imx8mn.h b/include/configs/phycore_imx8mn.h
+new file mode 100644
+index 00000000000..95cda3006a5
+--- /dev/null
++++ b/include/configs/phycore_imx8mn.h
+@@ -0,0 +1,105 @@
++/* SPDX-License-Identifier: GPL-2.0-or-later
++ *
++ * Copyright (C) 2019-2020 PHYTEC Messtechnik GmbH
++ * Author: Teresa Remmet <t.remmet@phytec.de>
++ */
++
++#ifndef __PHYCORE_IMX8MN_H
++#define __PHYCORE_IMX8MN_H
++
++#include <linux/sizes.h>
++#include <linux/stringify.h>
++#include <asm/arch/imx-regs.h>
++
++#define CONFIG_SYS_BOOTM_LEN		SZ_64M
++#define CONFIG_SPL_MAX_SIZE		(148 * SZ_1K)
++#define CONFIG_SYS_MONITOR_LEN		SZ_512K
++#define CONFIG_SYS_UBOOT_BASE \
++	(QSPI0_AMBA_BASE + CONFIG_SYS_MMCSD_RAW_MODE_U_BOOT_SECTOR * 512)
++
++#ifdef CONFIG_SPL_BUILD
++#define CONFIG_SPL_STACK		0x95dff0
++#define CONFIG_SPL_BSS_START_ADDR	0x95e000
++#define CONFIG_MALLOC_F_ADDR		0x970000
++#define CONFIG_SPL_BSS_MAX_SIZE		SZ_8K	/* 8 KB */
++#define CONFIG_SYS_SPL_MALLOC_START	0x42200000
++#define CONFIG_SYS_SPL_MALLOC_SIZE	SZ_512K	/* 512 KB */
++
++/* For RAW image gives a error info not panic */
++#define CONFIG_SPL_ABORT_ON_RAW_IMAGE
++#endif /* CONFIG_SPL_BUILD */
++
++#define CONFIG_EXTRA_ENV_SETTINGS \
++	"image=Image\0" \
++	"console=ttymxc2,115200\0" \
++	"fdt_addr=0x48000000\0" \
++	"fdt_file=" CONFIG_DEFAULT_FDT_FILE "\0" \
++	"ipaddr=192.168.3.11\0" \
++	"serverip=192.168.3.10\0" \
++	"netmask=255.255.255.0\0" \
++	"ip_dyn=no\0" \
++	"mmcdev=" __stringify(CONFIG_SYS_MMC_ENV_DEV) "\0" \
++	"mmcpart=1\0" \
++	"mmcroot=2\0" \
++	"mmcautodetect=yes\0" \
++	"mmcargs=setenv bootargs console=${console} " \
++		"root=/dev/mmcblk${mmcdev}p${mmcroot} rootwait rw\0" \
++	"loadimage=fatload mmc ${mmcdev}:${mmcpart} ${loadaddr} ${image}\0" \
++	"loadfdt=fatload mmc ${mmcdev}:${mmcpart} ${fdt_addr} ${fdt_file}\0" \
++	"mmcboot=echo Booting from mmc ...; " \
++		"run mmcargs; " \
++		"if run loadfdt; then " \
++			"booti ${loadaddr} - ${fdt_addr}; " \
++		"else " \
++			"echo WARN: Cannot load the DT; " \
++		"fi;\0 " \
++	"nfsroot=/nfs\0" \
++	"netargs=setenv bootargs console=${console} root=/dev/nfs ip=${nfsip} " \
++		"nfsroot=${serverip}:${nfsroot},v3,tcp\0" \
++	"netboot=echo Booting from net ...; " \
++		"if test ${ip_dyn} = yes; then " \
++			"setenv nfsip dhcp; " \
++			"setenv get_cmd dhcp; " \
++		"else " \
++			"setenv nfsip ${ipaddr}:${serverip}::${netmask}::eth0:on; " \
++			"setenv get_cmd tftp; " \
++		"fi; " \
++		"run netargs; " \
++		"${get_cmd} ${loadaddr} ${image}; " \
++		"if ${get_cmd} ${fdt_addr} ${fdt_file}; then " \
++			"booti ${loadaddr} - ${fdt_addr}; " \
++		"else " \
++			"echo WARN: Cannot load the DT; " \
++		"fi;\0" \
++
++/* Link Definitions */
++#define CONFIG_SYS_INIT_RAM_ADDR	0x40000000
++#define CONFIG_SYS_INIT_RAM_SIZE	SZ_512K
++#define CONFIG_SYS_INIT_SP_OFFSET \
++	(CONFIG_SYS_INIT_RAM_SIZE - GENERATED_GBL_DATA_SIZE)
++#define CONFIG_SYS_INIT_SP_ADDR \
++	(CONFIG_SYS_INIT_RAM_ADDR + CONFIG_SYS_INIT_SP_OFFSET)
++
++#define CONFIG_MMCROOT			"/dev/mmcblk2p2"  /* USDHC3 */
++
++/* Size of malloc() pool */
++#define CONFIG_SYS_SDRAM_BASE		0x40000000
++
++#define PHYS_SDRAM			0x40000000
++#define PHYS_SDRAM_SIZE			SZ_1G
++
++/* UART */
++#define CONFIG_MXC_UART_BASE		UART3_BASE_ADDR
++
++/* Monitor Command Prompt */
++#define CONFIG_SYS_CBSIZE		SZ_2K
++#define CONFIG_SYS_MAXARGS		64
++#define CONFIG_SYS_BARGSIZE		CONFIG_SYS_CBSIZE
++/* USDHC */
++#define CONFIG_SYS_FSL_USDHC_NUM	2
++#define CONFIG_SYS_FSL_ESDHC_ADDR       0
++
++/* I2C */
++#define CONFIG_SYS_I2C_SPEED		100000
++
++#endif /* __PHYCORE_IMX8MN_H */
+diff --git a/include/configs/phycore_imx8mp.h b/include/configs/phycore_imx8mp.h
+index 8c5ffeef544..92fb436681d 100644
+--- a/include/configs/phycore_imx8mp.h
++++ b/include/configs/phycore_imx8mp.h
+@@ -35,13 +35,16 @@
+ 	"console=ttymxc0,115200\0" \
+ 	"fdt_addr=0x48000000\0" \
+ 	"fdt_file=" CONFIG_DEFAULT_FDT_FILE "\0" \
+-	"ip_dyn=yes\0" \
++	"ipaddr=192.168.3.11\0" \
++	"serverip=192.168.3.10\0" \
++	"netmask=255.255.255.0\0" \
++	"ip_dyn=no\0" \
+ 	"mmcdev=" __stringify(CONFIG_SYS_MMC_ENV_DEV) "\0" \
+ 	"mmcpart=1\0" \
+ 	"mmcroot=2\0" \
+ 	"mmcautodetect=yes\0" \
+ 	"mmcargs=setenv bootargs console=${console} " \
+-		"root=/dev/mmcblk${mmcdev}p${mmcroot} rootwait rw\0" \
++		"root=/dev/mmcblk${mmcdev}p${mmcroot} fsck.repair=yes rootwait rw\0" \
+ 	"loadimage=fatload mmc ${mmcdev}:${mmcpart} ${loadaddr} ${image}\0" \
+ 	"loadfdt=fatload mmc ${mmcdev}:${mmcpart} ${fdt_addr} ${fdt_file}\0" \
+ 	"mmcboot=echo Booting from mmc ...; " \
+@@ -52,15 +55,17 @@
+ 			"echo WARN: Cannot load the DT; " \
+ 		"fi;\0 " \
+ 	"nfsroot=/nfs\0" \
+-	"netargs=setenv bootargs console=${console} root=/dev/nfs ip=dhcp " \
++	"netargs=setenv bootargs console=${console} root=/dev/nfs ip=${nfsip} " \
+ 		"nfsroot=${serverip}:${nfsroot},v3,tcp\0" \
+ 	"netboot=echo Booting from net ...; " \
+-		"run netargs; " \
+ 		"if test ${ip_dyn} = yes; then " \
++			"setenv nfsip dhcp; " \
+ 			"setenv get_cmd dhcp; " \
+ 		"else " \
++			"setenv nfsip ${ipaddr}:${serverip}::${netmask}::eth0:on; " \
+ 			"setenv get_cmd tftp; " \
+ 		"fi; " \
++		"run netargs; " \
+ 		"${get_cmd} ${loadaddr} ${image}; " \
+ 		"if ${get_cmd} ${fdt_addr} ${fdt_file}; then " \
+ 			"booti ${loadaddr} - ${fdt_addr}; " \
+@@ -82,10 +87,9 @@
+ #define CONFIG_SYS_SDRAM_BASE		0x40000000
+ 
+ #define PHYS_SDRAM			0x40000000
+-#define PHYS_SDRAM_SIZE			0x80000000
+-
+-/* UART */
+-#define CONFIG_MXC_UART_BASE		UART1_BASE_ADDR
++#define PHYS_SDRAM_SIZE			0xC0000000 /* 3GB */
++#define PHYS_SDRAM_2			0x100000000
++#define PHYS_SDRAM_2_SIZE		SZ_1G
+ 
+ /* Monitor Command Prompt */
+ #define CONFIG_SYS_CBSIZE		SZ_2K
+diff --git a/lib/Kconfig b/lib/Kconfig
+index acd3d51bc96..2e8c51034e9 100644
+--- a/lib/Kconfig
++++ b/lib/Kconfig
+@@ -352,6 +352,7 @@ config TPM
+ config SPL_TPM
+ 	bool "Trusted Platform Module (TPM) Support in SPL"
+ 	depends on SPL_DM
++	imply SPL_CRC8
+ 	help
+ 	  This enables support for TPMs which can be used to provide security
+ 	  features for your board. The TPM can be connected via LPC or I2C
+@@ -567,6 +568,23 @@ config SPL_MD5
+ 	  security applications, but it can be useful for providing a quick
+ 	  checksum of a block of data.
+ 
++config CRC8
++	def_bool y
++	help
++	  Enables CRC8 support in U-Boot. This is normally required. CRC8 is
++	  a simple and fast checksumming algorithm which does a bytewise
++	  checksum with feedback to produce an 8-bit result. The code is small
++	  and it does not require a lookup table (unlike CRC32).
++
++config SPL_CRC8
++	bool "Support CRC8 in SPL"
++	depends on SPL
++	help
++	  Enables CRC8 support in SPL. This is not normally required. CRC8 is
++	  a simple and fast checksumming algorithm which does a bytewise
++	  checksum with feedback to produce an 8-bit result. The code is small
++	  and it does not require a lookup table (unlike CRC32).
++
+ config CRC32
+ 	def_bool y
+ 	help
+diff --git a/lib/Makefile b/lib/Makefile
+index 632dcba8695..a23c53cd07c 100644
+--- a/lib/Makefile
++++ b/lib/Makefile
+@@ -37,7 +37,6 @@ else
+ obj-$(CONFIG_CIRCBUF) += circbuf.o
+ endif
+ 
+-obj-y += crc8.o
+ obj-y += crc16.o
+ obj-$(CONFIG_ERRNO_STR) += errno_str.o
+ obj-$(CONFIG_FIT) += fdtdec_common.o
+@@ -59,12 +58,13 @@ endif
+ 
+ obj-$(CONFIG_$(SPL_TPL_)TPM) += tpm-common.o
+ ifeq ($(CONFIG_$(SPL_TPL_)TPM),y)
+-obj-y += crc8.o
+ obj-$(CONFIG_TPM) += tpm_api.o
+ obj-$(CONFIG_TPM_V1) += tpm-v1.o
+ obj-$(CONFIG_TPM_V2) += tpm-v2.o
+ endif
+ 
++obj-$(CONFIG_$(SPL_TPL_)CRC8) += crc8.o
++
+ obj-$(CONFIG_$(SPL_TPL_)GENERATE_ACPI_TABLE) += acpi/
+ obj-$(CONFIG_$(SPL_)MD5) += md5.o
+ obj-$(CONFIG_ECDSA) += ecdsa/
+diff --git a/tools/.gitignore b/tools/.gitignore
+index a88453f64da..5b7b13330de 100644
+--- a/tools/.gitignore
++++ b/tools/.gitignore
+@@ -28,6 +28,7 @@
+ /mxsboot
+ /ncb
+ /prelink-riscv
++/printinitialenv
+ /proftool
+ /relocate-rela
+ /spl_size_limit
+diff --git a/tools/Makefile b/tools/Makefile
+index 60231c728ce..10dce12f62f 100644
+--- a/tools/Makefile
++++ b/tools/Makefile
+@@ -264,6 +264,10 @@ clean-dirs := lib common
+ 
+ always := $(hostprogs-y)
+ 
++# Host tool to dump the currently configured default environment,
++# build it on demand, i.e. not add it to 'always'.
++hostprogs-y += printinitialenv
++
+ # Generated LCD/video logo
+ LOGO_H = $(objtree)/include/bmp_logo.h
+ LOGO_DATA_H = $(objtree)/include/bmp_logo_data.h
+diff --git a/tools/printinitialenv.c b/tools/printinitialenv.c
+new file mode 100644
+index 00000000000..c58b234d679
+--- /dev/null
++++ b/tools/printinitialenv.c
+@@ -0,0 +1,44 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * (C) Copyright 2022
++ * Max Krummenacher, Toradex
++ *
++ * Snippets taken from tools/env/fw_env.c
++ *
++ * This prints the list of default environment variables as currently
++ * configured.
++ *
++ */
++
++#include <stdio.h>
++
++/* Pull in the current config to define the default environment */
++#include <linux/kconfig.h>
++
++#ifndef __ASSEMBLY__
++#define __ASSEMBLY__ /* get only #defines from config.h */
++#include <config.h>
++#undef	__ASSEMBLY__
++#else
++#include <config.h>
++#endif
++
++#define DEFAULT_ENV_INSTANCE_STATIC
++#include <generated/environment.h>
++#include <env_default.h>
++
++int main(void)
++{
++	char *env, *nxt;
++
++	for (env = default_environment; *env; env = nxt + 1) {
++		for (nxt = env; *nxt; ++nxt) {
++			if (nxt >= &default_environment[sizeof(default_environment)]) {
++				fprintf(stderr, "## Error: environment not terminated\n");
++				return -1;
++			}
++		}
++		printf("%s\n", env);
++	}
++	return 0;
++}
+-- 
+2.40.1
+

--- a/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0002-Revert-LFU-278-20-imx8m-Disable-BINMAN-for-iMX8M-EVK.patch
+++ b/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0002-Revert-LFU-278-20-imx8m-Disable-BINMAN-for-iMX8M-EVK.patch
@@ -1,7 +1,8 @@
-From 39f5340e0916c949ed1ddad662b0523362e45bbf Mon Sep 17 00:00:00 2001
+From 80b9b9e6b2921c6341c8ccb63be7f53eb0de4a78 Mon Sep 17 00:00:00 2001
 From: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>
 Date: Wed, 2 Nov 2022 16:34:15 -0100
-Subject: [PATCH] Revert "LFU-278-20 imx8m: Disable BINMAN for iMX8M EVK build"
+Subject: [PATCH 02/25] Revert "LFU-278-20 imx8m: Disable BINMAN for iMX8M EVK
+ build"
 
 This reverts commit d955c2248dd12f5c0d6afd3cf0ba1a013ed39646.
 ---
@@ -9,7 +10,7 @@ This reverts commit d955c2248dd12f5c0d6afd3cf0ba1a013ed39646.
  1 file changed, 3 insertions(+)
 
 diff --git a/arch/arm/mach-imx/imx8m/Kconfig b/arch/arm/mach-imx/imx8m/Kconfig
-index 456073873d..67e600453a 100644
+index d7edf88a655..a732da8f050 100644
 --- a/arch/arm/mach-imx/imx8m/Kconfig
 +++ b/arch/arm/mach-imx/imx8m/Kconfig
 @@ -66,6 +66,7 @@ config TARGET_IMX8MQ_CM
@@ -28,7 +29,7 @@ index 456073873d..67e600453a 100644
  	select IMX8MM
  	select SUPPORT_SPL
  	select IMX8M_LPDDR4
-@@ -188,6 +190,7 @@ config TARGET_IMX8MN_VENICE
+@@ -233,6 +235,7 @@ config TARGET_IMX8MN_VENICE
  
  config TARGET_IMX8MP_EVK
  	bool "imx8mp LPDDR4 EVK board"
@@ -37,5 +38,5 @@ index 456073873d..67e600453a 100644
  	select SUPPORT_SPL
  	select IMX8M_LPDDR4
 -- 
-2.25.1
+2.40.1
 

--- a/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0003-borad-imx8mq-evk-add-smbios-dt-node-and-config.patch
+++ b/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0003-borad-imx8mq-evk-add-smbios-dt-node-and-config.patch
@@ -1,7 +1,7 @@
-From 3209fb3d95ed82421c7d969688758e8645fab851 Mon Sep 17 00:00:00 2001
+From 1d7cba03de2d7d8d4e06a89b2dc302ae2f1f8265 Mon Sep 17 00:00:00 2001
 From: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>
 Date: Wed, 2 Nov 2022 23:06:20 -0100
-Subject: [PATCH] borad: imx8mq-evk: add smbios dt node and config
+Subject: [PATCH 03/25] borad: imx8mq-evk: add smbios dt node and config
 
 Signed-off-by: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>
 ---
@@ -10,14 +10,13 @@ Signed-off-by: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>
  2 files changed, 20 insertions(+)
 
 diff --git a/arch/arm/dts/imx8mq-evk.dts b/arch/arm/dts/imx8mq-evk.dts
-index de709088e5..9ad98bcd6e 100644
+index de709088e51..9af5b695360 100644
 --- a/arch/arm/dts/imx8mq-evk.dts
 +++ b/arch/arm/dts/imx8mq-evk.dts
-@@ -11,6 +11,24 @@
- / {
+@@ -12,6 +12,24 @@
  	model = "NXP i.MX8MQ EVK";
  	compatible = "fsl,imx8mq-evk", "fsl,imx8mq";
-+
+ 
 +	sysinfo {
 +		compatible = "u-boot,sysinfo-smbios";
 +		smbios {
@@ -35,19 +34,20 @@ index de709088e5..9ad98bcd6e 100644
 +			};
 +		};
 +	};
- 
++
  	chosen {
  		bootargs = "console=ttymxc0,115200 earlycon=ec_imx6q,0x30860000,115200";
+ 		stdout-path = &uart1;
 diff --git a/configs/imx8mq_evk_defconfig b/configs/imx8mq_evk_defconfig
-index dc2c5003f2..802fa920de 100644
+index 51f24980ccc..307a2a4202a 100644
 --- a/configs/imx8mq_evk_defconfig
 +++ b/configs/imx8mq_evk_defconfig
-@@ -169,3 +169,5 @@ CONFIG_TEE=y
+@@ -170,3 +170,5 @@ CONFIG_TEE=y
  CONFIG_EFI_ESRT=y
  CONFIG_EFI_HAVE_CAPSULE_UPDATE=y
  CONFIG_FIT_SIGNATURE=y
 +CONFIG_SYSINFO=y
 +CONFIG_SYSINFO_SMBIOS=y
 -- 
-2.25.1
+2.40.1
 

--- a/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0004-arch-arm-dts-imx8mq-evk-add-fdt-kernel-node-to-binma.patch
+++ b/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0004-arch-arm-dts-imx8mq-evk-add-fdt-kernel-node-to-binma.patch
@@ -1,8 +1,8 @@
-From fe9962e501632b58e04c896a523140fd8acb1312 Mon Sep 17 00:00:00 2001
+From e1cf0e912a8ca47ea42776f78e2fce705a735c87 Mon Sep 17 00:00:00 2001
 From: Insei <goodmobiledevices@gmail.com>
 Date: Thu, 8 Dec 2022 05:38:41 +0300
-Subject: [PATCH] arch: arm: dts: imx8mq-evk: add fdt-kernel node to binman
- configuration
+Subject: [PATCH 04/25] arch: arm: dts: imx8mq-evk: add fdt-kernel node to
+ binman configuration
 
 Signed-off-by: Insei <goodmobiledevices@gmail.com>
 ---
@@ -10,14 +10,13 @@ Signed-off-by: Insei <goodmobiledevices@gmail.com>
  1 file changed, 13 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm/dts/imx8mq-u-boot.dtsi b/arch/arm/dts/imx8mq-u-boot.dtsi
-index 1dc060ce0c..408b0cc8d8 100644
+index 1dc060ce0c2..e91b4d785f4 100644
 --- a/arch/arm/dts/imx8mq-u-boot.dtsi
 +++ b/arch/arm/dts/imx8mq-u-boot.dtsi
-@@ -103,6 +103,18 @@
- 						type = "blob-ext";
+@@ -104,6 +104,18 @@
  					};
  				};
-+
+ 
 +				fdt-kernel {
 +					compression = "none";
 +					description = "NAME";
@@ -29,9 +28,10 @@ index 1dc060ce0c..408b0cc8d8 100644
 +						type = "blob-ext";
 +					};
 +				};
- 
++
  				fdt {
  					compression = "none";
+ 					description = "NAME";
 @@ -123,7 +135,7 @@
  					description = "NAME";
  					fdt = "fdt";
@@ -42,5 +42,5 @@ index 1dc060ce0c..408b0cc8d8 100644
  			};
  		};
 -- 
-2.34.1
+2.40.1
 

--- a/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0005-imx8mq_evk-simple-framebuffer-dt-node-initialization.patch
+++ b/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0005-imx8mq_evk-simple-framebuffer-dt-node-initialization.patch
@@ -1,8 +1,8 @@
-From 21424076af911f57dea49ed7c1d03ec0bd339a51 Mon Sep 17 00:00:00 2001
+From 5f56058c71fb83f364ee87ecc6bcd6449d049564 Mon Sep 17 00:00:00 2001
 From: Insei <goodmobiledevices@gmail.com>
 Date: Thu, 8 Dec 2022 05:41:40 +0300
-Subject: [PATCH] imx8mq_evk: simple-framebuffer dt node initialization at
- ft_board_setup
+Subject: [PATCH 05/25] imx8mq_evk: simple-framebuffer dt node initialization
+ at ft_board_setup
 
 Signed-off-by: Insei <goodmobiledevices@gmail.com>
 ---
@@ -11,10 +11,10 @@ Signed-off-by: Insei <goodmobiledevices@gmail.com>
  2 files changed, 14 insertions(+)
 
 diff --git a/board/freescale/imx8mq_evk/imx8mq_evk.c b/board/freescale/imx8mq_evk/imx8mq_evk.c
-index 81a961883f..499ad1f4ee 100644
+index f470e6c7f50..89ff150ef67 100644
 --- a/board/freescale/imx8mq_evk/imx8mq_evk.c
 +++ b/board/freescale/imx8mq_evk/imx8mq_evk.c
-@@ -29,6 +29,8 @@
+@@ -30,6 +30,8 @@
  #include "../common/pfuze.h"
  #include <usb.h>
  #include <dwc3-uboot.h>
@@ -23,7 +23,7 @@ index 81a961883f..499ad1f4ee 100644
  
  DECLARE_GLOBAL_DATA_PTR;
  
-@@ -280,6 +282,16 @@ int board_late_init(void)
+@@ -298,6 +300,16 @@ int board_late_init(void)
  	return 0;
  }
  
@@ -41,7 +41,7 @@ index 81a961883f..499ad1f4ee 100644
  bool is_power_key_pressed(void) {
  	return (bool)(!!(readl(SNVS_HPSR) & (0x1 << 6)));
 diff --git a/configs/imx8mq_evk_defconfig b/configs/imx8mq_evk_defconfig
-index cf1c1f1c26..c0c894b557 100644
+index 307a2a4202a..ce900ef7390 100644
 --- a/configs/imx8mq_evk_defconfig
 +++ b/configs/imx8mq_evk_defconfig
 @@ -33,6 +33,7 @@ CONFIG_FIT_EXTERNAL_OFFSET=0x3000
@@ -52,7 +52,7 @@ index cf1c1f1c26..c0c894b557 100644
  CONFIG_BOARD_EARLY_INIT_F=y
  CONFIG_BOARD_LATE_INIT=y
  CONFIG_SPL_BOARD_INIT=y
-@@ -146,6 +147,7 @@ CONFIG_VIDEO_LOGO=y
+@@ -147,6 +148,7 @@ CONFIG_VIDEO_LOGO=y
  CONFIG_SYS_WHITE_ON_BLACK=y
  CONFIG_VIDEO_IMX8M_DCSS=y
  CONFIG_VIDEO_IMX8M_HDMI=y
@@ -61,5 +61,5 @@ index cf1c1f1c26..c0c894b557 100644
  CONFIG_SPLASH_SCREEN_ALIGN=y
  CONFIG_LEGACY_IMAGE_FORMAT=y
 -- 
-2.34.1
+2.40.1
 

--- a/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0006-configs-imx8mq-evk-disable-optee-os-We-get-an-error-.patch
+++ b/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0006-configs-imx8mq-evk-disable-optee-os-We-get-an-error-.patch
@@ -1,7 +1,7 @@
-From 3f1bdc167456e9d043541e8d959b7d26eb5af74d Mon Sep 17 00:00:00 2001
+From 1a1e880a8ac0b404d48bff5b05a50c6f9ee3bee7 Mon Sep 17 00:00:00 2001
 From: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>
 Date: Wed, 2 Nov 2022 23:13:03 -0100
-Subject: [PATCH] configs: imx8mq-evk: disable optee-os * We get an error
+Subject: [PATCH 06/25] configs: imx8mq-evk: disable optee-os * We get an error
  initializing the UEFI subsystem in u-boot, if we boot without
  optee-os(trusted execution environment) on bl32, so we will turn off optee
  driver.
@@ -12,10 +12,10 @@ Signed-off-by: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/configs/imx8mq_evk_defconfig b/configs/imx8mq_evk_defconfig
-index 802fa920de..cf1c1f1c26 100644
+index ce900ef7390..c40ae8c0092 100644
 --- a/configs/imx8mq_evk_defconfig
 +++ b/configs/imx8mq_evk_defconfig
-@@ -90,7 +90,7 @@ CONFIG_DM_I2C=y
+@@ -92,7 +92,7 @@ CONFIG_DM_I2C=y
  CONFIG_SPL_SYS_I2C_LEGACY=y
  CONFIG_SYS_I2C_MXC=y
  CONFIG_DM_MMC=y
@@ -24,7 +24,7 @@ index 802fa920de..cf1c1f1c26 100644
  CONFIG_SUPPORT_EMMC_BOOT=y
  CONFIG_MMC_IO_VOLTAGE=y
  CONFIG_MMC_UHS_SUPPORT=y
-@@ -162,8 +162,8 @@ CONFIG_SHA384=y
+@@ -165,8 +165,8 @@ CONFIG_SHA384=y
  CONFIG_EFI_VAR_BUF_SIZE=139264
  CONFIG_EFI_IGNORE_OSINDICATIONS=y
  CONFIG_EFI_CAPSULE_AUTHENTICATE=y
@@ -36,5 +36,5 @@ index 802fa920de..cf1c1f1c26 100644
  CONFIG_TEE=y
  CONFIG_EFI_ESRT=y
 -- 
-2.34.1
+2.40.1
 

--- a/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0007-arm-dts-imx8mp-u-boot-select-correct-bl31.patch
+++ b/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0007-arm-dts-imx8mp-u-boot-select-correct-bl31.patch
@@ -1,7 +1,7 @@
-From 69074cf413469dbb49e146c88556002d8e67703c Mon Sep 17 00:00:00 2001
+From 438cbd87a4dc206baab086b1bb269d41a8d3bbb6 Mon Sep 17 00:00:00 2001
 From: Troy Kisky <troy.kisky@boundarydevices.com>
 Date: Sat, 4 Jun 2022 11:39:19 -0700
-Subject: [PATCH 1/6] arm: dts: imx8mp-u-boot: select correct bl31
+Subject: [PATCH 07/25] arm: dts: imx8mp-u-boot: select correct bl31
 
 Signed-off-by: Troy Kisky <troy.kisky@boundarydevices.com>
 ---
@@ -56,5 +56,5 @@ index 120c4c4dbb1..6d31e206c03 100644
  				};
  			};
 -- 
-2.35.1
+2.40.1
 

--- a/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0008-arm-dts-imx8mp-u-boot-make-offset-reflect-MMC_ENV_PA.patch
+++ b/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0008-arm-dts-imx8mp-u-boot-make-offset-reflect-MMC_ENV_PA.patch
@@ -1,7 +1,8 @@
-From c4f02a3b97ca3fec6de8c08c78b5030b6bb73be3 Mon Sep 17 00:00:00 2001
+From 513a3429b9deab6d802e0cfc52e83d0274d41e19 Mon Sep 17 00:00:00 2001
 From: Troy Kisky <troy.kisky@boundarydevices.com>
 Date: Thu, 8 Sep 2022 16:48:20 -0700
-Subject: [PATCH 2/6] arm: dts: imx8mp-u-boot: make offset reflect MMC_ENV_PART
+Subject: [PATCH 08/25] arm: dts: imx8mp-u-boot: make offset reflect
+ MMC_ENV_PART
 
 Signed-off-by: Troy Kisky <troy.kisky@boundarydevices.com>
 ---
@@ -35,5 +36,5 @@ index 6d31e206c03..9f3beaf1086 100644
  	};
  };
 -- 
-2.35.1
+2.40.1
 

--- a/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0009-arch-arm-dts-Add-SMBIOS-information-for-Phytec-Pollu.patch
+++ b/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0009-arch-arm-dts-Add-SMBIOS-information-for-Phytec-Pollu.patch
@@ -1,7 +1,8 @@
-From fc532a2b79a612cb0eda3c2176045f5347cf084e Mon Sep 17 00:00:00 2001
+From 9ee71fea7e8577c743abb8d24692de26cdb5ed6b Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ren=C3=AA=20de=20Souza=20Pinto?= <rene@renesp.com.br>
 Date: Wed, 4 Jan 2023 19:11:13 +0100
-Subject: [PATCH 3/6] arch: arm: dts: Add SMBIOS information for Phytec Pollux
+Subject: [PATCH 09/25] arch: arm: dts: Add SMBIOS information for Phytec
+ Pollux
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -16,7 +17,7 @@ Signed-off-by: Renê de Souza Pinto <rene@renesp.com.br>
  2 files changed, 20 insertions(+)
 
 diff --git a/arch/arm/dts/imx8mp-phyboard-pollux-rdk.dts b/arch/arm/dts/imx8mp-phyboard-pollux-rdk.dts
-index 984a6b9ded8..5f66e1a5fe0 100644
+index 3083530cd38..3ccc36ada71 100644
 --- a/arch/arm/dts/imx8mp-phyboard-pollux-rdk.dts
 +++ b/arch/arm/dts/imx8mp-phyboard-pollux-rdk.dts
 @@ -15,6 +15,24 @@
@@ -45,15 +46,15 @@ index 984a6b9ded8..5f66e1a5fe0 100644
  		stdout-path = &uart1;
  	};
 diff --git a/configs/phycore-imx8mp_defconfig b/configs/phycore-imx8mp_defconfig
-index 2391aa49141..e38b7a52896 100644
+index 9623b84a783..d563aadc879 100644
 --- a/configs/phycore-imx8mp_defconfig
 +++ b/configs/phycore-imx8mp_defconfig
-@@ -107,3 +107,5 @@ CONFIG_SYSRESET_PSCI=y
+@@ -112,3 +112,5 @@ CONFIG_SYSRESET_PSCI=y
  CONFIG_SYSRESET_WATCHDOG=y
  CONFIG_DM_THERMAL=y
  CONFIG_IMX_WATCHDOG=y
 +CONFIG_SYSINFO=y
 +CONFIG_SYSINFO_SMBIOS=y
 -- 
-2.35.1
+2.40.1
 

--- a/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0010-dts-Add-mcu_rdc-node-to-imx8mp-phyboard-pollux-rdk-u.patch
+++ b/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0010-dts-Add-mcu_rdc-node-to-imx8mp-phyboard-pollux-rdk-u.patch
@@ -1,7 +1,7 @@
-From 35761515e1a2a2dcca15117faaa3dafa45b1d9d5 Mon Sep 17 00:00:00 2001
+From 5e924f26253bf686300bfa115a0f8fb72ae7ba8e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ren=C3=AA=20de=20Souza=20Pinto?= <rene@renesp.com.br>
 Date: Wed, 4 Jan 2023 19:23:04 +0100
-Subject: [PATCH 4/6] dts: Add mcu_rdc node to
+Subject: [PATCH 10/25] dts: Add mcu_rdc node to
  imx8mp-phyboard-pollux-rdk-u-boot.dtsi
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -89,5 +89,5 @@ index dbc48dfb484..78d7512fac5 100644
  
  &reg_usdhc2_vmmc {
 -- 
-2.35.1
+2.40.1
 

--- a/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0011-arm-dts-imx8mp-u-boot-Revert-bl31-filename.patch
+++ b/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0011-arm-dts-imx8mp-u-boot-Revert-bl31-filename.patch
@@ -1,7 +1,7 @@
-From 0f2e1fd5bc5d64538bdc4c04e51db693db3e4c1d Mon Sep 17 00:00:00 2001
+From 1efa5c4525985738cd1400ef0bf94058794eb9fe Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ren=C3=AA=20de=20Souza=20Pinto?= <rene@renesp.com.br>
 Date: Wed, 4 Jan 2023 19:46:56 +0100
-Subject: [PATCH 5/6] arm: dts: imx8mp-u-boot: Revert bl31 filename
+Subject: [PATCH 11/25] arm: dts: imx8mp-u-boot: Revert bl31 filename
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -32,5 +32,5 @@ index 9f3beaf1086..17daef31a27 100644
  					};
  				};
 -- 
-2.35.1
+2.40.1
 

--- a/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0012-configs-phycore-imx8mp-Enable-GPT-EFI-partition-supp.patch
+++ b/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0012-configs-phycore-imx8mp-Enable-GPT-EFI-partition-supp.patch
@@ -1,7 +1,7 @@
-From f2ccbac5dae658b83009cbd5f888960f5532db55 Mon Sep 17 00:00:00 2001
+From 94ad3031f5b77787a3ed63d11bf304dc8af38067 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ren=C3=AA=20de=20Souza=20Pinto?= <rene@renesp.com.br>
 Date: Wed, 4 Jan 2023 19:50:43 +0100
-Subject: [PATCH 6/6] configs: phycore-imx8mp: Enable GPT EFI partition
+Subject: [PATCH 12/25] configs: phycore-imx8mp: Enable GPT EFI partition
  support.
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -13,10 +13,10 @@ Signed-off-by: Renê de Souza Pinto <rene@renesp.com.br>
  1 file changed, 4 insertions(+)
 
 diff --git a/configs/phycore-imx8mp_defconfig b/configs/phycore-imx8mp_defconfig
-index e38b7a52896..77697e66c21 100644
+index d563aadc879..bdab98c7c62 100644
 --- a/configs/phycore-imx8mp_defconfig
 +++ b/configs/phycore-imx8mp_defconfig
-@@ -62,6 +62,10 @@ CONFIG_CMD_EXT4=y
+@@ -64,6 +64,10 @@ CONFIG_CMD_EXT4=y
  CONFIG_CMD_EXT4_WRITE=y
  CONFIG_CMD_FAT=y
  CONFIG_OF_CONTROL=y
@@ -28,5 +28,5 @@ index e38b7a52896..77697e66c21 100644
  CONFIG_ENV_OVERWRITE=y
  CONFIG_ENV_IS_IN_MMC=y
 -- 
-2.35.1
+2.40.1
 

--- a/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0013-configs-Add-custom-default-boot-command-for-Pollux-b.patch
+++ b/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0013-configs-Add-custom-default-boot-command-for-Pollux-b.patch
@@ -1,7 +1,8 @@
-From 8bf24918e94c07b1eb1d4e2213059aaa0e7aed05 Mon Sep 17 00:00:00 2001
+From 3e8c3a5416cfa6146b9f94d56350521d72a723da Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ren=C3=AA=20de=20Souza=20Pinto?= <rene@renesp.com.br>
 Date: Fri, 6 Jan 2023 15:30:50 +0100
-Subject: [PATCH] configs: Add custom default boot command for Pollux board
+Subject: [PATCH 13/25] configs: Add custom default boot command for Pollux
+ board
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -15,10 +16,10 @@ Signed-off-by: Renê de Souza Pinto <rene@renesp.com.br>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/configs/phycore-imx8mp_defconfig b/configs/phycore-imx8mp_defconfig
-index 77697e66c21..dccffbac970 100644
+index bdab98c7c62..164739c68d5 100644
 --- a/configs/phycore-imx8mp_defconfig
 +++ b/configs/phycore-imx8mp_defconfig
-@@ -25,7 +25,7 @@ CONFIG_SPL_LOAD_FIT=y
+@@ -26,7 +26,7 @@ CONFIG_SPL_LOAD_FIT=y
  # CONFIG_USE_SPL_FIT_GENERATOR is not set
  CONFIG_OF_SYSTEM_SETUP=y
  CONFIG_USE_BOOTCOMMAND=y
@@ -28,5 +29,5 @@ index 77697e66c21..dccffbac970 100644
  CONFIG_BOARD_LATE_INIT=y
  CONFIG_SPL_BOARD_INIT=y
 -- 
-2.35.1
+2.40.1
 

--- a/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0014-dts-Add-mcu_rdc-node-to-imx8mp-rsb3720-a1-u-boot.dts.patch
+++ b/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0014-dts-Add-mcu_rdc-node-to-imx8mp-rsb3720-a1-u-boot.dts.patch
@@ -1,7 +1,7 @@
-From b90a60af24e92118079d8d28273df14efd52e909 Mon Sep 17 00:00:00 2001
+From bf2496bbd360cbc1ed30602c34d726fe291ce248 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ren=C3=AA=20de=20Souza=20Pinto?= <rene@renesp.com.br>
 Date: Wed, 11 Jan 2023 14:33:10 +0100
-Subject: [PATCH 13/17] dts: Add mcu_rdc node to imx8mp-rsb3720-a1-u-boot.dtsi
+Subject: [PATCH 14/25] dts: Add mcu_rdc node to imx8mp-rsb3720-a1-u-boot.dtsi
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -81,5 +81,5 @@ index 2848b24f655..307c833cf4e 100644
  
  &iomuxc {
 -- 
-2.39.1
+2.40.1
 

--- a/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0015-configs-Remove-config-options-for-Advantech-s-EPC372.patch
+++ b/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0015-configs-Remove-config-options-for-Advantech-s-EPC372.patch
@@ -1,7 +1,7 @@
-From f9c9f508ac5673f7944d00cd5adbe102890fb59c Mon Sep 17 00:00:00 2001
+From 93e0b76966d7e715c614e518ed601bbb1852a2e0 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ren=C3=AA=20de=20Souza=20Pinto?= <rene@renesp.com.br>
 Date: Wed, 11 Jan 2023 14:59:34 +0100
-Subject: [PATCH 14/17] configs: Remove config options for Advantech's EPC3720
+Subject: [PATCH 15/25] configs: Remove config options for Advantech's EPC3720
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -44,5 +44,5 @@ index fe60b819e7d..e3c0a74088e 100644
 -CONFIG_EFI_CAPSULE_FIRMWARE_FIT=y
  CONFIG_EFI_SECURE_BOOT=y
 -- 
-2.39.1
+2.40.1
 

--- a/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0016-arch-arm-dts-Add-SMBIOS-information-for-Advantech-s-.patch
+++ b/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0016-arch-arm-dts-Add-SMBIOS-information-for-Advantech-s-.patch
@@ -1,7 +1,7 @@
-From f87eab4b21306b75e003902c6dcb106a45b90b4f Mon Sep 17 00:00:00 2001
+From 2353d7d54322da73b589b028c08757047262e2c5 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ren=C3=AA=20de=20Souza=20Pinto?= <rene@renesp.com.br>
 Date: Wed, 11 Jan 2023 15:09:35 +0100
-Subject: [PATCH 15/17] arch: arm: dts: Add SMBIOS information for Advantech's
+Subject: [PATCH 16/25] arch: arm: dts: Add SMBIOS information for Advantech's
  board
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -57,5 +57,5 @@ index e3c0a74088e..24fb1de1db7 100644
 +CONFIG_SYSINFO=y
 +CONFIG_SYSINFO_SMBIOS=y
 -- 
-2.39.1
+2.40.1
 

--- a/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0017-configs-Add-custom-default-boot-command-for-EPC3720-.patch
+++ b/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0017-configs-Add-custom-default-boot-command-for-EPC3720-.patch
@@ -1,7 +1,7 @@
-From e4a786f3ad3c35be3f5e9feb16f770802d5e84b0 Mon Sep 17 00:00:00 2001
+From dc1239809d624c82c81a32b42a9859ca50b3ecdf Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ren=C3=AA=20de=20Souza=20Pinto?= <rene@renesp.com.br>
 Date: Wed, 8 Feb 2023 14:46:29 +0100
-Subject: [PATCH 16/17] configs: Add custom default boot command for EPC3720
+Subject: [PATCH 17/25] configs: Add custom default boot command for EPC3720
  device
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -38,5 +38,5 @@ index 24fb1de1db7..b7329a30043 100644
  CONFIG_NET_RANDOM_ETHADDR=y
  CONFIG_SPL_DM=y
 -- 
-2.39.1
+2.40.1
 

--- a/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0018-arch-Fix-PHY-initialization-and-enable-eth1.patch
+++ b/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0018-arch-Fix-PHY-initialization-and-enable-eth1.patch
@@ -1,7 +1,7 @@
-From 08f5600145fda5295267e5fb2eeb0e6795516dd3 Mon Sep 17 00:00:00 2001
+From f5562c420eca1c23d699f41986adf026a9ca518e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ren=C3=AA=20de=20Souza=20Pinto?= <rene@renesp.com.br>
 Date: Wed, 8 Feb 2023 16:47:54 +0100
-Subject: [PATCH 17/17] arch: Fix PHY initialization and enable eth1
+Subject: [PATCH 18/25] arch: Fix PHY initialization and enable eth1
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -105,5 +105,5 @@ index ac4a7d0cb30..802519931c7 100644
  #define CONFIG_SYS_NONCACHED_MEMORY     (1 * SZ_1M)     /* 1M */
  #endif
 -- 
-2.39.1
+2.40.1
 

--- a/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0019-configs-imx8mp_rsb3720.h-Set-eth0-as-primary-interfa.patch
+++ b/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0019-configs-imx8mp_rsb3720.h-Set-eth0-as-primary-interfa.patch
@@ -1,7 +1,8 @@
-From 22ed1aa027f7374e88690f26c2e337be9c0a86c7 Mon Sep 17 00:00:00 2001
+From 8723bba4cd838740a03312c286ea6839df328903 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ren=C3=AA=20de=20Souza=20Pinto?= <rene@renesp.com.br>
 Date: Wed, 22 Feb 2023 15:17:22 +0100
-Subject: [PATCH] configs: imx8mp_rsb3720.h: Set eth0 as primary interface
+Subject: [PATCH 19/25] configs: imx8mp_rsb3720.h: Set eth0 as primary
+ interface
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -27,5 +28,5 @@ index 802519931c7..752b27ba1ea 100644
  #define CONFIG_FEC_XCV_TYPE             RGMII
  #define CONFIG_FEC_MXC_PHYADDR          1
 -- 
-2.39.1
+2.40.1
 

--- a/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0020-arm-mach-imx-Add-OPTEE-options-to-Kconfig.patch
+++ b/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0020-arm-mach-imx-Add-OPTEE-options-to-Kconfig.patch
@@ -1,7 +1,7 @@
-From 8761b446824300bb8e5a1f5ae0a0db680ef9f294 Mon Sep 17 00:00:00 2001
+From 992c2d5b49132c0a0678ce587f1bfcd63e393063 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ren=C3=AA=20de=20Souza=20Pinto?= <rene@renesp.com.br>
 Date: Thu, 23 Mar 2023 14:42:45 +0100
-Subject: [PATCH 19/20] arm: mach: imx: Add OPTEE options to Kconfig
+Subject: [PATCH 20/25] arm: mach: imx: Add OPTEE options to Kconfig
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -39,5 +39,5 @@ index 9976ab78d0f..12ff5034f4c 100644
  	bool
  
 -- 
-2.39.2
+2.40.1
 

--- a/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0021-configs-Enable-OPTEE-image-loading.patch
+++ b/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0021-configs-Enable-OPTEE-image-loading.patch
@@ -1,7 +1,7 @@
-From bb56bdcf90b736524a44e37b7758fb752cbc2441 Mon Sep 17 00:00:00 2001
+From fd6ed4b0379226ab015ae397b5cae228b679ba96 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ren=C3=AA=20de=20Souza=20Pinto?= <rene@renesp.com.br>
 Date: Thu, 23 Mar 2023 14:55:35 +0100
-Subject: [PATCH 20/20] configs: Enable OPTEE image loading
+Subject: [PATCH 21/25] configs: Enable OPTEE image loading
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -28,15 +28,15 @@ index b7329a30043..33bc53bdd55 100644
 +CONFIG_OPTEE_FIRMWARE_SET=y
 +CONFIG_OPTEE_FIRMWARE="tee.bin"
 diff --git a/configs/phycore-imx8mp_defconfig b/configs/phycore-imx8mp_defconfig
-index dccffbac970..68048bf5ed9 100644
+index 164739c68d5..839b595b8da 100644
 --- a/configs/phycore-imx8mp_defconfig
 +++ b/configs/phycore-imx8mp_defconfig
-@@ -113,3 +113,5 @@ CONFIG_DM_THERMAL=y
+@@ -118,3 +118,5 @@ CONFIG_DM_THERMAL=y
  CONFIG_IMX_WATCHDOG=y
  CONFIG_SYSINFO=y
  CONFIG_SYSINFO_SMBIOS=y
 +CONFIG_OPTEE_FIRMWARE_SET=y
 +CONFIG_OPTEE_FIRMWARE="tee.bin"
 -- 
-2.39.2
+2.40.1
 

--- a/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0022-arm-dts-Remove-binman-node-from-imx8mp-rsb3720-a1-u-.patch
+++ b/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0022-arm-dts-Remove-binman-node-from-imx8mp-rsb3720-a1-u-.patch
@@ -1,7 +1,7 @@
-From 904b0025dc2a950e6ddd0a7c224828c892dd50b9 Mon Sep 17 00:00:00 2001
+From 1ed242650d1a323d75872ce865dc29eb08e0a73c Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ren=C3=AA=20de=20Souza=20Pinto?= <rene@renesp.com.br>
 Date: Fri, 24 Mar 2023 14:05:59 +0100
-Subject: [PATCH] arm: dts: Remove binman node from
+Subject: [PATCH 22/25] arm: dts: Remove binman node from
  imx8mp-rsb3720-a1-u-boot.dtsi
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -49,5 +49,5 @@ index 3c2517a79ab..69ea625053a 100644
 -	};
 -};
 -- 
-2.39.2
+2.40.1
 

--- a/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0023-arm-imx8m-Set-mmcdev-variable-at-the-initialization.patch
+++ b/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0023-arm-imx8m-Set-mmcdev-variable-at-the-initialization.patch
@@ -1,7 +1,7 @@
-From 08cea66d64dba53850842ed92744685002d4295a Mon Sep 17 00:00:00 2001
+From dfac40fdc1126ef2aa1717379f064b774ef9a95c Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ren=C3=AA=20de=20Souza=20Pinto?= <rene@renesp.com.br>
 Date: Tue, 2 May 2023 16:42:19 +0200
-Subject: [PATCH] arm: imx8m: Set mmcdev variable at the initialization
+Subject: [PATCH 23/25] arm: imx8m: Set mmcdev variable at the initialization
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -48,5 +48,5 @@ index 16566092bd8..b0b890edfe7 100644
  
  	return 0;
 -- 
-2.39.2
+2.40.1
 

--- a/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0024-clk-imx8mp-handle-ECSPI-clocks.patch
+++ b/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0024-clk-imx8mp-handle-ECSPI-clocks.patch
@@ -1,7 +1,7 @@
-From ae43f7bbb9651f23540b6060db14e472eba0ac75 Mon Sep 17 00:00:00 2001
+From 751912f4bb3a2a30762a80f7890dbe0268c38837 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ren=C3=AA=20de=20Souza=20Pinto?= <rene@renesp.com.br>
 Date: Wed, 31 May 2023 12:01:25 +0200
-Subject: [PATCH 23/24] clk: imx8mp: handle ECSPI clocks
+Subject: [PATCH 24/25] clk: imx8mp: handle ECSPI clocks
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -63,5 +63,5 @@ index 435d5dc46b6..7869572b3ce 100644
  	clk_dm(IMX8MP_CLK_GPIO1_ROOT, imx_clk_gate4("gpio1_root_clk", "ipg_root", base + 0x40b0, 0));
  	clk_dm(IMX8MP_CLK_GPIO2_ROOT, imx_clk_gate4("gpio2_root_clk", "ipg_root", base + 0x40c0, 0));
 -- 
-2.39.2
+2.40.1
 

--- a/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0025-arm-imx8mp-Enable-hardware-TPM-on-phyBOARD-Pollux.patch
+++ b/pkg/bsp-imx/patches/uboot-patches-lf_v2022.04/0025-arm-imx8mp-Enable-hardware-TPM-on-phyBOARD-Pollux.patch
@@ -1,7 +1,7 @@
-From 3ab8196db7b4b1d1dfd34352ab675900488448c0 Mon Sep 17 00:00:00 2001
+From 205c86b39417c262a468f9daa9cbef6c9adc0c55 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ren=C3=AA=20de=20Souza=20Pinto?= <rene@renesp.com.br>
 Date: Wed, 31 May 2023 13:09:19 +0200
-Subject: [PATCH 24/24] arm: imx8mp: Enable hardware TPM on phyBOARD-Pollux
+Subject: [PATCH 25/25] arm: imx8mp: Enable hardware TPM on phyBOARD-Pollux
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -21,7 +21,7 @@ Signed-off-by: Renê de Souza Pinto <rene@renesp.com.br>
  2 files changed, 48 insertions(+)
 
 diff --git a/arch/arm/dts/imx8mp-phyboard-pollux-rdk.dts b/arch/arm/dts/imx8mp-phyboard-pollux-rdk.dts
-index 5f66e1a5fe0..83d2c676940 100644
+index 3ccc36ada71..c6b9515032f 100644
 --- a/arch/arm/dts/imx8mp-phyboard-pollux-rdk.dts
 +++ b/arch/arm/dts/imx8mp-phyboard-pollux-rdk.dts
 @@ -35,6 +35,7 @@
@@ -31,9 +31,9 @@ index 5f66e1a5fe0..83d2c676940 100644
 +		spi1 = &ecspi1;
  	};
  
- 	reg_usdhc2_vmmc: regulator-usdhc2 {
-@@ -220,4 +221,46 @@
- 			MX8MP_IOMUXC_GPIO1_IO04__USDHC2_VSELECT	0xc1
+ 	backlight1: backlight1 {
+@@ -535,4 +536,46 @@ csi1_i2c: &i2c3 {
+ 			MX8MP_IOMUXC_GPIO1_IO04__USDHC2_VSELECT	0xc0
  		>;
  	};
 +
@@ -80,10 +80,10 @@ index 5f66e1a5fe0..83d2c676940 100644
 +	};
  };
 diff --git a/configs/phycore-imx8mp_defconfig b/configs/phycore-imx8mp_defconfig
-index 68048bf5ed9..7b1c95ed520 100644
+index 839b595b8da..3b34cdb974a 100644
 --- a/configs/phycore-imx8mp_defconfig
 +++ b/configs/phycore-imx8mp_defconfig
-@@ -115,3 +115,8 @@ CONFIG_SYSINFO=y
+@@ -120,3 +120,8 @@ CONFIG_SYSINFO=y
  CONFIG_SYSINFO_SMBIOS=y
  CONFIG_OPTEE_FIRMWARE_SET=y
  CONFIG_OPTEE_FIRMWARE="tee.bin"
@@ -93,5 +93,5 @@ index 68048bf5ed9..7b1c95ed520 100644
 +CONFIG_TPM=y
 +CONFIG_TPM2_TIS_SPI=y
 -- 
-2.39.2
+2.40.1
 


### PR DESCRIPTION
The current U-Boot from pkg/bsp-imx doesn't support newer models (with 4GB) of the phyBOARD-Pollux board. This commit port the changes in order to allow EVE to run on both models.