### PR TITLE
[WIP] Patch Envelopes: support external binary blobs

### DIFF
--- a/pkg/pillar/cmd/zedagent/parsepatchenvelopes.go
+++ b/pkg/pillar/cmd/zedagent/parsepatchenvelopes.go
@@ -42,7 +42,7 @@ func parsePatchEnvelopesImpl(ctx *getconfigContext, config *zconfig.EdgeDevConfi
 
 	var blobsAfter []string
 	patchEnvelopes := config.GetPatchEnvelopes()
-	result := types.PatchEnvelopes{}
+	result := make([]types.PatchEnvelopeInfo, len(patchEnvelopes))
 	for _, pe := range patchEnvelopes {
 		peInfo := types.PatchEnvelopeInfo{
 			AllowedApps: pe.GetAppInstIdsAllowed(),
@@ -56,7 +56,7 @@ func parsePatchEnvelopesImpl(ctx *getconfigContext, config *zconfig.EdgeDevConfi
 			}
 		}
 
-		result.Envelopes = append(result.Envelopes, peInfo)
+		result = append(result, peInfo)
 
 		for _, inlineBlob := range peInfo.BinaryBlobs {
 			blobsAfter = append(blobsAfter, inlineBlob.FileName)
@@ -72,8 +72,8 @@ func parsePatchEnvelopesImpl(ctx *getconfigContext, config *zconfig.EdgeDevConfi
 	}
 }
 
-func publishPatchEnvelopes(ctx *getconfigContext, patchEnvelopes types.PatchEnvelopes) {
-	key := patchEnvelopes.Key()
+func publishPatchEnvelopes(ctx *getconfigContext, patchEnvelopes []types.PatchEnvelopeInfo) {
+	key := types.PatchEnvelopeInfoKey()
 	pub := ctx.pubPatchEnvelopeInfo
 
 	pub.Publish(key, patchEnvelopes)

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -1204,7 +1204,7 @@ func initPublications(zedagentCtx *zedagentContext) {
 	getconfigCtx.pubPatchEnvelopeInfo, err = ps.NewPublication(
 		pubsub.PublicationOptions{
 			AgentName:  agentName,
-			TopicType:  types.PatchEnvelopes{},
+			TopicType:  []types.PatchEnvelopeInfo{},
 			Persistent: true,
 		})
 	if err != nil {

--- a/pkg/pillar/cmd/zedrouter/metadata_handlers.go
+++ b/pkg/pillar/cmd/zedrouter/metadata_handlers.go
@@ -685,14 +685,6 @@ func HandlePatchFileDownload(z *zedrouter) func(http.ResponseWriter, *http.Reque
 func WithPatchEnvelopesByIP(z *zedrouter) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			peObj, err := z.subPatchEnvelopeInfo.Get("zedagent")
-			if err != nil {
-				sendError(w, http.StatusNoContent, "Cannot get patch envelope subscription")
-				return
-			}
-
-			pe := peObj.([]types.PatchEnvelopeInfo)
-
 			remoteIP := net.ParseIP(strings.Split(r.RemoteAddr, ":")[0])
 			anStatus := z.lookupAppNetworkStatusByAppIP(remoteIP)
 			if anStatus == nil {
@@ -704,7 +696,7 @@ func WithPatchEnvelopesByIP(z *zedrouter) func(http.Handler) http.Handler {
 
 			appUUID := anStatus.UUIDandVersion.UUID
 
-			envelopes := types.FindPatchEnvelopesByApp(pe, appUUID.String())
+			envelopes := z.patchEnvelopes.Get(appUUID.String())
 			if len(envelopes) == 0 {
 				sendError(w, http.StatusOK, fmt.Sprintf("No envelopes for %s", appUUID.String()))
 			}

--- a/pkg/pillar/cmd/zedrouter/metadata_handlers.go
+++ b/pkg/pillar/cmd/zedrouter/metadata_handlers.go
@@ -691,7 +691,7 @@ func WithPatchEnvelopesByIP(z *zedrouter) func(http.Handler) http.Handler {
 				return
 			}
 
-			pe := peObj.(types.PatchEnvelopes)
+			pe := peObj.([]types.PatchEnvelopeInfo)
 
 			remoteIP := net.ParseIP(strings.Split(r.RemoteAddr, ":")[0])
 			anStatus := z.lookupAppNetworkStatusByAppIP(remoteIP)
@@ -704,7 +704,7 @@ func WithPatchEnvelopesByIP(z *zedrouter) func(http.Handler) http.Handler {
 
 			appUUID := anStatus.UUIDandVersion.UUID
 
-			envelopes := pe.Get(appUUID.String())
+			envelopes := types.FindPatchEnvelopesByApp(pe, appUUID.String())
 			if len(envelopes) == 0 {
 				sendError(w, http.StatusOK, fmt.Sprintf("No envelopes for %s", appUUID.String()))
 			}

--- a/pkg/pillar/cmd/zedrouter/pubsubhandlers.go
+++ b/pkg/pillar/cmd/zedrouter/pubsubhandlers.go
@@ -629,3 +629,70 @@ func (z *zedrouter) handleAppInstDelete(ctxArg interface{}, key string,
 	z.unpublishAppInstMetadata(appInstMetadata)
 	z.log.Functionf("handleAppInstDelete(%s) done", key)
 }
+
+func (z *zedrouter) handlePatchEnvelopeCreate(ctxArg interface{}, key string,
+	configArg interface{}) {
+	peInfo := ctxArg.([]types.PatchEnvelopeInfo)
+	z.log.Functionf("handlePatchEnvelopeCreate: (UUID: %s)", key)
+
+	z.patchEnvelopes.Wg.Add(1)
+	z.patchEnvelopes.PatchEnvelopeInfoCh <- peInfo
+
+	z.log.Functionf("handleVolumeStatusCreate(%s) done", key)
+}
+
+func (z *zedrouter) handlePatchEnvelopeModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	peInfo := ctxArg.([]types.PatchEnvelopeInfo)
+	z.log.Functionf("handlePatchEnvelopeModify: (UUID: %s)", key)
+
+	z.patchEnvelopes.Wg.Add(1)
+	z.patchEnvelopes.PatchEnvelopeInfoCh <- peInfo
+
+	z.log.Functionf("handlePatchEnvelopeModify(%s) done", key)
+}
+
+func (z *zedrouter) handleVolumeStatusCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	volume := ctxArg.(types.VolumeStatus)
+	z.log.Functionf("handleVolumeStatusCreate: (UUID: %s, name:%s)",
+		key, volume.DisplayName)
+
+	z.patchEnvelopes.Wg.Add(1)
+	z.patchEnvelopes.VolumeStatusCh <- types.PatchEnvelopesVsCh{
+		Vs:     volume,
+		Action: types.PatchEnvelopesVsChActionPut,
+	}
+
+	z.log.Functionf("handleVolumeStatusCreate(%s) done", key)
+}
+
+func (z *zedrouter) handleVolumeStatusModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	volume := ctxArg.(types.VolumeStatus)
+	z.log.Functionf("handleVolumeStatusModify: (UUID: %s, name:%s)",
+		key, volume.DisplayName)
+
+	z.patchEnvelopes.Wg.Add(1)
+	z.patchEnvelopes.VolumeStatusCh <- types.PatchEnvelopesVsCh{
+		Vs:     volume,
+		Action: types.PatchEnvelopesVsChActionPut,
+	}
+
+	z.log.Functionf("handleVolumeStatusModify(%s) done", key)
+}
+
+func (z *zedrouter) handleVolumeStatusDelete(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	volume := ctxArg.(types.VolumeStatus)
+	z.log.Functionf("handleVolumeStatusDelete: (UUID: %s, name:%s)",
+		key, volume.DisplayName)
+
+	z.patchEnvelopes.Wg.Add(1)
+	z.patchEnvelopes.VolumeStatusCh <- types.PatchEnvelopesVsCh{
+		Vs:     volume,
+		Action: types.PatchEnvelopesVsChActionDelete,
+	}
+
+	z.log.Functionf("handleVolumeStatusDelete(%s) done", key)
+}

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -175,6 +175,7 @@ type zedrouter struct {
 	// for external patch envelopes
 	subPatchEnvelopeInfo pubsub.Subscription
 	subVolumeStatus      pubsub.Subscription
+	patchEnvelopes       *types.PatchEnvelopes
 }
 
 // AddAgentSpecificCLIFlags adds CLI options
@@ -246,6 +247,9 @@ func (z *zedrouter) init() (err error) {
 	z.reachProber = controllerReachProber
 	z.niReconciler = nireconciler.NewLinuxNIReconciler(z.log, z.logger, z.networkMonitor,
 		z.makeMetadataHandler(), true, true)
+
+	// Initialize Zedrouter component for  handling patchEnvelopes
+	z.patchEnvelopes = types.NewPatchEnvelopes(z.log)
 
 	z.initNumberAllocators()
 	return nil
@@ -799,12 +803,14 @@ func (z *zedrouter) initSubscriptions() (err error) {
 
 	// Information about patch envelopes
 	z.subPatchEnvelopeInfo, err = z.pubSub.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName:   "zedagent",
-		MyAgentName: agentName,
-		TopicImpl:   []types.PatchEnvelopeInfo{},
-		Activate:    false,
-		WarningTime: warningTime,
-		ErrorTime:   errorTime,
+		AgentName:     "zedagent",
+		MyAgentName:   agentName,
+		TopicImpl:     []types.PatchEnvelopeInfo{},
+		Activate:      false,
+		CreateHandler: z.handlePatchEnvelopeCreate,
+		ModifyHandler: z.handlePatchEnvelopeModify,
+		WarningTime:   warningTime,
+		ErrorTime:     errorTime,
 	})
 	if err != nil {
 		return err
@@ -812,12 +818,15 @@ func (z *zedrouter) initSubscriptions() (err error) {
 
 	// Information about volumes referred in external patch envelopes
 	z.subVolumeStatus, err = z.pubSub.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName:   "volumemgr",
-		MyAgentName: agentName,
-		TopicImpl:   types.VolumeStatus{},
-		Activate:    false,
-		WarningTime: warningTime,
-		ErrorTime:   errorTime,
+		AgentName:     "volumemgr",
+		MyAgentName:   agentName,
+		TopicImpl:     types.VolumeStatus{},
+		Activate:      false,
+		CreateHandler: z.handleVolumeStatusCreate,
+		ModifyHandler: z.handleVolumeStatusModify,
+		DeleteHandler: z.handleVolumeStatusDelete,
+		WarningTime:   warningTime,
+		ErrorTime:     errorTime,
 	})
 	if err != nil {
 		return err

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -801,7 +801,7 @@ func (z *zedrouter) initSubscriptions() (err error) {
 	z.subPatchEnvelopeInfo, err = z.pubSub.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:   "zedagent",
 		MyAgentName: agentName,
-		TopicImpl:   types.PatchEnvelopes{},
+		TopicImpl:   []types.PatchEnvelopeInfo{},
 		Activate:    false,
 		WarningTime: warningTime,
 		ErrorTime:   errorTime,

--- a/pkg/pillar/types/patchenvelopestypes.go
+++ b/pkg/pillar/types/patchenvelopestypes.go
@@ -5,11 +5,186 @@ package types
 
 import (
 	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
+	uuid "github.com/satori/go.uuid"
 )
 
-// Key for pubsub
-func PatchEnvelopeInfoKey() string {
-	return "zedagent"
+// PatchEnvelopes is a structure
+type PatchEnvelopes struct {
+	sync.Mutex
+	VolumeStatusCh      chan PatchEnvelopesVsCh
+	PatchEnvelopeInfoCh chan []PatchEnvelopeInfo
+	Wg                  sync.WaitGroup
+
+	envelopes        []PatchEnvelopeInfo
+	completedVolumes []VolumeStatus
+	log              *base.LogObject
+}
+
+// PatchEnvelopesVsChAction specifies action for patch envelope volume status
+type PatchEnvelopesVsChAction uint8
+
+const (
+	// PatchEnvelopesVsChActionDelete -- delete reference with volume
+	PatchEnvelopesVsChActionDelete PatchEnvelopesVsChAction = iota
+	// PatchEnvelopesVsChActionPut -- create or update reference with volume
+	PatchEnvelopesVsChActionPut
+)
+
+// PatchEnvelopesVsCh is a wrapper for VolumeStatus specifying action
+// for external Patch Envelope
+type PatchEnvelopesVsCh struct {
+	Vs     VolumeStatus
+	Action PatchEnvelopesVsChAction
+}
+
+// NewPatchEnvelopes returns PatchEnvelopes structure
+func NewPatchEnvelopes(log *base.LogObject) *PatchEnvelopes {
+	pe := &PatchEnvelopes{
+		VolumeStatusCh:      make(chan PatchEnvelopesVsCh),
+		PatchEnvelopeInfoCh: make(chan []PatchEnvelopeInfo),
+
+		log: log,
+	}
+
+	go pe.processMessages()
+
+	return pe
+}
+
+// Get returns list of Patch Envelopes available for this app instance
+func (pes *PatchEnvelopes) Get(appUUID string) []PatchEnvelopeInfo {
+	var res []PatchEnvelopeInfo
+
+	for _, envelope := range pes.envelopes {
+		for _, allowedUUID := range envelope.AllowedApps {
+			if allowedUUID == appUUID {
+				res = append(res, envelope)
+				break
+			}
+		}
+	}
+
+	return res
+}
+
+func (pes *PatchEnvelopes) processMessages() {
+	for {
+		select {
+		case volumeStatus := <-pes.VolumeStatusCh:
+			switch volumeStatus.Action {
+			case PatchEnvelopesVsChActionPut:
+				pes.updateExternalPatches(volumeStatus.Vs)
+			case PatchEnvelopesVsChActionDelete:
+				pes.deleteExternalPatches(volumeStatus.Vs)
+			}
+			pes.Wg.Done()
+		case newPatchEnvelopeInfo := <-pes.PatchEnvelopeInfoCh:
+			pes.updateEnvelopes(newPatchEnvelopeInfo)
+			pes.Wg.Done()
+		}
+	}
+}
+
+func (pes *PatchEnvelopes) updateExternalPatches(vs VolumeStatus) {
+	if vs.State != INSTALLED {
+		return
+	}
+
+	pes.Lock()
+	defer pes.Unlock()
+
+	volumeExists := false
+	for i := range pes.completedVolumes {
+		if pes.completedVolumes[i].VolumeID == vs.VolumeID {
+			pes.completedVolumes[i] = vs
+			volumeExists = true
+			break
+		}
+	}
+	if !volumeExists {
+		pes.completedVolumes = append(pes.completedVolumes, vs)
+	}
+
+	if err := pes.processVolumeStatus(vs); err != nil {
+		pes.log.Errorf("Failed to update external patches %v", err)
+	}
+}
+
+func (pes *PatchEnvelopes) deleteExternalPatches(vs VolumeStatus) {
+	pes.Lock()
+	defer pes.Unlock()
+
+	i := 0
+	for _, vol := range pes.completedVolumes {
+		if vol.VolumeID == vs.VolumeID {
+			break
+		}
+		i++
+	}
+
+	pes.completedVolumes[i] = pes.completedVolumes[len(pes.completedVolumes)-1]
+	pes.completedVolumes = pes.completedVolumes[:len(pes.completedVolumes)-1]
+}
+
+func (pes *PatchEnvelopes) updateEnvelopes(peInfo []PatchEnvelopeInfo) {
+	pes.Lock()
+	defer pes.Unlock()
+
+	pes.envelopes = peInfo
+	if err := pes.processVolumeStatusList(pes.completedVolumes); err != nil {
+		pes.log.Errorf("Failed to update external patches %v", err)
+	}
+}
+
+func (pes *PatchEnvelopes) processVolumeStatus(vs VolumeStatus) error {
+	for i := range pes.envelopes {
+		for j := range pes.envelopes[i].VolumeRefs {
+			volUUID, err := uuid.FromString(pes.envelopes[i].VolumeRefs[j].ImageID)
+			if err != nil {
+				return err
+			}
+			if volUUID == vs.VolumeID {
+				blob, err := blobFromVolRef(pes.envelopes[i].VolumeRefs[j], vs)
+				if err != nil {
+					return err
+				}
+
+				if idx := CompletedBinaryBlobIdxByName(pes.envelopes[i].BinaryBlobs, blob.FileName); idx != -1 {
+					pes.envelopes[i].BinaryBlobs[idx] = *blob
+				} else {
+					pes.envelopes[i].BinaryBlobs = append(pes.envelopes[i].BinaryBlobs, *blob)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (pes *PatchEnvelopes) processVolumeStatusList(volumeStatuses []VolumeStatus) error {
+	for _, vs := range volumeStatuses {
+		if err := pes.processVolumeStatus(vs); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func blobFromVolRef(vr BinaryBlobVolumeRef, vs VolumeStatus) (*BinaryBlobCompleted, error) {
+	sha, err := fileutils.ComputeShaFile(vs.FileLocation)
+	if err != nil {
+		return nil, err
+	}
+	return &BinaryBlobCompleted{
+		FileName:     vr.FileName,
+		FileMetadata: vr.FileMetadata,
+		FileSha:      fmt.Sprintf("%x", sha),
+		URL:          vs.FileLocation,
+	}, nil
 }
 
 // PatchEnvelopeInfo - information
@@ -19,6 +194,11 @@ type PatchEnvelopeInfo struct {
 	PatchID     string
 	BinaryBlobs []BinaryBlobCompleted
 	VolumeRefs  []BinaryBlobVolumeRef
+}
+
+// PatchEnvelopeInfoKey returns key for pubsub
+func PatchEnvelopeInfoKey() string {
+	return "zedagent"
 }
 
 // since we use json in pubsub we cannot use json - tag
@@ -47,12 +227,12 @@ func PatchEnvelopesJSONForAppInstance(pe []PatchEnvelopeInfo) ([]byte, error) {
 }
 
 // FindPatchEnvelopesByApp returns PatchEnvelopeInfo which are allowed to certain app instance
-func FindPatchEnvelopesByApp(pe []PatchEnvelopeInfo, appUuid string) []PatchEnvelopeInfo {
+func FindPatchEnvelopesByApp(pe []PatchEnvelopeInfo, appUUID string) []PatchEnvelopeInfo {
 	var res []PatchEnvelopeInfo
 
 	for _, envelope := range pe {
-		for _, allowedUuid := range envelope.AllowedApps {
-			if allowedUuid == appUuid {
+		for _, allowedUUID := range envelope.AllowedApps {
+			if allowedUUID == appUUID {
 				res = append(res, envelope)
 				break
 			}

--- a/pkg/pillar/types/patchenvelopestypes_test.go
+++ b/pkg/pillar/types/patchenvelopestypes_test.go
@@ -16,7 +16,7 @@ func TestPatchEnvelopes(t *testing.T) {
 	t.Parallel()
 
 	g := gomega.NewGomegaWithT(t)
-	pe := types.PatchEnvelopes{}
+	pe := []types.PatchEnvelopeInfo{}
 
 	uuidString := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
 	peInfo := types.PatchEnvelopeInfo{
@@ -32,9 +32,9 @@ func TestPatchEnvelopes(t *testing.T) {
 		},
 	}
 
-	pe.Envelopes = append(pe.Envelopes, peInfo)
+	pe = append(pe, peInfo)
 
-	g.Expect(pe.Get(uuidString)).To(gomega.BeEquivalentTo([]types.PatchEnvelopeInfo{peInfo}))
+	g.Expect(types.FindPatchEnvelopesByApp(pe, uuidString)).To(gomega.BeEquivalentTo([]types.PatchEnvelopeInfo{peInfo}))
 
 	// Test GetZipArchive
 	filecontent := "blobfilecontent"
@@ -62,11 +62,9 @@ func TestPatchEnvelopes(t *testing.T) {
 			},
 		},
 	}
-	pe = types.PatchEnvelopes{
-		Envelopes: []types.PatchEnvelopeInfo{peInfo},
-	}
+	pe = []types.PatchEnvelopeInfo{peInfo}
 
-	got := pe.Get("17daa0ff-39d6-42be-a537-44c974276aec")
+	got := types.FindPatchEnvelopesByApp(pe, "17daa0ff-39d6-42be-a537-44c974276aec")
 	assert.Equal(t, got, []types.PatchEnvelopeInfo{peInfo})
 
 	assert.Equal(t, peInfo, *types.FindPatchEnvelopeByID(got, "699fbdb2-e455-448f-84f5-68e547ec1305"))

--- a/pkg/pillar/utils/patchenvelopesutils_test.go
+++ b/pkg/pillar/utils/patchenvelopesutils_test.go
@@ -21,7 +21,7 @@ func TestGetZipArchive(t *testing.T) {
 	t.Parallel()
 
 	g := gomega.NewGomegaWithT(t)
-	pe := types.PatchEnvelopes{}
+	pe := []types.PatchEnvelopeInfo{}
 
 	uuidString := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
 	peInfo := types.PatchEnvelopeInfo{
@@ -37,9 +37,9 @@ func TestGetZipArchive(t *testing.T) {
 		},
 	}
 
-	pe.Envelopes = append(pe.Envelopes, peInfo)
+	pe = append(pe, peInfo)
 
-	g.Expect(pe.Get(uuidString)).To(gomega.BeEquivalentTo([]types.PatchEnvelopeInfo{peInfo}))
+	g.Expect(types.FindPatchEnvelopesByApp(pe, uuidString)).To(gomega.BeEquivalentTo([]types.PatchEnvelopeInfo{peInfo}))
 
 	// Test GetZipArchive
 	root := "./"


### PR DESCRIPTION
## TL;DR

This is Work In Progress Pull request on adding external binary blobs. It has not been tested yet with controller, will provide updates here. 

## Things I wanted to discuss 

In #3435 @milan-zededa mentioned that it's not a good idea to increase types more than it's needed, so I wanted to discuss if it makes sense to move logic (i.e. `PatchEnvelopes` struct from types to zedrouter, since zedrouter uses it in the end, my main concern if patch envelopes would be used in LOC, which will require importing this.

## Background and high level implementation

Patch envelopes are nothing more but a data exposed to Edge Applications
by EVE in runtime. This is done by metadata server which is part of zedrouter.
There are two types of patch envelopes: inline and external.

Inline patch envelopes are small objects (10Kbytes max as of now) which
are part of `EdgeDevConfig`.

External patch envelopes are volumes, downloaded by EVE and exposed to
Edge Applications via metadata server. Volumes are handled by other `volumemgr`
service which means that with external patch envelopes we need to get updates
not only from `zedagent` but also from `volumemgr` and those updates are not in
sync. So in order to handle that we need to

1) Separate information sent by `zedagent` to what we actually expose in `zedrouter`
2) Implement structure which will handle async updates from `volumemgr` and `zedagent`
3) Switch metadata server to using structure implemented in 2)
