### PR TITLE
[10.4 stable] Do not fail SealDiskKey if PCRs/eventlog can not be saved

### DIFF
--- a/pkg/pillar/cmd/vaultmgr/vaultmgr.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgr.go
@@ -418,7 +418,7 @@ func handleVaultKeyFromControllerImpl(ctxArg interface{}, key string,
 		}
 		// Try unlocking the vault now, in case it is not yet unlocked
 		log.Noticef("Vault is still locked, trying to unlock")
-		err = etpm.SealDiskKey(decryptedKey, etpm.DiskKeySealingPCRs)
+		err = etpm.SealDiskKey(log, decryptedKey, etpm.DiskKeySealingPCRs)
 		if err != nil {
 			log.Errorf("Failed to Seal key in TPM %v", err)
 			return

--- a/pkg/pillar/evetpm/tpm.go
+++ b/pkg/pillar/evetpm/tpm.go
@@ -518,7 +518,7 @@ func FetchSealedVaultKey(log *base.LogObject) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("GetRandom failed: %w", err)
 		}
-		err = SealDiskKey(key, DiskKeySealingPCRs)
+		err = SealDiskKey(log, key, DiskKeySealingPCRs)
 		if err != nil {
 			return nil, fmt.Errorf("sealing the fresh disk key failed: %w", err)
 		}
@@ -545,7 +545,7 @@ func FetchSealedVaultKey(log *base.LogObject) ([]byte, error) {
 
 		log.Noticef("try to convert the legacy key into a sealed key")
 
-		err = SealDiskKey(key, DiskKeySealingPCRs)
+		err = SealDiskKey(log, key, DiskKeySealingPCRs)
 		if err != nil {
 			return nil, fmt.Errorf("sealing the legacy disk key into TPM failed: %w", err)
 		}
@@ -566,7 +566,7 @@ func FetchSealedVaultKey(log *base.LogObject) ([]byte, error) {
 }
 
 // SealDiskKey seals key into TPM2.0, with provided PCRs
-func SealDiskKey(key []byte, pcrSel tpm2.PCRSelection) error {
+func SealDiskKey(log *base.LogObject, key []byte, pcrSel tpm2.PCRSelection) error {
 	rw, err := tpm2.OpenTPM(TpmDevicePath)
 	if err != nil {
 		return err
@@ -644,7 +644,7 @@ func SealDiskKey(key []byte, pcrSel tpm2.PCRSelection) error {
 
 	// save a snapshot of current PCR values
 	if err := saveDiskKeySealingPCRs(savedSealingPcrsFile); err != nil {
-		return fmt.Errorf("saving snapshot of sealing PCRs failed: %w", err)
+		log.Warnf("saving snapshot of sealing PCRs failed: %s", err)
 	}
 
 	// Backup the previous pair of logs if any, so at most we have two pairs of
@@ -654,17 +654,17 @@ func SealDiskKey(key []byte, pcrSel tpm2.PCRSelection) error {
 	// current measurement log (which is same as the content of MeasurementLogSealFail)
 	// and lose the ability to diff and diagnose the issue.
 	if err := backupCopiedMeasurementLogs(); err != nil {
-		return fmt.Errorf("collecting previous snapshot of TPM event log failed: %w", err)
+		log.Warnf("collecting previous snapshot of TPM event log failed: %s", err)
 	}
 
 	// fresh start, remove old copies of measurement logs.
 	if err := removeCopiedMeasurementLogs(); err != nil {
-		return fmt.Errorf("removing old copies of TPM measurement log failed: %w", err)
+		log.Warnf("removing old copies of TPM measurement log failed: %s", err)
 	}
 
 	// save a copy of the current measurement log
 	if err := copyMeasurementLog(measurementLogSealSuccess); err != nil {
-		return fmt.Errorf("copying current TPM measurement log failed: %w", err)
+		log.Warnf("copying current TPM measurement log failed: %s", err)
 	}
 
 	return nil

--- a/pkg/pillar/evetpm/tpm_test.go
+++ b/pkg/pillar/evetpm/tpm_test.go
@@ -15,8 +15,12 @@ import (
 
 	"github.com/google/go-tpm/tpm2"
 	"github.com/google/go-tpm/tpmutil"
+	"github.com/lf-edge/eve/pkg/pillar/base"
 	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
+	"github.com/sirupsen/logrus"
 )
+
+var log = base.NewSourceLogObject(logrus.StandardLogger(), "test", 1234)
 
 func TestSealUnseal(t *testing.T) {
 	_, err := os.Stat(TpmDevicePath)
@@ -25,7 +29,7 @@ func TestSealUnseal(t *testing.T) {
 	}
 
 	dataToSeal := []byte("secret")
-	if err := SealDiskKey(dataToSeal, DiskKeySealingPCRs); err != nil {
+	if err := SealDiskKey(log, dataToSeal, DiskKeySealingPCRs); err != nil {
 		t.Errorf("Seal operation failed with err: %v", err)
 		return
 	}
@@ -53,7 +57,7 @@ func TestSealUnsealMismatchReport(t *testing.T) {
 	defer rw.Close()
 
 	dataToSeal := []byte("secret")
-	if err := SealDiskKey(dataToSeal, DiskKeySealingPCRs); err != nil {
+	if err := SealDiskKey(log, dataToSeal, DiskKeySealingPCRs); err != nil {
 		t.Errorf("Seal operation failed with err: %v", err)
 		return
 	}
@@ -94,7 +98,7 @@ func TestSealUnsealTpmEventLogCollect(t *testing.T) {
 
 	// this should write the save the first event log
 	dataToSeal := []byte("secret")
-	if err := SealDiskKey(dataToSeal, DiskKeySealingPCRs); err != nil {
+	if err := SealDiskKey(log, dataToSeal, DiskKeySealingPCRs); err != nil {
 		t.Errorf("Seal operation failed with err: %v", err)
 		return
 	}
@@ -126,7 +130,7 @@ func TestSealUnsealTpmEventLogCollect(t *testing.T) {
 	}
 
 	// this should trigger collecting previous tpm event logs
-	if err := SealDiskKey(dataToSeal, DiskKeySealingPCRs); err != nil {
+	if err := SealDiskKey(log, dataToSeal, DiskKeySealingPCRs); err != nil {
 		t.Errorf("Seal operation failed with err: %v", err)
 		return
 	}

--- a/pkg/pillar/vault/handler_zfs.go
+++ b/pkg/pillar/vault/handler_zfs.go
@@ -98,7 +98,8 @@ func (h *ZFSHandler) SetupDefaultVault() error {
 		return fmt.Errorf("error in setting up ZFS vault %s:%v", types.SealedDataset, err)
 	}
 	// Log the type of key used for unlocking default vault
-	h.log.Noticef("default zfs vault unlocked")
+	h.log.Noticef("default zfs vault unlocked using key type: %s",
+		etpm.CompareLegacyandSealedKey().String())
 	return nil
 }
 


### PR DESCRIPTION
Forgotten commit to the stable branch:

```
For some reasons /hostfs/sys/kernel/security/tpm* might not exist on boot but that shouldn't cause tpmmgr to think that the seal failed.

Signed-off-by: eriknordmark <erik@zededa.com>
(cherry picked from commit 23da4f2843af91d389653ccb6c7c0e152e0116d8)
```

Might fix a ztests xen regression. Commit pointed by @shjala . Let's wait how it goes.