### PR TITLE
Add ModemManager dependencies to eve-alpine

### DIFF
--- a/pkg/alpine/Dockerfile
+++ b/pkg/alpine/Dockerfile
@@ -1,6 +1,6 @@
-# image was bootstraped using FROM lfedge/eve-alpine-base:f11c7a5dcffe1ab7b466bea7e26010a27da62b3b AS cache
+# image was bootstraped using FROM lfedge/eve-alpine-base:9fb9b9cbf7d90066a70e4704d04a6fe248ff52bb AS cache
 # to update please see https://github.com/lf-edge/eve/blob/master/docs/BUILD.md#how-to-update-eve-alpine-package
-FROM lfedge/eve-alpine:9fb9b9cbf7d90066a70e4704d04a6fe248ff52bb AS cache
+FROM lfedge/eve-alpine:fad44e3702708a8d044663a20fd98d933dddb41e AS cache
 
 ARG ALPINE_VERSION=3.16
 # this is only needed once, when this package

--- a/pkg/alpine/mirrors/3.16/community
+++ b/pkg/alpine/mirrors/3.16/community
@@ -36,6 +36,7 @@ tpm2-tss-tctildr
 tpm2-tss-fapi
 tpm2-tss-rc
 pkgconf
+libgudev-dev
 librados
 librbd
 libvirt

--- a/pkg/alpine/mirrors/3.16/main
+++ b/pkg/alpine/mirrors/3.16/main
@@ -29,6 +29,7 @@ cryptsetup-dev
 curl
 curl-dev
 dbus
+dbus-glib-dev
 dbus-libs
 dev86
 dhclient
@@ -129,6 +130,7 @@ lz4-libs
 lzo-dev
 m4
 make
+meson
 mkinitfs
 mpc1-dev
 mpfr-dev
@@ -143,6 +145,7 @@ ncurses-dev
 net-snmp
 netcat-openbsd
 nettle
+ninja
 numactl-dev
 open-iscsi
 openrc


### PR DESCRIPTION
These are dependencies missing in EVE alpine but [needed to build ModemManager](https://modemmanager.org/docs/modemmanager/dependencies/), which is going to be used for the management of cellular connectivity in EVE: https://wiki.lfedge.org/display/EVE/ModemManager+Evaluation