### PR TITLE
zedrouter: fix hosts file with multiple IPs assigned to the same hostname

### DIFF
--- a/pkg/pillar/nireconciler/genericitems/dnsmasq_test.go
+++ b/pkg/pillar/nireconciler/genericitems/dnsmasq_test.go
@@ -59,14 +59,14 @@ func exampleDnsmasqParams() genericitems.Dnsmasq {
 			IfName: "eth0",
 		},
 		UpstreamServers: []net.IP{{1, 1, 1, 1}, {141, 1, 1, 1}, {208, 67, 220, 220}},
-		StaticEntries: []genericitems.HostnameToIP{
+		StaticEntries: []genericitems.HostnameToIPs{
 			{
 				Hostname: "router",
-				IP:       net.IP{10, 0, 0, 1},
+				IPs:      []net.IP{{10, 0, 0, 1}},
 			},
 			{
 				Hostname: "app1",
-				IP:       net.IP{10, 0, 0, 5},
+				IPs:      []net.IP{{10, 0, 0, 5}},
 			},
 		},
 		LinuxIPSets: []genericitems.LinuxIPSet{

--- a/pkg/pillar/nireconciler/linux_test.go
+++ b/pkg/pillar/nireconciler/linux_test.go
@@ -1719,7 +1719,7 @@ func TestIPv6LocalAndSwitchNIs(test *testing.T) {
 	t.Expect(itemDescription(dg.Reference(dnsmasq))).To(ContainSubstring(
 		"ntpServers: [2610:20:6f15:15::27]"))
 	t.Expect(itemDescription(dg.Reference(dnsmasq))).To(ContainSubstring(
-		"staticEntries: [{test-hostname 2001:db8::1} {router 2001::1111:1} {app3 2001::1111:2}]"))
+		"staticEntries: [{test-hostname [2001:db8::1]} {router [2001::1111:1]} {app3 [2001::1111:2]}]"))
 	httpSrvN3 := genericitems.HTTPServer{
 		ListenIf: genericitems.NetworkIf{IfName: "bn3"}, Port: 80}
 	t.Expect(itemDescription(dg.Reference(httpSrvN3))).To(ContainSubstring(


### PR DESCRIPTION
Zedrouter creates one hosts file `/run/zedrouter/hosts.<bridge>/<hostname>` for every hostname (e.g. app name). However, when app has multiple VIFs in the same NI or there are static `hostname->IPs` entries configured for a NI with multiple IPs assigned to the same hostname, it is important that all hostname IPs are put into the same single hosts file. However, in the current implementation, zedrouter tries to split IPs and put each into a separate hosts file. With hostname that has multiple IPs, n-1 IPs will have their hosts file overwritten by the hosts file created for the last IP. Apart from the fact that only one IP will happen to be in effect for DNS, this additionally confuses zedrouter when it tries to delete VIFs and cannot find some of those hosts files (which can propagate further and break app purge operation for example).