### PR TITLE
`Patch Envelopes` to support external binary blobs

### DIFF
--- a/docs/ECO-METADATA.md
+++ b/docs/ECO-METADATA.md
@@ -315,7 +315,7 @@ The returned object is of Context-Type text - the same text which is sent to the
 ### Patch Envelope endpoints
 
 Applications might want to get some updates/configurations in runtime, this can be done via Patch Envelopes.
-More information on what Patch Envelopes are you can find in [PATCH-ENVELOPES.md](.PATCH-ENVELOPES.md) doc.
+More information on what Patch Envelopes are you can find in [PATCH-ENVELOPES.md](PATCH-ENVELOPES.md) doc.
 There are several endpoints which allow application to handle Patch Envelopes
 
 Get list of available Patch Envelopes `/eve/v1/patch/description.json`

--- a/docs/PATCH-ENVELOPES.md
+++ b/docs/PATCH-ENVELOPES.md
@@ -33,4 +33,4 @@ optional meta data. They are part of Edge Device configuration.
 ## How to use Patch Envelopes
 
 When Patch Envelopes are created on controller and exposed to EVE via API, app instance can access
-Patch Envelopes available to it from meta-data server using API defined in [metadata server](.ECO-METADATA.md)
+Patch Envelopes available to it from meta-data server using API defined in [metadata server](ECO-METADATA.md)

--- a/pkg/pillar/cmd/zedagent/parseconfig_test.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig_test.go
@@ -1326,10 +1326,11 @@ func TestParsePatchEnvelope(t *testing.T) {
 			AllowedApps: []string{appU1, appU2},
 			BinaryBlobs: []types.BinaryBlobCompleted{
 				{
-					FileName:     inlineFileName,
-					FileSha:      hex.EncodeToString(shaBytes[:]),
-					FileMetadata: fileMetadata,
-					URL:          filepath.Join(persistCacheFolder, inlineFileName),
+					FileName:         inlineFileName,
+					FileSha:          hex.EncodeToString(shaBytes[:]),
+					FileMetadata:     fileMetadata,
+					ArtifactMetadata: artiactMetadata,
+					URL:              filepath.Join(persistCacheFolder, inlineFileName),
 				},
 			},
 		},

--- a/pkg/pillar/cmd/zedagent/parseconfig_test.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig_test.go
@@ -1320,7 +1320,7 @@ func TestParsePatchEnvelope(t *testing.T) {
 	pes, ok := patchEnvelopes.(types.PatchEnvelopeInfoList)
 	g.Expect(ok).To(BeTrue())
 	shaBytes := sha256.Sum256([]byte(fileData))
-	g.Expect(pes.Get(appU1)).To(BeEquivalentTo([]types.PatchEnvelopeInfo{
+	g.Expect(pes.Get(appU1).Envelopes).To(BeEquivalentTo([]types.PatchEnvelopeInfo{
 		{
 			PatchID:     patchID,
 			AllowedApps: []string{appU1, appU2},

--- a/pkg/pillar/cmd/zedagent/parseconfig_test.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig_test.go
@@ -42,7 +42,7 @@ func initGetConfigCtx(g *GomegaWithT) *getconfigContext {
 	})
 	pubPatchEnvelopes, err := ps.NewPublication(pubsub.PublicationOptions{
 		AgentName: agentName,
-		TopicType: types.PatchEnvelopes{},
+		TopicType: types.PatchEnvelopeInfoList{},
 	})
 	g.Expect(err).To(BeNil())
 	getconfigCtx := &getconfigContext{
@@ -1317,7 +1317,7 @@ func TestParsePatchEnvelope(t *testing.T) {
 	patchEnvelopes, err := getconfigCtx.pubPatchEnvelopeInfo.Get("zedagent")
 
 	g.Expect(err).To(BeNil())
-	pes, ok := patchEnvelopes.(types.PatchEnvelopes)
+	pes, ok := patchEnvelopes.(types.PatchEnvelopeInfoList)
 	g.Expect(ok).To(BeTrue())
 	shaBytes := sha256.Sum256([]byte(fileData))
 	g.Expect(pes.Get(appU1)).To(BeEquivalentTo([]types.PatchEnvelopeInfo{

--- a/pkg/pillar/cmd/zedagent/parseconfig_test.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig_test.go
@@ -1314,7 +1314,7 @@ func TestParsePatchEnvelope(t *testing.T) {
 	// Impl because we have to change filepath of persist cache for testing
 	parsePatchEnvelopesImpl(getconfigCtx, config, persistCacheFolder)
 
-	patchEnvelopes, err := getconfigCtx.pubPatchEnvelopeInfo.Get("zedagent")
+	patchEnvelopes, err := getconfigCtx.pubPatchEnvelopeInfo.Get("global")
 
 	g.Expect(err).To(BeNil())
 	pes, ok := patchEnvelopes.(types.PatchEnvelopeInfoList)

--- a/pkg/pillar/cmd/zedagent/parsepatchenvelopes.go
+++ b/pkg/pillar/cmd/zedagent/parsepatchenvelopes.go
@@ -94,6 +94,7 @@ func addBinaryBlobToPatchEnvelope(pe *types.PatchEnvelopeInfo, artifact *zconfig
 		if err != nil {
 			return err
 		}
+		volumeRef.ArtifactMetadata = artifact.GetArtifactMetaData()
 		pe.VolumeRefs = append(pe.VolumeRefs, *volumeRef)
 		return nil
 	case zconfig.EVE_OPAQUE_OBJECT_CATEGORY_SECRET:
@@ -106,6 +107,7 @@ func addBinaryBlobToPatchEnvelope(pe *types.PatchEnvelopeInfo, artifact *zconfig
 		if err != nil {
 			return err
 		}
+		binaryBlob.ArtifactMetadata = artifact.GetArtifactMetaData()
 		pe.BinaryBlobs = append(pe.BinaryBlobs, *binaryBlob)
 		return nil
 	}

--- a/pkg/pillar/cmd/zedagent/parsepatchenvelopes.go
+++ b/pkg/pillar/cmd/zedagent/parsepatchenvelopes.go
@@ -42,7 +42,7 @@ func parsePatchEnvelopesImpl(ctx *getconfigContext, config *zconfig.EdgeDevConfi
 
 	var blobsAfter []string
 	patchEnvelopes := config.GetPatchEnvelopes()
-	result := types.PatchEnvelopes{}
+	result := types.PatchEnvelopeInfoList{}
 	for _, pe := range patchEnvelopes {
 		peInfo := types.PatchEnvelopeInfo{
 			AllowedApps: pe.GetAppInstIdsAllowed(),
@@ -72,7 +72,7 @@ func parsePatchEnvelopesImpl(ctx *getconfigContext, config *zconfig.EdgeDevConfi
 	}
 }
 
-func publishPatchEnvelopes(ctx *getconfigContext, patchEnvelopes types.PatchEnvelopes) {
+func publishPatchEnvelopes(ctx *getconfigContext, patchEnvelopes types.PatchEnvelopeInfoList) {
 	key := patchEnvelopes.Key()
 	pub := ctx.pubPatchEnvelopeInfo
 

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -1204,7 +1204,7 @@ func initPublications(zedagentCtx *zedagentContext) {
 	getconfigCtx.pubPatchEnvelopeInfo, err = ps.NewPublication(
 		pubsub.PublicationOptions{
 			AgentName:  agentName,
-			TopicType:  types.PatchEnvelopes{},
+			TopicType:  types.PatchEnvelopeInfoList{},
 			Persistent: true,
 		})
 	if err != nil {

--- a/pkg/pillar/cmd/zedrouter/metadata.go
+++ b/pkg/pillar/cmd/zedrouter/metadata.go
@@ -31,6 +31,13 @@ const SignerMaxSize = 65535
 // DiagMaxSize is the max returned size for diag
 const DiagMaxSize = 65535
 
+// PatchEnvelopeURLPath is route used for patch envelopes
+// it is used in URL composing of patch envelopes
+const PatchEnvelopeURLPath = "/eve/v1/patch/"
+
+// MetaDataServerIP is IP of meta data server
+const MetaDataServerIP = "169.254.169.254"
+
 func (z *zedrouter) makeMetadataHandler() http.Handler {
 	r := chi.NewRouter()
 
@@ -87,7 +94,7 @@ func (z *zedrouter) makeMetadataHandler() http.Handler {
 	diagHandler := &diagHandler{zedrouter: z}
 	r.Get("/eve/v1/diag", diagHandler.ServeHTTP)
 
-	r.Route("/eve/v1/patch/", func(r chi.Router) {
+	r.Route(PatchEnvelopeURLPath, func(r chi.Router) {
 		r.Use(WithPatchEnvelopesByIP(z))
 
 		r.Get("/description.json", HandlePatchDescription(z))

--- a/pkg/pillar/cmd/zedrouter/metadata_handlers.go
+++ b/pkg/pillar/cmd/zedrouter/metadata_handlers.go
@@ -691,7 +691,7 @@ func WithPatchEnvelopesByIP(z *zedrouter) func(http.Handler) http.Handler {
 				return
 			}
 
-			pe := peObj.(types.PatchEnvelopes)
+			pe := peObj.(types.PatchEnvelopeInfoList)
 
 			remoteIP := net.ParseIP(strings.Split(r.RemoteAddr, ":")[0])
 			anStatus := z.lookupAppNetworkStatusByAppIP(remoteIP)

--- a/pkg/pillar/cmd/zedrouter/metadata_handlers.go
+++ b/pkg/pillar/cmd/zedrouter/metadata_handlers.go
@@ -517,8 +517,8 @@ func (hdl AppInfoHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		blob := types.AppBlobsAvailable{
 			CustomMeta: st.CustomMeta,
-			DownloadURL: fmt.Sprintf("http://169.254.169.254/eve/app-custom-blobs/%s",
-				st.DisplayName),
+			DownloadURL: fmt.Sprintf("http://%s/eve/app-custom-blobs/%s",
+				MetaDataServerIP, st.DisplayName),
 		}
 
 		appInfo.AppBlobs = append(appInfo.AppBlobs, blob)
@@ -583,7 +583,7 @@ func HandlePatchDescription(z *zedrouter) func(http.ResponseWriter, *http.Reques
 		// WithPatchEnvelopesByIP middleware returns envelopes which are more than 0
 		envelopes := r.Context().Value(patchEnvelopesContextKey).(types.PatchEnvelopeInfoList)
 
-		b, err := PatchEnvelopesJSONForAppInstance(envelopes)
+		b, err := patchEnvelopesJSONForAppInstance(envelopes)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusUnprocessableEntity)
 			return

--- a/pkg/pillar/cmd/zedrouter/metadata_handlers.go
+++ b/pkg/pillar/cmd/zedrouter/metadata_handlers.go
@@ -583,7 +583,7 @@ func HandlePatchDescription(z *zedrouter) func(http.ResponseWriter, *http.Reques
 		// WithPatchEnvelopesByIP middleware returns envelopes which are more than 0
 		envelopes := r.Context().Value(patchEnvelopesContextKey).(types.PatchEnvelopeInfoList)
 
-		b, err := types.PatchEnvelopesJSONForAppInstance(envelopes)
+		b, err := PatchEnvelopesJSONForAppInstance(envelopes)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusUnprocessableEntity)
 			return
@@ -685,13 +685,6 @@ func HandlePatchFileDownload(z *zedrouter) func(http.ResponseWriter, *http.Reque
 func WithPatchEnvelopesByIP(z *zedrouter) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			peObj, err := z.subPatchEnvelopeInfo.Get("zedagent")
-			if err != nil {
-				sendError(w, http.StatusNoContent, "Cannot get patch envelope subscription")
-				return
-			}
-
-			pe := peObj.(types.PatchEnvelopeInfoList)
 
 			remoteIP := net.ParseIP(strings.Split(r.RemoteAddr, ":")[0])
 			anStatus := z.lookupAppNetworkStatusByAppIP(remoteIP)
@@ -704,7 +697,7 @@ func WithPatchEnvelopesByIP(z *zedrouter) func(http.Handler) http.Handler {
 
 			appUUID := anStatus.UUIDandVersion.UUID
 
-			accessablePe := pe.Get(appUUID.String())
+			accessablePe := z.patchEnvelopes.Get(appUUID.String())
 			if len(accessablePe.Envelopes) == 0 {
 				sendError(w, http.StatusOK, fmt.Sprintf("No envelopes for %s", appUUID.String()))
 			}

--- a/pkg/pillar/cmd/zedrouter/metadata_handlers.go
+++ b/pkg/pillar/cmd/zedrouter/metadata_handlers.go
@@ -581,7 +581,7 @@ func (hdl AppCustomBlobsHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 func HandlePatchDescription(z *zedrouter) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// WithPatchEnvelopesByIP middleware returns envelopes which are more than 0
-		envelopes := r.Context().Value(patchEnvelopesContextKey).([]types.PatchEnvelopeInfo)
+		envelopes := r.Context().Value(patchEnvelopesContextKey).(types.PatchEnvelopeInfoList)
 
 		b, err := types.PatchEnvelopesJSONForAppInstance(envelopes)
 		if err != nil {
@@ -607,14 +607,14 @@ func sendError(w http.ResponseWriter, code int, msg string) {
 func HandlePatchDownload(z *zedrouter) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// WithPatchEnvelopesByIP middleware returns envelopes which are more than 0
-		envelopes := r.Context().Value(patchEnvelopesContextKey).([]types.PatchEnvelopeInfo)
+		envelopes := r.Context().Value(patchEnvelopesContextKey).(types.PatchEnvelopeInfoList)
 
 		patchID := chi.URLParam(r, "patch")
 		if patchID == "" {
 			sendError(w, http.StatusNoContent, "patch in route is missing")
 			return
 		}
-		e := types.FindPatchEnvelopeByID(envelopes, patchID)
+		e := envelopes.FindPatchEnvelopeByID(patchID)
 		if e != nil {
 			path, err := os.MkdirTemp("", "patchEnvelopeZip")
 			if err != nil {
@@ -650,7 +650,7 @@ func HandlePatchDownload(z *zedrouter) func(http.ResponseWriter, *http.Request) 
 func HandlePatchFileDownload(z *zedrouter) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// WithPatchEnvelopesByIP middleware returns envelopes which are more than 0
-		envelopes := r.Context().Value(patchEnvelopesContextKey).([]types.PatchEnvelopeInfo)
+		envelopes := r.Context().Value(patchEnvelopesContextKey).(types.PatchEnvelopeInfoList)
 
 		patchID := chi.URLParam(r, "patch")
 		if patchID == "" {
@@ -663,7 +663,7 @@ func HandlePatchFileDownload(z *zedrouter) func(http.ResponseWriter, *http.Reque
 			return
 		}
 
-		e := types.FindPatchEnvelopeByID(envelopes, patchID)
+		e := envelopes.FindPatchEnvelopeByID(patchID)
 		if e != nil {
 			if idx := types.CompletedBinaryBlobIdxByName(e.BinaryBlobs, fileName); idx != -1 {
 				http.ServeFile(w, r, e.BinaryBlobs[idx].URL)
@@ -704,12 +704,12 @@ func WithPatchEnvelopesByIP(z *zedrouter) func(http.Handler) http.Handler {
 
 			appUUID := anStatus.UUIDandVersion.UUID
 
-			envelopes := pe.Get(appUUID.String())
-			if len(envelopes) == 0 {
+			accessablePe := pe.Get(appUUID.String())
+			if len(accessablePe.Envelopes) == 0 {
 				sendError(w, http.StatusOK, fmt.Sprintf("No envelopes for %s", appUUID.String()))
 			}
 
-			ctx := context.WithValue(r.Context(), patchEnvelopesContextKey, envelopes)
+			ctx := context.WithValue(r.Context(), patchEnvelopesContextKey, accessablePe)
 
 			r = r.WithContext(ctx)
 			next.ServeHTTP(w, r)

--- a/pkg/pillar/cmd/zedrouter/patchenvelopes.go
+++ b/pkg/pillar/cmd/zedrouter/patchenvelopes.go
@@ -1,0 +1,302 @@
+// Copyright (c) 2023 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package zedrouter
+
+import (
+	"encoding/json"
+
+	uuid "github.com/satori/go.uuid"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/lf-edge/eve/pkg/pillar/utils/generics"
+)
+
+// PatchEnvelopes is a structure representing
+// Patch Envelopes exposed to App instances via metadata server
+// for more info check docs/PATCH-ENVELOPES.md
+// Must be created by calling NewPatchEnvelopes()
+//
+// Internally, PatchEnvelopes structure stores envelopes which
+// come from EdgeDevConfig parsed by zedagent. This envelopes contains
+// both inline binary artifacts which are ready to be downloaded by app instances
+// and volume references, which are handled by volumemgr.
+// So PatchEnvelopes struct has completedVolumes and contentTreeStatus to store
+// information of all volumes and contentTree handled by volumemgr to link them with
+// patch envelope volume references. ContentTreeStatus is used to retrieve SHA of underlying
+// file.
+// App instances are accessing PatchEnvelopes via metadata server handlers, which is calling
+// PatchEnvelopes.Get() method to get list of available PatchEnvelopeInfo
+// to certain App Instance which are stored in currentState.
+// PatchEnvelopes also hasupdateStateNotificationCh channel
+// to receive notification about the need of updating specified PatchEnvelopes.
+// Those updates are written in envelopesToUpdate and envelopesToDelete boolean maps, that
+// means that request to update same object will be only once, so there will be no queue of
+// go routines piling up but it will take more CPU time to process it.
+// NewPatchEnvelopes() starts goroutine processStateUpdate() which reads from the channel and updates
+// currentState to desired one.
+// This way handlers can do work of determining which patch envelopes actually need change (if any)
+// and send back in go routine rest of the update including slow work.
+// Note that this channels are only accessible from the outside by calling a function which returns
+// write-only channel, meaning that updateStateNotificationCh should not be
+// read from anywhere except processStateUpdate() so that there could not be any deadlock.
+type PatchEnvelopes struct {
+	updateStateNotificationCh chan struct{}
+
+	envelopesToUpdate *generics.LockedMap[uuid.UUID, bool]
+	envelopesToDelete *generics.LockedMap[uuid.UUID, bool]
+
+	currentState      *generics.LockedMap[uuid.UUID, types.PatchEnvelopeInfo]
+	envelopes         *generics.LockedMap[uuid.UUID, types.PatchEnvelopeInfo]
+	completedVolumes  *generics.LockedMap[uuid.UUID, types.VolumeStatus]
+	contentTreeStatus *generics.LockedMap[uuid.UUID, types.ContentTreeStatus]
+
+	log *base.LogObject
+}
+
+// UpdateStateNotificationCh return update channel to send notifications to update currentState
+func (pes *PatchEnvelopes) UpdateStateNotificationCh() chan<- struct{} {
+	return pes.updateStateNotificationCh
+}
+
+// NewPatchEnvelopes returns PatchEnvelopes structure and starts goroutine
+// to process messages from channels. Note that we create buffered channels
+// to avoid unbounded processing time in writing to channel
+func NewPatchEnvelopes(log *base.LogObject) *PatchEnvelopes {
+	pe := &PatchEnvelopes{
+
+		updateStateNotificationCh: make(chan struct{}, 1),
+
+		envelopesToUpdate: generics.NewLockedMap[uuid.UUID, bool](),
+		envelopesToDelete: generics.NewLockedMap[uuid.UUID, bool](),
+
+		currentState:      generics.NewLockedMap[uuid.UUID, types.PatchEnvelopeInfo](),
+		envelopes:         generics.NewLockedMap[uuid.UUID, types.PatchEnvelopeInfo](),
+		completedVolumes:  generics.NewLockedMap[uuid.UUID, types.VolumeStatus](),
+		contentTreeStatus: generics.NewLockedMap[uuid.UUID, types.ContentTreeStatus](),
+
+		log: log,
+	}
+
+	go pe.processStateUpdate()
+
+	return pe
+}
+
+func (pes *PatchEnvelopes) processStateUpdate() {
+	for {
+		select {
+		case <-pes.updateStateNotificationCh:
+			pes.updateState()
+		}
+	}
+}
+
+func (pes *PatchEnvelopes) updateState() {
+	keys := pes.envelopesToDelete.Keys()
+	for _, k := range keys {
+		if toDelete, _ := pes.envelopesToDelete.Load(k); toDelete {
+			pes.currentState.Delete(k)
+			pes.envelopesToDelete.Store(k, false)
+		}
+	}
+
+	keys = pes.envelopesToUpdate.Keys()
+	for _, peUUID := range keys {
+		if needsUpdate, _ := pes.envelopesToUpdate.Load(peUUID); needsUpdate {
+			if peInfo, ok := pes.envelopes.Load(peUUID); ok {
+				pes.currentState.Store(peUUID, peInfo)
+
+				if pe, ok := pes.currentState.Load(peUUID); ok {
+					for _, volRef := range pe.VolumeRefs {
+						if blob := pes.blobFromVolumeRef(volRef); blob != nil {
+							if idx := types.CompletedBinaryBlobIdxByName(pe.BinaryBlobs, blob.FileName); idx != -1 {
+								pe.BinaryBlobs[idx] = *blob
+							} else {
+								pe.BinaryBlobs = append(pe.BinaryBlobs, *blob)
+							}
+						}
+					}
+
+					pes.currentState.Store(peUUID, pe)
+					pes.envelopesToUpdate.Store(peUUID, false)
+
+				} else {
+					pes.log.Errorf("No entry in currentState for %v to update", peUUID)
+				}
+			} else {
+				pes.log.Errorf("No entry in envelopes for %v to fetch", peUUID)
+			}
+		}
+	}
+}
+
+// Get returns list of Patch Envelopes available for this app instance
+func (pes *PatchEnvelopes) Get(appUUID string) types.PatchEnvelopeInfoList {
+	var res []types.PatchEnvelopeInfo
+	pes.currentState.Range(func(patchEnvelopeUUID uuid.UUID, envelope types.PatchEnvelopeInfo) bool {
+		for _, allowedUUID := range envelope.AllowedApps {
+			if allowedUUID == appUUID {
+				res = append(res, envelope)
+				break
+			}
+		}
+		return true
+	})
+
+	return types.PatchEnvelopeInfoList{
+		Envelopes: res,
+	}
+}
+
+func (pes *PatchEnvelopes) blobFromVolumeRef(vr types.BinaryBlobVolumeRef) *types.BinaryBlobCompleted {
+	volUUID, err := uuid.FromString(vr.ImageID)
+	if err != nil {
+		pes.log.Errorf("Failed to compose volUUID from string %v", err)
+		return nil
+	}
+	if vs, hasVs := pes.completedVolumes.Load(volUUID); hasVs {
+		result := &types.BinaryBlobCompleted{
+			FileName:         vr.FileName,
+			FileMetadata:     vr.FileMetadata,
+			ArtifactMetadata: vr.ArtifactMetadata,
+			URL:              vs.FileLocation,
+		}
+
+		if ct, hasCt := pes.contentTreeStatus.Load(vs.ContentID); hasCt {
+			result.FileSha = ct.ContentSha256
+		}
+
+		return result
+	}
+
+	return nil
+}
+
+// UpdateVolumeStatus adds or removes VolumeStatus from PatchEnvelopes structure
+func (pes *PatchEnvelopes) UpdateVolumeStatus(vs types.VolumeStatus, deleteVolume bool) {
+	if deleteVolume {
+		pes.completedVolumes.Delete(vs.VolumeID)
+	} else {
+		if vs.State < types.CREATED_VOLUME {
+			return
+		}
+		pes.completedVolumes.Store(vs.VolumeID, vs)
+	}
+	pes.affectedByVolumeStatus(vs)
+}
+
+// affectedByVolumeStatus fills in envelopesToUpdate map marking PatchEnvelopes
+// which need to be updated
+func (pes *PatchEnvelopes) affectedByVolumeStatus(vs types.VolumeStatus) {
+	UUIDList := pes.envelopes.Keys()
+
+	for _, UUID := range UUIDList {
+		if pe, ok := pes.envelopes.Load(UUID); ok {
+			for _, volRef := range pe.VolumeRefs {
+				volUUID, err := uuid.FromString(volRef.ImageID)
+				if err != nil {
+					pes.log.Errorf("Failed to compose volUUID from string %v", err)
+					continue
+				}
+				if vs.VolumeID == volUUID {
+					pes.envelopesToUpdate.Store(UUID, true)
+				}
+			}
+		} else {
+			pes.log.Errorf("No %v UUID in envelopes to check in affectedByVolumeStatus", UUID)
+		}
+	}
+}
+
+// UpdateEnvelopes sets pes.envelopes and marks envelopes that are not
+// present in new peInfo as ones to be deleted and updates the rest of them
+// all of the updates will happen after notification to updateStateNotificationCh
+// will be sent
+func (pes *PatchEnvelopes) UpdateEnvelopes(peInfo []types.PatchEnvelopeInfo) {
+
+	before := pes.envelopes.Keys()
+
+	envelopes := generics.NewLockedMap[uuid.UUID, types.PatchEnvelopeInfo]()
+
+	for _, pe := range peInfo {
+		peUUID, err := uuid.FromString(pe.PatchID)
+		if err != nil {
+			pes.log.Errorf("Failed to Update Envelopes :%v", err)
+		}
+		envelopes.Store(peUUID, pe)
+	}
+
+	toUpdate := envelopes.Keys()
+
+	toDelete, _ := generics.DiffSets(before, toUpdate)
+
+	pes.envelopes = envelopes
+
+	for _, deleteUUID := range toDelete {
+		pes.envelopesToDelete.Store(deleteUUID, true)
+	}
+
+	for _, updateUUID := range toUpdate {
+		pes.envelopesToUpdate.Store(updateUUID, true)
+	}
+}
+
+// UpdateContentTree adds or removes ContentTreeStatus from PatchEnvelopes structure
+// marks PatchEnvelopes which will require update. Update will happen explicitly
+// after sending notification to updateStateNotificationCh
+func (pes *PatchEnvelopes) UpdateContentTree(ct types.ContentTreeStatus, deleteCt bool) {
+	if deleteCt {
+		pes.contentTreeStatus.Delete(ct.ContentID)
+	} else {
+		pes.contentTreeStatus.Store(ct.ContentID, ct)
+	}
+
+	pes.affectedByContentTree(ct)
+}
+
+// affectedByContentTree fills in envelopesToUpdate map marking PatchEnvelopes
+// which will require update because they are linked to ContentTreeStatus specified
+func (pes *PatchEnvelopes) affectedByContentTree(ct types.ContentTreeStatus) {
+	UUIDList := pes.completedVolumes.Keys()
+
+	for _, UUID := range UUIDList {
+		if vs, ok := pes.completedVolumes.Load(UUID); ok {
+			if vs.ContentID == ct.ContentID {
+				pes.affectedByVolumeStatus(vs)
+			}
+		} else {
+			pes.log.Errorf("affectedByContentTree: no %v found in completedVolumes", UUID)
+		}
+	}
+}
+
+// PatchEnvelopeInfo contains fields that we don't want to expose to app instance (like AllowedApps), so we use
+// peInfoToDisplay and patchEnvelopesJSONFOrAppInstance to marshal PatchEnvelopeInfoList in a format, which is
+// suitable for app instance.
+// We cannot use json:"-" structure tag to omit AllowedApps from json marshaling since we use PatchEnvelopeInfo between
+// zedagent and zedrouter to communicate new PatchEnvelopes from EdgeDevConfig. This communication is done via pubSub,
+// which uses json marshaling to communicate structures between processes. And using json:"-" will make AllowedApps "magically"
+// disappear on zedrouter
+type peInfoToDisplay struct {
+	PatchID     string
+	BinaryBlobs []types.BinaryBlobCompleted
+	VolumeRefs  []types.BinaryBlobVolumeRef
+}
+
+// PatchEnvelopesJSONForAppInstance returns json representation
+// of Patch Envelopes list which are shown to app instances
+func PatchEnvelopesJSONForAppInstance(pe types.PatchEnvelopeInfoList) ([]byte, error) {
+	toDisplay := make([]peInfoToDisplay, len(pe.Envelopes))
+
+	for i, envelope := range pe.Envelopes {
+		toDisplay[i] = peInfoToDisplay{
+			PatchID:     envelope.PatchID,
+			BinaryBlobs: envelope.BinaryBlobs,
+			VolumeRefs:  envelope.VolumeRefs,
+		}
+	}
+
+	return json.Marshal(toDisplay)
+}

--- a/pkg/pillar/cmd/zedrouter/patchenvelopes.go
+++ b/pkg/pillar/cmd/zedrouter/patchenvelopes.go
@@ -5,6 +5,7 @@ package zedrouter
 
 import (
 	"encoding/json"
+	"fmt"
 
 	uuid "github.com/satori/go.uuid"
 
@@ -285,15 +286,28 @@ type peInfoToDisplay struct {
 	VolumeRefs  []types.BinaryBlobVolumeRef
 }
 
-// PatchEnvelopesJSONForAppInstance returns json representation
+// patchEnvelopesJSONForAppInstance returns json representation
 // of Patch Envelopes list which are shown to app instances
-func PatchEnvelopesJSONForAppInstance(pe types.PatchEnvelopeInfoList) ([]byte, error) {
+func patchEnvelopesJSONForAppInstance(pe types.PatchEnvelopeInfoList) ([]byte, error) {
 	toDisplay := make([]peInfoToDisplay, len(pe.Envelopes))
 
 	for i, envelope := range pe.Envelopes {
+
+		var binaryBlobs []types.BinaryBlobCompleted
+		binaryBlobs = nil
+		if envelope.BinaryBlobs != nil {
+			binaryBlobs = make([]types.BinaryBlobCompleted, len(envelope.BinaryBlobs))
+			copy(binaryBlobs, envelope.BinaryBlobs)
+		}
+
+		for j := range binaryBlobs {
+			url := fmt.Sprintf("http://%s%sdownload/%s/%s", MetaDataServerIP, PatchEnvelopeURLPath, envelope.PatchID, binaryBlobs[j].FileName)
+			binaryBlobs[j].URL = url
+		}
+
 		toDisplay[i] = peInfoToDisplay{
 			PatchID:     envelope.PatchID,
-			BinaryBlobs: envelope.BinaryBlobs,
+			BinaryBlobs: binaryBlobs,
 			VolumeRefs:  envelope.VolumeRefs,
 		}
 	}

--- a/pkg/pillar/cmd/zedrouter/patchenvelopes_test.go
+++ b/pkg/pillar/cmd/zedrouter/patchenvelopes_test.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2023 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package zedrouter_test
+
+import (
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/cmd/zedrouter"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/onsi/gomega"
+	uuid "github.com/satori/go.uuid"
+	"github.com/sirupsen/logrus"
+)
+
+func TestPatchEnvelopes(t *testing.T) {
+	t.Parallel()
+
+	g := gomega.NewGomegaWithT(t)
+
+	logger := logrus.StandardLogger()
+	log := base.NewSourceLogObject(logger, "petypes", 1234)
+	peStore := zedrouter.NewPatchEnvelopes(log)
+
+	u := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+	contentU := "6ba7b810-9dad-11d1-80b4-ffffffffffff"
+	u1, err := uuid.FromString(u)
+	g.Expect(err).To(gomega.BeNil())
+	u2, err := uuid.FromString(contentU)
+	g.Expect(err).To(gomega.BeNil())
+	fileSHA := "someFileSha"
+	f := "some/File/Location.txt"
+
+	volumeStatuses := []types.VolumeStatus{
+		{
+			VolumeID:     u1,
+			ContentID:    u2,
+			State:        types.INSTALLED,
+			FileLocation: f,
+		},
+	}
+
+	contentStatuses := []types.ContentTreeStatus{
+		{
+			ContentID:     u2,
+			ContentSha256: fileSHA,
+		},
+	}
+
+	peInfo := []types.PatchEnvelopeInfo{
+		{
+			PatchID:     "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+			AllowedApps: []string{u},
+			BinaryBlobs: []types.BinaryBlobCompleted{
+				{
+					FileName:     "TestFileName",
+					FileSha:      "TestFileSha",
+					FileMetadata: "TestFileMetadata",
+					URL:          "./testurl",
+				},
+			},
+			VolumeRefs: []types.BinaryBlobVolumeRef{
+				{
+					FileName:     "VolTestFileName",
+					ImageName:    "VolTestImageName",
+					FileMetadata: "VolTestFileMetadata",
+					ImageID:      u,
+				},
+			},
+		},
+	}
+
+	peStore.Wg.Add(1)
+	go func() {
+		for _, vs := range volumeStatuses {
+			peStore.UpdateVolumeStatus(vs, false)
+			peStore.UpdateStateNotificationCh() <- struct{}{}
+		}
+	}()
+
+	peStore.Wg.Add(1)
+	go func() {
+		for _, ct := range contentStatuses {
+			peStore.UpdateContentTree(ct, false)
+
+			peStore.UpdateStateNotificationCh() <- struct{}{}
+		}
+	}()
+
+	go func() {
+		peStore.UpdateEnvelopes(peInfo)
+
+		peStore.UpdateStateNotificationCh() <- struct{}{}
+
+	}()
+
+	finishedProcessing := make(chan struct{})
+	go func() {
+		for {
+
+			if len(peStore.Get(u).Envelopes) > 0 && len(peStore.Get(u).Envelopes[0].BinaryBlobs) >= 2 {
+				close(finishedProcessing)
+				return
+			}
+			time.Sleep(time.Second)
+		}
+	}()
+
+	g.Eventually(func() bool {
+		select {
+		case <-finishedProcessing:
+			return true
+		case <-time.After(time.Minute):
+			return false
+		}
+	}, 2*time.Minute, time.Second).Should(gomega.BeTrue())
+>>>>>>> 8d39825eb (MERGE ME 2)
+
+	g.Expect(peStore.Get(u).Envelopes).To(gomega.BeEquivalentTo(
+		[]types.PatchEnvelopeInfo{
+			{
+				PatchID:     "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+				AllowedApps: []string{u},
+				BinaryBlobs: []types.BinaryBlobCompleted{
+					{
+						FileName:     "TestFileName",
+						FileSha:      "TestFileSha",
+						FileMetadata: "TestFileMetadata",
+						URL:          "./testurl",
+					},
+					{
+						FileName: "VolTestFileName",
+						//pragma: allowlist nextline secret
+						FileSha:      fileSHA,
+						FileMetadata: "VolTestFileMetadata",
+						URL:          f,
+					},
+				},
+				VolumeRefs: []types.BinaryBlobVolumeRef{
+					{
+						FileName:     "VolTestFileName",
+						ImageName:    "VolTestImageName",
+						FileMetadata: "VolTestFileMetadata",
+						ImageID:      u,
+					},
+				},
+			},
+		}))
+}

--- a/pkg/pillar/cmd/zedrouter/patchenvelopes_test.go
+++ b/pkg/pillar/cmd/zedrouter/patchenvelopes_test.go
@@ -5,6 +5,7 @@ package zedrouter_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/cmd/zedrouter"
@@ -71,7 +72,6 @@ func TestPatchEnvelopes(t *testing.T) {
 		},
 	}
 
-	peStore.Wg.Add(1)
 	go func() {
 		for _, vs := range volumeStatuses {
 			peStore.UpdateVolumeStatus(vs, false)
@@ -79,7 +79,6 @@ func TestPatchEnvelopes(t *testing.T) {
 		}
 	}()
 
-	peStore.Wg.Add(1)
 	go func() {
 		for _, ct := range contentStatuses {
 			peStore.UpdateContentTree(ct, false)
@@ -98,7 +97,6 @@ func TestPatchEnvelopes(t *testing.T) {
 	finishedProcessing := make(chan struct{})
 	go func() {
 		for {
-
 			if len(peStore.Get(u).Envelopes) > 0 && len(peStore.Get(u).Envelopes[0].BinaryBlobs) >= 2 {
 				close(finishedProcessing)
 				return
@@ -115,7 +113,6 @@ func TestPatchEnvelopes(t *testing.T) {
 			return false
 		}
 	}, 2*time.Minute, time.Second).Should(gomega.BeTrue())
->>>>>>> 8d39825eb (MERGE ME 2)
 
 	g.Expect(peStore.Get(u).Envelopes).To(gomega.BeEquivalentTo(
 		[]types.PatchEnvelopeInfo{

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -801,7 +801,7 @@ func (z *zedrouter) initSubscriptions() (err error) {
 	z.subPatchEnvelopeInfo, err = z.pubSub.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:   "zedagent",
 		MyAgentName: agentName,
-		TopicImpl:   types.PatchEnvelopes{},
+		TopicImpl:   types.PatchEnvelopeInfoList{},
 		Activate:    false,
 		WarningTime: warningTime,
 		ErrorTime:   errorTime,

--- a/pkg/pillar/types/patchenvelopestypes.go
+++ b/pkg/pillar/types/patchenvelopestypes.go
@@ -11,14 +11,14 @@ import (
 	"path/filepath"
 )
 
-// PatchEnvelopes is a wrapper
+// PatchEnvelopeInfoList is a wrapper
 // to send patch envelopes
-type PatchEnvelopes struct {
+type PatchEnvelopeInfoList struct {
 	Envelopes []PatchEnvelopeInfo
 }
 
 // Get returns list of patch envelopes, which are available to appUUID
-func (pe *PatchEnvelopes) Get(appUUID string) []PatchEnvelopeInfo {
+func (pe *PatchEnvelopeInfoList) Get(appUUID string) []PatchEnvelopeInfo {
 	var res []PatchEnvelopeInfo
 
 	for _, envelope := range pe.Envelopes {
@@ -34,7 +34,7 @@ func (pe *PatchEnvelopes) Get(appUUID string) []PatchEnvelopeInfo {
 }
 
 // Key for pubsub
-func (PatchEnvelopes) Key() string {
+func (PatchEnvelopeInfoList) Key() string {
 	return "zedagent"
 }
 

--- a/pkg/pillar/types/patchenvelopestypes.go
+++ b/pkg/pillar/types/patchenvelopestypes.go
@@ -54,10 +54,13 @@ func (pe *PatchEnvelopeInfoList) FindPatchEnvelopeByID(patchID string) *PatchEnv
 // BinaryBlobCompleted is representation of
 // binary blob ready to be downloaded by app instance
 type BinaryBlobCompleted struct {
-	FileName     string `json:"fileName"`
-	FileSha      string `json:"fileSha"`
+	FileName string `json:"fileName"`
+	FileSha  string `json:"fileSha"`
+	// FileMetadata is related to file, i.e. env variables, cli arguments
 	FileMetadata string `json:"fileMetaData"`
-	URL          string `json:"url"` //nolint:var-naming
+	// ArtifactMetadata is generic info i.e. user info, desc etc.
+	ArtifactMetadata string `json:"artifactMetaData"`
+	URL              string `json:"url"` //nolint:var-naming
 }
 
 // CompletedBinaryBlobIdxByName returns index of element in blobs list
@@ -75,8 +78,11 @@ func CompletedBinaryBlobIdxByName(blobs []BinaryBlobCompleted, name string) int 
 // external binary blobs, which has not yet been
 // downloaded
 type BinaryBlobVolumeRef struct {
-	FileName     string `json:"fileName"`
-	ImageName    string `json:"imageName"`
+	FileName  string `json:"fileName"`
+	ImageName string `json:"imageName"`
+	// FileMetadata is related to file, i.e. env variables, cli arguments
 	FileMetadata string `json:"fileMetaData"`
-	ImageID      string `json:"imageId"`
+	// ArtifactMetadata is generic info i.e. user info, desc etc.
+	ArtifactMetadata string `json:"artifactMetaData"`
+	ImageID          string `json:"imageId"`
 }

--- a/pkg/pillar/types/patchenvelopestypes.go
+++ b/pkg/pillar/types/patchenvelopestypes.go
@@ -3,10 +3,6 @@
 
 package types
 
-import (
-	"encoding/json"
-)
-
 // PatchEnvelopeInfoList will be shared with zedrouter after parsing
 // in zedagent
 type PatchEnvelopeInfoList struct {
@@ -38,31 +34,6 @@ type PatchEnvelopeInfo struct {
 	PatchID     string
 	BinaryBlobs []BinaryBlobCompleted
 	VolumeRefs  []BinaryBlobVolumeRef
-}
-
-// since we use json in pubsub we cannot use json - tag
-// and therefore we need some representational structure
-// for PatchEnvelopeInfo.
-type peInfoToDisplay struct {
-	PatchID     string
-	BinaryBlobs []BinaryBlobCompleted
-	VolumeRefs  []BinaryBlobVolumeRef
-}
-
-// PatchEnvelopesJSONForAppInstance returns json representation
-// of Patch Envelopes list which are shown to app instances
-func PatchEnvelopesJSONForAppInstance(pe PatchEnvelopeInfoList) ([]byte, error) {
-	toDisplay := make([]peInfoToDisplay, len(pe.Envelopes))
-
-	for i, envelope := range pe.Envelopes {
-		toDisplay[i] = peInfoToDisplay{
-			PatchID:     envelope.PatchID,
-			BinaryBlobs: envelope.BinaryBlobs,
-			VolumeRefs:  envelope.VolumeRefs,
-		}
-	}
-
-	return json.Marshal(toDisplay)
 }
 
 // Key for pubsub

--- a/pkg/pillar/types/patchenvelopestypes_test.go
+++ b/pkg/pillar/types/patchenvelopestypes_test.go
@@ -4,21 +4,19 @@
 package types_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/onsi/gomega"
-	"github.com/stretchr/testify/assert"
 )
 
-func TestPatchEnvelopes(t *testing.T) {
+func TestPatchEnvelopeInfoList(t *testing.T) {
 	t.Parallel()
 
 	g := gomega.NewGomegaWithT(t)
 	pe := types.PatchEnvelopeInfoList{}
 
-	uuidString := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+	uuidString := "6ba7b810-9dad-13d0-80b4-00c04fd430c8"
 	peInfo := types.PatchEnvelopeInfo{
 		PatchID:     "PatchId1",
 		AllowedApps: []string{uuidString},
@@ -35,42 +33,6 @@ func TestPatchEnvelopes(t *testing.T) {
 	pe.Envelopes = append(pe.Envelopes, peInfo)
 
 	g.Expect(pe.Get(uuidString)).To(gomega.BeEquivalentTo([]types.PatchEnvelopeInfo{peInfo}))
-
-	// Test GetZipArchive
-	filecontent := "blobfilecontent"
-	err := os.WriteFile(peInfo.BinaryBlobs[0].URL, []byte(filecontent), 0600)
-	g.Expect(err).To(gomega.BeNil())
-	defer os.Remove(peInfo.BinaryBlobs[0].URL)
-
-	peInfo = types.PatchEnvelopeInfo{
-		AllowedApps: []string{"17daa0ff-39d6-42be-a537-44c974276aec"},
-		PatchID:     "699fbdb2-e455-448f-84f5-68e547ec1305",
-		BinaryBlobs: []types.BinaryBlobCompleted{
-			{
-				FileName: "textfile1.txt",
-				//pragma: allowlist nextline secret
-				FileSha:      "e5f3f80da0f9a3add3540a80d214069079f71e879b87c51c4c3a258989294812",
-				FileMetadata: "YXJ0aWZhY3QgbWV0YWRhdGE=",
-				URL:          "/persist/patchEnvelopesCache/textfile1.txt",
-			},
-			{
-				FileName: "textfile2.txt",
-				//pragma: allowlist nextline secret
-				FileSha:      "e5f3f80da0f9a3add3540a80d214069079f71e879b87c51c4c3a258989294812",
-				FileMetadata: "YXJ0aWZhY3QgbWV0YWRhdGE=",
-				URL:          "/persist/patchEnvelopesCache/textfile2.txt",
-			},
-		},
-	}
-	pe = types.PatchEnvelopeInfoList{
-		Envelopes: []types.PatchEnvelopeInfo{peInfo},
-	}
-
-	got := pe.Get("17daa0ff-39d6-42be-a537-44c974276aec")
-	assert.Equal(t, got, []types.PatchEnvelopeInfo{peInfo})
-
-	assert.Equal(t, peInfo, *types.FindPatchEnvelopeByID(got, "699fbdb2-e455-448f-84f5-68e547ec1305"))
-
 }
 
 func TestFindPatchEnvelopeById(t *testing.T) {
@@ -88,14 +50,16 @@ func TestFindPatchEnvelopeById(t *testing.T) {
 		PatchID: "PatchId3",
 	}
 
-	pes := []types.PatchEnvelopeInfo{pe1, pe2, pe3}
+	pes := types.PatchEnvelopeInfoList{
+		Envelopes: []types.PatchEnvelopeInfo{pe1, pe2, pe3},
+	}
 
-	got := types.FindPatchEnvelopeByID(pes, pe1.PatchID)
+	got := pes.FindPatchEnvelopeByID(pe1.PatchID)
 	g.Expect(got).To(gomega.BeEquivalentTo(&pe1))
 
-	got = types.FindPatchEnvelopeByID(pes, pe2.PatchID)
+	got = pes.FindPatchEnvelopeByID(pe2.PatchID)
 	g.Expect(got).To(gomega.BeEquivalentTo(&pe2))
 
-	got = types.FindPatchEnvelopeByID(pes, "NonExistingPatchId")
+	got = pes.FindPatchEnvelopeByID("NonExistingPatchId")
 	g.Expect(got).To(gomega.BeNil())
 }

--- a/pkg/pillar/types/patchenvelopestypes_test.go
+++ b/pkg/pillar/types/patchenvelopestypes_test.go
@@ -16,7 +16,7 @@ func TestPatchEnvelopes(t *testing.T) {
 	t.Parallel()
 
 	g := gomega.NewGomegaWithT(t)
-	pe := types.PatchEnvelopes{}
+	pe := types.PatchEnvelopeInfoList{}
 
 	uuidString := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
 	peInfo := types.PatchEnvelopeInfo{
@@ -62,7 +62,7 @@ func TestPatchEnvelopes(t *testing.T) {
 			},
 		},
 	}
-	pe = types.PatchEnvelopes{
+	pe = types.PatchEnvelopeInfoList{
 		Envelopes: []types.PatchEnvelopeInfo{peInfo},
 	}
 

--- a/pkg/pillar/types/patchenvelopestypes_test.go
+++ b/pkg/pillar/types/patchenvelopestypes_test.go
@@ -32,7 +32,7 @@ func TestPatchEnvelopeInfoList(t *testing.T) {
 
 	pe.Envelopes = append(pe.Envelopes, peInfo)
 
-	g.Expect(pe.Get(uuidString)).To(gomega.BeEquivalentTo([]types.PatchEnvelopeInfo{peInfo}))
+	g.Expect(pe.Get(uuidString).Envelopes).To(gomega.BeEquivalentTo([]types.PatchEnvelopeInfo{peInfo}))
 }
 
 func TestFindPatchEnvelopeById(t *testing.T) {

--- a/pkg/pillar/utils/generics/lockmap.go
+++ b/pkg/pillar/utils/generics/lockmap.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2023 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package generics
+
+import "sync"
+
+// LockedMap is a wrapper on map with locking API is similar to sync.Map
+// difference is that sync.Map is optimized for two common use cases:
+// (1) when the entry for a given key is only ever written once but read many times
+// (2) when multiple goroutines read, write and overwrite entries for disjoint set of keys
+// In these casees use sync.Map, in other cases consider using LockedMap
+//
+// LockedMap should be created by calling NewLockedMap()
+type LockedMap[K comparable, V any] struct {
+	sync.RWMutex
+	locked map[K]V
+}
+
+// NewLockedMap returns initialized LockedMap struct
+func NewLockedMap[K comparable, V any]() *LockedMap[K, V] {
+	return &LockedMap[K, V]{
+		locked: make(map[K]V),
+	}
+}
+
+// Load returns value for given key; bool shows if map contains variable
+func (lm *LockedMap[K, V]) Load(key K) (V, bool) {
+	lm.RLock()
+	result, ok := lm.locked[key]
+	lm.RUnlock()
+	return result, ok
+}
+
+// Delete removes value from map for given key
+func (lm *LockedMap[K, V]) Delete(key K) {
+	lm.Lock()
+	delete(lm.locked, key)
+	lm.Unlock()
+}
+
+// Store saves value for given key. Overrites previous value
+func (lm *LockedMap[K, V]) Store(key K, value V) {
+	lm.Lock()
+	lm.locked[key] = value
+	lm.Unlock()
+}
+
+// Keys return copy of keys for locked map
+func (lm *LockedMap[K, V]) Keys() []K {
+	lm.Lock()
+	defer lm.Unlock()
+
+	result := make([]K, 0, len(lm.locked))
+	for k := range lm.locked {
+		result = append(result, k)
+	}
+
+	return result
+}
+
+// LockedMapFunc is function signature for Range function
+type LockedMapFunc[K comparable, V any] func(K, V) bool
+
+// Range iterates over map and applies callback to every element
+// iteration stops if callback returns false.
+// callback function is not allowed to do any changes on map
+// (Store, Delete or Load) since that can deadlock
+func (lm *LockedMap[K, V]) Range(callback LockedMapFunc[K, V]) {
+	lm.RLock()
+	for k, v := range lm.locked {
+		if !callback(k, v) {
+			break
+		}
+	}
+	lm.RUnlock()
+}

--- a/pkg/pillar/utils/generics/lockmap_test.go
+++ b/pkg/pillar/utils/generics/lockmap_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2023 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package generics_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/utils/generics"
+	. "github.com/onsi/gomega"
+)
+
+func TestLockedMap(t *testing.T) {
+	t.Parallel()
+
+	g := NewGomegaWithT(t)
+
+	lm := generics.NewLockedMap[int, string]()
+
+	lm.Store(42, "bazinga")
+
+	got, ok := lm.Load(42)
+	g.Expect(ok).To(BeEquivalentTo(true))
+	g.Expect(got).To(BeEquivalentTo("bazinga"))
+
+	lm.Delete(42)
+	got, ok = lm.Load(42)
+	// in case value does not exist, underlying
+	// map will return default-initialized value for
+	// type V of LockedMap in this case it will be
+	// empty string
+	g.Expect(got).To(BeEquivalentTo(""))
+	g.Expect(ok).To(BeEquivalentTo(false))
+}
+
+func TestLockedMapAsyncWriteRead(t *testing.T) {
+	t.Parallel()
+
+	g := NewGomegaWithT(t)
+
+	data := map[int]string{
+		42:    "bazinga",
+		51:    "anotherpayload",
+		581:   "test",
+		423:   "another test",
+		5103:  "Another text",
+		10213: "Some more text",
+	}
+
+	lm := generics.NewLockedMap[int, string]()
+
+	wg := sync.WaitGroup{}
+
+	for k, v := range data {
+		wg.Add(1)
+		keyCopy, valueCopy := k, v
+		go func() {
+			lm.Store(keyCopy, valueCopy)
+			// check that value is stored
+			got, ok := lm.Load(keyCopy)
+			g.Expect(ok).To(BeEquivalentTo(true))
+			g.Expect(got).To(BeEquivalentTo(valueCopy))
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+
+	// check that all values are present
+	for k, v := range data {
+		got, ok := lm.Load(k)
+		g.Expect(ok).To(BeEquivalentTo(true))
+		g.Expect(got).To(BeEquivalentTo(v))
+	}
+}

--- a/pkg/pillar/utils/patchenvelopesutils_test.go
+++ b/pkg/pillar/utils/patchenvelopesutils_test.go
@@ -29,17 +29,18 @@ func TestGetZipArchive(t *testing.T) {
 		AllowedApps: []string{uuidString},
 		BinaryBlobs: []types.BinaryBlobCompleted{
 			{
-				FileName:     "TestFileName",
-				FileSha:      "TestFileSha",
-				FileMetadata: "TestFileMetadata",
-				URL:          "./testurl",
+				FileName:         "TestFileName",
+				FileSha:          "TestFileSha",
+				ArtifactMetadata: "TestArtifactMetadata",
+				FileMetadata:     "TestFileMetadata",
+				URL:              "./testurl",
 			},
 		},
 	}
 
 	pe.Envelopes = append(pe.Envelopes, peInfo)
 
-	g.Expect(pe.Get(uuidString)).To(gomega.BeEquivalentTo([]types.PatchEnvelopeInfo{peInfo}))
+	g.Expect(pe.Get(uuidString).Envelopes).To(gomega.BeEquivalentTo([]types.PatchEnvelopeInfo{peInfo}))
 
 	// Test GetZipArchive
 	root := "./"

--- a/pkg/pillar/utils/patchenvelopesutils_test.go
+++ b/pkg/pillar/utils/patchenvelopesutils_test.go
@@ -21,7 +21,7 @@ func TestGetZipArchive(t *testing.T) {
 	t.Parallel()
 
 	g := gomega.NewGomegaWithT(t)
-	pe := types.PatchEnvelopes{}
+	pe := types.PatchEnvelopeInfoList{}
 
 	uuidString := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
 	peInfo := types.PatchEnvelopeInfo{


### PR DESCRIPTION
rework of #3480 

### Background and high level implementation

Patch envelopes are nothing more but a data exposed to Edge Applications
by EVE in runtime. This is done by metadata server which is part of zedrouter.
There are two types of patch envelopes: inline and external.

Inline patch envelopes are small objects (10Kbytes max as of now) which
are part of EdgeDevConfig.

External patch envelopes are volumes, downloaded by EVE and exposed to
Edge Applications via metadata server. Volumes are handled by other volumemgr
service which means that with external patch envelopes we need to get updates
not only from zedagent but also from volumemgr and those updates are not in
sync. So in order to handle that we need to

1) Separate information sent by zedagent to what we actually expose in zedrouter
2) Implement structure which will handle async updates from volumemgr and zedagent
3) Switch metadata server to using structure implemented in 2)

In addition this PR adds artifactMetaData field to binary artifacts

This PR has been tested will remove WIP once all Yetus fixes are done 