### PR TITLE
workflows/unit.yml: add tpm test timeout

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -23,6 +23,7 @@ jobs:
         run: |
           make test
       - name : Test (TPM Required)
+        timeout-minutes: 30
         run: |
           bash tools/tpm-tests-on-qemu.sh
       - name: Report test results as Annotations


### PR DESCRIPTION
When"Test (TPM Required)" tries to ssh to the eve, It might (rarely) stuck for a random reason, added timeout to not block a runners for 6h.