### PR TITLE
[10.4 stable] return 600M overhead limit for containers case

### DIFF
--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -464,11 +464,7 @@ func (ctx kvmContext) Task(status *types.DomainStatus) types.Task {
 
 // TBD: Have a better way to calculate this number.
 // For now it is based on some trial-and-error experiments.
-// Container limit is reduced to 100MiB.
 func minVMMOverhead(config types.DomainConfig) int64 {
-	if config.IsOCIContainer() {
-		return 100 << 20 // Mb in bytes
-	}
 	return 600 << 20 // Mb in bytes
 }
 


### PR DESCRIPTION
This reverts commit 6f761791b46394d5fa31377878f93ddd44baeb3c.

We notice increased number of customer issues on the latest EVE versions, when QEMU process was killed by the OOM killer. So revert the overhead to 600M value.

In the EVE master the estimation algorithm is more sophisticated, please take a look here:

   d88091ba7959 ("New formula to estimate VMM memory overhead (x86)")

The rule of thumb is to leave the overhead tuning to a customer using the corresponding field on the controller side.