### PR TITLE
[9.4-stable] Do not fail SealDiskKey if PCRs/eventlog can not be saved

### DIFF
--- a/pkg/pillar/cmd/vaultmgr/vaultmgr.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgr.go
@@ -418,7 +418,7 @@ func handleVaultKeyFromControllerImpl(ctxArg interface{}, key string,
 		}
 		// Try unlocking the vault now, in case it is not yet unlocked
 		log.Noticef("Vault is still locked, trying to unlock")
-		err = etpm.SealDiskKey(decryptedKey, etpm.DiskKeySealingPCRs)
+		err = etpm.SealDiskKey(log, decryptedKey, etpm.DiskKeySealingPCRs)
 		if err != nil {
 			log.Errorf("Failed to Seal key in TPM %v", err)
 			return

--- a/pkg/pillar/evetpm/tpm_test.go
+++ b/pkg/pillar/evetpm/tpm_test.go
@@ -15,8 +15,12 @@ import (
 
 	"github.com/google/go-tpm/tpm2"
 	"github.com/google/go-tpm/tpmutil"
+	"github.com/lf-edge/eve/pkg/pillar/base"
 	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
+	"github.com/sirupsen/logrus"
 )
+
+var log = base.NewSourceLogObject(logrus.StandardLogger(), "test", 1234)
 
 func TestSealUnseal(t *testing.T) {
 	_, err := os.Stat(TpmDevicePath)
@@ -25,7 +29,7 @@ func TestSealUnseal(t *testing.T) {
 	}
 
 	dataToSeal := []byte("secret")
-	if err := SealDiskKey(dataToSeal, DiskKeySealingPCRs); err != nil {
+	if err := SealDiskKey(log, dataToSeal, DiskKeySealingPCRs); err != nil {
 		t.Errorf("Seal operation failed with err: %v", err)
 		return
 	}
@@ -53,7 +57,7 @@ func TestSealUnsealMismatchReport(t *testing.T) {
 	defer rw.Close()
 
 	dataToSeal := []byte("secret")
-	if err := SealDiskKey(dataToSeal, DiskKeySealingPCRs); err != nil {
+	if err := SealDiskKey(log, dataToSeal, DiskKeySealingPCRs); err != nil {
 		t.Errorf("Seal operation failed with err: %v", err)
 		return
 	}
@@ -94,7 +98,7 @@ func TestSealUnsealTpmEventLogCollect(t *testing.T) {
 
 	// this should write the save the first event log
 	dataToSeal := []byte("secret")
-	if err := SealDiskKey(dataToSeal, DiskKeySealingPCRs); err != nil {
+	if err := SealDiskKey(log, dataToSeal, DiskKeySealingPCRs); err != nil {
 		t.Errorf("Seal operation failed with err: %v", err)
 		return
 	}
@@ -126,7 +130,7 @@ func TestSealUnsealTpmEventLogCollect(t *testing.T) {
 	}
 
 	// this should trigger collecting previous tpm event logs
-	if err := SealDiskKey(dataToSeal, DiskKeySealingPCRs); err != nil {
+	if err := SealDiskKey(log, dataToSeal, DiskKeySealingPCRs); err != nil {
 		t.Errorf("Seal operation failed with err: %v", err)
 		return
 	}

--- a/pkg/pillar/vault/handler_zfs.go
+++ b/pkg/pillar/vault/handler_zfs.go
@@ -98,7 +98,8 @@ func (h *ZFSHandler) SetupDefaultVault() error {
 		return fmt.Errorf("error in setting up ZFS vault %s:%v", types.SealedDataset, err)
 	}
 	// Log the type of key used for unlocking default vault
-	h.log.Noticef("default zfs vault unlocked")
+	h.log.Noticef("default zfs vault unlocked using key type: %s",
+		etpm.CompareLegacyandSealedKey().String())
 	return nil
 }
 


### PR DESCRIPTION
Backport of https://github.com/lf-edge/eve/pull/3423, otherwise EVE might face vault unlock failure. 