### PR TITLE
[9.4-stable] containerd: Add error handling in getImageConfig for GetImageHash.

### DIFF
--- a/pkg/pillar/cas/containerd.go
+++ b/pkg/pillar/cas/containerd.go
@@ -914,7 +914,8 @@ func getImageConfig(c *containerdCAS, reference string) (*ocispec.Image, error) 
 	imageParentHash, err := c.GetImageHash(reference)
 	if err != nil {
 		err = fmt.Errorf("getImageConfig: exception while fetching reference hash of %s: %s", reference, err.Error())
-
+		logrus.Errorf(err.Error())
+		return nil, err
 	}
 
 	ctrdCtx, done := c.ctrdClient.CtrNewUserServicesCtx()


### PR DESCRIPTION
Added proper error logging and return when `GetImageHash` fails in the `getImageConfig` function. This ensures that the error is not silently ignored and provides clearer debugging information.

I propose to merge it into 9.4-stable so we can provide the next fix release to the customer, and see the system behavior when they roll it out (see CI-197).