### PR TITLE
[10.4-stable] diskmetrics: increase timeout of qemu img convert

### DIFF
--- a/pkg/pillar/diskmetrics/diskmetrics.go
+++ b/pkg/pillar/diskmetrics/diskmetrics.go
@@ -22,6 +22,9 @@ const qemuExecTimeout = 2 * time.Minute
 // qemuExecLongTimeout is a long timeout for command executions in separate worker thread that don't interfere with the watchdog
 const qemuExecLongTimeout = 1000 * time.Second
 
+// qemuExecUltraLongTimeout is a long timeout for command executions in separate worker thread that take especially long
+const qemuExecUltraLongTimeout = 120 * time.Hour
+
 func GetImgInfo(log *base.LogObject, diskfile string) (*types.ImgInfo, error) {
 	var imgInfo types.ImgInfo
 
@@ -99,7 +102,7 @@ func RolloutImgToBlock(ctx context.Context, log *base.LogObject, diskfile, outpu
 	// writeback cache instead of default unsafe, out of order enabled, skip file creation
 	// Timeout 2 hours
 	args := []string{"convert", "--target-is-zero", "-t", "writeback", "-W", "-n", "-O", outputFormat, diskfile, outputFile}
-	output, err := base.Exec(log, "/usr/bin/qemu-img", args...).WithContext(ctx).WithUnlimitedTimeout(qemuExecLongTimeout).CombinedOutput()
+	output, err := base.Exec(log, "/usr/bin/qemu-img", args...).WithContext(ctx).WithUnlimitedTimeout(qemuExecUltraLongTimeout).CombinedOutput()
 	if err != nil {
 		errStr := fmt.Sprintf("qemu-img failed: %s, %s\n",
 			err, output)


### PR DESCRIPTION
this partially reverts 193147f889660068db07f61714dbf8899ab55ea0

during testing it has been found out that the timeout is too short, therefore it is now set again to 5 days