### PR TITLE
collect-info.sh: add debug info from ModemManager

### DIFF
--- a/pkg/debug/scripts/collect-info.sh
+++ b/pkg/debug/scripts/collect-info.sh
@@ -5,7 +5,7 @@
 #
 
 # Script version, don't forget to bump up once something is changed
-VERSION=8
+VERSION=9
 
 # Add required packages here, it will be passed to "apk add".
 # Once something added here don't forget to add the same package
@@ -154,6 +154,36 @@ collect_network_info()
         echo "------ $iface -------"
         dhcpcd -U -4 "$iface"
     done > "$DIR/network/dhcpcd-all-ifaces" 2>&1
+
+    echo "   - cellular modems"
+    MODEMS="$(eve exec --fork wwan mmcli -L |\
+              sed -n 's/.*\/ModemManager1\/Modem\/\([0-9]\+\).*/\1/p' | uniq)"
+    for MODEM in $MODEMS; do
+        INFO="$(eve exec --fork wwan mmcli -m "$MODEM")"
+        echo
+        echo "Modem $MODEM:"
+        echo "$INFO"
+        SIMS="$(echo "$INFO" |\
+                sed -n 's/.*\/ModemManager1\/SIM\/\([0-9]\+\).*/\1/p' | uniq)"
+        for SIM in $SIMS; do
+            echo
+            echo "SIM $SIM used by modem $MODEM:"
+            eve exec --fork wwan mmcli -i "$SIM"
+        done
+        BEARERS="$(echo "$INFO" |\
+                   sed -n 's/.*\/ModemManager1\/Bearer\/\([0-9]\+\).*/\1/p' | uniq)"
+        for BEARER in $BEARERS; do
+            echo
+            echo "Bearer $BEARER used by modem $MODEM:"
+            eve exec --fork wwan mmcli -b "$BEARER"
+        done
+        echo
+        echo "Modem $MODEM location status:"
+        eve exec --fork wwan mmcli -m "$MODEM" --location-status
+        echo
+        echo "Modem $MODEM location:"
+        eve exec --fork wwan mmcli -m "$MODEM" --location-get
+    done > "$DIR/network/wwan" 2>&1
 
     echo "- done network info"
 }

--- a/pkg/dom0-ztools/rootfs/bin/eve
+++ b/pkg/dom0-ztools/rootfs/bin/eve
@@ -8,7 +8,7 @@ help() {
 Welcome to EVE!
   commands: enter [service] [command (assumed sh)]
             enter-user-app <service>
-            exec [service] command
+            exec [--fork] [service] command
             list
             status
             start <service>
@@ -115,12 +115,18 @@ dump_mem() {
 }
 
 case "$1" in
-    exec) # shellcheck disable=SC2086
+    exec) NO_FORK="-F"
+          if [ "$2" = "--fork" ]; then
+            NO_FORK=""
+            shift
+          fi
+          # shellcheck disable=SC2086
           ID=$(${CTR_CMD} t ls | awk '/^'${2:-pillar}' /{print $2;}' 2>/dev/null)
           CMD="${3:-sh}"
           shift ; shift ; shift
           for c in /sys/fs/cgroup/*/tasks; do echo "$$" >> "$c"; done
-          exec nsenter -F -a -t "${ID:-1}" "$CMD" "$@"
+          # shellcheck disable=SC2086
+          exec nsenter ${NO_FORK} -a -t "${ID:-1}" "$CMD" "$@"
           ;;
    enter) # shellcheck disable=SC2086
           ${CTR_CMD} t exec -t --exec-id $(basename $(mktemp)) ${2:-pillar} ${3:-sh -l}


### PR DESCRIPTION
Even though we already collect pubsub messages published by mmagent from the wwan microservice (WwanStatus, WwanMetrics, WwanLocationInfo), it can still be useful for troubleshooting to collect detailed (and some additional) info about modems, SIMs and bearers directly from the ModemManager.

For this to work I had to enable running `eve exec` with process forked by nsenter, see the first commit description. 