### PR TITLE
grub: xen installer, use kvm flavor

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -362,7 +362,10 @@ function set_kubevirt_boot {
 }
 
 function set_eve_flavor {
-   cat -s eve_flavor /etc/eve-hv-type
+   # don't overwrite as the XEN installer still uses KVM (and sets it explicitly)
+   if [ "$eve_flavor" = "" ] ; then
+       cat -s eve_flavor /etc/eve-hv-type
+   fi
 }
 
 function set_getty {


### PR DESCRIPTION
don't overwrite eve_flavor as the XEN installer still uses KVM (and sets it explicitly)