### PR TITLE
add support for writing files to containers from cloud-init config

### DIFF
--- a/docs/CLOUD-INIT.md
+++ b/docs/CLOUD-INIT.md
@@ -1,0 +1,46 @@
+# Cloud-Init
+
+EVE supports [cloud-init](https://cloudinit.readthedocs.io/en/latest/) for configuring VMs and containers. The user-data is passed through the corresponding fields in the [AppInstanceConfig message](https://github.com/lf-edge/eve-api/tree/main/proto/config/appconfig.proto).
+
+## Support in VMs
+
+For VMs, EVE supports cloud-init configuration using the NoCloud datasource. With NoCloud, EVE manually provides both meta-data and user-data received from the controller to the VM. This is done by placing these files on a virtual CD-ROM in the form of an ISO image. Further EVE relies on the cloud-init system present in the ECO's VM image. Upon booting the VM instance, if a cloud-init installation is present, the system checks for these data files, and if found, processes the configurations or scripts defined in them.
+
+For more information on the meta-data consult [ECO-METADATA.md](ECO-METADATA.md).
+
+## Support in Containers
+
+As opposed to the VM implementation, cloud-init in ECO containers does not rely on a cloud-init daemon being present in the container image. Instead, the cloud-init configuration is parsed by EVE and manually applied to the container. EVE's implementation supports two formats for user-data:
+
+- The **legacy** format only supports the definition of environment variables in the form of a simple key-value map. The equal sign "=" is used as delimiter in this case:
+
+    ```text
+    ENV1=value1
+    ENV2=value2
+    ```
+
+- In the **original** cloud-init format the user-data is specified like in any other cloud-init configuration. The current EVE implementation only supports two user-data fields: `runcmd` and `write_files`.
+
+  `runcmd` is only used to set environment variables, similar to the **legacy** format. Trying to use any other command will result in an error. The env definitions **must not** be preceded by an `export` keyword, but it's effect is implied in the implementation.
+
+  `write_files` field supports parameters such as path, content, permissions and encoding. It is used to write one or more files to the container image prior to the container start.
+
+  Every cloud-init configuration **must** begin with the `#cloud-config` header. Example:
+
+    ```yaml
+    #cloud-config
+    runcmd:
+      - ENV1=value1
+      - ENV2=value2
+    write_files:
+      - path: /etc/injected_file.txt
+        permissions: '0644'
+        encoding: b64
+        content: YmxhYmxh
+    ```
+
+## Versioning
+
+Both VM and container implementations support versioning of the user-data. This means that the cloud-init configuration is only reapplied if the version of the user-data has changed. The version is specified in the meta-data file in the `instance-id` field.
+
+If the controller implementation does not support versioning, the user-data will be reapplied each time the version of the `AppInstanceConfig` changes.

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -9,6 +9,7 @@
 package domainmgr
 
 import (
+	"bufio"
 	"encoding/base64"
 	"errors"
 	"flag"
@@ -38,6 +39,8 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/sriov"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils"
+	"github.com/lf-edge/eve/pkg/pillar/utils/cloudconfig"
+	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
@@ -1404,6 +1407,37 @@ func doAssignIoAdaptersToDomain(ctx *domainContext, config types.DomainConfig,
 	return nil
 }
 
+func getVersionFromMetaFile(path string) (uint64, error) {
+	var curCIVersion uint64
+
+	// read cloud init version from the meta-data file
+	metafile, err := os.Open(path)
+	if err != nil {
+		return 0, fmt.Errorf("Failed to open meta-data file: %s", err)
+	}
+	scanner := bufio.NewScanner(metafile)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "instance-id:") {
+			parts := strings.Split(line, "/")
+			if len(parts) >= 2 {
+				curCIVersion, err = strconv.ParseUint(parts[1], 10, 32)
+				if err != nil {
+					return 0, fmt.Errorf("Failed to parse cloud init version: %s", err.Error())
+				}
+				return curCIVersion, nil
+			}
+		}
+	}
+
+	// Check for scanner errors.
+	if err := scanner.Err(); err != nil {
+		return 0, fmt.Errorf("Reading the file failed: %s", err.Error())
+	}
+
+	return 0, errors.New("Version not found in meta-data file")
+}
+
 func doActivate(ctx *domainContext, config types.DomainConfig,
 	status *types.DomainStatus) {
 
@@ -1463,12 +1497,53 @@ func doActivate(ctx *domainContext, config types.DomainConfig,
 			// do nothing
 		case zconfig.Format_CONTAINER:
 			snapshotID := containerd.GetSnapshotID(ds.FileLocation)
-			if err := ctx.casClient.MountSnapshot(snapshotID, cas.GetRoofFsPath(ds.FileLocation)); err != nil {
+			rootPath := cas.GetRoofFsPath(ds.FileLocation)
+			if err := ctx.casClient.MountSnapshot(snapshotID, rootPath); err != nil {
 				err := fmt.Errorf("doActivate: Failed mount snapshot: %s for %s. Error %s",
 					snapshotID, config.UUIDandVersion.UUID, err)
 				log.Error(err.Error())
 				status.SetErrorNow(err.Error())
 				return
+			}
+
+			metadataPath := filepath.Join(rootPath, "meta-data")
+
+			// get current cloud init version
+			curCIVersion, err := getVersionFromMetaFile(metadataPath)
+			if err != nil {
+				curCIVersion = 0 // make sure the cloud init config gets executed
+			}
+
+			// get new cloud init version
+			newCIVersion, err := strconv.ParseUint(getCloudInitVersion(config), 10, 32)
+			if err != nil {
+				log.Error("Failed to parse cloud init version: ", err)
+				newCIVersion = curCIVersion + 1 // make sure the cloud init config gets executed
+			}
+
+			if curCIVersion < newCIVersion {
+				log.Notice("New cloud init config detected - applying")
+
+				// write meta-data file
+				versionString := fmt.Sprintf("instance-id: %s/%s\n", config.UUIDandVersion.UUID.String(), getCloudInitVersion(config))
+				err = fileutils.WriteRename(metadataPath, []byte(versionString))
+				if err != nil {
+					err := fmt.Errorf("doActivate: Failed to write cloud-init metadata file. Error %s", err)
+					log.Error(err.Error())
+					status.SetErrorNow(err.Error())
+					return
+				}
+
+				// apply cloud init config
+				for _, writableFile := range status.WritableFiles {
+					err := cloudconfig.WriteFile(log, writableFile, rootPath)
+					if err != nil {
+						err := fmt.Errorf("doActivate: Failed to apply cloud-init config. Error %s", err)
+						log.Error(err.Error())
+						status.SetErrorNow(err.Error())
+						return
+					}
+				}
 			}
 		default:
 			// assume everything else to be disk formats
@@ -1889,20 +1964,38 @@ func configToStatus(ctx *domainContext, config types.DomainConfig,
 	//clean environment variables
 	status.EnvVariables = nil
 
+	// Fetch cloud-init userdata
 	if config.IsCipher || config.CloudInitUserData != nil {
 		ciStr, err := fetchCloudInit(ctx, config)
 		if err != nil {
 			return fmt.Errorf("failed to fetch cloud-init userdata: %s",
 				err)
 		}
-		if status.OCIConfigDir != "" {
-			envList, err := parseEnvVariablesFromCloudInit(ciStr)
-			if err != nil {
-				return fmt.Errorf("failed to parse environment variable from cloud-init userdata: %s",
-					err)
+		if status.OCIConfigDir != "" { // If AppInstance is a container, we need to parse cloud-init config and apply the supported parts
+			if cloudconfig.IsCloudConfig(ciStr) { // treat like the cloud-init config
+				cc, err := cloudconfig.ParseCloudConfig(ciStr)
+				if err != nil {
+					return fmt.Errorf("failed to unmarshal cloud-init userdata: %s",
+						err)
+				}
+				status.WritableFiles = cc.WriteFiles
+
+				envList, err := parseEnvVariablesFromCloudInit(cc.RunCmd)
+				if err != nil {
+					return fmt.Errorf("failed to parse environment variable from cloud-init userdata: %s",
+						err)
+				}
+				status.EnvVariables = envList
+			} else { // treat like the key value map for envs (old syntax)
+				envPairs := strings.Split(ciStr, "\n")
+				envList, err := parseEnvVariablesFromCloudInit(envPairs)
+				if err != nil {
+					return fmt.Errorf("failed to parse environment variable from cloud-init env map: %s",
+						err)
+				}
+				status.EnvVariables = envList
 			}
-			status.EnvVariables = envList
-		} else {
+		} else { // If AppInstance is a VM, we need to create a cloud-init ISO
 			switch config.MetaDataType {
 			case types.MetaDataDrive, types.MetaDataDriveMultipart:
 				ds, err := createCloudInitISO(ctx, config, ciStr)
@@ -2515,11 +2608,10 @@ func fetchCloudInit(ctx *domainContext,
 // Example:
 // Key1=Val1
 // Key2=Val2 ...
-func parseEnvVariablesFromCloudInit(ciStr string) (map[string]string, error) {
+func parseEnvVariablesFromCloudInit(envPairs []string) (map[string]string, error) {
 
 	envList := make(map[string]string, 0)
-	list := strings.Split(ciStr, "\n")
-	for _, v := range list {
+	for _, v := range envPairs {
 		pair := strings.SplitN(v, "=", 2)
 		if len(pair) != 2 {
 			errStr := fmt.Sprintf("Variable \"%s\" not defined properly\nKey value pair should be delimited by \"=\"", pair[0])

--- a/pkg/pillar/go.mod
+++ b/pkg/pillar/go.mod
@@ -48,6 +48,7 @@ require (
 	golang.org/x/sys v0.13.0
 	google.golang.org/grpc v1.56.3
 	google.golang.org/protobuf v1.30.0
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
@@ -136,7 +137,6 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	howett.net/plist v0.0.0-20181124034731-591f970eefbb // indirect
 	oras.land/oras-go v1.2.0 // indirect

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	zconfig "github.com/lf-edge/eve-api/go/config"
 	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/utils/cloudconfig"
 )
 
 // The information DomainManager needs to boot and halt domains
@@ -278,9 +279,10 @@ type DomainStatus struct {
 	ConfigFailed   bool
 	BootFailed     bool
 	AdaptersFailed bool
-	OCIConfigDir   string            // folder holding an OCI Image config for this domain (empty string means no config)
-	EnvVariables   map[string]string // List of environment variables to be set in container
-	VmConfig                         // From DomainConfig
+	OCIConfigDir   string                     // folder holding an OCI Image config for this domain (empty string means no config)
+	EnvVariables   map[string]string          // List of environment variables to be set in container
+	WritableFiles  []cloudconfig.WritableFile // List of files from CloudInit scripts to be created in container
+	VmConfig                                  // From DomainConfig
 	Service        bool
 }
 

--- a/pkg/pillar/utils/cloudconfig/cloudconfig.go
+++ b/pkg/pillar/utils/cloudconfig/cloudconfig.go
@@ -1,0 +1,107 @@
+package cloudconfig
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
+	"gopkg.in/yaml.v2"
+)
+
+// CloudConfig represents the structure of the cloud configuration file.
+// Only supported fields are defined here. The rest is ignored.
+type CloudConfig struct {
+	RunCmd     []string       `yaml:"runcmd"`
+	WriteFiles []WritableFile `yaml:"write_files"` //nolint:tagliatelle // cloud-init standard uses snake_case
+}
+
+// WritableFile represents a file that can be written to disk with the specified content, permissions, encoding and owner.
+type WritableFile struct {
+	Path        string `yaml:"path"`
+	Content     string `yaml:"content"`
+	Permissions string `yaml:"permissions"`
+	Encoding    string `yaml:"encoding"`
+	Owner       string `yaml:"owner"`
+}
+
+// IsCloudConfig checks if the given string is a cloud-config file by checking if the first line starts with "#cloud-config".
+// It returns true if the first line starts with "#cloud-config", otherwise it returns false.
+func IsCloudConfig(ci string) bool {
+	// check if the first line is #cloud-config
+	lines := strings.Split(ci, "\n")
+	if len(lines) == 0 {
+		return false
+	}
+	return strings.HasPrefix(lines[0], "#cloud-config")
+}
+
+// ParseCloudConfig parses the given cloud-init configuration and returns a pointer to a CloudConfig struct and an error.
+func ParseCloudConfig(ci string) (*CloudConfig, error) {
+	var cc CloudConfig
+	err := yaml.Unmarshal([]byte(ci), &cc)
+	if err != nil {
+		return nil, err
+	}
+	return &cc, nil
+}
+
+// WriteFile checks the content of a WritableFile and writes it to the specified rootPath.
+func WriteFile(log *base.LogObject, file WritableFile, rootPath string) error {
+	// transform file.Permission to os.FileMode
+	perm, err := strconv.ParseUint(file.Permissions, 8, 32)
+	if err != nil {
+		return err
+	}
+	mode := os.FileMode(perm)
+
+	writePath := filepath.Join(rootPath, file.Path)
+	// sanitize path
+	if !strings.HasPrefix(filepath.Clean(writePath), rootPath) {
+		return fmt.Errorf("detected possible attempt to write file outside of root path. invalid path %s", file.Path)
+	}
+
+	var contentBytes []byte
+	switch file.Encoding {
+	case "b64":
+		// decode base64 content
+		contentBytes, err = base64.StdEncoding.DecodeString(file.Content)
+		if err != nil {
+			return err
+		}
+	case "plain":
+		contentBytes = []byte(file.Content)
+	default:
+		return errors.New("unsupported encoding type. Only base64 and plain are supported")
+	}
+
+	// check if the parent directory exists
+	parentDir := filepath.Dir(writePath)
+	if _, err := os.Stat(parentDir); os.IsNotExist(err) {
+		// create parent directory
+		err = os.MkdirAll(parentDir, 0755)
+		if err != nil {
+			return err
+		}
+	}
+
+	log.Tracef("Creating file %s with mode %s in %s\n", file.Path, mode, rootPath)
+	err = fileutils.WriteRename(writePath, contentBytes)
+	if err != nil {
+		return err
+	}
+	err = os.Chmod(writePath, mode)
+	if err != nil {
+		return err
+	}
+	if file.Owner != "" {
+		log.Warn("Changing owner of files written by cloud-init is not supported yet")
+	}
+
+	return nil
+}

--- a/pkg/pillar/utils/cloudconfig/cloudconfig_test.go
+++ b/pkg/pillar/utils/cloudconfig/cloudconfig_test.go
@@ -1,0 +1,163 @@
+package cloudconfig_test
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/utils/cloudconfig"
+	"github.com/sirupsen/logrus"
+)
+
+func TestCloudConfig(t *testing.T) {
+	t.Parallel()
+
+	log := base.NewSourceLogObject(logrus.StandardLogger(), "cloudconfig", 0)
+	// create a temporary directory to write files to
+	rootPath, err := os.MkdirTemp("", "cloudconfig_test")
+	if err != nil {
+		t.Fatalf("failed to create temporary directory: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(rootPath) })
+
+	// define the test cases
+	testCases := []struct {
+		name     string
+		input    string
+		expected []cloudconfig.WritableFile
+		errParse error
+		errWrite error
+	}{
+		{
+			name: "single file",
+			input: `#cloud-config
+write_files:
+- path: /tmp/test.txt
+  content: SGVsbG8gV29ybGQhCg==
+  permissions: "0644"
+  encoding: b64`,
+			expected: []cloudconfig.WritableFile{
+				{
+					Path:        "/tmp/test.txt",
+					Content:     "Hello World!\n",
+					Permissions: "0644",
+					Encoding:    "b64",
+				},
+			},
+			errParse: nil,
+			errWrite: nil,
+		},
+		{
+			name: "multiple files",
+			input: `#cloud-config
+write_files:
+- path: /tmp/test1.txt
+  content: SGVsbG8gV29ybGQhCg==
+  permissions: "0644"
+  encoding: b64
+- path: /tmp/test2.txt
+  content: world
+  permissions: "0644"
+  encoding: plain`,
+			expected: []cloudconfig.WritableFile{
+				{
+					Path:        "/tmp/test1.txt",
+					Content:     "Hello World!\n",
+					Permissions: "0644",
+					Encoding:    "b64",
+				},
+				{
+					Path:        "/tmp/test2.txt",
+					Content:     "world",
+					Permissions: "0644",
+					Encoding:    "plain",
+				},
+			},
+			errParse: nil,
+			errWrite: nil,
+		},
+		{
+			name: "unsupported encoding type",
+			input: `#cloud-config
+write_files:
+- path: /tmp/unsupported_encoding_type.txt
+  content: SGVsbG8gV29ybGQhCg==
+  permissions: "0644"
+  encoding: unsupported`,
+			errParse: nil,
+			errWrite: errors.New("unsupported encoding type. Only base64 and plain are supported"),
+		},
+		{
+			name: "invalid permissions",
+			input: `#cloud-config
+write_files:
+- path: /tmp/invalid_permissions.txt
+  content: SGVsbG8gV29ybGQhCg==
+  permissions: "invalid"
+  encoding: b64`,
+			expected: []cloudconfig.WritableFile{},
+			errParse: nil,
+			errWrite: errors.New("strconv.ParseUint: parsing \"invalid\": invalid syntax"),
+		},
+		{
+			name: "invalid path",
+			input: `#cloud-config
+write_files:
+- path: ../../etc/passwd
+  content: SGVsbG8gV29ybGQhCg==
+  permissions: "0644"
+  encoding: b64`,
+			expected: []cloudconfig.WritableFile{},
+			errParse: nil,
+			errWrite: fmt.Errorf("detected possible attempt to write file outside of root path. invalid path %s", "../../etc/passwd"),
+		},
+	}
+
+	// run the test cases
+	for _, tc := range testCases {
+		tc := tc // capture range variable
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cc, err := cloudconfig.ParseCloudConfig(tc.input)
+			checkError(t, err, tc.errParse)
+
+			// write the files specified in the config
+			for _, wf := range cc.WriteFiles {
+				err := cloudconfig.WriteFile(log, wf, rootPath)
+				checkError(t, err, tc.errWrite)
+			}
+
+			// compare the content of the written files with the expected content
+			for _, expected := range tc.expected {
+				path := filepath.Join(rootPath, expected.Path)
+				actualBytes, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatalf("failed to read file %s: %v", expected.Path, err)
+				}
+				actual := string(actualBytes)
+				if actual != expected.Content {
+					t.Errorf("content of file %s does not match expected content:\nactual:   %q\nexpected: %q", expected.Path, actual, expected.Content)
+				}
+			}
+		})
+	}
+}
+
+func checkError(t *testing.T, err error, expected error) {
+	t.Helper()
+	if err != nil {
+		if expected == nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if err.Error() != expected.Error() {
+			t.Fatalf("expected error %v, but got %v", expected, err)
+		}
+		return
+	}
+	if expected != nil {
+		t.Fatalf("expected error %v, but got nil", expected)
+	}
+}


### PR DESCRIPTION
We are extending the support for the cloud-init config for containers. While the old config format with
```
ENV1=value1
ENV2=value2
```
still remains available we also introduce the support for the original cloud-init config syntax with support for fields `runcmd` (only for defining envs) and `write_files`, like in the following example
```
#cloud-config
runcmd:
  - ENV1=value1
  - ENV2=value2

write_files:
 - path: /etc/injected_file.txt
   owner: root:root
   permissions: '0644'
   encoding: b64
   content: YmxhYmxh
```
The section `runcmd` will only be used for providing envs, while the new section `write_files` can be used to write files to the containers in the usual cloud-init way. The option to change the owner is however not supported at the moment.

The rest of the field of the cloud-init configuration will be ignored.