### PR TITLE
[10.4] exec: avoid clobbering timeout

### DIFF
--- a/pkg/pillar/base/execwrapper.go
+++ b/pkg/pillar/base/execwrapper.go
@@ -48,7 +48,9 @@ func (c *Command) Output() ([]byte, error) {
 	var buf bytes.Buffer
 	c.command.Stdout = &buf
 	c.buffer = &buf
-	c.timeout = defaultTimeout
+	if c.timeout == 0 {
+		c.timeout = defaultTimeout
+	}
 	return c.execCommand()
 }
 
@@ -59,7 +61,9 @@ func (c *Command) CombinedOutput() ([]byte, error) {
 	c.command.Stdout = &buf
 	c.command.Stderr = &buf
 	c.buffer = &buf
-	c.timeout = defaultTimeout
+	if c.timeout == 0 {
+		c.timeout = defaultTimeout
+	}
 	return c.execCommand()
 }
 


### PR DESCRIPTION
Backport of #3518 
(cherry picked from commit 7142b9df4b95f2d813cab1768675c2a2e4f1d2b9)