### PR TITLE
GitHub Actions: use env variable TAG instead of rewriting in assets.yml

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -96,7 +96,6 @@ jobs:
           result-encoding: string
           script: |
             console.log(context)
-            tag = '${TAG}'
 
             // first create a release -- it is OK if that fails,
             // since it means the release is already there
@@ -104,8 +103,8 @@ jobs:
               const raw = (await github.repos.createRelease({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                tag_name: tag,
-                name: 'Release ' + tag,
+                tag_name: TAG,
+                name: 'Release ' + TAG,
                 prerelease: true,
               })).data
               console.log(raw)
@@ -115,7 +114,7 @@ jobs:
             const release = (await github.repos.getReleaseByTag({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              tag: tag,
+              tag: TAG,
             })).data
 
             // get assets for that ID


### PR DESCRIPTION
Following #3529 this commit fixes publishing step. TAG variable should not be quoted. We remove tag environment variable and use TAG since it's already present.