### PR TITLE
[10.4-stable] Revert snapshot capability due to misleading support indication.

### DIFF
--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -614,11 +614,7 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext, dest destinationBitset) {
 
 	ReportDeviceInfo.State = getState(ctx)
 
-	// TODO: Enhance capability reporting with a bitmap-like approach for increased granularity.
-	// We report the snapshot capability despite the fact that we support snapshots only
-	// for file-based volumes. If a controller tries to make a snapshot of ZFS-based volume
-	// device returns a runtime error.
-	ReportDeviceInfo.ApiCapability = info.APICapability_API_CAPABILITY_VOLUME_SNAPSHOTS
+	ReportDeviceInfo.ApiCapability = info.APICapability_API_CAPABILITY_START_DELAY_IN_SECONDS
 
 	// Report if there is a local override of profile
 	if ctx.getconfigCtx.currentProfile != ctx.getconfigCtx.globalProfile {


### PR DESCRIPTION
Rolling back the reported capability from CAPABILITY_VOLUME_SNAPSHOTS to CAPABILITY_START_DELAY_IN_SECONDS in ReportDeviceInfo.

This change addresses the inconsistency where the UI indicated snapshot support in versions prior to its actual implementation (10.8.0).

Note that CAPABILITY_EDGEVIEW, which should technically precede, is commented out in the API proto file.