### PR TITLE
Introducing NVIDIA Jetson Xavier NX Platform support on EVE

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,15 @@ In Jetson nano, from January 22, 2021, it became possible to save the u-boot to 
 3. Build a live image `make ZARCH=arm64 HV=kvm live-raw` (Only KVM is supported)
 4. Flash the `dist/arm64/current/live.raw` live EVE image onto your SD card by [following these instructions](#how-to-write-eve-image-and-installer-onto-an-sd-card-or-an-installer-medium)
 
+## How to use on a Jetson Xavier NX platform
+
+Currently EVE supports the following devices from NVIDIA's Jetson Xavier NX platform:
+
+1. Lenovo ThinkEdge SE70
+2. NVIDIA Jetson Xavier NX developer kit
+
+See [NVIDIA-NX.md](./docs/NVIDIA-NX.md) for instructions on how to build and deploy EVE on these devices.
+
 ## How to use on a i.MX 8MQuad Evaluation Kit ARM board
 
 1. Set SW801 to 1100 for switch boot device to SD card.

--- a/docs/NVIDIA-NX.md
+++ b/docs/NVIDIA-NX.md
@@ -1,0 +1,93 @@
+# NVIDIA's Jetson Xavier NX platform
+
+Currently EVE supports the following devices from NVIDIA's Jetson Xavier NX platform:
+
+1. Lenovo ThinkEdge SE70
+1. NVIDIA Jetson Xavier NX developer kit
+
+The Jetson Xavier NX platform has a complex boot flow[[1]](#references) that performs a lot of operations
+to setup all the hardware: initialize memory controller, power up CPUs, load firmware components, etc. The last stage of
+the bootloader provides an UEFI interface able to boot an UEFI capable Operating System. The bootloader can be present
+in a bootable device, such as an SD Card, or at some internal memory of the device. EVE doesn't support embed the
+bootloader on its image for the Jetson Xavier NX platform, so the bootloader must be already present in the device.
+
+## Lenovo ThinkEdge SE70
+
+The bootloader of the Lenovo ThinkEdge SE70 device is already present on its internal memory and it also supports
+booting from an USB Stick. In order to install EVE (or run it from a live image) the corresponding image must be written
+to an USB Stick and the device must be configured to try to boot first from external bootable devices. The boot order
+can be changed in the bootloader's setup interface with the following steps:
+
+1. Power on the device
+1. Press F1 during initialization to enter in the bootloader setup interface. If key pressing doesn't work, perform a
+   full recovery of the device[[2]](#references)
+1. Inside the bootloader setup interface, navigate through the menus *Device Manager->NVIDIA Resource Configuration*
+1. In the field *"Add new devices to Top or bottom of boot order"* set the option *"Top"*
+1. Press F10 to save the new settings
+1. Exit the bootloader setup and reboot the device
+
+### Installing EVE on the ThinkEdge SE70
+
+1. Build an installation raw image `make ZARCH=arm64 HV=kvm PLATFORM=nvidia installer-raw` (Only KVM is supported)
+1. Flash the `dist/arm64/current/installer.raw` install EVE image onto an USB Stick [following these instructions](../README.md#how-to-write-eve-image-and-installer-onto-an-sd-card-or-an-installer-medium)
+1. Insert the USB Stick and power on the device
+
+The installation process will start and it will install EVE on the NVMe automatically. If the installation succeed, the
+device will be powered off. Remove the USB Stick and power on the device again.
+
+### Running a live image on the ThinkEdge SE70
+
+1. Build a live raw image `make ZARCH=arm64 HV=kvm PLATFORM=nvidia live-raw` (Only KVM is supported)
+1. Flash the `dist/arm64/current/live.raw` live EVE image onto an USB Stick [following these instructions](../README.md#how-to-write-eve-image-and-installer-onto-an-sd-card-or-an-installer-medium)
+1. Insert the USB Stick and power on the device
+
+EVE should boot the live image and run from the USB Stick. **NOTE** that the NVMe SSD must not contain an EVE installation,
+otherwise it will conflict with the live image and **EVE will not run properly**.
+
+## Jetson Xavier NX developer kit
+
+The Jetson Xavier NX developer kit comes with a CoM (Computer on Module) without eMMC, so the entire OS should run from
+an SD Card. However, the device has a small QSPI EEPROM where the bootloader can be written in order to boot the board.
+
+### Flashing the bootloader to QSPI EEPROM
+
+- Put the device into the recovery mode:
+
+1. Power off the board
+1. Connect the pin (using a jumper or a wire) **FC REC** to the **GND**. These are the second (GND) and third (FC REC) pins counting from the PWR BTN pin.
+1. Attach it to a host computer through the micro USB port.
+1. Power on the board
+
+On the host computer, the following device should appear in the USB bus:
+
+```sh
+Bus 001 Device 120: ID 0955:7e19 NVIDIA Corp. APX
+```
+
+- Download and extract the NVIDIA's Jetpack tarball from the following [link](https://developer.nvidia.com/embedded/l4t/r35_release_v1.0/release/jetson_linux_r35.1.0_aarch64.tbz2):
+
+```sh
+wget https://developer.nvidia.com/embedded/l4t/r35_release_v1.0/release/jetson_linux_r35.1.0_aarch64.tbz2
+tar -xvjf jetson_linux_r35.1.0_aarch64.tbz2
+```
+
+- Execute the flash.sh script tool to flash the bootloader to the QSPI EEPROM:
+
+```sh
+cd Linux_for_Tegra
+sudo ./flash.sh jetson-xavier-nx-devkit-qspi internal
+```
+
+Once the procedure is done, power off the board and disconnect the pin *FC REC* from the *GND*.
+
+### Running a live image on the Jetson Xavier NX developer kit
+
+1. Make sure the bootloader is present in the QSPI EEPROM
+1. Build a live raw image `make ZARCH=arm64 HV=kvm PLATFORM=nvidia live-raw` (Only KVM is supported)
+1. Flash the `dist/arm64/current/live.raw` live EVE image onto an SD Card [following these instructions](../README.md#how-to-write-eve-image-and-installer-onto-an-sd-card-or-an-installer-medium)
+1. Insert the SD Card and power on the board
+
+## References
+
+1. [Jetson Xavier NX BootFlow](https://docs.nvidia.com/jetson/archives/r35.2.1/DeveloperGuide/text/AR/BootArchitecture/JetsonXavierNxAndJetsonAgxXavierBootFlow.html)
+1. [ThinkEdge SE70 Recovery process](https://smartsupport.lenovo.com/de/en/products/smart/smart-edge/thinkedge-se70/)

--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -97,3 +97,29 @@ files:
     metadata: yaml
   - path: /etc/eve-hv-type
     contents: 'EVE_HV'
+  - path: /etc/securetty
+    contents: |
+      console
+      tty0
+      tty1
+      tty2
+      tty3
+      tty4
+      tty5
+      tty6
+      tty7
+      tty8
+      tty9
+      tty10
+      tty11
+      hvc0
+      ttyS0
+      ttyS1
+      ttyS2
+      ttyAMA0
+      ttyAMA1
+      ttyTCU0
+      ttyTHS0
+      ttyTHS1
+      ttymxc0
+      ttymxc2

--- a/kernel-version.mk
+++ b/kernel-version.mk
@@ -44,7 +44,7 @@ else ifeq ($(ZARCH), arm64)
         KERNEL_VERSION=v6.1.38
     endif
     KERNEL_COMMIT_generic=b18cb9e3e
-    KERNEL_COMMIT_nvidia=b0b5f116e
+    KERNEL_COMMIT_nvidia=e6cd9a55f
 else ifeq ($(ZARCH), riscv64)
     KERNEL_VERSION=v6.1.38
     KERNEL_FLAVOR=generic

--- a/pkg/alpine/mirrors/3.16/main
+++ b/pkg/alpine/mirrors/3.16/main
@@ -213,6 +213,7 @@ zip
 zlib
 zlib-dev
 zlib-static
+zstd
 zstd-dev
 zstd-libs
 zstd-static

--- a/pkg/fw/Dockerfile
+++ b/pkg/fw/Dockerfile
@@ -1,6 +1,7 @@
-FROM lfedge/eve-alpine:9fb9b9cbf7d90066a70e4704d04a6fe248ff52bb as build
+# syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
+FROM lfedge/eve-alpine:c61659241a11346dfb5a595d1217d64381df3adb as build
 
-ENV BUILD_PKGS tar make
+ENV BUILD_PKGS tar make binutils zstd
 RUN eve-alpine-deploy.sh
 
 ENV WIRELESS_REGDB_VERSION 2022.06.06
@@ -9,6 +10,20 @@ ADD ${WIRELESS_REGDB_REPO}-${WIRELESS_REGDB_VERSION}.tar.gz /wireless-regdb.tar.
 RUN mkdir /wireless-regdb &&\
     tar -xz --strip-components=1 -C /wireless-regdb -f /wireless-regdb.tar.gz &&\
     cp /wireless-regdb/regulatory.db /wireless-regdb/regulatory.db.p7s /lib/firmware
+
+# Nvidia Firmware
+ENV NVIDIA_FW_TEGRA nvidia-l4t-firmware_35.1.0-20220810203728_arm64.deb
+ADD https://repo.download.nvidia.com/jetson/t194/pool/main/n/nvidia-l4t-firmware/${NVIDIA_FW_TEGRA} /${NVIDIA_FW_TEGA}
+RUN mkdir -p /nvidia-firmware && \
+    cd /nvidia-firmware ;\
+    ar x ../"${NVIDIA_FW_TEGRA}" ;\
+    zstd -d < data.tar.zst > data.tar ;\
+    tar -xvf data.tar -C ./ ;\
+    rm data.tar.zst data.tar
+
+# RTL8822ce firmware
+ENV RTL8822_FW_VERSION ca9f4e199efbf8c377e8a1769ba5b05b23f92c82
+ADD https://github.com/lwfinger/rtw88.git#${RTL8822_FW_VERSION} /rtw88
 
 ENV LINUX_FIRMWARE_VERSION 20220708
 ENV LINUX_FIRMWARE_URL https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/snapshot/linux-firmware
@@ -61,8 +76,6 @@ COPY --from=build /lib/firmware/iwlwifi-9260* /lib/firmware/
 # AX210 160MHZ
 COPY --from=build /lib/firmware/iwlwifi-ty-a0-gf-a0-59.ucode /lib/firmware/
 COPY --from=build /lib/firmware/intel/ibt-0041-0041* /lib/firmware/intel/
-# NVidia Jetson
-COPY --from=build /lib/firmware/nvidia/tegra210 /lib/firmware/nvidia/tegra210
 # Dell Edge Gateway 300x firmware
 COPY --from=build /lib/firmware/rsi* /lib/firmware/rsi/
 # Intel Corporation Cannon Point-LP CNVi [Wireless-AC] (rev 30)
@@ -82,6 +95,26 @@ COPY --from=build /lib/firmware/ath10k /lib/firmware/ath10k
 COPY --from=build /lib/firmware/ti-connectivity /lib/firmware/ti-connectivity
 # to keep compatibility with the current layout
 RUN cp --symbolic-link /lib/firmware/brcm/* /lib/firmware
+# Nvidia Jetson Nano + Xavier NX
+COPY --from=build /nvidia-firmware/lib/firmware/bcm4354.hcd /lib/firmware/
+COPY --from=build /nvidia-firmware/lib/firmware/brcm/fw_bcmdhd.bin /lib/firmware/brcm/
+COPY --from=build /nvidia-firmware/lib/firmware/brcm/nvram.txt /lib/firmware/brcm/
+COPY --from=build /nvidia-firmware/lib/firmware/display-t234-dce.bin /lib/firmware/
+COPY --from=build /nvidia-firmware/lib/firmware/nv-BT-Version /lib/firmware/
+COPY --from=build /nvidia-firmware/lib/firmware/nvhost_nvdla010.fw /lib/firmware/
+COPY --from=build /nvidia-firmware/lib/firmware/nvhost_nvdla020.fw /lib/firmware/
+COPY --from=build /nvidia-firmware/lib/firmware/nvhost_ofa012.fw /lib/firmware/
+COPY --from=build /nvidia-firmware/lib/firmware/nvhost_vic042.fw /lib/firmware/
+COPY --from=build /nvidia-firmware/lib/firmware/nvpva_010.fw /lib/firmware/
+COPY --from=build /nvidia-firmware/lib/firmware/nvpva_020.fw /lib/firmware/
+COPY --from=build /nvidia-firmware/lib/firmware/nv-WIFI-Version /lib/firmware/
+COPY --from=build /nvidia-firmware/lib/firmware/nvidia/tegra194 /lib/firmware/nvidia/tegra194
+COPY --from=build /nvidia-firmware/lib/firmware/ga10b /lib/firmware/ga10b
+COPY --from=build /nvidia-firmware/lib/firmware/gv11b /lib/firmware/gv11b
+COPY --from=build /nvidia-firmware/lib/firmware/tegra19x /lib/firmware/tegra19x
+COPY --from=build /nvidia-firmware/lib/firmware/tegra23x /lib/firmware/tegra23x
+COPY --from=build /lib/firmware/nvidia/tegra210 /lib/firmware/nvidia/tegra210
+COPY --from=build /rtw88/*.bin /lib/firmware/rtw88/
 
 FROM scratch
 ENTRYPOINT []

--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -293,6 +293,11 @@ function set_arm64_baremetal {
       set_to_existing_file devicetree /boot/dtb/nvidia/tegra194-p3668-0000-p3509-0000.dtb
       set_global dom0_console "console=tty0 console=ttyTCU0 earlycon=ttyTCU0,115200 fbcon=map:0"
    fi
+   # Lenovo ThinkEdge SE70 (Jetson Xavier NX platform)
+   if [ "$smb_product" = "ThinkEdge SE70 (NVIDIA Jetson Xavier NX)" ]; then
+      set_to_existing_file devicetree /boot/dtb/nvidia/tegra194-p3668-0001-p3509-0000-lenovo-se70.dtb
+      set_global dom0_console "console=tty0 earlycon=tty0 fbcon=map:0 eve_install_disk=nvme0n1"
+   fi
 }
 
 function set_arm64_qemu {

--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -287,6 +287,12 @@ function set_arm64_baremetal {
          set_global dom0_console "console=tty0 console=hvc0 console=ttymxc2,115200 earlycon=ec_imx6q,0x30880000,115200"
       fi
    fi
+   # Nvidia's Jetson Xavier NX
+   smbios -t 1 -s 5 --set smb_product
+   if [ "$smb_product" = "NVIDIA Jetson Xavier NX Developer Kit" ]; then
+      set_to_existing_file devicetree /boot/dtb/nvidia/tegra194-p3668-0000-p3509-0000.dtb
+      set_global dom0_console "console=tty0 console=ttyTCU0 earlycon=ttyTCU0,115200 fbcon=map:0"
+   fi
 }
 
 function set_arm64_qemu {


### PR DESCRIPTION
This PR introduces the NVIDIA Jetson Xavier NX Platform support on EVE. Two devices are officially supported for this platform:

1. Lenovo ThinkEdge SE70
2. NVIDIA Jetson Xavier NX developer kit

The kernel customized for EVE for this platform it's already available at the [eve-kernel repo](https://github.com/lf-edge/eve-kernel), so this PR integrates:

1. Image building and generation
2. Firmware
3. Device tree loading
4. Documentation