### PR TITLE
ModemManager: enable all available FCC-unlock scripts

### DIFF
--- a/pkg/wwan/README.md
+++ b/pkg/wwan/README.md
@@ -931,3 +931,32 @@ rtt min/avg/max/mdev = 44.159/66.162/122.881/32.853 ms
 
 Now you have verified that your modem is compatible with EVE OS and you can try to configure
 cellular connection properly from the controller.
+
+## FCC lock
+
+The [FCC](https://www.fcc.gov/) lock is a software lock integrated in WWAN modems shipped by several
+different laptop and edge device vendors, such as Lenovo, Dell, or HP. This locks prevents the WWAN
+modem from being put online until some specific unlock procedure (usually a magic command sent
+to the modem) is executed. The purpose of this lock is to have a way to bind the WWAN modem
+to a specific device, so that the whole bundle of device+modem can go through the FCC certification
+process for radio-enabled devices in the USA. This lock has no other known purpose out of the US
+regulation.
+
+The FCC lock is part of a mutual authentication attempt between modem and device. On the device side,
+BIOS is configured with an allow-list of modems that the device can be used with. On the modem side,
+the FCC lock ensures that the modem is unlocked only by approved devices.
+
+The main challenge faced from the perspective of EVE is that device vendors often provide FCC unlock
+utilities exclusively for Windows or macOS, and their devices are not FCC-certified for use with
+GNU/Linux distributions. Fortunately, the ModemManager developers have successfully reverse-engineered
+FCC unlock procedures for some widely used Sierra Wireless and Quectel modems, providing scripts
+for these operations. In some cases, collaboration between ModemManager developers, device vendors,
+and modem manufacturers has resulted in FCC unlock scripts that have been verified by all parties.
+However, in other instances, there may be a slight risk associated with running reverse-engineered
+unlock procedures. Therefore, ModemManager will not use FCC unlock scripts unless explicitly enabled.
+
+For more information on FCC lock and how ModemManager deals with this challenge, please refer to this
+[article](https://modemmanager.org/docs/modemmanager/fcc-unlock/).
+
+In the case of EVE, the decision has been made to enable all FCC unlock scripts that come with
+ModemManager and then potentially disable only those for which issues are reported.

--- a/pkg/wwan/mm-init.sh
+++ b/pkg/wwan/mm-init.sh
@@ -4,6 +4,24 @@
 
 set -e
 
+# Enable all available FCC-unlock scripts.
+# For more info, see: https://modemmanager.org/docs/modemmanager/fcc-unlock/
+enable_fcc_unlock() {
+  SOURCE_DIR="/usr/share/ModemManager/fcc-unlock.available.d/"
+  TARGET_DIR="/etc/ModemManager/fcc-unlock.d/"
+
+  for SCRIPT in "${SOURCE_DIR}"*; do
+    if [ -f "$SCRIPT" ]; then
+      SCRIPT_NAME="$(basename "$SCRIPT")"
+      ln -sf "$SCRIPT" "${TARGET_DIR}${SCRIPT_NAME}"
+    fi
+  done
+
+  # "Quectel EM05G Smart Gateway" (2c7c:0311) is compatible with the same
+  # FCC unlock script as used for the regular "Quectel EM05G" (2c7c:030a).
+  ln -sf "${SOURCE_DIR}2c7c:030a" "${TARGET_DIR}2c7c:0311"
+}
+
 echo "Loading kernel modules used by ModemManager"
 modprobe -a qcserial usb_wwan qmi_wwan cdc_wdm cdc_mbim cdc_acm
 echo "Kernel modules are loaded"
@@ -21,6 +39,7 @@ udevadm trigger
 echo "Udev daemon started"
 
 echo "Starting Modem Manager"
+enable_fcc_unlock
 ModemManager --debug &
 
 echo "Starting Modem Manager Agent"

--- a/pkg/wwan/mmagent/mmdbus/client.go
+++ b/pkg/wwan/mmagent/mmdbus/client.go
@@ -1243,7 +1243,16 @@ func (c *Client) runSimpleConnect(modemObj dbus.BusObject,
 	var bearerPath dbus.ObjectPath
 	modem := c.modems[string(modemObj.Path())]
 	err := c.callDBusMethod(modemObj, SimpleMethodConnect, &bearerPath, connProps)
-	if err != nil && strings.HasPrefix(err.Error(), "No such interface") && modem != nil {
+	var errIsUseless bool
+	if err != nil {
+		if strings.HasPrefix(err.Error(), "No such interface") {
+			errIsUseless = true
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			errIsUseless = true
+		}
+	}
+	if errIsUseless && modem != nil {
 		// Try to determine more useful connection failure reason.
 		for _, simCard := range modem.Status.SimCards {
 			if !simCard.SlotActivated {


### PR DESCRIPTION
FCC-locked modems are in disabled state and in low-power mode. ModemManager is not able to use locked modem unless a suitable FCC-unlock procedure is triggered. For some widely used modems, [MM provides FCC-unlock scripts](https://modemmanager.org/docs/modemmanager/fcc-unlock/). However, in some cases, these scripts are a result of reverse engineering of proprietary unlock utilities and may not work correctly. Therefore, these scripts are disabled by default.

We already had a situation where FCC unlock was required by an EVE user. We will therefore enable all FCC unlock scripts and then potentially disable only those for which issues will be reported. More info in the documentation that was added.

Additionally in this PR, there is a small improvement in terms of errors reported for failed connectivity setup. mmagent tries to find more useful reason for failure than `context.DeadlineExceeded`.