### PR TITLE
Patch envelopes: Sent status

### DIFF
--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -107,6 +107,7 @@ type getconfigContext struct {
 	pubDisksConfig            pubsub.Publication
 	pubEdgeNodeInfo           pubsub.Publication
 	pubPatchEnvelopeInfo      pubsub.Publication
+	subPatchEnvelopeStatus    pubsub.Subscription
 	subCachedResolvedIPs      pubsub.Subscription
 	NodeAgentStatus           *types.NodeAgentStatus
 	configProcessingRV        configProcessingRetval

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -1050,10 +1050,12 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 
 	ReportAppInfo.AppID = uuid
 	ReportAppInfo.SystemApp = false
+
 	if aiStatus != nil {
 		ReportAppInfo.AppVersion = aiStatus.UUIDandVersion.Version
 		ReportAppInfo.AppName = aiStatus.DisplayName
 		ReportAppInfo.State = aiStatus.State.ZSwState()
+		ReportAppInfo.PatchEnvelope = composePatchEnvelopeUsage(uuid, ctx)
 		if !aiStatus.ErrorTime.IsZero() {
 			errInfo := encodeErrorInfo(
 				aiStatus.ErrorAndTimeWithSource.ErrorDescription)

--- a/pkg/pillar/cmd/zedagent/handlepatchenvelopes.go
+++ b/pkg/pillar/cmd/zedagent/handlepatchenvelopes.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2023 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package zedagent
+
+import (
+	"bytes"
+
+	"github.com/golang/protobuf/ptypes"
+	"github.com/lf-edge/eve-api/go/info"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"google.golang.org/protobuf/proto"
+)
+
+func handlePatchEnvelopeStatusCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handlePatchEnvelopeStatusImpl(ctxArg, key, statusArg)
+}
+
+func handlePatchEnvelopeStatusModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handlePatchEnvelopeStatusImpl(ctxArg, key, statusArg)
+}
+
+func handlePatchEnvelopeStatusImpl(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	peStatus := composeZInfoPatchEnvelope(statusArg.(types.PatchEnvelopeInfo))
+	ctx := ctxArg.(*zedagentContext)
+	publishPatchEnvelopeStatus(ctx, peStatus, ctx.iteration, ControllerDest)
+}
+
+func composeZInfoPatchEnvelope(peStatus types.PatchEnvelopeInfo) *info.ZInfoPatchEnvelope {
+	return &info.ZInfoPatchEnvelope{
+		Name:    peStatus.Name,
+		Id:      peStatus.PatchID,
+		Version: peStatus.Version,
+		State:   infoStateFromPatchEnvelopeState(peStatus.State),
+		Size:    uint64(peStatus.Size()),
+		Errors:  peStatus.Errors,
+	}
+}
+
+func infoStateFromPatchEnvelopeState(state types.PatchEnvelopeState) info.EVE_PATCH_ENVELOPE_STATE {
+	switch state {
+	case types.PatchEnvelopeStateError:
+		return info.EVE_PATCH_ENVELOPE_STATE_PATCH_ERROR
+	case types.PatchEnvelopeStateRecieved:
+		return info.EVE_PATCH_ENVELOPE_STATE_PATCH_RECEIVED
+	case types.PatchEnvelopeStateDownloading:
+		return info.EVE_PATCH_ENVELOPE_STATE_PATCH_DOWNLOADING
+	case types.PatchEnvelopeStateDownloaded:
+		return info.EVE_PATCH_ENVELOPE_STATE_PATCH_DOWNLOADED
+	case types.PatchEnvelopeStateReady:
+		return info.EVE_PATCH_ENVELOPE_STATE_PATCH_READY
+	case types.PatchEnvelopeStateActive:
+		return info.EVE_PATCH_ENVELOPE_STATE_PATCH_ACTIVE
+	default:
+		return info.EVE_PATCH_ENVELOPE_STATE_PATCH_UNKOWN
+	}
+}
+
+func publishPatchEnvelopeStatus(ctx *zedagentContext, patchInfo *info.ZInfoPatchEnvelope,
+	iteration int, dest destinationBitset) {
+	log.Functionf("publishPatchEnvelopeOpaqueStatus: iteration %d", iteration)
+	infoMsg := &info.ZInfoMsg{
+		Ztype: info.ZInfoTypes_ZiPatchEnvelope,
+		DevId: devUUID.String(),
+		InfoContent: &info.ZInfoMsg_PatchInfo{
+			PatchInfo: patchInfo,
+		},
+		AtTimeStamp: ptypes.TimestampNow(),
+	}
+
+	log.Functionf("publishPatchEnvelopeStatus: sending %v", infoMsg)
+	data, err := proto.Marshal(infoMsg)
+	if err != nil {
+		log.Fatal("publishPatchEnvelopeStatus: proto marshaling error: ", err)
+	}
+	buf := bytes.NewBuffer(data)
+	if buf == nil {
+		log.Fatal("malloc error")
+	}
+	size := int64(proto.Size(infoMsg))
+
+	const bailOnHTTPErr = false
+	const withNetTrace = false
+	key := "publishPatchEnvelopeStatus:" + patchInfo.Id
+
+	const forcePeriodic = false
+	queueInfoToDest(ctx, dest, key, buf, size, bailOnHTTPErr, withNetTrace,
+		forcePeriodic, info.ZInfoTypes_ZiPatchEnvelope)
+}

--- a/pkg/pillar/cmd/zedagent/handlepatchenvelopes.go
+++ b/pkg/pillar/cmd/zedagent/handlepatchenvelopes.go
@@ -12,6 +12,24 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+func composePatchEnvelopeUsage(appUUID string, ctx *zedagentContext) []*info.ZInfoPatchEnvelopeUsage {
+	result := []*info.ZInfoPatchEnvelopeUsage{}
+
+	for _, c := range ctx.subPatchEnvelopeUsage.GetAll() {
+		peUsage := c.(types.PatchEnvelopeUsage)
+		if peUsage.AppUUID == appUUID {
+			result = append(result, &info.ZInfoPatchEnvelopeUsage{
+				Uuid:              peUsage.PatchID,
+				Version:           peUsage.Version,
+				PatchApiCallCount: peUsage.PatchAPICallCount,
+				DownloadCount:     peUsage.DownloadCount,
+			})
+		}
+	}
+
+	return result
+}
+
 func handlePatchEnvelopeStatusCreate(ctxArg interface{}, key string,
 	statusArg interface{}) {
 	handlePatchEnvelopeStatusImpl(ctxArg, key, statusArg)
@@ -84,7 +102,7 @@ func publishPatchEnvelopeStatus(ctx *zedagentContext, patchInfo *info.ZInfoPatch
 
 	const bailOnHTTPErr = false
 	const withNetTrace = false
-	key := "publishPatchEnvelopeStatus:" + patchInfo.Id
+	key := "publishPatchEnvelopeStatus:" + patchInfo.Id + "v" + patchInfo.Version
 
 	const forcePeriodic = false
 	queueInfoToDest(ctx, dest, key, buf, size, bailOnHTTPErr, withNetTrace,

--- a/pkg/pillar/cmd/zedagent/parseconfig_test.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig_test.go
@@ -1323,6 +1323,8 @@ func TestParsePatchEnvelope(t *testing.T) {
 	g.Expect(pes.Get(appU1).Envelopes).To(BeEquivalentTo([]types.PatchEnvelopeInfo{
 		{
 			PatchID:     patchID,
+			Name:        displayName,
+			Version:     patchVersion,
 			AllowedApps: []string{appU1, appU2},
 			BinaryBlobs: []types.BinaryBlobCompleted{
 				{

--- a/pkg/pillar/cmd/zedagent/parseconfig_test.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig_test.go
@@ -1331,6 +1331,7 @@ func TestParsePatchEnvelope(t *testing.T) {
 					FileMetadata:     fileMetadata,
 					ArtifactMetadata: artiactMetadata,
 					URL:              filepath.Join(persistCacheFolder, inlineFileName),
+					Size:             int64(len(fileData)),
 				},
 			},
 		},

--- a/pkg/pillar/cmd/zedagent/parsepatchenvelopes.go
+++ b/pkg/pillar/cmd/zedagent/parsepatchenvelopes.go
@@ -47,11 +47,15 @@ func parsePatchEnvelopesImpl(ctx *getconfigContext, config *zconfig.EdgeDevConfi
 		peInfo := types.PatchEnvelopeInfo{
 			AllowedApps: pe.GetAppInstIdsAllowed(),
 			PatchID:     pe.GetUuid(),
+			Name:        pe.GetDisplayName(),
+			Version:     pe.GetVersion(),
 		}
 		for _, a := range pe.GetArtifacts() {
 			err := addBinaryBlobToPatchEnvelope(&peInfo, a, persistCacheFilepath)
 			if err != nil {
-				log.Errorf("Failed to compose binary blob for patch envelope %v", err)
+				msg := fmt.Sprintf("Failed to compose binary blob for patch envelope %v", err)
+				peInfo.Errors = append(peInfo.Errors, msg)
+				log.Errorf(msg)
 				return
 			}
 		}
@@ -139,6 +143,7 @@ func cacheInlineBase64Artifact(artifact *zconfig.InlineOpaqueBase64Data, persist
 		FileSha:      hex.EncodeToString(shaBytes[:]),
 		FileMetadata: metadata,
 		URL:          url,
+		Size:         int64(len(data)),
 	}, nil
 }
 

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -1033,6 +1033,9 @@ func mainEventLoop(zedagentCtx *zedagentContext, stillRunning *time.Ticker) {
 		case change := <-getconfigCtx.subCachedResolvedIPs.MsgChan():
 			getconfigCtx.subCachedResolvedIPs.ProcessChange(change)
 
+		case change := <-getconfigCtx.subPatchEnvelopeStatus.MsgChan():
+			getconfigCtx.subPatchEnvelopeStatus.ProcessChange(change)
+
 		case <-hwInfoTiker.C:
 			triggerPublishHwInfo(zedagentCtx)
 
@@ -1917,6 +1920,20 @@ func initPostOnboardSubs(zedagentCtx *zedagentContext) {
 		ErrorTime:   errorTime,
 		TopicImpl:   types.CachedResolvedIPs{},
 		Activate:    true,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	getconfigCtx.subPatchEnvelopeStatus, err = ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:     "zedrouter",
+		MyAgentName:   agentName,
+		TopicImpl:     types.PatchEnvelopeInfo{},
+		Activate:      true,
+		CreateHandler: handlePatchEnvelopeStatusCreate,
+		ModifyHandler: handlePatchEnvelopeStatusModify,
+		WarningTime:   warningTime,
+		ErrorTime:     errorTime,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/pillar/cmd/zedrouter/patchenvelopes.go
+++ b/pkg/pillar/cmd/zedrouter/patchenvelopes.go
@@ -10,6 +10,7 @@ import (
 	uuid "github.com/satori/go.uuid"
 
 	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils/generics"
 )
@@ -36,7 +37,9 @@ import (
 // means that request to update same object will be only once, so there will be no queue of
 // go routines piling up but it will take more CPU time to process it.
 // NewPatchEnvelopes() starts goroutine processStateUpdate() which reads from the channel and updates
-// currentState to desired one.
+// currentState to desired one. In addition, this goroutine publishes status for every PatchEnvelope
+// via pubsub. Note that PatchEnvelopes does not create PubSub, rather used one provided to NewPatchEnvelopes()
+// So it does not have a agentName, but could easily be split into one if needed
 // This way handlers can do work of determining which patch envelopes actually need change (if any)
 // and send back in go routine rest of the update including slow work.
 // Note that this channels are only accessible from the outside by calling a function which returns
@@ -53,7 +56,9 @@ type PatchEnvelopes struct {
 	completedVolumes  *generics.LockedMap[uuid.UUID, types.VolumeStatus]
 	contentTreeStatus *generics.LockedMap[uuid.UUID, types.ContentTreeStatus]
 
-	log *base.LogObject
+	pubSub                *pubsub.PubSub
+	log                   *base.LogObject
+	pubPatchEnvelopeState pubsub.Publication
 }
 
 // UpdateStateNotificationCh return update channel to send notifications to update currentState
@@ -62,9 +67,9 @@ func (pes *PatchEnvelopes) UpdateStateNotificationCh() chan<- struct{} {
 }
 
 // NewPatchEnvelopes returns PatchEnvelopes structure and starts goroutine
-// to process messages from channels. Note that we create buffered channels
+// to process notifications from channel. Note that we create buffered channel
 // to avoid unbounded processing time in writing to channel
-func NewPatchEnvelopes(log *base.LogObject) *PatchEnvelopes {
+func NewPatchEnvelopes(log *base.LogObject, ps *pubsub.PubSub) *PatchEnvelopes {
 	pe := &PatchEnvelopes{
 
 		updateStateNotificationCh: make(chan struct{}, 1),
@@ -77,7 +82,17 @@ func NewPatchEnvelopes(log *base.LogObject) *PatchEnvelopes {
 		completedVolumes:  generics.NewLockedMap[uuid.UUID, types.VolumeStatus](),
 		contentTreeStatus: generics.NewLockedMap[uuid.UUID, types.ContentTreeStatus](),
 
-		log: log,
+		log:    log,
+		pubSub: ps,
+	}
+
+	var err error
+	pe.pubPatchEnvelopeState, err = pe.pubSub.NewPublication(pubsub.PublicationOptions{
+		AgentName: agentName,
+		TopicType: types.PatchEnvelopeInfo{},
+	})
+	if err != nil {
+		return nil
 	}
 
 	go pe.processStateUpdate()
@@ -98,6 +113,9 @@ func (pes *PatchEnvelopes) updateState() {
 	keys := pes.envelopesToDelete.Keys()
 	for _, k := range keys {
 		if toDelete, _ := pes.envelopesToDelete.Load(k); toDelete {
+			if peInfo, ok := pes.currentState.Load(k); ok {
+				pes.unpublishPatchEnvelopeInfo(&peInfo)
+			}
 			pes.currentState.Delete(k)
 			pes.envelopesToDelete.Store(k, false)
 		}
@@ -130,6 +148,7 @@ func (pes *PatchEnvelopes) updateState() {
 
 					pe.State = peState
 					pes.currentState.Store(peUUID, pe)
+					pes.publishPatchEnvelopeInfo(&pe)
 					pes.envelopesToUpdate.Store(peUUID, false)
 
 				} else {
@@ -139,6 +158,34 @@ func (pes *PatchEnvelopes) updateState() {
 				pes.log.Errorf("No entry in envelopes for %v to fetch", peUUID)
 			}
 		}
+	}
+}
+
+func (pes *PatchEnvelopes) publishPatchEnvelopeInfo(peInfo *types.PatchEnvelopeInfo) {
+	if peInfo == nil {
+		pes.log.Errorf("publishPatchEnvelopeInfo: nil peInfo")
+	}
+	key := peInfo.Key()
+	pub := pes.pubPatchEnvelopeState
+	err := pub.Publish(key, *peInfo)
+	if err != nil {
+		pes.log.Errorf("publishPatchEnvelopeInfo failed: %v", err)
+	}
+}
+
+func (pes *PatchEnvelopes) unpublishPatchEnvelopeInfo(peInfo *types.PatchEnvelopeInfo) {
+	if peInfo == nil {
+		pes.log.Errorf("unpublishPatchEnvelopeInfo: nil peInfo")
+		return
+	}
+	key := peInfo.Key()
+	pub := pes.pubPatchEnvelopeState
+	if exists, _ := pub.Get(key); exists == nil {
+		pes.log.Errorf("unpublishPatchEnvelopeInfo: key %s not found", key)
+		return
+	}
+	if err := pub.Unpublish(key); err != nil {
+		pes.log.Errorf("unpublishPatchEnvelopeInfo failed: %v", err)
 	}
 }
 

--- a/pkg/pillar/cmd/zedrouter/patchenvelopes_test.go
+++ b/pkg/pillar/cmd/zedrouter/patchenvelopes_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/cmd/zedrouter"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/onsi/gomega"
 	uuid "github.com/satori/go.uuid"
@@ -22,7 +23,8 @@ func TestPatchEnvelopes(t *testing.T) {
 
 	logger := logrus.StandardLogger()
 	log := base.NewSourceLogObject(logger, "petypes", 1234)
-	peStore := zedrouter.NewPatchEnvelopes(log)
+	ps := pubsub.New(&pubsub.EmptyDriver{}, logger, log)
+	peStore := zedrouter.NewPatchEnvelopes(log, ps)
 
 	u := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
 	contentU := "6ba7b810-9dad-11d1-80b4-ffffffffffff"
@@ -119,6 +121,7 @@ func TestPatchEnvelopes(t *testing.T) {
 			{
 				PatchID:     "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
 				AllowedApps: []string{u},
+				State:       types.PatchEnvelopeStateActive,
 				BinaryBlobs: []types.BinaryBlobCompleted{
 					{
 						FileName:     "TestFileName",

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -216,7 +216,7 @@ func (z *zedrouter) init() (err error) {
 	z.zedcloudMetrics = zedcloud.NewAgentMetrics()
 	z.cipherMetrics = cipher.NewAgentMetrics(agentName)
 
-	z.patchEnvelopes = NewPatchEnvelopes(z.log)
+	z.patchEnvelopes = NewPatchEnvelopes(z.log, z.pubSub)
 
 	gcp := *types.DefaultConfigItemValueMap()
 	z.appContainerStatsInterval = gcp.GlobalValueInt(types.AppContainerStatsInterval)

--- a/pkg/pillar/types/patchenvelopestypes.go
+++ b/pkg/pillar/types/patchenvelopestypes.go
@@ -50,7 +50,7 @@ func (pe *PatchEnvelopeInfo) Size() (size int64) {
 
 // Key for pubsub
 func (pe *PatchEnvelopeInfo) Key() string {
-	return pe.PatchID
+	return pe.PatchID + "v" + pe.Version
 }
 
 // PatchEnvelopeState repeats constants from patch_envelope.pb.go from info API
@@ -125,4 +125,25 @@ type BinaryBlobVolumeRef struct {
 	// ArtifactMetadata is generic info i.e. user info, desc etc.
 	ArtifactMetadata string `json:"artifactMetaData"`
 	ImageID          string `json:"imageId"`
+}
+
+// PatchEnvelopeUsage stores information on how patchEnvelopes are
+// used by App Instances to send this information back to controller
+// reflects ZInfoPatchEnvelopeUsage proto message
+type PatchEnvelopeUsage struct {
+	AppUUID string
+	PatchID string
+	Version string
+	// count the number of times app instance called patch APIs
+	PatchAPICallCount uint64
+	// count the number of times app instance actually downloaded
+	// whole patch envelope or part of it
+	DownloadCount uint64
+}
+
+// Key for pubsub
+func (pe *PatchEnvelopeUsage) Key() string {
+	return "patchEnvelopeUsage:" + pe.PatchID +
+		"-v-" + pe.Version +
+		"-app-" + pe.AppUUID
 }

--- a/pkg/pillar/types/patchenvelopestypes.go
+++ b/pkg/pillar/types/patchenvelopestypes.go
@@ -48,6 +48,11 @@ func (pe *PatchEnvelopeInfo) Size() (size int64) {
 	return
 }
 
+// Key for pubsub
+func (pe *PatchEnvelopeInfo) Key() string {
+	return pe.PatchID
+}
+
 // PatchEnvelopeState repeats constants from patch_envelope.pb.go from info API
 type PatchEnvelopeState int32
 


### PR DESCRIPTION
This PR concludes work on PatchEnvelopes and contains code to send metrics about PatchEnvelopes to controller. There are two types of metrics we are sending to controller: `PatchEnvelopeStatus` and `PatchEnvelopeUsage`.
Former comes as part of `ZInfoMsg` with `ZInfoMsg_PatchInfo` type and contains general infromation about PatchEnvelope: what it contains and what its status (downloading, downloaded, is serving for clients, etc.), latter comes as part of `ZInfoApp` and contains statistics containing how many times specific PatchEnvelope was requested by App Instance and how many times it has been downloaded. Note that we PatchEnvelopeUsage key is composed from PatchID it's version and AppUUID (so usage will be different for every app for every patch envelope for every version of it) 
In order to handle async updates of usage by apps (since we have webserver which can call as many requests as it wants) this patch introduces ApplyOrStore function to LockedMap, because with current API you will write something like
```golang
  if v, ok := m.Load(key); ok {
    // Point where it can deffer
    m.Store(key, v++)
  }
```
And between Load and Store there's a point where it can diverge. By using `ApplyOrStore` operation becomes atomic