### PR TITLE
Hypervisor installation fix

### DIFF
--- a/pkg/mkimage-raw-efi/install
+++ b/pkg/mkimage-raw-efi/install
@@ -31,6 +31,8 @@ BAIL_FINAL_CMD=${BAIL_FINAL_CMD:-"exit 1"}
 # the contents of this file are saved to $REPORT/installer.log
 # After the USB install, users can see the installation status under /Volumes/INVENTORY/<serial#>/installer.log
 LOGFILE_DIR="/run"
+
+# pillar behaves differently if this file exists to check if it is running in installer mode - see hypervisor.go
 LOGFILE="$LOGFILE_DIR/installer.log"
 # logs to both console and a file.
 logmsg() {

--- a/pkg/pillar/hypervisor/hypervisor.go
+++ b/pkg/pillar/hypervisor/hypervisor.go
@@ -10,6 +10,7 @@ import (
 	"os"
 
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/mem"
 	"github.com/sirupsen/logrus"
@@ -18,6 +19,12 @@ import (
 var currentHypervisor Hypervisor
 
 func init() {
+	if fileutils.FileExists(nil, "/run/installer.log") {
+		// if this file exists it means we're running in the installer and we should not inititialize the containerd
+		// hypervisor as it interferes with the installer
+		return
+	}
+
 	var err error
 
 	flagSet := flag.NewFlagSet("", flag.ExitOnError)


### PR DESCRIPTION
    hypervisor: don't init in install mode
    
    if containerd is initialized during installation the installation will
    fail generating an onboarding certificate