### PR TITLE
grub: Clear eMMC partition table on ThinkEdge SE70

### DIFF
--- a/docs/NVIDIA-NX.md
+++ b/docs/NVIDIA-NX.md
@@ -32,8 +32,13 @@ can be changed in the bootloader's setup interface with the following steps:
 1. Flash the `dist/arm64/current/installer.raw` install EVE image onto an USB Stick [following these instructions](../README.md#how-to-write-eve-image-and-installer-onto-an-sd-card-or-an-installer-medium)
 1. Insert the USB Stick and power on the device
 
-The installation process will start and it will install EVE on the NVMe automatically. If the installation succeed, the
-device will be powered off. Remove the USB Stick and power on the device again.
+The installation process will start and it will install EVE on the NVMe automatically.
+
+> **:warning: WARNING !**
+>
+> The installation process will wipe off both eMMC and NVMe. Any data present on these devices will be lost.
+
+If the installation succeed, the device will be powered off. Remove the USB Stick and power on the device again.
 
 ### Running a live image on the ThinkEdge SE70
 

--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -296,7 +296,7 @@ function set_arm64_baremetal {
    # Lenovo ThinkEdge SE70 (Jetson Xavier NX platform)
    if [ "$smb_product" = "ThinkEdge SE70 (NVIDIA Jetson Xavier NX)" ]; then
       set_to_existing_file devicetree /boot/dtb/nvidia/tegra194-p3668-0001-p3509-0000-lenovo-se70.dtb
-      set_global dom0_console "console=tty0 earlycon=tty0 fbcon=map:0 eve_install_disk=nvme0n1"
+      set_global dom0_console "console=tty0 earlycon=tty0 fbcon=map:0 eve_nuke_disks=mmcblk0 eve_install_disk=nvme0n1"
    fi
 }
 


### PR DESCRIPTION
The Lenovo ThinkEdge SE70 device comes from factory with a bootable image on the eMMC. However, EVE is installed on the NVMe SSD, so we need to clear eMMC's partition table to avoid any boot attempt from it, letting the device boot normally from the NVMe.

Background: An issue was notice on a brand new device trying to boot from eMMC after EVE's installation. The changes in this PR fixed the issue.