### PR TITLE
pillar/qmp: return a proper error if response on "query-status" can't be parsed

### DIFF
--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -913,7 +913,7 @@ func (ctx KvmContext) Start(domainName string) error {
 		return logError("failed to start domain that is stopped %v", err)
 	}
 
-	if status, err := getQemuStatus(qmpFile); err != nil || status != "running" {
+	if status, err := getQemuStatus(qmpFile); err != nil || status != types.RUNNING {
 		return logError("domain status is not running but %s after cont command returned %v", status, err)
 	}
 	return nil
@@ -950,33 +950,13 @@ func (ctx KvmContext) Info(domainName string) (int, types.SwState, error) {
 		return effectiveDomainID, effectiveDomainState, err
 	}
 
-	// if task us alive, we augment task status with finer grained details from qemu
-	// lets parse the status according to https://github.com/qemu/qemu/blob/master/qapi/run-state.json#L8
-	stateMap := map[string]types.SwState{
-		"finish-migrate": types.PAUSED,
-		"inmigrate":      types.PAUSING,
-		"paused":         types.PAUSED,
-		"postmigrate":    types.PAUSED,
-		"prelaunch":      types.PAUSED,
-		"restore-vm":     types.PAUSED,
-		"running":        types.RUNNING,
-		"save-vm":        types.PAUSED,
-		"shutdown":       types.HALTING,
-		"suspended":      types.PAUSED,
-		"watchdog":       types.PAUSING,
-		"colo":           types.PAUSED,
-		"preconfig":      types.PAUSED,
-	}
-	res, err := getQemuStatus(GetQmpExecutorSocket(domainName))
+	_, err = getQemuStatus(GetQmpExecutorSocket(domainName))
 	if err != nil {
-		return effectiveDomainID, types.BROKEN, logError("couldn't retrieve status for domain %s: %v", domainName, err)
+		return effectiveDomainID, types.BROKEN,
+			logError("couldn't retrieve status for domain %s: %v", domainName, err)
 	}
 
-	if effectiveDomainState, matched := stateMap[res]; !matched {
-		return effectiveDomainID, types.BROKEN, logError("domain %s reported to be in unexpected state %s", domainName, res)
-	} else {
-		return effectiveDomainID, effectiveDomainState, nil
-	}
+	return effectiveDomainID, effectiveDomainState, nil
 }
 
 // Cleanup cleans up a domain

--- a/pkg/pillar/hypervisor/qmp.go
+++ b/pkg/pillar/hypervisor/qmp.go
@@ -206,7 +206,7 @@ func qmpEventHandler(listenerSocket, executorSocket string) {
 				}
 			default:
 				//Not handling the following events: RESUME, NIC_RX_FILTER_CHANGED, RTC_CHANGE, POWERDOWN, STOP
-				logrus.Debugf("qmpEventHandler: Unhandled event: %s from listenerSocket: %s", event.Event, listenerSocket)
+				logrus.Warnf("qmpEventHandler: Unhandled event: %s from QMP socket: %s", event.Event, listenerSocket)
 			}
 		}
 	}

--- a/pkg/pillar/hypervisor/qmp.go
+++ b/pkg/pillar/hypervisor/qmp.go
@@ -1,6 +1,7 @@
 package hypervisor
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -91,7 +92,14 @@ func getQemuStatus(socket string) (string, error) {
 				Status     string `json:"status"`
 			} `json:"return"`
 		}
-		err = json.Unmarshal(raw, &result)
+		dec := json.NewDecoder(bytes.NewReader(raw))
+		dec.DisallowUnknownFields()
+		err = dec.Decode(&result)
+		if err != nil {
+			err = fmt.Errorf("%v; (JSON received: '%s')", err, raw)
+		} else if result.Return.Status == "" {
+			err = fmt.Errorf("'status' is empty; (JSON received: '%s')", raw)
+		}
 		return result.Return.Status, err
 	} else {
 		return "", err

--- a/pkg/pillar/hypervisor/qmp.go
+++ b/pkg/pillar/hypervisor/qmp.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/digitalocean/go-qemu/qmp"
+	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/sirupsen/logrus"
 	"os"
 	"time"
@@ -82,7 +83,25 @@ func QmpExecDeviceAdd(socket, id string, busnum, devnum uint16) error {
 	return err
 }
 
-func getQemuStatus(socket string) (string, error) {
+func getQemuStatus(socket string) (types.SwState, error) {
+	// lets parse the status according to
+	// https://github.com/qemu/qemu/blob/master/qapi/run-state.json#L8
+	qmpStatusMap := map[string]types.SwState{
+		"finish-migrate": types.PAUSED,
+		"inmigrate":      types.PAUSING,
+		"paused":         types.PAUSED,
+		"postmigrate":    types.PAUSED,
+		"prelaunch":      types.PAUSED,
+		"restore-vm":     types.PAUSED,
+		"running":        types.RUNNING,
+		"save-vm":        types.PAUSED,
+		"shutdown":       types.HALTING,
+		"suspended":      types.PAUSED,
+		"watchdog":       types.PAUSING,
+		"colo":           types.PAUSED,
+		"preconfig":      types.PAUSED,
+	}
+
 	if raw, err := execRawCmd(socket, `{ "execute": "query-status" }`); err == nil {
 		var result struct {
 			ID     string `json:"id"`
@@ -95,14 +114,17 @@ func getQemuStatus(socket string) (string, error) {
 		dec := json.NewDecoder(bytes.NewReader(raw))
 		dec.DisallowUnknownFields()
 		err = dec.Decode(&result)
+		var matched bool
+		var state types.SwState
 		if err != nil {
 			err = fmt.Errorf("%v; (JSON received: '%s')", err, raw)
-		} else if result.Return.Status == "" {
-			err = fmt.Errorf("'status' is empty; (JSON received: '%s')", raw)
+		} else if state, matched = qmpStatusMap[result.Return.Status]; !matched {
+			err = fmt.Errorf("unknown QMP status '%s' for QMP socket '%s'; (JSON response: '%s')",
+				result.Return.Status, socket, raw)
 		}
-		return result.Return.Status, err
+		return state, err
 	} else {
-		return "", err
+		return types.UNKNOWN, err
 	}
 }
 

--- a/pkg/pillar/hypervisor/qmp.go
+++ b/pkg/pillar/hypervisor/qmp.go
@@ -83,6 +83,20 @@ func QmpExecDeviceAdd(socket, id string, busnum, devnum uint16) error {
 	return err
 }
 
+// There is errors.Join(), but stupid Yetus has old golang
+// and complains with "Join not declared by package errors".
+// Use our own.
+func joinErrors(err1, err2 error) error {
+	if err1 == nil {
+		return err2
+	}
+	if err2 == nil {
+		return err1
+	}
+
+	return fmt.Errorf("%v; %v", err1, err2)
+}
+
 func getQemuStatus(socket string) (types.SwState, error) {
 	// lets parse the status according to
 	// https://github.com/qemu/qemu/blob/master/qapi/run-state.json#L8
@@ -102,7 +116,21 @@ func getQemuStatus(socket string) (types.SwState, error) {
 		"preconfig":      types.PAUSED,
 	}
 
-	if raw, err := execRawCmd(socket, `{ "execute": "query-status" }`); err == nil {
+	// We do several retries, because correct QEMU status is very crucial to EVE
+	// and if for some reason (https://github.com/digitalocean/go-qemu/pull/210)
+	// the status is unexpected, EVE stops QEMU and game over.
+	var errs error
+	state := types.UNKNOWN
+	for attempt := 1; attempt <= 3; attempt++ {
+		raw, err := execRawCmd(socket, `{ "execute": "query-status" }`)
+		if err != nil {
+			err = fmt.Errorf("[attempt %d] qmp status failed for QMP socket '%s': err: '%v'; (JSON response: '%s')",
+				attempt, socket, err, raw)
+			errs = joinErrors(errs, err)
+			time.Sleep(time.Second)
+			continue
+		}
+
 		var result struct {
 			ID     string `json:"id"`
 			Return struct {
@@ -114,18 +142,33 @@ func getQemuStatus(socket string) (types.SwState, error) {
 		dec := json.NewDecoder(bytes.NewReader(raw))
 		dec.DisallowUnknownFields()
 		err = dec.Decode(&result)
-		var matched bool
-		var state types.SwState
 		if err != nil {
-			err = fmt.Errorf("%v; (JSON received: '%s')", err, raw)
-		} else if state, matched = qmpStatusMap[result.Return.Status]; !matched {
-			err = fmt.Errorf("unknown QMP status '%s' for QMP socket '%s'; (JSON response: '%s')",
-				result.Return.Status, socket, raw)
+			err = fmt.Errorf("[attempt %d] failed to parse QMP status response for QMP socket '%s': err: '%v'; (JSON response: '%s')",
+				attempt, socket, err, raw)
+			errs = joinErrors(errs, err)
+			time.Sleep(time.Second)
+			continue
 		}
-		return state, err
-	} else {
-		return types.UNKNOWN, err
+		var matched bool
+		if state, matched = qmpStatusMap[result.Return.Status]; !matched {
+			err = fmt.Errorf("[attempt %d] unknown QMP status '%s' for QMP socket '%s'; (JSON response: '%s')",
+				attempt, result.Return.Status, socket, raw)
+			errs = joinErrors(errs, err)
+			time.Sleep(time.Second)
+			continue
+		}
+
+		if errs != nil {
+			logrus.Errorf("getQemuStatus: %d retrieving status attempts failed '%v', but eventually '%s' status was retrieved, so return SUCCESS and continue",
+				attempt, errs, result.Return.Status)
+			errs = nil
+		}
+
+		// Success
+		break
 	}
+
+	return state, errs
 }
 
 func qmpEventHandler(listenerSocket, executorSocket string) {


### PR DESCRIPTION
This PR does a few things:
* Parses status in the `getQemuStatus()` call and returns a proper error if can't be parsed
* Retries retrieve of QEMU status several times unless success
* Adds explicit logging for all failures

The 'query-status' QMP request is a special one: if status can't be parsed - QEMU is stopped by EVE ('quit' is sent over QMP).
    
There are many customer complains on sudden QEMU stops with only a few lines in the log, e.g.:
    
      "domain c54579e8-f67e-43fa-ae44-8e03584606c2.1.2 reported to be in unexpected state "
      "one of the c54579e8-f67e-43fa-ae44-8e03584606c2 tasks has crashed (domain c54579e8-f67e-43fa-ae44-8e03584606c2.1.2 reported to be in unexpected state )"
      "qmpEventHandler: Received event: SHUTDOWN event details: map[guest:false reason:host-qmp-quit]. Calling quit on socket: /run/hypervisor/kvm/c54579e8-f67e-43fa-ae44-8e03584606c2.1.2/qmp"
    
Which indicates that `getQemuStatus()` routine returns a "" (empty) string.
(according to the code the actual returned state is printed: "domain %s reported to be in unexpected state %s", domainName, res)
    
The `getQemuStatus()` can return a "" (empty string) and no error only in one case: when received JSON does not match the expected structure.
    
This commit disallows unknown JSON fields, so that a returned string should match exactly the structure.
    
This does not fix the error or sudden stop, but rather makes an error explicit, so instead of:
    
       "domain c54579e8-f67e-43fa-ae44-8e03584606c2.1.2 reported to be in unexpected state "
    
 the following error may appear:
    
      "couldn't retrieve status for domain c54579e8-f67e-43fa-ae44-8e03584606c2.1.2: json: unknown field "error"; (the bytes received: '{"error": {"class": "CommandNotFound", "desc": "Expecting capabilities negotiation with 'qmp_capabilities'"}}')"
    
which explicitly indicates the expecting capabilities negotiations. (the error is made up and does not reflect the real problem!)
    
Again. This does not fix a problem, rather exposes it with a clear error message, so QEMU will be stopped by the domainmgr, but I hope clear error help to fix a real problem.

CC: @OhmSpectator 