### PR TITLE
Removal of '@' from usernames in pull request reviewer script

### DIFF
--- a/.github/workflows/request_codeowners_review.yml
+++ b/.github/workflows/request_codeowners_review.yml
@@ -52,7 +52,9 @@ jobs:
           done
           # Remove duplicates and format for JSON
           reviewers=$(echo "$reviewers" | xargs -n1 | sort -u | xargs)
-          IFS=' ' read -ra reviewers_array <<< "$reviewers"
+          # Remove @ from reviewers (it stays in the beginning of the username)
+          reviewers_cleaned=${reviewers//@/}
+          IFS=' ' read -ra reviewers_array <<< "$reviewers_cleaned"
           json_array=$(printf ',\"%s\"' "${reviewers_array[@]}")
           json_array="[${json_array:1}]" # Remove the leading comma
           echo "JSON array: $json_array"


### PR DESCRIPTION
I have removed it by mistake in this commit: [138720f067a29ce9527003c8f1f57978eafd1e4f](https://github.com/lf-edge/eve/commit/3f7b663580ac057ae99672363eecb4d169d7d7c6)