### PR TITLE
github/workflows :  fail test_suite_pr if PR images are not pushed yet 

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -22,7 +22,48 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check_pr_publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install curl and jq
+        run: sudo apt-get update && sudo apt-get install -y curl jq
+
+      - name: Check PR images are published on Docker Hub
+        run: |
+          DOCKER_HUB_PATH="evebuild/danger"
+          # currently we only test amd64 (kvms and xen) with Eden
+          IMAGE_AMD64_XEN="pr${{ github.event.pull_request.number }}-xen"
+          IMAGE_AMD64_KVM="pr${{ github.event.pull_request.number }}-kvm"
+
+          amd64_xen_res=$(curl -s "https://hub.docker.com/v2/repositories/${DOCKER_HUB_PATH}/tags/${IMAGE_AMD64_XEN}")
+          amd64_kvm_res=$(curl -s "https://hub.docker.com/v2/repositories/${DOCKER_HUB_PATH}/tags/${IMAGE_AMD64_KVM}")
+          if [[ "$(echo "$amd64_xen_res" | jq -r '.name')" == "${IMAGE_AMD64_XEN}" && "$(echo "$amd64_kvm_res" | jq -r '.name')" == "${IMAGE_AMD64_KVM}" ]]; then
+              echo "Docker image ${DOCKER_HUB_PATH}:${IMAGE_AMD64_XEN} and ${DOCKER_HUB_PATH}:${IMAGE_AMD64_KVM} are available on Docker Hub."
+              exit 0
+          else
+              echo "Docker image ${DOCKER_HUB_PATH}:${IMAGE_AMD64_XEN} and ${DOCKER_HUB_PATH}:${IMAGE_AMD64_KVM} are not available on Docker Hub."
+              exit 1
+          fi
+
+  report_pr_publish:
+    runs-on: ubuntu-latest
+    needs: check_pr_publish
+    if: failure()
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '⚠️ Docker image is not available on Docker Hub to run Eden PR tests. Please wait for the image to be built and published.'
+            })
+
   test_suite_pr:
+    needs: check_pr_publish
     if: github.event.review.state == 'approved'
     uses: lf-edge/eden/.github/workflows/test.yml@0.9.2
     with:


### PR DESCRIPTION
While investigating the problem with #3557, it appears that Eden requires the "Publish PR build" step (danger.yml) to complete before it can fetch the PR image for testing. However, "Publish PR build" depends on "PR build" (build.yml).

Sometimes, GitHub runners get stuck during certain builds (arm64, I'm looking at you) and we might trigger the Eden run by approving the PR before "PR build" is finished, and subsequently, "Publish PR build" is completed. This can result in Eden failing to pull the PR image because it hasn't been pushed yet.

I'm not a github expert so this will be a bit of trial and error, help is greatly welcomed. 