### PR TITLE
In Pillar, add new Makefile targets for Docker dev builds and shell access.

### DIFF
--- a/pkg/pillar/Makefile
+++ b/pkg/pillar/Makefile
@@ -76,6 +76,12 @@ build-docker-$(APPS): $(DISTDIR)
 build-docker:
 	docker build $(DOCKER_ARGS) -t $(DOCKER_TAG) .
 
+build-docker-dev:
+	docker build $(DOCKER_ARGS) -t $(DOCKER_TAG) . --target build
+
+enter-docker-dev: build-docker-dev
+	docker run -it --rm --entrypoint /bin/sh $(DOCKER_TAG)
+
 build-docker-git:
 	git archive HEAD | docker build $(DOCKER_ARGS) -t $(DOCKER_TAG) -
 


### PR DESCRIPTION
The Makefile has been updated to include two new targets: `build-docker-dev` and `enter-docker-dev`. These targets are designed to facilitate the evaluation of the codebase's state during the build process.

The `build-docker-dev` target constructs a Docker image up to the 'build' stage, enabling developers to assess the intermediate state of the code, particularly useful when applying patches that might only be present in temporary containers and are difficult to inspect otherwise.

Following the build, the `enter-docker-dev` target allows for immediate shell access within this intermediate Docker container, streamlining the process for developers to interact with the code and build environment directly.