### PR TITLE
Not having IP address with DhcpTypeNone is expected

### DIFF
--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -377,6 +377,15 @@ func VerifyAllIntf(ctx *ZedCloudContext, url string, requiredSuccessCount uint,
 			verifyRV.RemoteTempFailure = true
 		}
 		if err != nil {
+			var noAddrErr *types.IPAddrNotAvailError
+			if errors.As(err, &noAddrErr) {
+				// Interface link exists and is UP but does not have any IP address assigned.
+				// This is expected with app-shared interface and DhcpTypeNone.
+				if !portStatus.IsMgmt && portStatus.Dhcp == types.DhcpTypeNone {
+					verifyRV.IntfStatusMap.RecordSuccess(intf)
+					continue
+				}
+			}
 			log.Errorf("Zedcloud un-reachable via interface %s: %s",
 				intf, err)
 			if sendErr, ok := err.(*SendError); ok && len(sendErr.Attempts) > 0 {


### PR DESCRIPTION
EVE reports `IPAddrNotAvailError` even for app-shared ports with `DhcpTypeNone` (aka DHCP-passthrough). But with such config it is actually expected that there is no IP address assigned and error should not be reported for the port.