### PR TITLE
Add support for NVIDIA Jetson Xavier NX developer kit variant

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -296,7 +296,8 @@ function set_arm64_baremetal {
    # Lenovo ThinkEdge SE70 (Jetson Xavier NX platform)
    if [ "$smb_product" = "ThinkEdge SE70 (NVIDIA Jetson Xavier NX)" ]; then
       set_to_existing_file devicetree /boot/dtb/nvidia/tegra194-p3668-0001-p3509-0000-lenovo-se70.dtb
-      set_global dom0_console "console=tty0 earlycon=tty0 fbcon=map:0 eve_nuke_disks=mmcblk0 eve_install_disk=nvme0n1"
+      set_global dom0_console "console=tty0 earlycon=tty0"
+      set_global dom0_platform_tweaks "fbcon=map:0 eve_nuke_disks=mmcblk0 eve_install_disk=nvme0n1"
    fi
 }
 

--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -287,11 +287,18 @@ function set_arm64_baremetal {
          set_global dom0_console "console=tty0 console=hvc0 console=ttymxc2,115200 earlycon=ec_imx6q,0x30880000,115200"
       fi
    fi
-   # Nvidia's Jetson Xavier NX
+   # Nvidia's Jetson Xavier NX developer kit (variant identified by the Asset-Tag)
    smbios -t 1 -s 5 --set smb_product
    if [ "$smb_product" = "NVIDIA Jetson Xavier NX Developer Kit" ]; then
-      set_to_existing_file devicetree /boot/dtb/nvidia/tegra194-p3668-0000-p3509-0000.dtb
-      set_global dom0_console "console=tty0 console=ttyTCU0 earlycon=ttyTCU0,115200 fbcon=map:0"
+      set_global dom0_platform_tweaks "fbcon=map:0 eve_install_disk=nvme0n1"
+      smbios -t 3 -s 8 --set asset_tag
+      if regexp -- "699-.?3668-0001-.*" "$asset_tag"; then
+          set_to_existing_file devicetree /boot/dtb/nvidia/tegra194-p3668-0001-p3509-0000.dtb
+          set_global dom0_console "console=tty0 earlycon=tty0"
+      else
+          set_to_existing_file devicetree /boot/dtb/nvidia/tegra194-p3668-0000-p3509-0000.dtb
+          set_global dom0_console "console=ttyTCU0,115200 console=tty0 earlycon=ttyTCU0,115200"
+      fi
    fi
    # Lenovo ThinkEdge SE70 (Jetson Xavier NX platform)
    if [ "$smb_product" = "ThinkEdge SE70 (NVIDIA Jetson Xavier NX)" ]; then


### PR DESCRIPTION
 There is a version of the NVIDIA's Jetson Xavier NX developer kit that is
commercialized with a production module, which has eMMC, NVMe and doesn't
have SD Card slot. This commit adds the capability to detect those modules
(by reading the Asset-Tag from SMBIOS tables) and load the correct
parameters for boot (device tree, console, etc). The parameters for the
standard developer kit (with modules for development) are not affected, so
EVE should be able to boot on both variants without problems.
    
The Asset-Tag format was taken from the EEPROM layout description:
https://docs.nvidia.com/jetson/archives/r34.1/DeveloperGuide/text/HR/JetsonEepromLayout.html

This PR also provides a small cleanup in the options for the Lenovo SE70, from the same platform.
