### PR TITLE
nim: Exclude CAN and WiFi interfaces from last resort list

### DIFF
--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -1057,6 +1057,7 @@ func (n *nim) includeLastResortPort(ifAttrs netmonitor.IfAttrs) bool {
 	exclude := strings.HasPrefix(ifName, "vif") ||
 		strings.HasPrefix(ifName, "nbu") ||
 		strings.HasPrefix(ifName, "nbo") ||
+		strings.HasPrefix(ifName, "wlan") ||
 		strings.HasPrefix(ifName, "keth")
 	if exclude {
 		return false

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -1067,14 +1067,18 @@ func (n *nim) includeLastResortPort(ifAttrs netmonitor.IfAttrs) bool {
 	if ifAttrs.IsLoopback || !ifAttrs.WithBroadcast || ifAttrs.Enslaved {
 		return false
 	}
-	if ifAttrs.IfType == "device" {
+
+	switch ifAttrs.IfType {
+	case "device":
 		return true
-	}
-	if ifAttrs.IfType == "bridge" {
+	case "bridge":
 		// Was this originally an ethernet interface turned into a bridge?
 		_, exists, _ := n.networkMonitor.GetInterfaceIndex("k" + ifName)
 		return exists
+	case "can", "vcan":
+		return false
 	}
+
 	return false
 }
 


### PR DESCRIPTION
This commit excludes from the last resort list the CAN interfaces (which are non TCP/IP) and WiFi interfaces since no WiFi Network configuration is provided, so any attempt of connection through these interfaces will always fail.