### PR TITLE
Merge  kernel and zfs SBOM with eve SBOM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -664,7 +664,11 @@ $(SBOM): $(ROOTFS_TAR) | $(INSTALLER)
 	# this all can go away, and we can read the rootfs.tar
 	# see https://github.com/anchore/syft/issues/1400
 	tar xf $< -C $(TMP_ROOTDIR) --exclude "dev/*"
-	# kernel-sbom.spdx.json is now generated in eve-kernel repo and extracted from kernel docker image into rootfs by linuxkit
+	# kernel-*.spdx.json are now generated in eve-kernel repo and are stored in docker  image.
+	# Manually extract them to unpacked rootfs.
+	# Later linuxkit will get a support for SBOM in OCI metadata and this step as well as manual run of
+	# syft will be deprecated
+	docker export $(shell docker create $(KERNEL_TAG) create) | tar xv -C $(TMP_ROOTDIR) --wildcards --no-anchored '*.spdx.json'
 	docker run -v $(TMP_ROOTDIR):/rootdir:ro -v $(CURDIR)/.syft.yaml:/syft.yaml:ro $(SYFT_IMAGE) -c /syft.yaml --base-path /rootdir /rootdir > $@
 	rm -rf $(TMP_ROOTDIR)
 	$(QUIET): $@: Succeeded


### PR DESCRIPTION
This is a workaround for Linuxkit limitation. Currently Linuxkit ignores *.spdx.json files in kernel container so kernel SBOM is not a part of final SBOM.

In the near future SBOM for any container will be a part of image metadata and manual steps to run syft won't be required

A snippet from the final sbom.json

```
 6650    name: eve-kernel,                                                                                                                                                           
 6651    SPDXID: SPDXRef-Package-UnknownPackage-eve-kernel-fe8b907371f0efd0,                                                                                                         
 6652    versionInfo: d2da815271a22a8e34c8473898f12ad194b55620,                                                                                                                      
 6653    downloadLocation: NOASSERTION,                                                                                                                                              
 6654    filesAnalyzed: false,                                                                                                                                                       
 6655    sourceInfo: acquired package info from SBOM: /kernel-sbom-gh.spdx.json,                                                                                                     
 6656    licenseConcluded: GPL-2.0-or-later,                                                                                                                                         
 6657    licenseDeclared: LicenseRef-UNKNOWN-AND-GPL-2.0-or-later-AND-GPL-2.0,                                                                                                       
 6658    copyrightText: NOASSERTION,                                                                                                                                                 
 6659    externalRefs: [                                                                                                                                                             
 6660     {                                                                                                                                                                          
 6661     ┆referenceCategory: SECURITY,                                                                                                                                              
 6662     ┆referenceType: cpe23Type,                                                                                                                                                 
 6663     ┆referenceLocator: cpe:2.3:a:eve-kernel:eve-kernel:d2da815271a22a8e34c8473898f12ad194b55620:*:*:*:*:*:*:*                                                                  
 6664     },                                                                                                                                                                         
 6665     {                                                                                                                                                                          
 6666     ┆referenceCategory: SECURITY,                                                                                                                                              
 6667     ┆referenceType: cpe23Type,                                                                                                                                                 
 6668     ┆referenceLocator: cpe:2.3:a:eve-kernel:eve_kernel:d2da815271a22a8e34c8473898f12ad194b55620:*:*:*:*:*:*:*                                                                  
 6669     },                                                                                                                                                                         
 6670     {                                                                                                                                                                          
 6671     ┆referenceCategory: SECURITY,                                                                                                                                              
 6672     ┆referenceType: cpe23Type,                                                                                                                                                 
 6673     ┆referenceLocator: cpe:2.3:a:eve_kernel:eve-kernel:d2da815271a22a8e34c8473898f12ad194b55620:*:*:*:*:*:*:*
 ```