### PR TITLE
usbmanager: fix nil dereference

### DIFF
--- a/pkg/pillar/cmd/usbmanager/usbcontroller.go
+++ b/pkg/pillar/cmd/usbmanager/usbcontroller.go
@@ -236,7 +236,8 @@ func ioBundle2PassthroughRule(adapter types.IoBundle) passthroughRule {
 		}
 		busnum, err := strconv.ParseUint(usbParts[0], 10, 16)
 		if err != nil {
-			panic(err)
+			log.Warnf("usbaddr busnum (%s) not parseable", usbParts[0])
+			return nil
 		}
 		portnum := usbParts[1]
 		ud := usbdevice{

--- a/pkg/pillar/cmd/usbmanager/usbcontroller.go
+++ b/pkg/pillar/cmd/usbmanager/usbcontroller.go
@@ -126,6 +126,9 @@ func (uc *usbmanagerController) addVirtualmachine(vm virtualmachine) {
 		}
 
 		pr := ioBundle2PassthroughRule(*ioBundle)
+		if pr == nil {
+			continue
+		}
 		pr.setVirtualMachine(&vm)
 
 		uc.ruleEngine.addRule(pr)
@@ -159,6 +162,9 @@ func (uc *usbmanagerController) removeVirtualmachine(vm virtualmachine) {
 		}
 
 		pr := ioBundle2PassthroughRule(*ioBundle)
+		if pr == nil {
+			continue
+		}
 		uc.ruleEngine.delRule(pr)
 	}
 
@@ -172,6 +178,9 @@ func (uc *usbmanagerController) removeIOBundle(ioBundle types.IoBundle) {
 	uc.usbpassthroughs.delIoBundle(&ioBundle)
 
 	pr := ioBundle2PassthroughRule(ioBundle)
+	if pr == nil {
+		return
+	}
 	vm := uc.usbpassthroughs.vmsByIoBundlePhyLabel[ioBundle.Phylabel]
 	pr.setVirtualMachine(vm)
 
@@ -197,7 +206,6 @@ func (uc *usbmanagerController) addIOBundle(ioBundle types.IoBundle) {
 
 	pr := ioBundle2PassthroughRule(ioBundle)
 	if pr == nil {
-		log.Tracef("unusable iobundle %s: %s/%s\n", ioBundle.Phylabel, ioBundle.UsbAddr, ioBundle.PciLong)
 		return
 	}
 	vm := uc.usbpassthroughs.vmsByIoBundlePhyLabel[ioBundle.Phylabel]
@@ -249,6 +257,7 @@ func ioBundle2PassthroughRule(adapter types.IoBundle) passthroughRule {
 
 		pr = &usb
 	} else {
+		log.Tracef("cannot create rule out of adapter %+v\n", adapter)
 		pr = nil
 	}
 

--- a/pkg/pillar/cmd/usbmanager/usbcontroller_test.go
+++ b/pkg/pillar/cmd/usbmanager/usbcontroller_test.go
@@ -71,6 +71,27 @@ func testEventTable() [][]testingEvent {
 	return tetg.testEventTable
 }
 
+func TestAddNonRuleIOBundle(t *testing.T) {
+	uc := newTestUsbmanagerController()
+	ioBundle := types.IoBundle{
+		Type:         0,
+		Phylabel:     "Test",
+		Logicallabel: "Test",
+	}
+	uc.addIOBundle(ioBundle)
+	uc.removeIOBundle(ioBundle)
+
+	uc.usbpassthroughs.ioBundles[ioBundle.Phylabel] = &ioBundle
+
+	vm := virtualmachine{
+		qmpSocketPath: "",
+		adapters:      []string{"Test"},
+	}
+
+	uc.addVirtualmachine(vm)
+	uc.removeVirtualmachine(vm)
+}
+
 func TestRemovingVm(t *testing.T) {
 	usbEventBusnum := uint16(1)
 	usbEventDevnum := uint16(2)


### PR DESCRIPTION
in certain cases (neither usb- nor pci-passthrough) no passthrough-rule gets generated and ioBundl2PassthroughRule returns nil which then addRule tries to dereference and crashes.

fixes #3580