### PR TITLE
apparmor: add apparmor profile for guacd

### DIFF
--- a/pkg/apparmor/profiles/usr.sbin.guacd
+++ b/pkg/apparmor/profiles/usr.sbin.guacd
@@ -1,0 +1,12 @@
+# Copyright (c) 2023 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+#include <tunables/global>
+
+@{exec_path} = /usr/sbin/guacd
+profile guacd @{exec_path} {
+    #include <abstractions/base>
+
+    # allow network access
+    network inet stream,
+}


### PR DESCRIPTION
Guacd is running on EVE as proxy to provide VDI services to VMs and containers. This PR adds a apparmor profile for guacd, restricting its access to the almost everything in EVE except creating TCP connections.

The restricted profile allowed the guacd to remain functional, testing VNC connection, here is the guacd log: 
```
guacd[1540]: INFO:	Guacamole proxy daemon (guacd) version 1.0.0 started
guacd[1540]: INFO:	Listening on host 0.0.0.0, port 4822
guacd[1540]: INFO:	Creating new client for protocol "vnc"
guacd[1540]: INFO:	Connection ID is "$490dea4e-85c6-47ee-b67c-7cfebfbe3a67"
guacd[1542]: INFO:	Cursor rendering: local
guacd[1542]: INFO:	User "@cef173fa-b702-4ce1-a9d8-5c466a0b286d" joined connection "$490dea4e-85c6-47ee-b67c-7cfebfbe3a67" (1 users now present)
guacd[1542]: INFO:	User "@cef173fa-b702-4ce1-a9d8-5c466a0b286d" disconnected (0 users remain)
guacd[1542]: INFO:	Last user of connection "$490dea4e-85c6-47ee-b67c-7cfebfbe3a67" disconnected
guacd[1542]: INFO:	Internal VNC client disconnected
guacd[1540]: INFO:	Connection "$490dea4e-85c6-47ee-b67c-7cfebfbe3a67" removed.
```

and apparmor logs shows no `DENIED` : 
```
sudo cat  /dev/kmsg | grep apparmor
6,349,1026858,-;evm: security.apparmor
5,562,3395778,-;audit: type=1400 audit(1700053671.672:2): apparmor="STATUS" operation="profile_load" profile="unconfined" name="lsb_release" pid=589 comm="apparmor_parser"
5,563,3395867,-;audit: type=1400 audit(1700053671.672:3): apparmor="STATUS" operation="profile_load" profile="unconfined" name="/home/shah/eve/pkg/vtpm/vtpm_server" pid=588 comm="apparmor_parser"
5,564,3405190,-;audit: type=1400 audit(1700053671.680:4): apparmor="STATUS" operation="profile_load" profile="unconfined" name="/usr/bin/man" pid=595 comm="apparmor_parser"
5,565,3405194,-;audit: type=1400 audit(1700053671.680:5): apparmor="STATUS" operation="profile_load" profile="unconfined" name="man_filter" pid=595 comm="apparmor_parser"
5,566,3405195,-;audit: type=1400 audit(1700053671.680:6): apparmor="STATUS" operation="profile_load" profile="unconfined" name="man_groff" pid=595 comm="apparmor_parser"
5,567,3407374,-;audit: type=1400 audit(1700053671.684:7): apparmor="STATUS" operation="profile_load" profile="unconfined" name="nvidia_modprobe" pid=590 comm="apparmor_parser"
5,568,3407376,-;audit: type=1400 audit(1700053671.684:8): apparmor="STATUS" operation="profile_load" profile="unconfined" name="nvidia_modprobe//kmod" pid=590 comm="apparmor_parser"
5,569,3408293,-;audit: type=1400 audit(1700053671.688:9): apparmor="STATUS" operation="profile_load" profile="unconfined" name="/usr/lib/NetworkManager/nm-dhcp-client.action" pid=591 comm="apparmor_parser"
5,570,3408297,-;audit: type=1400 audit(1700053671.688:10): apparmor="STATUS" operation="profile_load" profile="unconfined" name="/usr/lib/NetworkManager/nm-dhcp-helper" pid=591 comm="apparmor_parser"
5,577,5239291,-;audit: type=1400 audit(1700053673.516:22): apparmor="STATUS" operation="profile_load" profile="unconfined" name="docker-default" pid=783 comm="apparmor_parser"
5,584,175404468,-;audit: type=1400 audit(1700053842.607:23): apparmor="STATUS" operation="profile_load" profile="unconfined" name="guacd" pid=1294 comm="apparmor_parser"
```

and VNC works : 
<img width="1713" alt="image" src="https://github.com/lf-edge/eve/assets/121871672/684226df-5561-48a7-a001-cde360aa17c6">

---
Notes: 
- SSL/TLS support is not supported (not [passing](https://github.com/lf-edge/eve/blob/bcce66b18f806bf72ba91f9cd6b384af36b27478/pkg/guacd/Dockerfile#L30) `-c/-k` for cert/key file), so we don't have to give read access to those files in aa profile.
- guacd is not creating any pid file (no `-p`), so we don't have to give write access for pid file path in aa profile.
- EVE is not [compiling](https://github.com/lf-edge/eve/blob/master/pkg/guacd/Dockerfile) `guacd` with RDP support (`--with-rdp` is not passed, and freerdp is not installed).


