### PR TITLE
Patchenvelopes test fix race

### DIFF
--- a/pkg/pillar/cmd/zedrouter/patchenvelopes_test.go
+++ b/pkg/pillar/cmd/zedrouter/patchenvelopes_test.go
@@ -4,6 +4,7 @@
 package zedrouter_test
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -72,10 +73,13 @@ func TestPatchEnvelopes(t *testing.T) {
 		},
 	}
 
+	peStoreMutex := sync.Mutex{}
 	go func() {
 		for _, vs := range volumeStatuses {
+			peStoreMutex.Lock()
 			peStore.UpdateVolumeStatus(vs, false)
 			peStore.UpdateStateNotificationCh() <- struct{}{}
+			peStoreMutex.Unlock()
 		}
 	}()
 
@@ -88,9 +92,11 @@ func TestPatchEnvelopes(t *testing.T) {
 	}()
 
 	go func() {
+		peStoreMutex.Lock()
 		peStore.UpdateEnvelopes(peInfo)
 
 		peStore.UpdateStateNotificationCh() <- struct{}{}
+		peStoreMutex.Unlock()
 
 	}()
 


### PR DESCRIPTION
hard parts have already been done in https://github.com/lf-edge/eve/pull/3584/

Now fix the simple race condition with a mutex.

Test with: 
`go test -v -run=TestPatchEnvelopes -race .`