### PR TITLE
Estimating Memory Overhead Before Domain Creation

### DIFF
--- a/pkg/pillar/cmd/zedmanager/memorysizemgmt.go
+++ b/pkg/pillar/cmd/zedmanager/memorysizemgmt.go
@@ -29,6 +29,7 @@ func getRemainingMemory(ctxPtr *zedmanagerContext) (uint64, uint64, uint64, erro
 	for _, st := range itemsAppInstanceStatus {
 		status := st.(types.AppInstanceStatus)
 		mem := uint64(status.FixedResources.Memory) << 10
+		mem += status.MemOverhead
 		if status.Activated || status.ActivateInprogress {
 			usedMemorySize += mem
 			accountedApps = append(accountedApps, status.Key())

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -586,18 +586,10 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 				log.Fatalf("Cannot get hypervisor: %s", err)
 			}
 
-			// Create a mock domain config to calculate memory overhead
-			mockDomainConfig := types.DomainConfig{
-				VmConfig: types.VmConfig{
-					Memory:  config.FixedResources.Memory,
-					MaxCpus: config.FixedResources.MaxCpus,
-					VCpus:   config.FixedResources.VCpus,
-				},
-				IoAdapterList:  config.IoAdapterList,
-				UUIDandVersion: config.UUIDandVersion,
-			}
-
-			status.MemOverhead, err = hyp.CountMemOverhead(status.DomainName, &mockDomainConfig, ctx.globalConfig, ctx.assignableAdapters)
+			status.MemOverhead, err = hyp.CountMemOverhead(status.DomainName, config.UUIDandVersion.UUID,
+				int64(config.FixedResources.Memory), int64(config.FixedResources.VMMMaxMem),
+				int64(config.FixedResources.MaxCpus), int64(config.FixedResources.VCpus), config.IoAdapterList,
+				ctx.assignableAdapters, ctx.globalConfig)
 			// We have to publish the status here, because we need to save the memory overhead value, it's used in getRemainingMemory
 			publishAppInstanceStatus(ctx, status)
 		}

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -5,6 +5,7 @@ package zedmanager
 
 import (
 	"fmt"
+	"github.com/lf-edge/eve/pkg/pillar/hypervisor"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -577,6 +578,30 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 	if !status.ActivateInprogress && !status.Activated &&
 		!ctx.globalConfig.GlobalValueBool(types.IgnoreMemoryCheckForApps) {
 
+		// If we have not yet calculated memory overhead - do it now
+		if status.MemOverhead == 0 {
+			// Get hypervisor
+			hyp, err := hypervisor.GetHypervisor(*ctx.hypervisorPtr)
+			if err != nil {
+				log.Fatalf("Cannot get hypervisor: %s", err)
+			}
+
+			// Create a mock domain config to calculate memory overhead
+			mockDomainConfig := types.DomainConfig{
+				VmConfig: types.VmConfig{
+					Memory:  config.FixedResources.Memory,
+					MaxCpus: config.FixedResources.MaxCpus,
+					VCpus:   config.FixedResources.VCpus,
+				},
+				IoAdapterList:  config.IoAdapterList,
+				UUIDandVersion: config.UUIDandVersion,
+			}
+
+			status.MemOverhead, err = hyp.CountMemOverhead(status.DomainName, &mockDomainConfig, ctx.globalConfig, ctx.assignableAdapters)
+			// We have to publish the status here, because we need to save the memory overhead value, it's used in getRemainingMemory
+			publishAppInstanceStatus(ctx, status)
+		}
+
 		remaining, latent, halting, err := getRemainingMemory(ctx)
 		if err != nil {
 			errStr := fmt.Sprintf("getRemainingMemory failed: %s\n",
@@ -594,7 +619,7 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 			changed = true
 			return changed
 		}
-		need := uint64(config.FixedResources.Memory) << 10
+		need := uint64(config.FixedResources.Memory)<<10 + status.MemOverhead
 		if remaining < need {
 			var errStr string
 			var entities []*types.ErrorEntity

--- a/pkg/pillar/hypervisor/containerd.go
+++ b/pkg/pillar/hypervisor/containerd.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"time"
 
+	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 )
 
@@ -51,7 +52,9 @@ func newContainerd() Hypervisor {
 
 // CountMemOverhead - returns the memory overhead for a domain.
 // This implementation is used for Xen as well
-func (ctx ctrdContext) CountMemOverhead(domainName string, config *types.DomainConfig, globalConfig *types.ConfigItemValueMap, aa *types.AssignableAdapters) (uint64, error) {
+func (ctx ctrdContext) CountMemOverhead(domainName string, domainUUID uuid.UUID, domainRAMMemory int64, vmmMaxMem int64,
+	domainMaxCpus int64, domainVCpus int64, domainIoAdapterList []types.IoAdapter, aa *types.AssignableAdapters,
+	globalConfig *types.ConfigItemValueMap) (uint64, error) {
 	// Does containerd have any overhead?
 	return 0, nil
 }

--- a/pkg/pillar/hypervisor/containerd.go
+++ b/pkg/pillar/hypervisor/containerd.go
@@ -49,6 +49,13 @@ func newContainerd() Hypervisor {
 	}
 }
 
+// CountMemOverhead - returns the memory overhead for a domain.
+// This implementation is used for Xen as well
+func (ctx ctrdContext) CountMemOverhead(domainName string, config *types.DomainConfig, globalConfig *types.ConfigItemValueMap, aa *types.AssignableAdapters) (uint64, error) {
+	// Does containerd have any overhead?
+	return 0, nil
+}
+
 func (ctx ctrdContext) GetCapabilities() (*types.Capabilities, error) {
 	//we are here because of no /dev/xen or /dev/kvm exists
 	return &types.Capabilities{

--- a/pkg/pillar/hypervisor/hypervisor.go
+++ b/pkg/pillar/hypervisor/hypervisor.go
@@ -27,6 +27,8 @@ type Hypervisor interface {
 	GetDomsCPUMem() (map[string]types.DomainMetric, error)
 
 	GetCapabilities() (*types.Capabilities, error)
+
+	CountMemOverhead(domainName string, config *types.DomainConfig, globalConfig *types.ConfigItemValueMap, aa *types.AssignableAdapters) (uint64, error)
 }
 
 type hypervisorDesc struct {

--- a/pkg/pillar/hypervisor/hypervisor.go
+++ b/pkg/pillar/hypervisor/hypervisor.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	uuid "github.com/satori/go.uuid"
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/mem"
 	"github.com/sirupsen/logrus"
@@ -28,7 +29,9 @@ type Hypervisor interface {
 
 	GetCapabilities() (*types.Capabilities, error)
 
-	CountMemOverhead(domainName string, config *types.DomainConfig, globalConfig *types.ConfigItemValueMap, aa *types.AssignableAdapters) (uint64, error)
+	CountMemOverhead(domainName string, domainUUID uuid.UUID, domainRAMSize int64, vmmMaxMem int64,
+		domainMaxCpus int64, domainVCpus int64, domainIoAdapterList []types.IoAdapter, aa *types.AssignableAdapters,
+		globalConfig *types.ConfigItemValueMap) (uint64, error)
 }
 
 type hypervisorDesc struct {

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -446,6 +446,11 @@ func (ctx KvmContext) GetCapabilities() (*types.Capabilities, error) {
 	return ctx.capabilities, nil
 }
 
+func (ctx KvmContext) CountMemOverhead(domainName string, config *types.DomainConfig, globalConfig *types.ConfigItemValueMap, aa *types.AssignableAdapters) (uint64, error) {
+	result, err := vmmOverhead(domainName, *config, globalConfig, aa)
+	return uint64(result), err
+}
+
 func (ctx KvmContext) checkIOVirtualisation() (bool, error) {
 	f, err := os.Open("/sys/kernel/iommu_groups")
 	if err == nil {

--- a/pkg/pillar/hypervisor/null.go
+++ b/pkg/pillar/hypervisor/null.go
@@ -37,6 +37,12 @@ func (ctx nullContext) GetCapabilities() (*types.Capabilities, error) {
 	}, nil
 }
 
+// CountMemOverhead - returns the memory overhead for a domain.
+// Null-implementation that returns 0 is used now for Acrn hypervisor
+func (ctx nullContext) CountMemOverhead(domainName string, config *types.DomainConfig, globalConfig *types.ConfigItemValueMap, aa *types.AssignableAdapters) (uint64, error) {
+	return 0, nil
+}
+
 func newNull() Hypervisor {
 	res := nullContext{tempDir: "/tmp",
 		doms:       map[string]*domState{},

--- a/pkg/pillar/hypervisor/null.go
+++ b/pkg/pillar/hypervisor/null.go
@@ -8,6 +8,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"os"
 
+	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 )
 
@@ -39,7 +40,9 @@ func (ctx nullContext) GetCapabilities() (*types.Capabilities, error) {
 
 // CountMemOverhead - returns the memory overhead for a domain.
 // Null-implementation that returns 0 is used now for Acrn hypervisor
-func (ctx nullContext) CountMemOverhead(domainName string, config *types.DomainConfig, globalConfig *types.ConfigItemValueMap, aa *types.AssignableAdapters) (uint64, error) {
+func (ctx nullContext) CountMemOverhead(domainName string, domainUUID uuid.UUID, domainRAMSize int64, vmmMaxMem int64,
+	domainMaxCpus int64, domainVCpus int64, domainIoAdapterList []types.IoAdapter, aa *types.AssignableAdapters,
+	globalConfig *types.ConfigItemValueMap) (uint64, error) {
 	return 0, nil
 }
 

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -264,6 +264,8 @@ type AppInstanceStatus struct {
 	StartTime time.Time
 	// Snapshot related information
 	SnapStatus SnapshottingStatus
+	// Estimated memory overhead for VM, counted in MB
+	MemOverhead uint64
 }
 
 // AppCount is uint8 and it should be sufficient for the number of apps we can support


### PR DESCRIPTION

This PR introduces an advanced approach to memory management during the creation of new domains within the ZedManager component. The primary innovation lies in the pre-estimation of memory overhead required by a new domain, ensuring the device has sufficient memory capacity to support both the domain's requirements and associated overhead.

## Key Changes
- **Memory Overhead Calculation**: Implemented in `updatestatus.go` utilizing the `CountMemOverhead` function from the hypervisor package.
- **Memory Usage Accounting**: Updated `getRemainingMemory` in `memorysizemgmt.go` to include memory overhead in the computation of used memory size.
- **Hypervisor Package Extensions**: Adapted to support memory overhead estimation across different hypervisor types.
- **Assignable Adapters Integration**: Added adapter information to `zedmanagerContext`, including a new subscription within `zedmanager.go`. This integration is critical for precise memory overhead estimations.


## Proposed Steps for Moving Forward
- **Step One**: Maintain the current PR, which incorporates `memOverhead` into the code. This update aims to mitigate the issue of initiating multiple large virtual machines, a challenge we currently face.
- **Step Two**: Backport this enhancement to the LTS branches.
- **Step Three**: Address the more complex issue of latent memory usage in a separate PR. This topic requires further discussion as it presents a nuanced challenge and does not offer an immediate resolution to our existing issues.



