### PR TITLE
GitHub actions: switch to buildjet native arm runners for build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: arm64-dirty
+          - os: buildjet-4vcpu-ubuntu-2204-arm
             arch: arm64
           - os: ubuntu-20.04
             arch: amd64
@@ -42,7 +42,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: ensure zstd for cache  # this should be removed once the arm64 VM includes zstd
-        if: ${{ matrix.os == 'arm64-dirty' || matrix.os == 'arm64-secure' }}
+        if: ${{ matrix.os == 'buildjet-4vcpu-ubuntu-2204-arm' || matrix.os == 'arm64-secure' }}
         run: |
           sudo apt install -y zstd
       - name: ensure packages for cross-arch build


### PR DESCRIPTION
Note still need to confirm that they are available to us 
Edit: we do have them

Switching to arm runners from buildjet actually should lower total buildjet running time 