### PR TITLE
[9.4-stable] Backport timeout improvements

### DIFF
--- a/pkg/pillar/base/execwrapper.go
+++ b/pkg/pillar/base/execwrapper.go
@@ -17,84 +17,57 @@ import (
 )
 
 const (
-	// Will wait for 1000s max for a call instead of waiting forever
-	maxTimeOutLimit = 1000
-	timeOutLimit    = 100
+	/*
+	 * execution timeout is supposed to be less than the watchdog timeout,
+	 * as otherwise the watchdog might fire and reboot the system before
+	 * the timeout fires
+	 * exceptions are when an executable is started from a different goroutine
+	 * source of the error timeout and the watchdog timeout:
+	 * error timeout: $ grep -r errorTime pkg/pillar/cmd/ | grep time
+	 * watchdog timeout: $ grep hv_watchdog_timer pkg/grub/rootfs.cfg
+	 */
+	timeoutLimit   = 3 * time.Minute
+	defaultTimeout = 100 * time.Second
 )
 
 // Command holds the necessary data to execute command
 type Command struct {
-	command   *exec.Cmd
-	log       *LogObject
-	agentName string
-	timeout   time.Duration
-	buffer    *bytes.Buffer
-	ctx       context.Context
+	command    *exec.Cmd
+	log        *LogObject
+	agentName  string
+	timeout    time.Duration
+	buffer     *bytes.Buffer
+	ctx        context.Context
+	errorMonad error
 }
 
 // Output runs the command and returns its standard output.
 // Any returned error will usually be of type *ExitError.
-// Waits for the exec call to finish for `maxTimeOutLimit` after which timeout error is returned
+// Waits for the exec call to finish for `defaultTimeout` after which timeout error is returned
 func (c *Command) Output() ([]byte, error) {
 	var buf bytes.Buffer
 	c.command.Stdout = &buf
 	c.buffer = &buf
-	c.timeout = maxTimeOutLimit
+	c.timeout = defaultTimeout
 	return c.execCommand()
 }
 
 // CombinedOutput runs the command and returns its combined standard output and standard error.
-// Waits for the exec call to finish for `maxTimeOutLimit` after which timeout error is returned
+// Waits for the exec call to finish for `defaultTimeout` after which timeout error is returned
 func (c *Command) CombinedOutput() ([]byte, error) {
 	var buf bytes.Buffer
 	c.command.Stdout = &buf
 	c.command.Stderr = &buf
 	c.buffer = &buf
-	c.timeout = maxTimeOutLimit
-	return c.execCommand()
-}
-
-// OutputWithTimeout waits for the exec call to finish for `timeOutLimit`
-// after which timeout error is returned
-func (c *Command) OutputWithTimeout() ([]byte, error) {
-	var buf bytes.Buffer
-	c.command.Stdout = &buf
-	c.buffer = &buf
-	c.timeout = timeOutLimit
-	return c.execCommand()
-}
-
-// CombinedOutputWithTimeout waits for the exec call to finish for `timeOutLimit`
-// after which timeout error is returned
-func (c *Command) CombinedOutputWithTimeout() ([]byte, error) {
-	var buf bytes.Buffer
-	c.command.Stdout = &buf
-	c.command.Stderr = &buf
-	c.buffer = &buf
-	c.timeout = timeOutLimit
-	return c.execCommand()
-}
-
-// OutputWithCustomTimeout accepts a custom timeout limit to wait for the exec call.
-func (c *Command) OutputWithCustomTimeout(timeout uint) ([]byte, error) {
-	var buf bytes.Buffer
-	c.command.Stdout = &buf
-	c.buffer = &buf
-	c.timeout = time.Duration(timeout)
-	return c.execCommand()
-}
-
-// CombinedOutputWithCustomTimeout accepts a custom timeout limit to wait for the exec call.
-func (c *Command) CombinedOutputWithCustomTimeout(timeout uint) ([]byte, error) {
-	var buf bytes.Buffer
-	c.command.Stdout = &buf
-	c.command.Stderr = &buf
-	c.buffer = &buf
-	c.timeout = time.Duration(timeout)
+	c.timeout = defaultTimeout
 	return c.execCommand()
 }
 
 func (c *Command) execCommand() ([]byte, error) {
+	if c.errorMonad != nil {
+		return nil, c.errorMonad
+	}
+
 	if c.log != nil {
 		c.log.Tracef("execCommand(%v)", c.command.Args)
 	}
@@ -108,7 +81,7 @@ func (c *Command) execCommand() ([]byte, error) {
 	stillRunning := time.NewTicker(25 * time.Second)
 	defer stillRunning.Stop()
 
-	waitTimer := time.NewTimer(c.timeout * time.Second)
+	waitTimer := time.NewTimer(c.timeout)
 	defer waitTimer.Stop()
 
 	if c.ctx == nil {
@@ -132,6 +105,23 @@ func (c *Command) execCommand() ([]byte, error) {
 		}
 		updateAgentTouchFile(c.log, c.agentName)
 	}
+}
+
+// WithLimitedTimeout set custom timeout for command
+func (c *Command) WithLimitedTimeout(timeout time.Duration) *Command {
+	c.timeout = timeout
+	if c.timeout > timeoutLimit {
+		c.errorMonad = fmt.Errorf("custom timeout (%v) is longer than watchdog timeout (%v)", c.timeout, defaultTimeout)
+	}
+
+	return c
+}
+
+// WithUnlimitedTimeout set custom timeout for command not bound to any limits for when run in a separate goroutine
+func (c *Command) WithUnlimitedTimeout(timeout time.Duration) *Command {
+	c.timeout = timeout
+
+	return c
 }
 
 // WithContext set context for command

--- a/pkg/pillar/base/execwrapper.go
+++ b/pkg/pillar/base/execwrapper.go
@@ -48,7 +48,9 @@ func (c *Command) Output() ([]byte, error) {
 	var buf bytes.Buffer
 	c.command.Stdout = &buf
 	c.buffer = &buf
-	c.timeout = defaultTimeout
+	if c.timeout == 0 {
+		c.timeout = defaultTimeout
+	}
 	return c.execCommand()
 }
 
@@ -59,7 +61,9 @@ func (c *Command) CombinedOutput() ([]byte, error) {
 	c.command.Stdout = &buf
 	c.command.Stderr = &buf
 	c.buffer = &buf
-	c.timeout = defaultTimeout
+	if c.timeout == 0 {
+		c.timeout = defaultTimeout
+	}
 	return c.execCommand()
 }
 

--- a/pkg/pillar/base/execwrapper_test.go
+++ b/pkg/pillar/base/execwrapper_test.go
@@ -1,0 +1,18 @@
+package base_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+)
+
+func TestTimeoutLongerThanLimit(t *testing.T) {
+	t.Parallel()
+
+	timeout := 600 * time.Second
+	_, err := base.Exec(nil, "/bin/true").WithLimitedTimeout(timeout).CombinedOutput()
+	if err == nil {
+		t.Fatalf("Execution should fail with timeout too long, but succeeded")
+	}
+}

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -2758,7 +2758,7 @@ func mkisofs(output string, dir string) error {
 		dir,
 	}
 	log.Functionf("Calling command %s %v\n", cmd, args)
-	stdoutStderr, err := base.Exec(log, cmd, args...).CombinedOutput()
+	stdoutStderr, err := base.Exec(log, cmd, args...).WithUnlimitedTimeout(15 * time.Minute).CombinedOutput()
 	if err != nil {
 		errStr := fmt.Sprintf("mkisofs failed: %s",
 			string(stdoutStderr))

--- a/pkg/pillar/diskmetrics/diskmetrics.go
+++ b/pkg/pillar/diskmetrics/diskmetrics.go
@@ -21,6 +21,9 @@ const qemuExecTimeout = 2 * time.Minute
 // qemuExecLongTimeout is a long timeout for command executions in separate worker thread that don't interfere with the watchdog
 const qemuExecLongTimeout = 1000 * time.Second
 
+// qemuExecUltraLongTimeout is a long timeout for command executions in separate worker thread that take especially long
+const qemuExecUltraLongTimeout = 120 * time.Hour
+
 func GetImgInfo(log *base.LogObject, diskfile string) (*types.ImgInfo, error) {
 	var imgInfo types.ImgInfo
 
@@ -98,7 +101,7 @@ func RolloutImgToBlock(ctx context.Context, log *base.LogObject, diskfile, outpu
 	// writeback cache instead of default unsafe, out of order enabled, skip file creation
 	// Timeout 2 hours
 	args := []string{"convert", "--target-is-zero", "-t", "writeback", "-W", "-n", "-O", outputFormat, diskfile, outputFile}
-	output, err := base.Exec(log, "/usr/bin/qemu-img", args...).WithContext(ctx).WithUnlimitedTimeout(qemuExecLongTimeout).CombinedOutput()
+	output, err := base.Exec(log, "/usr/bin/qemu-img", args...).WithContext(ctx).WithUnlimitedTimeout(qemuExecUltraLongTimeout).CombinedOutput()
 	if err != nil {
 		errStr := fmt.Sprintf("qemu-img failed: %s, %s\n",
 			err, output)

--- a/pkg/pillar/diskmetrics/diskmetrics.go
+++ b/pkg/pillar/diskmetrics/diskmetrics.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/types"
@@ -92,7 +93,7 @@ func RolloutImgToBlock(ctx context.Context, log *base.LogObject, diskfile, outpu
 	// writeback cache instead of default unsafe, out of order enabled, skip file creation
 	// Timeout 2 hours
 	args := []string{"convert", "--target-is-zero", "-t", "writeback", "-W", "-n", "-O", outputFormat, diskfile, outputFile}
-	output, err := base.Exec(log, "/usr/bin/qemu-img", args...).WithContext(ctx).CombinedOutputWithCustomTimeout(432000)
+	output, err := base.Exec(log, "/usr/bin/qemu-img", args...).WithContext(ctx).WithUnlimitedTimeout(15 * time.Minute).CombinedOutput()
 	if err != nil {
 		errStr := fmt.Sprintf("qemu-img failed: %s, %s\n",
 			err, output)

--- a/pkg/pillar/netmonitor/linux.go
+++ b/pkg/pillar/netmonitor/linux.go
@@ -245,7 +245,7 @@ func (m *LinuxNetworkMonitor) GetInterfaceDHCPInfo(ifIndex int) (info DHCPInfo, 
 	// XXX Getting error -1 unless we add argument -4.
 	// XXX Add IPv6 support.
 	m.Log.Functionf("Calling dhcpcd -U -4 %s\n", ifName)
-	stdoutStderr, err := base.Exec(m.Log, "dhcpcd", "-U", "-4", ifName).CombinedOutput()
+	stdoutStderr, err := base.Exec(m.Log, "dhcpcd", "-U", "-4", ifName).CombinedOutputWithTimeout()
 	if err != nil {
 		if strings.Contains(string(stdoutStderr), "dhcp_dump: No such file or directory") {
 			// DHCP is not configured for this interface. Return empty DHCPInfo.

--- a/pkg/pillar/netmonitor/linux.go
+++ b/pkg/pillar/netmonitor/linux.go
@@ -245,7 +245,7 @@ func (m *LinuxNetworkMonitor) GetInterfaceDHCPInfo(ifIndex int) (info DHCPInfo, 
 	// XXX Getting error -1 unless we add argument -4.
 	// XXX Add IPv6 support.
 	m.Log.Functionf("Calling dhcpcd -U -4 %s\n", ifName)
-	stdoutStderr, err := base.Exec(m.Log, "dhcpcd", "-U", "-4", ifName).CombinedOutputWithTimeout()
+	stdoutStderr, err := base.Exec(m.Log, "dhcpcd", "-U", "-4", ifName).CombinedOutput()
 	if err != nil {
 		if strings.Contains(string(stdoutStderr), "dhcp_dump: No such file or directory") {
 			// DHCP is not configured for this interface. Return empty DHCPInfo.


### PR DESCRIPTION
Backport to 9.4-stable the following PRs:

https://github.com/lf-edge/eve/pull/3428
https://github.com/lf-edge/eve/pull/3518
https://github.com/lf-edge/eve/pull/3509

In order to avoid unwanted triggers from watchdog.