### PR TITLE
bump linuxkit to version that supports sbom; disable for now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,7 +295,7 @@ DOCKER_GO = _() { $(SET_X); mkdir -p $(CURDIR)/.go/src/$${3:-dummy} ; mkdir -p $
 
 PARSE_PKGS=$(if $(strip $(EVE_HASH)),EVE_HASH=)$(EVE_HASH) DOCKER_ARCH_TAG=$(DOCKER_ARCH_TAG) KERNEL_TAG=$(KERNEL_TAG) ./tools/parse-pkgs.sh
 LINUXKIT=$(BUILDTOOLS_BIN)/linuxkit
-LINUXKIT_VERSION=7164b2c04d40eb276cee6e16c7fa617fe6840a17
+LINUXKIT_VERSION=bbd9b85fc153a9d64f839d37591b0dcbe5375407
 LINUXKIT_SOURCE=https://github.com/linuxkit/linuxkit.git
 LINUXKIT_OPTS=$(if $(strip $(EVE_HASH)),--hash) $(EVE_HASH) $(if $(strip $(EVE_REL)),--release) $(EVE_REL)
 LINUXKIT_PKG_TARGET=build

--- a/tools/makerootfs.sh
+++ b/tools/makerootfs.sh
@@ -24,8 +24,9 @@ do_image() {
     ARCHARG="--arch ${arch}"
   fi
   : > "$IMAGE"
+  # sbom disabled for now; will be re-enabled later
   # shellcheck disable=SC2086
-  linuxkit build --docker ${ARCHARG} -o - "$ymlfile" | docker run -i --rm -v /dev:/dev --privileged -v "$IMAGE:/rootfs.img" "${MKROOTFS_TAG}"
+  linuxkit build --no-sbom --docker ${ARCHARG} -o - "$ymlfile" | docker run -i --rm -v /dev:/dev --privileged -v "$IMAGE:/rootfs.img" "${MKROOTFS_TAG}"
 }
 
 # mode 1 - generate tarfile from yml and save
@@ -40,8 +41,9 @@ do_tar() {
   if [ -n "$arch" ]; then
     ARCHARG="--arch ${arch}"
   fi
+  # sbom disabled for now; will be re-enabled later
   # shellcheck disable=SC2086
-  linuxkit build --docker ${ARCHARG} --o "${tarfile}" "$ymlfile"
+  linuxkit build --no-sbom --docker ${ARCHARG} --o "${tarfile}" "$ymlfile"
 }
 
 # mode 2 - generate image from tarfile


### PR DESCRIPTION
This is the first of several small PRs to change how we generate SBoMs. It is meant to fix our missing SBoMs from the new external kernel format, but also simplify and speed up our SBoM generation.

This PR just bumps to the latest version of linuxkit, which has support for adding SBoMs both to packages via `linuxkit pkg build` (using `buildkit`'s sbom support), and collating those in the final image via `linuxkit build`.

For now, the package-sbom part is enabled (by default), which won't do anything with it yet. Since package contents are unchanged, and therefore the tags are unchanged, it won't rebuild anything. Any changes to a package after this PR merges will pick that up and get the SBoM added to the OCI image.

The collating part that happens when you build the rootfs, via `linuxkit build`, is disabled in this PR. We are keeping the current method through the next few PRs, where we run one big scan on the final `rootfs.tar`.

The entire list of PRs for this process are:

1. This one to bump linuxkit but disable final image sbom collation
2. Make insignificant changes to all of our packages (e.g. adding a comment line), which changes the git tree hash, forcing a rebuild. Since it will be _after_ this PR, those rebuilds will include SBoMs on all of the packages.
3. Add SBoM generation to eve-kernel
4. Enable SBoM collation in the final `linuxkit build` of `rootfs.tar`, which will work since all of the packages will have been updated with SBoMs. Simultaneously, disable the current sbom generation, and update the process that collates sources to get it from the newly-generated final SBoM

cc @mikem-zed 