### PR TITLE
.github/workflows/eden.yml: remove report_pr_publish job

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -45,23 +45,6 @@ jobs:
               exit 1
           fi
 
-  report_pr_publish:
-    runs-on: ubuntu-latest
-    needs: check_pr_publish
-    if: failure()
-    permissions:
-      issues: write
-    steps:
-      - uses: actions/github-script@v6
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '⚠️ Docker image is not available on Docker Hub to run Eden PR tests. Please wait for the image to be built and published.'
-            })
-
   test_suite_pr:
     needs: check_pr_publish
     if: github.event.review.state == 'approved'


### PR DESCRIPTION
The `report_pr_publish` [fails to comment](https://github.com/lf-edge/eve/actions/runs/6889270431/job/18739939878) on PRs because of some sort of permission error, lets remove it for now. We still fail the Eden PR test immediately if images are not published on dockerhub, so no worry about wasting Eden runners looping in a confused state for 5 hours and then failing.