### PR TITLE
noop comments to force rebuilding of packages and get sboms

### DIFF
--- a/pkg/acrn/Dockerfile
+++ b/pkg/acrn/Dockerfile
@@ -1,4 +1,8 @@
 # syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
+
+# Copyright (c) 2023 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 FROM lfedge/eve-alpine:9fb9b9cbf7d90066a70e4704d04a6fe248ff52bb AS kernel-build
 
 ENV BUILD_PKGS \

--- a/pkg/apparmor/Dockerfile
+++ b/pkg/apparmor/Dockerfile
@@ -1,5 +1,8 @@
 # syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
 
+# Copyright (c) 2023 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 FROM lfedge/eve-alpine:862d6db0e2e938d11ef83e83fe9c7a8c83631517 as build
 ENV BUILD_PKGS linux-headers musl-dev musl-utils musl-libintl git gcc g++ \
                autoconf automake libtool make flex bison bash sed gettext

--- a/pkg/debug/Dockerfile
+++ b/pkg/debug/Dockerfile
@@ -1,4 +1,8 @@
 # syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
+
+# Copyright (c) 2023 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 # for debug container we need to build our own copy of musl
 # with -fno-omit-frame-pointer to make sure that perf(1)
 # has a fast path for stack unwinding. This also happens

--- a/pkg/edgeview/Dockerfile
+++ b/pkg/edgeview/Dockerfile
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
 FROM lfedge/eve-alpine:9fb9b9cbf7d90066a70e4704d04a6fe248ff52bb as build
 ENV BUILD_PKGS git go
 ENV PKGS alpine-baselayout musl-utils iproute2 iptables

--- a/pkg/guacd/Dockerfile
+++ b/pkg/guacd/Dockerfile
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
 FROM lfedge/eve-alpine:9fb9b9cbf7d90066a70e4704d04a6fe248ff52bb as build
 ENV BUILD_PKGS cairo-dev jpeg-dev libpng-dev gcc make libc-dev openssl-dev libvncserver-dev file patch
 ENV PKGS alpine-baselayout musl-utils libtasn1-progs p11-kit cairo jpeg libpng libvncserver

--- a/pkg/kdump/Dockerfile
+++ b/pkg/kdump/Dockerfile
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
 FROM lfedge/eve-alpine:9fb9b9cbf7d90066a70e4704d04a6fe248ff52bb AS build
 
 ENV BUILD_PKGS patch curl make gcc perl util-linux-dev git mtools linux-headers musl-dev xz-dev elfutils-dev libbz2

--- a/pkg/measure-config/Dockerfile
+++ b/pkg/measure-config/Dockerfile
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
 FROM lfedge/eve-alpine:9fb9b9cbf7d90066a70e4704d04a6fe248ff52bb as build
 ENV BUILD_PKGS git go
 ENV PKGS alpine-baselayout musl-utils

--- a/pkg/newlog/Dockerfile
+++ b/pkg/newlog/Dockerfile
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
 FROM lfedge/eve-alpine:9fb9b9cbf7d90066a70e4704d04a6fe248ff52bb as build
 ENV BUILD_PKGS git go
 ENV PKGS coreutils

--- a/pkg/pillar/Dockerfile
+++ b/pkg/pillar/Dockerfile
@@ -1,6 +1,8 @@
 # Copyright (c) 2018 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+# Dockerfile to build pillar
+
 # use the same set of packages for simplicity
 ARG BUILD_PKGS_BASE="git gcc linux-headers libc-dev make linux-pam-dev m4 findutils go util-linux make patch \
                      libintl libuuid libtirpc libblkid libcrypto1.1 zlib tar"

--- a/pkg/rngd/Dockerfile
+++ b/pkg/rngd/Dockerfile
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
 FROM lfedge/eve-alpine:9fb9b9cbf7d90066a70e4704d04a6fe248ff52bb as build
 ENV BUILD_PKGS go gcc musl-dev linux-headers
 RUN eve-alpine-deploy.sh

--- a/pkg/storage-init/Dockerfile
+++ b/pkg/storage-init/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright (c) 2023 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 FROM lfedge/eve-alpine:9fb9b9cbf7d90066a70e4704d04a6fe248ff52bb as build
 ENV PKGS alpine-baselayout musl-utils bash glib squashfs-tools util-linux e2fsprogs e2fsprogs-extra keyutils dosfstools coreutils sgdisk smartmontools
 RUN eve-alpine-deploy.sh

--- a/pkg/vtpm/Dockerfile
+++ b/pkg/vtpm/Dockerfile
@@ -1,5 +1,8 @@
 # syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
 
+# Copyright (c) 2023 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 #There are four parts:
 # a) building tpm2-tss
 # b) building tpm2-tools

--- a/pkg/watchdog/Dockerfile
+++ b/pkg/watchdog/Dockerfile
@@ -1,4 +1,5 @@
-# Build watchdogd for alpine
+# Copyright (c) 2023 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
 
 FROM lfedge/eve-alpine:9fb9b9cbf7d90066a70e4704d04a6fe248ff52bb AS watchdog-build
 ENV BUILD_PKGS build-base file libtirpc-dev linux-headers tar util-linux

--- a/pkg/wlan/Dockerfile
+++ b/pkg/wlan/Dockerfile
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
 FROM lfedge/eve-alpine:9fb9b9cbf7d90066a70e4704d04a6fe248ff52bb as build
 ENV PKGS alpine-baselayout musl-utils wireless-tools wpa_supplicant
 RUN eve-alpine-deploy.sh

--- a/pkg/wwan/Dockerfile
+++ b/pkg/wwan/Dockerfile
@@ -1,4 +1,8 @@
 # syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
+
+# Copyright (c) 2023 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 FROM lfedge/eve-alpine:29dc7661e9c3dcd0ec7ef9b98d2df58354d85fc0 as build
 ENV BUILD_PKGS meson ninja git libc-dev glib-dev make gcc dbus-dev libgudev-dev go
 ENV PKGS alpine-baselayout dbus glib udev libgudev

--- a/pkg/xen-tools/Dockerfile
+++ b/pkg/xen-tools/Dockerfile
@@ -1,5 +1,8 @@
 # syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
 
+# Copyright (c) 2023 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 FROM lfedge/eve-uefi:d821658883d6748d8bbf0d6640c62288e3ce8c6f as uefi-build
 
 FROM lfedge/eve-alpine:0f4e313d0d84ac313ea35e966def9ef96f61aafb as runx-build


### PR DESCRIPTION
These changes are all a noop; they just add a simple comment to the pkg Dockerfile.

This does, however, change the git tree hash for those packages. With #3592 merged in, linuxkit will add an SBoM to those container images (via buildkit), which will be consumed in future PRs.

I went through `images/rootfs.yml.in` and found all of the images referenced there; those are the ones I updated. These are:

* acrn
* apparmor
* debug
* edgeview
* guacd
* kdump
* measure-config
* newlogd
* pillar
* rngd
* storage-init
* vtpm
* watchdog
* wlan
* wwan
* xen-tools

