### PR TITLE
pillar's Makefile: Improvements + allow multi-architecutre builds from host

### DIFF
--- a/docs/CUSTOM-BUILD.md
+++ b/docs/CUSTOM-BUILD.md
@@ -33,7 +33,7 @@ Once you are done modifying the package, from the root directory of eve, build t
 make pkg/<package>
 ```
 
-For example, `make pkg/pillar` or `make pkg/guacd`.
+For example, `make pkg/edgeview` or `make pkg/guacd`.
 
 Some packages require special treatment in the form of extra steps after build. Those should be invoked with their dedicated targets.
 As of this writing, only `pkg/kernel` is subject to this special treatment, and should be invoked as:
@@ -47,6 +47,45 @@ on the image is based on the [git tree hash](https://git-scm.com/docs/git-ls-tre
 
 If the directory has uncommitted changes, the resultant tag will include `-dirty`. It is your choice whether to accept
 the `-dirty` tag, or to commit your changes.
+
+### Building pillar
+
+Pillar is usually heavily developed, so sometimes developers might want to perform a quick build in order to do small checks,
+like look for compiler errors, etc. As any other package, pillar should be built using `make pkg/pillar`. However, it also
+provides a Makefile that can be used to build pillar directly on the host and/or build, export and run it in a docker
+container. The two targets dedicated for development are:
+
+* **build-docker-dev**: Builds the build container of pillar
+* **enter-docker-dev**: Builds and run the build container
+
+Both targets can be used through the following commands:
+
+```sh
+make -C pkg/pillar build-docker-dev
+```
+
+and/or
+
+```sh
+make -C pkg/pillar enter-docker-dev
+```
+
+To build pillar directly on the host, just use:
+
+```sh
+make -C pkg/pillar
+```
+
+The _ZARCH_ variable can also be used to specify the target architecture. For instance:
+
+```sh
+make ZARCH=arm64 -C pkg/pillar build-docker-dev
+make ZARCH=amd64 -C pkg/pillar build-docker-dev
+```
+
+If not specified, architecture from the host will be used. Note that in case of cross compilation, for instance,
+using `ZARCH=arm64` from a `amd64` host will produce a build container of `amd64` architecture. However, the final pillar
+binaries will be built to the target architecture (in this case, `arm64`).
 
 ### Pushing to Registry
 

--- a/pkg/pillar/Dockerfile
+++ b/pkg/pillar/Dockerfile
@@ -99,7 +99,7 @@ RUN set -e && for patch in ../patches/*.patch; do \
 RUN --mount=type=cache,target=/root/.cache/go-build echo "Running go vet" && go vet ./... && \
     echo "Running go fmt" && ERR="$(find . -name \*.go | grep -v /vendor/ | xargs gofmt -d -e -l -s)" && \
        if [ -n "$ERR" ] ; then printf 'go fmt Failed - ERR: %s' "$ERR" ; exit 1 ; fi && \
-       make DEV="$DEV" RSTATS=$RSTATS RSTATS_ENDPOINT=$RSTATS_ENDPOINT RSTATS_TAG=$RSTATS_TAG DISTDIR=/final/opt/zededa/bin BUILD_VERSION=${GOPKGVERSION} build
+       make ZARCH=${TARGETARCH} DEV="$DEV" RSTATS=$RSTATS RSTATS_ENDPOINT=$RSTATS_ENDPOINT RSTATS_TAG=$RSTATS_TAG DISTDIR=/final/opt/zededa/bin BUILD_VERSION=${GOPKGVERSION} build
 
 WORKDIR /
 

--- a/pkg/pillar/Makefile
+++ b/pkg/pillar/Makefile
@@ -65,14 +65,6 @@ $(APPS1): $(DISTDIR)
 shell:
 	make -C ../.. shell
 
-build-docker-$(APPS): $(DISTDIR)
-	docker build -f Dockerfile.in --target=build -t $(APPS)-builder .
-	# all of this goes away when we switch to full buildkit-based docker builds
-	docker container create --name $(APPS)-extract $(APPS)-builder
-	docker container cp $(APPS)-extract:/dist/$(APPS) $(DISTDIR)/$(APPS)
-	docker container rm -f $(APPS)-extract
-
-
 build-docker:
 	docker build $(DOCKER_ARGS) -t $(DOCKER_TAG) .
 

--- a/pkg/pillar/Makefile
+++ b/pkg/pillar/Makefile
@@ -5,17 +5,14 @@
 # 1. Build go provision binaries for arm64 and amd64
 # 2. Build on Linux as well on Mac
 
-ARCH         ?= amd64
-#ARCH        ?= arm64
-DISTDIR      := dist/$(ARCH)
+HOSTARCH      := $(subst aarch64,arm64,$(subst x86_64,amd64,$(shell uname -m)))
+ZARCH         ?= $(HOSTARCH)
+DISTDIR       := dist/$(ZARCH)
 BUILD_VERSION ?=
 
-DOCKER_ARGS=
-DOCKER_TAG=lfedge/eve-pillar:local
-ifneq ($(GOARCH),)
-DOCKER_ARGS:=--build-arg GOARCH=$(GOARCH)
-DOCKER_TAG:=$(DOCKER_TAG)-$(GOARCH)
-endif
+DOCKER_ARCH_ARGS:=--platform linux/$(ZARCH)
+DOCKER_ARGS:=$(DOCKER_ARCH_ARGS) --build-arg ZARCH=$(ZARCH)
+DOCKER_TAG:=lfedge/eve-pillar:local-$(ZARCH)
 
 APPS = zedbox
 APPS1 = $(notdir $(wildcard cmd/*))
@@ -55,7 +52,7 @@ endif
 $(APPS): $(DISTDIR)/$(APPS)
 $(DISTDIR)/$(APPS): $(DISTDIR)
 	@echo "Building $@"
-	GO111MODULE=on GOOS=linux go build -mod=vendor $(TAGS) $(GCFLAGS) $(LDFLAGS) -o $@ ./$(@F)
+	GO111MODULE=on GOOS=linux GOARCH=$(ZARCH) go build -mod=vendor $(TAGS) $(GCFLAGS) $(LDFLAGS) -o $@ ./$(@F)
 
 $(APPS1): $(DISTDIR)
 	@echo $@
@@ -72,7 +69,7 @@ build-docker-dev:
 	docker build $(DOCKER_ARGS) -t $(DOCKER_TAG) . --target build
 
 enter-docker-dev: build-docker-dev
-	docker run -it --rm --entrypoint /bin/sh $(DOCKER_TAG)
+	docker run --platform linux/$(ZARCH) -it --rm --entrypoint /bin/sh $(DOCKER_TAG)
 
 build-docker-git:
 	git archive HEAD | docker build $(DOCKER_ARGS) -t $(DOCKER_TAG) -


### PR DESCRIPTION
This PR provides some improvements on pillar's Makefile:

- Remove an unused target
- Allow multi-architecture builds when calling make from host build machine, like: `make ZARCH=arm64 -C pkg/pillar build-docker` in order to allow build pillar container on docker to help debugging and developing....
