### PR TITLE
[WIP] GitHub actions: switch to BuildJet cache for build.yml workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
         uses: buildjet/cache@v3
         with:
           path: ~/.linuxkit/cache
-          key: linuxkit-${{ matrix.arch }}-${{ github.sha }}
+          key: buildjet-linuxkit-${{ matrix.arch }}-${{ github.sha }}
       - name: Build packages
         run: |
           make V=1 PRUNE=1 ZARCH=${{ matrix.arch }} pkgs
@@ -89,7 +89,7 @@ jobs:
         uses: buildjet/cache/restore@v3
         with:
           path: ~/.linuxkit/cache
-          key: linuxkit-amd64-${{ github.sha }}
+          key: buildjet-linuxkit-amd64-${{ github.sha }}
           fail-on-cache-miss: true
       - name: load images we need from linuxkit cache into docker
         run: |
@@ -104,7 +104,7 @@ jobs:
         uses: buildjet/cache/restore@v3
         with:
           path: ~/.linuxkit/cache
-          key: linuxkit-${{ matrix.arch }}-${{ github.sha }}
+          key: buildjet-linuxkit-${{ matrix.arch }}-${{ github.sha }}
           fail-on-cache-miss: true
       - name: set environment
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: buildjet-4vcpu-ubuntu-2204-arm
+          - os: buildjet-4vcpu-ubuntu-2004-arm
             arch: arm64
           - os: ubuntu-20.04
             arch: amd64
@@ -42,7 +42,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: ensure zstd for cache  # this should be removed once the arm64 VM includes zstd
-        if: ${{ matrix.os == 'buildjet-4vcpu-ubuntu-2204-arm' || matrix.os == 'arm64-secure' }}
+        if: ${{ matrix.os == 'buildjet-4vcpu-ubuntu-2004-arm' || matrix.os == 'arm64-secure' }}
         run: |
           sudo apt install -y zstd
       - name: ensure packages for cross-arch build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: buildjet-4vcpu-ubuntu-2004-arm
+          - os: buildjet-4vcpu-ubuntu-2204-arm
             arch: arm64
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             arch: amd64
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             arch: riscv64
     steps:
       - name: Starting Report
@@ -42,7 +42,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: ensure zstd for cache  # this should be removed once the arm64 VM includes zstd
-        if: ${{ matrix.os == 'buildjet-4vcpu-ubuntu-2004-arm' || matrix.os == 'arm64-secure' }}
+        if: ${{ matrix.os == 'buildjet-4vcpu-ubuntu-2204-arm' || matrix.os == 'arm64-secure' }}
         run: |
           sudo apt install -y zstd
       - name: ensure packages for cross-arch build
@@ -71,7 +71,7 @@ jobs:
 
   eve:
     needs: packages  # all packages for all platforms must be built first
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,15 +71,26 @@ jobs:
 
   eve:
     needs: packages  # all packages for all platforms must be built first
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        arch: [arm64, amd64]
-        hv: [xen, kvm]
         include:
           - arch: riscv64
             hv: mini
+            os: ubuntu-22.04
+          - arch: arm64
+            hv: xen
+            os: buildjet-4vcpu-ubuntu-2204-arm
+          - arch: arm64
+            hv: kvm
+            os: buildjet-4vcpu-ubuntu-2204-arm
+          - arch: amd64
+            hv: kvm
+            os: ubuntu-22.04 
+          - arch: amd64
+            hv: xen
+            os: ubuntu-22.04 
     steps:
       - uses: actions/checkout@v3
         with:
@@ -89,18 +100,18 @@ jobs:
         uses: buildjet/cache/restore@v3
         with:
           path: ~/.linuxkit/cache
-          key: buildjet-linuxkit-amd64-${{ github.sha }}
+          key: buildjet-linuxkit-${{ matrix.arch }}-${{ github.sha }}
           fail-on-cache-miss: true
       - name: load images we need from linuxkit cache into docker
         run: |
           make cache-export-docker-load-all
       - name: clear linuxkit cache so we can load for target arch
-        if: ${{ matrix.arch != 'amd64' }}  # because our runner arch is amd64; if that changes, this will have to change
+        if: ${{ matrix.arch == 'riscv64' }}  # because our runner arch is amd64; if that changes, this will have to change
         run: |
           rm -rf ~/.linuxkit
       - name: update linuxkit cache for our arch
         id: cache_for_packages
-        if: ${{ matrix.arch != 'amd64' }}  # because our runner arch is amd64; if that changes, this will have to change
+        if: ${{ matrix.arch == 'riscv64' }}  # because our runner arch is amd64; if that changes, this will have to change
         uses: buildjet/cache/restore@v3
         with:
           path: ~/.linuxkit/cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
           # if the default server is responding -- we can skip apt update
           $APT_INSTALL || { sudo apt update && $APT_INSTALL ; }
       - name: update linuxkit cache if available
-        uses: actions/cache@v3
+        uses: buildjet/cache@v3
         with:
           path: ~/.linuxkit/cache
           key: linuxkit-${{ matrix.arch }}-${{ github.sha }}
@@ -86,7 +86,7 @@ jobs:
           fetch-depth: 0
       - name: update linuxkit cache for runner arch so we can get desired images
         id: cache_for_docker
-        uses: actions/cache/restore@v3
+        uses: buildjet/cache/restore@v3
         with:
           path: ~/.linuxkit/cache
           key: linuxkit-amd64-${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
       - name: update linuxkit cache for our arch
         id: cache_for_packages
         if: ${{ matrix.arch != 'amd64' }}  # because our runner arch is amd64; if that changes, this will have to change
-        uses: actions/cache/restore@v3
+        uses: buildjet/cache/restore@v3
         with:
           path: ~/.linuxkit/cache
           key: linuxkit-${{ matrix.arch }}-${{ github.sha }}


### PR DESCRIPTION
Recent build failures might be because of the GitHub cache. Switching to BuildJet cache for more stability and since it gives more space and is free it is a good alternative.