### PR TITLE
pillar/go.mod,go.sum,vendor: update eve-libs to latest

### DIFF
--- a/pkg/pillar/go.mod
+++ b/pkg/pillar/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/jaypipes/ghw v0.8.0
 	github.com/lf-edge/edge-containers v0.0.0-20221025050409-93c34bebadd2
 	github.com/lf-edge/eve-api/go v0.0.0-20231101130551-3e88f723673a
-	github.com/lf-edge/eve-libs v0.0.0-20230921141205-94d6f6b65597
+	github.com/lf-edge/eve-libs v0.0.0-20231120160159-666ed2307f8e
 	github.com/linuxkit/linuxkit/src/cmd/linuxkit v0.0.0-20220913135124-e532e7310810
 	github.com/miekg/dns v1.1.41
 	github.com/moby/sys/mountinfo v0.6.0

--- a/pkg/pillar/go.sum
+++ b/pkg/pillar/go.sum
@@ -1133,8 +1133,8 @@ github.com/lf-edge/edge-containers v0.0.0-20221025050409-93c34bebadd2 h1:ckxNk8M
 github.com/lf-edge/edge-containers v0.0.0-20221025050409-93c34bebadd2/go.mod h1:eA41YxPbZRVvewIYRzmqDB1PeLQXxCy9WQEc3AVCsPI=
 github.com/lf-edge/eve-api/go v0.0.0-20231101130551-3e88f723673a h1:GDjTYjRchuuCgYsHr1N/uprRmd6iMu2Gmt7mNWJ4d6A=
 github.com/lf-edge/eve-api/go v0.0.0-20231101130551-3e88f723673a/go.mod h1:6XqpOM8p1HsluNIGw2ihYPYsaAisQ5CuJpbIKHXQo5w=
-github.com/lf-edge/eve-libs v0.0.0-20230921141205-94d6f6b65597 h1:/UGYRj5tdRw5m3+VjZtTx1RVgphQbthfY/Gu5W7qb5o=
-github.com/lf-edge/eve-libs v0.0.0-20230921141205-94d6f6b65597/go.mod h1:dEMW+ISS+vVqukeNsorFlaGCo2nuDwkK0LGyBYd8yrc=
+github.com/lf-edge/eve-libs v0.0.0-20231120160159-666ed2307f8e h1:2k1XWU4x8Zkym6Cw1spObpVsyYBCYwB7mIcN8Ge02K8=
+github.com/lf-edge/eve-libs v0.0.0-20231120160159-666ed2307f8e/go.mod h1:fca8Jvpk2pnSdbfiCHjbvBE1Mn6WAQqeKyQezaSpLmU=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=

--- a/pkg/pillar/vendor/github.com/lf-edge/eve-libs/zedUpload/httputil/timeoutreader.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve-libs/zedUpload/httputil/timeoutreader.go
@@ -32,10 +32,14 @@ func (r *TimeoutReader) Read(p []byte) (int, error) {
 		n, err = r.reader.Read(p)
 		c <- 0
 	}()
+
+	timer := time.NewTimer(r.timeout)
+	defer timer.Stop()
+
 	select {
 	case <-c:
 		return n, err
-	case <-time.After(r.timeout):
+	case <-timer.C:
 		return 0, &ErrTimeout{}
 	}
 }

--- a/pkg/pillar/vendor/modules.txt
+++ b/pkg/pillar/vendor/modules.txt
@@ -505,7 +505,7 @@ github.com/lf-edge/eve-api/go/logs
 github.com/lf-edge/eve-api/go/metrics
 github.com/lf-edge/eve-api/go/profile
 github.com/lf-edge/eve-api/go/register
-# github.com/lf-edge/eve-libs v0.0.0-20230921141205-94d6f6b65597
+# github.com/lf-edge/eve-libs v0.0.0-20231120160159-666ed2307f8e
 ## explicit; go 1.20
 github.com/lf-edge/eve-libs/depgraph
 github.com/lf-edge/eve-libs/nettrace


### PR DESCRIPTION
The following commit of the eve-libs is of interest: d348f99a4e01 ("zedUpload/timeoutreader: fix timer leak which causes OOM")

This commit is auto-generated by the following commands:

   go mod tidy
   go mod vendor