### PR TITLE
[9.4-stable] Not having IP address with DT_NONE is expected

### DIFF
--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -329,6 +329,15 @@ func VerifyAllIntf(ctx *ZedCloudContext,
 			remoteTemporaryFailure = true
 		}
 		if err != nil {
+			var noAddrErr *types.IPAddrNotAvail
+			if errors.As(err, &noAddrErr) {
+				// Interface link exists and is UP but does not have any IP address assigned.
+				// This is expected with app-shared interface and DhcpTypeNone.
+				if !portStatus.IsMgmt && portStatus.Dhcp == types.DT_NONE {
+					intfStatusMap.RecordSuccess(intf)
+					continue
+				}
+			}
 			log.Errorf("Zedcloud un-reachable via interface %s: %s",
 				intf, err)
 			if sendErr, ok := err.(*SendError); ok && len(sendErr.Attempts) > 0 {


### PR DESCRIPTION
Backport of https://github.com/lf-edge/eve/pull/3576

EVE reports `IPAddrNotAvail` error even for app-shared ports with `DT_NONE` (aka DHCP-passthrough). But with such config it is actually expected that there is no IP address assigned and error should not be reported for the port.

Signed-off-by: Milan Lenco <milan@zededa.com>
(cherry picked from commit b4ca054d003a7aa6fc15d5bd2bef074821f15f44)