### PR TITLE
Patch envelopes store pe usage

### DIFF
--- a/pkg/pillar/cmd/zedagent/parsepatchenvelopes.go
+++ b/pkg/pillar/cmd/zedagent/parsepatchenvelopes.go
@@ -6,7 +6,6 @@ package zedagent
 import (
 	"encoding/hex"
 	"fmt"
-	"os"
 
 	"crypto/sha256"
 
@@ -24,13 +23,6 @@ func parsePatchEnvelopes(ctx *getconfigContext, config *zconfig.EdgeDevConfig) {
 func parsePatchEnvelopesImpl(ctx *getconfigContext, config *zconfig.EdgeDevConfig,
 	persistCacheFilepath string) {
 	log.Tracef("Parsing patchEnvelope from configuration")
-
-	// Remove previously created patch envelopes
-	// so that we will not have stale objects
-	if err := os.RemoveAll(persistCacheFilepath); err != nil {
-		log.Errorf("Failed to delete persistCacheFilepath %v", err)
-		return
-	}
 
 	// Store list of binary blobs which were created before
 	pc, err := persistcache.New(persistCacheFilepath)

--- a/pkg/pillar/cmd/zedrouter/patchenvelopes.go
+++ b/pkg/pillar/cmd/zedrouter/patchenvelopes.go
@@ -333,6 +333,20 @@ func (pes *PatchEnvelopes) affectedByContentTree(ct types.ContentTreeStatus) {
 	}
 }
 
+// EnvelopesInUsage returns list of currently patch envelopes currently attached to
+// app instances
+func (pes *PatchEnvelopes) EnvelopesInUsage() []string {
+	var result []string
+	pes.envelopes.Range(func(_ uuid.UUID, peInfo types.PatchEnvelopeInfo) bool {
+		peUsages := types.PatchEnvelopeUsageFromInfo(peInfo)
+		for _, usage := range peUsages {
+			result = append(result, usage.Key())
+		}
+		return true
+	})
+	return result
+}
+
 // PatchEnvelopeInfo contains fields that we don't want to expose to app instance (like AllowedApps), so we use
 // peInfoToDisplay and patchEnvelopesJSONFOrAppInstance to marshal PatchEnvelopeInfoList in a format, which is
 // suitable for app instance.

--- a/pkg/pillar/types/locationconsts.go
+++ b/pkg/pillar/types/locationconsts.go
@@ -41,6 +41,8 @@ const (
 	SnapshotInstanceStatusFilename = "snapshotInstanceStatus.json"
 	// PersistCachePatchEnvelopes - folder to store inline patch envelopes
 	PersistCachePatchEnvelopes = PersistDir + "/patchEnvelopesCache"
+	// PersistCachePatchEnvelopesUsage - folder to store patch envelopes usage stat per app
+	PersistCachePatchEnvelopesUsage = PersistDir + "/patchEnvelopesUsageCache"
 
 	// IdentityDirname - Config dir
 	IdentityDirname = "/config"

--- a/pkg/pillar/types/patchenvelopestypes.go
+++ b/pkg/pillar/types/patchenvelopestypes.go
@@ -147,3 +147,20 @@ func (pe *PatchEnvelopeUsage) Key() string {
 		"-v-" + pe.Version +
 		"-app-" + pe.AppUUID
 }
+
+// PatchEnvelopeUsageFromInfo returns PatchEnvelopeUsage structure from
+// PatchEnvelopeInfo struct
+func PatchEnvelopeUsageFromInfo(peInfo PatchEnvelopeInfo) []PatchEnvelopeUsage {
+	result := make([]PatchEnvelopeUsage, 0, len(peInfo.AllowedApps))
+
+	for _, appUUID := range peInfo.AllowedApps {
+		usage := PatchEnvelopeUsage{
+			AppUUID: appUUID,
+			PatchID: peInfo.PatchID,
+			Version: peInfo.Version,
+		}
+		result = append(result, usage)
+	}
+
+	return result
+}


### PR DESCRIPTION
This PR concludes first phase of PatchEnvelopes making PatchEnvelope app usage persistent across EVE reboots

Now patch envelope app usage counters won't be reset each time device reboots. Also they will be reset each time patch envelope is deattached from app instance.

We store patch envelope app usage conters in separate persistcache object and save it periodically because writing to a file might take time which would block metadata server call.

Alternatively, we could change persistcache to use lockedmap from pillar generics package, but it will stil block metadata_handler call for given app instance.

Also it removes unnecessary step of deleting all patch envelopes each time EdgeDevConfig changes, because we have logic identifying stale patch envelopes which we want to delete, therefore it is not necessary to delete all of them.
