### PR TITLE
Disable split lock detection

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -169,7 +169,7 @@ function set_generic {
 
    set_global dom0 /boot/kernel
    set_global dom0_rootfs "root=$rootfs_root"
-   set_global dom0_cmdline "$linuxkit_cmdline $panic_timeout rfkill.default_state=0"
+   set_global dom0_cmdline "$linuxkit_cmdline $panic_timeout rfkill.default_state=0 split_lock_detect=off"
 }
 
 function set_x86_64 {


### PR DESCRIPTION
We have experienced some cases where Guests are generating split lock exceptions that are flooding the host kernel with traps causing a tremendous impact to system's performance, besides flood log buffers with messages like the following:

x86/split lock detection: #AC: qemu-system-x86/4185 took a split_lock trap at address: 0x699e4dc1

There are several discussions about whether split lock detection should be enabled, disabled or marked to slow down the split lockers (which might affect our workloads). Since we cannot predict our workloads, let's disabled it to avoid these situations.

I'm marking this PR as WIP because I would like to discuss it. Here are good resources about the theme and some forums where people claim performance improvements after disabled it:

https://lwn.net/Articles/790464/
https://lwn.net/Articles/816918/
https://lwn.net/Articles/911219/
https://forum.proxmox.com/threads/x86-split-lock-detection.111544/
https://www.reddit.com/r/VFIO/comments/zqesqm/psa_use_split_lock_detectoff_to_avoid_substantial/
