### PR TITLE
DO NOT MERGE

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,10 @@ jobs:
       - name: Build packages
         run: |
           make V=1 PRUNE=1 ZARCH=${{ matrix.arch }} pkgs
+      - uses: actions/upload-artifact@v3
+        with:
+          name: lkt-cache-${{ matrix.arch }}
+          path: ~/.linuxkit/cache
       - name: Post package report
         run: |
           echo Disk usage

--- a/pkg/guacd/Dockerfile
+++ b/pkg/guacd/Dockerfile
@@ -1,5 +1,7 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
+
+# small change to force a rebuild
 FROM lfedge/eve-alpine:9fb9b9cbf7d90066a70e4704d04a6fe248ff52bb as build
 ENV BUILD_PKGS cairo-dev jpeg-dev libpng-dev gcc make libc-dev openssl-dev libvncserver-dev file patch
 ENV PKGS alpine-baselayout musl-utils libtasn1-progs p11-kit cairo jpeg libpng libvncserver


### PR DESCRIPTION
This is to test the contents of the linuxkit cache, specifically for SBoMs. It changes `pkg/guacd` to regenerate the package, and then uploads the linuxkit cache as an artifact. We can download that artifact to check contents.

DO NOT MERGE!!