### PR TITLE
makefile with manifest sbom

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,7 +295,7 @@ DOCKER_GO = _() { $(SET_X); mkdir -p $(CURDIR)/.go/src/$${3:-dummy} ; mkdir -p $
 
 PARSE_PKGS=$(if $(strip $(EVE_HASH)),EVE_HASH=)$(EVE_HASH) DOCKER_ARCH_TAG=$(DOCKER_ARCH_TAG) KERNEL_TAG=$(KERNEL_TAG) ./tools/parse-pkgs.sh
 LINUXKIT=$(BUILDTOOLS_BIN)/linuxkit
-LINUXKIT_VERSION=4c14831d6b61c6919024c2270d33ec30ce0934cc
+LINUXKIT_VERSION=d1a0596bee704a8d06855c90b495ffadea5fb8ab
 LINUXKIT_SOURCE=https://github.com/linuxkit/linuxkit.git
 LINUXKIT_OPTS=$(if $(strip $(EVE_HASH)),--hash) $(EVE_HASH) $(if $(strip $(EVE_REL)),--release) $(EVE_REL)
 LINUXKIT_PKG_TARGET=build


### PR DESCRIPTION
The previous 2 PRs for linxukit added sboms to `pkg build` and `pkg push`; this adds it to `pkg manifest`.

This should cause no changes. We will need another noop package bump to get the sboms pushed out.