### PR TITLE
[9.4-stable] Disable split lock detection

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -162,7 +162,7 @@ function set_generic {
 
    set_global dom0 /boot/kernel
    set_global dom0_rootfs "root=$rootfs_root"
-   set_global dom0_cmdline "$linuxkit_cmdline $panic_timeout rfkill.default_state=0"
+   set_global dom0_cmdline "$linuxkit_cmdline $panic_timeout rfkill.default_state=0 split_lock_detect=off"
 }
 
 function set_x86_64 {


### PR DESCRIPTION
Backport of PR https://github.com/lf-edge/eve/pull/3611


We have experienced some cases where Guests are generating split lock exceptions that are flooding the host kernel with traps causing a tremendous impact to system's performance, besides flooding log buffers with messages like the following:

x86/split lock detection: #AC: qemu-system-x86/4185 took a split_lock trap at address: 0x699e4dc1

There are several discussions about whether split lock detection should be enabled or not. Since we cannot predict our workloads, let's disabled it to avoid these situations.