### PR TITLE
[9.4-stable] newlogd: Kick watchdog inside doMoveCompressFile()

### DIFF
--- a/pkg/newlog/cmd/newlogd.go
+++ b/pkg/newlog/cmd/newlogd.go
@@ -321,7 +321,7 @@ func main() {
 
 		case tmpLogfileInfo := <-movefileChan:
 			// handle logfile to gzip conversion work
-			doMoveCompressFile(tmpLogfileInfo)
+			doMoveCompressFile(&ps, tmpLogfileInfo)
 
 		case panicBuf := <-panicFileChan:
 			// save panic stack into files
@@ -1032,7 +1032,7 @@ func checkKeepQuota() {
 	}
 }
 
-func doMoveCompressFile(tmplogfileInfo fileChanInfo) {
+func doMoveCompressFile(ps *pubsub.PubSub, tmplogfileInfo fileChanInfo) {
 	isApp := tmplogfileInfo.isApp
 	dirName, appuuid := getFileInfo(tmplogfileInfo)
 
@@ -1073,8 +1073,13 @@ func doMoveCompressFile(tmplogfileInfo fileChanInfo) {
 	gw, underlayWriter, oTmpFile := prepareGzipToOutTempFile(filepath.Dir(outfile), tmplogfileInfo, now)
 
 	fileID := 0
+	wdTime := time.Now()
 	var newSize int64
 	for scanner.Scan() {
+		if time.Since(wdTime) >= (15 * time.Second) {
+			ps.StillRunning(agentName, warningTime, errorTime)
+			wdTime = time.Now()
+		}
 		newLine := scanner.Bytes()
 		//trim non-graphic symbols
 		newLine = bytes.TrimFunc(newLine, func(r rune) bool {


### PR DESCRIPTION
Backport of PR https://github.com/lf-edge/eve/pull/3615

Kick watchdog inside doMoveCompressFile() because it can take longer to execute depending on the file size, besides be affected by external factors, like the system load, while parsing and compressing the contents.