### PR TITLE
Remove DownloaderStatus Pending flags

### DIFF
--- a/pkg/pillar/cmd/volumemgr/blob.go
+++ b/pkg/pillar/cmd/volumemgr/blob.go
@@ -81,10 +81,6 @@ func downloadBlob(ctx *volumemgrContext, blob *types.BlobStatus) bool {
 		}
 		changed = true
 	}
-	if ds.Pending() {
-		log.Tracef("lookupDownloaderStatus Pending for blob %s", blob.Sha256)
-		return changed
-	}
 	if ds.HasError() {
 		log.Errorf("Received error from downloader for blob %s: %s",
 			blob.Sha256, ds.Error)

--- a/pkg/pillar/types/downloadertypes.go
+++ b/pkg/pillar/types/downloadertypes.go
@@ -102,9 +102,6 @@ type DownloaderStatus struct {
 	DatastoreIDList []uuid.UUID
 	Target          string // file path where we download the file
 	Name            string
-	PendingAdd      bool
-	PendingModify   bool
-	PendingDelete   bool
 	RefCount        uint      // Zero means not downloaded
 	LastUse         time.Time // When RefCount dropped to zero
 	Expired         bool      // Handshake to client
@@ -128,20 +125,6 @@ func (status DownloaderStatus) Key() string {
 	return status.ImageSha256
 }
 
-func (status DownloaderStatus) Pending() bool {
-	return status.PendingAdd || status.PendingModify || status.PendingDelete
-}
-
-// ClearPendingStatus : Clear Pending Status for DownloaderStatus
-func (status *DownloaderStatus) ClearPendingStatus() {
-	if status.PendingAdd {
-		status.PendingAdd = false
-	}
-	if status.PendingModify {
-		status.PendingModify = false
-	}
-}
-
 // HandleDownloadFail : Do Failure specific tasks
 func (status *DownloaderStatus) HandleDownloadFail(errStr string, retryTime time.Duration, cancelled bool) {
 	errDescription := ErrorDescription{
@@ -153,7 +136,6 @@ func (status *DownloaderStatus) HandleDownloadFail(errStr string, retryTime time
 		errDescription.ErrorRetryCondition = fmt.Sprintf("Will retry in %s; have retried %d times", retryTime, status.RetryCount)
 	}
 	status.SetErrorDescription(errDescription)
-	status.ClearPendingStatus()
 }
 
 // LogCreate :


### PR DESCRIPTION
I do not see any practical value of DownloaderStatus Pending flags, other than
blocking error update propagation from `DownloaderStatus` to `BlobStatus`.
But this can be confusing for the user.

Consider this example:
1. User enters wrong datastore config
2. User adds app config with image from this misconfigured datastore
3. Downloader fails, error is published for the blob/volume/app
4. User fixes datastore config
5. App image download starts and progresses successfully
6. The obsolete error continues being reported until download
   completes, which for large VM images may take quite some time
7. User could get confused and think that he didn't actually fix the
   datastore config, then try further changes, etc.