### PR TITLE
Improves logging for the chroot2 utility and introduces EVE_CONTAINER_NO_POWEROFF mode 

### DIFF
--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -162,6 +162,12 @@ PID   USER     TIME  COMMAND
 ~ #
 ```
 
+## Prevent shutdown of a container applications
+
+If container's entrypoint (e.g. `init` script) misbehaves and exits, it becomes very difficult to debug such a container, because hosting Vm shuts down immediately by explicit poweroff call.
+
+If EVE_CONTAINER_NO_POWEROFF=1 environment variable is set on the controller side in the application instance userData/cipherData fields, then the hosting Vm does not shut down, but waits for further debugging session, for example attaching to a `prime-cons` console.
+
 ## Reboots
 
 EVE is architected in such a way that if any service is unresponsive for a period of time, the entire device will reboot. When this happens a BootReason is constructed and sent in the device info message to the controller. If there is a golang panic there can also be useful information found in `/persist/agentdebug/`.

--- a/pkg/xen-tools/Dockerfile
+++ b/pkg/xen-tools/Dockerfile
@@ -16,8 +16,8 @@ COPY initrd/poweroff /sbin/poweroff
 COPY initrd/chroot2.c initrd/hacf.c /tmp/
 COPY initrd/00000080 /etc/acpi/PWRF/
 COPY initrd/eve-enter-container /bin/
-RUN gcc -s -o /chroot2 /tmp/chroot2.c
-RUN gcc -s -o /hacf /tmp/hacf.c
+RUN gcc -s -o /chroot2 /tmp/chroot2.c -Wall -Werror
+RUN gcc -s -o /hacf /tmp/hacf.c -Wall -Werror
 RUN mkinitfs -n -F base -i /init-initrd -o /runx-initrd
 
 FROM lfedge/eve-alpine:d32cf7889da970a42fdf5c1c5454a311356cb8f8 as build

--- a/pkg/xen-tools/initrd/chroot2.c
+++ b/pkg/xen-tools/initrd/chroot2.c
@@ -61,6 +61,7 @@ int main(int argc, char **argv)
 {
     const char *pid_file = argv[5];
     uid_t uid, gid;
+    int wstatus;
     char *endptr;
     pid_t child_pid;
     struct clone_args args;
@@ -105,6 +106,9 @@ int main(int argc, char **argv)
         close(fd);
     }
 
-    waitpid(child_pid, NULL, 0);
-    return 0;
+    child_pid = wait(&wstatus);
+    if (child_pid < 0)
+        err(-1, "wait() failed:");
+
+    return WIFEXITED(wstatus) ? WEXITSTATUS(wstatus) : -1;
 }

--- a/pkg/xen-tools/initrd/init-initrd
+++ b/pkg/xen-tools/initrd/init-initrd
@@ -180,7 +180,18 @@ else
   #shellcheck disable=SC2086
   eval /chroot2 /mnt/rootfs "${WORKDIR:-/}" $ug $pid_file $cmd <> /dev/console 2>&1
 fi
+chroot_ret=$?
 
-# once the command exits -- the only thing left is shut everything down
-echo "chroot2 exited with $?, the init-initrd is about to quit by calling /sbin/poweroff, which shuts the whole VM down"
+# Container exited, final lines
+
+if test "$EVE_CONTAINER_NO_POWEROFF" = "1"; then
+  # Don't power off, wait for further debugging
+  echo "chroot2 exited with $chroot_ret, the init-initrd idles, please attach to the 'prime-cons' console of the hosting Vm for further debugging"
+  sleep infinity
+else
+  # Power off is the default behavior
+  echo "chroot2 exited with $chroot_ret, the init-initrd is about to quit by calling /sbin/poweroff, which shuts the whole VM down"
+fi
+
+# Do poweroff to avoid kernel panic on init exit
 /sbin/poweroff

--- a/pkg/xen-tools/initrd/init-initrd
+++ b/pkg/xen-tools/initrd/init-initrd
@@ -182,4 +182,5 @@ else
 fi
 
 # once the command exits -- the only thing left is shut everything down
+echo "chroot2 exited with $?, the init-initrd is about to quit by calling /sbin/poweroff, which shuts the whole VM down"
 /sbin/poweroff


### PR DESCRIPTION
PR improves logging for the chroot2 utility by printing possible parameters. There is a customer container, which provides invalid WORKDIR in its environment, so that chdir() fails. EVE considers this as fatal (which is ok), but does not print what exact directory does not exist, which is nasty. This PR improves that by err() libc call.

PR propagates an error from to a chroot2 caller and init-initrd scripts prints the exit value.  Valid expectations are that init (process which is executed by the following execvp() call) never exits, if it does - return an exit status. It is possible to get 0 (success) of a chroot2 execution status iif a spawned child process returned 0. If a child process was terminated by a signal or coredumped (same as terminated by a SIGSEGV), the chroot2 returns -1 (255).

The last few commits introduce EVE_CONTAINER_NO_POWEROFF flag. If container's init script misbehaves and exits, it becomes very difficult to debug such a container, because VM shuts down immediately by explicit poweroff call. The EVE_CONTAINER_NO_POWEROFF can be set in the application environment variables on the controller side and instead of calling /sbin/poweroff, init-initrd sleeps infinitely, waiting for attention from a developer. 

CC: @jsfakian 