### PR TITLE
[10.4 stable] Stop trying to move config from read-only config partition

### DIFF
--- a/pkg/pillar/scripts/onboot.sh
+++ b/pkg/pillar/scripts/onboot.sh
@@ -115,19 +115,6 @@ if [ ! -d $PERSISTDIR/status ]; then
     mkdir $PERSISTDIR/status
 fi
 
-if [ -f $CONFIGDIR/restartcounter ]; then
-    echo "$(date -Ins -u) move $CONFIGDIR/restartcounter $PERSISTDIR/status"
-    mv $CONFIGDIR/restartcounter $PERSISTDIR/status
-fi
-if [ -f $CONFIGDIR/rebootConfig ]; then
-    echo "$(date -Ins -u) move $CONFIGDIR/rebootConfig $PERSISTDIR/status"
-    mv $CONFIGDIR/rebootConfig $PERSISTDIR/status
-fi
-if [ -f $CONFIGDIR/hardwaremodel ]; then
-    echo "$(date -Ins -u) move $CONFIGDIR/hardwaremodel $PERSISTDIR/status"
-    mv $CONFIGDIR/hardwaremodel $PERSISTDIR/status
-fi
-
 # Checking for low diskspace at bootup. If used percentage of
 # /persist directory is more than 70% then we will remove the
 # following sub directories:


### PR DESCRIPTION
Backport of https://github.com/lf-edge/eve/pull/3625 to 10.4

There is some prehistoric code in the onboot script that allows to pass initial hardwaremodel, rebootConfig and restartcounter files via /config partition. However, as this partition became read-only, EVE is no longer able to remove them once applied:
```
move /config/rebootConfig /persist/status
mv: cannot remove '/config/rebootConfig': Read-only file system
```
But while the file cannot be removed, mv command will manage to copy its content to /persist. But this means that on every boot the current value in /persist is overwritten with this initial content from /config. This is very dangerous especially for rebootConfig. Device will end up in endless reboot cycle: on every boot it will replace the last applied reboot counter with whatever the initial value was set in /config, which results in counter mismatch wrt. the reboot counter from device config received from the controller.

I'm not aware of any practical value of setting initial values of these files through /config, therefore I think this functionality can be completely removed.

Signed-off-by: Milan Lenco <milan@zededa.com>
(cherry picked from commit c56cdb9dde52f30d175a6fae214f594515030c9c)