### PR TITLE
add workflow to manually rebuild and push packages and eve

### DIFF
--- a/.github/workflows/buildondemand.yml
+++ b/.github/workflows/buildondemand.yml
@@ -1,0 +1,124 @@
+name: build and publish packages on demand
+on:
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Force build even if no changes'
+        type: boolean
+        required: false
+        default: false
+
+env:
+  FORCE_BUILD: FORCE_BUiLD=${{ inputs.force && '--force' || '' }}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  packages:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: buildjet-4vcpu-ubuntu-2204-arm
+            arch: arm64
+          - os: buildjet-4vcpu-ubuntu-2004
+            arch: amd64
+          - os: buildjet-4vcpu-ubuntu-2004
+            arch: riscv64
+    steps:
+      - name: Starting Report
+        run: |
+          echo Git Ref: ${{ github.ref }}
+          echo GitHub Event: ${{ github.event_name }}
+          echo Disk usage
+          df -h
+          echo Memory
+          free -m
+      - name: Clear repository
+        run: |
+          sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
+          rm -fr ~/.linuxkit
+          docker system prune --all --force --volumes
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: ensure zstd for cache  # this should be removed once the arm64 VM includes zstd
+        if: ${{ matrix.os == 'buildjet-4vcpu-ubuntu-2204-arm' || matrix.os == 'arm64-secure' }}
+        run: |
+          sudo apt install -y zstd
+      - name: ensure packages for cross-arch build
+        if: ${{ matrix.arch == 'riscv64' }}
+        run: |
+          APT_INSTALL="sudo apt install -y binfmt-support qemu-user-static"
+          # the following weird statement is here to speed up the happy path
+          # if the default server is responding -- we can skip apt update
+          $APT_INSTALL || { sudo apt update && $APT_INSTALL ; }
+      - name: update linuxkit cache if available
+        uses: actions/cache@v3
+        with:
+          path: ~/.linuxkit/cache
+          key: linuxkit-${{ matrix.arch }}-${{ github.sha }}
+      - name: Build packages
+        run: |
+          make V=1 PRUNE=1 ZARCH=${{ matrix.arch }} LINUXKIT_PKG_TARGET=push $FORCE_BUILD pkgs
+      - name: Post package report
+        run: |
+          echo Disk usage
+          df -h
+          echo Memory
+          free -m
+          docker system df
+          docker system df -v
+
+  eve:
+    needs: packages  # all packages for all platforms must be built first
+    runs-on: buildjet-4vcpu-ubuntu-2004
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [arm64, amd64]
+        hv: [xen, kvm]
+        include:
+          - arch: riscv64
+            hv: mini
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: update linuxkit cache for our arch
+        id: cache_for_packages
+        if: ${{ matrix.arch != 'amd64' }}  # because our runner arch is amd64; if that changes, this will have to change
+        uses: actions/cache/restore@v3
+        with:
+          path: ~/.linuxkit/cache
+          key: linuxkit-${{ matrix.arch }}-${{ github.sha }}
+          fail-on-cache-miss: true
+
+      - uses: ./.github/actions/run-make
+        with:
+          command: "V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} LINUXKIT_PKG_TARGET=push $FORCE_BUILD eve"
+          dockerhub-token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+          dockerhub-account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
+      - uses: ./.github/actions/run-make
+        if: matrix.arch != 'riscv64'
+        with:
+          command: "V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} LINUXKIT_PKG_TARGET=push $FORCE_BUILD sbom collected_sources compare_sbom_collected_sources publish_sources"
+          dockerhub-token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+          dockerhub-account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
+
+  manifest:
+    if: github.event.repository.full_name == 'lf-edge/eve'
+    runs-on: ubuntu-latest
+    needs: packages
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/run-make
+        with:
+          command: "V=1 LINUXKIT_PKG_TARGET=manifest pkgs"
+          dockerhub-token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+          dockerhub-account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}


### PR DESCRIPTION
Creates a new GitHub action workflow that builds and publishes all packages and eve, according to the latest HEAD off of `master`. Optionally, can tell it to force rebuild.

As this is GHA, I expect it will take us a few runs to get it right.

Also, this reuses a _lot_ of code from `build.yml` and `publish.yml`. As such, I expect we will refactor much of it out shortly.