### PR TITLE
refer to the latest release of the eden tests

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -48,18 +48,18 @@ jobs:
   test_suite_pr:
     needs: check_pr_publish
     if: github.event.review.state == 'approved'
-    uses: lf-edge/eden/.github/workflows/test.yml@0.9.2
+    uses: lf-edge/eden/.github/workflows/test.yml@0.9.3
     with:
       eve_image: "evebuild/danger:pr${{ github.event.pull_request.number  }}"
 
   test_suite_master:
     if: github.ref == 'refs/heads/master'
-    uses: lf-edge/eden/.github/workflows/test.yml@0.9.2
+    uses: lf-edge/eden/.github/workflows/test.yml@0.9.3
     with:
       eve_image: "lfedge/eve:snapshot"
 
   test_suite_tag:
     if: startsWith(github.ref, 'refs/tags')
-    uses: lf-edge/eden/.github/workflows/test.yml@0.9.2
+    uses: lf-edge/eden/.github/workflows/test.yml@0.9.3
     with:
       eve_image: "lfedge/eve:${{ github.ref_name }}"


### PR DESCRIPTION
There are few changes done in the eden tests and we have a new release 0.9.3.  This PR is to bump up the release version to 0.9.3