### PR TITLE
Cleanup BaseOsConfig if controller removes it

### DIFF
--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -273,7 +273,7 @@ func parseBaseOS(getconfigCtx *getconfigContext,
 			log.Functionf("parseBaseOS: deleting %s\n", idStr)
 			unpublishBaseOsConfig(getconfigCtx, idStr)
 		}
-		baseOSPrevConfigHash = nil
+		baseOSPrevConfigHash = []byte{}
 		return
 	}
 	h := sha256.New()
@@ -2735,6 +2735,12 @@ func scheduleDeviceOperation(getconfigCtx *getconfigContext, opsCmd *zconfig.Dev
 
 	if opsCmd == nil {
 		removeDeviceOpsCmdConfig(op)
+		switch op {
+		case types.DeviceOperationReboot:
+			rebootPrevConfigHash = []byte{}
+		case types.DeviceOperationShutdown:
+			shutdownPrevConfigHash = []byte{}
+		}
 		return false
 	}
 
@@ -2823,6 +2829,7 @@ var backupPrevConfigHash []byte
 func scheduleBackup(backup *zconfig.DeviceOpsCmd) {
 	// XXX:FIXME  handle backup semantics
 	if backup == nil {
+		backupPrevConfigHash = []byte{}
 		return
 	}
 	configHash := computeConfigSha(backup)

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -268,6 +268,12 @@ func parseBaseOS(getconfigCtx *getconfigContext,
 	baseOS := config.GetBaseos()
 	if baseOS == nil {
 		log.Function("parseBaseOS: nil config received")
+		items := getconfigCtx.pubBaseOsConfig.GetAll()
+		for idStr := range items {
+			log.Functionf("parseBaseOS: deleting %s\n", idStr)
+			unpublishBaseOsConfig(getconfigCtx, idStr)
+		}
+		baseOSPrevConfigHash = nil
 		return
 	}
 	h := sha256.New()


### PR DESCRIPTION
I noticed that when I deleted all of the BaseOsConfig on the controller it still appeared in EVE (in e.g., /run/zedagent/BaseOsConfig). This fixes that.