### PR TITLE
Usbmanager allow wo pci controller

### DIFF
--- a/pkg/pillar/cmd/usbmanager/rules.go
+++ b/pkg/pillar/cmd/usbmanager/rules.go
@@ -130,7 +130,7 @@ type usbPortPassthroughRule struct {
 }
 
 func (uppr *usbPortPassthroughRule) String() string {
-	return fmt.Sprintf("USB Port Passthrough Rule %s on pci %s", uppr.ud.busnumAndDevnumString(), uppr.ud.usbControllerPCIAddress)
+	return fmt.Sprintf("USB Port Passthrough Rule %s on pci %s", uppr.ud.busnumAndPortnumString(), uppr.ud.usbControllerPCIAddress)
 }
 
 func (uppr *usbPortPassthroughRule) priority() uint8 {

--- a/pkg/pillar/cmd/usbmanager/scanusb.go
+++ b/pkg/pillar/cmd/usbmanager/scanusb.go
@@ -5,6 +5,7 @@ package usbmanager
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -97,6 +98,11 @@ func ueventFile2usbDevice(ueventFilePath string) *usbdevice {
 	}
 	defer ueventFp.Close()
 
+	return ueventFile2usbDeviceImpl(ueventFilePath, ueventFp)
+}
+
+func ueventFile2usbDeviceImpl(ueventFilePath string, ueventFp io.Reader) *usbdevice {
+
 	var busnum uint16
 	var devnum uint16
 	var vendorID uint32
@@ -152,9 +158,6 @@ func ueventFile2usbDevice(ueventFilePath string) *usbdevice {
 	}
 
 	pciAddress := extractPCIaddress(ueventFilePath)
-	if pciAddress == "" {
-		return nil
-	}
 
 	portnum := extractUSBPort(ueventFilePath)
 

--- a/pkg/pillar/cmd/usbmanager/scanusb_test.go
+++ b/pkg/pillar/cmd/usbmanager/scanusb_test.go
@@ -3,6 +3,7 @@
 package usbmanager
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -41,5 +42,39 @@ func TestExtractPCIAddress(t *testing.T) {
 		if port != test.pciAddress {
 			t.Fatalf("expected port %s but got %s, path is %s", test.pciAddress, port, test.path)
 		}
+	}
+}
+
+func TestUeventFile2usbDeviceImplWithoutPCIAddress(t *testing.T) {
+	fileFp := strings.NewReader(`
+MAJOR=189
+MINOR=132
+DEVNAME=bus/usb/002/005
+DEVTYPE=usb_device
+DRIVER=usb
+PRODUCT=951/1666/1
+TYPE=0/0/0
+BUSNUM=002
+DEVNUM=005
+`)
+	ud := ueventFile2usbDeviceImpl("/sys/devices/platform/3610000.xhci/usb2/2-3/2-3.1/uevent", fileFp)
+
+	if ud.busnum != 2 {
+		t.Fatalf("wrong busnum, got %d", ud.busnum)
+	}
+	if ud.devnum != 5 {
+		t.Fatalf("wrong devnum, got %d", ud.devnum)
+	}
+	if ud.vendorID != 2385 {
+		t.Fatalf("wrong vendor id, got %d", ud.vendorID)
+	}
+	if ud.productID != 5734 {
+		t.Fatalf("wrong product id, got %d", ud.productID)
+	}
+	if ud.devicetype != "0/0/0" {
+		t.Fatalf("wrong type, got %s", ud.devicetype)
+	}
+	if ud.usbControllerPCIAddress != "" {
+		t.Fatalf("wrong pci address , got %s", ud.usbControllerPCIAddress)
 	}
 }

--- a/pkg/pillar/cmd/usbmanager/usbdevice.go
+++ b/pkg/pillar/cmd/usbmanager/usbdevice.go
@@ -21,7 +21,7 @@ const (
 type usbAction uint8
 
 func (ud usbdevice) String() string {
-	return fmt.Sprintf("busnum: %s devnum: %s product: %s/%s parentPCIAddress: %s ueventFilePath: %s", ud.busnumString(), ud.devnumString(), ud.vendorIDString(), ud.productIDString(), ud.usbControllerPCIAddress, ud.ueventFilePath)
+	return fmt.Sprintf("busnum: %s portnum: %s product: %s/%s parentPCIAddress: %s ueventFilePath: %s", ud.busnumString(), ud.portnumString(), ud.vendorIDString(), ud.productIDString(), ud.usbControllerPCIAddress, ud.ueventFilePath)
 }
 
 func (ud usbdevice) vendorIDString() string {
@@ -36,16 +36,16 @@ func (ud usbdevice) vendorAndproductIDString() string {
 	return fmt.Sprintf("%s:%s", ud.vendorIDString(), ud.productIDString())
 }
 
-func (ud usbdevice) busnumAndDevnumString() string {
-	return fmt.Sprintf("%s:%s", ud.busnumString(), ud.devnumString())
+func (ud usbdevice) busnumAndPortnumString() string {
+	return fmt.Sprintf("%s:%s", ud.busnumString(), ud.portnumString())
 }
 
 func (ud usbdevice) busnumString() string {
 	return fmt.Sprintf("%03x", ud.busnum)
 }
 
-func (ud usbdevice) devnumString() string {
-	return fmt.Sprintf("%03x", ud.devnum)
+func (ud usbdevice) portnumString() string {
+	return fmt.Sprintf("%s", ud.portnum)
 }
 
 func (ud usbdevice) qemuDeviceName() string {


### PR DESCRIPTION
Make usb passthrough work on devices where the usb controller is not connected via pci.

Tested on an "NVIDIA Jetson Xavier NX Developer Kit" ARM device, but also other devices might have the USB controller attached without PCI.