### PR TITLE
[11.0 stable] Backport of important networking-related patches

### DIFF
--- a/pkg/pillar/cmd/volumemgr/blob.go
+++ b/pkg/pillar/cmd/volumemgr/blob.go
@@ -81,10 +81,6 @@ func downloadBlob(ctx *volumemgrContext, blob *types.BlobStatus) bool {
 		}
 		changed = true
 	}
-	if ds.Pending() {
-		log.Tracef("lookupDownloaderStatus Pending for blob %s", blob.Sha256)
-		return changed
-	}
 	if ds.HasError() {
 		log.Errorf("Received error from downloader for blob %s: %s",
 			blob.Sha256, ds.Error)

--- a/pkg/pillar/scripts/onboot.sh
+++ b/pkg/pillar/scripts/onboot.sh
@@ -115,19 +115,6 @@ if [ ! -d $PERSISTDIR/status ]; then
     mkdir $PERSISTDIR/status
 fi
 
-if [ -f $CONFIGDIR/restartcounter ]; then
-    echo "$(date -Ins -u) move $CONFIGDIR/restartcounter $PERSISTDIR/status"
-    mv $CONFIGDIR/restartcounter $PERSISTDIR/status
-fi
-if [ -f $CONFIGDIR/rebootConfig ]; then
-    echo "$(date -Ins -u) move $CONFIGDIR/rebootConfig $PERSISTDIR/status"
-    mv $CONFIGDIR/rebootConfig $PERSISTDIR/status
-fi
-if [ -f $CONFIGDIR/hardwaremodel ]; then
-    echo "$(date -Ins -u) move $CONFIGDIR/hardwaremodel $PERSISTDIR/status"
-    mv $CONFIGDIR/hardwaremodel $PERSISTDIR/status
-fi
-
 # Checking for low diskspace at bootup. If used percentage of
 # /persist directory is more than 70% then we will remove the
 # following sub directories:

--- a/pkg/pillar/types/downloadertypes.go
+++ b/pkg/pillar/types/downloadertypes.go
@@ -102,9 +102,6 @@ type DownloaderStatus struct {
 	DatastoreIDList []uuid.UUID
 	Target          string // file path where we download the file
 	Name            string
-	PendingAdd      bool
-	PendingModify   bool
-	PendingDelete   bool
 	RefCount        uint      // Zero means not downloaded
 	LastUse         time.Time // When RefCount dropped to zero
 	Expired         bool      // Handshake to client
@@ -128,20 +125,6 @@ func (status DownloaderStatus) Key() string {
 	return status.ImageSha256
 }
 
-func (status DownloaderStatus) Pending() bool {
-	return status.PendingAdd || status.PendingModify || status.PendingDelete
-}
-
-// ClearPendingStatus : Clear Pending Status for DownloaderStatus
-func (status *DownloaderStatus) ClearPendingStatus() {
-	if status.PendingAdd {
-		status.PendingAdd = false
-	}
-	if status.PendingModify {
-		status.PendingModify = false
-	}
-}
-
 // HandleDownloadFail : Do Failure specific tasks
 func (status *DownloaderStatus) HandleDownloadFail(errStr string, retryTime time.Duration, cancelled bool) {
 	errDescription := ErrorDescription{
@@ -153,7 +136,6 @@ func (status *DownloaderStatus) HandleDownloadFail(errStr string, retryTime time
 		errDescription.ErrorRetryCondition = fmt.Sprintf("Will retry in %s; have retried %d times", retryTime, status.RetryCount)
 	}
 	status.SetErrorDescription(errDescription)
-	status.ClearPendingStatus()
 }
 
 // LogCreate :

--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -377,6 +377,15 @@ func VerifyAllIntf(ctx *ZedCloudContext, url string, requiredSuccessCount uint,
 			verifyRV.RemoteTempFailure = true
 		}
 		if err != nil {
+			var noAddrErr *types.IPAddrNotAvailError
+			if errors.As(err, &noAddrErr) {
+				// Interface link exists and is UP but does not have any IP address assigned.
+				// This is expected with app-shared interface and DhcpTypeNone.
+				if !portStatus.IsMgmt && portStatus.Dhcp == types.DhcpTypeNone {
+					verifyRV.IntfStatusMap.RecordSuccess(intf)
+					continue
+				}
+			}
 			log.Errorf("Zedcloud un-reachable via interface %s: %s",
 				intf, err)
 			if sendErr, ok := err.(*SendError); ok && len(sendErr.Attempts) > 0 {

--- a/pkg/wwan/README.md
+++ b/pkg/wwan/README.md
@@ -931,3 +931,32 @@ rtt min/avg/max/mdev = 44.159/66.162/122.881/32.853 ms
 
 Now you have verified that your modem is compatible with EVE OS and you can try to configure
 cellular connection properly from the controller.
+
+## FCC lock
+
+The [FCC](https://www.fcc.gov/) lock is a software lock integrated in WWAN modems shipped by several
+different laptop and edge device vendors, such as Lenovo, Dell, or HP. This locks prevents the WWAN
+modem from being put online until some specific unlock procedure (usually a magic command sent
+to the modem) is executed. The purpose of this lock is to have a way to bind the WWAN modem
+to a specific device, so that the whole bundle of device+modem can go through the FCC certification
+process for radio-enabled devices in the USA. This lock has no other known purpose out of the US
+regulation.
+
+The FCC lock is part of a mutual authentication attempt between modem and device. On the device side,
+BIOS is configured with an allow-list of modems that the device can be used with. On the modem side,
+the FCC lock ensures that the modem is unlocked only by approved devices.
+
+The main challenge faced from the perspective of EVE is that device vendors often provide FCC unlock
+utilities exclusively for Windows or macOS, and their devices are not FCC-certified for use with
+GNU/Linux distributions. Fortunately, the ModemManager developers have successfully reverse-engineered
+FCC unlock procedures for some widely used Sierra Wireless and Quectel modems, providing scripts
+for these operations. In some cases, collaboration between ModemManager developers, device vendors,
+and modem manufacturers has resulted in FCC unlock scripts that have been verified by all parties.
+However, in other instances, there may be a slight risk associated with running reverse-engineered
+unlock procedures. Therefore, ModemManager will not use FCC unlock scripts unless explicitly enabled.
+
+For more information on FCC lock and how ModemManager deals with this challenge, please refer to this
+[article](https://modemmanager.org/docs/modemmanager/fcc-unlock/).
+
+In the case of EVE, the decision has been made to enable all FCC unlock scripts that come with
+ModemManager and then potentially disable only those for which issues are reported.

--- a/pkg/wwan/mm-init.sh
+++ b/pkg/wwan/mm-init.sh
@@ -4,6 +4,24 @@
 
 set -e
 
+# Enable all available FCC-unlock scripts.
+# For more info, see: https://modemmanager.org/docs/modemmanager/fcc-unlock/
+enable_fcc_unlock() {
+  SOURCE_DIR="/usr/share/ModemManager/fcc-unlock.available.d/"
+  TARGET_DIR="/etc/ModemManager/fcc-unlock.d/"
+
+  for SCRIPT in "${SOURCE_DIR}"*; do
+    if [ -f "$SCRIPT" ]; then
+      SCRIPT_NAME="$(basename "$SCRIPT")"
+      ln -sf "$SCRIPT" "${TARGET_DIR}${SCRIPT_NAME}"
+    fi
+  done
+
+  # "Quectel EM05G Smart Gateway" (2c7c:0311) is compatible with the same
+  # FCC unlock script as used for the regular "Quectel EM05G" (2c7c:030a).
+  ln -sf "${SOURCE_DIR}2c7c:030a" "${TARGET_DIR}2c7c:0311"
+}
+
 echo "Loading kernel modules used by ModemManager"
 modprobe -a qcserial usb_wwan qmi_wwan cdc_wdm cdc_mbim cdc_acm
 echo "Kernel modules are loaded"
@@ -21,6 +39,7 @@ udevadm trigger
 echo "Udev daemon started"
 
 echo "Starting Modem Manager"
+enable_fcc_unlock
 ModemManager --debug &
 
 echo "Starting Modem Manager Agent"

--- a/pkg/wwan/mmagent/mmdbus/client.go
+++ b/pkg/wwan/mmagent/mmdbus/client.go
@@ -1243,7 +1243,16 @@ func (c *Client) runSimpleConnect(modemObj dbus.BusObject,
 	var bearerPath dbus.ObjectPath
 	modem := c.modems[string(modemObj.Path())]
 	err := c.callDBusMethod(modemObj, SimpleMethodConnect, &bearerPath, connProps)
-	if err != nil && strings.HasPrefix(err.Error(), "No such interface") && modem != nil {
+	var errIsUseless bool
+	if err != nil {
+		if strings.HasPrefix(err.Error(), "No such interface") {
+			errIsUseless = true
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			errIsUseless = true
+		}
+	}
+	if errIsUseless && modem != nil {
 		// Try to determine more useful connection failure reason.
 		for _, simCard := range modem.Status.SimCards {
 			if !simCard.SlotActivated {


### PR DESCRIPTION
This is a backport of patches from latest master to 11.0 that I believe will be important for the users of the upcoming LTS version (not just bug fixes):

https://github.com/lf-edge/eve/commit/ed98e7dd7192704068392f77d9ffb7ad48f558cb  Remove DownloaderStatus Pending flags 
https://github.com/lf-edge/eve/commit/c56cdb9dde52f30d175a6fae214f594515030c9c Stop trying to move config from read-only config partition
https://github.com/lf-edge/eve/commit/258fe8aaef558473d83a7c8fac331202a01af509 Not having IP address with DhcpTypeNone is expected 
https://github.com/lf-edge/eve/commit/f0011351f61e147d88aed56f8efac7cc657d72e8 wwan: try to find more useful reason for failure than DeadlineExceeded 
https://github.com/lf-edge/eve/commit/62737d617cfec929212c80e54ec9d37896619b80 ModemManager: enable all available FCC-unlock scripts 