### PR TITLE
[11.0 stable] Align kernels with master and revert QEMU's MSR errors fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,10 +212,7 @@ ifeq ($(UNAME_S)_$(ZARCH),Darwin_arm64)
 QEMU_DEFAULT_MACHINE=virt,
 endif
 QEMU_ACCEL_Y_Darwin_amd64=-machine q35,accel=hvf,usb=off -cpu kvm64,kvmclock=off
-# NOTE: -vmx-true-ctls and -vmx-secondary-ctls is used as a workaround to
-# mitigate QEMU crashes due to MSR access errors like the following:
-# "error: failed to set MSR 0x48b to 0x137bff00000000"
-QEMU_ACCEL_Y_Linux_amd64=-machine q35,accel=kvm,usb=off,dump-guest-core=off -cpu host,-vmx-true-ctls,-vmx-secondary-ctls,invtsc=on,kvmclock=off -machine kernel-irqchip=split -device intel-iommu,intremap=on,caching-mode=on,aw-bits=48
+QEMU_ACCEL_Y_Linux_amd64=-machine q35,accel=kvm,usb=off,dump-guest-core=off -cpu host,invtsc=on,kvmclock=off -machine kernel-irqchip=split -device intel-iommu,intremap=on,caching-mode=on,aw-bits=48
 # -machine virt,gic_version=3
 QEMU_ACCEL_Y_Darwin_arm64=-machine $(QEMU_DEFAULT_MACHINE)accel=hvf,usb=off -cpu host
 QEMU_ACCEL_Y_Linux_arm64=-machine virt,accel=kvm,usb=off,dump-guest-core=off -cpu host

--- a/kernel-commits.mk
+++ b/kernel-commits.mk
@@ -1,7 +1,7 @@
-KERNEL_COMMIT_amd64_v5.10.186_generic = c23a03114a05
-KERNEL_COMMIT_amd64_v6.1.38_generic = 0c3194d84
-KERNEL_COMMIT_amd64_v6.1.38_rt = 585c1cf1e
-KERNEL_COMMIT_arm64_v5.10.104_nvidia = e6cd9a55f
-KERNEL_COMMIT_arm64_v5.10.186_generic = d728c693c149
-KERNEL_COMMIT_arm64_v6.1.38_generic = b18cb9e3e
-KERNEL_COMMIT_riscv64_v6.1.38_generic = 105a2b9bd8e7
+KERNEL_COMMIT_amd64_v5.10.186_generic = 27965edfa82a
+KERNEL_COMMIT_amd64_v6.1.38_generic = d2da815271a2
+KERNEL_COMMIT_amd64_v6.1.38_rt = 332ec0cf9b0e
+KERNEL_COMMIT_arm64_v5.10.104_nvidia = e8383fe4cf0b
+KERNEL_COMMIT_arm64_v5.10.186_generic = e1f7e4bb26e4
+KERNEL_COMMIT_arm64_v6.1.38_generic = 261c4f91e39c
+KERNEL_COMMIT_riscv64_v6.1.38_generic = 62076de26044

--- a/kernel-commits.mk
+++ b/kernel-commits.mk
@@ -1,0 +1,7 @@
+KERNEL_COMMIT_amd64_v5.10.186_generic = c23a03114a05
+KERNEL_COMMIT_amd64_v6.1.38_generic = 0c3194d84
+KERNEL_COMMIT_amd64_v6.1.38_rt = 585c1cf1e
+KERNEL_COMMIT_arm64_v5.10.104_nvidia = e6cd9a55f
+KERNEL_COMMIT_arm64_v5.10.186_generic = d728c693c149
+KERNEL_COMMIT_arm64_v6.1.38_generic = b18cb9e3e
+KERNEL_COMMIT_riscv64_v6.1.38_generic = 105a2b9bd8e7

--- a/kernel-version.mk
+++ b/kernel-version.mk
@@ -33,8 +33,6 @@ ifeq ($(ZARCH), amd64)
     # either generic or rt
     KERNEL_FLAVOR=$(PLATFORM)
     KERNEL_VERSION=v6.1.38
-    KERNEL_COMMIT_generic=0c3194d84
-    KERNEL_COMMIT_rt=585c1cf1e
 else ifeq ($(ZARCH), arm64)
     ifeq ($(PLATFORM), nvidia)
         KERNEL_FLAVOR=nvidia
@@ -43,25 +41,25 @@ else ifeq ($(ZARCH), arm64)
         KERNEL_FLAVOR=generic
         KERNEL_VERSION=v6.1.38
     endif
-    KERNEL_COMMIT_generic=b18cb9e3e
-    KERNEL_COMMIT_nvidia=e6cd9a55f
 else ifeq ($(ZARCH), riscv64)
     KERNEL_VERSION=v6.1.38
     KERNEL_FLAVOR=generic
-    KERNEL_COMMIT_generic=b52e17b4b
 endif
 
-# at this point ZARCH and FLAVOR must be defined. Check that we defined a commit for combination
-ifeq ($(origin KERNEL_COMMIT_$(KERNEL_FLAVOR)), undefined)
-    $(error "KERNEL_COMMIT_$(KERNEL_FLAVOR) is not defined. did you introduced new platform or ARCH?")
-endif
+include kernel-commits.mk
 
 # check if KERNEL_VERSION is defined
 ifeq ($(origin KERNEL_VERSION), undefined)
     $(error "KERNEL_VERSION is not defined. did you introduced new platform or ARCH?")
 endif
 
-KERNEL_COMMIT=$(KERNEL_COMMIT_$(KERNEL_FLAVOR))
+# at this point ZARCH, KERNEL_VERSION and FLAVOR must be defined.
+# Check that we defined a commit for combination
+ifeq ($(origin KERNEL_COMMIT_$(ZARCH)_$(KERNEL_VERSION)_$(KERNEL_FLAVOR)), undefined)
+    $(error "KERNEL_COMMIT_$(KERNEL_FLAVOR) is not defined. did you introduce new platform or ARCH?")
+endif
+
+KERNEL_COMMIT=$(KERNEL_COMMIT_$(ZARCH)_$(KERNEL_VERSION)_$(KERNEL_FLAVOR))
 KERNEL_BRANCH = eve-kernel-$(ZARCH)-$(KERNEL_VERSION)-$(KERNEL_FLAVOR)
 KERNEL_DOCKER_TAG = $(KERNEL_BRANCH)-$(KERNEL_COMMIT)-$(KERNEL_COMPILER)
 

--- a/kernel-version.mk
+++ b/kernel-version.mk
@@ -44,7 +44,7 @@ else ifeq ($(ZARCH), arm64)
         KERNEL_VERSION=v6.1.38
     endif
     KERNEL_COMMIT_generic=b18cb9e3e
-    KERNEL_COMMIT_nvidia=b0b5f116e
+    KERNEL_COMMIT_nvidia=e6cd9a55f
 else ifeq ($(ZARCH), riscv64)
     KERNEL_VERSION=v6.1.38
     KERNEL_FLAVOR=generic


### PR DESCRIPTION
The 11.0 was created in-between of migration from 5.10 to 6.1 kernel, so some kernel changes were missing. Better we have coming LTS with SBOM generation and aligned SHAs with eve master. (CC: @rucoder )

Also apply  forgotten revert of the "Makefile: Workaround to fix QEMU's MSR errors", which causes guest panics with the "KVM: entry failed, hardware error 0x80000021)". This patch makes possible to run EVE in QEMU (makes sense for developers) (CC: @rene )

