### PR TITLE
xen-tools/init-initrd: load wireguard for a container app

### DIFF
--- a/pkg/xen-tools/initrd/init-initrd
+++ b/pkg/xen-tools/initrd/init-initrd
@@ -108,6 +108,18 @@ then
     done
 fi
 
+# Make modules available for hosting Vm
+mount --bind /mnt/modules /lib/modules
+mount_res=$?
+echo "Mount /mnt/modules as /lib/modules, result $mount_res"
+
+#
+# Here load modules needed for a container
+#
+modprobe wireguard
+mod_res=$?
+echo "Modprobe wireguard, result $mod_res"
+
 # mount modules shared by EVE-OS in /mnt/modules to /lib/modules
 # if /lib/modules inside container is not empty we will silently ignore the content
 # we use overlayfs to allow replacing of modules from user's entrypoint scripts


### PR DESCRIPTION
Turns out that no modules are loaded by the Vm, which hosts container app. In order to modprobe a module /mnt/modules should be bind-mounted as /lib/modules.

In this patch only wireguard is loaded explicitly.