### PR TITLE
Patch Envelopes: Fix PatchEnvelopeAppInstUsage status

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -1055,7 +1055,7 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 		ReportAppInfo.AppVersion = aiStatus.UUIDandVersion.Version
 		ReportAppInfo.AppName = aiStatus.DisplayName
 		ReportAppInfo.State = aiStatus.State.ZSwState()
-		ReportAppInfo.PatchEnvelope = composePatchEnvelopeUsage(uuid, ctx)
+		ReportAppInfo.PatchEnvelope = composePatchEnvelopeUsage(aiStatus.UUIDandVersion.UUID.String(), ctx)
 		if !aiStatus.ErrorTime.IsZero() {
 			errInfo := encodeErrorInfo(
 				aiStatus.ErrorAndTimeWithSource.ErrorDescription)


### PR DESCRIPTION
This PR does two things:

1) It makes use app instance UUID for `PublishAppInfoToZedcloud` this function 
2) It introduces publishing app instance info to controller by timer

Timer is hard-coded for sending information every 5 minutes. I don't think that we need to change this timer, maybe we make a constant.