### PR TITLE
update linuxkit version for sbom fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,7 +295,7 @@ DOCKER_GO = _() { $(SET_X); mkdir -p $(CURDIR)/.go/src/$${3:-dummy} ; mkdir -p $
 
 PARSE_PKGS=$(if $(strip $(EVE_HASH)),EVE_HASH=)$(EVE_HASH) DOCKER_ARCH_TAG=$(DOCKER_ARCH_TAG) KERNEL_TAG=$(KERNEL_TAG) ./tools/parse-pkgs.sh
 LINUXKIT=$(BUILDTOOLS_BIN)/linuxkit
-LINUXKIT_VERSION=d1a0596bee704a8d06855c90b495ffadea5fb8ab
+LINUXKIT_VERSION=e115ce8dca74e7d1307490879fffec170f2fce34
 LINUXKIT_SOURCE=https://github.com/linuxkit/linuxkit.git
 LINUXKIT_OPTS=$(if $(strip $(EVE_HASH)),--hash) $(EVE_HASH) $(if $(strip $(EVE_REL)),--release) $(EVE_REL)
 LINUXKIT_PKG_TARGET=build


### PR DESCRIPTION
linuxkit recently had a patch for a case where sometimes, if a container image included in the `build.yaml` has an sbom, it can break the creation of the final image. This version fixed it.