### PR TITLE
pillar/zedrouter: introduce legacy MAC address generation mode

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -53,6 +53,7 @@
 | netdump.downloader.http.with.fieldvalue | boolean | false | include HTTP header field values in captured network traces for download requests (beware: may contain secrets, such as datastore credentials). |
 | network.switch.enable.arpsnoop | boolean | true | enable ARP Snooping on switch Network Instance, may need a device reboot to take effect |
 | wwan.query.visible.providers | bool | false | enable to periodically (once per hour) query the set of visible cellular service providers and publish them under WirelessStatus (for every modem) |
+| network.local.legacy.mac.address | bool | false | enables legacy MAC address generation for local network instances for those EVE nodes where changing MAC addresses in applications will lead to incorrect network configuration |
 
 In addition, there can be per-agent settings.
 The Per-agent settings begin with "agent.*agentname*.*setting*"

--- a/pkg/pillar/cmd/zedrouter/ipam.go
+++ b/pkg/pillar/cmd/zedrouter/ipam.go
@@ -56,6 +56,12 @@ func (z *zedrouter) generateAppMac(appUUID uuid.UUID, adapterNum int, appNum int
 	case types.NetworkInstanceTypeSwitch:
 		return net.HardwareAddr{0x02, 0x16, 0x3e, hash[0], hash[1], hash[2]}
 	case types.NetworkInstanceTypeLocal:
+		if z.localLegacyMACAddr {
+			z.log.Noticef("generateAppMac: legacy MAC address for app %v", appUUID)
+			// Room to handle multiple underlays in 5th byte
+			return net.HardwareAddr{0x00, 0x16, 0x3e, 0x00, byte(adapterNum), byte(appNum)}
+		}
+		z.log.Noticef("generateAppMac: random MAC address for app %v", appUUID)
 		mac := net.HardwareAddr{hash[0], hash[1], hash[2], hash[3], hash[4], hash[5]}
 		// Mark this MAC address as unicast by setting the I/G bit to zero.
 		mac[0] &= ^byte(1)

--- a/pkg/pillar/cmd/zedrouter/pubsubhandlers.go
+++ b/pkg/pillar/cmd/zedrouter/pubsubhandlers.go
@@ -52,6 +52,7 @@ func (z *zedrouter) handleGlobalConfigImpl(ctxArg interface{}, key string,
 			z.metricInterval = metricInterval
 		}
 		z.enableArpSnooping = gcp.GlobalValueBool(types.EnableARPSnoop)
+		z.localLegacyMACAddr = gcp.GlobalValueBool(types.NetworkLocalLegacyMACAddress)
 		z.niReconciler.ApplyUpdatedGCP(z.runCtx, *gcp)
 	}
 	z.log.Functionf("handleGlobalConfigImpl done for %s", key)

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -83,8 +83,9 @@ type zedrouter struct {
 	runCtx context.Context
 
 	// CLI options
-	versionPtr        *bool
-	enableArpSnooping bool // enable/disable switch NI arp snooping
+	versionPtr         *bool
+	enableArpSnooping  bool // enable/disable switch NI arp snooping
+	localLegacyMACAddr bool // switch to legacy MAC address generation
 
 	agentStartTime     time.Time
 	receivedConfigTime time.Time

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -284,6 +284,14 @@ const (
 	// network traces for download requests.
 	// Beware: may contain secrets, such as datastore credentials.
 	NetDumpDownloaderHTTPWithFieldValue GlobalSettingKey = "netdump.downloader.http.with.fieldvalue"
+	// NetworkLocalLegacyMACAddress : Enables legacy MAC address generation for
+	// local network instances. The legacy generation is not "that" random and
+	// probability of repeating MAC addresses across nodes is high. Later the
+	// algorithm was changed and more randomness was introduced, but some
+	// applications may be already configured with already allocated MAC
+	// address, and MAC address change on EVE node upgrade (switch from old
+	// generation logic to new one) can cause problems with the guest network.
+	NetworkLocalLegacyMACAddress GlobalSettingKey = "network.local.legacy.mac.address"
 )
 
 // AgentSettingKey - keys for per-agent settings
@@ -856,6 +864,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddBoolItem(ConsoleAccess, true) // Controller likely default to false
 	configItemSpecMap.AddBoolItem(EnableARPSnoop, true)
 	configItemSpecMap.AddBoolItem(WwanQueryVisibleProviders, false)
+	configItemSpecMap.AddBoolItem(NetworkLocalLegacyMACAddress, false)
 
 	// Add TriState Items
 	configItemSpecMap.AddTriStateItem(NetworkFallbackAnyEth, TS_DISABLED)
@@ -877,6 +886,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddIntItem(NetDumpTopicMaxCount, 10, 1, 0xFFFFFFFF)
 	configItemSpecMap.AddBoolItem(NetDumpDownloaderPCAP, false)
 	configItemSpecMap.AddBoolItem(NetDumpDownloaderHTTPWithFieldValue, false)
+
 	return configItemSpecMap
 }
 

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -188,6 +188,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		AllowLogFastupload,
 		EnableARPSnoop,
 		WwanQueryVisibleProviders,
+		NetworkLocalLegacyMACAddress,
 		// TriState Items
 		NetworkFallbackAnyEth,
 		MaintenanceMode,


### PR DESCRIPTION
The legacy MAC generation is not "that" random and probability of repeating MAC addresses across nodes is high. Later the generation algorithm was changed and more randomness was introduced, but some applications may be already configured with already allocated MAC address, and MAC address change on EVE node upgrade (switch from old generation logic to new one) can cause problems with the guest network.

This commit introduces old (but still so beloved) legacy MAC address generation, by setting the 'zedrouter.legacy.mac.address' to true.

This can help eliminate guest network misconfiguration on EVE node upgrades for certain cases by setting the 'zedrouter.legacy.mac.address' to true in advance, prior the upgrade.

The legacy algorithm was extracted from code prior the following patch: fdd167efa627 ("Generate random MAC addresses even for local network instances")