### PR TITLE
[9.4-stable] Backport #3607 (eventlog entries from measure-config)

### DIFF
--- a/pkg/pillar/evetpm/tpm.go
+++ b/pkg/pillar/evetpm/tpm.go
@@ -16,7 +16,6 @@ import (
 	"io/ioutil"
 	"math/big"
 	"os"
-	"path/filepath"
 	"sort"
 	"unsafe"
 
@@ -89,11 +88,7 @@ const (
 
 	// measurementLogFile is a kernel exposed variable that contains the
 	// TPM measurements and events log.
-	measurementLogFile = "binary_bios_measurements"
-
-	// syfsTpmDir is directory that TPMs get mapped on sysfs, and it contains
-	// measurement logs.
-	syfsTpmDir = "/hostfs/sys/kernel/security/tpm*"
+	measurementLogFile = "/hostfs/sys/kernel/security/tpm0/binary_bios_measurements"
 )
 
 // PCRBank256Status stores info about support for
@@ -650,14 +645,14 @@ func SealDiskKey(log *base.LogObject, key []byte, pcrSel tpm2.PCRSelection) erro
 		log.Warnf("saving snapshot of sealing PCRs failed: %s", err)
 	}
 
-	// Backup the previous pair of logs if any, so at most we have two pairs of
-	// measurement logs (per available tpm devices). This is needed because if the
-	// failing devices get connected to the controller and collects the backup key,
-	// we end up here again and will override the MeasurementLogSealSuccess  with
-	// current measurement log (which is same as the content of MeasurementLogSealFail)
-	// and lose the ability to diff and diagnose the issue.
+	// In order to not lose the ability to diff and diagnose the issue,
+	// first backup the previous pair of logs (if any). This is needed because
+	// once the failing devices get connected to the controller to fetch the
+	// backup key, we end up here again and it'll override the MeasurementLogSealSuccess
+	// file content with current tpm measurement logs (which is same as the
+	// content of MeasurementLogSealFail).
 	if err := backupCopiedMeasurementLogs(); err != nil {
-		log.Warnf("collecting previous snapshot of TPM event log failed: %s", err)
+		log.Warnf("copying previous snapshot of TPM event log failed: %s", err)
 	}
 
 	// fresh start, remove old copies of measurement logs.
@@ -665,7 +660,8 @@ func SealDiskKey(log *base.LogObject, key []byte, pcrSel tpm2.PCRSelection) erro
 		log.Warnf("removing old copies of TPM measurement log failed: %s", err)
 	}
 
-	// save a copy of the current measurement log
+	// save a copy of the current measurement log, this is also called
+	// if unseal fails to have copy when we fail to unlock the vault.
 	if err := copyMeasurementLog(measurementLogSealSuccess); err != nil {
 		log.Warnf("copying current TPM measurement log failed: %s", err)
 	}
@@ -850,127 +846,42 @@ func pcrBankSHA256EnabledHelper() bool {
 	return err == nil
 }
 
-func getLogCopyPath(destination string, tpmIndex int) string {
-	return fmt.Sprintf("%s-tpm%d", destination, tpmIndex)
-}
-
-func getLogBackupPath(destination string) string {
-	return fmt.Sprintf("%s-backup", destination)
-}
-
-func getMappedTpmsPath() ([]string, error) {
-	paths, err := filepath.Glob(syfsTpmDir)
-	if err != nil {
-		return nil, fmt.Errorf("failed to enumerate TPM(s) in sysfs: %w", err)
-	} else if len(paths) == 0 {
-		return nil, fmt.Errorf("found no TPM in sysfs")
-	}
-
-	return paths, nil
-}
-
-func countMappedTpms() (int, error) {
-	paths, err := getMappedTpmsPath()
-	if err != nil {
-		return 0, fmt.Errorf("getMappedTpmsPath failed: %w", err)
-	}
-
-	return len(paths), nil
-}
-
-func getMeasurementLogFiles() ([]string, error) {
-	paths, err := getMappedTpmsPath()
-	if err != nil {
-		return nil, fmt.Errorf("getMappedTpmsPath failed: %w", err)
-	}
-
-	enumerated := make([]string, 0)
-	for _, path := range paths {
-		fullPath := filepath.Join(path, measurementLogFile)
-		if fileutils.FileExists(nil, fullPath) {
-			enumerated = append(enumerated, fullPath)
-		}
-	}
-
-	return enumerated, nil
-}
-
 func backupCopiedMeasurementLogs() error {
-	counted, err := countMappedTpms()
-	if err != nil {
-		return fmt.Errorf("countMappedTPMs failed: %w", err)
-	}
+	sealSuccessBackupPath := fmt.Sprintf("%s-backup", measurementLogSealSuccess)
+	unsealFailBackupPath := fmt.Sprintf("%s-backup", measurementLogUnsealFail)
 
-	leftToBackup := counted
-	for i := 0; i < counted; i++ {
-		sealSuccessPath := getLogCopyPath(measurementLogSealSuccess, i)
-		unsealFailPath := getLogCopyPath(measurementLogUnsealFail, i)
-		if fileutils.FileExists(nil, sealSuccessPath) && fileutils.FileExists(nil, unsealFailPath) {
-			sealSuccessBackupPath := getLogBackupPath(sealSuccessPath)
-			unsealFailBackupPath := getLogBackupPath(unsealFailPath)
-			if err := os.Rename(sealSuccessPath, sealSuccessBackupPath); err != nil {
-				fmt.Fprintf(os.Stderr, "failed to backup tpm%d \"seal success\" previously copied measurement log: %v", i, err)
-				continue
-			}
-			if err := os.Rename(unsealFailPath, unsealFailBackupPath); err != nil {
-				fmt.Fprintf(os.Stderr, "failed to backup tpm%d \"unseal fail\" previously copied measurement log: %v", i, err)
-				_ = os.Rename(sealSuccessBackupPath, sealSuccessPath)
-				continue
-			}
+	if fileutils.FileExists(nil, measurementLogSealSuccess) {
+		if err := os.Rename(measurementLogSealSuccess, sealSuccessBackupPath); err != nil {
+			return fmt.Errorf("failed to backup tpm \"seal success event\" previously copied measurement log: %v", err)
 		}
-
-		leftToBackup--
 	}
 
-	if leftToBackup != 0 {
-		return fmt.Errorf("failed to backup %d number of previously copied TPM measurement logs", leftToBackup)
+	if fileutils.FileExists(nil, measurementLogUnsealFail) {
+		if err := os.Rename(measurementLogUnsealFail, unsealFailBackupPath); err != nil {
+			_ = os.Rename(sealSuccessBackupPath, measurementLogSealSuccess)
+			return fmt.Errorf("failed to backup tpm \"unseal fail event\" previously copied measurement log: %v", err)
+		}
 	}
 
 	return nil
 }
 
 func removeCopiedMeasurementLogs() error {
-	counted, err := countMappedTpms()
-	if err != nil {
-		return fmt.Errorf("countMappedTPMs failed: %w", err)
-	}
-
-	for i := 0; i < counted; i++ {
-		sealSuccessPath := getLogCopyPath(measurementLogSealSuccess, i)
-		unsealFailPath := getLogCopyPath(measurementLogUnsealFail, i)
-		_ = os.Remove(sealSuccessPath)
-		_ = os.Remove(unsealFailPath)
-	}
+	_ = os.Remove(measurementLogSealSuccess)
+	_ = os.Remove(measurementLogUnsealFail)
 
 	return nil
 }
 
 func copyMeasurementLog(dstPath string) error {
-	paths, err := getMeasurementLogFiles()
+	measurementLogContent, err := os.ReadFile(measurementLogFile)
 	if err != nil {
-		return fmt.Errorf("enumSourceEventLogFiles failed: %w", err)
+		return fmt.Errorf("failed to read TPM measurements log file: %v", err)
 	}
 
-	leftToCopy := len(paths)
-	for i, path := range paths {
-		measurementLogContent, err := os.ReadFile(path)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "failed to read stored measurement log file: %v", err)
-			continue
-		}
-
-		copyPath := getLogCopyPath(dstPath, i)
-		err = fileutils.WriteRename(copyPath, measurementLogContent)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "failed to copy stored measurement log file: %v", err)
-			continue
-		}
-
-		leftToCopy--
-	}
-
-	if leftToCopy != 0 {
-		return fmt.Errorf("failed to copy %d number of stored measurement log files", leftToCopy)
+	err = fileutils.WriteRename(dstPath, measurementLogContent)
+	if err != nil {
+		return fmt.Errorf("failed to copy stored measurement log file: %v", err)
 	}
 
 	return nil

--- a/pkg/pillar/evetpm/tpm.go
+++ b/pkg/pillar/evetpm/tpm.go
@@ -86,6 +86,9 @@ const (
 	// fails to unseal the vault key from TPM.
 	measurementLogUnsealFail = types.PersistStatusDir + "/tpm_measurement_unseal_fail"
 
+	// measurefsTpmEventLog is the file containing the event log from the measure-config
+	measurefsTpmEventLog = types.PersistStatusDir + "/measurefs_tpm_event_log"
+
 	// measurementLogFile is a kernel exposed variable that contains the
 	// TPM measurements and events log.
 	measurementLogFile = "/hostfs/sys/kernel/security/tpm0/binary_bios_measurements"
@@ -448,13 +451,13 @@ func writeDiskKey(key []byte) error {
 		tpm2.AttrOwnerWrite|tpm2.AttrOwnerRead,
 		uint16(len(key)),
 	); err != nil {
-		return fmt.Errorf("NVDefineSpace failed: %v", err)
+		return fmt.Errorf("NVDefineSpace failed: %w", err)
 	}
 
 	// Write the data
 	if err := tpm2.NVWrite(rw, tpm2.HandleOwner, TpmDiskKeyHdl,
 		EmptyPassword, key, 0); err != nil {
-		return fmt.Errorf("NVWrite failed: %v", err)
+		return fmt.Errorf("NVWrite failed: %w", err)
 	}
 	return nil
 }
@@ -470,7 +473,7 @@ func readDiskKey() ([]byte, error) {
 	keyBytes, err := tpm2.NVReadEx(rw, TpmDiskKeyHdl,
 		tpm2.HandleOwner, EmptyPassword, 0)
 	if err != nil {
-		return nil, fmt.Errorf("NVReadEx failed: %v", err)
+		return nil, fmt.Errorf("NVReadEx failed: %w", err)
 	}
 	return keyBytes, nil
 }
@@ -590,12 +593,12 @@ func SealDiskKey(log *base.LogObject, key []byte, pcrSel tpm2.PCRSelection) erro
 
 	session, policy, err := PolicyPCRSession(rw, pcrSel)
 	if err != nil {
-		return fmt.Errorf("PolicyPCRSession failed: %v", err)
+		return fmt.Errorf("PolicyPCRSession failed: %w", err)
 	}
 
 	//Don't need the handle, we need only the policy for sealing
 	if err := tpm2.FlushContext(rw, session); err != nil {
-		return fmt.Errorf("flushing session handle %v failed: %v", session, err)
+		return fmt.Errorf("flushing session handle %v failed: %w", session, err)
 	}
 
 	priv, public, err := tpm2.Seal(rw, TpmSRKHdl, EmptyPassword, EmptyPassword, policy, key)
@@ -613,13 +616,13 @@ func SealDiskKey(log *base.LogObject, key []byte, pcrSel tpm2.PCRSelection) erro
 		tpm2.AttrOwnerWrite|tpm2.AttrOwnerRead,
 		uint16(len(priv)),
 	); err != nil {
-		return fmt.Errorf("NVDefineSpace %v failed: %v", TpmSealedDiskPrivHdl, err)
+		return fmt.Errorf("NVDefineSpace %v failed: %w", TpmSealedDiskPrivHdl, err)
 	}
 
 	// Write the private data
 	if err := tpm2.NVWrite(rw, tpm2.HandleOwner, TpmSealedDiskPrivHdl,
 		EmptyPassword, priv, 0); err != nil {
-		return fmt.Errorf("NVWrite %v failed: %v", TpmSealedDiskPrivHdl, err)
+		return fmt.Errorf("NVWrite %v failed: %w", TpmSealedDiskPrivHdl, err)
 	}
 
 	// Define space in NV storage
@@ -632,12 +635,12 @@ func SealDiskKey(log *base.LogObject, key []byte, pcrSel tpm2.PCRSelection) erro
 		tpm2.AttrOwnerWrite|tpm2.AttrOwnerRead,
 		uint16(len(public)),
 	); err != nil {
-		return fmt.Errorf("NVDefineSpace %v failed: %v", TpmSealedDiskPubHdl, err)
+		return fmt.Errorf("NVDefineSpace %v failed: %w", TpmSealedDiskPubHdl, err)
 	}
 	// Write the public data
 	if err := tpm2.NVWrite(rw, tpm2.HandleOwner, TpmSealedDiskPubHdl,
 		EmptyPassword, public, 0); err != nil {
-		return fmt.Errorf("NVWrite %v failed: %v", TpmSealedDiskPubHdl, err)
+		return fmt.Errorf("NVWrite %v failed: %w", TpmSealedDiskPubHdl, err)
 	}
 
 	// save a snapshot of current PCR values
@@ -656,9 +659,7 @@ func SealDiskKey(log *base.LogObject, key []byte, pcrSel tpm2.PCRSelection) erro
 	}
 
 	// fresh start, remove old copies of measurement logs.
-	if err := removeCopiedMeasurementLogs(); err != nil {
-		log.Warnf("removing old copies of TPM measurement log failed: %s", err)
-	}
+	removeCopiedMeasurementLogs()
 
 	// save a copy of the current measurement log, this is also called
 	// if unseal fails to have copy when we fail to unlock the vault.
@@ -698,13 +699,13 @@ func UnsealDiskKey(pcrSel tpm2.PCRSelection) ([]byte, error) {
 	priv, err := tpm2.NVReadEx(rw, TpmSealedDiskPrivHdl,
 		tpm2.HandleOwner, EmptyPassword, 0)
 	if err != nil {
-		return nil, fmt.Errorf("NVReadEx %v failed: %v", TpmSealedDiskPrivHdl, err)
+		return nil, fmt.Errorf("NVReadEx %v failed: %w", TpmSealedDiskPrivHdl, err)
 	}
 	// Read all of the data with NVReadEx
 	pub, err := tpm2.NVReadEx(rw, TpmSealedDiskPubHdl,
 		tpm2.HandleOwner, EmptyPassword, 0)
 	if err != nil {
-		return nil, fmt.Errorf("NVReadEx %v failed: %v", TpmSealedDiskPubHdl, err)
+		return nil, fmt.Errorf("NVReadEx %v failed: %w", TpmSealedDiskPubHdl, err)
 	}
 
 	sealedObjHandle, _, err := tpm2.Load(rw, TpmSRKHdl, "", pub, priv)
@@ -715,7 +716,7 @@ func UnsealDiskKey(pcrSel tpm2.PCRSelection) ([]byte, error) {
 
 	session, _, err := PolicyPCRSession(rw, pcrSel)
 	if err != nil {
-		return nil, fmt.Errorf("PolicyPCRSession failed: %v", err)
+		return nil, fmt.Errorf("PolicyPCRSession failed: %w", err)
 	}
 	defer tpm2.FlushContext(rw, session)
 
@@ -753,7 +754,7 @@ func PolicyPCRSession(rw io.ReadWriteCloser, pcrSel tpm2.PCRSelection) (tpmutil.
 		/*symmetric=*/ tpm2.AlgNull,
 		/*authHash=*/ tpm2.AlgSHA256)
 	if err != nil {
-		return tpm2.HandleNull, nil, fmt.Errorf("StartAuthSession failed: %v", err)
+		return tpm2.HandleNull, nil, fmt.Errorf("StartAuthSession failed: %w", err)
 	}
 	defer func() {
 		if session != tpm2.HandleNull && err != nil {
@@ -762,7 +763,7 @@ func PolicyPCRSession(rw io.ReadWriteCloser, pcrSel tpm2.PCRSelection) (tpmutil.
 	}()
 
 	if err = tpm2.PolicyPCR(rw, session, nil, pcrSel); err != nil {
-		return session, nil, fmt.Errorf("PolicyPCR failed: %v", err)
+		return session, nil, fmt.Errorf("PolicyPCR failed: %w", err)
 	}
 
 	policy, err := tpm2.PolicyGetDigest(rw, session)
@@ -852,36 +853,48 @@ func backupCopiedMeasurementLogs() error {
 
 	if fileutils.FileExists(nil, measurementLogSealSuccess) {
 		if err := os.Rename(measurementLogSealSuccess, sealSuccessBackupPath); err != nil {
-			return fmt.Errorf("failed to backup tpm \"seal success event\" previously copied measurement log: %v", err)
+			return fmt.Errorf("failed to backup tpm \"seal success event\" previously copied measurement log: %w", err)
 		}
 	}
 
 	if fileutils.FileExists(nil, measurementLogUnsealFail) {
 		if err := os.Rename(measurementLogUnsealFail, unsealFailBackupPath); err != nil {
 			_ = os.Rename(sealSuccessBackupPath, measurementLogSealSuccess)
-			return fmt.Errorf("failed to backup tpm \"unseal fail event\" previously copied measurement log: %v", err)
+			return fmt.Errorf("failed to backup tpm \"unseal fail event\" previously copied measurement log: %w", err)
 		}
 	}
 
 	return nil
 }
 
-func removeCopiedMeasurementLogs() error {
-	_ = os.Remove(measurementLogSealSuccess)
-	_ = os.Remove(measurementLogUnsealFail)
-
-	return nil
+func removeCopiedMeasurementLogs() {
+	os.Remove(measurementLogSealSuccess)
+	os.Remove(measurementLogUnsealFail)
 }
 
 func copyMeasurementLog(dstPath string) error {
-	measurementLogContent, err := os.ReadFile(measurementLogFile)
+	var appendErr error
+	tpmEventLog, err := os.ReadFile(measurementLogFile)
 	if err != nil {
-		return fmt.Errorf("failed to read TPM measurements log file: %v", err)
+		return fmt.Errorf("failed to read TPM measurements log file: %w", err)
 	}
 
-	err = fileutils.WriteRename(dstPath, measurementLogContent)
+	measurefsEventLog, err := os.ReadFile(measurefsTpmEventLog)
+	if err == nil {
+		// append the measurefs event log to the tpm event log
+		tpmEventLog = append(tpmEventLog, measurefsEventLog...)
+	} else {
+		// don't fail yet, we might still be able to copy tpm event logs
+		appendErr = fmt.Errorf("failed to read measure-config measurements log file: %w", err)
+	}
+
+	err = fileutils.WriteRename(dstPath, tpmEventLog)
 	if err != nil {
-		return fmt.Errorf("failed to copy stored measurement log file: %v", err)
+		if appendErr != nil {
+			return fmt.Errorf("failed to copy tpm and measurefs event logs: %w, %v", err, appendErr)
+		}
+
+		return fmt.Errorf("failed to copy tpm measurement log data: %w", err)
 	}
 
 	return nil

--- a/pkg/pillar/evetpm/tpm_test.go
+++ b/pkg/pillar/evetpm/tpm_test.go
@@ -8,6 +8,7 @@ package evetpm
 import (
 	"bytes"
 	"crypto/sha256"
+	"fmt"
 	"os"
 	"reflect"
 	"strings"
@@ -30,16 +31,15 @@ func TestSealUnseal(t *testing.T) {
 
 	dataToSeal := []byte("secret")
 	if err := SealDiskKey(log, dataToSeal, DiskKeySealingPCRs); err != nil {
-		t.Errorf("Seal operation failed with err: %v", err)
-		return
+		t.Fatalf("Seal operation failed with err: %v", err)
 	}
+
 	unsealedData, err := UnsealDiskKey(DiskKeySealingPCRs)
 	if err != nil {
-		t.Errorf("Unseal operation failed with err: %v", err)
-		return
+		t.Fatalf("Unseal operation failed with err: %v", err)
 	}
 	if !reflect.DeepEqual(dataToSeal, unsealedData) {
-		t.Errorf("Seal/Unseal operation failed, want %v, but got %v", dataToSeal, unsealedData)
+		t.Fatalf("Seal/Unseal operation failed, want %v, but got %v", dataToSeal, unsealedData)
 	}
 }
 
@@ -51,35 +51,30 @@ func TestSealUnsealMismatchReport(t *testing.T) {
 
 	rw, err := tpm2.OpenTPM(TpmDevicePath)
 	if err != nil {
-		t.Errorf("OpenTPM failed with err: %v", err)
-		return
+		t.Fatalf("OpenTPM failed with err: %v", err)
 	}
 	defer rw.Close()
 
 	dataToSeal := []byte("secret")
 	if err := SealDiskKey(log, dataToSeal, DiskKeySealingPCRs); err != nil {
-		t.Errorf("Seal operation failed with err: %v", err)
-		return
+		t.Fatalf("Seal operation failed with err: %v", err)
 	}
 
 	pcrIndexes := [3]int{1, 7, 8}
 	pcrValue := bytes.Repeat([]byte{0xF}, sha256.Size)
 	for _, pcr := range pcrIndexes {
 		if err = tpm2.PCRExtend(rw, tpmutil.Handle(pcr), tpm2.AlgSHA256, pcrValue, ""); err != nil {
-			t.Errorf("Failed to extend PCR %d: %s", pcr, err)
-			return
+			t.Fatalf("Failed to extend PCR %d: %s", pcr, err)
 		}
 	}
 
 	_, err = UnsealDiskKey(DiskKeySealingPCRs)
 	if err == nil {
-		t.Errorf("Expected error from UnsealDiskKey, got nil")
-		return
+		t.Fatalf("Expected error from UnsealDiskKey, got nil")
 	}
 
 	if !strings.Contains(err.Error(), "[1 7 8]") {
-		t.Errorf("UnsealDiskKey expected to report mismatching PCR indexes, got : %v", err)
-		return
+		t.Fatalf("UnsealDiskKey expected to report mismatching PCR indexes, got : %v", err)
 	}
 }
 
@@ -91,70 +86,58 @@ func TestSealUnsealTpmEventLogCollect(t *testing.T) {
 
 	rw, err := tpm2.OpenTPM(TpmDevicePath)
 	if err != nil {
-		t.Errorf("OpenTPM failed with err: %v", err)
-		return
+		t.Fatalf("OpenTPM failed with err: %v", err)
 	}
 	defer rw.Close()
 
-	// this should write the save the first event log
+	// this should write tpm event log to measurementLogSealSuccess file
 	dataToSeal := []byte("secret")
 	if err := SealDiskKey(log, dataToSeal, DiskKeySealingPCRs); err != nil {
-		t.Errorf("Seal operation failed with err: %v", err)
-		return
+		t.Fatalf("Seal operation failed with err: %v", err)
 	}
 
-	// this won't write to event log, but still triggers saving it on unseal.
+	// this should cause UnsealDiskKey to fail
 	pcrValue := bytes.Repeat([]byte{0xF}, sha256.Size)
 	if err = tpm2.PCRExtend(rw, tpmutil.Handle(1), tpm2.AlgSHA256, pcrValue, ""); err != nil {
-		t.Errorf("Failed to extend PCR[1]: %v", err)
-		return
+		t.Fatalf("Failed to extend PCR[1]: %v", err)
 	}
 
-	// this should fail and result in saving the second tpm event log
+	// this should fail and result in saving creating measurementLogUnsealFail
 	_, err = UnsealDiskKey(DiskKeySealingPCRs)
 	if err == nil {
-		t.Errorf("Expected error from UnsealDiskKey, got nil")
-		return
+		t.Fatalf("Expected error from UnsealDiskKey, got nil")
 	}
 
-	// just check for tpm0
-	sealSuccess := getLogCopyPath(measurementLogSealSuccess, 0)
-	sealFail := getLogCopyPath(measurementLogUnsealFail, 0)
-	if !fileutils.FileExists(nil, sealSuccess) {
-		t.Errorf("TPM measurement log \"%s\" not found, Expected to be copied", sealSuccess)
-		return
+	if !fileutils.FileExists(nil, measurementLogSealSuccess) {
+		t.Fatalf("TPM measurement log \"%s\" not found, expected to exist", measurementLogSealSuccess)
 	}
-	if !fileutils.FileExists(nil, sealFail) {
-		t.Errorf("TPM measurement log \"%s\" not found, Expected to be copied", sealFail)
-		return
+	if !fileutils.FileExists(nil, measurementLogUnsealFail) {
+		t.Fatalf("TPM measurement log \"%s\" not found, expected to exist", measurementLogUnsealFail)
 	}
 
-	// this should trigger collecting previous tpm event logs
+	// this should trigger backing up previously saved tpm event logs
 	if err := SealDiskKey(log, dataToSeal, DiskKeySealingPCRs); err != nil {
-		t.Errorf("Seal operation failed with err: %v", err)
-		return
+		t.Fatalf("Seal operation failed with err: %v", err)
 	}
 
-	// current measurement log should exist
-	if !fileutils.FileExists(nil, sealSuccess) {
-		t.Errorf("TPM measurement log \"%s\" not found, Expected to be copied", sealSuccess)
-		return
+	// a new measurementLogSealSuccess file should exist
+	if !fileutils.FileExists(nil, measurementLogSealSuccess) {
+		t.Fatalf("TPM measurement log \"%s\" not found, Expected to be copied", measurementLogSealSuccess)
 	}
-	// this shouldn't exist because SealDiskKey will do a clean up
-	if fileutils.FileExists(nil, sealFail) {
-		t.Errorf("TPM measurement log \"%s\" found, Expected to not exist", sealFail)
-		return
+
+	// measurementLogUnsealFail file shouldn't exist because SealDiskKey
+	// will do a clean up.
+	if fileutils.FileExists(nil, measurementLogUnsealFail) {
+		t.Fatalf("TPM measurement log \"%s\" found, Expected to not exist", measurementLogUnsealFail)
 	}
 
 	// backed up measurement logs both should exist
-	prevSealSuccess := getLogBackupPath(sealSuccess)
-	prevSealFail := getLogBackupPath(sealFail)
+	prevSealSuccess := fmt.Sprintf("%s-backup", measurementLogSealSuccess)
+	prevSealFail := fmt.Sprintf("%s-backup", measurementLogUnsealFail)
 	if !fileutils.FileExists(nil, prevSealSuccess) {
-		t.Errorf("TPM measurement log \"%s\" not found, Expected to be backed up", prevSealSuccess)
-		return
+		t.Fatalf("TPM measurement log \"%s\" not found, Expected to be backed up", prevSealSuccess)
 	}
 	if !fileutils.FileExists(nil, prevSealFail) {
-		t.Errorf("TPM measurement log \"%s\" not found, Expected to be backed up", prevSealFail)
-		return
+		t.Fatalf("TPM measurement log \"%s\" not found, Expected to be backed up", prevSealFail)
 	}
 }


### PR DESCRIPTION
This is backport of #3607 .