### PR TITLE
PatchEnvelope: add test to handle delete case

### DIFF
--- a/pkg/pillar/cmd/zedrouter/patchenvelopes_test.go
+++ b/pkg/pillar/cmd/zedrouter/patchenvelopes_test.go
@@ -87,9 +87,11 @@ func TestPatchEnvelopes(t *testing.T) {
 
 	go func() {
 		for _, ct := range contentStatuses {
+			peStoreMutex.Lock()
 			peStore.UpdateContentTree(ct, false)
 
 			peStore.UpdateStateNotificationCh() <- struct{}{}
+			peStoreMutex.Unlock()
 		}
 	}()
 
@@ -163,4 +165,5 @@ func TestPatchEnvelopes(t *testing.T) {
 				},
 			},
 		}))
+
 }


### PR DESCRIPTION
This PR adds test case when we delete patch envelope to see if we properly handle it.

Also this test adds mutex to handle race condition which sometimes occurred if you ran
```
go test -v -run=TestPatchEnvelopes
```

However test still sometimes hangs and fails during running script above. I got 5 out of 100 fails

But when I run
```
go test -run=TestPatchEnvelopes
```
I got out 2 of 100 fails