### PR TITLE
Enable the required kubevirt features

### DIFF
--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -11,6 +11,7 @@ COPY cluster-init.sh /usr/bin/
 COPY cgconfig.conf /etc
 # kubevirt yaml files are patched files and will be removed later, look at cluster-init.sh
 COPY kubevirt-operator.yaml /etc
+COPY kubevirt-features.yaml /etc
 RUN mkdir -p /etc/containerd
 COPY config-k3s.toml /etc/containerd/
 RUN mkdir -p /etc/rancher/k3s

--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -160,6 +160,9 @@ if [ ! -f /var/lib/all_components_initialized ]; then
                 logmsg "Installing CDI version $CDI_VERSION"
                 kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-operator.yaml
                 kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-cr.yaml
+                #Add kubevirt feature gates
+                kubectl apply -f /etc/kubevirt-features.yaml
+
                 touch /var/lib/kubevirt_initialized
         fi
 

--- a/pkg/kube/kubevirt-features.yaml
+++ b/pkg/kube/kubevirt-features.yaml
@@ -1,0 +1,17 @@
+apiVersion: kubevirt.io/v1
+kind: KubeVirt
+metadata:
+  name: kubevirt
+  namespace: kubevirt
+spec:
+  configuration:
+    permittedHostDevices:
+      pciHostDevices:   # <- PCIe passthrough devices like nvme drives
+      mediatedDevices:  # <- GPUs
+    developerConfiguration:
+      featureGates:
+        - LiveMigration
+        - HostDisk
+        - Snapshot
+        - HostDevices
+        - GPU


### PR DESCRIPTION
We need to enable the feature gates in Kubevirt to actually use those.
This commit enables some of the features we need as of now.

    permittedHostDevices:
      pciHostDevices:   # <- PCIe passthrough devices like nvme drives
      mediatedDevices:  # <- GPUs
    developerConfiguration:
      featureGates:
        - LiveMigration
        - HostDisk
        - Snapshot
        - HostDevices
        - GPU


We enable those features when kubevirt gets installed on the device.