### PR TITLE
Kernel update - [amd64-generic, amd64-generic, amd64-rt, arm64-nvidia…

### DIFF
--- a/kernel-commits.mk
+++ b/kernel-commits.mk
@@ -1,7 +1,7 @@
-KERNEL_COMMIT_amd64_v5.10.186_generic = 27965edfa82a
-KERNEL_COMMIT_amd64_v6.1.38_generic = d2da815271a2
-KERNEL_COMMIT_amd64_v6.1.38_rt = 332ec0cf9b0e
-KERNEL_COMMIT_arm64_v5.10.104_nvidia = e8383fe4cf0b
-KERNEL_COMMIT_arm64_v5.10.186_generic = e1f7e4bb26e4
-KERNEL_COMMIT_arm64_v6.1.38_generic = 261c4f91e39c
-KERNEL_COMMIT_riscv64_v6.1.38_generic = 62076de26044
+KERNEL_COMMIT_amd64_v5.10.186_generic = e201acddaa99
+KERNEL_COMMIT_amd64_v6.1.38_generic = 3e39cb4a2fc4
+KERNEL_COMMIT_amd64_v6.1.38_rt = 476efe3129a3
+KERNEL_COMMIT_arm64_v5.10.104_nvidia = 0a65b40fb320
+KERNEL_COMMIT_arm64_v5.10.186_generic = a153e7561ec8
+KERNEL_COMMIT_arm64_v6.1.38_generic = f6df810a500b
+KERNEL_COMMIT_riscv64_v6.1.38_generic = ad6a4589904a


### PR DESCRIPTION
…, arm64-generic, arm64-generic, riscv64-generic]

eve-kernel-amd64-v5.10.186-generic
    e201acddaa99: modified the if condition for the branch build
    23159e865bc7: branch name as a variable
    05c2ed51cbd2: docker login only in case of branch build

eve-kernel-amd64-v6.1.38-generic
    3e39cb4a2fc4: Convert eve_defconfig to defconfig format
    b9d5206503c6: modified the if condition for the branch build
    f64bc18b37a6: branch name as a variable
    d69d8328be9c: docker login only in case of branch build

eve-kernel-amd64-v6.1.38-rt
    476efe3129a3: modified the if condition for the branch build
    951904eacc47: branch name as a variable
    84f55cc0f303: docker login only in case of branch build

eve-kernel-arm64-v5.10.104-nvidia
    0a65b40fb320: modified the if condition for the branch build
    42f87a1acd1f: branch name as a variable
    e42e79a6bdfd: docker login only in case of branch build

eve-kernel-arm64-v5.10.186-generic
    a153e7561ec8: Use savedefconfig to generate eve_defconfig
    71a1d0381b40: modified the if condition for the branch build
    b42d69042ea5: branch name as a variable
    3f97516097e7: docker login only in case of branch build

eve-kernel-arm64-v6.1.38-generic
    f6df810a500b: Force module signature requirement
    4c9bd511f732: Use savedefconfig to generate eve_defconfig
    4de0a596e1ce: modified the if condition for the branch build
    411c606a4361: branch name as a variable
    0894ccd63d98: docker login only in case of branch build

eve-kernel-riscv64-v6.1.38-generic
    ad6a4589904a: modified the if condition for the branch build
    2864550eb7df: branch name as a variable
    6a16b4a8fcc8: docker login only in case of branch build