### PR TITLE
Persist MAC generator ID used by a given app

### DIFF
--- a/pkg/pillar/base/logobjecttypes.go
+++ b/pkg/pillar/base/logobjecttypes.go
@@ -170,6 +170,8 @@ const (
 	EncryptedVaultKeyFromControllerLogType LogObjectType = "encrypted_vault_key_from_controller"
 	// CachedResolvedIPsLogType:
 	CachedResolvedIPsLogType LogObjectType = "cached_resolved_ips"
+	// AppMACGeneratorLogType : type for AppMACGenerator log entries
+	AppMACGeneratorLogType LogObjectType = "app_mac_generator"
 )
 
 // RelationObjectType :

--- a/pkg/pillar/cmd/zedrouter/appnetwork.go
+++ b/pkg/pillar/cmd/zedrouter/appnetwork.go
@@ -92,8 +92,7 @@ func (z *zedrouter) prepareConfigForVIFs(config types.AppNetworkConfig,
 			// User-configured static MAC address.
 			adapterStatus.Mac = adapterStatus.AppMacAddr
 		} else {
-			adapterStatus.Mac = z.generateAppMac(config.UUIDandVersion.UUID, adapterNum,
-				status.AppNum, netInstStatus)
+			adapterStatus.Mac = z.generateAppMac(adapterNum, status, netInstStatus)
 		}
 		adapterStatus.HostName = config.Key()
 		guestIP, err := z.lookupOrAllocateIPv4ForVIF(

--- a/pkg/pillar/cmd/zedrouter/ipam.go
+++ b/pkg/pillar/cmd/zedrouter/ipam.go
@@ -42,32 +42,37 @@ func (z *zedrouter) generateBridgeMAC(brNum int) net.HardwareAddr {
 // Since these MAC addresses will not appear on external Ethernet networks, we can also
 // use OUI octets for randomness. Only I/G and U/L bits need to stay constant and set
 // appropriately.
-func (z *zedrouter) generateAppMac(appUUID uuid.UUID, adapterNum int, appNum int,
+func (z *zedrouter) generateAppMac(adapterNum int, appStatus *types.AppNetworkStatus,
 	netInstStatus *types.NetworkInstanceStatus) net.HardwareAddr {
 	h := sha256.New()
-	h.Write(appUUID[:])
+	h.Write(appStatus.UUIDandVersion.UUID[:])
 	h.Write(netInstStatus.UUIDandVersion.UUID[:])
 	nums := make([]byte, 2)
 	nums[0] = byte(adapterNum)
-	nums[1] = byte(appNum)
+	nums[1] = byte(appStatus.AppNum)
 	h.Write(nums)
 	hash := h.Sum(nil)
 	switch netInstStatus.Type {
 	case types.NetworkInstanceTypeSwitch:
+		// For switch network instances, we always generate globally-scoped
+		// MAC addresses. There is no difference in behaviour between MAC address
+		// generators in this case.
 		return net.HardwareAddr{0x02, 0x16, 0x3e, hash[0], hash[1], hash[2]}
 	case types.NetworkInstanceTypeLocal:
-		if z.localLegacyMACAddr {
-			z.log.Noticef("generateAppMac: legacy MAC address for app %v", appUUID)
-			// Room to handle multiple underlays in 5th byte
-			return net.HardwareAddr{0x00, 0x16, 0x3e, 0x00, byte(adapterNum), byte(appNum)}
+		switch appStatus.MACGenerator {
+		case types.MACGeneratorNodeScoped:
+			return net.HardwareAddr{0x00, 0x16, 0x3e, 0x00,
+				byte(adapterNum), byte(appStatus.AppNum)}
+		case types.MACGeneratorGloballyScoped:
+			mac := net.HardwareAddr{hash[0], hash[1], hash[2], hash[3], hash[4], hash[5]}
+			// Mark this MAC address as unicast by setting the I/G bit to zero.
+			mac[0] &= ^byte(1)
+			// Mark this MAC address as locally administered by setting the U/L bit to 1.
+			mac[0] |= byte(1 << 1)
+			return mac
+		default:
+			z.log.Fatalf("undefined MAC generator")
 		}
-		z.log.Noticef("generateAppMac: random MAC address for app %v", appUUID)
-		mac := net.HardwareAddr{hash[0], hash[1], hash[2], hash[3], hash[4], hash[5]}
-		// Mark this MAC address as unicast by setting the I/G bit to zero.
-		mac[0] &= ^byte(1)
-		// Mark this MAC address as locally administered by setting the U/L bit to 1.
-		mac[0] |= byte(1 << 1)
-		return mac
 	default:
 		z.log.Fatalf("unsupported network instance type")
 	}

--- a/pkg/pillar/cmd/zedrouter/numallocators.go
+++ b/pkg/pillar/cmd/zedrouter/numallocators.go
@@ -110,6 +110,15 @@ func (z *zedrouter) initNumberAllocators() {
 			// Continue despite the error, this is best-effort.
 		}
 	}
+
+	// Persist ID of MAC generator used for each application.
+	macGeneratorPublisher, err := objtonum.NewObjNumPublisher(
+		z.log, z.pubSub, agentName, true, &types.AppMACGenerator{})
+	if err != nil {
+		z.log.Fatal(err)
+	}
+	z.appMACGeneratorMap = objtonum.NewPublishedMap(
+		z.log, macGeneratorPublisher, "appMACGenerator", objtonum.AllKeys)
 }
 
 // Either get existing or create a new allocator for app-interfaces connected

--- a/pkg/pillar/cmd/zedrouter/pubsubhandlers.go
+++ b/pkg/pillar/cmd/zedrouter/pubsubhandlers.go
@@ -470,6 +470,30 @@ func (z *zedrouter) handleAppNetworkCreate(ctxArg interface{}, key string,
 		return
 	}
 	status.AppNum = appNum
+
+	// For app already deployed (before node reboot), keep using the same MAC address
+	// generator. Changing MAC addresses could break network config inside the app.
+	macGenerator, _, err := z.appMACGeneratorMap.Get(appNumKey)
+	if err != nil || macGenerator == types.MACGeneratorUnspecified {
+		// New app or an existing app but without MAC generator ID persisted.
+		if z.localLegacyMACAddr {
+			// Use older node-scoped MAC address generator.
+			macGenerator = types.MACGeneratorNodeScoped
+		} else {
+			// Use newer (and preferred) globally-scoped MAC address generator.
+			macGenerator = types.MACGeneratorGloballyScoped
+		}
+		// Remember which MAC generator is being used for this app.
+		err = z.appMACGeneratorMap.Assign(appNumKey, macGenerator, false)
+		if err != nil {
+			err = fmt.Errorf("failed to persist MAC generator ID for app %s/%s: %v",
+				config.UUIDandVersion.UUID, config.DisplayName, err)
+			z.log.Errorf("handleAppNetworkCreate(%v): %v", config.UUIDandVersion.UUID, err)
+			z.addAppNetworkError(&status, "handleAppNetworkCreate", err)
+			return
+		}
+	}
+	status.MACGenerator = macGenerator
 	z.publishAppNetworkStatus(&status)
 
 	// Allocate application numbers on network instances.
@@ -594,6 +618,12 @@ func (z *zedrouter) handleAppNetworkDelete(ctxArg interface{}, key string,
 	err := z.appNumAllocator.Free(appNumKey, false)
 	if err != nil {
 		z.log.Errorf("failed to free number allocated to app %s/%s: %v",
+			status.UUIDandVersion.UUID, status.DisplayName, err)
+		// Continue anyway...
+	}
+	err = z.appMACGeneratorMap.Delete(appNumKey, false)
+	if err != nil {
+		z.log.Errorf("failed to delete persisted MAC generator ID for app %s/%s: %v",
 			status.UUIDandVersion.UUID, status.DisplayName, err)
 		// Continue anyway...
 	}

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -109,6 +109,7 @@ type zedrouter struct {
 	bridgeNumAllocator  *objtonum.Allocator
 	appIntfNumPublisher *objtonum.ObjNumPublisher
 	appIntfNumAllocator map[string]*objtonum.Allocator // key: network instance UUID as string
+	appMACGeneratorMap  objtonum.Map
 
 	// Info published to application via metadata server
 	subLocationInfo pubsub.Subscription


### PR DESCRIPTION
Persisting MAC address generator ID avoids changing MAC addresses for
already deployed apps, even when the option `network.local.legacy.mac.address`
is changed by the user. Only newly deployed apps will apply the latest config
change and use the most recently selected MAC generator.
