### PR TITLE
Report disk usage, fix low disk usage recovery, update EVE overhead limits to avoid running out

### DIFF
--- a/pkg/pillar/base/logobjecttypes.go
+++ b/pkg/pillar/base/logobjecttypes.go
@@ -94,6 +94,8 @@ const (
 	VolumeRefStatusLogType LogObjectType = "volume_ref_status"
 	// VolumeCreatePendingLogType:
 	VolumeCreatePendingLogType LogObjectType = "volume_create_pending"
+	// VolumeMgrStatusLogType:
+	VolumeMgrStatusLogType LogObjectType = "volumemgr_status"
 	// ServiceInitType:
 	ServiceInitLogType LogObjectType = "service_init"
 	// AppAndImageToHashLogType:

--- a/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
+++ b/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
@@ -270,6 +270,24 @@ func createOrUpdateDiskMetrics(ctx *volumemgrContext, wdName string) {
 		}
 	}
 
+	// If we have ZFS dataset, report their info from the ZFS perspective
+	if handler := volumehandlers.GetZFSVolumeHandler(log, ctx); handler != nil {
+		items, err := handler.GetAllDataSets()
+		if err != nil {
+			log.Error(err)
+		} else {
+			for _, img := range items {
+				metric := &types.DiskMetric{
+					DiskPath:   "dataset " + img.Filename,
+					TotalBytes: img.VirtualSize,
+					UsedBytes:  img.ActualSize,
+					IsDir:      true,
+				}
+				diskMetricList = append(diskMetricList, metric)
+			}
+		}
+	}
+
 	publishDiskMetrics(ctx, diskMetricList...)
 	for _, volumeStatus := range getAllVolumeStatus(ctx) {
 		ctx.ps.StillRunning(wdName, warningTime, errorTime)

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -72,6 +72,7 @@ type volumemgrContext struct {
 	pubVolumeCreatePending  pubsub.Publication
 	subVolumesSnapConfig    pubsub.Subscription
 	pubVolumesSnapStatus    pubsub.Publication
+	pubVolumeMgrStatus      pubsub.Publication
 	diskMetricsTickerHandle interface{}
 	gc                      *time.Ticker
 	deferDelete             *time.Ticker
@@ -555,6 +556,17 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		log.Fatal(err)
 	}
 	ctx.pubVolumesSnapStatus = pubVolumesSnapshotStatus
+
+	pubVolumeMgrStatus, err := ps.NewPublication(
+		pubsub.PublicationOptions{
+			AgentName: agentName,
+			TopicType: types.VolumeMgrStatus{},
+		},
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	ctx.pubVolumeMgrStatus = pubVolumeMgrStatus
 
 	if ctx.casClient, err = cas.NewCAS(casClientType); err != nil {
 		err = fmt.Errorf("Run: exception while initializing CAS client: %s", err.Error())

--- a/pkg/pillar/types/diskmetrics.go
+++ b/pkg/pillar/types/diskmetrics.go
@@ -20,8 +20,6 @@ var ReportDiskPaths = []string{
 
 // ReportDirPaths  Report directory usage for these paths
 var ReportDirPaths = []string{
-	PersistDir + "/downloads", // XXX old to be removed
-	PersistDir + "/img",       // XXX old to be removed
 	PersistDir + "/containerd",
 	PersistDir + "/tmp",
 	PersistDir + "/log",

--- a/pkg/pillar/types/diskmetrics.go
+++ b/pkg/pillar/types/diskmetrics.go
@@ -1,7 +1,5 @@
-/*
- * Copyright (c) 2020. Zededa, Inc.
- * SPDX-License-Identifier: Apache-2.0
- */
+// Copyright (c) 2020-2024. Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
 
 package types
 
@@ -13,21 +11,35 @@ import (
 
 // ReportDiskPaths Report disk usage for these paths
 var ReportDiskPaths = []string{
-	"/",
+	"/",       // overlayfs inside EVE
+	"/hostfs", // actual IMGx inside EVE
 	IdentityDirname,
 	PersistDir,
 }
 
 // ReportDirPaths  Report directory usage for these paths
 var ReportDirPaths = []string{
+	PersistConfigDir,
+	PersistStatusDir,
+	CertificateDirname,
+	SealedDirName,
+	ClearDirName,
+	PersistDebugDir,
+	PersistInstallerDir,
+	IngestedDirname,
+	NewlogDir,
 	PersistDir + "/containerd",
 	PersistDir + "/tmp",
 	PersistDir + "/log",
-	PersistDir + "/newlog",
-	PersistDir + "/config",
-	PersistDir + "/status",
-	PersistDir + "/certs",
 	PersistDir + "/checkpoint",
+	PersistDir + "/containerd-system-root",
+	PersistDir + "/netdump",
+	PersistDir + "/pubsub-large",
+	PersistDir + "/reserved",
+	PersistDir + "/etcd-storage",
+	PersistDir + "/memory-monitor/output", // for memory monitor dumps
+	PersistDir + "/kcrashes",
+	PersistDir + "/eve-info",
 }
 
 // AppPersistPaths  Application-related files live here
@@ -36,8 +48,12 @@ var ReportDirPaths = []string{
 var AppPersistPaths = []string{
 	VolumeEncryptedDirName,
 	VolumeClearDirName,
-	SealedDirName + "/downloader",
-	SealedDirName + "/verifier",
+	DownloaderDir,
+	VerifierDir,
+	ContainerdDir,
+	SnapshotsDirname,
+	PersistCachePatchEnvelopes,
+	PersistCachePatchEnvelopesUsage,
 }
 
 // DiskMetric holds metrics data per disk

--- a/pkg/pillar/types/diskmetrics.go
+++ b/pkg/pillar/types/diskmetrics.go
@@ -28,8 +28,8 @@ var ReportDirPaths = []string{
 	PersistInstallerDir,
 	IngestedDirname,
 	NewlogDir,
-	PersistDir + "/containerd",
-	PersistDir + "/tmp",
+	PersistDir + "/containerd", // Old location
+	PersistDir + "/tmp",        // Should not be used by anything
 	PersistDir + "/log",
 	PersistDir + "/checkpoint",
 	PersistDir + "/containerd-system-root",
@@ -44,7 +44,7 @@ var ReportDirPaths = []string{
 
 // AppPersistPaths  Application-related files live here
 // XXX do we need to exclude the ContentTrees used for eve image update?
-// If so how do we tell them apart
+// If so how do we tell them apart?
 var AppPersistPaths = []string{
 	VolumeEncryptedDirName,
 	VolumeClearDirName,

--- a/pkg/pillar/types/locationconsts.go
+++ b/pkg/pillar/types/locationconsts.go
@@ -107,8 +107,17 @@ const (
 	// ZFSArcMaxSizeFile - file with zfs_arc_max size in bytes
 	ZFSArcMaxSizeFile = "/hostfs/sys/module/zfs/parameters/zfs_arc_max"
 
+	// DownloaderDir - storage for downloader
+	DownloaderDir = SealedDirName + "/downloader"
+
+	// VerifierDir - storage for verifier
+	VerifierDir = SealedDirName + "/verifier"
+
+	// ContainerdDir - path to user containerd storage
+	ContainerdDir = SealedDirName + "/containerd"
+
 	// ContainerdContentDir - path to containerd`s content store
-	ContainerdContentDir = SealedDirName + "/containerd/io.containerd.content.v1.content"
+	ContainerdContentDir = ContainerdDir + "/io.containerd.content.v1.content"
 )
 
 var (

--- a/pkg/pillar/types/volumetypes.go
+++ b/pkg/pillar/types/volumetypes.go
@@ -593,3 +593,53 @@ func (status VolumeCreatePending) LogDelete(logBase *base.LogObject) {
 
 	base.DeleteLogObject(logBase, status.LogKey())
 }
+
+// VolumeMgrStatus :
+type VolumeMgrStatus struct {
+	Name           string
+	Initialized    bool
+	RemainingSpace uint64 // In bytes. Takes into account "reserved" for dom0
+}
+
+// Key :
+func (status VolumeMgrStatus) Key() string {
+	return status.Name
+}
+
+// LogCreate :
+func (status VolumeMgrStatus) LogCreate(logBase *base.LogObject) {
+	logObject := base.NewLogObject(logBase, base.VolumeMgrStatusLogType, status.Name,
+		nilUUID, status.LogKey())
+	if logObject == nil {
+		return
+	}
+	logObject.Noticef("Zedagent status create")
+}
+
+// LogModify :
+func (status VolumeMgrStatus) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.VolumeMgrStatusLogType, status.Name,
+		nilUUID, status.LogKey())
+
+	oldStatus, ok := old.(VolumeMgrStatus)
+	if !ok {
+		logObject.Clone().Fatalf("LogModify: Old object interface passed is not of VolumeMgrStatus type")
+	}
+	// XXX remove?
+	logObject.CloneAndAddField("diff", cmp.Diff(oldStatus, status)).
+		Noticef("Zedagent status modify")
+}
+
+// LogDelete :
+func (status VolumeMgrStatus) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.VolumeMgrStatusLogType, status.Name,
+		nilUUID, status.LogKey())
+	logObject.Noticef("Zedagent status delete")
+
+	base.DeleteLogObject(logBase, status.LogKey())
+}
+
+// LogKey :
+func (status VolumeMgrStatus) LogKey() string {
+	return string(base.VolumeMgrStatusLogType) + "-" + status.Key()
+}

--- a/pkg/pillar/types/zedagenttypes.go
+++ b/pkg/pillar/types/zedagenttypes.go
@@ -394,6 +394,7 @@ const (
 	MaintenanceModeReasonNone MaintenanceModeReason = iota
 	MaintenanceModeReasonUserRequested
 	MaintenanceModeReasonVaultLockedUp
+	MaintenanceModeReasonNoDiskSpace
 )
 
 // String returns the verbose equivalent of MaintenanceModeReason code
@@ -405,6 +406,8 @@ func (mmr MaintenanceModeReason) String() string {
 		return "MaintenanceModeReasonUserRequested"
 	case MaintenanceModeReasonVaultLockedUp:
 		return "MaintenanceModeReasonVaultLockedUp"
+	case MaintenanceModeReasonNoDiskSpace:
+		return "MaintenanceModeReasonNoDiskSpace"
 	default:
 		return fmt.Sprintf("Unknown MaintenanceModeReason %d", mmr)
 	}

--- a/pkg/pillar/volumehandlers/containerhandler.go
+++ b/pkg/pillar/volumehandlers/containerhandler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/cas"
 	"github.com/lf-edge/eve/pkg/pillar/containerd"
 	"github.com/lf-edge/eve/pkg/pillar/diskmetrics"
+	"github.com/lf-edge/eve/pkg/pillar/types"
 	utils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 )
 
@@ -111,4 +112,10 @@ func (handler *volumeHandlerContainer) DeleteSnapshot(snapshotMeta interface{}) 
 	errStr := fmt.Sprintf("DeleteSnapshot not implemented for container volumes")
 	handler.log.Errorf(errStr)
 	return fmt.Errorf(errStr)
+}
+
+func (handler *volumeHandlerContainer) GetAllDataSets() ([]types.ImgInfo, error) {
+	errStr := fmt.Sprintf("GetAllDataSets not implemented for container volumes")
+	handler.log.Errorf(errStr)
+	return nil, fmt.Errorf(errStr)
 }

--- a/pkg/pillar/volumehandlers/csihandler.go
+++ b/pkg/pillar/volumehandlers/csihandler.go
@@ -329,3 +329,9 @@ func (handler *volumeHandlerCSI) DeleteSnapshot(snapshotMeta interface{}) error 
 	err := errors.New(errStr)
 	return err
 }
+
+func (handler *volumeHandlerCSI) GetAllDataSets() ([]types.ImgInfo, error) {
+	errStr := fmt.Sprintf("GetAllDataSets not implemented for container volumes")
+	handler.log.Errorf(errStr)
+	return nil, fmt.Errorf(errStr)
+}

--- a/pkg/pillar/volumehandlers/filehandler.go
+++ b/pkg/pillar/volumehandlers/filehandler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lf-edge/edge-containers/pkg/registry"
 	zconfig "github.com/lf-edge/eve-api/go/config"
 	"github.com/lf-edge/eve/pkg/pillar/diskmetrics"
+	"github.com/lf-edge/eve/pkg/pillar/types"
 )
 
 type volumeHandlerFile struct {
@@ -251,4 +252,10 @@ func (handler *volumeHandlerFile) DeleteSnapshot(snapshotMeta interface{}) error
 		return err
 	}
 	return nil
+}
+
+func (handler *volumeHandlerFile) GetAllDataSets() ([]types.ImgInfo, error) {
+	errStr := fmt.Sprintf("GetAllDataSets not implemented for file volumes")
+	handler.log.Errorf(errStr)
+	return nil, fmt.Errorf(errStr)
 }

--- a/pkg/pillar/volumehandlers/handlers.go
+++ b/pkg/pillar/volumehandlers/handlers.go
@@ -38,6 +38,8 @@ type VolumeHandler interface {
 	RollbackToSnapshot(snapshotMeta interface{}) error
 	// DeleteSnapshot handles snapshot deletion
 	DeleteSnapshot(snapshotMeta interface{}) error
+	// GetAllDataSets returns any ZFS datasets
+	GetAllDataSets() ([]types.ImgInfo, error)
 }
 
 // VolumeMgr is an interface to obtain information required for volume processing
@@ -74,6 +76,16 @@ func GetVolumeHandler(log *base.LogObject, volumeManager VolumeMgr, status *type
 		return &volumeHandlerZVol{commonVolumeHandler: common, useVHost: useVhost(log, volumeManager)}
 	}
 	return &volumeHandlerFile{common}
+}
+
+// GetZFSVolumeHandler returns a ZFS handler (if /persist is ZFS)
+func GetZFSVolumeHandler(log *base.LogObject, volumeManager VolumeMgr) VolumeHandler {
+	if persist.ReadPersistType() == types.PersistZFS {
+		common := commonVolumeHandler{volumeManager: volumeManager, log: log}
+		return &volumeHandlerZVol{commonVolumeHandler: common,
+			useVHost: useVhost(log, volumeManager)}
+	}
+	return nil
 }
 
 func updateVolumeSizes(log *base.LogObject, handler VolumeHandler, status *types.VolumeStatus) {

--- a/pkg/pillar/volumehandlers/zvolhandler.go
+++ b/pkg/pillar/volumehandlers/zvolhandler.go
@@ -40,6 +40,10 @@ func (handler *volumeHandlerZVol) GetVolumeDetails() (uint64, uint64, string, bo
 		imgInfo.DirtyFlag, nil
 }
 
+func (handler *volumeHandlerZVol) GetAllDataSets() ([]types.ImgInfo, error) {
+	return zfs.GetAllZFSVolumeInfo()
+}
+
 func (handler *volumeHandlerZVol) UsageFromStatus() uint64 {
 	// use MaxVolSize for zvol
 	handler.log.Noticef("UsageFromStatus: Use MaxVolSize for Volume %s",


### PR DESCRIPTION
This PR addresses several issues related to trying to use "all" storage on the device. They include:
 - reporting all of the used directory paths and zvols in /persist; that is important to track down disk usage in the field
 - fix the recovery login in onboot.sh to work with ZFS and also change it to trigger at <4Gb of space left (and not 70% used as today)
 - Make the EVE overhead be more dynamic (include 2Gb for EVE + configured limit for newlog) and update the EVE number if we are currently using more in /persist e.g., for netdump or whatever

Separately we should probably also make it so that the system containerd can run without needing to allocate space in /persist.

If something uses up too much space in /persist, the console output during boot will include something like this:
Free space in /persist: 2369 MBytes
Free space in /persist is only 2369 hence below the limit 4096 MBytes
Free space in /persist after clearing /persist/log: 24917 MBytes
Free space in /persist after clearing /persist/log and 2s sleep: 24917 MBytes
Free space in /persist after recovery: 24917 MBytes

[The sleep is needed due to ZFS delayed deletes. The above output is with an ext4 /persist.]