### PR TITLE
Generate external boot image to launch container image as a VM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ conf/authorized_keys
 conf/grub.cfg
 conf/device.cert.pem
 conf/device.key.pem
+pkg/kube/external-boot-image.tar
+pkg/external-boot-image/build.yml

--- a/pkg/external-boot-image/Dockerfile
+++ b/pkg/external-boot-image/Dockerfile
@@ -1,0 +1,11 @@
+# syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
+
+ARG KERNEL=latest
+ARG XENTOOLS=latest
+
+FROM lfedge/eve-xen-tools:$XENTOOLS as initrd-build
+FROM lfedge/eve-kernel:$KERNEL as kernel-build
+
+FROM scratch
+COPY --from=initrd-build --chmod=666 /usr/lib/xen/boot/runx-initrd /
+COPY --from=kernel-build --chmod=666 /kernel /

--- a/pkg/external-boot-image/build.yml.in
+++ b/pkg/external-boot-image/build.yml.in
@@ -1,0 +1,9 @@
+# linuxkit build template
+#
+# Copyright (c) 2023 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+org: lfedge
+image: eve-external-boot-image
+buildArgs:
+  - KERNEL=KERNEL_TAG
+  - XENTOOLS=XENTOOLS_TAG

--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
 
-FROM lfedge/eve-alpine:12487b9900ba40f3ecdadfec2c84799fa34e5014 as build
+FROM lfedge/eve-alpine:57d6a8a768256bece2f03ae4fc0eedcb5bca41a6 as build
 ENV PKGS alpine-baselayout musl-utils iproute2 iptables curl openrc \
          open-iscsi libvirt libvirt-client util-linux grep findutils jq
 RUN eve-alpine-deploy.sh
@@ -15,6 +15,7 @@ RUN mkdir -p /etc/containerd
 COPY config-k3s.toml /etc/containerd/
 RUN mkdir -p /etc/rancher/k3s
 COPY config.yaml /etc/rancher/k3s
+COPY external-boot-image.tar /etc/
 WORKDIR /
 
 # Actual k3s install and config happens when this container starts during EVE bootup, look at cluster-init.sh

--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -86,6 +86,20 @@ check_start_containerd() {
                 mkdir -p /run/containerd-user
                 nohup /var/lib/rancher/k3s/data/current/bin/containerd --config /etc/containerd/config-k3s.toml > $CTRD_LOG 2>&1 &
         fi
+        if [ -f /etc/external-boot-image.tar ]; then
+                # NOTE: https://kubevirt.io/user-guide/virtual_machines/boot_from_external_source/
+                # Install external-boot-image image to our eve user containerd registry.
+                # This image contains just kernel and initrd to bootstrap a container image as a VM.
+                # This is very similar to what we do on kvm based eve to start container as a VM.
+                logmsg "Trying to install new external-boot-image"
+                # This import happens once per reboot
+                ctr -a /run/containerd-user/containerd.sock image import /etc/external-boot-image.tar docker.io/lfedge/eve-external-boot-image:latest
+                res=$?
+                if [ $res -eq 0 ]; then
+                        logmsg "Successfully installed external-boot-image"
+                        rm -f /etc/external-boot-image.tar
+                fi
+        fi
 }
 trigger_k3s_selfextraction() {
         # Analysis of the k3s source shows nearly any cli command will first self-extract a series of binaries.

--- a/tools/compose-external-boot-image-yml.sh
+++ b/tools/compose-external-boot-image-yml.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+yq() {
+  docker run -i --rm -v "${PWD}/":/workdir intoiter/yq:3.1.0 -y -i "$@"
+}
+
+patch_xentools() {
+    yq ".buildArgs[1] |= \"XENTOOLS=$1\"" "$2"
+}
+
+patch_kernel() {
+    yq ".buildArgs[0] |= \"KERNEL=$1\"" "$2"
+}
+main() {
+    local base_templ_path="$1"
+    local out_templ_path="$2"
+    local kernel_tag="$3"
+    local xentools_tag="$4"
+
+    cp "${base_templ_path}" "${out_templ_path}"
+
+    # Replace kernel_tag
+    patch_kernel "${kernel_tag}" "${out_templ_path}"
+    # Replace xentools_tag
+    patch_xentools "${xentools_tag}" "${out_templ_path}"
+}
+
+main "$@"


### PR DESCRIPTION
In kvm based eve we launch container as a VM.
To support similar functionality in kubevirt eve we use a feature in kubevirt Look at https://kubevirt.io/user-guide/virtual_machines/boot_from_external_source/ We provide a tiny scratch container image which just consists of kernel and initrd Then the user container image will be converted to a PV/PVC and passed into virtualmachineinstance spec as a boot disk.
EVE mount_disk.sh will mount the PVC as a rootfs in the VM

The code to create virtualmachineinstance spec will come in later commits (domainmgr and kubevirt.go)

This particular comit does the following.
1) Extracts kernel and initrd binaries from eve-kernel and eve-xen-tools packages and creates a scratch container.
2) Converts the container to external-boot-image.tar using docker save
3) Ships external-boot-image.tar in eve-kube container. 
4) When device boots external-boot-image.tar is imported into eve user containerd repo.

Basically every  kubevirt eve build gets its own image, this works nicely for upgrade scenario too. This adds additional 15MB to eve image size which is minimal.

Testing done
============
Compiled and verified nothing is broken in master branch.
Actual launch of container as a VM was tested in kubevirt eve poc branch
On eve device

ctr -a /run/containerd-user/containerd.sock image ls | grep external

docker.io/lfedge/eve-external-boot-image:latest                                                                                                  application/vnd.docker.distribution.manifest.v2+json      sha256:653fb9540cef1c514a428377c4ee28d7ca6d451dabc2cc467e9a5bf0f8576568 13.9 MiB  linux/amd64                                                                   io.cri-containerd.image=managed                     
