### PR TITLE
 [9.4 stable] Backport patches related to app MAC address change 

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -45,6 +45,7 @@
 | newlog.gzipfiles.ondisk.maxmegabytes | integer in Mbytes | 2048 | the quota for keepig newlog gzip files on device |
 | process.cloud-init.multipart | boolean | false | help VMs which do not handle mime multi-part themselves |
 | edgeview.authen.jwt | edgeview session jwt token | empty string(edgeview disabled) | format as standard JWT for websocket session for temporary testing, this configitem will be removed once controllers are setup to send EdgeViewConfig in configuration |
+| network.local.legacy.mac.address | bool | false | enables legacy MAC address generation for local network instances for those EVE nodes where changing MAC addresses in applications will lead to incorrect network configuration |
 
 In addition, there can be per-agent settings.
 The Per-agent settings begin with "agent.*agentname*.*setting*"

--- a/pkg/pillar/base/logobjecttypes.go
+++ b/pkg/pillar/base/logobjecttypes.go
@@ -164,6 +164,8 @@ const (
 	EncryptedVaultKeyFromDeviceLogType LogObjectType = "encrypted_vault_key_from_device"
 	// EncryptedVaultKeyFromControllerLogType:
 	EncryptedVaultKeyFromControllerLogType LogObjectType = "encrypted_vault_key_from_controller"
+	// AppMACGeneratorLogType : type for AppMACGenerator log entries
+	AppMACGeneratorLogType LogObjectType = "app_mac_generator"
 )
 
 // RelationObjectType :

--- a/pkg/pillar/cmd/zedrouter/appmacgenerator.go
+++ b/pkg/pillar/cmd/zedrouter/appmacgenerator.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2023 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Back-ported code for persisting of MAC address generator ID per app.
+// This code is adjusted specifically for 9.4. In newer EVE versions,
+// this is implemented using objtonum package which is not yet in 9.4.
+// We have to be careful here and replicate the format of persisted data
+// to match newer EVE versions and enable seamless upgrades.
+
+package zedrouter
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	uuid "github.com/satori/go.uuid"
+)
+
+func getAppMacGeneratorID(ctx *zedrouterContext, appUUID uuid.UUID) (int, error) {
+	rawItem, err := ctx.pubAppMACGenerator.Get(appUUID.String())
+	if err != nil {
+		log.Errorf("failed to get published MAC generator ID for app %v: %v",
+			appUUID, err)
+		return 0, err
+	}
+	item, ok := rawItem.(types.AppMACGenerator)
+	if !ok {
+		return 0, fmt.Errorf("invalid item type: %T, expected AppMACGenerator", rawItem)
+	}
+	return item.Number, nil
+}
+
+func publishAppMacGeneratorID(ctx *zedrouterContext, appUUID uuid.UUID, macGenID int) error {
+	now := time.Now()
+	item := types.AppMACGenerator{
+		UuidToNum: types.UuidToNum{
+			UUID:        appUUID,
+			CreateTime:  now,
+			LastUseTime: now,
+			InUse:       true,
+			NumType:     "appMACGenerator",
+			Number:      macGenID,
+		},
+	}
+	err := ctx.pubAppMACGenerator.Publish(item.Key(), item)
+	if err != nil {
+		log.Errorf("failed to publish MAC generator ID for app %v: %v",
+			appUUID, err)
+	}
+	return err
+}
+
+func unpublishAppMacGeneratorID(ctx *zedrouterContext, appUUID uuid.UUID) error {
+	err := ctx.pubAppMACGenerator.Unpublish(appUUID.String())
+	if err != nil {
+		log.Errorf("failed to un-publish MAC generator ID for app %v: %v",
+			appUUID, err)
+	}
+	return err
+}

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -59,6 +59,7 @@ type zedrouterContext struct {
 	agentStartTime        time.Time
 	receivedConfigTime    time.Time
 	triggerNumGC          bool // For appNum and bridgeNum
+	localLegacyMACAddr    bool // switch to legacy MAC address generation
 	subAppNetworkConfig   pubsub.Subscription
 	subAppNetworkConfigAg pubsub.Subscription // From zedagent for dom0
 	subAppInstanceConfig  pubsub.Subscription // From zedagent to cleanup appInstMetadata
@@ -2087,6 +2088,7 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 		ctx.GCInitialized = true
 		ctx.appStatsInterval = gcp.GlobalValueInt(types.AppContainerStatsInterval)
 		ctx.disableDHCPAllOnesNetMask = gcp.GlobalValueBool(types.DisableDHCPAllOnesNetMask)
+		ctx.localLegacyMACAddr = gcp.GlobalValueBool(types.NetworkLocalLegacyMACAddress)
 		metricInterval := gcp.GlobalValueInt(types.MetricInterval)
 		if metricInterval != 0 && ctx.metricInterval != metricInterval {
 			if ctx.publishTicker != nil {

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -259,6 +259,15 @@ const (
 
 	// XXX temp for testing edge-view
 	EdgeViewToken GlobalSettingKey = "edgeview.authen.jwt"
+
+	// NetworkLocalLegacyMACAddress : Enables legacy MAC address generation for
+	// local network instances. The legacy generation is not "that" random and
+	// probability of repeating MAC addresses across nodes is high. Later the
+	// algorithm was changed and more randomness was introduced, but some
+	// applications may be already configured with already allocated MAC
+	// address, and MAC address change on EVE node upgrade (switch from old
+	// generation logic to new one) can cause problems with the guest network.
+	NetworkLocalLegacyMACAddress GlobalSettingKey = "network.local.legacy.mac.address"
 )
 
 // AgentSettingKey - keys for per-agent settings
@@ -827,6 +836,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddBoolItem(DisableDHCPAllOnesNetMask, false)
 	configItemSpecMap.AddBoolItem(ProcessCloudInitMultiPart, false)
 	configItemSpecMap.AddBoolItem(ConsoleAccess, true) // Controller likely default to false
+	configItemSpecMap.AddBoolItem(NetworkLocalLegacyMACAddress, false)
 
 	// Add TriState Items
 	configItemSpecMap.AddTriStateItem(NetworkFallbackAnyEth, TS_DISABLED)

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -185,6 +185,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		IgnoreMemoryCheckForApps,
 		IgnoreDiskCheckForApps,
 		AllowLogFastupload,
+		NetworkLocalLegacyMACAddress,
 		// TriState Items
 		NetworkFallbackAnyEth,
 		MaintenanceMode,


### PR DESCRIPTION
A set of patches backported to handle upgrades from older EVE versions to 9.4 LTS, where app MAC generator works differently and can therefore break network config in already deployed VM apps with cloud-init.
