### PR TITLE
Fix cipher context assignment in handlecipherconfig.go

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlecipherconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecipherconfig.go
@@ -115,10 +115,10 @@ func parseCipherBlock(ctx *getconfigContext, key string, cfgCipherBlock *zcommon
 
 	// get CipherContext and embed it into CipherBlockStatus to avoid potential races
 	for _, cfgCipherContext := range ctx.cipherContexts {
-		if cfgCipherContext.ContextID != cipherBlock.CipherContextID {
-			continue
+		if cfgCipherContext.ContextID == cipherBlock.CipherContextID {
+			cipherBlock.CipherContext = &cfgCipherContext
+			break
 		}
-		cipherBlock.CipherContext = &cfgCipherContext
 	}
 
 	if cipherBlock.CipherContext == nil {


### PR DESCRIPTION
The previous version was always assigning the last cipher context in the slice instead of the one with the correct ID.