### PR TITLE
pillar: ledmanager: Fix user LED for phyBAORD-Pollux

### DIFF
--- a/pkg/pillar/cmd/ledmanager/ledmanager.go
+++ b/pkg/pillar/cmd/ledmanager/ledmanager.go
@@ -252,7 +252,7 @@ var mToF = []modelToFuncs{
 		regexp:      true,
 		initFunc:    InitLedCmd,
 		displayFunc: ExecuteLedCmd,
-		arg:         "user-led3", // Blue LED
+		arg:         "led3", // Blue LED
 	},
 	{
 		// Last in table as a default


### PR DESCRIPTION
Commit e1538b518f29edddd53a903a72e8336e9b3441c9 updated the u-boot for phyBOARD-Pollux device. In the new device tree the user LEDs were renamed from user-led? to just led?. This commit updates the LED name on ledmanager.