### PR TITLE
linxukit version with package build fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,7 +295,7 @@ DOCKER_GO = _() { $(SET_X); mkdir -p $(CURDIR)/.go/src/$${3:-dummy} ; mkdir -p $
 
 PARSE_PKGS=$(if $(strip $(EVE_HASH)),EVE_HASH=)$(EVE_HASH) DOCKER_ARCH_TAG=$(DOCKER_ARCH_TAG) KERNEL_TAG=$(KERNEL_TAG) ./tools/parse-pkgs.sh
 LINUXKIT=$(BUILDTOOLS_BIN)/linuxkit
-LINUXKIT_VERSION=e115ce8dca74e7d1307490879fffec170f2fce34
+LINUXKIT_VERSION=3a0405298aab1632524a6ccd074969b417e1ee92
 LINUXKIT_SOURCE=https://github.com/linuxkit/linuxkit.git
 LINUXKIT_OPTS=$(if $(strip $(EVE_HASH)),--hash) $(EVE_HASH) $(if $(strip $(EVE_REL)),--release) $(EVE_REL)
 LINUXKIT_PKG_TARGET=build


### PR DESCRIPTION
When linuxkit builds a package (if `--force` is not provided), it:

1. checks to see if it is in the cache, and if it is in cache, if it has all of the blobs for the target build architecture
2. if not in the cache, or incomplete, try to pull from OCI registry
3. otherwise build

The issue was with step 2. If it was not in cache and successfully pulled an index from the registry, it _assumes_ the index was complete, rather than validate it locally (like we do in step 1). This leads to later surprise failures if the pulled index does not have the expected target architecture.

This PR updates linuxkit with the version that properly checks the index after step 2, and, if missing, rebuilds.