### PR TITLE
Fix race conditions in DPCManager unit tests

### DIFF
--- a/tools/go-test.sh
+++ b/tools/go-test.sh
@@ -3,7 +3,7 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-BROKEN_TESTS="TestDPCWithReleasedAndRenamedInterface TestUnsubscribe/IPC_with_persistent TestRestarted TestUnsubscribe/IPC TestCheckMaxSize"
+BROKEN_TESTS="TestUnsubscribe/IPC_with_persistent TestRestarted TestUnsubscribe/IPC TestCheckMaxSize"
 SKIP_BROKEN_TESTS_PARAM=""
 for t in $BROKEN_TESTS
 do


### PR DESCRIPTION
`go test -race` has discovered some race conditions in DPCManager unit tests.
Some of them are due to unit tests accessing certain fields of DPCManager
(most notably dependency graphs) in an unsafe manner.
These are not affecting the production code.
    
More importantly, it is possible for DPCManager and DPCReconciler to access
the same DPC struct instance at the same time, although the risk of this leading
to some panic is very low, likely zero.
