### PR TITLE
tools: Fix kernel asset for NET installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -725,8 +725,8 @@ $(INSTALLER).iso: $(EFI_PART) $(ROOTFS_IMG) $(INITRD_IMG) $(INSTALLER_IMG) $(CON
 	./tools/makeiso.sh $| $@ installer
 	$(QUIET): $@: Succeeded
 
-$(INSTALLER).net: $(EFI_PART) $(ROOTFS_IMG) $(INITRD_IMG) $(INSTALLER_IMG) $(CONFIG_IMG) $(PERSIST_IMG) | $(INSTALLER)
-	./tools/makenet.sh $| installer.img $@
+$(INSTALLER).net: $(EFI_PART) $(ROOTFS_TAR) $(ROOTFS_IMG) $(INITRD_IMG) $(INSTALLER_IMG) $(CONFIG_IMG) $(PERSIST_IMG) | $(INSTALLER)
+	./tools/makenet.sh $| $(ROOTFS_TAR) installer.img $@
 	$(QUIET): $@: Succeeded
 
 $(LIVE).vdi: $(LIVE).raw
@@ -744,9 +744,9 @@ $(VERIFICATION).raw: $(BOOT_PART) $(EFI_PART) $(ROOTFS_IMG) $(INITRD_IMG) $(VERI
 	./tools/makeflash.sh "mkverification-raw-efi" -C 850 $| $@ "conf_win verification inventory_win"
 	$(QUIET): $@: Succeeded
 
-$(VERIFICATION).net: $(EFI_PART) $(ROOTFS_IMG) $(INITRD_IMG) $(VERIFICATION_IMG) $(CONFIG_IMG) $(PERSIST_IMG) | $(VERIFICATION)
+$(VERIFICATION).net: $(EFI_PART) $(ROOTFS_TAR) $(ROOTFS_IMG) $(INITRD_IMG) $(VERIFICATION_IMG) $(CONFIG_IMG) $(PERSIST_IMG) | $(VERIFICATION)
 	./tools/prepare-platform.sh "$(PLATFORM)" "$(BUILD_DIR)" "$(VERIFICATION)" || :
-	./tools/makenet.sh $| verification.img $@
+	./tools/makenet.sh $| $(ROOTFS_TAR) verification.img $@
 
 $(VERIFICATION).iso: $(EFI_PART) $(ROOTFS_IMG) $(INITRD_IMG) $(VERIFICATION_IMG) $(CONFIG_IMG) $(PERSIST_IMG) | $(VERIFICATION)
 	./tools/prepare-platform.sh "$(PLATFORM)" "$(BUILD_DIR)" "$(VERIFICATION)" || :

--- a/tools/makenet.sh
+++ b/tools/makenet.sh
@@ -2,11 +2,12 @@
 EVE="$(cd "$(dirname "$0")" && pwd)/../"
 PATH="$EVE/build-tools/bin:$PATH"
 SOURCE="$(cd "$1" && pwd)"
-IMG="$2"
-NET="$(cd "$(dirname "$3")" && pwd)/$(basename "$3")"
+ROOTFSTAR="$2"
+IMG="$3"
+NET="$(cd "$(dirname "$4")" && pwd)/$(basename "$4")"
 
-if [ ! -d "$SOURCE" ] || [ $# -lt 3 ]; then
-   echo "Usage: $0 <input dir> <image file name> <output tar image file>"
+if [ ! -d "$SOURCE" ] || [ $# -lt 4 ]; then
+   echo "Usage: $0 <input dir> <rootfs tarball> <image file name> <output tar image file>"
    exit 1
 fi
 
@@ -14,9 +15,11 @@ fi
 
 #  # FIXME: this will also go away once we rationalize
 #  # how we're managing config for things like netboot
-cat <<__EOT__ | docker run --rm -v "$SOURCE:/bits" -v "$NET:/output.tar" -i alpine:3.13 sh
+cat <<__EOT__ | docker run --rm -v "$SOURCE:/bits" -v "$ROOTFSTAR:/rootfs.tar" -v "$NET:/output.tar" -i alpine:3.13 sh
    cd "\$(mktemp -d)"
-   mkdir -p media/root-rw/boot
+   mkdir -p media/root-rw/boot /rootfs
+   tar -xf /rootfs.tar boot/kernel -C /rootfs/
+   cp /rootfs/boot/kernel /bits/
    cp /bits/config.img /bits/persist.img media/root-rw
    echo netboot > media/root-rw/boot/.uuid
    find . | sort | cpio --quiet -o -H newc | gzip > /initrd.bits


### PR DESCRIPTION
Due to the kernel build changes, the kernel binary asset is not copied to bits/ folder anymore, leading to the following error of the tools/makenet.sh script while building NET installer images:

```
ipxe.efi.cfg
tar: kernel: No such file or directory
initrd.img
installer.img
initrd.bits
rootfs.img
tar: error exit delayed from previous errors
```

Now that different kernel packages can be specified with the KERNEL_TAG variable, an approach to fix this issue is to pick the kernel image directly from the final rootfs image. However, this would require manipulate the rootfs image inside the Alpine container used by the makenet.sh script. An easier way (implemented by this commit) is to use the rootfs tarball and pick the kernel image from there, which will work regardless of the type of the rootfs image (squashfs, ext4, etc).