### PR TITLE
kernel: Update arm64 versions

### DIFF
--- a/kernel-commits.mk
+++ b/kernel-commits.mk
@@ -1,7 +1,7 @@
 KERNEL_COMMIT_amd64_v5.10.186_generic = e201acddaa99
 KERNEL_COMMIT_amd64_v6.1.38_generic = 3e39cb4a2fc4
 KERNEL_COMMIT_amd64_v6.1.38_rt = 476efe3129a3
-KERNEL_COMMIT_arm64_v5.10.104_nvidia = 0a65b40fb320
-KERNEL_COMMIT_arm64_v5.10.186_generic = a153e7561ec8
-KERNEL_COMMIT_arm64_v6.1.38_generic = f6df810a500b
+KERNEL_COMMIT_arm64_v5.10.104_nvidia = 68c24df0b352
+KERNEL_COMMIT_arm64_v5.10.186_generic = 7d82e10c7d66
+KERNEL_COMMIT_arm64_v6.1.38_generic = d888a2ed5db3
 KERNEL_COMMIT_riscv64_v6.1.38_generic = ad6a4589904a


### PR DESCRIPTION
eve-kernel-arm64-v5.10.104-nvidia:
	68c24df0b352 arm64: configs: Enable VIRTIO_GPU driver
	a17efc4ce4d9 arm64: configs: Save tegra_eveos_defconfig with savedefconfig

eve-kernel-arm64-v5.10.186-generic:
	7d82e10c7d66 arm64: configs: Enable VIRTIO_GPU driver

eve-kernel-arm64-v6.1.38-generic:
	d888a2ed5db3 eve_defconfig: Fix options for Raspberry Pi4
	e4f0d55bb7b9 arm64: configs: Enable VIRTIO_GPU driver