### PR TITLE
[9.4-stable] backport: Carry media type through download verify.

### DIFF
--- a/pkg/pillar/cmd/verifier/verifier.go
+++ b/pkg/pillar/cmd/verifier/verifier.go
@@ -633,6 +633,10 @@ func verifyImageStatusFromVerifiedImageFile(imageFileName string,
 	if len(parts) == 2 {
 		// just ignore the error and treat mediaType as empty
 		mediaType, _ = url.PathUnescape(parts[1])
+	} else {
+		// if there is no mediaType, we force the redownload process by returning nil
+		log.Warnf("verifyImageStatusFromVerifiedImageFile: no mediaType in %s", imageFileName)
+		return nil
 	}
 	status := types.VerifyImageStatus{
 		Name:         imageFileName,
@@ -686,7 +690,20 @@ func populateInitialStatusFromVerified(ctx *verifierContext,
 				pathname, size/(1024*1024))
 			status := verifyImageStatusFromVerifiedImageFile(
 				location.Name(), size, pathname)
-			if status != nil {
+			if status == nil {
+				log.Warnf("populateInitialStatusFromVerified: cannot create status for %s", location.Name())
+				// If the file exists, but we cannot create a status from it, consider it as corrupted and remove it
+				_, err := os.Stat(pathname)
+				if err != nil {
+					// file does not exist, nothing to do
+					continue
+				}
+				log.Functionf("populateInitialStatusFromVerified: removing corrupted file %s", pathname)
+				err = os.Remove(pathname)
+				if err != nil {
+					log.Errorf("populateInitialStatusFromVerified: cannot remove broken file: %v", err)
+				}
+			} else {
 				imageHash, err := fileutils.ComputeShaFile(pathname)
 				if err != nil {
 					log.Errorf("populateInitialStatusFromVerified: cannot compute sha: %v", err)

--- a/pkg/pillar/cmd/verifier/verifier.go
+++ b/pkg/pillar/cmd/verifier/verifier.go
@@ -617,7 +617,10 @@ func handleInitVerifiedObjects(ctx *verifierContext) {
 	}
 }
 
-func verifyImageStatusFromImageFile(imageFileName string,
+// verifyImageStatusFromVerifiedImageFile given a verified image file,
+// return a VerifyImageStatus. Note that this is for a verified file, not a
+// verifying file.
+func verifyImageStatusFromVerifiedImageFile(imageFileName string,
 	size int64, pathname string) *types.VerifyImageStatus {
 
 	// filename might have two parts, separated by '.': digest and PathEscape(mediaType)
@@ -681,7 +684,7 @@ func populateInitialStatusFromVerified(ctx *verifierContext,
 			}
 			log.Tracef("populateInitialStatusFromVerified: Processing %s: %d Mbytes",
 				pathname, size/(1024*1024))
-			status := verifyImageStatusFromImageFile(
+			status := verifyImageStatusFromVerifiedImageFile(
 				location.Name(), size, pathname)
 			if status != nil {
 				imageHash, err := fileutils.ComputeShaFile(pathname)

--- a/pkg/pillar/cmd/verifier/verifier.go
+++ b/pkg/pillar/cmd/verifier/verifier.go
@@ -633,6 +633,7 @@ func verifyImageStatusFromVerifiedImageFile(imageFileName string,
 	if len(parts) == 2 {
 		// just ignore the error and treat mediaType as empty
 		mediaType, _ = url.PathUnescape(parts[1])
+		log.Tracef("verifyImageStatusFromVerifiedImageFile: mediaType %s recovered from %s", mediaType, imageFileName)
 	} else {
 		// if there is no mediaType, we force the redownload process by returning nil
 		log.Warnf("verifyImageStatusFromVerifiedImageFile: no mediaType in %s", imageFileName)
@@ -698,7 +699,7 @@ func populateInitialStatusFromVerified(ctx *verifierContext,
 					// file does not exist, nothing to do
 					continue
 				}
-				log.Functionf("populateInitialStatusFromVerified: removing corrupted file %s", pathname)
+				log.Tracef("populateInitialStatusFromVerified: removing corrupted file %s", pathname)
 				err = os.Remove(pathname)
 				if err != nil {
 					log.Errorf("populateInitialStatusFromVerified: cannot remove broken file: %v", err)

--- a/pkg/pillar/cmd/verifier/verifier_test.go
+++ b/pkg/pillar/cmd/verifier/verifier_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2024 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package verifier
+
+import (
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/sirupsen/logrus"
+	"path"
+	"testing"
+)
+
+func TestMediaTypeInStatusFromVerifiedFilename(t *testing.T) {
+	log = base.NewSourceLogObject(logrus.StandardLogger(), "verifier_test", 0)
+	mediaType := "application/vnd.docker.distribution.manifest.v2+json"
+	tmpID := "tempID"
+	sha256 := "dummySha256"
+	infile := "dummyFile"
+
+	_, _, verifiedFilename := ImageVerifierFilenames(infile, sha256, tmpID, mediaType)
+	status := verifyImageStatusFromVerifiedImageFile(verifiedFilename, 12345, "dummyPath")
+
+	if status == nil {
+		t.Fatalf("Status is nil")
+	}
+
+	if status.MediaType != mediaType {
+		t.Errorf("MediaType in status %v does not match original %v", status.MediaType, mediaType)
+	}
+}

--- a/pkg/pillar/cmd/verifier/verifier_test.go
+++ b/pkg/pillar/cmd/verifier/verifier_test.go
@@ -28,3 +28,17 @@ func TestMediaTypeInStatusFromVerifiedFilename(t *testing.T) {
 		t.Errorf("MediaType in status %v does not match original %v", status.MediaType, mediaType)
 	}
 }
+
+func TestMediaTypeInStatusFromVerifiedFilenameWithNoMediaType(t *testing.T) {
+	log = base.NewSourceLogObject(logrus.StandardLogger(), "verifier_test", 0)
+	dummyPath := "dummyPath"
+	dummyFilename := "someSha256"
+	verifiedFilename := path.Join(dummyPath, dummyFilename)
+
+	status := verifyImageStatusFromVerifiedImageFile(verifiedFilename, 12345, "dummyPath")
+
+	if status != nil {
+		t.Errorf("Status is not nil")
+	}
+
+}

--- a/pkg/pillar/cmd/volumemgr/handleverifier.go
+++ b/pkg/pillar/cmd/volumemgr/handleverifier.go
@@ -71,6 +71,7 @@ func MaybeAddVerifyImageConfigBlob(ctx *volumemgrContext, blob types.BlobStatus)
 			ImageSha256:  blob.Sha256, // the sha to verify
 			Name:         blob.Sha256, // we are just going to use the sha for the verifier display
 			RefCount:     refcount,
+			MediaType:    blob.MediaType,
 		}
 		log.Tracef("MaybeAddVerifyImageConfigBlob - config: %+v", vic)
 	}

--- a/pkg/pillar/types/verifiertypes.go
+++ b/pkg/pillar/types/verifiertypes.go
@@ -21,6 +21,7 @@ import (
 type VerifyImageConfig struct {
 	ImageSha256  string // sha256 of immutable image
 	Name         string
+	MediaType    string // MIME type
 	FileLocation string // Current location; should be info about file
 	Size         int64  //FileLocation size
 	RefCount     uint
@@ -91,6 +92,7 @@ type VerifyImageStatus struct {
 	Name          string
 	FileLocation  string // Current location
 	Size          int64
+	MediaType     string // MIME type
 	PendingAdd    bool
 	PendingModify bool
 	PendingDelete bool


### PR DESCRIPTION
This PR is a backport of PR #3706.
It stores the Blob media type as a part of the verified status filename so it can be restored after reboot.