### PR TITLE
[10.4-stable] backport: httputil: fix potential memleak

### DIFF
--- a/libs/zedUpload/httputil/http.go
+++ b/libs/zedUpload/httputil/http.go
@@ -259,6 +259,7 @@ func execCmdGet(ctx context.Context, objSize int64, localFile string, host strin
 			//keep it to call cancel regardless of logic to releases resources
 			innerCtxCancel()
 		})
+		defer inactivityTimer.Stop()
 		req, err := http.NewRequestWithContext(innerCtx, http.MethodGet, host, nil)
 		if err != nil {
 			stats.Error = fmt.Errorf("request failed for get %s: %s",

--- a/libs/zedUpload/httputil/http.go
+++ b/libs/zedUpload/httputil/http.go
@@ -287,6 +287,7 @@ func execCmdGet(ctx context.Context, objSize int64, localFile string, host strin
 			appendToErrorList("client.Do failed: %s", err)
 			continue
 		}
+		defer resp.Body.Close()
 
 		// supportRange indicates if server supports range requests
 		supportRange = resp.Header.Get("Accept-Ranges") == "bytes"
@@ -295,10 +296,6 @@ func execCmdGet(ctx context.Context, objSize int64, localFile string, host strin
 		//it indicates that server misconfigured
 		if !withRange && resp.StatusCode != http.StatusOK || withRange && resp.StatusCode != http.StatusPartialContent {
 			respErr := fmt.Sprintf("bad response code: %d", resp.StatusCode)
-			err = resp.Body.Close()
-			if err != nil {
-				respErr = fmt.Sprintf("respErr: %v; close Body error: %v", respErr, err)
-			}
 			appendToErrorList(respErr)
 			//we do not want to process server misconfiguration here
 			break

--- a/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/httputil/http.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve/libs/zedUpload/httputil/http.go
@@ -259,6 +259,7 @@ func execCmdGet(ctx context.Context, objSize int64, localFile string, host strin
 			//keep it to call cancel regardless of logic to releases resources
 			innerCtxCancel()
 		})
+		defer inactivityTimer.Stop()
 		req, err := http.NewRequestWithContext(innerCtx, http.MethodGet, host, nil)
 		if err != nil {
 			stats.Error = fmt.Errorf("request failed for get %s: %s",
@@ -286,6 +287,7 @@ func execCmdGet(ctx context.Context, objSize int64, localFile string, host strin
 			appendToErrorList("client.Do failed: %s", err)
 			continue
 		}
+		defer resp.Body.Close()
 
 		// supportRange indicates if server supports range requests
 		supportRange = resp.Header.Get("Accept-Ranges") == "bytes"
@@ -294,10 +296,6 @@ func execCmdGet(ctx context.Context, objSize int64, localFile string, host strin
 		//it indicates that server misconfigured
 		if !withRange && resp.StatusCode != http.StatusOK || withRange && resp.StatusCode != http.StatusPartialContent {
 			respErr := fmt.Sprintf("bad response code: %d", resp.StatusCode)
-			err = resp.Body.Close()
-			if err != nil {
-				respErr = fmt.Sprintf("respErr: %v; close Body error: %v", respErr, err)
-			}
 			appendToErrorList(respErr)
 			//we do not want to process server misconfiguration here
 			break


### PR DESCRIPTION
IMHO similar to 9c194dd01514aa4fc59e95a156635fc22ea9dc31 the memleak also has to be fixed here

The fix for a newer version has also been introduced here: https://github.com/lf-edge/eve-libs/commit/127266b85fcc4557158cb3029d42efd72bc6bb01#diff-4a3ca89f1c1037aa18b0258facf633f93de2016bfb09906794e7cc7c88f4fd62R264 (which has then been replaced by https://github.com/lf-edge/eve-libs/commit/08a38c83afefbec7854d92fbc5419e53dea01af5 )