### PR TITLE
downloader: Improve comments

### DIFF
--- a/pkg/pillar/cmd/downloader/syncop.go
+++ b/pkg/pillar/cmd/downloader/syncop.go
@@ -346,7 +346,7 @@ func handleSyncOpResponse(ctx *downloaderContext, config types.DownloaderConfig,
 
 	if errStr != "" {
 		if cleanOnError {
-			// Delete downloaded files
+			// Delete downloaded + progress files
 			doDelete(ctx, key, locFilename, status)
 		}
 		return cancelled, errStr
@@ -355,7 +355,8 @@ func handleSyncOpResponse(ctx *downloaderContext, config types.DownloaderConfig,
 	// make sure the file exists
 	_, err := os.Stat(locFilename)
 	if err != nil {
-		// Nothing was downloaded? Delete progress files if any
+		// Nothing was downloaded? Call doDelete() to remove any remained
+		// progress file
 		doDelete(ctx, key, locFilename, status)
 		errStr := fmt.Sprintf("%v", err)
 		return cancelled, errStr


### PR DESCRIPTION
Improve comments from the donwloader code.

Original PR:
~When the destination file (locFilename) is not found, we try to remove any remained progress files. This commit adds the suffix for these files, which was missing.~
It turns out this modification is not needed.