### PR TITLE
Enhance dmesg readability and add disk usage info in collect-info.sh

### DIFF
--- a/pkg/debug/scripts/collect-info.sh
+++ b/pkg/debug/scripts/collect-info.sh
@@ -5,7 +5,7 @@
 #
 
 # Script version, don't forget to bump up once something is changed
-VERSION=13
+VERSION=14
 
 # Add required packages here, it will be passed to "apk add".
 # Once something added here don't forget to add the same package
@@ -265,7 +265,7 @@ chroot /hostfs lsusb -vvv -t > "$DIR/lsusb-vvv-t"
     ls -l /sys/class/net/
 } > "$DIR/sys-fs-usb"
 
-dmesg            > "$DIR/dmesg"
+dmesg -T         > "$DIR/dmesg-T"
 ps -xao uid,pid,ppid,vsz,rss,c,pcpu,pmem,stime,tname,stat,time,cmd \
                  > "$DIR/ps-xao"
 lspci -vvv       > "$DIR/lspci-vvv"
@@ -279,6 +279,7 @@ dmidecode        > "$DIR/dmidecode"
 ls -lRa /dev     > "$DIR/ls-lRa-dev"
 ls -lRa /persist > "$DIR/ls-lRa-persist"
 free             > "$DIR/free"
+df -h            > "$DIR/df-h"
 
 echo "- vmallocinfo, slabinfo, meminfo, zoneinfo, mounts, vmstat, cpuinfo, iomem"
 cat /proc/vmallocinfo > "$DIR/vmallocinfo"

--- a/pkg/debug/scripts/collect-info.sh
+++ b/pkg/debug/scripts/collect-info.sh
@@ -5,7 +5,7 @@
 #
 
 # Script version, don't forget to bump up once something is changed
-VERSION=14
+VERSION=15
 
 # Add required packages here, it will be passed to "apk add".
 # Once something added here don't forget to add the same package
@@ -331,12 +331,20 @@ collect_pillar_backtraces
 # ZFS part
 collect_zfs_info
 
+check_tar_flags() {
+  tar --version | grep -q "GNU tar"
+}
+
 # Make a tarball
 # --exlude='root-run/run'              /run/run/run/.. exclude symbolic link loop
 # --ignore-failed-read --warning=none  ignore all errors, even if read fails
 # --dereference                        follow symlinks
 echo "- tar/gzip"
-tar -C "$TMP_DIR" --exclude='root-run/run' --ignore-failed-read --warning=none --dereference -czf "$TARBALL_FILE" "$INFO_DIR"
+if check_tar_flags; then
+  tar -C "$TMP_DIR" --exclude='root-run/run' --ignore-failed-read --warning=none --dereference -czf "$TARBALL_FILE" "$INFO_DIR"
+else
+  tar -C "$TMP_DIR" --exclude='root-run/run' --dereference -czf "$TARBALL_FILE" "$INFO_DIR"
+fi
 rm -rf "$TMP_DIR"
 sync
 


### PR DESCRIPTION
Modified the dmesg command to use the -T flag, which converts timestamps to a human-readable format, improving log readability.

Added the 'du -h' command to gather disk usage information in a human-readable format, providing a clearer overview of the system's disk usage.