### PR TITLE
 [9.4-stable] backport: backport: httputil: fix potential memleak

### DIFF
--- a/libs/zedUpload/httputil/http.go
+++ b/libs/zedUpload/httputil/http.go
@@ -182,6 +182,7 @@ func ExecCmd(ctx context.Context, cmd, host, remoteFile, localFile string, objSi
 				//keep it to call cancel regardless of logic to releases resources
 				innerCtxCancel()
 			})
+			defer inactivityTimer.Stop()
 			req, err := http.NewRequestWithContext(innerCtx, http.MethodGet, host, nil)
 			if err != nil {
 				stats.Error = fmt.Errorf("request failed for get %s: %s",

--- a/libs/zedUpload/httputil/http.go
+++ b/libs/zedUpload/httputil/http.go
@@ -212,6 +212,7 @@ func ExecCmd(ctx context.Context, cmd, host, remoteFile, localFile string, objSi
 				}
 				continue
 			}
+			defer resp.Body.Close()
 
 			// supportRange indicates if server supports range requests
 			supportRange = resp.Header.Get("Accept-Ranges") == "bytes"
@@ -220,10 +221,6 @@ func ExecCmd(ctx context.Context, cmd, host, remoteFile, localFile string, objSi
 			//it indicates that server misconfigured
 			if !withRange && resp.StatusCode != http.StatusOK || withRange && resp.StatusCode != http.StatusPartialContent {
 				respErr := fmt.Errorf("bad response code: %d", resp.StatusCode)
-				err = resp.Body.Close()
-				if err != nil {
-					respErr = fmt.Errorf("respErr: %v; close Body error: %v", respErr, err)
-				}
 				appendToErrorList(attempt, respErr)
 				//we do not want to process server misconfiguration here
 				break


### PR DESCRIPTION
IMHO similar to https://github.com/lf-edge/eve/commit/9c194dd01514aa4fc59e95a156635fc22ea9dc31 the memleak also has to be fixed here

The fix for a newer version has also been introduced here: https://github.com/lf-edge/eve-libs/commit/127266b85fcc4557158cb3029d42efd72bc6bb01#diff-4a3ca89f1c1037aa18b0258facf633f93de2016bfb09906794e7cc7c88f4fd62R264 (which has then been replaced by https://github.com/lf-edge/eve-libs/commit/08a38c83afefbec7854d92fbc5419e53dea01af5 )