### PR TITLE
Fixes in the verification scripts and documentation

### DIFF
--- a/docs/HARDWARE-VERIFICATION.md
+++ b/docs/HARDWARE-VERIFICATION.md
@@ -87,12 +87,26 @@ the read performance of the available storage devices using
 ## Getting the results of the verification process
 
 The verification image prints the results of tests on the screen and stores
-them when possible (e.g., when we are using the raw version) in the
-**inventory partition** of the boot media. We can get the verification process
-results by running the command ```tools/extract_verification_info.sh <verification.raw>```
+them when possible (e.g., when we are using a USB or a raw file) in the
+**inventory partition** of the boot media. We can extract the logs of the
+verification process results by running the command
+```tools/extract-verification-info.sh <USB_device_name|verification_img>```
 on the `verification.raw` image file or on the USB stick. To achieve that, we must
-mount the USB stick or copy the image file to a PC and execute the script. The
+mount the USB stick or copy the image file to our PC and execute the script. The
 script copies, among other things, the logs of the tests, details about the
 hardware, etc. A file named ```summary.log``` contains a summary of the
 verification process results to help the user quickly understand potential
 problems.
+
+## Publishing the results of the verification processes
+
+Apart from extracting the logs of the verification process, we can upload
+the results of verification in a dedicated web application.
+For this, we need to plug the USB stick or copy the file containing the verification
+on our PC and execute the script `tools/publish-verification-info.sh`.
+Assuming the web application is running on `www.example.com:8999`, we can publish
+the results by running the script as follows:
+```./publish-verification-info.sh /dev/disk4 https://www.example.com:8999```
+or ```./publish-verification-info.sh verification.raw https://www.example.com:8999```.
+That way, we can access the logs of different verification processes in a centralized
+and user-friendly manner.

--- a/tools/extract-verification-info.sh
+++ b/tools/extract-verification-info.sh
@@ -2,15 +2,42 @@
 
 img=$1
 
-if [ "$img" == "" ]; then
-  echo "Usage ./extract_verification_info.sh <verification.img>"
+if [ "$img" == "" ] || [ "$EUID" -ne 0 ]; then
+  echo "Usage sudo ./extract-verification-info.sh <USB_device_name|verification_img>"
+  echo "E.g., sudo ./extract-verification-info.sh /dev/disk4"
+  echo "Or, sudo ./extract-verification-info.sh dist/amd64/current/verification.raw"
   exit
 fi
 
-size=$(fdisk -l "$img" | grep raw5 | awk '{print $2}')
-mkdir /tmp/verification_mnt
-sudo mount -o offset=$((size*512)) "$img" /tmp/verification_mnt
-cp /tmp/verification_mnt/*/summary.log ./
-cat /tmp/verification_mnt/*/summary.log
-sudo umount /tmp/verification_mnt
-rmdir /tmp/verification_mnt
+checkOScmd=$(echo "${OSTYPE}" | grep darwin) # Running on MacOS
+mountDir="/tmp/verification_mnt"
+if [ -n "${checkOScmd}" ]; then # MacOS
+  devicename="${img}"
+  if [ -f "${img}" ]; then # file
+    tmp=$(/usr/bin/hdiutil attach -imagekey diskimage-class=CRawDiskImage -nomount "${img}")
+    devicename=$(echo "${tmp}" | grep "GUID_partition_scheme" | awk '{print $1}')
+  fi
+  /usr/sbin/diskutil mount "${devicename}"s5
+  mountDir="/Volumes/INVENTORY"
+else # Linux
+  mkdir "${mountDir}"
+  if [ -f "${img}" ]; then # file
+    size=$(fdisk -l "$img" | grep raw5 | awk '{print $2}')
+    mount -o offset=$((size*512)) "$img" "${mountDir}"
+  else # block device
+    mount "${img}"5 "${mountDir}"
+  fi
+fi
+
+cp -r ${mountDir}/* ./
+cat ${mountDir}/*/summary.log
+
+if [ -n "${checkOScmd}" ]; then # MacOS
+  /usr/sbin/diskutil umount "${devicename}"s5
+  if [ -f "${img}" ]; then # file
+    /usr/bin/hdiutil detach "${devicename}"
+  fi
+else # Linux
+  umount "${mountDir}"
+  rmdir "${mountDir}"
+fi

--- a/tools/publish-verification-info.sh
+++ b/tools/publish-verification-info.sh
@@ -3,19 +3,18 @@
 img="$1"
 url="$2"
 
-if [ "$img" == "" ] || [ "$url" == "" ]; then
-  echo "Usage ./publish_verification_info.sh <USB_device_name|verification_img> <server_url>"
-  echo "E.g., ./publish_verification_info.sh /dev/disk4 https://somewhere.example.com:8999"
-  echo "Or, ./publish_verification_info.sh dist/amd64/current/verification.img https://somewhere.example.com:8999"
+if [ "$img" == "" ] || [ "$url" == "" ] || [ "$EUID" -ne 0 ]; then
+  echo "Usage sudo ./publish-verification-info.sh <USB_device_name|verification_img> <server_url>"
+  echo "E.g., sudo ./publish-verification-info.sh /dev/disk4 https://somewhere.example.com:8999"
+  echo "Or, sudo ./publish-verification-info.sh dist/amd64/current/verification.raw https://somewhere.example.com:8999"
   exit
 fi
 
-checkOScmd="echo ${OSTYPE} | grep -q darwin" # Running on MacOS
-checkVerificationImg="eval file ${img} | grep -q DOS/MBR" # this is a file not a block device
+checkOScmd=$(echo "${OSTYPE}" | grep darwin) # Running on MacOS
 mountDir="/tmp/verification_mnt"
-if eval "${checkOScmd}"; then # MacOS
+if [ -n "${checkOScmd}" ];  then # MacOS
   devicename="${img}"
-  if eval "${checkVerificationImg}"; then # file
+  if [ -f "${img}" ]; then # file
     tmp=$(/usr/bin/hdiutil attach -imagekey diskimage-class=CRawDiskImage -nomount "${img}")
     devicename=$(echo "${tmp}" | grep "GUID_partition_scheme" | awk '{print $1}')
   fi
@@ -23,11 +22,11 @@ if eval "${checkOScmd}"; then # MacOS
   mountDir="/Volumes/INVENTORY/"
 else # Linux
   mkdir "${mountDir}"
-  if eval "${checkVerificationImg}"; then # file
+  if [ -f "${img}" ]; then # file
     size=$(fdisk -l "$img" | grep raw5 | awk '{print $2}')
-    sudo mount -o offset=$((size*512)) "$img" "${mountDir}"
+    mount -o offset=$((size*512)) "$img" "${mountDir}"
   else # block device
-    sudo mount "${img}"5 "${mountDir}"
+    mount "${img}"5 "${mountDir}"
   fi
 fi
 
@@ -47,15 +46,15 @@ tar zcvf "${fname}" "${dirname}"
 rm -rf "${dirname}"
 
 CSRF_TOKEN=$(curl -s -c cookies.txt "$url/upload" | xmllint --html --xpath 'string(//input[@name="csrfmiddlewaretoken"]/@value)' - 2>/dev/null)
-curl -X POST -b cookies.txt -F "csrfmiddlewaretoken=$CSRF_TOKEN" -F  "file=@${fname}" "$url/upload"
+curl -e "$url" -X POST -b cookies.txt -F "csrfmiddlewaretoken=$CSRF_TOKEN" -F  "file=@${fname}" "$url/upload"
 
 rm cookies.txt "${fname}"
-if eval "${checkOScmd}"; then # MacOS
+if [ -n "${checkOScmd}" ]; then # MacOS
   /usr/sbin/diskutil umount "${devicename}"s5
-  if eval "${checkVerificationImg}"; then # file
+  if [ -f "${img}" ]; then # file
     /usr/bin/hdiutil detach "${devicename}"
   fi
 else # Linux
-  sudo umount "${mountDir}"
+  umount "${mountDir}"
   rmdir "${mountDir}"
 fi


### PR DESCRIPTION
- Added renderer in the curl command of publish-verification-info.sh. This is necessary because we changed the URL of the web application that stores the published verification results from http to https
- Added the necessary commands in the extract-verification-info.sh script so that it works in MAC as well.
- Updated the documentation that explains how to extract the logs of the verification process to match the current status.
- Added a section in the documentation that explains how to publish the verification process in the certification web application.