### PR TITLE
bump runc

### DIFF
--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -3,7 +3,7 @@ kernel:
   cmdline: "rootdelay=3"
 init:
   - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
-  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   # pillar's logic rely on existence of getty and /etc/init.d/001-getty inside
   - linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7


### PR DESCRIPTION
This version includes a fix for CVE-2024-21626 which allowed an attacker in bad circumstances to
"escape containerized environments".

See also https://access.redhat.com/security/cve/cve-2024-21626