### PR TITLE
[9.4-stable] Bump runc

### DIFF
--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -3,7 +3,7 @@ kernel:
   cmdline: "rootdelay=3"
 init:
   - linuxkit/init:8f1e6a0747acbbb4d7e24dc98f97faa8d1c6cec7
-  - linuxkit/runc:f01b88c7033180d50ae43562d72707c6881904e4
+  - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:de1b18eed76a266baa3092e5c154c84f595e56da
   # pillar's logic rely on existence of getty and /etc/init.d/001-getty inside
   - linuxkit/getty:c9d5afa9a61ac907904090643e946874ff6bf07c


### PR DESCRIPTION
This version includes a fix for CVE-2024-21626 which allowed an attacker in bad circumstances to
"escape containerized environments".

See also https://access.redhat.com/security/cve/cve-2024-21626