### PR TITLE
Call getpwuid only after chroot is set

### DIFF
--- a/pkg/xen-tools/initrd/chroot2.c
+++ b/pkg/xen-tools/initrd/chroot2.c
@@ -29,18 +29,19 @@ static int child_func(void *args)
     struct clone_args *parsed_args = args;
     struct passwd *pws;
 
-    pws = getpwuid(parsed_args->uid);
-    if (pws == NULL)
-        err(-1, "getpwuid(%d) failed:", parsed_args->uid);
-
-    if (initgroups(pws->pw_name, parsed_args->gid) != 0)
-        err(-1, "initgroups(%s, %d) failed:", pws->pw_name, parsed_args->gid);
 
     if (chroot(parsed_args->chroot) != 0)
         err(-1, "chroot(%s) failed:", parsed_args->chroot);
 
     if (chdir(parsed_args->workdir) != 0)
         err(-1, "chdir(%s) failed:", parsed_args->workdir);
+
+    pws = getpwuid(parsed_args->uid);
+    if (pws == NULL)
+        err(-1, "getpwuid(%d) failed:", parsed_args->uid);
+
+    if (initgroups(pws->pw_name, parsed_args->gid) != 0)
+        err(-1, "initgroups(%s, %d) failed:", pws->pw_name, parsed_args->gid);
 
     if (mount("proc", "/proc", "proc", 0, NULL) != 0)
         err(-1, "mount(proc) failed:");


### PR DESCRIPTION
There is a regression in recent commit where getpwuid() was added before chroot is set. Due to that any container which runs with non-root userid will fail to start. 

Testing done
===========
Before this fix grafana container which runs with user id 472 was failing to start. It works with this fix.