### PR TITLE
[10.4-stable] go.mod

### DIFF
--- a/pkg/pillar/go.mod
+++ b/pkg/pillar/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/jaypipes/ghw v0.8.0
 	github.com/lf-edge/edge-containers v0.0.0-20221025050409-93c34bebadd2
 	github.com/lf-edge/eve/api/go v0.0.0-20230602070228-0c11e32c7718
-	github.com/lf-edge/eve/libs v0.0.0-20230717153241-cc5629af4657
+	github.com/lf-edge/eve/libs v0.0.0-20240206160900-ca7870e7c35f
 	github.com/linuxkit/linuxkit/src/cmd/linuxkit v0.0.0-20220913135124-e532e7310810
 	github.com/miekg/dns v1.1.41
 	github.com/moby/sys/mountinfo v0.6.0

--- a/pkg/pillar/go.sum
+++ b/pkg/pillar/go.sum
@@ -1119,6 +1119,8 @@ github.com/lf-edge/eve/api/go v0.0.0-20230602070228-0c11e32c7718 h1:gtmjnX95WEKW
 github.com/lf-edge/eve/api/go v0.0.0-20230602070228-0c11e32c7718/go.mod h1:pNFho84HAA/Vlb1DpLFlatJgQBJ43wH28elAs7wXdtA=
 github.com/lf-edge/eve/libs v0.0.0-20230717153241-cc5629af4657 h1:2DERGuT2XEkCJIvtfnD0+XAaovV73KtMD3bzfV8AVdI=
 github.com/lf-edge/eve/libs v0.0.0-20230717153241-cc5629af4657/go.mod h1:OLbkEWaPL1SKTywCA3wg2xBwwF+wB78IB5ASHbJ52IQ=
+github.com/lf-edge/eve/libs v0.0.0-20240206160900-ca7870e7c35f h1:EW44Q94w7C9EEZhJXEEfXxKltXI9+g9DyiE9M1FA6LI=
+github.com/lf-edge/eve/libs v0.0.0-20240206160900-ca7870e7c35f/go.mod h1:9xoaLCcMlTZQBviUUxU4qBpB+nAbnPk2K156GLvyDsI=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=

--- a/pkg/pillar/vendor/modules.txt
+++ b/pkg/pillar/vendor/modules.txt
@@ -481,7 +481,7 @@ github.com/lf-edge/eve/api/go/logs
 github.com/lf-edge/eve/api/go/metrics
 github.com/lf-edge/eve/api/go/profile
 github.com/lf-edge/eve/api/go/register
-# github.com/lf-edge/eve/libs v0.0.0-20230717153241-cc5629af4657
+# github.com/lf-edge/eve/libs v0.0.0-20240206160900-ca7870e7c35f
 ## explicit; go 1.20
 github.com/lf-edge/eve/libs/depgraph
 github.com/lf-edge/eve/libs/nettrace


### PR DESCRIPTION
after https://github.com/lf-edge/eve/pull/3713 has been merged, this can be referenced in go.mod