### PR TITLE
yetus: Remove calls to rand.Seed()

### DIFF
--- a/pkg/pillar/execlib/execlib.go
+++ b/pkg/pillar/execlib/execlib.go
@@ -49,12 +49,7 @@ func New(ps *pubsub.PubSub, log *base.LogObject, agentName string, executor stri
 	})
 	pubExecConfig.Unpublish(agentName)
 
-	// Start with a random number in case the process as run before
-	// and used some sequence
-	now := time.Now()
-	_, _, seed := now.Clock()
-	seed += now.Nanosecond()
-	rand.Seed(int64(seed))
+	// No need to use rand.Seed() any more
 	sequence := rand.Int()
 
 	handle := ExecuteHandle{

--- a/pkg/pillar/tgt/tgt.go
+++ b/pkg/pillar/tgt/tgt.go
@@ -22,10 +22,6 @@ const (
 	naaPrefix  = "5001405" // from rtslib-fb
 )
 
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
-
 func waitForFile(fileName string) error {
 	maxDelay := time.Second * 5
 	delay := time.Millisecond * 500


### PR DESCRIPTION
Fixes: golangcilint: SA1019: rand.Seed has been deprecated since Go 1.20 and an alternative has been available since Go 1.0: As of Go 1.20 there is no reason to call Seed with a random value. Programs that call Seed with a known value to get a specific sequence of results should use New(NewSource(seed)) to obtain a local random generator. (staticcheck)