### PR TITLE
only get run ID when neededfor CI

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -20,6 +20,7 @@ concurrency:
 
 jobs:
   get-run-id:
+    if: github.event.review.state == 'approved'
     runs-on: ubuntu-latest
     outputs:
       result: ${{ steps.get-run-id.outputs.result }}


### PR DESCRIPTION
The previous PR #3698 removed danger, and found the run-id to get the artifact, passing it to `test_suite_pr`. That job `test_suite_pr` is the only job that needs the run ID, and it only runs if it is triggered by a PR approval.

As such, `get-run-id`  _also_ only needs to run on PR approval. Right now, it is running even on master, which is causing a failure, since it tries to reference the sha of the PR, nonsensical in the case of non-PR.

This PR adds the exact same `if` condition to `get-run-id` as what already exists on `test_suite_pr`.