### PR TITLE
[11.0-stable] Give wwan microservice access to the config partition

### DIFF
--- a/pkg/wwan/build.yml
+++ b/pkg/wwan/build.yml
@@ -5,6 +5,7 @@ config:
     - /lib/modules:/lib/modules
     - /dev:/dev
     - /run:/run
+    - /config:/config
     - /:/hostfs
     - /persist:/persist:rshared,rbind
   net: host


### PR DESCRIPTION
mmagent from the wwan microservice uses `GetCipherCredentials` to decrypt username/password for a cellular network. Internally, this depends on `IsTpmEnabled()` function, which determines the status of TPM by checking for the presence/absence of `/config/device.cert.pem` and `/config/device.key.pem`. This means that wwan container should have the config partition mounted as well, otherwise `IsTpmEnabled()` may return incorrect value and cause the decryption to fail.