### PR TITLE
xen-tools/init-initrd: Validates the environment file

### DIFF
--- a/pkg/xen-tools/initrd/init-initrd
+++ b/pkg/xen-tools/initrd/init-initrd
@@ -133,9 +133,18 @@ mount -t overlay -o rw,relatime,lowerdir=/mnt/modules,upperdir=/mnt/rootfs/tmp/m
 echo "Executing /mount_disk.sh"
 /mount_disk.sh
 
-# Commence launch sequence
-source /mnt/environment
+# Check if the environment file can be successfully processed by the shell,
+# otherwise write an error message and exit with the input data error code
+# shellcheck disable=SC1091,SC2091
+if $(. /mnt/environment); then
+    # shellcheck disable=SC1091
+    . /mnt/environment
+else
+    echo "Error processing the environment variables file!"
+    exit 65 # EX_DATAERR
+fi
 
+# Start launch sequence
 echo "Run acpid daemon"
 acpid -l /proc/self/fd/1
 


### PR DESCRIPTION
<del>Custom variables are passed to container applications through the /mnt/environment file. Although variables are parsed and trimmed (spaces and double quotes) by pillar, a wrong declaration like the following can still happen:</del>

<del>"MYVAR="wrong"</del>

<del>Other declaration ways can also be exploited to break the shell, which will lead the shim VM to crash.</del>

<del>This commit adds a protection against a bad environment file by first processing it in a sub shell and only executing source command if the file is valid.</del>

Custom variables are passed to container applications through the /mnt/environment file. Any syntax error on this file will break the shell and make the shim VM crash with no clear error indication.
    
This PR adds a validation of the /mnt/environment file and write a proper error message in the file cannot be processed by the shell.

PS: Parsing improvements are provided by the PR https://github.com/lf-edge/eve/pull/3760