### PR TITLE
Usbmanager: Implement parentassigngrp

### DIFF
--- a/pkg/debug/spec.sh
+++ b/pkg/debug/spec.sh
@@ -234,7 +234,7 @@ print_usb_controllers() {
         grp="group$(pci_iommu_group "$USB")"
         cat <<__EOT__
     {
-      "ztype": 2,
+      "ztype": "IO_TYPE_USB_CONTROLLER",
       "phylabel": "USB${ID}",
       "assigngrp": "${grp}",
       "phyaddrs": {
@@ -257,7 +257,7 @@ __EOT__
     if [ -z "$ID" ] && [ "$(lsusb -t | wc -l)" -gt 0 ]; then
     cat <<__EOT__
     {
-      "ztype": 2,
+      "ztype": "IO_TYPE_USB_CONTROLLER",
       "phylabel": "USB",
       "assigngrp": "USB",
       "logicallabel": "USB",
@@ -300,7 +300,7 @@ print_usb_devices() {
     for i in $(find /sys/devices/ -name uevent | grep -E '/usb[0-9]/' | grep -E '/[0-9]-[0-9](\.[0-9]+)?/uevent')
     do
         local labelprefix="USB"
-        local ztype="IO_TYPE_UNSPECIFIED"
+        local ztype="IO_TYPE_USB_DEVICE"
         local ignore_dev=0
         local devicepath
         devicepath=$(dirname "$i")
@@ -382,6 +382,7 @@ print_usb_devices() {
       "ztype": "${ztype}",
       "phylabel": "${label}",
       "assigngrp": "${assigngrp}",
+      "parentassigngrp": "${parentassigngrp}",
       "cost": ${cost},
       "phyaddrs": {
         "usbaddr": "$usbaddr",
@@ -396,6 +397,7 @@ __EOT__
 
 if [ "$usb_devices" = "1" ]
 then
+    print_usb_controllers
     print_usb_devices
 else
     print_usb_controllers

--- a/pkg/pillar/cmd/usbmanager/ioBundleTree.go
+++ b/pkg/pillar/cmd/usbmanager/ioBundleTree.go
@@ -1,0 +1,349 @@
+// Copyright (c) 2023 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package usbmanager
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+type ioBundlesArray []*types.IoBundle
+
+func (iba ioBundlesArray) Len() int {
+	return len(iba)
+}
+func (iba ioBundlesArray) Swap(i, j int) {
+	iba[i], iba[j] = iba[j], iba[i]
+}
+func (iba ioBundlesArray) Less(i, j int) bool {
+	return strings.Compare(iba[i].Phylabel, iba[j].Phylabel) == -1
+}
+
+type ioBundlesElem struct {
+	ioBundlesMap    map[string]*types.IoBundle // phylabel is key
+	assignmentGroup string
+	parent          *ioBundlesElem
+	children        map[string]*ioBundlesElem // assignmentGroup of child is key
+}
+
+func (ibe *ioBundlesElem) ioBundles() []*types.IoBundle {
+	ret := make([]*types.IoBundle, 0)
+
+	for _, ioBundle := range ibe.ioBundlesMap {
+		ret = append(ret, ioBundle)
+	}
+
+	sort.Sort(ioBundlesArray(ret))
+
+	return ret
+}
+
+type ioBundleTree struct {
+	root                      *ioBundlesElem
+	elementsByAssignmentGroup map[string]*ioBundlesElem
+	phylabel2ioBundle         map[string]*types.IoBundle
+}
+
+func newIOBundleTree() *ioBundleTree {
+	iobt := ioBundleTree{}
+
+	iobt.root = &ioBundlesElem{
+		ioBundlesMap:    map[string]*types.IoBundle{},
+		assignmentGroup: "",
+		parent:          nil,
+		children:        map[string]*ioBundlesElem{},
+	}
+
+	iobt.elementsByAssignmentGroup = make(map[string]*ioBundlesElem)
+	iobt.elementsByAssignmentGroup[iobt.root.assignmentGroup] = iobt.root
+	iobt.phylabel2ioBundle = make(map[string]*types.IoBundle)
+
+	return &iobt
+}
+
+func (iobt ioBundleTree) ioBundle(phylabel string) *types.IoBundle {
+	return iobt.phylabel2ioBundle[phylabel]
+}
+
+// groupParents returns assignment groups this assignment group is dependent on
+func (iobt ioBundleTree) groupParents(assigngrp string) []string {
+	ret := make([]string, 0)
+	ioBundleElem := iobt.elementsByAssignmentGroup[assigngrp]
+	if ioBundleElem == nil {
+		return ret
+	}
+
+	ioBundleElem = ioBundleElem.parent
+	for ioBundleElem != nil {
+		ret = append(ret, ioBundleElem.assignmentGroup)
+		ioBundleElem = ioBundleElem.parent
+	}
+
+	return ret
+}
+
+// groupDependents returns assignment groups that are dependent on this assignment group
+func (iobt ioBundleTree) groupDependendents(assigngrp string) []string {
+	groups := make(map[string]struct{})
+
+	ioBundlesElem := iobt.elementsByAssignmentGroup[assigngrp]
+	iobt.groupDependendentsImpl(groups, ioBundlesElem)
+
+	ret := make([]string, 0)
+	for assigngrp := range groups {
+		ret = append(ret, assigngrp)
+	}
+
+	sort.Strings(ret)
+	return ret
+}
+
+func (iobt ioBundleTree) groupDependendentsImpl(groups map[string]struct{}, ioBundlesElem *ioBundlesElem) {
+	if ioBundlesElem == nil {
+		return
+	}
+
+	for _, childioBundlesElem := range ioBundlesElem.children {
+		groups[childioBundlesElem.assignmentGroup] = struct{}{}
+		iobt.groupDependendentsImpl(groups, childioBundlesElem)
+	}
+
+}
+
+func (iobt *ioBundleTree) removeIOBundle(ioBundle *types.IoBundle) {
+	delete(iobt.phylabel2ioBundle, ioBundle.Phylabel)
+	ibe := iobt.elementsByAssignmentGroup[ioBundle.AssignmentGroup]
+
+	if ibe == nil {
+		return
+	}
+
+	delete(ibe.ioBundlesMap, ioBundle.Phylabel)
+
+	if len(ibe.ioBundlesMap) > 0 {
+		return
+	}
+
+	if ibe.parent == nil {
+		return
+	}
+
+	// if grandparent and parent have no ioBundles, then remove the grandparent
+	// and put the parent under the root element
+	if len(ibe.parent.ioBundlesMap) > 0 {
+		return
+	}
+
+	var ioBundlesGrandParent *ioBundlesElem
+	if ibe.parent != nil && ibe.parent.parent != nil {
+		ioBundlesGrandParent = ibe.parent.parent
+	}
+
+	if ioBundlesGrandParent != nil {
+		delete(ioBundlesGrandParent.children, ibe.parent.assignmentGroup)
+	}
+
+	ibe.parent = iobt.root
+}
+
+func (iobt *ioBundleTree) addIOBundle(ioBundle *types.IoBundle) {
+	dependents := iobt.groupDependendents(ioBundle.AssignmentGroup)
+	for _, dependee := range dependents {
+		if dependee == ioBundle.ParentAssignmentGroup {
+			log.Warnf("detected parentassigngrp circular dependency, not adding ioBundle %s", ioBundle.Phylabel)
+			return
+		}
+	}
+
+	iobt.phylabel2ioBundle[ioBundle.Phylabel] = ioBundle
+	if ioBundle.AssignmentGroup == "" {
+		iobt.root.ioBundlesMap[ioBundle.Phylabel] = ioBundle
+		return
+	}
+
+	ibe := iobt.elementsByAssignmentGroup[ioBundle.AssignmentGroup]
+	if ibe == nil {
+		ioBundleMap := make(map[string]*types.IoBundle)
+		ioBundleMap[ioBundle.Phylabel] = ioBundle
+		ibe = &ioBundlesElem{
+			ioBundlesMap:    ioBundleMap,
+			assignmentGroup: ioBundle.AssignmentGroup,
+			parent:          &ioBundlesElem{},
+			children:        map[string]*ioBundlesElem{},
+		}
+		iobt.elementsByAssignmentGroup[ioBundle.AssignmentGroup] = ibe
+	}
+
+	parentIbe := iobt.elementsByAssignmentGroup[ioBundle.ParentAssignmentGroup]
+	if parentIbe == nil {
+		parentIbe = &ioBundlesElem{
+			ioBundlesMap:    map[string]*types.IoBundle{},
+			assignmentGroup: ioBundle.ParentAssignmentGroup,
+			parent:          iobt.root,
+			children:        map[string]*ioBundlesElem{},
+		}
+
+		iobt.elementsByAssignmentGroup[ioBundle.ParentAssignmentGroup] = parentIbe
+		iobt.root.children[ioBundle.ParentAssignmentGroup] = parentIbe
+	}
+
+	if parentIbe.children[ibe.assignmentGroup] == nil {
+		parentIbe.children[ibe.assignmentGroup] = ibe
+	}
+
+	if ibe.parent == nil && ibe.assignmentGroup != "" {
+		ibe.parent = parentIbe
+	}
+
+	ibe.ioBundlesMap[ioBundle.Phylabel] = ioBundle
+
+	if ibe.parent != nil && ibe.parent.assignmentGroup != ioBundle.ParentAssignmentGroup {
+		if len(ibe.ioBundlesMap) == 1 {
+			// as there is only one ioBundle where there is a misalignment between ioBundle parent and the ioBundleElem parent
+			// we can fix this
+			// this f.e. happens when:
+			// add ioBundle with Parent X
+			// ioBundleElem with ioBundle and parent ioBundleElem X is added
+			// remove this ioBundle
+			// ioBundleElem still exists and the parent still points to ioBundleElem X
+			// add ioBundle with Parent Y
+			// now we set the parent of the ioBundleElemn to the Y ioBundleElem
+
+			ibe.parent = parentIbe
+		} else {
+			log.Warn("this should not happen, seems two ioBundles with same assignment group have two different parent assignment groups")
+		}
+	}
+
+}
+
+func (iobt *ioBundleTree) ioBundle2passthroughRule(ioBundle types.IoBundle) passthroughRule {
+	rootPrs := make([]passthroughRule, 0)
+
+	ioBundlesElem := iobt.elementsByAssignmentGroup[ioBundle.AssignmentGroup]
+
+	childPr := iobt.singleIOBundle2PassthroughRule(ioBundle)
+	if childPr != nil {
+		rootPrs = append(rootPrs, childPr)
+	}
+
+	if ioBundlesElem == nil {
+		return childPr
+	}
+
+	ioBundlesElem = ioBundlesElem.parent
+	for ioBundlesElem != nil && ioBundlesElem.assignmentGroup != "" {
+		elementPrs := make([]passthroughRule, 0)
+		for _, ioBundle := range ioBundlesElem.ioBundles() {
+			pr := iobt.singleIOBundle2PassthroughRule(*ioBundle)
+			if pr != nil {
+				elementPrs = append(elementPrs, pr)
+			}
+		}
+		if len(ioBundlesElem.ioBundlesMap) == 0 {
+			elementPrs = append(elementPrs, &neverPassthroughRule{})
+		}
+
+		elementPr := &compositionORPassthroughRule{
+			rules: elementPrs,
+		}
+		if len(elementPrs) == 1 {
+			rootPrs = append(rootPrs, elementPrs[0])
+		} else if len(elementPrs) > 1 {
+			rootPrs = append(rootPrs, elementPr)
+		}
+		ioBundlesElem = ioBundlesElem.parent
+
+	}
+
+	if len(rootPrs) == 0 {
+		return nil
+	} else if len(rootPrs) == 1 {
+		pciRule, ok := rootPrs[0].(*pciPassthroughRule)
+		if ok {
+			// if it is a single pci passthrough rule, it means it is a pci passthrough
+			// therefore convert it to a passthrough forbid rule
+			return &pciPassthroughForbidRule{
+				pciAddress: pciRule.pciAddress,
+			}
+		}
+		return rootPrs[0]
+	}
+
+	ret := &compositionANDPassthroughRule{
+		// level is AND
+		// within ioBundleElem it is OR
+		rules: rootPrs,
+	}
+
+	return ret
+}
+
+func (iobt *ioBundleTree) singleIOBundle2PassthroughRule(ioBundle types.IoBundle) passthroughRule {
+	prs := make([]passthroughRule, 0)
+
+	if ioBundle.PciLong != "" {
+		pci := pciPassthroughRule{pciAddress: ioBundle.PciLong}
+
+		prs = append(prs, &pci)
+	}
+	if ioBundle.UsbAddr != "" {
+		usbParts := strings.SplitN(ioBundle.UsbAddr, ":", 2)
+		if len(usbParts) != 2 {
+			log.Warnf("usbaddr %s not parseable", ioBundle.UsbAddr)
+			return nil
+		}
+		busnum, err := strconv.ParseUint(usbParts[0], 10, 16)
+		if err != nil {
+			log.Warnf("usbaddr busnum (%s) not parseable", usbParts[0])
+			return nil
+		}
+		portnum := usbParts[1]
+
+		usb := usbPortPassthroughRule{
+			busnum:  uint16(busnum),
+			portnum: portnum,
+		}
+
+		prs = append(prs, &usb)
+	}
+	if ioBundle.UsbProduct != "" {
+		usbParts := strings.SplitN(ioBundle.UsbProduct, ":", 2)
+		if len(usbParts) != 2 {
+			log.Warnf("usbproduct %s not parseable", ioBundle.UsbProduct)
+			return nil
+		}
+
+		vendorID, errVendor := strconv.ParseUint(usbParts[0], 16, 32)
+		productID, errProduct := strconv.ParseUint(usbParts[1], 16, 32)
+		if errVendor != nil || errProduct != nil {
+			log.Warnf("extracting vendor/product id out of usbproduct %s (phylabel: %s) failed: %v/%v",
+				ioBundle.UsbProduct, ioBundle.Phylabel, errVendor, errProduct)
+			return nil
+		}
+
+		usb := usbDevicePassthroughRule{
+			vendorID:  uint32(vendorID),
+			productID: uint32(productID),
+		}
+
+		prs = append(prs, &usb)
+	}
+
+	if len(prs) == 0 {
+		log.Tracef("cannot create rule out of adapter %+v\n", ioBundle)
+		return nil
+	}
+	if len(prs) == 1 {
+		return prs[0]
+	}
+
+	ret := compositionANDPassthroughRule{
+		rules: prs,
+	}
+
+	return &ret
+}

--- a/pkg/pillar/cmd/usbmanager/ioBundleTree_test.go
+++ b/pkg/pillar/cmd/usbmanager/ioBundleTree_test.go
@@ -1,0 +1,602 @@
+// Copyright (c) 2023 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package usbmanager
+
+import (
+	"fmt"
+	"io"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+func (iobt ioBundleTree) toDotFile(w io.Writer) {
+	iobt.consistencyCheck()
+	fmt.Fprintf(w, "digraph G {\n")
+	fmt.Fprintf(w, "\tcompound=true;\n")
+	for _, ioBundleElem := range iobt.elementsByAssignmentGroup {
+		fmt.Fprintf(w, "\tsubgraph \"cluster_%s\" {\n", ioBundleElem.assignmentGroup)
+		subgraphName := ioBundleElem.assignmentGroup
+		if subgraphName == "" {
+			subgraphName = "root"
+		}
+		fmt.Fprintf(w, "\t\tlabel = \"%s\"\n", subgraphName)
+		fmt.Fprintf(w, "\t\t\"cluster_%s_invisible_node\"[style=invis];\n", ioBundleElem.assignmentGroup)
+		for _, ioBundle := range ioBundleElem.ioBundles() {
+			fmt.Fprintf(w, "\t\t\"%s\";\n", ioBundle.Phylabel)
+		}
+		fmt.Fprintf(w, "\t}\n")
+	}
+	fmt.Fprintln(w)
+	for _, ioBundleElem := range iobt.elementsByAssignmentGroup {
+		if ioBundleElem.parent != nil {
+			fmt.Fprintf(w, "\t\"cluster_%s_invisible_node\" -> \"cluster_%s_invisible_node\"[lhead=cluster_%s];\n",
+				ioBundleElem.assignmentGroup,
+				ioBundleElem.parent.assignmentGroup,
+				ioBundleElem.parent.assignmentGroup)
+		}
+	}
+	fmt.Fprintf(w, "}\n")
+}
+
+func (iobt *ioBundleTree) consistencyCheck() {
+	for assigngrp, ioBundleElem := range iobt.elementsByAssignmentGroup {
+		iobt.groupDependendents(assigngrp)
+		iobt.groupParents(assigngrp)
+		if assigngrp != ioBundleElem.assignmentGroup {
+			panic("assigngrp in elementsByAssignmentGroup map is wrong")
+		}
+
+		for childAssigngrp, childIOBundleElem := range ioBundleElem.children {
+			if childAssigngrp != childIOBundleElem.assignmentGroup {
+				panic("key of children ioBundlesElem map is wrong")
+			}
+
+			childIOBundleElemInMap := iobt.elementsByAssignmentGroup[childAssigngrp]
+			if childIOBundleElemInMap != childIOBundleElem {
+				panic("childIOBundleElem not found in elementsByAssignmentGroup map")
+			}
+		}
+
+		for _, ioBundle := range ioBundleElem.ioBundles() {
+			if ioBundle.AssignmentGroup != ioBundleElem.assignmentGroup {
+				panic("assigngrp is wrong; ioBundleElem vs ioBundle")
+			}
+
+			if ioBundleElem.parent == nil && ioBundle.ParentAssignmentGroup != "" {
+				panic("ioBundle parent assignment group is nonempty, but ioBundleElem has no parent")
+			} else if ioBundleElem.parent != nil && ioBundle.ParentAssignmentGroup != ioBundleElem.parent.assignmentGroup {
+				panic("ioBundle parent assignment group is different from ioBundleElem.parent assignment group")
+			}
+
+		}
+	}
+
+}
+
+func TestIOBundle2PassthroughRule_AppearingParent(t *testing.T) {
+	var pr passthroughRule
+	var pa passthroughAction
+
+	iobt := newIOBundleTree()
+
+	iobt.addIOBundle(&types.IoBundle{
+		Phylabel:        "phy2",
+		AssignmentGroup: "2",
+	})
+
+	usbDeviceBundle := &types.IoBundle{
+		Phylabel:              "phy4.1",
+		AssignmentGroup:       "4",
+		ParentAssignmentGroup: "3",
+		UsbAddr:               "4:1",
+		UsbProduct:            "4:1",
+	}
+	iobt.addIOBundle(usbDeviceBundle)
+
+	pr = iobt.ioBundle2passthroughRule(*usbDeviceBundle)
+
+	ud := usbdevice{
+		busnum:                  4,
+		portnum:                 "1",
+		vendorID:                4,
+		productID:               1,
+		usbControllerPCIAddress: "4:1",
+		ueventFilePath:          "/uevent.file",
+	}
+
+	pa, _ = pr.evaluate(ud)
+
+	if pa != passthroughNo {
+		t.Fatalf("expected no passthrough, but got %v", pa)
+	}
+
+	iobt.addIOBundle(&types.IoBundle{
+		Phylabel:              "phy3",
+		AssignmentGroup:       "3",
+		ParentAssignmentGroup: "2",
+	})
+
+	pr = iobt.ioBundle2passthroughRule(*usbDeviceBundle)
+
+	pa, _ = pr.evaluate(ud)
+
+	if pa != passthroughDo {
+		t.Fatalf("expected passthrough, but got %v", pa)
+	}
+
+}
+
+func TestIOBundle2PassthroughRule(t *testing.T) {
+	iobt := newIOBundleTree()
+
+	iobt.addIOBundle(&types.IoBundle{
+		Phylabel:        "phy2",
+		AssignmentGroup: "2",
+	})
+
+	iobt.addIOBundle(&types.IoBundle{
+		Phylabel:              "phy3.1",
+		AssignmentGroup:       "3",
+		PciLong:               "3:1",
+		ParentAssignmentGroup: "2",
+	})
+	iobt.addIOBundle(&types.IoBundle{
+		Phylabel:              "phy3.2",
+		AssignmentGroup:       "3",
+		PciLong:               "3:2",
+		ParentAssignmentGroup: "2",
+	})
+
+	usbDeviceBundle := &types.IoBundle{
+		Phylabel:              "phy4.1",
+		AssignmentGroup:       "4",
+		ParentAssignmentGroup: "3",
+		UsbAddr:               "4:1",
+		UsbProduct:            "4:1",
+	}
+	iobt.addIOBundle(usbDeviceBundle)
+
+	pr := iobt.ioBundle2passthroughRule(*usbDeviceBundle)
+
+	ud := usbdevice{
+		busnum:                  4,
+		portnum:                 "1",
+		vendorID:                4,
+		productID:               1,
+		usbControllerPCIAddress: "3:1",
+		ueventFilePath:          "/uevent.file",
+	}
+
+	passthrough, _ := pr.evaluate(ud)
+	if passthrough != passthroughDo {
+		t.Fatalf("expected passthroughDo, but got %v", passthrough)
+	}
+
+	ud.usbControllerPCIAddress = ""
+	passthrough, _ = pr.evaluate(ud)
+	if passthrough != passthroughNo {
+		t.Fatalf("expected passthroughNo, but got %v", passthrough)
+	}
+
+	ud.usbControllerPCIAddress = "3:2"
+	passthrough, _ = pr.evaluate(ud)
+	if passthrough != passthroughDo {
+		t.Fatalf("expected passthroughDo, but got %v", passthrough)
+	}
+
+	ud.portnum = ""
+	passthrough, _ = pr.evaluate(ud)
+	if passthrough != passthroughNo {
+		t.Fatalf("expected passthroughNo, but got %v", passthrough)
+	}
+
+}
+
+func TestIOBundleTree(t *testing.T) {
+	iobt := newIOBundleTree()
+
+	iobt.addIOBundle(&types.IoBundle{
+		Phylabel:              "phy3",
+		AssignmentGroup:       "3",
+		ParentAssignmentGroup: "2",
+	})
+
+	iobt.addIOBundle(&types.IoBundle{
+		Phylabel:              "phy3.1",
+		AssignmentGroup:       "3",
+		ParentAssignmentGroup: "2",
+	})
+
+	iobt.addIOBundle(&types.IoBundle{
+		Phylabel:        "phy2",
+		AssignmentGroup: "2",
+	})
+
+	iobt.consistencyCheck()
+}
+
+func TestOrphanedIOBundleElem(t *testing.T) {
+	iobt := newIOBundleTree()
+
+	iobt.addIOBundle(&types.IoBundle{
+		Phylabel:              "phy3",
+		AssignmentGroup:       "3",
+		ParentAssignmentGroup: "2",
+	})
+
+	iobt.addIOBundle(&types.IoBundle{
+		Phylabel:              "phy2",
+		AssignmentGroup:       "2",
+		ParentAssignmentGroup: "",
+	})
+
+	iobt.consistencyCheck()
+
+}
+
+func TestGroupDependencies(t *testing.T) {
+	iobt := newIOBundleTree()
+
+	iobt.addIOBundle(&types.IoBundle{
+		Phylabel:              "phy3",
+		AssignmentGroup:       "group3",
+		ParentAssignmentGroup: "group2.1",
+	})
+
+	iobt.addIOBundle(&types.IoBundle{
+		Phylabel:              "phy2.1",
+		AssignmentGroup:       "group2.1",
+		ParentAssignmentGroup: "group1",
+	})
+
+	iobt.addIOBundle(&types.IoBundle{
+		Phylabel:              "phy2.2",
+		AssignmentGroup:       "group2.2",
+		ParentAssignmentGroup: "group1",
+	})
+
+	iobt.addIOBundle(&types.IoBundle{
+		Phylabel:              "phy1",
+		AssignmentGroup:       "group1",
+		ParentAssignmentGroup: "",
+	})
+
+	dependents := iobt.groupDependendents("group2.1")
+	if dependents[0] != "group3" {
+		t.Fatalf("group2.1 should have dependee group3")
+	}
+	found := 0
+	dependents = iobt.groupDependendents("group1")
+	for _, group := range []string{"group2.1", "group2.2", "group3"} {
+		for _, dependeeGroup := range dependents {
+			if group == dependeeGroup {
+				found++
+			}
+		}
+	}
+	if found != 3 {
+		t.Fatalf("did not find expected groups; groups are: %+v", dependents)
+	}
+
+	dependers := iobt.groupParents("group3")
+	found = 0
+	for _, group := range []string{"group2.1", "group1"} {
+		for _, dependerGroup := range dependers {
+			if group == dependerGroup {
+				found++
+			}
+		}
+	}
+	if found != 2 {
+		t.Fatalf("did not find expected groups; groups are: %+v", dependers)
+	}
+}
+
+func FuzzIOBundleTree(f *testing.F) {
+	f.Fuzz(func(t *testing.T,
+		phyLabel1 string,
+		assigngrp1 string,
+
+		phyLabel2 string,
+		assigngrp2 string,
+
+		phyLabel3 string,
+		assigngrp3 string,
+
+		phyLabel4 string,
+		assigngrp4 string,
+
+		phyLabel5 string,
+		assigngrp5 string,
+
+		delBundle1 int,
+		delBundle1Pos int,
+
+		delBundle2 int,
+		delBundle2Pos int,
+
+		delBundle3 int,
+		delBundle3Pos int,
+
+	) {
+
+		iobt := newIOBundleTree()
+
+		ioBundle1 := types.IoBundle{
+			Phylabel:        phyLabel1,
+			AssignmentGroup: assigngrp1,
+		}
+
+		ioBundle2 := types.IoBundle{
+			Phylabel:        phyLabel2,
+			AssignmentGroup: assigngrp2,
+		}
+
+		ioBundle3 := types.IoBundle{
+			Phylabel:        phyLabel3,
+			AssignmentGroup: assigngrp3,
+		}
+
+		ioBundle4 := types.IoBundle{
+			Phylabel:        phyLabel4,
+			AssignmentGroup: assigngrp4,
+		}
+
+		ioBundle5 := types.IoBundle{
+			Phylabel:        phyLabel5,
+			AssignmentGroup: assigngrp5,
+		}
+
+		ioBundlesArray := []*types.IoBundle{&ioBundle1, &ioBundle2, &ioBundle3, &ioBundle4, &ioBundle5}
+
+		delBundleCmd := []struct {
+			index int
+			pos   int
+		}{
+			{delBundle1, delBundle1Pos},
+			{delBundle2, delBundle2Pos},
+			{delBundle3, delBundle3Pos},
+		}
+
+		for i := range delBundleCmd {
+			if delBundleCmd[i].index < 0 {
+				delBundleCmd[i].index = -1 * delBundleCmd[i].index
+			}
+			if delBundleCmd[i].pos < 0 {
+				delBundleCmd[i].pos = -1 * delBundleCmd[i].pos
+			}
+			delBundleCmd[i].index = delBundleCmd[i].index % len(ioBundlesArray)
+			delBundleCmd[i].pos = delBundleCmd[i].pos % len(ioBundlesArray)
+		}
+
+		for pos, ioBundle := range ioBundlesArray {
+
+			for _, dbc := range delBundleCmd {
+				if dbc.pos == pos {
+					iobt.removeIOBundle(ioBundlesArray[dbc.index])
+					iobt.consistencyCheck()
+				}
+			}
+
+			var parentassigngrp string
+			if len(ioBundle.AssignmentGroup) > 0 {
+				_, size := utf8.DecodeLastRuneInString(ioBundle.AssignmentGroup)
+				// set the parentassigngrp to the assigngrp without the last character
+				// this way it is guaranteed that ioBundles with the same assigngrp
+				// have the same parentassigngrp
+				parentassigngrp = ioBundle.AssignmentGroup[:len(ioBundle.AssignmentGroup)-size]
+			}
+
+			ioBundle.ParentAssignmentGroup = parentassigngrp
+
+			iobt.addIOBundle(ioBundle)
+			iobt.consistencyCheck()
+		}
+
+	})
+}
+
+func FuzzIOBundle2PassthroughRule(f *testing.F) {
+	f.Fuzz(func(t *testing.T,
+		usbaddr string,
+		usbproduct string,
+		pcilong string,
+	) {
+		ioBundle := types.IoBundle{
+			UsbAddr:    usbaddr,
+			UsbProduct: usbproduct,
+			PciLong:    pcilong,
+		}
+
+		iobt := newIOBundleTree()
+		iobt.ioBundle2passthroughRule(ioBundle)
+	})
+}
+
+func TestIOBundleEmpty(t *testing.T) {
+	bundle := types.IoBundle{}
+
+	iobt := newIOBundleTree()
+	pr := iobt.ioBundle2passthroughRule(bundle)
+
+	if pr != nil {
+		t.Fatalf("expected nil rule but got %+v (%T)", pr, pr)
+	}
+}
+
+func TestIOBundlePCIForbidRule(t *testing.T) {
+	bundle := types.IoBundle{PciLong: "00:14.0"}
+
+	iobt := newIOBundleTree()
+	pr := iobt.ioBundle2passthroughRule(bundle)
+
+	_, ok := pr.(*pciPassthroughForbidRule)
+	if !ok {
+		t.Fatalf("expected pciPassthroughForbidRule type but got %T %+v", pr, pr)
+	}
+}
+
+func TestIOBundleUSBProductAndUSBAddress(t *testing.T) {
+	bundle := types.IoBundle{
+		UsbAddr:    "1:1",
+		UsbProduct: "2:2",
+	}
+
+	iobt := newIOBundleTree()
+	pr := iobt.ioBundle2passthroughRule(bundle)
+
+	ud := usbdevice{}
+
+	action, _ := pr.evaluate(ud)
+	if action != passthroughNo {
+		t.Fatalf("passthrough action should be passthroughNo, but got %v", action)
+	}
+
+	for _, test := range []struct {
+		beforeFunc     func()
+		expectedAction passthroughAction
+	}{
+		{
+			beforeFunc:     func() { ud.busnum = 1 },
+			expectedAction: passthroughNo,
+		},
+		{
+			beforeFunc:     func() { ud.portnum = "1" },
+			expectedAction: passthroughNo,
+		},
+		{
+			beforeFunc:     func() { ud.vendorID = 2 },
+			expectedAction: passthroughNo,
+		},
+		{
+			beforeFunc:     func() { ud.productID = 2 },
+			expectedAction: passthroughDo,
+		},
+		{
+			beforeFunc: func() {
+				bundle.PciLong = "3:3" // passthrough is now tied to this pci controller
+				pr = iobt.ioBundle2passthroughRule(bundle)
+
+				ud.usbControllerPCIAddress = "4:4"
+			},
+			expectedAction: passthroughNo,
+		},
+		{
+			beforeFunc:     func() { ud.usbControllerPCIAddress = "3:3" },
+			expectedAction: passthroughDo,
+		},
+	} {
+		test.beforeFunc()
+		action, _ := pr.evaluate(ud)
+		if action != test.expectedAction {
+			t.Fatalf("passthrough action should be %v, but got %v; ud: %+v", test.expectedAction, action, ud)
+		}
+	}
+}
+
+func TestIOBundlePCIAndUSBProduct(t *testing.T) {
+	bundle := types.IoBundle{
+		PciLong:    "0:0",
+		UsbProduct: "1:1",
+	}
+
+	iobt := newIOBundleTree()
+	pr := iobt.ioBundle2passthroughRule(bundle)
+
+	hasPCIRule := false
+	hasUSBProductRule := false
+	cpr := pr.(*compositionANDPassthroughRule)
+	for _, rule := range cpr.rules {
+		switch rule.(type) {
+		case *pciPassthroughRule:
+			hasPCIRule = true
+		case *usbDevicePassthroughRule:
+			hasUSBProductRule = true
+		}
+	}
+
+	if !hasPCIRule {
+		t.Fatal("not pciPassthroughRule")
+	}
+	if !hasUSBProductRule {
+		t.Fatal("not usbDevicePassthroughRule")
+	}
+
+	ud := usbdevice{
+		usbControllerPCIAddress: "2:2",
+	}
+
+	action, _ := pr.evaluate(ud)
+	if action != passthroughNo {
+		t.Fatalf("passthrough action should be passthroughNo, but got %v", action)
+	}
+
+	ud.vendorID = 1
+	ud.productID = 1
+	action, _ = pr.evaluate(ud)
+	if action != passthroughNo {
+		t.Fatalf("passthrough action should be passthroughNo, but got %v", action)
+	}
+	ud.usbControllerPCIAddress = "0:0"
+	action, _ = pr.evaluate(ud)
+	if action != passthroughDo {
+		t.Fatalf("passthrough action should be passthroughDo, but got %v", action)
+	}
+}
+
+func TestIOBundlePCIAndUSBAddress(t *testing.T) {
+	bundle := types.IoBundle{
+		PciLong: "0:0",
+		UsbAddr: "1:1",
+	}
+
+	iobt := newIOBundleTree()
+	pr := iobt.ioBundle2passthroughRule(bundle)
+
+	ud := usbdevice{
+		usbControllerPCIAddress: "2:2",
+	}
+
+	action, _ := pr.evaluate(ud)
+	if action != passthroughNo {
+		t.Fatalf("passthrough action should be passthroughNo, but got %v", action)
+	}
+
+	ud.busnum = 1
+	ud.portnum = "1"
+	action, _ = pr.evaluate(ud)
+	if action != passthroughNo {
+		t.Fatalf("passthrough action should be passthroughNo, but got %v", action)
+	}
+	ud.usbControllerPCIAddress = "0:0"
+	action, _ = pr.evaluate(ud)
+	if action != passthroughDo {
+		t.Fatalf("passthrough action should be passthroughDo, but got %v", action)
+	}
+}
+
+func TestAddIOBundleDeadlock(t *testing.T) {
+	ioBundles := []types.IoBundle{
+		{
+			Phylabel:              "1",
+			Logicallabel:          "1",
+			AssignmentGroup:       "1",
+			ParentAssignmentGroup: "2",
+			UsbAddr:               "1:1",
+		},
+		{
+			Phylabel:              "2",
+			Logicallabel:          "2",
+			AssignmentGroup:       "2",
+			ParentAssignmentGroup: "1",
+			UsbAddr:               "0:0",
+		},
+	}
+
+	iobt := newIOBundleTree()
+	iobt.addIOBundle(&ioBundles[0])
+	iobt.addIOBundle(&ioBundles[1])
+
+}

--- a/pkg/pillar/cmd/usbmanager/ruleengine.go
+++ b/pkg/pillar/cmd/usbmanager/ruleengine.go
@@ -10,11 +10,8 @@ type nullObjectPassthroughRule struct {
 	passthroughRuleVMBase
 }
 
-func (pr *nullObjectPassthroughRule) priority() uint8 {
-	return 0
-}
-func (pr *nullObjectPassthroughRule) evaluate(_ usbdevice) passthroughAction {
-	return passthroughNo
+func (pr *nullObjectPassthroughRule) evaluate(_ usbdevice) (passthroughAction, uint8) {
+	return passthroughNo, 0
 }
 func (pr *nullObjectPassthroughRule) String() string {
 	return ""
@@ -44,13 +41,17 @@ func (re *ruleEngine) apply(ud usbdevice) *virtualmachine {
 	var maxRule passthroughRule
 	maxRule = &nullObjectPassthroughRule{}
 
+	var maxPriority uint8
+
 	for _, r := range re.rules {
-		if r.evaluate(ud) == passthroughForbid {
+		eval, priority := r.evaluate(ud)
+		if eval == passthroughForbid {
 			return nil
 		}
-		if r.evaluate(ud) == passthroughDo {
-			if r.priority() > maxRule.priority() {
+		if eval == passthroughDo && r.virtualMachine() != nil {
+			if priority > maxPriority {
 				maxRule = r
+				maxPriority = priority
 			}
 		}
 	}

--- a/pkg/pillar/cmd/usbmanager/rules.go
+++ b/pkg/pillar/cmd/usbmanager/rules.go
@@ -289,7 +289,7 @@ func (*usbNetworkAdapterForbidPassthroughRule) netDevPathsImpl() []string {
 			panic(err)
 		}
 
-		// remove net/enp0s20f0u2u1/ and prefix with syfs dir
+		// remove net/enp0s20f0u2u1/ and prefix with sysfs dir
 		absPath, err := filepath.Abs(filepath.Join(netDir, relPath, "..", ".."))
 		if err != nil {
 			panic(err)

--- a/pkg/pillar/cmd/usbmanager/rules_test.go
+++ b/pkg/pillar/cmd/usbmanager/rules_test.go
@@ -17,7 +17,8 @@ func TestUsbNetworkAdapterForbidPassthroughRule(t *testing.T) {
 
 	ud.ueventFilePath = "/sys/devices/pci0000:00/0000:00:14.0/usb4/4-2/4-2.1/"
 
-	if usbNetworkAdapterForbidPassthroughRule.evaluate(ud) != passthroughForbid {
+	action, _ := usbNetworkAdapterForbidPassthroughRule.evaluate(ud)
+	if action != passthroughForbid {
 		t.Fatalf("passthrough should be forbidden, but isn't")
 	}
 }
@@ -33,7 +34,8 @@ func TestUsbNetworkAdapterAllowPassthroughRule(t *testing.T) {
 
 	ud.ueventFilePath = "/sys/devices/pci0000:00/0000:00:14.0/usb4/4-2/4-2.1/"
 
-	if usbNetworkAdapterForbidPassthroughRule.evaluate(ud) == passthroughForbid {
+	action, _ := usbNetworkAdapterForbidPassthroughRule.evaluate(ud)
+	if action == passthroughForbid {
 		t.Fatalf("passthrough should not be forbidden (port 1 versus port 11), but it is")
 	}
 }

--- a/pkg/pillar/cmd/usbmanager/scanusb.go
+++ b/pkg/pillar/cmd/usbmanager/scanusb.go
@@ -153,6 +153,11 @@ func ueventFile2usbDeviceImpl(ueventFilePath string, ueventFp io.Reader) *usbdev
 		}
 	}
 
+	if sc.Err() != nil {
+		log.Warnf("Parsing of %s failed: %v", ueventFilePath, sc.Err())
+		return nil
+	}
+
 	if !busnumSet || !devnumSet || !productSet {
 		return nil
 	}

--- a/pkg/pillar/cmd/usbmanager/subscriptions.go
+++ b/pkg/pillar/cmd/usbmanager/subscriptions.go
@@ -113,6 +113,10 @@ func (usbCtx *usbmanagerContext) handleDomainStatusNotRunning(status types.Domai
 	qmp := hypervisor.GetQmpExecutorSocket(status.DomainName)
 	vm := newVirtualmachine(qmp, nil)
 
+	for _, io := range status.IoAdapterList {
+		vm.addAdapter(io.Name)
+	}
+
 	usbCtx.controller.removeVirtualmachine(vm)
 }
 

--- a/pkg/pillar/cmd/usbmanager/usbcontroller.go
+++ b/pkg/pillar/cmd/usbmanager/usbcontroller.go
@@ -86,6 +86,9 @@ func (uc *usbmanagerController) addUSBDevice(ud usbdevice) {
 	uc.Lock()
 	defer uc.Unlock()
 
+	log.Noticef("add usb device usbaddr: %s usbproduct: %s pci: %s", ud.busnumAndPortnumString(),
+		ud.vendorAndproductIDString(),
+		ud.usbControllerPCIAddress)
 	uc.usbpassthroughs.addUsbdevice(&ud)
 	vm := uc.ruleEngine.apply(ud)
 	log.Tracef("add usb device %+v vm=%v; rules: %s\n", ud, vm, uc.ruleEngine.String())
@@ -100,6 +103,10 @@ func (uc *usbmanagerController) addUSBDevice(ud usbdevice) {
 func (uc *usbmanagerController) removeUSBDevice(ud usbdevice) {
 	uc.Lock()
 	defer uc.Unlock()
+	log.Noticef("remove usb device usbaddr: %s usbproduct: %s pci: %s", ud.busnumAndPortnumString(),
+		ud.vendorAndproductIDString(),
+		ud.usbControllerPCIAddress)
+
 	vm := uc.ruleEngine.apply(ud)
 	log.Tracef("remove usb device %+v vm=%v; rules: %s\n", ud, vm, uc.ruleEngine.String())
 	if vm != nil {

--- a/pkg/pillar/cmd/usbmanager/usbpassthrough.go
+++ b/pkg/pillar/cmd/usbmanager/usbpassthrough.go
@@ -104,8 +104,6 @@ func (ups *usbpassthroughs) addUsbpassthrough(up *usbpassthrough) {
 func (ups *usbpassthroughs) delUsbpassthrough(up *usbpassthrough) {
 	delete(ups.usbpassthroughs, up.String())
 	delete(ups.usbpassthroughsByVM, up.vm.qmpSocketPath)
-
-	ups.delVM(up.vm)
 }
 
 func (ups usbpassthroughs) usbpassthroughsOfVM(vm virtualmachine) map[string]*usbpassthrough {

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -1296,11 +1296,12 @@ func parseDeviceIoListConfig(getconfigCtx *getconfigContext,
 			continue
 		}
 		port := types.PhysicalIOAdapter{
-			Ptype:        ioDevicePtr.Ptype,
-			Phylabel:     ioDevicePtr.Phylabel,
-			Logicallabel: ioDevicePtr.Logicallabel,
-			Assigngrp:    ioDevicePtr.Assigngrp,
-			Usage:        ioDevicePtr.Usage,
+			Ptype:           ioDevicePtr.Ptype,
+			Phylabel:        ioDevicePtr.Phylabel,
+			Logicallabel:    ioDevicePtr.Logicallabel,
+			Assigngrp:       ioDevicePtr.Assigngrp,
+			Parentassigngrp: ioDevicePtr.Parentassigngrp,
+			Usage:           ioDevicePtr.Usage,
 		}
 		if ioDevicePtr.UsagePolicy != nil {
 			// Need to keep this to make proper determination

--- a/pkg/pillar/docs/usbmanager.md
+++ b/pkg/pillar/docs/usbmanager.md
@@ -1,0 +1,99 @@
+# USB Manager
+
+The USB Manager manages pillar in regards to USB devices and edge applications.
+
+## USB Controller
+
+The USB Controller is the core that is connected to all other components to perform
+the operations.
+It receives information:
+
+- USB devices"
+- Edge Application status
+- Model Manifest
+
+One example of of the USB controller is used, can be found in FuzzUSBManagerController test in
+[usbcontroller_test.go](./usbcontoller_test.go).
+
+### Flow when a new USB device is recognized
+
+1. Apply all passthrough rules on this device
+2. If a rule applies, attach the device to the vm that is returned by the rule with the highest priority
+
+### Flow when a USB device is removed
+
+1. Remove the device from the vm
+
+### Flow when an Edge Application (vm) is added
+
+1. Update all passthrough rules with this adapter and the ones in the same assigngrp
+2. Iterate over all USB devices and connect them to the vm if applicable this could even mean that the
+    USB device gets disconnected first from another vm, because now the passthrough rules priority is
+    higher
+
+### Flow when an Edge Application (vm) is removed
+
+1. Remove all adapters of this vm from all passthrough rules
+2. Iterate over all USB devices and check if other rules now apply and do a passthrough of those devices
+    accordingly
+
+### Flow when a new IOBundle is added
+
+1. Create a passthrough rule of the new IOBundle
+2. Update all depending rules of this new IOBundle (meaning all rules that have the according parentassigngrp)
+3. Iterate over all USB devices and update USB passthroughs accordingly, meaning
+    that a different rule may apply now for some USB device and it may be connected to another vm
+
+### Flow when a new IOBundle is removed
+
+1. Remove the IOBundle
+2. Update all depending rules of this new IOBundle (meaning all rules that have the according parentassigngrp)
+3. Iterate over all USB devices and update USB passthroughs accordingly, meaning
+    that a different rule may apply now for some USB device and it may be connected to another vm
+
+## Passthrough Rules
+
+### Passthrough Rule Actions
+
+A passthrough rule is a rule that decides if a USB device gets connected to a vm. A passthrough rule can
+evaluate to three possible actions:
+
+- passthroughDo -> passthrough of the USB device to the vm should be done, if there is no other rule with
+    a higher priority
+- passthroughNo -> this rule does not apply to the USB device and therefore don't passthrough the device
+    to this vm
+- passthroughForbid -> do not passthrough the device and overrule all other rules
+
+### Passthrough Rule Priorities
+
+Every passthrough Rule does not only provide the passthrough action but also a priority, because some
+ways of passthrough have a higher priority than others.
+F.e. Given a USB device and two passthrough rules to two different vms. One rule is addressing the device
+via USB address, the other rule is addressing the device via product and vendor id. For the user it would
+be unexpected if the device would be passed through to the vm with the rule for passing through by vendor
+and product id.
+
+Combined passthrough rules ([see](#list-of-passthrough-rules)) get their priorities added. If several
+passthrough rules within a combined passthrough rule match, the highest priority is returned.
+
+### List of Passthrough Rules
+
+- pciPassthroughForbidRule - this rule returns passthroughForbid if the PCI address matches; it is used
+    to forbid passthrough of USB devices that are connected to a PCI controller that might be passed through
+- neverPassthroughRule - this rule always returns passthroughNo; it is used for assigngroups that have no
+    ioBundles
+- pciPassthroughRule - this rule is used to match PCI addresses; it is used so far only in composition rules
+- usbDevicePassthroughRule - this rule matches USB devices via product and vendor id
+- usbPortPassthroughRule - this rule matches by USB bus number and port number
+- usbHubForbidPassthroughRule - this rule prevents passing through of USB hubs as it is not supported
+- usbNetworkAdapterForbidPassthroughRule - forbids passing through of network adapters as this could
+    take away the only working network adapter from EVE
+
+Composition rules are used to put several passthrough rules together:
+
+- compositionANDPassthroughRule - this rule matches if all containing rules match
+- compositionORPassthroughRule - this rule matches if at least one rule matches
+
+compositionORPassthroughRule is used to put all IOBundles together that have the same assigngrp.
+compositionANDPassthroughRule is used to put IOBundles together that are linked via the
+parentassigngrp feature.

--- a/pkg/pillar/types/assignableadapters.go
+++ b/pkg/pillar/types/assignableadapters.go
@@ -520,14 +520,14 @@ func (aa *AssignableAdapters) CheckParentAssigngrp() bool {
 
 // CheckBadUSBBundles sets ib.Error/ErrorTime if bundle collides in regards of USB
 func (aa *AssignableAdapters) CheckBadUSBBundles() {
-	usbProductsAddressMap := make(map[[3]string][]*IoBundle)
+	usbProductsAddressMap := make(map[[4]string][]*IoBundle)
 	for i := range aa.IoBundleList {
 		ioBundle := &aa.IoBundleList[i]
 		if ioBundle.UsbAddr == "" && ioBundle.UsbProduct == "" && ioBundle.PciLong == "" {
 			continue
 		}
 
-		id := [3]string{ioBundle.UsbAddr, ioBundle.UsbProduct, ioBundle.PciLong}
+		id := [4]string{ioBundle.UsbAddr, ioBundle.UsbProduct, ioBundle.PciLong, ioBundle.AssignmentGroup}
 		if usbProductsAddressMap[id] == nil {
 			usbProductsAddressMap[id] = make([]*IoBundle, 0)
 		}
@@ -542,8 +542,8 @@ func (aa *AssignableAdapters) CheckBadUSBBundles() {
 		errStr := "ioBundle collision:||"
 
 		for _, bundle := range bundles {
-			errStr += fmt.Sprintf("phylabel %s - usbaddr: %s usbproduct: %s pcilong: %s||",
-				bundle.Phylabel, bundle.UsbAddr, bundle.UsbProduct, bundle.PciLong)
+			errStr += fmt.Sprintf("phylabel %s - usbaddr: %s usbproduct: %s pcilong: %s assigngrp: %s||",
+				bundle.Phylabel, bundle.UsbAddr, bundle.UsbProduct, bundle.PciLong, bundle.AssignmentGroup)
 		}
 		for _, bundle := range bundles {
 			bundle.Error = errStr

--- a/pkg/pillar/types/assignableadapters.go
+++ b/pkg/pillar/types/assignableadapters.go
@@ -51,6 +51,13 @@ type IoBundle struct {
 	// If this is an empty string it means the IoBundle can not be assigned.
 	AssignmentGroup string
 
+	// Parent Assignment Group is there to reference the parent assignment group in order to make the device
+	// dependent on a different device.
+	// Currently the concrete reason to do this is to make a usb device dependent on the PCI address the USB
+	// controller is using to prevent passthrough of the USB controller in one application while trying to passthrough
+	// a USB device on this controller to another application.
+	ParentAssignmentGroup string
+
 	Usage zcommon.PhyIoMemberUsage
 
 	// Cost is zero for the free ports; less desirable ports have higher numbers
@@ -190,6 +197,7 @@ func IoBundleFromPhyAdapter(log *base.LogObject, phyAdapter PhysicalIOAdapter) *
 	ib.Phylabel = phyAdapter.Phylabel
 	ib.Logicallabel = phyAdapter.Logicallabel
 	ib.AssignmentGroup = phyAdapter.Assigngrp
+	ib.ParentAssignmentGroup = phyAdapter.Parentassigngrp
 	ib.Ifname = phyAdapter.Phyaddr.Ifname
 	ib.PciLong = phyAdapter.Phyaddr.PciLong
 	ib.UsbAddr = phyAdapter.Phyaddr.UsbAddr
@@ -446,6 +454,70 @@ func (aa *AssignableAdapters) LookupIoBundleIfName(ifname string) *IoBundle {
 	return nil
 }
 
+// CheckParentAssigngrp finds dependency loops between ioBundles
+func (aa *AssignableAdapters) CheckParentAssigngrp() bool {
+	assigngrp2parent := make(map[string]string)
+
+	var cycleDetectedAssigngrp string
+	for i := range aa.IoBundleList {
+		ioBundle := &aa.IoBundleList[i]
+
+		if ioBundle.AssignmentGroup == ioBundle.ParentAssignmentGroup && ioBundle.AssignmentGroup != "" {
+			ioBundle.Error = "IOBundle cannot be it's own parent"
+			ioBundle.ErrorTime = time.Now()
+			return true
+		}
+		parentassigngrp, ok := assigngrp2parent[ioBundle.AssignmentGroup]
+		if ok && parentassigngrp != ioBundle.ParentAssignmentGroup {
+			ioBundle.Error = "IOBundle with parentassigngrp mismatch found"
+			ioBundle.ErrorTime = time.Now()
+			return true
+		}
+
+		if ioBundle.AssignmentGroup == "" && ioBundle.ParentAssignmentGroup != "" {
+			ioBundle.Error = "IOBundle with empty assigngrp cannot have a parent"
+			ioBundle.ErrorTime = time.Now()
+			return true
+		}
+		assigngrp2parent[ioBundle.AssignmentGroup] = ioBundle.ParentAssignmentGroup
+	}
+
+	for assigngrp := range assigngrp2parent {
+		visitedAssigngrp := make(map[string]struct{})
+		visitedAssigngrp[assigngrp] = struct{}{}
+
+		for {
+			if assigngrp == "" {
+				break
+			}
+
+			assigngrp = assigngrp2parent[assigngrp]
+			_, visitedBefore := visitedAssigngrp[assigngrp]
+			if visitedBefore {
+				// cycle detected
+				cycleDetectedAssigngrp = assigngrp
+				break
+			}
+
+			visitedAssigngrp[assigngrp] = struct{}{}
+		}
+	}
+
+	if cycleDetectedAssigngrp == "" {
+		return false
+	}
+
+	for i := range aa.IoBundleList {
+		ioBundle := &aa.IoBundleList[i]
+		if ioBundle.AssignmentGroup == cycleDetectedAssigngrp {
+			ioBundle.Error = "Cycle detected, please check provided parentassigngrp/assigngrp"
+			ioBundle.ErrorTime = time.Now()
+		}
+	}
+
+	return true
+}
+
 // CheckBadUSBBundles sets ib.Error/ErrorTime if bundle collides in regards of USB
 func (aa *AssignableAdapters) CheckBadUSBBundles() {
 	usbProductsAddressMap := make(map[[3]string][]*IoBundle)
@@ -511,7 +583,8 @@ func (aa *AssignableAdapters) CheckBadAssignmentGroups(log *base.LogObject, PCIS
 			}
 		}
 	}
-	return changed
+
+	return changed || aa.CheckParentAssigngrp()
 }
 
 // ExpandControllers expands the list to include other PCI functions on the same PCI controller

--- a/pkg/pillar/types/assignableadapters_test.go
+++ b/pkg/pillar/types/assignableadapters_test.go
@@ -711,11 +711,11 @@ func TestCheckBadUSBBundles(t *testing.T) {
 			bundleWithError: []bundleWithError{
 				{
 					bundle:        IoBundle{Phylabel: "1", UsbAddr: "1:1", UsbProduct: "a:a", PciLong: "1:1"},
-					expectedError: "ioBundle collision:||phylabel 1 - usbaddr: 1:1 usbproduct: a:a||phylabel 2 - usbaddr: 1:1 usbproduct: a:a||",
+					expectedError: "ioBundle collision:||phylabel 1 - usbaddr: 1:1 usbproduct: a:a pcilong: 1:1 assigngrp: ||phylabel 2 - usbaddr: 1:1 usbproduct: a:a pcilong: 1:1 assigngrp: ||",
 				},
 				{
 					bundle:        IoBundle{Phylabel: "2", UsbAddr: "1:1", UsbProduct: "a:a", PciLong: "1:1"},
-					expectedError: "ioBundle collision:||phylabel 1 - usbaddr: 1:1 usbproduct: a:a||phylabel 2 - usbaddr: 1:1 usbproduct: a:a||",
+					expectedError: "ioBundle collision:||phylabel 1 - usbaddr: 1:1 usbproduct: a:a pcilong: 1:1 assigngrp: ||phylabel 2 - usbaddr: 1:1 usbproduct: a:a pcilong: 1:1 assigngrp: ||",
 				},
 			},
 		},
@@ -723,11 +723,11 @@ func TestCheckBadUSBBundles(t *testing.T) {
 			bundleWithError: []bundleWithError{
 				{
 					bundle:        IoBundle{Phylabel: "3", UsbAddr: "1:1", UsbProduct: "a:a"},
-					expectedError: "ioBundle collision:||phylabel 3 - usbaddr: 1:1 usbproduct: a:a||phylabel 4 - usbaddr: 1:1 usbproduct: a:a||",
+					expectedError: "ioBundle collision:||phylabel 3 - usbaddr: 1:1 usbproduct: a:a pcilong:  assigngrp: ||phylabel 4 - usbaddr: 1:1 usbproduct: a:a pcilong:  assigngrp: ||",
 				},
 				{
 					bundle:        IoBundle{Phylabel: "4", UsbAddr: "1:1", UsbProduct: "a:a"},
-					expectedError: "ioBundle collision:||phylabel 3 - usbaddr: 1:1 usbproduct: a:a||phylabel 4 - usbaddr: 1:1 usbproduct: a:a||",
+					expectedError: "ioBundle collision:||phylabel 3 - usbaddr: 1:1 usbproduct: a:a pcilong:  assigngrp: ||phylabel 4 - usbaddr: 1:1 usbproduct: a:a pcilong:  assigngrp: ||",
 				},
 				{
 					bundle:        IoBundle{Phylabel: "5", UsbAddr: "1:1", UsbProduct: ""},
@@ -739,11 +739,11 @@ func TestCheckBadUSBBundles(t *testing.T) {
 			bundleWithError: []bundleWithError{
 				{
 					bundle:        IoBundle{Phylabel: "6", UsbAddr: "1:1", UsbProduct: ""},
-					expectedError: "ioBundle collision:||phylabel 6 - usbaddr: 1:1 usbproduct: ||phylabel 7 - usbaddr: 1:1 usbproduct: ||",
+					expectedError: "ioBundle collision:||phylabel 6 - usbaddr: 1:1 usbproduct:  pcilong:  assigngrp: ||phylabel 7 - usbaddr: 1:1 usbproduct:  pcilong:  assigngrp: ||",
 				},
 				{
 					bundle:        IoBundle{Phylabel: "7", UsbAddr: "1:1", UsbProduct: ""},
-					expectedError: "ioBundle collision:||phylabel 6 - usbaddr: 1:1 usbproduct: ||phylabel 7 - usbaddr: 1:1 usbproduct: ||",
+					expectedError: "ioBundle collision:||phylabel 6 - usbaddr: 1:1 usbproduct:  pcilong:  assigngrp: ||phylabel 7 - usbaddr: 1:1 usbproduct:  pcilong:  assigngrp: ||",
 				},
 			},
 		},
@@ -751,11 +751,11 @@ func TestCheckBadUSBBundles(t *testing.T) {
 			bundleWithError: []bundleWithError{
 				{
 					bundle:        IoBundle{Phylabel: "8", UsbAddr: "", UsbProduct: "a:a"},
-					expectedError: "ioBundle collision:||phylabel 8 - usbaddr:  usbproduct: a:a||phylabel 9 - usbaddr:  usbproduct: a:a||",
+					expectedError: "ioBundle collision:||phylabel 8 - usbaddr:  usbproduct: a:a pcilong:  assigngrp: ||phylabel 9 - usbaddr:  usbproduct: a:a pcilong:  assigngrp: ||",
 				},
 				{
 					bundle:        IoBundle{Phylabel: "9", UsbAddr: "", UsbProduct: "a:a"},
-					expectedError: "ioBundle collision:||phylabel 8 - usbaddr:  usbproduct: a:a||phylabel 9 - usbaddr:  usbproduct: a:a||",
+					expectedError: "ioBundle collision:||phylabel 8 - usbaddr:  usbproduct: a:a pcilong:  assigngrp: ||phylabel 9 - usbaddr:  usbproduct: a:a pcilong:  assigngrp: ||",
 				},
 			},
 		},
@@ -783,9 +783,8 @@ func TestCheckBadUSBBundles(t *testing.T) {
 
 		for i, bundleWithErr := range testCase.bundleWithError {
 			if bundles[i].Error != bundleWithErr.expectedError {
-				t.Logf("bundle %s expected error \n'%s', got error \n'%s'",
+				t.Fatalf("bundle %s expected error \n'%s', got error \n'%s'",
 					bundleWithErr.bundle.Phylabel, bundleWithErr.expectedError, bundles[i].Error)
-
 			}
 		}
 	}

--- a/pkg/pillar/types/assignableadapters_test.go
+++ b/pkg/pillar/types/assignableadapters_test.go
@@ -608,6 +608,94 @@ func FuzzCheckBadUSBBundles(f *testing.F) {
 	})
 }
 
+func TestCheckBadParentAssigngrp(t *testing.T) {
+	t.Parallel()
+	aa := AssignableAdapters{}
+
+	aa.IoBundleList = []IoBundle{
+		{
+			Phylabel:              "1",
+			AssignmentGroup:       "BBB",
+			ParentAssignmentGroup: "AAA",
+		},
+		{
+			Phylabel:              "2",
+			AssignmentGroup:       "BBB",
+			ParentAssignmentGroup: "ZZZ",
+		},
+	}
+
+	aa.CheckParentAssigngrp()
+
+	errorSet := false
+	for _, ioBundle := range aa.IoBundleList {
+		if ioBundle.Error == "IOBundle with parentassigngrp mismatch found" {
+			errorSet = true
+			break
+		}
+	}
+
+	if !errorSet {
+		t.Fatal("wrong error message")
+	}
+}
+
+func TestCheckBadParentAssigngrpLoop(t *testing.T) {
+	t.Parallel()
+	aa := AssignableAdapters{}
+
+	aa.IoBundleList = []IoBundle{
+		{
+			Phylabel:              "1",
+			AssignmentGroup:       "BBB",
+			ParentAssignmentGroup: "AAA",
+		},
+		{
+			Phylabel:              "2",
+			AssignmentGroup:       "AAA",
+			ParentAssignmentGroup: "AAA",
+		},
+	}
+
+	aa.CheckParentAssigngrp()
+
+	for _, ioBundle := range aa.IoBundleList {
+		if ioBundle.Phylabel == "2" {
+			if ioBundle.Error != "IOBundle cannot be it's own parent" {
+				t.Fatal("wrong error message")
+			}
+		}
+	}
+
+	aa.IoBundleList = []IoBundle{
+		{
+			Phylabel:              "1",
+			AssignmentGroup:       "BBB",
+			ParentAssignmentGroup: "AAA",
+		},
+		{
+			Phylabel:              "2",
+			AssignmentGroup:       "AAA",
+			ParentAssignmentGroup: "BBB",
+		},
+	}
+
+	aa.CheckParentAssigngrp()
+
+	errorSet := false
+	for _, ioBundle := range aa.IoBundleList {
+		if ioBundle.Error == "Cycle detected, please check provided parentassigngrp/assigngrp" {
+			errorSet = true
+			break
+		}
+
+	}
+	if !errorSet {
+		t.Fatal("wrong error message")
+	}
+
+}
+
 func TestCheckBadUSBBundles(t *testing.T) {
 	t.Parallel()
 	aa := AssignableAdapters{}

--- a/pkg/pillar/types/physicalioadapters.go
+++ b/pkg/pillar/types/physicalioadapters.go
@@ -38,13 +38,14 @@ type PhyIOUsagePolicy struct {
 // PhysicalIOAdapter - Object used to store Adapter configuration (L1)
 // from controller for each Adapter.
 type PhysicalIOAdapter struct {
-	Ptype        zcommon.PhyIoType // Type of IO Device
-	Phylabel     string            // Label printed on the enclosure
-	Phyaddr      PhysicalAddress
-	Logicallabel string // Label assigned by model creator
-	Assigngrp    string
-	Usage        zcommon.PhyIoMemberUsage
-	UsagePolicy  PhyIOUsagePolicy
+	Ptype           zcommon.PhyIoType // Type of IO Device
+	Phylabel        string            // Label printed on the enclosure
+	Phyaddr         PhysicalAddress
+	Logicallabel    string // Label assigned by model creator
+	Assigngrp       string
+	Parentassigngrp string
+	Usage           zcommon.PhyIoMemberUsage
+	UsagePolicy     PhyIOUsagePolicy
 	//nolint:godox
 	// FIXME: cbattr - This needs to be thought through to be made into
 	//  a structure OR may be even various attributes in PhysicalIO structure


### PR DESCRIPTION
This PR implements usage of parentassigngrp in the model manifest.
With this new feature dependencies between IOBundles can be defined; so here for USB passthrough.

Now one edge application can use passthrough of the PCI controller and another edge application can use USB passthrough of the hardware.
Of course they cannot run and use USB passthrough at the same time, but they can use their implementation of passthrough alternating.