### PR TITLE
Makefile: run more than one pillar fuzz test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -393,7 +393,7 @@ currentversion:
 test: $(LINUXKIT) test-images-patches | $(DIST)
 	@echo Running tests on $(GOMODULE)
 	$(QUIET)$(DOCKER_GO) "gotestsum --jsonfile $(DOCKER_DIST)/results.json --junitfile $(DOCKER_DIST)/results.xml --raw-command -- go test -coverprofile=coverage.txt -covermode=atomic -race -json ./..." $(GOTREE) $(GOMODULE)
-	$(QUIET)$(DOCKER_GO) "cd \"$(GOTREE)\"; find ./ -type d \! -path ./vendor/\* -exec go test -fuzz=^Fuzz -run=^Fuzz -fuzztime=30s "{}" \;" $(GOTREE) $(GOMODULE)
+	$(QUIET)$(DOCKER_GO) "cd \"$(GOTREE)\"; ../../tools/fuzz_test.sh" $(GOTREE) $(GOMODULE)
 	$(QUIET): $@: Succeeded
 
 # wrap command into DOCKER_GO and propagate it to the pillar's Makefile

--- a/tools/fuzz_test.sh
+++ b/tools/fuzz_test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# from: https://github.com/golang/go/issues/46312#issuecomment-1727928218
+
+set -e
+
+fuzzTime="30s"
+
+files=$(find ./ -type f \! -path ./vendor/\* -iname \*.go)
+for file in ${files}; do
+    funcs=$(grep '^func Fuzz' "$file" | sed s/func\ // | sed 's/(.*$//')
+
+    for func in ${funcs}; do
+        echo "Fuzzing $func in $file"
+        parentDir=$(dirname "$file")
+        go test "$parentDir" -run="$func" -fuzz="$func" -fuzztime="${fuzzTime}"
+    done
+done


### PR DESCRIPTION
unfortunately fuzzing in go has a restrictions:
you cannot run several Fuzz tests in one package at once, but `go test` has to be started for each test