### PR TITLE
[11.8] Call getpwuid only after chroot is set

### DIFF
--- a/pkg/xen-tools/initrd/chroot2.c
+++ b/pkg/xen-tools/initrd/chroot2.c
@@ -29,18 +29,19 @@ static int child_func(void *args)
     struct clone_args *parsed_args = args;
     struct passwd *pws;
 
-    pws = getpwuid(parsed_args->uid);
-    if (pws == NULL)
-        err(-1, "getpwuid(%d) failed:", parsed_args->uid);
-
-    if (initgroups(pws->pw_name, parsed_args->gid) != 0)
-        err(-1, "initgroups(%s, %d) failed:", pws->pw_name, parsed_args->gid);
 
     if (chroot(parsed_args->chroot) != 0)
         err(-1, "chroot(%s) failed:", parsed_args->chroot);
 
     if (chdir(parsed_args->workdir) != 0)
         err(-1, "chdir(%s) failed:", parsed_args->workdir);
+
+    pws = getpwuid(parsed_args->uid);
+    if (pws == NULL)
+        err(-1, "getpwuid(%d) failed:", parsed_args->uid);
+
+    if (initgroups(pws->pw_name, parsed_args->gid) != 0)
+        err(-1, "initgroups(%s, %d) failed:", pws->pw_name, parsed_args->gid);
 
     if (mount("proc", "/proc", "proc", 0, NULL) != 0)
         err(-1, "mount(proc) failed:");


### PR DESCRIPTION
While starting a cmd from the container rootfs, initrd script tries to chroot to the rootfs and executes the cmd. The eve specific chroot (chroot2.c) tries to set root to the container rootfs and execute the command. /chroot2 /mnt/rootfs $ug $pidfile $cmd
The issue here is that chroot2.c is calling getpwuid() on the userid even before setting chroot. That makes getpwuid to process the user id in eve context than the user container context. This works fine with userid root, but for non-root users it fails since that user may (will not) be present in eve context.

This fix moves the getpwuid() call after chroot().

Signed-off-by: Pramodh Pallapothu <pramodh@zededa.com>
(cherry picked from commit f33609ab18d3804683e13db37ba036d4ffbf7cb9)