### PR TITLE
kernel: Update kernel versions

### DIFF
--- a/kernel-commits.mk
+++ b/kernel-commits.mk
@@ -1,7 +1,7 @@
-KERNEL_COMMIT_amd64_v5.10.186_generic = e201acddaa99
-KERNEL_COMMIT_amd64_v6.1.38_generic = 3e39cb4a2fc4
-KERNEL_COMMIT_amd64_v6.1.38_rt = 476efe3129a3
-KERNEL_COMMIT_arm64_v5.10.104_nvidia = 68c24df0b352
-KERNEL_COMMIT_arm64_v5.10.186_generic = 7d82e10c7d66
-KERNEL_COMMIT_arm64_v6.1.38_generic = d888a2ed5db3
+KERNEL_COMMIT_amd64_v5.10.186_generic = be89a9e63306
+KERNEL_COMMIT_amd64_v6.1.38_generic = d586ca2d3f2e
+KERNEL_COMMIT_amd64_v6.1.38_rt = 49dba60a59d9
+KERNEL_COMMIT_arm64_v5.10.104_nvidia = c21d5a4dd498
+KERNEL_COMMIT_arm64_v5.10.186_generic = 6a861e0433a6
+KERNEL_COMMIT_arm64_v6.1.38_generic = 92466d23a9bf
 KERNEL_COMMIT_riscv64_v6.1.38_generic = ad6a4589904a


### PR DESCRIPTION
eve-kernel-amd64-v5.10.186-generic:
    be89a9e63306 eve_defconfig: Enable options for CAN support
    8a4c5917770e eve_defconfig: Clean up config file

eve-kernel-amd64-v6.1.38-generic:
    d586ca2d3f2e eve_defconfig: Enable options for CAN support

eve-kernel-amd64-v6.1.38-rt:
    49dba60a59d9 eve_defconfig: Enable options for CAN support
    9767061cc7f0 x86/configs/eve_defconfig: enable NO_HZ_FULL
    9d17e90c27cc x86/configs/eve_defconfig: make defconfig
    50f85b0e0e55 eve_defconfig: enable kernel debug symbols
    712e12eeedcc mm/memcg: enable cgroups v1 for the PREEMPT_RT case

eve-kernel-arm64-v5.10.104-nvidia:
    c21d5a4dd498 eve_defconfig: Enable options for CAN support

eve-kernel-arm64-v5.10.186-generic:
    6a861e0433a6 eve_defconfig: Enable options for CAN support

eve-kernel-arm64-v6.1.38-generic
    92466d23a9bf eve_defconfig: Enable options for CAN support