### PR TITLE
Make EVE more robust (against controller not sending config followed by certificate roll)

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -83,8 +83,16 @@ func parseControllerCerts(ctx *zedagentContext, contents []byte) (changed bool, 
 				break
 			}
 		}
-		if !found {
-			log.Functionf("parseControllerCerts: deleting %s", config.Key())
+		if found {
+			continue
+		}
+		// Is the ControllerCert in use?
+		if lookupCipherContextByCCH(ctx.getconfigCtx, configHash) != nil {
+			log.Noticef("ControllerCert %s hash %s in use",
+				config.Key(), string(configHash))
+		} else {
+			log.Noticef("ControllerCert %s hash %s delete",
+				config.Key(), string(configHash))
 			unpublishControllerCert(ctx.getconfigCtx, config.Key())
 			changed = true
 		}

--- a/pkg/pillar/cmd/zedagent/handlecipherconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecipherconfig.go
@@ -17,6 +17,28 @@ import (
 
 var cipherCtxHash []byte
 
+// populateCipherContexts: fill in local map from persistent publication on boot
+func populateCipherContexts(ctx *getconfigContext) {
+	items := ctx.pubCipherContext.GetAll()
+	for _, item := range items {
+		context := item.(types.CipherContext)
+		ctx.cipherContexts[context.Key()] = context
+		log.Noticef("populateCipherContext found %s",
+			context.Key())
+	}
+}
+
+// lookupCipherContextByCCH: lookup by ControllerCertHash
+// The Key is a UUID so need to walk map
+func lookupCipherContextByCCH(ctx *getconfigContext, cch []byte) *types.CipherContext {
+	for _, context := range ctx.cipherContexts {
+		if bytes.Equal(context.ControllerCertHash, cch) {
+			return &context
+		}
+	}
+	return nil
+}
+
 // invalidateCipherContextDependenciesList function clear stored hashes for objects
 // which have parseCipherBlock inside
 // to re-run parse* functions on change of CipherContexts

--- a/pkg/pillar/cmd/zedagent/handlecipherconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecipherconfig.go
@@ -63,6 +63,7 @@ func parseCipherContext(ctx *getconfigContext,
 		if !found {
 			log.Functionf("parseCipherContext: deleting %s", idStr)
 			delete(ctx.cipherContexts, idStr)
+			unpublishCipherContext(ctx, idStr)
 		}
 	}
 
@@ -80,6 +81,7 @@ func parseCipherContext(ctx *getconfigContext,
 			ControllerCertHash: cfgCipherContext.GetControllerCertHash(),
 		}
 		ctx.cipherContexts[context.Key()] = context
+		publishCipherContext(ctx, context)
 	}
 	log.Functionf("parsing cipher context done")
 }
@@ -128,4 +130,25 @@ func parseCipherBlock(ctx *getconfigContext, key string, cfgCipherBlock *zcommon
 
 	log.Functionf("parseCipherBlock(%s) done", key)
 	return cipherBlock
+}
+
+func publishCipherContext(ctx *getconfigContext,
+	status types.CipherContext) {
+	key := status.Key()
+	log.Tracef("publishCipherContext(%s)", key)
+	pub := ctx.pubCipherContext
+	pub.Publish(key, status)
+	log.Tracef("publishCipherContext(%s) done", key)
+}
+
+func unpublishCipherContext(ctx *getconfigContext, key string) {
+	log.Tracef("unpublishCipherContext(%s)", key)
+	pub := ctx.pubCipherContext
+	c, _ := pub.Get(key)
+	if c == nil {
+		log.Errorf("unpublishCipherContext(%s) not found", key)
+		return
+	}
+	pub.Unpublish(key)
+	log.Tracef("unpublishCipherContext(%s) done", key)
 }

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -100,6 +100,7 @@ type getconfigContext struct {
 	pubDatastoreConfig        pubsub.Publication
 	pubNetworkInstanceConfig  pubsub.Publication
 	pubControllerCert         pubsub.Publication
+	pubCipherContext          pubsub.Publication
 	subContentTreeStatus      pubsub.Subscription
 	pubContentTreeConfig      pubsub.Publication
 	subVolumeStatus           pubsub.Subscription

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -1174,6 +1174,18 @@ func initPublications(zedagentCtx *zedagentContext) {
 	}
 	getconfigCtx.pubControllerCert.ClearRestarted()
 
+	// for CipherContextStatus Publisher
+	getconfigCtx.pubCipherContext, err = ps.NewPublication(
+		pubsub.PublicationOptions{
+			AgentName:  agentName,
+			Persistent: true,
+			TopicType:  types.CipherContext{},
+		})
+	if err != nil {
+		log.Fatal(err)
+	}
+	getconfigCtx.pubCipherContext.ClearRestarted()
+
 	// for ContentTree config Publisher
 	getconfigCtx.pubContentTreeConfig, err = ps.NewPublication(
 		pubsub.PublicationOptions{

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -1185,6 +1185,7 @@ func initPublications(zedagentCtx *zedagentContext) {
 		log.Fatal(err)
 	}
 	getconfigCtx.pubCipherContext.ClearRestarted()
+	populateCipherContexts(getconfigCtx)
 
 	// for ContentTree config Publisher
 	getconfigCtx.pubContentTreeConfig, err = ps.NewPublication(


### PR DESCRIPTION
We've seen a case where the controller can not send an updated configuration to a device (in this particular case due to a removed datastore configuration) for an extended period time. This was not detected for a long period.
Much later when the controller signing and encryption certificates were rolled (which results in configuration updates due to the object encryption now using the new controller encryption certificate) that configuration update was not delivered to the device by the controller for the above reason.

However, the new controller certificates were made available by the controller at the /certs API endpoint.
A device was then manually power cycled and at boot EVE fetched the new controller certs from that API, and as a result deleted the old controller certs were deleted by EVE.

This state with EdgeDevConfig from before the certificate roll and the new certificates in ControllerCert means that the cloud-init user-data etc can not be decrypted.

This PR avoids that state by not deleting the old controller certificates when they are referenced by the EdgeDevConfig (via the CipherContext). Note that this doesn't address the root cause at the controller of not being able to send any new configuration to the device, but it will allow the objects to be decrypted on EVE.