### PR TITLE
Volumemgr support for kubevirt eve

### DIFF
--- a/pkg/pillar/Dockerfile
+++ b/pkg/pillar/Dockerfile
@@ -157,6 +157,7 @@ ADD scripts/device-steps.sh \
     scripts/handlezedserverconfig.sh \
     scripts/veth.sh \
     scripts/dhcpcd.sh \
+    scripts/copy-image-to-qcow.sh \
   /out/opt/zededa/bin/
 ADD conf/lisp.config.base /out/var/tmp/zededa/lisp.config.base
 

--- a/pkg/pillar/Makefile
+++ b/pkg/pillar/Makefile
@@ -94,7 +94,7 @@ test: build-docker-test
 		--entrypoint /final/opt/gotestsum $(DOCKER_TAG) \
 		--jsonfile /pillar/results.json \
 		--junitfile /pillar/results.xml \
-		--raw-command -- go test -coverprofile=coverage.txt -covermode=atomic -race -json \
+		--raw-command -- go test -tags kubevirt -coverprofile=coverage.txt -covermode=atomic -race -json \
 		./...
 	docker run --platform linux/$(ZARCH) -w /pillar \
 		--entrypoint /bin/sh $(DOCKER_TAG) \

--- a/pkg/pillar/cas/containerd.go
+++ b/pkg/pillar/cas/containerd.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/mount"
 	"github.com/lf-edge/edge-containers/pkg/resolver"
+	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/containerd"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/moby/sys/mountinfo"
@@ -679,13 +681,6 @@ func (c *containerdCAS) PrepareContainerRootDir(rootPath, reference, rootBlobSha
 		logrus.Errorf(err.Error())
 		return err
 	}
-	mountpoints := clientImageSpec.Config.Volumes
-	execpath := clientImageSpec.Config.Entrypoint
-	cmd := clientImageSpec.Config.Cmd
-	workdir := clientImageSpec.Config.WorkingDir
-	unProcessedEnv := clientImageSpec.Config.Env
-	logrus.Infof("PrepareContainerRootDir: mountPoints %+v execpath %+v cmd %+v workdir %+v env %+v",
-		mountpoints, execpath, cmd, workdir, unProcessedEnv)
 	clientImageSpecJSON, err := getJSON(clientImageSpec)
 	if err != nil {
 		err = fmt.Errorf("PrepareContainerRootDir: Could not build json of image: %v. %v",
@@ -704,6 +699,122 @@ func (c *containerdCAS) PrepareContainerRootDir(rootPath, reference, rootBlobSha
 			rootPath, imageConfigFilename, err)
 		logrus.Errorf(err.Error())
 		return err
+	}
+	if base.IsHVTypeKube() {
+		err := c.prepareContainerRootDirForKubevirt(clientImageSpec, snapshotID, rootPath)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *containerdCAS) prepareContainerRootDirForKubevirt(clientImageSpec *spec.Image, snapshotID string, rootPath string) error {
+
+	// On kubevirt eve we also write the mountpoints and cmdline files to the rootPath.
+	// Once rootPath is populated with all necessary files, this rootPath directory will be
+	// converted to a PVC and passed in to domainmgr to attach to VM as rootdisk
+	// NOTE: For kvm eve these files are generated and passed to bootloader in pkg/pillar/containerd/oci.go:AddLoader()
+
+	mountpoints := clientImageSpec.Config.Volumes
+	execpath := clientImageSpec.Config.Entrypoint
+	cmd := clientImageSpec.Config.Cmd
+	workdir := clientImageSpec.Config.WorkingDir
+	unProcessedEnv := clientImageSpec.Config.Env
+	user := clientImageSpec.Config.User
+	logrus.Infof("PrepareContainerRootDir: mountPoints %+v execpath %+v cmd %+v workdir %+v env %+v user %+v",
+		mountpoints, execpath, cmd, workdir, unProcessedEnv, user)
+
+	// Mount the snapshot
+	// Do not unmount the rootfs in this code path, we need this containerdir to generate a qcow2->PVC from it in
+	// pkg/pillar/volumehandlers/csihandler.go
+	// Once qcow2 is successfully created, this directory will be unmounted in csihandler.go
+	if err := c.MountSnapshot(snapshotID, GetRoofFsPath(rootPath)); err != nil {
+		return fmt.Errorf("PrepareContainerRootDir error mount of snapshot: %s. %s", snapshotID, err)
+	}
+
+	err := c.writeKubevirtMountpointsFile(mountpoints, rootPath)
+	if err != nil {
+		return err
+	}
+
+	// create env manifest
+	envContent := ""
+	if workdir != "" {
+		envContent = fmt.Sprintf("export WORKDIR=\"%s\"\n", workdir)
+	} else {
+		envContent = fmt.Sprintf("export WORKDIR=/\n")
+	}
+	for _, e := range unProcessedEnv {
+		keyAndValueSlice := strings.SplitN(e, "=", 2)
+		if len(keyAndValueSlice) == 2 {
+			//handles Key=Value case
+			envContent = envContent + fmt.Sprintf("export %s=\"%s\"\n", keyAndValueSlice[0], keyAndValueSlice[1])
+		} else {
+			//handles Key= case
+			envContent = envContent + fmt.Sprintf("export %s\n", e)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(rootPath, "environment"), []byte(envContent), 0644); err != nil {
+		return err
+	}
+
+	// create cmdline manifest
+	// each item needs to be independently quoted for initrd
+	execpathQuoted := make([]string, 0)
+
+	// This loop is just to pick the execpath and eliminate any square braces around it.
+	// Just pick /entrypoint.sh from [/entrypoint.sh]
+	for _, c := range execpath {
+		execpathQuoted = append(execpathQuoted, fmt.Sprintf("\"%s\"", c))
+	}
+	for _, s := range cmd {
+		execpathQuoted = append(execpathQuoted, fmt.Sprintf("\"%s\"", s))
+	}
+	command := strings.Join(execpathQuoted, " ")
+	if err := os.WriteFile(filepath.Join(rootPath, "cmdline"),
+		[]byte(command), 0644); err != nil {
+		return err
+	}
+
+	// Userid and GID are same
+	ug := "0 0"
+	if user != "" {
+		uid, converr := strconv.Atoi(user)
+		if converr != nil {
+			return converr
+		}
+		ug = fmt.Sprintf("%d %d", uid, uid)
+	}
+	if err := os.WriteFile(filepath.Join(rootPath, "ug"),
+		[]byte(ug), 0644); err != nil {
+		return err
+	}
+
+	err = os.MkdirAll(filepath.Join(rootPath, "modules"), 0600)
+	return err
+}
+
+func (*containerdCAS) writeKubevirtMountpointsFile(mountpoints map[string]struct{}, rootPath string) error {
+	if len(mountpoints) > 0 {
+		f, err := os.OpenFile(filepath.Join(rootPath, "mountPoints"), os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			err = fmt.Errorf("PrepareContainerRootDir: Exception while creating file  mountpoints to %v %v",
+				rootPath, err)
+			logrus.Error(err.Error())
+			return err
+		}
+
+		defer f.Close()
+		for m := range mountpoints {
+			m += "\n"
+			if _, err := f.WriteString(m); err != nil {
+				err = fmt.Errorf("PrepareContainerRootDir: Exception while writing mountpoints to %v %v",
+					rootPath, err)
+				logrus.Error(err.Error())
+				return err
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/pillar/cas/containerd_test.go
+++ b/pkg/pillar/cas/containerd_test.go
@@ -1,0 +1,43 @@
+package cas
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteKubevirtMountpointsFile(t *testing.T) {
+	cas := containerdCAS{}
+	mountPoints := map[string]struct{}{
+		"/media/floppy": {},
+		"/media/cdrom":  {},
+	}
+
+	dname, err := os.MkdirTemp("", "prefix")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = cas.writeKubevirtMountpointsFile(mountPoints, dname)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	contentBytes, err := os.ReadFile(filepath.Join(dname, "mountPoints"))
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content := string(contentBytes)
+
+	for mountPoint := range mountPoints {
+		if !strings.Contains(content, mountPoint) {
+			t.Fatalf("mountPoint %s is missing", mountPoint)
+		}
+	}
+
+	os.RemoveAll(filepath.Join(dname, "mountPoints"))
+}

--- a/pkg/pillar/cmd/volumemgr/handlecontent.go
+++ b/pkg/pillar/cmd/volumemgr/handlecontent.go
@@ -10,6 +10,7 @@ import (
 
 	v1types "github.com/google/go-containerregistry/pkg/v1/types"
 	zconfig "github.com/lf-edge/eve-api/go/config"
+	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils"
 	"github.com/lf-edge/eve/pkg/pillar/vault"
@@ -182,6 +183,7 @@ func createContentTreeStatus(ctx *volumemgrContext, config types.ContentTreeConf
 			DisplayName:       config.DisplayName,
 			State:             types.INITIAL,
 			Blobs:             []string{},
+			HVTypeKube:        base.IsHVTypeKube(),
 			// LastRefCountChangeTime: time.Now(),
 		}
 		populateDatastoreFields(ctx, config, status)
@@ -325,7 +327,8 @@ func doDeleteContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 	log.Functionf("doDeleteContentTree for %v", status.ContentID)
 	RemoveAllBlobsFromContentTreeStatus(ctx, status, status.Blobs...)
 	//We create a reference when we load the blobs. We should remove that reference when we delete the contentTree.
-	if err := ctx.casClient.RemoveImage(status.ReferenceID()); err != nil {
+	refName := status.ReferenceID()
+	if err := ctx.casClient.RemoveImage(refName); err != nil {
 		log.Errorf("doDeleteContentTree: exception while deleting image %s: %s",
 			status.RelativeURL, err.Error())
 	}

--- a/pkg/pillar/cmd/volumemgr/handlevolumeref.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolumeref.go
@@ -38,6 +38,7 @@ func handleVolumeRefCreate(ctxArg interface{}, key string,
 			VerifyOnly:             config.VerifyOnly,
 			Target:                 vs.Target,
 			CustomMeta:             vs.CustomMeta,
+			ReferenceName:          vs.ReferenceName,
 		}
 		if vs.HasError() {
 			description := vs.ErrorDescription
@@ -187,6 +188,7 @@ func updateVolumeRefStatus(ctx *volumemgrContext, vs *types.VolumeStatus) {
 				status.Target = vs.Target
 				status.CustomMeta = vs.CustomMeta
 				status.WWN = vs.WWN
+				status.ReferenceName = vs.ReferenceName
 				if vs.HasError() {
 					description := vs.ErrorDescription
 					description.ErrorEntities = []*types.ErrorEntity{{
@@ -215,6 +217,7 @@ func updateVolumeRefStatus(ctx *volumemgrContext, vs *types.VolumeStatus) {
 				WWN:                    vs.WWN,
 				VerifyOnly:             config.VerifyOnly,
 				Target:                 vs.Target,
+				ReferenceName:          vs.ReferenceName,
 			}
 			if vs.HasError() {
 				description := vs.ErrorDescription

--- a/pkg/pillar/cmd/volumemgr/handlework.go
+++ b/pkg/pillar/cmd/volumemgr/handlework.go
@@ -235,8 +235,10 @@ func casIngestWorker(ctxPtr interface{}, w worker.Work) worker.WorkResult {
 		}
 	}
 
+	appImgName := status.ReferenceID()
+
 	// load the blobs
-	loadedBlobs, err := ctx.casClient.IngestBlobsAndCreateImage(status.ReferenceID(), *root, loadBlobs...)
+	loadedBlobs, err := ctx.casClient.IngestBlobsAndCreateImage(appImgName, *root, loadBlobs...)
 	// loadedBlobs are BlobStatus for the ones we loaded
 	for _, blob := range loadedBlobs {
 		d.loaded = append(d.loaded, blob.Sha256)

--- a/pkg/pillar/cmd/volumemgr/initialvolumestatus.go
+++ b/pkg/pillar/cmd/volumemgr/initialvolumestatus.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	zconfig "github.com/lf-edge/eve-api/go/config"
+	"github.com/lf-edge/eve/pkg/pillar/kubeapi"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/volumehandlers"
 	"github.com/lf-edge/eve/pkg/pillar/zfs"
@@ -66,6 +67,28 @@ func populateExistingVolumesFormatDatasets(_ *volumemgrContext, dataset string) 
 	log.Functionf("populateExistingVolumesFormatDatasets(%s) Done", dataset)
 }
 
+// populateExistingVolumesFormatPVC iterates over the namespace and takes format
+// from the name of the volume/PVC and prepares map of it
+func populateExistingVolumesFormatPVC(_ *volumemgrContext) {
+
+	log.Functionf("populateExistingVolumesFormatPVC")
+	pvlist, err := kubeapi.GetPVCList(log)
+	if err != nil {
+		log.Errorf("populateExistingVolumesFormatPVC: GetPVCList failed: %v", err)
+		return
+	}
+	for _, pvcName := range pvlist {
+		tempStatus, err := getVolumeStatusByPVC(pvcName)
+		if err != nil {
+			log.Error(err)
+			continue
+		}
+		volumeFormat[tempStatus.Key()] = tempStatus.ContentFormat
+	}
+	log.Functionf("populateExistingVolumesFormatPVC Done")
+
+}
+
 // Periodic garbage collection looking at RefCount=0 files in the unknown
 // Others have their delete handler.
 func gcObjects(ctx *volumemgrContext, dirName string) {
@@ -115,6 +138,38 @@ func gcVolumes(ctx *volumemgrContext, locations []string) {
 			}
 		}
 	}
+}
+
+func getVolumeStatusByPVC(pvcName string) (*types.VolumeStatus, error) {
+	var encrypted bool
+	var parsedFormat int32
+	var volumeIDAndGeneration string
+
+	volumeIDAndGeneration = pvcName
+	parsedFormat = int32(zconfig.Format_PVC)
+
+	generation := strings.Split(volumeIDAndGeneration, "-pvc-")
+	volUUID, err := uuid.FromString(generation[0])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse VolumeID: %s", err)
+	}
+	if len(generation) == 1 {
+		return nil, fmt.Errorf("cannot extract generation from PVC %s", pvcName)
+	}
+	// we cannot extract LocalGenerationCounter from the PVC name
+	// assume it is zero
+	generationCounter, err := strconv.ParseInt(generation[1], 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse GenerationCounter: %s", err)
+	}
+	vs := types.VolumeStatus{
+		VolumeID:          volUUID,
+		Encrypted:         encrypted,
+		GenerationCounter: generationCounter,
+		ContentFormat:     zconfig.Format(parsedFormat),
+		FileLocation:      pvcName,
+	}
+	return &vs, nil
 }
 
 func getVolumeStatusByLocation(location string) (*types.VolumeStatus, error) {

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -434,11 +434,12 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 		log.Functionf("doUpdateContentTree(%s) successfully loaded all blobs into CAS", status.Key())
 
 		// check if the image was created
-		if !lookupImageCAS(status.ReferenceID(), ctx.casClient) {
+		imgName := status.ReferenceID()
+		if !lookupImageCAS(imgName, ctx.casClient) {
 			log.Functionf("doUpdateContentTree(%s): image does not yet exist in CAS", status.Key())
 			return changed, false
 		}
-		log.Functionf("doUpdateContentTree(%s): image exists in CAS, Content Tree load is completely LOADED", status.Key())
+		log.Functionf("doUpdateContentTree(%s): image %v exists in CAS, Content Tree load is completely LOADED", status.Key(), imgName)
 		status.State = types.LOADED
 		status.CreateTime = time.Now()
 		// ContentTreeStatus.FileLocation has no meaning once everything is loaded
@@ -592,7 +593,8 @@ func doUpdateVol(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool)
 			status.State != types.CREATING_VOLUME &&
 			status.SubState == types.VolumeSubStateInitial {
 
-			_, err := ctx.casClient.GetImageHash(ctStatus.ReferenceID())
+			imgName := ctStatus.ReferenceID()
+			_, err := ctx.casClient.GetImageHash(imgName)
 			if err != nil {
 				log.Functionf("doUpdateVol(%s): waiting for image create: %s", status.Key(), err.Error())
 				return changed, false
@@ -614,7 +616,7 @@ func doUpdateVol(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool)
 					status.Key(), status.DisplayName)
 				return changed, false
 			}
-			status.ReferenceName = ctStatus.ReferenceID()
+			status.ReferenceName = imgName
 			status.ContentFormat = ctStatus.Format
 			log.Noticef("doUpdateVol(%s): setting VolumeStatus.ContentFormat by ContentTree to %s", status.Key(), status.ContentFormat)
 			changed = true

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/cas"
 	"github.com/lf-edge/eve/pkg/pillar/flextimer"
+	"github.com/lf-edge/eve/pkg/pillar/kubeapi"
 	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
@@ -102,6 +103,9 @@ type volumemgrContext struct {
 
 	// cli options
 	versionPtr *bool
+
+	// kube mode
+	hvTypeKube bool
 }
 
 func (ctxPtr *volumemgrContext) lookupVolumeStatusByUUID(id string) *types.VolumeStatus {
@@ -140,6 +144,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		deferContentDelete: 0,
 		globalConfig:       types.DefaultConfigItemValueMap(),
 		persistType:        vault.ReadPersistType(),
+		hvTypeKube:         base.IsHVTypeKube(),
 	}
 	agentbase.Init(&ctx, logger, log, agentName,
 		agentbase.WithArguments(arguments))
@@ -237,9 +242,23 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	}
 	log.Functionf("user containerd ready")
 
+	// wait for kubernetes up if in kube mode, if gets error, move on
+	if ctx.hvTypeKube {
+		log.Noticef("volumemgr run: wait for kubernetes")
+		err := kubeapi.WaitForKubernetes(agentName, ps, stillRunning)
+		if err != nil {
+			log.Errorf("volumemgr run: wait for kubernetes error %v", err)
+		} else {
+			log.Noticef("volumemgr run: kubernetes node ready, longhorn ready")
+		}
+
+	}
+
 	if ctx.persistType == types.PersistZFS {
 		if isZvol, _ := zfs.IsDatasetTypeZvol(types.SealedDataset); isZvol {
+			// This code is called only on kubevirt eve
 			initializeDirs()
+			populateExistingVolumesFormatPVC(&ctx)
 		} else {
 			// create datasets for volumes
 			initializeDatasets()

--- a/pkg/pillar/hypervisor/containerd_test.go
+++ b/pkg/pillar/hypervisor/containerd_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2024 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package hypervisor
 
 import (

--- a/pkg/pillar/scripts/copy-image-to-qcow.sh
+++ b/pkg/pillar/scripts/copy-image-to-qcow.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+# Copyright (c) 2024 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+#SRCDIR is the container rootfs directory of the image
+# ie /persist/vault/volumes/*container directory
+#DESTFILE is the qcow2 file
+# 1) Create an empty qcow2 file
+# 2) mkfs ext4 and mount it as nbd device
+# 3) rsync the SRCDIR to mounted qcow2
+
+echo "$(date -Ins -u) Starting copy-image-to-qcow.sh"
+
+SRCDIR=$1
+DESTFILE=$2
+MOUNTDIR=/tmp/dest.$$
+
+if [ ! -d "$SRCDIR" ]; then
+   echo "$SRCDIR does not exist"
+   exit 1
+fi
+
+if [ -f "$DESTFILE" ]; then
+   echo "$DESTFILE already exists"
+   exit 1
+fi
+
+SIZEMB=$(du -sm "$SRCDIR"/ | awk '{print $1}')
+#This is a workaround for now we allocate twice the size of SRCDIR, somehow rsync at the end of script does not like the
+#exact size allocated for qcow2, it expects little bit more, may be for some metadata.
+#It does not cost us anything allocating more space here since its thin allocated.
+SIZEMB=$((SIZEMB * 2))
+/usr/bin/qemu-img create -o preallocation=off -f qcow2 "$DESTFILE" "$SIZEMB""M"
+qemu-img info -U --output=json "$DESTFILE"
+#Get an exclusive lock so that no one else mounts the /dev/nbd10
+LOCK_FILE="/run/create-image.lock"
+WAIT_INTERVAL=5
+# Loop until an exclusive lock is acquired
+while true; do
+    exec 200>"$LOCK_FILE"
+    if flock -x 200; then
+        break  # Exit the loop if the lock is acquired
+    else
+        echo "Waiting for exclusive lock..."
+        sleep "$WAIT_INTERVAL"
+    fi
+done
+
+# Set up ndb to mount qcow file.
+modprobe nbd max_part=8
+/usr/bin/qemu-nbd --connect=/dev/nbd10 "$DESTFILE"
+sleep 10
+mke2fs -t ext4 /dev/nbd10
+qemu-img info -U --output=json "$DESTFILE"
+mkdir -p "$MOUNTDIR"
+mount -t ext4 /dev/nbd10 "$MOUNTDIR"
+failed=0
+
+echo "Starting rsync"
+#Use rsync to keep source permissions and ownership
+if ! rsync -arl  "$SRCDIR"/* "$MOUNTDIR"; then
+failed=1
+fi
+umount "$MOUNTDIR"
+qemu-nbd --disconnect /dev/nbd10
+rm -rf "$MOUNTDIR"
+flock -u 200
+if [ "$failed" = "1" ]; then
+echo "Failed to copy to qcow2 file $DESTFILE, deleting it"
+exit 1
+fi
+echo "rsync succeeded"
+qemu-img info -U --output=json "$DESTFILE"
+echo "$(date -Ins -u) Converted $SRCDIR to $DESTFILE"
+exit 0

--- a/pkg/pillar/types/contenttreetypes.go
+++ b/pkg/pillar/types/contenttreetypes.go
@@ -14,6 +14,9 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
+// KubeContainerImagePrefix : Container Image prefix adding to kubevirt container image name
+const KubeContainerImagePrefix = "docker.io/"
+
 // ContentTreeConfig specifies the needed information for content tree
 // which might need to be downloaded and verified
 type ContentTreeConfig struct {
@@ -132,6 +135,7 @@ type ContentTreeStatus struct {
 	// Blobs the sha256 hashes of the blobs that are in this tree, the first of which always is the root
 	Blobs []string
 
+	HVTypeKube bool
 	ErrorAndTimeWithSource
 }
 
@@ -157,6 +161,10 @@ func (status ContentTreeStatus) IsContainer() bool {
 
 // ReferenceID get the image reference ID
 func (status ContentTreeStatus) ReferenceID() string {
+
+	if status.HVTypeKube && status.IsContainer() {
+		return fmt.Sprintf("%s%s-%s", KubeContainerImagePrefix, status.ContentID.String(), status.RelativeURL)
+	}
 	return fmt.Sprintf("%s-%s", status.ContentID.String(), status.RelativeURL)
 }
 

--- a/pkg/pillar/types/volumetypes.go
+++ b/pkg/pillar/types/volumetypes.go
@@ -167,6 +167,15 @@ func (status VolumeStatus) PathName() string {
 		strings.ToLower(status.ContentFormat.String()))
 }
 
+// GetPVCName : returns the volume name for kubernetes(longhorn)
+// Kubernetes does not allow special characters like '#' in the object names.
+// so we need to generate a PVC name.
+func (status VolumeStatus) GetPVCName() string {
+	return fmt.Sprintf("%s-pvc-%d", status.VolumeID.String(),
+		status.GenerationCounter+status.LocalGenerationCounter)
+
+}
+
 // LogCreate :
 func (status VolumeStatus) LogCreate(logBase *base.LogObject) {
 	logObject := base.NewLogObject(logBase, base.VolumeStatusLogType, status.DisplayName,
@@ -398,6 +407,7 @@ type VolumeRefStatus struct {
 	VerifyOnly             bool
 	Target                 zconfig.Target
 	CustomMeta             string
+	ReferenceName          string
 
 	ErrorAndTimeWithSource
 }

--- a/pkg/pillar/volumehandlers/csihandler.go
+++ b/pkg/pillar/volumehandlers/csihandler.go
@@ -1,0 +1,331 @@
+// Copyright (c) 2024 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build kubevirt
+
+package volumehandlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/lf-edge/edge-containers/pkg/registry"
+	zconfig "github.com/lf-edge/eve-api/go/config"
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/kubeapi"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	kerr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/rest"
+)
+
+const imageToQcowScript = "/opt/zededa/bin/copy-image-to-qcow.sh"
+
+type volumeHandlerCSI struct {
+	commonVolumeHandler
+	useVHost bool
+	config   *rest.Config
+}
+
+// NewCSIHandler is a constructor for the kubernetes CSI handler.
+func NewCSIHandler(common commonVolumeHandler, useVHost bool) VolumeHandler {
+	return &volumeHandlerCSI{
+		commonVolumeHandler: common,
+		useVHost:            useVHost,
+	}
+}
+
+func (handler *volumeHandlerCSI) GetVolumeDetails() (uint64, uint64, string, bool, error) {
+	pvcName := handler.status.GetPVCName()
+	handler.log.Noticef("GetVolumeDetails called for PVC %s", pvcName)
+	imgInfo, err := kubeapi.GetPVCInfo(pvcName, handler.log)
+	if err != nil {
+		return 0, 0, "", false, fmt.Errorf("GetPVCInfo failed for %s: %v", pvcName, err)
+	}
+	return imgInfo.ActualSize, imgInfo.VirtualSize, imgInfo.Format,
+		imgInfo.DirtyFlag, nil
+}
+
+func (handler *volumeHandlerCSI) UsageFromStatus() uint64 {
+	// use MaxVolSize for PVC
+	handler.log.Noticef("UsageFromStatus: Use MaxVolSize for PVC %s",
+		handler.status.GetPVCName())
+	return handler.status.MaxVolSize
+}
+
+func (handler *volumeHandlerCSI) PrepareVolume() error {
+	handler.log.Noticef("PrepareVolume called for PVC %s", handler.status.GetPVCName())
+	return nil
+}
+
+func (handler *volumeHandlerCSI) HandlePrepared() (bool, error) {
+	handler.log.Noticef("HandlePrepared called for PVC %s", handler.status.GetPVCName())
+	return true, nil
+}
+
+func (handler *volumeHandlerCSI) HandleCreated() (bool, error) {
+	handler.log.Noticef("HandleCreated called for PVC %s", handler.status.GetPVCName())
+	// Though we convert container image to PVC, we need to keep the image format to tell domainmgr
+	// that we are launching a container as VM.
+	if !handler.status.IsContainer() {
+		handler.status.ContentFormat = zconfig.Format_PVC
+	}
+	updateVolumeSizes(handler.log, handler, handler.status)
+	return true, nil
+}
+
+func (handler *volumeHandlerCSI) CreateVolume() (string, error) {
+
+	createContext := context.Background()
+
+	// we call createCancel to break volume creation process
+	// removing of partially created objects must be done inside caller
+	createContext, createCancel := context.WithCancel(createContext)
+
+	done := make(chan struct{}, 1)
+
+	defer func() {
+		done <- struct{}{}
+	}()
+
+	go func() {
+		timer := time.NewTicker(time.Second)
+		defer timer.Stop()
+		for {
+			select {
+			case <-timer.C:
+				st := handler.volumeManager.LookupVolumeStatus(handler.status.Key())
+				// it disappears in case of deleting of volume config
+				if st == nil {
+					handler.log.Warnf("CreateVolume: VolumeStatus(%s) disappear during creation", handler.status.Key())
+					createCancel()
+					return
+				}
+			case <-done:
+				createCancel()
+				return
+			}
+		}
+	}()
+
+	pvcName := handler.status.GetPVCName()
+	pvcSize := handler.status.MaxVolSize
+
+	// We cannot create a PVC with size 0. MaxVolSize could be set to 0 for a DOWNLOADED volume.
+	// So use the totalsize of downloaded volume.
+	if pvcSize == 0 {
+		pvcSize = uint64(handler.status.TotalSize)
+	}
+	handler.log.Noticef("CreateVolume called for PVC %s size %v", pvcName, pvcSize)
+
+	// Reference Name is set for downloaded volumes. virtctl in RolloutImgToPVC can create PVC if not exists
+	// so we need not explicitly create the PVC here.
+	if handler.status.ReferenceName != "" {
+
+		// If this is an image in container format, then convert it to qcow2
+		// Some app images are already in qcow2 format, then just proceed to next step
+		// Downloaded volumes are almost always in qcow2 format
+		if handler.status.IsContainer() {
+
+			// This is a multistep process.
+			// 1) Use container volume handler to Prepare a containerimage rootdir
+			// 2) Call CopyImgDirToRawImg to convert the rootdir to a qcow2 file
+			// NOTE: This qcow2 will be converted to PVC in later steps.
+			// For container images we convert to qcow2 file under /persist/vault/volumes/pvcName.qcow2
+
+			rawImgFile := "/persist/vault/volumes/" + pvcName + ".img"
+
+			chandler := &volumeHandlerContainer{handler.commonVolumeHandler}
+
+			// This lays out container rootfs directory and creates all bootloader files for kubevirt eve.
+			imgDirLocation, err := chandler.CreateVolume()
+
+			handler.log.Noticef("After CreateVolume fileloc %s err %v", imgDirLocation, err)
+
+			if err != nil {
+				errStr := fmt.Sprintf("Error CreateVolume %s err: %v",
+					imgDirLocation, err)
+				handler.log.Error(errStr)
+				return "", errors.New(errStr)
+			}
+
+			err = handler.CopyImgDirToRawImg(createContext, handler.log, imgDirLocation, rawImgFile)
+			if err != nil {
+				errStr := fmt.Sprintf("Error copying container image to raw image %s err: %v",
+					imgDirLocation, err)
+				handler.log.Error(errStr)
+				return "", errors.New(errStr)
+			}
+
+			chandler.status.FileLocation = imgDirLocation
+			// If we are here, we converted container image to rawImgFile, no reason to keep the containerdir
+			// So delete the container image mount we created as part of CreateVolume() above
+			// DestroyVolume() just umounts rootfs and deletes the container directory in /persist/vault/volumes.
+			// It does not delete the image, which is what we want.
+			imgDirLocation, err = chandler.DestroyVolume()
+			if err != nil {
+				errStr := fmt.Sprintf("Error DestroyVolume %s err: %v",
+					imgDirLocation, err)
+				handler.log.Error(errStr)
+				return "", errors.New(errStr)
+			}
+
+			// Convert to PVC
+			pvcerr := kubeapi.RolloutDiskToPVC(createContext, handler.log, false, rawImgFile, pvcName, false)
+
+			// Since we succeeded or failed to create PVC above, no point in keeping the rawImgFile.
+			// Delete it to save space.
+			if err = os.RemoveAll(rawImgFile); err != nil {
+				errStr := fmt.Sprintf("CreateVolume: exception while deleting: %v. %v", rawImgFile, err)
+				handler.log.Error(errStr)
+				return pvcName, errors.New(errStr)
+			}
+
+			if pvcerr != nil {
+				errStr := fmt.Sprintf("Error converting %s to PVC %s: %v",
+					rawImgFile, pvcName, pvcerr)
+				handler.log.Error(errStr)
+				return pvcName, errors.New(errStr)
+			}
+		} else {
+			qcowFile, err := handler.getVolumeFilePath()
+			if err != nil {
+				errStr := fmt.Sprintf("Error obtaining file for PVC at volume %s, error=%v",
+					pvcName, err)
+				handler.log.Error(errStr)
+				return pvcName, errors.New(errStr)
+			}
+			// Convert qcow2 to PVC
+			err = kubeapi.RolloutDiskToPVC(createContext, handler.log, false, qcowFile, pvcName, false)
+
+			if err != nil {
+				errStr := fmt.Sprintf("Error converting %s to PVC %s: %v",
+					qcowFile, pvcName, err)
+				handler.log.Error(errStr)
+				return pvcName, errors.New(errStr)
+			}
+		}
+	} else {
+		err := kubeapi.CreatePVC(pvcName, pvcSize, handler.log)
+		if err != nil {
+			errStr := fmt.Sprintf("Error creating PVC %s", pvcName)
+			handler.log.Error(errStr)
+			return "", errors.New(errStr)
+		}
+	}
+
+	handler.log.Functionf("CreateVolume(%s) DONE", pvcName)
+	return pvcName, nil
+}
+
+func (handler *volumeHandlerCSI) DestroyVolume() (string, error) {
+	pvcName := handler.status.GetPVCName()
+	handler.log.Noticef("DestroyVolume called for PVC %s", pvcName)
+	err := kubeapi.DeletePVC(pvcName, handler.log)
+	if err != nil {
+		// Its OK if not found since PVC might have been deleted already
+		if kerr.IsNotFound(err) {
+			handler.log.Noticef("PVC %s not found, might have been deleted", pvcName)
+			return pvcName, nil
+		} else {
+			return pvcName, err
+		}
+	}
+	return pvcName, nil
+}
+
+func (handler *volumeHandlerCSI) Populate() (bool, error) {
+	pvcName := handler.status.GetPVCName()
+	handler.log.Noticef("Populate called for PVC %s", pvcName)
+	_, err := kubeapi.FindPVC(pvcName, handler.log)
+	if err != nil {
+		// Its OK if not found since PVC might not be created yet.
+		if kerr.IsNotFound(err) {
+			handler.log.Noticef("PVC %s not found", pvcName)
+			return false, nil
+		} else {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+// Copied from zvolhandler.go
+func (handler *volumeHandlerCSI) getVolumeFilePath() (string, error) {
+	puller := registry.Puller{
+		Image: handler.status.ReferenceName,
+	}
+	ctrdCtx, done := handler.volumeManager.GetCasClient().CtrNewUserServicesCtx()
+	defer done()
+
+	resolver, err := handler.volumeManager.GetCasClient().Resolver(ctrdCtx)
+	if err != nil {
+		errStr := fmt.Sprintf("error getting CAS resolver: %v", err)
+		handler.log.Error(errStr)
+		return "", errors.New(errStr)
+	}
+	pathToFile := ""
+	_, i, err := puller.Config(true, os.Stderr, resolver)
+	if err != nil {
+		errStr := fmt.Sprintf("error Config for ref %s: %v", handler.status.ReferenceName, err)
+		handler.log.Error(errStr)
+		return "", errors.New(errStr)
+	}
+	if len(i.RootFS.DiffIDs) > 0 {
+		// FIXME we expects root in the first layer for now
+		b := i.RootFS.DiffIDs[0]
+		// FIXME we need the proper way to extract file from content dir of containerd
+		pathToFile = filepath.Join(types.ContainerdContentDir, "blobs", b.Algorithm().String(), b.Encoded())
+	}
+
+	if pathToFile == "" {
+		errStr := fmt.Sprintf("no blobs to convert found for ref %s", handler.status.ReferenceName)
+		handler.log.Error(errStr)
+		return "", errors.New(errStr)
+	}
+	return pathToFile, nil
+}
+
+// Creates a dest qcow2 file from the srcLocation
+func (handler *volumeHandlerCSI) CopyImgDirToRawImg(ctx context.Context, log *base.LogObject, srcLocation string, destFile string) error {
+
+	args := []string{srcLocation, destFile}
+
+	log.Noticef("%s args %v", imageToQcowScript, args)
+
+	output, err := base.Exec(log, imageToQcowScript, args...).WithContext(ctx).WithUnlimitedTimeout(120 * time.Hour).CombinedOutput()
+
+	if err != nil {
+		return fmt.Errorf("CopyImgDirToRawImg: Failed to create raw image file  %s: %w", output, err)
+	}
+
+	return nil
+}
+
+func (handler *volumeHandlerCSI) CreateSnapshot() (interface{}, time.Time, error) {
+	//TODO implement me
+	errStr := fmt.Sprintf("CreateSnapshot not implemented for CSI")
+	handler.log.Error(errStr)
+	err := errors.New(errStr)
+	timeCreated := time.Time{}
+	return "", timeCreated, err
+}
+
+func (handler *volumeHandlerCSI) RollbackToSnapshot(snapshotMeta interface{}) error {
+	//TODO implement me
+	errStr := fmt.Sprintf("RollbackToSnapshot not implemented for CSI")
+	handler.log.Error(errStr)
+	err := errors.New(errStr)
+	return err
+}
+
+func (handler *volumeHandlerCSI) DeleteSnapshot(snapshotMeta interface{}) error {
+	//TODO implement me
+	errStr := fmt.Sprintf("DeleteSnapshot not implemented for CSI")
+	handler.log.Error(errStr)
+	err := errors.New(errStr)
+	return err
+}

--- a/pkg/pillar/volumehandlers/handlers.go
+++ b/pkg/pillar/volumehandlers/handlers.go
@@ -62,6 +62,10 @@ func useVhost(log *base.LogObject, volumeManager VolumeMgr) bool {
 // GetVolumeHandler returns handler based on provided status
 func GetVolumeHandler(log *base.LogObject, volumeManager VolumeMgr, status *types.VolumeStatus) VolumeHandler {
 	common := commonVolumeHandler{volumeManager: volumeManager, status: status, log: log}
+
+	if base.IsHVTypeKube() {
+		return NewCSIHandler(common, false) // kubevirt does not support vhost yet
+	}
 	if status.IsContainer() {
 		return &volumeHandlerContainer{common}
 	}

--- a/pkg/pillar/volumehandlers/nokube.go
+++ b/pkg/pillar/volumehandlers/nokube.go
@@ -1,0 +1,11 @@
+// Copyright (c) 202 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !kubevirt
+
+package volumehandlers
+
+// NewCSIHandler in this file is just stub for non-kubevirt hypervisors.
+func NewCSIHandler(common commonVolumeHandler, useVHost bool) VolumeHandler {
+	panic("Kubernetes CSI handler is not built")
+}


### PR DESCRIPTION
Implements the new volumehandler, csihandler to create kubernetes specific volumes Implements the volumehandler interface functions like CreateVolume, DestroyVolume etc. for PersistentVolumes (Kubernetes based volumes) Though longhorn can support filemode volumes we only create blockmode volumes since eve only deals with block volumes.

CreateVolume() does the following:
 1) A blank volume create request, creates a blockmode PVC
 2) A downloaded volume qcow2 is converted to blockmode PVC
 3) For container images, we follow the same path of extracting rootfs to /persist/vault/volumes/*container directory
    once the rootfs is laid out, the files required for runx-initrd are generated and copied into /persist/vault/volumes/*container
    The directory content will look like this:
    4b6da250-6608-4686-a9fd-89e16f39ded6:/persist/vault/volumes/fe328d99-a380-45a7-99af-612b6264f628#0.container# ls
    cmdline            environment        image-config.json  modules            rootfs             ug
    This entire directory is first copied to a qcow2 using copy-image-to-qcow.sh script
    The qcow2 is copied to PVC, which will be used as bootdisk for the VM.
    The qcow2 will be deleted to save space.

Volume snapshots are not supported yet and a corresponding error is returned. Kubenertes naming convention does not support "#", so all PVC are keyed with -pvc- instead of "#" Added docker.io/ prefix to the container images inserted into the containerd repository