### PR TITLE
Implement snapshotting for ZFS volumes

### DIFF
--- a/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
+++ b/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
@@ -453,6 +453,24 @@ func deserializeSnapshotInstanceStatus(snapshotID string) (*types.SnapshotInstan
 	return snapshotInstanceStatus, nil
 }
 
+func isSnapshotDescInSlice(slice *[]types.SnapshotDesc, id string) bool {
+	for _, snap := range *slice {
+		if snap.SnapshotID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func removeSnapshotDescFromSlice(slice *[]types.SnapshotDesc, id string) {
+	for i, snap := range *slice {
+		if snap.SnapshotID == id {
+			*slice = append((*slice)[:i], (*slice)[i+1:]...)
+			return
+		}
+	}
+}
+
 func removeSnapshotFromSlice(slice *[]types.SnapshotInstanceStatus, id string) (removedSnap *types.SnapshotInstanceStatus) {
 	removedSnap = nil
 	for i, snap := range *slice {

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -283,6 +283,9 @@ func triggerSnapshotDeletion(snapshotsToBeDeleted []types.SnapshotDesc, ctx *zed
 			log.Noticef("It has already been triggered, so deleting the config and notifying volumemanager")
 			volumesSnapshotConfig.Action = types.VolumesSnapshotDelete
 			unpublishVolumesSnapshotConfig(ctx, volumesSnapshotConfig)
+			// Remove the snapshot from the list of snapshots to be deleted and publish the status
+			removeSnapshotDescFromSlice(&status.SnapStatus.SnapshotsToBeDeleted, snapshot.SnapshotID)
+			publishAppInstanceStatus(ctx, status)
 		}
 	}
 }

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -949,9 +949,12 @@ func updateSnapshotsInAIStatus(status *types.AppInstanceStatus, config types.App
 		}
 		status.SnapStatus.RequestedSnapshots = append(status.SnapStatus.RequestedSnapshots, newSnapshotStatus)
 	}
-	status.SnapStatus.SnapshotsToBeDeleted = snapshotsToBeDeleted
 	// Remove the snapshots marked for deletion from the list of available snapshots
 	for _, snapshot := range snapshotsToBeDeleted {
+		// If snapshot is not yet in the list of the snapshots to be deleted, add it there
+		if !isSnapshotDescInSlice(&status.SnapStatus.SnapshotsToBeDeleted, snapshot.SnapshotID) {
+			status.SnapStatus.SnapshotsToBeDeleted = append(status.SnapStatus.SnapshotsToBeDeleted, snapshot)
+		}
 		_ = removeSnapshotFromSlice(&status.SnapStatus.AvailableSnapshots, snapshot.SnapshotID)
 	}
 }

--- a/pkg/pillar/volumehandlers/zvolhandler.go
+++ b/pkg/pillar/volumehandlers/zvolhandler.go
@@ -270,26 +270,54 @@ func (handler *volumeHandlerZVol) getVolumeFilePath() (string, error) {
 }
 
 func (handler *volumeHandlerZVol) CreateSnapshot() (interface{}, time.Time, error) {
-	//TODO implement me
-	errStr := fmt.Sprintf("CreateSnapshot not implemented for zvol")
-	handler.log.Error(errStr)
-	err := errors.New(errStr)
-	timeCreated := time.Time{}
-	return "", timeCreated, err
+	handler.log.Noticef("CreateSnapshot for ZFS-based volume %s", handler.status.Key())
+	snapshotName, err := zfs.CreateSnapshot(handler.status.ZVolName())
+	if err != nil {
+		errStr := fmt.Sprintf("Error creating ZFS snapshot for %s: %v",
+			handler.status.Key(), err)
+		handler.log.Error(errStr)
+		return nil, time.Time{}, errors.New(errStr)
+	}
+	handler.log.Noticef("CreateSnapshot for ZFS-based volume %s: snapshot %s created", handler.status.Key(), snapshotName)
+	return snapshotName, time.Now(), nil
 }
 
 func (handler *volumeHandlerZVol) RollbackToSnapshot(snapshotMeta interface{}) error {
-	//TODO implement me
-	errStr := fmt.Sprintf("RollbackToSnapshot not implemented for zvol")
-	handler.log.Error(errStr)
-	err := errors.New(errStr)
-	return err
+	snapshotName, ok := snapshotMeta.(string)
+	if !ok {
+		errStr := fmt.Sprintf("RollbackToSnapshot failed for %s: invalid snapshotMeta",
+			handler.status.Key())
+		handler.log.Error(errStr)
+		return errors.New(errStr)
+	}
+	datasetName := handler.status.ZVolName()
+	err := zfs.RollbackToSnapshot(datasetName, snapshotName)
+	if err != nil {
+		errStr := fmt.Sprintf("RollbackToSnapshot failed for %s: %v",
+			handler.status.Key(), err)
+		handler.log.Error(errStr)
+		return errors.New(errStr)
+	}
+	handler.log.Noticef("RollbackToSnapshot for ZFS-based volume %s: snapshot %s rolled back", handler.status.Key(), snapshotName)
+	return nil
 }
 
 func (handler *volumeHandlerZVol) DeleteSnapshot(snapshotMeta interface{}) error {
-	//TODO implement me
-	errStr := fmt.Sprintf("DeleteSnapshot not implemented for zvol")
-	handler.log.Error(errStr)
-	err := errors.New(errStr)
-	return err
+	snapshotName, ok := snapshotMeta.(string)
+	if !ok {
+		errStr := fmt.Sprintf("DeleteSnapshot failed for %s: invalid snapshotMeta",
+			handler.status.Key())
+		handler.log.Error(errStr)
+		return errors.New(errStr)
+	}
+	err := zfs.DestroyDataset(snapshotName)
+	if err != nil {
+		errStr := fmt.Sprintf("DeleteSnapshot failed for %s: %v",
+			handler.status.Key(), err)
+		handler.log.Error(errStr)
+		return errors.New(errStr)
+
+	}
+	handler.log.Noticef("DeleteSnapshot for ZFS-based volume %s: snapshot %s deleted", handler.status.Key(), snapshotName)
+	return nil
 }


### PR DESCRIPTION
Leveraging the `libzfs` library, this update implements a full suite of snapshot operations, specifically tailored for ZFS-based volumes. These operations include:

- **Snapshot Creation:** Utilizes `libzfs.DatasetSnapshot` to create snapshots.
- **Snapshot Rollback:** Employs and `dataset.Rollback` methods to revert volumes to a previous state.
- **Snapshot Deletion:** Calls upon `libzfs.DestroyDataset` to remove snapshot.

These enhancements make extensive use of the `libzfs` library's functionalities, offering a robust framework for snapshot management that integrates seamlessly with EVE's ZFS volume handling.

## Consistent Operation Across EVE Setups
Despite the capabilities of ZFS snapshots to be created and utilized while VMs are running, this implementation enforces snapshot operations during VM halt states. This approach ensures consistent behavior across different EVE setups.

## Testing and Validation
- The changes were tested with a VM application with both purgable and unpurgable volumes, confirming the expected behavior of snapshot creation, rollback, and deletion across system reboots.
- The most advanced scenario tested involved creating a snapshot, rolling it back, removing the first snapshot, creating a new snapshot, rebooting the node, rolling back again, and finally deleting the snapshot, all of which were executed successfully.





