### PR TITLE
[10.4-stable] Backport #3765 and #3770 for increased robustness around keys and certificates

### DIFF
--- a/pkg/pillar/cmd/vaultmgr/vaultmgr.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgr.go
@@ -487,7 +487,8 @@ func publishVaultKey(ctx *vaultMgrContext, vaultName string) error {
 	var encryptedVaultKey []byte
 	//we try to fill EncryptedVaultKey only in case of tpm enabled
 	//otherwise we leave it empty
-	if etpm.IsTpmEnabled() {
+	isTpmEnabled := etpm.IsTpmEnabled()
+	if isTpmEnabled {
 		if !ctx.defaultVaultUnlocked {
 			log.Errorf("Vault is not yet unlocked, waiting for Controller key")
 			return nil
@@ -499,6 +500,7 @@ func publishVaultKey(ctx *vaultMgrContext, vaultName string) error {
 
 		encryptedKey, err := etpm.EncryptDecryptUsingTpm(keyBytes, true)
 		if err != nil {
+			// XXX should we still send with no key?
 			return fmt.Errorf("Failed to encrypt vault key %w", err)
 		}
 
@@ -519,6 +521,7 @@ func publishVaultKey(ctx *vaultMgrContext, vaultName string) error {
 	keyFromDevice := types.EncryptedVaultKeyFromDevice{}
 	keyFromDevice.Name = vaultName
 	keyFromDevice.EncryptedVaultKey = encryptedVaultKey
+	keyFromDevice.IsTpmEnabled = isTpmEnabled
 	key := keyFromDevice.Key()
 	log.Tracef("Publishing EncryptedVaultKeyFromDevice %s\n", key)
 	pub := ctx.pubVaultKeyFromDevice

--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -79,8 +79,16 @@ func parseControllerCerts(ctx *zedagentContext, contents []byte) (changed bool, 
 				break
 			}
 		}
-		if !found {
-			log.Functionf("parseControllerCerts: deleting %s", config.Key())
+		if found {
+			continue
+		}
+		// Is the ControllerCert in use?
+		if lookupCipherContextByCCH(ctx.getconfigCtx, configHash) != nil {
+			log.Noticef("ControllerCert %s hash %s in use",
+				config.Key(), string(configHash))
+		} else {
+			log.Noticef("ControllerCert %s hash %s delete",
+				config.Key(), string(configHash))
 			unpublishControllerCert(ctx.getconfigCtx, config.Key())
 			changed = true
 		}

--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -424,8 +424,6 @@ func publishEdgeNodeCertsToController(ctx *zedagentContext) {
 	log.Tracef("publishEdgeNodeCertsToController: after send, total elapse sec %v",
 		time.Since(startPubTime).Seconds())
 	ctx.cipherCtx.iteration++
-	// XXX remove log?
-	log.Noticef("Maybe sent EdgeNodeCerts")
 	// The getDeferredSentHandlerFunction will set ctx.publishedEdgeNodeCerts
 	// when the message has been sent.
 }

--- a/pkg/pillar/cmd/zedagent/handlecipherconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecipherconfig.go
@@ -16,6 +16,28 @@ import (
 
 var cipherCtxHash []byte
 
+// populateCipherContexts: fill in local map from persistent publication on boot
+func populateCipherContexts(ctx *getconfigContext) {
+	items := ctx.pubCipherContext.GetAll()
+	for _, item := range items {
+		context := item.(types.CipherContext)
+		ctx.cipherContexts[context.Key()] = context
+		log.Noticef("populateCipherContext found %s",
+			context.Key())
+	}
+}
+
+// lookupCipherContextByCCH: lookup by ControllerCertHash
+// The Key is a UUID so need to walk map
+func lookupCipherContextByCCH(ctx *getconfigContext, cch []byte) *types.CipherContext {
+	for _, context := range ctx.cipherContexts {
+		if bytes.Equal(context.ControllerCertHash, cch) {
+			return &context
+		}
+	}
+	return nil
+}
+
 // invalidateCipherContextDependenciesList function clear stored hashes for objects
 // which have parseCipherBlock inside
 // to re-run parse* functions on change of CipherContexts

--- a/pkg/pillar/cmd/zedagent/handlecipherconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecipherconfig.go
@@ -62,6 +62,7 @@ func parseCipherContext(ctx *getconfigContext,
 		if !found {
 			log.Functionf("parseCipherContext: deleting %s", idStr)
 			delete(ctx.cipherContexts, idStr)
+			unpublishCipherContext(ctx, idStr)
 		}
 	}
 
@@ -79,6 +80,7 @@ func parseCipherContext(ctx *getconfigContext,
 			ControllerCertHash: cfgCipherContext.GetControllerCertHash(),
 		}
 		ctx.cipherContexts[context.Key()] = context
+		publishCipherContext(ctx, context)
 	}
 	log.Functionf("parsing cipher context done")
 }
@@ -127,4 +129,25 @@ func parseCipherBlock(ctx *getconfigContext, key string, cfgCipherBlock *zconfig
 
 	log.Functionf("parseCipherBlock(%s) done", key)
 	return cipherBlock
+}
+
+func publishCipherContext(ctx *getconfigContext,
+	status types.CipherContext) {
+	key := status.Key()
+	log.Tracef("publishCipherContext(%s)", key)
+	pub := ctx.pubCipherContext
+	pub.Publish(key, status)
+	log.Tracef("publishCipherContext(%s) done", key)
+}
+
+func unpublishCipherContext(ctx *getconfigContext, key string) {
+	log.Tracef("unpublishCipherContext(%s)", key)
+	pub := ctx.pubCipherContext
+	c, _ := pub.Get(key)
+	if c == nil {
+		log.Errorf("unpublishCipherContext(%s) not found", key)
+		return
+	}
+	pub.Unpublish(key)
+	log.Tracef("unpublishCipherContext(%s) done", key)
 }

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -436,6 +436,9 @@ func configTimerTask(getconfigCtx *getconfigContext, handleChannel chan interfac
 			if getconfigCtx.configProcessingSkipFlag {
 				log.Noticef("config processing skip flag set")
 			}
+			if ctx.publishedEdgeNodeCerts && !ctx.publishedAttestEscrow {
+				log.Warning("Not yet published AttestEscrow")
+			}
 		}
 		ctx.ps.StillRunning(wdName, warningTime, errorTime)
 	}

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -492,14 +492,6 @@ func requestConfigByURL(getconfigCtx *getconfigContext, url string,
 	iteration int, withNetTracing bool) (configProcessingRetval, []netdump.TracedNetRequest) {
 
 	log.Tracef("getLatestConfig(%s, %d)", url, iteration)
-	// On first boot, if we haven't yet published our certificates we defer
-	// to ensure that the controller has our certs and can add encrypted
-	// secrets to our config.
-	if getconfigCtx.zedagentCtx.bootReason == types.BootReasonFirst &&
-		!getconfigCtx.zedagentCtx.publishedEdgeNodeCerts {
-		log.Noticef("Defer fetching config until our EdgeNodeCerts have been published")
-		return defferConfig, nil
-	}
 	ctx := getconfigCtx.zedagentCtx
 	const bailOnHTTPErr = false // For 4xx and 5xx HTTP errors we try other interfaces
 	// except http.StatusForbidden(which returns error

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -97,6 +97,7 @@ type getconfigContext struct {
 	pubDatastoreConfig        pubsub.Publication
 	pubNetworkInstanceConfig  pubsub.Publication
 	pubControllerCert         pubsub.Publication
+	pubCipherContext          pubsub.Publication
 	subContentTreeStatus      pubsub.Subscription
 	pubContentTreeConfig      pubsub.Publication
 	subVolumeStatus           pubsub.Subscription

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -203,8 +203,11 @@ type zedagentContext struct {
 	// Track the counter from force.fallback.counter to detect changes
 	forceFallbackCounter int
 
-	// Interlock with controller to ensure we get the encrypted secrets
+	// Used for retry of EdgeNodeCerts
 	publishedEdgeNodeCerts bool
+
+	// Used for retry of SendAttestEscrow
+	publishedAttestEscrow bool
 
 	attestationTryCount int
 	// cli options

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -1122,6 +1122,18 @@ func initPublications(zedagentCtx *zedagentContext) {
 	}
 	getconfigCtx.pubControllerCert.ClearRestarted()
 
+	// for CipherContextStatus Publisher
+	getconfigCtx.pubCipherContext, err = ps.NewPublication(
+		pubsub.PublicationOptions{
+			AgentName:  agentName,
+			Persistent: true,
+			TopicType:  types.CipherContext{},
+		})
+	if err != nil {
+		log.Fatal(err)
+	}
+	getconfigCtx.pubCipherContext.ClearRestarted()
+
 	// for ContentTree config Publisher
 	getconfigCtx.pubContentTreeConfig, err = ps.NewPublication(
 		pubsub.PublicationOptions{

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -1133,6 +1133,7 @@ func initPublications(zedagentCtx *zedagentContext) {
 		log.Fatal(err)
 	}
 	getconfigCtx.pubCipherContext.ClearRestarted()
+	populateCipherContexts(getconfigCtx)
 
 	// for ContentTree config Publisher
 	getconfigCtx.pubContentTreeConfig, err = ps.NewPublication(

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -2454,7 +2454,7 @@ func getDeferredSentHandlerFunction(ctx *zedagentContext) *zedcloud.SentHandlerF
 				ctx.publishedEdgeNodeCerts = true
 			}
 		} else {
-			if _, ok := itemType.(attest.ZAttestReqType); ok {
+			if el, ok := itemType.(attest.ZAttestReqType); ok {
 				switch result {
 				case types.SenderStatusUpgrade:
 					log.Functionf("sendAttestReqProtobuf: Controller upgrade in progress")
@@ -2467,6 +2467,13 @@ func getDeferredSentHandlerFunction(ctx *zedagentContext) *zedcloud.SentHandlerF
 				case types.SenderStatusNotFound:
 					log.Functionf("sendAttestReqProtobuf: Controller SenderStatusNotFound")
 					potentialUUIDUpdate(ctx.getconfigCtx)
+				}
+				if el == attest.ZAttestReqType_ATTEST_REQ_CERT {
+					log.Warnf("sendAttestReqProtobuf: Failed to send EdgeNodeCerts: %s",
+						result.String())
+					// XXX should we declare maintenance mode?
+					// We get SenderStatusNotFound when a cert can
+					// not be replaced in the controller for security reasons.
 				}
 				if !ctx.publishedEdgeNodeCerts {
 					// Attestation request does not clog the send queue (issued

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -429,14 +429,15 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	// XXX defer this until we have some config from cloud or saved copy
 	getconfigCtx.pubAppInstanceConfig.SignalRestarted()
 
+	// Initialize remote attestation context. Do this before we get events
+	// from the AttestQuote and EncryptedKeyFromDevice subscriptions
+	attestModuleInitialize(zedagentCtx)
+
 	// With device UUID, zedagent is ready to initialize and activate all subscriptions.
 	initPostOnboardSubs(zedagentCtx)
 
 	//initialize cipher processing block
 	cipherModuleInitialize(zedagentCtx)
-
-	//initialize remote attestation context
-	attestModuleInitialize(zedagentCtx)
 
 	// Pick up debug aka log level before we start real work
 	waitUntilGCReady(zedagentCtx, stillRunning)

--- a/pkg/pillar/types/vaultmgrtypes.go
+++ b/pkg/pillar/types/vaultmgrtypes.go
@@ -83,6 +83,7 @@ func (status VaultStatus) LogKey() string {
 type EncryptedVaultKeyFromDevice struct {
 	Name              string
 	EncryptedVaultKey []byte // empty if no TPM enabled
+	IsTpmEnabled      bool
 }
 
 // Key returns name of the vault corresponding to this object


### PR DESCRIPTION
Pulling in the following commits from master:
git cherry-pick -x 78b440088062cd5e9dba9d3046290e508f6c0191 c1a0e10c482a12e15cc4c854a81c6bc97506e3d6 443497dae716987f100fc645aa9d21c2f60bf516 d5d34f867d6fd2614dcbceb809984565fd25d4c1 1aead7f874f6536b1aeaafd3c4834dcaf311be48 6d8d99763e1c4914ce74e83d170bafe371a2dd99 344853e366d903ab672ef39c6deed8d7fd3d281c

