### PR TITLE
zedagent: remove duplicated cipherContext map

### DIFF
--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -162,8 +162,6 @@ type getconfigContext struct {
 	currentMetricInterval uint32
 
 	configEdgeview *types.EdgeviewConfig // edge-view config save
-
-	cipherContexts map[string]types.CipherContext
 }
 
 func (ctx *getconfigContext) getCachedResolvedIPs(hostname string) []types.CachedIP {

--- a/pkg/pillar/cmd/zedagent/parseconfig_test.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig_test.go
@@ -53,7 +53,6 @@ func initGetConfigCtx(g *GomegaWithT) *getconfigContext {
 		zedagentCtx: &zedagentContext{
 			physicalIoAdapterMap: make(map[string]types.PhysicalIOAdapter),
 		},
-		cipherContexts: make(map[string]types.CipherContext),
 	}
 	// cleanup between tests
 	deviceIoListPrevConfigHash = nil

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -591,7 +591,6 @@ func (zedagentCtx *zedagentContext) init() {
 		currentMetricInterval: zedagentCtx.globalConfig.GlobalValueInt(types.MetricInterval),
 		// edge-view configure
 		configEdgeview: &types.EdgeviewConfig{},
-		cipherContexts: make(map[string]types.CipherContext),
 	}
 	getconfigCtx.sideController.localServerMap = &localServerMap{}
 
@@ -1189,7 +1188,6 @@ func initPublications(zedagentCtx *zedagentContext) {
 		log.Fatal(err)
 	}
 	getconfigCtx.pubCipherContext.ClearRestarted()
-	populateCipherContexts(getconfigCtx)
 
 	// for ContentTree config Publisher
 	getconfigCtx.pubContentTreeConfig, err = ps.NewPublication(


### PR DESCRIPTION
Addressing the suggestion in
https://github.com/lf-edge/eve/pull/3765#pullrequestreview-1896883019