### PR TITLE
parseconfig: set old hash to new only when updated

### DIFF
--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -2410,15 +2410,16 @@ func parseConfigItems(ctx *getconfigContext, config *zconfig.EdgeDevConfig,
 	}
 	configHash := h.Sum(nil)
 	same := bytes.Equal(configHash, itemsPrevConfigHash)
-	itemsPrevConfigHash = configHash
 	if same {
 		return
 	}
+
 	log.Functionf("parseConfigItems: Applying updated config "+
 		"prevSha: % x, "+
 		"NewSha : % x, "+
 		"items: %v",
 		itemsPrevConfigHash, configHash, items)
+	itemsPrevConfigHash = configHash
 
 	// Start with the defaults so that we revert to default when no data
 	// 1) Use the specified Value if no Errors


### PR DESCRIPTION
This improvement mainly concerns the log
```golang
	log.Functionf("parseConfigItems: Applying updated config "+
		"prevSha: % x, "+
		"NewSha : % x, "+
		"items: %v",
		itemsPrevConfigHash, configHash, items)
```
- if `itemsPrevConfigHash` is set to `configHash` before the log, the values will always appear the same, although the log is only called when the values differ.