### PR TITLE
[9.4-stable] Backport PR #3778

### DIFF
--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -764,19 +764,11 @@ func SendOnIntf(workContext context.Context, ctx *ZedCloudContext, destURL strin
 				continue
 			}
 
-			if connState.OCSPResponse == nil ||
-				!stapledCheck(log, connState) {
-
-				if connState.OCSPResponse == nil {
-					// XXX remove debug check
-					log.Tracef("no OCSP response for %s\n",
-						reqUrl)
-				}
-				errStr := fmt.Sprintf("OCSP stapled check failed for %s",
-					reqUrl)
-
-				//XXX OSCP is not implemented in cloud side so
-				// commenting out it for now.
+			if ok, err := stapledCheck(log, connState); !ok {
+				errStr := fmt.Sprintf("OCSP stapled check failed for %s: %s",
+					reqUrl, err)
+				// XXX OSCP is not implemented in controller
+				// so commenting out it for now.
 				if false {
 					log.Errorln(errStr)
 					// Inform ledmanager about broken cloud connectivity

--- a/pkg/pillar/zedcloud/tls.go
+++ b/pkg/pillar/zedcloud/tls.go
@@ -308,38 +308,45 @@ func UpdateTLSProxyCerts(ctx *ZedCloudContext) bool {
 	return true
 }
 
-func stapledCheck(log *base.LogObject, connState *tls.ConnectionState) bool {
+func stapledCheck(log *base.LogObject, connState *tls.ConnectionState) (bool, error) {
+	if connState.OCSPResponse == nil {
+		return false, errors.New("no OCSP response")
+	}
 	if connState.VerifiedChains == nil {
-		log.Errorln("stapledCheck: No VerifiedChains")
-		return false
+		return false, errors.New("stapledCheck: No VerifiedChains")
+
 	}
 	if len(connState.VerifiedChains[0]) == 0 {
-		log.Errorln("stapledCheck: No VerifiedChains 2")
-		return false
+		return false, errors.New("stapledCheck: No VerifiedChains 2")
+
 	}
 
 	issuer := connState.VerifiedChains[0][1]
 	resp, err := ocsp.ParseResponse(connState.OCSPResponse, issuer)
 	if err != nil {
-		log.Errorln("stapledCheck: error parsing response: ", err)
-		return false
+		return false,
+			fmt.Errorf("stapledCheck: error parsing response: %s ",
+				err)
+
 	}
 	now := time.Now()
 	age := now.Unix() - resp.ProducedAt.Unix()
 	remain := resp.NextUpdate.Unix() - now.Unix()
 	log.Tracef("OCSP age %d, remain %d\n", age, remain)
 	if remain < 0 {
-		log.Errorln("OCSP expired.")
-		return false
+		return false, errors.New("OCSP expired.")
 	}
-	if resp.Status == ocsp.Good {
+	switch resp.Status {
+	case ocsp.Good:
 		log.Traceln("Certificate Status Good.")
-	} else if resp.Status == ocsp.Unknown {
-		log.Errorln("Certificate Status Unknown")
-	} else {
-		log.Errorln("Certificate Status Revoked")
+		return true, nil
+	case ocsp.Unknown:
+		return false, errors.New("Certificate Status Unknown")
+	case ocsp.Revoked:
+		return false, errors.New("Certificate Status Revoked")
+	default:
+		return false, fmt.Errorf("Unknown OCSP status %d", resp.Status)
 	}
-	return resp.Status == ocsp.Good
 }
 
 func updateEtcSSLforProxyCerts(ctx *ZedCloudContext, dns *types.DeviceNetworkStatus) {


### PR DESCRIPTION
From
git cherry-pick -x 000b3561baa41600d038b718bea8c1bf8d013467 82281522e6bf17762accbe4ba5288835e3850e7c

Note that the second commit ends up empty in 9.4 since the offending code and log message did not exist. But keeping this as an empty commit to make the history line up with 10.4-stable and 11.0-stable