### PR TITLE
grub/rootfs.cfg: set 'cmos-rtc-probe=1' for Xen on the "ProLiant m750 Server Blade"

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -194,7 +194,7 @@ function set_x86_64_baremetal {
    smbios -t 1 -s 0 --set smb_vendor
    if [ "$smb_vendor" = "HPE" ]; then
       smbios -t 1 -s 5 --set smb_product
-      if [ "$smb_product" = "ProLiant DL360 Gen10" ]; then
+      if [ "$smb_product" = "ProLiant DL360 Gen10" -o "$smb_product" = "ProLiant m750 Server Blade" ]; then
          set_global hv_platform_tweaks "$hv_platform_tweaks cmos-rtc-probe=1"
       fi
       # On m750 BAR registers are not correctly reassigned by Linux


### PR DESCRIPTION
If not set 'cmos-rtc-probe=1' for Xen on the "ProLiant m750 Server Blade" then Xen panics with the following message:

  System with no CMOS RTC advertised must be booted from EFI
  or with command line option "cmos-rtc-probe"