### PR TITLE
Reduce the amount of logs coming from networking microservices

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -185,27 +185,25 @@ func protoEncodeGenericInstanceMetric(status types.NetworkInstanceMetrics,
 	networkStats := new(zmet.ZMetricNetworkStats)
 	rxStats := new(zmet.NetworkStats)
 	txStats := new(zmet.NetworkStats)
-	netMetric := status.NetworkMetrics.MetricList[0]
-	rxStats.TotalPackets = netMetric.RxPkts
-	rxStats.TotalBytes = netMetric.RxBytes
-	rxStats.Errors = netMetric.RxErrors
-	// Add all types of Rx drops
-	var drops uint64 = 0
-	drops += netMetric.RxDrops
-	drops += netMetric.RxAclDrops
-	drops += netMetric.RxAclRateLimitDrops
-	rxStats.Drops = drops
-
-	txStats.TotalPackets = netMetric.TxPkts
-	txStats.TotalBytes = netMetric.TxBytes
-	txStats.Errors = netMetric.TxErrors
-	// Add all types of Tx drops
-	drops = 0
-	drops += netMetric.TxDrops
-	drops += netMetric.TxAclDrops
-	drops += netMetric.TxAclRateLimitDrops
-	txStats.Drops = drops
-
+	for _, netMetrics := range status.NetworkMetrics.MetricList {
+		// Tx/Rx of NI is equal to the total of Tx/Rx on all member
+		// virtual interfaces excluding the bridge itself.
+		if netMetrics.IfName != status.BridgeName {
+			rxStats.TotalBytes += netMetrics.RxBytes
+			rxStats.TotalPackets += netMetrics.RxPkts
+			txStats.TotalBytes += netMetrics.TxBytes
+			txStats.TotalPackets += netMetrics.TxPkts
+		}
+		// Drops and errors are collected both from VIFs and the bridge.
+		rxStats.Errors += netMetrics.RxErrors
+		rxStats.Drops += netMetrics.RxDrops
+		rxStats.Drops += netMetrics.RxAclDrops
+		rxStats.Drops += netMetrics.RxAclRateLimitDrops
+		txStats.Errors += netMetrics.TxErrors
+		txStats.Drops += netMetrics.TxDrops
+		txStats.Drops += netMetrics.TxAclDrops
+		txStats.Drops += netMetrics.TxAclRateLimitDrops
+	}
 	networkStats.Rx = rxStats
 	networkStats.Tx = txStats
 	metric.NetworkStats = networkStats

--- a/pkg/pillar/cmd/zedrouter/pubsubhandlers.go
+++ b/pkg/pillar/cmd/zedrouter/pubsubhandlers.go
@@ -163,7 +163,6 @@ func (z *zedrouter) handleNetworkInstanceCreate(ctxArg interface{}, key string,
 		NetworkInstanceConfig: config,
 		NetworkInstanceInfo: types.NetworkInstanceInfo{
 			IPAssignments: make(map[string]types.AssignedAddrs),
-			VifMetricMap:  make(map[string]types.NetworkMetric),
 			VlanMap:       make(map[uint32]uint32),
 		},
 	}

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -1200,7 +1200,6 @@ func (z *zedrouter) publishNetworkInstanceMetricsAll(nms *types.NetworkMetrics) 
 		if err != nil {
 			z.log.Errorf("publishNetworkInstanceMetricsAll failed: %v", err)
 		}
-		z.publishNetworkInstanceStatus(&status)
 	}
 }
 
@@ -1211,17 +1210,19 @@ func (z *zedrouter) createNetworkInstanceMetrics(status *types.NetworkInstanceSt
 		UUIDandVersion: status.UUIDandVersion,
 		DisplayName:    status.DisplayName,
 		Type:           status.Type,
+		BridgeName:     status.BridgeName,
 	}
 	netMetrics := types.NetworkMetrics{}
-	// Update status.VifMetricMap and get bridge metrics as a sum of all VIF metrics.
-	brNetMetric := status.UpdateNetworkMetrics(z.log, nms)
-	// Add metrics of the bridge interface itself into brNetMetric.
-	status.UpdateBridgeMetrics(z.log, nms, brNetMetric)
-
-	// XXX For some strange reason we do not include VIFs into the returned
-	// NetworkInstanceMetrics.
-	netMetrics.MetricList = []types.NetworkMetric{*brNetMetric}
+	if bridgeMetrics, found := nms.LookupNetworkMetrics(status.BridgeName); found {
+		netMetrics.MetricList = append(netMetrics.MetricList, bridgeMetrics)
+	}
+	for _, vif := range status.Vifs {
+		if vifMetrics, found := nms.LookupNetworkMetrics(vif.Name); found {
+			netMetrics.MetricList = append(netMetrics.MetricList, vifMetrics)
+		}
+	}
 	niMetrics.NetworkMetrics = netMetrics
+
 	if status.WithUplinkProbing() {
 		probeMetrics, err := z.uplinkProber.GetProbeMetrics(status.UUID)
 		if err == nil {

--- a/pkg/pillar/devicenetwork/dns.go
+++ b/pkg/pillar/devicenetwork/dns.go
@@ -181,9 +181,9 @@ func ResolveWithPortsLambda(domain string,
 				})
 			}
 		}
-		return responses, nil
+		return responses, errs
 	case ip := <-resolvedIPsChan:
 		close(quit)
-		return ip, errs
+		return ip, nil
 	}
 }

--- a/pkg/pillar/devicenetwork/dns_test.go
+++ b/pkg/pillar/devicenetwork/dns_test.go
@@ -4,6 +4,7 @@
 package devicenetwork_test
 
 import (
+	"errors"
 	"net"
 	"sync/atomic"
 	"testing"
@@ -198,5 +199,47 @@ func TestResolveWithPortsLambda(t *testing.T) {
 		t.Errorf(
 			"more calls to resolverFunc than dnsMaxParallelRequests+1, but first call should already succeed",
 		)
+	}
+}
+
+func TestResolveWithPortsLambdaWithErrors(t *testing.T) {
+	t.Parallel()
+
+	expectedIP := net.IP{1, 2, 3, 4}
+	resolverFunc := func(domain string, dnsServer net.IP, srcIP net.IP) ([]devicenetwork.DNSResponse, error) {
+		if srcIP.Equal(net.IP{192, 168, 0, 1}) && domain == "example.com" {
+			return []devicenetwork.DNSResponse{
+				{
+					IP:  expectedIP,
+					TTL: 3600,
+				},
+			}, nil
+		}
+		return nil, errors.New("resolver failed")
+	}
+
+	deviceNetworkStatus := createDeviceNetworkStatus()
+	res, err := devicenetwork.ResolveWithPortsLambda(
+		"example.com",
+		deviceNetworkStatus,
+		resolverFunc,
+	)
+	if err != nil {
+		t.Errorf("expected no error, but got: %+v", err)
+	}
+	if !res[0].IP.Equal(expectedIP) {
+		t.Errorf("expected IP 1.2.3.4, but got: %+v", res)
+	}
+
+	res, err = devicenetwork.ResolveWithPortsLambda(
+		"resolver-should-fail.com",
+		deviceNetworkStatus,
+		resolverFunc,
+	)
+	if err == nil {
+		t.Error("expected error, but got nil")
+	}
+	if len(res) > 0 {
+		t.Errorf("expected empty response, but got: %+v", res)
 	}
 }

--- a/pkg/pillar/dpcmanager/verify.go
+++ b/pkg/pillar/dpcmanager/verify.go
@@ -148,9 +148,8 @@ func (m *DpcManager) runVerify(ctx context.Context, reason string) {
 		}
 	}
 
-	// If there are port level errors in current selected DPC, we should mark
-	// it for re-test during the next TestBetterTimer invocation.
-	if m.dpcList.CurrentIndex != 0 || m.deviceNetStatus.HasErrors() {
+	// Try to get back to the latest and the highest priority DPC.
+	if m.dpcList.CurrentIndex != 0 {
 		m.Log.Warnf("DPC verify: Working with DPC configuration found "+
 			"at index %d in DPC list", m.dpcList.CurrentIndex)
 		if m.dpcTestBetterInterval != 0 {
@@ -185,7 +184,9 @@ func (m *DpcManager) runVerify(ctx context.Context, reason string) {
 	default:
 	}
 
-	// Restart network test timer
+	// Restart network test timer.
+	// Tests run by this timer can later detect lost/reestablished connectivity,
+	// or simply update/clear errors reported for ports.
 	m.dpcTestTimer = time.NewTimer(m.dpcTestInterval)
 }
 

--- a/pkg/pillar/iptables/iptables.go
+++ b/pkg/pillar/iptables/iptables.go
@@ -46,10 +46,8 @@ func IptableCmdOut(log *base.LogObject, args ...string) (string, error) {
 	args[1] = "5"
 	if log != nil {
 		log.Functionf("Calling command %s %v\n", iptablesCmd, args)
-		out, err = base.Exec(log, iptablesCmd, args...).CombinedOutput()
-	} else {
-		out, err = base.Exec(log, iptablesCmd, args...).Output()
 	}
+	out, err = base.Exec(log, iptablesCmd, args...).CombinedOutput()
 	if err != nil {
 		outStr := strings.TrimSpace(string(out))
 		outStr = strings.ReplaceAll(outStr, "\n", "; ")

--- a/pkg/pillar/netmonitor/linux.go
+++ b/pkg/pillar/netmonitor/linux.go
@@ -225,7 +225,10 @@ func (m *LinuxNetworkMonitor) GetInterfaceDNSInfo(ifIndex int) (info DNSInfo, er
 	ifName := attrs.IfName
 	resolvConf := devicenetwork.IfnameToResolvConf(ifName)
 	if resolvConf == "" {
-		m.Log.Warnf("No resolv.conf for %s", ifName)
+		// Interface without IP is expected to not have resolv.conf file.
+		// We should be therefore careful about the log level here to avoid
+		// many log messages.
+		m.Log.Functionf("No resolv.conf for %s", ifName)
 		return info, nil
 	}
 	info = m.parseDNSInfo(resolvConf)

--- a/pkg/pillar/nireconciler/linux_config.go
+++ b/pkg/pillar/nireconciler/linux_config.go
@@ -446,6 +446,19 @@ func (r *LinuxNIReconciler) getIntendedBlackholeCfg() dg.Graph {
 		Description: "Rule to ensure that packets marked with the drop action " +
 			"are indeed dropped and never sent out via downlink or uplink interfaces",
 	}, nil)
+	// Add NOOP "DROP-COUNTER" chain used in the place of the default DROP rule to merely
+	// count the to-be-dropped packets.
+	// The actual drop is performed by routing the matched packet towards the blackhole
+	// interface.
+	for _, table := range []string{"raw", "filter"} {
+		for _, forIPv6 := range []bool{false, true} {
+			intendedBlackholeCfg.PutItem(iptables.Chain{
+				ChainName: dropCounterChain,
+				Table:     table,
+				ForIPv6:   forIPv6,
+			}, nil)
+		}
+	}
 	return intendedBlackholeCfg
 }
 

--- a/pkg/pillar/nistate/linux.go
+++ b/pkg/pillar/nistate/linux.go
@@ -236,21 +236,8 @@ func (lc *LinuxCollector) GetNetworkMetrics() (types.NetworkMetrics, error) {
 			ipVer = 4
 		}
 
-		// DROP action is used in two case.
-		// 1. DROP rule for the packets exceeding rate-limiter.
-		// 2. Default DROP rule in the end.
-		// With flow-monitoring support, we cannot have the default DROP rule
-		// in the end of rule list. This is to avoid conntrack from deleting
-		// connections matching the default rule. Just before the default DROP
-		// rule, we add a LOG rule for logging packets that are being forwarded
-		// to dummy interface.
-		// Packets matching the default DROP rule also match the default LOG rule.
-		// Since we will not have the default DROP rule, we can copy statistics
-		// from default LOG rule as DROP statistics.
 		metric.TxAclDrops = lc.getIptablesACLDrop(ac, brIfName, vifName, ipVer, true)
-		metric.TxAclDrops += lc.getIptablesACLLog(ac, brIfName, vifName, ipVer, true)
 		metric.RxAclDrops = lc.getIptablesACLDrop(ac, brIfName, vifName, ipVer, false)
-		metric.RxAclDrops += lc.getIptablesACLLog(ac, brIfName, vifName, ipVer, false)
 		metric.TxAclRateLimitDrops = lc.getIptablesACLRateLimitDrop(
 			ac, brIfName, vifName, ipVer, true)
 		metric.RxAclRateLimitDrops = lc.getIptablesACLRateLimitDrop(

--- a/pkg/pillar/types/dns.go
+++ b/pkg/pillar/types/dns.go
@@ -160,11 +160,8 @@ func (status DeviceNetworkStatus) LogModify(logBase *base.LogObject, old interfa
 				AddField("old-last-succeeded", op.LastSucceeded).
 				AddField("old-last-failed", op.LastFailed)
 			if p.HasError() == op.HasError() &&
-				p.LastFailed == op.LastFailed &&
-				p.LastError == op.LastError &&
-				p.LastSucceeded.After(op.LastFailed) &&
-				op.LastSucceeded.After(op.LastFailed) {
-				// if we have success again, reduce log level
+				p.LastError == op.LastError {
+				// if we have success or the same error again, reduce log level
 				logData.Function("DeviceNetworkStatus port modify")
 			} else {
 				logData.Notice("DeviceNetworkStatus port modify")

--- a/pkg/pillar/types/dpc.go
+++ b/pkg/pillar/types/dpc.go
@@ -163,9 +163,9 @@ func (config DevicePortConfig) LogModify(logBase *base.LogObject, old interface{
 			config.LastSucceeded.After(oldConfig.LastFailed) &&
 			oldConfig.LastSucceeded.After(oldConfig.LastFailed) {
 			// if we have success again, reduce log level
-			logData.Function("DevicePortConfig port modify")
+			logData.Function("DevicePortConfig modify")
 		} else {
-			logData.Notice("DevicePortConfig port modify")
+			logData.Notice("DevicePortConfig modify")
 		}
 	}
 	// XXX which fields to compare/log?
@@ -187,11 +187,8 @@ func (config DevicePortConfig) LogModify(logBase *base.LogObject, old interface{
 				AddField("old-last-succeeded", op.LastSucceeded).
 				AddField("old-last-failed", op.LastFailed)
 			if p.HasError() == op.HasError() &&
-				p.LastFailed == op.LastFailed &&
-				p.LastError == op.LastError &&
-				p.LastSucceeded.After(op.LastFailed) &&
-				op.LastSucceeded.After(op.LastFailed) {
-				// if we have success again, reduce log level
+				p.LastError == op.LastError {
+				// if we have success or the same error again, reduce log level
 				logData.Function("DevicePortConfig port modify")
 			} else {
 				logData.Notice("DevicePortConfig port modify")

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -367,15 +367,6 @@ type NetworkInstanceInfo struct {
 	// Set of vifs on this bridge
 	Vifs []VifNameMac
 
-	// Vif metric map. This should have a union of currently existing
-	// vifs and previously deleted vifs.
-	// XXX When a vif is removed from bridge (app instance delete case),
-	// device might start reporting smaller statistic values. To avoid this
-	// from happening, we keep a list of all vifs that were ever connected
-	// to this bridge and their statistics.
-	// We add statistics from all vifs while reporting to cloud.
-	VifMetricMap map[string]NetworkMetric
-
 	// Maintain a map of all access vlan ids to their counts, used by apps
 	// connected to this network instance.
 	VlanMap map[uint32]uint32
@@ -454,6 +445,7 @@ type NetworkInstanceMetrics struct {
 	UUIDandVersion UUIDandVersion
 	DisplayName    string
 	Type           NetworkInstanceType
+	BridgeName     string
 	NetworkMetrics NetworkMetrics
 	ProbeMetrics   ProbeMetrics
 	VlanMetrics    VlanMetrics
@@ -864,62 +856,6 @@ func (status NetworkInstanceStatus) LogDelete(logBase *base.LogObject) {
 // LogKey :
 func (status NetworkInstanceStatus) LogKey() string {
 	return string(base.NetworkInstanceStatusLogType) + "-" + status.Key()
-}
-
-// UpdateNetworkMetrics : update collected network metrics.
-// Tx/Rx of bridge is equal to the total of Tx/Rx on all member
-// virtual interfaces excluding the bridge itself.
-// Drops/Errors/AclDrops of bridge is equal to total of Drops/Errors/AclDrops
-// on all member virtual interface including the bridge.
-func (status *NetworkInstanceStatus) UpdateNetworkMetrics(log *base.LogObject,
-	nms *NetworkMetrics) (brNetMetric *NetworkMetric) {
-
-	brNetMetric = &NetworkMetric{IfName: status.BridgeName}
-	status.VifMetricMap = make(map[string]NetworkMetric) // clear previous metrics
-	for _, vif := range status.Vifs {
-		metric, found := nms.LookupNetworkMetrics(vif.Name)
-		if !found {
-			log.Tracef("No metrics found for interface %s",
-				vif.Name)
-			continue
-		}
-		status.VifMetricMap[vif.Name] = metric
-	}
-	for _, metric := range status.VifMetricMap {
-		brNetMetric.TxBytes += metric.TxBytes
-		brNetMetric.RxBytes += metric.RxBytes
-		brNetMetric.TxPkts += metric.TxPkts
-		brNetMetric.RxPkts += metric.RxPkts
-		brNetMetric.TxErrors += metric.TxErrors
-		brNetMetric.RxErrors += metric.RxErrors
-		brNetMetric.TxDrops += metric.TxDrops
-		brNetMetric.RxDrops += metric.RxDrops
-		brNetMetric.TxAclDrops += metric.TxAclDrops
-		brNetMetric.RxAclDrops += metric.RxAclDrops
-		brNetMetric.TxAclRateLimitDrops += metric.TxAclRateLimitDrops
-		brNetMetric.RxAclRateLimitDrops += metric.RxAclRateLimitDrops
-	}
-	return brNetMetric
-}
-
-// UpdateBridgeMetrics records metrics of the bridge interface itself.
-func (status *NetworkInstanceStatus) UpdateBridgeMetrics(log *base.LogObject,
-	nms *NetworkMetrics, netMetric *NetworkMetric) {
-	// Get bridge metrics
-	bridgeMetric, found := nms.LookupNetworkMetrics(status.BridgeName)
-	if !found {
-		log.Tracef("No metrics found for Bridge %s",
-			status.BridgeName)
-	} else {
-		netMetric.TxErrors += bridgeMetric.TxErrors
-		netMetric.RxErrors += bridgeMetric.RxErrors
-		netMetric.TxDrops += bridgeMetric.TxDrops
-		netMetric.RxDrops += bridgeMetric.RxDrops
-		netMetric.TxAclDrops += bridgeMetric.TxAclDrops
-		netMetric.RxAclDrops += bridgeMetric.RxAclDrops
-		netMetric.TxAclRateLimitDrops += bridgeMetric.TxAclRateLimitDrops
-		netMetric.RxAclRateLimitDrops += bridgeMetric.RxAclRateLimitDrops
-	}
 }
 
 // IsIpAssigned returns true if the given IP address is assigned to any app VIF.


### PR DESCRIPTION
Multiple commits aimed to reduce frequent and yet useless log messages related to EVE networking:

**1.  Move NI metrics out of the NetworkInstanceStatus topic**

This commit completely removes VifMetricMap from NetworkInstanceStatus
to avoid frequent NI status changes, resulting in many Info logs.

The algorithm to collect metrics is also somewhat simplified.
Zedrouter simply collects metrics for all current VIFs and the bridge
interface itself. Then zedagent combines them together to get one set
of Rx/Tx/error/drop counters for the whole NI. No longer existing VIFs
(of deleted apps) are not included anymore. It is questionable if it is
desirable to have them accounted for. In any case, the implementation
based on VifMetricMap was not correct anyway. Newly deployed app can
recycle VIF names and overwrite metrics of deleted applications.
If we wish to include metrics of deleted VIFs, then the algorithm needs
to be more sophisticated and store metrics by VIF name AND app UUID.

**2. Fix redundant trigger of dpcTestBetterTimer**

No need to use dpcTestBetterTimer to just clear/update port errors for
the latest DPC. We have dpcTestTimer for that.

**3. Reduce log level if DNS port error did not change**

No need to log DNS port modification if only timestamps have been
updated but the error message remained the same.

**4. Remove iptables LOG rules**

iptables LOG rules have long been obsoleted by flow logging.
In order to reduce the log file size, it is therefore better to
completely remove them. For packet drop counting purposes, which
the LOG rules were also used for, we instead introduce a NOOP
DROP-COUNTER target chain.

**5. Decrease log level for missing resolv.conf file**

Missing resolv.conf file is expected in many situations so we
should not log it as warning or error.

**6. Reduce log level if DPC port error did not change**

No need to log DPC port modification if only timestamps have been
updated but the error message remained the same

**7. Fix error handling in ResolveWithPortsLambda**

If any DNS server for any port / src IP succeeds to resolve a given
hostname, ResolveWithPortsLambda should return no error
(regardless of how other attempts ended up).
This helps to avoid logging error when the resolution was in fact
successful.
On the other hand, if the function fails to resolve after trying
all the ports and DNS servers available, then it should return all
collected errors.