### PR TITLE
Make test on every commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -397,6 +397,11 @@ test: $(LINUXKIT) test-images-patches | $(DIST)
 	cp pkg/pillar/results.xml $(DIST)/
 	$(QUIET): $@: Succeeded
 
+test-commits:
+	@echo -n "Warning this is going to use git rebase underneath; press [ENTER] if you really want to continue or Ctrl-c to cancel ..."
+	@read a
+	GIT_SEQUENCE_EDITOR=/bin/true git rebase -i --exec 'make test' origin/master
+
 # wrap command into DOCKER_GO and propagate it to the pillar's Makefile
 # for example make pillar-fmt will run docker container based on
 # build-tools/src/scripts/Dockerfile


### PR DESCRIPTION
Run `make test` on every commit of a PR.

Advantages:
- Every commit (in pillar) builds and the tests succeed and this helps when bisecting
- More likely to find flaky tests

Disadvantages:
- It slows down building the PR (roughly 20 minutes with average amount of commits)
- Perhaps it is too strict and scares people away from doing a PR or slows them down
- It punishes splitting a PR in more commits