### PR TITLE
Draft:pkg/pillar: kvm does not call KvmContext:Delete

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -2320,6 +2320,11 @@ func handleDelete(ctx *domainContext, key string, status *types.DomainStatus) {
 	// No point in publishing metrics any more
 	ctx.pubDomainMetric.Unpublish(status.Key())
 
+	err := hyper.Task(status).Delete(status.DomainName)
+	if err != nil {
+		log.Errorln(err)
+	}
+
 	log.Functionf("handleDelete(%v) DONE for %s",
 		status.UUIDandVersion, status.DisplayName)
 }

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -941,9 +941,12 @@ func (ctx KvmContext) Stop(domainName string, _ bool) error {
 // Delete deletes a domain
 func (ctx KvmContext) Delete(domainName string) (result error) {
 	//Sending a stop signal to then domain before quitting. This is done to freeze the domain before quitting it.
-	execStop(GetQmpExecutorSocket(domainName))
-	if err := execQuit(GetQmpExecutorSocket(domainName)); err != nil {
-		return logError("failed to execute quit command %v", err)
+	_, err := os.Stat(GetQmpExecutorSocket(domainName))
+	if err == nil {
+		execStop(GetQmpExecutorSocket(domainName))
+		if err = execQuit(GetQmpExecutorSocket(domainName)); err != nil {
+			return logError("failed to execute quit command %v", err)
+		}
 	}
 	// we may want to wait a little bit here and actually kill qemu process if it gets wedged
 	if err := os.RemoveAll(kvmStateDir + domainName); err != nil {

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -486,9 +486,15 @@ func (ctx xenContext) Delete(domainName string) (result error) {
 		}
 	}()
 
-	logrus.Infof("xlDestroy %s\n", domainName)
+	logrus.Infof("xl destroy %s\n", domainName)
 	ctrdSystemCtx, done := ctx.ctrdClient.CtrNewSystemServicesCtx()
 	defer done()
+
+	container, _ := ctx.ctrdClient.CtrLoadContainer(ctrdSystemCtx, domainName)
+	if container == nil {
+		logrus.Infof("xl destroy %s assume previously deleted", domainName)
+		return nil
+	}
 	stdOut, stdErr, err := ctx.ctrdClient.CtrSystemExec(ctrdSystemCtx, "xen-tools",
 		[]string{"xl", "destroy", domainName})
 	if err != nil {


### PR DESCRIPTION
The handleDelete function in domainmgr does not call the Delete function of the underlying hypervisor struct.  The result is that the status directory (/run/hypervisor/kvm/<domainName>) is not removed.

Adding the function then fails as the socket qmp has been deleted. Added check in KvmContext:Delete to only try to remove this qemu control socket if it exists.