### PR TITLE
Kernel update - [amd64-generic, amd64-generic, amd64-rt, amd64-generi…

### DIFF
--- a/kernel-commits.mk
+++ b/kernel-commits.mk
@@ -1,7 +1,8 @@
-KERNEL_COMMIT_amd64_v5.10.186_generic = be89a9e63306
-KERNEL_COMMIT_amd64_v6.1.38_generic = d586ca2d3f2e
-KERNEL_COMMIT_amd64_v6.1.38_rt = 49dba60a59d9
-KERNEL_COMMIT_arm64_v5.10.104_nvidia = c21d5a4dd498
-KERNEL_COMMIT_arm64_v5.10.186_generic = 6a861e0433a6
-KERNEL_COMMIT_arm64_v6.1.38_generic = 92466d23a9bf
-KERNEL_COMMIT_riscv64_v6.1.38_generic = ad6a4589904a
+KERNEL_COMMIT_amd64_v5.10.186_generic = 37256d6aff33
+KERNEL_COMMIT_amd64_v6.1.38_generic = ae347d3a26ec
+KERNEL_COMMIT_amd64_v6.1.38_rt = fecb28161e3e
+KERNEL_COMMIT_amd64_v6.1.68_generic = b4d7ad0a73b1
+KERNEL_COMMIT_arm64_v5.10.104_nvidia = 11760a953d2d
+KERNEL_COMMIT_arm64_v5.10.186_generic = 594f2361a83f
+KERNEL_COMMIT_arm64_v6.1.38_generic = ec65bbcdb13b
+KERNEL_COMMIT_riscv64_v6.1.38_generic = 72192e3cbc74


### PR DESCRIPTION
…c, arm64-nvidia, arm64-generic, arm64-generic, riscv64-generic]

eve-kernel-amd64-v5.10.186-generic
    37256d6aff33: Make sure we have correct buildx builder
    267ad2db3562: Use buildkit's builtin mechanism to generate SBOM
    91fd3293dbe8: Remove SBOM generation by external tools
    4d7866684f79: Update to OpenZFS 2.2.2

eve-kernel-amd64-v6.1.38-generic
    ae347d3a26ec: Make sure we have correct buildx builder
    885b542a6cfb: Use buildkit's builtin mechanism to generate SBOM
    f997da2bb1a2: Remove SBOM generation by external tools
    820be3b1c356: Update to OpenZFS 2.2.2

eve-kernel-amd64-v6.1.38-rt
    fecb28161e3e: Make sure we have correct buildx builder
    6f814ad1e9b4: Use buildkit's builtin mechanism to generate SBOM
    48196eb559de: Remove SBOM generation by external tools
    7148ced52fc1: Update to OpenZFS 2.2.2

eve-kernel-amd64-v6.1.68-generic
    Unable to fetch commit subjects

eve-kernel-arm64-v5.10.104-nvidia
    11760a953d2d: Make sure we have correct buildx builder
    32a8475cee9f: Use buildkit's builtin mechanism to generate SBOM
    52e748f6400f: Remove SBOM generation by external tools
    ab0df9cfc431: Update to OpenZFS 2.2.2

eve-kernel-arm64-v5.10.186-generic
    594f2361a83f: Make sure we have correct buildx builder
    8f0a984e3398: Use buildkit's builtin mechanism to generate SBOM
    ded865c6a821: Remove SBOM generation by external tools
    438959506e33: Update to OpenZFS 2.2.2

eve-kernel-arm64-v6.1.38-generic
    ec65bbcdb13b: Make sure we have correct buildx builder
    a698f0eb0f37: Use buildkit's builtin mechanism to generate SBOM
    f6e03d06eb00: Remove SBOM generation by external tools
    50c6e530bbd2: Update to OpenZFS 2.2.2

eve-kernel-riscv64-v6.1.38-generic
    72192e3cbc74: Make sure we have correct buildx builder
    6cac8e9774b9: Use buildkit's builtin mechanism to generate SBOM
    0c299e6e7e87: Remove SBOM generation by external tools