### PR TITLE
yetus: Install dependencies inside Yetus container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -412,13 +412,7 @@ clean:
 yetus:
 	@echo Running yetus
 	mkdir -p yetus-output
-	docker run --rm -v $(CURDIR):/src:delegated,z ghcr.io/apache/yetus:0.15.0 \
-		--basedir=/src \
-		--test-parallel=true \
-		--dirty-workspace \
-		--empty-patch \
-		--plugins=all \
-		--patch-dir=/src/yetus-output
+	docker run --rm -v $(CURDIR):/src:delegated,z ghcr.io/apache/yetus:0.15.0 /src/tools/run-yetus.sh
 
 build-tools: $(LINUXKIT)
 	@echo Done building $<

--- a/tools/run-yetus.sh
+++ b/tools/run-yetus.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+ZFS_BRANCH=zfs-2.2.2
+
+# Build and install libzfs
+libzfs() {
+    [ -d /zfs ] && return
+    apt -y install uuid-dev libblkid-dev libssl-dev
+    git clone https://github.com/openzfs/zfs.git -b ${ZFS_BRANCH} /zfs
+    cd /zfs || return
+    ./autogen.sh && \
+    ./configure \
+        --prefix=/usr \
+        --with-tirpc \
+        --sysconfdir=/etc \
+        --mandir=/usr/share/man \
+        --infodir=/usr/share/info \
+        --localstatedir=/var \
+        --with-config=user \
+        --with-udevdir=/lib/udev \
+        --disable-systemd \
+        --disable-static && \
+    ./scripts/make_gitrev.sh && \
+    make -j "$(getconf _NPROCESSORS_ONLN)" && \
+    make -j "$(getconf _NPROCESSORS_ONLN)" install
+}
+
+# Install dependencies
+apt -y update
+libzfs
+
+# Run test-patch
+test-patch \
+    --basedir=/src \
+    --test-parallel=true \
+    --dirty-workspace \
+    --empty-patch \
+    --plugins=all \
+    --patch-dir=/src/yetus-output


### PR DESCRIPTION
go-libzfs module depends on libzfs to be built. However, the package libzfslinux-dev is not available inside the Yetus container, leading to the following error:

cmd/zfsmanager/handlediskconfig.go:12:9: could not import github.com/bicomsystems/go-libzfs

This commit introduces the script tools/run-yetus.sh that allows to install and manage all dependencies inside the container before start to execute all the tests.