### PR TITLE
yetus: Remove blank space at the end of line

### DIFF
--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -45,7 +45,7 @@ onboot:
     command: ["/opt/zededa/bin/onboot.sh"]
   - name: apparmor
     image: APPARMOR_TAG
-  # measure-config must be executed after any other container that changes 
+  # measure-config must be executed after any other container that changes
   # /config. Let's keep it the latest
   - name: measure-config
     image: MEASURE_CONFIG_TAG


### PR DESCRIPTION
Remove blank space at the end of the line from images/rootfs.yml.in and make blanks plugin pass 100% successfully in Yetus.