### PR TITLE
pkg/pillar: switch to fscrypt v0.3.4 and v2 policies

### DIFF
--- a/pkg/pillar/Dockerfile
+++ b/pkg/pillar/Dockerfile
@@ -111,7 +111,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build if [ ${DEV} = "y" ]; then \
     cp dlv /final/opt/ ; \
 fi
 
-FROM lfedge/eve-fscrypt:0b7cc0d9d620e47fc54e21d56cb8a5cd224f9c9b as fscrypt
+FROM lfedge/eve-fscrypt:e8507303431c8c11ec1a2b3b7fb02e1a0dcdf296 as fscrypt
 FROM lfedge/eve-dnsmasq:3af908d86a95a627c729e09b1b125bf8de7fadcb as dnsmasq
 FROM lfedge/eve-gpt-tools:51ecda7bc185c655c1d0423228dc83e29d4c674d as gpttools
 

--- a/pkg/pillar/rootfs/fscrypt.conf
+++ b/pkg/pillar/rootfs/fscrypt.conf
@@ -9,6 +9,8 @@
 	"options": {
 		"padding": "32",
 		"contents": "AES_256_XTS",
-		"filenames": "AES_256_CTS"
-	}
+		"filenames": "AES_256_CTS",
+		"policy_version": "2"
+	},
+	"use_fs_keyring_for_v1_policies": true
 }


### PR DESCRIPTION
This patch switches fscrypt to the newest v0.3.4 version, which supports v2 policies. Should be merged after this one PR #3791 merged. Since our Makefile does not have dependencies, `make pkgs` fails to build fscrypt and pillar updates in one go, because pillar depends on the fscrypt and should be built afterwards. 

The main benefit of v2 policies for EVE is possibility to use fs keyring (keys set per inode), instead of per process kernel API keyring.

New fscrypt.conf will be applied with the following 2 options:

1. "policy_version: 2"  -- "is the version of encryption policy
   to use. The choices are "1" and "2". If unset, "1" is assumed.
   Directories created with policy version "2" are only usable on
   kernel v5.4 or later, but are preferable to version "1" if you
   don't mind this restriction."[1]

2. "use_fs_keyring_for_v1_policies: true" -- "specifies whether to
   add keys for v1 encryption policies to the filesystem keyrings,
   rather than to user keyrings. This can solve issues with processes
   being unable to access unlocked encrypted files. However, it requires
   kernel v5.4 or later, and it makes unlocking and locking encrypted
   directories require root. (The PAM module will still work.)

   The purpose of this setting is to allow people to take advantage
   of some of the improvements in Linux v5.4 on encrypted directories
   that are also compatible with older kernels. If you don't need
   compatibility with older kernels, it's better to not use this
   setting and instead (re-)create your encrypted directories with
   "policy_version": "2".

[1] https://github.com/google/fscrypt?tab=readme-ov-file#configuration-file

In simple words means that on newly freshed installed EVE nodes v2 policies will be used, in case of upgrade - v1 policy metadata won't be changed, but fs keyring will be applied anyway (all EVE kernels have the v2 policies feature).
