### PR TITLE
test: run fuzzing tests from correct directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -393,7 +393,7 @@ currentversion:
 test: $(LINUXKIT) test-images-patches | $(DIST)
 	@echo Running tests on $(GOMODULE)
 	$(QUIET)$(DOCKER_GO) "gotestsum --jsonfile $(DOCKER_DIST)/results.json --junitfile $(DOCKER_DIST)/results.xml --raw-command -- go test -coverprofile=coverage.txt -covermode=atomic -race -json ./..." $(GOTREE) $(GOMODULE)
-	$(QUIET)$(DOCKER_GO) "cd \"$(GOTREE)\"; ../../tools/fuzz_test.sh" $(GOTREE) $(GOMODULE)
+	$(QUIET)$(DOCKER_GO) "cd /eve/pkg/pillar; ../../tools/fuzz_test.sh" $(GOTREE) $(GOMODULE)
 	$(QUIET): $@: Succeeded
 
 # wrap command into DOCKER_GO and propagate it to the pillar's Makefile


### PR DESCRIPTION
DOCKER_GO (Makefile) is exporting the following directory: -v $${HOME}:/home/$(USER):z

in my case /home/christoph is mounted to /home/christoph and everything is good, but in other cases it might be not be the same

This makes running the fuzz tests fail. Therefore
use /eve directory instead.