### PR TITLE
pkg/pillar: introduce syslog and kernel loglevels

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -31,8 +31,10 @@
 | debug.enable.vga | boolean | false | allow VGA console on device |
 | debug.enable.ssh | authorized ssh key | empty string(ssh disabled) | allow ssh to EVE |
 | debug.enable.console | boolean | false | allow console access to EVE (reboot required to disable) |
-| debug.default.loglevel | string | info | min level saved in files on device |
-| debug.default.remote.loglevel | string | warning | min level sent to controller |
+| debug.default.loglevel | string | info | min level saved in files on device. Used logrus log levels as described here ["https://pkg.go.dev/github.com/sirupsen/logrus"]: panic, fatal, error, warning, info, debug and trace.
+| debug.syslog.loglevel | string | info | min level of the syslog messages saved in files on device. System default loglevel string representation should be used as described here ["https://man7.org/linux/man-pages/man3/syslog.3.html"]: emerg, alert, crit, err, warning, notice, info, debug. |
+| debug.kernel.loglevel | string | info | min level of the kernel messages saved in files on device. System default loglevel string representation should be used as described here ["https://man7.org/linux/man-pages/man3/syslog.3.html"]: emerg, alert, crit, err, warning, notice, info, debug. |
+| debug.default.remote.loglevel | string | warning | min level sent to controller. Should be used log levels as described in "debug.syslog.loglevel" settings. |
 | storage.dom0.disk.minusage.percent | integer percent | 20 | min. percent of persist partition reserved for dom0 |
 | storage.zfs.reserved.percent | integer percent | 20 | min. percent of persist partition reserved for zfs performance |
 | storage.apps.ignore.disk.check | boolean | false | Ignore disk usage check for Apps. Allows apps to create images bigger than available disk|

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -872,12 +872,12 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 
 	// Add String Items
 	configItemSpecMap.AddStringItem(SSHAuthorizedKeys, "", blankValidator)
-	configItemSpecMap.AddStringItem(DefaultLogLevel, "info", parseLevel)
-	configItemSpecMap.AddStringItem(DefaultRemoteLogLevel, "info", parseLevel)
+	configItemSpecMap.AddStringItem(DefaultLogLevel, "info", validateLogrusLevel)
+	configItemSpecMap.AddStringItem(DefaultRemoteLogLevel, "info", validateLogrusLevel)
 
 	// Add Agent Settings
-	configItemSpecMap.AddAgentSettingStringItem(LogLevel, "info", parseLevel)
-	configItemSpecMap.AddAgentSettingStringItem(RemoteLogLevel, "info", parseLevel)
+	configItemSpecMap.AddAgentSettingStringItem(LogLevel, "info", validateLogrusLevel)
+	configItemSpecMap.AddAgentSettingStringItem(RemoteLogLevel, "info", validateLogrusLevel)
 
 	// Add NetDump settings
 	configItemSpecMap.AddBoolItem(NetDumpEnable, true)
@@ -890,8 +890,8 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	return configItemSpecMap
 }
 
-// parseLevel - Wrapper that ignores the 'Level' output of the logrus.ParseLevel function
-func parseLevel(level string) error {
+// validateLogrusLevel - Wrapper for validating logrus loglevel
+func validateLogrusLevel(level string) error {
 	_, err := logrus.ParseLevel(level)
 	return err
 }

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -256,6 +256,10 @@ const (
 	DefaultLogLevel GlobalSettingKey = "debug.default.loglevel"
 	// DefaultRemoteLogLevel global setting key
 	DefaultRemoteLogLevel GlobalSettingKey = "debug.default.remote.loglevel"
+	// SyslogLogLevel global setting key
+	SyslogLogLevel GlobalSettingKey = "debug.syslog.loglevel"
+	// KernelLogLevel global setting key
+	KernelLogLevel GlobalSettingKey = "debug.kernel.loglevel"
 
 	// XXX Temporary flag to disable RFC 3442 classless static route usage
 	DisableDHCPAllOnesNetMask GlobalSettingKey = "debug.disable.dhcp.all-ones.netmask"
@@ -323,6 +327,31 @@ const (
 	ConfigItemTypeString
 	// ConfigItemTypeTriState - for config item's who's value is a tristate
 	ConfigItemTypeTriState
+)
+
+var (
+	// SyslogKernelLogLevelStr is a string representation of syslog/kernel
+	// loglevels.
+	SyslogKernelLogLevelStr = [8]string{
+		"emerg", "alert", "crit", "err", "warning", "notice", "info", "debug",
+	}
+	// SyslogKernelLogLevelNum is a number representation of syslog/kernel
+	// loglevels.
+	SyslogKernelLogLevelNum = map[string]uint32{
+		"emerg":    0,
+		"alert":    1,
+		"crit":     2,
+		"critical": 2,
+		"err":      3,
+		"error":    3,
+		"warning":  4,
+		"warn":     4,
+		"notice":   5,
+		"info":     6,
+		"debug":    7,
+	}
+	// SyslogKernelDefaultLogLevel is a default loglevel for syslog and kernel.
+	SyslogKernelDefaultLogLevel = "info"
 )
 
 // ConfigItemSpec - Defines what a specification for a configuration should be
@@ -874,6 +903,8 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddStringItem(SSHAuthorizedKeys, "", blankValidator)
 	configItemSpecMap.AddStringItem(DefaultLogLevel, "info", validateLogrusLevel)
 	configItemSpecMap.AddStringItem(DefaultRemoteLogLevel, "info", validateLogrusLevel)
+	configItemSpecMap.AddStringItem(SyslogLogLevel, "info", validateSyslogKernelLevel)
+	configItemSpecMap.AddStringItem(KernelLogLevel, "info", validateSyslogKernelLevel)
 
 	// Add Agent Settings
 	configItemSpecMap.AddAgentSettingStringItem(LogLevel, "info", validateLogrusLevel)
@@ -894,6 +925,16 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 func validateLogrusLevel(level string) error {
 	_, err := logrus.ParseLevel(level)
 	return err
+}
+
+// validateSyslogKernelLevel - Wrapper for validating syslog and kernel
+// loglevels.
+func validateSyslogKernelLevel(level string) error {
+	_, ok := SyslogKernelLogLevelNum[level]
+	if !ok {
+		return fmt.Errorf("validateSyslogKernelLevel: unknown loglevel '%v'", level)
+	}
+	return nil
 }
 
 // blankValidator - A validator that accepts any string

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -124,7 +124,7 @@ func TestAddStringItem(t *testing.T) {
 	}
 	for testname, test := range testMatrix {
 		t.Logf("Running test case %s", testname)
-		(&specMap).AddStringItem(test.key, test.defaultString, parseLevel)
+		(&specMap).AddStringItem(test.key, test.defaultString, validateLogrusLevel)
 		assert.Equal(t, test.expectedVal, specMap.GlobalSettings[test.key].StringDefault)
 	}
 }

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -196,6 +196,8 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		SSHAuthorizedKeys,
 		DefaultLogLevel,
 		DefaultRemoteLogLevel,
+		SyslogLogLevel,
+		KernelLogLevel,
 		DisableDHCPAllOnesNetMask,
 		ProcessCloudInitMultiPart,
 		NetDumpEnable,


### PR DESCRIPTION
This PR introduces syslog and kernel log levels configuration parameters, which is defined in pkg/pillar. In the following PR the pkg/newlog will use new log levels pillar definitions. PR should be split in order to have correct build dependencies. Patches are the following:

1.  pkg/pillar: rename 'parseLevel' to 'parseLogrusLevel'
    
    Rename 'parseLevel' to 'parseLogrusLevel' emphasising that logging levels
    should be used as described in logrus library.
    
    In the next patch another parsing function will be introduced, which will
    have syslog/kernel log levels, that's why separation. Stay tuned.

2.  pkg/pillar: introduce 'debug.syslog.loglevel' and 'debug.kernel.loglevel'
    
    Introduce two configuration parameters:
    
       debug.syslog.loglevel - controls log level of the /dev/log, which is used
                               system-wide for system user-space tools and daemons.
    
       debug.kernel.loglevel - controls log level of the /dev/kmsg, log messages
                               added by kernel.
    
    Both settings use the log levels described in
    https://man7.org/linux/man-pages/man3/syslog.3.html, e.g.
    
       emerg, alert, crit, err, warning, notice, info, debug
       (sorted by reduced severity)
    
    The logrus log levels are also supported for the sake of compatibility.

3.  docs/CONFIG-PROPERTIES.md: describe 'debug.syslog.loglevel' and 'debug.kernel.loglevel'
    
    A few lines of syslog and kernel log level description.

4. pkg/pillar: add syslog/kernel settings to the global_test
    
    Just a test extension.
