### PR TITLE
build-tools: dep is no longer used so remove

### DIFF
--- a/build-tools/src/scripts/Dockerfile
+++ b/build-tools/src/scripts/Dockerfile
@@ -17,9 +17,6 @@ RUN deluser ${USER} ; delgroup ${GROUP} || :
 RUN sed -ie /:${UID}:/d /etc/passwd /etc/shadow ; sed -ie /:${GID}:/d /etc/group || :
 RUN addgroup -g ${GID} ${GROUP} && adduser -h /home/${USER} -G ${GROUP} -D -H -u ${UID} ${USER}
 RUN echo "${USER} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/${USER}
-# dep is deprecated and probably should be gotten rid of; no need to parametrize the version, as there will be no further releases
-# hadolint ignore=SC2086,DL4006
-RUN OS="$(uname -o | tr '[:upper:]' '[:lower:]')" && PLATFORM="$(go version | sed 's#^.*'${OS}'/##g')" && curl -o /usr/local/bin/dep -L "https://github.com/golang/dep/releases/download/v0.5.4/dep-${OS}-${PLATFORM}" && chmod +x /usr/local/bin/dep
 ### Build OpenZFS 2.2.2 libs here for 'make test' and full eve build in one spot
 # should be aligned with kernel
 #  * ZFS on Linux


### PR DESCRIPTION
I saw the build hang waiting for this, but it isn't needed any more.