### PR TITLE
[11.0-stable] GitHub Actions: Specify eden test workflow version

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -59,7 +59,7 @@ jobs:
         arch: [amd64]
         hv: [kvm]
     if: github.event.review.state == 'approved'
-    uses: lf-edge/eden/.github/workflows/test.yml
+    uses: lf-edge/eden/.github/workflows/test.yml@0.9.3-stable
     with:
       eve_image: "evebuild/pr:${{ github.event.pull_request.number  }}"
       eve_artifact_name: eve-${{ matrix.hv }}-${{ matrix.arch }}
@@ -68,14 +68,14 @@ jobs:
 
   test_suite_master:
     if: github.ref == 'refs/heads/master'
-    uses: lf-edge/eden/.github/workflows/test.yml
+    uses: lf-edge/eden/.github/workflows/test.yml@0.9.3-stable
     with:
       eve_image: "lfedge/eve:snapshot"
       eden_version: "0.9.3-stable"
 
   test_suite_tag:
     if: startsWith(github.ref, 'refs/tags')
-    uses: lf-edge/eden/.github/workflows/test.yml
+    uses: lf-edge/eden/.github/workflows/test.yml@0.9.3-stable
     with:
       eve_image: "lfedge/eve:${{ github.ref_name }}"
       eden_version: "0.9.3-stable"


### PR DESCRIPTION
This should fix Eden workflow which I previously broke in #3796 

Now eden test should show up here 