### PR TITLE
Take baseos activation status from zboot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 build-tools/bin/
 images/out/
 .go/
+go.work*
 tags
 tmp/
 mkdocs.yml


### PR DESCRIPTION
It is safer to get the activation status of the baseOS from zboot instead of the pubsub, since pubsub only gets populated after a config is read. This information is needed to determine whether the app-related part of the config should be inhaled. In particular consider the following scenario:
- a new config arrives from the controller and has a baseos.Activate field set to true, however this baseos version is already activated
- EVE checks whether it's a known baseos and since pubsub is empty after a reboot - EVE decides that it is
- EVE skips inhaling the config, because it thinks it should activate a new baseos, however the activation is already done - so nothing happens

This PR is supposed to help mitigate such a scenario.