### PR TITLE
pillar: Add configuration for depguard linter

### DIFF
--- a/pkg/pillar/.golangci.yml
+++ b/pkg/pillar/.golangci.yml
@@ -2,6 +2,14 @@
 run:
   deadline: 30m
 
+linters-settings:
+  depguard:
+    rules:
+      main:
+        list-mode: lax  # allow unless explicitly denied
+        files:
+          - $all
+
 linters:
   enable-all: true
   disable:


### PR DESCRIPTION
golangcilint is throwing the following error for all GO imported packages:

`import '<go package>' is not allowed from list 'Main' (depguard)`

depguard is the linter which checks if package imports are in a list of acceptable packages. Since there is no configuration provided, all imported packages will be denied by depguard, throwing the error above.

This commit adds a standard configuration for depguard setting 'list-mode' to 'lax', which will allow any package import, unless the package is explicitly denied.