### PR TITLE
Set cpuset cgroups for memlogd

### DIFF
--- a/pkg/dom0-ztools/rootfs/etc/init.d/002-logging
+++ b/pkg/dom0-ztools/rootfs/etc/init.d/002-logging
@@ -5,6 +5,13 @@ if test -f /proc/vmcore; then
     exit 0;
 fi
 
-#Starting memlogd as part as part of a cgroup
-mkdir -p /sys/fs/cgroup/memory/eve/memlogd
-sh -c 'echo $$ > /sys/fs/cgroup/memory/eve/memlogd/tasks && /usr/bin/memlogd -daemonize -max-line-len 8192'
+# Create 'memory' controller for the 'memlogd' making it part
+# of the eve/services
+mkdir -p /sys/fs/cgroup/memory/eve/services/memlogd
+
+# Add 'memlogd' to the 'memory' controller. Further 'memlogd'
+# cgroup changes happen in the 010-eve-cgroup, see all the
+# details there.
+echo $$ > /sys/fs/cgroup/memory/eve/services/memlogd/tasks
+
+/usr/bin/memlogd -daemonize -max-line-len 8192

--- a/pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup
+++ b/pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup
@@ -8,16 +8,15 @@ fi
 hv=`cat /run/eve-hv-type`
 default_cgroup_cpus_limit=1
 
+default_cgroup_memory_limit=838860800 #800M
+EVESERVICES="sshd edgeview wwan wlan lisp guacd pillar vtpm watchdog xen-tools newlogd"
+
 #Increase memory limits temporarily for kubevirt type only.
 case $hv in
    kubevirt)
-            default_cgroup_memory_limit=8388608000 #8G
-            EVESERVICES="sshd edgeview wwan wlan lisp guacd pillar vtpm watchdog xen-tools newlogd kube "
-            ;;
-          *)
-            default_cgroup_memory_limit=838860800 #800M
-            EVESERVICES="sshd edgeview wwan wlan lisp guacd pillar vtpm watchdog xen-tools newlogd "
-            ;;
+       default_cgroup_memory_limit=8388608000 #8G
+       EVESERVICES="${EVESERVICES} kube"
+       ;;
 esac
 
 dom0_cgroup_memory_soft_limit=$(</proc/cmdline grep -o '\bdom0_mem=[^, ]*' | cut -d = -f 2)

--- a/pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup
+++ b/pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup
@@ -9,7 +9,7 @@ hv=`cat /run/eve-hv-type`
 default_cgroup_cpus_limit=1
 
 default_cgroup_memory_limit=838860800 #800M
-EVESERVICES="sshd edgeview wwan wlan lisp guacd pillar vtpm watchdog xen-tools newlogd"
+EVESERVICES="sshd edgeview wwan wlan lisp guacd pillar vtpm watchdog xen-tools newlogd memlogd"
 
 #Increase memory limits temporarily for kubevirt type only.
 case $hv in
@@ -93,11 +93,6 @@ done
 #Creating cgroup for containerd
 mkdir -p /sys/fs/cgroup/memory/eve/containerd
 
-#Creating cgroup for memlogd
-for cg in $CGROUPS; do
-    mkdir -p /sys/fs/cgroup/"${cg}"/eve/memlogd
-done
-
 existingCPULimit=$(</sys/fs/cgroup/cpuset/cpuset.cpus grep -o '0-[1-9]*' | cut -d '-' -f 2)
 if [ -z "${existingCPULimit}" ]; then
     existingCPULimit=$(cat /sys/fs/cgroup/cpuset/cpuset.cpus)
@@ -108,6 +103,7 @@ fi
 #Value that we are trying to update should not be greater than the existing value in cgroup system.
 if [ -n "${existingCPULimit}" ] && [ "$existingCPULimit" -ge "$dom0_cgroup_cpus_limit" ]; then
     /bin/echo "0-$((dom0_cgroup_cpus_limit-1))" > /sys/fs/cgroup/cpuset/eve/cpuset.cpus
+    /bin/echo "0-$((dom0_cgroup_cpus_limit-1))" > /sys/fs/cgroup/cpuset/eve/cpuset.mems
 fi
 
 /bin/echo $ctrd_cgroup_memory_limit > /sys/fs/cgroup/memory/eve/containerd/memory.limit_in_bytes
@@ -117,6 +113,7 @@ fi
 /bin/echo $eve_cgroup_memory_soft_limit > /sys/fs/cgroup/memory/eve/services/memory.soft_limit_in_bytes
 if [ -n "${existingCPULimit}" ] && [ "$existingCPULimit" -ge "$eve_cgroup_cpus_limit" ]; then
     /bin/echo "0-$((eve_cgroup_cpus_limit-1))" > /sys/fs/cgroup/cpuset/eve/services/cpuset.cpus
+    /bin/echo "0-$((eve_cgroup_cpus_limit-1))" > /sys/fs/cgroup/cpuset/eve/services/cpuset.mems
 fi
 
 for srv in $EVESERVICES; do
@@ -124,5 +121,12 @@ for srv in $EVESERVICES; do
     /bin/echo $eve_cgroup_memory_soft_limit > /sys/fs/cgroup/memory/eve/services/"${srv}"/memory.soft_limit_in_bytes
     if [ -n "${existingCPULimit}" ] && [ "$existingCPULimit" -ge "$eve_cgroup_cpus_limit" ]; then
         /bin/echo "0-$((eve_cgroup_cpus_limit-1))" > /sys/fs/cgroup/cpuset/eve/services/"${srv}"/cpuset.cpus
+        /bin/echo "0-$((eve_cgroup_cpus_limit-1))" > /sys/fs/cgroup/cpuset/eve/services/"${srv}"/cpuset.mems
     fi
+done
+
+# Once all 'cpuset.cpus' and 'cpuset.mems' are prepared copy memlogd
+# tasks from 'memory' controller to the 'cpuset' controller.
+for pid in $(cat /sys/fs/cgroup/memory/eve/services/memlogd/tasks); do
+    echo $pid > /sys/fs/cgroup/cpuset/eve/services/memlogd/tasks;
 done


### PR DESCRIPTION
PR sets cpuset cgroups for memlogd. The motivation of doing that is to move memlogd away from VM CPUs to avoid interference, so memlogd becomes being pinned to the CPU0 in default configuration.

Patches are:

1. dom0-ztools/010-eve-cgroup: a bit of refactoring
    
    Nothing special, just reduce copy-pastes.

2. dom0-ztools/002-logging,010-eve-cgroup: set cpuset cgroups for memlogd
    
    This patch does a few things:
    
    1. Moves memlogd to /eve/services cgroup folder since memlogd is a
       service anyway and this simplifies its cgroups settings.
    
    2. Sets cpuset.mems similar to cpuset.cpus. This gives possibility
       to add memlogd to cpuset tasks just in the 010-eve-cgroup.
       If cpuset.mems is not set an attempt to write pid to the 'tasks'
       cgroup file returns an error.
    
    3. Populates memlogd cpuset 'tasks' file with pids copied from
       'memory' controller just to avoid games with listing threads
       of the memlogd process.
    
    The motivation of doing that is to move memlogd away from VM CPUs
    to avoid interference, so memlogd becomes being pinned to the CPU0
    in default configuration.

CC: @deitch if you remember, we discussed the solution of pinning the onboot services, here is the simplest possible way without touching the linuxkit