### PR TITLE
kubevirt - encrypt etcd-storage with vault.

### DIFF
--- a/docs/BOOTING.md
+++ b/docs/BOOTING.md
@@ -132,7 +132,7 @@ in grub.cfg with graphical GRUB menu to get the device to boot again.
     11. `eve_install_skip_rootfs` - do not install rootfs partition onto device. May be selected from graphical GRUB menu.
     12. `eve_install_skip_zfs_checks` - install zfs by skipping minimum requirement checks.
     13. `eve_install_zfs_with_raid_level` - Sets raid level for zfs storage. Valid values are none,raid1,raid5,raid6. Default value is none. This option also applied for the first boot of a live image to prepare zfs persist pool instead of ext4.
-    14. `eve_install_kubevirt_reserve_for_eve_sizeGB` - Amount of space in GB to reserve for eve services in kubevirt based images (This is highly experimental and not supported config, also its an optional parameter and defaults to 20GB if not set)
+    14. `eve_install_kubevirt_etcd_sizeGB` - Size in GB of the etcd-storage zvol.  Defaults to 10GB.
 3. General kernel parameters may be adjusted with `set_global dom0_extra_args "$dom0_extra_args OPTION1=VAL1 OPTION2 "`.
    They will be added to kernel cmdline.
 

--- a/pkg/mkimage-raw-efi/install
+++ b/pkg/mkimage-raw-efi/install
@@ -22,7 +22,7 @@
 #   eve_install_skip_rootfs
 #   eve_install_skip_zfs_checks
 #   eve_install_zfs_with_raid_level
-#   eve_install_kubevirt_reserve_for_eve_sizeGB
+#   eve_install_kubevirt_etcd_sizeGB
 #
 BAIL_FINAL_CMD=${BAIL_FINAL_CMD:-"exit 1"}
 [ -n "$DEBUG" ] && set -x
@@ -140,7 +140,7 @@ collect_black_box() {
    pillar_run tpmmgr saveTpmInfo "$1"/tpminfo.txt
 }
 
-# prepare_mounts_and_zfs_pool POOL_CREATION_COMMAND_SUFFIX_SUFFIX INSTALL_CLUSTERED_STORAGE RESERVE_EVE_STORAGE_SIZEGB
+# prepare_mounts_and_zfs_pool POOL_CREATION_COMMAND_SUFFIX_SUFFIX INSTALL_CLUSTERED_STORAGE
 prepare_mounts_and_zfs_pool() {
   logmsg "Preparing ZFS pool and mounts"
   [ -e /root/sys ] || mkdir /root/sys && mount -t sysfs sysfs /root/sys
@@ -298,15 +298,7 @@ eve_flavor=$(cat /root/etc/eve-hv-type)
 if [ "$eve_flavor" = "kubevirt" ]; then
    INSTALL_CLUSTERED_STORAGE=true
    INSTALL_ZFS=true
-   RESERVE_EVE_STORAGE_SIZEGB=$(</proc/cmdline tr ' ' '\012' | sed -ne '/^eve_install_kubevirt_reserve_for_eve_sizeGB=/s#^.*=##p')
-
-   #If not set, default it to 20GB
-   # NOTE reserving 20GB for eve services is an experimental change and could be modified in future after analysing data.
-   if [ -z "$RESERVE_EVE_STORAGE_SIZEGB" ]; then
-      RESERVE_EVE_STORAGE_SIZEGB=20
-   fi
-
-   logmsg "Kubevirt image installing ZFS and EVE reserved storage sizeGB $RESERVE_EVE_STORAGE_SIZEGB"
+   logmsg "Kubevirt image installing ZFS and EVE reserved storage sizeGB"
 fi
 
 

--- a/pkg/mkimage-raw-efi/install
+++ b/pkg/mkimage-raw-efi/install
@@ -298,7 +298,7 @@ eve_flavor=$(cat /root/etc/eve-hv-type)
 if [ "$eve_flavor" = "kubevirt" ]; then
    INSTALL_CLUSTERED_STORAGE=true
    INSTALL_ZFS=true
-   logmsg "Kubevirt image installing ZFS and EVE reserved storage sizeGB"
+   logmsg "Kubevirt image installing ZFS"
 fi
 
 

--- a/pkg/pillar/base/kubevirt.go
+++ b/pkg/pillar/base/kubevirt.go
@@ -27,6 +27,8 @@ const (
 	InstallOptionEtcdSizeGB = "eve_install_kubevirt_etcd_sizeGB"
 	// DefaultEtcdSizeGB default for InstallOptionEtcdSizeGB
 	DefaultEtcdSizeGB uint32 = 10
+	// EtcdVolBlockSizeBytes is the block size for the etcd volume
+	EtcdVolBlockSizeBytes = uint64(4 * 1024)
 )
 
 // IsHVTypeKube - return true if the EVE image is kube cluster type.

--- a/pkg/pillar/base/kubevirt.go
+++ b/pkg/pillar/base/kubevirt.go
@@ -23,6 +23,10 @@ const (
 	KubeAppNameUUIDSuffixLen = 5
 	// VMIPodNamePrefix : prefix added to name of every pod created to run VM.
 	VMIPodNamePrefix = "virt-launcher-"
+	// InstallOptionEtcdSizeGB grub option at install time.  Size of etcd volume in GB.
+	InstallOptionEtcdSizeGB = "eve_install_kubevirt_etcd_sizeGB"
+	// DefaultEtcdSizeGB default for InstallOptionEtcdSizeGB
+	DefaultEtcdSizeGB uint32 = 10
 )
 
 // IsHVTypeKube - return true if the EVE image is kube cluster type.

--- a/pkg/pillar/vault/handler_zfs.go
+++ b/pkg/pillar/vault/handler_zfs.go
@@ -444,7 +444,7 @@ func getEtcdSizeSetting() (uint32, error) {
 		if strings.HasPrefix(arg, base.InstallOptionEtcdSizeGB) {
 			argSplitted := strings.Split(arg, "=")
 			if len(argSplitted) == 2 {
-				valGB, err := strconv.Atoi(argSplitted[1])
+				valGB, err := strconv.ParseUint(argSplitted[1], 10, 32)
 				if err == nil {
 					return uint32(valGB), nil
 				}

--- a/pkg/pillar/volumehandlers/zvolhandler.go
+++ b/pkg/pillar/volumehandlers/zvolhandler.go
@@ -66,7 +66,7 @@ func (handler *volumeHandlerZVol) PrepareVolume() error {
 		}
 	}
 	zVolName := handler.status.ZVolName()
-	if err := zfs.CreateVolumeDataset(handler.log, zVolName, size, "zstd", zfs.VolBlockSize); err != nil {
+	if err := zfs.CreateVolumeDataset(handler.log, zVolName, size, "zstd", zfs.VolBlockSizeBytes); err != nil {
 		errStr := fmt.Sprintf("Error creating zfs zvol at %s, error=%v",
 			zVolName, err)
 		handler.log.Error(errStr)

--- a/pkg/pillar/volumehandlers/zvolhandler.go
+++ b/pkg/pillar/volumehandlers/zvolhandler.go
@@ -66,7 +66,7 @@ func (handler *volumeHandlerZVol) PrepareVolume() error {
 		}
 	}
 	zVolName := handler.status.ZVolName()
-	if err := zfs.CreateVolumeDataset(handler.log, zVolName, size, "zstd"); err != nil {
+	if err := zfs.CreateVolumeDataset(handler.log, zVolName, size, "zstd", zfs.VolBlockSize); err != nil {
 		errStr := fmt.Sprintf("Error creating zfs zvol at %s, error=%v",
 			zVolName, err)
 		handler.log.Error(errStr)

--- a/pkg/pillar/zfs/zfs.go
+++ b/pkg/pillar/zfs/zfs.go
@@ -21,13 +21,8 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-const (
-	// VolBlockSize is the default dataset block size
-	VolBlockSize = uint64(16 * 1024)
-
-	// ReserveEveStorageSizeGb is the unused reserve taken from mkimage-raw-efi/install kubevirt RESERVE_EVE_STORAGE_SIZEGB
-	ReserveEveStorageSizeGb = uint64(20 * 1024 * 1024 * 1024)
-)
+// VolBlockSize is the default dataset block size
+const VolBlockSize = uint64(16 * 1024)
 
 // CreateDatasets - creates all the non-existing parent datasets.
 // Datasets created in this manner are automatically mounted

--- a/pkg/pillar/zfs/zfs.go
+++ b/pkg/pillar/zfs/zfs.go
@@ -21,7 +21,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// VolBlockSize is the default dataset block size in bytes
+// VolBlockSizeBytes is the default dataset block size in bytes
 const VolBlockSizeBytes = uint64(16 * 1024)
 
 // CreateDatasets - creates all the non-existing parent datasets.


### PR DESCRIPTION
New installs of the kubevirt image should encrypt the etcd-storage zvol identically with vault and unlock it at the same time.