### PR TITLE
Detect Network Instance IP subnet conflict

### DIFF
--- a/pkg/pillar/cmd/zedrouter/pubsubhandlers.go
+++ b/pkg/pillar/cmd/zedrouter/pubsubhandlers.go
@@ -108,6 +108,10 @@ func (z *zedrouter) handleDNSImpl(ctxArg interface{}, key string,
 		z.initReconcileDone = true
 	}
 
+	// A new IP address may have been assigned to a device port, or a previously existing
+	// one may have been removed, potentially creating or resolving an IP conflict.
+	z.checkAllNetworkInstanceIPConflicts()
+
 	// Update uplink config for network instances.
 	// Also handle (dis)appearance of uplink interfaces.
 	// Note that even if uplink interface disappears, we do not revert activated NI.
@@ -181,11 +185,19 @@ func (z *zedrouter) handleNetworkInstanceCreate(ctxArg interface{}, key string,
 		return
 	}
 
-	if niConflict, err := z.doNetworkInstanceSanityCheck(&config); err != nil {
+	if err := z.doNetworkInstanceSanityCheck(&config); err != nil {
 		z.log.Error(err)
 		status.SetErrorNow(err.Error())
 		status.ChangeInProgress = types.ChangeInProgressTypeNone
-		status.NIConflict = niConflict
+		z.publishNetworkInstanceStatus(&status)
+		return
+	}
+
+	if err := z.checkNetworkInstanceIPConflicts(&config); err != nil {
+		z.log.Error(err)
+		status.SetErrorNow(err.Error())
+		status.ChangeInProgress = types.ChangeInProgressTypeNone
+		status.IPConflict = true
 		z.publishNetworkInstanceStatus(&status)
 		return
 	}
@@ -301,15 +313,25 @@ func (z *zedrouter) handleNetworkInstanceModify(ctxArg interface{}, key string,
 
 	prevPortLL := status.PortLogicalLabel
 	status.NetworkInstanceConfig = config
-	if niConflict, err := z.doNetworkInstanceSanityCheck(&config); err != nil {
+	if err := z.doNetworkInstanceSanityCheck(&config); err != nil {
 		z.log.Error(err)
 		status.SetErrorNow(err.Error())
 		status.WaitingForUplink = false
 		status.ChangeInProgress = types.ChangeInProgressTypeNone
-		status.NIConflict = niConflict
 		z.publishNetworkInstanceStatus(status)
 		return
 	}
+
+	if err := z.checkNetworkInstanceIPConflicts(&config); err != nil {
+		z.log.Error(err)
+		status.SetErrorNow(err.Error())
+		status.IPConflict = true
+		status.WaitingForUplink = false
+		status.ChangeInProgress = types.ChangeInProgressTypeNone
+		z.publishNetworkInstanceStatus(status)
+		return
+	}
+	status.IPConflict = false
 
 	// Get or (less likely) allocate a bridge number.
 	bridgeNumKey := types.UuidToNumKey{UUID: status.UUID}
@@ -399,8 +421,8 @@ func (z *zedrouter) handleNetworkInstanceModify(ctxArg interface{}, key string,
 		z.doUpdateActivatedNetworkInstance(config, status)
 	}
 
-	// Check if some inter-NI conflicts were resolved by this modification.
-	z.checkConflictingNetworkInstances()
+	// Check if some IP conflicts were resolved by this modification.
+	z.checkAllNetworkInstanceIPConflicts()
 	z.log.Functionf("handleNetworkInstanceModify(%s) done", key)
 }
 
@@ -417,8 +439,8 @@ func (z *zedrouter) handleNetworkInstanceDelete(ctxArg interface{}, key string,
 	z.publishNetworkInstanceStatus(status)
 
 	done := z.maybeDelOrInactivateNetworkInstance(status)
-	// Check if some inter-NI conflicts were resolved by this delete.
-	z.checkConflictingNetworkInstances()
+	// Check if some IP conflicts were resolved by this NI deletion.
+	z.checkAllNetworkInstanceIPConflicts()
 	z.log.Functionf("handleNetworkInstanceDelete(%s) done %t", key, done)
 }
 

--- a/pkg/pillar/cmd/zedrouter/validation.go
+++ b/pkg/pillar/cmd/zedrouter/validation.go
@@ -9,11 +9,11 @@ import (
 	"time"
 
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/lf-edge/eve/pkg/pillar/utils/netutils"
 	uuid "github.com/satori/go.uuid"
 )
 
-func (z *zedrouter) doNetworkInstanceSanityCheck(
-	config *types.NetworkInstanceConfig) (niConflict bool, err error) {
+func (z *zedrouter) doNetworkInstanceSanityCheck(config *types.NetworkInstanceConfig) error {
 	z.log.Functionf("Sanity Checking NetworkInstance(%s-%s): type:%d, IpType:%d",
 		config.DisplayName, config.UUID, config.Type, config.IpType)
 
@@ -24,7 +24,7 @@ func (z *zedrouter) doNetworkInstanceSanityCheck(
 	case types.NetworkInstanceTypeSwitch:
 		// Do nothing
 	default:
-		return false, fmt.Errorf("network instance type %d is not supported", config.Type)
+		return fmt.Errorf("network instance type %d is not supported", config.Type)
 	}
 
 	// IpType - Check for valid types
@@ -33,63 +33,32 @@ func (z *zedrouter) doNetworkInstanceSanityCheck(
 		// Do nothing
 	case types.AddressTypeIPV4, types.AddressTypeIPV6,
 		types.AddressTypeCryptoIPV4, types.AddressTypeCryptoIPV6:
-		niConflict, err = z.doNetworkInstanceSubnetSanityCheck(config)
+		err := z.doNetworkInstanceSubnetSanityCheck(config)
 		if err != nil {
-			return niConflict, err
+			return err
 		}
 		err = z.doNetworkInstanceDhcpRangeSanityCheck(config)
 		if err != nil {
-			return false, err
+			return err
 		}
 		err = z.doNetworkInstanceGatewaySanityCheck(config)
 		if err != nil {
-			return false, err
+			return err
 		}
 
 	default:
-		return false, fmt.Errorf("IpType %d not supported", config.IpType)
+		return fmt.Errorf("IpType %d not supported", config.IpType)
 	}
-	return false, nil
+	return nil
 }
 
 func (z *zedrouter) doNetworkInstanceSubnetSanityCheck(
-	config *types.NetworkInstanceConfig) (niConflict bool, err error) {
+	config *types.NetworkInstanceConfig) error {
 	if config.Subnet.IP == nil || config.Subnet.IP.IsUnspecified() {
-		return false, fmt.Errorf("subnet unspecified for %s-%s: %+v",
+		return fmt.Errorf("subnet unspecified for %s-%s: %+v",
 			config.Key(), config.DisplayName, config.Subnet)
 	}
-
-	items := z.subNetworkInstanceConfig.GetAll()
-	for key2, config2 := range items {
-		niConfig2 := config2.(types.NetworkInstanceConfig)
-		if config.Key() == key2 {
-			continue
-		}
-
-		// We check for overlapping subnets by checking the
-		// SubnetAddr ( first address ) is not contained in the subnet of
-		// any other NI and vice-versa ( Other NI Subnet addrs are not
-		// contained in the current NI subnet)
-
-		// Check if config.Subnet is contained in iterStatusEntry.Subnet
-		if niConfig2.Subnet.Contains(config.Subnet.IP) {
-			return true, fmt.Errorf("subnet(%s, IP:%s) overlaps with another "+
-				"network instance(%s-%s) Subnet(%s)",
-				config.Subnet.String(), config.Subnet.IP.String(),
-				niConfig2.DisplayName, niConfig2.UUID,
-				niConfig2.Subnet.String())
-		}
-
-		// Reverse check: check if iterStatusEntry.Subnet is contained in config.subnet
-		if config.Subnet.Contains(niConfig2.Subnet.IP) {
-			return true, fmt.Errorf("another network instance(%s-%s) Subnet(%s) "+
-				"overlaps with Subnet(%s)",
-				niConfig2.DisplayName, niConfig2.UUID,
-				niConfig2.Subnet.String(),
-				config.Subnet.String())
-		}
-	}
-	return false, nil
+	return nil
 }
 
 func (z *zedrouter) doNetworkInstanceDhcpRangeSanityCheck(
@@ -127,6 +96,33 @@ func (z *zedrouter) doNetworkInstanceGatewaySanityCheck(
 		return fmt.Errorf("gateway(%s) is in DHCP Range(%v,%v)",
 			config.Gateway, config.DhcpRange.Start,
 			config.DhcpRange.End)
+	}
+	return nil
+}
+
+func (z *zedrouter) checkNetworkInstanceIPConflicts(
+	config *types.NetworkInstanceConfig) error {
+	// Check for overlapping subnets between NIs.
+	items := z.subNetworkInstanceConfig.GetAll()
+	for key2, config2 := range items {
+		niConfig2 := config2.(types.NetworkInstanceConfig)
+		if config.Key() == key2 {
+			continue
+		}
+		if netutils.OverlappingSubnets(&config.Subnet, &niConfig2.Subnet) {
+			return fmt.Errorf("subnet (%s) overlaps with another "+
+				"network instance (%s-%s) subnet (%s)",
+				config.Subnet.String(), niConfig2.DisplayName, niConfig2.UUID,
+				niConfig2.Subnet.String())
+		}
+	}
+	// Check for overlapping subnets between the NI and device ports.
+	for _, port := range z.deviceNetworkStatus.Ports {
+		if netutils.OverlappingSubnets(&config.Subnet, &port.Subnet) {
+			return fmt.Errorf("subnet (%s) overlaps with device port %s "+
+				"subnet (%s)", config.Subnet.String(), port.Logicallabel,
+				port.Subnet.String())
+		}
 	}
 	return nil
 }

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -963,7 +963,7 @@ func (z *zedrouter) processNIReconcileStatus(recStatus nireconciler.NIReconcileS
 			changed = true
 		}
 	} else {
-		if niStatus.HasError() {
+		if niStatus.HasError() && !niStatus.IPConflict {
 			niStatus.ClearError()
 			changed = true
 		}

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -244,14 +244,14 @@ func (z *zedrouter) init() (err error) {
 
 	z.peUsagePersist, err = persistcache.New(types.PersistCachePatchEnvelopesUsage)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	// restore cached patchEnvelopeUsage counters
 	for _, key := range z.peUsagePersist.Objects() {
 		cached, err := z.peUsagePersist.Get(key)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 		buf := bytes.NewBuffer(cached)
 		dec := gob.NewDecoder(buf)
@@ -259,7 +259,7 @@ func (z *zedrouter) init() (err error) {
 		var peUsage types.PatchEnvelopeUsage
 
 		if err := dec.Decode(&peUsage); err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		z.patchEnvelopesUsage.Store(key, peUsage)

--- a/pkg/pillar/nireconciler/linux_currentstate.go
+++ b/pkg/pillar/nireconciler/linux_currentstate.go
@@ -349,7 +349,7 @@ func (r *LinuxNIReconciler) updateCurrentVIFs(niID uuid.UUID) (changed bool) {
 					break
 				}
 			}
-			ifIndex, found, err := r.netMonitor.GetInterfaceIndex(vif.hostIfName)
+			_, found, err := r.netMonitor.GetInterfaceIndex(vif.hostIfName)
 			if err != nil {
 				r.log.Errorf("%s: updateCurrentVIFs: failed to get ifIndex "+
 					"for (VIF) %s: %v", LogAndErrPrefix, vif.hostIfName, err)
@@ -360,30 +360,9 @@ func (r *LinuxNIReconciler) updateCurrentVIFs(niID uuid.UUID) (changed bool) {
 				changed = r.updateSingleItem(prevVIF, nil, appConnSG) || changed
 				continue
 			}
-			ifAttrs, err := r.netMonitor.GetInterfaceAttrs(ifIndex)
-			if err != nil {
-				r.log.Errorf(
-					"%s: updateCurrentVIFs: failed to get interface %s "+
-						"(VIF) attributes: %v", LogAndErrPrefix, vif.hostIfName, err)
-				changed = r.updateSingleItem(prevVIF, nil, appConnSG) || changed
-				continue
-			}
-			var masterIfName string
-			if ifAttrs.Enslaved {
-				masterIfAttrs, err := r.netMonitor.GetInterfaceAttrs(ifAttrs.MasterIfIndex)
-				if err != nil {
-					r.log.Errorf("%s: updateCurrentVIFs: failed to get attrs "+
-						"for interface %s master (ifIndex: %d): %v",
-						LogAndErrPrefix, vif.hostIfName, ifAttrs.MasterIfIndex, err)
-					// Continue as if this VIF interface didn't have master...
-				} else {
-					masterIfName = masterIfAttrs.IfName
-				}
-			}
 			newVIF := linux.VIF{
 				HostIfName:     vif.hostIfName,
 				NetAdapterName: vif.NetAdapterName,
-				BridgeIfName:   masterIfName,
 				Variant:        linux.VIFVariant{External: true},
 			}
 			changed = r.updateSingleItem(prevVIF, newVIF, appConnSG) || changed

--- a/pkg/pillar/nireconciler/linux_reconciler.go
+++ b/pkg/pillar/nireconciler/linux_reconciler.go
@@ -1109,10 +1109,13 @@ func (r *LinuxNIReconciler) getSubgraphState(intSG, currSG dg.GraphR, forApp boo
 		if item.Type() == linux.VIFTypename {
 			return true
 		}
-		if item.Type() == linux.VLANPortTypename {
-			if item.(linux.VLANPort).BridgePort.VIFIfName != "" {
+		if item.Type() == linux.BridgePortTypename {
+			if item.(linux.BridgePort).Variant.VIFIfName != "" {
 				return true
 			}
+		}
+		if item.Type() == linux.VLANPortTypename {
+			return true
 		}
 		if route, isRoute := item.(linux.Route); isRoute {
 			if route.ForApp.ID != emptyUUID {

--- a/pkg/pillar/nireconciler/linuxitems/bridgeport.go
+++ b/pkg/pillar/nireconciler/linuxitems/bridgeport.go
@@ -1,0 +1,227 @@
+// Copyright (c) 2024 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package linuxitems
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/vishvananda/netlink"
+
+	dg "github.com/lf-edge/eve-libs/depgraph"
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/netmonitor"
+	generic "github.com/lf-edge/eve/pkg/pillar/nireconciler/genericitems"
+)
+
+// BridgePort : network interface added into a Linux bridge.
+type BridgePort struct {
+	// BridgeIfName : interface name of the bridge.
+	BridgeIfName string
+	// Variant : port should be one of the supported variants.
+	Variant BridgePortVariant
+}
+
+// BridgePortVariant is like union, only one option should have non-zero value.
+type BridgePortVariant struct {
+	// UplinkIfName : bridged uplink interface.
+	UplinkIfName string
+	// VIFIfName : bridged VIF.
+	VIFIfName string
+}
+
+// Name returns the interface name of the bridged port
+func (p BridgePort) Name() string {
+	return p.portIfName()
+}
+
+// Label for VLANPort.
+func (p BridgePort) Label() string {
+	return p.portIfName() + " (bridge port)"
+}
+
+// Type of the item.
+func (p BridgePort) Type() string {
+	return BridgePortTypename
+}
+
+// Equal compares two BridgePort instances.
+func (p BridgePort) Equal(other dg.Item) bool {
+	p2, isBridgePort := other.(BridgePort)
+	if !isBridgePort {
+		return false
+	}
+	return p == p2
+}
+
+// External returns false.
+func (p BridgePort) External() bool {
+	return false
+}
+
+// String describes BridgePort.
+func (p BridgePort) String() string {
+	return fmt.Sprintf("BridgePort: {bridgeIfName: %s, portIfName: %s}",
+		p.BridgeIfName, p.portIfName())
+}
+
+// Dependencies returns the bridge and the port as the dependencies.
+func (p BridgePort) Dependencies() (deps []dg.Dependency) {
+	deps = append(deps, dg.Dependency{
+		RequiredItem: dg.ItemRef{
+			ItemType: BridgeTypename,
+			ItemName: p.BridgeIfName,
+		},
+		Description: "Bridge must exist",
+	})
+	if p.Variant.VIFIfName != "" {
+		deps = append(deps, dg.Dependency{
+			RequiredItem: dg.ItemRef{
+				ItemType: VIFTypename,
+				ItemName: p.Variant.VIFIfName,
+			},
+			Description: "VIF must exist",
+			Attributes: dg.DependencyAttributes{
+				AutoDeletedByExternal: true,
+			},
+		})
+	} else if p.Variant.UplinkIfName != "" {
+		deps = append(deps, dg.Dependency{
+			RequiredItem: dg.ItemRef{
+				ItemType: generic.UplinkTypename,
+				ItemName: p.Variant.UplinkIfName,
+			},
+			MustSatisfy: func(item dg.Item) bool {
+				uplink, isUplink := item.(generic.Uplink)
+				if !isUplink {
+					// unreachable
+					return false
+				}
+				// Bridging is actually done by NIM for uplink interfaces.
+				// BridgePort is only used for dependency purposes in this case
+				// (VLANPort depends on BridgePort).
+				return uplink.MasterIfName == p.BridgeIfName
+			},
+			Description: "Uplink must exist and it must be bridged (by NIM)",
+			Attributes: dg.DependencyAttributes{
+				AutoDeletedByExternal: true,
+			},
+		})
+	}
+	return deps
+}
+
+func (p BridgePort) portIfName() string {
+	if p.Variant.VIFIfName != "" {
+		return p.Variant.VIFIfName
+	}
+	if p.Variant.UplinkIfName != "" {
+		return p.Variant.UplinkIfName
+	}
+	return ""
+}
+
+// BridgePortConfigurator implements Configurator interface (libs/reconciler)
+// for Linux bridge port.
+type BridgePortConfigurator struct {
+	Log            *base.LogObject
+	NetworkMonitor netmonitor.NetworkMonitor
+}
+
+// Create attaches port to a bridge.
+func (c *BridgePortConfigurator) Create(ctx context.Context, item dg.Item) error {
+	bridgePort, isBridgePort := item.(BridgePort)
+	if !isBridgePort {
+		return fmt.Errorf("invalid item type %T, expected BridgePort", item)
+	}
+	if bridgePort.Variant.UplinkIfName != "" {
+		// NOOP for uplink - NIM is responsible for bridging uplink ports.
+		return nil
+	}
+	link, err := netlink.LinkByName(bridgePort.portIfName())
+	if err != nil {
+		err = fmt.Errorf("failed to get link for interface %s: %w",
+			bridgePort.portIfName(), err)
+		c.Log.Error(err)
+		return err
+	}
+	bridge, err := netlink.LinkByName(bridgePort.BridgeIfName)
+	if err != nil {
+		err = fmt.Errorf("failed to get link for bridge %s: %w",
+			bridgePort.BridgeIfName, err)
+		c.Log.Error(err)
+		return err
+	}
+	err = netlink.LinkSetUp(link)
+	if err != nil {
+		err = fmt.Errorf("failed to set interface %s UP: %w",
+			bridgePort.portIfName(), err)
+		c.Log.Error(err)
+		return err
+	}
+	err = netlink.LinkSetMaster(link, bridge)
+	if err != nil {
+		err = fmt.Errorf("failed to attach interface %s to bridge %s: %w",
+			bridgePort.portIfName(), bridgePort.BridgeIfName, err)
+		c.Log.Error(err)
+		return err
+	}
+	return nil
+}
+
+// Modify is not implemented.
+func (c *BridgePortConfigurator) Modify(ctx context.Context, oldItem, newItem dg.Item) (err error) {
+	return errors.New("not implemented")
+}
+
+// Delete detaches port from the bridge.
+func (c *BridgePortConfigurator) Delete(ctx context.Context, item dg.Item) (err error) {
+	defer func() {
+		if err != nil {
+			var linkNotFound netlink.LinkNotFoundError
+			if errors.As(err, &linkNotFound) {
+				// (VIF) Port was already removed (by hypervisor),
+				// but we have not yet received netlink notification about the deletion.
+				// Ignore the error.
+				err = nil
+				return
+			}
+		}
+	}()
+	bridgePort, isBridgePort := item.(BridgePort)
+	if !isBridgePort {
+		return fmt.Errorf("invalid item type %T, expected BridgePort", item)
+	}
+	if bridgePort.Variant.UplinkIfName != "" {
+		// NOOP for uplink - NIM is responsible for bridging uplink ports.
+		return nil
+	}
+	link, err := netlink.LinkByName(bridgePort.portIfName())
+	if err != nil {
+		err = fmt.Errorf("failed to get link for interface %s: %w",
+			bridgePort.portIfName(), err)
+		c.Log.Error(err)
+		return err
+	}
+	err = netlink.LinkSetNoMaster(link)
+	if err != nil {
+		err = fmt.Errorf("failed to detach interface %s from bridge %s: %w",
+			bridgePort.portIfName(), bridgePort.BridgeIfName, err)
+		c.Log.Error(err)
+		return err
+	}
+	err = netlink.LinkSetDown(link)
+	if err != nil {
+		err = fmt.Errorf("failed to set interface %s DOWN: %w",
+			bridgePort.portIfName(), err)
+		c.Log.Error(err)
+		return err
+	}
+	return nil
+}
+
+// NeedsRecreate returns true - Modify is not implemented.
+func (c *BridgePortConfigurator) NeedsRecreate(oldItem, newItem dg.Item) (recreate bool) {
+	return true
+}

--- a/pkg/pillar/nireconciler/linuxitems/registry.go
+++ b/pkg/pillar/nireconciler/linuxitems/registry.go
@@ -19,6 +19,7 @@ func RegisterItems(log *base.LogObject, registry *reconciler.DefaultRegistry,
 	}
 	configurators := []configurator{
 		{c: &BridgeConfigurator{Log: log}, t: BridgeTypename},
+		{c: &BridgePortConfigurator{Log: log}, t: BridgePortTypename},
 		{c: &DummyIfConfigurator{Log: log}, t: DummyIfTypename},
 		{c: &IPRuleConfigurator{Log: log}, t: IPRuleTypename},
 		{c: &IPSetConfigurator{Log: log}, t: generic.IPSetTypename},

--- a/pkg/pillar/nireconciler/linuxitems/typenames.go
+++ b/pkg/pillar/nireconciler/linuxitems/typenames.go
@@ -10,6 +10,8 @@ const (
 	IPRuleTypename = "IPRule"
 	// BridgeTypename : typename for Linux bridges.
 	BridgeTypename = "Bridge"
+	// BridgePortTypename : typename for network interface added into a Linux bridge.
+	BridgePortTypename = "BridgePort"
 	// DummyIfTypename : typename for Linux dummy interface.
 	DummyIfTypename = "DummyInterface"
 	// VLANBridgeTypename : typename for (Linux bridge) enabled for VLANs.

--- a/pkg/pillar/nireconciler/linuxitems/vlanport.go
+++ b/pkg/pillar/nireconciler/linuxitems/vlanport.go
@@ -7,11 +7,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
 	dg "github.com/lf-edge/eve-libs/depgraph"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/netmonitor"
-	generic "github.com/lf-edge/eve/pkg/pillar/nireconciler/genericitems"
 	"github.com/lf-edge/eve/pkg/pillar/utils/generics"
 	"github.com/vishvananda/netlink"
 )
@@ -25,19 +23,10 @@ const (
 type VLANPort struct {
 	// BridgeIfName : interface name of the bridge.
 	BridgeIfName string
-	// BridgePort references the bridged interface to configure VLANs for.
-	BridgePort BridgePort
+	// PortIfName : interface name of the bridge port.
+	PortIfName string
 	// VLANConfig : VLAN configuration to apply on the bridged interface.
 	VLANConfig VLANConfig
-}
-
-// BridgePort : port attached to a bridge.
-// Only one of these should be defined (this is like union).
-type BridgePort struct {
-	// UplinkIfName : bridged uplink interface.
-	UplinkIfName string
-	// VIFIfName : bridged VIF.
-	VIFIfName string
 }
 
 // VLANConfig : VLAN configuration to apply on the bridge port.
@@ -61,12 +50,12 @@ type AccessPort struct {
 // Name returns the interface name of the bridged port
 // (there can be at most one instance of VLANPort associated with a given bridged port).
 func (v VLANPort) Name() string {
-	return v.portIfName()
+	return v.PortIfName
 }
 
 // Label for VLANPort.
 func (v VLANPort) Label() string {
-	return v.portIfName() + " (VLAN port)"
+	return v.PortIfName + " (VLAN port)"
 }
 
 // Type of the item.
@@ -96,7 +85,7 @@ func (v VLANPort) Equal(other dg.Item) bool {
 		}
 	}
 	return v.BridgeIfName == v2.BridgeIfName &&
-		v.BridgePort == v2.BridgePort
+		v.PortIfName == v2.PortIfName
 }
 
 // External returns false.
@@ -106,13 +95,6 @@ func (v VLANPort) External() bool {
 
 // String describes VLANPort.
 func (v VLANPort) String() string {
-	var bridgePort string
-	if v.BridgePort.UplinkIfName != "" {
-		bridgePort = fmt.Sprintf("uplinkIfName: %s", v.BridgePort.UplinkIfName)
-	}
-	if v.BridgePort.VIFIfName != "" {
-		bridgePort = fmt.Sprintf("vifIfName: %s", v.BridgePort.VIFIfName)
-	}
 	var vlanConfig string
 	if v.VLANConfig.TrunkPort != nil {
 		vlanConfig = fmt.Sprintf("trunkPort: {allVIDs: %t, vids:%v}",
@@ -121,8 +103,8 @@ func (v VLANPort) String() string {
 	if v.VLANConfig.AccessPort != nil {
 		vlanConfig = fmt.Sprintf("accessPort: {vid: %d}", v.VLANConfig.AccessPort.VID)
 	}
-	return fmt.Sprintf("VLANPort: {bridgeIfName: %s, %s, %s}",
-		v.BridgeIfName, bridgePort, vlanConfig)
+	return fmt.Sprintf("VLANPort: {bridgeIfName: %s, portIfName: %s, %s}",
+		v.BridgeIfName, v.PortIfName, vlanConfig)
 }
 
 // Dependencies returns the (VLAN-enabled) bridge and the port as the dependencies.
@@ -137,56 +119,22 @@ func (v VLANPort) Dependencies() (deps []dg.Dependency) {
 			AutoDeletedByExternal: true,
 		},
 	})
-	if v.BridgePort.VIFIfName != "" {
-		deps = append(deps, dg.Dependency{
-			RequiredItem: dg.ItemRef{
-				ItemType: VIFTypename,
-				ItemName: v.BridgePort.VIFIfName,
-			},
-			MustSatisfy: func(item dg.Item) bool {
-				vif, isVIF := item.(VIF)
-				if !isVIF {
-					// unreachable
-					return false
-				}
-				return vif.BridgeIfName == v.BridgeIfName
-			},
-			Description: "VIF must exist and it must be bridged",
-			Attributes: dg.DependencyAttributes{
-				AutoDeletedByExternal: true,
-			},
-		})
-	} else if v.BridgePort.UplinkIfName != "" {
-		deps = append(deps, dg.Dependency{
-			RequiredItem: dg.ItemRef{
-				ItemType: generic.UplinkTypename,
-				ItemName: v.BridgePort.UplinkIfName,
-			},
-			MustSatisfy: func(item dg.Item) bool {
-				uplink, isUplink := item.(generic.Uplink)
-				if !isUplink {
-					// unreachable
-					return false
-				}
-				return uplink.MasterIfName == v.BridgeIfName
-			},
-			Description: "Uplink must exist and it must be bridged",
-			Attributes: dg.DependencyAttributes{
-				AutoDeletedByExternal: true,
-			},
-		})
-	}
+	deps = append(deps, dg.Dependency{
+		RequiredItem: dg.ItemRef{
+			ItemType: BridgePortTypename,
+			ItemName: v.PortIfName,
+		},
+		MustSatisfy: func(item dg.Item) bool {
+			bridgePort, isBridgePort := item.(BridgePort)
+			if !isBridgePort {
+				// unreachable
+				return false
+			}
+			return bridgePort.BridgeIfName == v.BridgeIfName
+		},
+		Description: "Port must be attached to the bridge",
+	})
 	return deps
-}
-
-func (v VLANPort) portIfName() string {
-	if v.BridgePort.VIFIfName != "" {
-		return v.BridgePort.VIFIfName
-	}
-	if v.BridgePort.UplinkIfName != "" {
-		return v.BridgePort.UplinkIfName
-	}
-	return ""
 }
 
 // VLANPortConfigurator implements Configurator interface (libs/reconciler)
@@ -201,17 +149,29 @@ func (c *VLANPortConfigurator) Create(ctx context.Context, item dg.Item) error {
 	return c.createOrDelete(item, false)
 }
 
-func (c *VLANPortConfigurator) createOrDelete(item dg.Item, del bool) error {
+func (c *VLANPortConfigurator) createOrDelete(item dg.Item, del bool) (err error) {
+	defer func() {
+		if err != nil {
+			var linkNotFound netlink.LinkNotFoundError
+			if del && errors.As(err, &linkNotFound) {
+				// Port was already removed (by hypervisor or domainmgr),
+				// but we have not yet received netlink notification about the deletion.
+				// Ignore the error.
+				err = nil
+				return
+			}
+		}
+	}()
 	vlanPort, isVLANPort := item.(VLANPort)
 	if !isVLANPort {
 		return fmt.Errorf("invalid item type %T, expected VLANPort", item)
 	}
-	link, err := netlink.LinkByName(vlanPort.portIfName())
+	link, err := netlink.LinkByName(vlanPort.PortIfName)
 	if err != nil {
-		// Dependencies should prevent this.
 		err = fmt.Errorf("failed to get link for bridge port %s: %w",
-			vlanPort.portIfName(), err)
+			vlanPort.PortIfName, err)
 		c.Log.Error(err)
+		// Dependencies should prevent this.
 		return err
 	}
 	if vlanPort.VLANConfig.TrunkPort != nil {

--- a/pkg/pillar/nireconciler/nireconciler.go
+++ b/pkg/pillar/nireconciler/nireconciler.go
@@ -103,6 +103,13 @@ type NIBridge struct {
 	// Uplink interface selected for this network instance.
 	// Zero value if network instance is air-gapped.
 	Uplink Uplink
+	// IPConflict is used to mark (Local) NI with IP subnet that overlaps with the network
+	// of one of the uplink ports.
+	// Currently, for conflicting NI, NIReconciler keeps only app VIFs configured, and even
+	// they are in the DOWN state to prevent any traffic getting through.
+	// In the future, we may improve isolation between NIs and uplinks using advanced
+	// policy-based routing or VRFs. This will enable conflicting NIs to remain functional.
+	IPConflict bool
 }
 
 // Uplink used by a network instance to provide external connectivity for applications.

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -805,7 +805,10 @@ type NetworkInstanceStatus struct {
 	Activate uint64
 
 	ChangeInProgress ChangeInProgressType
-	NIConflict       bool // True if config conflicts with another NI
+
+	// True if NI IP subnet overlaps with the subnet of one the device ports
+	// or another NI.
+	IPConflict bool
 
 	// Activated is true if the network instance has been created in the network stack.
 	Activated bool

--- a/pkg/pillar/utils/netutils/ip.go
+++ b/pkg/pillar/utils/netutils/ip.go
@@ -96,3 +96,13 @@ func HostSubnet(ip net.IP) *net.IPNet {
 	}
 	return &net.IPNet{IP: ip, Mask: net.CIDRMask(128, 128)}
 }
+
+// OverlappingSubnets returns true if the given subnets share at least one IP address.
+func OverlappingSubnets(subnet1, subnet2 *net.IPNet) bool {
+	if subnet1 == nil || len(subnet1.IP) == 0 ||
+		subnet2 == nil || len(subnet2.IP) == 0 {
+		// One of the subnets or both are undefined.
+		return false
+	}
+	return subnet1.Contains(subnet2.IP) || subnet2.Contains(subnet1.IP)
+}


### PR DESCRIPTION
Zedrouter is able to detect if NI IP subnet overlaps with the subnet of another NI or with a device port network. When a conflict is detected for a new NI, it is blocked from being created. If IP conflict arises for an already created NI (e.g. a device port later received IP from an overlapping subnet), the NI is unconfigured and VIFs are set DOWN (not deleted). In both cases an error is reported for the NI.

This is crucial because, previously, a NI with a subnet overlapping with a device port network would result in the device permanently losing controller connectivity (due to routing conflicts), with very limited options to restore connectivity and make the device manageable again. Instead, the device should remain online, inform the user about the issue, and allow to correct the IP configuration.

When IP conflict is detected for an already created NI with an app connected to it, we intentionally do not halt and undeploy the app. Instead, the app is left running, just VIFs connected to the problematic NI lose their connectivity. This allows the user to fix the network config or at least backup the application data when IP conflict arises.

To enable the deletion of NI when an IP conflict is detected, followed by its later recreation when the conflict is resolved, and to reconnect already running apps, few enhancements had to be made to the NI Reconciler, particularly in the area of VIF bridging.