### PR TITLE
pkg/fscrypt: support builds for other ARCHs

### DIFF
--- a/pkg/fscrypt/Dockerfile
+++ b/pkg/fscrypt/Dockerfile
@@ -2,7 +2,14 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:9fb9b9cbf7d90066a70e4704d04a6fe248ff52bb AS build
+FROM lfedge/eve-alpine:9fb9b9cbf7d90066a70e4704d04a6fe248ff52bb AS build-base
+
+FROM build-base AS build-amd64
+FROM build-base AS build-arm64
+FROM build-base AS build-riscv64
+
+# hadolint ignore=DL3006
+FROM build-${TARGETARCH} AS build
 
 ENV BUILD_PKGS git gcc make libc-dev linux-pam-dev m4 findutils go util-linux make patch
 RUN eve-alpine-deploy.sh


### PR DESCRIPTION
Pillar, which is crossbuildable, depends on fscrypt. Without this cludge any attempt to build pillar for any ARCH other than amd64 raises the following absolutely implicit and opague error:

```
   Error: error building "lfedge/eve-pillar:f6cd4c5f47f4900781840ea5b861ddecca52c35d": error building for arch arm64: failed to solve: no match for platform in manifest: not found
```

Which can mean anything. By trials and errors build problems with the fscrypt were determined.

cc: @deitch 