### PR TITLE
pkg/pillar: fscrypt sha update

### DIFF
--- a/pkg/pillar/Dockerfile
+++ b/pkg/pillar/Dockerfile
@@ -115,7 +115,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build if [ "${TEST_TOOLS}" = "y" ]
     GOBIN=/final/opt/ GOFLAGS="" go install gotest.tools/gotestsum@v1.7.0; \
 fi
 
-FROM lfedge/eve-fscrypt:e8507303431c8c11ec1a2b3b7fb02e1a0dcdf296 as fscrypt
+FROM lfedge/eve-fscrypt:68d40d7e70585669adef91279ba39dd134d3a15f as fscrypt
 FROM lfedge/eve-dnsmasq:3af908d86a95a627c729e09b1b125bf8de7fadcb as dnsmasq
 FROM lfedge/eve-gpt-tools:51ecda7bc185c655c1d0423228dc83e29d4c674d as gpttools
 


### PR DESCRIPTION
Pillar is crossbuildable, and it seems that every dependable package has to be crossbuildable as well. Update fscrypt SHA, which includes arm64 and riscv builds.

Should be rebased and merged after the https://github.com/lf-edge/eve/pull/3824

cc: @deitch 