### PR TITLE
Container-in-VM: put DNS servers from all ports to resolv.conf

### DIFF
--- a/pkg/pillar/nireconciler/linux_test.go
+++ b/pkg/pillar/nireconciler/linux_test.go
@@ -2221,6 +2221,8 @@ func TestStaticAndConnectedRoutes(test *testing.T) {
 	t.Expect(err).ToNot(HaveOccurred())
 	t.Eventually(updatesCh).Should(Receive(&recUpdate))
 	t.Expect(recUpdate.UpdateType).To(Equal(nirec.NIReconcileStatusChanged))
+	// NI5 will propagate user-configured DNS server to apps.
+	ni5Config.DnsServers = []net.IP{ipAddress("1.1.1.1")}
 	_, err = niReconciler.AddNI(ctx, ni5Config, ni5Bridge)
 	t.Expect(err).ToNot(HaveOccurred())
 	t.Eventually(updatesCh).Should(Receive(&recUpdate))
@@ -2297,28 +2299,30 @@ func TestStaticAndConnectedRoutes(test *testing.T) {
 		"withDefaultRoute: false"))
 
 	// Connected routes (of local NIs) should not be propagated to applications.
+	// Only host routes for DNS and NTP servers should be.
 	t.Expect(itemDescription(dg.Reference(dnsmasqNI1))).To(ContainSubstring(
-		"propagateRoutes: []"))
+		"propagateRoutes: [{132.163.96.5/32 10.10.10.1}]"))
 	t.Expect(itemDescription(dg.Reference(dnsmasqNI5))).To(ContainSubstring(
-		"propagateRoutes: []"))
+		"propagateRoutes: [{132.163.96.5/32 10.10.20.1} {1.1.1.1/32 10.10.20.1}]"))
 
 	// Enable propagation of connected routes for NI1 (only).
 	ni1Config.PropagateConnRoutes = true
 	_, err = niReconciler.UpdateNI(ctx, ni1Config, ni1Bridge)
 	t.Expect(err).ToNot(HaveOccurred())
 	t.Expect(itemDescription(dg.Reference(dnsmasqNI1))).To(ContainSubstring(
-		"propagateRoutes: [{192.168.10.0/24 10.10.10.1}]"))
+		"propagateRoutes: [{132.163.96.5/32 10.10.10.1} {192.168.10.0/24 10.10.10.1}]"))
 	t.Expect(itemDescription(dg.Reference(dnsmasqNI5))).To(ContainSubstring(
-		"propagateRoutes: []"))
+		"propagateRoutes: [{132.163.96.5/32 10.10.20.1} {1.1.1.1/32 10.10.20.1}]}"))
 
 	// Enable propagation of connected routes for NI5 as well.
 	ni5Config.PropagateConnRoutes = true
 	_, err = niReconciler.UpdateNI(ctx, ni5Config, ni5Bridge)
 	t.Expect(err).ToNot(HaveOccurred())
 	t.Expect(itemDescription(dg.Reference(dnsmasqNI1))).To(ContainSubstring(
-		"propagateRoutes: [{192.168.10.0/24 10.10.10.1}]"))
+		"propagateRoutes: [{132.163.96.5/32 10.10.10.1} {192.168.10.0/24 10.10.10.1}]"))
 	t.Expect(itemDescription(dg.Reference(dnsmasqNI5))).To(ContainSubstring(
-		"propagateRoutes: [{172.20.0.0/16 10.10.20.1}]"))
+		"propagateRoutes: [{132.163.96.5/32 10.10.20.1} {1.1.1.1/32 10.10.20.1} " +
+			"{172.20.0.0/16 10.10.20.1}]"))
 
 	// Make N1 air-gapped.
 	ni1Uplink := ni1Bridge.Uplink
@@ -2328,7 +2332,8 @@ func TestStaticAndConnectedRoutes(test *testing.T) {
 	t.Expect(itemDescription(dg.Reference(dnsmasqNI1))).To(ContainSubstring(
 		"propagateRoutes: []"))
 	t.Expect(itemDescription(dg.Reference(dnsmasqNI5))).To(ContainSubstring(
-		"propagateRoutes: [{172.20.0.0/16 10.10.20.1}]"))
+		"propagateRoutes: [{132.163.96.5/32 10.10.20.1} {1.1.1.1/32 10.10.20.1} " +
+			"{172.20.0.0/16 10.10.20.1}]"))
 
 	// Add some static routes.
 	ni1Config.StaticRoutes = []types.IPRoute{
@@ -2352,7 +2357,8 @@ func TestStaticAndConnectedRoutes(test *testing.T) {
 	t.Expect(itemDescription(dg.Reference(dnsmasqNI5))).To(ContainSubstring(
 		"withDefaultRoute: true"))
 	t.Expect(itemDescription(dg.Reference(dnsmasqNI5))).To(ContainSubstring(
-		"propagateRoutes: [{10.50.1.0/24 10.10.20.1} {172.20.0.0/16 10.10.20.1}]"))
+		"propagateRoutes: [{132.163.96.5/32 10.10.20.1} {1.1.1.1/32 10.10.20.1} " +
+			"{10.50.1.0/24 10.10.20.1} {172.20.0.0/16 10.10.20.1}]"))
 
 	// Check routing tables
 	t.Expect(itemCount(func(item dg.Item) bool {
@@ -2427,6 +2433,7 @@ func TestStaticAndConnectedRoutes(test *testing.T) {
 	// Revert back config changes.
 	ni1Config.StaticRoutes = nil
 	ni5Config.StaticRoutes = nil
+	ni5Config.DnsServers = nil
 	ni1Bridge.Uplink = ni1Uplink
 	ni1Config.PropagateConnRoutes = false
 	ni5Config.PropagateConnRoutes = false

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lf-edge/eve/pkg/kube/cnirpc"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/objtonum"
+	"github.com/lf-edge/eve/pkg/pillar/utils/netutils"
 	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 )
@@ -679,6 +680,12 @@ func (r IPRoute) IsDefaultRoute() bool {
 	}
 	ones, _ := r.DstNetwork.Mask.Size()
 	return r.DstNetwork.IP.IsUnspecified() && ones == 0
+}
+
+// EqualIPRoutes compares two IP routes.
+func EqualIPRoutes(route1, route2 IPRoute) bool {
+	return netutils.EqualIPs(route1.Gateway, route2.Gateway) &&
+		netutils.EqualIPNets(route1.DstNetwork, route2.DstNetwork)
 }
 
 // Key :


### PR DESCRIPTION
When container application has multiple network interfaces, it should be configured to failover between DNS servers collected from all interfaces.

The current behaviour is that we only put DNS servers from the first (eth0) interface into resolv.conf. However, if the uplink port corresponding to the first app interface looses connectivity, name resolution will stop working and app will not try DNS servers from other interfaces (that could be potentially using different uplinks).
However, there is nothing in EVE API that would declare the first app interface as being special and exclusively used for DNS.

Comparing this to Linux or Windows (i.e. VM apps), the default behaviour of the resolver is to iterate over all ports and try every DNS server until one responds. We should therefore replicate the same behaviour in our shim VM created for container applications.

Additionally, in order to make sure that query destined to a user-configured DNS server is sent out through the appropriate application interface, for every NI we use DHCP to propagate host routes (/32) for all DNS (and also NTP) servers (with the NI bridge IP as GW) into applications.
