### PR TITLE
Images and Blobs GC support in Kubevirt eve

### DIFF
--- a/pkg/pillar/cas/cas.go
+++ b/pkg/pillar/cas/cas.go
@@ -71,6 +71,9 @@ type CAS interface {
 	//GetImageHash: returns a blob hash of format <algo>:<hash> (currently supporting only sha256:<hash>) which the given 'reference' is pointing to.
 	// Returns error if the given 'reference' is not found.
 	GetImageHash(reference string) (string, error)
+	//s  returns the labels set on the image.
+	//Returns error if the given reference is not found
+	GetImageLabels(reference string) (map[string]string, error)
 	//ListImages: returns a list of references
 	ListImages() ([]string, error)
 	//RemoveImage removes an reference from CAS

--- a/pkg/pillar/types/blob.go
+++ b/pkg/pillar/types/blob.go
@@ -49,6 +49,13 @@ type BlobStatus struct {
 	ErrorAndTimeWithSource
 }
 
+const (
+	// EVEDownloadedLabel : Label to set on all eve downloaded images/blobs
+	EVEDownloadedLabel = "eve-downloaded"
+	// EVEDownloadedValue : Value to set on the label
+	EVEDownloadedValue = "true"
+)
+
 // Key returns the pubsub Key.
 func (status BlobStatus) Key() string {
 	return status.Sha256


### PR DESCRIPTION
1) Added GetImageLabel() to CAS interface
2) For any newly created image on any flavor of eve always set the label eve-downloaded=true
   on both images and blobs.
3) During volumemgr start (reboot/upgrade) populateInitBlobStatus() will do the following:
   a) On kubevirt eve publish only blobs that have label eve-downloaded=true
   b) On non kubevirt eve publish all the blobs, because we assume all the blobs present
      are certainly downloaded by eve.
4) Since gcBlobStatus() works on published blobs, it covers all flavors of eve
5) gcImagesFromCAS() will do the following:
   a) On kubevirt eve gc images that have label eve-downloaded=true
   b) On non kubevirt eve gc any image because we assume that image was certainly downloaded by eve.

NOTE: This PR does not change labels on existing images or blobs on non-kubevirt eve.