### PR TITLE
[10.4 stable] Detect Network Instance IP subnet conflict

### DIFF
--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -66,6 +66,7 @@ func (z *zedrouter) getNIBridgeConfig(
 		MACAddress: status.BridgeMac,
 		IPAddress:  ipAddr,
 		Uplink:     z.getNIUplinkConfig(status),
+		IPConflict: status.IPConflict,
 	}
 }
 
@@ -296,26 +297,57 @@ func (z *zedrouter) delNetworkInstance(status *types.NetworkInstanceStatus) {
 	z.deleteNetworkInstanceMetrics(status.Key())
 }
 
-// Called when a NetworkInstance is deleted or modified to check if there are other
-// NIs that previously could not be configured due to inter-NI config conflicts.
-func (z *zedrouter) checkConflictingNetworkInstances() {
+// Called when a NetworkInstance is deleted or modified, or when a device port IP is
+// added or removed, to check if there are new IP conflicts or if some existing
+// have been resolved.
+func (z *zedrouter) checkAllNetworkInstanceIPConflicts() {
 	for _, item := range z.pubNetworkInstanceStatus.GetAll() {
 		niStatus := item.(types.NetworkInstanceStatus)
-		if !niStatus.NIConflict {
-			continue
-		}
 		niConfig := z.lookupNetworkInstanceConfig(niStatus.Key())
 		if niConfig == nil {
 			continue
 		}
-		niConflict, err := z.doNetworkInstanceSanityCheck(niConfig)
-		if err == nil && niConflict == false {
-			// Try to re-create the network instance now that the conflict is gone.
-			z.log.Noticef("Recreating NI %s (%s) now that inter-NI conflict "+
-				"is not present anymore", niConfig.UUID, niConfig.DisplayName)
-			// First release whatever has been already allocated for this NI.
-			z.delNetworkInstance(&niStatus)
-			z.handleNetworkInstanceCreate(nil, niConfig.Key(), *niConfig)
+		conflictErr := z.checkNetworkInstanceIPConflicts(niConfig)
+		if conflictErr == nil && niStatus.IPConflict {
+			// IP conflict was resolved.
+			if niStatus.Activated {
+				// Local NI was initially activated prior to the IP conflict.
+				// Subsequently, when the IP conflict arose, it was almost completely
+				// un-configured (only preserving app VIFs) to keep device connectivity
+				// unaffected. Now, it can be restored to full functionality.
+				z.log.Noticef("Updating NI %s (%s) now that IP conflict "+
+					"is not present anymore", niConfig.UUID, niConfig.DisplayName)
+				niStatus.IPConflict = false
+				niStatus.ClearError()
+				// This also publishes the new status.
+				z.doUpdateActivatedNetworkInstance(*niConfig, &niStatus)
+			} else {
+				// NI is not in an active state (nothing configured in the network stack).
+				// We can simply re-create the network instance now that the IP conflict
+				// is gone.
+				z.log.Noticef("Recreating NI %s (%s) now that IP conflict "+
+					"is not present anymore", niConfig.UUID, niConfig.DisplayName)
+				// First release whatever has been already allocated for this NI.
+				z.delNetworkInstance(&niStatus)
+				z.handleNetworkInstanceCreate(nil, niConfig.Key(), *niConfig)
+			}
+		}
+		if conflictErr != nil && !niStatus.IPConflict {
+			// New IP conflict arose.
+			z.log.Error(conflictErr)
+			niStatus.IPConflict = true
+			niStatus.SetErrorNow(conflictErr.Error())
+			z.publishNetworkInstanceStatus(&niStatus)
+			if niStatus.Activated {
+				// Local NI is already activated. Instead of removing it and halting
+				// all connected applications (which can lead to loss of data), we
+				// un-configure everything but app VIFs, which will be set DOWN
+				// on the host side. User has a chance to fix the configuration.
+				// When IP conflict is removed, NI will be automatically fully restored.
+				z.log.Noticef("Updating NI %s (%s) after detecting an IP conflict (%s)",
+					niConfig.UUID, niConfig.DisplayName, conflictErr)
+				z.doUpdateActivatedNetworkInstance(*niConfig, &niStatus)
+			}
 		}
 	}
 }

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -817,7 +817,7 @@ func (z *zedrouter) processNIReconcileStatus(recStatus nireconciler.NIReconcileS
 			changed = true
 		}
 	} else {
-		if niStatus.HasError() {
+		if niStatus.HasError() && !niStatus.IPConflict {
 			niStatus.ClearError()
 			changed = true
 		}

--- a/pkg/pillar/nireconciler/genericitems/vif.go
+++ b/pkg/pillar/nireconciler/genericitems/vif.go
@@ -18,9 +18,6 @@ type VIF struct {
 	// in NetworkAdapter.Name.
 	// Unique in the scope of the application.
 	NetAdapterName string
-	// MasterIfName : name of the master interface under which this VIF is enslaved.
-	// Empty if not enslaved.
-	MasterIfName string
 }
 
 // Name returns the physical interface name.
@@ -54,8 +51,8 @@ func (v VIF) External() bool {
 
 // String describes VIF.
 func (v VIF) String() string {
-	return fmt.Sprintf("VIF: {ifName: %s, netAdapterName: %s, masterIfName: %s}",
-		v.IfName, v.NetAdapterName, v.MasterIfName)
+	return fmt.Sprintf("VIF: {ifName: %s, netAdapterName: %s}",
+		v.IfName, v.NetAdapterName)
 }
 
 // Dependencies returns nothing (external item).

--- a/pkg/pillar/nireconciler/linux_config.go
+++ b/pkg/pillar/nireconciler/linux_config.go
@@ -86,11 +86,11 @@ import (
 //  |   |   +----------------------------------------------------+   |   |
 //  |   |   |                        L2                          |   |   |
 //  |   |   |                                                    |   |   |
-//  |   |   |              +----------------------+              |   |   |
-//  |   |   |              |        Bridge        |              |   |   |
-//  |   |   |              |  (L2 NI: external)   |              |   |   |
-//  |   |   |              |  (L3 NI: managed)    |              |   |   |
-//  |   |   |              +----------------------+              |   |   |
+//  |   |   |   +----------------------+    +----------------+   |   |   |
+//  |   |   |   |        Bridge        |    |  BridgePort    |   |   |   |
+//  |   |   |   |  (L2 NI: external)   |    |  (for uplink)  |   |   |   |
+//  |   |   |   |  (L3 NI: managed)    |    +----------------+   |   |   |
+//  |   |   |   +----------------------+                         |   |   |
 //  |   |   |                                                    |   |   |
 //  |   |   |      +---------------+    +-----------------+      |   |   |
 //  |   |   |      |  VLANBridge   |    |    VLANPort     |      |   |   |
@@ -131,15 +131,15 @@ import (
 //  |   |   |           AppConn-<UUID>-<adapter-name>            |   |   |
 //  |   |   |                (one for every VIF)                 |   |   |
 //  |   |   |                                                    |   |   |
-//  |   |   |       +---------------+   +---------------+        |   |   |
-//  |   |   |       |      VIF      |   |   VLANPort    |        |   |   |
-//  |   |   |       |   (external)  |   |  (for L2 NI)  |        |   |   |
-//  |   |   |       +---------------+   +---------------+        |   |   |
+//  |   |   |       +---------------+     +--------------+       |   |   |
+//  |   |   |       |      VIF      |     |  BridgePort  |       |   |   |
+//  |   |   |       |   (external)  |     |  (for VIF)   |       |   |   |
+//  |   |   |       +---------------+     +--------------+       |   |   |
 //  |   |   |                                                    |   |   |
-//  |   |   |                    +----------+                    |   |   |
-//  |   |   |                    |  IPSet   |                    |   |   |
-//  |   |   |                    |  (eids)  |                    |   |   |
-//  |   |   |                    +----------+                    |   |   |
+//  |   |   |       +---------------+    +----------+            |   |   |
+//  |   |   |       |  VLANPort     |    |  IPSet   |            |   |   |
+//  |   |   |       |  (for L2 NI)  |    |  (eids)  |            |   |   |
+//  |   |   |       +---------------+    +----------+            |   |   |
 //  |   |   |                                                    |   |   |
 //  |   |   |   +--------------------------------------------+   |   |   |
 //  |   |   |   |                   ACLs                     |   |   |   |
@@ -469,9 +469,12 @@ func (r *LinuxNIReconciler) getIntendedNICfg(niID uuid.UUID) dg.Graph {
 	if r.nis[niID] == nil || r.nis[niID].deleted {
 		return intendedCfg
 	}
-	intendedCfg.PutSubGraph(r.getIntendedNIL2Cfg(niID))
-	intendedCfg.PutSubGraph(r.getIntendedNIL3Cfg(niID))
-	intendedCfg.PutSubGraph(r.getIntendedNIServices(niID))
+	ni := r.nis[niID]
+	if !ni.bridge.IPConflict {
+		intendedCfg.PutSubGraph(r.getIntendedNIL2Cfg(niID))
+		intendedCfg.PutSubGraph(r.getIntendedNIL3Cfg(niID))
+		intendedCfg.PutSubGraph(r.getIntendedNIServices(niID))
+	}
 	for _, app := range r.apps {
 		if app.deleted {
 			continue
@@ -553,11 +556,15 @@ func (r *LinuxNIReconciler) getIntendedNIL2Cfg(niID uuid.UUID) dg.Graph {
 			break
 		}
 	}
-	intendedL2Cfg.PutItem(linux.VLANPort{
+	intendedL2Cfg.PutItem(linux.BridgePort{
 		BridgeIfName: ni.brIfName,
-		BridgePort: linux.BridgePort{
+		Variant: linux.BridgePortVariant{
 			UplinkIfName: uplinkPhysIfName(ni.bridge.Uplink.IfName),
 		},
+	}, nil)
+	intendedL2Cfg.PutItem(linux.VLANPort{
+		BridgeIfName: ni.brIfName,
+		PortIfName:   uplinkPhysIfName(ni.bridge.Uplink.IfName),
 		VLANConfig: linux.VLANConfig{
 			TrunkPort: &trunkPort,
 		},
@@ -972,7 +979,19 @@ func (r *LinuxNIReconciler) getIntendedAppConnCfg(niID uuid.UUID,
 	intendedAppConnCfg.PutItem(generic.VIF{
 		IfName:         vif.hostIfName,
 		NetAdapterName: vif.NetAdapterName,
-		MasterIfName:   ni.brIfName,
+	}, nil)
+	if ni.bridge.IPConflict {
+		// Do not configure ACLs if we have IP conflict with an uplink port.
+		// We could block management traffic by an accident.
+		// The bridge will not be created, and VIFs will be down. Therefore, all app
+		// traffic will be dropped anyway.
+		return intendedAppConnCfg
+	}
+	intendedAppConnCfg.PutItem(linux.BridgePort{
+		BridgeIfName: ni.brIfName,
+		Variant: linux.BridgePortVariant{
+			VIFIfName: vif.hostIfName,
+		},
 	}, nil)
 	if ni.config.Type == types.NetworkInstanceTypeSwitch {
 		var vlanConfig linux.VLANConfig
@@ -985,10 +1004,8 @@ func (r *LinuxNIReconciler) getIntendedAppConnCfg(niID uuid.UUID,
 		}
 		intendedAppConnCfg.PutItem(linux.VLANPort{
 			BridgeIfName: ni.brIfName,
-			BridgePort: linux.BridgePort{
-				VIFIfName: vif.hostIfName,
-			},
-			VLANConfig: vlanConfig,
+			PortIfName:   vif.hostIfName,
+			VLANConfig:   vlanConfig,
 		}, nil)
 	}
 	// Create ipset with all the addresses from the DnsNameToIPList plus the VIF IP itself.

--- a/pkg/pillar/nireconciler/linux_currentstate.go
+++ b/pkg/pillar/nireconciler/linux_currentstate.go
@@ -337,7 +337,7 @@ func (r *LinuxNIReconciler) updateCurrentVIFs(niID uuid.UUID) (changed bool) {
 					break
 				}
 			}
-			ifIndex, found, err := r.netMonitor.GetInterfaceIndex(vif.hostIfName)
+			_, found, err := r.netMonitor.GetInterfaceIndex(vif.hostIfName)
 			if err != nil {
 				r.log.Errorf("%s: updateCurrentVIFs: failed to get ifIndex "+
 					"for (VIF) %s: %v", LogAndErrPrefix, vif.hostIfName, err)
@@ -348,30 +348,9 @@ func (r *LinuxNIReconciler) updateCurrentVIFs(niID uuid.UUID) (changed bool) {
 				changed = r.updateSingleItem(prevVIF, nil, appConnSG) || changed
 				continue
 			}
-			ifAttrs, err := r.netMonitor.GetInterfaceAttrs(ifIndex)
-			if err != nil {
-				r.log.Errorf(
-					"%s: updateCurrentVIFs: failed to get interface %s "+
-						"(VIF) attributes: %v", LogAndErrPrefix, vif.hostIfName, err)
-				changed = r.updateSingleItem(prevVIF, nil, appConnSG) || changed
-				continue
-			}
-			var masterIfName string
-			if ifAttrs.Enslaved {
-				masterIfAttrs, err := r.netMonitor.GetInterfaceAttrs(ifAttrs.MasterIfIndex)
-				if err != nil {
-					r.log.Errorf("%s: updateCurrentVIFs: failed to get attrs "+
-						"for interface %s master (ifIndex: %d): %v",
-						LogAndErrPrefix, vif.hostIfName, ifAttrs.MasterIfIndex, err)
-					// Continue as if this VIF interface didn't have master...
-				} else {
-					masterIfName = masterIfAttrs.IfName
-				}
-			}
 			newVIF := generic.VIF{
 				IfName:         vif.hostIfName,
 				NetAdapterName: vif.NetAdapterName,
-				MasterIfName:   masterIfName,
 			}
 			changed = r.updateSingleItem(prevVIF, newVIF, appConnSG) || changed
 		}

--- a/pkg/pillar/nireconciler/linux_reconciler.go
+++ b/pkg/pillar/nireconciler/linux_reconciler.go
@@ -1055,10 +1055,13 @@ func (r *LinuxNIReconciler) getSubgraphState(intSG, currSG dg.GraphR, forApp boo
 		if item.Type() == generic.VIFTypename {
 			return true
 		}
-		if item.Type() == linux.VLANPortTypename {
-			if item.(linux.VLANPort).BridgePort.VIFIfName != "" {
+		if item.Type() == linux.BridgePortTypename {
+			if item.(linux.BridgePort).Variant.VIFIfName != "" {
 				return true
 			}
+		}
+		if item.Type() == linux.VLANPortTypename {
+			return true
 		}
 		return false
 	}

--- a/pkg/pillar/nireconciler/linux_test.go
+++ b/pkg/pillar/nireconciler/linux_test.go
@@ -1279,14 +1279,13 @@ func TestIPv4LocalAndSwitchNIs(test *testing.T) {
 	t.Expect(recUpdate.UpdateType).To(Equal(nirec.AppConnReconcileStatusChanged))
 	t.Expect(recUpdate.AppConnStatus.Equal(appStatus)).To(BeTrue())
 
-	// Simulate domainmgr creating all VIFs, but VIF3 will not be bridged yet.
+	// Simulate domainmgr creating all VIFs.
 	networkMonitor.AddOrUpdateInterface(app2VIF1)
 	t.Eventually(updatesCh).Should(Receive(&recUpdate))
 	t.Expect(recUpdate.UpdateType).To(Equal(nirec.CurrentStateChanged))
 	networkMonitor.AddOrUpdateInterface(app2VIF2)
 	t.Eventually(updatesCh).Should(Receive(&recUpdate))
 	t.Expect(recUpdate.UpdateType).To(Equal(nirec.CurrentStateChanged))
-	app2VIF3.Attrs.Enslaved = false
 	networkMonitor.AddOrUpdateInterface(app2VIF3)
 	t.Eventually(updatesCh).Should(Receive(&recUpdate))
 	t.Expect(recUpdate.UpdateType).To(Equal(nirec.CurrentStateChanged))
@@ -1295,11 +1294,7 @@ func TestIPv4LocalAndSwitchNIs(test *testing.T) {
 	t.Eventually(updatesCh).Should(Receive(&recUpdate))
 	t.Expect(recUpdate.UpdateType).To(Equal(nirec.AppConnReconcileStatusChanged))
 	for i := 0; i < 3; i++ {
-		if i < 2 {
-			t.Expect(recUpdate.AppConnStatus.VIFs[i].InProgress).To(BeFalse())
-		} else {
-			t.Expect(recUpdate.AppConnStatus.VIFs[i].InProgress).To(BeTrue())
-		}
+		t.Expect(recUpdate.AppConnStatus.VIFs[i].InProgress).To(BeFalse())
 		t.Expect(recUpdate.AppConnStatus.VIFs[i].FailedItems).To(BeEmpty())
 	}
 
@@ -1319,39 +1314,18 @@ func TestIPv4LocalAndSwitchNIs(test *testing.T) {
 	t.Expect(itemIsCreated(dg.Reference(
 		linuxitems.VLANPort{
 			BridgeIfName: "bn1",
-			BridgePort: linuxitems.BridgePort{
-				VIFIfName: "nbu1x2",
-			}}))).To(BeFalse())
+			PortIfName:   "nbu1x2",
+		}))).To(BeFalse())
 	t.Expect(itemIsCreated(dg.Reference(
 		linuxitems.VLANPort{
 			BridgeIfName: "eth1",
-			BridgePort: linuxitems.BridgePort{
-				VIFIfName: "nbu2x2",
-			}}))).To(BeTrue())
+			PortIfName:   "nbu2x2",
+		}))).To(BeTrue())
 	t.Expect(itemIsCreated(dg.Reference(
 		linuxitems.VLANPort{
 			BridgeIfName: "eth1",
-			BridgePort: linuxitems.BridgePort{
-				VIFIfName: "nbu3x2",
-			}}))).To(BeFalse())
-
-	// Now VIF3 is bridged as well
-	app2VIF3.Attrs.Enslaved = true
-	networkMonitor.AddOrUpdateInterface(app2VIF3)
-	t.Eventually(updatesCh).Should(Receive(&recUpdate))
-	t.Expect(recUpdate.UpdateType).To(Equal(nirec.CurrentStateChanged))
-	niReconciler.ResumeReconcile(ctx)
-
-	t.Eventually(updatesCh).Should(Receive(&recUpdate))
-	t.Expect(recUpdate.UpdateType).To(Equal(nirec.AppConnReconcileStatusChanged))
-	t.Expect(recUpdate.AppConnStatus.VIFs[2].InProgress).To(BeFalse())
-
-	t.Expect(itemIsCreated(dg.Reference(
-		linuxitems.VLANPort{
-			BridgeIfName: "eth1",
-			BridgePort: linuxitems.BridgePort{
-				VIFIfName: "nbu2x2",
-			}}))).To(BeTrue())
+			PortIfName:   "nbu3x2",
+		}))).To(BeTrue())
 
 	vif2Eidset := itemDescription(dg.Reference(linuxitems.IPSet{SetName: "ipv4.eids.nbu2x2"}))
 	t.Expect(vif2Eidset).To(ContainSubstring("entries: []"))
@@ -1679,9 +1653,7 @@ func TestIPv6LocalAndSwitchNIs(test *testing.T) {
 
 	vif2VLAN := linuxitems.VLANPort{
 		BridgeIfName: "eth2",
-		BridgePort: linuxitems.BridgePort{
-			VIFIfName: "nbu2x3",
-		},
+		PortIfName:   "nbu2x3",
 	}
 	t.Expect(itemIsCreated(dg.Reference(vif2VLAN))).To(BeTrue())
 	t.Expect(itemDescription(dg.Reference(vif2VLAN))).To(ContainSubstring(
@@ -1931,20 +1903,15 @@ func TestAirGappedLocalAndSwitchNIs(test *testing.T) {
 	t.Expect(itemIsCreated(dg.Reference(
 		linuxitems.VLANPort{
 			BridgeIfName: "bn1",
-			BridgePort: linuxitems.BridgePort{
-				VIFIfName: "nbu1x2",
-			}}))).To(BeFalse())
+			PortIfName:   "nbu1x2",
+		}))).To(BeFalse())
 	vif2VLANPort := linuxitems.VLANPort{
 		BridgeIfName: "bn2",
-		BridgePort: linuxitems.BridgePort{
-			VIFIfName: "nbu2x2",
-		},
+		PortIfName:   "nbu2x2",
 	}
 	vif3VLANPort := linuxitems.VLANPort{
 		BridgeIfName: "bn2",
-		BridgePort: linuxitems.BridgePort{
-			VIFIfName: "nbu3x2",
-		},
+		PortIfName:   "nbu3x2",
 	}
 	t.Expect(itemDescription(dg.Reference(vif2VLANPort))).To(ContainSubstring(
 		"accessPort: {vid: 10}"))

--- a/pkg/pillar/nireconciler/linuxitems/bridgeport.go
+++ b/pkg/pillar/nireconciler/linuxitems/bridgeport.go
@@ -1,0 +1,227 @@
+// Copyright (c) 2024 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package linuxitems
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	dg "github.com/lf-edge/eve/libs/depgraph"
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/netmonitor"
+	generic "github.com/lf-edge/eve/pkg/pillar/nireconciler/genericitems"
+	"github.com/vishvananda/netlink"
+)
+
+// BridgePort : network interface added into a Linux bridge.
+type BridgePort struct {
+	// BridgeIfName : interface name of the bridge.
+	BridgeIfName string
+	// Variant : port should be one of the supported variants.
+	Variant BridgePortVariant
+}
+
+// BridgePortVariant is like union, only one option should have non-zero value.
+type BridgePortVariant struct {
+	// UplinkIfName : bridged uplink interface.
+	UplinkIfName string
+	// VIFIfName : bridged VIF.
+	VIFIfName string
+}
+
+// Name returns the interface name of the bridged port
+func (p BridgePort) Name() string {
+	return p.portIfName()
+}
+
+// Label for VLANPort.
+func (p BridgePort) Label() string {
+	return p.portIfName() + " (bridge port)"
+}
+
+// Type of the item.
+func (p BridgePort) Type() string {
+	return BridgePortTypename
+}
+
+// Equal compares two BridgePort instances.
+func (p BridgePort) Equal(other dg.Item) bool {
+	p2, isBridgePort := other.(BridgePort)
+	if !isBridgePort {
+		return false
+	}
+	return p == p2
+}
+
+// External returns false.
+func (p BridgePort) External() bool {
+	return false
+}
+
+// String describes BridgePort.
+func (p BridgePort) String() string {
+	return fmt.Sprintf("BridgePort: {bridgeIfName: %s, portIfName: %s}",
+		p.BridgeIfName, p.portIfName())
+}
+
+// Dependencies returns the bridge and the port as the dependencies.
+func (p BridgePort) Dependencies() (deps []dg.Dependency) {
+	deps = append(deps, dg.Dependency{
+		RequiredItem: dg.ItemRef{
+			ItemType: BridgeTypename,
+			ItemName: p.BridgeIfName,
+		},
+		Description: "Bridge must exist",
+	})
+	if p.Variant.VIFIfName != "" {
+		deps = append(deps, dg.Dependency{
+			RequiredItem: dg.ItemRef{
+				ItemType: generic.VIFTypename,
+				ItemName: p.Variant.VIFIfName,
+			},
+			Description: "VIF must exist",
+			Attributes: dg.DependencyAttributes{
+				AutoDeletedByExternal: true,
+			},
+		})
+	} else if p.Variant.UplinkIfName != "" {
+		deps = append(deps, dg.Dependency{
+			RequiredItem: dg.ItemRef{
+				ItemType: generic.UplinkTypename,
+				ItemName: p.Variant.UplinkIfName,
+			},
+			MustSatisfy: func(item dg.Item) bool {
+				uplink, isUplink := item.(generic.Uplink)
+				if !isUplink {
+					// unreachable
+					return false
+				}
+				// Bridging is actually done by NIM for uplink interfaces.
+				// BridgePort is only used for dependency purposes in this case
+				// (VLANPort depends on BridgePort).
+				return uplink.MasterIfName == p.BridgeIfName
+			},
+			Description: "Uplink must exist and it must be bridged (by NIM)",
+			Attributes: dg.DependencyAttributes{
+				AutoDeletedByExternal: true,
+			},
+		})
+	}
+	return deps
+}
+
+func (p BridgePort) portIfName() string {
+	if p.Variant.VIFIfName != "" {
+		return p.Variant.VIFIfName
+	}
+	if p.Variant.UplinkIfName != "" {
+		return p.Variant.UplinkIfName
+	}
+	return ""
+}
+
+// BridgePortConfigurator implements Configurator interface (libs/reconciler)
+// for Linux bridge port.
+type BridgePortConfigurator struct {
+	Log            *base.LogObject
+	NetworkMonitor netmonitor.NetworkMonitor
+}
+
+// Create attaches port to a bridge.
+func (c *BridgePortConfigurator) Create(ctx context.Context, item dg.Item) error {
+	bridgePort, isBridgePort := item.(BridgePort)
+	if !isBridgePort {
+		return fmt.Errorf("invalid item type %T, expected BridgePort", item)
+	}
+	if bridgePort.Variant.UplinkIfName != "" {
+		// NOOP for uplink - NIM is responsible for bridging uplink ports.
+		return nil
+	}
+	link, err := netlink.LinkByName(bridgePort.portIfName())
+	if err != nil {
+		err = fmt.Errorf("failed to get link for interface %s: %w",
+			bridgePort.portIfName(), err)
+		c.Log.Error(err)
+		return err
+	}
+	bridge, err := netlink.LinkByName(bridgePort.BridgeIfName)
+	if err != nil {
+		err = fmt.Errorf("failed to get link for bridge %s: %w",
+			bridgePort.BridgeIfName, err)
+		c.Log.Error(err)
+		return err
+	}
+	err = netlink.LinkSetUp(link)
+	if err != nil {
+		err = fmt.Errorf("failed to set interface %s UP: %w",
+			bridgePort.portIfName(), err)
+		c.Log.Error(err)
+		return err
+	}
+	err = netlink.LinkSetMaster(link, bridge)
+	if err != nil {
+		err = fmt.Errorf("failed to attach interface %s to bridge %s: %w",
+			bridgePort.portIfName(), bridgePort.BridgeIfName, err)
+		c.Log.Error(err)
+		return err
+	}
+	return nil
+}
+
+// Modify is not implemented.
+func (c *BridgePortConfigurator) Modify(ctx context.Context, oldItem, newItem dg.Item) (err error) {
+	return errors.New("not implemented")
+}
+
+// Delete detaches port from the bridge.
+func (c *BridgePortConfigurator) Delete(ctx context.Context, item dg.Item) (err error) {
+	defer func() {
+		if err != nil {
+			var linkNotFound netlink.LinkNotFoundError
+			if errors.As(err, &linkNotFound) {
+				// (VIF) Port was already removed (by hypervisor),
+				// but we have not yet received netlink notification about the deletion.
+				// Ignore the error.
+				err = nil
+				return
+			}
+		}
+	}()
+	bridgePort, isBridgePort := item.(BridgePort)
+	if !isBridgePort {
+		return fmt.Errorf("invalid item type %T, expected BridgePort", item)
+	}
+	if bridgePort.Variant.UplinkIfName != "" {
+		// NOOP for uplink - NIM is responsible for bridging uplink ports.
+		return nil
+	}
+	link, err := netlink.LinkByName(bridgePort.portIfName())
+	if err != nil {
+		err = fmt.Errorf("failed to get link for interface %s: %w",
+			bridgePort.portIfName(), err)
+		c.Log.Error(err)
+		return err
+	}
+	err = netlink.LinkSetNoMaster(link)
+	if err != nil {
+		err = fmt.Errorf("failed to detach interface %s from bridge %s: %w",
+			bridgePort.portIfName(), bridgePort.BridgeIfName, err)
+		c.Log.Error(err)
+		return err
+	}
+	err = netlink.LinkSetDown(link)
+	if err != nil {
+		err = fmt.Errorf("failed to set interface %s DOWN: %w",
+			bridgePort.portIfName(), err)
+		c.Log.Error(err)
+		return err
+	}
+	return nil
+}
+
+// NeedsRecreate returns true - Modify is not implemented.
+func (c *BridgePortConfigurator) NeedsRecreate(oldItem, newItem dg.Item) (recreate bool) {
+	return true
+}

--- a/pkg/pillar/nireconciler/linuxitems/registry.go
+++ b/pkg/pillar/nireconciler/linuxitems/registry.go
@@ -19,6 +19,7 @@ func RegisterItems(log *base.LogObject, registry *reconciler.DefaultRegistry,
 	}
 	configurators := []configurator{
 		{c: &BridgeConfigurator{Log: log}, t: BridgeTypename},
+		{c: &BridgePortConfigurator{Log: log}, t: BridgePortTypename},
 		{c: &DummyIfConfigurator{Log: log}, t: DummyIfTypename},
 		{c: &IPRuleConfigurator{Log: log}, t: IPRuleTypename},
 		{c: &IPSetConfigurator{Log: log}, t: generic.IPSetTypename},

--- a/pkg/pillar/nireconciler/linuxitems/typenames.go
+++ b/pkg/pillar/nireconciler/linuxitems/typenames.go
@@ -8,6 +8,8 @@ const (
 	IPRuleTypename = "IPRule"
 	// BridgeTypename : typename for Linux bridges.
 	BridgeTypename = "Bridge"
+	// BridgePortTypename : typename for network interface added into a Linux bridge.
+	BridgePortTypename = "BridgePort"
 	// DummyIfTypename : typename for Linux dummy interface.
 	DummyIfTypename = "DummyInterface"
 	// VLANBridgeTypename : typename for (Linux bridge) enabled for VLANs.

--- a/pkg/pillar/nireconciler/nireconciler.go
+++ b/pkg/pillar/nireconciler/nireconciler.go
@@ -97,6 +97,13 @@ type NIBridge struct {
 	// Uplink interface selected for this network instance.
 	// Zero value if network instance is air-gapped.
 	Uplink Uplink
+	// IPConflict is used to mark (Local) NI with IP subnet that overlaps with the network
+	// of one of the uplink ports.
+	// Currently, for conflicting NI, NIReconciler keeps only app VIFs configured, and even
+	// they are in the DOWN state to prevent any traffic getting through.
+	// In the future, we may improve isolation between NIs and uplinks using advanced
+	// policy-based routing or VRFs. This will enable conflicting NIs to remain functional.
+	IPConflict bool
 }
 
 // Uplink used by a network instance to provide external connectivity for applications.

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -2608,7 +2608,10 @@ type NetworkInstanceStatus struct {
 	Activate uint64
 
 	ChangeInProgress ChangeInProgressType
-	NIConflict       bool // True if config conflicts with another NI
+
+	// True if NI IP subnet overlaps with the subnet of one the device ports
+	// or another NI.
+	IPConflict bool
 
 	// Activated is true if the network instance has been created in the network stack.
 	Activated bool

--- a/pkg/pillar/utils/ip.go
+++ b/pkg/pillar/utils/ip.go
@@ -34,3 +34,13 @@ func SameIPVersions(ip1, ip2 net.IP) bool {
 	secondIsV4 := ip2.To4() != nil
 	return firstIsV4 == secondIsV4
 }
+
+// OverlappingSubnets returns true if the given subnets share at least one IP address.
+func OverlappingSubnets(subnet1, subnet2 *net.IPNet) bool {
+	if subnet1 == nil || len(subnet1.IP) == 0 ||
+		subnet2 == nil || len(subnet2.IP) == 0 {
+		// One of the subnets or both are undefined.
+		return false
+	}
+	return subnet1.Contains(subnet2.IP) || subnet2.Contains(subnet1.IP)
+}


### PR DESCRIPTION
Zedrouter is able to detect if NI IP subnet overlaps with the subnet of another NI or with a device port network. When a conflict is detected for a new NI, it is blocked from being created. If IP conflict arises for an already created NI (e.g. a device port later received IP from an overlapping subnet), the NI is unconfigured and VIFs are set DOWN (not deleted). In both cases an error is reported for the NI.

This is crucial because, previously, an NI with a subnet overlapping with a device port network would result in the device permanently losing controller connectivity (due to routing conflicts), with very limited options to restore connectivity and make the device manageable again. Instead, the device should remain online, inform the user about the issue, and allow to correct the IP configuration.

When IP conflict is detected for an already created NI with an app connected to it, we intentionally do not halt and undeploy the app. Instead, the app is left running, just VIFs connected to the problematic NI lose their connectivity. This allows the user to fix the network config or at least backup the application data when IP conflict arises.

To enable the deletion of NI when an IP conflict is detected, followed by its later recreation when the conflict is resolved, and to reconnect already running apps, few enhancements had to be made to the NI Reconciler, particularly in the area of VIF bridging.

(cherry picked from commit f868941b2fd32aa6337d58afa985f4a75fd2b6f0)