### PR TITLE
Pass the KubeImageName to domainmgr

### DIFF
--- a/pkg/pillar/cmd/zedmanager/handledomainmgr.go
+++ b/pkg/pillar/cmd/zedmanager/handledomainmgr.go
@@ -61,7 +61,9 @@ func MaybeAddDomainConfig(ctx *zedmanagerContext,
 			continue
 		}
 		location := vrs.ActiveFileLocation
-		if location == "" {
+		// Volumes in kubevirt eve are of PVC type and managed by kubernetes.
+		// There is no specific filelocation
+		if location == "" && !ctx.hvTypeKube {
 			errStr := fmt.Sprintf("No ActiveFileLocation for %s", vrs.DisplayName)
 			log.Error(errStr)
 			return nil, errors.New(errStr)
@@ -77,6 +79,12 @@ func MaybeAddDomainConfig(ctx *zedmanagerContext,
 		disk.Target = vrs.Target
 		disk.CustomMeta = vrs.CustomMeta
 		dc.DiskConfigList = append(dc.DiskConfigList, disk)
+		// For kubevirt eve native containers (NOHYPER) we need set the KubeImageName in domainconfig
+		// pods will be launched using that KubeImageName
+		if aiConfig.FixedResources.VirtualizationMode == types.NOHYPER && ctx.hvTypeKube {
+			dc.VirtualizationMode = types.NOHYPER
+			dc.KubeImageName = vrs.ReferenceName
+		}
 	}
 	// let's fill some of the default values (arguably we may want controller
 	// to do this for us and give us complete config, but it is easier to
@@ -150,12 +158,12 @@ func lookupDomainStatus(ctx *zedmanagerContext, key string) *types.DomainStatus 
 }
 
 func publishDomainConfig(ctx *zedmanagerContext,
-	status *types.DomainConfig) {
+	config *types.DomainConfig) {
 
-	key := status.Key()
+	key := config.Key()
 	log.Tracef("publishDomainConfig(%s)", key)
 	pub := ctx.pubDomainConfig
-	pub.Publish(key, *status)
+	pub.Publish(key, *config)
 }
 
 func unpublishDomainConfig(ctx *zedmanagerContext, uuidStr string) {

--- a/pkg/pillar/cmd/zedmanager/handledomainmgr.go
+++ b/pkg/pillar/cmd/zedmanager/handledomainmgr.go
@@ -79,9 +79,10 @@ func MaybeAddDomainConfig(ctx *zedmanagerContext,
 		disk.Target = vrs.Target
 		disk.CustomMeta = vrs.CustomMeta
 		dc.DiskConfigList = append(dc.DiskConfigList, disk)
-		// For kubevirt eve native containers (NOHYPER) we need set the KubeImageName in domainconfig
-		// pods will be launched using that KubeImageName
-		if aiConfig.FixedResources.VirtualizationMode == types.NOHYPER && ctx.hvTypeKube {
+		// For NOHYPER type virtualization mode pass the KubeImageName to domainmgr
+		// pods will be launched using that KubeImageName in kubevirt eve
+		// Reference name can be empty for non-kubevirt eve and KubeImageName will be ignored in such cases.
+		if aiConfig.FixedResources.VirtualizationMode == types.NOHYPER {
 			dc.VirtualizationMode = types.NOHYPER
 			dc.KubeImageName = vrs.ReferenceName
 		}

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -74,6 +74,8 @@ type zedmanagerContext struct {
 	// hypervisorPtr is the name of the hypervisor to use
 	hypervisorPtr      *string
 	assignableAdapters *types.AssignableAdapters
+	// Is it kubevirt eve
+	hvTypeKube bool
 }
 
 // AddAgentSpecificCLIFlags adds CLI options
@@ -93,6 +95,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	// Any state needed by handler functions
 	ctx := zedmanagerContext{
 		globalConfig: types.DefaultConfigItemValueMap(),
+		hvTypeKube:   base.IsHVTypeKube(),
 	}
 	agentbase.Init(&ctx, logger, log, agentName,
 		agentbase.WithArguments(arguments))

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -38,6 +38,9 @@ type DomainConfig struct {
 	DiskConfigList []DiskConfig
 	VifList        []VifConfig
 	IoAdapterList  []IoAdapter
+	// KubeImageName is the container image reference we pass to domainmgr to launch a native container
+	// in kubevirt eve
+	KubeImageName string
 
 	// XXX: to be deprecated, use CipherBlockStatus instead
 	CloudInitUserData *string `json:"pubsub-large-CloudInitUserData"` // base64-encoded


### PR DESCRIPTION
If in the app manifest HV is set to NOHYPER and the eve flavor is kubevirt we set the KubeImageName in the domainconfig to the volumereference name

domainmgr will use that to start pods (native containers)