### PR TITLE
Publish HvTypeKubevirt optional capabilities to controller

### DIFF
--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -630,6 +630,7 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext, dest destinationBitset) {
 	ReportDeviceInfo.RebootInprogress = ctx.rebootCmd || ctx.deviceReboot
 
 	ReportDeviceInfo.Capabilities = getCapabilities(ctx)
+	ReportDeviceInfo.OptionalCapabilities = getOptionalCapabilities(ctx)
 
 	devState := getDeviceState(ctx)
 	if ctx.devState != devState {
@@ -1259,6 +1260,12 @@ func getCapabilities(ctx *zedagentContext) *info.Capabilities {
 	return &info.Capabilities{
 		HWAssistedVirtualization: capabilities.HWAssistedVirtualization,
 		IOVirtualization:         capabilities.IOVirtualization,
+	}
+}
+
+func getOptionalCapabilities(ctx *zedagentContext) *info.OptionalCapabilities {
+	return &info.OptionalCapabilities{
+		HvTypeKubevirt: ctx.hvTypeKube,
 	}
 }
 

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -230,6 +230,9 @@ type zedagentContext struct {
 	fatalPtr    *bool
 	hangPtr     *bool
 
+	// Is Kubevirt eve
+	hvTypeKube bool
+
 	// Netdump
 	netDumper            *netdump.NetDumper // nil if netdump is disabled
 	netdumpInterval      time.Duration
@@ -608,6 +611,7 @@ func (zedagentCtx *zedagentContext) init() {
 
 	attestCtx.zedagentCtx = zedagentCtx
 	zedagentCtx.attestCtx = attestCtx
+	zedagentCtx.hvTypeKube = base.IsHVTypeKube()
 }
 
 func initializeDirs() {


### PR DESCRIPTION
eve info api publishes OptionalCapabilities to the controller. HvTypeKubevirt is one of the fields which specifies if the device supports kubevirt virtualization. On kubevirt eve setting that field to true