### PR TITLE
Forbid traffic forwarding between device network ports

### DIFF
--- a/pkg/pillar/dpcreconciler/linux.go
+++ b/pkg/pillar/dpcreconciler/linux.go
@@ -1474,6 +1474,7 @@ func (r *LinuxDpcReconciler) getIntendedACLs(
 		{Table: "filter", ChainName: "INPUT"}:       {devACLs: true, appACLs: true},
 		{Table: "filter", ChainName: "FORWARD"}:     {devACLs: false, appACLs: true},
 		{Table: "mangle", ChainName: "PREROUTING"}:  {devACLs: true, appACLs: true},
+		{Table: "mangle", ChainName: "FORWARD"}:     {devACLs: true, appACLs: false},
 		{Table: "mangle", ChainName: "POSTROUTING"}: {devACLs: false, appACLs: true},
 		{Table: "mangle", ChainName: "OUTPUT"}:      {devACLs: true, appACLs: false},
 		{Table: "nat", ChainName: "PREROUTING"}:     {devACLs: false, appACLs: true},
@@ -1647,35 +1648,35 @@ func (r *LinuxDpcReconciler) getIntendedACLs(
 		RuleLabel:   "SSH and Guacamole mark",
 		MatchOpts:   []string{"-p", "tcp", "--match", "multiport", "--dports", "22,4822"},
 		Target:      "CONNMARK",
-		TargetOpts:  []string{"--set-mark", iptables.ControlProtocolMarkingIDMap["in_http_ssh_guacamole"]},
+		TargetOpts:  []string{"--set-mark", controlProtoMark("in_http_ssh_guacamole")},
 		Description: "Mark ingress SSH and Guacamole traffic",
 	}
 	markVnc := iptables.Rule{
 		RuleLabel:   "VNC mark",
 		MatchOpts:   []string{"-p", "tcp", "--match", "multiport", "--dports", "5900:5999"},
 		Target:      "CONNMARK",
-		TargetOpts:  []string{"--set-mark", iptables.ControlProtocolMarkingIDMap["in_vnc"]},
+		TargetOpts:  []string{"--set-mark", controlProtoMark("in_vnc")},
 		Description: "Mark ingress VNC traffic",
 	}
 	markIcmpV4 := iptables.Rule{
 		RuleLabel:   "ICMP mark",
 		MatchOpts:   []string{"-p", "icmp"},
 		Target:      "CONNMARK",
-		TargetOpts:  []string{"--set-mark", iptables.ControlProtocolMarkingIDMap["in_icmp"]},
+		TargetOpts:  []string{"--set-mark", controlProtoMark("in_icmp")},
 		Description: "Mark ingress ICMP traffic",
 	}
 	markIcmpV6 := iptables.Rule{
 		RuleLabel:   "ICMPv6 traffic",
 		MatchOpts:   []string{"-p", "icmpv6"},
 		Target:      "CONNMARK",
-		TargetOpts:  []string{"--set-mark", iptables.ControlProtocolMarkingIDMap["in_icmp"]},
+		TargetOpts:  []string{"--set-mark", controlProtoMark("in_icmp")},
 		Description: "Mark ingress ICMPv6 traffic",
 	}
 	markDhcp := iptables.Rule{
 		RuleLabel:   "DHCP mark",
 		MatchOpts:   []string{"-p", "udp", "--dport", "bootps:bootpc"},
 		Target:      "CONNMARK",
-		TargetOpts:  []string{"--set-mark", iptables.ControlProtocolMarkingIDMap["in_dhcp"]},
+		TargetOpts:  []string{"--set-mark", controlProtoMark("in_dhcp")},
 		Description: "Mark ingress DHCP traffic",
 	}
 	// Allow kubernetes DNS replies from an external server.
@@ -1685,7 +1686,7 @@ func (r *LinuxDpcReconciler) getIntendedACLs(
 		RuleLabel:   "Incoming DNS replies",
 		MatchOpts:   []string{"-p", "udp", "--sport", "domain"},
 		Target:      "CONNMARK",
-		TargetOpts:  []string{"--set-mark", iptables.ControlProtocolMarkingIDMap["in_dns"]},
+		TargetOpts:  []string{"--set-mark", controlProtoMark("in_dns")},
 		Description: "Incoming DNS replies (used to allow kubernetes DNS replies from external server)",
 	}
 
@@ -1698,6 +1699,40 @@ func (r *LinuxDpcReconciler) getIntendedACLs(
 	protoMarkV6Rules := []iptables.Rule{
 		markSSHAndGuacamole, markVnc, markIcmpV6,
 	}
+
+	// Do not overwrite mark that was already added be rules from zedrouter
+	// for application traffic.
+	skipMarkedFlowRule := iptables.Rule{
+		RuleLabel: "Skip marked ingress",
+		ChainName: "PREROUTING" + iptables.DeviceChainSuffix,
+		Table:     "mangle",
+		MatchOpts: []string{"-m", "mark", "!", "--mark", "0"},
+		Target:    "RETURN",
+	}
+	for _, markV4Rule := range protoMarkV4Rules {
+		skipMarkedFlowRule.AppliedBefore = append(skipMarkedFlowRule.AppliedBefore,
+			markV4Rule.RuleLabel)
+	}
+	intendedIPv4ACLs.PutItem(skipMarkedFlowRule, nil)
+	restoreConnmarkRule := iptables.Rule{
+		RuleLabel:     "Restore ingress mark",
+		ChainName:     "PREROUTING" + iptables.DeviceChainSuffix,
+		Table:         "mangle",
+		Target:        "CONNMARK",
+		TargetOpts:    []string{"--restore-mark"},
+		AppliedBefore: []string{skipMarkedFlowRule.RuleLabel},
+	}
+	intendedIPv4ACLs.PutItem(restoreConnmarkRule, nil)
+	// The same for IPv6:
+	skipMarkedFlowRule.ForIPv6 = true
+	skipMarkedFlowRule.AppliedBefore = nil
+	for _, markV6Rule := range protoMarkV6Rules {
+		skipMarkedFlowRule.AppliedBefore = append(skipMarkedFlowRule.AppliedBefore,
+			markV6Rule.RuleLabel)
+	}
+	intendedIPv6ACLs.PutItem(skipMarkedFlowRule, nil)
+	restoreConnmarkRule.ForIPv6 = true
+	intendedIPv6ACLs.PutItem(restoreConnmarkRule, nil)
 
 	// Mark ingress traffic not matched by the rules above with the DROP action.
 	// Create a separate chain for marking.
@@ -1712,7 +1747,7 @@ func (r *LinuxDpcReconciler) getIntendedACLs(
 		Table:     "mangle",
 		ForIPv6:   true,
 	}, nil)
-	ingressDefDrop := iptables.GetConnmark(0, iptables.DefaultDropAceID, true)
+	ingressDefDrop := iptables.GetConnmark(0, iptables.DefaultDropAceID, false, true)
 	ingressDefDropStr := strconv.FormatUint(uint64(ingressDefDrop), 10)
 	ingressDefDropRules := []iptables.Rule{
 		{
@@ -1791,6 +1826,24 @@ func (r *LinuxDpcReconciler) getIntendedACLs(
 		intendedIPv6ACLs.PutItem(markRule, nil)
 	}
 
+	// Deny traffic forwarding between device ports (e.g. from eth0 to eth1).
+	// Simply drop all non-application forwarded traffic.
+	// Zero application mark means that the matched flow is not from/to application.
+	nonAppMark := fmt.Sprintf("0/%d", iptables.AppIDMask)
+	denyNonAppForwarding := iptables.Rule{
+		RuleLabel: "Drop traffic forwarded between ports",
+		Table:     "mangle",
+		ChainName: "FORWARD" + iptables.DeviceChainSuffix,
+		MatchOpts: []string{"--match", "connmark", "--mark", nonAppMark},
+		Target:    "DROP",
+		Description: "Rule to ensure that forwarding between device ports is not allowed " +
+			"(device cannot be used as a router to hop from one network to another)",
+	}
+	denyNonAppForwarding.ForIPv6 = false
+	intendedIPv4ACLs.PutItem(denyNonAppForwarding, nil)
+	denyNonAppForwarding.ForIPv6 = true
+	intendedIPv6ACLs.PutItem(denyNonAppForwarding, nil)
+
 	// Mark all un-marked local traffic generated by local services.
 	outputRules := []iptables.Rule{
 		{
@@ -1806,7 +1859,7 @@ func (r *LinuxDpcReconciler) getIntendedACLs(
 		{
 			RuleLabel:  "Default egress mark",
 			Target:     "MARK",
-			TargetOpts: []string{"--set-mark", iptables.ControlProtocolMarkingIDMap["out_all"]},
+			TargetOpts: []string{"--set-mark", controlProtoMark("out_all")},
 		},
 		{
 			RuleLabel:  "Save egress mark",
@@ -1827,4 +1880,9 @@ func (r *LinuxDpcReconciler) getIntendedACLs(
 		intendedIPv6ACLs.PutItem(outputRule, nil)
 	}
 	return intendedACLs
+}
+
+func controlProtoMark(protoName string) string {
+	mark := iptables.ControlProtocolMarkingIDMap[protoName]
+	return strconv.FormatUint(uint64(mark), 10)
 }

--- a/pkg/pillar/dpcreconciler/linux_test.go
+++ b/pkg/pillar/dpcreconciler/linux_test.go
@@ -156,10 +156,10 @@ func TestReconcileWithEmptyArgs(test *testing.T) {
 	t.Expect(status.DNS.Error).To(BeNil())
 	t.Expect(status.DNS.Servers).To(BeEmpty())
 	t.Expect(itemCountWithType(linux.LocalIPRuleTypename)).To(Equal(1))
-	t.Expect(itemCountWithType(iptables.ChainV4Typename)).To(Equal(11))
-	t.Expect(itemCountWithType(iptables.ChainV6Typename)).To(Equal(11))
-	t.Expect(itemCountWithType(iptables.RuleV4Typename)).To(Equal(28))
-	t.Expect(itemCountWithType(iptables.RuleV6Typename)).To(Equal(27)) // without markDhcp
+	t.Expect(itemCountWithType(iptables.ChainV4Typename)).To(Equal(12))
+	t.Expect(itemCountWithType(iptables.ChainV6Typename)).To(Equal(12))
+	t.Expect(itemCountWithType(iptables.RuleV4Typename)).To(Equal(32))
+	t.Expect(itemCountWithType(iptables.RuleV6Typename)).To(Equal(31)) // without markDhcp
 	t.Expect(itemIsCreatedWithLabel("Block SSH")).To(BeTrue())
 
 	// Enable SSH access

--- a/pkg/pillar/iptables/configitem.go
+++ b/pkg/pillar/iptables/configitem.go
@@ -35,7 +35,7 @@ var (
 	builtinChains = []string{"INPUT", "OUTPUT", "FORWARD", "PREROUTING", "POSTROUTING"}
 	// Used as a constant.
 	builtinTargets = []string{"ACCEPT", "DROP", "REJECT", "LOG", "DNAT", "SNAT",
-		"MASQUERADE", "CONNMARK", "MARK"}
+		"MASQUERADE", "CONNMARK", "MARK", "RETURN"}
 )
 
 // RegisterItems : add Items and their Configurators into the provided registry.

--- a/pkg/pillar/iptables/connmark.go
+++ b/pkg/pillar/iptables/connmark.go
@@ -7,11 +7,14 @@ package iptables
 // and which ACE was applied.
 // The 32 bits of a connmark are used as follows:
 //
-//	+------------------------+---------------+------------------+
-//	| Application ID (8bits) | Action (1bit) | ACE ID (23 bits) |
-//	+------------------------+---------------+------------------+
+//	+------------------------+---------------+-----------------+------------------+
+//	| Application ID (8bits) | Action (1bit) | User ACE (1bit) | ACE ID (22 bits) |
+//	+------------------------+---------------+-----------------+------------------+
 //
-// where: Drop action = 1; Allow action = 0
+// Where:
+//
+//	Action: 1 means to drop the flow, 0 to allow it
+//	User ACE: 1 is used for user-configured ACE, 0 for automatically added rules
 const (
 	// AppIDMask : bits of the connection mark allocated to store application ID.
 	AppIDMask = 0xff << 24
@@ -19,8 +22,10 @@ const (
 	AceActionMask = 0x1 << 23
 	// AceDropAction : bit representation of the Drop action.
 	AceDropAction = AceActionMask
+	// AceFromUser : bit value set for user-defined ACEs.
+	AceFromUser = 0x1 << 22
 	// AceIDMask : bits of the connection mark allocated to store ACE ID.
-	AceIDMask = 0x7fffff
+	AceIDMask = 0x3fffff
 	// DefaultDropAceID : by default, traffic not matched by any ACE is dropped.
 	// For this default rule we use the maximum integer value available for ACE ID.
 	DefaultDropAceID = AceIDMask
@@ -30,37 +35,41 @@ const (
 // (for implicit, i.e. not user defined, ACL rules) that we intend to use.
 // XXX It is only read from, never written to, hence no concurrency.
 // But LockedStringMap would be better.
-var ControlProtocolMarkingIDMap = map[string]string{
+var ControlProtocolMarkingIDMap = map[string]uint32{
 	// INPUT flows for HTTP, SSH & GUACAMOLE
-	"in_http_ssh_guacamole": "1",
+	"in_http_ssh_guacamole": 1,
 	// INPUT flows for VNC
-	"in_vnc": "2",
+	"in_vnc": 2,
 	// There was some feature here that used marking values "3" & "4".
 	// Marking values "3" & "4" are unused as of now.
 
 	// OUTPUT flows for all types
-	"out_all": "5",
+	"out_all": 5,
 	// App initiated UDP flows towards dom0 for DHCP
-	"app_dhcp": "6",
+	"app_dhcp": 6,
 	// App initiated TCP/UDP flows towards dom0 for DNS
-	"app_dns": "7",
+	"app_dns": 7,
 	// 8 : deprecated (previously: VPN control packets)
 	// ICMP and ICMPv6
-	"in_icmp": "9",
+	"in_icmp": 9,
 	// DHCP packets originating from outside
 	// (e.g. DHCP multicast requests from other devices on the same network)
-	"in_dhcp": "10",
+	"in_dhcp": 10,
 	// App initiated HTTP requests towards the metadata server running in dom0
-	"app_http": "11",
+	"app_http": 11,
 	// ICMPv6 traffic to and from an application
-	"app_icmpv6": "12",
+	"app_icmpv6": 12,
 	// for Kubernetes DNS, allowing coreDNS to talk to external DNS servers
-	"in_dns": "13",
+	"in_dns": 13,
 }
 
 // GetConnmark : create connection mark corresponding to the given attributes.
-func GetConnmark(appID uint8, aceID uint32, drop bool) uint32 {
-	mark := uint32(appID)<<24 | aceID
+func GetConnmark(appID uint8, aceID uint32, userAce, drop bool) uint32 {
+	mark := uint32(appID) << 24
+	mark |= aceID & AceIDMask
+	if userAce {
+		mark |= AceFromUser
+	}
 	if drop {
 		mark |= AceDropAction
 	}
@@ -68,9 +77,10 @@ func GetConnmark(appID uint8, aceID uint32, drop bool) uint32 {
 }
 
 // ParseConnmark : parse attributes stored inside a connection mark.
-func ParseConnmark(mark uint32) (appID uint8, aceID uint32, drop bool) {
+func ParseConnmark(mark uint32) (appID uint8, aceID uint32, userAce, drop bool) {
 	appID = uint8(mark >> 24)
 	aceID = mark & AceIDMask
+	userAce = (mark & AceFromUser) != 0
 	drop = (mark & AceActionMask) == AceDropAction
 	return
 }

--- a/pkg/pillar/nireconciler/linux_acl.go
+++ b/pkg/pillar/nireconciler/linux_acl.go
@@ -28,7 +28,7 @@ type essentialProto struct {
 	label          string
 	ingressMatch   []string
 	egressMatch    []string
-	mark           string
+	mark           uint32
 	markChainName  string
 	canOrigOutside bool // true if communication can be initiated from outside the edge node
 }
@@ -964,8 +964,10 @@ func (r *LinuxNIReconciler) getIntendedAppConnMangleIptables(vif vifInfo,
 			continue
 		}
 		markChain := markChainPrefix + proto.markChainName
+		mark := iptables.GetConnmark(
+			uint8(app.appNum), proto.mark, false, false)
 		if _, alreadyAdded := addedMarkChains[markChain]; !alreadyAdded {
-			items = append(items, getMarkingChainCfg(markChain, ipv6, proto.mark)...)
+			items = append(items, getMarkingChainCfg(markChain, ipv6, markToString(mark))...)
 			addedMarkChains[markChain] = struct{}{}
 		}
 		ingressRules = append(ingressRules, iptables.Rule{
@@ -996,7 +998,7 @@ func (r *LinuxNIReconciler) getIntendedAppConnMangleIptables(vif vifInfo,
 		}
 		markChain := markChainPrefix + strconv.Itoa(int(aclRule.RuleID))
 		mark := iptables.GetConnmark(
-			uint8(app.appNum), uint32(aclRule.RuleID), parsedRule.drop)
+			uint8(app.appNum), uint32(aclRule.RuleID), true, parsedRule.drop)
 		if _, alreadyAdded := addedMarkChains[markChain]; !alreadyAdded {
 			items = append(items,
 				getMarkingChainCfg(markChain, ipv6, markToString(mark))...)
@@ -1051,8 +1053,10 @@ mangleEgress:
 	// 2.1. Mark essential protocols allowed implicitly.
 	for _, proto := range essentialProtos {
 		markChain := markChainPrefix + proto.markChainName
+		mark := iptables.GetConnmark(
+			uint8(app.appNum), proto.mark, false, false)
 		if _, alreadyAdded := addedMarkChains[markChain]; !alreadyAdded {
-			items = append(items, getMarkingChainCfg(markChain, ipv6, proto.mark)...)
+			items = append(items, getMarkingChainCfg(markChain, ipv6, markToString(mark))...)
 			addedMarkChains[markChain] = struct{}{}
 		}
 		egressRules = append(egressRules, iptables.Rule{
@@ -1063,10 +1067,12 @@ mangleEgress:
 	}
 	// 2.2. Mark request from app to the metadata server
 	if !ipv6 && bridgeIP != nil {
-		httpMark := iptables.ControlProtocolMarkingIDMap["app_http"]
+		httpMark := iptables.GetConnmark(uint8(app.appNum),
+			iptables.ControlProtocolMarkingIDMap["app_http"], false, false)
 		markMetadataChain := markChainPrefix + "metadata"
 		if _, alreadyAdded := addedMarkChains[markMetadataChain]; !alreadyAdded {
-			items = append(items, getMarkingChainCfg(markMetadataChain, ipv6, httpMark)...)
+			items = append(items,
+				getMarkingChainCfg(markMetadataChain, ipv6, markToString(httpMark))...)
 			addedMarkChains[markMetadataChain] = struct{}{}
 		}
 		egressRules = append(egressRules, iptables.Rule{
@@ -1091,7 +1097,7 @@ mangleEgress:
 		}
 		markChain := markChainPrefix + strconv.Itoa(int(aclRule.RuleID))
 		mark := iptables.GetConnmark(
-			uint8(app.appNum), uint32(aclRule.RuleID), parsedRule.drop)
+			uint8(app.appNum), uint32(aclRule.RuleID), true, parsedRule.drop)
 		if _, alreadyAdded := addedMarkChains[markChain]; !alreadyAdded {
 			items = append(items,
 				getMarkingChainCfg(markChain, ipv6, markToString(mark))...)
@@ -1114,7 +1120,7 @@ mangleEgress:
 	if ni.config.Type == types.NetworkInstanceTypeLocal {
 		dropAllChain := markChainPrefix + "drop-all"
 		mark := iptables.GetConnmark(
-			uint8(app.appNum), iptables.DefaultDropAceID, true)
+			uint8(app.appNum), iptables.DefaultDropAceID, false, true)
 		items = append(items,
 			getMarkingChainCfg(dropAllChain, ipv6, markToString(mark))...)
 		defaultDropMark := iptables.Rule{

--- a/pkg/pillar/nistate/linux_flow.go
+++ b/pkg/pillar/nistate/linux_flow.go
@@ -155,10 +155,10 @@ func (lc *LinuxCollector) convertConntrackToFlow(
 	if timeOut > conntrackFlowExtraTimeout {
 		return ipFlow, true
 	}
-	appNum, aclID, drop := iptables.ParseConnmark(entry.Mark)
+	appNum, aclID, userAce, drop := iptables.ParseConnmark(entry.Mark)
 	// Only handle App related flows applied against user defined ACL rules or default
 	// drop rules.
-	if int(appNum) == 0 {
+	if int(appNum) == 0 || (!userAce && !drop) {
 		return ipFlow, true
 	}
 	vifs := lc.getVIFsByAppNum(int(appNum))


### PR DESCRIPTION
It should not be possible to take advantage of EVE device and use it as a router to hop from one network to another.

However, with out current iptables rules, EVE inadvertently allows icmp as well as tcp traffic on ports 22 (ssh), 4822 (Guacamole) and 5900-5999 (VNC) to get forwarded from one port to another. These are the protocols that we allow to be initiated from outside and enter EVE (if enabled by configuration), but we do not check if the traffic is locally destined or if it will continue out through another port.

This is obviously a security issue. Luckily, it is not so easily exploitable - for an attacker to establish connection with an endpoint in another network, the routing in the other network must be configured such that the EVE device is used as the gateway (at least for the attacker's IP). Otherwise, the returning traffic will not take the same path and most likely will not reach the attacker.

The solution in this commit is to first ensure that application traffic is always marked with app IDs (including for implicit ACL rules). Then, we can take advantage of the fact that only application traffic (non-zero app ID mark) should be allowed to be forwarded. Everything else that hits the FORWARD chain should be dropped.