### PR TITLE
Do not forget to report error severity

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -147,6 +147,7 @@ func encodeTestResults(tr types.TestResults) *info.ErrorInfo {
 	if tr.HasError() {
 		timestamp = tr.LastFailed
 		errInfo.Description = tr.LastError
+		errInfo.Severity = info.Severity_SEVERITY_ERROR
 	} else {
 		timestamp = tr.LastSucceeded
 	}

--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -88,6 +88,7 @@ func prepareAndPublishNetworkInstanceInfoMsg(ctx *zedagentContext,
 			errInfo.Description = status.Error
 			errTime, _ := ptypes.TimestampProto(status.ErrorTime)
 			errInfo.Timestamp = errTime
+			errInfo.Severity = zinfo.Severity(status.ErrorSeverity)
 			info.NetworkErr = append(info.NetworkErr, errInfo)
 			info.State = zinfo.ZNetworkInstanceState_ZNETINST_STATE_ERROR
 		} else if status.ChangeInProgress != types.ChangeInProgressTypeNone {

--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -532,6 +532,7 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext, dest destinationBitset) {
 		if ib.Error != "" {
 			errInfo := new(info.ErrorInfo)
 			errInfo.Description = ib.Error
+			errInfo.Severity = info.Severity_SEVERITY_ERROR
 			if !ib.ErrorTime.IsZero() {
 				protoTime, err := ptypes.TimestampProto(ib.ErrorTime)
 				if err == nil {


### PR DESCRIPTION
For network instances, network connectivity testing and IO bundle processing we do not really use different error severity levels at the moment. For any encountered issue we simply report an error message up to zedagent and further to the controller. However, zedagent forgets to set the severity to "error" and leaves it as unspecified. This may have unwanted effect on how the error message is treated/displayed by the controller.

Later, we could improve this and use different severity levels also for connectivity testing. For example, longer the port connectivity is down, the more severe the error reported would be (i.e. we do not immediately report failed connectivity test as "error" but start with e.g. "warning").