### PR TITLE
Kernel update - [amd64-generic, amd64-rt]

### DIFF
--- a/kernel-commits.mk
+++ b/kernel-commits.mk
@@ -1,8 +1,8 @@
 KERNEL_COMMIT_amd64_v5.10.186_generic = 37256d6aff33
-KERNEL_COMMIT_amd64_v6.1.38_generic = ae347d3a26ec
-KERNEL_COMMIT_amd64_v6.1.38_rt = fecb28161e3e
+KERNEL_COMMIT_amd64_v6.1.38_generic = ddbb9e41fa01
+KERNEL_COMMIT_amd64_v6.1.38_rt = 94c2c02bf1b9
 KERNEL_COMMIT_amd64_v6.1.68_generic = b4d7ad0a73b1
 KERNEL_COMMIT_arm64_v5.10.104_nvidia = 11760a953d2d
 KERNEL_COMMIT_arm64_v5.10.186_generic = 594f2361a83f
-KERNEL_COMMIT_arm64_v6.1.38_generic = ec65bbcdb13b
+KERNEL_COMMIT_arm64_v6.1.38_generic = 5e51e61211ea
 KERNEL_COMMIT_riscv64_v6.1.38_generic = 72192e3cbc74


### PR DESCRIPTION
eve-kernel-amd64-v6.1.38-generic
    ddbb9e41fa01: Enable AX88179 USB Ethernet driver
    7d58ae6abf66: Enable modules needed for QCOM-based PCIe cellular modems
    1652efd00f5b: Enable Intel ICE NIC driver for E800 series

eve-kernel-amd64-v6.1.38-rt
    94c2c02bf1b9: Enable modules needed for QCOM-based PCIe cellular modems

eve-kernel-arm64-v6.1.38-generic
    5e51e61211ea: Enable modules needed for QCOM-based PCIe cellular modems