### PR TITLE
Add rdfind package to Alpine

### DIFF
--- a/pkg/alpine/mirrors/3.16/community
+++ b/pkg/alpine/mirrors/3.16/community
@@ -37,6 +37,7 @@ py3-webencodings
 qemu
 qemu-img
 qemu-system-x86_64
+rdfind
 sudo
 sysstat
 tini


### PR DESCRIPTION
The latest Linux FW packages use rdfind. This commit prepares us to upgrade Linux FW to the latest version