### PR TITLE
Set Upper Memory Limit for Go Tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -397,6 +397,9 @@ test: $(LINUXKIT) test-images-patches | $(DIST)
 	cp pkg/pillar/results.xml $(DIST)/
 	$(QUIET): $@: Succeeded
 
+test-profiling:
+	make -C pkg/pillar test-profiling
+
 # wrap command into DOCKER_GO and propagate it to the pillar's Makefile
 # for example make pillar-fmt will run docker container based on
 # build-tools/src/scripts/Dockerfile
@@ -1022,6 +1025,7 @@ help:
 	@echo "Commonly used maintenance and development targets:"
 	@echo "   build-vm       prepare a build VM for EVE in qcow2 format"
 	@echo "   test           run EVE tests"
+	@echo "   test-profiling run pillar tests with memory profiler"
 	@echo "   clean          clean build artifacts in a current directory (doesn't clean Docker)"
 	@echo "   release        prepare branch for a release (VERSION=x.y.z required)"
 	@echo "   patch          make a patch release on a current branch (must be a release branch)"

--- a/pkg/pillar/Makefile
+++ b/pkg/pillar/Makefile
@@ -100,6 +100,17 @@ test: build-docker-test
 		--entrypoint /bin/sh $(DOCKER_TAG) \
 		/pillar/build-scripts/fuzz_test.sh
 
+test-profiling-create: build-docker-test
+	docker run --memory=800m --platform linux/$(ZARCH) -w /pillar \
+                --mount type=bind,source=./,target=/pillar/ \
+                --entrypoint /bin/sh $(DOCKER_TAG) \
+                /pillar/build-scripts/memprof_test.sh
+
+test-profiling: test-profiling-create
+	for i in *.profile; \
+                do go tool pprof -output "$${i}.png" -png "$${i}" ;\
+        done
+
 clean:
 	@rm -rf $(DISTDIR)
 

--- a/pkg/pillar/Makefile
+++ b/pkg/pillar/Makefile
@@ -88,7 +88,7 @@ test: build-docker-test
 	rm -f results.xml
 	touch results.json
 	touch results.xml
-	docker run --platform linux/$(ZARCH) -w /pillar \
+	docker run --memory=800m --platform linux/$(ZARCH) -w /pillar \
 		--mount type=bind,source=./results.json,target=/pillar/results.json \
 		--mount type=bind,source=./results.xml,target=/pillar/results.xml \
 		--entrypoint /final/opt/gotestsum $(DOCKER_TAG) \
@@ -96,7 +96,7 @@ test: build-docker-test
 		--junitfile /pillar/results.xml \
 		--raw-command -- go test -tags kubevirt -coverprofile=coverage.txt -covermode=atomic -race -json \
 		./...
-	docker run --platform linux/$(ZARCH) -w /pillar \
+	docker run --memory=800m --platform linux/$(ZARCH) -w /pillar \
 		--entrypoint /bin/sh $(DOCKER_TAG) \
 		/pillar/build-scripts/fuzz_test.sh
 

--- a/pkg/pillar/build-scripts/memprof_test.sh
+++ b/pkg/pillar/build-scripts/memprof_test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+dirs=$(find ./ -type d \! -path ./vendor/\*)
+for dir in ${dirs}; do
+    if ! grep -q 'func Test' "$dir"/*_test.go >/dev/null 2>&1; then
+        continue
+    fi
+    cleandir="${dir:2}"
+    echo "Testing in $dir"
+    memprofile=/pillar/mem-${cleandir//\//_}.profile
+    /final/opt/gotestsum --jsonfile /pillar/results.json --junitfile /pillar/results.xml \
+        --raw-command -- go test "$dir" -tags kubevirt -coverprofile=coverage.txt -covermode=atomic -race -json -memprofile="$memprofile"
+done


### PR DESCRIPTION
Set an upper memory limit to know when we merge something that increases memory usage by a lot.
If this happens `test-profiling` can be used to look where the memory is going to.