### PR TITLE
grub/rootfs.cfg: add 'isolate CPU0 (only for PREEMPT_RT)' menu option

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -392,6 +392,12 @@ function set_getty {
       set_global dom0_extra_args "$dom0_extra_args getty"
 }
 
+function set_isolcpus {
+   # the 'inverse' is our own flag, see details here:
+   # https://github.com/lf-edge/eve-kernel/pull/90
+   set_global dom0_extra_args "$dom0_extra_args isolcpus=inverse,0 nohz_full=inverse,0"
+}
+
 set arch=${grub_cpu}
 if [ "$arch" = "i386" ]; then
    # grub CPU i386 means we are running in legacy BIOS mode
@@ -461,6 +467,10 @@ submenu 'Set Boot Options' {
 
    menuentry 'enable getty' {
       set_getty
+   }
+
+   menuentry 'isolate CPU0 (only for PREEMPT_RT)' {
+      set_isolcpus
    }
 
    menuentry 'unset dom0_extra_args' {


### PR DESCRIPTION
This will set the 'isolcpus=inverse,0 nohz_full=inverse,0' kernel command line, which by default pins all the service tasks running on EVE to the CPU0, isolating other CPUs to VM needs and prevents scheduling interference.

This command line uses the 'inverse' flag, which was introduced here:

   https://github.com/lf-edge/eve-kernel/pull/90

Now the configuration is general and does not depend on the number of CPUs. This option makes sense to set for the PREEMPT_RT kernel, which uses the 'inverse' flag. 

XXX kernel version for RT is not yet updated, build server is gone, this change will follow.

