### PR TITLE
Kubevirt: longhorn configuration

### DIFF
--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -19,6 +19,10 @@ RUN GO111MODULE=on CGO_ENABLED=0 go build -v -ldflags "-s -w" -mod=vendor -o /ou
 FROM scratch
 COPY --from=build /out/ /
 COPY cluster-init.sh /usr/bin/
+COPY nsmounter /usr/bin/
+COPY longhorn-generate-support-bundle.sh /usr/bin/
+COPY k3s-pod-logs.sh /usr/bin/
+COPY iscsid.conf /etc/iscsi/
 COPY cgconfig.conf /etc
 # kubevirt yaml files are patched files and will be removed later, look at cluster-init.sh
 COPY multus-daemonset.yaml /etc

--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -5,7 +5,7 @@
 
 K3S_VERSION=v1.26.3+k3s1
 KUBEVIRT_VERSION=v0.59.0
-LONGHORN_VERSION=v1.4.2
+LONGHORN_VERSION=v1.6.0
 CDI_VERSION=v1.56.0
 NODE_IP=""
 
@@ -133,6 +133,28 @@ setup_prereqs () {
         mount_etcd_vol
 }
 
+apply_longhorn_disk_config() {
+        node=$1
+        kubectl label node "$node" node.longhorn.io/create-default-disk='config'
+        kubectl annotate node "$node" node.longhorn.io/default-disks-config='[ { "path":"/persist/vault/volumes", "allowScheduling":true }]'
+}
+
+check_overwrite_nsmounter() {
+        ### REMOVE ME+
+        # When https://github.com/longhorn/longhorn/issues/6857 is resolved, remove this 'REMOVE ME' section
+        # In addition to pkg/kube/nsmounter and the copy of it in pkg/kube/Dockerfile
+        longhornCsiPluginPods=$(kubectl -n longhorn-system get pod -o json | jq -r '.items[] | select(.metadata.labels.app=="longhorn-csi-plugin" and .status.phase=="Running") | .metadata.name')
+        for csiPod in $longhornCsiPluginPods; do
+                if ! kubectl -n longhorn-system exec "pod/${csiPod}" --container=longhorn-csi-plugin -- ls /usr/local/sbin/nsmounter.updated > /dev/null 2>@1; then
+                        if kubectl -n longhorn-system exec -i "pod/${csiPod}" --container=longhorn-csi-plugin -- tee /usr/local/sbin/nsmounter < /usr/bin/nsmounter; then
+                                logmsg "Updated nsmounter in longhorn pod ${csiPod}"
+                                kubectl -n longhorn-system exec "pod/${csiPod}" --container=longhorn-csi-plugin -- touch /usr/local/sbin/nsmounter.updated
+                        fi
+                fi
+        done
+        ### REMOVE ME-
+}
+
 check_start_containerd() {
         # Needed to get the pods to start
         if [ ! -L /usr/bin/runc ]; then
@@ -247,7 +269,15 @@ if [ ! -f /var/lib/all_components_initialized ]; then
 
         if [ ! -f /var/lib/longhorn_initialized ]; then
                 logmsg "Installing longhorn version ${LONGHORN_VERSION}"
-                kubectl apply -f  https://raw.githubusercontent.com/longhorn/longhorn/${LONGHORN_VERSION}/deploy/longhorn.yaml
+                apply_longhorn_disk_config "$(/bin/hostname)"
+                lhCfgPath=/var/lib/lh-cfg-${LONGHORN_VERSION}.yaml
+                if [ ! -e $lhCfgPath ]; then
+                        curl -k https://raw.githubusercontent.com/longhorn/longhorn/${LONGHORN_VERSION}/deploy/longhorn.yaml > "$lhCfgPath"
+                fi
+                if ! grep -q 'create-default-disk-labeled-nodes: true' "$lhCfgPath"; then
+                        sed -i '/  default-setting.yaml: |-/a\    create-default-disk-labeled-nodes: true' "$lhCfgPath"
+                fi
+                kubectl apply -f "$lhCfgPath"
                 touch /var/lib/longhorn_initialized
         fi
 
@@ -259,6 +289,9 @@ else
         check_start_containerd
         if pgrep k3s >> $INSTALL_LOG 2>&1; then
                 logmsg "k3s is alive "
+                if [ -e /var/lib/longhorn_initialized ]; then
+                        check_overwrite_nsmounter
+                fi
         else
                 ## Must be after reboot
                 ln -s /var/lib/k3s/bin/* /usr/bin

--- a/pkg/kube/config.yaml
+++ b/pkg/kube/config.yaml
@@ -4,8 +4,8 @@
 write-kubeconfig-mode: "0644"
 cluster-init: true
 log: "/var/lib/rancher/k3s/k3s.log"
-# Remove debug flag before release to avoid overlogging
-debug: true
+# Use longhorn storage
+disable: local-storage
 etcd-expose-metrics: true
 container-runtime-endpoint: "/run/containerd-user/containerd.sock"
 etcd-arg:

--- a/pkg/kube/iscsid.conf
+++ b/pkg/kube/iscsid.conf
@@ -1,0 +1,340 @@
+# From open-iscsi package
+# With node.session.queue_depth decreased to 1 temporarily
+
+#
+# Open-iSCSI default configuration.
+# Could be located at /etc/iscsi/iscsid.conf or ~/.iscsid.conf
+#
+# Note: To set any of these values for a specific node/session run
+# the iscsiadm --mode node --op command for the value. See the README
+# and man page for iscsiadm for details on the --op command.
+#
+
+######################
+# iscsid daemon config
+######################
+#
+# If you want iscsid to start the first time an iscsi tool
+# needs to access it, instead of starting it when the init
+# scripts run, set the iscsid startup command here. This
+# should normally only need to be done by distro package
+# maintainers. If you leave the iscsid daemon running all
+# the time then leave this attribute commented out.
+#
+
+# Alpine startup
+ iscsid.startup = /etc/init.d/iscsid start
+#
+# Default for Fedora and RHEL. (uncomment to activate).
+# iscsid.startup = /bin/systemctl start iscsid.socket iscsiuio.socket
+#
+# Default if you are not using systemd (uncomment to activate)
+# iscsid.startup = /usr/bin/service start iscsid
+
+# Check for active mounts on devices reachable through a session
+# and refuse to logout if there are any.  Defaults to "No".
+# iscsid.safe_logout = Yes
+
+#############################
+# NIC/HBA and driver settings
+#############################
+# open-iscsi can create a session and bind it to a NIC/HBA.
+# To set this up see the example iface config file.
+
+#*****************
+# Startup settings
+#*****************
+
+# To request that the iscsi initd scripts startup a session set to "automatic".
+# node.startup = automatic
+#
+# To manually startup the session set to "manual". The default is manual.
+node.startup = manual
+
+# For "automatic" startup nodes, setting this to "Yes" will try logins on each
+# available iface until one succeeds, and then stop.  The default "No" will try
+# logins on all available ifaces simultaneously.
+node.leading_login = No
+
+# *************
+# CHAP Settings
+# *************
+
+# To enable CHAP authentication set node.session.auth.authmethod
+# to CHAP. The default is None.
+#node.session.auth.authmethod = CHAP
+
+# To configure which CHAP algorithms to enable set
+# node.session.auth.chap_algs to a comma separated list.
+# The algorithms should be listen with most preferred first.
+# Valid values are MD5, SHA1, SHA256, and SHA3-256.
+# The default is MD5.
+#node.session.auth.chap_algs = SHA3-256,SHA256,SHA1,MD5
+
+# To set a CHAP username and password for initiator
+# authentication by the target(s), uncomment the following lines:
+#node.session.auth.username = username
+#node.session.auth.password = password
+
+# To set a CHAP username and password for target(s)
+# authentication by the initiator, uncomment the following lines:
+#node.session.auth.username_in = username_in
+#node.session.auth.password_in = password_in
+
+# To enable CHAP authentication for a discovery session to the target
+# set discovery.sendtargets.auth.authmethod to CHAP. The default is None.
+#discovery.sendtargets.auth.authmethod = CHAP
+
+# To set a discovery session CHAP username and password for the initiator
+# authentication by the target(s), uncomment the following lines:
+#discovery.sendtargets.auth.username = username
+#discovery.sendtargets.auth.password = password
+
+# To set a discovery session CHAP username and password for target(s)
+# authentication by the initiator, uncomment the following lines:
+#discovery.sendtargets.auth.username_in = username_in
+#discovery.sendtargets.auth.password_in = password_in
+
+# ********
+# Timeouts
+# ********
+#
+# See the iSCSI README's Advanced Configuration section for tips
+# on setting timeouts when using multipath or doing root over iSCSI.
+#
+# To specify the length of time to wait for session re-establishment
+# before failing SCSI commands back to the application when running
+# the Linux SCSI Layer error handler, edit the line.
+# The value is in seconds and the default is 120 seconds.
+# Special values:
+# - If the value is 0, IO will be failed immediately.
+# - If the value is less than 0, IO will remain queued until the session
+# is logged back in, or until the user runs the logout command.
+node.session.timeo.replacement_timeout = 120
+
+# To specify the time to wait for login to complete, edit the line.
+# The value is in seconds and the default is 15 seconds.
+node.conn[0].timeo.login_timeout = 15
+
+# To specify the time to wait for logout to complete, edit the line.
+# The value is in seconds and the default is 15 seconds.
+node.conn[0].timeo.logout_timeout = 15
+
+# Time interval to wait for on connection before sending a ping.
+node.conn[0].timeo.noop_out_interval = 5
+
+# To specify the time to wait for a Nop-out response before failing
+# the connection, edit this line. Failing the connection will
+# cause IO to be failed back to the SCSI layer. If using dm-multipath
+# this will cause the IO to be failed to the multipath layer.
+node.conn[0].timeo.noop_out_timeout = 5
+
+# To specify the time to wait for abort response before
+# failing the operation and trying a logical unit reset edit the line.
+# The value is in seconds and the default is 15 seconds.
+node.session.err_timeo.abort_timeout = 30
+
+# To specify the time to wait for a logical unit response
+# before failing the operation and trying session re-establishment
+# edit the line.
+# The value is in seconds and the default is 30 seconds.
+node.session.err_timeo.lu_reset_timeout = 60
+
+# To specify the time to wait for a target response
+# before failing the operation and trying session re-establishment
+# edit the line.
+# The value is in seconds and the default is 30 seconds.
+node.session.err_timeo.tgt_reset_timeout = 60
+
+
+#******
+# Retry
+#******
+
+# To specify the number of times iscsid should retry a login
+# if the login attempt fails due to the node.conn[0].timeo.login_timeout
+# expiring modify the following line. Note that if the login fails
+# quickly (before node.conn[0].timeo.login_timeout fires) because the network
+# layer or the target returns an error, iscsid may retry the login more than
+# node.session.initial_login_retry_max times.
+#
+# This retry count along with node.conn[0].timeo.login_timeout
+# determines the maximum amount of time iscsid will try to
+# establish the initial login. node.session.initial_login_retry_max is
+# multiplied by the node.conn[0].timeo.login_timeout to determine the
+# maximum amount.
+#
+# The default node.session.initial_login_retry_max is 8 and
+# node.conn[0].timeo.login_timeout is 15 so we have:
+#
+# node.conn[0].timeo.login_timeout * node.session.initial_login_retry_max =
+#                               120 seconds
+#
+# Valid values are any integer value. This only
+# affects the initial login. Setting it to a high value can slow
+# down the iscsi service startup. Setting it to a low value can
+# cause a session to not get logged into, if there are distuptions
+# during startup or if the network is not ready at that time.
+node.session.initial_login_retry_max = 8
+
+################################
+# session and device queue depth
+################################
+
+# To control how many commands the session will queue set
+# node.session.cmds_max to an integer between 2 and 2048 that is also
+# a power of 2. The default is 128.
+node.session.cmds_max = 128
+
+# To control the device's queue depth set node.session.queue_depth
+# to a value between 1 and 1024. The default is 32.
+node.session.queue_depth = 1
+
+##################################
+# MISC SYSTEM PERFORMANCE SETTINGS
+##################################
+
+# For software iscsi (iscsi_tcp) and iser (ib_iser) each session
+# has a thread used to transmit or queue data to the hardware. For
+# cxgb3i you will get a thread per host.
+#
+# Setting the thread's priority to a lower value can lead to higher throughput
+# and lower latencies. The lowest value is -20. Setting the priority to
+# a higher value, can lead to reduced IO performance, but if you are seeing
+# the iscsi or scsi threads dominate the use of the CPU then you may want
+# to set this value higher.
+#
+# Note: For cxgb3i you must set all sessions to the same value, or the
+# behavior is not defined.
+#
+# The default value is -20. The setting must be between -20 and 20.
+node.session.xmit_thread_priority = -20
+
+
+#***************
+# iSCSI settings
+#***************
+
+# To enable R2T flow control (i.e., the initiator must wait for an R2T
+# command before sending any data), uncomment the following line:
+#
+#node.session.iscsi.InitialR2T = Yes
+#
+# To disable R2T flow control (i.e., the initiator has an implied
+# initial R2T of "FirstBurstLength" at offset 0), uncomment the following line:
+#
+# The defaults is No.
+node.session.iscsi.InitialR2T = No
+
+#
+# To disable immediate data (i.e., the initiator does not send
+# unsolicited data with the iSCSI command PDU), uncomment the following line:
+#
+#node.session.iscsi.ImmediateData = No
+#
+# To enable immediate data (i.e., the initiator sends unsolicited data
+# with the iSCSI command packet), uncomment the following line:
+#
+# The default is Yes
+node.session.iscsi.ImmediateData = Yes
+
+# To specify the maximum number of unsolicited data bytes the initiator
+# can send in an iSCSI PDU to a target, edit the following line.
+#
+# The value is the number of bytes in the range of 512 to (2^24-1) and
+# the default is 262144
+node.session.iscsi.FirstBurstLength = 262144
+
+# To specify the maximum SCSI payload that the initiator will negotiate
+# with the target for, edit the following line.
+#
+# The value is the number of bytes in the range of 512 to (2^24-1) and
+# the default is 16776192
+node.session.iscsi.MaxBurstLength = 16776192
+
+# To specify the maximum number of data bytes the initiator can receive
+# in an iSCSI PDU from a target, edit the following line.
+#
+# The value is the number of bytes in the range of 512 to (2^24-1) and
+# the default is 262144
+node.conn[0].iscsi.MaxRecvDataSegmentLength = 262144
+
+# To specify the maximum number of data bytes the initiator will send
+# in an iSCSI PDU to the target, edit the following line.
+#
+# The value is the number of bytes in the range of 512 to (2^24-1).
+# Zero is a special case. If set to zero, the initiator will use
+# the target's MaxRecvDataSegmentLength for the MaxXmitDataSegmentLength.
+# The default is 0.
+node.conn[0].iscsi.MaxXmitDataSegmentLength = 0
+
+# To specify the maximum number of data bytes the initiator can receive
+# in an iSCSI PDU from a target during a discovery session, edit the
+# following line.
+#
+# The value is the number of bytes in the range of 512 to (2^24-1) and
+# the default is 32768
+discovery.sendtargets.iscsi.MaxRecvDataSegmentLength = 32768
+
+# To allow the targets to control the setting of the digest checking,
+# with the initiator requesting a preference of enabling the checking, uncomment# one or both of the following lines:
+#node.conn[0].iscsi.HeaderDigest = CRC32C,None
+#node.conn[0].iscsi.DataDigest = CRC32C,None
+#
+# To allow the targets to control the setting of the digest checking,
+# with the initiator requesting a preference of disabling the checking,
+# uncomment one or both of the following lines:
+#node.conn[0].iscsi.HeaderDigest = None,CRC32C
+#node.conn[0].iscsi.DataDigest = None,CRC32C
+#
+# To enable CRC32C digest checking for the header and/or data part of
+# iSCSI PDUs, uncomment one or both of the following lines:
+#node.conn[0].iscsi.HeaderDigest = CRC32C
+#node.conn[0].iscsi.DataDigest = CRC32C
+#
+# To disable digest checking for the header and/or data part of
+# iSCSI PDUs, uncomment one or both of the following lines:
+#node.conn[0].iscsi.HeaderDigest = None
+#node.conn[0].iscsi.DataDigest = None
+#
+# The default is to never use DataDigests or HeaderDigests.
+#
+
+# For multipath configurations, you may want more than one session to be
+# created on each iface record.  If node.session.nr_sessions is greater
+# than 1, performing a 'login' for that node will ensure that the
+# appropriate number of sessions is created.
+node.session.nr_sessions = 1
+
+# When iscsid starts up it recovers existing sessions, if possible.
+# If the target for a session has gone away when this occurs, the
+# iscsid daemon normally tries to reestablish each session,
+# in succession, in the background, by trying again every two
+# seconds, until all sessions are restored. This configuration
+# variable can limits the number of retries for each session.
+# For example, setting reopen_max=150 would mean that each session
+# recovery was limited to about five minutes.
+node.session.reopen_max = 0
+
+#************
+# Workarounds
+#************
+
+# Some targets like IET prefer after an initiator has sent a task
+# management function like an ABORT TASK or LOGICAL UNIT RESET, that
+# it does not respond to PDUs like R2Ts. To enable this behavior uncomment
+# the following line (The default behavior is Yes):
+node.session.iscsi.FastAbort = Yes
+
+# Some targets like Equalogic prefer that after an initiator has sent
+# a task management function like an ABORT TASK or LOGICAL UNIT RESET, that
+# it continue to respond to R2Ts. To enable this uncomment this line
+# node.session.iscsi.FastAbort = No
+
+# To prevent doing automatic scans that would add unwanted luns to the system
+# we can disable them and have sessions only do manually requested scans.
+# Automatic scans are performed on startup, on login, and on AEN/AER reception
+# on devices supporting it.  For HW drivers all sessions will use the value
+# defined in the configuration file.  This configuration option is independent
+# of scsi_mod scan parameter. (The default behavior is auto):
+node.session.scan = auto

--- a/pkg/kube/k3s-pod-logs.sh
+++ b/pkg/kube/k3s-pod-logs.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+rm -f /persist/newlog/kube/k3s-pod-logs-*.tar.gz
+OUT_FILE=/persist/newlog/kube/k3s-pod-logs-$(date +'%Y%m%d-%H%M%S' -u).tar.gz
+tar cfz "$OUT_FILE" -C /var/log/pods/ .
+echo "Created: $OUT_FILE"

--- a/pkg/kube/longhorn-generate-support-bundle.sh
+++ b/pkg/kube/longhorn-generate-support-bundle.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+#
+# Copyright (c) 2024 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+LOG_DIR=/persist/newlog/kube
+
+echo "Apply longhorn support bundle yaml at $(date)"
+
+cat <<EOF | kubectl apply -f -
+---
+apiVersion: longhorn.io/v1beta2
+kind: SupportBundle
+metadata:
+  name: support-bundle-collect-info
+  namespace: longhorn-system
+spec:
+  description: collect-info
+  issueURL: ""
+  nodeID: ""
+EOF
+
+while true; do
+    state=$(kubectl -n longhorn-system get supportbundle.longhorn.io/support-bundle-collect-info -o json | jq -r .status.state)
+    if [ "$state" = "ReadyForDownload" ]; then
+        break
+    fi
+    sleep 10
+    progress=$(kubectl -n longhorn-system get supportbundle.longhorn.io/support-bundle-collect-info -o json | jq -r .status.progress)
+    echo "support bundle progress percentage: $progress"
+done
+
+ip=$(kubectl -n longhorn-system get supportbundle.longhorn.io/support-bundle-collect-info -o json | jq -r .status.managerIP)
+filename=$(kubectl -n longhorn-system get supportbundle.longhorn.io/support-bundle-collect-info -o json | jq -r .status.filename)
+
+# Sort creation time, keep 4 latest support bundles
+find "${LOG_DIR}" -name "longhornsupportbundle_*" | sort -n | head -n -4 | xargs rm -f
+
+curl "http://${ip}:8080/bundle" > "${LOG_DIR}/longhorn${filename}"
+echo "longhorn support bundle downloaded to ${LOG_DIR}/longhorn${filename}"
+
+kubectl -n longhorn-system delete supportbundle.longhorn.io/support-bundle-collect-info

--- a/pkg/kube/nsmounter
+++ b/pkg/kube/nsmounter
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Copyright (c) 2024 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# nsmounter: called by the longhorn-csi-plugin pod
+#   used to find the correct PID to nsenter into and
+#   mount RWX volumes for longhorn
+#
+target_pid=1
+kube_pid=$(pgrep -f "cluster-init.sh")
+if [ -n "$kube_pid" ]; then
+  target_pid=$kube_pid
+fi
+nsenter -t "$target_pid" -m -n -u -- "$@"


### PR DESCRIPTION
Bump to latest version 1.6.0 including upstream change to find the correct iscsid pid when running k3s in a container. nsmounter replacement to fix PID enabling RWX PVC mounts findutils: needed for -regextype option
nfs-utils: for RWX (nfs) PVCs
longhorn-generate-support-bundle.sh:
request a support bundle containing complete lh logs written to longhornsupportbundle_*.zip in
/persist/newlog/kube/
Lowered iSCSI queue depth to handle large CDI volume uploads. This is temporary until performance testing completes. Set default disk path (pool) to /persist/vault/volumes

Part 2 of the breakup of now-draft PR:https://github.com/lf-edge/eve/pull/3838