### PR TITLE
Crashkernel improvements

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -352,7 +352,7 @@ function set_kvm_boot {
    set_global load_initrd_cmd initrd
    set_global dom0_flavor_tweaks "pcie_acs_override=downstream,multifunction"
    if [ "$arch" = "x86_64" ]; then
-      set_global dom0_flavor_tweaks "$dom0_flavor_tweaks crashkernel=2G-64G:128M,64G-1T:256M,1T-:512M"
+      set_global dom0_flavor_tweaks "$dom0_flavor_tweaks crashkernel=2G-16G:128M,16G-128G:256M,128G-:512M"
    fi
    # this may strike readers as circular, but it really isn't
    # the reason we have to also set eve_flavor to kvm here is
@@ -375,7 +375,7 @@ function set_kubevirt_boot {
    set_global load_initrd_cmd initrd
    set_global dom0_flavor_tweaks "pcie_acs_override=downstream,multifunction"
    if [ "$arch" = "x86_64" ]; then
-      set_global dom0_flavor_tweaks "$dom0_flavor_tweaks crashkernel=2G-64G:128M,64G-1T:256M,1T-:512M"
+      set_global dom0_flavor_tweaks "$dom0_flavor_tweaks crashkernel=2G-16G:128M,16G-128G:256M,128G-:512M"
    fi
    # see the set_global eve_flavor kvm comment in set_kvm_boot
    set_global eve_flavor kubevirt

--- a/pkg/kdump/kdump.sh
+++ b/pkg/kdump/kdump.sh
@@ -27,9 +27,14 @@ if test -f /proc/vmcore; then
     makedumpfile --dump-dmesg /proc/vmcore /tmp/dmesg > /dev/null
     sed -n -e '/Kernel panic - not syncing/,$p' /tmp/dmesg > /tmp/backtrace
 
-    # Show backtrace from the dmesg of a crashed kernel
+    # Show backtrace from the dmesg of a crashed kernel. Print line by
+    # line with some reasonable sleep in-between lines to slow down the
+    # output on the console and give a chance to record the stack
+    # properly. Typical use case is BMC which records with very low
+    # frame rate so the video contains the bottom of the long stack
+    # only, but the top is missing.
     echo ">>>>>>>>>> Crashed kernel dmesg BEGIN <<<<<<<<<<" > /dev/kmsg
-    while read -r line; do echo "$line" > /dev/kmsg; done < /tmp/backtrace
+    while read -r line; do echo "$line" > /dev/kmsg; sleep 0.2; done < /tmp/backtrace
     echo ">>>>>>>>>> Crashed kernel dmesg END <<<<<<<<<<" > /dev/kmsg
 
     TS=$(date -Is)


### PR DESCRIPTION
This PR targets a few things which lead to a missing dumps of crashed
kernel:

1. Not enough memory for crashkernel to run on 32G of ram, so now
   kernel reserves 256M for the crashkernel.

2. Print dmesg of the crashed kernel line by line with some reasonable
   sleep in-between lines to slow down the output on the console and give
   a chance to record the stack properly. Typical use case is BMC which
   records with very low frame rate so the video contains the bottom of
   the long stack only but the top is missing. This happens if the stack
   is huge and occupies more than 1 screen height.
