### PR TITLE
spec.sh: Fix total storage listing

### DIFF
--- a/pkg/debug/spec.sh
+++ b/pkg/debug/spec.sh
@@ -164,7 +164,7 @@ else
    MEM=$(awk '/MemTotal:/ { print int($2 / 1024); }' < /proc/meminfo)
 fi
 
-DISK=$(lsblk -b -o NAME,TYPE,TRAN,SIZE | grep disk | grep -v usb | awk '{ total += $4; } END { print int(total/(1024*1024*1024)); }')
+DISK=$(lsblk -b -o NAME,TYPE,TRAN,SIZE | grep disk | grep -v usb | awk '{ total += $NF; } END { print int(total/(1024*1024*1024)); }')
 WDT=$([ -e /dev/watchdog ] && echo true || echo false)
 HSM=$([ -e /dev/tpmrm0 ] && echo 1 || echo 0)
 


### PR DESCRIPTION
Four fields are expected from lsblk command output: NAME, TYPE, TRAN and SIZE.  However, in some cases the field TRAN might not be available, as shown in the following real outputs below:

NAME   TYPE TRAN          SIZE
sda    disk sata   21474836480

NAME   TYPE TRAN        SIZE
vda    disk      21474836480

In the former, SIZE will be in the 4th field while in the latter it will be in the 3rd field. This commit fixes the awk rule to always fetch the last field, which will always be SIZE.