### PR TITLE
Kubevirt: k3s debugging/logging improvements

### DIFF
--- a/pkg/alpine/mirrors/3.16/main
+++ b/pkg/alpine/mirrors/3.16/main
@@ -145,6 +145,7 @@ ncurses-dev
 net-snmp
 netcat-openbsd
 nettle
+nfs-utils
 ninja
 numactl-dev
 open-iscsi

--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -1,10 +1,10 @@
 # syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
 
-FROM lfedge/eve-alpine:a76c418ea841a1c433e0ab562653c3801f494d8e as build
+FROM lfedge/eve-alpine:61cdbba633ac08243ee55a371c5b74d01a673784 as build
 ENV BUILD_PKGS go
 ENV PKGS alpine-baselayout musl-utils iproute2 iptables curl openrc \
          open-iscsi libvirt libvirt-client util-linux grep findutils jq \
-         cni-plugins
+         cni-plugins nfs-utils
 RUN eve-alpine-deploy.sh
 
 # Remove unused CNI plugins
@@ -16,23 +16,36 @@ COPY eve-bridge /plugins/eve-bridge
 WORKDIR /plugins/eve-bridge
 RUN GO111MODULE=on CGO_ENABLED=0 go build -v -ldflags "-s -w" -mod=vendor -o /out/usr/bin/eve-bridge .
 
+COPY cert-gen /plugins/cert-gen
+WORKDIR /plugins/cert-gen
+RUN GO111MODULE=on CGO_ENABLED=0 go build -v -ldflags "-s -w" -o /out/usr/bin/cert-gen .
+
 FROM scratch
 COPY --from=build /out/ /
 COPY cluster-init.sh /usr/bin/
-COPY nsmounter /usr/bin/
-COPY longhorn-generate-support-bundle.sh /usr/bin/
-COPY k3s-pod-logs.sh /usr/bin/
-COPY iscsid.conf /etc/iscsi/
 COPY cgconfig.conf /etc
+
+# k3s
+COPY install-etcdctl.sh /usr/bin/
+RUN mkdir -p /etc/rancher/k3s
+COPY config.yaml /etc/rancher/k3s
+COPY debuguser-role-binding.yaml /etc/
+COPY k3s-pod-logs.sh /usr/bin/
+
 # kubevirt yaml files are patched files and will be removed later, look at cluster-init.sh
 COPY multus-daemonset.yaml /etc
 COPY kubevirt-operator.yaml /etc
 COPY kubevirt-features.yaml /etc
+COPY external-boot-image.tar /etc/
+
+# Longhorn config
+COPY iscsid.conf /etc/iscsi/
+COPY longhorn-generate-support-bundle.sh /usr/bin/
+COPY nsmounter /usr/bin/
+
+# Containerd config
 RUN mkdir -p /etc/containerd
 COPY config-k3s.toml /etc/containerd/
-RUN mkdir -p /etc/rancher/k3s
-COPY config.yaml /etc/rancher/k3s
-COPY external-boot-image.tar /etc/
 WORKDIR /
 
 # Actual k3s install and config happens when this container starts during EVE bootup, look at cluster-init.sh
@@ -42,10 +55,6 @@ WORKDIR /
 #RUN install virtctl-${VIRTCTL_VERSION}-linux-amd64 /usr/bin/virtctl
 # We installed under /usr/bin. Remove the downloaded version
 #RUN rm -f ./virtctl-${VIRTCTL_VERSION}-linux-amd64
-
-ENV ETCDCTL_VERSION v3.5.5
-ADD https://github.com/etcd-io/etcd/releases/download/${ETCDCTL_VERSION}/etcd-${ETCDCTL_VERSION}-linux-amd64.tar.gz .
-RUN tar -zxv --strip-components=1 -C /usr/local/bin  < ./etcd-${ETCDCTL_VERSION}-linux-amd64.tar.gz
 
 ENTRYPOINT []
 CMD ["/usr/bin/cluster-init.sh"]

--- a/pkg/kube/cert-gen/cert-gen.go
+++ b/pkg/kube/cert-gen/cert-gen.go
@@ -1,0 +1,243 @@
+// Copyright (c) 2024 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Create a non-CA certificate with arbitrarily short lifetime and ECDSA keys.
+// Signed by a CA cert.
+
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"flag"
+	"fmt"
+	"math/big"
+	"os"
+	"strings"
+	"time"
+)
+
+const lifetimeInSecs = 1200
+
+var (
+	caCert         *x509.Certificate
+	caPrivKey      *ecdsa.PrivateKey
+	caCertName     = "ca.cert.pem"
+	caKeyName      = "ca.key.pem"
+	outputDir      = "."
+	certCommonName = ""
+	certOrg        = ""
+)
+
+func main() {
+	var (
+		keyName  string
+		certName string
+		notAfter time.Time
+	)
+
+	outputPrefixPtr := flag.String("o", "signing", "prefix for output files")
+	lifetimePtr := flag.Int("l", lifetimeInSecs, "cert lifetime in seconds")
+	isCAPtr := flag.Bool("C", false, "generate CA cert")
+	caCertPathPtr := flag.String("ca-cert", caCertName, "CA certificate file")
+	caKeyPathPtr := flag.String("ca-key", caKeyName, "CA key file")
+	outputDirPtr := flag.String("output-dir", "", "Output directory for cert and key files")
+	certCnPtr := flag.String("cert-cn", "", "Common Name for the certificate")
+	certOPtr := flag.String("cert-o", "", "Organization for the certificate")
+	flag.Parse()
+
+	if *outputDirPtr != "" {
+		outputDir = *outputDirPtr
+	}
+	if *certCnPtr != "" {
+		certCommonName = *certCnPtr
+	}
+	if *certOPtr != "" {
+		certOrg = *certOPtr
+	}
+
+	if *isCAPtr {
+		notAfter = time.Now().AddDate(20, 0, 0)
+		// Fixed names
+		certName = caCertName
+		keyName = caKeyName
+	} else {
+		// Read CA from ca.cert.name and ca.key.name
+		var err error
+		caCert, err = GetCertFromFile(*caCertPathPtr)
+		if err != nil {
+			fmt.Printf("GetCertFromFile failed: %s\n", err)
+			return
+		}
+		caPrivKey, err = GetPrivateKeyFromFile(*caKeyPathPtr)
+		if err != nil {
+			fmt.Printf("GetPrivateKeyFromFile failed: %s\n", err)
+			return
+		}
+		notAfter = time.Now().Add(time.Second * time.Duration(*lifetimePtr))
+		timeStamp := notAfter.Format("2006-01-02T150405Z0700")
+		fmt.Printf("End: %s\n", timeStamp)
+		outputPrefix := *outputPrefixPtr + "." + timeStamp
+		certName = outputPrefix + ".cert.pem"
+		keyName = outputPrefix + ".key.pem"
+	}
+	if err := createCert(*isCAPtr, notAfter, certName, keyName); err != nil {
+		fmt.Printf("failed: %s\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Wrote %s and %s\n", certName, keyName)
+}
+
+// generate a key and certificate,
+// the certificate is self-signed using the private key unless isCA
+// Assumes no TPM hence device private key is in a file
+func createCert(isCA bool, notAfter time.Time, certName string, keyName string) error {
+	// Generate private key
+	certPrivKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return fmt.Errorf("Failed to generate software device key pair: %v",
+			err)
+	}
+
+	// get the device cert template
+	template := createCertTemplate(isCA, notAfter)
+	// Who will sign? Self-signed if CA
+	var ca = caCert
+	if isCA {
+		ca = template
+		caPrivKey = certPrivKey
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader,
+		template, ca, certPrivKey.Public(), caPrivKey)
+	if err != nil {
+		return fmt.Errorf("Failed to create device certificate: %w",
+			err)
+	}
+
+	certBlock := &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: derBytes,
+	}
+
+	// public cert bytes
+	certBytes := pem.EncodeToMemory(certBlock)
+	if certBytes == nil {
+		return fmt.Errorf("Failed in PEM encoding of device cert: empty bytes")
+	}
+
+	// private cert bytes
+	privBytes, err := x509.MarshalPKCS8PrivateKey(certPrivKey)
+	if err != nil {
+		return fmt.Errorf("Failed in MarshalECPrivateKey of ECDH cert: %v", err)
+	}
+	keyBlock := &pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: privBytes,
+	}
+
+	keyBytes := pem.EncodeToMemory(keyBlock)
+	if keyBytes == nil {
+		return fmt.Errorf("Failed in PEM encoding of ECDH key: empty bytes")
+	}
+	return writeDeviceCertToFile(certName, certBytes, keyName, keyBytes)
+}
+
+func writeDeviceCertToFile(certName string, certBytes []byte, keyName string, keyBytes []byte) error {
+	if err := os.WriteFile(outputDir+"/"+keyName, keyBytes, 0600); err != nil {
+		return err
+	}
+	return os.WriteFile(outputDir+"/"+certName, certBytes, 0644)
+}
+
+// create deviceCert Template with requested lifetime
+func createCertTemplate(isCA bool, notAfter time.Time) *x509.Certificate {
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, _ := rand.Int(rand.Reader, serialNumberLimit)
+	// Backdate one day in case clock is off a bit
+	// XXX adjust this?
+	yesterday := time.Now().AddDate(0, 0, -1)
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{certOrg},
+			CommonName:   certCommonName,
+		},
+		NotBefore: yesterday,
+		NotAfter:  notAfter,
+		IsCA:      isCA,
+		// No x509.KeyUsageKeyEncipherment for ECC
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyAgreement | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+	if isCA {
+		template.KeyUsage |= x509.KeyUsageCertSign
+	}
+	return &template
+}
+
+// GetPrivateKeyFromFile reads a private key file
+func GetPrivateKeyFromFile(keyFile string) (*ecdsa.PrivateKey, error) {
+	keyPEMBlock, err := os.ReadFile(keyFile)
+	if err != nil {
+		return nil, err
+	}
+	//Following logic is derived from steps in
+	//https://golang.org/src/crypto/tls/tls.go:X509KeyPair()
+	var keyDERBlock *pem.Block
+	var skippedBlockTypes []string
+	for {
+		keyDERBlock, keyPEMBlock = pem.Decode(keyPEMBlock)
+		if keyDERBlock == nil {
+			if len(skippedBlockTypes) == 0 {
+				return nil, errors.New("Failed to find any PEM data in key input")
+			}
+			if len(skippedBlockTypes) == 1 && skippedBlockTypes[0] == "CERTIFICATE" {
+				return nil, errors.New("Got a certificate instead of key")
+			}
+			return nil, errors.New("No PEM block found with type PRIVATE KEY")
+		}
+		if keyDERBlock.Type == "PRIVATE KEY" ||
+			strings.HasSuffix(keyDERBlock.Type, "EC PRIVATE KEY") {
+			break
+		}
+		skippedBlockTypes = append(skippedBlockTypes, keyDERBlock.Type)
+	}
+	if key, err := x509.ParsePKCS8PrivateKey(keyDERBlock.Bytes); err == nil {
+		var pkey *ecdsa.PrivateKey
+		var ok bool
+		if pkey, ok = key.(*ecdsa.PrivateKey); !ok {
+			return nil, errors.New("Private key is not ecdsa type")
+		}
+		return pkey, nil
+	}
+	if key, err := x509.ParseECPrivateKey(keyDERBlock.Bytes); err == nil {
+		return key, nil
+	} else {
+		return nil, err
+	}
+}
+
+// GetCertFromFile reads a X.509 cert
+func GetCertFromFile(certFile string) (*x509.Certificate, error) {
+	//read public key from ecdh certificate
+	certBytes, err := os.ReadFile(certFile)
+	if err != nil {
+		fmt.Printf("error in reading ecdh cert file: %v", err)
+		return nil, err
+	}
+	block, _ := pem.Decode(certBytes)
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		fmt.Printf("error in parsing ecdh cert file: %v", err)
+		return nil, err
+	}
+	return cert, nil
+}

--- a/pkg/kube/cert-gen/go.mod
+++ b/pkg/kube/cert-gen/go.mod
@@ -1,0 +1,3 @@
+module cert-gen
+
+go 1.21

--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -3,17 +3,22 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-K3S_VERSION=v1.26.3+k3s1
+K3S_VERSION=v1.28.5+k3s1
 KUBEVIRT_VERSION=v1.1.0
 LONGHORN_VERSION=v1.6.0
 CDI_VERSION=v1.57.0
+EVE_EXTERNAL_BOOT_IMG_TAG=325e7463e093db2c1abc0da0260b193e73bcef5d
+EVE_EXTERNAL_BOOT_IMG=docker.io/lfedge/eve-external-boot-image:${EVE_EXTERNAL_BOOT_IMG_TAG}
 NODE_IP=""
 MAX_K3S_RESTARTS=10
 RESTART_COUNT=0
-
-INSTALL_LOG=/var/lib/install.log
-CTRD_LOG=/var/lib/containerd-user.log
+K3S_LOG_DIR="/persist/newlog/kube"
+INSTALL_LOG="${K3S_LOG_DIR}/k3s-install.log"
+CTRD_LOG="${K3S_LOG_DIR}/containerd-user.log"
 LOG_SIZE=$((5*1024*1024))
+HOSTNAME=""
+VMICONFIG_FILENAME="/run/zedkube/vmiVNC.run"
+VNC_RUNNING=false
 
 logmsg() {
         local MSG
@@ -27,6 +32,33 @@ setup_cgroup () {
         echo "cgroup /sys/fs/cgroup cgroup defaults 0 0" >> /etc/fstab
 }
 
+check_log_file_size() {
+        currentSize=$(wc -c <"$K3S_LOG_DIR/$1")
+        if [ "$currentSize" -gt "$LOG_SIZE" ]; then
+                if [ -f "$K3S_LOG_DIR/$1.2" ]; then
+                        cp "$K3S_LOG_DIR/$1.2" "$K3S_LOG_DIR/$1.3"
+                fi
+                if [ -f "$K3S_LOG_DIR/$1.1" ]; then
+                        cp "$K3S_LOG_DIR/$1.1" "$K3S_LOG_DIR/$1.2"
+                fi
+                cp "$K3S_LOG_DIR/$1" "$K3S_LOG_DIR/$1.1"
+                truncate -s 0 "$K3S_LOG_DIR/$1"
+                logmsg "k3s logfile size $currentSize rotate"
+        fi
+}
+
+save_crash_log() {
+        if [ "$RESTART_COUNT" = "1" ]; then
+                return
+        fi
+        fileBaseName=$1
+        # This pattern will alias with older crashes, but also a simple way to contain log bloat
+        crashLogBaseName="${fileBaseName}.restart.${RESTART_COUNT}.gz"
+        if [ -e "${K3S_LOG_DIR}/${crashLogBaseName}" ]; then
+                rm "${K3S_LOG_DIR}/${crashLogBaseName}"
+        fi
+        gzip -k -9 "${K3S_LOG_DIR}/${fileBaseName}" -c > "${K3S_LOG_DIR}/${crashLogBaseName}"
+}
 
 check_network_connection () {
         while true; do
@@ -70,6 +102,31 @@ get_default_intf_IP_prefix() {
         ip_prefix="$NODE_IP/32"
         # Fill in the outbound external Interface IP prefix in multus config
         awk -v new_ip="$ip_prefix" '{gsub("IPAddressReplaceMe", new_ip)}1' /etc/multus-daemonset.yaml > /tmp/multus-daemonset.yaml
+}
+
+# kubernetes's name must be lower case and '-' instead of '_'
+convert_to_k8s_compatible() {
+        echo "$1" | tr '[:upper:]_' '[:lower:]-'
+}
+
+wait_for_device_name() {
+        logmsg "Waiting for DeviceName from controller..."
+        EdgeNodeInfoPath="/persist/status/zedagent/EdgeNodeInfo/global.json"
+        while [ ! -f $EdgeNodeInfoPath ]; do
+                sleep 5
+        done
+        dName=$(jq -r '.DeviceName' $EdgeNodeInfoPath)
+        if [ -n "$dName" ]; then
+                HOSTNAME=$(convert_to_k8s_compatible "$dName")
+        fi
+
+        # we should have the uuid since we got the device name
+        DEVUUID=$(/bin/hostname)
+
+        if ! grep -q node-name /etc/rancher/k3s/config.yaml; then
+                echo "node-name: $HOSTNAME" >> /etc/rancher/k3s/config.yaml
+        fi
+        logmsg "Hostname: $HOSTNAME"
 }
 
 apply_multus_cni() {
@@ -126,14 +183,43 @@ setup_prereqs () {
         modprobe iscsi_tcp
         #Needed for iscsi tools
         mkdir -p /run/lock
+        mkdir -p "$K3S_LOG_DIR"
         /usr/sbin/iscsid start
         mount --make-rshared /
         setup_cgroup
         #Check network and default routes are up
         wait_for_default_route
         check_network_connection
+        wait_for_device_name
+        chmod o+rw /dev/null
         wait_for_vault
         mount_etcd_vol
+}
+
+config_cluster_roles() {
+        # generate user debugging-user certificates
+        # 10 year expiration for now
+        if ! /usr/bin/cert-gen -l 315360000 --ca-cert /var/lib/rancher/k3s/server/tls/client-ca.crt \
+                --ca-key /var/lib/rancher/k3s/server/tls/client-ca.key \
+                -o k3s-debuguser --output-dir /tmp --cert-cn debugging-user --cert-o rbac; then
+                logmsg "Failed to generate debuguser cert"
+                return 1
+        fi
+        user_key_path=$(ls -c /tmp/k3s-debuguser*.key.pem)
+        user_crt_path=$(ls -c /tmp/k3s-debuguser*.cert.pem)
+        user_key_base64=$(base64 -w0 < "$user_key_path")
+        user_crt_base64=$(base64 -w0 < "$user_crt_path")
+
+        # generate kubeConfigure user for debugging-user
+        user_yaml_path=/var/lib/rancher/k3s/user.yaml
+        cp /etc/rancher/k3s/k3s.yaml "$user_yaml_path"
+        sed -i "s|client-certificate-data:.*|client-certificate-data: $user_crt_base64|g" "$user_yaml_path"
+        sed -i "s|client-key-data:.*|client-key-data: $user_key_base64|g" "$user_yaml_path"
+        cp "$user_yaml_path" /run/.kube/k3s/user.yaml
+
+        # apply kubernetes and kubevirt roles and binding to debugging-user
+        kubectl apply -f /etc/debuguser-role-binding.yaml
+        touch /var/lib/debuguser-initialized
 }
 
 apply_longhorn_disk_config() {
@@ -164,6 +250,7 @@ check_start_k3s() {
       if [ $RESTART_COUNT -lt $MAX_K3S_RESTARTS ]; then
           ## Must be after reboot, or from k3s restart
           RESTART_COUNT=$((RESTART_COUNT+1))
+          save_crash_log "k3s.log"
           ln -s /var/lib/k3s/bin/* /usr/bin
           logmsg "Starting k3s server, restart count: $RESTART_COUNT"
           # for now, always copy to get the latest
@@ -208,7 +295,7 @@ check_start_containerd() {
                 # This is very similar to what we do on kvm based eve to start container as a VM.
                 logmsg "Trying to install new external-boot-image"
                 # This import happens once per reboot
-                if ctr -a /run/containerd-user/containerd.sock image import /etc/external-boot-image.tar docker.io/lfedge/eve-external-boot-image:latest; then
+                if ctr -a /run/containerd-user/containerd.sock image import /etc/external-boot-image.tar ${EVE_EXTERNAL_BOOT_IMG}; then
                         logmsg "Successfully installed external-boot-image"
                         rm -f /etc/external-boot-image.tar
                 fi
@@ -233,6 +320,22 @@ trigger_k3s_selfextraction() {
         /usr/bin/k3s check-config >> $INSTALL_LOG 2>&1
 }
 
+# wait for debugging flag in /persist/k3s/wait_{flagname} if exist
+wait_for_item() {
+        filename="/persist/k3s/wait_$1"
+        processname="k3s server"
+        while [ -e "$filename" ]; do
+                k3sproc=""
+                if pgrep -x "$processname" > /dev/null; then
+                        k3sproc="k3s server is running"
+                else
+                        k3sproc="k3s server is NOT running"
+                fi
+                logmsg "Found $filename file. $k3sproc, Waiting for 60 seconds..."
+                sleep 60
+        done
+}
+
 # Return success if all pods are Running/Succeeded and Ready
 # Used in install time to control api server load
 # Return unix style 0 for success.  (Not 0 for false)
@@ -251,11 +354,6 @@ are_all_pods_ready() {
         return 0
 }
 
-#Make sure all prereqs are set after /var/lib is mounted to get logging info
-setup_prereqs
-
-VMICONFIG_FILENAME="/run/zedkube/vmiVNC.run"
-VNC_RUNNING=false
 # run virtctl vnc
 check_and_run_vnc() {
   pid=$(pgrep -f "/usr/bin/virtctl vnc" )
@@ -302,14 +400,18 @@ check_and_run_vnc() {
   fi
 }
 
-date >> $INSTALL_LOG
+setup_prereqs
+DATESTR=$(date)
+echo "========================== $DATESTR ==========================" >> $INSTALL_LOG
+echo "cluster-init.sh start for $HOSTNAME, uuid $DEVUUID" >> $INSTALL_LOG
+logmsg "Using ZFS persistent storage"
 
 #Forever loop every 15 secs
 while true;
 do
 if [ ! -f /var/lib/all_components_initialized ]; then
         if [ ! -f /var/lib/k3s_initialized ]; then
-                logmsg "Installing K3S version $K3S_VERSION on $(/bin/hostname)"
+                logmsg "Installing K3S version $K3S_VERSION on $HOSTNAME"
                 mkdir -p /var/lib/k3s/bin
                 /usr/bin/curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=${K3S_VERSION} INSTALL_K3S_SKIP_ENABLE=true INSTALL_K3S_BIN_DIR=/var/lib/k3s/bin sh -
                 logmsg "Initializing K3S version $K3S_VERSION"
@@ -326,9 +428,14 @@ if [ ! -f /var/lib/all_components_initialized ]; then
                 continue
         fi
 
-        this_node_ready=$(kubectl get node "$(/bin/hostname)" -o json | jq '.status.conditions[] | select(.reason=="KubeletReady") | .status=="True"')
+        this_node_ready=$(kubectl get node "$HOSTNAME" -o json | jq '.status.conditions[] | select(.reason=="KubeletReady") | .status=="True"')
         if [ "$this_node_ready" != "true" ]; then
                 continue
+        fi
+        node_uuid_len=$(kubectl get nodes -l node-uuid="$DEVUUID" -o json | jq '.items | length')
+        if [ "$node_uuid_len" -eq 0 ]; then
+          logmsg "set node label with uuid $DEVUUID"
+          kubectl label node "$HOSTNAME" node-uuid="$DEVUUID"
         fi
 
         if ! are_all_pods_ready; then
@@ -348,12 +455,20 @@ if [ ! -f /var/lib/all_components_initialized ]; then
                 /opt/cni/bin/dhcp daemon &
         fi
 
+        # setup debug user credential, role and binding
+        if [ ! -f /var/lib/debuguser-initialized ]; then
+                config_cluster_roles
+                continue
+        fi
+
         if [ ! -f /var/lib/kubevirt_initialized ]; then
+                wait_for_item "kubevirt"
                 # This patched version will be removed once the following PR https://github.com/kubevirt/kubevirt/pull/9668 is merged
                 logmsg "Installing patched Kubevirt"
                 kubectl apply -f /etc/kubevirt-operator.yaml
                 kubectl apply -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-cr.yaml
 
+                wait_for_item "cdi"
                 #CDI (containerzed data importer) is need to convert qcow2/raw formats to Persistent Volumes and Data volumes
                 #Since CDI goes with kubevirt we install with that.
                 logmsg "Installing CDI version $CDI_VERSION"
@@ -367,8 +482,9 @@ if [ ! -f /var/lib/all_components_initialized ]; then
         fi
 
         if [ ! -f /var/lib/longhorn_initialized ]; then
+                wait_for_item "longhorn"
                 logmsg "Installing longhorn version ${LONGHORN_VERSION}"
-                apply_longhorn_disk_config "$(/bin/hostname)"
+                apply_longhorn_disk_config "$HOSTNAME"
                 lhCfgPath=/var/lib/lh-cfg-${LONGHORN_VERSION}.yaml
                 if [ ! -e $lhCfgPath ]; then
                         curl -k https://raw.githubusercontent.com/longhorn/longhorn/${LONGHORN_VERSION}/deploy/longhorn.yaml > "$lhCfgPath"
@@ -387,7 +503,7 @@ if [ ! -f /var/lib/all_components_initialized ]; then
 else
         check_start_containerd
         if ! check_start_k3s; then
-                while [ "$(kubectl get node "$(/bin/hostname)" -o json | jq '.status.conditions[] | select(.reason=="KubeletReady") | .status=="True"')" != "true" ];
+                while [ "$(kubectl get node "$HOSTNAME" -o json | jq '.status.conditions[] | select(.reason=="KubeletReady") | .status=="True"')" != "true" ];
                 do
                         sleep 5;
                 done
@@ -402,19 +518,24 @@ else
                         # launch CNI dhcp service
                         /opt/cni/bin/dhcp daemon &
                 fi
+                # setup debug user credential, role and binding
+                if [ ! -f /var/lib/debuguser-initialized ]; then
+                        config_cluster_roles
+                else
+                        cp /var/lib/rancher/k3s/user.yaml /run/.kube/k3s/user.yaml
+                fi
         else
                 if [ -e /var/lib/longhorn_initialized ]; then
                         check_overwrite_nsmounter
                 fi
         fi
 fi
-        currentSize=$(wc -c <"$CTRD_LOG")
-        if [ "$currentSize" -gt "$LOG_SIZE" ]; then
-                cp "$CTRD_LOG" "${CTRD_LOG}.1"
-                truncate -s 0 "$CTRD_LOG"
-        fi
-
-        # Check and run vnc
+        check_log_file_size "k3s.log"
+        check_log_file_size "multus.log"
+        check_log_file_size "k3s-install.log"
+        check_log_file_size "eve-bridge.log"
+        check_log_file_size "containerd-user.log"
         check_and_run_vnc
+        wait_for_item "wait"
         sleep 15
 done

--- a/pkg/kube/config.yaml
+++ b/pkg/kube/config.yaml
@@ -2,12 +2,12 @@
 # k3s server config file.
 
 write-kubeconfig-mode: "0644"
-cluster-init: true
-log: "/var/lib/rancher/k3s/k3s.log"
+log: "/persist/newlog/kube/k3s.log"
 # Use longhorn storage
 disable: local-storage
-etcd-expose-metrics: true
-container-runtime-endpoint: "/run/containerd-user/containerd.sock"
 etcd-arg:
   - "quota-backend-bytes=8589934592"
+etcd-expose-metrics: true
+container-runtime-endpoint: "/run/containerd-user/containerd.sock"
 disable-network-policy: true
+disable-cloud-controller: true

--- a/pkg/kube/debuguser-role-binding.yaml
+++ b/pkg/kube/debuguser-role-binding.yaml
@@ -1,0 +1,119 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: vm-read-access
+  labels:
+    kubevirt.io: ""
+rules:
+  - apiGroups:
+      - subresources.kubevirt.io
+    resources:
+      - virtualmachineinstances/vnc
+      - virtualmachineinstances/console
+    verbs:
+      - get
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - kubevirts
+      - virtualmachines
+      - virtualmachineinstances
+      - virtualmachineinstancepresets
+      - virtualmachineinstancereplicasets
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - longhorn.io
+    resources:
+      - volumes
+      - volumes/status
+      - replicas
+      - replicas/status
+      - nodes
+      - nodes/status
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - metrics.k8s.io
+    resources:
+      - nodes
+      - pods
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vm-read-access-binding
+subjects:
+  - kind: User
+    name: debugging-user
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: vm-read-access
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: debugging-cluster-role
+rules:
+  - apiGroups: ["", "apps", "extensions", "k8s.cni.cncf.io", "apiextensions.k8s.io"]
+    resources: ['*']
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: debugging-cluster-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: debugging-cluster-role
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: debugging-user
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: debugging-exec-role
+  namespace: eve-kube-app
+rules:
+  - apiGroups: [""]
+    resources: ['pods/exec']
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: debugging-exec-role-binding
+  namespace: eve-kube-app
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: debugging-exec-role
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: debugging-user

--- a/pkg/kube/install-etcdctl.sh
+++ b/pkg/kube/install-etcdctl.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+#
+# Copyright (c) 2023 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+ETCDCTL_VERSION=v3.5.5
+/usr/bin/wget https://github.com/etcd-io/etcd/releases/download/${ETCDCTL_VERSION}/etcd-${ETCDCTL_VERSION}-linux-amd64.tar.gz
+tar -zxv --strip-components=1 -C /usr/local/bin  < ./etcd-${ETCDCTL_VERSION}-linux-amd64.tar.gz
+rm ./etcd-${ETCDCTL_VERSION}-linux-amd64.tar.gz


### PR DESCRIPTION
K3s to version v1.28.5+k3s1
On k3s restarts compress /persist/newlog/kube/k3s.log to k3s.log.restart..gz for root cause analysis.
Otherwise regular k3s log rotation can lose the crashes after the system becomes stable for some time.
Switched from etcd to SQLite for perf on
smaller nodes.
nfs-utils as it was missing in previous longhorn pr for rwx volumes.
Including debuguser role by @naiming-zededa.

Part 5 of: PR https://github.com/lf-edge/eve/pull/3838