### PR TITLE
fix a kubeapi function passing param caused by two PR merged same time

### DIFF
--- a/pkg/pillar/cmd/zedkube/vnc.go
+++ b/pkg/pillar/cmd/zedkube/vnc.go
@@ -68,7 +68,7 @@ func runAppVNC(ctx *zedkubeContext, config *types.AppInstanceConfig) {
 }
 
 func getVMIdomainName(ctx *zedkubeContext, config *types.AppInstanceConfig) (string, error) {
-	clientset, err := kubeapi.GetKubevirtClientSet()
+	clientset, err := kubeapi.GetKubevirtClientSet(nil)
 	if err != nil {
 		log.Errorf("getVMIs: get virtclient error %v", err)
 		return "", err


### PR DESCRIPTION
- fix an issue caused by two PRs merged almost at the same time.