### PR TITLE
Let crashkernel load modules

### DIFF
--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -25,11 +25,9 @@ onboot:
     capabilities:
       - CAP_SYS_ADMIN
       - CAP_NET_ADMIN
-  - name: modprobe
-    image: linuxkit/modprobe:ff76e806a0da0ea35f16951541cf3d24094b52c9
-    command: ["/bin/sh", "-c", "modprobe -a nct6775 w83627hf_wdt hpwdt wlcore_sdio wl18xx br_netfilter dwc3 rk808 rk808-regulator smsc75xx cp210x nicvf tpm_tis_spi rtc_rx8010 os-em32x regmap-i2c gpio_pca953x leds_gpio leds_siemens_ipc127 upboard-fpga pinctrl-upboard leds-upboard xhci_tegra 2>/dev/null || :"]
   # If you change the order of storage-init don't forget to
-  # change 003-installer in pkg/mkimage-raw-efi accordingly:
+  # change path to the "002-installer" in "pkg/mkimage-raw-efi/Dockerfile" and
+  # "pkg/mkverification-raw-efi/Dockerfile" accordingly:
   # storage-init must follow installer
   - name: storage-init
     image: STORAGE_INIT_TAG
@@ -37,9 +35,10 @@ onboot:
   - name: kdump
     image: KDUMP_TAG
   # If you change the order of pillar-onboot don't forget to
-  # change /containers/onboot/005-pillar-onboot/lower in pkg/mkimage-raw-efi accordingly:
-  # 005-pillar-onboot must follow the order number of pillar-onboot
-  # onboot part of pillar to prepare services to start
+  # change path to the "/containers/onboot/004-pillar-onboot/lower" in
+  # "pkg/mkimage-raw-efi/config.json" and "pkg/mkverification-raw-efi/config.json"
+  # accordingly: 004-pillar-onboot must follow the order number of pillar-onboot
+  # to prepare services to start
   - name: pillar-onboot
     image: PILLAR_TAG
     command: ["/opt/zededa/bin/onboot.sh"]

--- a/pkg/dom0-ztools/rootfs/etc/init.d/000-kexec
+++ b/pkg/dom0-ztools/rootfs/etc/init.d/000-kexec
@@ -9,7 +9,7 @@ if cat /proc/cmdline | grep -q crashkernel; then
     # This means we are on arch which does not support kdump
     # (e.g. riscv64, arm64) or xen (see pkg/grub/rootfs.cfg)
     #
-    kexec -p --reuse-cmdline --command-line="irqpoll nr_cpus=1 reset_devices nomodule" /boot/kernel
+    kexec -p --reuse-cmdline --command-line="irqpoll nr_cpus=1 reset_devices" /boot/kernel
 fi
 
 #

--- a/pkg/dom0-ztools/rootfs/etc/init.d/000-mod-params
+++ b/pkg/dom0-ztools/rootfs/etc/init.d/000-mod-params
@@ -36,3 +36,41 @@ zfs_set_default_parameters() {
 # Load ZFS and set parameters
 modprobe zfs
 zfs_set_default_parameters
+
+if ! test -f /proc/vmcore; then
+    #
+    # Load other modules for regular EVE kernel (not crashdump).
+    #
+    # FIXME: This was moved from the images/rootfs.yml.in, thus preserves
+    # FIXME: original indifference to any errors, which can happen while
+    # FIXME: loading on a machine, where particular hardware is missing.
+    # FIXME:
+    # FIXME: Future editor of this list, please take the trouble and at
+    # FIXME: least describe for what hardware and under what conditions
+    # FIXME: the module should be loaded.
+
+    modprobe nct6775              2>/dev/null
+    modprobe w83627hf_wdt         2>/dev/null
+    modprobe hpwdt                2>/dev/null
+    modprobe wlcore_sdio          2>/dev/null
+    modprobe wl18xx               2>/dev/null
+    modprboe br_netfilter         2>/dev/null
+    modprobe dwc3                 2>/dev/null
+    modprobe rk808                2>/dev/null
+    modprobe rk808-regulator      2>/dev/null
+    modprobe smsc75xx             2>/dev/null
+    modprobe cp210x               2>/dev/null
+    modprobe nct6775              2>/dev/null
+    modprobe nicvf                2>/dev/null
+    modprobe tpm_tis_spi          2>/dev/null
+    modprobe rtc_rx8010           2>/dev/null
+    modprobe os-em32x             2>/dev/null
+    modprobe regmap-i2c           2>/dev/null
+    modprobe gpio_pca953x         2>/dev/null
+    modprobe leds_gpio            2>/dev/null
+    modprobe leds_siemens_ipc127  2>/dev/null
+    modprobe upboard-fpga         2>/dev/null
+    modprobe pinctrl-upboard      2>/dev/null
+    modprobe leds-upboard         2>/dev/null
+    modprobe xhci_tegra           2>/dev/null
+fi

--- a/pkg/mkimage-raw-efi/Dockerfile
+++ b/pkg/mkimage-raw-efi/Dockerfile
@@ -31,8 +31,8 @@ COPY make-raw install grub.cfg.in UsbInvocationScript.txt ./
 # precede the storage-init container.
 #
 # now lets create an edge container
-# FIXME: 003-installer? why not linuxkit build?
-WORKDIR /eco/media/root-rw/root/containers/onboot/003-installer
+# FIXME: 002-installer? why not linuxkit build?
+WORKDIR /eco/media/root-rw/root/containers/onboot/002-installer
 COPY runtime.json config.json ./
 RUN mv /out rootfs
 # hadolint ignore=DL3003

--- a/pkg/mkimage-raw-efi/config.json
+++ b/pkg/mkimage-raw-efi/config.json
@@ -220,7 +220,7 @@
         {
             "destination": "/opt/pillar",
             "type": "bind",
-            "source": "/containers/onboot/005-pillar-onboot/lower",
+            "source": "/containers/onboot/004-pillar-onboot/lower",
             "options": [
                 "rw",
                 "rbind",

--- a/pkg/mkverification-raw-efi/config.json
+++ b/pkg/mkverification-raw-efi/config.json
@@ -220,7 +220,7 @@
         {
             "destination": "/opt/pillar",
             "type": "bind",
-            "source": "/containers/onboot/005-pillar-onboot/lower",
+            "source": "/containers/onboot/004-pillar-onboot/lower",
             "options": [
                 "rw",
                 "rbind",


### PR DESCRIPTION
This PR fixes the inability to collect kernel dumps for the /persist formatted as ZFS and consists of 2 commits:

1. rootfs: move modprobe to the 000-mod-params initd script
    Let's have modules load in a proper place: /etc/init.d/000-mod-params
    scripts, which is responsible for loading modules and providing
    parameters.
    
    The other motivation is to have fine control over modules and for
    example do not load modules (except ZFS) for the crashkernel.
    
2.  000-kexec: remove 'nomodule' parameter, allows crashkernel to load modules
    Patch removes 'nomodule' kernel parameter, which lets crashskernel
    to load modules. This is utterly needed for interacting with the /persist
    formatted as ZFS. ZFS is built separately out-of-tree as a module, so
    has to be loaded explicitly by the crashkernel.
    
    The majority of other modules are excluded from loading for the
    crashkernel, see the 000-mod-params script.
