### PR TITLE
read simple persist-type reader out of vault

### DIFF
--- a/pkg/pillar/cas/cas.go
+++ b/pkg/pillar/cas/cas.go
@@ -12,28 +12,31 @@ import (
 
 // BlobInfo holds the info of a blob present in CAS's blob store
 type BlobInfo struct {
-	//Digest to identify the blob uniquely. The format will/should be <algo>:<hash> (currently supporting only sha256:<hash>).
+	// Digest to identify the blob uniquely. The format will/should be <algo>:<hash> (currently supporting only sha256:<hash>).
 	Digest string
 
-	//Size of the blob
+	// Size of the blob
 	Size int64
 
-	//Labels to add/define properties for the blob
+	// Labels to add/define properties for the blob
 	Labels map[string]string
 }
 
 // CAS provides methods to interact with CAS clients
 // Context handling should be taken care by the underlying implementor.
+//
+//nolint:interfacebloat
 type CAS interface {
-	//Blob APIs
-	//CheckBlobExists: returns true if the blob exists.
-	//Arg 'blobHash' should be of format <algo>:<hash> (currently supporting only sha256:<hash>).
+	// Blob APIs
+
+	// CheckBlobExists: returns true if the blob exists.
+	// Arg 'blobHash' should be of format <algo>:<hash> (currently supporting only sha256:<hash>).
 	CheckBlobExists(blobHash string) bool
-	//GetBlobInfo: returns BlobInfo of type BlobInfo for the given blobHash.
-	//Arg 'blobHash' should be of format <algo>:<hash> (currently supporting only sha256:<hash>).
-	//Returns error if no blob is found for the given 'blobHash'.
+	// GetBlobInfo: returns BlobInfo of type BlobInfo for the given blobHash.
+	// Arg 'blobHash' should be of format <algo>:<hash> (currently supporting only sha256:<hash>).
+	// Returns error if no blob is found for the given 'blobHash'.
 	GetBlobInfo(blobHash string) (*BlobInfo, error)
-	//ListBlobInfo: returns list of BlobInfo for all the blob present in CAS
+	// ListBlobInfo: returns list of BlobInfo for all the blob present in CAS
 	ListBlobInfo() ([]*BlobInfo, error)
 	// ListBlobsMediaTypes get a map of all blobs and their media types.
 	// If a blob does not have a media type, it is not returned here.
@@ -46,51 +49,53 @@ type CAS interface {
 	// respective BlobStatus.Sha256 or if there is an exception while reading the blob data.
 	// In case of exception, the returned list of loaded blob will contain all the blob that were loaded until that point.
 	IngestBlob(ctx context.Context, blobs ...types.BlobStatus) ([]types.BlobStatus, error)
-	//UpdateBlobInfo updates BlobInfo of a blob in CAS.
-	//Arg is BlobInfo type struct in which BlobInfo.Digest is mandatory, and other field to be fill only if need to be updated
-	//Returns error is no blob is found match blobInfo.Digest
+	// UpdateBlobInfo updates BlobInfo of a blob in CAS.
+	// Arg is BlobInfo type struct in which BlobInfo.Digest is mandatory, and other field to be fill only if need to be updated
+	// Returns error is no blob is found match blobInfo.Digest
 	UpdateBlobInfo(blobInfo BlobInfo) error
-	//ReadBlob: returns a reader to consume the raw data of the blob which matches the given arg 'blobHash'.
-	//Returns error if no blob is found for the given 'blobHash'.
-	//Arg 'blobHash' should be of format <algo>:<hash> (currently supporting only sha256:<hash>).
+	// ReadBlob: returns a reader to consume the raw data of the blob which matches the given arg 'blobHash'.
+	// Returns error if no blob is found for the given 'blobHash'.
+	// Arg 'blobHash' should be of format <algo>:<hash> (currently supporting only sha256:<hash>).
 	ReadBlob(ctx context.Context, blobHash string) (io.Reader, error)
-	//RemoveBlob: removes a blob which matches the given arg 'blobHash'.
-	//To keep this method idempotent, no error is returned if the given arg 'blobHash' does not match any blob.
-	//Arg 'blobHash' should be of format <algo>:<hash> (currently supporting only sha256:<hash>).
+	// RemoveBlob: removes a blob which matches the given arg 'blobHash'.
+	// To keep this method idempotent, no error is returned if the given arg 'blobHash' does not match any blob.
+	// Arg 'blobHash' should be of format <algo>:<hash> (currently supporting only sha256:<hash>).
 	RemoveBlob(blobHash string) error
-	//Children: returns a list of child blob hashes if the given arg 'blobHash' belongs to a
+	// Children: returns a list of child blob hashes if the given arg 'blobHash' belongs to a
 	// index or a manifest blob, else an empty list is returned.
-	//Format of returned blob hash list and arg 'blobHash' is <algo>:<hash> (currently supporting only sha256:<hash>)
+	// Format of returned blob hash list and arg 'blobHash' is <algo>:<hash> (currently supporting only sha256:<hash>)
 	Children(blobHash string) ([]string, error)
 
-	//Image APIs
-	//CreateImage: creates a reference which points to a blob with 'blobHash'. 'blobHash' must belong to a index blob
-	//Arg 'blobHash' should be of format <algo>:<hash> (currently supporting only sha256:<hash>).
-	//Returns error if no blob is found matching the given 'blobHash' or if the given 'blobHash' does not belong to an index.
+	// Image APIs
+
+	// CreateImage: creates a reference which points to a blob with 'blobHash'. 'blobHash' must belong to a index blob
+	// Arg 'blobHash' should be of format <algo>:<hash> (currently supporting only sha256:<hash>).
+	// Returns error if no blob is found matching the given 'blobHash' or if the given 'blobHash' does not belong to an index.
 	CreateImage(reference, mediaType, blobHash string) error
-	//GetImageHash: returns a blob hash of format <algo>:<hash> (currently supporting only sha256:<hash>) which the given 'reference' is pointing to.
+	// GetImageHash: returns a blob hash of format <algo>:<hash> (currently supporting only sha256:<hash>) which the given 'reference' is pointing to.
 	// Returns error if the given 'reference' is not found.
 	GetImageHash(reference string) (string, error)
-	//s  returns the labels set on the image.
-	//Returns error if the given reference is not found
+	// GetImageLabels  returns the labels set on the image.
+	// Returns error if the given reference is not found
 	GetImageLabels(reference string) (map[string]string, error)
-	//ListImages: returns a list of references
+	// ListImages: returns a list of references
 	ListImages() ([]string, error)
-	//RemoveImage removes an reference from CAS
-	//To keep this method idempotent, no error  is returned if the given 'reference' is not found.
+	// RemoveImage removes an reference from CAS
+	// To keep this method idempotent, no error  is returned if the given 'reference' is not found.
 	RemoveImage(reference string) error
-	//ReplaceImage: replaces the blob hash to which the given 'reference' is pointing to with the given 'blobHash'.
-	//Returns error if the given 'reference' or a blob matching the given arg 'blobHash' is not found.
-	//Returns if the given 'blobHash' does not belong to an index.
-	//Arg 'blobHash' should be of format <algo>:<hash> (currently supporting only sha256:<hash>).
+	// ReplaceImage: replaces the blob hash to which the given 'reference' is pointing to with the given 'blobHash'.
+	// Returns error if the given 'reference' or a blob matching the given arg 'blobHash' is not found.
+	// Returns if the given 'blobHash' does not belong to an index.
+	// Arg 'blobHash' should be of format <algo>:<hash> (currently supporting only sha256:<hash>).
 	ReplaceImage(reference, mediaType, blobHash string) error
 
-	//Snapshot APIs
-	//CreateSnapshotForImage: creates an snapshot with the given snapshotID for the given 'reference'
-	//Arg 'snapshotID' should be of format <algo>:<hash> (currently supporting only sha256:<hash>).
+	// Snapshot APIs
+
+	// CreateSnapshotForImage: creates an snapshot with the given snapshotID for the given 'reference'
+	// Arg 'snapshotID' should be of format <algo>:<hash> (currently supporting only sha256:<hash>).
 	CreateSnapshotForImage(snapshotID, reference string) error
-	//MountSnapshot: mounts the snapshot on the given target path
-	//Arg 'snapshotID' should be of format <algo>:<hash> (currently supporting only sha256:<hash>).
+	// MountSnapshot: mounts the snapshot on the given target path
+	// Arg 'snapshotID' should be of format <algo>:<hash> (currently supporting only sha256:<hash>).
 	MountSnapshot(snapshotID, targetPath string) error
 	// SnapshotUsage returns current usage of snapshot in bytes
 	// We create snapshots for every layer of image and one active snapshot on top of them
@@ -98,11 +103,11 @@ type CAS interface {
 	// If parents defined also adds usage of all parents of provided snapshot,
 	// not only the top active one
 	SnapshotUsage(snapshotID string, parents bool) (int64, error)
-	//ListSnapshots: returns a list of snapshotIDs where each entry is of format <algo>:<hash> (currently supporting only sha256:<hash>).
+	// ListSnapshots returns a list of snapshotIDs where each entry is of format <algo>:<hash> (currently supporting only sha256:<hash>).
 	ListSnapshots() ([]string, error)
-	//ListSnapshots: removes a snapshot matching the given 'snapshotID'.
-	//Arg 'snapshotID' should be of format <algo>:<hash> (currently supporting only sha256:<hash>).
-	//To keep this method idempotent, no error  is returned if the given 'snapshotID' is not found.
+	// RemoveSnapshot removes a snapshot matching the given 'snapshotID'.
+	// Arg 'snapshotID' should be of format <algo>:<hash> (currently supporting only sha256:<hash>).
+	// To keep this method idempotent, no error  is returned if the given 'snapshotID' is not found.
 	RemoveSnapshot(snapshotID string) error
 
 	// PrepareContainerRootDir creates a reference pointing to the rootBlob and prepares a writable snapshot
@@ -127,9 +132,9 @@ type CAS interface {
 	// but this API will add a lock, upload all the blobs, add reference to the blobs and release the lock.
 	// By adding a lock before uploading the blobs we prevent the unreferenced blobs from getting GCed.
 	// We will assume that the first blob in the list will be the root blob for which the reference will be created.
-	// Returns an an error if the read blob's hash does not match with the respective BlobStatus.Sha256 or
+	// Returns an error if the read blob's hash does not match with the respective BlobStatus.Sha256 or
 	// if there is an exception while reading the blob data.
-	//NOTE: This either loads all the blobs or loads nothing. In other words, in case of error,
+	// NOTE: This either loads all the blobs or loads nothing. In other words, in case of error,
 	// this API will GC all blobs that were loaded until that point.
 	IngestBlobsAndCreateImage(reference string, root types.BlobStatus, blobs ...types.BlobStatus) ([]types.BlobStatus, error)
 
@@ -161,7 +166,7 @@ func CheckAndCorrectBlobHash(blobHash string) string {
 func NewCAS(selectedCAS string) (CAS, error) {
 	if _, found := knownCASHandlers[selectedCAS]; !found {
 		return nil, fmt.Errorf("Unknown CAS handler %s", selectedCAS)
-	} else {
-		return knownCASHandlers[selectedCAS].constructor(), nil
 	}
+	return knownCASHandlers[selectedCAS].constructor(), nil
+
 }

--- a/pkg/pillar/cmd/vaultmgr/vaultmgr.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgr.go
@@ -40,6 +40,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils"
+	"github.com/lf-edge/eve/pkg/pillar/utils/persist"
 	"github.com/lf-edge/eve/pkg/pillar/vault"
 	"github.com/lf-edge/eve/pkg/pillar/zfs"
 	"github.com/sirupsen/logrus"
@@ -148,7 +149,7 @@ func initializeSelfPublishHandles(ps *pubsub.PubSub, ctx *vaultMgrContext) {
 func checkAndPublishVaultConfig(ctx *vaultMgrContext) bool {
 	// We do not have vault config, publish it
 	if vaultConfigInited == false {
-		persistFsType := vault.ReadPersistType()
+		persistFsType := persist.ReadPersistType()
 		tpmKeyOnly := false
 
 		switch persistFsType {

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -22,7 +22,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils"
-	"github.com/lf-edge/eve/pkg/pillar/vault"
+	"github.com/lf-edge/eve/pkg/pillar/utils/persist"
 	"github.com/lf-edge/eve/pkg/pillar/worker"
 	"github.com/lf-edge/eve/pkg/pillar/zfs"
 	"github.com/sirupsen/logrus"
@@ -143,7 +143,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		vdiskGCTime:        3600,
 		deferContentDelete: 0,
 		globalConfig:       types.DefaultConfigItemValueMap(),
-		persistType:        vault.ReadPersistType(),
+		persistType:        persist.ReadPersistType(),
 		hvTypeKube:         base.IsHVTypeKube(),
 	}
 	agentbase.Init(&ctx, logger, log, agentName,

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -25,7 +25,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/flextimer"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils"
-	"github.com/lf-edge/eve/pkg/pillar/vault"
+	"github.com/lf-edge/eve/pkg/pillar/utils/persist"
 	"github.com/lf-edge/eve/pkg/pillar/zedcloud"
 	"github.com/shirou/gopsutil/host"
 	"google.golang.org/protobuf/proto"
@@ -662,7 +662,7 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 	ReportDeviceMetric.DormantTimeInSeconds = getDormantTime(ctx)
 
 	// Report metrics from ZFS
-	if vault.ReadPersistType() == types.PersistZFS {
+	if persist.ReadPersistType() == types.PersistZFS {
 		for _, el := range ctx.subZFSPoolMetrics.GetAll() {
 			zfsPoolMetrics := el.(types.ZFSPoolMetrics)
 			ReportDeviceMetric.StorageMetrics = append(ReportDeviceMetric.StorageMetrics,

--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -25,6 +25,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils"
 	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
+	"github.com/lf-edge/eve/pkg/pillar/utils/persist"
 	"github.com/lf-edge/eve/pkg/pillar/vault"
 	uuid "github.com/satori/go.uuid"
 	"github.com/shirou/gopsutil/host"
@@ -387,7 +388,7 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext, dest destinationBitset) {
 	}
 
 	// Reporting all zpools in Strorage Info
-	if vault.ReadPersistType() == types.PersistZFS {
+	if persist.ReadPersistType() == types.PersistZFS {
 		zfsPoolStatusMap := ctx.subZFSPoolStatus.GetAll()
 		for _, el := range zfsPoolStatusMap {
 			zfsPoolStatus := el.(types.ZFSPoolStatus)

--- a/pkg/pillar/cmd/zedmanager/memorysizemgmt.go
+++ b/pkg/pillar/cmd/zedmanager/memorysizemgmt.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/lf-edge/eve/pkg/pillar/types"
-	"github.com/lf-edge/eve/pkg/pillar/vault"
+	"github.com/lf-edge/eve/pkg/pillar/utils/persist"
 )
 
 // getRemainingMemory returns how many bytes remain for app instance usage
@@ -42,7 +42,7 @@ func getRemainingMemory(ctxPtr *zedmanagerContext) (uint64, uint64, uint64, erro
 		}
 	}
 	memoryReservedForEve := uint64(ctxPtr.globalConfig.GlobalValueInt(types.EveMemoryLimitInBytes))
-	if vault.ReadPersistType() == types.PersistZFS {
+	if persist.ReadPersistType() == types.PersistZFS {
 		zfsArcMaxLimit, err := types.GetZFSArcMaxSizeInBytes()
 		if err != nil {
 			return 0, 0, 0, fmt.Errorf("failed to get data from zfs_arc_max. error: %v", err)

--- a/pkg/pillar/cmd/zfsmanager/handlediskconfig.go
+++ b/pkg/pillar/cmd/zfsmanager/handlediskconfig.go
@@ -12,7 +12,7 @@ import (
 	libzfs "github.com/andrewd-zededa/go-libzfs"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils/disks"
-	"github.com/lf-edge/eve/pkg/pillar/vault"
+	"github.com/lf-edge/eve/pkg/pillar/utils/persist"
 	"github.com/lf-edge/eve/pkg/pillar/zfs"
 )
 
@@ -90,7 +90,7 @@ func processDisksTask(ctx *zfsContext) {
 }
 
 func processDisks(ctx *zfsContext) error {
-	if vault.ReadPersistType() != types.PersistZFS {
+	if persist.ReadPersistType() != types.PersistZFS {
 		return nil
 	}
 	disksConfigInterface, err := ctx.subDisksConfig.Get("global")

--- a/pkg/pillar/cmd/zfsmanager/zfsmanager.go
+++ b/pkg/pillar/cmd/zfsmanager/zfsmanager.go
@@ -17,7 +17,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils"
-	"github.com/lf-edge/eve/pkg/pillar/vault"
+	"github.com/lf-edge/eve/pkg/pillar/utils/persist"
 	"github.com/lf-edge/eve/pkg/pillar/zfs"
 	"github.com/sirupsen/logrus"
 )
@@ -385,7 +385,7 @@ func maybeUpdateConfigItems(ctx *zfsContext, newConfigItemValueMap *types.Config
 	log.Functionf("maybeUpdateConfigItems")
 	oldConfigItemValueMap := ctx.globalConfig
 
-	if vault.ReadPersistType() != types.PersistZFS {
+	if persist.ReadPersistType() != types.PersistZFS {
 		return
 	}
 	newStorageZfsReserved := newConfigItemValueMap.GlobalValueInt(types.StorageZfsReserved)

--- a/pkg/pillar/cmd/zfsmanager/zfsstoragemetrics.go
+++ b/pkg/pillar/cmd/zfsmanager/zfsstoragemetrics.go
@@ -8,7 +8,7 @@ import (
 
 	libzfs "github.com/andrewd-zededa/go-libzfs"
 	"github.com/lf-edge/eve/pkg/pillar/types"
-	"github.com/lf-edge/eve/pkg/pillar/vault"
+	"github.com/lf-edge/eve/pkg/pillar/utils/persist"
 	"github.com/lf-edge/eve/pkg/pillar/zfs"
 )
 
@@ -17,7 +17,7 @@ const (
 )
 
 func storageMetricsPublisher(ctxPtr *zfsContext) {
-	if vault.ReadPersistType() != types.PersistZFS {
+	if persist.ReadPersistType() != types.PersistZFS {
 		return
 	}
 	collectAndPublishStorageMetrics(ctxPtr)
@@ -56,7 +56,7 @@ func collectAndPublishStorageMetrics(ctxPtr *zfsContext) {
 					// we did not go to creating of volume, nothing to measure
 					continue
 				}
-				if !volumeStatus.UseZVolDisk(vault.ReadPersistType()) {
+				if !volumeStatus.UseZVolDisk(persist.ReadPersistType()) {
 					// we do not create zvol for that volumeStatus
 					continue
 				}

--- a/pkg/pillar/cmd/zfsmanager/zfsstoragestatus.go
+++ b/pkg/pillar/cmd/zfsmanager/zfsstoragestatus.go
@@ -9,7 +9,7 @@ import (
 
 	libzfs "github.com/andrewd-zededa/go-libzfs"
 	"github.com/lf-edge/eve/pkg/pillar/types"
-	"github.com/lf-edge/eve/pkg/pillar/vault"
+	"github.com/lf-edge/eve/pkg/pillar/utils/persist"
 	"github.com/lf-edge/eve/pkg/pillar/zfs"
 )
 
@@ -18,7 +18,7 @@ const (
 )
 
 func storageStatusPublisher(ctxPtr *zfsContext) {
-	if vault.ReadPersistType() != types.PersistZFS {
+	if persist.ReadPersistType() != types.PersistZFS {
 		return
 	}
 	collectAndPublishStorageStatus(ctxPtr)

--- a/pkg/pillar/containerd/containerd.go
+++ b/pkg/pillar/containerd/containerd.go
@@ -30,7 +30,7 @@ import (
 	"github.com/lf-edge/edge-containers/pkg/resolver"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/types"
-	"github.com/lf-edge/eve/pkg/pillar/vault"
+	"github.com/lf-edge/eve/pkg/pillar/utils/persist"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
 	"github.com/vishvananda/netlink"
@@ -97,7 +97,7 @@ func GetServicesNamespace() string {
 func init() {
 	logrus.Info("Containerd Init")
 	// see if we need to use zfs snapshotter based on what flavor of storage persist partition is
-	if vault.ReadPersistType() == types.PersistZFS {
+	if persist.ReadPersistType() == types.PersistZFS {
 		defaultSnapshotter = types.ZFSSnapshotter
 	}
 

--- a/pkg/pillar/diskmetrics/usage.go
+++ b/pkg/pillar/diskmetrics/usage.go
@@ -14,7 +14,7 @@ import (
 	"github.com/containerd/containerd/mount"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/types"
-	"github.com/lf-edge/eve/pkg/pillar/vault"
+	"github.com/lf-edge/eve/pkg/pillar/utils/persist"
 	"github.com/lf-edge/eve/pkg/pillar/zfs"
 	"github.com/shirou/gopsutil/disk"
 )
@@ -156,7 +156,7 @@ func FindLargestDisk(log *base.LogObject) string {
 // DirUsage calculates usage of directory
 // it checks if provided directory is zfs mountpoint and take usage from zfs in that case
 func DirUsage(log *base.LogObject, dir string) (uint64, error) {
-	if vault.ReadPersistType() != types.PersistZFS || !strings.HasPrefix(dir, types.PersistDir) {
+	if persist.ReadPersistType() != types.PersistZFS || !strings.HasPrefix(dir, types.PersistDir) {
 		return SizeFromDir(log, dir)
 	}
 	mi, err := mount.Lookup(dir)
@@ -198,7 +198,7 @@ func Dom0DiskReservedSize(log *base.LogObject, globalConfig *types.ConfigItemVal
 // usage of zvols and snapshots
 // Note that we subtract usage of persist/reserved dataset (about 20% of persist capacity)
 func PersistUsageStat(log *base.LogObject) (*types.UsageStat, error) {
-	if vault.ReadPersistType() != types.PersistZFS {
+	if persist.ReadPersistType() != types.PersistZFS {
 		deviceDiskUsage, err := disk.Usage(types.PersistDir)
 		if err != nil {
 			return nil, err

--- a/pkg/pillar/utils/persist/persist.go
+++ b/pkg/pillar/utils/persist/persist.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2024 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package persist
+
+import (
+	"os"
+	"strings"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+const (
+	evePersistTypeFile = "/run/eve.persist_type"
+)
+
+// ReadPersistType returns the persist filesystem
+func ReadPersistType() types.PersistType {
+	persistFsType := ""
+	pBytes, err := os.ReadFile(evePersistTypeFile)
+	if err == nil {
+		persistFsType = strings.TrimSpace(string(pBytes))
+	}
+	return types.ParsePersistType(persistFsType)
+}

--- a/pkg/pillar/vault/handler.go
+++ b/pkg/pillar/vault/handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/lf-edge/eve-api/go/info"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/lf-edge/eve/pkg/pillar/utils/persist"
 )
 
 // HandlerOptions defines options for handler
@@ -28,7 +29,7 @@ type Handler interface {
 
 // GetHandler returns Handler implementation for the current persist type
 func GetHandler(log *base.LogObject) Handler {
-	persistFsType := ReadPersistType()
+	persistFsType := persist.ReadPersistType()
 	switch persistFsType {
 	case types.PersistZFS:
 		return &ZFSHandler{log: log}

--- a/pkg/pillar/vault/vault.go
+++ b/pkg/pillar/vault/vault.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 
 	"github.com/lf-edge/eve-api/go/info"
 	"github.com/lf-edge/eve/pkg/pillar/base"
@@ -18,8 +17,6 @@ import (
 )
 
 const (
-	evePersistTypeFile = "/run/eve.persist_type"
-
 	// allowVaultCleanFile existence indicates that we want to recreate vault in case of no controller key
 	// we set it in installer and storage-init
 	// so path must be aligned
@@ -30,16 +27,6 @@ const (
 func GetOperationalInfo(log *base.LogObject) (info.DataSecAtRestStatus, string) {
 	h := GetHandler(log)
 	return h.GetOperationalInfo()
-}
-
-// ReadPersistType returns the persist filesystem
-func ReadPersistType() types.PersistType {
-	persistFsType := ""
-	pBytes, err := os.ReadFile(evePersistTypeFile)
-	if err == nil {
-		persistFsType = strings.TrimSpace(string(pBytes))
-	}
-	return types.ParsePersistType(persistFsType)
 }
 
 // DisallowVaultCleanup do not allow vault cleanup

--- a/pkg/pillar/volumehandlers/handlers.go
+++ b/pkg/pillar/volumehandlers/handlers.go
@@ -4,11 +4,12 @@
 package volumehandlers
 
 import (
+	"time"
+
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/cas"
 	"github.com/lf-edge/eve/pkg/pillar/types"
-	"github.com/lf-edge/eve/pkg/pillar/vault"
-	"time"
+	"github.com/lf-edge/eve/pkg/pillar/utils/persist"
 )
 
 // VolumeHandler implements processing of different volumes types
@@ -69,7 +70,7 @@ func GetVolumeHandler(log *base.LogObject, volumeManager VolumeMgr, status *type
 	if status.IsContainer() {
 		return &volumeHandlerContainer{common}
 	}
-	if status.UseZVolDisk(vault.ReadPersistType()) {
+	if status.UseZVolDisk(persist.ReadPersistType()) {
 		return &volumeHandlerZVol{commonVolumeHandler: common, useVHost: useVhost(log, volumeManager)}
 	}
 	return &volumeHandlerFile{common}


### PR DESCRIPTION
Any usage of `pkg/pillar/utils`, especially those things calling `WaitFor*()`, ends up depending on `pkg/pillar/containerd`, just to get the containerd client. It then depends on `pkg/pillar/vault`, because it needs to call `vault.ReadPersistType()`.

`ReadPersistType()` is a simple function to read a file. But because it is in `vault`, it in turns depends on the go-zfs library, which is CGO, only available on Linux and with the right packages installed.

That complex dependency shouldn't exist for something like utils. 

This moves just `ReadPersistType()` out of `pkg/pillar/vault` and into `pkg/pillar/utils/persist`. The dependency tree is simplified.