### PR TITLE
Remove RESTARTING/PURGING states

### DIFF
--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -219,10 +219,6 @@ func countRunningApps(getconfigCtx *getconfigContext) (runningCount uint) {
 		switch status.State {
 		case types.BOOTING, types.RUNNING, types.HALTING:
 			runningCount++
-		case types.PURGING, types.RESTARTING:
-			log.Noticef("countRunningApps: %s for %s in %s",
-				status.Key(), status.DisplayName, status.State)
-			runningCount++
 		}
 	}
 	return runningCount

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -802,15 +802,10 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 		}
 	}
 	if ds.State != status.State {
-		switch status.State {
-		case types.RESTARTING, types.PURGING:
-			// Leave unchanged
-		default:
-			log.Functionf("Set State from DomainStatus from %d to %d",
-				status.State, ds.State)
-			status.State = ds.State
-			changed = true
-		}
+		log.Functionf("Set State from DomainStatus from %d to %d",
+			status.State, ds.State)
+		status.State = ds.State
+		changed = true
 	}
 	// XXX compare with equal before setting changed?
 	status.IoAdapterList = ds.IoAdapterList

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -171,6 +171,7 @@ func doUpdate(ctx *zedmanagerContext,
 		log.Functionf("PurgeInprogress(%s) volumemgr done",
 			status.Key())
 		status.PurgeInprogress = types.BringDown
+		status.State = types.HALTING
 		changed = true
 		// Keep the old volumes in place
 		_, done := doRemove(ctx, status, false)

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -1174,15 +1174,10 @@ func doInactivateHalt(ctx *zedmanagerContext,
 		changed = true
 	}
 	if ds.State != status.State {
-		switch status.State {
-		case types.RESTARTING, types.PURGING:
-			// Leave unchanged
-		default:
-			log.Functionf("Set State from DomainStatus from %d to %d",
-				status.State, ds.State)
-			status.State = ds.State
-			changed = true
-		}
+		log.Functionf("Set State from DomainStatus from %d to %d",
+			status.State, ds.State)
+		status.State = ds.State
+		changed = true
 	}
 	// Ignore errors during a halt
 	if ds.HasError() {

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -1062,7 +1062,6 @@ func handleCreate(ctxArg interface{}, key string,
 			log.Warnf("handleCreate(%v) for %s found different purge counter %d vs. %d",
 				config.UUIDandVersion, config.DisplayName, persistedCounter, configCounter)
 			status.PurgeInprogress = types.DownloadAndVerify
-			status.State = types.PURGING
 			status.PurgeStartedAt = time.Now()
 			// We persist the PurgeCmd Counter when
 			// PurgeInprogress is done
@@ -1222,8 +1221,7 @@ func handleModify(ctxArg interface{}, key string,
 			// Will restart even if we crash/power cycle since that
 			// would also restart the app. Hence we can update
 			// the status counter here.
-			status.RestartInprogress = types.BringDown
-			status.State = types.RESTARTING
+			status.RestartInprogress = types.BringDown // indicate to restart
 			status.RestartStartedAt = time.Now()
 		} else {
 			log.Functionf("handleModify(%v) for %s restartcmd ignored config !Activate",
@@ -1254,7 +1252,6 @@ func handleModify(ctxArg interface{}, key string,
 			status.ClearErrorWithSource()
 		}
 		status.PurgeInprogress = types.DownloadAndVerify
-		status.State = types.PURGING
 		status.PurgeStartedAt = time.Now()
 		// We persist the PurgeCmd Counter when PurgeInprogress is done
 	} else if needPurge {

--- a/pkg/pillar/types/types.go
+++ b/pkg/pillar/types/types.go
@@ -18,7 +18,7 @@ import (
 
 // SwState started with enum names from OMA-TS-LWM2M_SwMgmt-V1_0-20151201-C
 // but now has many additions.
-// They are in order of progression (except for the RESTARTING and PURGING ones)
+// They are in order of progression
 // We map this to info.ZSwState
 type SwState uint8
 
@@ -44,10 +44,8 @@ const (
 	PAUSED
 	HALTING // being halted
 	HALTED
-	RESTARTING // Restarting due to config change or zcli
-	PURGING    // Purging due to config change
-	BROKEN     // Domain is still alive, but its device model has failed
-	UNKNOWN    // State of the domain can't be determined
+	BROKEN  // BROKEN means domain is still alive, but its device model has failed
+	UNKNOWN // UNKNOWN means state of the domain can't be determined
 	// PENDING to start
 	PENDING
 	// SCHEDULING waiting to be scheduled
@@ -98,10 +96,6 @@ func (state SwState) String() string {
 		return "HALTING"
 	case HALTED:
 		return "HALTED"
-	case RESTARTING:
-		return "RESTARTING"
-	case PURGING:
-		return "PURGING"
 	case PENDING:
 		return "PENDING"
 	case FAILED:
@@ -170,10 +164,6 @@ func (state SwState) ZSwState() info.ZSwState {
 		return info.ZSwState_HALTING
 	case HALTED:
 		return info.ZSwState_HALTED
-	case RESTARTING:
-		return info.ZSwState_RESTARTING
-	case PURGING:
-		return info.ZSwState_PURGING
 	// we map BROKEN to HALTING to indicate that EVE has an active
 	// role in reaping BROKEN domains and transitioning them to
 	// a final HALTED state


### PR DESCRIPTION
if an edge app upgrade is done while an EVE update is done,
the app status state stays in RESTARTING although EVE
will restart and therefore halt the app instance; therefore
the app status should go to HALT in this case.