### PR TITLE
Kernel update - [amd64-generic, amd64-rt, arm64-nvidia]

### DIFF
--- a/kernel-commits.mk
+++ b/kernel-commits.mk
@@ -1,8 +1,8 @@
 KERNEL_COMMIT_amd64_v5.10.186_generic = 37256d6aff33
-KERNEL_COMMIT_amd64_v6.1.38_generic = ddbb9e41fa01
-KERNEL_COMMIT_amd64_v6.1.38_rt = 94c2c02bf1b9
+KERNEL_COMMIT_amd64_v6.1.38_generic = fcab2e7830ca
+KERNEL_COMMIT_amd64_v6.1.38_rt = 1ead4c5f5ee7
 KERNEL_COMMIT_amd64_v6.1.68_generic = b4d7ad0a73b1
-KERNEL_COMMIT_arm64_v5.10.104_nvidia = 11760a953d2d
+KERNEL_COMMIT_arm64_v5.10.104_nvidia = 69009e88617e
 KERNEL_COMMIT_arm64_v5.10.186_generic = 594f2361a83f
 KERNEL_COMMIT_arm64_v6.1.38_generic = 5e51e61211ea
 KERNEL_COMMIT_riscv64_v6.1.38_generic = 72192e3cbc74


### PR DESCRIPTION
**NOTE:** this PR supersedes https://github.com/lf-edge/eve/pull/3903

eve-kernel-amd64-v6.1.38-generic
    fcab2e7830ca: stmmac: Do not enable/disable runtime PM for PCI devices

eve-kernel-amd64-v6.1.38-rt
    1ead4c5f5ee7: sched/isolation: add 'inverse' parameter for the 'nohz_full' and 'isolcpus'

eve-kernel-arm64-v5.10.104-nvidia
    69009e88617e: Dockerfile.gcc: Change rtw88 revision