### PR TITLE
move nvme-zfs func out of types into own package to avoid dependency pollution

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -46,6 +46,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/utils/cloudconfig"
 	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 	"github.com/lf-edge/eve/pkg/pillar/utils/wait"
+	zfsutil "github.com/lf-edge/eve/pkg/pillar/utils/zfs"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
@@ -3056,7 +3057,7 @@ func updatePortAndPciBackIoBundle(ctx *domainContext, ib *types.IoBundle) (chang
 				log.Error(err)
 			}
 		}
-		if ib.Type == types.IoNVME && types.NVMEIsUsed(log, ctx.subZFSPoolStatus.GetAll(), ib.PciLong) {
+		if ib.Type == types.IoNVME && zfsutil.NVMEIsUsed(log, ctx.subZFSPoolStatus.GetAll(), ib.PciLong) {
 			keepInHost = true
 		}
 		if ib.Type == types.IoNetEthPF {

--- a/pkg/pillar/types/assignableadapters_test.go
+++ b/pkg/pillar/types/assignableadapters_test.go
@@ -5,7 +5,6 @@ package types
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	zcommon "github.com/lf-edge/eve-api/go/evecommon"
@@ -459,41 +458,6 @@ func TestExpandControllers(t *testing.T) {
 				}
 			}
 			assert.True(t, found, fmt.Sprintf("Expected %s in postList", m))
-		}
-	}
-}
-
-func TestNVMEIsUsed(t *testing.T) {
-	t.Parallel()
-	log := base.NewSourceLogObject(logrus.StandardLogger(), "test", 1234)
-	var err error
-
-	zfsManagerDir, err = os.MkdirTemp("./", "zfsmanager")
-	if err != nil {
-		t.Fatalf("unable to make %s directory: %v", zfsManagerDir, err)
-	}
-	defer os.RemoveAll(zfsManagerDir)
-
-	// Init phase
-	testMatrix := map[string]struct {
-		pciIDs          []string
-		devNames        []string // e.g., nvme0
-		mountEntries    []string // e.g., /dev/nvme0p1 /mnt/nvme0p1 ext4 rw 0 0
-		expectedAnswers []bool
-	}{
-		"Test empty": {},
-		"falseDev": {
-			pciIDs:          []string{"0000:00:00.0"},
-			devNames:        []string{"nvme0"},
-			mountEntries:    []string{""},
-			expectedAnswers: []bool{false},
-		},
-	}
-
-	for testname, test := range testMatrix {
-		t.Logf("Running test case %s", testname)
-		for i, pciID := range test.pciIDs {
-			assert.Equal(t, test.expectedAnswers[i], NVMEIsUsed(log, nil, pciID))
 		}
 	}
 }

--- a/pkg/pillar/utils/zfs/nvme.go
+++ b/pkg/pillar/utils/zfs/nvme.go
@@ -1,0 +1,72 @@
+package zfs
+
+import (
+	"os"
+	"strings"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/shirou/gopsutil/disk"
+)
+
+const sysfsPciDevices = "/sys/bus/pci/devices/"
+
+var zfsManagerDir = "/run/zfsmanager"
+
+// NVMEIsUsed checks if an NVME device is in a ZFS pool or mounted
+func NVMEIsUsed(log *base.LogObject, zfsPoolStatusMap map[string]interface{}, pciID string) bool {
+	if _, err := os.Stat(zfsManagerDir); os.IsNotExist(err) {
+		log.Noticef("ZFS manager is not initialized yet")
+		return true
+	}
+
+	// Get /dev/nvmX from pciID
+	deviceName, err := getDeviceNameFromPciID(pciID)
+	if err != nil {
+		log.Errorf("Can't determine nvme device name for %s (%v)", pciID, err)
+		return false
+	}
+
+	// Checking zfs pools
+	for _, el := range zfsPoolStatusMap {
+		zfsPoolStatus, ok := el.(types.ZFSPoolStatus)
+		if !ok {
+			log.Errorf("Could not convert to ZFSPoolStatus")
+			continue
+		}
+		for _, disk := range zfsPoolStatus.Disks {
+			if strings.Contains(disk.DiskName.LogicalName, deviceName) {
+				return true
+			}
+		}
+	}
+
+	// Checking mounted partitions
+	partitions, err := disk.Partitions(true)
+	if err != nil {
+		log.Errorf("Could not find mounted partitions error:%+v", err)
+		return false
+	}
+
+	for _, partition := range partitions {
+		if strings.Contains(partition.Device, deviceName) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func getDeviceNameFromPciID(pciID string) (string, error) {
+	// e.g., ls /sys/bus/pci/devices/<pciID>/nvme/
+	//  -> nvme0
+	deviceName := ""
+	nvmePath, err := os.ReadDir(sysfsPciDevices + pciID + "/nvme")
+	if err != nil {
+		return "", err
+	}
+	for _, file := range nvmePath {
+		deviceName = file.Name()
+	}
+	return deviceName, nil
+}

--- a/pkg/pillar/utils/zfs/nvme_test.go
+++ b/pkg/pillar/utils/zfs/nvme_test.go
@@ -1,0 +1,46 @@
+//nolint:testpackage // TestNVMEIsUsed is a test function which requires access to unexported vars
+package zfs
+
+import (
+	"os"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNVMEIsUsed(t *testing.T) {
+	t.Parallel()
+	log := base.NewSourceLogObject(logrus.StandardLogger(), "test", 1234)
+	var err error
+
+	zfsManagerDir, err = os.MkdirTemp("./", "zfsmanager")
+	if err != nil {
+		t.Fatalf("unable to make %s directory: %v", zfsManagerDir, err)
+	}
+	defer os.RemoveAll(zfsManagerDir)
+
+	// Init phase
+	testMatrix := map[string]struct {
+		pciIDs          []string
+		devNames        []string // e.g., nvme0
+		mountEntries    []string // e.g., /dev/nvme0p1 /mnt/nvme0p1 ext4 rw 0 0
+		expectedAnswers []bool
+	}{
+		"Test empty": {},
+		"falseDev": {
+			pciIDs:          []string{"0000:00:00.0"},
+			devNames:        []string{"nvme0"},
+			mountEntries:    []string{""},
+			expectedAnswers: []bool{false},
+		},
+	}
+
+	for testname, test := range testMatrix {
+		t.Logf("Running test case %s", testname)
+		for i, pciID := range test.pciIDs {
+			assert.Equal(t, test.expectedAnswers[i], NVMEIsUsed(log, nil, pciID))
+		}
+	}
+}


### PR DESCRIPTION
Anything that pulls in `pkg/pillar/types/`, also pulls in `github.com/shirou/gopsutil/disk`, which requires CGO and has specific platform library requirements. This is because of a single function in `types/assignableadapters.go`: `NVMEIsUsed()`.

This actually has little to do with adapters, and checks if an NVME is in a ZFS pool and/or is mounted.

The function only ever is consumed by `domainmgr`.

I moved it into its own package, `pkg/pillar/utils/zfs/`, as well as its test, so that anything pulling in `types/` does not get the downstream dependencies, unless it explicitly wants to.