### PR TITLE
Don't panic in nokube.go newKubevirt() searching for a hypervisor

### DIFF
--- a/pkg/pillar/hypervisor/nokube.go
+++ b/pkg/pillar/hypervisor/nokube.go
@@ -5,6 +5,8 @@
 
 package hypervisor
 
+import "github.com/sirupsen/logrus"
+
 const (
 	// KubevirtHypervisorName : Name of the kubevirt hypervisor
 	KubevirtHypervisorName = "kubevirt"
@@ -12,5 +14,6 @@ const (
 
 // newKubevirt in this file is just stub for non-kubevirt hypervisors.
 func newKubevirt() Hypervisor {
-	panic("Hypervisor for kubevirt is not built")
+	logrus.Warn("Kubevirt hypervisor is not enabled")
+	return nil
 }


### PR DESCRIPTION
Don't panic in nokube.go newKubevirt(), just return nil
Let the hypervisor search continue

nokube.go newKubevirt() was leading to boot time panics and watchdog reboot at least on kubevirt builds.