### PR TITLE
extend Run() signature to include baseDir; unify agentInit options

### DIFF
--- a/pkg/pillar/Makefile
+++ b/pkg/pillar/Makefile
@@ -40,7 +40,7 @@ ifneq ($(TAGS),)
 	TAGS:=-tags "$(TAGS)"
 endif
 
-LDFLAGS=-X=main.Version=$(BUILD_VERSION)
+LDFLAGS=
 ifneq ($(DEV),y)
 	LDFLAGS+=-s -w
 endif

--- a/pkg/pillar/agentbase/agent.go
+++ b/pkg/pillar/agentbase/agent.go
@@ -2,10 +2,11 @@ package agentbase
 
 import (
 	"flag"
+	"time"
+
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
-	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -36,6 +37,7 @@ type AgentBase struct {
 	needWatchdog bool
 	needPidFile  bool
 	arguments    []string
+	baseDir      string
 }
 
 // AgentOpt function may be used to modify options
@@ -62,6 +64,13 @@ func WithWatchdog(pubSub *pubsub.PubSub, warningTime, errorTime time.Duration) A
 		a.warningTime = warningTime
 		a.errorTime = errorTime
 		a.needWatchdog = true
+	}
+}
+
+// WithBaseDir defines base directory for file-related activities, such as pidfile
+func WithBaseDir(baseDir string) AgentOpt {
+	return func(a *AgentBase) {
+		a.baseDir = baseDir
 	}
 }
 
@@ -119,7 +128,7 @@ func Init(agent Agent, logger *logrus.Logger, log *base.LogObject, agentName str
 		logger.SetLevel(logrus.InfoLevel)
 	}
 	if agentBase.needPidFile {
-		if err := pidfile.CheckAndCreatePidfile(log, agentBase.agentName); err != nil {
+		if err := pidfile.CheckAndCreatePidfile(log, agentBase.agentName, pidfile.WithBaseDir(agentBase.baseDir)); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/pkg/pillar/cmd/baseosmgr/baseosmgr.go
+++ b/pkg/pillar/cmd/baseosmgr/baseosmgr.go
@@ -15,7 +15,6 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/agentbase"
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/base"
-	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils/wait"
@@ -72,7 +71,7 @@ func (ctxPtr *baseOsMgrContext) AddAgentSpecificCLIFlags(flagSet *flag.FlagSet) 
 var logger *logrus.Logger
 var log *base.LogObject
 
-func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string, baseDir string) int {
 	logger = loggerArg
 	log = logArg
 
@@ -81,14 +80,13 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		globalConfig: types.DefaultConfigItemValueMap(),
 	}
 	agentbase.Init(&ctx, logger, log, agentName,
+		agentbase.WithPidFile(),
+		agentbase.WithBaseDir(baseDir),
 		agentbase.WithArguments(arguments))
 
 	if *ctx.versionPtr {
 		fmt.Printf("%s: %s\n", agentName, Version)
 		return 0
-	}
-	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
-		log.Fatal(err)
 	}
 
 	// Run a periodic timer so we always update StillRunning

--- a/pkg/pillar/cmd/baseosmgr/baseosmgr.go
+++ b/pkg/pillar/cmd/baseosmgr/baseosmgr.go
@@ -35,9 +35,6 @@ const (
 	configRetryUpdateCounterFile = types.PersistStatusDir + "/config_retry_update_counter"
 )
 
-// Set from Makefile
-var Version = "No version specified"
-
 type baseOsMgrContext struct {
 	agentbase.AgentBase
 	pubBaseOsStatus    pubsub.Publication
@@ -59,13 +56,10 @@ type baseOsMgrContext struct {
 	configUpdateRetry    uint32    // UpdateRetryCounter from config; to avoid loop after reboot with failed testing
 
 	worker worker.Worker // For background work
-	// cli options
-	versionPtr *bool
 }
 
 // AddAgentSpecificCLIFlags adds CLI options
 func (ctxPtr *baseOsMgrContext) AddAgentSpecificCLIFlags(flagSet *flag.FlagSet) {
-	ctxPtr.versionPtr = flagSet.Bool("v", false, "Version")
 }
 
 var logger *logrus.Logger
@@ -83,11 +77,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		agentbase.WithPidFile(),
 		agentbase.WithBaseDir(baseDir),
 		agentbase.WithArguments(arguments))
-
-	if *ctx.versionPtr {
-		fmt.Printf("%s: %s\n", agentName, Version)
-		return 0
-	}
 
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(25 * time.Second)

--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -47,9 +47,6 @@ const (
 // Really a constant
 var nilUUID uuid.UUID
 
-// Set from Makefile
-var Version = "No version specified"
-
 // Assumes the config files are in IdentityDirname, which is /config
 // by default. The files are
 //  root-certificate.pem	Root CA cert(s) for object signing
@@ -72,13 +69,11 @@ type clientContext struct {
 	zedcloudMetrics        *zedcloud.AgentMetrics
 	// cli options
 	operations    map[string]bool
-	versionPtr    *bool
 	maxRetriesPtr *int
 }
 
 // AddAgentSpecificCLIFlags adds CLI options
 func (ctxPtr *clientContext) AddAgentSpecificCLIFlags(flagSet *flag.FlagSet) {
-	ctxPtr.versionPtr = flagSet.Bool("v", false, "Version")
 	ctxPtr.maxRetriesPtr = flagSet.Int("r", 0, "Max retries")
 }
 
@@ -131,10 +126,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	agentbase.Init(&clientCtx, logger, log, agentName, args...)
 
 	maxRetries := *clientCtx.maxRetriesPtr
-	if *clientCtx.versionPtr {
-		fmt.Printf("%s: %s\n", agentName, Version)
-		return 0
-	}
 
 	pub, err := ps.NewPublication(pubsub.PublicationOptions{
 		AgentName: agentName,

--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -73,14 +73,12 @@ type clientContext struct {
 	// cli options
 	operations    map[string]bool
 	versionPtr    *bool
-	noPidPtr      *bool
 	maxRetriesPtr *int
 }
 
 // AddAgentSpecificCLIFlags adds CLI options
 func (ctxPtr *clientContext) AddAgentSpecificCLIFlags(flagSet *flag.FlagSet) {
 	ctxPtr.versionPtr = flagSet.Bool("v", false, "Version")
-	ctxPtr.noPidPtr = flagSet.Bool("p", false, "Do not check for running client")
 	ctxPtr.maxRetriesPtr = flagSet.Int("r", 0, "Max retries")
 }
 
@@ -129,10 +127,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		},
 	}
 
-	args := []agentbase.AgentOpt{agentbase.WithArguments(arguments), agentbase.WithBaseDir(baseDir)}
-	if !*clientCtx.noPidPtr {
-		args = append(args, agentbase.WithPidFile())
-	}
+	args := []agentbase.AgentOpt{agentbase.WithArguments(arguments), agentbase.WithBaseDir(baseDir), agentbase.WithPidFile()}
 	agentbase.Init(&clientCtx, logger, log, agentName, args...)
 
 	maxRetries := *clientCtx.maxRetriesPtr

--- a/pkg/pillar/cmd/command/command.go
+++ b/pkg/pillar/cmd/command/command.go
@@ -82,7 +82,7 @@ func (ctx *commandAgentState) AddAgentSpecificCLIFlags(flagSet *flag.FlagSet) {
 }
 
 // Run is the main aka only entrypoint
-func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string, baseDir string) int { //nolint:gocyclo
 	logger = loggerArg
 	log = logArg
 	// Report nano timestamps
@@ -94,7 +94,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	// Context to pass around
 	ctx := commandAgentState{}
 	agentbase.Init(&ctx, logger, log, agentName,
-		agentbase.WithArguments(arguments))
+		agentbase.WithArguments(arguments), agentbase.WithBaseDir(baseDir))
 
 	timeLimit = *ctx.timeLimitPtr
 	combinedOutput = *ctx.combinedPtr

--- a/pkg/pillar/cmd/conntrack/conntrack.go
+++ b/pkg/pillar/cmd/conntrack/conntrack.go
@@ -45,12 +45,13 @@ func (state *connTrackAgentState) AddAgentSpecificCLIFlags(flagSet *flag.FlagSet
 	state.markMask = flagSet.Int("mask", 0, "Delete flow with Mark mask")
 }
 
-func Run(_ *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string) int {
+func Run(_ *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string, baseDir string) int {
 	logger = loggerArg
 	log = logArg
 
 	ctx := connTrackAgentState{}
 	agentbase.Init(&ctx, logger, log, agentName,
+		agentbase.WithBaseDir(baseDir),
 		agentbase.WithArguments(arguments))
 
 	// conntrack [-D <-s address> [-p proto][-P port][-m Mark]]

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -80,7 +80,6 @@ type diagContext struct {
 	usingOnboardCert        bool
 	devUUID                 uuid.UUID
 	// cli options
-	versionPtr             *bool
 	foreverPtr             *bool
 	pacContentsPtr         *bool
 	simulateDNSFailurePtr  *bool
@@ -95,7 +94,6 @@ type diagContext struct {
 
 // AddAgentSpecificCLIFlags adds CLI options
 func (ctxPtr *diagContext) AddAgentSpecificCLIFlags(flagSet *flag.FlagSet) {
-	ctxPtr.versionPtr = flagSet.Bool("v", false, "Version")
 	ctxPtr.foreverPtr = flagSet.Bool("f", false, "Forever flag")
 	ctxPtr.pacContentsPtr = flagSet.Bool("p", false, "Print PAC file contents")
 	ctxPtr.simulateDNSFailurePtr = flagSet.Bool("D", false, "simulateDnsFailure flag")
@@ -105,9 +103,6 @@ func (ctxPtr *diagContext) AddAgentSpecificCLIFlags(flagSet *flag.FlagSet) {
 	ctxPtr.rowPtr = flagSet.Int("r", 40, "Max number of rows")
 	ctxPtr.columnPtr = flagSet.Int("c", 80, "Max number of columns")
 }
-
-// Set from Makefile
-var Version = "No version specified"
 
 var simulateDnsFailure = false
 var simulatePingFailure = false
@@ -137,10 +132,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	simulateDnsFailure = *ctx.simulateDNSFailurePtr
 	simulatePingFailure = *ctx.simulatePingFailurePtr
 	outFilename := *ctx.outFilenamePtr
-	if *ctx.versionPtr {
-		fmt.Printf("%s: %s\n", agentName, Version)
-		return 0
-	}
 	if outFilename != "" {
 		outfile, err = os.OpenFile(outFilename, os.O_APPEND|os.O_CREATE|os.O_WRONLY|syscall.O_NONBLOCK, 0644)
 		if err != nil {

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -116,7 +116,7 @@ var nilUUID uuid.UUID
 var logger *logrus.Logger
 var log *base.LogObject
 
-func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string, baseDir string) int { //nolint:gocyclo
 	logger = loggerArg
 	log = logArg
 	triggerPrintChan := make(chan string, 1)
@@ -126,6 +126,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		triggerPrintChan: triggerPrintChan,
 	}
 	agentbase.Init(&ctx, logger, log, agentName,
+		agentbase.WithBaseDir(baseDir),
 		agentbase.WithArguments(arguments))
 
 	ctx.forever = *ctx.foreverPtr

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -37,7 +37,6 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/flextimer"
 	"github.com/lf-edge/eve/pkg/pillar/hypervisor"
 	"github.com/lf-edge/eve/pkg/pillar/kubeapi"
-	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/sema"
 	"github.com/lf-edge/eve/pkg/pillar/sriov"
@@ -148,7 +147,7 @@ var hyper hypervisor.Hypervisor // Current hypervisor
 var logger *logrus.Logger
 var log *base.LogObject
 
-func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string, baseDir string) int { //nolint:gocyclo
 	logger = loggerArg
 	log = logArg
 
@@ -169,6 +168,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		hvTypeKube:          base.IsHVTypeKube(),
 	}
 	agentbase.Init(&domainCtx, logger, log, agentName,
+		agentbase.WithBaseDir(baseDir),
+		agentbase.WithPidFile(),
 		agentbase.WithArguments(arguments))
 
 	var err error
@@ -183,9 +184,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		log.Fatal(err)
 	}
 
-	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
-		log.Fatal(err)
-	}
 	log.Functionf("Starting %s with %s hypervisor backend", agentName, hyper.Name())
 
 	// Run a periodic timer so we always update StillRunning

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -67,9 +67,6 @@ const (
 // Really a constant
 var nilUUID = uuid.UUID{}
 
-// Set from Makefile
-var Version = "No version specified"
-
 func isPort(ctx *domainContext, ifname string) bool {
 	ctx.dnsLock.Lock()
 	defer ctx.dnsLock.Unlock()
@@ -122,7 +119,6 @@ type domainContext struct {
 	processCloudInitMultiPart bool
 	publishTicker             flextimer.FlexTickerHandle
 	// cli options
-	versionPtr    *bool
 	hypervisorPtr *string
 	// CPUs management
 	cpuAllocator        *cpuallocator.CPUAllocator
@@ -133,7 +129,6 @@ type domainContext struct {
 
 // AddAgentSpecificCLIFlags adds CLI options
 func (ctx *domainContext) AddAgentSpecificCLIFlags(flagSet *flag.FlagSet) {
-	ctx.versionPtr = flagSet.Bool("v", false, "Version")
 	allHypervisors, enabledHypervisors := hypervisor.GetAvailableHypervisors()
 	ctx.hypervisorPtr = flagSet.String("h", enabledHypervisors[0], fmt.Sprintf("Current hypervisor %+q", allHypervisors))
 }
@@ -175,10 +170,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	var err error
 	handlersInit()
 
-	if *domainCtx.versionPtr {
-		fmt.Printf("%s: %s\n", agentName, Version)
-		return 0
-	}
 	hyper, err = hypervisor.GetHypervisor(*domainCtx.hypervisorPtr)
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/pillar/cmd/downloader/context.go
+++ b/pkg/pillar/cmd/downloader/context.go
@@ -40,12 +40,10 @@ type downloaderContext struct {
 	netdumpWithPCAP          bool
 	netdumpWithHdrFieldVal   bool
 	// cli options
-	versionPtr *bool
 }
 
 // AddAgentSpecificCLIFlags adds CLI options
 func (ctx *downloaderContext) AddAgentSpecificCLIFlags(flagSet *flag.FlagSet) {
-	ctx.versionPtr = flagSet.Bool("v", false, "Version")
 }
 
 func (ctx *downloaderContext) registerHandlers(ps *pubsub.PubSub) error {

--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -39,7 +39,6 @@ const (
 var (
 	retryTime      = time.Duration(600) * time.Second // Unless from GlobalConfig
 	maxStalledTime = time.Duration(600) * time.Second // Unless from GlobalConfig
-	Version        = "No version specified"           // Set from Makefile
 	dHandler       = makeDownloadHandler()
 	resHandler     = makeResolveHandler()
 	logger         *logrus.Logger
@@ -60,11 +59,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		agentbase.WithPidFile(),
 		agentbase.WithBaseDir(baseDir),
 		agentbase.WithArguments(arguments))
-
-	if *ctx.versionPtr {
-		fmt.Printf("%s: %s\n", agentName, Version)
-		return 0
-	}
 
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(25 * time.Second)

--- a/pkg/pillar/cmd/downloader/downloader.go
+++ b/pkg/pillar/cmd/downloader/downloader.go
@@ -17,7 +17,6 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/cipher"
 	"github.com/lf-edge/eve/pkg/pillar/flextimer"
-	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils"
@@ -48,7 +47,7 @@ var (
 )
 
 // Run downloader
-func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string, baseDir string) int {
 	logger = loggerArg
 	log = logArg
 
@@ -58,14 +57,13 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		cipherMetrics:   cipher.NewAgentMetrics(agentName),
 	}
 	agentbase.Init(&ctx, logger, log, agentName,
+		agentbase.WithPidFile(),
+		agentbase.WithBaseDir(baseDir),
 		agentbase.WithArguments(arguments))
 
 	if *ctx.versionPtr {
 		fmt.Printf("%s: %s\n", agentName, Version)
 		return 0
-	}
-	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
-		log.Fatal(err)
 	}
 
 	// Run a periodic timer so we always update StillRunning

--- a/pkg/pillar/cmd/executor/exec.go
+++ b/pkg/pillar/cmd/executor/exec.go
@@ -17,7 +17,6 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/agentbase"
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/base"
-	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/sirupsen/logrus"
@@ -68,11 +67,13 @@ var logger *logrus.Logger
 var log *base.LogObject
 
 // Run is the main aka only entrypoint
-func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string, baseDir string) int {
 	logger = loggerArg
 	log = logArg
 	execCtx := executorContext{}
 	agentbase.Init(&execCtx, logger, log, agentName,
+		agentbase.WithPidFile(),
+		agentbase.WithBaseDir(baseDir),
 		agentbase.WithArguments(arguments))
 
 	fatalFlag := *execCtx.fatalPtr
@@ -84,10 +85,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		fmt.Printf("%s: %s\n", agentName, Version)
 		return 0
 	}
-	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
-		log.Fatal(err)
-	}
-
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(25 * time.Second)
 	ps.StillRunning(agentName, warningTime, errorTime)

--- a/pkg/pillar/cmd/executor/exec.go
+++ b/pkg/pillar/cmd/executor/exec.go
@@ -9,7 +9,6 @@ package executor
 import (
 	"context"
 	"flag"
-	"fmt"
 	"os/exec"
 	"syscall"
 	"time"
@@ -29,9 +28,6 @@ const (
 	warningTime = 40 * time.Second
 )
 
-// Version can be set from Makefile
-var Version = "No version specified"
-
 // Any state used by handlers goes here
 type executorContext struct {
 	agentbase.AgentBase
@@ -47,7 +43,6 @@ type executorContext struct {
 	timeLimit uint // In seconds
 
 	// CLI args
-	versionPtr   *bool
 	timeLimitPtr *uint // In seconds
 	fatalPtr     *bool
 	panicPtr     *bool
@@ -56,7 +51,6 @@ type executorContext struct {
 
 // AddAgentSpecificCLIFlags adds CLI options
 func (ctxPtr *executorContext) AddAgentSpecificCLIFlags(flagSet *flag.FlagSet) {
-	ctxPtr.versionPtr = flagSet.Bool("v", false, "Version")
 	ctxPtr.timeLimitPtr = flagSet.Uint("t", 120, "Maximum time to wait for command")
 	ctxPtr.fatalPtr = flagSet.Bool("F", false, "Cause log.Fatal fault injection")
 	ctxPtr.panicPtr = flagSet.Bool("P", false, "Cause golang panic fault injection")
@@ -81,10 +75,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	hangFlag := *execCtx.hangPtr
 	execCtx.timeLimit = *execCtx.timeLimitPtr
 
-	if *execCtx.versionPtr {
-		fmt.Printf("%s: %s\n", agentName, Version)
-		return 0
-	}
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(25 * time.Second)
 	ps.StillRunning(agentName, warningTime, errorTime)

--- a/pkg/pillar/cmd/faultinjection/run.go
+++ b/pkg/pillar/cmd/faultinjection/run.go
@@ -53,12 +53,13 @@ var logger *logrus.Logger
 var log *base.LogObject
 
 // Run is the main aka only entrypoint
-func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string, baseDir string) int {
 	logger = loggerArg
 	log = logArg
 	ctx := faultContext{}
 	agentbase.Init(&ctx, logger, log, agentName,
 		agentbase.WithPidFile(),
+		agentbase.WithBaseDir(baseDir),
 		agentbase.WithWatchdog(ps, warningTime, errorTime),
 		agentbase.WithArguments(arguments))
 

--- a/pkg/pillar/cmd/hardwaremodel/hardwaremodel.go
+++ b/pkg/pillar/cmd/hardwaremodel/hardwaremodel.go
@@ -19,21 +19,16 @@ const (
 	agentName = "hardwaremodel"
 )
 
-// Set from Makefile
-var Version = "No version specified"
-
 // Any state used by handlers goes here
 type hardwareModelAgentState struct {
 	agentbase.AgentBase
 	// cli options
-	versionPtr    *bool
 	cPtr          *bool
 	outputFilePtr *string
 }
 
 // AddAgentSpecificCLIFlags adds CLI options
 func (state *hardwareModelAgentState) AddAgentSpecificCLIFlags(flagSet *flag.FlagSet) {
-	state.versionPtr = flagSet.Bool("v", false, "Version")
 	state.cPtr = flagSet.Bool("c", false, "No CRLF")
 	state.outputFilePtr = flagSet.String("o", "/dev/tty", "file or device for output")
 }
@@ -51,10 +46,6 @@ func Run(_ *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arg
 		agentbase.WithArguments(arguments))
 
 	outputFile := *state.outputFilePtr
-	if *state.versionPtr {
-		fmt.Printf("%s: %s\n", agentName, Version)
-		return 0
-	}
 	model := hardware.GetHardwareModelNoOverride(log)
 	if *state.cPtr {
 		b := []byte(fmt.Sprintf("%s", model))

--- a/pkg/pillar/cmd/hardwaremodel/hardwaremodel.go
+++ b/pkg/pillar/cmd/hardwaremodel/hardwaremodel.go
@@ -41,12 +41,13 @@ func (state *hardwareModelAgentState) AddAgentSpecificCLIFlags(flagSet *flag.Fla
 var logger *logrus.Logger
 var log *base.LogObject
 
-func Run(_ *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string) int {
+func Run(_ *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string, baseDir string) int {
 	logger = loggerArg
 	log = logArg
 
 	state := hardwareModelAgentState{}
 	agentbase.Init(&state, logger, log, agentName,
+		agentbase.WithBaseDir(baseDir),
 		agentbase.WithArguments(arguments))
 
 	outputFile := *state.outputFilePtr

--- a/pkg/pillar/cmd/ipcmonitor/ipcmonitor.go
+++ b/pkg/pillar/cmd/ipcmonitor/ipcmonitor.go
@@ -56,12 +56,13 @@ func (state *ipcMonitorAgentState) AddAgentSpecificCLIFlags(flagSet *flag.FlagSe
 var logger *logrus.Logger
 var log *base.LogObject
 
-func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string, baseDir string) int {
 	logger = loggerArg
 	log = logArg
 
 	state := ipcMonitorAgentState{}
 	agentbase.Init(&state, logger, log, agentName,
+		agentbase.WithBaseDir(baseDir),
 		agentbase.WithArguments(arguments))
 
 	agentName = *state.agentNamePtr

--- a/pkg/pillar/cmd/ledmanager/ledmanager.go
+++ b/pkg/pillar/cmd/ledmanager/ledmanager.go
@@ -52,14 +52,12 @@ type ledManagerContext struct {
 	blinkSendStop          chan string // Used by sender to stop the running forever blink routine
 	blinkRecvStop          chan string // Sender waits for the ack.
 	// cli options
-	versionPtr *bool
-	fatalPtr   *bool
-	hangPtr    *bool
+	fatalPtr *bool
+	hangPtr  *bool
 }
 
 // AddAgentSpecificCLIFlags adds CLI options
 func (ctxPtr *ledManagerContext) AddAgentSpecificCLIFlags(flagSet *flag.FlagSet) {
-	ctxPtr.versionPtr = flagSet.Bool("v", false, "Version")
 	ctxPtr.fatalPtr = flagSet.Bool("F", false, "Cause log.Fatal fault injection")
 	ctxPtr.hangPtr = flagSet.Bool("H", false, "Cause watchdog .touch fault injection")
 }
@@ -264,9 +262,6 @@ var mToF = []modelToFuncs{
 var logger *logrus.Logger
 var log *base.LogObject
 
-// Set from Makefile
-var Version = "No version specified"
-
 var appStatusDisplayFunc AppStatusDisplayFunc
 var appStatusArgs []string
 
@@ -284,10 +279,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 
 	fatalFlag := *ctx.fatalPtr
 	hangFlag := *ctx.hangPtr
-	if *ctx.versionPtr {
-		fmt.Printf("%s: %s\n", agentName, Version)
-		return 0
-	}
 	log.Functionf("Starting %s", agentName)
 
 	// Run a periodic timer so we always update StillRunning

--- a/pkg/pillar/cmd/ledmanager/ledmanager.go
+++ b/pkg/pillar/cmd/ledmanager/ledmanager.go
@@ -25,7 +25,6 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/diskmetrics"
 	"github.com/lf-edge/eve/pkg/pillar/hardware"
-	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/sirupsen/logrus"
@@ -271,7 +270,7 @@ var Version = "No version specified"
 var appStatusDisplayFunc AppStatusDisplayFunc
 var appStatusArgs []string
 
-func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string, baseDir string) int {
 	logger = loggerArg
 	log = logArg
 
@@ -279,6 +278,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		countChange: make(chan types.LedBlinkCount),
 	}
 	agentbase.Init(&ctx, logger, log, agentName,
+		agentbase.WithPidFile(),
+		agentbase.WithBaseDir(baseDir),
 		agentbase.WithArguments(arguments))
 
 	fatalFlag := *ctx.fatalPtr
@@ -286,9 +287,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	if *ctx.versionPtr {
 		fmt.Printf("%s: %s\n", agentName, Version)
 		return 0
-	}
-	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
-		log.Fatal(err)
 	}
 	log.Functionf("Starting %s", agentName)
 

--- a/pkg/pillar/cmd/loguploader/loguploader.go
+++ b/pkg/pillar/cmd/loguploader/loguploader.go
@@ -98,7 +98,7 @@ func (ctx *loguploaderContext) getCachedResolvedIPs(hostname string) []types.Cac
 }
 
 // Run - an loguploader run
-func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string, baseDir string) int {
 	logger = loggerArg
 	log = logArg
 
@@ -108,6 +108,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	}
 	agentbase.Init(&loguploaderCtx, logger, log, agentName,
 		agentbase.WithPidFile(),
+		agentbase.WithBaseDir(baseDir),
 		agentbase.WithWatchdog(ps, warningTime, errorTime),
 		agentbase.WithArguments(arguments))
 

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -49,9 +49,6 @@ const (
 // Really a constant
 var nilUUID uuid.UUID
 
-// Version is set from the Makefile.
-var Version = "No version specified"
-
 // NIM - Network Interface Manager.
 // Manage (physical) network interfaces of the device based on configuration from
 // various sources (controller, override, last-resort, persisted config).
@@ -65,11 +62,9 @@ type nim struct {
 	PubSub *pubsub.PubSub
 
 	useStdout bool
-	version   bool
 
 	// CLI args
-	stdoutPtr  *bool
-	versionPtr *bool
+	stdoutPtr *bool
 
 	// NIM components
 	connTester     *conntester.ZedcloudConnectivityTester
@@ -115,14 +110,12 @@ type nim struct {
 
 // AddAgentSpecificCLIFlags adds CLI options
 func (n *nim) AddAgentSpecificCLIFlags(flagSet *flag.FlagSet) {
-	n.versionPtr = flagSet.Bool("v", false, "Print Version of the agent.")
 	n.stdoutPtr = flagSet.Bool("s", false, "Use stdout")
 }
 
 // ProcessAgentSpecificCLIFlags process received CLI options
 func (n *nim) ProcessAgentSpecificCLIFlags(_ *flag.FlagSet) {
 	n.useStdout = *n.stdoutPtr
-	n.version = *n.versionPtr
 }
 
 // Run - Main function - invoked from zedbox.go
@@ -147,10 +140,6 @@ func Run(ps *pubsub.PubSub, logger *logrus.Logger, log *base.LogObject, argument
 }
 
 func (n *nim) init() (err error) {
-	if n.version {
-		fmt.Printf("%s: %s\n", agentName, Version)
-		return nil
-	}
 
 	n.cipherMetrics = cipher.NewAgentMetrics(agentName)
 	n.zedcloudMetrics = zedcloud.NewAgentMetrics()

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -23,7 +23,6 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/dpcreconciler"
 	"github.com/lf-edge/eve/pkg/pillar/flextimer"
 	"github.com/lf-edge/eve/pkg/pillar/netmonitor"
-	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
@@ -127,13 +126,15 @@ func (n *nim) ProcessAgentSpecificCLIFlags(_ *flag.FlagSet) {
 }
 
 // Run - Main function - invoked from zedbox.go
-func Run(ps *pubsub.PubSub, logger *logrus.Logger, log *base.LogObject, arguments []string) int {
+func Run(ps *pubsub.PubSub, logger *logrus.Logger, log *base.LogObject, arguments []string, baseDir string) int {
 	nim := &nim{
 		Log:    log,
 		PubSub: ps,
 		Logger: logger,
 	}
 	agentbase.Init(nim, logger, log, agentName,
+		agentbase.WithBaseDir(baseDir),
+		agentbase.WithPidFile(),
 		agentbase.WithArguments(arguments))
 
 	if err := nim.init(); err != nil {
@@ -200,9 +201,6 @@ func (n *nim) init() (err error) {
 }
 
 func (n *nim) run(ctx context.Context) (err error) {
-	if err = pidfile.CheckAndCreatePidfile(n.Log, agentName); err != nil {
-		return err
-	}
 	n.Log.Noticef("Starting %s", agentName)
 
 	// Start DPC Manager.

--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -63,8 +63,6 @@ const (
 )
 
 var (
-	// Version : module version
-	Version           = "No version specified"
 	smartData         = types.NewSmartDataWithDefaults()
 	previousSmartData = types.NewSmartDataWithDefaults()
 )

--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -152,12 +152,13 @@ func newNodeagentContext(ps *pubsub.PubSub, _ *logrus.Logger, _ *base.LogObject)
 var log *base.LogObject
 
 // Run : nodeagent run entry function
-func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string, baseDir string) int {
 	log = logArg
 
 	ctxPtr := newNodeagentContext(ps, loggerArg, logArg)
 	agentbase.Init(ctxPtr, loggerArg, logArg, agentName,
 		agentbase.WithPidFile(),
+		agentbase.WithBaseDir(baseDir),
 		agentbase.WithWatchdog(ps, warningTime, errorTime),
 		agentbase.WithArguments(arguments))
 

--- a/pkg/pillar/cmd/pbuf/pbuf.go
+++ b/pkg/pillar/cmd/pbuf/pbuf.go
@@ -33,12 +33,13 @@ var logger *logrus.Logger
 var log *base.LogObject
 
 // Run is our main function called by zedbox
-func Run(_ *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string) int {
+func Run(_ *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string, baseDir string) int {
 	logger = loggerArg
 	log = logArg
 
 	state := pbufAgentState{}
 	agentbase.Init(&state, logger, log, agentName,
+		agentbase.WithBaseDir(baseDir),
 		agentbase.WithArguments(arguments))
 
 	for _, arg := range state.args {

--- a/pkg/pillar/cmd/tpmmgr/tpmmgr.go
+++ b/pkg/pillar/cmd/tpmmgr/tpmmgr.go
@@ -28,7 +28,6 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	etpm "github.com/lf-edge/eve/pkg/pillar/evetpm"
-	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
@@ -1383,26 +1382,37 @@ func initializeDirs() {
 // Run is the entry point for tpmmgr, from zedbox
 //
 //nolint:funlen,gocognit,gocyclo
-func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string, baseDir string) int {
 	logger = loggerArg
 	log = logArg
 
 	// Context to pass around
 	ctx := tpmMgrContext{}
-	agentbase.Init(&ctx, logger, log, agentName,
-		agentbase.WithArguments(arguments))
 
-	// if any args defined, will run command inline and return
-	if len(ctx.args) > 0 {
-		return runInline(ctx.args[0], ctx.args[1:])
+	// do we run a single command, or long-running service?
+	// if any args defined, will run that single command and exit.
+	// otherwise, will run the agent
+	var (
+		command string
+		args    []string
+	)
+	if len(arguments) > 0 {
+		command = arguments[0]
 	}
+	if len(arguments) > 1 {
+		args = arguments[1:]
+	}
+
+	// if an explicit command was given, run that command and return, else run the agent
+	if command != "" {
+		return runCommand(command, args)
+	}
+
+	agentArgs := []agentbase.AgentOpt{agentbase.WithBaseDir(baseDir), agentbase.WithArguments(arguments), agentbase.WithPidFile()}
+	agentbase.Init(&ctx, logger, log, agentName, agentArgs...)
 
 	// Create required directories if not present
 	initializeDirs()
-
-	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
-		log.Fatal(err)
-	}
 
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(15 * time.Second)
@@ -1521,7 +1531,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	}
 }
 
-func runInline(command string, args []string) int {
+func runCommand(command string, args []string) int {
 	var err error
 	switch command {
 	case "createDeviceCert":
@@ -1724,8 +1734,7 @@ func handleAttestNonceDelete(ctxArg interface{}, key string, statusArg interface
 	log.Functionf("handleAttestNonceDelete received")
 	ctx := ctxArg.(*tpmMgrContext)
 	pub := ctx.pubAttestQuote
-	st, _ := pub.Get(key)
-	if st != nil {
+	if st, _ := pub.Get(key); st != nil {
 		log.Functionf("Unpublishing quote for nonce %x", key)
 		pub := ctx.pubAttestQuote
 		pub.Unpublish(key)

--- a/pkg/pillar/cmd/upgradeconverter/upgradeconverter.go
+++ b/pkg/pillar/cmd/upgradeconverter/upgradeconverter.go
@@ -150,7 +150,7 @@ var logger *logrus.Logger
 var log *base.LogObject
 
 // Run - runs the main upgradeconverter process
-func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string, baseDir string) int {
 	logger = loggerArg
 	log = logArg
 	ctx := &ucContext{agentName: "upgradeconverter",
@@ -161,6 +161,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	}
 	agentbase.Init(ctx, logger, log, agentName,
 		agentbase.WithPidFile(),
+		agentbase.WithBaseDir(baseDir),
 		agentbase.WithArguments(arguments))
 
 	ctx.persistDir = *ctx.persistPtr // XXX remove? Or use for tests?

--- a/pkg/pillar/cmd/usbmanager/usbmanager.go
+++ b/pkg/pillar/cmd/usbmanager/usbmanager.go
@@ -57,7 +57,7 @@ func newUsbmanagerContext() *usbmanagerContext {
 }
 
 // Run - Main function - invoked from zedbox.go
-func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string, baseDir string) int {
 	logger = loggerArg
 	log = logArg
 
@@ -66,6 +66,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 
 	agentbase.Init(usbCtx, logger, log, agentName,
 		agentbase.WithPidFile(),
+		agentbase.WithBaseDir(baseDir),
 		agentbase.WithWatchdog(ps, warningTime, errorTime),
 		agentbase.WithArguments(arguments))
 

--- a/pkg/pillar/cmd/vaultmgr/vaultmgr.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgr.go
@@ -36,7 +36,6 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	uc "github.com/lf-edge/eve/pkg/pillar/cmd/upgradeconverter"
 	etpm "github.com/lf-edge/eve/pkg/pillar/evetpm"
-	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils/persist"
@@ -173,7 +172,7 @@ func checkAndPublishVaultConfig(ctx *vaultMgrContext) bool {
 }
 
 // Run is the entrypoint for running vaultmgr as a standalone program
-func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string, baseDir string) int {
 	logger = loggerArg
 	log = logArg
 
@@ -182,21 +181,33 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		ps:     ps,
 		ucChan: make(chan struct{}),
 	}
-	agentbase.Init(&ctx, logger, log, agentName,
-		agentbase.WithArguments(arguments))
+
+	// do we run a single command, or long-running service?
+	// if any args defined, will run that single command and exit.
+	// otherwise, will run the agent
+	var (
+		command string
+		args    []string
+	)
+	if len(arguments) > 0 {
+		command = arguments[0]
+	}
+	if len(arguments) > 1 {
+		args = arguments[1:]
+	}
+
+	// if an explicit command was given, run that command and return, else run the agent
+	if command != "" {
+		return runCommand(ps, command, args)
+	}
+
+	agentArgs := []agentbase.AgentOpt{agentbase.WithBaseDir(baseDir), agentbase.WithArguments(arguments), agentbase.WithPidFile()}
+	agentbase.Init(&ctx, logger, log, agentName, agentArgs...)
 
 	handler = vault.GetHandler(log)
 
-	// if any args defined, will run command inline and return
-	if len(ctx.args) > 0 {
-		return runInline(ps, ctx.args[0], ctx.args[1:])
-	}
-
 	log.Functionf("Starting %s\n", agentName)
 
-	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
-		log.Fatal(err)
-	}
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(15 * time.Second)
 	ps.StillRunning(agentName, warningTime, errorTime)
@@ -310,7 +321,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	}
 }
 
-func runInline(ps *pubsub.PubSub, command string, _ []string) int {
+func runCommand(ps *pubsub.PubSub, command string, _ []string) int {
 	switch command {
 	case "setupDeprecatedVaults":
 		if err := handler.SetupDeprecatedVaults(); err != nil {

--- a/pkg/pillar/cmd/verifier/verifier.go
+++ b/pkg/pillar/cmd/verifier/verifier.go
@@ -44,9 +44,6 @@ var (
 	vHandler = makeVerifyHandler()
 )
 
-// Set from Makefile
-var Version = "No version specified"
-
 // Any state used by handlers goes here
 type verifierContext struct {
 	agentbase.AgentBase
@@ -57,12 +54,10 @@ type verifierContext struct {
 
 	GCInitialized bool
 	// cli options
-	versionPtr *bool
 }
 
 // AddAgentSpecificCLIFlags adds CLI options
 func (ctx *verifierContext) AddAgentSpecificCLIFlags(flagSet *flag.FlagSet) {
-	ctx.versionPtr = flagSet.Bool("v", false, "Version")
 }
 
 var logger *logrus.Logger
@@ -78,11 +73,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		agentbase.WithPidFile(),
 		agentbase.WithBaseDir(baseDir),
 		agentbase.WithArguments(arguments))
-
-	if *ctx.versionPtr {
-		fmt.Printf("%s: %s\n", agentName, Version)
-		return 0
-	}
 
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(25 * time.Second)

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -18,7 +18,6 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/cas"
 	"github.com/lf-edge/eve/pkg/pillar/flextimer"
 	"github.com/lf-edge/eve/pkg/pillar/kubeapi"
-	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils/persist"
@@ -133,7 +132,7 @@ var logger *logrus.Logger
 var log *base.LogObject
 
 // Run - the main function invoked by zedbox
-func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string, baseDir string) int {
 	logger = loggerArg
 	log = logArg
 
@@ -147,14 +146,13 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		hvTypeKube:         base.IsHVTypeKube(),
 	}
 	agentbase.Init(&ctx, logger, log, agentName,
+		agentbase.WithPidFile(),
+		agentbase.WithBaseDir(baseDir),
 		agentbase.WithArguments(arguments))
 
 	if *ctx.versionPtr {
 		fmt.Printf("%s: %s\n", agentName, Version)
 		return 0
-	}
-	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
-		log.Fatal(err)
 	}
 
 	// Run a periodic timer so we always update StillRunning

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -41,9 +41,6 @@ const (
 	blankVolumeFormat = zconfig.Format_RAW // format of blank volume TODO: make configurable
 )
 
-// Set from Makefile
-var Version = "No version specified"
-
 var volumeFormat = make(map[string]zconfig.Format)
 
 type volumemgrContext struct {
@@ -101,7 +98,6 @@ type volumemgrContext struct {
 	capabilities *types.Capabilities
 
 	// cli options
-	versionPtr *bool
 
 	// kube mode
 	hvTypeKube bool
@@ -125,7 +121,6 @@ func (ctxPtr *volumemgrContext) GetCasClient() cas.CAS {
 
 // AddAgentSpecificCLIFlags adds CLI options
 func (ctxPtr *volumemgrContext) AddAgentSpecificCLIFlags(flagSet *flag.FlagSet) {
-	ctxPtr.versionPtr = flagSet.Bool("v", false, "Version")
 }
 
 var logger *logrus.Logger
@@ -149,11 +144,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		agentbase.WithPidFile(),
 		agentbase.WithBaseDir(baseDir),
 		agentbase.WithArguments(arguments))
-
-	if *ctx.versionPtr {
-		fmt.Printf("%s: %s\n", agentName, Version)
-		return 0
-	}
 
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(25 * time.Second)

--- a/pkg/pillar/cmd/waitforaddr/waitforaddr.go
+++ b/pkg/pillar/cmd/waitforaddr/waitforaddr.go
@@ -8,7 +8,6 @@ package waitforaddr
 
 import (
 	"flag"
-	"fmt"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -26,9 +25,6 @@ const (
 	warningTime = 40 * time.Second
 )
 
-// Set from Makefile
-var Version = "No version specified"
-
 // Context for handleDNSModify
 type DNSContext struct {
 	agentbase.AgentBase
@@ -37,12 +33,10 @@ type DNSContext struct {
 	DNSinitialized         bool // Received DeviceNetworkStatus
 	subDeviceNetworkStatus pubsub.Subscription
 	// cli options
-	versionPtr *bool
 }
 
 // AddAgentSpecificCLIFlags adds CLI options
 func (ctx *DNSContext) AddAgentSpecificCLIFlags(flagSet *flag.FlagSet) {
-	ctx.versionPtr = flagSet.Bool("v", false, "Version")
 }
 
 var logger *logrus.Logger
@@ -55,11 +49,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	DNSctx := DNSContext{}
 	args := []agentbase.AgentOpt{agentbase.WithArguments(arguments), agentbase.WithBaseDir(baseDir), agentbase.WithPidFile()}
 	agentbase.Init(&DNSctx, logger, log, agentName, args...)
-
-	if *DNSctx.versionPtr {
-		fmt.Printf("%s: %s\n", agentName, Version)
-		return 0
-	}
 
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(25 * time.Second)

--- a/pkg/pillar/cmd/waitforaddr/waitforaddr.go
+++ b/pkg/pillar/cmd/waitforaddr/waitforaddr.go
@@ -38,13 +38,11 @@ type DNSContext struct {
 	subDeviceNetworkStatus pubsub.Subscription
 	// cli options
 	versionPtr *bool
-	noPidPtr   *bool
 }
 
 // AddAgentSpecificCLIFlags adds CLI options
 func (ctx *DNSContext) AddAgentSpecificCLIFlags(flagSet *flag.FlagSet) {
 	ctx.versionPtr = flagSet.Bool("v", false, "Version")
-	ctx.noPidPtr = flagSet.Bool("p", false, "Do not check for running agent")
 }
 
 var logger *logrus.Logger
@@ -55,10 +53,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	log = logArg
 
 	DNSctx := DNSContext{}
-	args := []agentbase.AgentOpt{agentbase.WithArguments(arguments), agentbase.WithBaseDir(baseDir)}
-	if !*DNSctx.noPidPtr {
-		args = append(args, agentbase.WithPidFile())
-	}
+	args := []agentbase.AgentOpt{agentbase.WithArguments(arguments), agentbase.WithBaseDir(baseDir), agentbase.WithPidFile()}
 	agentbase.Init(&DNSctx, logger, log, agentName, args...)
 
 	if *DNSctx.versionPtr {

--- a/pkg/pillar/cmd/watcher/watcher.go
+++ b/pkg/pillar/cmd/watcher/watcher.go
@@ -11,7 +11,6 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/agentbase"
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/base"
-	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils/wait"
@@ -54,7 +53,7 @@ var logger *logrus.Logger
 var log *base.LogObject
 
 // Run :
-func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string, baseDir string) int {
 	logger = loggerArg
 	log = logArg
 
@@ -62,14 +61,13 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		ps: ps,
 	}
 	agentbase.Init(&ctx, logger, log, agentName,
+		agentbase.WithPidFile(),
+		agentbase.WithBaseDir(baseDir),
 		agentbase.WithArguments(arguments))
 
 	if *ctx.versionPtr {
 		fmt.Printf("%s: %s\n", agentName, Version)
 		return 0
-	}
-	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
-		log.Fatal(err)
 	}
 
 	// Run a periodic timer so we always update StillRunning

--- a/pkg/pillar/cmd/watcher/watcher.go
+++ b/pkg/pillar/cmd/watcher/watcher.go
@@ -5,7 +5,6 @@ package watcher
 
 import (
 	"flag"
-	"fmt"
 	"time"
 
 	"github.com/lf-edge/eve/pkg/pillar/agentbase"
@@ -36,16 +35,11 @@ type watcherContext struct {
 
 	GCInitialized bool
 	// cli options
-	versionPtr *bool
 }
 
 // AddAgentSpecificCLIFlags adds CLI options
 func (ctx *watcherContext) AddAgentSpecificCLIFlags(flagSet *flag.FlagSet) {
-	ctx.versionPtr = flagSet.Bool("v", false, "Version")
 }
-
-// Version :
-var Version = "No version specified"
 
 var prevDiskNotification types.DiskNotification
 var prevMemNotification types.MemoryNotification
@@ -64,11 +58,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		agentbase.WithPidFile(),
 		agentbase.WithBaseDir(baseDir),
 		agentbase.WithArguments(arguments))
-
-	if *ctx.versionPtr {
-		fmt.Printf("%s: %s\n", agentName, Version)
-		return 0
-	}
 
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(25 * time.Second)

--- a/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
+++ b/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
@@ -15,11 +15,10 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/agentbase"
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/base"
-	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/zedcloud"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 )
 
@@ -64,20 +63,19 @@ func (ctx *wstunnelclientContext) AddAgentSpecificCLIFlags(flagSet *flag.FlagSet
 var logger *logrus.Logger
 var log *base.LogObject
 
-func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string, baseDir string) int {
 	logger = loggerArg
 	log = logArg
 
 	wscCtx := wstunnelclientContext{}
 	agentbase.Init(&wscCtx, logger, log, agentName,
+		agentbase.WithPidFile(),
+		agentbase.WithBaseDir(baseDir),
 		agentbase.WithArguments(arguments))
 
 	if *wscCtx.versionPtr {
 		fmt.Printf("%s: %s\n", agentName, Version)
 		return 0
-	}
-	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
-		log.Fatal(err)
 	}
 
 	// Run a periodic timer so we always update StillRunning

--- a/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
+++ b/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
@@ -29,9 +29,6 @@ const (
 	warningTime = 40 * time.Second
 )
 
-// Set from Makefile
-var Version = "No version specified"
-
 // Context for handleDNSModify
 type DNSContext struct {
 	usableAddressCount     int
@@ -52,12 +49,10 @@ type wstunnelclientContext struct {
 	// XXX add any output from scanAIConfigs()?
 
 	// cli options
-	versionPtr *bool
 }
 
 // AddAgentSpecificCLIFlags adds CLI options
 func (ctx *wstunnelclientContext) AddAgentSpecificCLIFlags(flagSet *flag.FlagSet) {
-	ctx.versionPtr = flagSet.Bool("v", false, "Version")
 }
 
 var logger *logrus.Logger
@@ -72,11 +67,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		agentbase.WithPidFile(),
 		agentbase.WithBaseDir(baseDir),
 		agentbase.WithArguments(arguments))
-
-	if *wscCtx.versionPtr {
-		fmt.Printf("%s: %s\n", agentName, Version)
-		return 0
-	}
 
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(25 * time.Second)

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -65,9 +65,6 @@ const (
 	dormantTimeScaleFactor = 3
 )
 
-// Set from Makefile
-var Version = "No version specified"
-
 // XXX move to a context? Which? Used in handleconfig and handlemetrics!
 var deviceNetworkStatus = &types.DeviceNetworkStatus{}
 
@@ -223,7 +220,6 @@ type zedagentContext struct {
 
 	attestationTryCount int
 	// cli options
-	versionPtr  *bool
 	parsePtr    *string
 	validatePtr *bool
 	fatalPtr    *bool
@@ -242,7 +238,6 @@ type zedagentContext struct {
 
 // AddAgentSpecificCLIFlags adds CLI options
 func (zedagentCtx *zedagentContext) AddAgentSpecificCLIFlags(flagSet *flag.FlagSet) {
-	zedagentCtx.versionPtr = flagSet.Bool("v", false, "Version")
 	zedagentCtx.parsePtr = flagSet.String("p", "", "parse checkpoint file")
 	zedagentCtx.validatePtr = flagSet.Bool("V", false, "validate UTF-8 in checkpoint")
 	zedagentCtx.fatalPtr = flagSet.Bool("F", false, "Cause log.Fatal fault injection")
@@ -319,10 +314,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	var err error
 	parse := *zedagentCtx.parsePtr
 	validate := *zedagentCtx.validatePtr
-	if *zedagentCtx.versionPtr {
-		fmt.Printf("%s: %s\n", agentName, Version)
-		return 0
-	}
 	if validate && parse == "" {
 		fmt.Printf("Setting -V requires -p\n")
 		return 1

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -41,7 +41,6 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/netdump"
-	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/zedcloud"
@@ -307,12 +306,14 @@ type infoForObjectKey struct {
 	infoDest  destinationBitset
 }
 
-func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string, baseDir string) int {
 	logger = loggerArg
 	log = logArg
 
 	zedagentCtx := &zedagentContext{}
 	agentbase.Init(zedagentCtx, logger, log, agentName,
+		agentbase.WithPidFile(),
+		agentbase.WithBaseDir(baseDir),
 		agentbase.WithArguments(arguments))
 
 	var err error
@@ -325,9 +326,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	if validate && parse == "" {
 		fmt.Printf("Setting -V requires -p\n")
 		return 1
-	}
-	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
-		log.Fatal(err)
 	}
 
 	// Initialize zedagent context.

--- a/pkg/pillar/cmd/zedkube/nokube.go
+++ b/pkg/pillar/cmd/zedkube/nokube.go
@@ -27,13 +27,14 @@ type zedkubeContext struct {
 }
 
 // Run in this file is just stub for non-kubevirt hypervisors.
-func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string, baseDir string) int {
 	logger := loggerArg
 	log := logArg
 
 	zedkubeCtx := zedkubeContext{}
 	agentbase.Init(&zedkubeCtx, logger, log, agentName,
 		agentbase.WithPidFile(),
+		agentbase.WithBaseDir(baseDir),
 		agentbase.WithWatchdog(ps, warningTime, errorTime),
 		agentbase.WithArguments(arguments))
 

--- a/pkg/pillar/cmd/zedkube/zedkube.go
+++ b/pkg/pillar/cmd/zedkube/zedkube.go
@@ -48,7 +48,7 @@ type zedkubeContext struct {
 }
 
 // Run - an zedkube run
-func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string, baseDir string) int {
 	logger = loggerArg
 	log = logArg
 

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -22,7 +22,6 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/flextimer"
 	"github.com/lf-edge/eve/pkg/pillar/hypervisor"
 	"github.com/lf-edge/eve/pkg/pillar/objtonum"
-	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
@@ -88,7 +87,7 @@ func (ctx *zedmanagerContext) AddAgentSpecificCLIFlags(flagSet *flag.FlagSet) {
 var logger *logrus.Logger
 var log *base.LogObject
 
-func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string, baseDir string) int {
 	logger = loggerArg
 	log = logArg
 
@@ -98,6 +97,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		hvTypeKube:   base.IsHVTypeKube(),
 	}
 	agentbase.Init(&ctx, logger, log, agentName,
+		agentbase.WithPidFile(),
+		agentbase.WithBaseDir(baseDir),
 		agentbase.WithArguments(arguments))
 
 	ctx.assignableAdapters = &types.AssignableAdapters{}
@@ -105,9 +106,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	if *ctx.versionPtr {
 		fmt.Printf("%s: %s\n", agentName, Version)
 		return 0
-	}
-	if err := pidfile.CheckAndCreatePidfile(log, agentName); err != nil {
-		log.Fatal(err)
 	}
 
 	// Run a periodic timer so we always update StillRunning

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -36,9 +36,6 @@ const (
 	warningTime = 40 * time.Second
 )
 
-// Version can be set from Makefile
-var Version = "No version specified"
-
 // State used by handlers
 type zedmanagerContext struct {
 	agentbase.AgentBase
@@ -69,7 +66,6 @@ type zedmanagerContext struct {
 	// The time from which the configured applications delays should be counted
 	delayBaseTime time.Time
 	// cli options
-	versionPtr *bool
 	// hypervisorPtr is the name of the hypervisor to use
 	hypervisorPtr      *string
 	assignableAdapters *types.AssignableAdapters
@@ -79,7 +75,6 @@ type zedmanagerContext struct {
 
 // AddAgentSpecificCLIFlags adds CLI options
 func (ctx *zedmanagerContext) AddAgentSpecificCLIFlags(flagSet *flag.FlagSet) {
-	ctx.versionPtr = flagSet.Bool("v", false, "Version")
 	allHypervisors, enabledHypervisors := hypervisor.GetAvailableHypervisors()
 	ctx.hypervisorPtr = flagSet.String("h", enabledHypervisors[0], fmt.Sprintf("Current hypervisor %+q", allHypervisors))
 }
@@ -102,11 +97,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		agentbase.WithArguments(arguments))
 
 	ctx.assignableAdapters = &types.AssignableAdapters{}
-
-	if *ctx.versionPtr {
-		fmt.Printf("%s: %s\n", agentName, Version)
-		return 0
-	}
 
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(25 * time.Second)

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -69,9 +69,6 @@ const (
 	flowStaleSec int64 = 1800
 )
 
-// Version is set from Makefile
-var Version = "No version specified"
-
 // zedrouter creates and manages network instances - a set of virtual switches
 // providing connectivity and various network services for applications.
 type zedrouter struct {
@@ -82,7 +79,6 @@ type zedrouter struct {
 	runCtx context.Context
 
 	// CLI options
-	versionPtr         *bool
 	enableArpSnooping  bool // enable/disable switch NI arp snooping
 	localLegacyMACAddr bool // switch to legacy MAC address generation
 
@@ -195,7 +191,6 @@ type zedrouter struct {
 
 // AddAgentSpecificCLIFlags adds CLI options
 func (z *zedrouter) AddAgentSpecificCLIFlags(flagSet *flag.FlagSet) {
-	z.versionPtr = flagSet.Bool("v", false, "Version")
 }
 
 func Run(ps *pubsub.PubSub, logger *logrus.Logger, log *base.LogObject, args []string, baseDir string) int {
@@ -211,11 +206,6 @@ func Run(ps *pubsub.PubSub, logger *logrus.Logger, log *base.LogObject, args []s
 		agentbase.WithPidFile(),
 		agentbase.WithBaseDir(baseDir),
 		agentbase.WithArguments(args))
-
-	if *zedrouter.versionPtr {
-		fmt.Printf("%s: %s\n", agentName, Version)
-		return 0
-	}
 
 	if err := zedrouter.init(); err != nil {
 		log.Fatal(err)

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -47,7 +47,6 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/nistate"
 	"github.com/lf-edge/eve/pkg/pillar/objtonum"
 	"github.com/lf-edge/eve/pkg/pillar/persistcache"
-	"github.com/lf-edge/eve/pkg/pillar/pidfile"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/uplinkprober"
@@ -199,7 +198,7 @@ func (z *zedrouter) AddAgentSpecificCLIFlags(flagSet *flag.FlagSet) {
 	z.versionPtr = flagSet.Bool("v", false, "Version")
 }
 
-func Run(ps *pubsub.PubSub, logger *logrus.Logger, log *base.LogObject, args []string) int {
+func Run(ps *pubsub.PubSub, logger *logrus.Logger, log *base.LogObject, args []string, baseDir string) int {
 	zedrouter := zedrouter{
 		pubSub: ps,
 		logger: logger,
@@ -209,6 +208,8 @@ func Run(ps *pubsub.PubSub, logger *logrus.Logger, log *base.LogObject, args []s
 	}
 
 	agentbase.Init(&zedrouter, logger, log, agentName,
+		agentbase.WithPidFile(),
+		agentbase.WithBaseDir(baseDir),
 		agentbase.WithArguments(args))
 
 	if *zedrouter.versionPtr {
@@ -302,9 +303,6 @@ func (z *zedrouter) init() (err error) {
 
 func (z *zedrouter) run(ctx context.Context) (err error) {
 	z.runCtx = ctx
-	if err = pidfile.CheckAndCreatePidfile(z.log, agentName); err != nil {
-		return err
-	}
 	z.log.Noticef("Starting %s", agentName)
 
 	if base.IsHVTypeKube() {

--- a/pkg/pillar/cmd/zfsmanager/zfsmanager.go
+++ b/pkg/pillar/cmd/zfsmanager/zfsmanager.go
@@ -60,7 +60,7 @@ type zfsContext struct {
 }
 
 // Run - an zfs run
-func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string) int {
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string, baseDir string) int {
 	logger = loggerArg
 	log = logArg
 
@@ -72,6 +72,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	}
 	agentbase.Init(ctxPtr, logger, log, agentName,
 		agentbase.WithPidFile(),
+		agentbase.WithBaseDir(baseDir),
 		agentbase.WithWatchdog(ps, warningTime, errorTime),
 		agentbase.WithArguments(arguments))
 

--- a/pkg/pillar/types/agent.go
+++ b/pkg/pillar/types/agent.go
@@ -1,0 +1,10 @@
+package types
+
+import (
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/sirupsen/logrus"
+)
+
+// AgentRunner is a function type that any agent that can be run by a caller process should export
+type AgentRunner func(pubsubImpl *pubsub.PubSub, logger *logrus.Logger, baseLog *base.LogObject, arguments []string, baseDir string) int

--- a/pkg/wwan/mmagent/agent.go
+++ b/pkg/wwan/mmagent/agent.go
@@ -70,16 +70,12 @@ var (
 	emptyIPSettings  = types.WwanIPSettings{}
 )
 
-// Version is set from Makefile
-var Version = "No version specified"
-
 // MMAgent is an EVE microservice controlling ModemManager (https://modemmanager.org/).
 type MMAgent struct {
 	agentbase.AgentBase
-	logger     *logrus.Logger
-	log        *base.LogObject
-	ps         *pubsub.PubSub
-	versionPtr *bool
+	logger *logrus.Logger
+	log    *base.LogObject
+	ps     *pubsub.PubSub
 
 	// publications
 	pubWwanStatus        pubsub.Publication
@@ -151,7 +147,6 @@ func (m *ModemInfo) IsManaged() bool {
 
 // AddAgentSpecificCLIFlags defines the version argument.
 func (a *MMAgent) AddAgentSpecificCLIFlags(flagSet *flag.FlagSet) {
-	a.versionPtr = flagSet.Bool("v", false, "Version")
 }
 
 // Init performs initialization of the agent. Should be called before Run.
@@ -164,10 +159,6 @@ func (a *MMAgent) Init() (err error) {
 	agentbase.Init(a, a.logger, a.log, agentName,
 		agentbase.WithArguments(arguments), agentbase.WithPidFile(),
 		agentbase.WithWatchdog(a.ps, warningTime, errorTime))
-	if *a.versionPtr {
-		fmt.Printf("%s: %s\n", agentName, Version)
-		return nil
-	}
 	a.modemInfo = make(map[string]*ModemInfo)
 	if err = a.ensureDir(WwanResolvConfDir); err != nil {
 		return err


### PR DESCRIPTION
A few changes in this PR, closely related. None should change functionality, but let's let CI be the judge of that.

## 1. Extend the pillar service `Run()` signature to include baseDir

There are a few activities that take place inside start of each service, notably creating a pidfile.

That has been hard-coded to `/run/<agentName>.pid` in the past. The previous PR #3911 created an option pass a different base directory than `/run/`.

This PR plumbs the option for the basedir through to each agent via adding an option to `Run()`, and then passes it on when creating the pidfile. In normal use case, nothing changes. This creates override options.

## 2. Unify creation of pidfile

Each service does pidfile creation a wee bit differently:

* Some services use `agentbase.Init(agentbase.WithPidFile())` 
* Some run `agentbase.Init()` _without_ that option, and then call `pidfile.CheckAndCreatePidfile()` a few lines later.
* Still others do not create a pidfile
* Others create a pidfile unless a "no pidfile" option is set (on a struct that is create a few lines above and therefore cannot be set, but let's ignore that here)

This unifies all of those to call `WithPidFile()` unless they do not create a pidfile. Those that have it optional, set the argument optionally. 

## 3. Create a `WithBaseDir()` option to `agentbase.Init()`

With this, `agentbase.Init()` can know where to create the pidfile.

## 4. Remove unused options from services

The `pkg/pillar/cmd/*` services all have options for `-v` for version and `-p` for "do not check for pid file. None of these is used, at all. I clarified this with @eriknordmark (to give credit, he pointed out to me that these are unused), so they have been removed, in 2 separate commits.


