### PR TITLE
wwan: Add FCC-unlock tool from Lenovo

### DIFF
--- a/pkg/wwan/Dockerfile
+++ b/pkg/wwan/Dockerfile
@@ -13,6 +13,7 @@ ENV LIBMBIM_VERSION=1.30.0
 ENV LIBQMI_VERSION=1.34.0
 ENV LIBQRTR_VERSION=1.2.2
 ENV PICOCOM_COMMIT=1acf1ddabaf3576b4023c4f6f09c5a3e4b086fb8
+ENV LENOVO_WWAN_UNLOCK_COMMIT=058d555e79314b6c2afca44d30986744819e8160
 
 ADD --keep-git-dir=true https://gitlab.freedesktop.org/mobile-broadband/libqrtr-glib.git#${LIBQRTR_VERSION} /libqrtr
 WORKDIR /libqrtr
@@ -47,6 +48,14 @@ ADD --keep-git-dir=true https://github.com/npat-efault/picocom.git#${PICOCOM_COM
 WORKDIR /picocom
 # Need this patch to build with musl: https://github.com/npat-efault/picocom/commit/1acf1ddabaf3576b4023c4f6f09c5a3e4b086fb8
 RUN make -j "$(getconf _NPROCESSORS_ONLN)" && strip picocom && cp picocom /usr/bin/
+
+# Install FCC-unlock scripts/tools provided by device vendors
+ADD --keep-git-dir=true https://github.com/lenovo/lenovo-wwan-unlock.git#${LENOVO_WWAN_UNLOCK_COMMIT} /lenovo-wwan-unlock
+WORKDIR /lenovo-wwan-unlock
+RUN cp libmbimtools.so /out/usr/lib/ && chmod 444 /out/usr/lib/libmbimtools.so
+RUN mkdir -p /out/opt/lenovo/ && \
+    cp DPR_Fcc_unlock_service /out/opt/lenovo/ && chmod 544 /out/opt/lenovo/DPR_Fcc_unlock_service
+COPY --chown=root:root --chmod=500 fcc-unlock /out/usr/lib/ModemManager/fcc-unlock.d
 
 RUN strip /usr/bin/*cli /usr/libexec/*proxy
 

--- a/pkg/wwan/fcc-unlock/1eac:1002
+++ b/pkg/wwan/fcc-unlock/1eac:1002
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Copyright (c) 2024 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Quectel EM160R-GL FCC Unlock Script
+
+ARCH="$(uname -m)"
+VENDOR="$(cat /sys/class/dmi/id/sys_vendor)"
+PRODUCT="$(cat /sys/class/dmi/id/product_family)"
+
+# Fallback to the open-source FCC unlock script when vendor-specific unlock tool
+# is not available or fails.
+# shellcheck disable=SC2015
+[ "$ARCH" = "x86_64" ] && [ "$VENDOR" = "LENOVO" ] && [ "$PRODUCT" = "ThinkEdge SE30" ] &&
+  /opt/lenovo/DPR_Fcc_unlock_service || /etc/ModemManager/fcc-unlock.d/1eac "$@"
+
+exit $?

--- a/pkg/wwan/fcc-unlock/2c7c:030a
+++ b/pkg/wwan/fcc-unlock/2c7c:030a
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Copyright (c) 2024 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Quectel EM05-G FCC Unlock Script
+
+ARCH="$(uname -m)"
+VENDOR="$(cat /sys/class/dmi/id/sys_vendor)"
+PRODUCT="$(cat /sys/class/dmi/id/product_family)"
+
+# Fallback to the open-source FCC unlock script when vendor-specific unlock tool
+# is not available or fails.
+# shellcheck disable=SC2015
+[ "$ARCH" = "x86_64" ] && [ "$VENDOR" = "LENOVO" ] && [ "$PRODUCT" = "ThinkEdge SE10" ] &&
+  /opt/lenovo/DPR_Fcc_unlock_service || /etc/ModemManager/fcc-unlock.d/2c7c "$@"
+
+exit $?

--- a/pkg/wwan/fcc-unlock/2c7c:0311
+++ b/pkg/wwan/fcc-unlock/2c7c:0311
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Copyright (c) 2024 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Quectel EM05-G Smart Gateway FCC Unlock Script
+
+ARCH="$(uname -m)"
+VENDOR="$(cat /sys/class/dmi/id/sys_vendor)"
+PRODUCT="$(cat /sys/class/dmi/id/product_family)"
+
+# Fallback to the open-source FCC unlock script when vendor-specific unlock tool
+# is not available or fails.
+# shellcheck disable=SC2015
+[ "$ARCH" = "x86_64" ] && [ "$VENDOR" = "LENOVO" ] && [ "$PRODUCT" = "ThinkEdge SE10" ] &&
+  /opt/lenovo/DPR_Fcc_unlock_service || /etc/ModemManager/fcc-unlock.d/2c7c "$@"
+
+exit $?

--- a/pkg/wwan/mm-init.sh
+++ b/pkg/wwan/mm-init.sh
@@ -13,13 +13,15 @@ enable_fcc_unlock() {
   for SCRIPT in "${SOURCE_DIR}"*; do
     if [ -f "$SCRIPT" ]; then
       SCRIPT_NAME="$(basename "$SCRIPT")"
+      case "$SCRIPT_NAME" in
+        "1eac:1002" | "2c7c:030a" | "2c7c:0311")
+          # For these modems we have our own custom scripts.
+          continue
+          ;;
+      esac
       ln -sf "$SCRIPT" "${TARGET_DIR}${SCRIPT_NAME}"
     fi
   done
-
-  # "Quectel EM05G Smart Gateway" (2c7c:0311) is compatible with the same
-  # FCC unlock script as used for the regular "Quectel EM05G" (2c7c:030a).
-  ln -sf "${SOURCE_DIR}2c7c:030a" "${TARGET_DIR}2c7c:0311"
 }
 
 echo "Loading kernel modules used by ModemManager"


### PR DESCRIPTION
This tool is able to perform FCC unlock procedure on devices:
* ThinkEdge SE30 with modem Quectel EM160
* ThinkEdge SE10 with modem Quectel EM05-G