### PR TITLE
Kubevirt: Tag external-boot-image with eve-release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -798,8 +798,8 @@ pkg/external-boot-image/build.yml: pkg/external-boot-image/build.yml.in
 pkg/external-boot-image: pkg/external-boot-image/build.yml
 pkg/kube: pkg/external-boot-image
 	$(MAKE) eve-external-boot-image
-	$(MAKE) cache-export IMAGE=$(shell $(LINUXKIT) pkg show-tag pkg/external-boot-image) OUTFILE=pkg/kube/external-boot-image.tar && \
-	$(MAKE) eve-kube && rm -f pkg/kube/external-boot-image.tar && rm -f pkg/external-boot-image/build.yml
+	$(MAKE) cache-export IMAGE=$(shell $(LINUXKIT) pkg show-tag pkg/external-boot-image | tee pkg/kube/external-boot-image.tag) OUTFILE=pkg/kube/external-boot-image.tar && \
+	$(MAKE) eve-kube && rm -f pkg/kube/external-boot-image.tar pkg/kube/external-boot-image.tag pkg/external-boot-image/build.yml
 	$(QUIET): $@: Succeeded
 pkg/pillar: pkg/dnsmasq pkg/gpt-tools pkg/dom0-ztools eve-pillar
 	$(QUIET): $@: Succeeded

--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -37,6 +37,7 @@ COPY multus-daemonset.yaml /etc
 COPY kubevirt-operator.yaml /etc
 COPY kubevirt-features.yaml /etc
 COPY external-boot-image.tar /etc/
+COPY external-boot-image.tag /etc/
 
 # Longhorn config
 COPY iscsid.conf /etc/iscsi/

--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -294,7 +294,12 @@ check_start_containerd() {
                 # This is very similar to what we do on kvm based eve to start container as a VM.
                 logmsg "Trying to install new external-boot-image"
                 # This import happens once per reboot
-                if ctr -a /run/containerd-user/containerd.sock image import /etc/external-boot-image.tar docker.io/lfedge/eve-external-boot-image:latest; then
+                if ctr -a /run/containerd-user/containerd.sock image import /etc/external-boot-image.tar; then
+                        eve_external_boot_img_tag=$(cat /run/eve-release)
+                        eve_external_boot_img=docker.io/lfedge/eve-external-boot-image:"$eve_external_boot_img_tag"
+                        import_tag=$(cat /etc/external-boot-image.tag)
+                        ctr -a /run/containerd-user/containerd.sock image tag "docker.io/${import_tag}" "$eve_external_boot_img"
+
                         logmsg "Successfully installed external-boot-image"
                         rm -f /etc/external-boot-image.tar
                 fi

--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -296,7 +296,11 @@ func (ctx kubevirtContext) CreateVMIConfig(domainName string, config types.Domai
 				// https://kubevirt.io/user-guide/virtual_machines/boot_from_external_source/
 				// Since disks are virtio disks we assume /dev/vda is the boot disk
 				kernelArgs := "console=tty0 root=/dev/vda dhcp=1 rootfstype=ext4"
-				scratchImage := "docker.io/lfedge/eve-external-boot-image:latest"
+				eveRelease, err := os.ReadFile("/run/eve-release")
+				if err != nil {
+					return logError("Failed to fetch eve-release %v", err)
+				}
+				scratchImage := "docker.io/lfedge/eve-external-boot-image:" + string(eveRelease)
 				kernelPath := "/kernel"
 				initrdPath := "/runx-initrd"
 


### PR DESCRIPTION
At build of pkg/kube:
Save pkg/external-boot-image tag to pkg/kube/external-boot-image.tag

During runtime of cluster-init.sh:
Import and tag external-boot-image to contents of /run/eve-release

pillar kubevirt hypervisor will read /run/eve-release to generate the external-boot-image tag to use.