### PR TITLE
Kubevirt: don't delete external-boot-image.tar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -795,11 +795,10 @@ pkgs: build-tools $(PKGS)
 
 pkg/external-boot-image/build.yml: pkg/external-boot-image/build.yml.in
 	$(QUIET)tools/compose-external-boot-image-yml.sh $< $@ $(shell echo ${KERNEL_TAG} | cut -d':' -f2) $(shell $(LINUXKIT) pkg show-tag pkg/xen-tools | cut -d':' -f2)
-pkg/external-boot-image: pkg/external-boot-image/build.yml
-pkg/kube: pkg/external-boot-image
-	$(MAKE) eve-external-boot-image
-	$(MAKE) cache-export IMAGE=$(shell $(LINUXKIT) pkg show-tag pkg/external-boot-image | tee pkg/kube/external-boot-image.tag) OUTFILE=pkg/kube/external-boot-image.tar && \
-	$(MAKE) eve-kube && rm -f pkg/kube/external-boot-image.tar pkg/kube/external-boot-image.tag pkg/external-boot-image/build.yml
+eve-external-boot-image: pkg/external-boot-image/build.yml
+pkg/kube/external-boot-image.tar: pkg/external-boot-image
+	$(MAKE) cache-export IMAGE=$(shell $(LINUXKIT) pkg show-tag pkg/external-boot-image) OUTFILE=pkg/kube/external-boot-image.tar
+pkg/kube: pkg/kube/external-boot-image.tar eve-kube
 	$(QUIET): $@: Succeeded
 pkg/pillar: pkg/dnsmasq pkg/gpt-tools pkg/dom0-ztools eve-pillar
 	$(QUIET): $@: Succeeded

--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -37,7 +37,6 @@ COPY multus-daemonset.yaml /etc
 COPY kubevirt-operator.yaml /etc
 COPY kubevirt-features.yaml /etc
 COPY external-boot-image.tar /etc/
-COPY external-boot-image.tag /etc/
 
 # Longhorn config
 COPY iscsid.conf /etc/iscsi/

--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -297,10 +297,10 @@ check_start_containerd() {
                 if ctr -a /run/containerd-user/containerd.sock image import /etc/external-boot-image.tar; then
                         eve_external_boot_img_tag=$(cat /run/eve-release)
                         eve_external_boot_img=docker.io/lfedge/eve-external-boot-image:"$eve_external_boot_img_tag"
-                        import_tag=$(cat /etc/external-boot-image.tag)
-                        ctr -a /run/containerd-user/containerd.sock image tag "docker.io/${import_tag}" "$eve_external_boot_img"
+                        import_tag=$(tar -xOf /etc/external-boot-image.tar manifest.json | jq -r '.[0].RepoTags[0]')
+                        ctr -a /run/containerd-user/containerd.sock image tag "$import_tag" "$eve_external_boot_img"
 
-                        logmsg "Successfully installed external-boot-image"
+                        logmsg "Successfully installed external-boot-image $import_tag as $eve_external_boot_img"
                         rm -f /etc/external-boot-image.tar
                 fi
         fi


### PR DESCRIPTION
Deletion of these files leads to unreliability of
pkg/kube build where build-time tag and post-build tag didn't match. The result was installer-raw or live targets failed to find pkg/kube in the cache.
Refactored pkg/kube, pkg/external-boot-image target deps to see the issue clearer.