### PR TITLE
Small bug fixes related to cellular connectivity

### DIFF
--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -1045,6 +1045,7 @@ func (n *nim) includeLastResortPort(ifAttrs netmonitor.IfAttrs) bool {
 		strings.HasPrefix(ifName, "nbu") ||
 		strings.HasPrefix(ifName, "nbo") ||
 		strings.HasPrefix(ifName, "wlan") ||
+		strings.HasPrefix(ifName, "wwan") ||
 		strings.HasPrefix(ifName, "keth")
 	if exclude {
 		return false

--- a/pkg/wwan/mmagent/mmdbus/mmapi.go
+++ b/pkg/wwan/mmagent/mmdbus/mmapi.go
@@ -65,6 +65,7 @@ const (
 // SIM type
 // https://www.freedesktop.org/software/ModemManager/doc/latest/ModemManager/ModemManager-Flags-and-Enumerations.html#MMSimType
 const (
+	SIMTypeUnknown  = 0
 	SIMTypePhysical = 1
 	SIMTypeESIM     = 2
 )


### PR DESCRIPTION
3 commits in this PR:

**Exclude cellular ports from the last-resort config**

Without cellular configuration (APN, etc.), any attempt to connect
through wwan interfaces will always fail.

**Do not assume that SIM is absent if its type is not known**

I have seen cases where modem would not report SIM card type
(the returned value was not specified), even though the (physical)
SIM card was inserted.
If SIM card type is not known, we can instead determine the card
presence based on the ICCID number availability.

Moreover, when ModemManager is unable to recognize the SIM card type,
EVE would report the type as SimTypePhysical. This is clearly
incorrect, SimTypeUnspecified should be reported instead.

**Do not log user password in clear text**

Instead the password should be masked and replaced with e.g. asterisks.