### PR TITLE
yetus/golangcilint: disable new musttag checker

### DIFF
--- a/pkg/pillar/.golangci.yml
+++ b/pkg/pillar/.golangci.yml
@@ -42,6 +42,7 @@ linters:
     - cyclop            # Raises warnings even for relatively simple functions
     - ireturn           # Returning interfaces is a common practise for constructors in defensive programming
     - exhaustive        # Complains even if struct has default branch
+    - musttag           # pillar uses implicit tags for all structs
 
 issues:
   max-issues-per-linter: 0


### PR DESCRIPTION
This seems to have shown up in yetus recently as can be seen in e.g.,   https://github.com/lf-edge/eve/actions/runs/9187826783?pr=3926

Doesn't make sense for pillar since we use json encode/decode for all structs which appear in pubsub.