### PR TITLE
pubsub: publish deep copied object instead of value by ref

### DIFF
--- a/pkg/pillar/pubsub/publish.go
+++ b/pkg/pillar/pubsub/publish.go
@@ -139,7 +139,7 @@ func (pub *PublicationImpl) Publish(key string, item interface{}) error {
 	}
 	pub.updatersNotify(name)
 	// marshal to json bytes to send to the driver
-	b, err := json.Marshal(item)
+	b, err := json.Marshal(newItem)
 	if err != nil {
 		pub.log.Fatal("json Marshal in Publish", err)
 	}


### PR DESCRIPTION
In Publish() func in PublishImpl we create a deep copy of an object we are publishing, because caller can change map values, or object itself, etc. However, for some reason we are marshalling byte slice of item, not its copy, which could lead to saving publication of another type.