### PR TITLE
.gitignore: Add files non intended to be under revision control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,7 @@ conf/authorized_keys
 conf/grub.cfg
 conf/device.cert.pem
 conf/device.key.pem
+conf/soft_serial
 pkg/kube/external-boot-image.tar
 pkg/external-boot-image/build.yml
+tools/compare-sbom-sources/vendor


### PR DESCRIPTION
This commit adds some files that don't need to be under revision control:

- conf/soft_serial: Not intended to be under revision control
- tools/compare-sbom-sources/vendor: Vendor files for sbom tools