### PR TITLE
Allow device access when OCI config is loaded from file

### DIFF
--- a/pkg/pillar/containerd/oci.go
+++ b/pkg/pillar/containerd/oci.go
@@ -245,6 +245,18 @@ func (s *ociSpec) Load(file *os.File) error {
 	if s.Annotations == nil {
 		s.Annotations = map[string]string{}
 	}
+	// default OCI specs have all devices being denied by default,
+	// we flip it back to all allow for now, but later on we may
+	// need to get more fine-grained
+	if s.Linux == nil {
+		s.Linux = &specs.Linux{}
+	}
+	if s.Linux.Resources == nil {
+		s.Linux.Resources = &specs.LinuxResources{}
+	}
+	if s.Linux.Resources.Devices == nil {
+		s.Linux.Resources.Devices = []specs.LinuxDeviceCgroup{{Type: "a", Allow: true, Access: "rwm"}}
+	}
 	return nil
 }
 


### PR DESCRIPTION
Since the update to runc v1.1.0 and containerd v1.6.1 in 158cecdb9a021a403461f466b1eb0a72ffc009cf we need to explicitly allow device access in the OCI config. This is done when generating a new OCI spec.
However, when loading an OCI config from a file, we need to make sure that the device access is added, because older OCI configs may lack this configuration.