### PR TITLE
Do not try to use invalid network config

### DIFF
--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -886,6 +886,10 @@ func printOutput(ctx *diagContext, caller string) {
 			mgmtPorts++
 		}
 
+		var isValidStr string
+		if port.InvalidConfig {
+			isValidStr = " (invalid config)"
+		}
 		typeStr := "use: app-shared "
 		if isMgmt {
 			if priority == types.PortCostMin {
@@ -913,8 +917,8 @@ func printOutput(ctx *diagContext, caller string) {
 			ipCount++
 			noGeo := ipinfo.IPInfo{}
 			if dpcSuccess {
-				ctx.ph.Print("INFO: Port %s: %s%s%s%s\n",
-					ifname, macStr, linkStr, typeStr, ai.Addr)
+				ctx.ph.Print("INFO: Port %s%s: %s%s%s%s\n",
+					ifname, isValidStr, macStr, linkStr, typeStr, ai.Addr)
 			} else if ai.Geo == noGeo {
 				ctx.ph.Print("INFO: %s: IP address %s not geolocated\n",
 					ifname, ai.Addr)
@@ -924,8 +928,8 @@ func printOutput(ctx *diagContext, caller string) {
 			}
 		}
 		if ipCount == 0 {
-			ctx.ph.Print("INFO: Port %s: %s%s%sNo IP address\n",
-				ifname, macStr, linkStr, typeStr)
+			ctx.ph.Print("INFO: Port %s%s: %s%s%sNo IP address\n",
+				ifname, isValidStr, macStr, linkStr, typeStr)
 		}
 
 		// Skip details if we are connected to controller. Count
@@ -955,6 +959,13 @@ func printOutput(ctx *diagContext, caller string) {
 				ifname, port.NtpServer.String())
 		}
 		printProxy(ctx, port, ifname)
+		if port.HasError() {
+			if port.InvalidConfig {
+				ctx.ph.Print("ERROR: %s: invalid config: %s\n", ifname, port.LastError)
+			} else {
+				ctx.ph.Print("ERROR: %s: has error: %s\n", ifname, port.LastError)
+			}
+		}
 
 		if !isMgmt {
 			ctx.ph.Print("INFO: %s: not intended for EV controller; skipping those tests\n",

--- a/pkg/pillar/cmd/zedagent/parseconfig_test.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig_test.go
@@ -195,7 +195,7 @@ func TestDPCWithError(t *testing.T) {
 	g.Expect(dpc.LastFailed).ToNot(BeZero())
 	g.Expect(dpc.LastSucceeded).To(BeZero())
 	g.Expect(getPortError(&dpc, "adapter-shopfloor")).
-		To(ContainSubstring("UNKNOWN Network UUID"))
+		To(ContainSubstring("Port adapter-shopfloor configured with unknown Network UUID"))
 	g.Expect(dpc.Ports).To(HaveLen(1))
 	port := dpc.Ports[0]
 	g.Expect(port.Logicallabel).To(Equal("adapter-shopfloor"))

--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -118,7 +118,12 @@ func (z *zedrouter) setSelectedUplink(uplinkLogicalLabel string,
 		// Wait for DPC update
 		return true, err
 	case 1:
-		// OK
+		if ports[0].InvalidConfig {
+			return false, fmt.Errorf("port %s has invalid config: %s", ports[0].Logicallabel,
+				ports[0].LastError)
+		}
+		// Selected port is OK
+		break
 	default:
 		err = fmt.Errorf("label of selected uplink matches multiple ports (%v)", ports)
 		return false, err

--- a/pkg/pillar/conntester/zedcloud.go
+++ b/pkg/pillar/conntester/zedcloud.go
@@ -94,6 +94,9 @@ func (t *ZedcloudConnectivityTester) TestConnectivity(dns types.DeviceNetworkSta
 	}
 	zedcloudCtx.TlsConfig = tlsConfig
 	for ix := range dns.Ports {
+		if dns.Ports[ix].InvalidConfig {
+			continue
+		}
 		ifName := dns.Ports[ix].IfName
 		err = devicenetwork.CheckAndGetNetworkProxy(t.Log, &dns, ifName, t.Metrics)
 		if err != nil {

--- a/pkg/pillar/dpcmanager/dns.go
+++ b/pkg/pillar/dpcmanager/dns.go
@@ -69,6 +69,7 @@ func (m *DpcManager) updateDNS() {
 		// Prefer errors recorded by DPC verification.
 		// New errors are recorded from this function only when there is none yet
 		// (HasError() == false).
+		m.deviceNetStatus.Ports[ix].InvalidConfig = port.InvalidConfig
 		m.deviceNetStatus.Ports[ix].TestResults = port.TestResults
 		m.deviceNetStatus.Ports[ix].WirelessStatus.WType = port.WirelessCfg.WType
 		// If this is a cellular network connectivity, add status information

--- a/pkg/pillar/types/dns.go
+++ b/pkg/pillar/types/dns.go
@@ -29,12 +29,16 @@ type DeviceNetworkStatus struct {
 }
 
 type NetworkPortStatus struct {
-	IfName         string
-	Phylabel       string // Physical name set by controller/model
-	Logicallabel   string
-	Alias          string // From SystemAdapter's alias
-	IsMgmt         bool   // Used to talk to controller
-	IsL3Port       bool   // True if port is applicable to operate on the network layer
+	IfName       string
+	Phylabel     string // Physical name set by controller/model
+	Logicallabel string
+	Alias        string // From SystemAdapter's alias
+	IsMgmt       bool   // Used to talk to controller
+	IsL3Port     bool   // True if port is applicable to operate on the network layer
+	// InvalidConfig is used to flag port config which failed parsing or (static) validation
+	// checks, such as: malformed IP address, undefined required field, IP address not inside
+	// the subnet, etc.
+	InvalidConfig  bool
 	Cost           uint8
 	Dhcp           DhcpType
 	Type           NetworkType // IPv4 or IPv6 or Dual stack
@@ -210,7 +214,9 @@ func (status DeviceNetworkStatus) MostlyEqual(status2 DeviceNetworkStatus) bool 
 			p1.Alias != p2.Alias ||
 			p1.IsMgmt != p2.IsMgmt ||
 			p1.IsL3Port != p2.IsL3Port ||
-			p1.Cost != p2.Cost {
+			p1.InvalidConfig != p2.InvalidConfig ||
+			p1.Cost != p2.Cost ||
+			p1.MTU != p2.MTU {
 			return false
 		}
 		if p1.Dhcp != p2.Dhcp ||

--- a/pkg/pillar/types/dpc.go
+++ b/pkg/pillar/types/dpc.go
@@ -355,10 +355,12 @@ func (config *DevicePortConfig) DoSanitize(log *base.LogObject,
 
 // CountMgmtPorts returns the number of management ports
 // Exclude any broken ones with Dhcp = DhcpTypeNone
-func (config *DevicePortConfig) CountMgmtPorts() int {
+// Optionally exclude mgmt ports with invalid config
+func (config *DevicePortConfig) CountMgmtPorts(onlyValidConfig bool) int {
 	count := 0
 	for _, port := range config.Ports {
-		if port.IsMgmt && port.Dhcp != DhcpTypeNone {
+		if port.IsMgmt && port.Dhcp != DhcpTypeNone &&
+			!(onlyValidConfig && port.InvalidConfig) {
 			count++
 		}
 	}
@@ -434,7 +436,7 @@ func (config DevicePortConfig) IsDPCUntested() bool {
 // IsDPCUsable - checks whether something is invalid; no management IP
 // addresses means it isn't usable hence we return false if none.
 func (config DevicePortConfig) IsDPCUsable() bool {
-	mgmtCount := config.CountMgmtPorts()
+	mgmtCount := config.CountMgmtPorts(true)
 	return mgmtCount > 0
 }
 
@@ -511,9 +513,13 @@ type NetworkPortConfig struct {
 	Alias        string // From SystemAdapter's alias
 	// NetworkUUID - UUID of the Network Object configured for the port.
 	NetworkUUID uuid.UUID
-	IsMgmt      bool  // Used to talk to controller
-	IsL3Port    bool  // True if port is applicable to operate on the network layer
-	Cost        uint8 // Zero is free
+	IsMgmt      bool // Used to talk to controller
+	IsL3Port    bool // True if port is applicable to operate on the network layer
+	// InvalidConfig is used to flag port config which failed parsing or (static) validation
+	// checks, such as: malformed IP address, undefined required field, IP address not inside
+	// the subnet, etc.
+	InvalidConfig bool
+	Cost          uint8 // Zero is free
 	DhcpConfig
 	ProxyConfig
 	L2LinkConfig

--- a/pkg/pillar/uplinkprober/uplinkprober.go
+++ b/pkg/pillar/uplinkprober/uplinkprober.go
@@ -438,7 +438,7 @@ func (p *UplinkProber) applyPendingDNS(pendingDNS types.DeviceNetworkStatus) {
 			continue
 		}
 		port := ports[0]
-		if !port.IsMgmt {
+		if !port.IsMgmt || port.InvalidConfig {
 			p.log.Noticef("UplinkProber: Removed %s from the list of probed uplinks",
 				uplinkLL)
 			delete(p.uplinkProbeStatus, uplinkLL)
@@ -446,7 +446,7 @@ func (p *UplinkProber) applyPendingDNS(pendingDNS types.DeviceNetworkStatus) {
 	}
 	// Add ports that have just appeared and update existing.
 	for _, port := range p.pendingDNS.Ports {
-		if !port.IsMgmt {
+		if !port.IsMgmt || port.InvalidConfig {
 			continue
 		}
 		uplinkStatus, haveStatus := p.uplinkProbeStatus[port.Logicallabel]

--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -335,6 +335,11 @@ func VerifyAllIntf(ctx *ZedCloudContext, url string, requiredSuccessCount uint,
 	// (aka dry-run).
 	for _, intf := range intfs {
 		portStatus := types.GetPort(*ctx.DeviceNetworkStatus, intf)
+		if portStatus.InvalidConfig {
+			// Do not try to test port with invalid config.
+			// Otherwise, the test would fail and the parsing error would get overwritten.
+			continue
+		}
 		// If we have enough uplinks with cloud connectivity, then the remaining
 		// interfaces (some of which might not be free) are verified using
 		// only local checks, without generating any traffic.


### PR DESCRIPTION
Even if zedagent detects invalid network config and reports DPC with error, NIM may still try to use it, run connection tests and overwrite the error with another or even with nil.
Instead, NIM should skip mgmt ports with invalid config and preserve the error (incl. across reboots).
Similarly, DPC reconciler should not try to apply invalid config into the network stack.
Additionally, diag was extended to report when port config is not valid.
Lastly, readability of some parsing error messages was improved.