### PR TITLE
pillar/vaultmgr.go: fix segfault on attempt to init fscrypt

### DIFF
--- a/pkg/pillar/cmd/vaultmgr/vaultmgr.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgr.go
@@ -196,6 +196,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		args = arguments[1:]
 	}
 
+	handler = vault.GetHandler(log)
+
 	// if an explicit command was given, run that command and return, else run the agent
 	if command != "" {
 		return runCommand(ps, command, args)
@@ -203,8 +205,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 
 	agentArgs := []agentbase.AgentOpt{agentbase.WithBaseDir(baseDir), agentbase.WithArguments(arguments), agentbase.WithPidFile()}
 	agentbase.Init(&ctx, logger, log, agentName, agentArgs...)
-
-	handler = vault.GetHandler(log)
 
 	log.Functionf("Starting %s\n", agentName)
 


### PR DESCRIPTION
This fixes the following crash:
```
  (ns: pillar) 617351bd-6ed6-4cb5-a8e1-04ad4a53e63f:/# /opt/zededa/bin/vaultmgr setupDeprecatedVaults
  INFO[0000] Containerd Init
  panic: runtime error: invalid memory address or nil pointer dereference
  [signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x2382518]

  goroutine 1 [running]:
  github.com/lf-edge/eve/pkg/pillar/cmd/vaultmgr.runCommand(0xc0007ffa70?, {0x7ffdfb082f21, 0x15}, {0x40b58a0?, 0x1?, 0xc0007ffa68?})
	        /pillar/cmd/vaultmgr/vaultmgr.go:327 +0x158
		github.com/lf-edge/eve/pkg/pillar/cmd/vaultmgr.Run(0xc00088d2f0, 0x2b75c4c?, 0x23?, {0xc000052050?, 0x1, 0x1}, {0x0, 0x0})
	        /pillar/cmd/vaultmgr/vaultmgr.go:201 +0x776
		main.runService({0x7ffdfb082f18?, 0xc000052050?}, {0x2c0f7e8?, 0x8?}, 0xa0?)
	        /pillar/zedbox/zedbox.go:157 +0x217
		main.main()
	        /pillar/zedbox/zedbox.go:130 +0x145
```
This crash leads to a missing fscrypt first initialization, so node onboards, but vault is not ready and no applications are started. The following error message can be observed:
```
  Encryption failed: exit status 1, ,
  [ERROR] fscrypt encrypt: filesystem /hostfs/persist is not setup for use with fscrypt
          Run "sudo fscrypt setup /hostfs/persist" to use fscrypt on this filesystem.
```

Reported-by: Milan Lenco <milan@zededa.com>
Fixes: 449b6f268ae9 ("extend Run() signature to include baseDir; add
	              WithBaseDir option to agent.Init; remove pidfile
		      creation from all pillar services, replacing with
		      call to agent.Init(WithPidfile()); passed inline
		      or not explicitly to Run()")


CC: @milan-zededa 
CC: @deitch 