### PR TITLE
Kernel update - [amd64-generic, amd64-rt, amd64-generic, arm64-nvidia…

### DIFF
--- a/kernel-commits.mk
+++ b/kernel-commits.mk
@@ -1,8 +1,8 @@
 KERNEL_COMMIT_amd64_v5.10.186_generic = 37256d6aff33
-KERNEL_COMMIT_amd64_v6.1.38_generic = fcab2e7830ca
-KERNEL_COMMIT_amd64_v6.1.38_rt = 1ead4c5f5ee7
-KERNEL_COMMIT_amd64_v6.1.68_generic = b4d7ad0a73b1
+KERNEL_COMMIT_amd64_v6.1.38_generic = 2049bda2c9ed
+KERNEL_COMMIT_amd64_v6.1.38_rt = ef571b34f5ad
+KERNEL_COMMIT_amd64_v6.1.68_generic = 662de9abec4d
 KERNEL_COMMIT_arm64_v5.10.104_nvidia = 02c64aba1d9f
 KERNEL_COMMIT_arm64_v5.10.186_generic = 594f2361a83f
-KERNEL_COMMIT_arm64_v6.1.38_generic = 5e51e61211ea
+KERNEL_COMMIT_arm64_v6.1.38_generic = aa4b24ade858
 KERNEL_COMMIT_riscv64_v6.1.38_generic = 72192e3cbc74


### PR DESCRIPTION
    Kernel update - [amd64-generic, amd64-rt, amd64-generic, arm64-generic]
    
    eve-kernel-amd64-v6.1.38-generic
        2049bda2c9ed: Enable PLD for Kontron devices
        9bf23b004876: kernel: enable debug info
        085a54afd612: Dockerfile: add pahole dependency
    
    eve-kernel-amd64-v6.1.38-rt
        ef571b34f5ad: kernel: enable debug info
        d0fbf78234ec: Dockerfile: add pahole dependency
    
    eve-kernel-amd64-v6.1.68-generic
        662de9abec4d: kernel: enable debug info
        8522329a4108: Dockerfile: add pahole dependency
    
    eve-kernel-arm64-v6.1.38-generic
        aa4b24ade858: kernel: enable debug info
        d1859d28c3e2: Dockerfile: add pahole dependency