### PR TITLE
move waitforcontainerd into containerd package to avoid transitive dependencies in wait

### DIFF
--- a/pkg/pillar/cmd/baseosmgr/baseosmgr.go
+++ b/pkg/pillar/cmd/baseosmgr/baseosmgr.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/agentbase"
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/containerd"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils/wait"
@@ -130,7 +131,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	}
 	log.Functionf("processed Vault Status")
 
-	if err := wait.WaitForUserContainerd(ps, log, agentName, warningTime, errorTime); err != nil {
+	if err := containerd.WaitForUserContainerd(ps, log, agentName, warningTime, errorTime); err != nil {
 		log.Fatal(err)
 	}
 	log.Functionf("user containerd ready")

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -579,7 +579,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		log.Fatalf("StartUserContainerdInstance: failed %v", err)
 	}
 
-	if err := wait.WaitForUserContainerd(ps, log, agentName, warningTime, errorTime); err != nil {
+	if err := containerd.WaitForUserContainerd(ps, log, agentName, warningTime, errorTime); err != nil {
 		log.Fatal(err)
 	}
 	log.Functionf("user containerd ready")

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -16,6 +16,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/cas"
+	"github.com/lf-edge/eve/pkg/pillar/containerd"
 	"github.com/lf-edge/eve/pkg/pillar/flextimer"
 	"github.com/lf-edge/eve/pkg/pillar/kubeapi"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
@@ -225,7 +226,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	}
 	log.Functionf("processed Vault Status")
 
-	if err := wait.WaitForUserContainerd(ps, log, agentName, warningTime, errorTime); err != nil {
+	if err := containerd.WaitForUserContainerd(ps, log, agentName, warningTime, errorTime); err != nil {
 		log.Fatal(err)
 	}
 	log.Functionf("user containerd ready")

--- a/pkg/pillar/containerd/waitfor.go
+++ b/pkg/pillar/containerd/waitfor.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2024 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package containerd
+
+import (
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+)
+
+// WaitForUserContainerd waits until user containerd started
+func WaitForUserContainerd(ps *pubsub.PubSub, log *base.LogObject, agentName string, warningTime, errorTime time.Duration) error {
+	stillRunning := time.NewTicker(25 * time.Second)
+	ps.StillRunning(agentName, warningTime, errorTime)
+	checkTicker := time.NewTicker(5 * time.Second)
+	initialized := false
+
+	for !initialized {
+		log.Noticeln("Waiting for user containerd socket initialized")
+		select {
+		case <-checkTicker.C:
+			ctrdClient, err := NewContainerdClient(true)
+			if err != nil {
+				log.Tracef("user containerd not ready: %v", err)
+				continue
+			}
+			_ = ctrdClient.CloseClient()
+			initialized = true
+		case <-stillRunning.C:
+		}
+		ps.StillRunning(agentName, warningTime, errorTime)
+	}
+	stillRunning.Stop()
+	return nil
+}

--- a/pkg/pillar/utils/wait/waitfor.go
+++ b/pkg/pillar/utils/wait/waitfor.go
@@ -8,7 +8,6 @@ import (
 
 	info "github.com/lf-edge/eve-api/go/info"
 	"github.com/lf-edge/eve/pkg/pillar/base"
-	"github.com/lf-edge/eve/pkg/pillar/containerd"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	uuid "github.com/satori/go.uuid"
@@ -145,30 +144,4 @@ func handleOnboardStatusImpl(ctxArg interface{}, key string,
 		return
 	}
 	ctx.Initialized = true
-}
-
-// WaitForUserContainerd waits until user containerd started
-func WaitForUserContainerd(ps *pubsub.PubSub, log *base.LogObject, agentName string, warningTime, errorTime time.Duration) error {
-	stillRunning := time.NewTicker(25 * time.Second)
-	ps.StillRunning(agentName, warningTime, errorTime)
-	checkTicker := time.NewTicker(5 * time.Second)
-	initialized := false
-
-	for !initialized {
-		log.Noticeln("Waiting for user containerd socket initialized")
-		select {
-		case <-checkTicker.C:
-			ctrdClient, err := containerd.NewContainerdClient(true)
-			if err != nil {
-				log.Tracef("user containerd not ready: %v", err)
-				continue
-			}
-			_ = ctrdClient.CloseClient()
-			initialized = true
-		case <-stillRunning.C:
-		}
-		ps.StillRunning(agentName, warningTime, errorTime)
-	}
-	stillRunning.Stop()
-	return nil
 }


### PR DESCRIPTION
package `pkg/pillar/utils/wait` contains a few wait functions. One of them is `WaitForUserContainerd()`, which creates a dependency on `pkg/pillar/containerd` and transitively on `github.com/containerd/containerd` and everything it depends upon. That makes other functions pull it in, which is not desired.

This moves it into `pkg/pillar/containerd`, and updates downstream dependencies.