### PR TITLE
[9.4-stable] pillar: Release CPUs on domain activation failure

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1247,6 +1247,9 @@ func updateNonPinnedCPUs(ctx *domainContext, config *types.DomainConfig, status 
 	return nil
 }
 
+// assignCPUs assigns CPUs to the VM based on the configuration
+// By the assignment, we mean that the CPUs are assigned in the CPUAllocator context to the given VM
+// and the cpumask is updated in the *status*
 func assignCPUs(ctx *domainContext, config *types.DomainConfig, status *types.DomainStatus) error {
 	if config.VmConfig.CPUsPinned { // Pin the CPU
 		cpusToAssign, err := ctx.cpuAllocator.Allocate(config.UUIDandVersion.UUID, config.VCpus)
@@ -1260,6 +1263,17 @@ func assignCPUs(ctx *domainContext, config *types.DomainConfig, status *types.Do
 		status.VmConfig.CPUs = constructNonPinnedCpumaskString(ctx)
 	}
 	return nil
+}
+
+// releaseCPUs releases the CPUs that were previously assigned to the VM.
+// The cpumask in the *status* is updated accordingly, and the CPUs are released in the CPUAllocator context.
+func releaseCPUs(ctx *domainContext, config *types.DomainConfig, status *types.DomainStatus) {
+	if ctx.cpuPinningSupported && config.VmConfig.CPUsPinned && status.VmConfig.CPUs != "" {
+		if err := ctx.cpuAllocator.Free(config.UUIDandVersion.UUID); err != nil {
+			log.Errorf("Failed to free CPUs for %s: %s", config.DisplayName, err)
+		}
+	}
+	status.VmConfig.CPUs = ""
 }
 
 func handleCreate(ctx *domainContext, key string, config *types.DomainConfig) {
@@ -1419,6 +1433,7 @@ func doActivate(ctx *domainContext, config types.DomainConfig,
 		status.PendingAdd = false
 		status.SetErrorDescription(*errDescription)
 		status.AdaptersFailed = true
+		releaseCPUs(ctx, &config, status)
 		publishDomainStatus(ctx, status)
 		releaseAdapters(ctx, config.IoAdapterList, config.UUIDandVersion.UUID,
 			nil)
@@ -1442,6 +1457,7 @@ func doActivate(ctx *domainContext, config types.DomainConfig,
 		status.PendingAdd = false
 		status.SetErrorNow(err.Error())
 		status.AdaptersFailed = true
+		releaseCPUs(ctx, &config, status)
 		publishDomainStatus(ctx, status)
 		releaseAdapters(ctx, config.IoAdapterList, config.UUIDandVersion.UUID,
 			nil)
@@ -1460,6 +1476,7 @@ func doActivate(ctx *domainContext, config types.DomainConfig,
 					snapshotID, config.UUIDandVersion.UUID, err)
 				log.Error(err.Error())
 				status.SetErrorNow(err.Error())
+				releaseCPUs(ctx, &config, status)
 				return
 			}
 		default:
@@ -1473,6 +1490,7 @@ func doActivate(ctx *domainContext, config types.DomainConfig,
 			if err != nil {
 				log.Errorf("Failed to check disk format: %v", err.Error())
 				status.SetErrorNow(err.Error())
+				releaseCPUs(ctx, &config, status)
 				return
 			}
 		}
@@ -1490,6 +1508,7 @@ func doActivate(ctx *domainContext, config types.DomainConfig,
 		log.Errorf("Failed to create DomainStatus from %v: %s",
 			config, err)
 		status.SetErrorNow(err.Error())
+		releaseCPUs(ctx, &config, status)
 		return
 	}
 
@@ -1509,6 +1528,7 @@ func doActivate(ctx *domainContext, config types.DomainConfig,
 			log.Errorf("DomainCreate for %s: %s", status.DomainName, err)
 			status.BootFailed = true
 			status.SetErrorNow(err.Error())
+			releaseCPUs(ctx, &config, status)
 			publishDomainStatus(ctx, status)
 			return
 		}


### PR DESCRIPTION
Backport https://github.com/lf-edge/eve/pull/3952 into 9.4.