### PR TITLE
Incorporate Longhorn 1.6.2 fixes

### DIFF
--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 #
-# Copyright (c) 2023 Zededa, Inc.
+# Copyright (c) 2023-2024 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 K3S_VERSION=v1.28.5+k3s1
 KUBEVIRT_VERSION=v1.1.0
-LONGHORN_VERSION=v1.6.0
-CDI_VERSION=v1.57.0
+LONGHORN_VERSION=v1.6.2
+CDI_VERSION=v1.54.0
 NODE_IP=""
 MAX_K3S_RESTARTS=10
 RESTART_COUNT=0

--- a/pkg/pillar/kubeapi/vitoapiserver.go
+++ b/pkg/pillar/kubeapi/vitoapiserver.go
@@ -198,7 +198,7 @@ func NewPVCDefinition(pvcName string, size string, annotations,
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			StorageClassName: stringPtr(VolumeCSIClusterStorageClass),
-			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 			VolumeMode:       &volumeModeBlock,
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{


### PR DESCRIPTION
Longhorn 1.6.2 includes a number of improvements
including an apiserver performance improvement
and an rpc deadlock fix

This commit has to drop the CDI version to handle
competing security changes in CDI and longhorn as
the default configuration of Longhorn 1.6.1+
is incompatible with CDI 1.55+.  This needs to be
resolved but in the short term the updated longhorn is needed more than the updated CDI, the CDI 1.57.0 release was primarily included for a qcow2 performance improvement on slower devices.

The changes which broke compatibility appear to be: CDI 1.55+ started running uploads as a nonroot kvm user. Longhorn 1.6.1+ started adding volume devices to a disk group. There is a configuration change available to resolve this issue but analysis of the changes to security are ongoing.

Fix NewPVCDefinition default AccessMode to RWO.  An earlier merge mistakenly changed it to RWX-Block for non downloaded volumes which is a combination not supported by Longhorn.