### PR TITLE
Introduce `debug.enable.vnc.shim.vm` flag for enabling VNC for a shim VM

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -31,6 +31,7 @@
 | debug.enable.vga | boolean | false | allow VGA console on device |
 | debug.enable.ssh | authorized ssh key | empty string(ssh disabled) | allow ssh to EVE |
 | debug.enable.console | boolean | false | allow console access to EVE (reboot required to disable) |
+| debug.enable.vnc.shim.vm | boolean | false | allow VNC access to the container application shim VM (reboot required to disable) |
 | debug.default.loglevel | string | info | min level saved in files on device. Used logrus log levels as described here ["https://pkg.go.dev/github.com/sirupsen/logrus"]: panic, fatal, error, warning, info, debug and trace.
 | debug.syslog.loglevel | string | info | min level of the syslog messages saved in files on device. System default loglevel string representation should be used as described here ["https://man7.org/linux/man-pages/man3/syslog.3.html"]: emerg, alert, crit, err, warning, notice, info, debug. |
 | debug.kernel.loglevel | string | info | min level of the kernel messages saved in files on device. System default loglevel string representation should be used as described here ["https://man7.org/linux/man-pages/man3/syslog.3.html"]: emerg, alert, crit, err, warning, notice, info, debug. |

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -81,6 +81,10 @@ To enable USB keyboard and/or storage access post onboarding it is necessary to 
 
 Further, to enable any console input post onboarding it is necessary to set debug.enable.console to true as specified in [configuration properties](CONFIG-PROPERTIES.md). Note that this setting is persisted by the device across reboots, hence it is re-applied once the pillar container starts. To see output on a screen post onboarding it is necessary to set debug.enable.vga, which is also persisted and re-applied after a reboot.
 
+## VNC access to the shim VM
+
+For security reasons VNC access to the shim VM is disabled by default. To enable such access the `debug.enable.vnc.shim.vm` has to be set to true. The flag is global per node, see the [VNC doc](DEBUGGING.md) for details.
+
 ## Diagnostic output
 
 If the device has an attached console or screen per the above, then EVE will send textual output to that which summarizes the connectivity to the controller, the device status including remote attestation state, the application status and errors, and any download status and errors.

--- a/docs/VNC.md
+++ b/docs/VNC.md
@@ -8,6 +8,8 @@ However there is a special case for the container applications: the flag `Enable
 Please note that `EnableVncShimVm` can only be activated if `EnableVnc` is set to true.
 If both flags (`EnableVnc` and `EnableVncShimVm`) are enabled the user will be able to switch between the container and the shim VM session by pressing a key combination.
 
+The other option to enable VNC to the shim VM is to set the `debug.enable.vnc.shim.vm` to true, which acts as a global flag for the whole node, unlike the `EnableVncShimVm`, which is a per-application flag.
+
 ## Guacamole
 
 EVE has a [guacamole](https://guacamole.apache.org/) server running as a service, which allows the user to connect to the ECOs via a web browser.

--- a/pkg/pillar/.golangci.yml
+++ b/pkg/pillar/.golangci.yml
@@ -43,6 +43,9 @@ linters:
     - ireturn           # Returning interfaces is a common practise for constructors in defensive programming
     - exhaustive        # Complains even if struct has default branch
     - musttag           # pillar uses implicit tags for all structs
+    - maintidx          # Disable maintainability index
+    - ifshort
+    - dupl
 
 issues:
   max-issues-per-linter: 0

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -2611,6 +2611,10 @@ func checkAndPublishAppInstanceConfig(getconfigCtx *getconfigContext,
 		config.Errors = append(config.Errors, err.Error())
 	}
 
+	// Be aware there is also a per-device global flag
+	// "debug.enable.vnc.shim.vm", which does not throw any
+	// errors if VNC is disabled, but silently ignores the
+	// flag that is set.
 	if config.FixedResources.EnableVnc == false && config.FixedResources.EnableVncShimVM == true {
 		err := fmt.Errorf("VNC shim VM enabled but VNC disabled for app instance %s", config.UUIDandVersion.UUID)
 		log.Error(err)

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -722,6 +722,19 @@ func (ctx KvmContext) Setup(status types.DomainStatus, config types.DomainConfig
 	return nil
 }
 
+// Coalesce per-app `EnableVncShimVM` flag and global `debug.enable.vnc.shim.vm`
+// debug flag, making sure we don't activate VNC for shim VM if VNC for
+// this application is disabled.
+func isVncShimVMEnabled(
+	globalConfig *types.ConfigItemValueMap, config types.DomainConfig) bool {
+	globalShimVnc := false
+	if globalConfig != nil {
+		item, ok := globalConfig.GlobalSettings[types.VncShimVMAccess]
+		globalShimVnc = ok && item.BoolValue
+	}
+	return config.EnableVnc && (config.EnableVncShimVM || globalShimVnc)
+}
+
 // CreateDomConfig creates a domain config (a qemu config file,
 // typically named something like xen-%d.cfg)
 func (ctx KvmContext) CreateDomConfig(domainName string,
@@ -734,6 +747,8 @@ func (ctx KvmContext) CreateDomConfig(domainName string,
 		types.DomainStatus
 	}{ctx.devicemodel, config, status}
 	tmplCtx.DomainConfig.Memory = (config.Memory + 1023) / 1024
+	tmplCtx.DomainConfig.EnableVncShimVM =
+		isVncShimVMEnabled(globalConfig, config)
 	tmplCtx.DomainConfig.DisplayName = domainName
 
 	// render global device model settings

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -672,7 +672,8 @@ func (ctx KvmContext) Setup(status types.DomainStatus, config types.DomainConfig
 	domainName := status.DomainName
 	domainUUID := status.UUIDandVersion.UUID
 	// first lets build the domain config
-	if err := ctx.CreateDomConfig(domainName, config, status, diskStatusList, aa, file); err != nil {
+	if err := ctx.CreateDomConfig(domainName, config, status, diskStatusList,
+		aa, globalConfig, file); err != nil {
 		return logError("failed to build domain config: %v", err)
 	}
 
@@ -721,9 +722,12 @@ func (ctx KvmContext) Setup(status types.DomainStatus, config types.DomainConfig
 	return nil
 }
 
-// CreateDomConfig creates a domain config (a qemu config file, typically named something like xen-%d.cfg)
-func (ctx KvmContext) CreateDomConfig(domainName string, config types.DomainConfig, status types.DomainStatus,
-	diskStatusList []types.DiskStatus, aa *types.AssignableAdapters, file *os.File) error {
+// CreateDomConfig creates a domain config (a qemu config file,
+// typically named something like xen-%d.cfg)
+func (ctx KvmContext) CreateDomConfig(domainName string,
+	config types.DomainConfig, status types.DomainStatus,
+	diskStatusList []types.DiskStatus, aa *types.AssignableAdapters,
+	globalConfig *types.ConfigItemValueMap, file *os.File) error {
 	tmplCtx := struct {
 		Machine string
 		types.DomainConfig

--- a/pkg/pillar/hypervisor/kvm_test.go
+++ b/pkg/pillar/hypervisor/kvm_test.go
@@ -82,7 +82,8 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
 
 	t.Run("amd64", func(t *testing.T) {
 		conf.Seek(0, 0)
-		if err := kvmIntel.CreateDomConfig("test", config, types.DomainStatus{}, disks, &aa, conf); err != nil {
+		if err := kvmIntel.CreateDomConfig("test", config, types.DomainStatus{},
+			disks, &aa, nil, conf); err != nil {
 			t.Errorf("CreateDomConfig failed %v", err)
 		}
 		defer os.Truncate(conf.Name(), 0)
@@ -347,7 +348,8 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
 	config.VirtualizationMode = types.FML
 	t.Run("amd64-fml", func(t *testing.T) {
 		conf.Seek(0, 0)
-		if err := kvmIntel.CreateDomConfig("test", config, types.DomainStatus{}, disks, &aa, conf); err != nil {
+		if err := kvmIntel.CreateDomConfig("test", config, types.DomainStatus{},
+			disks, &aa, nil, conf); err != nil {
 			t.Errorf("CreateDomConfig failed %v", err)
 		}
 		defer os.Truncate(conf.Name(), 0)
@@ -612,7 +614,8 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
 	config.VirtualizationMode = types.HVM
 	t.Run("arm64", func(t *testing.T) {
 		conf.Seek(0, 0)
-		if err := kvmArm.CreateDomConfig("test", config, types.DomainStatus{}, disks, &aa, conf); err != nil {
+		if err := kvmArm.CreateDomConfig("test", config, types.DomainStatus{},
+			disks, &aa, nil, conf); err != nil {
 			t.Errorf("CreateDomConfig failed %v", err)
 		}
 		defer os.Truncate(conf.Name(), 0)
@@ -864,7 +867,8 @@ func TestCreateDomConfigAmd64(t *testing.T) {
 
 	diskConfigs, diskStatuses := qemuDisks()
 	config, aa := domainConfigAndAssignableAdapters(diskConfigs)
-	if err := kvmIntel.CreateDomConfig("test", config, types.DomainStatus{}, diskStatuses, &aa, conf); err != nil {
+	if err := kvmIntel.CreateDomConfig("test", config, types.DomainStatus{},
+		diskStatuses, &aa, nil, conf); err != nil {
 		t.Errorf("CreateDomConfig failed %v", err)
 	}
 	defer os.Truncate(conf.Name(), 0)
@@ -890,7 +894,8 @@ func TestCreateDomConfigAmd64Legacy(t *testing.T) {
 	diskCondigsLegacy, diskStatusesLegacy := qemuDisksLegacy()
 	config, aa := domainConfigAndAssignableAdapters(diskCondigsLegacy)
 	config.VirtualizationMode = types.LEGACY
-	if err := kvmIntel.CreateDomConfig("test", config, types.DomainStatus{}, diskStatusesLegacy, &aa, conf); err != nil {
+	if err := kvmIntel.CreateDomConfig("test", config, types.DomainStatus{},
+		diskStatusesLegacy, &aa, nil, conf); err != nil {
 		t.Errorf("CreateDomConfig failed %v", err)
 	}
 	defer os.Truncate(conf.Name(), 0)
@@ -916,7 +921,8 @@ func TestCreateDomConfigAmd64Fml(t *testing.T) {
 	config, aa := domainConfigAndAssignableAdapters(diskConfigs)
 	config.VirtualizationMode = types.FML
 	addNonExistingAdapter(&config, &aa)
-	if err := kvmIntel.CreateDomConfig("test", config, types.DomainStatus{}, diskStatuses, &aa, conf); err != nil {
+	if err := kvmIntel.CreateDomConfig("test", config, types.DomainStatus{},
+		diskStatuses, &aa, nil, conf); err != nil {
 		t.Errorf("CreateDomConfig failed %v", err)
 	}
 	aa.IoBundleList = aa.IoBundleList[:len(aa.IoBundleList)-1]
@@ -945,7 +951,8 @@ func TestCreateDomConfigArm64(t *testing.T) {
 	diskConfigs, diskStatuses := qemuDisks()
 	config, aa := domainConfigAndAssignableAdapters(diskConfigs)
 	config.VirtualizationMode = types.HVM
-	if err := kvmArm.CreateDomConfig("test", config, types.DomainStatus{}, diskStatuses, &aa, conf); err != nil {
+	if err := kvmArm.CreateDomConfig("test", config, types.DomainStatus{},
+		diskStatuses, &aa, nil, conf); err != nil {
 		t.Errorf("CreateDomConfig failed %v", err)
 	}
 	defer os.Truncate(conf.Name(), 0)
@@ -2637,7 +2644,8 @@ func TestCreateDomConfigContainerVNC(t *testing.T) {
 	// enable VNC and VNC for shim VM
 	config.VmConfig.EnableVnc = true
 	config.VmConfig.EnableVncShimVM = true
-	if err := kvmIntel.CreateDomConfig("test", config, types.DomainStatus{}, diskStatuses, &aa, conf); err != nil {
+	if err := kvmIntel.CreateDomConfig("test", config, types.DomainStatus{},
+		diskStatuses, &aa, nil, conf); err != nil {
 		t.Errorf("CreateDomConfig failed %v", err)
 	}
 	defer os.Truncate(conf.Name(), 0)

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -121,7 +121,8 @@ func (ctx xenContext) Task(status *types.DomainStatus) types.Task {
 func (ctx xenContext) Setup(status types.DomainStatus, config types.DomainConfig,
 	aa *types.AssignableAdapters, globalConfig *types.ConfigItemValueMap, file *os.File) error {
 	// first lets build the domain config
-	if err := ctx.CreateDomConfig(status.DomainName, config, status.DiskStatusList, aa, file); err != nil {
+	if err := ctx.CreateDomConfig(status.DomainName, config,
+		status.DiskStatusList, aa, globalConfig, file); err != nil {
 		return logError("failed to build domain config: %v", err)
 	}
 
@@ -145,8 +146,10 @@ func (ctx xenContext) Setup(status types.DomainStatus, config types.DomainConfig
 	return nil
 }
 
-func (ctx xenContext) CreateDomConfig(domainName string, config types.DomainConfig, diskStatusList []types.DiskStatus,
-	aa *types.AssignableAdapters, file *os.File) error {
+func (ctx xenContext) CreateDomConfig(domainName string,
+	config types.DomainConfig, diskStatusList []types.DiskStatus,
+	aa *types.AssignableAdapters, globalConfig *types.ConfigItemValueMap,
+	file *os.File) error {
 	xenType := "pvh"
 	rootDev := ""
 	extra := config.ExtraArgs

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -252,6 +252,8 @@ const (
 	SSHAuthorizedKeys GlobalSettingKey = "debug.enable.ssh"
 	// ConsoleAccess global setting key
 	ConsoleAccess GlobalSettingKey = "debug.enable.console"
+	// Shim VM VNC access global setting key
+	VncShimVMAccess GlobalSettingKey = "debug.enable.vnc.shim.vm"
 	// DefaultLogLevel global setting key
 	DefaultLogLevel GlobalSettingKey = "debug.default.loglevel"
 	// DefaultRemoteLogLevel global setting key
@@ -891,6 +893,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddBoolItem(DisableDHCPAllOnesNetMask, false)
 	configItemSpecMap.AddBoolItem(ProcessCloudInitMultiPart, false)
 	configItemSpecMap.AddBoolItem(ConsoleAccess, true) // Controller likely default to false
+	configItemSpecMap.AddBoolItem(VncShimVMAccess, false)
 	configItemSpecMap.AddBoolItem(EnableARPSnoop, true)
 	configItemSpecMap.AddBoolItem(WwanQueryVisibleProviders, false)
 	configItemSpecMap.AddBoolItem(NetworkLocalLegacyMACAddress, false)

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -180,6 +180,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		UsbAccess,
 		VgaAccess,
 		ConsoleAccess,
+		VncShimVMAccess,
 		AllowAppVnc,
 		EveMemoryLimitInBytes,
 		VmmMemoryLimitInMiB,


### PR DESCRIPTION
This PR introduces  `debug.enable.vnc.shim.vm` flag for enabling VNC for a shim VM. Flag works per-device and complements already existing `EnableVncShimVm` per-app flag, which is not implemented on the controller and for now is NOP.

The idea is to enable access to the shim VM over the VNC by setting the `debug.enable.vnc.shim.vm` flag from the cli tool.