### PR TITLE
codeQL complains about invalid toolchain version

### DIFF
--- a/pkg/kube/cert-gen/go.mod
+++ b/pkg/kube/cert-gen/go.mod
@@ -1,3 +1,3 @@
 module cert-gen
 
-go 1.21
+go 1.21.0

--- a/pkg/newlog/go.mod
+++ b/pkg/newlog/go.mod
@@ -1,6 +1,6 @@
 module github.com/lf-edge/eve/pkg/newlog
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/euank/go-kmsg-parser v2.0.0+incompatible

--- a/pkg/pillar/go.mod
+++ b/pkg/pillar/go.mod
@@ -1,6 +1,6 @@
 module github.com/lf-edge/eve/pkg/pillar
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/anatol/smart.go v0.0.0-20220615232124-371056cd18c3

--- a/pkg/wwan/mmagent/go.mod
+++ b/pkg/wwan/mmagent/go.mod
@@ -1,6 +1,6 @@
 module github.com/lf-edge/eve/pkg/wwan/mmagent
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/godbus/dbus/v5 v5.1.0


### PR DESCRIPTION
As of Go 1.21, toolchain versions must use the 1.N.P syntax.