### PR TITLE
Driver support wifi on Kontron devices

### DIFF
--- a/kernel-commits.mk
+++ b/kernel-commits.mk
@@ -1,5 +1,5 @@
 KERNEL_COMMIT_amd64_v5.10.186_generic = 37256d6aff33
-KERNEL_COMMIT_amd64_v6.1.38_generic = 2049bda2c9ed
+KERNEL_COMMIT_amd64_v6.1.38_generic = 5807270eacf2
 KERNEL_COMMIT_amd64_v6.1.38_rt = ef571b34f5ad
 KERNEL_COMMIT_amd64_v6.1.68_generic = 662de9abec4d
 KERNEL_COMMIT_arm64_v5.10.104_nvidia = 02c64aba1d9f

--- a/pkg/fw/Dockerfile
+++ b/pkg/fw/Dockerfile
@@ -37,6 +37,10 @@ RUN ln -s brcmfmac43455-sdio.raspberrypi,3-model-b-plus.txt /lib/firmware/brcm/b
     ln -s brcmfmac43430-sdio.raspberrypi,3-model-b.txt /lib/firmware/brcm/brcmfmac43430-sdio.txt
 # symlinks for Visionfive1 riscv64 boards
 RUN ln -s ../cypress/cyfmac43430-sdio.bin /lib/firmware/brcm/brcmfmac43430-sdio.starfive,visionfive-v1.bin
+# symlinks for kondor wifi device (brcmfmac4356)
+RUN ln -s brcmfmac4356-pcie.gpd-win-pocket.txt '/lib/firmware/brcm/brcmfmac4356-pcie.Kontron America-Agora Gateway 403.txt'
+RUN ln -s brcmfmac4356-pcie.bin '/lib/firmware/brcm/brcmfmac4356-pcie.Kontron America-.bin'
+RUN ln -s brcmfmac4356-pcie.gpd-win-pocket.txt /lib/firmware/brcm/brcmfmac4356-pcie.txt
 
 ENV RPI_FIRMWARE_VERSION 2c8f665254899a52260788dd902083bb57a99738
 ENV RPI_FIRMWARE_URL https://github.com/RPi-Distro/firmware-nonfree/archive

--- a/pkg/fw/Dockerfile
+++ b/pkg/fw/Dockerfile
@@ -37,7 +37,7 @@ RUN ln -s brcmfmac43455-sdio.raspberrypi,3-model-b-plus.txt /lib/firmware/brcm/b
     ln -s brcmfmac43430-sdio.raspberrypi,3-model-b.txt /lib/firmware/brcm/brcmfmac43430-sdio.txt
 # symlinks for Visionfive1 riscv64 boards
 RUN ln -s ../cypress/cyfmac43430-sdio.bin /lib/firmware/brcm/brcmfmac43430-sdio.starfive,visionfive-v1.bin
-# symlinks for kondor wifi device (brcmfmac4356)
+# symlinks for Kontron wifi device (brcmfmac4356)
 RUN ln -s brcmfmac4356-pcie.gpd-win-pocket.txt '/lib/firmware/brcm/brcmfmac4356-pcie.Kontron America-Agora Gateway 403.txt'
 RUN ln -s brcmfmac4356-pcie.bin '/lib/firmware/brcm/brcmfmac4356-pcie.Kontron America-.bin'
 RUN ln -s brcmfmac4356-pcie.gpd-win-pocket.txt /lib/firmware/brcm/brcmfmac4356-pcie.txt


### PR DESCRIPTION
- This change in kconfig concerns the driver support for WIFI on the Kontron devices, which is currently not present. The goal is to enable the Broadcom BCM4356 802.11ac Wireless Network Adapter.
- We tested it on the Kontron 403 edge device.