### PR TITLE
Allow forwarding of all DHCP traffic

### DIFF
--- a/pkg/pillar/dpcreconciler/linux_test.go
+++ b/pkg/pillar/dpcreconciler/linux_test.go
@@ -158,8 +158,8 @@ func TestReconcileWithEmptyArgs(test *testing.T) {
 	t.Expect(itemCountWithType(linux.LocalIPRuleTypename)).To(Equal(1))
 	t.Expect(itemCountWithType(iptables.ChainV4Typename)).To(Equal(12))
 	t.Expect(itemCountWithType(iptables.ChainV6Typename)).To(Equal(12))
-	t.Expect(itemCountWithType(iptables.RuleV4Typename)).To(Equal(32))
-	t.Expect(itemCountWithType(iptables.RuleV6Typename)).To(Equal(31)) // without markDhcp
+	t.Expect(itemCountWithType(iptables.RuleV4Typename)).To(Equal(33))
+	t.Expect(itemCountWithType(iptables.RuleV6Typename)).To(Equal(31)) // without markDhcp & allowDHCPForwarding
 	t.Expect(itemIsCreatedWithLabel("Block SSH")).To(BeTrue())
 
 	// Enable SSH access


### PR DESCRIPTION
Recently we added iptables rule to prevent forwarding of non-app traffic (so that attacker cannot use EVE to hop from one network to another). This rule is based on connection tracking and differentiating between host and app traffic using marks. However, app-initiated DHCP requests can match the same conntrack entry as was created for DHCP requests sent by the DHCP client of EVE.
This is because source/destination IPs are undefined or broadcast:
```
  [72]: udp 17 src=0.0.0.0 dst=255.255.255.255 sport=68 dport=67
        src=255.255.255.255 dst=0.0.0.0 sport=67 dport=68 mark=0xa
```
This means that application DHCP traffic may get mark `in_dhcp` (as opposed to `app_dhcp`) and forwarding will not be allowed. This is particularly problem for switch NI.

Lets create an exception rule, allowing forwarding of DHCP traffic even if it has `in_dhcp` mark, given that the same mark can be accidentally assigned also to an application DHCP request.