### PR TITLE
Manually assign uid/gid to username and groupname in dom0

### DIFF
--- a/pkg/dom0-ztools/Dockerfile
+++ b/pkg/dom0-ztools/Dockerfile
@@ -49,12 +49,12 @@ RUN touch /etc/group && touch /etc/passwd
 RUN addgroup -g 0 root
 RUN adduser -D -H -h /root -s /bin/sh -g "root" -G root -u 0 root
 # add nobody user and group
-RUN addgroup -g 65534 nobody
-RUN adduser -D -H -h /nonexistent -s /bin/false -g "nobody" -u 65534 -G nobody nobody
+RUN addgroup -g 65534 nogroup
+RUN adduser -D -H -h /nonexistent -s /bin/false -g "nobody" -u 65534 -G nogroup nobody
 # add tpms group so /dev/tpm* is accessible to non-root users via tpms group,
 # the group is set for /dev/tpm* in the mdev.conf file
-RUN addgroup -S tpms
+RUN addgroup -g 100 tpms
 # setup user and group for vtpm container and allow TPM access via tpms group
-RUN addgroup -S vtpm
-RUN adduser -S -D -H -h /nonexistent -s /bin/false -g "vtpm" -G vtpm vtpm
+RUN addgroup -g 101 vtpm
+RUN adduser -D -H -h /nonexistent -s /bin/false -g "vtpm" -G vtpm -u 101 vtpm
 RUN addgroup vtpm tpms


### PR DESCRIPTION
Linuxkit dosn't use container's /etc/passwd and /etc/group files to resolve user and group names defined in build.yml. Instead it assignes increamentally created ids to the container[1] based on their delared position in rootfs.yml. It only respects the container's build.yml uid/gid value if its integer[2].

By assigning a fixed uid/gid in dom0, we can use the same value in the build.yml of the containers and be sure that access to resources work as expected, and adding/reordering containers in rootfs.yml won't break the access control.

[1] https://github.com/linuxkit/linuxkit/blob/4f89f4f67e392ffa8c8bab63dfaf31746e3c11a0/src/cmd/linuxkit/moby/build/build.go#L188
[2] https://github.com/linuxkit/linuxkit/blob/4f89f4f67e392ffa8c8bab63dfaf31746e3c11a0/src/cmd/linuxkit/moby/config.go#L708