### PR TITLE
Fix panic in TestVlansAndBonds

### DIFF
--- a/pkg/pillar/dpcreconciler/linux_test.go
+++ b/pkg/pillar/dpcreconciler/linux_test.go
@@ -877,7 +877,6 @@ func TestVlansAndBonds(test *testing.T) {
 	t.Expect(vlan200.ParentLL).To(BeEquivalentTo("bond-shopfloor"))
 	t.Expect(vlan200.ParentIfName).To(BeEquivalentTo("bond0"))
 	t.Expect(vlan200.MTU).To(BeEquivalentTo(3000))
-	release()
 
 	vlan100AdapterRef := dg.Reference(linux.Adapter{IfName: "shopfloor.100"})
 	item, _, _, found = currentState.Item(vlan100AdapterRef)


### PR DESCRIPTION
I have accidentaly added duplicate call to `release()` in `TestVlansAndBonds` as part of my recently merged PR.

This can trigger panic:
```
goroutine 52 [running]:
sync.fatal({0x17540dd?, 0xffffffff?})
	/usr/lib/go/src/runtime/panic.go:1031 +0x1e
sync.(*Mutex).unlockSlow(0xc0004bee00, 0xffffffff)
	/usr/lib/go/src/sync/mutex.go:229 +0x49
sync.(*Mutex).Unlock(0xc0004bee00)
	/usr/lib/go/src/sync/mutex.go:223 +0x55
github.com/lf-edge/eve/pkg/pillar/dpcreconciler.(*LinuxDpcReconciler).pauseWatcher.func1()
	/pillar/dpcreconciler/linux.go:272 +0x73
github.com/lf-edge/eve/pkg/pillar/dpcreconciler_test.TestVlansAndBonds(0xc00009ba00?)
	/pillar/dpcreconciler/linux_test.go:915 +0x2c16
testing.tRunner(0xc00009ba00, 0x17a82b8)
	/usr/lib/go/src/testing/testing.go:1576 +0x217
created by testing.(*T).Run
	/usr/lib/go/src/testing/testing.go:1629 +0x806
```