### PR TITLE
Add disk group for mdev zvol enumeration

### DIFF
--- a/pkg/dom0-ztools/Dockerfile
+++ b/pkg/dom0-ztools/Dockerfile
@@ -58,3 +58,5 @@ RUN addgroup -g 100 tpms
 RUN addgroup -g 101 vtpm
 RUN adduser -D -H -h /nonexistent -s /bin/false -g "vtpm" -G vtpm -u 101 vtpm
 RUN addgroup vtpm tpms
+# setup group for disk access, mdev handling
+RUN addgroup -g 6 disk

--- a/pkg/pillar/build-kubevirt.yml
+++ b/pkg/pillar/build-kubevirt.yml
@@ -2,6 +2,8 @@
 #
 # Copyright (c) 2024 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
+
+---
 org: lfedge
 image: eve-pillar
 config:


### PR DESCRIPTION
Resolve regression from commit 3f78153.  

Touching /dev/mdev.log would show mdev errors like the below:

mdev[2051]: unknown user/group 'root:disk' on line 7