### PR TITLE
bump kernel for BPF lockdown

### DIFF
--- a/kernel-commits.mk
+++ b/kernel-commits.mk
@@ -1,8 +1,8 @@
 KERNEL_COMMIT_amd64_v5.10.186_generic = d61682724485
-KERNEL_COMMIT_amd64_v6.1.38_generic = e0f7423a397f
-KERNEL_COMMIT_amd64_v6.1.38_rt = 6e14ff1f47dd
-KERNEL_COMMIT_amd64_v6.1.68_generic = c825cbffe24f
+KERNEL_COMMIT_amd64_v6.1.38_generic = fb31ce85306c
+KERNEL_COMMIT_amd64_v6.1.38_rt = 08e4fdb34436
+KERNEL_COMMIT_amd64_v6.1.68_generic = 45e0ac394428
 KERNEL_COMMIT_arm64_v5.10.104_nvidia = 2473fcc9c1bb
 KERNEL_COMMIT_arm64_v5.10.186_generic = 804663a82829
-KERNEL_COMMIT_arm64_v6.1.38_generic = 39d6c83d31ea
-KERNEL_COMMIT_riscv64_v6.1.38_generic = a90bcdfa08f8
+KERNEL_COMMIT_arm64_v6.1.38_generic = 369b61c861e7
+KERNEL_COMMIT_riscv64_v6.1.38_generic = 2dbca8568caf


### PR DESCRIPTION
amd64_v6.1.38_generic:
https://github.com/lf-edge/eve-kernel/compare/e0f7423a397f...fb31ce85306c

amd64_v6.1.38_rt:
https://github.com/lf-edge/eve-kernel/compare/6e14ff1f47dd...08e4fdb34436

v6.1.68_generic:
https://github.com/lf-edge/eve-kernel/compare/c825cbffe24f...45e0ac394428

arm64_v6.1.38_generic:
https://github.com/lf-edge/eve-kernel/compare/39d6c83d31ea...369b61c861e7

riscv64_v6.1.38_generic:
https://github.com/lf-edge/eve-kernel/compare/a90bcdfa08f8...2dbca8568caf