### PR TITLE
Metadata server: subscribe to DeviceNetworkStatus and fix AppInstMetaData key

### DIFF
--- a/pkg/pillar/cmd/msrv/pubsub.go
+++ b/pkg/pillar/cmd/msrv/pubsub.go
@@ -43,7 +43,15 @@ func (srv *Msrv) getExternalIPForApp(remoteIP net.IP) (net.IP, int) {
 		// Nothing to report */
 		return nil, http.StatusNoContent
 	}
-	ip, err := types.GetLocalAddrAnyNoLinkLocal(*srv.deviceNetworkStatus,
+
+	dnStatus, err := srv.subDeviceNetworkStatus.Get("global")
+	if err != nil {
+		srv.Log.Error(fmt.Sprintf("cannot fetch device network status: %s", err))
+		return nil, http.StatusInternalServerError
+	}
+
+	dns := dnStatus.(types.DeviceNetworkStatus)
+	ip, err := types.GetLocalAddrAnyNoLinkLocal(dns,
 		0, netstatus.SelectedUplinkIntfName)
 	if err != nil {
 		srv.Log.Errorf("getExternalIPForApp: No externalIP for %s: %s",

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -4,6 +4,7 @@
 package types
 
 import (
+	"fmt"
 	"net"
 	"strings"
 	"time"
@@ -1075,7 +1076,8 @@ type AppInstMetaData struct {
 
 // Key : App Instance Metadata unique key
 func (data AppInstMetaData) Key() string {
-	return data.AppInstUUID.String() + "-" + string(data.Type)
+	// because string(data.Type) would return empty string
+	return fmt.Sprintf("%s-%d", data.AppInstUUID.String(), data.Type)
 }
 
 // At the MinSubnetSize there is room for one app instance (.0 being reserved,


### PR DESCRIPTION
This patch fixes bug introduced by refactoring metadata service. DeviceNetworkStatus Subscription was missed, because it was used in types function.

Also this patch fixes AppInstMetaData key generation, string(enum) returns empty string