### PR TITLE
Use fixed uid/gid for vtpm container

### DIFF
--- a/pkg/vtpm/Dockerfile
+++ b/pkg/vtpm/Dockerfile
@@ -10,7 +10,7 @@
 # d) extracting only required bits from tpm2-tss and tpm2-tools
 #    and the server
 
-FROM lfedge/eve-dom0-ztools:0e2f436441764689b37aeeffeb4bea64c3c5a46e as dom0
+FROM lfedge/eve-dom0-ztools:b8eaeec19d373228a4a842374e5de0d50f050853 as dom0
 FROM lfedge/eve-alpine:1f7685f95a475c6bbe682f0b976f12180b6c8726 as build
 ENV BUILD_PKGS linux-headers git gcc g++ autoconf automake libtool doxygen make \
                openssl-dev protobuf-dev gnupg curl-dev patch json-c json-c-dev \

--- a/pkg/vtpm/build.yml
+++ b/pkg/vtpm/build.yml
@@ -1,8 +1,10 @@
 image: eve-vtpm
 org: lfedge
 config:
-  uid: vtpm
-  gid: vtpm
+  # these ids must match the corresponding container specific user/group
+  # created in pkg/dom0-ztools 
+  uid: 101
+  gid: 101
   binds:
     - /dev:/dev
     - /run:/run


### PR DESCRIPTION
Use the fixed ids create in dom0 to run the VTPM container, this allows to run the container as non-root user and have control over the access control as described in #3989 .
```
linuxkit-525400123456:~# ps aux | grep vtpm
 1540 root      0:00 /usr/bin/containerd-shim-runc-v2 -namespace services.linuxkit -id vtpm -address /run/containerd/containerd.sock
 1561 vtpm      0:00 {init.sh} /bin/sh /usr/bin/init.sh
 1629 vtpm      0:00 /usr/bin/vtpm_server
 3297 root      0:00 grep vtpm
 ```