### PR TITLE
show container name upon entering

### DIFF
--- a/pkg/dom0-ztools/rootfs/bin/eve
+++ b/pkg/dom0-ztools/rootfs/bin/eve
@@ -183,8 +183,9 @@ case "$1" in
           # Start tio
           tio "$PTY"
           ;;
-   enter) # shellcheck disable=SC2086
-          ${CTR_CMD} t exec -t --exec-id $(basename $(mktemp)) ${2:-pillar} ${3:-sh -l}
+   enter) PROMPT="[${2:-pillar}] \u@\h:\w\$ "
+          # shellcheck disable=SC2086
+          ${CTR_CMD} t exec -t --exec-id $(basename $(mktemp)) ${2:-pillar} ${3:-/bin/sh -lc "export PS1='$PROMPT'; exec /bin/sh"}
           ;;
    enter-user-app) [ -z "$2" ] && help
           # shellcheck disable=SC2046,SC2086

--- a/pkg/pillar/rootfs/etc/profile.d/ns.sh
+++ b/pkg/pillar/rootfs/etc/profile.d/ns.sh
@@ -1,1 +1,0 @@
-PS1="(ns: pillar) $PS1"


### PR DESCRIPTION
show container name upon entering : 
```
linuxkit-525400123456:~# eve enter debug
[debug] root@linuxkit-525400123456:/$ eve enter 
[pillar] root@linuxkit-525400123456:/$ 
```
fixes #3922 .