### PR TITLE
pkg/kdump: add makedumpfile to SBoM

### DIFF
--- a/pkg/kdump/Dockerfile
+++ b/pkg/kdump/Dockerfile
@@ -9,7 +9,8 @@ RUN eve-alpine-deploy.sh
 
 # Build makedumpfile
 WORKDIR /tmp/makedumpfile/makedumpfile-1.7.1
-RUN curl -L https://github.com/makedumpfile/makedumpfile/archive/refs/tags/1.7.1.tar.gz | tar -C .. -xzvf -
+ADD https://github.com/makedumpfile/makedumpfile/archive/refs/tags/1.7.1.tar.gz 1.7.1.tar.gz
+RUN tar -C .. -xzvf 1.7.1.tar.gz
 RUN ln -s /usr/lib/libbz2.so.1 /usr/lib/libbz2.so && \
     make LINKTYPE=dynamic && \
     make DESTDIR=/out install

--- a/pkg/kdump/build.yml
+++ b/pkg/kdump/build.yml
@@ -1,6 +1,5 @@
 image: eve-kdump
 org: lfedge
-network: yes
 config:
   binds:
     - /dev:/dev


### PR DESCRIPTION
If we build without network in the build.yml and use ADD in the dockerfile then the source we pull down gets added to the SBoM.

Turned out that pkg/kdump was not using that approach.