### PR TITLE
Fix Pkill confusion with proper pkill usage and zboot retry

### DIFF
--- a/pkg/dom0-ztools/rootfs/bin/eve
+++ b/pkg/dom0-ztools/rootfs/bin/eve
@@ -100,7 +100,7 @@ http_debug_request() {
     fi
 
     if [ "$running" = "0" ]; then
-        pkill -USR2 zedbox
+        kill -USR2 "$(cat /run/zedbox.pid)"
     fi
 
     printf "POST %s HTTP/1.0\r\n\r\n" "$URL" | nc 127.1 6543
@@ -230,7 +230,7 @@ __EOT__
           fi
           ;;
  http-debug) if [ -z "$2" ] || [ "$2" = "start" ]; then
-              pkill -USR2 zedbox
+              kill -USR2 "$(cat /run/zedbox.pid)"
               echo "Listening on :6543 -- use 'eve http-debug stop' to stop"
           elif [ "$2" = "stop" ]; then
               printf "POST /stop HTTP/1.0\r\n\r\n" | nc 127.1 6543
@@ -247,7 +247,7 @@ __EOT__
           echo "Your information can be found in logread"
           ;;
  memory-monitor-update-config)
-          pkill -SIGHUP /sbin/memory-monitor
+          pkill -SIGHUP -o /sbin/memory-monitor
           echo "Updated memory-monitor configuration"
           ;;
  verbose) # first lets find our piping process

--- a/pkg/pillar/zboot/zboot_test.go
+++ b/pkg/pillar/zboot/zboot_test.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2024 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package zboot
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/sirupsen/logrus"
+)
+
+func findExePath(exe string) string {
+	pathEnv := os.Getenv("PATH")
+
+	paths := strings.Split(pathEnv, ":")
+
+	for _, path := range paths {
+		fullPath := filepath.Join(path, exe)
+		_, err := os.Stat(fullPath)
+		if err == nil {
+			return fullPath
+		}
+	}
+
+	return ""
+}
+
+// let's do our own pkill, as handling different versions of it is a pain
+// f.e. procps pkill needs '-f' if the string is longer than 15 characters
+// but busybox pkill doesn't work with '-f'
+func pkill(path string) bool {
+	dirEntries, err := os.ReadDir("/proc")
+	if err != nil {
+		panic(err)
+	}
+
+	for _, dirEntry := range dirEntries {
+		var pid int
+		pidString := filepath.Base(dirEntry.Name())
+		if pid, err = strconv.Atoi(pidString); err != nil {
+			continue
+		}
+		cmdlinePath := filepath.Join("/proc", dirEntry.Name(), "cmdline")
+		cmdline, err := os.ReadFile(cmdlinePath)
+		if err != nil {
+			continue
+		}
+		exe := string(bytes.Split(cmdline, []byte{0})[0])
+		if len(exe) == 0 {
+			continue
+		}
+		if path != exe {
+			continue
+		}
+
+		syscall.Kill(pid, syscall.SIGUSR2)
+		return true
+	}
+
+	return false
+}
+
+func TestExecWithRetry(t *testing.T) {
+	t.Parallel()
+
+	logger := logrus.New()
+	logBuf := &bytes.Buffer{}
+	logger.Out = logBuf
+	log := base.NewSourceLogObject(logger, "zboot_test", -255)
+	data, err := os.ReadFile(findExePath("sleep"))
+	if err != nil {
+		panic(err)
+	}
+	tmpDir, err := os.MkdirTemp("/tmp", "sleep-TestExecWithRetry")
+	defer os.RemoveAll(tmpDir)
+	tmpFile := filepath.Join(tmpDir, "sleep")
+	err = os.WriteFile(tmpFile, data, 0700)
+	if err != nil {
+		panic(err)
+	}
+
+	var pkillOutput []byte
+	go func() {
+		for !pkill(tmpFile) {
+			time.Sleep(1 * time.Second)
+		}
+		// remove the binary, otherwise execWithRetry would retry endlessly
+		os.Remove(tmpFile)
+	}()
+
+	_, err = execWithRetry(log, tmpFile, "60")
+	if err != nil {
+		t.Log(err)
+	}
+
+	logOutput := logBuf.String()
+
+	if !strings.Contains(logOutput, "because of signal user defined signal 2") {
+		t.Fatalf("Killed sleep with USR2 went unnoticed, pkill output is: %s", string(pkillOutput))
+	}
+	t.Log(logBuf.String())
+}


### PR DESCRIPTION
Under certain cases (https://github.com/lf-edge/eve/pull/4005#issuecomment-2196792194 ) `busybox pkill/pgrep` reports a newly forked subprocess (before it had the change to exec) of zedbox. This leads that the subprocess gets killed with USR2 which leads to termination of the process if there is no USR2 handler - and there is none for some of the subprocesses of zedbox.
In order to fix this:
1. only pkill zedbox by using the pidfile of zedbox
2. for zboot: restart the process if it got killed with USR{1,2}