### PR TITLE
zedagent: fix agent name of topics which were moved from zedrouter to msrv

### DIFF
--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -1717,7 +1717,7 @@ func initPostOnboardSubs(zedagentCtx *zedagentContext) {
 	// before Modify handler is called by SubscriptionImpl.populate()
 	// (only needed for persistent subs).
 	zedagentCtx.subAppInstMetaData, err = ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName:     "zedrouter",
+		AgentName:     "msrv",
 		MyAgentName:   agentName,
 		TopicImpl:     types.AppInstMetaData{},
 		Activate:      false,
@@ -1948,7 +1948,7 @@ func initPostOnboardSubs(zedagentCtx *zedagentContext) {
 		log.Fatal(err)
 	}
 	zedagentCtx.subPatchEnvelopeUsage, err = ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName:   "zedrouter",
+		AgentName:   "msrv",
 		MyAgentName: agentName,
 		TopicImpl:   types.PatchEnvelopeUsage{},
 		Activate:    true,
@@ -1958,7 +1958,7 @@ func initPostOnboardSubs(zedagentCtx *zedagentContext) {
 	})
 
 	getconfigCtx.subPatchEnvelopeStatus, err = ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName:     "zedrouter",
+		AgentName:     "msrv",
 		MyAgentName:   agentName,
 		TopicImpl:     types.PatchEnvelopeInfo{},
 		Activate:      true,


### PR DESCRIPTION
`AppInstMetaData`, `PatchEnvelopeUsage` and `PatchEnvelopeInfo` are now published by new service `msrv`.

@uncleDecart Can you please re-test patch envelopes? I guess they are also broken on the master but we do not have eden test to confirm (would be great to add something similar to [metadata test](https://github.com/lf-edge/eden/blob/master/tests/eclient/testdata/metadata.txt)). Also, since the _**persisted**_ topic `AppInstMetaData` moved from one dir to another, we will have to add procedure to [upgrade-converter](https://github.com/lf-edge/eve/tree/master/pkg/pillar/cmd/upgradeconverter) to re-publish any messages from `/persist/status/zedrouter/AppInstMetaData/` to `/persist/status/msrv/AppInstMetaData/`. This is needed to preserve already published app metadata after EVE upgrade. Pavel, could you please take care of it?