### PR TITLE
Allow VTPM container to access TPM devices via tpms group

### DIFF
--- a/pkg/vtpm/build.yml
+++ b/pkg/vtpm/build.yml
@@ -5,6 +5,8 @@ config:
   # created in pkg/dom0-ztools 
   uid: 101
   gid: 101
+  # give container access to the host TPM device via tpms group
+  additionalGids: [100]
   binds:
     - /dev:/dev
     - /run:/run


### PR DESCRIPTION
Allows the VTPM container to access the TPM devices via the tpms group set in the additionalGids in the build.yml file.