### PR TITLE
Memory Monitor: Adjust pressure level, preserve errno, and improve string handling

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,6 +20,7 @@
 /pkg/kexec/                   @rouming
 /pkg/kube/                    @zedi-pramodh
 /pkg/measure-config/          @rucoder
+/pkg/memory-monitor/          @OhmSpectator
 /pkg/mkimage-raw-efi/         @jsfakian @zedi-pramodh
 /pkg/mkverification-raw-efi/  @jsfakian
 /pkg/new-kernel/              @rucoder @rene @rouming @shjala

--- a/pkg/memory-monitor/src/monitor/cgroups.c
+++ b/pkg/memory-monitor/src/monitor/cgroups.c
@@ -205,16 +205,11 @@ int cgroup_get_memory_limit(const char *cgroup_name, unsigned long *limit) {
         }
     }
 
-    // Convert the string to an unsigned long
-    char* endptr;
-    *limit = strtoul(str_limit, &endptr, 10);
-    if (errno == ERANGE && *limit == ULONG_MAX) {
-        syslog(LOG_ERR, "strtoul: %s", strerror(errno));
-        syslog(LOG_INFO, "Limit value is out of range\n");
-        close(fd);
-        return -1;
-    } else if (endptr == &str_limit[0]) {
-        syslog(LOG_ERR, "strtoul: %s", strerror(errno));
+    // Convert the string to the unsigned long
+    bool error;
+    *limit = strtoudec(str_limit, &error);
+    if (error) {
+        syslog(LOG_ERR, "strtoudec: %s", strerror(errno));
         close(fd);
         return -1;
     }

--- a/pkg/memory-monitor/src/monitor/config.c
+++ b/pkg/memory-monitor/src/monitor/config.c
@@ -59,7 +59,13 @@ void config_read(config_t *config) {
                 config->cgroup_pillar_threshold_bytes = DEFAULT_CGROUP_PILLAR_THRESHOLD_MB << 20;
             }
         } else if (strcmp(key, "PROC_ZEDBOX_THRESHOLD_MB") == 0) {
-            threshold = strtoul(value, NULL, 10);
+            threshold = strtoudec(value, &error);
+            if (error) {
+                syslog(LOG_WARNING, "Invalid value for PROC_ZEDBOX_THRESHOLD_MB: %s, using default value", value);
+                config->proc_zedbox_threshold_bytes = DEFAULT_PROC_ZEDBOX_THRESHOLD_MB << 20;
+            } else {
+                config->proc_zedbox_threshold_bytes = threshold << 20;
+            }
             if (convert_mb_to_bytes(threshold, &config->proc_zedbox_threshold_bytes) != 0) {
                 syslog(LOG_WARNING, "Invalid value for PROC_ZEDBOX_THRESHOLD_MB: %s, using default value", value);
                 config->proc_zedbox_threshold_bytes = DEFAULT_PROC_ZEDBOX_THRESHOLD_MB << 20;

--- a/pkg/memory-monitor/src/monitor/main.c
+++ b/pkg/memory-monitor/src/monitor/main.c
@@ -73,9 +73,11 @@ void term_handler(int signo) {
 
 void hup_handler(int signo) {
     (void)signo; // Unused
+    int backup_errno = errno;
     sem_post(&reload_semaphore);
     // Stop the thread
     onreload_cleanup();
+    errno = backup_errno;
 }
 
 int main(int argc, char *argv[]) {

--- a/pkg/memory-monitor/src/monitor/monitor.c
+++ b/pkg/memory-monitor/src/monitor/monitor.c
@@ -248,9 +248,9 @@ static pthread_t run_cgroups_events_monitor(config_t *config, fds_to_close_t *fd
             .cgroup_name = EVE_CGROUP,
             .control_fd = eve_control_fd,
             .type = PRESSURE_EVENT,
-            // Use "medium" pressure level for the eve cgroup, as "low" is triggered too often,
+            // Use "critical" pressure level for the eve cgroup, as "low" and "medium" are triggered too often,
             // for example, when the system reclaim the memory used by the cache
-            .pressure_level = PRESSURE_LEVEL_MEDIUM,
+            .pressure_level = PRESSURE_LEVEL_CRITICAL,
             .event_fd = -1, // will be set by the event_register function
             .trigger_fd = -1, // will be set by the event_register function
     };

--- a/pkg/memory-monitor/src/monitor/util.c
+++ b/pkg/memory-monitor/src/monitor/util.c
@@ -103,7 +103,7 @@ long strtodec(const char *str, bool *error) {
     long val = strtol(str, &endptr, 10);
     if ( (errno == ERANGE && (val == LONG_MAX || val == LONG_MIN  )) || // overflow or underflow
          (errno != 0 && val == 0) || // conversion error
-         (*endptr != '\0') || // trailing characters
+         (*endptr != '\0' && *endptr != '\n') || // trailing characters
          (endptr == str) ) { // no digits were found
         syslog(LOG_ERR, "Invalid value: %s", str);
         *error = true;
@@ -119,7 +119,7 @@ unsigned long strtoudec(const char *str, bool *error) {
     unsigned long val = strtoul(str, &endptr, 10);
     if ( (errno == ERANGE && val == ULONG_MAX) || // overflow
          (errno != 0 && val == 0) || // conversion error
-         (*endptr != '\0') || // trailing characters
+         (*endptr != '\0' && *endptr != '\n') || // trailing characters
          (endptr == str) ) { // no digits were found
         syslog(LOG_ERR, "Invalid value: %s", str);
         *error = true;


### PR DESCRIPTION
This pull request includes several enhancements and fixes for the memory-monitor component to improve error handling, robustness, and maintainability of the code.

The main change adjusts the pressure level for the EVE cgroup from "medium" to "critical". This modification aims to reduce the frequency of triggers during system memory reclamation by focusing on more significant memory pressure situations. Another important update ensures that the errno value is preserved during the execution of the SIGHUP signal handler, maintaining the correctness of error handling by storing and restoring errno in non-terminating signal handlers.

Additionally, direct calls to the `strtoul` function have been replaced with a more robust wrapper, `strtoudec`, in the `cgroups.c` and `config.c` modules, which provides better error handling and improves code robustness. Lastly, the `strtodec` and `strtoudec` functions have been modified to handle input strings ending with a newline character, ensuring that such strings are considered valid, a common case when reading from files or the console.

These changes collectively enhance the memory-monitor component by improving its ability to handle memory pressure situations more effectively and providing more reliable string-to-number conversions.