### PR TITLE
Metadata server: move persist pubsubs from zedrouter to msrv

### DIFF
--- a/pkg/pillar/cmd/upgradeconverter/movepatchenvelopes.go
+++ b/pkg/pillar/cmd/upgradeconverter/movepatchenvelopes.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2024 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package upgradeconverter
+
+import (
+	"path/filepath"
+
+	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
+)
+
+const (
+	srcDir  = "/zedrouter/AppInstMetaData"
+	destDir = "/msrv/AppInstMetaData"
+)
+
+func movePersistPubsub(ctxPtr *ucContext) error {
+	src := filepath.Join(ctxPtr.persistStatusDir, srcDir)
+	dst := filepath.Join(ctxPtr.persistStatusDir, destDir)
+
+	srcExists := fileutils.DirExists(log, src)
+	dstExists := fileutils.DirExists(log, dst)
+
+	if srcExists && !dstExists {
+		return fileutils.CopyDir(src, dst)
+	}
+
+	return nil
+}

--- a/pkg/pillar/cmd/upgradeconverter/upgradeconverter.go
+++ b/pkg/pillar/cmd/upgradeconverter/upgradeconverter.go
@@ -48,6 +48,10 @@ var preVaultconversionHandlers = []ConversionHandler{
 		description: "Move UUIDPairToNum to AppInterfaceToNum",
 		handlerFunc: convertUUIDPairToNum,
 	},
+	{
+		description: "Move /status/zedrouter/AppInstMetaData to /status/msrv/AppInstMetaData",
+		handlerFunc: movePersistPubsub,
+	},
 }
 
 // postVaultconversionHandlers run after vault is setup


### PR DESCRIPTION
In case older version of EVE contained patch envelopes which needs to be saved.

Needs to be tested 