### PR TITLE
Patchset of chrony and NTP related fixes

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlentp.go
+++ b/pkg/pillar/cmd/zedagent/handlentp.go
@@ -261,6 +261,9 @@ func dialUnixWithChronyd(address string) (*chronyConn, error) {
 func getNTPSourcesInfo(ctx *zedagentContext) *info.ZInfoNTPSources {
 	conn, err := dialUnixWithChronyd(unixChronydPath)
 	if err != nil {
+		// Even there was an error, net.DialUnix() leaves trash behind.
+		// What a shame.
+		os.Remove(conn.local)
 		log.Errorf("getNTPSourcesInfo: can't connect to chronyd: %v", err)
 		return nil
 	}


### PR DESCRIPTION
This PR contains three patches, addressing issues related to NTP and chrony.

1. Use waitsync command for initial NTP sync: The first patch also modifies the device-steps.sh script, replacing the chronyd -q command with the waitsync command from the chronyc client for the initial NTP synchronization. This change simplifies the process by avoiding the need to parse the configuration file.

2. Reload NTP sources without restarting daemon: The second patch updates the device-steps.sh script to reload NTP sources directly, instead of restarting the chronyd daemon. This change avoids issues with the watchdog detecting the absence of the chronyd process and firing incorrectly. The patch includes a loop to delete old sources and add new ones, due to the lack of a single command in chronyc to clear all sources. This should help to fix the #4014 

3. Remove Unix socket on error path: The third patch modifies the handlentp.go to ensure that the Unix socket file is deleted if net.DialUnix() encounters an error, preventing "address already in use" errors.




