### PR TITLE
GitHub Actions: Bump Eden version to 0.9.9

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -64,18 +64,18 @@ jobs:
       eve_image: "evebuild/pr:${{ github.event.pull_request.number  }}"
       eve_artifact_name: eve-${{ matrix.hv }}-${{ matrix.arch }}
       artifact_run_id: ${{ needs.get-run-id.outputs.result }}
-      eden_version: "0.9.8"
+      eden_version: "0.9.9"
 
   test_suite_master:
     if: github.ref == 'refs/heads/master'
     uses: lf-edge/eden/.github/workflows/test.yml@0.9.8
     with:
       eve_image: "lfedge/eve:snapshot"
-      eden_version: "0.9.8"
+      eden_version: "0.9.9"
 
   test_suite_tag:
     if: startsWith(github.ref, 'refs/tags')
     uses: lf-edge/eden/.github/workflows/test.yml@0.9.8
     with:
       eve_image: "lfedge/eve:${{ github.ref_name }}"
-      eden_version: "0.9.8"
+      eden_version: "0.9.9"


### PR DESCRIPTION
Release notes can be found here https://github.com/lf-edge/eden/releases/tag/0.9.9