### PR TITLE
Login to dockerhub before building eve

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Login to Docker Hub
+        if: github.event.repository.full_name == 'lf-edge/eve'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
+          password: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
       - name: ensure zstd for cache  # this should be removed once the arm64 VM includes zstd
         if: ${{ matrix.os == 'buildjet-4vcpu-ubuntu-2204-arm' || matrix.os == 'arm64-secure' }}
         run: |
@@ -99,6 +105,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Login to Docker Hub
+        if: github.event.repository.full_name == 'lf-edge/eve'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
+          password: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
       # the next three steps - cache_for_docker, load images, and cache_for_packages -
       # having nothing to do with the content of the final eve image. Instead, it is because we are running
       # on amd64, and we need some of the tools in order to compose the final eve image for the target arch.


### PR DESCRIPTION
When building eve and pulling container dependencies, we may hit the Docker Hub imposed limit of 100 pulls per day (for anonymous pulls). Step to solving this problem is to login into Docker Hub before pulling. That way we will get 200 pulls per day instead of 100 (which are potentially shared with other users of BuildJet runners). We can also consider upgrading our Docker Hub account to the Pro version with 5000 pulls a day.