### PR TITLE
Makefile: add bpftrace for riscv64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -377,7 +377,7 @@ endif
 PKGS_riscv64=pkg/ipxe pkg/mkconf pkg/mkimage-iso-efi pkg/grub     \
              pkg/mkimage-raw-efi pkg/uefi pkg/u-boot pkg/cross-compilers \
 	     pkg/debug pkg/dom0-ztools pkg/gpt-tools pkg/storage-init pkg/mkrootfs-squash \
-	     pkg/bsp-imx pkg/optee-os pkg/recovertpm
+	     pkg/bsp-imx pkg/optee-os pkg/recovertpm pkg/bpftrace
 # alpine-base and alpine must be the first packages to build
 PKGS=pkg/alpine $(PKGS_$(ZARCH))
 # eve-alpine-base is bootstrap image for eve-alpine


### PR DESCRIPTION
debug container is built for riscv64 and depends on bpftrace

This is needed for https://github.com/lf-edge/eve/pull/4018

I hope it will also push the container.