### PR TITLE
used github native docker actions to login to dockerhub

### DIFF
--- a/.github/actions/run-make/action.yml
+++ b/.github/actions/run-make/action.yml
@@ -1,3 +1,4 @@
+---
 name: 'Run EVE make comand'
 description: 'Fetch tags, login to dockerhub, build and push artifacts produced by make command'
 
@@ -20,11 +21,12 @@ runs:
       run: |
         git fetch --force --tags
       shell: bash
-    - name: Login to DockerHUB
-      run: |
-        echo "${{ inputs.dockerhub-token }}" |\
-           docker login -u "${{ inputs.dockerhub-account }}" --password-stdin
-      shell: bash
+    - name: Login to Docker Hub
+      if: ${{ github.event.repository.full_name }}== 'lf-edge/eve'
+      uses: docker/login-action@v3
+      with:
+        username: ${{ inputs.dockerhub-account }}
+        password: ${{ inputs.dockerhub-token }}
     - name: Build and push `make -e ${{ inputs.command }}`
       run: |
         make -e ${{ inputs.command }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Login to Docker Hub
+        if: ${{ github.event.repository.full_name }}== 'lf-edge/eve'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
+          password: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+
       - name: ensure zstd for cache  # this should be removed once the arm64 VM includes zstd
         if: ${{ matrix.os == 'buildjet-4vcpu-ubuntu-2204-arm' || matrix.os == 'arm64-secure' }}
         run: |
@@ -99,6 +107,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Login to Docker Hub
+        if: ${{ github.event.repository.full_name }}== 'lf-edge/eve'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
+          password: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+
       # the next three steps - cache_for_docker, load images, and cache_for_packages -
       # having nothing to do with the content of the final eve image. Instead, it is because we are running
       # on amd64, and we need some of the tools in order to compose the final eve image for the target arch.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,10 +55,14 @@ jobs:
           fi
           echo "ARCH=${{ matrix.arch }}" >> "$GITHUB_ENV"
           echo "TAG=$(echo "$REF" | sed -e 's#^.*/##' -e 's#master#snapshot#' -e 's#main#snapshot#')" >> "$GITHUB_ENV"
-      - name: Login to DockerHUB
-        run: |
-          echo "${{ secrets.RELEASE_DOCKERHUB_TOKEN }}" |\
-             docker login -u "${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}" --password-stdin
+
+      - name: Login to Docker Hub
+        if: ${{ github.event.repository.full_name }}== 'lf-edge/eve'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
+          password: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+
       - name: Build packages
         run: |
           SUCCESS=


### PR DESCRIPTION
In continuation with the [PR](https://github.com/lf-edge/eve/pull/4043) @milan-zededa raised.

Description:

When building eve and pulling container dependencies, we may hit the Docker Hub imposed limit of 100 pulls per day (for anonymous pulls). Step to solving this problem is to login into Docker Hub before pulling. That way we will get 200 pulls per day instead of 100 (which are potentially shared with other users of BuildJet runners). We can also consider upgrading our Docker Hub account to the Pro version with 5000 pulls a day.

Reference: https://docs.docker.com/docker-hub/download-rate-limit/

The actions in `build.yml` are failing due to the following reasons:

GitHub Actions do not expose secrets to workflows triggered by pull requests from forked repositories for security reasons. This is to prevent malicious actors from exploiting the secrets by submitting pull requests that could print the secrets to the log or otherwise expose them. 

Since we cannot login using the secrets in the eve repo, I have created a test WF to check the login and it is working as expected. 

https://github.com/yash-zededa/eve/actions/runs/9766293699/job/26959040309


![image](https://github.com/lf-edge/eve/assets/126680600/c3ec1a57-1d51-47e3-b8df-a91a9a5088d4)


