### PR TITLE
Wait for wwan to apply the latest config before testing connectivity

### DIFF
--- a/pkg/pillar/dpcmanager/dpcmanager.go
+++ b/pkg/pillar/dpcmanager/dpcmanager.go
@@ -371,7 +371,8 @@ func (m *DpcManager) run(ctx context.Context) {
 						switch dpc.State {
 						case types.DPCStateIPDNSWait,
 							types.DPCStatePCIWait,
-							types.DPCStateIntfWait:
+							types.DPCStateIntfWait,
+							types.DPCStateWwanWait:
 							// Note that DPCStatePCIWait and DPCStateIntfWait can be returned
 							// also in scenarios where some ports are in PCIBack while others
 							// are waiting for IP addresses.

--- a/pkg/pillar/dpcmanager/dpcmanager_test.go
+++ b/pkg/pillar/dpcmanager/dpcmanager_test.go
@@ -1086,34 +1086,28 @@ func TestWireless(test *testing.T) {
 	dpcManager.UpdateAA(aa)
 	dpcManager.AddDPC(dpc)
 
-	// Verification will wait for IP addresses.
+	// Verification will wait for wwan config to be applied.
 	t.Eventually(testingInProgressCb()).Should(BeTrue())
 	t.Eventually(dpcIdxCb()).Should(Equal(0))
 	t.Eventually(dpcKeyCb(0)).Should(Equal("zedagent"))
 	t.Eventually(dpcTimePrioCb(0, timePrio1)).Should(BeTrue())
 	t.Eventually(dnsKeyCb()).Should(Equal("zedagent"))
-	t.Expect(getDPC(0).State).To(Equal(types.DPCStateIPDNSWait))
+	t.Expect(getDPC(0).State).To(Equal(types.DPCStateWwanWait))
 
-	// Simulate working wlan connectivity.
-	wlan0 = mockWlan0() // with IP
-	networkMonitor.AddOrUpdateInterface(wlan0)
+	// Simulate working wwan connectivity.
+	rs := types.RadioSilence{}
+	wwan0Status := mockWwan0Status(dpc, rs)
+	dpcManager.ProcessWwanStatus(wwan0Status)
+	wwan0 = mockWwan0() // with IP
+	networkMonitor.AddOrUpdateInterface(wwan0)
 	t.Eventually(testingInProgressCb()).Should(BeFalse())
 	t.Eventually(dpcIdxCb()).Should(Equal(0))
 	t.Expect(getDPC(0).State).To(Equal(types.DPCStateSuccess))
-
-	// Simulate working wwan connectivity.
-	wwan0 = mockWwan0() // with IP
-	networkMonitor.AddOrUpdateInterface(wwan0)
 	t.Eventually(func() bool {
 		ports := getDNS().Ports
 		return len(ports) == 2 && len(ports[1].AddrInfoList) == 1 &&
 			ports[1].AddrInfoList[0].Addr.String() == "15.123.87.20"
 	}).Should(BeTrue())
-
-	// Simulate an event of receiving WwanStatus from the wwan microservice.
-	rs := types.RadioSilence{}
-	wwan0Status := mockWwan0Status(dpc, rs)
-	dpcManager.ProcessWwanStatus(wwan0Status)
 
 	// Check DNS content, it should include wwan state data.
 	t.Eventually(wwanOpModeCb(types.WwanOpModeConnected)).Should(BeTrue())
@@ -1142,6 +1136,15 @@ func TestWireless(test *testing.T) {
 	t.Expect(wwanDNS.Cellular.PhysAddrs.Interface).To(Equal("wwan0"))
 	t.Expect(wwanDNS.Cellular.PhysAddrs.USB).To(Equal("1:3.3"))
 	t.Expect(wwanDNS.Cellular.PhysAddrs.PCI).To(Equal("0000:f4:00.0"))
+
+	// Simulate working wlan connectivity.
+	wlan0 = mockWlan0() // with IP
+	networkMonitor.AddOrUpdateInterface(wlan0)
+	t.Eventually(func() bool {
+		ports := getDNS().Ports
+		return len(ports) == 2 && len(ports[0].AddrInfoList) == 1 &&
+			ports[0].AddrInfoList[0].Addr.String() == "192.168.77.2"
+	}).Should(BeTrue())
 
 	// Impose radio silence.
 	// But actually there is a config error coming from upper layers,

--- a/pkg/pillar/dpcmanager/wwan.go
+++ b/pkg/pillar/dpcmanager/wwan.go
@@ -82,8 +82,12 @@ func (m *DpcManager) processWwanStatus(ctx context.Context, status types.WwanSta
 				m.publishDPCL()
 			}
 		}
-		m.restartVerify(ctx, "wwan status changed")
 		m.updateDNS()
+		if dpc.State == types.DPCStateWwanWait {
+			m.runVerify(ctx, "wwan status is up-to-date")
+		} else {
+			m.restartVerify(ctx, "wwan status changed")
+		}
 	}
 }
 

--- a/pkg/pillar/types/dpc.go
+++ b/pkg/pillar/types/dpc.go
@@ -52,6 +52,9 @@ const (
 	// DPCStateAsyncWait : waiting for some config operations to finalize which are
 	// running asynchronously in the background.
 	DPCStateAsyncWait
+	// DPCStateWwanWait : waiting for the wwan microservice to apply the latest
+	// cellular configuration.
+	DPCStateWwanWait
 )
 
 // String returns the string name
@@ -75,6 +78,8 @@ func (status DPCState) String() string {
 		return "DPC_REMOTE_WAIT"
 	case DPCStateAsyncWait:
 		return "DPC_ASYNC_WAIT"
+	case DPCStateWwanWait:
+		return "DPC_WWAN_WAIT"
 	default:
 		return fmt.Sprintf("Unknown status %d", status)
 	}
@@ -741,9 +746,14 @@ func (ap CellularAccessPoint) Equal(ap2 CellularAccessPoint) bool {
 		ap.APN != ap2.APN {
 		return false
 	}
+	enc1 := ap.EncryptedCredentials
+	enc2 := ap2.EncryptedCredentials
 	if ap.AuthProtocol != ap2.AuthProtocol ||
-		// TODO (how to properly detect changed username/password ?)
-		!reflect.DeepEqual(ap.EncryptedCredentials, ap2.EncryptedCredentials) {
+		enc1.CipherBlockID != enc2.CipherBlockID ||
+		enc1.CipherContextID != enc2.CipherContextID ||
+		!bytes.Equal(enc1.InitialValue, enc2.InitialValue) ||
+		!bytes.Equal(enc1.CipherData, enc2.CipherData) ||
+		!bytes.Equal(enc1.ClearTextHash, enc2.ClearTextHash) {
 		return false
 	}
 	if !generics.EqualLists(ap.PreferredPLMNs, ap2.PreferredPLMNs) ||


### PR DESCRIPTION
When cellular network config changes, it may take few seconds for the wwan microservice and the modem to apply the new config. NIM microservice should wait for the wwan config to be fully applied when cellular connectivity is used for management and ethernet is not available. Otherwise, it may determine the connectivity as not working and failover to the previous config too fast, not giving the modem the chance to connect with the latest config.

Also fixed in this commit is the `Equal()` method for `CellularAccessPoint`. It used to compare also timestamp inside `ErrorAndTime` which may change even if there is no actual config change. As a result, wwan microservice would trigger re-connection even when there was no config change to apply. This fix is in pillar and will be propagated into `pkg/wwan/mmagent` in the next commit (with `go get`) once this one is merged.