### PR TITLE
fix/to use pull_request_target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,9 @@
 ---
 name: PR build
 on:  # yamllint disable-line rule:truthy
-  pull_request:
+  pull_request_target:
+    paths-ignore:
+      - '.github/workflows/**'
     branches:
       - "master"
       - "[0-9]+.[0-9]+"

--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -60,7 +60,8 @@ jobs:
         hv: [kvm]
         platform: ["generic"]
     if: github.event.review.state == 'approved'
-    uses: lf-edge/eden/.github/workflows/test.yml@0.9.8
+    uses: lf-edge/eden/.github/workflows/test.yml@0.9.9
+    secrets: inherit
     with:
       eve_image: "evebuild/pr:${{ github.event.pull_request.number  }}"
       eve_artifact_name: eve-${{ matrix.hv }}-${{ matrix.arch }}-${{ matrix.platform }}
@@ -69,14 +70,16 @@ jobs:
 
   test_suite_master:
     if: github.ref == 'refs/heads/master'
-    uses: lf-edge/eden/.github/workflows/test.yml@0.9.8
+    uses: lf-edge/eden/.github/workflows/test.yml@0.9.9
+    secrets: inherit
     with:
       eve_image: "lfedge/eve:snapshot"
       eden_version: "0.9.9"
 
   test_suite_tag:
     if: startsWith(github.ref, 'refs/tags')
-    uses: lf-edge/eden/.github/workflows/test.yml@0.9.8
+    uses: lf-edge/eden/.github/workflows/test.yml@0.9.9
+    secrets: inherit
     with:
       eve_image: "lfedge/eve:${{ github.ref_name }}"
       eden_version: "0.9.9"


### PR DESCRIPTION
The PR builds are being executed without Docker login, leading to issues with rate limiting. Since `build.yml` cannot access the repository secrets with the `pull_request` event, we need to switch to `pull_request_target`. This will allow forked PRs to access the repository secrets, enabling the PR builds to pull Docker images within the authenticated user rate limit.

However, using `pull_request_target` has its drawbacks. Any changes to the workflow could potentially expose the secrets.. Therefore, to mitigate the risk of exposing secrets, we will not build PRs that include changes to the workflow files.

The above solution is interim. An ideal solution would be to check if there are any changes in the workflow files. If there are, we should request approval from a list of reviewers. Once approved, we can proceed to build the PR.


I will be testing this approach on sample repositories to verify the GitHub Actions workflow. Once it is confirmed to be working, I will raise a PR for the implementation.
