### PR TITLE
Fix dhcpcd and virtual interface handling for native containers

### DIFF
--- a/pkg/pillar/scripts/dhcpcd.sh
+++ b/pkg/pillar/scripts/dhcpcd.sh
@@ -16,11 +16,10 @@ down)
   umount "$VIF_TASK"/bin || :
   umount "$VIF_TASK"/usr/bin || :
   umount "$VIF_TASK"/sbin || :
-  rm -rf "$VIF_TASK"
+  rm -rf "$VIF_TASK"/etc/dhcpcd.conf
   ;;
 up)
   VIF_NS=$(jq '.pid')
-  mkdir -p "$VIF_TASK"
 
   # mount files and directories required to run dhcpcd
 


### PR DESCRIPTION
This PR solves an issue like the log below, observed while deploying native containers and in some Eden tests:

```
ERROR: App BM-1 uuid 98c7224d-07bb-42a0-99fd-8afcd0d0e808 state HALTED error: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "/run/tasks/vifs/98c7224d-07bb-42a0-99fd-8afcd0d0e808.7.1/etc/resolv.conf.new" to rootfs at "/etc/resolv.conf": stat /run/tasks/vifs/98c7224d-07bb-42a0-99fd-8afcd0d0e808.7.1/etc/resolv.conf.new: no such file or directory: unknown
```

Two commits are provided to solve the issue (descriptions below):

## Implement retry mechanism for _veth.sh_

When deploying native containers, during the setup of the virtual network interfaces, the Bridge device might no be ready, leading to errors like the following:

```    
"brctl: bridge bn1: Resource busy - Cannot find device nbu1x1.1"
```
    
This commit provides a workaround by implementing a retry mechanism, so in case of error the script will retry the operation after 5 seconds for at most 3 times before fail.

## Do not remove directory for dhcpcd

The dhcpcd.sh script creates the /run/task/vifs/<APP_UUID>/ directories on an up command (configured as a Prestart hook in the container OCI interface) and removes it entirely on a down command (configured as Poststop). However, the etc/resolv.conf.new file is created by pillar and should be mounted inside the container. If any issue arises while setting up the bridge + virtual network interface during container initialization, pillar will retry to start the container, but at this point the etc/resolv.conf.new will not be available anymore since it was removed by along with the other directories created by the dhcpcd.sh script.
    
This commit solves this issue by simply not removing the entire directory, but only the resolv.conf file that is created during the setup. Pillar already handles the creation and removal of this directory, so no changes are required on his side and the directory will be removed when not needed anymore.

cc: @milan-zededa 