### PR TITLE
pillar/device-steps.sh: fix global NTPSERVER var initialization

### DIFF
--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -91,7 +91,8 @@ get_ntp_servers_from_nim() {
                  .NtpServers | .[]' $INPUTFILE)
 
     # Concat all in one string
-    ntp_all="$ntp_static $ntp_dynamic"
+    # shellcheck disable=SC3037
+    ntp_all=$(echo -e "$ntp_static\n$ntp_dynamic" | sort | uniq)
 
     # Make the following: "$mode $ntp" and separate
     # each with \n for further processing in a caller

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -73,7 +73,7 @@ DEFAULT_NTPMODE=pool
 NTPSERVERS=
 
 # Return one line with all the NTP servers for all the ports
-get_ntp_servers() {
+get_ntp_servers_from_nim() {
     if [ ! -f "$INPUTFILE" ];  then
         return
     fi
@@ -100,6 +100,13 @@ get_ntp_servers() {
         list="$list server\n$ntp\n"
     done
     ntp_all="$list"
+
+    # shellcheck disable=SC3037
+    echo -n "$ntp_all"
+}
+
+get_ntp_servers() {
+    ntp_all=$(get_ntp_servers_from_nim)
 
     # Fallback to default if nothing is configured
     if [ -z "$ntp_all" ]; then


### PR DESCRIPTION
A few commits target the following:
1. On NTP servers restart NTPSERVER variable should be assigned, otherwise chrony will be reloaded with same values.
1. Handle absence of the DeviceNetworkStatus/global.json correctly and return default pool.
1. Make NTP servers sorted and uniq
1. Make error path of the `dialUnixWithChronyd()` cleaner by moving socket cleanup directly into the function.
