### PR TITLE
pillar: device-steps.sh: Load time from RTC at boot

### DIFF
--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -331,6 +331,10 @@ else
 fi
 if [ $RTC = 0 ]; then
     echo "$(date -Ins -u) No real-time clock"
+else
+    # Load time & date from RTC
+    hwclock --hctosys
+    echo "$(date -Ins -u) System time loaded from RTC"
 fi
 # On first boot (of boxes which have been powered off for a while) force
 # ntp setting of clock


### PR DESCRIPTION
Set system time from RTC (when available) at boot so we can get the correct date earlier without need to wait for the chrony daemon initialization, this is specially important for ARM devices that don't have a battery packed RTC, in the first boot the date will be invalid, but it doesn't get lost between restarts (while the RTC is powered).

cc: @rouming 