### PR TITLE
[12.0 stable] Added Broadcom wireless driver for Kontron devices

### DIFF
--- a/kernel-commits.mk
+++ b/kernel-commits.mk
@@ -1,8 +1,8 @@
-KERNEL_COMMIT_amd64_v5.10.186_generic = 37256d6aff33
-KERNEL_COMMIT_amd64_v6.1.38_generic = ddbb9e41fa01
-KERNEL_COMMIT_amd64_v6.1.38_rt = 94c2c02bf1b9
-KERNEL_COMMIT_amd64_v6.1.68_generic = b4d7ad0a73b1
-KERNEL_COMMIT_arm64_v5.10.104_nvidia = 11760a953d2d
-KERNEL_COMMIT_arm64_v5.10.186_generic = 594f2361a83f
-KERNEL_COMMIT_arm64_v6.1.38_generic = 5e51e61211ea
-KERNEL_COMMIT_riscv64_v6.1.38_generic = 72192e3cbc74
+KERNEL_COMMIT_amd64_v5.10.186_generic = d61682724485
+KERNEL_COMMIT_amd64_v6.1.38_generic = e0f7423a397f
+KERNEL_COMMIT_amd64_v6.1.38_rt = 6e14ff1f47dd
+KERNEL_COMMIT_amd64_v6.1.68_generic = c825cbffe24f
+KERNEL_COMMIT_arm64_v5.10.104_nvidia = 2473fcc9c1bb
+KERNEL_COMMIT_arm64_v5.10.186_generic = 804663a82829
+KERNEL_COMMIT_arm64_v6.1.38_generic = 39d6c83d31ea
+KERNEL_COMMIT_riscv64_v6.1.38_generic = a90bcdfa08f8

--- a/pkg/fw/Dockerfile
+++ b/pkg/fw/Dockerfile
@@ -44,6 +44,10 @@ RUN ln -s brcmfmac43455-sdio.raspberrypi,3-model-b-plus.txt /lib/firmware/brcm/b
     ln -s brcmfmac43430-sdio.raspberrypi,3-model-b.txt /lib/firmware/brcm/brcmfmac43430-sdio.txt
 # symlinks for Visionfive1 riscv64 boards
 RUN ln -s ../cypress/cyfmac43430-sdio.bin /lib/firmware/brcm/brcmfmac43430-sdio.starfive,visionfive-v1.bin
+# symlinks for kondor wifi device (brcmfmac4356)
+RUN ln -s brcmfmac4356-pcie.gpd-win-pocket.txt '/lib/firmware/brcm/brcmfmac4356-pcie.Kontron America-Agora Gateway 403.txt'
+RUN ln -s brcmfmac4356-pcie.bin '/lib/firmware/brcm/brcmfmac4356-pcie.Kontron America-.bin'
+RUN ln -s brcmfmac4356-pcie.gpd-win-pocket.txt /lib/firmware/brcm/brcmfmac4356-pcie.txt
 
 ENV RPI_FIRMWARE_VERSION 2c8f665254899a52260788dd902083bb57a99738
 ENV RPI_FIRMWARE_URL https://github.com/RPi-Distro/firmware-nonfree/archive


### PR DESCRIPTION
Kernel update - [amd64-generic, amd64-generic, amd64-rt, amd64-generic, arm64-nvidia, arm64-generic, arm64-generic, riscv64-generic]

eve-kernel-amd64-v5.10.186-generic
    d61682724485: Dockerfile.clang: fix spelling errors

eve-kernel-amd64-v6.1.38-generic
    e0f7423a397f: Update Hailo driver to 4.16 version
    c00fe6ae5149: Add Hailo 8 GPU driver
    5807270eacf2: Added Broadcom wireless driver
    17e008a1095b: Dockerfile.clang: fix spelling errors
    2049bda2c9ed: Enable PLD for Kontron devices
    9bf23b004876: kernel: enable debug info
    085a54afd612: Dockerfile: add pahole dependency
    fcab2e7830ca: stmmac: Do not enable/disable runtime PM for PCI devices

eve-kernel-amd64-v6.1.38-rt
    6e14ff1f47dd: Dockerfile.clang: fix spelling errors
    ef571b34f5ad: kernel: enable debug info
    d0fbf78234ec: Dockerfile: add pahole dependency
    1ead4c5f5ee7: sched/isolation: add 'inverse' parameter for the 'nohz_full' and 'isolcpus'

eve-kernel-amd64-v6.1.68-generic
    c825cbffe24f: Dockerfile.clang: fix spelling errors
    662de9abec4d: kernel: enable debug info
    8522329a4108: Dockerfile: add pahole dependency

eve-kernel-arm64-v5.10.104-nvidia
    2473fcc9c1bb: Dockerfile.clang: fix spelling errors
    02c64aba1d9f: arm64: dts: Add device tree for Siemens IPC520A
    8dba6b8fe169: usb: core: add warm reset workaround for Siemens IPC520A
    69009e88617e: Dockerfile.gcc: Change rtw88 revision

eve-kernel-arm64-v5.10.186-generic
    804663a82829: Dockerfile.clang: fix spelling errors

eve-kernel-arm64-v6.1.38-generic
    39d6c83d31ea: Dockerfile.clang: fix spelling errors
    aa4b24ade858: kernel: enable debug info
    d1859d28c3e2: Dockerfile: add pahole dependency

eve-kernel-riscv64-v6.1.38-generic
    a90bcdfa08f8: Dockerfile.clang: fix spelling errors

Signed-off-by: Mikhail Malyshev <mike.malyshev@gmail.com>
(cherry picked from commit https://github.com/jsfakian/eve/commit/211603510d29188b6f169ce3e9d7d7692517ffdb)

Added firmware for the Kontron wifi device

(cherry picked from commit 211603510d29188b6f169ce3e9d7d7692517ffdb)
(cherry picked from commit 58e98545ec2af6ab3a41670a3e3cb200b03d82ec)