### PR TITLE
pkg/bpftrace: push empty image to dockerhub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -377,7 +377,7 @@ endif
 PKGS_riscv64=pkg/ipxe pkg/mkconf pkg/mkimage-iso-efi pkg/grub     \
              pkg/mkimage-raw-efi pkg/uefi pkg/u-boot pkg/cross-compilers \
 	     pkg/debug pkg/dom0-ztools pkg/gpt-tools pkg/storage-init pkg/mkrootfs-squash \
-	     pkg/bsp-imx pkg/optee-os pkg/recovertpm
+	     pkg/bsp-imx pkg/optee-os pkg/recovertpm pkg/bpftrace
 # alpine-base and alpine must be the first packages to build
 PKGS=pkg/alpine $(PKGS_$(ZARCH))
 # eve-alpine-base is bootstrap image for eve-alpine

--- a/pkg/bpftrace/Dockerfile
+++ b/pkg/bpftrace/Dockerfile
@@ -15,9 +15,9 @@ WORKDIR /usr/src/bpftrace
 RUN for i in patches/*.patch; do git apply "$i"; done
 RUN mkdir build
 WORKDIR /usr/src/bpftrace/build
-RUN cmake ..
+RUN cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang ..
 RUN make -j "$(getconf _NPROCESSORS_ONLN)"
-RUN make DESTDIR="/out/opt/zededa" install
+RUN make install
 # portability analyser is disabled, therefore skip those tests
 # skip file exist test - probably broken because of container
 
@@ -29,12 +29,20 @@ RUN if perl -ne 'exit 1 if (m/^bogomips\s*:\s*(\d+)/i && $1 < 500);' /proc/cpuin
         ./tests/bpftrace_test --gtest_filter=-"portability_analyser.*:utils.file_exists_and_ownedby_root:childproc.ptrace_child*" 2>/dev/null; \
     fi
 
+FROM scratch AS bin
+COPY --from=build /usr/bin/bpftrace /bpftrace/usr/bin/bpftrace
 
-FROM scratch
-COPY --from=build /out/opt/zededa/usr/local/bin/bpftrace-aotrt /usr/bin/bpftrace-aotrt
-COPY --from=build /usr/lib/libbpf.so.0 /usr/lib/libbpf.so.0
-COPY --from=build /usr/lib/libelf.so.1 /usr/lib/libelf.so.1
-COPY --from=build /lib/libz.so.1 /lib/libz.so.1
-COPY --from=build /usr/lib/libbcc_bpf.so.0 /usr/lib/libbcc_bpf.so.0
-COPY --from=build /usr/lib/libstdc++.so.6 /usr/lib/libstdc++.so.6
-COPY --from=build /usr/lib/libgcc_s.so.1 /usr/lib/libgcc_s.so.1
+COPY --from=build /usr/bin/bpftrace-aotrt /bpftrace-aotrt/usr/bin/bpftrace-aotrt
+COPY --from=build /usr/lib/libbpf.so.0 /bpftrace-aotrt/usr/lib/libbpf.so.0
+COPY --from=build /usr/lib/libelf.so.1 /bpftrace-aotrt/usr/lib/libelf.so.1
+COPY --from=build /lib/libz.so.1 /bpftrace-aotrt/lib/libz.so.1
+COPY --from=build /usr/lib/libbcc_bpf.so.0 /bpftrace-aotrt/usr/lib/libbcc_bpf.so.0
+COPY --from=build /usr/lib/libstdc++.so.6 /bpftrace-aotrt/usr/lib/libstdc++.so.6
+COPY --from=build /usr/lib/libgcc_s.so.1 /bpftrace-aotrt/usr/lib/libgcc_s.so.1
+
+FROM bin AS bin-amd64
+FROM bin AS bin-arm64
+FROM scratch AS bin-riscv64
+
+# hadolint ignore=DL3006
+FROM bin-${TARGETARCH} AS bpftrace


### PR DESCRIPTION
this way we can work around the fact that get-deps does not build dependencies architecture specific and therefore tries to build bpftrace for riscv64
with this change an empty image will be pulled and put into the debug container on riscv64

other architectures stay the same as before

This fixes https://github.com/lf-edge/eve/pull/4018