### PR TITLE
[12.0 stable] Update pillar in wwan/mmagent

### DIFF
--- a/pkg/wwan/mmagent/go.mod
+++ b/pkg/wwan/mmagent/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/godbus/dbus/v5 v5.1.0
-	github.com/lf-edge/eve/pkg/pillar v0.0.0-20240417234153-53dbc10640ca
+	github.com/lf-edge/eve/pkg/pillar v0.0.0-20240707181159-e6f9597bf316
 	github.com/miekg/dns v1.1.55
 	github.com/sirupsen/logrus v1.9.3
 	github.com/tatsushid/go-fastping v0.0.0-20160109021039-d7bb493dee3e

--- a/pkg/wwan/mmagent/go.sum
+++ b/pkg/wwan/mmagent/go.sum
@@ -48,8 +48,8 @@ github.com/lf-edge/eve-api/go v0.0.0-20240405192828-57b8263b8048 h1:Z0eG6ILyCUUa
 github.com/lf-edge/eve-api/go v0.0.0-20240405192828-57b8263b8048/go.mod h1:ot6MhAhBXapUDl/hXklaX4kY88T3uC4PTg0D2wD8DzA=
 github.com/lf-edge/eve/pkg/kube/cnirpc v0.0.0-20240315102754-0f6d1f182e0d h1:tUBb9M6u42LXwHAYHyh22wJeUUQlTpDkXwRXalpRqbo=
 github.com/lf-edge/eve/pkg/kube/cnirpc v0.0.0-20240315102754-0f6d1f182e0d/go.mod h1:Nn3juMJJ1G8dyHOebdZyS4jOB/fuxAd5fIajBaWjHr8=
-github.com/lf-edge/eve/pkg/pillar v0.0.0-20240417234153-53dbc10640ca h1:pNlM0qUxLNelkgb5JVIlcXPNy/2EWCVRev7OtkHMUh0=
-github.com/lf-edge/eve/pkg/pillar v0.0.0-20240417234153-53dbc10640ca/go.mod h1:N64mWKjr3OghMhpAI+2RFj4didjqHTrljhiNw/J3Sf4=
+github.com/lf-edge/eve/pkg/pillar v0.0.0-20240707181159-e6f9597bf316 h1:mVXJy1l/rPbyfYolWfkeZ9kr7pmJCkHcrfyzOnWXU94=
+github.com/lf-edge/eve/pkg/pillar v0.0.0-20240707181159-e6f9597bf316/go.mod h1:N64mWKjr3OghMhpAI+2RFj4didjqHTrljhiNw/J3Sf4=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/miekg/dns v1.1.55 h1:GoQ4hpsj0nFLYe+bWiCToyrBEJXkQfOOIvFGFy0lEgo=
 github.com/miekg/dns v1.1.55/go.mod h1:uInx36IzPl7FYnDcMeVWxj9byh7DutNykX4G9Sj60FY=

--- a/pkg/wwan/mmagent/vendor/github.com/lf-edge/eve/pkg/pillar/types/dns.go
+++ b/pkg/wwan/mmagent/vendor/github.com/lf-edge/eve/pkg/pillar/types/dns.go
@@ -29,12 +29,16 @@ type DeviceNetworkStatus struct {
 }
 
 type NetworkPortStatus struct {
-	IfName         string
-	Phylabel       string // Physical name set by controller/model
-	Logicallabel   string
-	Alias          string // From SystemAdapter's alias
-	IsMgmt         bool   // Used to talk to controller
-	IsL3Port       bool   // True if port is applicable to operate on the network layer
+	IfName       string
+	Phylabel     string // Physical name set by controller/model
+	Logicallabel string
+	Alias        string // From SystemAdapter's alias
+	IsMgmt       bool   // Used to talk to controller
+	IsL3Port     bool   // True if port is applicable to operate on the network layer
+	// InvalidConfig is used to flag port config which failed parsing or (static) validation
+	// checks, such as: malformed IP address, undefined required field, IP address not inside
+	// the subnet, etc.
+	InvalidConfig  bool
 	Cost           uint8
 	Dhcp           DhcpType
 	Type           NetworkType // IPv4 or IPv6 or Dual stack
@@ -210,7 +214,9 @@ func (status DeviceNetworkStatus) MostlyEqual(status2 DeviceNetworkStatus) bool 
 			p1.Alias != p2.Alias ||
 			p1.IsMgmt != p2.IsMgmt ||
 			p1.IsL3Port != p2.IsL3Port ||
-			p1.Cost != p2.Cost {
+			p1.InvalidConfig != p2.InvalidConfig ||
+			p1.Cost != p2.Cost ||
+			p1.MTU != p2.MTU {
 			return false
 		}
 		if p1.Dhcp != p2.Dhcp ||

--- a/pkg/wwan/mmagent/vendor/modules.txt
+++ b/pkg/wwan/mmagent/vendor/modules.txt
@@ -59,7 +59,7 @@ github.com/lf-edge/eve-api/go/profile
 # github.com/lf-edge/eve/pkg/kube/cnirpc v0.0.0-20240315102754-0f6d1f182e0d
 ## explicit; go 1.20
 github.com/lf-edge/eve/pkg/kube/cnirpc
-# github.com/lf-edge/eve/pkg/pillar v0.0.0-20240417234153-53dbc10640ca
+# github.com/lf-edge/eve/pkg/pillar v0.0.0-20240707181159-e6f9597bf316
 ## explicit; go 1.21
 github.com/lf-edge/eve/pkg/pillar/agentbase
 github.com/lf-edge/eve/pkg/pillar/agentlog


### PR DESCRIPTION
This brings the fixed `CellularAccessPoint.Equal()` method (fixed in f208c6763fad4609cdbdc5c76ff846b3cec1da4a) to `mmagent`.

This update is for the 12.0 LTS branch.
It is not a cherry-pick but rather running "go get pillar ..." in the mmagent package specifically for 12.0 branch.