### PR TITLE
GitHub Actions: Bump Eden version to 0.9.10

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -60,26 +60,26 @@ jobs:
         hv: [kvm]
         platform: ["generic"]
     if: github.event.review.state == 'approved'
-    uses: lf-edge/eden/.github/workflows/test.yml@0.9.9
+    uses: lf-edge/eden/.github/workflows/test.yml@0.9.10
     secrets: inherit
     with:
       eve_image: "evebuild/pr:${{ github.event.pull_request.number  }}"
       eve_artifact_name: eve-${{ matrix.hv }}-${{ matrix.arch }}-${{ matrix.platform }}
       artifact_run_id: ${{ needs.get-run-id.outputs.result }}
-      eden_version: "0.9.9"
+      eden_version: "0.9.10"
 
   test_suite_master:
     if: github.ref == 'refs/heads/master'
-    uses: lf-edge/eden/.github/workflows/test.yml@0.9.9
+    uses: lf-edge/eden/.github/workflows/test.yml@0.9.10
     secrets: inherit
     with:
       eve_image: "lfedge/eve:snapshot"
-      eden_version: "0.9.9"
+      eden_version: "0.9.10"
 
   test_suite_tag:
     if: startsWith(github.ref, 'refs/tags')
-    uses: lf-edge/eden/.github/workflows/test.yml@0.9.9
+    uses: lf-edge/eden/.github/workflows/test.yml@0.9.10
     secrets: inherit
     with:
       eve_image: "lfedge/eve:${{ github.ref_name }}"
-      eden_version: "0.9.9"
+      eden_version: "0.9.10"


### PR DESCRIPTION
Release notes can be found here:
 https://github.com/lf-edge/eden/releases/tag/0.9.10

There is only one small patch fixing one of the initial steps of smoke tests.