### PR TITLE
Only syscall.Stat() vol paths in metrics path

### DIFF
--- a/pkg/pillar/diskmetrics/usage.go
+++ b/pkg/pillar/diskmetrics/usage.go
@@ -69,20 +69,36 @@ func SizeFromDir(log *base.LogObject, dirname string) (uint64, error) {
 				log.Tracef("Dir %s size %d\n", filename, size)
 				totalUsed += size
 			} else {
-				// FileInfo.Size() returns the provisioned size
-				// Sparse files will have a smaller allocated size than provisioned
-				// Use full syscall.Stat_t to get the allocated size
-				allocatedBytes, err := StatAllocatedBytes(filename)
-				if err != nil {
-					allocatedBytes = uint64(location.Size())
+				// The selection of these two persist directories is intended to pick a balance
+				// between:
+				// 		- calling syscall.Stat() on every file which is heavy on time and compute
+				//		- not calling syscall.Stat() on anything which can overestimate storage allocated
+				//			because the difference between allocated and provisioned storage is
+				//			not accounted for.
+				//
+				// It is believed that the majority of sparsefile usage (by provisioned GB)
+				// will be in the clear and vault volumes base directories so a lot of compute time
+				// can be saved by not checking detailed allocated bytes information in deeper
+				// directories.
+				if dirname == types.VolumeEncryptedDirName || dirname == types.VolumeClearDirName {
+					// FileInfo.Size() returns the provisioned size
+					// Sparse files will have a smaller allocated size than provisioned
+					// Use full syscall.Stat_t to get the allocated size
+					allocatedBytes, err := StatAllocatedBytes(filename)
+					if err != nil {
+						allocatedBytes = uint64(location.Size())
+					}
+					// Fully Allocated: don't use allocated bytes
+					// stat math of %b*%B as it will over-account space
+					if allocatedBytes >= uint64(location.Size()) {
+						allocatedBytes = uint64(location.Size())
+					}
+					log.Tracef("File %s Size %d\n", filename, allocatedBytes)
+					totalUsed += allocatedBytes
+				} else {
+					log.Tracef("File %s Size %d\n", filename, location.Size())
+					totalUsed += uint64(location.Size())
 				}
-				// Fully Allocated: don't use allocated bytes
-				// stat math of %b*%B as it will over-account space
-				if allocatedBytes >= uint64(location.Size()) {
-					allocatedBytes = uint64(location.Size())
-				}
-				log.Tracef("File %s Size %d\n", filename, allocatedBytes)
-				totalUsed += allocatedBytes
 			}
 		}
 	}


### PR DESCRIPTION
Balance between syscall.Stat() everything with
the aim of very accurate allocated storage usage
or syscall.Stat() nothing which will miss the deltas of provisioned vs allocated storage.
Don't syscall.Stat() in the child directories of each volume path.