### PR TITLE
updated checkout options to use the correct repository and ref

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Starting Report
         run: |
-          echo Git Ref: ${{ github.ref }}
+          echo Git Ref: ${{ github.event.pull_request.head.ref  }}
           echo GitHub Event: ${{ github.event_name }}
           echo Disk usage
           df -h
@@ -42,15 +42,15 @@ jobs:
           docker system prune --all --force --volumes
       - uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
-
       - name: Login to Docker Hub
         if: ${{ github.event.repository.full_name }}== 'lf-edge/eve'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
           password: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
-
       - name: ensure zstd for cache  # this should be removed once the arm64 VM includes zstd
         if: ${{ matrix.os == 'buildjet-4vcpu-ubuntu-2204-arm' || matrix.os == 'arm64-secure' }}
         run: |


### PR DESCRIPTION
Since migrating to `pull_request_target`, the GitHub context for the checkout action defaults to the target repository, resulting in always checking out the target master branch. 

To resolve this, I updated the checkout action to use the correct GitHub context for cloning the source repository.