### PR TITLE
Update NTP servers variable if chronyc returns success 

### DIFF
--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -155,8 +155,11 @@ populate_ntp_sources() {
     echo "$args" | xargs /usr/bin/chronyc -m
     ret_code=$?
     echo "$(date -Ins -u) chronyc: $ret_code"
-    # Init global variable
-    NTPSERVERS="$ns"
+    if [ "$ret_code" = "0" ]; then
+        # Init global variable only in case of success.
+        # In case of failure we should repeat shortly.
+        NTPSERVERS="$ns"
+    fi
 }
 
 # Start NTP daemon

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -511,5 +511,5 @@ while true; do
         # Reload NTP sources
         reload_ntp_sources "$ns"
     fi
-    sleep 300
+    sleep 30
 done


### PR DESCRIPTION
This PR does the following:

* update NTP servers in case of success only
    `NTPSERVERS` variable should be updated only if `chronyc` returns
    success. This behavior gurantees, that in case of failure NTP servers
    update will be repeated shortly and we won't stay with blank
    NTP servers list.

* reduce NTP servers update delay from 5min to 30sec
    There is no good reason to delay NTP server update to 5
    minutes, let's make cycles shorter and set 30 seconds.

CC: @rene 
