### PR TITLE
[12.0-stable] pkg/debug: use correct libexecdir

### DIFF
--- a/pkg/debug/Dockerfile
+++ b/pkg/debug/Dockerfile
@@ -76,7 +76,6 @@ RUN git apply fix-utmpx-ipv6.patch
 RUN ./configure \
     --prefix=/usr \
     --sysconfdir=/etc/ssh \
-    --libexecdir=/usr/lib/ssh \
     --mandir=/usr/share/man \
     --with-pid-dir=/run \
     --with-mantype=doc \


### PR DESCRIPTION
this fixes that sshd-session cannot be found and therefore
1. debug container is not started
2. ssh server is not started

Signed-off-by: Christoph Ostarek <christoph@zededa.com>
(cherry picked from commit 8c9f92aa3e7097a5ae9d406b56add7eccb9d1d22)