### PR TITLE
fix: handle empty image spec JSON in PrepareContainerRootDir

### DIFF
--- a/pkg/pillar/cas/containerd.go
+++ b/pkg/pillar/cas/containerd.go
@@ -25,6 +25,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/containerd"
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 	"github.com/moby/sys/mountinfo"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -695,7 +696,7 @@ func (c *containerdCAS) PrepareContainerRootDir(rootPath, reference, _ string) e
 		logrus.Errorf(err.Error())
 		return err
 	}
-	clientImageSpecJSON, err := getJSON(clientImageSpec)
+	clientImageSpecJSON, err := json.MarshalIndent(clientImageSpec, "", "    ")
 	if err != nil {
 		err = fmt.Errorf("PrepareContainerRootDir: Could not build json of image: %v. %v",
 			reference, err.Error())
@@ -708,13 +709,20 @@ func (c *containerdCAS) PrepareContainerRootDir(rootPath, reference, _ string) e
 		logrus.Errorf(err.Error())
 		return err
 	}
-	//nolint:gosec // we want this file to be 0666
-	if err := os.WriteFile(filepath.Join(rootPath, imageConfigFilename), []byte(clientImageSpecJSON), 0666); err != nil {
-		err = fmt.Errorf("PrepareContainerRootDir: Exception while writing image info to %v/%v. %w",
-			rootPath, imageConfigFilename, err)
+	ociConfPath := filepath.Join(rootPath, imageConfigFilename)
+	if err := fileutils.WriteRename(ociConfPath, clientImageSpecJSON); err != nil {
+		err = fmt.Errorf("PrepareContainerRootDir: Exception while writing image info to %s. %w",
+			ociConfPath, err)
 		logrus.Errorf(err.Error())
 		return err
 	}
+	if err := os.Chmod(ociConfPath, 0666); err != nil {
+		err = fmt.Errorf("PrepareContainerRootDir: Exception while setting permissions on %s. %w",
+			ociConfPath, err)
+		logrus.Errorf(err.Error())
+		return err
+	}
+	logrus.Infof("written image config for reference %s. content: %s", reference, string(clientImageSpecJSON))
 	if base.IsHVTypeKube() {
 		err := c.prepareContainerRootDirForKubevirt(clientImageSpec, snapshotID, rootPath)
 		if err != nil {
@@ -1144,15 +1152,6 @@ func getImageConfig(c *containerdCAS, reference string) (*ocispec.Image, error) 
 		return nil, err
 	}
 	return &imageConfig, nil
-}
-
-// getJSON - returns input in JSON format
-func getJSON(x interface{}) (string, error) {
-	b, err := json.MarshalIndent(x, "", "    ")
-	if err != nil {
-		return "", fmt.Errorf("getJSON: Exception while marshalling container spec JSON. %w", err)
-	}
-	return fmt.Sprint(string(b)), nil
 }
 
 // GetRoofFsPath returns rootfs path

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1120,7 +1120,7 @@ func maybeRetryBoot(ctx *domainContext, status *types.DomainStatus) {
 
 	if err := hyper.Task(status).Setup(*status, *config, ctx.assignableAdapters, nil, file); err != nil {
 		//it is retry, so omit error
-		log.Errorf("Failed to create DomainStatus from %v: %s",
+		log.Errorf("Failed to create DomainStatus from %+v: %s",
 			config, err)
 	}
 
@@ -1330,7 +1330,7 @@ func handleCreate(ctx *domainContext, key string, config *types.DomainConfig) {
 		config.DisplayName)
 
 	if err := configToStatus(ctx, *config, &status); err != nil {
-		log.Errorf("Failed to create DomainStatus from %v: %s",
+		log.Errorf("Failed to create DomainStatus from %+v: %s",
 			config, err)
 		status.PendingAdd = false
 		// will retry in maybeRetryConfig
@@ -1609,7 +1609,7 @@ func doActivate(ctx *domainContext, config types.DomainConfig,
 
 	globalConfig := agentlog.GetGlobalConfig(log, ctx.subGlobalConfig)
 	if err := hyper.Task(status).Setup(*status, config, ctx.assignableAdapters, globalConfig, file); err != nil {
-		log.Errorf("Failed to create DomainStatus from %v: %s",
+		log.Errorf("Failed to create DomainStatus from %+v: %s",
 			config, err)
 		status.SetErrorNow(err.Error())
 		releaseCPUs(ctx, &config, status)

--- a/pkg/pillar/containerd/containerd.go
+++ b/pkg/pillar/containerd/containerd.go
@@ -791,8 +791,16 @@ func getSavedImageInfo(containerPath string) (ocispec.Image, error) {
 		logrus.Errorf("getSavedImageInfo: could not read image config file: %v", err)
 		return image, err
 	}
+	if len(data) == 0 {
+		files, err := os.ReadDir(filepath.Join(containerPath, "rootfs"))
+		if err != nil {
+			logrus.Errorf("%s is empty and rootfs directory also not present", imageConfigFilename)
+		} else {
+			logrus.Errorf("%s is empty, but rootfs is present and has %d files", imageConfigFilename, len(files))
+		}
+	}
 	if err := json.Unmarshal(data, &image); err != nil {
-		logrus.Errorf("getSavedImageInfo: could not unmarshal image config: %v", err)
+		logrus.Errorf("getSavedImageInfo: could not unmarshal image config: %v.\nOriginal file content (%d bytes): %s", err, len(data), data)
 		return image, err
 	}
 	return image, nil

--- a/pkg/pillar/utils/file/file.go
+++ b/pkg/pillar/utils/file/file.go
@@ -88,7 +88,7 @@ func backupFile(fileName string) error {
 	return err
 }
 
-// WriteRename write data to a fmpfile and then rename it to a desired name
+// WriteRename write data to a tmpfile and then rename it to a desired name
 func WriteRename(fileName string, b []byte) error {
 	return writeRename(fileName, b, false)
 }


### PR DESCRIPTION
If the clientImageSpecJSON is empty, it indicates an error in building the JSON of the image. This commit adds a check for an empty clientImageSpecJSON and returns an error with the appropriate message. Additionally, it logs the content of the clientImageSpecJSON for debugging purposes.