### PR TITLE
nodeagent: clarifies reboot reason message

### DIFF
--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -562,7 +562,7 @@ func handleLastRebootReason(ctx *nodeagentContext) {
 					dateStr)
 				bootReason = types.BootReasonPowerFail
 			} else {
-				reason = fmt.Sprintf("Reboot reason - kernel crash (no kdump) - at %s",
+				reason = fmt.Sprintf("Reboot reason - system reset, reboot or kernel panic due to watchdog or kernel bug (no kdump) - at %s",
 					dateStr)
 				bootReason = types.BootReasonKernel
 			}


### PR DESCRIPTION
SMART power cycle counter does not expose much and stays same (previous counter and current counter) if system was reset, rebooted or paniced. Previous quite pessimistic reboot message said "kernel crash", which is not always the case and confuses our support and customers. More clear message should be "system reset, reboot or kernel panic due to watchdog or kernel bug (no kdump)".