### PR TITLE
Update alpine mirrors for 3.16 to build swtpm

### DIFF
--- a/pkg/alpine/mirrors/3.16/community
+++ b/pkg/alpine/mirrors/3.16/community
@@ -6,6 +6,8 @@ fmt
 hwinfo
 i2c-tools-dev
 iw
+json-glib
+json-glib-dev
 libbpf-dev
 libgudev-dev
 librados

--- a/pkg/alpine/mirrors/3.16/main
+++ b/pkg/alpine/mirrors/3.16/main
@@ -49,6 +49,7 @@ elfutils
 elfutils-dev
 ethtool
 eudev-dev
+expect
 file
 findutils
 flex
@@ -94,6 +95,7 @@ libbz2
 libcap-ng-dev
 libc-dev
 libcrypto1.1
+libcrypto3
 libc-utils
 libdrm
 libdrm-dev
@@ -199,6 +201,7 @@ ssl_client
 strace
 swig
 tar
+tcl
 tcpdump
 texinfo
 u-boot-tools


### PR DESCRIPTION
Add the extra packages to build swtpm.