### PR TITLE
Makefile: Remove duplicated linuxkit argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -883,7 +883,7 @@ cache-export: image-set outfile-set $(LINUXKIT)
 ## export an image from linuxkit cache and load it into docker.
 cache-export-docker-load: $(LINUXKIT)
 	$(eval TARFILE := $(shell mktemp))
-	$(MAKE) cache-export --format docker OUTFILE=${TARFILE} && cat ${TARFILE} | docker load
+	$(MAKE) cache-export OUTFILE=${TARFILE} && cat ${TARFILE} | docker load
 	rm -rf ${TARFILE}
 
 %-cache-export-docker-load: $(LINUXKIT)


### PR DESCRIPTION
This PR fixes the following error when calling 'make cache-export-docker-load':

```
make IMAGE=docker.io/lfedge/eve-alpine:532dab1b2b14fd49c9e4150246ddc5ccf9e2a3d5 OUTFILE=alpine.tar cache-export-docker-load
Using kernel from KERNEL_TAG=docker.io/lfedge/eve-kernel:eve-kernel-amd64-v6.1.38-generic-fb31ce85306c-gcc 
make cache-export --format docker OUTFILE=/tmp/tmp.4Mu6K7yQ8I && cat /tmp/tmp.4Mu6K7yQ8I | docker load
make: unrecognized option '--format'
```

The target 'cache-export-docker-load' already calls `$(MAKE) cache-export` which has the argument included.