### PR TITLE
fix: use tag to set rootfs version only on tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,8 @@ endif
 
 REPO_BRANCH=$(shell git rev-parse --abbrev-ref HEAD | tr / _)
 REPO_SHA=$(shell git describe --match '$$^' --abbrev=8 --always --dirty)
-REPO_TAG=$(shell git describe --always --tags | grep -E '[0-9]*\.[0-9]*\.[0-9]*' || echo snapshot)
+# set this variable to the current tag only if we are building from a tag (annotated or not), otherwise set it to "snapshot", which means rootfs version will be constructed differently
+REPO_TAG=$(shell git describe --always --tags | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$$' || echo snapshot)
 REPO_DIRTY_TAG=$(if $(findstring -dirty,$(REPO_SHA)),-$(shell date -u +"%Y-%m-%d.%H.%M"))
 EVE_TREE_TAG = $(shell git describe --abbrev=8 --always --dirty --tags)
 
@@ -103,6 +104,7 @@ ifeq ($(DEV),y)
 endif
 
 # ROOTFS_VERSION used to construct the installer directory
+# set this to the current tag only if we are building from a tag
 ROOTFS_VERSION:=$(if $(findstring snapshot,$(REPO_TAG)),$(EVE_SNAPSHOT_VERSION)-$(REPO_BRANCH)-$(REPO_SHA)$(REPO_DIRTY_TAG)$(DEV_TAG),$(REPO_TAG))
 
 HOSTARCH:=$(subst aarch64,arm64,$(subst x86_64,amd64,$(shell uname -m)))


### PR DESCRIPTION
The rootfs version should be set to tag only if building from a clean tagged state. Otherwise we have a different version naming scheme.

This commit fixes the `git describe --tags` command to match the tag exactly, because it default behavior is to "suffixes the tag name with the number of additional commits on top of the tagged object and the abbreviated object name of the most recent commit". So a simple match would always return the tag related rootfs version like 12.6.0-2-g8d558024e.