### PR TITLE
IoBundle.KeepInHost should not forbid assignment

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1397,7 +1397,7 @@ func doAssignIoAdaptersToDomain(ctx *domainContext, config types.DomainConfig,
 				log.Functionf("Assigning %s (%s) to %s",
 					ib.Phylabel, ib.UsbAddr, status.DomainName)
 				assignmentsUsb = addNoDuplicate(assignmentsUsb, ib.UsbAddr)
-			} else if ib.PciLong != "" && !ib.IsPCIBack && !ib.KeepInHost {
+			} else if ib.PciLong != "" && !ib.IsPCIBack {
 				if !(ctx.hvTypeKube && config.VirtualizationMode == types.NOHYPER) || ib.Type != types.IoNetEth {
 					log.Functionf("Assigning %s (%s) to %s",
 						ib.Phylabel, ib.PciLong, status.DomainName)


### PR DESCRIPTION
`KeepInHost` is used to keep unassigned devices visible to the host, i.e., not reserved for future PCI passthrough. However, once a device with `KeepInHost=true` is selected for assignment to an application, the assignment takes precedence over `KeepInHost`. Only `IsPort=true` devices are forbidden from assignment.

After a recent change, everything is kept in the host until assignment, and therefore we may consider removing the `KeepInHost` flag. See commit: aad213f4282d5468e2ea9d33ded3d6aa6d49009d

But here we only fix a bug introduced in the commit referenced above. Specifically, `KeepInHost` was misunderstood and used to forbid (or more precisely skip) device assignment. This makes it impossible, for example, to assign WiFi adapters or cellular modems.