### PR TITLE
proper flag to show-tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1054,7 +1054,7 @@ $(ROOTFS_FULL_NAME)-%-$(ZARCH).$(ROOTFS_FORMAT): $(ROOTFS_IMG)
 	$(QUIET): $@: Succeeded
 
 %-show-tag:
-	@$(LINUXKIT) pkg show-tag -canonical pkg/$*
+	@$(LINUXKIT) pkg show-tag --canonical pkg/$*
 
 %Gopkg.lock: %Gopkg.toml | $(GOBUILDER)
 	@$(DOCKER_GO) "dep ensure -update $(GODEP_NAME)" $(dir $@)

--- a/kernel-version.mk
+++ b/kernel-version.mk
@@ -66,4 +66,3 @@ KERNEL_DOCKER_TAG = $(KERNEL_BRANCH)-$(KERNEL_COMMIT)-$(KERNEL_COMPILER)
 # one can override the whole tag from the command line and set it to
 # output of make -f Makefile.eve docker-tag-${KERNEL_COMPILER} in github.com/lf-edge/eve-kernel
 KERNEL_TAG ?= docker.io/lfedge/eve-kernel:$(KERNEL_DOCKER_TAG)
-$(info Using kernel from KERNEL_TAG=$(KERNEL_TAG))


### PR DESCRIPTION
We were calling `lkt pkg show-tag -canonical` when it should be gnu-style, not plan9-style; `--canonical` is correct