### PR TITLE
get-deps: Do not build get-deps all the time

### DIFF
--- a/tools/get-deps/Makefile
+++ b/tools/get-deps/Makefile
@@ -5,11 +5,11 @@ EXECUTABLE=get-deps
 .PHONY: clean
 
 all: $(EXECUTABLE)
+
+$(EXECUTABLE): $(SOURCES) $(MODULES)
 	go mod tidy
 	go mod vendor
 	CGO_ENABLED=0 go build -o $(EXECUTABLE) $(SOURCES)
-
-$(EXECUTABLE): $(SOURCES) $(MODULES)
 
 clean:
 	rm -f $(EXECUTABLE)


### PR DESCRIPTION
Move build commands to the proper target in Makefile so get-deps won't get build every time make -C tools/get-deps is called.