### PR TITLE
Run Collect-info through Edgeview

### DIFF
--- a/pkg/debug/Dockerfile
+++ b/pkg/debug/Dockerfile
@@ -111,7 +111,7 @@ RUN mkdir -p /out/var/empty
 
 # tweaking various bit
 WORKDIR /out
-COPY ssh.sh spec.sh scripts/ ./usr/bin/
+COPY debug-services.sh ssh-service.sh edgeview-collectinfo.sh spec.sh scripts/ ./usr/bin/
 RUN mkdir -p ./etc/ssh ./root/.ssh
 RUN chmod 0700 ./root/.ssh
 RUN cp /etc/passwd /etc/group ./etc/
@@ -132,4 +132,4 @@ WORKDIR /
 COPY --from=build /out/ /
 COPY --from=build /bpftrace/bpftrace-aotrt /
 
-CMD ["/sbin/tini", "/usr/bin/ssh.sh"]
+CMD ["/sbin/tini", "/usr/bin/debug-services.sh"]

--- a/pkg/debug/debug-services.sh
+++ b/pkg/debug/debug-services.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# Copyright (c) 2024 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Start the monitoring task in the background
+/usr/bin/edgeview-collectinfo.sh &
+
+# Start the sshd service
+/usr/bin/ssh-service.sh

--- a/pkg/debug/edgeview-collectinfo.sh
+++ b/pkg/debug/edgeview-collectinfo.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+#
+# Copyright (c) 2024 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Background monitoring non-ssh related tasks
+monitor_file_and_execute_tasks() {
+    # edgeview request to generate collect-info and remove tar.gz file
+    # the protocol is for edgeview to create a file
+    # /run/edgeview/edgeview-request-collect-info, and debug container
+    # run 'collect-info.sh' to generate the tar.gz file, when the job is
+    # done, remove the file /run/edgeview/edgeview-request-collect-info.
+    # edgeview can also request to remove the tar.gz file by creating
+    # /run/edgeview/edgeview-request-remove-tar.gz file, and debug container
+    # will get the file name and remove the generated tar.gz file.
+    #
+    last_check_time=$(date +%s)
+    while true; do
+        if [ -f "/run/edgeview/edgeview-request-collect-info" ]; then
+            echo "edgeview request to run collect-info..."
+            # the newlog part of the collection, only collect last 10 days,
+            # and add 'edgeview' to tarball name
+            /usr/bin/collect-info.sh -t 10 -e
+            # remove the request file
+            echo "edgeview request collect-info done"
+            rm /run/edgeview/edgeview-request-collect-info
+        fi
+        # edgeview request to remove tar.gz file by sending the suffix string of the
+        # file name to remove, the file to remove is eve-info-edgeview-$suffix
+        if [ -f "/run/edgeview/edgeview-request-remove-tar-gz" ]; then
+            fileSuffixToRemove=$(cat /run/edgeview/edgeview-request-remove-tar-gz)
+            fileToRemove="/persist/eve-info/eve-info-edgeview-$fileSuffixToRemove"
+            echo "edgeview request to remove $fileToRemove file"
+            if [ -f "$fileToRemove" ]; then
+                rm "$fileToRemove"
+            fi
+            # remove the request file
+            rm /run/edgeview/edgeview-request-remove-tar-gz
+        fi
+
+        current_time=$(date +%s)
+        diff=$((current_time - last_check_time))
+        if [ $diff -ge 86400 ]; then # check every 24 hours
+            last_check_time=$current_time
+
+            if find "/persist/eve-info" -type f -name "eve-info-edgeview-v*.tar.gz" | grep -q .; then
+                # Find and delete files matching the pattern and older than 10 days
+                find "/persist/eve-info" -type f -name "eve-info-edgeview-v*.tar.gz" -mtime +1 -print0 | xargs -0 rm -f
+
+                echo "Deleted files older edgeview generated eve-info-edgeivew-v*.tar.gz"
+            fi
+        fi
+
+        sleep 10
+    done
+}
+
+# Start the monitoring and execute tasks
+monitor_file_and_execute_tasks

--- a/pkg/debug/ssh-service.sh
+++ b/pkg/debug/ssh-service.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+#
+# Copyright (c) 2024 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
 
 # setting things up for being able to access linux kernel symbols
 echo 0 >  /proc/sys/kernel/kptr_restrict
@@ -6,7 +10,6 @@ echo -1 > /proc/sys/kernel/perf_event_paranoid
 
 KEYS=$(find /etc/ssh -name 'ssh_host_*_key')
 [ -z "$KEYS" ] && ssh-keygen -A >/dev/null 2>/dev/null
-
 
 if [ -f "/config/remote_access_disabled" ]; then
     # this is picked up by newlogd
@@ -18,4 +21,3 @@ if [ -f "/config/remote_access_disabled" ]; then
 else
     exec /usr/sbin/sshd -D -e
 fi
-

--- a/pkg/edgeview/src/basics.go
+++ b/pkg/edgeview/src/basics.go
@@ -94,6 +94,7 @@ func initOpts() {
 		"watcher",
 		"zedagent",
 		"zedclient",
+		"zedkube",
 		"zedmanager",
 		"zedrouter",
 		"zfsmanager"}
@@ -115,6 +116,7 @@ func initOpts() {
 		"app",
 		"configitem",
 		"cat",
+		"collectinfo",
 		"cp",
 		"datastore",
 		"dmesg",
@@ -686,6 +688,8 @@ func printHelp(opt string) {
 		// system
 		case "configitem":
 			helpOn("configitem", "display the device configitem settings, highlight the non-default values")
+		case "collectinfo":
+			helpOn("collectinfo", "collect the device information using collect-info.sh and download a compressed file in tar.gz format")
 		case "cp":
 			helpOn("cp/<path>", "copy file from the device to locally mounted directory by specify the path")
 			helpExample("cp//config/device.cert.pem", "copy the /config/device.cert.pem file to local directory", true)

--- a/pkg/edgeview/src/copyfile.go
+++ b/pkg/edgeview/src/copyfile.go
@@ -37,6 +37,7 @@ const (
 	copyTarFiles
 	copyTechSupport
 	copyKubeConfig
+	copyCollectInfo
 )
 
 var (

--- a/pkg/edgeview/src/edge-view.go
+++ b/pkg/edgeview/src/edge-view.go
@@ -230,6 +230,9 @@ func main() {
 		} else if strings.HasPrefix(pqueryopt, "tar/") {
 			psysopt = pqueryopt
 			fstatus.cType = copyTarFiles
+		} else if strings.HasPrefix(pqueryopt, "collectinfo") {
+			psysopt = pqueryopt
+			fstatus.cType = copyCollectInfo
 		} else {
 			_, err := checkOpts(pqueryopt, netopts)
 			if err != nil {


### PR DESCRIPTION
there are a number of request to have edgeview support for collectinfo,
this patch has the list of implementation:

- Add the implementation on running collect-info through Edgeview
- Egeview is mostly only with read permission access to device filesystems
   and it does not want to import all the pkgs and replicate the collect-info.sh
   operations and maintain compatibility of two sets of the collect-info
- this implementation has a protocol to setup a request for debug container
  to start run 'collect-info.sh', and remove the request file after it is done;
  Edgeview then uses existing copy file protocol to transfer the collect-info
  tarball file back to user's laptop; then Edgeview put another request for
  debug container to remove the created tarball file in /persist
- debug container has added a background task to monitor the requests
- Since collect-info is mostly live info, there is no need to get all the newlogs,
  only fetch the newlogs of the past 10 days.
- Introduced debug/debug-services.sh around the exiting sshd and the new edgeview-collectinfo.sh
