### PR TITLE
Avoid overwriting the original error from the failed app network creation

### DIFF
--- a/pkg/pillar/cmd/zedrouter/appnetwork.go
+++ b/pkg/pillar/cmd/zedrouter/appnetwork.go
@@ -26,11 +26,16 @@ func (z *zedrouter) retryFailedAppNetworks() {
 		}
 		z.log.Functionf("retryFailedAppNetworks: retry AppNetworkConfigCreate(%s)",
 			status.Key())
-		// We wouldn't have even copied AppNetAdapter networks into status.
-		// This is as good as starting from scratch all over.
-		// App num that would have been allocated will be used this time also,
-		// since the app UUID does not change.
-		z.handleAppNetworkCreate(nil, status.Key(), *config)
+		if !status.Activated {
+			// We wouldn't have even copied AppNetAdapter networks into status.
+			// This is as good as starting from scratch all over.
+			// App num that would have been allocated will be used this time also,
+			// since the app UUID does not change.
+			z.handleAppNetworkCreate(nil, status.Key(), *config)
+		} else {
+			// Retry by running modify without any actual config change.
+			z.handleAppNetworkModify(nil, status.Key(), *config, *config)
+		}
 	}
 }
 


### PR DESCRIPTION
Retrying a failed attempt to connect an application to a network instance mistakenly repeats the call to `doActivateAppNetwork` instead of calling `doUpdateActivatedAppNetwork` (if it failed after/during activation). NIReconciler does not accept duplicate calls to `AddAppConn` and will return an error:
```doActivateAppNetwork: failed to activate application network: NI Reconciler: App <uuid> is already connected.```

Zedrouter should instead call `UpdateAppConn` in the attempt to fix the config.

Worse, this error from the retry attempt overwrites the original error, potentially misleading the user and obscuring the real root cause of the failed app network creation.