### PR TITLE
Add info about volume ref counts and communication with zedmanager to docs

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1863,7 +1863,7 @@ func doCleanup(ctx *domainContext, status *types.DomainStatus) {
 	status.IoAdapterList = nil
 	publishDomainStatus(ctx, status)
 
-	log.Functionf("doClennup(%v) done for %s",
+	log.Functionf("doCleanup(%v) done for %s",
 		status.UUIDandVersion, status.DisplayName)
 }
 

--- a/pkg/pillar/docs/volumemgr.md
+++ b/pkg/pillar/docs/volumemgr.md
@@ -133,9 +133,13 @@ In practice, to date, these have been the directories:
 For a OriginTypeDownload which is not a container, this consist of creating a read/write image in /persist/img through a simple copy.
 For a container this uses containerd to prepare the container for use.
 
+Each volume gets it's own reference count, which shows how many config instances point to (use) it. These configs are either VolumeConfigs or VolumeRefConfigs. The final sum of all configs pointing to the volume is recorded in VolumeStatus and updated each time a new config is added or removed.
+
 ### Destroying volumes
 
 When zedmanager or baseosmgr deletes a VolumeConfig, then volumemgr will destroy the volume (and delete the VolumeStatus). This includes dropping any reference counts it has on a DownloaderConfig, and/or VerifyImageConfig. Finally any Read/Write volume is deleted.
+
+The volume can only be deleted if the reference count is zero. In the case of persistent volumes (explicit volumes), all VolumeRefConfigs can be deleted, but the volume will not be deleted until the VolumeConfig is deleted. However, the container volumes will be unmounted from `/persist/*/volumes` and their contents will only be stored in CAS until another application instance that needs them is created and the volumes are mounted again.
 
 ### Garbage collection
 

--- a/pkg/pillar/docs/zedmanager.md
+++ b/pkg/pillar/docs/zedmanager.md
@@ -41,3 +41,22 @@ The restart means restarting/rebooting the application instance without any chan
 The purge means replacing the first volume (the "boot disk") with a copy recreated from the immutable content. As part of that it is also possible to add and drop virtual disks, network adapters, and/or I/O adapters.
 
 The purge orchestration takes pains to minimize the downtime for the application by creating the new volume or volumes (which might involve downloading and verifying new versions or new content) while the application is running using the old volumes. After that the application instance is halted, and the I/O and network adapters are released. Then the instance is recreated and booted using the new volumes and I/O plus networking adapters.
+
+## Communication
+
+### zedmanager and volumemgr
+
+Zedmanager communicates with the volumemgr by sending VolumeRefConfigs (VRC) and receiving VolumeRefStatuses (VRS). Both objects represent the link between a volume and an application instance and therefore contain parameters such as
+
+- Volume UUID
+- Volume Generation Counter
+- Volume Local Generation Counter
+- App Instance UUID
+
+to represent that connection. There can be only one VolumeRefConfig and VolumeRefStatus per link, so these parameters also form a unique key to represent a VRC or VRS instance. Both VRC and VRS describing the same link will have the same key, so they can be easily matched.
+
+The VRC, which initially comes from DeviceConfig and is part of AppInstanceConfig, also carries the information about the volume mount point for the application instance. This information is immutable.
+Additionally, the VRC will carry a command (`vrc.VerifyOnly`) from zedmanager about how far the volume initialization should go. Initially, volumemgr will be instructed to only download and verify all volumes (`vrc.VerifyOnly == true`). Later in the process of starting the application instance, zedmanager will send a `vrc.VerifyOnly == false` command to volumemgr to actually create the volume.
+Although the set of VRCs in the AppInstanceConfig is immutable, the zedmanager can control the creation and deletion of volumes by publishing (`MaybeAddVolumeRefConfig`) or unpublishing (`MaybeRemoveVolumeRefConfig`) the VRCs to the volumemgr.
+
+The VRS is published by the volumemgr to the zedmanager to inform about the status of the volume creation process. However the zedmanager maintains it's own set of VRSs inside AppInstanceStatus which is created to resemble the corresponding set of VRCs upon their arrival. This set of VRSs is managed by the zedmanager and only occasionally synchronized with the state coming from the volumemgr. The VRSs in the AppInstanceStatus are used to keep track of the volumes even when their VRCs are removed from the AppInstanceConfig during an update or purge operation. They play a big part in determining the current state for zedmanager's state machine and it's logic. And of course the VRSs in the AppInstanceStatus are also used to inform the controller about the current state of the volumes.


### PR DESCRIPTION
Upon @milan-zededa's [request](https://github.com/lf-edge/eve/pull/4060#pullrequestreview-2193451578) adding some interesting finding to the docs of volumemgr and zedmanager.