### PR TITLE
Introducing portprober as successor to uplinkprober

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,6 +51,7 @@
 /pkg/pillar/nistate/          @milan-zededa
 /pkg/pillar/sriov/            @uncleDecart
 /pkg/pillar/uplinkprober/     @milan-zededa
+/pkg/pillar/portprober/       @milan-zededa
 /pkg/pillar/utils/            @milan-zededa
 /pkg/pillar/volumehandlers/   @OhmSpectator
 /pkg/pillar/zedcloud/         @christoph-zededa @rouming

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -729,7 +729,14 @@ func (n *nim) handleDPCFileModify(_ interface{}, key string, configArg, _ interf
 
 func (n *nim) handleDPCImpl(key string, configArg interface{}, fromFile bool) {
 	dpc := configArg.(types.DevicePortConfig)
-	dpc.DoSanitize(n.Log, true, true, key, true, true)
+	dpc.DoSanitize(n.Log, types.DPCSanitizeArgs{
+		SanitizeTimePriority: true,
+		SanitizeKey:          true,
+		KeyToUseIfEmpty:      key,
+		SanitizeName:         true,
+		SanitizeL3Port:       true,
+		SanitizeSharedLabels: true,
+	})
 	if fromFile {
 		// Use sha to determine if file has already been ingested
 		filename := filepath.Join(types.TmpDirname, "DevicePortConfig",
@@ -759,7 +766,14 @@ func (n *nim) handleDPCImpl(key string, configArg interface{}, fromFile bool) {
 
 func (n *nim) handleDPCDelete(_ interface{}, key string, configArg interface{}) {
 	dpc := configArg.(types.DevicePortConfig)
-	dpc.DoSanitize(n.Log, false, true, key, true, true)
+	dpc.DoSanitize(n.Log, types.DPCSanitizeArgs{
+		SanitizeTimePriority: false,
+		SanitizeKey:          true,
+		KeyToUseIfEmpty:      key,
+		SanitizeName:         true,
+		SanitizeL3Port:       true,
+		SanitizeSharedLabels: true,
+	})
 	n.dpcManager.DelDPC(dpc)
 }
 
@@ -908,7 +922,14 @@ func (n *nim) ingestDevicePortConfigFile(oldDirname string, newDirname string, n
 		return
 	}
 	key := strings.TrimSuffix(name, ".json")
-	dpc.DoSanitize(n.Log, true, true, key, true, true)
+	dpc.DoSanitize(n.Log, types.DPCSanitizeArgs{
+		SanitizeTimePriority: true,
+		SanitizeKey:          true,
+		KeyToUseIfEmpty:      key,
+		SanitizeName:         true,
+		SanitizeL3Port:       true,
+		SanitizeSharedLabels: true,
+	})
 
 	// Use sha to determine if file has already been ingested
 	basename := filepath.Base(filename)
@@ -1030,7 +1051,7 @@ func (n *nim) makeLastResortDPC() (types.DevicePortConfig, error) {
 			},
 		}
 		dns := n.dpcManager.GetDNS()
-		portStatus := dns.GetPortByIfName(ifName)
+		portStatus := dns.LookupPortByIfName(ifName)
 		if portStatus != nil {
 			port.WirelessCfg = portStatus.WirelessCfg
 		}
@@ -1089,7 +1110,7 @@ func (n *nim) processInterfaceChange(ifChange netmonitor.IfChange) {
 		return
 	}
 	includePort := n.includeLastResortPort(ifChange.Attrs)
-	port := n.lastResort.GetPortByIfName(ifChange.Attrs.IfName)
+	port := n.lastResort.LookupPortByIfName(ifChange.Attrs.IfName)
 	if port == nil && includePort {
 		n.publishLastResortDPC(fmt.Sprintf("interface %s should be included",
 			ifChange.Attrs.IfName))

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -1681,11 +1681,11 @@ func protoEncodeNetworkInstanceMetricProto(status types.NetworkInstanceMetrics) 
 
 func protoEncodeProbeMetrics(probeMetrics types.ProbeMetrics) *metrics.ZProbeNIMetrics {
 	protoMetrics := &metrics.ZProbeNIMetrics{
-		CurrentIntf:    probeMetrics.SelectedUplinkIntf,
+		CurrentIntf:    probeMetrics.SelectedPortIfName,
 		RemoteEndpoint: strings.Join(probeMetrics.RemoteEndpoints, ", "),
 		PingIntv:       probeMetrics.LocalPingIntvl,
 		RemotePingIntv: probeMetrics.RemotePingIntvl,
-		UplinkCnt:      probeMetrics.UplinkCount,
+		UplinkCnt:      probeMetrics.PortCount,
 	}
 	for _, intfStats := range probeMetrics.IntfProbeStats {
 		var nextHops []string

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -428,7 +428,7 @@ func parseStaticRoute(route *zconfig.IPRoute, config *types.NetworkInstanceConfi
 	if gatewayIP.IsUnspecified() {
 		return errors.New("gateway IP address is all-zeroes")
 	}
-	config.StaticRoutes = append(config.StaticRoutes, types.IPRoute{
+	config.StaticRoutes = append(config.StaticRoutes, types.IPRouteConfig{
 		DstNetwork: dstNetwork,
 		Gateway:    gatewayIP,
 	})

--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -1005,9 +1005,9 @@ func encodeSystemAdapterInfo(ctx *zedagentContext) *info.SystemAdapterInfo {
 			}
 			if i == dpcl.CurrentIndex {
 				// For the currently used DPC we publish the status (DeviceNetworkStatus).
-				portStatus := deviceNetworkStatus.GetPortsByLogicallabel(p.Logicallabel)
-				if len(portStatus) == 1 {
-					dps.Ports[j] = encodeNetworkPortStatus(ctx, portStatus[0], p.NetworkUUID)
+				portStatus := deviceNetworkStatus.LookupPortByLogicallabel(p.Logicallabel)
+				if portStatus != nil {
+					dps.Ports[j] = encodeNetworkPortStatus(ctx, portStatus, p.NetworkUUID)
 					continue
 				}
 			}

--- a/pkg/pillar/conntester/mock.go
+++ b/pkg/pillar/conntester/mock.go
@@ -79,7 +79,7 @@ func (t *MockConnectivityTester) TestConnectivity(dns types.DeviceNetworkStatus,
 			intfStatusMap.RecordFailure(ifName, err.Error())
 			continue
 		}
-		port := dns.GetPortByIfName(ifName)
+		port := dns.LookupPortByIfName(ifName)
 		if !port.IsMgmt {
 			continue
 		}

--- a/pkg/pillar/conntester/zedcloud.go
+++ b/pkg/pillar/conntester/zedcloud.go
@@ -156,13 +156,13 @@ func (t *ZedcloudConnectivityTester) getPortsNotReady(
 		for _, attempt := range sendErr.Attempts {
 			var dnsErr *types.DNSNotAvailError
 			if errors.As(attempt.Err, &dnsErr) {
-				if port := dns.GetPortByIfName(dnsErr.IfName); port != nil {
+				if port := dns.LookupPortByIfName(dnsErr.IfName); port != nil {
 					portMap[port.Logicallabel] = struct{}{}
 				}
 			}
 			var ipErr *types.IPAddrNotAvailError
 			if errors.As(attempt.Err, &ipErr) {
-				if port := dns.GetPortByIfName(ipErr.IfName); port != nil {
+				if port := dns.LookupPortByIfName(ipErr.IfName); port != nil {
 					portMap[port.Logicallabel] = struct{}{}
 				}
 			}

--- a/pkg/pillar/devicenetwork/wpad.go
+++ b/pkg/pillar/devicenetwork/wpad.go
@@ -20,7 +20,7 @@ import (
 func CheckAndGetNetworkProxy(log *base.LogObject, dns *types.DeviceNetworkStatus,
 	ifname string, metrics *zedcloud.AgentMetrics) error {
 
-	portStatus := dns.GetPortByIfName(ifname)
+	portStatus := dns.LookupPortByIfName(ifname)
 	if portStatus == nil {
 		errStr := fmt.Sprintf("Missing port status for interface %s", ifname)
 		log.Errorln(errStr)

--- a/pkg/pillar/dpcmanager/dns.go
+++ b/pkg/pillar/dpcmanager/dns.go
@@ -49,6 +49,7 @@ func (m *DpcManager) updateDNS() {
 		m.deviceNetStatus.Ports[ix].IfName = port.IfName
 		m.deviceNetStatus.Ports[ix].Phylabel = port.Phylabel
 		m.deviceNetStatus.Ports[ix].Logicallabel = port.Logicallabel
+		m.deviceNetStatus.Ports[ix].SharedLabels = port.SharedLabels
 		m.deviceNetStatus.Ports[ix].Alias = port.Alias
 		m.deviceNetStatus.Ports[ix].IsMgmt = port.IsMgmt
 		m.deviceNetStatus.Ports[ix].IsL3Port = port.IsL3Port

--- a/pkg/pillar/dpcmanager/dpc.go
+++ b/pkg/pillar/dpcmanager/dpc.go
@@ -232,7 +232,13 @@ func (m *DpcManager) ingestDPCList() (dpclPresentAtBoot bool) {
 	var dpcl types.DevicePortConfigList
 	for _, portConfig := range storedDpcl.PortConfigList {
 		// Sanitize port labels and IsL3Port flag.
-		portConfig.DoSanitize(m.Log, false, false, "", true, true)
+		portConfig.DoSanitize(m.Log, types.DPCSanitizeArgs{
+			SanitizeTimePriority: false,
+			SanitizeKey:          false,
+			SanitizeName:         true,
+			SanitizeL3Port:       true,
+			SanitizeSharedLabels: true,
+		})
 		// Clear runtime errors (not config validation errors) from before reboot
 		// and start fresh.
 		for i := 0; i < len(portConfig.Ports); i++ {

--- a/pkg/pillar/dpcmanager/dpcmanager_test.go
+++ b/pkg/pillar/dpcmanager/dpcmanager_test.go
@@ -1772,12 +1772,12 @@ func TestTransientDNSError(test *testing.T) {
 	t.Consistently(testingInProgressCb(), 8*time.Second).Should(BeTrue())
 	t.Expect(getDPC(0).State).To(Equal(types.DPCStateIPDNSWait))
 	dpc = getDPC(0)
-	dpcEth0 := dpc.GetPortByIfName("eth0")
+	dpcEth0 := dpc.LookupPortByIfName("eth0")
 	t.Expect(dpcEth0).ToNot(BeNil())
 	t.Expect(dpcEth0.HasError()).To(BeTrue())
 	t.Expect(dpcEth0.LastError).To(Equal("interface eth0: no DNS server available"))
 	dns := getDNS()
-	dnsEth0 := dns.GetPortByIfName("eth0")
+	dnsEth0 := dns.LookupPortByIfName("eth0")
 	t.Expect(dnsEth0).ToNot(BeNil())
 	t.Expect(dnsEth0.HasError()).To(BeTrue())
 	t.Expect(dnsEth0.LastError).To(Equal("interface eth0: no DNS server available"))
@@ -1787,12 +1787,12 @@ func TestTransientDNSError(test *testing.T) {
 	t.Eventually(testingInProgressCb()).Should(BeFalse())
 	t.Expect(getDPC(0).State).To(Equal(types.DPCStateSuccess))
 	dpc = getDPC(0)
-	dpcEth0 = dpc.GetPortByIfName("eth0")
+	dpcEth0 = dpc.LookupPortByIfName("eth0")
 	t.Expect(dpcEth0).ToNot(BeNil())
 	t.Expect(dpcEth0.HasError()).To(BeFalse())
 	t.Expect(dpcEth0.LastError).To(BeEmpty())
 	dns = getDNS()
-	dnsEth0 = dns.GetPortByIfName("eth0")
+	dnsEth0 = dns.LookupPortByIfName("eth0")
 	t.Expect(dnsEth0).ToNot(BeNil())
 	t.Expect(dnsEth0.HasError()).To(BeFalse())
 	t.Expect(dnsEth0.LastError).To(BeEmpty())
@@ -1821,7 +1821,13 @@ func TestOldDPC(test *testing.T) {
 
 	// This is run by nim for any input DPC to make sure that it is compliant
 	// with the latest EVE version.
-	dpc.DoSanitize(logObj, true, false, "", true, true)
+	dpc.DoSanitize(logObj, types.DPCSanitizeArgs{
+		SanitizeTimePriority: true,
+		SanitizeKey:          false,
+		SanitizeName:         true,
+		SanitizeL3Port:       true,
+		SanitizeSharedLabels: true,
+	})
 
 	dpcManager.AddDPC(dpc)
 

--- a/pkg/pillar/dpcmanager/verify.go
+++ b/pkg/pillar/dpcmanager/verify.go
@@ -538,13 +538,13 @@ func (m *DpcManager) isInterfaceCrucial(ifName string) bool {
 		return false
 	}
 	// Is part of DPC at CurrentIndex in DPCL?
-	portStatus := portConfigList[currentIndex].GetPortByIfName(ifName)
-	if portStatus != nil {
+	portConfig := portConfigList[currentIndex].LookupPortByIfName(ifName)
+	if portConfig != nil {
 		return true
 	}
 	// Is part of DPC at index 0 in DPCL?
-	portStatus = portConfigList[0].GetPortByIfName(ifName)
-	if portStatus != nil {
+	portConfig = portConfigList[0].LookupPortByIfName(ifName)
+	if portConfig != nil {
 		return true
 	}
 	return false

--- a/pkg/pillar/portprober/linuxreachprober.go
+++ b/pkg/pillar/portprober/linuxreachprober.go
@@ -1,0 +1,202 @@
+// Copyright (c) 2024 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package portprober
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/lf-edge/eve/pkg/pillar/utils/netutils"
+	"github.com/tatsushid/go-fastping"
+)
+
+// HostnameAddr is an implementation of net.Addr that can be used to store hostname
+// and optionally also port.
+// Other implementations provided by Golang can only store already resolved IP address.
+type HostnameAddr struct {
+	Hostname string
+	Port     uint16
+}
+
+// Network returns the address's network type.
+func (h *HostnameAddr) Network() string {
+	if h.Port == 0 {
+		return "ip"
+	}
+	// We do not provide UDP-based probing method for now.
+	return "tcp"
+}
+
+// String returns the address in the form "hostname:port".
+func (h *HostnameAddr) String() string {
+	if h.Port == 0 {
+		return h.Hostname
+	}
+	return fmt.Sprintf("%s:%d", h.Hostname, h.Port)
+}
+
+// LinuxReachabilityProberICMP is an implementation of ReachabilityProber
+// for the ICMP-based probing method and the Linux TCP/IP network stack.
+type LinuxReachabilityProberICMP struct{}
+
+// Probe reachability of <dstAddr> using ICMP ping sent via the given port.
+func (p *LinuxReachabilityProberICMP) Probe(ctx context.Context, portIfName string,
+	srcIP net.IP, dstAddr net.Addr, dnsServers []net.IP) error {
+	// Do not use DNS servers other than those that belong to the probed
+	// network port.
+	customResolver := &dnsResolver{
+		dnsServers: dnsServers,
+		srcIP:      srcIP,
+		ifName:     portIfName,
+	}
+	resolver := customResolver.getNetResolver()
+	var dstIPs []*net.IPAddr
+	switch addr := dstAddr.(type) {
+	case *net.IPAddr:
+		// Resolver is not needed, dstAddr is already an IP address.
+		dstIPs = append(dstIPs, addr)
+	case *HostnameAddr:
+		// Try to resolve destination hostname.
+		ips, err := resolver.LookupIP(ctx, "ip", addr.Hostname)
+		if err != nil {
+			return fmt.Errorf("failed to resolve %s: %w", dstAddr, err)
+		}
+		if len(ips) == 0 {
+			return fmt.Errorf("resolver returned no IPs for %s", dstAddr)
+		}
+		for _, ip := range ips {
+			dstIPs = append(dstIPs, &net.IPAddr{IP: ip})
+		}
+	default:
+		return fmt.Errorf("unexpected dstAddr type for ICMP probe: %T", dstAddr)
+	}
+	for i, dstIP := range dstIPs {
+		// Determine timeout for the ping based on the context.
+		var pingTimeout time.Duration
+		if deadline, hasDeadline := ctx.Deadline(); hasDeadline {
+			pingTimeout = deadline.Sub(time.Now())
+			if pingTimeout <= 0 {
+				return fmt.Errorf("ping timeout expired")
+			}
+			// Leave some time to try remaining IPs.
+			pingTimeout = pingTimeout / time.Duration(len(dstIPs)-i)
+		}
+		var pingSuccess bool
+		pinger := fastping.NewPinger()
+		pinger.AddIPAddr(dstIP)
+		_, err := pinger.Source(srcIP.String())
+		if err != nil {
+			// Should be unreachable, source IP is valid.
+			return err
+		}
+		if pingTimeout != 0 {
+			pinger.MaxRTT = pingTimeout
+		}
+		pinger.OnRecv = func(ip *net.IPAddr, d time.Duration) {
+			if ip != nil && ip.IP.Equal(dstIP.IP) {
+				pingSuccess = true
+			}
+		}
+		err = pinger.Run()
+		if err != nil {
+			// Check remaining time and try the next IP.
+			continue
+		}
+		if pingSuccess {
+			return nil
+		}
+	}
+	return fmt.Errorf("no ping response received from %v", dstAddr)
+}
+
+// LinuxReachabilityProberTCP is an implementation of ReachabilityProber
+// for the TCP-based probing method and the Linux TCP/IP network stack.
+type LinuxReachabilityProberTCP struct{}
+
+// Probe reachability of <dstAddr> using TCP handshake initiated via the given port.
+func (p *LinuxReachabilityProberTCP) Probe(ctx context.Context, portIfName string,
+	srcIP net.IP, dstAddr net.Addr, dnsServers []net.IP) error {
+	// Do not use DNS servers other than those that belong to the probed
+	// network port.
+	customResolver := &dnsResolver{
+		dnsServers: dnsServers,
+		srcIP:      srcIP,
+		ifName:     portIfName,
+	}
+	resolver := customResolver.getNetResolver()
+	switch dstAddr.(type) {
+	case *net.TCPAddr:
+		// Resolver is not needed, dstAddr is already an IP address.
+		resolver = nil
+	case *HostnameAddr:
+		// Continue...
+	default:
+		return fmt.Errorf("unexpected dstAddr type for TCP probe: %T", dstAddr)
+	}
+	tcpDialer := &net.Dialer{
+		LocalAddr: &net.TCPAddr{IP: srcIP},
+		Resolver:  resolver,
+	}
+	conn, err := tcpDialer.DialContext(ctx, "tcp", dstAddr.String())
+	if err != nil {
+		return fmt.Errorf("TCP connect request to %v failed: %w", dstAddr, err)
+	}
+	// TCP handshake succeeded.
+	_ = conn.Close()
+	return nil
+}
+
+// dnsResolver makes sure that only defined <dnsServers> are tried to resolve
+// the given hostname.
+type dnsResolver struct {
+	srcIP      net.IP
+	dnsServers []net.IP
+	ifName     string
+}
+
+func (r *dnsResolver) getNetResolver() *net.Resolver {
+	return &net.Resolver{Dial: r.resolverDial, PreferGo: true, StrictErrors: false}
+}
+
+func (r *dnsResolver) resolverDial(
+	ctx context.Context, network, address string) (net.Conn, error) {
+	dnsHost, _, err := net.SplitHostPort(address)
+	if err != nil {
+		// No port in the address.
+		dnsHost = address
+	}
+	dnsIP := net.ParseIP(dnsHost)
+	if dnsIP == nil {
+		return nil, fmt.Errorf("failed to parse DNS server IP address '%s'", dnsHost)
+	}
+	if dnsIP.IsLoopback() {
+		// 127.0.0.1:53 is tried by Golang resolver when resolv.conf does not contain
+		// any nameservers (see defaultNS in net/dnsconfig_unix.go).
+		// There is no point in looking for DNS server on the loopback interface on EVE.
+		return nil, &types.DNSNotAvailError{IfName: r.ifName}
+	}
+	var acceptedServer bool
+	for _, dnsServer := range r.dnsServers {
+		if netutils.EqualIPs(dnsServer, dnsIP) {
+			acceptedServer = true
+			break
+		}
+	}
+	if !acceptedServer {
+		return nil, fmt.Errorf("DNS server %s is not valid for port %s", dnsIP, r.ifName)
+	}
+	switch network {
+	case "udp", "udp4", "udp6":
+		d := net.Dialer{LocalAddr: &net.UDPAddr{IP: r.srcIP}}
+		return d.DialContext(ctx, network, address)
+	case "tcp", "tcp4", "tcp6":
+		d := net.Dialer{LocalAddr: &net.TCPAddr{IP: r.srcIP}}
+		return d.DialContext(ctx, network, address)
+	default:
+		return nil, fmt.Errorf("unsupported address type: %v", network)
+	}
+}

--- a/pkg/pillar/portprober/mockprober.go
+++ b/pkg/pillar/portprober/mockprober.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2024 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package portprober
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+)
+
+// MockReachProber is a mock ReachabilityProber used only for unit testing.
+// Can be used as a mock implementation for every probing method.
+type MockReachProber struct {
+	sync.Mutex
+	reachState map[string]reachState
+	lastProbe  map[string]time.Time
+}
+
+// mocked reachability state
+type reachState struct {
+	reachErr error
+	probeRTT time.Duration
+}
+
+// NewMockReachProber is constructor for NewMockReachProber.
+func NewMockReachProber() *MockReachProber {
+	return &MockReachProber{
+		reachState: make(map[string]reachState),
+		lastProbe:  make(map[string]time.Time),
+	}
+}
+
+// SetReachabilityState is used to simulate the state of a remote endpoint reachability
+// for a given output port.
+// Provide non-nil error if the endpoint is not reachable and the time it takes to execute
+// one probe.
+func (p *MockReachProber) SetReachabilityState(portIfName string,
+	dstAddr net.Addr, reachErr error, probeRTT time.Duration) {
+	p.Lock()
+	defer p.Unlock()
+	p.reachState[p.probeKey(portIfName, dstAddr)] = reachState{
+		reachErr: reachErr,
+		probeRTT: probeRTT,
+	}
+}
+
+// Probe return fake probing results prepared using SetReachabilityState.
+func (p *MockReachProber) Probe(ctx context.Context, portIfName string,
+	srcIP net.IP, dstAddr net.Addr, dnsServers []net.IP) error {
+	p.Lock()
+	defer p.Unlock()
+	key := p.probeKey(portIfName, dstAddr)
+	p.lastProbe[key] = time.Now()
+	reachState, hasReachState := p.reachState[key]
+	if !hasReachState {
+		return errors.New("unreachable")
+	}
+	select {
+	case <-time.After(reachState.probeRTT):
+		// continue below the select
+	case <-ctx.Done():
+		return errors.New("timeout")
+	}
+	return reachState.reachErr
+}
+
+// LastProbe returns the timestamp of the last probing executed
+// for the given destination and the output port.
+func (p *MockReachProber) LastProbe(portIfName string, dstAddr net.Addr) time.Time {
+	p.Lock()
+	defer p.Unlock()
+	return p.lastProbe[p.probeKey(portIfName, dstAddr)]
+}
+
+func (p *MockReachProber) probeKey(portIfName string, dstAddr net.Addr) string {
+	return fmt.Sprintf("%s-%s", portIfName, dstAddr.String())
+}

--- a/pkg/pillar/portprober/portprober.go
+++ b/pkg/pillar/portprober/portprober.go
@@ -1,0 +1,956 @@
+// Copyright (c) 2024 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package portprober is used by zedrouter to determine the connectivity status
+// of device ports and to decide which port should be used by a given multipath
+// route configured for a network instance (with a shared port label) at a given moment.
+package portprober
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"net"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/lf-edge/eve/pkg/pillar/utils/generics"
+	uuid "github.com/satori/go.uuid"
+)
+
+// PortProber is used by zedrouter to test the connectivity status of device ports
+// used by network instances with multipath routes.
+// For every multipath route, PortProber picks one of the ports to use at the given
+// time, based on probe results, ports costs, etc. (criteria to consider are configured
+// separately for every route).
+// Whenever the selected port changes, zedrouter is notified by the prober.
+// It is up to the zedrouter to perform update of the route from one port to another
+// inside the network stack.
+type PortProber struct {
+	sync.Mutex
+	log             *base.LogObject
+	config          Config
+	reachProberICMP ReachabilityProber
+	reachProberTCP  ReachabilityProber
+
+	dns         types.DeviceNetworkStatus
+	pendingDNS  *types.DeviceNetworkStatus
+	wwanMetrics types.WwanMetrics
+
+	watcherChs []chan []ProbeStatus
+
+	probeTicker *time.Ticker
+	forcedTick  bool
+
+	routes map[string]*multipathRoute // key: routeKey(ni,dstNet)
+	ports  map[string]*portStatus     // key: port logical label
+
+	probeIteration int
+	pickIteration  int
+}
+
+const (
+	minNHToUserProbeRatio uint8 = 5
+	maxCost               uint8 = 255
+	minRSSI               int32 = math.MinInt32
+)
+
+// Config : configuration for port prober.
+// Currently, this is not configurable via controller.
+type Config struct {
+	// MaxContFailCnt : maximum number of continuous failures that is allowed to happen
+	// before the next hop or user-defined endpoint reachability is declared as DOWN.
+	MaxContFailCnt uint8
+	// MaxContSuccessCnt : maximum number of continuous successes that is allowed to happen
+	// before the next hop or user-defined endpoint reachability is declared as UP.
+	MaxContSuccessCnt uint8
+	// MinContPrevStateCnt : how many continuous confirmations of the previous UP/DOWN state
+	// are needed for a sudden change to be applied immediately. This avoids frequent
+	// port selection changes with a flapping connectivity, but also ensures that
+	// an occasional change is reflected as soon as possible.
+	// Currently only applied for Next Hop probing, not for user-defined endpoint probing.
+	MinContPrevStateCnt uint8
+	// NextHopProbeTimeout : timeout for a single next hop probe.
+	NextHopProbeTimeout time.Duration
+	// UserProbeTimeout : timeout for a single user probe.
+	UserProbeTimeout time.Duration
+	// NHToUserProbeRatio : How many NH probes must be run first before a single user
+	// probe is executed.
+	// Minimum allowed value is 5.
+	NHToUserProbeRatio uint8
+	// NHProbeInterval : how often to execute NH probe.
+	// User probe interval is NHProbeInterval * NHToUserProbeRatio
+	NHProbeInterval time.Duration
+}
+
+// DefaultConfig : default configuration for PortProber.
+// Since these options are currently not configurable via controller,
+// non-default config is used only in unit tests.
+func DefaultConfig() Config {
+	return Config{
+		MaxContFailCnt:      4,
+		MaxContSuccessCnt:   3,
+		MinContPrevStateCnt: 40, // 40 * 15sec = 10 minutes
+		NextHopProbeTimeout: 100 * time.Millisecond,
+		UserProbeTimeout:    3 * time.Second,
+		NHToUserProbeRatio:  10,
+		NHProbeInterval:     15 * time.Second,
+	}
+}
+
+// ReachabilityProber is used by PortProber to test the reachability of device port's
+// next hop(s) (the closest router(s)) or remote networks (Internet, cloud VPC, etc.).
+// PortProber expects one ReachabilityProber for every probing method (ICMP, TCP, ...).
+// There might be a different set of probers implemented for every supported network
+// stack (currently only Linux networking is supported by EVE).
+// A mock implementation is also provided for unit testing purposes.
+type ReachabilityProber interface {
+	// Probe reachability of <dstAddr> via the given port.
+	// If <dstAddr> is IP address and not hostname, <dnsServers> can be nil.
+	Probe(ctx context.Context, portIfName string, srcIP net.IP, dstAddr net.Addr,
+		dnsServers []net.IP) error
+}
+
+// ProbeStatus is published whenever the selected port for a given multipath route
+// changes.
+type ProbeStatus struct {
+	NetworkInstance uuid.UUID
+	MPRoute         types.IPRouteConfig
+	SelectedPortLL  string
+	SelectedAt      time.Time
+}
+
+// multipathRoute is used only internally to store configs of multipath routes and
+// labels of their currently selected output ports.
+type multipathRoute struct {
+	ProbeStatus
+	NIPortLabel string
+}
+
+// portStatus - used only internally to track the probing state of every probed port.
+type portStatus struct {
+	logicallabel string
+	sharedlabels []string
+	ifName       string
+	cost         uint8
+	isWwan       bool
+	localAddrs   []net.IP
+	nextHops     []net.IP
+	dnsServers   []net.IP
+	newlyAdded   bool
+	nhProbe      probeStatus
+	userProbes   map[types.ConnectivityProbe]*probeStatus
+}
+
+func (ps portStatus) matchesLabels(labels ...string) bool {
+	for _, label := range labels {
+		if ps.logicallabel != label && !generics.ContainsItem(ps.sharedlabels, label) {
+			return false
+		}
+	}
+	return true
+}
+
+func (ps portStatus) upCount(probeCfg types.NIPortProbe) int {
+	var upCount int
+	if probeCfg.EnabledGwPing && ps.cost <= probeCfg.GwPingMaxCost {
+		if ps.nhProbe.connIsUP {
+			upCount++
+		}
+	}
+	userProbe := ps.userProbes[probeCfg.UserDefinedProbe]
+	if userProbe != nil {
+		if userProbe.connIsUP {
+			upCount++
+		}
+	}
+	return upCount
+}
+
+type probeStatus struct {
+	refCount   int
+	connIsUP   bool
+	failedCnt  uint32 // continuous fail count, reset on success
+	successCnt uint32 // continuous success count, reset on fail
+	avgLatency time.Duration
+}
+
+// NewPortProber is a constructor for PortProber.
+func NewPortProber(log *base.LogObject, config Config,
+	reachProberICMP, reachProberTCP ReachabilityProber) *PortProber {
+	if config.NHToUserProbeRatio < minNHToUserProbeRatio {
+		config.NHToUserProbeRatio = minNHToUserProbeRatio
+	}
+	prober := &PortProber{
+		log:             log,
+		config:          config,
+		reachProberICMP: reachProberICMP,
+		reachProberTCP:  reachProberTCP,
+		routes:          make(map[string]*multipathRoute),
+		ports:           make(map[string]*portStatus),
+	}
+	prober.probeTicker = time.NewTicker(config.NHProbeInterval)
+	go prober.runProbing()
+	return prober
+}
+
+// StartPortProbing tells PortProber to start periodic probing of network ports
+// for this multipath route.
+// It is called by zedrouter whenever a new multipath route is configured for an existing
+// or a new network instance.
+// If probing config options change for an existing route, zedrouter first stops an ongoing
+// probing activity, then starts a new one.
+func (p *PortProber) StartPortProbing(ni uuid.UUID, niPortLabel string,
+	mpRoute types.IPRouteConfig) (
+	initialStatus ProbeStatus, err error) {
+	p.Lock()
+	defer p.Unlock()
+	key := p.routeKey(ni, mpRoute.DstNetwork)
+	p.routes[key] = &multipathRoute{
+		ProbeStatus: ProbeStatus{
+			NetworkInstance: ni,
+			MPRoute:         mpRoute},
+		NIPortLabel: niPortLabel,
+	}
+	probeCfg := mpRoute.PortProbe
+	for _, port := range p.getPortsMatchingLabels(niPortLabel, mpRoute.OutputPortLabel) {
+		if probeCfg.EnabledGwPing && port.cost <= probeCfg.GwPingMaxCost {
+			port.nhProbe.refCount++
+		}
+		if probeCfg.UserDefinedProbe.Method != types.ConnectivityProbeMethodNone {
+			userProbe := port.userProbes[probeCfg.UserDefinedProbe]
+			if userProbe != nil {
+				userProbe.refCount++
+			} else {
+				port.userProbes[probeCfg.UserDefinedProbe] = &probeStatus{refCount: 1}
+			}
+		}
+	}
+	// Initial pick is made based on the last probing results.
+	p.log.Noticef("PortProber: Started port probing for route dst=%v NI=%v",
+		mpRoute.DstNetwork, ni)
+	p.pickPortForRoute(key)
+	p.forceProbing()
+	return p.routes[key].ProbeStatus, nil
+}
+
+// StopPortProbing tells PortProber to stop periodic probing of network ports
+// for this multipath route.
+// It is called by zedrouter whenever multipath route is removed or the probing config
+// options have changed (in that case zedrouter will restart probing with the new config).
+func (p *PortProber) StopPortProbing(ni uuid.UUID, mpRouteDst *net.IPNet) error {
+	p.Lock()
+	defer p.Unlock()
+	key := p.routeKey(ni, mpRouteDst)
+	mpRoute, exists := p.routes[key]
+	if !exists {
+		return fmt.Errorf("route dst=%v NI=%v is without probing", mpRouteDst, ni)
+	}
+	delete(p.routes, key)
+	probeCfg := mpRoute.MPRoute.PortProbe
+	matchingPorts := p.getPortsMatchingLabels(mpRoute.NIPortLabel,
+		mpRoute.MPRoute.OutputPortLabel)
+	for _, port := range matchingPorts {
+		if probeCfg.EnabledGwPing && port.cost <= probeCfg.GwPingMaxCost {
+			port.nhProbe.refCount--
+			if port.nhProbe.refCount == 0 {
+				// Zero out all values.
+				port.nhProbe = probeStatus{}
+			}
+		}
+		userProbe := port.userProbes[probeCfg.UserDefinedProbe]
+		if userProbe != nil {
+			userProbe.refCount--
+			if userProbe.refCount == 0 {
+				delete(port.userProbes, probeCfg.UserDefinedProbe)
+			}
+		}
+	}
+	p.log.Noticef("PortProber: Stopped port probing for route dst=%v NI=%v",
+		mpRouteDst, ni)
+	return nil
+}
+
+// ApplyDNSUpdate : update the state of probing based on a newly received
+// Device Network Status from NIM.
+func (p *PortProber) ApplyDNSUpdate(dns types.DeviceNetworkStatus) {
+	p.Lock()
+	defer p.Unlock()
+	p.pendingDNS = &dns
+	p.forceProbing()
+}
+
+// ApplyWwanMetricsUpdate : update the state of probing based on a newly received
+// wwan metrics from the mmagent.
+// This is needed to implement the PreferStrongerWwanSignal config option.
+func (p *PortProber) ApplyWwanMetricsUpdate(wwanMetrics types.WwanMetrics) {
+	p.Lock()
+	defer p.Unlock()
+	p.wwanMetrics = wwanMetrics
+	// Do not force probing, we get wwan metrics updates quite often...
+}
+
+// WatchProbeUpdates returns channel where PortProber will be publishing updates
+// about ports to use for multipath routes.
+// Channel type is a slice of probe statuses - this is used to publish multiple updates
+// in a bulk for efficiency.
+func (p *PortProber) WatchProbeUpdates() <-chan []ProbeStatus {
+	p.Lock()
+	defer p.Unlock()
+	watcherCh := make(chan []ProbeStatus)
+	p.watcherChs = append(p.watcherChs, watcherCh)
+	return watcherCh
+}
+
+// GetProbeStatus : get the current probing status for a given multipath route.
+func (p *PortProber) GetProbeStatus(ni uuid.UUID, mpRouteDst *net.IPNet) (
+	ProbeStatus, error) {
+	p.Lock()
+	defer p.Unlock()
+	key := p.routeKey(ni, mpRouteDst)
+	mpRoute, exists := p.routes[key]
+	if !exists {
+		return ProbeStatus{}, fmt.Errorf("route dst=%v NI=%v is without probing",
+			mpRouteDst, ni)
+	}
+	return mpRoute.ProbeStatus, nil
+}
+
+// GetProbeMetrics : get probing metrics for all multipath routes configured
+// for a given network instance.
+func (p *PortProber) GetProbeMetrics(
+	ni uuid.UUID) (allMetrics []types.ProbeMetrics, err error) {
+	p.Lock()
+	defer p.Unlock()
+	nhProbeInterval := uint32(p.config.NHProbeInterval / time.Second)
+	userProbeInterval := uint32((time.Duration(p.config.NHToUserProbeRatio) *
+		p.config.NHProbeInterval) / time.Second)
+	for _, mpRoute := range p.routes {
+		if mpRoute.NetworkInstance != ni {
+			continue
+		}
+		probeCfg := mpRoute.MPRoute.PortProbe
+		selectedPort := mpRoute.SelectedPortLL
+		metrics := types.ProbeMetrics{
+			DstNetwork:      mpRoute.MPRoute.DstNetwork.String(),
+			SelectedPort:    selectedPort,
+			LocalPingIntvl:  nhProbeInterval,
+			RemotePingIntvl: userProbeInterval,
+			IntfProbeStats:  nil,
+		}
+		if probeCfg.UserDefinedProbe.Method != types.ConnectivityProbeMethodNone {
+			metrics.RemoteEndpoints = append(metrics.RemoteEndpoints,
+				probeCfg.UserDefinedProbe.String())
+		}
+		matchingPorts := p.getPortsMatchingLabels(mpRoute.NIPortLabel,
+			mpRoute.MPRoute.OutputPortLabel)
+		for _, port := range matchingPorts {
+			if port.logicallabel == selectedPort {
+				metrics.SelectedPortIfName = port.ifName
+			}
+			metrics.PortCount++
+			intfMetrics := types.ProbeIntfMetrics{
+				IntfName:       port.ifName,
+				NexthopIPs:     port.nextHops,
+				NexthopUP:      port.nhProbe.connIsUP,
+				NexthopUPCnt:   port.nhProbe.successCnt,
+				NexthopDownCnt: port.nhProbe.failedCnt,
+			}
+			userProbe := port.userProbes[probeCfg.UserDefinedProbe]
+			if userProbe != nil {
+				intfMetrics.RemoteUP = userProbe.connIsUP
+				intfMetrics.RemoteUPCnt = userProbe.successCnt
+				intfMetrics.RemoteDownCnt = userProbe.failedCnt
+				latency := uint32(userProbe.avgLatency / time.Millisecond)
+				intfMetrics.LatencyToRemote = latency
+			}
+			metrics.IntfProbeStats = append(metrics.IntfProbeStats, intfMetrics)
+			// Keep the interface order from DNS.
+			comparePortIndex := func(i, j int) bool {
+				intfI := metrics.IntfProbeStats[i].IntfName
+				intfJ := metrics.IntfProbeStats[j].IntfName
+				return p.getIntfOrderInDNS(intfI, false) < p.getIntfOrderInDNS(intfJ, false)
+			}
+			sort.Slice(metrics.IntfProbeStats, comparePortIndex)
+		}
+		allMetrics = append(allMetrics, metrics)
+	}
+	// Make the order of probe metrics deterministic.
+	// This is solely to simplify unit testing.
+	compareRouteDst := func(i, j int) bool {
+		return allMetrics[i].DstNetwork < allMetrics[j].DstNetwork
+	}
+	sort.Slice(allMetrics, compareRouteDst)
+	return allMetrics, nil
+}
+
+// Run periodic port probing from a separate Go routine.
+func (p *PortProber) runProbing() {
+	for {
+		select {
+		case <-p.probeTicker.C:
+			p.Lock()
+			var updates []ProbeStatus
+			updates = p.probePorts()
+			if p.forcedTick {
+				// Reset back to the regular interval.
+				p.probeTicker.Reset(p.config.NHProbeInterval)
+			}
+			p.forcedTick = false
+			watchers := p.watcherChs
+			p.Unlock()
+			for _, watcherCh := range watchers {
+				watcherCh <- updates
+			}
+		}
+	}
+}
+
+// Trigger probing sooner that it would be otherwise.
+func (p *PortProber) forceProbing() {
+	p.probeTicker.Reset(time.Second)
+	p.forcedTick = true
+}
+
+// Main method performing probing of all ports used by at least one
+// multipath route. Next it iterates over all multipath routes with enabled probing
+// and decides if selected port should change.
+func (p *PortProber) probePorts() (updates []ProbeStatus) {
+	defer func() { p.probeIteration++ }()
+	// 1. Apply pending DNS update if there is any
+	p.applyPendingDNS()
+	// 2. probe every used port
+	for _, port := range p.ports {
+		if port.nhProbe.refCount > 0 {
+			// Perform next-hop probing if it is enabled at least for one route
+			// matching this port.
+			p.probePortNH(port)
+		}
+		// 2.2. Maybe probe also user endpoints.
+		if port.newlyAdded ||
+			p.probeIteration%int(p.config.NHToUserProbeRatio) == 0 {
+			for userProbeConfig := range port.userProbes {
+				p.probePortUserEp(port, userProbeConfig)
+			}
+		}
+		port.newlyAdded = false
+	}
+	// 3. update port selections for routes
+	for routeKey := range p.routes {
+		if changed := p.pickPortForRoute(routeKey); changed {
+			updates = append(updates, p.routes[routeKey].ProbeStatus)
+		}
+	}
+	return updates
+}
+
+// Take the latest received DNS update into effect.
+func (p *PortProber) applyPendingDNS() {
+	if p.pendingDNS == nil {
+		return
+	}
+	defer func() {
+		p.dns = *p.pendingDNS
+	}()
+	// Remove ports from portProbeStatus that do not exist anymore or have invalid config.
+	// or are no longer configured for management.
+	for portLL := range p.ports {
+		port := p.pendingDNS.LookupPortByLogicallabel(portLL)
+		if port == nil || port.InvalidConfig {
+			p.log.Noticef("PortProber: Removed %s from the list of probed ports",
+				portLL)
+			delete(p.ports, portLL)
+			continue
+		}
+	}
+	// Add ports that have just appeared and update existing.
+	for _, dnsPort := range p.pendingDNS.Ports {
+		if dnsPort.InvalidConfig {
+			continue
+		}
+		portLL := dnsPort.Logicallabel
+		port, havePort := p.ports[portLL]
+		if !havePort {
+			// Newly appeared port.
+			p.addPort(dnsPort)
+			p.log.Noticef("PortProber: Added %s to list of probed ports", portLL)
+		} else {
+			// Update existing.
+			isWwan := dnsPort.WirelessCfg.WType == types.WirelessTypeCellular
+			labelsChanged := !generics.EqualSets(port.sharedlabels, dnsPort.SharedLabels)
+			if port.ifName != dnsPort.IfName || port.cost != dnsPort.Cost ||
+				port.isWwan != isWwan || labelsChanged {
+				// Port config changed. It is easier to re-add the port.
+				delete(p.ports, portLL)
+				p.addPort(dnsPort)
+				p.log.Noticef("PortProber: Updated config of the probed port %s", portLL)
+			} else {
+				// Just update IP status.
+				port.localAddrs = getLocalIPs(dnsPort)
+				port.nextHops = getNextHops(dnsPort)
+				port.dnsServers = dnsPort.DNSServers
+			}
+		}
+	}
+}
+
+func (p *PortProber) addPort(dnsPort types.NetworkPortStatus) {
+	port := &portStatus{
+		logicallabel: dnsPort.Logicallabel,
+		sharedlabels: dnsPort.SharedLabels,
+		ifName:       dnsPort.IfName,
+		cost:         dnsPort.Cost,
+		isWwan:       dnsPort.WirelessCfg.WType == types.WirelessTypeCellular,
+		localAddrs:   getLocalIPs(dnsPort),
+		nextHops:     getNextHops(dnsPort),
+		dnsServers:   dnsPort.DNSServers,
+		// Mark as new so that the following probing will run fully
+		// and decide the UP/DOWN states.
+		newlyAdded: true,
+		nhProbe:    probeStatus{},
+		userProbes: make(map[types.ConnectivityProbe]*probeStatus),
+	}
+	for _, route := range p.routes {
+		if !port.matchesLabels(route.NIPortLabel, route.MPRoute.OutputPortLabel) {
+			continue
+		}
+		probeCfg := route.MPRoute.PortProbe
+		if probeCfg.EnabledGwPing && port.cost <= probeCfg.GwPingMaxCost {
+			port.nhProbe.refCount++
+		}
+		if probeCfg.UserDefinedProbe.Method != types.ConnectivityProbeMethodNone {
+			userProbe := port.userProbes[probeCfg.UserDefinedProbe]
+			if userProbe != nil {
+				userProbe.refCount++
+			} else {
+				port.userProbes[probeCfg.UserDefinedProbe] = &probeStatus{refCount: 1}
+			}
+		}
+	}
+	p.ports[dnsPort.Logicallabel] = port
+}
+
+// Probe next-hops of the given port.
+func (p *PortProber) probePortNH(port *portStatus) {
+	portLL := port.logicallabel
+	err := errors.New("missing next-hop or local IP")
+	for _, nhIP := range port.nextHops {
+		nhAddr := &net.IPAddr{IP: nhIP}
+		for _, localIP := range port.localAddrs {
+			if !localIP.IsGlobalUnicast() {
+				continue
+			}
+			ctx := context.Background()
+			ctx, cancel := context.WithTimeout(ctx, p.config.NextHopProbeTimeout)
+			err = p.reachProberICMP.Probe(ctx, port.ifName, localIP, nhAddr, nil)
+			cancel()
+			if err == nil {
+				break
+			}
+		}
+		if err == nil {
+			break
+		}
+	}
+	if err == nil {
+		// (At least one) next hop is reachable.
+		if port.newlyAdded {
+			port.nhProbe.connIsUP = true
+		} else {
+			if !port.nhProbe.connIsUP &&
+				port.nhProbe.successCnt == 0 &&
+				port.nhProbe.failedCnt >= uint32(p.config.MinContPrevStateCnt) {
+				port.nhProbe.connIsUP = true
+				p.log.Noticef("PortProber: Setting NH to UP for port %s "+
+					"(sudden change)", portLL)
+			}
+			port.nhProbe.successCnt++
+			port.nhProbe.failedCnt = 0
+			if !port.nhProbe.connIsUP &&
+				port.nhProbe.successCnt > uint32(p.config.MaxContSuccessCnt) {
+				port.nhProbe.connIsUP = true
+				p.log.Noticef(
+					"PortProber: Setting NH to UP for port %s "+
+						"(continuously UP)", portLL)
+			}
+		}
+	} else {
+		// Next hop is NOT reachable.
+		if port.newlyAdded {
+			port.nhProbe.connIsUP = false
+		} else {
+			if port.nhProbe.connIsUP &&
+				port.nhProbe.failedCnt == 0 &&
+				port.nhProbe.successCnt >= uint32(p.config.MinContPrevStateCnt) {
+				port.nhProbe.connIsUP = false
+				p.log.Noticef("PortProber: Setting NH to DOWN for port %s "+
+					"(sudden change; probe err: %v)", portLL, err)
+			}
+			port.nhProbe.failedCnt++
+			port.nhProbe.successCnt = 0
+			if port.nhProbe.connIsUP &&
+				port.nhProbe.failedCnt > uint32(p.config.MaxContFailCnt) {
+				port.nhProbe.connIsUP = false
+				p.log.Noticef(
+					"PortProber: Setting NH to DOWN for port %s "+
+						"(continuously DOWN; probe err: %v)", portLL, err)
+			}
+		}
+	}
+	if port.newlyAdded {
+		p.log.Noticef("PortProber: Initial NH status for port %s: %t (probe err: %v)",
+			portLL, port.nhProbe.connIsUP, err)
+	}
+}
+
+// Probe user-defined endpoint through the given port.
+func (p *PortProber) probePortUserEp(port *portStatus, probe types.ConnectivityProbe) {
+	portLL := port.logicallabel
+	var (
+		duration time.Duration
+		dstAddr  net.Addr
+		prober   ReachabilityProber
+	)
+	switch probe.Method {
+	case types.ConnectivityProbeMethodICMP:
+		if hostIP := net.ParseIP(probe.ProbeHost); hostIP != nil {
+			dstAddr = &net.IPAddr{IP: hostIP}
+		} else {
+			dstAddr = &HostnameAddr{Hostname: probe.ProbeHost}
+		}
+		prober = p.reachProberICMP
+	case types.ConnectivityProbeMethodTCP:
+		if hostIP := net.ParseIP(probe.ProbeHost); hostIP != nil {
+			dstAddr = &net.TCPAddr{
+				IP:   hostIP,
+				Port: int(probe.ProbePort),
+			}
+		} else {
+			dstAddr = &HostnameAddr{
+				Hostname: probe.ProbeHost,
+				Port:     probe.ProbePort,
+			}
+		}
+		prober = p.reachProberTCP
+	}
+	err := errors.New("missing local IP")
+	for _, localIP := range port.localAddrs {
+		if !localIP.IsGlobalUnicast() {
+			continue
+		}
+		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(ctx, p.config.UserProbeTimeout)
+		startTime := time.Now()
+		err = prober.Probe(ctx, port.ifName, localIP, dstAddr, port.dnsServers)
+		duration = time.Since(startTime)
+		cancel()
+		if err == nil {
+			break
+		}
+	}
+	userProbe := port.userProbes[probe]
+	if err == nil {
+		// User-defined endpoint is reachable.
+		totalDuration := userProbe.avgLatency *
+			time.Duration(userProbe.successCnt)
+		userProbe.successCnt++
+		userProbe.avgLatency = (totalDuration + duration) /
+			time.Duration(userProbe.successCnt)
+		userProbe.failedCnt = 0
+		if port.newlyAdded {
+			userProbe.connIsUP = true
+		} else if !userProbe.connIsUP &&
+			userProbe.successCnt > uint32(p.config.MaxContSuccessCnt) {
+			userProbe.connIsUP = true
+			p.log.Noticef(
+				"PortProber: Setting User-probe %s status to UP for port %s "+
+					"(continuously UP)", probe, portLL)
+		}
+	} else {
+		// User-defined endpoint is NOT reachable.
+		userProbe.failedCnt++
+		userProbe.successCnt = 0
+		userProbe.avgLatency = 0
+		if port.newlyAdded {
+			userProbe.connIsUP = false
+		} else if userProbe.connIsUP &&
+			userProbe.failedCnt > uint32(p.config.MaxContFailCnt) {
+			userProbe.connIsUP = false
+			p.log.Noticef(
+				"PortProber: Setting User-probe %s status to DOWN for port %s "+
+					"(continuously DOWN; probe err: %v)", probe, portLL, err)
+		}
+	}
+	if port.newlyAdded {
+		p.log.Noticef("PortProber: Initial User-probe %s status for port %s: %t "+
+			"(probe err: %v)", probe, portLL, userProbe.connIsUP, err)
+	}
+}
+
+func (p *PortProber) getPortsMatchingLabels(labels ...string) (ports []*portStatus) {
+	for _, port := range p.ports {
+		if !port.matchesLabels(labels...) {
+			continue
+		}
+		ports = append(ports, port)
+	}
+	return ports
+}
+
+// Pick the best port for the given multipath route.
+// PortProber optimizes first by cost, then by the number of UP states and finally
+// by the presence or lack of a local IP address, wwan signal strength, etc.
+func (p *PortProber) pickPortForRoute(routeKey string) (changed bool) {
+	route := p.routes[routeKey]
+	probeCfg := route.MPRoute.PortProbe
+	defer func() {
+		if changed {
+			route.SelectedAt = time.Now()
+		}
+	}()
+	// 1. Check if the selected port is still available.
+	if route.SelectedPortLL != "" {
+		if _, exists := p.ports[route.SelectedPortLL]; !exists {
+			p.log.Noticef(
+				"PortProber: Previously selected port %s for route dst=%v NI=%v "+
+					"is no longer available", route.SelectedPortLL,
+				route.MPRoute.DstNetwork, route.NetworkInstance)
+			route.SelectedPortLL = ""
+		}
+	}
+	// 2. Find best ports with working connectivity (best = lowest cost, most UP states)
+	// 2.1. Find the lowest cost for which there is at least one port available
+	//      with at least one UP state.
+	lowestCost := maxCost
+	anyUPState := false
+	matchingPorts := p.getPortsMatchingLabels(route.NIPortLabel,
+		route.MPRoute.OutputPortLabel)
+	for _, port := range matchingPorts {
+		if port.newlyAdded {
+			// Not yet probed, skip.
+			continue
+		}
+		if port.upCount(probeCfg) > 0 {
+			anyUPState = true
+			if port.cost < lowestCost {
+				lowestCost = port.cost
+			}
+		}
+	}
+	if anyUPState {
+		// 2.2. Find the highest UP count at this cost.
+		var highestUPCnt int
+		for _, port := range matchingPorts {
+			if port.newlyAdded ||
+				(route.MPRoute.PreferLowerCost && port.cost != lowestCost) {
+				continue
+			}
+			if port.upCount(probeCfg) > highestUPCnt {
+				highestUPCnt = port.upCount(probeCfg)
+			}
+		}
+		// 2.3. Find the best cellular signal at this cost and UP count
+		bestRSSI := minRSSI
+		for _, port := range matchingPorts {
+			if port.newlyAdded ||
+				(route.MPRoute.PreferLowerCost && port.cost != lowestCost) {
+				continue
+			}
+			if port.upCount(probeCfg) != highestUPCnt {
+				continue
+			}
+			if !port.isWwan {
+				continue
+			}
+			portRSSI := p.getWwanRSSI(port.logicallabel)
+			if portRSSI > bestRSSI {
+				bestRSSI = portRSSI
+			}
+		}
+		// 2.3. Collect labels of ports with lowestCost + highestUPCnt + bestRSSI
+		//      If NI is already using one of them, then return without any change.
+		var bestPorts []string
+		for _, port := range matchingPorts {
+			if port.newlyAdded ||
+				(route.MPRoute.PreferLowerCost && port.cost != lowestCost) {
+				continue
+			}
+			if port.upCount(probeCfg) != highestUPCnt {
+				continue
+			}
+			if route.MPRoute.PreferStrongerWwanSignal && port.isWwan {
+				if p.getWwanRSSI(port.logicallabel) != bestRSSI {
+					continue
+				}
+			}
+			if route.SelectedPortLL == port.logicallabel {
+				return false
+			}
+			bestPorts = append(bestPorts, port.logicallabel)
+		}
+		// 2.4. Try to share load between these ports using round-robin approach.
+		selectedPort := p.roundRobinPick(bestPorts)
+		if route.SelectedPortLL == "" {
+			p.log.Noticef(
+				"PortProber: Selecting port %s for route dst=%v NI=%v "+
+					"(UP count = %d)", selectedPort, route.MPRoute.DstNetwork,
+				route.NetworkInstance, highestUPCnt)
+		} else {
+			p.log.Noticef("PortProber: Changing port from %s to %s for route dst=%v NI=%v "+
+				"(UP count = %d)", route.SelectedPortLL, selectedPort,
+				route.MPRoute.DstNetwork, route.NetworkInstance, highestUPCnt)
+		}
+		route.SelectedPortLL = selectedPort
+		return true
+	}
+
+	// If we got here, then there is no port with working connectivity...
+	// Keep the existing if NI already has one.
+	if route.SelectedPortLL != "" {
+		return false
+	}
+	// 3. Find lowest-cost port matching the label that has unicast IP address.
+	var suitablePorts []string
+	for _, port := range matchingPorts {
+		for _, ip := range port.localAddrs {
+			if ip.IsGlobalUnicast() {
+				suitablePorts = append(suitablePorts, port.logicallabel)
+			}
+		}
+	}
+	if len(suitablePorts) > 0 {
+		if route.MPRoute.PreferLowerCost {
+			suitablePorts = p.lowestCostPorts(suitablePorts)
+		}
+		route.SelectedPortLL = p.roundRobinPick(suitablePorts)
+		p.log.Noticef(
+			"PortProber: Selecting port %s for route dst=%v NI=%v "+
+				"(has at least unicast IP)", route.SelectedPortLL, route.MPRoute.DstNetwork,
+			route.NetworkInstance)
+		return true
+	}
+	// 4. Find lowest-cost port matching the label that at least has a local IP address.
+	suitablePorts = nil
+	for _, port := range matchingPorts {
+		if len(port.localAddrs) > 0 {
+			suitablePorts = append(suitablePorts, port.logicallabel)
+		}
+	}
+	if len(suitablePorts) > 0 {
+		if route.MPRoute.PreferLowerCost {
+			suitablePorts = p.lowestCostPorts(suitablePorts)
+		}
+		route.SelectedPortLL = p.roundRobinPick(suitablePorts)
+		p.log.Noticef(
+			"PortProber: Selecting port %s for route dst=%v NI=%v "+
+				"(has at least local IP)", route.SelectedPortLL, route.MPRoute.DstNetwork,
+			route.NetworkInstance)
+		return true
+	}
+	// 5. If none of the ports have valid unicast/local IP address just pick
+	//    the lowest-cost port that matches the label
+	suitablePorts = nil
+	for _, port := range matchingPorts {
+		suitablePorts = append(suitablePorts, port.logicallabel)
+	}
+	if len(suitablePorts) > 0 {
+		if route.MPRoute.PreferLowerCost {
+			suitablePorts = p.lowestCostPorts(suitablePorts)
+		}
+		route.SelectedPortLL = p.roundRobinPick(suitablePorts)
+		p.log.Noticef(
+			"PortProber: Selecting port %s for route dst=%v NI=%v "+
+				"(last resort)", route.SelectedPortLL, route.MPRoute.DstNetwork,
+			route.NetworkInstance)
+		return true
+	}
+	// 6. If nothing found, just leave the empty port label for this NI.
+	return false
+}
+
+func (p *PortProber) roundRobinPick(ports []string) string {
+	// The list must be sorted otherwise we could get random order which breaks
+	// round-robin selection.
+	comparePortIndex := func(i, j int) bool {
+		iIdx := p.getIntfOrderInDNS(ports[i], true)
+		jIdx := p.getIntfOrderInDNS(ports[j], true)
+		return iIdx < jIdx
+	}
+	sort.Slice(ports, comparePortIndex)
+	p.pickIteration++
+	return ports[p.pickIteration%len(ports)]
+}
+
+func (p *PortProber) lowestCostPorts(ports []string) []string {
+	lowestCost := maxCost
+	for _, port := range ports {
+		cost := p.getPortCost(port)
+		if cost < lowestCost {
+			lowestCost = cost
+		}
+	}
+	var lowestCostPorts []string
+	for _, port := range ports {
+		cost := p.getPortCost(port)
+		if cost == lowestCost {
+			lowestCostPorts = append(lowestCostPorts, port)
+		}
+	}
+	return lowestCostPorts
+}
+
+func (p *PortProber) routeKey(ni uuid.UUID, dstNet *net.IPNet) string {
+	return fmt.Sprintf("%s-%s", ni, dstNet.String())
+}
+
+func (p *PortProber) getIntfOrderInDNS(ifNameOrLabel string, isLabel bool) int {
+	for i := range p.dns.Ports {
+		if isLabel && p.dns.Ports[i].Logicallabel == ifNameOrLabel {
+			return i
+		}
+		if !isLabel && p.dns.Ports[i].IfName == ifNameOrLabel {
+			return i
+		}
+	}
+	return -1
+}
+
+func (p *PortProber) getPortCost(portLabel string) (cost uint8) {
+	for _, port := range p.dns.Ports {
+		if port.Logicallabel == portLabel {
+			return port.Cost
+		}
+	}
+	return maxCost // unavailable cost is worse than any actual cost
+}
+
+func (p *PortProber) getWwanRSSI(portLabel string) (rssi int32) {
+	for _, wwanNet := range p.wwanMetrics.Networks {
+		if wwanNet.LogicalLabel == portLabel {
+			return wwanNet.SignalInfo.RSSI
+		}
+	}
+	return minRSSI // unavailable RSSI is worse than any actual RSSI
+}
+
+func getLocalIPs(port types.NetworkPortStatus) (ips []net.IP) {
+	for _, addr := range port.AddrInfoList {
+		if !addr.Addr.IsUnspecified() {
+			ips = append(ips, addr.Addr)
+		}
+	}
+	return ips
+}
+
+func getNextHops(port types.NetworkPortStatus) (ips []net.IP) {
+	for _, dr := range port.DefaultRouters {
+		if !dr.IsUnspecified() {
+			ips = append(ips, dr)
+		}
+	}
+	return ips
+}

--- a/pkg/pillar/portprober/portprober_test.go
+++ b/pkg/pillar/portprober/portprober_test.go
@@ -1,0 +1,1391 @@
+// Copyright (c) 2024 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package portprober_test
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	// revive:disable:dot-imports
+	. "github.com/onsi/gomega"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/portprober"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	gomegatypes "github.com/onsi/gomega/types"
+	uuid "github.com/satori/go.uuid"
+	"github.com/sirupsen/logrus"
+)
+
+func configForTest() portprober.Config {
+	return portprober.Config{
+		MaxContFailCnt:      3,
+		MaxContSuccessCnt:   2,
+		MinContPrevStateCnt: 5,
+		NextHopProbeTimeout: 500 * time.Millisecond, // 0.5 second
+		UserProbeTimeout:    time.Second,
+		NHToUserProbeRatio:  5, // once per second
+		NHProbeInterval:     200 * time.Millisecond,
+	}
+}
+
+func prepareGomega(test *testing.T) *GomegaWithT {
+	t := NewGomegaWithT(test)
+	t.SetDefaultEventuallyTimeout(10 * time.Second)
+	t.SetDefaultEventuallyPollingInterval(50 * time.Millisecond)
+	t.SetDefaultConsistentlyDuration(5 * time.Second)
+	t.SetDefaultConsistentlyPollingInterval(50 * time.Millisecond)
+	return t
+}
+
+var (
+	prober          *portprober.PortProber
+	reachProberICMP *portprober.MockReachProber
+	reachProberTCP  *portprober.MockReachProber
+)
+
+var (
+	latestStatusLock sync.Mutex
+	latestStatus     map[string]portprober.ProbeStatus // key: routeKey(NI, dst)
+)
+
+func routeKey(ni uuid.UUID, dstNet *net.IPNet) string {
+	return fmt.Sprintf("%s-%s", ni, dstNet.String())
+}
+
+func initportprober(t *GomegaWithT, intfs selectedIntfs) {
+	logger := logrus.StandardLogger()
+	logger.SetLevel(logrus.TraceLevel)
+	/*
+		formatter := logrus.JSONFormatter{
+			TimestampFormat: time.RFC3339Nano,
+		}
+		logger.SetFormatter(&formatter)
+	*/
+	logObj := base.NewSourceLogObject(logger, "test", 1234)
+	reachProberICMP = portprober.NewMockReachProber()
+	setDefaultReachState(intfs)
+	reachProberTCP = portprober.NewMockReachProber()
+	prober = portprober.NewPortProber(logObj, configForTest(),
+		reachProberICMP, reachProberTCP)
+	t.Expect(prober).ToNot(BeNil())
+	updatesCh := prober.WatchProbeUpdates()
+	t.Expect(updatesCh).ToNot(BeNil())
+	latestStatus = make(map[string]portprober.ProbeStatus)
+	go runWatcher(updatesCh)
+}
+
+func clearLatestStatus() {
+	latestStatusLock.Lock()
+	defer latestStatusLock.Unlock()
+	latestStatus = make(map[string]portprober.ProbeStatus)
+}
+
+func runWatcher(updateCh <-chan []portprober.ProbeStatus) {
+	for {
+		select {
+		case updates := <-updateCh:
+			latestStatusLock.Lock()
+			for _, update := range updates {
+				key := routeKey(update.NetworkInstance, update.MPRoute.DstNetwork)
+				latestStatus[key] = update
+			}
+			latestStatusLock.Unlock()
+		}
+	}
+}
+
+func getRouteProbeStatus(niUUID uuid.UUID, dstNet *net.IPNet) portprober.ProbeStatus {
+	latestStatusLock.Lock()
+	defer latestStatusLock.Unlock()
+	key := routeKey(niUUID, dstNet)
+	status, exists := latestStatus[key]
+	if !exists {
+		status, _ = prober.GetProbeStatus(niUUID, dstNet)
+	}
+	return status
+}
+
+const (
+	eth0LL  = "mgmt-ethernet"
+	eth1LL  = "appshared-ethernet"
+	wlanLL  = "wifi"
+	wwan0LL = "lte1"
+	wwan1LL = "lte2"
+)
+
+func portIfName(portLL string) string {
+	switch portLL {
+	case eth0LL:
+		return "eth0"
+	case eth1LL:
+		return "eth1"
+	case wlanLL:
+		return "wlan0"
+	case wwan0LL:
+		return "wwan0"
+	case wwan1LL:
+		return "wwan1"
+	}
+	return ""
+}
+
+func ipAddress(ipAddr string) net.IP {
+	ip := net.ParseIP(ipAddr)
+	if ip == nil {
+		log.Fatal(fmt.Sprintf("bad IP: %s", ipAddr))
+	}
+	return ip
+}
+
+func ipSubnet(ipAddr string) *net.IPNet {
+	_, subnet, err := net.ParseCIDR(ipAddr)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return subnet
+}
+
+func mockEth0Status() types.NetworkPortStatus {
+	localOnlyIP := ipAddress("169.254.50.50")
+	ip, subnet, _ := net.ParseCIDR("192.168.1.1/24")
+	return types.NetworkPortStatus{
+		IfName:         portIfName(eth0LL),
+		Phylabel:       portIfName(eth0LL),
+		Logicallabel:   eth0LL,
+		SharedLabels:   []string{"all", "uplink", "freeuplink", "internet", "ethernet"},
+		IsMgmt:         true,
+		IsL3Port:       true,
+		Cost:           0,
+		Subnet:         *subnet,
+		AddrInfoList:   []types.AddrInfo{{Addr: ip}, {Addr: localOnlyIP}},
+		DefaultRouters: []net.IP{ipAddress("192.168.1.2")},
+	}
+}
+
+func mockEth1Status() types.NetworkPortStatus {
+	ip, subnet, _ := net.ParseCIDR("10.10.0.1/16")
+	return types.NetworkPortStatus{
+		IfName:         portIfName(eth1LL),
+		Phylabel:       portIfName(eth1LL),
+		Logicallabel:   eth1LL,
+		SharedLabels:   []string{"all", "localnet", "ethernet"},
+		IsMgmt:         false,
+		IsL3Port:       true,
+		Cost:           0,
+		Subnet:         *subnet,
+		AddrInfoList:   []types.AddrInfo{{Addr: ip}},
+		DefaultRouters: []net.IP{ipAddress("10.10.0.250")},
+	}
+}
+
+func mockWlanStatus() types.NetworkPortStatus {
+	ip, subnet, _ := net.ParseCIDR("172.30.1.1/24")
+	return types.NetworkPortStatus{
+		IfName:         portIfName(wlanLL),
+		Phylabel:       portIfName(wlanLL),
+		Logicallabel:   wlanLL,
+		SharedLabels:   []string{"all", "wireless", "localnet"},
+		IsMgmt:         false,
+		IsL3Port:       true,
+		Cost:           2,
+		Subnet:         *subnet,
+		AddrInfoList:   []types.AddrInfo{{Addr: ip}},
+		DefaultRouters: []net.IP{ipAddress("172.30.1.10")},
+		WirelessCfg:    types.WirelessConfig{WType: types.WirelessTypeWifi},
+	}
+}
+
+func mockWwan0Status() types.NetworkPortStatus {
+	ip, subnet, _ := net.ParseCIDR("172.18.40.199/24")
+	return types.NetworkPortStatus{
+		IfName:         portIfName(wwan0LL),
+		Phylabel:       portIfName(wwan0LL),
+		Logicallabel:   wwan0LL,
+		SharedLabels:   []string{"all", "uplink", "wireless", "internet"},
+		IsMgmt:         true,
+		IsL3Port:       true,
+		Cost:           10,
+		Subnet:         *subnet,
+		AddrInfoList:   []types.AddrInfo{{Addr: ip}},
+		DefaultRouters: []net.IP{ipAddress("172.18.40.200")},
+		WirelessCfg:    types.WirelessConfig{WType: types.WirelessTypeCellular},
+	}
+}
+
+func mockWwan1Status() types.NetworkPortStatus {
+	ip, subnet, _ := net.ParseCIDR("172.95.6.12/24")
+	return types.NetworkPortStatus{
+		IfName:         portIfName(wwan1LL),
+		Phylabel:       portIfName(wwan1LL),
+		Logicallabel:   wwan1LL,
+		SharedLabels:   []string{"all", "uplink", "wireless", "internet"},
+		IsMgmt:         true,
+		IsL3Port:       true,
+		Cost:           10,
+		Subnet:         *subnet,
+		AddrInfoList:   []types.AddrInfo{{Addr: ip}},
+		DefaultRouters: []net.IP{ipAddress("172.95.6.11")},
+		WirelessCfg:    types.WirelessConfig{WType: types.WirelessTypeCellular},
+	}
+}
+
+var (
+	eth0NHAddr  = &net.IPAddr{IP: mockEth0Status().DefaultRouters[0]}
+	eth1NHAddr  = &net.IPAddr{IP: mockEth1Status().DefaultRouters[0]}
+	wlan0NHAddr = &net.IPAddr{IP: mockWlanStatus().DefaultRouters[0]}
+	wwan0NHAddr = &net.IPAddr{IP: mockWwan0Status().DefaultRouters[0]}
+	wwan1NHAddr = &net.IPAddr{IP: mockWwan1Status().DefaultRouters[0]}
+)
+
+type selectedIntfs struct {
+	eth0  bool
+	eth1  bool
+	wlan0 bool
+	wwan0 bool
+	wwan1 bool
+}
+
+func makeDNS(intfs selectedIntfs) types.DeviceNetworkStatus {
+	dns := types.DeviceNetworkStatus{
+		DPCKey:  "test",
+		Version: types.DPCIsMgmt,
+		Testing: false,
+		State:   types.DPCStateSuccess,
+	}
+	if intfs.eth0 {
+		dns.Ports = append(dns.Ports, mockEth0Status())
+	}
+	if intfs.eth1 {
+		dns.Ports = append(dns.Ports, mockEth1Status())
+	}
+	if intfs.wlan0 {
+		dns.Ports = append(dns.Ports, mockWlanStatus())
+	}
+	if intfs.wwan0 {
+		dns.Ports = append(dns.Ports, mockWwan0Status())
+	}
+	if intfs.wwan1 {
+		dns.Ports = append(dns.Ports, mockWwan1Status())
+	}
+	return dns
+}
+
+func makeWwanMetrics(intfs selectedIntfs) types.WwanMetrics {
+	metrics := types.WwanMetrics{}
+	if intfs.wwan0 {
+		metrics.Networks = append(metrics.Networks, types.WwanNetworkMetrics{
+			LogicalLabel: wwan0LL,
+			PhysAddrs: types.WwanPhysAddrs{
+				Interface: portIfName(wwan0LL),
+				USB:       "1:3",
+				PCI:       "0000:a2:00.0",
+			},
+			SignalInfo: types.WwanSignalInfo{
+				RSSI: -67,
+			},
+		})
+	}
+	if intfs.wwan1 {
+		metrics.Networks = append(metrics.Networks, types.WwanNetworkMetrics{
+			LogicalLabel: wwan1LL,
+			PhysAddrs: types.WwanPhysAddrs{
+				Interface: portIfName(wwan1LL),
+				USB:       "1:4",
+				PCI:       "0000:f4:00.0",
+			},
+			SignalInfo: types.WwanSignalInfo{
+				RSSI: -82,
+			},
+		})
+	}
+	return metrics
+}
+
+func copyDNS(dns types.DeviceNetworkStatus) types.DeviceNetworkStatus {
+	dnsCopy := dns
+	dnsCopy.Ports = make([]types.NetworkPortStatus, len(dns.Ports))
+	for i := range dns.Ports {
+		dnsCopy.Ports[i] = dns.Ports[i]
+	}
+	return dnsCopy
+}
+
+func copyWwanMetrics(metrics types.WwanMetrics) types.WwanMetrics {
+	metricsCopy := metrics
+	metricsCopy.Networks = make([]types.WwanNetworkMetrics, len(metrics.Networks))
+	for i := range metrics.Networks {
+		metricsCopy.Networks[i] = metrics.Networks[i]
+	}
+	return metricsCopy
+}
+
+func setDefaultReachState(intfs selectedIntfs) {
+	if intfs.eth0 {
+		reachProberICMP.SetReachabilityState(portIfName(eth0LL), eth0NHAddr, nil, 50*time.Millisecond)
+	}
+	if intfs.eth1 {
+		reachProberICMP.SetReachabilityState(portIfName(eth1LL), eth1NHAddr, nil, 50*time.Millisecond)
+	}
+	if intfs.wlan0 {
+		reachProberICMP.SetReachabilityState(portIfName(wlanLL), wlan0NHAddr, nil, 100*time.Millisecond)
+	}
+	if intfs.wwan0 {
+		reachProberICMP.SetReachabilityState(portIfName(wwan0LL), wwan0NHAddr, nil, 200*time.Millisecond)
+	}
+	if intfs.wwan1 {
+		reachProberICMP.SetReachabilityState(portIfName(wwan1LL), wwan1NHAddr, nil, 300*time.Millisecond)
+	}
+}
+
+var (
+	ni1, _ = uuid.FromString("0d6a128b-b36f-4bd0-a71c-087ba2d71ebc")
+	ni2, _ = uuid.FromString("f9a3acd0-85ae-4c1f-8fb2-0ac22b5dd312")
+)
+
+const (
+	ni1PortLabel = eth0LL
+	ni2PortLabel = "all"
+)
+
+func eventuallyProbe(t *GomegaWithT, portLL string, dstAddr net.Addr) {
+	startTime := time.Now()
+	probeDone := func() bool {
+		probeTimeICMP := reachProberICMP.LastProbe(portIfName(portLL), dstAddr)
+		probeTimeTCP := reachProberTCP.LastProbe(portIfName(portLL), dstAddr)
+		return probeTimeICMP.After(startTime) || probeTimeTCP.After(startTime)
+	}
+	t.Eventually(probeDone).Should(BeTrue())
+}
+
+func neverProbe(t *GomegaWithT, portLL string, dstAddr net.Addr) {
+	startTime := time.Now()
+	probeDone := func() bool {
+		probeTimeICMP := reachProberICMP.LastProbe(portIfName(portLL), dstAddr)
+		probeTimeTCP := reachProberTCP.LastProbe(portIfName(portLL), dstAddr)
+		return probeTimeICMP.After(startTime) || probeTimeTCP.After(startTime)
+	}
+	t.Consistently(probeDone).Should(BeFalse())
+}
+
+func eventuallySelectedPort(t *GomegaWithT,
+	niUUID uuid.UUID, dstNet *net.IPNet, portLLs ...string) (selectedAt time.Time) {
+	selectedPort := func() string {
+		status := getRouteProbeStatus(niUUID, dstNet)
+		return status.SelectedPortLL
+	}
+	var conds []gomegatypes.GomegaMatcher
+	for _, portLL := range portLLs {
+		conds = append(conds, BeEquivalentTo(portLL))
+	}
+	t.Eventually(selectedPort).Should(Or(conds...))
+	return getRouteProbeStatus(niUUID, dstNet).SelectedAt
+}
+
+func neverChangedPort(t *GomegaWithT, niUUID uuid.UUID, dstNet *net.IPNet) {
+	lastSelectedAt := getRouteProbeStatus(niUUID, dstNet).SelectedAt
+	changedPort := func() bool {
+		status := getRouteProbeStatus(niUUID, dstNet)
+		return status.SelectedAt.After(lastSelectedAt)
+	}
+	t.Consistently(changedPort()).Should(BeFalse())
+}
+
+func isGatewayUP(portLL string) bool {
+	var niMetrics []types.ProbeMetrics
+	var err error
+	for _, niUUID := range []uuid.UUID{ni1, ni2} {
+		niMetrics, err = prober.GetProbeMetrics(niUUID)
+		if err != nil {
+			panic(err)
+		}
+		for _, routeMetrics := range niMetrics {
+			for _, intfMetrics := range routeMetrics.IntfProbeStats {
+				if intfMetrics.IntfName == portIfName(portLL) {
+					return intfMetrics.NexthopUP
+				}
+			}
+		}
+	}
+	panic("unknown/unused port interface")
+}
+
+func isUserEpUP(portLL string, userProbeAddrStr string) bool {
+	var niMetrics []types.ProbeMetrics
+	var err error
+	for _, niUUID := range []uuid.UUID{ni1, ni2} {
+		niMetrics, err = prober.GetProbeMetrics(niUUID)
+		if err != nil {
+			panic(err)
+		}
+		for _, routeMetrics := range niMetrics {
+			if len(routeMetrics.RemoteEndpoints) != 1 ||
+				routeMetrics.RemoteEndpoints[0] != userProbeAddrStr {
+				continue
+			}
+			for _, intfMetrics := range routeMetrics.IntfProbeStats {
+				if intfMetrics.IntfName == portIfName(portLL) {
+					return intfMetrics.RemoteUP
+				}
+			}
+		}
+	}
+	panic("unknown/unused port interface")
+}
+
+func TestProbingSingleRoute(test *testing.T) {
+	t := prepareGomega(test)
+	intfs := selectedIntfs{eth0: true, eth1: true, wlan0: true, wwan0: true, wwan1: true}
+	initportprober(t, intfs)
+	wwanMetrics := makeWwanMetrics(intfs)
+	prober.ApplyWwanMetricsUpdate(wwanMetrics)
+
+	routeDst := ipSubnet("100.100.100.0/24")
+	mpRoute := types.IPRouteConfig{
+		DstNetwork:      routeDst,
+		OutputPortLabel: "internet",
+		PortProbe: types.NIPortProbe{
+			EnabledGwPing: true,
+			GwPingMaxCost: 0, // next-hop ping disabled for wwan ports
+			UserDefinedProbe: types.ConnectivityProbe{
+				Method:    types.ConnectivityProbeMethodTCP,
+				ProbeHost: "100.100.100.50",
+				ProbePort: 80,
+			},
+		},
+		PreferLowerCost:          true,
+		PreferStrongerWwanSignal: true,
+	}
+	userProbeAddr := &net.TCPAddr{IP: ipAddress("100.100.100.50"), Port: 80}
+	userProbeAddrStr := "tcp://100.100.100.50:80"
+	reachProberTCP.SetReachabilityState(portIfName(eth0LL), userProbeAddr, nil, 250*time.Millisecond)
+
+	// portprober does not have DNS yet,
+	// i.e. the list of ports to probe is still unknown.
+	_, err := prober.GetProbeStatus(ni1, routeDst)
+	t.Expect(err).To(HaveOccurred())
+	status, err := prober.StartPortProbing(ni1, ni1PortLabel, mpRoute)
+	t.Expect(err).ToNot(HaveOccurred())
+	t.Expect(status.NetworkInstance.String()).To(Equal(ni1.String()))
+	t.Expect(status.MPRoute).To(Equal(mpRoute))
+	t.Expect(status.SelectedPortLL).To(BeZero())
+	t.Expect(status.SelectedAt.IsZero()).To(BeTrue())
+
+	// Apply DNS with eth0, eth1, wwan0 and wwan1 (all with working connectivity).
+	dnsAppliedAt := time.Now()
+	dns := makeDNS(intfs)
+	prober.ApplyDNSUpdate(dns)
+
+	// Route should only be using eth0 (the only interface used by NI1).
+	eventuallyProbe(t, eth0LL, eth0NHAddr)
+	eventuallyProbe(t, eth0LL, userProbeAddr)
+	neverProbe(t, eth1LL, userProbeAddr)
+	neverProbe(t, wwan0LL, userProbeAddr)
+	neverProbe(t, wwan1LL, userProbeAddr)
+
+	selectedAt := eventuallySelectedPort(t, ni1, routeDst, eth0LL)
+	t.Expect(selectedAt.After(dnsAppliedAt)).To(BeTrue())
+
+	status, err = prober.GetProbeStatus(ni1, routeDst)
+	t.Expect(err).ToNot(HaveOccurred())
+	t.Expect(status.SelectedPortLL).To(Equal(eth0LL))
+	t.Expect(status.MPRoute).To(Equal(mpRoute))
+	t.Expect(status.SelectedAt.After(dnsAppliedAt)).To(BeTrue())
+	t.Expect(status.NetworkInstance.String()).To(Equal(ni1.String()))
+
+	metrics, err := prober.GetProbeMetrics(ni1)
+	t.Expect(err).ToNot(HaveOccurred())
+	t.Expect(metrics).To(HaveLen(1))
+	t.Expect(metrics[0].DstNetwork).To(Equal(routeDst.String()))
+	t.Expect(metrics[0].PortCount).To(BeEquivalentTo(1)) // eth0 only selected for NI1
+	t.Expect(metrics[0].SelectedPortIfName).To(Equal(portIfName(eth0LL)))
+	t.Expect(metrics[0].RemotePingIntvl).To(BeEquivalentTo(1))
+	t.Expect(metrics[0].LocalPingIntvl).To(BeEquivalentTo(0)) // less than 1 sec in UTs
+	t.Expect(metrics[0].RemoteEndpoints).To(BeEquivalentTo([]string{userProbeAddrStr}))
+	t.Expect(metrics[0].IntfProbeStats).To(HaveLen(1))
+	intfStats := metrics[0].IntfProbeStats[0]
+	t.Expect(intfStats.IntfName).To(Equal(portIfName(eth0LL)))
+	t.Expect(intfStats.NexthopUP).To(BeTrue())
+	t.Expect(intfStats.NexthopDownCnt).To(BeZero())
+	t.Expect(intfStats.NexthopUPCnt).ToNot(BeZero())
+	t.Expect(intfStats.NexthopIPs).To(HaveLen(1))
+	t.Expect(intfStats.NexthopIPs[0].Equal(eth0NHAddr.IP)).To(BeTrue())
+	t.Expect(intfStats.RemoteUP).To(BeTrue())
+	t.Expect(intfStats.RemoteDownCnt).To(BeZero())
+	t.Expect(intfStats.RemoteUPCnt).ToNot(BeZero())
+	t.Expect(intfStats.LatencyToRemote >= 200).To(BeTrue()) // should be around 250ms
+	t.Expect(intfStats.LatencyToRemote <= 300).To(BeTrue())
+
+	neverChangedPort(t, ni1, routeDst)
+
+	err = prober.StopPortProbing(ni1, routeDst)
+	t.Expect(err).ToNot(HaveOccurred())
+	status, err = prober.GetProbeStatus(ni1, routeDst)
+	t.Expect(err).To(HaveOccurred())
+	metrics, err = prober.GetProbeMetrics(ni1)
+	t.Expect(err).ToNot(HaveOccurred())
+	t.Expect(metrics).To(HaveLen(0))
+
+	neverProbe(t, eth0LL, eth0NHAddr)
+	neverProbe(t, eth0LL, userProbeAddr)
+
+	// Now try the same route but with NI2 which uses all ports.
+	// Route narrows down the port selection to eth0, wwan0 and wwan1.
+	reachProberTCP.SetReachabilityState(portIfName(eth0LL), userProbeAddr, nil, 250*time.Millisecond)
+	reachProberTCP.SetReachabilityState(portIfName(wwan0LL), userProbeAddr, nil, 400*time.Millisecond)
+	reachProberTCP.SetReachabilityState(portIfName(wwan1LL), userProbeAddr, nil, 500*time.Millisecond)
+
+	// eth0 should be already selected (lowest cost).
+	probingStartedAt := time.Now()
+	status, err = prober.StartPortProbing(ni2, ni2PortLabel, mpRoute)
+	t.Expect(err).ToNot(HaveOccurred())
+	t.Expect(status.NetworkInstance.String()).To(Equal(ni2.String()))
+	t.Expect(status.MPRoute).To(Equal(mpRoute))
+	t.Expect(status.SelectedPortLL).To(Equal(eth0LL))
+	t.Expect(status.SelectedAt.After(probingStartedAt)).To(BeTrue())
+
+	neverChangedPort(t, ni2, routeDst)
+
+	status, err = prober.GetProbeStatus(ni2, routeDst)
+	t.Expect(err).ToNot(HaveOccurred())
+	t.Expect(status.SelectedPortLL).To(Equal(eth0LL))
+	t.Expect(status.MPRoute).To(Equal(mpRoute))
+	t.Expect(status.SelectedAt.After(probingStartedAt)).To(BeTrue())
+	t.Expect(status.NetworkInstance.String()).To(Equal(ni2.String()))
+
+	// Next-hop for eth0 stops being reachable.
+	reachProberICMP.SetReachabilityState(portIfName(eth0LL), eth0NHAddr,
+		errors.New("unreachable"), 50*time.Millisecond)
+	// Probing interval is 200 ms, MaxContFailCnt is 3 => it will take 800 ms
+	// at least for the state to change (+ probing durations ~ 200ms).
+	// All well inside the eventual timeout.
+	t.Eventually(func() bool { return isGatewayUP(eth0LL) }).Should(BeFalse())
+
+	// However, eth0 is still the best pick, even if nexthop is down.
+	neverChangedPort(t, ni2, routeDst)
+
+	// Check metrics
+	metrics, err = prober.GetProbeMetrics(ni2)
+	t.Expect(err).ToNot(HaveOccurred())
+	t.Expect(metrics).To(HaveLen(1))
+	t.Expect(metrics[0].DstNetwork).To(Equal(routeDst.String()))
+	t.Expect(metrics[0].PortCount).To(BeEquivalentTo(3)) // eth0, wwan0, wwan1
+	t.Expect(metrics[0].SelectedPortIfName).To(Equal(portIfName(eth0LL)))
+	t.Expect(metrics[0].RemotePingIntvl).To(BeEquivalentTo(1))
+	t.Expect(metrics[0].LocalPingIntvl).To(BeEquivalentTo(0)) // less than 1 sec in UTs
+	t.Expect(metrics[0].RemoteEndpoints).To(BeEquivalentTo([]string{userProbeAddrStr}))
+	t.Expect(metrics[0].IntfProbeStats).To(HaveLen(3))
+	eth0Stats := metrics[0].IntfProbeStats[0]
+	t.Expect(eth0Stats.IntfName).To(Equal(portIfName(eth0LL)))
+	t.Expect(eth0Stats.NexthopUP).To(BeFalse())
+	t.Expect(eth0Stats.NexthopDownCnt).ToNot(BeZero())
+	t.Expect(eth0Stats.NexthopUPCnt).To(BeZero())
+	t.Expect(eth0Stats.NexthopIPs).To(HaveLen(1))
+	t.Expect(eth0Stats.NexthopIPs[0].Equal(eth0NHAddr.IP)).To(BeTrue())
+	t.Expect(eth0Stats.RemoteUP).To(BeTrue())
+	t.Expect(eth0Stats.RemoteDownCnt).To(BeZero())
+	t.Expect(eth0Stats.RemoteUPCnt).ToNot(BeZero())
+	t.Expect(eth0Stats.LatencyToRemote >= 200).To(BeTrue()) // should be around 250ms
+	t.Expect(eth0Stats.LatencyToRemote <= 300).To(BeTrue())
+	wwan0Stats := metrics[0].IntfProbeStats[1]
+	t.Expect(wwan0Stats.IntfName).To(Equal(portIfName(wwan0LL)))
+	t.Expect(wwan0Stats.NexthopUP).To(BeFalse()) // next-hop ping is disabled for wwan ports
+	t.Expect(wwan0Stats.NexthopDownCnt).To(BeZero())
+	t.Expect(wwan0Stats.NexthopUPCnt).To(BeZero())
+	t.Expect(wwan0Stats.NexthopIPs).To(HaveLen(1))
+	t.Expect(wwan0Stats.NexthopIPs[0].Equal(wwan0NHAddr.IP)).To(BeTrue())
+	t.Expect(wwan0Stats.RemoteUP).To(BeTrue())
+	t.Expect(wwan0Stats.RemoteDownCnt).To(BeZero())
+	t.Expect(wwan0Stats.RemoteUPCnt).ToNot(BeZero())
+	t.Expect(wwan0Stats.LatencyToRemote >= 350).To(BeTrue()) // should be around 400ms
+	t.Expect(wwan0Stats.LatencyToRemote <= 450).To(BeTrue())
+	wwan1Stats := metrics[0].IntfProbeStats[2]
+	t.Expect(wwan1Stats.IntfName).To(Equal(portIfName(wwan1LL)))
+	t.Expect(wwan1Stats.NexthopUP).To(BeFalse()) // next-hop ping is disabled for wwan ports
+	t.Expect(wwan1Stats.NexthopDownCnt).To(BeZero())
+	t.Expect(wwan1Stats.NexthopUPCnt).To(BeZero())
+	t.Expect(wwan1Stats.NexthopIPs).To(HaveLen(1))
+	t.Expect(wwan1Stats.NexthopIPs[0].Equal(wwan1NHAddr.IP)).To(BeTrue())
+	t.Expect(wwan1Stats.RemoteUP).To(BeTrue())
+	t.Expect(wwan1Stats.RemoteDownCnt).To(BeZero())
+	t.Expect(wwan1Stats.RemoteUPCnt).ToNot(BeZero())
+	t.Expect(wwan1Stats.LatencyToRemote >= 450).To(BeTrue()) // should be around 500ms
+	t.Expect(wwan1Stats.LatencyToRemote <= 550).To(BeTrue())
+
+	// When user-defined endpoint reachability for eth0 goes down, wwan0 becomes better pick
+	// (it has better RSSI than wwan1).
+	// User-defined endpoint stops responding within the (1sec) probing timeout.
+	userProbeChange := time.Now()
+	reachProberTCP.SetReachabilityState(portIfName(eth0LL), userProbeAddr,
+		nil, time.Minute)
+	// Probing interval is 1 sec, MaxContFailCnt is 3, probe duration 1 sec (after timeout
+	// is triggered) => it will take 8 seconds at least for the state to change.
+	// Still within the eventual timeout.
+	t.Eventually(func() bool { return isUserEpUP(eth0LL, userProbeAddrStr) }).Should(BeFalse())
+
+	selectedAt = eventuallySelectedPort(t, ni2, routeDst, wwan0LL)
+	t.Expect(selectedAt.After(userProbeChange)).To(BeTrue())
+
+	status, err = prober.GetProbeStatus(ni2, routeDst)
+	t.Expect(err).ToNot(HaveOccurred())
+	t.Expect(status.SelectedPortLL).To(Equal(wwan0LL))
+	t.Expect(status.MPRoute).To(Equal(mpRoute))
+	t.Expect(status.SelectedAt.After(userProbeChange)).To(BeTrue())
+	t.Expect(status.NetworkInstance.String()).To(Equal(ni2.String()))
+
+	// When all ports lose connectivity, portprober prefers to not change
+	// the currently selected port.
+	reachProberTCP.SetReachabilityState(portIfName(wwan0LL), userProbeAddr,
+		errors.New("unreachable"), 50*time.Millisecond)
+	reachProberTCP.SetReachabilityState(portIfName(wwan1LL), userProbeAddr,
+		errors.New("unreachable"), 50*time.Millisecond)
+	t.Eventually(func() bool { return isUserEpUP(wwan0LL, userProbeAddrStr) }).Should(BeFalse())
+	t.Eventually(func() bool { return isUserEpUP(wwan1LL, userProbeAddrStr) }).Should(BeFalse())
+	neverChangedPort(t, ni2, routeDst)
+
+	// Re-check metrics with the connectivity being DOWN.
+	metrics, err = prober.GetProbeMetrics(ni2)
+	t.Expect(err).ToNot(HaveOccurred())
+	t.Expect(metrics).To(HaveLen(1))
+	t.Expect(metrics[0].DstNetwork).To(Equal(routeDst.String()))
+	t.Expect(metrics[0].PortCount).To(BeEquivalentTo(3)) // eth0, wwan0, wwan1
+	t.Expect(metrics[0].SelectedPortIfName).To(Equal(portIfName(wwan0LL)))
+	t.Expect(metrics[0].RemotePingIntvl).To(BeEquivalentTo(1))
+	t.Expect(metrics[0].LocalPingIntvl).To(BeEquivalentTo(0)) // less than 1 sec in UTs
+	t.Expect(metrics[0].RemoteEndpoints).To(BeEquivalentTo([]string{userProbeAddrStr}))
+	t.Expect(metrics[0].IntfProbeStats).To(HaveLen(3))
+	eth0Stats = metrics[0].IntfProbeStats[0]
+	t.Expect(eth0Stats.IntfName).To(Equal(portIfName(eth0LL)))
+	t.Expect(eth0Stats.NexthopUP).To(BeFalse())
+	t.Expect(eth0Stats.NexthopDownCnt).ToNot(BeZero())
+	t.Expect(eth0Stats.NexthopUPCnt).To(BeZero())
+	t.Expect(eth0Stats.NexthopIPs).To(HaveLen(1))
+	t.Expect(eth0Stats.NexthopIPs[0].Equal(eth0NHAddr.IP)).To(BeTrue())
+	t.Expect(eth0Stats.RemoteUP).To(BeFalse())
+	t.Expect(eth0Stats.RemoteDownCnt).ToNot(BeZero())
+	t.Expect(eth0Stats.RemoteUPCnt).To(BeZero())
+	wwan0Stats = metrics[0].IntfProbeStats[1]
+	t.Expect(wwan0Stats.IntfName).To(Equal(portIfName(wwan0LL)))
+	t.Expect(wwan0Stats.NexthopUP).To(BeFalse()) // next-hop ping is disabled for wwan ports
+	t.Expect(wwan0Stats.NexthopDownCnt).To(BeZero())
+	t.Expect(wwan0Stats.NexthopUPCnt).To(BeZero())
+	t.Expect(wwan0Stats.NexthopIPs).To(HaveLen(1))
+	t.Expect(wwan0Stats.NexthopIPs[0].Equal(wwan0NHAddr.IP)).To(BeTrue())
+	t.Expect(wwan0Stats.RemoteUP).To(BeFalse())
+	t.Expect(wwan0Stats.RemoteDownCnt).ToNot(BeZero())
+	t.Expect(wwan0Stats.RemoteUPCnt).To(BeZero())
+	wwan1Stats = metrics[0].IntfProbeStats[2]
+	t.Expect(wwan1Stats.IntfName).To(Equal(portIfName(wwan1LL)))
+	t.Expect(wwan1Stats.NexthopUP).To(BeFalse()) // next-hop ping is disabled for wwan ports
+	t.Expect(wwan1Stats.NexthopDownCnt).To(BeZero())
+	t.Expect(wwan1Stats.NexthopUPCnt).To(BeZero())
+	t.Expect(wwan1Stats.NexthopIPs).To(HaveLen(1))
+	t.Expect(wwan1Stats.NexthopIPs[0].Equal(wwan1NHAddr.IP)).To(BeTrue())
+	t.Expect(wwan1Stats.RemoteUP).To(BeFalse())
+	t.Expect(wwan1Stats.RemoteDownCnt).ToNot(BeZero())
+	t.Expect(wwan1Stats.RemoteUPCnt).To(BeZero())
+
+	// Restore eth0 connectivity - at least next hop..
+	nhChange := time.Now()
+	reachProberICMP.SetReachabilityState(portIfName(eth0LL), eth0NHAddr, nil, 50*time.Millisecond)
+	selectedAt = eventuallySelectedPort(t, ni2, routeDst, eth0LL)
+	t.Expect(selectedAt.After(nhChange)).To(BeTrue())
+
+	err = prober.StopPortProbing(ni2, routeDst)
+	t.Expect(err).ToNot(HaveOccurred())
+	_, err = prober.GetProbeStatus(ni2, routeDst)
+	t.Expect(err).To(HaveOccurred())
+}
+
+func TestProbingMultipleRoutes(test *testing.T) {
+	t := prepareGomega(test)
+	intfs := selectedIntfs{eth0: true, eth1: true, wlan0: true, wwan0: true, wwan1: true}
+	initportprober(t, intfs)
+
+	// Apply DNS and wwan metrics with all ports having working connectivity.
+	dns := makeDNS(intfs)
+	prober.ApplyDNSUpdate(dns)
+	wwanMetrics := makeWwanMetrics(intfs)
+	prober.ApplyWwanMetricsUpdate(wwanMetrics)
+
+	route1Dst := ipSubnet("200.50.0.0/16")
+	mpRoute1 := types.IPRouteConfig{
+		DstNetwork:      route1Dst,
+		OutputPortLabel: "internet", // eth0, wwan0 and wwan1
+		PortProbe: types.NIPortProbe{
+			EnabledGwPing: true,
+			GwPingMaxCost: 0, // next-hop ping disabled for wwan ports
+			UserDefinedProbe: types.ConnectivityProbe{
+				Method:    types.ConnectivityProbeMethodICMP,
+				ProbeHost: "remote-hostname-for-probing.com",
+			},
+		},
+		PreferLowerCost:          true,
+		PreferStrongerWwanSignal: true,
+	}
+	userProbe1Addr := &portprober.HostnameAddr{Hostname: "remote-hostname-for-probing.com"}
+	userProbe1AddrStr := "icmp://remote-hostname-for-probing.com"
+	reachProberICMP.SetReachabilityState(portIfName(eth0LL), userProbe1Addr, nil, 250*time.Millisecond)
+	reachProberICMP.SetReachabilityState(portIfName(wwan0LL), userProbe1Addr, nil, 400*time.Millisecond)
+	reachProberICMP.SetReachabilityState(portIfName(wwan1LL), userProbe1Addr, nil, 400*time.Millisecond)
+
+	probing1StartedAt := time.Now()
+	_, err := prober.StartPortProbing(ni2, ni2PortLabel, mpRoute1)
+	t.Expect(err).ToNot(HaveOccurred())
+
+	route2Dst := ipSubnet("192.168.5.0/24")
+	mpRoute2 := types.IPRouteConfig{
+		DstNetwork:      route2Dst,
+		OutputPortLabel: "localnet", // eth1 & wlan
+		PortProbe: types.NIPortProbe{
+			EnabledGwPing: true,
+			GwPingMaxCost: 2, // next-hop ping enabled for wlan
+			UserDefinedProbe: types.ConnectivityProbe{
+				Method:    types.ConnectivityProbeMethodTCP,
+				ProbeHost: "192.168.5.5",
+				ProbePort: 443,
+			},
+		},
+		PreferLowerCost: false, // We do not care about the cost
+	}
+	userProbe2Addr := &net.TCPAddr{IP: ipAddress("192.168.5.5"), Port: 443}
+	userProbe2AddrStr := "tcp://192.168.5.5:443"
+	reachProberTCP.SetReachabilityState(portIfName(eth1LL), userProbe2Addr, nil, 250*time.Millisecond)
+	reachProberTCP.SetReachabilityState(portIfName(wlanLL), userProbe2Addr, nil, 350*time.Millisecond)
+
+	probing2StartedAt := time.Now()
+	_, err = prober.StartPortProbing(ni2, ni2PortLabel, mpRoute2)
+	t.Expect(err).ToNot(HaveOccurred())
+
+	route3Dst := ipSubnet("210.100.100.0/24")
+	mpRoute3 := types.IPRouteConfig{
+		DstNetwork:      route3Dst,
+		OutputPortLabel: "all",
+		// Same probe as for route2:
+		PortProbe: types.NIPortProbe{
+			EnabledGwPing: true,
+			GwPingMaxCost: 2, // next-hop ping enabled for wlan, but not for wwan
+			UserDefinedProbe: types.ConnectivityProbe{
+				Method:    types.ConnectivityProbeMethodTCP,
+				ProbeHost: "192.168.5.5",
+				ProbePort: 443,
+			},
+		},
+		PreferLowerCost:          true,
+		PreferStrongerWwanSignal: true,
+	}
+	// Reachability of userProbe2Addr is already set for eth1 and wlan.
+	reachProberTCP.SetReachabilityState(portIfName(eth0LL), userProbe2Addr, nil, 250*time.Millisecond)
+	reachProberTCP.SetReachabilityState(portIfName(wwan0LL), userProbe2Addr, nil, 400*time.Millisecond)
+	reachProberTCP.SetReachabilityState(portIfName(wwan1LL), userProbe2Addr, nil, 400*time.Millisecond)
+
+	probing3StartedAt := time.Now()
+	_, err = prober.StartPortProbing(ni2, ni2PortLabel, mpRoute3)
+	t.Expect(err).ToNot(HaveOccurred())
+
+	// For route1, eth0 should be selected (lowest cost).
+	selectedAt := eventuallySelectedPort(t, ni2, route1Dst, eth0LL)
+	t.Expect(selectedAt.After(probing1StartedAt)).To(BeTrue())
+
+	status, err := prober.GetProbeStatus(ni2, route1Dst)
+	t.Expect(err).ToNot(HaveOccurred())
+	t.Expect(status.NetworkInstance.String()).To(Equal(ni2.String()))
+	t.Expect(status.MPRoute).To(Equal(mpRoute1))
+	t.Expect(status.SelectedPortLL).To(Equal(eth0LL))
+	t.Expect(status.SelectedAt.After(probing1StartedAt)).To(BeTrue())
+
+	// For route2, eth1 and wlan have equal preference at this moment
+	selectedAt = eventuallySelectedPort(t, ni2, route2Dst, eth1LL, wlanLL)
+	t.Expect(selectedAt.After(probing1StartedAt)).To(BeTrue())
+
+	status, err = prober.GetProbeStatus(ni2, route2Dst)
+	t.Expect(status.NetworkInstance.String()).To(Equal(ni2.String()))
+	t.Expect(status.MPRoute).To(Equal(mpRoute2))
+	t.Expect(status.SelectedPortLL).To(Or(Equal(eth1LL), Equal(wlanLL)))
+	t.Expect(status.SelectedAt.After(probing2StartedAt)).To(BeTrue())
+
+	// For route3, eth0 or eth1 should be selected (lowest cost).
+	selectedAt = eventuallySelectedPort(t, ni2, route3Dst, eth0LL, eth1LL)
+	t.Expect(selectedAt.After(probing3StartedAt)).To(BeTrue())
+
+	status, err = prober.GetProbeStatus(ni2, route3Dst)
+	t.Expect(err).ToNot(HaveOccurred())
+	t.Expect(status.NetworkInstance.String()).To(Equal(ni2.String()))
+	t.Expect(status.MPRoute).To(Equal(mpRoute3))
+	t.Expect(status.SelectedPortLL).To(Or(Equal(eth0LL), Equal(eth1LL)))
+	t.Expect(status.SelectedAt.After(probing3StartedAt)).To(BeTrue())
+
+	// Selections remain stable.
+	neverChangedPort(t, ni2, route1Dst)
+	neverChangedPort(t, ni2, route2Dst)
+	neverChangedPort(t, ni2, route3Dst)
+
+	// Check metrics
+	metrics, err := prober.GetProbeMetrics(ni2)
+	t.Expect(err).ToNot(HaveOccurred())
+	t.Expect(metrics).To(HaveLen(3))
+	// Route2 comes first (ordered by dst network address)
+	t.Expect(metrics[0].DstNetwork).To(Equal(route2Dst.String()))
+	t.Expect(metrics[0].PortCount).To(BeEquivalentTo(2)) // eth0, wwan0, wwan1
+	t.Expect(metrics[0].SelectedPortIfName).To(Or(Equal(portIfName(eth1LL)), Equal(portIfName(wlanLL))))
+	t.Expect(metrics[0].RemotePingIntvl).To(BeEquivalentTo(1))
+	t.Expect(metrics[0].LocalPingIntvl).To(BeEquivalentTo(0)) // less than 1 sec in UTs
+	t.Expect(metrics[0].RemoteEndpoints).To(BeEquivalentTo([]string{userProbe2AddrStr}))
+	t.Expect(metrics[0].IntfProbeStats).To(HaveLen(2))
+	eth1Stats := metrics[0].IntfProbeStats[0]
+	t.Expect(eth1Stats.IntfName).To(Equal(portIfName(eth1LL)))
+	t.Expect(eth1Stats.NexthopUP).To(BeTrue())
+	t.Expect(eth1Stats.NexthopDownCnt).To(BeZero())
+	t.Expect(eth1Stats.NexthopUPCnt).ToNot(BeZero())
+	t.Expect(eth1Stats.NexthopIPs).To(HaveLen(1))
+	t.Expect(eth1Stats.NexthopIPs[0].Equal(eth1NHAddr.IP)).To(BeTrue())
+	t.Expect(eth1Stats.RemoteUP).To(BeTrue())
+	t.Expect(eth1Stats.RemoteDownCnt).To(BeZero())
+	t.Expect(eth1Stats.RemoteUPCnt).ToNot(BeZero())
+	t.Expect(eth1Stats.LatencyToRemote >= 200).To(BeTrue()) // should be around 250ms
+	t.Expect(eth1Stats.LatencyToRemote <= 300).To(BeTrue())
+	wlanStats := metrics[0].IntfProbeStats[1]
+	t.Expect(wlanStats.IntfName).To(Equal(portIfName(wlanLL)))
+	t.Expect(wlanStats.NexthopUP).To(BeTrue()) // next-hop ping is enabled for wlan
+	t.Expect(wlanStats.NexthopDownCnt).To(BeZero())
+	t.Expect(wlanStats.NexthopUPCnt).ToNot(BeZero())
+	t.Expect(wlanStats.NexthopIPs).To(HaveLen(1))
+	t.Expect(wlanStats.NexthopIPs[0].Equal(wlan0NHAddr.IP)).To(BeTrue())
+	t.Expect(wlanStats.RemoteUP).To(BeTrue())
+	t.Expect(wlanStats.RemoteDownCnt).To(BeZero())
+	t.Expect(wlanStats.RemoteUPCnt).ToNot(BeZero())
+	t.Expect(wlanStats.LatencyToRemote >= 300).To(BeTrue()) // should be around 350ms
+	t.Expect(wlanStats.LatencyToRemote <= 400).To(BeTrue())
+	// Route1
+	t.Expect(metrics[1].DstNetwork).To(Equal(route1Dst.String()))
+	t.Expect(metrics[1].PortCount).To(BeEquivalentTo(3)) // eth0, wwan0, wwan1
+	t.Expect(metrics[1].SelectedPortIfName).To(Equal(portIfName(eth0LL)))
+	t.Expect(metrics[1].RemotePingIntvl).To(BeEquivalentTo(1))
+	t.Expect(metrics[1].LocalPingIntvl).To(BeEquivalentTo(0)) // less than 1 sec in UTs
+	t.Expect(metrics[1].RemoteEndpoints).To(BeEquivalentTo([]string{userProbe1AddrStr}))
+	t.Expect(metrics[1].IntfProbeStats).To(HaveLen(3))
+	eth0Stats := metrics[1].IntfProbeStats[0]
+	t.Expect(eth0Stats.IntfName).To(Equal(portIfName(eth0LL)))
+	t.Expect(eth0Stats.NexthopUP).To(BeTrue())
+	t.Expect(eth0Stats.NexthopDownCnt).To(BeZero())
+	t.Expect(eth0Stats.NexthopUPCnt).ToNot(BeZero())
+	t.Expect(eth0Stats.NexthopIPs).To(HaveLen(1))
+	t.Expect(eth0Stats.NexthopIPs[0].Equal(eth0NHAddr.IP)).To(BeTrue())
+	t.Expect(eth0Stats.RemoteUP).To(BeTrue())
+	t.Expect(eth0Stats.RemoteDownCnt).To(BeZero())
+	t.Expect(eth0Stats.RemoteUPCnt).ToNot(BeZero())
+	t.Expect(eth0Stats.LatencyToRemote >= 200).To(BeTrue()) // should be around 250ms
+	t.Expect(eth0Stats.LatencyToRemote <= 300).To(BeTrue())
+	wwan0Stats := metrics[1].IntfProbeStats[1]
+	t.Expect(wwan0Stats.IntfName).To(Equal(portIfName(wwan0LL)))
+	t.Expect(wwan0Stats.NexthopUP).To(BeFalse()) // next-hop ping is disabled for wwan ports
+	t.Expect(wwan0Stats.NexthopDownCnt).To(BeZero())
+	t.Expect(wwan0Stats.NexthopUPCnt).To(BeZero())
+	t.Expect(wwan0Stats.NexthopIPs).To(HaveLen(1))
+	t.Expect(wwan0Stats.NexthopIPs[0].Equal(wwan0NHAddr.IP)).To(BeTrue())
+	t.Expect(wwan0Stats.RemoteUP).To(BeTrue())
+	t.Expect(wwan0Stats.RemoteDownCnt).To(BeZero())
+	t.Expect(wwan0Stats.RemoteUPCnt).ToNot(BeZero())
+	t.Expect(wwan0Stats.LatencyToRemote >= 350).To(BeTrue()) // should be around 400ms
+	t.Expect(wwan0Stats.LatencyToRemote <= 450).To(BeTrue())
+	wwan1Stats := metrics[1].IntfProbeStats[2]
+	t.Expect(wwan1Stats.IntfName).To(Equal(portIfName(wwan1LL)))
+	t.Expect(wwan1Stats.NexthopUP).To(BeFalse()) // next-hop ping is disabled for wwan ports
+	t.Expect(wwan1Stats.NexthopDownCnt).To(BeZero())
+	t.Expect(wwan1Stats.NexthopUPCnt).To(BeZero())
+	t.Expect(wwan1Stats.NexthopIPs).To(HaveLen(1))
+	t.Expect(wwan1Stats.NexthopIPs[0].Equal(wwan1NHAddr.IP)).To(BeTrue())
+	t.Expect(wwan1Stats.RemoteUP).To(BeTrue())
+	t.Expect(wwan1Stats.RemoteDownCnt).To(BeZero())
+	t.Expect(wwan1Stats.RemoteUPCnt).ToNot(BeZero())
+	t.Expect(wwan1Stats.LatencyToRemote >= 350).To(BeTrue()) // should be around 400ms
+	t.Expect(wwan1Stats.LatencyToRemote <= 450).To(BeTrue())
+	// Route3
+	t.Expect(metrics[2].DstNetwork).To(Equal(route3Dst.String()))
+	t.Expect(metrics[2].PortCount).To(BeEquivalentTo(5))
+	t.Expect(metrics[2].SelectedPortIfName).To(Or(Equal(portIfName(eth0LL)), Equal(portIfName(eth1LL))))
+	t.Expect(metrics[2].RemotePingIntvl).To(BeEquivalentTo(1))
+	t.Expect(metrics[2].LocalPingIntvl).To(BeEquivalentTo(0)) // less than 1 sec in UTs
+	t.Expect(metrics[2].RemoteEndpoints).To(BeEquivalentTo([]string{userProbe2AddrStr}))
+	t.Expect(metrics[2].IntfProbeStats).To(HaveLen(5))
+	eth0Stats = metrics[2].IntfProbeStats[0]
+	t.Expect(eth0Stats.IntfName).To(Equal(portIfName(eth0LL)))
+	t.Expect(eth0Stats.NexthopUP).To(BeTrue())
+	t.Expect(eth0Stats.NexthopDownCnt).To(BeZero())
+	t.Expect(eth0Stats.NexthopUPCnt).ToNot(BeZero())
+	t.Expect(eth0Stats.NexthopIPs).To(HaveLen(1))
+	t.Expect(eth0Stats.NexthopIPs[0].Equal(eth0NHAddr.IP)).To(BeTrue())
+	t.Expect(eth0Stats.RemoteUP).To(BeTrue())
+	t.Expect(eth0Stats.RemoteDownCnt).To(BeZero())
+	t.Expect(eth0Stats.RemoteUPCnt).ToNot(BeZero())
+	t.Expect(eth0Stats.LatencyToRemote >= 200).To(BeTrue()) // should be around 250ms
+	t.Expect(eth0Stats.LatencyToRemote <= 300).To(BeTrue())
+	eth1Stats = metrics[2].IntfProbeStats[1]
+	t.Expect(eth1Stats.IntfName).To(Equal(portIfName(eth1LL)))
+	t.Expect(eth1Stats.NexthopUP).To(BeTrue())
+	t.Expect(eth1Stats.NexthopDownCnt).To(BeZero())
+	t.Expect(eth1Stats.NexthopUPCnt).ToNot(BeZero())
+	t.Expect(eth1Stats.NexthopIPs).To(HaveLen(1))
+	t.Expect(eth1Stats.NexthopIPs[0].Equal(eth1NHAddr.IP)).To(BeTrue())
+	t.Expect(eth1Stats.RemoteUP).To(BeTrue())
+	t.Expect(eth1Stats.RemoteDownCnt).To(BeZero())
+	t.Expect(eth1Stats.RemoteUPCnt).ToNot(BeZero())
+	t.Expect(eth1Stats.LatencyToRemote >= 200).To(BeTrue()) // should be around 250ms
+	t.Expect(eth1Stats.LatencyToRemote <= 300).To(BeTrue())
+	wlanStats = metrics[2].IntfProbeStats[2]
+	t.Expect(wlanStats.IntfName).To(Equal(portIfName(wlanLL)))
+	t.Expect(wlanStats.NexthopUP).To(BeTrue()) // next-hop ping is enabled for wlan
+	t.Expect(wlanStats.NexthopDownCnt).To(BeZero())
+	t.Expect(wlanStats.NexthopUPCnt).ToNot(BeZero())
+	t.Expect(wlanStats.NexthopIPs).To(HaveLen(1))
+	t.Expect(wlanStats.NexthopIPs[0].Equal(wlan0NHAddr.IP)).To(BeTrue())
+	t.Expect(wlanStats.RemoteUP).To(BeTrue())
+	t.Expect(wlanStats.RemoteDownCnt).To(BeZero())
+	t.Expect(wlanStats.RemoteUPCnt).ToNot(BeZero())
+	t.Expect(wlanStats.LatencyToRemote >= 300).To(BeTrue()) // should be around 350ms
+	t.Expect(wlanStats.LatencyToRemote <= 400).To(BeTrue())
+	wwan0Stats = metrics[2].IntfProbeStats[3]
+	t.Expect(wwan0Stats.IntfName).To(Equal(portIfName(wwan0LL)))
+	t.Expect(wwan0Stats.NexthopUP).To(BeFalse()) // next-hop ping is disabled for wwan ports
+	t.Expect(wwan0Stats.NexthopDownCnt).To(BeZero())
+	t.Expect(wwan0Stats.NexthopUPCnt).To(BeZero())
+	t.Expect(wwan0Stats.NexthopIPs).To(HaveLen(1))
+	t.Expect(wwan0Stats.NexthopIPs[0].Equal(wwan0NHAddr.IP)).To(BeTrue())
+	t.Expect(wwan0Stats.RemoteUP).To(BeTrue())
+	t.Expect(wwan0Stats.RemoteDownCnt).To(BeZero())
+	t.Expect(wwan0Stats.RemoteUPCnt).ToNot(BeZero())
+	t.Expect(wwan0Stats.LatencyToRemote >= 350).To(BeTrue()) // should be around 400ms
+	t.Expect(wwan0Stats.LatencyToRemote <= 450).To(BeTrue())
+	wwan1Stats = metrics[2].IntfProbeStats[4]
+	t.Expect(wwan1Stats.IntfName).To(Equal(portIfName(wwan1LL)))
+	t.Expect(wwan1Stats.NexthopUP).To(BeFalse()) // next-hop ping is disabled for wwan ports
+	t.Expect(wwan1Stats.NexthopDownCnt).To(BeZero())
+	t.Expect(wwan1Stats.NexthopUPCnt).To(BeZero())
+	t.Expect(wwan1Stats.NexthopIPs).To(HaveLen(1))
+	t.Expect(wwan1Stats.NexthopIPs[0].Equal(wwan1NHAddr.IP)).To(BeTrue())
+	t.Expect(wwan1Stats.RemoteUP).To(BeTrue())
+	t.Expect(wwan1Stats.RemoteDownCnt).To(BeZero())
+	t.Expect(wwan1Stats.RemoteUPCnt).ToNot(BeZero())
+	t.Expect(wwan1Stats.LatencyToRemote >= 350).To(BeTrue()) // should be around 400ms
+	t.Expect(wwan1Stats.LatencyToRemote <= 450).To(BeTrue())
+
+	// Next-hop for eth1 stops being reachable.
+	reachProberICMP.SetReachabilityState(portIfName(eth1LL), eth1NHAddr, errors.New("unreachable"), 50*time.Millisecond)
+	t.Eventually(func() bool { return isGatewayUP(eth1LL) }).Should(BeFalse())
+
+	// eth1 NH being down should have no effect on route1.
+	neverChangedPort(t, ni2, route1Dst)
+
+	// Since cost preference is disabled, Route2 will now pick wlan
+	// (if it was not done in the first probing).
+	_ = eventuallySelectedPort(t, ni2, route2Dst, wlanLL)
+
+	status, err = prober.GetProbeStatus(ni2, route2Dst)
+	t.Expect(err).ToNot(HaveOccurred())
+	t.Expect(status.SelectedPortLL).To(Equal(wlanLL))
+	t.Expect(status.MPRoute).To(Equal(mpRoute2))
+	t.Expect(status.NetworkInstance.String()).To(Equal(ni2.String()))
+
+	// Route3 should now switch to eth0 if it is using eth1.
+	_ = eventuallySelectedPort(t, ni2, route3Dst, eth0LL)
+
+	status, err = prober.GetProbeStatus(ni2, route3Dst)
+	t.Expect(err).ToNot(HaveOccurred())
+	t.Expect(status.SelectedPortLL).To(Equal(eth0LL))
+	t.Expect(status.MPRoute).To(Equal(mpRoute3))
+	t.Expect(status.NetworkInstance.String()).To(Equal(ni2.String()))
+
+	err = prober.StopPortProbing(ni2, route1Dst)
+	t.Expect(err).ToNot(HaveOccurred())
+	err = prober.StopPortProbing(ni2, route2Dst)
+	t.Expect(err).ToNot(HaveOccurred())
+	err = prober.StopPortProbing(ni2, route3Dst)
+	t.Expect(err).ToNot(HaveOccurred())
+
+	neverProbe(t, eth0LL, eth0NHAddr)
+	neverProbe(t, eth0LL, userProbe1Addr)
+	neverProbe(t, eth0LL, userProbe2Addr)
+	neverProbe(t, eth1LL, eth1NHAddr)
+	neverProbe(t, eth1LL, userProbe2Addr)
+}
+
+func TestProbingNoConnectivity(test *testing.T) {
+	t := prepareGomega(test)
+	intfs := selectedIntfs{eth0: true, wlan0: true, wwan0: true}
+	initportprober(t, intfs)
+
+	// Apply DNS with eth0, wlan0 and wwan0.
+	// However, none of them has working connectivity.
+	dns := makeDNS(intfs)
+	prober.ApplyDNSUpdate(dns)
+
+	routeDst := ipSubnet("192.168.100.0/24")
+	mpRoute := types.IPRouteConfig{
+		DstNetwork:      routeDst,
+		OutputPortLabel: "all",
+		PortProbe: types.NIPortProbe{
+			EnabledGwPing: true,
+			GwPingMaxCost: 2, // enable NH probing for wlan
+			UserDefinedProbe: types.ConnectivityProbe{
+				Method:    types.ConnectivityProbeMethodTCP,
+				ProbeHost: "webserver",
+				ProbePort: 80,
+			},
+		},
+		PreferLowerCost: true,
+	}
+	userProbeAddr := &portprober.HostnameAddr{Hostname: "webserver", Port: 80}
+	unresponsive := errors.New("unresponsive")
+	reachProberTCP.SetReachabilityState(portIfName(eth0LL), userProbeAddr, unresponsive, 50*time.Millisecond)
+	reachProberICMP.SetReachabilityState(portIfName(eth0LL), eth0NHAddr, unresponsive, 50*time.Millisecond)
+	reachProberTCP.SetReachabilityState(portIfName(wlanLL), userProbeAddr, unresponsive, 100*time.Millisecond)
+	reachProberICMP.SetReachabilityState(portIfName(wlanLL), wlan0NHAddr, unresponsive, 100*time.Millisecond)
+	reachProberTCP.SetReachabilityState(portIfName(wwan0LL), userProbeAddr, unresponsive, 200*time.Millisecond)
+	reachProberICMP.SetReachabilityState(portIfName(wwan0LL), wwan0NHAddr, unresponsive, 200*time.Millisecond)
+
+	probingStartedAt := time.Now()
+	status, err := prober.StartPortProbing(ni2, ni2PortLabel, mpRoute)
+	t.Expect(err).ToNot(HaveOccurred())
+
+	eventuallyProbe(t, eth0LL, eth0NHAddr)
+	eventuallyProbe(t, eth0LL, userProbeAddr)
+	eventuallyProbe(t, wlanLL, wlan0NHAddr)
+	eventuallyProbe(t, wlanLL, userProbeAddr)
+	eventuallyProbe(t, wwan0LL, userProbeAddr)
+
+	// Pick eth0 based on having the lowest cost.
+	selectedAt := eventuallySelectedPort(t, ni2, routeDst, eth0LL)
+	t.Expect(selectedAt.After(probingStartedAt)).To(BeTrue())
+
+	status, err = prober.GetProbeStatus(ni2, routeDst)
+	t.Expect(err).ToNot(HaveOccurred())
+	t.Expect(status.SelectedPortLL).To(Equal(eth0LL))
+	t.Expect(status.MPRoute).To(Equal(mpRoute))
+	t.Expect(status.SelectedAt.After(probingStartedAt)).To(BeTrue())
+	t.Expect(status.NetworkInstance.String()).To(Equal(ni2.String()))
+
+	// Remove IP addresses from eth0
+	dns = copyDNS(dns)
+	dns.Ports[0].AddrInfoList = nil
+	prober.ApplyDNSUpdate(dns)
+
+	// Without connectivity, portprober will prefer already selected port over
+	// switching to another.
+	neverChangedPort(t, ni2, routeDst)
+
+	// Restart probing to get a new selection.
+	err = prober.StopPortProbing(ni2, routeDst)
+	t.Expect(err).ToNot(HaveOccurred())
+	clearLatestStatus()
+	probingStartedAt = time.Now()
+	status, err = prober.StartPortProbing(ni2, ni2PortLabel, mpRoute)
+	t.Expect(err).ToNot(HaveOccurred())
+
+	// Now portprober will select wlan1 because it has the lowest cost among
+	// ports with IP address.
+	selectedAt = eventuallySelectedPort(t, ni2, routeDst, wlanLL)
+	t.Expect(selectedAt.After(probingStartedAt)).To(BeTrue())
+
+	status, err = prober.GetProbeStatus(ni2, routeDst)
+	t.Expect(err).ToNot(HaveOccurred())
+	t.Expect(status.SelectedPortLL).To(Equal(wlanLL))
+	t.Expect(status.MPRoute).To(Equal(mpRoute))
+	t.Expect(status.SelectedAt.After(probingStartedAt)).To(BeTrue())
+	t.Expect(status.NetworkInstance.String()).To(Equal(ni2.String()))
+
+	// Remove IP address from all interfaces but give wwan only a local-only IP.
+	dns = copyDNS(dns)
+	dns.Ports[1].AddrInfoList = nil
+	dns.Ports[2].AddrInfoList = []types.AddrInfo{
+		{
+			Addr: ipAddress("169.254.50.50"),
+		},
+	}
+	prober.ApplyDNSUpdate(dns)
+
+	// Without connectivity, portprober will prefer already selected port over
+	// switching to another.
+	neverChangedPort(t, ni2, routeDst)
+
+	// Restart probing to get a new selection.
+	err = prober.StopPortProbing(ni2, routeDst)
+	t.Expect(err).ToNot(HaveOccurred())
+	clearLatestStatus()
+	probingStartedAt = time.Now()
+	status, err = prober.StartPortProbing(ni2, ni2PortLabel, mpRoute)
+	t.Expect(err).ToNot(HaveOccurred())
+
+	// Now portprober will select wwan because it has at least a local IP address.
+	selectedAt = eventuallySelectedPort(t, ni2, routeDst, wwan0LL)
+	t.Expect(selectedAt.After(probingStartedAt)).To(BeTrue())
+
+	status, err = prober.GetProbeStatus(ni2, routeDst)
+	t.Expect(err).ToNot(HaveOccurred())
+	t.Expect(status.SelectedPortLL).To(Equal(wwan0LL))
+	t.Expect(status.MPRoute).To(Equal(mpRoute))
+	t.Expect(status.SelectedAt.After(probingStartedAt)).To(BeTrue())
+	t.Expect(status.NetworkInstance.String()).To(Equal(ni2.String()))
+
+	// Remove all IP addresses from all interfaces.
+	dns = copyDNS(dns)
+	dns.Ports[2].AddrInfoList = nil
+	prober.ApplyDNSUpdate(dns)
+
+	// Without connectivity, portprober will prefer already selected port over
+	// switching to another.
+	neverChangedPort(t, ni2, routeDst)
+
+	// Restart probing to get a new selection.
+	err = prober.StopPortProbing(ni2, routeDst)
+	t.Expect(err).ToNot(HaveOccurred())
+	clearLatestStatus()
+	probingStartedAt = time.Now()
+	status, err = prober.StartPortProbing(ni2, ni2PortLabel, mpRoute)
+	t.Expect(err).ToNot(HaveOccurred())
+
+	// Now portprober cannot use connectivity status or IP address presence to distinguish
+	// between ports.
+	// It will simply pick eth0 as port with the lowest cost.
+	selectedAt = eventuallySelectedPort(t, ni2, routeDst, eth0LL)
+	t.Expect(selectedAt.After(probingStartedAt)).To(BeTrue())
+
+	status, err = prober.GetProbeStatus(ni2, routeDst)
+	t.Expect(err).ToNot(HaveOccurred())
+	t.Expect(status.SelectedPortLL).To(Equal(eth0LL))
+	t.Expect(status.MPRoute).To(Equal(mpRoute))
+	t.Expect(status.SelectedAt.After(probingStartedAt)).To(BeTrue())
+	t.Expect(status.NetworkInstance.String()).To(Equal(ni2.String()))
+}
+
+func TestPortCostChange(test *testing.T) {
+	t := prepareGomega(test)
+	intfs := selectedIntfs{eth0: true, wlan0: true}
+	initportprober(t, intfs)
+
+	// Apply DNS with eth0 and wlan (all with working connectivity).
+	dns := makeDNS(intfs)
+	prober.ApplyDNSUpdate(dns)
+
+	routeDst := ipSubnet("192.168.100.0/24")
+	mpRoute := types.IPRouteConfig{
+		DstNetwork:      routeDst,
+		OutputPortLabel: "all",
+		PortProbe: types.NIPortProbe{
+			EnabledGwPing: true,
+			GwPingMaxCost: 2, // enable NH probing for wlan
+			UserDefinedProbe: types.ConnectivityProbe{
+				Method:    types.ConnectivityProbeMethodTCP,
+				ProbeHost: "webserver",
+				ProbePort: 80,
+			},
+		},
+		PreferLowerCost: true,
+	}
+	userProbeAddr := &portprober.HostnameAddr{Hostname: "webserver", Port: 80}
+	reachProberTCP.SetReachabilityState(portIfName(eth0LL), userProbeAddr, nil, 50*time.Millisecond)
+	reachProberTCP.SetReachabilityState(portIfName(wlanLL), userProbeAddr, nil, 100*time.Millisecond)
+
+	probingStartedAt := time.Now()
+	status, err := prober.StartPortProbing(ni2, ni2PortLabel, mpRoute)
+	t.Expect(err).ToNot(HaveOccurred())
+
+	eventuallyProbe(t, eth0LL, eth0NHAddr)
+	eventuallyProbe(t, eth0LL, userProbeAddr)
+	eventuallyProbe(t, wlanLL, wlan0NHAddr)
+	eventuallyProbe(t, wlanLL, userProbeAddr)
+
+	// Pick eth0 based on already executed probes and having lower cost.
+	selectedAt := eventuallySelectedPort(t, ni2, routeDst, eth0LL)
+	t.Expect(selectedAt.After(probingStartedAt)).To(BeTrue())
+
+	status, err = prober.GetProbeStatus(ni2, routeDst)
+	t.Expect(err).ToNot(HaveOccurred())
+	t.Expect(status.SelectedPortLL).To(Equal(eth0LL))
+	t.Expect(status.MPRoute).To(Equal(mpRoute))
+	t.Expect(status.SelectedAt.After(probingStartedAt)).To(BeTrue())
+	t.Expect(status.NetworkInstance.String()).To(Equal(ni2.String()))
+
+	neverChangedPort(t, ni2, routeDst)
+
+	// Increase eth0 cost.
+	eth0CostIncreasedAt := time.Now()
+	dns = copyDNS(dns)
+	dns.Ports[0].Cost = 100
+	prober.ApplyDNSUpdate(dns)
+
+	// portprober switches the route to now cheaper wlan interface.
+	selectedAt = eventuallySelectedPort(t, ni2, routeDst, wlanLL)
+	t.Expect(selectedAt.After(eth0CostIncreasedAt)).To(BeTrue())
+
+	status, err = prober.GetProbeStatus(ni2, routeDst)
+	t.Expect(err).ToNot(HaveOccurred())
+	t.Expect(status.SelectedPortLL).To(Equal(wlanLL))
+	t.Expect(status.MPRoute).To(Equal(mpRoute))
+	t.Expect(status.SelectedAt.After(eth0CostIncreasedAt)).To(BeTrue())
+	t.Expect(status.NetworkInstance.String()).To(Equal(ni2.String()))
+
+	// Decrease eth0 cost back to 0.
+	eth0CostDecreasedAt := time.Now()
+	dns = copyDNS(dns)
+	dns.Ports[0].Cost = 0
+	prober.ApplyDNSUpdate(dns)
+
+	// portprober switches the route back to eth0.
+	selectedAt = eventuallySelectedPort(t, ni2, routeDst, eth0LL)
+	t.Expect(selectedAt.After(eth0CostDecreasedAt)).To(BeTrue())
+
+	status, err = prober.GetProbeStatus(ni2, routeDst)
+	t.Expect(err).ToNot(HaveOccurred())
+	t.Expect(status.SelectedPortLL).To(Equal(eth0LL))
+	t.Expect(status.MPRoute).To(Equal(mpRoute))
+	t.Expect(status.SelectedAt.After(eth0CostDecreasedAt)).To(BeTrue())
+	t.Expect(status.NetworkInstance.String()).To(Equal(ni2.String()))
+}
+
+func TestAvoidStateFlapping(test *testing.T) {
+	t := prepareGomega(test)
+	intfs := selectedIntfs{eth0: true, wlan0: true}
+	initportprober(t, intfs)
+
+	// Apply DNS with eth0 and wlan (all with working connectivity).
+	dns := makeDNS(intfs)
+	prober.ApplyDNSUpdate(dns)
+
+	routeDst := ipSubnet("192.168.100.0/24")
+	mpRoute := types.IPRouteConfig{
+		DstNetwork:      routeDst,
+		OutputPortLabel: "all",
+		PortProbe: types.NIPortProbe{
+			EnabledGwPing: true,
+			GwPingMaxCost: 2, // enable NH probing for wlan
+			UserDefinedProbe: types.ConnectivityProbe{
+				Method:    types.ConnectivityProbeMethodTCP,
+				ProbeHost: "webserver",
+				ProbePort: 80,
+			},
+		},
+		PreferLowerCost: true,
+	}
+	userProbeAddr := &portprober.HostnameAddr{Hostname: "webserver", Port: 80}
+	// Avoid large probing times for this test.
+	reachProberTCP.SetReachabilityState(portIfName(eth0LL), userProbeAddr, nil, time.Millisecond)
+	reachProberICMP.SetReachabilityState(portIfName(eth0LL), eth0NHAddr, nil, time.Millisecond)
+	reachProberTCP.SetReachabilityState(portIfName(wlanLL), userProbeAddr, nil, time.Millisecond)
+	reachProberICMP.SetReachabilityState(portIfName(wlanLL), wlan0NHAddr, nil, time.Millisecond)
+
+	probingStartedAt := time.Now()
+	status, err := prober.StartPortProbing(ni2, ni2PortLabel, mpRoute)
+	t.Expect(err).ToNot(HaveOccurred())
+
+	eventuallyProbe(t, eth0LL, eth0NHAddr)
+	eventuallyProbe(t, eth0LL, userProbeAddr)
+	eventuallyProbe(t, wlanLL, wlan0NHAddr)
+	eventuallyProbe(t, wlanLL, userProbeAddr)
+
+	// Pick eth0 based on already executed probes and having lower cost.
+	selectedAt := eventuallySelectedPort(t, ni2, routeDst, eth0LL)
+	t.Expect(selectedAt.After(probingStartedAt)).To(BeTrue())
+
+	status, err = prober.GetProbeStatus(ni2, routeDst)
+	t.Expect(err).ToNot(HaveOccurred())
+	t.Expect(status.SelectedPortLL).To(Equal(eth0LL))
+	t.Expect(status.MPRoute).To(Equal(mpRoute))
+	t.Expect(status.SelectedAt.After(probingStartedAt)).To(BeTrue())
+	t.Expect(status.NetworkInstance.String()).To(Equal(ni2.String()))
+
+	// Simulate connectivity flapping..
+	flappingFrom := time.Now()
+	for i := 0; i < 10; i++ {
+		if i%2 == 0 {
+			// eth0 looses connectivity.
+			unresponsive := errors.New("unresponsive")
+			reachProberICMP.SetReachabilityState(portIfName(eth0LL), eth0NHAddr, unresponsive, 50*time.Millisecond)
+			reachProberTCP.SetReachabilityState(portIfName(eth0LL), userProbeAddr, unresponsive, 250*time.Millisecond)
+		} else {
+			// eth0 regains connectivity.
+			reachProberICMP.SetReachabilityState(portIfName(eth0LL), eth0NHAddr, nil, time.Millisecond)
+			reachProberTCP.SetReachabilityState(portIfName(eth0LL), userProbeAddr, nil, time.Millisecond)
+		}
+		// New state remains only for two probes at most. Too short to be taken into effect.
+		time.Sleep(300 * time.Millisecond)
+	}
+
+	status, err = prober.GetProbeStatus(ni2, routeDst)
+	t.Expect(err).ToNot(HaveOccurred())
+	t.Expect(status.SelectedPortLL).To(Equal(eth0LL))
+	t.Expect(status.SelectedAt.Before(flappingFrom)).To(BeTrue())
+	t.Expect(status.NetworkInstance.String()).To(Equal(ni2.String()))
+	neverChangedPort(t, ni2, routeDst)
+}
+
+func TestDisappearedPort(test *testing.T) {
+	t := prepareGomega(test)
+	intfs := selectedIntfs{eth0: true, wlan0: true}
+	initportprober(t, intfs)
+
+	// Apply DNS with eth0 and wlan (all with working connectivity).
+	dns := makeDNS(intfs)
+	prober.ApplyDNSUpdate(dns)
+
+	routeDst := ipSubnet("192.168.100.0/24")
+	mpRoute := types.IPRouteConfig{
+		DstNetwork:      routeDst,
+		OutputPortLabel: "all",
+		PortProbe: types.NIPortProbe{
+			EnabledGwPing: false, // probe only user-defined endpoint
+			UserDefinedProbe: types.ConnectivityProbe{
+				Method:    types.ConnectivityProbeMethodTCP,
+				ProbeHost: "webserver",
+				ProbePort: 80,
+			},
+		},
+		PreferLowerCost: true,
+	}
+	userProbeAddr := &portprober.HostnameAddr{Hostname: "webserver", Port: 80}
+	reachProberTCP.SetReachabilityState(portIfName(eth0LL), userProbeAddr, nil, 250*time.Millisecond)
+	reachProberTCP.SetReachabilityState(portIfName(wlanLL), userProbeAddr, nil, 250*time.Millisecond)
+
+	probingStartedAt := time.Now()
+	status, err := prober.StartPortProbing(ni2, ni2PortLabel, mpRoute)
+	t.Expect(err).ToNot(HaveOccurred())
+
+	neverProbe(t, eth0LL, eth0NHAddr)
+	eventuallyProbe(t, eth0LL, userProbeAddr)
+	neverProbe(t, wlanLL, wlan0NHAddr)
+	eventuallyProbe(t, wlanLL, userProbeAddr)
+
+	// Pick eth0 based on already executed probes and having lower cost.
+	selectedAt := eventuallySelectedPort(t, ni2, routeDst, eth0LL)
+	t.Expect(selectedAt.After(probingStartedAt)).To(BeTrue())
+
+	status, err = prober.GetProbeStatus(ni2, routeDst)
+	t.Expect(err).ToNot(HaveOccurred())
+	t.Expect(status.SelectedPortLL).To(Equal(eth0LL))
+	t.Expect(status.MPRoute).To(Equal(mpRoute))
+	t.Expect(status.SelectedAt.After(probingStartedAt)).To(BeTrue())
+	t.Expect(status.NetworkInstance.String()).To(Equal(ni2.String()))
+
+	// Simulate that eth0 disappeared (e.g. assigned to pciback).
+	eth0DisappearedAt := time.Now()
+	dns = copyDNS(dns)
+	dns.Ports = dns.Ports[1:]
+	prober.ApplyDNSUpdate(dns)
+	eventuallyProbe(t, wlanLL, userProbeAddr)
+
+	// portprober selects the remaining wlan interface.
+	selectedAt = eventuallySelectedPort(t, ni2, routeDst, wlanLL)
+	t.Expect(selectedAt.After(probingStartedAt)).To(BeTrue())
+
+	status, err = prober.GetProbeStatus(ni2, routeDst)
+	t.Expect(err).ToNot(HaveOccurred())
+	t.Expect(status.SelectedPortLL).To(Equal(wlanLL))
+	t.Expect(status.MPRoute).To(Equal(mpRoute))
+	t.Expect(status.SelectedAt.After(eth0DisappearedAt)).To(BeTrue())
+	t.Expect(status.NetworkInstance.String()).To(Equal(ni2.String()))
+}

--- a/pkg/pillar/types/zedroutertypes_test.go
+++ b/pkg/pillar/types/zedroutertypes_test.go
@@ -354,7 +354,7 @@ func TestWasDPCWorking(t *testing.T) {
 	}
 }
 
-func TestGetPortByIfName(t *testing.T) {
+func TestLookupPortByIfName(t *testing.T) {
 	testMatrix := map[string]struct {
 		deviceNetworkStatus DeviceNetworkStatus
 		port                string
@@ -375,7 +375,7 @@ func TestGetPortByIfName(t *testing.T) {
 	}
 	for testname, test := range testMatrix {
 		t.Logf("Running test case %s", testname)
-		value := test.deviceNetworkStatus.GetPortByIfName(test.port)
+		value := test.deviceNetworkStatus.LookupPortByIfName(test.port)
 		assert.Equal(t, test.expectedValue, *value)
 	}
 }

--- a/pkg/pillar/uplinkprober/reachprober.go
+++ b/pkg/pillar/uplinkprober/reachprober.go
@@ -54,14 +54,10 @@ func (p *ControllerReachProber) ProbeNextHopReach(ctx context.Context,
 	}
 	// Determine source and destination IP addresses for the ping.
 	var dstAddr, srcAddr net.IPAddr
-	ports := dns.GetPortsByLogicallabel(uplinkLL)
-	if len(ports) == 0 {
+	port := dns.LookupPortByLogicallabel(uplinkLL)
+	if port == nil {
 		return nil, fmt.Errorf("missing status for uplink interface %s", uplinkLL)
 	}
-	if len(ports) > 1 {
-		return nil, fmt.Errorf("multiple uplink interfaces match label %s", uplinkLL)
-	}
-	port := ports[0]
 	nextHopIP := p.getPortNextHop(port)
 	if nextHopIP == nil || nextHopIP.IsUnspecified() {
 		return nil, fmt.Errorf("uplink %s has no suitable next hop IP address", uplinkLL)
@@ -130,14 +126,10 @@ func (p *ControllerReachProber) ProbeRemoteReach(ctx context.Context,
 		AgentName:        p.agentName,
 		DevNetworkStatus: dns,
 	})
-	ports := dns.GetPortsByLogicallabel(uplinkLL)
-	if len(ports) == 0 {
+	port := dns.LookupPortByLogicallabel(uplinkLL)
+	if port == nil {
 		return probedEps, fmt.Errorf("missing status for uplink interface %s", uplinkLL)
 	}
-	if len(ports) > 1 {
-		return probedEps, fmt.Errorf("multiple uplink interfaces match label %s", uplinkLL)
-	}
-	port := ports[0]
 	rv, err := zedcloud.SendOnIntf(
 		ctx, &zcloudCtx, p.controllerURL.String(), port.IfName,
 		0, nil, allowProxy, useOnboard, withNetTracing, false)

--- a/pkg/pillar/uplinkprober/uplinkprober_test.go
+++ b/pkg/pillar/uplinkprober/uplinkprober_test.go
@@ -388,8 +388,8 @@ func TestProbingSingleNI(test *testing.T) {
 
 	metrics, err := prober.GetProbeMetrics(ni1.UUID)
 	t.Expect(err).ToNot(HaveOccurred())
-	t.Expect(metrics.UplinkCount).To(BeEquivalentTo(2)) // without eth1
-	t.Expect(metrics.SelectedUplinkIntf).To(Equal("eth0"))
+	t.Expect(metrics.PortCount).To(BeEquivalentTo(2)) // without eth1
+	t.Expect(metrics.SelectedPortIfName).To(Equal("eth0"))
 	t.Expect(metrics.RemotePingIntvl).To(BeEquivalentTo(1))
 	t.Expect(metrics.LocalPingIntvl).To(BeEquivalentTo(0)) // less than 1 sec in UTs
 	t.Expect(metrics.RemoteEndpoints).To(BeEquivalentTo([]string{controllerAddr}))
@@ -453,8 +453,8 @@ func TestProbingSingleNI(test *testing.T) {
 	// Re-check metrics with the connectivity being DOWN.
 	metrics, err = prober.GetProbeMetrics(ni1.UUID)
 	t.Expect(err).ToNot(HaveOccurred())
-	t.Expect(metrics.UplinkCount).To(BeEquivalentTo(2)) // without eth1
-	t.Expect(metrics.SelectedUplinkIntf).To(Equal("wwan0"))
+	t.Expect(metrics.PortCount).To(BeEquivalentTo(2)) // without eth1
+	t.Expect(metrics.SelectedPortIfName).To(Equal("wwan0"))
 	t.Expect(metrics.RemotePingIntvl).To(BeEquivalentTo(1))
 	t.Expect(metrics.LocalPingIntvl).To(BeEquivalentTo(0)) // less than 1 sec in UTs
 	t.Expect(metrics.RemoteEndpoints).To(BeEquivalentTo([]string{controllerAddr}))


### PR DESCRIPTION
As we generalize the concept of NI port probing, which is currently limited to uplink & freeuplink shared labels and one port selected for all NI routes, into a multipath routing with probing-based port selection with user-defined shared labels, it is necessary to replace uplinkprober with a more advanced component (and preferably avoid using "uplink" for the name).
See: https://github.com/lf-edge/eve-api/pull/53

This commit introduces portprober - a sucessor to uplinkprober. It will be used by zedrouter to probe port connectivity for multipath IP routes. These are routes that select multiple possible output ports using a shared label. This can be EVE-defined label, such as `uplink` matching all mgmt ports, or a user-defined label selecting a custom subset of ports. A typical example of multipath route is the default route for NI with multiple ports attached.

For now we will not support load-balancing and zedrouter will have to pick one output port at a time for each multipath route. This will be done by portprober. It will probe connectivity of each port (with possibly user-defined probing endpoint and probing method) and based on the results and some other criteria such as cost, wwan signal strength, etc., it will pick the best port. The probing algorithm is pretty much the same as implemented in uplinkprober, just extended to support user-defined shared labels, user-defined probing method, etc.

Note that in this commit we just add the portprober package and make only minimal changes in the `pillar/types` package (e.g. introducing `SharedLabels` into DPC & DNS). In the follow-up PR(s), uplinkprober will be removed and zedrouter will be updated to support multipath routes and to use portprober instead.