### PR TITLE
collect-info: gzip before write into /tmp

### DIFF
--- a/pkg/debug/scripts/collect-info.sh
+++ b/pkg/debug/scripts/collect-info.sh
@@ -156,7 +156,7 @@ fi
 
 # Create temporary dir
 echo "- basic setup"
-TMP_DIR=$(mktemp -d)
+TMP_DIR=$(mktemp -d -t -p /persist/tmp/)
 DIR="$TMP_DIR/$INFO_DIR"
 mkdir -p "$DIR"
 mkdir -p "$DIR/network"

--- a/pkg/dom0-ztools/rootfs/bin/eve
+++ b/pkg/dom0-ztools/rootfs/bin/eve
@@ -251,8 +251,20 @@ __EOT__
           echo "Updated memory-monitor configuration"
           ;;
  verbose) # first lets find our piping process
-          for PIPE in $(pgrep cat); do
-             [ "$(readlink /proc/"$PIPE"/fd/0)" = /run/diag.pipe ] && break
+          PIPE=""
+          while [ "$PIPE" = "" ]
+          do
+              for pid in $(pgrep cat)
+              do
+                 if [ "$(readlink /proc/"$pid"/fd/0)" = /run/diag.pipe ]
+                 then
+                     PIPE="$pid"
+                 fi
+              done
+              if [ -z "$PIPE" ]
+              then
+                  sleep 1
+              fi
           done
           # now lets see what to do with it
           case "$2" in


### PR DESCRIPTION
/tmp is a ramdisk and by compressing the file, we
need less memory when running collect-info

also use `eve http-debug` for backtraces instead of fiddling around grepping logread