### PR TITLE
pillar/device-steps.sh: separate USB attach loop from NTP loop

### DIFF
--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -162,6 +162,28 @@ populate_ntp_sources() {
     fi
 }
 
+# Reload NTP sources
+reload_ntp_sources() {
+    ns="$1"
+    echo "$(date -Ins -u) Remove all NTP sources from chronyd"
+    while true; do
+        # Get all sources, skip 2 lines header, take first line
+        ip=$(/usr/bin/chronyc -n sources | tail +3 | head -1 | awk '{print $2}')
+        if [ -z "$ip" ]; then
+            break
+        fi
+        # Delete IP
+        echo "$(date -Ins -u) chronyc delete \"$ip\""
+        /usr/bin/chronyc delete "$ip"
+        ret_code=$?
+        echo "$(date -Ins -u) chronyc: $ret_code"
+        if [ "$ret_code" != "0" ]; then
+            break
+        fi
+    done
+    populate_ntp_sources "$ns"
+}
+
 # Start NTP daemon
 start_ntp_daemon() {
     ns=$(get_ntp_servers)
@@ -185,28 +207,6 @@ start_ntp_daemon() {
     else
         echo "$(date -Ins -u) ERROR: no NTP (chrony) on EVE"
     fi
-}
-
-# Reload NTP sources
-reload_ntp_sources() {
-    ns="$1"
-    echo "$(date -Ins -u) Remove all NTP sources from chronyd"
-    while true; do
-        # Get all sources, skip 2 lines header, take first line
-        ip=$(/usr/bin/chronyc -n sources | tail +3 | head -1 | awk '{print $2}')
-        if [ -z "$ip" ]; then
-            break
-        fi
-        # Delete IP
-        echo "$(date -Ins -u) chronyc delete \"$ip\""
-        /usr/bin/chronyc delete "$ip"
-        ret_code=$?
-        echo "$(date -Ins -u) chronyc: $ret_code"
-        if [ "$ret_code" != "0" ]; then
-            break
-        fi
-    done
-    populate_ntp_sources "$ns"
 }
 
 # If zedbox is already running we don't have to start it.

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -141,7 +141,7 @@ wait_ntp_sync() {
     echo "$(date -Ins -u) Wait NTP sync for 1 min"
     /usr/bin/chronyc waitsync 6
     ret_code=$?
-    echo "$(date -Ins -u) chronyc: $ret_code"
+    echo "$(date -Ins -u) chronyc waitsync: $ret_code"
 }
 
 # Populate NTP sources from the string argument, which represents
@@ -184,9 +184,22 @@ reload_ntp_sources() {
     populate_ntp_sources "$ns"
 }
 
+# Poll if NTP servers and reload if changed
+reload_ntp_sources_in_loop() {
+    while true; do
+        ns=$(get_ntp_servers)
+        if [ -n "$ns" ] && [ "$ns" != "$NTPSERVERS" ]; then
+            echo "$(date -Ins -u) NTP server changed from \"$NTPSERVERS\" to \"$ns\", reload NTP sources"
+            # Reload NTP sources
+            reload_ntp_sources "$ns"
+        fi
+        # Why strange number? Easy to spot in `ps` output and debug.
+        sleep 30.1
+    done
+}
+
 # Start NTP daemon
 start_ntp_daemon() {
-    ns=$(get_ntp_servers)
     echo "$(date -Ins -u) Check for NTP config"
     if [ -f /usr/sbin/chronyd ]; then
         # Run chronyd to keep it in sync.
@@ -197,12 +210,9 @@ start_ntp_daemon() {
         # Add chronyd to watchdog
         touch "$WATCHDOG_PID/chronyd.pid"
 
-        # Pass NTP server through the chronyc, unfortunately can't pass as
-        # an argument to the daemon itself.
         if [ "$ret_code" = "0" ]; then
-            # Give some time for chronyd to start
-            sleep 1
-            populate_ntp_sources "$ns"
+            # Start reload of NTP sources in a loop asynchronously
+            reload_ntp_sources_in_loop &
         fi
     else
         echo "$(date -Ins -u) ERROR: no NTP (chrony) on EVE"
@@ -502,14 +512,7 @@ echo "$(date -Ins -u) Done starting EVE version: $(cat /run/eve-release)"
 # check for any usb.json with DevicePortConfig, deposit our identity,
 # and dump any diag information
 while true; do
-    access_usb
-    # Check if NTP servers changed
-    # Note that this really belongs in a separate ntpd container
-    ns=$(get_ntp_servers)
-    if [ -n "$ns" ] && [ "$ns" != "$NTPSERVERS" ]; then
-        echo "$(date -Ins -u) NTP server changed from \"$NTPSERVERS\" to \"$ns\", reload NTP sources"
-        # Reload NTP sources
-        reload_ntp_sources "$ns"
-    fi
-    sleep 30
+     access_usb
+     # Why strange number? Easy to spot in `ps` output and debug.
+     sleep 30.2
 done


### PR DESCRIPTION
Make USB attach and NTP loops separate (namely asynchronous) and keep NTP reload loop in the same `start_ntp_daemon()` function so that synchronous logic along the code after the `start_ntp_daemon()` won't affect the NTP reload, for instance we can stuck in the `selfRegister` procedure if network is down and device has not been yet onboarded.

Also sleep in float seconds for easy debugging: once you don't see `sleep 30.1` in `ps` output, means device-steps.sh is stuck somewhere, which probably requires debugging.

CC: @rene 