### PR TITLE
Move tpm2.OpenTPM call to CreateKey

### DIFF
--- a/pkg/pillar/cmd/tpmmgr/tpmmgr.go
+++ b/pkg/pillar/cmd/tpmmgr/tpmmgr.go
@@ -715,26 +715,19 @@ func writeDeviceCertToFile(certBytes, keyBytes []byte) error {
 }
 
 func createOtherKeys(override bool) error {
-	rw, err := tpm2.OpenTPM(etpm.TpmDevicePath)
-	if err != nil {
-		log.Errorln(err)
-		return err
-	}
-	defer rw.Close()
-
-	if err := etpm.CreateKey(log, rw, etpm.TpmEKHdl, tpm2.HandleEndorsement, etpm.DefaultEkTemplate, override); err != nil {
+	if err := etpm.CreateKey(log, etpm.TpmDevicePath, etpm.TpmEKHdl, tpm2.HandleEndorsement, etpm.DefaultEkTemplate, override); err != nil {
 		return fmt.Errorf("error in creating Endorsement key: %w ", err)
 	}
-	if err := etpm.CreateKey(log, rw, etpm.TpmSRKHdl, tpm2.HandleOwner, etpm.DefaultSrkTemplate, override); err != nil {
+	if err := etpm.CreateKey(log, etpm.TpmDevicePath, etpm.TpmSRKHdl, tpm2.HandleOwner, etpm.DefaultSrkTemplate, override); err != nil {
 		return fmt.Errorf("error in creating SRK key: %w ", err)
 	}
-	if err := etpm.CreateKey(log, rw, etpm.TpmAIKHdl, tpm2.HandleOwner, etpm.DefaultAikTemplate, override); err != nil {
+	if err := etpm.CreateKey(log, etpm.TpmDevicePath, etpm.TpmAIKHdl, tpm2.HandleOwner, etpm.DefaultAikTemplate, override); err != nil {
 		return fmt.Errorf("error in creating Attestation key: %w ", err)
 	}
-	if err := etpm.CreateKey(log, rw, etpm.TpmQuoteKeyHdl, tpm2.HandleOwner, etpm.DefaultQuoteKeyTemplate, override); err != nil {
+	if err := etpm.CreateKey(log, etpm.TpmDevicePath, etpm.TpmQuoteKeyHdl, tpm2.HandleOwner, etpm.DefaultQuoteKeyTemplate, override); err != nil {
 		return fmt.Errorf("error in creating Quote key: %w ", err)
 	}
-	if err := etpm.CreateKey(log, rw, etpm.TpmEcdhKeyHdl, tpm2.HandleOwner, etpm.DefaultEcdhKeyTemplate, override); err != nil {
+	if err := etpm.CreateKey(log, etpm.TpmDevicePath, etpm.TpmEcdhKeyHdl, tpm2.HandleOwner, etpm.DefaultEcdhKeyTemplate, override); err != nil {
 		return fmt.Errorf("error in creating ECDH key: %w ", err)
 	}
 	return nil

--- a/pkg/pillar/evetpm/tpm.go
+++ b/pkg/pillar/evetpm/tpm.go
@@ -295,8 +295,16 @@ func (s TpmPrivateKey) Sign(r io.Reader, digest []byte, opts crypto.SignerOpts) 
 	return asn1.Marshal(ecdsaSignature{R, S})
 }
 
-// CreateKey helps creating various keys, according to the supplied template, and hierarchy
-func CreateKey(log *base.LogObject, rw io.ReadWriteCloser, keyHandle, ownerHandle tpmutil.Handle, template tpm2.Public, overwrite bool) error {
+// CreateKey helps creating various keys, according to the supplied template, and hierarchy,
+// we pass TPM path here because in some places we pass socket rather than char device.
+func CreateKey(log *base.LogObject, TpmPath string, keyHandle, ownerHandle tpmutil.Handle, template tpm2.Public, overwrite bool) error {
+	rw, err := tpm2.OpenTPM(TpmPath)
+	if err != nil {
+		log.Errorln(err)
+		return err
+	}
+	defer rw.Close()
+
 	if !overwrite {
 		//don't overwrite if key already exists, and if the attributes match up
 		pub, _, _, err := tpm2.ReadPublic(rw, keyHandle)


### PR DESCRIPTION
This PR fixes a subtle bug introduced in 8a3971771dd7cc18b9968b7433c44fb439b6e64e by moving `tpm2.OpenTPM` call to CreateKey, otherwise if we open tpm and pass the same handle to `CreateKey` multiple times (for example in `createOtherKeys`) it may lead to resource exhaustion in TPM.