### PR TITLE
domainmgr: config.enable.usb for new usb type

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -3117,7 +3117,7 @@ func updatePortAndPciBackIoBundle(ctx *domainContext, ib *types.IoBundle) (chang
 			// is assigned to an application, EVE will not be able to manage the state of the wireless device.
 			keepInHost = true
 		}
-		if ctx.usbAccess && ib.Type == types.IoUSB {
+		if ctx.usbAccess && (ib.Type == types.IoUSB || ib.Type == types.IoUSBController) {
 			keepInHost = true
 		}
 		if ctx.vgaAccess && ib.Type == types.IoHDMI {


### PR DESCRIPTION
instead of IoUSB, now IoUSBController is used for the PCI controller

this means that if the model is created with a newer spec.sh, config.enable.usb would not work