### PR TITLE
Make table index part of the IP-rule definition.

### DIFF
--- a/pkg/pillar/dpcreconciler/linux.go
+++ b/pkg/pillar/dpcreconciler/linux.go
@@ -1147,6 +1147,7 @@ func (r *LinuxDpcReconciler) getIntendedSrcIPRules(dpc types.DevicePortConfig) d
 				AdapterIfName: port.IfName,
 				IPAddr:        ipAddr.IP,
 				Priority:      devicenetwork.PbrLocalOrigPrio,
+				Table:         devicenetwork.DPCBaseRTIndex + ifIndex,
 			}, nil)
 		}
 	}


### PR DESCRIPTION
When wwan modem is reset by ModemManager (because it is not responsive), the wwan interface is recreated and will get a different interface index. This means that the target routing table index for the port (calculated as `500 + interface index`) will change. However, if the IP address assigned by the network is the same after the reset (common in private LTE networks), then only the table index needs to be updated in the corresponding IP rule. But this will be missed because table index is not part of the IP rule definition (`SrcIPRule` struct) and instead it is calculated on-demand inside the Create/Modify method of the configurator. As a result, there is no change detected by the `SrcIPRule.Equal()` method between the current and the new intended state, hence Modify method is not called by the reconciler and IP rule is not updated after modem reset.

In this commit this is fixed by adding the table ID into the IP rule definition.

In theory, this can also affect wlan or eth interface if there is e.g. a driver reset and the interface is recreated (while getting the same IP). However, with cellular modems this is more likely because they are quite flaky and ModemManager resets them when they get stuck.