### PR TITLE
Add rust to eve-alpine

### DIFF
--- a/pkg/alpine/Dockerfile
+++ b/pkg/alpine/Dockerfile
@@ -1,6 +1,6 @@
 # image was bootstraped using FROM lfedge/eve-alpine-base:fad44e3702708a8d044663a20fd98d933dddb41e AS cache
 # to update please see https://github.com/lf-edge/eve/blob/master/docs/BUILD.md#how-to-update-eve-alpine-package
-FROM lfedge/eve-alpine:1f7685f95a475c6bbe682f0b976f12180b6c8726 AS cache
+FROM lfedge/eve-alpine:fbf39533415522ac124a2da9a695fda686adedc3 AS cache
 
 ARG ALPINE_VERSION=3.16
 # this is only needed once, when this package

--- a/pkg/alpine/build-cache.sh
+++ b/pkg/alpine/build-cache.sh
@@ -10,7 +10,7 @@ bail() {
 
 ALPINE_VERSION=$1
 
-if [ "$ALPINE_VERSION" != "edge" ]; then
+if [ "${ALPINE_VERSION#edge}" = "$ALPINE_VERSION" ]; then
   ALPINE_VERSION=v$1
 fi
 

--- a/pkg/alpine/mirrors/edge/main
+++ b/pkg/alpine/mirrors/edge/main
@@ -1,0 +1,2 @@
+rust
+cargo


### PR DESCRIPTION
Adds rust from `edge` to eve-alpine, following the instructions in [ALPINE.md](https://github.com/lf-edge/eve/blob/master/docs/ALPINE.md#adding-new-packages-to-eve-alpine):

1. Found latest tag for `eve-alpine` from [Docker Hub](https://hub.docker.com/r/lfedge/eve-alpine/tags) to be `fbf39533415522ac124a2da9a695fda686adedc3`
2. Changed the `FROM` line in `pkg/alpine/Dockerfile` to use that tag
3. Added `rust` to `pkg/alpine/mirrors/edge`
4. Committed and pushed changes
5. Opened this PR 😁 

Offhand I do not recall if our pipeline automatically pushes out the updated lfedge/eve-alpine once built. 