### PR TITLE
[12.0] usbmanager: do not panic

### DIFF
--- a/pkg/pillar/cmd/usbmanager/scanusb.go
+++ b/pkg/pillar/cmd/usbmanager/scanusb.go
@@ -128,7 +128,8 @@ func ueventFile2usbDeviceImpl(ueventFilePath string, ueventFp io.Reader) *usbdev
 		if vals[0] == "BUSNUM" {
 			val64, err := strconv.ParseUint(vals[1], 10, 16)
 			if err != nil {
-				panic(err)
+				log.Warnf("could not parse BUSNUM %+v", vals)
+				return nil
 			}
 			busnum = uint16(val64)
 			busnumSet = true
@@ -136,7 +137,8 @@ func ueventFile2usbDeviceImpl(ueventFilePath string, ueventFp io.Reader) *usbdev
 		if vals[0] == "DEVNUM" {
 			val64, err := strconv.ParseUint(vals[1], 10, 16)
 			if err != nil {
-				panic(err)
+				log.Warnf("could not parse DEVNUM %+v", vals)
+				return nil
 			}
 			devnum = uint16(val64)
 			devnumSet = true


### PR DESCRIPTION
replace all panics with warnings

sometimes the kernel f.e. cannot do a readlink of a file in /sys, because it is not a symlink (e.g. bonding_masters)

Signed-off-by: Christoph Ostarek <christoph@zededa.com>
(cherry picked from commit 06ed3189bbbc5501e5aa8d46d57194cf7048cee5)