### PR TITLE
Make microservices robust against late /config/server   @eriknordmark

### DIFF
--- a/pkg/pillar/Dockerfile
+++ b/pkg/pillar/Dockerfile
@@ -149,9 +149,6 @@ COPY --from=dnsmasq /usr/sbin/dnsmasq /out/opt/zededa/bin/dnsmasq
 # to avoid conflicts and speedup re-builds
 COPY --from=build /final /out
 
-# We have to make sure configs survive in some location, but they don't pollute
-# the default /config (since that is expected to be an empty mount point)
-ADD conf/root-certificate.pem conf/server conf/server.production /out/opt/zededa/examples/config/
 ADD scripts/device-steps.sh \
     scripts/onboot.sh \
     scripts/handlezedserverconfig.sh \

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -176,9 +176,17 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	}
 	log.Functionf("processed GlobalConfig")
 
-	server, err := os.ReadFile(types.ServerFileName)
-	if err != nil {
-		log.Fatal(err)
+	var server []byte
+	for len(server) == 0 {
+		server, err = os.ReadFile(types.ServerFileName)
+		if err != nil {
+			log.Warn(err)
+			time.Sleep(10 * time.Second)
+		} else if len(server) == 0 {
+			log.Warnf("Empty %s file - waiting for it",
+				types.ServerFileName)
+			time.Sleep(10 * time.Second)
+		}
 	}
 	ctx.serverNameAndPort = strings.TrimSpace(string(server))
 	ctx.serverName = strings.Split(ctx.serverNameAndPort, ":")[0]

--- a/pkg/pillar/cmd/nim/resolvercache.go
+++ b/pkg/pillar/cmd/nim/resolvercache.go
@@ -27,12 +27,20 @@ const (
 // The cached IP address can be used with SendOnIntf function to speed up
 // controller API calls by avoiding repeated hostname resolutions.
 func (n *nim) runResolverCacheForController() {
-	content, err := os.ReadFile(types.ServerFileName)
-	if err != nil {
-		n.Log.Errorf("Failed to read %s: %v; "+
-			"will not run resolver cache for the controller hostname",
-			types.ServerFileName, err)
-		return
+	var content []byte
+	var err error
+	for len(content) == 0 {
+		content, err = os.ReadFile(types.ServerFileName)
+		if err != nil {
+			n.Log.Errorf("Failed to read %s: %v; "+
+				"waiting for it",
+				types.ServerFileName, err)
+			time.Sleep(10 * time.Second)
+		} else if len(content) == 0 {
+			n.Log.Errorf("Empty %s file - waiting for it",
+				types.ServerFileName)
+			time.Sleep(10 * time.Second)
+		}
 	}
 	controllerHostname := string(content)
 	controllerHostname = strings.TrimSpace(controllerHostname)

--- a/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
+++ b/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
@@ -134,9 +134,19 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	wscCtx.subAppInstanceConfig = subAppInstanceConfig
 
 	//get server name
-	bytes, err := os.ReadFile(types.ServerFileName)
-	if err != nil {
-		log.Fatal(err)
+	var bytes []byte
+	for len(bytes) == 0 {
+		bytes, err = os.ReadFile(types.ServerFileName)
+		if err != nil {
+			log.Error(err)
+			time.Sleep(10 * time.Second)
+			ps.StillRunning(agentName, warningTime, errorTime)
+		} else if len(bytes) == 0 {
+			log.Warnf("Empty %s file - waiting for it",
+				types.ServerFileName)
+			time.Sleep(10 * time.Second)
+			ps.StillRunning(agentName, warningTime, errorTime)
+		}
 	}
 	wscCtx.serverNameAndPort = strings.TrimSpace(string(bytes))
 

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -357,9 +357,18 @@ func initZedcloudContext(getconfigCtx *getconfigContext,
 	agentMetrics *zedcloud.AgentMetrics) *zedcloud.ZedCloudContext {
 
 	// get the server name
-	bytes, err := os.ReadFile(types.ServerFileName)
-	if err != nil {
-		log.Fatal(err)
+	var bytes []byte
+	var err error
+	for len(bytes) == 0 {
+		bytes, err = os.ReadFile(types.ServerFileName)
+		if err != nil {
+			log.Error(err)
+			time.Sleep(10 * time.Second)
+		} else if len(bytes) == 0 {
+			log.Warnf("Empty %s file - waiting for it",
+				types.ServerFileName)
+			time.Sleep(10 * time.Second)
+		}
 	}
 	serverNameAndPort = strings.TrimSpace(string(bytes))
 

--- a/pkg/pillar/conntester/zedcloud.go
+++ b/pkg/pillar/conntester/zedcloud.go
@@ -51,7 +51,10 @@ func (t *ZedcloudConnectivityTester) TestConnectivity(dns types.DeviceNetworkSta
 
 	server, err := os.ReadFile(types.ServerFileName)
 	if err != nil {
-		t.Log.Fatal(err)
+		t.Log.Error(err)
+		// XXX should we return an indicating that the intf is unknown
+		// and not failed?
+		return intfStatusMap, nil, err
 	}
 	serverNameAndPort := strings.TrimSpace(string(server))
 

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -447,10 +447,10 @@ if [ ! -s "$DEVICE_CERT_NAME" ]; then
 else
     echo "$(date -Ins -u) Using existing device key pair"
 fi
-if [ ! -s $CONFIGDIR/server ] || [ ! -s $CONFIGDIR/root-certificate.pem ]; then
-    echo "$(date -Ins -u) No server or root-certificate to connect to. Done" | tee /dev/console
-    exit 0
-fi
+while [ ! -s $CONFIGDIR/server ] || [ ! -s $CONFIGDIR/root-certificate.pem ]; do
+    echo "$(date -Ins -u) No server or root-certificate to connect to. Wait for them" | tee /dev/console
+    sleep 10
+done
 
 if [ -c $TPM_DEVICE_PATH ] && ! [ -f $DEVICE_KEY_NAME ]; then
     echo "$(date -Ins -u) device-steps: TPM device, creating additional security certificates"


### PR DESCRIPTION
This is a set of fixes which were used to enable the FDO demo in #3859, but they are useful if we have other cases where /config/server and/or /config/root-certificate.pem are initially missing and are added (e.g., using some config tool) during the first boot since the fixes makes sure that the microservices do not exit or fail but wait for these files to appear.