### PR TITLE
Add kernel tag to ROOTFS_VERSION if KERNEL_TAG is provided

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,10 @@ endif
 # set this to the current tag only if we are building from a tag
 ROOTFS_VERSION:=$(if $(findstring snapshot,$(REPO_TAG)),$(EVE_SNAPSHOT_VERSION)-$(REPO_BRANCH)-$(REPO_SHA)$(REPO_DIRTY_TAG)$(DEV_TAG),$(REPO_TAG))
 
+#if KERNEL_TAG is set, append it to the ROOTFS_VERSION but replace docker.io/lfedge/eve-kernel:eve-kernel- part with k-
+SHORT_KERNEL_TAG=$(subst docker.io/lfedge/eve-kernel:eve-kernel-,k-,$(KERNEL_TAG))
+ROOTFS_VERSION:=$(if $(SHORT_KERNEL_TAG),$(ROOTFS_VERSION)-$(SHORT_KERNEL_TAG),$(ROOTFS_VERSION))
+
 HOSTARCH:=$(subst aarch64,arm64,$(subst x86_64,amd64,$(shell uname -m)))
 # by default, take the host architecture as the target architecture, but can override with `make ZARCH=foo`
 #    assuming that the toolchain supports it, of course...


### PR DESCRIPTION
When building EVE with custome kernel i.e. make KERNEL_TAG=... rootfs version doesn’t take it into account and it may be really confusing especially when building from a tag. E.g. when building from 12.0.3-lts tag EVE version will be set to 12.0.3-lts and so

- it looks like an official image but it is not
- if the image is uploaded to cloud the official image with the same tag cannot be uploaded anymore

**QUESTION:** the only concern I have is a length of version string **on cloud side**. Is there any limit?