### PR TITLE
add PROGRAM parameter to eve-enter-container

### DIFF
--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -153,7 +153,7 @@ In order to attach to the console of the hosting Vm of the Container application
 
 The `prime-cons` console exists only for the Container applications and is always reachable for executing commands on the Vm which hosts corresponding container.
 
-Once terminal responds on the `prime-cons` console it is possible to enter container by executing the `eve-enter-container` command:
+Once terminal responds on the `prime-cons` console it is possible to enter container by executing the `eve-enter-container` command. The script takes an optional argument with the path to the program to run in the container (the path is relative to the root of the container filesystem). If no argument is provided, the script will try to call the shell (`/bin/sh`) in the container:
 
 ```bash
 ~ # eve-enter-container

--- a/pkg/xen-tools/initrd/eve-enter-container
+++ b/pkg/xen-tools/initrd/eve-enter-container
@@ -10,4 +10,12 @@ if [ ! -f "$PID_FILE" ]; then
 fi
 
 PID=$(cat "$PID_FILE")
-nsenter -t "$PID" -m -u -i -n -p -r/mnt/rootfs -w/mnt/rootfs
+
+# Check if the first argument is provided, otherwise use /bin/sh as the default
+PROGRAM=${1:-/bin/sh}
+
+# Shift arguments if a program is provided, so "$@" contains the rest of the command-line arguments
+shift
+
+# Enter the namespaces and execute the specified program with its arguments
+nsenter -t "$PID" -m -u -i -n -p -r/mnt/rootfs -w/mnt/rootfs "$PROGRAM" "$@"


### PR DESCRIPTION
The script eve-enter-container calls internally nsenter, which defaults to calling $(SHELL) if no PROGRAM parameter is provided. And since the shim VM is built from alpine image, the default shell is /bin/ash. So unless the container running in the shim VM is also based on alpine, it won't have /bin/ash and the script will fail.

This commit adds a PROGRAM parameter to the script, so that the user can specify the shell (or another program) to be used when entering the container. If the parameter is not provided, the default is /bin/sh.