### PR TITLE
Fix cgroup name mismatches and add missing services

### DIFF
--- a/pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup
+++ b/pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup
@@ -9,7 +9,7 @@ hv=`cat /run/eve-hv-type`
 default_cgroup_cpus_limit=1
 
 default_cgroup_memory_limit=838860800 #800M
-EVESERVICES="sshd edgeview wwan wlan lisp guacd pillar vtpm watchdog xen-tools newlogd memlogd"
+EVESERVICES="sshd eve-edgeview wwan wlan lisp guacd pillar vtpm watchdog xen-tools newlogd memlogd"
 
 #Increase memory limits temporarily for kubevirt type only.
 case $hv in

--- a/pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup
+++ b/pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup
@@ -9,7 +9,7 @@ hv=`cat /run/eve-hv-type`
 default_cgroup_cpus_limit=1
 
 default_cgroup_memory_limit=838860800 #800M
-EVESERVICES="sshd eve-edgeview wwan wlan lisp guacd pillar vtpm watchdog xen-tools newlogd memlogd memory-monitor"
+EVESERVICES="sshd eve-edgeview wwan wlan lisp guacd pillar vtpm watchdog xen-tools newlogd memlogd memory-monitor debug"
 
 #Increase memory limits temporarily for kubevirt type only.
 case $hv in

--- a/pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup
+++ b/pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup
@@ -9,7 +9,7 @@ hv=`cat /run/eve-hv-type`
 default_cgroup_cpus_limit=1
 
 default_cgroup_memory_limit=838860800 #800M
-EVESERVICES="sshd eve-edgeview wwan wlan lisp guacd pillar vtpm watchdog xen-tools newlogd memlogd"
+EVESERVICES="sshd eve-edgeview wwan wlan lisp guacd pillar vtpm watchdog xen-tools newlogd memlogd memory-monitor"
 
 #Increase memory limits temporarily for kubevirt type only.
 case $hv in

--- a/pkg/memory-monitor/README.md
+++ b/pkg/memory-monitor/README.md
@@ -12,27 +12,19 @@ So, a usual memory hierarchy in the EVE system looks like this:
 ```shell
 $ tree /sys/fs/cgroup/memory/eve -d
 /sys/fs/cgroup/memory/eve <--- is set from dom0_mem kernel argument, usually 800Mb (or 8GB for ZFS)
-├── containerd
+├── containerd <-------------- is set from ctrd_mem kernel argument, usually 400Mb
 └── services <---------------- is set from eve_mem kernel argument, usually 650Mb
-    ├── debug
-    ├── edgeview
-    ├── eve-edgeview
-    ├── guacd
-    ├── lisp
-    ├── memlogd
-    ├── newlogd
+    ├── <some services>
     ├── pillar <-------------- is set from eve_mem kernel argument, usually 650Mb
-    ├── sshd
-    ├── vtpm
-    ├── watchdog
-    ├── wlan
-    ├── wwan
+    ├── <some other services>
     └── xen-tools
 ```
 
-These limits are set within `pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup` script.
-The "eve" cgroup limit is set according to the `dom0_mem` kernel argument, and
-the "pillar" cgroup limit is set according the `eve_mem` kernel argument.
+These limits are set within `pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup`
+script. The "eve" cgroup limit is set according to the `dom0_mem` kernel
+argument, and the "pillar" cgroup (along with the parent "services" cgroup
+and all other sub-cgroups of "services" cgroup) limit is set according the
+`eve_mem` kernel argument.
 
 In its turn, the "pillar" cgroup encapsulates several processes, the most
 important of which is `zedbox`:


### PR DESCRIPTION
This PR addresses discrepancies between cgroup names used in the 010-eve-cgroup initialization script and the service configuration files. These mismatches have led to certain memory limits not being applied correctly to specific services. The changes included in this PR ensure consistency across service names in the cgroup settings and service configurations, thereby fixing the memory limit application issue.

There were three main issues identified:

* EdgeView Service Name Mismatch: The edgeview service was using a different name in the cgroup settings and service configuration files, leading to incorrect cgroup paths and, subsequently, memory limits not being applied.
* Debug Service Omission: The debug service was not listed in the EVESERVICES array in the 010-eve-cgroup initialization script, which caused it to bypass the regular EVE cgroup memory limit.
* Memory-Monitor Service Omission: Similar to the debug service, the memory-monitor service was also missing from the EVESERVICES array, leading to it not being assigned the appropriate memory limit.