### PR TITLE
Add GH Action to check SPDX license headers in new files.

### DIFF
--- a/.github/workflows/spdx.yml
+++ b/.github/workflows/spdx.yml
@@ -1,0 +1,35 @@
+# Copyright (c) 2024, Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+---
+name: Check SPDX License Headers
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - "master"
+      - "[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+-stable"
+  pull_request:
+    branches:
+      - "master"
+      - "[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+-stable"
+
+jobs:
+  spdx-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref }}
+          fetch-depth: 0
+
+      - name: Fetch the PR's head ref
+        run: |
+          git fetch origin ${{ github.event.pull_request.head.sha }}:${{ github.event.pull_request.head.ref }}
+          git checkout ${{ github.event.pull_request.head.ref }}
+
+      - name: Run SPDX check
+        run: |
+          ./tools/spdx-check.sh ${{ github.event.pull_request.base.sha }}

--- a/tools/spdx-check.sh
+++ b/tools/spdx-check.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Copyright (c) 2024 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+BASE_COMMIT=$1
+
+# List of files to check, excluding vendor directories
+files=$(git diff --name-only --diff-filter=A "${BASE_COMMIT}"..HEAD | grep -v "vendor/")
+
+# SPDX License Identifier to check for
+license_identifier="SPDX-License-Identifier: Apache-2.0"
+
+# Array of file extensions to check for SPDX header
+file_extensions=("sh" "c" "h" "go" "py" "rs" "yaml" "yml" "proto")
+file_names=("Dockerfile" "Dockerfile.in" "Makefile")
+
+# Flag to check if all files contain the SPDX header
+all_files_contain_spdx=true
+
+# Loop through the files and check for the SPDX header
+for file in $files; do
+  echo "Checking $file"
+  # Get the file extension
+  file_extension="${file##*.}"
+
+  # Check if the file is a source file that should have a license header
+  for ext in "${file_extensions[@]}"; do
+    if [[ "$file_extension" == "$ext" ]]; then
+      # Check if the file contains the SPDX identifier
+      if ! grep -q "$license_identifier" "$file"; then
+        all_files_contain_spdx=false
+        echo "Missing SPDX-License-Identifier in $file"
+      fi
+      break
+    fi
+  done
+  for name in "${file_names[@]}"; do
+    if [[ "$file" == "$name" ]]; then
+      # Check if the file contains the SPDX identifier
+      if ! grep -q "$license_identifier" "$file"; then
+        all_files_contain_spdx=false
+        echo "Missing SPDX-License-Identifier in $file"
+      fi
+      break
+    fi
+  done
+done
+
+if [ "$all_files_contain_spdx" = true ]; then
+  echo "All files contain SPDX-License-Identifier."
+  exit 0
+else
+  exit 1
+fi


### PR DESCRIPTION
- Created a workflow to automatically check for SPDX license headers in new files when a PR is opened or changes are pushed to `master` or version-stable branches.
- Added `tools/spdx-check.sh` script that scans new files with specific extensions and certain filenames for the `SPDX-License-Identifier` header.
- The script excludes files in `vendor/` directories from the check.
- The workflow will fail if any of the new files are missing the required SPDX license header.