### PR TITLE
Fix get-deps tool to handle non LinuxKit containers

### DIFF
--- a/tools/get-deps/main.go
+++ b/tools/get-deps/main.go
@@ -199,13 +199,18 @@ func filterPkg(deps []string) []string {
 	var depList []string
 	dpList := make(map[string]bool)
 
-	reLF  := regexp.MustCompile("lfedge/.*")
+	reLF := regexp.MustCompile("lfedge/.*")
 	rePkg := regexp.MustCompile("lfedge/(?:eve-)?(.*):.*")
 	for _, s := range deps {
 		// We are just interested on packages from lfegde (those that we
 		// published)
 		if reLF.MatchString(s) {
 			str := rePkg.ReplaceAllString(s, "pkg/$1")
+			// Check that the directory ./pkg/$1 exists.
+			// It doesn't exist for lfedge packages outside eve source tree e.g. eve-rust
+			if _, err := os.Stat(str); err != nil {
+				continue
+			}
 			if !dpList[str] {
 				dpList[str] = true
 				depList = append(depList, str)

--- a/tools/get-deps/main_test.go
+++ b/tools/get-deps/main_test.go
@@ -1,15 +1,49 @@
 package main
 
 import (
+	"os"
+	"sort"
 	"strings"
 	"testing"
 )
 
 func TestParseDockerfile(t *testing.T) {
+	targets := readDockerFile()
+
+	expected := map[string]bool{
+		"abcd:12345": false,
+		"f":          false,
+		"f-amd64":    false,
+		"lfedge/eve-alpine:1f7685f95a475c6bbe682f0b976f121":       false,
+		"lfedge/eve-alpine:1f7685f95a475c6bbe682f0b976f121-amd64": false,
+		"lfedge/eve-rust:1.80.1":                                  false,
+		"lfedge/eve-xen-tools:":                                   false,
+	}
+
+	for _, target := range targets {
+		expected[target] = true
+	}
+
+	if len(expected) != len(targets) {
+		t.Fatalf("expected %d, got %d", len(expected), len(targets))
+	}
+
+	for target, found := range expected {
+		if !found {
+			t.Fatalf("did not find target %s", target)
+		}
+	}
+}
+
+func readDockerFile() []string {
 	f := strings.NewReader(`
 			FROM abcd:12345 AS f
 			RUN echo \
 			FROM thisshouldnotbeincluded:666666
+			FROM lfedge/eve-alpine:1f7685f95a475c6bbe682f0b976f121
+			FROM lfedge/eve-alpine:1f7685f95a475c6bbe682f0b976f121-amd64
+			FROM lfedge/eve-rust:1.80.1
+			FROM lfedge/eve-xen-tools:$XENTOOLS
 
 			FROM f
 			RUN echo
@@ -18,20 +52,30 @@ func TestParseDockerfile(t *testing.T) {
 		`)
 
 	targets := parseDockerfile(f)
+	return targets
+}
 
-	foundMap := map[string]bool{
-		"abcd:12345": false,
-		"f":          false,
-		"f-amd64":    false,
+func TestNoneLinuxKitImage(t *testing.T) {
+	// set current directory to ../..
+	// so that we can find ./pkg/xxx
+	if os.Chdir("../..") != nil {
+		t.Fatalf("could not change working directory")
 	}
 
-	for _, target := range targets {
-		foundMap[target] = true
+	targets := readDockerFile()
+	filtered := filterPkg(targets)
+	sort.Strings(filtered)
+
+	expected := []string{"pkg/alpine", "pkg/xen-tools"}
+	sort.Strings(expected)
+
+	if len(filtered) != len(expected) {
+		t.Fatalf("expected %d, got %d [%v, %v]", len(expected), len(filtered), expected, filtered)
 	}
 
-	for target, found := range foundMap {
-		if !found {
-			t.Fatalf("did not find target %s", target)
+	for i, target := range filtered {
+		if target != expected[i] {
+			t.Fatalf("expected %s, got %s", expected[i], target)
 		}
 	}
 }


### PR DESCRIPTION
The tool assumed that all lfedge/<name>... docker images are LinuxKit images and there must be pkg/<name> directory which it not true for e.g. eve-rust container `lfedge/eve-rust:1.80.1` Improve version parsing algorithm

@jsfakian I think you also need this PR