### PR TITLE
kernel: Bump kernel for NVIDIA Platforms

### DIFF
--- a/kernel-commits.mk
+++ b/kernel-commits.mk
@@ -3,6 +3,7 @@ KERNEL_COMMIT_amd64_v6.1.38_generic = 8859f43ee8c9
 KERNEL_COMMIT_amd64_v6.1.38_rt = 37bc37278441
 KERNEL_COMMIT_amd64_v6.1.68_generic = 45e0ac394428
 KERNEL_COMMIT_arm64_v5.10.104_nvidia = 7b9a55e0b659
+KERNEL_COMMIT_arm64_v5.10.192_nvidia = c2b4176f82b1
 KERNEL_COMMIT_arm64_v5.10.186_generic = 804663a82829
 KERNEL_COMMIT_arm64_v6.1.38_generic = acbfadebeb76
 KERNEL_COMMIT_riscv64_v6.1.38_generic = 2dbca8568caf

--- a/kernel-version.mk
+++ b/kernel-version.mk
@@ -36,7 +36,7 @@ ifeq ($(ZARCH), amd64)
 else ifeq ($(ZARCH), arm64)
     ifeq ($(PLATFORM), nvidia)
         KERNEL_FLAVOR=nvidia
-        KERNEL_VERSION=v5.10.104
+        KERNEL_VERSION=v5.10.192
     else
         KERNEL_FLAVOR=generic
         KERNEL_VERSION=v6.1.38


### PR DESCRIPTION
This commit bumps the kernel version for NVIDIA Platforms. The new kernel (EVE's custom kernel) is based on the Jetson Linux 3.5.50, from Jetpack 5.1.3. The following devices are supported by this version:

* Jetson Xavier NX
* Jetson AGX Orin
* Jetson AGX Orin Industrial
* Jetson Orin NX / Orin Nano
* Jetson AGX Xavier
* Jetson AGX Xavier Industrial

Kernel version bumps from 5.10.104 to 5.10.192.

For more information see:

* https://github.com/lf-edge/eve-kernel
* https://developer.nvidia.com/embedded/jetson-linux-r3550