### PR TITLE
Fix cmdline options for newer NVIDIA kernel and add Jetson Orin Nano Developer Kit to GRUB options

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -297,21 +297,23 @@ function set_arm64_baremetal {
           if regexp -- "699-13668-0001-.*" "$asset_tag"; then
               set_to_existing_file devicetree /boot/dtb/nvidia/tegra194-siemens-ipc520a.dtb
               set_global dom0_console "console=tty0 earlycon=tty0"
-              set_global dom0_platform_tweaks "fbcon=map:0 pci=noaer usbcore.warm_reset_workaround=1 eve_nuke_disks=mmcblk0 eve_install_disk=nvme0n1"
+              set_global dom0_platform_tweaks "fbcon=map:0 video=efifb:off pci=noaer usbcore.warm_reset_workaround=1 eve_nuke_disks=mmcblk0 eve_install_disk=nvme0n1"
           else
               set_to_existing_file devicetree /boot/dtb/nvidia/tegra194-p3668-0001-p3509-0000.dtb
               set_global dom0_console "console=tty0 earlycon=tty0"
+              set_global dom0_platform_tweaks "video=efifb:off"
           fi
       else
           set_to_existing_file devicetree /boot/dtb/nvidia/tegra194-p3668-0000-p3509-0000.dtb
           set_global dom0_console "console=ttyTCU0,115200 console=tty0 earlycon=ttyTCU0,115200"
+          set_global dom0_platform_tweaks "video=efifb:off"
       fi
    fi
    # Lenovo ThinkEdge SE70 (Jetson Xavier NX platform)
    if [ "$smb_product" = "ThinkEdge SE70 (NVIDIA Jetson Xavier NX)" ]; then
       set_to_existing_file devicetree /boot/dtb/nvidia/tegra194-p3668-0001-p3509-0000-lenovo-se70.dtb
       set_global dom0_console "console=tty0 earlycon=tty0"
-      set_global dom0_platform_tweaks "fbcon=map:0 eve_nuke_disks=mmcblk0 eve_install_disk=nvme0n1"
+      set_global dom0_platform_tweaks "fbcon=map:0 eve_nuke_disks=mmcblk0 eve_install_disk=nvme0n1 video=efifb:off"
    fi
 }
 

--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -315,6 +315,12 @@ function set_arm64_baremetal {
       set_global dom0_console "console=tty0 earlycon=tty0"
       set_global dom0_platform_tweaks "fbcon=map:0 eve_nuke_disks=mmcblk0 eve_install_disk=nvme0n1 video=efifb:off"
    fi
+   # Jetson Orin Nano Developer Kit
+   if [ "$smb_product" = "NVIDIA Orin Nano Developer Kit" ]; then
+      set_to_existing_file devicetree /boot/dtb/nvidia/tegra234-p3767-0003-p3768-0000-a0.dtb
+      set_global dom0_console "console=ttyAMA0,115200 console=tty0 console=ttyTCU0,115200 earlycon=ttyTCU0,115200"
+      set_global dom0_platform_tweaks "fbcon=map:0 video=efifb:off nospectre_bhb"
+   fi
 }
 
 function set_arm64_qemu {


### PR DESCRIPTION
## Description
This PR remove the EFI framebuffer setup of NVIDIA Jetson devices (framebuffer is supported by native driver) and adds the device tree loading for the Jetson Orin Nano Developer Kit to GRUB configuration file.

## Dependencies
PR https://github.com/lf-edge/eve/pull/4170 