### PR TITLE
pillar: containerd: Do not add hooks when no interfaces are configured

### DIFF
--- a/pkg/pillar/containerd/oci.go
+++ b/pkg/pillar/containerd/oci.go
@@ -286,8 +286,9 @@ func (s *ociSpec) AdjustMemLimit(dom types.DomainConfig, addMemory int64) {
 
 // UpdateVifList creates VIF management hooks in OCI spec
 func (s *ociSpec) UpdateVifList(vifs []types.VifConfig) {
-	if s.service {
-		// we do not want to hook network for service
+	if s.service || len(vifs) == 0 {
+		// we do not want to hook network for service or for containers
+		// without any virtual interface
 		return
 	}
 	// use pre-start and post-stop hooks for networking


### PR DESCRIPTION
The hooks for veth.sh and dhcpcd scripts don't need to be added to OCI spec when no network interfaces are configured for the container.

This will be required for bare-metal container Edge Applications.