### PR TITLE
newer version of linuxkit/init with more debugging options

### DIFF
--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -3,7 +3,7 @@ kernel:
   # the unified_cgroup_hierarchy forces cgroupsv1, which is required until pillar is ready to support v2
   cmdline: "rootdelay=3 linuxkit.unified_cgroup_hierarchy=0"
 init:
-  - linuxkit/init:e6f99bdda1628d47f59dab20c85794b4ea6fad95
+  - linuxkit/init:e120ea2a30d906bd1ee1874973d6e4b1403b5ca3
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   # pillar's logic rely on existence of getty and /etc/init.d/001-getty inside


### PR DESCRIPTION
The previous PR #4161 bumped `linuxkit/init` to a version that has extra cmdline debugging support via `linuxkit.runc_debug=1`. This is a slight improvement, in that it controls debugging via `runc_debug=1`, while enabling console output to be controlled separately via `linuxkit.runc_console=1`.

More importantly, the previous version, when in debug mode, tried to write to both console and file simultaneously, which made runc quite unhappy and made things hang. This fixes that.

I expect no functional changes here. If CI is green, it should be good to go.