### PR TITLE
[backport 12.0-stable] Fix cgroup name mismatches and add missing service

### DIFF
--- a/pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup
+++ b/pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup
@@ -9,7 +9,7 @@ hv=`cat /run/eve-hv-type`
 default_cgroup_cpus_limit=1
 
 default_cgroup_memory_limit=838860800 #800M
-EVESERVICES="sshd edgeview wwan wlan lisp guacd pillar vtpm watchdog xen-tools newlogd memlogd"
+EVESERVICES="sshd eve-edgeview wwan wlan lisp guacd pillar vtpm watchdog xen-tools newlogd memlogd"
 
 #Increase memory limits temporarily for kubevirt type only.
 case $hv in

--- a/pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup
+++ b/pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup
@@ -9,7 +9,7 @@ hv=`cat /run/eve-hv-type`
 default_cgroup_cpus_limit=1
 
 default_cgroup_memory_limit=838860800 #800M
-EVESERVICES="sshd eve-edgeview wwan wlan lisp guacd pillar vtpm watchdog xen-tools newlogd memlogd"
+EVESERVICES="sshd eve-edgeview wwan wlan lisp guacd pillar vtpm watchdog xen-tools newlogd memlogd debug"
 
 #Increase memory limits temporarily for kubevirt type only.
 case $hv in


### PR DESCRIPTION
This PR is a backport of PR #4165.

The commits related to the memory-monitor tool were not cherry-picked as the tool had not yet been introduced in 12.0.