### PR TITLE
[backport 10.4-stable] Fix cgroup name mismatches and add missing service

### DIFF
--- a/pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup
+++ b/pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup
@@ -12,11 +12,11 @@ default_cgroup_cpus_limit=1
 case $hv in
    kubevirt)
             default_cgroup_memory_limit=8388608000 #8G
-            EVESERVICES="sshd eve-edgeview wwan wlan lisp guacd pillar vtpm watchdog xen-tools newlogd kube "
+            EVESERVICES="sshd eve-edgeview wwan wlan lisp guacd pillar vtpm watchdog xen-tools newlogd kube debug "
             ;;
           *)
             default_cgroup_memory_limit=838860800 #800M
-            EVESERVICES="sshd eve-edgeview wwan wlan lisp guacd pillar vtpm watchdog xen-tools newlogd "
+            EVESERVICES="sshd eve-edgeview wwan wlan lisp guacd pillar vtpm watchdog xen-tools newlogd debug "
             ;;
 esac
 

--- a/pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup
+++ b/pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup
@@ -12,11 +12,11 @@ default_cgroup_cpus_limit=1
 case $hv in
    kubevirt)
             default_cgroup_memory_limit=8388608000 #8G
-            EVESERVICES="sshd edgeview wwan wlan lisp guacd pillar vtpm watchdog xen-tools newlogd kube "
+            EVESERVICES="sshd eve-edgeview wwan wlan lisp guacd pillar vtpm watchdog xen-tools newlogd kube "
             ;;
           *)
             default_cgroup_memory_limit=838860800 #800M
-            EVESERVICES="sshd edgeview wwan wlan lisp guacd pillar vtpm watchdog xen-tools newlogd "
+            EVESERVICES="sshd eve-edgeview wwan wlan lisp guacd pillar vtpm watchdog xen-tools newlogd "
             ;;
 esac
 


### PR DESCRIPTION
This PR is a backport of PR https://github.com/lf-edge/eve/pull/4165.

The commits related to the memory-monitor tool were not cherry-picked as the tool had not yet been introduced in 10.4.