### PR TITLE
dom0-ztools: rootfs: Enable Container Device Interface

### DIFF
--- a/pkg/dom0-ztools/Dockerfile
+++ b/pkg/dom0-ztools/Dockerfile
@@ -39,6 +39,9 @@ RUN rm -rf /tmp/zfs-out/usr/share && rm -rf /tmp/zfs-out/usr/src && \
 RUN find /tmp/zfs-out -mindepth 1|sed 's@/tmp/zfs-out@@'>/out/etc/zfs-files
 RUN cp -r /tmp/zfs-out/* /out
 
+# Add directory for CDI files
+RUN mkdir -p /out/etc/cdi
+
 FROM scratch
 COPY --from=zfs /out/ /
 # hadolint ignore=DL3020

--- a/pkg/dom0-ztools/rootfs/etc/cni/net.d/lo.conf
+++ b/pkg/dom0-ztools/rootfs/etc/cni/net.d/lo.conf
@@ -1,0 +1,5 @@
+{
+       "cniVersion": "0.2.0",
+       "name": "lo",
+       "type": "loopback"
+}

--- a/pkg/dom0-ztools/rootfs/etc/containerd/config.toml
+++ b/pkg/dom0-ztools/rootfs/etc/containerd/config.toml
@@ -2,13 +2,20 @@ version = 2
 state = "/run/containerd"
 root = "/persist/containerd-system-root"
 disabled_plugins = [
-    "io.containerd.grpc.v1.cri",
     "io.containerd.snapshotter.v1.btrfs",
     "io.containerd.snapshotter.v1.aufs",
     "io.containerd.internal.v1.opt",
     "io.containerd.internal.v1.tracing",
     "io.containerd.tracing.processor.v1.otlp"
 ]
+
+[plugins]
+  [plugins."io.containerd.grpc.v1.cri"]
+    enable_cdi = true
+    cdi_spec_dirs = ["/etc/cdi"]
+
+  [plugins."io.containerd.grpc.v1.cri".cni]
+    max_conf_num = 1
 
 [grpc]
   address = "/run/containerd/containerd.sock"


### PR DESCRIPTION
- Enable CDI plugin in order to allow native containers to access devices specified by CDI spec.

- Add a default loopback network configuration otherwise the plugin will throw an error during initialization.