### PR TITLE
 Clarify commit message guidelines and improve error messages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,9 +93,13 @@ the first try, don't get discouraged!
 
 ### Commit Messages
 
-Commit messages must start with a capitalized and short summary (max. 50 chars)
-written in the imperative, followed by an optional, more detailed explanatory
-text which is separated from the summary by an empty line.
+Each commit message includes a subject and a body, separated by an empty line.
+The subject should be a brief summary of the changes, and the body should
+provide a more detailed explanation. The body must start with a capital letter.
+Additionally, each commit message must include a "Signed-off-by" line at the
+end, certifying that the contributor has the right to submit the patch under the
+open-source license. This line can be automatically added by using the `-s` flag
+with the `git commit` command.
 
 Commit messages should follow best practices, including explaining the context
 of the problem and how it was solved, including in caveats or follow up changes

--- a/tools/check-commit-messages/check_commit_messages.py
+++ b/tools/check-commit-messages/check_commit_messages.py
@@ -40,7 +40,7 @@ def check_commit_message(commit):
     body_lines = [line for line in body_lines if not line.lower().startswith("signed-off-by")]
 
     if not body_lines:
-        return False, f"Commit {commit.hexsha} has a body but only contains Signed-off-by."
+        return False, f"Commit {commit.hexsha} has no body."
 
     # Check if the body starts with a capital letter
     if not body_lines[0][0].isupper():
@@ -70,6 +70,9 @@ def main():
         valid, error_message = check_commit_message(commit)
         if not valid:
             print(error_message)
+            print(f"Commit message:\n{'-'*72}\n{commit.message}{'-'*72}")
+            print("For more details, see: "
+            "https://github.com/lf-edge/eve/blob/master/CONTRIBUTING.md#commit-messages")
             sys.exit(1)
 
     print("All commits are valid.")


### PR DESCRIPTION
This PR includes the following changes:

Update commit message guidelines in CONTRIBUTING.md: Revised the commit message section to provide clearer instructions. Each commit message now includes a subject and a body, separated by an empty line. The body must start with a capital letter and include a "Signed-off-by" line at the end.

Clarify error message in check_commit_messages.py: Updated the script to provide more detailed error messages when a commit has no body. Added a link to the CONTRIBUTING.md file for more information on commit message guidelines.