### PR TITLE
Enhance SPDX check script with ignoring mechanism and improved flexibility

### DIFF
--- a/.spdxignore
+++ b/.spdxignore
@@ -1,0 +1,9 @@
+pkg/edgeview/vendor/
+pkg/kube/eve-bridge/vendor/
+pkg/measure-config/vendor/
+pkg/newlog/vendor/
+pkg/pillar/vendor/
+pkg/rngd/cmd/rngd/vendor/
+pkg/wwan/mmagent/vendor/
+pkg/recovertpm/src/vendor/
+tools/get-deps/vendor/

--- a/tools/spdx-check.sh
+++ b/tools/spdx-check.sh
@@ -12,39 +12,61 @@ files=$(git diff --name-only --diff-filter=A "${BASE_COMMIT}"..HEAD | grep -v "v
 license_identifier="SPDX-License-Identifier: Apache-2.0"
 
 # Array of file extensions to check for SPDX header
-file_extensions=("sh" "c" "h" "go" "py" "rs" "yaml" "yml" "proto")
-file_names=("Dockerfile" "Dockerfile.in" "Makefile")
+file_extensions=(
+  "sh"
+  "c" "h"
+  "go"
+  "py"
+  "rs"
+  "yaml" "yml"
+  "proto"
+)
+
+# Array of file names to check for SPDX header
+file_names=(
+  "Dockerfile" "Dockerfile.in"
+  "Makefile"
+)
 
 # Flag to check if all files contain the SPDX header
 all_files_contain_spdx=true
 
-# Loop through the files and check for the SPDX header
-for file in $files; do
-  echo "Checking $file"
-  # Get the file extension
-  file_extension="${file##*.}"
+check_spdx() {
+  local file="$1"
+  # Check if the file contains the SPDX identifier
+  if ! grep -q -i "$license_identifier" "$file"; then
+    return 1
+  fi
+  return 0
+}
 
+file_to_be_checked() {
+  local file="$1"
   # Check if the file is a source file that should have a license header
   for ext in "${file_extensions[@]}"; do
-    if [[ "$file_extension" == "$ext" ]]; then
-      # Check if the file contains the SPDX identifier
-      if ! grep -q "$license_identifier" "$file"; then
-        all_files_contain_spdx=false
-        echo "Missing SPDX-License-Identifier in $file"
-      fi
-      break
+    if [[ "$file" == *.$ext ]]; then
+      return 0
     fi
   done
   for name in "${file_names[@]}"; do
-    if [[ "$file" == "$name" ]]; then
-      # Check if the file contains the SPDX identifier
-      if ! grep -q "$license_identifier" "$file"; then
-        all_files_contain_spdx=false
-        echo "Missing SPDX-License-Identifier in $file"
-      fi
-      break
+    if [[ "$1" == "$name" ]]; then
+      return 0
     fi
   done
+  return 1
+}
+
+# Loop through the files and check for the SPDX header
+for file in $files; do
+  if file_to_be_checked "$file"; then
+    echo -n "Checking $file ..."
+    if ! check_spdx "$file"; then
+      echo " missing SPDX-License-Identifier."
+      all_files_contain_spdx=false
+    else
+      echo " OK"
+    fi
+  fi
 done
 
 if [ "$all_files_contain_spdx" = true ]; then


### PR DESCRIPTION
This pull request focuses on enhancing the `spdx-check.sh` script by introducing an ignoring mechanism. This new feature allows the script to skip specific files or patterns, providing more control over which files are subjected to SPDX license checks. Additionally, the script has been refactored to improve maintainability and support for multiple Apache-2.0 compatible SPDX license identifiers.