### PR TITLE
update_kernel_commits.py: mke automated commit msg

### DIFF
--- a/tools/update_kernel_commits.py
+++ b/tools/update_kernel_commits.py
@@ -217,7 +217,7 @@ def generate_commit_message(branches, repo_owner, repo_name, verbose=False):
         commit_message += "\n"
 
     arch_list = f"[{', '.join(get_short_arch_flavor(branch) for branch in branches)}]"
-    commit_subject = f"Kernel update - {arch_list}\n\n"
+    commit_subject = f"Kernel update - {arch_list}\n\nThis commit changes:\n"
 
     commit_message = commit_subject + commit_message
     return commit_message


### PR DESCRIPTION
The commit message generated by this script should conform to our commit style - i.e. it should start with a capital letter.

https://github.com/lf-edge/eve/blob/master/CONTRIBUTING.md#commit-messages