### PR TITLE
pillar/agentlog: Improve debug information in PSI-collector test.

### DIFF
--- a/pkg/pillar/agentlog/agentlog_test.go
+++ b/pkg/pillar/agentlog/agentlog_test.go
@@ -1078,7 +1078,7 @@ func TestManageStatFileSizeTargetSizesAvgThreshold(t *testing.T) {
 	assert.NotEqual(t, avgSize, 0)
 
 	duration := timeEnd.Sub(timeStart)
-	assert.True(t, duration < 1*time.Second)
+	assert.Truef(t, duration < 1*time.Second, "expected duration to be less than 1 second, but got %v", duration)
 	t.Logf("Duration: %v", duration)
 	t.Logf("AvgSize: %v", avgSize)
 


### PR DESCRIPTION
Use `assert.Truef` to provide a detailed error message on failure. Without the message, the error was unclear as it just indicated the boolean expression evaluated to false.