### PR TITLE
hypervisor/kvm.go: drop QEMU "mem-lock=on" and "cpu-pm=on" for ARM

### DIFF
--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -463,13 +463,12 @@ func newKvm() Hypervisor {
 			ctrdContext:  *ctrdCtx,
 			devicemodel:  "virt",
 			dmExec:       "/usr/lib/xen/bin/qemu-system-aarch64",
-			dmArgs:       []string{"-display", "none", "-S", "-no-user-config", "-nodefaults", "-no-shutdown", "-overcommit", "mem-lock=on", "-overcommit", "cpu-pm=on", "-serial", "chardev:charserial0"},
+			dmArgs:       []string{"-display", "none", "-S", "-no-user-config", "-nodefaults", "-no-shutdown", "-serial", "chardev:charserial0"},
 			dmCPUArgs:    []string{"-cpu", "host"},
 			dmFmlCPUArgs: []string{"-cpu", "host"},
 		}
 	case "amd64":
 		return KvmContext{
-			//nolint:godox // FIXME: Removing "-overcommit", "mem-lock=on", "-overcommit" for now, revisit it later as part of resource partitioning
 			ctrdContext:  *ctrdCtx,
 			devicemodel:  "pc-q35-3.1",
 			dmExec:       "/usr/lib/xen/bin/qemu-system-x86_64",


### PR DESCRIPTION
Drop overcommit options for ARM:

 - "mem-lock=on" does not make sense for EVE, because EVE does not support swap area, so guest memory won't be paged anyway.

 - "cpu-pm=on" is NO-OP for ARM and used only for x86 family, which is again not what we need for EVE anyway.

By default both options are set to OFF.