### PR TITLE
fix: updated publish.yml to use the github.ref_name

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -99,6 +99,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ inputs.tag_ref }}
+          make_latest: false
           files: |
             assets/${{ env.ARCH }}.rootfs.img
             assets/${{ env.ARCH }}.kernel

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -166,4 +166,4 @@ jobs:
     needs: [manifest, verification, eve]
     uses: lf-edge/eve/.github/workflows/assets.yml@master
     with:
-      tag_ref: ${{ github.ref }}
+      tag_ref: ${{ github.ref_name }}


### PR DESCRIPTION
This will ensure that assets from various architecture builds are successfully uploaded to the release.

Added a `make_latest` attribute to prevent uploaded builds from being marked as the latest. Since we have multiple tagged builds, we'll manually designate the latest build.