### PR TITLE
github-wf: prevent builds from triggering on workflow and markdown file changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -66,3 +66,4 @@
 /pkg/xen/                     @OhmSpectator @rucoder @rene @shjala
 /tests/eden/                  @milan-zededa @uncleDecart
 /tools/                       @deitch @jsfakian
+.github/workflows/            @deitch @uncleDecart @yash-zededa

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:  # yamllint disable-line rule:truthy
       - "[0-9]+.[0-9]+"
       - "[0-9]+.[0-9]+-stable"
     paths-ignore:
-      - '.github/workflows/build.yml'
+      - '.github/**'
       - '**/*.md'
 
 concurrency:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,7 @@ on:  # yamllint disable-line rule:truthy
       - "[0-9]+.[0-9]+-stable"
     paths-ignore:
       - '**/*.md'
+      - '.github/**'
   pull_request:
     # The branches below must be a subset of the branches above
     branches:

--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -10,6 +10,7 @@ on:
       - "[0-9]+.[0-9]+-stable"
     paths-ignore:
       - '**/*.md'
+      - '.github/**'
   pull_request_review:
     types: [submitted]
 
@@ -18,12 +19,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check_md_files:
+  check_md_wf_files:
     if: ${{ github.event.review.state == 'approved' }}
     runs-on: ubuntu-latest
     outputs:
-      only_md: ${{ steps.check_md.outputs.only_md }}
-      build_yml_modified: ${{ steps.check_md.outputs.build_yml_modified }}
+      only_md: ${{ steps.check_md_wf.outputs.only_md }}
+      workflow_files_modified: ${{ steps.check_md_wf.outputs.workflow_files_modified }}
     steps:
       - name: Check if only Markdown files are changed
         env:
@@ -43,26 +44,26 @@ jobs:
             echo "Non-Markdown files detected."
             echo "only_md=false" >> $GITHUB_ENV
           fi
-          # Check if build.yml is modified
-          if echo "$MODIFIED_FILES" | grep -q 'build.yml'; then
-            echo "build.yml is modified."
-            echo "build_yml_modified=true" >> $GITHUB_ENV
+          # Check if any GitHub workflow files in .github/workflows are modified
+          if echo "$MODIFIED_FILES" | grep -qE '^\.github/workflows/.*\.(yml|yaml)$'; then
+            echo "GitHub workflow files in .github/workflows are modified."
+            echo "workflow_files_modified=true" >> $GITHUB_ENV
           else
-            echo "build.yml is not modified."
-            echo "build_yml_modified=false" >> $GITHUB_ENV
+            echo "No GitHub workflow files in .github/workflows are modified."
+            echo "workflow_files_modified=false" >> $GITHUB_ENV
           fi
       - name: Output result
-        id: check_md
+        id: check_md_wf
         run: |
           echo "${{ env.only_md }}"
           echo "only_md=${{ env.only_md }}" >> $GITHUB_OUTPUT
-          echo "${{ env.build_yml_modified }}"
-          echo "build_yml_modified=${{ env.build_yml_modified }}" >> $GITHUB_OUTPUT
+          echo "${{ env.workflow_files_modified }}"
+          echo "workflow_files_modified=${{ env.workflow_files_modified }}" >> $GITHUB_OUTPUT
 
   get_run_id:
-    if: ${{ github.event.review.state == 'approved' && needs.check_md_files.outputs.only_md == 'false' && needs.check_md_files.outputs.build_yml_modified == 'false' }}
+    if: ${{ github.event.review.state == 'approved' && needs.check_md_wf_files.outputs.only_md == 'false' && needs.check_md_wf_files.outputs.workflow_files_modified == 'false' }}
     runs-on: ubuntu-latest
-    needs: check_md_files
+    needs: check_md_wf_files
     outputs:
       run_id: ${{ steps.get_run_id.outputs.run_id }}
     steps:

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -8,6 +8,7 @@ on:  # yamllint disable-line rule:truthy
       - "[0-9]+.[0-9]+-stable"
     paths-ignore:
       - '**/*.md'
+      - '.github/**'
   pull_request:
     branches:
       - "master"
@@ -15,6 +16,7 @@ on:  # yamllint disable-line rule:truthy
       - "[0-9]+.[0-9]+-stable"
     paths-ignore:
       - '**/*.md'
+      - '.github/**'
 
 jobs:
   test:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,7 @@ on:  # yamllint disable-line rule:truthy
       - "[0-9]+.[0-9]+-stable"
     paths-ignore:
       - '**/*.md'
+      - '.github/**'
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
       - "[0-9]+.[0-9]+.[0-9]+-lts"


### PR DESCRIPTION
Added .github/workflows to CODEOWNERS for automatic review and approval.

Modified eden.yml to skip tests when there changes are made to the github/workflows. This prevents unnecessary builds triggered by updates to workflows and markdown files.

Workflows changes should now be handled separately from code changes to ensure proper handling.