### PR TITLE
Get the publish workflow to work in 13.0

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -99,6 +99,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ inputs.tag_ref }}
+          make_latest: false
           files: |
             assets/${{ env.ARCH }}.rootfs.img
             assets/${{ env.ARCH }}.kernel

--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -11,7 +11,7 @@
 # qemu-user-static
 
 ---
-name: Assets
+name: Release Assets
 on:  # yamllint disable-line rule:truthy
   workflow_call:
     inputs:
@@ -47,8 +47,8 @@ jobs:
           # if the default server is responding -- we can skip apt update
           $APT_INSTALL || { sudo apt update && $APT_INSTALL ; }
           echo "ARCH=${{ matrix.arch }}" >> "$GITHUB_ENV"
-          echo "TAG=$(git describe --always --tags | grep -E '[0-9]*\.[0-9]*\.[0-9]*' || echo snapshot)" >> "$GITHUB_ENV"
-      - name: ensure clean assets dir
+          echo "TAG=$(git describe --always --tags | grep -E '[0-9]+\.[0-9]+\.[0-9]+-(lts|rc[0-9]+)' || echo snapshot)" >> "$GITHUB_ENV"
+      - name: ensure clean assets directory
         run: |
           rm -rf assets && mkdir -p assets
       - name: Pull the EVE release from DockerHUB or build it
@@ -80,60 +80,6 @@ jobs:
           docker create --name eve_sources "$EVE_SOURCES" bash
           docker export --output assets/collected_sources.tar.gz eve_sources
           docker rm eve_sources
-      - name: Create a GitHub release and clean up artifacts
-        id: create-release
-        uses: actions/github-script@v7
-        with:
-          result-encoding: string
-          script: |
-            console.log(context)
-            const {TAG} = process.env
-
-            // first create a release -- it is OK if that fails,
-            // since it means the release is already there
-            try {
-              const raw = (await github.repos.createRelease({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                tag_name: `${TAG}`,
-                name: `Release ${TAG}`,
-                prerelease: true,
-              })).data
-              console.log(raw)
-            } catch (e) {}
-
-            // get the release ID
-            const release = (await github.repos.getReleaseByTag({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag: `${TAG}`,
-            })).data
-
-            // get assets for that ID
-            const assets = (await github.repos.listReleaseAssets({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              release_id: release.id,
-            })).data
-
-            // remove all assets (since we will be uploading new ones)
-            // note that we only consider assets coming from the same
-            // architecture we're running on -- this is because GH
-            // release assets can only be flat (no folders allowed)
-            if (Array.isArray(assets) && assets.length > 0) {
-              for (const asset of assets) {
-                if (asset.name.startsWith('${{ env.ARCH }}')) {
-                  await github.repos.deleteReleaseAsset({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    asset_id: asset.id,
-                  })
-                }
-              }
-            }
-
-            return release.upload_url
-
       - name: Rename files for release
         id: rename-files-for-release
         run: |
@@ -146,14 +92,13 @@ jobs:
           mv assets/ipxe.efi.cfg assets/${{ env.ARCH }}.ipxe.efi.cfg
           mv assets/ipxe.efi.ip.cfg assets/${{ env.ARCH }}.ipxe.efi.ip.cfg
           mv assets/collected_sources.tar.gz assets/${{ env.ARCH }}.collected_sources.tar.gz
-
       - name: Upload release files
         id: upload-release-files
         uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: startsWith(github.ref, 'refs/tags/')
         with:
+          tag_name: ${{ inputs.tag_ref }}
           files: |
             assets/${{ env.ARCH }}.rootfs.img
             assets/${{ env.ARCH }}.kernel

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -164,4 +164,4 @@ jobs:
     needs: [manifest, verification, eve]
     uses: lf-edge/eve/.github/workflows/assets.yml@master
     with:
-      tag_ref: ${{ github.ref }}
+      tag_ref: ${{ github.ref_name }}

--- a/conf/server
+++ b/conf/server
@@ -1,1 +1,1 @@
-zedcloud.alpha.zededa.net
+zedcloud.zededa.net


### PR DESCRIPTION
In addition to testing the latest commit this will also be used to create a 13.0.1 since 13.0.0 failed to publish the assets.