### PR TITLE
Update SPDX check script to improve copyright notice detection and file comparison

### DIFF
--- a/tools/spdx-check.sh
+++ b/tools/spdx-check.sh
@@ -67,13 +67,13 @@ check_copyright() {
   current_year=$(date +"%Y")
 
   # Check if the file contains the copyright
-  if ! grep -iq "Copyright (c)" "$file"; then
+  if ! grep -iq "Copyright[ ]*(c)" "$file"; then
     echo "does not have the copyright!"
     return 1
   fi
 
   # Check if the file contains the current year
-  if ! grep -iq "Copyright (c) .*$current_year" "$file"; then
+  if ! grep -iq "Copyright[ ]*(c) .*$current_year" "$file"; then
     echo "does not have the current year $current_year in the copyright notice!"
     return 1
   fi

--- a/tools/spdx-check.sh
+++ b/tools/spdx-check.sh
@@ -104,8 +104,10 @@ file_to_be_checked() {
       return 0
     fi
   done
+  # Extract the file name from the path
+  file_name=$(basename "$file")
   for name in "${file_names[@]}"; do
-    if [[ "$1" == "$name" ]]; then
+    if [[ "$file_name" == "$name" ]]; then
       return 0
     fi
   done


### PR DESCRIPTION
This PR modifies the grep command in the SPDX check script to make the space between "Copyright" and "(c)" optional, ensuring the script correctly identifies copyright notices with or without a space. Additionally, it updates the file comparison logic by extracting the file name from the path before comparing it with the list of files, ensuring more accurate identification of files that need to be checked.