### PR TITLE
github: Fix Eden GCP tests

### DIFF
--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -144,7 +144,7 @@ jobs:
         run: |
           git reset --hard '${{ github.event.workflow_run.head_sha }}'
           git clean -f -x -d
-          echo "EVE_TAG=$(make version)" >> "$GITHUB_ENV"
+          echo "EVE_TAG=$(make version | tail -n1)" >> "$GITHUB_ENV"
           echo "EVE_REGISTRY=lfedge/eve" >> "$GITHUB_ENV"
       - name: Prepare EVE (manual run)
         if: github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
Run "make version" from a clean repository will make get-deps to be built and produce more output, so grab only last line, which is the version string.