### PR TITLE
pillar: Remove full device access to native containers

### DIFF
--- a/pkg/pillar/containerd/oci.go
+++ b/pkg/pillar/containerd/oci.go
@@ -65,6 +65,7 @@ type OCISpec interface {
 	UpdateFromVolume(string) error
 	UpdateMounts([]types.DiskStatus) error
 	UpdateEnvVar(map[string]string)
+	GrantFullAccessToDevices()
 }
 
 // NewOciSpec returns a default oci spec from the containerd point of view
@@ -85,16 +86,13 @@ func (client *Client) NewOciSpec(name string, service bool) (OCISpec, error) {
 	if s.Annotations == nil {
 		s.Annotations = map[string]string{}
 	}
-	// default OCI specs have all devices being denied by default,
-	// we flip it back to all allow for now, but later on we may
-	// need to get more fine-grained
 	if s.Linux == nil {
 		s.Linux = &specs.Linux{}
 	}
 	if s.Linux.Resources == nil {
 		s.Linux.Resources = &specs.LinuxResources{}
 	}
-	s.Linux.Resources.Devices = []specs.LinuxDeviceCgroup{{Type: "a", Allow: true, Access: "rwm"}}
+
 	s.Root.Path = "/"
 	s.service = service
 	return s, nil
@@ -247,17 +245,11 @@ func (s *ociSpec) Load(file *os.File) error {
 	if s.Annotations == nil {
 		s.Annotations = map[string]string{}
 	}
-	// default OCI specs have all devices being denied by default,
-	// we flip it back to all allow for now, but later on we may
-	// need to get more fine-grained
 	if s.Linux == nil {
 		s.Linux = &specs.Linux{}
 	}
 	if s.Linux.Resources == nil {
 		s.Linux.Resources = &specs.LinuxResources{}
-	}
-	if s.Linux.Resources.Devices == nil {
-		s.Linux.Resources.Devices = []specs.LinuxDeviceCgroup{{Type: "a", Allow: true, Access: "rwm"}}
 	}
 	return nil
 }
@@ -534,4 +526,16 @@ func (s *ociSpec) UpdateEnvVar(envVars map[string]string) {
 			}
 		}
 	}
+}
+
+// GrantFullAccessToDevices grants full access to all file devices
+func (s *ociSpec) GrantFullAccessToDevices() {
+	// default OCI specs have all devices being denied by default,
+	// we flip it back to all allow for now, but later on we may
+	// need to get more fine-grained
+	s.Linux.Resources.Devices = []specs.LinuxDeviceCgroup{{
+		Type:   "a",
+		Allow:  true,
+		Access: "rwm",
+	}}
 }

--- a/pkg/pillar/containerd/oci_test.go
+++ b/pkg/pillar/containerd/oci_test.go
@@ -850,7 +850,7 @@ func deepCopy(in interface{}) interface{} {
 	return val.Interface()
 }
 
-func TestAllowAllDevicesInSpec(t *testing.T) {
+func TestDenyAllDevicesInSpec(t *testing.T) {
 	t.Parallel()
 
 	// create a temp dir to hold resulting files
@@ -887,5 +887,5 @@ func TestAllowAllDevicesInSpec(t *testing.T) {
 	// Check that the devices are allowed
 	assert.NotNil(t, spec.Get().Linux)
 	assert.NotNil(t, spec.Get().Linux.Resources)
-	assert.Equal(t, []specs.LinuxDeviceCgroup{{Type: "a", Allow: true, Access: "rwm"}}, spec.Get().Linux.Resources.Devices)
+	assert.Nil(t, spec.Get().Linux.Resources.Devices)
 }

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -750,6 +750,8 @@ func (ctx KvmContext) Setup(status types.DomainStatus, config types.DomainConfig
 	spec.Get().Process.Args = args
 	logrus.Infof("Hypervisor args: %v", args)
 
+	spec.GrantFullAccessToDevices()
+
 	if err := spec.CreateContainer(true); err != nil {
 		return logError("Failed to create container for task %s from %v: %v", status.DomainName, config, err)
 	}

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -133,12 +133,14 @@ func (ctx xenContext) Setup(status types.DomainStatus, config types.DomainConfig
 	if err = spec.AddLoader("/containers/services/xen-tools"); err != nil {
 		return logError("failed to add xen hypervisor loader to domain %s: %v", status.DomainName, err)
 	}
-
-	// finally we can start it up
 	spec.Get().Process.Args = []string{"/etc/xen/scripts/xen-start", status.DomainName, file.Name()}
 	if config.MetaDataType == types.MetaDataOpenStack {
 		spec.Get().Process.Args = append(spec.Get().Process.Args, "smbios_product")
 	}
+
+	spec.GrantFullAccessToDevices()
+
+	// finally we can start it up
 	if err := spec.CreateContainer(true); err != nil {
 		return logError("Failed to create container for task %s from %v: %v", status.DomainName, config, err)
 	}


### PR DESCRIPTION
Access to all file devices are granted to QEMU container loader in order to be able to access kvm and other I/O devices. The access is included during the creation/load of the OCI spec for the container in pkg/pillar/containerd/oci.go. However, native deployed containers will also have access to all file devices from the host. This commit moves the corresponding code to the hypervisor setup functions, so native deployed containers will not have full access to the host.

Since this full access is not added to created OCI specs anymore, the test to check full device access was changed to check for non-full access.