### PR TITLE
tools: Add yetus template to mini-yetus.sh

### DIFF
--- a/tools/mini-yetus.sh
+++ b/tools/mini-yetus.sh
@@ -78,7 +78,7 @@ if ! git rev-parse --verify "$DST_BRANCH" >/dev/null 2>&1; then
 fi
 
 MISSING_FILE_REPORTED=false
-SRC_DIR=$(mktemp -d)
+SRC_DIR=$(mktemp -d --tmpdir yetus.XXXXXXXXXX)
 git diff --name-only "$SRC_BRANCH".."$DST_BRANCH" | grep -v '/vendor/' | while IFS= read -r file; do
     if [ -e "$file" ]; then
         cp --parents -r "$PWD/$file" "$SRC_DIR/" || { echo "Failed to copy $file"; exit 1; }


### PR DESCRIPTION
Add the template "yetus.XXXXXXXXXX" to mktemp command on mini-yetus.sh script so it makes easier to users to find and access the output directory.

The output will be stored always at `/tmp/yetus.*` directory:

```sh
Running mini-yetus
./tools/mini-yetus.sh   
[+] Running mini-yetus
[+] No source branch specified. Using the main branch: master
[+] No destination branch specified. Using the current branch: improve-mini-yetus
[+] Running yetus on the changes...
[+] Results stored in /tmp/yetus.BAzEReo7uA/yetus-output
```