### PR TITLE
Fix bugs introduced when support for multi-port NI was added 

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -92,11 +92,20 @@ func prepareAndPublishNetworkInstanceInfoMsg(ctx *zedagentContext,
 		}
 		info.Mtu = uint32(status.MTU)
 		for _, route := range status.CurrentRoutes {
+			// Gateway and GatewayApp can be each empty (for e.g. connected route).
+			// Avoid returning "<nil>" and UUID with all zeroes.
+			var gwIP, gwApp string
+			if route.Gateway != nil {
+				gwIP = route.Gateway.String()
+			}
+			if route.GatewayApp != nilUUID {
+				gwApp = route.GatewayApp.String()
+			}
 			info.IpRoutes = append(info.IpRoutes, &zinfo.IPRoute{
 				DestinationNetwork: route.DstNetwork.String(),
-				Gateway:            route.Gateway.String(),
+				Gateway:            gwIP,
 				Port:               route.OutputPort,
-				GatewayApp:         route.GatewayApp.String(),
+				GatewayApp:         gwApp,
 			})
 		}
 		if !status.ErrorTime.IsZero() {

--- a/pkg/pillar/dpcreconciler/linux_test.go
+++ b/pkg/pillar/dpcreconciler/linux_test.go
@@ -173,8 +173,8 @@ func TestReconcileWithEmptyArgs(test *testing.T) {
 	t.Expect(itemCountWithType(linux.LocalIPRuleTypename)).To(Equal(1))
 	t.Expect(itemCountWithType(iptables.ChainV4Typename)).To(Equal(14))
 	t.Expect(itemCountWithType(iptables.ChainV6Typename)).To(Equal(14))
-	t.Expect(itemCountWithType(iptables.RuleV4Typename)).To(Equal(20))
-	t.Expect(itemCountWithType(iptables.RuleV6Typename)).To(Equal(20))
+	t.Expect(itemCountWithType(iptables.RuleV4Typename)).To(Equal(22))
+	t.Expect(itemCountWithType(iptables.RuleV6Typename)).To(Equal(21))
 	t.Expect(itemIsCreatedWithDescrSnippet("--dport 22 -j REJECT")).To(BeTrue())
 
 	// Enable SSH access

--- a/pkg/pillar/nireconciler/linux_reconciler.go
+++ b/pkg/pillar/nireconciler/linux_reconciler.go
@@ -1238,7 +1238,7 @@ func (r *LinuxNIReconciler) getNIRouteInfo(niID uuid.UUID) (routes []types.IPRou
 			continue
 		}
 		switch route.OutputIf.IfName {
-		case "":
+		case "", "lo":
 			// Skip unreachable route.
 			continue
 		case niInfo.brIfName:


### PR DESCRIPTION
As always, new features also introduce new bugs. Here is a PR with patches to address all bugs identified since the support for Local NI with multiple port was merged. Actually, one of them was introduced by configurable flow-logging, which was merged around the same time...

**Avoid unecessary re-creation of static NI routes**

We may have some discrepancies between the intended and the current
state of NI static routes mostly caused by Linux kernel being smart
and automatically setting some route fields which we leave undefined.
From the reconciler point of view, the current vs. the intended route
config therefore differ and it will unecessarily recreate the route.
Let's therefore set all those automatically filled route fields already
in the intended config (or ignore them in the comparison function)
to avoid unecessary route recreations.


**Properly sync routes of NI with multiple ports**

When we are syncing the current state of the NI routing table,
we should list all the routes in the table, even those with an output
port no longer used by NI. Otherwise, if user removes port from NI
(through a change in shared labels), current state re-sync will
incorrectly omit obsolete routes and reconciler will thus not remove
them (because they already appear removed from the reconciler point
of view).


**Allow ICMP and server-initiated DHCP traffic to enter device**

Now that the flow logging is configurable, we no longer rely on
the connection marking for device INPUT rules. Instead we use ACCEPT/DROP
rules inside the filter table. But with this change, we forgot to add
ICMP and DHCP rule to the filter/INPUT-device chain. As a consequence,
device will for example not reply to ICMP pings...
As for DHCP, most of the traffic is initiated by client and will match
the "ctstate RELATED,ESTABLISHED" rule with the ACCEPT action, so this
is not that much affected.


**Avoid returning "< nil >" or zero UUID as route gateway IP/app**

IP Route Gateway IP and Gateway App can be each empty (for e.g. connected
route). But EVE should avoid publishing "< nil >" or zero UUID inside the
NetworkInstanceInfo message.
