### PR TITLE
github: Remove push event triggers for commit message and SPDX checks.

### DIFF
--- a/.github/workflows/commit-messages.yml
+++ b/.github/workflows/commit-messages.yml
@@ -4,11 +4,6 @@
 name: Lint Commit Messages
 
 on:  # yamllint disable-line rule:truthy
-  push:
-    branches:
-      - "master"
-      - "[0-9]+.[0-9]+"
-      - "[0-9]+.[0-9]+-stable"
   pull_request:
     branches:
       - "master"

--- a/.github/workflows/spdx.yml
+++ b/.github/workflows/spdx.yml
@@ -4,13 +4,6 @@
 name: Check SPDX License Headers
 
 on:  # yamllint disable-line rule:truthy
-  push:
-    branches:
-      - "master"
-      - "[0-9]+.[0-9]+"
-      - "[0-9]+.[0-9]+-stable"
-    paths-ignore:
-      - '**/*.md'
   pull_request:
     branches:
       - "master"


### PR DESCRIPTION
Remove the push event triggers for the commit message linter and SPDX license header checks. These workflows are primarily needed during PR review, so there is no need to run them after a branch has been merged into master or stable branches. This helps to optimize CI by not running unnecessary checks post-merge.