### PR TITLE
Cleanup /persist/pubsub-large on boot

### DIFF
--- a/pkg/pillar/pubsub/socketdriver/publish.go
+++ b/pkg/pillar/pubsub/socketdriver/publish.go
@@ -268,6 +268,10 @@ func (s *Publisher) Restart(restartCounter int) error {
 }
 
 // LargeDirName where to put large fields
+// Note that this is in /persist to avoid using overlayfs aka memory for
+// content which might be Megabytes in size, but there is no assumption that
+// it is persisted across reboots. In fact, the directory should be cleaned up
+// on boot since we do not garbage collect old files from here.
 func (s *Publisher) LargeDirName() string {
 	return fmt.Sprintf("%s/persist/pubsub-large", s.rootDir)
 }

--- a/pkg/pillar/scripts/onboot.sh
+++ b/pkg/pillar/scripts/onboot.sh
@@ -132,6 +132,11 @@ percent_used() {
     fi
 }
 
+# /persist/pubsub-large does not need to be persisted across reboots, but
+# is in /persist to avoid using overlayfs aka memory for content which might
+# be Megabytes in size
+rm -rf /persist/pubsub-large
+
 # free_space <dataset name> (without leading '/')
 # return value is truncated to MBytes
 # Note that we use df even for zfs since the "available" property in zfs
@@ -146,7 +151,7 @@ free_space() {
 # If there is less than 4Mbytes (MIN_DISKSPACE) then remove the content of the
 # following directories in order until we have that amount of available space
 # following sub directories:
-PERSIST_CLEANUPS='log netdump kcrashes memory-monitor/output eve-info pubsub-large patchEnvelopesCache patchEnvelopesUsageCache newlog/keepSentQueue newlog/failedUpload newlog/appUpload newlog/devUpload containerd-system-root vault/downloader vault/verifier agentdebug'
+PERSIST_CLEANUPS='log netdump kcrashes memory-monitor/output eve-info patchEnvelopesCache patchEnvelopesUsageCache newlog/keepSentQueue newlog/failedUpload newlog/appUpload newlog/devUpload containerd-system-root vault/downloader vault/verifier agentdebug'
 # NOTE that we can not cleanup /persist/containerd and /persist/{vault,clear}/volumes since those are used by applications.
 #
 # Note that we need to free up some space before Linuxkit starts containerd,


### PR DESCRIPTION
These files do not need to be persisted across reboots but live in /persist since they might be quite large.
We see a large number of these small files on some test devices, so let's delete on reboot to handle any test-specific issues and then see if we still see the set of files growing between reboots.