### PR TITLE
pillar/hypervisor: remove deref SIGSEGV

### DIFF
--- a/pkg/pillar/hypervisor/containerd.go
+++ b/pkg/pillar/hypervisor/containerd.go
@@ -5,6 +5,7 @@ package hypervisor
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"time"
@@ -143,6 +144,9 @@ func (ctx ctrdContext) Create(domainName string, cfgFilename string, config *typ
 	_ = ctx.ctrdClient.CtrStopContainer(ctrdCtx, domainName, true)
 
 	task, err := ctx.ctrdClient.CtrCreateTask(ctrdCtx, domainName, ctx.ctrdClient.CtrLogIOCreator(domainName))
+	if err != nil {
+		return math.MinInt, logError("failed to create task: %v", err)
+	}
 
 	return int(task.Pid()), err
 }


### PR DESCRIPTION
under certain circumstances an error is returned, but still `task` is dereferenced to get the PID.
If an error is returned, return math.MinInt as -1 has a special meaning (see man 2 kill).