### PR TITLE
bpftrace-compiler: add run-via-edgeview

### DIFF
--- a/eve-tools/bpftrace-compiler/README.md
+++ b/eve-tools/bpftrace-compiler/README.md
@@ -29,6 +29,26 @@ architecture and kernel and run `bpftrace` in it to compile your bpftrace script
 go build
 ```
 
+## Usage
+
+`bpftrace-compiler` offers several ways of use:
+
+* `compile` - to compile only
+* `run-via-ssh` to compile and run the compiled script via a ssh connection to EVE
+* `run-via-http` to compile and run the compiled script via a http connection to EVE's http-debug
+* `run-via-edgeview` to compile and run the compiled script via a edgeview connection to EVE
+
+### Userspace probes
+
+If the bpftrace script is using userspace probes, it needs to know which container to include
+during compilation. For this `-u` can be used, f.e.:
+
+```bash
+./bpftrace-compiler run-via-edgeview -u service,pillar ~/Downloads/run.edgeview.sh examples/pcap_mmap-trace.bt
+```
+
+This will include `pillar` as a service container as `pcap_mmap-trace.bt` is using a userspace-probe.
+
 ## Example Usage With Local EVE in Qemu
 
 Run EVE:
@@ -66,6 +86,15 @@ Stop http-debug on EVE:
 ```sh
 eve http-debug stop
 ```
+
+### Via Edgeview
+
+```bash
+./bpftrace compiler run-via-edgeview ~/Downloads/run.\*.sh examples/undump.bt
+```
+
+If you use globbing (as `\*` in the example above) it will automatically use the newest script.
+This comes in handy if you have several downloaded scripts for the same EVE node.
 
 ## List available probes
 

--- a/eve-tools/bpftrace-compiler/edgeview.go
+++ b/eve-tools/bpftrace-compiler/edgeview.go
@@ -1,0 +1,264 @@
+// Copyright (c) 2024 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io/fs"
+	"log"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"time"
+	"unicode"
+
+	"github.com/creack/pty"
+)
+
+type edgeviewRun struct {
+	cmd     *exec.Cmd
+	ctx     context.Context
+	cancel  func()
+	path    string
+	port    uint16
+	tty     *os.File
+	started atomic.Bool
+}
+
+func pathToScript(path string) string {
+	scripts, err := filepath.Glob(path)
+	if err != nil {
+		log.Fatalf("could not glob '%s': %v", path, err)
+	}
+
+	newestScript := ""
+	newestTime := time.Unix(0, 0)
+	for _, script := range scripts {
+		st, err := os.Stat(script)
+		if err != nil {
+			continue
+		}
+
+		if st.ModTime().After(newestTime) {
+			newestTime = st.ModTime()
+			newestScript = script
+		}
+	}
+
+	return newestScript
+}
+
+func (er *edgeviewRun) enablePprof() error {
+	edgeviewParam := "pprof/on"
+
+	// see ../../pkg/edgeview/src/system.go:68
+	matchOutput := "=== System: <pprof/on> ==="
+
+	_, err := er.runEdgeview(edgeviewParam, matchOutput)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (er *edgeviewRun) disablePprof() error {
+	edgeviewParam := "pprof/off"
+	// see ../../pkg/edgeview/src/system.go:68
+	matchOutput := "=== System: <pprof/off> ==="
+
+	_, err := er.runEdgeview(edgeviewParam, matchOutput)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (er *edgeviewRun) stopHTTPDebugPort() {
+	_, err := er.tty.Write([]byte{'\x03'})
+	if err != nil {
+		_, ok := err.(*fs.PathError)
+		if !ok {
+			log.Printf("could not send ctrl+c: %v", err)
+		}
+	}
+	if er.cmd != nil {
+		_ = er.cmd.Process.Signal(os.Interrupt)
+	}
+
+	if er.cancel != nil {
+		er.cancel()
+		er.ctx = nil
+		er.port = 0
+	}
+	if er.cmd != nil {
+		err = er.cmd.Wait()
+		if err != nil {
+			exitErr, ok := err.(*exec.ExitError)
+			if ok {
+				status := exitErr.Sys().(syscall.WaitStatus)
+				if !status.Signaled() {
+					log.Printf("expected that the process exited because of signal, but %v", err)
+				}
+			} else if !strings.Contains(err.Error(), "Wait was already called") {
+				log.Printf("waiting failed: %v/%T", err, err)
+			}
+		}
+	}
+	err = er.tty.Close()
+	if err != nil {
+		_, ok := err.(*fs.PathError)
+		if !ok {
+			log.Printf("closing tty failed: %v", err)
+		}
+	}
+
+	if er.cmd != nil {
+		_ = er.cmd.Process.Kill()
+		er.cmd = nil
+	}
+}
+
+func (er *edgeviewRun) forwardHTTPDebugPort() error {
+	var err error
+
+	er.ctx, er.cancel = context.WithTimeout(context.Background(), 5*time.Minute)
+	er.cmd = exec.CommandContext(er.ctx, "bash", er.path, "tcp/127.0.0.1:6543")
+
+	er.tty, err = pty.Start(er.cmd)
+	if err != nil {
+		log.Fatalf("starting pty for cmd (%v) failed: %v", er.cmd, err)
+	}
+
+	matchedChan := make(chan struct{})
+
+	var forwardLine string
+	var output string
+	go func() {
+		scanner := bufio.NewScanner(er.tty)
+		for scanner.Scan() {
+			line := scanner.Text()
+			output += line + "\n"
+
+			if strings.Contains(line, "127.0.0.1:6543") {
+				forwardLine = strings.TrimFunc(line, func(r rune) bool {
+					return !unicode.IsGraphic(r)
+				})
+				close(matchedChan)
+			}
+		}
+	}()
+
+	select {
+	case <-er.ctx.Done():
+		return nil
+	case <-matchedChan:
+	}
+
+	er.port, err = matchEdgeviewIPOutput(forwardLine)
+	if err != nil {
+		return fmt.Errorf("could not match output - output was: %s, err is: %v", output, err)
+	}
+
+	return nil
+}
+
+func matchEdgeviewIPOutput(line string) (uint16, error) {
+	rex := regexp.MustCompile(`(\S+) -> `)
+	matches := rex.FindStringSubmatch(line)
+	if len(matches) != 2 {
+		return 0, fmt.Errorf("could not match '%s'", line)
+	}
+	_, portString, err := net.SplitHostPort(matches[1])
+	if err != nil {
+		return 0, fmt.Errorf("could not extract port from '%s': %v", matches[1], err)
+	}
+
+	port, err := strconv.ParseUint(portString, 10, 16)
+	if err != nil {
+		return 0, fmt.Errorf("could not convert %s to int: %v", portString, err)
+	}
+
+	return uint16(port), nil
+}
+
+func (er *edgeviewRun) runEdgeview(edgeviewParam string, matchOutput string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "bash", er.path, edgeviewParam)
+
+	tty, err := pty.Start(cmd)
+	if err != nil {
+		log.Fatalf("starting pty for cmd (%v) failed: %v", cmd, err)
+	}
+
+	defer tty.Close()
+
+	scanner := bufio.NewScanner(tty)
+	success := false
+	var output string
+	for scanner.Scan() {
+		line := scanner.Text()
+		output += line + "\n"
+
+		if strings.Contains(line, matchOutput) {
+			success = true
+		}
+	}
+	if !success {
+		return "", fmt.Errorf("%s failed, output was:\n%s", edgeviewParam, output)
+	}
+
+	err = cmd.Wait()
+	if err != nil {
+		return "", fmt.Errorf("waiting for cmd (%v) failed: %v", cmd, err)
+	}
+	return output, nil
+}
+
+func (er *edgeviewRun) start(evScript string) (uint16, error) {
+	var err error
+
+	if er.started.Swap(true) {
+		return 0, fmt.Errorf("edgeview already started")
+	}
+
+	er.path = pathToScript(evScript)
+	for i := 0; i < 5; i++ {
+		err = er.enablePprof()
+		if err == nil {
+			break
+		}
+	}
+	if err != nil {
+		return 0, fmt.Errorf("could not enable pprof: %v", err)
+	}
+
+	err = er.forwardHTTPDebugPort()
+	if err != nil {
+		return 0, fmt.Errorf("could not forward http port: %v", err)
+	}
+
+	return er.port, nil
+}
+
+func (er *edgeviewRun) shutdown() {
+	er.stopHTTPDebugPort()
+	time.Sleep(5 * time.Second)
+	err := er.disablePprof()
+	if err != nil {
+		log.Fatalf("could not disable pprof: %v", err)
+	}
+	// give edgeview some time ...
+	time.Sleep(5 * time.Second)
+}

--- a/eve-tools/bpftrace-compiler/go.mod
+++ b/eve-tools/bpftrace-compiler/go.mod
@@ -3,6 +3,7 @@ module bpftrace-compiler
 go 1.22.5
 
 require (
+	github.com/creack/pty v1.1.18
 	github.com/linuxkit/linuxkit/src/cmd/linuxkit v0.0.0-20240829191519-fa3207c86e64
 	github.com/opencontainers/image-spec v1.1.0-rc5
 	github.com/pkg/errors v0.9.1

--- a/eve-tools/bpftrace-compiler/go.sum
+++ b/eve-tools/bpftrace-compiler/go.sum
@@ -49,6 +49,8 @@ github.com/containerd/ttrpc v1.2.3/go.mod h1:ieWsXucbb8Mj9PH0rXCw1i8IunRbbAiDkpX
 github.com/containerd/typeurl/v2 v2.1.1 h1:3Q4Pt7i8nYwy2KmQWIw2+1hTvwTE/6w9FqcttATPO/4=
 github.com/containerd/typeurl/v2 v2.1.1/go.mod h1:IDp2JFvbwZ31H8dQbEIY7sDl2L3o3HZj1hsSQlywkQ0=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
+github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/eve-tools/bpftrace-compiler/main.go
+++ b/eve-tools/bpftrace-compiler/main.go
@@ -6,12 +6,27 @@ package main
 import (
 	"fmt"
 	"log"
+	"net/http"
+	"net/url"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"time"
 
 	"github.com/spf13/cobra"
 )
+
+var defers []func()
+
+func init() {
+	defers = make([]func(), 0)
+}
+
+func shutdown() {
+	for i := len(defers) - 1; i >= 0; i-- {
+		defers[i]()
+	}
+}
 
 func main() {
 	var sshKey string
@@ -19,6 +34,19 @@ func main() {
 	var userspaceContainerDebugFlag *[]string
 	var userspaceContainerListFlag *[]string
 	var userspaceContainerHTTPFlag *[]string
+	var userspaceContainerEVFlag *[]string
+
+	defer shutdown()
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	go func() {
+		sig := <-c
+		signal.Stop(c)
+		log.Printf("Got signal %v, shutting down ...\n", sig)
+		shutdown()
+		os.Exit(0)
+	}()
 
 	execName, err := os.Executable()
 	if err != nil {
@@ -63,7 +91,7 @@ func main() {
 				log.Fatal(err)
 			}
 			sr.run(args[1], nil, timeout)
-			sr.end()
+			defers = append(defers, func() { sr.end() })
 		},
 	}
 
@@ -86,7 +114,49 @@ func main() {
 			}
 			hr := newHTTPRun(args[0])
 			hr.run(args[1], uc, timeout)
-			hr.end()
+			defers = append(defers, func() { hr.end() })
+		},
+	}
+
+	runEdgeviewCmd := &cobra.Command{
+		Use:        "run-via-edgeview <path to edgeview script> <bpftrace script>",
+		Aliases:    []string{"re", "run-edgeview", "run-ev"},
+		SuggestFor: []string{},
+		Short:      "run bpftrace script on host via edgeview",
+		Example:    fmt.Sprintf("%s re ~/Downloads/run.\\*.sh examples/undump.bt", execName),
+		Args:       cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			var uc userspaceContainer
+			if len(*userspaceContainerEVFlag) == 2 {
+				switch (*userspaceContainerEVFlag)[0] {
+				case "onboot":
+					uc = onbootContainer((*userspaceContainerEVFlag)[1])
+				case "service":
+					uc = serviceContainer((*userspaceContainerEVFlag)[1])
+				}
+			}
+			ev := edgeviewRun{}
+			port, err := ev.start(args[0])
+			if err != nil {
+				log.Fatalf("could not start edgeview for bpftrace: %v", err)
+			}
+
+			for i := 0; i < 10; i++ {
+				u := url.URL{
+					Scheme: "http",
+					Host:   fmt.Sprintf("127.0.0.1:%d", port),
+					Path:   "/",
+				}
+				resp, err := http.Get(u.String())
+				if err != nil || resp.StatusCode != http.StatusOK {
+					time.Sleep(time.Second)
+					continue
+				}
+			}
+
+			hr := newHTTPRun(fmt.Sprintf("localhost:%d", port))
+			defers = append(defers, func() { hr.end(); ev.shutdown() })
+			hr.run(args[1], uc, timeout)
 		},
 	}
 
@@ -158,12 +228,13 @@ func main() {
 
 	runHTTPCmd.PersistentFlags().DurationVarP(&timeout, "timeout", "t", 10*time.Second, "")
 	userspaceContainerHTTPFlag = runHTTPCmd.PersistentFlags().StringSliceP("userspace", "u", []string{}, "onboot|service,name")
+	userspaceContainerEVFlag = runEdgeviewCmd.PersistentFlags().StringSliceP("userspace", "u", []string{}, "onboot|service,name")
 
 	userspaceContainerDebugFlag = debugShellCmd.PersistentFlags().StringSliceP("userspace", "u", []string{}, "onboot|service,name,image")
 
 	userspaceContainerListFlag = listCmd.PersistentFlags().StringSliceP("userspace", "u", []string{}, "onboot|service,name,image")
 
-	rootCmd.AddCommand(compileCmd, runSSHCmd, runHTTPCmd, listCmd, debugShellCmd)
+	rootCmd.AddCommand(compileCmd, runSSHCmd, runHTTPCmd, runEdgeviewCmd, listCmd, debugShellCmd)
 
 	err = rootCmd.Execute()
 	if err != nil {


### PR DESCRIPTION
In more RL like scenarios, it is neither possible to reach EVE via ssh nor via direct network access. For these cases edgeview was developed.
This new feature leverages edgeview to run bpftrace scripts in more tough environments.