### PR TITLE
[12.0-stable] Cleanup /persist/pubsub-large on boot

### DIFF
--- a/pkg/pillar/pubsub/socketdriver/publish.go
+++ b/pkg/pillar/pubsub/socketdriver/publish.go
@@ -268,6 +268,10 @@ func (s *Publisher) Restart(restartCounter int) error {
 }
 
 // LargeDirName where to put large fields
+// Note that this is in /persist to avoid using overlayfs aka memory for
+// content which might be Megabytes in size, but there is no assumption that
+// it is persisted across reboots. In fact, the directory should be cleaned up
+// on boot since we do not garbage collect old files from here.
 func (s *Publisher) LargeDirName() string {
 	return fmt.Sprintf("%s/persist/pubsub-large", s.rootDir)
 }

--- a/pkg/pillar/scripts/onboot.sh
+++ b/pkg/pillar/scripts/onboot.sh
@@ -115,6 +115,12 @@ if [ ! -d $PERSISTDIR/status ]; then
     mkdir $PERSISTDIR/status
 fi
 
+
+# /persist/pubsub-large does not need to be persisted across reboots, but
+# is in /persist to avoid using overlayfs aka memory for content which might
+# be Megabytes in size
+rm -rf /persist/pubsub-large
+
 # Checking for low diskspace at bootup. If used percentage of
 # /persist directory is more than 70% then we will remove the
 # following sub directories:


### PR DESCRIPTION
These files do not need to be persisted across reboots but live in /persist since they might be quite large.

Signed-off-by: eriknordmark <erik@zededa.com>
(cherry picked from commit 28d14c9e96c442677d37eba0f913f0310cb951b9)