### PR TITLE
nvidia: Change default FAN controlling profile to quiet

### DIFF
--- a/pkg/nvidia/scripts/nv-init.sh
+++ b/pkg/nvidia/scripts/nv-init.sh
@@ -30,5 +30,5 @@ echo "add" > /sys/module/nvidia/uevent 2> /dev/null
 
 # Start FAN controller detached from terminal
 if [ -f "$FANCTRL" ]; then
-    "$FANCTRL" -m cool > /dev/kmsg 2>&1 &
+    "$FANCTRL" -m quiet > /dev/kmsg 2>&1 &
 fi


### PR DESCRIPTION
The nvfanctrl utility is mainly used for developer kits, so change the default profile to quiet in order to reduce the noise of the FAN and not stress developers.