### PR TITLE
[12.0-stable] Kernel update - [amd64-generic, amd64-rt, amd64-generic, amd64-rt, am…

### DIFF
--- a/kernel-commits.mk
+++ b/kernel-commits.mk
@@ -1,8 +1,8 @@
 KERNEL_COMMIT_amd64_v5.10.186_generic = d61682724485
-KERNEL_COMMIT_amd64_v6.1.38_generic = e0f7423a397f
-KERNEL_COMMIT_amd64_v6.1.38_rt = 6e14ff1f47dd
+KERNEL_COMMIT_amd64_v6.1.38_generic = b404564c5910
+KERNEL_COMMIT_amd64_v6.1.38_rt = 37bc37278441
 KERNEL_COMMIT_amd64_v6.1.68_generic = c825cbffe24f
-KERNEL_COMMIT_arm64_v5.10.104_nvidia = 2473fcc9c1bb
+KERNEL_COMMIT_arm64_v5.10.104_nvidia = 7b9a55e0b659
 KERNEL_COMMIT_arm64_v5.10.186_generic = 804663a82829
-KERNEL_COMMIT_arm64_v6.1.38_generic = 39d6c83d31ea
-KERNEL_COMMIT_riscv64_v6.1.38_generic = a90bcdfa08f8
+KERNEL_COMMIT_arm64_v6.1.38_generic = 6dc8132a2e10
+KERNEL_COMMIT_riscv64_v6.1.38_generic = 2dbca8568caf


### PR DESCRIPTION
The main purpose of this PR is to fix 2 problems on Kontron devices:

1. KEMPLD Watchdog driver in upstream kernel cannot properly handle KEMPLD chip on Kontron devices. Device reboots every 30 minutes.
2. New driver for 'MaxLinear/Exar USB to Serial driver' This driver has fixes for RS485 mode. Each port mode can be set individually from kernel command line

eve-kernel-amd64-v6.1.38-generic
    b404564c5910: Enable RS485 mode for USB_SERIAL_XR_RS485
    5e52c170d79c: Enable USB_SERIAL_XR_RS485 for EVE
    0b3b7d58be9a: Add USB MaxLinear/Exar USB to Serial driver. Version 1G
    e2c350f8c50a: MFD: Add Kontron PLD drivers (kempld)
    3fcba9b6a4ff: Revert KEMPLD v33 driver
    ea5616553bc8: Disable KEMPLD_GPIO
    d0e0aa8e9a50: Use template instead of gpiochip_irqchip_add_nested
    98bd856cdfb8: MFD: Add Kontron PLD drivers (kempld)
    8859f43ee8c9: eve_defconfig: Enable PSI (Pressure Stall Information).
    fb31ce85306c: Dockerfile: ensure this option is not set
    065c88891950: gen_compile_commands: fix illegal escape sequence
    47c1f38031dd: bpf: lockdown for security

eve-kernel-amd64-v6.1.38-rt
    37bc37278441: eve_defconfig: Enable PSI (Pressure Stall Information).
    08e4fdb34436: Dockerfile: ensure this option is not set
    d8ef6c6b889f: gen_compile_commands: fix illegal escape sequence
    b3202a070e76: bpf: lockdown for security

eve-kernel-arm64-v5.10.104-nvidia
    7b9a55e0b659: defconfig: Enable PSI in default configuration.
    f4906094020b: config: enable tracing like for amd64

eve-kernel-arm64-v6.1.38-generic
    6dc8132a2e10: drivers: rtc: add rpi-rtc driver for Raspberry Pi 5
    dccb76edb094: dts: Add device tree for Raspberry Pi 5
    dcc640f25194: Add ethernet support for Raspberry Pi 5
    c6323f5c51f3: Add pci/usb support for Raspberry Pi 5
    1a0891be1657: Add sd card support for Raspberry Pi 5
    c892d29d4ab1: Add general support for Raspberry Pi 5
    acbfadebeb76: eve_defconfig: Enable PSI in default configuration.
    bb8ed98284d6: eve_defconfig: Remove ST33HTPM support.
    394a3bcff39d: arm64: dts: Change TPM i2c driver for EPC R3720 device
    ca506de9d4fc: Revert "drivers: tpm: Add driver for ST33HTPM"
    fa15f43bb695: config: enable tracing like for amd64
    7a6b80ab3f67: config: synchronize with savedefconfig
    369b61c861e7: Dockerfile: ensure this option is not set
    905bac9d639b: gen_compile_commands: fix illegal escape sequence
    1dcaa0fcce52: bpf: lockdown for security

eve-kernel-riscv64-v6.1.38-generic
    2dbca8568caf: Dockerfile: ensure this option is not set
    0108be4fcaa6: gen_compile_commands: fix illegal escape sequence
    be5ef3205f08: bpf: lockdown for security