### PR TITLE
[12.0-stable] Set RS485 mode for ttyXRUSB2/3 on kontron devices

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -203,6 +203,13 @@ function set_x86_64_baremetal {
          set_global dom0_platform_tweaks "$dom0_platform_tweaks pci=realloc=off"
       fi
    fi
+   if [ "$smb_vendor" = "Kontron America" ]; then
+      smbios -t 1 -s 5 --set smb_product
+      # switch ttyXRUSB2/3 to RS485 Half-Duplex mode
+      if regexp -- "Agora Gateway" "$smb_product"; then
+         set_global dom0_platform_tweaks "$dom0_platform_tweaks xr_usb_serial_common.mode=2h,3h"
+      fi
+   fi
    set_global ucode /boot/ucode.img
 }
 


### PR DESCRIPTION
On Kontron devices 402/403/202 set ports 2 and 3 to RS485 Half-duplaex mode

Signed-off-by: Mikhail Malyshev <mike.malyshev@gmail.com>
(cherry picked from commit 43d4521abf86b2059d9eb30c55f0818a81971662)