### PR TITLE
[12.0-stable] Blacklist wdat_wdt for Siemens IPC227G

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -210,6 +210,12 @@ function set_x86_64_baremetal {
          set_global dom0_platform_tweaks "$dom0_platform_tweaks xr_usb_serial_common.mode=2h,3h"
       fi
    fi
+   if [ "$smb_vendor" = "SIEMENS AG" ]; then
+      smbios -t 1 -s 5 --set smb_product
+      if [ "$smb_product" = "SIMATIC IPC227G" ]; then
+         set_global dom0_platform_tweaks "$dom0_platform_tweaks modprobe.blacklist=wdat_wdt"
+      fi
+   fi
    set_global ucode /boot/ucode.img
 }
 


### PR DESCRIPTION
This device has two WDs and EVE supports only one so disable ACPI WD

Signed-off-by: Mikhail Malyshev <mike.malyshev@gmail.com>
(cherry picked from commit 7bd7ab931b82899d150f29838f809890f602d715)