### PR TITLE
vTPM : fix arm issue by selecting correct dev name based on arch

### DIFF
--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -426,7 +426,14 @@ const qemuSwtpmTemplate = `
   chardev = "swtpm"
 
 [device "tpm-tis"]
+# 'virt' refers to aarch64
+# 'tpm-tis-device' for aarch64 versus 'tpm-tis' for x86
+# Reference: https://listman.redhat.com/archives/libvir-list/2021-February/msg00647.html
+{{- if eq .Machine "virt"}}
+  driver = "tpm-tis-device"
+{{- else}}
   driver = "tpm-tis"
+{{- end}}
   tpmdev = "tpm0"
 `
 


### PR DESCRIPTION
The vTPM device name is different on ARM and x86. This patch fixes the the issue by selecting the correct device name based on the architecture.

Thanks to @rene for bringing it to my attention. 