### PR TITLE
[12.0-stable] Revert unnecessary device support commits

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -210,12 +210,6 @@ function set_x86_64_baremetal {
          set_global dom0_platform_tweaks "$dom0_platform_tweaks xr_usb_serial_common.mode=2h,3h"
       fi
    fi
-   if [ "$smb_vendor" = "SIEMENS AG" ]; then
-      smbios -t 1 -s 5 --set smb_product
-      if [ "$smb_product" = "SIMATIC IPC227G" ]; then
-         set_global dom0_platform_tweaks "$dom0_platform_tweaks modprobe.blacklist=wdat_wdt"
-      fi
-   fi
    set_global ucode /boot/ucode.img
 }
 

--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -203,13 +203,6 @@ function set_x86_64_baremetal {
          set_global dom0_platform_tweaks "$dom0_platform_tweaks pci=realloc=off"
       fi
    fi
-   if [ "$smb_vendor" = "Kontron America" ]; then
-      smbios -t 1 -s 5 --set smb_product
-      # switch ttyXRUSB2/3 to RS485 Half-Duplex mode
-      if regexp -- "Agora Gateway" "$smb_product"; then
-         set_global dom0_platform_tweaks "$dom0_platform_tweaks xr_usb_serial_common.mode=2h,3h"
-      fi
-   fi
    set_global ucode /boot/ucode.img
 }
 


### PR DESCRIPTION
This pull request reverts two commits from the 12.0-stable branch. We have decided not to backport the corresponding device support for Siemens IPC227G and certain Kontron devices. Therefore, the changes introduced by these commits are no longer necessary and should be removed to maintain branch stability.

See #4243 