### PR TITLE
Enhance LinuxCollector to support detecting multiple app VIF IPs

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -55,7 +55,7 @@
 | netdump.topic.maxcount | integer | 10 | maximum number of netdumps that can be published for each topic. The oldest netdump is unpublished should a new netdump exceed the limit.
 | netdump.downloader.with.pcap | boolean | false | include packet captures inside netdumps for download requests. However, even if enabled, TCP segments carrying non-empty payload (i.e. content which is being downloaded) are excluded and the overall PCAP size is limited to 64MB. |
 | netdump.downloader.http.with.fieldvalue | boolean | false | include HTTP header field values in captured network traces for download requests (beware: may contain secrets, such as datastore credentials). |
-| network.switch.enable.arpsnoop | boolean | true | enable ARP Snooping on switch Network Instance, may need a device reboot to take effect |
+| network.switch.enable.arpsnoop | boolean | true | enable ARP Snooping on switch Network Instances |
 | wwan.query.visible.providers | bool | false | enable to periodically (once per hour) query the set of visible cellular service providers and publish them under WirelessStatus (for every modem) |
 | network.local.legacy.mac.address | bool | false | enables legacy MAC address generation for local network instances for those EVE nodes where changing MAC addresses in applications will lead to incorrect network configuration |
 

--- a/pkg/pillar/cmd/msrv/msrv_test.go
+++ b/pkg/pillar/cmd/msrv/msrv_test.go
@@ -47,7 +47,14 @@ func TestPostKubeconfig(t *testing.T) {
 		},
 		AppNetAdapterList: []types.AppNetAdapterStatus{
 			{
-				AllocatedIPv4Addr: net.ParseIP("192.168.1.1"),
+				AssignedAddresses: types.AssignedAddrs{
+					IPv4Addrs: []types.AssignedAddr{
+						{
+							Address: net.ParseIP("192.168.1.1"),
+						},
+					},
+					IPv6Addrs: nil,
+				},
 			},
 		},
 	})
@@ -83,7 +90,11 @@ func TestPostKubeconfig(t *testing.T) {
 	niStatus := types.NetworkInstanceStatus{
 		NetworkInstanceInfo: types.NetworkInstanceInfo{
 			IPAssignments: map[string]types.AssignedAddrs{"k": {
-				IPv4Addr: net.ParseIP("192.168.1.1"),
+				IPv4Addrs: []types.AssignedAddr{
+					{
+						Address: net.ParseIP("192.168.1.1"),
+					},
+				},
 			}},
 		},
 	}
@@ -161,7 +172,14 @@ func TestRequestPatchEnvelopes(t *testing.T) {
 		},
 		AppNetAdapterList: []types.AppNetAdapterStatus{
 			{
-				AllocatedIPv4Addr: net.ParseIP("192.168.1.1"),
+				AssignedAddresses: types.AssignedAddrs{
+					IPv4Addrs: []types.AssignedAddr{
+						{
+							Address: net.ParseIP("192.168.1.1"),
+						},
+					},
+					IPv6Addrs: nil,
+				},
 			},
 		},
 	})
@@ -309,7 +327,14 @@ func TestHandleAppInstanceDiscovery(t *testing.T) {
 		},
 		AppNetAdapters: []types.AppNetAdapterStatus{
 			{
-				AllocatedIPv4Addr: net.ParseIP("192.168.1.1"),
+				AssignedAddresses: types.AssignedAddrs{
+					IPv4Addrs: []types.AssignedAddr{
+						{
+							Address: net.ParseIP("192.168.1.1"),
+						},
+					},
+					IPv6Addrs: nil,
+				},
 				AppNetAdapterConfig: types.AppNetAdapterConfig{
 					IfIdx:           2,
 					AllowToDiscover: true,
@@ -320,8 +345,15 @@ func TestHandleAppInstanceDiscovery(t *testing.T) {
 	err = appInstanceStatus.Publish(u.String(), a)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	discoverableNet := types.AppNetAdapterStatus{
-		AllocatedIPv4Addr: net.ParseIP("192.168.1.2"),
-		VifInfo:           types.VifInfo{VifConfig: types.VifConfig{Vif: "eth0"}},
+		AssignedAddresses: types.AssignedAddrs{
+			IPv4Addrs: []types.AssignedAddr{
+				{
+					Address: net.ParseIP("192.168.1.2"),
+				},
+			},
+			IPv6Addrs: nil,
+		},
+		VifInfo: types.VifInfo{VifConfig: types.VifConfig{Vif: "eth0"}},
 	}
 	a1 := types.AppInstanceStatus{
 		UUIDandVersion: types.UUIDandVersion{
@@ -367,7 +399,7 @@ func TestHandleAppInstanceDiscovery(t *testing.T) {
 	expected := map[string][]msrv.AppInstDiscovery{
 		u1.String(): {{
 			Port:    discoverableNet.Vif,
-			Address: discoverableNet.AllocatedIPv4Addr.String(),
+			Address: discoverableNet.AssignedAddresses.IPv4Addrs[0].Address.String(),
 		}},
 	}
 	g.Expect(got).To(gomega.BeEquivalentTo(expected))

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -1210,8 +1210,22 @@ func updateLocalServerMap(getconfigCtx *getconfigContext, localServerURL string)
 				continue
 			}
 			if localServerIP != nil {
-				// check if the defined IP of localServer equals the allocated IP of the app
-				if adapterStatus.AllocatedIPv4Addr.Equal(localServerIP) {
+				// Check if the defined IP of localServer equals one of the IPs
+				// allocated to the app.
+				var matchesApp bool
+				for _, ip := range adapterStatus.AssignedAddresses.IPv4Addrs {
+					if ip.Address.Equal(localServerIP) {
+						matchesApp = true
+						break
+					}
+				}
+				for _, ip := range adapterStatus.AssignedAddresses.IPv6Addrs {
+					if ip.Address.Equal(localServerIP) {
+						matchesApp = true
+						break
+					}
+				}
+				if matchesApp {
 					srvAddr := localServerAddr{
 						localServerAddr: localServerURL,
 						bridgeIP:        adapterStatus.BridgeIPAddr,

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -1112,16 +1112,18 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 		for _, ifname := range ifNames {
 			networkInfo := new(info.ZInfoNetwork)
 			networkInfo.LocalName = *proto.String(ifname)
-			ipv4Addr, ipv6Addrs, allocated, macAddr, ipAddrMismatch :=
-				getAppIP(ctx, aiStatus, ifname)
-			if ipv4Addr != nil {
-				networkInfo.IPAddrs = append(networkInfo.IPAddrs, ipv4Addr.String())
+			addrs, hasIPv4Addr, macAddr, ipAddrMismatch :=
+				getAppIPs(ctx, aiStatus, ifname)
+			for _, ipv4Addr := range addrs.IPv4Addrs {
+				networkInfo.IPAddrs = append(networkInfo.IPAddrs,
+					ipv4Addr.Address.String())
 			}
-			for _, ipv6Addr := range ipv6Addrs {
-				networkInfo.IPAddrs = append(networkInfo.IPAddrs, ipv6Addr.String())
+			for _, ipv6Addr := range addrs.IPv6Addrs {
+				networkInfo.IPAddrs = append(networkInfo.IPAddrs,
+					ipv6Addr.Address.String())
 			}
 			networkInfo.MacAddr = *proto.String(macAddr.String())
-			networkInfo.Ipv4Up = allocated
+			networkInfo.Ipv4Up = hasIPv4Addr
 			networkInfo.IpAddrMisMatch = ipAddrMismatch
 			name := appIfnameToName(aiStatus, ifname)
 			log.Tracef("app %s/%s localName %s devName %s",
@@ -1560,21 +1562,22 @@ func sendMetricsProtobuf(ctx *getconfigContext,
 
 // Use the ifname/vifname to find the AppNetAdapter status
 // and from there the (ip, allocated, mac) addresses for the app
-func getAppIP(ctx *zedagentContext, aiStatus *types.AppInstanceStatus,
-	vifname string) (net.IP, []net.IP, bool, net.HardwareAddr, bool) {
+func getAppIPs(ctx *zedagentContext, aiStatus *types.AppInstanceStatus,
+	vifname string) (types.AssignedAddrs, bool, net.HardwareAddr, bool) {
 
 	log.Tracef("getAppIP(%s, %s)", aiStatus.Key(), vifname)
 	for _, adapterStatus := range aiStatus.AppNetAdapters {
 		if adapterStatus.VifUsed != vifname {
 			continue
 		}
-		log.Tracef("getAppIP(%s, %s) found AppIP v4: %s, v6: %s, ipv4 assigned %v mac %s",
-			aiStatus.Key(), vifname, adapterStatus.AllocatedIPv4Addr,
-			adapterStatus.AllocatedIPv6List, adapterStatus.IPv4Assigned, adapterStatus.Mac)
-		return adapterStatus.AllocatedIPv4Addr, adapterStatus.AllocatedIPv6List, adapterStatus.IPv4Assigned,
+		log.Tracef("getAppIP(%s, %s) found AppIPs v4: %v, v6: %v, ipv4 assigned %v mac %s",
+			aiStatus.Key(), vifname, adapterStatus.AssignedAddresses.IPv4Addrs,
+			adapterStatus.AssignedAddresses.IPv6Addrs, adapterStatus.IPv4Assigned,
+			adapterStatus.Mac)
+		return adapterStatus.AssignedAddresses, adapterStatus.IPv4Assigned,
 			adapterStatus.Mac, adapterStatus.IPAddrMisMatch
 	}
-	return nil, nil, false, nil, false
+	return types.AssignedAddrs{}, false, nil, false
 }
 
 func createVolumeInstanceMetrics(ctx *zedagentContext, reportMetrics *metrics.ZMetricMsg) {

--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -8,7 +8,6 @@ package zedagent
 import (
 	"bytes"
 	"fmt"
-	"net"
 	"time"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
@@ -134,11 +133,13 @@ func prepareAndPublishNetworkInstanceInfoMsg(ctx *zedagentContext,
 		for mac, addrs := range status.IPAssignments {
 			assignment := new(zinfo.ZmetIPAssignmentEntry)
 			assignment.MacAddress = mac
-			if !addrs.IPv4Addr.Equal(net.IP{}) {
-				assignment.IpAddress = append(assignment.IpAddress, addrs.IPv4Addr.String())
+			for _, assignedIP := range addrs.IPv4Addrs {
+				assignment.IpAddress = append(assignment.IpAddress,
+					assignedIP.Address.String())
 			}
-			for _, ip := range addrs.IPv6Addrs {
-				assignment.IpAddress = append(assignment.IpAddress, ip.String())
+			for _, assignedIP := range addrs.IPv6Addrs {
+				assignment.IpAddress = append(assignment.IpAddress,
+					assignedIP.Address.String())
 			}
 			info.IpAssignments = append(info.IpAssignments, assignment)
 		}

--- a/pkg/pillar/cmd/zedrouter/appnetwork.go
+++ b/pkg/pillar/cmd/zedrouter/appnetwork.go
@@ -67,7 +67,8 @@ func (z *zedrouter) updateVIFsForStateCollecting(
 		}
 		_, vifs, err := z.getArgsForNIStateCollecting(network)
 		if err == nil {
-			err = z.niStateCollector.UpdateCollectingForNI(*netConfig, vifs)
+			err = z.niStateCollector.UpdateCollectingForNI(*netConfig, vifs,
+				z.enableArpSnooping)
 		}
 		if err != nil {
 			z.log.Error(err)
@@ -174,10 +175,7 @@ func (z *zedrouter) updateNIStatusAfterAppNetworkActivate(status *types.AppNetwo
 		netInstStatus.AddVif(z.log, adapterStatus.Vif, adapterStatus.Mac,
 			status.UUIDandVersion.UUID)
 		netInstStatus.IPAssignments[adapterStatus.Mac.String()] =
-			types.AssignedAddrs{
-				IPv4Addr:  adapterStatus.AllocatedIPv4Addr,
-				IPv6Addrs: adapterStatus.AllocatedIPv6List,
-			}
+			adapterStatus.AssignedAddresses
 		z.publishNetworkInstanceStatus(netInstStatus)
 	}
 }

--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -542,7 +542,7 @@ func (z *zedrouter) doUpdateActivatedNetworkInstance(config types.NetworkInstanc
 	z.processNIReconcileStatus(niRecStatus, status)
 	_, vifs, err := z.getArgsForNIStateCollecting(config.UUID)
 	if err == nil {
-		err = z.niStateCollector.UpdateCollectingForNI(config, vifs)
+		err = z.niStateCollector.UpdateCollectingForNI(config, vifs, z.enableArpSnooping)
 	}
 	if err != nil {
 		z.log.Error(err)

--- a/pkg/pillar/cmd/zedrouter/pubsubhandlers.go
+++ b/pkg/pillar/cmd/zedrouter/pubsubhandlers.go
@@ -50,7 +50,33 @@ func (z *zedrouter) handleGlobalConfigImpl(ctxArg interface{}, key string,
 			}
 			z.metricInterval = metricInterval
 		}
-		z.enableArpSnooping = gcp.GlobalValueBool(types.EnableARPSnoop)
+		enableArpSnooping := gcp.GlobalValueBool(types.EnableARPSnoop)
+		if z.enableArpSnooping != enableArpSnooping {
+			z.enableArpSnooping = enableArpSnooping
+			// Start/Stop ARP snooping in every activated Switch NI.
+			for _, item := range z.pubNetworkInstanceStatus.GetAll() {
+				niStatus := item.(types.NetworkInstanceStatus)
+				if !niStatus.Activated {
+					continue
+				}
+				if niStatus.Type != types.NetworkInstanceTypeSwitch {
+					// ARP snooping is only used in Switch NIs.
+					continue
+				}
+				niConfig := z.lookupNetworkInstanceConfig(niStatus.Key())
+				if niConfig == nil {
+					continue
+				}
+				_, vifs, err := z.getArgsForNIStateCollecting(niConfig.UUID)
+				if err == nil {
+					err = z.niStateCollector.UpdateCollectingForNI(
+						*niConfig, vifs, z.enableArpSnooping)
+				}
+				if err != nil {
+					z.log.Error(err)
+				}
+			}
+		}
 		z.localLegacyMACAddr = gcp.GlobalValueBool(types.NetworkLocalLegacyMACAddress)
 		z.niReconciler.ApplyUpdatedGCP(z.runCtx, *gcp)
 	}
@@ -225,7 +251,13 @@ func (z *zedrouter) handleNetworkInstanceCreate(ctxArg interface{}, key string,
 
 	// Set bridge IP address.
 	if status.Gateway != nil {
-		addrs := types.AssignedAddrs{IPv4Addr: status.Gateway}
+		addrs := types.AssignedAddrs{
+			IPv4Addrs: []types.AssignedAddr{
+				{
+					Address:    status.Gateway,
+					AssignedBy: types.AddressSourceEVEInternal,
+				}},
+		}
 		status.IPAssignments[status.BridgeMac.String()] = addrs
 		status.BridgeIPAddr = status.Gateway
 	}
@@ -337,7 +369,9 @@ func (z *zedrouter) handleNetworkInstanceModify(ctxArg interface{}, key string,
 		delete(status.IPAssignments, status.BridgeMac.String())
 	}
 	if status.Gateway != nil && status.BridgeMac != nil {
-		addrs := types.AssignedAddrs{IPv4Addr: status.Gateway}
+		addrs := types.AssignedAddrs{
+			IPv4Addrs: []types.AssignedAddr{{Address: status.Gateway}},
+		}
 		status.IPAssignments[status.BridgeMac.String()] = addrs
 		status.BridgeIPAddr = status.Gateway
 	}

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -446,10 +446,7 @@ func (z *zedrouter) run(ctx context.Context) (err error) {
 						niKey, vif.NetAdapterName)
 					continue
 				}
-				netStatus.IPAssignments[mac] = types.AssignedAddrs{
-					IPv4Addr:  newAddrs.IPv4Addr,
-					IPv6Addrs: newAddrs.IPv6Addrs,
-				}
+				netStatus.IPAssignments[mac] = newAddrs.AssignedAddrs
 				z.publishNetworkInstanceStatus(netStatus)
 				appKey := vif.App.String()
 				appStatus := z.lookupAppNetworkStatus(appKey)

--- a/pkg/pillar/nistate/linux_flow.go
+++ b/pkg/pillar/nistate/linux_flow.go
@@ -8,8 +8,10 @@ package nistate
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"net"
 	"strconv"
+	"sync"
 	"syscall"
 	"time"
 
@@ -48,6 +50,10 @@ const (
 	// To prevent the DNS record list from growing indefinitely, each record is retained
 	// for a maximum of one day (a typical "long" TTL for DNS responses).
 	dnsRecordRetentionTime = 24 * time.Hour
+
+	// Statically configured IP address, detected using ARP snooping, is considered
+	// valid until we do not see any more ARPs for this IP for more than 10 minutes.
+	staticIPValidDuration = 10 * time.Minute
 )
 
 type capturedPacket struct {
@@ -119,8 +125,8 @@ func (lc *LinuxCollector) collectFlows() (flows []types.IPFlow) {
 			var sequence int
 			ipFlow := types.IPFlow{
 				Scope: types.FlowScope{
-					AppUUID:        vif.VIF.App,
-					NetAdapterName: vif.VIF.NetAdapterName,
+					AppUUID:        vif.App,
+					NetAdapterName: vif.NetAdapterName,
 					BrIfName:       niInfo.bridge.BrIfName,
 					NetUUID:        niInfo.config.UUID,
 				},
@@ -138,8 +144,8 @@ func (lc *LinuxCollector) collectFlows() (flows []types.IPFlow) {
 				sequence++
 			}
 			for _, flowrec := range timeoutedFlows {
-				if flowrec.vif.App != vif.VIF.App ||
-					flowrec.vif.NetAdapterName != vif.VIF.NetAdapterName {
+				if flowrec.vif.App != vif.App ||
+					flowrec.vif.NetAdapterName != vif.NetAdapterName {
 					continue
 				}
 				ipFlow.Flows = append(ipFlow.Flows, flowrec.FlowRec)
@@ -150,7 +156,7 @@ func (lc *LinuxCollector) collectFlows() (flows []types.IPFlow) {
 
 			// Append DNS flows corresponding to this app.
 			for _, dnsReq := range dnsReqs {
-				if !vif.HasIP(dnsReq.appIP) {
+				if !vif.hasIP(dnsReq.appIP) {
 					continue
 				}
 				ipFlow.DNSReqs = append(ipFlow.DNSReqs, dnsReq.DNSReq)
@@ -211,16 +217,16 @@ func (lc *LinuxCollector) convertConntrackToFlow(
 	// refers to a remote endpoint, even for outside initiated flows, meaning
 	// that "src" and "dst" is indeed a very confusing naming (already used
 	// in EVE API therefore not easy to change).
-	vif := vifs.LookupByIP(entry.Forward.SrcIP)
+	vif := lookupVIFByIP(entry.Forward.SrcIP, vifs)
 	forwSrcApp = vif != nil
 	if !forwSrcApp {
-		vif = vifs.LookupByIP(entry.Forward.DstIP)
+		vif = lookupVIFByIP(entry.Forward.DstIP, vifs)
 		forwDstApp = vif != nil
 		if !forwDstApp {
-			vif = vifs.LookupByIP(entry.Reverse.SrcIP)
+			vif = lookupVIFByIP(entry.Reverse.SrcIP, vifs)
 			backSrcApp = vif != nil
 			if !backSrcApp {
-				vif = vifs.LookupByIP(entry.Reverse.DstIP)
+				vif = lookupVIFByIP(entry.Reverse.DstIP, vifs)
 				backDstApp = vif != nil
 			}
 		}
@@ -243,7 +249,7 @@ func (lc *LinuxCollector) convertConntrackToFlow(
 	// similar to RFC5130 to merge two bidirectional flow using the method of "Perimeter",
 	// here we define the flow src is always the local App endpoint, the flow dst will
 	// be the opposite endpoint.
-	ipFlow.vif = vif.VIF
+	ipFlow.vif = vif.AppVIF
 	ipFlow.Flow.Proto = int32(entry.Forward.Protocol)
 	if forwSrcApp {
 		// Src initiated flow, forward-src is the src, reverse-src is the flow dst
@@ -298,8 +304,9 @@ func (lc *LinuxCollector) convertConntrackToFlow(
 // This function is merely capturing packets and then sending them to runStateCollecting,
 // so that all state collecting and processing happens from the main event loop
 // (to simplify and avoid race conditions...).
-func (lc *LinuxCollector) sniffDNSandDHCP(ctx context.Context,
+func (lc *LinuxCollector) sniffDNSandDHCP(ctx context.Context, wg *sync.WaitGroup,
 	br NIBridge, niType types.NetworkInstanceType, enableArpSnoop bool) {
+	defer wg.Done()
 	var (
 		err         error
 		snapshotLen int32 = 1280             // draft-madi-dnsop-udp4dns-00
@@ -523,13 +530,13 @@ func (lc *LinuxCollector) processARPPacket(
 		return nil
 	}
 
-	var vif *VIFAddrs
+	var vif *vifInfo
 	var weAreSource bool
 	var gotAddress []byte
 	if arp.Operation == layers.ARPReply || arp.Operation == layers.ARPRequest {
-		vif = niInfo.vifs.LookupByGuestMAC(arp.DstHwAddress)
+		vif = niInfo.lookupVIFByGuestMAC(arp.DstHwAddress)
 		if vif == nil {
-			vif = niInfo.vifs.LookupByGuestMAC(arp.SourceHwAddress)
+			vif = niInfo.lookupVIFByGuestMAC(arp.SourceHwAddress)
 			if vif != nil {
 				weAreSource = true
 			}
@@ -541,21 +548,16 @@ func (lc *LinuxCollector) processARPPacket(
 		return nil
 	}
 
-	prevAddrs := *vif
 	if weAreSource {
 		gotAddress = arp.SourceProtAddress
 	} else {
 		gotAddress = arp.DstProtAddress
 	}
-	if vif.IPv4Addr.Equal(gotAddress) {
-		return nil
+	validUntil := time.Now().Add(staticIPValidDuration)
+	update := vif.addIP(gotAddress, types.AddressSourceStatic, validUntil)
+	if update != nil {
+		addrUpdates = append(addrUpdates, *update)
 	}
-	vif.IPv4Addr = gotAddress
-	newAddrs := *vif
-	addrUpdates = append(addrUpdates, VIFAddrsUpdate{
-		Prev: prevAddrs,
-		New:  newAddrs,
-	})
 	return addrUpdates
 }
 
@@ -580,7 +582,7 @@ func (lc *LinuxCollector) processDHCPPacket(
 			// need to check those in payload to see if it's for an app.
 			isBroadcast = true
 		} else {
-			foundDstMac = niInfo.vifs.LookupByGuestMAC(etherPkt.DstMAC) != nil
+			foundDstMac = niInfo.lookupVIFByGuestMAC(etherPkt.DstMAC) != nil
 		}
 	}
 	if !foundDstMac && !isBroadcast {
@@ -600,16 +602,22 @@ func (lc *LinuxCollector) processDHCPPacket(
 		}
 		dhcpv4 := dhcpLayer.(*layers.DHCPv4)
 		var isReplyAck bool
+		var validUntil time.Time
 		if dhcpv4.Operation == layers.DHCPOpReply {
 			opts := dhcpv4.Options
 			for _, opt := range opts {
-				if opt.Type == layers.DHCPOptMessageType &&
-					int(opt.Data[0]) == int(layers.DHCPMsgTypeAck) {
-					isReplyAck = true
-					break
+				switch opt.Type {
+				case layers.DHCPOptMessageType:
+					if int(opt.Data[0]) == int(layers.DHCPMsgTypeAck) {
+						isReplyAck = true
+					}
+				case layers.DHCPOptLeaseTime:
+					leaseTimeSecs := binary.BigEndian.Uint32(opt.Data)
+					validUntil = time.Now().Add(time.Duration(leaseTimeSecs) * time.Second)
 				}
 			}
 		}
+
 		if !isReplyAck {
 			// This is indeed a DHCP packet but not the DHCP Reply type.
 			return nil, true
@@ -628,20 +636,15 @@ func (lc *LinuxCollector) processDHCPPacket(
 			return nil, true
 		}
 
-		vif := niInfo.vifs.LookupByGuestMAC(dhcpv4.ClientHWAddr)
+		vif := niInfo.lookupVIFByGuestMAC(dhcpv4.ClientHWAddr)
 		if vif == nil {
 			return nil, true
 		}
-		if vif.IPv4Addr.Equal(dhcpv4.YourClientIP) {
-			return nil, true
+		update := vif.addIP(dhcpv4.YourClientIP, types.AddressSourceExternalDHCP,
+			validUntil)
+		if update != nil {
+			addrUpdates = append(addrUpdates, *update)
 		}
-		prevAddrs := *vif
-		vif.IPv4Addr = dhcpv4.YourClientIP
-		newAddrs := *vif
-		addrUpdates = append(addrUpdates, VIFAddrsUpdate{
-			Prev: prevAddrs,
-			New:  newAddrs,
-		})
 		return addrUpdates, true
 	}
 
@@ -661,29 +664,32 @@ func (lc *LinuxCollector) processDHCPPacket(
 		// This is indeed a DHCP packet but not the DHCP Reply type.
 		return nil, true
 	}
+	var vif *vifInfo
+	var validUntil time.Time
 	for _, opt := range dhcpv6.Options {
-		if opt.Code != layers.DHCPv6OptClientID {
-			continue
+		switch opt.Code {
+		case layers.DHCPv6OptClientID:
+			clientOption := &layers.DHCPv6DUID{}
+			clientOption.DecodeFromBytes(opt.Data)
+			vif = niInfo.lookupVIFByGuestMAC(clientOption.LinkLayerAddress)
+		case layers.DHCPv6OptIAAddr:
+			// Parse IA Address option to get valid-lifetime.
+			if len(opt.Data) >= 24 {
+				// Valid-lifetime is at offset 20-23 (4 bytes).
+				validLifetimeSecs := binary.BigEndian.Uint32(opt.Data[20:24])
+				validUntil = time.Now().Add(time.Duration(validLifetimeSecs) * time.Second)
+			}
 		}
-		clientOption := &layers.DHCPv6DUID{}
-		clientOption.DecodeFromBytes(opt.Data)
-		vif := niInfo.vifs.LookupByGuestMAC(clientOption.LinkLayerAddress)
-		if vif == nil {
-			return nil, true
-		}
-		if isAddrPresent(vif.IPv6Addrs, dhcpv6.LinkAddr) {
-			return nil, true
-		}
-		prevAddrs := *vif
-		vif.IPv6Addrs = append(vif.IPv6Addrs, dhcpv6.LinkAddr)
-		newAddrs := *vif
-		addrUpdates = append(addrUpdates, VIFAddrsUpdate{
-			Prev: prevAddrs,
-			New:  newAddrs,
-		})
-		return addrUpdates, true
 	}
-	return nil, true
+	if vif == nil {
+		return nil, true
+	}
+	update := vif.addIP(dhcpv6.LinkAddr, types.AddressSourceExternalDHCP,
+		validUntil)
+	if update != nil {
+		addrUpdates = append(addrUpdates, *update)
+	}
+	return addrUpdates, true
 }
 
 // Process captured ICMPv6 NS packet for a switched network instance to learn
@@ -692,10 +698,10 @@ func (lc *LinuxCollector) processDHCPPacket(
 // by processing this packet.
 func (lc *LinuxCollector) processDADProbe(
 	niInfo *niInfo, packet gopacket.Packet) (addrUpdates []VIFAddrsUpdate) {
-	var vif *VIFAddrs
+	var vif *vifInfo
 	if etherLayer := packet.Layer(layers.LayerTypeEthernet); etherLayer != nil {
 		etherPkt := etherLayer.(*layers.Ethernet)
-		vif = niInfo.vifs.LookupByGuestMAC(etherPkt.SrcMAC)
+		vif = niInfo.lookupVIFByGuestMAC(etherPkt.SrcMAC)
 	}
 	if vif == nil {
 		return
@@ -716,16 +722,15 @@ func (lc *LinuxCollector) processDADProbe(
 		return
 	}
 	icmp6 := icmp6Layer.(*layers.ICMPv6NeighborSolicitation)
-	if isAddrPresent(vif.IPv6Addrs, icmp6.TargetAddress) {
-		return nil
+	// DAD is not performed periodically, therefore we should not remove the IP address
+	// from the list after some time duration just because we have not seen another
+	// ICMPv6 NS packet.
+	undefinedValidity := time.Time{}
+	update := vif.addIP(icmp6.TargetAddress, types.AddressSourceSLAAC,
+		undefinedValidity)
+	if update != nil {
+		addrUpdates = append(addrUpdates, *update)
 	}
-	prevAddrs := *vif
-	vif.IPv6Addrs = append(vif.IPv6Addrs, icmp6.TargetAddress)
-	newAddrs := *vif
-	addrUpdates = append(addrUpdates, VIFAddrsUpdate{
-		Prev: prevAddrs,
-		New:  newAddrs,
-	})
 	return addrUpdates
 }
 
@@ -793,11 +798,11 @@ func (lc *LinuxCollector) processDNSPacketInfo(
 	}
 }
 
-func isAddrPresent(list []net.IP, addr net.IP) bool {
-	for i := 0; i < len(list); i++ {
-		if addr.Equal(list[i]) {
-			return true
+func lookupVIFByIP(ip net.IP, vifs []*vifInfo) *vifInfo {
+	for _, vif := range vifs {
+		if vif.hasIP(ip) {
+			return vif
 		}
 	}
-	return false
+	return nil
 }

--- a/pkg/pillar/nistate/linux_iptables.go
+++ b/pkg/pillar/nistate/linux_iptables.go
@@ -56,7 +56,7 @@ func (lc *LinuxCollector) fetchIptablesCounters() []aclCounters {
 	for _, niState := range lc.nis {
 		for _, niVif := range niState.vifs {
 			vifs = append(vifs, vif{
-				ifName: niVif.VIF.HostIfName,
+				ifName: niVif.HostIfName,
 				bridge: niState.bridge.BrIfName,
 			})
 		}

--- a/pkg/pillar/nistate/statecollector.go
+++ b/pkg/pillar/nistate/statecollector.go
@@ -10,7 +10,6 @@
 package nistate
 
 import (
-	"bytes"
 	"fmt"
 	"net"
 
@@ -40,7 +39,7 @@ type Collector interface {
 	// Note that not every change in network instance config is supported. For example,
 	// network instance type (switch / local) cannot change.
 	UpdateCollectingForNI(
-		niConfig types.NetworkInstanceConfig, vifs []AppVIF) error
+		niConfig types.NetworkInstanceConfig, vifs []AppVIF, enableArpSnoop bool) error
 
 	// StopCollectingForNI : stop collecting state data for network instance.
 	// It is called by zedrouter whenever a network instance is about to be deleted.
@@ -135,45 +134,11 @@ func (vifs VIFAddrsList) LookupByAdapterName(
 	return nil
 }
 
-// LookupByGuestMAC : Lookup VIF by the MAC address of the guest interface.
-func (vifs VIFAddrsList) LookupByGuestMAC(mac net.HardwareAddr) *VIFAddrs {
-	for i := range vifs {
-		if bytes.Equal(vifs[i].VIF.GuestIfMAC, mac) {
-			return &vifs[i]
-		}
-	}
-	return nil
-}
-
-// LookupByIP : Lookup VIF by the IP address assigned to the guest interface.
-// Returns first match.
-func (vifs VIFAddrsList) LookupByIP(ip net.IP) *VIFAddrs {
-	for i := range vifs {
-		if vifs[i].HasIP(ip) {
-			return &vifs[i]
-		}
-	}
-	return nil
-}
-
 // VIFAddrs lists IP addresses assigned to a VIF on the guest side
 // (inside the app). This is provided to zedrouter by Collector.
 type VIFAddrs struct {
 	types.AssignedAddrs
 	VIF AppVIF
-}
-
-// HasIP returns true if the given IP address is assigned to this VIF.
-func (vif VIFAddrs) HasIP(ip net.IP) bool {
-	if ip.Equal(vif.IPv4Addr) {
-		return true
-	}
-	for _, ipv6Addr := range vif.IPv6Addrs {
-		if ip.Equal(ipv6Addr) {
-			return true
-		}
-	}
-	return false
 }
 
 // VIFAddrsUpdate describes a change in the address assignment for a single VIF.

--- a/pkg/pillar/pubsub/memdriver_test.go
+++ b/pkg/pillar/pubsub/memdriver_test.go
@@ -40,7 +40,14 @@ func TestMemoryDriverPubSub(t *testing.T) {
 		},
 		AppNetAdapterList: []types.AppNetAdapterStatus{
 			{
-				AllocatedIPv4Addr: net.ParseIP("192.168.1.1"),
+				AssignedAddresses: types.AssignedAddrs{
+					IPv4Addrs: []types.AssignedAddr{
+						{
+							Address:    net.ParseIP("192.168.1.1"),
+							AssignedBy: types.AddressSourceInternalDHCP,
+						},
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Application VIF may have multiple IP addresses assigned. They can be either assigned directly on the same interface, or used on separate VLAN sub-interfaces which share the parent interface MAC address.

LinuxCollector should detect and publish all of them, instead of flapping between them and generating many IP address change notifications, which trigger a flood of NI and App info messages published to the controller.

For DHCP assigned IP addresses, we use lease time to determine if a previously detected IP address is still valid. For statically assigned IP, we expect to see at least one associated ARP packet every 10 minutes. Otherwise, we consider the IP address to be removed or simply not used anymore.

This commit also enhances LinuxCollector to support enabling or disabling ARP snooping in runtime, without requiring to recreate all switch network instances or rebooting device.

Please note that I have added the stable tag because we will need to backport this to stable releases to fix the NI info message flooding caused by arp snooping when app interface has multiple IPs assigned.