### PR TITLE
kvm: Add Machine field to the template of qemuSwtpm

### DIFF
--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -812,8 +812,9 @@ func (ctx KvmContext) CreateDomConfig(domainName string,
 	// render swtpm settings
 	if swtpmCtrlSock != "" {
 		swtpmContext := struct {
+			Machine    string
 			CtrlSocket string
-		}{swtpmCtrlSock}
+		}{ctx.devicemodel, swtpmCtrlSock}
 		t, _ = template.New("qemuSwtpm").Parse(qemuSwtpmTemplate)
 		if err := t.Execute(file, swtpmContext); err != nil {
 			return logError("can't write to config file %s (%v)", file.Name(), err)


### PR DESCRIPTION
Machine field is now used to choose the QEMU's vtpm driver, so it must be added to the qemuSwtpm template. It fixes the following error:

"failed to build domain config: can't write to config file /run/domainmgr/xen/xen1.cfg (template: qemuSwtpm:11:10: executing "qemuSwtpm" at <.Machine>: can't evaluate field Machine in type struct { CtrlSocket string })"