### PR TITLE
[11.0 stable] Enhance LinuxCollector to support detecting multiple app VIF IPs

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -51,7 +51,7 @@
 | netdump.topic.maxcount | integer | 10 | maximum number of netdumps that can be published for each topic. The oldest netdump is unpublished should a new netdump exceed the limit.
 | netdump.downloader.with.pcap | boolean | false | include packet captures inside netdumps for download requests. However, even if enabled, TCP segments carrying non-empty payload (i.e. content which is being downloaded) are excluded and the overall PCAP size is limited to 64MB. |
 | netdump.downloader.http.with.fieldvalue | boolean | false | include HTTP header field values in captured network traces for download requests (beware: may contain secrets, such as datastore credentials). |
-| network.switch.enable.arpsnoop | boolean | true | enable ARP Snooping on switch Network Instance, may need a device reboot to take effect |
+| network.switch.enable.arpsnoop | boolean | true | enable ARP Snooping on switch Network Instances |
 | wwan.query.visible.providers | bool | false | enable to periodically (once per hour) query the set of visible cellular service providers and publish them under WirelessStatus (for every modem) |
 | network.local.legacy.mac.address | bool | false | enables legacy MAC address generation for local network instances for those EVE nodes where changing MAC addresses in applications will lead to incorrect network configuration |
 

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -1201,8 +1201,22 @@ func updateLocalServerMap(getconfigCtx *getconfigContext, localServerURL string)
 				continue
 			}
 			if localServerIP != nil {
-				// check if the defined IP of localServer equals the allocated IP of the app
-				if adapterStatus.AllocatedIPv4Addr.Equal(localServerIP) {
+				// Check if the defined IP of localServer equals one of the IPs
+				// allocated to the app.
+				var matchesApp bool
+				for _, ip := range adapterStatus.AssignedAddresses.IPv4Addrs {
+					if ip.Address.Equal(localServerIP) {
+						matchesApp = true
+						break
+					}
+				}
+				for _, ip := range adapterStatus.AssignedAddresses.IPv6Addrs {
+					if ip.Address.Equal(localServerIP) {
+						matchesApp = true
+						break
+					}
+				}
+				if matchesApp {
 					srvAddr := localServerAddr{
 						localServerAddr: localServerURL,
 						bridgeIP:        adapterStatus.BridgeIPAddr,

--- a/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
+++ b/pkg/pillar/cmd/zedagent/handlenetworkinstance.go
@@ -8,7 +8,6 @@ package zedagent
 import (
 	"bytes"
 	"fmt"
-	"net"
 	"time"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
@@ -108,11 +107,13 @@ func prepareAndPublishNetworkInstanceInfoMsg(ctx *zedagentContext,
 		for mac, addrs := range status.IPAssignments {
 			assignment := new(zinfo.ZmetIPAssignmentEntry)
 			assignment.MacAddress = mac
-			if !addrs.IPv4Addr.Equal(net.IP{}) {
-				assignment.IpAddress = append(assignment.IpAddress, addrs.IPv4Addr.String())
+			for _, assignedIP := range addrs.IPv4Addrs {
+				assignment.IpAddress = append(assignment.IpAddress,
+					assignedIP.Address.String())
 			}
-			for _, ip := range addrs.IPv6Addrs {
-				assignment.IpAddress = append(assignment.IpAddress, ip.String())
+			for _, assignedIP := range addrs.IPv6Addrs {
+				assignment.IpAddress = append(assignment.IpAddress,
+					assignedIP.Address.String())
 			}
 			info.IpAssignments = append(info.IpAssignments, assignment)
 		}

--- a/pkg/pillar/cmd/zedrouter/appnetwork.go
+++ b/pkg/pillar/cmd/zedrouter/appnetwork.go
@@ -62,7 +62,8 @@ func (z *zedrouter) updateVIFsForStateCollecting(
 		}
 		_, vifs, err := z.getArgsForNIStateCollecting(network)
 		if err == nil {
-			err = z.niStateCollector.UpdateCollectingForNI(*netConfig, vifs)
+			err = z.niStateCollector.UpdateCollectingForNI(*netConfig, vifs,
+				z.enableArpSnooping)
 		}
 		if err != nil {
 			z.log.Error(err)
@@ -167,10 +168,7 @@ func (z *zedrouter) updateNIStatusAfterAppNetworkActivate(status *types.AppNetwo
 		netInstStatus.AddVif(z.log, adapterStatus.Vif, adapterStatus.Mac,
 			status.UUIDandVersion.UUID)
 		netInstStatus.IPAssignments[adapterStatus.Mac.String()] =
-			types.AssignedAddrs{
-				IPv4Addr:  adapterStatus.AllocatedIPv4Addr,
-				IPv6Addrs: adapterStatus.AllocatedIPv6List,
-			}
+			adapterStatus.AssignedAddresses
 		z.publishNetworkInstanceStatus(netInstStatus)
 	}
 }

--- a/pkg/pillar/cmd/zedrouter/ipam.go
+++ b/pkg/pillar/cmd/zedrouter/ipam.go
@@ -120,13 +120,15 @@ func (z *zedrouter) lookupOrAllocateIPv4ForVIF(niStatus *types.NetworkInstanceSt
 	// Lookup to see if it is already allocated.
 	if ipAddr == nil {
 		addrs := niStatus.IPAssignments[adapterStatus.Mac.String()]
-		if !isEmptyIP(addrs.IPv4Addr) {
-			z.log.Functionf("lookupOrAllocateIPv4(NI:%v, app:%v): found IP %v for MAC %v",
-				networkID, appID, addrs.IPv4Addr, adapterStatus.Mac)
-			ipAddr = addrs.IPv4Addr
+		ipAddr = addrs.GetInternallyLeasedIPv4Addr()
+		if ipAddr != nil {
+			z.log.Functionf("lookupOrAllocateIPv4(NI:%v, app:%v): "+
+				"found EVE-allocated IP %v for MAC %v", networkID, appID, ipAddr,
+				adapterStatus.Mac)
 		}
 	}
 
+	var newlyAllocated bool
 	if ipAddr == nil {
 		// Allocate IP address dynamically.
 		// Get the app number for the AppNetAdapter entry.
@@ -140,6 +142,7 @@ func (z *zedrouter) lookupOrAllocateIPv4ForVIF(niStatus *types.NetworkInstanceSt
 		}
 		// Pick an IP address from the subnet.
 		ipAddr = netutils.AddToIP(niStatus.DhcpRange.Start, appNum)
+		newlyAllocated = true
 		// Check if the address falls into the Dhcp Range.
 		if !niStatus.DhcpRange.Contains(ipAddr) {
 			err := fmt.Errorf("no free IP addresses in DHCP range(%v, %v)",
@@ -162,12 +165,19 @@ func (z *zedrouter) lookupOrAllocateIPv4ForVIF(niStatus *types.NetworkInstanceSt
 		}
 	}
 	// Later will be overwritten with addresses received from nistate.Collector,
-	// which snoops DHCP traffic and watches DNS server leases to learn the *actual*
+	// which snoops DHCP traffic and watches DHCP server leases to learn the *actual*
 	// IP address assignments.
-	addrs := niStatus.IPAssignments[adapterStatus.Mac.String()] // preserve IPv6 addresses
-	addrs.IPv4Addr = ipAddr
-	niStatus.IPAssignments[adapterStatus.Mac.String()] = addrs
-	z.publishNetworkInstanceStatus(niStatus)
+	if newlyAllocated {
+		// Preserve other IPv4 and IPv6 addresses.
+		addrs := niStatus.IPAssignments[adapterStatus.Mac.String()]
+		addrs.IPv4Addrs = append(addrs.IPv4Addrs,
+			types.AssignedAddr{
+				Address:    ipAddr,
+				AssignedBy: types.AddressSourceInternalDHCP,
+			})
+		niStatus.IPAssignments[adapterStatus.Mac.String()] = addrs
+		z.publishNetworkInstanceStatus(niStatus)
+	}
 	z.log.Functionf("lookupOrAllocateIPv4(NI:%v, app:%v): allocated IP %v for MAC %v",
 		networkID, appID, ipAddr, adapterStatus.Mac)
 	return ipAddr, nil
@@ -188,16 +198,16 @@ func (z *zedrouter) recordAssignedIPsToAdapterStatus(adapter *types.AppNetAdapte
 		z.removeAssignedIPsFromAdapterStatus(adapter)
 		return
 	}
-	adapter.AllocatedIPv4Addr = vifAddrs.IPv4Addr
-	if !isEmptyIP(adapter.AppIPAddr) &&
-		!adapter.AppIPAddr.Equal(adapter.AllocatedIPv4Addr) {
-		// Config and status do not match.
-		adapter.IPAddrMisMatch = true
-	} else {
-		adapter.IPAddrMisMatch = false
+	adapter.AssignedAddresses = vifAddrs.AssignedAddrs
+	adapter.IPAddrMisMatch = false
+	if !isEmptyIP(adapter.AppIPAddr) {
+		leasedIP := adapter.AssignedAddresses.GetInternallyLeasedIPv4Addr()
+		if !adapter.AppIPAddr.Equal(leasedIP) {
+			// Config and status do not match.
+			adapter.IPAddrMisMatch = true
+		}
 	}
-	adapter.AllocatedIPv6List = vifAddrs.IPv6Addrs
-	adapter.IPv4Assigned = !isEmptyIP(vifAddrs.IPv4Addr)
+	adapter.IPv4Assigned = len(vifAddrs.IPv4Addrs) > 0
 }
 
 func (z *zedrouter) removeAssignedIPsFromAppNetStatus(status *types.AppNetworkStatus) {
@@ -208,8 +218,8 @@ func (z *zedrouter) removeAssignedIPsFromAppNetStatus(status *types.AppNetworkSt
 }
 
 func (z *zedrouter) removeAssignedIPsFromAdapterStatus(adapterStatus *types.AppNetAdapterStatus) {
-	adapterStatus.AllocatedIPv6List = nil
-	adapterStatus.AllocatedIPv4Addr = nil
+	adapterStatus.AssignedAddresses.IPv4Addrs = nil
+	adapterStatus.AssignedAddresses.IPv6Addrs = nil
 	adapterStatus.IPAddrMisMatch = false
 	adapterStatus.IPv4Assigned = false
 }

--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -230,7 +230,7 @@ func (z *zedrouter) doUpdateActivatedNetworkInstance(config types.NetworkInstanc
 	z.processNIReconcileStatus(niRecStatus, status)
 	_, vifs, err := z.getArgsForNIStateCollecting(config.UUID)
 	if err == nil {
-		err = z.niStateCollector.UpdateCollectingForNI(config, vifs)
+		err = z.niStateCollector.UpdateCollectingForNI(config, vifs, z.enableArpSnooping)
 	}
 	if err != nil {
 		z.log.Error(err)

--- a/pkg/pillar/cmd/zedrouter/zedrouter.go
+++ b/pkg/pillar/cmd/zedrouter/zedrouter.go
@@ -459,10 +459,7 @@ func (z *zedrouter) run(ctx context.Context) (err error) {
 						niKey, vif.NetAdapterName)
 					continue
 				}
-				netStatus.IPAssignments[mac] = types.AssignedAddrs{
-					IPv4Addr:  newAddrs.IPv4Addr,
-					IPv6Addrs: newAddrs.IPv6Addrs,
-				}
+				netStatus.IPAssignments[mac] = newAddrs.AssignedAddrs
 				z.publishNetworkInstanceStatus(netStatus)
 				appKey := vif.App.String()
 				appStatus := z.lookupAppNetworkStatus(appKey)
@@ -1000,11 +997,13 @@ func (z *zedrouter) lookupNetworkInstanceStatusByAppIP(
 	for _, st := range items {
 		status := st.(types.NetworkInstanceStatus)
 		for _, addrs := range status.IPAssignments {
-			if ip.Equal(addrs.IPv4Addr) {
-				return &status
+			for _, assignedIP := range addrs.IPv4Addrs {
+				if ip.Equal(assignedIP.Address) {
+					return &status
+				}
 			}
-			for _, nip := range addrs.IPv6Addrs {
-				if ip.Equal(nip) {
+			for _, assignedIP := range addrs.IPv6Addrs {
+				if ip.Equal(assignedIP.Address) {
 					return &status
 				}
 			}
@@ -1187,8 +1186,15 @@ func (z *zedrouter) lookupAppNetworkStatusByAppIP(ip net.IP) *types.AppNetworkSt
 	for _, st := range items {
 		status := st.(types.AppNetworkStatus)
 		for _, adapterStatus := range status.AppNetAdapterList {
-			if adapterStatus.AllocatedIPv4Addr.Equal(ip) {
-				return &status
+			for _, adapterIP := range adapterStatus.AssignedAddresses.IPv4Addrs {
+				if adapterIP.Address.Equal(ip) {
+					return &status
+				}
+			}
+			for _, adapterIP := range adapterStatus.AssignedAddresses.IPv6Addrs {
+				if adapterIP.Address.Equal(ip) {
+					return &status
+				}
 			}
 		}
 	}

--- a/pkg/pillar/nistate/linux_iptables.go
+++ b/pkg/pillar/nistate/linux_iptables.go
@@ -56,7 +56,7 @@ func (lc *LinuxCollector) fetchIptablesCounters() []aclCounters {
 	for _, niState := range lc.nis {
 		for _, niVif := range niState.vifs {
 			vifs = append(vifs, vif{
-				ifName: niVif.VIF.HostIfName,
+				ifName: niVif.HostIfName,
 				bridge: niState.bridge.BrIfName,
 			})
 		}

--- a/pkg/pillar/nistate/statecollector.go
+++ b/pkg/pillar/nistate/statecollector.go
@@ -10,7 +10,6 @@
 package nistate
 
 import (
-	"bytes"
 	"fmt"
 	"net"
 
@@ -40,7 +39,7 @@ type Collector interface {
 	// Note that not every change in network instance config is supported. For example,
 	// network instance type (switch / local) cannot change.
 	UpdateCollectingForNI(
-		niConfig types.NetworkInstanceConfig, vifs []AppVIF) error
+		niConfig types.NetworkInstanceConfig, vifs []AppVIF, enableArpSnoop bool) error
 
 	// StopCollectingForNI : stop collecting state data for network instance.
 	// It is called by zedrouter whenever a network instance is about to be deleted.
@@ -135,45 +134,11 @@ func (vifs VIFAddrsList) LookupByAdapterName(
 	return nil
 }
 
-// LookupByGuestMAC : Lookup VIF by the MAC address of the guest interface.
-func (vifs VIFAddrsList) LookupByGuestMAC(mac net.HardwareAddr) *VIFAddrs {
-	for i := range vifs {
-		if bytes.Equal(vifs[i].VIF.GuestIfMAC, mac) {
-			return &vifs[i]
-		}
-	}
-	return nil
-}
-
-// LookupByIP : Lookup VIF by the IP address assigned to the guest interface.
-// Returns first match.
-func (vifs VIFAddrsList) LookupByIP(ip net.IP) *VIFAddrs {
-	for i := range vifs {
-		if vifs[i].HasIP(ip) {
-			return &vifs[i]
-		}
-	}
-	return nil
-}
-
 // VIFAddrs lists IP addresses assigned to a VIF on the guest side
 // (inside the app). This is provided to zedrouter by Collector.
 type VIFAddrs struct {
 	types.AssignedAddrs
 	VIF AppVIF
-}
-
-// HasIP returns true if the given IP address is assigned to this VIF.
-func (vif VIFAddrs) HasIP(ip net.IP) bool {
-	if ip.Equal(vif.IPv4Addr) {
-		return true
-	}
-	for _, ipv6Addr := range vif.IPv6Addrs {
-		if ip.Equal(ipv6Addr) {
-			return true
-		}
-	}
-	return false
 }
 
 // VIFAddrsUpdate describes a change in the address assignment for a single VIF.

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -345,10 +345,9 @@ type AppNetAdapterStatus struct {
 	AppNetAdapterConfig
 	VifInfo
 	BridgeMac         net.HardwareAddr
-	BridgeIPAddr      net.IP   // The address for DNS/DHCP service in zedrouter
-	AllocatedIPv4Addr net.IP   // Assigned to domU
-	AllocatedIPv6List []net.IP // IPv6 addresses assigned to domU
-	IPv4Assigned      bool     // Set to true once DHCP has assigned it to domU
+	BridgeIPAddr      net.IP        // The address for DNS/DHCP service in zedrouter
+	AssignedAddresses AssignedAddrs // IPv4 and IPv6 addresses assigned to domU
+	IPv4Assigned      bool          // Set to true once DHCP has assigned it to domU
 	IPAddrMisMatch    bool
 	HostName          string
 }
@@ -376,8 +375,48 @@ type NetworkInstanceInfo struct {
 
 // AssignedAddrs : IP addresses assigned to application network adapter.
 type AssignedAddrs struct {
-	IPv4Addr  net.IP
-	IPv6Addrs []net.IP
+	IPv4Addrs []AssignedAddr
+	IPv6Addrs []AssignedAddr
+}
+
+// GetInternallyLeasedIPv4Addr returns IPv4 address leased by EVE using
+// an internally run DHCP server.
+func (aa AssignedAddrs) GetInternallyLeasedIPv4Addr() net.IP {
+	for _, addr := range aa.IPv4Addrs {
+		if addr.AssignedBy == AddressSourceInternalDHCP {
+			return addr.Address
+		}
+	}
+	return nil
+}
+
+// AddressSource determines the source of an IP address assigned to an app VIF.
+// Values are power of two and therefore can be used with a bit mask.
+type AddressSource uint8
+
+const (
+	// AddressSourceUndefined : IP address source is not defined
+	AddressSourceUndefined AddressSource = 0
+	// AddressSourceEVEInternal : IP address is used only internally by EVE
+	// (i.e. inside dom0).
+	AddressSourceEVEInternal AddressSource = 1 << iota
+	// AddressSourceInternalDHCP : IP address is leased to an app by an internal DHCP server
+	// run by EVE.
+	AddressSourceInternalDHCP
+	// AddressSourceExternalDHCP : IP address is leased to an app by an external DHCP server.
+	AddressSourceExternalDHCP
+	// AddressSourceSLAAC : Stateless Address Autoconfiguration (SLAAC) was used by the client
+	// to generate a unique IPv6 address.
+	AddressSourceSLAAC
+	// AddressSourceStatic : IP address is assigned to an app statically
+	// (using e.g. cloud-init).
+	AddressSourceStatic
+)
+
+// AssignedAddr : IP address assigned to an application interface (on the guest side).
+type AssignedAddr struct {
+	Address    net.IP
+	AssignedBy AddressSource
 }
 
 // VifNameMac : name and MAC address assigned to app VIF.
@@ -864,11 +903,13 @@ func (status NetworkInstanceStatus) LogKey() string {
 // IsIpAssigned returns true if the given IP address is assigned to any app VIF.
 func (status *NetworkInstanceStatus) IsIpAssigned(ip net.IP) bool {
 	for _, assignments := range status.IPAssignments {
-		if ip.Equal(assignments.IPv4Addr) {
-			return true
+		for _, assignedIP := range assignments.IPv4Addrs {
+			if ip.Equal(assignedIP.Address) {
+				return true
+			}
 		}
-		for _, nip := range assignments.IPv6Addrs {
-			if ip.Equal(nip) {
+		for _, assignedIP := range assignments.IPv6Addrs {
+			if ip.Equal(assignedIP.Address) {
 				return true
 			}
 		}


### PR DESCRIPTION
Application VIF may have multiple IP address assigned. They can be either assigned directly on the same interface, or used on separate VLAN sub-interfaces which share the parent interface MAC address.

LinuxCollector should detect and publish all of them, instead of flapping between them and generating many IP address change notifications, which trigger a flood of NI and App info messages published to the controller.

For DHCP assigned IP addresses, we use lease time to determine if a previously detected IP address is still valid. For statically assigned IP, we expect to see at least one associated ARP packet every 10 minutes. Otherwise, we consider the IP address to be removed or simply not used anymore.

This commit also enhances LinuxCollector to support enabling or disabling ARP snooping in runtime, without requiring to recreate all switch network instances or rebooting device.

Signed-off-by: Milan Lenco <milan@zededa.com>
(cherry picked from commit 5b2acf4)