### PR TITLE
Fix bridge IP source after NI modification

### DIFF
--- a/pkg/pillar/cmd/zedrouter/pubsubhandlers.go
+++ b/pkg/pillar/cmd/zedrouter/pubsubhandlers.go
@@ -370,7 +370,11 @@ func (z *zedrouter) handleNetworkInstanceModify(ctxArg interface{}, key string,
 	}
 	if status.Gateway != nil && status.BridgeMac != nil {
 		addrs := types.AssignedAddrs{
-			IPv4Addrs: []types.AssignedAddr{{Address: status.Gateway}},
+			IPv4Addrs: []types.AssignedAddr{
+				{
+					Address:    status.Gateway,
+					AssignedBy: types.AddressSourceEVEInternal,
+				}},
 		}
 		status.IPAssignments[status.BridgeMac.String()] = addrs
 		status.BridgeIPAddr = status.Gateway


### PR DESCRIPTION
There is a small bug in the master [recently introduced](https://github.com/lf-edge/eve/pull/4253), where the address source of the reported bridge IP changes from `AddressSourceEVEInternal` to `AddressSourceUndefined` when NI config is modified in any way (note that IP source is reported only internally between microservices, not to the controller).
While the reported source of the bridge IP is not important at all, we should still fix it to avoid any confusion.
Please note that this is already fixed in the backport PRs https://github.com/lf-edge/eve/pull/4257 and https://github.com/lf-edge/eve/pull/4256