### PR TITLE
[11.0 stable] Update eden to the latest version 0.9.11

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -59,23 +59,23 @@ jobs:
         arch: [amd64]
         hv: [kvm]
     if: github.event.review.state == 'approved'
-    uses: lf-edge/eden/.github/workflows/test.yml@0.9.3-stable
+    uses: lf-edge/eden/.github/workflows/test.yml@0.9.11
     with:
       eve_image: "evebuild/pr:${{ github.event.pull_request.number  }}"
       eve_artifact_name: eve-${{ matrix.hv }}-${{ matrix.arch }}
       artifact_run_id: ${{ needs.get-run-id.outputs.result }}
-      eden_version: "0.9.3-stable"
+      eden_version: "0.9.11"
 
   test_suite_master:
     if: github.ref == 'refs/heads/master'
-    uses: lf-edge/eden/.github/workflows/test.yml@0.9.3-stable
+    uses: lf-edge/eden/.github/workflows/test.yml@0.9.11
     with:
       eve_image: "lfedge/eve:snapshot"
-      eden_version: "0.9.3-stable"
+      eden_version: "0.9.11"
 
   test_suite_tag:
     if: startsWith(github.ref, 'refs/tags')
-    uses: lf-edge/eden/.github/workflows/test.yml@0.9.3-stable
+    uses: lf-edge/eden/.github/workflows/test.yml@0.9.11
     with:
       eve_image: "lfedge/eve:${{ github.ref_name }}"
-      eden_version: "0.9.3-stable"
+      eden_version: "0.9.11"


### PR DESCRIPTION
Try the latest eden version in the 11.0-stable branch. Currently, most of the test suites are failing on that branch and are therefore pretty much useless.

Signed-off-by: Milan Lenco <milan@zededa.com>
(cherry picked from commit b283541075144f33cbab4f20aebaceaf622f3492)