### PR TITLE
[WIP] Add config for FML mode custom resolution

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -3,6 +3,7 @@
 | Name | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
 | app.allow.vnc | boolean | false (only local access) | allow access to EVE's VNC ports from external IPs |
+| app.fml.resolution | string | notset | Set system-wide value of forced resolution for applications running in FML mode, it can be one of [predefined](/pkg/pillar/types/global.go) FmlResolution* values. |
 | timer.config.interval | integer in seconds | 60 | how frequently device gets config |
 | timer.cert.interval | integer in seconds | 1 day (24*3600) | how frequently device checks for new controller certificates |
 | timer.metric.interval  | integer in seconds | 60 | how frequently device reports metrics |

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -50,6 +50,7 @@ import (
 	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
+	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -2067,6 +2068,15 @@ func configToStatus(ctx *domainContext, config types.DomainConfig,
 			return fmt.Errorf("failed to fetch cloud-init userdata: %s",
 				err)
 		}
+
+		// Set FML custom resolution if it is set in cloud-init config,
+		// xxx : this is hack and this should be removed, this should be
+		// part of the vm config, but desprate times call for desprate measures.
+		status.FmlCustomResolution = types.FmlResolutionUnset
+		if cloudconfig.IsCloudConfig(ciStr) {
+			setFmlCustomResolution(ciStr, status)
+		}
+
 		if status.OCIConfigDir != "" { // If AppInstance is a container, we need to parse cloud-init config and apply the supported parts
 			if cloudconfig.IsCloudConfig(ciStr) { // treat like the cloud-init config
 				cc, err := cloudconfig.ParseCloudConfig(ciStr)
@@ -2111,6 +2121,23 @@ func configToStatus(ctx *domainContext, config types.DomainConfig,
 		})
 	}
 	return nil
+}
+
+func setFmlCustomResolution(config string, status *types.DomainStatus) {
+	var cloudinit map[string]interface{}
+	err := yaml.Unmarshal([]byte(config), &cloudinit)
+	if err != nil {
+		log.Errorf("error parsing cloud-config YAML: %v", err)
+		return
+	}
+
+	status.FmlCustomResolution = types.FmlResolutionUnset
+	if val, ok := cloudinit[string(types.FmlCustomResolution)]; ok {
+		if fmlCustomResolution, valid := val.(string); valid {
+			status.FmlCustomResolution = fmlCustomResolution
+			log.Noticef("FML resolution is set to: %s", status.FmlCustomResolution)
+		}
+	}
 }
 
 // Check for errors and reserve any assigned adapters.

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -715,6 +715,14 @@ func (ctx KvmContext) Setup(status types.DomainStatus, config types.DomainConfig
 	domainName := status.DomainName
 	domainUUID := status.UUIDandVersion.UUID
 
+	// this needs to be reworked to fit into the OVMF_VAR changes.
+	res, err := getFmlCustomResolution(&status, globalConfig)
+	if err != nil {
+		logError("failed to get fml custom resolution: %v", err)
+	} else {
+		logError("fml custom resolution is set to: %s", res)
+	}
+
 	// check if vTPM is enabled
 	swtpmCtrlSock := ""
 	if status.VirtualTPM {
@@ -789,6 +797,34 @@ func isVncShimVMEnabled(
 		globalShimVnc = ok && item.BoolValue
 	}
 	return config.EnableVnc && (config.EnableVncShimVM || globalShimVnc)
+}
+
+func getFmlCustomResolution(status *types.DomainStatus, globalConfig *types.ConfigItemValueMap) (string, error) {
+	fmlResolutions := status.FmlCustomResolution
+	// if not set in the domain status, try to get it from the global config
+	if fmlResolutions == types.FmlResolutionUnset {
+		if globalConfig != nil {
+			item, ok := globalConfig.GlobalSettings[types.FmlCustomResolution]
+			if ok {
+				fmlResolutions = item.StringValue()
+			}
+		}
+	}
+
+	// debug, remove later
+	logError("getFmlCustomResolution -> FmlResolution is set to: %s", fmlResolutions)
+
+	// validate the resolution
+	switch fmlResolutions {
+	case types.FmlResolution800x600,
+		types.FmlResolution1024x768,
+		types.FmlResolution1280x800,
+		types.FmlResolution1920x1080,
+		types.FmlResolutionUnset:
+		return fmlResolutions, nil
+	}
+
+	return "", fmt.Errorf("invalid fml resolution %s", fmlResolutions)
 }
 
 // CreateDomConfig creates a domain config (a qemu config file,

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -318,6 +318,9 @@ type DomainStatus struct {
 	// VirtualTPM is a flag to signal the hypervisor implementation
 	// that vTPM is available for the domain.
 	VirtualTPM bool
+	// FmlCustomResolution is the custom resolution for FML mode,
+	// xxx: this should be moved to VmConfig
+	FmlCustomResolution string
 }
 
 func (status DomainStatus) Key() string {

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -264,6 +264,8 @@ const (
 	SyslogLogLevel GlobalSettingKey = "debug.syslog.loglevel"
 	// KernelLogLevel global setting key
 	KernelLogLevel GlobalSettingKey = "debug.kernel.loglevel"
+	// FmlCustomResolution global setting key
+	FmlCustomResolution GlobalSettingKey = "app.fml.resolution"
 
 	// XXX Temporary flag to disable RFC 3442 classless static route usage
 	DisableDHCPAllOnesNetMask GlobalSettingKey = "debug.disable.dhcp.all-ones.netmask"
@@ -356,6 +358,19 @@ var (
 	}
 	// SyslogKernelDefaultLogLevel is a default loglevel for syslog and kernel.
 	SyslogKernelDefaultLogLevel = "info"
+)
+
+var (
+	// FmlResolutionUnset is a string to indicate that custom resolution is not set
+	FmlResolutionUnset = "unset"
+	// FmlResolution800x600 is a string to indicate 800x600 resolution
+	FmlResolution800x600 = "800x600"
+	// FmlResolution1024x768 is a string to indicate 1024x768 resolution
+	FmlResolution1024x768 = "1024x768"
+	// FmlResolution1280x800 is a string to indicate 1280x720 resolution
+	FmlResolution1280x800 = "1280x800"
+	// FmlResolution1920x1080 is a string to indicate 1280x720 resolution
+	FmlResolution1920x1080 = "1920x1080"
 )
 
 // ConfigItemSpec - Defines what a specification for a configuration should be
@@ -911,6 +926,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddStringItem(DefaultRemoteLogLevel, "info", validateLogrusLevel)
 	configItemSpecMap.AddStringItem(SyslogLogLevel, "info", validateSyslogKernelLevel)
 	configItemSpecMap.AddStringItem(KernelLogLevel, "info", validateSyslogKernelLevel)
+	configItemSpecMap.AddStringItem(FmlCustomResolution, FmlResolutionUnset, blankValidator)
 
 	// Add Agent Settings
 	configItemSpecMap.AddAgentSettingStringItem(LogLevel, "info", validateLogrusLevel)

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -200,6 +200,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		DefaultRemoteLogLevel,
 		SyslogLogLevel,
 		KernelLogLevel,
+		FmlCustomResolution,
 		DisableDHCPAllOnesNetMask,
 		ProcessCloudInitMultiPart,
 		NetDumpEnable,


### PR DESCRIPTION
Add a new config value `app.fml.resolution` to set custom resolution for FML apps. This is a string value in the format of "widthxheight" and must be one of the predefined values, it can be a global config set by zcli :
```
zcli edge-node update <name> --config="app.fml.resolution:1024x768"
```
or it can be set per-vm as part of the "cloud-config" **_top-level_** values:
```
#cloud-config

hostname: vm01
manage_etc_hosts: true
app.fml.resolution: 800x600

ethernets:
    eth0:
        addresses:
        - 192.168.1.3/24
        dhcp4: false
        gateway4: 192.168.1.1
        match:
            macaddress: DE:AD:BE:EF:06:97
        nameservers:
            addresses:
            - 1.1.1.1
            - 8.8.8.8
        set-name: eth0
version: 2
```
This needs to be reworked  and go after we #4261.

## Tests
I've successfully tested the followings : 

1. Config is received if set either via cloud-config or global config ✅
2. `app.fml.resolution` does not make cloud-config invalid and it is not affecting the other configs in the cloud-config (tested with Ubuntu) ✅
3. If both global and cloud-config are set, cloud-config takes precedence ✅
4. If no cloud-config is set, the global config is used ✅