### PR TITLE
pillar: Add support to CDI for native containers

### DIFF
--- a/pkg/pillar/build.yml
+++ b/pkg/pillar/build.yml
@@ -9,6 +9,7 @@ config:
     - /lib/modules:/lib/modules
     - /dev:/dev
     - /etc/resolv.conf:/etc/resolv.conf
+    - /etc/cdi:/etc/cdi
     - /run:/run
     - /config:/config
     - /:/hostfs

--- a/pkg/pillar/go.mod
+++ b/pkg/pillar/go.mod
@@ -62,6 +62,7 @@ require (
 	k8s.io/metrics v0.29.3
 	kubevirt.io/api v1.1.1
 	kubevirt.io/client-go v1.2.0
+	tags.cncf.io/container-device-interface v0.6.2
 )
 
 require (
@@ -202,6 +203,7 @@ require (
 	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0 // indirect
+	github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626 // indirect
 	github.com/openshift/api v0.0.0-20230503133300-8bbcb7ca7183 // indirect
 	github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47 // indirect
 	github.com/openshift/custom-resource-status v1.1.2 // indirect
@@ -217,6 +219,7 @@ require (
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
+	tags.cncf.io/container-device-interface/specs-go v0.6.0 // indirect
 )
 
 replace (

--- a/pkg/pillar/go.sum
+++ b/pkg/pillar/go.sum
@@ -653,7 +653,9 @@ github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngE
 github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
@@ -1292,6 +1294,7 @@ github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBt
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-envparse v0.1.0 h1:bE++6bhIsNCPLvgDZkYqo3nA+/PFI51pkrHdmPSDFPY=
@@ -1300,6 +1303,7 @@ github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjh
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v0.0.0-20161216184304-ed905158d874/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
@@ -1617,6 +1621,7 @@ github.com/opencontainers/runtime-spec v1.1.0 h1:HHUyrt9mwHUjtasSbXSMvs4cyFxh+Bl
 github.com/opencontainers/runtime-spec v1.1.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
 github.com/opencontainers/runtime-tools v0.9.0/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
+github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626 h1:DmNGcqH3WDbV5k8OJ+esPWbqUOX5rMLR2PMvziDMJi0=
 github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626/go.mod h1:BRHJJd0E+cx42OybVYSgUvZmU0B8P9gZuRXlZUP7TKI=
 github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqiriPsEqVhc+svHE=
 github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3ogry1nUQF8Evvo=
@@ -2944,3 +2949,7 @@ sigs.k8s.io/structured-merge-diff/v4 v4.4.1/go.mod h1:N8hJocpFajUSSeSJ9bOZ77Vzej
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
+tags.cncf.io/container-device-interface v0.6.2 h1:dThE6dtp/93ZDGhqaED2Pu374SOeUkBfuvkLuiTdwzg=
+tags.cncf.io/container-device-interface v0.6.2/go.mod h1:Shusyhjs1A5Na/kqPVLL0KqnHQHuunol9LFeUNkuGVE=
+tags.cncf.io/container-device-interface/specs-go v0.6.0 h1:V+tJJN6dqu8Vym6p+Ru+K5mJ49WL6Aoc5SJFSY0RLsQ=
+tags.cncf.io/container-device-interface/specs-go v0.6.0/go.mod h1:hMAwAbMZyBLdmYqWgYcKH0F/yctNpV3P35f+/088A80=

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -748,7 +748,11 @@ func (ctx KvmContext) Setup(status types.DomainStatus, config types.DomainConfig
 		"-readconfig", file.Name(),
 		"-pidfile", kvmStateDir+domainName+"/pid")
 
-	spec, err := ctx.setupSpec(&status, &config, status.OCIConfigDir)
+	spec, err := ctx.setupSpec(&status, &config, &types.AssignableAdapters{
+		Initialized:  false,
+		IoBundleList: []types.IoBundle{},
+	}, types.NewConfigItemValueMap(), status.OCIConfigDir)
+
 	if err != nil {
 		return logError("failed to load OCI spec for domain %s: %v", status.DomainName, err)
 	}

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -128,7 +128,11 @@ func (ctx xenContext) Setup(status types.DomainStatus, config types.DomainConfig
 		return logError("failed to build domain config: %v", err)
 	}
 
-	spec, err := ctx.setupSpec(&status, &config, status.OCIConfigDir)
+	spec, err := ctx.setupSpec(&status, &config, &types.AssignableAdapters{
+		Initialized:  false,
+		IoBundleList: []types.IoBundle{},
+	}, types.NewConfigItemValueMap(), status.OCIConfigDir)
+
 	if err != nil {
 		return logError("failed to load OCI spec for domain %s: %v", status.DomainName, err)
 	}

--- a/pkg/pillar/vendor/github.com/opencontainers/runtime-tools/LICENSE
+++ b/pkg/pillar/vendor/github.com/opencontainers/runtime-tools/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2015 The Linux Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkg/pillar/vendor/github.com/opencontainers/runtime-tools/generate/config.go
+++ b/pkg/pillar/vendor/github.com/opencontainers/runtime-tools/generate/config.go
@@ -1,0 +1,194 @@
+package generate
+
+import (
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func (g *Generator) initConfig() {
+	if g.Config == nil {
+		g.Config = &rspec.Spec{}
+	}
+}
+
+func (g *Generator) initConfigProcess() {
+	g.initConfig()
+	if g.Config.Process == nil {
+		g.Config.Process = &rspec.Process{}
+	}
+}
+
+func (g *Generator) initConfigProcessConsoleSize() {
+	g.initConfigProcess()
+	if g.Config.Process.ConsoleSize == nil {
+		g.Config.Process.ConsoleSize = &rspec.Box{}
+	}
+}
+
+func (g *Generator) initConfigProcessCapabilities() {
+	g.initConfigProcess()
+	if g.Config.Process.Capabilities == nil {
+		g.Config.Process.Capabilities = &rspec.LinuxCapabilities{}
+	}
+}
+
+func (g *Generator) initConfigRoot() {
+	g.initConfig()
+	if g.Config.Root == nil {
+		g.Config.Root = &rspec.Root{}
+	}
+}
+
+func (g *Generator) initConfigAnnotations() {
+	g.initConfig()
+	if g.Config.Annotations == nil {
+		g.Config.Annotations = make(map[string]string)
+	}
+}
+
+func (g *Generator) initConfigHooks() {
+	g.initConfig()
+	if g.Config.Hooks == nil {
+		g.Config.Hooks = &rspec.Hooks{}
+	}
+}
+
+func (g *Generator) initConfigLinux() {
+	g.initConfig()
+	if g.Config.Linux == nil {
+		g.Config.Linux = &rspec.Linux{}
+	}
+}
+
+func (g *Generator) initConfigLinuxIntelRdt() {
+	g.initConfigLinux()
+	if g.Config.Linux.IntelRdt == nil {
+		g.Config.Linux.IntelRdt = &rspec.LinuxIntelRdt{}
+	}
+}
+
+func (g *Generator) initConfigLinuxSysctl() {
+	g.initConfigLinux()
+	if g.Config.Linux.Sysctl == nil {
+		g.Config.Linux.Sysctl = make(map[string]string)
+	}
+}
+
+func (g *Generator) initConfigLinuxSeccomp() {
+	g.initConfigLinux()
+	if g.Config.Linux.Seccomp == nil {
+		g.Config.Linux.Seccomp = &rspec.LinuxSeccomp{}
+	}
+}
+
+func (g *Generator) initConfigLinuxResources() {
+	g.initConfigLinux()
+	if g.Config.Linux.Resources == nil {
+		g.Config.Linux.Resources = &rspec.LinuxResources{}
+	}
+}
+
+func (g *Generator) initConfigLinuxResourcesBlockIO() {
+	g.initConfigLinuxResources()
+	if g.Config.Linux.Resources.BlockIO == nil {
+		g.Config.Linux.Resources.BlockIO = &rspec.LinuxBlockIO{}
+	}
+}
+
+// InitConfigLinuxResourcesCPU initializes CPU of Linux resources
+func (g *Generator) InitConfigLinuxResourcesCPU() {
+	g.initConfigLinuxResources()
+	if g.Config.Linux.Resources.CPU == nil {
+		g.Config.Linux.Resources.CPU = &rspec.LinuxCPU{}
+	}
+}
+
+func (g *Generator) initConfigLinuxResourcesMemory() {
+	g.initConfigLinuxResources()
+	if g.Config.Linux.Resources.Memory == nil {
+		g.Config.Linux.Resources.Memory = &rspec.LinuxMemory{}
+	}
+}
+
+func (g *Generator) initConfigLinuxResourcesNetwork() {
+	g.initConfigLinuxResources()
+	if g.Config.Linux.Resources.Network == nil {
+		g.Config.Linux.Resources.Network = &rspec.LinuxNetwork{}
+	}
+}
+
+func (g *Generator) initConfigLinuxResourcesPids() {
+	g.initConfigLinuxResources()
+	if g.Config.Linux.Resources.Pids == nil {
+		g.Config.Linux.Resources.Pids = &rspec.LinuxPids{}
+	}
+}
+
+func (g *Generator) initConfigLinuxResourcesUnified() {
+	g.initConfigLinuxResources()
+	if g.Config.Linux.Resources.Unified == nil {
+		g.Config.Linux.Resources.Unified = map[string]string{}
+	}
+}
+
+func (g *Generator) initConfigSolaris() {
+	g.initConfig()
+	if g.Config.Solaris == nil {
+		g.Config.Solaris = &rspec.Solaris{}
+	}
+}
+
+func (g *Generator) initConfigSolarisCappedCPU() {
+	g.initConfigSolaris()
+	if g.Config.Solaris.CappedCPU == nil {
+		g.Config.Solaris.CappedCPU = &rspec.SolarisCappedCPU{}
+	}
+}
+
+func (g *Generator) initConfigSolarisCappedMemory() {
+	g.initConfigSolaris()
+	if g.Config.Solaris.CappedMemory == nil {
+		g.Config.Solaris.CappedMemory = &rspec.SolarisCappedMemory{}
+	}
+}
+
+func (g *Generator) initConfigWindows() {
+	g.initConfig()
+	if g.Config.Windows == nil {
+		g.Config.Windows = &rspec.Windows{}
+	}
+}
+
+func (g *Generator) initConfigWindowsNetwork() {
+	g.initConfigWindows()
+	if g.Config.Windows.Network == nil {
+		g.Config.Windows.Network = &rspec.WindowsNetwork{}
+	}
+}
+
+func (g *Generator) initConfigWindowsHyperV() {
+	g.initConfigWindows()
+	if g.Config.Windows.HyperV == nil {
+		g.Config.Windows.HyperV = &rspec.WindowsHyperV{}
+	}
+}
+
+func (g *Generator) initConfigWindowsResources() {
+	g.initConfigWindows()
+	if g.Config.Windows.Resources == nil {
+		g.Config.Windows.Resources = &rspec.WindowsResources{}
+	}
+}
+
+func (g *Generator) initConfigWindowsResourcesMemory() {
+	g.initConfigWindowsResources()
+	if g.Config.Windows.Resources.Memory == nil {
+		g.Config.Windows.Resources.Memory = &rspec.WindowsMemoryResources{}
+	}
+}
+
+func (g *Generator) initConfigVM() {
+	g.initConfig()
+	if g.Config.VM == nil {
+		g.Config.VM = &rspec.VM{}
+	}
+}

--- a/pkg/pillar/vendor/github.com/opencontainers/runtime-tools/generate/generate.go
+++ b/pkg/pillar/vendor/github.com/opencontainers/runtime-tools/generate/generate.go
@@ -1,0 +1,1874 @@
+// Package generate implements functions generating container config files.
+package generate
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-tools/generate/seccomp"
+	capsCheck "github.com/opencontainers/runtime-tools/validate/capabilities"
+	"github.com/syndtr/gocapability/capability"
+)
+
+var (
+	// Namespaces include the names of supported namespaces.
+	Namespaces = []string{"network", "pid", "mount", "ipc", "uts", "user", "cgroup"}
+
+	// we don't care about order...and this is way faster...
+	removeFunc = func(s []string, i int) []string {
+		s[i] = s[len(s)-1]
+		return s[:len(s)-1]
+	}
+)
+
+// Generator represents a generator for a container config.
+type Generator struct {
+	Config       *rspec.Spec
+	HostSpecific bool
+	// This is used to keep a cache of the ENVs added to improve
+	// performance when adding a huge number of ENV variables
+	envMap map[string]int
+}
+
+// ExportOptions have toggles for exporting only certain parts of the specification
+type ExportOptions struct {
+	Seccomp bool // seccomp toggles if only seccomp should be exported
+}
+
+// New creates a configuration Generator with the default
+// configuration for the target operating system.
+func New(os string) (generator Generator, err error) {
+	if os != "linux" && os != "solaris" && os != "windows" && os != "freebsd" {
+		return generator, fmt.Errorf("no defaults configured for %s", os)
+	}
+
+	config := rspec.Spec{
+		Version:  rspec.Version,
+		Hostname: "mrsdalloway",
+	}
+
+	if os == "windows" {
+		config.Process = &rspec.Process{
+			Args: []string{
+				"cmd",
+			},
+			Cwd: `C:\`,
+		}
+		config.Windows = &rspec.Windows{}
+	} else {
+		config.Root = &rspec.Root{
+			Path:     "rootfs",
+			Readonly: false,
+		}
+		config.Process = &rspec.Process{
+			Terminal: false,
+			Args: []string{
+				"sh",
+			},
+		}
+	}
+
+	if os == "linux" || os == "solaris" || os == "freebsd" {
+		config.Process.User = rspec.User{}
+		config.Process.Env = []string{
+			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+			"TERM=xterm",
+		}
+		config.Process.Cwd = "/"
+		config.Process.Rlimits = []rspec.POSIXRlimit{
+			{
+				Type: "RLIMIT_NOFILE",
+				Hard: uint64(1024),
+				Soft: uint64(1024),
+			},
+		}
+	}
+
+	if os == "linux" {
+		config.Process.Capabilities = &rspec.LinuxCapabilities{
+			Bounding: []string{
+				"CAP_CHOWN",
+				"CAP_DAC_OVERRIDE",
+				"CAP_FSETID",
+				"CAP_FOWNER",
+				"CAP_MKNOD",
+				"CAP_NET_RAW",
+				"CAP_SETGID",
+				"CAP_SETUID",
+				"CAP_SETFCAP",
+				"CAP_SETPCAP",
+				"CAP_NET_BIND_SERVICE",
+				"CAP_SYS_CHROOT",
+				"CAP_KILL",
+				"CAP_AUDIT_WRITE",
+			},
+			Permitted: []string{
+				"CAP_CHOWN",
+				"CAP_DAC_OVERRIDE",
+				"CAP_FSETID",
+				"CAP_FOWNER",
+				"CAP_MKNOD",
+				"CAP_NET_RAW",
+				"CAP_SETGID",
+				"CAP_SETUID",
+				"CAP_SETFCAP",
+				"CAP_SETPCAP",
+				"CAP_NET_BIND_SERVICE",
+				"CAP_SYS_CHROOT",
+				"CAP_KILL",
+				"CAP_AUDIT_WRITE",
+			},
+			Inheritable: []string{
+				"CAP_CHOWN",
+				"CAP_DAC_OVERRIDE",
+				"CAP_FSETID",
+				"CAP_FOWNER",
+				"CAP_MKNOD",
+				"CAP_NET_RAW",
+				"CAP_SETGID",
+				"CAP_SETUID",
+				"CAP_SETFCAP",
+				"CAP_SETPCAP",
+				"CAP_NET_BIND_SERVICE",
+				"CAP_SYS_CHROOT",
+				"CAP_KILL",
+				"CAP_AUDIT_WRITE",
+			},
+			Effective: []string{
+				"CAP_CHOWN",
+				"CAP_DAC_OVERRIDE",
+				"CAP_FSETID",
+				"CAP_FOWNER",
+				"CAP_MKNOD",
+				"CAP_NET_RAW",
+				"CAP_SETGID",
+				"CAP_SETUID",
+				"CAP_SETFCAP",
+				"CAP_SETPCAP",
+				"CAP_NET_BIND_SERVICE",
+				"CAP_SYS_CHROOT",
+				"CAP_KILL",
+				"CAP_AUDIT_WRITE",
+			},
+			Ambient: []string{
+				"CAP_CHOWN",
+				"CAP_DAC_OVERRIDE",
+				"CAP_FSETID",
+				"CAP_FOWNER",
+				"CAP_MKNOD",
+				"CAP_NET_RAW",
+				"CAP_SETGID",
+				"CAP_SETUID",
+				"CAP_SETFCAP",
+				"CAP_SETPCAP",
+				"CAP_NET_BIND_SERVICE",
+				"CAP_SYS_CHROOT",
+				"CAP_KILL",
+				"CAP_AUDIT_WRITE",
+			},
+		}
+		config.Mounts = []rspec.Mount{
+			{
+				Destination: "/proc",
+				Type:        "proc",
+				Source:      "proc",
+				Options:     []string{"nosuid", "noexec", "nodev"},
+			},
+			{
+				Destination: "/dev",
+				Type:        "tmpfs",
+				Source:      "tmpfs",
+				Options:     []string{"nosuid", "noexec", "strictatime", "mode=755", "size=65536k"},
+			},
+			{
+				Destination: "/dev/pts",
+				Type:        "devpts",
+				Source:      "devpts",
+				Options:     []string{"nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620", "gid=5"},
+			},
+			{
+				Destination: "/dev/shm",
+				Type:        "tmpfs",
+				Source:      "shm",
+				Options:     []string{"nosuid", "noexec", "nodev", "mode=1777", "size=65536k"},
+			},
+			{
+				Destination: "/dev/mqueue",
+				Type:        "mqueue",
+				Source:      "mqueue",
+				Options:     []string{"nosuid", "noexec", "nodev"},
+			},
+			{
+				Destination: "/sys",
+				Type:        "sysfs",
+				Source:      "sysfs",
+				Options:     []string{"nosuid", "noexec", "nodev", "ro"},
+			},
+		}
+		config.Linux = &rspec.Linux{
+			Resources: &rspec.LinuxResources{
+				Devices: []rspec.LinuxDeviceCgroup{
+					{
+						Allow:  false,
+						Access: "rwm",
+					},
+				},
+			},
+			Namespaces: []rspec.LinuxNamespace{
+				{
+					Type: "pid",
+				},
+				{
+					Type: "network",
+				},
+				{
+					Type: "ipc",
+				},
+				{
+					Type: "uts",
+				},
+				{
+					Type: "mount",
+				},
+			},
+			Seccomp: seccomp.DefaultProfile(&config),
+		}
+	} else if os == "freebsd" {
+		config.Mounts = []rspec.Mount{
+			{
+				Destination: "/dev",
+				Type:        "devfs",
+				Source:      "devfs",
+				Options:     []string{"ruleset=4"},
+			},
+			{
+				Destination: "/dev/fd",
+				Type:        "fdescfs",
+				Source:      "fdesc",
+				Options:     []string{},
+			},
+		}
+	}
+
+	envCache := map[string]int{}
+	if config.Process != nil {
+		envCache = createEnvCacheMap(config.Process.Env)
+	}
+
+	return Generator{Config: &config, envMap: envCache}, nil
+}
+
+// NewFromSpec creates a configuration Generator from a given
+// configuration.
+func NewFromSpec(config *rspec.Spec) Generator {
+	envCache := map[string]int{}
+	if config != nil && config.Process != nil {
+		envCache = createEnvCacheMap(config.Process.Env)
+	}
+
+	return Generator{
+		Config: config,
+		envMap: envCache,
+	}
+}
+
+// NewFromFile loads the template specified in a file into a
+// configuration Generator.
+func NewFromFile(path string) (Generator, error) {
+	cf, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Generator{}, fmt.Errorf("template configuration at %s not found", path)
+		}
+		return Generator{}, err
+	}
+	defer cf.Close()
+
+	return NewFromTemplate(cf)
+}
+
+// NewFromTemplate loads the template from io.Reader into a
+// configuration Generator.
+func NewFromTemplate(r io.Reader) (Generator, error) {
+	var config rspec.Spec
+	if err := json.NewDecoder(r).Decode(&config); err != nil {
+		return Generator{}, err
+	}
+
+	envCache := map[string]int{}
+	if config.Process != nil {
+		envCache = createEnvCacheMap(config.Process.Env)
+	}
+
+	return Generator{
+		Config: &config,
+		envMap: envCache,
+	}, nil
+}
+
+// createEnvCacheMap creates a hash map with the ENV variables given by the config
+func createEnvCacheMap(env []string) map[string]int {
+	envMap := make(map[string]int, len(env))
+	for i, val := range env {
+		envMap[val] = i
+	}
+	return envMap
+}
+
+// SetSpec sets the configuration in the Generator g.
+//
+// Deprecated: Replace with:
+//
+//   Use generator.Config = config
+func (g *Generator) SetSpec(config *rspec.Spec) {
+	g.Config = config
+}
+
+// Spec gets the configuration from the Generator g.
+//
+// Deprecated: Replace with generator.Config.
+func (g *Generator) Spec() *rspec.Spec {
+	return g.Config
+}
+
+// Save writes the configuration into w.
+func (g *Generator) Save(w io.Writer, exportOpts ExportOptions) (err error) {
+	var data []byte
+
+	if g.Config.Linux != nil {
+		buf, err := json.Marshal(g.Config.Linux)
+		if err != nil {
+			return err
+		}
+		if string(buf) == "{}" {
+			g.Config.Linux = nil
+		}
+	}
+
+	if exportOpts.Seccomp {
+		data, err = json.MarshalIndent(g.Config.Linux.Seccomp, "", "\t")
+	} else {
+		data, err = json.MarshalIndent(g.Config, "", "\t")
+	}
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(data)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// SaveToFile writes the configuration into a file.
+func (g *Generator) SaveToFile(path string, exportOpts ExportOptions) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return g.Save(f, exportOpts)
+}
+
+// SetVersion sets g.Config.Version.
+func (g *Generator) SetVersion(version string) {
+	g.initConfig()
+	g.Config.Version = version
+}
+
+// SetRootPath sets g.Config.Root.Path.
+func (g *Generator) SetRootPath(path string) {
+	g.initConfigRoot()
+	g.Config.Root.Path = path
+}
+
+// SetRootReadonly sets g.Config.Root.Readonly.
+func (g *Generator) SetRootReadonly(b bool) {
+	g.initConfigRoot()
+	g.Config.Root.Readonly = b
+}
+
+// SetHostname sets g.Config.Hostname.
+func (g *Generator) SetHostname(s string) {
+	g.initConfig()
+	g.Config.Hostname = s
+}
+
+// SetOCIVersion sets g.Config.Version.
+func (g *Generator) SetOCIVersion(s string) {
+	g.initConfig()
+	g.Config.Version = s
+}
+
+// ClearAnnotations clears g.Config.Annotations.
+func (g *Generator) ClearAnnotations() {
+	if g.Config == nil {
+		return
+	}
+	g.Config.Annotations = make(map[string]string)
+}
+
+// AddAnnotation adds an annotation into g.Config.Annotations.
+func (g *Generator) AddAnnotation(key, value string) {
+	g.initConfigAnnotations()
+	g.Config.Annotations[key] = value
+}
+
+// RemoveAnnotation remove an annotation from g.Config.Annotations.
+func (g *Generator) RemoveAnnotation(key string) {
+	if g.Config == nil || g.Config.Annotations == nil {
+		return
+	}
+	delete(g.Config.Annotations, key)
+}
+
+// RemoveHostname removes g.Config.Hostname, setting it to an empty string.
+func (g *Generator) RemoveHostname() {
+	if g.Config == nil {
+		return
+	}
+	g.Config.Hostname = ""
+}
+
+// SetProcessConsoleSize sets g.Config.Process.ConsoleSize.
+func (g *Generator) SetProcessConsoleSize(width, height uint) {
+	g.initConfigProcessConsoleSize()
+	g.Config.Process.ConsoleSize.Width = width
+	g.Config.Process.ConsoleSize.Height = height
+}
+
+// SetProcessUID sets g.Config.Process.User.UID.
+func (g *Generator) SetProcessUID(uid uint32) {
+	g.initConfigProcess()
+	g.Config.Process.User.UID = uid
+}
+
+// SetProcessUsername sets g.Config.Process.User.Username.
+func (g *Generator) SetProcessUsername(username string) {
+	g.initConfigProcess()
+	g.Config.Process.User.Username = username
+}
+
+// SetProcessUmask sets g.Config.Process.User.Umask.
+func (g *Generator) SetProcessUmask(umask uint32) {
+	g.initConfigProcess()
+	u := umask
+	g.Config.Process.User.Umask = &u
+}
+
+// SetProcessGID sets g.Config.Process.User.GID.
+func (g *Generator) SetProcessGID(gid uint32) {
+	g.initConfigProcess()
+	g.Config.Process.User.GID = gid
+}
+
+// SetProcessCwd sets g.Config.Process.Cwd.
+func (g *Generator) SetProcessCwd(cwd string) {
+	g.initConfigProcess()
+	g.Config.Process.Cwd = cwd
+}
+
+// SetProcessNoNewPrivileges sets g.Config.Process.NoNewPrivileges.
+func (g *Generator) SetProcessNoNewPrivileges(b bool) {
+	g.initConfigProcess()
+	g.Config.Process.NoNewPrivileges = b
+}
+
+// SetProcessTerminal sets g.Config.Process.Terminal.
+func (g *Generator) SetProcessTerminal(b bool) {
+	g.initConfigProcess()
+	g.Config.Process.Terminal = b
+}
+
+// SetProcessApparmorProfile sets g.Config.Process.ApparmorProfile.
+func (g *Generator) SetProcessApparmorProfile(prof string) {
+	g.initConfigProcess()
+	g.Config.Process.ApparmorProfile = prof
+}
+
+// SetProcessArgs sets g.Config.Process.Args.
+func (g *Generator) SetProcessArgs(args []string) {
+	g.initConfigProcess()
+	g.Config.Process.Args = args
+}
+
+// ClearProcessEnv clears g.Config.Process.Env.
+func (g *Generator) ClearProcessEnv() {
+	if g.Config == nil || g.Config.Process == nil {
+		return
+	}
+	g.Config.Process.Env = []string{}
+	// Clear out the env cache map as well
+	g.envMap = map[string]int{}
+}
+
+// AddProcessEnv adds name=value into g.Config.Process.Env, or replaces an
+// existing entry with the given name.
+func (g *Generator) AddProcessEnv(name, value string) {
+	if name == "" {
+		return
+	}
+
+	g.initConfigProcess()
+	g.addEnv(fmt.Sprintf("%s=%s", name, value), name)
+}
+
+// AddMultipleProcessEnv adds multiple name=value into g.Config.Process.Env, or replaces
+// existing entries with the given name.
+func (g *Generator) AddMultipleProcessEnv(envs []string) {
+	g.initConfigProcess()
+
+	for _, val := range envs {
+		split := strings.SplitN(val, "=", 2)
+		g.addEnv(val, split[0])
+	}
+}
+
+// addEnv looks through adds ENV to the Process and checks envMap for
+// any duplicates
+// This is called by both AddMultipleProcessEnv and AddProcessEnv
+func (g *Generator) addEnv(env, key string) {
+	if idx, ok := g.envMap[key]; ok {
+		// The ENV exists in the cache, so change its value in g.Config.Process.Env
+		g.Config.Process.Env[idx] = env
+	} else {
+		// else the env doesn't exist, so add it and add it's index to g.envMap
+		g.Config.Process.Env = append(g.Config.Process.Env, env)
+		g.envMap[key] = len(g.Config.Process.Env) - 1
+	}
+}
+
+// AddProcessRlimits adds rlimit into g.Config.Process.Rlimits.
+func (g *Generator) AddProcessRlimits(rType string, rHard uint64, rSoft uint64) {
+	g.initConfigProcess()
+	for i, rlimit := range g.Config.Process.Rlimits {
+		if rlimit.Type == rType {
+			g.Config.Process.Rlimits[i].Hard = rHard
+			g.Config.Process.Rlimits[i].Soft = rSoft
+			return
+		}
+	}
+
+	newRlimit := rspec.POSIXRlimit{
+		Type: rType,
+		Hard: rHard,
+		Soft: rSoft,
+	}
+	g.Config.Process.Rlimits = append(g.Config.Process.Rlimits, newRlimit)
+}
+
+// RemoveProcessRlimits removes a rlimit from g.Config.Process.Rlimits.
+func (g *Generator) RemoveProcessRlimits(rType string) {
+	if g.Config == nil || g.Config.Process == nil {
+		return
+	}
+	for i, rlimit := range g.Config.Process.Rlimits {
+		if rlimit.Type == rType {
+			g.Config.Process.Rlimits = append(g.Config.Process.Rlimits[:i], g.Config.Process.Rlimits[i+1:]...)
+			return
+		}
+	}
+}
+
+// ClearProcessRlimits clear g.Config.Process.Rlimits.
+func (g *Generator) ClearProcessRlimits() {
+	if g.Config == nil || g.Config.Process == nil {
+		return
+	}
+	g.Config.Process.Rlimits = []rspec.POSIXRlimit{}
+}
+
+// ClearProcessAdditionalGids clear g.Config.Process.AdditionalGids.
+func (g *Generator) ClearProcessAdditionalGids() {
+	if g.Config == nil || g.Config.Process == nil {
+		return
+	}
+	g.Config.Process.User.AdditionalGids = []uint32{}
+}
+
+// AddProcessAdditionalGid adds an additional gid into g.Config.Process.AdditionalGids.
+func (g *Generator) AddProcessAdditionalGid(gid uint32) {
+	g.initConfigProcess()
+	for _, group := range g.Config.Process.User.AdditionalGids {
+		if group == gid {
+			return
+		}
+	}
+	g.Config.Process.User.AdditionalGids = append(g.Config.Process.User.AdditionalGids, gid)
+}
+
+// SetProcessSelinuxLabel sets g.Config.Process.SelinuxLabel.
+func (g *Generator) SetProcessSelinuxLabel(label string) {
+	g.initConfigProcess()
+	g.Config.Process.SelinuxLabel = label
+}
+
+// SetLinuxCgroupsPath sets g.Config.Linux.CgroupsPath.
+func (g *Generator) SetLinuxCgroupsPath(path string) {
+	g.initConfigLinux()
+	g.Config.Linux.CgroupsPath = path
+}
+
+// SetLinuxIntelRdtClosID sets g.Config.Linux.IntelRdt.ClosID
+func (g *Generator) SetLinuxIntelRdtClosID(clos string) {
+	g.initConfigLinuxIntelRdt()
+	g.Config.Linux.IntelRdt.ClosID = clos
+}
+
+// SetLinuxIntelRdtL3CacheSchema sets g.Config.Linux.IntelRdt.L3CacheSchema
+func (g *Generator) SetLinuxIntelRdtL3CacheSchema(schema string) {
+	g.initConfigLinuxIntelRdt()
+	g.Config.Linux.IntelRdt.L3CacheSchema = schema
+}
+
+// SetLinuxMountLabel sets g.Config.Linux.MountLabel.
+func (g *Generator) SetLinuxMountLabel(label string) {
+	g.initConfigLinux()
+	g.Config.Linux.MountLabel = label
+}
+
+// SetProcessOOMScoreAdj sets g.Config.Process.OOMScoreAdj.
+func (g *Generator) SetProcessOOMScoreAdj(adj int) {
+	g.initConfigProcess()
+	g.Config.Process.OOMScoreAdj = &adj
+}
+
+// SetLinuxResourcesBlockIOLeafWeight sets g.Config.Linux.Resources.BlockIO.LeafWeight.
+func (g *Generator) SetLinuxResourcesBlockIOLeafWeight(weight uint16) {
+	g.initConfigLinuxResourcesBlockIO()
+	g.Config.Linux.Resources.BlockIO.LeafWeight = &weight
+}
+
+// AddLinuxResourcesBlockIOLeafWeightDevice adds or sets g.Config.Linux.Resources.BlockIO.WeightDevice.LeafWeight.
+func (g *Generator) AddLinuxResourcesBlockIOLeafWeightDevice(major int64, minor int64, weight uint16) {
+	g.initConfigLinuxResourcesBlockIO()
+	for i, weightDevice := range g.Config.Linux.Resources.BlockIO.WeightDevice {
+		if weightDevice.Major == major && weightDevice.Minor == minor {
+			g.Config.Linux.Resources.BlockIO.WeightDevice[i].LeafWeight = &weight
+			return
+		}
+	}
+	weightDevice := new(rspec.LinuxWeightDevice)
+	weightDevice.Major = major
+	weightDevice.Minor = minor
+	weightDevice.LeafWeight = &weight
+	g.Config.Linux.Resources.BlockIO.WeightDevice = append(g.Config.Linux.Resources.BlockIO.WeightDevice, *weightDevice)
+}
+
+// DropLinuxResourcesBlockIOLeafWeightDevice drops a item form g.Config.Linux.Resources.BlockIO.WeightDevice.LeafWeight
+func (g *Generator) DropLinuxResourcesBlockIOLeafWeightDevice(major int64, minor int64) {
+	if g.Config == nil || g.Config.Linux == nil || g.Config.Linux.Resources == nil || g.Config.Linux.Resources.BlockIO == nil {
+		return
+	}
+
+	for i, weightDevice := range g.Config.Linux.Resources.BlockIO.WeightDevice {
+		if weightDevice.Major == major && weightDevice.Minor == minor {
+			if weightDevice.Weight != nil {
+				newWeightDevice := new(rspec.LinuxWeightDevice)
+				newWeightDevice.Major = major
+				newWeightDevice.Minor = minor
+				newWeightDevice.Weight = weightDevice.Weight
+				g.Config.Linux.Resources.BlockIO.WeightDevice[i] = *newWeightDevice
+			} else {
+				g.Config.Linux.Resources.BlockIO.WeightDevice = append(g.Config.Linux.Resources.BlockIO.WeightDevice[:i], g.Config.Linux.Resources.BlockIO.WeightDevice[i+1:]...)
+			}
+			return
+		}
+	}
+}
+
+// SetLinuxResourcesBlockIOWeight sets g.Config.Linux.Resources.BlockIO.Weight.
+func (g *Generator) SetLinuxResourcesBlockIOWeight(weight uint16) {
+	g.initConfigLinuxResourcesBlockIO()
+	g.Config.Linux.Resources.BlockIO.Weight = &weight
+}
+
+// AddLinuxResourcesBlockIOWeightDevice adds or sets g.Config.Linux.Resources.BlockIO.WeightDevice.Weight.
+func (g *Generator) AddLinuxResourcesBlockIOWeightDevice(major int64, minor int64, weight uint16) {
+	g.initConfigLinuxResourcesBlockIO()
+	for i, weightDevice := range g.Config.Linux.Resources.BlockIO.WeightDevice {
+		if weightDevice.Major == major && weightDevice.Minor == minor {
+			g.Config.Linux.Resources.BlockIO.WeightDevice[i].Weight = &weight
+			return
+		}
+	}
+	weightDevice := new(rspec.LinuxWeightDevice)
+	weightDevice.Major = major
+	weightDevice.Minor = minor
+	weightDevice.Weight = &weight
+	g.Config.Linux.Resources.BlockIO.WeightDevice = append(g.Config.Linux.Resources.BlockIO.WeightDevice, *weightDevice)
+}
+
+// DropLinuxResourcesBlockIOWeightDevice drops a item form g.Config.Linux.Resources.BlockIO.WeightDevice.Weight
+func (g *Generator) DropLinuxResourcesBlockIOWeightDevice(major int64, minor int64) {
+	if g.Config == nil || g.Config.Linux == nil || g.Config.Linux.Resources == nil || g.Config.Linux.Resources.BlockIO == nil {
+		return
+	}
+
+	for i, weightDevice := range g.Config.Linux.Resources.BlockIO.WeightDevice {
+		if weightDevice.Major == major && weightDevice.Minor == minor {
+			if weightDevice.LeafWeight != nil {
+				newWeightDevice := new(rspec.LinuxWeightDevice)
+				newWeightDevice.Major = major
+				newWeightDevice.Minor = minor
+				newWeightDevice.LeafWeight = weightDevice.LeafWeight
+				g.Config.Linux.Resources.BlockIO.WeightDevice[i] = *newWeightDevice
+			} else {
+				g.Config.Linux.Resources.BlockIO.WeightDevice = append(g.Config.Linux.Resources.BlockIO.WeightDevice[:i], g.Config.Linux.Resources.BlockIO.WeightDevice[i+1:]...)
+			}
+			return
+		}
+	}
+}
+
+// AddLinuxResourcesBlockIOThrottleReadBpsDevice adds or sets g.Config.Linux.Resources.BlockIO.ThrottleReadBpsDevice.
+func (g *Generator) AddLinuxResourcesBlockIOThrottleReadBpsDevice(major int64, minor int64, rate uint64) {
+	g.initConfigLinuxResourcesBlockIO()
+	throttleDevices := addOrReplaceBlockIOThrottleDevice(g.Config.Linux.Resources.BlockIO.ThrottleReadBpsDevice, major, minor, rate)
+	g.Config.Linux.Resources.BlockIO.ThrottleReadBpsDevice = throttleDevices
+}
+
+// DropLinuxResourcesBlockIOThrottleReadBpsDevice drops a item from g.Config.Linux.Resources.BlockIO.ThrottleReadBpsDevice.
+func (g *Generator) DropLinuxResourcesBlockIOThrottleReadBpsDevice(major int64, minor int64) {
+	if g.Config == nil || g.Config.Linux == nil || g.Config.Linux.Resources == nil || g.Config.Linux.Resources.BlockIO == nil {
+		return
+	}
+
+	throttleDevices := dropBlockIOThrottleDevice(g.Config.Linux.Resources.BlockIO.ThrottleReadBpsDevice, major, minor)
+	g.Config.Linux.Resources.BlockIO.ThrottleReadBpsDevice = throttleDevices
+}
+
+// AddLinuxResourcesBlockIOThrottleReadIOPSDevice adds or sets g.Config.Linux.Resources.BlockIO.ThrottleReadIOPSDevice.
+func (g *Generator) AddLinuxResourcesBlockIOThrottleReadIOPSDevice(major int64, minor int64, rate uint64) {
+	g.initConfigLinuxResourcesBlockIO()
+	throttleDevices := addOrReplaceBlockIOThrottleDevice(g.Config.Linux.Resources.BlockIO.ThrottleReadIOPSDevice, major, minor, rate)
+	g.Config.Linux.Resources.BlockIO.ThrottleReadIOPSDevice = throttleDevices
+}
+
+// DropLinuxResourcesBlockIOThrottleReadIOPSDevice drops a item from g.Config.Linux.Resources.BlockIO.ThrottleReadIOPSDevice.
+func (g *Generator) DropLinuxResourcesBlockIOThrottleReadIOPSDevice(major int64, minor int64) {
+	if g.Config == nil || g.Config.Linux == nil || g.Config.Linux.Resources == nil || g.Config.Linux.Resources.BlockIO == nil {
+		return
+	}
+
+	throttleDevices := dropBlockIOThrottleDevice(g.Config.Linux.Resources.BlockIO.ThrottleReadIOPSDevice, major, minor)
+	g.Config.Linux.Resources.BlockIO.ThrottleReadIOPSDevice = throttleDevices
+}
+
+// AddLinuxResourcesBlockIOThrottleWriteBpsDevice adds or sets g.Config.Linux.Resources.BlockIO.ThrottleWriteBpsDevice.
+func (g *Generator) AddLinuxResourcesBlockIOThrottleWriteBpsDevice(major int64, minor int64, rate uint64) {
+	g.initConfigLinuxResourcesBlockIO()
+	throttleDevices := addOrReplaceBlockIOThrottleDevice(g.Config.Linux.Resources.BlockIO.ThrottleWriteBpsDevice, major, minor, rate)
+	g.Config.Linux.Resources.BlockIO.ThrottleWriteBpsDevice = throttleDevices
+}
+
+// DropLinuxResourcesBlockIOThrottleWriteBpsDevice drops a item from g.Config.Linux.Resources.BlockIO.ThrottleWriteBpsDevice.
+func (g *Generator) DropLinuxResourcesBlockIOThrottleWriteBpsDevice(major int64, minor int64) {
+	if g.Config == nil || g.Config.Linux == nil || g.Config.Linux.Resources == nil || g.Config.Linux.Resources.BlockIO == nil {
+		return
+	}
+
+	throttleDevices := dropBlockIOThrottleDevice(g.Config.Linux.Resources.BlockIO.ThrottleWriteBpsDevice, major, minor)
+	g.Config.Linux.Resources.BlockIO.ThrottleWriteBpsDevice = throttleDevices
+}
+
+// AddLinuxResourcesBlockIOThrottleWriteIOPSDevice adds or sets g.Config.Linux.Resources.BlockIO.ThrottleWriteIOPSDevice.
+func (g *Generator) AddLinuxResourcesBlockIOThrottleWriteIOPSDevice(major int64, minor int64, rate uint64) {
+	g.initConfigLinuxResourcesBlockIO()
+	throttleDevices := addOrReplaceBlockIOThrottleDevice(g.Config.Linux.Resources.BlockIO.ThrottleWriteIOPSDevice, major, minor, rate)
+	g.Config.Linux.Resources.BlockIO.ThrottleWriteIOPSDevice = throttleDevices
+}
+
+// DropLinuxResourcesBlockIOThrottleWriteIOPSDevice drops a item from g.Config.Linux.Resources.BlockIO.ThrottleWriteIOPSDevice.
+func (g *Generator) DropLinuxResourcesBlockIOThrottleWriteIOPSDevice(major int64, minor int64) {
+	if g.Config == nil || g.Config.Linux == nil || g.Config.Linux.Resources == nil || g.Config.Linux.Resources.BlockIO == nil {
+		return
+	}
+
+	throttleDevices := dropBlockIOThrottleDevice(g.Config.Linux.Resources.BlockIO.ThrottleWriteIOPSDevice, major, minor)
+	g.Config.Linux.Resources.BlockIO.ThrottleWriteIOPSDevice = throttleDevices
+}
+
+// SetLinuxResourcesCPUShares sets g.Config.Linux.Resources.CPU.Shares.
+func (g *Generator) SetLinuxResourcesCPUShares(shares uint64) {
+	g.InitConfigLinuxResourcesCPU()
+	g.Config.Linux.Resources.CPU.Shares = &shares
+}
+
+// SetLinuxResourcesCPUQuota sets g.Config.Linux.Resources.CPU.Quota.
+func (g *Generator) SetLinuxResourcesCPUQuota(quota int64) {
+	g.InitConfigLinuxResourcesCPU()
+	g.Config.Linux.Resources.CPU.Quota = &quota
+}
+
+// SetLinuxResourcesCPUPeriod sets g.Config.Linux.Resources.CPU.Period.
+func (g *Generator) SetLinuxResourcesCPUPeriod(period uint64) {
+	g.InitConfigLinuxResourcesCPU()
+	g.Config.Linux.Resources.CPU.Period = &period
+}
+
+// SetLinuxResourcesCPURealtimeRuntime sets g.Config.Linux.Resources.CPU.RealtimeRuntime.
+func (g *Generator) SetLinuxResourcesCPURealtimeRuntime(time int64) {
+	g.InitConfigLinuxResourcesCPU()
+	g.Config.Linux.Resources.CPU.RealtimeRuntime = &time
+}
+
+// SetLinuxResourcesCPURealtimePeriod sets g.Config.Linux.Resources.CPU.RealtimePeriod.
+func (g *Generator) SetLinuxResourcesCPURealtimePeriod(period uint64) {
+	g.InitConfigLinuxResourcesCPU()
+	g.Config.Linux.Resources.CPU.RealtimePeriod = &period
+}
+
+// SetLinuxResourcesCPUCpus sets g.Config.Linux.Resources.CPU.Cpus.
+func (g *Generator) SetLinuxResourcesCPUCpus(cpus string) {
+	g.InitConfigLinuxResourcesCPU()
+	g.Config.Linux.Resources.CPU.Cpus = cpus
+}
+
+// SetLinuxResourcesCPUMems sets g.Config.Linux.Resources.CPU.Mems.
+func (g *Generator) SetLinuxResourcesCPUMems(mems string) {
+	g.InitConfigLinuxResourcesCPU()
+	g.Config.Linux.Resources.CPU.Mems = mems
+}
+
+// AddLinuxResourcesHugepageLimit adds or sets g.Config.Linux.Resources.HugepageLimits.
+func (g *Generator) AddLinuxResourcesHugepageLimit(pageSize string, limit uint64) {
+	hugepageLimit := rspec.LinuxHugepageLimit{
+		Pagesize: pageSize,
+		Limit:    limit,
+	}
+
+	g.initConfigLinuxResources()
+	for i, pageLimit := range g.Config.Linux.Resources.HugepageLimits {
+		if pageLimit.Pagesize == pageSize {
+			g.Config.Linux.Resources.HugepageLimits[i].Limit = limit
+			return
+		}
+	}
+	g.Config.Linux.Resources.HugepageLimits = append(g.Config.Linux.Resources.HugepageLimits, hugepageLimit)
+}
+
+// DropLinuxResourcesHugepageLimit drops a hugepage limit from g.Config.Linux.Resources.HugepageLimits.
+func (g *Generator) DropLinuxResourcesHugepageLimit(pageSize string) {
+	if g.Config == nil || g.Config.Linux == nil || g.Config.Linux.Resources == nil {
+		return
+	}
+
+	for i, pageLimit := range g.Config.Linux.Resources.HugepageLimits {
+		if pageLimit.Pagesize == pageSize {
+			g.Config.Linux.Resources.HugepageLimits = append(g.Config.Linux.Resources.HugepageLimits[:i], g.Config.Linux.Resources.HugepageLimits[i+1:]...)
+			return
+		}
+	}
+}
+
+// AddLinuxResourcesUnified sets the g.Config.Linux.Resources.Unified
+func (g *Generator) SetLinuxResourcesUnified(unified map[string]string) {
+	g.initConfigLinuxResourcesUnified()
+	for k, v := range unified {
+		g.Config.Linux.Resources.Unified[k] = v
+	}
+}
+
+// AddLinuxResourcesUnified adds or updates the key-value pair from g.Config.Linux.Resources.Unified
+func (g *Generator) AddLinuxResourcesUnified(key, val string) {
+	g.initConfigLinuxResourcesUnified()
+	g.Config.Linux.Resources.Unified[key] = val
+}
+
+// DropLinuxResourcesUnified drops a key-value pair from g.Config.Linux.Resources.Unified
+func (g *Generator) DropLinuxResourcesUnified(key string) {
+	if g.Config == nil || g.Config.Linux == nil || g.Config.Linux.Resources == nil || g.Config.Linux.Resources.Unified == nil {
+		return
+	}
+	delete(g.Config.Linux.Resources.Unified, key)
+}
+
+// SetLinuxResourcesMemoryLimit sets g.Config.Linux.Resources.Memory.Limit.
+func (g *Generator) SetLinuxResourcesMemoryLimit(limit int64) {
+	g.initConfigLinuxResourcesMemory()
+	g.Config.Linux.Resources.Memory.Limit = &limit
+}
+
+// SetLinuxResourcesMemoryReservation sets g.Config.Linux.Resources.Memory.Reservation.
+func (g *Generator) SetLinuxResourcesMemoryReservation(reservation int64) {
+	g.initConfigLinuxResourcesMemory()
+	g.Config.Linux.Resources.Memory.Reservation = &reservation
+}
+
+// SetLinuxResourcesMemorySwap sets g.Config.Linux.Resources.Memory.Swap.
+func (g *Generator) SetLinuxResourcesMemorySwap(swap int64) {
+	g.initConfigLinuxResourcesMemory()
+	g.Config.Linux.Resources.Memory.Swap = &swap
+}
+
+// SetLinuxResourcesMemoryKernel sets g.Config.Linux.Resources.Memory.Kernel.
+func (g *Generator) SetLinuxResourcesMemoryKernel(kernel int64) {
+	g.initConfigLinuxResourcesMemory()
+	g.Config.Linux.Resources.Memory.Kernel = &kernel
+}
+
+// SetLinuxResourcesMemoryKernelTCP sets g.Config.Linux.Resources.Memory.KernelTCP.
+func (g *Generator) SetLinuxResourcesMemoryKernelTCP(kernelTCP int64) {
+	g.initConfigLinuxResourcesMemory()
+	g.Config.Linux.Resources.Memory.KernelTCP = &kernelTCP
+}
+
+// SetLinuxResourcesMemorySwappiness sets g.Config.Linux.Resources.Memory.Swappiness.
+func (g *Generator) SetLinuxResourcesMemorySwappiness(swappiness uint64) {
+	g.initConfigLinuxResourcesMemory()
+	g.Config.Linux.Resources.Memory.Swappiness = &swappiness
+}
+
+// SetLinuxResourcesMemoryDisableOOMKiller sets g.Config.Linux.Resources.Memory.DisableOOMKiller.
+func (g *Generator) SetLinuxResourcesMemoryDisableOOMKiller(disable bool) {
+	g.initConfigLinuxResourcesMemory()
+	g.Config.Linux.Resources.Memory.DisableOOMKiller = &disable
+}
+
+// SetLinuxResourcesNetworkClassID sets g.Config.Linux.Resources.Network.ClassID.
+func (g *Generator) SetLinuxResourcesNetworkClassID(classid uint32) {
+	g.initConfigLinuxResourcesNetwork()
+	g.Config.Linux.Resources.Network.ClassID = &classid
+}
+
+// AddLinuxResourcesNetworkPriorities adds or sets g.Config.Linux.Resources.Network.Priorities.
+func (g *Generator) AddLinuxResourcesNetworkPriorities(name string, prio uint32) {
+	g.initConfigLinuxResourcesNetwork()
+	for i, netPriority := range g.Config.Linux.Resources.Network.Priorities {
+		if netPriority.Name == name {
+			g.Config.Linux.Resources.Network.Priorities[i].Priority = prio
+			return
+		}
+	}
+	interfacePrio := new(rspec.LinuxInterfacePriority)
+	interfacePrio.Name = name
+	interfacePrio.Priority = prio
+	g.Config.Linux.Resources.Network.Priorities = append(g.Config.Linux.Resources.Network.Priorities, *interfacePrio)
+}
+
+// DropLinuxResourcesNetworkPriorities drops one item from g.Config.Linux.Resources.Network.Priorities.
+func (g *Generator) DropLinuxResourcesNetworkPriorities(name string) {
+	if g.Config == nil || g.Config.Linux == nil || g.Config.Linux.Resources == nil || g.Config.Linux.Resources.Network == nil {
+		return
+	}
+
+	for i, netPriority := range g.Config.Linux.Resources.Network.Priorities {
+		if netPriority.Name == name {
+			g.Config.Linux.Resources.Network.Priorities = append(g.Config.Linux.Resources.Network.Priorities[:i], g.Config.Linux.Resources.Network.Priorities[i+1:]...)
+			return
+		}
+	}
+}
+
+// SetLinuxResourcesPidsLimit sets g.Config.Linux.Resources.Pids.Limit.
+func (g *Generator) SetLinuxResourcesPidsLimit(limit int64) {
+	g.initConfigLinuxResourcesPids()
+	g.Config.Linux.Resources.Pids.Limit = limit
+}
+
+// ClearLinuxSysctl clears g.Config.Linux.Sysctl.
+func (g *Generator) ClearLinuxSysctl() {
+	if g.Config == nil || g.Config.Linux == nil {
+		return
+	}
+	g.Config.Linux.Sysctl = make(map[string]string)
+}
+
+// AddLinuxSysctl adds a new sysctl config into g.Config.Linux.Sysctl.
+func (g *Generator) AddLinuxSysctl(key, value string) {
+	g.initConfigLinuxSysctl()
+	g.Config.Linux.Sysctl[key] = value
+}
+
+// RemoveLinuxSysctl removes a sysctl config from g.Config.Linux.Sysctl.
+func (g *Generator) RemoveLinuxSysctl(key string) {
+	if g.Config == nil || g.Config.Linux == nil || g.Config.Linux.Sysctl == nil {
+		return
+	}
+	delete(g.Config.Linux.Sysctl, key)
+}
+
+// ClearLinuxUIDMappings clear g.Config.Linux.UIDMappings.
+func (g *Generator) ClearLinuxUIDMappings() {
+	if g.Config == nil || g.Config.Linux == nil {
+		return
+	}
+	g.Config.Linux.UIDMappings = []rspec.LinuxIDMapping{}
+}
+
+// AddLinuxUIDMapping adds uidMap into g.Config.Linux.UIDMappings.
+func (g *Generator) AddLinuxUIDMapping(hid, cid, size uint32) {
+	idMapping := rspec.LinuxIDMapping{
+		HostID:      hid,
+		ContainerID: cid,
+		Size:        size,
+	}
+
+	g.initConfigLinux()
+	g.Config.Linux.UIDMappings = append(g.Config.Linux.UIDMappings, idMapping)
+}
+
+// ClearLinuxGIDMappings clear g.Config.Linux.GIDMappings.
+func (g *Generator) ClearLinuxGIDMappings() {
+	if g.Config == nil || g.Config.Linux == nil {
+		return
+	}
+	g.Config.Linux.GIDMappings = []rspec.LinuxIDMapping{}
+}
+
+// AddLinuxGIDMapping adds gidMap into g.Config.Linux.GIDMappings.
+func (g *Generator) AddLinuxGIDMapping(hid, cid, size uint32) {
+	idMapping := rspec.LinuxIDMapping{
+		HostID:      hid,
+		ContainerID: cid,
+		Size:        size,
+	}
+
+	g.initConfigLinux()
+	g.Config.Linux.GIDMappings = append(g.Config.Linux.GIDMappings, idMapping)
+}
+
+// SetLinuxRootPropagation sets g.Config.Linux.RootfsPropagation.
+func (g *Generator) SetLinuxRootPropagation(rp string) error {
+	switch rp {
+	case "":
+	case "private":
+	case "rprivate":
+	case "slave":
+	case "rslave":
+	case "shared":
+	case "rshared":
+	case "unbindable":
+	case "runbindable":
+	default:
+		return fmt.Errorf("rootfs-propagation %q must be empty or one of (r)private|(r)slave|(r)shared|(r)unbindable", rp)
+	}
+	g.initConfigLinux()
+	g.Config.Linux.RootfsPropagation = rp
+	return nil
+}
+
+// ClearPreStartHooks clear g.Config.Hooks.Prestart.
+func (g *Generator) ClearPreStartHooks() {
+	if g.Config == nil || g.Config.Hooks == nil {
+		return
+	}
+	g.Config.Hooks.Prestart = []rspec.Hook{}
+}
+
+// AddPreStartHook add a prestart hook into g.Config.Hooks.Prestart.
+func (g *Generator) AddPreStartHook(preStartHook rspec.Hook) {
+	g.initConfigHooks()
+	g.Config.Hooks.Prestart = append(g.Config.Hooks.Prestart, preStartHook)
+}
+
+// ClearPostStopHooks clear g.Config.Hooks.Poststop.
+func (g *Generator) ClearPostStopHooks() {
+	if g.Config == nil || g.Config.Hooks == nil {
+		return
+	}
+	g.Config.Hooks.Poststop = []rspec.Hook{}
+}
+
+// AddPostStopHook adds a poststop hook into g.Config.Hooks.Poststop.
+func (g *Generator) AddPostStopHook(postStopHook rspec.Hook) {
+	g.initConfigHooks()
+	g.Config.Hooks.Poststop = append(g.Config.Hooks.Poststop, postStopHook)
+}
+
+// ClearPostStartHooks clear g.Config.Hooks.Poststart.
+func (g *Generator) ClearPostStartHooks() {
+	if g.Config == nil || g.Config.Hooks == nil {
+		return
+	}
+	g.Config.Hooks.Poststart = []rspec.Hook{}
+}
+
+// AddPostStartHook adds a poststart hook into g.Config.Hooks.Poststart.
+func (g *Generator) AddPostStartHook(postStartHook rspec.Hook) {
+	g.initConfigHooks()
+	g.Config.Hooks.Poststart = append(g.Config.Hooks.Poststart, postStartHook)
+}
+
+// AddMount adds a mount into g.Config.Mounts.
+func (g *Generator) AddMount(mnt rspec.Mount) {
+	g.initConfig()
+
+	g.Config.Mounts = append(g.Config.Mounts, mnt)
+}
+
+// RemoveMount removes a mount point on the dest directory
+func (g *Generator) RemoveMount(dest string) {
+	g.initConfig()
+
+	for index, mount := range g.Config.Mounts {
+		if mount.Destination == dest {
+			g.Config.Mounts = append(g.Config.Mounts[:index], g.Config.Mounts[index+1:]...)
+			return
+		}
+	}
+}
+
+// Mounts returns the list of mounts
+func (g *Generator) Mounts() []rspec.Mount {
+	g.initConfig()
+
+	return g.Config.Mounts
+}
+
+// ClearMounts clear g.Config.Mounts
+func (g *Generator) ClearMounts() {
+	if g.Config == nil {
+		return
+	}
+	g.Config.Mounts = []rspec.Mount{}
+}
+
+// SetupPrivileged sets up the privilege-related fields inside g.Config.
+func (g *Generator) SetupPrivileged(privileged bool) {
+	if privileged { // Add all capabilities in privileged mode.
+		var finalCapList []string
+		for _, cap := range capability.List() {
+			if g.HostSpecific && cap > capsCheck.LastCap() {
+				continue
+			}
+			finalCapList = append(finalCapList, fmt.Sprintf("CAP_%s", strings.ToUpper(cap.String())))
+		}
+		g.initConfigLinux()
+		g.initConfigProcessCapabilities()
+		g.ClearProcessCapabilities()
+		g.Config.Process.Capabilities.Bounding = append(g.Config.Process.Capabilities.Bounding, finalCapList...)
+		g.Config.Process.Capabilities.Effective = append(g.Config.Process.Capabilities.Effective, finalCapList...)
+		g.Config.Process.Capabilities.Inheritable = append(g.Config.Process.Capabilities.Inheritable, finalCapList...)
+		g.Config.Process.Capabilities.Permitted = append(g.Config.Process.Capabilities.Permitted, finalCapList...)
+		g.Config.Process.Capabilities.Ambient = append(g.Config.Process.Capabilities.Ambient, finalCapList...)
+		g.Config.Process.SelinuxLabel = ""
+		g.Config.Process.ApparmorProfile = ""
+		g.Config.Linux.Seccomp = nil
+	}
+}
+
+// ClearProcessCapabilities clear g.Config.Process.Capabilities.
+func (g *Generator) ClearProcessCapabilities() {
+	if g.Config == nil || g.Config.Process == nil || g.Config.Process.Capabilities == nil {
+		return
+	}
+	g.Config.Process.Capabilities.Bounding = []string{}
+	g.Config.Process.Capabilities.Effective = []string{}
+	g.Config.Process.Capabilities.Inheritable = []string{}
+	g.Config.Process.Capabilities.Permitted = []string{}
+	g.Config.Process.Capabilities.Ambient = []string{}
+}
+
+// AddProcessCapability adds a process capability into all 5 capability sets.
+func (g *Generator) AddProcessCapability(c string) error {
+	cp := strings.ToUpper(c)
+	if err := capsCheck.CapValid(cp, g.HostSpecific); err != nil {
+		return err
+	}
+
+	g.initConfigProcessCapabilities()
+
+	var foundAmbient, foundBounding, foundEffective, foundInheritable, foundPermitted bool
+	for _, cap := range g.Config.Process.Capabilities.Ambient {
+		if strings.ToUpper(cap) == cp {
+			foundAmbient = true
+			break
+		}
+	}
+	if !foundAmbient {
+		g.Config.Process.Capabilities.Ambient = append(g.Config.Process.Capabilities.Ambient, cp)
+	}
+
+	for _, cap := range g.Config.Process.Capabilities.Bounding {
+		if strings.ToUpper(cap) == cp {
+			foundBounding = true
+			break
+		}
+	}
+	if !foundBounding {
+		g.Config.Process.Capabilities.Bounding = append(g.Config.Process.Capabilities.Bounding, cp)
+	}
+
+	for _, cap := range g.Config.Process.Capabilities.Effective {
+		if strings.ToUpper(cap) == cp {
+			foundEffective = true
+			break
+		}
+	}
+	if !foundEffective {
+		g.Config.Process.Capabilities.Effective = append(g.Config.Process.Capabilities.Effective, cp)
+	}
+
+	for _, cap := range g.Config.Process.Capabilities.Inheritable {
+		if strings.ToUpper(cap) == cp {
+			foundInheritable = true
+			break
+		}
+	}
+	if !foundInheritable {
+		g.Config.Process.Capabilities.Inheritable = append(g.Config.Process.Capabilities.Inheritable, cp)
+	}
+
+	for _, cap := range g.Config.Process.Capabilities.Permitted {
+		if strings.ToUpper(cap) == cp {
+			foundPermitted = true
+			break
+		}
+	}
+	if !foundPermitted {
+		g.Config.Process.Capabilities.Permitted = append(g.Config.Process.Capabilities.Permitted, cp)
+	}
+
+	return nil
+}
+
+// AddProcessCapabilityAmbient adds a process capability into g.Config.Process.Capabilities.Ambient.
+func (g *Generator) AddProcessCapabilityAmbient(c string) error {
+	cp := strings.ToUpper(c)
+	if err := capsCheck.CapValid(cp, g.HostSpecific); err != nil {
+		return err
+	}
+
+	g.initConfigProcessCapabilities()
+
+	var foundAmbient bool
+	for _, cap := range g.Config.Process.Capabilities.Ambient {
+		if strings.ToUpper(cap) == cp {
+			foundAmbient = true
+			break
+		}
+	}
+
+	if !foundAmbient {
+		g.Config.Process.Capabilities.Ambient = append(g.Config.Process.Capabilities.Ambient, cp)
+	}
+
+	return nil
+}
+
+// AddProcessCapabilityBounding adds a process capability into g.Config.Process.Capabilities.Bounding.
+func (g *Generator) AddProcessCapabilityBounding(c string) error {
+	cp := strings.ToUpper(c)
+	if err := capsCheck.CapValid(cp, g.HostSpecific); err != nil {
+		return err
+	}
+
+	g.initConfigProcessCapabilities()
+
+	var foundBounding bool
+	for _, cap := range g.Config.Process.Capabilities.Bounding {
+		if strings.ToUpper(cap) == cp {
+			foundBounding = true
+			break
+		}
+	}
+	if !foundBounding {
+		g.Config.Process.Capabilities.Bounding = append(g.Config.Process.Capabilities.Bounding, cp)
+	}
+
+	return nil
+}
+
+// AddProcessCapabilityEffective adds a process capability into g.Config.Process.Capabilities.Effective.
+func (g *Generator) AddProcessCapabilityEffective(c string) error {
+	cp := strings.ToUpper(c)
+	if err := capsCheck.CapValid(cp, g.HostSpecific); err != nil {
+		return err
+	}
+
+	g.initConfigProcessCapabilities()
+
+	var foundEffective bool
+	for _, cap := range g.Config.Process.Capabilities.Effective {
+		if strings.ToUpper(cap) == cp {
+			foundEffective = true
+			break
+		}
+	}
+	if !foundEffective {
+		g.Config.Process.Capabilities.Effective = append(g.Config.Process.Capabilities.Effective, cp)
+	}
+
+	return nil
+}
+
+// AddProcessCapabilityInheritable adds a process capability into g.Config.Process.Capabilities.Inheritable.
+func (g *Generator) AddProcessCapabilityInheritable(c string) error {
+	cp := strings.ToUpper(c)
+	if err := capsCheck.CapValid(cp, g.HostSpecific); err != nil {
+		return err
+	}
+
+	g.initConfigProcessCapabilities()
+
+	var foundInheritable bool
+	for _, cap := range g.Config.Process.Capabilities.Inheritable {
+		if strings.ToUpper(cap) == cp {
+			foundInheritable = true
+			break
+		}
+	}
+	if !foundInheritable {
+		g.Config.Process.Capabilities.Inheritable = append(g.Config.Process.Capabilities.Inheritable, cp)
+	}
+
+	return nil
+}
+
+// AddProcessCapabilityPermitted adds a process capability into g.Config.Process.Capabilities.Permitted.
+func (g *Generator) AddProcessCapabilityPermitted(c string) error {
+	cp := strings.ToUpper(c)
+	if err := capsCheck.CapValid(cp, g.HostSpecific); err != nil {
+		return err
+	}
+
+	g.initConfigProcessCapabilities()
+
+	var foundPermitted bool
+	for _, cap := range g.Config.Process.Capabilities.Permitted {
+		if strings.ToUpper(cap) == cp {
+			foundPermitted = true
+			break
+		}
+	}
+	if !foundPermitted {
+		g.Config.Process.Capabilities.Permitted = append(g.Config.Process.Capabilities.Permitted, cp)
+	}
+
+	return nil
+}
+
+// DropProcessCapability drops a process capability from all 5 capability sets.
+func (g *Generator) DropProcessCapability(c string) error {
+	if g.Config == nil || g.Config.Process == nil || g.Config.Process.Capabilities == nil {
+		return nil
+	}
+
+	cp := strings.ToUpper(c)
+	for i, cap := range g.Config.Process.Capabilities.Ambient {
+		if strings.ToUpper(cap) == cp {
+			g.Config.Process.Capabilities.Ambient = removeFunc(g.Config.Process.Capabilities.Ambient, i)
+		}
+	}
+	for i, cap := range g.Config.Process.Capabilities.Bounding {
+		if strings.ToUpper(cap) == cp {
+			g.Config.Process.Capabilities.Bounding = removeFunc(g.Config.Process.Capabilities.Bounding, i)
+		}
+	}
+	for i, cap := range g.Config.Process.Capabilities.Effective {
+		if strings.ToUpper(cap) == cp {
+			g.Config.Process.Capabilities.Effective = removeFunc(g.Config.Process.Capabilities.Effective, i)
+		}
+	}
+	for i, cap := range g.Config.Process.Capabilities.Inheritable {
+		if strings.ToUpper(cap) == cp {
+			g.Config.Process.Capabilities.Inheritable = removeFunc(g.Config.Process.Capabilities.Inheritable, i)
+		}
+	}
+	for i, cap := range g.Config.Process.Capabilities.Permitted {
+		if strings.ToUpper(cap) == cp {
+			g.Config.Process.Capabilities.Permitted = removeFunc(g.Config.Process.Capabilities.Permitted, i)
+		}
+	}
+
+	return capsCheck.CapValid(cp, false)
+}
+
+// DropProcessCapabilityAmbient drops a process capability from g.Config.Process.Capabilities.Ambient.
+func (g *Generator) DropProcessCapabilityAmbient(c string) error {
+	if g.Config == nil || g.Config.Process == nil || g.Config.Process.Capabilities == nil {
+		return nil
+	}
+
+	cp := strings.ToUpper(c)
+	for i, cap := range g.Config.Process.Capabilities.Ambient {
+		if strings.ToUpper(cap) == cp {
+			g.Config.Process.Capabilities.Ambient = removeFunc(g.Config.Process.Capabilities.Ambient, i)
+		}
+	}
+
+	return capsCheck.CapValid(cp, false)
+}
+
+// DropProcessCapabilityBounding drops a process capability from g.Config.Process.Capabilities.Bounding.
+func (g *Generator) DropProcessCapabilityBounding(c string) error {
+	if g.Config == nil || g.Config.Process == nil || g.Config.Process.Capabilities == nil {
+		return nil
+	}
+
+	cp := strings.ToUpper(c)
+	for i, cap := range g.Config.Process.Capabilities.Bounding {
+		if strings.ToUpper(cap) == cp {
+			g.Config.Process.Capabilities.Bounding = removeFunc(g.Config.Process.Capabilities.Bounding, i)
+		}
+	}
+
+	return capsCheck.CapValid(cp, false)
+}
+
+// DropProcessCapabilityEffective drops a process capability from g.Config.Process.Capabilities.Effective.
+func (g *Generator) DropProcessCapabilityEffective(c string) error {
+	if g.Config == nil || g.Config.Process == nil || g.Config.Process.Capabilities == nil {
+		return nil
+	}
+
+	cp := strings.ToUpper(c)
+	for i, cap := range g.Config.Process.Capabilities.Effective {
+		if strings.ToUpper(cap) == cp {
+			g.Config.Process.Capabilities.Effective = removeFunc(g.Config.Process.Capabilities.Effective, i)
+		}
+	}
+
+	return capsCheck.CapValid(cp, false)
+}
+
+// DropProcessCapabilityInheritable drops a process capability from g.Config.Process.Capabilities.Inheritable.
+func (g *Generator) DropProcessCapabilityInheritable(c string) error {
+	if g.Config == nil || g.Config.Process == nil || g.Config.Process.Capabilities == nil {
+		return nil
+	}
+
+	cp := strings.ToUpper(c)
+	for i, cap := range g.Config.Process.Capabilities.Inheritable {
+		if strings.ToUpper(cap) == cp {
+			g.Config.Process.Capabilities.Inheritable = removeFunc(g.Config.Process.Capabilities.Inheritable, i)
+		}
+	}
+
+	return capsCheck.CapValid(cp, false)
+}
+
+// DropProcessCapabilityPermitted drops a process capability from g.Config.Process.Capabilities.Permitted.
+func (g *Generator) DropProcessCapabilityPermitted(c string) error {
+	if g.Config == nil || g.Config.Process == nil || g.Config.Process.Capabilities == nil {
+		return nil
+	}
+
+	cp := strings.ToUpper(c)
+	for i, cap := range g.Config.Process.Capabilities.Permitted {
+		if strings.ToUpper(cap) == cp {
+			g.Config.Process.Capabilities.Permitted = removeFunc(g.Config.Process.Capabilities.Permitted, i)
+		}
+	}
+
+	return capsCheck.CapValid(cp, false)
+}
+
+func mapStrToNamespace(ns string, path string) (rspec.LinuxNamespace, error) {
+	switch ns {
+	case "network":
+		return rspec.LinuxNamespace{Type: rspec.NetworkNamespace, Path: path}, nil
+	case "pid":
+		return rspec.LinuxNamespace{Type: rspec.PIDNamespace, Path: path}, nil
+	case "mount":
+		return rspec.LinuxNamespace{Type: rspec.MountNamespace, Path: path}, nil
+	case "ipc":
+		return rspec.LinuxNamespace{Type: rspec.IPCNamespace, Path: path}, nil
+	case "uts":
+		return rspec.LinuxNamespace{Type: rspec.UTSNamespace, Path: path}, nil
+	case "user":
+		return rspec.LinuxNamespace{Type: rspec.UserNamespace, Path: path}, nil
+	case "cgroup":
+		return rspec.LinuxNamespace{Type: rspec.CgroupNamespace, Path: path}, nil
+	default:
+		return rspec.LinuxNamespace{}, fmt.Errorf("unrecognized namespace %q", ns)
+	}
+}
+
+// ClearLinuxNamespaces clear g.Config.Linux.Namespaces.
+func (g *Generator) ClearLinuxNamespaces() {
+	if g.Config == nil || g.Config.Linux == nil {
+		return
+	}
+	g.Config.Linux.Namespaces = []rspec.LinuxNamespace{}
+}
+
+// AddOrReplaceLinuxNamespace adds or replaces a namespace inside
+// g.Config.Linux.Namespaces.
+func (g *Generator) AddOrReplaceLinuxNamespace(ns string, path string) error {
+	namespace, err := mapStrToNamespace(ns, path)
+	if err != nil {
+		return err
+	}
+
+	g.initConfigLinux()
+	for i, ns := range g.Config.Linux.Namespaces {
+		if ns.Type == namespace.Type {
+			g.Config.Linux.Namespaces[i] = namespace
+			return nil
+		}
+	}
+	g.Config.Linux.Namespaces = append(g.Config.Linux.Namespaces, namespace)
+	return nil
+}
+
+// RemoveLinuxNamespace removes a namespace from g.Config.Linux.Namespaces.
+func (g *Generator) RemoveLinuxNamespace(ns string) error {
+	namespace, err := mapStrToNamespace(ns, "")
+	if err != nil {
+		return err
+	}
+
+	if g.Config == nil || g.Config.Linux == nil {
+		return nil
+	}
+	for i, ns := range g.Config.Linux.Namespaces {
+		if ns.Type == namespace.Type {
+			g.Config.Linux.Namespaces = append(g.Config.Linux.Namespaces[:i], g.Config.Linux.Namespaces[i+1:]...)
+			return nil
+		}
+	}
+	return nil
+}
+
+// AddDevice - add a device into g.Config.Linux.Devices
+func (g *Generator) AddDevice(device rspec.LinuxDevice) {
+	g.initConfigLinux()
+
+	for i, dev := range g.Config.Linux.Devices {
+		if dev.Path == device.Path {
+			g.Config.Linux.Devices[i] = device
+			return
+		}
+	}
+
+	g.Config.Linux.Devices = append(g.Config.Linux.Devices, device)
+}
+
+// RemoveDevice remove a device from g.Config.Linux.Devices
+func (g *Generator) RemoveDevice(path string) {
+	if g.Config == nil || g.Config.Linux == nil || g.Config.Linux.Devices == nil {
+		return
+	}
+
+	for i, device := range g.Config.Linux.Devices {
+		if device.Path == path {
+			g.Config.Linux.Devices = append(g.Config.Linux.Devices[:i], g.Config.Linux.Devices[i+1:]...)
+			return
+		}
+	}
+}
+
+// ClearLinuxDevices clears g.Config.Linux.Devices
+func (g *Generator) ClearLinuxDevices() {
+	if g.Config == nil || g.Config.Linux == nil || g.Config.Linux.Devices == nil {
+		return
+	}
+
+	g.Config.Linux.Devices = []rspec.LinuxDevice{}
+}
+
+// AddLinuxResourcesDevice - add a device into g.Config.Linux.Resources.Devices
+func (g *Generator) AddLinuxResourcesDevice(allow bool, devType string, major, minor *int64, access string) {
+	g.initConfigLinuxResources()
+
+	device := rspec.LinuxDeviceCgroup{
+		Allow:  allow,
+		Type:   devType,
+		Access: access,
+		Major:  major,
+		Minor:  minor,
+	}
+	g.Config.Linux.Resources.Devices = append(g.Config.Linux.Resources.Devices, device)
+}
+
+// RemoveLinuxResourcesDevice - remove a device from g.Config.Linux.Resources.Devices
+func (g *Generator) RemoveLinuxResourcesDevice(allow bool, devType string, major, minor *int64, access string) {
+	if g.Config == nil || g.Config.Linux == nil || g.Config.Linux.Resources == nil {
+		return
+	}
+	for i, device := range g.Config.Linux.Resources.Devices {
+		if device.Allow == allow &&
+			(devType == device.Type || (devType != "" && device.Type != "" && devType == device.Type)) &&
+			(access == device.Access || (access != "" && device.Access != "" && access == device.Access)) &&
+			(major == device.Major || (major != nil && device.Major != nil && *major == *device.Major)) &&
+			(minor == device.Minor || (minor != nil && device.Minor != nil && *minor == *device.Minor)) {
+
+			g.Config.Linux.Resources.Devices = append(g.Config.Linux.Resources.Devices[:i], g.Config.Linux.Resources.Devices[i+1:]...)
+			return
+		}
+	}
+}
+
+// SetSyscallAction adds rules for syscalls with the specified action
+func (g *Generator) SetSyscallAction(arguments seccomp.SyscallOpts) error {
+	g.initConfigLinuxSeccomp()
+	return seccomp.ParseSyscallFlag(arguments, g.Config.Linux.Seccomp)
+}
+
+// SetDefaultSeccompAction sets the default action for all syscalls not defined
+// and then removes any syscall rules with this action already specified.
+func (g *Generator) SetDefaultSeccompAction(action string) error {
+	g.initConfigLinuxSeccomp()
+	return seccomp.ParseDefaultAction(action, g.Config.Linux.Seccomp)
+}
+
+// SetDefaultSeccompActionForce only sets the default action for all syscalls not defined
+func (g *Generator) SetDefaultSeccompActionForce(action string) error {
+	g.initConfigLinuxSeccomp()
+	return seccomp.ParseDefaultActionForce(action, g.Config.Linux.Seccomp)
+}
+
+// SetDomainName sets g.Config.Domainname
+func (g *Generator) SetDomainName(domain string) {
+	g.initConfig()
+	g.Config.Domainname = domain
+}
+
+// SetSeccompArchitecture sets the supported seccomp architectures
+func (g *Generator) SetSeccompArchitecture(architecture string) error {
+	g.initConfigLinuxSeccomp()
+	return seccomp.ParseArchitectureFlag(architecture, g.Config.Linux.Seccomp)
+}
+
+// RemoveSeccompRule removes rules for any specified syscalls
+func (g *Generator) RemoveSeccompRule(arguments string) error {
+	g.initConfigLinuxSeccomp()
+	return seccomp.RemoveAction(arguments, g.Config.Linux.Seccomp)
+}
+
+// RemoveAllSeccompRules removes all syscall rules
+func (g *Generator) RemoveAllSeccompRules() error {
+	g.initConfigLinuxSeccomp()
+	return seccomp.RemoveAllSeccompRules(g.Config.Linux.Seccomp)
+}
+
+// AddLinuxMaskedPaths adds masked paths into g.Config.Linux.MaskedPaths.
+func (g *Generator) AddLinuxMaskedPaths(path string) {
+	g.initConfigLinux()
+	g.Config.Linux.MaskedPaths = append(g.Config.Linux.MaskedPaths, path)
+}
+
+// AddLinuxReadonlyPaths adds readonly paths into g.Config.Linux.MaskedPaths.
+func (g *Generator) AddLinuxReadonlyPaths(path string) {
+	g.initConfigLinux()
+	g.Config.Linux.ReadonlyPaths = append(g.Config.Linux.ReadonlyPaths, path)
+}
+
+func addOrReplaceBlockIOThrottleDevice(tmpList []rspec.LinuxThrottleDevice, major int64, minor int64, rate uint64) []rspec.LinuxThrottleDevice {
+	throttleDevices := tmpList
+	for i, throttleDevice := range throttleDevices {
+		if throttleDevice.Major == major && throttleDevice.Minor == minor {
+			throttleDevices[i].Rate = rate
+			return throttleDevices
+		}
+	}
+	throttleDevice := new(rspec.LinuxThrottleDevice)
+	throttleDevice.Major = major
+	throttleDevice.Minor = minor
+	throttleDevice.Rate = rate
+	throttleDevices = append(throttleDevices, *throttleDevice)
+
+	return throttleDevices
+}
+
+func dropBlockIOThrottleDevice(tmpList []rspec.LinuxThrottleDevice, major int64, minor int64) []rspec.LinuxThrottleDevice {
+	throttleDevices := tmpList
+	for i, throttleDevice := range throttleDevices {
+		if throttleDevice.Major == major && throttleDevice.Minor == minor {
+			throttleDevices = append(throttleDevices[:i], throttleDevices[i+1:]...)
+			return throttleDevices
+		}
+	}
+
+	return throttleDevices
+}
+
+// AddSolarisAnet adds network into g.Config.Solaris.Anet
+func (g *Generator) AddSolarisAnet(anet rspec.SolarisAnet) {
+	g.initConfigSolaris()
+	g.Config.Solaris.Anet = append(g.Config.Solaris.Anet, anet)
+}
+
+// SetSolarisCappedCPUNcpus sets g.Config.Solaris.CappedCPU.Ncpus
+func (g *Generator) SetSolarisCappedCPUNcpus(ncpus string) {
+	g.initConfigSolarisCappedCPU()
+	g.Config.Solaris.CappedCPU.Ncpus = ncpus
+}
+
+// SetSolarisCappedMemoryPhysical sets g.Config.Solaris.CappedMemory.Physical
+func (g *Generator) SetSolarisCappedMemoryPhysical(physical string) {
+	g.initConfigSolarisCappedMemory()
+	g.Config.Solaris.CappedMemory.Physical = physical
+}
+
+// SetSolarisCappedMemorySwap sets g.Config.Solaris.CappedMemory.Swap
+func (g *Generator) SetSolarisCappedMemorySwap(swap string) {
+	g.initConfigSolarisCappedMemory()
+	g.Config.Solaris.CappedMemory.Swap = swap
+}
+
+// SetSolarisLimitPriv sets g.Config.Solaris.LimitPriv
+func (g *Generator) SetSolarisLimitPriv(limitPriv string) {
+	g.initConfigSolaris()
+	g.Config.Solaris.LimitPriv = limitPriv
+}
+
+// SetSolarisMaxShmMemory sets g.Config.Solaris.MaxShmMemory
+func (g *Generator) SetSolarisMaxShmMemory(memory string) {
+	g.initConfigSolaris()
+	g.Config.Solaris.MaxShmMemory = memory
+}
+
+// SetSolarisMilestone sets g.Config.Solaris.Milestone
+func (g *Generator) SetSolarisMilestone(milestone string) {
+	g.initConfigSolaris()
+	g.Config.Solaris.Milestone = milestone
+}
+
+// SetVMHypervisorPath sets g.Config.VM.Hypervisor.Path
+func (g *Generator) SetVMHypervisorPath(path string) error {
+	if !strings.HasPrefix(path, "/") {
+		return fmt.Errorf("hypervisorPath %v is not an absolute path", path)
+	}
+	g.initConfigVM()
+	g.Config.VM.Hypervisor.Path = path
+	return nil
+}
+
+// SetVMHypervisorParameters sets g.Config.VM.Hypervisor.Parameters
+func (g *Generator) SetVMHypervisorParameters(parameters []string) {
+	g.initConfigVM()
+	g.Config.VM.Hypervisor.Parameters = parameters
+}
+
+// SetVMKernelPath sets g.Config.VM.Kernel.Path
+func (g *Generator) SetVMKernelPath(path string) error {
+	if !strings.HasPrefix(path, "/") {
+		return fmt.Errorf("kernelPath %v is not an absolute path", path)
+	}
+	g.initConfigVM()
+	g.Config.VM.Kernel.Path = path
+	return nil
+}
+
+// SetVMKernelParameters sets g.Config.VM.Kernel.Parameters
+func (g *Generator) SetVMKernelParameters(parameters []string) {
+	g.initConfigVM()
+	g.Config.VM.Kernel.Parameters = parameters
+}
+
+// SetVMKernelInitRD sets g.Config.VM.Kernel.InitRD
+func (g *Generator) SetVMKernelInitRD(initrd string) error {
+	if !strings.HasPrefix(initrd, "/") {
+		return fmt.Errorf("kernelInitrd %v is not an absolute path", initrd)
+	}
+	g.initConfigVM()
+	g.Config.VM.Kernel.InitRD = initrd
+	return nil
+}
+
+// SetVMImagePath sets g.Config.VM.Image.Path
+func (g *Generator) SetVMImagePath(path string) error {
+	if !strings.HasPrefix(path, "/") {
+		return fmt.Errorf("imagePath %v is not an absolute path", path)
+	}
+	g.initConfigVM()
+	g.Config.VM.Image.Path = path
+	return nil
+}
+
+// SetVMImageFormat sets g.Config.VM.Image.Format
+func (g *Generator) SetVMImageFormat(format string) error {
+	switch format {
+	case "raw":
+	case "qcow2":
+	case "vdi":
+	case "vmdk":
+	case "vhd":
+	default:
+		return fmt.Errorf("Commonly supported formats are: raw, qcow2, vdi, vmdk, vhd")
+	}
+	g.initConfigVM()
+	g.Config.VM.Image.Format = format
+	return nil
+}
+
+// SetWindowsHypervUntilityVMPath sets g.Config.Windows.HyperV.UtilityVMPath.
+func (g *Generator) SetWindowsHypervUntilityVMPath(path string) {
+	g.initConfigWindowsHyperV()
+	g.Config.Windows.HyperV.UtilityVMPath = path
+}
+
+// SetWindowsIgnoreFlushesDuringBoot sets g.Config.Windows.IgnoreFlushesDuringBoot.
+func (g *Generator) SetWindowsIgnoreFlushesDuringBoot(ignore bool) {
+	g.initConfigWindows()
+	g.Config.Windows.IgnoreFlushesDuringBoot = ignore
+}
+
+// AddWindowsLayerFolders adds layer folders into  g.Config.Windows.LayerFolders.
+func (g *Generator) AddWindowsLayerFolders(folder string) {
+	g.initConfigWindows()
+	g.Config.Windows.LayerFolders = append(g.Config.Windows.LayerFolders, folder)
+}
+
+// AddWindowsDevices adds or sets g.Config.Windwos.Devices
+func (g *Generator) AddWindowsDevices(id, idType string) error {
+	if idType != "class" {
+		return fmt.Errorf("Invalid idType value: %s. Windows only supports a value of class", idType)
+	}
+	device := rspec.WindowsDevice{
+		ID:     id,
+		IDType: idType,
+	}
+
+	g.initConfigWindows()
+	for i, device := range g.Config.Windows.Devices {
+		if device.ID == id {
+			g.Config.Windows.Devices[i].IDType = idType
+			return nil
+		}
+	}
+	g.Config.Windows.Devices = append(g.Config.Windows.Devices, device)
+	return nil
+}
+
+// SetWindowsNetwork sets g.Config.Windows.Network.
+func (g *Generator) SetWindowsNetwork(network rspec.WindowsNetwork) {
+	g.initConfigWindows()
+	g.Config.Windows.Network = &network
+}
+
+// SetWindowsNetworkAllowUnqualifiedDNSQuery sets g.Config.Windows.Network.AllowUnqualifiedDNSQuery
+func (g *Generator) SetWindowsNetworkAllowUnqualifiedDNSQuery(setting bool) {
+	g.initConfigWindowsNetwork()
+	g.Config.Windows.Network.AllowUnqualifiedDNSQuery = setting
+}
+
+// SetWindowsNetworkNamespace sets g.Config.Windows.Network.NetworkNamespace
+func (g *Generator) SetWindowsNetworkNamespace(path string) {
+	g.initConfigWindowsNetwork()
+	g.Config.Windows.Network.NetworkNamespace = path
+}
+
+// SetWindowsResourcesCPU sets g.Config.Windows.Resources.CPU.
+func (g *Generator) SetWindowsResourcesCPU(cpu rspec.WindowsCPUResources) {
+	g.initConfigWindowsResources()
+	g.Config.Windows.Resources.CPU = &cpu
+}
+
+// SetWindowsResourcesMemoryLimit sets g.Config.Windows.Resources.Memory.Limit.
+func (g *Generator) SetWindowsResourcesMemoryLimit(limit uint64) {
+	g.initConfigWindowsResourcesMemory()
+	g.Config.Windows.Resources.Memory.Limit = &limit
+}
+
+// SetWindowsResourcesStorage sets g.Config.Windows.Resources.Storage.
+func (g *Generator) SetWindowsResourcesStorage(storage rspec.WindowsStorageResources) {
+	g.initConfigWindowsResources()
+	g.Config.Windows.Resources.Storage = &storage
+}
+
+// SetWindowsServicing sets g.Config.Windows.Servicing.
+func (g *Generator) SetWindowsServicing(servicing bool) {
+	g.initConfigWindows()
+	g.Config.Windows.Servicing = servicing
+}

--- a/pkg/pillar/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/consts.go
+++ b/pkg/pillar/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/consts.go
@@ -1,0 +1,7 @@
+package seccomp
+
+const (
+	seccompOverwrite = "overwrite"
+	seccompAppend    = "append"
+	nothing          = "nothing"
+)

--- a/pkg/pillar/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/parse_action.go
+++ b/pkg/pillar/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/parse_action.go
@@ -1,0 +1,135 @@
+package seccomp
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// SyscallOpts contain options for parsing syscall rules
+type SyscallOpts struct {
+	Action   string
+	Syscall  string
+	Index    string
+	Value    string
+	ValueTwo string
+	Operator string
+}
+
+// ParseSyscallFlag takes a SyscallOpts struct and the seccomp configuration
+// and sets the new syscall rule accordingly
+func ParseSyscallFlag(args SyscallOpts, config *rspec.LinuxSeccomp) error {
+	var arguments []string
+	if args.Index != "" && args.Value != "" && args.ValueTwo != "" && args.Operator != "" {
+		arguments = []string{args.Action, args.Syscall, args.Index, args.Value,
+			args.ValueTwo, args.Operator}
+	} else {
+		arguments = []string{args.Action, args.Syscall}
+	}
+
+	action, _ := parseAction(arguments[0])
+	if action == config.DefaultAction && args.argsAreEmpty() {
+		// default already set, no need to make changes
+		return nil
+	}
+
+	var newSyscall rspec.LinuxSyscall
+	numOfArgs := len(arguments)
+	if numOfArgs == 6 || numOfArgs == 2 {
+		argStruct, err := parseArguments(arguments[1:])
+		if err != nil {
+			return err
+		}
+		newSyscall = newSyscallStruct(arguments[1], action, argStruct)
+	} else {
+		return fmt.Errorf("incorrect number of arguments to ParseSyscall: %d", numOfArgs)
+	}
+
+	descison, err := decideCourseOfAction(&newSyscall, config.Syscalls)
+	if err != nil {
+		return err
+	}
+	delimDescison := strings.Split(descison, ":")
+
+	if delimDescison[0] == seccompAppend {
+		config.Syscalls = append(config.Syscalls, newSyscall)
+	}
+
+	if delimDescison[0] == seccompOverwrite {
+		indexForOverwrite, err := strconv.ParseInt(delimDescison[1], 10, 32)
+		if err != nil {
+			return err
+		}
+		config.Syscalls[indexForOverwrite] = newSyscall
+	}
+
+	return nil
+}
+
+var actions = map[string]rspec.LinuxSeccompAction{
+	"allow": rspec.ActAllow,
+	"errno": rspec.ActErrno,
+	"kill":  rspec.ActKill,
+	"trace": rspec.ActTrace,
+	"trap":  rspec.ActTrap,
+}
+
+// Take passed action, return the SCMP_ACT_<ACTION> version of it
+func parseAction(action string) (rspec.LinuxSeccompAction, error) {
+	a, ok := actions[action]
+	if !ok {
+		return "", fmt.Errorf("unrecognized action: %s", action)
+	}
+	return a, nil
+}
+
+// ParseDefaultAction sets the default action of the seccomp configuration
+// and then removes any rules that were already specified with this action
+func ParseDefaultAction(action string, config *rspec.LinuxSeccomp) error {
+	if action == "" {
+		return nil
+	}
+
+	defaultAction, err := parseAction(action)
+	if err != nil {
+		return err
+	}
+	config.DefaultAction = defaultAction
+	err = RemoveAllMatchingRules(config, defaultAction)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// ParseDefaultActionForce simply sets the default action of the seccomp configuration
+func ParseDefaultActionForce(action string, config *rspec.LinuxSeccomp) error {
+	if action == "" {
+		return nil
+	}
+
+	defaultAction, err := parseAction(action)
+	if err != nil {
+		return err
+	}
+	config.DefaultAction = defaultAction
+	return nil
+}
+
+func newSyscallStruct(name string, action rspec.LinuxSeccompAction, args []rspec.LinuxSeccompArg) rspec.LinuxSyscall {
+	syscallStruct := rspec.LinuxSyscall{
+		Names:  []string{name},
+		Action: action,
+		Args:   args,
+	}
+	return syscallStruct
+}
+
+func (s SyscallOpts) argsAreEmpty() bool {
+	return (s.Index == "" &&
+		s.Value == "" &&
+		s.ValueTwo == "" &&
+		s.Operator == "")
+}

--- a/pkg/pillar/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/parse_architecture.go
+++ b/pkg/pillar/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/parse_architecture.go
@@ -1,0 +1,55 @@
+package seccomp
+
+import (
+	"fmt"
+
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// ParseArchitectureFlag takes the raw string passed with the --arch flag, parses it
+// and updates the Seccomp config accordingly
+func ParseArchitectureFlag(architectureArg string, config *rspec.LinuxSeccomp) error {
+	correctedArch, err := parseArch(architectureArg)
+	if err != nil {
+		return err
+	}
+
+	shouldAppend := true
+	for _, alreadySpecified := range config.Architectures {
+		if correctedArch == alreadySpecified {
+			shouldAppend = false
+		}
+	}
+	if shouldAppend {
+		config.Architectures = append(config.Architectures, correctedArch)
+	}
+	return nil
+}
+
+func parseArch(arch string) (rspec.Arch, error) {
+	arches := map[string]rspec.Arch{
+		"x86":         rspec.ArchX86,
+		"amd64":       rspec.ArchX86_64,
+		"x32":         rspec.ArchX32,
+		"arm":         rspec.ArchARM,
+		"arm64":       rspec.ArchAARCH64,
+		"mips":        rspec.ArchMIPS,
+		"mips64":      rspec.ArchMIPS64,
+		"mips64n32":   rspec.ArchMIPS64N32,
+		"mipsel":      rspec.ArchMIPSEL,
+		"mipsel64":    rspec.ArchMIPSEL64,
+		"mipsel64n32": rspec.ArchMIPSEL64N32,
+		"parisc":      rspec.ArchPARISC,
+		"parisc64":    rspec.ArchPARISC64,
+		"ppc":         rspec.ArchPPC,
+		"ppc64":       rspec.ArchPPC64,
+		"ppc64le":     rspec.ArchPPC64LE,
+		"s390":        rspec.ArchS390,
+		"s390x":       rspec.ArchS390X,
+	}
+	a, ok := arches[arch]
+	if !ok {
+		return "", fmt.Errorf("unrecognized architecture: %s", arch)
+	}
+	return a, nil
+}

--- a/pkg/pillar/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/parse_arguments.go
+++ b/pkg/pillar/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/parse_arguments.go
@@ -1,0 +1,73 @@
+package seccomp
+
+import (
+	"fmt"
+	"strconv"
+
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// parseArguments takes a list of arguments (delimArgs). It parses and fills out
+// the argument information and returns a slice of arg structs
+func parseArguments(delimArgs []string) ([]rspec.LinuxSeccompArg, error) {
+	nilArgSlice := []rspec.LinuxSeccompArg{}
+	numberOfArgs := len(delimArgs)
+
+	// No parameters passed with syscall
+	if numberOfArgs == 1 {
+		return nilArgSlice, nil
+	}
+
+	// Correct number of parameters passed with syscall
+	if numberOfArgs == 5 {
+		syscallIndex, err := strconv.ParseUint(delimArgs[1], 10, 0)
+		if err != nil {
+			return nilArgSlice, err
+		}
+
+		syscallValue, err := strconv.ParseUint(delimArgs[2], 10, 64)
+		if err != nil {
+			return nilArgSlice, err
+		}
+
+		syscallValueTwo, err := strconv.ParseUint(delimArgs[3], 10, 64)
+		if err != nil {
+			return nilArgSlice, err
+		}
+
+		syscallOp, err := parseOperator(delimArgs[4])
+		if err != nil {
+			return nilArgSlice, err
+		}
+
+		argStruct := rspec.LinuxSeccompArg{
+			Index:    uint(syscallIndex),
+			Value:    syscallValue,
+			ValueTwo: syscallValueTwo,
+			Op:       syscallOp,
+		}
+
+		argSlice := []rspec.LinuxSeccompArg{}
+		argSlice = append(argSlice, argStruct)
+		return argSlice, nil
+	}
+
+	return nilArgSlice, fmt.Errorf("incorrect number of arguments passed with syscall: %d", numberOfArgs)
+}
+
+func parseOperator(operator string) (rspec.LinuxSeccompOperator, error) {
+	operators := map[string]rspec.LinuxSeccompOperator{
+		"NE": rspec.OpNotEqual,
+		"LT": rspec.OpLessThan,
+		"LE": rspec.OpLessEqual,
+		"EQ": rspec.OpEqualTo,
+		"GE": rspec.OpGreaterEqual,
+		"GT": rspec.OpGreaterThan,
+		"ME": rspec.OpMaskedEqual,
+	}
+	o, ok := operators[operator]
+	if !ok {
+		return "", fmt.Errorf("unrecognized operator: %s", operator)
+	}
+	return o, nil
+}

--- a/pkg/pillar/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/parse_remove.go
+++ b/pkg/pillar/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/parse_remove.go
@@ -1,0 +1,52 @@
+package seccomp
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// RemoveAction takes the argument string that was passed with the --remove flag,
+// parses it, and updates the Seccomp config accordingly
+func RemoveAction(arguments string, config *rspec.LinuxSeccomp) error {
+	if config == nil {
+		return fmt.Errorf("Cannot remove action from nil Seccomp pointer")
+	}
+
+	syscallsToRemove := strings.Split(arguments, ",")
+
+	for counter, syscallStruct := range config.Syscalls {
+		if reflect.DeepEqual(syscallsToRemove, syscallStruct.Names) {
+			config.Syscalls = append(config.Syscalls[:counter], config.Syscalls[counter+1:]...)
+		}
+	}
+
+	return nil
+}
+
+// RemoveAllSeccompRules removes all seccomp syscall rules
+func RemoveAllSeccompRules(config *rspec.LinuxSeccomp) error {
+	if config == nil {
+		return fmt.Errorf("Cannot remove action from nil Seccomp pointer")
+	}
+	newSyscallSlice := []rspec.LinuxSyscall{}
+	config.Syscalls = newSyscallSlice
+	return nil
+}
+
+// RemoveAllMatchingRules will remove any syscall rules that match the specified action
+func RemoveAllMatchingRules(config *rspec.LinuxSeccomp, seccompAction rspec.LinuxSeccompAction) error {
+	if config == nil {
+		return fmt.Errorf("Cannot remove action from nil Seccomp pointer")
+	}
+
+	for _, syscall := range config.Syscalls {
+		if reflect.DeepEqual(syscall.Action, seccompAction) {
+			RemoveAction(strings.Join(syscall.Names, ","), config)
+		}
+	}
+
+	return nil
+}

--- a/pkg/pillar/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/seccomp_default.go
+++ b/pkg/pillar/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/seccomp_default.go
@@ -1,0 +1,606 @@
+package seccomp
+
+import (
+	"runtime"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func arches() []rspec.Arch {
+	native := runtime.GOARCH
+
+	switch native {
+	case "amd64":
+		return []rspec.Arch{rspec.ArchX86_64, rspec.ArchX86, rspec.ArchX32}
+	case "arm64":
+		return []rspec.Arch{rspec.ArchARM, rspec.ArchAARCH64}
+	case "mips64":
+		return []rspec.Arch{rspec.ArchMIPS, rspec.ArchMIPS64, rspec.ArchMIPS64N32}
+	case "mips64n32":
+		return []rspec.Arch{rspec.ArchMIPS, rspec.ArchMIPS64, rspec.ArchMIPS64N32}
+	case "mipsel64":
+		return []rspec.Arch{rspec.ArchMIPSEL, rspec.ArchMIPSEL64, rspec.ArchMIPSEL64N32}
+	case "mipsel64n32":
+		return []rspec.Arch{rspec.ArchMIPSEL, rspec.ArchMIPSEL64, rspec.ArchMIPSEL64N32}
+	case "s390x":
+		return []rspec.Arch{rspec.ArchS390, rspec.ArchS390X}
+	default:
+		return []rspec.Arch{}
+	}
+}
+
+// DefaultProfile defines the whitelist for the default seccomp profile.
+func DefaultProfile(rs *specs.Spec) *rspec.LinuxSeccomp {
+
+	syscalls := []rspec.LinuxSyscall{
+		{
+			Names: []string{
+				"accept",
+				"accept4",
+				"access",
+				"alarm",
+				"bind",
+				"brk",
+				"capget",
+				"capset",
+				"chdir",
+				"chmod",
+				"chown",
+				"chown32",
+				"clock_getres",
+				"clock_gettime",
+				"clock_nanosleep",
+				"close",
+				"connect",
+				"copy_file_range",
+				"creat",
+				"dup",
+				"dup2",
+				"dup3",
+				"epoll_create",
+				"epoll_create1",
+				"epoll_ctl",
+				"epoll_ctl_old",
+				"epoll_pwait",
+				"epoll_wait",
+				"epoll_wait_old",
+				"eventfd",
+				"eventfd2",
+				"execve",
+				"execveat",
+				"exit",
+				"exit_group",
+				"faccessat",
+				"fadvise64",
+				"fadvise64_64",
+				"fallocate",
+				"fanotify_mark",
+				"fchdir",
+				"fchmod",
+				"fchmodat",
+				"fchown",
+				"fchown32",
+				"fchownat",
+				"fcntl",
+				"fcntl64",
+				"fdatasync",
+				"fgetxattr",
+				"flistxattr",
+				"flock",
+				"fork",
+				"fremovexattr",
+				"fsetxattr",
+				"fstat",
+				"fstat64",
+				"fstatat64",
+				"fstatfs",
+				"fstatfs64",
+				"fsync",
+				"ftruncate",
+				"ftruncate64",
+				"futex",
+				"futimesat",
+				"getcpu",
+				"getcwd",
+				"getdents",
+				"getdents64",
+				"getegid",
+				"getegid32",
+				"geteuid",
+				"geteuid32",
+				"getgid",
+				"getgid32",
+				"getgroups",
+				"getgroups32",
+				"getitimer",
+				"getpeername",
+				"getpgid",
+				"getpgrp",
+				"getpid",
+				"getppid",
+				"getpriority",
+				"getrandom",
+				"getresgid",
+				"getresgid32",
+				"getresuid",
+				"getresuid32",
+				"getrlimit",
+				"get_robust_list",
+				"getrusage",
+				"getsid",
+				"getsockname",
+				"getsockopt",
+				"get_thread_area",
+				"gettid",
+				"gettimeofday",
+				"getuid",
+				"getuid32",
+				"getxattr",
+				"inotify_add_watch",
+				"inotify_init",
+				"inotify_init1",
+				"inotify_rm_watch",
+				"io_cancel",
+				"ioctl",
+				"io_destroy",
+				"io_getevents",
+				"ioprio_get",
+				"ioprio_set",
+				"io_setup",
+				"io_submit",
+				"ipc",
+				"kill",
+				"landlock_add_rule",
+				"landlock_create_ruleset",
+				"landlock_restrict_self",
+				"lchown",
+				"lchown32",
+				"lgetxattr",
+				"link",
+				"linkat",
+				"listen",
+				"listxattr",
+				"llistxattr",
+				"_llseek",
+				"lremovexattr",
+				"lseek",
+				"lsetxattr",
+				"lstat",
+				"lstat64",
+				"madvise",
+				"memfd_create",
+				"mincore",
+				"mkdir",
+				"mkdirat",
+				"mknod",
+				"mknodat",
+				"mlock",
+				"mlock2",
+				"mlockall",
+				"mmap",
+				"mmap2",
+				"mprotect",
+				"mq_getsetattr",
+				"mq_notify",
+				"mq_open",
+				"mq_timedreceive",
+				"mq_timedsend",
+				"mq_unlink",
+				"mremap",
+				"msgctl",
+				"msgget",
+				"msgrcv",
+				"msgsnd",
+				"msync",
+				"munlock",
+				"munlockall",
+				"munmap",
+				"nanosleep",
+				"newfstatat",
+				"_newselect",
+				"open",
+				"openat",
+				"pause",
+				"pipe",
+				"pipe2",
+				"poll",
+				"ppoll",
+				"prctl",
+				"pread64",
+				"preadv",
+				"prlimit64",
+				"pselect6",
+				"pwrite64",
+				"pwritev",
+				"read",
+				"readahead",
+				"readlink",
+				"readlinkat",
+				"readv",
+				"recv",
+				"recvfrom",
+				"recvmmsg",
+				"recvmsg",
+				"remap_file_pages",
+				"removexattr",
+				"rename",
+				"renameat",
+				"renameat2",
+				"restart_syscall",
+				"rmdir",
+				"rt_sigaction",
+				"rt_sigpending",
+				"rt_sigprocmask",
+				"rt_sigqueueinfo",
+				"rt_sigreturn",
+				"rt_sigsuspend",
+				"rt_sigtimedwait",
+				"rt_tgsigqueueinfo",
+				"sched_getaffinity",
+				"sched_getattr",
+				"sched_getparam",
+				"sched_get_priority_max",
+				"sched_get_priority_min",
+				"sched_getscheduler",
+				"sched_rr_get_interval",
+				"sched_setaffinity",
+				"sched_setattr",
+				"sched_setparam",
+				"sched_setscheduler",
+				"sched_yield",
+				"seccomp",
+				"select",
+				"semctl",
+				"semget",
+				"semop",
+				"semtimedop",
+				"send",
+				"sendfile",
+				"sendfile64",
+				"sendmmsg",
+				"sendmsg",
+				"sendto",
+				"setfsgid",
+				"setfsgid32",
+				"setfsuid",
+				"setfsuid32",
+				"setgid",
+				"setgid32",
+				"setgroups",
+				"setgroups32",
+				"setitimer",
+				"setpgid",
+				"setpriority",
+				"setregid",
+				"setregid32",
+				"setresgid",
+				"setresgid32",
+				"setresuid",
+				"setresuid32",
+				"setreuid",
+				"setreuid32",
+				"setrlimit",
+				"set_robust_list",
+				"setsid",
+				"setsockopt",
+				"set_thread_area",
+				"set_tid_address",
+				"setuid",
+				"setuid32",
+				"setxattr",
+				"shmat",
+				"shmctl",
+				"shmdt",
+				"shmget",
+				"shutdown",
+				"sigaltstack",
+				"signalfd",
+				"signalfd4",
+				"sigreturn",
+				"socket",
+				"socketcall",
+				"socketpair",
+				"splice",
+				"stat",
+				"stat64",
+				"statfs",
+				"statfs64",
+				"statx",
+				"symlink",
+				"symlinkat",
+				"sync",
+				"sync_file_range",
+				"syncfs",
+				"sysinfo",
+				"syslog",
+				"tee",
+				"tgkill",
+				"time",
+				"timer_create",
+				"timer_delete",
+				"timerfd_create",
+				"timerfd_gettime",
+				"timerfd_settime",
+				"timer_getoverrun",
+				"timer_gettime",
+				"timer_settime",
+				"times",
+				"tkill",
+				"truncate",
+				"truncate64",
+				"ugetrlimit",
+				"umask",
+				"uname",
+				"unlink",
+				"unlinkat",
+				"utime",
+				"utimensat",
+				"utimes",
+				"vfork",
+				"vmsplice",
+				"wait4",
+				"waitid",
+				"waitpid",
+				"write",
+				"writev",
+			},
+			Action: rspec.ActAllow,
+			Args:   []rspec.LinuxSeccompArg{},
+		},
+		{
+			Names:  []string{"personality"},
+			Action: rspec.ActAllow,
+			Args: []rspec.LinuxSeccompArg{
+				{
+					Index: 0,
+					Value: 0x0,
+					Op:    rspec.OpEqualTo,
+				},
+			},
+		},
+		{
+			Names:  []string{"personality"},
+			Action: rspec.ActAllow,
+			Args: []rspec.LinuxSeccompArg{
+				{
+					Index: 0,
+					Value: 0x0008,
+					Op:    rspec.OpEqualTo,
+				},
+			},
+		},
+		{
+			Names:  []string{"personality"},
+			Action: rspec.ActAllow,
+			Args: []rspec.LinuxSeccompArg{
+				{
+					Index: 0,
+					Value: 0xffffffff,
+					Op:    rspec.OpEqualTo,
+				},
+			},
+		},
+	}
+	var sysCloneFlagsIndex uint
+
+	capSysAdmin := false
+	caps := make(map[string]bool)
+
+	for _, cap := range rs.Process.Capabilities.Bounding {
+		caps[cap] = true
+	}
+	for _, cap := range rs.Process.Capabilities.Effective {
+		caps[cap] = true
+	}
+	for _, cap := range rs.Process.Capabilities.Inheritable {
+		caps[cap] = true
+	}
+	for _, cap := range rs.Process.Capabilities.Permitted {
+		caps[cap] = true
+	}
+	for _, cap := range rs.Process.Capabilities.Ambient {
+		caps[cap] = true
+	}
+
+	for cap := range caps {
+		switch cap {
+		case "CAP_DAC_READ_SEARCH":
+			syscalls = append(syscalls, []rspec.LinuxSyscall{
+				{
+					Names:  []string{"open_by_handle_at"},
+					Action: rspec.ActAllow,
+					Args:   []rspec.LinuxSeccompArg{},
+				},
+			}...)
+		case "CAP_SYS_ADMIN":
+			capSysAdmin = true
+			syscalls = append(syscalls, []rspec.LinuxSyscall{
+				{
+					Names: []string{
+						"bpf",
+						"clone",
+						"fanotify_init",
+						"lookup_dcookie",
+						"mount",
+						"name_to_handle_at",
+						"perf_event_open",
+						"setdomainname",
+						"sethostname",
+						"setns",
+						"umount",
+						"umount2",
+						"unshare",
+					},
+					Action: rspec.ActAllow,
+					Args:   []rspec.LinuxSeccompArg{},
+				},
+			}...)
+		case "CAP_SYS_BOOT":
+			syscalls = append(syscalls, []rspec.LinuxSyscall{
+				{
+					Names:  []string{"reboot"},
+					Action: rspec.ActAllow,
+					Args:   []rspec.LinuxSeccompArg{},
+				},
+			}...)
+		case "CAP_SYS_CHROOT":
+			syscalls = append(syscalls, []rspec.LinuxSyscall{
+				{
+					Names:  []string{"chroot"},
+					Action: rspec.ActAllow,
+					Args:   []rspec.LinuxSeccompArg{},
+				},
+			}...)
+		case "CAP_SYS_MODULE":
+			syscalls = append(syscalls, []rspec.LinuxSyscall{
+				{
+					Names: []string{
+						"delete_module",
+						"init_module",
+						"finit_module",
+						"query_module",
+					},
+					Action: rspec.ActAllow,
+					Args:   []rspec.LinuxSeccompArg{},
+				},
+			}...)
+		case "CAP_SYS_PACCT":
+			syscalls = append(syscalls, []rspec.LinuxSyscall{
+				{
+					Names:  []string{"acct"},
+					Action: rspec.ActAllow,
+					Args:   []rspec.LinuxSeccompArg{},
+				},
+			}...)
+		case "CAP_SYS_PTRACE":
+			syscalls = append(syscalls, []rspec.LinuxSyscall{
+				{
+					Names: []string{
+						"kcmp",
+						"process_vm_readv",
+						"process_vm_writev",
+						"ptrace",
+					},
+					Action: rspec.ActAllow,
+					Args:   []rspec.LinuxSeccompArg{},
+				},
+			}...)
+		case "CAP_SYS_RAWIO":
+			syscalls = append(syscalls, []rspec.LinuxSyscall{
+				{
+					Names: []string{
+						"iopl",
+						"ioperm",
+					},
+					Action: rspec.ActAllow,
+					Args:   []rspec.LinuxSeccompArg{},
+				},
+			}...)
+		case "CAP_SYS_TIME":
+			syscalls = append(syscalls, []rspec.LinuxSyscall{
+				{
+					Names: []string{
+						"settimeofday",
+						"stime",
+						"adjtimex",
+					},
+					Action: rspec.ActAllow,
+					Args:   []rspec.LinuxSeccompArg{},
+				},
+			}...)
+		case "CAP_SYS_TTY_CONFIG":
+			syscalls = append(syscalls, []rspec.LinuxSyscall{
+				{
+					Names:  []string{"vhangup"},
+					Action: rspec.ActAllow,
+					Args:   []rspec.LinuxSeccompArg{},
+				},
+			}...)
+		}
+	}
+
+	if !capSysAdmin {
+		syscalls = append(syscalls, []rspec.LinuxSyscall{
+			{
+				Names:  []string{"clone"},
+				Action: rspec.ActAllow,
+				Args: []rspec.LinuxSeccompArg{
+					{
+						Index:    sysCloneFlagsIndex,
+						Value:    CloneNewNS | CloneNewUTS | CloneNewIPC | CloneNewUser | CloneNewPID | CloneNewNet | CloneNewCgroup,
+						ValueTwo: 0,
+						Op:       rspec.OpMaskedEqual,
+					},
+				},
+			},
+		}...)
+
+	}
+
+	arch := runtime.GOARCH
+	switch arch {
+	case "arm", "arm64":
+		syscalls = append(syscalls, []rspec.LinuxSyscall{
+			{
+				Names: []string{
+					"breakpoint",
+					"cacheflush",
+					"set_tls",
+				},
+				Action: rspec.ActAllow,
+				Args:   []rspec.LinuxSeccompArg{},
+			},
+		}...)
+	case "amd64", "x32":
+		syscalls = append(syscalls, []rspec.LinuxSyscall{
+			{
+				Names:  []string{"arch_prctl"},
+				Action: rspec.ActAllow,
+				Args:   []rspec.LinuxSeccompArg{},
+			},
+		}...)
+		fallthrough
+	case "x86":
+		syscalls = append(syscalls, []rspec.LinuxSyscall{
+			{
+				Names:  []string{"modify_ldt"},
+				Action: rspec.ActAllow,
+				Args:   []rspec.LinuxSeccompArg{},
+			},
+		}...)
+	case "s390", "s390x":
+		syscalls = append(syscalls, []rspec.LinuxSyscall{
+			{
+				Names: []string{
+					"s390_pci_mmio_read",
+					"s390_pci_mmio_write",
+					"s390_runtime_instr",
+				},
+				Action: rspec.ActAllow,
+				Args:   []rspec.LinuxSeccompArg{},
+			},
+		}...)
+		/* Flags parameter of the clone syscall is the 2nd on s390 */
+		syscalls = append(syscalls, []rspec.LinuxSyscall{
+			{
+				Names:  []string{"clone"},
+				Action: rspec.ActAllow,
+				Args: []rspec.LinuxSeccompArg{
+					{
+						Index:    1,
+						Value:    2080505856,
+						ValueTwo: 0,
+						Op:       rspec.OpMaskedEqual,
+					},
+				},
+			},
+		}...)
+	}
+
+	return &rspec.LinuxSeccomp{
+		DefaultAction: rspec.ActErrno,
+		Architectures: arches(),
+		Syscalls:      syscalls,
+	}
+}

--- a/pkg/pillar/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/seccomp_default_linux.go
+++ b/pkg/pillar/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/seccomp_default_linux.go
@@ -1,0 +1,17 @@
+//go:build linux
+// +build linux
+
+package seccomp
+
+import "golang.org/x/sys/unix"
+
+// System values passed through on linux
+const (
+	CloneNewIPC    = unix.CLONE_NEWIPC
+	CloneNewNet    = unix.CLONE_NEWNET
+	CloneNewNS     = unix.CLONE_NEWNS
+	CloneNewPID    = unix.CLONE_NEWPID
+	CloneNewUser   = unix.CLONE_NEWUSER
+	CloneNewUTS    = unix.CLONE_NEWUTS
+	CloneNewCgroup = unix.CLONE_NEWCGROUP
+)

--- a/pkg/pillar/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/seccomp_default_unsupported.go
+++ b/pkg/pillar/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/seccomp_default_unsupported.go
@@ -1,0 +1,16 @@
+//go:build !linux
+// +build !linux
+
+package seccomp
+
+// These are copied from linux/amd64 syscall values, as a reference for other
+// platforms to have access to
+const (
+	CloneNewIPC    = 0x8000000
+	CloneNewNet    = 0x40000000
+	CloneNewNS     = 0x20000
+	CloneNewPID    = 0x20000000
+	CloneNewUser   = 0x10000000
+	CloneNewUTS    = 0x4000000
+	CloneNewCgroup = 0x02000000
+)

--- a/pkg/pillar/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/syscall_compare.go
+++ b/pkg/pillar/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/syscall_compare.go
@@ -1,0 +1,124 @@
+package seccomp
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// Determine if a new syscall rule should be appended, overwrite an existing rule
+// or if no action should be taken at all
+func decideCourseOfAction(newSyscall *rspec.LinuxSyscall, syscalls []rspec.LinuxSyscall) (string, error) {
+	ruleForSyscallAlreadyExists := false
+
+	var sliceOfDeterminedActions []string
+	for i, syscall := range syscalls {
+		if sameName(&syscall, newSyscall) {
+			ruleForSyscallAlreadyExists = true
+
+			if identical(newSyscall, &syscall) {
+				sliceOfDeterminedActions = append(sliceOfDeterminedActions, nothing)
+			}
+
+			if sameAction(newSyscall, &syscall) {
+				if bothHaveArgs(newSyscall, &syscall) {
+					sliceOfDeterminedActions = append(sliceOfDeterminedActions, seccompAppend)
+				}
+				if onlyOneHasArgs(newSyscall, &syscall) {
+					if firstParamOnlyHasArgs(newSyscall, &syscall) {
+						sliceOfDeterminedActions = append(sliceOfDeterminedActions, "overwrite:"+strconv.Itoa(i))
+					} else {
+						sliceOfDeterminedActions = append(sliceOfDeterminedActions, nothing)
+					}
+				}
+			}
+
+			if !sameAction(newSyscall, &syscall) {
+				if bothHaveArgs(newSyscall, &syscall) {
+					if sameArgs(newSyscall, &syscall) {
+						sliceOfDeterminedActions = append(sliceOfDeterminedActions, "overwrite:"+strconv.Itoa(i))
+					}
+					if !sameArgs(newSyscall, &syscall) {
+						sliceOfDeterminedActions = append(sliceOfDeterminedActions, seccompAppend)
+					}
+				}
+				if onlyOneHasArgs(newSyscall, &syscall) {
+					sliceOfDeterminedActions = append(sliceOfDeterminedActions, seccompAppend)
+				}
+				if neitherHasArgs(newSyscall, &syscall) {
+					sliceOfDeterminedActions = append(sliceOfDeterminedActions, "overwrite:"+strconv.Itoa(i))
+				}
+			}
+		}
+	}
+
+	if !ruleForSyscallAlreadyExists {
+		sliceOfDeterminedActions = append(sliceOfDeterminedActions, seccompAppend)
+	}
+
+	// Nothing has highest priority
+	for _, determinedAction := range sliceOfDeterminedActions {
+		if determinedAction == nothing {
+			return determinedAction, nil
+		}
+	}
+
+	// Overwrite has second highest priority
+	for _, determinedAction := range sliceOfDeterminedActions {
+		if strings.Contains(determinedAction, seccompOverwrite) {
+			return determinedAction, nil
+		}
+	}
+
+	// Append has the lowest priority
+	for _, determinedAction := range sliceOfDeterminedActions {
+		if determinedAction == seccompAppend {
+			return determinedAction, nil
+		}
+	}
+
+	return "", fmt.Errorf("Trouble determining action: %s", sliceOfDeterminedActions)
+}
+
+func hasArguments(config *rspec.LinuxSyscall) bool {
+	nilSyscall := new(rspec.LinuxSyscall)
+	return !sameArgs(nilSyscall, config)
+}
+
+func identical(config1, config2 *rspec.LinuxSyscall) bool {
+	return reflect.DeepEqual(config1, config2)
+}
+
+func sameName(config1, config2 *rspec.LinuxSyscall) bool {
+	return reflect.DeepEqual(config1.Names, config2.Names)
+}
+
+func sameAction(config1, config2 *rspec.LinuxSyscall) bool {
+	return config1.Action == config2.Action
+}
+
+func sameArgs(config1, config2 *rspec.LinuxSyscall) bool {
+	return reflect.DeepEqual(config1.Args, config2.Args)
+}
+
+func bothHaveArgs(config1, config2 *rspec.LinuxSyscall) bool {
+	return hasArguments(config1) && hasArguments(config2)
+}
+
+func onlyOneHasArgs(config1, config2 *rspec.LinuxSyscall) bool {
+	conf1 := hasArguments(config1)
+	conf2 := hasArguments(config2)
+
+	return (conf1 && !conf2) || (!conf1 && conf2)
+}
+
+func neitherHasArgs(config1, config2 *rspec.LinuxSyscall) bool {
+	return !hasArguments(config1) && !hasArguments(config2)
+}
+
+func firstParamOnlyHasArgs(config1, config2 *rspec.LinuxSyscall) bool {
+	return !hasArguments(config1) && hasArguments(config2)
+}

--- a/pkg/pillar/vendor/github.com/opencontainers/runtime-tools/validate/capabilities/validate.go
+++ b/pkg/pillar/vendor/github.com/opencontainers/runtime-tools/validate/capabilities/validate.go
@@ -1,0 +1,31 @@
+package capabilities
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/syndtr/gocapability/capability"
+)
+
+// CapValid checks whether a capability is valid
+func CapValid(c string, hostSpecific bool) error {
+	isValid := false
+
+	if !strings.HasPrefix(c, "CAP_") {
+		return fmt.Errorf("capability %s must start with CAP_", c)
+	}
+	for _, cap := range capability.List() {
+		if c == fmt.Sprintf("CAP_%s", strings.ToUpper(cap.String())) {
+			if hostSpecific && cap > LastCap() {
+				return fmt.Errorf("%s is not supported on the current host", c)
+			}
+			isValid = true
+			break
+		}
+	}
+
+	if !isValid {
+		return fmt.Errorf("invalid capability: %s", c)
+	}
+	return nil
+}

--- a/pkg/pillar/vendor/github.com/opencontainers/runtime-tools/validate/capabilities/validate_linux.go
+++ b/pkg/pillar/vendor/github.com/opencontainers/runtime-tools/validate/capabilities/validate_linux.go
@@ -1,0 +1,16 @@
+package capabilities
+
+import (
+	"github.com/syndtr/gocapability/capability"
+)
+
+// LastCap return last cap of system
+func LastCap() capability.Cap {
+	last := capability.CAP_LAST_CAP
+	// hack for RHEL6 which has no /proc/sys/kernel/cap_last_cap
+	if last == capability.Cap(63) {
+		last = capability.CAP_BLOCK_SUSPEND
+	}
+
+	return last
+}

--- a/pkg/pillar/vendor/github.com/opencontainers/runtime-tools/validate/capabilities/validate_unsupported.go
+++ b/pkg/pillar/vendor/github.com/opencontainers/runtime-tools/validate/capabilities/validate_unsupported.go
@@ -1,0 +1,13 @@
+//go:build !linux
+// +build !linux
+
+package capabilities
+
+import (
+	"github.com/syndtr/gocapability/capability"
+)
+
+// LastCap return last cap of system
+func LastCap() capability.Cap {
+	return capability.Cap(-1)
+}

--- a/pkg/pillar/vendor/modules.txt
+++ b/pkg/pillar/vendor/modules.txt
@@ -746,6 +746,11 @@ github.com/opencontainers/image-spec/specs-go/v1
 # github.com/opencontainers/runtime-spec v1.1.0
 ## explicit
 github.com/opencontainers/runtime-spec/specs-go
+# github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626
+## explicit; go 1.16
+github.com/opencontainers/runtime-tools/generate
+github.com/opencontainers/runtime-tools/generate/seccomp
+github.com/opencontainers/runtime-tools/validate/capabilities
 # github.com/opencontainers/selinux v1.11.0
 ## explicit; go 1.19
 github.com/opencontainers/selinux/go-selinux
@@ -1555,6 +1560,16 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
+# tags.cncf.io/container-device-interface v0.6.2
+## explicit; go 1.19
+tags.cncf.io/container-device-interface/internal/multierror
+tags.cncf.io/container-device-interface/internal/validation
+tags.cncf.io/container-device-interface/internal/validation/k8s
+tags.cncf.io/container-device-interface/pkg/cdi
+tags.cncf.io/container-device-interface/pkg/parser
+# tags.cncf.io/container-device-interface/specs-go v0.6.0
+## explicit; go 1.19
+tags.cncf.io/container-device-interface/specs-go
 # github.com/openshift/api => github.com/openshift/api v0.0.0-20210105115604-44119421ec6b
 # k8s.io/api => k8s.io/api v0.26.3
 # k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.26.3

--- a/pkg/pillar/vendor/tags.cncf.io/container-device-interface/LICENSE
+++ b/pkg/pillar/vendor/tags.cncf.io/container-device-interface/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkg/pillar/vendor/tags.cncf.io/container-device-interface/internal/multierror/multierror.go
+++ b/pkg/pillar/vendor/tags.cncf.io/container-device-interface/internal/multierror/multierror.go
@@ -1,0 +1,82 @@
+/*
+   Copyright © 2022 The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package multierror
+
+import (
+	"strings"
+)
+
+// New combines several errors into a single error. Parameters that are nil are
+// ignored. If no errors are passed in or all parameters are nil, then the
+// result is also nil.
+func New(errors ...error) error {
+	// Filter out nil entries.
+	numErrors := 0
+	for _, err := range errors {
+		if err != nil {
+			errors[numErrors] = err
+			numErrors++
+		}
+	}
+	if numErrors == 0 {
+		return nil
+	}
+	return multiError(errors[0:numErrors])
+}
+
+// multiError is the underlying implementation used by New.
+//
+// Beware that a null multiError is not the same as a nil error.
+type multiError []error
+
+// multiError returns all individual error strings concatenated with "\n"
+func (e multiError) Error() string {
+	var builder strings.Builder
+	for i, err := range e {
+		if i > 0 {
+			_, _ = builder.WriteString("\n")
+		}
+		_, _ = builder.WriteString(err.Error())
+	}
+	return builder.String()
+}
+
+// Append returns a new multi error all errors concatenated. Errors that are
+// multi errors get flattened, nil is ignored.
+func Append(err error, errors ...error) error {
+	var result multiError
+	if m, ok := err.(multiError); ok {
+		result = m
+	} else if err != nil {
+		result = append(result, err)
+	}
+
+	for _, e := range errors {
+		if e == nil {
+			continue
+		}
+		if m, ok := e.(multiError); ok {
+			result = append(result, m...)
+		} else {
+			result = append(result, e)
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}

--- a/pkg/pillar/vendor/tags.cncf.io/container-device-interface/internal/validation/k8s/objectmeta.go
+++ b/pkg/pillar/vendor/tags.cncf.io/container-device-interface/internal/validation/k8s/objectmeta.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Adapted from k8s.io/apimachinery/pkg/api/validation:
+// https://github.com/kubernetes/apimachinery/blob/7687996c715ee7d5c8cf1e3215e607eb065a4221/pkg/api/validation/objectmeta.go
+
+package k8s
+
+import (
+	"fmt"
+	"strings"
+
+	"tags.cncf.io/container-device-interface/internal/multierror"
+)
+
+// TotalAnnotationSizeLimitB defines the maximum size of all annotations in characters.
+const TotalAnnotationSizeLimitB int = 256 * (1 << 10) // 256 kB
+
+// ValidateAnnotations validates that a set of annotations are correctly defined.
+func ValidateAnnotations(annotations map[string]string, path string) error {
+	errors := multierror.New()
+	for k := range annotations {
+		// The rule is QualifiedName except that case doesn't matter, so convert to lowercase before checking.
+		for _, msg := range IsQualifiedName(strings.ToLower(k)) {
+			errors = multierror.Append(errors, fmt.Errorf("%v.%v is invalid: %v", path, k, msg))
+		}
+	}
+	if err := ValidateAnnotationsSize(annotations); err != nil {
+		errors = multierror.Append(errors, fmt.Errorf("%v is too long: %v", path, err))
+	}
+	return errors
+}
+
+// ValidateAnnotationsSize validates that a set of annotations is not too large.
+func ValidateAnnotationsSize(annotations map[string]string) error {
+	var totalSize int64
+	for k, v := range annotations {
+		totalSize += (int64)(len(k)) + (int64)(len(v))
+	}
+	if totalSize > (int64)(TotalAnnotationSizeLimitB) {
+		return fmt.Errorf("annotations size %d is larger than limit %d", totalSize, TotalAnnotationSizeLimitB)
+	}
+	return nil
+}

--- a/pkg/pillar/vendor/tags.cncf.io/container-device-interface/internal/validation/k8s/validation.go
+++ b/pkg/pillar/vendor/tags.cncf.io/container-device-interface/internal/validation/k8s/validation.go
@@ -1,0 +1,217 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Adapted from k8s.io/apimachinery/pkg/util/validation:
+// https://github.com/kubernetes/apimachinery/blob/7687996c715ee7d5c8cf1e3215e607eb065a4221/pkg/util/validation/validation.go
+
+package k8s
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const qnameCharFmt string = "[A-Za-z0-9]"
+const qnameExtCharFmt string = "[-A-Za-z0-9_.]"
+const qualifiedNameFmt string = "(" + qnameCharFmt + qnameExtCharFmt + "*)?" + qnameCharFmt
+const qualifiedNameErrMsg string = "must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character"
+const qualifiedNameMaxLength int = 63
+
+var qualifiedNameRegexp = regexp.MustCompile("^" + qualifiedNameFmt + "$")
+
+// IsQualifiedName tests whether the value passed is what Kubernetes calls a
+// "qualified name".  This is a format used in various places throughout the
+// system.  If the value is not valid, a list of error strings is returned.
+// Otherwise an empty list (or nil) is returned.
+func IsQualifiedName(value string) []string {
+	var errs []string
+	parts := strings.Split(value, "/")
+	var name string
+	switch len(parts) {
+	case 1:
+		name = parts[0]
+	case 2:
+		var prefix string
+		prefix, name = parts[0], parts[1]
+		if len(prefix) == 0 {
+			errs = append(errs, "prefix part "+EmptyError())
+		} else if msgs := IsDNS1123Subdomain(prefix); len(msgs) != 0 {
+			errs = append(errs, prefixEach(msgs, "prefix part ")...)
+		}
+	default:
+		return append(errs, "a qualified name "+RegexError(qualifiedNameErrMsg, qualifiedNameFmt, "MyName", "my.name", "123-abc")+
+			" with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')")
+	}
+
+	if len(name) == 0 {
+		errs = append(errs, "name part "+EmptyError())
+	} else if len(name) > qualifiedNameMaxLength {
+		errs = append(errs, "name part "+MaxLenError(qualifiedNameMaxLength))
+	}
+	if !qualifiedNameRegexp.MatchString(name) {
+		errs = append(errs, "name part "+RegexError(qualifiedNameErrMsg, qualifiedNameFmt, "MyName", "my.name", "123-abc"))
+	}
+	return errs
+}
+
+const labelValueFmt string = "(" + qualifiedNameFmt + ")?"
+const labelValueErrMsg string = "a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character"
+
+// LabelValueMaxLength is a label's max length
+const LabelValueMaxLength int = 63
+
+var labelValueRegexp = regexp.MustCompile("^" + labelValueFmt + "$")
+
+// IsValidLabelValue tests whether the value passed is a valid label value.  If
+// the value is not valid, a list of error strings is returned.  Otherwise an
+// empty list (or nil) is returned.
+func IsValidLabelValue(value string) []string {
+	var errs []string
+	if len(value) > LabelValueMaxLength {
+		errs = append(errs, MaxLenError(LabelValueMaxLength))
+	}
+	if !labelValueRegexp.MatchString(value) {
+		errs = append(errs, RegexError(labelValueErrMsg, labelValueFmt, "MyValue", "my_value", "12345"))
+	}
+	return errs
+}
+
+const dns1123LabelFmt string = "[a-z0-9]([-a-z0-9]*[a-z0-9])?"
+const dns1123LabelErrMsg string = "a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character"
+
+// DNS1123LabelMaxLength is a label's max length in DNS (RFC 1123)
+const DNS1123LabelMaxLength int = 63
+
+var dns1123LabelRegexp = regexp.MustCompile("^" + dns1123LabelFmt + "$")
+
+// IsDNS1123Label tests for a string that conforms to the definition of a label in
+// DNS (RFC 1123).
+func IsDNS1123Label(value string) []string {
+	var errs []string
+	if len(value) > DNS1123LabelMaxLength {
+		errs = append(errs, MaxLenError(DNS1123LabelMaxLength))
+	}
+	if !dns1123LabelRegexp.MatchString(value) {
+		errs = append(errs, RegexError(dns1123LabelErrMsg, dns1123LabelFmt, "my-name", "123-abc"))
+	}
+	return errs
+}
+
+const dns1123SubdomainFmt string = dns1123LabelFmt + "(\\." + dns1123LabelFmt + ")*"
+const dns1123SubdomainErrorMsg string = "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character"
+
+// DNS1123SubdomainMaxLength is a subdomain's max length in DNS (RFC 1123)
+const DNS1123SubdomainMaxLength int = 253
+
+var dns1123SubdomainRegexp = regexp.MustCompile("^" + dns1123SubdomainFmt + "$")
+
+// IsDNS1123Subdomain tests for a string that conforms to the definition of a
+// subdomain in DNS (RFC 1123).
+func IsDNS1123Subdomain(value string) []string {
+	var errs []string
+	if len(value) > DNS1123SubdomainMaxLength {
+		errs = append(errs, MaxLenError(DNS1123SubdomainMaxLength))
+	}
+	if !dns1123SubdomainRegexp.MatchString(value) {
+		errs = append(errs, RegexError(dns1123SubdomainErrorMsg, dns1123SubdomainFmt, "example.com"))
+	}
+	return errs
+}
+
+const dns1035LabelFmt string = "[a-z]([-a-z0-9]*[a-z0-9])?"
+const dns1035LabelErrMsg string = "a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character"
+
+// DNS1035LabelMaxLength is a label's max length in DNS (RFC 1035)
+const DNS1035LabelMaxLength int = 63
+
+var dns1035LabelRegexp = regexp.MustCompile("^" + dns1035LabelFmt + "$")
+
+// IsDNS1035Label tests for a string that conforms to the definition of a label in
+// DNS (RFC 1035).
+func IsDNS1035Label(value string) []string {
+	var errs []string
+	if len(value) > DNS1035LabelMaxLength {
+		errs = append(errs, MaxLenError(DNS1035LabelMaxLength))
+	}
+	if !dns1035LabelRegexp.MatchString(value) {
+		errs = append(errs, RegexError(dns1035LabelErrMsg, dns1035LabelFmt, "my-name", "abc-123"))
+	}
+	return errs
+}
+
+// wildcard definition - RFC 1034 section 4.3.3.
+// examples:
+// - valid: *.bar.com, *.foo.bar.com
+// - invalid: *.*.bar.com, *.foo.*.com, *bar.com, f*.bar.com, *
+const wildcardDNS1123SubdomainFmt = "\\*\\." + dns1123SubdomainFmt
+const wildcardDNS1123SubdomainErrMsg = "a wildcard DNS-1123 subdomain must start with '*.', followed by a valid DNS subdomain, which must consist of lower case alphanumeric characters, '-' or '.' and end with an alphanumeric character"
+
+// IsWildcardDNS1123Subdomain tests for a string that conforms to the definition of a
+// wildcard subdomain in DNS (RFC 1034 section 4.3.3).
+func IsWildcardDNS1123Subdomain(value string) []string {
+	wildcardDNS1123SubdomainRegexp := regexp.MustCompile("^" + wildcardDNS1123SubdomainFmt + "$")
+
+	var errs []string
+	if len(value) > DNS1123SubdomainMaxLength {
+		errs = append(errs, MaxLenError(DNS1123SubdomainMaxLength))
+	}
+	if !wildcardDNS1123SubdomainRegexp.MatchString(value) {
+		errs = append(errs, RegexError(wildcardDNS1123SubdomainErrMsg, wildcardDNS1123SubdomainFmt, "*.example.com"))
+	}
+	return errs
+}
+
+// MaxLenError returns a string explanation of a "string too long" validation
+// failure.
+func MaxLenError(length int) string {
+	return fmt.Sprintf("must be no more than %d characters", length)
+}
+
+// RegexError returns a string explanation of a regex validation failure.
+func RegexError(msg string, fmt string, examples ...string) string {
+	if len(examples) == 0 {
+		return msg + " (regex used for validation is '" + fmt + "')"
+	}
+	msg += " (e.g. "
+	for i := range examples {
+		if i > 0 {
+			msg += " or "
+		}
+		msg += "'" + examples[i] + "', "
+	}
+	msg += "regex used for validation is '" + fmt + "')"
+	return msg
+}
+
+// EmptyError returns a string explanation of a "must not be empty" validation
+// failure.
+func EmptyError() string {
+	return "must be non-empty"
+}
+
+func prefixEach(msgs []string, prefix string) []string {
+	for i := range msgs {
+		msgs[i] = prefix + msgs[i]
+	}
+	return msgs
+}
+
+// InclusiveRangeError returns a string explanation of a numeric "must be
+// between" validation failure.
+func InclusiveRangeError(lo, hi int) string {
+	return fmt.Sprintf(`must be between %d and %d, inclusive`, lo, hi)
+}

--- a/pkg/pillar/vendor/tags.cncf.io/container-device-interface/internal/validation/validate.go
+++ b/pkg/pillar/vendor/tags.cncf.io/container-device-interface/internal/validation/validate.go
@@ -1,0 +1,56 @@
+/*
+   Copyright © The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package validation
+
+import (
+	"fmt"
+	"strings"
+
+	"tags.cncf.io/container-device-interface/internal/validation/k8s"
+)
+
+// ValidateSpecAnnotations checks whether spec annotations are valid.
+func ValidateSpecAnnotations(name string, any interface{}) error {
+	if any == nil {
+		return nil
+	}
+
+	switch v := any.(type) {
+	case map[string]interface{}:
+		annotations := make(map[string]string)
+		for k, v := range v {
+			if s, ok := v.(string); ok {
+				annotations[k] = s
+			} else {
+				return fmt.Errorf("invalid annotation %v.%v; %v is not a string", name, k, any)
+			}
+		}
+		return validateSpecAnnotations(name, annotations)
+	}
+
+	return nil
+}
+
+// validateSpecAnnotations checks whether spec annotations are valid.
+func validateSpecAnnotations(name string, annotations map[string]string) error {
+	path := "annotations"
+	if name != "" {
+		path = strings.Join([]string{name, path}, ".")
+	}
+
+	return k8s.ValidateAnnotations(annotations, path)
+}

--- a/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/cdi/annotations.go
+++ b/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/cdi/annotations.go
@@ -1,0 +1,141 @@
+/*
+   Copyright © 2021-2022 The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cdi
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"tags.cncf.io/container-device-interface/pkg/parser"
+)
+
+const (
+	// AnnotationPrefix is the prefix for CDI container annotation keys.
+	AnnotationPrefix = "cdi.k8s.io/"
+)
+
+// UpdateAnnotations updates annotations with a plugin-specific CDI device
+// injection request for the given devices. Upon any error a non-nil error
+// is returned and annotations are left intact. By convention plugin should
+// be in the format of "vendor.device-type".
+func UpdateAnnotations(annotations map[string]string, plugin string, deviceID string, devices []string) (map[string]string, error) {
+	key, err := AnnotationKey(plugin, deviceID)
+	if err != nil {
+		return annotations, fmt.Errorf("CDI annotation failed: %w", err)
+	}
+	if _, ok := annotations[key]; ok {
+		return annotations, fmt.Errorf("CDI annotation failed, key %q used", key)
+	}
+	value, err := AnnotationValue(devices)
+	if err != nil {
+		return annotations, fmt.Errorf("CDI annotation failed: %w", err)
+	}
+
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[key] = value
+
+	return annotations, nil
+}
+
+// ParseAnnotations parses annotations for CDI device injection requests.
+// The keys and devices from all such requests are collected into slices
+// which are returned as the result. All devices are expected to be fully
+// qualified CDI device names. If any device fails this check empty slices
+// are returned along with a non-nil error. The annotations are expected
+// to be formatted by, or in a compatible fashion to UpdateAnnotations().
+func ParseAnnotations(annotations map[string]string) ([]string, []string, error) {
+	var (
+		keys    []string
+		devices []string
+	)
+
+	for key, value := range annotations {
+		if !strings.HasPrefix(key, AnnotationPrefix) {
+			continue
+		}
+		for _, d := range strings.Split(value, ",") {
+			if !IsQualifiedName(d) {
+				return nil, nil, fmt.Errorf("invalid CDI device name %q", d)
+			}
+			devices = append(devices, d)
+		}
+		keys = append(keys, key)
+	}
+
+	return keys, devices, nil
+}
+
+// AnnotationKey returns a unique annotation key for an device allocation
+// by a K8s device plugin. pluginName should be in the format of
+// "vendor.device-type". deviceID is the ID of the device the plugin is
+// allocating. It is used to make sure that the generated key is unique
+// even if multiple allocations by a single plugin needs to be annotated.
+func AnnotationKey(pluginName, deviceID string) (string, error) {
+	const maxNameLen = 63
+
+	if pluginName == "" {
+		return "", errors.New("invalid plugin name, empty")
+	}
+	if deviceID == "" {
+		return "", errors.New("invalid deviceID, empty")
+	}
+
+	name := pluginName + "_" + strings.ReplaceAll(deviceID, "/", "_")
+
+	if len(name) > maxNameLen {
+		return "", fmt.Errorf("invalid plugin+deviceID %q, too long", name)
+	}
+
+	if c := rune(name[0]); !parser.IsAlphaNumeric(c) {
+		return "", fmt.Errorf("invalid name %q, first '%c' should be alphanumeric",
+			name, c)
+	}
+	if len(name) > 2 {
+		for _, c := range name[1 : len(name)-1] {
+			switch {
+			case parser.IsAlphaNumeric(c):
+			case c == '_' || c == '-' || c == '.':
+			default:
+				return "", fmt.Errorf("invalid name %q, invalid character '%c'",
+					name, c)
+			}
+		}
+	}
+	if c := rune(name[len(name)-1]); !parser.IsAlphaNumeric(c) {
+		return "", fmt.Errorf("invalid name %q, last '%c' should be alphanumeric",
+			name, c)
+	}
+
+	return AnnotationPrefix + name, nil
+}
+
+// AnnotationValue returns an annotation value for the given devices.
+func AnnotationValue(devices []string) (string, error) {
+	value, sep := "", ""
+	for _, d := range devices {
+		if _, _, _, err := ParseQualifiedName(d); err != nil {
+			return "", err
+		}
+		value += sep + d
+		sep = ","
+	}
+
+	return value, nil
+}

--- a/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/cdi/cache.go
+++ b/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/cdi/cache.go
@@ -1,0 +1,581 @@
+/*
+   Copyright © 2021 The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cdi
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+	oci "github.com/opencontainers/runtime-spec/specs-go"
+	"tags.cncf.io/container-device-interface/internal/multierror"
+	cdi "tags.cncf.io/container-device-interface/specs-go"
+)
+
+// Option is an option to change some aspect of default CDI behavior.
+type Option func(*Cache) error
+
+// Cache stores CDI Specs loaded from Spec directories.
+type Cache struct {
+	sync.Mutex
+	specDirs  []string
+	specs     map[string][]*Spec
+	devices   map[string]*Device
+	errors    map[string][]error
+	dirErrors map[string]error
+
+	autoRefresh bool
+	watch       *watch
+}
+
+// WithAutoRefresh returns an option to control automatic Cache refresh.
+// By default, auto-refresh is enabled, the list of Spec directories are
+// monitored and the Cache is automatically refreshed whenever a change
+// is detected. This option can be used to disable this behavior when a
+// manually refreshed mode is preferable.
+func WithAutoRefresh(autoRefresh bool) Option {
+	return func(c *Cache) error {
+		c.autoRefresh = autoRefresh
+		return nil
+	}
+}
+
+// NewCache creates a new CDI Cache. The cache is populated from a set
+// of CDI Spec directories. These can be specified using a WithSpecDirs
+// option. The default set of directories is exposed in DefaultSpecDirs.
+func NewCache(options ...Option) (*Cache, error) {
+	c := &Cache{
+		autoRefresh: true,
+		watch:       &watch{},
+	}
+
+	WithSpecDirs(DefaultSpecDirs...)(c)
+	c.Lock()
+	defer c.Unlock()
+
+	return c, c.configure(options...)
+}
+
+// Configure applies options to the Cache. Updates and refreshes the
+// Cache if options have changed.
+func (c *Cache) Configure(options ...Option) error {
+	if len(options) == 0 {
+		return nil
+	}
+
+	c.Lock()
+	defer c.Unlock()
+
+	return c.configure(options...)
+}
+
+// Configure the Cache. Start/stop CDI Spec directory watch, refresh
+// the Cache if necessary.
+func (c *Cache) configure(options ...Option) error {
+	var err error
+
+	for _, o := range options {
+		if err = o(c); err != nil {
+			return fmt.Errorf("failed to apply cache options: %w", err)
+		}
+	}
+
+	c.dirErrors = make(map[string]error)
+
+	c.watch.stop()
+	if c.autoRefresh {
+		c.watch.setup(c.specDirs, c.dirErrors)
+		c.watch.start(&c.Mutex, c.refresh, c.dirErrors)
+	}
+	c.refresh()
+
+	return nil
+}
+
+// Refresh rescans the CDI Spec directories and refreshes the Cache.
+// In manual refresh mode the cache is always refreshed. In auto-
+// refresh mode the cache is only refreshed if it is out of date.
+func (c *Cache) Refresh() error {
+	c.Lock()
+	defer c.Unlock()
+
+	// force a refresh in manual mode
+	if refreshed, err := c.refreshIfRequired(!c.autoRefresh); refreshed {
+		return err
+	}
+
+	// collect and return cached errors, much like refresh() does it
+	var result error
+	for _, errors := range c.errors {
+		result = multierror.Append(result, errors...)
+	}
+	return result
+}
+
+// Refresh the Cache by rescanning CDI Spec directories and files.
+func (c *Cache) refresh() error {
+	var (
+		specs      = map[string][]*Spec{}
+		devices    = map[string]*Device{}
+		conflicts  = map[string]struct{}{}
+		specErrors = map[string][]error{}
+		result     []error
+	)
+
+	// collect errors per spec file path and once globally
+	collectError := func(err error, paths ...string) {
+		result = append(result, err)
+		for _, path := range paths {
+			specErrors[path] = append(specErrors[path], err)
+		}
+	}
+	// resolve conflicts based on device Spec priority (order of precedence)
+	resolveConflict := func(name string, dev *Device, old *Device) bool {
+		devSpec, oldSpec := dev.GetSpec(), old.GetSpec()
+		devPrio, oldPrio := devSpec.GetPriority(), oldSpec.GetPriority()
+		switch {
+		case devPrio > oldPrio:
+			return false
+		case devPrio == oldPrio:
+			devPath, oldPath := devSpec.GetPath(), oldSpec.GetPath()
+			collectError(fmt.Errorf("conflicting device %q (specs %q, %q)",
+				name, devPath, oldPath), devPath, oldPath)
+			conflicts[name] = struct{}{}
+		}
+		return true
+	}
+
+	_ = scanSpecDirs(c.specDirs, func(path string, priority int, spec *Spec, err error) error {
+		path = filepath.Clean(path)
+		if err != nil {
+			collectError(fmt.Errorf("failed to load CDI Spec %w", err), path)
+			return nil
+		}
+
+		vendor := spec.GetVendor()
+		specs[vendor] = append(specs[vendor], spec)
+
+		for _, dev := range spec.devices {
+			qualified := dev.GetQualifiedName()
+			other, ok := devices[qualified]
+			if ok {
+				if resolveConflict(qualified, dev, other) {
+					continue
+				}
+			}
+			devices[qualified] = dev
+		}
+
+		return nil
+	})
+
+	for conflict := range conflicts {
+		delete(devices, conflict)
+	}
+
+	c.specs = specs
+	c.devices = devices
+	c.errors = specErrors
+
+	return multierror.New(result...)
+}
+
+// RefreshIfRequired triggers a refresh if necessary.
+func (c *Cache) refreshIfRequired(force bool) (bool, error) {
+	// We need to refresh if
+	// - it's forced by an explicit call to Refresh() in manual mode
+	// - a missing Spec dir appears (added to watch) in auto-refresh mode
+	if force || (c.autoRefresh && c.watch.update(c.dirErrors)) {
+		return true, c.refresh()
+	}
+	return false, nil
+}
+
+// InjectDevices injects the given qualified devices to an OCI Spec. It
+// returns any unresolvable devices and an error if injection fails for
+// any of the devices.
+func (c *Cache) InjectDevices(ociSpec *oci.Spec, devices ...string) ([]string, error) {
+	var unresolved []string
+
+	if ociSpec == nil {
+		return devices, fmt.Errorf("can't inject devices, nil OCI Spec")
+	}
+
+	c.Lock()
+	defer c.Unlock()
+
+	c.refreshIfRequired(false)
+
+	edits := &ContainerEdits{}
+	specs := map[*Spec]struct{}{}
+
+	for _, device := range devices {
+		d := c.devices[device]
+		if d == nil {
+			unresolved = append(unresolved, device)
+			continue
+		}
+		if _, ok := specs[d.GetSpec()]; !ok {
+			specs[d.GetSpec()] = struct{}{}
+			edits.Append(d.GetSpec().edits())
+		}
+		edits.Append(d.edits())
+	}
+
+	if unresolved != nil {
+		return unresolved, fmt.Errorf("unresolvable CDI devices %s",
+			strings.Join(unresolved, ", "))
+	}
+
+	if err := edits.Apply(ociSpec); err != nil {
+		return nil, fmt.Errorf("failed to inject devices: %w", err)
+	}
+
+	return nil, nil
+}
+
+// highestPrioritySpecDir returns the Spec directory with highest priority
+// and its priority.
+func (c *Cache) highestPrioritySpecDir() (string, int) {
+	if len(c.specDirs) == 0 {
+		return "", -1
+	}
+
+	prio := len(c.specDirs) - 1
+	dir := c.specDirs[prio]
+
+	return dir, prio
+}
+
+// WriteSpec writes a Spec file with the given content into the highest
+// priority Spec directory. If name has a "json" or "yaml" extension it
+// choses the encoding. Otherwise the default YAML encoding is used.
+func (c *Cache) WriteSpec(raw *cdi.Spec, name string) error {
+	var (
+		specDir string
+		path    string
+		prio    int
+		spec    *Spec
+		err     error
+	)
+
+	specDir, prio = c.highestPrioritySpecDir()
+	if specDir == "" {
+		return errors.New("no Spec directories to write to")
+	}
+
+	path = filepath.Join(specDir, name)
+	if ext := filepath.Ext(path); ext != ".json" && ext != ".yaml" {
+		path += defaultSpecExt
+	}
+
+	spec, err = newSpec(raw, path, prio)
+	if err != nil {
+		return err
+	}
+
+	return spec.write(true)
+}
+
+// RemoveSpec removes a Spec with the given name from the highest
+// priority Spec directory. This function can be used to remove a
+// Spec previously written by WriteSpec(). If the file exists and
+// its removal fails RemoveSpec returns an error.
+func (c *Cache) RemoveSpec(name string) error {
+	var (
+		specDir string
+		path    string
+		err     error
+	)
+
+	specDir, _ = c.highestPrioritySpecDir()
+	if specDir == "" {
+		return errors.New("no Spec directories to remove from")
+	}
+
+	path = filepath.Join(specDir, name)
+	if ext := filepath.Ext(path); ext != ".json" && ext != ".yaml" {
+		path += defaultSpecExt
+	}
+
+	err = os.Remove(path)
+	if err != nil && errors.Is(err, fs.ErrNotExist) {
+		err = nil
+	}
+
+	return err
+}
+
+// GetDevice returns the cached device for the given qualified name.
+func (c *Cache) GetDevice(device string) *Device {
+	c.Lock()
+	defer c.Unlock()
+
+	c.refreshIfRequired(false)
+
+	return c.devices[device]
+}
+
+// ListDevices lists all cached devices by qualified name.
+func (c *Cache) ListDevices() []string {
+	var devices []string
+
+	c.Lock()
+	defer c.Unlock()
+
+	c.refreshIfRequired(false)
+
+	for name := range c.devices {
+		devices = append(devices, name)
+	}
+	sort.Strings(devices)
+
+	return devices
+}
+
+// ListVendors lists all vendors known to the cache.
+func (c *Cache) ListVendors() []string {
+	var vendors []string
+
+	c.Lock()
+	defer c.Unlock()
+
+	c.refreshIfRequired(false)
+
+	for vendor := range c.specs {
+		vendors = append(vendors, vendor)
+	}
+	sort.Strings(vendors)
+
+	return vendors
+}
+
+// ListClasses lists all device classes known to the cache.
+func (c *Cache) ListClasses() []string {
+	var (
+		cmap    = map[string]struct{}{}
+		classes []string
+	)
+
+	c.Lock()
+	defer c.Unlock()
+
+	c.refreshIfRequired(false)
+
+	for _, specs := range c.specs {
+		for _, spec := range specs {
+			cmap[spec.GetClass()] = struct{}{}
+		}
+	}
+	for class := range cmap {
+		classes = append(classes, class)
+	}
+	sort.Strings(classes)
+
+	return classes
+}
+
+// GetVendorSpecs returns all specs for the given vendor.
+func (c *Cache) GetVendorSpecs(vendor string) []*Spec {
+	c.Lock()
+	defer c.Unlock()
+
+	c.refreshIfRequired(false)
+
+	return c.specs[vendor]
+}
+
+// GetSpecErrors returns all errors encountered for the spec during the
+// last cache refresh.
+func (c *Cache) GetSpecErrors(spec *Spec) []error {
+	var errors []error
+
+	c.Lock()
+	defer c.Unlock()
+
+	if errs, ok := c.errors[spec.GetPath()]; ok {
+		errors = make([]error, len(errs))
+		copy(errors, errs)
+	}
+
+	return errors
+}
+
+// GetErrors returns all errors encountered during the last
+// cache refresh.
+func (c *Cache) GetErrors() map[string][]error {
+	c.Lock()
+	defer c.Unlock()
+
+	errors := map[string][]error{}
+	for path, errs := range c.errors {
+		errors[path] = errs
+	}
+	for path, err := range c.dirErrors {
+		errors[path] = []error{err}
+	}
+
+	return errors
+}
+
+// GetSpecDirectories returns the CDI Spec directories currently in use.
+func (c *Cache) GetSpecDirectories() []string {
+	c.Lock()
+	defer c.Unlock()
+
+	dirs := make([]string, len(c.specDirs))
+	copy(dirs, c.specDirs)
+	return dirs
+}
+
+// GetSpecDirErrors returns any errors related to configured Spec directories.
+func (c *Cache) GetSpecDirErrors() map[string]error {
+	if c.dirErrors == nil {
+		return nil
+	}
+
+	c.Lock()
+	defer c.Unlock()
+
+	errors := make(map[string]error)
+	for dir, err := range c.dirErrors {
+		errors[dir] = err
+	}
+	return errors
+}
+
+// Our fsnotify helper wrapper.
+type watch struct {
+	watcher *fsnotify.Watcher
+	tracked map[string]bool
+}
+
+// Setup monitoring for the given Spec directories.
+func (w *watch) setup(dirs []string, dirErrors map[string]error) {
+	var (
+		dir string
+		err error
+	)
+	w.tracked = make(map[string]bool)
+	for _, dir = range dirs {
+		w.tracked[dir] = false
+	}
+
+	w.watcher, err = fsnotify.NewWatcher()
+	if err != nil {
+		for _, dir := range dirs {
+			dirErrors[dir] = fmt.Errorf("failed to create watcher: %w", err)
+		}
+		return
+	}
+
+	w.update(dirErrors)
+}
+
+// Start watching Spec directories for relevant changes.
+func (w *watch) start(m *sync.Mutex, refresh func() error, dirErrors map[string]error) {
+	go w.watch(w.watcher, m, refresh, dirErrors)
+}
+
+// Stop watching directories.
+func (w *watch) stop() {
+	if w.watcher == nil {
+		return
+	}
+
+	w.watcher.Close()
+	w.tracked = nil
+}
+
+// Watch Spec directory changes, triggering a refresh if necessary.
+func (w *watch) watch(fsw *fsnotify.Watcher, m *sync.Mutex, refresh func() error, dirErrors map[string]error) {
+	watch := fsw
+	if watch == nil {
+		return
+	}
+	for {
+		select {
+		case event, ok := <-watch.Events:
+			if !ok {
+				return
+			}
+
+			if (event.Op & (fsnotify.Rename | fsnotify.Remove | fsnotify.Write)) == 0 {
+				continue
+			}
+			if event.Op == fsnotify.Write {
+				if ext := filepath.Ext(event.Name); ext != ".json" && ext != ".yaml" {
+					continue
+				}
+			}
+
+			m.Lock()
+			if event.Op == fsnotify.Remove && w.tracked[event.Name] {
+				w.update(dirErrors, event.Name)
+			} else {
+				w.update(dirErrors)
+			}
+			refresh()
+			m.Unlock()
+
+		case _, ok := <-watch.Errors:
+			if !ok {
+				return
+			}
+		}
+	}
+}
+
+// Update watch with pending/missing or removed directories.
+func (w *watch) update(dirErrors map[string]error, removed ...string) bool {
+	var (
+		dir    string
+		ok     bool
+		err    error
+		update bool
+	)
+
+	for dir, ok = range w.tracked {
+		if ok {
+			continue
+		}
+
+		err = w.watcher.Add(dir)
+		if err == nil {
+			w.tracked[dir] = true
+			delete(dirErrors, dir)
+			update = true
+		} else {
+			w.tracked[dir] = false
+			dirErrors[dir] = fmt.Errorf("failed to monitor for changes: %w", err)
+		}
+	}
+
+	for _, dir = range removed {
+		w.tracked[dir] = false
+		dirErrors[dir] = errors.New("directory removed")
+		update = true
+	}
+
+	return update
+}

--- a/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/cdi/cache_test_unix.go
+++ b/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/cdi/cache_test_unix.go
@@ -1,0 +1,26 @@
+//go:build !windows
+// +build !windows
+
+/*
+   Copyright © 2021 The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cdi
+
+import "syscall"
+
+func osSync() {
+	syscall.Sync()
+}

--- a/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/cdi/cache_test_windows.go
+++ b/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/cdi/cache_test_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+// +build windows
+
+/*
+   Copyright © 2021 The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cdi
+
+func osSync() {}

--- a/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/cdi/container-edits.go
+++ b/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/cdi/container-edits.go
@@ -1,0 +1,332 @@
+/*
+   Copyright © 2021 The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cdi
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	oci "github.com/opencontainers/runtime-spec/specs-go"
+	ocigen "github.com/opencontainers/runtime-tools/generate"
+	"tags.cncf.io/container-device-interface/specs-go"
+)
+
+const (
+	// PrestartHook is the name of the OCI "prestart" hook.
+	PrestartHook = "prestart"
+	// CreateRuntimeHook is the name of the OCI "createRuntime" hook.
+	CreateRuntimeHook = "createRuntime"
+	// CreateContainerHook is the name of the OCI "createContainer" hook.
+	CreateContainerHook = "createContainer"
+	// StartContainerHook is the name of the OCI "startContainer" hook.
+	StartContainerHook = "startContainer"
+	// PoststartHook is the name of the OCI "poststart" hook.
+	PoststartHook = "poststart"
+	// PoststopHook is the name of the OCI "poststop" hook.
+	PoststopHook = "poststop"
+)
+
+var (
+	// Names of recognized hooks.
+	validHookNames = map[string]struct{}{
+		PrestartHook:        {},
+		CreateRuntimeHook:   {},
+		CreateContainerHook: {},
+		StartContainerHook:  {},
+		PoststartHook:       {},
+		PoststopHook:        {},
+	}
+)
+
+// ContainerEdits represent updates to be applied to an OCI Spec.
+// These updates can be specific to a CDI device, or they can be
+// specific to a CDI Spec. In the former case these edits should
+// be applied to all OCI Specs where the corresponding CDI device
+// is injected. In the latter case, these edits should be applied
+// to all OCI Specs where at least one devices from the CDI Spec
+// is injected.
+type ContainerEdits struct {
+	*specs.ContainerEdits
+}
+
+// Apply edits to the given OCI Spec. Updates the OCI Spec in place.
+// Returns an error if the update fails.
+func (e *ContainerEdits) Apply(spec *oci.Spec) error {
+	if spec == nil {
+		return errors.New("can't edit nil OCI Spec")
+	}
+	if e == nil || e.ContainerEdits == nil {
+		return nil
+	}
+
+	specgen := ocigen.NewFromSpec(spec)
+	if len(e.Env) > 0 {
+		specgen.AddMultipleProcessEnv(e.Env)
+	}
+
+	for _, d := range e.DeviceNodes {
+		dn := DeviceNode{d}
+
+		err := dn.fillMissingInfo()
+		if err != nil {
+			return err
+		}
+		dev := d.ToOCI()
+		if dev.UID == nil && spec.Process != nil {
+			if uid := spec.Process.User.UID; uid > 0 {
+				dev.UID = &uid
+			}
+		}
+		if dev.GID == nil && spec.Process != nil {
+			if gid := spec.Process.User.GID; gid > 0 {
+				dev.GID = &gid
+			}
+		}
+
+		specgen.RemoveDevice(dev.Path)
+		specgen.AddDevice(dev)
+
+		if dev.Type == "b" || dev.Type == "c" {
+			access := d.Permissions
+			if access == "" {
+				access = "rwm"
+			}
+			specgen.AddLinuxResourcesDevice(true, dev.Type, &dev.Major, &dev.Minor, access)
+		}
+	}
+
+	if len(e.Mounts) > 0 {
+		for _, m := range e.Mounts {
+			specgen.RemoveMount(m.ContainerPath)
+			specgen.AddMount(m.ToOCI())
+		}
+		sortMounts(&specgen)
+	}
+
+	for _, h := range e.Hooks {
+		switch h.HookName {
+		case PrestartHook:
+			specgen.AddPreStartHook(h.ToOCI())
+		case PoststartHook:
+			specgen.AddPostStartHook(h.ToOCI())
+		case PoststopHook:
+			specgen.AddPostStopHook(h.ToOCI())
+			// TODO: Maybe runtime-tools/generate should be updated with these...
+		case CreateRuntimeHook:
+			ensureOCIHooks(spec)
+			spec.Hooks.CreateRuntime = append(spec.Hooks.CreateRuntime, h.ToOCI())
+		case CreateContainerHook:
+			ensureOCIHooks(spec)
+			spec.Hooks.CreateContainer = append(spec.Hooks.CreateContainer, h.ToOCI())
+		case StartContainerHook:
+			ensureOCIHooks(spec)
+			spec.Hooks.StartContainer = append(spec.Hooks.StartContainer, h.ToOCI())
+		default:
+			return fmt.Errorf("unknown hook name %q", h.HookName)
+		}
+	}
+
+	return nil
+}
+
+// Validate container edits.
+func (e *ContainerEdits) Validate() error {
+	if e == nil || e.ContainerEdits == nil {
+		return nil
+	}
+
+	if err := ValidateEnv(e.Env); err != nil {
+		return fmt.Errorf("invalid container edits: %w", err)
+	}
+	for _, d := range e.DeviceNodes {
+		if err := (&DeviceNode{d}).Validate(); err != nil {
+			return err
+		}
+	}
+	for _, h := range e.Hooks {
+		if err := (&Hook{h}).Validate(); err != nil {
+			return err
+		}
+	}
+	for _, m := range e.Mounts {
+		if err := (&Mount{m}).Validate(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Append other edits into this one. If called with a nil receiver,
+// allocates and returns newly allocated edits.
+func (e *ContainerEdits) Append(o *ContainerEdits) *ContainerEdits {
+	if o == nil || o.ContainerEdits == nil {
+		return e
+	}
+	if e == nil {
+		e = &ContainerEdits{}
+	}
+	if e.ContainerEdits == nil {
+		e.ContainerEdits = &specs.ContainerEdits{}
+	}
+
+	e.Env = append(e.Env, o.Env...)
+	e.DeviceNodes = append(e.DeviceNodes, o.DeviceNodes...)
+	e.Hooks = append(e.Hooks, o.Hooks...)
+	e.Mounts = append(e.Mounts, o.Mounts...)
+
+	return e
+}
+
+// isEmpty returns true if these edits are empty. This is valid in a
+// global Spec context but invalid in a Device context.
+func (e *ContainerEdits) isEmpty() bool {
+	if e == nil {
+		return false
+	}
+	return len(e.Env)+len(e.DeviceNodes)+len(e.Hooks)+len(e.Mounts) == 0
+}
+
+// ValidateEnv validates the given environment variables.
+func ValidateEnv(env []string) error {
+	for _, v := range env {
+		if strings.IndexByte(v, byte('=')) <= 0 {
+			return fmt.Errorf("invalid environment variable %q", v)
+		}
+	}
+	return nil
+}
+
+// DeviceNode is a CDI Spec DeviceNode wrapper, used for validating DeviceNodes.
+type DeviceNode struct {
+	*specs.DeviceNode
+}
+
+// Validate a CDI Spec DeviceNode.
+func (d *DeviceNode) Validate() error {
+	validTypes := map[string]struct{}{
+		"":  {},
+		"b": {},
+		"c": {},
+		"u": {},
+		"p": {},
+	}
+
+	if d.Path == "" {
+		return errors.New("invalid (empty) device path")
+	}
+	if _, ok := validTypes[d.Type]; !ok {
+		return fmt.Errorf("device %q: invalid type %q", d.Path, d.Type)
+	}
+	for _, bit := range d.Permissions {
+		if bit != 'r' && bit != 'w' && bit != 'm' {
+			return fmt.Errorf("device %q: invalid permissions %q",
+				d.Path, d.Permissions)
+		}
+	}
+	return nil
+}
+
+// Hook is a CDI Spec Hook wrapper, used for validating hooks.
+type Hook struct {
+	*specs.Hook
+}
+
+// Validate a hook.
+func (h *Hook) Validate() error {
+	if _, ok := validHookNames[h.HookName]; !ok {
+		return fmt.Errorf("invalid hook name %q", h.HookName)
+	}
+	if h.Path == "" {
+		return fmt.Errorf("invalid hook %q with empty path", h.HookName)
+	}
+	if err := ValidateEnv(h.Env); err != nil {
+		return fmt.Errorf("invalid hook %q: %w", h.HookName, err)
+	}
+	return nil
+}
+
+// Mount is a CDI Mount wrapper, used for validating mounts.
+type Mount struct {
+	*specs.Mount
+}
+
+// Validate a mount.
+func (m *Mount) Validate() error {
+	if m.HostPath == "" {
+		return errors.New("invalid mount, empty host path")
+	}
+	if m.ContainerPath == "" {
+		return errors.New("invalid mount, empty container path")
+	}
+	return nil
+}
+
+// Ensure OCI Spec hooks are not nil so we can add hooks.
+func ensureOCIHooks(spec *oci.Spec) {
+	if spec.Hooks == nil {
+		spec.Hooks = &oci.Hooks{}
+	}
+}
+
+// sortMounts sorts the mounts in the given OCI Spec.
+func sortMounts(specgen *ocigen.Generator) {
+	mounts := specgen.Mounts()
+	specgen.ClearMounts()
+	sort.Sort(orderedMounts(mounts))
+	specgen.Config.Mounts = mounts
+}
+
+// orderedMounts defines how to sort an OCI Spec Mount slice.
+// This is the almost the same implementation sa used by CRI-O and Docker,
+// with a minor tweak for stable sorting order (easier to test):
+//
+//	https://github.com/moby/moby/blob/17.05.x/daemon/volumes.go#L26
+type orderedMounts []oci.Mount
+
+// Len returns the number of mounts. Used in sorting.
+func (m orderedMounts) Len() int {
+	return len(m)
+}
+
+// Less returns true if the number of parts (a/b/c would be 3 parts) in the
+// mount indexed by parameter 1 is less than that of the mount indexed by
+// parameter 2. Used in sorting.
+func (m orderedMounts) Less(i, j int) bool {
+	ip, jp := m.parts(i), m.parts(j)
+	if ip < jp {
+		return true
+	}
+	if jp < ip {
+		return false
+	}
+	return m[i].Destination < m[j].Destination
+}
+
+// Swap swaps two items in an array of mounts. Used in sorting
+func (m orderedMounts) Swap(i, j int) {
+	m[i], m[j] = m[j], m[i]
+}
+
+// parts returns the number of parts in the destination of a mount. Used in sorting.
+func (m orderedMounts) parts(i int) int {
+	return strings.Count(filepath.Clean(m[i].Destination), string(os.PathSeparator))
+}

--- a/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/cdi/container-edits_unix.go
+++ b/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/cdi/container-edits_unix.go
@@ -1,0 +1,88 @@
+//go:build !windows
+// +build !windows
+
+/*
+   Copyright © 2021 The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cdi
+
+import (
+	"errors"
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	blockDevice = "b"
+	charDevice  = "c" // or "u"
+	fifoDevice  = "p"
+)
+
+// deviceInfoFromPath takes the path to a device and returns its type,
+// major and minor device numbers.
+//
+// It was adapted from https://github.com/opencontainers/runc/blob/v1.1.9/libcontainer/devices/device_unix.go#L30-L69
+func deviceInfoFromPath(path string) (devType string, major, minor int64, _ error) {
+	var stat unix.Stat_t
+	err := unix.Lstat(path, &stat)
+	if err != nil {
+		return "", 0, 0, err
+	}
+	switch stat.Mode & unix.S_IFMT {
+	case unix.S_IFBLK:
+		devType = blockDevice
+	case unix.S_IFCHR:
+		devType = charDevice
+	case unix.S_IFIFO:
+		devType = fifoDevice
+	default:
+		return "", 0, 0, errors.New("not a device node")
+	}
+	devNumber := uint64(stat.Rdev) //nolint:unconvert // Rdev is uint32 on e.g. MIPS.
+	return devType, int64(unix.Major(devNumber)), int64(unix.Minor(devNumber)), nil
+}
+
+// fillMissingInfo fills in missing mandatory attributes from the host device.
+func (d *DeviceNode) fillMissingInfo() error {
+	if d.HostPath == "" {
+		d.HostPath = d.Path
+	}
+
+	if d.Type != "" && (d.Major != 0 || d.Type == "p") {
+		return nil
+	}
+
+	deviceType, major, minor, err := deviceInfoFromPath(d.HostPath)
+	if err != nil {
+		return fmt.Errorf("failed to stat CDI host device %q: %w", d.HostPath, err)
+	}
+
+	if d.Type == "" {
+		d.Type = deviceType
+	} else {
+		if d.Type != deviceType {
+			return fmt.Errorf("CDI device (%q, %q), host type mismatch (%s, %s)",
+				d.Path, d.HostPath, d.Type, deviceType)
+		}
+	}
+	if d.Major == 0 && d.Type != "p" {
+		d.Major = major
+		d.Minor = minor
+	}
+
+	return nil
+}

--- a/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/cdi/container-edits_windows.go
+++ b/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/cdi/container-edits_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+// +build windows
+
+/*
+   Copyright © 2021 The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cdi
+
+import "fmt"
+
+// fillMissingInfo fills in missing mandatory attributes from the host device.
+func (d *DeviceNode) fillMissingInfo() error {
+	return fmt.Errorf("unimplemented")
+}

--- a/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/cdi/device.go
+++ b/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/cdi/device.go
@@ -1,0 +1,88 @@
+/*
+   Copyright © 2021 The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cdi
+
+import (
+	"fmt"
+
+	oci "github.com/opencontainers/runtime-spec/specs-go"
+	"tags.cncf.io/container-device-interface/internal/validation"
+	"tags.cncf.io/container-device-interface/pkg/parser"
+	cdi "tags.cncf.io/container-device-interface/specs-go"
+)
+
+// Device represents a CDI device of a Spec.
+type Device struct {
+	*cdi.Device
+	spec *Spec
+}
+
+// Create a new Device, associate it with the given Spec.
+func newDevice(spec *Spec, d cdi.Device) (*Device, error) {
+	dev := &Device{
+		Device: &d,
+		spec:   spec,
+	}
+
+	if err := dev.validate(); err != nil {
+		return nil, err
+	}
+
+	return dev, nil
+}
+
+// GetSpec returns the Spec this device is defined in.
+func (d *Device) GetSpec() *Spec {
+	return d.spec
+}
+
+// GetQualifiedName returns the qualified name for this device.
+func (d *Device) GetQualifiedName() string {
+	return parser.QualifiedName(d.spec.GetVendor(), d.spec.GetClass(), d.Name)
+}
+
+// ApplyEdits applies the device-speific container edits to an OCI Spec.
+func (d *Device) ApplyEdits(ociSpec *oci.Spec) error {
+	return d.edits().Apply(ociSpec)
+}
+
+// edits returns the applicable container edits for this spec.
+func (d *Device) edits() *ContainerEdits {
+	return &ContainerEdits{&d.ContainerEdits}
+}
+
+// Validate the device.
+func (d *Device) validate() error {
+	if err := ValidateDeviceName(d.Name); err != nil {
+		return err
+	}
+	name := d.Name
+	if d.spec != nil {
+		name = d.GetQualifiedName()
+	}
+	if err := validation.ValidateSpecAnnotations(name, d.Annotations); err != nil {
+		return err
+	}
+	edits := d.edits()
+	if edits.isEmpty() {
+		return fmt.Errorf("invalid device, empty device edits")
+	}
+	if err := edits.Validate(); err != nil {
+		return fmt.Errorf("invalid device %q: %w", d.Name, err)
+	}
+	return nil
+}

--- a/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/cdi/doc.go
+++ b/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/cdi/doc.go
@@ -1,0 +1,276 @@
+// Package cdi has the primary purpose of providing an API for
+// interacting with CDI and consuming CDI devices.
+//
+// For more information about Container Device Interface, please refer to
+// https://tags.cncf.io/container-device-interface
+//
+// # Container Device Interface
+//
+// Container Device Interface, or CDI for short, provides comprehensive
+// third party device support for container runtimes. CDI uses vendor
+// provided specification files, CDI Specs for short, to describe how a
+// container's runtime environment should be modified when one or more
+// of the vendor-specific devices is injected into the container. Beyond
+// describing the low level platform-specific details of how to gain
+// basic access to a device, CDI Specs allow more fine-grained device
+// initialization, and the automatic injection of any necessary vendor-
+// or device-specific software that might be required for a container
+// to use a device or take full advantage of it.
+//
+// In the CDI device model containers request access to a device using
+// fully qualified device names, qualified names for short, consisting of
+// a vendor identifier, a device class and a device name or identifier.
+// These pieces of information together uniquely identify a device among
+// all device vendors, classes and device instances.
+//
+// This package implements an API for easy consumption of CDI. The API
+// implements discovery, loading and caching of CDI Specs and injection
+// of CDI devices into containers. This is the most common functionality
+// the vast majority of CDI consumers need. The API should be usable both
+// by OCI runtime clients and runtime implementations.
+//
+// # CDI Registry
+//
+// The primary interface to interact with CDI devices is the Registry. It
+// is essentially a cache of all Specs and devices discovered in standard
+// CDI directories on the host. The registry has two main functionality,
+// injecting devices into an OCI Spec and refreshing the cache of CDI
+// Specs and devices.
+//
+// # Device Injection
+//
+// Using the Registry one can inject CDI devices into a container with code
+// similar to the following snippet:
+//
+//	import (
+//	    "fmt"
+//	    "strings"
+//
+//	    log "github.com/sirupsen/logrus"
+//
+//	    "tags.cncf.io/container-device-interface/pkg/cdi"
+//	    oci "github.com/opencontainers/runtime-spec/specs-go"
+//	)
+//
+//	func injectCDIDevices(spec *oci.Spec, devices []string) error {
+//	    log.Debug("pristine OCI Spec: %s", dumpSpec(spec))
+//
+//	    unresolved, err := cdi.GetRegistry().InjectDevices(spec, devices)
+//	    if err != nil {
+//	        return fmt.Errorf("CDI device injection failed: %w", err)
+//	    }
+//
+//	    log.Debug("CDI-updated OCI Spec: %s", dumpSpec(spec))
+//	    return nil
+//	}
+//
+// # Cache Refresh
+//
+// By default the CDI Spec cache monitors the configured Spec directories
+// and automatically refreshes itself when necessary. This behavior can be
+// disabled using the WithAutoRefresh(false) option.
+//
+// Failure to set up monitoring for a Spec directory causes the directory to
+// get ignored and an error to be recorded among the Spec directory errors.
+// These errors can be queried using the GetSpecDirErrors() function. If the
+// error condition is transient, for instance a missing directory which later
+// gets created, the corresponding error will be removed once the condition
+// is over.
+//
+// With auto-refresh enabled injecting any CDI devices can be done without
+// an explicit call to Refresh(), using a code snippet similar to the
+// following:
+//
+// In a runtime implementation one typically wants to make sure the
+// CDI Spec cache is up to date before performing device injection.
+// A code snippet similar to the following accmplishes that:
+//
+//	import (
+//	    "fmt"
+//	    "strings"
+//
+//	    log "github.com/sirupsen/logrus"
+//
+//	    "tags.cncf.io/container-device-interface/pkg/cdi"
+//	    oci "github.com/opencontainers/runtime-spec/specs-go"
+//	)
+//
+//	func injectCDIDevices(spec *oci.Spec, devices []string) error {
+//	    registry := cdi.GetRegistry()
+//
+//	    if err := registry.Refresh(); err != nil {
+//	        // Note:
+//	        //   It is up to the implementation to decide whether
+//	        //   to abort injection on errors. A failed Refresh()
+//	        //   does not necessarily render the registry unusable.
+//	        //   For instance, a parse error in a Spec file for
+//	        //   vendor A does not have any effect on devices of
+//	        //   vendor B...
+//	        log.Warnf("pre-injection Refresh() failed: %v", err)
+//	    }
+//
+//	    log.Debug("pristine OCI Spec: %s", dumpSpec(spec))
+//
+//	    unresolved, err := registry.InjectDevices(spec, devices)
+//	    if err != nil {
+//	        return fmt.Errorf("CDI device injection failed: %w", err)
+//	    }
+//
+//	    log.Debug("CDI-updated OCI Spec: %s", dumpSpec(spec))
+//	    return nil
+//	}
+//
+// # Generated Spec Files, Multiple Directories, Device Precedence
+//
+// It is often necessary to generate Spec files dynamically. On some
+// systems the available or usable set of CDI devices might change
+// dynamically which then needs to be reflected in CDI Specs. For
+// some device classes it makes sense to enumerate the available
+// devices at every boot and generate Spec file entries for each
+// device found. Some CDI devices might need special client- or
+// request-specific configuration which can only be fulfilled by
+// dynamically generated client-specific entries in transient Spec
+// files.
+//
+// CDI can collect Spec files from multiple directories. Spec files are
+// automatically assigned priorities according to which directory they
+// were loaded from. The later a directory occurs in the list of CDI
+// directories to scan, the higher priority Spec files loaded from that
+// directory are assigned to. When two or more Spec files define the
+// same device, conflict is resolved by choosing the definition from the
+// Spec file with the highest priority.
+//
+// The default CDI directory configuration is chosen to encourage
+// separating dynamically generated CDI Spec files from static ones.
+// The default directories are '/etc/cdi' and '/var/run/cdi'. By putting
+// dynamically generated Spec files under '/var/run/cdi', those take
+// precedence over static ones in '/etc/cdi'. With this scheme, static
+// Spec files, typically installed by distro-specific packages, go into
+// '/etc/cdi' while all the dynamically generated Spec files, transient
+// or other, go into '/var/run/cdi'.
+//
+// # Spec File Generation
+//
+// CDI offers two functions for writing and removing dynamically generated
+// Specs from CDI Spec directories. These functions, WriteSpec() and
+// RemoveSpec() implicitly follow the principle of separating dynamic Specs
+// from the rest and therefore always write to and remove Specs from the
+// last configured directory.
+//
+// Corresponding functions are also provided for generating names for Spec
+// files. These functions follow a simple naming convention to ensure that
+// multiple entities generating Spec files simultaneously on the same host
+// do not end up using conflicting Spec file names. GenerateSpecName(),
+// GenerateNameForSpec(), GenerateTransientSpecName(), and
+// GenerateTransientNameForSpec() all generate names which can be passed
+// as such to WriteSpec() and subsequently to RemoveSpec().
+//
+// Generating a Spec file for a vendor/device class can be done with a
+// code snippet similar to the following:
+//
+// import (
+//
+//	"fmt"
+//	...
+//	"tags.cncf.io/container-device-interface/specs-go"
+//	"tags.cncf.io/container-device-interface/pkg/cdi"
+//
+// )
+//
+//	func generateDeviceSpecs() error {
+//	    registry := cdi.GetRegistry()
+//	    spec := &specs.Spec{
+//	        Version: specs.CurrentVersion,
+//	        Kind:    vendor+"/"+class,
+//	    }
+//
+//	    for _, dev := range enumerateDevices() {
+//	        spec.Devices = append(spec.Devices, specs.Device{
+//	            Name: dev.Name,
+//	            ContainerEdits: getContainerEditsForDevice(dev),
+//	        })
+//	    }
+//
+//	    specName, err := cdi.GenerateNameForSpec(spec)
+//	    if err != nil {
+//	        return fmt.Errorf("failed to generate Spec name: %w", err)
+//	    }
+//
+//	    return registry.SpecDB().WriteSpec(spec, specName)
+//	}
+//
+// Similarly, generating and later cleaning up transient Spec files can be
+// done with code fragments similar to the following. These transient Spec
+// files are temporary Spec files with container-specific parametrization.
+// They are typically created before the associated container is created
+// and removed once that container is removed.
+//
+// import (
+//
+//	"fmt"
+//	...
+//	"tags.cncf.io/container-device-interface/specs-go"
+//	"tags.cncf.io/container-device-interface/pkg/cdi"
+//
+// )
+//
+//	func generateTransientSpec(ctr Container) error {
+//	    registry := cdi.GetRegistry()
+//	    devices := getContainerDevs(ctr, vendor, class)
+//	    spec := &specs.Spec{
+//	        Version: specs.CurrentVersion,
+//	        Kind:    vendor+"/"+class,
+//	    }
+//
+//	    for _, dev := range devices {
+//	        spec.Devices = append(spec.Devices, specs.Device{
+//	            // the generated name needs to be unique within the
+//	            // vendor/class domain on the host/node.
+//	            Name: generateUniqueDevName(dev, ctr),
+//	            ContainerEdits: getEditsForContainer(dev),
+//	        })
+//	    }
+//
+//	    // transientID is expected to guarantee that the Spec file name
+//	    // generated using <vendor, class, transientID> is unique within
+//	    // the host/node. If more than one device is allocated with the
+//	    // same vendor/class domain, either all generated Spec entries
+//	    // should go to a single Spec file (like in this sample snippet),
+//	    // or transientID should be unique for each generated Spec file.
+//	    transientID := getSomeSufficientlyUniqueIDForContainer(ctr)
+//	    specName, err := cdi.GenerateNameForTransientSpec(vendor, class, transientID)
+//	    if err != nil {
+//	        return fmt.Errorf("failed to generate Spec name: %w", err)
+//	    }
+//
+//	    return registry.SpecDB().WriteSpec(spec, specName)
+//	}
+//
+//	func removeTransientSpec(ctr Container) error {
+//	    registry := cdi.GetRegistry()
+//	    transientID := getSomeSufficientlyUniqueIDForContainer(ctr)
+//	    specName := cdi.GenerateNameForTransientSpec(vendor, class, transientID)
+//
+//	    return registry.SpecDB().RemoveSpec(specName)
+//	}
+//
+// # CDI Spec Validation
+//
+// This package performs both syntactic and semantic validation of CDI
+// Spec file data when a Spec file is loaded via the registry or using
+// the ReadSpec API function. As part of the semantic verification, the
+// Spec file is verified against the CDI Spec JSON validation schema.
+//
+// If a valid externally provided JSON validation schema is found in
+// the filesystem at /etc/cdi/schema/schema.json it is loaded and used
+// as the default validation schema. If such a file is not found or
+// fails to load, an embedded no-op schema is used.
+//
+// The used validation schema can also be changed programmatically using
+// the SetSchema API convenience function. This function also accepts
+// the special "builtin" (BuiltinSchemaName) and "none" (NoneSchemaName)
+// schema names which switch the used schema to the in-repo validation
+// schema embedded into the binary or the now default no-op schema
+// correspondingly. Other names are interpreted as the path to the actual
+// validation schema to load and use.
+package cdi

--- a/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/cdi/qualified-device.go
+++ b/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/cdi/qualified-device.go
@@ -1,0 +1,113 @@
+/*
+   Copyright © 2021 The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cdi
+
+import (
+	"tags.cncf.io/container-device-interface/pkg/parser"
+)
+
+// QualifiedName returns the qualified name for a device.
+// The syntax for a qualified device names is
+//
+//	"<vendor>/<class>=<name>".
+//
+// A valid vendor and class name may contain the following runes:
+//
+//	'A'-'Z', 'a'-'z', '0'-'9', '.', '-', '_'.
+//
+// A valid device name may contain the following runes:
+//
+//	'A'-'Z', 'a'-'z', '0'-'9', '-', '_', '.', ':'
+//
+// Deprecated: use parser.QualifiedName instead
+func QualifiedName(vendor, class, name string) string {
+	return parser.QualifiedName(vendor, class, name)
+}
+
+// IsQualifiedName tests if a device name is qualified.
+//
+// Deprecated: use parser.IsQualifiedName instead
+func IsQualifiedName(device string) bool {
+	return parser.IsQualifiedName(device)
+}
+
+// ParseQualifiedName splits a qualified name into device vendor, class,
+// and name. If the device fails to parse as a qualified name, or if any
+// of the split components fail to pass syntax validation, vendor and
+// class are returned as empty, together with the verbatim input as the
+// name and an error describing the reason for failure.
+//
+// Deprecated: use parser.ParseQualifiedName instead
+func ParseQualifiedName(device string) (string, string, string, error) {
+	return parser.ParseQualifiedName(device)
+}
+
+// ParseDevice tries to split a device name into vendor, class, and name.
+// If this fails, for instance in the case of unqualified device names,
+// ParseDevice returns an empty vendor and class together with name set
+// to the verbatim input.
+//
+// Deprecated: use parser.ParseDevice instead
+func ParseDevice(device string) (string, string, string) {
+	return parser.ParseDevice(device)
+}
+
+// ParseQualifier splits a device qualifier into vendor and class.
+// The syntax for a device qualifier is
+//
+//	"<vendor>/<class>"
+//
+// If parsing fails, an empty vendor and the class set to the
+// verbatim input is returned.
+//
+// Deprecated: use parser.ParseQualifier instead
+func ParseQualifier(kind string) (string, string) {
+	return parser.ParseQualifier(kind)
+}
+
+// ValidateVendorName checks the validity of a vendor name.
+// A vendor name may contain the following ASCII characters:
+//   - upper- and lowercase letters ('A'-'Z', 'a'-'z')
+//   - digits ('0'-'9')
+//   - underscore, dash, and dot ('_', '-', and '.')
+//
+// Deprecated: use parser.ValidateVendorName instead
+func ValidateVendorName(vendor string) error {
+	return parser.ValidateVendorName(vendor)
+}
+
+// ValidateClassName checks the validity of class name.
+// A class name may contain the following ASCII characters:
+//   - upper- and lowercase letters ('A'-'Z', 'a'-'z')
+//   - digits ('0'-'9')
+//   - underscore, dash, and dot ('_', '-', and '.')
+//
+// Deprecated: use parser.ValidateClassName instead
+func ValidateClassName(class string) error {
+	return parser.ValidateClassName(class)
+}
+
+// ValidateDeviceName checks the validity of a device name.
+// A device name may contain the following ASCII characters:
+//   - upper- and lowercase letters ('A'-'Z', 'a'-'z')
+//   - digits ('0'-'9')
+//   - underscore, dash, dot, colon ('_', '-', '.', ':')
+//
+// Deprecated: use parser.ValidateDeviceName instead
+func ValidateDeviceName(name string) error {
+	return parser.ValidateDeviceName(name)
+}

--- a/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/cdi/registry.go
+++ b/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/cdi/registry.go
@@ -1,0 +1,150 @@
+/*
+   Copyright © 2021 The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cdi
+
+import (
+	"sync"
+
+	oci "github.com/opencontainers/runtime-spec/specs-go"
+	cdi "tags.cncf.io/container-device-interface/specs-go"
+)
+
+// Registry keeps a cache of all CDI Specs installed or generated on
+// the host. Registry is the primary interface clients should use to
+// interact with CDI.
+//
+// The most commonly used Registry functions are for refreshing the
+// registry and injecting CDI devices into an OCI Spec.
+type Registry interface {
+	RegistryResolver
+	RegistryRefresher
+	DeviceDB() RegistryDeviceDB
+	SpecDB() RegistrySpecDB
+}
+
+// RegistryRefresher is the registry interface for refreshing the
+// cache of CDI Specs and devices.
+//
+// Configure reconfigures the registry with the given options.
+//
+// Refresh rescans all CDI Spec directories and updates the
+// state of the cache to reflect any changes. It returns any
+// errors encountered during the refresh.
+//
+// GetErrors returns all errors encountered for any of the scanned
+// Spec files during the last cache refresh.
+//
+// GetSpecDirectories returns the set up CDI Spec directories
+// currently in use. The directories are returned in the scan
+// order of Refresh().
+//
+// GetSpecDirErrors returns any errors related to the configured
+// Spec directories.
+type RegistryRefresher interface {
+	Configure(...Option) error
+	Refresh() error
+	GetErrors() map[string][]error
+	GetSpecDirectories() []string
+	GetSpecDirErrors() map[string]error
+}
+
+// RegistryResolver is the registry interface for injecting CDI
+// devices into an OCI Spec.
+//
+// InjectDevices takes an OCI Spec and injects into it a set of
+// CDI devices given by qualified name. It returns the names of
+// any unresolved devices and an error if injection fails.
+type RegistryResolver interface {
+	InjectDevices(spec *oci.Spec, device ...string) (unresolved []string, err error)
+}
+
+// RegistryDeviceDB is the registry interface for querying devices.
+//
+// GetDevice returns the CDI device for the given qualified name. If
+// the device is not GetDevice returns nil.
+//
+// ListDevices returns a slice with the names of qualified device
+// known. The returned slice is sorted.
+type RegistryDeviceDB interface {
+	GetDevice(device string) *Device
+	ListDevices() []string
+}
+
+// RegistrySpecDB is the registry interface for querying CDI Specs.
+//
+// ListVendors returns a slice with all vendors known. The returned
+// slice is sorted.
+//
+// ListClasses returns a slice with all classes known. The returned
+// slice is sorted.
+//
+// GetVendorSpecs returns a slice of all Specs for the vendor.
+//
+// GetSpecErrors returns any errors for the Spec encountered during
+// the last cache refresh.
+//
+// WriteSpec writes the Spec with the given content and name to the
+// last Spec directory.
+type RegistrySpecDB interface {
+	ListVendors() []string
+	ListClasses() []string
+	GetVendorSpecs(vendor string) []*Spec
+	GetSpecErrors(*Spec) []error
+	WriteSpec(raw *cdi.Spec, name string) error
+	RemoveSpec(name string) error
+}
+
+type registry struct {
+	*Cache
+}
+
+var _ Registry = &registry{}
+
+var (
+	reg      *registry
+	initOnce sync.Once
+)
+
+// GetRegistry returns the CDI registry. If any options are given, those
+// are applied to the registry.
+func GetRegistry(options ...Option) Registry {
+	var new bool
+	initOnce.Do(func() {
+		reg, _ = getRegistry(options...)
+		new = true
+	})
+	if !new && len(options) > 0 {
+		reg.Configure(options...)
+		reg.Refresh()
+	}
+	return reg
+}
+
+// DeviceDB returns the registry interface for querying devices.
+func (r *registry) DeviceDB() RegistryDeviceDB {
+	return r
+}
+
+// SpecDB returns the registry interface for querying Specs.
+func (r *registry) SpecDB() RegistrySpecDB {
+	return r
+}
+
+func getRegistry(options ...Option) (*registry, error) {
+	c, err := NewCache(options...)
+	return &registry{c}, err
+}

--- a/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/cdi/spec-dirs.go
+++ b/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/cdi/spec-dirs.go
@@ -1,0 +1,114 @@
+/*
+   Copyright © 2021 The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cdi
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+const (
+	// DefaultStaticDir is the default directory for static CDI Specs.
+	DefaultStaticDir = "/etc/cdi"
+	// DefaultDynamicDir is the default directory for generated CDI Specs
+	DefaultDynamicDir = "/var/run/cdi"
+)
+
+var (
+	// DefaultSpecDirs is the default Spec directory configuration.
+	// While altering this variable changes the package defaults,
+	// the preferred way of overriding the default directories is
+	// to use a WithSpecDirs options. Otherwise the change is only
+	// effective if it takes place before creating the Registry or
+	// other Cache instances.
+	DefaultSpecDirs = []string{DefaultStaticDir, DefaultDynamicDir}
+	// ErrStopScan can be returned from a ScanSpecFunc to stop the scan.
+	ErrStopScan = errors.New("stop Spec scan")
+)
+
+// WithSpecDirs returns an option to override the CDI Spec directories.
+func WithSpecDirs(dirs ...string) Option {
+	return func(c *Cache) error {
+		specDirs := make([]string, len(dirs))
+		for i, dir := range dirs {
+			specDirs[i] = filepath.Clean(dir)
+		}
+		c.specDirs = specDirs
+		return nil
+	}
+}
+
+// scanSpecFunc is a function for processing CDI Spec files.
+type scanSpecFunc func(string, int, *Spec, error) error
+
+// ScanSpecDirs scans the given directories looking for CDI Spec files,
+// which are all files with a '.json' or '.yaml' suffix. For every Spec
+// file discovered, ScanSpecDirs loads a Spec from the file then calls
+// the scan function passing it the path to the file, the priority (the
+// index of the directory in the slice of directories given), the Spec
+// itself, and any error encountered while loading the Spec.
+//
+// Scanning stops once all files have been processed or when the scan
+// function returns an error. The result of ScanSpecDirs is the error
+// returned by the scan function, if any. The special error ErrStopScan
+// can be used to terminate the scan gracefully without ScanSpecDirs
+// returning an error. ScanSpecDirs silently skips any subdirectories.
+func scanSpecDirs(dirs []string, scanFn scanSpecFunc) error {
+	var (
+		spec *Spec
+		err  error
+	)
+
+	for priority, dir := range dirs {
+		err = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+			// for initial stat failure Walk calls us with nil info
+			if info == nil {
+				if errors.Is(err, fs.ErrNotExist) {
+					return nil
+				}
+				return err
+			}
+			// first call from Walk is for dir itself, others we skip
+			if info.IsDir() {
+				if path == dir {
+					return nil
+				}
+				return filepath.SkipDir
+			}
+
+			// ignore obviously non-Spec files
+			if ext := filepath.Ext(path); ext != ".json" && ext != ".yaml" {
+				return nil
+			}
+
+			if err != nil {
+				return scanFn(path, priority, nil, err)
+			}
+
+			spec, err = ReadSpec(path, priority)
+			return scanFn(path, priority, spec, err)
+		})
+
+		if err != nil && err != ErrStopScan {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/cdi/spec.go
+++ b/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/cdi/spec.go
@@ -1,0 +1,352 @@
+/*
+   Copyright © 2021 The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cdi
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	oci "github.com/opencontainers/runtime-spec/specs-go"
+	"sigs.k8s.io/yaml"
+
+	"tags.cncf.io/container-device-interface/internal/validation"
+	cdi "tags.cncf.io/container-device-interface/specs-go"
+)
+
+const (
+	// defaultSpecExt is the file extension for the default encoding.
+	defaultSpecExt = ".yaml"
+)
+
+var (
+	// Externally set CDI Spec validation function.
+	specValidator func(*cdi.Spec) error
+	validatorLock sync.RWMutex
+)
+
+// Spec represents a single CDI Spec. It is usually loaded from a
+// file and stored in a cache. The Spec has an associated priority.
+// This priority is inherited from the associated priority of the
+// CDI Spec directory that contains the CDI Spec file and is used
+// to resolve conflicts if multiple CDI Spec files contain entries
+// for the same fully qualified device.
+type Spec struct {
+	*cdi.Spec
+	vendor   string
+	class    string
+	path     string
+	priority int
+	devices  map[string]*Device
+}
+
+// ReadSpec reads the given CDI Spec file. The resulting Spec is
+// assigned the given priority. If reading or parsing the Spec
+// data fails ReadSpec returns a nil Spec and an error.
+func ReadSpec(path string, priority int) (*Spec, error) {
+	data, err := ioutil.ReadFile(path)
+	switch {
+	case os.IsNotExist(err):
+		return nil, err
+	case err != nil:
+		return nil, fmt.Errorf("failed to read CDI Spec %q: %w", path, err)
+	}
+
+	raw, err := ParseSpec(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse CDI Spec %q: %w", path, err)
+	}
+	if raw == nil {
+		return nil, fmt.Errorf("failed to parse CDI Spec %q, no Spec data", path)
+	}
+
+	spec, err := newSpec(raw, path, priority)
+	if err != nil {
+		return nil, err
+	}
+
+	return spec, nil
+}
+
+// newSpec creates a new Spec from the given CDI Spec data. The
+// Spec is marked as loaded from the given path with the given
+// priority. If Spec data validation fails newSpec returns a nil
+// Spec and an error.
+func newSpec(raw *cdi.Spec, path string, priority int) (*Spec, error) {
+	err := validateSpec(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	spec := &Spec{
+		Spec:     raw,
+		path:     filepath.Clean(path),
+		priority: priority,
+	}
+
+	if ext := filepath.Ext(spec.path); ext != ".yaml" && ext != ".json" {
+		spec.path += defaultSpecExt
+	}
+
+	spec.vendor, spec.class = ParseQualifier(spec.Kind)
+
+	if spec.devices, err = spec.validate(); err != nil {
+		return nil, fmt.Errorf("invalid CDI Spec: %w", err)
+	}
+
+	return spec, nil
+}
+
+// Write the CDI Spec to the file associated with it during instantiation
+// by newSpec() or ReadSpec().
+func (s *Spec) write(overwrite bool) error {
+	var (
+		data []byte
+		dir  string
+		tmp  *os.File
+		err  error
+	)
+
+	err = validateSpec(s.Spec)
+	if err != nil {
+		return err
+	}
+
+	if filepath.Ext(s.path) == ".yaml" {
+		data, err = yaml.Marshal(s.Spec)
+		data = append([]byte("---\n"), data...)
+	} else {
+		data, err = json.Marshal(s.Spec)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to marshal Spec file: %w", err)
+	}
+
+	dir = filepath.Dir(s.path)
+	err = os.MkdirAll(dir, 0o755)
+	if err != nil {
+		return fmt.Errorf("failed to create Spec dir: %w", err)
+	}
+
+	tmp, err = os.CreateTemp(dir, "spec.*.tmp")
+	if err != nil {
+		return fmt.Errorf("failed to create Spec file: %w", err)
+	}
+	_, err = tmp.Write(data)
+	tmp.Close()
+	if err != nil {
+		return fmt.Errorf("failed to write Spec file: %w", err)
+	}
+
+	err = renameIn(dir, filepath.Base(tmp.Name()), filepath.Base(s.path), overwrite)
+
+	if err != nil {
+		os.Remove(tmp.Name())
+		err = fmt.Errorf("failed to write Spec file: %w", err)
+	}
+
+	return err
+}
+
+// GetVendor returns the vendor of this Spec.
+func (s *Spec) GetVendor() string {
+	return s.vendor
+}
+
+// GetClass returns the device class of this Spec.
+func (s *Spec) GetClass() string {
+	return s.class
+}
+
+// GetDevice returns the device for the given unqualified name.
+func (s *Spec) GetDevice(name string) *Device {
+	return s.devices[name]
+}
+
+// GetPath returns the filesystem path of this Spec.
+func (s *Spec) GetPath() string {
+	return s.path
+}
+
+// GetPriority returns the priority of this Spec.
+func (s *Spec) GetPriority() int {
+	return s.priority
+}
+
+// ApplyEdits applies the Spec's global-scope container edits to an OCI Spec.
+func (s *Spec) ApplyEdits(ociSpec *oci.Spec) error {
+	return s.edits().Apply(ociSpec)
+}
+
+// edits returns the applicable global container edits for this spec.
+func (s *Spec) edits() *ContainerEdits {
+	return &ContainerEdits{&s.ContainerEdits}
+}
+
+// Validate the Spec.
+func (s *Spec) validate() (map[string]*Device, error) {
+	if err := validateVersion(s.Version); err != nil {
+		return nil, err
+	}
+
+	minVersion, err := MinimumRequiredVersion(s.Spec)
+	if err != nil {
+		return nil, fmt.Errorf("could not determine minimum required version: %v", err)
+	}
+	if newVersion(minVersion).IsGreaterThan(newVersion(s.Version)) {
+		return nil, fmt.Errorf("the spec version must be at least v%v", minVersion)
+	}
+
+	if err := ValidateVendorName(s.vendor); err != nil {
+		return nil, err
+	}
+	if err := ValidateClassName(s.class); err != nil {
+		return nil, err
+	}
+	if err := validation.ValidateSpecAnnotations(s.Kind, s.Annotations); err != nil {
+		return nil, err
+	}
+	if err := s.edits().Validate(); err != nil {
+		return nil, err
+	}
+
+	devices := make(map[string]*Device)
+	for _, d := range s.Devices {
+		dev, err := newDevice(s, d)
+		if err != nil {
+			return nil, fmt.Errorf("failed add device %q: %w", d.Name, err)
+		}
+		if _, conflict := devices[d.Name]; conflict {
+			return nil, fmt.Errorf("invalid spec, multiple device %q", d.Name)
+		}
+		devices[d.Name] = dev
+	}
+
+	return devices, nil
+}
+
+// validateVersion checks whether the specified spec version is supported.
+func validateVersion(version string) error {
+	if !validSpecVersions.isValidVersion(version) {
+		return fmt.Errorf("invalid version %q", version)
+	}
+
+	return nil
+}
+
+// ParseSpec parses CDI Spec data into a raw CDI Spec.
+func ParseSpec(data []byte) (*cdi.Spec, error) {
+	var raw *cdi.Spec
+	err := yaml.UnmarshalStrict(data, &raw)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal CDI Spec: %w", err)
+	}
+	return raw, nil
+}
+
+// SetSpecValidator sets a CDI Spec validator function. This function
+// is used for extra CDI Spec content validation whenever a Spec file
+// loaded (using ReadSpec() or written (using WriteSpec()).
+func SetSpecValidator(fn func(*cdi.Spec) error) {
+	validatorLock.Lock()
+	defer validatorLock.Unlock()
+	specValidator = fn
+}
+
+// validateSpec validates the Spec using the extneral validator.
+func validateSpec(raw *cdi.Spec) error {
+	validatorLock.RLock()
+	defer validatorLock.RUnlock()
+
+	if specValidator == nil {
+		return nil
+	}
+	err := specValidator(raw)
+	if err != nil {
+		return fmt.Errorf("Spec validation failed: %w", err)
+	}
+	return nil
+}
+
+// GenerateSpecName generates a vendor+class scoped Spec file name. The
+// name can be passed to WriteSpec() to write a Spec file to the file
+// system.
+//
+// vendor and class should match the vendor and class of the CDI Spec.
+// The file name is generated without a ".json" or ".yaml" extension.
+// The caller can append the desired extension to choose a particular
+// encoding. Otherwise WriteSpec() will use its default encoding.
+//
+// This function always returns the same name for the same vendor/class
+// combination. Therefore it cannot be used as such to generate multiple
+// Spec file names for a single vendor and class.
+func GenerateSpecName(vendor, class string) string {
+	return vendor + "-" + class
+}
+
+// GenerateTransientSpecName generates a vendor+class scoped transient
+// Spec file name. The name can be passed to WriteSpec() to write a Spec
+// file to the file system.
+//
+// Transient Specs are those whose lifecycle is tied to that of some
+// external entity, for instance a container. vendor and class should
+// match the vendor and class of the CDI Spec. transientID should be
+// unique among all CDI users on the same host that might generate
+// transient Spec files using the same vendor/class combination. If
+// the external entity to which the lifecycle of the transient Spec
+// is tied to has a unique ID of its own, then this is usually a
+// good choice for transientID.
+//
+// The file name is generated without a ".json" or ".yaml" extension.
+// The caller can append the desired extension to choose a particular
+// encoding. Otherwise WriteSpec() will use its default encoding.
+func GenerateTransientSpecName(vendor, class, transientID string) string {
+	transientID = strings.ReplaceAll(transientID, "/", "_")
+	return GenerateSpecName(vendor, class) + "_" + transientID
+}
+
+// GenerateNameForSpec generates a name for the given Spec using
+// GenerateSpecName with the vendor and class taken from the Spec.
+// On success it returns the generated name and a nil error. If
+// the Spec does not contain a valid vendor or class, it returns
+// an empty name and a non-nil error.
+func GenerateNameForSpec(raw *cdi.Spec) (string, error) {
+	vendor, class := ParseQualifier(raw.Kind)
+	if vendor == "" {
+		return "", fmt.Errorf("invalid vendor/class %q in Spec", raw.Kind)
+	}
+
+	return GenerateSpecName(vendor, class), nil
+}
+
+// GenerateNameForTransientSpec generates a name for the given transient
+// Spec using GenerateTransientSpecName with the vendor and class taken
+// from the Spec. On success it returns the generated name and a nil error.
+// If the Spec does not contain a valid vendor or class, it returns an
+// an empty name and a non-nil error.
+func GenerateNameForTransientSpec(raw *cdi.Spec, transientID string) (string, error) {
+	vendor, class := ParseQualifier(raw.Kind)
+	if vendor == "" {
+		return "", fmt.Errorf("invalid vendor/class %q in Spec", raw.Kind)
+	}
+
+	return GenerateTransientSpecName(vendor, class, transientID), nil
+}

--- a/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/cdi/spec_linux.go
+++ b/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/cdi/spec_linux.go
@@ -1,0 +1,48 @@
+/*
+   Copyright © 2022 The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cdi
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// Rename src to dst, both relative to the directory dir. If dst already exists
+// refuse renaming with an error unless overwrite is explicitly asked for.
+func renameIn(dir, src, dst string, overwrite bool) error {
+	var flags uint
+
+	dirf, err := os.Open(dir)
+	if err != nil {
+		return fmt.Errorf("rename failed: %w", err)
+	}
+	defer dirf.Close()
+
+	if !overwrite {
+		flags = unix.RENAME_NOREPLACE
+	}
+
+	dirFd := int(dirf.Fd())
+	err = unix.Renameat2(dirFd, src, dirFd, dst, flags)
+	if err != nil {
+		return fmt.Errorf("rename failed: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/cdi/spec_other.go
+++ b/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/cdi/spec_other.go
@@ -1,0 +1,39 @@
+//go:build !linux
+// +build !linux
+
+/*
+   Copyright © 2022 The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cdi
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Rename src to dst, both relative to the directory dir. If dst already exists
+// refuse renaming with an error unless overwrite is explicitly asked for.
+func renameIn(dir, src, dst string, overwrite bool) error {
+	src = filepath.Join(dir, src)
+	dst = filepath.Join(dir, dst)
+
+	_, err := os.Stat(dst)
+	if err == nil && !overwrite {
+		return os.ErrExist
+	}
+
+	return os.Rename(src, dst)
+}

--- a/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/cdi/version.go
+++ b/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/cdi/version.go
@@ -1,0 +1,188 @@
+/*
+   Copyright © The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cdi
+
+import (
+	"strings"
+
+	"golang.org/x/mod/semver"
+
+	"tags.cncf.io/container-device-interface/pkg/parser"
+	cdi "tags.cncf.io/container-device-interface/specs-go"
+)
+
+const (
+	// CurrentVersion is the current version of the CDI Spec.
+	CurrentVersion = cdi.CurrentVersion
+
+	// vCurrent is the current version as a semver-comparable type
+	vCurrent version = "v" + CurrentVersion
+
+	// These represent the released versions of the CDI specification
+	v010 version = "v0.1.0"
+	v020 version = "v0.2.0"
+	v030 version = "v0.3.0"
+	v040 version = "v0.4.0"
+	v050 version = "v0.5.0"
+	v060 version = "v0.6.0"
+
+	// vEarliest is the earliest supported version of the CDI specification
+	vEarliest version = v030
+)
+
+// validSpecVersions stores a map of spec versions to functions to check the required versions.
+// Adding new fields / spec versions requires that a `requiredFunc` be implemented and
+// this map be updated.
+var validSpecVersions = requiredVersionMap{
+	v010: nil,
+	v020: nil,
+	v030: nil,
+	v040: requiresV040,
+	v050: requiresV050,
+	v060: requiresV060,
+}
+
+// MinimumRequiredVersion determines the minimum spec version for the input spec.
+func MinimumRequiredVersion(spec *cdi.Spec) (string, error) {
+	minVersion := validSpecVersions.requiredVersion(spec)
+	return minVersion.String(), nil
+}
+
+// version represents a semantic version string
+type version string
+
+// newVersion creates a version that can be used for semantic version comparisons.
+func newVersion(v string) version {
+	return version("v" + strings.TrimPrefix(v, "v"))
+}
+
+// String returns the string representation of the version.
+// This trims a leading v if present.
+func (v version) String() string {
+	return strings.TrimPrefix(string(v), "v")
+}
+
+// IsGreaterThan checks with a version is greater than the specified version.
+func (v version) IsGreaterThan(o version) bool {
+	return semver.Compare(string(v), string(o)) > 0
+}
+
+// IsLatest checks whether the version is the latest supported version
+func (v version) IsLatest() bool {
+	return v == vCurrent
+}
+
+type requiredFunc func(*cdi.Spec) bool
+
+type requiredVersionMap map[version]requiredFunc
+
+// isValidVersion checks whether the specified version is valid.
+// A version is valid if it is contained in the required version map.
+func (r requiredVersionMap) isValidVersion(specVersion string) bool {
+	_, ok := validSpecVersions[newVersion(specVersion)]
+
+	return ok
+}
+
+// requiredVersion returns the minimum version required for the given spec
+func (r requiredVersionMap) requiredVersion(spec *cdi.Spec) version {
+	minVersion := vEarliest
+
+	for v, isRequired := range validSpecVersions {
+		if isRequired == nil {
+			continue
+		}
+		if isRequired(spec) && v.IsGreaterThan(minVersion) {
+			minVersion = v
+		}
+		// If we have already detected the latest version then no later version could be detected
+		if minVersion.IsLatest() {
+			break
+		}
+	}
+
+	return minVersion
+}
+
+// requiresV060 returns true if the spec uses v0.6.0 features
+func requiresV060(spec *cdi.Spec) bool {
+	// The v0.6.0 spec allows annotations to be specified at a spec level
+	for range spec.Annotations {
+		return true
+	}
+
+	// The v0.6.0 spec allows annotations to be specified at a device level
+	for _, d := range spec.Devices {
+		for range d.Annotations {
+			return true
+		}
+	}
+
+	// The v0.6.0 spec allows dots "." in Kind name label (class)
+	vendor, class := parser.ParseQualifier(spec.Kind)
+	if vendor != "" {
+		if strings.ContainsRune(class, '.') {
+			return true
+		}
+	}
+
+	return false
+}
+
+// requiresV050 returns true if the spec uses v0.5.0 features
+func requiresV050(spec *cdi.Spec) bool {
+	var edits []*cdi.ContainerEdits
+
+	for _, d := range spec.Devices {
+		// The v0.5.0 spec allowed device names to start with a digit instead of requiring a letter
+		if len(d.Name) > 0 && !parser.IsLetter(rune(d.Name[0])) {
+			return true
+		}
+		edits = append(edits, &d.ContainerEdits)
+	}
+
+	edits = append(edits, &spec.ContainerEdits)
+	for _, e := range edits {
+		for _, dn := range e.DeviceNodes {
+			// The HostPath field was added in v0.5.0
+			if dn.HostPath != "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// requiresV040 returns true if the spec uses v0.4.0 features
+func requiresV040(spec *cdi.Spec) bool {
+	var edits []*cdi.ContainerEdits
+
+	for _, d := range spec.Devices {
+		edits = append(edits, &d.ContainerEdits)
+	}
+
+	edits = append(edits, &spec.ContainerEdits)
+	for _, e := range edits {
+		for _, m := range e.Mounts {
+			// The Type field was added in v0.4.0
+			if m.Type != "" {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/parser/parser.go
+++ b/pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/parser/parser.go
@@ -1,0 +1,212 @@
+/*
+   Copyright © The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package parser
+
+import (
+	"fmt"
+	"strings"
+)
+
+// QualifiedName returns the qualified name for a device.
+// The syntax for a qualified device names is
+//
+//	"<vendor>/<class>=<name>".
+//
+// A valid vendor and class name may contain the following runes:
+//
+//	'A'-'Z', 'a'-'z', '0'-'9', '.', '-', '_'.
+//
+// A valid device name may contain the following runes:
+//
+//	'A'-'Z', 'a'-'z', '0'-'9', '-', '_', '.', ':'
+func QualifiedName(vendor, class, name string) string {
+	return vendor + "/" + class + "=" + name
+}
+
+// IsQualifiedName tests if a device name is qualified.
+func IsQualifiedName(device string) bool {
+	_, _, _, err := ParseQualifiedName(device)
+	return err == nil
+}
+
+// ParseQualifiedName splits a qualified name into device vendor, class,
+// and name. If the device fails to parse as a qualified name, or if any
+// of the split components fail to pass syntax validation, vendor and
+// class are returned as empty, together with the verbatim input as the
+// name and an error describing the reason for failure.
+func ParseQualifiedName(device string) (string, string, string, error) {
+	vendor, class, name := ParseDevice(device)
+
+	if vendor == "" {
+		return "", "", device, fmt.Errorf("unqualified device %q, missing vendor", device)
+	}
+	if class == "" {
+		return "", "", device, fmt.Errorf("unqualified device %q, missing class", device)
+	}
+	if name == "" {
+		return "", "", device, fmt.Errorf("unqualified device %q, missing device name", device)
+	}
+
+	if err := ValidateVendorName(vendor); err != nil {
+		return "", "", device, fmt.Errorf("invalid device %q: %w", device, err)
+	}
+	if err := ValidateClassName(class); err != nil {
+		return "", "", device, fmt.Errorf("invalid device %q: %w", device, err)
+	}
+	if err := ValidateDeviceName(name); err != nil {
+		return "", "", device, fmt.Errorf("invalid device %q: %w", device, err)
+	}
+
+	return vendor, class, name, nil
+}
+
+// ParseDevice tries to split a device name into vendor, class, and name.
+// If this fails, for instance in the case of unqualified device names,
+// ParseDevice returns an empty vendor and class together with name set
+// to the verbatim input.
+func ParseDevice(device string) (string, string, string) {
+	if device == "" || device[0] == '/' {
+		return "", "", device
+	}
+
+	parts := strings.SplitN(device, "=", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", device
+	}
+
+	name := parts[1]
+	vendor, class := ParseQualifier(parts[0])
+	if vendor == "" {
+		return "", "", device
+	}
+
+	return vendor, class, name
+}
+
+// ParseQualifier splits a device qualifier into vendor and class.
+// The syntax for a device qualifier is
+//
+//	"<vendor>/<class>"
+//
+// If parsing fails, an empty vendor and the class set to the
+// verbatim input is returned.
+func ParseQualifier(kind string) (string, string) {
+	parts := strings.SplitN(kind, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", kind
+	}
+	return parts[0], parts[1]
+}
+
+// ValidateVendorName checks the validity of a vendor name.
+// A vendor name may contain the following ASCII characters:
+//   - upper- and lowercase letters ('A'-'Z', 'a'-'z')
+//   - digits ('0'-'9')
+//   - underscore, dash, and dot ('_', '-', and '.')
+func ValidateVendorName(vendor string) error {
+	err := validateVendorOrClassName(vendor)
+	if err != nil {
+		err = fmt.Errorf("invalid vendor. %w", err)
+	}
+	return err
+}
+
+// ValidateClassName checks the validity of class name.
+// A class name may contain the following ASCII characters:
+//   - upper- and lowercase letters ('A'-'Z', 'a'-'z')
+//   - digits ('0'-'9')
+//   - underscore, dash, and dot ('_', '-', and '.')
+func ValidateClassName(class string) error {
+	err := validateVendorOrClassName(class)
+	if err != nil {
+		err = fmt.Errorf("invalid class. %w", err)
+	}
+	return err
+}
+
+// validateVendorOrClassName checks the validity of vendor or class name.
+// A name may contain the following ASCII characters:
+//   - upper- and lowercase letters ('A'-'Z', 'a'-'z')
+//   - digits ('0'-'9')
+//   - underscore, dash, and dot ('_', '-', and '.')
+func validateVendorOrClassName(name string) error {
+	if name == "" {
+		return fmt.Errorf("empty name")
+	}
+	if !IsLetter(rune(name[0])) {
+		return fmt.Errorf("%q, should start with letter", name)
+	}
+	for _, c := range string(name[1 : len(name)-1]) {
+		switch {
+		case IsAlphaNumeric(c):
+		case c == '_' || c == '-' || c == '.':
+		default:
+			return fmt.Errorf("invalid character '%c' in name %q",
+				c, name)
+		}
+	}
+	if !IsAlphaNumeric(rune(name[len(name)-1])) {
+		return fmt.Errorf("%q, should end with a letter or digit", name)
+	}
+
+	return nil
+}
+
+// ValidateDeviceName checks the validity of a device name.
+// A device name may contain the following ASCII characters:
+//   - upper- and lowercase letters ('A'-'Z', 'a'-'z')
+//   - digits ('0'-'9')
+//   - underscore, dash, dot, colon ('_', '-', '.', ':')
+func ValidateDeviceName(name string) error {
+	if name == "" {
+		return fmt.Errorf("invalid (empty) device name")
+	}
+	if !IsAlphaNumeric(rune(name[0])) {
+		return fmt.Errorf("invalid class %q, should start with a letter or digit", name)
+	}
+	if len(name) == 1 {
+		return nil
+	}
+	for _, c := range string(name[1 : len(name)-1]) {
+		switch {
+		case IsAlphaNumeric(c):
+		case c == '_' || c == '-' || c == '.' || c == ':':
+		default:
+			return fmt.Errorf("invalid character '%c' in device name %q",
+				c, name)
+		}
+	}
+	if !IsAlphaNumeric(rune(name[len(name)-1])) {
+		return fmt.Errorf("invalid name %q, should end with a letter or digit", name)
+	}
+	return nil
+}
+
+// IsLetter reports whether the rune is a letter.
+func IsLetter(c rune) bool {
+	return ('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z')
+}
+
+// IsDigit reports whether the rune is a digit.
+func IsDigit(c rune) bool {
+	return '0' <= c && c <= '9'
+}
+
+// IsAlphaNumeric reports whether the rune is a letter or digit.
+func IsAlphaNumeric(c rune) bool {
+	return IsLetter(c) || IsDigit(c)
+}

--- a/pkg/pillar/vendor/tags.cncf.io/container-device-interface/specs-go/LICENSE
+++ b/pkg/pillar/vendor/tags.cncf.io/container-device-interface/specs-go/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkg/pillar/vendor/tags.cncf.io/container-device-interface/specs-go/config.go
+++ b/pkg/pillar/vendor/tags.cncf.io/container-device-interface/specs-go/config.go
@@ -1,0 +1,62 @@
+package specs
+
+import "os"
+
+// CurrentVersion is the current version of the Spec.
+const CurrentVersion = "0.6.0"
+
+// Spec is the base configuration for CDI
+type Spec struct {
+	Version string `json:"cdiVersion"`
+	Kind    string `json:"kind"`
+	// Annotations add meta information per CDI spec. Note these are CDI-specific and do not affect container metadata.
+	Annotations    map[string]string `json:"annotations,omitempty"`
+	Devices        []Device          `json:"devices"`
+	ContainerEdits ContainerEdits    `json:"containerEdits,omitempty"`
+}
+
+// Device is a "Device" a container runtime can add to a container
+type Device struct {
+	Name string `json:"name"`
+	// Annotations add meta information per device. Note these are CDI-specific and do not affect container metadata.
+	Annotations    map[string]string `json:"annotations,omitempty"`
+	ContainerEdits ContainerEdits    `json:"containerEdits"`
+}
+
+// ContainerEdits are edits a container runtime must make to the OCI spec to expose the device.
+type ContainerEdits struct {
+	Env         []string      `json:"env,omitempty"`
+	DeviceNodes []*DeviceNode `json:"deviceNodes,omitempty"`
+	Hooks       []*Hook       `json:"hooks,omitempty"`
+	Mounts      []*Mount      `json:"mounts,omitempty"`
+}
+
+// DeviceNode represents a device node that needs to be added to the OCI spec.
+type DeviceNode struct {
+	Path        string       `json:"path"`
+	HostPath    string       `json:"hostPath,omitempty"`
+	Type        string       `json:"type,omitempty"`
+	Major       int64        `json:"major,omitempty"`
+	Minor       int64        `json:"minor,omitempty"`
+	FileMode    *os.FileMode `json:"fileMode,omitempty"`
+	Permissions string       `json:"permissions,omitempty"`
+	UID         *uint32      `json:"uid,omitempty"`
+	GID         *uint32      `json:"gid,omitempty"`
+}
+
+// Mount represents a mount that needs to be added to the OCI spec.
+type Mount struct {
+	HostPath      string   `json:"hostPath"`
+	ContainerPath string   `json:"containerPath"`
+	Options       []string `json:"options,omitempty"`
+	Type          string   `json:"type,omitempty"`
+}
+
+// Hook represents a hook that needs to be added to the OCI spec.
+type Hook struct {
+	HookName string   `json:"hookName"`
+	Path     string   `json:"path"`
+	Args     []string `json:"args,omitempty"`
+	Env      []string `json:"env,omitempty"`
+	Timeout  *int     `json:"timeout,omitempty"`
+}

--- a/pkg/pillar/vendor/tags.cncf.io/container-device-interface/specs-go/oci.go
+++ b/pkg/pillar/vendor/tags.cncf.io/container-device-interface/specs-go/oci.go
@@ -1,0 +1,38 @@
+package specs
+
+import (
+	spec "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// ToOCI returns the opencontainers runtime Spec Hook for this Hook.
+func (h *Hook) ToOCI() spec.Hook {
+	return spec.Hook{
+		Path:    h.Path,
+		Args:    h.Args,
+		Env:     h.Env,
+		Timeout: h.Timeout,
+	}
+}
+
+// ToOCI returns the opencontainers runtime Spec Mount for this Mount.
+func (m *Mount) ToOCI() spec.Mount {
+	return spec.Mount{
+		Source:      m.HostPath,
+		Destination: m.ContainerPath,
+		Options:     m.Options,
+		Type:        m.Type,
+	}
+}
+
+// ToOCI returns the opencontainers runtime Spec LinuxDevice for this DeviceNode.
+func (d *DeviceNode) ToOCI() spec.LinuxDevice {
+	return spec.LinuxDevice{
+		Path:     d.Path,
+		Type:     d.Type,
+		Major:    d.Major,
+		Minor:    d.Minor,
+		FileMode: d.FileMode,
+		UID:      d.UID,
+		GID:      d.GID,
+	}
+}


### PR DESCRIPTION
The Container Device Interface (CDI) is already available on containerd and that are CDI files provided for NVIDIA platform that describes GPU devices for native container access. This commit introduces the support for CDI on pillar, so Video I/O adapters can pass a CDI device name to enable the direct access on native containers.

The corresponding documentation is also provided.
