### PR TITLE
bpftrace-compiler: add cache, loading kernel modules, fixes

### DIFF
--- a/eve-tools/bpftrace-compiler/.gitignore
+++ b/eve-tools/bpftrace-compiler/.gitignore
@@ -1,1 +1,2 @@
 bpftrace-compiler
+kernel-commits.mk

--- a/eve-tools/bpftrace-compiler/Dockerfile
+++ b/eve-tools/bpftrace-compiler/Dockerfile
@@ -1,0 +1,17 @@
+# Copyright (c) 2024 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+FROM alpine:3.20
+
+# hadolint ignore=DL3018
+RUN apk add --no-cache qemu-system-x86_64 qemu-system-aarch64 go make git docker
+
+COPY init_docker_tests.sh /init_docker_tests.sh
+RUN chmod u+x /init_docker_tests.sh
+
+RUN mkdir /src
+COPY kernel-commits.mk /
+
+WORKDIR /src
+
+ENTRYPOINT ["/init_docker_tests.sh"]

--- a/eve-tools/bpftrace-compiler/Makefile
+++ b/eve-tools/bpftrace-compiler/Makefile
@@ -4,7 +4,15 @@
 bpftrace-compiler: *.go
 	go build
 
-.PHONY: test
+.PHONY: test bare-test docker-test
 
-test:
-	go test -test.timeout 30m -v -race .
+bare-test:
+	go test -test.timeout 1h -v -race .
+
+test: bare-test
+
+kernel-commits.mk: ../../kernel-commits.mk
+	cp ../../kernel-commits.mk .
+
+docker-test: kernel-commits.mk
+	docker run --cap-add=SYS_PTRACE --cap-add=SYS_ADMIN --privileged --security-opt seccomp=unconfined -v $(shell pwd):/src $(shell docker build -q .) make bare-test

--- a/eve-tools/bpftrace-compiler/cmdRun.go
+++ b/eve-tools/bpftrace-compiler/cmdRun.go
@@ -104,12 +104,7 @@ func compile(arch string, lkConf lkConf, uc userspaceContainer, kernelModules []
 	defer os.RemoveAll(imageDir)
 	createImage(arch, lkConf, uc, imageDir)
 
-	var qr *qemuRunner
-	if arch == "arm64" {
-		qr = newQemuArm64Runner(imageDir, bpfFile, outputFile)
-	} else if arch == "amd64" {
-		qr = newQemuAmd64Runner(imageDir, bpfFile, outputFile)
-	}
+	qr := newQemuRunner(arch, imageDir, bpfFile, outputFile)
 
 	qr.withLoadKernelModule(kernelModules)
 

--- a/eve-tools/bpftrace-compiler/cmdRun.go
+++ b/eve-tools/bpftrace-compiler/cmdRun.go
@@ -49,6 +49,7 @@ func (r *run) run(bpfFile string, uc userspaceContainer, kernelModules []string,
 }
 
 func compileWithCache(arch string, lkConf lkConf, uc userspaceContainer, kernelModules []string, bpfFile string, outputFile string) error {
+	var err error
 	if bpftraceCompilerDir == "" {
 		return compile(arch, lkConf, uc, kernelModules, bpfFile, outputFile)
 	}

--- a/eve-tools/bpftrace-compiler/cmdRun.go
+++ b/eve-tools/bpftrace-compiler/cmdRun.go
@@ -50,7 +50,7 @@ func compile(arch string, lkConf lkConf, uc userspaceContainer, bpfFile string, 
 	arch = cleanArch(arch)
 	imageDir, err := os.MkdirTemp("/var/tmp", "bpftrace-image")
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("creating image dir %s failed: %v", imageDir, err)
 	}
 	defer os.RemoveAll(imageDir)
 	createImage(arch, lkConf, uc, imageDir)

--- a/eve-tools/bpftrace-compiler/compile_test.go
+++ b/eve-tools/bpftrace-compiler/compile_test.go
@@ -36,7 +36,7 @@ func testCompile(t *testing.T, arch, eveKernel string) {
 	defer aotFh.Close()
 	defer os.Remove(aotFilename)
 
-	err = compile(arch, lkConf{kernel: eveKernel}, nil, btFilename, aotFilename)
+	err = compile(arch, lkConf{kernel: eveKernel}, nil, []string{}, btFilename, aotFilename)
 	if err != nil {
 		t.Fatalf("compiling failed: %v", err)
 	}

--- a/eve-tools/bpftrace-compiler/edgeview.go
+++ b/eve-tools/bpftrace-compiler/edgeview.go
@@ -132,8 +132,9 @@ func (er *edgeviewRun) stopHTTPDebugPort() {
 func (er *edgeviewRun) forwardHTTPDebugPort() error {
 	var err error
 
+	hostForward := "localhost:6543"
 	er.ctx, er.cancel = context.WithTimeout(context.Background(), 5*time.Minute)
-	er.cmd = exec.CommandContext(er.ctx, "bash", er.path, "tcp/127.0.0.1:6543")
+	er.cmd = exec.CommandContext(er.ctx, "bash", er.path, fmt.Sprintf("tcp/%s", hostForward))
 
 	er.tty, err = pty.Start(er.cmd)
 	if err != nil {
@@ -150,7 +151,7 @@ func (er *edgeviewRun) forwardHTTPDebugPort() error {
 			line := scanner.Text()
 			output += line + "\n"
 
-			if strings.Contains(line, "127.0.0.1:6543") {
+			if strings.Contains(line, hostForward) {
 				forwardLine = strings.TrimFunc(line, func(r rune) bool {
 					return !unicode.IsGraphic(r)
 				})

--- a/eve-tools/bpftrace-compiler/go.mod
+++ b/eve-tools/bpftrace-compiler/go.mod
@@ -1,6 +1,6 @@
 module bpftrace-compiler
 
-go 1.22.5
+go 1.21
 
 require (
 	github.com/creack/pty v1.1.18

--- a/eve-tools/bpftrace-compiler/go.mod
+++ b/eve-tools/bpftrace-compiler/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0
 	golang.org/x/crypto v0.21.0
+	golang.org/x/mod v0.14.0
 	gopkg.in/yaml.v2 v2.4.0
 )
 
@@ -85,7 +86,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.21.0 // indirect
 	go.opentelemetry.io/otel/trace v1.21.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
-	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/sync v0.6.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect

--- a/eve-tools/bpftrace-compiler/httpRun.go
+++ b/eve-tools/bpftrace-compiler/httpRun.go
@@ -139,11 +139,11 @@ func (hr *httpRun) runBpftrace(aotFile string, timeout time.Duration) error {
 
 	err = <-errChan
 	if err != nil {
-		log.Fatalf("received err: %v", err)
+		log.Fatalf("received error from http: %v", err)
 	}
 	err = multipartWriter.Close()
 	if err != nil && !strings.Contains(err.Error(), "io: read/write on closed pipe") {
-		log.Fatalf("closing multipart writer failed: %v %T", err, err)
+		log.Fatalf("closing multipart writer failed: %v", err)
 	}
 
 	return nil

--- a/eve-tools/bpftrace-compiler/httpRun.go
+++ b/eve-tools/bpftrace-compiler/httpRun.go
@@ -127,6 +127,7 @@ func (hr *httpRun) runBpftrace(aotFile string, timeout time.Duration) error {
 	if err != nil {
 		log.Fatalf("received response %v with error %v", resp, err)
 	}
+	defer resp.Body.Close()
 	log.Printf("http multiform resp is %+v\n", resp)
 
 	scanner := bufio.NewScanner(resp.Body)

--- a/eve-tools/bpftrace-compiler/init_docker_tests.sh
+++ b/eve-tools/bpftrace-compiler/init_docker_tests.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Copyright (c) 2024 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+mkdir -p /sys/fs/cgroup/init
+echo 1 > /sys/fs/cgroup/init/cgroup.procs
+echo +cpu > /sys/fs/cgroup/cgroup.subtree_control
+
+/usr/bin/dockerd -l fatal &
+exec "$@"

--- a/eve-tools/bpftrace-compiler/list_test.go
+++ b/eve-tools/bpftrace-compiler/list_test.go
@@ -10,7 +10,12 @@ import (
 	"testing"
 )
 
-func testList(arch string, kernel string, t *testing.T, expectedTracepoint string) {
+type eveKernelWithArch struct {
+	image string
+	arch  string
+}
+
+func testList(arch string, kernel string, t *testing.T, kernelModules []string, expectedTracepoint string) {
 	imageDir, err := os.MkdirTemp("/var/tmp", "bpftrace-image")
 	if err != nil {
 		panic(err)
@@ -24,6 +29,7 @@ func testList(arch string, kernel string, t *testing.T, expectedTracepoint strin
 	} else if arch == "arm64" {
 		qr = newQemuArm64Runner(imageDir, "", "")
 	}
+	qr.withLoadKernelModule(kernelModules)
 
 	output, err := qr.runList("")
 	if err != nil {
@@ -35,36 +41,54 @@ func testList(arch string, kernel string, t *testing.T, expectedTracepoint strin
 	}
 }
 
-func TestListKernelProbesAmd64(t *testing.T) {
-	_, err := exec.LookPath("/usr/bin/qemu-system-x86_64")
-	if err != nil {
-		t.Skipf("no qemu for amd64 installed, skipping this test")
-		return
-	}
+func skip(t *testing.T) bool {
 	if testing.Short() {
 		t.Skip("Test takes too long")
+		return true
+	}
+
+	for _, qemuBin := range []string{"qemu-system-x86_64", "qemu-system-aarch64"} {
+		_, err := exec.LookPath(qemuBin)
+		if err != nil {
+			t.Skipf("%s cannot be found, skipping", qemuBin)
+			return true
+		}
+	}
+
+	return false
+}
+
+func TestListKernelProbesAmd64(t *testing.T) {
+	if skip(t) {
 		return
 	}
 	kernel := "docker.io/lfedge/eve-kernel:eve-kernel-amd64-v6.1.38-generic-fb31ce85306c-gcc"
 	arch := "amd64"
 	expectedTracepoint := "tracepoint:syscalls:sys_enter_ptrace"
 
-	testList(arch, kernel, t, expectedTracepoint)
+	testList(arch, kernel, t, []string{}, expectedTracepoint)
 }
 
 func TestListKernelProbesArm64(t *testing.T) {
-	_, err := exec.LookPath("/usr/bin/qemu-system-aarch64")
-	if err != nil {
-		t.Skipf("no qemu for aarch64 installed, skipping this test")
-		return
-	}
-	if testing.Short() {
-		t.Skip("Test takes too long")
+	if skip(t) {
 		return
 	}
 	kernel := "docker.io/lfedge/eve-kernel:eve-kernel-arm64-v6.1.38-generic-394a3bcff39d-gcc"
 	arch := "arm64"
 	expectedTracepoint := "tracepoint:syscalls:sys_enter_ptrace"
 
-	testList(arch, kernel, t, expectedTracepoint)
+	testList(arch, kernel, t, []string{}, expectedTracepoint)
+}
+
+func TestListKernelProbesAmd64WithModules(t *testing.T) {
+	if skip(t) {
+		return
+	}
+
+	kernel := "docker.io/lfedge/eve-kernel:eve-kernel-amd64-v6.1.38-generic-fb31ce85306c-gcc"
+	kernelModules := []string{"dm_crypt", "zfs"}
+	arch := "amd64"
+	expectedTracepoint := "kprobe:zfs_open"
+
+	testList(arch, kernel, t, kernelModules, expectedTracepoint)
 }

--- a/eve-tools/bpftrace-compiler/list_test.go
+++ b/eve-tools/bpftrace-compiler/list_test.go
@@ -23,12 +23,7 @@ func testList(arch string, kernel string, t *testing.T, kernelModules []string, 
 	defer os.RemoveAll(imageDir)
 	createImage(arch, lkConf{kernel: kernel}, nil, imageDir)
 
-	var qr *qemuRunner
-	if arch == "amd64" {
-		qr = newQemuAmd64Runner(imageDir, "", "")
-	} else if arch == "arm64" {
-		qr = newQemuArm64Runner(imageDir, "", "")
-	}
+	qr := newQemuRunner(arch, imageDir, "", "")
 	qr.withLoadKernelModule(kernelModules)
 
 	output, err := qr.runList("")

--- a/eve-tools/bpftrace-compiler/main.go
+++ b/eve-tools/bpftrace-compiler/main.go
@@ -54,18 +54,11 @@ func init() {
 	if err == nil {
 		bpftraceCompilerDir = filepath.Join(homedir, ".bpftrace-compiler")
 	}
+
 }
 
 func main() {
 	var err error
-	var sshKey string
-	var timeout time.Duration
-	var userspaceContainerDebugFlag *[]string
-	var userspaceContainerListFlag *[]string
-	var userspaceContainerHTTPFlag *[]string
-	var userspaceContainerEVFlag *[]string
-	var userspaceContainerSSHFlag *[]string
-	var kernelModulesDebugFlag *[]string
 
 	defer shutdown()
 
@@ -82,7 +75,7 @@ func main() {
 		Short:      "compile only",
 		Example:    fmt.Sprintf("%s compile amd64 docker.io/lfedge/eve-kernel:eve-kernel-amd64-v6.1.38-generic-fb31ce85306c-gcc examples/opensnoop.bt opensnoop.aot", execName),
 		Args:       cobra.ExactArgs(4),
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			lkConf := lkConf{
 				kernel: args[1],
 			}
@@ -93,72 +86,142 @@ func main() {
 		},
 	}
 
-	runSSHCmd := &cobra.Command{
-		Use:        "run-via-ssh <host:port> <bpftrace script>",
-		Aliases:    []string{"rs", "run-ssh"},
-		SuggestFor: []string{},
-		Short:      "run bpftrace script on host via ssh",
-		Example:    fmt.Sprintf("%s run-via-ssh 127.1:2222 examples/opensnoop.bt", execName),
-		Args:       cobra.ExactArgs(2),
-		Run: func(cmd *cobra.Command, args []string) {
-			var uc userspaceContainer
-			if len(*userspaceContainerSSHFlag) == 2 {
-				switch (*userspaceContainerSSHFlag)[0] {
-				case "onboot":
-					uc = onbootContainer((*userspaceContainerSSHFlag)[1])
-				case "service":
-					uc = serviceContainer((*userspaceContainerSSHFlag)[1])
-				}
+	runSSHCmd := newRunSSHCmd()
+
+	runHTTPCmd := newRunHTTPCmd()
+
+	runEdgeviewCmd := newEdgeviewCmd()
+
+	debugShellCmd := newDebugShellCmd()
+
+	listCmd := newListCmd()
+
+	cacheCmd := &cobra.Command{
+		Use:     "cache - manage bpftrace-compiler cache",
+		Aliases: []string{"c"},
+	}
+
+	cacheEnableCmd := &cobra.Command{
+		Use:     "enable - enable cache",
+		Aliases: []string{"e"},
+		Short:   fmt.Sprintf("creates a cache directory under %s/.bpftrace-compiler", bpftraceCompilerDir),
+		Args:    cobra.NoArgs,
+		Run: func(_ *cobra.Command, _ []string) {
+			cacheDir := filepath.Join(bpftraceCompilerDir, "cache")
+			err := os.MkdirAll(cacheDir, 0700)
+			if err != nil {
+				log.Fatalf("could not create cache dir %s: %v", cacheDir, err)
 			}
-			sr, err := newSSHRun(args[0], sshKey)
+		},
+	}
+	cacheDisableCmd := &cobra.Command{
+		Use:     "disable - disable and purge cache",
+		Aliases: []string{"e"},
+		Short:   fmt.Sprintf("deletes the cache directory under %s/.bpftrace-compiler", bpftraceCompilerDir),
+		Long:    "if bpftrace-compiler cannot find a cache directory, no cache will be used",
+		Args:    cobra.NoArgs,
+		Run: func(_ *cobra.Command, _ []string) {
+			cacheDir := filepath.Join(bpftraceCompilerDir, "cache")
+			err := os.RemoveAll(cacheDir)
+			if err != nil {
+				log.Fatalf("could not remove cache dir %s: %v", cacheDir, err)
+			}
+		},
+	}
+	cacheCmd.AddCommand(cacheEnableCmd, cacheDisableCmd)
+
+	rootCmd.AddCommand(compileCmd, runSSHCmd, runHTTPCmd, runEdgeviewCmd, listCmd, debugShellCmd)
+	if bpftraceCompilerDir != "" {
+		rootCmd.AddCommand(cacheCmd)
+	}
+
+	err = rootCmd.Execute()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+type flags struct {
+	timeout                      time.Duration
+	userspaceContainerFlag       *[]string
+	userspaceContainerVersioning bool
+	kernelModulesFlag            *[]string
+}
+
+func (f *flags) setFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().DurationVarP(&f.timeout, "timeout", "t", 10*time.Second, "")
+	if f.userspaceContainerVersioning {
+		f.userspaceContainerFlag = cmd.PersistentFlags().StringSliceP("userspace", "u", []string{}, "onboot|service,name,image")
+	} else {
+		f.userspaceContainerFlag = cmd.PersistentFlags().StringSliceP("userspace", "u", []string{}, "onboot|service,name")
+	}
+	f.kernelModulesFlag = cmd.PersistentFlags().StringSliceP("kernel-modules", "k", []string{}, "dm_crypt")
+}
+
+func newListCmd() *cobra.Command {
+	f := flags{
+		timeout:                      0,
+		userspaceContainerFlag:       &[]string{},
+		userspaceContainerVersioning: true,
+		kernelModulesFlag:            &[]string{},
+	}
+	cmd := &cobra.Command{
+		Use:     "list-probes <arm64|amd64> <eve kernel docker image> <binary path|>",
+		Aliases: []string{"l", "list"},
+		Args:    cobra.RangeArgs(2, 3),
+		Run: func(_ *cobra.Command, args []string) {
+			arch, lkConf, uc := interpretDebugCmdArgs(args, f.userspaceContainerFlag)
+
+			imageDir, err := os.MkdirTemp("/var/tmp", "bpftrace-image")
 			if err != nil {
 				log.Fatal(err)
 			}
-			sr.run(args[1], uc, []string{}, timeout)
-			defers = append(defers, func() { sr.end() })
-		},
-	}
+			defer os.RemoveAll(imageDir)
+			createImage(arch, lkConf, uc, imageDir)
 
-	runHTTPCmd := &cobra.Command{
-		Use:        "run-via-http <host:port> <bpftrace script>",
-		Aliases:    []string{"rh", "run-http"},
-		SuggestFor: []string{},
-		Short:      "run bpftrace script on host via http debug",
-		Example:    fmt.Sprintf("%s run-via-http 127.1:6543 examples/opensnoop.bt", execName),
-		Args:       cobra.ExactArgs(2),
-		Run: func(cmd *cobra.Command, args []string) {
-			var uc userspaceContainer
-			if len(*userspaceContainerHTTPFlag) == 2 {
-				switch (*userspaceContainerHTTPFlag)[0] {
-				case "onboot":
-					uc = onbootContainer((*userspaceContainerHTTPFlag)[1])
-				case "service":
-					uc = serviceContainer((*userspaceContainerHTTPFlag)[1])
-				default:
-					log.Fatalf("unknown userspace container type %s", (*userspaceContainerHTTPFlag)[0])
-				}
+			qr := newQemuRunner(arch, imageDir)
+			qr.withLoadKernelModule(*f.kernelModulesFlag)
+
+			listArg := ""
+			if len(args) == 3 {
+				listArg = args[2]
 			}
-			hr := newHTTPRun(args[0])
-			hr.run(args[1], uc, []string{}, timeout)
-			defers = append(defers, func() { hr.end() })
+			output, err := qr.runList(listArg)
+			if err != nil {
+				fmt.Println(err)
+			}
+
+			fmt.Printf("%s", string(output))
 		},
 	}
+	f.setFlags(cmd)
 
-	runEdgeviewCmd := &cobra.Command{
+	return cmd
+}
+
+func newEdgeviewCmd() *cobra.Command {
+	f := flags{
+		timeout:                      0,
+		userspaceContainerFlag:       &[]string{},
+		userspaceContainerVersioning: false,
+		kernelModulesFlag:            &[]string{},
+	}
+
+	cmd := &cobra.Command{
 		Use:        "run-via-edgeview <path to edgeview script> <bpftrace script>",
 		Aliases:    []string{"re", "run-edgeview", "run-ev"},
 		SuggestFor: []string{},
 		Short:      "run bpftrace script on host via edgeview",
 		Example:    fmt.Sprintf("%s re ~/Downloads/run.\\*.sh examples/undump.bt", execName),
 		Args:       cobra.ExactArgs(2),
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			var uc userspaceContainer
-			if len(*userspaceContainerEVFlag) == 2 {
-				switch (*userspaceContainerEVFlag)[0] {
+			if len(*f.userspaceContainerFlag) == 2 {
+				switch (*f.userspaceContainerFlag)[0] {
 				case "onboot":
-					uc = onbootContainer((*userspaceContainerEVFlag)[1])
+					uc = onbootContainer((*f.userspaceContainerFlag)[1])
 				case "service":
-					uc = serviceContainer((*userspaceContainerEVFlag)[1])
+					uc = serviceContainer((*f.userspaceContainerFlag)[1])
 				}
 			}
 			ev := edgeviewRun{}
@@ -182,17 +245,28 @@ func main() {
 
 			hr := newHTTPRun(fmt.Sprintf("localhost:%d", port))
 			defers = append(defers, func() { hr.end(); ev.shutdown() })
-			hr.run(args[1], uc, []string{}, timeout)
+			hr.run(args[1], uc, *f.kernelModulesFlag, f.timeout)
 		},
 	}
+	f.setFlags(cmd)
 
-	debugShellCmd := &cobra.Command{
+	return cmd
+}
+
+func newDebugShellCmd() *cobra.Command {
+	f := flags{
+		timeout:                      0,
+		userspaceContainerFlag:       &[]string{},
+		userspaceContainerVersioning: true,
+		kernelModulesFlag:            &[]string{},
+	}
+	cmd := &cobra.Command{
 		Use:  "debug <arm64|amd64> <eve kernel docker image> <folder>",
 		Args: cobra.ExactArgs(3),
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			shareFolder := args[2]
 
-			arch, lkConf, uc := interpretDebugCmdArgs(args, userspaceContainerDebugFlag)
+			arch, lkConf, uc := interpretDebugCmdArgs(args, f.userspaceContainerFlag)
 
 			imageDir, err := os.MkdirTemp("/var/tmp", "bpftrace-image")
 			if err != nil {
@@ -209,8 +283,8 @@ func main() {
 			}
 			qr.timeout = 0
 
-			if kernelModulesDebugFlag != nil && len(*kernelModulesDebugFlag) > 0 {
-				qr.withLoadKernelModule(*kernelModulesDebugFlag)
+			if f.kernelModulesFlag != nil && len(*f.kernelModulesFlag) > 0 {
+				qr.withLoadKernelModule(*f.kernelModulesFlag)
 			}
 
 			err = qr.runDebug(shareFolder)
@@ -219,97 +293,87 @@ func main() {
 			}
 		},
 	}
-	listCmd := &cobra.Command{
-		Use:     "list-probes <arm64|amd64> <eve kernel docker image> <binary path|>",
-		Aliases: []string{"l", "list"},
-		Args:    cobra.RangeArgs(2, 3),
-		Run: func(cmd *cobra.Command, args []string) {
-			arch, lkConf, uc := interpretDebugCmdArgs(args, userspaceContainerListFlag)
+	f.setFlags(cmd)
 
-			imageDir, err := os.MkdirTemp("/var/tmp", "bpftrace-image")
+	return cmd
+}
+
+func newRunHTTPCmd() *cobra.Command {
+	f := flags{
+		timeout:                      0,
+		userspaceContainerFlag:       &[]string{},
+		userspaceContainerVersioning: false,
+		kernelModulesFlag:            &[]string{},
+	}
+
+	cmd := &cobra.Command{
+		Use:        "run-via-http <host:port> <bpftrace script>",
+		Aliases:    []string{"rh", "run-http"},
+		SuggestFor: []string{},
+		Short:      "run bpftrace script on host via http debug",
+		Example:    fmt.Sprintf("%s run-via-http 127.1:6543 examples/opensnoop.bt", execName),
+		Args:       cobra.ExactArgs(2),
+		Run: func(_ *cobra.Command, args []string) {
+			var uc userspaceContainer
+			if len(*f.userspaceContainerFlag) == 2 {
+				switch (*f.userspaceContainerFlag)[0] {
+				case "onboot":
+					uc = onbootContainer((*f.userspaceContainerFlag)[1])
+				case "service":
+					uc = serviceContainer((*f.userspaceContainerFlag)[1])
+				default:
+					log.Fatalf("unknown userspace container type %s", (*f.userspaceContainerFlag)[0])
+				}
+			}
+			hr := newHTTPRun(args[0])
+			hr.run(args[1], uc, *f.kernelModulesFlag, f.timeout)
+			hr.end()
+		},
+	}
+	f.setFlags(cmd)
+
+	return cmd
+}
+
+func newRunSSHCmd() *cobra.Command {
+	f := flags{
+		timeout:                      0,
+		userspaceContainerFlag:       &[]string{},
+		userspaceContainerVersioning: false,
+		kernelModulesFlag:            &[]string{},
+	}
+	var sshKey string
+	cmd := &cobra.Command{
+		Use:        "run-via-ssh <host:port> <bpftrace script>",
+		Aliases:    []string{"rs", "run-ssh"},
+		SuggestFor: []string{},
+		Short:      "run bpftrace script on host via ssh",
+		Example:    fmt.Sprintf("%s run-via-ssh 127.1:2222 examples/opensnoop.bt", execName),
+		Args:       cobra.ExactArgs(2),
+		Run: func(_ *cobra.Command, args []string) {
+			var uc userspaceContainer
+			if len(*f.userspaceContainerFlag) == 2 {
+				switch (*f.userspaceContainerFlag)[0] {
+				case "onboot":
+					uc = onbootContainer((*f.userspaceContainerFlag)[1])
+				case "service":
+					uc = serviceContainer((*f.userspaceContainerFlag)[1])
+				default:
+					log.Fatalf("unknown userspace container type %s", (*f.userspaceContainerFlag)[0])
+				}
+			}
+			sr, err := newSSHRun(args[0], sshKey)
 			if err != nil {
 				log.Fatal(err)
 			}
-			defer os.RemoveAll(imageDir)
-			createImage(arch, lkConf, uc, imageDir)
-
-			var qr *qemuRunner
-			if arch == "arm64" {
-				qr = newQemuArm64Runner(imageDir, "", "")
-			} else if arch == "amd64" {
-				qr = newQemuAmd64Runner(imageDir, "", "")
-			}
-
-			listArg := ""
-			if len(args) == 3 {
-				listArg = args[2]
-			}
-			output, err := qr.runList(listArg)
-			if err != nil {
-				fmt.Println(err)
-			}
-
-			fmt.Printf("%s", string(output))
+			sr.run(args[1], uc, []string{}, f.timeout)
+			sr.end()
 		},
 	}
+	cmd.PersistentFlags().StringVarP(&sshKey, "identity-file", "i", "", "")
+	f.setFlags(cmd)
 
-	cacheCmd := &cobra.Command{
-		Use:     "cache - manage bpftrace-compiler cache",
-		Aliases: []string{"c"},
-	}
-
-	cacheEnableCmd := &cobra.Command{
-		Use:     "enable - enable cache",
-		Aliases: []string{"e"},
-		Short:   fmt.Sprintf("creates a cache directory under %s/.bpftrace-compiler", bpftraceCompilerDir),
-		Args:    cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			cacheDir := filepath.Join(bpftraceCompilerDir, "cache")
-			err := os.MkdirAll(cacheDir, 0700)
-			if err != nil {
-				log.Fatalf("could not create cache dir %s: %v", cacheDir, err)
-			}
-		},
-	}
-	cacheDisableCmd := &cobra.Command{
-		Use:     "disable - disable and purge cache",
-		Aliases: []string{"e"},
-		Short:   fmt.Sprintf("deletes the cache directory under %s/.bpftrace-compiler", bpftraceCompilerDir),
-		Long:    "if bpftrace-compiler cannot find a cache directory, no cache will be used",
-		Args:    cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			cacheDir := filepath.Join(bpftraceCompilerDir, "cache")
-			err := os.RemoveAll(cacheDir)
-			if err != nil {
-				log.Fatalf("could not remove cache dir %s: %v", cacheDir, err)
-			}
-		},
-	}
-	cacheCmd.AddCommand(cacheEnableCmd, cacheDisableCmd)
-
-	runSSHCmd.PersistentFlags().StringVarP(&sshKey, "identity-file", "i", "", "")
-	runSSHCmd.PersistentFlags().DurationVarP(&timeout, "timeout", "t", 10*time.Second, "")
-
-	runHTTPCmd.PersistentFlags().DurationVarP(&timeout, "timeout", "t", 10*time.Second, "")
-	userspaceContainerHTTPFlag = runHTTPCmd.PersistentFlags().StringSliceP("userspace", "u", []string{}, "onboot|service,name")
-	userspaceContainerEVFlag = runEdgeviewCmd.PersistentFlags().StringSliceP("userspace", "u", []string{}, "onboot|service,name")
-	userspaceContainerSSHFlag = runSSHCmd.PersistentFlags().StringSliceP("userspace", "u", []string{}, "onboot|service,name")
-
-	kernelModulesDebugFlag = debugShellCmd.PersistentFlags().StringSliceP("kernel-modules", "k", []string{}, "dm_crypt")
-
-	userspaceContainerDebugFlag = debugShellCmd.PersistentFlags().StringSliceP("userspace", "u", []string{}, "onboot|service,name,image")
-
-	userspaceContainerListFlag = listCmd.PersistentFlags().StringSliceP("userspace", "u", []string{}, "onboot|service,name,image")
-
-	rootCmd.AddCommand(compileCmd, runSSHCmd, runHTTPCmd, runEdgeviewCmd, listCmd, debugShellCmd)
-	if bpftraceCompilerDir != "" {
-		rootCmd.AddCommand(cacheCmd)
-	}
-
-	err = rootCmd.Execute()
-	if err != nil {
-		log.Fatal(err)
-	}
+	return cmd
 }
 
 func interpretDebugCmdArgs(args []string, ucFlag *[]string) (string, lkConf, userspaceContainer) {
@@ -343,4 +407,17 @@ func interpretDebugCmdArgs(args []string, ucFlag *[]string) (string, lkConf, use
 		}
 	}
 	return arch, lkConf, uc
+}
+
+func newQemuRunner(arch string, imageDir string) *qemuRunner {
+	var qr *qemuRunner
+	switch arch {
+	case "arm64":
+		qr = newQemuArm64Runner(imageDir, "", "")
+	case "amd64":
+		qr = newQemuAmd64Runner(imageDir, "", "")
+	default:
+		log.Fatalf("unknown architecture %s", arch)
+	}
+	return qr
 }

--- a/eve-tools/bpftrace-compiler/main.go
+++ b/eve-tools/bpftrace-compiler/main.go
@@ -241,6 +241,7 @@ func newEdgeviewCmd() *cobra.Command {
 					time.Sleep(time.Second)
 					continue
 				}
+				break
 			}
 
 			hr := newHTTPRun(fmt.Sprintf("localhost:%d", port))

--- a/eve-tools/bpftrace-compiler/main.go
+++ b/eve-tools/bpftrace-compiler/main.go
@@ -179,7 +179,7 @@ func newListCmd() *cobra.Command {
 			defer os.RemoveAll(imageDir)
 			createImage(arch, lkConf, uc, imageDir)
 
-			qr := newQemuRunner(arch, imageDir)
+			qr := newQemuRunner(arch, imageDir, "", "")
 			qr.withLoadKernelModule(*f.kernelModulesFlag)
 
 			listArg := ""
@@ -275,12 +275,7 @@ func newDebugShellCmd() *cobra.Command {
 			defer os.RemoveAll(imageDir)
 			createImage(arch, lkConf, uc, imageDir)
 
-			var qr *qemuRunner
-			if arch == "arm64" {
-				qr = newQemuArm64Runner(imageDir, "", "")
-			} else if arch == "amd64" {
-				qr = newQemuAmd64Runner(imageDir, "", "")
-			}
+			qr := newQemuRunner(arch, imageDir, "", "")
 			qr.timeout = 0
 
 			if f.kernelModulesFlag != nil && len(*f.kernelModulesFlag) > 0 {
@@ -407,17 +402,4 @@ func interpretDebugCmdArgs(args []string, ucFlag *[]string) (string, lkConf, use
 		}
 	}
 	return arch, lkConf, uc
-}
-
-func newQemuRunner(arch string, imageDir string) *qemuRunner {
-	var qr *qemuRunner
-	switch arch {
-	case "arm64":
-		qr = newQemuArm64Runner(imageDir, "", "")
-	case "amd64":
-		qr = newQemuAmd64Runner(imageDir, "", "")
-	default:
-		log.Fatalf("unknown architecture %s", arch)
-	}
-	return qr
 }

--- a/eve-tools/bpftrace-compiler/main.go
+++ b/eve-tools/bpftrace-compiler/main.go
@@ -110,6 +110,8 @@ func main() {
 					uc = onbootContainer((*userspaceContainerHTTPFlag)[1])
 				case "service":
 					uc = serviceContainer((*userspaceContainerHTTPFlag)[1])
+				default:
+					log.Fatalf("unknown userspace container type %s", (*userspaceContainerHTTPFlag)[0])
 				}
 			}
 			hr := newHTTPRun(args[0])
@@ -240,14 +242,13 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-
 }
 
 func interpretDebugCmdArgs(args []string, ucFlag *[]string) (string, lkConf, userspaceContainer) {
 	var uc userspaceContainer
 
 	if len(*ucFlag) != 0 && len(*ucFlag) != 3 {
-		panic("wrong userspace flag usage")
+		log.Fatal("wrong userspace flag usage")
 	}
 
 	arch := cleanArch(args[0])
@@ -269,6 +270,8 @@ func interpretDebugCmdArgs(args []string, ucFlag *[]string) (string, lkConf, use
 			lkConf.services = map[string]string{
 				(*ucFlag)[1]: (*ucFlag)[2],
 			}
+		default:
+			log.Fatalf("unknown userspace container type %s", (*ucFlag)[0])
 		}
 	}
 	return arch, lkConf, uc

--- a/eve-tools/bpftrace-compiler/pkgbuild.go
+++ b/eve-tools/bpftrace-compiler/pkgbuild.go
@@ -48,11 +48,11 @@ func createImage(arch string, lc lkConf, uc userspaceContainer, outputDir string
 	ib.userspace = uc
 	err = ib.buildPkgs([]string{"root"})
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("building pkgs 'root' failed: %v", err)
 	}
 	err = ib.buildImg()
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("building image failed: %v", err)
 	}
 
 	ib.cleanup()

--- a/eve-tools/bpftrace-compiler/root/bpftrace-helper/bpftrace-helper.go
+++ b/eve-tools/bpftrace-compiler/root/bpftrace-helper/bpftrace-helper.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"github.com/pmorjan/kmod"
 	"io/fs"
 	"log"
 	"os"
@@ -192,6 +193,14 @@ func main() {
 		if unit == "list" {
 			bpftraceListKernelUnit()
 		}
+		if strings.HasPrefix(unit, "insmod=") {
+			split := strings.SplitN(unit, "=", 2)
+			if len(split) != 2 {
+				log.Printf("could not parse %s", unit)
+				break
+			}
+			bpftraceLoadKernelModule(split[1])
+		}
 		if strings.HasPrefix(unit, "list@") {
 			split := strings.SplitN(unit, "@", 2)
 			if len(split) != 2 {
@@ -297,4 +306,18 @@ func bpftraceCompileUnit() {
 		log.Printf("Rename failed: %+v\nbpftrace output was: %s\nStderr: %s\n", err, cmdStdoutBuf.String(), cmdStderrBuf.String())
 	}
 
+}
+
+func bpftraceLoadKernelModule(module string) {
+	k, err := kmod.New()
+	if err != nil {
+		log.Printf("could not create kernel module loader: %v", err)
+		return
+	}
+
+	err = k.Load(module, "", 0)
+	if err != nil {
+		log.Printf("could not load '%s' kernel module: %v", module, err)
+		return
+	}
 }

--- a/eve-tools/bpftrace-compiler/root/bpftrace-helper/go.mod
+++ b/eve-tools/bpftrace-compiler/root/bpftrace-helper/go.mod
@@ -3,6 +3,8 @@ module bpftrace-helper
 go 1.22
 
 require (
+	github.com/pmorjan/kmod v1.1.1
 	golang.org/x/sync v0.7.0
-	golang.org/x/sys v0.21.0
 )
+
+require golang.org/x/sys v0.21.0 // indirect

--- a/eve-tools/bpftrace-compiler/root/bpftrace-helper/go.sum
+++ b/eve-tools/bpftrace-compiler/root/bpftrace-helper/go.sum
@@ -1,3 +1,5 @@
+github.com/pmorjan/kmod v1.1.1 h1:Vfw6bMaOg/sYSBCqJPT9TbqHHf5zK00GbaL5JQLO4r0=
+github.com/pmorjan/kmod v1.1.1/go.mod h1:jR4fVosEpQ6b5U0rpxaqoShTDPvCjLIP8vEESZyvnqQ=
 golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
 golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=

--- a/eve-tools/bpftrace-compiler/runQemu.go
+++ b/eve-tools/bpftrace-compiler/runQemu.go
@@ -114,6 +114,12 @@ func (q *qemuRunner) runList(listArg string) ([]byte, error) {
 	return stdout, err
 }
 
+func (q *qemuRunner) withLoadKernelModule(modules []string) {
+	for _, mod := range modules {
+		q.units = append(q.units, fmt.Sprintf("insmod=%s", mod))
+	}
+}
+
 func (q *qemuRunner) run() ([]byte, error) {
 	shareDir, err := os.MkdirTemp("/var/tmp", "bpftrace-9pshare")
 	if err != nil {

--- a/eve-tools/bpftrace-compiler/ssh-client.go
+++ b/eve-tools/bpftrace-compiler/ssh-client.go
@@ -34,9 +34,7 @@ func (s *eveSSHClient) startSftpClientWithCustomPath(path string) error {
 		return err
 	}
 
-	var b bytes.Buffer
-	sshCommand := "/usr/libexec/sftp-server"
-	s.sftpClientSession.Stdout = &b
+	sshCommand := path
 	rStdout, wStdout := io.Pipe()
 	rStdin, wStdin := io.Pipe()
 

--- a/eve-tools/bpftrace-compiler/ssh-client.go
+++ b/eve-tools/bpftrace-compiler/ssh-client.go
@@ -89,8 +89,7 @@ func (s *eveSSHClient) startSSHClient(sshHost string, privKey string) {
 		panic("$HOME not set")
 	}
 
-	authPrivKeys := []ssh.AuthMethod{}
-
+	signers := []ssh.Signer{}
 	addPrivKey := func(privKeyPath string) {
 		key, err := os.ReadFile(privKeyPath)
 		if errors.Is(err, os.ErrNotExist) {
@@ -105,7 +104,7 @@ func (s *eveSSHClient) startSSHClient(sshHost string, privKey string) {
 			log.Fatalf("unable to parse private key: %v", err)
 		}
 
-		authPrivKeys = append(authPrivKeys, ssh.PublicKeys(signer))
+		signers = append(signers, signer)
 
 	}
 
@@ -130,7 +129,7 @@ func (s *eveSSHClient) startSSHClient(sshHost string, privKey string) {
 	}
 	config := &ssh.ClientConfig{
 		User: "root",
-		Auth: authPrivKeys,
+		Auth: []ssh.AuthMethod{ssh.PublicKeys(signers...)},
 		HostKeyCallback: func(hostname string, remote net.Addr, key ssh.PublicKey) error {
 			err := hostKeyCallback(hostname, remote, key)
 			if err != nil {

--- a/eve-tools/bpftrace-compiler/util.go
+++ b/eve-tools/bpftrace-compiler/util.go
@@ -42,7 +42,7 @@ func linuxkitYml2KernelConf(ymlBytes []byte) lkConf {
 	var y lkConfYaml
 	err := yaml.Unmarshal(ymlBytes, &y)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("unmarshalling from yaml failed: %v", err)
 	}
 
 	l := lkConf{

--- a/eve-tools/bpftrace-compiler/util.go
+++ b/eve-tools/bpftrace-compiler/util.go
@@ -24,6 +24,10 @@ type lkConf struct {
 	services map[string]string // name -> image
 }
 
+func (l lkConf) String() string {
+	return fmt.Sprintf("kernel: %s onboot: %+q services: %+q", l.kernel, l.onboot, l.services)
+}
+
 type lkConfYaml struct {
 	Kernel struct {
 		Image string `yaml:"image"`

--- a/eve-tools/bpftrace-compiler/util.go
+++ b/eve-tools/bpftrace-compiler/util.go
@@ -157,3 +157,16 @@ func waitForKeyFromStdin(timeout time.Duration) bool {
 		return false
 	}
 }
+
+func newQemuRunner(arch string, imageDir string, bpfFile, outputFile string) *qemuRunner {
+	var qr *qemuRunner
+	switch arch {
+	case "arm64":
+		qr = newQemuArm64Runner(imageDir, bpfFile, outputFile)
+	case "amd64":
+		qr = newQemuAmd64Runner(imageDir, bpfFile, outputFile)
+	default:
+		log.Fatalf("unknown architecture %s", arch)
+	}
+	return qr
+}


### PR DESCRIPTION
* 7e8649eaf config
*  don't use 127.1 forwarding
*  connect faster
*  ensure current kernel works
*  run tests in docker
*  factory method for qemu runner
*  generalize cobra cmds
*  cleanup ssh/sftp client
*  fix ssh auth
*  introduce caching
*  enable loading kernel modules
*  improve error handling
*  fix go.mod