### PR TITLE
installer: Find persist partition when installing into another disk

### DIFF
--- a/pkg/installer/install
+++ b/pkg/installer/install
@@ -477,7 +477,7 @@ if [ "$INSTALL_ZFS" = true ]; then
       done
   fi
 else
-  P3="$(find_part P3 "$INSTALL_DEV")"
+  P3="$(find_part P3 "$INSTALL_PERSIST")"
   [ -z "$P3" ] && bail "Installation failed. Cannot found P3. Entering shell..."
   # attempt to zero the first and last 5Mb of the P3 (to get rid of any residual prior data)
   dd if=/dev/zero of="/dev/$P3" bs=512 count=10240 2>/dev/null
@@ -486,7 +486,7 @@ else
   mkfs -t ext4 -v -F -F -O encrypt "/dev/$P3"
   mkdir -p /persist
   # now the disk is ready - mount partitions
-  mount_part P3 "$INSTALL_DEV" /persist 2>/dev/null
+  mount_part P3 "$INSTALL_PERSIST" /persist 2>/dev/null
 fi
 
 


### PR DESCRIPTION
## Description

When installing persist into another storage device, the installer script must search for the persist partition in the corresponding destination and not in the main storage device.

## How to test

First, build the installer raw image (to create all needed files):

```sh
$ make installer-raw
$ make run-installer-raw # it doesn't need to run QEMU, that's only for build OVMF files
```

After that, create an additional disk image file for the persist and call qemu accordingly:

```sh
qemu-img create -f qcow2 ${EVE_REPO}/dist/amd64/current/target.img 32768M
qemu-img create -f qcow2 ${EVE_REPO}/dist/amd64/current/persist.img 32768M
qemu-system-x86_64 \
	-drive file=${EVE_REPO}/dist/amd64/current/installer.raw,format=raw \
	-drive file=${EVE_REPO}/dist/amd64/current/target.img,format=qcow2 \
	-drive file=${EVE_REPO}/dist/amd64/current/persist.img,format=qcow2 \
	-m 4096 -smp 4 -display none \
	-drive if=pflash,format=raw,unit=0,readonly,file=${EVE_REPO}/dist/amd64/current/installer/firmware/OVMF_CODE.fd \
	-drive if=pflash,format=raw,unit=1,file=${EVE_REPO}/dist/amd64/current/installer/firmware/OVMF_VARS.fd \
	-serial mon:stdio -global ICH9-LPC.noreboot=false -watchdog-action reset -rtc base=utc,clock=rt \
	-netdev user,id=eth0,net=192.168.1.0/24,dhcpstart=192.168.1.10,hostfwd=tcp::2222-:22 \
	-device virtio-net-pci,netdev=eth0,romfile="" \
	-netdev user,id=eth1,net=192.168.2.0/24,dhcpstart=192.168.2.10 -device virtio-net-pci,netdev=eth1,romfile="" \
	-device nec-usb-xhci,id=xhci \
	-qmp unix:${EVE_REPO}/qmp.sock,server,wait=off \
	-machine q35,accel=kvm,usb=off,dump-guest-core=off \
	-cpu host,invtsc=on,kvmclock=off -machine kernel-irqchip=split \
	-device intel-iommu,intremap=on,caching-mode=on,aw-bits=48 -smbios type=1,serial=31415926  
```

After boot, the GRUB options can be added manually:

```sh
eve_install_disk=sdb eve_persist_disk=sdc
```