### PR TITLE
[0.9.4-stable] GitHub Actions Add buildondemand.yml action

### DIFF
--- a/.github/actions/run-make/action.yml
+++ b/.github/actions/run-make/action.yml
@@ -1,0 +1,57 @@
+---
+name: 'Run EVE make comand'
+description: 'Fetch tags, login to dockerhub, build and push artifacts produced by make command'
+
+inputs:
+  command:
+    required: true
+    type: string
+  dockerhub-token:
+    required: true
+    type: string
+  dockerhub-account:
+    required: true
+    type: string
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Force fetch annotated tags (workaround)
+      # Workaround for https://github.com/actions/checkout/issues/290
+      run: |
+        git fetch --force --tags
+      shell: bash
+    - name: Login to Docker Hub
+      if: ${{ github.event.repository.full_name }}== 'lf-edge/eve'
+      uses: docker/login-action@v3
+      with:
+        username: ${{ inputs.dockerhub-account }}
+        password: ${{ inputs.dockerhub-token }}
+    - name: Build and push `make -e ${{ inputs.command }}`
+      run: |
+        make -e ${{ inputs.command }}
+      shell: bash
+    - name: Post `make -e ${{ inputs.command }}` report
+      run: |
+        echo Disk usage
+        df -h
+        echo Memory
+        free -m
+        docker system df
+        docker system df -v
+      shell: bash
+    - name: Pre clean report
+      run: |
+        echo Disk usage
+        df -h
+        echo Memory
+        free -m
+        docker system df
+        docker system df -v
+      shell: bash
+    - name: Clean
+      run: |
+        make clean
+        docker system prune -f -a
+        rm -rf ~/.linuxkit
+      shell: bash

--- a/.github/workflows/buildondemand_094.yml
+++ b/.github/workflows/buildondemand_094.yml
@@ -1,0 +1,141 @@
+name: build and publish packages on demand 0.9.4
+on:
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Force build even if no changes'
+        type: boolean
+        required: false
+        default: false
+
+
+env:
+  FORCE_BUILD: FORCE_BUILD=${{ inputs.force && '--force' || '' }}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  packages:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: buildjet-4vcpu-ubuntu-2204-arm
+            arch: arm64
+          - os: buildjet-4vcpu-ubuntu-2004
+            arch: amd64
+          - os: buildjet-4vcpu-ubuntu-2004
+            arch: riscv64
+    steps:
+      - name: Starting Report
+        run: |
+          echo Git Ref: ${{ github.ref }}
+          echo GitHub Event: ${{ github.event_name }}
+          echo Disk usage
+          df -h
+          echo Memory
+          free -m
+      - name: Clear repository
+        run: |
+          sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
+          rm -fr ~/.linuxkit
+          docker system prune --all --force --volumes
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: ensure zstd for cache  # this should be removed once the arm64 VM includes zstd
+        if: ${{ matrix.os == 'buildjet-4vcpu-ubuntu-2204-arm' || matrix.os == 'arm64-secure' }}
+        run: |
+          sudo apt install -y zstd
+      - name: ensure packages for cross-arch build
+        if: ${{ matrix.arch == 'riscv64' }}
+        run: |
+          APT_INSTALL="sudo apt install -y binfmt-support qemu-user-static"
+          # the following weird statement is here to speed up the happy path
+          # if the default server is responding -- we can skip apt update
+          $APT_INSTALL || { sudo apt update && $APT_INSTALL ; }
+      - name: update linuxkit cache if available
+        uses: actions/cache@v4
+        with:
+          path: ~/.linuxkit/cache
+          key: linuxkit-${{ matrix.arch }}-${{ github.sha }}
+      - name: Build packages
+        uses: ./.github/actions/run-make
+        with:
+          command: "V=1 PRUNE=1 ZARCH=${{ matrix.arch }} LINUXKIT_PKG_TARGET=push $FORCE_BUILD pkgs"
+          dockerhub-token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+          dockerhub-account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
+      - name: Post package report
+        run: |
+          echo Disk usage
+          df -h
+          echo Memory
+          free -m
+          docker system df
+          docker system df -v
+
+  eve:
+    needs: packages  # all packages for all platforms must be built first
+    runs-on: buildjet-4vcpu-ubuntu-2004
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [arm64, amd64]
+        hv: [xen, kvm]
+        platform: ["generic"]
+        include:
+          - arch: riscv64
+            hv: mini
+            platform: "generic"
+          - arch: amd64
+            hv: kvm
+            platform: "rt"
+          - arch: arm64
+            hv: kvm
+            platform: "nvidia"
+          - arch: arm64
+            hv: kvm
+            platform: "imx8mp_pollux"
+          - arch: arm64
+            hv: kvm
+            platform: "imx8mp_epc_r3720"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: update linuxkit cache for our arch
+        id: cache_for_packages
+        if: ${{ matrix.arch != 'amd64' }}  # because our runner arch is amd64; if that changes, this will have to change
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.linuxkit/cache
+          key: linuxkit-${{ matrix.arch }}-${{ github.sha }}
+          fail-on-cache-miss: true
+
+      - uses: ./.github/actions/run-make
+        with:
+          command: "V=1 HV=${{ matrix.hv }} PLATFORM=${{ matrix.platform }} ZARCH=${{ matrix.arch }} LINUXKIT_PKG_TARGET=push $FORCE_BUILD eve"
+          dockerhub-token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+          dockerhub-account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
+      - uses: ./.github/actions/run-make
+        if: matrix.arch != 'riscv64'
+        with:
+          command: "V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} LINUXKIT_PKG_TARGET=push $FORCE_BUILD sbom collected_sources compare_sbom_collected_sources publish_sources"
+          dockerhub-token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+          dockerhub-account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
+
+  manifest:
+    runs-on: ubuntu-latest
+    needs: packages
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/run-make
+        with:
+          command: "V=1 LINUXKIT_PKG_TARGET=manifest pkgs"
+          dockerhub-token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+          dockerhub-account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}


### PR DESCRIPTION
Since danger.yml is no longer in master (i.e. default branch) so it won't be triggered from other old workflows. This workaround allows user to run build and publish manually