### PR TITLE
GitHub Actions: Switch to GitHub-hosted runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,9 @@ jobs:
         include:
           - os: buildjet-4vcpu-ubuntu-2204-arm
             arch: arm64
-          - os: buildjet-4vcpu-ubuntu-2004
+          - os: ubuntu-20.04
             arch: amd64
-          - os: buildjet-4vcpu-ubuntu-2004
+          - os: ubuntu-20.04
             arch: riscv64
     steps:
       - name: Starting Report
@@ -82,7 +82,7 @@ jobs:
 
   eve:
     needs: packages  # all packages for all platforms must be built first
-    runs-on: buildjet-4vcpu-ubuntu-2004
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/buildondemand.yml
+++ b/.github/workflows/buildondemand.yml
@@ -27,9 +27,9 @@ jobs:
         include:
           - os: buildjet-4vcpu-ubuntu-2204-arm
             arch: arm64
-          - os: buildjet-4vcpu-ubuntu-2004
+          - os: ubuntu-20.04
             arch: amd64
-          - os: buildjet-4vcpu-ubuntu-2004
+          - os: ubuntu-20.04
             arch: riscv64
     steps:
       - name: Starting Report
@@ -83,7 +83,7 @@ jobs:
     needs: packages  # all packages for all platforms must be built first
     # Only run for the default branch
     if: github.ref_name == github.event.repository.default_branch
-    runs-on: buildjet-4vcpu-ubuntu-2004
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Latest documentation on GitHub shows that their
runners have same resources as BuildJet. Why not
use free stuff?

https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories