### PR TITLE
[12.0-stable] mkimage-raw-efi: Find persist partition when installing into another disk

### DIFF
--- a/pkg/mkimage-raw-efi/install
+++ b/pkg/mkimage-raw-efi/install
@@ -419,7 +419,7 @@ if [ "$INSTALL_ZFS" = true ]; then
       done
   fi
 else
-  P3="$(find_part P3 "$INSTALL_DEV")"
+  P3="$(find_part P3 "$INSTALL_PERSIST")"
   [ -z "$P3" ] && bail "Installation failed. Cannot found P3. Entering shell..."
   # attempt to zero the first and last 5Mb of the P3 (to get rid of any residual prior data)
   dd if=/dev/zero of="/dev/$P3" bs=512 count=10240 2>/dev/null
@@ -428,7 +428,7 @@ else
   mkfs -t ext4 -v -F -F -O encrypt "/dev/$P3"
   mkdir -p /persist
   # now the disk is ready - mount partitions
-  mount_part P3 "$INSTALL_DEV" /persist 2>/dev/null
+  mount_part P3 "$INSTALL_PERSIST" /persist 2>/dev/null
 fi
 
 


### PR DESCRIPTION
Parent PR: https://github.com/lf-edge/eve/pull/4277

When installing persist into another storage device, the installer script must search for the persist partition (and mount it) in the corresponding destination and not in the main storage device. This can be achieved by simply looking to INSTALL_PERSIST variable instead of INSTALL_DEV.