### PR TITLE
[12.0 stable] Properly initialize AppNetworkStatus after invalid config was fixed

### DIFF
--- a/pkg/pillar/cmd/zedrouter/appnetwork.go
+++ b/pkg/pillar/cmd/zedrouter/appnetwork.go
@@ -404,3 +404,29 @@ func (z *zedrouter) doAppNetworkModifyAppIntfNum(appID uuid.UUID,
 	}
 	return nil
 }
+
+// For app already deployed (before node reboot), keep using the same MAC address
+// generator. Changing MAC addresses could break network config inside the app.
+func (z *zedrouter) selectMACGeneratorForApp(status *types.AppNetworkStatus) error {
+	appKey := types.UuidToNumKey{UUID: status.UUIDandVersion.UUID}
+	macGenerator, _, err := z.appMACGeneratorMap.Get(appKey)
+	if err != nil || macGenerator == types.MACGeneratorUnspecified {
+		// New app or an existing app but without MAC generator ID persisted.
+		if z.localLegacyMACAddr {
+			// Use older node-scoped MAC address generator.
+			macGenerator = types.MACGeneratorNodeScoped
+		} else {
+			// Use newer (and preferred) globally-scoped MAC address generator.
+			macGenerator = types.MACGeneratorGloballyScoped
+		}
+		// Remember which MAC generator is being used for this app.
+		err = z.appMACGeneratorMap.Assign(appKey, macGenerator, false)
+		if err != nil {
+			err = fmt.Errorf("failed to persist MAC generator ID for app %s/%s: %v",
+				status.UUIDandVersion.UUID, status.DisplayName, err)
+			return err
+		}
+	}
+	status.MACGenerator = macGenerator
+	return nil
+}


### PR DESCRIPTION
When the application network configuration fails validation, the AppNetworkStatus will be marked with an error, while the AppNum and MACGenerator fields will remain unset. If the user corrects the invalid part of the configuration, the handleAppNetworkModify callback will be triggered, and validation will succeed. However, before activating the application network, the zedrouter must ensure that AppNum and MACGenerator are initialized. Otherwise, the zedbox will panic with a fatal error: "undefined MAC generator."

Issue addressed by this patch was **introduced in version 11.5.0** (so **not backporting this to 11.0**)

Signed-off-by: Milan Lenco <milan@zededa.com>
(cherry picked from commit 3dc9624c758e2116d54dd6a4d719820a9a4cd2e5)