### PR TITLE
Enable QEMU for eve packages build step in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,6 +113,9 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
 
+      - name: Set up QEMU so cross-builds will work
+        uses: docker/setup-qemu-action@v3
+
       - name: Login to Docker Hub
         if: ${{ github.event.repository.full_name }}== 'lf-edge/eve'
         uses: docker/login-action@v3


### PR DESCRIPTION
When we call `make pkgs eve`, if a package is not available for an architecture other than the one it is running on, e.g. arm64 on an amd64 runner, the build can fail. Docker can handle emulation, but you need to enable it first. This adds enabling emulation.

This adds the standard GitHub Action to setup qemu to the `eve` job.