### PR TITLE
installer: Exclude RAM disks from verification

### DIFF
--- a/pkg/installer/verify
+++ b/pkg/installer/verify
@@ -9,7 +9,7 @@
 
 #storage device benchmarking
 mkdir "$REPORT/storage-performance/"
-for i in $(lsblk -anlb -o "TYPE,NAME,SIZE" | grep "^disk" | awk '$3 { print $2;}'); do
+for i in $(lsblk -anlb -o "TYPE,NAME,SIZE" | grep "^disk" | awk '$3 { print $2;}' | grep -v "^ram.*"); do
    echo  "Verifying disk /dev/$i"
    #if dd if="/dev/$i" of=/dev/null bs=512 count=34 >/dev/null 2>&1; then
    # echo "Read from device $i succeeded" >> "$REPORT/storage-check.log"


### PR DESCRIPTION
Exclude RAM disks from fio verification. Currently the installation (specially on arm devices) takes a long time checking ram disks:

```
Disk stats (read/write):
  ram3: ios=0/0, merge=0/0, ticks=0/0, in_queue=0, util=0.00%
+ echo 'Verifying disk /dev/ram4'
Verifying disk /dev/ram4
+ /usr/bin/fio '--filename=/dev/ram4' '--direct=1' '--rw=randread' '--bs=4k' '--ioengine=libaio' '--runtime=10' '--numjobs=4' --time_based '--name=test' '--filesize=10M'
+ cat /run/INVENTORY/32a8ad14-3e02-11ef-8111-db72c5e6f762/storage-performance/ram4.log
test: (g=0): rw=randread, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=1
...
fio-3.30
Starting 4 processes

test: (groupid=0, jobs=1): err= 0: pid=2624: Tue Sep 24 15:24:20 2024
  read: IOPS=3228, BW=12.6MiB/s (13.2MB/s)(126MiB/10001msec)
    slat (usec): min=78, max=2133, avg=177.41, stdev=69.56
    clat (usec): min=38, max=1002, avg=86.34, stdev=43.94
     lat (usec): min=122, max=2750, avg=276.00, stdev=97.77
    clat percentiles (usec):
     |  1.00th=[   44],  5.00th=[   56], 10.00th=[   69], 20.00th=[   73],
     | 30.00th=[   75], 40.00th=[   77], 50.00th=[   81], 60.00th=[   85],
     | 70.00th=[   90], 80.00th=[   93], 90.00th=[   97], 95.00th=[  112],
     | 99.00th=[  229], 99.50th=[  433], 99.90th=[  668], 99.95th=[  783],
     | 99.99th=[  955]
   bw (  KiB/s): min=10730, max=20742, per=25.39%, avg=12888.47, stdev=2231.56, samples=19
   iops        : min= 2682, max= 5185, avg=3221.89, stdev=557.82, samples=19
  lat (usec)   : 50=3.12%, 100=88.58%, 250=7.35%, 500=0.70%, 750=0.20%
  lat (usec)   : 1000=0.05%
  lat (msec)   : 2=0.01%
  cpu          : usr=51.80%, sys=48.07%, ctx=51, majf=0, minf=22
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwts: total=32292,0,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=1
test: (groupid=0, jobs=1): err= 0: pid=2625: Tue Sep 24 15:24:20 2024
  read: IOPS=3297, BW=12.9MiB/s (13.5MB/s)(129MiB/10002msec)
    slat (usec): min=76, max=4868, avg=171.95, stdev=101.09
    clat (usec): min=37, max=4123, avg=85.06, stdev=80.76
     lat (usec): min=120, max=5048, avg=269.22, stdev=138.15
    clat percentiles (usec):
     |  1.00th=[   48],  5.00th=[   67], 10.00th=[   70], 20.00th=[   73],
     | 30.00th=[   75], 40.00th=[   78], 50.00th=[   79], 60.00th=[   80],
     | 70.00th=[   82], 80.00th=[   85], 90.00th=[   93], 95.00th=[  106],
     | 99.00th=[  215], 99.50th=[  416], 99.90th=[  791], 99.95th=[ 1319],
     | 99.99th=[ 3589]
   bw (  KiB/s): min=11105, max=16495, per=26.04%, avg=13214.05, stdev=1213.81, samples=19
   iops        : min= 2776, max= 4123, avg=3303.21, stdev=303.48, samples=19
  lat (usec)   : 50=1.22%, 100=92.92%, 250=4.99%, 500=0.56%, 750=0.19%
  lat (usec)   : 1000=0.05%
  lat (msec)   : 2=0.02%, 4=0.04%, 10=0.01%
  cpu          : usr=51.03%, sys=47.46%, ctx=127, majf=0, minf=21
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwts: total=32977,0,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=1
test: (groupid=0, jobs=1): err= 0: pid=2626: Tue Sep 24 15:24:20 2024
  read: IOPS=3274, BW=12.8MiB/s (13.4MB/s)(128MiB/10001msec)
    slat (usec): min=81, max=2462, avg=173.87, stdev=72.00
    clat (usec): min=39, max=1474, avg=84.04, stdev=41.84
     lat (usec): min=127, max=3497, avg=270.18, stdev=99.09
    clat percentiles (usec):
     |  1.00th=[   47],  5.00th=[   59], 10.00th=[   69], 20.00th=[   73],
     | 30.00th=[   74], 40.00th=[   77], 50.00th=[   79], 60.00th=[   80],
     | 70.00th=[   83], 80.00th=[   87], 90.00th=[   94], 95.00th=[  120],
     | 99.00th=[  221], 99.50th=[  392], 99.90th=[  578], 99.95th=[  725],
     | 99.99th=[ 1156]
   bw (  KiB/s): min=11417, max=19376, per=25.77%, avg=13081.47, stdev=1813.13, samples=19
   iops        : min= 2854, max= 4844, avg=3270.16, stdev=453.29, samples=19
  lat (usec)   : 50=2.15%, 100=90.95%, 250=6.02%, 500=0.71%, 750=0.13%
  lat (usec)   : 1000=0.02%
  lat (msec)   : 2=0.02%
  cpu          : usr=51.81%, sys=48.09%, ctx=43, majf=0, minf=21
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwts: total=32749,0,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=1
test: (groupid=0, jobs=1): err= 0: pid=2627: Tue Sep 24 15:24:20 2024
  read: IOPS=2888, BW=11.3MiB/s (11.8MB/s)(113MiB/10002msec)
    slat (usec): min=77, max=10907, avg=196.98, stdev=187.36
    clat (usec): min=37, max=2725, avg=94.94, stdev=118.11
     lat (usec): min=121, max=11011, avg=306.16, stdev=234.48
    clat percentiles (usec):
     |  1.00th=[   44],  5.00th=[   56], 10.00th=[   69], 20.00th=[   73],
     | 30.00th=[   75], 40.00th=[   78], 50.00th=[   81], 60.00th=[   84],
     | 70.00th=[   86], 80.00th=[   89], 90.00th=[   97], 95.00th=[  135],
     | 99.00th=[  578], 99.50th=[ 1139], 99.90th=[ 1680], 99.95th=[ 1909],
     | 99.99th=[ 2540]
   bw (  KiB/s): min= 8088, max=19049, per=22.85%, avg=11597.74, stdev=2165.10, samples=19
   iops        : min= 2022, max= 4762, avg=2899.05, stdev=541.30, samples=19
  lat (usec)   : 50=3.16%, 100=88.61%, 250=6.56%, 500=0.55%, 750=0.25%
  lat (usec)   : 1000=0.22%
  lat (msec)   : 2=0.61%, 4=0.04%
  cpu          : usr=46.31%, sys=45.97%, ctx=927, majf=0, minf=21
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwts: total=28888,0,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=1

Run status group 0 (all jobs):
   READ: bw=49.6MiB/s (52.0MB/s), 11.3MiB/s-12.9MiB/s (11.8MB/s-13.5MB/s), io=496MiB (520MB), run=10001-10002msec

Disk stats (read/write):
  ram4: ios=0/0, merge=0/0, ticks=0/0, in_queue=0, util=0.00%
+ echo 'Verifying disk /dev/ram5'
Verifying disk /dev/ram5
+ /usr/bin/fio '--filename=/dev/ram5' '--direct=1' '--rw=randread' '--bs=4k' '--ioengine=libaio' '--runtime=10' '--numjobs=4' --time_based '--name=test' '--filesize=10M'

+ cat /run/INVENTORY/32a8ad14-3e02-11ef-8111-db72c5e6f762/storage-performance/ram5.log
test: (g=0): rw=randread, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=1
...
fio-3.30
Starting 4 processes

test: (groupid=0, jobs=1): err= 0: pid=2635: Tue Sep 24 15:24:31 2024
  read: IOPS=4568, BW=17.8MiB/s (18.7MB/s)(178MiB/10001msec)
    slat (usec): min=76, max=2739, avg=125.11, stdev=67.84
    clat (usec): min=37, max=2883, avg=61.60, stdev=39.66
     lat (usec): min=118, max=3910, avg=195.11, stdev=98.99
    clat percentiles (usec):
     |  1.00th=[   39],  5.00th=[   40], 10.00th=[   40], 20.00th=[   41],
     | 30.00th=[   42], 40.00th=[   44], 50.00th=[   50], 60.00th=[   69],
     | 70.00th=[   73], 80.00th=[   75], 90.00th=[   81], 95.00th=[   98],
     | 99.00th=[  172], 99.50th=[  243], 99.90th=[  490], 99.95th=[  668],
     | 99.99th=[ 1029]
   bw (  KiB/s): min=12231, max=27353, per=25.37%, avg=17969.00, stdev=5973.02, samples=19
   iops        : min= 3057, max= 6836, avg=4491.95, stdev=1493.09, samples=19
  lat (usec)   : 50=50.10%, 100=45.01%, 250=4.41%, 500=0.39%, 750=0.07%
  lat (usec)   : 1000=0.01%
  lat (msec)   : 2=0.01%, 4=0.01%
  cpu          : usr=51.79%, sys=48.10%, ctx=42, majf=0, minf=21
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwts: total=45694,0,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=1
test: (groupid=0, jobs=1): err= 0: pid=2636: Tue Sep 24 15:24:31 2024
  read: IOPS=4271, BW=16.7MiB/s (17.5MB/s)(167MiB/10001msec)
    slat (usec): min=82, max=6560, avg=135.18, stdev=94.49
    clat (usec): min=38, max=3527, avg=64.41, stdev=63.72
     lat (usec): min=126, max=6803, avg=208.70, stdev=127.77
    clat percentiles (usec):
     |  1.00th=[   41],  5.00th=[   42], 10.00th=[   42], 20.00th=[   43],
     | 30.00th=[   44], 40.00th=[   46], 50.00th=[   56], 60.00th=[   72],
     | 70.00th=[   76], 80.00th=[   78], 90.00th=[   83], 95.00th=[   91],
     | 99.00th=[  163], 99.50th=[  258], 99.90th=[  619], 99.95th=[ 1074],
     | 99.99th=[ 3228]
   bw (  KiB/s): min=11712, max=25237, per=23.70%, avg=16783.58, stdev=5039.60, samples=19
   iops        : min= 2928, max= 6309, avg=4195.63, stdev=1259.97, samples=19
  lat (usec)   : 50=46.91%, 100=50.05%, 250=2.53%, 500=0.34%, 750=0.09%
  lat (usec)   : 1000=0.03%
  lat (msec)   : 2=0.02%, 4=0.03%
  cpu          : usr=49.11%, sys=49.60%, ctx=127, majf=0, minf=21
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwts: total=42718,0,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=1
test: (groupid=0, jobs=1): err= 0: pid=2637: Tue Sep 24 15:24:31 2024
  read: IOPS=4545, BW=17.8MiB/s (18.6MB/s)(178MiB/10001msec)
    slat (usec): min=75, max=3341, avg=124.58, stdev=65.63
    clat (usec): min=37, max=3452, avg=61.84, stdev=37.97
     lat (usec): min=120, max=3612, avg=195.40, stdev=94.16
    clat percentiles (usec):
     |  1.00th=[   39],  5.00th=[   41], 10.00th=[   41], 20.00th=[   42],
     | 30.00th=[   43], 40.00th=[   44], 50.00th=[   52], 60.00th=[   70],
     | 70.00th=[   73], 80.00th=[   75], 90.00th=[   81], 95.00th=[   94],
     | 99.00th=[  163], 99.50th=[  227], 99.90th=[  474], 99.95th=[  603],
     | 99.99th=[  914]
   bw (  KiB/s): min=11704, max=26802, per=25.21%, avg=17858.53, stdev=5757.34, samples=19
   iops        : min= 2926, max= 6700, avg=4464.53, stdev=1439.45, samples=19
  lat (usec)   : 50=49.39%, 100=46.04%, 250=4.13%, 500=0.35%, 750=0.07%
  lat (usec)   : 1000=0.01%
  lat (msec)   : 2=0.01%, 4=0.01%
  cpu          : usr=52.67%, sys=47.23%, ctx=53, majf=0, minf=21
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwts: total=45463,0,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=1
test: (groupid=0, jobs=1): err= 0: pid=2638: Tue Sep 24 15:24:31 2024
  read: IOPS=4319, BW=16.9MiB/s (17.7MB/s)(169MiB/10001msec)
    slat (usec): min=77, max=3378, avg=132.08, stdev=112.72
    clat (usec): min=37, max=2268, avg=64.27, stdev=72.61
     lat (usec): min=120, max=3483, avg=205.71, stdev=148.46
    clat percentiles (usec):
     |  1.00th=[   39],  5.00th=[   40], 10.00th=[   41], 20.00th=[   41],
     | 30.00th=[   42], 40.00th=[   44], 50.00th=[   48], 60.00th=[   70],
     | 70.00th=[   73], 80.00th=[   75], 90.00th=[   81], 95.00th=[   91],
     | 99.00th=[  221], 99.50th=[  545], 99.90th=[ 1074], 99.95th=[ 1237],
     | 99.99th=[ 1958]
   bw (  KiB/s): min=11712, max=25456, per=23.96%, avg=16969.42, stdev=5809.51, samples=19
   iops        : min= 2928, max= 6364, avg=4242.05, stdev=1452.48, samples=19
  lat (usec)   : 50=52.03%, 100=44.70%, 250=2.33%, 500=0.31%, 750=0.28%
  lat (usec)   : 1000=0.20%
  lat (msec)   : 2=0.14%, 4=0.01%
  cpu          : usr=48.25%, sys=46.10%, ctx=945, majf=0, minf=21
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwts: total=43201,0,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=
```