### PR TITLE
Revert "GitHub Actions: Switch to GitHub-hosted runners"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,9 @@ jobs:
         include:
           - os: buildjet-4vcpu-ubuntu-2204-arm
             arch: arm64
-          - os: ubuntu-20.04
+          - os: buildjet-4vcpu-ubuntu-2004
             arch: amd64
-          - os: ubuntu-20.04
+          - os: buildjet-4vcpu-ubuntu-2004
             arch: riscv64
     steps:
       - name: Starting Report
@@ -82,7 +82,7 @@ jobs:
 
   eve:
     needs: packages  # all packages for all platforms must be built first
-    runs-on: ubuntu-20.04
+    runs-on: buildjet-4vcpu-ubuntu-2004
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/buildondemand.yml
+++ b/.github/workflows/buildondemand.yml
@@ -27,9 +27,9 @@ jobs:
         include:
           - os: buildjet-4vcpu-ubuntu-2204-arm
             arch: arm64
-          - os: ubuntu-20.04
+          - os: buildjet-4vcpu-ubuntu-2004
             arch: amd64
-          - os: ubuntu-20.04
+          - os: buildjet-4vcpu-ubuntu-2004
             arch: riscv64
     steps:
       - name: Starting Report
@@ -83,7 +83,7 @@ jobs:
     needs: packages  # all packages for all platforms must be built first
     # Only run for the default branch
     if: github.ref_name == github.event.repository.default_branch
-    runs-on: ubuntu-20.04
+    runs-on: buildjet-4vcpu-ubuntu-2004
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This reverts commit 55e539debf00c1c7d81145d35ceab9443f3c93e5.

The recent switch to GitHub-hosted runners introduced issues with actions/cache path handling, resulting in build failures due to inconsistent home directory depths. Reverting to self-hosted runners to restore build stability and functionality.

References:
- Issue: https://github.com/actions/cache/issues/1440