### PR TITLE
[9.4-stable] Rised hard limit for /eve and /eve/services cgroups

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -150,9 +150,9 @@ function set_rootfs_title {
 }
 
 function set_generic {
-   set_global hv_dom0_mem_settings "dom0_mem=800M,max:800M"
+   set_global hv_dom0_mem_settings "dom0_mem=2G,max:2G"
    set_global hv_dom0_cpu_settings "dom0_max_vcpus=1 dom0_vcpus_pin"
-   set_global hv_eve_mem_settings "eve_mem=650M,max:650M"
+   set_global hv_eve_mem_settings "eve_mem=1600M,max:1600M"
    set_global hv_eve_cpu_settings "eve_max_vcpus=1"
    set_global hv_ctrd_mem_settings "ctrd_mem=400M,max:400M"
    set_global hv_ctrd_cpu_settings "ctrd_max_vcpus=1"


### PR DESCRIPTION
By special request this patch increases memory limit (soft and hard) for `/eve` and `/eve/services` cgroups:

 * /eve          from 800M to 2048M (dom0_mem configuration parameter)
 * /eve/services from 650M to 1600M (eve_mem configuration parameter)

Rised hard limit should help to mitigate OOM caused by bloated zedbox (pillar) application.

Unfortunately branch 9.4-stable has 1.18 version of Golang, which makes it impossible to cherry-pick the following commit 2aa31d211305faacb08ee6beb1fc3c425ec691bc  from master, which uses `runtime.debug.SetMemoryLimit()` golang call, introduced in the 1.19 Golang version

Cc: @rene @OhmSpectator @eriknordmark 