### PR TITLE
remove reference to unused verification from github workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,7 +22,6 @@
 /pkg/measure-config/          @rucoder
 /pkg/memory-monitor/          @OhmSpectator
 /pkg/mkimage-raw-efi/         @jsfakian @zedi-pramodh
-/pkg/mkverification-raw-efi/  @jsfakian
 /pkg/new-kernel/              @rucoder @rene @rouming @shjala
 /pkg/newlog/                  @deitch @naiming-zededa
 /pkg/optee-os/                @rene
@@ -59,7 +58,7 @@
 /pkg/storage-init/            @rouming
 /pkg/u-boot/                  @rene
 /pkg/uefi/                    @rucoder
-/pkg/verification/            @jsfakian
+/pkg/verifier-rs/             @jsfakian
 /pkg/vtpm/                    @shjala
 /pkg/wwan/                    @milan-zededa
 /pkg/xen-tools/               @OhmSpectator @rucoder @rene @shjala

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -129,25 +129,6 @@ jobs:
           dockerhub-token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
           dockerhub-account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
 
-  verification:
-    if: github.event.repository.full_name == 'lf-edge/eve'
-    needs: packages
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: [arm64, amd64]
-        hv: [kvm, xen]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: ./.github/actions/run-make
-        with:
-          command: "V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} LINUXKIT_PKG_TARGET=push verification"
-          dockerhub-token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
-          dockerhub-account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
-
   manifest:
     if: github.event.repository.full_name == 'lf-edge/eve'
     runs-on: ubuntu-latest
@@ -164,7 +145,7 @@ jobs:
 
   trigger_assets:
     if: ${{ (startsWith(github.ref, 'refs/tags/')) && (github.event.repository.full_name == 'lf-edge/eve') }}
-    needs: [manifest, verification, eve]
+    needs: [manifest, eve]
     uses: lf-edge/eve/.github/workflows/assets.yml@master
     with:
       tag_ref: ${{ github.ref_name }}


### PR DESCRIPTION
A prior commit removed the separate verification image and integrated it into installer. This removes a call to that make target from the publish.yml workflow, and updates the CODEOWNERS to reference the correct ones.