### PR TITLE
Fix interactive shell called from installer script

### DIFF
--- a/pkg/installer/install
+++ b/pkg/installer/install
@@ -196,6 +196,9 @@ spec() {
    DEBUG="$DEBUG" /spec.sh "$@"
 }
 
+# we may be asked to pause before install procedure
+cmdline eve_pause_before_install && pause "start the installation"
+
 logmsg "EVE-OS installation started"
 # do this just in case
 modprobe usbhid && modprobe usbkbd
@@ -323,9 +326,6 @@ ln -s /bits/* ${ARTIFACTS_DIR} 2>/dev/null
 for i in rootfs config persist; do
    cmdline "eve_install_skip_$i" && trunc "${ARTIFACTS_DIR}/$i.img"
 done
-
-# we may be asked to pause before install procedure
-cmdline eve_pause_before_install && pause "formatting the /dev/$INSTALL_DEV"
 
 # Do we want random or fixed disk and partition UUIDs?
 RANDOM_DISK_UUIDS=

--- a/pkg/installer/install
+++ b/pkg/installer/install
@@ -64,8 +64,8 @@ logmsg() {
 }
 
 pause() {
-   echo "Pausing before $1. Entering shell. Type 'exit' to proceed to $1"
-   sh
+   echo "Pausing before $1. Entering shell. Type 'exit' to proceed to $1" > /dev/console 2>&1
+   sh < /dev/console > /dev/console 2>&1
 }
 
 bail() {


### PR DESCRIPTION
## Description

One fix and one small improvement in the installer script:

#### Forces shell to run interactively when required
    
The installer script runs within a onboot container, with output/input not redirected to the current tty console. When a pause is required by the user (before or after the installation process), the shell called within the install script will not work. Forcing input/output to /dev/console fixes the problem.
    
#### Move "pause before install" to early stage
    
The boot option "pause before install" will pause the installation process only after wiping disks (when required), so move the pause to an earlier stage, before any destructive action to storage devices is performed.
