### PR TITLE
Allow EVE memory limits above 4GB.

### DIFF
--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -227,7 +227,12 @@ const (
 	VgaAccess GlobalSettingKey = "debug.enable.vga"
 	// AllowAppVnc global setting key
 	AllowAppVnc GlobalSettingKey = "app.allow.vnc"
-	// EveMemoryLimitInBytes global setting key
+	// EveMemoryLimitInMiB global setting key, memory limit for EVE in MiB
+	EveMemoryLimitInMiB GlobalSettingKey = "memory.eve.limit.MiB"
+	// EveMemoryLimitInBytes global setting key, memory limit for EVE in bytes
+	// Deprecated: Use EveMemoryLimitInMiB. This config is limited to 4GB
+	// as it is stored as uint32. Nevertheles, for backward compatibility,
+	// this config is still supported and has higher priority than EveMemoryLimitInMiB.
 	EveMemoryLimitInBytes GlobalSettingKey = "memory.eve.limit.bytes"
 	// How much memory overhead is allowed for VMM needs
 	VmmMemoryLimitInMiB GlobalSettingKey = "memory.vmm.limit.MiB"
@@ -847,6 +852,8 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	if err != nil {
 		logrus.Errorf("getEveMemoryLimitInBytes failed: %v", err)
 	}
+	// Round up to the nearest MiB
+	eveMemoryLimitInMiB := uint32((eveMemoryLimitInBytes + 1024*1024 - 1) / (1024 * 1024))
 	var configItemSpecMap ConfigItemSpecMap
 	configItemSpecMap.GlobalSettings = make(map[GlobalSettingKey]ConfigItemSpec)
 	configItemSpecMap.AgentSettings = make(map[AgentSettingKey]ConfigItemSpec)
@@ -902,6 +909,8 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddIntItem(GOGCPercent, 100, 0, 500)
 	configItemSpecMap.AddIntItem(EveMemoryLimitInBytes, uint32(eveMemoryLimitInBytes),
 		uint32(eveMemoryLimitInBytes), 0xFFFFFFFF)
+	configItemSpecMap.AddIntItem(EveMemoryLimitInMiB, eveMemoryLimitInMiB,
+		eveMemoryLimitInMiB, 0xFFFFFFFF)
 	// Limit manual vmm overhead override to 1 PiB
 	configItemSpecMap.AddIntItem(VmmMemoryLimitInMiB, 0, 0, uint32(1024*1024*1024))
 	// LogRemainToSendMBytes - Default is 2 Gbytes, minimum is 10 Mbytes

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -186,6 +186,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		GOGCMemoryLimitInBytes,
 		GOGCPercent,
 		EveMemoryLimitInBytes,
+		EveMemoryLimitInMiB,
 		VmmMemoryLimitInMiB,
 		IgnoreMemoryCheckForApps,
 		IgnoreDiskCheckForApps,


### PR DESCRIPTION
Previously, EVE's memory limit was stored in bytes using a uint32 value in the global configuration, limiting the maximum memory to approximately 4GB. This restriction prevented setting higher memory limits necessary for example for kubevirt. Configuring a memory limit larger than 4GB caused EVE to incorrectly store the value as 0, resulting in inaccurate memory requirement estimations.

This commit changes the memory limit configuration to use mebibytes (MiB) instead of bytes, allowing EVE to support memory limits beyond 4GB.