### PR TITLE
[12.0-stable] pkg/pillar: make ioBundleError deepcopy-able

### DIFF
--- a/pkg/pillar/pubsub/publish.go
+++ b/pkg/pillar/pubsub/publish.go
@@ -110,7 +110,7 @@ func (pub *PublicationImpl) Publish(key string, item interface{}) error {
 		pub.log.Fatalf("Publish got a pointer for %s", name)
 	}
 	// Perform a deepCopy in case the caller might change a map etc
-	newItem := deepCopy(pub.log, item)
+	newItem := DeepCopy(pub.log, item)
 	if m, ok := pub.km.key.Load(key); ok {
 		if cmp.Equal(m, newItem) {
 			pub.log.Tracef("Publish(%s/%s) unchanged\n", name, key)
@@ -190,7 +190,7 @@ func (pub *PublicationImpl) ClearRestarted() error {
 func (pub *PublicationImpl) Get(key string) (interface{}, error) {
 	m, ok := pub.km.key.Load(key)
 	if ok {
-		newIntf := deepCopy(pub.log, m)
+		newIntf := DeepCopy(pub.log, m)
 		return newIntf, nil
 	} else {
 		name := pub.nameString()
@@ -203,7 +203,7 @@ func (pub *PublicationImpl) Get(key string) (interface{}, error) {
 func (pub *PublicationImpl) GetAll() map[string]interface{} {
 	result := make(map[string]interface{})
 	assigner := func(key string, val interface{}) bool {
-		newVal := deepCopy(pub.log, val)
+		newVal := DeepCopy(pub.log, val)
 		result[key] = newVal
 		return true
 	}

--- a/pkg/pillar/pubsub/subscribe.go
+++ b/pkg/pillar/pubsub/subscribe.go
@@ -263,7 +263,7 @@ func handleModify(ctxArg interface{}, key string, itemcb []byte) {
 		sub.dump("after handleModify")
 	}
 	// Need a copy in case the caller will modify e.g., embedded maps
-	newItem := deepCopy(sub.log, item)
+	newItem := DeepCopy(sub.log, item)
 	if created {
 		if sub.CreateHandler != nil {
 			(sub.CreateHandler)(sub.userCtx, key, newItem)

--- a/pkg/pillar/pubsub/util.go
+++ b/pkg/pillar/pubsub/util.go
@@ -14,7 +14,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/base"
 )
 
-// deepCopy returns the same type as what is passed as input
+// DeepCopy returns the same type as what is passed as input
 // Warning: only public fields will be exported
 // Note why json marshalling is used:
 // Type casting and associated type assertions in golang are only
@@ -24,7 +24,7 @@ import (
 // Golang doesn't have support for a deep copy. Once can build it
 // oneself using reflect package, but it ends up doing the same thing
 // as json encode+decode apart from the exported fields check.
-func deepCopy(log *base.LogObject, in interface{}) interface{} {
+func DeepCopy(log *base.LogObject, in interface{}) interface{} {
 	b, err := json.Marshal(in)
 	if err != nil {
 		log.Fatal("json Marshal in deepCopy", err)

--- a/pkg/pillar/pubsub/util_test.go
+++ b/pkg/pillar/pubsub/util_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2024 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package pubsub_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/sirupsen/logrus"
+)
+
+func TestDeepCopyIoBundlError(t *testing.T) {
+	logger := logrus.StandardLogger()
+	log := base.NewSourceLogObject(logger, "test", 1234)
+
+	errs := []error{
+		fmt.Errorf("some error"),
+		types.ErrOwnParent{},
+		types.ErrParentAssigngrpMismatch{},
+		types.ErrEmptyAssigngrpWithParent{},
+		types.ErrCycleDetected{},
+		types.ErrIOBundleCollision{
+			Collisions: []types.IOBundleCollision{{
+				Phylabel:   "phy1",
+				USBAddr:    "usb1",
+				USBProduct: "usbprod1",
+				PCILong:    "pcilong",
+				Assigngrp:  "assigngrp",
+			},
+			},
+		},
+	}
+	iob := types.IoBundle{
+		Error: types.IOBundleError{
+			TimeOfError: time.Time{},
+		},
+	}
+
+	for _, err := range errs {
+		iob.Error.Append(err)
+	}
+	output := pubsub.DeepCopy(log, iob)
+
+	t.Logf("copy: %v", output)
+
+	for _, err := range errs {
+		if !iob.Error.HasErrorByType(err) {
+			t.Fatalf("error %v missing", err)
+		}
+	}
+
+	if !cmp.Equal(output, iob) {
+		t.Fatalf("not equal: %s", cmp.Diff(output, iob))
+	}
+}


### PR DESCRIPTION
error types very often have private members that cannot be marshalled with `json.Marshal`

we fix this by only storing the error type and the error string (err.Error()) as values in uppercase members of our own ioBundleError type

log output:
```
json Unmarshal in deepCopy: json: cannot unmarshal object into Go struct field IoBundleError.IoBundleList.Error.Errors of type error
```

introduced by d1e13b8f880218470de48c4d569957dd89410de4

Signed-off-by: Christoph Ostarek <christoph@zededa.com>
(cherry picked from commit 9cc6ca87330a62d7f56d357df62f4b84d99aceee)