### PR TITLE
start user apps from image instead of rootfs

### DIFF
--- a/pkg/pillar/.gitignore
+++ b/pkg/pillar/.gitignore
@@ -1,0 +1,5 @@
+*.test
+*.profile*
+coverage.txt
+results.json
+results.xml

--- a/pkg/pillar/containerd/containerd.go
+++ b/pkg/pillar/containerd/containerd.go
@@ -32,7 +32,6 @@ import (
 	"github.com/lf-edge/edge-containers/pkg/resolver"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/types"
-	"github.com/lf-edge/eve/pkg/pillar/utils/persist"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
 	runtimespecs "github.com/opencontainers/runtime-spec/specs-go"
@@ -98,10 +97,6 @@ func GetServicesNamespace() string {
 
 func init() {
 	logrus.Info("Containerd Init")
-	// see if we need to use zfs snapshotter based on what flavor of storage persist partition is
-	if persist.ReadPersistType() == types.PersistZFS {
-		defaultSnapshotter = types.ZFSSnapshotter
-	}
 
 	if base.IsHVTypeKube() {
 		defaultSnapshotter = "overlayfs"

--- a/pkg/pillar/containerd/oci.go
+++ b/pkg/pillar/containerd/oci.go
@@ -45,13 +45,14 @@ var dhcpcdScript = []string{"eve", "exec", "pillar", "/opt/zededa/bin/dhcpcd.sh"
 // for all the different task usecases
 type ociSpec struct {
 	specs.Spec
-	name         string
-	client       *Client
-	exposedPorts map[string]struct{}
-	volumes      map[string]struct{}
-	labels       map[string]string
-	stopSignal   string
-	service      bool
+	name          string
+	client        *Client
+	exposedPorts  map[string]struct{}
+	volumes       map[string]struct{}
+	labels        map[string]string
+	stopSignal    string
+	service       bool
+	containerOpts []containerd.NewContainerOpts
 }
 
 // OCISpec provides methods to manipulate OCI runtime specifications and create containers based on them
@@ -114,7 +115,42 @@ func (s *ociSpec) AddLoader(volume string) error {
 		return err
 	}
 
-	spec.Root = &specs.Root{Readonly: true, Path: filepath.Join(volume, "rootfs")}
+	// we're gonna use a little hack: since we already have the rootfs of a xen-tools container
+	// laid out on disk, but don't have it in a form of a snapshot or an image, we're going to
+	// create an empty snapshot and then overlay the rootfs on top of it - this way we can save
+	// ourselves copying the rootfs around and still have the newest version of xen-tools on every
+	// boot, while the original xen-tools rootfs stays read-only
+
+	ctrdCtx, done := s.client.CtrNewUserServicesCtx()
+	defer done()
+
+	// create a clean snapshot
+	snapshotName := s.name
+	snapshotMount, err := s.client.CtrCreateEmptySnapshot(ctrdCtx, snapshotName)
+	if err != nil {
+		return err
+	}
+
+	// remove fs from the end of snapshotMount
+	snapshotPath := strings.TrimSuffix(snapshotMount[0].Source, "/fs")
+	logrus.Debugf("Snapshot path: %s", snapshotPath)
+
+	xenToolsMount := specs.Mount{
+		Type:        "overlay",
+		Source:      "overlay",
+		Destination: "/",
+		Options: []string{
+			"index=off",
+			"workdir=" + snapshotPath + "/work",
+			"upperdir=" + snapshotPath + "/fs",
+			"lowerdir=" + volume + "/rootfs",
+		}}
+
+	// we need to prepend the loader mount to the existing mounts to make sure it's mounted first because it's the rootfs
+	spec.Mounts = append([]specs.Mount{xenToolsMount}, spec.Mounts...)
+
+	s.containerOpts = append(s.containerOpts, containerd.WithSnapshot(snapshotName))
+
 	spec.Linux.Resources = s.Linux.Resources
 	spec.Linux.CgroupsPath = s.Linux.CgroupsPath
 
@@ -261,11 +297,14 @@ func (s *ociSpec) Load(file *os.File) error {
 func (s *ociSpec) CreateContainer(removeExisting bool) error {
 	ctrdCtx, done := s.client.CtrNewUserServicesCtx()
 	defer done()
-	_, err := s.client.ctrdClient.NewContainer(ctrdCtx, s.name, containerd.WithSpec(&s.Spec))
+
+	containerOpts := append(s.containerOpts, containerd.WithSpec(&s.Spec))
+
+	_, err := s.client.ctrdClient.NewContainer(ctrdCtx, s.name, containerOpts...)
 	// if container exists, is stopped and we are asked to remove existing - try that
 	if err != nil && removeExisting {
 		_ = s.client.CtrDeleteContainer(ctrdCtx, s.name)
-		_, err = s.client.ctrdClient.NewContainer(ctrdCtx, s.name, containerd.WithSpec(&s.Spec))
+		_, err = s.client.ctrdClient.NewContainer(ctrdCtx, s.name, containerOpts...)
 	}
 	return err
 }

--- a/pkg/pillar/containerd/oci_test.go
+++ b/pkg/pillar/containerd/oci_test.go
@@ -4,14 +4,12 @@
 package containerd
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"net"
 	"os"
 	"path"
 	"path/filepath"
-	"reflect"
 	"testing"
 
 	zconfig "github.com/lf-edge/eve-api/go/config"
@@ -475,6 +473,9 @@ func TestCreateMountPointExecEnvFiles(t *testing.T) {
         }
     ]
 }`
+
+	client := initClient(t)
+
 	//create a temp dir to hold resulting files
 	dir, _ := os.MkdirTemp("/tmp", "podfiles")
 	rootDir := path.Join(dir, "runx")
@@ -497,7 +498,6 @@ func TestCreateMountPointExecEnvFiles(t *testing.T) {
 		t.Errorf("failed to write to a runtime spec file %v", err)
 	}
 
-	client := &Client{}
 	spec, err := client.NewOciSpec("test", false)
 	if err != nil {
 		t.Errorf("failed to create new OCI spec %v", err)
@@ -623,6 +623,8 @@ func TestPrepareMount(t *testing.T) {
     ]
 }`
 
+	client := initClient(t)
+
 	err := os.MkdirAll(path.Join(oldTempRootPath, "tmp"), 0777)
 	if err != nil {
 		t.Errorf("TestPrepareMount: Failed to create %s: %s", oldTempRootPath, err.Error())
@@ -677,7 +679,6 @@ func TestPrepareMount(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client := &Client{}
 			spec, err := client.NewOciSpec("test", false)
 			if err != nil {
 				t.Errorf("failed to create new OCI spec")
@@ -790,10 +791,10 @@ func TestEnvs(t *testing.T) {
 	g.Expect(spec.Process.Args).To(Equal([]string{"echo", "hello"}))
 }
 
-func TestAddLoader(t *testing.T) {
-	g := NewGomegaWithT(t)
-	specTemplate := ociSpec{
+func specTemplate(client *Client) ociSpec {
+	return ociSpec{
 		name:    "test",
+		client:  client,
 		volumes: map[string]struct{}{"/myvol": {}, "/hisvol": {}},
 		Spec: specs.Spec{
 			Process: &specs.Process{
@@ -809,8 +810,39 @@ func TestAddLoader(t *testing.T) {
 			Linux:       &specs.Linux{CgroupsPath: "/foo/bar/baz"},
 		},
 	}
-	spec1 := deepCopy(specTemplate).(ociSpec)
-	spec2 := deepCopy(specTemplate).(ociSpec)
+}
+
+func initClient(t *testing.T) *Client {
+	client, err := NewContainerdClient(false)
+	if err != nil {
+		t.Skipf("test must be run on a system with a functional containerd")
+	}
+
+	t.Cleanup(func() {
+		ctrdCtx, done := client.CtrNewUserServicesCtx()
+		defer done()
+
+		// clean up the snapshots that were created in AddLoader()
+		snapshots, err := client.CtrListSnapshotInfo(ctrdCtx)
+		if err != nil {
+			t.Errorf("failed to list snapshots %v", err)
+		}
+		for _, snapshot := range snapshots {
+			if err := client.CtrRemoveSnapshot(ctrdCtx, snapshot.Name); err != nil {
+				t.Errorf("failed to remove snapshot %s %v", snapshot.Name, err)
+			}
+		}
+
+		// add more things here if other containerd artifacts were created
+	})
+
+	return client
+}
+
+func TestAddLoader(t *testing.T) {
+	client := initClient(t)
+
+	g := NewGomegaWithT(t)
 
 	tmpdir, err := os.MkdirTemp("/tmp", "volume")
 	if err != nil {
@@ -822,36 +854,30 @@ func TestAddLoader(t *testing.T) {
 		log.Fatalf("failed to create tmpfile %v", err)
 	}
 
+	spec1 := specTemplate(client)
 	g.Expect(spec1.AddLoader("/foo/bar/baz")).To(HaveOccurred())
 
 	g.Expect(spec1.AddLoader(tmpdir)).ToNot(HaveOccurred())
-	g.Expect(spec1.Root).To(Equal(&specs.Root{Path: filepath.Join(tmpdir, "rootfs"), Readonly: true}))
+	g.Expect(spec1.Root).To(Equal(&specs.Root{Path: "rootfs", Readonly: false}))
 	g.Expect(spec1.Linux.CgroupsPath).To(Equal("/foo/bar/baz"))
-	g.Expect(spec1.Mounts[9]).To(Equal(specs.Mount{Destination: "/mnt/rootfs/test", Type: "bind", Source: "/test", Options: []string{"ro"}}))
-	g.Expect(spec1.Mounts[0]).To(Equal(specs.Mount{Destination: "/dev", Type: "bind", Source: "/dev", Options: []string{"rw", "rbind", "rshared"}}))
+	g.Expect(spec1.Mounts[10]).To(Equal(specs.Mount{Destination: "/mnt/rootfs/test", Type: "bind", Source: "/test", Options: []string{"ro"}}))
+	g.Expect(spec1.Mounts[1]).To(Equal(specs.Mount{Destination: "/dev", Type: "bind", Source: "/dev", Options: []string{"rw", "rbind", "rshared"}}))
 
+	spec2 := specTemplate(client)
 	spec2.Root.Path = tmpdir
 	g.Expect(spec2.AddLoader(tmpdir)).ToNot(HaveOccurred())
-	g.Expect(spec2.Root).To(Equal(&specs.Root{Path: filepath.Join(tmpdir, "rootfs"), Readonly: true}))
+	g.Expect(spec2.Root).To(Equal(&specs.Root{Path: "rootfs", Readonly: false}))
 	g.Expect(spec2.Linux.CgroupsPath).To(Equal("/foo/bar/baz"))
-	g.Expect(spec2.Mounts[11]).To(Equal(specs.Mount{Destination: "/mnt/rootfs/test", Type: "bind", Source: "/test", Options: []string{"ro"}}))
-	g.Expect(spec2.Mounts[10]).To(Equal(specs.Mount{Destination: "/mnt/modules", Type: "bind", Source: "/lib/modules", Options: []string{"rbind", "ro", "rslave"}}))
-	g.Expect(spec2.Mounts[9]).To(Equal(specs.Mount{Destination: "/mnt", Type: "bind", Source: path.Join(tmpdir, ".."), Options: []string{"rbind", "rw", "rslave"}}))
-	g.Expect(spec2.Mounts[0]).To(Equal(specs.Mount{Destination: "/dev", Type: "bind", Source: "/dev", Options: []string{"rw", "rbind", "rshared"}}))
-}
-
-func deepCopy(in interface{}) interface{} {
-	b, _ := json.Marshal(in)
-	p := reflect.New(reflect.TypeOf(in))
-	output := p.Interface()
-	_ = json.Unmarshal(b, output)
-	val := reflect.ValueOf(output)
-	val = val.Elem()
-	return val.Interface()
+	g.Expect(spec2.Mounts[12]).To(Equal(specs.Mount{Destination: "/mnt/rootfs/test", Type: "bind", Source: "/test", Options: []string{"ro"}}))
+	g.Expect(spec2.Mounts[11]).To(Equal(specs.Mount{Destination: "/mnt/modules", Type: "bind", Source: "/lib/modules", Options: []string{"rbind", "ro", "rslave"}}))
+	g.Expect(spec2.Mounts[10]).To(Equal(specs.Mount{Destination: "/mnt", Type: "bind", Source: path.Join(tmpdir, ".."), Options: []string{"rbind", "rw", "rslave"}}))
+	g.Expect(spec2.Mounts[1]).To(Equal(specs.Mount{Destination: "/dev", Type: "bind", Source: "/dev", Options: []string{"rw", "rbind", "rshared"}}))
 }
 
 func TestDenyAllDevicesInSpec(t *testing.T) {
 	t.Parallel()
+
+	client := initClient(t)
 
 	// create a temp dir to hold resulting files
 	dir, _ := os.MkdirTemp("/tmp", "podfiles")
@@ -870,7 +896,6 @@ func TestDenyAllDevicesInSpec(t *testing.T) {
 		t.Errorf("failed to write to a runtime spec file %v", err)
 	}
 
-	client := &Client{}
 	spec, err := client.NewOciSpec("test", false)
 	if err != nil {
 		t.Errorf("failed to create new OCI spec %v", err)

--- a/pkg/pillar/hypervisor/containerd.go
+++ b/pkg/pillar/hypervisor/containerd.go
@@ -191,6 +191,11 @@ func (ctx ctrdContext) Delete(domainName string) error {
 	if err := ctx.ctrdClient.CtrDeleteContainer(ctrdCtx, domainName); err != nil {
 		return err
 	}
+	if persistentSnapshotExists, _ := ctx.ctrdClient.CtrSnapshotExists(ctrdCtx, domainName); persistentSnapshotExists {
+		if err := ctx.ctrdClient.CtrRemoveSnapshot(ctrdCtx, domainName); err != nil {
+			return err
+		}
+	}
 	vifsTaskDir := filepath.Join(vifsDir, domainName)
 	if err := os.RemoveAll(vifsTaskDir); err != nil {
 		return logError("cannot clear vifs task dir %s: %v", vifsTaskDir, err)
@@ -203,10 +208,17 @@ func (ctx ctrdContext) Cleanup(domainName string) error {
 	ctrdCtx, done := ctx.ctrdClient.CtrNewUserServicesCtx()
 	defer done()
 	container, _ := ctx.ctrdClient.CtrLoadContainer(ctrdCtx, domainName)
-	if container == nil {
-		return nil
+	if container != nil {
+		if err := ctx.Delete(domainName); err != nil {
+			return err
+		}
 	}
-	return ctx.Delete(domainName)
+	if persistentSnapshotExists, _ := ctx.ctrdClient.CtrSnapshotExists(ctrdCtx, domainName); persistentSnapshotExists {
+		if err := ctx.ctrdClient.CtrRemoveSnapshot(ctrdCtx, domainName); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (ctx ctrdContext) Annotations(domainName string) (map[string]string, error) {

--- a/pkg/pillar/hypervisor/hypervisor.go
+++ b/pkg/pillar/hypervisor/hypervisor.go
@@ -20,6 +20,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	xenToolsPath = "/containers/services/xen-tools"
+)
+
 // Hypervisor provides methods for manipulating domains on the host
 type Hypervisor interface {
 	Name() string

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -851,7 +851,7 @@ func (ctx KvmContext) Setup(status types.DomainStatus, config types.DomainConfig
 	if err != nil {
 		return logError("failed to load OCI spec for domain %s: %v", status.DomainName, err)
 	}
-	if err = spec.AddLoader("/containers/services/xen-tools"); err != nil {
+	if err = spec.AddLoader(xenToolsPath); err != nil {
 		return logError("failed to add kvm hypervisor loader to domain %s: %v", status.DomainName, err)
 	}
 	overhead, err := vmmOverhead(domainName, domainUUID, int64(config.Memory), int64(config.VMMMaxMem), int64(config.MaxCpus), int64(config.VCpus), config.IoAdapterList, aa, globalConfig)

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -133,7 +133,7 @@ func (ctx xenContext) Setup(status types.DomainStatus, config types.DomainConfig
 	if err != nil {
 		return logError("failed to load OCI spec for domain %s: %v", status.DomainName, err)
 	}
-	if err = spec.AddLoader("/containers/services/xen-tools"); err != nil {
+	if err = spec.AddLoader(xenToolsPath); err != nil {
 		return logError("failed to add xen hypervisor loader to domain %s: %v", status.DomainName, err)
 	}
 	spec.Get().Process.Args = []string{"/etc/xen/scripts/xen-start", status.DomainName, file.Name()}


### PR DESCRIPTION
Closes #4303 

Since starting containers from rootfs does not provide sufficient isolation (especially with mounting), we create a OCI image from the xen-tools rootfs and start user apps from that image.

The xen-tools image is created only once when initializing hypervisors KVM and Xen. It is not recreated on reboot and never chagned. After EVE update the containerd content store is emptry again, so the image is recreated, since xen-tools rootfs may have changed.