### PR TITLE
[12.0-stable] pillar: Use hard memory limit for EVE memory management.

### DIFF
--- a/pkg/pillar/types/locationconsts.go
+++ b/pkg/pillar/types/locationconsts.go
@@ -101,7 +101,7 @@ const (
 	// PillarHardMemoryLimitFile - hard memory reserved for pillar
 	PillarHardMemoryLimitFile = "/hostfs/sys/fs/cgroup/memory/eve/services/pillar/memory.limit_in_bytes"
 	// EveMemoryLimitFile - stores memory reserved for eve
-	EveMemoryLimitFile = "/hostfs/sys/fs/cgroup/memory/eve/memory.soft_limit_in_bytes"
+	EveMemoryLimitFile = "/hostfs/sys/fs/cgroup/memory/eve/memory.limit_in_bytes"
 	// EveMemoryUsageFile - current usage
 	EveMemoryUsageFile = "/hostfs/sys/fs/cgroup/memory/eve/memory.usage_in_bytes"
 	// EveKmemUsageFile - current kernel usage


### PR DESCRIPTION
Backport of #4300 

Previously, EVE referenced the soft memory limit
(`memory.soft_limit_in_bytes`) to determine available memory for VM creation. By default, the soft and hard memory limits were set to the same value, so this did not cause any issues. However, if the soft and hard limits are configured differently, EVE would not respect the hard memory constraints, allowing VMs to be created without adhering to the intended maximum memory limits.

This commit updates the `EveMemoryLimitFile` path to use the hard memory limit (`memory.limit_in_bytes`) instead of the soft limit. By doing so, EVE will now properly account for the hard memory restrictions when managing memory for containers and creating new VMs, preventing potential memory overcommitment when soft and hard limits differ.

Signed-off-by: Nikolay Martyanov <nikolay@zededa.com>
(cherry picked from commit db4f3f37c68d1de7e7ead64f6ff700de64dd443a)