### PR TITLE
Do not try to decrypt empty wwan cipher data

### DIFF
--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -2087,7 +2087,9 @@ func parseNetworkWirelessConfig(ctx *getconfigContext, key string, netEnt *zconf
 				log.Errorf("parseNetworkWirelessConfig: unrecognized AuthProtocol: %+v",
 					accessPoint)
 			}
-			ap.EncryptedCredentials = parseCipherBlock(ctx, key, accessPoint.GetCipherData())
+			if ap.AuthProtocol != types.WwanAuthProtocolNone {
+				ap.EncryptedCredentials = parseCipherBlock(ctx, key, accessPoint.GetCipherData())
+			}
 			for _, plmn := range accessPoint.PreferredPlmns {
 				ap.PreferredPLMNs = append(ap.PreferredPLMNs, plmn)
 			}


### PR DESCRIPTION
Even when username/password credentials are not used for cellular connection, zedagent still tries to decrypt the cipher block which in this case will contain empty `CipherData`. This results in error `block contains incomplete data` being reported inside the `DeviceNetworkStatus` for the cellular port (in `WirelessCfg`).  Even though EVE will not end up publishing this to the controller (because mmagent will not try to use `CipherBlockStatus` unless user auth is enabled), we should still fix this to avoid confusing error inside the `DeviceNetworkStatus` pubsub message.