### PR TITLE
linuxkit: Bump linuxkit to version 1.5.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -306,7 +306,7 @@ PARSE_PKGS=$(if $(strip $(EVE_HASH)),EVE_HASH=)$(EVE_HASH) DOCKER_ARCH_TAG=$(DOC
 LINUXKIT=$(BUILDTOOLS_BIN)/linuxkit
 # linuxkit version. This **must** be a published semver version so it can be downloaded already compiled from
 # the release page at https://github.com/linuxkit/linuxkit/releases
-LINUXKIT_VERSION=v1.5.1
+LINUXKIT_VERSION=v1.5.2
 LINUXKIT_SOURCE=https://github.com/linuxkit/linuxkit
 LINUXKIT_OPTS=$(if $(strip $(EVE_HASH)),--hash) $(EVE_HASH) $(if $(strip $(EVE_REL)),--release) $(EVE_REL)
 LINUXKIT_PKG_TARGET=build


### PR DESCRIPTION
Bump linux kit to version 1.5.2 so we can get the following fix:

cb8f36adf moby: check architecture for docker image

That fixes mismatching architecture packages in the linuxkit's cache.