### PR TITLE
Fix deadlock  in Go tests when Debug Server startup fails.

### DIFF
--- a/pkg/pillar/agentlog/agentlog_test.go
+++ b/pkg/pillar/agentlog/agentlog_test.go
@@ -422,6 +422,7 @@ func startIntegratedPSICollectorAPI() (cancel context.CancelFunc, err error) {
 		time.Sleep(100 * time.Millisecond)
 	}
 	if !started {
+		psiServerMutex.Unlock()
 		return nil, fmt.Errorf("could not start the server in 10 seconds")
 	}
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
In `startIntegratedPSICollectorAPI`, if the server does not start within 10 seconds, the function returns an error without unlocking `psiServerMutex`. This oversight leads to a deadlock in subsequent tests that attempt to acquire the same mutex.

This commit adds `psiServerMutex.Unlock()` before returning the error to ensure that the mutex is properly released even when the server fails to start.

There are no affected stable branches where the fix should be backported.