### PR TITLE
[11.0-stable] Use eden from the branch EVE-11.0-stable

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -59,23 +59,23 @@ jobs:
         arch: [amd64]
         hv: [kvm]
     if: github.event.review.state == 'approved'
-    uses: lf-edge/eden/.github/workflows/test.yml@0.9.3-stable
+    uses: lf-edge/eden/.github/workflows/test.yml@EVE-11.0-stable
     with:
       eve_image: "evebuild/pr:${{ github.event.pull_request.number  }}"
       eve_artifact_name: eve-${{ matrix.hv }}-${{ matrix.arch }}
       artifact_run_id: ${{ needs.get-run-id.outputs.result }}
-      eden_version: "0.9.3-stable"
+      eden_version: "EVE-11.0-stable"
 
   test_suite_master:
     if: github.ref == 'refs/heads/master'
-    uses: lf-edge/eden/.github/workflows/test.yml@0.9.3-stable
+    uses: lf-edge/eden/.github/workflows/test.yml@EVE-11.0-stable
     with:
       eve_image: "lfedge/eve:snapshot"
-      eden_version: "0.9.3-stable"
+      eden_version: "EVE-11.0-stable"
 
   test_suite_tag:
     if: startsWith(github.ref, 'refs/tags')
-    uses: lf-edge/eden/.github/workflows/test.yml@0.9.3-stable
+    uses: lf-edge/eden/.github/workflows/test.yml@EVE-11.0-stable
     with:
       eve_image: "lfedge/eve:${{ github.ref_name }}"
-      eden_version: "0.9.3-stable"
+      eden_version: "EVE-11.0-stable"


### PR DESCRIPTION
The Eden branch `EVE-11.0-stable` is based on the latest Eden version 0.9.12 but reverts a commit that includes a test targeting a feature not yet supported in EVE 11.0.

We aim to use the latest version of Eden minus unsupported tests because Eden 0.9.3-stable is not truly stable. Most of its test suites are failing, rendering them largely ineffective.