### PR TITLE
xen-tools/init-initrd: Enable clock synchronization by default

### DIFF
--- a/docs/CLOCK-SYNCHRONIZATION.md
+++ b/docs/CLOCK-SYNCHRONIZATION.md
@@ -69,9 +69,9 @@ clock drifts when NTP is not available, one of the following options are
 recommended:
 
 - Use the virtual PTP kvm clock. EVE enables the chrony daemon
-  automatically for containers when the environment variable
-  EVE_ENABLE_CHRONY=1 is defined. This variable can be setup for each Edge
-  Application through the remote controller. For regulars VMs, the chrony
+  automatically for containers (it can be disabled defining the environment
+  variable EVE_ENABLE_CHRONY=0, this variable can be setup for each Edge
+  Application through the remote controller). For regulars VMs, the chrony
   daemon must be installed and configured to sync the guest's clock with
   the device /dev/ptp0 or /dev/ptp_kvm. The kernel must also support the
   virtual PTP device driver.

--- a/pkg/xen-tools/initrd/init-initrd
+++ b/pkg/xen-tools/initrd/init-initrd
@@ -66,8 +66,6 @@ gw=`cat /proc/cmdline | grep -o '\bgw=[^ ]*' | cut -d = -f 2`
 route=`cat /proc/cmdline | grep -o '\broute=[^ ]*' | cut -d = -f 2`
 pvcalls=`cat /proc/cmdline | grep  'pvcalls=1'`
 dhcp=`cat /proc/cmdline | grep  'dhcp=1'`
-# shellcheck disable=SC2002,SC2006
-chrony=`cat /proc/cmdline | grep 'chrony=1'`
 if test "$pvcalls"
 then
         mkdir -p /mnt/rootfs/etc
@@ -158,8 +156,9 @@ fi
 echo "Run acpid daemon"
 acpid -l /proc/self/fd/1
 
-# Start chrony daemon for clock synchronization through PTP_KVM device
-if test "$chrony" -o "$EVE_ENABLE_CHRONY" = "1"; then
+# Start chrony daemon for clock synchronization through PTP_KVM device,
+# this option is enabled by default
+if [ ! "$EVE_ENABLE_CHRONY" = "0" ]; then
   # PTP_KVM is only available with KVM
   if test -c /dev/ptp0; then
     echo "Starting chrony daemon..." > /dev/kmsg


### PR DESCRIPTION
Enable clock synchronization through PTP_KVM for containers by default, i.e., always run chrony daemon except when explicitly disabled by the EVE_ENABLE_CHRONY=0 variable.