### PR TITLE
Make sure ethernet interface is DOWN before renaming and changing MAC

### DIFF
--- a/pkg/pillar/dpcreconciler/linuxitems/adapter.go
+++ b/pkg/pillar/dpcreconciler/linuxitems/adapter.go
@@ -150,6 +150,15 @@ func (c *AdapterConfigurator) Create(ctx context.Context, item depgraph.Item) er
 		c.Log.Error(err)
 		return err
 	}
+	// Make sure the ethernet interface is DOWN before renaming
+	// and changing the MAC address, otherwise we get error
+	// `Device or resource busy`.
+	if err := netlink.LinkSetDown(link); err != nil {
+		err = fmt.Errorf("netlink.LinkSetDown(%s) failed: %v",
+			adapter.IfName, err)
+		c.Log.Error(err)
+		return err
+	}
 	// Get MAC address and create the alternate with the group bit toggled.
 	macAddr := link.Attrs().HardwareAddr
 	altMacAddr := c.alternativeMAC(link.Attrs().HardwareAddr)
@@ -301,6 +310,15 @@ func (c *AdapterConfigurator) Delete(ctx context.Context, item depgraph.Item) er
 	if err := netlink.LinkDel(bridge); err != nil {
 		err = fmt.Errorf("netlink.LinkDel(%s) failed: %v",
 			adapter.IfName, err)
+		c.Log.Error(err)
+		return err
+	}
+	// Make sure the ethernet interface is DOWN before renaming
+	// and changing the MAC address, otherwise we get error
+	// `Device or resource busy`.
+	if err := netlink.LinkSetDown(kernLink); err != nil {
+		err = fmt.Errorf("netlink.LinkSetDown(%s) failed: %v",
+			kernIfname, err)
 		c.Log.Error(err)
 		return err
 	}


### PR DESCRIPTION
This is a continuation to fix https://github.com/lf-edge/eve/commit/6ffa07f2f2725a5cf428a4d34a9712295623befc

On some devices, we were still encountering the error `Device or resource busy`.
It turned out we had overlooked a few cases where NIM attempted
to change the MAC address while the interface was in the UP state.