### PR TITLE
pkg/pillar: reduce test memory usage

### DIFF
--- a/pkg/pillar/agentlog/agentlog_test.go
+++ b/pkg/pillar/agentlog/agentlog_test.go
@@ -273,9 +273,7 @@ func increaseTotalRandomly(total int64) int64 {
 
 func generateRandomAvgValue() float64 {
 	// Avg is a float of format 0.00 in range [0.00, 100.00]
-	seed := time.Now().UnixNano()
-	r := rand.New(rand.NewSource(seed))
-	return r.Float64() * 100
+	return rand.Float64() * 100
 }
 
 func matchPsiStats(line string) bool {


### PR DESCRIPTION
apparently rand.Seed needs a bit of memory, so better not to call it all the time

Before:
![mem-agentlog profile](https://github.com/user-attachments/assets/92115e1e-2fa6-4c19-8cb6-1d712c7c66e9)


After:
![mem-agentlog profile](https://github.com/user-attachments/assets/9f993f50-e4d3-410b-adb1-477fb55c08c4)
