### PR TITLE
apparmor: allow SWTPM to receive term signal from vTPM

### DIFF
--- a/pkg/apparmor/profiles/usr.bin.swtpm
+++ b/pkg/apparmor/profiles/usr.bin.swtpm
@@ -16,4 +16,6 @@ profile swtpm @{exec_path} {
     # to save/load tpm state for vms.
     owner /persist/swtpm/{,*,**}    rwk,
 
+    # allow swtpm to receive term signal from vtpm
+    signal (receive) set=(term) peer=vtpm,
 }

--- a/pkg/apparmor/profiles/usr.bin.vtpm
+++ b/pkg/apparmor/profiles/usr.bin.vtpm
@@ -23,4 +23,7 @@ profile vtpm @{exec_path} {
 
     # allow executing swtpm
     /usr/bin/swtpm                  Px,
+
+    # allow vtpm to send term signal to swtpm
+    signal (send) peer=swtpm,
 }


### PR DESCRIPTION
In case of VM crash vTPM tries to kill the stalled SWTPM instances to clean up the resources. This change allows vTPM to send term signal to swtpm instances.

This change is minimum, profiles are loaded and working: 
```sh
828b6224-395b-4f15-bdfa-ec108fc4de27:~# eve enter debug
[debug] root@828b6224-395b-4f15-bdfa-ec108fc4de27:/$ apk add apparmor-utils
[debug] root@828b6224-395b-4f15-bdfa-ec108fc4de27:/$ aa-status
apparmor module is loaded.
5 profiles are loaded.
5 profiles are in enforce mode.
   guacd
   ptpm
   swtpm
   tpm2
   vtpm
0 profiles are in complain mode.
0 profiles are in kill mode.
0 profiles are in unconfined mode.
3 processes have profiles defined.
3 processes are in enforce mode.
   /usr/sbin/guacd (1949) guacd
   /usr/bin/ptpm (2181) ptpm
   /usr/bin/vtpm (2180) vtpm
0 processes are in complain mode.
0 processes are unconfined but have a profile defined.
0 processes are in mixed mode.
0 processes are in kill mode.
[debug] root@828b6224-395b-4f15-bdfa-ec108fc4de27:/$
```