### PR TITLE
[13.4-stable] memory-monitor: Fix log files clean up to prevent storage overflow.

### DIFF
--- a/pkg/memory-monitor/src/monitor/memory-monitor-handler.sh
+++ b/pkg/memory-monitor/src/monitor/memory-monitor-handler.sh
@@ -183,10 +183,12 @@ for dir in */; do
   fi
 done
 
+MEMORY_MONITOR_HANDLER_LOG_FILE="memory-monitor-handler.log"
+
 # Remove old archives, do not keep more than 100 MB of archives
 total_size=$(du -s | awk '{print $1}') # Size in KB
 # Subtract the size of the handler log file
-total_size=$((total_size - $(stat -c %s memory-monitor-handler.log) / 1024))
+total_size=$((total_size - $(stat -c %s "$MEMORY_MONITOR_HANDLER_LOG_FILE") / 1024))
 # Subtract the size of the psi.txt file (if it exists) as it size is regulated by the PSICollector
 if [ -f psi.txt ]; then
   total_size=$((total_size - $(stat -c %s psi.txt) / 1024))
@@ -201,5 +203,5 @@ while [ "$total_size" -gt 102400 ]; do
   # Remove the first line from the events.log file: it contains the oldest event info
   sed -i '1d' events.log
   total_size=$(du -s | awk '{print $1}')
-  total_size=$((total_size - $(stat -c %s handler.log) / 1024))
+  total_size=$((total_size - $(stat -c %s "$MEMORY_MONITOR_HANDLER_LOG_FILE") / 1024))
 done


### PR DESCRIPTION
It's a backport of #4331