### PR TITLE
 [13.4-stable] apparmor: allow swtpm to receive term signal from vtpm

### DIFF
--- a/pkg/apparmor/profiles/usr.bin.swtpm
+++ b/pkg/apparmor/profiles/usr.bin.swtpm
@@ -16,4 +16,6 @@ profile swtpm @{exec_path} {
     # to save/load tpm state for vms.
     owner /persist/swtpm/{,*,**}    rwk,
 
+    # allow swtpm to receive term signal from vtpm
+    signal (receive) set=(term) peer=vtpm,
 }

--- a/pkg/apparmor/profiles/usr.bin.vtpm
+++ b/pkg/apparmor/profiles/usr.bin.vtpm
@@ -23,4 +23,7 @@ profile vtpm @{exec_path} {
 
     # allow executing swtpm
     /usr/bin/swtpm                  Px,
+
+    # allow vtpm to send term signal to swtpm
+    signal (send) peer=swtpm,
 }


### PR DESCRIPTION
Backport of https://github.com/lf-edge/eve/pull/4333.