### PR TITLE
add missing dependencies packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -456,26 +456,19 @@ clean:
 $(DOCKERFILE_FROM_CHECKER): $(DOCKERFILE_FROM_CHECKER)
 	make -C $(DOCKERFILE_FROM_CHECKER_DIR)
 
+# this next section checks that the FROM hashes for any image in any dockerfile anywhere here are consistent.
+# For example, one Dockerfile has foo:abc and the next has foo:def, it will flag them.
+# These are the packages that we are ignoring for now
+IGNORE_DOCKERFILE_HASHES_PKGS=bsp-imx vtpm optee-os installer wwan wlan watchdog uefi acrn acrn-kernel u-boot udev xen-tools xen alpine
+IGNORE_DOCKERFILE_HASHES_EVE_TOOLS=bpftrace-compiler
+
+IGNORE_DOCKERFILE_HASHES_PKGS_ARGS=$(foreach pkg,$(IGNORE_DOCKERFILE_HASHES_PKGS),-i pkg/$(pkg)/Dockerfile)
+IGNORE_DOCKERFILE_HASHES_EVE_TOOLS_ARGS=$(foreach tool,$(IGNORE_DOCKERFILE_HASHES_EVE_TOOLS),$(addprefix -i ,$(shell find eve-tools/$(tool) -path '*/vendor' -prune -o -name Dockerfile -print)))
+
 .PHONY: check-docker-hashes-consistency
 check-docker-hashes-consistency: $(DOCKERFILE_FROM_CHECKER)
 	@echo "Checking Dockerfiles for inconsistencies"
-	$(DOCKERFILE_FROM_CHECKER) ./ \
-		-i ./eve-tools/bpftrace-compiler/Dockerfile \
-		-i ./eve-tools/bpftrace-compiler/root/Dockerfile \
-		-i pkg/bsp-imx/Dockerfile \
-		-i pkg/vtpm/Dockerfile \
-		-i pkg/optee-os/Dockerfile \
-		-i pkg/installer/Dockerfile \
-		-i pkg/wwan/Dockerfile \
-		-i pkg/wlan/Dockerfile \
-		-i pkg/watchdog/Dockerfile \
-		-i pkg/uefi/Dockerfile \
-		-i pkg/acrn/Dockerfile \
-		-i pkg/acrn-kernel/Dockerfile \
-		-i pkg/u-boot/Dockerfile \
-		-i pkg/udev/Dockerfile \
-		-i pkg/xen-tools/Dockerfile \
-		-i pkg/xen/Dockerfile
+	$(DOCKERFILE_FROM_CHECKER) ./ $(IGNORE_DOCKERFILE_HASHES_PKGS_ARGS) $(IGNORE_DOCKERFILE_HASHES_EVE_TOOLS_ARGS)
 
 yetus:
 	@echo Running yetus

--- a/pkg/alpine/Dockerfile
+++ b/pkg/alpine/Dockerfile
@@ -1,6 +1,6 @@
 # image was bootstraped using FROM lfedge/eve-alpine-base:fad44e3702708a8d044663a20fd98d933dddb41e AS cache
 # to update please see https://github.com/lf-edge/eve/blob/master/docs/BUILD.md#how-to-update-eve-alpine-package
-FROM lfedge/eve-alpine:82df60e43ab9f8c935584b8c7b4d0a4b0271d608 AS cache
+FROM lfedge/eve-alpine:2ed33236f1eea746532f612d6c4b7779c5da2193 AS cache
 
 ARG ALPINE_VERSION=3.16
 # this is only needed once, when this package

--- a/pkg/alpine/mirrors/3.16/community
+++ b/pkg/alpine/mirrors/3.16/community
@@ -3,7 +3,9 @@ cereal
 cni-plugins
 fio
 fmt
+hwinfo-libs
 hwinfo
+i2c-tools
 i2c-tools-dev
 iw
 json-glib
@@ -53,7 +55,13 @@ tpm2-tss
 tpm2-tss-dev
 tpm2-tss-esys
 tpm2-tss-fapi
+tpm2-tss-mu
 tpm2-tss-rc
 tpm2-tss-sys
+tpm2-tss-tcti-cmd
+tpm2-tss-tcti-device
+tpm2-tss-tcti-mssim
+tpm2-tss-tcti-pcap
+tpm2-tss-tcti-swtpm
 tpm2-tss-tctildr
 yq


### PR DESCRIPTION
Some changes in alpine packaging have caused elements that were in previous packages to be broken out. This adds them in explicitly:

* hwinfo needs hwinfo-libs
* i2c-tools-dev needs i2c-tools
* tpm2-tss-dev needs tpm2-tss-mu and tpm2-tss-tcti-*

This should resolve the issue raised in #4334 specifically [this comment](https://github.com/lf-edge/eve/pull/4334#issuecomment-2405704587)