### PR TITLE
[13.4 stable] App-shared port without DNS server is not necessarily an issue

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -150,6 +150,10 @@ func encodeTestResults(tr types.TestResults) *info.ErrorInfo {
 		errInfo.Severity = info.Severity_SEVERITY_ERROR
 	} else {
 		timestamp = tr.LastSucceeded
+		if tr.HasWarning() {
+			errInfo.Description = tr.LastWarning
+			errInfo.Severity = info.Severity_SEVERITY_WARNING
+		}
 	}
 	if !timestamp.IsZero() {
 		protoTime, err := ptypes.TimestampProto(timestamp)

--- a/pkg/pillar/types/dns.go
+++ b/pkg/pillar/types/dns.go
@@ -116,6 +116,7 @@ func (status DeviceNetworkStatus) LogCreate(logBase *base.LogObject) {
 		// XXX different logobject for a particular port?
 		logObject.CloneAndAddField("ifname", p.IfName).
 			AddField("last-error", p.LastError).
+			AddField("last-warning", p.LastWarning).
 			AddField("last-succeeded", p.LastSucceeded).
 			AddField("last-failed", p.LastFailed).
 			Noticef("DeviceNetworkStatus port create")
@@ -163,16 +164,20 @@ func (status DeviceNetworkStatus) LogModify(logBase *base.LogObject, old interfa
 		if p.HasError() != op.HasError() ||
 			p.LastFailed != op.LastFailed ||
 			p.LastSucceeded != op.LastSucceeded ||
-			p.LastError != op.LastError {
+			p.LastError != op.LastError ||
+			p.LastWarning != op.LastWarning {
 			logData := logObject.CloneAndAddField("ifname", p.IfName).
 				AddField("last-error", p.LastError).
+				AddField("last-warning", p.LastWarning).
 				AddField("last-succeeded", p.LastSucceeded).
 				AddField("last-failed", p.LastFailed).
 				AddField("old-last-error", op.LastError).
+				AddField("old-last-warning", op.LastWarning).
 				AddField("old-last-succeeded", op.LastSucceeded).
 				AddField("old-last-failed", op.LastFailed)
 			if p.HasError() == op.HasError() &&
-				p.LastError == op.LastError {
+				p.LastError == op.LastError &&
+				p.LastWarning == op.LastWarning {
 				// if we have success or the same error again, reduce log level
 				logData.Function("DeviceNetworkStatus port modify")
 			} else {
@@ -194,6 +199,7 @@ func (status DeviceNetworkStatus) LogDelete(logBase *base.LogObject) {
 		// XXX different logobject for a particular port?
 		logObject.CloneAndAddField("ifname", p.IfName).
 			AddField("last-error", p.LastError).
+			AddField("last-warning", p.LastWarning).
 			AddField("last-succeeded", p.LastSucceeded).
 			AddField("last-failed", p.LastFailed).
 			Noticef("DeviceNetworkStatus port delete")

--- a/pkg/pillar/types/dpc.go
+++ b/pkg/pillar/types/dpc.go
@@ -137,12 +137,14 @@ func (config DevicePortConfig) LogCreate(logBase *base.LogObject) {
 		AddField("last-failed", config.LastFailed).
 		AddField("last-succeeded", config.LastSucceeded).
 		AddField("last-error", config.LastError).
+		AddField("last-warning", config.LastWarning).
 		AddField("state", config.State.String()).
 		Noticef("DevicePortConfig create")
 	for _, p := range config.Ports {
 		// XXX different logobject for a particular port?
 		logObject.CloneAndAddField("ifname", p.IfName).
 			AddField("last-error", p.LastError).
+			AddField("last-warning", p.LastWarning).
 			AddField("last-succeeded", p.LastSucceeded).
 			AddField("last-failed", p.LastFailed).
 			Noticef("DevicePortConfig port create")
@@ -162,21 +164,25 @@ func (config DevicePortConfig) LogModify(logBase *base.LogObject, old interface{
 		oldConfig.LastFailed != config.LastFailed ||
 		oldConfig.LastSucceeded != config.LastSucceeded ||
 		oldConfig.LastError != config.LastError ||
+		oldConfig.LastWarning != config.LastWarning ||
 		oldConfig.State != config.State {
 
 		logData := logObject.CloneAndAddField("ports-int64", len(config.Ports)).
 			AddField("last-failed", config.LastFailed).
 			AddField("last-succeeded", config.LastSucceeded).
 			AddField("last-error", config.LastError).
+			AddField("last-warning", config.LastWarning).
 			AddField("state", config.State.String()).
 			AddField("old-ports-int64", len(oldConfig.Ports)).
 			AddField("old-last-failed", oldConfig.LastFailed).
 			AddField("old-last-succeeded", oldConfig.LastSucceeded).
 			AddField("old-last-error", oldConfig.LastError).
+			AddField("old-last-warning", oldConfig.LastWarning).
 			AddField("old-state", oldConfig.State.String())
 		if len(oldConfig.Ports) == len(config.Ports) &&
 			config.LastFailed == oldConfig.LastFailed &&
 			config.LastError == oldConfig.LastError &&
+			config.LastWarning == oldConfig.LastWarning &&
 			oldConfig.State == config.State &&
 			config.LastSucceeded.After(oldConfig.LastFailed) &&
 			oldConfig.LastSucceeded.After(oldConfig.LastFailed) {
@@ -196,16 +202,20 @@ func (config DevicePortConfig) LogModify(logBase *base.LogObject, old interface{
 		if p.HasError() != op.HasError() ||
 			p.LastFailed != op.LastFailed ||
 			p.LastSucceeded != op.LastSucceeded ||
-			p.LastError != op.LastError {
+			p.LastError != op.LastError ||
+			p.LastWarning != op.LastWarning {
 			logData := logObject.CloneAndAddField("ifname", p.IfName).
 				AddField("last-error", p.LastError).
+				AddField("last-warning", p.LastWarning).
 				AddField("last-succeeded", p.LastSucceeded).
 				AddField("last-failed", p.LastFailed).
 				AddField("old-last-error", op.LastError).
+				AddField("old-last-warning", op.LastWarning).
 				AddField("old-last-succeeded", op.LastSucceeded).
 				AddField("old-last-failed", op.LastFailed)
 			if p.HasError() == op.HasError() &&
-				p.LastError == op.LastError {
+				p.LastError == op.LastError &&
+				p.LastWarning == op.LastWarning {
 				// if we have success or the same error again, reduce log level
 				logData.Function("DevicePortConfig port modify")
 			} else {
@@ -223,12 +233,14 @@ func (config DevicePortConfig) LogDelete(logBase *base.LogObject) {
 		AddField("last-failed", config.LastFailed).
 		AddField("last-succeeded", config.LastSucceeded).
 		AddField("last-error", config.LastError).
+		AddField("last-warning", config.LastWarning).
 		AddField("state", config.State.String()).
 		Noticef("DevicePortConfig delete")
 	for _, p := range config.Ports {
 		// XXX different logobject for a particular port?
 		logObject.CloneAndAddField("ifname", p.IfName).
 			AddField("last-error", p.LastError).
+			AddField("last-warning", p.LastWarning).
 			AddField("last-succeeded", p.LastSucceeded).
 			AddField("last-failed", p.LastFailed).
 			Noticef("DevicePortConfig port delete")


### PR DESCRIPTION
Not having DNS servers configured (while link is OK and IP address is assigned), is not necessarily a failure for an app-shared interface. Some applications might not require DNS for external hostnames and may only use internal DNS servers to resolve the names of other apps running on the same device. However, we should still issue a warning about this potential issue.

Signed-off-by: Milan Lenco <milan@zededa.com>
(cherry picked from commit e7bb2302a8214cf5e6097bb212ca9f5636e6c29d)