### PR TITLE
Set WType even for wireless ports without network config

### DIFF
--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -1362,6 +1362,17 @@ func parseOneSystemAdapterConfig(getconfigCtx *getconfigContext,
 		log.Errorf("parseSystemAdapterConfig: %s", errStr)
 		port.RecordFailure(errStr)
 	}
+	// Make sure that even without wireless network config attached,
+	// EVE microservices properly recognize wireless network ports
+	// using the WType attribute.
+	if port.WirelessCfg.IsEmpty() && phyio != nil {
+		switch phyio.Ptype {
+		case zevecommon.PhyIoType_PhyIoNetWLAN:
+			port.WirelessCfg.WType = types.WirelessTypeWifi
+		case zevecommon.PhyIoType_PhyIoNetWWAN:
+			port.WirelessCfg.WType = types.WirelessTypeCellular
+		}
+	}
 	ports = append(ports, port)
 	return ports, nil // there can still be error recorded inside individual ports
 }

--- a/pkg/pillar/dpcmanager/verify.go
+++ b/pkg/pillar/dpcmanager/verify.go
@@ -604,14 +604,15 @@ func (m *DpcManager) waitForWwanUpdate() bool {
 	if dpc == nil {
 		return false
 	}
-	var hasMgmtWwan bool
+	var hasUsedMgmtWwan bool
 	for _, port := range dpc.Ports {
-		if port.IsMgmt && port.WirelessCfg.WType == types.WirelessTypeCellular {
-			hasMgmtWwan = true
+		if port.IsMgmt && port.WirelessCfg.WType == types.WirelessTypeCellular &&
+			!port.WirelessCfg.IsEmpty() {
+			hasUsedMgmtWwan = true
 			break
 		}
 	}
-	if !hasMgmtWwan {
+	if !hasUsedMgmtWwan {
 		return false
 	}
 	statusIsUpToDate := dpc.Key == m.wwanStatus.DPCKey &&

--- a/pkg/pillar/dpcreconciler/linux.go
+++ b/pkg/pillar/dpcreconciler/linux.go
@@ -1365,7 +1365,8 @@ func (r *LinuxDpcReconciler) getIntendedWlanConfig(
 	dpc types.DevicePortConfig, radioSilence types.RadioSilence) dg.Item {
 	var wifiPort *types.NetworkPortConfig
 	for _, portCfg := range dpc.Ports {
-		if portCfg.WirelessCfg.WType == types.WirelessTypeWifi {
+		if portCfg.WirelessCfg.WType == types.WirelessTypeWifi &&
+			!portCfg.WirelessCfg.IsEmpty() {
 			wifiPort = &portCfg
 			break
 		}
@@ -1457,7 +1458,8 @@ func (r *LinuxDpcReconciler) getIntendedWwanConfig(dpc types.DevicePortConfig,
 		if port.InvalidConfig {
 			continue
 		}
-		if port.WirelessCfg.WType != types.WirelessTypeCellular {
+		if port.WirelessCfg.WType != types.WirelessTypeCellular ||
+			port.WirelessCfg.IsEmpty() {
 			continue
 		}
 		if !aa.Initialized {

--- a/pkg/pillar/types/dpc.go
+++ b/pkg/pillar/types/dpc.go
@@ -750,6 +750,18 @@ type WirelessConfig struct {
 	Cellular []DeprecatedCellConfig
 }
 
+// IsEmpty returns true if the wireless config is empty.
+func (wc WirelessConfig) IsEmpty() bool {
+	switch wc.WType {
+	case WirelessTypeWifi:
+		return len(wc.Wifi) == 0
+	case WirelessTypeCellular:
+		return len(wc.CellularV2.AccessPoints) == 0 &&
+			len(wc.Cellular) == 0
+	}
+	return true
+}
+
 // WifiConfig - Wifi structure
 type WifiConfig struct {
 	SSID      string            // wifi SSID


### PR DESCRIPTION
nim, zedrouter and other microservices depend on the `WType` port attribute to recognize wireless network port. This is needed even in cases where the wireless adapter is not really used and has no network config attached. Otherwise, we may get to situation where we try to bridge a wireless adapter or perform some other invalid operation, especially after the switch NI enhancements done in: 7a6981ba729e0802bd1c3cb2b8da3ec2b93b8ae7

In the case wireless config is not present, we can get the physical port type from the device model and set `WType` accordingly.

Marking as stable, will need to backport this to 13.4. For older LTS versions, this is not necessary, no serious problem is reachable when `WType` is unset.