### PR TITLE
Still more packages missing from alpine

### DIFF
--- a/pkg/alpine/Dockerfile
+++ b/pkg/alpine/Dockerfile
@@ -1,6 +1,6 @@
 # image was bootstraped using FROM lfedge/eve-alpine-base:fad44e3702708a8d044663a20fd98d933dddb41e AS cache
 # to update please see https://github.com/lf-edge/eve/blob/master/docs/BUILD.md#how-to-update-eve-alpine-package
-FROM lfedge/eve-alpine:c114cf1d3ea51534f061f9aa949beb6ac5c12fb3 AS cache
+FROM lfedge/eve-alpine:43c5a193374e44350e27fad7ad6fe28a929109b5 AS cache
 
 ARG ALPINE_VERSION=3.16
 # this is only needed once, when this package

--- a/pkg/alpine/mirrors/3.16/community
+++ b/pkg/alpine/mirrors/3.16/community
@@ -10,8 +10,10 @@ i2c-tools-dev
 iw
 json-glib
 json-glib-dev
+libbpf
 libbpf-dev
 libgudev-dev
+libproc
 librados
 librbd
 libtss2-tcti-armbd

--- a/pkg/alpine/mirrors/3.16/main
+++ b/pkg/alpine/mirrors/3.16/main
@@ -70,6 +70,7 @@ gtest-dev
 gtk-doc
 hdparm
 iasl
+ifupdown-ng
 installkernel
 ip6tables
 ip6tables-openrc


### PR DESCRIPTION
This time packages that were split in two, needed for bpftrace, kube, debug

I tested each and every `pkg/*` installation of alpine packages, and now none complains.
Let's get this in, then we can finally get #4348 going.