### PR TITLE
Enhance memory-monitor with improved logging, cleanup, and task handling

### DIFF
--- a/pkg/memory-monitor/src/monitor/config.h
+++ b/pkg/memory-monitor/src/monitor/config.h
@@ -12,6 +12,7 @@
 
 #define HANDLER_SCRIPT "memory-monitor-handler.sh"
 
+// The paths here should correspond to the paths in src/monitor/memory-monitor-handler.sh
 #define LOG_DIR             "output"
 #define EVENT_LOG_FILE      "events.log"
 #define HANDLER_LOG_FILE    "memory-monitor-handler.log"

--- a/pkg/memory-monitor/src/monitor/memory-monitor-handler.sh
+++ b/pkg/memory-monitor/src/monitor/memory-monitor-handler.sh
@@ -11,23 +11,11 @@ find_pids_of_cgroup() {
     path=$1
     tempfile=$2
 
-    # Get a copy of the list of tasks in the cgroup, not to block the cgroup while handling
-    tmp_tasks=$(mktemp)
-    cat "$path"/tasks > "$tmp_tasks"
-
-    # List all tasks, filter out unique PIDs
-    while read -r tid; do
-      if [ -z "$tid" ]; then
-        continue
-      fi
-      # Find the main PID for each TID
-      pid=$(awk '/^Tgid:/ {print $2}' "/proc/$tid/status" 2>/dev/null)
-      if [ -n "$pid" ]; then
+    # Get the PIDs of the cgroup
+    pids=$(cat "$path"/cgroup.procs)
+    for pid in $pids; do
         echo "$pid" >> "$tempfile"
-      fi
-    done < "$tmp_tasks"
-
-    rm "$tmp_tasks"
+    done
 
     # Recurse into subdirectories
     for subdir in "$path"/*/; do

--- a/pkg/memory-monitor/src/monitor/monitor.c
+++ b/pkg/memory-monitor/src/monitor/monitor.c
@@ -162,6 +162,15 @@ int run_handler(const char *script_name, const char *event_msg) {
                 pthread_mutex_unlock(&handler_mutex);
                 return 1;
             }
+        } else {
+            // If the status is not 0, print several lines from the end of the log file
+            char *tail = get_tail(LOG_DIR "/" HANDLER_LOG_FILE, 10);
+            if (tail != NULL) {
+                syslog(LOG_ERR, "Handler script output (last 10 lines):\n%s\n", tail);
+                free(tail);
+            } else {
+                syslog(LOG_ERR, "Failed to read the handler log file\n");
+            }
         }
     } else {
         syslog(LOG_INFO, "Handler script exited abnormally by signal %d\n", WTERMSIG(status));

--- a/pkg/memory-monitor/src/monitor/util.h
+++ b/pkg/memory-monitor/src/monitor/util.h
@@ -36,5 +36,6 @@ int get_eve_release(char *eve_release);
 void log_event(const time_t *t, const char *format, ...);
 long strtodec(const char *str, bool *error);
 unsigned long strtoudec(const char *str, bool *error);
+char* get_tail(const char *file_path, size_t lines);
 
 #endif //MM_UTILS_H


### PR DESCRIPTION
This PR includes multiple improvements to the memory-monitor script for better reliability, efficiency, and visibility:

* Reliable file cleanup:
Moved the file cleanup process to an exit handler to ensure it runs even when the script encounters errors. This ensures that temporary files are always removed and archives are properly maintained under 100 MB.

* Enhanced error logging:
Added functionality to log the last 10 lines of the handler script to syslog when it fails, making error diagnosis easier and ensuring logs are accessible via aggregation tools.

* Simplified task handling:
Refactored the cgroup PID retrieval process by directly reading from `cgroup.procs`, eliminating unnecessary temporary file creation and streamlining the code.