### PR TITLE
[13.4-stable] fix: update lts-release.sh to create the lts tag from the latest rc tag

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -47,7 +47,7 @@ jobs:
           # if the default server is responding -- we can skip apt update
           $APT_INSTALL || { sudo apt update && $APT_INSTALL ; }
           echo "ARCH=${{ matrix.arch }}" >> "$GITHUB_ENV"
-          echo "TAG=$(git describe --always --tags | grep -E '[0-9]+\.[0-9]+\.[0-9]+-(lts|rc[0-9]+)' || echo snapshot)" >> "$GITHUB_ENV"
+          echo "TAG=$(git describe --always --tags | grep -E '[0-9]+\.[0-9]+\.[0-9]' || echo snapshot)" >> "$GITHUB_ENV"
       - name: ensure clean assets directory
         run: |
           rm -rf assets && mkdir -p assets

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,7 @@ on:  # yamllint disable-line rule:truthy
       - '**/*.md'
       - '.github/**'
     tags:
-      - "[0-9]+.[0-9]+.[0-9]+"
-      - "[0-9]+.[0-9]+.[0-9]+-lts"
+      - "[0-9]+\\.[0-9]+\\.[0-9]+"
 
 jobs:
   packages:

--- a/Makefile
+++ b/Makefile
@@ -887,20 +887,11 @@ bump-eve-api:
 
 .PHONY: proto-api-%
 
-check-patch-%:
-	@if ! echo $* | grep -Eq '^[0-9]+\.[0-9]+$$'; then echo "ERROR: must be on a release branch X.Y"; exit 1; fi
-	@if ! echo $(EVE_TREE_TAG) | grep -Eq '^$*.[0-9]+-'; then echo "ERROR: can't find previous release's tag X.Y.Z"; exit 1; fi
+rc-release:
+	./tools/rc-release.sh
 
-patch-%: check-patch-%
-	@$(eval PATCH_TAG:=$*.$(shell echo $$((`echo $(EVE_TREE_TAG) | sed -e 's#-.*$$##' | cut -f3 -d.` + 1))))
-
-patch-%-stable: patch-%
-	@$(eval PATCH_TAG:=$(PATCH_TAG)-lts)
-
-patch: patch-$(REPO_BRANCH)
-	@git tag -a -m"Release $(PATCH_TAG)" $(PATCH_TAG)
-	@echo "Done tagging $(PATCH_TAG) patch release. Check the branch with git log and then run"
-	@echo "  git push origin $(REPO_BRANCH) $(PATCH_TAG)"
+lts-release:
+	./tools/lts-release.sh
 
 release:
 	@bail() { echo "ERROR: $$@" ; exit 1 ; } ;\
@@ -1077,7 +1068,12 @@ help:
 	@echo "   test-profiling run pillar tests with memory profiler"
 	@echo "   clean          clean build artifacts in a current directory (doesn't clean Docker)"
 	@echo "   release        prepare branch for a release (VERSION=x.y.z required)"
-	@echo "   patch          make a patch release on a current branch (must be a release branch)"
+	@echo "   rc-release     make a rc release on a current branch (must be a release branch)"
+	@echo "                  If the latest lts tag is 14.4.0 then running make rc-release will"
+	@echo "                  create 14.4.0-rc1 tag and if the latest tag is 14.4.1-lts then"
+	@echo "   lts-release    make a lts release on a current branch (must be a release branch)"
+	@echo "                  If the latest lts tag is 14.4.0-lts then running make lts-release
+	@echo "                  will create a new lts release 14.4.1-lts"
 	@echo "   proto          generates Go and Python source from protobuf API definitions"
 	@echo "   proto-vendor   update vendored API in packages that require it (e.g. pkg/pillar)"
 	@echo "   shell          drop into docker container setup for Go development"

--- a/tools/lts-release.sh
+++ b/tools/lts-release.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+#
+# Copyright (c) 2024 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Get the current branch
+git_branch=$(git rev-parse --abbrev-ref HEAD | tr / _)
+
+# Get the latest tag from the specified branch
+latest_tag=$(git describe --tags --abbrev=0 "$git_branch")
+
+echo "Latest tag: $latest_tag"
+
+# Check if the input is a valid release branch in the format X.Y (e.g., 1.2)
+check_release_branch() {
+    if ! echo "${git_branch}" | grep -Eq "^[0-9]+\.[0-9]+(-[a-zA-Z]+)?$"; then
+        echo "ERROR: must be on a release branch X.Y"
+        exit 1
+    fi
+}
+
+# Validate if the latest tag is a valid release tag (e.g., X.Y.Z or X.Y.Z-<suffix>)
+check_tag() {
+    if ! echo "${latest_tag}" | grep -Eq "^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$"; then
+        echo "ERROR: can't find previous release's tag X.Y.Z"
+        exit 1
+    fi
+}
+
+# Function to check if the latest tag is an RC tag
+is_rc_tag() {
+    if echo "${latest_tag}" | grep -Eq "^[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$"; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Function to increment the patch version
+increment_patch_version() {
+    local version=$1
+    local major minor patch
+    IFS='.' read -r major minor patch <<< "$version"
+    patch=$((patch + 1))
+    echo "$major.$minor.$patch"
+}
+
+# Perform release branch validation
+check_release_branch
+
+# Perform tag validation
+check_tag
+
+# If the latest tag is an RC tag
+if is_rc_tag; then
+    # Extract the base version (remove the -rc suffix)
+    base_version="${latest_tag%-rc*}"
+    new_tag="${base_version}-lts"
+    echo "Creating LTS tag: $new_tag from the commit of $latest_tag"
+    # Create the LTS tag from the commit of the RC release
+    if git tag -a "$new_tag" "$latest_tag" -m "Release $new_tag"; then
+        echo "Tagged new version: $new_tag"
+        echo "Now, push the tag to the remote repository using:"
+        echo "git push origin $git_branch $new_tag"
+    else
+        echo "Error: Failed to create the new LTS tag."
+        exit 1
+    fi
+else
+    # If the latest tag is not an RC tag
+    echo "Latest tag is not an RC tag. Incrementing the patch version."
+    # Increment the patch version
+    new_version=$(increment_patch_version "$latest_tag")
+    new_tag="${new_version}-lts"
+    echo "Creating LTS tag: $new_tag from the latest non-RC tag"
+    # Create the LTS tag from the latest non-RC release
+    if git tag -a "$new_tag" -m "Release $new_tag"; then
+        echo "Tagged new version: $new_tag"
+        echo "Now, push the tag to the remote repository using:"
+        echo "git push origin $git_branch $new_tag"
+    else
+        echo "Error: Failed to create the new LTS tag."
+        exit 1
+    fi
+fi

--- a/tools/rc-release.sh
+++ b/tools/rc-release.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+#
+# Copyright (c) 2024 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Get the current branch and replace slashes with underscores
+git_branch=$(git rev-parse --abbrev-ref HEAD | tr / _)
+
+# Get the latest tag from the specified branch
+latest_tag=$(git describe --tags --abbrev=0 "$git_branch")
+
+# Check if the input is a valid release branch in the format X.Y (e.g., 1.2)
+check_release_branch() {
+    if ! echo "${git_branch}" | grep -Eq "^[0-9]+\.[0-9]+(-[a-zA-Z]+)?$"; then
+        echo "ERROR: must be on a release branch X.Y"
+        exit 1
+    fi
+}
+
+# Check if the latest tag follows the format X.Y.Z
+check_tag() {
+    if ! echo "${latest_tag}" | grep -Eq "^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$"; then
+        echo "ERROR: can't find previous release's tag X.Y.Z"
+        exit 1
+    fi
+}
+
+# Function to increment the numeric part of a version
+increment_version() {
+    local version=$1
+    local base=${version%-*}   # Get the base version (e.g., 12.0.4 from 12.0.4-lts)
+    local suffix=${version##*-} # Get the suffix (e.g., lts or rc1)
+
+    if [[ $suffix == "$version" ]]; then
+        suffix=""  # No suffix
+    fi
+
+    if [[ $suffix == "lts" ]]; then
+        # If the suffix is lts, increment the base version and add -rc1
+        IFS='.' read -r major minor patch <<< "$base"
+        patch=$((patch + 1))
+        echo "$major.$minor.$patch-rc1"
+    elif [[ $suffix == rc* ]]; then
+        # If the suffix is rc, increment the rc number
+        local rc_number=${suffix#rc}  # Get the number after rc
+        rc_number=$((rc_number + 1))
+        echo "$base-rc$rc_number"
+    else
+        # If no suffix or unknown suffix, start with rc1
+        echo "$base-rc1"
+    fi
+}
+
+# Validate the new tag name
+validate_tag_name() {
+    # Updated regex to match '12.0.5', '12.0.5-lts', '12.0.5-rc1', etc.
+    if [[ ! "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z]+[0-9]*)?$ ]]; then
+        echo "ERROR: '$1' is not a valid tag name."
+        exit 1
+    fi
+}
+
+# Check if a tag is fetched
+if [[ -z $latest_tag ]]; then
+    # If no latest tag is found, assume we're starting fresh and create the first rc0 tag
+    echo "No tags found in the repository. Starting with version 0.0.0-rc0."
+    new_version="0.0.0-rc0"
+else
+    # Increment the version according to the rules
+    check_release_branch
+    check_tag
+    new_version=$(increment_version "$latest_tag")
+fi
+
+validate_tag_name "$new_version"
+
+echo "Creating RC release: '${new_version}'"
+
+# Create a new tag and check if the command succeeds
+if ! git tag -a -m "Release ${new_version}" "${new_version}"; then
+    echo "Error: Failed to create a new tag."
+    exit 1
+fi
+
+echo "Tagged new version: $new_version. Please push the tag to the remote repository"
+
+echo "git push origin $git_branch $new_version"


### PR DESCRIPTION
feat: Add scripts and Makefile targets for RC and LTS releases

In accordance with the testing team's requirement to create a release
candidate (RC) before releasing the LTS version of Eve for certification.

These scripts automate the creation of RC and LTS releases by calculating
the version number based on the latest tag and incrementing it accordingly.

PR to master: https://github.com/lf-edge/eve/pull/4323

Signed-off-by: yash-zededa <yash@zededa.com>

(cherry picked from commit https://github.com/lf-edge/eve/commit/b20a9db0957accfc20390b98144e898c474c4517)