### PR TITLE
Add hv:kubevirt platform:generic arch:amd64 to builds.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: [arm64, amd64]
-        hv: [xen, kvm]
+        hv: [xen, kvm, kubevirt]
         platform: ["generic"]
         include:
           - arch: riscv64
@@ -108,6 +108,10 @@ jobs:
           - arch: arm64
             hv: kvm
             platform: "imx8mp_epc_r3720"
+        exclude:
+          - arch: arm64
+            hv: kubevirt
+            platform: "generic"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Multus, cdi, longhorn support arm64 but k8s kubevirt does not have release builds yet.

Just start building for now to help minimize regressions, publishing will start later when the bulk of PRs get merged.