### PR TITLE
[13.4-stable] Include ZFS in installer

### DIFF
--- a/images/installer.yml.in
+++ b/images/installer.yml.in
@@ -9,6 +9,7 @@ init:
   - linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
   - linuxkit/memlogd:1ded209c4cc10aa8de2099f4156164b59df14e3c
   - GRUB_TAG
+  - DOM0ZTOOLS_TAG
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee


### PR DESCRIPTION
Needed for ZFS vault, HV=kubevirt

Signed-off-by: Andrew Durbin <andrewd@zededa.com>
(cherry picked from commit 472daeecbfe53a3431c70a6df9c689c296a936d9)

Backport of #4362 