### PR TITLE
fix: update lts-release.sh to create the lts tag from the latest rc tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1072,7 +1072,7 @@ help:
 	@echo "                  If the latest lts tag is 14.4.0 then running make rc-release will"
 	@echo "                  create 14.4.0-rc1 tag and if the latest tag is 14.4.1-lts then"
 	@echo "   lts-release    make a lts release on a current branch (must be a release branch)"
-	@echo "                  If the latest lts tag is 14.4.0-lts then running make lts-release
+	@echo "                  If the latest lts tag is 14.4.0-lts then running make lts-release"
 	@echo "                  will create a new lts release 14.4.1-lts"
 	@echo "   proto          generates Go and Python source from protobuf API definitions"
 	@echo "   proto-vendor   update vendored API in packages that require it (e.g. pkg/pillar)"


### PR DESCRIPTION
fix: added the missing quotation for the lts-release help target

The help target in the stable branch was missing the quotation for the lts-release target. This commit adds the missing quotation.

This change only applies to the stable branch; no issues were found in the master.

Original PR to master: https://github.com/lf-edge/eve/pull/4323