### PR TITLE
[13.4-stable] memory-monitor: Restore output limit to 100 MB after refactor mistake.

### DIFF
--- a/pkg/memory-monitor/src/monitor/memory-monitor-handler.sh
+++ b/pkg/memory-monitor/src/monitor/memory-monitor-handler.sh
@@ -11,7 +11,7 @@ MEMORY_MONITOR_HANDLER_LOG_FILE="memory-monitor-handler.log"
 EVENT_LOG_FILE="events.log"
 PSI_FILE="psi.txt"
 
-MAX_OUTPUT_SIZE_MB=1 # 100 MB
+MAX_OUTPUT_SIZE_MB=100 # 100 MB
 MAX_OUTPUT_SIZE_KB=$((MAX_OUTPUT_SIZE_MB * 1024))
 
 tar_old_output() {


### PR DESCRIPTION
It's a backport of #4372 

Reverted the `MAX_OUTPUT_SIZE_MB` value back to 100 MB after mistakenly reducing it to 1 MB during a refactor of the cleanup function. This change ensures the output limit is appropriate for handling multiple runs of the script.

Signed-off-by: Nikolay Martyanov <nikolay@zededa.com>
(cherry picked from commit 6900ef1c191f2b54581e50d96cb22496bea1c922)