### PR TITLE
Fix an issue in Edgeview not getting App interface IP address

### DIFF
--- a/pkg/edgeview/go.mod
+++ b/pkg/edgeview/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/lf-edge/eve-api/go v0.0.0-20240829123634-7c8ebda876ff
-	github.com/lf-edge/eve/pkg/pillar v0.0.0-20240808182004-78201574b04a
+	github.com/lf-edge/eve/pkg/pillar v0.0.0-20241011162601-efd973923722
 	github.com/satori/go.uuid v1.2.1-0.20180404165556-75cca531ea76
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/sirupsen/logrus v1.9.3

--- a/pkg/edgeview/go.sum
+++ b/pkg/edgeview/go.sum
@@ -41,8 +41,8 @@ github.com/lf-edge/eve-api/go v0.0.0-20240829123634-7c8ebda876ff h1:3uGTOvWQFQkI
 github.com/lf-edge/eve-api/go v0.0.0-20240829123634-7c8ebda876ff/go.mod h1:ot6MhAhBXapUDl/hXklaX4kY88T3uC4PTg0D2wD8DzA=
 github.com/lf-edge/eve/pkg/kube/cnirpc v0.0.0-20240315102754-0f6d1f182e0d h1:tUBb9M6u42LXwHAYHyh22wJeUUQlTpDkXwRXalpRqbo=
 github.com/lf-edge/eve/pkg/kube/cnirpc v0.0.0-20240315102754-0f6d1f182e0d/go.mod h1:Nn3juMJJ1G8dyHOebdZyS4jOB/fuxAd5fIajBaWjHr8=
-github.com/lf-edge/eve/pkg/pillar v0.0.0-20240808182004-78201574b04a h1:zFoed+ALAI+Tl2Q56NDSDd8ds85r9ouP3ICvznPg9Kk=
-github.com/lf-edge/eve/pkg/pillar v0.0.0-20240808182004-78201574b04a/go.mod h1:OY0o5/pdM7twlZ/MvkDKb2ChoSYpl1+vDuH1GxDXKEQ=
+github.com/lf-edge/eve/pkg/pillar v0.0.0-20241011162601-efd973923722 h1:wy0+46dsTULgAqVMmumzT1i2HVSMXSWeT76DuR+Il0M=
+github.com/lf-edge/eve/pkg/pillar v0.0.0-20241011162601-efd973923722/go.mod h1:5zB+wlsiTBE2N/Jb0Zr7DaUJMG2OCcAP6X+dyftIdzo=
 github.com/miekg/dns v1.1.27/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
 github.com/miekg/dns v1.1.43 h1:JKfpVSCB84vrAmHzyrsxB5NAr5kLoMXZArPSw7Qlgyg=
 github.com/miekg/dns v1.1.43/go.mod h1:+evo5L0630/F6ca/Z9+GAqzhjGyn8/c+TBaOyfEl0V4=

--- a/pkg/edgeview/src/network.go
+++ b/pkg/edgeview/src/network.go
@@ -187,7 +187,7 @@ func doAppNet(status, appstr string, isSummary bool) string {
 		}
 
 		fmt.Printf("\n = bridge: %s, VIF: %s, VIF IP: %v, VIF MAC: %s\n",
-			item.Bridge, item.Vif, item.AllocatedIPv4Addr, item.Mac)
+			item.Bridge, item.Vif, item.AssignedAddresses.IPv4Addrs, item.Mac)
 
 		for _, portLL := range niStatus.Ports {
 			var portIPs []net.IP
@@ -205,23 +205,18 @@ func doAppNet(status, appstr string, isSummary bool) string {
 			continue
 		}
 
-		var appIP string
-		if item.AllocatedIPv4Addr != nil {
-			appIP = item.AllocatedIPv4Addr.String()
+		var appIP []string
+		for _, assignedip := range item.AssignedAddresses.IPv4Addrs {
+			appIP = append(appIP, assignedip.Address.String())
 		}
 		appMAC := item.Mac.String()
 
-		if appIP != "" {
-			printColor("\n - ping app ip address: "+appIP, colorRED)
-			pingIPHost(appIP, "")
+		if len(appIP) > 0 {
+			joinedAppIPs := strings.Join(appIP, ", ")
+			printColor("\n - ping app ip address: "+joinedAppIPs, colorRED)
 		}
 
 		if niStatus.Type != types.NetworkInstanceTypeSwitch {
-			if appIP != "" {
-				printColor("\n - check open ports for "+appIP, colorRED)
-				// TODO: nmap package
-			}
-
 			files, err := listRecursiveFiles("/run/zedrouter", ".inet")
 			if err == nil {
 				printColor("\n - dhcp host file:\n", colorGREEN)
@@ -255,8 +250,10 @@ func doAppNet(status, appstr string, isSummary bool) string {
 				}
 			}
 
-			if appIP != "" {
-				getAppNetTable(appIP, &niStatus)
+			if len(appIP) > 0 {
+				for _, ip := range appIP {
+					getAppNetTable(ip, &niStatus)
+				}
 			}
 		}
 
@@ -555,8 +552,8 @@ func getAppIPs(status string) ([]string, uuid.UUID) {
 	var appIPs []string
 	appUUID := appStatus.UUIDandVersion.UUID
 	for _, item := range appStatus.AppNetAdapterList {
-		if item.AllocatedIPv4Addr != nil {
-			appIPs = append(appIPs, item.AllocatedIPv4Addr.String())
+		for _, assignedip := range item.AssignedAddresses.IPv4Addrs {
+			appIPs = append(appIPs, assignedip.Address.String())
 		}
 	}
 	return appIPs, appUUID


### PR DESCRIPTION
- due to the change of multiple port in zedrouter, the AppNetAdapterList.AllocatedIPv4Addr was changed to AssignedAddresses, do the same change
- update the vendor files for pkg/pillar in pkg/edgeview

Signed-off-by: Naiming Shen <naiming@zededa.com>
(cherry picked from commit a54bfb3c0c119bc62e65b94c7a4deccc64c45a63)