### PR TITLE
Update Eden verison to 0.9.13 and set debug log level for eden test workflows

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -113,17 +113,18 @@ jobs:
         hv: [kvm]
         platform: ["generic"]
     if: github.event.review.state == 'approved'
-    uses: lf-edge/eden/.github/workflows/test.yml@0.9.12
+    uses: lf-edge/eden/.github/workflows/test.yml@0.9.13
     secrets: inherit
     with:
       eve_image: "evebuild/pr:${{ github.event.pull_request.number  }}"
+      eve_log_level: "debug"
       eve_artifact_name: eve-${{ matrix.hv }}-${{ matrix.arch }}-${{ matrix.platform }}
       artifact_run_id: ${{ needs.get_run_id.outputs.run_id }}
       eden_version: "0.9.12"
 
   test_suite_master:
     if: github.ref == 'refs/heads/master'
-    uses: lf-edge/eden/.github/workflows/test.yml@0.9.12
+    uses: lf-edge/eden/.github/workflows/test.yml@0.9.13
     secrets: inherit
     with:
       eve_image: "lfedge/eve:snapshot"
@@ -131,7 +132,7 @@ jobs:
 
   test_suite_tag:
     if: startsWith(github.ref, 'refs/tags')
-    uses: lf-edge/eden/.github/workflows/test.yml@0.9.12
+    uses: lf-edge/eden/.github/workflows/test.yml@0.9.13
     secrets: inherit
     with:
       eve_image: "lfedge/eve:${{ github.ref_name }}"


### PR DESCRIPTION
Update the eden test workflows to 0.9.13 and use the [new feature to set the EVE log level](https://github.com/lf-edge/eden/pull/1033) to debug. This will allow us to get more information from EVE for debugging failed tests.