### PR TITLE
Fix: tty not found error for COM passthrough

### DIFF
--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -399,11 +399,7 @@ const qemuPciPassthruTemplate = `
 `
 const qemuSerialTemplate = `
 [chardev "charserial-usr{{.ID}}"]
-{{- if eq .Machine "virt"}}
   backend = "serial"
-{{- else}}
-  backend = "tty"
-{{- end}}
   path = "{{.SerialPortName}}"
 
 [device "serial-usr{{.ID}}"]

--- a/pkg/pillar/hypervisor/kvm_test.go
+++ b/pkg/pillar/hypervisor/kvm_test.go
@@ -353,7 +353,7 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
   addr = "0x0"
 
 [chardev "charserial-usr0"]
-  backend = "tty"
+  backend = "serial"
   path = "/dev/ttyS0"
 
 [device "serial-usr0"]
@@ -639,7 +639,7 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
   addr = "0x0"
 
 [chardev "charserial-usr0"]
-  backend = "tty"
+  backend = "serial"
   path = "/dev/ttyS0"
 
 [device "serial-usr0"]
@@ -1704,7 +1704,7 @@ func domConfigAmd64FML() string {
   bus = "pci.11"
   addr = "0x0"
 [chardev "charserial-usr0"]
-  backend = "tty"
+  backend = "serial"
   path = "/dev/ttyS0"
 
 [device "serial-usr0"]
@@ -1992,7 +1992,7 @@ func domConfigAmd64Legacy() string {
   bus = "pci.10"
   addr = "0x0"
 [chardev "charserial-usr0"]
-  backend = "tty"
+  backend = "serial"
   path = "/dev/ttyS0"
 
 [device "serial-usr0"]
@@ -2276,7 +2276,7 @@ func domConfigAmd64() string {
   bus = "pci.10"
   addr = "0x0"
 [chardev "charserial-usr0"]
-  backend = "tty"
+  backend = "serial"
   path = "/dev/ttyS0"
 
 [device "serial-usr0"]
@@ -2562,7 +2562,7 @@ func domConfigContainerVNC() string {
   bus = "pci.9"
   addr = "0x0"
 [chardev "charserial-usr0"]
-  backend = "tty"
+  backend = "serial"
   path = "/dev/ttyS0"
 
 [device "serial-usr0"]

--- a/pkg/xen-tools/Dockerfile
+++ b/pkg/xen-tools/Dockerfile
@@ -27,7 +27,7 @@ ENV BUILD_PKGS \
     pixman-dev libaio-dev yajl-dev argp-standalone \
     linux-headers git patch texinfo tar libcap-ng-dev \
     attr-dev flex bison cmake libusb-dev zstd-dev \
-    python3 build-base ninja gnutls-dev
+    python3 build-base ninja gnutls-dev agetty
 
 ENV BUILD_PKGS_arm64 dtc-dev
 


### PR DESCRIPTION
Adding agetty in build pkgs xen-tools/Dockerfile to fix "tty not found" error