### PR TITLE
fix: update regex in Makefile to correctly handle rc and lts tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ endif
 REPO_BRANCH=$(shell git rev-parse --abbrev-ref HEAD | tr / _)
 REPO_SHA=$(shell git describe --match '$$^' --abbrev=8 --always --dirty)
 # set this variable to the current tag only if we are building from a tag (annotated or not), otherwise set it to "snapshot", which means rootfs version will be constructed differently
-REPO_TAG=$(shell git describe --always --tags | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$$' || echo snapshot)
+REPO_TAG=$(shell git describe --always --tags | grep -E '^[0-9]+\.[0-9]+\.[0-9]+(-lts|-rc[0-9]+)?$$' || echo snapshot)
 REPO_DIRTY_TAG=$(if $(findstring -dirty,$(REPO_SHA)),-$(shell date -u +"%Y-%m-%d.%H.%M"))
 EVE_TREE_TAG = $(shell git describe --abbrev=8 --always --dirty --tags)
 


### PR DESCRIPTION
We ran into an issue with the [13.4.0-rc2 actions](https://github.com/lf-edge/eve/actions/runs/11444302145) where the Docker images were pushed to Docker Hub with the wrong names. This misnaming occurred during the image push process, leading to a failure in the associated assets. Because the images had incorrect names, the assets couldn't be properly linked or utilized, causing the overall action to fail. 

The regex now supports both rc and lts, in addition to the major.minor.patch version format.

**For branch example `13.4-stable`**

```
/Users/yash/lf-edge/eve/build-tools/bin/linuxkit -v pkg push   --release 13.4-stable --platforms linux/arm64 --build-yml    build.yml pkg/debug
if [ -n "1" ]; then \
		/Users/yash/lf-edge/eve/build-tools/bin/linuxkit pkg builder prune; \
		docker image prune -f; \
	fi
```
**For tag example `13.4.0-rc3`**
```
: "eve-guacd: Begin: LINUXKIT_PKG_TARGET=push"
/Users/yash/lf-edge/eve/build-tools/bin/linuxkit -v pkg push   --release 13.4.0-rc3 --platforms linux/arm64 --build-yml    build.yml pkg/guacd
if [ -n "1" ]; then \
		/Users/yash/lf-edge/eve/build-tools/bin/linuxkit pkg builder prune; \
		docker image prune -f; \
	fi
: "eve-guacd: Succeeded (intermediate for pkg/%)"
: pkg/guacd: Succeeded
```


**For master branch example**

```
: "eve-guacd: Begin: LINUXKIT_PKG_TARGET=push"
/Users/yash/lf-edge/eve/build-tools/bin/linuxkit -v pkg push   --release snapshot --platforms linux/arm64 --build-yml    build.yml pkg/guacd
if [ -n "1" ]; then \
		/Users/yash/lf-edge/eve/build-tools/bin/linuxkit pkg builder prune; \
		docker image prune -f; \
	fi
: "eve-guacd: Succeeded (intermediate for pkg/%)"
```


