### PR TITLE
Simplify assets.yml by using wildcards and loops

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -83,15 +83,9 @@ jobs:
       - name: Rename files for release
         id: rename-files-for-release
         run: |
-          mv assets/rootfs.img assets/${{ env.ARCH }}.rootfs.img
-          mv assets/kernel assets/${{ env.ARCH }}.kernel
-          mv assets/installer.img assets/${{ env.ARCH }}.installer.img
-          mv assets/initrd.img assets/${{ env.ARCH }}.initrd.img
-          mv assets/initrd.bits assets/${{ env.ARCH }}.initrd.bits
-          mv assets/ipxe.efi assets/${{ env.ARCH }}.ipxe.efi
-          mv assets/ipxe.efi.cfg assets/${{ env.ARCH }}.ipxe.efi.cfg
-          mv assets/ipxe.efi.ip.cfg assets/${{ env.ARCH }}.ipxe.efi.ip.cfg
-          mv assets/collected_sources.tar.gz assets/${{ env.ARCH }}.collected_sources.tar.gz
+          for asset in assets/*; do
+            mv "$asset" "assets/${{ env.ARCH }}.$(basename "$asset")"
+          done
       - name: Upload release files
         id: upload-release-files
         uses: softprops/action-gh-release@v2
@@ -101,12 +95,4 @@ jobs:
           tag_name: ${{ inputs.tag_ref }}
           make_latest: false
           files: |
-            assets/${{ env.ARCH }}.rootfs.img
-            assets/${{ env.ARCH }}.kernel
-            assets/${{ env.ARCH }}.installer.img
-            assets/${{ env.ARCH }}.initrd.img
-            assets/${{ env.ARCH }}.initrd.bits
-            assets/${{ env.ARCH }}.ipxe.efi
-            assets/${{ env.ARCH }}.ipxe.efi.cfg
-            assets/${{ env.ARCH }}.ipxe.efi.ip.cfg
-            assets/${{ env.ARCH }}.collected_sources.tar.gz
+            assets/${{ env.ARCH }}.*


### PR DESCRIPTION
The list of assets to convert to `${{ env.ARCH }}` followed by the name, and then the list of uploads, was a fixed list. This made it break when anything changed. This PR changes it so that it just converts all assets in `assets/` to prepend `${{ env.ARCH }}`, and uses the glob for uploading, `assets/${{ env.ARCH }}.*`

FYI, the usage of wildcards/glob in `softprops/action-gh-release` is documented [here](https://github.com/deitch/eve/pull/new/update-assets-yml).

@yash-zededa 