### PR TITLE
vTPM communication and error handling refactoring

### DIFF
--- a/.spdxignore
+++ b/.spdxignore
@@ -13,3 +13,4 @@ pkg/installer/vendor/
 pkg/kube/descheduler-job.yaml
 pkg/kube/descheduler_rbac.yaml
 pkg/kube/lh-cfg-v1.6.2.yaml
+pkg/vtpm/swtpm-vtpm/vendor/

--- a/pkg/pillar/hypervisor/containerd.go
+++ b/pkg/pillar/hypervisor/containerd.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/lf-edge/eve/pkg/pillar/containerd"
-	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/opencontainers/runtime-spec/specs-go"
 
@@ -339,14 +338,14 @@ func (ctx ctrdContext) GetDomsCPUMem() (map[string]types.DomainMetric, error) {
 	return res, nil
 }
 
-func (ctx ctrdContext) VirtualTPMSetup(domainName, agentName string, ps *pubsub.PubSub, warnTime, errTime time.Duration) error {
+func (ctx ctrdContext) VirtualTPMSetup(domainName string, wp *types.WatchdogParam) error {
 	return fmt.Errorf("not implemented")
 }
 
-func (ctx ctrdContext) VirtualTPMTerminate(domainName string) error {
+func (ctx ctrdContext) VirtualTPMTerminate(domainName string, wp *types.WatchdogParam) error {
 	return fmt.Errorf("not implemented")
 }
 
-func (ctx ctrdContext) VirtualTPMTeardown(domainName string) error {
+func (ctx ctrdContext) VirtualTPMTeardown(domainName string, wp *types.WatchdogParam) error {
 	return fmt.Errorf("not implemented")
 }

--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/lf-edge/eve/pkg/pillar/base"
-	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 
 	netattdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
@@ -1362,14 +1361,14 @@ func (ctx kubevirtContext) PCISameController(id1 string, id2 string) bool {
 	return PCISameControllerGeneric(id1, id2)
 }
 
-func (ctx kubevirtContext) VirtualTPMSetup(domainName, agentName string, ps *pubsub.PubSub, warnTime, errTime time.Duration) error {
+func (ctx kubevirtContext) VirtualTPMSetup(domainName string, wp *types.WatchdogParam) error {
 	return fmt.Errorf("not implemented")
 }
 
-func (ctx kubevirtContext) VirtualTPMTerminate(domainName string) error {
+func (ctx kubevirtContext) VirtualTPMTerminate(domainName string, wp *types.WatchdogParam) error {
 	return fmt.Errorf("not implemented")
 }
 
-func (ctx kubevirtContext) VirtualTPMTeardown(domainName string) error {
+func (ctx kubevirtContext) VirtualTPMTeardown(domainName string, wp *types.WatchdogParam) error {
 	return fmt.Errorf("not implemented")
 }

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -20,7 +20,6 @@ import (
 	zconfig "github.com/lf-edge/eve-api/go/config"
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/containerd"
-	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils"
 	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
@@ -44,9 +43,15 @@ var (
 	clientCid  = uint32(unix.VMADDR_CID_HOST + 1)
 	vTPMClient = &http.Client{
 		Transport: vtpmClientUDSTransport(),
-		Timeout:   2 * time.Second,
+		Timeout:   5 * time.Second,
 	}
 )
+
+// vtpmRequestResult holds the result of a vTPM request.
+type vtpmRequestResult struct {
+	Body  string
+	Error error
+}
 
 // We build device model around PCIe topology according to best practices
 //    https://github.com/qemu/qemu/blob/master/docs/pcie.txt
@@ -1323,38 +1328,46 @@ func getQmpListenerSocket(domainName string) string {
 }
 
 // VirtualTPMSetup launches a vTPM instance for the domain
-func (ctx KvmContext) VirtualTPMSetup(domainName, agentName string, ps *pubsub.PubSub, warnTime, errTime time.Duration) error {
-	if ps != nil {
-		wk := utils.NewWatchdogKick(ps, agentName, warnTime, errTime)
-		domainUUID, _, _, err := types.DomainnameToUUID(domainName)
-		if err != nil {
-			return fmt.Errorf("failed to extract UUID from domain name: %v", err)
-		}
-		return requestvTPMLaunch(domainUUID, wk, swtpmTimeout)
+func (ctx KvmContext) VirtualTPMSetup(domainName string, wp *types.WatchdogParam) error {
+	if wp == nil {
+		return fmt.Errorf("invalid watchdog configuration")
 	}
 
-	return fmt.Errorf("invalid watchdog configuration")
-}
-
-// VirtualTPMTerminate terminates the vTPM instance
-func (ctx KvmContext) VirtualTPMTerminate(domainName string) error {
 	domainUUID, _, _, err := types.DomainnameToUUID(domainName)
 	if err != nil {
 		return fmt.Errorf("failed to extract UUID from domain name: %v", err)
 	}
-	if err := requestvTPMTermination(domainUUID); err != nil {
+	return requestvTPMLaunch(domainUUID, wp, swtpmTimeout)
+
+}
+
+// VirtualTPMTerminate terminates the vTPM instance
+func (ctx KvmContext) VirtualTPMTerminate(domainName string, wp *types.WatchdogParam) error {
+	if wp == nil {
+		return fmt.Errorf("invalid watchdog configuration")
+	}
+
+	domainUUID, _, _, err := types.DomainnameToUUID(domainName)
+	if err != nil {
+		return fmt.Errorf("failed to extract UUID from domain name: %v", err)
+	}
+	if err := requestvTPMTermination(domainUUID, wp); err != nil {
 		return fmt.Errorf("failed to terminate vTPM for domain %s: %w", domainName, err)
 	}
 	return nil
 }
 
 // VirtualTPMTeardown purges the vTPM instance.
-func (ctx KvmContext) VirtualTPMTeardown(domainName string) error {
+func (ctx KvmContext) VirtualTPMTeardown(domainName string, wp *types.WatchdogParam) error {
+	if wp == nil {
+		return fmt.Errorf("invalid watchdog configuration")
+	}
+
 	domainUUID, _, _, err := types.DomainnameToUUID(domainName)
 	if err != nil {
 		return fmt.Errorf("failed to extract UUID from domain name: %v", err)
 	}
-	if err := requestvTPMPurge(domainUUID); err != nil {
+	if err := requestvTPMPurge(domainUUID, wp); err != nil {
 		return fmt.Errorf("failed to purge vTPM for domain %s: %w", domainName, err)
 	}
 
@@ -1370,54 +1383,74 @@ func vtpmClientUDSTransport() *http.Transport {
 	}
 }
 
-func makeRequest(client *http.Client, endpoint, id string) (string, error) {
+func makeRequestAsync(client *http.Client, endpoint, id string, rChan chan<- vtpmRequestResult) {
 	url := fmt.Sprintf("http://unix/%s?id=%s", endpoint, id)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
-		return "", fmt.Errorf("error when creating request: %v", err)
+		rChan <- vtpmRequestResult{Error: fmt.Errorf("error when creating request to %s endpoint: %v", url, err)}
+		return
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("request failed: %v", err)
+		rChan <- vtpmRequestResult{Error: fmt.Errorf("error when sending request to %s endpoint: %v", url, err)}
+		return
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("error when reading response body: %v", err)
+		rChan <- vtpmRequestResult{Error: fmt.Errorf("error when reading response body from %s endpoint: %v", url, err)}
+		return
 	}
 	if resp.StatusCode != http.StatusOK {
-		return string(body), fmt.Errorf("received status code %d", resp.StatusCode)
+		rChan <- vtpmRequestResult{Error: fmt.Errorf("received status code %d from %s endpoint", resp.StatusCode, url), Body: string(body)}
+		return
 	}
 
-	return string(body), nil
+	rChan <- vtpmRequestResult{Body: string(body)}
 }
 
-func requestvTPMLaunch(id uuid.UUID, wk *utils.WatchdogKick, timeoutSeconds uint) error {
-	body, err := makeRequest(vTPMClient, vtpmLaunchEndpoint, id.String())
+func makeRequest(client *http.Client, wk *utils.WatchdogKicker, endpoint, id string) (body string, err error) {
+	rChan := make(chan vtpmRequestResult)
+	go makeRequestAsync(client, endpoint, id, rChan)
+
+	startTime := time.Now()
+	for {
+		select {
+		case res := <-rChan:
+			return res.Body, res.Error
+		default:
+			utils.KickWatchdog(wk)
+			if time.Since(startTime).Seconds() >= float64(client.Timeout.Seconds()) {
+				return "", fmt.Errorf("timeout")
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+}
+
+func requestvTPMLaunch(id uuid.UUID, wp *types.WatchdogParam, timeoutSeconds uint) error {
+	wk := utils.NewWatchdogKicker(wp.Ps, wp.AgentName, wp.WarnTime, wp.ErrTime)
+	body, err := makeRequest(vTPMClient, wk, vtpmLaunchEndpoint, id.String())
 	if err != nil {
 		return fmt.Errorf("failed to launch vTPM instance: %w (%s)", err, body)
 	}
 
 	// Wait for SWTPM to start.
 	pidPath := fmt.Sprintf(types.SwtpmPidPath, id.String())
-	pid, err := utils.GetPidFromFileTimeout(pidPath, timeoutSeconds, wk)
+	_, err = utils.GetPidFromFileTimeout(pidPath, timeoutSeconds, wk)
 	if err != nil {
 		return fmt.Errorf("failed to get pid from file %s: %w", pidPath, err)
-	}
-
-	// One last time, check SWTPM is not dead right after launch.
-	if !utils.IsProcAlive(pid) {
-		return fmt.Errorf("SWTPM (pid: %d) is dead", pid)
 	}
 
 	return nil
 }
 
-func requestvTPMPurge(id uuid.UUID) error {
+func requestvTPMPurge(id uuid.UUID, wp *types.WatchdogParam) error {
 	// Send a request to vTPM control socket, ask it to purge the instance
 	// and all its data.
-	body, err := makeRequest(vTPMClient, vtpmPurgeEndpoint, id.String())
+	wk := utils.NewWatchdogKicker(wp.Ps, wp.AgentName, wp.WarnTime, wp.ErrTime)
+	body, err := makeRequest(vTPMClient, wk, vtpmPurgeEndpoint, id.String())
 	if err != nil {
 		return fmt.Errorf("failed to purge vTPM instance: %w (%s)", err, body)
 	}
@@ -1425,9 +1458,10 @@ func requestvTPMPurge(id uuid.UUID) error {
 	return nil
 }
 
-func requestvTPMTermination(id uuid.UUID) error {
+func requestvTPMTermination(id uuid.UUID, wp *types.WatchdogParam) error {
 	// Send a request to vTPM control socket, ask it to terminate the instance.
-	body, err := makeRequest(vTPMClient, vtpmTermEndpoint, id.String())
+	wk := utils.NewWatchdogKicker(wp.Ps, wp.AgentName, wp.WarnTime, wp.ErrTime)
+	body, err := makeRequest(vTPMClient, wk, vtpmTermEndpoint, id.String())
 	if err != nil {
 		return fmt.Errorf("failed to terminate vTPM instance: %w (%s)", err, body)
 	}

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -4,8 +4,11 @@
 package hypervisor
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -28,16 +31,22 @@ import (
 
 const (
 	// KVMHypervisorName is a name of kvm hypervisor
-	KVMHypervisorName = "kvm"
-	minUringKernelTag = uint64((5 << 16) | (4 << 8) | (72 << 0))
-	swtpmTimeout      = 10 // seconds
-	qemuTimeout       = 3  // seconds
-	vtpmPurgePrefix   = "purge;"
-	vtpmDeletePrefix  = "terminate;"
-	vtpmLaunchPrefix  = "launch;"
+	KVMHypervisorName  = "kvm"
+	minUringKernelTag  = uint64((5 << 16) | (4 << 8) | (72 << 0))
+	swtpmTimeout       = 10 // seconds
+	qemuTimeout        = 3  // seconds
+	vtpmPurgeEndpoint  = "purge"
+	vtpmTermEndpoint   = "terminate"
+	vtpmLaunchEndpoint = "launch"
 )
 
-var clientCid = uint32(unix.VMADDR_CID_HOST + 1)
+var (
+	clientCid  = uint32(unix.VMADDR_CID_HOST + 1)
+	vTPMClient = &http.Client{
+		Transport: vtpmClientUDSTransport(),
+		Timeout:   2 * time.Second,
+	}
+)
 
 // We build device model around PCIe topology according to best practices
 //    https://github.com/qemu/qemu/blob/master/docs/pcie.txt
@@ -1319,21 +1328,21 @@ func (ctx KvmContext) VirtualTPMSetup(domainName, agentName string, ps *pubsub.P
 		wk := utils.NewWatchdogKick(ps, agentName, warnTime, errTime)
 		domainUUID, _, _, err := types.DomainnameToUUID(domainName)
 		if err != nil {
-			return fmt.Errorf("failed to extract UUID from domain name (vTPM setup): %v", err)
+			return fmt.Errorf("failed to extract UUID from domain name: %v", err)
 		}
-		return requestVtpmLaunch(domainUUID, wk, swtpmTimeout)
+		return requestvTPMLaunch(domainUUID, wk, swtpmTimeout)
 	}
 
-	return fmt.Errorf("invalid watchdog configuration (vTPM setup)")
+	return fmt.Errorf("invalid watchdog configuration")
 }
 
 // VirtualTPMTerminate terminates the vTPM instance
 func (ctx KvmContext) VirtualTPMTerminate(domainName string) error {
 	domainUUID, _, _, err := types.DomainnameToUUID(domainName)
 	if err != nil {
-		return fmt.Errorf("failed to extract UUID from domain name (vTPM terminate): %v", err)
+		return fmt.Errorf("failed to extract UUID from domain name: %v", err)
 	}
-	if err := requestVtpmTermination(domainUUID); err != nil {
+	if err := requestvTPMTermination(domainUUID); err != nil {
 		return fmt.Errorf("failed to terminate vTPM for domain %s: %w", domainName, err)
 	}
 	return nil
@@ -1343,31 +1352,55 @@ func (ctx KvmContext) VirtualTPMTerminate(domainName string) error {
 func (ctx KvmContext) VirtualTPMTeardown(domainName string) error {
 	domainUUID, _, _, err := types.DomainnameToUUID(domainName)
 	if err != nil {
-		return fmt.Errorf("failed to extract UUID from domain name (vTPM teardown): %v", err)
+		return fmt.Errorf("failed to extract UUID from domain name: %v", err)
 	}
-	if err := requestVtpmPurge(domainUUID); err != nil {
+	if err := requestvTPMPurge(domainUUID); err != nil {
 		return fmt.Errorf("failed to purge vTPM for domain %s: %w", domainName, err)
 	}
 
 	return nil
 }
 
-func requestVtpmLaunch(id uuid.UUID, wk *utils.WatchdogKick, timeoutSeconds uint) error {
-	conn, err := net.Dial("unix", types.VtpmdCtrlSocket)
-	if err != nil {
-		return fmt.Errorf("failed to connect to vTPM control socket: %w", err)
+// This is the Unix Domain Socket (UDS) transport for vTPM requests.
+func vtpmClientUDSTransport() *http.Transport {
+	return &http.Transport{
+		DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+			return net.Dial("unix", types.VtpmdCtrlSocket)
+		},
 	}
-	defer conn.Close()
+}
 
+func makeRequest(client *http.Client, endpoint, id string) (string, error) {
+	url := fmt.Sprintf("http://unix/%s?id=%s", endpoint, id)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("error when creating request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("error when reading response body: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return string(body), fmt.Errorf("received status code %d", resp.StatusCode)
+	}
+
+	return string(body), nil
+}
+
+func requestvTPMLaunch(id uuid.UUID, wk *utils.WatchdogKick, timeoutSeconds uint) error {
+	body, err := makeRequest(vTPMClient, vtpmLaunchEndpoint, id.String())
+	if err != nil {
+		return fmt.Errorf("failed to launch vTPM instance: %w (%s)", err, body)
+	}
+
+	// Wait for SWTPM to start.
 	pidPath := fmt.Sprintf(types.SwtpmPidPath, id.String())
-
-	// Send the request to the vTPM control socket, ask it to launch a swtpm instance.
-	_, err = conn.Write([]byte(fmt.Sprintf("%s%s\n", vtpmLaunchPrefix, id.String())))
-	if err != nil {
-		return fmt.Errorf("failed to write to vTPM control socket: %w", err)
-	}
-
-	// Loop and wait for SWTPM to start.
 	pid, err := utils.GetPidFromFileTimeout(pidPath, timeoutSeconds, wk)
 	if err != nil {
 		return fmt.Errorf("failed to get pid from file %s: %w", pidPath, err)
@@ -1381,34 +1414,22 @@ func requestVtpmLaunch(id uuid.UUID, wk *utils.WatchdogKick, timeoutSeconds uint
 	return nil
 }
 
-func requestVtpmPurge(id uuid.UUID) error {
-	conn, err := net.Dial("unix", types.VtpmdCtrlSocket)
-	if err != nil {
-		return fmt.Errorf("failed to connect to vTPM control socket: %w", err)
-	}
-	defer conn.Close()
-
+func requestvTPMPurge(id uuid.UUID) error {
 	// Send a request to vTPM control socket, ask it to purge the instance
 	// and all its data.
-	_, err = conn.Write([]byte(fmt.Sprintf("%s%s\n", vtpmPurgePrefix, id.String())))
+	body, err := makeRequest(vTPMClient, vtpmPurgeEndpoint, id.String())
 	if err != nil {
-		return fmt.Errorf("failed to write to vTPM control socket: %w", err)
+		return fmt.Errorf("failed to purge vTPM instance: %w (%s)", err, body)
 	}
 
 	return nil
 }
 
-func requestVtpmTermination(id uuid.UUID) error {
-	conn, err := net.Dial("unix", types.VtpmdCtrlSocket)
+func requestvTPMTermination(id uuid.UUID) error {
+	// Send a request to vTPM control socket, ask it to terminate the instance.
+	body, err := makeRequest(vTPMClient, vtpmTermEndpoint, id.String())
 	if err != nil {
-		return fmt.Errorf("failed to connect to vTPM control socket: %w", err)
-	}
-	defer conn.Close()
-
-	// Send a request to the vTPM control socket, ask it to delete the instance.
-	_, err = conn.Write([]byte(fmt.Sprintf("%s%s\n", vtpmDeletePrefix, id.String())))
-	if err != nil {
-		return fmt.Errorf("failed to write to vTPM control socket: %w", err)
+		return fmt.Errorf("failed to terminate vTPM instance: %w (%s)", err, body)
 	}
 
 	return nil

--- a/pkg/pillar/hypervisor/null.go
+++ b/pkg/pillar/hypervisor/null.go
@@ -6,9 +6,7 @@ package hypervisor
 import (
 	"fmt"
 	"os"
-	"time"
 
-	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 
 	uuid "github.com/satori/go.uuid"
@@ -174,14 +172,14 @@ func (ctx nullContext) GetDomsCPUMem() (map[string]types.DomainMetric, error) {
 	return nil, nil
 }
 
-func (ctx nullContext) VirtualTPMSetup(domainName, agentName string, ps *pubsub.PubSub, warnTime, errTime time.Duration) error {
+func (ctx nullContext) VirtualTPMSetup(domainName string, wp *types.WatchdogParam) error {
 	return fmt.Errorf("not implemented")
 }
 
-func (ctx nullContext) VirtualTPMTerminate(domainName string) error {
+func (ctx nullContext) VirtualTPMTerminate(domainName string, wp *types.WatchdogParam) error {
 	return fmt.Errorf("not implemented")
 }
 
-func (ctx nullContext) VirtualTPMTeardown(domainName string) error {
+func (ctx nullContext) VirtualTPMTeardown(domainName string, wp *types.WatchdogParam) error {
 	return fmt.Errorf("not implemented")
 }

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -11,9 +11,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"time"
 
-	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/mem"
@@ -877,14 +875,14 @@ func fallbackDomainMetric() map[string]types.DomainMetric {
 	return dmList
 }
 
-func (ctx xenContext) VirtualTPMSetup(domainName, agentName string, ps *pubsub.PubSub, warnTime, errTime time.Duration) error {
+func (ctx xenContext) VirtualTPMSetup(domainName string, wp *types.WatchdogParam) error {
 	return fmt.Errorf("not implemented")
 }
 
-func (ctx xenContext) VirtualTPMTerminate(domainName string) error {
+func (ctx xenContext) VirtualTPMTerminate(domainName string, wp *types.WatchdogParam) error {
 	return fmt.Errorf("not implemented")
 }
 
-func (ctx xenContext) VirtualTPMTeardown(domainName string) error {
+func (ctx xenContext) VirtualTPMTeardown(domainName string, wp *types.WatchdogParam) error {
 	return fmt.Errorf("not implemented")
 }

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -279,9 +279,9 @@ const (
 type Task interface {
 	Setup(DomainStatus, DomainConfig, *AssignableAdapters,
 		*ConfigItemValueMap, *os.File) error
-	VirtualTPMSetup(domainName, agentName string, ps *pubsub.PubSub, warnTime, errTime time.Duration) error
-	VirtualTPMTerminate(domainName string) error
-	VirtualTPMTeardown(domainName string) error
+	VirtualTPMSetup(domainName string, wp *WatchdogParam) error
+	VirtualTPMTerminate(domainName string, wp *WatchdogParam) error
+	VirtualTPMTeardown(domainName string, wp *WatchdogParam) error
 	Create(string, string, *DomainConfig) (int, error)
 	Start(string) error
 	Stop(string, bool) error
@@ -587,4 +587,13 @@ type Capabilities struct {
 	IOVirtualization         bool // I/O Virtualization support
 	CPUPinning               bool // CPU Pinning support
 	UseVHost                 bool // vHost support
+}
+
+// WatchdogParam is used in some proc functions that have a timeout,
+// to tell the watchdog agent is still alive.
+type WatchdogParam struct {
+	Ps        *pubsub.PubSub
+	AgentName string
+	WarnTime  time.Duration
+	ErrTime   time.Duration
 }

--- a/pkg/pillar/utils/proc.go
+++ b/pkg/pillar/utils/proc.go
@@ -15,23 +15,28 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 )
 
-// WatchdogKick is used in some proc functions that have a timeout,
+// WatchdogKicker is used in some proc functions that have a timeout,
 // to tell the watchdog agent is still alive.
-type WatchdogKick struct {
+type WatchdogKicker struct {
 	ps        *pubsub.PubSub
 	agentName string
 	warnTime  time.Duration
 	errTime   time.Duration
 }
 
-// NewWatchdogKick creates a new WatchdogKick.
-func NewWatchdogKick(ps *pubsub.PubSub, agentName string, warnTime time.Duration, errTime time.Duration) *WatchdogKick {
-	return &WatchdogKick{
+// NewWatchdogKicker creates a new WatchdogKick.
+func NewWatchdogKicker(ps *pubsub.PubSub, agentName string, warnTime time.Duration, errTime time.Duration) *WatchdogKicker {
+	return &WatchdogKicker{
 		ps:        ps,
 		agentName: agentName,
 		warnTime:  warnTime,
 		errTime:   errTime,
 	}
+}
+
+// KickWatchdog tells the watchdog agent is still alive.
+func KickWatchdog(wk *WatchdogKicker) {
+	wk.ps.StillRunning(wk.agentName, wk.warnTime, wk.errTime)
 }
 
 // PkillArgs does a pkill
@@ -85,7 +90,7 @@ func GetPidFromFile(pidFile string) (int, error) {
 }
 
 // GetPidFromFileTimeout reads a pid from a file with a timeout.
-func GetPidFromFileTimeout(pidFile string, timeoutSeconds uint, wk *WatchdogKick) (int, error) {
+func GetPidFromFileTimeout(pidFile string, timeoutSeconds uint, wk *WatchdogKicker) (int, error) {
 	startTime := time.Now()
 	for {
 		if time.Since(startTime).Seconds() >= float64(timeoutSeconds) {
@@ -118,7 +123,7 @@ func IsProcAlive(pid int) bool {
 }
 
 // IsProcAliveTimeout checks if a process is alive for a given timeout.
-func IsProcAliveTimeout(pid int, timeoutSeconds uint, wk *WatchdogKick) bool {
+func IsProcAliveTimeout(pid int, timeoutSeconds uint, wk *WatchdogKicker) bool {
 	startTime := time.Now()
 	for {
 		if time.Since(startTime).Seconds() >= float64(timeoutSeconds) {

--- a/pkg/vtpm/swtpm-vtpm/go.mod
+++ b/pkg/vtpm/swtpm-vtpm/go.mod
@@ -4,6 +4,7 @@ go 1.22
 
 require (
 	github.com/lf-edge/eve/pkg/pillar v0.0.0-20240820084217-3f317a9e801f
+	github.com/satori/go.uuid v1.2.1-0.20180404165556-75cca531ea76
 	github.com/sirupsen/logrus v1.9.3
 )
 
@@ -20,7 +21,6 @@ require (
 	github.com/leodido/go-urn v1.2.4 // indirect
 	github.com/lf-edge/eve-api/go v0.0.0-20240722173316-ed56da45126b // indirect
 	github.com/lf-edge/eve/pkg/kube/cnirpc v0.0.0-20240315102754-0f6d1f182e0d // indirect
-	github.com/satori/go.uuid v1.2.1-0.20180404165556-75cca531ea76 // indirect
 	github.com/vishvananda/netlink v1.2.1-beta.2 // indirect
 	github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f // indirect
 	golang.org/x/crypto v0.21.0 // indirect

--- a/pkg/vtpm/swtpm-vtpm/src/main.go
+++ b/pkg/vtpm/swtpm-vtpm/src/main.go
@@ -29,7 +29,7 @@ import (
 const (
 	swtpmPath      = "/usr/bin/swtpm"
 	maxInstances   = 10
-	maxPidWaitTime = 1 //seconds
+	maxPidWaitTime = 5 //seconds
 )
 
 var (

--- a/pkg/vtpm/swtpm-vtpm/src/main.go
+++ b/pkg/vtpm/swtpm-vtpm/src/main.go
@@ -7,14 +7,14 @@
 package main
 
 import (
-	"bufio"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"os/exec"
-	"os/signal"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -26,21 +26,18 @@ import (
 )
 
 const (
-	swtpmPath    = "/usr/bin/swtpm"
-	purgeReq     = "purge"
-	terminateReq = "terminate"
-	launchReq    = "launch"
-	maxInstances = 10
-	maxIDLen     = 128
-	maxWaitTime  = 3 //seconds
+	swtpmPath      = "/usr/bin/swtpm"
+	maxInstances   = 10
+	maxPidWaitTime = 3 //seconds
 )
 
 var (
 	liveInstances int
+	m             sync.Mutex
 	log           *base.LogObject
 	pids          = make(map[string]int, 0)
+	// XXX : move the paths to types so we have everything EVE creates in one place.
 	// These are defined as vars to be able to mock them in tests
-	// XXX : move this to types so we have everything EVE creates in one place.
 	stateEncryptionKey   = "/run/swtpm/%s.binkey"
 	swtpmIsEncryptedPath = "/persist/swtpm/%s.encrypted"
 	swtpmStatePath       = "/persist/swtpm/tpm-state-%s"
@@ -56,35 +53,11 @@ var (
 	}
 )
 
-func parseRequest(id string) (string, string, error) {
-	id = strings.TrimSpace(id)
-	if id == "" || len(id) > maxIDLen {
-		return "", "", fmt.Errorf("invalid SWTPM ID received")
-	}
-
-	// breake the string and get the request type
-	split := strings.Split(id, ";")
-	if len(split) != 2 {
-		return "", "", fmt.Errorf("invalid SWTPM ID received (no request)")
-	}
-
-	if split[1] == "" {
-		return "", "", fmt.Errorf("invalid SWTPM ID received (no id)")
-	}
-
-	// request, id
-	return split[0], split[1], nil
-}
-
 func cleanupFiles(id string) {
-	statePath := fmt.Sprintf(swtpmStatePath, id)
-	ctrlSockPath := fmt.Sprintf(swtpmCtrlSockPath, id)
-	pidPath := fmt.Sprintf(swtpmPidPath, id)
-	isEncryptedPath := fmt.Sprintf(swtpmIsEncryptedPath, id)
-	os.RemoveAll(statePath)
-	os.Remove(ctrlSockPath)
-	os.Remove(pidPath)
-	os.Remove(isEncryptedPath)
+	os.RemoveAll(fmt.Sprintf(swtpmStatePath, id))
+	os.Remove(fmt.Sprintf(swtpmCtrlSockPath, id))
+	os.Remove(fmt.Sprintf(swtpmPidPath, id))
+	os.Remove(fmt.Sprintf(swtpmIsEncryptedPath, id))
 }
 
 func makeDirs(dir string) error {
@@ -144,7 +117,7 @@ func runSwtpm(id string) (int, error) {
 		// if SWTPM state for app marked as as encrypted, and TPM is not available
 		// anymore, fail because this will corrupt the SWTPM state.
 		if utils.FileExists(log, isEncryptedPath) {
-			return 0, fmt.Errorf("state encryption was enabled for app, but TPM is no longer available")
+			return 0, fmt.Errorf("state encryption was enabled for SWTPM, but TPM is no longer available")
 		}
 
 		cmd := exec.Command(swtpmPath, swtpmArgs...)
@@ -159,7 +132,7 @@ func runSwtpm(id string) (int, error) {
 			return 0, fmt.Errorf("failed to get SWTPM state encryption key : %w", err)
 		}
 
-		// we are about to write the key to the disk, so mark the app SWTPM state
+		// we are about to write the key to the disk, so mark the SWTPM state
 		// as encrypted
 		if !utils.FileExists(log, isEncryptedPath) {
 			if err := utils.WriteRename(isEncryptedPath, []byte("Y")); err != nil {
@@ -183,121 +156,87 @@ func runSwtpm(id string) (int, error) {
 		}
 	}
 
-	pid, err := getSwtpmPid(pidPath, maxWaitTime)
+	pid, err := getSwtpmPid(pidPath, maxPidWaitTime)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get SWTPM pid: %w", err)
 	}
 
-	// Add to the list.
+	// Add it to the list.
 	pids[id] = pid
 	return pid, nil
 }
 
-func main() {
-	log = base.NewSourceLogObject(logrus.StandardLogger(), "vtpm", os.Getpid())
-	if log == nil {
-		fmt.Println("Failed to create log object")
-		os.Exit(1)
-	}
-
-	serviceLoop()
-}
-
-func serviceLoop() {
-	uds, err := net.Listen("unix", vtpmdCtrlSockPath)
-	if err != nil {
-		log.Errorf("failed to create vtpm control socket: %v", err)
+// Domain manager is requesting to launch a new VM/App, run a new SWTPM
+// instance with the given id.
+func handleLaunch(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		err := fmt.Sprintf("Method %s not allowed", r.Method)
+		http.Error(w, err, http.StatusMethodNotAllowed)
 		return
 	}
-	defer uds.Close()
 
-	// Make sure we remove the socket file on exit.
-	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
-	go func() {
-		<-sigs
-		os.Remove(vtpmdCtrlSockPath)
-		os.Exit(0)
-	}()
+	// pids and liveInstances is shared, take care of them.
+	m.Lock()
+	defer m.Unlock()
 
-	for {
-		// xxx : later get peer creds (getpeereid) and check if the caller is
-		// the domain manager to avoid any other process from sending requests.
-		conn, err := uds.Accept()
-		if err != nil {
-			log.Errorf("failed to accept connection over vtpmd control socket: %v", err)
-			continue
-		}
-
-		id, err := bufio.NewReader(conn).ReadString('\n')
-		if err != nil {
-			log.Errorf("failed to read SWTPM ID from connection: %v", err)
-			continue
-		}
-
-		// Close the connection as soon as we read the ID,
-		// handle one request at a time.
-		conn.Close()
-
-		// Don't launch go routines, instead serve requests one by one to avoid
-		// using any locks, handle* functions access pids global variable.
-		err = handleRequest(id)
-		if err != nil {
-			log.Errorf("failed to handle request: %v", err)
-		}
-	}
-}
-
-func handleRequest(id string) error {
-	request, id, err := parseRequest(id)
-	if err != nil {
-		return fmt.Errorf("failed to parse request: %w", err)
-	}
-
-	switch request {
-	case launchReq:
-		// Domain manager is requesting to launch a new VM/App, run a new SWTPM
-		// instance with the given id.
-		return handleLaunch(id)
-	case purgeReq:
-		// VM/App is being deleted, domain manager is sending a purge request,
-		// delete the SWTPM instance and clean up all the files.
-		return handlePurge(id)
-	case terminateReq:
-		// Domain manager is sending a terminate request because it hit an error while
-		// starting the app (i.e. qemu crashed), so just remove kill SWTPM instance,
-		// remove it's pid for the list and decrease the liveInstances count.
-		return handleTerminate(id)
-	default:
-		return fmt.Errorf("invalid request received")
-	}
-}
-
-func handleLaunch(id string) error {
 	if liveInstances >= maxInstances {
-		return fmt.Errorf("max number of vTPM instances reached %d", liveInstances)
+		err := fmt.Sprintf("vTPM max number of SWTPM instances reached %d", liveInstances)
+		http.Error(w, err, http.StatusTooManyRequests)
+		return
+	}
+
+	id := r.URL.Query().Get("id")
+	if id == "" {
+		err := "vTPM launch request failed, id is required"
+		http.Error(w, err, http.StatusBadRequest)
+		return
 	}
 	// If we have SWTPM instance with the same id running, it means either the
-	// domain got rebooted or something went wrong on the dommain manager side!!
-	// it the later case it should have sent a delete request if VM crashed or
+	// domain got rebooted or something went wrong on the dommain manager side!
+	// it the later case it should have sent a terminate request if VM crashed or
 	// there was any other VM related errors. Anyway, refuse to launch a new
 	// instance with the same id as this might corrupt the state.
 	if _, ok := pids[id]; ok {
-		return fmt.Errorf("SWTPM instance with id %s already running", id)
+		log.Warnf("SWTPM instance with id %s already running", id)
+		// technically request is satisfied
+		w.WriteHeader(http.StatusOK)
+		return
 	}
 
 	pid, err := runSwtpm(id)
 	if err != nil {
-		return fmt.Errorf("failed to start SWTPM instance: %v", err)
+		err := fmt.Sprintf("vTPM failed to start SWTPM instance: %v", err)
+		http.Error(w, err, http.StatusFailedDependency)
+		return
 	}
 
-	log.Noticef("SWTPM instance with id %s is running with pid %d", id, pid)
+	log.Noticef("vTPM launched SWTPM instance with id: %s, pid: %d", id, pid)
 
+	// Send a success response.
 	liveInstances++
-	return nil
+	w.WriteHeader(http.StatusOK)
 }
 
-func handleTerminate(id string) error {
+// Domain manager is sending a terminate request because it hit an error while
+// starting the app (i.e. qemu crashed), so just kill SWTPM instance,
+// remove it's pid from the list and decrease the liveInstances count.
+func handleTerminate(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		err := fmt.Sprintf("Method %s not allowed", r.Method)
+		http.Error(w, err, http.StatusMethodNotAllowed)
+		return
+	}
+
+	// pids and liveInstances is shared, take care of it.
+	m.Lock()
+	defer m.Unlock()
+
+	id := r.URL.Query().Get("id")
+	if id == "" {
+		err := "vTPM terminate request failed, id is required"
+		http.Error(w, err, http.StatusBadRequest)
+		return
+	}
 	// We expect the SWTPM to be terminated at this point, but just in case send
 	// a term signal.
 	pid, ok := pids[id]
@@ -305,20 +244,43 @@ func handleTerminate(id string) error {
 		if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
 			if err != syscall.ESRCH {
 				// This should not happen, but log it just in case.
-				log.Errorf("failed to kill SWTPM instance (terminate request): %v", err)
+				log.Errorf("vTPM failed to kill SWTPM instance (terminate request): %v", err)
 			}
 		}
 		delete(pids, id)
 		liveInstances--
 	} else {
-		return fmt.Errorf("terminate request failed, SWTPM instance with id %s not found", id)
+		err := fmt.Sprintf("vTPM terminate request failed, SWTPM instance with id %s not found", id)
+		http.Error(w, err, http.StatusNotFound)
+		return
 	}
 
-	return nil
+	log.Noticef("vTPM terminated SWTPM instance with id: %s, pid: %d", id, pid)
+
+	// send a success response.
+	w.WriteHeader(http.StatusOK)
 }
 
-func handlePurge(id string) error {
-	log.Noticef("Purging SWTPM instance with id: %s", id)
+// VM/App is being deleted, domain manager is sending a purge request,
+// delete the SWTPM instance and clean up all the files.
+func handlePurge(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		err := fmt.Sprintf("Method %s not allowed", r.Method)
+		http.Error(w, err, http.StatusMethodNotAllowed)
+		return
+	}
+
+	// pids and liveInstances is shared, take care of it.
+	m.Lock()
+	defer m.Unlock()
+
+	id := r.URL.Query().Get("id")
+	if id == "" {
+		err := "vTPM purge request failed, id is required"
+		http.Error(w, err, http.StatusBadRequest)
+		return
+	}
+
 	// we actually expect the SWTPM to be terminated at this point, because qemu
 	// either sends CMD_SHUTDOWN through the control socket or in case of qemu
 	// crashing, SWTPM terminates itself when the control socket is closed since
@@ -331,12 +293,44 @@ func handlePurge(id string) error {
 				log.Errorf("failed to kill SWTPM instance (purge request): %v", err)
 			}
 		}
-
 		delete(pids, id)
 		liveInstances--
 	}
 
-	// clean up files if exists
+	log.Noticef("vTPM purged SWTPM instance with id: %s, pid: %d", id, pid)
+
+	// clean up the files and send a success response.
 	cleanupFiles(id)
-	return nil
+	w.WriteHeader(http.StatusOK)
+}
+
+func startServing() {
+	if _, err := os.Stat(vtpmdCtrlSockPath); err == nil {
+		os.Remove(vtpmdCtrlSockPath)
+	}
+	listener, err := net.Listen("unix", vtpmdCtrlSockPath)
+	if err != nil {
+		log.Fatalf("Error creating Unix socket: %v", err)
+	}
+	defer listener.Close()
+
+	os.Chmod(vtpmdCtrlSockPath, 0600)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/launch", handleLaunch)
+	mux.HandleFunc("/terminate", handleTerminate)
+	mux.HandleFunc("/purge", handlePurge)
+
+	log.Noticef("vTPM server is listening on Unix socket: %s", vtpmdCtrlSockPath)
+	http.Serve(listener, mux)
+}
+
+func main() {
+	log = base.NewSourceLogObject(logrus.StandardLogger(), "vtpm", os.Getpid())
+	if log == nil {
+		fmt.Println("Failed to create log object")
+		os.Exit(1)
+	}
+
+	// this never returns, ideally.
+	startServing()
 }


### PR DESCRIPTION
This pull request includes changes to the `vtpm`, `domainmgr` and `kvm` components to improve the handling of virtual TPM (vTPM) instances. The changes includes bug fix, enhance error handling, refactor the vTPM launch and termination processes, and introduce HTTP-based communication for vTPM commands.

- **vTPM : refactor control socket communication and error handling**
This changes refactors the control socket communication and error handling
in the vTPM (server) and KVM (client). The control socket communication
is now handled by HTTP over UDS, and the error handling is improved,
since the vTPM server now returns an error message when an error occurs.

- **Domainmgr : refactor virtual TPM setup and termination**
Use a defer function to ensure that the virtual TPM is always terminated
when the domain manager hits an error during the setup process or boot
process.

- **domainmgr : call vTPM asynchronously**
Refactor vTPM setup/term/teardown functions to call the vTPM server
endpoints asynchronously, this remove the timeout guessworks and make the
vTPM setup more reliable.

## Bug Fix
When server gets a launch request, it checks if the the requested instance is already running, but it only checks the internal list and not actually the running instances. This can lead to server thinking the instance is running but client fails to get the PID with error `failed to handle request: SWTPM instance with id XXXX already running` followed by `failed to get pid from file XXXX`. 

This can occur in case like explicit shutdown of the VM (from within the VM), or re-activating the app via cloud-controler and as result the VM will still boot up but **_without_** a vTPM.

This PR fixes this issue.

---

TODO : 
- [x] add unit-test for the bug.
- [x] Test the bug on master and report here the implication.
- [x] Check Azure IoT 
-- Azure IoT Legacy (ptpm) passed
-- Azure IoT vTPM passed
