### PR TITLE
wwan: Do not change initial bearer config and properly clear unused default bearers

### DIFF
--- a/pkg/wwan/mmagent/mmdbus/mmapi.go
+++ b/pkg/wwan/mmagent/mmdbus/mmapi.go
@@ -31,6 +31,7 @@ const (
 	ModemMethodSetPowerState       = ModemInterface + ".SetPowerState"
 	ModemMethodSetPrimarySimSlot   = ModemInterface + ".SetPrimarySimSlot"
 	ModemMethodSetCurrentModes     = ModemInterface + ".SetCurrentModes"
+	ModemMethodDeleteBearer        = ModemInterface + ".DeleteBearer"
 	ModemPropertyModel             = ModemInterface + ".Model"
 	ModemPropertyRevision          = ModemInterface + ".Revision"
 	ModemPropertyManufacturer      = ModemInterface + ".Manufacturer"


### PR DESCRIPTION
This PR addresses two issues related to cellular connectivity.
    
First, make sure that there are no bearers left from previous
connection attempts before starting a new connection, Otherwise, we may get
`interface-in-use-config-match` error from ModemManager.
    
Second, we should not change the initial EPS bearer settings and assume that
the same APN should be used for both the initial and the default bearer.
This is not always the case and the modem registration may fail when we
apply the same APN. However, we might want to make this user configurable
through EVE API and the controller.
    
Some background for understanding: LTE connection consists of two IP bearers,
the initial EPS bearer and the default bearer. Device must first establish
the initial bearer (which shows as transition from the `searching` to `registered`
state) and then it connects to a default bearer (transition from `registered` to
`connected`). Both bearers require PDP context settings (APN, ip-type, potentially
username/password, etc.).
Settings for the initial bearer are typically provided by the SIM card while
settings for the default bearer are user-configured.
    
It is not necessarily the case that the APNs for the initial and the default bearers
are the same. We used to make that assumption but this has led to cases where modem
was failing registration because the APN for the initial bearer was wrong. It is
better to let the SIM card provide the PDP context setting for the initial EPS bearer.
Furthermore, once these settings are changed, there is no straightforward method to
revert back to the SIM-provided configuration; for more details, see the discussion here:
https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/1490#note_2628804
    
Users may only need to override SIM-provided settings in rather rare cases: either when
the SIM card has incorrect configuration (we have seen this only once) or when the initial
EPS bearer requires username/password authentication (also uncommon). Despite the rarity
of these cases, these settings should be user-configurable. We will do this later
(requires EVE API and controller changes).
Please note, that the same enhancement was recently implemented in NetworkManager
(used by Ubuntu and other major Linux distributions):
https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/merge_requests/1915

Also included in this PR is a documentation how to capture control-plane traffic on
Qualcomm-based modems.