### PR TITLE
Allow reporting cpu physical core count.

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -4,6 +4,7 @@
 | ---- | ---- | ------- | ----------- |
 | app.allow.vnc | boolean | false (only local access) | allow access to EVE's VNC ports from external IPs |
 | app.fml.resolution | string | notset | Set system-wide value of forced resolution for applications running in FML mode, it can be one of [predefined](/pkg/pillar/types/global.go) FmlResolution* values. |
+| cpu.stats.physicalcore.enable | boolean  | false | Report Ncpus as physical cores instead of HyperThread/SMT cores |
 | timer.config.interval | integer in seconds | 60 | how frequently device gets config |
 | timer.cert.interval | integer in seconds | 1 day (24*3600) | how frequently device checks for new controller certificates |
 | timer.metric.interval  | integer in seconds | 60 | how frequently device reports metrics |

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -107,6 +107,7 @@ type domainContext struct {
 	setInitialVgaAccess     bool
 	consoleAccess           bool
 	setInitialConsoleAccess bool
+	reportPhyCores          bool
 
 	GCInitialized       bool
 	domainBootRetryTime uint32 // In seconds
@@ -543,7 +544,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	var resources types.HostMemory
 	for i := 0; true; i++ {
 		delay := 10
-		resources, err = hyper.GetHostCPUMem()
+		resources, err = hyper.GetHostCPUMem(domainCtx.reportPhyCores)
 		if err == nil {
 			break
 		}
@@ -2639,6 +2640,7 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 			ctx.metricInterval = metricInterval
 		}
 		ctx.processCloudInitMultiPart = gcp.GlobalValueBool(types.ProcessCloudInitMultiPart)
+		ctx.reportPhyCores = gcp.GlobalValueBool(types.CPUStatsPhysicalCoreEnable)
 		ctx.GCInitialized = true
 	}
 	log.Functionf("handleGlobalConfigImpl done for %s. "+

--- a/pkg/pillar/cmd/domainmgr/metric.go
+++ b/pkg/pillar/cmd/domainmgr/metric.go
@@ -5,8 +5,9 @@ package domainmgr
 
 import (
 	"fmt"
-	"github.com/lf-edge/eve/pkg/pillar/hypervisor"
 	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/hypervisor"
 
 	"github.com/lf-edge/eve/pkg/pillar/flextimer"
 	"github.com/lf-edge/eve/pkg/pillar/types"
@@ -93,7 +94,7 @@ func logWatermarks(ctx *domainContext, status *types.DomainStatus, dm *types.Dom
 
 func getAndPublishMetrics(ctx *domainContext, hyper hypervisor.Hypervisor) {
 	dmList, _ := hyper.GetDomsCPUMem()
-	hm, err := hyper.GetHostCPUMem()
+	hm, err := hyper.GetHostCPUMem(ctx.reportPhyCores)
 	if err != nil {
 		log.Errorf("Cannot obtain HostCPUMem: %s", err)
 		return

--- a/pkg/pillar/hypervisor/containerd.go
+++ b/pkg/pillar/hypervisor/containerd.go
@@ -278,8 +278,8 @@ func (ctx ctrdContext) PCISameController(id1 string, id2 string) bool {
 	return types.PCISameController(id1, id2)
 }
 
-func (ctx ctrdContext) GetHostCPUMem() (types.HostMemory, error) {
-	return selfDomCPUMem()
+func (ctx ctrdContext) GetHostCPUMem(reportPhyCores bool) (types.HostMemory, error) {
+	return selfDomCPUMem(reportPhyCores)
 }
 
 const nanoSecToSec uint64 = 1000000000

--- a/pkg/pillar/hypervisor/null.go
+++ b/pkg/pillar/hypervisor/null.go
@@ -166,8 +166,8 @@ func (ctx nullContext) PCISameController(id1 string, id2 string) bool {
 	return types.PCISameController(id1, id2)
 }
 
-func (ctx nullContext) GetHostCPUMem() (types.HostMemory, error) {
-	return selfDomCPUMem()
+func (ctx nullContext) GetHostCPUMem(reportPhyCores bool) (types.HostMemory, error) {
+	return selfDomCPUMem(reportPhyCores)
 }
 
 func (ctx nullContext) GetDomsCPUMem() (map[string]types.DomainMetric, error) {

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -623,7 +623,7 @@ func (ctx xenContext) PCISameController(id1 string, id2 string) bool {
 	return false
 }
 
-func (ctx xenContext) GetHostCPUMem() (types.HostMemory, error) {
+func (ctx xenContext) GetHostCPUMem(reportPhyCores bool) (types.HostMemory, error) {
 	hm := types.HostMemory{}
 	ctrdSystemCtx, done := ctx.ctrdClient.CtrNewSystemServicesCtx()
 	defer done()

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -256,6 +256,8 @@ const (
 	EnableARPSnoop GlobalSettingKey = "network.switch.enable.arpsnoop"
 	// WwanQueryVisibleProviders : periodically query visible cellular service providers
 	WwanQueryVisibleProviders GlobalSettingKey = "wwan.query.visible.providers"
+	// CPUStatsPhysicalCoreEnable: report Ncpus as Physical Cores instead of Hyperthread/SMT
+	CPUStatsPhysicalCoreEnable GlobalSettingKey = "cpu.stats.physicalcore.enable"
 
 	// TriState Items
 	// NetworkFallbackAnyEth global setting key
@@ -947,6 +949,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddBoolItem(EnableARPSnoop, true)
 	configItemSpecMap.AddBoolItem(WwanQueryVisibleProviders, false)
 	configItemSpecMap.AddBoolItem(NetworkLocalLegacyMACAddress, false)
+	configItemSpecMap.AddBoolItem(CPUStatsPhysicalCoreEnable, false)
 
 	// Add TriState Items
 	configItemSpecMap.AddTriStateItem(NetworkFallbackAnyEth, TS_DISABLED)

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -197,6 +197,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		EnableARPSnoop,
 		WwanQueryVisibleProviders,
 		NetworkLocalLegacyMACAddress,
+		CPUStatsPhysicalCoreEnable,
 		// TriState Items
 		NetworkFallbackAnyEth,
 		MaintenanceMode,


### PR DESCRIPTION
cpu.Info() reports a list of cpus and the list
will be double in length when hyperthreading
is enabled.  This difference also scales cpu utilization.

New config property: cpu.stats.physicalcore.enabled 
Default set to false to allow opt-in usage.
When set to true domainmgr will:
	Take the last cpu.InfoStat's CoreID
	Add 1 (since CoreID starts at 0)
	Set HostMemory.Ncpus to that value.