### PR TITLE
Blocking kube container logs to be sent and some minor changes

### DIFF
--- a/pkg/debug/scripts/collect-info.sh
+++ b/pkg/debug/scripts/collect-info.sh
@@ -6,7 +6,7 @@
 
 # Script version, don't forget to bump up once something is changed
 
-VERSION=29
+VERSION=30
 # Add required packages here, it will be passed to "apk add".
 # Once something added here don't forget to add the same package
 # to the Dockerfile ('ENV PKGS' line) of the debug container,
@@ -453,6 +453,7 @@ fi
 
 ln -s /persist/status       "$DIR/persist-status"
 ln -s /persist/log          "$DIR/persist-log"
+[ -d /persist/kubelog ] && ln -s /persist/kubelog "$DIR/persist-kubelog"
 ln -s /persist/netdump      "$DIR/persist-netdump"
 ln -s /persist/kcrashes     "$DIR/persist-kcrashes"
 [ -d /persist/memory-monitor/output ] && ln -s /persist/memory-monitor/output "$DIR/persist-memory-monitor-output"

--- a/pkg/kube/eve-bridge/eve-bridge.go
+++ b/pkg/kube/eve-bridge/eve-bridge.go
@@ -35,7 +35,7 @@ const (
 )
 
 const (
-	logfileDir    = "/persist/newlog/kube/"
+	logfileDir    = "/persist/kubelog/"
 	logfile       = logfileDir + "eve-bridge.log"
 	logMaxSize    = 100 // 100 Mbytes in size
 	logMaxBackups = 3   // old log files to retain
@@ -84,7 +84,11 @@ func parseArgs(args *skel.CmdArgs) (stdinArgs rawJSONStruct, cniVersion,
 	}
 	podName = string(envArgs.K8S_POD_NAME)
 	isVMI = strings.HasPrefix(podName, vmiPodNamePrefix)
+
 	isEveApp = string(envArgs.K8S_POD_NAMESPACE) == eveKubeNamespace
+	if !isVMI && strings.Contains(podName, "-pvc-") && strings.HasPrefix(podName, "cdi-upload-") {
+		isEveApp = false
+	}
 	if envArgs.MAC != "" {
 		mac, err = net.ParseMAC(string(envArgs.MAC))
 		if err != nil {

--- a/pkg/kube/multus-daemonset.yaml
+++ b/pkg/kube/multus-daemonset.yaml
@@ -124,7 +124,7 @@ data:
       "capabilities": {
         "portMappings": true
       },
-      "logFile": "/persist/newlog/kube/multus.log",
+      "logFile": "/persist/kubelog/multus.log",
       "logLevel": "debug",
       "binDir": "/var/lib/cni/bin",
       "kubeconfig": "/var/lib/rancher/k3s/agent/etc/cni/net.d/multus.d/multus.kubeconfig",

--- a/pkg/newlog/cmd/newlogd.go
+++ b/pkg/newlog/cmd/newlogd.go
@@ -656,6 +656,11 @@ func getMemlogMsg(logChan chan inputEntry, panicFileChan chan []byte) {
 			pidStr = strconv.Itoa(logInfo.Pid)
 		}
 
+		// not to upload 'kube' container logs, one can find in /persist/kubelog for detail
+		if logInfo.Source == "kube" {
+			continue
+		}
+
 		entry := inputEntry{
 			source:    logInfo.Source,
 			content:   logInfo.Msg,

--- a/pkg/pillar/scripts/onboot.sh
+++ b/pkg/pillar/scripts/onboot.sh
@@ -151,7 +151,7 @@ free_space() {
 # If there is less than 4Mbytes (MIN_DISKSPACE) then remove the content of the
 # following directories in order until we have that amount of available space
 # following sub directories:
-PERSIST_CLEANUPS='log netdump kcrashes memory-monitor/output eve-info patchEnvelopesCache patchEnvelopesUsageCache newlog/keepSentQueue newlog/failedUpload newlog/appUpload newlog/devUpload containerd-system-root vault/downloader vault/verifier agentdebug'
+PERSIST_CLEANUPS='log netdump kcrashes memory-monitor/output eve-info patchEnvelopesCache patchEnvelopesUsageCache newlog/keepSentQueue newlog/failedUpload newlog/appUpload newlog/devUpload kubelog containerd-system-root vault/downloader vault/verifier agentdebug'
 # NOTE that we can not cleanup /persist/containerd and /persist/{vault,clear}/volumes since those are used by applications.
 #
 # Note that we need to free up some space before Linuxkit starts containerd,

--- a/pkg/pillar/types/diskmetrics.go
+++ b/pkg/pillar/types/diskmetrics.go
@@ -40,6 +40,7 @@ var ReportDirPaths = []string{
 	PersistDir + "/etcd-storage",
 	PersistDir + "/kcrashes",
 	PersistDir + "/eve-info",
+	PersistDir + "/kubelog",
 }
 
 // AppPersistPaths  Application-related files live here


### PR DESCRIPTION
 - Not sending kube container side of logs, if needed, use collect-info to get the info or logs.
 - kube log directory has changed, adjust various component logging to that