### PR TITLE
[13.6] fix: assets upload to use the correct variable name.

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -42,10 +42,12 @@ jobs:
             }' https://api.github.com/repos/${{ github.repository }}/releases)
           release_id=$(echo "$response" | jq -r .id)
           upload_url=$(echo "$response" | jq -r .upload_url | sed -e "s/{?name,label}//")
+          echo $upload_url
           echo "release_id=$release_id" >> "$GITHUB_OUTPUT"
           echo "upload_url=$upload_url" >> "$GITHUB_OUTPUT"
   build:
     runs-on: ubuntu-20.04
+    needs: create_release
     strategy:
       fail-fast: false
       matrix:
@@ -113,11 +115,11 @@ jobs:
           # Create SHA256 checksum for rootfs.img
           sha256sum "assets/rootfs.img" | awk '{ print $1 }' > "assets/rootfs.img.sha256"
           for file in assets/*; do
-            base_name=$(basename "$asset")
+            base_name=$(basename "$file")
             # Add ARCH prefix
             new_name="${ARCH}.${base_name}"
             # Rename the file
-            mv "$asset" "assets/$new_name"
+            mv "$file" "assets/$new_name"
             echo "Uploading assets/$new_name as $new_name..."
             upload_response=$(curl -s -X POST \
               -H "Authorization: Bearer $GITHUB_TOKEN" \


### PR DESCRIPTION
Backport of: [4411](https://github.com/lf-edge/eve/pull/4411)

No changes made.

Added needs on for the upload job to get the upload url from the create release job.