### PR TITLE
memory-monitor: Add error tolerance to memory allocation logging

### DIFF
--- a/pkg/memory-monitor/src/monitor/memory-monitor-handler.sh
+++ b/pkg/memory-monitor/src/monitor/memory-monitor-handler.sh
@@ -226,7 +226,7 @@ show_pid_mem_usage "eve" "$sorted_eve_processes" "$current_output_dir/memstat_ev
 # ==== Dump memory allocation sites for Pillar ====
 
 eve dump-memory
-logread | grep logMemAllocationSites > "$current_output_dir/allocations_pillar.out"
+logread | grep logMemAllocationSites > "$current_output_dir/allocations_pillar.out" || :
 
 # ==== Trigger a heap dump for Pillar ====
 


### PR DESCRIPTION
Allow the memory-monitor-handler script to proceed even if no memory allocation sites are found in `logread` output. Previously, if `logread` returned no matches for "logMemAllocationSites," the script would terminate due to `set -e`. This change adds `|| :` to handle the potential absence of matches, enabling the script to continue executing subsequent commands.