### PR TITLE
[13.4-stable] memory-monitor: Add error tolerance to memory allocation logging in handler script

### DIFF
--- a/pkg/memory-monitor/src/monitor/memory-monitor-handler.sh
+++ b/pkg/memory-monitor/src/monitor/memory-monitor-handler.sh
@@ -226,7 +226,7 @@ show_pid_mem_usage "eve" "$sorted_eve_processes" "$current_output_dir/memstat_ev
 # ==== Dump memory allocation sites for Pillar ====
 
 eve dump-memory
-logread | grep logMemAllocationSites > "$current_output_dir/allocations_pillar.out"
+logread | grep logMemAllocationSites > "$current_output_dir/allocations_pillar.out" || :
 
 # ==== Trigger a heap dump for Pillar ====
 


### PR DESCRIPTION
Backport of #4415 