### PR TITLE
Update liburing source URL to kernel.org

### DIFF
--- a/pkg/xen-tools/Dockerfile
+++ b/pkg/xen-tools/Dockerfile
@@ -42,12 +42,12 @@ COPY alpine.patch /
 RUN patch -p1 < alpine.patch
 
 ENV LIBURING_VERSION 0.7
-ENV LIBURING_SOURCE=https://git.kernel.dk/cgit/liburing/snapshot/liburing-${LIBURING_VERSION}.tar.bz2
+ENV LIBURING_SOURCE=https://git.kernel.org/pub/scm/linux/kernel/git/axboe/liburing.git/snapshot/liburing-${LIBURING_VERSION}.tar.gz
 
 # Download and verify liburing
 # hadolint ignore=DL3020
-ADD ${LIBURING_SOURCE} /liburing.tar.bz2
-RUN tar --absolute-names -xj < /liburing.tar.bz2 && mv "/liburing-${LIBURING_VERSION}" /liburing
+ADD ${LIBURING_SOURCE} /liburing.tar.gz
+RUN tar --absolute-names -xz < /liburing.tar.gz && mv "/liburing-${LIBURING_VERSION}" /liburing
 
 WORKDIR /liburing
 RUN ./configure --prefix=/usr


### PR DESCRIPTION
The liburing-0.7 is missing from the original source URL. This change updates the source URL to kernel.org. The kernel.org version is the same:

```bash
➜  shah-dev git clone https://git.kernel.dk/cgit/liburing/
➜  liburing git:(master) git checkout 45f0735219a615ae848033c47c7e2d85d101d43e
Note: switching to '45f0735219a615ae848033c47c7e2d85d101d43e'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at 45f0735 .gitignore: add test/cq-overflow-peek
➜  liburing git:(liburing-0.7)
➜  liburing git:(liburing-0.7) cd ..
➜  shah-dev wget https://git.kernel.org/pub/scm/linux/kernel/git/axboe/liburing.git/snapshot//liburing-0.7.tar.gz
➜  shah-dev tar -xzf liburing-0.7.tar.gz
➜  shah-dev diff -r --exclude=".git" liburing liburing-0.7
➜  shah-dev
```