### PR TITLE
Disable iptables for L2-only traffic when everything is allowed by ACLs

### DIFF
--- a/pkg/dom0-ztools/rootfs/etc/sysctl.d/02-eve.conf
+++ b/pkg/dom0-ztools/rootfs/etc/sysctl.d/02-eve.conf
@@ -6,10 +6,6 @@
 # zedrouter settings
 net.ipv4.ip_forward = 1
 net.ipv6.conf.all.forwarding = 1
-# We use ip6tables for the bridge
-net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-net.bridge.bridge-nf-call-arptables = 1
 # The following differs from default linuxkit/alpine of 1
 net.ipv4.conf.all.rp_filter = 2
 net.netfilter.nf_conntrack_acct = 1

--- a/pkg/pillar/nireconciler/linux_reconciler.go
+++ b/pkg/pillar/nireconciler/linux_reconciler.go
@@ -961,7 +961,8 @@ func (r *LinuxNIReconciler) AddAppConn(ctx context.Context,
 	}
 	r.apps[appID] = appInfo
 	reconcileReason := fmt.Sprintf("connecting new app (%v)", appID)
-	// Rebuild and reconcile also global config to update the set of intended IPSets.
+	// Rebuild and reconcile also global config to update the set of intended IPSets
+	// and sysctl settings.
 	r.scheduleGlobalCfgRebuild(reconcileReason)
 	// Rebuild and reconcile config of every NI that this app is trying to connect into.
 	for _, vif := range vifs {
@@ -1006,7 +1007,8 @@ func (r *LinuxNIReconciler) UpdateAppConn(ctx context.Context,
 	}
 	r.apps[appID] = appInfo
 	reconcileReason := fmt.Sprintf("updating app connectivity (%v)", appID)
-	// Rebuild and reconcile also global config to update the set of intended IPSets.
+	// Rebuild and reconcile also global config to update the set of intended IPSets
+	// and sysctl settings.
 	r.scheduleGlobalCfgRebuild(reconcileReason)
 	// Reconcile every NI that this app is disconnecting from, connecting to,
 	// or just updating its connection parameters with.
@@ -1039,7 +1041,8 @@ func (r *LinuxNIReconciler) DelAppConn(ctx context.Context,
 	// Deleted from the map when removal is completed successfully (incl. async ops).
 	r.apps[appID].deleted = true
 	reconcileReason := fmt.Sprintf("disconnecting app (%v)", appID)
-	// Rebuild and reconcile also global config to update the set of intended IPSets.
+	// Rebuild and reconcile also global config to update the set of intended IPSets
+	// and sysctl settings.
 	r.scheduleGlobalCfgRebuild(reconcileReason)
 	// Reconcile every NI that this app is trying to disconnect from.
 	for _, vif := range r.apps[appID].vifs {

--- a/pkg/pillar/nireconciler/linuxitems/sysctl.go
+++ b/pkg/pillar/nireconciler/linuxitems/sysctl.go
@@ -21,20 +21,40 @@ type Sysctl struct {
 	// (and not for the host).
 	ForApp ContainerApp
 	// NetIf : network interface for which parameters are applied.
+	// Leave empty if these are global settings not corresponding to any particular
+	// interface.
 	NetIf genericitems.NetworkIf
+
+	// Leave nil value for undefined options.
+	// SysctlConfigurator will not touch them.
+
 	// EnableDAD : enable duplicate address detection (IPv6).
-	EnableDAD bool
+	// This is a per-interface option.
+	EnableDAD *bool
 	// EnableARPNotify : generate gratuitous arp requests when device is brought up
 	// or hardware address changes
-	EnableARPNotify bool
+	// This is a per-interface option.
+	EnableARPNotify *bool
+	// BridgeCallIptables enables processing of IPv4 packets traversing a Linux bridge
+	// by iptables rules.
+	// This is a global option.
+	BridgeCallIptables *bool
+	// BridgeCallIp6tables enables processing of IPv6 packets traversing a Linux bridge
+	// by ip6tables rules.
+	// This is a global option.
+	BridgeCallIp6tables *bool
 }
 
 // Name of the item instance.
 func (s Sysctl) Name() string {
-	if s.ForApp.ID == emptyUUID {
-		return fmt.Sprintf("sysctl-host-%s", s.NetIf.IfName)
+	var forIfName string
+	if s.NetIf.IfName != "" {
+		forIfName = "-" + s.NetIf.IfName
 	}
-	return fmt.Sprintf("sysctl-%s-%s", s.ForApp.ID, s.NetIf.IfName)
+	if s.ForApp.ID == emptyUUID {
+		return fmt.Sprintf("sysctl-host%s", forIfName)
+	}
+	return fmt.Sprintf("sysctl-%s%s", s.ForApp.ID, forIfName)
 }
 
 // Label is not defined.
@@ -53,7 +73,10 @@ func (s Sysctl) Equal(other dg.Item) bool {
 	if !isSysctl {
 		return false
 	}
-	return s == s2
+	return equalBoolPtr(s.EnableDAD, s2.EnableDAD) &&
+		equalBoolPtr(s.EnableARPNotify, s2.EnableARPNotify) &&
+		equalBoolPtr(s.BridgeCallIptables, s2.BridgeCallIptables) &&
+		equalBoolPtr(s.BridgeCallIp6tables, s2.BridgeCallIp6tables)
 }
 
 // External returns false.
@@ -69,18 +92,51 @@ func (s Sysctl) String() string {
 	} else {
 		prefix = fmt.Sprintf("App %s", s.ForApp)
 	}
+	var forIfName string
+	if s.NetIf.IfName != "" {
+		forIfName = fmt.Sprintf(" for interface '%s'", s.NetIf.IfName)
+	}
 	return fmt.Sprintf(
-		"%s Sysctl: {ifName: %s, enableDAD: %t, enableARPNotify: %t}",
-		prefix, s.NetIf.IfName, s.EnableDAD, s.EnableARPNotify)
+		"%s Sysctl%s: {enableDAD: %s, enableARPNotify: %s, "+
+			"bridgeCallIptables: %s, bridgeCallIp6tables: %s}",
+		prefix, forIfName, boolPtrToString(s.EnableDAD),
+		boolPtrToString(s.EnableARPNotify), boolPtrToString(s.BridgeCallIptables),
+		boolPtrToString(s.BridgeCallIp6tables))
 }
 
 // Dependencies returns the target interface as the only dependency.
 func (s Sysctl) Dependencies() (deps []dg.Dependency) {
-	deps = append(deps, dg.Dependency{
-		RequiredItem: s.NetIf.ItemRef,
-		Description:  "interface referenced by sysctl config must exist",
-	})
+	if s.NetIf.IfName != "" {
+		deps = append(deps, dg.Dependency{
+			RequiredItem: s.NetIf.ItemRef,
+			Description:  "interface referenced by sysctl config must exist",
+		})
+	}
 	return deps
+}
+
+func equalBoolPtr(value1, value2 *bool) bool {
+	if value1 == nil || value2 == nil {
+		return value1 == value2
+	}
+	return *value1 == *value2
+}
+
+func boolPtrToString(value *bool) string {
+	if value == nil {
+		return "undefined"
+	}
+	if *value {
+		return "true"
+	}
+	return "false"
+}
+
+func boolToDigitString(value bool) string {
+	if value {
+		return "1"
+	}
+	return "0"
 }
 
 // SysctlConfigurator implements Configurator for sysctl settings.
@@ -94,11 +150,7 @@ func (c *SysctlConfigurator) Create(ctx context.Context, item dg.Item) error {
 	if !isSysctl {
 		return fmt.Errorf("invalid item type %T, expected Sysctl", item)
 	}
-	err := c.setDAD(sysctl.ForApp.NetNsName, sysctl.NetIf.IfName, sysctl.EnableDAD)
-	if err != nil {
-		return err
-	}
-	return c.setArpNotify(sysctl.ForApp.NetNsName, sysctl.NetIf.IfName, sysctl.EnableARPNotify)
+	return c.apply(sysctl)
 }
 
 // Modify updates sysctl settings.
@@ -107,11 +159,7 @@ func (c *SysctlConfigurator) Modify(ctx context.Context, oldItem, newItem dg.Ite
 	if !isSysctl {
 		return fmt.Errorf("invalid item type %T, expected Sysctl", newItem)
 	}
-	err := c.setDAD(sysctl.ForApp.NetNsName, sysctl.NetIf.IfName, sysctl.EnableDAD)
-	if err != nil {
-		return err
-	}
-	return c.setArpNotify(sysctl.ForApp.NetNsName, sysctl.NetIf.IfName, sysctl.EnableARPNotify)
+	return c.apply(sysctl)
 }
 
 // Delete sets default sysctl settings.
@@ -120,31 +168,83 @@ func (c *SysctlConfigurator) Delete(ctx context.Context, item dg.Item) error {
 	if !isSysctl {
 		return fmt.Errorf("invalid item type %T, expected Sysctl", item)
 	}
-	err := c.setDAD(sysctl.ForApp.NetNsName, sysctl.NetIf.IfName, true)
-	if err != nil {
-		return err
+	defaultSysctl := Sysctl{
+		ForApp: sysctl.ForApp,
+		NetIf:  sysctl.NetIf,
 	}
-	return c.setArpNotify(sysctl.ForApp.NetNsName, sysctl.NetIf.IfName, false)
+	if sysctl.EnableDAD != nil {
+		defaultDAD := true
+		defaultSysctl.EnableDAD = &defaultDAD
+	}
+	if sysctl.EnableARPNotify != nil {
+		defaultARPNotify := false
+		defaultSysctl.EnableARPNotify = &defaultARPNotify
+	}
+	if sysctl.BridgeCallIptables != nil {
+		defaultBridgeCallIptables := true
+		defaultSysctl.BridgeCallIptables = &defaultBridgeCallIptables
+	}
+	if sysctl.BridgeCallIp6tables != nil {
+		defaultBridgeCallIp6tables := true
+		defaultSysctl.BridgeCallIp6tables = &defaultBridgeCallIp6tables
+	}
+	return c.apply(defaultSysctl)
 }
 
-func (c *SysctlConfigurator) setDAD(netNs string, ifName string, enable bool) error {
-	value := c.boolValueToStr(enable)
-	sysctlKV := fmt.Sprintf("net/ipv6/conf/%s/accept_dad=%s", ifName, value)
-	out, err := namespacedCmd(netNs, "sysctl", "-w", sysctlKV).CombinedOutput()
-	if err != nil {
-		errMsg := fmt.Errorf("failed to set DAD for interface %s: %s", ifName, out)
-		c.Log.Error(errMsg)
-		return err
+func (c *SysctlConfigurator) apply(sysctl Sysctl) error {
+	if sysctl.EnableDAD != nil {
+		err := c.setOption(sysctl.ForApp.NetNsName, sysctl.NetIf.IfName,
+			"net/ipv6/conf/%s/accept_dad", *sysctl.EnableDAD)
+		if err != nil {
+			return err
+		}
+	}
+	if sysctl.EnableARPNotify != nil {
+		err := c.setOption(sysctl.ForApp.NetNsName, sysctl.NetIf.IfName,
+			"net/ipv4/conf/%s/arp_notify", *sysctl.EnableARPNotify)
+		if err != nil {
+			return err
+		}
+	}
+	if sysctl.BridgeCallIptables != nil {
+		err := c.setOption(sysctl.ForApp.NetNsName, "",
+			"net.bridge.bridge-nf-call-iptables", *sysctl.BridgeCallIptables)
+		if err != nil {
+			return err
+		}
+	}
+	if sysctl.BridgeCallIp6tables != nil {
+		err := c.setOption(sysctl.ForApp.NetNsName, "",
+			"net.bridge.bridge-nf-call-ip6tables", *sysctl.BridgeCallIp6tables)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }
 
-func (c *SysctlConfigurator) setArpNotify(netNs string, ifName string, enable bool) error {
-	value := c.boolValueToStr(enable)
-	sysctlKV := fmt.Sprintf("net/ipv4/conf/%s/arp_notify=%s", ifName, value)
+func (c *SysctlConfigurator) setOption(
+	netNs, ifName, keyTemplate string, enable bool) error {
+	var sysctlKey string
+	if ifName == "" {
+		// Global option.
+		sysctlKey = keyTemplate
+	} else {
+		sysctlKey = fmt.Sprintf(keyTemplate, ifName)
+	}
+	sysctlKV := sysctlKey + "=" + boolToDigitString(enable)
 	out, err := namespacedCmd(netNs, "sysctl", "-w", sysctlKV).CombinedOutput()
 	if err != nil {
-		errMsg := fmt.Errorf("failed to set ARP-notify for interface %s: %s", ifName, out)
+		action := "enable"
+		if !enable {
+			action = "disable"
+		}
+		var forInterface string
+		if ifName != "" {
+			forInterface = " for interface " + ifName
+		}
+		errMsg := fmt.Errorf("failed to %s option %s%s: %s",
+			action, sysctlKey, forInterface, out)
 		c.Log.Error(errMsg)
 		return err
 	}
@@ -154,11 +254,4 @@ func (c *SysctlConfigurator) setArpNotify(netNs string, ifName string, enable bo
 // NeedsRecreate returns false - Modify is able to apply any change.
 func (c *SysctlConfigurator) NeedsRecreate(oldItem, newItem dg.Item) (recreate bool) {
 	return false
-}
-
-func (c *SysctlConfigurator) boolValueToStr(enable bool) string {
-	if enable {
-		return "1"
-	}
-	return "0"
 }


### PR DESCRIPTION
Avoid using iptables for L2-forwaded (application) traffic if ACLs allow everything (without rate limiting) and flow logging is disabled. Otherwise, unnecessary packet processing steps are added which reduce network performance significantly.

In NFV use cases, filtering and flow logging/monitoring are typically handled by applications (VNFs), so EVE should only focus on providing efficient virtual wiring.

This PR is part of a series of network performance optimizations coming into EVE, see [documentation](https://github.com/milan-zededa/eve/commit/87818d15f1b14141a01813b3800a66084602623c) (will be submitted in a separate PR)