### PR TITLE
Enable the vhost backend for the virtio-net interfaces in the KVM hypervisor

### DIFF
--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -372,6 +372,9 @@ const qemuNetTemplate = `
   br = "{{.Bridge}}"
   script = "/etc/xen/scripts/qemu-ifup"
   downscript = "no"
+{{- if eq .Driver "virtio-net-pci" }}
+  vhost = "on"
+{{- end}}
 
 [device "net{{.NetID}}"]
   driver = "{{.Driver}}"

--- a/pkg/pillar/hypervisor/kvm_test.go
+++ b/pkg/pillar/hypervisor/kvm_test.go
@@ -324,6 +324,7 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
   br = "bn0"
   script = "/etc/xen/scripts/qemu-ifup"
   downscript = "no"
+  vhost = "on"
 
 [device "net0"]
   driver = "virtio-net-pci"
@@ -346,6 +347,7 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
   br = "bn0"
   script = "/etc/xen/scripts/qemu-ifup"
   downscript = "no"
+  vhost = "on"
 
 [device "net1"]
   driver = "virtio-net-pci"
@@ -610,6 +612,7 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
   br = "bn0"
   script = "/etc/xen/scripts/qemu-ifup"
   downscript = "no"
+  vhost = "on"
 
 [device "net0"]
   driver = "virtio-net-pci"
@@ -632,6 +635,7 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
   br = "bn0"
   script = "/etc/xen/scripts/qemu-ifup"
   downscript = "no"
+  vhost = "on"
 
 [device "net1"]
   driver = "virtio-net-pci"
@@ -863,6 +867,7 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
   br = "bn0"
   script = "/etc/xen/scripts/qemu-ifup"
   downscript = "no"
+  vhost = "on"
 
 [device "net0"]
   driver = "virtio-net-pci"
@@ -885,6 +890,7 @@ func TestCreateDomConfigOnlyCom1(t *testing.T) {
   br = "bn0"
   script = "/etc/xen/scripts/qemu-ifup"
   downscript = "no"
+  vhost = "on"
 
 [device "net1"]
   driver = "virtio-net-pci"
@@ -1352,6 +1358,7 @@ func domConfigArm64() string {
   br = "bn0"
   script = "/etc/xen/scripts/qemu-ifup"
   downscript = "no"
+  vhost = "on"
 
 [device "net0"]
   driver = "virtio-net-pci"
@@ -1374,6 +1381,7 @@ func domConfigArm64() string {
   br = "bn0"
   script = "/etc/xen/scripts/qemu-ifup"
   downscript = "no"
+  vhost = "on"
 
 [device "net1"]
   driver = "virtio-net-pci"
@@ -1649,6 +1657,7 @@ func domConfigAmd64FML() string {
   br = "bn0"
   script = "/etc/xen/scripts/qemu-ifup"
   downscript = "no"
+  vhost = "on"
 
 [device "net0"]
   driver = "virtio-net-pci"
@@ -1671,6 +1680,7 @@ func domConfigAmd64FML() string {
   br = "bn0"
   script = "/etc/xen/scripts/qemu-ifup"
   downscript = "no"
+  vhost = "on"
 
 [device "net1"]
   driver = "virtio-net-pci"
@@ -2234,6 +2244,7 @@ func domConfigAmd64() string {
   br = "bn0"
   script = "/etc/xen/scripts/qemu-ifup"
   downscript = "no"
+  vhost = "on"
 
 [device "net0"]
   driver = "virtio-net-pci"
@@ -2256,6 +2267,7 @@ func domConfigAmd64() string {
   br = "bn0"
   script = "/etc/xen/scripts/qemu-ifup"
   downscript = "no"
+  vhost = "on"
 
 [device "net1"]
   driver = "virtio-net-pci"
@@ -2520,6 +2532,7 @@ func domConfigContainerVNC() string {
   br = "bn0"
   script = "/etc/xen/scripts/qemu-ifup"
   downscript = "no"
+  vhost = "on"
 
 [device "net0"]
   driver = "virtio-net-pci"
@@ -2542,6 +2555,7 @@ func domConfigContainerVNC() string {
   br = "bn0"
   script = "/etc/xen/scripts/qemu-ifup"
   downscript = "no"
+  vhost = "on"
 
 [device "net1"]
   driver = "virtio-net-pci"


### PR DESCRIPTION
Using vhost as the backend for virtio-net in a QEMU/KVM setup bypasses QEMU's user-space network packet processing by moving packet handling directly into the Linux kernel. Normally, QEMU would process network I/O in user space, which incurs significant CPU overhead and latency due to frequent context switching between user space (QEMU) and kernel space. With vhost, packet processing is handled by a dedicated kernel thread, avoiding QEMU for most networking tasks. This direct kernel handling minimizes the need for QEMU’s intervention, resulting in lower latency, higher throughput, and better CPU efficiency for network-intensive applications running on virtual machines.

Using vhost is a clear choice with no downsides, as it is already included in eve-kernel and does not increase the EVE image size. Reducing QEMU overhead is especially important for EVE, where we enforce cgroup CPU quotas to limit application to using no more than N CPUs at a time, with N being the number of vCPUs assigned to the app in its configuration (see [here](https://github.com/lf-edge/eve/blob/master/pkg/pillar/containerd/oci.go#L484-L488)). These CPU quotas apply to both the application and QEMU itself, so removing QEMU from packet processing is essential to prevent it from consuming CPU cycles needed by the application.

This PR is part of a series of network performance optimizations coming into EVE, see [documentation](https://github.com/milan-zededa/eve/commit/87818d15f1b14141a01813b3800a66084602623c) (will be submitted in a separate PR)