### PR TITLE
All-Ones netmask is not needed for ACLs or flow logging

### DIFF
--- a/pkg/pillar/nireconciler/genericitems/dnsmasq_test.go
+++ b/pkg/pillar/nireconciler/genericitems/dnsmasq_test.go
@@ -36,8 +36,7 @@ func exampleDnsmasqParams() genericitems.Dnsmasq {
 	dnsmasq.ListenIf.IfName = "br0"
 	_, subnet, _ := net.ParseCIDR("10.0.0.0/24")
 	dnsmasq.DHCPServer = genericitems.DHCPServer{
-		Subnet:         subnet,
-		AllOnesNetmask: true,
+		Subnet: subnet,
 		IPRange: genericitems.IPRange{
 			FromIP: net.IP{10, 0, 0, 2},
 			ToIP:   net.IP{10, 0, 0, 123},
@@ -156,10 +155,10 @@ hostsdir=/run/zedrouter/hosts.br0
 dhcp-hostsdir=/run/zedrouter/dhcp-hosts.br0
 dhcp-option=option:dns-server,10.0.0.1,1.1.1.1
 dhcp-option=option:ntp-server,94.130.35.4,94.16.114.254
-dhcp-option=option:netmask,255.255.255.255
+dhcp-option=option:netmask,255.255.255.0
 dhcp-option=option:router,10.0.0.1
-dhcp-option=tag:endpoint,option:classless-static-route,10.0.0.1/32,0.0.0.0,10.0.0.0/24,10.0.0.1,192.168.1.0/24,10.0.0.1,172.30.0.0/16,10.0.0.1,0.0.0.0/0,10.0.0.1
-dhcp-option=tag:gateway-10-0-0-100,option:classless-static-route,10.0.0.1/32,0.0.0.0,10.0.0.0/24,10.0.0.1,192.168.1.0/24,10.0.0.1,0.0.0.0/0,10.0.0.1
+dhcp-option=tag:endpoint,option:classless-static-route,10.0.0.0/24,0.0.0.0,192.168.1.0/24,10.0.0.1,172.30.0.0/16,10.0.0.100,0.0.0.0/0,10.0.0.1
+dhcp-option=tag:gateway-10-0-0-100,option:classless-static-route,10.0.0.0/24,0.0.0.0,192.168.1.0/24,10.0.0.1,0.0.0.0/0,10.0.0.1
 dhcp-range=10.0.0.2,10.0.0.123,255.255.255.0,60m
 `
 	if configExpected != config {
@@ -202,23 +201,6 @@ func TestCreateDnsmasqConfigWithoutGateway(t *testing.T) {
 
 	dhcpRangeRex := "(?m)^dhcp-range=10.0.0.2,10.0.0.123,255.255.255.0,60m$"
 	ok, err = regexp.MatchString(dhcpRangeRex, config)
-	if err != nil {
-		panic(err)
-	}
-	if !ok {
-		t.Fatalf("expected to match '%s', but got '%s'", dhcpRangeRex, config)
-	}
-}
-
-func TestCreateDnsmasqConfigWithDisabledAllOnesNetmask(t *testing.T) {
-	t.Parallel()
-
-	dnsmasq := exampleDnsmasqParams()
-	dnsmasq.DHCPServer.AllOnesNetmask = false
-	config := createDnsmasqConfig(dnsmasq)
-
-	dhcpRangeRex := "(?m)^dhcp-range=10.0.0.2,10.0.0.123,255.255.255.0,60m$"
-	ok, err := regexp.MatchString(dhcpRangeRex, config)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/pillar/nireconciler/linux_config.go
+++ b/pkg/pillar/nireconciler/linux_config.go
@@ -746,7 +746,7 @@ func (r *LinuxNIReconciler) getIntendedNIL3Cfg(niID uuid.UUID) dg.Graph {
 			continue
 		}
 		isAppGW := gateway != nil && r.getNISubnet(ni).Contains(gateway)
-		if isAppGW && r.disableAllOnesNetmask {
+		if isAppGW {
 			// Route is not needed inside the host, traffic is just forwarded
 			// by the bridge.
 			continue
@@ -1055,8 +1055,7 @@ func (r *LinuxNIReconciler) getIntendedDnsmasqCfg(niID uuid.UUID) (items []dg.It
 	}
 	propagateRoutes = generics.FilterDuplicatesFn(propagateRoutes, generic.EqualIPRoutes)
 	dhcpCfg := generic.DHCPServer{
-		Subnet:         r.getNISubnet(ni),
-		AllOnesNetmask: !r.disableAllOnesNetmask,
+		Subnet: r.getNISubnet(ni),
 		IPRange: generic.IPRange{
 			FromIP: ni.config.DhcpRange.Start,
 			ToIP:   ni.config.DhcpRange.End,

--- a/pkg/pillar/nireconciler/linux_reconciler.go
+++ b/pkg/pillar/nireconciler/linux_reconciler.go
@@ -67,9 +67,6 @@ type LinuxNIReconciler struct {
 	exportIntendedState      bool
 	withKubernetesNetworking bool
 
-	// From GCP
-	disableAllOnesNetmask bool
-
 	reconcileMu   sync.Mutex
 	currentState  dg.Graph
 	intendedState dg.Graph
@@ -801,25 +798,7 @@ func (r *LinuxNIReconciler) ResumeReconcile(ctx context.Context) {
 // ApplyUpdatedGCP : apply change in the global config properties.
 func (r *LinuxNIReconciler) ApplyUpdatedGCP(ctx context.Context,
 	newGCP types.ConfigItemValueMap) {
-	contWatcher := r.pauseWatcher()
-	defer contWatcher()
-	disableAllOnesNetmask := newGCP.GlobalValueBool(types.DisableDHCPAllOnesNetMask)
-	if r.disableAllOnesNetmask == disableAllOnesNetmask {
-		// No change in GCP relevant for network instances.
-		return
-	}
-	r.disableAllOnesNetmask = disableAllOnesNetmask
-	for niID, ni := range r.nis {
-		if ni.config.Type == types.NetworkInstanceTypeSwitch {
-			// Not running DHCP server for switch NI inside EVE.
-			continue
-		}
-		r.scheduleNICfgRebuild(niID,
-			fmt.Sprintf("global config property %s changed to %t",
-				types.DisableDHCPAllOnesNetMask, r.disableAllOnesNetmask))
-	}
-	updates := r.reconcile(ctx)
-	r.publishReconcilerUpdates(updates...)
+	// NOOP
 }
 
 // AddNI : create this new network instance inside the network stack.

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -298,7 +298,12 @@ const (
 	// FmlCustomResolution global setting key
 	FmlCustomResolution GlobalSettingKey = "app.fml.resolution"
 
-	// XXX Temporary flag to disable RFC 3442 classless static route usage
+	// DisableDHCPAllOnesNetMask option is deprecated and has no effect.
+	// Zedrouter no longer uses the all-ones netmask as it adds unnecessary complexity,
+	// causes confusion for some applications, and is no longer required for any EVE
+	// functionality (previously it was supposedly needed for ACLs and flow logging).
+	// We keep the option defined to avoid reporting errors in ZInfoDevice.ConfigItemStatus
+	// for older deployments where this option is still configured.
 	DisableDHCPAllOnesNetMask GlobalSettingKey = "debug.disable.dhcp.all-ones.netmask"
 
 	// ProcessCloudInitMultiPart to help VMs which do not handle mime multi-part themselves


### PR DESCRIPTION
The DHCP server deployed by EVE for Local Network Instances assigns IP addresses to applications with a `/32` netmask (all-ones) and uses the Classless Static Route Option ([RFC 3442](https://datatracker.ietf.org/doc/html/rfc3442)) to configure static routes for the NI subnet. This setup enforces routing even for east-west (app-to-app) traffic, which would otherwise only be forwarded if the actual NI subnet mask (e.g., `/24`) was used.

This approach was historically implemented to prevent east-west traffic from bypassing ACLs and to ensure that connection tracking (conntrack) entries were created for flow logging purposes. However, it became unnecessary after we enabled the `net.bridge.bridge-nf-call-ip(6)tables` option, which ensures that even traffic forwarded by a bridge within EVE passes through iptables filtering and has conntrack entries created.

Using a `/32` netmask now offers no added value and has some drawbacks. First, applications may use DHCP servers with the Classless Route option disabled, resulting in obtaining all-ones netmask with no reachable destinations due to missing connected routes. Second, enforcing routing adds extra packet processing steps for traffic that could be directly forwarded between applications, increasing overhead and reducing network performance.

We previously added an option to disable the all-ones netmask (while still keeping it enabled by default), but this has increased code complexity since it requires two distinct routing configurations to manage (and test). I propose removing the all-ones netmask configuration altogether to simplify the code and reduce packet processing overhead. While some may consider this a breaking change, I believe the change in the netmask should not impact applications as long as IP addresses are preserved and the overall routing/bridging functionality remains consistent across EVE upgrades (the set of reachable destinations does not change).

This PR is part of a series of network performance optimizations coming into EVE, see [documentation](https://github.com/milan-zededa/eve/commit/87818d15f1b14141a01813b3800a66084602623c) (will be submitted in a separate PR)