### PR TITLE
Initial raspberrypi5 support

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -257,10 +257,9 @@ function set_arm64_baremetal {
    fi
    if [ "$smb_vendor" = "raspberrypi" ]; then
       smbios -t 1 -s 5 --set smb_product
-      if [ "$smb_product" = "rpi" ]; then
+      if regexp -- "Raspberry Pi 4 Model B Rev.*" "$smb_product"; then
          set_to_existing_file devicetree /boot/dtb/broadcom/bcm2711-rpi-4-b.dtb
-      elif [ "$smb_product" = "Raspberry Pi 5 Model B Rev 1.0" ]; then
-         #set_to_existing_file devicetree /boot/dtb/broadcom/bcm2712-rpi-5-b.dtb
+      elif regexp -- "Raspberry Pi 5 Model B Rev.*" "$smb_product"; then
          set_global dom0_console "console=ttyAMA10 console=tty1"
       elif [ "$smb_product" = "uno-220" ]; then
          set_to_existing_file devicetree /boot/dtb/broadcom/raspberrypi-uno-220.dtb

--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -259,6 +259,9 @@ function set_arm64_baremetal {
       smbios -t 1 -s 5 --set smb_product
       if [ "$smb_product" = "rpi" ]; then
          set_to_existing_file devicetree /boot/dtb/broadcom/bcm2711-rpi-4-b.dtb
+      elif [ "$smb_product" = "Raspberry Pi 5 Model B Rev 1.0" ]; then
+         #set_to_existing_file devicetree /boot/dtb/broadcom/bcm2712-rpi-5-b.dtb
+         set_global dom0_console "console=ttyAMA10 console=tty1"
       elif [ "$smb_product" = "uno-220" ]; then
          set_to_existing_file devicetree /boot/dtb/broadcom/raspberrypi-uno-220.dtb
       fi

--- a/pkg/u-boot/Dockerfile
+++ b/pkg/u-boot/Dockerfile
@@ -8,7 +8,9 @@ SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
 ENV VERSION v2024.10-rc2
 ENV SOURCE_URL https://github.com/u-boot/u-boot/archive/${VERSION}.tar.gz
 ENV RASPBERRY_FIRMWARE_BLOBS_VERSION 1.20211007
+ENV RASPBERRY_FIRMWARE_BLOBS_VERSION2 1.20240306
 ENV RASPBERRY_FIRMWARE_BLOBS https://github.com/raspberrypi/firmware/raw/${RASPBERRY_FIRMWARE_BLOBS_VERSION}
+ENV RASPBERRY_FIRMWARE_BLOBS2 https://github.com/raspberrypi/firmware/raw/${RASPBERRY_FIRMWARE_BLOBS_VERSION2}
 
 # hadolint ignore=DL3020
 ADD ${SOURCE_URL} /uboot.tar.gz
@@ -39,6 +41,8 @@ ADD ${RASPBERRY_FIRMWARE_BLOBS}/boot/fixup4.dat /tmp/rpi/fixup4.dat
 ADD ${RASPBERRY_FIRMWARE_BLOBS}/boot/start4.elf /tmp/rpi/start4.elf
 # hadolint ignore=DL3020
 ADD ${RASPBERRY_FIRMWARE_BLOBS}/boot/bcm2711-rpi-cm4.dtb /tmp/rpi/bcm2711-rpi-cm4.dtb
+# hadolint ignore=DL3020
+ADD ${RASPBERRY_FIRMWARE_BLOBS2}/boot/bcm2712-rpi-5-b.dtb /tmp/rpi/bcm2712-rpi-5-b.dtb
 # hadolint ignore=DL3020,SC3060
 RUN  for i in /tmp/rpi/overlays/*.dts ; do                                         \
           dtc -@ -I dts -O dtb -o "${i/.dts/.dtbo}" "$i" && rm "$i"     ;\

--- a/pkg/u-boot/Dockerfile
+++ b/pkg/u-boot/Dockerfile
@@ -8,9 +8,9 @@ SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
 ENV VERSION v2024.10-rc2
 ENV SOURCE_URL https://github.com/u-boot/u-boot/archive/${VERSION}.tar.gz
 ENV RASPBERRY_FIRMWARE_BLOBS_VERSION 1.20211007
-ENV RASPBERRY_FIRMWARE_BLOBS_VERSION2 1.20240306
+ENV RASPBERRY_FIRMWARE_BLOBS_VERSION_RPI5 1.20240306
 ENV RASPBERRY_FIRMWARE_BLOBS https://github.com/raspberrypi/firmware/raw/${RASPBERRY_FIRMWARE_BLOBS_VERSION}
-ENV RASPBERRY_FIRMWARE_BLOBS2 https://github.com/raspberrypi/firmware/raw/${RASPBERRY_FIRMWARE_BLOBS_VERSION2}
+ENV RASPBERRY_FIRMWARE_BLOBS_RPI5 https://github.com/raspberrypi/firmware/raw/${RASPBERRY_FIRMWARE_BLOBS_VERSION_RPI5}
 
 # hadolint ignore=DL3020
 ADD ${SOURCE_URL} /uboot.tar.gz
@@ -42,7 +42,7 @@ ADD ${RASPBERRY_FIRMWARE_BLOBS}/boot/start4.elf /tmp/rpi/start4.elf
 # hadolint ignore=DL3020
 ADD ${RASPBERRY_FIRMWARE_BLOBS}/boot/bcm2711-rpi-cm4.dtb /tmp/rpi/bcm2711-rpi-cm4.dtb
 # hadolint ignore=DL3020
-ADD ${RASPBERRY_FIRMWARE_BLOBS2}/boot/bcm2712-rpi-5-b.dtb /tmp/rpi/bcm2712-rpi-5-b.dtb
+ADD ${RASPBERRY_FIRMWARE_BLOBS_RPI5}/boot/bcm2712-rpi-5-b.dtb /tmp/rpi/bcm2712-rpi-5-b.dtb
 # hadolint ignore=DL3020,SC3060
 RUN  for i in /tmp/rpi/overlays/*.dts ; do                                         \
           dtc -@ -I dts -O dtb -o "${i/.dts/.dtbo}" "$i" && rm "$i"     ;\

--- a/pkg/u-boot/patches/patches-v2024.10-rc2/0005-Enable-mmc_sdhci_bcmstb.patch
+++ b/pkg/u-boot/patches/patches-v2024.10-rc2/0005-Enable-mmc_sdhci_bcmstb.patch
@@ -1,0 +1,27 @@
+From 888d45191674ba34c9ec03100e9db9f51bf7f562 Mon Sep 17 00:00:00 2001
+From: Dimitrios Poulios <dpoulios85@gmail.com>
+Date: Wed, 6 Nov 2024 11:53:46 +0200
+Subject: [PATCH] Enable mmc_sdhci_bcmstb
+
+Enable mmc_sdhci_bcmstb needed by rpi5
+
+Signed-off-by: Dimitrios Poulios <dpoulios85@gmail.com>
+---
+ configs/rpi_4_defconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/configs/rpi_4_defconfig b/configs/rpi_4_defconfig
+index fe44933d..8d92bc6a 100644
+--- a/configs/rpi_4_defconfig
++++ b/configs/rpi_4_defconfig
+@@ -39,6 +39,7 @@ CONFIG_BCM2835_GPIO=y
+ CONFIG_MMC_SDHCI=y
+ CONFIG_MMC_SDHCI_SDMA=y
+ CONFIG_MMC_SDHCI_BCM2835=y
++CONFIG_MMC_SDHCI_BCMSTB=y
+ CONFIG_BCMGENET=y
+ CONFIG_PCI_BRCMSTB=y
+ CONFIG_PINCTRL=y
+-- 
+2.45.2
+


### PR DESCRIPTION
Initial support for rpi5:
- u-boot still has very limited support for rpi5 (no pci/usb/ethernet/hdmi output)
- so, we can only boot from the sd card now
- eve support is ok, however