### PR TITLE
memory-monitor: Fix memory monitor config update for debug container.

### DIFF
--- a/pkg/dom0-ztools/rootfs/bin/eve
+++ b/pkg/dom0-ztools/rootfs/bin/eve
@@ -256,7 +256,7 @@ __EOT__
           echo "Your information can be found in logread"
           ;;
  memory-monitor-update-config)
-          pkill -SIGHUP -o /sbin/memory-monitor
+          pkill -SIGHUP -o memory-monitor
           echo "Updated memory-monitor configuration"
           ;;
  psi-collector)


### PR DESCRIPTION
Update the pkill command in the memory-monitor-update-config case to use the process name (memory-monitor) instead of the full path (/sbin/memory-monitor). This change ensures compatibility with the debug container, which uses procps-ng version 3.3.17 that does not support full paths in the pkill command.

This adjustment makes the command functional when executed in the debug container, improving usability for users connecting via SSH.

To be backported into 13.4.0-stable