### PR TITLE
[13.4-stable] memory-monitor: Fix memory monitor config update for debug container.

### DIFF
--- a/pkg/dom0-ztools/rootfs/bin/eve
+++ b/pkg/dom0-ztools/rootfs/bin/eve
@@ -256,7 +256,7 @@ __EOT__
           echo "Your information can be found in logread"
           ;;
  memory-monitor-update-config)
-          pkill -SIGHUP -o /sbin/memory-monitor
+          pkill -SIGHUP -o memory-monitor
           echo "Updated memory-monitor configuration"
           ;;
  psi-collector)


### PR DESCRIPTION
Backport of #4453 