### PR TITLE
Add missing nil check for DPC when processing wwan status update

### DIFF
--- a/pkg/pillar/dpcmanager/wwan.go
+++ b/pkg/pillar/dpcmanager/wwan.go
@@ -76,14 +76,14 @@ func (m *DpcManager) processWwanStatus(ctx context.Context, status types.WwanSta
 	}
 
 	if changed || wasInProgress {
-		if m.currentDPC() != nil {
-			changedDPC := m.setDiscoveredWwanIfNames(m.currentDPC())
+		if dpc != nil {
+			changedDPC := m.setDiscoveredWwanIfNames(dpc)
 			if changedDPC {
 				m.publishDPCL()
 			}
 		}
 		m.updateDNS()
-		if dpc.State == types.DPCStateWwanWait {
+		if dpc != nil && dpc.State == types.DPCStateWwanWait {
 			m.runVerify(ctx, "wwan status is up-to-date")
 		} else {
 			m.restartVerify(ctx, "wwan status changed")


### PR DESCRIPTION
DPC can be still nil when `DPCManager` receives the first status from the wwan microservice. Without the nil check, `processWwanStatus` function may therefore hit the nil dereference panic.

Another small change in this commit is to avoid redundant calls to `currentDPC()` - dpc is already retrieved at the beginning of the function.

The issue was found during 13.4 LTS testing - it is also the only LTS version affected (the problematic if-statement was added in 12.5.0)