### PR TITLE
ioBundle->NetworkPortStatus matching tightening for IsPort()

### DIFF
--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -887,9 +887,9 @@ func printOutput(ctx *diagContext, caller string) {
 		// Print usefully formatted info based on which
 		// fields are set and Dhcp type; proxy info order
 		ifname := port.IfName
-		isMgmt := types.IsMgmtPort(*ctx.DeviceNetworkStatus, ifname)
+		isMgmt := types.IsMgmtPort(*ctx.DeviceNetworkStatus, ifname, port.USBAddr, port.USBProd, port.PCIAddr)
 		cost := types.GetPortCost(*ctx.DeviceNetworkStatus,
-			ifname)
+			ifname, port.USBAddr, port.USBProd, port.PCIAddr)
 		if isMgmt {
 			mgmtPorts++
 		}

--- a/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
+++ b/pkg/pillar/cmd/wstunnelclient/wstunnelclient.go
@@ -387,7 +387,7 @@ func scanAIConfigs(ctx *wstunnelclientContext) {
 	deviceNetworkStatus := ctx.dnsContext.deviceNetworkStatus
 	for _, port := range deviceNetworkStatus.Ports {
 		ifname := port.IfName
-		if !types.IsMgmtPort(*deviceNetworkStatus, ifname) {
+		if !types.IsMgmtPort(*deviceNetworkStatus, ifname, port.USBAddr, port.USBProd, port.PCIAddr) {
 			log.Tracef("Skipping connection using non-mangement intf %s\n",
 				ifname)
 			continue

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -1138,6 +1138,7 @@ func propagatePhyioAttrsToPort(port *types.NetworkPortConfig, phyio *types.Physi
 	port.Phylabel = phyio.Phylabel
 	port.IfName = phyio.Phyaddr.Ifname
 	port.USBAddr = phyio.Phyaddr.UsbAddr
+	port.USBProd = phyio.Phyaddr.UsbProduct
 	port.PCIAddr = phyio.Phyaddr.PciLong
 	if port.IfName == "" {
 		// Inside device model, network adapter may be referenced by PCI or USB address

--- a/pkg/pillar/dpcmanager/dns.go
+++ b/pkg/pillar/dpcmanager/dns.go
@@ -47,6 +47,9 @@ func (m *DpcManager) updateDNS() {
 	m.deviceNetStatus.Ports = make([]types.NetworkPortStatus, len(dpc.Ports))
 	for ix, port := range dpc.Ports {
 		m.deviceNetStatus.Ports[ix].IfName = port.IfName
+		m.deviceNetStatus.Ports[ix].USBAddr = port.USBAddr
+		m.deviceNetStatus.Ports[ix].USBProd = port.USBProd
+		m.deviceNetStatus.Ports[ix].PCIAddr = port.PCIAddr
 		m.deviceNetStatus.Ports[ix].Phylabel = port.Phylabel
 		m.deviceNetStatus.Ports[ix].Logicallabel = port.Logicallabel
 		m.deviceNetStatus.Ports[ix].SharedLabels = port.SharedLabels

--- a/pkg/pillar/types/dns.go
+++ b/pkg/pillar/types/dns.go
@@ -31,6 +31,9 @@ type DeviceNetworkStatus struct {
 
 type NetworkPortStatus struct {
 	IfName       string
+	USBAddr      string
+	USBProd      string
+	PCIAddr      string
 	Phylabel     string // Physical name set by controller/model
 	Logicallabel string
 	// Unlike the logicallabel, which is defined in the device model and unique
@@ -682,9 +685,18 @@ func getLocalAddrListImpl(dns DeviceNetworkStatus,
 }
 
 // Check if an interface name is a port owned by nim
-func IsPort(dns DeviceNetworkStatus, ifname string) bool {
+func IsPort(dns DeviceNetworkStatus, ifname string, usbaddr string, usbprod string, pciaddr string) bool {
 	for _, us := range dns.Ports {
-		if us.IfName != ifname {
+		if ifname != "" && us.IfName != ifname {
+			continue
+		}
+		if us.USBAddr != usbaddr {
+			continue
+		}
+		if us.USBProd != usbprod {
+			continue
+		}
+		if us.PCIAddr != pciaddr {
 			continue
 		}
 		return true
@@ -692,21 +704,19 @@ func IsPort(dns DeviceNetworkStatus, ifname string) bool {
 	return false
 }
 
-// IsL3Port checks if an interface name belongs to a port with SystemAdapter attached.
-func IsL3Port(dns DeviceNetworkStatus, ifname string) bool {
+// Check if a physical label or ifname is a management port
+func IsMgmtPort(dns DeviceNetworkStatus, ifname string, usbaddr string, usbprod string, pciaddr string) bool {
 	for _, us := range dns.Ports {
-		if us.IfName != ifname {
+		if ifname != "" && us.IfName != ifname {
 			continue
 		}
-		return us.IsL3Port
-	}
-	return false
-}
-
-// Check if a physical label or ifname is a management port
-func IsMgmtPort(dns DeviceNetworkStatus, ifname string) bool {
-	for _, us := range dns.Ports {
-		if us.IfName != ifname {
+		if us.USBAddr != usbaddr {
+			continue
+		}
+		if us.USBProd != usbprod {
+			continue
+		}
+		if us.PCIAddr != pciaddr {
 			continue
 		}
 		if dns.Version >= DPCIsMgmt &&
@@ -720,9 +730,18 @@ func IsMgmtPort(dns DeviceNetworkStatus, ifname string) bool {
 
 // GetPortCost returns the port cost
 // Returns 0 if the ifname does not exist.
-func GetPortCost(dns DeviceNetworkStatus, ifname string) uint8 {
+func GetPortCost(dns DeviceNetworkStatus, ifname string, usbaddr string, usbprod string, pciaddr string) uint8 {
 	for _, us := range dns.Ports {
-		if us.IfName != ifname {
+		if ifname != "" && us.IfName != ifname {
+			continue
+		}
+		if us.USBAddr != usbaddr {
+			continue
+		}
+		if us.USBProd != usbprod {
+			continue
+		}
+		if us.PCIAddr != pciaddr {
 			continue
 		}
 		return us.Cost
@@ -732,7 +751,7 @@ func GetPortCost(dns DeviceNetworkStatus, ifname string) uint8 {
 
 func GetPort(dns DeviceNetworkStatus, ifname string) *NetworkPortStatus {
 	for _, us := range dns.Ports {
-		if us.IfName != ifname {
+		if ifname != "" && us.IfName != ifname {
 			continue
 		}
 		if dns.Version < DPCIsMgmt {

--- a/pkg/pillar/types/dpc.go
+++ b/pkg/pillar/types/dpc.go
@@ -442,6 +442,7 @@ func (config *DevicePortConfig) MostlyEqual(config2 *DevicePortConfig) bool {
 		if p1.IfName != p2.IfName ||
 			p1.PCIAddr != p2.PCIAddr ||
 			p1.USBAddr != p2.USBAddr ||
+			p1.USBProd != p2.USBProd ||
 			p1.Phylabel != p2.Phylabel ||
 			p1.Logicallabel != p2.Logicallabel ||
 			!generics.EqualSets(p1.SharedLabels, p2.SharedLabels) ||
@@ -567,6 +568,7 @@ func (config *DevicePortConfig) IsAnyPortInPciBack(
 type NetworkPortConfig struct {
 	IfName       string
 	USBAddr      string
+	USBProd      string
 	PCIAddr      string
 	Phylabel     string // Physical name set by controller/model
 	Logicallabel string // SystemAdapter's name which is logical label in phyio


### PR DESCRIPTION
Check all three identifiers: ifname, usbaddr, pciaddr
Some io types can have an empty string in one of these fields.
Expand matching conditions to ensure ioBundles are not incorrectly matched to a different NetworkPort.

While modifying the parameters to types.IsPort() I discovered an unused isPort() which referenced a lock that appears to be used nowhere else and removed both.
