### PR TITLE
[13.4 stable] Re-execute full validation for AppNetworkConfig once pending NIs are ready

### DIFF
--- a/pkg/pillar/cmd/zedrouter/appnetwork.go
+++ b/pkg/pillar/cmd/zedrouter/appnetwork.go
@@ -266,7 +266,12 @@ func (z *zedrouter) checkAndRecreateAppNetworks(niID uuid.UUID) {
 		}
 		if !appNetStatus.HasError() && !appNetStatus.AwaitNetworkInstance &&
 			appNetConfig.Activate && !appNetStatus.Activated {
-			z.doActivateAppNetwork(*appNetConfig, &appNetStatus)
+			// Re-execute the entire pubsub handler to repeat the full validation process.
+			// The conditions might have changed while the application was waiting for the
+			// network instance to appear or get fixed. For instance, another application
+			// with conflicting port forwarding rules could have been deployed during this
+			// time, which would necessitate preventing the activation of this app's network.
+			z.handleAppNetworkCreate(nil, appNetConfig.Key(), *appNetConfig)
 		}
 		z.log.Functionf("checkAndRecreateAppNetworks(%v) done for %s",
 			niID, appNetConfig.DisplayName)


### PR DESCRIPTION
When an application network configuration depends on a network instance (NI) that is either missing or in an error state, zedrouter flags the AppNetworkStatus with AwaitNetworkInstance. It then waits until the network instance becomes available and is activated without errors before proceeding with the activation of the application network.

However, conditions may change while the application is waiting for the network instance to be available. For instance, another application with conflicting port forwarding rules could have been deployed during this time, which would necessitate preventing the activation of this app's network.

To address this, we adopt the approach used in zedrouter.retryFailedAppNetworks(), where the entire pubsub handler is re-executed to repeat the full validation process. The handler is idempotent, ensuring operations like AppNum allocation reuse previously set values.

Signed-off-by: Milan Lenco <milan@zededa.com>
(cherry picked from commit 06454fad7f3921b78c97c6073394090d430f5818)