### PR TITLE
Bump Eden version to 1.0.0 in GHA

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -113,27 +113,27 @@ jobs:
         hv: [kvm]
         platform: ["generic"]
     if: github.event.review.state == 'approved'
-    uses: lf-edge/eden/.github/workflows/test.yml@0.9.13
+    uses: lf-edge/eden/.github/workflows/test.yml@v1.0.0
     secrets: inherit
     with:
       eve_image: "evebuild/pr:${{ github.event.pull_request.number  }}"
       eve_log_level: "debug"
       eve_artifact_name: eve-${{ matrix.hv }}-${{ matrix.arch }}-${{ matrix.platform }}
       artifact_run_id: ${{ needs.get_run_id.outputs.run_id }}
-      eden_version: "0.9.13"
+      eden_version: "v1.0.0"
 
   test_suite_master:
     if: github.ref == 'refs/heads/master'
-    uses: lf-edge/eden/.github/workflows/test.yml@0.9.13
+    uses: lf-edge/eden/.github/workflows/test.yml@v1.0.0
     secrets: inherit
     with:
       eve_image: "lfedge/eve:snapshot"
-      eden_version: "0.9.13"
+      eden_version: "v1.0.0"
 
   test_suite_tag:
     if: startsWith(github.ref, 'refs/tags')
-    uses: lf-edge/eden/.github/workflows/test.yml@0.9.13
+    uses: lf-edge/eden/.github/workflows/test.yml@v1.0.0
     secrets: inherit
     with:
       eve_image: "lfedge/eve:${{ github.ref_name }}"
-      eden_version: "0.9.13"
+      eden_version: "v1.0.0"


### PR DESCRIPTION
Eden tests that relied on the remote log level being set correctly were fixed in Eden v1.0.0.