### PR TITLE
[GH action] Assets use actions for release creation

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -23,28 +23,16 @@ jobs:
   create_release:
     runs-on: ubuntu-latest
     outputs:
-      release_id: ${{ steps.create_release.outputs.release_id }}
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
+      release_id: ${{ steps.create_release.outputs.id }}
     steps:
       - name: Create GitHub Release
         id: create_release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          response=$(curl -s -X POST \
-            -H "Authorization: Bearer $GITHUB_TOKEN" \
-            -H "Content-Type: application/json" \
-            -d '{
-              "tag_name": "${{ inputs.tag_ref }}",
-              "name": "${{ inputs.tag_ref }}",
-              "draft": false,
-              "prerelease": true
-            }' https://api.github.com/repos/${{ github.repository }}/releases)
-          release_id=$(echo "$response" | jq -r .id)
-          upload_url=$(echo "$response" | jq -r .upload_url | sed -e "s/{?name,label}//")
-          echo $upload_url
-          echo "release_id=$release_id" >> "$GITHUB_OUTPUT"
-          echo "upload_url=$upload_url" >> "$GITHUB_OUTPUT"
+        uses: actions/create-release@v1
+        with:
+          tag_name: ${{ inputs.tag_ref }}
+          release_name: ${{ inputs.tag_ref }}
+          draft: false
+          prerelease: true
   build:
     runs-on: ubuntu-20.04
     needs: create_release
@@ -106,29 +94,17 @@ jobs:
           docker create --name eve_sources "$EVE_SOURCES" bash
           docker export --output assets/collected_sources.tar.gz eve_sources
           docker rm eve_sources
-      - name: Create SHA256 checksum, rename, and upload files
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_ID: ${{ needs.create_release.outputs.release_id }}
-          UPLOAD_URL: ${{ needs.create_release.outputs.upload_url }}
+      - name: Create SHA256 checksum and rename files
         run: |
-          # Create SHA256 checksum for rootfs.img
           sha256sum "assets/rootfs.img" | awk '{ print $1 }' > "assets/rootfs.img.sha256"
           for file in assets/*; do
             base_name=$(basename "$file")
-            # Add ARCH prefix
-            new_name="${ARCH}.${base_name}"
-            # Rename the file
+            new_name="${{ env.ARCH }}.${base_name}"
             mv "$file" "assets/$new_name"
-            echo "Uploading assets/$new_name as $new_name..."
-            upload_response=$(curl -s -X POST \
-              -H "Authorization: Bearer $GITHUB_TOKEN" \
-              -H "Content-Type: application/octet-stream" \
-              --data-binary @"assets/$new_name" \
-              "$UPLOAD_URL?name=$new_name")
-            if echo "$upload_response" | jq -e .id > /dev/null; then
-              echo "$file_name uploaded successfully."
-            else
-              echo "Error uploading $file_name: $upload_response"
-            fi
-          done
+      - name: Upload Assets to Release
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_path: assets/*
+          asset_name: ${{ env.ARCH }}.${{ basename }}
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
The changes primarily involve simplifying the release creation and asset upload processes by utilizing GitHub Actions' built-in functionalities instead of custom scripts.

Improvements to GitHub Actions workflow:

* Simplified the release creation process by replacing the custom script with the `actions/create-release@v1` action and updating the output references accordingly.
* Streamlined the asset upload process by removing the custom upload script and using the `actions/upload-release-asset@v1` action to handle the file uploads.