### PR TITLE
agentlog: fix race condition in tests

### DIFF
--- a/pkg/pillar/agentlog/agentlog_test.go
+++ b/pkg/pillar/agentlog/agentlog_test.go
@@ -297,8 +297,8 @@ func emulateMemoryPressureStats() (cancel context.CancelFunc, err error) {
 	}
 
 	fakePSIFileName := fakePSIFileHandler.Name()
-	originalPressureMemoryFile := agentlog.PressureMemoryFile
-	agentlog.PressureMemoryFile = fakePSIFileName
+	originalPressureMemoryFile := agentlog.PressureMemoryFile()
+	agentlog.UpdatePressureMemoryFile(fakePSIFileName)
 
 	// Start a ticker to write a new line to the file every 0.5 seconds
 	ticker := time.NewTicker(500 * time.Millisecond)
@@ -342,7 +342,7 @@ func emulateMemoryPressureStats() (cancel context.CancelFunc, err error) {
 				agentlog.PsiMutex.Lock()
 				fakePSIFileHandler.Close()
 				os.Remove(fakePSIFileName)
-				agentlog.PressureMemoryFile = originalPressureMemoryFile
+				agentlog.UpdatePressureMemoryFile(originalPressureMemoryFile)
 				agentlog.PsiMutex.Unlock()
 				// We destroy this producer, so release the mutex
 				psiProducerMutex.Unlock()
@@ -371,8 +371,8 @@ func createFakePSIStatsFile() (cleanupFunc context.CancelFunc, err error) {
 	}
 
 	fakePSIFileName := fakePSIFileHandler.Name()
-	originalPressureMemoryFile := agentlog.PressureMemoryFile
-	agentlog.PressureMemoryFile = fakePSIFileName
+	originalPressureMemoryFile := agentlog.PressureMemoryFile()
+	agentlog.UpdatePressureMemoryFile(fakePSIFileName)
 
 	// Write some content to the file
 	agentlog.PsiMutex.Lock()
@@ -389,7 +389,7 @@ func createFakePSIStatsFile() (cleanupFunc context.CancelFunc, err error) {
 		agentlog.PsiMutex.Lock()
 		fakePSIFileHandler.Close()
 		os.Remove(fakePSIFileName)
-		agentlog.PressureMemoryFile = originalPressureMemoryFile
+		agentlog.UpdatePressureMemoryFile(originalPressureMemoryFile)
 		agentlog.PsiMutex.Unlock()
 		// We destroy this producer, so release the mutex
 		psiProducerMutex.Unlock()


### PR DESCRIPTION
Output of the race condition detector was:

```
=== FAIL: agentlog TestPsiEveIntegratedStartTwice (0.17s) ==================
WARNING: DATA RACE
Write at 0x0000029a6120 by goroutine 80:
  github.com/lf-edge/eve/pkg/pillar/agentlog_test.emulateMemoryPressureStats()
      /pillar/agentlog/agentlog_test.go:301 +0xd1
  github.com/lf-edge/eve/pkg/pillar/agentlog_test.preparePSIEnvironment()
      /pillar/agentlog/agentlog_test.go:455 +0x85
  github.com/lf-edge/eve/pkg/pillar/agentlog_test.TestPsiEveIntegratedStartTwice()
      /pillar/agentlog/agentlog_test.go:616 +0x44
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /usr/lib/go/src/testing/testing.go:1629 +0x47

Previous read at 0x0000029a6120 by goroutine 78:
  github.com/lf-edge/eve/pkg/pillar/agentlog.collectMemoryPSI()
      /pillar/agentlog/memprofile.go:151 +0x116
  github.com/lf-edge/eve/pkg/pillar/agentlog.MemoryPSICollector()
      /pillar/agentlog/memprofile.go:248 +0x810
  github.com/lf-edge/eve/pkg/pillar/agentlog.ListenDebug.func6.1()
      /pillar/agentlog/http-debug.go:474 +0x7e

Goroutine 80 (running) created at:
  testing.(*T).Run()
      /usr/lib/go/src/testing/testing.go:1629 +0x805
  testing.runTests.func1()
      /usr/lib/go/src/testing/testing.go:2036 +0x8d
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:1576 +0x216
  testing.runTests()
      /usr/lib/go/src/testing/testing.go:2034 +0x87c
  testing.(*M).Run()
      /usr/lib/go/src/testing/testing.go:1906 +0xb44
  main.main()
      _testmain.go:102 +0x2fc

Goroutine 78 (running) created at:
  github.com/lf-edge/eve/pkg/pillar/agentlog.ListenDebug.func6()
      /pillar/agentlog/http-debug.go:473 +0x2ce
  net/http.HandlerFunc.ServeHTTP()
      /usr/lib/go/src/net/http/server.go:2122 +0x4d
  net/http.(*ServeMux).ServeHTTP()
      /usr/lib/go/src/net/http/server.go:2500 +0xc5
  net/http.serverHandler.ServeHTTP()
      /usr/lib/go/src/net/http/server.go:2936 +0x682
  net/http.(*conn).serve()
      /usr/lib/go/src/net/http/server.go:1995 +0xbd4
  net/http.(*Server).Serve.func3()
      /usr/lib/go/src/net/http/server.go:3089 +0x58
==================
    testing.go:1446: race detected during execution of test
```