### PR TITLE
Integrate monitor-rs version v0.1.2

### DIFF
--- a/pkg/monitor/Dockerfile
+++ b/pkg/monitor/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-ARG MONITOR_RS_VERSION=v0.1.1
+ARG MONITOR_RS_VERSION=v0.1.2
 ARG RUST_VERSION=lfedge/eve-rust:1.80.1
 FROM --platform=$BUILDPLATFORM ${RUST_VERSION} AS toolchain-base
 ARG TARGETARCH


### PR DESCRIPTION
- Integrate the latest eve-monitor-rs application. Following issues were fixed
  - update test files
  - Fix incorrect action sent on dialog box 'ok' key
  - Display current DPC key name
  - Fix deserialization of AppInstanceStatus

See PR https://github.com/lf-edge/eve-monitor-rs/pull/5 for details and screenshots