### PR TITLE
Remove deprecated protobuf functions from zedagent

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlelocation.go
+++ b/pkg/pillar/cmd/zedagent/handlelocation.go
@@ -10,13 +10,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/protobuf/ptypes"
-
 	"github.com/lf-edge/eve-api/go/info"
 	"github.com/lf-edge/eve/pkg/pillar/flextimer"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/zedcloud"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (
@@ -136,7 +135,7 @@ func publishLocationToDest(ctx *zedagentContext, locInfo *info.ZInfoLocation,
 		InfoContent: &info.ZInfoMsg_Locinfo{
 			Locinfo: locInfo,
 		},
-		AtTimeStamp: ptypes.TimestampNow(),
+		AtTimeStamp: timestamppb.Now(),
 	}
 
 	log.Functionf("publishLocationToDest: sending %v", infoMsg)
@@ -241,13 +240,12 @@ func getLocationInfo(ctx *zedagentContext) *info.ZInfoLocation {
 	unixSec := int64(locInfo.UTCTimestamp / 1000)
 	unixNano := int64((locInfo.UTCTimestamp % 1000) * 1000000)
 	timestamp := time.Unix(unixSec, unixNano)
-	timestampProto, _ := ptypes.TimestampProto(timestamp)
 	return &info.ZInfoLocation{
 		Logicallabel:          locInfo.LogicalLabel,
 		Latitude:              locInfo.Latitude,
 		Longitude:             locInfo.Longitude,
 		Altitude:              locInfo.Altitude,
-		UtcTimestamp:          timestampProto,
+		UtcTimestamp:          timestamppb.New(timestamp),
 		HorizontalReliability: locationReliabilityToProto(locInfo.HorizontalReliability),
 		VerticalReliability:   locationReliabilityToProto(locInfo.VerticalReliability),
 		HorizontalUncertainty: locInfo.HorizontalUncertainty,

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/protobuf/ptypes"
 	"github.com/lf-edge/eve-api/go/evecommon"
 	"github.com/lf-edge/eve-api/go/info"
 	"github.com/lf-edge/eve-api/go/metrics"
@@ -123,13 +122,7 @@ func encodeErrorInfo(et types.ErrorDescription) *info.ErrorInfo {
 	}
 	errInfo := new(info.ErrorInfo)
 	errInfo.Description = et.Error
-	protoTime, err := ptypes.TimestampProto(et.ErrorTime)
-	if err == nil {
-		errInfo.Timestamp = protoTime
-	} else {
-		log.Errorf("Failed to convert timestamp (%+v) for ErrorStr (%s) "+
-			"into TimestampProto. err: %s", et.ErrorTime, et.Error, err)
-	}
+	errInfo.Timestamp = timestamppb.New(et.ErrorTime)
 	errInfo.Severity = info.Severity(et.ErrorSeverity)
 	errInfo.RetryCondition = et.ErrorRetryCondition
 	errInfo.Entities = make([]*info.DeviceEntity, len(et.ErrorEntities))
@@ -156,13 +149,7 @@ func encodeTestResults(tr types.TestResults) *info.ErrorInfo {
 		}
 	}
 	if !timestamp.IsZero() {
-		protoTime, err := ptypes.TimestampProto(timestamp)
-		if err == nil {
-			errInfo.Timestamp = protoTime
-		} else {
-			log.Errorf("Failed to convert timestamp (%+v) for ErrorStr (%s) "+
-				"into TimestampProto. err: %s", timestamp, tr.LastError, err)
-		}
+		errInfo.Timestamp = timestamppb.New(timestamp)
 	}
 	return errInfo
 }
@@ -306,7 +293,7 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 
 	// This will be overridden with the timestamp for the CPU metrics
 	// below to make CPU usage calculations more accurate
-	ReportMetrics.AtTimeStamp = ptypes.TimestampNow()
+	ReportMetrics.AtTimeStamp = timestamppb.Now()
 
 	info, err := host.Info()
 	if err != nil {
@@ -319,9 +306,8 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 	// Note that uptime is seconds we've been up. We're converting
 	// to a timestamp. That better not be interpreted as a time since
 	// the epoch
-	uptime, _ := ptypes.TimestampProto(
+	ReportDeviceMetric.CpuMetric.UpTime = timestamppb.New(
 		time.Unix(int64(info.Uptime), 0).UTC())
-	ReportDeviceMetric.CpuMetric.UpTime = uptime
 
 	// Memory related info for the device
 	var totalMemory, freeMemory, usedEveMB uint64
@@ -416,12 +402,10 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 			AuthVerifyFailure: cm.AuthFailCount,
 		}
 		if !cm.LastFailure.IsZero() {
-			lf, _ := ptypes.TimestampProto(cm.LastFailure)
-			metric.LastFailure = lf
+			metric.LastFailure = timestamppb.New(cm.LastFailure)
 		}
 		if !cm.LastSuccess.IsZero() {
-			ls, _ := ptypes.TimestampProto(cm.LastSuccess)
-			metric.LastSuccess = ls
+			metric.LastSuccess = timestamppb.New(cm.LastSuccess)
 		}
 		for url, um := range cm.URLCounters {
 			log.Tracef("CloudMetrics[%s] url %s %v",
@@ -464,7 +448,7 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 		TotalSizeLogs:       newlogMetrics.TotalSizeLogs,
 	}
 	if !newlogMetrics.FailSentStartTime.IsZero() {
-		nlm.FailSentStartTime, _ = ptypes.TimestampProto(newlogMetrics.FailSentStartTime)
+		nlm.FailSentStartTime = timestamppb.New(newlogMetrics.FailSentStartTime)
 	}
 	if !newlogMetrics.OldestSavedDeviceLog.IsZero() {
 		nlm.OldestSavedDeviceLog = timestamppb.New(newlogMetrics.OldestSavedDeviceLog)
@@ -480,10 +464,10 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 		NumGzipFileKeptLocal: newlogMetrics.DevMetrics.NumGZipFileKeptLocal,
 	}
 	if !newlogMetrics.DevMetrics.RecentUploadTimestamp.IsZero() {
-		devM.RecentGzipFileTime, _ = ptypes.TimestampProto(newlogMetrics.DevMetrics.RecentUploadTimestamp)
+		devM.RecentGzipFileTime = timestamppb.New(newlogMetrics.DevMetrics.RecentUploadTimestamp)
 	}
 	if !newlogMetrics.DevMetrics.LastGZipFileSendTime.IsZero() {
-		devM.LastGzipFileSendTime, _ = ptypes.TimestampProto(newlogMetrics.DevMetrics.LastGZipFileSendTime)
+		devM.LastGzipFileSendTime = timestamppb.New(newlogMetrics.DevMetrics.LastGZipFileSendTime)
 	}
 	nlm.DeviceMetrics = devM
 
@@ -497,10 +481,10 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 		NumGzipFileKeptLocal: newlogMetrics.AppMetrics.NumGZipFileKeptLocal,
 	}
 	if !newlogMetrics.AppMetrics.RecentUploadTimestamp.IsZero() {
-		appM.RecentGzipFileTime, _ = ptypes.TimestampProto(newlogMetrics.AppMetrics.RecentUploadTimestamp)
+		appM.RecentGzipFileTime = timestamppb.New(newlogMetrics.AppMetrics.RecentUploadTimestamp)
 	}
 	if !newlogMetrics.AppMetrics.LastGZipFileSendTime.IsZero() {
-		appM.LastGzipFileSendTime, _ = ptypes.TimestampProto(newlogMetrics.AppMetrics.LastGZipFileSendTime)
+		appM.LastGzipFileSendTime = timestamppb.New(newlogMetrics.AppMetrics.LastGZipFileSendTime)
 	}
 	nlm.AppMetrics = appM
 
@@ -526,12 +510,10 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 			SuccessCount: cm.SuccessCount,
 		}
 		if !cm.LastFailure.IsZero() {
-			lf, _ := ptypes.TimestampProto(cm.LastFailure)
-			metric.LastFailure = lf
+			metric.LastFailure = timestamppb.New(cm.LastFailure)
 		}
 		if !cm.LastSuccess.IsZero() {
-			ls, _ := ptypes.TimestampProto(cm.LastSuccess)
-			metric.LastSuccess = ls
+			metric.LastSuccess = timestamppb.New(cm.LastSuccess)
 		}
 		for i := range cm.TypeCounters {
 			tc := metrics.TypeCounter{
@@ -602,8 +584,7 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 		// Override the time of the report with the time from
 		// domainmgr
 		if !dm.LastHeard.IsZero() {
-			lh, _ := ptypes.TimestampProto(dm.LastHeard)
-			ReportMetrics.AtTimeStamp = lh
+			ReportMetrics.AtTimeStamp = timestamppb.New(dm.LastHeard)
 		}
 
 		ReportDeviceMetric.CpuMetric.Total = *proto.Uint64(dm.CPUTotalNs / nanoSecToSec)
@@ -654,22 +635,10 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 	}
 
 	if !ctx.getconfigCtx.lastReceivedConfig.IsZero() {
-		protoTime, err := ptypes.TimestampProto(ctx.getconfigCtx.lastReceivedConfig)
-		if err == nil {
-			ReportDeviceMetric.LastReceivedConfig = protoTime
-		} else {
-			log.Errorf("Failed to convert timestamp (%+v) for LastReceivedConfig into TimestampProto. err: %s",
-				ctx.getconfigCtx.lastReceivedConfig, err)
-		}
+		ReportDeviceMetric.LastReceivedConfig = timestamppb.New(ctx.getconfigCtx.lastReceivedConfig)
 	}
 	if !ctx.getconfigCtx.lastProcessedConfig.IsZero() {
-		protoTime, err := ptypes.TimestampProto(ctx.getconfigCtx.lastProcessedConfig)
-		if err == nil {
-			ReportDeviceMetric.LastProcessedConfig = protoTime
-		} else {
-			log.Errorf("Failed to convert timestamp (%+v) for LastProcessedConfig into TimestampProto. err: %s",
-				ctx.getconfigCtx.lastProcessedConfig, err)
-		}
+		ReportDeviceMetric.LastProcessedConfig = timestamppb.New(ctx.getconfigCtx.lastProcessedConfig)
 	}
 	ReportDeviceMetric.DormantTimeInSeconds = getDormantTime(ctx)
 
@@ -714,9 +683,8 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 
 		if !aiStatus.BootTime.IsZero() && aiStatus.Activated {
 			elapsed := time.Since(aiStatus.BootTime)
-			uptime, _ := ptypes.TimestampProto(
+			ReportAppMetric.Cpu.UpTime = timestamppb.New(
 				time.Unix(0, elapsed.Nanoseconds()).UTC())
-			ReportAppMetric.Cpu.UpTime = uptime
 		}
 
 		dm := lookupDomainMetric(ctx, aiStatus.Key())
@@ -835,8 +803,7 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 					appContainerMetric.PIDs = stats.Pids
 
 					appContainerMetric.Cpu = new(metrics.AppCpuMetric)
-					uptime, _ := ptypes.TimestampProto(time.Unix(0, stats.Uptime).UTC())
-					appContainerMetric.Cpu.UpTime = uptime
+					appContainerMetric.Cpu.UpTime = timestamppb.New(time.Unix(0, stats.Uptime).UTC())
 					// convert to seconds
 					appContainerMetric.Cpu.Total = stats.CPUTotal / nanoSecToSec
 					appContainerMetric.Cpu.SystemTotal = stats.SystemCPUTotal / nanoSecToSec
@@ -1059,7 +1026,7 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 	*appType = info.ZInfoTypes_ZiApp
 	ReportInfo.Ztype = *appType
 	ReportInfo.DevId = *proto.String(devUUID.String())
-	ReportInfo.AtTimeStamp = ptypes.TimestampNow()
+	ReportInfo.AtTimeStamp = timestamppb.Now()
 
 	ReportAppInfo := new(info.ZInfoApp)
 
@@ -1081,8 +1048,7 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 			// If never booted
 			log.Functionln("BootTime is empty")
 		} else {
-			bootTime, _ := ptypes.TimestampProto(aiStatus.BootTime)
-			ReportAppInfo.BootTime = bootTime
+			ReportAppInfo.BootTime = timestamppb.New(aiStatus.BootTime)
 		}
 
 		for _, ia := range aiStatus.IoAdapterList {
@@ -1213,7 +1179,7 @@ func PublishContentInfoToZedCloud(ctx *zedagentContext, uuid string,
 	*contentType = info.ZInfoTypes_ZiContentTree
 	ReportInfo.Ztype = *contentType
 	ReportInfo.DevId = *proto.String(devUUID.String())
-	ReportInfo.AtTimeStamp = ptypes.TimestampNow()
+	ReportInfo.AtTimeStamp = timestamppb.Now()
 
 	ReportContentInfo := new(info.ZInfoContentTree)
 
@@ -1230,12 +1196,11 @@ func PublishContentInfoToZedCloud(ctx *zedagentContext, uuid string,
 		ContentResourcesInfo := new(info.ContentResources)
 		ContentResourcesInfo.CurSizeBytes = uint64(ctStatus.TotalSize)
 		ReportContentInfo.Resources = ContentResourcesInfo
-		createTime, _ := ptypes.TimestampProto(ctStatus.CreateTime)
 		ReportContentInfo.Usage = &info.UsageInfo{
 			// XXX RefCount: uint32(ctStatus.RefCount),
 			RefCount:               1,
-			LastRefcountChangeTime: createTime,
-			CreateTime:             createTime,
+			LastRefcountChangeTime: timestamppb.New(ctStatus.CreateTime),
+			CreateTime:             timestamppb.New(ctStatus.CreateTime),
 		}
 		ReportContentInfo.Sha256 = ctStatus.ContentSha256
 		ReportContentInfo.ProgressPercentage = uint32(ctStatus.Progress)
@@ -1281,7 +1246,7 @@ func PublishVolumeToZedCloud(ctx *zedagentContext, uuid string,
 	*volumeType = info.ZInfoTypes_ZiVolume
 	ReportInfo.Ztype = *volumeType
 	ReportInfo.DevId = *proto.String(devUUID.String())
-	ReportInfo.AtTimeStamp = ptypes.TimestampNow()
+	ReportInfo.AtTimeStamp = timestamppb.Now()
 
 	ReportVolumeInfo := new(info.ZInfoVolume)
 
@@ -1308,12 +1273,10 @@ func PublishVolumeToZedCloud(ctx *zedagentContext, uuid string,
 				ReportVolumeInfo.Resources = VolumeResourcesInfo
 			}
 		}
-		createTime, _ := ptypes.TimestampProto(volStatus.CreateTime)
-		lastChangeTime, _ := ptypes.TimestampProto(volStatus.LastRefCountChangeTime)
 		ReportVolumeInfo.Usage = &info.UsageInfo{
 			RefCount:               uint32(volStatus.RefCount),
-			LastRefcountChangeTime: lastChangeTime,
-			CreateTime:             createTime,
+			LastRefcountChangeTime: timestamppb.New(volStatus.LastRefCountChangeTime),
+			CreateTime:             timestamppb.New(volStatus.CreateTime),
 		}
 
 		ReportVolumeInfo.ProgressPercentage = uint32(volStatus.Progress)
@@ -1357,7 +1320,7 @@ func PublishBlobInfoToZedCloud(ctx *zedagentContext, blobSha string,
 	*contentType = info.ZInfoTypes_ZiBlobList
 	ReportInfo.Ztype = *contentType
 	ReportInfo.DevId = *proto.String(devUUID.String())
-	ReportInfo.AtTimeStamp = ptypes.TimestampNow()
+	ReportInfo.AtTimeStamp = timestamppb.Now()
 
 	ReportBlobInfoList := new(info.ZInfoBlobList)
 
@@ -1367,12 +1330,10 @@ func PublishBlobInfoToZedCloud(ctx *zedagentContext, blobSha string,
 	if blobStatus != nil {
 		ReportBlobInfo.State = blobStatus.State.ZSwState()
 		ReportBlobInfo.ProgressPercentage = blobStatus.GetDownloadedPercentage()
-		createTime, _ := ptypes.TimestampProto(blobStatus.CreateTime)
-		lastChangeTime, _ := ptypes.TimestampProto(blobStatus.LastRefCountChangeTime)
 		ReportBlobInfo.Usage = &info.UsageInfo{
 			RefCount:               uint32(blobStatus.RefCount),
-			LastRefcountChangeTime: lastChangeTime,
-			CreateTime:             createTime,
+			LastRefcountChangeTime: timestamppb.New(blobStatus.LastRefCountChangeTime),
+			CreateTime:             timestamppb.New(blobStatus.CreateTime),
 		}
 		ReportBlobInfo.Resources = &info.ContentResources{CurSizeBytes: blobStatus.Size}
 	}
@@ -1416,14 +1377,12 @@ func PublishEdgeviewToZedCloud(ctx *zedagentContext,
 	*evType = info.ZInfoTypes_ZiEdgeview
 	ReportInfo.Ztype = *evType
 	ReportInfo.DevId = *proto.String(devUUID.String())
-	ReportInfo.AtTimeStamp = ptypes.TimestampNow()
+	ReportInfo.AtTimeStamp = timestamppb.Now()
 
 	ReportEvInfo := new(info.ZInfoEdgeview)
 	if evStatus != nil {
-		expTime, _ := ptypes.TimestampProto(time.Unix(int64(evStatus.ExpireOn), 0).UTC())
-		startTime, _ := ptypes.TimestampProto(evStatus.StartedOn)
-		ReportEvInfo.ExpireTime = expTime
-		ReportEvInfo.StartedTime = startTime
+		ReportEvInfo.ExpireTime = timestamppb.New(time.Unix(int64(evStatus.ExpireOn), 0).UTC())
+		ReportEvInfo.StartedTime = timestamppb.New(evStatus.StartedOn)
 		ReportEvInfo.CountDev = evStatus.CmdCountDev
 		ReportEvInfo.CountApp = evStatus.CmdCountApp
 		ReportEvInfo.CountExt = evStatus.CmdCountExt
@@ -1639,10 +1598,7 @@ func createProcessMetrics(ctx *zedagentContext, reportMetrics *metrics.ZMetricMs
 		processMetric.UserTime = p.UserTime
 		processMetric.SystemTime = p.SystemTime
 		processMetric.CpuPercent = p.CPUPercent
-		protoTime, err := ptypes.TimestampProto(p.CreateTime)
-		if err == nil {
-			processMetric.CreateTime = protoTime
-		}
+		processMetric.CreateTime = timestamppb.New(p.CreateTime)
 		processMetric.VmBytes = p.VMBytes
 		processMetric.RssBytes = p.RssBytes
 		processMetric.MemoryPercent = p.MemoryPercent
@@ -1801,11 +1757,7 @@ func fillStorageChildrenMetrics(childrenDataset *types.StorageChildrenMetrics) *
 func fillStorageMetrics(zpoolMetrics *types.ZFSPoolMetrics) *metrics.StorageMetric {
 	storageMetrics := new(metrics.StorageMetric)
 	storageMetrics.PoolName = *proto.String(zpoolMetrics.PoolName)
-	tmpCollectionTime, err := ptypes.TimestampProto(zpoolMetrics.CollectionTime)
-	if err != nil {
-		log.Errorf("fillStorageMetrics: failed to convert CollectionTime %v", err)
-	}
-	storageMetrics.CollectionTime = tmpCollectionTime
+	storageMetrics.CollectionTime = timestamppb.New(zpoolMetrics.CollectionTime)
 	storageMetrics.ZpoolMetrics = fillStorageVDevMetrics(zpoolMetrics.Metrics)
 
 	// Fill metrics for RAID or Mirror

--- a/pkg/pillar/cmd/zedagent/handlentp.go
+++ b/pkg/pillar/cmd/zedagent/handlentp.go
@@ -11,8 +11,6 @@ import (
 	"path"
 	"time"
 
-	"github.com/golang/protobuf/ptypes"
-
 	chrony "github.com/facebook/time/ntp/chrony"
 	"github.com/lf-edge/eve-api/go/info"
 	"github.com/lf-edge/eve/pkg/pillar/types"
@@ -136,7 +134,7 @@ func publishNTPSourcesToDest(ctx *zedagentContext,
 		InfoContent: &info.ZInfoMsg_NtpSources{
 			NtpSources: infoNTPSources,
 		},
-		AtTimeStamp: ptypes.TimestampNow(),
+		AtTimeStamp: timestamppb.Now(),
 	}
 
 	log.Functionf("publishNTPSourcesToDest: sending %v", infoMsg)

--- a/pkg/pillar/cmd/zedagent/handlepatchenvelopes.go
+++ b/pkg/pillar/cmd/zedagent/handlepatchenvelopes.go
@@ -6,11 +6,11 @@ package zedagent
 import (
 	"bytes"
 
-	"github.com/golang/protobuf/ptypes"
 	"github.com/lf-edge/eve-api/go/info"
 	"github.com/lf-edge/eve-api/go/metrics"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func composePatchEnvelopeUsage(appUUID string, ctx *zedagentContext) []*metrics.AppPatchEnvelopeMetric {
@@ -87,7 +87,7 @@ func publishPatchEnvelopeStatus(ctx *zedagentContext, patchInfo *info.ZInfoPatch
 		InfoContent: &info.ZInfoMsg_PatchInfo{
 			PatchInfo: patchInfo,
 		},
-		AtTimeStamp: ptypes.TimestampNow(),
+		AtTimeStamp: timestamppb.Now(),
 	}
 
 	log.Functionf("publishPatchEnvelopeStatus: sending %v", infoMsg)

--- a/pkg/pillar/cmd/zedagent/hardwareinfo.go
+++ b/pkg/pillar/cmd/zedagent/hardwareinfo.go
@@ -8,11 +8,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/golang/protobuf/ptypes"
 	"github.com/lf-edge/eve-api/go/info"
 	"github.com/lf-edge/eve/pkg/pillar/hardware"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func hardwareInfoTask(ctxPtr *zedagentContext, triggerHwInfo <-chan destinationBitset) {
@@ -48,7 +48,7 @@ func PublishHardwareInfoToZedCloud(ctx *zedagentContext, dest destinationBitset)
 	*hwType = info.ZInfoTypes_ZiHardware
 	ReportHwInfo.Ztype = *hwType
 	ReportHwInfo.DevId = *proto.String(devUUID.String())
-	ReportHwInfo.AtTimeStamp = ptypes.TimestampNow()
+	ReportHwInfo.AtTimeStamp = timestamppb.Now()
 	log.Functionf("PublishHardwareInfoToZedCloud uuid %s", hwInfoKey)
 
 	hwInfo := new(info.ZInfoHardware)

--- a/pkg/pillar/cmd/zedagent/localinfo.go
+++ b/pkg/pillar/cmd/zedagent/localinfo.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/protobuf/ptypes"
 	"github.com/lf-edge/eve-api/go/info"
 	"github.com/lf-edge/eve-api/go/profile"
 	"github.com/lf-edge/eve/pkg/pillar/flextimer"
@@ -22,6 +21,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/zedcloud"
 	uuid "github.com/satori/go.uuid"
 	"github.com/shirou/gopsutil/host"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (
@@ -688,9 +688,8 @@ func prepareLocalDevInfo(ctx *zedagentContext) *profile.LocalDevInfo {
 	if err != nil {
 		log.Errorf("host.Info(): %s", err)
 	} else {
-		bootTime, _ := ptypes.TimestampProto(
+		msg.BootTime = timestamppb.New(
 			time.Unix(int64(hinfo.BootTime), 0).UTC())
-		msg.BootTime = bootTime
 	}
 	msg.LastBootReason = info.BootReason(ctx.bootReason)
 	msg.LastCmdTimestamp = ctx.getconfigCtx.sideController.lastDevCmdTimestamp

--- a/pkg/pillar/go.mod
+++ b/pkg/pillar/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/go-chi/chi/v5 v5.0.10
 	github.com/go-playground/validator/v10 v10.15.5
 	github.com/golang-jwt/jwt v3.2.2+incompatible
-	github.com/golang/protobuf v1.5.4
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-containerregistry v0.14.0
 	github.com/google/go-tpm v0.9.1
@@ -201,6 +200,7 @@ require (
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/golang/glog v1.1.2 // indirect
 	github.com/golang/mock v1.6.0 // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect


### PR DESCRIPTION
Replace the deprecated functions for time conversion to protobug from ptypes with the recomended and simpler ones from timestamppb:
- ptypes.TimestampProto() with timestamppb.New()
- ptypes.TimestampNow() with timestamppb.Now()