### PR TITLE
Fix broken installer ISO from docker run, by simplifying mkimage-iso-efi entrypoint script

### DIFF
--- a/pkg/eve/runme.sh
+++ b/pkg/eve/runme.sh
@@ -157,9 +157,17 @@ do_installer_raw() {
   dump "$OUTPUT_IMG" installer.raw
 }
 
+# create_installer_iso creates the installer iso and leaves it as /output.iso
+# common base for other usages like do_installer_iso and do_installer_net
+create_installer_iso() {
+  mkdir -p /installer_root
+  unsquashfs -f -d /installer_root /bits/installer.img 1>&2
+  tar -C /installer_root -cf - . | /make-efi installer
+  rm -rf /installer_root
+}
+
 do_installer_iso() {
-  rm -rf /parts
-  /make-efi installer
+  create_installer_iso
   dump /output.iso installer.iso
 }
 
@@ -170,7 +178,7 @@ do_installer_net() {
   cp /bits/ipxe.efi.cfg /installer
   mkdir -p /installer/EFI/BOOT
   cp /bits/EFI/BOOT/BOOT*EFI /installer/EFI/BOOT/
-  /make-efi installer
+  create_installer_iso
   mv /output.iso /installer/installer.iso
 
   # all of this is taken straight from ../../tools/makenet.sh

--- a/pkg/mkimage-iso-efi/make-efi
+++ b/pkg/mkimage-iso-efi/make-efi
@@ -14,16 +14,14 @@ copy() {
 }
 
 #
-# Extract partitions from stdin or look them up in /bits
+# Extract partitions from stdin to a working directory
+# We could do this in /tmp, but it might be really big, and for cases where
+# /tmp is tmpfs, that might use up a lot of memory
 #
-mkdir -p /parts 2>/dev/null || :
-cd /parts
-if [ -d /bits ]; then
-   ln -s /bits/* .
-   rm \* >/dev/null 2>&1 || :
-else
-   bsdtar xzf -
-fi
+TMPDIR=/var/efiparts-$$
+mkdir -p $TMPDIR
+cd $TMPDIR
+bsdtar xzf -
 
 # create a ISO with a EFI boot partition
 # Stuff it into a FAT filesystem, making it as small as possible.  511KiB


### PR DESCRIPTION
Simplifies the entrypoint script `make-efi` from `pkg/mkimage-iso-efi`, and its dependency in `pkg/eve/runme.sh`.

The entrypoint script make-efi in mkimage-iso-efi is used in 2 places:

* the script makeiso.sh, where it expects to pipe a tar stream to the container's stdin
* the script runme.sh, as the entrypoint to pkg/eve, i.e. the container image lfedge/eve

This does not change the first use case. The make-efi is changed so that it *always* reads a tar stream from stdin. This makes it a much simpler program to understand (consistency is nice).

For the case of runme.sh, that script is changed so that instead of assuming it has the installer in a particular directory, it explicitly takes the installer.img, unpackages it into a temporary working directory, and creates a tar stream from the contents of that directory, so that it can stream it to make-efi.

This has the important benefit of fixing the bug wherein making an installer_iso from `docker run lfedge/eve installer_iso` gives an ISO that does not install correctly.

I tested by running both `make run-installer-iso`, which I know works, and see that it has the proper setup information in grub, and then `docker run lfedge/eve:<tag> installer_iso > installer.iso` and booting that ISO. It gives the same (now correct) result.

Fixes #4475
