### PR TITLE
Clarify commercial use of Project EVE

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -11,6 +11,8 @@ The following projects and users are or have been leveraging Project EVE.
 
 ## List of commercial adopters (in alphabetical order)
 
+Some of the referenced documentation below has specific mentions of Project EVE and EVE-OS, but all of these adopters rely on the Project EVE for the edge computing deployment (and on the ZEDEDA commercial controller for management and orchestration). Furthermore, the EVE-OS which is used comes directly from LF Edge, whether docker pulled from lfedge/eve:$VERSION (as described in <https://help.zededa.com/hc/en-us/articles/27589207303451-Get-EVE-OS>), or installed directly from <https://github.com/lf-edge/eve/releases/> (as described in <https://help.zededa.com/hc/en-us/articles/22287949181467-PXE-server-setup#h_01HMSZWE0Y2C16YSNN490WRMA7>). Thus the use of ZEDEDA here implies direct and unmodified usage of the output of Project EVE.
+
 * BOBST. See <https://zededa.com/case_studies/bobst-case-study/>.
 * Emerson. See <https://zededa.com/blog/how-emerson-achieved-boundless-automation-with-zededa/>.
 * PeopleFlo. See <https://zededa.com/case_studies/peopleflo-case-study/>.


### PR DESCRIPTION
The referenced adopters might not state explicitly that they are using Project EVE, but the ZEDEDA documentation specifies this is required that that it is retrieved from either the LF Edge docker hub organization or from the LF Edge github organization's pages.