### PR TITLE
[12.0-stable] Only check IsPort for iobundle types which are Net

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -3006,7 +3006,7 @@ func updatePortAndPciBackIoBundle(ctx *domainContext, ib *types.IoBundle) (chang
 	// EVE controller doesn't know it
 	list = aa.ExpandControllers(log, list, hyper.PCISameController)
 	for _, ib := range list {
-		if types.IsPort(ctx.deviceNetworkStatus, ib.Ifname) {
+		if types.IsPort(ctx.deviceNetworkStatus, ib.Ifname) && ib.Type.IsNet() {
 			isPort = true
 			keepInHost = true
 		}


### PR DESCRIPTION
Backport of https://github.com/lf-edge/eve/pull/4482

Skip over HDMI, COM.  IsPort only checks Ifname which can incorrectly flag non-net devices as a port.

Signed-off-by: Andrew Durbin <andrewd@zededa.com>
(cherry picked from commit 7311ddf59a747d524cb1dd8a30754b542c6fa9f6)