### PR TITLE
Ignore /persist/kube-save-var-lib directory

### DIFF
--- a/pkg/pillar/types/diskmetrics.go
+++ b/pkg/pillar/types/diskmetrics.go
@@ -41,6 +41,7 @@ var ReportDirPaths = []string{
 	PersistDir + "/kcrashes",
 	PersistDir + "/eve-info",
 	PersistDir + "/kubelog",
+	PersistDir + "/kube-save-var-lib",
 }
 
 // AppPersistPaths  Application-related files live here


### PR DESCRIPTION
We save the backup of k3s installation to /persist to switch from clustering to single node. Exclude this directory from diskmetrics collection. This leads to 200+ json files which are processed unneccesarily, also the space occupied is already accounted in /persist